### PR TITLE
feat(api/tempo): stub /api/search/tags + /api/v2/search/tags

### DIFF
--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -63,6 +63,16 @@ func (h *Handler) Mount(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/status/version", h.handleVersion)
 	mux.HandleFunc("GET /api/search", h.handleSearch)
 	mux.HandleFunc("GET /api/traces/{id}", h.handleTraceByID)
+	// /api/search/tags + /api/search/tag/<n>/values power Grafana's
+	// TraceQL Search UI autocomplete. v1 returns a flat tagNames list;
+	// v2 (used by Grafana 11+) returns scoped tags. Both stub here —
+	// real implementation gated on RC6 sqlbuilder (CLAUDE.md
+	// no-Sprintf rule). Stub keeps the Search UI from showing a red
+	// banner; the autocomplete simply has no suggestions.
+	mux.HandleFunc("GET /api/search/tags", h.handleSearchTagsV1)
+	mux.HandleFunc("GET /api/v2/search/tags", h.handleSearchTagsV2)
+	mux.HandleFunc("GET /api/search/tag/{name}/values", h.handleSearchTagValuesV1)
+	mux.HandleFunc("GET /api/v2/search/tag/{name}/values", h.handleSearchTagValuesV2)
 }
 
 func (h *Handler) handleEcho(w http.ResponseWriter, _ *http.Request) {
@@ -75,6 +85,35 @@ func (h *Handler) handleVersion(w http.ResponseWriter, _ *http.Request) {
 		Version:   h.Version,
 		GoVersion: runtime.Version(),
 	})
+}
+
+// handleSearchTagsV1 returns the v1-shape `{tagNames: [...]}` for the
+// TraceQL Search UI's tag-name autocomplete. Stub returns an empty
+// list — Grafana's UI shows no suggestions but the search box keeps
+// working. Real implementation needs CH-side SQL (DISTINCT mapKeys on
+// SpanAttributes / ResourceAttributes / intrinsics); gated on RC6
+// sqlbuilder per the CLAUDE.md no-Sprintf rule.
+func (h *Handler) handleSearchTagsV1(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, SearchTagsV1Response{TagNames: []string{}})
+}
+
+// handleSearchTagsV2 returns the v2-shape used by Grafana 11+:
+// `{scopes: [{name, tags: [...]}]}` where each scope is one of
+// `intrinsic`, `resource`, `span`. Stub returns empty scopes.
+func (h *Handler) handleSearchTagsV2(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, SearchTagsV2Response{Scopes: []TagScope{}})
+}
+
+// handleSearchTagValuesV1 returns the values for a specific tag in
+// the v1 shape `{tagValues: [...]}`. Stub returns empty.
+func (h *Handler) handleSearchTagValuesV1(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, SearchTagValuesV1Response{TagValues: []string{}})
+}
+
+// handleSearchTagValuesV2 returns the v2 shape
+// `{tagValues: [{type, value}]}` used by Grafana 11+. Stub returns empty.
+func (h *Handler) handleSearchTagValuesV2(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, SearchTagValuesV2Response{TagValues: []TagValue{}})
 }
 
 func (h *Handler) handleSearch(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/tempo/handler_test.go
+++ b/internal/api/tempo/handler_test.go
@@ -199,3 +199,94 @@ func TestTraceByID_Found(t *testing.T) {
 		t.Fatalf("expected 1 span, got %d", len(tr.Batches[0].Spans))
 	}
 }
