### PR TITLE
feat(promql,schema): add PromQL vertical slice (parse → lower → emit)

### DIFF
--- a/internal/chplan/map_access.go
+++ b/internal/chplan/map_access.go
@@ -1,0 +1,19 @@
+package chplan
+
+// MapAccess is a key lookup on a ClickHouse Map column, rendered by the
+// emitter as `<Map>[<Key>]`. PromQL label matchers lower into MapAccess on
+// the configured Attributes column.
+type MapAccess struct {
+	Map Expr
+	Key Expr
+}
+
+func (*MapAccess) exprNode() {}
+
+func (m *MapAccess) Equal(other Expr) bool {
+	o, ok := other.(*MapAccess)
+	if !ok {
+		return false
+	}
+	return m.Map.Equal(o.Map) && m.Key.Equal(o.Key)
+}

--- a/internal/chsql/emit_expr.go
+++ b/internal/chsql/emit_expr.go
@@ -23,6 +23,8 @@ func (e *emitter) emitExpr(x chplan.Expr) error {
 		return e.emitBinary(v)
 	case *chplan.FuncCall:
 		return e.emitFunc(v)
+	case *chplan.MapAccess:
+		return e.emitMapAccess(v)
 	default:
 		return fmt.Errorf("%w: expr %T", ErrUnsupported, x)
 	}
@@ -62,6 +64,18 @@ func (e *emitter) emitBinary(b *chplan.Binary) error {
 		return err
 	}
 	e.b.WriteByte(')')
+	return nil
+}
+
+func (e *emitter) emitMapAccess(m *chplan.MapAccess) error {
+	if err := e.emitExpr(m.Map); err != nil {
+		return err
+	}
+	e.b.WriteByte('[')
+	if err := e.emitExpr(m.Key); err != nil {
+		return err
+	}
+	e.b.WriteByte(']')
 	return nil
 }
 

--- a/internal/chsql/emit_test.go
+++ b/internal/chsql/emit_test.go
@@ -89,6 +89,18 @@ var plans = map[string]chplan.Node{
 		Input: &chplan.Scan{Table: "otel_logs"},
 		Count: 1000,
 	},
