### PR TITLE
feat(logql,chplan,chsql,schema): LogQL stream selectors + line filters (M3.1)

### DIFF
--- a/internal/chplan/line_content.go
+++ b/internal/chplan/line_content.go
@@ -1,0 +1,29 @@
+package chplan
+
+// LineContent matches a substring or regex against a log body column.
+// LogQL `|=` / `!=` / `|~` / `!~` operators lower to this expression.
+//
+//   - IsRegex=false, Negated=false → `position(<Source>, <Pattern>) > 0`
+//   - IsRegex=false, Negated=true  → `position(<Source>, <Pattern>) = 0`
+//   - IsRegex=true,  Negated=false → `match(<Source>, <Pattern>)`
+//   - IsRegex=true,  Negated=true  → `NOT match(<Source>, <Pattern>)`
+//
+// The emitter renders it as the CH expression that yields a UInt8
+// suitable for a WHERE predicate.
+type LineContent struct {
+	Source  Expr
+	Pattern string
+	IsRegex bool
+	Negated bool
+}
+
+func (*LineContent) exprNode() {}
+
+func (l *LineContent) Equal(other Expr) bool {
+	o, ok := other.(*LineContent)
+	if !ok {
+		return false
+	}
+	return l.Pattern == o.Pattern && l.IsRegex == o.IsRegex &&
+		l.Negated == o.Negated && l.Source.Equal(o.Source)
+}

--- a/internal/chsql/emit_expr.go
+++ b/internal/chsql/emit_expr.go
@@ -27,6 +27,8 @@ func (e *emitter) emitExpr(x chplan.Expr) error {
 		return e.emitMapAccess(v)
 	case *chplan.MapWithoutKeys:
 		return e.emitMapWithoutKeys(v)
+	case *chplan.LineContent:
+		return e.emitLineContent(v)
 	default:
 		return fmt.Errorf("%w: expr %T", ErrUnsupported, x)
 	}
@@ -108,6 +110,40 @@ func (e *emitter) emitMapWithoutKeys(m *chplan.MapWithoutKeys) error {
 	if err := e.emitExpr(m.Map); err != nil {
 		return err
 	}
+	e.b.WriteByte(')')
+	return nil
+}
+
+func (e *emitter) emitLineContent(l *chplan.LineContent) error {
+	if l.IsRegex {
+		if l.Negated {
+			e.b.WriteString("NOT ")
+		}
+		e.b.WriteString("match(")
+		if err := e.emitExpr(l.Source); err != nil {
+			return err
+		}
+		e.b.WriteString(", ")
+		if err := e.bindArg(l.Pattern); err != nil {
+			return err
+		}
+		e.b.WriteByte(')')
+		return nil
+	}
+	op := " > 0"
+	if l.Negated {
+		op = " = 0"
+	}
+	e.b.WriteString("(position(")
+	if err := e.emitExpr(l.Source); err != nil {
+		return err
+	}
+	e.b.WriteString(", ")
+	if err := e.bindArg(l.Pattern); err != nil {
+		return err
+	}
+	e.b.WriteString(")")
+	e.b.WriteString(op)
 	e.b.WriteByte(')')
 	return nil
 }

