### PR TITLE
docs(release): CHANGELOG + README for v1.0.0-RC1 (M5.1/M5.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,60 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 ### Added
 
-- Three-phase RC roadmap to v1.0.0 (`docs/roadmap.md`).
-- AI-agent context (`CLAUDE.md`, `AGENTS.md`, three `.claude/skills/`).
-- Engineering hygiene: `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `.github/CODEOWNERS`, PR template.
-- Release plumbing: `.goreleaser.yml`, `Dockerfile` (distroless), `.github/workflows/release.yml`.
+- Five-phase RC roadmap (RC1–RC5) plus RC6 sqlbuilder refactor in `docs/roadmap.md`.
 
-### Changed
+## [v1.0.0-RC1] — Full PromQL / LogQL / TraceQL slice
 
-### Fixed
+The first release candidate. PromQL is functionally complete against the `prometheus/compliance` suite (informational baseline tracked); LogQL covers stream selectors, label filters, the metric form, and aggregations; TraceQL covers spanset filters, structural relations, and `count()`. The Prom HTTP head is fully wired into Grafana; Loki's `query` / `query_range` work end-to-end.
+
+### Added
+
+#### PromQL (M1.1 – M1.7)
+
+- Real `RangeWindow` SQL emission via the promshim-clickhouse windowed-array idiom (`groupArray` + `arraySort` + `arrayFilter` + `arrayPopBack/Front` for counter-reset deltas). [#40]
+- `BinaryExpr` lowering: scalar/vector arithmetic and pow / mod. [#41]
+- Instant-vector functions: `abs`, `ceil`, `floor`, `round`, `sqrt`, `exp`, `ln`, `log2`, `log10`, `sgn`. [#42]
+- Aggregation completeness: `without (...)` (new `chplan.MapWithoutKeys`), `stddev`, `stdvar`, `group`, parameterised `quantile(phi, ...)`. [#43]
+- `offset` and `@` modifiers thread through `RangeWindow.Offset` / `End` plus a `Timestamp <= anchor` predicate on instant-vector queries. [#44]
+- Vector matching: default + `on(...)` + `ignoring(...)` via the new `chplan.VectorJoin` (per-series argMax + INNER JOIN). [#45]
+- Comparison ops + `bool` modifier (Filter shape vs `toFloat64(...)` Project). [#48]
+- Clamp family and 2-arg `round(v, to_nearest)`. [#49]
+
+#### Prom HTTP API (M2.1 – M2.7)
+
+- Real per-step bucketing in `/api/v1/query_range` with 5-min lookback. [#50]
+- Aggregate result shaping — Sample-shape Project on top of `chplan.Aggregate` so `sum by (job)` etc. flow through the existing chclient decoder. [#52]
+- `/api/v1/labels`, `/api/v1/label/{name}/values`, `/api/v1/series` with UNION ALL across metric tables. [#51]
+- `/api/v1/metadata` sourcing `MetricDescription` + `MetricUnit` from each table. [#53]
+- `X-Prometheus-API-Version` + `X-Cerberus-CH-Millis` debug headers via a header-stamping middleware that times each CH call into a request-scoped counter; `match[]` selector support on `/labels` and `/label/.../values`. [#54]
+
+#### LogQL (M3.1 – M3.5)
+
+- `schema.Logs` + `chplan.LineContent`; stream selectors (`{job="api"}`) and the line-filter family (`|=` / `!=` / `|~` / `!~`) with chained-filter AND-folding and `or`-disjunction. [#55]
+- Label filters (`| label="val"` / `| label=~"r"`); `BinaryLabelFilter` and `LineFilterLabelFilter` share the same `*labels.Matcher`-based lowering helper. [#58]
+- Metric form: `rate({...}[5m])`, `count_over_time(...)`, `bytes_rate(...)`, `bytes_over_time(...)`. New `log_rate` emitter binds `range_seconds` via a `?` placeholder rather than Sprintf'ing it inline. [#61]
+- Aggregations: `sum(rate(...))`, `avg by (job) (count_over_time(...))`, `sum without (pod) (...)`, with stddev / stdvar / group / quantile parity to PromQL. [#62]
+- Loki HTTP `query` + `query_range` handlers; metric queries return Prom-style matrix/vector, log queries return Loki "streams" shape. [#63]
+
+#### TraceQL (M4.1 – M4.3)
+
+- `schema.Traces` + `chplan.FieldAccess` for dotted-path attribute references; SpansetFilter with intrinsic resolution (`duration`, `name`, `kind`, `status`, `traceID`, `spanID`, `parent`) and scope-prefixed paths (`resource.` → ResourceAttributes, `span.` → SpanAttributes). [#64]
+- Direct structural ops `>` (parent of) and `<` (child of) via `chplan.StructuralJoin` rendering an INNER JOIN of two span subqueries on `(TraceId, ParentSpanId)`. [#65]
+- `| count() > 0` aggregate + scalar-filter wrapping; reuses the M1.4 `chplan.Aggregate` shape. [#66]
+
+#### Engineering / CI
+
+- Required-status checks: `check`, `lint`, `dashboard` (full-stack k3d + cerberus + Grafana + Playwright smoke). `enforce_admins: true`; `gh pr merge --admin` is forbidden. [#56, #59, #60]
+- Compliance harness drops the `pull_request` trigger until M6; runs nightly + on `main` push as informational baseline. [#56]
+- RC6 roadmap entry with hard rule: no `fmt.Sprintf` (or string concatenation) for ClickHouse SQL going forward; existing emitter Sprintf is grandfathered until R6.1–R6.10 ports it through `huandu/go-sqlbuilder`. [#57]
+
+### Deferred to RC2
+
+- PromQL: subqueries, `histogram_quantile` over native histograms, `topk` / `bottomk` / `count_values` (output-shape changes).
+- LogQL: parser stages (`| json`, `| logfmt`, `| regexp`, `| pattern`); `unwrap`-based ops; `tail`; `index/stats`.
+- TraceQL: recursive structural ops `>>` / `<<`, set ops, sibling ops; `sum/avg/max/min` over inner attributes (Tempo's parser keeps the inner expression on an unexported field — needs an upstream accessor); `| select(...)`.
+- Loki HTTP: `/labels`, `/label/.../values`, `/series` (gated on RC6 R6.1's sqlbuilder integration so the new SQL is type-safe), stream-aware row decoder, `tail`.
+- Tempo HTTP: `/api/search`, `/api/traces/<id>`, `/api/search/tags`, `/api/search/tag/<n>/values`.
 
 ## [v0.1.0] — Seed
 
@@ -28,5 +74,6 @@ First tagged release. Closes the seed series (PR1–PR7 + admin + roadmap):
 - CI: two-job workflow (`check` + `lint`), commitlint relaxed for Dependabot, markdownlint, mutation testing (gremlins) on a nightly cron.
 - Branch protection on `main`: required checks, linear history, no force pushes / deletions.
 
-[Unreleased]: https://github.com/tsouza/cerberus/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/tsouza/cerberus/compare/v1.0.0-RC1...HEAD
+[v1.0.0-RC1]: https://github.com/tsouza/cerberus/releases/tag/v1.0.0-RC1
 [v0.1.0]: https://github.com/tsouza/cerberus/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ ClickHouse is a great single store for all three signals. The only thing missing
 
 ## Status
 
-> 🚧 **v0.1 seed in progress** — the architecture, build, test, and CI surface are landing; PromQL works end-to-end as a vertical slice; LogQL and TraceQL are scaffolded for symmetry but not yet wired through.
+> 🟢 **`v1.0.0-RC1` — release candidate.** PromQL is functionally complete (`prometheus/compliance` informational baseline tracked, gates at M6); LogQL covers stream selectors, label filters, the metric form, and aggregations; TraceQL covers spanset filters, structural relations (`>`, `<`), and `count()`. The Prom HTTP head is fully wired into Grafana; Loki's `query` / `query_range` work end-to-end. See [`CHANGELOG.md`](CHANGELOG.md) for the full v1.0.0-RC1 entry and the deferral list for RC2.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
First release-candidate documentation:

- \`CHANGELOG.md\`: full v1.0.0-RC1 entry covering M1.1 → M1.7, M2.1 → M2.7, M3.1 → M3.5, M4.1 → M4.3, plus the engineering changes (branch protection, --admin ban, RC6 sqlbuilder roadmap, compliance trigger drop). Each item links its PR.
- \`README.md\`: status block flips from \"v0.1 seed in progress\" → \"v1.0.0-RC1 — release candidate\" with one-line scope summary and link back to the changelog.

The deferral list for RC2 enumerates the known gaps (subqueries, native-histogram quantiles, output-shape-changing aggregates, LogQL parsers, recursive TraceQL structural ops + sum/avg/max/min over inner attributes blocked on Tempo's unexported AST, `| select(...)`, Loki metadata endpoints gated on RC6 R6.1, Tempo search/traces).

## Tag
After this lands: \`git tag v1.0.0-RC1 && git push --tags\` triggers \`release.yml\` → goreleaser cuts the multi-arch binaries + Docker image at \`ghcr.io/tsouza/cerberus:v1.0.0-RC1\`. Maintainer step (the agent doesn't push tags).

## Test plan
- [x] \`just test\` green
- [x] \`just lint\` clean
- [ ] CI green