### PR TITLE
fix(api): wrap-sample projection over derived plans

### DIFF
--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -193,7 +193,14 @@ func wrapWithLogSampleProjection(plan chplan.Node, s schema.Logs, expr syntax.Ex
 			Projections: []chplan.Projection{
 				{Expr: &chplan.LitString{V: ""}, Alias: "MetricName"},
 				{Expr: &chplan.ColumnRef{Name: s.ResourceAttributesColumn}, Alias: "Attributes"},
-				{Expr: &chplan.FuncCall{Name: "now64", Args: []chplan.Expr{&chplan.LitInt{V: 9}}}, Alias: "TimeUnix"},
+				// now64(9) - 5s buffer; see prom handler's synthesizedAnchor
+				// docstring. Avoids toMatrixStepGrid dropping the only row
+				// when CH-now > client-end.
+				{Expr: &chplan.Binary{
+					Op:    chplan.OpSub,
+					Left:  &chplan.FuncCall{Name: "now64", Args: []chplan.Expr{&chplan.LitInt{V: 9}}},
+					Right: &chplan.FuncCall{Name: "toIntervalNanosecond", Args: []chplan.Expr{&chplan.LitInt{V: 5_000_000_000}}},
+				}, Alias: "TimeUnix"},
 				{Expr: &chplan.ColumnRef{Name: "value"}, Alias: "Value"},
 			},
 		}

--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -184,15 +184,17 @@ func (h *Handler) execute(ctx context.Context, expr syntax.Expr) ([]chclient.Sam
 // the streams formatter), and the per-record Timestamp.
 func wrapWithLogSampleProjection(plan chplan.Node, s schema.Logs, expr syntax.Expr) chplan.Node {
 	if isMetricQuery(expr) {
-		// Metric queries' wrap-aggregate already produces sample shape;
-		// pass-through Project keeps the chclient column ordering.
+		// Metric queries lower to RangeWindow / Aggregate / Filter(Aggregate),
+		// whose output is just (group-keys…, value). MetricName + TimeUnix
+		// don't exist in that scope — synthesise them so the chclient
+		// Sample scanner has the four positional columns it expects.
 		return &chplan.Project{
 			Input: plan,
 			Projections: []chplan.Projection{
-				{Expr: &chplan.ColumnRef{Name: "MetricName"}},
-				{Expr: &chplan.ColumnRef{Name: "Attributes"}},
-				{Expr: &chplan.ColumnRef{Name: "TimeUnix"}},
-				{Expr: &chplan.ColumnRef{Name: "Value"}},
+				{Expr: &chplan.LitString{V: ""}, Alias: "MetricName"},
+				{Expr: &chplan.ColumnRef{Name: s.ResourceAttributesColumn}, Alias: "Attributes"},
+				{Expr: &chplan.FuncCall{Name: "now64", Args: []chplan.Expr{&chplan.LitInt{V: 9}}}, Alias: "TimeUnix"},
+				{Expr: &chplan.ColumnRef{Name: "value"}, Alias: "Value"},
 			},
 		}
 	}

--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -167,19 +167,51 @@ func (h *Handler) executeInstant(ctx context.Context, query string) ([]chclient.
 	return samples, nil
 }
 
-// wrapWithSampleProjection adds a Project on top of plan that selects
-// exactly MetricName, Attributes, TimeUnix, Value (in that order) so the
-// chclient.Sample scanner can decode rows positionally.
+// wrapWithSampleProjection adds a Project on top of plan that emits
+// the canonical chclient.Sample shape — (MetricName, Attributes,
+// TimeUnix, Value) — adapted to whatever the inner plan's output
+// schema actually exposes. Two distinct shapes are recognised:
+//
+//  1. Scan / Filter(Scan) — the otel_metrics_* columns are available
+//     directly; project MetricName / Attributes / TimeUnix / Value.
+//  2. RangeWindow / Aggregate / Filter(Aggregate) — derived shapes
+//     whose inner SELECT exposes only (group-keys…, value). The
+//     canonical MetricName and TimeUnix don't exist in that scope;
+//     synthesise them as empty string + now64() respectively. The
+//     value column comes from the RangeWindow / Aggregate output
+//     (always lowercase `value` by chsql convention).
 func wrapWithSampleProjection(plan chplan.Node, s schema.Metrics) chplan.Node {
-	return &chplan.Project{
-		Input: plan,
-		Projections: []chplan.Projection{
-			{Expr: &chplan.ColumnRef{Name: s.MetricNameColumn}},
-			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}},
-			{Expr: &chplan.ColumnRef{Name: s.TimestampColumn}},
-			{Expr: &chplan.ColumnRef{Name: s.ValueColumn}},
-		},
+	projections := []chplan.Projection{
+		{Expr: &chplan.ColumnRef{Name: s.MetricNameColumn}},
+		{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}},
+		{Expr: &chplan.ColumnRef{Name: s.TimestampColumn}},
+		{Expr: &chplan.ColumnRef{Name: s.ValueColumn}},
 	}
+	if isDerivedShape(plan) {
+		projections = []chplan.Projection{
+			{Expr: &chplan.LitString{V: ""}, Alias: s.MetricNameColumn},
+			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
+			{Expr: &chplan.FuncCall{Name: "now64", Args: []chplan.Expr{&chplan.LitInt{V: 9}}}, Alias: s.TimestampColumn},
+			{Expr: &chplan.ColumnRef{Name: "value"}, Alias: s.ValueColumn},
+		}
+	}
+	return &chplan.Project{Input: plan, Projections: projections}
+}
+
+// isDerivedShape reports whether the plan's output schema lacks the
+// canonical Sample columns (MetricName / TimeUnix / Value as-is) and
+// has only the (group-keys…, value) shape produced by RangeWindow,
+// Aggregate, or a Filter on top of one of those.
+func isDerivedShape(plan chplan.Node) bool {
+	switch v := plan.(type) {
+	case *chplan.RangeWindow, *chplan.Aggregate:
+		return true
+	case *chplan.Filter:
+		return isDerivedShape(v.Input)
+	case *chplan.Project:
+		return false
+	}
+	return false
 }
 
 // toVector groups samples by label set, picks the latest value per series,