--- a/internal/logql/lower.go
+++ b/internal/logql/lower.go
@@ -1,0 +1,186 @@
+// Package logql lowers Loki LogQL queries into the shared cerberus chplan
+// IR. The seed (M3.1) covers stream selectors with `=`/`!=`/`=~`/`!~`
+// label matchers and the line-filter family (`|=`, `!=`, `|~`, `!~`).
+//
+// Subsequent milestones add label filters (`| label="v"`), parsers
+// (`| json`, `| logfmt`), the metric form (rate, count_over_time, ...),
+// and aggregations.
+package logql
+
+import (
+	"fmt"
+
+	loglib "github.com/grafana/loki/v3/pkg/logql/log"
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// Lower turns a parsed LogQL expression into a chplan tree.
+func Lower(expr syntax.Expr, s schema.Logs) (chplan.Node, error) {
+	return lower(expr, s)
+}
+
+func lower(expr syntax.Expr, s schema.Logs) (chplan.Node, error) {
+	switch e := expr.(type) {
+	case *syntax.MatchersExpr:
+		return lowerMatchers(e, s), nil
+	case *syntax.PipelineExpr:
+		return lowerPipeline(e, s)
+	default:
+		return nil, fmt.Errorf("logql: unsupported expression %T", expr)
+	}
+}
+
+// lowerMatchers turns `{job="api", env=~"prod|stg"}` into Scan + Filter.
+// Stream-selector label matchers go against the ResourceAttributes map
+// since OTel-CH stores stream-identity labels there.
+func lowerMatchers(e *syntax.MatchersExpr, s schema.Logs) chplan.Node {
+	scan := &chplan.Scan{Table: s.LogsTable}
+	pred := buildMatchersPredicate(e.Mts, s)
+	if pred == nil {
+		return scan
+	}
+	return &chplan.Filter{Input: scan, Predicate: pred}
+}
+
+// lowerPipeline handles a stream selector followed by line filters
+// (and, in later milestones, label filters and parsers).
+func lowerPipeline(e *syntax.PipelineExpr, s schema.Logs) (chplan.Node, error) {
+	inner := lowerMatchers(e.Left, s)
+	pred := chplan.Expr(nil)
+	if f, ok := inner.(*chplan.Filter); ok {
+		pred = f.Predicate
+		inner = f.Input
+	}
+	for _, stage := range e.MultiStages {
+		next, err := lowerStage(stage, s)
+		if err != nil {
+			return nil, err
+		}
+		if pred == nil {
+			pred = next
+		} else {
+			pred = &chplan.Binary{Op: chplan.OpAnd, Left: pred, Right: next}
+		}
+	}
+	if pred == nil {
+		return inner, nil
+	}
+	return &chplan.Filter{Input: inner, Predicate: pred}, nil
+}
+
+func lowerStage(stage syntax.StageExpr, s schema.Logs) (chplan.Expr, error) {
+	switch st := stage.(type) {
+	case *syntax.LineFilterExpr:
+		return lowerLineFilter(st, s)
+	default:
+		return nil, fmt.Errorf("logql: pipeline stage %T is not yet supported (label filters and parsers land in M3.2)", stage)
+	}
+}
+
+// lowerLineFilter handles `|=`, `!=`, `|~`, `!~` against the Body column.
+//
+// Loki packs chained line filters in the same pipeline into one
+// `LineFilterExpr`: `Left` walks the previous filter (older chained
+// clauses) and `Or` walks alternates joined by `or`. We AND the Left
+// chain and OR the Or chain so the final predicate matches Loki's
+// evaluation order.
+func lowerLineFilter(f *syntax.LineFilterExpr, s schema.Logs) (chplan.Expr, error) {
+	body := &chplan.ColumnRef{Name: s.BodyColumn}
+	return lowerLineFilterChain(f, body)
+}
+
+func lowerLineFilterChain(f *syntax.LineFilterExpr, body chplan.Expr) (chplan.Expr, error) {
+	current, err := lineFilterPart(&f.LineFilter, body)
+	if err != nil {
+		return nil, err
+	}
+	// `or` alternates fold into a disjunction with the head clause.
+	for or := f.Or; or != nil; or = or.Or {
+		next, err := lineFilterPart(&or.LineFilter, body)
+		if err != nil {
+			return nil, err
+		}
+		current = &chplan.Binary{Op: chplan.OpOr, Left: current, Right: next}
+	}
+	// Older filters in the same pipeline live on `Left`. AND them in.
+	if f.Left != nil {
+		prev, err := lowerLineFilterChain(f.Left, body)
+		if err != nil {
+			return nil, err
+		}
+		current = &chplan.Binary{Op: chplan.OpAnd, Left: prev, Right: current}
+	}
+	return current, nil
+}
+
+func lineFilterPart(lf *syntax.LineFilter, body chplan.Expr) (chplan.Expr, error) {
+	isRegex, negated, err := lineFilterOp(lf.Ty)
+	if err != nil {
+		return nil, err
+	}
+	return &chplan.LineContent{
+		Source:  body,
+		Pattern: lf.Match,
+		IsRegex: isRegex,
+		Negated: negated,
+	}, nil
+}
+
+func lineFilterOp(t loglib.LineMatchType) (isRegex, negated bool, err error) {
+	switch t {
+	case loglib.LineMatchEqual:
+		return false, false, nil
+	case loglib.LineMatchNotEqual:
+		return false, true, nil
+	case loglib.LineMatchRegexp:
+		return true, false, nil
+	case loglib.LineMatchNotRegexp:
+		return true, true, nil
+	}
+	return false, false, fmt.Errorf("logql: line-filter op %s is not yet supported (`|>` pattern filters land in M3.2)", t)
+}
+
+// buildMatchersPredicate AND-folds the stream-selector matchers into a
+// chplan.Expr. Each matcher targets `ResourceAttributes[<label>]`.
+func buildMatchersPredicate(matchers []*labels.Matcher, s schema.Logs) chplan.Expr {
+	var out chplan.Expr
+	for _, m := range matchers {
+		cond := matcherToExpr(m, s)
+		if out == nil {
+			out = cond
+			continue
+		}
+		out = &chplan.Binary{Op: chplan.OpAnd, Left: out, Right: cond}
+	}
+	return out
+}
+
+func matcherToExpr(m *labels.Matcher, s schema.Logs) chplan.Expr {
+	lhs := &chplan.MapAccess{
+		Map: &chplan.ColumnRef{Name: s.ResourceAttributesColumn},
+		Key: &chplan.LitString{V: m.Name},
+	}
+	return &chplan.Binary{
+		Op:    matchOp(m.Type),
+		Left:  lhs,
+		Right: &chplan.LitString{V: m.Value},
+	}
+}
+
+func matchOp(t labels.MatchType) chplan.BinaryOp {
+	switch t {
+	case labels.MatchEqual:
+		return chplan.OpEq
+	case labels.MatchNotEqual:
+		return chplan.OpNe
+	case labels.MatchRegexp:
+		return chplan.OpMatch
+	case labels.MatchNotRegexp:
+		return chplan.OpNotMatch
+	}
+	return chplan.OpEq
+}

--- a/internal/logql/lower_test.go
+++ b/internal/logql/lower_test.go
@@ -1,0 +1,63 @@
+package logql_test
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/logql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/test/spec"
+)
+
+var fixtureDir = filepath.Join("..", "..", "test", "spec", "logql")
+
+// TestLower walks every *.txtar fixture under test/spec/logql/, parses
+// the LogQL in `query.logql`, lowers it, emits SQL, and compares the
+// result to the recorded `sql` + `args` sections.
+func TestLower(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelLogs()
+
+	spec.Walk(t, fixtureDir, func(t *testing.T, c *spec.Case) {
+		query, ok := c.Section("query.logql")
+		if !ok {
+			t.Fatalf("fixture %s missing 'query.logql' section", c.Name)
+		}
+		query = strings.TrimSpace(query)
+
+		expr, err := syntax.ParseExpr(query)
+		if err != nil {
+			t.Fatalf("ParseExpr(%q): %v", query, err)
+		}
+		plan, err := logql.Lower(expr, s)
+		if err != nil {
+			t.Fatalf("Lower(%q): %v", query, err)
+		}
+		sqlStr, args, err := chsql.Emit(plan)
+		if err != nil {
+			t.Fatalf("Emit: %v", err)
+		}
+
+		spec.Match(t, c, map[string]string{
+			"sql":  sqlStr,
+			"args": formatArgs(args),
+		})
+	})
+}
+
+func formatArgs(args []any) string {
+	if len(args) == 0 {
+		return "(none)\n"
+	}
+	var b strings.Builder
+	for i, a := range args {
+		fmt.Fprintf(&b, "[%d] %T = %#v\n", i, a, a)
+	}
+	return b.String()
+}