+
+	"filter_map_access": &chplan.Filter{
+		Input: &chplan.Scan{Table: "otel_metrics_gauge"},
+		Predicate: &chplan.Binary{
+			Op: chplan.OpEq,
+			Left: &chplan.MapAccess{
+				Map: &chplan.ColumnRef{Name: "Attributes"},
+				Key: &chplan.LitString{V: "job"},
+			},
+			Right: &chplan.LitString{V: "api"},
+		},
+	},
 }
 
 func TestEmit(t *testing.T) {

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -1,0 +1,198 @@
+package promql
+
+import (
+	"fmt"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// Lower turns a parsed PromQL expression into a chplan tree, using s for
+// table and column name conventions.
+//
+// v0.1 scope: VectorSelector, MatrixSelector (only as a Call argument),
+// Call with `rate` / `increase` / `delta` / `*_over_time`, AggregateExpr
+// with `by (...)`, ParenExpr. Subqueries, scalar arithmetic, `without`,
+// and BinaryExpr are out of scope for the seed.
+func Lower(expr parser.Expr, s schema.Metrics) (chplan.Node, error) {
+	return lower(expr, s)
+}
+
+func lower(expr parser.Expr, s schema.Metrics) (chplan.Node, error) {
+	switch e := expr.(type) {
+	case *parser.VectorSelector:
+		return lowerVectorSelector(e, s), nil
+	case *parser.Call:
+		return lowerCall(e, s)
+	case *parser.AggregateExpr:
+		return lowerAggregate(e, s)
+	case *parser.ParenExpr:
+		return lower(e.Expr, s)
+	default:
+		return nil, fmt.Errorf("promql: unsupported expression %T", expr)
+	}
+}
+
+// lowerVectorSelector turns `metric{label="val"}` into Scan + Filter.
+func lowerVectorSelector(v *parser.VectorSelector, s schema.Metrics) chplan.Node {
+	metricName := metricNameFromMatchers(v.LabelMatchers)
+	table := s.GaugeTable
+	if metricName != "" {
+		table = s.TableFor(metricName)
+	}
+
+	scan := &chplan.Scan{Table: table}
+
+	pred := buildPredicate(v.LabelMatchers, s)
+	if pred == nil {
+		return scan
+	}
+	return &chplan.Filter{Input: scan, Predicate: pred}
+}
+
+// metricNameFromMatchers returns the value of the __name__ matcher (if any
+// exists with MatchType == Equal); empty string otherwise. Used to pick the
+// CH table for VectorSelectors that name a specific metric.
+func metricNameFromMatchers(ms []*labels.Matcher) string {
+	for _, m := range ms {
+		if m.Name == model.MetricNameLabel && m.Type == labels.MatchEqual {
+			return m.Value
+		}
+	}
+	return ""
+}
+
+// buildPredicate AND-folds the label matchers into a single chplan.Expr.
+// __name__ goes against the MetricName column; everything else goes against
+// `Attributes[<label>]` via MapAccess.
+func buildPredicate(matchers []*labels.Matcher, s schema.Metrics) chplan.Expr {
+	var out chplan.Expr
+	for _, m := range matchers {
+		cond := matcherToExpr(m, s)
+		if out == nil {
+			out = cond
+			continue
+		}
+		out = &chplan.Binary{Op: chplan.OpAnd, Left: out, Right: cond}
+	}
+	return out
+}
+
+func matcherToExpr(m *labels.Matcher, s schema.Metrics) chplan.Expr {
+	var lhs chplan.Expr
+	if m.Name == model.MetricNameLabel {
+		lhs = &chplan.ColumnRef{Name: s.MetricNameColumn}
+	} else {
+		lhs = &chplan.MapAccess{
+			Map: &chplan.ColumnRef{Name: s.AttributesColumn},
+			Key: &chplan.LitString{V: m.Name},
+		}
+	}
+	return &chplan.Binary{
+		Op:    matchOp(m.Type),
+		Left:  lhs,
+		Right: &chplan.LitString{V: m.Value},
+	}
+}
+
+func matchOp(t labels.MatchType) chplan.BinaryOp {
+	switch t {
+	case labels.MatchEqual:
+		return chplan.OpEq
+	case labels.MatchNotEqual:
+		return chplan.OpNe
+	case labels.MatchRegexp:
+		return chplan.OpMatch
+	case labels.MatchNotRegexp:
+		return chplan.OpNotMatch
+	}
+	// Any new labels.MatchType added upstream would land here as Equal —
+	// safer than panicking, and we'd notice via the spec tests.
+	return chplan.OpEq
+}
+
+// lowerCall handles range-vector functions: rate, increase, delta, and the
+// `*_over_time` family. The single argument is a MatrixSelector wrapping a
+// VectorSelector; we lower the VectorSelector and wrap the result in a
+// RangeWindow capturing the function name + range duration.
+func lowerCall(c *parser.Call, s schema.Metrics) (chplan.Node, error) {
+	if len(c.Args) != 1 {
+		return nil, fmt.Errorf("promql: %s expects exactly 1 argument, got %d", c.Func.Name, len(c.Args))
+	}
+	ms, ok := c.Args[0].(*parser.MatrixSelector)
+	if !ok {
+		return nil, fmt.Errorf("promql: %s argument must be a range-vector selector, got %T",
+			c.Func.Name, c.Args[0])
+	}
+	vs, ok := ms.VectorSelector.(*parser.VectorSelector)
+	if !ok {
+		return nil, fmt.Errorf("promql: matrix selector's inner must be a VectorSelector, got %T",
+			ms.VectorSelector)
+	}
+
+	inner := lowerVectorSelector(vs, s)
+	return &chplan.RangeWindow{
+		Input: inner,
+		Func:  c.Func.Name,
+		Range: ms.Range,
+	}, nil
+}
+
+// lowerAggregate handles `sum by (job) (...)`, `count(...)`, etc.
+// Only the `by` form is supported in v0.1; `without` requires schema-wide
+// label introspection that lands later.
+func lowerAggregate(a *parser.AggregateExpr, s schema.Metrics) (chplan.Node, error) {
+	if a.Without {
+		return nil, fmt.Errorf("promql: 'without' aggregation is not yet supported (v0.1 supports 'by' only)")
+	}
+	if a.Param != nil {
+		return nil, fmt.Errorf("promql: parameterised aggregation (%s) is not yet supported", a.Op.String())
+	}
+
+	input, err := lower(a.Expr, s)
+	if err != nil {
+		return nil, err
+	}
+
+	groupBy := make([]chplan.Expr, 0, len(a.Grouping))
+	for _, label := range a.Grouping {
+		groupBy = append(groupBy, &chplan.MapAccess{
+			Map: &chplan.ColumnRef{Name: s.AttributesColumn},
+			Key: &chplan.LitString{V: label},
+		})
+	}
+
+	chFunc, err := chAggFunc(a.Op)
+	if err != nil {
+		return nil, err
+	}
+	return &chplan.Aggregate{
+		Input:   input,
+		GroupBy: groupBy,
+		AggFuncs: []chplan.AggFunc{{
+			Name:  chFunc,
+			Args:  []chplan.Expr{&chplan.ColumnRef{Name: s.ValueColumn}},
+			Alias: s.ValueColumn,
+		}},
+	}, nil
+}
+
+func chAggFunc(op parser.ItemType) (string, error) {
+	switch op {
+	case parser.SUM:
+		return "sum", nil
+	case parser.COUNT:
+		return "count", nil
+	case parser.AVG:
+		return "avg", nil
+	case parser.MIN:
+		return "min", nil
+	case parser.MAX:
+		return "max", nil
+	}
+	return "", fmt.Errorf("promql: aggregation op %s is not yet supported", op.String())
+}

--- a/internal/promql/lower_test.go
+++ b/internal/promql/lower_test.go
@@ -1,0 +1,107 @@
+package promql_test
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/test/spec"
+)
+
+var fixtureDir = filepath.Join("..", "..", "test", "spec", "promql")
+
+// TestLower walks every *.txtar fixture under test/spec/promql/, parses the
+// PromQL in `query.promql`, lowers it to a chplan, emits SQL, and asserts
+// the `sql` + `args` sections match what's recorded.
+//
+// To add a new case: create test/spec/promql/<name>.txtar with a
+// `-- query.promql --` section, then run `just update-golden`.
+func TestLower(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{})
+
+	spec.Walk(t, fixtureDir, func(t *testing.T, c *spec.Case) {
+		query, ok := c.Section("query.promql")
+		if !ok {
+			t.Fatalf("fixture %s missing 'query.promql' section", c.Name)
+		}
+		query = strings.TrimSpace(query)
+
+		expr, err := p.ParseExpr(query)
+		if err != nil {
+			t.Fatalf("ParseExpr(%q): %v", query, err)
+		}
+		plan, err := promql.Lower(expr, s)
+		if err != nil {
+			t.Fatalf("Lower(%q): %v", query, err)
+		}
+		sql, args, err := chsql.Emit(plan)
+		if err != nil {
+			t.Fatalf("Emit: %v", err)
+		}
+
+		spec.Match(t, c, map[string]string{
+			"sql":  sql,
+			"args": formatArgs(args),
+		})
+	})
+}
+
+// TestLower_errors covers the unsupported-PromQL paths so regressions in
+// the error message remain visible.
+func TestLower_errors(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{})
+
+	cases := []struct {
+		name    string
+		query   string
+		wantErr string
+	}{
+		{
+			name:    "without aggregation rejected",
+			query:   `sum without (instance) (up)`,
+			wantErr: "'without' aggregation is not yet supported",
+		},
+		{
+			name:    "binary op rejected",
+			query:   `up + up`,
+			wantErr: "unsupported expression",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr: %v", err)
+			}
+			if _, err := promql.Lower(expr, s); err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			} else if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func formatArgs(args []any) string {
+	if len(args) == 0 {
+		return "(none)\n"
+	}
+	var b strings.Builder
+	for i, a := range args {
+		fmt.Fprintf(&b, "[%d] %T = %#v\n", i, a, a)
+	}
+	return b.String()
+}

