### PR TITLE
feat(api/prom,chclient,schema): /api/v1/metadata endpoint (M2.6)

### DIFF
--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -25,6 +25,7 @@ type Querier interface {
 	Query(ctx context.Context, sql string, args ...any) ([]chclient.Sample, error)
 	QueryStrings(ctx context.Context, sql string, args ...any) ([]string, error)
 	QueryLabelSets(ctx context.Context, sql string, args ...any) ([]map[string]string, error)
+	QueryMetricMeta(ctx context.Context, sql, metricType string, args ...any) ([]chclient.MetricMetaRow, error)
 }
 
 // Handler implements the Prometheus HTTP API endpoints cerberus speaks.
@@ -63,6 +64,7 @@ func (h *Handler) Mount(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/v1/label/{name}/values", h.handleLabelValues)
 	mux.HandleFunc("GET /api/v1/series", h.handleSeries)
 	mux.HandleFunc("POST /api/v1/series", h.handleSeries)
+	mux.HandleFunc("GET /api/v1/metadata", h.handleMetadata)
 }
 
 func (h *Handler) handleQuery(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/prom/handler_test.go
+++ b/internal/api/prom/handler_test.go
@@ -20,6 +20,7 @@ type stubQuerier struct {
 	samples   []chclient.Sample
 	strings   []string
 	labelSets []map[string]string
+	metaRows  []chclient.MetricMetaRow
 	err       error
 	lastSQL   string
 	lastArgs  []any
@@ -50,6 +51,15 @@ func (s *stubQuerier) QueryLabelSets(_ context.Context, sql string, args ...any)
 		return nil, s.err
 	}
 	return s.labelSets, nil
+}
+
+func (s *stubQuerier) QueryMetricMeta(_ context.Context, sql, _ string, args ...any) ([]chclient.MetricMetaRow, error) {
+	s.lastSQL = sql
+	s.lastArgs = args
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.metaRows, nil
 }
 
 func newServer(q prom.Querier) *httptest.Server {

--- a/internal/api/prom/metadata.go
+++ b/internal/api/prom/metadata.go
@@ -6,9 +6,12 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/prometheus/common/model"
+
+	"github.com/tsouza/cerberus/internal/chclient"
 )
 
 // handleLabels implements GET /api/v1/labels — distinct label names across
@@ -67,6 +70,127 @@ func (h *Handler) handleLabelValues(w http.ResponseWriter, r *http.Request) {
 		Status: "success",
 		Data:   values,
 	})
