### PR TITLE
fix(e2e): expose cerberus + grafana via NodePort so k3d LB routes from localhost

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -97,11 +97,14 @@ K3D_CLUSTER := "cerberus-e2e"
 CERBERUS_IMAGE := "cerberus:e2e"
 
 # Boot the k3d cluster, build cerberus image, import it, apply manifests, wait for pods.
+# Host ports map via the k3d loadbalancer to NodePorts on the k3s nodes:
+#   host:8080 -> LB -> NodePort 30080 (cerberus svc)
+#   host:3000 -> LB -> NodePort 30030 (grafana svc)
 e2e-up: e2e-down
     @echo "==> creating k3d cluster {{K3D_CLUSTER}}"
     k3d cluster create {{K3D_CLUSTER}} \
-        --port "3000:3000@loadbalancer" \
-        --port "8080:8080@loadbalancer" \
+        --port "3000:30030@loadbalancer" \
+        --port "8080:30080@loadbalancer" \
         --no-lb=false \
         --k3s-arg "--disable=traefik@server:0" \
         --wait

--- a/deploy/k3s/cerberus.yaml
+++ b/deploy/k3s/cerberus.yaml
@@ -20,10 +20,12 @@ metadata:
   labels:
     app: cerberus
 spec:
+  type: NodePort
   ports:
     - name: http
       port: 8080
       targetPort: 8080
+      nodePort: 30080
   selector:
     app: cerberus
 ---

--- a/deploy/k3s/grafana.yaml
+++ b/deploy/k3s/grafana.yaml
@@ -38,10 +38,12 @@ metadata:
   labels:
     app: grafana
 spec:
+  type: NodePort
   ports:
     - name: http
       port: 3000
       targetPort: 3000
+      nodePort: 30030
   selector:
     app: grafana
 ---


### PR DESCRIPTION
## Summary
Follow-up to M0.2. The e2e workflow's first run (PR #35) failed at \`TestHealthz\` with \`GET http://localhost:8080/healthz: EOF\` — the cerberus Service was ClusterIP, traefik is disabled, and nothing was listening on the host port that k3d's loadbalancer was forwarding to.

Fix: make cerberus + grafana NodePort services (30080 + 30030) and map k3d host ports to the NodePorts via its bundled loadbalancer.

\`\`\`text
host:8080 -> LB -> NodePort 30080 -> cerberus svc -> pod :8080
host:3000 -> LB -> NodePort 30030 -> grafana  svc -> pod :3000
\`\`\`

No traefik dependency; works on stock k3d without enabling the bundled ingress controller.

## Test plan
- [x] \`just lint-md\` clean
- [x] \`go vet -tags=e2e ./test/e2e/...\` clean
- [ ] CI \`e2e\` (path-gated; triggered by deploy/** + Justfile + workflow file) green this run

🤖 Generated with [Claude Code](https://claude.com/claude-code)