### PR TITLE
feat(promql): lower bare-vector subqueries (P0 4.5)

### DIFF
--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -37,6 +37,8 @@ func lower(expr parser.Expr, s schema.Metrics) (chplan.Node, error) {
 		return lower(e.Expr, s)
 	case *parser.BinaryExpr:
 		return lowerBinary(e, s)
+	case *parser.SubqueryExpr:
+		return lowerSubquery(e, s)
 	default:
 		return nil, fmt.Errorf("promql: unsupported expression %T", expr)
 	}

--- a/internal/promql/subquery.go
+++ b/internal/promql/subquery.go
@@ -1,0 +1,107 @@
+package promql
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// defaultSubqueryStep is the step cerberus substitutes when a subquery
+// omits an explicit `step` (`expr[5m:]`). Prom defines empty-step
+// semantics as "use the engine's eval step"; cerberus doesn't thread
+// that through lowering yet (M2.1 territory) so we hardcode 1m, which
+// matches Prom's default eval step.
+const defaultSubqueryStep = time.Minute
+
+// lowerSubquery handles `<expr>[<range>:<step>]`. P0 4.5 scope: the
+// inner is a `*parser.VectorSelector` (`up[5m:1m]`). Inner ranges over
+// other call shapes (`rate(m[5m])[1h:5m]`) land in P0 4.6; outer
+// range-vector functions over a subquery (`max_over_time(...)[1h:5m]`)
+// land in P0 4.7.
+//
+// The lowered shape is a matrix-mode RangeWindow with Identity=true
+// (the "last value in window" emission). Each anchor across
+// `[End-OuterRange, End]` evaluates the inner selector by picking the
+// last sample whose timestamp falls within `[anchor-Step, anchor]`.
+func lowerSubquery(e *parser.SubqueryExpr, s schema.Metrics) (chplan.Node, error) {
+	if e.Range <= 0 {
+		return nil, fmt.Errorf("promql: subquery range must be positive, got %s", e.Range)
+	}
+	step := e.Step
+	if step == 0 {
+		step = defaultSubqueryStep
+	}
+	if step < 0 {
+		return nil, fmt.Errorf("promql: subquery step must be positive, got %s", e.Step)
+	}
+	if e.StartOrEnd != 0 {
+		return nil, fmt.Errorf("promql: subquery `@ start()` / `@ end()` is not yet supported (deferred from P0 4)")
+	}
+
+	switch inner := e.Expr.(type) {
+	case *parser.VectorSelector:
+		return lowerSubqueryOverVectorSelector(e, inner, step, s)
+	case *parser.SubqueryExpr:
+		return nil, fmt.Errorf("promql: nested subqueries are not yet supported (deferred to RC3)")
+	}
+	return nil, fmt.Errorf("promql: subquery over %T is not yet supported (lands in P0 4.6 / 4.7)", e.Expr)
+}
+
+// lowerSubqueryOverVectorSelector — `metric[range:step]` lowering.
+//
+// The subquery's own modifiers (offset, @) shadow any modifiers on the
+// inner VectorSelector — Prom evaluates `up[5m:1m] offset 10m` as the
+// subquery anchored at `now - 10m`, NOT at the inner VS's modifier
+// (which is illegal on a subquery's inner anyway). We strip the
+// inner's modifier before lowering and apply the subquery's own.
+func lowerSubqueryOverVectorSelector(
+	sub *parser.SubqueryExpr,
+	vs *parser.VectorSelector,
+	step time.Duration,
+	s schema.Metrics,
+) (chplan.Node, error) {
+	vsNoModifier := *vs
+	vsNoModifier.Timestamp = nil
+	vsNoModifier.OriginalOffset = 0
+	vsNoModifier.Offset = 0
+	inner, err := lowerVectorSelector(&vsNoModifier, s)
+	if err != nil {
+		return nil, err
+	}
+
+	anchor, err := subqueryAnchor(sub)
+	if err != nil {
+		return nil, err
+	}
+
+	return &chplan.RangeWindow{
+		Input:           inner,
+		Identity:        true,
+		Range:           step, // per-anchor lookback = subquery step
+		OuterRange:      sub.Range,
+		Step:            step,
+		End:             anchor.End,
+		Offset:          anchor.Offset,
+		TimestampColumn: s.TimestampColumn,
+		ValueColumn:     s.ValueColumn,
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}},
+	}, nil
+}
+
+// subqueryAnchor reads the subquery's `@` + `offset` modifiers into an
+// evalAnchor. Mirrors anchorFromSelector for SubqueryExpr's identical
+// modifier fields.
+func subqueryAnchor(e *parser.SubqueryExpr) (evalAnchor, error) {
+	a := evalAnchor{Offset: e.OriginalOffset}
+	if e.StartOrEnd != 0 {
+		return evalAnchor{}, fmt.Errorf("promql: subquery `@ start()` / `@ end()` modifiers are not yet supported")
+	}
+	if e.Timestamp != nil {
+		a.End = time.UnixMilli(*e.Timestamp).UTC()
+	}
+	return a, nil
+}

