### PR TITLE
ci: add markdownlint via markdownlint-cli2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,14 @@ jobs:
       - uses: wagoid/commitlint-github-action@v6
         with:
           configFile: .commitlintrc.json
+
+  markdownlint:
+    name: markdownlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: DavidAnson/markdownlint-cli2-action@v18
+        with:
+          globs: |
+            **/*.md

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,25 @@
+# https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+default: true
+
+# MD013 — line-length: relax for READMEs and PR bodies; URLs + tables don't
+# wrap well at 80 chars.
+MD013: false
+
+# MD033 — inline-html: allow for badges, <details>/<summary>, <sub>, etc.
+MD033: false
+
+# MD041 — first-line-h1: not every doc starts with a top-level heading
+# (e.g. docs/ files with frontmatter).
+MD041: false
+
+# MD024 — duplicate-headings: allow under different parents (CHANGELOG style).
+MD024:
+  siblings_only: true
+
+# MD034 — bare-URL: enabled by default; flag stray URLs so they get markdown
+# link syntax or angle brackets.
+
+# MD046 — code-block-style: prefer fenced; consistent with all our existing
+# code blocks.
+MD046:
+  style: fenced

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,4 @@
+node_modules/
+test/e2e/playwright/node_modules/
+test/e2e/playwright/playwright-report/
+test/e2e/playwright/test-results/

--- a/Justfile
+++ b/Justfile
@@ -7,6 +7,7 @@ GOLANGCI_LINT_VERSION := "v2.12.2"
 GOFUMPT_VERSION := "v0.7.0"
 GOIMPORTS_VERSION := "latest"
 GREMLINS_VERSION := "v0.6.0"
+MARKDOWNLINT_VERSION := "v0.18.1"
 MODULE := "github.com/tsouza/cerberus"
 
 # Default: list recipes.
@@ -62,9 +63,17 @@ mutate-pkg PATH:
 
 # === Lint / format ===
 
-# Run all linters.
+# Run Go linters.
 lint:
     golangci-lint run ./...
+
+# Lint all Markdown files (run via npm exec; no global Node deps).
+lint-md:
+    npm exec --yes -- markdownlint-cli2@{{MARKDOWNLINT_VERSION}} "**/*.md"
+
+# Auto-fix Markdown lint issues where possible.
+fmt-md:
+    npm exec --yes -- markdownlint-cli2@{{MARKDOWNLINT_VERSION}} --fix "**/*.md"
 
 # Format Go code.
 fmt:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ ClickHouse is a great single store for all three signals. The only thing missing
 
 ## Architecture
 
-```
+```text
    PromQL                LogQL                TraceQL
      │                     │                     │
      ▼                     ▼                     ▼
@@ -84,17 +84,17 @@ just e2e-down          # tear down
 
 ## Testing layers
 
-| Layer | What it covers | How to run |
-|-------|----------------|-----------|
-| **Unit** | Per-package logic, `Equal` contracts, optimizer rule kernels | `just test` |
-| **Spec (TXTAR)** | `<QL> → expected SQL` and `plan → optimized plan` golden tests under `test/spec/` | `just test`; `just update-golden` to regenerate |
-| **Integration** | `chclient` against a real ClickHouse via testcontainers | `go test -tags=integration ./internal/chclient/...` |
-| **E2E** | k3d cluster with CH + Grafana + cerberus; Grafana playwright smoke | `just e2e` |
-| **Mutation** | Gremlins mutation testing on `internal/` logic packages | `just mutate` (slow, nightly in CI) |
+| Layer            | What it covers                                                                 | How to run                                                  |
+| ---------------- | ------------------------------------------------------------------------------ | ----------------------------------------------------------- |
+| **Unit**         | Per-package logic, `Equal` contracts, optimizer rule kernels                   | `just test`                                                 |
+| **Spec (TXTAR)** | `<QL> → expected SQL` and `plan → optimized plan` golden tests under `test/spec/` | `just test`; `just update-golden` to regenerate          |
+| **Integration**  | `chclient` against a real ClickHouse via testcontainers                        | `go test -tags=integration ./internal/chclient/...`         |
+| **E2E**          | k3d cluster with CH + Grafana + cerberus; Grafana playwright smoke             | `just e2e`                                                  |
+| **Mutation**     | Gremlins mutation testing on `internal/` logic packages                        | `just mutate` (slow, nightly in CI)                         |
 
 ## Project structure
 
-```
+```text
 cmd/cerberus/            # main entrypoint
 internal/
   api/{prom,loki,tempo}/ # HTTP handlers per upstream API


### PR DESCRIPTION
## Summary
Adds Markdown linting to the project, in parallel with the existing Go lint + commitlint jobs.

### What lands
- **\`.markdownlint.yaml\`** — relaxes line-length (MD013) and allows inline HTML (MD033 for badges, \`<details>\`), but keeps fenced-code-language (MD040) and table-column-style (MD060) enforced so the README stays scannable.
- **\`.markdownlintignore\`** — covers \`node_modules\` + playwright artifacts so future PR8 additions don't accidentally get linted.
- **Justfile** — new \`lint-md\` and \`fmt-md\` recipes (run via \`npm exec\` so no global Node packages are required).
- **\`ci.yml\`** — parallel \`markdownlint\` job using \`DavidAnson/markdownlint-cli2-action\`. Runs on push + PR.
- **README** — fixed to pass the new ruleset: \`text\` language tags on the ASCII architecture + project-structure fences, and the testing-layers table is now space-padded.

### Follow-up
Once this merges and the \`markdownlint\` check name is visible to branch protection, I'll add it to the required status check list (currently: \`lint + test + build\`, \`commitlint\`).

## Test plan
- [x] \`just lint-md\` clean locally
- [ ] CI \`markdownlint\` job passes
- [ ] Add \`markdownlint\` to required status checks after first run

🤖 Generated with [Claude Code](https://claude.com/claude-code)