### PR TITLE
feat(chsql): scaffold public Builder + SelectBuilder (RC6 R6.1)

### DIFF
--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -1,0 +1,413 @@
+package chsql
+
+import (
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Builder accumulates a parameterised ClickHouse SQL fragment plus the
+// positional `?` argument slice that the chclient driver binds.
+//
+// Builder is the public, named version of the private emitter struct in
+// emit.go. As of RC6 R6.1 it is pure scaffolding — no emit_*.go function
+// uses it yet; R6.2–R6.10 port each emit function in turn. The
+// architectural intent (per docs/sql-builder-evaluation.md) is to expose
+// the same `strings.Builder` + `[]any` args primitives the emitter
+// already uses, plus a handful of CH-specific helpers (MapAt, MapKeys,
+// MapFilterExcept, Now64, SubtractNanos, DateTime64Lit, Lambda,
+// ParamAgg) and a SelectBuilder with first-class PREWHERE, so the RC3
+// optimizer rules can compose SQL fragments without re-parsing rendered
+// strings.
+//
+// The zero value is ready to use.
+type Builder struct {
+	sb   strings.Builder
+	args []any
+}
+
+// NewBuilder returns an empty Builder. Equivalent to &Builder{}.
+func NewBuilder() *Builder { return &Builder{} }
+
+// String returns the accumulated SQL.
+func (b *Builder) String() string { return b.sb.String() }
+
+// Args returns the positional argument slice, in the order `?`
+// placeholders were emitted. The slice is owned by the Builder; callers
+// should not mutate it.
+func (b *Builder) Args() []any { return b.args }
+
+// Build is the conventional terminator: returns the rendered SQL and
+// its positional argument slice.
+func (b *Builder) Build() (string, []any) { return b.sb.String(), b.args }
+
+// WriteSQL appends raw SQL text. Most callers should prefer the named
+// helpers — Ident for identifiers, Arg for values, MapAt / Lambda /
+// ParamAgg for CH idioms. WriteSQL is an explicit escape hatch for
+// shapes the helpers don't yet cover.
+//
+// (There is intentionally no WriteByte method on Builder: io.ByteWriter
+// expects WriteByte(byte) error, and offering a non-error variant
+// confuses both govet and callers. Single-byte writes go through
+// WriteSQL with a one-character string.)
+func (b *Builder) WriteSQL(s string) { b.sb.WriteString(s) }
+
+// Ident appends a ClickHouse identifier with backtick quoting, doubling
+// any embedded backticks. Mirrors writeIdent in emit_node.go and
+// quoteIdent in range_window.go; R6.2+ replaces both call sites with
+// this method.
+func (b *Builder) Ident(name string) {
+	b.sb.WriteByte('`')
+	b.sb.WriteString(strings.ReplaceAll(name, "`", "``"))
+	b.sb.WriteByte('`')
+}
+
+// QualIdent appends "<qualifier>.<name>" with both parts backtick-quoted.
+// Used by VectorJoin output where columns are qualified as L.<col> /
+// R.<col>.
+func (b *Builder) QualIdent(qualifier, name string) {
+	b.Ident(qualifier)
+	b.sb.WriteByte('.')
+	b.Ident(name)
+}
+
+// Arg appends a `?` placeholder and records v in the args slice.
+// Every dynamic value (literals, regex patterns, map keys) flows
+// through Arg so the driver parameterises them rather than splicing
+// them into the SQL.
+func (b *Builder) Arg(v any) {
+	b.sb.WriteByte('?')
+	b.args = append(b.args, v)
+}
+
+// MapAt appends "<col>[?]" and binds key as a positional argument —
+// CH's Map column access. col is a single bare column name; for nested
+// or qualified references, write the prefix via WriteSQL / QualIdent
+// before the bracket form lands.
+func (b *Builder) MapAt(col, key string) {
+	b.Ident(col)
+	b.sb.WriteByte('[')
+	b.Arg(key)
+	b.sb.WriteByte(']')
+}
+
+// MapKeys appends "mapKeys(<col>)" — CH's built-in for extracting the
+// key set of a Map column. Used by the metadata SQL stack to derive the
+// list of attribute names known for a metric.
+func (b *Builder) MapKeys(col string) {
+	b.sb.WriteString("mapKeys(")
+	b.Ident(col)
+	b.sb.WriteByte(')')
+}
+
+// MapFilterExcept appends
+//
+//	mapFilter((k, v) -> NOT (k IN (?, ?, ...)), <col>)
+//
+// binding each key as a positional `?` argument. The shape mirrors
+// emit_expr.go's emitMapWithoutKeys (used by PromQL's ignoring(…)
+// modifier) and vector_join.go's mapFilter for the same purpose;
+// R6.4 / R6.6 collapse both call sites onto this helper.
+//
+// Empty keys is a programmer error and panics: the resulting CH SQL
+// would always pass the filter, which is never the caller's intent
+// (an empty `ignoring()` round-trips through the parser as no
+// ignoring clause at all).
+func (b *Builder) MapFilterExcept(col string, keys ...string) {
+	if len(keys) == 0 {
+		panic("chsql: MapFilterExcept requires at least one key")
+	}
+	b.sb.WriteString("mapFilter((k, v) -> NOT (k IN (")
+	for i, k := range keys {
+		if i > 0 {
+			b.sb.WriteString(", ")
+		}
+		b.Arg(k)
+	}
+	b.sb.WriteString(")), ")
+	b.Ident(col)
+	b.sb.WriteByte(')')
+}
+
+// Now64 appends "now64(9)" — ClickHouse's current-time-at-nanosecond
+// precision builtin. The range-window stack falls back to this when
+// the lowering hasn't populated an explicit End time (typically only
+// in the M0–M1 transition fixtures).
+func (b *Builder) Now64() { b.sb.WriteString("now64(9)") }
+
+// SubtractNanos appends "(<lhs> - toIntervalNanosecond(<ns>))". lhs
+// writes the left-hand expression at the right SQL position so callers
+// can compose with any expression-emitting helper (DateTime64Lit,
+// Now64, or another SubtractNanos).
+//
+// ns is rendered as a literal integer, not parameterised. Duration
+// constants are part of the query *shape* — CH sort-key pruning needs
+// them visible to the planner, and parameterising them would force
+// CH to recompute the bound per request.
+func (b *Builder) SubtractNanos(lhs func(b *Builder), ns int64) {
+	b.sb.WriteByte('(')
+	lhs(b)
+	b.sb.WriteString(" - toIntervalNanosecond(")
+	b.sb.WriteString(strconv.FormatInt(ns, 10))
+	b.sb.WriteString("))")
+}
+
+// DateTime64Lit appends a CH DateTime64(9) literal in the form
+//
+//	toDateTime64('YYYY-MM-DD HH:MM:SS.NNNNNNNNN', 9)
+//
+// The format mirrors timeOrNow in range_window.go. The time is
+// rendered in UTC; the 9-digit fractional second covers nanosecond
+// precision exactly.
+func (b *Builder) DateTime64Lit(t time.Time) {
+	b.sb.WriteString("toDateTime64('")
+	b.sb.WriteString(t.UTC().Format("2006-01-02 15:04:05.000000000"))
+	b.sb.WriteString("', 9)")
+}
+
+// Lambda appends "(<p1>, <p2>, ...) -> " and runs body() to write the
+// lambda body. CH lambdas are bare (no `function` keyword); used by
+// mapFilter, arrayMap, arrayFilter, etc. Args bound inside body land
+// at the position body emits them, so positional `?` ordering follows
+// the SQL stream.
+func (b *Builder) Lambda(params []string, body func(b *Builder)) {
+	b.sb.WriteByte('(')
+	for i, p := range params {
+		if i > 0 {
+			b.sb.WriteString(", ")
+		}
+		b.sb.WriteString(p)
+	}
+	b.sb.WriteString(") -> ")
+	body(b)
+}
+
+// ParamAgg appends "<name>(<param1>, ...)(<arg1>, ...)" — the CH
+// parameterised-aggregate shape used by quantile / quantiles /
+// topK / etc. If params is empty, the leading parens are omitted,
+// matching the non-parameterised shape "<name>(<arg1>, ...)".
+//
+// params and args are each rendered via callback so callers can use
+// any expression-emitting helper (Arg, Ident, ParamAgg-of-ParamAgg,
+// …). Bound args land in the order the callbacks emit them.
+func (b *Builder) ParamAgg(name string, params, args []func(b *Builder)) {
+	b.sb.WriteString(name)
+	if len(params) > 0 {
+		b.sb.WriteByte('(')
+		for i, p := range params {
+			if i > 0 {
+				b.sb.WriteString(", ")
+			}
+			p(b)
+		}
+		b.sb.WriteByte(')')
+	}
+	b.sb.WriteByte('(')
+	for i, a := range args {
+		if i > 0 {
+			b.sb.WriteString(", ")
+		}
+		a(b)
+	}
+	b.sb.WriteByte(')')
+}
+
+// Frag is the unit of composition: anything that knows how to write
+// itself into a Builder. SelectBuilder's slots hold Frag values
+// rather than rendered strings so positional `?` arguments stay
+// tied to the position they're written at — a fragment passed to
+// Where renders into the WHERE clause with its args at the WHERE
+// position in the args slice.
+type Frag func(b *Builder)
+
+// Col returns a Frag that emits a backtick-quoted column identifier.
+// Equivalent to b.Ident(name) but usable as a SelectBuilder slot.
+func Col(name string) Frag {
+	return func(b *Builder) { b.Ident(name) }
+}
+
+// Qual returns a Frag that emits "<qualifier>.<name>" with both
+// parts backtick-quoted.
+func Qual(qualifier, name string) Frag {
+	return func(b *Builder) { b.QualIdent(qualifier, name) }
+}
+
+// Lit returns a Frag that emits a `?` placeholder and binds v.
+func Lit(v any) Frag {
+	return func(b *Builder) { b.Arg(v) }
+}
+
+// Raw returns a Frag that emits sql verbatim — the escape hatch for
+// shapes not (yet) covered by a typed helper. R6.9's lint rule will
+// flag direct fmt.Sprintf-on-SQL but Raw is the sanctioned bypass
+// for one-off CH idioms; reach for it sparingly.
+func Raw(sql string) Frag {
+	return func(b *Builder) { b.sb.WriteString(sql) }
+}
+
+// SelectBuilder accumulates a SELECT statement's parts. Slots are
+// appended to in order; rendering walks each slot, emitting the
+// canonical clause prefix (SELECT, FROM, WHERE, …) and joining
+// per-slot Frags with the right separator.
+//
+// PREWHERE is a first-class slot, distinct from WHERE. ClickHouse
+// evaluates PREWHERE before WHERE on the primary-key columns,
+// pruning rows before the full row read; RC3's optimizer rules
+// promote predicates from WHERE → PREWHERE when the predicate
+// only references sort-key columns. Modelling PREWHERE separately
+// here means those rewrites are slot-level operations rather than
+// string rewrites on rendered SQL.
+//
+// The zero value is ready to use; NewSelect is provided for clarity.
+type SelectBuilder struct {
+	selectList []Frag
+	from       Frag
+	where      []Frag
+	prewhere   []Frag
+	groupBy    []Frag
+	orderBy    []orderKey
+	limit      int
+	hasLimit   bool
+}
+
+type orderKey struct {
+	Expr Frag
+	Desc bool
+}
+
+// NewSelect returns an empty SelectBuilder.
+func NewSelect() *SelectBuilder { return &SelectBuilder{} }
+
+// Select appends one or more expressions to the SELECT list. If the
+// list is left empty at Build time the rendered SQL emits `SELECT *`.
+func (s *SelectBuilder) Select(exprs ...Frag) *SelectBuilder {
+	s.selectList = append(s.selectList, exprs...)
+	return s
+}
+
+// From sets the FROM source. Accepts any Frag — Col(table), Raw for
+// subquery escape hatches, or another SelectBuilder via its Frag()
+// method (which wraps the nested SELECT in parens).
+func (s *SelectBuilder) From(src Frag) *SelectBuilder {
+	s.from = src
+	return s
+}
+
+// Where appends predicates to the WHERE clause. Multiple predicates
+// are joined with " AND " when rendered.
+func (s *SelectBuilder) Where(conds ...Frag) *SelectBuilder {
+	s.where = append(s.where, conds...)
+	return s
+}
+
+// Prewhere appends predicates to the PREWHERE clause. Multiple
+// predicates are joined with " AND " when rendered. PREWHERE is
+// emitted before WHERE in the SQL.
+func (s *SelectBuilder) Prewhere(conds ...Frag) *SelectBuilder {
+	s.prewhere = append(s.prewhere, conds...)
+	return s
+}
+
+// GroupBy appends grouping expressions.
+func (s *SelectBuilder) GroupBy(keys ...Frag) *SelectBuilder {
+	s.groupBy = append(s.groupBy, keys...)
+	return s
+}
+
+// OrderBy appends a sort key. desc selects DESC; default is ASC
+// (implicit, ClickHouse default).
+func (s *SelectBuilder) OrderBy(expr Frag, desc bool) *SelectBuilder {
+	s.orderBy = append(s.orderBy, orderKey{Expr: expr, Desc: desc})
+	return s
+}
+
+// Limit sets the LIMIT count. n <= 0 emits no LIMIT clause; positive
+// n is rendered as a literal integer (CH's LIMIT does not accept
+// `?` placeholders in all driver paths and the value is part of the
+// query shape, not user data).
+func (s *SelectBuilder) Limit(n int) *SelectBuilder {
+	s.limit = n
+	s.hasLimit = n > 0
+	return s
+}
+
+// Frag returns a Frag that emits the rendered SELECT wrapped in
+// parentheses. Used to plug a SelectBuilder into another's From
+// without flattening to a string: args bound inside the nested
+// SELECT stay tied to their position in the outer args slice.
+func (s *SelectBuilder) Frag() Frag {
+	return func(b *Builder) {
+		b.sb.WriteByte('(')
+		s.writeInto(b)
+		b.sb.WriteByte(')')
+	}
+}
+
+// Build renders the SELECT statement to (sql, args). Equivalent to
+// running Frag() into a fresh Builder, minus the surrounding parens.
+func (s *SelectBuilder) Build() (string, []any) {
+	b := NewBuilder()
+	s.writeInto(b)
+	return b.Build()
+}
+
+func (s *SelectBuilder) writeInto(b *Builder) {
+	b.sb.WriteString("SELECT ")
+	if len(s.selectList) == 0 {
+		b.sb.WriteByte('*')
+	} else {
+		for i, f := range s.selectList {
+			if i > 0 {
+				b.sb.WriteString(", ")
+			}
+			f(b)
+		}
+	}
+	if s.from != nil {
+		b.sb.WriteString(" FROM ")
+		s.from(b)
+	}
+	if len(s.prewhere) > 0 {
+		b.sb.WriteString(" PREWHERE ")
+		for i, f := range s.prewhere {
+			if i > 0 {
+				b.sb.WriteString(" AND ")
+			}
+			f(b)
+		}
+	}
+	if len(s.where) > 0 {
+		b.sb.WriteString(" WHERE ")
+		for i, f := range s.where {
+			if i > 0 {
+				b.sb.WriteString(" AND ")
+			}
+			f(b)
+		}
+	}
+	if len(s.groupBy) > 0 {
+		b.sb.WriteString(" GROUP BY ")
+		for i, f := range s.groupBy {
+			if i > 0 {
+				b.sb.WriteString(", ")
+			}
+			f(b)
+		}
+	}
+	if len(s.orderBy) > 0 {
+		b.sb.WriteString(" ORDER BY ")
+		for i, k := range s.orderBy {
+			if i > 0 {
+				b.sb.WriteString(", ")
+			}
+			k.Expr(b)
+			if k.Desc {
+				b.sb.WriteString(" DESC")
+			}
+		}
+	}
+	if s.hasLimit {
+		b.sb.WriteString(" LIMIT ")
+		b.sb.WriteString(strconv.Itoa(s.limit))
+	}
+}

--- a/internal/chsql/builder_test.go
+++ b/internal/chsql/builder_test.go
@@ -1,0 +1,482 @@
+package chsql_test
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+)
+
+// TestBuilder_Empty — the zero-value Builder renders empty SQL and a
+// nil args slice. Confirms NewBuilder is unnecessary; the zero value
+// is usable.
+func TestBuilder_Empty(t *testing.T) {
+	t.Parallel()
+
+	var b chsql.Builder
+	sql, args := b.Build()
+	if sql != "" {
+		t.Errorf("empty Builder produced SQL %q; want empty", sql)
+	}
+	if args != nil {
+		t.Errorf("empty Builder produced args %v; want nil", args)
+	}
+}
+
+// TestBuilder_Ident — backtick quoting with embedded-backtick doubling.
+// Mirrors the existing emit_node.go behaviour so the future R6.2 port
+// is a one-for-one swap.
+func TestBuilder_Ident(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name, in, want string
+	}{
+		{"plain", "Attributes", "`Attributes`"},
+		{"with_backtick", "weird`name", "`weird``name`"},
+		{"empty", "", "``"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			b := chsql.NewBuilder()
+			b.Ident(tc.in)
+			if got := b.String(); got != tc.want {
+				t.Errorf("Ident(%q) = %q; want %q", tc.in, got, tc.want)
+			}
+			if args := b.Args(); args != nil {
+				t.Errorf("Ident bound args %v; want none", args)
+			}
+		})
+	}
+}
+
+// TestBuilder_QualIdent — "qual"."name" with both parts backtick-quoted.
+func TestBuilder_QualIdent(t *testing.T) {
+	t.Parallel()
+
+	b := chsql.NewBuilder()
+	b.QualIdent("L", "Value")
+	if got, want := b.String(), "`L`.`Value`"; got != want {
+		t.Errorf("QualIdent = %q; want %q", got, want)
+	}
+}
+
+// TestBuilder_Arg — `?` placeholder appends a positional arg.
+func TestBuilder_Arg(t *testing.T) {
+	t.Parallel()
+
+	b := chsql.NewBuilder()
+	b.Arg("hello")
+	b.WriteSQL(", ")
+	b.Arg(42)
+	gotSQL, gotArgs := b.Build()
+	if want := "?, ?"; gotSQL != want {
+		t.Errorf("SQL = %q; want %q", gotSQL, want)
+	}
+	if want := []any{"hello", 42}; !reflect.DeepEqual(gotArgs, want) {
+		t.Errorf("Args = %v; want %v", gotArgs, want)
+	}
+}
+
+// TestBuilder_MapAt — Attributes['?'] form, key bound as positional arg.
+func TestBuilder_MapAt(t *testing.T) {
+	t.Parallel()
+
+	b := chsql.NewBuilder()
+	b.MapAt("Attributes", "service.name")
+	gotSQL, gotArgs := b.Build()
+	if want := "`Attributes`[?]"; gotSQL != want {
+		t.Errorf("SQL = %q; want %q", gotSQL, want)
+	}
+	if want := []any{"service.name"}; !reflect.DeepEqual(gotArgs, want) {
+		t.Errorf("Args = %v; want %v", gotArgs, want)
+	}
+}
+
+// TestBuilder_MapKeys — mapKeys(`Attributes`).
+func TestBuilder_MapKeys(t *testing.T) {
+	t.Parallel()
+
+	b := chsql.NewBuilder()
+	b.MapKeys("Attributes")
+	gotSQL, gotArgs := b.Build()
+	if want := "mapKeys(`Attributes`)"; gotSQL != want {
+		t.Errorf("SQL = %q; want %q", gotSQL, want)
+	}
+	if gotArgs != nil {
+		t.Errorf("Args = %v; want nil", gotArgs)
+	}
+}
+
+// TestBuilder_MapFilterExcept — mapFilter NOT IN form, all keys bound.
+func TestBuilder_MapFilterExcept(t *testing.T) {
+	t.Parallel()
+
+	b := chsql.NewBuilder()
+	b.MapFilterExcept("Attributes", "instance", "job")
+	gotSQL, gotArgs := b.Build()
+	want := "mapFilter((k, v) -> NOT (k IN (?, ?)), `Attributes`)"
+	if gotSQL != want {
+		t.Errorf("SQL = %q; want %q", gotSQL, want)
+	}
+	if w := []any{"instance", "job"}; !reflect.DeepEqual(gotArgs, w) {
+		t.Errorf("Args = %v; want %v", gotArgs, w)
+	}
+}
+
+// TestBuilder_MapFilterExceptPanicsOnEmpty — empty keys is a programmer
+// error: the resulting CH SQL would never filter anything, which is
+// never the caller's intent.
+func TestBuilder_MapFilterExceptPanicsOnEmpty(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("MapFilterExcept with no keys did not panic")
+		}
+		msg, _ := r.(string)
+		if !strings.Contains(msg, "MapFilterExcept") {
+			t.Errorf("panic value = %v; want message mentioning MapFilterExcept", r)
+		}
+	}()
+	b := chsql.NewBuilder()
+	b.MapFilterExcept("Attributes")
+}
+
+// TestBuilder_Now64 — bare CH builtin, no args.
+func TestBuilder_Now64(t *testing.T) {
+	t.Parallel()
+
+	b := chsql.NewBuilder()
+	b.Now64()
+	if got, want := b.String(), "now64(9)"; got != want {
+		t.Errorf("Now64 = %q; want %q", got, want)
+	}
+}
+
+// TestBuilder_SubtractNanos — wraps (<lhs> - toIntervalNanosecond(<ns>))
+// with the lhs callback running at the right position so its args
+// land before the ns literal.
+func TestBuilder_SubtractNanos(t *testing.T) {
+	t.Parallel()
+
+	b := chsql.NewBuilder()
+	b.SubtractNanos(func(b *chsql.Builder) { b.Now64() }, int64(5*time.Minute))
+	if got, want := b.String(), "(now64(9) - toIntervalNanosecond(300000000000))"; got != want {
+		t.Errorf("SubtractNanos = %q; want %q", got, want)
+	}
+}
+
+// TestBuilder_SubtractNanos_PreservesArgOrder — args bound inside lhs
+// appear in the args slice at the position they were emitted (i.e.
+// before the literal ns).
+func TestBuilder_SubtractNanos_PreservesArgOrder(t *testing.T) {
+	t.Parallel()
+
+	b := chsql.NewBuilder()
+	b.SubtractNanos(func(b *chsql.Builder) {
+		b.WriteSQL("max(")
+		b.MapAt("Attributes", "service.name")
+		b.WriteSQL(")")
+	}, 1000)
+	gotSQL, gotArgs := b.Build()
+	wantSQL := "(max(`Attributes`[?]) - toIntervalNanosecond(1000))"
+	if gotSQL != wantSQL {
+		t.Errorf("SQL = %q; want %q", gotSQL, wantSQL)
+	}
+	if want := []any{"service.name"}; !reflect.DeepEqual(gotArgs, want) {
+		t.Errorf("Args = %v; want %v", gotArgs, want)
+	}
+}
+
+// TestBuilder_DateTime64Lit — fixed-format CH DateTime64(9) literal,
+// nanosecond precision, UTC.
+func TestBuilder_DateTime64Lit(t *testing.T) {
+	t.Parallel()
+
+	// 2026-05-13 06:07:08.123456789 UTC.
+	tm := time.Date(2026, 5, 13, 6, 7, 8, 123456789, time.UTC)
+	b := chsql.NewBuilder()
+	b.DateTime64Lit(tm)
+	want := "toDateTime64('2026-05-13 06:07:08.123456789', 9)"
+	if got := b.String(); got != want {
+		t.Errorf("DateTime64Lit = %q; want %q", got, want)
+	}
+}
+
+// TestBuilder_DateTime64Lit_NormalisesToUTC — non-UTC time is rendered
+// in UTC so fixtures are reproducible across local timezones.
+func TestBuilder_DateTime64Lit_NormalisesToUTC(t *testing.T) {
+	t.Parallel()
+
+	loc, err := time.LoadLocation("America/Sao_Paulo")
+	if err != nil {
+		t.Fatalf("LoadLocation: %v", err)
+	}
+	// 2026-05-13 00:00:00 in America/Sao_Paulo == 2026-05-13 03:00:00 UTC.
+	tm := time.Date(2026, 5, 13, 0, 0, 0, 0, loc)
+	b := chsql.NewBuilder()
+	b.DateTime64Lit(tm)
+	want := "toDateTime64('2026-05-13 03:00:00.000000000', 9)"
+	if got := b.String(); got != want {
+		t.Errorf("DateTime64Lit = %q; want %q", got, want)
+	}
+}
+
+// TestBuilder_Lambda — "(k, v) -> NOT (k IN (?))" with the body
+// callback running at the lambda-body position.
+func TestBuilder_Lambda(t *testing.T) {
+	t.Parallel()
+
+	b := chsql.NewBuilder()
+	b.Lambda([]string{"k", "v"}, func(b *chsql.Builder) {
+		b.WriteSQL("k = ")
+		b.Arg("env")
+	})
+	gotSQL, gotArgs := b.Build()
+	if want := "(k, v) -> k = ?"; gotSQL != want {
+		t.Errorf("SQL = %q; want %q", gotSQL, want)
+	}
+	if want := []any{"env"}; !reflect.DeepEqual(gotArgs, want) {
+		t.Errorf("Args = %v; want %v", gotArgs, want)
+	}
+}
+
+// TestBuilder_ParamAgg_Parameterised — quantile(0.95)(value) style,
+// with both params and args via callbacks.
+func TestBuilder_ParamAgg_Parameterised(t *testing.T) {
+	t.Parallel()
+
+	b := chsql.NewBuilder()
+	b.ParamAgg(
+		"quantile",
+		[]func(b *chsql.Builder){
+			func(b *chsql.Builder) { b.Arg(0.95) },
+		},
+		[]func(b *chsql.Builder){
+			func(b *chsql.Builder) { b.Ident("Value") },
+		},
+	)
+	gotSQL, gotArgs := b.Build()
+	if want := "quantile(?)(`Value`)"; gotSQL != want {
+		t.Errorf("SQL = %q; want %q", gotSQL, want)
+	}
+	if want := []any{0.95}; !reflect.DeepEqual(gotArgs, want) {
+		t.Errorf("Args = %v; want %v", gotArgs, want)
+	}
+}
+
+// TestBuilder_ParamAgg_NoParams — non-parameterised form drops the
+// leading params parens, matching CH's "sum(value)" shape.
+func TestBuilder_ParamAgg_NoParams(t *testing.T) {
+	t.Parallel()
+
+	b := chsql.NewBuilder()
+	b.ParamAgg(
+		"sum",
+		nil,
+		[]func(b *chsql.Builder){
+			func(b *chsql.Builder) { b.Ident("Value") },
+		},
+	)
+	if got, want := b.String(), "sum(`Value`)"; got != want {
+		t.Errorf("ParamAgg(no params) = %q; want %q", got, want)
+	}
+}
+
+// TestBuilder_ParamAgg_MultiParam — quantiles(0.5, 0.9)(value) style.
+func TestBuilder_ParamAgg_MultiParam(t *testing.T) {
+	t.Parallel()
+
+	b := chsql.NewBuilder()
+	b.ParamAgg(
+		"quantiles",
+		[]func(b *chsql.Builder){
+			func(b *chsql.Builder) { b.Arg(0.5) },
+			func(b *chsql.Builder) { b.Arg(0.9) },
+		},
+		[]func(b *chsql.Builder){
+			func(b *chsql.Builder) { b.Ident("Value") },
+		},
+	)
+	gotSQL, gotArgs := b.Build()
+	if want := "quantiles(?, ?)(`Value`)"; gotSQL != want {
+		t.Errorf("SQL = %q; want %q", gotSQL, want)
+	}
+	if want := []any{0.5, 0.9}; !reflect.DeepEqual(gotArgs, want) {
+		t.Errorf("Args = %v; want %v", gotArgs, want)
+	}
+}
+
+// TestFrag_HelpersBindAtPosition — Col / Lit / Raw / Qual produce
+// Frags that can be plugged into a SelectBuilder slot; args bind in
+// emission order.
+func TestFrag_HelpersBindAtPosition(t *testing.T) {
+	t.Parallel()
+
+	b := chsql.NewBuilder()
+	chsql.Col("Value")(b)
+	b.WriteSQL(", ")
+	chsql.Lit(42)(b)
+	b.WriteSQL(", ")
+	chsql.Raw("now64(9)")(b)
+	b.WriteSQL(", ")
+	chsql.Qual("L", "TimeUnix")(b)
+	gotSQL, gotArgs := b.Build()
+	wantSQL := "`Value`, ?, now64(9), `L`.`TimeUnix`"
+	if gotSQL != wantSQL {
+		t.Errorf("SQL = %q; want %q", gotSQL, wantSQL)
+	}
+	if want := []any{42}; !reflect.DeepEqual(gotArgs, want) {
+		t.Errorf("Args = %v; want %v", gotArgs, want)
+	}
+}
+
+// TestSelectBuilder_Empty — empty SelectBuilder renders "SELECT *".
+// (No FROM is fine; CH accepts SELECT * alone for fixture-style
+// shapes, even if it's not what production emits.)
+func TestSelectBuilder_Empty(t *testing.T) {
+	t.Parallel()
+
+	sql, args := chsql.NewSelect().Build()
+	if want := "SELECT *"; sql != want {
+		t.Errorf("empty SELECT = %q; want %q", sql, want)
+	}
+	if args != nil {
+		t.Errorf("empty SELECT args = %v; want nil", args)
+	}
+}
+
+// TestSelectBuilder_Basic — Select / From / Where / Limit composed
+// in order, args from a Lit() in Where bind at the WHERE position.
+func TestSelectBuilder_Basic(t *testing.T) {
+	t.Parallel()
+
+	sql, args := chsql.NewSelect().
+		Select(chsql.Col("MetricName"), chsql.Col("Value")).
+		From(chsql.Col("otel_metrics_gauge")).
+		Where(func(b *chsql.Builder) {
+			b.Ident("MetricName")
+			b.WriteSQL(" = ")
+			b.Arg("http_requests_total")
+		}).
+		Limit(100).
+		Build()
+
+	wantSQL := "SELECT `MetricName`, `Value` FROM `otel_metrics_gauge`" +
+		" WHERE `MetricName` = ? LIMIT 100"
+	if sql != wantSQL {
+		t.Errorf("SQL = %q; want %q", sql, wantSQL)
+	}
+	if want := []any{"http_requests_total"}; !reflect.DeepEqual(args, want) {
+		t.Errorf("Args = %v; want %v", args, want)
+	}
+}
+
+// TestSelectBuilder_Prewhere — PREWHERE is emitted before WHERE in
+// the rendered SQL; multiple predicates in either slot join with AND.
+func TestSelectBuilder_Prewhere(t *testing.T) {
+	t.Parallel()
+
+	sql, args := chsql.NewSelect().
+		Select(chsql.Col("Value")).
+		From(chsql.Col("otel_metrics_gauge")).
+		Prewhere(func(b *chsql.Builder) {
+			b.Ident("TimeUnix")
+			b.WriteSQL(" > ")
+			b.Now64()
+		}).
+		Where(
+			func(b *chsql.Builder) {
+				b.Ident("MetricName")
+				b.WriteSQL(" = ")
+				b.Arg("http_requests_total")
+			},
+			func(b *chsql.Builder) {
+				b.Ident("Value")
+				b.WriteSQL(" > ")
+				b.Arg(0.5)
+			},
+		).
+		Build()
+
+	wantSQL := "SELECT `Value` FROM `otel_metrics_gauge`" +
+		" PREWHERE `TimeUnix` > now64(9)" +
+		" WHERE `MetricName` = ? AND `Value` > ?"
+	if sql != wantSQL {
+		t.Errorf("SQL = %q; want %q", sql, wantSQL)
+	}
+	if want := []any{"http_requests_total", 0.5}; !reflect.DeepEqual(args, want) {
+		t.Errorf("Args = %v; want %v", args, want)
+	}
+}
+
+// TestSelectBuilder_GroupByOrderBy — GROUP BY + ORDER BY composition;
+// DESC flag on the OrderBy key emits the DESC keyword.
+func TestSelectBuilder_GroupByOrderBy(t *testing.T) {
+	t.Parallel()
+
+	sql, args := chsql.NewSelect().
+		Select(chsql.Col("MetricName"), chsql.Raw("sum(`Value`) AS `total`")).
+		From(chsql.Col("otel_metrics_gauge")).
+		GroupBy(chsql.Col("MetricName")).
+		OrderBy(chsql.Col("total"), true).
+		Limit(10).
+		Build()
+
+	wantSQL := "SELECT `MetricName`, sum(`Value`) AS `total`" +
+		" FROM `otel_metrics_gauge`" +
+		" GROUP BY `MetricName`" +
+		" ORDER BY `total` DESC" +
+		" LIMIT 10"
+	if sql != wantSQL {
+		t.Errorf("SQL = %q; want %q", sql, wantSQL)
+	}
+	if args != nil {
+		t.Errorf("Args = %v; want nil", args)
+	}
+}
+
+// TestSelectBuilder_NestedSubquery — the worst-case nested case the
+// roadmap calls out: an inner SELECT with its own placeholders feeds
+// the outer SELECT's FROM, and an outer WHERE adds another `?`. Args
+// must appear in the same order as the `?` placeholders in the
+// rendered SQL.
+func TestSelectBuilder_NestedSubquery(t *testing.T) {
+	t.Parallel()
+
+	inner := chsql.NewSelect().
+		Select(chsql.Col("MetricName"), chsql.Col("Value")).
+		From(chsql.Col("otel_metrics_gauge")).
+		Where(func(b *chsql.Builder) {
+			b.MapAt("Attributes", "service.name")
+			b.WriteSQL(" = ")
+			b.Arg("api")
+		})
+
+	sql, args := chsql.NewSelect().
+		Select(chsql.Col("Value")).
+		From(inner.Frag()).
+		Where(func(b *chsql.Builder) {
+			b.Ident("Value")
+			b.WriteSQL(" > ")
+			b.Arg(0.5)
+		}).
+		Build()
+
+	wantSQL := "SELECT `Value` FROM (" +
+		"SELECT `MetricName`, `Value` FROM `otel_metrics_gauge`" +
+		" WHERE `Attributes`[?] = ?" +
+		") WHERE `Value` > ?"
+	if sql != wantSQL {
+		t.Errorf("SQL = %q; want %q", sql, wantSQL)
+	}
+	// `?` order: MapAt key, inner WHERE rhs, outer WHERE rhs.
+	if want := []any{"service.name", "api", 0.5}; !reflect.DeepEqual(args, want) {
+		t.Errorf("Args = %v; want %v", args, want)
+	}
+}