+
+func TestSearchTags_V1_Stub(t *testing.T) {
+	t.Parallel()
+	srv := newServer(&stubQuerier{}, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/search/tags")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	var body tempo.SearchTagsV1Response
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.TagNames == nil {
+		t.Errorf("expected non-nil tagNames (empty list serialises as `[]`); got nil")
+	}
+	if len(body.TagNames) != 0 {
+		t.Errorf("stub should return empty tagNames; got %d", len(body.TagNames))
+	}
+}
+
+func TestSearchTags_V2_Stub(t *testing.T) {
+	t.Parallel()
+	srv := newServer(&stubQuerier{}, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v2/search/tags")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	var body tempo.SearchTagsV2Response
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Scopes == nil {
+		t.Errorf("expected non-nil scopes (empty list serialises as `[]`); got nil")
+	}
+}
+
+func TestSearchTagValues_V1_Stub(t *testing.T) {
+	t.Parallel()
+	srv := newServer(&stubQuerier{}, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/search/tag/service.name/values")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	var body tempo.SearchTagValuesV1Response
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.TagValues == nil {
+		t.Errorf("expected non-nil tagValues; got nil")
+	}
+}
+
+func TestSearchTagValues_V2_Stub(t *testing.T) {
+	t.Parallel()
+	srv := newServer(&stubQuerier{}, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v2/search/tag/service.name/values")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	var body tempo.SearchTagValuesV2Response
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.TagValues == nil {
+		t.Errorf("expected non-nil tagValues; got nil")
+	}
+}

--- a/internal/api/tempo/types.go
+++ b/internal/api/tempo/types.go
@@ -102,3 +102,47 @@ type VersionResponse struct {
 	BuildDate string `json:"buildDate,omitempty"`
 	GoVersion string `json:"goVersion,omitempty"`
 }
+
+// SearchTagsV1Response is the body of `GET /api/search/tags` — the
+// v1 shape that returns a flat list of tag names available across
+// the indexed spans. Used by Grafana's TraceQL Search UI for the tag
+// autocomplete dropdown.
+type SearchTagsV1Response struct {
+	TagNames []string `json:"tagNames"`
+}
+
+// SearchTagsV2Response is the body of `GET /api/v2/search/tags` —
+// the v2 shape Grafana 11+ uses. Each scope groups tags by where
+// they live: `intrinsic` (cerberus's TraceQL keywords), `resource`
+// (ResourceAttributes), `span` (SpanAttributes).
+type SearchTagsV2Response struct {
+	Scopes []TagScope `json:"scopes"`
+}
+
+// TagScope is one entry in SearchTagsV2Response.Scopes.
+type TagScope struct {
+	Name string   `json:"name"`
+	Tags []string `json:"tags"`
+}
+
+// SearchTagValuesV1Response is the body of
+// `GET /api/search/tag/<name>/values` — flat list of values seen for
+// the named tag.
+type SearchTagValuesV1Response struct {
+	TagValues []string `json:"tagValues"`
+}
+
+// SearchTagValuesV2Response is the body of
+// `GET /api/v2/search/tag/<name>/values` — list of typed values used
+// by Grafana 11+.
+type SearchTagValuesV2Response struct {
+	TagValues []TagValue `json:"tagValues"`
+}
+
+// TagValue is one entry in SearchTagValuesV2Response.TagValues. Type
+// is one of `string`, `int`, `float`, `bool`, `duration`, `status`,
+// `kind`.
+type TagValue struct {
+	Type  string `json:"type"`
+	Value string `json:"value"`
+}


### PR DESCRIPTION
## Summary

Grafana's TraceQL Search UI polls these endpoints to populate the
tag-name / tag-value autocomplete in the search box. Without them
the panel renders a red error banner; with empty-list stubs the
panel renders normally and the autocomplete just shows "no
suggestions" — the search box itself keeps working.

Adds four routes + handlers + types:

| Route                                | Shape                              | Used by         |
| ------------------------------------ | ---------------------------------- | --------------- |
| `GET /api/search/tags`               | `{tagNames: []}`                   | v1 (Grafana 10) |
| `GET /api/v2/search/tags`            | `{scopes: []}`                     | v2 (Grafana 11+)|
| `GET /api/search/tag/{n}/values`     | `{tagValues: []}`                  | v1              |
| `GET /api/v2/search/tag/{n}/values`  | `{tagValues: [{type, value}]}`     | v2              |

Real implementation (DISTINCT mapKeys / mapValues queries against
SpanAttributes + ResourceAttributes) is gated on **RC6 sqlbuilder**
per the no-Sprintf-on-SQL rule in CLAUDE.md.

## Test plan

- [ ] `check` — 4 new unit tests confirm stubs respond `200` + non-nil empty slices
- [ ] `lint`