### PR TITLE
docs: add CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, CODEOWNERS, PR template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,42 @@
+# CODEOWNERS — auto-request review on touched paths.
+# Format: <pattern> <owner1> <owner2> ...
+
+# Fallback: everything goes to @tsouza
+*                                          @tsouza
+
+# QL heads + shared IR + emitter + optimizer
+/internal/chplan/                          @tsouza
+/internal/chsql/                           @tsouza
+/internal/optimizer/                       @tsouza
+/internal/promql/                          @tsouza
+/internal/logql/                           @tsouza
+/internal/traceql/                         @tsouza
+
+# HTTP API surface
+/internal/api/                             @tsouza
+
+# Schema, config, CH client
+/internal/schema/                          @tsouza
+/internal/config/                          @tsouza
+/internal/chclient/                        @tsouza
+
+# CI + workflows + release plumbing
+/.github/                                  @tsouza
+/.goreleaser.yml                           @tsouza
+/Justfile                                  @tsouza
+
+# Test surfaces
+/test/                                     @tsouza
+/harness/                                  @tsouza
+
+# Deploy manifests
+/deploy/                                   @tsouza
+
+# Docs + roadmap
+/docs/                                     @tsouza
+/README.md                                 @tsouza
+/CLAUDE.md                                 @tsouza
+/AGENTS.md                                 @tsouza
+/CONTRIBUTING.md                           @tsouza
+/CODE_OF_CONDUCT.md                        @tsouza
+/SECURITY.md                               @tsouza

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+<!--
+PR title: Conventional Commits subject (e.g. `feat(promql): support offset modifier`).
+commitlint runs on the PR commits + the squash-merge subject.
+
+Project tracker: https://github.com/users/tsouza/projects/1
+Roadmap: docs/roadmap.md
+-->
+
+## Summary
+
+<!-- 2–4 bullets, focused on the WHY. Reviewers should be able to skim this and know the change's intent. -->
+
+-
+-
+
+## Roadmap link
+
+<!-- Which milestone does this PR close or move forward? e.g. M1.2 — BinaryExpr lowering. -->
+
+-
+
+## Test plan
+
+<!-- Check every line you actually ran. Add lines specific to the change. -->
+
+- [ ] `just lint` clean
+- [ ] `just test` passes (race + spec)
+- [ ] New / updated TXTAR fixture(s) reviewed: <paths>
+- [ ] Compliance pass rate moved (if PromQL-touching): <before> → <after>
+- [ ] CI green
+
+## Notes for reviewers
+
+<!-- Anything non-obvious: trade-offs, deferrals, rationale for an allowlist entry, etc. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,54 @@
+# Code of Conduct
+
+cerberus follows the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+
+## Our pledge
+
+We pledge to make participation in cerberus a harassment-free experience for everyone — regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+## Our standards
+
+Examples of behaviour that contributes to a positive environment:
+
+- Showing empathy and kindness toward other people.
+- Being respectful of differing opinions, viewpoints, and experiences.
+- Giving and gracefully accepting constructive feedback.
+- Accepting responsibility and apologising to those affected by our mistakes, learning from the experience.
+- Focusing on what's best not just for us as individuals, but for the overall community.
+
+Examples of unacceptable behaviour:
+
+- The use of sexualised language or imagery, and sexual attention or advances of any kind.
+- Trolling, insulting or derogatory comments, and personal or political attacks.
+- Public or private harassment.
+- Publishing others' private information, such as a physical or email address, without their explicit permission.
+- Other conduct which could reasonably be considered inappropriate in a professional setting.
+
+## Enforcement responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards and will take appropriate and fair corrective action in response to any behaviour they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces — issues are disabled on this repo, so the spaces are: PR descriptions and reviews, discussions (when enabled), and any external community space when an individual is officially representing the project.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported to the project maintainer at **<tcostasouza@gmail.com>**. All complaints will be reviewed and investigated promptly and fairly. The maintainer is obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement guidelines
+
+The maintainer will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+1. **Correction** — private written warning, with clarity around the nature of the violation and an explanation of why the behaviour was inappropriate. A public apology may be requested.
+2. **Warning** — a warning with consequences for continued behaviour. No interaction with the people involved (including unsolicited interaction with those enforcing the Code of Conduct) for a specified period. Violating these terms may lead to a temporary or permanent ban.
+3. **Temporary ban** — a temporary ban from any sort of interaction or public communication with the community for a specified period.
+4. **Permanent ban** — a permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1, available at <https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the FAQ at <https://www.contributor-covenant.org/faq>. Translations are available at <https://www.contributor-covenant.org/translations>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,86 @@
+# Contributing to cerberus
+
+Thanks for your interest. cerberus is small + opinionated — here's how to land a change.
+
+## The 30-second version
+
+```sh
+git checkout -b feat/<short-name>
+# ...edit...
+just lint && just test
+git commit -m "feat(<scope>): <subject>"   # Conventional Commits
+git push -u origin <branch>
+gh pr create
+```
+
+Two CI checks gate `main`: **`ci / check`** (golangci-lint + race tests + build) and **`ci / lint`** (commitlint + markdownlint). Branch protection is strict — your branch must be up-to-date with `main` before merging. Squash is the only merge style.
+
+## House rules
+
+1. **PR-per-change.** No direct pushes to `main` — branch protection rejects them. Even tiny fixes go through a PR.
+2. **No GitHub Issues.** They're disabled. Backlog narratives live in `docs/*.md`; status tracking lives in the [Cerberus v1.0.0 Roadmap Project](https://github.com/users/tsouza/projects/1). Open a draft PR if you want a place to discuss something before implementing.
+3. **Conventional Commits.** Subjects look like `feat(promql): support offset modifier` or `chore(deps): bump grafana/loki/v3 to v3.8.0`. `subject-case` is relaxed (Dependabot's `Bump X from Y to Z` passes); type + scope are still enforced. `commitlint.config.json` is the source of truth.
+4. **Justfile is the canonical task runner.** `just` lists every recipe. Don't run `go test ./...` directly — `just test` sets the race flag, cover profile, and correct toolchain. If you want a new workflow, add a recipe.
+5. **Fixture-first PRs.** A new PromQL/LogQL/TraceQL feature lands with its TXTAR spec first (failing, with the right `query.<ql>` section), then implementation that turns it green. Reviewers can sanity-check intent by reading fixtures before code.
+6. **Compliance suite is the source of truth.** If a PromQL feature lands but doesn't move the `prometheus/compliance` pass rate, the PR is incomplete. Adding an entry to `harness/compliance/expected-failures.json` requires a comment with the upstream rationale; never empty-string.
+
+## Setup
+
+```sh
+git clone git@github.com-tsouza:tsouza/cerberus.git   # or HTTPS; SSH alias if you have multiple GH identities
+cd cerberus
+direnv allow                                          # loads .envrc; puts Go + GOTOOLCHAIN=auto on PATH
+just install-tools                                    # one-time: golangci-lint, gofumpt, goimports, gremlins
+just ci                                               # lint + test + build
+```
+
+If `direnv allow` complains, `eval "$(direnv export bash)"` once per shell.
+
+`go.mod` may pin a newer Go than your system Go. `GOTOOLCHAIN=auto` (the default) silently fetches the right version into `~/go/pkg/mod/golang.org/toolchain@...`; no manual install needed.
+
+## Pull request flow
+
+1. **Pick a milestone.** [`docs/roadmap.md`](docs/roadmap.md) lists every RC1 milestone (M0.1 → M5.4) with one-line outcomes. Lower-numbered milestones generally come first.
+2. **Branch from current `main`.** Branch names match the work: `seed/m1.2-binary-expr`, `chore/bump-grafana-deps`, `fix/range-window-counter-reset`.
+3. **Write the failing fixture first.** For QL changes, that's a TXTAR under `test/spec/<ql>/`. Use the `/cerberus:add-fixture` skill if you're driving Claude Code.
+4. **Implement + iterate.** `just test` for the inner loop; `just lint` before pushing.
+5. **Commit with Conventional Commits.** Examples in [`docs/roadmap.md`](docs/roadmap.md) milestone tables.
+6. **Push + open PR.** Title matches the commit subject; body explains *why* + a Test plan checklist. Link the milestone draft in the [Project](https://github.com/users/tsouza/projects/1).
+7. **CI green → squash-merge.** Branch deleted on merge.
+
+### A good PR description
+
+```markdown
+## Summary
+- One bullet per substantive change, focused on *why*.
+
+## Test plan
+- [ ] just lint clean
+- [ ] just test passes (race + spec)
+- [ ] new TXTAR fixture(s) reviewed: <paths>
+- [ ] compliance pass rate moved: <from> → <to>
+- [ ] CI green
+```
+
+If you're touching the compliance harness, include the JSON diff (`harness/compliance/expected-failures.json` before/after) in the body.
+
+## Testing layers
+
+`docs/roadmap.md` has the full table. Headline:
+
+- **Unit + spec (TXTAR)** — run on every PR; merge gate.
+- **PromQL compliance** — `prometheus/compliance` Docker harness; merge gate for PRs touching `internal/promql/**`, `internal/chsql/**`, `internal/optimizer/**`.
+- **E2E (k3d + Grafana playwright)** — path-gated on `internal/api/**` + `deploy/**`; merge gate when touched.
+- **Mutation** — Gremlins nightly; informational, investigated weekly.
+
+## Project memory and AI assistants
+
+If you use Claude Code (or any agent that reads `CLAUDE.md` / `AGENTS.md`), the context is pre-loaded. The three skills under `.claude/skills/` cover the most common workflows (add fixture, add optimizer rule, bump parser deps).
+
+## Reporting security issues
+
+See [`SECURITY.md`](SECURITY.md) — don't open public PRs for security-sensitive reports.
+
+## Code of conduct
+
+See [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md). Be kind; assume good faith.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,46 @@
+# Security policy
+
+## Supported versions
+
+cerberus is pre-1.0; only the latest tagged release (or `main` if no tag exists) is supported. Once v1.0 ships, this section will document an N-1 support window.
+
+## Reporting a vulnerability
+
+**Do not open a public PR or GitHub Discussion** for a security report. The repo has GitHub Issues disabled by policy; the secure channels are:
+
+1. **GitHub private vulnerability reporting** — preferred. Click the `Security` tab on <https://github.com/tsouza/cerberus> and use "Report a vulnerability". This routes through GitHub's [private advisory flow](https://docs.github.com/en/code-security/security-advisories) and stays confidential until a fix ships.
+2. **Email** — `tcostasouza@gmail.com` with `[cerberus security]` in the subject if you can't use the GitHub flow.
+
+Please include:
+
+- A clear description of the issue.
+- A minimal reproducer (a TXTAR fixture, a curl command against `/api/v1/query`, etc.).
+- The version of cerberus + ClickHouse you tested against.
+- Your assessment of impact (information disclosure, denial of service, unauthenticated execution, etc.).
+
+## What to expect
+
+- **Acknowledgement** within 72 hours.
+- **Triage** (a public-facing patch plan, or "this is not a vulnerability, here's why") within 7 days.
+- **Coordinated disclosure** — we'll work with you on a timeline. Default window is 90 days from the initial report unless severity dictates faster, in which case we'll publish the advisory + patch on the same day.
+
+## Threat model in scope
+
+- Query-injection / SQL-construction safety in `internal/chsql`. Arguments are bound positionally via `?` placeholders; bugs that allow literal interpolation are in scope.
+- Authentication and tenant-isolation flaws once the multi-tenant header (`X-Scope-OrgID`) lands.
+- ReDoS or super-linear parser pathologies in any of the three QL parsers (cerberus passes input verbatim to upstream parsers; if a query is rejected upstream as expensive, cerberus should reject it too).
+- Information disclosure via error messages (CH-side schema details leaking into Prometheus-shaped error responses).
+
+## Out of scope
+
+- Bugs in upstream `prometheus/prometheus`, `grafana/loki`, `grafana/tempo`, or `clickhouse-go` — please file upstream.
+- Misconfigurations in deployments (e.g. exposing CH without auth in front of cerberus).
+- Denial of service via legitimately expensive queries; cerberus relies on ClickHouse's query-time controls. We'll happily document mitigations.
+
+## Cryptographic hardening
+
+cerberus doesn't ship cryptographic primitives. The HTTP server delegates TLS to a reverse proxy (per the deployment manifests in `deploy/k3s/`). Bugs in upstream TLS / authn libraries should go to those projects.
+
+## Hall of fame
+
+We'll list responsible reporters here once we have any. Add yourself in the same PR that fixes the issue if you'd like attribution.


### PR DESCRIPTION
## Summary
M0.4 from the [roadmap](https://github.com/tsouza/cerberus/blob/main/docs/roadmap.md). Engineering-hygiene files; nothing boilerplate — each is opinionated to match the project's actual rules.

### What lands
- **\`CONTRIBUTING.md\`** — 30-second loop, house rules (PR-per-change, no Issues, Conventional Commits, Justfile, fixture-first, compliance is truth), setup, PR flow, good PR description template.
- **\`CODE_OF_CONDUCT.md\`** — Contributor Covenant 2.1, adapted (community spaces are PR descriptions/reviews + discussions because issues are off). Email + enforcement ladder.
- **\`SECURITY.md\`** — private vulnerability reporting via the GitHub Security tab (preferred) or email; ack/triage/coordinated-disclosure SLOs; in-scope vs out-of-scope threat model.
- **\`.github/CODEOWNERS\`** — @tsouza on everything for now; structured per-area for co-owners later.
- **\`.github/PULL_REQUEST_TEMPLATE.md\`** — Summary / Roadmap link / Test plan (with compliance-rate line for PromQL-touching PRs) / Notes for reviewers. No issue templates.

## Roadmap link

- M0.4 — Engineering hygiene

## Test plan
- [x] \`just lint-md\` clean (markdownlint passes on all 7 markdown files)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)