### PR TITLE
feat(promql,chplan,chsql): vector-vector matching with on/ignoring (M1.6)

### DIFF
--- a/internal/chplan/node_test.go
+++ b/internal/chplan/node_test.go
@@ -45,6 +45,35 @@ func TestEqual(t *testing.T) {
 		t.Fatalf("Filter: different predicates should not be Equal")
 	}
 
+	vj := &chplan.VectorJoin{
+		Left:             &chplan.Scan{Table: "otel_metrics_sum"},
+		Right:            &chplan.Scan{Table: "otel_metrics_sum"},
+		Op:               chplan.OpAdd,
+		Match:            chplan.VectorMatch{Labels: []string{"job"}, On: true},
+		MetricNameColumn: "MetricName",
+		AttributesColumn: "Attributes",
+		TimestampColumn:  "TimeUnix",
+		ValueColumn:      "Value",
+	}
+	vjSame := &chplan.VectorJoin{
+		Left:             &chplan.Scan{Table: "otel_metrics_sum"},
+		Right:            &chplan.Scan{Table: "otel_metrics_sum"},
+		Op:               chplan.OpAdd,
+		Match:            chplan.VectorMatch{Labels: []string{"job"}, On: true},
+		MetricNameColumn: "MetricName",
+		AttributesColumn: "Attributes",
+		TimestampColumn:  "TimeUnix",
+		ValueColumn:      "Value",
+	}
+	vjDifferentMatch := *vjSame
+	vjDifferentMatch.Match = chplan.VectorMatch{Labels: []string{"job"}, On: false}
+	if !vj.Equal(vjSame) {
+		t.Fatalf("VectorJoin: identical trees should be Equal")
+	}
+	if vj.Equal(&vjDifferentMatch) {
+		t.Fatalf("VectorJoin: on(job) vs ignoring(job) should not be Equal")
+	}
+
 	rw := &chplan.RangeWindow{
 		Input: &chplan.Scan{Table: "otel_metrics_sum"},
 		Func:  "rate",

--- a/internal/chplan/vector_join.go
+++ b/internal/chplan/vector_join.go
@@ -1,0 +1,59 @@
+package chplan
+
+import "slices"
+
+// VectorMatch describes how two vector inputs join on labels in a PromQL
+// binary expression. `Labels` is empty + `On` false → default matching on
+// the full Attributes map. `On` true (with Labels non-empty) → match only
+// on the listed labels. `On` false (with Labels non-empty) → match on
+// everything except the listed labels (`ignoring(...)`).
+type VectorMatch struct {
+	Labels []string
+	On     bool
+}
+
+// Equal reports structural equality with another VectorMatch.
+func (m VectorMatch) Equal(other VectorMatch) bool {
+	return m.On == other.On && slices.Equal(m.Labels, other.Labels)
+}
+
+// VectorJoin produces the per-pair binary-op result of matching two vector
+// inputs by labels. The emitter renders an INNER JOIN of per-series latest
+// samples (argMax(Value, TimeUnix) grouped by series-identity columns),
+// then evaluates `(L.Value <Op> R.Value)` on the joined rows.
+//
+// `group_left` / `group_right` (many-to-one / one-to-many) cardinality
+// modifiers are intentionally out of scope here and surface as a lowering
+// error from internal/promql.
+type VectorJoin struct {
+	Left  Node
+	Right Node
+	Op    BinaryOp
+	Match VectorMatch
+
+	MetricNameColumn string
+	AttributesColumn string
+	TimestampColumn  string
+	ValueColumn      string
+}
+
+func (*VectorJoin) planNode() {}
+
+func (v *VectorJoin) Children() []Node { return []Node{v.Left, v.Right} }
+
+func (v *VectorJoin) Equal(other Node) bool {
+	o, ok := other.(*VectorJoin)
+	if !ok {
+		return false
+	}
+	if v.Op != o.Op || !v.Match.Equal(o.Match) {
+		return false
+	}
+	if v.MetricNameColumn != o.MetricNameColumn ||
+		v.AttributesColumn != o.AttributesColumn ||
+		v.TimestampColumn != o.TimestampColumn ||
+		v.ValueColumn != o.ValueColumn {
+		return false
+	}
+	return v.Left.Equal(o.Left) && v.Right.Equal(o.Right)
+}

--- a/internal/chsql/emit.go
+++ b/internal/chsql/emit.go
@@ -54,6 +54,8 @@ func (e *emitter) emitNode(n chplan.Node) error {
 		return e.emitRangeWindow(v)
 	case *chplan.Limit:
 		return e.emitLimit(v)
+	case *chplan.VectorJoin:
+		return e.emitVectorJoin(v)
 	default:
 		return fmt.Errorf("%w: node %T", ErrUnsupported, n)
 	}

--- a/internal/chsql/vector_join.go
+++ b/internal/chsql/vector_join.go
@@ -1,0 +1,131 @@
+package chsql
+
+import (
+	"fmt"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// emitVectorJoin renders a PromQL vector-vector binary expression as an
+// INNER JOIN of per-series latest samples. Shape:
+//
+//	SELECT
+//	    L.<MetricName>, L.<Attributes>, L.<TimeUnix>,
+//	    (L.<Value> <Op> R.<Value>) AS <Value>
+//	FROM (
+//	    SELECT <MetricName>, <Attributes>,
+//	           max(<TimeUnix>) AS <TimeUnix>,
+//	           argMax(<Value>, <TimeUnix>) AS <Value>
+//	    FROM (<left>) GROUP BY <MetricName>, <Attributes>
+//	) AS L
+//	INNER JOIN (
+//	    SELECT <MetricName>, <Attributes>,
+//	           max(<TimeUnix>) AS <TimeUnix>,
+//	           argMax(<Value>, <TimeUnix>) AS <Value>
+//	    FROM (<right>) GROUP BY <MetricName>, <Attributes>
+//	) AS R
+//	ON <match-key-on-L> = <match-key-on-R>
+//
+// The match-key expression depends on `Match`:
+//   - default (Labels empty, On false) → `L.Attributes = R.Attributes`
+//   - on(labels)                       → AND of `L.Attributes['lbl'] = R.Attributes['lbl']`
+//   - ignoring(labels)                 → mapFilter-stripped Attributes equality
+func (e *emitter) emitVectorJoin(j *chplan.VectorJoin) error {
+	if err := e.validateVectorJoinCols(j); err != nil {
+		return err
+	}
+
+	attrsCol := quoteIdent(j.AttributesColumn)
+	metricCol := quoteIdent(j.MetricNameColumn)
+	tsCol := quoteIdent(j.TimestampColumn)
+	valCol := quoteIdent(j.ValueColumn)
+
+	// Outer SELECT.
+	fmt.Fprintf(&e.b, "SELECT L.%s, L.%s, L.%s, (L.%s %s R.%s) AS %s FROM ",
+		metricCol, attrsCol, tsCol, valCol, string(j.Op), valCol, valCol)
+
+	// Left side — argMax per series.
+	if err := e.emitLatestPerSeries(j.Left, metricCol, attrsCol, tsCol, valCol); err != nil {
+		return err
+	}
+	e.b.WriteString(" AS L INNER JOIN ")
+	if err := e.emitLatestPerSeries(j.Right, metricCol, attrsCol, tsCol, valCol); err != nil {
+		return err
+	}
+	e.b.WriteString(" AS R ON ")
+	return e.writeVectorMatchPredicate(j.Match, attrsCol)
+}
+
+func (e *emitter) validateVectorJoinCols(j *chplan.VectorJoin) error {
+	switch {
+	case j.AttributesColumn == "":
+		return fmt.Errorf("%w: VectorJoin.AttributesColumn unset", ErrUnsupported)
+	case j.MetricNameColumn == "":
+		return fmt.Errorf("%w: VectorJoin.MetricNameColumn unset", ErrUnsupported)
+	case j.TimestampColumn == "":
+		return fmt.Errorf("%w: VectorJoin.TimestampColumn unset", ErrUnsupported)
+	case j.ValueColumn == "":
+		return fmt.Errorf("%w: VectorJoin.ValueColumn unset", ErrUnsupported)
+	}
+	return nil
+}
+
+// emitLatestPerSeries wraps a subquery in a per-series latest aggregation:
+// (SELECT metric, attrs, max(ts) AS ts, argMax(value, ts) AS value FROM <n>
+//
+//	GROUP BY metric, attrs).
+func (e *emitter) emitLatestPerSeries(n chplan.Node, metricCol, attrsCol, tsCol, valCol string) error {
+	e.b.WriteByte('(')
+	fmt.Fprintf(&e.b, "SELECT %s, %s, max(%s) AS %s, argMax(%s, %s) AS %s FROM ",
+		metricCol, attrsCol, tsCol, tsCol, valCol, tsCol, valCol)
+	if err := e.emitSubquery(n); err != nil {
+		return err
+	}
+	fmt.Fprintf(&e.b, " GROUP BY %s, %s)", metricCol, attrsCol)
+	return nil
+}
+
+func (e *emitter) writeVectorMatchPredicate(m chplan.VectorMatch, attrsCol string) error {
+	// Default: full-Attributes equality.
+	if len(m.Labels) == 0 && !m.On {
+		fmt.Fprintf(&e.b, "L.%s = R.%s", attrsCol, attrsCol)
+		return nil
+	}
+
+	if m.On {
+		// on(l1, l2): conjunction of per-label key equalities.
+		for i, lbl := range m.Labels {
+			if i > 0 {
+				e.b.WriteString(" AND ")
+			}
+			fmt.Fprintf(&e.b, "L.%s[", attrsCol)
+			if err := e.bindArg(lbl); err != nil {
+				return err
+			}
+			fmt.Fprintf(&e.b, "] = R.%s[", attrsCol)
+			if err := e.bindArg(lbl); err != nil {
+				return err
+			}
+			e.b.WriteByte(']')
+		}
+		return nil
+	}
+
+	// ignoring(l1, l2): mapFilter-stripped Attributes equality on each side.
+	for _, side := range []string{"L", "R"} {
+		if side == "R" {
+			e.b.WriteString(" = ")
+		}
+		fmt.Fprintf(&e.b, "mapFilter((k, v) -> NOT (k IN (")
+		for i, lbl := range m.Labels {
+			if i > 0 {
+				e.b.WriteString(", ")
+			}
+			if err := e.bindArg(lbl); err != nil {
+				return err
+			}
+		}
+		fmt.Fprintf(&e.b, ")), %s.%s)", side, attrsCol)
+	}
+	return nil
+}

--- a/internal/promql/binary.go
+++ b/internal/promql/binary.go
@@ -9,16 +9,18 @@ import (
 	"github.com/tsouza/cerberus/internal/schema"
 )
 
-// lowerBinary handles PromQL BinaryExpr — arithmetic for now. Comparison
-// and logical ops, plus vector-vector matching, land in M1.x follow-ups.
+// lowerBinary handles PromQL BinaryExpr.
 //
 // Supported shapes:
 //   - scalar OP scalar           → folded to chplan.LitFloat at lowering
 //   - scalar OP vector / vec OP scalar → Project that maps Value through
 //     the binary op
+//   - vector OP vector           → VectorJoin with default / `on(...)` /
+//     `ignoring(...)` matching (M1.6)
 //
-// Vector OP vector is rejected with a clear error pointing at M1.6
-// (vector matching), since the join semantics need first-class support.
+// `group_left` / `group_right` (many-to-one / one-to-many) and comparison /
+// logical ops are deferred — they need first-class support for cardinality
+// and the `bool` modifier respectively.
 func lowerBinary(b *parser.BinaryExpr, s schema.Metrics) (chplan.Node, error) {
 	op, err := promBinaryOp(b.Op, b.ReturnBool)
 	if err != nil {
@@ -36,8 +38,53 @@ func lowerBinary(b *parser.BinaryExpr, s schema.Metrics) (chplan.Node, error) {
 	case rhsIsScalar:
 		return projectWithScalar(b.LHS, s, op, rhsScalar, false)
 	default:
-		return nil, fmt.Errorf("promql: vector OP vector binary expressions require vector matching (lands in M1.6); op=%s", b.Op.String())
+		return lowerVectorVector(b, s, op)
 	}
+}
+
+// lowerVectorVector handles the vector-vector case: both sides lower to a
+// Node, and the result is a VectorJoin that the emitter renders as an
+// INNER JOIN of per-series latest samples.
+//
+// `group_left` / `group_right` are rejected here — cardinality enforcement
+// needs additional output-shape work and is intentionally deferred.
+func lowerVectorVector(b *parser.BinaryExpr, s schema.Metrics, op chplan.BinaryOp) (chplan.Node, error) {
+	if b.VectorMatching != nil && (b.VectorMatching.Card == parser.CardManyToOne || b.VectorMatching.Card == parser.CardOneToMany) {
+		side := "left"
+		if b.VectorMatching.Card == parser.CardOneToMany {
+			side = "right"
+		}
+		return nil, fmt.Errorf("promql: group_%s vector matching is not yet supported (cardinality enforcement lands with M1.7 result shaping)", side)
+	}
+	if b.VectorMatching != nil && len(b.VectorMatching.Include) > 0 {
+		return nil, fmt.Errorf("promql: group_left/right with `include(...)` is not yet supported")
+	}
+
+	left, err := lower(b.LHS, s)
+	if err != nil {
+		return nil, err
+	}
+	right, err := lower(b.RHS, s)
+	if err != nil {
+		return nil, err
+	}
+
+	match := chplan.VectorMatch{}
+	if b.VectorMatching != nil {
+		match.Labels = append([]string(nil), b.VectorMatching.MatchingLabels...)
+		match.On = b.VectorMatching.On
+	}
+
+	return &chplan.VectorJoin{
+		Left:             left,
+		Right:            right,
+		Op:               op,
+		Match:            match,
+		MetricNameColumn: s.MetricNameColumn,
+		AttributesColumn: s.AttributesColumn,
+		TimestampColumn:  s.TimestampColumn,
+		ValueColumn:      s.ValueColumn,
+	}, nil
 }
 
 // promBinaryOp maps a PromQL parser op to the chplan op. Comparison ops

--- a/internal/promql/binary_test.go
+++ b/internal/promql/binary_test.go
@@ -27,9 +27,14 @@ func TestLower_Binary_Errors(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name:    "vector OP vector deferred",
-			query:   `up + up`,
-			wantErr: "vector OP vector binary expressions require vector matching",
+			name:    "group_left deferred",
+			query:   `up * on(job) group_left up`,
+			wantErr: "group_left vector matching is not yet supported",
+		},
+		{
+			name:    "group_right deferred",
+			query:   `up * on(job) group_right up`,
+			wantErr: "group_right vector matching is not yet supported",
 		},
 		{
 			name:    "bool modifier deferred",

--- a/test/spec/promql/vector_ignoring_instance.txtar
+++ b/test/spec/promql/vector_ignoring_instance.txtar
@@ -1,0 +1,9 @@
+-- query.promql --
+http_server_request_duration_count - ignoring(instance) http_server_request_duration_count
+-- sql --
+SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` - R.`Value`) AS `Value` FROM (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_sum`) WHERE (`MetricName` = ?)) GROUP BY `MetricName`, `Attributes`) AS L INNER JOIN (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_sum`) WHERE (`MetricName` = ?)) GROUP BY `MetricName`, `Attributes`) AS R ON mapFilter((k, v) -> NOT (k IN (?)), L.`Attributes`) = mapFilter((k, v) -> NOT (k IN (?)), R.`Attributes`)
+-- args --
+[0] string = "http_server_request_duration_count"
+[1] string = "http_server_request_duration_count"
+[2] string = "instance"
+[3] string = "instance"

--- a/test/spec/promql/vector_on_job.txtar
+++ b/test/spec/promql/vector_on_job.txtar
@@ -1,0 +1,9 @@
+-- query.promql --
+http_server_request_duration_count / on(job) http_server_request_duration_sum
+-- sql --
+SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` / R.`Value`) AS `Value` FROM (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_sum`) WHERE (`MetricName` = ?)) GROUP BY `MetricName`, `Attributes`) AS L INNER JOIN (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_sum`) WHERE (`MetricName` = ?)) GROUP BY `MetricName`, `Attributes`) AS R ON L.`Attributes`[?] = R.`Attributes`[?]
+-- args --
+[0] string = "http_server_request_duration_count"
+[1] string = "http_server_request_duration_sum"
+[2] string = "job"
+[3] string = "job"

