### PR TITLE
feat(promql,chplan): BinaryExpr lowering — scalar/vector arithmetic (M1.2)

### DIFF
--- a/internal/chplan/binary.go
+++ b/internal/chplan/binary.go
@@ -19,6 +19,8 @@ const (
 	OpSub      BinaryOp = "-"
 	OpMul      BinaryOp = "*"
 	OpDiv      BinaryOp = "/"
+	OpMod      BinaryOp = "%"
+	OpPow      BinaryOp = "^"
 )
 
 // Binary is a binary-operator expression.

--- a/internal/chsql/emit_expr.go
+++ b/internal/chsql/emit_expr.go
@@ -53,6 +53,19 @@ func (e *emitter) emitBinary(b *chplan.Binary) error {
 		}
 		e.b.WriteByte(')')
 		return nil
+
+	case chplan.OpPow:
+		// CH has no `^` operator; lower to `pow(left, right)`.
+		e.b.WriteString("pow(")
+		if err := e.emitExpr(b.Left); err != nil {
+			return err
+		}
+		e.b.WriteString(", ")
+		if err := e.emitExpr(b.Right); err != nil {
+			return err
+		}
+		e.b.WriteByte(')')
+		return nil
 	}
 
 	e.b.WriteByte('(')

--- a/internal/promql/binary.go
+++ b/internal/promql/binary.go
@@ -1,0 +1,117 @@
+package promql
+
+import (
+	"fmt"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// lowerBinary handles PromQL BinaryExpr — arithmetic for now. Comparison
+// and logical ops, plus vector-vector matching, land in M1.x follow-ups.
+//
+// Supported shapes:
+//   - scalar OP scalar           → folded to chplan.LitFloat at lowering
+//   - scalar OP vector / vec OP scalar → Project that maps Value through
+//     the binary op
+//
+// Vector OP vector is rejected with a clear error pointing at M1.6
+// (vector matching), since the join semantics need first-class support.
+func lowerBinary(b *parser.BinaryExpr, s schema.Metrics) (chplan.Node, error) {
+	op, err := promBinaryOp(b.Op, b.ReturnBool)
+	if err != nil {
+		return nil, err
+	}
+
+	lhsScalar, lhsIsScalar := tryScalarLiteral(b.LHS)
+	rhsScalar, rhsIsScalar := tryScalarLiteral(b.RHS)
+
+	switch {
+	case lhsIsScalar && rhsIsScalar:
+		return nil, fmt.Errorf("promql: scalar-only binary expressions not yet lowered (constant fold lands when scalars are first-class chplan nodes)")
+	case lhsIsScalar:
+		return projectWithScalar(b.RHS, s, op, lhsScalar, true /*scalarOnLeft*/)
+	case rhsIsScalar:
+		return projectWithScalar(b.LHS, s, op, rhsScalar, false)
+	default:
+		return nil, fmt.Errorf("promql: vector OP vector binary expressions require vector matching (lands in M1.6); op=%s", b.Op.String())
+	}
+}
+
+// promBinaryOp maps a PromQL parser op to the chplan op. Comparison ops
+// and the bool modifier defer to a follow-up.
+func promBinaryOp(op parser.ItemType, returnBool bool) (chplan.BinaryOp, error) {
+	if returnBool {
+		return "", fmt.Errorf("promql: 'bool' modifier on binary ops is not yet supported")
+	}
+	switch op {
+	case parser.ADD:
+		return chplan.OpAdd, nil
+	case parser.SUB:
+		return chplan.OpSub, nil
+	case parser.MUL:
+		return chplan.OpMul, nil
+	case parser.DIV:
+		return chplan.OpDiv, nil
+	case parser.MOD:
+		return chplan.OpMod, nil
+	case parser.POW:
+		return chplan.OpPow, nil
+	}
+	return "", fmt.Errorf("promql: binary op %s not yet supported (comparison + logical ops land in M1.x follow-ups)", op.String())
+}
+
+// tryScalarLiteral unwraps NumberLiteral, ParenExpr around a literal, and
+// UnaryExpr(-N) at lowering time. Returns the literal value and true on a
+// match, or 0+false otherwise.
+func tryScalarLiteral(e parser.Expr) (float64, bool) {
+	switch v := e.(type) {
+	case *parser.NumberLiteral:
+		return v.Val, true
+	case *parser.ParenExpr:
+		return tryScalarLiteral(v.Expr)
+	case *parser.UnaryExpr:
+		if v.Op == parser.SUB {
+			if inner, ok := tryScalarLiteral(v.Expr); ok {
+				return -inner, true
+			}
+		}
+		if v.Op == parser.ADD {
+			return tryScalarLiteral(v.Expr)
+		}
+	}
+	return 0, false
+}
+
+// projectWithScalar lowers the vector side and wraps it with a Project
+// that replaces ValueColumn with (scalar OP Value) or (Value OP scalar).
+//
+// The projection list is explicit (MetricName, Attributes, TimestampColumn,
+// transformed Value) so the downstream emitter knows the column shape.
+// scalarOnLeft flips the operand order — important for non-commutative
+// ops like SUB and DIV.
+func projectWithScalar(vec parser.Expr, s schema.Metrics, op chplan.BinaryOp, scalar float64, scalarOnLeft bool) (chplan.Node, error) {
+	inner, err := lower(vec, s)
+	if err != nil {
+		return nil, err
+	}
+	valueRef := &chplan.ColumnRef{Name: s.ValueColumn}
+	scalarLit := &chplan.LitFloat{V: scalar}
+	var newValue chplan.Expr
+	if scalarOnLeft {
+		newValue = &chplan.Binary{Op: op, Left: scalarLit, Right: valueRef}
+	} else {
+		newValue = &chplan.Binary{Op: op, Left: valueRef, Right: scalarLit}
+	}
+	return &chplan.Project{
+		Input: inner,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.ColumnRef{Name: s.MetricNameColumn}},
+			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}},
+			{Expr: &chplan.ColumnRef{Name: s.TimestampColumn}},
+			{Expr: newValue, Alias: s.ValueColumn},
+		},
+	}, nil
+}

