### PR TITLE
feat(promshim/local): scaffold local Go PromQL evaluator (RC3 R3.10)

### DIFF
--- a/internal/promshim/local/doc.go
+++ b/internal/promshim/local/doc.go
@@ -1,0 +1,16 @@
+// Package local provides an in-process PromQL evaluator intended to serve as
+// the differential-testing oracle for cerberus shadow-mode (RC3 R3.9).
+//
+// The evaluator wraps Prometheus's own promql.Engine and runs queries against
+// an in-memory SampleStore. It performs no ClickHouse I/O; callers seed
+// synthetic series, then issue Instant or Range queries, and the resulting
+// samples are diffed against cerberus's ClickHouse-emitted results.
+//
+// Design lineage: this package is inspired by the BadLiveware/promshim-clickhouse
+// project's local evaluator, but is implemented from scratch on top of the
+// Prometheus engine API (no code is ported verbatim, so no attribution is
+// required).
+//
+// Status: scaffold (RC3 R3.10). No callers yet. RC3 R3.9 will wire this into
+// the shadow-mode harness.
+package local

--- a/internal/promshim/local/engine.go
+++ b/internal/promshim/local/engine.go
@@ -1,0 +1,51 @@
+package local
+
+import (
+	"time"
+
+	"github.com/prometheus/prometheus/promql"
+)
+
+// Options configures a local PromQL evaluator. Zero-valued fields fall back to
+// safe defaults appropriate for an in-process oracle.
+type Options struct {
+	// MaxSamples caps the number of samples a single query may load. Defaults
+	// to 50_000_000, matching Prometheus's default in production setups.
+	MaxSamples int
+	// Timeout is the per-query wall-clock budget. Defaults to 2 minutes.
+	Timeout time.Duration
+	// LookbackDelta is the time since the last sample after which a series is
+	// considered stale. Defaults to 5 minutes (Prometheus's default).
+	LookbackDelta time.Duration
+}
+
+// Engine is a thin wrapper around promql.Engine that exposes the cerberus
+// shadow-mode oracle surface: Instant and Range query evaluation against a
+// caller-supplied SampleStore.
+type Engine struct {
+	engine *promql.Engine
+}
+
+// NewEngine constructs a local PromQL evaluator with the provided options.
+// The wrapped promql.Engine has @ modifier and negative offsets enabled to
+// mirror modern Prometheus defaults.
+func NewEngine(opts Options) *Engine {
+	if opts.MaxSamples == 0 {
+		opts.MaxSamples = 50_000_000
+	}
+	if opts.Timeout == 0 {
+		opts.Timeout = 2 * time.Minute
+	}
+	if opts.LookbackDelta == 0 {
+		opts.LookbackDelta = 5 * time.Minute
+	}
+	return &Engine{
+		engine: promql.NewEngine(promql.EngineOpts{
+			MaxSamples:           opts.MaxSamples,
+			Timeout:              opts.Timeout,
+			LookbackDelta:        opts.LookbackDelta,
+			EnableAtModifier:     true,
+			EnableNegativeOffset: true,
+		}),
+	}
+}