--- a/test/spec/promql/vector_plus_vector.txtar
+++ b/test/spec/promql/vector_plus_vector.txtar
@@ -1,0 +1,7 @@
+-- query.promql --
+http_server_request_duration_count + http_server_request_duration_sum
+-- sql --
+SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` + R.`Value`) AS `Value` FROM (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_sum`) WHERE (`MetricName` = ?)) GROUP BY `MetricName`, `Attributes`) AS L INNER JOIN (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_sum`) WHERE (`MetricName` = ?)) GROUP BY `MetricName`, `Attributes`) AS R ON L.`Attributes` = R.`Attributes`
+-- args --
+[0] string = "http_server_request_duration_count"
+[1] string = "http_server_request_duration_sum"


### PR DESCRIPTION
## Summary
- New \`chplan.VectorJoin\` node renders \`m1 OP m2\` as an INNER JOIN of per-series latest samples (argMax on each side, then JOIN).
- \`chplan.VectorMatch{Labels, On}\` covers the three match strategies: default (full Attributes), \`on(...)\` (per-label key equalities), \`ignoring(...)\` (mapFilter-stripped Attributes equality).
- 3 new TXTAR fixtures + Equal test for VectorJoin.

## Deferred to M1.7
- \`group_left\` / \`group_right\` cardinality modifiers — need many-to-one row expansion + Include label projection.

## Test plan
- [x] \`just test\` green
- [x] \`just lint\` clean
- [ ] CI green