### PR TITLE
feat(promql,chplan,chsql): aggregate result shaping (M2.2)

### DIFF
--- a/internal/chplan/aggregate.go
+++ b/internal/chplan/aggregate.go
@@ -35,10 +35,16 @@ func (a AggFunc) Equal(other AggFunc) bool {
 // Aggregate groups rows by the GroupBy expressions and computes the
 // AggFuncs. SQL form: `SELECT <GroupBy>, <AggFuncs> FROM <Input> GROUP BY
 // <GroupBy>`.
+//
+// GroupByAliases is an optional parallel slice (same length as GroupBy
+// when non-empty); each entry aliases the matching group-key column in
+// the SELECT list so a wrapping Project can reference it by name. Empty
+// means "no aliases" — emit the raw expression.
 type Aggregate struct {
-	Input    Node
-	GroupBy  []Expr
-	AggFuncs []AggFunc
+	Input          Node
+	GroupBy        []Expr
+	GroupByAliases []string
+	AggFuncs       []AggFunc
 }
 
 func (*Aggregate) planNode() {}

--- a/internal/chsql/emit_node.go
+++ b/internal/chsql/emit_node.go
@@ -58,13 +58,17 @@ func (e *emitter) emitProject(p *chplan.Project) error {
 func (e *emitter) emitAggregate(a *chplan.Aggregate) error {
 	e.b.WriteString("SELECT ")
 	first := true
-	for _, g := range a.GroupBy {
+	for i, g := range a.GroupBy {
 		if !first {
 			e.b.WriteString(", ")
 		}
 		first = false
 		if err := e.emitExpr(g); err != nil {
 			return err
+		}
+		if i < len(a.GroupByAliases) && a.GroupByAliases[i] != "" {
+			e.b.WriteString(" AS ")
+			writeIdent(&e.b, a.GroupByAliases[i])
 		}
 	}
 	for _, af := range a.AggFuncs {

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -209,6 +209,12 @@ func lowerRangeVectorCall(c *parser.Call, s schema.Metrics) (chplan.Node, error)
 // `quantile(0.95, ...)`. Output-shape-changing aggregates (`topk`, `bottomk`,
 // `count_values`) are deferred to M1.7 since they produce K rows per group
 // rather than one.
+//
+// The Aggregate is wrapped with a Project that re-shapes its output into
+// the Sample contract (MetricName, Attributes, TimeUnix, Value) so the
+// API layer can stream rows through `chclient.Sample` directly. PromQL
+// aggregations drop `__name__`, so the projected MetricName is the empty
+// string; the projected Attributes is built from the group-key columns.
 func lowerAggregate(a *parser.AggregateExpr, s schema.Metrics) (chplan.Node, error) {
 	input, err := lower(a.Expr, s)
 	if err != nil {
@@ -225,11 +231,79 @@ func lowerAggregate(a *parser.AggregateExpr, s schema.Metrics) (chplan.Node, err
 		return nil, err
 	}
 
-	return &chplan.Aggregate{
-		Input:    input,
-		GroupBy:  groupBy,
-		AggFuncs: []chplan.AggFunc{aggFunc},
-	}, nil
+	aliases := groupKeyAliases(len(groupBy))
+	agg := &chplan.Aggregate{
+		Input:          input,
+		GroupBy:        groupBy,
+		GroupByAliases: aliases,
+		AggFuncs:       []chplan.AggFunc{aggFunc},
+	}
+	return wrapAggregateForSample(agg, a, s, aliases), nil
+}
+
+// groupKeyAliases returns ["gkey_0", "gkey_1", ...] of length n. Empty
+// slice for n=0 so unaggregated aggregates (`count(up)` with no `by/
+// without`) still skip the aliasing path.
+func groupKeyAliases(n int) []string {
+	if n == 0 {
+		return nil
+	}
+	out := make([]string, n)
+	for i := range out {
+		out[i] = fmt.Sprintf("gkey_%d", i)
+	}
+	return out
+}
+
+// wrapAggregateForSample produces the Sample-shape Project on top of an
+// Aggregate so downstream `chclient.Sample` decoding works for any
+// PromQL aggregation.
+//
+//	MetricName  = ''                          (aggregations drop __name__)
+//	Attributes  = map('lbl0', gkey_0, ...)    for `by (lbl0, lbl1, ...)`
+//	            | gkey_0                       for `without (...)` (mapFilter output)
+//	            | empty Map(String,String)     for unaggregated forms
+//	TimeUnix    = now64(9)                    (eval time)
+//	Value       = <aggFunc alias>             (sum / avg / quantile / ...)
+func wrapAggregateForSample(agg *chplan.Aggregate, a *parser.AggregateExpr, s schema.Metrics, aliases []string) chplan.Node {
+	var attrs chplan.Expr
+	switch {
+	case len(aliases) == 0:
+		// No grouping — emit an empty Map(String, String).
+		attrs = emptyAttrsMap()
+	case a.Without:
+		// Single mapFilter-derived attribute column; the gkey IS the map.
+		attrs = &chplan.ColumnRef{Name: aliases[0]}
+	default:
+		args := make([]chplan.Expr, 0, len(a.Grouping)*2)
+		for i, label := range a.Grouping {
+			args = append(args, &chplan.LitString{V: label}, &chplan.ColumnRef{Name: aliases[i]})
+		}
+		attrs = &chplan.FuncCall{Name: "map", Args: args}
+	}
+
+	return &chplan.Project{
+		Input: agg,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.LitString{V: ""}, Alias: s.MetricNameColumn},
+			{Expr: attrs, Alias: s.AttributesColumn},
+			{Expr: &chplan.FuncCall{Name: "now64", Args: []chplan.Expr{&chplan.LitInt{V: 9}}}, Alias: s.TimestampColumn},
+			{Expr: &chplan.ColumnRef{Name: s.ValueColumn}, Alias: s.ValueColumn},
+		},
+	}
+}
+
+// emptyAttrsMap returns a CH expression for an empty Map(String,String),
+// used when an aggregation drops all labels (e.g. `count(up)` with no
+// `by/without` clause).
+func emptyAttrsMap() chplan.Expr {
+	return &chplan.FuncCall{
+		Name: "CAST",
+		Args: []chplan.Expr{
+			&chplan.FuncCall{Name: "map", Args: nil},
+			&chplan.LitString{V: "Map(String,String)"},
+		},
+	}
 }
 
 // aggregateGroupBy builds the group-key list for an aggregation. For

--- a/test/spec/promql/count_no_group.txtar
+++ b/test/spec/promql/count_no_group.txtar
@@ -1,6 +1,9 @@
 -- query.promql --
 count(up)
 -- args --
-[0] string = "up"
+[0] string = ""
+[1] string = "Map(String,String)"
+[2] int64 = 9
+[3] string = "up"
 -- sql --
-SELECT count(`Value`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?))
+SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT count(`Value`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?)))

--- a/test/spec/promql/group_by_job.txtar
+++ b/test/spec/promql/group_by_job.txtar
@@ -1,9 +1,12 @@
 -- query.promql --
 group by (job) (up)
 -- sql --
-SELECT `Attributes`[?], any(?) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?)) GROUP BY `Attributes`[?]
+SELECT ? AS `MetricName`, map(?, `gkey_0`) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes`[?] AS `gkey_0`, any(?) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?)) GROUP BY `Attributes`[?])
 -- args --
-[0] string = "job"
-[1] int64 = 1
-[2] string = "up"
+[0] string = ""
+[1] string = "job"
+[2] int64 = 9
 [3] string = "job"
+[4] int64 = 1
+[5] string = "up"
+[6] string = "job"

--- a/test/spec/promql/quantile_by_job.txtar
+++ b/test/spec/promql/quantile_by_job.txtar
@@ -1,9 +1,12 @@
 -- query.promql --
 quantile(0.95, latency_seconds) by (job)
 -- sql --
-SELECT `Attributes`[?], quantile(?)(`Value`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?)) GROUP BY `Attributes`[?]
+SELECT ? AS `MetricName`, map(?, `gkey_0`) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes`[?] AS `gkey_0`, quantile(?)(`Value`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?)) GROUP BY `Attributes`[?])
 -- args --
