### PR TITLE
build(e2e): add k3d deploy manifests, Dockerfile.local, e2e Justfile recipes

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,0 +1,27 @@
+# syntax=docker/dockerfile:1
+# Local-build Dockerfile for E2E (consumed by `just e2e-up`).
+#
+# The release Dockerfile (`./Dockerfile`) expects the binary to already be
+# built by goreleaser. For E2E we want a one-shot multi-stage build that
+# produces the same final image without needing goreleaser locally.
+
+FROM golang:1.26 AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w -X main.Version=e2e" -o /out/cerberus ./cmd/cerberus
+
+FROM gcr.io/distroless/static-debian12:nonroot
+
+LABEL org.opencontainers.image.title="cerberus"
+LABEL org.opencontainers.image.description="Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse"
+LABEL org.opencontainers.image.licenses="MIT"
+
+COPY --from=build /out/cerberus /usr/local/bin/cerberus
+
+EXPOSE 8080
+
+USER nonroot:nonroot
+
+ENTRYPOINT ["/usr/local/bin/cerberus"]

--- a/Justfile
+++ b/Justfile
@@ -90,3 +90,62 @@ ci: lint test build
 # go mod tidy.
 deps-tidy:
     go mod tidy
+
+# === E2E (k3d + ClickHouse + Grafana + cerberus) ===
+
+K3D_CLUSTER := "cerberus-e2e"
+CERBERUS_IMAGE := "cerberus:e2e"
+
+# Boot the k3d cluster, build cerberus image, import it, apply manifests, wait for pods.
+e2e-up: e2e-down
+    @echo "==> creating k3d cluster {{K3D_CLUSTER}}"
+    k3d cluster create {{K3D_CLUSTER}} \
+        --port "3000:3000@loadbalancer" \
+        --port "8080:8080@loadbalancer" \
+        --no-lb=false \
+        --k3s-arg "--disable=traefik@server:0" \
+        --wait
+    @echo "==> building cerberus image"
+    docker build -t {{CERBERUS_IMAGE}} -f Dockerfile.local .
+    @echo "==> importing image into k3d"
+    k3d image import {{CERBERUS_IMAGE}} -c {{K3D_CLUSTER}}
+    @echo "==> applying manifests"
+    kubectl apply -k deploy/k3s/
+    @echo "==> waiting for pods (up to 3 min)"
+    kubectl -n cerberus wait --for=condition=Available deployment/clickhouse --timeout=180s
+    kubectl -n cerberus wait --for=condition=Available deployment/cerberus   --timeout=180s
+    kubectl -n cerberus wait --for=condition=Available deployment/grafana    --timeout=180s
+    @echo "==> e2e-up done"
+    @echo "    grafana:    http://localhost:3000 (admin/admin)"
+    @echo "    cerberus:   http://localhost:8080/healthz"
+
+# Ingest sample OTel data into ClickHouse.
+e2e-seed:
+    @echo "==> seeding OTel metrics"
+    kubectl -n cerberus exec deploy/clickhouse -- \
+        clickhouse-client --user cerberus --password cerberus --multiquery < test/e2e/seed/otel_metrics.sql
+    @echo "==> seed done"
+
+# Run Go E2E HTTP tests against the deployed stack.
+e2e-run:
+    @echo "==> running Go E2E tests"
+    go test -tags=e2e ./test/e2e/...
+
+# Run the Grafana playwright smoke (lands in M0.2).
+e2e-playwright:
+    @echo "==> playwright smoke (lands in M0.2)"
+    @if [ -d test/e2e/playwright ]; then \
+        cd test/e2e/playwright && npm ci && npx playwright test; \
+    else \
+        echo "    (no playwright suite yet — landing in M0.2)"; \
+    fi
+
+# Tear down the cluster.
+e2e-down:
+    @if k3d cluster list | grep -q "^{{K3D_CLUSTER}} "; then \
+        echo "==> deleting k3d cluster {{K3D_CLUSTER}}"; \
+        k3d cluster delete {{K3D_CLUSTER}}; \
+    fi
+
+# Full lifecycle.
+e2e: e2e-up e2e-seed e2e-run e2e-playwright e2e-down

