### PR TITLE
feat(logql): aggregations (M3.4)

### DIFF
--- a/internal/logql/lower.go
+++ b/internal/logql/lower.go
@@ -31,6 +31,8 @@ func lower(expr syntax.Expr, s schema.Logs) (chplan.Node, error) {
 		return lowerPipeline(e, s)
 	case *syntax.RangeAggregationExpr:
 		return lowerRangeAggregation(e, s)
+	case *syntax.VectorAggregationExpr:
+		return lowerVectorAggregation(e, s)
 	default:
 		return nil, fmt.Errorf("logql: unsupported expression %T", expr)
 	}

--- a/internal/logql/vector_aggregation.go
+++ b/internal/logql/vector_aggregation.go
@@ -1,0 +1,175 @@
+package logql
+
+import (
+	"fmt"
+
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// lowerVectorAggregation handles `sum(rate(...))`, `avg by (job) (...)`,
+// `count without (instance) (...)`, and friends. Mirrors the PromQL
+// aggregation lowering: GROUP BY the requested labels (or all-but-the-
+// excluded ones for `without`), apply the aggregator on the inner
+// stream's `value` column.
+//
+// `topk` / `bottomk` change output shape (K rows per group) and stay
+// deferred to M1.7-style follow-ups; `quantile` requires a parameterised
+// CH aggregate that we already support for PromQL.
+func lowerVectorAggregation(e *syntax.VectorAggregationExpr, s schema.Logs) (chplan.Node, error) {
+	if e.Left == nil {
+		return nil, fmt.Errorf("logql: vector-aggregation has nil inner")
+	}
+
+	innerExpr, ok := e.Left.(syntax.Expr)
+	if !ok {
+		return nil, fmt.Errorf("logql: vector-aggregation inner is not an Expr (%T)", e.Left)
+	}
+	input, err := lower(innerExpr, s)
+	if err != nil {
+		return nil, err
+	}
+
+	groupBy, aliases := vectorAggregationGroupBy(e, s)
+	aggFunc, err := buildVectorAggFunc(e, s)
+	if err != nil {
+		return nil, err
+	}
+
+	agg := &chplan.Aggregate{
+		Input:          input,
+		GroupBy:        groupBy,
+		GroupByAliases: aliases,
+		AggFuncs:       []chplan.AggFunc{aggFunc},
+	}
+	return wrapVectorAggregateForSample(agg, e, s, aliases), nil
+}
+
+// vectorAggregationGroupBy mirrors PromQL aggregateGroupBy, but Loki's
+// LogQL groups against the carrier-stream attributes (ResourceAttributes
+// in OTel-CH). The output shape exposes group-key columns as
+// `gkey_0`, `gkey_1`, ... so the wrapping Project can build a
+// Map(String, String) Attributes column from them.
+func vectorAggregationGroupBy(e *syntax.VectorAggregationExpr, s schema.Logs) ([]chplan.Expr, []string) {
+	if e.Grouping == nil {
+		return nil, nil
+	}
+	if e.Grouping.Without {
+		// `without (k1, k2)`: group by the full ResourceAttributes map
+		// minus the excluded keys.
+		return []chplan.Expr{
+				&chplan.MapWithoutKeys{
+					Map:  &chplan.ColumnRef{Name: s.ResourceAttributesColumn},
+					Keys: append([]string(nil), e.Grouping.Groups...),
+				},
+			},
+			[]string{"gkey_0"}
+	}
+	if len(e.Grouping.Groups) == 0 {
+		return nil, nil
+	}
+	out := make([]chplan.Expr, 0, len(e.Grouping.Groups))
+	aliases := make([]string, 0, len(e.Grouping.Groups))
+	for i, label := range e.Grouping.Groups {
+		out = append(out, &chplan.MapAccess{
+			Map: &chplan.ColumnRef{Name: s.ResourceAttributesColumn},
+			Key: &chplan.LitString{V: label},
+		})
+		aliases = append(aliases, fmt.Sprintf("gkey_%d", i))
+	}
+	return out, aliases
+}
+
+// buildVectorAggFunc produces the AggFunc for the LogQL operator.
+// Output-shape-changing ops (topk, bottomk, sort, sort_desc, quantile)
+// stay deferred — CH support exists for quantile but the LogQL semantic
+// for K-row-per-group ops needs result shaping.
+func buildVectorAggFunc(e *syntax.VectorAggregationExpr, _ schema.Logs) (chplan.AggFunc, error) {
+	const valueAlias = "Value"
+	valueArg := &chplan.ColumnRef{Name: valueAlias}
+
+	switch e.Operation {
+	case syntax.OpTypeSum:
+		return chplan.AggFunc{Name: "sum", Args: []chplan.Expr{valueArg}, Alias: valueAlias}, nil
+	case syntax.OpTypeAvg:
+		return chplan.AggFunc{Name: "avg", Args: []chplan.Expr{valueArg}, Alias: valueAlias}, nil
+	case syntax.OpTypeMin:
+		return chplan.AggFunc{Name: "min", Args: []chplan.Expr{valueArg}, Alias: valueAlias}, nil
+	case syntax.OpTypeMax:
+		return chplan.AggFunc{Name: "max", Args: []chplan.Expr{valueArg}, Alias: valueAlias}, nil
+	case syntax.OpTypeCount:
+		return chplan.AggFunc{Name: "count", Args: []chplan.Expr{valueArg}, Alias: valueAlias}, nil
+	case syntax.OpTypeStddev:
+		return chplan.AggFunc{Name: "stddevPop", Args: []chplan.Expr{valueArg}, Alias: valueAlias}, nil
+	case syntax.OpTypeStdvar:
+		return chplan.AggFunc{Name: "varPop", Args: []chplan.Expr{valueArg}, Alias: valueAlias}, nil
+
+	case syntax.OpTypeTopK, syntax.OpTypeBottomK:
+		return chplan.AggFunc{}, fmt.Errorf("logql: %s changes output shape and lands with M1.7-style result shaping", e.Operation)
+	case syntax.OpTypeSort, syntax.OpTypeSortDesc:
+		return chplan.AggFunc{}, fmt.Errorf("logql: %s requires output ordering rather than aggregation", e.Operation)
+	}
+	return chplan.AggFunc{}, fmt.Errorf("logql: aggregation operation %q is not yet supported", e.Operation)
+}
+
+// wrapVectorAggregateForSample mirrors PromQL's wrapAggregateForSample:
+// re-shape the aggregate output into the Sample contract so the API
+// layer can stream rows through chclient.Sample. LogQL aggregations
+// drop `__name__`-equivalent stream identity except for the requested
+// grouping labels.
+//
+//	MetricName  = ''
+//	Attributes  = map('lbl0', gkey_0, ...)    for `by (...)`
+//	            | gkey_0                        for `without (...)` (mapFilter output)
+//	            | empty Map(String,String)      for unaggregated
+//	TimeUnix    = now64(9)
+//	Value       = <agg alias>
+func wrapVectorAggregateForSample(agg *chplan.Aggregate, e *syntax.VectorAggregationExpr, s schema.Logs, aliases []string) chplan.Node {
+	var attrs chplan.Expr
+	switch {
+	case len(aliases) == 0:
+		attrs = emptyAttrsMap()
+	case e.Grouping != nil && e.Grouping.Without:
+		attrs = &chplan.ColumnRef{Name: aliases[0]}
+	default:
+		args := make([]chplan.Expr, 0, len(e.Grouping.Groups)*2)
+		for i, label := range e.Grouping.Groups {
+			args = append(args, &chplan.LitString{V: label}, &chplan.ColumnRef{Name: aliases[i]})
+		}
+		attrs = &chplan.FuncCall{Name: "map", Args: args}
+	}
+
+	// Use the metrics-schema column names for the Sample contract; the
+	// API layer reads MetricName/Attributes/TimeUnix/Value regardless of
+	// which head produced the row.
+	const (
+		metricNameCol = "MetricName"
+		attrsCol      = "Attributes"
+		tsCol         = "TimeUnix"
+		valueCol      = "Value"
+	)
+
+	return &chplan.Project{
+		Input: agg,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.LitString{V: ""}, Alias: metricNameCol},
+			{Expr: attrs, Alias: attrsCol},
+			{Expr: &chplan.FuncCall{Name: "now64", Args: []chplan.Expr{&chplan.LitInt{V: 9}}}, Alias: tsCol},
+			{Expr: &chplan.ColumnRef{Name: "Value"}, Alias: valueCol},
+		},
+	}
+}
+
+// emptyAttrsMap returns CH `CAST(map(), 'Map(String,String)')` for the
+// no-grouping aggregation case. Same helper shape as the PromQL side.
+func emptyAttrsMap() chplan.Expr {
+	return &chplan.FuncCall{
+		Name: "CAST",
+		Args: []chplan.Expr{
+			&chplan.FuncCall{Name: "map", Args: nil},
+			&chplan.LitString{V: "Map(String,String)"},
+		},
+	}
+}