### PR DESCRIPTION
## Summary

First implementation milestone of RC6's type-safe-SQL refactor.
Adds `internal/chsql/builder.go` — the public named Builder API
referenced by the R6.0 evaluation
([`docs/sql-builder-evaluation.md`](https://github.com/tsouza/cerberus/blob/main/docs/sql-builder-evaluation.md),
shipped in #125; the doc reconciliation lands in #129) — and the
helper inventory the eval committed to.

**No emit_*.go changes.** Per the eval and the roadmap, R6.1 is
pure scaffolding; R6.2 onwards ports each `emit*` function to use
the new builder one at a time.

## Sequencing

This PR depends on #125 (the eval doc) and #129 (the
CLAUDE.md / roadmap reconciliation) being on `main` before merge,
because:

- #125 ships the eval doc this PR's design is based on. If this
  merges before #125, the design rationale isn't yet linkable from
  the codebase.
- #129 updates the CLAUDE.md hard rule to say \"new emitter code
  must go through `internal/chsql.Builder`\" rather than
  `huandu/go-sqlbuilder`. Without #129, this PR's `Builder` type
  technically conflicts with the wording of the rule.

Both have auto-merge enabled. This PR also has auto-merge enabled
and will rebase as the others land.

## What's in this PR

### `internal/chsql/builder.go`

- **`Builder`** — the public, named version of the unexported
  `emitter` struct. Wraps the same primitives the emitter already
  uses (`strings.Builder` + `[]any` args, identifier quoting,
  `?`-placeholder binding) and exposes them as a stable API:
  - `WriteSQL`, `Ident`, `QualIdent`, `Arg`
  - `MapAt(col, key)` → `` `col`[?] ``
  - `MapKeys(col)` → `mapKeys(\`col\`)`
  - `MapFilterExcept(col, keys...)` → `mapFilter((k, v) -> NOT (k IN (?, ?, ...)), \`col\`)`
  - `Now64()` → `now64(9)`
  - `SubtractNanos(lhs, ns)` → `(<lhs> - toIntervalNanosecond(<ns>))`
  - `DateTime64Lit(t)` → `toDateTime64('YYYY-MM-DD HH:MM:SS.NNNNNNNNN', 9)`
  - `Lambda(params, body)` → `(k, v) -> <body>`
  - `ParamAgg(name, params, args)` → `name(p…)(a…)` (CH's
    parameterised aggregate shape: quantile(0.95)(value),
    quantiles(0.5, 0.9)(value))
- **`Frag`** — `func(*Builder)`; the unit of composition.
  Constructors: `Col(name)`, `Qual(qual, name)`, `Lit(v)`,
  `Raw(sql)`.
- **`SelectBuilder`** — accumulates a SELECT statement's parts.
  Slots: SELECT, FROM, WHERE, **PREWHERE**, GROUP BY, ORDER BY,
  LIMIT. Methods: `Select(exprs...)`, `From(src)`, `Where(conds...)`,
  `Prewhere(conds...)`, `GroupBy(keys...)`, `OrderBy(expr, desc)`,
  `Limit(n)`, `Frag()` (renders as a nested-SELECT for
  composition), `Build()` (renders to `(sql, args)`).

PREWHERE is modelled as a first-class slot distinct from WHERE
so RC3 optimizer rules can promote predicates between the two as
slot-level operations rather than string rewrites on rendered SQL.

### `internal/chsql/builder_test.go`

- ≥ 1 test per helper. Total: 21 tests / 23 sub-tests.
- Worst-case nested-subquery test (`TestSelectBuilder_NestedSubquery`)
  pinning arg-ordering across an inner SELECT plugged into the
  outer's `FROM` via `inner.Frag()`. Confirms positional `?`
  ordering matches emission order, including args bound inside
  the nested SELECT.
- `TestBuilder_DateTime64Lit_NormalisesToUTC` confirms the
  literal renders in UTC regardless of input zone (deterministic
  fixtures).
- `TestBuilder_MapFilterExceptPanicsOnEmpty` confirms the
  programmer-error path is loud (CH SQL for an empty IN-set
  would never filter anything; we panic instead of silently
  emitting wrong SQL).

## Out of scope (deferred to R6.2+)

- No expression DSL (`Eq`, `And`, `Or`, etc.) — callers compose
  via closures or `Raw()`. R6.2 will add a small expression
  combinator surface as it ports `emit_expr.go`.
- No `emit*` migration — the existing emitter is unchanged and
  remains the source of truth for production SQL.
- No lint enforcement of \"no new Sprintf in SQL paths\" — that's
  R6.9 and requires the migration to be substantially complete
  before it lands without churn.

## Test plan

- [ ] CI lint passes (golangci-lint v2 clean — verified locally).
- [ ] CI check passes (`go test -race ./...` all green
      locally; new chsql tests don't break existing emit tests).
- [ ] No emit_*.go changes (verifiable via diffstat — only
      adds `internal/chsql/builder*.go`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)