### PR TITLE
chore(ci): switch auto-merge-deps to workflow_run trigger

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -2,10 +2,15 @@ name: auto-merge-deps
 
 # Enables auto-merge on Dependabot PRs that meet two conditions:
 #
-#  1. The PR is opened by `dependabot[bot]`.
+#  1. The PR head branch starts with `dependabot/` (Dependabot's
+#     fixed prefix).
 #  2. The update-type matches the allowed set for the affected dep
-#     (patch-only for upstream parsers; patch+minor for GitHub
-#     Actions / npm test tooling).
+#     (patch-only for upstream parsers; patch+minor for GitHub Actions).
+#
+# Trigger is `workflow_run` chained after `ci` completes, NOT
+# `pull_request_target`, so non-Dependabot PRs never see a "Skipped"
+# `enable-auto-merge` check in their status list — the workflow simply
+# isn't registered for them.
 #
 # Branch protection on `main` still gates the actual merge —
 # auto-merge stays pending until `check + lint + dashboard` go green
@@ -14,11 +19,9 @@ name: auto-merge-deps
 # for the full rationale.
 
 on:
-  pull_request_target:
-    types:
-      - opened
-      - reopened
-      - synchronize
+  workflow_run:
+    workflows: [ci]
+    types: [completed]
 
 permissions:
   contents: write
@@ -26,9 +29,27 @@ permissions:
 
 jobs:
   enable-auto-merge:
-    if: github.actor == 'dependabot[bot]'
+    # Only act on Dependabot's own branches. `workflow_run.head_branch`
+    # is the PR's head branch on workflow_run events — Dependabot
+    # prefixes every branch with `dependabot/`.
+    if: |
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      startsWith(github.event.workflow_run.head_branch, 'dependabot/')
     runs-on: ubuntu-latest
     steps:
+      # Resolve the PR number from the head_sha (workflow_run doesn't
+      # carry the PR number directly).
+      - id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          pr=$(gh api "repos/$REPO/commits/$HEAD_SHA/pulls" --jq '.[0].number')
+          echo "number=$pr" >> "$GITHUB_OUTPUT"
+          echo "Resolved PR: $pr"
+
       - name: Fetch Dependabot metadata
         id: meta
         uses: dependabot/fetch-metadata@v2
@@ -48,6 +69,7 @@ jobs:
             (steps.meta.outputs.update-type == 'version-update:semver-patch' ||
              steps.meta.outputs.update-type == 'version-update:semver-minor'))
         env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr merge --auto --squash --delete-branch "$PR_URL"
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: gh pr merge --auto --squash --delete-branch -R "$REPO" "$PR_NUMBER"


### PR DESCRIPTION
## Summary

The auto-merge workflow previously used `pull_request_target`, which
registers the workflow for EVERY PR. Non-Dependabot PRs evaluated the
job's `if: github.actor == 'dependabot[bot]'` to false and the job
appeared as **Skipped** in the status checks — visual clutter on
every non-Dependabot PR.

Switch to `workflow_run` chained after `ci` completes, gated on the
head-branch prefix `dependabot/` (Dependabot's fixed naming
convention). Non-Dependabot PRs never trigger the workflow → no
Skipped entry in their status list.

**Trade-off:** auto-merge gets enabled a few seconds later (after CI
finishes) instead of immediately on PR open. Acceptable — the merge
itself was already waiting on CI to go green.

`workflow_run` doesn't carry the PR number, so the workflow resolves
it from `head_sha` via
`gh api repos/{owner}/{repo}/commits/{sha}/pulls` before passing to
`gh pr merge --auto`.

## Test plan

- [ ] `check`
- [ ] `lint`
- [ ] Next Dependabot PR (probably tomorrow): verify the workflow
  fires after CI completes and either auto-merges (allowlist hit) or
  no-ops (allowlist miss) cleanly.

## Out of scope

- This PR doesn't change the allowlist logic. Same trusted-patch-only
  set as before.