--- a/deploy/k3s/cerberus.yaml
+++ b/deploy/k3s/cerberus.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cerberus-config
+  namespace: cerberus
+data:
+  CERBERUS_HTTP_ADDR: ":8080"
+  CERBERUS_CH_ADDR: "clickhouse:9000"
+  CERBERUS_CH_DATABASE: "otel"
+  CERBERUS_CH_USERNAME: "cerberus"
+  CERBERUS_CH_PASSWORD: "cerberus"
+  CERBERUS_CH_DIAL_TIMEOUT: "10s"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cerberus
+  namespace: cerberus
+  labels:
+    app: cerberus
+spec:
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+  selector:
+    app: cerberus
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cerberus
+  namespace: cerberus
+  labels:
+    app: cerberus
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: cerberus
+  template:
+    metadata:
+      labels:
+        app: cerberus
+    spec:
+      containers:
+        - name: cerberus
+          # Image is built locally and imported into k3d via `just e2e-up`.
+          # See Justfile's e2e-up recipe.
+          image: cerberus:e2e
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: cerberus-config
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10

--- a/deploy/k3s/clickhouse.yaml
+++ b/deploy/k3s/clickhouse.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: clickhouse
+  namespace: cerberus
+  labels:
+    app: clickhouse
+spec:
+  ports:
+    - name: native
+      port: 9000
+      targetPort: 9000
+    - name: http
+      port: 8123
+      targetPort: 8123
+  selector:
+    app: clickhouse
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: clickhouse
+  namespace: cerberus
+  labels:
+    app: clickhouse
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: clickhouse
+  template:
+    metadata:
+      labels:
+        app: clickhouse
+    spec:
+      containers:
+        - name: clickhouse
+          image: clickhouse/clickhouse-server:24.8-alpine
+          ports:
+            - name: native
+              containerPort: 9000
+            - name: http
+              containerPort: 8123
+          env:
+            - name: CLICKHOUSE_DB
+              value: otel
+            - name: CLICKHOUSE_USER
+              value: cerberus
+            - name: CLICKHOUSE_PASSWORD
+              value: cerberus
+            - name: CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT
+              value: "1"
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+            limits:
+              memory: 2Gi
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10

--- a/deploy/k3s/grafana.yaml
+++ b/deploy/k3s/grafana.yaml
@@ -1,0 +1,101 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasources
+  namespace: cerberus
+data:
+  datasources.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: Cerberus-Prometheus
+        type: prometheus
+        access: proxy
+        url: http://cerberus:8080
+        isDefault: true
+        editable: false
+        jsonData:
+          timeInterval: 15s
+      - name: Cerberus-Loki
+        type: loki
+        access: proxy
+        url: http://cerberus:8080
+        editable: false
+      - name: Cerberus-Tempo
+        type: tempo
+        access: proxy
+        url: http://cerberus:8080
+        editable: false
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  namespace: cerberus
+  labels:
+    app: grafana
+spec:
+  ports:
+    - name: http
+      port: 3000
+      targetPort: 3000
+  selector:
+    app: grafana
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  namespace: cerberus
+  labels:
+    app: grafana
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+        - name: grafana
+          image: grafana/grafana:11.4.0
+          ports:
+            - name: http
+              containerPort: 3000
+          env:
+            - name: GF_SECURITY_ADMIN_USER
+              value: admin
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              value: admin
+            - name: GF_AUTH_ANONYMOUS_ENABLED
+              value: "true"
+            - name: GF_AUTH_ANONYMOUS_ORG_ROLE
+              value: Viewer
+            - name: GF_USERS_DEFAULT_THEME
+              value: dark
+            - name: GF_FEATURE_TOGGLES_ENABLE
+              value: traceqlSearch
+          volumeMounts:
+            - name: datasources
+              mountPath: /etc/grafana/provisioning/datasources
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              memory: 512Mi
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      volumes:
+        - name: datasources
+          configMap:
+            name: grafana-datasources

--- a/deploy/k3s/kustomization.yaml
+++ b/deploy/k3s/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: cerberus
+
+resources:
+  - namespace.yaml
+  - clickhouse.yaml
+  - cerberus.yaml
+  - grafana.yaml
+
+commonLabels:
+  app.kubernetes.io/part-of: cerberus