--- a/internal/promshim/local/engine_test.go
+++ b/internal/promshim/local/engine_test.go
@@ -1,0 +1,217 @@
+package local
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+// seedDataset populates a SampleStore with three series of http_requests_total
+// counters and one `up` series, spanning a 5-minute window at 15s resolution.
+//
+// Layout (counter values are cumulative, starting at 0):
+//
+//	http_requests_total{job="api",   method="get"}  → +1 every 15s
+//	http_requests_total{job="api",   method="post"} → +2 every 15s
+//	http_requests_total{job="batch", method="get"}  → +5 every 15s
+//	up{job="api"}                                   ≡ 1
+//	up{job="batch"}                                 ≡ 1
+//
+// baseTS is the inclusive start of the 5-minute window.
+func seedDataset(t *testing.T, store *SampleStore, baseTS time.Time) {
+	t.Helper()
+	step := 15 * time.Second
+	const samples = 21 // 5 minutes inclusive of both endpoints at 15s
+
+	series := []struct {
+		lset      labels.Labels
+		increment float64
+	}{
+		{labels.FromStrings("__name__", "http_requests_total", "job", "api", "method", "get"), 1},
+		{labels.FromStrings("__name__", "http_requests_total", "job", "api", "method", "post"), 2},
+		{labels.FromStrings("__name__", "http_requests_total", "job", "batch", "method", "get"), 5},
+	}
+	for _, s := range series {
+		var v float64
+		for i := 0; i < samples; i++ {
+			ts := baseTS.Add(time.Duration(i) * step)
+			store.Append(s.lset, ts.UnixMilli(), v)
+			v += s.increment
+		}
+	}
+	upSeries := []labels.Labels{
+		labels.FromStrings("__name__", "up", "job", "api"),
+		labels.FromStrings("__name__", "up", "job", "batch"),
+	}
+	for _, lset := range upSeries {
+		for i := 0; i < samples; i++ {
+			ts := baseTS.Add(time.Duration(i) * step)
+			store.Append(lset, ts.UnixMilli(), 1)
+		}
+	}
+}
+
+func TestEngine_Instant(t *testing.T) {
+	t.Parallel()
+	baseTS := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	store := NewSampleStore()
+	seedDataset(t, store, baseTS)
+	eng := NewEngine(Options{})
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		query     string
+		evalAt    time.Time
+		wantKind  ResultKind
+		wantCount int // expected number of series (0 means "don't check")
+		// check is an optional extra assertion on the result.
+		check func(t *testing.T, res Result)
+	}{
+		{
+			name:      "rate_5m_yields_three_series",
+			query:     `rate(http_requests_total[5m])`,
+			evalAt:    baseTS.Add(5 * time.Minute),
+			wantKind:  ResultKindVector,
+			wantCount: 3,
+			check: func(t *testing.T, res Result) {
+				// At evalAt, each series has been incrementing for 5 minutes
+				// (300s). rate() over [5m] for the api/get series should equal
+				// (20 increments * 1) / 300s ≈ 0.0666...; api/post ≈ 0.1333...;
+				// batch/get ≈ 0.3333...
+				for _, s := range res.Vector {
+					method := s.Metric.Get("method")
+					job := s.Metric.Get("job")
+					switch {
+					case job == "api" && method == "get":
+						assertApprox(t, s.V, 20.0/300.0, 1e-6, "api/get rate")
+					case job == "api" && method == "post":
+						assertApprox(t, s.V, 40.0/300.0, 1e-6, "api/post rate")
+					case job == "batch" && method == "get":
+						assertApprox(t, s.V, 100.0/300.0, 1e-6, "batch/get rate")
+					default:
+						t.Fatalf("unexpected series in rate result: %s", s.Metric)
+					}
+				}
+			},
+		},
+		{
+			name:      "sum_by_job_collapses_methods",
+			query:     `sum by (job) (rate(http_requests_total[5m]))`,
+			evalAt:    baseTS.Add(5 * time.Minute),
+			wantKind:  ResultKindVector,
+			wantCount: 2,
+			check: func(t *testing.T, res Result) {
+				got := map[string]float64{}
+				for _, s := range res.Vector {
+					got[s.Metric.Get("job")] = s.V
+				}
+				// api: (20 + 40) / 300 = 0.2
+				assertApprox(t, got["api"], 0.2, 1e-6, "sum by job=api")
+				// batch: 100 / 300 ≈ 0.3333
+				assertApprox(t, got["batch"], 100.0/300.0, 1e-6, "sum by job=batch")
+			},
+		},
+		{
+			name:      "scalar_literal",
+			query:     `scalar(vector(42))`,
+			evalAt:    baseTS.Add(5 * time.Minute),
+			wantKind:  ResultKindScalar,
+			wantCount: 0,
+			check: func(t *testing.T, res Result) {
+				if res.Scalar == nil {
+					t.Fatalf("expected scalar result, got nil")
+				}
+				assertApprox(t, res.Scalar.V, 42, 1e-9, "scalar value")
+			},
+		},
+		{
+			name:      "up_matcher_filters_to_one_series",
+			query:     `up{job="api"}`,
+			evalAt:    baseTS.Add(2 * time.Minute),
+			wantKind:  ResultKindVector,
+			wantCount: 1,
+			check: func(t *testing.T, res Result) {
+				if got := res.Vector[0].Metric.Get("job"); got != "api" {
+					t.Fatalf("expected job=api, got %q", got)
+				}
+				assertApprox(t, res.Vector[0].V, 1, 1e-9, "up value")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			res, err := eng.Instant(ctx, store, tc.query, tc.evalAt)
+			if err != nil {
+				t.Fatalf("Instant(%q): %v", tc.query, err)
+			}
+			if res.Kind != tc.wantKind {
+				t.Fatalf("Instant(%q) kind: got %v, want %v", tc.query, res.Kind, tc.wantKind)
+			}
+			if tc.wantCount > 0 && len(res.Vector) != tc.wantCount {
+				t.Fatalf("Instant(%q): got %d vector samples, want %d (vector=%v)",
+					tc.query, len(res.Vector), tc.wantCount, res.Vector)
+			}
+			if tc.check != nil {
+				tc.check(t, res)
+			}
+		})
+	}
+}
+
+func TestEngine_Range(t *testing.T) {
+	t.Parallel()
+	baseTS := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	store := NewSampleStore()
+	seedDataset(t, store, baseTS)
+	eng := NewEngine(Options{})
+	ctx := context.Background()
+
+	res, err := eng.Range(ctx, store, `rate(http_requests_total{job="batch"}[1m])`,
+		baseTS.Add(1*time.Minute), baseTS.Add(5*time.Minute), 30*time.Second)
+	if err != nil {
+		t.Fatalf("Range: %v", err)
+	}
+	if res.Kind != ResultKindMatrix {
+		t.Fatalf("Range kind: got %v, want Matrix", res.Kind)
+	}
+	if len(res.Matrix) != 1 {
+		t.Fatalf("Range matrix: got %d series, want 1", len(res.Matrix))
+	}
+	// step = 30s over [1m, 5m] → 9 evaluation points (1:00, 1:30, …, 5:00).
+	if got := len(res.Matrix[0].Points); got != 9 {
+		t.Fatalf("Range matrix points: got %d, want 9", got)
+	}
+	// Every point should report rate ≈ 5/15 ≈ 0.3333 (one increment of 5 per
+	// 15s sample). Tolerance is generous because rate() uses extrapolation at
+	// window edges.
+	for _, p := range res.Matrix[0].Points {
+		if p.V <= 0 || math.IsNaN(p.V) {
+			t.Fatalf("Range point: non-positive or NaN value at t=%d: %v", p.T, p.V)
+		}
+		assertApprox(t, p.V, 5.0/15.0, 0.05, "batch/get range rate")
+	}
+}
+
+func TestEngine_Range_RejectsZeroStep(t *testing.T) {
+	t.Parallel()
+	store := NewSampleStore()
+	eng := NewEngine(Options{})
+	ts := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	if _, err := eng.Range(context.Background(), store, `up`, ts, ts.Add(time.Minute), 0); err == nil {
+		t.Fatalf("Range with step=0 should error")
+	}
+}
+
+func assertApprox(t *testing.T, got, want, tol float64, label string) {
+	t.Helper()
+	if math.Abs(got-want) > tol {
+		t.Fatalf("%s: got %v, want %v (±%v)", label, got, want, tol)
+	}
+}