+}
+
+// MetricMetaEntry is one entry in the per-metric metadata array Prometheus
+// emits from /api/v1/metadata. Cerberus emits exactly one entry per
+// metric for now (multiple entries would be required only if the same
+// metric appears in multiple types — uncommon).
+type MetricMetaEntry struct {
+	Type string `json:"type"`
+	Help string `json:"help"`
+	Unit string `json:"unit"`
+}
+
+// handleMetadata implements GET /api/v1/metadata — per-metric type / help /
+// unit, sourced from the OTel `MetricDescription` and `MetricUnit` columns.
+// Type is derived from the source table: gauge / counter / histogram.
+//
+// The `metric` query parameter restricts the result to a single metric;
+// `limit` caps the number of metrics returned (per Prom convention).
+func (h *Handler) handleMetadata(w http.ResponseWriter, r *http.Request) {
+	metricName := r.URL.Query().Get("metric")
+	limitStr := r.URL.Query().Get("limit")
+
+	rows, err := h.fetchMetricMeta(r.Context(), metricName)
+	if err != nil {
+		h.respondError(w, err)
+		return
+	}
+
+	// Group by metric name; each metric gets a slice of entries.
+	grouped := make(map[string][]MetricMetaEntry, len(rows))
+	for _, row := range rows {
+		grouped[row.Name] = append(grouped[row.Name], MetricMetaEntry{
+			Type: row.Type,
+			Help: row.Description,
+			Unit: row.Unit,
+		})
+	}
+
+	if limitStr != "" {
+		limit, err := parseLimit(limitStr)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, ErrBadData, err)
+			return
+		}
+		grouped = truncateMetadata(grouped, limit)
+	}
+
+	writeJSON(w, http.StatusOK, Response{
+		Status: "success",
+		Data:   grouped,
+	})
+}
+
+func (h *Handler) fetchMetricMeta(ctx context.Context, metricName string) ([]chclient.MetricMetaRow, error) {
+	specs := []struct {
+		table string
+		kind  string
+	}{
+		{h.Schema.GaugeTable, "gauge"},
+		{h.Schema.SumTable, "counter"},
+		{h.Schema.HistogramTable, "histogram"},
+	}
+
+	var out []chclient.MetricMetaRow
+	for _, spec := range specs {
+		sql, args := h.metricMetaSQL(spec.table, metricName)
+		rows, err := h.Client.QueryMetricMeta(ctx, sql, spec.kind, args...)
+		if err != nil {
+			return nil, &apiError{kind: ErrInternal, err: err, status: http.StatusBadGateway}
+		}
+		out = append(out, rows...)
+	}
+	return out, nil
+}
+
+// metricMetaSQL builds the per-table metadata SQL. The result columns are
+// (MetricName, MetricDescription, MetricUnit). When metricName is empty
+// we list all distinct metrics; otherwise we filter to the named one.
+func (h *Handler) metricMetaSQL(table, metricName string) (string, []any) {
+	nameCol := quoteIdentCH(h.Schema.MetricNameColumn)
+	descCol := quoteIdentCH(h.Schema.MetricDescriptionColumn)
+	unitCol := quoteIdentCH(h.Schema.MetricUnitColumn)
+	tbl := quoteIdentCH(table)
+
+	if metricName == "" {
+		return fmt.Sprintf(
+			"SELECT %s, any(%s), any(%s) FROM %s GROUP BY %s ORDER BY %s",
+			nameCol, descCol, unitCol, tbl, nameCol, nameCol,
+		), nil
+	}
+	return fmt.Sprintf(
+		"SELECT %s, any(%s), any(%s) FROM %s WHERE %s = ? GROUP BY %s",
+		nameCol, descCol, unitCol, tbl, nameCol, nameCol,
+	), []any{metricName}
+}
+
+// parseLimit decodes the `limit` query parameter — a positive integer.
+func parseLimit(raw string) (int, error) {
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 0 {
+		return 0, errors.New("'limit' must be a non-negative integer")
+	}
+	return n, nil
+}
+
+// truncateMetadata trims the metadata map to at most `limit` metric keys
+// (in alphabetic order to make the truncation deterministic).
+func truncateMetadata(in map[string][]MetricMetaEntry, limit int) map[string][]MetricMetaEntry {
+	if limit <= 0 || len(in) <= limit {
+		return in
+	}
+	keys := make([]string, 0, len(in))
+	for k := range in {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	out := make(map[string][]MetricMetaEntry, limit)
+	for _, k := range keys[:limit] {
+		out[k] = in[k]
+	}
+	return out
 }
 
 // handleSeries implements GET /api/v1/series. Each matcher in `match[]`

--- a/internal/api/prom/metadata_test.go
+++ b/internal/api/prom/metadata_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/tsouza/cerberus/internal/api/prom"
 	"github.com/tsouza/cerberus/internal/chclient"
 )
 
@@ -229,5 +230,91 @@ func TestSeries_RequiresMatch(t *testing.T) {
 	}
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestMetadata_Endpoint(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{
+		metaRows: []chclient.MetricMetaRow{
+			{Name: "up", Description: "scrape ok", Unit: "", Type: "gauge"},
+			{Name: "temperature", Description: "ambient temp", Unit: "celsius", Type: "gauge"},
+		},
+	}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/metadata")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	var parsed metadataResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if parsed.Status != "success" {
+		t.Fatalf("status: got %q", parsed.Status)
+	}
+
+	var grouped map[string][]prom.MetricMetaEntry
+	if err := json.Unmarshal(parsed.Data, &grouped); err != nil {
+		t.Fatalf("decode data: %v", err)
+	}
+	if _, ok := grouped["up"]; !ok {
+		t.Errorf("expected 'up' metadata; got %+v", grouped)
+	}
+	if _, ok := grouped["temperature"]; !ok {
+		t.Errorf("expected 'temperature' metadata; got %+v", grouped)
+	}
+}
+
+func TestMetadata_FilterByName(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{
+		metaRows: []chclient.MetricMetaRow{
+			{Name: "up", Description: "scrape ok", Type: "gauge"},
+		},
+	}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/metadata?metric=up")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	defer resp.Body.Close()
+
+	if len(q.lastArgs) == 0 || q.lastArgs[0] != "up" {
+		t.Errorf("expected last query arg = 'up', got %v", q.lastArgs)
+	}
+}
+
+func TestMetadata_LimitBadValue(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{"-1", "abc"}
+	for _, raw := range cases {
+		t.Run(raw, func(t *testing.T) {
+			t.Parallel()
+			srv := newServer(&stubQuerier{})
+			t.Cleanup(srv.Close)
+			resp, err := http.Get(srv.URL + "/api/v1/metadata?limit=" + raw)
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("limit=%q: expected 400, got %d", raw, resp.StatusCode)
+			}
+		})
 	}
 }

