### PR TITLE
test(e2e): add playwright smoke and e2e.yml workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,100 @@
+name: e2e
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - 'cmd/**'
+      - 'internal/**'
+      - 'deploy/**'
+      - 'test/e2e/**'
+      - 'Justfile'
+      - 'Dockerfile.local'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/e2e.yml'
+  schedule:
+    # nightly at 03:17 UTC
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  e2e:
+    name: k3d + cerberus + grafana + playwright
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: 'test/e2e/playwright/package.json'
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just
+
+      - name: Install k3d
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v5.8.3 bash
+
+      - name: Bring up k3d stack
+        run: just e2e-up
+
+      - name: Seed OTel data
+        run: just e2e-seed
+
+      - name: Run Go E2E tests
+        run: just e2e-run
+
+      - name: Install Playwright + browsers
+        working-directory: test/e2e/playwright
+        run: |
+          npm ci || npm install
+          npx playwright install --with-deps chromium
+
+      - name: Run Playwright smoke
+        working-directory: test/e2e/playwright
+        env:
+          GRAFANA_URL: http://localhost:3000
+          CERBERUS_URL: http://localhost:8080
+        run: npx playwright test
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: test/e2e/playwright/playwright-report
+          retention-days: 14
+
+      - name: Dump cluster state on failure
+        if: failure()
+        run: |
+          echo "=== pods ==="
+          kubectl -n cerberus get pods -o wide || true
+          echo "=== cerberus logs ==="
+          kubectl -n cerberus logs deploy/cerberus --tail 200 || true
+          echo "=== clickhouse logs ==="
+          kubectl -n cerberus logs deploy/clickhouse --tail 200 || true
+          echo "=== grafana logs ==="
+          kubectl -n cerberus logs deploy/grafana --tail 200 || true
+
+      - name: Tear down
+        if: always()
+        run: just e2e-down

--- a/deploy/k3s/grafana.yaml
+++ b/deploy/k3s/grafana.yaml
@@ -9,6 +9,7 @@ data:
     apiVersion: 1
     datasources:
       - name: Cerberus-Prometheus
+        uid: cerberus-prometheus
         type: prometheus
         access: proxy
         url: http://cerberus:8080
@@ -17,11 +18,13 @@ data:
         jsonData:
           timeInterval: 15s
       - name: Cerberus-Loki
+        uid: cerberus-loki
         type: loki
         access: proxy
         url: http://cerberus:8080
         editable: false
       - name: Cerberus-Tempo
+        uid: cerberus-tempo
         type: tempo
         access: proxy
         url: http://cerberus:8080

