### PR TITLE
chore(ci): consolidate lint into one job + add bodyclose, errorlint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # `check` is the test + build job. Linting moved to the `lint` job
+  # below so lint failures and test failures are surfaced independently
+  # and can run in parallel.
   check:
     name: check
     runs-on: ubuntu-latest
@@ -28,16 +31,15 @@ jobs:
         with:
           tool: just
 
-      - name: Install golangci-lint
-        env:
-          GOLANGCI_LINT_VERSION: v2.12.2
+      - name: test + build
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh \
-            | sh -s -- -b "$(go env GOPATH)/bin" "$GOLANGCI_LINT_VERSION"
+          just test
+          just build
 
-      - name: just ci
-        run: just ci
-
+  # `lint` consolidates ALL linting in one job:
+  #   - Go (golangci-lint v2 = formatters + linters from .golangci.yml)
+  #   - Commit messages (commitlint, PR-only)
+  #   - Markdown (markdownlint-cli2)
   lint:
     name: lint
     runs-on: ubuntu-latest
@@ -45,6 +47,19 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0  # commitlint needs full history
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: golangci-lint (Go + formatters)
+        # v7+ is required for golangci-lint v2; v6 caps at v1.
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.12.2
+          # Honours .golangci.yml; runs across the whole module.
+          args: ./...
 
       - name: commitlint
         if: github.event_name == 'pull_request'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,15 @@ linters:
     - gosec
     - revive
     - misspell
+    # bodyclose: catches `resp, _ := client.Do(req); ...` without
+    #   `defer resp.Body.Close()`. Cerberus does a lot of HTTP — leaks
+    #   here are easy to introduce.
+    - bodyclose
+    # errorlint: flags naked `%v` formatting of error values and
+    #   non-wrapped error comparisons. Pushes toward `errors.Is/As` +
+    #   `fmt.Errorf("...: %w", err)` which gives consumers structured
+    #   error handling.
+    - errorlint
   settings:
     revive:
       rules:
@@ -21,6 +30,12 @@ linters:
         # docs cover intent; method comments only appear where WHY is non-obvious.
         - name: exported
           disabled: true
+    errorlint:
+      # Allow comparing error sentinel values via `errors.Is`; flag
+      # everything else (`err == sentinel` becomes a finding).
+      errorf: true
+      asserts: true
+      comparison: true
   exclusions:
     rules:
       - path: _test\.go
@@ -28,6 +43,8 @@ linters:
           - gosec
           - revive
           - errcheck
+          - bodyclose
+          - errorlint
       - path: cmd/
         linters:
           - revive


### PR DESCRIPTION
## Summary

Three changes:

### 1. CI reorganisation

`ci.yml` previously split linting awkwardly:

- `check` job ran `just ci` (lint + test + build, with golangci-lint inside)
- `lint` job only ran commitlint + markdownlint

A Go-lint failure showed up as a `check` failure, mixed in with test
failures. Reorganise so the jobs match their names:

- `check` job: `just test && just build` only
- `lint` job: golangci-lint (Go) + commitlint + markdownlint

Branch protection keeps the same required check names (`check` +
`lint`) → no protection rule changes needed.

### 2. Drop the `curl | sh` golangci-lint installer

Replaced with the official `golangci/golangci-lint-action@v6`. The
custom installer was an ad-hoc `curl | sh` that bypassed the action's
caching + version-checksum guarantees. The official Action handles
both and self-updates.

### 3. Two narrow new linters

Both catch real bug classes in HTTP-heavy code:

- **`bodyclose`** — flags `resp.Body` left unclosed after HTTP calls.
- **`errorlint`** — flags `%v` formatting of errors + non-wrapped
  sentinel comparisons. Pushes toward `errors.Is/As` +
  `fmt.Errorf("...: %w", err)`.

Both exempted from `_test.go` (test scaffolding) and `cmd/`.

## Test plan

- [ ] `check` job (test + build)
- [ ] `lint` job (Go lint will surface any existing bodyclose / errorlint findings — fix as follow-up if any)