### PR TITLE
fix(release): don't advance :latest on prereleases + SLSA attestation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: write
   packages: write
+  # SLSA provenance attestation needs `id-token` (Sigstore OIDC) +
+  # `attestations` (writes the attestation record back to the repo).
+  id-token: write
+  attestations: write
 
 jobs:
   release:
@@ -35,10 +39,20 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: goreleaser/goreleaser-action@v6
+      - id: goreleaser
+        uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
           version: '~> v2'
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # SLSA build provenance for the release binaries. Lets downstream
+      # consumers verify each artifact was built from this repo at this
+      # commit via `gh attestation verify ...`. Sigstore signs the
+      # attestation through the workflow's OIDC token.
+      - name: Attest release binary provenance
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: 'dist/*.tar.gz'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,10 +49,14 @@ changelog:
   use: github-native
 
 dockers:
+  # Per-arch versioned image. Always pushed regardless of prerelease
+  # status. Tagged both `{{ .Version }}` (e.g. `1.0.0-RC1`, the
+  # goreleaser convention) and `v{{ .Version }}` (e.g. `v1.0.0-RC1`,
+  # the SemVer-with-`v` convention many ops tools default to).
   - id: cerberus-amd64
     image_templates:
       - "ghcr.io/tsouza/cerberus:{{ .Version }}-amd64"
-      - "ghcr.io/tsouza/cerberus:latest-amd64"
+      - "ghcr.io/tsouza/cerberus:v{{ .Version }}-amd64"
     use: buildx
     goos: linux
     goarch: amd64
@@ -70,7 +74,7 @@ dockers:
   - id: cerberus-arm64
     image_templates:
       - "ghcr.io/tsouza/cerberus:{{ .Version }}-arm64"
-      - "ghcr.io/tsouza/cerberus:latest-arm64"
+      - "ghcr.io/tsouza/cerberus:v{{ .Version }}-arm64"
     use: buildx
     goos: linux
     goarch: arm64
@@ -85,12 +89,57 @@ dockers:
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.licenses=MIT"
 
+  # `latest-*` tags published ONLY for stable (non-prerelease) tags.
+  # Otherwise an RC / alpha / beta tag would advance `:latest` and
+  # silently break consumers that pin to the tag.
+  - id: cerberus-amd64-latest
+    image_templates:
+      - "ghcr.io/tsouza/cerberus:latest-amd64"
+    skip_push: "{{ if .Prerelease }}true{{ else }}false{{ end }}"
+    use: buildx
+    goos: linux
+    goarch: amd64
+    dockerfile: Dockerfile
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.url=https://github.com/tsouza/cerberus"
+      - "--label=org.opencontainers.image.source=https://github.com/tsouza/cerberus"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.licenses=MIT"
+
+  - id: cerberus-arm64-latest
+    image_templates:
+      - "ghcr.io/tsouza/cerberus:latest-arm64"
+    skip_push: "{{ if .Prerelease }}true{{ else }}false{{ end }}"
+    use: buildx
+    goos: linux
+    goarch: arm64
+    dockerfile: Dockerfile
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.url=https://github.com/tsouza/cerberus"
+      - "--label=org.opencontainers.image.source=https://github.com/tsouza/cerberus"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.licenses=MIT"
+
 docker_manifests:
+  # Versioned multi-arch manifests — always published.
   - name_template: "ghcr.io/tsouza/cerberus:{{ .Version }}"
     image_templates:
       - "ghcr.io/tsouza/cerberus:{{ .Version }}-amd64"
       - "ghcr.io/tsouza/cerberus:{{ .Version }}-arm64"
+  - name_template: "ghcr.io/tsouza/cerberus:v{{ .Version }}"
+    image_templates:
+      - "ghcr.io/tsouza/cerberus:v{{ .Version }}-amd64"
+      - "ghcr.io/tsouza/cerberus:v{{ .Version }}-arm64"
+  # `:latest` manifest — only for stable tags, so RC / alpha / beta
+  # never advance the rolling `:latest`.
   - name_template: "ghcr.io/tsouza/cerberus:latest"
+    skip_push: "{{ if .Prerelease }}true{{ else }}false{{ end }}"
     image_templates:
       - "ghcr.io/tsouza/cerberus:latest-amd64"
       - "ghcr.io/tsouza/cerberus:latest-arm64"

--- a/README.md
+++ b/README.md
@@ -64,7 +64,28 @@ Schema defaults to the [OpenTelemetry ClickHouse Exporter](https://github.com/op
 
 ## Quick start
 
-Local dev:
+### From a published release
+
+Pull the container image (pin to a specific RC — `:latest` is **only**
+advanced by stable releases; RC / alpha / beta tags don't move it):
+
+```sh
+docker pull ghcr.io/tsouza/cerberus:v1.0.0-RC1
+docker run --rm -p 8080:8080 \
+  -e CERBERUS_CH_ADDR=clickhouse:9000 \
+  ghcr.io/tsouza/cerberus:v1.0.0-RC1
+```
+
+Or download a prebuilt binary from the [release page](https://github.com/tsouza/cerberus/releases)
+(linux / darwin × amd64 / arm64). Each release also ships a
+[SLSA build provenance](https://slsa.dev) attestation; verify with:
+
+```sh
+gh attestation verify cerberus_*_linux_amd64.tar.gz \
+  --owner tsouza --repo cerberus
+```
+
+### Local dev
 
 ```sh
 direnv allow           # loads .envrc (puts Go on PATH, GOTOOLCHAIN=auto)
@@ -73,7 +94,7 @@ just ci                # lint + test + build
 just build && ./bin/cerberus --help
 ```
 
-End-to-end against a real ClickHouse + Grafana in k3d (lands in PR8):
+End-to-end against a real ClickHouse + Grafana in k3d:
 
 ```sh
 just e2e-up            # boot k3d cluster, deploy CH / Grafana / cerberus


### PR DESCRIPTION
## Summary

Three things the RC1 release exposed as missing/wrong:

1. **`:latest` advanced by an RC1 prerelease.** `ghcr.io/tsouza/cerberus:latest`
   now points at the RC1 build. Consumers pinning to `:latest`
   silently get an RC. Fix: split docker config so `latest-*` and the
   `:latest` multi-arch manifest are gated on `skip_push` that fires
   only when `.Prerelease == false`. RC / alpha / beta won't advance
   `:latest` going forward. (The current GHCR `:latest` will be
   overwritten the next stable release; users should pin to a
   specific version until then.)

2. **No `v`-prefixed container tags.** Goreleaser's default is
   `1.0.0-RC1` (no `v`), but ops tools often pin via the SemVer-with-v
   convention. Add parallel `v1.0.0-RC1` tags.

3. **No release-time SLSA provenance.** Adds
   `actions/attest-build-provenance@v3` to the release workflow.
   Each released `.tar.gz` now carries a Sigstore-signed SLSA build
   provenance attestation; consumers verify via:

   ```sh
   gh attestation verify cerberus_*_linux_amd64.tar.gz \
     --owner tsouza --repo cerberus
   ```

4. README quick-start now points at the GHCR image + shows the
   provenance verification command.

## Verification

Next stable release (`v1.0.0` proper) will exercise the new code
path; the RC2 tag will still publish the versioned image but
**will not** advance `:latest`.

## Test plan

- [ ] `check`
- [ ] `lint`