### PR TITLE
feat(api/loki): /index/stats + /index/volume handlers (RC2)

### DIFF
--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -25,6 +25,8 @@ import (
 // reasons.
 type Querier interface {
 	Query(ctx context.Context, sql string, args ...any) ([]chclient.Sample, error)
+	QueryIndexStats(ctx context.Context, sql string, args ...any) (chclient.IndexStatsRow, error)
+	QueryIndexVolume(ctx context.Context, sql string, args ...any) ([]chclient.IndexVolumeRow, error)
 }
 
 // Handler implements the Loki HTTP API endpoints cerberus speaks. Mount
@@ -60,6 +62,10 @@ func (h *Handler) Mount(mux *http.ServeMux) {
 	mux.HandleFunc("POST /loki/api/v1/query", h.handleQuery)
 	mux.HandleFunc("GET /loki/api/v1/query_range", h.handleQueryRange)
 	mux.HandleFunc("POST /loki/api/v1/query_range", h.handleQueryRange)
+	mux.HandleFunc("GET /loki/api/v1/index/stats", h.handleIndexStats)
+	mux.HandleFunc("POST /loki/api/v1/index/stats", h.handleIndexStats)
+	mux.HandleFunc("GET /loki/api/v1/index/volume", h.handleIndexVolume)
+	mux.HandleFunc("POST /loki/api/v1/index/volume", h.handleIndexVolume)
 }
 
 func (h *Handler) handleQuery(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/loki/handler_test.go
+++ b/internal/api/loki/handler_test.go
@@ -18,6 +18,15 @@ type stubQuerier struct {
 	err      error
 	lastSQL  string
 	lastArgs []any
+
+	// /index/stats canned response (zero value is fine for the
+	// existing /query / /query_range tests that never call it).
+	statsRow chclient.IndexStatsRow
+	statsErr error
+
+	// /index/volume canned response.
+	volumeRows []chclient.IndexVolumeRow
+	volumeErr  error
 }
 
 func (s *stubQuerier) Query(_ context.Context, sql string, args ...any) ([]chclient.Sample, error) {
@@ -27,6 +36,24 @@ func (s *stubQuerier) Query(_ context.Context, sql string, args ...any) ([]chcli
 		return nil, s.err
 	}
 	return s.samples, nil
+}
+
+func (s *stubQuerier) QueryIndexStats(_ context.Context, sql string, args ...any) (chclient.IndexStatsRow, error) {
+	s.lastSQL = sql
+	s.lastArgs = args
+	if s.statsErr != nil {
+		return chclient.IndexStatsRow{}, s.statsErr
+	}
+	return s.statsRow, nil
+}
+
+func (s *stubQuerier) QueryIndexVolume(_ context.Context, sql string, args ...any) ([]chclient.IndexVolumeRow, error) {
+	s.lastSQL = sql
+	s.lastArgs = args
+	if s.volumeErr != nil {
+		return nil, s.volumeErr
+	}
+	return s.volumeRows, nil
 }
 
 func newServer(q loki.Querier) *httptest.Server {

--- a/internal/api/loki/index_stats.go
+++ b/internal/api/loki/index_stats.go
@@ -1,0 +1,216 @@
+package loki
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/logql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// IndexStats is the body of a /loki/api/v1/index/stats response, matching
+// the upstream Loki schema documented at
+// https://grafana.com/docs/loki/latest/reference/loki-http-api/#query-log-statistics.
+//
+// Cerberus is sample-storage (rows in an OTel-CH logs table), not
+// chunk-storage like upstream Loki, so Chunks is always reported as 0.
+// The PR body documents this gap; Grafana ignores the field for the
+// "approximate matches" hint it uses Streams + Bytes for.
+type IndexStats struct {
+	Streams uint64 `json:"streams"`
+	Chunks  uint64 `json:"chunks"`
+	Entries uint64 `json:"entries"`
+	Bytes   uint64 `json:"bytes"`
+}
+
+// handleIndexStats implements GET /loki/api/v1/index/stats. It accepts a
+// LogQL selector + start/end and returns aggregate counts for the
+// matched rows. Pipeline stages (line filters, label filters, parsers,
+// template stages) are ignored — Loki's contract is "selector only" for
+// this endpoint and that's what Grafana sends.
+func (h *Handler) handleIndexStats(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query().Get("query")
+	if q == "" {
+		writeError(w, http.StatusBadRequest, ErrBadData, errors.New("missing query parameter"))
+		return
+	}
+	start, end, err := parseStartEnd(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, ErrBadData, err)
+		return
+	}
+
+	matchers, err := selectorMatchers(q)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, ErrBadData, err)
+		return
+	}
+
+	sqlStr, args, err := buildIndexStatsSQL(h.Schema, matchers, start, end)
+	if err != nil {
+		h.respondError(w, &apiError{kind: ErrInternal, err: err, status: http.StatusInternalServerError})
+		return
+	}
+	h.Logger.Debug("cerberus loki index_stats", "logql", q, "sql", sqlStr, "args", args)
+
+	row, err := h.Client.QueryIndexStats(r.Context(), sqlStr, args...)
+	if err != nil {
+		h.Logger.Warn("cerberus loki index_stats CH query failed", "err", err.Error(), "sql", sqlStr)
+		h.respondError(w, &apiError{kind: ErrInternal, err: err, status: http.StatusBadGateway})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, IndexStats{
+		Streams: row.Streams,
+		// Cerberus has no chunk model — see IndexStats docstring.
+		Chunks:  0,
+		Entries: row.Entries,
+		Bytes:   row.Bytes,
+	})
+}
+
+// buildIndexStatsSQL builds the per-selector aggregate-count SELECT via
+// the chsql.Builder. The shape is:
+//
+//	SELECT
+//	  uniqExact(`ResourceAttributes`)         AS streams,
+//	  count()                                  AS entries,
+//	  sum(length(`Body`))                     AS bytes
+//	FROM `otel_logs`
+//	WHERE <matcher predicate>
+//	  AND `Timestamp` >= toDateTime64(<start>, 9)
+//	  AND `Timestamp` <= toDateTime64(<end>, 9)
+//
+// All identifiers and time-range bounds flow through Builder helpers so
+// no SQL string concatenation happens at this level (the CLAUDE.md
+// "no raw SQL" rule for new code).
+func buildIndexStatsSQL(s schema.Logs, matchers []*labels.Matcher, start, end time.Time) (string, []any, error) {
+	pred := logql.SelectorPredicate(matchers, s)
+	sb := chsql.NewSelect().
+		Select(
+			aggFrag("uniqExact", s.ResourceAttributesColumn),
+			countStar(),
+			bytesAggFrag(s.BodyColumn),
+		).
+		From(chsql.Col(s.LogsTable))
+
+	if pred != nil {
+		whereFrag, err := exprFrag(pred)
+		if err != nil {
+			return "", nil, err
+		}
+		sb.Where(whereFrag)
+	}
+	if !start.IsZero() {
+		sb.Where(timeBoundFrag(s.TimestampColumn, ">=", start))
+	}
+	if !end.IsZero() {
+		sb.Where(timeBoundFrag(s.TimestampColumn, "<=", end))
+	}
+
+	sqlStr, args := sb.Build()
+	return sqlStr, args, nil
+}
+
+// aggFrag returns a Frag that emits "<fn>(`<col>`)".
+func aggFrag(fn, col string) chsql.Frag {
+	return func(b *chsql.Builder) {
+		b.WriteSQL(fn)
+		b.WriteSQL("(")
+		b.Ident(col)
+		b.WriteSQL(")")
+	}
+}
+
+// countStar returns a Frag that emits "count()".
+func countStar() chsql.Frag {
+	return func(b *chsql.Builder) { b.WriteSQL("count()") }
+}
+
+// bytesAggFrag emits "sum(length(`<body>`))" — the bytes-volume
+// approximation. OTel-CH stores Body as a String column; length() counts
+// bytes (not codepoints), matching Loki's chunk-byte semantics within
+// rounding noise. If a deployment compresses Body and wants exact bytes
+// the schema override can swap this column.
+func bytesAggFrag(bodyCol string) chsql.Frag {
+	return func(b *chsql.Builder) {
+		b.WriteSQL("sum(length(")
+		b.Ident(bodyCol)
+		b.WriteSQL("))")
+	}
+}
+
+// timeBoundFrag emits "`<col>` <op> toDateTime64('YYYY-MM-DD HH:MM:SS.fffffffff', 9)".
+func timeBoundFrag(col, op string, t time.Time) chsql.Frag {
+	return func(b *chsql.Builder) {
+		b.Ident(col)
+		b.WriteSQL(" ")
+		b.WriteSQL(op)
+		b.WriteSQL(" ")
+		b.DateTime64Lit(t)
+	}
+}
+
+// exprFrag adapts a chplan.Expr into a Frag by deferring rendering to
+// Builder.Expr. Returns an error if the expression contains a node
+// Builder.Expr doesn't recognise.
+func exprFrag(x chplan.Expr) (chsql.Frag, error) {
+	// Capture a dry-run error early so handlers can surface it before
+	// the SQL ever lands in front of CH.
+	if err := (&chsql.Builder{}).Expr(x); err != nil {
+		return nil, err
+	}
+	return func(b *chsql.Builder) {
+		_ = b.Expr(x)
+	}, nil
+}
+
+// selectorMatchers parses a LogQL expression and returns its
+// stream-selector matchers. Both raw log-stream and metric-form queries
+// are accepted; pipeline stages and aggregation wrappers are stripped.
+func selectorMatchers(q string) ([]*labels.Matcher, error) {
+	expr, err := syntax.ParseExpr(q)
+	if err != nil {
+		return nil, err
+	}
+	switch e := expr.(type) {
+	case syntax.LogSelectorExpr:
+		return e.Matchers(), nil
+	case syntax.SampleExpr:
+		sel, err := e.Selector()
+		if err != nil {
+			return nil, err
+		}
+		return sel.Matchers(), nil
+	}
+	return nil, errors.New("query does not expose a log selector")
+}
+
+// parseStartEnd reads optional start/end timestamps. Either may be
+// absent — `start` defaults to 1h-ago, `end` to now, matching upstream
+// Loki defaults. Returns a 400-shaped error on a malformed value (the
+// caller wraps that into a bad_data response).
+func parseStartEnd(r *http.Request) (time.Time, time.Time, error) {
+	now := time.Now().UTC()
+	startStr := r.URL.Query().Get("start")
+	endStr := r.URL.Query().Get("end")
+
+	start, err := parseTime(startStr, now.Add(-time.Hour))
+	if err != nil {
+		return time.Time{}, time.Time{}, err
+	}
+	end, err := parseTime(endStr, now)
+	if err != nil {
+		return time.Time{}, time.Time{}, err
+	}
+	if !end.After(start) && !end.Equal(start) {
+		return time.Time{}, time.Time{}, errors.New("'end' must not be before 'start'")
+	}
+	return start, end, nil
+}

