### PR TITLE
feat(api/prom,chclient): labels/values/series endpoints (M2.3-2.5)

### DIFF
--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -23,6 +23,8 @@ import (
 // it makes unit tests possible without a live ClickHouse.
 type Querier interface {
 	Query(ctx context.Context, sql string, args ...any) ([]chclient.Sample, error)
+	QueryStrings(ctx context.Context, sql string, args ...any) ([]string, error)
+	QueryLabelSets(ctx context.Context, sql string, args ...any) ([]map[string]string, error)
 }
 
 // Handler implements the Prometheus HTTP API endpoints cerberus speaks.
@@ -56,6 +58,11 @@ func (h *Handler) Mount(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/v1/query_range", h.handleQueryRange)
 	mux.HandleFunc("POST /api/v1/query", h.handleQuery)
 	mux.HandleFunc("POST /api/v1/query_range", h.handleQueryRange)
+	mux.HandleFunc("GET /api/v1/labels", h.handleLabels)
+	mux.HandleFunc("POST /api/v1/labels", h.handleLabels)
+	mux.HandleFunc("GET /api/v1/label/{name}/values", h.handleLabelValues)
+	mux.HandleFunc("GET /api/v1/series", h.handleSeries)
+	mux.HandleFunc("POST /api/v1/series", h.handleSeries)
 }
 
 func (h *Handler) handleQuery(w http.ResponseWriter, r *http.Request) {
@@ -79,7 +86,7 @@ func (h *Handler) handleQuery(w http.ResponseWriter, r *http.Request) {
 	result := toVector(samples, ts)
 	writeJSON(w, http.StatusOK, Response{
 		Status: "success",
-		Data:   &Data{ResultType: "vector", Result: result},
+		Data:   &QueryData{ResultType: "vector", Result: result},
 	})
 }
 
@@ -108,7 +115,7 @@ func (h *Handler) handleQueryRange(w http.ResponseWriter, r *http.Request) {
 	result := toMatrix(samples, end)
 	writeJSON(w, http.StatusOK, Response{
 		Status: "success",
-		Data:   &Data{ResultType: "matrix", Result: result},
+		Data:   &QueryData{ResultType: "matrix", Result: result},
 	})
 }
 

--- a/internal/api/prom/handler_test.go
+++ b/internal/api/prom/handler_test.go
@@ -17,10 +17,12 @@ import (
 )
 
 type stubQuerier struct {
-	samples  []chclient.Sample
-	err      error
-	lastSQL  string
-	lastArgs []any
+	samples   []chclient.Sample
+	strings   []string
+	labelSets []map[string]string
+	err       error
+	lastSQL   string
+	lastArgs  []any
 }
 
 func (s *stubQuerier) Query(_ context.Context, sql string, args ...any) ([]chclient.Sample, error) {
@@ -32,11 +34,40 @@ func (s *stubQuerier) Query(_ context.Context, sql string, args ...any) ([]chcli
 	return s.samples, nil
 }
 
+func (s *stubQuerier) QueryStrings(_ context.Context, sql string, args ...any) ([]string, error) {
+	s.lastSQL = sql
+	s.lastArgs = args
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.strings, nil
+}
+
+func (s *stubQuerier) QueryLabelSets(_ context.Context, sql string, args ...any) ([]map[string]string, error) {
+	s.lastSQL = sql
+	s.lastArgs = args
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.labelSets, nil
+}
+
 func newServer(q prom.Querier) *httptest.Server {
 	h := prom.New(q, schema.DefaultOTelMetrics(), nil)
 	mux := http.NewServeMux()
 	h.Mount(mux)
 	return httptest.NewServer(mux)
+}
+
+// queryResponse mirrors prom.Response for tests that need access to the
+// QueryData shape (ResultType + Result). Since prom.Response.Data is now
+// `any` to accommodate metadata endpoints, tests decode into this typed
+// shape directly.
+type queryResponse struct {
+	Status    string         `json:"status"`
+	Data      prom.QueryData `json:"data"`
+	ErrorType string         `json:"errorType"`
+	Error     string         `json:"error"`
 }
 
 func TestQuery_Vector(t *testing.T) {
@@ -63,7 +94,7 @@ func TestQuery_Vector(t *testing.T) {
 		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
 	}
 
-	var parsed prom.Response
+	var parsed queryResponse
 	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
 		t.Fatalf("unmarshal: %v\nbody=%s", err, body)
 	}
@@ -124,12 +155,21 @@ func TestQueryRange_Matrix(t *testing.T) {
 		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
 	}
 
-	var parsed prom.Response
+	var parsed queryResponse
 	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if parsed.Data.ResultType != "matrix" {
 		t.Fatalf("resultType: got %q, want matrix", parsed.Data.ResultType)
+	}
+
+	rawResult, _ := json.Marshal(parsed.Data.Result)
+	var matrix []prom.MatrixSample
+	if err := json.Unmarshal(rawResult, &matrix); err != nil {
+		t.Fatalf("decode matrix: %v", err)
+	}
+	if len(matrix) == 0 {
+		t.Fatalf("expected matrix samples, got none")
 	}
 }
 

--- a/internal/api/prom/metadata.go
+++ b/internal/api/prom/metadata.go
@@ -1,0 +1,259 @@
+package prom
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/prometheus/common/model"
+)
+
+// handleLabels implements GET /api/v1/labels — distinct label names across
+// all metric tables, plus the synthetic `__name__` for the metric-name
+// dimension.
+//
+// `match[]` selector filtering is not yet supported; it lands with M2.7.
+func (h *Handler) handleLabels(w http.ResponseWriter, r *http.Request) {
+	if len(r.URL.Query()["match[]"]) > 0 {
+		writeError(w, http.StatusBadRequest, ErrBadData,
+			errors.New("'match[]' selectors are not yet supported on /api/v1/labels"))
+		return
+	}
+
+	names, err := h.fetchLabelNames(r.Context())
+	if err != nil {
+		h.respondError(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, Response{
+		Status: "success",
+		Data:   names,
+	})
+}
+
+// handleLabelValues implements GET /api/v1/label/<name>/values.
+//
+// For the synthetic `__name__` label we union the `MetricName` column
+// across metric tables. For other labels we read `Attributes[<name>]` and
+// drop the empty-string sentinel.
+func (h *Handler) handleLabelValues(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	if name == "" {
+		writeError(w, http.StatusBadRequest, ErrBadData, errors.New("missing label name"))
+		return
+	}
+	if !validLabelName(name) {
+		writeError(w, http.StatusBadRequest, ErrBadData,
+			fmt.Errorf("invalid label name %q", name))
+		return
+	}
+	if len(r.URL.Query()["match[]"]) > 0 {
+		writeError(w, http.StatusBadRequest, ErrBadData,
+			errors.New("'match[]' selectors are not yet supported on /api/v1/label/<name>/values"))
+		return
+	}
+
+	values, err := h.fetchLabelValues(r.Context(), name)
+	if err != nil {
+		h.respondError(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, Response{
+		Status: "success",
+		Data:   values,
+	})
+}
+
+// handleSeries implements GET /api/v1/series. Each matcher in `match[]`
+// is expected to be a single VectorSelector; the union of distinct label
+// sets across all matchers is returned (Prom convention: each entry
+// includes the synthetic `__name__` label).
+//
+// Time-range filtering (start/end) is parsed but not yet pushed into the
+// SQL — lands with M2.7.
+func (h *Handler) handleSeries(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		writeError(w, http.StatusBadRequest, ErrBadData, err)
+		return
+	}
+	matchers := append([]string(nil), r.Form["match[]"]...)
+	if len(matchers) == 0 {
+		writeError(w, http.StatusBadRequest, ErrBadData,
+			errors.New("at least one 'match[]' selector is required"))
+		return
+	}
+
+	seen := make(map[string]map[string]string)
+	for _, m := range matchers {
+		sets, err := h.fetchSeries(r.Context(), m)
+		if err != nil {
+			h.respondError(w, err)
+			return
+		}
+		for _, lset := range sets {
+			key := canonicalKey(lset)
+			if _, ok := seen[key]; !ok {
+				seen[key] = lset
+			}
+		}
+	}
+
+	out := make([]map[string]string, 0, len(seen))
+	keys := make([]string, 0, len(seen))
+	for k := range seen {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		out = append(out, seen[k])
+	}
+
+	writeJSON(w, http.StatusOK, Response{
+		Status: "success",
+		Data:   out,
+	})
+}
+
+// fetchLabelNames unions the Attributes-map keys across the metric tables
+// and prepends `__name__`. The returned slice is sorted.
+func (h *Handler) fetchLabelNames(ctx context.Context) ([]string, error) {
+	sql := h.unionLabelNamesSQL()
+	names, err := h.Client.QueryStrings(ctx, sql)
+	if err != nil {
+		return nil, &apiError{kind: ErrInternal, err: err, status: http.StatusBadGateway}
+	}
+	out := append([]string{model.MetricNameLabel}, names...)
+	sort.Strings(out)
+	return out, nil
+}
+
+func (h *Handler) fetchLabelValues(ctx context.Context, name string) ([]string, error) {
+	if name == model.MetricNameLabel {
+		values, err := h.Client.QueryStrings(ctx, h.unionMetricNamesSQL())
+		if err != nil {
+			return nil, &apiError{kind: ErrInternal, err: err, status: http.StatusBadGateway}
+		}
+		sort.Strings(values)
+		return values, nil
+	}
+	sql, args := h.unionLabelValuesSQL(name)
+	values, err := h.Client.QueryStrings(ctx, sql, args...)
+	if err != nil {
+		return nil, &apiError{kind: ErrInternal, err: err, status: http.StatusBadGateway}
+	}
+	sort.Strings(values)
+	return values, nil
+}
+
+// fetchSeries lowers the matcher to a Scan+Filter, runs as a sample query,
+// and dedupes the resulting label sets.
+func (h *Handler) fetchSeries(ctx context.Context, matcher string) ([]map[string]string, error) {
+	// Reuse the existing instant-query pipeline; rows come back as Samples
+	// and we dedupe to label sets in canonicalKey order.
+	samples, err := h.executeInstant(ctx, matcher)
+	if err != nil {
+		return nil, err
+	}
+
+	seen := make(map[string]map[string]string)
+	for _, s := range samples {
+		labels := withMetricName(s.Labels, s.MetricName)
+		key := canonicalKey(labels)
+		if _, ok := seen[key]; !ok {
+			seen[key] = labels
+		}
+	}
+	out := make([]map[string]string, 0, len(seen))
+	for _, l := range seen {
+		out = append(out, l)
+	}
+	return out, nil
+}
+
+// unionLabelNamesSQL builds a UNION of all metric tables' label keys.
+func (h *Handler) unionLabelNamesSQL() string {
+	tables := h.metricTables()
+	parts := make([]string, 0, len(tables))
+	attrsCol := quoteIdentCH(h.Schema.AttributesColumn)
+	for _, t := range tables {
+		parts = append(parts,
+			fmt.Sprintf("SELECT DISTINCT arrayJoin(mapKeys(%s)) AS name FROM %s",
+				attrsCol, quoteIdentCH(t)))
+	}
+	return "SELECT DISTINCT name FROM (" + strings.Join(parts, " UNION ALL ") + ") ORDER BY name"
+}
+
+// unionMetricNamesSQL returns the distinct MetricName values across tables.
+func (h *Handler) unionMetricNamesSQL() string {
+	tables := h.metricTables()
+	metricCol := quoteIdentCH(h.Schema.MetricNameColumn)
+	parts := make([]string, 0, len(tables))
+	for _, t := range tables {
+		parts = append(parts, fmt.Sprintf("SELECT DISTINCT %s AS value FROM %s",
+			metricCol, quoteIdentCH(t)))
+	}
+	return "SELECT DISTINCT value FROM (" + strings.Join(parts, " UNION ALL ") + ") ORDER BY value"
+}
+
+// unionLabelValuesSQL returns the distinct Attributes[?] values across
+// tables, skipping the empty-string sentinel that mapAccess yields when a
+// key is absent. Returns (sql, args). The name is bound once per table
+// (twice: in SELECT and WHERE) — args lists it 2*N times.
+func (h *Handler) unionLabelValuesSQL(name string) (string, []any) {
+	tables := h.metricTables()
+	attrsCol := quoteIdentCH(h.Schema.AttributesColumn)
+	parts := make([]string, 0, len(tables))
+	args := make([]any, 0, len(tables)*2)
+	for _, t := range tables {
+		parts = append(parts,
+			fmt.Sprintf("SELECT DISTINCT %s[?] AS value FROM %s WHERE %s[?] != ''",
+				attrsCol, quoteIdentCH(t), attrsCol))
+		args = append(args, name, name)
+	}
+	return "SELECT DISTINCT value FROM (" + strings.Join(parts, " UNION ALL ") + ") ORDER BY value", args
+}
+
+// metricTables returns the configured metric-table names in a stable
+// order, used for UNION construction.
+func (h *Handler) metricTables() []string {
+	return []string{
+		h.Schema.GaugeTable,
+		h.Schema.SumTable,
+		h.Schema.HistogramTable,
+	}
+}
+
+// validLabelName mirrors the Prometheus label-name grammar: [a-zA-Z_][a-zA-Z0-9_]*.
+// The synthetic `__name__` matches this pattern naturally.
+func validLabelName(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'a' && c <= 'z':
+		case c >= 'A' && c <= 'Z':
+		case c == '_':
+		case c >= '0' && c <= '9' && i > 0:
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// quoteIdentCH backtick-quotes a CH identifier; thin local helper since
+// chsql.writeIdent is unexported.
+func quoteIdentCH(name string) string {
+	var b strings.Builder
+	b.WriteByte('`')
+	b.WriteString(strings.ReplaceAll(name, "`", "``"))
+	b.WriteByte('`')
+	return b.String()
+}

--- a/internal/api/prom/metadata_test.go
+++ b/internal/api/prom/metadata_test.go
@@ -1,0 +1,233 @@
+package prom_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+// metadataResponse decodes the Prom metadata-endpoint shape — `data` is a
+// direct slice rather than a {resultType, result} wrapper.
+type metadataResponse struct {
+	Status string          `json:"status"`
+	Data   json.RawMessage `json:"data"`
+	Error  string          `json:"error"`
+}
+
+func TestLabels_Endpoint(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{
+		strings: []string{"foo", "bar", "instance"},
+	}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/labels")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	var parsed metadataResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if parsed.Status != "success" {
+		t.Fatalf("status: got %q, want success; err=%s", parsed.Status, parsed.Error)
+	}
+
+	var names []string
+	if err := json.Unmarshal(parsed.Data, &names); err != nil {
+		t.Fatalf("decode data: %v", err)
+	}
+
+	// `__name__` is always prepended; result is sorted.
+	if len(names) < 1 || names[0] != "__name__" {
+		t.Fatalf("expected first name to be __name__, got %v", names)
+	}
+	wantContains := []string{"bar", "foo", "instance"}
+	for _, w := range wantContains {
+		found := false
+		for _, n := range names {
+			if n == w {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("missing %q in %v", w, names)
+		}
+	}
+
+	if !strings.Contains(q.lastSQL, "mapKeys") {
+		t.Errorf("expected SQL to use mapKeys; got %q", q.lastSQL)
+	}
+}
+
+func TestLabels_MatchSelectorRejected(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/labels?" +
+		"match%5B%5D=up%7Bjob%3D%22api%22%7D")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 for match[] selector, got %d", resp.StatusCode)
+	}
+}
+
+func TestLabelValues_Endpoint(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{
+		strings: []string{"api", "db", "cache"},
+	}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/label/job/values")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	var parsed metadataResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var values []string
+	if err := json.Unmarshal(parsed.Data, &values); err != nil {
+		t.Fatalf("decode data: %v", err)
+	}
+	if len(values) != 3 {
+		t.Fatalf("expected 3 values, got %d: %v", len(values), values)
+	}
+	// Sorted ascending.
+	if values[0] != "api" || values[1] != "cache" || values[2] != "db" {
+		t.Errorf("expected sorted values, got %v", values)
+	}
+
+	// The job label should bind through Attributes['job'].
+	if !strings.Contains(q.lastSQL, "Attributes`[?]") {
+		t.Errorf("expected SQL to reference Attributes map access; got %q", q.lastSQL)
+	}
+	// arg[0..N] should all be "job" (one per UNION segment + WHERE bind).
+	for i, a := range q.lastArgs {
+		if a != "job" {
+			t.Errorf("arg[%d] = %v, want %q", i, a, "job")
+		}
+	}
+}
+
+func TestLabelValues_MetricNameLabel(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{strings: []string{"up", "http_requests_total"}}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/label/__name__/values")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+
+	// __name__ uses MetricName column, no Attributes mapAccess.
+	if strings.Contains(q.lastSQL, "Attributes`[") {
+		t.Errorf("__name__ should NOT use Attributes mapAccess; got %q", q.lastSQL)
+	}
+	if !strings.Contains(q.lastSQL, "MetricName") {
+		t.Errorf("__name__ should query the MetricName column; got %q", q.lastSQL)
+	}
+}
+
+func TestLabelValues_InvalidName(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	// Invalid char (slash would be eaten by routing, so use a leading digit).
+	resp, err := http.Get(srv.URL + "/api/v1/label/1invalid/values")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid label name, got %d", resp.StatusCode)
+	}
+}
+
+func TestSeries_Endpoint(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{
+		samples: []chclient.Sample{
+			{MetricName: "up", Labels: map[string]string{"job": "api", "instance": "h1:8080"}},
+			{MetricName: "up", Labels: map[string]string{"job": "api", "instance": "h2:8080"}},
+			// Duplicate of the first row → should dedupe.
+			{MetricName: "up", Labels: map[string]string{"job": "api", "instance": "h1:8080"}},
+		},
+	}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/series?match%5B%5D=up")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	var parsed metadataResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var series []map[string]string
+	if err := json.Unmarshal(parsed.Data, &series); err != nil {
+		t.Fatalf("decode data: %v", err)
+	}
+	if len(series) != 2 {
+		t.Fatalf("expected 2 deduped series, got %d: %+v", len(series), series)
+	}
+	for _, lset := range series {
+		if lset["__name__"] != "up" {
+			t.Errorf("expected __name__=up, got %+v", lset)
+		}
+	}
+}
+
+func TestSeries_RequiresMatch(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/series")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+}

--- a/internal/api/prom/types.go
+++ b/internal/api/prom/types.go
@@ -7,15 +7,20 @@ package prom
 // any datasource-specific quirks.
 
 // Response is the top-level wrapper for every /api/v1/* response.
+// For query endpoints `Data` is a *QueryData; for metadata endpoints
+// (`labels`, `label/.../values`, `series`) it's a direct slice.
 type Response struct {
 	Status    string `json:"status"`              // "success" | "error"
-	Data      *Data  `json:"data,omitempty"`      // nil on errors
+	Data      any    `json:"data,omitempty"`      // nil on errors
 	ErrorType string `json:"errorType,omitempty"` // present on errors
 	Error     string `json:"error,omitempty"`     // present on errors
 }
 
-// Data is the body of a successful response.
-type Data struct {
+// QueryData wraps a /api/v1/query or /api/v1/query_range response body.
+// Kept as a named type (rather than inlining the fields on Response) so
+// metadata-endpoint Data can stay a plain slice without polluting the
+// query-endpoint shape.
+type QueryData struct {
 	ResultType string `json:"resultType"` // "vector" | "matrix" | "scalar" | "string"
 	Result     any    `json:"result"`     // shape depends on ResultType
 }

--- a/internal/chclient/client.go
+++ b/internal/chclient/client.go
@@ -111,3 +111,54 @@ func (c *Client) Query(ctx context.Context, sql string, args ...any) ([]Sample, 
 	}
 	return out, nil
 }
+
+// QueryStrings runs sql and decodes a single-string-column result into a
+// flat slice. Used by metadata endpoints (/api/v1/labels, label values,
+// metadata) that return a list of names.
+func (c *Client) QueryStrings(ctx context.Context, sql string, args ...any) ([]string, error) {
+	rows, err := c.conn.Query(ctx, sql, args...)
+	if err != nil {
+		return nil, fmt.Errorf("chclient: query: %w", err)
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+
+	var out []string
+	for rows.Next() {
+		var s string
+		if err := rows.Scan(&s); err != nil {
+			return nil, fmt.Errorf("chclient: scan: %w", err)
+		}
+		out = append(out, s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("chclient: rows.Err: %w", err)
+	}
+	return out, nil
+}
+
+// QueryLabelSets runs sql and decodes each row into a Map(String,String)
+// label set. Used by /api/v1/series.
+func (c *Client) QueryLabelSets(ctx context.Context, sql string, args ...any) ([]map[string]string, error) {
+	rows, err := c.conn.Query(ctx, sql, args...)
+	if err != nil {
+		return nil, fmt.Errorf("chclient: query: %w", err)
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+
+	var out []map[string]string
+	for rows.Next() {
+		var m map[string]string
+		if err := rows.Scan(&m); err != nil {
+			return nil, fmt.Errorf("chclient: scan: %w", err)
+		}
+		out = append(out, m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("chclient: rows.Err: %w", err)
+	}
+	return out, nil
+}


### PR DESCRIPTION
## Summary
Add the Prom metadata endpoints Grafana uses for label & metric pickers:

- \`GET /api/v1/labels\` — UNIONs \`arrayJoin(mapKeys(Attributes))\` across metric tables, prepends \`__name__\`.
- \`GET /api/v1/label/{name}/values\` — \`__name__\` queries MetricName; other labels read \`Attributes[?]\` and drop empty-string.
- \`GET /api/v1/series\` — each \`match[]\` selector goes through the existing instant pipeline; dedupes by canonical label key.

\`chclient\` gains \`QueryStrings\` and \`QueryLabelSets\` helpers.

\`prom.Response.Data\` is now \`any\` to accommodate metadata endpoints (direct slices); query endpoints wrap with the new \`QueryData\` type.

## Deferred to M2.7
- \`match[]\` filtering on /labels and /label/.../values.
- start/end time-range pushdown for /series.

## Test plan
- [x] \`just test\` green (new metadata_test.go covers all endpoints)
- [x] \`just lint\` clean
- [ ] CI green