### PR TITLE
test(spec): chsql IR shapes + optimizer rule-interaction fixtures

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,1 @@
-{"sessionId":"f5574358-7c30-4259-abb7-a23e8e6d99e4","pid":3019247,"procStart":"78622179","acquiredAt":1778540677780}
+{"sessionId":"f5574358-7c30-4259-abb7-a23e8e6d99e4","pid":305230,"procStart":"87577653","acquiredAt":1778601367388}

--- a/internal/chsql/emit_test.go
+++ b/internal/chsql/emit_test.go
@@ -299,6 +299,128 @@ var plans = map[string]chplan.Node{
 			},
 		},
 	},
+
+	// nested_filters_no_fuse: two explicit Filter wrappers should emit
+	// nested subqueries; the optimizer's filter-fusion only fires when
+	// the driver runs over the tree. At the chsql layer, the IR is
+	// emitted as-is.
+	"nested_filters_no_fuse": &chplan.Filter{
+		Input: &chplan.Filter{
+			Input: &chplan.Scan{Table: "otel_metrics_gauge"},
+			Predicate: &chplan.Binary{
+				Op: chplan.OpEq, Left: &chplan.ColumnRef{Name: "MetricName"}, Right: &chplan.LitString{V: "up"},
+			},
+		},
+		Predicate: &chplan.Binary{
+			Op: chplan.OpEq, Left: &chplan.ColumnRef{Name: "job"}, Right: &chplan.LitString{V: "api"},
+		},
+	},
+
+	// project_on_aggregate: outer Project rewrapping an Aggregate's
+	// output. Common pattern after the wrap-sample projection in
+	// api/prom/handler.go.
+	"project_on_aggregate": &chplan.Project{
+		Input: &chplan.Aggregate{
+			Input:   &chplan.Scan{Table: "otel_metrics_gauge"},
+			GroupBy: []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+			AggFuncs: []chplan.AggFunc{
+				{Name: "sum", Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}, Alias: "total"},
+			},
+		},
+		Projections: []chplan.Projection{
+			{Expr: &chplan.ColumnRef{Name: "Attributes"}, Alias: "attrs"},
+			{Expr: &chplan.ColumnRef{Name: "total"}, Alias: "v"},
+		},
+	},
+
+	// filter_on_aggregate: HAVING-shape. Filter sits on top of an
+	// Aggregate's grouped output. The scalar-filter lowering for TraceQL's
+	// `| count() > 0` produces this shape.
+	"filter_on_aggregate": &chplan.Filter{
+		Input: &chplan.Aggregate{
+			Input:   &chplan.Scan{Table: "otel_metrics_gauge"},
+			GroupBy: []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+			AggFuncs: []chplan.AggFunc{
+				{Name: "count", Args: []chplan.Expr{&chplan.LitInt{V: 1}}, Alias: "Value"},
+			},
+		},
+		Predicate: &chplan.Binary{
+			Op: chplan.OpGt, Left: &chplan.ColumnRef{Name: "Value"}, Right: &chplan.LitInt{V: 0},
+		},
+	},
+
+	// vector_join_set_and: VectorJoin with OpAnd (set-intersection
+	// shape). Unusual operator on this node but the IR allows it.
+	"vector_join_set_and": &chplan.VectorJoin{
+		Left:             &chplan.Scan{Table: "otel_metrics_gauge"},
+		Right:            &chplan.Scan{Table: "otel_metrics_sum"},
+		Op:               chplan.OpAnd,
+		Match:            chplan.VectorMatch{Labels: []string{"job"}, On: true},
+		MetricNameColumn: "MetricName",
+		AttributesColumn: "Attributes",
+		TimestampColumn:  "TimeUnix",
+		ValueColumn:      "Value",
+	},
+
+	// func_call_zero_args: CH function with no arguments — `now()`.
+	"project_func_call_zero_args": &chplan.Project{
+		Input: &chplan.Scan{Table: "otel_metrics_gauge"},
+		Projections: []chplan.Projection{
+			{Expr: &chplan.FuncCall{Name: "now"}, Alias: "current_time"},
+		},
+	},
+
+	// map_access_special_key: MapAccess key containing a literal dot
+	// and underscores — common shape for OTel `service.name`,
+	// `http.status_code`, etc. The emitter must bind the key as a
+	// parameter (not splice into the SQL), so CH-special chars in the
+	// key are no-op.
+	"filter_map_access_dotted_key": &chplan.Filter{
+		Input: &chplan.Scan{Table: "otel_traces"},
+		Predicate: &chplan.Binary{
+			Op: chplan.OpEq,
+			Left: &chplan.MapAccess{
+				Map: &chplan.ColumnRef{Name: "SpanAttributes"},
+				Key: &chplan.LitString{V: "http.status_code"},
+			},
+			Right: &chplan.LitInt{V: 200},
+		},
+	},
+
+	// deeply_nested_binary: 4-level nested Binary tree. Verifies
+	// emitBinary parenthesizes correctly across multiple depths.
+	"filter_deeply_nested_binary": &chplan.Filter{
+		Input: &chplan.Scan{Table: "otel_metrics_gauge"},
+		Predicate: &chplan.Binary{
+			Op: chplan.OpAnd,
+			Left: &chplan.Binary{
+				Op:    chplan.OpEq,
+				Left:  &chplan.ColumnRef{Name: "MetricName"},
+				Right: &chplan.LitString{V: "up"},
+			},
+			Right: &chplan.Binary{
+				Op: chplan.OpOr,
+				Left: &chplan.Binary{
+					Op: chplan.OpAnd,
+					Left: &chplan.Binary{
+						Op:    chplan.OpEq,
+						Left:  &chplan.ColumnRef{Name: "job"},
+						Right: &chplan.LitString{V: "api"},
+					},
+					Right: &chplan.Binary{
+						Op:    chplan.OpGt,
+						Left:  &chplan.ColumnRef{Name: "Value"},
+						Right: &chplan.LitFloat{V: 0.5},
+					},
+				},
+				Right: &chplan.Binary{
+					Op:    chplan.OpEq,
+					Left:  &chplan.ColumnRef{Name: "MetricName"},
+					Right: &chplan.LitString{V: "down"},
+				},
+			},
+		},
+	},
 }
 
 func TestEmit(t *testing.T) {

--- a/internal/optimizer/optimizer_test.go
+++ b/internal/optimizer/optimizer_test.go
@@ -82,6 +82,64 @@ var inputs = map[string]chplan.Node{
 			{Expr: &chplan.ColumnRef{Name: "TimeUnix"}, Alias: "t"},
 		},
 	},
