### PR TITLE
feat(chsql): port emitScan/Filter/Project/Limit to Builder (RC6 R6.2)

### DIFF
--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -1,9 +1,12 @@
 package chsql
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
 )
 
 // Builder accumulates a parameterised ClickHouse SQL fragment plus the
@@ -210,6 +213,179 @@ func (b *Builder) ParamAgg(name string, params, args []func(b *Builder)) {
 		a(b)
 	}
 	b.sb.WriteByte(')')
+}
+
+// Expr renders a chplan.Expr through the Builder using the public
+// Builder helpers (Ident / Arg / etc.). It mirrors the legacy
+// emitter.emitExpr in emit_expr.go; RC6 R6.2 introduces this method so
+// the ported emitFilter / emitProject can emit predicates and
+// projection expressions without reaching into the private emitter.
+//
+// The legacy emitter.emitExpr is intentionally retained — it is the
+// canonical implementation until RC6 R6.4 ports the expression tree.
+// Both paths produce byte-identical SQL for every fixture; once the
+// rest of the emitter migrates, emitExpr collapses into this method.
+func (b *Builder) Expr(x chplan.Expr) error {
+	switch v := x.(type) {
+	case *chplan.ColumnRef:
+		if v.Qualifier != "" {
+			b.QualIdent(v.Qualifier, v.Name)
+			return nil
+		}
+		b.Ident(v.Name)
+		return nil
+	case *chplan.LitString:
+		b.Arg(v.V)
+		return nil
+	case *chplan.LitInt:
+		b.Arg(v.V)
+		return nil
+	case *chplan.LitFloat:
+		b.Arg(v.V)
+		return nil
+	case *chplan.LitBool:
+		b.Arg(v.V)
+		return nil
+	case *chplan.Binary:
+		return b.exprBinary(v)
+	case *chplan.FuncCall:
+		return b.exprFunc(v)
+	case *chplan.MapAccess:
+		return b.exprMapAccess(v)
+	case *chplan.MapWithoutKeys:
+		return b.exprMapWithoutKeys(v)
+	case *chplan.LineContent:
+		return b.exprLineContent(v)
+	case *chplan.FieldAccess:
+		return b.exprFieldAccess(v)
+	default:
+		return fmt.Errorf("%w: expr %T", ErrUnsupported, x)
+	}
+}
+
+func (b *Builder) exprBinary(bx *chplan.Binary) error {
+	switch bx.Op {
+	case chplan.OpMatch, chplan.OpNotMatch:
+		if bx.Op == chplan.OpNotMatch {
+			b.sb.WriteString("NOT ")
+		}
+		b.sb.WriteString("match(")
+		if err := b.Expr(bx.Left); err != nil {
+			return err
+		}
+		b.sb.WriteString(", ")
+		if err := b.Expr(bx.Right); err != nil {
+			return err
+		}
+		b.sb.WriteByte(')')
+		return nil
+	case chplan.OpPow:
+		b.sb.WriteString("pow(")
+		if err := b.Expr(bx.Left); err != nil {
+			return err
+		}
+		b.sb.WriteString(", ")
+		if err := b.Expr(bx.Right); err != nil {
+			return err
+		}
+		b.sb.WriteByte(')')
+		return nil
+	}
+	b.sb.WriteByte('(')
+	if err := b.Expr(bx.Left); err != nil {
+		return err
+	}
+	b.sb.WriteByte(' ')
+	b.sb.WriteString(string(bx.Op))
+	b.sb.WriteByte(' ')
+	if err := b.Expr(bx.Right); err != nil {
+		return err
+	}
+	b.sb.WriteByte(')')
+	return nil
+}
+
+func (b *Builder) exprFunc(f *chplan.FuncCall) error {
+	b.sb.WriteString(f.Name)
+	b.sb.WriteByte('(')
+	for i, a := range f.Args {
+		if i > 0 {
+			b.sb.WriteString(", ")
+		}
+		if err := b.Expr(a); err != nil {
+			return err
+		}
+	}
+	b.sb.WriteByte(')')
+	return nil
+}
+
+func (b *Builder) exprMapAccess(m *chplan.MapAccess) error {
+	if err := b.Expr(m.Map); err != nil {
+		return err
+	}
+	b.sb.WriteByte('[')
+	if err := b.Expr(m.Key); err != nil {
+		return err
+	}
+	b.sb.WriteByte(']')
+	return nil
+}
+
+func (b *Builder) exprMapWithoutKeys(m *chplan.MapWithoutKeys) error {
+	b.sb.WriteString("mapFilter((k, v) -> NOT (k IN (")
+	for i, k := range m.Keys {
+		if i > 0 {
+			b.sb.WriteString(", ")
+		}
+		b.Arg(k)
+	}
+	b.sb.WriteString(")), ")
+	if err := b.Expr(m.Map); err != nil {
+		return err
+	}
+	b.sb.WriteByte(')')
+	return nil
+}
+
+func (b *Builder) exprLineContent(l *chplan.LineContent) error {
+	if l.IsRegex {
+		if l.Negated {
+			b.sb.WriteString("NOT ")
+		}
+		b.sb.WriteString("match(")
+		if err := b.Expr(l.Source); err != nil {
+			return err
+		}
+		b.sb.WriteString(", ")
+		b.Arg(l.Pattern)
+		b.sb.WriteByte(')')
+		return nil
+	}
+	op := " > 0"
+	if l.Negated {
+		op = " = 0"
+	}
+	b.sb.WriteString("(position(")
+	if err := b.Expr(l.Source); err != nil {
+		return err
+	}
+	b.sb.WriteString(", ")
+	b.Arg(l.Pattern)
+	b.sb.WriteByte(')')
+	b.sb.WriteString(op)
+	b.sb.WriteByte(')')
+	return nil
+}
+
+func (b *Builder) exprFieldAccess(f *chplan.FieldAccess) error {
+	if err := b.Expr(f.Source); err != nil {
+		return err
+	}
+	b.sb.WriteByte('[')
+	b.Arg(f.Path)
+	b.sb.WriteByte(']')
+	return nil
 }
 
 // Frag is the unit of composition: anything that knows how to write