--- a/internal/promql/binary_test.go
+++ b/internal/promql/binary_test.go
@@ -1,0 +1,125 @@
+package promql_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestLower_Binary_Errors covers the cases lowerBinary rejects today —
+// vector/vector (deferred to M1.6 vector matching), the `bool` modifier
+// on comparisons, and pure scalar/scalar (deferred until scalars are
+// first-class chplan nodes).
+func TestLower_Binary_Errors(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{})
+
+	cases := []struct {
+		name    string
+		query   string
+		wantErr string
+	}{
+		{
+			name:    "vector OP vector deferred",
+			query:   `up + up`,
+			wantErr: "vector OP vector binary expressions require vector matching",
+		},
+		{
+			name:    "bool modifier deferred",
+			query:   `up > bool 0`,
+			wantErr: "'bool' modifier on binary ops is not yet supported",
+		},
+		{
+			name:    "scalar OP scalar deferred",
+			query:   `1 + 2`,
+			wantErr: "scalar-only binary expressions not yet lowered",
+		},
+		{
+			name:    "comparison op deferred",
+			query:   `up > 0.5`,
+			wantErr: "binary op > not yet supported",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr: %v", err)
+			}
+			_, err = promql.Lower(expr, s)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestLower_Binary_VectorScalar end-to-end checks the happy path: lowering
+// produces a chplan with a Project node, and chsql.Emit produces SQL that
+// references the schema's Value column with the scalar operation applied.
+func TestLower_Binary_VectorScalar(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{})
+
+	cases := []struct {
+		name      string
+		query     string
+		wantInSQL []string
+	}{
+		{
+			name:      "vector times scalar",
+			query:     `up * 2`,
+			wantInSQL: []string{"`Value` * ?", "AS `Value`"},
+		},
+		{
+			name:      "scalar minus vector preserves order",
+			query:     `100 - up`,
+			wantInSQL: []string{"? - `Value`"},
+		},
+		{
+			name:      "vector div scalar",
+			query:     `metric / 1000`,
+			wantInSQL: []string{"`Value` / ?"},
+		},
+		{
+			name:      "negated scalar unwraps",
+			query:     `up * -1`,
+			wantInSQL: []string{"`Value` * ?"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr: %v", err)
+			}
+			plan, err := promql.Lower(expr, s)
+			if err != nil {
+				t.Fatalf("Lower: %v", err)
+			}
+			sql, _, err := chsql.Emit(plan)
+			if err != nil {
+				t.Fatalf("Emit: %v", err)
+			}
+			for _, want := range tc.wantInSQL {
+				if !strings.Contains(sql, want) {
+					t.Errorf("expected SQL to contain %q; full SQL:\n%s", want, sql)
+				}
+			}
+		})
+	}
+}

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -32,6 +32,8 @@ func lower(expr parser.Expr, s schema.Metrics) (chplan.Node, error) {
 		return lowerAggregate(e, s)
 	case *parser.ParenExpr:
 		return lower(e.Expr, s)
+	case *parser.BinaryExpr:
+		return lowerBinary(e, s)
 	default:
 		return nil, fmt.Errorf("promql: unsupported expression %T", expr)
 	}