--- a/internal/schema/otel.go
+++ b/internal/schema/otel.go
@@ -1,0 +1,58 @@
+package schema
+
+// Metrics describes how cerberus reads metrics from ClickHouse. The default
+// (returned by DefaultOTelMetrics) matches the OpenTelemetry ClickHouse
+// Exporter v0.x schema; users with custom layouts override individual
+// fields via Config.
+type Metrics struct {
+	// GaugeTable is the table holding gauge metrics.
+	GaugeTable string
+	// SumTable is the table holding sum / counter metrics.
+	SumTable string
+	// HistogramTable is the table holding histogram metrics.
+	HistogramTable string
+
+	// MetricNameColumn names the column holding the metric name.
+	MetricNameColumn string
+	// AttributesColumn names the column holding metric labels (Map(String, String)).
+	AttributesColumn string
+	// ResourceAttributesColumn names the column holding resource labels.
+	ResourceAttributesColumn string
+	// TimestampColumn names the timestamp column (DateTime64).
+	TimestampColumn string
+	// ValueColumn names the numeric value column (Float64).
+	ValueColumn string
+}
+
+// DefaultOTelMetrics returns the schema produced by the upstream OTel
+// ClickHouse Exporter.
+func DefaultOTelMetrics() Metrics {
+	return Metrics{
+		GaugeTable:               "otel_metrics_gauge",
+		SumTable:                 "otel_metrics_sum",
+		HistogramTable:           "otel_metrics_histogram",
+		MetricNameColumn:         "MetricName",
+		AttributesColumn:         "Attributes",
+		ResourceAttributesColumn: "ResourceAttributes",
+		TimestampColumn:          "TimeUnix",
+		ValueColumn:              "Value",
+	}
+}
+
+// TableFor picks which metrics table a PromQL metric name belongs in. For
+// the v0.1 seed we use a Prom-naming heuristic — `_count`, `_total`, `_sum`,
+// `_bucket` suffixes are treated as cumulative (Sum table); everything else
+// goes to the Gauge table. This is the same convention the Prometheus
+// remote-write integration uses for OTel metrics.
+func (m Metrics) TableFor(metricName string) string {
+	for _, suf := range []string{"_count", "_total", "_sum", "_bucket"} {
+		if hasSuffix(metricName, suf) {
+			return m.SumTable
+		}
+	}
+	return m.GaugeTable
+}
+
+func hasSuffix(s, suffix string) bool {
+	return len(s) >= len(suffix) && s[len(s)-len(suffix):] == suffix
+}

