### PR TITLE
feat(chsql): step-grid emission for matrix-shape RangeWindow (P0 4.3)

### DIFF
--- a/internal/chsql/emit_test.go
+++ b/internal/chsql/emit_test.go
@@ -272,6 +272,46 @@ var plans = map[string]chplan.Node{
 		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "ResourceAttributes"}},
 	},
 
+	// Matrix-shape RangeWindow — emits one row per anchor across
+	// [End-OuterRange, End] spaced by Step. Used by PromQL subqueries
+	// `rate(m[5m])[1h:5m]` (P0 #4).
+	"range_window_matrix_rate": &chplan.RangeWindow{
+		Input:           &chplan.Scan{Table: "otel_metrics_sum"},
+		Func:            "rate",
+		Range:           5 * time.Minute,
+		Step:            5 * time.Minute,
+		OuterRange:      time.Hour,
+		TimestampColumn: "TimeUnix",
+		ValueColumn:     "Value",
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+	},
+
+	// Matrix-shape RangeWindow + sum_over_time (the inner reducer in
+	// the canonical `max_over_time(rate(...)[1h:5m])` shape).
+	"range_window_matrix_sum_over_time": &chplan.RangeWindow{
+		Input:           &chplan.Scan{Table: "otel_metrics_gauge"},
+		Func:            "sum_over_time",
+		Range:           5 * time.Minute,
+		Step:            time.Minute,
+		OuterRange:      30 * time.Minute,
+		TimestampColumn: "TimeUnix",
+		ValueColumn:     "Value",
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+	},
+
+	// Identity-flagged RangeWindow — the "last value in window" shape
+	// used by bare-vector subqueries (`up[5m:1m]`).
+	"range_window_identity": &chplan.RangeWindow{
+		Input:           &chplan.Scan{Table: "otel_metrics_gauge"},
+		Identity:        true,
+		Range:           time.Minute,
+		Step:            time.Minute,
+		OuterRange:      5 * time.Minute,
+		TimestampColumn: "TimeUnix",
+		ValueColumn:     "Value",
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+	},
+
 	// FieldAccess — TraceQL dotted attribute access.
 	"filter_field_access": &chplan.Filter{
 		Input: &chplan.Scan{Table: "otel_traces"},

--- a/internal/chsql/range_window.go
+++ b/internal/chsql/range_window.go
@@ -19,11 +19,24 @@ import (
 //     `if(c < p, c, c - p)` to repair counter resets, arraySum to total.
 //     - *_over_time: straight array aggregation (arrayAvg, arraySum, ...).
 //
-// The emitter substitutes literal timestamps for r.End (and r.Start, when
-// we add step-grid support) inline. Zero values fall back to ClickHouse's
-// `now64(9)` so fixtures stay deterministic and runtime queries still
-// resolve to the current eval time.
+// The emitter substitutes literal timestamps for r.End inline. Zero
+// values fall back to ClickHouse's `now64(9)` so fixtures stay
+// deterministic and runtime queries still resolve to the current eval
+// time.
+//
+// When r.OuterRange > 0 emission switches to the matrix shape: an
+// arrayJoin fans out one row per anchor across [End-OuterRange, End]
+// spaced by Step (end-inclusive), and the outer SELECT projects the
+// anchor timestamp alongside the per-anchor value. Used by PromQL
+// subqueries (P0 #4).
+//
+// When r.Identity is true, Func is ignored and the per-window value is
+// the last sample in the window — used by bare-vector subqueries like
+// `up[5m:1m]`.
 func (e *emitter) emitRangeWindow(r *chplan.RangeWindow) error {
+	if r.Identity {
+		return e.emitRangeWindowIdentity(r)
+	}
 	switch r.Func {
 	case "rate":
 		return e.emitRangeWindowRate(r)
@@ -36,6 +49,14 @@ func (e *emitter) emitRangeWindow(r *chplan.RangeWindow) error {
 	default:
 		return fmt.Errorf("%w: range function %q (lands in M1.1 follow-ups)", ErrUnsupported, r.Func)
 	}
+}
+
+// emitRangeWindowIdentity emits the "last value in window" shape used
+// by bare-vector subqueries (`up[5m:1m]`). Functionally equivalent to
+// last_over_time but lowered from a SubqueryExpr (P0 #4.5) rather than
+// a Call.
+func (e *emitter) emitRangeWindowIdentity(r *chplan.RangeWindow) error {
+	return e.emitWindowedArray(r, "if(length(window_vals) > 0, window_vals[length(window_vals)], nan)")
 }
 
 // emitRangeWindowLogRate emits SQL for LogQL-style `rate({...}[range])`
@@ -148,12 +169,23 @@ func (e *emitter) emitWindowedArray(r *chplan.RangeWindow, valueExpr string) err
 // valueWriter callback runs at the exact SQL position where the value
 // expression lands; callers may bind args inside it (via e.bindArg) so
 // `?` placeholders are emitted in lock-step with the args slice.
+//
+// When r.OuterRange > 0 emission switches to the matrix path: each
+// series emits N rows, one per anchor across [End-OuterRange, End]
+// spaced by Step (end-inclusive). The outer SELECT additionally
+// projects the anchor timestamp as `anchor_ts`.
 func (e *emitter) emitWindowedArrayCb(r *chplan.RangeWindow, valueWriter func() error) error {
 	if r.TimestampColumn == "" {
 		return fmt.Errorf("%w: RangeWindow.TimestampColumn unset", ErrUnsupported)
 	}
 	if r.ValueColumn == "" {
 		return fmt.Errorf("%w: RangeWindow.ValueColumn unset", ErrUnsupported)
+	}
+	if r.OuterRange > 0 {
+		if r.Step <= 0 {
+			return fmt.Errorf("%w: RangeWindow.OuterRange > 0 requires Step > 0", ErrUnsupported)
+		}
+		return e.emitWindowedArrayMatrix(r, valueWriter)
 	}
 
 	endExpr := timeOrNow(r.End)
@@ -204,6 +236,107 @@ func (e *emitter) emitWindowedArrayCb(r *chplan.RangeWindow, valueWriter func() 
 	}
 	e.b.WriteByte(')')
 
+	e.b.WriteByte(')')
+	e.b.WriteByte(')')
+	return nil
+}
+
+// emitWindowedArrayMatrix is the OuterRange > 0 variant: each series
+// emits N rows, one per anchor across [End-OuterRange, End] spaced by
+// Step (end-inclusive). The innermost SELECT computes the per-series
+// (TimeUnix, Value) array once via groupArray + arraySort, then an
+// arrayJoin in the next layer fans out one row per anchor. Subsequent
+// layers operate on the per-(series, anchor) tuple.
+//
+// SQL skeleton (with N = OuterRange/Step + 1):
+//
+//	SELECT series_key, anchor_ts, <valueExpr> AS value FROM (
+//	  SELECT series_key, anchor_ts, <window_vals + counter_delta> FROM (
+//	    SELECT series_key, anchor_ts, arrayFilter(p -> p.1 in [anchor_ts - range, anchor_ts], series_array) AS window_pairs FROM (
+//	      SELECT series_key, series_array,
+//	        arrayJoin(arrayMap(i -> <end> - toIntervalNanosecond(i * <step_ns>), range(0, N))) AS anchor_ts
+//	      FROM (
+//	        SELECT series_key, arraySort(groupArray((TimeUnix, Value))) AS series_array
+//	        FROM (<input>) GROUP BY series_key
+//	      )
+//	    )
+//	  )
+//	)
+func (e *emitter) emitWindowedArrayMatrix(r *chplan.RangeWindow, valueWriter func() error) error {
+	endExpr := timeOrNow(r.End)
+	if r.Offset > 0 {
+		endExpr = "(" + endExpr + " - toIntervalNanosecond(" + strconv.FormatInt(r.Offset.Nanoseconds(), 10) + "))"
+	}
+	rangeNS := r.Range.Nanoseconds()
+	stepNS := r.Step.Nanoseconds()
+	// End-inclusive anchor count. e.g. [5m:2m] = 5m/2m + 1 = 3 anchors
+	// at end, end-2m, end-4m. Truncating division matches Prom semantics.
+	numAnchors := r.OuterRange.Nanoseconds()/stepNS + 1
+	groupKeys, err := e.collectGroupBy(r.GroupBy)
+	if err != nil {
+		return err
+	}
+
+	// Outer SELECT — per-(series, anchor) row.
+	e.b.WriteString("SELECT ")
+	e.writeGroupSelectList(groupKeys)
+	if len(groupKeys) > 0 {
+		e.b.WriteString(", ")
+	}
+	e.b.WriteString("anchor_ts, ")
+	if err := valueWriter(); err != nil {
+		return err
+	}
+	e.b.WriteString(" AS value FROM (")
+
+	// Middle SELECT — window_vals + counter_delta per (series, anchor).
+	e.b.WriteString("SELECT ")
+	e.writeGroupSelectList(groupKeys)
+	if len(groupKeys) > 0 {
+		e.b.WriteString(", ")
+	}
+	e.b.WriteString("anchor_ts, arrayMap(p -> tupleElement(p, 2), window_pairs) AS window_vals")
+	e.b.WriteString(", arraySum(arrayMap((p, c) -> if(c < p, c, c - p), ")
+	e.b.WriteString("arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), ")
+	e.b.WriteString("arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs))")
+	e.b.WriteString(")) AS counter_delta FROM (")
+
+	// Inner-middle SELECT — arrayFilter to [anchor_ts - range, anchor_ts].
+	e.b.WriteString("SELECT ")
+	e.writeGroupSelectList(groupKeys)
+	if len(groupKeys) > 0 {
+		e.b.WriteString(", ")
+	}
+	fmt.Fprintf(&e.b, "anchor_ts, arrayFilter(p -> tupleElement(p, 1) >= anchor_ts - toIntervalNanosecond(%d) AND tupleElement(p, 1) <= anchor_ts, series_array) AS window_pairs FROM (",
+		rangeNS)
+
+	// Anchor-fanout SELECT — arrayJoin produces one row per anchor.
+	e.b.WriteString("SELECT ")
+	e.writeGroupSelectList(groupKeys)
+	if len(groupKeys) > 0 {
+		e.b.WriteString(", ")
+	}
+	fmt.Fprintf(&e.b, "series_array, arrayJoin(arrayMap(i -> %s - toIntervalNanosecond(i * %d), range(0, %d))) AS anchor_ts FROM (",
+		endExpr, stepNS, numAnchors)
+
+	// Innermost SELECT — groupArray of (ts, value), sorted.
+	e.b.WriteString("SELECT ")
+	e.writeGroupSelectList(groupKeys)
+	if len(groupKeys) > 0 {
+		e.b.WriteString(", ")
+	}
+	fmt.Fprintf(&e.b, "arraySort(groupArray((%s, %s))) AS series_array FROM ",
+		quoteIdent(r.TimestampColumn), quoteIdent(r.ValueColumn))
+	if err := e.emitSubquery(r.Input); err != nil {
+		return err
+	}
+	if len(groupKeys) > 0 {
+		e.b.WriteString(" GROUP BY ")
+		e.writeGroupSelectList(groupKeys)
+	}
+	e.b.WriteByte(')')
+
+	e.b.WriteByte(')')
 	e.b.WriteByte(')')
 	e.b.WriteByte(')')
 	return nil

--- a/test/spec/chsql/range_window_identity.txtar
+++ b/test/spec/chsql/range_window_identity.txtar
@@ -1,0 +1,4 @@
+-- args --
+(none)
+-- sql --
+SELECT `Attributes`, anchor_ts, if(length(window_vals) > 0, window_vals[length(window_vals)], nan) AS value FROM (SELECT `Attributes`, anchor_ts, arrayMap(p -> tupleElement(p, 2), window_pairs) AS window_vals, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS counter_delta FROM (SELECT `Attributes`, anchor_ts, arrayFilter(p -> tupleElement(p, 1) >= anchor_ts - toIntervalNanosecond(60000000000) AND tupleElement(p, 1) <= anchor_ts, series_array) AS window_pairs FROM (SELECT `Attributes`, series_array, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS anchor_ts FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS series_array FROM (SELECT * FROM `otel_metrics_gauge`) GROUP BY `Attributes`))))

--- a/test/spec/chsql/range_window_matrix_rate.txtar
+++ b/test/spec/chsql/range_window_matrix_rate.txtar
@@ -1,0 +1,4 @@
+-- args --
+(none)
+-- sql --
+SELECT `Attributes`, anchor_ts, if(length(window_vals) > 1, counter_delta / 300, 0.0) AS value FROM (SELECT `Attributes`, anchor_ts, arrayMap(p -> tupleElement(p, 2), window_pairs) AS window_vals, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS counter_delta FROM (SELECT `Attributes`, anchor_ts, arrayFilter(p -> tupleElement(p, 1) >= anchor_ts - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= anchor_ts, series_array) AS window_pairs FROM (SELECT `Attributes`, series_array, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 300000000000), range(0, 13))) AS anchor_ts FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS series_array FROM (SELECT * FROM `otel_metrics_sum`) GROUP BY `Attributes`))))

