### PR TITLE
feat(api/prom): /api/v1/query_exemplars stub

### DIFF
--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -75,6 +75,8 @@ func (h *Handler) Mount(mux *http.ServeMux) {
 	register("POST /api/v1/format_query", h.handleFormatQuery)
 	register("GET /api/v1/parse_query", h.handleParseQuery)
 	register("POST /api/v1/parse_query", h.handleParseQuery)
+	register("GET /api/v1/query_exemplars", h.handleQueryExemplars)
+	register("POST /api/v1/query_exemplars", h.handleQueryExemplars)
 }
 
 // handleFormatQuery implements `/api/v1/format_query`. Takes a `query`
@@ -127,6 +129,19 @@ func (h *Handler) handleParseQuery(w http.ResponseWriter, r *http.Request) {
 			"type": fmt.Sprintf("%T", expr),
 			"node": expr.String(),
 		},
+	})
+}
+
+// handleQueryExemplars implements `/api/v1/query_exemplars`. Cerberus
+// doesn't store exemplars yet (lands with RC4 self-observability),
+// but Grafana's panel UI polls this endpoint regardless — returning
+// 404 or 500 makes the panel render an unsightly red banner. Stub
+// returns an empty array with success status; Grafana renders the
+// panel without exemplar overlays.
+func (h *Handler) handleQueryExemplars(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, Response{
+		Status: "success",
+		Data:   []any{},
 	})
 }
 

--- a/internal/api/prom/handler_test.go
+++ b/internal/api/prom/handler_test.go
@@ -427,6 +427,43 @@ func TestFormatQuery_BadQuery(t *testing.T) {
 	}
 }
 
+// TestQuery_Exemplars_Stub — Grafana panels poll
+// `/api/v1/query_exemplars` regardless of whether cerberus stores
+// exemplars; returning 404 / 500 paints a red banner. The stub
+// returns 200 + empty array; the panel renders normally without
+// exemplar overlays. Real exemplar storage lands in RC4
+// self-observability.
+func TestQuery_Exemplars_Stub(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/query_exemplars?query=up")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+
+	var parsed struct {
+		Status string        `json:"status"`
+		Data   []interface{} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v body=%s", err, body)
+	}
+	if parsed.Status != "success" {
+		t.Errorf("status: got %q, want success", parsed.Status)
+	}
+	if len(parsed.Data) != 0 {
+		t.Errorf("data: got %d entries, want empty stub", len(parsed.Data))
+	}
+}
+
 func TestQuery_UpstreamError(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Grafana panels poll `/api/v1/query_exemplars` regardless of whether the
backend stores exemplars; returning 404 / 500 paints a red banner on
the panel.

This stub returns `200 OK` + empty array (`{status: success, data: []}`)
so the panel renders normally without exemplar overlays. Real exemplar
storage lands in RC4 (self-observability) when cerberus emits its own
OTel data into ClickHouse.

## Test plan

- [ ] `check` — `TestQuery_Exemplars_Stub`
- [ ] `lint`