+
+	// filter_fusion_after_constant_fold: outer predicate is
+	// `LitBool(true) AND <real>` — constant-fold reduces to `<real>`,
+	// then filter-fusion can run on the result. Tests that the
+	// driver re-applies rules after a change (fixpoint behaviour).
+	"filter_fusion_after_constant_fold": &chplan.Filter{
+		Input: &chplan.Filter{
+			Input: &chplan.Scan{Table: "otel_metrics_gauge"},
+			Predicate: &chplan.Binary{
+				Op:    chplan.OpEq,
+				Left:  &chplan.ColumnRef{Name: "MetricName"},
+				Right: &chplan.LitString{V: "up"},
+			},
+		},
+		Predicate: &chplan.Binary{
+			Op:   chplan.OpAnd,
+			Left: &chplan.LitBool{V: true},
+			Right: &chplan.Binary{
+				Op:    chplan.OpEq,
+				Left:  &chplan.ColumnRef{Name: "job"},
+				Right: &chplan.LitString{V: "api"},
+			},
+		},
+	},
+
+	// nested_filter_fold: three-deep Filter(Filter(Filter(Scan)))
+	// with non-trivial predicates. Verifies fusion runs to fixpoint
+	// (collapses all three Filters into one AND-of-three).
+	"nested_filter_fold": &chplan.Filter{
+		Input: &chplan.Filter{
+			Input: &chplan.Filter{
+				Input: &chplan.Scan{Table: "otel_metrics_gauge"},
+				Predicate: &chplan.Binary{
+					Op: chplan.OpEq, Left: &chplan.ColumnRef{Name: "MetricName"}, Right: &chplan.LitString{V: "up"},
+				},
+			},
+			Predicate: &chplan.Binary{
+				Op: chplan.OpEq, Left: &chplan.ColumnRef{Name: "job"}, Right: &chplan.LitString{V: "api"},
+			},
+		},
+		Predicate: &chplan.Binary{
+			Op: chplan.OpGt, Left: &chplan.ColumnRef{Name: "Value"}, Right: &chplan.LitFloat{V: 0},
+		},
+	},
+
+	// constant_fold_idempotent: an already-folded predicate (no
+	// constants to reduce) — the fixture records optimized SQL
+	// byte-identical to unoptimized. Sanity check that the driver
+	// doesn't rewrite already-optimal plans into something
+	// semantically equivalent-but-different.
+	"constant_fold_idempotent": &chplan.Filter{
+		Input: &chplan.Scan{Table: "otel_metrics_gauge"},
+		Predicate: &chplan.Binary{
+			Op:    chplan.OpEq,
+			Left:  &chplan.ColumnRef{Name: "MetricName"},
+			Right: &chplan.LitString{V: "up"},
+		},
+	},
 }
 
 func TestOptimizer(t *testing.T) {

--- a/test/spec/chsql/filter_deeply_nested_binary.txtar
+++ b/test/spec/chsql/filter_deeply_nested_binary.txtar
@@ -1,0 +1,7 @@
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE ((`MetricName` = ?) AND (((`job` = ?) AND (`Value` > ?)) OR (`MetricName` = ?)))
+-- args --
+[0] string = "up"
+[1] string = "api"
+[2] float64 = 0.5
+[3] string = "down"

--- a/test/spec/chsql/filter_map_access_dotted_key.txtar
+++ b/test/spec/chsql/filter_map_access_dotted_key.txtar
@@ -1,0 +1,5 @@
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`SpanAttributes`[?] = ?)
+-- args --
+[0] string = "http.status_code"
+[1] int64 = 200

