### PR TITLE
feat(traceql,chplan,chsql,schema): TraceQL span selectors (M4.1)

### DIFF
--- a/internal/chplan/field_access.go
+++ b/internal/chplan/field_access.go
@@ -1,0 +1,30 @@
+package chplan
+
+// FieldAccess is a chplan expression for resolving dotted-path
+// attribute references like TraceQL's `.service.name`,
+// `resource.k8s.pod.name`, or `span.http.status_code`.
+//
+// Conceptually it's a generalised MapAccess: the Source carries the
+// outer column to dereference (the carrier map), and Path is the
+// (possibly multi-segment) key. The emitter renders it as
+// `Source[<dotted-key>]` since the OTel-CH attribute maps store the
+// dotted form verbatim as the key — `Attributes['http.status_code']`,
+// not nested `Attributes['http']['status_code']`.
+//
+// Distinct from MapAccess so the lowering layer can express
+// scope-aware resolution (resource. vs span. vs scope.) without
+// stringifying the AST first.
+type FieldAccess struct {
+	Source Expr
+	Path   string
+}
+
+func (*FieldAccess) exprNode() {}
+
+func (f *FieldAccess) Equal(other Expr) bool {
+	o, ok := other.(*FieldAccess)
+	if !ok {
+		return false
+	}
+	return f.Path == o.Path && f.Source.Equal(o.Source)
+}

--- a/internal/chsql/emit_expr.go
+++ b/internal/chsql/emit_expr.go
@@ -29,9 +29,23 @@ func (e *emitter) emitExpr(x chplan.Expr) error {
 		return e.emitMapWithoutKeys(v)
 	case *chplan.LineContent:
 		return e.emitLineContent(v)
+	case *chplan.FieldAccess:
+		return e.emitFieldAccess(v)
 	default:
 		return fmt.Errorf("%w: expr %T", ErrUnsupported, x)
 	}