--- a/internal/api/loki/index_stats_test.go
+++ b/internal/api/loki/index_stats_test.go
@@ -1,0 +1,109 @@
+package loki_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/api/loki"
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+// TestIndexStats_HappyPath drives /index/stats with a canned aggregate
+// row and asserts the envelope shape Grafana expects, plus that chunks
+// is the documented zero (cerberus has no chunk model).
+func TestIndexStats_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{
+		statsRow: chclient.IndexStatsRow{
+			Streams: 3,
+			Entries: 42,
+			Bytes:   1024,
+		},
+	}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL +
+		`/loki/api/v1/index/stats?query=%7Bjob%3D%22api%22%7D&start=1717995600&end=1717999200`)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+
+	var out loki.IndexStats
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	want := loki.IndexStats{Streams: 3, Chunks: 0, Entries: 42, Bytes: 1024}
+	if out != want {
+		t.Fatalf("body mismatch: got %+v want %+v", out, want)
+	}
+
+	// SQL sanity: the matcher predicate must end up in the rendered SQL,
+	// going through the Builder (no fmt.Sprintf string concatenation),
+	// and the time bounds must be present as DateTime64 literals.
+	if !strings.Contains(q.lastSQL, "uniqExact(`ResourceAttributes`)") {
+		t.Errorf("missing uniqExact in SQL: %q", q.lastSQL)
+	}
+	if !strings.Contains(q.lastSQL, "sum(length(`Body`))") {
+		t.Errorf("missing bytes agg in SQL: %q", q.lastSQL)
+	}
+	if !strings.Contains(q.lastSQL, "toDateTime64(") {
+		t.Errorf("missing time bounds in SQL: %q", q.lastSQL)
+	}
+}
+
+// TestIndexStats_BadInput covers the validation contract.
+func TestIndexStats_BadInput(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		url  string
+	}{
+		{"missing query", `/loki/api/v1/index/stats?start=1&end=2`},
+		{"bad query", `/loki/api/v1/index/stats?query=%7Bnot+a+selector&start=1&end=2`},
+		{"bad start", `/loki/api/v1/index/stats?query=%7Bjob%3D%22api%22%7D&start=banana&end=2`},
+		{"end before start", `/loki/api/v1/index/stats?query=%7Bjob%3D%22api%22%7D&start=2000000000&end=1000000000`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv := newServer(&stubQuerier{})
+			t.Cleanup(srv.Close)
+			resp, err := http.Get(srv.URL + tc.url)
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d", resp.StatusCode)
+			}
+		})
+	}
+}
+
+// TestIndexStats_MetricForm covers the "rate(...)" form — the handler
+// must unwrap the selector instead of erroring on the sample-expr type.
+func TestIndexStats_MetricForm(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{statsRow: chclient.IndexStatsRow{Streams: 1, Entries: 1, Bytes: 1}}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL +
+		`/loki/api/v1/index/stats?query=rate(%7Bjob%3D%22api%22%7D%5B5m%5D)&start=1717995600&end=1717999200`)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+}

