### PR TITLE
fix(.envrc): drop gh-helper invocation entirely — keep workflow off the public surface

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -16,11 +16,3 @@ export GOFLAGS="-trimpath"
 
 # Marker that we're in a cerberus dev shell.
 export CERBERUS_DEV=1
-
-# Match the active `gh` account to whoever owns this repo's origin
-# remote — useful on machines with multiple GitHub identities (personal
-# + work). The helper is defined in ~/.direnvrc (personal, untracked);
-# falls through silently when the helper isn't installed or the target
-# account isn't logged in. See the function definition for the full
-# no-op matrix.
-type use_gh_repo_owner >/dev/null 2>&1 && use_gh_repo_owner


### PR DESCRIPTION
## Summary

PR #80 hid the account *names* by moving the helper to \`~/.direnvrc\`, but the cerberus \`.envrc\` still had the \`type use_gh_repo_owner ... && use_gh_repo_owner\` line + a comment block explaining it. Reviewing the file as a public surface: even that line documents that the maintainer's machine has multiple \`gh\` accounts — personal workflow info the cerberus codebase shouldn't advertise.

The helper now auto-invokes from \`~/.direnvrc\` itself; the cerberus \`.envrc\` goes back to being just Go-toolchain config.

## Helper auto-invoke

The trick is that \`direnv\` sources \`~/.direnvrc\` once at the start of every \`.envrc\` evaluation. So if the auto-invoke lives in \`~/.direnvrc\` (right after the function definition), every direnv-allowed repo automatically gets the gh account pinned to its \`origin\` owner — no per-repo opt-in needed.

\`\`\`bash
# in ~/.direnvrc, after the function definition:
use_gh_repo_owner
\`\`\`

Silent no-op outside git repos / when the helper hits any of its no-op conditions.

## Test plan

- [x] \`.envrc\` has zero gh-related references (\`grep -i gh .envrc\` returns nothing)
- [x] \`direnv reload\` in cerberus still results in \`gh auth status\` showing the right account as Active (verified locally)
- [ ] CI: \`check + lint + dashboard\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)