--- a/test/spec/chsql/filter_map_access.txtar
+++ b/test/spec/chsql/filter_map_access.txtar
@@ -1,0 +1,5 @@
+-- args --
+[0] string = "job"
+[1] string = "api"
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`Attributes`[?] = ?)

--- a/test/spec/promql/count_no_group.txtar
+++ b/test/spec/promql/count_no_group.txtar
@@ -1,0 +1,6 @@
+-- query.promql --
+count(up)
+-- args --
+[0] string = "up"
+-- sql --
+SELECT count(`Value`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?))

--- a/test/spec/promql/rate_http_count.txtar
+++ b/test/spec/promql/rate_http_count.txtar
@@ -1,0 +1,6 @@
+-- query.promql --
+rate(http_server_request_duration_count[1m])
+-- args --
+[0] string = "http_server_request_duration_count"
+-- sql --
+/* range_window: func=rate range=1m0s step=0s */ SELECT * FROM (SELECT * FROM (SELECT * FROM `otel_metrics_sum`) WHERE (`MetricName` = ?))

--- a/test/spec/promql/sum_by_job.txtar
+++ b/test/spec/promql/sum_by_job.txtar
@@ -1,0 +1,8 @@
+-- query.promql --
+sum by (job) (up)
+-- args --
+[0] string = "job"
+[1] string = "up"
+[2] string = "job"
+-- sql --
+SELECT `Attributes`[?], sum(`Value`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?)) GROUP BY `Attributes`[?]

