### PR TITLE
feat(promql): instant-vector functions (M1.3)

### DIFF
--- a/internal/promql/instant_fns.go
+++ b/internal/promql/instant_fns.go
@@ -1,0 +1,61 @@
+package promql
+
+import (
+	"fmt"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// instantFnCH maps PromQL instant-vector functions to the ClickHouse
+// function that implements the same transform on `Value`. PromQL `ln` is
+// the natural log; CH spells that `log`. Everything else is 1:1.
+//
+// Each entry is a 1-arg function over a vector; we wrap the lowered vector
+// with a Project that replaces ValueColumn with `<chFn>(Value)`.
+var instantFnCH = map[string]string{
+	"abs":   "abs",
+	"ceil":  "ceil",
+	"floor": "floor",
+	"round": "round",
+	"sqrt":  "sqrt",
+	"exp":   "exp",
+	"ln":    "log",
+	"log2":  "log2",
+	"log10": "log10",
+	"sgn":   "sign",
+}
+
+// lowerInstantFn handles single-arg math functions like abs / sqrt / ln. The
+// arg is expected to be an instant-vector expression; we lower it, then
+// wrap with a Project that maps the Value column through the CH function.
+//
+// Multi-arg forms (e.g. PromQL `round(v, to_nearest)`) are deferred — only
+// the unary form lands in M1.3.
+func lowerInstantFn(c *parser.Call, s schema.Metrics, chFn string) (chplan.Node, error) {
+	if len(c.Args) != 1 {
+		return nil, fmt.Errorf("promql: %s with %d arguments is not yet supported (M1.3 supports the unary form only)",
+			c.Func.Name, len(c.Args))
+	}
+
+	inner, err := lower(c.Args[0], s)
+	if err != nil {
+		return nil, err
+	}
+
+	newValue := &chplan.FuncCall{
+		Name: chFn,
+		Args: []chplan.Expr{&chplan.ColumnRef{Name: s.ValueColumn}},
+	}
+	return &chplan.Project{
+		Input: inner,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.ColumnRef{Name: s.MetricNameColumn}},
+			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}},
+			{Expr: &chplan.ColumnRef{Name: s.TimestampColumn}},
+			{Expr: newValue, Alias: s.ValueColumn},
+		},
+	}, nil
+}

--- a/internal/promql/instant_fns_test.go
+++ b/internal/promql/instant_fns_test.go
@@ -1,0 +1,53 @@
+package promql_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestLower_InstantFn_Errors covers the unsupported instant-fn shapes so
+// the error messages stay observable as the surface grows.
+func TestLower_InstantFn_Errors(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{})
+
+	cases := []struct {
+		name    string
+		query   string
+		wantErr string
+	}{
+		{
+			name:    "round 2-arg deferred",
+			query:   `round(temperature, 0.1)`,
+			wantErr: "supports the unary form only",
+		},
+		{
+			name:    "unknown fn",
+			query:   `histogram_quantile(0.9, foo)`,
+			wantErr: "function histogram_quantile is not yet supported",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr: %v", err)
+			}
+			_, err = promql.Lower(expr, s)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -14,10 +14,13 @@ import (
 // Lower turns a parsed PromQL expression into a chplan tree, using s for
 // table and column name conventions.
 //
-// v0.1 scope: VectorSelector, MatrixSelector (only as a Call argument),
-// Call with `rate` / `increase` / `delta` / `*_over_time`, AggregateExpr
-// with `by (...)`, ParenExpr. Subqueries, scalar arithmetic, `without`,
-// and BinaryExpr are out of scope for the seed.
+// RC1 scope as it grows: VectorSelector, MatrixSelector (only as a Call
+// argument), range-vector Call (`rate` / `increase` / `delta` /
+// `*_over_time`), instant-vector Call (`abs`, `sqrt`, `ln`, ...),
+// AggregateExpr with `by (...)`, ParenExpr, BinaryExpr with
+// scalar/vector arithmetic. Subqueries, `without`, vector-vector
+// matching, `offset`, `@`, and comparison/logical ops land in
+// follow-up milestones.
 func Lower(expr parser.Expr, s schema.Metrics) (chplan.Node, error) {
 	return lower(expr, s)
 }
@@ -117,11 +120,29 @@ func matchOp(t labels.MatchType) chplan.BinaryOp {
 	return chplan.OpEq
 }
 
-// lowerCall handles range-vector functions: rate, increase, delta, and the
-// `*_over_time` family. The single argument is a MatrixSelector wrapping a
-// VectorSelector; we lower the VectorSelector and wrap the result in a
-// RangeWindow capturing the function name + range duration.
+// lowerCall dispatches PromQL function calls. The arg shape decides the
+// path: a MatrixSelector means a range-vector function (rate, increase,
+// *_over_time); anything else is treated as an instant-vector function
+// (abs, sqrt, ln, ...) if recognised. Other functions surface a clear
+// "not yet supported" error pointing at the relevant milestone.
 func lowerCall(c *parser.Call, s schema.Metrics) (chplan.Node, error) {
+	if len(c.Args) >= 1 {
+		if _, ok := c.Args[0].(*parser.MatrixSelector); ok {
+			return lowerRangeVectorCall(c, s)
+		}
+	}
+	if chFn, ok := instantFnCH[c.Func.Name]; ok {
+		return lowerInstantFn(c, s, chFn)
+	}
+	return nil, fmt.Errorf("promql: function %s is not yet supported", c.Func.Name)
+}
+
+// lowerRangeVectorCall handles range-vector functions: rate, increase,
+// delta, and the `*_over_time` family. The single argument is a
+// MatrixSelector wrapping a VectorSelector; we lower the VectorSelector
+// and wrap the result in a RangeWindow capturing the function name +
+// range duration.
+func lowerRangeVectorCall(c *parser.Call, s schema.Metrics) (chplan.Node, error) {
 	if len(c.Args) != 1 {
 		return nil, fmt.Errorf("promql: %s expects exactly 1 argument, got %d", c.Func.Name, len(c.Args))
 	}

--- a/test/spec/promql/abs_metric.txtar
+++ b/test/spec/promql/abs_metric.txtar
@@ -1,0 +1,6 @@
+-- query.promql --
+abs(temperature)
+-- args --
+[0] string = "temperature"
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, abs(`Value`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?))

--- a/test/spec/promql/ceil_metric.txtar
+++ b/test/spec/promql/ceil_metric.txtar
@@ -1,0 +1,6 @@
+-- query.promql --
+ceil(temperature)
+-- args --
+[0] string = "temperature"
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, ceil(`Value`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?))

--- a/test/spec/promql/exp_metric.txtar
+++ b/test/spec/promql/exp_metric.txtar
@@ -1,0 +1,6 @@
+-- query.promql --
+exp(temperature)
+-- args --
+[0] string = "temperature"
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, exp(`Value`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?))

