### PR TITLE
test(spec/logql): 9 new TXTAR fixtures for parser edge cases

### DIFF
--- a/test/spec/logql/bytes_over_time_query.txtar
+++ b/test/spec/logql/bytes_over_time_query.txtar
@@ -1,0 +1,7 @@
+-- query.logql --
+bytes_over_time({job="api"}[1h])
+-- sql --
+SELECT `ResourceAttributes`, arraySum(window_vals) AS value FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS window_vals, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS counter_delta FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) >= now64(9) - toIntervalNanosecond(3600000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS window_pairs FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS series_array FROM (SELECT `ResourceAttributes`, `Timestamp`, length(`Body`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_logs`) WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`)))
+-- args --
+[0] string = "job"
+[1] string = "api"

--- a/test/spec/logql/bytes_rate_query.txtar
+++ b/test/spec/logql/bytes_rate_query.txtar
@@ -1,0 +1,8 @@
+-- query.logql --
+bytes_rate({job="api"}[5m])
+-- sql --
+SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS value FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS window_vals, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS counter_delta FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) >= now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS window_pairs FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS series_array FROM (SELECT `ResourceAttributes`, `Timestamp`, length(`Body`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_logs`) WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`)))
+-- args --
+[0] float64 = 300
+[1] string = "job"
+[2] string = "api"

--- a/test/spec/logql/filter_with_or_alt.txtar
+++ b/test/spec/logql/filter_with_or_alt.txtar
@@ -1,0 +1,9 @@
+-- query.logql --
+{job="api"} |= "error" or "warn"
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_logs`) WHERE ((`ResourceAttributes`[?] = ?) AND ((position(`Body`, ?) > 0) OR (position(`Body`, ?) > 0)))
+-- args --
+[0] string = "job"
+[1] string = "api"
+[2] string = "error"
+[3] string = "warn"

--- a/test/spec/logql/level_label_filter.txtar
+++ b/test/spec/logql/level_label_filter.txtar
@@ -1,0 +1,9 @@
+-- query.logql --
+{job="api"} | level="ERROR"
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_logs`) WHERE ((`ResourceAttributes`[?] = ?) AND (`ResourceAttributes`[?] = ?))
+-- args --
+[0] string = "job"
+[1] string = "api"
+[2] string = "level"
+[3] string = "ERROR"

--- a/test/spec/logql/multiple_label_matchers.txtar
+++ b/test/spec/logql/multiple_label_matchers.txtar
@@ -1,0 +1,9 @@
+-- query.logql --
+{job="api",env="prod"}
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_logs`) WHERE ((`ResourceAttributes`[?] = ?) AND (`ResourceAttributes`[?] = ?))
+-- args --
+[0] string = "job"
+[1] string = "api"
+[2] string = "env"
+[3] string = "prod"

--- a/test/spec/logql/not_eq_matcher.txtar
+++ b/test/spec/logql/not_eq_matcher.txtar
@@ -1,0 +1,9 @@
+-- query.logql --
+{job="api",env!="prod"}
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_logs`) WHERE ((`ResourceAttributes`[?] = ?) AND (`ResourceAttributes`[?] != ?))
+-- args --
+[0] string = "job"
+[1] string = "api"
+[2] string = "env"
+[3] string = "prod"

--- a/test/spec/logql/regex_alternation_filter.txtar
+++ b/test/spec/logql/regex_alternation_filter.txtar
@@ -1,0 +1,8 @@
+-- query.logql --
+{job="api"} |~ "(error|warn)"
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_logs`) WHERE ((`ResourceAttributes`[?] = ?) AND match(`Body`, ?))
+-- args --
+[0] string = "job"
+[1] string = "api"
+[2] string = "(error|warn)"

--- a/test/spec/logql/three_filter_chain.txtar
+++ b/test/spec/logql/three_filter_chain.txtar
@@ -1,0 +1,10 @@
+-- query.logql --
+{job="api"} |= "a" != "b" |~ "c"
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_logs`) WHERE ((`ResourceAttributes`[?] = ?) AND (((position(`Body`, ?) > 0) AND (position(`Body`, ?) = 0)) AND match(`Body`, ?)))
+-- args --
+[0] string = "job"
+[1] string = "api"
+[2] string = "a"
+[3] string = "b"
+[4] string = "c"

--- a/test/spec/logql/whitespace_in_braces.txtar
+++ b/test/spec/logql/whitespace_in_braces.txtar
@@ -1,0 +1,7 @@
+-- query.logql --
+{ job = "api" }
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_logs`) WHERE (`ResourceAttributes`[?] = ?)
+-- args --
+[0] string = "job"
+[1] string = "api"


### PR DESCRIPTION
## Summary

LogQL parser shapes cerberus's lowering already handles, locked in as golden fixtures so a regression shows up as a TXTAR diff.

## Coverage adds (9 fixtures)

| Fixture | Input | Notes |
|---|---|---|
| \`whitespace_in_braces\` | \`{ job = "api" }\` | whitespace tolerated |
| \`three_filter_chain\` | \`{job="api"} \|= "a" != "b" \|~ "c"\` | three line filters (AND-fold) |
| \`filter_with_or_alt\` | \`{job="api"} \|= "error" or "warn"\` | OR-fold |
| \`regex_alternation_filter\` | \`{job="api"} \|~ "(error\|warn)"\` | regex alternation |
| \`multiple_label_matchers\` | \`{job="api",env="prod"}\` | multi-matcher in one selector |
| \`not_eq_matcher\` | \`{job="api",env!="prod"}\` | \`!=\` matcher alongside \`=\` |
| \`level_label_filter\` | \`{job="api"} \| level="ERROR"\` | string-equality label filter |
| \`bytes_rate_query\` | \`bytes_rate({job="api"}[5m])\` | bytes_rate range aggregation |
| \`bytes_over_time_query\` | \`bytes_over_time({job="api"}[1h])\` | bytes_over_time |

## Dropped during \`GOLDEN_UPDATE\` run

- \`duration_label_filter\` (\`| latency > 250ms\`) — cerberus rejects \`DurationLabelFilter\` at the lowering layer (RC2 deferral)
- \`numeric_label_filter\` (\`| status_code >= 500\`) — same, numeric label filters not yet lowered (RC2 deferral)
- \`empty_label_value\` (\`{job=""}\`) — upstream parser rejects selectors with only-empty matchers

## Test plan

- [x] \`GOLDEN_UPDATE=1 go test ./internal/logql/...\` populates all 9 fixtures cleanly
- [x] LogQL fixture count: 21 → 30
- [ ] CI: \`check + lint + dashboard\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)