### PR TITLE
fix(e2e): pass -i to kubectl exec so seed stdin reaches CH

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -123,10 +123,23 @@ e2e-up: e2e-down
     @echo "    cerberus:   http://localhost:8080/healthz"
 
 # Ingest sample OTel data into ClickHouse.
+# kubectl exec needs -i to forward stdin into the remote container; without
+# it, the `< file` redirect goes only to local stdin and the seed never runs.
 e2e-seed:
     @echo "==> seeding OTel metrics"
+    kubectl -n cerberus exec -i deploy/clickhouse -- \
+        clickhouse-client \
+            --user cerberus --password cerberus \
+            --database otel --multiquery \
+            < test/e2e/seed/otel_metrics.sql
+    @echo "==> verifying table rowcounts"
     kubectl -n cerberus exec deploy/clickhouse -- \
-        clickhouse-client --user cerberus --password cerberus --multiquery < test/e2e/seed/otel_metrics.sql
+        clickhouse-client --user cerberus --password cerberus --database otel --query "\
+            SELECT MetricName, count() AS rows FROM ( \
+                SELECT MetricName FROM otel_metrics_gauge \
+                UNION ALL \
+                SELECT MetricName FROM otel_metrics_sum \
+            ) GROUP BY MetricName ORDER BY MetricName FORMAT PrettyCompact"
     @echo "==> seed done"
 
 # Run Go E2E HTTP tests against the deployed stack.


### PR DESCRIPTION
## Summary
Second leg of the e2e port-fix arc. The previous run got past \`TestHealthz\` thanks to NodePort, but \`TestPromQueryUp\` failed with \`UNKNOWN_TABLE\` for \`otel_metrics_gauge\`. Root cause: \`kubectl exec\` was not forwarding stdin, so the seed SQL never reached \`clickhouse-client\`.

### Fix
- \`-i\` on the seed's \`kubectl exec\` so stdin flows into the container.
- \`--database otel\` so the seed session is anchored even if future seed SQL drops fully-qualified table names.
- A post-seed verification step that prints per-metric rowcounts so any future silent seeder regression is loud in the workflow log.

## Test plan
- [x] \`just lint-md\` clean (no md changes)
- [ ] CI \`check\` + \`lint\` green
- [ ] CI \`e2e\` green this run

🤖 Generated with [Claude Code](https://claude.com/claude-code)