### PR TITLE
feat(traceql,chplan,chsql): structural ops > and < (M4.2)

### DIFF
--- a/internal/chplan/structural_join.go
+++ b/internal/chplan/structural_join.go
@@ -1,0 +1,54 @@
+package chplan
+
+// StructuralOp identifies a TraceQL-style spanset relation.
+//
+//	StructuralChild     — `A > B`  : A is the direct parent of B  (return B rows)
+//	StructuralDescendant — `A >> B`: A is an ancestor of B         (return B rows)
+//	StructuralParent    — `A < B`  : A is the direct child of B   (return B rows)
+//	StructuralAncestor  — `A << B` : A is a descendant of B        (return B rows)
+//
+// `>>` and `<<` need recursive CTE / multi-level joins; the seed
+// (M4.2) emits `>` and `<` and rejects the recursive forms with a
+// pointer to the M4.2 follow-up.
+type StructuralOp string
+
+const (
+	StructuralChild      StructuralOp = ">"
+	StructuralParent     StructuralOp = "<"
+	StructuralDescendant StructuralOp = ">>"
+	StructuralAncestor   StructuralOp = "<<"
+)
+
+// StructuralJoin produces the rows from `Right` whose spans satisfy the
+// requested structural relation with a span in `Left`. Both sides
+// produce span rows from otel_traces (or a derived projection thereof);
+// the join key uses TraceID + (Span/Parent)ID columns named in the
+// schema.
+type StructuralJoin struct {
+	Left, Right Node
+	Op          StructuralOp
+
+	TraceIDColumn      string
+	SpanIDColumn       string
+	ParentSpanIDColumn string
+}
+
+func (*StructuralJoin) planNode() {}
+
+func (j *StructuralJoin) Children() []Node { return []Node{j.Left, j.Right} }
+
+func (j *StructuralJoin) Equal(other Node) bool {
+	o, ok := other.(*StructuralJoin)
+	if !ok {
+		return false
+	}
+	if j.Op != o.Op {
+		return false
+	}
+	if j.TraceIDColumn != o.TraceIDColumn ||
+		j.SpanIDColumn != o.SpanIDColumn ||
+		j.ParentSpanIDColumn != o.ParentSpanIDColumn {
+		return false
+	}
+	return j.Left.Equal(o.Left) && j.Right.Equal(o.Right)
+}

--- a/internal/chsql/emit.go
+++ b/internal/chsql/emit.go
@@ -56,6 +56,8 @@ func (e *emitter) emitNode(n chplan.Node) error {
 		return e.emitLimit(v)
 	case *chplan.VectorJoin:
 		return e.emitVectorJoin(v)
+	case *chplan.StructuralJoin:
+		return e.emitStructuralJoin(v)
 	default:
 		return fmt.Errorf("%w: node %T", ErrUnsupported, n)
 	}

