### PR TITLE
feat(promql,chplan,chsql): offset and @ modifiers (M1.5)

### DIFF
--- a/internal/chplan/range_window.go
+++ b/internal/chplan/range_window.go
@@ -33,6 +33,11 @@ type RangeWindow struct {
 	Start time.Time
 	End   time.Time
 
+	// Offset is the PromQL `offset` modifier shifted onto the inner
+	// VectorSelector. Subtracted from End at emit time so the window
+	// becomes [End - Offset - Range, End - Offset]. Zero means no offset.
+	Offset time.Duration
+
 	// TimestampColumn names the column carrying the per-sample timestamp
 	// on Input (typically "TimeUnix" for OTel-CH).
 	TimestampColumn string
@@ -57,7 +62,7 @@ func (r *RangeWindow) Equal(other Node) bool {
 	if !ok {
 		return false
 	}
-	if r.Func != o.Func || r.Range != o.Range || r.Step != o.Step {
+	if r.Func != o.Func || r.Range != o.Range || r.Step != o.Step || r.Offset != o.Offset {
 		return false
 	}
 	if !r.Start.Equal(o.Start) || !r.End.Equal(o.End) {

--- a/internal/chsql/range_window.go
+++ b/internal/chsql/range_window.go
@@ -126,6 +126,9 @@ func (e *emitter) emitWindowedArray(r *chplan.RangeWindow, valueExpr string) err
 	}
 
 	endExpr := timeOrNow(r.End)
+	if r.Offset > 0 {
+		endExpr = "(" + endExpr + " - toIntervalNanosecond(" + strconv.FormatInt(r.Offset.Nanoseconds(), 10) + "))"
+	}
 	rangeNS := r.Range.Nanoseconds()
 	groupKeys, err := e.collectGroupBy(r.GroupBy)
 	if err != nil {

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -28,7 +28,7 @@ func Lower(expr parser.Expr, s schema.Metrics) (chplan.Node, error) {
 func lower(expr parser.Expr, s schema.Metrics) (chplan.Node, error) {
 	switch e := expr.(type) {
 	case *parser.VectorSelector:
-		return lowerVectorSelector(e, s), nil
+		return lowerVectorSelector(e, s)
 	case *parser.Call:
 		return lowerCall(e, s)
 	case *parser.AggregateExpr:
@@ -43,7 +43,9 @@ func lower(expr parser.Expr, s schema.Metrics) (chplan.Node, error) {
 }
 
 // lowerVectorSelector turns `metric{label="val"}` into Scan + Filter.
-func lowerVectorSelector(v *parser.VectorSelector, s schema.Metrics) chplan.Node {
+// `@` and `offset` modifiers add a `Timestamp <= anchor` predicate so the
+// instant evaluation reflects the requested shifted time.
+func lowerVectorSelector(v *parser.VectorSelector, s schema.Metrics) (chplan.Node, error) {
 	metricName := metricNameFromMatchers(v.LabelMatchers)
 	table := s.GaugeTable
 	if metricName != "" {
@@ -53,10 +55,22 @@ func lowerVectorSelector(v *parser.VectorSelector, s schema.Metrics) chplan.Node
 	scan := &chplan.Scan{Table: table}
 
 	pred := buildPredicate(v.LabelMatchers, s)
-	if pred == nil {
-		return scan
+	if hasModifier(v) {
+		anchor, err := anchorFromSelector(v)
+		if err != nil {
+			return nil, err
+		}
+		timeBound := timeBoundExpr(s.TimestampColumn, anchor)
+		if pred == nil {
+			pred = timeBound
+		} else {
+			pred = &chplan.Binary{Op: chplan.OpAnd, Left: pred, Right: timeBound}
+		}
 	}
-	return &chplan.Filter{Input: scan, Predicate: pred}
+	if pred == nil {
+		return scan, nil
+	}
+	return &chplan.Filter{Input: scan, Predicate: pred}, nil
 }
 
 // metricNameFromMatchers returns the value of the __name__ matcher (if any
@@ -157,11 +171,28 @@ func lowerRangeVectorCall(c *parser.Call, s schema.Metrics) (chplan.Node, error)
 			ms.VectorSelector)
 	}
 
-	inner := lowerVectorSelector(vs, s)
+	anchor, err := anchorFromSelector(vs)
+	if err != nil {
+		return nil, err
+	}
+
+	// The RangeWindow already encodes the window's eval anchor; emitting a
+	// duplicate time-bound predicate on the inner Filter would double-count.
+	// Build the inner Scan/Filter without the modifier-derived bound here.
+	vsNoModifier := *vs
+	vsNoModifier.Timestamp = nil
+	vsNoModifier.OriginalOffset = 0
+	vsNoModifier.Offset = 0
+	inner, err := lowerVectorSelector(&vsNoModifier, s)
+	if err != nil {
+		return nil, err
+	}
 	return &chplan.RangeWindow{
 		Input:           inner,
 		Func:            c.Func.Name,
 		Range:           ms.Range,
+		End:             anchor.End,
+		Offset:          anchor.Offset,
 		TimestampColumn: s.TimestampColumn,
 		ValueColumn:     s.ValueColumn,
 		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}},

--- a/internal/promql/modifiers.go
+++ b/internal/promql/modifiers.go
@@ -1,0 +1,75 @@
+package promql
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// evalAnchor describes the time-anchor that a VectorSelector's `@` and
+// `offset` modifiers resolve to. End is the absolute anchor (zero means
+// "use eval time, lower as `now64(9)` in SQL"); Offset is the shift to
+// subtract from End. `@ start()` / `@ end()` are not yet supported and
+// surface as an error.
+type evalAnchor struct {
+	End    time.Time
+	Offset time.Duration
+}
+
+func anchorFromSelector(vs *parser.VectorSelector) (evalAnchor, error) {
+	a := evalAnchor{Offset: vs.OriginalOffset}
+	if vs.StartOrEnd != 0 {
+		return evalAnchor{}, fmt.Errorf("promql: `@ start()` / `@ end()` modifiers are not yet supported (lands when the API layer threads the query range through lowering)")
+	}
+	if vs.Timestamp != nil {
+		// Upstream stores @ as Unix milliseconds.
+		a.End = time.UnixMilli(*vs.Timestamp).UTC()
+	}
+	return a, nil
+}
+
+// hasModifier reports whether vs has anything that affects the time
+// anchor — `@`, `offset`, or `@ start()` / `@ end()`.
+func hasModifier(vs *parser.VectorSelector) bool {
+	return vs.Timestamp != nil || vs.OriginalOffset != 0 || vs.StartOrEnd != 0
+}
+
+// timeBoundExpr builds `<col> <= <anchor>` for an instant-vector
+// VectorSelector with `@` or `offset`. The anchor is `now64(9)` (or a
+// literal toDateTime64) optionally minus a nanosecond interval.
+func timeBoundExpr(col string, a evalAnchor) chplan.Expr {
+	var base chplan.Expr
+	if a.End.IsZero() {
+		base = &chplan.FuncCall{
+			Name: "now64",
+			Args: []chplan.Expr{&chplan.LitInt{V: 9}},
+		}
+	} else {
+		base = &chplan.FuncCall{
+			Name: "toDateTime64",
+			Args: []chplan.Expr{
+				&chplan.LitString{V: a.End.Format("2006-01-02 15:04:05.000000000")},
+				&chplan.LitInt{V: 9},
+			},
+		}
+	}
+	bound := base
+	if a.Offset > 0 {
+		bound = &chplan.Binary{
+			Op:   chplan.OpSub,
+			Left: base,
+			Right: &chplan.FuncCall{
+				Name: "toIntervalNanosecond",
+				Args: []chplan.Expr{&chplan.LitInt{V: a.Offset.Nanoseconds()}},
+			},
+		}
+	}
+	return &chplan.Binary{
+		Op:    chplan.OpLe,
+		Left:  &chplan.ColumnRef{Name: col},
+		Right: bound,
+	}
+}

--- a/internal/promql/modifiers_test.go
+++ b/internal/promql/modifiers_test.go
@@ -1,0 +1,54 @@
+package promql_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestLower_Modifiers_Errors covers the modifier paths that intentionally
+// stay out of scope in M1.5 (the start()/end() variants depend on the API
+// layer threading the query range through lowering).
+func TestLower_Modifiers_Errors(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{})
+
+	cases := []struct {
+		name    string
+		query   string
+		wantErr string
+	}{
+		{
+			name:    "at start() deferred",
+			query:   `up @ start()`,
+			wantErr: "`@ start()` / `@ end()` modifiers are not yet supported",
+		},
+		{
+			name:    "at end() in range vector deferred",
+			query:   `rate(http_requests_total[5m] @ end())`,
+			wantErr: "`@ start()` / `@ end()` modifiers are not yet supported",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr: %v", err)
+			}
+			_, err = promql.Lower(expr, s)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}

--- a/test/spec/promql/rate_offset_5m.txtar
+++ b/test/spec/promql/rate_offset_5m.txtar
@@ -1,0 +1,6 @@
+-- query.promql --
+rate(http_server_request_duration_count[1m] offset 5m)
+-- sql --
+SELECT `Attributes`, if(length(window_vals) > 1, counter_delta / 60, 0.0) AS value FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS window_vals, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS counter_delta FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) >= (now64(9) - toIntervalNanosecond(300000000000)) - toIntervalNanosecond(60000000000) AND tupleElement(p, 1) <= (now64(9) - toIntervalNanosecond(300000000000)), series_array) AS window_pairs FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS series_array FROM (SELECT * FROM (SELECT * FROM `otel_metrics_sum`) WHERE (`MetricName` = ?)) GROUP BY `Attributes`)))
+-- args --
+[0] string = "http_server_request_duration_count"

--- a/test/spec/promql/up_at_offset_combined.txtar
+++ b/test/spec/promql/up_at_offset_combined.txtar
@@ -1,0 +1,9 @@
+-- query.promql --
+up @ 1640995200 offset 5m
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE ((`MetricName` = ?) AND (`TimeUnix` <= (toDateTime64(?, ?) - toIntervalNanosecond(?))))
+-- args --
+[0] string = "up"
+[1] string = "2022-01-01 00:00:00.000000000"
+[2] int64 = 9
+[3] int64 = 300000000000

--- a/test/spec/promql/up_at_timestamp.txtar
+++ b/test/spec/promql/up_at_timestamp.txtar
@@ -1,0 +1,8 @@
+-- query.promql --
+up @ 1640995200
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE ((`MetricName` = ?) AND (`TimeUnix` <= toDateTime64(?, ?)))
+-- args --
+[0] string = "up"
+[1] string = "2022-01-01 00:00:00.000000000"
+[2] int64 = 9

--- a/test/spec/promql/up_offset_5m.txtar
+++ b/test/spec/promql/up_offset_5m.txtar
@@ -1,0 +1,8 @@
+-- query.promql --
+up offset 5m
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE ((`MetricName` = ?) AND (`TimeUnix` <= (now64(?) - toIntervalNanosecond(?))))
+-- args --
+[0] string = "up"
+[1] int64 = 9
+[2] int64 = 300000000000


### PR DESCRIPTION
## Summary
- VectorSelector with `@`/`offset` adds a `Timestamp <= anchor` predicate; anchor is `now64(9)` (or `toDateTime64(T, 9)`) optionally minus `toIntervalNanosecond(offset_ns)`.
- RangeWindow gains an `Offset time.Duration` field; emitter subtracts the offset from the end expression so the window becomes `[end - offset - range, end - offset]`.
- Inner VectorSelector's modifier is stripped before the inner Filter is built — RangeWindow already encodes the anchor, so a duplicate predicate would double-bind.
- 4 new TXTAR fixtures: instant offset, instant @, instant @+offset, range offset.

## Deferred
- `@ start()` / `@ end()` — need the HTTP API to thread the query range into lowering (lands with M2).

## Test plan
- [x] \`just test\` green
- [x] \`just lint\` clean
- [ ] CI green