### PR TITLE
test(traceql): expand TXTAR corpus from 8 to 26 fixtures (RC1)

### DIFF
--- a/test/spec/traceql/and_or_combined.txtar
+++ b/test/spec/traceql/and_or_combined.txtar
@@ -1,0 +1,10 @@
+-- query.traceql --
+{ resource.service.name = "frontend" && (duration > 100ms || span.http.status_code >= 500) }
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE ((`ResourceAttributes`[?] = ?) AND ((`Duration` > ?) OR (`SpanAttributes`[?] >= ?)))
+-- args --
+[0] string = "service.name"
+[1] string = "frontend"
+[2] int64 = 100000000
+[3] string = "http.status_code"
+[4] int64 = 500

--- a/test/spec/traceql/bool_attr.txtar
+++ b/test/spec/traceql/bool_attr.txtar
@@ -1,0 +1,7 @@
+-- query.traceql --
+{ span.cache.hit = true }
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`SpanAttributes`[?] = ?)
+-- args --
+[0] string = "cache.hit"
+[1] bool = true

--- a/test/spec/traceql/count_ge_threshold.txtar
+++ b/test/spec/traceql/count_ge_threshold.txtar
@@ -1,0 +1,9 @@
+-- query.traceql --
+{ resource.service.name = "frontend" } | count() >= 5
+-- sql --
+SELECT * FROM (SELECT count(?) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`ResourceAttributes`[?] = ?))) WHERE (`Value` >= ?)
+-- args --
+[0] int64 = 1
+[1] string = "service.name"
+[2] string = "frontend"
+[3] int64 = 5

--- a/test/spec/traceql/float_attr.txtar
+++ b/test/spec/traceql/float_attr.txtar
@@ -1,0 +1,7 @@
+-- query.traceql --
+{ span.cpu.usage > 0.5 }
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`SpanAttributes`[?] > ?)
+-- args --
+[0] string = "cpu.usage"
+[1] float64 = 0.5

--- a/test/spec/traceql/http_status_int.txtar
+++ b/test/spec/traceql/http_status_int.txtar
@@ -1,0 +1,7 @@
+-- query.traceql --
+{ span.http.status_code >= 500 }
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`SpanAttributes`[?] >= ?)
+-- args --
+[0] string = "http.status_code"
+[1] int64 = 500

--- a/test/spec/traceql/kind_intrinsic.txtar
+++ b/test/spec/traceql/kind_intrinsic.txtar
@@ -1,0 +1,6 @@
+-- query.traceql --
+{ kind = "client" }
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`SpanKind` = ?)
+-- args --
+[0] string = "client"

--- a/test/spec/traceql/name_intrinsic.txtar
+++ b/test/spec/traceql/name_intrinsic.txtar
@@ -1,0 +1,6 @@
+-- query.traceql --
+{ name = "GET /api/users" }
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`SpanName` = ?)
+-- args --
+[0] string = "GET /api/users"

--- a/test/spec/traceql/not_eq_attr.txtar
+++ b/test/spec/traceql/not_eq_attr.txtar
@@ -1,0 +1,7 @@
+-- query.traceql --
+{ resource.service.name != "backend" }
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`ResourceAttributes`[?] != ?)
+-- args --
+[0] string = "service.name"
+[1] string = "backend"

--- a/test/spec/traceql/not_regex_attr.txtar
+++ b/test/spec/traceql/not_regex_attr.txtar
@@ -1,0 +1,7 @@
+-- query.traceql --
+{ resource.service.name !~ "back.*" }
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE NOT match(`ResourceAttributes`[?], ?)
+-- args --
+[0] string = "service.name"
+[1] string = "back.*"

--- a/test/spec/traceql/or_two_attrs.txtar
+++ b/test/spec/traceql/or_two_attrs.txtar
@@ -1,0 +1,8 @@
+-- query.traceql --
+{ resource.service.name = "frontend" || duration > 100ms }
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE ((`ResourceAttributes`[?] = ?) OR (`Duration` > ?))
+-- args --
+[0] string = "service.name"
+[1] string = "frontend"
+[2] int64 = 100000000

--- a/test/spec/traceql/parent_intrinsic.txtar
+++ b/test/spec/traceql/parent_intrinsic.txtar
@@ -1,0 +1,6 @@
+-- query.traceql --
+{ parent = "fedcba9876543210" }
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`ParentSpanId` = ?)
+-- args --
+[0] string = "fedcba9876543210"

--- a/test/spec/traceql/regex_attr.txtar
+++ b/test/spec/traceql/regex_attr.txtar
@@ -1,0 +1,7 @@
+-- query.traceql --
+{ resource.service.name =~ "front.*" }
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE match(`ResourceAttributes`[?], ?)
+-- args --
+[0] string = "service.name"
+[1] string = "front.*"

