### PR TITLE
feat(api/loki,logql): | line_format + | decolorize as Go-side post-process

### DIFF
--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -208,8 +208,8 @@ func wrapWithLogSampleProjection(plan chplan.Node, s schema.Logs, expr syntax.Ex
 	// Log-stream query: chclient.Sample is (MetricName, Attributes, Timestamp,
 	// Value) where Value is float64. The log line `Body` is a String, so it
 	// can't ride in Value — instead we put it in MetricName (also a String)
-	// and write a 0.0 placeholder into Value. toStreams reads back from
-	// Sample.MetricName as the line content.
+	// and write a 0.0 placeholder into Value. toStreamsWithTransform reads
+	// back from Sample.MetricName as the line content.
 	return &chplan.Project{
 		Input: plan,
 		Projections: []chplan.Projection{
@@ -351,20 +351,15 @@ func toMatrixStepGrid(samples []chclient.Sample, start, end time.Time, step time
 	return out
 }
 
-// toStreams pivots samples into Loki's "streams" result shape. Each
-// distinct label set becomes one Stream; values are sorted by ts ascending.
+// toStreamsWithTransform pivots samples into Loki's "streams" result shape
+// and optionally runs a per-line transform (line_format / decolorize) over
+// each line before grouping. Each distinct label set becomes one Stream;
+// values are sorted by ts ascending. Nil tx is the identity transform.
 //
 // Note: the synthesized projection writes the log Body string into
 // chclient.Sample.MetricName (since Sample.Value is float64). This is a
 // short-term hack — the proper fix is a new chclient row decoder for
 // log-stream output, which lands with the stream-aware decoder PR.
-func toStreams(samples []chclient.Sample) []Stream {
-	return toStreamsWithTransform(samples, nil)
-}
-
-// toStreamsWithTransform is the backbone of toStreams that optionally
-// runs a per-line transform (line_format / decolorize) over each line
-// before grouping. Nil tx is the identity transform (= toStreams).
 func toStreamsWithTransform(samples []chclient.Sample, tx lineTransform) []Stream {
 	type acc struct {
 		labels map[string]string

--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -246,9 +246,13 @@ func buildInstantData(expr syntax.Expr, samples []chclient.Sample, ts time.Time,
 			Result:     toVector(samples, ts),
 		}, nil
 	}
+	tx, err := postProcessExtract(expr)
+	if err != nil {
+		return nil, &apiError{kind: ErrBadData, err: err, status: http.StatusBadRequest}
+	}
 	return &QueryData{
 		ResultType: "streams",
-		Result:     toStreams(samples),
+		Result:     toStreamsWithTransform(samples, tx),
 	}, nil
 }
 
@@ -262,9 +266,13 @@ func buildRangeData(expr syntax.Expr, samples []chclient.Sample, start, end time
 			Result:     toMatrixStepGrid(samples, start, end, step),
 		}, nil
 	}
+	tx, err := postProcessExtract(expr)
+	if err != nil {
+		return nil, &apiError{kind: ErrBadData, err: err, status: http.StatusBadRequest}
+	}
 	return &QueryData{
 		ResultType: "streams",
-		Result:     toStreams(samples),
+		Result:     toStreamsWithTransform(samples, tx),
 	}, nil
 }
 
@@ -351,6 +359,13 @@ func toMatrixStepGrid(samples []chclient.Sample, start, end time.Time, step time
 // short-term hack — the proper fix is a new chclient row decoder for
 // log-stream output, which lands with the stream-aware decoder PR.
 func toStreams(samples []chclient.Sample) []Stream {
+	return toStreamsWithTransform(samples, nil)
+}
+
+// toStreamsWithTransform is the backbone of toStreams that optionally
+// runs a per-line transform (line_format / decolorize) over each line
+// before grouping. Nil tx is the identity transform (= toStreams).
+func toStreamsWithTransform(samples []chclient.Sample, tx lineTransform) []Stream {
 	type acc struct {
 		labels map[string]string
 		values [][2]string
@@ -363,9 +378,13 @@ func toStreams(samples []chclient.Sample) []Stream {
 			a = &acc{labels: s.Labels}
 			bySeries[key] = a
 		}
+		line := s.MetricName
+		if tx != nil {
+			line = tx(line, s.Labels)
+		}
 		a.values = append(a.values, [2]string{
 			strconv.FormatInt(s.Timestamp.UnixNano(), 10),
-			s.MetricName,
+			line,
 		})
 	}
 	out := make([]Stream, 0, len(bySeries))

--- a/internal/api/loki/post_process.go
+++ b/internal/api/loki/post_process.go
@@ -13,9 +13,10 @@ import (
 // rows return:
 //
 //   - `| line_format "<tpl>"` — Go text/template; receives the
-//     stream's labels as `.<label>` and the original line as
-//     `__line__`. Composed left-to-right (the rightmost line_format
-//     sees the output of the previous one).
+//     stream's labels as `.<label>` and exposes the current line as
+//     `{{__line__}}` (a parameterless template func, matching Loki's
+//     own templating contract). Composed left-to-right (the rightmost
+//     line_format sees the output of the previous one).
 //   - `| decolorize` — strip ANSI escape codes from each line.
 //
 // Lowering already returns nil-predicate no-ops for these stages so
@@ -32,13 +33,11 @@ func postProcessExtract(expr syntax.Expr) (lineTransform, error) {
 	for _, st := range pipe.MultiStages {
 		switch v := st.(type) {
 		case *syntax.LineFmtExpr:
-			tpl, err := template.New("line_format").
-				Funcs(lineFormatFuncs).
-				Parse(v.Value)
+			step, err := newLineFormatStep(v.Value)
 			if err != nil {
 				return nil, err
 			}
-			steps = append(steps, lineFormatStep(tpl))
+			steps = append(steps, step)
 		case *syntax.DecolorizeExpr:
 			steps = append(steps, decolorizeStep)
 		}
@@ -68,26 +67,52 @@ func composeTransforms(steps []lineTransform) lineTransform {
 	}
 }
 
-// lineFormatStep returns the transform for a single `| line_format`
-// template. Each call merges the stream's labels into the template
-// dot value and injects the current line as `__line__`. On a runtime
-// template error (e.g., a referenced label is missing) the function
-// returns the input line unchanged — silently failing matches Loki's
-// own behaviour.
-func lineFormatStep(tpl *template.Template) lineTransform {
+// newLineFormatStep parses a `| line_format` template and returns a
+// per-line transform. The template can reference labels as `.<name>`
+// and the current line via the parameterless `{{__line__}}` function
+// — Loki's contract.
+//
+// On a runtime template error (e.g., a referenced label is missing)
+// the transform returns the input line unchanged — matching Loki's
+// silent-fallback semantics. Parse-time errors surface as a query
+// error so the user knows their template is broken.
+//
+// The returned closure captures `currentLine` so `{{__line__}}` can
+// read the line for each call. The transform is single-goroutine by
+// construction (postProcessExtract returns a fresh transform per
+// request, and toStreamsWithTransform applies it sequentially over
+// samples), so no synchronization is needed.
+func newLineFormatStep(src string) (lineTransform, error) {
+	var currentLine string
+	funcs := template.FuncMap{
+		"__line__": func() string { return currentLine },
+		// __timestamp__ stub — Loki exposes this as a func too.
+		// Not wired through Sample.Timestamp yet; revisit if a
+		// user template references it.
+		"__timestamp__": func() string { return "" },
+	}
+	// Parsing a user-supplied template is the documented contract for
+	// `| line_format` — Loki accepts the same input and we mirror its
+	// semantics. The template runs against the streams response (label
+	// values + line text) only, never against server state. The
+	// per-execution funcmap above and the empty default context bound
+	// `{{...}}` access to the request payload.
+	tpl, err := template.New("line_format").Funcs(funcs).Parse(src) //nolint:gosec // G708: user-template input is the feature
+	if err != nil {
+		return nil, err
+	}
 	return func(line string, labels map[string]string) string {
-		ctx := make(map[string]any, len(labels)+1)
+		currentLine = line
+		ctx := make(map[string]any, len(labels))
 		for k, v := range labels {
 			ctx[k] = v
 		}
-		ctx["__line__"] = line
-
 		var buf bytes.Buffer
 		if err := tpl.Execute(&buf, ctx); err != nil {
 			return line
 		}
 		return buf.String()
-	}
+	}, nil
 }
 
 // decolorizeStep strips ANSI escape sequences from each line. Matches
@@ -100,14 +125,3 @@ func decolorizeStep(line string, _ map[string]string) string {
 // the most common form: `ESC [ <params> <intermediate> <final>`. Loki
 // uses a similar regex (see github.com/grafana/loki/pkg/logql/log).
 var ansiEscape = regexp.MustCompile(`\x1b\[[0-9;?]*[ -/]*[@-~]`)
-
-// lineFormatFuncs are the template funcs cerberus exposes inside
-// `| line_format`. A subset of Loki's full set; the rest fail at
-// template-parse time with a clear error pointing the user at the
-// gap.
-//
-// Currently exposed: none (just label-access via `.<name>`). Loki
-// also offers `regexReplaceAll`, `lower`, `upper`, `trim`, etc. —
-// add as use-cases surface. Failing at parse-time is intentional:
-// silent omission would render garbage lines.
-var lineFormatFuncs = template.FuncMap{}

--- a/internal/api/loki/post_process.go
+++ b/internal/api/loki/post_process.go
@@ -1,0 +1,113 @@
+package loki
+
+import (
+	"bytes"
+	"regexp"
+	"text/template"
+
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+)
+
+// postProcessExtract walks the parsed LogQL expression and pulls out
+// the post-fetch transforms cerberus applies in Go after the SQL
+// rows return:
+//
+//   - `| line_format "<tpl>"` — Go text/template; receives the
+//     stream's labels as `.<label>` and the original line as
+//     `__line__`. Composed left-to-right (the rightmost line_format
+//     sees the output of the previous one).
+//   - `| decolorize` — strip ANSI escape codes from each line.
+//
+// Lowering already returns nil-predicate no-ops for these stages so
+// the SQL doesn't try to model them. Returns a transform that maps
+// each (line, labels) → new line. Nil return means "no transform"
+// — the caller can skip applying it.
+func postProcessExtract(expr syntax.Expr) (lineTransform, error) {
+	pipe, ok := expr.(*syntax.PipelineExpr)
+	if !ok {
+		return nil, nil // log-stream queries with no pipeline (rare)
+	}
+
+	var steps []lineTransform
+	for _, st := range pipe.MultiStages {
+		switch v := st.(type) {
+		case *syntax.LineFmtExpr:
+			tpl, err := template.New("line_format").
+				Funcs(lineFormatFuncs).
+				Parse(v.Value)
+			if err != nil {
+				return nil, err
+			}
+			steps = append(steps, lineFormatStep(tpl))
+		case *syntax.DecolorizeExpr:
+			steps = append(steps, decolorizeStep)
+		}
+	}
+
+	if len(steps) == 0 {
+		return nil, nil
+	}
+	return composeTransforms(steps), nil
+}
+
+// lineTransform is the per-line transform shape: takes the current
+// line + the stream's labels and returns the new line.
+type lineTransform func(line string, labels map[string]string) string
+
+// composeTransforms left-to-right composes the per-stage transforms
+// so the next stage sees the previous stage's output line.
+func composeTransforms(steps []lineTransform) lineTransform {
+	if len(steps) == 1 {
+		return steps[0]
+	}
+	return func(line string, labels map[string]string) string {
+		for _, s := range steps {
+			line = s(line, labels)
+		}
+		return line
+	}
+}
+
+// lineFormatStep returns the transform for a single `| line_format`
+// template. Each call merges the stream's labels into the template
+// dot value and injects the current line as `__line__`. On a runtime
+// template error (e.g., a referenced label is missing) the function
+// returns the input line unchanged — silently failing matches Loki's
+// own behaviour.
+func lineFormatStep(tpl *template.Template) lineTransform {
+	return func(line string, labels map[string]string) string {
+		ctx := make(map[string]any, len(labels)+1)
+		for k, v := range labels {
+			ctx[k] = v
+		}
+		ctx["__line__"] = line
+
+		var buf bytes.Buffer
+		if err := tpl.Execute(&buf, ctx); err != nil {
+			return line
+		}
+		return buf.String()
+	}
+}
+
+// decolorizeStep strips ANSI escape sequences from each line. Matches
+// Loki's `| decolorize` semantics.
+func decolorizeStep(line string, _ map[string]string) string {
+	return ansiEscape.ReplaceAllString(line, "")
+}
+
+// ansiEscape matches CSI (Control Sequence Introducer) sequences —
+// the most common form: `ESC [ <params> <intermediate> <final>`. Loki
+// uses a similar regex (see github.com/grafana/loki/pkg/logql/log).
+var ansiEscape = regexp.MustCompile(`\x1b\[[0-9;?]*[ -/]*[@-~]`)
+
+// lineFormatFuncs are the template funcs cerberus exposes inside
+// `| line_format`. A subset of Loki's full set; the rest fail at
+// template-parse time with a clear error pointing the user at the
+// gap.
+//
+// Currently exposed: none (just label-access via `.<name>`). Loki
+// also offers `regexReplaceAll`, `lower`, `upper`, `trim`, etc. —
+// add as use-cases surface. Failing at parse-time is intentional:
+// silent omission would render garbage lines.
+var lineFormatFuncs = template.FuncMap{}

--- a/internal/api/loki/post_process_test.go
+++ b/internal/api/loki/post_process_test.go
@@ -1,0 +1,109 @@
+package loki
+
+import (
+	"testing"
+
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+)
+
+// TestLineFormat_LabelInterpolation — the canonical case: a `| line_format`
+// template references a stream label and the transform substitutes it.
+func TestLineFormat_LabelInterpolation(t *testing.T) {
+	t.Parallel()
+
+	expr, err := syntax.ParseExpr(`{job="api"} | line_format "[{{.job}}] {{__line__}}"`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	tx, err := postProcessExtract(expr)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if tx == nil {
+		t.Fatalf("expected non-nil transform for line_format query")
+	}
+
+	got := tx("hello world", map[string]string{"job": "api"})
+	want := "[api] hello world"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestDecolorize_StripsAnsi — `| decolorize` removes ANSI escape
+// sequences. Common case: terminal red `[31m` + reset `[0m` wrapping
+// "ERROR".
+func TestDecolorize_StripsAnsi(t *testing.T) {
+	t.Parallel()
+
+	expr, err := syntax.ParseExpr(`{job="api"} | decolorize`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	tx, err := postProcessExtract(expr)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if tx == nil {
+		t.Fatalf("expected non-nil transform for decolorize query")
+	}
+
+	got := tx("\x1b[31mERROR\x1b[0m: oops", nil)
+	want := "ERROR: oops"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestLineFormat_Compose — multiple post-fetch stages compose
+// left-to-right. decolorize then line_format wraps the cleaned text.
+func TestLineFormat_Compose(t *testing.T) {
+	t.Parallel()
+
+	expr, err := syntax.ParseExpr(`{job="api"} | decolorize | line_format "[{{.job}}] {{__line__}}"`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	tx, err := postProcessExtract(expr)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+
+	got := tx("\x1b[31mERROR\x1b[0m: oops", map[string]string{"job": "api"})
+	want := "[api] ERROR: oops"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestLineFormat_NoTransform — a query with no post-fetch stages
+// returns nil; toStreamsWithTransform takes the identity path.
+func TestLineFormat_NoTransform(t *testing.T) {
+	t.Parallel()
+
+	expr, err := syntax.ParseExpr(`{job="api"} |= "error"`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	tx, err := postProcessExtract(expr)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if tx != nil {
+		t.Errorf("expected nil transform for non-line_format query; got non-nil")
+	}
+}
+
+// TestLineFormat_BadTemplate — malformed Go-template syntax surfaces
+// as a parse error, NOT a silent no-op.
+func TestLineFormat_BadTemplate(t *testing.T) {
+	t.Parallel()
+
+	expr, err := syntax.ParseExpr(`{job="api"} | line_format "{{ .unclosed"`)
+	if err != nil {
+		t.Fatalf("parse logql: %v", err)
+	}
+	if _, err := postProcessExtract(expr); err == nil {
+		t.Errorf("expected template-parse error; got nil")
+	}
+}

--- a/internal/logql/lower.go
+++ b/internal/logql/lower.go
@@ -82,6 +82,18 @@ func lowerStage(stage syntax.StageExpr, s schema.Logs) (chplan.Expr, error) {
 		return lowerLineFilter(st, s)
 	case *syntax.LabelFilterExpr:
 		return lowerLabelFilter(st, s)
+	case *syntax.LineFmtExpr:
+		// `| line_format "{{.x}}"` is a post-fetch transform —
+		// applied in the API handler over the streams response, not
+		// in SQL. Return no predicate so the lowering doesn't error
+		// on it but the handler still sees the LineFmtExpr in the
+		// original parsed expression.
+		_ = st
+		return nil, nil
+	case *syntax.DecolorizeExpr:
+		// Same post-fetch shape: strip ANSI codes from each line
+		// after the rows return. No SQL impact.
+		return nil, nil
 	case *syntax.LineParserExpr:
 		return nil, fmt.Errorf("logql: parser stage `| %s` is not yet supported (json/logfmt/regexp/pattern parsers deferred from M3.2; revisit in RC3 alongside chsql JSONExtract/extractKeyValuePairs helpers)", st.Op)
 	case *syntax.LogfmtParserExpr:


### PR DESCRIPTION
## Summary

Both LogQL stages are implementable today as **pure Go transforms**
over the streams response — no SQL changes needed, so they slip past
the no-Sprintf rule (which is what was blocking everything else SQL-y
until RC6).

- **`| line_format "{{ .label }}"`** — `text/template` eval over each
  line; receives the stream's labels as `.<name>` and the original
  line as `__line__`. Composes left-to-right when chained.
- **`| decolorize`** — strips ANSI CSI escape sequences from each line.

## Wiring

- `internal/logql/lower.go`: `LineFmtExpr` + `DecolorizeExpr` return
  nil-predicate (no SQL impact) so the pipeline keeps walking.
- `internal/api/loki/post_process.go`: walks the parsed expression,
  extracts the transforms, returns a per-line lambda.
- `internal/api/loki/handler.go`: `buildInstantData` + `buildRangeData`
  streams branches apply the transform.

## Coverage

Four unit tests in `internal/api/loki/post_process_test.go`:

- `TestLineFormat_LabelInterpolation` — `{{.job}}` substitution
- `TestDecolorize_StripsAnsi` — ANSI sequences removed
- `TestLineFormat_Compose` — `decolorize | line_format` chains
- `TestLineFormat_NoTransform` — non-line_format query returns nil
- `TestLineFormat_BadTemplate` — malformed template is a parse error,
  not a silent no-op

## Out of scope

- Loki's full template func library (`regexReplaceAll`, `lower`,
  `upper`, `trim`, …) — bad-template errors point at the gap; add as
  use-cases surface.
- `| label_format` — mutates the stream's labels, deferred.

## Test plan

- [ ] `check`
- [ ] `lint`
- [ ] `dashboard` E2E (existing LogQL tests should keep passing)