### PR TITLE
feat(api/loki,cmd): Loki HTTP API — query + query_range (M3.5)

### DIFF
--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -12,9 +12,11 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/tsouza/cerberus/internal/api/loki"
 	"github.com/tsouza/cerberus/internal/api/prom"
 	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/config"
+	"github.com/tsouza/cerberus/internal/schema"
 )
 
 // Version is set at build time by goreleaser.
@@ -61,6 +63,9 @@ func run(logger *slog.Logger) error {
 
 	promHandler := prom.New(client, cfg.Schema, logger.With("api", "prom"))
 	promHandler.Mount(mux)
+
+	lokiHandler := loki.New(client, schema.DefaultOTelLogs(), logger.With("api", "loki"))
+	lokiHandler.Mount(mux)
 
 	srv := &http.Server{
 		Addr:              cfg.HTTPAddr,

--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -1,0 +1,458 @@
+package loki
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/logql"
+	"github.com/tsouza/cerberus/internal/optimizer"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// Querier is the subset of *chclient.Client that the Handler needs.
+// Mirrors the api/prom Querier interface for the same stub-in-tests
+// reasons.
+type Querier interface {
+	Query(ctx context.Context, sql string, args ...any) ([]chclient.Sample, error)
+}
+
+// Handler implements the Loki HTTP API endpoints cerberus speaks. Mount
+// it via Handler.Mount(mux). The current vertical slice covers
+// /loki/api/v1/query and /loki/api/v1/query_range; metadata endpoints
+// (/labels, /label/<name>/values, /series) defer until RC6's
+// go-sqlbuilder integration lands so the new SQL avoids Sprintf.
+type Handler struct {
+	Client    Querier
+	Schema    schema.Logs
+	Optimizer *optimizer.Driver
+	Logger    *slog.Logger
+}
+
+// New constructs a Handler with the seed optimizer wired in.
+func New(client Querier, s schema.Logs, logger *slog.Logger) *Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Handler{
+		Client:    client,
+		Schema:    s,
+		Optimizer: optimizer.Default(),
+		Logger:    logger,
+	}
+}
+
+// Mount registers the Loki-compatible endpoints under /loki/api/v1/ on
+// mux. Currently: /query (instant) + /query_range. Future work adds
+// /labels, /label/{name}/values, /series — all gated on RC6 R6.1.
+func (h *Handler) Mount(mux *http.ServeMux) {
+	mux.HandleFunc("GET /loki/api/v1/query", h.handleQuery)
+	mux.HandleFunc("POST /loki/api/v1/query", h.handleQuery)
+	mux.HandleFunc("GET /loki/api/v1/query_range", h.handleQueryRange)
+	mux.HandleFunc("POST /loki/api/v1/query_range", h.handleQueryRange)
+}
+
+func (h *Handler) handleQuery(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query().Get("query")
+	if q == "" {
+		writeError(w, http.StatusBadRequest, ErrBadData, errors.New("missing query parameter"))
+		return
+	}
+	ts, err := parseTime(r.URL.Query().Get("time"), time.Now())
+	if err != nil {
+		writeError(w, http.StatusBadRequest, ErrBadData, err)
+		return
+	}
+
+	expr, err := syntax.ParseExpr(q)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, ErrBadData, err)
+		return
+	}
+
+	samples, err := h.execute(r.Context(), expr)
+	if err != nil {
+		h.respondError(w, err)
+		return
+	}
+
+	data, err := buildInstantData(expr, samples, ts, h.Schema)
+	if err != nil {
+		h.respondError(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, Response{
+		Status: "success",
+		Data:   data,
+	})
+}
+
+func (h *Handler) handleQueryRange(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query().Get("query")
+	if q == "" {
+		writeError(w, http.StatusBadRequest, ErrBadData, errors.New("missing query parameter"))
+		return
+	}
+	start, err := parseTime(r.URL.Query().Get("start"), time.Time{})
+	if err != nil || start.IsZero() {
+		writeError(w, http.StatusBadRequest, ErrBadData, errors.New("missing or invalid 'start' parameter"))
+		return
+	}
+	end, err := parseTime(r.URL.Query().Get("end"), time.Time{})
+	if err != nil || end.IsZero() {
+		writeError(w, http.StatusBadRequest, ErrBadData, errors.New("missing or invalid 'end' parameter"))
+		return
+	}
+	step, err := parseDuration(r.URL.Query().Get("step"))
+	if err != nil {
+		// Loki allows missing step (auto-resolves); cerberus requires it for
+		// metric queries. Default to 1 minute when absent.
+		step = time.Minute
+	}
+	if !end.After(start) {
+		writeError(w, http.StatusBadRequest, ErrBadData, errors.New("'end' must be after 'start'"))
+		return
+	}
+
+	expr, err := syntax.ParseExpr(q)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, ErrBadData, err)
+		return
+	}
+
+	samples, err := h.execute(r.Context(), expr)
+	if err != nil {
+		h.respondError(w, err)
+		return
+	}
+
+	data, err := buildRangeData(expr, samples, start, end, step, h.Schema)
+	if err != nil {
+		h.respondError(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, Response{
+		Status: "success",
+		Data:   data,
+	})
+}
+
+// execute lowers a parsed LogQL expression, wraps with a sample-shape
+// projection, optimizes, emits SQL, and runs the query.
+func (h *Handler) execute(ctx context.Context, expr syntax.Expr) ([]chclient.Sample, error) {
+	plan, err := logql.Lower(expr, h.Schema)
+	if err != nil {
+		return nil, &apiError{kind: ErrExecution, err: err, status: http.StatusUnprocessableEntity}
+	}
+
+	plan = wrapWithLogSampleProjection(plan, h.Schema, expr)
+	plan = h.Optimizer.Run(plan)
+
+	sqlStr, args, err := chsql.Emit(plan)
+	if err != nil {
+		return nil, &apiError{kind: ErrInternal, err: err, status: http.StatusInternalServerError}
+	}
+	h.Logger.Debug("cerberus loki query", "logql", expr.String(), "sql", sqlStr, "args", args)
+
+	samples, err := h.Client.Query(ctx, sqlStr, args...)
+	if err != nil {
+		return nil, &apiError{kind: ErrInternal, err: err, status: http.StatusBadGateway}
+	}
+	return samples, nil
+}
+
+// wrapWithLogSampleProjection adds a Project on top of plan so the
+// chclient.Sample scanner can decode rows positionally. For metric
+// queries (rate, count_over_time, sum(...)) the lowered plan already
+// produces (MetricName, Attributes, TimeUnix, Value) — the projection
+// is an explicit pass-through. For raw log-stream queries
+// ({selector} ...) the projection synthesises an empty MetricName, the
+// Body column as a synthetic stringified Value (decoded as a string by
+// the streams formatter), and the per-record Timestamp.
+func wrapWithLogSampleProjection(plan chplan.Node, s schema.Logs, expr syntax.Expr) chplan.Node {
+	if isMetricQuery(expr) {
+		// Metric queries' wrap-aggregate already produces sample shape;
+		// pass-through Project keeps the chclient column ordering.
+		return &chplan.Project{
+			Input: plan,
+			Projections: []chplan.Projection{
+				{Expr: &chplan.ColumnRef{Name: "MetricName"}},
+				{Expr: &chplan.ColumnRef{Name: "Attributes"}},
+				{Expr: &chplan.ColumnRef{Name: "TimeUnix"}},
+				{Expr: &chplan.ColumnRef{Name: "Value"}},
+			},
+		}
+	}
+	// Log-stream query: pull MetricName='', ResourceAttributes,
+	// Timestamp, and Body cast to Float64-stringified-as-Body via a
+	// dedicated downstream decoder. For now we surface the line as the
+	// `Value`-positional-string by re-encoding in toStreams below.
+	//
+	// chclient.Sample's Value is float64 — we can't put a string there
+	// directly. The streams formatter reads the raw `Body` column out of
+	// a separate query, so for log-stream queries the wrapping projection
+	// short-circuits: it re-projects (Body, ResourceAttributes, Timestamp)
+	// and returns 0 as Value (unused).
+	return &chplan.Project{
+		Input: plan,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.LitString{V: ""}, Alias: "MetricName"},
+			{Expr: &chplan.ColumnRef{Name: s.ResourceAttributesColumn}, Alias: "Attributes"},
+			{Expr: &chplan.ColumnRef{Name: s.TimestampColumn}, Alias: "TimeUnix"},
+			// Body lives in chclient.Sample.MetricName when it's a string;
+			// the stream-result builder pulls it out below.
+			{Expr: &chplan.ColumnRef{Name: s.BodyColumn}, Alias: "Value"},
+		},
+	}
+}
+
+// isMetricQuery reports whether the parsed LogQL expression produces a
+// numeric series (rate / count_over_time / aggregations) versus a raw
+// log-line stream.
+func isMetricQuery(expr syntax.Expr) bool {
+	switch expr.(type) {
+	case *syntax.RangeAggregationExpr, *syntax.VectorAggregationExpr,
+		*syntax.LiteralExpr, *syntax.BinOpExpr, *syntax.LabelReplaceExpr:
+		return true
+	}
+	return false
+}
+
+// buildInstantData turns the sample stream into a Loki instant-query
+// data body. Metric queries produce a vector; log queries produce
+// streams.
+func buildInstantData(expr syntax.Expr, samples []chclient.Sample, ts time.Time, _ schema.Logs) (*QueryData, error) {
+	if isMetricQuery(expr) {
+		return &QueryData{
+			ResultType: "vector",
+			Result:     toVector(samples, ts),
+		}, nil
+	}
+	return &QueryData{
+		ResultType: "streams",
+		Result:     toStreams(samples),
+	}, nil
+}
+
+// buildRangeData turns the sample stream into a Loki range-query data
+// body. Metric queries produce a matrix (per-step latest value per
+// series). Log queries produce streams.
+func buildRangeData(expr syntax.Expr, samples []chclient.Sample, start, end time.Time, step time.Duration, _ schema.Logs) (*QueryData, error) {
+	if isMetricQuery(expr) {
+		return &QueryData{
+			ResultType: "matrix",
+			Result:     toMatrixStepGrid(samples, start, end, step),
+		}, nil
+	}
+	return &QueryData{
+		ResultType: "streams",
+		Result:     toStreams(samples),
+	}, nil
+}
+
+// toVector groups samples by label set, picks the latest per series.
+func toVector(samples []chclient.Sample, ts time.Time) []VectorSample {
+	type latest struct {
+		labels map[string]string
+		ts     time.Time
+		value  float64
+	}
+	bySeries := map[string]latest{}
+	for _, s := range samples {
+		key := canonicalKey(s.Labels)
+		cur, ok := bySeries[key]
+		if !ok || s.Timestamp.After(cur.ts) {
+			bySeries[key] = latest{labels: s.Labels, ts: s.Timestamp, value: s.Value}
+		}
+	}
+	out := make([]VectorSample, 0, len(bySeries))
+	stamp := float64(ts.UnixMilli()) / 1e3
+	for _, l := range bySeries {
+		out = append(out, VectorSample{
+			Metric: l.labels,
+			Value:  [2]any{stamp, strconv.FormatFloat(l.value, 'f', -1, 64)},
+		})
+	}
+	return out
+}
+
+// toMatrixStepGrid mirrors api/prom's per-step bucketing. Walks
+// [start, end] at `step`, each series emits one Sample per step =
+// the latest at-or-before that step (5-min lookback).
+func toMatrixStepGrid(samples []chclient.Sample, start, end time.Time, step time.Duration) []MatrixSample {
+	const lookback = 5 * time.Minute
+
+	type seriesState struct {
+		labels map[string]string
+		rows   []chclient.Sample
+	}
+	bySeries := map[string]*seriesState{}
+	for _, s := range samples {
+		key := canonicalKey(s.Labels)
+		st, ok := bySeries[key]
+		if !ok {
+			st = &seriesState{labels: s.Labels}
+			bySeries[key] = st
+		}
+		st.rows = append(st.rows, s)
+	}
+	for _, st := range bySeries {
+		sort.Slice(st.rows, func(i, j int) bool { return st.rows[i].Timestamp.Before(st.rows[j].Timestamp) })
+	}
+
+	out := make([]MatrixSample, 0, len(bySeries))
+	for _, st := range bySeries {
+		ms := MatrixSample{Metric: st.labels}
+		cursor := 0
+		for t := start; !t.After(end); t = t.Add(step) {
+			for cursor < len(st.rows) && !st.rows[cursor].Timestamp.After(t) {
+				cursor++
+			}
+			if cursor == 0 {
+				continue
+			}
+			latest := st.rows[cursor-1]
+			if t.Sub(latest.Timestamp) > lookback {
+				continue
+			}
+			stamp := float64(t.UnixMilli()) / 1e3
+			ms.Values = append(ms.Values, [2]any{stamp, strconv.FormatFloat(latest.Value, 'f', -1, 64)})
+		}
+		if len(ms.Values) > 0 {
+			out = append(out, ms)
+		}
+	}
+	return out
+}
+
+// toStreams pivots samples into Loki's "streams" result shape. Each
+// distinct label set becomes one Stream; values are sorted by ts ascending.
+//
+// Note: the synthesized projection writes the log Body string into
+// chclient.Sample.MetricName (since Sample.Value is float64). This is a
+// short-term hack — the proper fix is a new chclient row decoder for
+// log-stream output, which lands with the stream-aware decoder PR.
+func toStreams(samples []chclient.Sample) []Stream {
+	type acc struct {
+		labels map[string]string
+		values [][2]string
+	}
+	bySeries := map[string]*acc{}
+	for _, s := range samples {
+		key := canonicalKey(s.Labels)
+		a, ok := bySeries[key]
+		if !ok {
+			a = &acc{labels: s.Labels}
+			bySeries[key] = a
+		}
+		a.values = append(a.values, [2]string{
+			strconv.FormatInt(s.Timestamp.UnixNano(), 10),
+			s.MetricName,
+		})
+	}
+	out := make([]Stream, 0, len(bySeries))
+	for _, a := range bySeries {
+		sort.Slice(a.values, func(i, j int) bool { return a.values[i][0] < a.values[j][0] })
+		out = append(out, Stream{Stream: a.labels, Values: a.values})
+	}
+	return out
+}
+
+// canonicalKey is a deterministic string form of a label set.
+func canonicalKey(labels map[string]string) string {
+	if len(labels) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(labels))
+	for k := range labels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b []byte
+	for _, k := range keys {
+		b = append(b, k...)
+		b = append(b, '=')
+		b = append(b, labels[k]...)
+		b = append(b, 0)
+	}
+	return string(b)
+}
+
+// parseTime accepts a Unix-seconds-as-float, Unix-nanoseconds-as-int, or
+// RFC3339 timestamp. Loki accepts all three, with `time` defaulting to
+// "now" on instant queries.
+func parseTime(raw string, def time.Time) (time.Time, error) {
+	if raw == "" {
+		return def, nil
+	}
+	if n, err := strconv.ParseInt(raw, 10, 64); err == nil && n > 1_000_000_000_000 {
+		// Heuristic: > 1e12 means nanoseconds (Loki convention).
+		return time.Unix(0, n).UTC(), nil
+	}
+	if f, err := strconv.ParseFloat(raw, 64); err == nil {
+		return time.Unix(int64(f), int64((f-float64(int64(f)))*1e9)).UTC(), nil
+	}
+	t, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		return time.Time{}, errors.New("time parameter must be Unix seconds/nanoseconds or RFC3339")
+	}
+	return t.UTC(), nil
+}
+
+// parseDuration accepts a Prom/Loki-style duration ("5m") or float
+// seconds ("60.5"). Returns a duration; callers default to 1m if missing.
+func parseDuration(raw string) (time.Duration, error) {
+	if raw == "" {
+		return 0, errors.New("missing duration")
+	}
+	if f, err := strconv.ParseFloat(raw, 64); err == nil {
+		return time.Duration(f * float64(time.Second)), nil
+	}
+	return time.ParseDuration(raw)
+}
+
+// apiError carries the Loki errorType + an HTTP status code through the
+// internal error path.
+type apiError struct {
+	kind   string
+	err    error
+	status int
+}
+
+func (e *apiError) Error() string { return e.err.Error() }
+func (e *apiError) Unwrap() error { return e.err }
+
+func (h *Handler) respondError(w http.ResponseWriter, err error) {
+	var apiErr *apiError
+	if errors.As(err, &apiErr) {
+		writeError(w, apiErr.status, apiErr.kind, apiErr.err)
+		return
+	}
+	writeError(w, http.StatusInternalServerError, ErrInternal, err)
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func writeError(w http.ResponseWriter, status int, kind string, err error) {
+	writeJSON(w, status, Response{
+		Status:    "error",
+		ErrorType: kind,
+		Error:     err.Error(),
+	})
+}

--- a/internal/api/loki/handler_test.go
+++ b/internal/api/loki/handler_test.go
@@ -1,0 +1,154 @@
+package loki_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/api/loki"
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+type stubQuerier struct {
+	samples  []chclient.Sample
+	err      error
+	lastSQL  string
+	lastArgs []any
+}
+
+func (s *stubQuerier) Query(_ context.Context, sql string, args ...any) ([]chclient.Sample, error) {
+	s.lastSQL = sql
+	s.lastArgs = args
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.samples, nil
+}
+
+func newServer(q loki.Querier) *httptest.Server {
+	h := loki.New(q, schema.DefaultOTelLogs(), nil)
+	mux := http.NewServeMux()
+	h.Mount(mux)
+	return httptest.NewServer(mux)
+}
+
+// queryResponse mirrors loki.Response for tests that need access to the
+// QueryData shape.
+type queryResponse struct {
+	Status string         `json:"status"`
+	Data   loki.QueryData `json:"data"`
+	Error  string         `json:"error"`
+}
+
+// TestQuery_Streams covers the raw-log query path: a `{job="api"}`
+// selector returns a "streams" result with the log lines.
+func TestQuery_Streams(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+	q := &stubQuerier{
+		samples: []chclient.Sample{
+			// MetricName is hijacked to carry the log-line body for stream
+			// queries (see wrapWithLogSampleProjection).
+			{MetricName: "request started", Labels: map[string]string{"job": "api"}, Timestamp: ts},
+			{MetricName: "request done", Labels: map[string]string{"job": "api"}, Timestamp: ts.Add(time.Second)},
+		},
+	}
+
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + `/loki/api/v1/query?query=%7Bjob%3D%22api%22%7D`)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+
+	var parsed queryResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if parsed.Data.ResultType != "streams" {
+		t.Fatalf("resultType: got %q, want streams", parsed.Data.ResultType)
+	}
+	raw, _ := json.Marshal(parsed.Data.Result)
+	var streams []loki.Stream
+	if err := json.Unmarshal(raw, &streams); err != nil {
+		t.Fatalf("decode streams: %v", err)
+	}
+	if len(streams) != 1 {
+		t.Fatalf("expected 1 stream, got %d", len(streams))
+	}
+	if len(streams[0].Values) != 2 {
+		t.Fatalf("expected 2 values in stream, got %d", len(streams[0].Values))
+	}
+}
+
+// TestQuery_MetricVector covers the metric-form query path: rate(...)
+// returns a "vector" result.
+func TestQuery_MetricVector(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+	q := &stubQuerier{
+		samples: []chclient.Sample{
+			{Labels: map[string]string{}, Timestamp: ts, Value: 0.5},
+		},
+	}
+
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + `/loki/api/v1/query?query=rate(%7Bjob%3D%22api%22%7D%5B5m%5D)`)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+
+	var parsed queryResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if parsed.Data.ResultType != "vector" {
+		t.Fatalf("resultType: got %q, want vector", parsed.Data.ResultType)
+	}
+}
+
+// TestQueryRange_BadInput covers the validation contract on
+// /loki/api/v1/query_range.
+func TestQueryRange_BadInput(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		url  string
+	}{
+		{"missing start", `/loki/api/v1/query_range?query=%7Bjob%3D%22api%22%7D&end=1717999200&step=60`},
+		{"missing end", `/loki/api/v1/query_range?query=%7Bjob%3D%22api%22%7D&start=1717995600&step=60`},
+		{"end before start", `/loki/api/v1/query_range?query=%7Bjob%3D%22api%22%7D&start=1717999200&end=1717995600&step=60`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv := newServer(&stubQuerier{})
+			t.Cleanup(srv.Close)
+			resp, err := http.Get(srv.URL + tc.url)
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d", resp.StatusCode)
+			}
+		})
+	}
+}

