### PR TITLE
fix(test): data race in TestTraceByID_InvalidHex sub-tests

### DIFF
--- a/internal/api/tempo/handler_error_paths_test.go
+++ b/internal/api/tempo/handler_error_paths_test.go
@@ -106,6 +106,12 @@ func TestTraceByID_CHFailure(t *testing.T) {
 // strings; with no rows matching, the response is the standard
 // not-found envelope. Verify cerberus doesn't panic on weird input
 // (single quote, dollar sign, etc.).
+//
+// NOTE: sub-tests deliberately run sequentially (no inner
+// `t.Parallel()`) so they don't race on the shared `stubQuerier`'s
+// `lastSQL` / `lastArgs` fields. The outer `t.Parallel()` still
+// allows this test to run alongside other top-level tests in the
+// package — each of which builds its own stubQuerier instance.
 func TestTraceByID_InvalidHex(t *testing.T) {
 	t.Parallel()
 
@@ -120,7 +126,7 @@ func TestTraceByID_InvalidHex(t *testing.T) {
 	}
 	for _, id := range cases {
 		t.Run(id, func(t *testing.T) {
-			t.Parallel()
+			// No t.Parallel() inside — see comment above.
 			resp, err := http.Get(srv.URL + "/api/traces/" + id)
 			if err != nil {
 				t.Fatalf("GET: %v", err)


### PR DESCRIPTION
## Summary

PR #83 landed a sub-test loop in \`TestTraceByID_InvalidHex\` that called \`t.Parallel()\` inside \`t.Run(...)\` while all three sub-tests share the outer \`stubQuerier\`'s mutable \`lastSQL\` / \`lastArgs\` fields. Three goroutines writing the same struct concurrently → \`go test -race\` fires; every test in the \`internal/api/tempo\` package gets marked failed.

Fix: drop \`t.Parallel()\` inside the inner \`t.Run\` so the sub-tests run sequentially. Outer \`t.Parallel()\` stays, so the test still races against other top-level tests (each of which builds its own stubQuerier).

## Repro

\`go test -race ./internal/api/tempo/...\` on current main → race detected in \`stubQuerier.Query\` at \`handler_test.go:25-26\`.

## Impact

Was blocking #84 (parser smoke), #86 (PromQL TXTAR), #91 (Playwright) — all three pulled main into their CI runs after merging PR #83 and hit the same race.

## Test plan

- [ ] CI: \`check + lint + dashboard\` green
- [ ] Once this merges, #84/#86/#91 should go green on next update-branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)