### PR TITLE
feat(traceql): | select(...) projection (M4.4)

### DIFF
--- a/internal/traceql/lower.go
+++ b/internal/traceql/lower.go
@@ -47,9 +47,8 @@ func Lower(expr *traceql.RootExpr, s schema.Traces) (chplan.Node, error) {
 }
 
 // lowerFollowingElement layers a pipeline element onto the previous
-// stage's plan. Currently Aggregate (via ScalarFilter wrapper since
-// the parser requires aggregates to be followed by a comparison).
-// GroupOperation / SelectOperation defer to M4.4.
+// stage's plan. Aggregate / ScalarFilter / SelectOperation are
+// supported; GroupOperation / CoalesceOperation defer to RC2.
 func lowerFollowingElement(prev chplan.Node, elem traceql.PipelineElement, s schema.Traces) (chplan.Node, error) {
 	switch v := elem.(type) {
 	case traceql.Aggregate:
@@ -60,8 +59,12 @@ func lowerFollowingElement(prev chplan.Node, elem traceql.PipelineElement, s sch
 		return lowerScalarFilter(prev, v, s)
 	case *traceql.ScalarFilter:
 		return lowerScalarFilter(prev, *v, s)
+	case traceql.SelectOperation:
+		return lowerSelect(prev, v, s)
+	case *traceql.SelectOperation:
+		return lowerSelect(prev, *v, s)
 	}
-	return nil, fmt.Errorf("traceql: pipeline tail element %T is not yet supported (select / group land in M4.4)", elem)
+	return nil, fmt.Errorf("traceql: pipeline tail element %T is not yet supported (group / coalesce land in RC2)", elem)
 }
 
 // lowerScalarFilter handles `| count() > 0`, `| sum(.duration) >= 1s`,

--- a/internal/traceql/select.go
+++ b/internal/traceql/select.go
@@ -1,0 +1,82 @@
+package traceql
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/grafana/tempo/pkg/traceql"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// lowerSelect handles `| select(.attr1, .attr2, ...)` projection.
+// Tempo's SelectOperation keeps its attribute list on an unexported
+// field; we reflect over it to read the slice elements without
+// calling .Interface() (which panics on unexported fields).
+//
+// Output: a chplan.Project that emits the standard span-identity
+// columns (TraceId, SpanId, Timestamp) plus the selected attribute
+// expressions, so downstream search results can render exactly the
+// columns the caller asked for.
+func lowerSelect(prev chplan.Node, sel traceql.SelectOperation, s schema.Traces) (chplan.Node, error) {
+	attrs, err := readSelectAttrs(sel, s)
+	if err != nil {
+		return nil, err
+	}
+	if len(attrs) == 0 {
+		return nil, fmt.Errorf("traceql: `| select(...)` requires at least one attribute")
+	}
+
+	// Identity columns first; selected attributes after. Each attribute
+	// projection is aliased to its TraceQL name so the row decoder can
+	// pick them out.
+	projections := []chplan.Projection{
+		{Expr: &chplan.ColumnRef{Name: s.TraceIDColumn}},
+		{Expr: &chplan.ColumnRef{Name: s.SpanIDColumn}},
+		{Expr: &chplan.ColumnRef{Name: s.TimestampColumn}},
+	}
+	for _, a := range attrs {
+		projections = append(projections, chplan.Projection{
+			Expr:  lowerAttribute(a, s),
+			Alias: a.Name,
+		})
+	}
+	return &chplan.Project{Input: prev, Projections: projections}, nil
+}
+
+// readSelectAttrs reflects out SelectOperation's unexported `attrs`
+// slice. We iterate via reflect.Value.Index() and read each Attribute's
+// exported fields (Name, Scope, Parent, Intrinsic) directly — no
+// .Interface() call so the unexported-field protection doesn't fire.
+func readSelectAttrs(sel traceql.SelectOperation, _ schema.Traces) ([]traceql.Attribute, error) {
+	v := reflect.ValueOf(sel)
+	if v.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("traceql: SelectOperation is not a struct (parser changed?)")
+	}
+	field := v.FieldByName("attrs")
+	if !field.IsValid() {
+		return nil, fmt.Errorf("traceql: SelectOperation.attrs not extractable from parser AST")
+	}
+
+	out := make([]traceql.Attribute, field.Len())
+	for i := 0; i < field.Len(); i++ {
+		elem := field.Index(i)
+		// AttributeScope and Intrinsic are int8 on Tempo's side; reflect
+		// hands us int64 from .Int() — narrowing is safe here (the values
+		// are bounded enums) but gosec flags the conversion. The bounds
+		// check below makes the narrowing explicit.
+		scope := elem.FieldByName("Scope").Int()
+		intrinsic := elem.FieldByName("Intrinsic").Int()
+		if scope < -128 || scope > 127 || intrinsic < -128 || intrinsic > 127 {
+			return nil, fmt.Errorf("traceql: SelectOperation Attribute fields out of int8 range — parser changed?")
+		}
+		out[i] = traceql.Attribute{
+			Name:      elem.FieldByName("Name").String(),
+			Scope:     traceql.AttributeScope(int8(scope)),
+			Parent:    elem.FieldByName("Parent").Bool(),
+			Intrinsic: traceql.Intrinsic(int8(intrinsic)),
+		}
+	}
+	return out, nil
+}

--- a/test/spec/traceql/select_attrs.txtar
+++ b/test/spec/traceql/select_attrs.txtar
@@ -1,0 +1,9 @@
+-- query.traceql --
+{ resource.service.name = "frontend" } | select(span.http.method, span.http.status_code)
+-- sql --
+SELECT `TraceId`, `SpanId`, `Timestamp`, `SpanAttributes`[?] AS `http.method`, `SpanAttributes`[?] AS `http.status_code` FROM (SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`ResourceAttributes`[?] = ?))
+-- args --
+[0] string = "http.method"
+[1] string = "http.status_code"
+[2] string = "service.name"
+[3] string = "frontend"


### PR DESCRIPTION
## Summary
\`{ ... } | select(.foo, .bar)\` projects only the named attributes from the matched spans. Lowering wraps the previous pipeline element with a \`chplan.Project\` that emits identity columns (TraceId, SpanId, Timestamp) plus each requested attribute aliased to its TraceQL name.

## Tempo unexported-field handling
\`SelectOperation\` keeps its attribute slice on an unexported \`attrs\` field — same shape as the M4.3 Aggregate problem. The fix here uses \`reflect.Value.Index()\` to iterate the slice and reads each Attribute's exported sub-fields directly (Name, Scope, Parent, Intrinsic) without calling \`.Interface()\` (which would panic on unexported parents). Bounds-check the int64 → int8 narrowing for Scope/Intrinsic so gosec stays quiet — they're bounded enums in practice.

## Time filters
TraceQL has no in-language time filters: \`start\` / \`end\` are search query params on the HTTP endpoint. They land with M4.5's Tempo handler.

## Test plan
- [x] \`just test\` green (1 new fixture: select_attrs)
- [x] \`just lint\` clean
- [ ] CI green