### PR TITLE
docs(agents): add CLAUDE.md, AGENTS.md, and project skills

### DIFF
--- a/.claude/skills/cerberus-add-fixture.md
+++ b/.claude/skills/cerberus-add-fixture.md
@@ -1,0 +1,61 @@
+---
+name: cerberus-add-fixture
+description: Scaffold a new TXTAR fixture under test/spec/<ql>/. Use when adding spec coverage for a new PromQL/LogQL/TraceQL/optimizer/chsql construct. Prompts for the QL (or area) and fixture name, creates the file with the right section headers pre-populated.
+tools: Read, Write, Bash
+---
+
+# /cerberus:add-fixture
+
+Create a new TXTAR fixture under `test/spec/<area>/<name>.txtar` and remind the user how to fill it in.
+
+## When to invoke
+
+The user says any of:
+
+- "add a fixture for `<query>`"
+- "scaffold a TXTAR for `<rule>`"
+- "new spec test"
+- "/cerberus:add-fixture"
+
+…and the active project is cerberus (`pwd` contains `cerberus`, repo origin is `tsouza/cerberus`).
+
+## Inputs
+
+Two positional arguments (prompt the user if missing):
+
+1. **Area** — one of `promql`, `logql`, `traceql`, `chsql`, `optimizer`.
+2. **Name** — snake_case, e.g. `rate_http_requests`, `filter_fusion_chain`. Must not already exist as a file under `test/spec/<area>/`.
+
+## What to do
+
+1. Confirm `pwd` is the repo root (the directory containing `go.mod`).
+2. Check `test/spec/<area>/<name>.txtar` doesn't already exist; if it does, abort and tell the user.
+3. Create the file with the right header per area:
+
+   **promql / logql / traceql**:
+
+   ```text
+   -- query.<area> --
+   <PASTE QUERY HERE>
+   ```
+
+   (only `query.<area>` — the `sql` and `args` sections get filled by `GOLDEN_UPDATE=1`.)
+
+   **chsql**: this area's fixtures don't have an input section because the input plan is constructed in Go (`internal/chsql/emit_test.go` `plans` map). Create the fixture with **no content** (just `touch test/spec/chsql/<name>.txtar`) and remind the user to add the matching entry to the `plans` map in `internal/chsql/emit_test.go`.
+
+   **optimizer**: same as `chsql` — input plans live in Go in `internal/optimizer/optimizer_test.go` `inputs` map. Create the empty file and remind the user to add the corresponding entry.
+
+4. Tell the user the three follow-up steps:
+   - For QL fixtures: paste the query into the `query.<area>` section.
+   - For chsql/optimizer: add the corresponding entry to the `plans` / `inputs` map in the matching `_test.go` file.
+   - Run `just update-golden` and review `git diff test/spec/` before committing.
+
+## Tools
+
+You only need:
+
+- `Read` — to check whether the fixture already exists and to read the matching `_test.go` file for chsql/optimizer.
+- `Write` — to create the file.
+- `Bash` — to `mkdir -p` the area dir and `touch` empty fixtures.
+
+Don't run `go test` — that's the user's job once the fixture is filled.

