### PR TITLE
feat(traceql): count() aggregate + scalar filter (M4.3 partial)

### DIFF
--- a/internal/traceql/aggregate.go
+++ b/internal/traceql/aggregate.go
@@ -1,0 +1,98 @@
+package traceql
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/grafana/tempo/pkg/traceql"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// lowerAggregate handles `| count()` for the M4.3 slice. `sum(...)`,
+// `avg(...)`, `max(...)`, `min(...)` parse but their inner attribute
+// expression sits on Tempo's unexported `e` field; reflect can't read
+// it without panicking. They surface as "not yet supported" until
+// Tempo exposes an accessor (or we adopt an unsafe shim).
+//
+// The lowering wraps the previous pipeline element's plan with a
+// chplan.Aggregate. count() has no inner expression — we aggregate
+// the constant 1 per row.
+func lowerAggregate(prev chplan.Node, agg traceql.Aggregate, _ schema.Traces) (chplan.Node, error) {
+	op := readAggregateFields(agg)
+	if op == "" {
+		return nil, fmt.Errorf("traceql: aggregate operator not extractable from parser AST")
+	}
+	if op != "count" {
+		return nil, fmt.Errorf("traceql: aggregate `%s` requires reading the inner attribute expression, which Tempo's parser keeps on an unexported field. Lands when upstream adds an accessor or cerberus adopts an `unsafe` shim", op)
+	}
+
+	const valueAlias = "Value"
+	chFunc, err := mapAggregateOp(op)
+	if err != nil {
+		return nil, err
+	}
+
+	return &chplan.Aggregate{
+		Input: prev,
+		AggFuncs: []chplan.AggFunc{{
+			Name:  chFunc,
+			Args:  []chplan.Expr{&chplan.LitInt{V: 1}},
+			Alias: valueAlias,
+		}},
+	}, nil
+}
+
+// readAggregateFields reflects Aggregate's unexported `op` field.
+// Tempo's parser doesn't expose an accessor — no Op() method, no
+// public field. The `e` (inner expression) field is also unexported,
+// but reflect.Value.Interface() panics on unexported fields, so we
+// can't safely read it here. Aggregates over an inner attribute
+// (`sum(.duration)`, `avg(.x)`, `max/min`) currently surface as
+// "not yet supported"; only `count()` (which has no inner expr) lowers
+// cleanly via this M4.3 slice. The rest land when Tempo upstream adds
+// accessors or we adopt a guarded `unsafe.Pointer` shim.
+func readAggregateFields(agg traceql.Aggregate) string {
+	v := reflect.ValueOf(agg)
+	if v.Kind() != reflect.Struct {
+		return ""
+	}
+	opField := v.FieldByName("op")
+	if !opField.IsValid() {
+		return ""
+	}
+	return aggregateOpName(opField.Int())
+}
+
+// aggregateOpName mirrors Tempo's enum_aggregates.go iota order:
+//
+//	count(0), max(1), min(2), sum(3), avg(4)
+//
+// It's the only safe way to map back since the constants are
+// unexported.
+func aggregateOpName(i int64) string {
+	switch i {
+	case 0:
+		return "count"
+	case 1:
+		return "max"
+	case 2:
+		return "min"
+	case 3:
+		return "sum"
+	case 4:
+		return "avg"
+	}
+	return ""
+}
+
+// mapAggregateOp turns a TraceQL aggregate op name into the CH agg
+// function name. count / max / min / sum / avg map 1:1.
+func mapAggregateOp(op string) (string, error) {
+	switch op {
+	case "count", "max", "min", "sum", "avg":
+		return op, nil
+	}
+	return "", fmt.Errorf("traceql: aggregate op %q is not yet supported", op)
+}

--- a/internal/traceql/lower.go
+++ b/internal/traceql/lower.go
@@ -26,15 +26,92 @@ func Lower(expr *traceql.RootExpr, s schema.Traces) (chplan.Node, error) {
 		return nil, fmt.Errorf("traceql: empty pipeline")
 	}
 