--- a/test/spec/logql/avg_count_over_time.txtar
+++ b/test/spec/logql/avg_count_over_time.txtar
@@ -1,0 +1,11 @@
+-- query.logql --
+avg(count_over_time({job="api"}[5m]))
+-- sql --
+SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT avg(`Value`) AS `Value` FROM (SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS value FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS window_vals, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS counter_delta FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) >= now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS window_pairs FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS series_array FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_logs`) WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`)))))
+-- args --
+[0] string = ""
+[1] string = "Map(String,String)"
+[2] int64 = 9
+[3] int64 = 1
+[4] string = "job"
+[5] string = "api"

--- a/test/spec/logql/sum_by_job_rate.txtar
+++ b/test/spec/logql/sum_by_job_rate.txtar
@@ -1,0 +1,14 @@
+-- query.logql --
+sum by (job) (rate({app="api"}[5m]))
+-- sql --
+SELECT ? AS `MetricName`, map(?, `gkey_0`) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`[?] AS `gkey_0`, sum(`Value`) AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS value FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS window_vals, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS counter_delta FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) >= now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS window_pairs FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS series_array FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_logs`) WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`)))) GROUP BY `ResourceAttributes`[?])
+-- args --
+[0] string = ""
+[1] string = "job"
+[2] int64 = 9
+[3] string = "job"
+[4] float64 = 300
+[5] int64 = 1
+[6] string = "app"
+[7] string = "api"
+[8] string = "job"

--- a/test/spec/logql/sum_rate.txtar
+++ b/test/spec/logql/sum_rate.txtar
@@ -1,0 +1,12 @@
+-- query.logql --
+sum(rate({job="api"}[1m]))
+-- sql --
+SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT sum(`Value`) AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS value FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS window_vals, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS counter_delta FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) >= now64(9) - toIntervalNanosecond(60000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS window_pairs FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS series_array FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_logs`) WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`)))))
+-- args --
+[0] string = ""
+[1] string = "Map(String,String)"
+[2] int64 = 9
+[3] float64 = 60
+[4] int64 = 1
+[5] string = "job"
+[6] string = "api"

--- a/test/spec/logql/sum_without_pod.txtar
+++ b/test/spec/logql/sum_without_pod.txtar
@@ -1,0 +1,13 @@
+-- query.logql --
+sum without (pod) (rate({job="api"}[5m]))
+-- sql --
+SELECT ? AS `MetricName`, `gkey_0` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT mapFilter((k, v) -> NOT (k IN (?)), `ResourceAttributes`) AS `gkey_0`, sum(`Value`) AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS value FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS window_vals, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS counter_delta FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) >= now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS window_pairs FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS series_array FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_logs`) WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`)))) GROUP BY mapFilter((k, v) -> NOT (k IN (?)), `ResourceAttributes`))
+-- args --
+[0] string = ""
+[1] int64 = 9
+[2] string = "pod"
+[3] float64 = 300
+[4] int64 = 1
+[5] string = "job"
+[6] string = "api"
+[7] string = "pod"


### PR DESCRIPTION
## Summary
\`sum(rate(...))\`, \`avg by (job) (count_over_time(...))\`, \`sum without (pod) (rate(...))\`, etc. lower cleanly through a new \`VectorAggregationExpr\` handler that mirrors PromQL's aggregation pipeline.

- \`vectorAggregationGroupBy\` translates \`by (...)\` to per-label MapAccess on ResourceAttributes (with \`gkey_<i>\` aliases for the wrapping Project), and \`without (...)\` to MapWithoutKeys.
- \`buildVectorAggFunc\` maps op names: sum/avg/min/max/count → 1:1; stddev → stddevPop; stdvar → varPop.
- \`wrapVectorAggregateForSample\` re-shapes into the Sample contract so the API layer reads MetricName/Attributes/TimeUnix/Value just like PromQL aggregate output.

## Deferred to RC2
- \`topk\`, \`bottomk\`, \`sort\`, \`sort_desc\` (output-shape-changing).
- \`quantile\` (parameterised — same pattern as PromQL but needs the agg-func params plumbing).

## Test plan
- [x] \`just test\` green (4 new fixtures: sum/rate, sum-by-job/rate, avg/count_over_time, sum-without/rate)
- [x] \`just lint\` clean
- [ ] CI green