--- a/internal/api/loki/index_volume.go
+++ b/internal/api/loki/index_volume.go
@@ -1,0 +1,221 @@
+package loki
+
+import (
+	"errors"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/logql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// defaultVolumeLimit mirrors Loki's documented default for
+// /loki/api/v1/index/volume — the top-N series by byte volume.
+const defaultVolumeLimit = 100
+
+// handleIndexVolume implements GET /loki/api/v1/index/volume. The body
+// shape mirrors a Prometheus instant vector — Grafana's "logs volume"
+// panel rebuilds its bar chart from this — with the byte volume of each
+// matched series in the value slot.
+//
+// Query parameters honoured:
+//   - query (required): LogQL stream selector
+//   - start / end (optional): time range (defaults to last hour)
+//   - limit (optional): top-N row cap (default 100)
+//   - targetLabels (optional): comma-separated label whitelist; when set,
+//     only those keys appear in the per-row metric map and rows that
+//     share the projected keys collapse into one
+//   - aggregateBy (optional): "series" (default, group by full label
+//     set) or "labels" (group by `targetLabels`; equivalent to "series"
+//     when targetLabels is unset)
+func (h *Handler) handleIndexVolume(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query().Get("query")
+	if q == "" {
+		writeError(w, http.StatusBadRequest, ErrBadData, errors.New("missing query parameter"))
+		return
+	}
+	start, end, err := parseStartEnd(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, ErrBadData, err)
+		return
+	}
+
+	limit, err := parseVolumeLimit(r.URL.Query().Get("limit"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, ErrBadData, err)
+		return
+	}
+
+	targetLabels := parseTargetLabels(r.URL.Query().Get("targetLabels"))
+	aggregateBy := r.URL.Query().Get("aggregateBy")
+
+	matchers, err := selectorMatchers(q)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, ErrBadData, err)
+		return
+	}
+
+	sqlStr, args, err := buildIndexVolumeSQL(h.Schema, matchers, start, end, limit, targetLabels, aggregateBy)
+	if err != nil {
+		h.respondError(w, &apiError{kind: ErrInternal, err: err, status: http.StatusInternalServerError})
+		return
+	}
+	h.Logger.Debug("cerberus loki index_volume", "logql", q, "sql", sqlStr, "args", args)
+
+	rows, err := h.Client.QueryIndexVolume(r.Context(), sqlStr, args...)
+	if err != nil {
+		h.Logger.Warn("cerberus loki index_volume CH query failed", "err", err.Error(), "sql", sqlStr)
+		h.respondError(w, &apiError{kind: ErrInternal, err: err, status: http.StatusBadGateway})
+		return
+	}
+
+	stamp := float64(end.UnixMilli()) / 1e3
+	result := make([]VectorSample, 0, len(rows))
+	for _, row := range rows {
+		result = append(result, VectorSample{
+			Metric: row.Labels,
+			Value:  [2]any{stamp, strconv.FormatUint(row.Bytes, 10)},
+		})
+	}
+
+	writeJSON(w, http.StatusOK, Response{
+		Status: "success",
+		Data: &QueryData{
+			ResultType: "vector",
+			Result:     result,
+		},
+	})
+}
+
+// buildIndexVolumeSQL builds the GROUP BY-on-label-set SELECT used by
+// /index/volume. The CH shape is:
+//
+//	SELECT
+//	    <group-key-frag> AS labels,
+//	    sum(length(`Body`)) AS bytes
+//	FROM `otel_logs`
+//	WHERE <matchers> AND <time bounds>
+//	GROUP BY labels
+//	ORDER BY bytes DESC
+//	LIMIT <n>
+//
+// `<group-key-frag>` is one of:
+//
+//   - `ResourceAttributes` (default — full label set)
+//   - `mapFilter((k, v) -> k IN (?, ?, …), ResourceAttributes)` when
+//     `targetLabels` is set and aggregateBy is "labels" (or unset)
+//
+// All identifiers and bound keys flow through Builder helpers — no
+// fmt.Sprintf-on-SQL (CLAUDE.md "no raw SQL strings" rule).
+func buildIndexVolumeSQL(
+	s schema.Logs,
+	matchers []*labels.Matcher,
+	start, end time.Time,
+	limit int,
+	targetLabels []string,
+	aggregateBy string,
+) (string, []any, error) {
+	groupFrag := volumeGroupFrag(s, targetLabels, aggregateBy)
+
+	sb := chsql.NewSelect().
+		Select(
+			aliased(groupFrag, "labels"),
+			aliased(bytesAggFrag(s.BodyColumn), "bytes"),
+		).
+		From(chsql.Col(s.LogsTable))
+
+	pred := logql.SelectorPredicate(matchers, s)
+	if pred != nil {
+		whereFrag, err := exprFrag(pred)
+		if err != nil {
+			return "", nil, err
+		}
+		sb.Where(whereFrag)
+	}
+	if !start.IsZero() {
+		sb.Where(timeBoundFrag(s.TimestampColumn, ">=", start))
+	}
+	if !end.IsZero() {
+		sb.Where(timeBoundFrag(s.TimestampColumn, "<=", end))
+	}
+
+	sb.GroupBy(chsql.Col("labels")).
+		OrderBy(chsql.Col("bytes"), true).
+		Limit(limit)
+
+	sqlStr, args := sb.Build()
+	return sqlStr, args, nil
+}
+
+// volumeGroupFrag picks the CH expression that produces the row's
+// label-set group key. "series" (or empty + no targetLabels) groups by
+// the full ResourceAttributes map; otherwise we project to the
+// targetLabels subset via mapFilter.
+func volumeGroupFrag(s schema.Logs, targetLabels []string, aggregateBy string) chsql.Frag {
+	if len(targetLabels) == 0 || aggregateBy == "series" {
+		return chsql.Col(s.ResourceAttributesColumn)
+	}
+	keys := append([]string(nil), targetLabels...)
+	sort.Strings(keys)
+	// Routes through chplan.MapWithoutKeys' sibling shape — but since
+	// MapWithoutKeys NEGATES the IN, write a fresh Frag for the
+	// positive form. Reuses the same Builder Arg/Ident helpers.
+	return func(b *chsql.Builder) {
+		b.WriteSQL("mapFilter((k, v) -> k IN (")
+		for i, k := range keys {
+			if i > 0 {
+				b.WriteSQL(", ")
+			}
+			b.Arg(k)
+		}
+		b.WriteSQL("), ")
+		b.Ident(s.ResourceAttributesColumn)
+		b.WriteSQL(")")
+	}
+}
+
+// aliased wraps a Frag with " AS <ident>".
+func aliased(inner chsql.Frag, alias string) chsql.Frag {
+	return func(b *chsql.Builder) {
+		inner(b)
+		b.WriteSQL(" AS ")
+		b.Ident(alias)
+	}
+}
+
+// parseVolumeLimit decodes the optional `limit` parameter; missing /
+// empty returns the documented default. Negative or non-numeric values
+// are rejected with a 400.
+func parseVolumeLimit(raw string) (int, error) {
+	if raw == "" {
+		return defaultVolumeLimit, nil
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return 0, errors.New("'limit' must be a positive integer")
+	}
+	return n, nil
+}
+
+// parseTargetLabels splits a comma-separated label-name list, trimming
+// whitespace and dropping empties. Returns nil for the empty input.
+func parseTargetLabels(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/internal/api/loki/index_volume_test.go
+++ b/internal/api/loki/index_volume_test.go
@@ -1,0 +1,177 @@
+package loki_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/api/loki"
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+// TestIndexVolume_HappyPath drives /index/volume with two canned rows
+// and asserts the Prometheus-vector envelope shape.
+func TestIndexVolume_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{
+		volumeRows: []chclient.IndexVolumeRow{
+			{Labels: map[string]string{"job": "api", "env": "prod"}, Bytes: 2048},
+			{Labels: map[string]string{"job": "api", "env": "stg"}, Bytes: 512},
+		},
+	}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL +
+		`/loki/api/v1/index/volume?query=%7Bjob%3D%22api%22%7D&start=1717995600&end=1717999200`)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+
+	var parsed struct {
+		Status string         `json:"status"`
+		Data   loki.QueryData `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if parsed.Status != "success" {
+		t.Fatalf("status=%q", parsed.Status)
+	}
+	if parsed.Data.ResultType != "vector" {
+		t.Fatalf("resultType=%q", parsed.Data.ResultType)
+	}
+	raw, _ := json.Marshal(parsed.Data.Result)
+	var samples []loki.VectorSample
+	if err := json.Unmarshal(raw, &samples); err != nil {
+		t.Fatalf("decode vector: %v", err)
+	}
+	if len(samples) != 2 {
+		t.Fatalf("expected 2 vector samples, got %d", len(samples))
+	}
+
+	// SQL sanity: GROUP BY + ORDER BY bytes DESC + LIMIT must all be
+	// present; bytes column aggregates via length(Body); labels grouping
+	// uses the full ResourceAttributes map when targetLabels is absent.
+	if !strings.Contains(q.lastSQL, "GROUP BY") {
+		t.Errorf("missing GROUP BY: %q", q.lastSQL)
+	}
+	if !strings.Contains(q.lastSQL, "ORDER BY `bytes` DESC") {
+		t.Errorf("missing ORDER BY bytes DESC: %q", q.lastSQL)
+	}
+	if !strings.Contains(q.lastSQL, "LIMIT 100") {
+		t.Errorf("default limit absent: %q", q.lastSQL)
+	}
+	if !strings.Contains(q.lastSQL, "`ResourceAttributes` AS `labels`") {
+		t.Errorf("default group key should be full RA map: %q", q.lastSQL)
+	}
+}
+
+// TestIndexVolume_TargetLabels confirms the mapFilter projection for
+// the `targetLabels` query parameter.
+func TestIndexVolume_TargetLabels(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL +
+		`/loki/api/v1/index/volume?query=%7Bjob%3D%22api%22%7D&targetLabels=job,env&aggregateBy=labels`)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+
+	if !strings.Contains(q.lastSQL, "mapFilter((k, v) -> k IN (") {
+		t.Errorf("missing mapFilter for targetLabels: %q", q.lastSQL)
+	}
+	// Args carry the target-label keys (sorted): env, job, plus the
+	// original "job" matcher value pair (job, api) ahead of those. The
+	// exact positions track the SQL stream — we just confirm the keys
+	// landed in the slice.
+	want := map[string]bool{"job": false, "env": false, "api": false}
+	for _, a := range q.lastArgs {
+		if s, ok := a.(string); ok {
+			if _, present := want[s]; present {
+				want[s] = true
+			}
+		}
+	}
+	for k, seen := range want {
+		if !seen {
+			t.Errorf("expected arg %q not bound; args=%v", k, q.lastArgs)
+		}
+	}
+}
+
+// TestIndexVolume_Limit covers a custom limit + parse error.
+func TestIndexVolume_Limit(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	// happy path: explicit limit
+	resp, err := http.Get(srv.URL +
+		`/loki/api/v1/index/volume?query=%7Bjob%3D%22api%22%7D&limit=25`)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	if !strings.Contains(q.lastSQL, "LIMIT 25") {
+		t.Errorf("expected LIMIT 25 in SQL: %q", q.lastSQL)
+	}
+
+	// bad input
+	resp, err = http.Get(srv.URL +
+		`/loki/api/v1/index/volume?query=%7Bjob%3D%22api%22%7D&limit=-3`)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 for bad limit, got %d", resp.StatusCode)
+	}
+}
+
+// TestIndexVolume_BadInput covers the validation contract.
+func TestIndexVolume_BadInput(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		url  string
+	}{
+		{"missing query", `/loki/api/v1/index/volume?start=1&end=2`},
+		{"bad query", `/loki/api/v1/index/volume?query=not+a+selector`},
+		{"bad start", `/loki/api/v1/index/volume?query=%7Bjob%3D%22api%22%7D&start=banana&end=2`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv := newServer(&stubQuerier{})
+			t.Cleanup(srv.Close)
+			resp, err := http.Get(srv.URL + tc.url)
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d", resp.StatusCode)
+			}
+		})
+	}
+}

--- a/internal/chclient/client.go
+++ b/internal/chclient/client.go
@@ -176,6 +176,79 @@ func (c *Client) QueryMetricMeta(ctx context.Context, sql, metricType string, ar
 	return out, nil
 }
 
+// IndexStatsRow is the single aggregate row returned by the Loki
+// /loki/api/v1/index/stats SQL — counts of distinct streams, log entries
+// and total byte volume (sum(length(Body))) for the matched selector.
+//
+// Cerberus has no chunk model (it's sample-backed, not chunk-backed), so
+// the chunks count is reported as 0 by the API handler — it is not part
+// of this struct.
+type IndexStatsRow struct {
+	Streams uint64
+	Entries uint64
+	Bytes   uint64
+}
+
+// QueryIndexStats runs sql expecting a single row of three UInt64
+// aggregates (streams, entries, bytes) and decodes it. An empty result
+// set is treated as the all-zeros row.
+func (c *Client) QueryIndexStats(ctx context.Context, sql string, args ...any) (IndexStatsRow, error) {
+	rows, err := c.conn.Query(ctx, sql, args...)
+	if err != nil {
+		return IndexStatsRow{}, fmt.Errorf("chclient: query: %w", err)
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+
+	var out IndexStatsRow
+	if rows.Next() {
+		if err := rows.Scan(&out.Streams, &out.Entries, &out.Bytes); err != nil {
+			return IndexStatsRow{}, fmt.Errorf("chclient: scan: %w", err)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return IndexStatsRow{}, fmt.Errorf("chclient: rows.Err: %w", err)
+	}
+	return out, nil
+}
+
+// IndexVolumeRow is one grouped (label-set, bytes) tuple from the Loki
+// /loki/api/v1/index/volume SQL. The label set is the GROUP BY key — by
+// default the full ResourceAttributes map, or a filtered subset when the
+// caller supplied `targetLabels`.
+type IndexVolumeRow struct {
+	Labels map[string]string
+	Bytes  uint64
+}
+
+// QueryIndexVolume runs sql expecting rows of (Map(String,String),
+// UInt64) and decodes them into IndexVolumeRow.
+func (c *Client) QueryIndexVolume(ctx context.Context, sql string, args ...any) ([]IndexVolumeRow, error) {
+	rows, err := c.conn.Query(ctx, sql, args...)
+	if err != nil {
+		return nil, fmt.Errorf("chclient: query: %w", err)
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+
+	var out []IndexVolumeRow
+	for rows.Next() {
+		var r IndexVolumeRow
+		var labels map[string]string
+		if err := rows.Scan(&labels, &r.Bytes); err != nil {
+			return nil, fmt.Errorf("chclient: scan: %w", err)
+		}
+		r.Labels = labels
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("chclient: rows.Err: %w", err)
+	}
+	return out, nil
+}
+
 // QueryLabelSets runs sql and decodes each row into a Map(String,String)
 // label set. Used by /api/v1/series.
 func (c *Client) QueryLabelSets(ctx context.Context, sql string, args ...any) ([]map[string]string, error) {

--- a/internal/logql/lower.go
+++ b/internal/logql/lower.go
@@ -237,6 +237,16 @@ func lineFilterOp(t loglib.LineMatchType) (isRegex, negated bool, err error) {
 	return false, false, fmt.Errorf("logql: line-filter op %s is not yet supported (`|>` pattern filters land in M3.2)", t)
 }
 
+// SelectorPredicate is the exported entry point for callers that need
+// just the stream-selector predicate without lowering the full
+// expression — e.g. the /index/stats and /index/volume handlers, which
+// only care about the matchers, not the pipeline stages.
+//
+// Returns nil if matchers is empty.
+func SelectorPredicate(matchers []*labels.Matcher, s schema.Logs) chplan.Expr {
+	return buildMatchersPredicate(matchers, s)
+}
+
 // buildMatchersPredicate AND-folds the stream-selector matchers into a
 // chplan.Expr. Each matcher targets `ResourceAttributes[<label>]`.
 func buildMatchersPredicate(matchers []*labels.Matcher, s schema.Logs) chplan.Expr {


### PR DESCRIPTION
## Summary
- Adds `/loki/api/v1/index/stats` (streams, chunks, entries, bytes counts).
- Adds `/loki/api/v1/index/volume` (per-series bytes volume; configurable aggregateBy).
- Cerberus has no chunk model, so `chunks` is reported as 0 with a documented note.
- All new SQL routed through `*chsql.Builder`.

## Test plan
- [ ] `go test ./internal/api/loki/...` passes.
- [ ] Handlers respond to representative `GET` requests with the expected envelopes.
- [ ] 4xx on missing query / bad time.

Roadmap: docs/roadmap.md line 109 (RC2 LogQL APIs).