### PR TITLE
feat(harness/shadow): scaffold differential-testing harness (RC3 R3.9)

### DIFF
--- a/.github/workflows/shadow-mode.yml
+++ b/.github/workflows/shadow-mode.yml
@@ -1,0 +1,92 @@
+name: shadow-mode
+
+# RC3 R3.9 — shadow-mode differential testing harness.
+#
+# Scaffold only. The oracle (`internal/promshim/local/`) lands in R3.10, so
+# this workflow runs on manual dispatch only. Once R3.10 merges, we will:
+#   * flip the strategy default to force-native,
+#   * add `schedule:` (nightly) + `push:` (main, scoped paths) triggers,
+#   * remove `continue-on-error`.
+
+on:
+  workflow_dispatch:
+    inputs:
+      corpus:
+        description: 'Path to a corpus TXTAR file'
+        required: false
+        default: 'harness/compatibility/shadow/corpus/smoke.txt'
+      strategy:
+        description: 'Diff strategy: prefer-native | force-native | oracle-only'
+        required: false
+        default: 'prefer-native'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: shadow-mode-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  shadow:
+    name: shadow-mode
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Informational until R3.10 lands. The noop oracle marks every query
+    # "oracle skipped"; under `prefer-native` the harness still exits 0 but
+    # we keep this guard so a future strategy bump doesn't immediately fail
+    # required-checks.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just
+
+      - name: Build harness
+        run: go build -trimpath -o bin/shadow ./harness/compatibility/shadow/cmd/shadow
+
+      - name: Run shadow-mode against smoke corpus
+        env:
+          # No real cerberus is started here yet; with the noop oracle the
+          # harness will report native HTTP errors per query, which is the
+          # expected shape until R3.10 wires the in-process oracle.
+          CERBERUS_URL: ${{ vars.SHADOW_CERBERUS_URL || 'http://localhost:9090' }}
+        run: |
+          ./bin/shadow \
+            --corpus "${{ github.event.inputs.corpus }}" \
+            --strategy "${{ github.event.inputs.strategy }}" \
+            --report shadow-report.json \
+            || echo "shadow-mode exited non-zero (expected pre-R3.10)"
+
+      - name: Summarise report
+        if: always()
+        run: |
+          if [ -f shadow-report.json ]; then
+            jq '{
+              strategy: .strategy,
+              total: .total_queries,
+              diffs: .diffs,
+              native_errors: .native_errors,
+              oracle_skipped: .oracle_skipped
+            }' shadow-report.json
+          else
+            echo "no report produced"
+          fi
+
+      - name: Upload diff report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: shadow-report
+          path: shadow-report.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/Justfile
+++ b/Justfile
@@ -196,3 +196,20 @@ compatibility-keep:
 # Tear down the compatibility stack manually.
 compatibility-down:
     cd harness/compatibility && docker compose down -v
+
+# === Shadow-mode differential testing (RC3 R3.9) ===
+
+# Build + run the shadow-mode harness against a corpus.
+# Expects a running cerberus reachable at $CERBERUS_URL (default
+# http://localhost:9090). Oracle wiring is stubbed until R3.10 lands;
+# under `prefer-native` (default) the noop oracle records diffs as
+# "oracle skipped" (non-fatal). See harness/compatibility/shadow/README.md.
+shadow-mode CORPUS="harness/compatibility/shadow/corpus/smoke.txt" STRATEGY="prefer-native":
+    @echo "==> building shadow-mode harness"
+    go build -trimpath -o bin/shadow ./harness/compatibility/shadow/cmd/shadow
+    @echo "==> running shadow-mode (strategy={{STRATEGY}})"
+    ./bin/shadow \
+        --corpus {{CORPUS}} \
+        --strategy {{STRATEGY}} \
+        --cerberus-url "${CERBERUS_URL:-http://localhost:9090}" \
+        --report shadow-report.json

--- a/harness/compatibility/shadow/README.md
+++ b/harness/compatibility/shadow/README.md
@@ -24,11 +24,11 @@ that runs without containers.
 
 The CLI takes `--strategy`:
 
-| Strategy        | Behaviour                                                            | Use case                                                            |
-| --------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| `prefer-native` | Run both; return native; record diff; non-fatal on disagreement     | **Default.** CI baseline; lets you measure the gap over time.       |
-| `force-native`  | Run both; return native; **fail** on diff                            | Pre-release gate. Use when the oracle is trusted to be correct.     |
-| `oracle-only`   | Run only the oracle; native is skipped                               | Debugging the oracle; isolating semantic-vs-emitter bugs.           |
+| Strategy        | Behaviour                                                        | Use case                                                        |
+| --------------- | ---------------------------------------------------------------- | --------------------------------------------------------------- |
+| `prefer-native` | Run both; return native; record diff; non-fatal on disagreement  | **Default.** CI baseline; lets you measure the gap over time.   |
+| `force-native`  | Run both; return native; **fail** on diff                        | Pre-release gate. Use when the oracle is trusted to be correct. |
+| `oracle-only`   | Run only the oracle; native is skipped                           | Debugging the oracle; isolating semantic-vs-emitter bugs.       |
 
 ## Diff algorithm
 
@@ -46,16 +46,16 @@ the end.
 
 ## Exit codes
 
-| Code | Meaning                                                              |
-| ---- | -------------------------------------------------------------------- |
-| `0`  | All queries agree (or strategy is `prefer-native` with diffs present) |
-| `1`  | One or more diffs under `force-native` strategy                       |
-| `2`  | Setup failure (corpus unreadable, cerberus unreachable, etc.)        |
+| Code | Meaning                                                                      |
+| ---- | ---------------------------------------------------------------------------- |
+| `0`  | All queries agree (or strategy is `prefer-native` with diffs present)        |
+| `1`  | One or more diffs under `force-native` strategy                              |
+| `2`  | Setup failure (corpus unreadable, cerberus unreachable, etc.)                |
 | `3`  | Oracle unavailable when strategy requires it (`force-native`, `oracle-only`) |
 
 ## How it slots into `harness/compatibility/`
 
-```
+```text
 harness/compatibility/
   docker-compose.yml         <-- existing: reference Prom + cerberus + CH + seeder
   scripts/run-compatibility.sh
