### PR TITLE
feat(optimizer): pattern-based Rule API scaffold (RC3 R3.1)

### DIFF
--- a/internal/optimizer/pattern.go
+++ b/internal/optimizer/pattern.go
@@ -1,0 +1,190 @@
+package optimizer
+
+// Pattern matching for the cerberus plan IR.
+//
+// Design lineage: Apache Calcite's `org.apache.calcite.rel.rules` operands
+// (declarative match → transform) and Spark Catalyst's `Rule[LogicalPlan]`
+// quasiquote-style pattern matching. Calcite's rule-engine matches a tree of
+// `RelOptRuleOperand`s against a `RelNode`; Catalyst leans on Scala pattern
+// matching directly. Cerberus splits the difference: the chplan IR is
+// hand-rolled Go structs, so we provide a small combinator API that builds
+// up a `Pattern` tree which can be matched and bound against a `chplan.Node`
+// tree.
+//
+// The combinators in this file are pure value constructors — they don't
+// touch the tree. `Pattern.Match` is the only place that walks a candidate
+// node. Bindings flow back to the caller (a `PatternRule`'s `Apply`
+// function) via a `Bindings` map keyed on the names supplied to `Capture`.
+//
+// Scope (RC3 R3.1): scaffold only. The existing three optimizer rules
+// (filter-fusion, constant-fold, projection-pushdown) keep their bespoke
+// type-switch shape. RC3 R3.2 ports them to `PatternRule`.
+
+import (
+	"reflect"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// NodeKind identifies a concrete chplan node type. The chplan package
+// itself does not define an enum; we identify kinds by their `reflect.Type`
+// (specifically the pointer-receiver type — every chplan node satisfies
+// `chplan.Node` via a pointer receiver, e.g. `*chplan.Filter`).
+//
+// Callers acquire a kind via the package-level helpers (`KindFilter`,
+// `KindScan`, ...) or `KindOf` for a one-off lookup from an existing node.
+type NodeKind struct {
+	t reflect.Type
+}
+
+// KindOf returns the NodeKind of n. Useful for asserting "kind preserved"
+// in tests.
+func KindOf(n chplan.Node) NodeKind {
+	if n == nil {
+		return NodeKind{}
+	}
+	return NodeKind{t: reflect.TypeOf(n)}
+}
+
+// Predefined kinds for every concrete chplan operator. Kept in lockstep
+// with the chplan package; new operators land here when they land there.
+var (
+	KindScan           = NodeKind{t: reflect.TypeOf((*chplan.Scan)(nil))}
+	KindFilter         = NodeKind{t: reflect.TypeOf((*chplan.Filter)(nil))}
+	KindProject        = NodeKind{t: reflect.TypeOf((*chplan.Project)(nil))}
+	KindAggregate      = NodeKind{t: reflect.TypeOf((*chplan.Aggregate)(nil))}
+	KindRangeWindow    = NodeKind{t: reflect.TypeOf((*chplan.RangeWindow)(nil))}
+	KindLimit          = NodeKind{t: reflect.TypeOf((*chplan.Limit)(nil))}
+	KindOrderBy        = NodeKind{t: reflect.TypeOf((*chplan.OrderBy)(nil))}
+	KindVectorJoin     = NodeKind{t: reflect.TypeOf((*chplan.VectorJoin)(nil))}
+	KindStructuralJoin = NodeKind{t: reflect.TypeOf((*chplan.StructuralJoin)(nil))}
+)
+
+// Bindings is the result of a successful pattern match: a map from the
+// names supplied to `Capture` combinators to the concrete nodes they bound.
+//
+// A nil map means "the pattern didn't use Capture" — every pattern returns
+// a usable (possibly empty) map on success; callers should check the
+// boolean rather than the map's nilness.
+type Bindings map[string]chplan.Node
+
+// Get returns the node bound under name and whether it was present. A
+// convenience wrapper around the underlying map access.
+func (b Bindings) Get(name string) (chplan.Node, bool) {
+	if b == nil {
+		return nil, false
+	}
+	n, ok := b[name]
+	return n, ok
+}
+
+// Pattern is a value that knows how to match against a `chplan.Node`. On a
+// successful match it returns a fresh `Bindings` map; on no match it
+// returns `(nil, false)`. Patterns are immutable and safe to share across
+// rules and goroutines.
+type Pattern interface {
+	Match(n chplan.Node) (Bindings, bool)
+}
+
+// Any matches any non-nil node. Use it as a leaf wildcard inside
+// `WithChildren`, or wrap it with `Capture` to bind an arbitrary subtree
+// to a name.
+func Any() Pattern { return anyPattern{} }
+
+type anyPattern struct{}
+
+func (anyPattern) Match(n chplan.Node) (Bindings, bool) {
+	if n == nil {
+		return nil, false
+	}
+	return Bindings{}, true
+}
+
+// Kind matches a single node of the given kind, regardless of its
+// children. It does not recurse into children — use `WithChildren` for
+// shape-aware matching.
+func Kind(k NodeKind) Pattern { return kindPattern{k: k} }
+
+type kindPattern struct{ k NodeKind }
+
+func (p kindPattern) Match(n chplan.Node) (Bindings, bool) {
+	if n == nil {
+		return nil, false
+	}
+	if reflect.TypeOf(n) != p.k.t {
+		return nil, false
+	}
+	return Bindings{}, true
+}
+
+// Capture wraps p and, on a successful match, additionally binds the
+// matched node under name. The wrapped pattern's own bindings are
+// preserved; if it bound a node under the same name, this Capture
+// overrides it (the outermost Capture wins).
+func Capture(name string, p Pattern) Pattern {
+	return capturePattern{name: name, inner: p}
+}
+
+type capturePattern struct {
+	name  string
+	inner Pattern
+}
+
+func (p capturePattern) Match(n chplan.Node) (Bindings, bool) {
+	inner, ok := p.inner.Match(n)
+	if !ok {
+		return nil, false
+	}
+	if inner == nil {
+		inner = Bindings{}
+	}
+	inner[p.name] = n
+	return inner, true
+}
+
+// WithChildren matches a node whose own shape matches `parent` and whose
+// immediate children (in order, as returned by `chplan.Node.Children()`)
+// match the supplied child patterns. The number of supplied child
+// patterns must equal the candidate node's child count for a match.
+//
+// Bindings from `parent` and every child pattern are merged into a single
+// `Bindings` map. If two patterns bind the same name, the later one
+// (child patterns first to last, then parent — parent wins last because
+// it conceptually owns the node) wins. Rules that need disjoint names
+// should pick disjoint names.
+func WithChildren(parent Pattern, children ...Pattern) Pattern {
+	return withChildrenPattern{parent: parent, children: children}
+}
+
+type withChildrenPattern struct {
+	parent   Pattern
+	children []Pattern
+}
+
+func (p withChildrenPattern) Match(n chplan.Node) (Bindings, bool) {
+	if n == nil {
+		return nil, false
+	}
+	kids := n.Children()
+	if len(kids) != len(p.children) {
+		return nil, false
+	}
+	parentB, ok := p.parent.Match(n)
+	if !ok {
+		return nil, false
+	}
+	out := Bindings{}
+	for i, cp := range p.children {
+		cb, ok := cp.Match(kids[i])
+		if !ok {
+			return nil, false
+		}
+		for k, v := range cb {
+			out[k] = v
+		}
+	}
+	for k, v := range parentB {
+		out[k] = v
+	}
+	return out, true
+}

--- a/internal/optimizer/pattern_test.go
+++ b/internal/optimizer/pattern_test.go
@@ -1,0 +1,192 @@
+package optimizer_test
+
+import (
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/optimizer"
+)
+
+// Shared fixtures.
+func scan() *chplan.Scan {
+	return &chplan.Scan{Table: "otel_metrics_gauge"}
+}
+
+func filterScan() *chplan.Filter {
+	return &chplan.Filter{
+		Input: scan(),
+		Predicate: &chplan.Binary{
+			Op:    chplan.OpEq,
+			Left:  &chplan.ColumnRef{Name: "MetricName"},
+			Right: &chplan.LitString{V: "up"},
+		},
+	}
+}
+
+func TestAny_MatchesAnyNonNilNode(t *testing.T) {
+	t.Parallel()
+	p := optimizer.Any()
+
+	for _, n := range []chplan.Node{scan(), filterScan(), &chplan.Limit{Input: scan(), Count: 10}} {
+		if b, ok := p.Match(n); !ok || b == nil {
+			t.Fatalf("Any().Match(%T) = (%v, %v); want match", n, b, ok)
+		}
+	}
+}
+
+func TestAny_RejectsNil(t *testing.T) {
+	t.Parallel()
+	if _, ok := optimizer.Any().Match(nil); ok {
+		t.Fatal("Any().Match(nil) matched; want no match")
+	}
+}
+
+func TestKind_MatchesSameKind(t *testing.T) {
+	t.Parallel()
+	if _, ok := optimizer.Kind(optimizer.KindScan).Match(scan()); !ok {
+		t.Fatal("Kind(KindScan).Match(Scan) failed")
+	}
+	if _, ok := optimizer.Kind(optimizer.KindFilter).Match(filterScan()); !ok {
+		t.Fatal("Kind(KindFilter).Match(Filter) failed")
+	}
+}
+
+func TestKind_RejectsDifferentKind(t *testing.T) {
+	t.Parallel()
+	if _, ok := optimizer.Kind(optimizer.KindFilter).Match(scan()); ok {
+		t.Fatal("Kind(KindFilter).Match(Scan) matched; want no match")
+	}
+	if _, ok := optimizer.Kind(optimizer.KindScan).Match(filterScan()); ok {
+		t.Fatal("Kind(KindScan).Match(Filter) matched; want no match")
+	}
+}
+
+func TestKind_RejectsNil(t *testing.T) {
+	t.Parallel()
+	if _, ok := optimizer.Kind(optimizer.KindScan).Match(nil); ok {
+		t.Fatal("Kind(KindScan).Match(nil) matched; want no match")
+	}
+}
+
+func TestKindOf_RoundTrip(t *testing.T) {
+	t.Parallel()
+	s := scan()
+	if got := optimizer.KindOf(s); got != optimizer.KindScan {
+		t.Fatalf("KindOf(Scan) = %v; want KindScan", got)
+	}
+	f := filterScan()
+	if got := optimizer.KindOf(f); got != optimizer.KindFilter {
+		t.Fatalf("KindOf(Filter) = %v; want KindFilter", got)
+	}
+}
+
+func TestCapture_BindsMatchedNode(t *testing.T) {
+	t.Parallel()
+	s := scan()
+	p := optimizer.Capture("root", optimizer.Kind(optimizer.KindScan))
+
+	b, ok := p.Match(s)
+	if !ok {
+		t.Fatal("Capture(...Kind(KindScan)).Match(Scan) failed")
+	}
+	got, ok := b.Get("root")
+	if !ok {
+		t.Fatal("Bindings.Get(root) missing")
+	}
+	if got != chplan.Node(s) {
+		t.Fatalf("captured node = %v; want the scan itself", got)
+	}
+}
+
+func TestCapture_DoesNotBindOnMissMatch(t *testing.T) {
+	t.Parallel()
+	p := optimizer.Capture("root", optimizer.Kind(optimizer.KindFilter))
+	if b, ok := p.Match(scan()); ok {
+		t.Fatalf("Capture over miss matched: bindings=%v", b)
+	}
+}
+
+func TestWithChildren_MatchesParentAndChildrenInOrder(t *testing.T) {
+	t.Parallel()
+	f := filterScan()
+
+	p := optimizer.WithChildren(
+		optimizer.Kind(optimizer.KindFilter),
+		optimizer.Capture("input", optimizer.Kind(optimizer.KindScan)),
+	)
+
+	b, ok := p.Match(f)
+	if !ok {
+		t.Fatal("WithChildren(Filter, Scan).Match(Filter(Scan)) failed")
+	}
+	got, ok := b.Get("input")
+	if !ok || got != chplan.Node(f.Input) {
+		t.Fatalf("captured input = %v; want Filter.Input", got)
+	}
+}
+
+func TestWithChildren_RejectsWrongChildKind(t *testing.T) {
+	t.Parallel()
+	f := filterScan()
+	// Filter has a Scan child, not a Limit.
+	p := optimizer.WithChildren(
+		optimizer.Kind(optimizer.KindFilter),
+		optimizer.Kind(optimizer.KindLimit),
+	)
+	if _, ok := p.Match(f); ok {
+		t.Fatal("WithChildren(Filter, Limit).Match(Filter(Scan)) matched; want no match")
+	}
+}
+
+func TestWithChildren_RejectsArityMismatch(t *testing.T) {
+	t.Parallel()
+	// Scan has 0 children; specifying 1 child must reject.
+	p := optimizer.WithChildren(
+		optimizer.Kind(optimizer.KindScan),
+		optimizer.Any(),
+	)
+	if _, ok := p.Match(scan()); ok {
+		t.Fatal("WithChildren(Scan, Any).Match(Scan) matched; want no match (arity)")
+	}
+}
+
+func TestWithChildren_RejectsParentMiss(t *testing.T) {
+	t.Parallel()
+	p := optimizer.WithChildren(
+		optimizer.Kind(optimizer.KindLimit),
+		optimizer.Any(),
+	)
+	if _, ok := p.Match(filterScan()); ok {
+		t.Fatal("WithChildren(Limit, Any).Match(Filter(Scan)) matched; want no match")
+	}
+}
+
+func TestWithChildren_MergesBindings(t *testing.T) {
+	t.Parallel()
+	f := filterScan()
+	p := optimizer.WithChildren(
+		optimizer.Capture("parent", optimizer.Kind(optimizer.KindFilter)),
+		optimizer.Capture("child", optimizer.Any()),
+	)
+	b, ok := p.Match(f)
+	if !ok {
+		t.Fatal("WithChildren capture-parent + capture-child failed to match")
+	}
+	if got, _ := b.Get("parent"); got != chplan.Node(f) {
+		t.Fatalf("parent binding = %v; want Filter", got)
+	}
+	if got, _ := b.Get("child"); got != chplan.Node(f.Input) {
+		t.Fatalf("child binding = %v; want Scan", got)
+	}
+}
+
+func TestBindings_GetMissingReturnsFalse(t *testing.T) {
+	t.Parallel()
+	b, ok := optimizer.Any().Match(scan())
+	if !ok {
+		t.Fatal("Any().Match(Scan) failed")
+	}
+	if _, present := b.Get("never-bound"); present {
+		t.Fatal("Bindings.Get(missing) reported present")
+	}
+}

--- a/internal/optimizer/rule_pattern.go
+++ b/internal/optimizer/rule_pattern.go
@@ -1,0 +1,64 @@
+package optimizer
+
+import "github.com/tsouza/cerberus/internal/chplan"
+
+// PatternRule is a `Rule` defined declaratively as `match → transform`.
+//
+// `Match` is a `Pattern` (see pattern.go) that the driver tests against
+// every node in the plan tree. When the pattern matches, `Apply` is
+// called with the resulting `Bindings`; `Apply` returns the rewritten
+// node, or `nil` to signal "no change" (the original node is preserved
+// and the rule reports `changed=false`).
+//
+// PatternRule satisfies the existing `Rule` interface, so the existing
+// fixpoint driver (`Driver.Run`) picks it up with no modification — the
+// driver's bottom-up tree walk visits every node, and PatternRule does
+// its own per-node match. This mirrors Calcite's `RelOptRule`
+// (`onMatch`) and Spark Catalyst's `Rule[LogicalPlan]` (`apply(plan)`):
+// both engines schedule rules and let each rule decide whether the
+// candidate node is a match.
+//
+// Scope (RC3 R3.1): the type + driver wiring only. The first batch of
+// rules ported to PatternRule lands in RC3 R3.2.
+type PatternRule struct {
+	// RuleName is the rule's identifier, surfaced via `Rule.Name()` for
+	// debug logging and test fixtures.
+	RuleName string
+
+	// Match is the pattern the driver tests against each node.
+	Match Pattern
+
+	// Transform is invoked when `Match` succeeds. It returns the
+	// rewritten subtree (replacing the matched node) or `nil` to
+	// indicate "no change at this node".
+	//
+	// The supplied `Bindings` map is owned by the caller; rules must
+	// not retain it past the call.
+	//
+	// Field name (`Transform`, not `Apply`) sidesteps the name clash
+	// with the `Rule.Apply` method below — Calcite calls the analogous
+	// hook `onMatch`, Catalyst calls it `apply`; we go with `Transform`
+	// because it reads naturally next to `Match`.
+	Transform func(b Bindings) chplan.Node
+}
+
+// Name satisfies `Rule`.
+func (r *PatternRule) Name() string { return r.RuleName }
+
+// Apply satisfies `Rule`. The existing driver walks the tree bottom-up
+// and calls Apply on each node; this method therefore only needs to
+// match the single supplied node, not recurse.
+func (r *PatternRule) Apply(n chplan.Node) (chplan.Node, bool) {
+	if n == nil || r == nil || r.Match == nil || r.Transform == nil {
+		return n, false
+	}
+	b, ok := r.Match.Match(n)
+	if !ok {
+		return n, false
+	}
+	rewritten := r.Transform(b)
+	if rewritten == nil {
+		return n, false
+	}
+	return rewritten, true
+}

--- a/internal/optimizer/rule_pattern_test.go
+++ b/internal/optimizer/rule_pattern_test.go
@@ -1,0 +1,135 @@
+package optimizer_test
+
+import (
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/optimizer"
+)
+
+// TestPatternRule_IdentityNoop wires a PatternRule that matches any Filter
+// and returns nil (no change). The driver should produce a tree
+// structurally equal to the input.
+func TestPatternRule_IdentityNoop(t *testing.T) {
+	t.Parallel()
+
+	identity := &optimizer.PatternRule{
+		RuleName:  "identity-filter",
+		Match:     optimizer.Kind(optimizer.KindFilter),
+		Transform: func(_ optimizer.Bindings) chplan.Node { return nil },
+	}
+
+	input := &chplan.Filter{
+		Input: &chplan.Scan{Table: "otel_metrics_gauge"},
+		Predicate: &chplan.Binary{
+			Op:    chplan.OpEq,
+			Left:  &chplan.ColumnRef{Name: "MetricName"},
+			Right: &chplan.LitString{V: "up"},
+		},
+	}
+
+	out := optimizer.New(identity).Run(input)
+	if !out.Equal(input) {
+		t.Fatalf("identity rule mutated the plan: got %#v, want %#v", out, input)
+	}
+}
+
+// TestPatternRule_DropLimit defines a rule that matches a Limit with a
+// captured child input and replaces the Limit with its input — i.e. the
+// Limit is stripped from the tree.
+func TestPatternRule_DropLimit(t *testing.T) {
+	t.Parallel()
+
+	dropLimit := &optimizer.PatternRule{
+		RuleName: "drop-limit",
+		Match: optimizer.WithChildren(
+			optimizer.Kind(optimizer.KindLimit),
+			optimizer.Capture("input", optimizer.Any()),
+		),
+		Transform: func(b optimizer.Bindings) chplan.Node {
+			in, ok := b.Get("input")
+			if !ok {
+				return nil
+			}
+			return in
+		},
+	}
+
+	inner := &chplan.Scan{Table: "otel_metrics_gauge"}
+	input := &chplan.Limit{Input: inner, Count: 10}
+
+	out := optimizer.New(dropLimit).Run(input)
+	if !out.Equal(inner) {
+		t.Fatalf("drop-limit produced %#v, want %#v", out, inner)
+	}
+}
+
+// TestPatternRule_DropLimit_Nested confirms the rule fires inside a
+// larger tree — the existing driver walks the whole tree, so PatternRule
+// gets its per-node match at every depth.
+func TestPatternRule_DropLimit_Nested(t *testing.T) {
+	t.Parallel()
+
+	dropLimit := &optimizer.PatternRule{
+		RuleName: "drop-limit",
+		Match: optimizer.WithChildren(
+			optimizer.Kind(optimizer.KindLimit),
+			optimizer.Capture("input", optimizer.Any()),
+		),
+		Transform: func(b optimizer.Bindings) chplan.Node {
+			in, _ := b.Get("input")
+			return in
+		},
+	}
+
+	scan := &chplan.Scan{Table: "otel_metrics_gauge"}
+	input := &chplan.Filter{
+		Input: &chplan.Limit{Input: scan, Count: 10},
+		Predicate: &chplan.Binary{
+			Op:    chplan.OpEq,
+			Left:  &chplan.ColumnRef{Name: "MetricName"},
+			Right: &chplan.LitString{V: "up"},
+		},
+	}
+
+	out := optimizer.New(dropLimit).Run(input)
+
+	got, ok := out.(*chplan.Filter)
+	if !ok {
+		t.Fatalf("expected Filter at root, got %T", out)
+	}
+	if !got.Input.Equal(scan) {
+		t.Fatalf("Filter.Input = %#v, want Scan after Limit was dropped", got.Input)
+	}
+}
+
+// TestPatternRule_NilFieldsNoop guards against accidental nil-deref when
+// a malformed PatternRule (missing Match or Transform) ends up in a
+// driver — it should be a no-op rather than crash.
+func TestPatternRule_NilFieldsNoop(t *testing.T) {
+	t.Parallel()
+
+	scan := &chplan.Scan{Table: "otel_metrics_gauge"}
+
+	for _, r := range []*optimizer.PatternRule{
+		{RuleName: "no-match"},
+		{RuleName: "no-transform", Match: optimizer.Any()},
+		{RuleName: "no-match-only-transform", Transform: func(optimizer.Bindings) chplan.Node { return scan }},
+	} {
+		out, changed := r.Apply(scan)
+		if changed {
+			t.Fatalf("%s: reported change on degenerate rule", r.RuleName)
+		}
+		if out != chplan.Node(scan) {
+			t.Fatalf("%s: returned %v, want input unchanged", r.RuleName, out)
+		}
+	}
+}
+
+// TestPatternRule_ImplementsRule is a compile-time check that PatternRule
+// satisfies the existing Rule interface — i.e. the existing driver picks
+// it up with no plumbing changes.
+func TestPatternRule_ImplementsRule(t *testing.T) {
+	t.Parallel()
+	var _ optimizer.Rule = (*optimizer.PatternRule)(nil)
+}


### PR DESCRIPTION
## Summary
- New `internal/optimizer/pattern.go`: `Pattern` interface + `Kind` / `Capture` / `WithChildren` / `Any` combinators + `Bindings` type.
- New `internal/optimizer/rule_pattern.go`: `PatternRule` struct implementing the existing `Rule` interface.
- Unit tests covering combinator behavior + end-to-end PatternRule application via the existing driver.
- Existing 3 rules untouched. Their port lands in R3.2.

## Test plan
- [ ] `go test ./internal/optimizer/...` passes.
- [ ] `go vet ./internal/optimizer/...` clean.

Roadmap: docs/roadmap.md § RC3 R3.1. Calcite + Catalyst design lineage noted in `pattern.go` doc comment.