+}
+
+func (e *emitter) emitFieldAccess(f *chplan.FieldAccess) error {
+	if err := e.emitExpr(f.Source); err != nil {
+		return err
+	}
+	e.b.WriteByte('[')
+	if err := e.bindArg(f.Path); err != nil {
+		return err
+	}
+	e.b.WriteByte(']')
+	return nil
 }
 
 func (e *emitter) bindArg(v any) error {

--- a/internal/schema/traces.go
+++ b/internal/schema/traces.go
@@ -1,0 +1,71 @@
+package schema
+
+// Traces describes how cerberus reads spans from ClickHouse. The default
+// (returned by DefaultOTelTraces) matches the OpenTelemetry ClickHouse
+// Exporter v0.x traces schema; users with custom layouts override
+// individual fields.
+type Traces struct {
+	// SpansTable is the table holding span records.
+	SpansTable string
+
+	// TraceIDColumn names the trace-id column (FixedString(16) hex).
+	TraceIDColumn string
+	// SpanIDColumn names the span-id column (FixedString(8) hex).
+	SpanIDColumn string
+	// ParentSpanIDColumn names the parent-span-id column.
+	ParentSpanIDColumn string
+	// SpanNameColumn names the span name column.
+	SpanNameColumn string
+	// SpanKindColumn names the span kind column ("Client", "Server", ...).
+	SpanKindColumn string
+	// ServiceNameColumn names the dedicated service.name column.
+	ServiceNameColumn string
+
+	// DurationColumn names the span-duration column (Int64 nanoseconds).
+	DurationColumn string
+	// StartTimeColumn names the span-start timestamp column.
+	StartTimeColumn string
+	// EndTimeColumn names the span-end timestamp column.
+	EndTimeColumn string
+
+	// StatusCodeColumn names the status code column ("Unset", "Ok", "Error").
+	StatusCodeColumn string
+	// StatusMessageColumn names the status message column.
+	StatusMessageColumn string
+
+	// AttributesColumn names the span-level attribute map.
+	AttributesColumn string
+	// ResourceAttributesColumn names the resource attribute map (carries
+	// service-identity labels).
+	ResourceAttributesColumn string
+	// ScopeAttributesColumn names the instrumentation-scope attribute map.
+	ScopeAttributesColumn string
+
+	// TimestampColumn names the canonical event timestamp column. For
+	// OTel-CH this is the same as StartTimeColumn ("Timestamp" in newer
+	// schemas, often "StartTimeUnix" in older).
+	TimestampColumn string
+}
+
+// DefaultOTelTraces returns the schema produced by the upstream OTel
+// ClickHouse Exporter for traces.
+func DefaultOTelTraces() Traces {
+	return Traces{
+		SpansTable:               "otel_traces",
+		TraceIDColumn:            "TraceId",
+		SpanIDColumn:             "SpanId",
+		ParentSpanIDColumn:       "ParentSpanId",
+		SpanNameColumn:           "SpanName",
+		SpanKindColumn:           "SpanKind",
+		ServiceNameColumn:        "ServiceName",
+		DurationColumn:           "Duration",
+		StartTimeColumn:          "Timestamp",
+		EndTimeColumn:            "Timestamp", // OTel-CH stores duration; end = start + duration
+		StatusCodeColumn:         "StatusCode",
+		StatusMessageColumn:      "StatusMessage",
+		AttributesColumn:         "SpanAttributes",
+		ResourceAttributesColumn: "ResourceAttributes",
+		ScopeAttributesColumn:    "ScopeAttributes",
+		TimestampColumn:          "Timestamp",
+	}
+}

--- a/internal/traceql/lower.go
+++ b/internal/traceql/lower.go
@@ -1,0 +1,207 @@
+// Package traceql lowers Tempo TraceQL queries into the shared cerberus
+// chplan IR. The seed (M4.1) covers the SpansetFilter form: attribute
+// matchers like `{ .service.name = "x" }`, `{ duration > 100ms }`,
+// `{ span.http.status_code >= 500 }`. Structural operators (`>>`/`>`),
+// aggregators, time filters, and `| select(...)` land in M4.2-M4.4.
+package traceql
+
+import (
+	"fmt"
+
+	"github.com/grafana/tempo/pkg/traceql"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// Lower turns a parsed TraceQL expression into a chplan tree.
+func Lower(expr *traceql.RootExpr, s schema.Traces) (chplan.Node, error) {
+	if expr == nil {
+		return nil, fmt.Errorf("traceql: nil RootExpr")
+	}
+	if expr.MetricsPipeline != nil {
+		return nil, fmt.Errorf("traceql: metrics pipelines (`| count()`, `| rate()`) are not yet supported (lands with M4.3)")
+	}
+	if len(expr.Pipeline.Elements) == 0 {
+		return nil, fmt.Errorf("traceql: empty pipeline")
+	}
+
+	// First element must be a SpansetFilter for the M4.1 slice. Subsequent
+	// elements (structural ops, scalar filters, group / coalesce / select)
+	// defer to M4.2-M4.4.
+	if len(expr.Pipeline.Elements) > 1 {
+		return nil, fmt.Errorf("traceql: multi-stage pipelines are not yet supported (structural ops + filters land in M4.2)")
+	}
+
+	first := expr.Pipeline.Elements[0]
+	if v, ok := first.(*traceql.SpansetFilter); ok {
+		return lowerSpansetFilter(v, s)
+	}
+	return nil, fmt.Errorf("traceql: pipeline element %T is not yet supported", first)
+}
+
+// lowerSpansetFilter turns `{ <field-expr> }` into Scan + Filter on
+// otel_traces. The field expression is recursively lowered into a
+// chplan.Expr predicate.
+func lowerSpansetFilter(f *traceql.SpansetFilter, s schema.Traces) (chplan.Node, error) {
+	pred, err := lowerFieldExpr(f.Expression, s)
+	if err != nil {
+		return nil, err
+	}
+	scan := &chplan.Scan{Table: s.SpansTable}
+	if pred == nil {
+		return scan, nil
+	}
+	return &chplan.Filter{Input: scan, Predicate: pred}, nil
+}
+
+// lowerFieldExpr recursively translates a TraceQL FieldExpression into
+// a chplan.Expr. Handles BinaryOperation (= / != / </ <= / > / >= /
+// =~ / !~ / + / - / etc.), Attribute (dotted paths), Static (typed
+// literal).
+func lowerFieldExpr(e traceql.FieldExpression, s schema.Traces) (chplan.Expr, error) {
+	switch v := e.(type) {
+	case *traceql.BinaryOperation:
+		return lowerBinaryOperation(v, s)
+	case *traceql.Attribute:
+		return lowerAttribute(*v, s), nil
+	case traceql.Attribute:
+		return lowerAttribute(v, s), nil
+	case *traceql.Static:
+		return lowerStatic(*v)
+	case traceql.Static:
+		return lowerStatic(v)
+	}
+	return nil, fmt.Errorf("traceql: field expression %T is not yet supported", e)
+}
+
+func lowerBinaryOperation(b *traceql.BinaryOperation, s schema.Traces) (chplan.Expr, error) {
+	op, err := mapBinaryOp(b.Op)
+	if err != nil {
+		return nil, err
+	}
+	lhs, err := lowerFieldExpr(b.LHS, s)
+	if err != nil {
+		return nil, err
+	}
+	rhs, err := lowerFieldExpr(b.RHS, s)
+	if err != nil {
+		return nil, err
+	}
+	return &chplan.Binary{Op: op, Left: lhs, Right: rhs}, nil
+}
+
+// lowerAttribute resolves a TraceQL attribute reference to a chplan
+// expression against the appropriate carrier column.
+//
+// Scope mapping:
+//   - .name (no prefix), span.name → SpanAttributes['name']
+//   - resource.name        → ResourceAttributes['name']
+//   - intrinsic duration   → Duration
+//   - intrinsic name       → SpanName
+//   - intrinsic kind       → SpanKind
+//   - intrinsic status     → StatusCode
+//   - intrinsic statusMessage → StatusMessage
+//   - intrinsic traceID    → TraceId
+//   - intrinsic spanID     → SpanId
+//   - intrinsic parent     → ParentSpanId
+func lowerAttribute(a traceql.Attribute, s schema.Traces) chplan.Expr {
+	if a.Intrinsic != traceql.IntrinsicNone {
+		if col := intrinsicColumn(a.Intrinsic, s); col != "" {
+			return &chplan.ColumnRef{Name: col}
+		}
+	}
+	carrier := s.AttributesColumn
+	switch a.Scope {
+	case traceql.AttributeScopeResource:
+		carrier = s.ResourceAttributesColumn
+	case traceql.AttributeScopeSpan:
+		carrier = s.AttributesColumn
+	}
+	return &chplan.FieldAccess{
+		Source: &chplan.ColumnRef{Name: carrier},
+		Path:   a.Name,
+	}
+}
+
+func intrinsicColumn(i traceql.Intrinsic, s schema.Traces) string {
+	switch i {
+	case traceql.IntrinsicDuration:
+		return s.DurationColumn
+	case traceql.IntrinsicName:
+		return s.SpanNameColumn
+	case traceql.IntrinsicKind:
+		return s.SpanKindColumn
+	case traceql.IntrinsicStatus:
+		return s.StatusCodeColumn
+	case traceql.IntrinsicStatusMessage:
+		return s.StatusMessageColumn
+	case traceql.IntrinsicTraceID:
+		return s.TraceIDColumn
+	case traceql.IntrinsicSpanID:
+		return s.SpanIDColumn
+	case traceql.IntrinsicParent:
+		return s.ParentSpanIDColumn
+	}
+	return ""
+}
+
+// lowerStatic turns a TraceQL Static literal into a chplan literal.
+func lowerStatic(st traceql.Static) (chplan.Expr, error) {
+	switch st.Type {
+	case traceql.TypeString:
+		return &chplan.LitString{V: st.EncodeToString(false)}, nil
+	case traceql.TypeInt:
+		i, _ := st.Int()
+		return &chplan.LitInt{V: int64(i)}, nil
+	case traceql.TypeFloat:
+		return &chplan.LitFloat{V: st.Float()}, nil
+	case traceql.TypeBoolean:
+		b, _ := st.Bool()
+		return &chplan.LitBool{V: b}, nil
+	case traceql.TypeDuration:
+		// Durations encode as nanoseconds; emit as int64 since the
+		// Duration column in OTel-CH is Int64 ns.
+		d, _ := st.Duration()
+		return &chplan.LitInt{V: d.Nanoseconds()}, nil
+	}
+	return nil, fmt.Errorf("traceql: static literal type %s is not yet supported", st.Type)
+}
+
+func mapBinaryOp(op traceql.Operator) (chplan.BinaryOp, error) {
+	switch op {
+	case traceql.OpEqual:
+		return chplan.OpEq, nil
+	case traceql.OpNotEqual:
+		return chplan.OpNe, nil
+	case traceql.OpLess:
+		return chplan.OpLt, nil
+	case traceql.OpLessEqual:
+		return chplan.OpLe, nil
+	case traceql.OpGreater:
+		return chplan.OpGt, nil
+	case traceql.OpGreaterEqual:
+		return chplan.OpGe, nil
+	case traceql.OpRegex:
+		return chplan.OpMatch, nil
+	case traceql.OpNotRegex:
+		return chplan.OpNotMatch, nil
+	case traceql.OpAnd:
+		return chplan.OpAnd, nil
+	case traceql.OpOr:
+		return chplan.OpOr, nil
+	case traceql.OpAdd:
+		return chplan.OpAdd, nil
+	case traceql.OpSub:
+		return chplan.OpSub, nil
+	case traceql.OpMult:
+		return chplan.OpMul, nil
+	case traceql.OpDiv:
+		return chplan.OpDiv, nil
+	case traceql.OpMod:
+		return chplan.OpMod, nil
+	case traceql.OpPower:
+		return chplan.OpPow, nil
+	}
+	return "", fmt.Errorf("traceql: operator %s is not yet supported", op)
+}

--- a/internal/traceql/lower_test.go
+++ b/internal/traceql/lower_test.go
@@ -1,0 +1,63 @@
+package traceql_test
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tempo "github.com/grafana/tempo/pkg/traceql"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/traceql"
+	"github.com/tsouza/cerberus/test/spec"
+)
+
+var fixtureDir = filepath.Join("..", "..", "test", "spec", "traceql")
+
+// TestLower walks every *.txtar fixture under test/spec/traceql/, parses
+// the TraceQL in `query.traceql`, lowers it, emits SQL, and compares
+// the result to the recorded `sql` + `args` sections.
+func TestLower(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelTraces()
+
+	spec.Walk(t, fixtureDir, func(t *testing.T, c *spec.Case) {
+		query, ok := c.Section("query.traceql")
+		if !ok {
+			t.Fatalf("fixture %s missing 'query.traceql' section", c.Name)
+		}
+		query = strings.TrimSpace(query)
+
+		expr, err := tempo.Parse(query)
+		if err != nil {
+			t.Fatalf("Parse(%q): %v", query, err)
+		}
+		plan, err := traceql.Lower(expr, s)
+		if err != nil {
+			t.Fatalf("Lower(%q): %v", query, err)
+		}
+		sqlStr, args, err := chsql.Emit(plan)
+		if err != nil {
+			t.Fatalf("Emit: %v", err)
+		}
+
+		spec.Match(t, c, map[string]string{
+			"sql":  sqlStr,
+			"args": formatArgs(args),
+		})
+	})
+}
+
+func formatArgs(args []any) string {
+	if len(args) == 0 {
+		return "(none)\n"
+	}
+	var b strings.Builder
+	for i, a := range args {
+		fmt.Fprintf(&b, "[%d] %T = %#v\n", i, a, a)
+	}
+	return b.String()
+}

--- a/test/spec/traceql/and_two_attrs.txtar
+++ b/test/spec/traceql/and_two_attrs.txtar
@@ -1,0 +1,8 @@
+-- query.traceql --
+{ resource.service.name = "frontend" && duration > 100ms }
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE ((`ResourceAttributes`[?] = ?) AND (`Duration` > ?))
+-- args --
+[0] string = "service.name"
+[1] string = "frontend"
+[2] int64 = 100000000

--- a/test/spec/traceql/duration_gt.txtar
+++ b/test/spec/traceql/duration_gt.txtar
@@ -1,0 +1,6 @@
+-- query.traceql --
+{ duration > 100ms }
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`Duration` > ?)
+-- args --
+[0] int64 = 100000000