--- a/deploy/k3s/namespace.yaml
+++ b/deploy/k3s/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cerberus
+  labels:
+    app.kubernetes.io/part-of: cerberus

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,0 +1,103 @@
+//go:build e2e
+
+// Package e2e holds HTTP-level end-to-end tests run against a deployed
+// cerberus stack (k3d + ClickHouse + Grafana + cerberus, brought up by
+// `just e2e-up`). Gated by the `e2e` build tag so regular `go test ./...`
+// doesn't try to dial localhost:8080.
+//
+// Run via: just e2e-run  (after just e2e-up && just e2e-seed)
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+)
+
+// baseURL is the cerberus HTTP endpoint. Defaults to the port-forwarded
+// localhost address that `just e2e-up` exposes; override via CERBERUS_URL
+// to point at a different deployment.
+func baseURL() string {
+	if v := os.Getenv("CERBERUS_URL"); v != "" {
+		return v
+	}
+	return "http://localhost:8080"
+}
+
+func TestHealthz(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL()+"/healthz", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /healthz: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "ok" {
+		t.Fatalf("body: got %q, want %q", body, "ok")
+	}
+}
+
+func TestPromQueryUp(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL()+"/api/v1/query?query=up", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /api/v1/query?query=up: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: got %d, want 200; body=%s", resp.StatusCode, body)
+	}
+
+	var parsed struct {
+		Status string `json:"status"`
+		Data   struct {
+			ResultType string `json:"resultType"`
+			Result     []struct {
+				Metric map[string]string `json:"metric"`
+				Value  []any             `json:"value"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if parsed.Status != "success" {
+		t.Fatalf("status: got %q, want success", parsed.Status)
+	}
+	if parsed.Data.ResultType != "vector" {
+		t.Fatalf("resultType: got %q, want vector", parsed.Data.ResultType)
+	}
+	if len(parsed.Data.Result) < 1 {
+		t.Fatalf("expected at least one series; got %d", len(parsed.Data.Result))
+	}
+	for _, s := range parsed.Data.Result {
+		if s.Metric["__name__"] != "up" {
+			t.Errorf("series missing __name__=up; got %+v", s.Metric)
+		}
+		if _, ok := s.Metric["job"]; !ok {
+			t.Errorf("series missing job label; got %+v", s.Metric)
+		}
+	}
+}

--- a/test/e2e/seed/otel_metrics.sql
+++ b/test/e2e/seed/otel_metrics.sql
@@ -1,0 +1,71 @@
+-- Seed minimal OTel-CH metrics for E2E. Mirrors the columns the OTel
+-- ClickHouse Exporter writes for the Gauge / Sum tables, narrowed to the
+-- subset cerberus's PromQL slice reads today.
+--
+-- Run via `just e2e-seed`.
+
+CREATE TABLE IF NOT EXISTS otel.otel_metrics_gauge (
+    ResourceAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    ResourceSchemaUrl  String CODEC(ZSTD(1)),
+    ScopeName          String CODEC(ZSTD(1)),
+    ScopeVersion       String CODEC(ZSTD(1)),
+    ScopeAttributes    Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    MetricName         String CODEC(ZSTD(1)),
+    MetricDescription  String CODEC(ZSTD(1)),
+    MetricUnit         String CODEC(ZSTD(1)),
+    Attributes         Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    StartTimeUnix      DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+    TimeUnix           DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+    Value              Float64 CODEC(ZSTD(1))
+)
+ENGINE = MergeTree()
+PARTITION BY toYYYYMMDD(TimeUnix)
+ORDER BY (MetricName, toUnixTimestamp64Nano(TimeUnix))
+TTL toDateTime(TimeUnix) + INTERVAL 1 DAY;
+
+CREATE TABLE IF NOT EXISTS otel.otel_metrics_sum (
+    ResourceAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    ResourceSchemaUrl  String CODEC(ZSTD(1)),
+    ScopeName          String CODEC(ZSTD(1)),
+    ScopeVersion       String CODEC(ZSTD(1)),
+    ScopeAttributes    Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    MetricName         String CODEC(ZSTD(1)),
+    MetricDescription  String CODEC(ZSTD(1)),
+    MetricUnit         String CODEC(ZSTD(1)),
+    Attributes         Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    StartTimeUnix      DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+    TimeUnix           DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+    Value              Float64 CODEC(ZSTD(1)),
+    Flags              UInt32 CODEC(ZSTD(1)),
+    AggregationTemporality Int32 CODEC(ZSTD(1)),
+    IsMonotonic        Bool CODEC(ZSTD(1))
+)
+ENGINE = MergeTree()
+PARTITION BY toYYYYMMDD(TimeUnix)
+ORDER BY (MetricName, toUnixTimestamp64Nano(TimeUnix))
+TTL toDateTime(TimeUnix) + INTERVAL 1 DAY;
+
+-- Two `up` series at the current time so the PromQL slice has something to
+-- return. PR8's playwright smoke queries these.
+INSERT INTO otel.otel_metrics_gauge
+  (ResourceAttributes, MetricName, MetricDescription, MetricUnit, Attributes, StartTimeUnix, TimeUnix, Value)
+VALUES
+  ({'service.name': 'api'}, 'up', 'Is the scrape target up', '1', {'job': 'api'}, now64(9), now64(9), 1.0),
+  ({'service.name': 'db'},  'up', 'Is the scrape target up', '1', {'job': 'db'},  now64(9), now64(9), 0.0);
+
+-- A small counter to exercise rate() once M1.1 lands RangeWindow emission.
+INSERT INTO otel.otel_metrics_sum
+  (ResourceAttributes, MetricName, MetricDescription, MetricUnit, Attributes, StartTimeUnix, TimeUnix, Value, Flags, AggregationTemporality, IsMonotonic)
+SELECT
+    map('service.name', 'api'),
+    'http_server_request_duration_count',
+    'HTTP request count by status',
+    '1',
+    map('job', 'api', 'http_status', '200'),
+    now64(9) - INTERVAL number SECOND,
+    now64(9) - INTERVAL number SECOND,
+    toFloat64(1000 + number * 5),
+    toUInt32(0),
+    toInt32(2),
+    true
+FROM numbers(60);


### PR DESCRIPTION
## Summary
M0.1 from the [roadmap](https://github.com/tsouza/cerberus/blob/main/docs/roadmap.md). Brings the E2E harness online so M0.2 (playwright smoke) and PR-level integration tests have a real stack.

### What lands
- **\`deploy/k3s/\`** — namespace + ClickHouse 24.8 (\`otel\` db, \`cerberus/cerberus\` auth) + cerberus Deployment + Service + ConfigMap + Grafana 11.4 with three pre-provisioned datasources (Prom / Loki / Tempo) all pointing at the cerberus service. Anonymous viewer enabled so playwright doesn't have to log in; \`traceqlSearch\` feature toggle on.
- **\`Dockerfile.local\`** — multi-stage build for E2E (release Dockerfile expects goreleaser to drop the binary; this one builds it). Same distroless nonroot base, image parity with prod.
- **\`test/e2e/seed/otel_metrics.sql\`** — creates \`otel_metrics_gauge\` + \`otel_metrics_sum\` with the OTel-CH exporter schema; inserts two \`up\` series and 60 rows of a monotonic counter (\`http_server_request_duration_count\`) so M1.1's \`rate()\` emission has something to chew on.
- **\`test/e2e/e2e_test.go\`** — \`-tags=e2e\` gated; covers \`/healthz\` and \`/api/v1/query?query=up\`. \`CERBERUS_URL\` env overrides the localhost:8080 default.
- **\`Justfile\`** — \`e2e-up\` / \`e2e-seed\` / \`e2e-run\` / \`e2e-playwright\` (stub until M0.2) / \`e2e-down\` / \`e2e\` (full lifecycle).

### Quick start

\`\`\`sh
just e2e-up && just e2e-seed && just e2e-run && just e2e-down
\`\`\`

### Roadmap link

- M0.1 — k3d deploy + e2e Justfile recipes

## Test plan
- [x] \`just --list\` shows new e2e-* recipes
- [x] \`go vet -tags=e2e ./test/e2e/...\` clean
- [x] \`just lint-md\` clean
- [ ] Local: \`just e2e-up && just e2e-seed && just e2e-run && just e2e-down\` green (requires Docker + k3d + kubectl)
- [ ] CI green (compile check only; e2e workflow lands M0.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)