--- a/test/spec/promql/subquery_bare_default_step.txtar
+++ b/test/spec/promql/subquery_bare_default_step.txtar
@@ -1,0 +1,6 @@
+-- query.promql --
+up[5m:]
+-- args --
+[0] string = "up"
+-- sql --
+SELECT `Attributes`, anchor_ts, if(length(window_vals) > 0, window_vals[length(window_vals)], nan) AS value FROM (SELECT `Attributes`, anchor_ts, arrayMap(p -> tupleElement(p, 2), window_pairs) AS window_vals, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS counter_delta FROM (SELECT `Attributes`, anchor_ts, arrayFilter(p -> tupleElement(p, 1) >= anchor_ts - toIntervalNanosecond(60000000000) AND tupleElement(p, 1) <= anchor_ts, series_array) AS window_pairs FROM (SELECT `Attributes`, series_array, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS anchor_ts FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS series_array FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?)) GROUP BY `Attributes`))))

--- a/test/spec/promql/subquery_bare_vector.txtar
+++ b/test/spec/promql/subquery_bare_vector.txtar
@@ -1,0 +1,6 @@
+-- query.promql --
+up[5m:1m]
+-- args --
+[0] string = "up"
+-- sql --
+SELECT `Attributes`, anchor_ts, if(length(window_vals) > 0, window_vals[length(window_vals)], nan) AS value FROM (SELECT `Attributes`, anchor_ts, arrayMap(p -> tupleElement(p, 2), window_pairs) AS window_vals, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS counter_delta FROM (SELECT `Attributes`, anchor_ts, arrayFilter(p -> tupleElement(p, 1) >= anchor_ts - toIntervalNanosecond(60000000000) AND tupleElement(p, 1) <= anchor_ts, series_array) AS window_pairs FROM (SELECT `Attributes`, series_array, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS anchor_ts FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS series_array FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?)) GROUP BY `Attributes`))))

--- a/test/spec/promql/subquery_bare_vector_with_label.txtar
+++ b/test/spec/promql/subquery_bare_vector_with_label.txtar
@@ -1,0 +1,8 @@
+-- query.promql --
+up{job="api"}[5m:1m]
+-- args --
+[0] string = "job"
+[1] string = "api"
+[2] string = "up"
+-- sql --
+SELECT `Attributes`, anchor_ts, if(length(window_vals) > 0, window_vals[length(window_vals)], nan) AS value FROM (SELECT `Attributes`, anchor_ts, arrayMap(p -> tupleElement(p, 2), window_pairs) AS window_vals, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS counter_delta FROM (SELECT `Attributes`, anchor_ts, arrayFilter(p -> tupleElement(p, 1) >= anchor_ts - toIntervalNanosecond(60000000000) AND tupleElement(p, 1) <= anchor_ts, series_array) AS window_pairs FROM (SELECT `Attributes`, series_array, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS anchor_ts FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS series_array FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE ((`Attributes`[?] = ?) AND (`MetricName` = ?))) GROUP BY `Attributes`))))

--- a/test/spec/promql/subquery_offset.txtar
+++ b/test/spec/promql/subquery_offset.txtar
@@ -1,0 +1,6 @@
+-- query.promql --
+up[5m:1m] offset 10m
+-- args --
+[0] string = "up"
+-- sql --
+SELECT `Attributes`, anchor_ts, if(length(window_vals) > 0, window_vals[length(window_vals)], nan) AS value FROM (SELECT `Attributes`, anchor_ts, arrayMap(p -> tupleElement(p, 2), window_pairs) AS window_vals, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS counter_delta FROM (SELECT `Attributes`, anchor_ts, arrayFilter(p -> tupleElement(p, 1) >= anchor_ts - toIntervalNanosecond(60000000000) AND tupleElement(p, 1) <= anchor_ts, series_array) AS window_pairs FROM (SELECT `Attributes`, series_array, arrayJoin(arrayMap(i -> (now64(9) - toIntervalNanosecond(600000000000)) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS anchor_ts FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS series_array FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?)) GROUP BY `Attributes`))))


### PR DESCRIPTION
## Summary

**P0 4.5** — adds `*parser.SubqueryExpr` to the top-level dispatch in
`lower.go` and implements `lowerSubquery` for the bare-VectorSelector
case (`up[5m:1m]`, `up{job="api"}[5m:1m]`, etc.).

The lowered shape is a matrix-mode RangeWindow with `Identity=true`:
each anchor across `[End-OuterRange, End]` evaluates the inner
selector by picking the last sample whose timestamp falls within
`[anchor-Step, anchor]`. Uses the emit + Sample-shape projection from
P0 4.3 / 4.4.

Defaults:

- Empty step (`up[5m:]`) → **1m** (Prom's default eval step; M2.1 will
  thread the API's eval step through lowering proper).
- Inner lookback window = subquery step (Prom doesn't precisely define
  this; if compatibility shows drift, switch to the engine's 5m
  lookback delta).

Rejected (deferred to RC3 or later P0 4.x):

- Subquery over Call / AggregateExpr — needs P0 4.6 / 4.7.
- Nested subqueries — deferred to RC3.
- `@ start()` / `@ end()` — deferred (same blocker as instant `@`).

## Dependencies

Branch is stacked on PR 104 (4.4). When 104 merges, this rebases
cleanly.

## Test plan

- [ ] `check` — 4 new TXTAR fixtures via the spec walker:
  - `subquery_bare_vector.txtar`           `up[5m:1m]`
  - `subquery_bare_vector_with_label.txtar` `up{job="api"}[5m:1m]`
  - `subquery_bare_default_step.txtar`      `up[5m:]`
  - `subquery_offset.txtar`                 `up[5m:1m] offset 10m`
- [ ] `lint`