### PR TITLE
test(chplan,chsql): negative-case coverage for Equal + Emit

### DIFF
--- a/internal/chplan/node_negatives_test.go
+++ b/internal/chplan/node_negatives_test.go
@@ -1,0 +1,221 @@
+package chplan_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// TestEqual_MismatchedNodeTypes — Equal() across different concrete
+// node types must always return false. Catches a class of bugs where
+// a node's Equal forgets to type-assert and accidentally calls
+// Equal() against itself.
+func TestEqual_MismatchedNodeTypes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		a, b chplan.Node
+	}{
+		{
+			"Scan vs Filter",
+			&chplan.Scan{Table: "t"},
+			&chplan.Filter{Input: &chplan.Scan{Table: "t"}, Predicate: &chplan.LitBool{V: true}},
+		},
+		{
+			"Filter vs Project",
+			&chplan.Filter{Input: &chplan.Scan{Table: "t"}, Predicate: &chplan.LitBool{V: true}},
+			&chplan.Project{Input: &chplan.Scan{Table: "t"}, Projections: []chplan.Projection{{Expr: &chplan.ColumnRef{Name: "c"}}}},
+		},
+		{
+			"Aggregate vs Limit",
+			&chplan.Aggregate{Input: &chplan.Scan{Table: "t"}},
+			&chplan.Limit{Input: &chplan.Scan{Table: "t"}, Count: 10},
+		},
+		{
+			"RangeWindow vs Filter",
+			&chplan.RangeWindow{Input: &chplan.Scan{Table: "t"}, Func: "rate", Range: time.Minute, TimestampColumn: "TimeUnix", ValueColumn: "Value"},
+			&chplan.Filter{Input: &chplan.Scan{Table: "t"}, Predicate: &chplan.LitBool{V: true}},
+		},
+		{
+			"VectorJoin vs StructuralJoin",
+			&chplan.VectorJoin{
+				Left: &chplan.Scan{Table: "t"}, Right: &chplan.Scan{Table: "t"},
+				Op: chplan.OpAdd, MetricNameColumn: "MetricName", AttributesColumn: "Attributes",
+				TimestampColumn: "TimeUnix", ValueColumn: "Value",
+			},
+			&chplan.StructuralJoin{
+				Left: &chplan.Scan{Table: "t"}, Right: &chplan.Scan{Table: "t"},
+				Op:            chplan.StructuralChild,
+				TraceIDColumn: "TraceId", SpanIDColumn: "SpanId", ParentSpanIDColumn: "ParentSpanId",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if tc.a.Equal(tc.b) {
+				t.Errorf("%T.Equal(%T): got true, want false", tc.a, tc.b)
+			}
+			if tc.b.Equal(tc.a) {
+				t.Errorf("%T.Equal(%T) (reverse): got true, want false", tc.b, tc.a)
+			}
+		})
+	}
+}
+
+// TestExprEqual_MismatchedTypes — same contract for Expr nodes.
+// Distinct concrete types must never be Equal.
+func TestExprEqual_MismatchedTypes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		a, b chplan.Expr
+	}{
+		{
+			"ColumnRef vs LitString",
+			&chplan.ColumnRef{Name: "x"},
+			&chplan.LitString{V: "x"},
+		},
+		{
+			"LitInt vs LitFloat",
+			&chplan.LitInt{V: 1},
+			&chplan.LitFloat{V: 1.0},
+		},
+		{
+			"LitString vs LitBool",
+			&chplan.LitString{V: "true"},
+			&chplan.LitBool{V: true},
+		},
+		{
+			"Binary vs FuncCall",
+			&chplan.Binary{Op: chplan.OpEq, Left: &chplan.LitInt{V: 1}, Right: &chplan.LitInt{V: 1}},
+			&chplan.FuncCall{Name: "eq", Args: []chplan.Expr{&chplan.LitInt{V: 1}, &chplan.LitInt{V: 1}}},
+		},
+		{
+			"MapAccess vs FieldAccess",
+			&chplan.MapAccess{Map: &chplan.ColumnRef{Name: "Attrs"}, Key: &chplan.LitString{V: "k"}},
+			&chplan.FieldAccess{Source: &chplan.ColumnRef{Name: "Attrs"}, Path: "k"},
+		},
+		{
+			"FuncCall vs LineContent",
+			&chplan.FuncCall{Name: "match", Args: []chplan.Expr{&chplan.ColumnRef{Name: "Body"}, &chplan.LitString{V: "x"}}},
+			&chplan.LineContent{Source: &chplan.ColumnRef{Name: "Body"}, Pattern: "x"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if tc.a.Equal(tc.b) {
+				t.Errorf("%T.Equal(%T): got true, want false", tc.a, tc.b)
+			}
+			if tc.b.Equal(tc.a) {
+				t.Errorf("%T.Equal(%T) (reverse): got true, want false", tc.b, tc.a)
+			}
+		})
+	}
+}
+
+// TestExprEqual_SameTypeDifferentValues — same concrete type, but
+// observably different inner state, must return false.
+func TestExprEqual_SameTypeDifferentValues(t *testing.T) {
+	t.Parallel()
+
+	pairs := []struct {
+		name string
+		a, b chplan.Expr
+	}{
+		{"ColumnRef different name", &chplan.ColumnRef{Name: "a"}, &chplan.ColumnRef{Name: "b"}},
+		{"LitString different value", &chplan.LitString{V: "a"}, &chplan.LitString{V: "b"}},
+		{"LitInt different value", &chplan.LitInt{V: 1}, &chplan.LitInt{V: 2}},
+		{"LitFloat different value", &chplan.LitFloat{V: 1.0}, &chplan.LitFloat{V: 2.0}},
+		{"LitBool different value", &chplan.LitBool{V: true}, &chplan.LitBool{V: false}},
+		{
+			"Binary different op",
+			&chplan.Binary{Op: chplan.OpEq, Left: &chplan.LitInt{V: 1}, Right: &chplan.LitInt{V: 1}},
+			&chplan.Binary{Op: chplan.OpNe, Left: &chplan.LitInt{V: 1}, Right: &chplan.LitInt{V: 1}},
+		},
+		{
+			"Binary different children",
+			&chplan.Binary{Op: chplan.OpEq, Left: &chplan.LitInt{V: 1}, Right: &chplan.LitInt{V: 1}},
+			&chplan.Binary{Op: chplan.OpEq, Left: &chplan.LitInt{V: 1}, Right: &chplan.LitInt{V: 2}},
+		},
+		{
+			"FuncCall different name",
+			&chplan.FuncCall{Name: "abs", Args: []chplan.Expr{&chplan.LitInt{V: 1}}},
+			&chplan.FuncCall{Name: "ceil", Args: []chplan.Expr{&chplan.LitInt{V: 1}}},
+		},
+		{
+			"FuncCall different arg count",
+			&chplan.FuncCall{Name: "f", Args: []chplan.Expr{&chplan.LitInt{V: 1}}},
+			&chplan.FuncCall{Name: "f", Args: []chplan.Expr{&chplan.LitInt{V: 1}, &chplan.LitInt{V: 2}}},
+		},
+		{
+			"MapAccess different key",
+			&chplan.MapAccess{Map: &chplan.ColumnRef{Name: "Attrs"}, Key: &chplan.LitString{V: "a"}},
+			&chplan.MapAccess{Map: &chplan.ColumnRef{Name: "Attrs"}, Key: &chplan.LitString{V: "b"}},
+		},
+		{
+			"FieldAccess different path",
+			&chplan.FieldAccess{Source: &chplan.ColumnRef{Name: "SpanAttributes"}, Path: "http.method"},
+			&chplan.FieldAccess{Source: &chplan.ColumnRef{Name: "SpanAttributes"}, Path: "http.status_code"},
+		},
+		{
+			"LineContent different pattern",
+			&chplan.LineContent{Source: &chplan.ColumnRef{Name: "Body"}, Pattern: "ERROR"},
+			&chplan.LineContent{Source: &chplan.ColumnRef{Name: "Body"}, Pattern: "WARN"},
+		},
+		{
+			"LineContent different negation",
+			&chplan.LineContent{Source: &chplan.ColumnRef{Name: "Body"}, Pattern: "x", Negated: false},
+			&chplan.LineContent{Source: &chplan.ColumnRef{Name: "Body"}, Pattern: "x", Negated: true},
+		},
+		{
+			"LineContent different regex flag",
+			&chplan.LineContent{Source: &chplan.ColumnRef{Name: "Body"}, Pattern: "x", IsRegex: false},
+			&chplan.LineContent{Source: &chplan.ColumnRef{Name: "Body"}, Pattern: "x", IsRegex: true},
+		},
+	}
+	for _, tc := range pairs {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if tc.a.Equal(tc.b) {
+				t.Errorf("Equal: identical type, different values — got true, want false")
+			}
+			if tc.b.Equal(tc.a) {
+				t.Errorf("Equal reverse: got true, want false")
+			}
+		})
+	}
+}
+
+// TestExprEqual_DeeplyNested verifies Equal recurses through deep
+// trees correctly. A 4-level Binary that differs only in the deepest
+// literal must return false.
+func TestExprEqual_DeeplyNested(t *testing.T) {
+	t.Parallel()
+
+	build := func(deepest int64) chplan.Expr {
+		return &chplan.Binary{
+			Op:   chplan.OpAdd,
+			Left: &chplan.LitInt{V: 1},
+			Right: &chplan.Binary{
+				Op:   chplan.OpAdd,
+				Left: &chplan.LitInt{V: 2},
+				Right: &chplan.Binary{
+					Op:    chplan.OpAdd,
+					Left:  &chplan.LitInt{V: 3},
+					Right: &chplan.LitInt{V: deepest},
+				},
+			},
+		}
+	}
+	if !build(99).Equal(build(99)) {
+		t.Errorf("Equal: identical 4-deep trees should be Equal")
+	}
+	if build(99).Equal(build(100)) {
+		t.Errorf("Equal: 4-deep trees differing only in deepest leaf should NOT be Equal")
+	}
+}