--- a/internal/schema/logs.go
+++ b/internal/schema/logs.go
@@ -1,0 +1,51 @@
+package schema
+
+// Logs describes how cerberus reads logs from ClickHouse. The default
+// (returned by DefaultOTelLogs) matches the OpenTelemetry ClickHouse
+// Exporter v0.x logs schema; users with custom layouts override
+// individual fields via Config.
+type Logs struct {
+	// LogsTable is the table holding log records.
+	LogsTable string
+
+	// BodyColumn names the column carrying the log message body (String).
+	BodyColumn string
+	// SeverityColumn names the column carrying the severity text
+	// (e.g. "INFO", "ERROR").
+	SeverityColumn string
+	// SeverityNumberColumn names the numeric severity column (Int32).
+	SeverityNumberColumn string
+	// AttributesColumn names the log-level attribute map.
+	AttributesColumn string
+	// ResourceAttributesColumn names the resource attribute map
+	// (carries stream-identity labels like service.name, job, etc.).
+	ResourceAttributesColumn string
+	// ScopeAttributesColumn names the instrumentation-scope attribute map.
+	ScopeAttributesColumn string
+	// TimestampColumn names the per-record timestamp column (DateTime64).
+	TimestampColumn string
+	// TraceIDColumn names the trace-id correlation column.
+	TraceIDColumn string
+	// SpanIDColumn names the span-id correlation column.
+	SpanIDColumn string
+	// ServiceNameColumn names the dedicated service name column.
+	ServiceNameColumn string
+}
+
+// DefaultOTelLogs returns the schema produced by the upstream OTel
+// ClickHouse Exporter for logs.
+func DefaultOTelLogs() Logs {
+	return Logs{
+		LogsTable:                "otel_logs",
+		BodyColumn:               "Body",
+		SeverityColumn:           "SeverityText",
+		SeverityNumberColumn:     "SeverityNumber",
+		AttributesColumn:         "LogAttributes",
+		ResourceAttributesColumn: "ResourceAttributes",
+		ScopeAttributesColumn:    "ScopeAttributes",
+		TimestampColumn:          "Timestamp",
+		TraceIDColumn:            "TraceId",
+		SpanIDColumn:             "SpanId",
+		ServiceNameColumn:        "ServiceName",
+	}
+}

