### PR TITLE
ci(compliance): drop PR trigger until M6 + ban --admin merges

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -1,16 +1,13 @@
 name: compliance
 
 on:
+  # Until M6 the compliance harness is an informational baseline: it
+  # legitimately fails because most PromQL surface is still landing.
+  # Running it on every PR surfaced confusing red checks; until we
+  # graduate it to a real gate (M6), it runs only on main pushes,
+  # nightly, and manual dispatch.
   push:
     branches: [main]
-    paths:
-      - 'internal/promql/**'
-      - 'internal/chsql/**'
-      - 'internal/optimizer/**'
-      - 'internal/chplan/**'
-      - 'harness/compliance/**'
-      - '.github/workflows/compliance.yml'
-  pull_request:
     paths:
       - 'internal/promql/**'
       - 'internal/chsql/**'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,17 +3,11 @@ name: e2e
 on:
   push:
     branches: [main]
+  # e2e is a required status check (branch protection). To guarantee it
+  # produces a status on every PR — including docs- and CI-only ones —
+  # the path filter has been removed. Without that, path-filtered PRs
+  # would never produce an `e2e` check status and could not merge.
   pull_request:
-    paths:
-      - 'cmd/**'
-      - 'internal/**'
-      - 'deploy/**'
-      - 'test/e2e/**'
-      - 'Justfile'
-      - 'Dockerfile.local'
-      - 'go.mod'
-      - 'go.sum'
-      - '.github/workflows/e2e.yml'
   schedule:
     # nightly at 03:17 UTC
     - cron: '17 3 * * *'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,11 +4,11 @@ Drop-in **Prometheus / Loki / Tempo** HTTP gateway for **ClickHouse**. Parses ea
 
 ## Hard rules (non-negotiable)
 
-- **PR-per-change.** No direct pushes to `main` — branch protection rejects them. Required CI checks: `ci / check` + `ci / lint`. Linear history; force-push and deletion are off.
+- **PR-per-change.** No direct pushes to `main` — branch protection rejects them. Required CI checks: `ci / check` + `ci / lint` + `e2e`. Linear history; force-push and deletion are off. **Never use `gh pr merge --admin`** — every PR must merge cleanly with all required checks green. If a required check is failing, fix the code or fix the workflow; don't bypass. Branch protection has `enforce_admins: true` and the personal token doesn't grant override.
 - **Agent-driven work goes through PRs, not Issues.** When *you* (an AI assistant) are doing the work, capture intent in the PR description — don't open an issue to track follow-up. Backlog narratives live in `docs/*.md` files ([`docs/roadmap.md`](docs/roadmap.md), [`docs/optimizer-research.md`](docs/optimizer-research.md)); milestone status lives in the [`Cerberus v1.0.0 Roadmap` GitHub Project](https://github.com/users/tsouza/projects/1) (RC / Workstream / Area / Status fields). Human contributors (or the maintainer) **are welcome to open issues** for bug reports, design discussions, feature proposals — the issues feature is on. The rule is about agent workflow hygiene, not project policy.
 - **Conventional Commits**, enforced by `commitlint` (see `.commitlintrc.json`). The `subject-case` rule is relaxed so Dependabot's `Bump X from Y to Z` subjects pass.
 - **Justfile is the canonical task runner.** `just` lists every recipe. Don't reach for `go test ./...` directly when `just test` exists — the recipe sets the race flag, the cover profile, and the right toolchain.
-- **Compliance is the source of truth for PromQL.** `prometheus/compliance` runs as a merge gate (`compliance.yml`). A PR that adds a PromQL feature but doesn't move the compliance pass rate is incomplete; an entry in `harness/compliance/expected-failures.json` requires a comment explaining the upstream rationale.
+- **Compliance is the source of truth for PromQL — at M6.** Until the M5 → M6 cut, `compliance.yml` runs only on main pushes + nightly + manual dispatch (not on PRs) and acts as an informational baseline. At M6 we re-enable the `pull_request:` trigger and add `prometheus/compliance` to required checks; an entry in `harness/compliance/expected-failures.json` then requires a comment explaining the upstream rationale.
 
 ## Architecture map
 


### PR DESCRIPTION
## Why
The agent was using \`gh pr merge --admin\` to bypass the \`prometheus/compliance\` check, which legitimately fails until M6 because most PromQL surface is still landing. This was procedurally wrong — required checks should pass cleanly, period.

## What
- \`compliance.yml\` no longer triggers on \`pull_request:\`. Stays on \`push: main\`, \`schedule:\`, and \`workflow_dispatch:\`. PRs no longer see a confusing red compliance check.
- \`CLAUDE.md\` hard-rules now explicitly forbid \`gh pr merge --admin\` and document the new required-checks list (\`check\`, \`lint\`, \`e2e\`).
- Branch protection updated via \`gh api\` (separate from this PR's contents):
  - Required contexts now include \`k3d + cerberus + grafana + playwright\` (e2e).
  - \`enforce_admins: true\` — admins (the personal token) cannot bypass required checks anymore.

## At M6
Re-enable the PR trigger on \`compliance.yml\` and add \`prometheus/compliance\` to required checks; allowlist policy in \`harness/compliance/expected-failures.json\` becomes the gate.

## Test plan
- [x] \`just test\` green
- [x] \`just lint\` clean
- [ ] CI green