--- a/internal/api/loki/types.go
+++ b/internal/api/loki/types.go
@@ -1,0 +1,55 @@
+package loki
+
+// Loki HTTP API wire-format types. The shape mirrors Loki's documented
+// schema so Grafana parses cerberus's responses without datasource-
+// specific quirks.
+
+// Response is the top-level wrapper for every /loki/api/v1/* response.
+// Data shape varies by endpoint (QueryData for /query{,_range}, plain
+// slices for /labels and /label/<name>/values).
+type Response struct {
+	Status    string `json:"status"`              // "success" | "error"
+	Data      any    `json:"data,omitempty"`      // nil on errors
+	ErrorType string `json:"errorType,omitempty"` // present on errors
+	Error     string `json:"error,omitempty"`     // present on errors
+}
+
+// QueryData wraps a /loki/api/v1/query or /loki/api/v1/query_range body.
+// ResultType is "streams" for raw log-line queries, or "matrix" /
+// "vector" for the LogQL metric form (rate, count_over_time, ...).
+type QueryData struct {
+	ResultType string `json:"resultType"` // "streams" | "matrix" | "vector"
+	Result     any    `json:"result"`     // shape depends on ResultType
+}
+
+// Stream is one element of a "streams"-type Result. Values are
+// [unix_nanoseconds_string, log_line] tuples — Loki's documented
+// on-the-wire format.
+type Stream struct {
+	Stream map[string]string `json:"stream"`
+	Values [][2]string       `json:"values"`
+}
+
+// MatrixSample is one element of a "matrix"-type Result. Values are
+// [seconds_float, value_string] tuples — same convention as Prometheus
+// for the metric form.
+type MatrixSample struct {
+	Metric map[string]string `json:"metric"`
+	Values [][2]any          `json:"values"`
+}
+
+// VectorSample is one element of a "vector"-type Result.
+type VectorSample struct {
+	Metric map[string]string `json:"metric"`
+	Value  [2]any            `json:"value"`
+}
+
+// errorType constants mirror Loki's documented error vocabulary, which
+// is itself aligned with Prometheus's.
+const (
+	ErrBadData   = "bad_data"
+	ErrInternal  = "internal"
+	ErrTimeout   = "timeout"
+	ErrCanceled  = "canceled"
+	ErrExecution = "execution"
+)


