### PR TITLE
feat(api/tempo): /api/search/recent + chplan.OrderBy IR node

### DIFF
--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -62,6 +62,7 @@ func (h *Handler) Mount(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/echo", h.handleEcho)
 	mux.HandleFunc("GET /api/status/version", h.handleVersion)
 	mux.HandleFunc("GET /api/search", h.handleSearch)
+	mux.HandleFunc("GET /api/search/recent", h.handleSearchRecent)
 	mux.HandleFunc("GET /api/traces/{id}", h.handleTraceByID)
 }
 
@@ -111,6 +112,57 @@ func (h *Handler) handleSearch(w http.ResponseWriter, r *http.Request) {
 	samples, err := h.Client.Query(r.Context(), sqlStr, args...)
 	if err != nil {
 		h.Logger.Warn("cerberus tempo search CH query failed", "err", err.Error(), "sql", sqlStr)
+		writeError(w, http.StatusBadGateway, "", "", err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, SearchResponse{
+		Traces:  toTraceSummaries(samples),
+		Metrics: SearchMetrics{InspectedTraces: len(samples)},
+	})
+}
+
+// handleSearchRecent implements `GET /api/search/recent`. Returns the
+// most-recent N traces (per the seeded Timestamp) without applying a
+// TraceQL filter. Grafana's Tempo Search UI calls this on first page
+// load to populate the trace list.
+//
+// Honors `?limit=N` (default 20, max 200); ignores `start` / `end` for
+// now (the emitter doesn't thread them through OrderBy + Limit).
+func (h *Handler) handleSearchRecent(w http.ResponseWriter, r *http.Request) {
+	limit := int64(20)
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
+			if n > 200 {
+				n = 200
+			}
+			limit = n
+		}
+	}
+
+	s := h.Schema
+	// Plan: Limit(OrderBy(Scan(otel_traces) ORDER BY Timestamp DESC) LIMIT N)
+	plan := chplan.Node(&chplan.Scan{Table: s.SpansTable})
+	plan = &chplan.OrderBy{
+		Input: plan,
+		Keys: []chplan.OrderKey{
+			{Expr: &chplan.ColumnRef{Name: s.TimestampColumn}, Desc: true},
+		},
+	}
+	plan = &chplan.Limit{Input: plan, Count: limit}
+	plan = wrapWithSampleProjection(plan, s)
+	plan = h.Optimizer.Run(plan)
+
+	sqlStr, args, err := chsql.Emit(plan)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "", "", err)
+		return
+	}
+	h.Logger.Debug("cerberus tempo search/recent", "limit", limit, "sql", sqlStr, "args", args)
+
+	samples, err := h.Client.Query(r.Context(), sqlStr, args...)
+	if err != nil {
+		h.Logger.Warn("cerberus tempo search/recent CH query failed", "err", err.Error(), "sql", sqlStr)
 		writeError(w, http.StatusBadGateway, "", "", err)
 		return
 	}

--- a/internal/chplan/node_negatives_test.go
+++ b/internal/chplan/node_negatives_test.go
@@ -229,3 +229,30 @@ func TestExprEqual_DeeplyNested(t *testing.T) {
 		t.Errorf("Equal: 4-deep trees differing only in deepest leaf should NOT be Equal")
 	}
 }
+
+// TestOrderByEqual_Negatives — OrderBy Equal() must distinguish
+// direction (ASC vs DESC) and key expression. Equal-length but
+// different-direction keys must not compare equal.
+func TestOrderByEqual_Negatives(t *testing.T) {
+	t.Parallel()
+
+	scan := &chplan.Scan{Table: "otel_traces"}
+	tsCol := &chplan.ColumnRef{Name: "Timestamp"}
+
+	a := &chplan.OrderBy{Input: scan, Keys: []chplan.OrderKey{{Expr: tsCol, Desc: true}}}
+	b := &chplan.OrderBy{Input: scan, Keys: []chplan.OrderKey{{Expr: tsCol, Desc: false}}}
+	if a.Equal(b) {
+		t.Errorf("OrderBy DESC vs ASC should not be Equal")
+	}
+	if b.Equal(a) {
+		t.Errorf("OrderBy Equal must be symmetric")
+	}
+
+	c := &chplan.OrderBy{Input: scan, Keys: []chplan.OrderKey{
+		{Expr: tsCol, Desc: true},
+		{Expr: &chplan.ColumnRef{Name: "Duration"}, Desc: false},
+	}}
+	if a.Equal(c) {
+		t.Errorf("OrderBy with different key count should not be Equal")
+	}
+}