--- a/internal/chsql/builder_test.go
+++ b/internal/chsql/builder_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/tsouza/cerberus/internal/chplan"
 	"github.com/tsouza/cerberus/internal/chsql"
 )
 
@@ -478,5 +479,73 @@ func TestSelectBuilder_NestedSubquery(t *testing.T) {
 	// `?` order: MapAt key, inner WHERE rhs, outer WHERE rhs.
 	if want := []any{"service.name", "api", 0.5}; !reflect.DeepEqual(args, want) {
 		t.Errorf("Args = %v; want %v", args, want)
+	}
+}
+
+// TestBuilder_Expr — Builder.Expr renders representative chplan
+// expression shapes with byte-identical output to the legacy
+// emitter.emitExpr. Locked here so the RC6 R6.2 port can't drift from
+// the canonical shape before R6.4 collapses both paths.
+func TestBuilder_Expr(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		expr    chplan.Expr
+		wantSQL string
+		wantArg []any
+	}{
+		{
+			name:    "column_ref",
+			expr:    &chplan.ColumnRef{Name: "MetricName"},
+			wantSQL: "`MetricName`",
+		},
+		{
+			name:    "column_ref_qualified",
+			expr:    &chplan.ColumnRef{Qualifier: "L", Name: "Value"},
+			wantSQL: "`L`.`Value`",
+		},
+		{
+			name:    "lit_string",
+			expr:    &chplan.LitString{V: "http_requests_total"},
+			wantSQL: "?",
+			wantArg: []any{"http_requests_total"},
+		},
+		{
+			name: "binary_eq",
+			expr: &chplan.Binary{
+				Op:    chplan.OpEq,
+				Left:  &chplan.ColumnRef{Name: "MetricName"},
+				Right: &chplan.LitString{V: "x"},
+			},
+			wantSQL: "(`MetricName` = ?)",
+			wantArg: []any{"x"},
+		},
+		{
+			name: "binary_match",
+			expr: &chplan.Binary{
+				Op:    chplan.OpMatch,
+				Left:  &chplan.ColumnRef{Name: "ServiceName"},
+				Right: &chplan.LitString{V: "^api-.*"},
+			},
+			wantSQL: "match(`ServiceName`, ?)",
+			wantArg: []any{"^api-.*"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			b := chsql.NewBuilder()
+			if err := b.Expr(tc.expr); err != nil {
+				t.Fatalf("Expr: %v", err)
+			}
+			sql, args := b.Build()
+			if sql != tc.wantSQL {
+				t.Errorf("SQL = %q; want %q", sql, tc.wantSQL)
+			}
+			if !reflect.DeepEqual(args, tc.wantArg) {
+				t.Errorf("Args = %v; want %v", args, tc.wantArg)
+			}
+		})
 	}
 }

--- a/internal/chsql/emit_node.go
+++ b/internal/chsql/emit_node.go
@@ -2,56 +2,87 @@ package chsql
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/tsouza/cerberus/internal/chplan"
 )
 