--- a/.claude/skills/cerberus-add-optimizer-rule.md
+++ b/.claude/skills/cerberus-add-optimizer-rule.md
@@ -1,0 +1,90 @@
+---
+name: cerberus-add-optimizer-rule
+description: Scaffold a new optimizer rule under internal/optimizer/. Creates the rule file, a unit test, and one TXTAR before/after fixture. Use when adding a new chplan→chplan rewrite (filter pushdown, projection elision, constant fold variant, transpose, …).
+tools: Read, Write, Bash
+---
+
+# /cerberus:add-optimizer-rule
+
+Scaffold the four files that make up a new optimizer rule.
+
+## When to invoke
+
+The user says any of:
+
+- "add an optimizer rule"
+- "new pushdown rule for X"
+- "/cerberus:add-optimizer-rule"
+
+## Inputs
+
+One positional argument (prompt if missing):
+
+- **Name** — Go type name in PascalCase, e.g. `FilterProjectTranspose`, `LimitFusion`. The filename is the snake_case form (`filter_project_transpose.go`).
+
+## Files to create
+
+1. **`internal/optimizer/<snake_name>.go`** — the rule implementation:
+
+   ```go
+   package optimizer
+
+   import "github.com/tsouza/cerberus/internal/chplan"
+
+   // <PascalName> describes what the rule does and why it matters.
+   // (Write this comment.)
+   type <PascalName> struct{}
+
+   func (<PascalName>) Name() string { return "<kebab-name>" }
+
+   func (<PascalName>) Apply(n chplan.Node) (chplan.Node, bool) {
+       // Pattern match + transform. Return (n, false) when no match.
+       return n, false
+   }
+   ```
+
+2. **`internal/optimizer/<snake_name>_test.go`** — Go-level unit test asserting the transformation:
+
+   ```go
+   package optimizer_test
+
+   import (
+       "testing"
+
+       "github.com/tsouza/cerberus/internal/chplan"
+       "github.com/tsouza/cerberus/internal/optimizer"
+   )
+
+   func Test<PascalName>_HappyPath(t *testing.T) {
+       t.Parallel()
+       // Build the matching tree, apply the rule, assert .Equal() against the expected tree.
+   }
+
+   func Test<PascalName>_NoMatch(t *testing.T) {
+       t.Parallel()
+       // Build a tree that shouldn't match, assert (n, false).
+   }
+   ```
+
+3. **`test/spec/optimizer/<snake_name>.txtar`** — empty file. The matching entry in `internal/optimizer/optimizer_test.go` `inputs` map is what generates the `unoptimized` / `optimized` sections via `GOLDEN_UPDATE=1`. The skill creates the empty file and tells the user to add the input plan in Go.
+
+4. **Register the rule** — add the rule to `optimizer.Default()` in `internal/optimizer/rule.go`. Find the existing call (e.g., `New(ConstantFold{}, FilterFusion{}, ProjectionPushdown{})`) and append the new rule **after** any rule it depends on (constant folding usually runs first; pushdowns later).
+
+## What to do
+
+1. Confirm `pwd` is the repo root.
+2. Check the four target paths don't already exist; abort if any does.
+3. Compute name forms: `PascalName` → `snake_name` (via simple regex) → `kebab-name`.
+4. Write each file.
+5. Tell the user the follow-up:
+   - Implement the rule body in `<snake_name>.go`.
+   - Add the matching entry to `optimizer_test.go` `inputs` map.
+   - Run `just update-golden` to generate the TXTAR `unoptimized` / `optimized` sections.
+   - Review the diff, then run `just test` + `just lint`.
+   - Commit with a Conventional Commits message: `feat(optimizer): add <kebab-name> rule`.
+
+## Don't
+
+- Don't implement the rule body — that's the user's actual work.
+- Don't run `just update-golden` automatically — the user wants to fill in the plan first.
+- Don't modify `optimizer.Default()` registration silently — the user may want the rule disabled at first; tell them what to add and where.

