### PR TITLE
fix(ci): pin gremlins to v0.6.0 (v0.7.1 was never tagged)

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -25,6 +25,6 @@ jobs:
         with:
           tool: just
       - name: Install gremlins
-        run: go install github.com/go-gremlins/gremlins/cmd/gremlins@v0.7.1
+        run: go install github.com/go-gremlins/gremlins/cmd/gremlins@v0.6.0
       - name: just mutate
         run: just mutate

--- a/Justfile
+++ b/Justfile
@@ -6,7 +6,7 @@ set shell := ["bash", "-eu", "-o", "pipefail", "-c"]
 GOLANGCI_LINT_VERSION := "v2.12.2"
 GOFUMPT_VERSION := "v0.7.0"
 GOIMPORTS_VERSION := "latest"
-GREMLINS_VERSION := "v0.7.1"
+GREMLINS_VERSION := "v0.6.0"
 MODULE := "github.com/tsouza/cerberus"
 
 # Default: list recipes.


### PR DESCRIPTION
## Summary
Unbreak \`mutation.yml\` on main.

The PR4 bundle pinned gremlins at \`v0.7.1\`, but that tag doesn't exist upstream — latest is \`v0.6.0\`. The first \`mutation.yml\` run after merging PR4 failed with \`invalid version: unknown revision cmd/gremlins/v0.7.1\`. Bumping both the Justfile constant and the workflow's \`go install\` line unbreaks the workflow.

## Test plan
- [x] \`go install github.com/go-gremlins/gremlins/cmd/gremlins@v0.6.0\` succeeds locally
- [x] \`gremlins --version\` runs after install
- [ ] CI passes
- [ ] \`mutation.yml\` runs to completion on merge to main (and is non-blocking even if thresholds fail; we tune the floor as the codebase grows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)