### PR TITLE
fix(.envrc): move gh account pinning to ~/.direnvrc helper (don't leak account names)

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -17,15 +17,10 @@ export GOFLAGS="-trimpath"
 # Marker that we're in a cerberus dev shell.
 export CERBERUS_DEV=1
 
-# Pin `gh` to the tsouza GitHub account for every command issued from
-# this repo. Cerberus is owned by tsouza; the host's default `gh` auth
-# may be the work account (tsouza-squid) which lacks collaborator rights
-# here. `gh auth switch` writes ~/.config/gh/hosts.yml so it's sticky
-# across shells; this re-asserts it on each direnv reload as a cheap
-# no-op when already correct.
-if command -v gh >/dev/null 2>&1; then
-    current=$(gh auth status -h github.com 2>/dev/null | awk '/Active account/{print $3; exit}')
-    if [ "$current" != "tsouza" ]; then
-        gh auth switch -u tsouza -h github.com >/dev/null 2>&1 || true
-    fi
-fi
+# Match the active `gh` account to whoever owns this repo's origin
+# remote — useful on machines with multiple GitHub identities (personal
+# + work). The helper is defined in ~/.direnvrc (personal, untracked);
+# falls through silently when the helper isn't installed or the target
+# account isn't logged in. See the function definition for the full
+# no-op matrix.
+type use_gh_repo_owner >/dev/null 2>&1 && use_gh_repo_owner


### PR DESCRIPTION
## Summary

PR #79's \`.envrc\` had hardcoded GitHub account names — fine on the maintainer's machine, but leaks personal identity into a public OSS repo and forces every contributor's fork to either rename to their own user or carry the wrong default.

Refactor: the per-repo \`.envrc\` calls a generic helper:

\`\`\`bash
type use_gh_repo_owner >/dev/null 2>&1 && use_gh_repo_owner
\`\`\`

…defined in the developer's own \`~/.direnvrc\` (untracked, personal). The helper reads the owner from \`git remote get-url origin\` and switches \`gh\` to that account if it isn't already active.

## Helper definition (suggested ~/.direnvrc snippet)

\`\`\`bash
use_gh_repo_owner() {
    command -v gh >/dev/null 2>&1 || return 0
    local url owner
    url=\$(git config --get remote.origin.url 2>/dev/null) || return 0
    case "\$url" in
        *github*:*/*) owner="\${url#*:}"; owner="\${owner%%/*}";;
        *github.com/*/*) owner=\$(printf '%s\n' "\$url" | sed -E 's|.*github\.com/([^/]+)/.*|\1|');;
        *) return 0;;
    esac
    [ -n "\$owner" ] || return 0
    local current
    current=\$(gh auth status -h github.com 2>/dev/null | awk '/Active account/{print \$3; exit}')
    if [ "\$current" != "\$owner" ]; then
        gh auth switch -u "\$owner" -h github.com >/dev/null 2>&1 || true
    fi
}
\`\`\`

## Silent no-op matrix

The helper falls through on:
- \`gh\` not installed
- no \`origin\` remote
- owner unparseable
- account already correct
- target account not logged in

So it's safe for anyone's machine — won't break if they don't have multi-account auth set up.

## Test plan

- [x] Local: \`direnv reload\` runs the helper; \`gh auth status\` shows the repo-owner account as Active.
- [x] No personal account names in the .envrc anymore (\`grep tsouza .envrc\` returns nothing).
- [ ] CI: \`check + lint + dashboard\` green (no Go changes; trivial chore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)