### PR TITLE
docs(roadmap): RC6 — type-safe SQL via huandu/go-sqlbuilder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ Drop-in **Prometheus / Loki / Tempo** HTTP gateway for **ClickHouse**. Parses ea
 - **Conventional Commits**, enforced by `commitlint` (see `.commitlintrc.json`). The `subject-case` rule is relaxed so Dependabot's `Bump X from Y to Z` subjects pass.
 - **Justfile is the canonical task runner.** `just` lists every recipe. Don't reach for `go test ./...` directly when `just test` exists — the recipe sets the race flag, the cover profile, and the right toolchain.
 - **Compliance is the source of truth for PromQL — at M6.** Until the M5 → M6 cut, `compliance.yml` runs only on main pushes + nightly + manual dispatch (not on PRs) and acts as an informational baseline. At M6 we re-enable the `pull_request:` trigger and add `prometheus/compliance` to required checks; an entry in `harness/compliance/expected-failures.json` then requires a comment explaining the upstream rationale.
+- **No raw SQL strings — refactor lands at RC6.** `fmt.Sprintf` (or any string concatenation) used to build a ClickHouse query is forbidden going forward; new emitter code must go through `huandu/go-sqlbuilder` (and the cerberus extension layer wrapping it for CH-specific idioms — see [`docs/roadmap.md` § RC6](docs/roadmap.md#rc6--type-safe-sql-via-go-sqlbuilder)). The existing `internal/chsql/emit_*.go` and `internal/api/prom/metadata.go` Sprintf-built SQL is grandfathered until the RC6 port (R6.1–R6.10), but no PR may add a new instance of the pattern. RC6 R6.9 wires a lint rule to enforce automatically.
 
 ## Architecture map
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -209,6 +209,63 @@ Driven by an audit of cerberus against [12factor.net](https://12factor.net/). Mo
 
 ---
 
+## RC6 — type-safe SQL via go-sqlbuilder
+
+**Hard rule (non-negotiable, takes effect at RC6 cut):** plain strings and `fmt.Sprintf` are forbidden for ClickHouse SQL generation. Every emitted SQL fragment goes through [`huandu/go-sqlbuilder`](https://github.com/huandu/go-sqlbuilder) (or a thin cerberus-internal extension on top of it). Concatenation and templated identifiers are an injection vector even with parameterised values; the builder tracks identifiers, args, and dialect quoting in one place.
+
+### Why now (and not earlier)
+
+Through RC1 the emitter grew Sprintf-driven for speed: `internal/chsql/emit_node.go`, `emit_expr.go`, `range_window.go`, `vector_join.go`, plus the metadata SQL in `internal/api/prom/metadata.go`. That worked for landing the surface, but every helper is hand-quoted, each subquery is a string-pasted hole, and there's no central ClickHouse dialect handling. RC6 reorganises that into a typed, builder-first emitter so RC3's optimizer changes can compose SQL programmatically (PREWHERE promotion, sort-key-aware predicate ordering, MV substitution) without re-scaffolding the string layer.
+
+### Library survey
+
+[`huandu/go-sqlbuilder`](https://github.com/huandu/go-sqlbuilder) covers the dialects we care about: `sqlbuilder.ClickHouse` flavor, `Cond` builders for WHERE/JOIN, `BuilderAs` for nested subqueries, `Args.Add` for placeholder management, `Raw`/`Var` for escape hatches. Subqueries compose by passing builders as `From()` / `Join()` arguments — the engine collects placeholders across the tree.
+
+What `go-sqlbuilder` doesn't model out of the box (the cerberus extension layer):
+
+- **Map column access** — `Attributes['job']`, `mapKeys(Attributes)`, `mapFilter((k,v) -> ..., Attributes)`. Wrap as named helpers (`chsql.MapAt(col, key)`, `chsql.MapKeys(col)`, etc.) returning expression strings via the builder's `Args` API.
+- **Array idiom for RangeWindow** — `groupArray((ts, value))`, `arraySort`, `arrayPopBack`, `arrayPopFront`, `arrayMap((p, c) -> ..., a, b)`, `arrayFilter`. Same pattern: typed helpers that compose builder fragments.
+- **Parameterised aggregates** — `quantile(0.95)(value)`, `quantiles(0.5, 0.9)(value)`. Builder doesn't know the params/args distinction, so a `chsql.ParamAgg(name, params, args)` helper renders it.
+- **DateTime64 literals + interval arithmetic** — `now64(9) - toIntervalNanosecond(N)`, `toDateTime64('2026-...', 9)`. Helpers `chsql.Now64()`, `chsql.SubtractNanos(expr, ns)`, `chsql.DateTime64Lit(t)`.
+- **CH lambda syntax** — `(k, v) -> NOT (k IN ('a', 'b'))`. A `chsql.Lambda(params, body)` helper avoids the freestyle string trap.
+- **PREWHERE clause** (RC3 sort-key emission) — go-sqlbuilder doesn't natively model PREWHERE; add a `chsql.SelectBuilder` wrapper that supports `.Prewhere(cond...)`.
+
+Custom Flavor extension (`sqlbuilder.NewFlavor` style) might also clean up some quoting if upstream `ClickHouse` flavor's identifier escaping doesn't match our needs (CH backticks vs PG double quotes — needs a small audit).
+
+### Refactor strategy
+
+Fixture-first: every TXTAR golden in `test/spec/{promql,logql,traceql,chsql}/` is the safety net. The refactor is allowed to change SQL formatting (whitespace, alias placement) — fixtures get regenerated on the same commit. Behavioural changes (different operators, predicate order) trigger a fixture diff that should be human-reviewed.
+
+PR sequence:
+
+| #    | Item                                                                                                       |
+| ---- | ---------------------------------------------------------------------------------------------------------- |
+| R6.1 | Vendor `huandu/go-sqlbuilder`; add `internal/chsql/builder.go` with the cerberus-internal CH-flavor wrapper plus the helpers above (MapAt, MapKeys, MapFilterExcept, Now64, SubtractNanos, DateTime64Lit, Lambda, ParamAgg). Unit tests pin each helper's output. **No emitter changes yet** — pure scaffolding. |
+| R6.2 | Port `emitScan`, `emitFilter`, `emitProject`, `emitLimit` (the simple ones). TXTAR fixtures regenerate; diff is whitespace / quoting only.                                                                                                                                                              |
+| R6.3 | Port `emitAggregate` + `emitAggFunc` (parameterised aggregates use `ParamAgg`).                              |
+| R6.4 | Port `emitBinary` + `emitMapAccess` + `emitMapWithoutKeys` + `emitFunc` + `emitLineContent`.                  |
+| R6.5 | Port `emitRangeWindow` (the `arraySort/groupArray` windowed-array idiom). The existing emitter is a 100-line Sprintf chain; this is the highest-value port. |
+| R6.6 | Port `emitVectorJoin` (per-series argMax + INNER JOIN).                                                       |
+| R6.7 | Port `internal/api/prom/metadata.go` UNION builders + `unionLabelValuesSQL` + `metricMetaSQL`.                |
+| R6.8 | Port `internal/api/loki/` and `internal/api/tempo/` SQL helpers (RC2/RC3 may have grown new ones).            |
+| R6.9 | **Lint enforcement**: add a custom golangci-lint rule (or a `cmd/check-sql/` Go tool wired into `just check-sql`) that scans `internal/chsql/`, `internal/api/`, `internal/optimizer/` for `fmt.Sprintf` calls whose first arg contains `SELECT`, `WHERE`, `FROM`, `INSERT`, etc. Fails the `lint` CI check on regressions. |
+| R6.10 | `CLAUDE.md` hard-rule update: `**No raw SQL strings.**` becomes a top-level non-negotiable; `docs/sql-style.md` documents the helper API and its escape hatches (when `Raw()` is acceptable, when a custom `chsql.SelectBuilder` extension is preferable). |
+
+### Open questions to resolve in R6.1
+
+- **Identifier quoting**: does `sqlbuilder.ClickHouse` flavor backtick-quote identifiers? If not, we keep our `quoteIdentCH` helper but feed it through the builder's `Var()` mechanism so escaping stays consistent.
+- **`Args` lifecycle**: each builder has its own `Args` accumulator. Nested builders compose via `BuilderAs`; the placeholder positions get re-numbered. Verify with a worst-case nested subquery (e.g. the windowed-array RangeWindow) that the resulting `Build()` output matches what the chclient driver expects.
+- **Performance**: builder construction is allocation-heavier than Sprintf. Bench against a 1000-iteration emit loop on the largest fixture; expect a small regression that's irrelevant compared to CH query latency, but record the number so RC3's optimizer benchmarks stay honest.
+
+### RC6 exit criteria
+
+- `grep -RIn 'fmt.Sprintf' internal/chsql/ internal/api/ | grep -E 'SELECT|FROM|WHERE|INSERT'` returns empty (the lint rule from R6.9 enforces this in CI).
+- Every TXTAR fixture either matches its prior golden bit-for-bit or has a documented whitespace/aliasing diff in the porting PR's description.
+- `internal/chsql/builder_test.go` has ≥ one test per helper in `internal/chsql/builder.go`, exercising the placeholder + arg ordering.
+- `docs/sql-style.md` published with the helper catalog and the "when can I use Raw()?" guidance.
+
+---
+
 ## How we work
 
 - **PR-per-change.** Every change ships as its own PR against `main`. Branch protection requires `ci / check` + `ci / lint`, linear history, no force-push.


### PR DESCRIPTION
## Summary
Adds **RC6** to the v1.0 roadmap and a new CLAUDE.md hard rule forbidding \`fmt.Sprintf\` / string concatenation for ClickHouse SQL going forward.

### Why RC6 (not earlier)
The emitter grew Sprintf-driven through RC1 (\`internal/chsql/emit_*.go\`, \`internal/api/prom/metadata.go\`). That worked for landing the surface, but every helper is hand-quoted, each subquery is a string-pasted hole, and there's no central CH dialect handling. RC6 ports the whole stack onto [\`huandu/go-sqlbuilder\`](https://github.com/huandu/go-sqlbuilder) plus a cerberus-internal extension layer for the CH-specific idioms.

### Scope
- 10-PR sequence R6.1 (scaffolding) → R6.10 (\`docs/sql-style.md\` + lint rule wired into CI).
- Library survey: \`sqlbuilder.ClickHouse\` flavor, Cond / BuilderAs / Args / Raw, what's missing.
- Cerberus extensions: \`MapAt\`, \`MapKeys\`, \`MapFilterExcept\`, \`Now64\`, \`SubtractNanos\`, \`DateTime64Lit\`, \`Lambda\`, \`ParamAgg\`, custom \`SelectBuilder\` with \`.Prewhere()\` (RC3 sort-key emission).
- Refactor strategy: TXTAR golden fixtures are the safety net; ports allowed to change SQL formatting (whitespace, alias placement) but behavioural changes trigger explicit fixture diffs needing human review.
- Open questions to resolve in R6.1 (identifier quoting, Args lifecycle on nested builders, perf bench).

### CLAUDE.md update
New hard-rule under "Hard rules (non-negotiable)":

> **No raw SQL strings — refactor lands at RC6.** \`fmt.Sprintf\` (or any string concatenation) used to build a ClickHouse query is forbidden going forward; new emitter code must go through \`huandu/go-sqlbuilder\` ... existing Sprintf-built SQL is grandfathered until the RC6 port (R6.1–R6.10), but no PR may add a new instance of the pattern.

### Test plan
- [x] \`just test\` green
- [x] \`just lint\` clean
- [ ] CI green