+// splice drains b's accumulated SQL + args into the emitter. Used by the
+// RC6 R6.2 ported emitters (emitScan / emitFilter / emitProject /
+// emitLimit) so they can build SQL fragments through the public
+// *Builder API and re-thread them into the shared emitter state at the
+// point the unported subquery / expression emitters expect to find
+// them. R6.3+ retires this helper as each remaining emit function gets
+// ported and the emitter struct converts to a *Builder directly.
+func (e *emitter) splice(b *Builder) {
+	sql, args := b.Build()
+	e.b.WriteString(sql)
+	e.args = append(e.args, args...)
+}
+
 func (e *emitter) emitScan(s *chplan.Scan) error {
-	e.b.WriteString("SELECT ")
+	b := NewBuilder()
+	b.WriteSQL("SELECT ")
 	if len(s.Columns) == 0 {
-		e.b.WriteByte('*')
+		b.WriteSQL("*")
 	} else {
 		for i, c := range s.Columns {
 			if i > 0 {
-				e.b.WriteString(", ")
+				b.WriteSQL(", ")
 			}
-			writeIdent(&e.b, c)
+			b.Ident(c)
 		}
 	}
-	e.b.WriteString(" FROM ")
-	writeIdent(&e.b, s.Table)
+	b.WriteSQL(" FROM ")
+	b.Ident(s.Table)
+	e.splice(b)
 	return nil
 }
 
 func (e *emitter) emitFilter(f *chplan.Filter) error {
-	e.b.WriteString("SELECT * FROM ")
+	// Prefix: SELECT * FROM
+	prefix := NewBuilder()
+	prefix.WriteSQL("SELECT * FROM ")
+	e.splice(prefix)
+	// Subquery is still rendered through the legacy emitter — its
+	// args land in e.args at this textual position, before the WHERE
+	// clause emitted next.
 	if err := e.emitSubquery(f.Input); err != nil {
 		return err
 	}
-	e.b.WriteString(" WHERE ")
-	return e.emitExpr(f.Predicate)
+	// Suffix: WHERE <predicate>
+	suffix := NewBuilder()
+	suffix.WriteSQL(" WHERE ")
+	if err := suffix.Expr(f.Predicate); err != nil {
+		return err
+	}
+	e.splice(suffix)
+	return nil
 }
 
 func (e *emitter) emitProject(p *chplan.Project) error {
-	e.b.WriteString("SELECT ")
+	// Prefix: SELECT <projections>
+	prefix := NewBuilder()
+	prefix.WriteSQL("SELECT ")
 	if len(p.Projections) == 0 {
-		e.b.WriteByte('*')
+		prefix.WriteSQL("*")
 	} else {
 		for i, pr := range p.Projections {
 			if i > 0 {
-				e.b.WriteString(", ")
+				prefix.WriteSQL(", ")
 			}
-			if err := e.emitExpr(pr.Expr); err != nil {
+			if err := prefix.Expr(pr.Expr); err != nil {
 				return err
 			}
 			if pr.Alias != "" {
-				e.b.WriteString(" AS ")
-				writeIdent(&e.b, pr.Alias)
+				prefix.WriteSQL(" AS ")
+				prefix.Ident(pr.Alias)
 			}
 		}
 	}
-	e.b.WriteString(" FROM ")
+	prefix.WriteSQL(" FROM ")
+	e.splice(prefix)
 	return e.emitSubquery(p.Input)
 }
 
@@ -137,12 +168,19 @@ func (e *emitter) emitAggFunc(af chplan.AggFunc) error {
 // emitRangeWindow lives in range_window.go — full windowed-array idiom.
 
 func (e *emitter) emitLimit(l *chplan.Limit) error {
-	e.b.WriteString("SELECT * FROM ")
+	prefix := NewBuilder()
+	prefix.WriteSQL("SELECT * FROM ")
+	e.splice(prefix)
 	if err := e.emitSubquery(l.Input); err != nil {
 		return err
 	}
 	if l.Count > 0 {
-		fmt.Fprintf(&e.b, " LIMIT %d", l.Count)
+		// LIMIT count is part of the query *shape*, not user data —
+		// rendered as a literal integer, matching SelectBuilder.Limit.
+		suffix := NewBuilder()
+		suffix.WriteSQL(" LIMIT ")
+		suffix.WriteSQL(strconv.FormatInt(l.Count, 10))
+		e.splice(suffix)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- Port `emitScan` / `emitFilter` / `emitProject` / `emitLimit` to use the public `*chsql.Builder` API landed in R6.1.
- Expression emission gets a builder-aware `Builder.Expr(...)` method; legacy `emitExpr` retained (ported in R6.4).
- SQL output unchanged for all TXTAR fixtures (whitespace-only diff if any, documented below).

## Test plan
- [ ] `go test ./internal/chsql/...` passes.
- [ ] `just update-golden` produces zero diff (or whitespace-only — documented if so).
- [ ] `go test ./test/spec/...` passes.

Roadmap: docs/roadmap.md § RC6 R6.2. Next: R6.3 (Aggregate + AggFunc).