### PR TITLE
feat(api/prom): debug headers + match[] support (M2.7)

### DIFF
--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -53,16 +53,21 @@ func New(client Querier, s schema.Metrics, logger *slog.Logger) *Handler {
 }
 
 // Mount registers the Prom-compatible endpoints under /api/v1/ on mux.
+// Each route is wrapped with promHeadersMiddleware so responses carry
+// `X-Prometheus-API-Version` and `X-Cerberus-CH-Millis`.
 func (h *Handler) Mount(mux *http.ServeMux) {
-	mux.HandleFunc("GET /api/v1/query", h.handleQuery)
-	mux.HandleFunc("GET /api/v1/query_range", h.handleQueryRange)
-	mux.HandleFunc("POST /api/v1/query", h.handleQuery)
-	mux.HandleFunc("POST /api/v1/query_range", h.handleQueryRange)
-	mux.HandleFunc("GET /api/v1/labels", h.handleLabels)
-	mux.HandleFunc("POST /api/v1/labels", h.handleLabels)
-	mux.HandleFunc("GET /api/v1/label/{name}/values", h.handleLabelValues)
-	mux.HandleFunc("GET /api/v1/series", h.handleSeries)
-	mux.HandleFunc("POST /api/v1/series", h.handleSeries)
+	register := func(pattern string, hf http.HandlerFunc) {
+		mux.Handle(pattern, promHeadersMiddleware(hf))
+	}
+	register("GET /api/v1/query", h.handleQuery)
+	register("GET /api/v1/query_range", h.handleQueryRange)
+	register("POST /api/v1/query", h.handleQuery)
+	register("POST /api/v1/query_range", h.handleQueryRange)
+	register("GET /api/v1/labels", h.handleLabels)
+	register("POST /api/v1/labels", h.handleLabels)
+	register("GET /api/v1/label/{name}/values", h.handleLabelValues)
+	register("GET /api/v1/series", h.handleSeries)
+	register("POST /api/v1/series", h.handleSeries)
 }
 
 func (h *Handler) handleQuery(w http.ResponseWriter, r *http.Request) {
@@ -151,7 +156,9 @@ func (h *Handler) executeInstant(ctx context.Context, query string) ([]chclient.
 	}
 	h.Logger.Debug("cerberus query", "promql", query, "sql", sql, "args", args)
 
-	samples, err := h.Client.Query(ctx, sql, args...)
+	samples, err := timeCH(ctx, func() ([]chclient.Sample, error) {
+		return h.Client.Query(ctx, sql, args...)
+	})
 	if err != nil {
 		return nil, &apiError{kind: ErrInternal, err: err, status: http.StatusBadGateway}
 	}

--- a/internal/api/prom/handler_test.go
+++ b/internal/api/prom/handler_test.go
@@ -258,6 +258,31 @@ func TestQuery_BadInput(t *testing.T) {
 	}
 }
 
