### PR TITLE
test(chsql): expand fixtures from 15 to 29 — cover every chplan IR node (RC1)

### DIFF
--- a/internal/chsql/emit_test.go
+++ b/internal/chsql/emit_test.go
@@ -144,6 +144,161 @@ var plans = map[string]chplan.Node{
 			Right: &chplan.LitString{V: "api"},
 		},
 	},
+
+	// VectorJoin — PromQL `on(...)` vector matching.
+	"vector_join_on_job": &chplan.VectorJoin{
+		Left:             &chplan.Scan{Table: "otel_metrics_gauge"},
+		Right:            &chplan.Scan{Table: "otel_metrics_sum"},
+		Op:               chplan.OpAdd,
+		Match:            chplan.VectorMatch{Labels: []string{"job"}, On: true},
+		MetricNameColumn: "MetricName",
+		AttributesColumn: "Attributes",
+		TimestampColumn:  "TimeUnix",
+		ValueColumn:      "Value",
+	},
+	// VectorJoin — PromQL `ignoring(...)` vector matching.
+	"vector_join_ignoring_instance": &chplan.VectorJoin{
+		Left:             &chplan.Scan{Table: "otel_metrics_gauge"},
+		Right:            &chplan.Scan{Table: "otel_metrics_sum"},
+		Op:               chplan.OpSub,
+		Match:            chplan.VectorMatch{Labels: []string{"instance"}, On: false},
+		MetricNameColumn: "MetricName",
+		AttributesColumn: "Attributes",
+		TimestampColumn:  "TimeUnix",
+		ValueColumn:      "Value",
+	},
+
+	// StructuralJoin — TraceQL `>` (parent_of).
+	"structural_join_child": &chplan.StructuralJoin{
+		Left:               &chplan.Scan{Table: "otel_traces"},
+		Right:              &chplan.Scan{Table: "otel_traces"},
+		Op:                 chplan.StructuralChild,
+		TraceIDColumn:      "TraceId",
+		SpanIDColumn:       "SpanId",
+		ParentSpanIDColumn: "ParentSpanId",
+	},
+	// StructuralJoin — TraceQL `<` (child_of).
+	"structural_join_parent": &chplan.StructuralJoin{
+		Left:               &chplan.Scan{Table: "otel_traces"},
+		Right:              &chplan.Scan{Table: "otel_traces"},
+		Op:                 chplan.StructuralParent,
+		TraceIDColumn:      "TraceId",
+		SpanIDColumn:       "SpanId",
+		ParentSpanIDColumn: "ParentSpanId",
+	},
+
+	// MapWithoutKeys used inside an Aggregate group-key: PromQL `without`.
+	"aggregate_sum_without": &chplan.Aggregate{
+		Input: &chplan.Scan{Table: "otel_metrics_gauge"},
+		GroupBy: []chplan.Expr{
+			&chplan.MapWithoutKeys{
+				Map:  &chplan.ColumnRef{Name: "Attributes"},
+				Keys: []string{"instance", "pod"},
+			},
+		},
+		AggFuncs: []chplan.AggFunc{
+			{Name: "sum", Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}, Alias: "total"},
+		},
+	},
+
+	// Aggregate with parameterised CH aggregate: quantile(0.95)(value).
+	"aggregate_quantile_param": &chplan.Aggregate{
+		Input: &chplan.Scan{Table: "otel_metrics_gauge"},
+		GroupBy: []chplan.Expr{
+			&chplan.ColumnRef{Name: "Attributes"},
+		},
+		AggFuncs: []chplan.AggFunc{
+			{
+				Name:   "quantile",
+				Params: []chplan.Expr{&chplan.LitFloat{V: 0.95}},
+				Args:   []chplan.Expr{&chplan.ColumnRef{Name: "Value"}},
+				Alias:  "p95",
+			},
+		},
+	},
+
+	// LineContent variants (LogQL line filters).
+	"filter_line_contains": &chplan.Filter{
+		Input: &chplan.Scan{Table: "otel_logs"},
+		Predicate: &chplan.LineContent{
+			Source:  &chplan.ColumnRef{Name: "Body"},
+			Pattern: "ERROR",
+		},
+	},
+	"filter_line_not_contains": &chplan.Filter{
+		Input: &chplan.Scan{Table: "otel_logs"},
+		Predicate: &chplan.LineContent{
+			Source:  &chplan.ColumnRef{Name: "Body"},
+			Pattern: "DEBUG",
+			Negated: true,
+		},
+	},
+	"filter_line_regex": &chplan.Filter{
+		Input: &chplan.Scan{Table: "otel_logs"},
+		Predicate: &chplan.LineContent{
+			Source:  &chplan.ColumnRef{Name: "Body"},
+			Pattern: `failed: \w+`,
+			IsRegex: true,
+		},
+	},
+	"filter_line_not_regex": &chplan.Filter{
+		Input: &chplan.Scan{Table: "otel_logs"},
+		Predicate: &chplan.LineContent{
+			Source:  &chplan.ColumnRef{Name: "Body"},
+			Pattern: `health.*ok`,
+			IsRegex: true,
+			Negated: true,
+		},
+	},
+
+	// RangeWindow with offset modifier (PromQL `rate(...)[5m] offset 1h`).
+	"range_window_rate_offset": &chplan.RangeWindow{
+		Input:           &chplan.Scan{Table: "otel_metrics_sum"},
+		Func:            "rate",
+		Range:           5 * time.Minute,
+		Offset:          time.Hour,
+		TimestampColumn: "TimeUnix",
+		ValueColumn:     "Value",
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+	},
+
+	// RangeWindow with the LogQL-specific log_rate function.
+	"range_window_log_rate": &chplan.RangeWindow{
+		Input:           &chplan.Scan{Table: "otel_logs"},
+		Func:            "log_rate",
+		Range:           5 * time.Minute,
+		TimestampColumn: "Timestamp",
+		ValueColumn:     "Value",
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "ResourceAttributes"}},
+	},
+
+	// FieldAccess — TraceQL dotted attribute access.
+	"filter_field_access": &chplan.Filter{
+		Input: &chplan.Scan{Table: "otel_traces"},
+		Predicate: &chplan.Binary{
+			Op: chplan.OpEq,
+			Left: &chplan.FieldAccess{
+				Source: &chplan.ColumnRef{Name: "SpanAttributes"},
+				Path:   "http.status_code",
+			},
+			Right: &chplan.LitInt{V: 500},
+		},
+	},
+
+	// FuncCall — generic CH function expression (length on a column).
+	"project_func_call_length": &chplan.Project{
+		Input: &chplan.Scan{Table: "otel_logs"},
+		Projections: []chplan.Projection{
+			{Expr: &chplan.ColumnRef{Name: "Timestamp"}, Alias: "t"},
+			{
+				Expr: &chplan.FuncCall{
+					Name: "length",
+					Args: []chplan.Expr{&chplan.ColumnRef{Name: "Body"}},
+				},
+				Alias: "body_bytes",
+			},
+		},
+	},
 }
 
 func TestEmit(t *testing.T) {

--- a/test/spec/chsql/aggregate_quantile_param.txtar
+++ b/test/spec/chsql/aggregate_quantile_param.txtar
@@ -1,0 +1,4 @@
+-- sql --
+SELECT `Attributes`, quantile(?)(`Value`) AS `p95` FROM (SELECT * FROM `otel_metrics_gauge`) GROUP BY `Attributes`
+-- args --
+[0] float64 = 0.95

--- a/test/spec/chsql/aggregate_sum_without.txtar
+++ b/test/spec/chsql/aggregate_sum_without.txtar
@@ -1,0 +1,7 @@
+-- sql --
+SELECT mapFilter((k, v) -> NOT (k IN (?, ?)), `Attributes`), sum(`Value`) AS `total` FROM (SELECT * FROM `otel_metrics_gauge`) GROUP BY mapFilter((k, v) -> NOT (k IN (?, ?)), `Attributes`)
+-- args --
+[0] string = "instance"
+[1] string = "pod"
+[2] string = "instance"
+[3] string = "pod"

--- a/test/spec/chsql/filter_field_access.txtar
+++ b/test/spec/chsql/filter_field_access.txtar
@@ -1,0 +1,5 @@
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`SpanAttributes`[?] = ?)
+-- args --
+[0] string = "http.status_code"
+[1] int64 = 500

