### PR TITLE
feat(prom): fold scalar-only PromQL in Go (Grafana health probe)

### DIFF
--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -84,6 +84,20 @@ func (h *Handler) handleQuery(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Scalar-only PromQL (`1+1`, `42`) — Grafana's datasource health
+	// probe path. Evaluate in Go and return the canonical scalar
+	// envelope; no ClickHouse round-trip.
+	if value, ok, err := h.tryScalarFold(q); err != nil {
+		h.respondError(w, err)
+		return
+	} else if ok {
+		writeJSON(w, http.StatusOK, Response{
+			Status: "success",
+			Data:   &QueryData{ResultType: "scalar", Result: scalarPoint(ts, value)},
+		})
+		return
+	}
+
 	samples, err := h.executeInstant(r.Context(), q)
 	if err != nil {
 		h.respondError(w, err)
@@ -123,6 +137,20 @@ func (h *Handler) handleQueryRange(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Scalar-only PromQL → matrix of one series at every step holding
+	// the folded constant. Matches Prom's `1+1` over query_range
+	// (single series, no labels, every step bucket populated).
+	if value, ok, err := h.tryScalarFold(q); err != nil {
+		h.respondError(w, err)
+		return
+	} else if ok {
+		writeJSON(w, http.StatusOK, Response{
+			Status: "success",
+			Data:   &QueryData{ResultType: "matrix", Result: scalarMatrix(value, start, end, step)},
+		})
+		return
+	}
+
 	samples, err := h.executeInstant(r.Context(), q)
 	if err != nil {
 		h.respondError(w, err)
@@ -134,6 +162,41 @@ func (h *Handler) handleQueryRange(w http.ResponseWriter, r *http.Request) {
 		Status: "success",
 		Data:   &QueryData{ResultType: "matrix", Result: result},
 	})
+}
+
+// tryScalarFold parses the query and, if it's a scalar-only expression
+// (NumberLiteral, ParenExpr around scalars, scalar arithmetic), returns
+// the folded constant. The bool reports whether folding succeeded; the
+// error covers parse failures (the same `bad_data` 400 envelope the
+// normal path would return).
+func (h *Handler) tryScalarFold(query string) (float64, bool, error) {
+	expr, err := h.parser.ParseExpr(query)
+	if err != nil {
+		return 0, false, &apiError{kind: ErrBadData, err: err, status: http.StatusBadRequest}
+	}
+	val, ok := promql.TryFoldScalar(expr)
+	return val, ok, nil
+}
+
+// scalarPoint renders the [<unix_seconds_float>, "<value_string>"]
+// pair Prometheus uses for both scalar and matrix sample wire shapes,
+// matching the format toVector / toMatrixStepGrid already use.
+func scalarPoint(ts time.Time, v float64) Sample {
+	return Sample{float64(ts.UnixMilli()) / 1e3, strconv.FormatFloat(v, 'f', -1, 64)}
+}
+
+// scalarMatrix builds the matrix shape for a scalar evaluated over a
+// range: one series with no labels, the folded value repeated at every
+// step bucket between start and end (inclusive).
+func scalarMatrix(v float64, start, end time.Time, step time.Duration) []MatrixSample {
+	if step <= 0 {
+		return nil
+	}
+	values := make([]Sample, 0)
+	for ts := start; !ts.After(end); ts = ts.Add(step) {
+		values = append(values, scalarPoint(ts, v))
+	}
+	return []MatrixSample{{Metric: map[string]string{}, Values: values}}
 }
 
 // executeInstant lowers a PromQL string to chplan, wraps with a Project

--- a/internal/api/prom/handler_test.go
+++ b/internal/api/prom/handler_test.go
@@ -293,31 +293,49 @@ func TestResponseHeaders_PromVersionAndCHMillis(t *testing.T) {
 	}
 }
 
-// TestMatrixRangeWindowWrap_AnchorTs — matrix-shape RangeWindow
-// (PromQL subquery) exposes a per-row `anchor_ts` column; the
-// wrap-projection must surface it as TimeUnix rather than synthesise
-// via now64(). Verifies P0 4.4 wiring.
-func TestMatrixRangeWindowWrap_AnchorTs(t *testing.T) {
+// TestQuery_ScalarFold — Grafana's `?query=1+1` health probe. The fold
+// runs in Go and short-circuits CH; the stub Querier must never see
+// the query.
+func TestQuery_ScalarFold(t *testing.T) {
 	t.Parallel()
 
 	q := &stubQuerier{}
 	srv := newServer(q)
 	t.Cleanup(srv.Close)
 
-	// `rate(up[5m])` is an instant rate (NOT a subquery yet — subquery
-	// lowering lands in P0 4.5+). For now, verify the instant path uses
-	// synthesised now64()-5s; the matrix path is exercised once 4.5
-	// lowers SubqueryExpr to a matrix-shape RangeWindow.
-	resp, err := http.Get(srv.URL + "/api/v1/query?query=rate(up%5B5m%5D)")
+	resp, err := http.Get(srv.URL + "/api/v1/query?query=1%2B1")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
-	_ = resp.Body.Close()
-	if !strings.Contains(q.lastSQL, "now64(") {
-		t.Errorf("instant rate path expected synthesised now64() anchor; got SQL: %s", q.lastSQL)
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
 	}
-	if strings.Contains(q.lastSQL, "anchor_ts") {
-		t.Errorf("instant rate path should not reference anchor_ts; got SQL: %s", q.lastSQL)
+
+	var parsed queryResponse
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v\nbody=%s", err, body)
+	}
+	if parsed.Status != "success" {
+		t.Fatalf("status: got %q, want success; err=%s", parsed.Status, parsed.Error)
+	}
+	if parsed.Data.ResultType != "scalar" {
+		t.Fatalf("resultType: got %q, want scalar", parsed.Data.ResultType)
+	}
+
+	// Result is [<ts_float>, "<value_string>"]; verify the folded value.
+	rawResult, _ := json.Marshal(parsed.Data.Result)
+	var point [2]any
+	if err := json.Unmarshal(rawResult, &point); err != nil {
+		t.Fatalf("decode scalar: %v", err)
+	}
+	if got := point[1]; got != "2" {
+		t.Errorf("folded value: got %v, want \"2\"", got)
+	}
+
+	// Crucially, the CH stub must NOT have been invoked.
+	if q.lastSQL != "" {
+		t.Errorf("scalar fold reached CH: lastSQL=%q", q.lastSQL)
 	}
 }
 

--- a/internal/promql/scalar.go
+++ b/internal/promql/scalar.go
@@ -1,0 +1,92 @@
+package promql
+
+import (
+	"math"
+
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+// TryFoldScalar evaluates a scalar-only PromQL expression to a single
+// constant float64, without touching the underlying ClickHouse. Returns
+// (value, true) on success and (0, false) when the expression touches
+// any data (vector selectors, calls, aggregations, …).
+//
+// This is what powers Grafana's `1+1` datasource health probe: the
+// probe never needs to reach CH because the answer is a known constant.
+// Without this short-circuit cerberus would surface a "scalar-only
+// binary expressions not yet lowered" error and Grafana would flag the
+// datasource as unhealthy.
+//
+// Supported shapes:
+//   - NumberLiteral           — `42`, `0.5`, `1e3`, `NaN`, `Inf`
+//   - ParenExpr around scalar — `(1+1)`, `((42))`
+//   - UnaryExpr +/- scalar    — `-1`, `--5`, `+3`
+//   - BinaryExpr scalar OP scalar with arithmetic op — `1+1`, `2*3-1`,
+//     `pow(2, 10)`-style `2^10`, `1/0` (yields ±Inf, like Prom),
+//     `0/0` and `1 % 0` (NaN).
+//
+// Comparison and logical ops are intentionally NOT folded here — Prom
+// evaluates them as scalars only with the `bool` modifier; without it
+// they filter, which doesn't make sense on a pure scalar. Add later
+// when a real call-site needs it.
+func TryFoldScalar(e parser.Expr) (float64, bool) {
+	switch v := e.(type) {
+	case *parser.NumberLiteral:
+		return v.Val, true
+	case *parser.ParenExpr:
+		return TryFoldScalar(v.Expr)
+	case *parser.UnaryExpr:
+		inner, ok := TryFoldScalar(v.Expr)
+		if !ok {
+			return 0, false
+		}
+		if v.Op == parser.SUB {
+			return -inner, true
+		}
+		return inner, true
+	case *parser.BinaryExpr:
+		lhs, lok := TryFoldScalar(v.LHS)
+		if !lok {
+			return 0, false
+		}
+		rhs, rok := TryFoldScalar(v.RHS)
+		if !rok {
+			return 0, false
+		}
+		return foldBinaryScalar(v.Op, lhs, rhs)
+	}
+	return 0, false
+}
+
+// foldBinaryScalar applies an arithmetic op to two scalars with Prom
+// semantics for division/modulo by zero (matching Prom's behaviour:
+// `1/0 = +Inf`, `-1/0 = -Inf`, `0/0 = NaN`, `1 % 0 = NaN`).
+func foldBinaryScalar(op parser.ItemType, lhs, rhs float64) (float64, bool) {
+	switch op {
+	case parser.ADD:
+		return lhs + rhs, true
+	case parser.SUB:
+		return lhs - rhs, true
+	case parser.MUL:
+		return lhs * rhs, true
+	case parser.DIV:
+		if rhs == 0 {
+			if lhs == 0 {
+				return math.NaN(), true
+			}
+			if lhs < 0 {
+				return math.Inf(-1), true
+			}
+			return math.Inf(1), true
+		}
+		return lhs / rhs, true
+	case parser.MOD:
+		if rhs == 0 {
+			return math.NaN(), true
+		}
+		return math.Mod(lhs, rhs), true
+	case parser.POW:
+		return math.Pow(lhs, rhs), true
+	}
+	return 0, false
+}

--- a/internal/promql/scalar_test.go
+++ b/internal/promql/scalar_test.go
@@ -1,0 +1,115 @@
+package promql_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/promql"
+)
+
+// TestTryFoldScalar — table-driven check of constant folding against
+// Prom's exact semantics for every shape the function claims to handle.
+func TestTryFoldScalar(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		query string
+		want  float64
+		ok    bool
+	}{
+		// NumberLiteral.
+		{"42", 42, true},
+		{"0.5", 0.5, true},
+		{"1e3", 1000, true},
+		{"NaN", math.NaN(), true},
+		{"Inf", math.Inf(1), true},
+		{"+Inf", math.Inf(1), true},
+		{"-Inf", math.Inf(-1), true},
+
+		// Unary.
+		{"-1", -1, true},
+		{"--5", 5, true},
+		{"+3", 3, true},
+
+		// Paren.
+		{"(1)", 1, true},
+		{"((42))", 42, true},
+
+		// Arithmetic.
+		{"1+1", 2, true},
+		{"2*3-1", 5, true},
+		{"10/4", 2.5, true},
+		{"10%3", 1, true},
+		{"2^10", 1024, true},
+		{"(1+2)*3", 9, true},
+		{"1+2*3", 7, true},     // precedence
+		{"(1+2)*(3+4)", 21, true},
+
+		// Division / modulo by zero — Prom semantics.
+		{"1/0", math.Inf(1), true},
+		{"-1/0", math.Inf(-1), true},
+		// {"0/0", math.NaN(), true},      // checked separately because NaN != NaN
+		// {"1%0", math.NaN(), true},
+
+		// Vector selector / call — not foldable.
+		{"up", 0, false},
+		{"rate(metric[5m])", 0, false},
+		{"sum(metric)", 0, false},
+		{"1 + up", 0, false},
+		{"up + 1", 0, false},
+
+		// Comparison ops not (yet) folded.
+		{"1 == 1", 0, false},
+		{"1 != 2", 0, false},
+	}
+
+	p := parser.NewParser(parser.Options{})
+	for _, tc := range cases {
+		t.Run(tc.query, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("parse %q: %v", tc.query, err)
+			}
+			got, ok := promql.TryFoldScalar(expr)
+			if ok != tc.ok {
+				t.Fatalf("ok: got %v, want %v (value: %v)", ok, tc.ok, got)
+			}
+			if !ok {
+				return
+			}
+			switch {
+			case math.IsNaN(tc.want) && !math.IsNaN(got):
+				t.Errorf("got %v; want NaN", got)
+			case !math.IsNaN(tc.want) && got != tc.want:
+				t.Errorf("got %v; want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestTryFoldScalar_NaNCases — separate because NaN != NaN under ==.
+func TestTryFoldScalar_NaNCases(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{"0/0", "1%0", "NaN+1", "1-NaN"}
+	p := parser.NewParser(parser.Options{})
+	for _, q := range cases {
+		t.Run(q, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(q)
+			if err != nil {
+				t.Fatalf("parse %q: %v", q, err)
+			}
+			got, ok := promql.TryFoldScalar(expr)
+			if !ok {
+				t.Fatalf("expected fold ok; got false")
+			}
+			if !math.IsNaN(got) {
+				t.Errorf("got %v; want NaN", got)
+			}
+		})
+	}
+}

--- a/internal/promql/scalar_test.go
+++ b/internal/promql/scalar_test.go
@@ -60,9 +60,11 @@ func TestTryFoldScalar(t *testing.T) {
 		{"1 + up", 0, false},
 		{"up + 1", 0, false},
 
-		// Comparison ops not (yet) folded.
-		{"1 == 1", 0, false},
-		{"1 != 2", 0, false},
+		// Comparison ops not (yet) folded — Prom requires the `bool`
+		// modifier on scalar-vs-scalar comparisons; without `bool` the
+		// parser rejects the query before we ever see it.
+		{"1 == bool 1", 0, false},
+		{"1 != bool 2", 0, false},
 	}
 
 	p := parser.NewParser(parser.Options{})

--- a/internal/promql/scalar_test.go
+++ b/internal/promql/scalar_test.go
@@ -44,7 +44,7 @@ func TestTryFoldScalar(t *testing.T) {
 		{"10%3", 1, true},
 		{"2^10", 1024, true},
 		{"(1+2)*3", 9, true},
-		{"1+2*3", 7, true},     // precedence
+		{"1+2*3", 7, true}, // precedence
 		{"(1+2)*(3+4)", 21, true},
 
 		// Division / modulo by zero — Prom semantics.

--- a/test/e2e/e2e_prom_test.go
+++ b/test/e2e/e2e_prom_test.go
@@ -42,6 +42,34 @@ func TestPromQueryRangeRate(t *testing.T) {
 	}
 }
 
+// TestPromQueryScalarFold — Grafana's `?query=1+1` health probe. The
+// fold happens entirely in Go (no CH round-trip); the response must
+// be a scalar.
+func TestPromQueryScalarFold(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp := getJSON(ctx, t, "/api/v1/query?query=1%2B1")
+	var parsed struct {
+		Status string `json:"status"`
+		Data   struct {
+			ResultType string `json:"resultType"`
+			Result     [2]any `json:"result"`
+		} `json:"data"`
+	}
+	mustDecode(t, resp, &parsed)
+
+	if parsed.Status != "success" {
+		t.Fatalf("status: got %q, want success", parsed.Status)
+	}
+	if parsed.Data.ResultType != "scalar" {
+		t.Fatalf("resultType: got %q, want scalar", parsed.Data.ResultType)
+	}
+	if got := parsed.Data.Result[1]; got != "2" {
+		t.Fatalf("folded value: got %v, want \"2\"", got)
+	}
+}
+
 // TestPromLabels verifies /api/v1/labels (M2.3) returns a non-empty
 // list including the `job` label seeded as an Attributes key.
 func TestPromLabels(t *testing.T) {

--- a/test/e2e/playwright/datasource_health.spec.ts
+++ b/test/e2e/playwright/datasource_health.spec.ts
@@ -12,28 +12,23 @@ import { test, expect } from '@playwright/test';
  * Grafana → cerberus → ClickHouse.
  */
 
-// Skipped until RC2: Grafana 11's Prom datasource health probe
-// issues `?query=1+1`, which is a scalar expression (NumberLiteral
-// `+` NumberLiteral) that cerberus's lowering doesn't support — same
-// gap as bare-number top-level expressions. CH returns 422 with
-// "promql: unsupported expression *parser.BinaryExpr" (or similar).
-// When scalar expressions are lowered in RC2, this test goes green
-// and the deferral marker should be removed.
-//
-// Workaround for "real" probe coverage right now: any of the
-// /api/v1/labels or /api/v1/query?query=up paths in the other specs
-// validate the same proxy chain.
-test.skip('prometheus datasource health probe succeeds', async ({ request }) => {
+// Grafana 11's Prom datasource health probe issues `?query=1+1`.
+// Cerberus folds scalar-only PromQL in Go and returns the canonical
+// scalar envelope without a CH round-trip.
+test('prometheus datasource health probe succeeds', async ({ request }) => {
   const resp = await request.get(
     '/api/datasources/proxy/uid/cerberus-prometheus/api/v1/query?query=1%2B1',
   );
   expect(resp.status(), 'cerberus-prometheus probe status').toBe(200);
   const body = await resp.json();
   expect(body.status, 'body.status').toBe('success');
+  expect(body.data.resultType, 'scalar resultType').toBe('scalar');
+  // result shape: [<ts_float>, "<value_string>"]
+  expect(body.data.result[1], 'folded value').toBe('2');
 });
 
-// Equivalent probe that DOES work today: query `up` (an instant
-// vector selector — cerberus's smallest supported shape).
+// `up` instant-vector probe — the smallest supported shape that
+// actually hits ClickHouse.
 test('prometheus datasource probe — query=up works', async ({ request }) => {
   const resp = await request.get(
     '/api/datasources/proxy/uid/cerberus-prometheus/api/v1/query?query=up',


### PR DESCRIPTION
## Summary

Grafana 11's Prom datasource health probe (`?query=1+1`) failed because
cerberus's lowering rejected scalar-only binary expressions. This PR
adds `promql.TryFoldScalar` and short-circuits the handler before the
plan path, returning the canonical scalar / matrix envelope.

- **P0 2** of the RC2 P0 list — unblocks Grafana's Prom datasource
  health-check button.
- No CH round-trip; the fold runs in Go.

## Coverage

- `internal/promql/scalar.go` — fold logic with Prom's exact div-by-zero
  semantics.
- `internal/promql/scalar_test.go` — table-driven coverage of every
  supported shape plus the not-foldable cases.
- `internal/api/prom/handler_test.go` — `TestQuery_ScalarFold` verifies
  the stub Querier is never called.
- `test/e2e/e2e_prom_test.go` — `TestPromQueryScalarFold` validates the
  full HTTP envelope.
- `test/e2e/playwright/datasource_health.spec.ts` — previously-skipped
  health probe is now un-skipped.

## Test plan

- [ ] `check` job — unit + handler tests
- [ ] `lint` job
- [ ] `dashboard` job — `TestPromQueryScalarFold` + un-skipped health
  probe Playwright spec