### PR TITLE
feat(api/prom): per-step bucketing in query_range (M2.1)

### DIFF
--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -89,23 +89,33 @@ func (h *Handler) handleQueryRange(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, ErrBadData, errors.New("missing query parameter"))
 		return
 	}
-	end, err := parseTime(r.URL.Query().Get("end"), time.Now())
-	if err != nil {
-		writeError(w, http.StatusBadRequest, ErrBadData, err)
+	start, err := parseTime(r.URL.Query().Get("start"), time.Time{})
+	if err != nil || start.IsZero() {
+		writeError(w, http.StatusBadRequest, ErrBadData, errors.New("missing or invalid 'start' parameter"))
+		return
+	}
+	end, err := parseTime(r.URL.Query().Get("end"), time.Time{})
+	if err != nil || end.IsZero() {
+		writeError(w, http.StatusBadRequest, ErrBadData, errors.New("missing or invalid 'end' parameter"))
+		return
+	}
+	step, err := parseDuration(r.URL.Query().Get("step"))
+	if err != nil || step <= 0 {
+		writeError(w, http.StatusBadRequest, ErrBadData, errors.New("missing or invalid 'step' parameter"))
+		return
+	}
+	if end.Before(start) {
+		writeError(w, http.StatusBadRequest, ErrBadData, errors.New("'end' must be after 'start'"))
 		return
 	}
 
-	// v0.1 range-query lowering returns the same row set as an instant
-	// query, then projects every sample at the `end` timestamp. Real per-
-	// step bucketing lands when the RangeWindow chplan node grows full
-	// emission semantics (post-PR8 follow-up).
 	samples, err := h.executeInstant(r.Context(), q)
 	if err != nil {
 		h.respondError(w, err)
 		return
 	}
 
-	result := toMatrix(samples, end)
+	result := toMatrixStepGrid(samples, start, end, step)
 	writeJSON(w, http.StatusOK, Response{
 		Status: "success",
 		Data:   &Data{ResultType: "matrix", Result: result},
@@ -187,34 +197,85 @@ func toVector(samples []chclient.Sample, ts time.Time) []VectorSample {
 	return out
 }
 
-// toMatrix is the v0.1 placeholder range result — one point per series at
-// the end timestamp. Full per-step rendering follows when RangeWindow
-// emission lands.
-func toMatrix(samples []chclient.Sample, end time.Time) []MatrixSample {
-	type latest struct {
+// toMatrixStepGrid pivots the sample stream into the Prom matrix shape.
+// For each evaluation step T in [start, end] (inclusive, spaced by step),
+// each series emits one Sample: the value of the latest input row whose
+// timestamp <= T (the standard PromQL latest-sample-at-eval-time
+// semantics). Series with no eligible samples for a given step are
+// represented as a stale-marker gap (the step is simply skipped in the
+// Values slice — Prometheus permits this).
+//
+// Lookback delta: a hard 5-minute lookback by default; older samples are
+// considered stale. Future work threads the API's `lookback_delta`
+// param through here.
+func toMatrixStepGrid(samples []chclient.Sample, start, end time.Time, step time.Duration) []MatrixSample {
+	const lookback = 5 * time.Minute
+
+	type seriesState struct {
 		labels map[string]string
-		ts     time.Time
-		value  float64
+		// rows holds the sorted (ascending) timestamps + values for this
+		// series; we walk the row cursor forward as we advance through
+		// the step grid.
+		rows []chclient.Sample
 	}
-	bySeries := map[string]latest{}
+
+	bySeries := map[string]*seriesState{}
 	for _, s := range samples {
 		labels := withMetricName(s.Labels, s.MetricName)
 		key := canonicalKey(labels)
-		cur, ok := bySeries[key]
-		if !ok || s.Timestamp.After(cur.ts) {
-			bySeries[key] = latest{labels: labels, ts: s.Timestamp, value: s.Value}
+		st, ok := bySeries[key]
+		if !ok {
+			st = &seriesState{labels: labels}
+			bySeries[key] = st
+		}
+		st.rows = append(st.rows, s)
+	}
+	for _, st := range bySeries {
+		// Inline insertion sort by Timestamp ascending — samples are
+		// typically already nearly sorted from CH.
+		for i := 1; i < len(st.rows); i++ {
+			for j := i; j > 0 && st.rows[j-1].Timestamp.After(st.rows[j].Timestamp); j-- {
+				st.rows[j-1], st.rows[j] = st.rows[j], st.rows[j-1]
+			}
 		}
 	}
 
-	stamp := float64(end.UnixMilli()) / 1e3
 	out := make([]MatrixSample, 0, len(bySeries))
-	for _, l := range bySeries {
-		out = append(out, MatrixSample{
-			Metric: l.labels,
-			Values: []Sample{{stamp, strconv.FormatFloat(l.value, 'f', -1, 64)}},
-		})
+	for _, st := range bySeries {
+		ms := MatrixSample{Metric: st.labels}
+		cursor := 0
+		for t := start; !t.After(end); t = t.Add(step) {
+			// Advance cursor as long as the next row's ts <= t.
+			for cursor < len(st.rows) && !st.rows[cursor].Timestamp.After(t) {
+				cursor++
+			}
+			if cursor == 0 {
+				continue // no row at-or-before this step yet
+			}
+			latest := st.rows[cursor-1]
+			if t.Sub(latest.Timestamp) > lookback {
+				continue // older than the lookback window; stale
+			}
+			stamp := float64(t.UnixMilli()) / 1e3
+			ms.Values = append(ms.Values, Sample{stamp, strconv.FormatFloat(latest.Value, 'f', -1, 64)})
+		}
+		if len(ms.Values) > 0 {
+			out = append(out, ms)
+		}
 	}
 	return out
+}
+
+// parseDuration parses a Prom-style step / range duration. Accepts plain
+// floats (seconds) or Go-style durations like `30s`, `5m`, `1h`.
+func parseDuration(raw string) (time.Duration, error) {
+	if raw == "" {
+		return 0, errors.New("missing duration")
+	}
+	if f, err := strconv.ParseFloat(raw, 64); err == nil {
+		return time.Duration(f * float64(time.Second)), nil
+	}
+	return time.ParseDuration(raw)
 }
 
 func withMetricName(labels map[string]string, name string) map[string]string {

--- a/internal/api/prom/handler_test.go
+++ b/internal/api/prom/handler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -105,17 +106,24 @@ func TestQuery_Vector(t *testing.T) {
 func TestQueryRange_Matrix(t *testing.T) {
 	t.Parallel()
 
-	ts := time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC)
+	// Three samples spaced 30s apart in the requested [start, end] window;
+	// step=60s should produce 5 evaluation points (start, +60, +120, +180, end).
+	start := time.Unix(1717995600, 0).UTC()
+	end := start.Add(4 * time.Minute) // 1717995840
 	q := &stubQuerier{
 		samples: []chclient.Sample{
-			{MetricName: "up", Labels: map[string]string{"job": "api"}, Timestamp: ts, Value: 1.0},
+			{MetricName: "up", Labels: map[string]string{"job": "api"}, Timestamp: start, Value: 1.0},
+			{MetricName: "up", Labels: map[string]string{"job": "api"}, Timestamp: start.Add(90 * time.Second), Value: 2.0},
+			{MetricName: "up", Labels: map[string]string{"job": "api"}, Timestamp: start.Add(180 * time.Second), Value: 3.0},
 		},
 	}
 
 	srv := newServer(q)
 	t.Cleanup(srv.Close)
 
-	resp, err := http.Get(srv.URL + "/api/v1/query_range?query=up&start=1717995600&end=1717999200&step=60")
+	url := fmt.Sprintf("%s/api/v1/query_range?query=up&start=%d&end=%d&step=60",
+		srv.URL, start.Unix(), end.Unix())
+	resp, err := http.Get(url)
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -130,6 +138,55 @@ func TestQueryRange_Matrix(t *testing.T) {
 	}
 	if parsed.Data.ResultType != "matrix" {
 		t.Fatalf("resultType: got %q, want matrix", parsed.Data.ResultType)
+	}
+
+	rawResult, _ := json.Marshal(parsed.Data.Result)
+	var matrix []prom.MatrixSample
+	if err := json.Unmarshal(rawResult, &matrix); err != nil {
+		t.Fatalf("decode matrix: %v", err)
+	}
+	if len(matrix) != 1 {
+		t.Fatalf("expected 1 series, got %d", len(matrix))
+	}
+	// 5 step points expected for [start..start+4m] step=60s.
+	if got := len(matrix[0].Values); got != 5 {
+		t.Fatalf("expected 5 sample points in matrix, got %d: %+v", got, matrix[0].Values)
+	}
+	// Latest-at-step values: [1, 1, 2, 3, 3] for steps [0, 60, 120, 180, 240].
+	wantValues := []string{"1", "1", "2", "3", "3"}
+	for i, want := range wantValues {
+		if got := matrix[0].Values[i][1]; got != want {
+			t.Errorf("step %d: got value %q, want %q", i, got, want)
+		}
+	}
+}
+
+func TestQueryRange_BadInput(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		url  string
+	}{
+		{"missing start", "/api/v1/query_range?query=up&end=1717999200&step=60"},
+		{"missing end", "/api/v1/query_range?query=up&start=1717995600&step=60"},
+		{"missing step", "/api/v1/query_range?query=up&start=1717995600&end=1717999200"},
+		{"end before start", "/api/v1/query_range?query=up&start=1717999200&end=1717995600&step=60"},
+		{"zero step", "/api/v1/query_range?query=up&start=1717995600&end=1717999200&step=0"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv := newServer(&stubQuerier{})
+			t.Cleanup(srv.Close)
+			resp, err := http.Get(srv.URL + tc.url)
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d body=%s", resp.StatusCode, readBody(t, resp))
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- \`/api/v1/query_range\` now honors \`start\`, \`end\`, \`step\` strictly.
- New \`toMatrixStepGrid\` walks the [start, end] grid and emits the latest sample at-or-before each step T per series; 5-minute lookback marks older samples stale.
- Validation: missing/zero params and end<start return 400 (previously fell through silently).

The chplan RangeWindow still emits a single-eval-at-end SQL; per-step grid emission lands as M2 progresses.

## Test plan
- [x] \`just test\` green (TestQueryRange_Matrix asserts 5 step points)
- [x] \`just lint\` clean
- [ ] CI green