--- a/test/e2e/playwright/package.json
+++ b/test/e2e/playwright/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "cerberus-e2e-playwright",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Grafana e2e smoke tests against cerberus.",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "report": "playwright show-report"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.50.0",
+    "@types/node": "^22.10.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/test/e2e/playwright/playwright.config.ts
+++ b/test/e2e/playwright/playwright.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright config for the Grafana smoke suite.
+ *
+ * Run via `just e2e-playwright` (which assumes `just e2e-up` has already
+ * brought up the k3d stack on localhost:3000).
+ *
+ * Env:
+ *   GRAFANA_URL   default http://localhost:3000  (Grafana base URL)
+ *   CERBERUS_URL  default http://localhost:8080  (cerberus HTTP, for
+ *                                                  direct API-shape tests)
+ */
+const grafanaURL = process.env.GRAFANA_URL ?? 'http://localhost:3000';
+
+export default defineConfig({
+  testDir: '.',
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
+
+  use: {
+    baseURL: grafanaURL,
+    trace: 'on-first-retry',
+    video: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/test/e2e/playwright/smoke.spec.ts
+++ b/test/e2e/playwright/smoke.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Smoke test for the Grafana <-> cerberus integration.
+ *
+ * Strategy:
+ *   1. Hit Grafana's /api/health to confirm Grafana itself is up.
+ *   2. Hit cerberus's /healthz to confirm cerberus is up.
+ *   3. Query through Grafana's datasource proxy at
+ *      /api/datasources/proxy/uid/cerberus-prometheus/api/v1/query?query=up
+ *      and assert we get a `success` Prom-shaped response with at least
+ *      one series carrying the `job` label. This proves the entire
+ *      chain: Grafana sees cerberus as a Prom datasource, cerberus
+ *      receives the request, lowers it, executes against ClickHouse,
+ *      and returns Prom-shaped JSON that Grafana parses.
+ *
+ * Grafana anonymous viewer access is enabled in deploy/k3s/grafana.yaml,
+ * so the request goes through without auth.
+ *
+ * UI-level (Explore page) checks land once M2 lands real label/series
+ * endpoints; today the metadata picker in Explore would error.
+ */
+test('grafana sees cerberus as a prometheus datasource', async ({ request }) => {
+  // Grafana health.
+  const grafanaHealth = await request.get('/api/health');
+  expect(grafanaHealth.status(), 'grafana /api/health').toBe(200);
+
+  // cerberus health (direct, not via Grafana).
+  const cerberusURL = process.env.CERBERUS_URL ?? 'http://localhost:8080';
+  const cerberusHealth = await request.get(`${cerberusURL}/healthz`);
+  expect(cerberusHealth.status(), 'cerberus /healthz').toBe(200);
+
+  // Datasource proxy query via Grafana.
+  const queryResp = await request.get(
+    '/api/datasources/proxy/uid/cerberus-prometheus/api/v1/query?query=up',
+  );
+  expect(queryResp.status(), 'grafana ds-proxy query status').toBe(200);
+
+  const body = await queryResp.json();
+  expect(body.status, 'prom response status').toBe('success');
+  expect(body.data.resultType, 'prom resultType').toBe('vector');
+  expect(body.data.result.length, 'at least one series in vector').toBeGreaterThan(0);
+
+  // Every series should carry __name__=up and a job label (from the seed).
+  for (const sample of body.data.result) {
+    expect(sample.metric.__name__, 'series __name__').toBe('up');
+    expect(sample.metric.job, 'series job label').toBeTruthy();
+  }
+});

--- a/test/e2e/playwright/tsconfig.json
+++ b/test/e2e/playwright/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "types": ["node", "@playwright/test"]
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
## Summary
M0.2 from the [roadmap](https://github.com/tsouza/cerberus/blob/main/docs/roadmap.md). Wires playwright over the k3d stack from M0.1 and gates merges that touch \`internal/api/**\` or \`deploy/**\`.

### What lands
- **\`test/e2e/playwright/\`** — Playwright 1.50 + TypeScript 5.7 with one spec (\`smoke.spec.ts\`) that proves the full plumbing:
  1. Grafana \`/api/health\` is 200
  2. cerberus \`/healthz\` is 200
  3. Grafana datasource proxy \`/api/datasources/proxy/uid/cerberus-prometheus/api/v1/query?query=up\` returns Prom-shaped JSON with at least one series carrying \`__name__=up\` and a \`job\` label
  
  UI-level Explore-page checks are deferred until M2 lands real label/series endpoints.

- **\`deploy/k3s/grafana.yaml\`** — deterministic UIDs added to all three datasources so the playwright spec can address them stably.

- **\`.github/workflows/e2e.yml\`** — path-gated PR runs (\`internal/api/**\`, \`deploy/**\`, \`test/e2e/**\`, Justfile, Dockerfile.local, etc.), every push to main, nightly at 03:17 UTC, plus manual dispatch. Full lifecycle: setup-go (from go.mod) → setup-node 22 → install k3d → \`just e2e-up\` → \`just e2e-seed\` → \`just e2e-run\` → install Chromium → \`npx playwright test\` → \`just e2e-down\`. On failure, dumps pod logs + uploads the Playwright HTML report as a 14-day artifact.

### Roadmap link
- M0.2 — Playwright smoke + e2e workflow

## Test plan
- [x] \`just lint-md\` clean
- [x] \`just --list\` shows existing e2e-* recipes; this PR doesn't change them
- [ ] CI \`check\` + \`lint\` green
- [ ] CI \`e2e\` (new workflow) green — first run will validate the whole stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)