--- a/internal/promshim/local/evaluator.go
+++ b/internal/promshim/local/evaluator.go
@@ -1,0 +1,113 @@
+package local
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/util/annotations"
+)
+
+// ResultKind tags which variant a Result carries.
+type ResultKind int
+
+const (
+	// ResultKindVector indicates an instant-query result (one value per series
+	// at a single timestamp).
+	ResultKindVector ResultKind = iota
+	// ResultKindMatrix indicates a range-query result (a time series per
+	// matching series).
+	ResultKindMatrix
+	// ResultKindScalar indicates a single-valued numeric result.
+	ResultKindScalar
+)
+
+// VectorSample mirrors promql.Sample but is decoupled from Prometheus's
+// internal types so downstream diff code can compare against cerberus's own
+// chclient sample shape without dragging in promql/parser internals.
+type VectorSample struct {
+	Metric labels.Labels
+	T      int64
+	V      float64
+}
+
+// MatrixSeries is one labelled time series in a range-query result.
+type MatrixSeries struct {
+	Metric labels.Labels
+	Points []FloatSample
+}
+
+// Result is the cerberus-shaped output of an evaluator query. Exactly one of
+// Vector / Matrix / Scalar is populated depending on Kind.
+type Result struct {
+	Kind     ResultKind
+	Vector   []VectorSample
+	Matrix   []MatrixSeries
+	Scalar   *VectorSample // Scalar carries a single (T, V) pair; Metric is empty.
+	Warnings annotations.Annotations
+}
+
+// Instant evaluates query at instant ts against the supplied SampleStore and
+// returns a cerberus-shaped Result.
+func (e *Engine) Instant(ctx context.Context, store storage.Queryable, query string, ts time.Time) (Result, error) {
+	q, err := e.engine.NewInstantQuery(ctx, store, nil, query, ts)
+	if err != nil {
+		return Result{}, fmt.Errorf("local: prepare instant query: %w", err)
+	}
+	defer q.Close()
+	res := q.Exec(ctx)
+	if res.Err != nil {
+		return Result{}, fmt.Errorf("local: exec instant query: %w", res.Err)
+	}
+	return toResult(res)
+}
+
+// Range evaluates query over [start, end] at the given step against the
+// supplied SampleStore and returns a cerberus-shaped Result. Step must be > 0.
+func (e *Engine) Range(ctx context.Context, store storage.Queryable, query string, start, end time.Time, step time.Duration) (Result, error) {
+	if step <= 0 {
+		return Result{}, fmt.Errorf("local: range step must be > 0, got %s", step)
+	}
+	q, err := e.engine.NewRangeQuery(ctx, store, nil, query, start, end, step)
+	if err != nil {
+		return Result{}, fmt.Errorf("local: prepare range query: %w", err)
+	}
+	defer q.Close()
+	res := q.Exec(ctx)
+	if res.Err != nil {
+		return Result{}, fmt.Errorf("local: exec range query: %w", res.Err)
+	}
+	return toResult(res)
+}
+
+func toResult(res *promql.Result) (Result, error) {
+	switch v := res.Value.(type) {
+	case promql.Vector:
+		out := Result{Kind: ResultKindVector, Warnings: res.Warnings, Vector: make([]VectorSample, 0, len(v))}
+		for _, s := range v {
+			out.Vector = append(out.Vector, VectorSample{Metric: s.Metric, T: s.T, V: s.F})
+		}
+		return out, nil
+	case promql.Matrix:
+		out := Result{Kind: ResultKindMatrix, Warnings: res.Warnings, Matrix: make([]MatrixSeries, 0, len(v))}
+		for _, s := range v {
+			pts := make([]FloatSample, 0, len(s.Floats))
+			for _, p := range s.Floats {
+				pts = append(pts, FloatSample{T: p.T, V: p.F})
+			}
+			out.Matrix = append(out.Matrix, MatrixSeries{Metric: s.Metric, Points: pts})
+		}
+		return out, nil
+	case promql.Scalar:
+		return Result{
+			Kind:     ResultKindScalar,
+			Warnings: res.Warnings,
+			Scalar:   &VectorSample{T: v.T, V: v.V},
+		}, nil
+	default:
+		return Result{}, fmt.Errorf("local: unsupported result value type %T", res.Value)
+	}
+}