--- a/internal/chplan/order_by.go
+++ b/internal/chplan/order_by.go
@@ -1,0 +1,41 @@
+package chplan
+
+// OrderBy sorts the rows of its input by one or more keys. Emits a
+// SQL `ORDER BY <key1> [DESC], <key2> [DESC], ...` clause.
+//
+// The IR carries a small struct per key rather than parallel slices so
+// the (expression, direction) pair stays atomic — easier to reason
+// about during rewrites.
+type OrderBy struct {
+	Input Node
+	Keys  []OrderKey
+}
+
+// OrderKey is one sort key. Desc=false means ASC (the SQL default).
+type OrderKey struct {
+	Expr Expr
+	Desc bool
+}
+
+func (*OrderBy) planNode() {}
+
+func (o *OrderBy) Children() []Node { return []Node{o.Input} }
+
+func (o *OrderBy) Equal(other Node) bool {
+	p, ok := other.(*OrderBy)
+	if !ok {
+		return false
+	}
+	if len(o.Keys) != len(p.Keys) {
+		return false
+	}
+	for i := range o.Keys {
+		if o.Keys[i].Desc != p.Keys[i].Desc {
+			return false
+		}
+		if !o.Keys[i].Expr.Equal(p.Keys[i].Expr) {
+			return false
+		}
+	}
+	return o.Input.Equal(p.Input)
+}

--- a/internal/chsql/emit.go
+++ b/internal/chsql/emit.go
@@ -54,6 +54,8 @@ func (e *emitter) emitNode(n chplan.Node) error {
 		return e.emitRangeWindow(v)
 	case *chplan.Limit:
 		return e.emitLimit(v)
+	case *chplan.OrderBy:
+		return e.emitOrderBy(v)
 	case *chplan.VectorJoin:
 		return e.emitVectorJoin(v)
 	case *chplan.StructuralJoin:

--- a/internal/chsql/emit_node.go
+++ b/internal/chsql/emit_node.go
@@ -147,6 +147,32 @@ func (e *emitter) emitLimit(l *chplan.Limit) error {
 	return nil
 }
 
+// emitOrderBy renders `SELECT * FROM (<input>) ORDER BY <k1> [DESC], …`.
+// Empty Keys is a programmer error — emit an error so the plan tree
+// doesn't silently lose its sort intent.
+func (e *emitter) emitOrderBy(o *chplan.OrderBy) error {
+	if len(o.Keys) == 0 {
+		return fmt.Errorf("%w: OrderBy with no keys", ErrUnsupported)
+	}
+	e.b.WriteString("SELECT * FROM ")
+	if err := e.emitSubquery(o.Input); err != nil {
+		return err
+	}
+	e.b.WriteString(" ORDER BY ")
+	for i, k := range o.Keys {
+		if i > 0 {
+			e.b.WriteString(", ")
+		}
+		if err := e.emitExpr(k.Expr); err != nil {
+			return err
+		}
+		if k.Desc {
+			e.b.WriteString(" DESC")
+		}
+	}
+	return nil
+}
+
 // writeIdent writes a ClickHouse identifier with backtick quoting, escaping
 // embedded backticks. ClickHouse accepts backtick-quoted identifiers in all
 // positions where an identifier is expected.

--- a/internal/chsql/emit_test.go
+++ b/internal/chsql/emit_test.go
@@ -133,6 +133,26 @@ var plans = map[string]chplan.Node{
 		Count: 1000,
 	},
 
+	// OrderBy — single-key DESC. Tempo `/api/search/recent` lowers to
+	// Limit(OrderBy(Scan, Timestamp DESC), N).
+	"order_by_timestamp_desc": &chplan.Limit{
+		Input: &chplan.OrderBy{
+			Input: &chplan.Scan{Table: "otel_traces"},
+			Keys: []chplan.OrderKey{
+				{Expr: &chplan.ColumnRef{Name: "Timestamp"}, Desc: true},
+			},
+		},
+		Count: 20,
+	},
+	// OrderBy — two-key (composite sort).
+	"order_by_composite": &chplan.OrderBy{
+		Input: &chplan.Scan{Table: "otel_traces"},
+		Keys: []chplan.OrderKey{
+			{Expr: &chplan.ColumnRef{Name: "ServiceName"}, Desc: false},
+			{Expr: &chplan.ColumnRef{Name: "Timestamp"}, Desc: true},
+		},
+	},
+
 	"filter_map_access": &chplan.Filter{
 		Input: &chplan.Scan{Table: "otel_metrics_gauge"},
 		Predicate: &chplan.Binary{

--- a/internal/optimizer/rule.go
+++ b/internal/optimizer/rule.go
@@ -123,6 +123,14 @@ func rewriteChildren(n chplan.Node, fn func(chplan.Node) (chplan.Node, bool)) (c
 		cp := *v
 		cp.Input = newInput
 		return &cp, true
+	case *chplan.OrderBy:
+		newInput, ch := fn(v.Input)
+		if !ch {
+			return v, false
+		}
+		cp := *v
+		cp.Input = newInput
+		return &cp, true
 	}
 	return n, false
 }

--- a/test/e2e/e2e_tempo_extra_test.go
+++ b/test/e2e/e2e_tempo_extra_test.go
@@ -160,3 +160,35 @@ func TestTempoSearch_InvalidTraceQL(t *testing.T) {
 		t.Errorf("envelope: empty message")
 	}
 }
+
+// TestTempoSearch_Recent_Default — `/api/search/recent` returns most-
+// recent traces from the seed (7 spans), ordered by Timestamp DESC.
+// Honors the default limit (20 → returns all 7).
+func TestTempoSearch_Recent_Default(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	resp := getJSON(ctx, t, "/api/search/recent")
+	var parsed struct {
+		Traces []any `json:"traces"`
+	}
+	mustDecode(t, resp, &parsed)
+	if len(parsed.Traces) == 0 {
+		t.Fatalf("expected at least one recent trace from the seed; got 0")
+	}
+}
+
+// TestTempoSearch_Recent_Limit — explicit ?limit=N caps the result count.
+func TestTempoSearch_Recent_Limit(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	resp := getJSON(ctx, t, "/api/search/recent?limit=2")
+	var parsed struct {
+		Traces []any `json:"traces"`
+	}
+	mustDecode(t, resp, &parsed)
+	if len(parsed.Traces) > 2 {
+		t.Errorf("limit=2 should cap traces; got %d", len(parsed.Traces))
+	}
+}

--- a/test/spec/chsql/order_by_composite.txtar
+++ b/test/spec/chsql/order_by_composite.txtar
@@ -1,0 +1,4 @@
+-- args --
+(none)
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) ORDER BY `ServiceName`, `Timestamp` DESC