--- a/test/spec/traceql/select_resource_attrs.txtar
+++ b/test/spec/traceql/select_resource_attrs.txtar
@@ -1,0 +1,9 @@
+-- query.traceql --
+{ resource.service.name = "frontend" } | select(resource.service.namespace, resource.k8s.cluster.name)
+-- sql --
+SELECT `TraceId`, `SpanId`, `Timestamp`, `ResourceAttributes`[?] AS `service.namespace`, `ResourceAttributes`[?] AS `k8s.cluster.name` FROM (SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`ResourceAttributes`[?] = ?))
+-- args --
+[0] string = "service.namespace"
+[1] string = "k8s.cluster.name"
+[2] string = "service.name"
+[3] string = "frontend"

--- a/test/spec/traceql/span_attr_default.txtar
+++ b/test/spec/traceql/span_attr_default.txtar
@@ -1,0 +1,7 @@
+-- query.traceql --
+{ .http.method = "GET" }
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`SpanAttributes`[?] = ?)
+-- args --
+[0] string = "http.method"
+[1] string = "GET"

--- a/test/spec/traceql/span_attr_explicit.txtar
+++ b/test/spec/traceql/span_attr_explicit.txtar
@@ -1,0 +1,7 @@
+-- query.traceql --
+{ span.http.method = "GET" }
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`SpanAttributes`[?] = ?)
+-- args --
+[0] string = "http.method"
+[1] string = "GET"

--- a/test/spec/traceql/span_id_intrinsic.txtar
+++ b/test/spec/traceql/span_id_intrinsic.txtar
@@ -1,0 +1,6 @@
+-- query.traceql --
+{ span:id = "0123456789abcdef" }
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`SpanId` = ?)
+-- args --
+[0] string = "0123456789abcdef"

--- a/test/spec/traceql/status_message.txtar
+++ b/test/spec/traceql/status_message.txtar
@@ -1,0 +1,6 @@
+-- query.traceql --
+{ statusMessage = "internal server error" }
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`StatusMessage` = ?)
+-- args --
+[0] string = "internal server error"

--- a/test/spec/traceql/trace_id_intrinsic.txtar
+++ b/test/spec/traceql/trace_id_intrinsic.txtar
@@ -1,0 +1,6 @@
+-- query.traceql --
+{ trace:id = "abcdef0123456789" }
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`TraceId` = ?)
+-- args --
+[0] string = "abcdef0123456789"


### PR DESCRIPTION
## Summary

Pre-RC1 fixture gap-fill: TraceQL had only 8 TXTAR fixtures vs the 30+ surface features M4.1–M4.4 shipped. This brings it to 26.

## New fixtures (18)

| # | File | What it covers |
|---|---|---|
| 1 | `or_two_attrs.txtar` | `\|\|` between two predicates |
| 2 | `and_or_combined.txtar` | nested `&&` + `\|\|` precedence |
| 3 | `not_eq_attr.txtar` | `!=` matcher |
| 4 | `regex_attr.txtar` | `=~` regex |
| 5 | `not_regex_attr.txtar` | `!~` not-regex |
| 6 | `http_status_int.txtar` | numeric `>= 500` |
| 7 | `float_attr.txtar` | float literal `> 0.5` |
| 8 | `bool_attr.txtar` | boolean literal `= true` |
| 9 | `name_intrinsic.txtar` | intrinsic `name = "..."` → `SpanName` |
| 10 | `kind_intrinsic.txtar` | intrinsic `kind = "..."` → `SpanKind` |
| 11 | `status_message.txtar` | intrinsic `statusMessage = "..."` |
| 12 | `parent_intrinsic.txtar` | intrinsic `parent = "..."` → `ParentSpanId` |
| 13 | `trace_id_intrinsic.txtar` | scoped intrinsic `trace:id = "..."` |
| 14 | `span_id_intrinsic.txtar` | scoped intrinsic `span:id = "..."` |
| 15 | `span_attr_explicit.txtar` | explicit `span.http.method` |
| 16 | `span_attr_default.txtar` | bare `.http.method` (default span scope) |
| 17 | `count_ge_threshold.txtar` | `\| count() >= 5` scalar-filter threshold |
| 18 | `select_resource_attrs.txtar` | `\| select(resource.X, resource.Y)` |

## Skipped (deferred to RC2 — already tracked)

- `>>` / `<<` recursive structural ops — emitter doesn't yet produce the JOIN-on-prefix SQL.
- `status = error` enum static — Tempo's typed-static encoding needs Status/Kind enum support in `lowerStatic`.

## Test plan

- [x] `just test` — 26 TraceQL fixtures pass (was 8)
- [x] `just lint` — clean
- [ ] CI: `check + lint + dashboard` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)