--- a/test/spec/logql/line_filter_chained.txtar
+++ b/test/spec/logql/line_filter_chained.txtar
@@ -1,0 +1,9 @@
+-- query.logql --
+{job="api"} |= "error" |~ "5[0-9]{2}"
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_logs`) WHERE ((`ResourceAttributes`[?] = ?) AND ((position(`Body`, ?) > 0) AND match(`Body`, ?)))
+-- args --
+[0] string = "job"
+[1] string = "api"
+[2] string = "error"
+[3] string = "5[0-9]{2}"

--- a/test/spec/logql/line_filter_contains.txtar
+++ b/test/spec/logql/line_filter_contains.txtar
@@ -1,0 +1,8 @@
+-- query.logql --
+{job="api"} |= "error"
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_logs`) WHERE ((`ResourceAttributes`[?] = ?) AND (position(`Body`, ?) > 0))
+-- args --
+[0] string = "job"
+[1] string = "api"
+[2] string = "error"

--- a/test/spec/logql/line_filter_not_contains.txtar
+++ b/test/spec/logql/line_filter_not_contains.txtar
@@ -1,0 +1,8 @@
+-- query.logql --
+{job="api"} != "debug"
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_logs`) WHERE ((`ResourceAttributes`[?] = ?) AND (position(`Body`, ?) = 0))
+-- args --
+[0] string = "job"
+[1] string = "api"
+[2] string = "debug"

--- a/test/spec/logql/line_filter_not_regex.txtar
+++ b/test/spec/logql/line_filter_not_regex.txtar
@@ -1,0 +1,8 @@
+-- query.logql --
+{job="api"} !~ "health"
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_logs`) WHERE ((`ResourceAttributes`[?] = ?) AND NOT match(`Body`, ?))
+-- args --
+[0] string = "job"
+[1] string = "api"
+[2] string = "health"

--- a/test/spec/logql/line_filter_regex.txtar
+++ b/test/spec/logql/line_filter_regex.txtar
@@ -1,0 +1,8 @@
+-- query.logql --
+{job="api"} |~ "(?i)error|fatal"
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_logs`) WHERE ((`ResourceAttributes`[?] = ?) AND match(`Body`, ?))
+-- args --
+[0] string = "job"
+[1] string = "api"
+[2] string = "(?i)error|fatal"

--- a/test/spec/logql/stream_selector.txtar
+++ b/test/spec/logql/stream_selector.txtar
@@ -1,0 +1,7 @@
+-- query.logql --
+{job="api"}
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_logs`) WHERE (`ResourceAttributes`[?] = ?)
+-- args --
+[0] string = "job"
+[1] string = "api"

--- a/test/spec/logql/stream_with_regex.txtar
+++ b/test/spec/logql/stream_with_regex.txtar
@@ -1,0 +1,7 @@
+-- query.logql --
+{env=~"prod|stg"}
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_logs`) WHERE match(`ResourceAttributes`[?], ?)
+-- args --
+[0] string = "env"
+[1] string = "prod|stg"

--- a/test/spec/logql/stream_with_two_labels.txtar
+++ b/test/spec/logql/stream_with_two_labels.txtar
@@ -1,0 +1,9 @@
+-- query.logql --
+{job="api", env="prod"}
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_logs`) WHERE ((`ResourceAttributes`[?] = ?) AND (`ResourceAttributes`[?] = ?))
+-- args --
+[0] string = "job"
+[1] string = "api"
+[2] string = "env"
+[3] string = "prod"


### PR DESCRIPTION
## Summary
Bootstraps the LogQL head:

- \`schema.Logs\` + \`DefaultOTelLogs()\` mirroring the OTel-CH logs schema (otel_logs, Body, ResourceAttributes, ...).
- New \`chplan.LineContent\` expression for \`|=\` / \`!=\` / \`|~\` / \`!~\` against a Body column. Plain strings render as \`position(Body, ?) > 0\`; regexes as \`match(Body, ?)\`. Negated flips both.
- \`logql.Lower\` handles \`MatchersExpr\` (stream selectors against ResourceAttributes) and \`PipelineExpr\` with chained line filters. Walks the LineFilterExpr.Left chain into an AND for chained filters; \`Or\` on each clause folds into a disjunction.

7 TXTAR fixtures cover the contract.

## Deferred
- Label filters / parsers (M3.2)
- Metric form (M3.3)
- Aggregations (M3.4)
- Loki HTTP API + derived corpus (M3.5)

## Test plan
- [x] \`just test\` green
- [x] \`just lint\` clean
- [ ] CI green