### PR TITLE
test(spec/traceql): 11 new TXTAR fixtures for parser edge cases

### DIFF
--- a/test/spec/traceql/attribute_arithmetic_add.txtar
+++ b/test/spec/traceql/attribute_arithmetic_add.txtar
@@ -1,0 +1,8 @@
+-- query.traceql --
+{ .a + .b > 10 }
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE ((`SpanAttributes`[?] + `SpanAttributes`[?]) > ?)
+-- args --
+[0] string = "a"
+[1] string = "b"
+[2] int64 = 10

--- a/test/spec/traceql/attribute_arithmetic_mul.txtar
+++ b/test/spec/traceql/attribute_arithmetic_mul.txtar
@@ -1,0 +1,8 @@
+-- query.traceql --
+{ .a * 2 > 10 }
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE ((`SpanAttributes`[?] * ?) > ?)
+-- args --
+[0] string = "a"
+[1] int64 = 2
+[2] int64 = 10

--- a/test/spec/traceql/count_eq_zero.txtar
+++ b/test/spec/traceql/count_eq_zero.txtar
@@ -1,0 +1,9 @@
+-- query.traceql --
+{ resource.service.name = "frontend" } | count() = 0
+-- sql --
+SELECT * FROM (SELECT count(?) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`ResourceAttributes`[?] = ?))) WHERE (`Value` = ?)
+-- args --
+[0] int64 = 1
+[1] string = "service.name"
+[2] string = "frontend"
+[3] int64 = 0

--- a/test/spec/traceql/count_lt_threshold.txtar
+++ b/test/spec/traceql/count_lt_threshold.txtar
@@ -1,0 +1,9 @@
+-- query.traceql --
+{ resource.service.name = "frontend" } | count() < 10
+-- sql --
+SELECT * FROM (SELECT count(?) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`ResourceAttributes`[?] = ?))) WHERE (`Value` < ?)
+-- args --
+[0] int64 = 1
+[1] string = "service.name"
+[2] string = "frontend"
+[3] int64 = 10

--- a/test/spec/traceql/duration_ge.txtar
+++ b/test/spec/traceql/duration_ge.txtar
@@ -1,0 +1,6 @@
+-- query.traceql --
+{ duration >= 1s }
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`Duration` >= ?)
+-- args --
+[0] int64 = 1000000000

--- a/test/spec/traceql/duration_lt.txtar
+++ b/test/spec/traceql/duration_lt.txtar
@@ -1,0 +1,6 @@
+-- query.traceql --
+{ duration < 50ms }
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`Duration` < ?)
+-- args --
+[0] int64 = 50000000

--- a/test/spec/traceql/multi_attr_compound.txtar
+++ b/test/spec/traceql/multi_attr_compound.txtar
@@ -1,0 +1,10 @@
+-- query.traceql --
+{ resource.service.name = "frontend" && span.http.status_code = 500 && duration > 100ms }
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (((`ResourceAttributes`[?] = ?) AND (`SpanAttributes`[?] = ?)) AND (`Duration` > ?))
+-- args --
+[0] string = "service.name"
+[1] string = "frontend"
+[2] string = "http.status_code"
+[3] int64 = 500
+[4] int64 = 100000000

--- a/test/spec/traceql/select_one_attr.txtar
+++ b/test/spec/traceql/select_one_attr.txtar
@@ -1,0 +1,8 @@
+-- query.traceql --
+{ resource.service.name = "frontend" } | select(span.http.method)
+-- sql --
+SELECT `TraceId`, `SpanId`, `Timestamp`, `SpanAttributes`[?] AS `http.method` FROM (SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`ResourceAttributes`[?] = ?))
+-- args --
+[0] string = "http.method"
+[1] string = "service.name"
+[2] string = "frontend"

--- a/test/spec/traceql/static_float.txtar
+++ b/test/spec/traceql/static_float.txtar
@@ -1,0 +1,7 @@
+-- query.traceql --
+{ .ratio = 0.95 }
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`SpanAttributes`[?] = ?)
+-- args --
+[0] string = "ratio"
+[1] float64 = 0.95

--- a/test/spec/traceql/static_int.txtar
+++ b/test/spec/traceql/static_int.txtar
@@ -1,0 +1,7 @@
+-- query.traceql --
+{ .attempt = 1 }
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`SpanAttributes`[?] = ?)
+-- args --
+[0] string = "attempt"
+[1] int64 = 1

--- a/test/spec/traceql/status_code_eq.txtar
+++ b/test/spec/traceql/status_code_eq.txtar
@@ -1,0 +1,7 @@
+-- query.traceql --
+{ span.http.status_code = 200 }
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`SpanAttributes`[?] = ?)
+-- args --
+[0] string = "http.status_code"
+[1] int64 = 200


### PR DESCRIPTION
## Summary

TraceQL parser shapes cerberus's lowering already handles, locked in as golden fixtures.

## Coverage adds (11 fixtures)

| Fixture | Input |
|---|---|
| \`static_int\` | \`{ .attempt = 1 }\` |
| \`static_float\` | \`{ .ratio = 0.95 }\` |
| \`status_code_eq\` | \`{ span.http.status_code = 200 }\` |
| \`duration_lt\` | \`{ duration < 50ms }\` |
| \`duration_ge\` | \`{ duration >= 1s }\` |
| \`attribute_arithmetic_add\` | \`{ .a + .b > 10 }\` |
| \`attribute_arithmetic_mul\` | \`{ .a * 2 > 10 }\` |
| \`multi_attr_compound\` | 3-clause \`&&\` chain |
| \`count_eq_zero\` | \`\| count() = 0\` |
| \`count_lt_threshold\` | \`\| count() < 10\` |
| \`select_one_attr\` | \`\| select(span.http.method)\` |

## Dropped during \`GOLDEN_UPDATE\` run

- \`nested_and_or_parens\` (\`(... = "GET" || ... = "POST")\`) — the Tempo parser collapses this into an \`IN\` operator (interesting discovery!), which cerberus doesn't yet lower. Useful future fixture once IN lands as part of an RC2 follow-up.

## Test plan

- [x] \`GOLDEN_UPDATE=1 go test ./internal/traceql/...\` populates all 11 fixtures cleanly
- [x] TraceQL fixture count: 26 → 37
- [ ] CI: \`check + lint + dashboard\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)