--- a/internal/chclient/client.go
+++ b/internal/chclient/client.go
@@ -138,6 +138,44 @@ func (c *Client) QueryStrings(ctx context.Context, sql string, args ...any) ([]s
 	return out, nil
 }
 
+// MetricMetaRow is one row from the metadata-discovery query — a metric
+// name plus its OTel description and unit text and the cerberus-derived
+// Prom-style type (gauge / counter / histogram).
+type MetricMetaRow struct {
+	Name        string
+	Description string
+	Unit        string
+	Type        string
+}
+
+// QueryMetricMeta runs sql and decodes each row as a (name, description,
+// unit) triple. The caller supplies the `metricType` (gauge / counter /
+// histogram) since the table the row came from determines that — the SQL
+// itself only returns the OTel columns.
+func (c *Client) QueryMetricMeta(ctx context.Context, sql, metricType string, args ...any) ([]MetricMetaRow, error) {
+	rows, err := c.conn.Query(ctx, sql, args...)
+	if err != nil {
+		return nil, fmt.Errorf("chclient: query: %w", err)
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+
+	var out []MetricMetaRow
+	for rows.Next() {
+		var r MetricMetaRow
+		r.Type = metricType
+		if err := rows.Scan(&r.Name, &r.Description, &r.Unit); err != nil {
+			return nil, fmt.Errorf("chclient: scan: %w", err)
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("chclient: rows.Err: %w", err)
+	}
+	return out, nil
+}
+
 // QueryLabelSets runs sql and decodes each row into a Map(String,String)
 // label set. Used by /api/v1/series.
 func (c *Client) QueryLabelSets(ctx context.Context, sql string, args ...any) ([]map[string]string, error) {

--- a/internal/schema/otel.go
+++ b/internal/schema/otel.go
@@ -22,6 +22,12 @@ type Metrics struct {
 	TimestampColumn string
 	// ValueColumn names the numeric value column (Float64).
 	ValueColumn string
+
+	// MetricDescriptionColumn names the column carrying the OTel
+	// metric description text (free-form help string).
+	MetricDescriptionColumn string
+	// MetricUnitColumn names the column carrying the OTel metric unit.
+	MetricUnitColumn string
 }
 
 // DefaultOTelMetrics returns the schema produced by the upstream OTel
@@ -36,6 +42,8 @@ func DefaultOTelMetrics() Metrics {
 		ResourceAttributesColumn: "ResourceAttributes",
 		TimestampColumn:          "TimeUnix",
 		ValueColumn:              "Value",
+		MetricDescriptionColumn:  "MetricDescription",
+		MetricUnitColumn:         "MetricUnit",
 	}
 }
 


### PR DESCRIPTION
## Summary
- \`schema.Metrics\` gets \`MetricDescriptionColumn\` / \`MetricUnitColumn\` (OTel defaults: \`MetricDescription\` / \`MetricUnit\`).
- \`chclient.QueryMetricMeta\` + \`MetricMetaRow\` decode (name, desc, unit) triples; caller tags each row with the table-derived type.
- \`handleMetadata\` fans out to gauge/sum/histogram tables (type = gauge/counter/histogram), groups by metric name.
- \`metric\` query param filters; \`limit\` caps (alphabetic truncation for determinism); invalid limits → 400.

## Test plan
- [x] \`just test\` green (4 new metadata tests)
- [x] \`just lint\` clean
- [ ] CI green