--- a/internal/chsql/structural_join.go
+++ b/internal/chsql/structural_join.go
@@ -1,0 +1,50 @@
+package chsql
+
+import (
+	"fmt"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// emitStructuralJoin renders a TraceQL structural relation as an INNER
+// JOIN of two span subqueries. The result projects the right-hand
+// span's columns (TraceQL convention: `A > B` returns the matched B
+// spans).
+//
+//	StructuralChild  (`>`):  L.SpanID = R.ParentSpanID  (R's parent matches L)
+//	StructuralParent (`<`):  L.ParentSpanID = R.SpanID  (R is L's parent)
+//
+// Recursive forms (`>>`, `<<`) need a recursive CTE / multi-level join
+// and surface as ErrUnsupported until the M4.2 follow-up.
+func (e *emitter) emitStructuralJoin(j *chplan.StructuralJoin) error {
+	if j.TraceIDColumn == "" || j.SpanIDColumn == "" || j.ParentSpanIDColumn == "" {
+		return fmt.Errorf("%w: StructuralJoin column names unset", ErrUnsupported)
+	}
+
+	traceCol := quoteIdent(j.TraceIDColumn)
+	spanCol := quoteIdent(j.SpanIDColumn)
+	parentCol := quoteIdent(j.ParentSpanIDColumn)
+
+	var rel string
+	switch j.Op {
+	case chplan.StructuralChild:
+		rel = "L." + spanCol + " = R." + parentCol
+	case chplan.StructuralParent:
+		rel = "L." + parentCol + " = R." + spanCol
+	case chplan.StructuralDescendant, chplan.StructuralAncestor:
+		return fmt.Errorf("%w: structural op %q (recursive form lands with M4.2 follow-up)", ErrUnsupported, j.Op)
+	default:
+		return fmt.Errorf("%w: structural op %q", ErrUnsupported, j.Op)
+	}
+
+	e.b.WriteString("SELECT R.* FROM ")
+	if err := e.emitSubquery(j.Left); err != nil {
+		return err
+	}
+	e.b.WriteString(" AS L INNER JOIN ")
+	if err := e.emitSubquery(j.Right); err != nil {
+		return err
+	}
+	fmt.Fprintf(&e.b, " AS R ON L.%s = R.%s AND %s", traceCol, traceCol, rel)
+	return nil
+}

--- a/internal/traceql/lower.go
+++ b/internal/traceql/lower.go
@@ -34,10 +34,85 @@ func Lower(expr *traceql.RootExpr, s schema.Traces) (chplan.Node, error) {
 	}
 
 	first := expr.Pipeline.Elements[0]
-	if v, ok := first.(*traceql.SpansetFilter); ok {
+	return lowerPipelineElement(first, s)
+}
+
+// lowerPipelineElement dispatches a single TraceQL pipeline element to
+// its corresponding lowering routine. Currently SpansetFilter and
+// SpansetOperation; aggregates / select / scalar filters defer.
+func lowerPipelineElement(elem traceql.PipelineElement, s schema.Traces) (chplan.Node, error) {
+	switch v := elem.(type) {
+	case *traceql.SpansetFilter:
 		return lowerSpansetFilter(v, s)
+	case traceql.SpansetOperation:
+		return lowerSpansetOperation(&v, s)
+	case *traceql.SpansetOperation:
+		return lowerSpansetOperation(v, s)
 	}
-	return nil, fmt.Errorf("traceql: pipeline element %T is not yet supported", first)
+	return nil, fmt.Errorf("traceql: pipeline element %T is not yet supported", elem)
+}
+
+// lowerSpansetOperation handles structural relations (`A > B`, `A < B`)
+// and set operations (`A && B`, `A || B`). The seed (M4.2) covers
+// direct-parent / direct-child structural ops; recursive forms (`>>`,
+// `<<`) and set ops defer.
+func lowerSpansetOperation(op *traceql.SpansetOperation, s schema.Traces) (chplan.Node, error) {
+	left, err := lowerSpansetExpr(op.LHS, s)
+	if err != nil {
+		return nil, err
+	}
+	right, err := lowerSpansetExpr(op.RHS, s)
+	if err != nil {
+		return nil, err
+	}
+
+	relation, err := mapStructuralOp(op.Op)
+	if err != nil {
+		return nil, err
+	}
+	return &chplan.StructuralJoin{
+		Left:               left,
+		Right:              right,
+		Op:                 relation,
+		TraceIDColumn:      s.TraceIDColumn,
+		SpanIDColumn:       s.SpanIDColumn,
+		ParentSpanIDColumn: s.ParentSpanIDColumn,
+	}, nil
+}
+
+// lowerSpansetExpr lowers a TraceQL SpansetExpression (the LHS/RHS of
+// a SpansetOperation). Currently SpansetFilter; nested operations land
+// once `>>` / `<<` recursive support arrives.
+func lowerSpansetExpr(e traceql.SpansetExpression, s schema.Traces) (chplan.Node, error) {
+	switch v := e.(type) {
+	case *traceql.SpansetFilter:
+		return lowerSpansetFilter(v, s)
+	case *traceql.SpansetOperation:
+		return lowerSpansetOperation(v, s)
+	case traceql.SpansetOperation:
+		return lowerSpansetOperation(&v, s)
+	}
+	return nil, fmt.Errorf("traceql: spanset expression %T is not yet supported", e)
+}
+
+// mapStructuralOp translates Tempo's structural Operator enum to the
+// chplan.StructuralOp this emitter understands.
+func mapStructuralOp(op traceql.Operator) (chplan.StructuralOp, error) {
+	switch op {
+	case traceql.OpSpansetChild:
+		return chplan.StructuralChild, nil
+	case traceql.OpSpansetParent:
+		return chplan.StructuralParent, nil
+	case traceql.OpSpansetDescendant:
+		return chplan.StructuralDescendant, nil
+	case traceql.OpSpansetAncestor:
+		return chplan.StructuralAncestor, nil
+	case traceql.OpSpansetAnd, traceql.OpSpansetUnion, traceql.OpSpansetSibling,
+		traceql.OpSpansetNotChild, traceql.OpSpansetNotParent, traceql.OpSpansetNotSibling,
+		traceql.OpSpansetNotAncestor, traceql.OpSpansetNotDescendant:
+		return "", fmt.Errorf("traceql: spanset op %s is not yet supported (set / sibling ops land in M4.2 follow-ups)", op)
+	}
+	return "", fmt.Errorf("traceql: spanset op %s is not a structural relation", op)
 }
 
 // lowerSpansetFilter turns `{ <field-expr> }` into Scan + Filter on

--- a/test/spec/traceql/child_of.txtar
+++ b/test/spec/traceql/child_of.txtar
@@ -1,0 +1,9 @@
+-- query.traceql --
+{ resource.service.name = "api" } < { resource.service.name = "frontend" }
+-- sql --
+SELECT R.* FROM (SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`ResourceAttributes`[?] = ?)) AS L INNER JOIN (SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`ResourceAttributes`[?] = ?)) AS R ON L.`TraceId` = R.`TraceId` AND L.`ParentSpanId` = R.`SpanId`
+-- args --
+[0] string = "service.name"
+[1] string = "api"
+[2] string = "service.name"
+[3] string = "frontend"