--- a/test/spec/promql/floor_metric.txtar
+++ b/test/spec/promql/floor_metric.txtar
@@ -1,0 +1,6 @@
+-- query.promql --
+floor(temperature)
+-- args --
+[0] string = "temperature"
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, floor(`Value`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?))

--- a/test/spec/promql/ln_metric.txtar
+++ b/test/spec/promql/ln_metric.txtar
@@ -1,0 +1,6 @@
+-- query.promql --
+ln(http_requests_total)
+-- args --
+[0] string = "http_requests_total"
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, log(`Value`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_sum`) WHERE (`MetricName` = ?))

--- a/test/spec/promql/log10_metric.txtar
+++ b/test/spec/promql/log10_metric.txtar
@@ -1,0 +1,6 @@
+-- query.promql --
+log10(temperature)
+-- args --
+[0] string = "temperature"
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, log10(`Value`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?))

--- a/test/spec/promql/log2_metric.txtar
+++ b/test/spec/promql/log2_metric.txtar
@@ -1,0 +1,6 @@
+-- query.promql --
+log2(temperature)
+-- args --
+[0] string = "temperature"
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, log2(`Value`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?))

--- a/test/spec/promql/round_metric.txtar
+++ b/test/spec/promql/round_metric.txtar
@@ -1,0 +1,6 @@
+-- query.promql --
+round(temperature)
+-- args --
+[0] string = "temperature"
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, round(`Value`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?))

--- a/test/spec/promql/sgn_metric.txtar
+++ b/test/spec/promql/sgn_metric.txtar
@@ -1,0 +1,6 @@
+-- query.promql --
+sgn(temperature)
+-- args --
+[0] string = "temperature"
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, sign(`Value`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?))

--- a/test/spec/promql/sqrt_metric.txtar
+++ b/test/spec/promql/sqrt_metric.txtar
@@ -1,0 +1,6 @@
+-- query.promql --
+sqrt(latency_seconds)
+-- args --
+[0] string = "latency_seconds"
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, sqrt(`Value`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?))


### PR DESCRIPTION
## Summary
- Lower PromQL instant-vector math functions: `abs`, `ceil`, `floor`, `round` (1-arg), `sqrt`, `exp`, `ln`, `log2`, `log10`, `sgn`.
- `lowerCall` now dispatches on arg shape: `MatrixSelector` → existing range-vector path; vector → new `instant_fns` path wrapping the inner Node with a `Project` that replaces `Value` with `chFn(Value)`.
- PromQL `ln` → CH `log` (natural log); everything else 1:1.
- 10 new TXTAR fixtures + 2 error-path unit tests (multi-arg `round`, unknown fn).

## Deferred
- `round(v, to_nearest)` — multi-arg form lands with M1.4.
- `scalar(v)` / `vector(s)` — change value-type semantics; land with M1.7 result shaping.

## Test plan
- [x] `just test` green
- [x] `just lint` clean
- [ ] CI green