--- a/test/spec/chsql/range_window_matrix_sum_over_time.txtar
+++ b/test/spec/chsql/range_window_matrix_sum_over_time.txtar
@@ -1,0 +1,4 @@
+-- args --
+(none)
+-- sql --
+SELECT `Attributes`, anchor_ts, arraySum(window_vals) AS value FROM (SELECT `Attributes`, anchor_ts, arrayMap(p -> tupleElement(p, 2), window_pairs) AS window_vals, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS counter_delta FROM (SELECT `Attributes`, anchor_ts, arrayFilter(p -> tupleElement(p, 1) >= anchor_ts - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= anchor_ts, series_array) AS window_pairs FROM (SELECT `Attributes`, series_array, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 31))) AS anchor_ts FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS series_array FROM (SELECT * FROM `otel_metrics_gauge`) GROUP BY `Attributes`))))


### PR DESCRIPTION
## Summary

**P0 4.3** — extends `internal/chsql/range_window.go` to generalise
the windowed-array idiom from instant single-anchor to matrix
multi-anchor. Required for PromQL subqueries (P0 4.5-4.7).

When `RangeWindow.OuterRange > 0`:

- innermost layer adds an `arrayJoin` fan-out producing N = OuterRange/Step + 1
  anchors (end-inclusive) per series.
- every subsequent layer carries `anchor_ts` forward.
- `arrayFilter` window slides relative to `anchor_ts` (not `End`).
- outer SELECT projects `(series_key, anchor_ts, value)` — the
  canonical 4-column Sample shape comes in **P0 4.4**.

The instant path (`OuterRange == 0`) is byte-for-byte unchanged.

Also adds the `Identity` branch (**P0 4.5 prep**): bare-vector
subqueries (`up[5m:1m]`) emit the last-value-in-window shape.

## Coverage

Three new chsql-level TXTAR fixtures (`test/spec/chsql/`):

- `range_window_matrix_rate.txtar` — `rate[5m]` over `[1h:5m]` = 13 anchors
- `range_window_matrix_sum_over_time.txtar` — `[5m]` over `[30m:1m]` = 31 anchors
- `range_window_identity.txtar` — `[1m]` over `[5m:1m]` = 6 anchors, last-value

## Test plan

- [ ] `check` — chsql spec walker over new + existing fixtures
- [ ] `lint`
- [ ] No dashboard impact yet — the subquery lowering needs 4.5+