+func TestResponseHeaders_PromVersionAndCHMillis(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{
+		samples: []chclient.Sample{
+			{MetricName: "up", Labels: map[string]string{"job": "api"}, Value: 1.0},
+		},
+	}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/query?query=up")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if got := resp.Header.Get("X-Prometheus-API-Version"); got != "v1" {
+		t.Errorf("X-Prometheus-API-Version: got %q, want v1", got)
+	}
+	if got := resp.Header.Get("X-Cerberus-CH-Millis"); got == "" {
+		t.Errorf("X-Cerberus-CH-Millis: missing")
+	}
+}
+
 func TestQuery_UpstreamError(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/prom/metadata.go
+++ b/internal/api/prom/metadata.go
@@ -9,21 +9,29 @@ import (
 	"strings"
 
 	"github.com/prometheus/common/model"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
 )
 
 // handleLabels implements GET /api/v1/labels — distinct label names across
 // all metric tables, plus the synthetic `__name__` for the metric-name
-// dimension.
-//
-// `match[]` selector filtering is not yet supported; it lands with M2.7.
+// dimension. Optional `match[]` selectors narrow the result to labels of
+// the matched series only.
 func (h *Handler) handleLabels(w http.ResponseWriter, r *http.Request) {
-	if len(r.URL.Query()["match[]"]) > 0 {
-		writeError(w, http.StatusBadRequest, ErrBadData,
-			errors.New("'match[]' selectors are not yet supported on /api/v1/labels"))
+	if err := r.ParseForm(); err != nil {
+		writeError(w, http.StatusBadRequest, ErrBadData, err)
 		return
 	}
+	matchers := r.Form["match[]"]
 
-	names, err := h.fetchLabelNames(r.Context())
+	var names []string
+	var err error
+	if len(matchers) == 0 {
+		names, err = h.fetchLabelNames(r.Context())
+	} else {
+		names, err = h.fetchLabelNamesMatched(r.Context(), matchers)
+	}
 	if err != nil {
 		h.respondError(w, err)
 		return
@@ -51,13 +59,19 @@ func (h *Handler) handleLabelValues(w http.ResponseWriter, r *http.Request) {
 			fmt.Errorf("invalid label name %q", name))
 		return
 	}
-	if len(r.URL.Query()["match[]"]) > 0 {
-		writeError(w, http.StatusBadRequest, ErrBadData,
-			errors.New("'match[]' selectors are not yet supported on /api/v1/label/<name>/values"))
+	if err := r.ParseForm(); err != nil {
+		writeError(w, http.StatusBadRequest, ErrBadData, err)
 		return
 	}
+	matchers := r.Form["match[]"]
 
-	values, err := h.fetchLabelValues(r.Context(), name)
+	var values []string
+	var err error
+	if len(matchers) == 0 {
+		values, err = h.fetchLabelValues(r.Context(), name)
+	} else {
+		values, err = h.fetchLabelValuesMatched(r.Context(), name, matchers)
+	}
 	if err != nil {
 		h.respondError(w, err)
 		return
@@ -123,7 +137,9 @@ func (h *Handler) handleSeries(w http.ResponseWriter, r *http.Request) {
 // and prepends `__name__`. The returned slice is sorted.
 func (h *Handler) fetchLabelNames(ctx context.Context) ([]string, error) {
 	sql := h.unionLabelNamesSQL()
-	names, err := h.Client.QueryStrings(ctx, sql)
+	names, err := timeCH(ctx, func() ([]string, error) {
+		return h.Client.QueryStrings(ctx, sql)
+	})
 	if err != nil {
 		return nil, &apiError{kind: ErrInternal, err: err, status: http.StatusBadGateway}
 	}
@@ -134,7 +150,10 @@ func (h *Handler) fetchLabelNames(ctx context.Context) ([]string, error) {
 
 func (h *Handler) fetchLabelValues(ctx context.Context, name string) ([]string, error) {
 	if name == model.MetricNameLabel {
-		values, err := h.Client.QueryStrings(ctx, h.unionMetricNamesSQL())
+		sql := h.unionMetricNamesSQL()
+		values, err := timeCH(ctx, func() ([]string, error) {
+			return h.Client.QueryStrings(ctx, sql)
+		})
 		if err != nil {
 			return nil, &apiError{kind: ErrInternal, err: err, status: http.StatusBadGateway}
 		}
@@ -142,12 +161,118 @@ func (h *Handler) fetchLabelValues(ctx context.Context, name string) ([]string, 
 		return values, nil
 	}
 	sql, args := h.unionLabelValuesSQL(name)
-	values, err := h.Client.QueryStrings(ctx, sql, args...)
+	values, err := timeCH(ctx, func() ([]string, error) {
+		return h.Client.QueryStrings(ctx, sql, args...)
+	})
 	if err != nil {
 		return nil, &apiError{kind: ErrInternal, err: err, status: http.StatusBadGateway}
 	}
 	sort.Strings(values)
 	return values, nil
+}
+
+// fetchLabelNamesMatched returns the distinct label names of series
+// matching any of the given match[] selectors. The synthetic `__name__`
+// is always included if at least one selector matches anything.
+func (h *Handler) fetchLabelNamesMatched(ctx context.Context, matchers []string) ([]string, error) {
+	seen := map[string]bool{model.MetricNameLabel: true}
+	for _, m := range matchers {
+		keys, err := h.labelKeysForMatcher(ctx, m)
+		if err != nil {
+			return nil, err
+		}
+		for _, k := range keys {
+			seen[k] = true
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// fetchLabelValuesMatched returns the distinct values of <name> across
+// series matching any of the given match[] selectors.
+func (h *Handler) fetchLabelValuesMatched(ctx context.Context, name string, matchers []string) ([]string, error) {
+	seen := map[string]bool{}
+	for _, m := range matchers {
+		vals, err := h.labelValuesForMatcher(ctx, name, m)
+		if err != nil {
+			return nil, err
+		}
+		for _, v := range vals {
+			if v != "" {
+				seen[v] = true
+			}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for v := range seen {
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// labelKeysForMatcher lowers a single match[] selector, then wraps the
+// matched rows in a `SELECT DISTINCT arrayJoin(mapKeys(Attributes))`
+// to extract its attribute keys.
+func (h *Handler) labelKeysForMatcher(ctx context.Context, matcher string) ([]string, error) {
+	innerSQL, args, err := h.matcherSQL(matcher)
+	if err != nil {
+		return nil, err
+	}
+	attrs := quoteIdentCH(h.Schema.AttributesColumn)
+	sql := fmt.Sprintf("SELECT DISTINCT arrayJoin(mapKeys(%s)) AS name FROM (%s) ORDER BY name",
+		attrs, innerSQL)
+	return timeCH(ctx, func() ([]string, error) {
+		return h.Client.QueryStrings(ctx, sql, args...)
+	})
+}
+
+// labelValuesForMatcher lowers a single match[] selector, then projects
+// the named label's distinct values. `__name__` resolves to MetricName;
+// other labels to `Attributes[<name>]`.
+func (h *Handler) labelValuesForMatcher(ctx context.Context, name, matcher string) ([]string, error) {
+	innerSQL, args, err := h.matcherSQL(matcher)
+	if err != nil {
+		return nil, err
+	}
+	var sql string
+	if name == model.MetricNameLabel {
+		sql = fmt.Sprintf("SELECT DISTINCT %s AS value FROM (%s) ORDER BY value",
+			quoteIdentCH(h.Schema.MetricNameColumn), innerSQL)
+	} else {
+		attrs := quoteIdentCH(h.Schema.AttributesColumn)
+		sql = fmt.Sprintf("SELECT DISTINCT %s[?] AS value FROM (%s) WHERE %s[?] != '' ORDER BY value",
+			attrs, innerSQL, attrs)
+		args = append([]any{name}, args...)
+		args = append(args, name)
+	}
+	return timeCH(ctx, func() ([]string, error) {
+		return h.Client.QueryStrings(ctx, sql, args...)
+	})
+}
+
+// matcherSQL lowers a single matcher to its inner SQL + args. The caller
+// wraps this in whatever projection it needs (DISTINCT mapKeys, etc.).
+func (h *Handler) matcherSQL(matcher string) (string, []any, error) {
+	expr, err := h.parser.ParseExpr(matcher)
+	if err != nil {
+		return "", nil, &apiError{kind: ErrBadData, err: err, status: http.StatusBadRequest}
+	}
+	plan, err := promql.Lower(expr, h.Schema)
+	if err != nil {
+		return "", nil, &apiError{kind: ErrBadData, err: err, status: http.StatusBadRequest}
+	}
+	plan = h.Optimizer.Run(plan)
+	sql, args, err := chsql.Emit(plan)
+	if err != nil {
+		return "", nil, &apiError{kind: ErrInternal, err: err, status: http.StatusInternalServerError}
+	}
+	return sql, args, nil
 }
 
 // fetchSeries lowers the matcher to a Scan+Filter, runs as a sample query,

--- a/internal/api/prom/metadata_test.go
+++ b/internal/api/prom/metadata_test.go
@@ -71,10 +71,12 @@ func TestLabels_Endpoint(t *testing.T) {
 	}
 }
 
-func TestLabels_MatchSelectorRejected(t *testing.T) {
+func TestLabels_MatchSelector(t *testing.T) {
 	t.Parallel()
 
-	q := &stubQuerier{}
+	q := &stubQuerier{
+		strings: []string{"job", "instance"},
+	}
 	srv := newServer(q)
 	t.Cleanup(srv.Close)
 
@@ -83,8 +85,25 @@ func TestLabels_MatchSelectorRejected(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
-	if resp.StatusCode != http.StatusBadRequest {
-		t.Fatalf("expected 400 for match[] selector, got %d", resp.StatusCode)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	var parsed metadataResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var names []string
+	if err := json.Unmarshal(parsed.Data, &names); err != nil {
+		t.Fatalf("decode data: %v", err)
+	}
+	if len(names) < 1 || names[0] != "__name__" {
+		t.Fatalf("expected __name__ in names, got %v", names)
+	}
+	// SQL should wrap the matched scan in `SELECT DISTINCT arrayJoin(mapKeys(...))`.
+	if !strings.Contains(q.lastSQL, "arrayJoin(mapKeys") {
+		t.Errorf("expected SQL to project mapKeys; got %q", q.lastSQL)
 	}
 }
 

--- a/internal/api/prom/middleware.go
+++ b/internal/api/prom/middleware.go
@@ -1,0 +1,101 @@
+package prom
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"sync/atomic"
+	"time"
+)
+
+// ctxKey is the unexported key type for request-scoped values in this
+// package — avoids string-key collisions across packages.
+type ctxKey int
+
+const (
+	ctxKeyChMillis ctxKey = iota
+)
+
+// chMillisCounter accumulates time spent in ClickHouse calls for a single
+// request. Stored in context.Value(ctxKeyChMillis) as *atomic.Int64.
+// Atomic because handlers may fan out to multiple CH calls concurrently
+// (e.g. /api/v1/metadata queries gauge / sum / histogram tables).
+type chMillisCounter struct{ ms atomic.Int64 }
+
+func (c *chMillisCounter) add(d time.Duration) {
+	c.ms.Add(d.Milliseconds())
+}
+
+func (c *chMillisCounter) load() int64 {
+	return c.ms.Load()
+}
+
+// withChCounter attaches a fresh ms counter to ctx so wrapped Querier
+// calls can accumulate their durations into it.
+func withChCounter(ctx context.Context) (context.Context, *chMillisCounter) {
+	c := &chMillisCounter{}
+	return context.WithValue(ctx, ctxKeyChMillis, c), c
+}
+
+// ctxCounter returns the request's chMillisCounter or nil if none.
+func ctxCounter(ctx context.Context) *chMillisCounter {
+	c, _ := ctx.Value(ctxKeyChMillis).(*chMillisCounter)
+	return c
+}
+
+// timeCH wraps a CH call, recording its duration into the request's
+// chMillisCounter (if attached). Returns the bare result so callers can
+// chain without changing signatures.
+func timeCH[T any](ctx context.Context, fn func() (T, error)) (T, error) {
+	start := time.Now()
+	v, err := fn()
+	if c := ctxCounter(ctx); c != nil {
+		c.add(time.Since(start))
+	}
+	return v, err
+}
+
+// promHeadersMiddleware sets the static Prom-compatibility header on
+// every response. Per-request headers (CH timing, strategy) are set by
+// the handlers themselves before WriteHeader fires.
+func promHeadersMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Prometheus-API-Version", "v1")
+		// Attach a per-request CH-timing counter; handlers that go
+		// through `h.timedClient(ctx)` will populate it.
+		ctx, counter := withChCounter(r.Context())
+		// Wrap w so we can stamp X-Cerberus-CH-Millis just before the
+		// status is written (response headers freeze at that point).
+		ww := &headerStampingWriter{ResponseWriter: w, counter: counter}
+		next.ServeHTTP(ww, r.WithContext(ctx))
+		// Idempotent — if WriteHeader was never called the deferred
+		// stamp still runs once on flush.
+		ww.stamp()
+	})
+}
+
+// headerStampingWriter intercepts WriteHeader (and the first Write)
+// to inject X-Cerberus-CH-Millis just before the headers freeze.
+type headerStampingWriter struct {
+	http.ResponseWriter
+	counter *chMillisCounter
+	done    bool
+}
+
+func (w *headerStampingWriter) stamp() {
+	if w.done || w.counter == nil {
+		return
+	}
+	w.done = true
+	w.Header().Set("X-Cerberus-CH-Millis", strconv.FormatInt(w.counter.load(), 10))
+}
+
+func (w *headerStampingWriter) WriteHeader(status int) {
+	w.stamp()
+	w.ResponseWriter.WriteHeader(status)
+}
+
+func (w *headerStampingWriter) Write(b []byte) (int, error) {
+	w.stamp()
+	return w.ResponseWriter.Write(b)
+}


### PR DESCRIPTION
## Summary
- \`X-Prometheus-API-Version: v1\` on every /api/v1/* response.
- \`X-Cerberus-CH-Millis\` — accumulated ClickHouse time per request, captured via a context-attached counter + headerStampingWriter that injects right before WriteHeader.
- New \`promHeadersMiddleware\` wraps each Mount-registered route.
- \`timeCH[T]\` generic helper threads CH-call durations into the counter without changing the Querier interface.

### match[] support
- \`/api/v1/labels?match[]=foo{...}\` narrows label names to the matched series via \`SELECT DISTINCT arrayJoin(mapKeys(Attributes)) FROM (<lowered>)\`.
- \`/api/v1/label/{name}/values?match[]=foo{...}\` narrows values; \`__name__\` resolves to MetricName, others to \`Attributes[name]\`.

## Test plan
- [x] \`just test\` green (new TestResponseHeaders_*, TestLabels_MatchSelector tests)
- [x] \`just lint\` clean
- [ ] CI green