--- a/test/spec/chsql/filter_on_aggregate.txtar
+++ b/test/spec/chsql/filter_on_aggregate.txtar
@@ -1,0 +1,5 @@
+-- sql --
+SELECT * FROM (SELECT `Attributes`, count(?) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge`) GROUP BY `Attributes`) WHERE (`Value` > ?)
+-- args --
+[0] int64 = 1
+[1] int64 = 0

--- a/test/spec/chsql/nested_filters_no_fuse.txtar
+++ b/test/spec/chsql/nested_filters_no_fuse.txtar
@@ -1,0 +1,5 @@
+-- sql --
+SELECT * FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?)) WHERE (`job` = ?)
+-- args --
+[0] string = "up"
+[1] string = "api"

--- a/test/spec/chsql/project_func_call_zero_args.txtar
+++ b/test/spec/chsql/project_func_call_zero_args.txtar
@@ -1,0 +1,4 @@
+-- sql --
+SELECT now() AS `current_time` FROM (SELECT * FROM `otel_metrics_gauge`)
+-- args --
+(none)

--- a/test/spec/chsql/project_on_aggregate.txtar
+++ b/test/spec/chsql/project_on_aggregate.txtar
@@ -1,0 +1,4 @@
+-- sql --
+SELECT `Attributes` AS `attrs`, `total` AS `v` FROM (SELECT `Attributes`, sum(`Value`) AS `total` FROM (SELECT * FROM `otel_metrics_gauge`) GROUP BY `Attributes`)
+-- args --
+(none)

--- a/test/spec/chsql/vector_join_set_and.txtar
+++ b/test/spec/chsql/vector_join_set_and.txtar
@@ -1,0 +1,5 @@
+-- sql --
+SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` AND R.`Value`) AS `Value` FROM (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge`) GROUP BY `MetricName`, `Attributes`) AS L INNER JOIN (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT * FROM `otel_metrics_sum`) GROUP BY `MetricName`, `Attributes`) AS R ON L.`Attributes`[?] = R.`Attributes`[?]
+-- args --
+[0] string = "job"
+[1] string = "job"

--- a/test/spec/optimizer/constant_fold_idempotent.txtar
+++ b/test/spec/optimizer/constant_fold_idempotent.txtar
@@ -1,0 +1,4 @@
+-- unoptimized --
+SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?)
+-- optimized --
+SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?)

--- a/test/spec/optimizer/filter_fusion_after_constant_fold.txtar
+++ b/test/spec/optimizer/filter_fusion_after_constant_fold.txtar
@@ -1,0 +1,4 @@
+-- unoptimized --
+SELECT * FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?)) WHERE (? AND (`job` = ?))
+-- optimized --
+SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE ((`MetricName` = ?) AND (`job` = ?))

--- a/test/spec/optimizer/nested_filter_fold.txtar
+++ b/test/spec/optimizer/nested_filter_fold.txtar
@@ -1,0 +1,4 @@
+-- unoptimized --
+SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?)) WHERE (`job` = ?)) WHERE (`Value` > ?)
+-- optimized --
+SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (((`MetricName` = ?) AND (`job` = ?)) AND (`Value` > ?))


### PR DESCRIPTION
## Summary

Two related layers of TXTAR coverage.

### chsql additions (7 fixtures, 29 → 36 total)

| Fixture | What |
|---|---|
| \`nested_filters_no_fuse\` | Filter(Filter(Scan)) emitted as-is at the chsql layer (optimizer fuses; chsql shows pre-optimizer shape) |
| \`project_on_aggregate\` | outer Project on an Aggregate's output (common after wrap-sample projection) |
| \`filter_on_aggregate\` | HAVING-shape — TraceQL \`\| count() > 0\` lowers to this |
| \`vector_join_set_and\` | VectorJoin with OpAnd (set-intersection style) |
| \`project_func_call_zero_args\` | \`now()\` — exercises FuncCall zero-arg branch |
| \`filter_map_access_dotted_key\` | MapAccess key with \`.\` and \`_\` — verifies the key flows as a parameter |
| \`filter_deeply_nested_binary\` | 4-level nested Binary tree — emitBinary parenthesizes across depths |

### optimizer additions (3 fixtures, 4 → 7 total)

| Fixture | What |
|---|---|
| \`filter_fusion_after_constant_fold\` | Outer predicate \`LitBool(true) AND <real>\` → constant-fold reduces to \`<real>\`, then filter-fusion runs. Verifies the driver re-applies rules after a change (fixpoint behaviour). |
| \`nested_filter_fold\` | 3-deep Filter(Filter(Filter(Scan))) collapses to a single Filter with AND-of-three. |
| \`constant_fold_idempotent\` | Already-folded plan — fixture records optimized SQL byte-identical to unoptimized. Sanity check that the driver doesn't rewrite optimal plans. |

## Test plan

- [x] \`GOLDEN_UPDATE=1 go test ./internal/chsql/... ./internal/optimizer/...\` populates all 10 fixtures cleanly
- [ ] CI: \`check + lint + dashboard\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)