### PR TITLE
test(spec/logql): TXTAR fixtures for | line_format and | decolorize

### DIFF
--- a/test/spec/logql/decolorize.txtar
+++ b/test/spec/logql/decolorize.txtar
@@ -1,0 +1,7 @@
+-- query.logql --
+{job="api"} | decolorize
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_logs`) WHERE (`ResourceAttributes`[?] = ?)
+-- args --
+[0] string = "job"
+[1] string = "api"

--- a/test/spec/logql/line_format.txtar
+++ b/test/spec/logql/line_format.txtar
@@ -1,0 +1,7 @@
+-- query.logql --
+{job="api"} | line_format "[{{.job}}] {{__line__}}"
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_logs`) WHERE (`ResourceAttributes`[?] = ?)
+-- args --
+[0] string = "job"
+[1] string = "api"

--- a/test/spec/logql/line_format_after_line_filter.txtar
+++ b/test/spec/logql/line_format_after_line_filter.txtar
@@ -1,0 +1,8 @@
+-- query.logql --
+{job="api"} |= "error" | line_format "[{{.job}}] {{__line__}}"
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_logs`) WHERE ((`ResourceAttributes`[?] = ?) AND (position(`Body`, ?) > 0))
+-- args --
+[0] string = "job"
+[1] string = "api"
+[2] string = "error"

--- a/test/spec/logql/line_format_compose.txtar
+++ b/test/spec/logql/line_format_compose.txtar
@@ -1,0 +1,7 @@
+-- query.logql --
+{job="api"} | decolorize | line_format "[{{.job}}] {{__line__}}"
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_logs`) WHERE (`ResourceAttributes`[?] = ?)
+-- args --
+[0] string = "job"
+[1] string = "api"


### PR DESCRIPTION
## Summary

Pin the SQL emit contract for the post-fetch stages shipped in PR #124 and #127. Four new TXTAR fixtures:

- `line_format.txtar` — `{job=\"api\"} | line_format \"[{{.job}}] {{__line__}}\"`
- `decolorize.txtar` — `{job=\"api\"} | decolorize`
- `line_format_compose.txtar` — `{job=\"api\"} | decolorize | line_format \"...\"`
- `line_format_after_line_filter.txtar` — `{job=\"api\"} |= \"error\" | line_format \"...\"` (mixed)

Each fixture confirms:

- `| line_format \"...\"` and `| decolorize` are **NO-OPs at the SQL layer** — the lowering returns matcher-only SQL (the transforms apply in Go after rows return).
- Composing the two stages doesn't add SQL.
- Mixing with `|= \"...\"` line filters keeps the line filter in the emitted WHERE clause (only the post-fetch stages drop).

## Why this matters

These would have caught the `lowerPipeline` nil-stage bug fixed in PR #127 — the expected SQL has no malformed `AND nil` Binary that the pre-fix lowering produced. Going forward, any regression in the no-op handling trips a golden diff.

## Test plan

- [x] `go test -race ./internal/logql/...` — 104 logql tests pass (up from 100; 4 new fixtures)
- [ ] CI green