--- a/test/spec/chsql/order_by_timestamp_desc.txtar
+++ b/test/spec/chsql/order_by_timestamp_desc.txtar
@@ -1,0 +1,4 @@
+-- args --
+(none)
+-- sql --
+SELECT * FROM (SELECT * FROM (SELECT * FROM `otel_traces`) ORDER BY `Timestamp` DESC) LIMIT 20


### PR DESCRIPTION
## Summary

Real RC2 work — not a stub. Grafana's Tempo Search UI calls
`/api/search/recent` on first page load to populate the trace list
before the user types a TraceQL query. Cerberus returned 404; now
returns the N most-recent traces ordered by `Timestamp DESC`.

### IR addition

New `chplan.OrderBy` node:

```go
type OrderBy struct {
    Input Node
    Keys  []OrderKey  // {Expr, Desc bool}
}
```

Emits `SELECT * FROM (<input>) ORDER BY <k1> [DESC], <k2> [DESC], …`.
Optimizer's `rewriteChildren` recurses through it (preserves Keys via
shallow copy).

### Handler

```go
plan := Limit(OrderBy(Scan(otel_traces), [Timestamp DESC]), N)
```

Built via chplan IR — no Sprintf, no SQL strings — fits the no-Sprintf
rule. `?limit=N` honored (default 20, max 200).

## Coverage

- `internal/chplan/node_negatives_test.go` — OrderBy Equal contract
  (direction + key count).
- `internal/chsql/emit_test.go` + 2 TXTAR fixtures pinning the SQL.
- `internal/optimizer/rule.go` — OrderBy added to rewriteChildren.
- `test/e2e/e2e_tempo_extra_test.go` — `/api/search/recent` default +
  `?limit=2`.

## Test plan

- [ ] `check`
- [ ] `lint`
- [ ] `dashboard` E2E