--- a/internal/chsql/emit_negatives_test.go
+++ b/internal/chsql/emit_negatives_test.go
@@ -1,0 +1,158 @@
+package chsql_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+)
+
+// TestEmit_NilNode — calling Emit on a nil node returns ErrUnsupported
+// instead of panicking. The handler / optimizer paths can pass a nil
+// in pathological cases (e.g., an over-eager optimizer rule replaces
+// a node with nil); catching it here is friendlier than crashing.
+func TestEmit_NilNode(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := chsql.Emit(nil)
+	if err == nil {
+		t.Fatalf("Emit(nil) returned nil error; expected ErrUnsupported")
+	}
+	if !errors.Is(err, chsql.ErrUnsupported) {
+		t.Errorf("Emit(nil) returned %v; expected wrapped ErrUnsupported", err)
+	}
+}
+
+// TestEmit_AggregateMissingBoth — an Aggregate with no GroupBy and no
+// AggFuncs is meaningless (no output columns); emit must error
+// rather than producing `SELECT FROM (...)` which CH would reject.
+func TestEmit_AggregateMissingBoth(t *testing.T) {
+	t.Parallel()
+
+	plan := &chplan.Aggregate{
+		Input: &chplan.Scan{Table: "otel_metrics_gauge"},
+	}
+	_, _, err := chsql.Emit(plan)
+	if err == nil {
+		t.Fatalf("Emit(Aggregate with no GroupBy/AggFuncs) returned nil error")
+	}
+	if !errors.Is(err, chsql.ErrUnsupported) {
+		t.Errorf("expected wrapped ErrUnsupported; got %v", err)
+	}
+}
+
+// TestEmit_RangeWindowMissingColumns — RangeWindow needs both
+// TimestampColumn and ValueColumn set; emit must error early rather
+// than producing SQL with empty column references.
+func TestEmit_RangeWindowMissingColumns(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		rw   *chplan.RangeWindow
+	}{
+		{
+			"TimestampColumn unset",
+			&chplan.RangeWindow{
+				Input:       &chplan.Scan{Table: "otel_metrics_sum"},
+				Func:        "rate",
+				Range:       5 * time.Minute,
+				ValueColumn: "Value", // TimestampColumn missing
+			},
+		},
+		{
+			"ValueColumn unset",
+			&chplan.RangeWindow{
+				Input:           &chplan.Scan{Table: "otel_metrics_sum"},
+				Func:            "rate",
+				Range:           5 * time.Minute,
+				TimestampColumn: "TimeUnix", // ValueColumn missing
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, _, err := chsql.Emit(tc.rw)
+			if err == nil {
+				t.Fatalf("Emit(%s) returned nil error", tc.name)
+			}
+			if !errors.Is(err, chsql.ErrUnsupported) {
+				t.Errorf("expected wrapped ErrUnsupported; got %v", err)
+			}
+		})
+	}
+}
+
+// TestEmit_RangeWindowUnknownFunc — RangeWindow with a function name
+// the emitter doesn't know about must error with a clear message.
+func TestEmit_RangeWindowUnknownFunc(t *testing.T) {
+	t.Parallel()
+
+	plan := &chplan.RangeWindow{
+		Input:           &chplan.Scan{Table: "otel_metrics_sum"},
+		Func:            "wharblgarbl",
+		Range:           5 * time.Minute,
+		TimestampColumn: "TimeUnix",
+		ValueColumn:     "Value",
+	}
+	_, _, err := chsql.Emit(plan)
+	if err == nil {
+		t.Fatalf("Emit(RangeWindow with unknown Func) returned nil")
+	}
+	if !errors.Is(err, chsql.ErrUnsupported) {
+		t.Errorf("expected wrapped ErrUnsupported; got %v", err)
+	}
+}
+
+// TestEmit_StructuralJoinMissingColumns — StructuralJoin needs
+// TraceIDColumn / SpanIDColumn / ParentSpanIDColumn set; emit must
+// reject early.
+func TestEmit_StructuralJoinMissingColumns(t *testing.T) {
+	t.Parallel()
+
+	plan := &chplan.StructuralJoin{
+		Left:  &chplan.Scan{Table: "otel_traces"},
+		Right: &chplan.Scan{Table: "otel_traces"},
+		Op:    chplan.StructuralChild,
+		// All column names unset.
+	}
+	_, _, err := chsql.Emit(plan)
+	if err == nil {
+		t.Fatalf("Emit(StructuralJoin with no columns) returned nil")
+	}
+	if !errors.Is(err, chsql.ErrUnsupported) {
+		t.Errorf("expected wrapped ErrUnsupported; got %v", err)
+	}
+}
+
+// TestEmit_StructuralJoinRecursiveOpRejected — `>>` (descendant) and
+// `<<` (ancestor) are mapped at the lowering layer but the emitter
+// doesn't yet produce JOIN-on-prefix SQL. Emit must reject cleanly
+// rather than producing broken SQL.
+func TestEmit_StructuralJoinRecursiveOpRejected(t *testing.T) {
+	t.Parallel()
+
+	for _, op := range []chplan.StructuralOp{chplan.StructuralDescendant, chplan.StructuralAncestor} {
+		t.Run(string(op), func(t *testing.T) {
+			t.Parallel()
+			plan := &chplan.StructuralJoin{
+				Left:               &chplan.Scan{Table: "otel_traces"},
+				Right:              &chplan.Scan{Table: "otel_traces"},
+				Op:                 op,
+				TraceIDColumn:      "TraceId",
+				SpanIDColumn:       "SpanId",
+				ParentSpanIDColumn: "ParentSpanId",
+			}
+			_, _, err := chsql.Emit(plan)
+			if err == nil {
+				t.Fatalf("Emit(StructuralJoin %s) returned nil; recursive form should error until RC2", op)
+			}
+			if !errors.Is(err, chsql.ErrUnsupported) {
+				t.Errorf("expected wrapped ErrUnsupported; got %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Pins the contracts I never had assertions on across cerberus's IR + emitter:

### \`internal/chplan/node_negatives_test.go\`
- \`TestEqual_MismatchedNodeTypes\` — every cross-type combination (Scan vs Filter, Filter vs Project, Aggregate vs Limit, RangeWindow vs Filter, VectorJoin vs StructuralJoin) returns false in both directions
- \`TestExprEqual_MismatchedTypes\` — same for Expr (ColumnRef vs LitString, LitInt vs LitFloat, Binary vs FuncCall, MapAccess vs FieldAccess, FuncCall vs LineContent)
- \`TestExprEqual_SameTypeDifferentValues\` — same concrete type but observably different inner state must return false (different Binary.Op, different FuncCall.Name, different FuncCall arg count, different MapAccess.Key, different LineContent.Negated/IsRegex flags, etc.)
- \`TestExprEqual_DeeplyNested\` — 4-level Binary tree differing only in the deepest literal verifies Equal recurses correctly

### \`internal/chsql/emit_negatives_test.go\`
- \`TestEmit_NilNode\` — \`Emit(nil)\` returns wrapped \`ErrUnsupported\`, no panic
- \`TestEmit_AggregateMissingBoth\` — Aggregate with no GroupBy and no AggFuncs errors (meaningless plan)
- \`TestEmit_RangeWindowMissingColumns\` — RangeWindow without TimestampColumn or ValueColumn errors early
- \`TestEmit_RangeWindowUnknownFunc\` — unknown range-function name errors
- \`TestEmit_StructuralJoinMissingColumns\` — StructuralJoin without TraceIDColumn/SpanIDColumn/ParentSpanIDColumn errors
- \`TestEmit_StructuralJoinRecursiveOpRejected\` — \`>>\` / \`<<\` must error (recursive form lands in RC2). Regression-guards the M4.2 deferral.

All emit errors wrap \`ErrUnsupported\` via \`errors.Is\` so callers can pattern-match.

## Test plan

- [ ] CI: \`check + lint + dashboard\` green
- [ ] ~30 new sub-tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)