@@ -96,7 +96,7 @@ harness exits with code `2` and a clear error.
 
 TXTAR file with two sections per query:
 
-```
+```text
 -- query --
 rate(http_requests_total[5m])
 -- expected_strategy --

--- a/harness/compatibility/shadow/README.md
+++ b/harness/compatibility/shadow/README.md
@@ -1,0 +1,132 @@
+# Shadow-mode differential testing harness
+
+> RC3 R3.9 scaffold. See [`docs/roadmap.md` § RC3](../../../docs/roadmap.md#advanced-testing).
+> Oracle wiring stubbed until [R3.10](../../../docs/roadmap.md#advanced-testing)
+> lands the in-process PromQL evaluator (`internal/promshim/local/`).
+
+## What "shadow mode" means
+
+For every query in a corpus, the harness invokes **two** evaluators and diffs
+the result vectors:
+
+| Side       | What it is                                                        | When it's authoritative                      |
+| ---------- | ----------------------------------------------------------------- | -------------------------------------------- |
+| **native** | cerberus's normal pipeline (HTTP → parse → lower → optimize → CH) | Production-shaped path. Default truth.       |
+| **oracle** | In-process PromQL evaluator over an in-memory sample set          | Reference truth (Prometheus's own evaluator) |
+
+The diff catches regressions where the CH-backed path drifts from PromQL
+semantics without having to spin up a full reference Prometheus + remote-write
+seeder (which is what the sibling `harness/compatibility/` Docker Compose stack
+already does). Shadow mode is the lighter-weight, faster-feedback companion
+that runs without containers.
+
+## Strategies
+
+The CLI takes `--strategy`:
+
+| Strategy        | Behaviour                                                            | Use case                                                            |
+| --------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| `prefer-native` | Run both; return native; record diff; non-fatal on disagreement     | **Default.** CI baseline; lets you measure the gap over time.       |
+| `force-native`  | Run both; return native; **fail** on diff                            | Pre-release gate. Use when the oracle is trusted to be correct.     |
+| `oracle-only`   | Run only the oracle; native is skipped                               | Debugging the oracle; isolating semantic-vs-emitter bugs.           |
+
+## Diff algorithm
+
+`differ.Diff` compares two `VectorResult`s by:
+
+1. **Cardinality**: number of series in each side.
+2. **Label-set match**: each native series is paired with its label-equal oracle series.
+3. **Point-wise value equality** with a configurable epsilon (default `1e-9`,
+   relative for non-zero values, absolute for zero).
+4. **Timestamp alignment**: timestamps must match exactly (no resampling).
+
+Any mismatch yields a structured `Diff` record with the offending series and a
+short reason string. The CLI prints one line per query and a JSON summary at
+the end.
+
+## Exit codes
+
+| Code | Meaning                                                              |
+| ---- | -------------------------------------------------------------------- |
+| `0`  | All queries agree (or strategy is `prefer-native` with diffs present) |
+| `1`  | One or more diffs under `force-native` strategy                       |
+| `2`  | Setup failure (corpus unreadable, cerberus unreachable, etc.)        |
+| `3`  | Oracle unavailable when strategy requires it (`force-native`, `oracle-only`) |
+
+## How it slots into `harness/compatibility/`
+
+```
+harness/compatibility/
+  docker-compose.yml         <-- existing: reference Prom + cerberus + CH + seeder
+  scripts/run-compatibility.sh
+  shadow/                    <-- this directory (RC3 R3.9)
+    cmd/shadow/main.go         CLI entry point
+    differ.go                  pure diff function
+    corpus.go                  TXTAR corpus loader
+    corpus/smoke.txt           5-query smoke corpus
+```
+
+The Docker Compose stack remains the heavyweight reference; shadow mode is the
+in-process companion. They share the corpus format eventually (R3.10 follow-up)
+but ship independently.
+
+## Usage
+
+The harness expects a running cerberus reachable at `$CERBERUS_URL` (defaults
+to `http://localhost:9090`):
+
+```sh
+just shadow-mode CORPUS=harness/compatibility/shadow/corpus/smoke.txt STRATEGY=prefer-native
+```
+
+Or invoke the binary directly:
+
+```sh
+go build -o bin/shadow ./harness/compatibility/shadow/cmd/shadow
+CERBERUS_URL=http://localhost:9090 ./bin/shadow \
+    --corpus harness/compatibility/shadow/corpus/smoke.txt \
+    --strategy prefer-native \
+    --report shadow-report.json
+```
+
+If `CERBERUS_URL` is unset and the strategy requires the native side, the
+harness exits with code `2` and a clear error.
+
+## Corpus format
+
+TXTAR file with two sections per query:
+
+```
+-- query --
+rate(http_requests_total[5m])
+-- expected_strategy --
+prefer-native
+```
+
+`expected_strategy` is optional and overrides the CLI flag per-query (used to
+mark known-divergent queries that should stay `prefer-native` even when CI
+flips the global flag to `force-native`).
+
+## Oracle stub
+
+Until R3.10 lands, the binary ships with a `noopOracle` that returns
+`OracleSkipped` for every query. Under `prefer-native` this is fine — the
+native answer is returned and the diff is recorded as "oracle skipped"
+(non-fatal). Under `force-native` or `oracle-only`, the binary exits with
+code `3` to make the missing dependency loud.
+
+The wiring point is a single interface:
+
+```go
+type OracleProvider interface {
+    Evaluate(ctx context.Context, q Query) (VectorResult, error)
+}
+```
+
+R3.10 will swap `noopOracle` for `promshimlocal.New(...)`.
+
+## Status
+
+**Scaffold only.** Native evaluator wiring is a real HTTP client; oracle is
+stubbed. Workflow is `workflow_dispatch` only — it does not run on PRs or
+nightly until R3.10 unblocks the oracle.

--- a/harness/compatibility/shadow/cmd/shadow/main.go
+++ b/harness/compatibility/shadow/cmd/shadow/main.go
@@ -1,0 +1,377 @@
+// Command shadow is the RC3 R3.9 shadow-mode differential testing CLI.
+//
+// It reads a corpus of PromQL queries, evaluates each one against cerberus
+// (native path, over HTTP) and an in-process PromQL oracle, and diffs the
+// two result vectors. The oracle is stubbed until R3.10 lands
+// `internal/promshim/local/`.
+//
+// See ../../README.md for the strategy matrix, exit codes, and corpus format.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/tsouza/cerberus/harness/compatibility/shadow"
+)
+
+// Strategy selects which evaluator(s) to consult and whether disagreement is fatal.
+type Strategy string
+
+const (
+	StrategyPreferNative Strategy = "prefer-native"
+	StrategyForceNative  Strategy = "force-native"
+	StrategyOracleOnly   Strategy = "oracle-only"
+)
+
+// Exit codes (kept in sync with README).
+const (
+	exitOK              = 0
+	exitDiffForceNative = 1
+	exitSetupFailure    = 2
+	exitOracleMissing   = 3
+)
+
+// OracleProvider is the seam R3.10 fills. Until then, noopOracle returns
+// ErrOracleSkipped for every query.
+type OracleProvider interface {
+	Evaluate(ctx context.Context, expr string) (shadow.VectorResult, error)
+}
+
+// ErrOracleSkipped signals the noop oracle has been invoked. Callers handle
+// per strategy.
+var ErrOracleSkipped = errors.New("oracle: skipped (R3.10 not yet wired)")
+
+type noopOracle struct{}
+
+func (noopOracle) Evaluate(_ context.Context, _ string) (shadow.VectorResult, error) {
+	return shadow.VectorResult{}, ErrOracleSkipped
+}
+
+// QueryResult is the per-query record emitted in the report.
+type QueryResult struct {
+	Name             string      `json:"name"`
+	Expr             string      `json:"expr"`
+	Strategy         string      `json:"strategy"`
+	NativeError      string      `json:"native_error,omitempty"`
+	OracleError      string      `json:"oracle_error,omitempty"`
+	OracleSkipped    bool        `json:"oracle_skipped,omitempty"`
+	Diff             *shadow.Diff `json:"diff,omitempty"`
+	NativeSeriesLen  int         `json:"native_series_len"`
+	OracleSeriesLen  int         `json:"oracle_series_len"`
+	DurationNativeMs int64       `json:"duration_native_ms"`
+	DurationOracleMs int64       `json:"duration_oracle_ms"`
+}
+
+// Report is the JSON written to --report.
+type Report struct {
+	Strategy        string        `json:"strategy"`
+	CerberusURL     string        `json:"cerberus_url"`
+	Corpus          string        `json:"corpus"`
+	TotalQueries    int           `json:"total_queries"`
+	Diffs           int           `json:"diffs"`
+	NativeErrors    int           `json:"native_errors"`
+	OracleSkipped   int           `json:"oracle_skipped"`
+	Queries         []QueryResult `json:"queries"`
+}
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+func run(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("shadow", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	corpusPath := fs.String("corpus", "", "path to a corpus TXTAR file (required)")
+	strategyFlag := fs.String("strategy", string(StrategyPreferNative),
+		"one of: prefer-native, force-native, oracle-only")
+	cerberusURL := fs.String("cerberus-url", os.Getenv("CERBERUS_URL"),
+		"base URL of running cerberus (e.g. http://localhost:9090). Falls back to $CERBERUS_URL.")
+	reportPath := fs.String("report", "", "if set, write a JSON report to this path")
+	timeoutSec := fs.Int("timeout", 30, "per-query timeout in seconds")
+	queryTimestamp := fs.Int64("at", 0, "evaluate instant queries at this UNIX timestamp (0 = now)")
+
+	if err := fs.Parse(args); err != nil {
+		return exitSetupFailure
+	}
+
+	strategy := Strategy(*strategyFlag)
+	switch strategy {
+	case StrategyPreferNative, StrategyForceNative, StrategyOracleOnly:
+	default:
+		fmt.Fprintf(stderr, "unknown strategy %q (want prefer-native | force-native | oracle-only)\n", *strategyFlag)
+		return exitSetupFailure
+	}
+
+	if *corpusPath == "" {
+		fmt.Fprintln(stderr, "--corpus is required")
+		return exitSetupFailure
+	}
+
+	queries, err := shadow.LoadCorpus(*corpusPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "load corpus: %v\n", err)
+		return exitSetupFailure
+	}
+
+	if strategy != StrategyOracleOnly && *cerberusURL == "" {
+		fmt.Fprintln(stderr, "native path required but neither --cerberus-url nor $CERBERUS_URL set")
+		return exitSetupFailure
+	}
+
+	oracle := OracleProvider(noopOracle{})
+
+	// Under force-native / oracle-only, an unavailable oracle is fatal up front.
+	if strategy == StrategyForceNative || strategy == StrategyOracleOnly {
+		if _, isNoop := oracle.(noopOracle); isNoop {
+			fmt.Fprintf(stderr, "strategy %q requires an oracle but R3.10 has not landed; aborting\n", strategy)
+			return exitOracleMissing
+		}
+	}
+
+	at := time.Now()
+	if *queryTimestamp != 0 {
+		at = time.Unix(*queryTimestamp, 0)
+	}
+
+	report := Report{
+		Strategy:    string(strategy),
+		CerberusURL: *cerberusURL,
+		Corpus:      *corpusPath,
+	}
+
+	httpClient := &http.Client{Timeout: time.Duration(*timeoutSec) * time.Second}
+
+	for _, q := range queries {
+		qStrategy := strategy
+		if q.ExpectedStrategy != "" {
+			qStrategy = Strategy(q.ExpectedStrategy)
+		}
+
+		result := QueryResult{
+			Name:     q.Name,
+			Expr:     q.Expr,
+			Strategy: string(qStrategy),
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(*timeoutSec)*time.Second)
+
+		var nativeRes, oracleRes shadow.VectorResult
+
+		if qStrategy != StrategyOracleOnly {
+			t0 := time.Now()
+			r, err := evaluateNative(ctx, httpClient, *cerberusURL, q.Expr, at)
+			result.DurationNativeMs = time.Since(t0).Milliseconds()
+			if err != nil {
+				result.NativeError = err.Error()
+				report.NativeErrors++
+			} else {
+				nativeRes = r
+				result.NativeSeriesLen = len(r.Series)
+			}
+		}
+
+		// We always run the oracle when available, since prefer-native /
+		// force-native both need its output for the diff. The noop oracle
+		// short-circuits below.
+		t0 := time.Now()
+		or, err := oracle.Evaluate(ctx, q.Expr)
+		result.DurationOracleMs = time.Since(t0).Milliseconds()
+		switch {
+		case errors.Is(err, ErrOracleSkipped):
+			result.OracleSkipped = true
+			report.OracleSkipped++
+		case err != nil:
+			result.OracleError = err.Error()
+		default:
+			oracleRes = or
+			result.OracleSeriesLen = len(or.Series)
+		}
+
+		// Compute diff only when both sides produced something.
+		if !result.OracleSkipped && result.OracleError == "" && result.NativeError == "" && qStrategy != StrategyOracleOnly {
+			d := shadow.Compare(nativeRes, oracleRes, shadow.DefaultDiffOptions())
+			if !d.Equal {
+				result.Diff = &d
+				report.Diffs++
+			}
+		}
+
+		report.Queries = append(report.Queries, result)
+		printQueryLine(stdout, result)
+
+		cancel()
+	}
+
+	report.TotalQueries = len(report.Queries)
+
+	if *reportPath != "" {
+		if err := writeReport(*reportPath, report); err != nil {
+			fmt.Fprintf(stderr, "write report: %v\n", err)
+			return exitSetupFailure
+		}
+	}
+
+	printSummary(stdout, report)
+
+	if strategy == StrategyForceNative && report.Diffs > 0 {
+		return exitDiffForceNative
+	}
+	return exitOK
+}
+
+func printQueryLine(w io.Writer, r QueryResult) {
+	status := "OK"
+	switch {
+	case r.NativeError != "":
+		status = "NATIVE_ERR"
+	case r.OracleSkipped:
+		status = "ORACLE_SKIP"
+	case r.OracleError != "":
+		status = "ORACLE_ERR"
+	case r.Diff != nil:
+		status = "DIFF"
+	}
+	fmt.Fprintf(w, "[%-11s] %-32s  native=%dms oracle=%dms  expr=%s\n",
+		status, r.Name, r.DurationNativeMs, r.DurationOracleMs, oneline(r.Expr))
+}
+
+func printSummary(w io.Writer, r Report) {
+	fmt.Fprintln(w, "----")
+	fmt.Fprintf(w, "total=%d  diffs=%d  native_errors=%d  oracle_skipped=%d  strategy=%s\n",
+		r.TotalQueries, r.Diffs, r.NativeErrors, r.OracleSkipped, r.Strategy)
+}
+
+func oneline(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '\n' || c == '\r' || c == '\t' {
+			out = append(out, ' ')
+			continue
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+func writeReport(path string, r Report) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "  ")
+	return enc.Encode(r)
+}
+
+// evaluateNative calls cerberus's Prometheus-compatible /api/v1/query endpoint
+// and decodes the result into the shadow VectorResult shape. It deliberately
+// avoids importing prometheus/common/model to keep the harness's dependency
+// surface minimal.
+func evaluateNative(ctx context.Context, c *http.Client, base, expr string, at time.Time) (shadow.VectorResult, error) {
+	u, err := url.Parse(base)
+	if err != nil {
+		return shadow.VectorResult{}, fmt.Errorf("parse cerberus URL: %w", err)
+	}
+	u.Path = "/api/v1/query"
+	q := u.Query()
+	q.Set("query", expr)
+	q.Set("time", strconv.FormatInt(at.Unix(), 10))
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return shadow.VectorResult{}, err
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return shadow.VectorResult{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return shadow.VectorResult{}, fmt.Errorf("native HTTP %d: %s", resp.StatusCode, body)
+	}
+
+	var raw struct {
+		Status string `json:"status"`
+		Data   struct {
+			ResultType string            `json:"resultType"`
+			Result     []json.RawMessage `json:"result"`
+		} `json:"data"`
+		ErrorType string `json:"errorType"`
+		Error     string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return shadow.VectorResult{}, fmt.Errorf("decode native response: %w", err)
+	}
+	if raw.Status != "success" {
+		return shadow.VectorResult{}, fmt.Errorf("native query failed: %s: %s", raw.ErrorType, raw.Error)
+	}
+	return parsePromVector(raw.Data.ResultType, raw.Data.Result)
+}
+
+// parsePromVector handles the two response shapes shadow-mode cares about:
+// "vector" (instant) and "matrix" (range). Each result entry has a "metric"
+// label map plus either "value" [ts, "v"] or "values" [[ts, "v"], ...].
+func parsePromVector(resultType string, results []json.RawMessage) (shadow.VectorResult, error) {
+	out := shadow.VectorResult{Series: make([]shadow.Series, 0, len(results))}
+	for i, raw := range results {
+		var entry struct {
+			Metric map[string]string `json:"metric"`
+			Value  [2]json.RawMessage `json:"value"`
+			Values [][2]json.RawMessage `json:"values"`
+		}
+		if err := json.Unmarshal(raw, &entry); err != nil {
+			return shadow.VectorResult{}, fmt.Errorf("decode series %d: %w", i, err)
+		}
+		series := shadow.Series{Labels: entry.Metric}
+		switch resultType {
+		case "vector":
+			s, err := decodeSample(entry.Value)
+			if err != nil {
+				return shadow.VectorResult{}, fmt.Errorf("series %d sample: %w", i, err)
+			}
+			series.Samples = []shadow.Sample{s}
+		case "matrix":
+			for j, v := range entry.Values {
+				s, err := decodeSample(v)
+				if err != nil {
+					return shadow.VectorResult{}, fmt.Errorf("series %d sample %d: %w", i, j, err)
+				}
+				series.Samples = append(series.Samples, s)
+			}
+		default:
+			return shadow.VectorResult{}, fmt.Errorf("unsupported resultType %q", resultType)
+		}
+		out.Series = append(out.Series, series)
+	}
+	return out, nil
+}
+
+func decodeSample(raw [2]json.RawMessage) (shadow.Sample, error) {
+	var tsFloat float64
+	if err := json.Unmarshal(raw[0], &tsFloat); err != nil {
+		return shadow.Sample{}, fmt.Errorf("timestamp: %w", err)
+	}
+	var valStr string
+	if err := json.Unmarshal(raw[1], &valStr); err != nil {
+		return shadow.Sample{}, fmt.Errorf("value: %w", err)
+	}
+	v, err := strconv.ParseFloat(valStr, 64)
+	if err != nil {
+		return shadow.Sample{}, fmt.Errorf("parse value %q: %w", valStr, err)
+	}
+	return shadow.Sample{TimestampMs: int64(tsFloat * 1000), Value: v}, nil
+}

--- a/harness/compatibility/shadow/cmd/shadow/main.go
+++ b/harness/compatibility/shadow/cmd/shadow/main.go
@@ -59,29 +59,29 @@ func (noopOracle) Evaluate(_ context.Context, _ string) (shadow.VectorResult, er
 
 // QueryResult is the per-query record emitted in the report.
 type QueryResult struct {
-	Name             string      `json:"name"`
-	Expr             string      `json:"expr"`
-	Strategy         string      `json:"strategy"`
-	NativeError      string      `json:"native_error,omitempty"`
-	OracleError      string      `json:"oracle_error,omitempty"`
-	OracleSkipped    bool        `json:"oracle_skipped,omitempty"`
+	Name             string       `json:"name"`
+	Expr             string       `json:"expr"`
+	Strategy         string       `json:"strategy"`
+	NativeError      string       `json:"native_error,omitempty"`
+	OracleError      string       `json:"oracle_error,omitempty"`
+	OracleSkipped    bool         `json:"oracle_skipped,omitempty"`
 	Diff             *shadow.Diff `json:"diff,omitempty"`
-	NativeSeriesLen  int         `json:"native_series_len"`
-	OracleSeriesLen  int         `json:"oracle_series_len"`
-	DurationNativeMs int64       `json:"duration_native_ms"`
-	DurationOracleMs int64       `json:"duration_oracle_ms"`
+	NativeSeriesLen  int          `json:"native_series_len"`
+	OracleSeriesLen  int          `json:"oracle_series_len"`
+	DurationNativeMs int64        `json:"duration_native_ms"`
+	DurationOracleMs int64        `json:"duration_oracle_ms"`
 }
 
 // Report is the JSON written to --report.
 type Report struct {
-	Strategy        string        `json:"strategy"`
-	CerberusURL     string        `json:"cerberus_url"`
-	Corpus          string        `json:"corpus"`
-	TotalQueries    int           `json:"total_queries"`
-	Diffs           int           `json:"diffs"`
-	NativeErrors    int           `json:"native_errors"`
-	OracleSkipped   int           `json:"oracle_skipped"`
-	Queries         []QueryResult `json:"queries"`
+	Strategy      string        `json:"strategy"`
+	CerberusURL   string        `json:"cerberus_url"`
+	Corpus        string        `json:"corpus"`
+	TotalQueries  int           `json:"total_queries"`
+	Diffs         int           `json:"diffs"`
+	NativeErrors  int           `json:"native_errors"`
+	OracleSkipped int           `json:"oracle_skipped"`
+	Queries       []QueryResult `json:"queries"`
 }
 
 func main() {
@@ -265,11 +265,11 @@ func oneline(s string) string {
 }
 
 func writeReport(path string, r Report) error {
-	f, err := os.Create(path)
+	f, err := os.Create(path) //nolint:gosec // G304: report path is a trusted CLI argument
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	enc := json.NewEncoder(f)
 	enc.SetIndent("", "  ")
 	return enc.Encode(r)
@@ -290,15 +290,15 @@ func evaluateNative(ctx context.Context, c *http.Client, base, expr string, at t
 	q.Set("time", strconv.FormatInt(at.Unix(), 10))
 	u.RawQuery = q.Encode()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil) //nolint:gosec // G704: cerberus URL is a trusted CLI argument (--cerberus-url)
 	if err != nil {
 		return shadow.VectorResult{}, err
 	}
-	resp, err := c.Do(req)
+	resp, err := c.Do(req) //nolint:gosec // G704: see above
 	if err != nil {
 		return shadow.VectorResult{}, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode/100 != 2 {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		return shadow.VectorResult{}, fmt.Errorf("native HTTP %d: %s", resp.StatusCode, body)
@@ -329,8 +329,8 @@ func parsePromVector(resultType string, results []json.RawMessage) (shadow.Vecto
 	out := shadow.VectorResult{Series: make([]shadow.Series, 0, len(results))}
 	for i, raw := range results {
 		var entry struct {
-			Metric map[string]string `json:"metric"`
-			Value  [2]json.RawMessage `json:"value"`
+			Metric map[string]string    `json:"metric"`
+			Value  [2]json.RawMessage   `json:"value"`
 			Values [][2]json.RawMessage `json:"values"`
 		}
 		if err := json.Unmarshal(raw, &entry); err != nil {

--- a/harness/compatibility/shadow/corpus.go
+++ b/harness/compatibility/shadow/corpus.go
@@ -1,0 +1,142 @@
+package shadow
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// Query is a single corpus entry.
+type Query struct {
+	// Name is a short identifier for reporting (file:line or explicit `-- name --`).
+	Name string
+	// Expr is the PromQL expression to evaluate.
+	Expr string
+	// ExpectedStrategy optionally overrides the CLI-level strategy for this query.
+	// Empty string means "use the CLI strategy".
+	ExpectedStrategy string
+}
+
+// LoadCorpus reads a corpus file. Format is a lightweight TXTAR variant:
+//
+//	-- query --
+//	rate(http_requests_total[5m])
+//	-- expected_strategy --
+//	prefer-native
+//	-- query --
+//	up
+//
+// Lines starting with `#` outside section bodies are comments and ignored.
+// Blank lines between sections are ignored. The first `-- query --` marker
+// starts the first entry.
+func LoadCorpus(path string) ([]Query, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open corpus %q: %w", path, err)
+	}
+	defer f.Close()
+	return parseCorpus(f, path)
+}
+
+func parseCorpus(r io.Reader, source string) ([]Query, error) {
+	const (
+		secQuery    = "query"
+		secStrategy = "expected_strategy"
+	)
+
+	var (
+		out      []Query
+		current  Query
+		section  string
+		buf      strings.Builder
+		haveOpen bool
+		lineNum  int
+	)
+
+	flushSection := func() {
+		body := strings.TrimSpace(buf.String())
+		buf.Reset()
+		switch section {
+		case secQuery:
+			current.Expr = body
+		case secStrategy:
+			current.ExpectedStrategy = body
+		}
+	}
+
+	flushQuery := func() {
+		if !haveOpen {
+			return
+		}
+		if current.Name == "" {
+			current.Name = fmt.Sprintf("%s:q%d", source, len(out)+1)
+		}
+		out = append(out, current)
+		current = Query{}
+		haveOpen = false
+	}
+
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		lineNum++
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+
+		if strings.HasPrefix(trimmed, "-- ") && strings.HasSuffix(trimmed, " --") {
+			name := strings.TrimSpace(trimmed[3 : len(trimmed)-3])
+			// First header inside a query closes the previous section.
+			if haveOpen {
+				flushSection()
+			}
+			switch name {
+			case secQuery:
+				// New query starts.
+				flushQuery()
+				haveOpen = true
+				section = secQuery
+			case secStrategy:
+				if !haveOpen {
+					return nil, fmt.Errorf("%s:%d: expected_strategy outside a query block", source, lineNum)
+				}
+				section = secStrategy
+			default:
+				return nil, fmt.Errorf("%s:%d: unknown section %q", source, lineNum, name)
+			}
+			continue
+		}
+
+		if !haveOpen {
+			// Skip leading comments / blank lines until the first `-- query --`.
+			if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+				continue
+			}
+			return nil, fmt.Errorf("%s:%d: content before first '-- query --' header", source, lineNum)
+		}
+
+		buf.WriteString(line)
+		buf.WriteByte('\n')
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read corpus %q: %w", source, err)
+	}
+
+	// Final flushes.
+	if haveOpen {
+		flushSection()
+		flushQuery()
+	}
+
+	if len(out) == 0 {
+		return nil, fmt.Errorf("%s: corpus is empty", source)
+	}
+	for i, q := range out {
+		if q.Expr == "" {
+			return nil, fmt.Errorf("%s: query #%d has empty expression", source, i+1)
+		}
+	}
+
+	return out, nil
+}

--- a/harness/compatibility/shadow/corpus.go
+++ b/harness/compatibility/shadow/corpus.go
@@ -32,11 +32,11 @@ type Query struct {
 // Blank lines between sections are ignored. The first `-- query --` marker
 // starts the first entry.
 func LoadCorpus(path string) ([]Query, error) {
-	f, err := os.Open(path)
+	f, err := os.Open(path) //nolint:gosec // G304: corpus path is a trusted CLI argument
 	if err != nil {
 		return nil, fmt.Errorf("open corpus %q: %w", path, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	return parseCorpus(f, path)
 }
 

--- a/harness/compatibility/shadow/corpus/smoke.txt
+++ b/harness/compatibility/shadow/corpus/smoke.txt
@@ -1,0 +1,26 @@
+# Shadow-mode smoke corpus.
+# These are deliberately simple PromQL expressions that exercise the three
+# main shapes the diff cares about: instant vectors, range vectors with rate,
+# and grouped aggregations. R3.10's oracle will validate semantics; R3.9 just
+# proves the harness end-to-end.
+
+-- query --
+up
+
+-- query --
+rate(http_requests_total[5m])
+
+-- query --
+sum by (job) (rate(http_requests_total[5m]))
+
+-- query --
+sum by (job, instance) (up)
+
+-- query --
+avg_over_time(node_load1[10m])
+
+-- query --
+histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket[5m])))
+
+-- query --
+count by (job) (up == 1)

--- a/harness/compatibility/shadow/corpus_test.go
+++ b/harness/compatibility/shadow/corpus_test.go
@@ -1,0 +1,53 @@
+package shadow
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseCorpus_Basic(t *testing.T) {
+	t.Parallel()
+	in := `# smoke
+-- query --
+up
+-- query --
+rate(http_requests_total[5m])
+-- expected_strategy --
+prefer-native
+`
+	got, err := parseCorpus(strings.NewReader(in), "test")
+	if err != nil {
+		t.Fatalf("parseCorpus: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 queries, got %d", len(got))
+	}
+	if got[0].Expr != "up" {
+		t.Fatalf("q0 expr = %q, want %q", got[0].Expr, "up")
+	}
+	if got[1].ExpectedStrategy != "prefer-native" {
+		t.Fatalf("q1 strategy = %q, want %q", got[1].ExpectedStrategy, "prefer-native")
+	}
+}
+
+func TestParseCorpus_EmptyFails(t *testing.T) {
+	t.Parallel()
+	if _, err := parseCorpus(strings.NewReader("# only comments\n"), "test"); err == nil {
+		t.Fatal("expected error on empty corpus")
+	}
+}
+
+func TestParseCorpus_ContentBeforeHeaderFails(t *testing.T) {
+	t.Parallel()
+	if _, err := parseCorpus(strings.NewReader("up\n-- query --\nup\n"), "test"); err == nil {
+		t.Fatal("expected error on content before first header")
+	}
+}
+
+func TestParseCorpus_UnknownSectionFails(t *testing.T) {
+	t.Parallel()
+	in := "-- query --\nup\n-- bogus --\nx\n"
+	if _, err := parseCorpus(strings.NewReader(in), "test"); err == nil {
+		t.Fatal("expected error on unknown section")
+	}
+}

--- a/harness/compatibility/shadow/differ.go
+++ b/harness/compatibility/shadow/differ.go
@@ -1,0 +1,190 @@
+// Package shadow implements the RC3 R3.9 shadow-mode differential testing
+// harness.
+//
+// The harness runs each query through cerberus (native path) and an in-process
+// PromQL oracle, then diffs the two result vectors. See ./README.md for the
+// strategy matrix and ./cmd/shadow for the CLI entry point.
+package shadow
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+)
+
+// Sample is a single (timestamp, value) pair within a series.
+type Sample struct {
+	TimestampMs int64
+	Value       float64
+}
+
+// Series is one labelled time-series within a vector result.
+type Series struct {
+	// Labels is the label set keyed by name. Both sides MUST agree byte-for-byte
+	// after normalisation for the series to be considered a match.
+	Labels map[string]string
+	// Samples is sorted ascending by timestamp.
+	Samples []Sample
+}
+
+// VectorResult is the shape we diff. It mirrors a Prometheus
+// matrix/range-vector response after JSON decoding but kept independent of the
+// upstream types so the harness does not pull in `prometheus/common/model`.
+type VectorResult struct {
+	Series []Series
+}
+
+// DiffOptions controls the comparison.
+type DiffOptions struct {
+	// AbsEpsilon is the absolute tolerance for values near zero.
+	AbsEpsilon float64
+	// RelEpsilon is the relative tolerance for non-zero values.
+	RelEpsilon float64
+}
+
+// DefaultDiffOptions returns the standard tolerances.
+func DefaultDiffOptions() DiffOptions {
+	return DiffOptions{
+		AbsEpsilon: 1e-9,
+		RelEpsilon: 1e-9,
+	}
+}
+
+// Diff is the structured outcome of comparing two VectorResults.
+type Diff struct {
+	// Equal is true iff the two results match within tolerances.
+	Equal bool
+	// Reasons lists every mismatch in deterministic order.
+	Reasons []string
+	// ExtraInA  / ExtraInB list series present on one side but not the other.
+	ExtraInA []string
+	ExtraInB []string
+}
+
+// Compare diffs two VectorResults under the given options. Pure function;
+// safe for parallel use. Named Compare (not Diff) so it does not collide with
+// the Diff result type.
+func Compare(a, b VectorResult, opts DiffOptions) Diff {
+	out := Diff{Equal: true}
+
+	if opts.AbsEpsilon == 0 && opts.RelEpsilon == 0 {
+		opts = DefaultDiffOptions()
+	}
+
+	if len(a.Series) != len(b.Series) {
+		out.Equal = false
+		out.Reasons = append(out.Reasons,
+			fmt.Sprintf("cardinality: a=%d series, b=%d series", len(a.Series), len(b.Series)))
+	}
+
+	aByKey := indexByLabels(a.Series)
+	bByKey := indexByLabels(b.Series)
+
+	for key := range aByKey {
+		if _, ok := bByKey[key]; !ok {
+			out.Equal = false
+			out.ExtraInA = append(out.ExtraInA, key)
+		}
+	}
+	for key := range bByKey {
+		if _, ok := aByKey[key]; !ok {
+			out.Equal = false
+			out.ExtraInB = append(out.ExtraInB, key)
+		}
+	}
+	sort.Strings(out.ExtraInA)
+	sort.Strings(out.ExtraInB)
+
+	// Compare the intersection series by series.
+	matched := make([]string, 0, len(aByKey))
+	for key := range aByKey {
+		if _, ok := bByKey[key]; ok {
+			matched = append(matched, key)
+		}
+	}
+	sort.Strings(matched)
+
+	for _, key := range matched {
+		as := aByKey[key]
+		bs := bByKey[key]
+		if reasons := compareSamples(key, as.Samples, bs.Samples, opts); len(reasons) > 0 {
+			out.Equal = false
+			out.Reasons = append(out.Reasons, reasons...)
+		}
+	}
+
+	return out
+}
+
+func indexByLabels(series []Series) map[string]Series {
+	out := make(map[string]Series, len(series))
+	for _, s := range series {
+		out[labelKey(s.Labels)] = s
+	}
+	return out
+}
+
+// labelKey produces a stable string key from a label set.
+func labelKey(labels map[string]string) string {
+	if len(labels) == 0 {
+		return "{}"
+	}
+	keys := make([]string, 0, len(labels))
+	for k := range labels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	b.WriteByte('{')
+	for i, k := range keys {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(k)
+		b.WriteString("=\"")
+		b.WriteString(labels[k])
+		b.WriteByte('"')
+	}
+	b.WriteByte('}')
+	return b.String()
+}
+
+func compareSamples(key string, a, b []Sample, opts DiffOptions) []string {
+	var reasons []string
+	if len(a) != len(b) {
+		reasons = append(reasons,
+			fmt.Sprintf("series %s: sample count a=%d b=%d", key, len(a), len(b)))
+		return reasons
+	}
+	for i := range a {
+		if a[i].TimestampMs != b[i].TimestampMs {
+			reasons = append(reasons,
+				fmt.Sprintf("series %s: timestamp[%d] a=%d b=%d",
+					key, i, a[i].TimestampMs, b[i].TimestampMs))
+			continue
+		}
+		if !valuesClose(a[i].Value, b[i].Value, opts) {
+			reasons = append(reasons,
+				fmt.Sprintf("series %s: value[%d] @ ts=%d a=%g b=%g (delta=%g)",
+					key, i, a[i].TimestampMs, a[i].Value, b[i].Value,
+					math.Abs(a[i].Value-b[i].Value)))
+		}
+	}
+	return reasons
+}
+
+func valuesClose(a, b float64, opts DiffOptions) bool {
+	if math.IsNaN(a) && math.IsNaN(b) {
+		return true
+	}
+	if math.IsInf(a, 0) || math.IsInf(b, 0) {
+		return a == b
+	}
+	delta := math.Abs(a - b)
+	if delta <= opts.AbsEpsilon {
+		return true
+	}
+	scale := math.Max(math.Abs(a), math.Abs(b))
+	return delta <= opts.RelEpsilon*scale
+}

--- a/harness/compatibility/shadow/differ_test.go
+++ b/harness/compatibility/shadow/differ_test.go
@@ -1,0 +1,142 @@
+package shadow
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+func TestDiff_Identical(t *testing.T) {
+	t.Parallel()
+	a := VectorResult{Series: []Series{
+		{
+			Labels:  map[string]string{"__name__": "up", "job": "api"},
+			Samples: []Sample{{TimestampMs: 1000, Value: 1.0}, {TimestampMs: 2000, Value: 1.0}},
+		},
+	}}
+	b := a // identical contents are diff-equal
+
+	d := Compare(a, b, DefaultDiffOptions())
+	if !d.Equal {
+		t.Fatalf("expected Equal=true, got %+v", d)
+	}
+	if len(d.Reasons)+len(d.ExtraInA)+len(d.ExtraInB) != 0 {
+		t.Fatalf("expected no diffs, got %+v", d)
+	}
+}
+
+func TestDiff_MissingSeries(t *testing.T) {
+	t.Parallel()
+	a := VectorResult{Series: []Series{
+		{Labels: map[string]string{"job": "api"}, Samples: []Sample{{TimestampMs: 1000, Value: 1}}},
+		{Labels: map[string]string{"job": "web"}, Samples: []Sample{{TimestampMs: 1000, Value: 1}}},
+	}}
+	b := VectorResult{Series: []Series{
+		{Labels: map[string]string{"job": "api"}, Samples: []Sample{{TimestampMs: 1000, Value: 1}}},
+	}}
+
+	d := Compare(a, b, DefaultDiffOptions())
+	if d.Equal {
+		t.Fatalf("expected Equal=false, got Equal=true")
+	}
+	if len(d.ExtraInA) != 1 || !strings.Contains(d.ExtraInA[0], "web") {
+		t.Fatalf("expected ExtraInA to contain 'web' series, got %+v", d.ExtraInA)
+	}
+	if len(d.ExtraInB) != 0 {
+		t.Fatalf("expected ExtraInB empty, got %+v", d.ExtraInB)
+	}
+}
+
+func TestDiff_ValueDrift(t *testing.T) {
+	t.Parallel()
+	a := VectorResult{Series: []Series{
+		{Labels: map[string]string{"job": "api"}, Samples: []Sample{{TimestampMs: 1000, Value: 1.0}}},
+	}}
+	b := VectorResult{Series: []Series{
+		{Labels: map[string]string{"job": "api"}, Samples: []Sample{{TimestampMs: 1000, Value: 1.5}}},
+	}}
+
+	d := Compare(a, b, DefaultDiffOptions())
+	if d.Equal {
+		t.Fatalf("expected Equal=false, got Equal=true")
+	}
+	if len(d.Reasons) == 0 || !strings.Contains(d.Reasons[0], "value[0]") {
+		t.Fatalf("expected value-drift reason, got %+v", d.Reasons)
+	}
+}
+
+func TestDiff_LabelSetDifference(t *testing.T) {
+	t.Parallel()
+	a := VectorResult{Series: []Series{
+		{Labels: map[string]string{"job": "api"}, Samples: []Sample{{TimestampMs: 1000, Value: 1.0}}},
+	}}
+	b := VectorResult{Series: []Series{
+		{Labels: map[string]string{"job": "api", "env": "prod"}, Samples: []Sample{{TimestampMs: 1000, Value: 1.0}}},
+	}}
+
+	d := Compare(a, b, DefaultDiffOptions())
+	if d.Equal {
+		t.Fatalf("expected Equal=false on different label sets")
+	}
+	if len(d.ExtraInA) != 1 || len(d.ExtraInB) != 1 {
+		t.Fatalf("expected one extra on each side, got A=%v B=%v", d.ExtraInA, d.ExtraInB)
+	}
+}
+
+func TestDiff_EpsilonTolerance(t *testing.T) {
+	t.Parallel()
+	a := VectorResult{Series: []Series{
+		{Labels: map[string]string{"job": "api"}, Samples: []Sample{{TimestampMs: 1000, Value: 1.0}}},
+	}}
+	b := VectorResult{Series: []Series{
+		{Labels: map[string]string{"job": "api"}, Samples: []Sample{{TimestampMs: 1000, Value: 1.0 + 1e-12}}},
+	}}
+
+	d := Compare(a, b, DefaultDiffOptions())
+	if !d.Equal {
+		t.Fatalf("expected Equal=true within default epsilon, got %+v", d)
+	}
+}
+
+func TestDiff_SampleCountMismatch(t *testing.T) {
+	t.Parallel()
+	a := VectorResult{Series: []Series{
+		{Labels: map[string]string{"job": "api"}, Samples: []Sample{
+			{TimestampMs: 1000, Value: 1}, {TimestampMs: 2000, Value: 2},
+		}},
+	}}
+	b := VectorResult{Series: []Series{
+		{Labels: map[string]string{"job": "api"}, Samples: []Sample{{TimestampMs: 1000, Value: 1}}},
+	}}
+
+	d := Compare(a, b, DefaultDiffOptions())
+	if d.Equal {
+		t.Fatalf("expected Equal=false")
+	}
+	found := false
+	for _, r := range d.Reasons {
+		if strings.Contains(r, "sample count") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected 'sample count' reason, got %+v", d.Reasons)
+	}
+}
+
+func TestDiff_NaNEquality(t *testing.T) {
+	t.Parallel()
+	nan := math.NaN()
+	a := VectorResult{Series: []Series{
+		{Labels: map[string]string{"job": "api"}, Samples: []Sample{{TimestampMs: 1000, Value: nan}}},
+	}}
+	b := VectorResult{Series: []Series{
+		{Labels: map[string]string{"job": "api"}, Samples: []Sample{{TimestampMs: 1000, Value: nan}}},
+	}}
+
+	d := Compare(a, b, DefaultDiffOptions())
+	if !d.Equal {
+		t.Fatalf("expected NaN == NaN under shadow-mode diff, got %+v", d)
+	}
+}


### PR DESCRIPTION
## Summary
- New `harness/compatibility/shadow/` subtree: differ + corpus loader + CLI scaffold.
- `.github/workflows/shadow-mode.yml` (manual dispatch only — full activation gated on R3.10 oracle landing).
- Justfile: `shadow-mode` recipe.
- Scope: scaffold + smoke corpus. Oracle wiring stubbed; R3.10 fills it.

## Test plan
- [ ] `go test ./harness/compatibility/shadow/...` passes.
- [ ] `just shadow-mode CORPUS=harness/compatibility/shadow/corpus/smoke.txt` builds and runs against a running cerberus (or fails gracefully if `CERBERUS_URL` unset).

Roadmap: docs/roadmap.md § RC3 R3.9. Oracle: R3.10.