### PR TITLE
test(e2e): cerberus-side HTTP tests for Loki + Tempo + Prom metadata (RC1)

### DIFF
--- a/test/e2e/e2e_loki_test.go
+++ b/test/e2e/e2e_loki_test.go
@@ -1,0 +1,90 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"testing"
+	"time"
+)
+
+// TestLokiQueryStreamSelector verifies /loki/api/v1/query (M3.5)
+// returns the `streams` result type for a bare stream selector.
+// The seed (test/e2e/seed/otel_logs.sql) inserts 60 log records
+// across 3 services in the last minute, so {service_name="api"}
+// must return at least one stream with values.
+func TestLokiQueryStreamSelector(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	v := url.Values{}
+	v.Set("query", `{service_name="api"}`)
+
+	resp := getJSON(ctx, t, "/loki/api/v1/query?"+v.Encode())
+	var parsed struct {
+		Status string `json:"status"`
+		Data   struct {
+			ResultType string `json:"resultType"`
+			Result     []struct {
+				Stream map[string]string `json:"stream"`
+				Values [][]string        `json:"values"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	mustDecode(t, resp, &parsed)
+
+	if parsed.Status != "success" {
+		t.Fatalf("status: got %q, want success", parsed.Status)
+	}
+	if parsed.Data.ResultType != "streams" {
+		t.Fatalf("resultType: got %q, want streams", parsed.Data.ResultType)
+	}
+	if len(parsed.Data.Result) == 0 {
+		t.Fatalf("expected at least one stream; got 0")
+	}
+	for _, s := range parsed.Data.Result {
+		if len(s.Stream) == 0 {
+			t.Errorf("stream missing labels: %+v", s)
+		}
+	}
+}
+
+// TestLokiQueryRangeCountOverTime verifies the LogQL metric path
+// (M3.3): count_over_time({selector}[5m]) returns a matrix.
+func TestLokiQueryRangeCountOverTime(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	now := time.Now().Unix()
+	start := now - 5*60
+	v := url.Values{}
+	v.Set("query", `count_over_time({service_name=~".+"}[5m])`)
+	v.Set("start", fmt.Sprintf("%d", start))
+	v.Set("end", fmt.Sprintf("%d", now))
+	v.Set("step", "30")
+
+	resp := getJSON(ctx, t, "/loki/api/v1/query_range?"+v.Encode())
+	var parsed struct {
+		Status string `json:"status"`
+		Data   struct {
+			ResultType string `json:"resultType"`
+			Result     []struct {
+				Metric map[string]string `json:"metric"`
+				Values [][]any           `json:"values"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	mustDecode(t, resp, &parsed)
+
+	if parsed.Status != "success" {
+		t.Fatalf("status: got %q, want success", parsed.Status)
+	}
+	if parsed.Data.ResultType != "matrix" {
+		t.Fatalf("resultType: got %q, want matrix", parsed.Data.ResultType)
+	}
+	if len(parsed.Data.Result) == 0 {
+		t.Fatalf("expected at least one series; got 0")
+	}
+}

--- a/test/e2e/e2e_prom_test.go
+++ b/test/e2e/e2e_prom_test.go
@@ -1,0 +1,141 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+)
+
+// TestPromQueryRangeRate exercises the M1.1 RangeWindow SQL path:
+// rate() over a 5-minute window against the seeded counter. The seed
+// (test/e2e/seed/otel_metrics.sql) inserts 60 samples of
+// http_server_request_duration_count over the last minute, so a rate
+// query must return at least one series with a positive value.
+func TestPromQueryRangeRate(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	now := time.Now().Unix()
+	start := now - 5*60
+	v := url.Values{}
+	v.Set("query", "rate(http_server_request_duration_count[5m])")
+	v.Set("start", fmt.Sprintf("%d", start))
+	v.Set("end", fmt.Sprintf("%d", now))
+	v.Set("step", "30")
+
+	resp := getJSON(ctx, t, "/api/v1/query_range?"+v.Encode())
+	var parsed promRangeResponse
+	mustDecode(t, resp, &parsed)
+
+	if parsed.Status != "success" {
+		t.Fatalf("status: got %q, want success", parsed.Status)
+	}
+	if parsed.Data.ResultType != "matrix" {
+		t.Fatalf("resultType: got %q, want matrix", parsed.Data.ResultType)
+	}
+	if len(parsed.Data.Result) == 0 {
+		t.Fatalf("expected at least one series; got 0")
+	}
+}
+
+// TestPromLabels verifies /api/v1/labels (M2.3) returns a non-empty
+// list including the `job` label seeded as an Attributes key.
+func TestPromLabels(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	resp := getJSON(ctx, t, "/api/v1/labels")
+	var parsed struct {
+		Status string   `json:"status"`
+		Data   []string `json:"data"`
+	}
+	mustDecode(t, resp, &parsed)
+
+	if parsed.Status != "success" {
+		t.Fatalf("status: got %q, want success", parsed.Status)
+	}
+	if len(parsed.Data) == 0 {
+		t.Fatalf("expected non-empty label list")
+	}
+	if !contains(parsed.Data, "job") {
+		t.Errorf("expected `job` in labels; got %v", parsed.Data)
+	}
+}
+
+// TestPromLabelValuesName verifies /api/v1/label/__name__/values
+// (M2.4) returns the metric names cerberus seeded.
+func TestPromLabelValuesName(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	resp := getJSON(ctx, t, "/api/v1/label/__name__/values")
+	var parsed struct {
+		Status string   `json:"status"`
+		Data   []string `json:"data"`
+	}
+	mustDecode(t, resp, &parsed)
+
+	if parsed.Status != "success" {
+		t.Fatalf("status: got %q, want success", parsed.Status)
+	}
+	if !contains(parsed.Data, "up") {
+		t.Errorf("expected `up` in label values; got %v", parsed.Data)
+	}
+	if !contains(parsed.Data, "http_server_request_duration_count") {
+		t.Errorf("expected `http_server_request_duration_count` in label values; got %v", parsed.Data)
+	}
+}
+
+// promRangeResponse is the Prom `query_range` response shape.
+type promRangeResponse struct {
+	Status string `json:"status"`
+	Data   struct {
+		ResultType string `json:"resultType"`
+		Result     []struct {
+			Metric map[string]string `json:"metric"`
+			Values [][]any           `json:"values"`
+		} `json:"result"`
+	} `json:"data"`
+}
+
+// getJSON is a small test helper that issues a GET, fails the test on
+// dial / non-200, and returns the open response (caller closes).
+func getJSON(ctx context.Context, t *testing.T, path string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL()+path, nil)
+	if err != nil {
+		t.Fatalf("new request %q: %v", path, err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET %s: %v", path, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		_ = resp.Body.Close()
+		t.Fatalf("GET %s: status %d", path, resp.StatusCode)
+	}
+	return resp
+}
+
+func mustDecode(t *testing.T, resp *http.Response, v any) {
+	t.Helper()
+	defer func() { _ = resp.Body.Close() }()
+	if err := json.NewDecoder(resp.Body).Decode(v); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/test/e2e/e2e_tempo_test.go
+++ b/test/e2e/e2e_tempo_test.go
@@ -1,0 +1,150 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestTempoEcho verifies /api/echo returns the literal "echo" string
+// that Grafana's Tempo datasource health-check expects.
+func TestTempoEcho(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL()+"/api/echo", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /api/echo: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if strings.TrimSpace(string(body)) != "echo" {
+		t.Fatalf("body: got %q, want %q", body, "echo")
+	}
+}
+
+// TestTempoVersion verifies /api/status/version returns a JSON body
+// with both `version` and `goVersion` fields populated.
+func TestTempoVersion(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp := getJSON(ctx, t, "/api/status/version")
+	var parsed struct {
+		Version   string `json:"version"`
+		GoVersion string `json:"goVersion"`
+	}
+	mustDecode(t, resp, &parsed)
+	if parsed.Version == "" {
+		t.Errorf("expected `version` set; got empty")
+	}
+	if parsed.GoVersion == "" {
+		t.Errorf("expected `goVersion` set; got empty")
+	}
+}
+
+// TestTempoSearch verifies /api/search returns trace summaries for a
+// TraceQL filter. The seed inserts a trace with
+// resource.service.name = "frontend", so the query must return ≥ 1.
+func TestTempoSearch(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	v := url.Values{}
+	v.Set("q", `{ resource.service.name = "frontend" }`)
+
+	resp := getJSON(ctx, t, "/api/search?"+v.Encode())
+	var parsed struct {
+		Traces []struct {
+			TraceID         string `json:"traceID"`
+			RootServiceName string `json:"rootServiceName"`
+			RootTraceName   string `json:"rootTraceName"`
+			DurationMs      int    `json:"durationMs"`
+		} `json:"traces"`
+	}
+	mustDecode(t, resp, &parsed)
+
+	if len(parsed.Traces) == 0 {
+		t.Fatalf("expected at least one trace summary; got 0")
+	}
+	for _, tr := range parsed.Traces {
+		if tr.RootServiceName == "" {
+			t.Errorf("summary missing rootServiceName: %+v", tr)
+		}
+	}
+}
+
+// TestTempoTraceByID_Found verifies /api/traces/<id> returns batches
+// for a seeded trace ID.
+func TestTempoTraceByID_Found(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	traceID := "a0000000000000000000000000000001"
+	resp := getJSON(ctx, t, "/api/traces/"+traceID)
+	var parsed struct {
+		Batches []struct {
+			Spans []struct {
+				Name string `json:"name"`
+			} `json:"spans"`
+		} `json:"batches"`
+	}
+	mustDecode(t, resp, &parsed)
+
+	if len(parsed.Batches) == 0 {
+		t.Fatalf("expected at least one batch; got 0")
+	}
+	totalSpans := 0
+	for _, b := range parsed.Batches {
+		totalSpans += len(b.Spans)
+	}
+	if totalSpans == 0 {
+		t.Errorf("expected at least one span across all batches; got 0")
+	}
+}
+
+// TestTempoTraceByID_NotFound verifies the Tempo error envelope
+// shape on a miss — Grafana relies on this distinct shape to render
+// the right "trace not found" UI.
+func TestTempoTraceByID_NotFound(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL()+"/api/traces/deadbeef00000000000000000000dead", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /api/traces/<missing>: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404", resp.StatusCode)
+	}
+	var parsed struct {
+		TraceID string `json:"traceID"`
+		Error   bool   `json:"error"`
+		Message string `json:"message"`
+	}
+	mustDecode(t, resp, &parsed)
+	if !parsed.Error {
+		t.Errorf("expected error=true in body; got %+v", parsed)
+	}
+	if parsed.TraceID == "" {
+		t.Errorf("expected traceID set in body; got %+v", parsed)
+	}
+}


### PR DESCRIPTION
## Summary

Stacked on **#76**. Targets that PR's branch so the diff is just the test additions and CI has the seed files.

Existing \`test/e2e/e2e_test.go\` covers \`/healthz\` + one PromQL query (\`up\`). RC1 needs the Loki + Tempo handlers and the Prom metadata endpoints exercised through real HTTP against the deployed cerberus — not just unit-level Querier stubs.

## New test files (all build-tagged \`e2e\`)

### \`e2e_prom_test.go\`
- \`TestPromQueryRangeRate\` — \`rate(http_server_request_duration_count[5m])\` returns a matrix with ≥ 1 series (exercises M1.1 windowed-array)
- \`TestPromLabels\` — \`/api/v1/labels\` (M2.3) includes \`job\`
- \`TestPromLabelValuesName\` — \`/api/v1/label/__name__/values\` (M2.4) includes both seeded metric names

### \`e2e_loki_test.go\`
- \`TestLokiQueryStreamSelector\` — \`{service_name="api"}\` returns the streams shape with values (M3.1 + M3.5)
- \`TestLokiQueryRangeCountOverTime\` — \`count_over_time({...}[5m])\` returns a matrix (M3.3)

### \`e2e_tempo_test.go\`
- \`TestTempoEcho\` — \`/api/echo\` returns "echo" (M4.5)
- \`TestTempoVersion\` — \`/api/status/version\` has version + goVersion
- \`TestTempoSearch\` — \`{resource.service.name="frontend"}\` returns summaries with rootServiceName set
- \`TestTempoTraceByID_Found\` — seeded trace returns batches with spans
- \`TestTempoTraceByID_NotFound\` — missing trace returns 404 + the Tempo error envelope shape (Grafana relies on this for UI)

## Test plan

- [ ] CI: \`check + lint + dashboard\` green
- [ ] Once #76 merges, this PR's base auto-rebases to \`main\` and merges next

🤖 Generated with [Claude Code](https://claude.com/claude-code)