--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -191,11 +191,34 @@ func wrapWithSampleProjection(plan chplan.Node, s schema.Metrics) chplan.Node {
 		projections = []chplan.Projection{
 			{Expr: &chplan.LitString{V: ""}, Alias: s.MetricNameColumn},
 			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
-			{Expr: &chplan.FuncCall{Name: "now64", Args: []chplan.Expr{&chplan.LitInt{V: 9}}}, Alias: s.TimestampColumn},
+			// Synthesised eval anchor: now64(9) minus 5s. The minus-5s
+			// buffer keeps the stamped TimeUnix safely within the request's
+			// [start, end] window — CH's now64() runs slightly after the
+			// client's `end` parameter (RTT + cluster clock skew), and
+			// toMatrixStepGrid drops samples timestamped past `end`. M2.1
+			// threads the API's `end` param into the plan so this hack
+			// goes away; until then 5s covers realistic skew.
+			{Expr: synthesizedAnchor(), Alias: s.TimestampColumn},
 			{Expr: &chplan.ColumnRef{Name: "value"}, Alias: s.ValueColumn},
 		}
 	}
 	return &chplan.Project{Input: plan, Projections: projections}
+}
+
+// synthesizedAnchor returns the CH expression cerberus stamps on
+// rate / count_over_time / … sample rows for query_range bucketing.
+// Equivalent to `now64(9) - toIntervalNanosecond(5e9)` — 5 seconds
+// before CH-now. See the docstring on wrapWithSampleProjection's
+// derived-shape branch for the rationale.
+func synthesizedAnchor() chplan.Expr {
+	return &chplan.Binary{
+		Op:   chplan.OpSub,
+		Left: &chplan.FuncCall{Name: "now64", Args: []chplan.Expr{&chplan.LitInt{V: 9}}},
+		Right: &chplan.FuncCall{
+			Name: "toIntervalNanosecond",
+			Args: []chplan.Expr{&chplan.LitInt{V: 5_000_000_000}},
+		},
+	}
 }
 
 // isDerivedShape reports whether the plan's output schema lacks the

--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -181,26 +181,106 @@ func (h *Handler) lowerTraceByID(traceID string) (chplan.Node, error) {
 	}, nil
 }
 
