### PR TITLE
ci: relax commitlint subject-case rule (Dependabot uses sentence-case)

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -3,6 +3,7 @@
   "rules": {
     "header-max-length": [2, "always", 100],
     "body-max-line-length": [1, "always", 120],
+    "subject-case": [0],
     "type-enum": [
       2,
       "always",


### PR DESCRIPTION
## Summary
Dependabot's auto-generated commit subjects look like \`Bump actions/checkout from 4 to 6\` (capital 'B'). \`@commitlint/config-conventional\` rejects those with \`subject-case\`. Disabling that single rule lets weekly dep bumps merge cleanly; conventional type + scope are still enforced.

The two open Dependabot PRs (#2, #3) will go green on their next push or via 'Re-run all jobs'.

## Test plan
- [x] \`.commitlintrc.json\` validates locally
- [ ] CI green on this PR
- [ ] After merge, re-run CI on PR #2 + #3 → commitlint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)