### PR TITLE
feat(traceql): lower status / kind static literals

### DIFF
--- a/internal/traceql/lower.go
+++ b/internal/traceql/lower.go
@@ -302,6 +302,11 @@ func intrinsicColumn(i traceql.Intrinsic, s schema.Traces) string {
 }
 
 // lowerStatic turns a TraceQL Static literal into a chplan literal.
+//
+// TypeStatus and TypeKind map to the TitleCase string the OTel-CH
+// exporter writes into StatusCode / SpanKind. Tempo's Status.String() /
+// Kind.String() emits lowercase ("error", "client", …); we re-case
+// here so `{ status = error }` matches CH's `'Error'` row.
 func lowerStatic(st traceql.Static) (chplan.Expr, error) {
 	switch st.Type {
 	case traceql.TypeString:
@@ -319,8 +324,59 @@ func lowerStatic(st traceql.Static) (chplan.Expr, error) {
 		// Duration column in OTel-CH is Int64 ns.
 		d, _ := st.Duration()
 		return &chplan.LitInt{V: d.Nanoseconds()}, nil
+	case traceql.TypeStatus:
+		s, ok := st.Status()
+		if !ok {
+			return nil, fmt.Errorf("traceql: static status literal has no Status() value")
+		}
+		return &chplan.LitString{V: statusString(s)}, nil
+	case traceql.TypeKind:
+		k, ok := st.Kind()
+		if !ok {
+			return nil, fmt.Errorf("traceql: static kind literal has no Kind() value")
+		}
+		return &chplan.LitString{V: kindString(k)}, nil
 	}
 	return nil, fmt.Errorf("traceql: static literal type %s is not yet supported", st.Type)
+}
+
+// statusString maps Tempo's Status enum to the StatusCode string the
+// OTel-CH exporter writes. Tempo's Status.String() is lowercase; CH
+// rows carry TitleCase ("Unset" / "Ok" / "Error").
+func statusString(s traceql.Status) string {
+	switch s {
+	case traceql.StatusError:
+		return "Error"
+	case traceql.StatusOk:
+		return "Ok"
+	case traceql.StatusUnset:
+		return "Unset"
+	}
+	// Defensive: future enum values surface as-is rather than silently
+	// producing an empty filter.
+	return s.String()
+}
+
+// kindString maps Tempo's Kind enum to the SpanKind string the OTel-CH
+// exporter writes. Tempo's Kind.String() is lowercase; CH rows carry
+// TitleCase ("Internal" / "Client" / "Server" / "Producer" / "Consumer";
+// "Unspecified" is the conventional unset value).
+func kindString(k traceql.Kind) string {
+	switch k {
+	case traceql.KindUnspecified:
+		return "Unspecified"
+	case traceql.KindInternal:
+		return "Internal"
+	case traceql.KindClient:
+		return "Client"
+	case traceql.KindServer:
+		return "Server"
+	case traceql.KindProducer:
+		return "Producer"
+	case traceql.KindConsumer:
+		return "Consumer"
+	}
+	return k.String()
 }
 
 func mapBinaryOp(op traceql.Operator) (chplan.BinaryOp, error) {

--- a/test/spec/traceql/kind_eq_client.txtar
+++ b/test/spec/traceql/kind_eq_client.txtar
@@ -1,0 +1,6 @@
+-- query.traceql --
+{ kind = client }
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`SpanKind` = ?)
+-- args --
+[0] string = "Client"

--- a/test/spec/traceql/kind_eq_server.txtar
+++ b/test/spec/traceql/kind_eq_server.txtar
@@ -1,0 +1,6 @@
+-- query.traceql --
+{ kind = server }
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`SpanKind` = ?)
+-- args --
+[0] string = "Server"

--- a/test/spec/traceql/status_and_kind_combined.txtar
+++ b/test/spec/traceql/status_and_kind_combined.txtar
@@ -1,0 +1,7 @@
+-- query.traceql --
+{ status = error && kind = server }
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE ((`StatusCode` = ?) AND (`SpanKind` = ?))
+-- args --
+[0] string = "Error"
+[1] string = "Server"

--- a/test/spec/traceql/status_eq_error.txtar
+++ b/test/spec/traceql/status_eq_error.txtar
@@ -1,0 +1,6 @@
+-- query.traceql --
+{ status = error }
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`StatusCode` = ?)
+-- args --
+[0] string = "Error"

--- a/test/spec/traceql/status_neq_ok.txtar
+++ b/test/spec/traceql/status_neq_ok.txtar
@@ -1,0 +1,6 @@
+-- query.traceql --
+{ status != ok }
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`StatusCode` != ?)
+-- args --
+[0] string = "Ok"

--- a/test/spec/traceql/status_unset.txtar
+++ b/test/spec/traceql/status_unset.txtar
@@ -1,0 +1,6 @@
+-- query.traceql --
+{ status = unset }
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`StatusCode` = ?)
+-- args --
+[0] string = "Unset"


### PR DESCRIPTION
## Summary

**P0 6** of the RC2 P0 list. `{ status = error }` and `{ kind = client }`
are common TraceQL filters Grafana sends via its TraceQL Search UI;
cerberus previously rejected them with "static literal type Status is
not yet supported."

This adds TypeStatus and TypeKind cases to `lowerStatic`, mapping
Tempo's lowercase enum strings (`"error"`, `"client"`, …) to the
TitleCase strings the OTel-CH exporter writes into the StatusCode /
SpanKind columns (`"Error"`, `"Client"`, …).

## Coverage

Six new TXTAR fixtures:
- `status_eq_error.txtar` — `{ status = error }`
- `status_neq_ok.txtar` — `{ status != ok }`
- `status_unset.txtar` — `{ status = unset }`
- `kind_eq_client.txtar` — `{ kind = client }`
- `kind_eq_server.txtar` — `{ kind = server }`
- `status_and_kind_combined.txtar` — `{ status = error && kind = server }`

## Test plan

- [ ] `check` job: TXTAR walker (`internal/traceql/lower_test.go`) over
  the six new fixtures
- [ ] `lint` job