-// wrapWithSampleProjection adds a Project on top of plan that selects
-// the columns the chclient.Sample scanner expects positionally:
-// MetricName (used for SpanName here), Attributes (ResourceAttributes),
-// TimeUnix (Timestamp), Value (Duration as float64-castable). Tempo
-// queries reuse the same Sample shape for transport; the response
-// formatters re-derive richer span data from row context.
+// wrapWithSampleProjection adds a Project on top of plan that emits
+// the canonical chclient.Sample shape — (MetricName, Attributes,
+// TimeUnix, Value) — adapted to whatever the inner plan's output
+// schema actually exposes. Three distinct shapes are recognised:
+//
+//  1. Scan / Filter(Scan) — the otel_traces columns are available
+//     directly; project SpanName / ResourceAttributes / Timestamp /
+//     toFloat64(Duration).
+//  2. StructuralJoin — the emitter renders `SELECT R.* FROM (L)
+//     INNER JOIN (R) ON …`, which exposes R's columns as
+//     R-prefixed names (not unqualified). The wrap-projection uses
+//     ColumnRef.Qualifier="R" to reach them.
+//  3. Aggregate or Filter(Aggregate) — the inner SELECT is just
+//     `<group-keys>, <agg-funcs>`; SpanName / Timestamp / Duration
+//     don't exist in that scope. Synthesise MetricName="" and
+//     TimeUnix=now64(); read Value from the Aggregate's alias.
 func wrapWithSampleProjection(plan chplan.Node, s schema.Traces) chplan.Node {
-	return &chplan.Project{
-		Input: plan,
-		Projections: []chplan.Projection{
-			{Expr: &chplan.ColumnRef{Name: s.SpanNameColumn}, Alias: "MetricName"},
-			{Expr: &chplan.ColumnRef{Name: s.ResourceAttributesColumn}, Alias: "Attributes"},
-			{Expr: &chplan.ColumnRef{Name: s.TimestampColumn}, Alias: "TimeUnix"},
-			// Duration is Int64 (nanoseconds) in OTel-CH; chclient.Sample.Value
-			// is float64 and clickhouse-go's Scan refuses Int64→float64 without
-			// a cast. toFloat64 keeps the wire shape lossless within the
-			// 53-bit mantissa range (a 100-day duration in ns still fits).
-			{Expr: &chplan.FuncCall{Name: "toFloat64", Args: []chplan.Expr{&chplan.ColumnRef{Name: s.DurationColumn}}}, Alias: "Value"},
+	// Default shape — Scan / Filter(Scan) — canonical columns available.
+	projections := []chplan.Projection{
+		{Expr: &chplan.ColumnRef{Name: s.SpanNameColumn}, Alias: "MetricName"},
+		{Expr: &chplan.ColumnRef{Name: s.ResourceAttributesColumn}, Alias: "Attributes"},
+		{Expr: &chplan.ColumnRef{Name: s.TimestampColumn}, Alias: "TimeUnix"},
+		// Duration is Int64 (nanoseconds) in OTel-CH; chclient.Sample.Value
+		// is float64 and clickhouse-go's Scan refuses Int64→float64 without
+		// a cast. toFloat64 keeps the wire shape lossless within the
+		// 53-bit mantissa range (a 100-day duration in ns still fits).
+		{Expr: &chplan.FuncCall{Name: "toFloat64", Args: []chplan.Expr{&chplan.ColumnRef{Name: s.DurationColumn}}}, Alias: "Value"},
+	}
+
+	switch {
+	case isStructuralJoin(plan):
+		// CH exposes the right side of a self-join as R.<col>. Use the
+		// qualifier so the outer SELECT can reach those columns.
+		projections = []chplan.Projection{
+			{Expr: &chplan.ColumnRef{Qualifier: "R", Name: s.SpanNameColumn}, Alias: "MetricName"},
+			{Expr: &chplan.ColumnRef{Qualifier: "R", Name: s.ResourceAttributesColumn}, Alias: "Attributes"},
+			{Expr: &chplan.ColumnRef{Qualifier: "R", Name: s.TimestampColumn}, Alias: "TimeUnix"},
+			{Expr: &chplan.FuncCall{Name: "toFloat64", Args: []chplan.Expr{&chplan.ColumnRef{Qualifier: "R", Name: s.DurationColumn}}}, Alias: "Value"},
+		}
+	case isAggregateShape(plan):
+		// Aggregate output is just (group-keys, agg-func-aliases). SpanName
+		// and Duration aren't in scope; synthesise the missing pieces.
+		// The aggregate's alias is "Value" by convention (set by
+		// internal/traceql/aggregate.go); other code shapes that emit a
+		// different alias would need to thread it through. count() has
+		// no GROUP BY so ResourceAttributes isn't in scope either — use
+		// an empty Map(String,String) CAST, same pattern as PromQL's
+		// emptyAttrsMap helper.
+		projections = []chplan.Projection{
+			{Expr: &chplan.LitString{V: ""}, Alias: "MetricName"},
+			{Expr: emptyAttrsMap(), Alias: "Attributes"},
+			{Expr: &chplan.FuncCall{Name: "now64", Args: []chplan.Expr{&chplan.LitInt{V: 9}}}, Alias: "TimeUnix"},
+			{Expr: &chplan.FuncCall{Name: "toFloat64", Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}}, Alias: "Value"},
+		}
+	}
+
+	return &chplan.Project{Input: plan, Projections: projections}
+}
+
+// emptyAttrsMap returns a CH expression for an empty Map(String,String),
+// used when an Aggregate's GROUP BY is empty (e.g. bare `count()`) and
+// ResourceAttributes isn't in the inner scope. Mirrors the helper in
+// internal/promql/lower.go and internal/logql/vector_aggregation.go so
+// the rendered SQL has the same shape across the three QL surfaces.
+func emptyAttrsMap() chplan.Expr {
+	return &chplan.FuncCall{
+		Name: "CAST",
+		Args: []chplan.Expr{
+			&chplan.FuncCall{Name: "map", Args: nil},
+			&chplan.LitString{V: "Map(String,String)"},
 		},
 	}
+}
+
+// isStructuralJoin reports whether the plan root is a StructuralJoin
+// (or a thin wrapper over one). Today only the bare form needs the
+// R-qualifier handling; nested wrappers would need recursive shape
+// inspection — defer until a real call-site needs it.
+func isStructuralJoin(plan chplan.Node) bool {
+	_, ok := plan.(*chplan.StructuralJoin)
+	return ok
+}
+
+// isAggregateShape reports whether the plan's output schema is just
+// the Aggregate's projected columns (group-keys + agg-func aliases),
+// i.e. the otel_traces canonical columns aren't available. Covers
+// bare Aggregate, Filter(Aggregate) (TraceQL scalar-filter HAVING
+// shape), and Project(Aggregate) (potential future shape).
+func isAggregateShape(plan chplan.Node) bool {
+	switch v := plan.(type) {
+	case *chplan.Aggregate:
+		return true
+	case *chplan.Filter:
+		return isAggregateShape(v.Input)
+	case *chplan.Project:
+		// Explicit Project — assume the user took responsibility for
+		// the output columns.
+		return false
+	}
+	return false
 }
 
 // toTraceSummaries pivots samples into the per-trace summary shape

--- a/internal/chplan/expr.go
+++ b/internal/chplan/expr.go
@@ -12,15 +12,22 @@ type Expr interface {
 
 // ColumnRef references a ClickHouse column by name. Quoting and escaping
 // happen at emit time.
+//
+// Qualifier is optional. When non-empty, the emitter renders
+// `<Qualifier>.<Name>` (both identifiers backtick-quoted) — useful for
+// referencing columns out of a named join side (e.g. `R.SpanName` for
+// the right half of a chplan.StructuralJoin). Empty Qualifier emits
+// just the bare column name.
 type ColumnRef struct {
-	Name string
+	Name      string
+	Qualifier string
 }
 
 func (*ColumnRef) exprNode() {}
 
 func (c *ColumnRef) Equal(other Expr) bool {
 	o, ok := other.(*ColumnRef)
-	return ok && c.Name == o.Name
+	return ok && c.Name == o.Name && c.Qualifier == o.Qualifier
 }
 
 // LitString is a string literal. Emitted as a `?` placeholder with the value

--- a/internal/chplan/node_negatives_test.go
+++ b/internal/chplan/node_negatives_test.go
@@ -128,6 +128,16 @@ func TestExprEqual_SameTypeDifferentValues(t *testing.T) {
 		a, b chplan.Expr
 	}{
 		{"ColumnRef different name", &chplan.ColumnRef{Name: "a"}, &chplan.ColumnRef{Name: "b"}},
+		{
+			"ColumnRef different qualifier",
+			&chplan.ColumnRef{Name: "c", Qualifier: "L"},
+			&chplan.ColumnRef{Name: "c", Qualifier: "R"},
+		},
+		{
+			"ColumnRef qualifier vs bare",
+			&chplan.ColumnRef{Name: "c"},
+			&chplan.ColumnRef{Name: "c", Qualifier: "R"},
+		},
 		{"LitString different value", &chplan.LitString{V: "a"}, &chplan.LitString{V: "b"}},
 		{"LitInt different value", &chplan.LitInt{V: 1}, &chplan.LitInt{V: 2}},
 		{"LitFloat different value", &chplan.LitFloat{V: 1.0}, &chplan.LitFloat{V: 2.0}},

--- a/internal/chsql/emit_expr.go
+++ b/internal/chsql/emit_expr.go
@@ -9,6 +9,10 @@ import (
 func (e *emitter) emitExpr(x chplan.Expr) error {
 	switch v := x.(type) {
 	case *chplan.ColumnRef:
+		if v.Qualifier != "" {
+			writeIdent(&e.b, v.Qualifier)
+			e.b.WriteByte('.')
+		}
 		writeIdent(&e.b, v.Name)
 		return nil
 	case *chplan.LitString:

--- a/internal/chsql/emit_negatives_test.go
+++ b/internal/chsql/emit_negatives_test.go
@@ -2,6 +2,7 @@ package chsql_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -125,6 +126,35 @@ func TestEmit_StructuralJoinMissingColumns(t *testing.T) {
 	}
 	if !errors.Is(err, chsql.ErrUnsupported) {
 		t.Errorf("expected wrapped ErrUnsupported; got %v", err)
+	}
+}
+
+// TestEmit_ColumnRefQualifier — a ColumnRef with a non-empty Qualifier
+// renders `<qualifier>.<name>` (both backtick-quoted). Needed for
+// referencing the right-hand side of a StructuralJoin, whose emit
+// shape is `SELECT R.* FROM (L) JOIN (R) ON …` — outer projections
+// must address those columns through the `R` alias.
+func TestEmit_ColumnRefQualifier(t *testing.T) {
+	t.Parallel()
+
+	plan := &chplan.Project{
+		Input: &chplan.Scan{Table: "otel_traces"},
+		Projections: []chplan.Projection{
+			{Expr: &chplan.ColumnRef{Qualifier: "R", Name: "SpanName"}, Alias: "MetricName"},
+			{Expr: &chplan.ColumnRef{Name: "Timestamp"}, Alias: "TimeUnix"},
+		},
+	}
+	sql, _, err := chsql.Emit(plan)
+	if err != nil {
+		t.Fatalf("Emit returned unexpected error: %v", err)
+	}
+	want := "`R`.`SpanName`"
+	if !strings.Contains(sql, want) {
+		t.Errorf("emitted SQL missing qualified column ref:\n  got  %q\n  want it to contain %q", sql, want)
+	}
+	wantBare := "`Timestamp`"
+	if !strings.Contains(sql, wantBare) {
+		t.Errorf("emitted SQL missing bare column ref:\n  got  %q\n  want it to contain %q", sql, wantBare)
 	}
 }
 

--- a/test/e2e/e2e_loki_test.go
+++ b/test/e2e/e2e_loki_test.go
@@ -54,12 +54,12 @@ func TestLokiQueryStreamSelector(t *testing.T) {
 // TestLokiQueryRangeCountOverTime verifies the LogQL metric path
 // (M3.3): count_over_time({selector}[5m]) returns a matrix.
 //
-// Skipped until RC2 for the same reason as TestPromQueryRangeRate:
-// the wrap-projection over RangeWindow references columns the
-// windowed-array output doesn't carry, so CH responds with a
-// missing-columns error.
+// Un-skipped in RC2 alongside TestPromQueryRangeRate after
+// wrapWithLogSampleProjection / wrapWithSampleProjection became shape-
+// aware: the metric-query path now synthesises MetricName / TimeUnix
+// and aliases the windowed `value` column rather than referencing the
+// canonical Sample columns that only exist on the streams path.
 func TestLokiQueryRangeCountOverTime(t *testing.T) {
-	t.Skip("count_over_time projection deferred to RC2 — wrap-projection vs RangeWindow output column mismatch (same as TestPromQueryRangeRate)")
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 

--- a/test/e2e/e2e_loki_test.go
+++ b/test/e2e/e2e_loki_test.go
@@ -53,12 +53,6 @@ func TestLokiQueryStreamSelector(t *testing.T) {
 
 // TestLokiQueryRangeCountOverTime verifies the LogQL metric path
 // (M3.3): count_over_time({selector}[5m]) returns a matrix.
-//
-// Un-skipped in RC2 alongside TestPromQueryRangeRate after
-// wrapWithLogSampleProjection / wrapWithSampleProjection became shape-
-// aware: the metric-query path now synthesises MetricName / TimeUnix
-// and aliases the windowed `value` column rather than referencing the
-// canonical Sample columns that only exist on the streams path.
 func TestLokiQueryRangeCountOverTime(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()

--- a/test/e2e/e2e_prom_test.go
+++ b/test/e2e/e2e_prom_test.go
@@ -15,12 +15,6 @@ import (
 
 // TestPromQueryRangeRate exercises the M1.1 RangeWindow SQL path:
 // rate() over a 5-minute window against the seeded counter.
-//
-// Un-skipped in RC2 after wrapWithSampleProjection became shape-aware:
-// when the lowered plan root is a RangeWindow / Aggregate / Filter(Aggregate)
-// the wrap synthesises MetricName / TimeUnix and aliases the windowed
-// `value` column rather than referencing the canonical Sample columns
-// that only exist on a raw Scan.
 func TestPromQueryRangeRate(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()

--- a/test/e2e/e2e_prom_test.go
+++ b/test/e2e/e2e_prom_test.go
@@ -16,17 +16,12 @@ import (
 // TestPromQueryRangeRate exercises the M1.1 RangeWindow SQL path:
 // rate() over a 5-minute window against the seeded counter.
 //
-// Skipped until RC2: the wrap-sample projection on top of RangeWindow
-// references MetricName / TimeUnix / Value columns, but RangeWindow's
-// output is just (<group keys>, value). CH responds with a
-// "missing columns" error and the request returns 502. The fix lives
-// in either the chsql emitter (project group-keys + synthesise the
-// missing columns at the windowed-array boundary) or in executeInstant
-// (skip the wrap when the lowered plan root is a RangeWindow). The
-// existing Prom unit tests don't surface this because they stub the
-// Querier — only a real CH integration like this E2E exercise does.
+// Un-skipped in RC2 after wrapWithSampleProjection became shape-aware:
+// when the lowered plan root is a RangeWindow / Aggregate / Filter(Aggregate)
+// the wrap synthesises MetricName / TimeUnix and aliases the windowed
+// `value` column rather than referencing the canonical Sample columns
+// that only exist on a raw Scan.
 func TestPromQueryRangeRate(t *testing.T) {
-	t.Skip("rate-in-query_range projection deferred to RC2 — wrap-projection vs RangeWindow output column mismatch")
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 

--- a/test/e2e/e2e_tempo_extra_test.go
+++ b/test/e2e/e2e_tempo_extra_test.go
@@ -88,17 +88,12 @@ func TestTempoSearch_AndFilter(t *testing.T) {
 // TestTempoSearch_StructuralChild — `{ frontend } > { api }` runs the
 // inner-join self-query on (TraceId, ParentSpanId).
 //
-// Skipped until RC2: the wrap-sample projection on top of
-// StructuralJoin references SpanName/ResourceAttributes/Timestamp by
-// their bare names, but StructuralJoin's `SELECT R.* FROM ...` output
-// doesn't expose them without R-prefixed qualifiers. CH responds:
-//
-//	code 47, message: Unknown expression identifier 'SpanName' in scope
-//
-// Same bug class as TestPromQueryRangeRate (wrap-projection vs
-// derived-plan column mismatch). Tracked on the project board.
+// Un-skipped in RC2 once wrapWithSampleProjection became shape-aware:
+// when the lowered plan root is a StructuralJoin the wrap now
+// references the join's right-hand columns through an `R.` qualifier
+// (added to chplan.ColumnRef in the same change), matching the
+// `SELECT R.* FROM (L) INNER JOIN (R) ON ...` emit shape.
 func TestTempoSearch_StructuralChild(t *testing.T) {
-	t.Skip("wrap-projection over StructuralJoin column-scope mismatch — deferred to RC2 (same bug class as TestPromQueryRangeRate)")
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
@@ -120,13 +115,12 @@ func TestTempoSearch_StructuralChild(t *testing.T) {
 // TestTempoSearch_CountScalar — `{ frontend } | count() > 0` exercises
 // the Aggregate + ScalarFilter lowering.
 //
-// Skipped until RC2: the wrap-sample projection on top of
-// Filter(Aggregate(Scan)) references SpanName, but the Aggregate's
-// output is just `Value`. Same column-scope mismatch as
-// TestTempoSearch_StructuralChild; CH responds with code 47 "Unknown
-// expression identifier 'SpanName' in scope".
+// Un-skipped in RC2 alongside TestTempoSearch_StructuralChild: when the
+// lowered plan root is an Aggregate (or Filter(Aggregate)), the wrap
+// synthesises MetricName / TimeUnix / Attributes and aliases the
+// aggregate's `Value` column rather than referencing the canonical
+// Sample columns that only exist on a raw Scan.
 func TestTempoSearch_CountScalar(t *testing.T) {
-	t.Skip("wrap-projection over Filter(Aggregate) column-scope mismatch — deferred to RC2")
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 

--- a/test/e2e/e2e_tempo_extra_test.go
+++ b/test/e2e/e2e_tempo_extra_test.go
@@ -87,12 +87,6 @@ func TestTempoSearch_AndFilter(t *testing.T) {
 
 // TestTempoSearch_StructuralChild — `{ frontend } > { api }` runs the
 // inner-join self-query on (TraceId, ParentSpanId).
-//
-// Un-skipped in RC2 once wrapWithSampleProjection became shape-aware:
-// when the lowered plan root is a StructuralJoin the wrap now
-// references the join's right-hand columns through an `R.` qualifier
-// (added to chplan.ColumnRef in the same change), matching the
-// `SELECT R.* FROM (L) INNER JOIN (R) ON ...` emit shape.
 func TestTempoSearch_StructuralChild(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
@@ -114,12 +108,6 @@ func TestTempoSearch_StructuralChild(t *testing.T) {
 
 // TestTempoSearch_CountScalar — `{ frontend } | count() > 0` exercises
 // the Aggregate + ScalarFilter lowering.
-//
-// Un-skipped in RC2 alongside TestTempoSearch_StructuralChild: when the
-// lowered plan root is an Aggregate (or Filter(Aggregate)), the wrap
-// synthesises MetricName / TimeUnix / Attributes and aliases the
-// aggregate's `Value` column rather than referencing the canonical
-// Sample columns that only exist on a raw Scan.
 func TestTempoSearch_CountScalar(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()

--- a/test/e2e/playwright/loki_logs.spec.ts
+++ b/test/e2e/playwright/loki_logs.spec.ts
@@ -41,9 +41,6 @@ test('logql stream selector returns log lines', async ({ request }) => {
   }
 });
 
-// Un-skipped in RC2 alongside the prom_metrics rate test: the LogQL
-// metric path's wrapWithLogSampleProjection synthesises MetricName /
-// TimeUnix / Value when the lowered plan root is a RangeWindow.
 test('logql metric query returns a matrix', async ({ request }) => {
   // Range = last 5 minutes; step = 30s. Covers the 60s of seeded data.
   const now = Math.floor(Date.now() / 1000);

--- a/test/e2e/playwright/loki_logs.spec.ts
+++ b/test/e2e/playwright/loki_logs.spec.ts
@@ -41,10 +41,10 @@ test('logql stream selector returns log lines', async ({ request }) => {
   }
 });
 
-// Skipped until RC2: same wrap-projection-vs-RangeWindow column
-// mismatch as in prom_metrics.spec.ts. CH returns missing-columns;
-// cerberus surfaces 502.
-test.skip('logql metric query returns a matrix', async ({ request }) => {
+// Un-skipped in RC2 alongside the prom_metrics rate test: the LogQL
+// metric path's wrapWithLogSampleProjection synthesises MetricName /
+// TimeUnix / Value when the lowered plan root is a RangeWindow.
+test('logql metric query returns a matrix', async ({ request }) => {
   // Range = last 5 minutes; step = 30s. Covers the 60s of seeded data.
   const now = Math.floor(Date.now() / 1000);
   const start = now - 5 * 60;

--- a/test/e2e/playwright/prom_metrics.spec.ts
+++ b/test/e2e/playwright/prom_metrics.spec.ts
@@ -15,10 +15,6 @@ import { test, expect } from '@playwright/test';
 
 const promProxy = '/api/datasources/proxy/uid/cerberus-prometheus/api/v1';
 
-// Un-skipped in RC2 once wrapWithSampleProjection became shape-aware:
-// when the lowered plan root is a RangeWindow / Aggregate the wrap
-// synthesises MetricName / TimeUnix / Value rather than referencing
-// columns that only exist on a raw Scan.
 test('rate(http_server_request_duration_count[5m]) returns a matrix', async ({ request }) => {
   const now = Math.floor(Date.now() / 1000);
   const start = now - 5 * 60;

--- a/test/e2e/playwright/prom_metrics.spec.ts
+++ b/test/e2e/playwright/prom_metrics.spec.ts
@@ -15,10 +15,11 @@ import { test, expect } from '@playwright/test';
 
 const promProxy = '/api/datasources/proxy/uid/cerberus-prometheus/api/v1';
 
-// Skipped until RC2: wrap-sample projection over RangeWindow references
-// MetricName / TimeUnix / Value columns the windowed-array SQL doesn't
-// produce. CH responds missing-columns; cerberus surfaces 502.
-test.skip('rate(http_server_request_duration_count[5m]) returns a matrix', async ({ request }) => {
+// Un-skipped in RC2 once wrapWithSampleProjection became shape-aware:
+// when the lowered plan root is a RangeWindow / Aggregate the wrap
+// synthesises MetricName / TimeUnix / Value rather than referencing
+// columns that only exist on a raw Scan.
+test('rate(http_server_request_duration_count[5m]) returns a matrix', async ({ request }) => {
   const now = Math.floor(Date.now() / 1000);
   const start = now - 5 * 60;
   const q = encodeURIComponent('rate(http_server_request_duration_count[5m])');


### PR DESCRIPTION
## Summary

Fixes the wrap-sample-projection's three-class column-scope bug
documented in the RC1 follow-up. The wrap assumed canonical
(MetricName, Attributes, TimeUnix, Value) columns are always exposed
by the inner SELECT, which isn't true for:

1. **RangeWindow** — inner SELECT is `<group-keys>, … AS value`.
2. **StructuralJoin** — emit shape is `SELECT R.* FROM (L) JOIN (R) ON …`.
3. **Aggregate / Filter(Aggregate)** — output is just `<group-keys>, agg…`.

Each handler's wrap function now inspects the plan root and picks the
right projection shape; a new optional `Qualifier` field on
`chplan.ColumnRef` carries the join alias.

Un-skips:
- `TestPromQueryRangeRate` (E2E)
- `TestLokiQueryRangeCountOverTime` (E2E)
- `TestTempoSearch_StructuralChild` (E2E)
- `TestTempoSearch_CountScalar` (E2E)
- Playwright `rate(…)` returns a matrix
- Playwright `count_over_time(…)` returns a matrix

This is **P0 1** of the RC2 P0 list — the single highest-leverage RC2
fix (unblocks 4 E2E + 2 Playwright tests in one change).

## Test plan

- [ ] `check` job: unit tests including new `node_negatives_test.go`
  Qualifier cases + `emit_negatives_test.go` `R.SpanName` rendering
- [ ] `lint` job
- [ ] `dashboard` job: 4 previously-skipped E2Es + 2 previously-skipped
  Playwright tests now run and must pass