### PR TITLE
feat(promql): clamp family + 2-arg round (M1.7 part 2)

### DIFF
--- a/internal/promql/instant_fns.go
+++ b/internal/promql/instant_fns.go
@@ -32,11 +32,17 @@ var instantFnCH = map[string]string{
 // arg is expected to be an instant-vector expression; we lower it, then
 // wrap with a Project that maps the Value column through the CH function.
 //
-// Multi-arg forms (e.g. PromQL `round(v, to_nearest)`) are deferred — only
-// the unary form lands in M1.3.
+// Multi-arg variants of round and the clamp family are handled separately.
 func lowerInstantFn(c *parser.Call, s schema.Metrics, chFn string) (chplan.Node, error) {
+	switch c.Func.Name {
+	case "round":
+		if len(c.Args) == 2 {
+			return lowerRoundToNearest(c, s)
+		}
+	}
+
 	if len(c.Args) != 1 {
-		return nil, fmt.Errorf("promql: %s with %d arguments is not yet supported (M1.3 supports the unary form only)",
+		return nil, fmt.Errorf("promql: %s with %d arguments is not yet supported (instant math fns are unary)",
 			c.Func.Name, len(c.Args))
 	}
 
@@ -49,6 +55,102 @@ func lowerInstantFn(c *parser.Call, s schema.Metrics, chFn string) (chplan.Node,
 		Name: chFn,
 		Args: []chplan.Expr{&chplan.ColumnRef{Name: s.ValueColumn}},
 	}
+	return projectValueOverInner(inner, s, newValue), nil
+}
+
+// lowerRoundToNearest implements PromQL `round(v, to_nearest)` as
+// `round(Value / to_nearest) * to_nearest`. CH's native `round(v, N)`
+// rounds to N decimal places, not to a multiple, so we synthesise the
+// multiple-rounding semantics explicitly.
+func lowerRoundToNearest(c *parser.Call, s schema.Metrics) (chplan.Node, error) {
+	toNearest, ok := tryScalarLiteral(c.Args[1])
+	if !ok {
+		return nil, fmt.Errorf("promql: round(v, to_nearest) requires a scalar literal to_nearest")
+	}
+
+	inner, err := lower(c.Args[0], s)
+	if err != nil {
+		return nil, err
+	}
+
+	valueRef := &chplan.ColumnRef{Name: s.ValueColumn}
+	tn := &chplan.LitFloat{V: toNearest}
+
+	rounded := &chplan.FuncCall{
+		Name: "round",
+		Args: []chplan.Expr{&chplan.Binary{Op: chplan.OpDiv, Left: valueRef, Right: tn}},
+	}
+	newValue := &chplan.Binary{Op: chplan.OpMul, Left: rounded, Right: tn}
+	return projectValueOverInner(inner, s, newValue), nil
+}
+
+// lowerClamp implements the PromQL clamp family:
+//
+//	clamp_max(v, max) → least(Value, max)
+//	clamp_min(v, min) → greatest(Value, min)
+//	clamp(v, min, max) → greatest(min, least(max, Value))
+//
+// Bounds must be scalar literals at lowering time (computed bounds defer
+// to RC2 when scalars are first-class chplan nodes).
+func lowerClamp(c *parser.Call, s schema.Metrics) (chplan.Node, error) {
+	switch c.Func.Name {
+	case "clamp_max", "clamp_min":
+		if len(c.Args) != 2 {
+			return nil, fmt.Errorf("promql: %s expects 2 arguments, got %d", c.Func.Name, len(c.Args))
+		}
+		bound, ok := tryScalarLiteral(c.Args[1])
+		if !ok {
+			return nil, fmt.Errorf("promql: %s requires a scalar-literal bound", c.Func.Name)
+		}
+		inner, err := lower(c.Args[0], s)
+		if err != nil {
+			return nil, err
+		}
+		fnName := "least"
+		if c.Func.Name == "clamp_min" {
+			fnName = "greatest"
+		}
+		newValue := &chplan.FuncCall{
+			Name: fnName,
+			Args: []chplan.Expr{
+				&chplan.ColumnRef{Name: s.ValueColumn},
+				&chplan.LitFloat{V: bound},
+			},
+		}
+		return projectValueOverInner(inner, s, newValue), nil
+
+	case "clamp":
+		if len(c.Args) != 3 {
+			return nil, fmt.Errorf("promql: clamp expects 3 arguments, got %d", len(c.Args))
+		}
+		minB, okMin := tryScalarLiteral(c.Args[1])
+		maxB, okMax := tryScalarLiteral(c.Args[2])
+		if !okMin || !okMax {
+			return nil, fmt.Errorf("promql: clamp requires scalar-literal bounds for min and max")
+		}
+		inner, err := lower(c.Args[0], s)
+		if err != nil {
+			return nil, err
+		}
+		valueRef := &chplan.ColumnRef{Name: s.ValueColumn}
+		newValue := &chplan.FuncCall{
+			Name: "greatest",
+			Args: []chplan.Expr{
+				&chplan.LitFloat{V: minB},
+				&chplan.FuncCall{
+					Name: "least",
+					Args: []chplan.Expr{&chplan.LitFloat{V: maxB}, valueRef},
+				},
+			},
+		}
+		return projectValueOverInner(inner, s, newValue), nil
+	}
+	return nil, fmt.Errorf("promql: unknown clamp function %s", c.Func.Name)
+}
+
+// projectValueOverInner wraps inner with a Project that keeps
+// MetricName / Attributes / Timestamp and replaces Value with newValue.
+func projectValueOverInner(inner chplan.Node, s schema.Metrics, newValue chplan.Expr) chplan.Node {
 	return &chplan.Project{
 		Input: inner,
 		Projections: []chplan.Projection{
@@ -57,5 +159,5 @@ func lowerInstantFn(c *parser.Call, s schema.Metrics, chFn string) (chplan.Node,
 			{Expr: &chplan.ColumnRef{Name: s.TimestampColumn}},
 			{Expr: newValue, Alias: s.ValueColumn},
 		},
-	}, nil
+	}
 }

--- a/internal/promql/instant_fns_test.go
+++ b/internal/promql/instant_fns_test.go
@@ -24,14 +24,19 @@ func TestLower_InstantFn_Errors(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name:    "round 2-arg deferred",
-			query:   `round(temperature, 0.1)`,
-			wantErr: "supports the unary form only",
+			name:    "round 2-arg requires scalar bound",
+			query:   `round(temperature, scalar(other))`,
+			wantErr: "requires a scalar literal to_nearest",
 		},
 		{
 			name:    "unknown fn",
 			query:   `histogram_quantile(0.9, foo)`,
 			wantErr: "function histogram_quantile is not yet supported",
+		},
+		{
+			name:    "clamp_max needs scalar bound",
+			query:   `clamp_max(up, scalar(other))`,
+			wantErr: "requires a scalar-literal bound",
 		},
 	}
 	for _, tc := range cases {

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -136,14 +136,19 @@ func matchOp(t labels.MatchType) chplan.BinaryOp {
 
 // lowerCall dispatches PromQL function calls. The arg shape decides the
 // path: a MatrixSelector means a range-vector function (rate, increase,
-// *_over_time); anything else is treated as an instant-vector function
-// (abs, sqrt, ln, ...) if recognised. Other functions surface a clear
-// "not yet supported" error pointing at the relevant milestone.
+// *_over_time); the clamp family takes a vector + scalar bounds; everything
+// else is treated as an instant-vector math function (abs, sqrt, ln, ...)
+// if recognised. Other functions surface a clear "not yet supported"
+// error pointing at the relevant milestone.
 func lowerCall(c *parser.Call, s schema.Metrics) (chplan.Node, error) {
 	if len(c.Args) >= 1 {
 		if _, ok := c.Args[0].(*parser.MatrixSelector); ok {
 			return lowerRangeVectorCall(c, s)
 		}
+	}
+	switch c.Func.Name {
+	case "clamp", "clamp_min", "clamp_max":
+		return lowerClamp(c, s)
 	}
 	if chFn, ok := instantFnCH[c.Func.Name]; ok {
 		return lowerInstantFn(c, s, chFn)

--- a/test/spec/promql/clamp.txtar
+++ b/test/spec/promql/clamp.txtar
@@ -1,0 +1,8 @@
+-- query.promql --
+clamp(temperature, 0, 100)
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, greatest(?, least(?, `Value`)) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?))
+-- args --
+[0] float64 = 0
+[1] float64 = 100
+[2] string = "temperature"

--- a/test/spec/promql/clamp_max.txtar
+++ b/test/spec/promql/clamp_max.txtar
@@ -1,0 +1,7 @@
+-- query.promql --
+clamp_max(temperature, 100)
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, least(`Value`, ?) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?))
+-- args --
+[0] float64 = 100
+[1] string = "temperature"

--- a/test/spec/promql/clamp_min.txtar
+++ b/test/spec/promql/clamp_min.txtar
@@ -1,0 +1,7 @@
+-- query.promql --
+clamp_min(temperature, 0)
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, greatest(`Value`, ?) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?))
+-- args --
+[0] float64 = 0
+[1] string = "temperature"

--- a/test/spec/promql/round_to_nearest.txtar
+++ b/test/spec/promql/round_to_nearest.txtar
@@ -1,0 +1,8 @@
+-- query.promql --
+round(temperature, 0.1)
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, (round((`Value` / ?)) * ?) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?))
+-- args --
+[0] float64 = 0.1
+[1] float64 = 0.1
+[2] string = "temperature"


### PR DESCRIPTION
Rebased version of #47. Adds clamp / clamp_max / clamp_min / 2-arg round.