--- a/internal/promql/lower_test.go
+++ b/internal/promql/lower_test.go
@@ -73,11 +73,8 @@ func TestLower_errors(t *testing.T) {
 			query:   `sum without (instance) (up)`,
 			wantErr: "'without' aggregation is not yet supported",
 		},
-		{
-			name:    "binary op rejected",
-			query:   `up + up`,
-			wantErr: "unsupported expression",
-		},
+		// Note: BinaryExpr vector+vector rejection moved to binary_test.go;
+		// arithmetic ops are now lowered for the scalar-vector case (M1.2).
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/test/spec/promql/scalar_minus_vector.txtar
+++ b/test/spec/promql/scalar_minus_vector.txtar
@@ -1,0 +1,7 @@
+-- query.promql --
+100 - up
+-- args --
+[0] float64 = 100
+[1] string = "up"
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, (? - `Value`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?))

--- a/test/spec/promql/up_times_two.txtar
+++ b/test/spec/promql/up_times_two.txtar
@@ -1,0 +1,7 @@
+-- query.promql --
+up * 2
+-- args --
+[0] float64 = 2
+[1] string = "up"
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, (`Value` * ?) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?))

--- a/test/spec/promql/vector_div_scalar.txtar
+++ b/test/spec/promql/vector_div_scalar.txtar
@@ -1,0 +1,7 @@
+-- query.promql --
+http_requests_total / 1000
+-- args --
+[0] float64 = 1000
+[1] string = "http_requests_total"
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, (`Value` / ?) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_sum`) WHERE (`MetricName` = ?))

--- a/test/spec/promql/vector_mod_scalar.txtar
+++ b/test/spec/promql/vector_mod_scalar.txtar
@@ -1,0 +1,7 @@
+-- query.promql --
+up % 7
+-- args --
+[0] float64 = 7
+[1] string = "up"
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, (`Value` % ?) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?))

--- a/test/spec/promql/vector_pow_scalar.txtar
+++ b/test/spec/promql/vector_pow_scalar.txtar
@@ -1,0 +1,7 @@
+-- query.promql --
+up ^ 2
+-- args --
+[0] float64 = 2
+[1] string = "up"
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, pow(`Value`, ?) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?))


### PR DESCRIPTION
## Summary
First slice of PromQL binary expressions. Arithmetic ops (\`+\`, \`-\`, \`*\`, \`/\`, \`%\`, \`^\`) between a scalar literal and a vector selector lower into a \`Project\` that reprojects the Value column through the binary operation. Comparison ops, the \`bool\` modifier, logical ops, and vector-vs-vector all return clean error messages pointing at the milestone where they land.

### What lands
- **\`chplan.Binary\`** — \`OpMod\` (\`%\`) + \`OpPow\` (\`^\`).
- **\`chsql/emit_expr.go\`** — \`OpPow\` lowers to ClickHouse's \`pow(x, y)\` function call. All other ops stay as infix operators.
- **\`internal/promql/binary.go\`** — \`lowerBinary\`:
  - \`scalar OP scalar\` → ErrUnsupported (lands when scalars are first-class chplan nodes)
  - \`scalar OP vector\` / \`vector OP scalar\` → \`Project\` over the vector side with Value transformed; non-commutative ops (SUB, DIV, MOD, POW) honour scalar-side ordering
  - \`vector OP vector\` → ErrUnsupported (lands in M1.6 vector matching)
- **5 new TXTAR fixtures** + a Go test (\`binary_test.go\`) covering both the error cases and happy paths end-to-end.

### Sample output
\`up * 2\`:
\`\`\`sql
SELECT \`MetricName\`, \`Attributes\`, \`TimeUnix\`, (\`Value\` * ?) AS \`Value\`
FROM (SELECT * FROM (SELECT * FROM \`otel_metrics_gauge\`) WHERE (\`MetricName\` = ?))
\`\`\`

\`100 - up\`:
\`\`\`sql
SELECT \`MetricName\`, \`Attributes\`, \`TimeUnix\`, (? - \`Value\`) AS \`Value\`
FROM (SELECT * FROM (SELECT * FROM \`otel_metrics_gauge\`) WHERE (\`MetricName\` = ?))
\`\`\`

## Roadmap link
- M1.2 — BinaryExpr lowering

## Test plan
- [x] \`just lint\` clean
- [x] \`just test\` passes (chplan + chsql + promql, race + spec)
- [x] 5 new TXTAR fixtures + 4 new error-path Go tests
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)