### PR TITLE
chore(deps): bump actions/checkout to v6 across workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     name: lint + test + build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-go@v6
         with:
@@ -43,7 +43,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'


### PR DESCRIPTION
## Summary
Supersedes Dependabot PR #2 which conflicted with the \`actions/setup-go\` v6 bump in #3 (both modify the same workflow files).

Same intent — bump \`actions/checkout@v4\` → \`@v6\` in both \`ci.yml\` and \`mutation.yml\`. Squash-merge.

## Test plan
- [ ] CI green