### PR TITLE
feat(promql,chplan,chsql): aggregation completeness (M1.4)

### DIFF
--- a/internal/chplan/aggregate.go
+++ b/internal/chplan/aggregate.go
@@ -1,17 +1,28 @@
 package chplan
 
 // AggFunc is one aggregate-function call in an Aggregate node's projection
-// list. The emitter renders `<Name>(<args>) AS <alias>` (alias optional).
+// list. The emitter renders `<Name>(<Args>) AS <Alias>` for plain aggregates
+// and `<Name>(<Params>)(<Args>) AS <Alias>` for parameterised aggregates
+// (e.g. CH `quantile(0.95)(value)`).
 type AggFunc struct {
-	Name  string // ClickHouse function name: "sum", "count", "avg", "max", "min", ...
-	Args  []Expr
-	Alias string
+	Name string // ClickHouse function name: "sum", "count", "avg", "max", "min", ...
+	// Params is the parameter list for parameterised aggregates (CH-style).
+	// Nil/empty for plain aggregates.
+	Params []Expr
+	Args   []Expr
+	Alias  string
 }
 
 // Equal reports structural equality with another AggFunc.
 func (a AggFunc) Equal(other AggFunc) bool {
-	if a.Name != other.Name || a.Alias != other.Alias || len(a.Args) != len(other.Args) {
+	if a.Name != other.Name || a.Alias != other.Alias ||
+		len(a.Args) != len(other.Args) || len(a.Params) != len(other.Params) {
 		return false
+	}
+	for i := range a.Params {
+		if !a.Params[i].Equal(other.Params[i]) {
+			return false
+		}
 	}
 	for i := range a.Args {
 		if !a.Args[i].Equal(other.Args[i]) {

--- a/internal/chplan/map_without_keys.go
+++ b/internal/chplan/map_without_keys.go
@@ -1,0 +1,25 @@
+package chplan
+
+import "slices"
+
+// MapWithoutKeys is a Map-valued expression that yields the input Map with
+// the named Keys removed. Lowers to ClickHouse's `mapFilter` with a lambda
+// rejecting the key set.
+//
+// Used by PromQL `aggregation without (k1, k2) (expr)`: the group key is
+// the Attributes map with the listed labels stripped, so each output group
+// preserves every other label of the input series.
+type MapWithoutKeys struct {
+	Map  Expr
+	Keys []string
+}
+
+func (*MapWithoutKeys) exprNode() {}
+
+func (m *MapWithoutKeys) Equal(other Expr) bool {
+	o, ok := other.(*MapWithoutKeys)
+	if !ok {
+		return false
+	}
+	return m.Map.Equal(o.Map) && slices.Equal(m.Keys, o.Keys)
+}

--- a/internal/chplan/node_test.go
+++ b/internal/chplan/node_test.go
@@ -45,6 +45,25 @@ func TestEqual(t *testing.T) {
 		t.Fatalf("Filter: different predicates should not be Equal")
 	}
 
+	mwk := &chplan.MapWithoutKeys{
+		Map:  &chplan.ColumnRef{Name: "Attributes"},
+		Keys: []string{"instance", "pod"},
+	}
+	mwkSame := &chplan.MapWithoutKeys{
+		Map:  &chplan.ColumnRef{Name: "Attributes"},
+		Keys: []string{"instance", "pod"},
+	}
+	mwkReordered := &chplan.MapWithoutKeys{
+		Map:  &chplan.ColumnRef{Name: "Attributes"},
+		Keys: []string{"pod", "instance"},
+	}
+	if !mwk.Equal(mwkSame) {
+		t.Fatalf("MapWithoutKeys: identical keys should be Equal")
+	}
+	if mwk.Equal(mwkReordered) {
+		t.Fatalf("MapWithoutKeys: reordered keys are observably different (groups would differ)")
+	}
+
 	rw := &chplan.RangeWindow{
 		Input: &chplan.Scan{Table: "otel_metrics_sum"},
 		Func:  "rate",

--- a/internal/chsql/emit_expr.go
+++ b/internal/chsql/emit_expr.go
@@ -25,6 +25,8 @@ func (e *emitter) emitExpr(x chplan.Expr) error {
 		return e.emitFunc(v)
 	case *chplan.MapAccess:
 		return e.emitMapAccess(v)
+	case *chplan.MapWithoutKeys:
+		return e.emitMapWithoutKeys(v)
 	default:
 		return fmt.Errorf("%w: expr %T", ErrUnsupported, x)
 	}
@@ -89,6 +91,24 @@ func (e *emitter) emitMapAccess(m *chplan.MapAccess) error {
 		return err
 	}
 	e.b.WriteByte(']')
+	return nil
+}
+
+func (e *emitter) emitMapWithoutKeys(m *chplan.MapWithoutKeys) error {
+	e.b.WriteString("mapFilter((k, v) -> NOT (k IN (")
+	for i, k := range m.Keys {
+		if i > 0 {
+			e.b.WriteString(", ")
+		}
+		if err := e.bindArg(k); err != nil {
+			return err
+		}
+	}
+	e.b.WriteString(")), ")
+	if err := e.emitExpr(m.Map); err != nil {
+		return err
+	}
+	e.b.WriteByte(')')
 	return nil
 }
 

--- a/internal/chsql/emit_node.go
+++ b/internal/chsql/emit_node.go
@@ -99,6 +99,20 @@ func (e *emitter) emitAggregate(a *chplan.Aggregate) error {
 
 func (e *emitter) emitAggFunc(af chplan.AggFunc) error {
 	e.b.WriteString(af.Name)
+	// Parameterised aggregates emit `<name>(<params>)(<args>)` — used by CH
+	// for `quantile(0.95)(value)`, `quantiles(0.5, 0.9)(value)`, etc.
+	if len(af.Params) > 0 {
+		e.b.WriteByte('(')
+		for i, p := range af.Params {
+			if i > 0 {
+				e.b.WriteString(", ")
+			}
+			if err := e.emitExpr(p); err != nil {
+				return err
+			}
+		}
+		e.b.WriteByte(')')
+	}
 	e.b.WriteByte('(')
 	for i, a := range af.Args {
 		if i > 0 {

--- a/internal/promql/aggregate_test.go
+++ b/internal/promql/aggregate_test.go
@@ -1,0 +1,64 @@
+package promql_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestLower_Aggregate_Errors covers the M1.4 surface that intentionally
+// stays out of scope (output-shape-changing aggregates) plus the param /
+// no-param mismatch paths so the error messages remain observable.
+func TestLower_Aggregate_Errors(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{})
+
+	cases := []struct {
+		name    string
+		query   string
+		wantErr string
+	}{
+		{
+			name:    "topk shape change deferred",
+			query:   `topk(3, up)`,
+			wantErr: "changes output shape and lands with M1.7",
+		},
+		{
+			name:    "bottomk shape change deferred",
+			query:   `bottomk(3, up)`,
+			wantErr: "changes output shape and lands with M1.7",
+		},
+		{
+			name:    "count_values shape change deferred",
+			query:   `count_values("v", up)`,
+			wantErr: "changes output shape and lands with M1.7",
+		},
+		{
+			name:    "quantile needs scalar literal phi",
+			query:   `quantile(scalar(up), latency_seconds)`,
+			wantErr: "scalar literal phi",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr: %v", err)
+			}
+			_, err = promql.Lower(expr, s)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -147,46 +147,111 @@ func lowerCall(c *parser.Call, s schema.Metrics) (chplan.Node, error) {
 	}, nil
 }
 
-// lowerAggregate handles `sum by (job) (...)`, `count(...)`, etc.
-// Only the `by` form is supported in v0.1; `without` requires schema-wide
-// label introspection that lands later.
+// lowerAggregate handles `sum by (job) (...)`, `sum without (instance) (...)`,
+// `count(...)`, `stddev(...)`, `stdvar(...)`, `group(...)`, and
+// `quantile(0.95, ...)`. Output-shape-changing aggregates (`topk`, `bottomk`,
+// `count_values`) are deferred to M1.7 since they produce K rows per group
+// rather than one.
 func lowerAggregate(a *parser.AggregateExpr, s schema.Metrics) (chplan.Node, error) {
-	if a.Without {
-		return nil, fmt.Errorf("promql: 'without' aggregation is not yet supported (v0.1 supports 'by' only)")
-	}
-	if a.Param != nil {
-		return nil, fmt.Errorf("promql: parameterised aggregation (%s) is not yet supported", a.Op.String())
-	}
-
 	input, err := lower(a.Expr, s)
 	if err != nil {
 		return nil, err
 	}
 
-	groupBy := make([]chplan.Expr, 0, len(a.Grouping))
+	groupBy, err := aggregateGroupBy(a, s)
+	if err != nil {
+		return nil, err
+	}
+
+	aggFunc, err := buildAggFunc(a, s)
+	if err != nil {
+		return nil, err
+	}
+
+	return &chplan.Aggregate{
+		Input:    input,
+		GroupBy:  groupBy,
+		AggFuncs: []chplan.AggFunc{aggFunc},
+	}, nil
+}
+
+// aggregateGroupBy builds the group-key list for an aggregation. For
+// `by (...)` it returns one MapAccess per named label; for `without (...)`
+// it returns a single MapWithoutKeys spanning the full Attributes map with
+// the named labels stripped.
+func aggregateGroupBy(a *parser.AggregateExpr, s schema.Metrics) ([]chplan.Expr, error) {
+	if a.Without {
+		return []chplan.Expr{
+			&chplan.MapWithoutKeys{
+				Map:  &chplan.ColumnRef{Name: s.AttributesColumn},
+				Keys: append([]string(nil), a.Grouping...),
+			},
+		}, nil
+	}
+	out := make([]chplan.Expr, 0, len(a.Grouping))
 	for _, label := range a.Grouping {
-		groupBy = append(groupBy, &chplan.MapAccess{
+		out = append(out, &chplan.MapAccess{
 			Map: &chplan.ColumnRef{Name: s.AttributesColumn},
 			Key: &chplan.LitString{V: label},
 		})
 	}
-
-	chFunc, err := chAggFunc(a.Op)
-	if err != nil {
-		return nil, err
-	}
-	return &chplan.Aggregate{
-		Input:   input,
-		GroupBy: groupBy,
-		AggFuncs: []chplan.AggFunc{{
-			Name:  chFunc,
-			Args:  []chplan.Expr{&chplan.ColumnRef{Name: s.ValueColumn}},
-			Alias: s.ValueColumn,
-		}},
-	}, nil
+	return out, nil
 }
 
-func chAggFunc(op parser.ItemType) (string, error) {
+// buildAggFunc produces the single AggFunc for an aggregation. Output-shape-
+// changing aggregates (`topk`, `bottomk`, `count_values`) are intentionally
+// rejected here pointing at M1.7.
+func buildAggFunc(a *parser.AggregateExpr, s schema.Metrics) (chplan.AggFunc, error) {
+	valueArg := &chplan.ColumnRef{Name: s.ValueColumn}
+
+	switch a.Op {
+	case parser.SUM, parser.COUNT, parser.AVG, parser.MIN, parser.MAX, parser.STDDEV, parser.STDVAR:
+		if a.Param != nil {
+			return chplan.AggFunc{}, fmt.Errorf("promql: aggregation %s does not take a parameter", a.Op.String())
+		}
+		name, err := plainAggCH(a.Op)
+		if err != nil {
+			return chplan.AggFunc{}, err
+		}
+		return chplan.AggFunc{
+			Name:  name,
+			Args:  []chplan.Expr{valueArg},
+			Alias: s.ValueColumn,
+		}, nil
+
+	case parser.GROUP:
+		// PromQL `group(...)` returns 1 for every label combination; emit
+		// `any(1)` which yields a constant 1 per CH group.
+		if a.Param != nil {
+			return chplan.AggFunc{}, fmt.Errorf("promql: group() does not take a parameter")
+		}
+		return chplan.AggFunc{
+			Name:  "any",
+			Args:  []chplan.Expr{&chplan.LitInt{V: 1}},
+			Alias: s.ValueColumn,
+		}, nil
+
+	case parser.QUANTILE:
+		phi, ok := tryScalarLiteral(a.Param)
+		if !ok {
+			return chplan.AggFunc{}, fmt.Errorf("promql: quantile(phi, ...) requires a scalar literal phi (computed phi defers to M1.7)")
+		}
+		return chplan.AggFunc{
+			Name:   "quantile",
+			Params: []chplan.Expr{&chplan.LitFloat{V: phi}},
+			Args:   []chplan.Expr{valueArg},
+			Alias:  s.ValueColumn,
+		}, nil
+
+	case parser.TOPK, parser.BOTTOMK, parser.COUNT_VALUES:
+		return chplan.AggFunc{}, fmt.Errorf("promql: %s changes output shape and lands with M1.7 result shaping", a.Op.String())
+	}
+
+	return chplan.AggFunc{}, fmt.Errorf("promql: aggregation op %s is not yet supported", a.Op.String())
+}
+
+// plainAggCH maps a non-parameterised PromQL aggregator to its CH name.
+func plainAggCH(op parser.ItemType) (string, error) {
 	switch op {
 	case parser.SUM:
 		return "sum", nil
@@ -198,6 +263,10 @@ func chAggFunc(op parser.ItemType) (string, error) {
 		return "min", nil
 	case parser.MAX:
 		return "max", nil
+	case parser.STDDEV:
+		return "stddevPop", nil
+	case parser.STDVAR:
+		return "varPop", nil
 	}
 	return "", fmt.Errorf("promql: aggregation op %s is not yet supported", op.String())
 }

--- a/internal/promql/lower_test.go
+++ b/internal/promql/lower_test.go
@@ -69,12 +69,13 @@ func TestLower_errors(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name:    "without aggregation rejected",
-			query:   `sum without (instance) (up)`,
-			wantErr: "'without' aggregation is not yet supported",
+			name:    "topk changes output shape",
+			query:   `topk(5, up)`,
+			wantErr: "changes output shape and lands with M1.7",
 		},
-		// Note: BinaryExpr vector+vector rejection moved to binary_test.go;
-		// arithmetic ops are now lowered for the scalar-vector case (M1.2).
+		// Note: 'without' now lowers (M1.4); BinaryExpr vector+vector
+		// rejection moved to binary_test.go; arithmetic ops are lowered
+		// for the scalar-vector case (M1.2).
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/test/spec/promql/group_by_job.txtar
+++ b/test/spec/promql/group_by_job.txtar
@@ -1,0 +1,9 @@
+-- query.promql --
+group by (job) (up)
+-- sql --
+SELECT `Attributes`[?], any(?) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?)) GROUP BY `Attributes`[?]
+-- args --
+[0] string = "job"
+[1] int64 = 1
+[2] string = "up"
+[3] string = "job"

--- a/test/spec/promql/quantile_by_job.txtar
+++ b/test/spec/promql/quantile_by_job.txtar
@@ -1,0 +1,9 @@
+-- query.promql --
+quantile(0.95, latency_seconds) by (job)
+-- sql --
+SELECT `Attributes`[?], quantile(?)(`Value`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?)) GROUP BY `Attributes`[?]
+-- args --
+[0] string = "job"
+[1] float64 = 0.95
+[2] string = "latency_seconds"
+[3] string = "job"

--- a/test/spec/promql/stddev_by_job.txtar
+++ b/test/spec/promql/stddev_by_job.txtar
@@ -1,0 +1,8 @@
+-- query.promql --
+stddev by (job) (latency_seconds)
+-- sql --
+SELECT `Attributes`[?], stddevPop(`Value`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?)) GROUP BY `Attributes`[?]
+-- args --
+[0] string = "job"
+[1] string = "latency_seconds"
+[2] string = "job"

--- a/test/spec/promql/stdvar_no_group.txtar
+++ b/test/spec/promql/stdvar_no_group.txtar
@@ -1,0 +1,6 @@
+-- query.promql --
+stdvar(latency_seconds)
+-- sql --
+SELECT varPop(`Value`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?))
+-- args --
+[0] string = "latency_seconds"

--- a/test/spec/promql/sum_without_instance.txtar
+++ b/test/spec/promql/sum_without_instance.txtar
@@ -1,0 +1,8 @@
+-- query.promql --
+sum without (instance) (up)
+-- args --
+[0] string = "instance"
+[1] string = "up"
+[2] string = "instance"
+-- sql --
+SELECT mapFilter((k, v) -> NOT (k IN (?)), `Attributes`), sum(`Value`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?)) GROUP BY mapFilter((k, v) -> NOT (k IN (?)), `Attributes`)

--- a/test/spec/promql/sum_without_two_labels.txtar
+++ b/test/spec/promql/sum_without_two_labels.txtar
@@ -1,0 +1,10 @@
+-- query.promql --
+sum without (instance, pod) (up)
+-- sql --
+SELECT mapFilter((k, v) -> NOT (k IN (?, ?)), `Attributes`), sum(`Value`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?)) GROUP BY mapFilter((k, v) -> NOT (k IN (?, ?)), `Attributes`)
+-- args --
+[0] string = "instance"
+[1] string = "pod"
+[2] string = "up"
+[3] string = "instance"
+[4] string = "pod"


### PR DESCRIPTION
## Summary
- `without (k1, k2)` aggregations — new `chplan.MapWithoutKeys` expr renders as CH `mapFilter((k, v) -> NOT (k IN (...)), Attributes)`.
- `stddev` / `stdvar` / `group` / `quantile(phi, X)` aggregations — `stddevPop` / `varPop` / `any(1)` / `quantile(phi)(value)` in CH.
- `AggFunc` gets a `Params []Expr` field for CH parameterised aggregates (`<name>(<params>)(<args>)`).
- 6 new TXTAR fixtures (sum without 1 + 2 labels, stddev by job, stdvar no group, group by job, quantile by job).

## Deferred to M1.7 (result shaping)
- `topk` / `bottomk` / `count_values` — return K rows per group, not 1.
- Computed phi for `quantile` (only scalar-literal phi lowers in M1.4).

## Test plan
- [x] `just test` green
- [x] `just lint` clean
- [ ] CI green