--- a/.claude/skills/cerberus-bump-parser-deps.md
+++ b/.claude/skills/cerberus-bump-parser-deps.md
@@ -1,0 +1,106 @@
+---
+name: cerberus-bump-parser-deps
+description: Bump the upstream PromQL/LogQL/TraceQL parser modules + dependent transitive packages, run the full test suite, and prepare a PR description summarising the upstream changelogs. Use when you want to pick up new parser features or security fixes.
+tools: Read, Write, Bash, WebFetch
+---
+
+# /cerberus:bump-parser-deps
+
+Bump `prometheus/prometheus`, `grafana/loki/v3`, `grafana/tempo`. Tame any new transitive-dep fallout (the memberlist swap is the recurring suspect). Capture changelog deltas for the PR description.
+
+## When to invoke
+
+User says:
+
+- "bump parsers"
+- "update PromQL/LogQL/TraceQL deps"
+- "/cerberus:bump-parser-deps"
+
+## What to do
+
+1. **Branch off main**:
+
+   ```sh
+   git checkout main && git pull --ff-only && git checkout -b chore/bump-parser-deps-$(date +%Y%m%d)
+   ```
+
+2. **Record current versions** before bumping:
+
+   ```sh
+   go list -m github.com/prometheus/prometheus github.com/grafana/loki/v3 github.com/grafana/tempo
+   ```
+
+3. **Bump**:
+
+   ```sh
+   go get -u github.com/prometheus/prometheus
+   go get github.com/grafana/loki/v3@latest
+   go get github.com/grafana/tempo@main
+   go mod tidy
+   ```
+
+   (Tempo uses `@main` because its v1.x tag is stale — see `docs/optimizer-research.md` notes.)
+
+4. **Try to build**:
+
+   ```sh
+   go build ./...
+   ```
+
+   **If it fails with `undefined: memberlist.NodeState` (or similar) from `dskit/kv/memberlist`:** the upstream memberlist pin has shifted. Find the new version by reading `~/go/pkg/mod/github.com/grafana/loki/v3@<new-version>/go.mod` for the `replace github.com/hashicorp/memberlist => github.com/grafana/memberlist@...` line and copy that version into cerberus's own `replace` in `go.mod`. Then `go mod tidy` again.
+
+5. **Run the full suite**:
+
+   ```sh
+   just lint && just test
+   ```
+
+   If a smoke test in `internal/{promql,logql,traceql}/parser_smoke_test.go` fails because of an API change (e.g. `parser.ParseExpr` → `parser.NewParser().ParseExpr`), fix the smoke test inline; the lowering callers in `lower.go` may need adjustments too.
+
+6. **Capture changelog deltas** for the PR description. For each bumped module, fetch the upstream release notes / commits and summarise the breaking changes + headline features. Use `WebFetch` against the project's GitHub releases page:
+   - `https://github.com/prometheus/prometheus/releases`
+   - `https://github.com/grafana/loki/releases`
+   - `https://github.com/grafana/tempo/releases`
+
+7. **Commit + open PR**:
+
+   ```sh
+   git add go.mod go.sum
+   git commit -m "chore(deps): bump <projects> to <versions>"
+   git push -u origin <branch>
+   gh pr create --base main --title "..." --body "<changelog summary>"
+   ```
+
+   PR body template:
+
+   ```markdown
+   ## Summary
+   - prometheus/prometheus: <old> → <new>
+   - grafana/loki/v3:       <old> → <new>
+   - grafana/tempo:         <old> → <new>
+
+   ## Upstream highlights
+   <one paragraph per project>
+
+   ## Local adjustments
+   - <e.g. memberlist replace version bumped from X to Y>
+   - <e.g. smoke test updated to use new ParseExpr API>
+
+   ## Test plan
+   - [ ] CI green
+   - [ ] Compliance suite pass rate unchanged or improved
+   ```
+
+8. **Monitor CI**. If `compliance.yml` shows new failures, the parser may have started accepting new queries that cerberus doesn't yet lower — those move to `expected-failures.json` with a comment, NOT silently allowed.
+
+## Tools
+
+- `Bash` — git, go, just.
+- `WebFetch` — release notes.
+- `Read` — `go.mod` after tidy, transitive `go.mod` files for memberlist.
+- `Write` — only for the PR body if you stash it to a temp file before `gh pr create`.
+
+## Don't
+
+- Don't bump just one of the three; bump them together so transitive resolutions stabilise in one go.
+- Don't silently add an `expected-failures.json` entry to make compliance pass. Investigate; if the failure is a genuine new feature we don't yet support, file the deferral as a separate item.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,78 @@
+# Cerberus — agent context
+
+Drop-in **Prometheus / Loki / Tempo** HTTP gateway for **ClickHouse**. Parses each upstream query language with its reference parser, lowers into a shared plan IR (`internal/chplan`), applies a small rule-based optimizer, and emits parameterised ClickHouse SQL. The HTTP layer speaks the upstream Prom / Loki / Tempo wire format so Grafana sees cerberus as three drop-in datasources.
+
+## Hard rules (non-negotiable)
+
+- **PR-per-change.** No direct pushes to `main` — branch protection rejects them. Required CI checks: `ci / check` + `ci / lint`. Linear history; force-push and deletion are off.
+- **No GitHub Issues.** They're disabled on the repo. Work is tracked in the [`Cerberus v1.0.0 Roadmap` GitHub Project](https://github.com/users/tsouza/projects/1) (RC / Workstream / Area / Status fields) and in PR descriptions. Backlog narratives live in `docs/*.md` files (notably [`docs/roadmap.md`](docs/roadmap.md) and [`docs/optimizer-research.md`](docs/optimizer-research.md)).
+- **Conventional Commits**, enforced by `commitlint` (see `.commitlintrc.json`). The `subject-case` rule is relaxed so Dependabot's `Bump X from Y to Z` subjects pass.
+- **Justfile is the canonical task runner.** `just` lists every recipe. Don't reach for `go test ./...` directly when `just test` exists — the recipe sets the race flag, the cover profile, and the right toolchain.
+- **Compliance is the source of truth for PromQL.** `prometheus/compliance` runs as a merge gate (`compliance.yml`). A PR that adds a PromQL feature but doesn't move the compliance pass rate is incomplete; an entry in `harness/compliance/expected-failures.json` requires a comment explaining the upstream rationale.
+
+## Architecture map
+
+```text
+internal/
+  api/{prom,loki,tempo}/    HTTP handlers per upstream API
+  promql/, logql/, traceql/ three heads: parse + lower
+  chplan/                    shared plan IR (Scan, Filter, Project, Aggregate, RangeWindow, Limit + Expr tree)
+  optimizer/                 rule-based, fixpoint driver. RC1 ships 3 rules (filter-fusion, constant-fold, projection-pushdown); RC3 expands.
+  chsql/                     plan → ClickHouse SQL emitter
+  chclient/                  CH driver wrapper (clickhouse-go/v2)
+  schema/                    OTel-CH default + override config
+  config/                    runtime config (env-driven)
+cmd/cerberus/                main entrypoint
+test/spec/                   TXTAR golden tests (input QL → SQL/plan)
+test/e2e/                    k3d cluster + Grafana playwright smoke
+harness/compliance/          prometheus/compliance Docker Compose harness (lands M0.6)
+deploy/{k3s,grafana}/        Kubernetes manifests + Grafana Helm values
+docs/                        roadmap.md, optimizer-research.md, compliance.md (M5.4)
+```
+
+Top-level reading order for any new contributor (human or agent):
+
+1. `README.md` — what the project is, quick start.
+2. `docs/roadmap.md` — RC1 / RC2 / RC3 plan, milestone tables, exit criteria.
+3. `docs/optimizer-research.md` — durable optimizer backlog for RC3.
+4. `internal/promql/lower.go` — the canonical lowering pattern; mirror it when adding LogQL / TraceQL slices.
+
+## Common workflows
+
+- **Add a TXTAR fixture** — use the `/cerberus:add-fixture` skill (under `.claude/skills/`). It creates `test/spec/<ql>/<name>.txtar` with the right section headers; run `just update-golden` after the implementation lands to fill in expected sections.
+- **Add an optimizer rule** — use the `/cerberus:add-optimizer-rule` skill. Scaffolds `internal/optimizer/<name>.go` + test + TXTAR fixtures.
+- **Bump parser deps** — use the `/cerberus:bump-parser-deps` skill. Runs `go get -u` on the three upstream parsers, runs `go mod tidy`, captures the diff for the PR description.
+- **Run E2E locally** — `just e2e-up && just e2e-seed && just e2e-run && just e2e-down` (lands in M0.1).
+- **Run the compliance suite** — `just compliance` (lands in M0.6). Diffs cerberus against reference Prometheus on a deterministic OTel fixture.
+
+## Toolchain notes
+
+- **Go version** — `go.mod` may pin a newer Go than what's installed system-wide. `GOTOOLCHAIN=auto` (the default) silently downloads the right version into `~/go/pkg/mod/golang.org/toolchain@...`. The `.envrc` (loaded by `direnv allow`) puts both the system Go and the downloaded toolchains on PATH.
+- **CGO** — left at the platform default so `go test -race` works. Goreleaser pins `CGO_ENABLED=0` for release builds independently.
+- **`golangci-lint` v2** — the config in `.golangci.yml` uses the v2 schema. `gofumpt` + `goimports` are configured under `formatters`, not `linters`. The v2 install path is `github.com/golangci/golangci-lint/v2/cmd/golangci-lint` (note the `/v2/`).
+
+## Transitive-dep gotcha (the one that bit us)
+
+`go.mod` has this entry:
+
+```text
+replace github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20260410131411-8c2f3bdae9db
+```
+
+Grafana's Loki, Tempo, and `dskit` all use a forked memberlist internally (via their own `replace` directives). Those replaces **do not propagate** to consumers. Without our own replace, the build fails with `undefined: memberlist.NodeState`, `mlCfg.NodeSelection`, `mlCfg.PushPullNodes` from `dskit/kv/memberlist`. If you bump Loki / Tempo and the build breaks here, check whether they've updated their pinned memberlist version and bump ours in lock-step.
+
+## GitHub identity
+
+Local SSH config has two GitHub identities:
+
+- `github.com` (default) → `tsouza-squid` (work). **Don't push cerberus work through this.**
+- `github.com-tsouza` → `tsouza` (personal). All cerberus commits + pushes go through this alias. Remote URL is `git@github.com-tsouza:tsouza/cerberus.git`.
+
+`gh` CLI may need `gh auth switch -u tsouza` if it lands on a different account. Project ops require the `project` scope on the `tsouza` token.
+
+## Pointers if you're lost
+
+- "How does this PR ship?" → branch + push + `gh pr create` → CI must pass → squash-merge with `gh pr merge --squash --delete-branch`.
+- "Where do I add this feature?" → check `docs/roadmap.md` first; the milestone tells you which package + which fixture dir.
+- "Is this RC1 / RC2 / RC3?" → roadmap tables make this explicit. When in doubt, add a comment to the PR asking.
+- "Can I update the Project from a PR?" → yes, the repo is linked. Move the matching draft item to `In Progress` when you start, `Done` when the PR merges (or wire a workflow that does it).