--- a/test/spec/chsql/filter_line_contains.txtar
+++ b/test/spec/chsql/filter_line_contains.txtar
@@ -1,0 +1,4 @@
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_logs`) WHERE (position(`Body`, ?) > 0)
+-- args --
+[0] string = "ERROR"

--- a/test/spec/chsql/filter_line_not_contains.txtar
+++ b/test/spec/chsql/filter_line_not_contains.txtar
@@ -1,0 +1,4 @@
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_logs`) WHERE (position(`Body`, ?) = 0)
+-- args --
+[0] string = "DEBUG"

--- a/test/spec/chsql/filter_line_not_regex.txtar
+++ b/test/spec/chsql/filter_line_not_regex.txtar
@@ -1,0 +1,4 @@
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_logs`) WHERE NOT match(`Body`, ?)
+-- args --
+[0] string = "health.*ok"

--- a/test/spec/chsql/filter_line_regex.txtar
+++ b/test/spec/chsql/filter_line_regex.txtar
@@ -1,0 +1,4 @@
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_logs`) WHERE match(`Body`, ?)
+-- args --
+[0] string = "failed: \\w+"

--- a/test/spec/chsql/project_func_call_length.txtar
+++ b/test/spec/chsql/project_func_call_length.txtar
@@ -1,0 +1,4 @@
+-- sql --
+SELECT `Timestamp` AS `t`, length(`Body`) AS `body_bytes` FROM (SELECT * FROM `otel_logs`)
+-- args --
+(none)