--- a/test/spec/traceql/service_name_eq.txtar
+++ b/test/spec/traceql/service_name_eq.txtar
@@ -1,0 +1,7 @@
+-- query.traceql --
+{ resource.service.name = "frontend" }
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`ResourceAttributes`[?] = ?)
+-- args --
+[0] string = "service.name"
+[1] string = "frontend"

--- a/test/spec/traceql/status_code_ge.txtar
+++ b/test/spec/traceql/status_code_ge.txtar
@@ -1,0 +1,7 @@
+-- query.traceql --
+{ span.http.status_code >= 500 }
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`SpanAttributes`[?] >= ?)
+-- args --
+[0] string = "http.status_code"
+[1] int64 = 500


### PR DESCRIPTION
## Summary
Bootstraps the TraceQL head with the SpansetFilter slice: \`{ <attribute-expr> }\` queries that match spans in otel_traces.

- \`schema.Traces\` + \`DefaultOTelTraces()\` mirroring the OTel-CH traces schema (otel_traces, TraceId, SpanId, ParentSpanId, SpanName, SpanKind, ServiceName, Duration, Timestamp, StatusCode, StatusMessage, SpanAttributes, ResourceAttributes, ScopeAttributes).
- New \`chplan.FieldAccess\` — generalised MapAccess for dotted-path attribute references (\`resource.k8s.pod.name\`, \`span.http.status_code\`). Emitter renders as \`Source[<dotted-key>]\` since OTel-CH stores the dotted form verbatim.
- \`traceql.Lower\` handles RootExpr → Pipeline → SpansetFilter → FieldExpression:
  - \`BinaryOperation\` walks comparison / logical / arithmetic operators.
  - \`Attribute\` resolves intrinsics (duration/name/kind/status/traceID/spanID/parent) to canonical columns; scope-prefixed paths (\`resource.\` → ResourceAttributes, \`span.\` → SpanAttributes).
  - \`Static\` decodes string / int / float / bool / duration literals.

4 TXTAR fixtures: service-name equality, duration comparison, status-code comparison, AND-conjunction.

## Deferred
- Multi-stage pipelines (structural ops `>>` / `>` / `<<` / `<`) → M4.2.
- Aggregate operators (count, sum, avg, max, min) → M4.3.
- Time filters + \`| select(...)\` → M4.4.
- \`TypeKind\`-typed enum literals (\`{ kind = client }\`) — defers; needs Kind enum mapping to OTel-CH's "Client"/"Server"/etc. capitalised strings.

## Test plan
- [x] \`just test\` green
- [x] \`just lint\` clean
- [ ] CI green