### PR TITLE
feat(api/loki,logql): | label_format rename + template stages

### DIFF
--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -352,9 +352,16 @@ func toMatrixStepGrid(samples []chclient.Sample, start, end time.Time, step time
 }
 
 // toStreamsWithTransform pivots samples into Loki's "streams" result shape
-// and optionally runs a per-line transform (line_format / decolorize) over
-// each line before grouping. Each distinct label set becomes one Stream;
-// values are sorted by ts ascending. Nil tx is the identity transform.
+// and optionally runs a per-row transform (line_format / decolorize /
+// label_format) before grouping. Each distinct *output* label set
+// becomes one Stream; values are sorted by ts ascending. Nil tx is
+// the identity transform.
+//
+// When the transform mutates labels (e.g., `| label_format`), the
+// grouping reflects the post-format label set — two rows that differ
+// only on a dropped label collapse into a single stream. Conversely,
+// two rows that share the original labels but diverge after a
+// template-set stay in distinct streams.
 //
 // Note: the synthesized projection writes the log Body string into
 // chclient.Sample.MetricName (since Sample.Value is float64). This is a
@@ -367,15 +374,16 @@ func toStreamsWithTransform(samples []chclient.Sample, tx lineTransform) []Strea
 	}
 	bySeries := map[string]*acc{}
 	for _, s := range samples {
-		key := canonicalKey(s.Labels)
+		line := s.MetricName
+		labels := s.Labels
+		if tx != nil {
+			line, labels = tx(line, labels)
+		}
+		key := canonicalKey(labels)
 		a, ok := bySeries[key]
 		if !ok {
-			a = &acc{labels: s.Labels}
+			a = &acc{labels: labels}
 			bySeries[key] = a
-		}
-		line := s.MetricName
-		if tx != nil {
-			line = tx(line, s.Labels)
 		}
 		a.values = append(a.values, [2]string{
 			strconv.FormatInt(s.Timestamp.UnixNano(), 10),

--- a/internal/api/loki/handler_post_process_test.go
+++ b/internal/api/loki/handler_post_process_test.go
@@ -133,6 +133,67 @@ func TestHandler_LineFormat_BadTemplate_400(t *testing.T) {
 	}
 }
 
+// TestHandler_LabelFormat_GroupsByOutputLabels — when `| label_format`
+// renames a label, the streams response must group rows by the
+// POST-format label set. Without this, the rename would be visible in
+// streams[*].stream but the canonical key would still use the old
+// labels — splitting what should be one stream into two.
+func TestHandler_LabelFormat_GroupsByOutputLabels(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+	q := &stubQuerier{
+		samples: []chclient.Sample{
+			{MetricName: "row 1", Labels: map[string]string{"job": "api"}, Timestamp: ts},
+			{MetricName: "row 2", Labels: map[string]string{"job": "api"}, Timestamp: ts.Add(time.Second)},
+		},
+	}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	streams := getStreams(t, srv.URL, `{job="api"} | label_format svc=job`)
+	if len(streams) != 1 {
+		t.Fatalf("expected 1 stream (post-format key), got %d: %+v", len(streams), streams)
+	}
+	got := streams[0].Stream
+	if got["svc"] != "api" {
+		t.Errorf("expected svc=api in renamed labels; got %v", got)
+	}
+	if _, ok := got["job"]; ok {
+		t.Errorf("expected job to be removed by rename; got %v", got)
+	}
+	if len(streams[0].Values) != 2 {
+		t.Errorf("expected 2 values rolled into one stream, got %d", len(streams[0].Values))
+	}
+}
+
+// TestHandler_LabelFormat_TemplateThenLineFormat — composition:
+// label_format sets a templated label, then line_format references
+// the new label. Pins that the line_format template sees the
+// post-format dot map.
+func TestHandler_LabelFormat_TemplateThenLineFormat(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+	q := &stubQuerier{
+		samples: []chclient.Sample{
+			{MetricName: "boom", Labels: map[string]string{"job": "api", "severity": "ERROR"}, Timestamp: ts},
+		},
+	}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	streams := getStreams(t, srv.URL,
+		"{job=\"api\"} | label_format lvl=`{{.severity}}` | line_format `[{{.lvl}}] {{__line__}}`")
+	if len(streams) != 1 || len(streams[0].Values) != 1 {
+		t.Fatalf("unexpected shape: %+v", streams)
+	}
+	got := streams[0].Values[0][1]
+	if got != "[ERROR] boom" {
+		t.Errorf("line: got %q, want %q", got, "[ERROR] boom")
+	}
+}
+
 // TestHandler_NoLineFormat_PassThrough — a query with no post-fetch
 // stages goes through the identity path. Regression test for the
 // nil-transform branch in toStreamsWithTransform.

--- a/internal/api/loki/label_format_test.go
+++ b/internal/api/loki/label_format_test.go
@@ -1,0 +1,155 @@
+package loki
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+)
+
+// TestLabelFormat_Rename — `| label_format new=old` copies the old
+// label's value under the new name and drops the source. Mirrors
+// Loki's Rename semantics.
+func TestLabelFormat_Rename(t *testing.T) {
+	t.Parallel()
+
+	expr, err := syntax.ParseExpr(`{job="api"} | label_format svc=job`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	tx, err := postProcessExtract(expr)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if tx == nil {
+		t.Fatalf("expected non-nil transform for label_format query")
+	}
+
+	gotLine, gotLabels := tx("hello", map[string]string{"job": "api", "env": "prod"})
+	if gotLine != "hello" {
+		t.Errorf("line should pass through, got %q", gotLine)
+	}
+	want := map[string]string{"svc": "api", "env": "prod"}
+	if !reflect.DeepEqual(gotLabels, want) {
+		t.Errorf("labels: got %v, want %v", gotLabels, want)
+	}
+}
+
+// TestLabelFormat_RenameMissingSource — Loki silently skips a rename
+// when the source label doesn't exist; cerberus mirrors that.
+func TestLabelFormat_RenameMissingSource(t *testing.T) {
+	t.Parallel()
+
+	expr, _ := syntax.ParseExpr(`{job="api"} | label_format svc=missing`)
+	tx, err := postProcessExtract(expr)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+
+	_, labels := tx("hello", map[string]string{"job": "api"})
+	if _, ok := labels["svc"]; ok {
+		t.Errorf("svc should not be set when source missing; got %v", labels)
+	}
+	if labels["job"] != "api" {
+		t.Errorf("job should be untouched; got %v", labels)
+	}
+}
+
+// TestLabelFormat_Template — `| label_format lvl=` + "`" + `{{.severity}}` + "`" — set
+// the destination label to the templated value.
+func TestLabelFormat_Template(t *testing.T) {
+	t.Parallel()
+
+	expr, err := syntax.ParseExpr("{job=\"api\"} | label_format lvl=`{{.severity}}-suffix`")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	tx, err := postProcessExtract(expr)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+
+	_, labels := tx("hello", map[string]string{"job": "api", "severity": "error"})
+	if labels["lvl"] != "error-suffix" {
+		t.Errorf("expected lvl=error-suffix, got %q (labels=%v)", labels["lvl"], labels)
+	}
+}
+
+// TestLabelFormat_TemplateMissingKey — Loki uses `missingkey=zero`
+// which renders an unset label as `<no value>`. cerberus mirrors
+// that — silent fallback, not error.
+func TestLabelFormat_TemplateMissingKey(t *testing.T) {
+	t.Parallel()
+
+	expr, _ := syntax.ParseExpr("{job=\"api\"} | label_format lvl=`{{.absent}}`")
+	tx, err := postProcessExtract(expr)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	_, labels := tx("hello", map[string]string{"job": "api"})
+	if labels["lvl"] != "<no value>" {
+		t.Errorf("expected <no value> sentinel, got %q", labels["lvl"])
+	}
+}
+
+// TestLabelFormat_RenameThenLineFormat — composition: rename a label,
+// then line_format references the new name. The line_format template
+// MUST see the renamed label (post-format dot map).
+func TestLabelFormat_RenameThenLineFormat(t *testing.T) {
+	t.Parallel()
+
+	expr, err := syntax.ParseExpr(`{job="api"} | label_format svc=job | line_format "[{{.svc}}] {{__line__}}"`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	tx, err := postProcessExtract(expr)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+
+	gotLine, _ := tx("hello", map[string]string{"job": "api"})
+	want := "[api] hello"
+	if gotLine != want {
+		t.Errorf("got %q, want %q", gotLine, want)
+	}
+}
+
+// TestLabelFormat_DoesNotMutateInput — the transform must allocate a
+// fresh map; the original sample's labels stay unchanged. Without
+// this, two samples sharing the same Labels reference would corrupt
+// each other's data.
+func TestLabelFormat_DoesNotMutateInput(t *testing.T) {
+	t.Parallel()
+
+	expr, _ := syntax.ParseExpr(`{job="api"} | label_format svc=job`)
+	tx, err := postProcessExtract(expr)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+
+	input := map[string]string{"job": "api", "env": "prod"}
+	tx("hello", input)
+	if input["job"] != "api" {
+		t.Errorf("input.job mutated to %q", input["job"])
+	}
+	if _, ok := input["svc"]; ok {
+		t.Errorf("input.svc was added: %v", input)
+	}
+	if len(input) != 2 {
+		t.Errorf("input length changed: %v", input)
+	}
+}
+
+// TestLabelFormat_BadTemplate — a parse-time template error surfaces
+// up rather than failing silently per row. Same shape as line_format.
+func TestLabelFormat_BadTemplate(t *testing.T) {
+	t.Parallel()
+
+	expr, err := syntax.ParseExpr("{job=\"api\"} | label_format lvl=`{{ .unclosed`")
+	if err != nil {
+		t.Fatalf("parse logql: %v", err)
+	}
+	if _, err := postProcessExtract(expr); err == nil {
+		t.Errorf("expected template-parse error; got nil")
+	}
+}

--- a/internal/api/loki/post_process.go
+++ b/internal/api/loki/post_process.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"text/template"
 
+	loglib "github.com/grafana/loki/v3/pkg/logql/log"
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
 )
 
@@ -18,11 +19,16 @@ import (
 //     own templating contract). Composed left-to-right (the rightmost
 //     line_format sees the output of the previous one).
 //   - `| decolorize` — strip ANSI escape codes from each line.
+//   - `| label_format new=old, lvl=` + "`" + `{{.severity}}` + "`" — rename and/or
+//     template-set labels on the row. Subsequent line_format stages
+//     see the updated label map; the streams response groups rows by
+//     the final (post-format) label set.
 //
 // Lowering already returns nil-predicate no-ops for these stages so
 // the SQL doesn't try to model them. Returns a transform that maps
-// each (line, labels) → new line. Nil return means "no transform"
-// — the caller can skip applying it.
+// each (line, labels) → (line', labels'). Nil return means "no
+// transform" — the caller can skip applying it and use sample's
+// original labels.
 func postProcessExtract(expr syntax.Expr) (lineTransform, error) {
 	pipe, ok := expr.(*syntax.PipelineExpr)
 	if !ok {
@@ -40,6 +46,12 @@ func postProcessExtract(expr syntax.Expr) (lineTransform, error) {
 			steps = append(steps, step)
 		case *syntax.DecolorizeExpr:
 			steps = append(steps, decolorizeStep)
+		case *syntax.LabelFmtExpr:
+			step, err := newLabelFormatStep(v.Formats)
+			if err != nil {
+				return nil, err
+			}
+			steps = append(steps, step)
 		}
 	}
 
@@ -49,26 +61,32 @@ func postProcessExtract(expr syntax.Expr) (lineTransform, error) {
 	return composeTransforms(steps), nil
 }
 
-// lineTransform is the per-line transform shape: takes the current
-// line + the stream's labels and returns the new line.
-type lineTransform func(line string, labels map[string]string) string
+// lineTransform is the per-row transform shape: takes the current
+// line + the stream's labels and returns the new line + new labels.
+// Transforms that don't modify labels (line_format, decolorize)
+// return the input map reference unchanged; transforms that DO
+// modify labels (label_format) return a fresh map so callers can
+// safely treat the original sample's labels as immutable.
+type lineTransform func(line string, labels map[string]string) (string, map[string]string)
 
 // composeTransforms left-to-right composes the per-stage transforms
-// so the next stage sees the previous stage's output line.
+// so the next stage sees the previous stage's output line AND output
+// labels. A `| label_format` followed by a `| line_format` template
+// thus sees the renamed labels in the template's dot map.
 func composeTransforms(steps []lineTransform) lineTransform {
 	if len(steps) == 1 {
 		return steps[0]
 	}
-	return func(line string, labels map[string]string) string {
+	return func(line string, labels map[string]string) (string, map[string]string) {
 		for _, s := range steps {
-			line = s(line, labels)
+			line, labels = s(line, labels)
 		}
-		return line
+		return line, labels
 	}
 }
 
 // newLineFormatStep parses a `| line_format` template and returns a
-// per-line transform. The template can reference labels as `.<name>`
+// per-row transform. The template can reference labels as `.<name>`
 // and the current line via the parameterless `{{__line__}}` function
 // — Loki's contract.
 //
@@ -81,7 +99,8 @@ func composeTransforms(steps []lineTransform) lineTransform {
 // read the line for each call. The transform is single-goroutine by
 // construction (postProcessExtract returns a fresh transform per
 // request, and toStreamsWithTransform applies it sequentially over
-// samples), so no synchronization is needed.
+// samples), so no synchronization is needed. Labels pass through
+// unchanged.
 func newLineFormatStep(src string) (lineTransform, error) {
 	var currentLine string
 	funcs := template.FuncMap{
@@ -101,7 +120,7 @@ func newLineFormatStep(src string) (lineTransform, error) {
 	if err != nil {
 		return nil, err
 	}
-	return func(line string, labels map[string]string) string {
+	return func(line string, labels map[string]string) (string, map[string]string) {
 		currentLine = line
 		ctx := make(map[string]any, len(labels))
 		for k, v := range labels {
@@ -109,19 +128,100 @@ func newLineFormatStep(src string) (lineTransform, error) {
 		}
 		var buf bytes.Buffer
 		if err := tpl.Execute(&buf, ctx); err != nil {
-			return line
+			return line, labels
 		}
-		return buf.String()
+		return buf.String(), labels
 	}, nil
 }
 
 // decolorizeStep strips ANSI escape sequences from each line. Matches
-// Loki's `| decolorize` semantics.
-func decolorizeStep(line string, _ map[string]string) string {
-	return ansiEscape.ReplaceAllString(line, "")
+// Loki's `| decolorize` semantics. Labels pass through unchanged.
+func decolorizeStep(line string, labels map[string]string) (string, map[string]string) {
+	return ansiEscape.ReplaceAllString(line, ""), labels
 }
 
 // ansiEscape matches CSI (Control Sequence Introducer) sequences —
 // the most common form: `ESC [ <params> <intermediate> <final>`. Loki
 // uses a similar regex (see github.com/grafana/loki/pkg/logql/log).
 var ansiEscape = regexp.MustCompile(`\x1b\[[0-9;?]*[ -/]*[@-~]`)
+
+// newLabelFormatStep returns the transform for a single `| label_format`
+// stage. Each `LabelFmt` is either a Rename (copy old→new, drop old) or a
+// Template (set Name to the rendered Value template).
+//
+// Renames where source doesn't exist are silently skipped — matches
+// Loki's `lbs.GetWithCategory` early-return path. Renames where Name
+// equals Value are no-ops.
+//
+// Template errors at execute-time are swallowed (the target label is
+// left unset); Loki's own implementation sets an error label, but
+// cerberus mirrors the silent semantics it uses for line_format.
+// Parse-time errors surface as a query error.
+//
+// Returns a FRESH labels map per row so callers can safely treat the
+// original sample's labels as immutable (a shared reference from a
+// previous step is also fine — we always allocate).
+func newLabelFormatStep(formats []loglib.LabelFmt) (lineTransform, error) {
+	// Pre-parse all template Formats so per-row execution is cheap.
+	type compiled struct {
+		dst    string
+		src    string
+		rename bool
+		tpl    *template.Template
+	}
+	steps := make([]compiled, 0, len(formats))
+	for _, f := range formats {
+		c := compiled{dst: f.Name, src: f.Value, rename: f.Rename}
+		if !f.Rename {
+			// Loki uses `Option("missingkey=zero")` so a missing label
+			// renders as `<no value>`; cerberus mirrors that — silent
+			// rather than error, same as line_format. The funcmap is
+			// empty for label_format (Loki exposes the same set, none
+			// of which are commonly used in label_format templates;
+			// add on demand).
+			tpl, err := template.New("label_format").
+				Option("missingkey=zero").
+				Parse(f.Value) //nolint:gosec // G708: user-template input is the feature
+			if err != nil {
+				return nil, err
+			}
+			c.tpl = tpl
+		}
+		steps = append(steps, c)
+	}
+	return func(line string, labels map[string]string) (string, map[string]string) {
+		// Copy the input labels into a fresh map; mutations stay scoped
+		// to this row's result.
+		out := make(map[string]string, len(labels))
+		for k, v := range labels {
+			out[k] = v
+		}
+		// Build a template context (map[string]any) once per row from
+		// the *input* labels — Loki templates see the pre-format label
+		// set, matching their `lbs.IntoMap(m)` pattern.
+		var ctx map[string]any
+		for _, c := range steps {
+			if c.rename {
+				if v, ok := out[c.src]; ok {
+					out[c.dst] = v
+					if c.dst != c.src {
+						delete(out, c.src)
+					}
+				}
+				continue
+			}
+			if ctx == nil {
+				ctx = make(map[string]any, len(labels))
+				for k, v := range labels {
+					ctx[k] = v
+				}
+			}
+			var buf bytes.Buffer
+			if err := c.tpl.Execute(&buf, ctx); err != nil {
+				continue
+			}
+			out[c.dst] = buf.String()
+		}
+		return line, out
+	}, nil
+}

--- a/internal/api/loki/post_process_test.go
+++ b/internal/api/loki/post_process_test.go
@@ -23,7 +23,7 @@ func TestLineFormat_LabelInterpolation(t *testing.T) {
 		t.Fatalf("expected non-nil transform for line_format query")
 	}
 
-	got := tx("hello world", map[string]string{"job": "api"})
+	got, _ := tx("hello world", map[string]string{"job": "api"})
 	want := "[api] hello world"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
@@ -48,7 +48,7 @@ func TestDecolorize_StripsAnsi(t *testing.T) {
 		t.Fatalf("expected non-nil transform for decolorize query")
 	}
 
-	got := tx("\x1b[31mERROR\x1b[0m: oops", nil)
+	got, _ := tx("\x1b[31mERROR\x1b[0m: oops", nil)
 	want := "ERROR: oops"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
@@ -69,7 +69,7 @@ func TestLineFormat_Compose(t *testing.T) {
 		t.Fatalf("extract: %v", err)
 	}
 
-	got := tx("\x1b[31mERROR\x1b[0m: oops", map[string]string{"job": "api"})
+	got, _ := tx("\x1b[31mERROR\x1b[0m: oops", map[string]string{"job": "api"})
 	want := "[api] ERROR: oops"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)

--- a/internal/logql/lower.go
+++ b/internal/logql/lower.go
@@ -100,6 +100,13 @@ func lowerStage(stage syntax.StageExpr, s schema.Logs) (chplan.Expr, error) {
 		// Same post-fetch shape: strip ANSI codes from each line
 		// after the rows return. No SQL impact.
 		return nil, nil
+	case *syntax.LabelFmtExpr:
+		// `| label_format new=old, lvl="{{.severity}}"` mutates the
+		// row's label set in Go after the rows return — rename or
+		// template-set per Loki's contract. No SQL impact; the
+		// post-process pipeline pulls the LabelFmtExpr from the
+		// parsed expression on the handler side.
+		return nil, nil
 	case *syntax.LineParserExpr:
 		return nil, fmt.Errorf("logql: parser stage `| %s` is not yet supported (json/logfmt/regexp/pattern parsers deferred from M3.2; revisit in RC3 alongside chsql JSONExtract/extractKeyValuePairs helpers)", st.Op)
 	case *syntax.LogfmtParserExpr:

--- a/test/spec/logql/label_format.txtar
+++ b/test/spec/logql/label_format.txtar
@@ -1,0 +1,7 @@
+-- query.logql --
+{job="api"} | label_format svc=job
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_logs`) WHERE (`ResourceAttributes`[?] = ?)
+-- args --
+[0] string = "job"
+[1] string = "api"


### PR DESCRIPTION
## Summary

Third post-fetch transform alongside `| line_format` and `| decolorize` (shipped in #124 / #127). `| label_format` mutates the streams response's labels:

- **Rename form** (`| label_format svc=job`): copy `job`'s value under `svc` and drop `job`. Matches Loki's `lbs.Set() ; lbs.Del()` pattern.
- **Template form** (`| label_format lvl=` + "`" + `{{.severity}}-suffix` + "`" + `): set `lvl` to the rendered template. Loki's `Option(\"missingkey=zero\")` is mirrored so `{{.absent}}` renders as `<no value>` (silent fallback, no error label).

## Transform signature change

`lineTransform` changes from `(line) → line` to `(line, labels) → (line, labels)` so each stage can mutate either side. `line_format` and `decolorize` pass labels through unchanged (same map reference); `label_format` always allocates a fresh map so the original sample's labels stay immutable.

`toStreamsWithTransform` now keys series buckets by the **post-format** labels — two rows that differ only on a renamed-away label collapse into one stream, matching Loki's semantics. The new `TestHandler_LabelFormat_GroupsByOutputLabels` integration test pins this.

## Tests

- 7 unit cases in `internal/api/loki/label_format_test.go` covering rename, missing source, template, missing-key, compose-with-line_format, immutability of input, bad-template
- 2 handler-integration cases pinning stream-grouping by post-format labels and the template→line_format compose path
- 1 TXTAR fixture pinning the SQL emit contract (matcher-only, no label_format effect on the WHERE clause)
- All 672 tests pass (up from 647; +25 new). Lint clean.

## Non-overlap with RC6 R6.1

This PR doesn't touch `internal/chsql/*` or any SQL emitter code — it's purely a Go-side post-process. Independent from the R6.1 chsql.Builder scaffolding work.

## Test plan

- [x] `go test -race ./...` — 672 pass
- [x] `golangci-lint run ./internal/api/loki/... ./internal/logql/...` — clean
- [ ] CI green