--- a/test/spec/chsql/range_window_log_rate.txtar
+++ b/test/spec/chsql/range_window_log_rate.txtar
@@ -1,0 +1,4 @@
+-- sql --
+SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS value FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS window_vals, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS counter_delta FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) >= now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS window_pairs FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS series_array FROM (SELECT * FROM `otel_logs`) GROUP BY `ResourceAttributes`)))
+-- args --
+[0] float64 = 300

--- a/test/spec/chsql/range_window_rate_offset.txtar
+++ b/test/spec/chsql/range_window_rate_offset.txtar
@@ -1,0 +1,4 @@
+-- sql --
+SELECT `Attributes`, if(length(window_vals) > 1, counter_delta / 300, 0.0) AS value FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS window_vals, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS counter_delta FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) >= (now64(9) - toIntervalNanosecond(3600000000000)) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= (now64(9) - toIntervalNanosecond(3600000000000)), series_array) AS window_pairs FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS series_array FROM (SELECT * FROM `otel_metrics_sum`) GROUP BY `Attributes`)))
+-- args --
+(none)

--- a/test/spec/chsql/structural_join_child.txtar
+++ b/test/spec/chsql/structural_join_child.txtar
@@ -1,0 +1,4 @@
+-- sql --
+SELECT R.* FROM (SELECT * FROM `otel_traces`) AS L INNER JOIN (SELECT * FROM `otel_traces`) AS R ON L.`TraceId` = R.`TraceId` AND L.`SpanId` = R.`ParentSpanId`
+-- args --
+(none)

--- a/test/spec/chsql/structural_join_parent.txtar
+++ b/test/spec/chsql/structural_join_parent.txtar
@@ -1,0 +1,4 @@
+-- sql --
+SELECT R.* FROM (SELECT * FROM `otel_traces`) AS L INNER JOIN (SELECT * FROM `otel_traces`) AS R ON L.`TraceId` = R.`TraceId` AND L.`ParentSpanId` = R.`SpanId`
+-- args --
+(none)

--- a/test/spec/chsql/vector_join_ignoring_instance.txtar
+++ b/test/spec/chsql/vector_join_ignoring_instance.txtar
@@ -1,0 +1,5 @@
+-- sql --
+SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` - R.`Value`) AS `Value` FROM (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge`) GROUP BY `MetricName`, `Attributes`) AS L INNER JOIN (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT * FROM `otel_metrics_sum`) GROUP BY `MetricName`, `Attributes`) AS R ON mapFilter((k, v) -> NOT (k IN (?)), L.`Attributes`) = mapFilter((k, v) -> NOT (k IN (?)), R.`Attributes`)
+-- args --
+[0] string = "instance"
+[1] string = "instance"

--- a/test/spec/chsql/vector_join_on_job.txtar
+++ b/test/spec/chsql/vector_join_on_job.txtar
@@ -1,0 +1,5 @@
+-- sql --
+SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` + R.`Value`) AS `Value` FROM (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge`) GROUP BY `MetricName`, `Attributes`) AS L INNER JOIN (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT * FROM `otel_metrics_sum`) GROUP BY `MetricName`, `Attributes`) AS R ON L.`Attributes`[?] = R.`Attributes`[?]
+-- args --
+[0] string = "job"
+[1] string = "job"


### PR DESCRIPTION
## Summary

The chsql fixture corpus was missing direct tests for several chplan IR nodes that landed in M1.4–M4.4 — they were only covered *transitively* through PromQL/LogQL/TraceQL fixtures. 14 new entries fill those gaps.

## New fixtures

| Node                  | Variants                                                |
| --------------------- | ------------------------------------------------------- |
| \`VectorJoin\`         | \`on(job)\`, \`ignoring(instance)\`                       |
| \`StructuralJoin\`     | \`>\` (parent_of), \`<\` (child_of)                       |
| \`MapWithoutKeys\`     | as Aggregate group-key (PromQL \`without\`)              |
| \`AggFunc.Params\`     | \`quantile(0.95)(Value)\` — parameterised CH aggregate    |
| \`LineContent\`        | contains, not_contains, regex, not_regex                |
| \`RangeWindow.Offset\` | \`rate(...)[5m] offset 1h\`                              |
| \`RangeWindow\` log_rate | the LogQL-specific function name                       |
| \`FieldAccess\`        | dotted attribute on \`SpanAttributes\`                   |
| \`FuncCall\`           | \`length(Body)\` inside a Project                       |

Each fixture exercises \`chsql.Emit\` for the node in isolation, so a regression in any branch is caught at the chsql layer instead of only via a downstream parser+lowering+emit chain.

## Test plan

- [x] \`GOLDEN_UPDATE=1 go test ./internal/chsql/...\` produces deterministic SQL
- [ ] CI: \`check + lint + dashboard\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)