-[0] string = "job"
-[1] float64 = 0.95
-[2] string = "latency_seconds"
+[0] string = ""
+[1] string = "job"
+[2] int64 = 9
 [3] string = "job"
+[4] float64 = 0.95
+[5] string = "latency_seconds"
+[6] string = "job"

--- a/test/spec/promql/stddev_by_job.txtar
+++ b/test/spec/promql/stddev_by_job.txtar
@@ -1,8 +1,11 @@
 -- query.promql --
 stddev by (job) (latency_seconds)
 -- sql --
-SELECT `Attributes`[?], stddevPop(`Value`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?)) GROUP BY `Attributes`[?]
+SELECT ? AS `MetricName`, map(?, `gkey_0`) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes`[?] AS `gkey_0`, stddevPop(`Value`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?)) GROUP BY `Attributes`[?])
 -- args --
-[0] string = "job"
-[1] string = "latency_seconds"
-[2] string = "job"
+[0] string = ""
+[1] string = "job"
+[2] int64 = 9
+[3] string = "job"
+[4] string = "latency_seconds"
+[5] string = "job"

--- a/test/spec/promql/stdvar_no_group.txtar
+++ b/test/spec/promql/stdvar_no_group.txtar
@@ -1,6 +1,9 @@
 -- query.promql --
 stdvar(latency_seconds)
 -- sql --
-SELECT varPop(`Value`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?))
+SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT varPop(`Value`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?)))
 -- args --
-[0] string = "latency_seconds"
+[0] string = ""
+[1] string = "Map(String,String)"
+[2] int64 = 9
+[3] string = "latency_seconds"

--- a/test/spec/promql/sum_by_job.txtar
+++ b/test/spec/promql/sum_by_job.txtar
@@ -1,8 +1,11 @@
 -- query.promql --
 sum by (job) (up)
 -- args --
-[0] string = "job"
-[1] string = "up"
-[2] string = "job"
+[0] string = ""
+[1] string = "job"
+[2] int64 = 9
+[3] string = "job"
+[4] string = "up"
+[5] string = "job"
 -- sql --
-SELECT `Attributes`[?], sum(`Value`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?)) GROUP BY `Attributes`[?]
+SELECT ? AS `MetricName`, map(?, `gkey_0`) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes`[?] AS `gkey_0`, sum(`Value`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?)) GROUP BY `Attributes`[?])