--- a/test/spec/traceql/parent_of.txtar
+++ b/test/spec/traceql/parent_of.txtar
@@ -1,0 +1,9 @@
+-- query.traceql --
+{ resource.service.name = "frontend" } > { resource.service.name = "api" }
+-- sql --
+SELECT R.* FROM (SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`ResourceAttributes`[?] = ?)) AS L INNER JOIN (SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`ResourceAttributes`[?] = ?)) AS R ON L.`TraceId` = R.`TraceId` AND L.`SpanId` = R.`ParentSpanId`
+-- args --
+[0] string = "service.name"
+[1] string = "frontend"
+[2] string = "service.name"
+[3] string = "api"


### PR DESCRIPTION
## Summary
TraceQL's \`A > B\` (A is direct parent of B) and \`A < B\` (A is direct child of B) lower to a new \`chplan.StructuralJoin\` node:

\`\`\`sql
SELECT R.*
FROM (<A>) AS L
INNER JOIN (<B>) AS R
ON L.TraceId = R.TraceId AND <relation>
\`\`\`

…where \`<relation>\` is \`L.SpanId = R.ParentSpanId\` for \`>\` (R's parent matches L) and \`L.ParentSpanId = R.SpanId\` for \`<\`. TraceQL convention returns the right-hand spans matching the relation.

## Deferred
- Recursive forms (\`>>\` ancestor, \`<<\` descendant) — need a recursive CTE / multi-level join.
- Set ops (\`&&\`, \`||\`) and sibling ops (\`~\`).

## Test plan
- [x] \`just test\` green (2 new fixtures: parent_of, child_of)
- [x] \`just lint\` clean
- [ ] CI green