--- a/internal/promshim/local/sample_store.go
+++ b/internal/promshim/local/sample_store.go
@@ -170,13 +170,13 @@ type chunkSample struct {
 	v float64
 }
 
-func (s chunkSample) T() int64                            { return s.t }
-func (s chunkSample) ST() int64                           { return 0 }
-func (s chunkSample) F() float64                          { return s.v }
-func (s chunkSample) H() *histogram.Histogram             { return nil }
-func (s chunkSample) FH() *histogram.FloatHistogram       { return nil }
-func (s chunkSample) Type() chunkenc.ValueType            { return chunkenc.ValFloat }
-func (s chunkSample) Copy() chunks.Sample                 { return s }
+func (s chunkSample) T() int64                      { return s.t }
+func (s chunkSample) ST() int64                     { return 0 }
+func (s chunkSample) F() float64                    { return s.v }
+func (s chunkSample) H() *histogram.Histogram       { return nil }
+func (s chunkSample) FH() *histogram.FloatHistogram { return nil }
+func (s chunkSample) Type() chunkenc.ValueType      { return chunkenc.ValFloat }
+func (s chunkSample) Copy() chunks.Sample           { return s }
 
 func toChunkSamples(in []FloatSample) []chunks.Sample {
 	out := make([]chunks.Sample, len(in))

--- a/internal/promshim/local/sample_store.go
+++ b/internal/promshim/local/sample_store.go
@@ -1,0 +1,206 @@
+package local
+
+import (
+	"context"
+	"sort"
+	"sync"
+
+	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+	"github.com/prometheus/prometheus/util/annotations"
+)
+
+// FloatSample is a single (timestamp, value) tuple stored in a SampleStore.
+// Timestamps are unix milliseconds, matching Prometheus's internal convention.
+type FloatSample struct {
+	T int64
+	V float64
+}
+
+// SampleStore is a minimal in-memory implementation of storage.Queryable
+// suitable for use as the shadow-mode oracle. Series are keyed by their full
+// labelset; per-series samples are kept sorted by timestamp.
+//
+// The zero value is ready to use, but prefer NewSampleStore for clarity.
+type SampleStore struct {
+	mu     sync.RWMutex
+	series map[uint64]*storedSeries
+}
+
+type storedSeries struct {
+	lset    labels.Labels
+	samples []FloatSample
+}
+
+// NewSampleStore returns an empty SampleStore.
+func NewSampleStore() *SampleStore {
+	return &SampleStore{series: make(map[uint64]*storedSeries)}
+}
+
+// Append inserts a (timestamp, value) sample for the given labelset. Samples
+// are kept sorted by timestamp; out-of-order inserts are placed in order.
+// Duplicate timestamps for the same series overwrite the previous value.
+func (s *SampleStore) Append(lset labels.Labels, t int64, v float64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.series == nil {
+		s.series = make(map[uint64]*storedSeries)
+	}
+	key := lset.Hash()
+	ser, ok := s.series[key]
+	if !ok {
+		ser = &storedSeries{lset: lset.Copy()}
+		s.series[key] = ser
+	}
+	idx := sort.Search(len(ser.samples), func(i int) bool {
+		return ser.samples[i].T >= t
+	})
+	if idx < len(ser.samples) && ser.samples[idx].T == t {
+		ser.samples[idx].V = v
+		return
+	}
+	ser.samples = append(ser.samples, FloatSample{})
+	copy(ser.samples[idx+1:], ser.samples[idx:])
+	ser.samples[idx] = FloatSample{T: t, V: v}
+}
+
+// Querier implements storage.Queryable.
+func (s *SampleStore) Querier(mint, maxt int64) (storage.Querier, error) {
+	return &sampleStoreQuerier{store: s, mint: mint, maxt: maxt}, nil
+}
+
+type sampleStoreQuerier struct {
+	store      *SampleStore
+	mint, maxt int64
+}
+
+func (q *sampleStoreQuerier) Select(_ context.Context, sortSeries bool, _ *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
+	q.store.mu.RLock()
+	defer q.store.mu.RUnlock()
+
+	var matched []storage.Series
+	for _, ser := range q.store.series {
+		if !matchAll(ser.lset, matchers) {
+			continue
+		}
+		samples := windowSamples(ser.samples, q.mint, q.maxt)
+		if len(samples) == 0 {
+			continue
+		}
+		matched = append(matched, storage.NewListSeries(ser.lset, toChunkSamples(samples)))
+	}
+	if sortSeries {
+		sort.Slice(matched, func(i, j int) bool {
+			return labels.Compare(matched[i].Labels(), matched[j].Labels()) < 0
+		})
+	}
+	return &sliceSeriesSet{series: matched, idx: -1}
+}
+
+func (q *sampleStoreQuerier) LabelValues(_ context.Context, name string, _ *storage.LabelHints, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	q.store.mu.RLock()
+	defer q.store.mu.RUnlock()
+	seen := make(map[string]struct{})
+	for _, ser := range q.store.series {
+		if !matchAll(ser.lset, matchers) {
+			continue
+		}
+		if v := ser.lset.Get(name); v != "" {
+			seen[v] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for v := range seen {
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out, nil, nil
+}
+
+func (q *sampleStoreQuerier) LabelNames(_ context.Context, _ *storage.LabelHints, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	q.store.mu.RLock()
+	defer q.store.mu.RUnlock()
+	seen := make(map[string]struct{})
+	for _, ser := range q.store.series {
+		if !matchAll(ser.lset, matchers) {
+			continue
+		}
+		ser.lset.Range(func(l labels.Label) {
+			seen[l.Name] = struct{}{}
+		})
+	}
+	out := make([]string, 0, len(seen))
+	for v := range seen {
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out, nil, nil
+}
+
+func (q *sampleStoreQuerier) Close() error { return nil }
+
+func matchAll(lset labels.Labels, matchers []*labels.Matcher) bool {
+	for _, m := range matchers {
+		if !m.Matches(lset.Get(m.Name)) {
+			return false
+		}
+	}
+	return true
+}
+
+func windowSamples(samples []FloatSample, mint, maxt int64) []FloatSample {
+	if len(samples) == 0 {
+		return nil
+	}
+	lo := sort.Search(len(samples), func(i int) bool { return samples[i].T >= mint })
+	hi := sort.Search(len(samples), func(i int) bool { return samples[i].T > maxt })
+	if lo >= hi {
+		return nil
+	}
+	return samples[lo:hi]
+}
+
+// chunkSample adapts a FloatSample to the chunks.Sample interface required by
+// storage.NewListSeries.
+type chunkSample struct {
+	t int64
+	v float64
+}
+
+func (s chunkSample) T() int64                            { return s.t }
+func (s chunkSample) ST() int64                           { return 0 }
+func (s chunkSample) F() float64                          { return s.v }
+func (s chunkSample) H() *histogram.Histogram             { return nil }
+func (s chunkSample) FH() *histogram.FloatHistogram       { return nil }
+func (s chunkSample) Type() chunkenc.ValueType            { return chunkenc.ValFloat }
+func (s chunkSample) Copy() chunks.Sample                 { return s }
+
+func toChunkSamples(in []FloatSample) []chunks.Sample {
+	out := make([]chunks.Sample, len(in))
+	for i, s := range in {
+		out[i] = chunkSample{t: s.T, v: s.V}
+	}
+	return out
+}
+
+// sliceSeriesSet is a trivial storage.SeriesSet backed by a slice.
+type sliceSeriesSet struct {
+	series []storage.Series
+	idx    int
+}
+
+func (s *sliceSeriesSet) Next() bool {
+	s.idx++
+	return s.idx < len(s.series)
+}
+
+func (s *sliceSeriesSet) At() storage.Series {
+	return s.series[s.idx]
+}
+
+func (s *sliceSeriesSet) Err() error { return nil }
+
+func (s *sliceSeriesSet) Warnings() annotations.Annotations { return nil }


### PR DESCRIPTION
## Summary
- New `internal/promshim/local/` package: in-process PromQL evaluator backed by `prometheus/prometheus/promql.NewEngine`.
- Provides `Engine.Instant` + `Engine.Range` for use as the RC3 R3.9 differential-testing oracle.
- Scaffold scope: SampleStore + Engine + 4-6 test queries. No callers yet - R3.9 wires it.

## Test plan
- [ ] `go test ./internal/promshim/local/...` passes.
- [ ] `go vet ./internal/promshim/local/...` clean.

Roadmap: docs/roadmap.md § RC3 R3.10.