--- a/test/spec/promql/sum_without_instance.txtar
+++ b/test/spec/promql/sum_without_instance.txtar
@@ -1,8 +1,10 @@
 -- query.promql --
 sum without (instance) (up)
 -- args --
-[0] string = "instance"
-[1] string = "up"
+[0] string = ""
+[1] int64 = 9
 [2] string = "instance"
+[3] string = "up"
+[4] string = "instance"
 -- sql --
-SELECT mapFilter((k, v) -> NOT (k IN (?)), `Attributes`), sum(`Value`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?)) GROUP BY mapFilter((k, v) -> NOT (k IN (?)), `Attributes`)
+SELECT ? AS `MetricName`, `gkey_0` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT mapFilter((k, v) -> NOT (k IN (?)), `Attributes`) AS `gkey_0`, sum(`Value`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?)) GROUP BY mapFilter((k, v) -> NOT (k IN (?)), `Attributes`))

--- a/test/spec/promql/sum_without_two_labels.txtar
+++ b/test/spec/promql/sum_without_two_labels.txtar
@@ -1,10 +1,12 @@
 -- query.promql --
 sum without (instance, pod) (up)
 -- sql --
-SELECT mapFilter((k, v) -> NOT (k IN (?, ?)), `Attributes`), sum(`Value`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?)) GROUP BY mapFilter((k, v) -> NOT (k IN (?, ?)), `Attributes`)
+SELECT ? AS `MetricName`, `gkey_0` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT mapFilter((k, v) -> NOT (k IN (?, ?)), `Attributes`) AS `gkey_0`, sum(`Value`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?)) GROUP BY mapFilter((k, v) -> NOT (k IN (?, ?)), `Attributes`))
 -- args --
-[0] string = "instance"
-[1] string = "pod"
-[2] string = "up"
-[3] string = "instance"
-[4] string = "pod"
+[0] string = ""
+[1] int64 = 9
+[2] string = "instance"
+[3] string = "pod"
+[4] string = "up"
+[5] string = "instance"
+[6] string = "pod"


### PR DESCRIPTION
## Summary
Aggregations now emit Sample-shaped output rows (MetricName, Attributes, TimeUnix, Value) so the API layer streams them through \`chclient.Sample\` directly.

- \`chplan.Aggregate.GroupByAliases\` — optional parallel slice; emitter renders \`<expr> AS <alias>\` so a wrapping Project can reference group columns by name.
- \`promql.lowerAggregate\` now wraps every Aggregate with a Sample-shape Project:
  - MetricName = ''  (aggregations drop \`__name__\`)
  - Attributes = \`map('lbl', gkey_0, ...)\` for by; \`gkey_0\` for without; empty Map for unaggregated
  - TimeUnix = \`now64(9)\` (eval time)
  - Value = \`<aggFunc alias>\`

This unblocks \`sum by (job) (...)\` and friends in Grafana — the result decoder reads 4 columns out of aggregations the same as raw vector queries.

## Test plan
- [x] \`just test\` green
- [x] \`just lint\` clean
- [ ] CI green