--- a/test/spec/promql/up.txtar
+++ b/test/spec/promql/up.txtar
@@ -1,0 +1,6 @@
+-- query.promql --
+up
+-- args --
+[0] string = "up"
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?)

--- a/test/spec/promql/up_with_label.txtar
+++ b/test/spec/promql/up_with_label.txtar
@@ -1,0 +1,8 @@
+-- query.promql --
+up{job="api"}
+-- args --
+[0] string = "job"
+[1] string = "api"
+[2] string = "up"
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE ((`Attributes`[?] = ?) AND (`MetricName` = ?))

--- a/test/spec/promql/up_with_regex.txtar
+++ b/test/spec/promql/up_with_regex.txtar
@@ -1,0 +1,8 @@
+-- query.promql --
+up{job=~"api-.*"}
+-- args --
+[0] string = "job"
+[1] string = "api-.*"
+[2] string = "up"
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (match(`Attributes`[?], ?) AND (`MetricName` = ?))


### PR DESCRIPTION
## Summary
PR 5 of 9 in the cerberus seed series — the first head goes end-to-end (parse → lower → SQL).

### \`internal/schema\`
\`Metrics\` struct describing the CH layout. \`DefaultOTelMetrics()\` matches the upstream OTel ClickHouse Exporter schema. \`TableFor(name)\` routes metric names ending in \`_count\` / \`_total\` / \`_sum\` / \`_bucket\` to the Sum table; everything else to Gauge.

### \`internal/promql\`
\`Lower(expr, schema)\` → \`chplan.Node\`, handling:
- \`VectorSelector\` (with \`__name__\` + label matchers + regex matchers)
- \`Call(rate|increase|delta|*_over_time, MatrixSelector(...))\`
- \`AggregateExpr\` (\`by\` form only; \`without\` rejected for v0.1)
- \`ParenExpr\`

### \`internal/chplan\`
Adds \`MapAccess\` expression for CH \`Map\` column lookups (rendered as \`<map>[<key>]\`). Used by PromQL label access; the IR remains QL-agnostic.

### \`internal/chsql\`
\`emit_expr.go\` grows a \`MapAccess\` arm; \`filter_map_access.txtar\` covers the direct emission.

### \`test/spec/promql\`
Six TXTAR fixtures, same runner as chsql:
- \`up\` — instant vector, no labels
- \`up_with_label\` — instant vector + Eq label
- \`up_with_regex\` — instant vector + regex label
- \`rate_http_count\` — range vector (rate over \`_count\`)
- \`sum_by_job\` — aggregation with \`by (...)\`
- \`count_no_group\` — aggregation, no grouping

## Sample output
\`up\`:
\`\`\`sql
SELECT * FROM (SELECT * FROM \`otel_metrics_gauge\`) WHERE (\`MetricName\` = ?)
\`\`\`
args: \`[\"up\"]\`

\`sum by (job) (up)\`:
\`\`\`sql
SELECT \`Attributes\`[?], sum(\`Value\`) AS \`Value\` FROM (SELECT * FROM (SELECT * FROM \`otel_metrics_gauge\`) WHERE (\`MetricName\` = ?)) GROUP BY \`Attributes\`[?]
\`\`\`
args: \`[\"job\", \"up\", \"job\"]\` — args duplication and nested-subquery flattening are optimizer rules in PR6.

## Test plan
- [x] \`just lint\` clean
- [x] \`just test\` passes (chplan/chsql/promql + smoke tests on logql/traceql)
- [x] All 6 PromQL fixtures regenerated + reviewed
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)