### PR DESCRIPTION
## Summary
M0.3 from the [roadmap](https://github.com/tsouza/cerberus/blob/main/docs/roadmap.md). Brings the repo onto the AI-agent grid so future contributors (Claude Code, Cursor, Copilot CLI, OpenAI Codex, etc.) load the right context without each one re-discovering it.

### What lands
- **\`CLAUDE.md\`** — agent context: project overview, hard rules (PR-per-change, no Issues, Conventional Commits, Justfile, compliance as source of truth), architecture map, common workflows, toolchain notes (\`GOTOOLCHAIN=auto\`, CGO defaults, golangci-lint v2), the **memberlist transitive-dep gotcha** spelled out, GitHub identity reminder (\`github.com-tsouza\` SSH alias).
- **\`AGENTS.md\`** — symlink to \`CLAUDE.md\`. Non-Claude agents that look for \`AGENTS.md\` pick up the same content.
- **\`.claude/skills/cerberus-add-fixture.md\`** — scaffolds a TXTAR file under \`test/spec/<area>/\`.
- **\`.claude/skills/cerberus-add-optimizer-rule.md\`** — scaffolds a rule file + unit test + TXTAR fixture; reminds the user to register in \`optimizer.Default()\`.
- **\`.claude/skills/cerberus-bump-parser-deps.md\`** — end-to-end parser-dep bump workflow, including the memberlist-replace remediation playbook and a changelog-summary PR body template.

Skills explicitly *don't* run \`update-golden\` / \`go test\` / register rules silently — scaffolds stay scaffolds; the user keeps the final commit.

## Test plan
- [x] \`just lint-md\` clean (markdownlint passes on all 8 markdown files)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)