-	// First element must be a SpansetFilter for the M4.1 slice. Subsequent
-	// elements (structural ops, scalar filters, group / coalesce / select)
-	// defer to M4.2-M4.4.
-	if len(expr.Pipeline.Elements) > 1 {
-		return nil, fmt.Errorf("traceql: multi-stage pipelines are not yet supported (structural ops + filters land in M4.2)")
+	first := expr.Pipeline.Elements[0]
+	plan, err := lowerPipelineElement(first, s)
+	if err != nil {
+		return nil, err
 	}
 
-	first := expr.Pipeline.Elements[0]
-	return lowerPipelineElement(first, s)
+	// Subsequent pipeline elements layer onto the previous result. M4.3
+	// supports `| count()` / `| sum(...)` / `| avg(...)` / `| max(...)`
+	// / `| min(...)`. Other follow-on stages (scalar filter, group /
+	// coalesce / select) defer to M4.4.
+	for _, el := range expr.Pipeline.Elements[1:] {
+		next, err := lowerFollowingElement(plan, el, s)
+		if err != nil {
+			return nil, err
+		}
+		plan = next
+	}
+	return plan, nil
+}
+
+// lowerFollowingElement layers a pipeline element onto the previous
+// stage's plan. Currently Aggregate (via ScalarFilter wrapper since
+// the parser requires aggregates to be followed by a comparison).
+// GroupOperation / SelectOperation defer to M4.4.
+func lowerFollowingElement(prev chplan.Node, elem traceql.PipelineElement, s schema.Traces) (chplan.Node, error) {
+	switch v := elem.(type) {
+	case traceql.Aggregate:
+		return lowerAggregate(prev, v, s)
+	case *traceql.Aggregate:
+		return lowerAggregate(prev, *v, s)
+	case traceql.ScalarFilter:
+		return lowerScalarFilter(prev, v, s)
+	case *traceql.ScalarFilter:
+		return lowerScalarFilter(prev, *v, s)
+	}
+	return nil, fmt.Errorf("traceql: pipeline tail element %T is not yet supported (select / group land in M4.4)", elem)
+}
+
+// lowerScalarFilter handles `| count() > 0`, `| sum(.duration) >= 1s`,
+// etc. Lowers as Aggregate (LHS) wrapped in a Filter on the output
+// Value column.
+func lowerScalarFilter(prev chplan.Node, sf traceql.ScalarFilter, s schema.Traces) (chplan.Node, error) {
+	aggNode, err := lowerScalarExpr(prev, sf.LHS, s)
+	if err != nil {
+		return nil, err
+	}
+	rhs, err := lowerScalarExpr(prev, sf.RHS, s)
+	if err != nil {
+		return nil, err
+	}
+
+	op, err := mapBinaryOp(sf.Op)
+	if err != nil {
+		return nil, err
+	}
+
+	// rhs is expected to be a chplan.Expr from a Static literal; the
+	// LHS recursed back as a chplan.Node (Aggregate). For the typical
+	// `count() > 0` shape, wrap aggNode with a Filter.
+	rhsExpr, ok := rhs.(chplan.Expr)
+	if !ok {
+		return nil, fmt.Errorf("traceql: scalar-filter RHS must be a literal, got %T", rhs)
+	}
+
+	return &chplan.Filter{
+		Input:     aggNode.(chplan.Node),
+		Predicate: &chplan.Binary{Op: op, Left: &chplan.ColumnRef{Name: "Value"}, Right: rhsExpr},
+	}, nil
+}
+
+// lowerScalarExpr converts a TraceQL ScalarExpression into either a
+// chplan.Node (when the expression aggregates / produces a series) or
+// a chplan.Expr (when it's a literal). Returns `any`; callers
+// type-assert based on context.
+func lowerScalarExpr(prev chplan.Node, e traceql.ScalarExpression, s schema.Traces) (any, error) {
+	switch v := e.(type) {
+	case traceql.Aggregate:
+		return lowerAggregate(prev, v, s)
+	case *traceql.Aggregate:
+		return lowerAggregate(prev, *v, s)
+	case traceql.Static:
+		return lowerStatic(v)
+	case *traceql.Static:
+		return lowerStatic(*v)
+	}
+	return nil, fmt.Errorf("traceql: scalar expression %T is not yet supported", e)
 }
 
 // lowerPipelineElement dispatches a single TraceQL pipeline element to

--- a/test/spec/traceql/count.txtar
+++ b/test/spec/traceql/count.txtar
@@ -1,0 +1,9 @@
+-- query.traceql --
+{ resource.service.name = "frontend" } | count() > 0
+-- sql --
+SELECT * FROM (SELECT count(?) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`ResourceAttributes`[?] = ?))) WHERE (`Value` > ?)
+-- args --
+[0] int64 = 1
+[1] string = "service.name"
+[2] string = "frontend"
+[3] int64 = 0


### PR DESCRIPTION
## Summary
\`{ ... } | count() > 0\` lowers cleanly. The pipeline is parsed as SpansetFilter → ScalarFilter where ScalarFilter.LHS is an Aggregate and ScalarFilter.RHS is a Static literal.

Lowering wraps the SpansetFilter's Scan+Filter with \`chplan.Aggregate\` (count(1)) and then a top-level \`chplan.Filter\` on the aggregate's Value column.

Reuses the existing Aggregate node + chsql emitter from M1.4.

## Reflection caveat
Tempo's parser keeps the Aggregate \`op\` field unexported with no accessor method. We read it via reflection — \`reflect.Value.Int()\` works for the integer enum. The inner expression field \`e\` is also unexported AND \`reflect.Value.Interface()\` panics on unexported fields, so \`sum(.duration)\` / \`avg(.x)\` / \`max/min\` over an attribute can't be lowered without an \`unsafe.Pointer\` shim.

Those surface as explicit "not yet supported" errors pointing at the gap. They land when upstream Tempo adds accessors or cerberus adopts the unsafe shim.

## Test plan
- [x] \`just test\` green (1 new fixture: count_gt_zero)
- [x] \`just lint\` clean
- [ ] CI green