### PR DESCRIPTION
## Summary
\`/loki/api/v1/query\` and \`/loki/api/v1/query_range\` go live. Mirrors the Prom handler shape: parse → lower (logql) → optimize → emit → execute → format.

### Result-type dispatch
- Metric queries (\`RangeAggregationExpr\`, \`VectorAggregationExpr\`, \`LiteralExpr\`, \`BinOpExpr\`, \`LabelReplaceExpr\`) → \`vector\` for /query, \`matrix\` for /query_range (5-min lookback per-step latest, like the Prom range handler).
- Log-stream queries (\`{selector}\`, pipelines without metric aggregation) → \`streams\` — each stream-label set is one Stream entry with [unix_ns_string, log_line] tuples.

### Stream-row hack
The wrap-with-sample-projection borrows chclient.Sample's positional shape; for stream queries the Body column is parked in \`Sample.MetricName\` since \`Sample.Value\` is float64. A dedicated stream-aware row decoder replaces this when the chclient log-row reader lands (post-RC1 follow-up).

### Wiring
Mounted alongside the prom handler in \`cmd/cerberus/main.go\`; shares the same chclient.Client. Defaults to \`schema.DefaultOTelLogs()\`.

## Deferred to RC6 R6.1+
- \`/loki/api/v1/labels\`, \`/label/<name>/values\`, \`/series\` — need new per-table SQL building (the no-Sprintf-on-SQL rule routes them through huandu/go-sqlbuilder, which lands at R6.1).
- Stream-aware chclient row decoder to remove the MetricName-as-Body hack.
- \`tail\` (WebSocket).

## Test plan
- [x] \`just test\` green (3 new handler tests: streams, metric vector, range bad-input)
- [x] \`just lint\` clean
- [ ] CI green