### PR TITLE
chore(dev): pin gh to tsouza in cerberus repo + ignore .claude/settings.local.json

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -16,3 +16,16 @@ export GOFLAGS="-trimpath"
 
 # Marker that we're in a cerberus dev shell.
 export CERBERUS_DEV=1
+
+# Pin `gh` to the tsouza GitHub account for every command issued from
+# this repo. Cerberus is owned by tsouza; the host's default `gh` auth
+# may be the work account (tsouza-squid) which lacks collaborator rights
+# here. `gh auth switch` writes ~/.config/gh/hosts.yml so it's sticky
+# across shells; this re-asserts it on each direnv reload as a cheap
+# no-op when already correct.
+if command -v gh >/dev/null 2>&1; then
+    current=$(gh auth status -h github.com 2>/dev/null | awk '/Active account/{print $3; exit}')
+    if [ "$current" != "tsouza" ]; then
+        gh auth switch -u tsouza -h github.com >/dev/null 2>&1 || true
+    fi
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ dist/
 .direnv/
 .envrc.local
 
+# Per-developer Claude Code settings (permissions etc.)
+.claude/settings.local.json
+
 # Local kubeconfig / k3d state
 .kube/
 .k3d/


### PR DESCRIPTION
## Summary

Two dev-tooling housekeeping items.

### 1. \`.envrc\` — pin \`gh\` to tsouza in cerberus

Host's default \`gh\` login is \`tsouza-squid\` (work), which lacks collaborator rights here. \`gh pr create\` failed twice in one session before I manually ran \`gh auth switch -u tsouza\`. The \`.envrc\` now re-asserts the switch on every direnv reload when the active account isn't already tsouza. Idempotent: silent no-op when correct, silent skip when tsouza isn't logged in.

### 2. \`.gitignore\` — \`.claude/settings.local.json\`

Per-developer Claude Code permission overrides; shouldn't be shared across the team. Standard for the \`.local.json\` suffix.

## Test plan

- [ ] CI: \`check + lint + dashboard\` green (no Go changes)
- [x] Local: \`direnv reload\` puts active \`gh\` account at \`tsouza\` regardless of prior state

🤖 Generated with [Claude Code](https://claude.com/claude-code)