### PR TITLE
feat(ci): fuzz + perf-benchmark workflow scaffolds (RC3 R3.11)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,51 @@
+name: fuzz
+
+# Weekly fuzz pass over the three parser heads. Runs the seed `FuzzParse`
+# targets in `internal/{promql,logql,traceql}` for a bounded duration each.
+# Any crash is uploaded as a `testdata/fuzz/...` corpus artifact so the
+# triggering input can be replayed locally with `go test -run=<TestName>/<hash>`.
+#
+# RC3 R3.11 scaffold. PR-comment + corpus-promotion polish lands later.
+
+on:
+  schedule:
+    # Sunday 03:00 UTC.
+    - cron: '0 3 * * 0'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fuzz-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  fuzz:
+    name: fuzz (${{ matrix.ql }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ql: [promql, logql, traceql]
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: fuzz ${{ matrix.ql }}
+        run: |
+          go test -run='^$' -fuzz=Fuzz -fuzztime=120s ./internal/${{ matrix.ql }}/...
+
+      - name: upload fuzz corpus on crash
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-corpus-${{ matrix.ql }}
+          path: |
+            internal/${{ matrix.ql }}/testdata/fuzz/**
+          if-no-files-found: ignore
+          retention-days: 30

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -1,0 +1,69 @@
+name: perf-benchmark
+
+# Weekly perf-regression sweep. Runs `go test -bench=.` against `main` and
+# against the trigger ref, then diffs the two with benchstat. Both raw
+# outputs and the benchstat diff are uploaded as artifacts.
+#
+# RC3 R3.11 scaffold. PR-comment integration lands as RC3 polish.
+
+on:
+  schedule:
+    # Sunday 04:00 UTC.
+    - cron: '0 4 * * 0'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: perf-benchmark-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  bench:
+    name: benchstat diff (main vs ref)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: install benchstat
+        run: go install golang.org/x/perf/cmd/benchstat@latest
+
+      - name: capture ref SHA
+        id: ref
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: bench against main
+        run: |
+          git fetch origin main
+          git checkout origin/main
+          go test -bench=. -benchmem -benchtime=10x -run='^$' ./... \
+            | tee main.bench
+
+      - name: bench against trigger ref
+        run: |
+          git checkout ${{ steps.ref.outputs.sha }}
+          go test -bench=. -benchmem -benchtime=10x -run='^$' ./... \
+            | tee ref.bench
+
+      - name: benchstat diff
+        run: benchstat main.bench ref.bench | tee benchstat.txt
+
+      - name: upload bench artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-benchmark
+          path: |
+            main.bench
+            ref.bench
+            benchstat.txt
+          if-no-files-found: warn
+          retention-days: 30

--- a/Justfile
+++ b/Justfile
@@ -43,6 +43,15 @@ clean:
 test:
     go test -race ./...
 
+# Run the FuzzParse target for one parser head for a bounded duration.
+# Usage: `just fuzz QL=promql DURATION=60s` (defaults).
+fuzz QL="promql" DURATION="60s":
+    go test -run='^$' -fuzz=FuzzParse -fuzztime={{DURATION}} ./internal/{{QL}}/...
+
+# Run all Go benchmarks (no tests). Short benchtime for local use.
+bench:
+    go test -bench=. -benchmem -benchtime=5x -run='^$' ./...
+
 # Regenerate TXTAR golden sections in test/spec/**/*.txtar from current output.
 # Review `git diff test/spec/` before committing.
 update-golden:

--- a/internal/logql/fuzz_test.go
+++ b/internal/logql/fuzz_test.go
@@ -1,0 +1,47 @@
+package logql_test
+
+import (
+	"testing"
+
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+
+	"github.com/tsouza/cerberus/internal/logql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// FuzzParse drives random inputs through the upstream LogQL parser and,
+// on a successful parse, through cerberus's lowering. The goal is
+// panic-freedom: any panic surfaces as a fuzz crash with the offending
+// seed promoted to testdata/fuzz/FuzzParse/.
+//
+// RC3 R3.11 — seed corpus is intentionally small; CI runs `-fuzztime=120s`
+// per parser weekly to grow the corpus organically.
+func FuzzParse(f *testing.F) {
+	seeds := []string{
+		`{job="api"}`,
+		`{job="api"} |= "ERROR"`,
+		`{job="api"} | json | level="ERROR"`,
+		`{job="api"} | logfmt | latency > 100ms`,
+		`rate({job="api"}[5m])`,
+		`sum by (level) (rate({job="api"} |= "error" [5m]))`,
+		`count_over_time({job="api"}[5m])`,
+		`sum_over_time({job="api"} | unwrap latency [5m])`,
+		`topk(5, sum by (level) (rate({job="api"}[5m])))`,
+		`{job="api"} | line_format "{{.message}}"`,
+		`{job="api"} | label_format new_level="{{.level}}"`,
+		`{job="api"} | regexp "(?P<status>\\d+)"`,
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	s := schema.DefaultOTelLogs()
+
+	f.Fuzz(func(t *testing.T, q string) {
+		expr, err := syntax.ParseExpr(q)
+		if err != nil {
+			return
+		}
+		_, _ = logql.Lower(expr, s)
+	})
+}

--- a/internal/promql/fuzz_test.go
+++ b/internal/promql/fuzz_test.go
@@ -1,0 +1,48 @@
+package promql_test
+
+import (
+	"testing"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// FuzzParse drives random inputs through the upstream PromQL parser and,
+// on a successful parse, through cerberus's lowering. The goal is
+// panic-freedom: any panic surfaces as a fuzz crash with the offending
+// seed promoted to testdata/fuzz/FuzzParse/.
+//
+// RC3 R3.11 — seed corpus is intentionally small; CI runs `-fuzztime=120s`
+// per parser weekly to grow the corpus organically.
+func FuzzParse(f *testing.F) {
+	seeds := []string{
+		`up`,
+		`up{job="api"}`,
+		`rate(http_requests_total[5m])`,
+		`sum by (job) (rate(http_requests_total[5m]))`,
+		`histogram_quantile(0.9, sum by (le) (rate(http_request_duration_seconds_bucket[5m])))`,
+		`up + on(job) up`,
+		`up offset 5m`,
+		`up @ 1700000000`,
+		`max_over_time(rate(http_requests_total[5m])[1h:5m])`,
+		`100 * (1 - avg(rate(node_cpu_seconds_total{mode="idle"}[5m])))`,
+		`absent_over_time(up[5m])`,
+		`label_replace(up, "new", "$1", "job", "(.+)")`,
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{})
+
+	f.Fuzz(func(t *testing.T, q string) {
+		expr, err := p.ParseExpr(q)
+		if err != nil {
+			return
+		}
+		_, _ = promql.Lower(expr, s)
+	})
+}

--- a/internal/traceql/fuzz_test.go
+++ b/internal/traceql/fuzz_test.go
@@ -1,0 +1,47 @@
+package traceql_test
+
+import (
+	"testing"
+
+	tempo "github.com/grafana/tempo/pkg/traceql"
+
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/traceql"
+)
+
+// FuzzParse drives random inputs through the upstream TraceQL parser and,
+// on a successful parse, through cerberus's lowering. The goal is
+// panic-freedom: any panic surfaces as a fuzz crash with the offending
+// seed promoted to testdata/fuzz/FuzzParse/.
+//
+// RC3 R3.11 — seed corpus is intentionally small; CI runs `-fuzztime=120s`
+// per parser weekly to grow the corpus organically.
+func FuzzParse(f *testing.F) {
+	seeds := []string{
+		`{ resource.service.name = "frontend" }`,
+		`{ duration > 100ms }`,
+		`{ span.http.status_code >= 500 }`,
+		`{ resource.service.name = "frontend" && duration > 100ms }`,
+		`{ resource.service.name = "frontend" } | count() > 0`,
+		`{ resource.service.name = "api" } | avg(duration) > 100ms`,
+		`{ resource.service.name = "frontend" } | select(span.http.method)`,
+		`{ resource.service.name = "frontend" } > { resource.service.name = "api" }`,
+		`{ name =~ "GET /.*" }`,
+		`{ .a + .b > 10 }`,
+		`{ !(.a = .b) }`,
+		`{ resource.deployment.environment = "prod" && span.http.method = "POST" }`,
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	s := schema.DefaultOTelTraces()
+
+	f.Fuzz(func(t *testing.T, q string) {
+		expr, err := tempo.Parse(q)
+		if err != nil {
+			return
+		}
+		_, _ = traceql.Lower(expr, s)
+	})
+}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/fuzz.yml` (weekly + manual; per-QL matrix).
- Adds `.github/workflows/perf-benchmark.yml` (weekly + manual; benchstat diff vs `main`).
- Adds seed `FuzzParse` tests for promql / logql / traceql + Justfile recipes.
- Scope: scaffold only. RC3 R3.11. No existing files modified beyond Justfile.

## Test plan
- [ ] `fuzz.yml` lints clean in GH Actions (workflow parsed).
- [ ] `perf-benchmark.yml` lints clean.
- [ ] `just fuzz QL=promql DURATION=5s` runs locally.
- [ ] `just bench` runs locally.

Roadmap: docs/roadmap.md § RC3 R3.11.