### PR TITLE
feat(logql): | unpack + | pattern parser stages (RC2)

### DIFF
--- a/internal/api/loki/post_process.go
+++ b/internal/api/loki/post_process.go
@@ -2,11 +2,14 @@ package loki
 
 import (
 	"bytes"
+	"encoding/json"
 	"regexp"
 	"text/template"
 
 	loglib "github.com/grafana/loki/v3/pkg/logql/log"
+	"github.com/grafana/loki/v3/pkg/logql/log/pattern"
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
+	"github.com/grafana/loki/v3/pkg/logqlmodel"
 )
 
 // postProcessExtract walks the parsed LogQL expression and pulls out
@@ -23,6 +26,13 @@ import (
 //     template-set labels on the row. Subsequent line_format stages
 //     see the updated label map; the streams response groups rows by
 //     the final (post-format) label set.
+//   - `| unpack` — parses the line as a JSON object and merges each
+//     string-valued key into the labels map. A special `_entry` key
+//     replaces the line, restoring the original payload from
+//     Promtail's `pack` stage.
+//   - `| pattern "<ip> <_> <method> <path>"` — matches the line against
+//     a Loki pattern expression and adds each named capture to the
+//     labels map. `<_>` skips a segment.
 //
 // Lowering already returns nil-predicate no-ops for these stages so
 // the SQL doesn't try to model them. Returns a transform that maps
@@ -52,6 +62,17 @@ func postProcessExtract(expr syntax.Expr) (lineTransform, error) {
 				return nil, err
 			}
 			steps = append(steps, step)
+		case *syntax.LineParserExpr:
+			switch v.Op {
+			case syntax.OpParserTypeUnpack:
+				steps = append(steps, unpackStep)
+			case syntax.OpParserTypePattern:
+				step, err := newPatternStep(v.Param)
+				if err != nil {
+					return nil, err
+				}
+				steps = append(steps, step)
+			}
 		}
 	}
 
@@ -218,6 +239,100 @@ func newLabelFormatStep(formats []loglib.LabelFmt) (lineTransform, error) {
 				continue
 			}
 			out[c.dst] = buf.String()
+		}
+		return line, out
+	}, nil
+}
+
+// unpackStep implements `| unpack`. The line is expected to be a JSON
+// object emitted by Promtail's `pack` stage: each string-valued key
+// becomes a label, and the special `_entry` key replaces the line.
+//
+// Non-object payloads and JSON-decode errors leave the line and labels
+// unchanged — matching Loki's silent-on-malformed-JSON contract.
+// Non-string values (numbers, arrays, nested objects) are skipped at
+// the label level but the `_entry` rewrite still applies.
+//
+// Returns a FRESH labels map so callers can treat the input as
+// immutable, consistent with newLabelFormatStep.
+func unpackStep(line string, labels map[string]string) (string, map[string]string) {
+	if len(line) == 0 || line[0] != '{' {
+		return line, labels
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(line), &raw); err != nil {
+		return line, labels
+	}
+	out := make(map[string]string, len(labels)+len(raw))
+	for k, v := range labels {
+		out[k] = v
+	}
+	newLine := line
+	for k, v := range raw {
+		// Skip non-string values (Loki's unpack only extracts strings).
+		if len(v) == 0 || v[0] != '"' {
+			continue
+		}
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			continue
+		}
+		if k == logqlmodel.PackedEntryKey {
+			newLine = s
+			continue
+		}
+		// Don't shadow stream labels — Loki appends a duplicate suffix
+		// in that case. Mirror that behavior so cerberus's row output
+		// matches Loki's.
+		if _, ok := labels[k]; ok {
+			out[k+duplicateSuffix] = s
+			continue
+		}
+		out[k] = s
+	}
+	return newLine, out
+}
+
+// duplicateSuffix matches Loki's `_extracted` suffix appended to
+// parser-extracted labels that would otherwise shadow a stream label.
+// See `loglib.duplicateSuffix` (unexported, kept in sync by name).
+const duplicateSuffix = "_extracted"
+
+// newPatternStep implements `| pattern "<ip> <_> <method> <path>"`.
+// The pattern parser is taken straight from upstream Loki so cerberus
+// matches Loki's named-capture semantics (including `<_>` skips and
+// the trailing-anchor / inter-literal boundaries).
+//
+// Each named capture is added to the labels map. Captures that would
+// shadow a stream label get the `_extracted` suffix, mirroring Loki's
+// disambiguation contract.
+//
+// A pattern that fails to match (Matches returns nil) leaves the line
+// and labels unchanged — Loki's silent-fallback semantics.
+func newPatternStep(p string) (lineTransform, error) {
+	m, err := pattern.New(p)
+	if err != nil {
+		return nil, err
+	}
+	names := m.Names()
+	return func(line string, lbs map[string]string) (string, map[string]string) {
+		caps := m.Matches([]byte(line))
+		if len(caps) == 0 {
+			return line, lbs
+		}
+		out := make(map[string]string, len(lbs)+len(names))
+		for k, v := range lbs {
+			out[k] = v
+		}
+		for i, c := range caps {
+			if i >= len(names) {
+				break
+			}
+			name := names[i]
+			if _, ok := lbs[name]; ok {
+				name += duplicateSuffix
+			}
+			out[name] = string(c)
 		}
 		return line, out
 	}, nil

--- a/internal/api/loki/unpack_pattern_test.go
+++ b/internal/api/loki/unpack_pattern_test.go
@@ -1,0 +1,236 @@
+package loki
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+)
+
+// TestUnpack_ExtractsLabelsAndEntry — the canonical Promtail `pack`
+// payload: a JSON object whose `_entry` key is the original line and
+// whose remaining string keys are added as labels.
+func TestUnpack_ExtractsLabelsAndEntry(t *testing.T) {
+	t.Parallel()
+
+	expr, err := syntax.ParseExpr(`{job="api"} | unpack`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	tx, err := postProcessExtract(expr)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if tx == nil {
+		t.Fatalf("expected non-nil transform for unpack")
+	}
+
+	line := `{"_entry":"original log line","pod":"web-1","container":"app"}`
+	gotLine, gotLabels := tx(line, map[string]string{"job": "api"})
+
+	if gotLine != "original log line" {
+		t.Errorf("line: got %q, want %q", gotLine, "original log line")
+	}
+	want := map[string]string{"job": "api", "pod": "web-1", "container": "app"}
+	if !reflect.DeepEqual(gotLabels, want) {
+		t.Errorf("labels mismatch\n got %#v\nwant %#v", gotLabels, want)
+	}
+}
+
+// TestUnpack_DuplicateSuffix — a parser-extracted label that collides
+// with a stream label gets the `_extracted` suffix (matches Loki's
+// disambiguation contract).
+func TestUnpack_DuplicateSuffix(t *testing.T) {
+	t.Parallel()
+
+	expr, _ := syntax.ParseExpr(`{job="api"} | unpack`)
+	tx, _ := postProcessExtract(expr)
+
+	line := `{"_entry":"l","job":"shadowed"}`
+	_, gotLabels := tx(line, map[string]string{"job": "api"})
+
+	if gotLabels["job"] != "api" {
+		t.Errorf("stream label `job` should be preserved; got %q", gotLabels["job"])
+	}
+	if gotLabels["job_extracted"] != "shadowed" {
+		t.Errorf("clashing key should land under `job_extracted`; got %q",
+			gotLabels["job_extracted"])
+	}
+}
+
+// TestUnpack_NonJSONLeavesLineAlone — a non-JSON line silently passes
+// through. Loki sets `__error__=JSONParserErr` in that case; cerberus
+// uses silent-fallback semantics (matching its line_format /
+// label_format style).
+func TestUnpack_NonJSONLeavesLineAlone(t *testing.T) {
+	t.Parallel()
+
+	expr, _ := syntax.ParseExpr(`{job="api"} | unpack`)
+	tx, _ := postProcessExtract(expr)
+
+	gotLine, gotLabels := tx("not json", map[string]string{"job": "api"})
+	if gotLine != "not json" {
+		t.Errorf("line should pass through; got %q", gotLine)
+	}
+	if !reflect.DeepEqual(gotLabels, map[string]string{"job": "api"}) {
+		t.Errorf("labels should be unchanged; got %#v", gotLabels)
+	}
+}
+
+// TestUnpack_SkipsNonStringValues — Promtail's pack only ever emits
+// string-valued keys, but real-world JSON has numbers and objects;
+// unpack skips those (Loki's contract).
+func TestUnpack_SkipsNonStringValues(t *testing.T) {
+	t.Parallel()
+
+	expr, _ := syntax.ParseExpr(`{job="api"} | unpack`)
+	tx, _ := postProcessExtract(expr)
+
+	line := `{"_entry":"l","count":42,"nested":{"x":1},"pod":"web-1"}`
+	_, gotLabels := tx(line, map[string]string{"job": "api"})
+
+	if _, ok := gotLabels["count"]; ok {
+		t.Errorf("non-string `count` should be skipped; got %q", gotLabels["count"])
+	}
+	if _, ok := gotLabels["nested"]; ok {
+		t.Errorf("object-valued `nested` should be skipped")
+	}
+	if gotLabels["pod"] != "web-1" {
+		t.Errorf("string-valued `pod` should be extracted; got %q", gotLabels["pod"])
+	}
+}
+
+// TestPattern_NamedCaptures — the canonical case: each named segment
+// in the pattern becomes a label. `<_>` segments are skipped.
+func TestPattern_NamedCaptures(t *testing.T) {
+	t.Parallel()
+
+	expr, err := syntax.ParseExpr(`{job="api"} | pattern "<ip> <_> <method> <path>"`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	tx, err := postProcessExtract(expr)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if tx == nil {
+		t.Fatalf("expected non-nil transform")
+	}
+
+	gotLine, gotLabels := tx(`10.0.0.1 - GET /index.html`, map[string]string{"job": "api"})
+	if gotLine != `10.0.0.1 - GET /index.html` {
+		t.Errorf("pattern shouldn't rewrite line; got %q", gotLine)
+	}
+	want := map[string]string{
+		"job":    "api",
+		"ip":     "10.0.0.1",
+		"method": "GET",
+		"path":   "/index.html",
+	}
+	if !reflect.DeepEqual(gotLabels, want) {
+		t.Errorf("labels mismatch\n got %#v\nwant %#v", gotLabels, want)
+	}
+}
+
+// TestPattern_EmptyLineNoExtraction — Loki's Matcher returns nil for
+// empty input. Cerberus mirrors that: no captures means labels pass
+// through untouched.
+func TestPattern_EmptyLineNoExtraction(t *testing.T) {
+	t.Parallel()
+
+	expr, _ := syntax.ParseExpr(`{job="api"} | pattern "<ip> <_> <method> <path>"`)
+	tx, _ := postProcessExtract(expr)
+
+	gotLine, gotLabels := tx("", map[string]string{"job": "api"})
+	if gotLine != "" {
+		t.Errorf("line should pass through; got %q", gotLine)
+	}
+	if !reflect.DeepEqual(gotLabels, map[string]string{"job": "api"}) {
+		t.Errorf("labels should be unchanged; got %#v", gotLabels)
+	}
+}
+
+// TestPattern_PartialCapture — Loki's matcher emits whatever it could
+// capture even on a malformed line (matches its `if i == -1` fallback
+// path that returns up to the end as the last capture). Cerberus
+// mirrors that. The point of the test is to pin the contract, not to
+// promise full-line validation.
+func TestPattern_PartialCapture(t *testing.T) {
+	t.Parallel()
+
+	expr, _ := syntax.ParseExpr(`{job="api"} | pattern "<a> <b> <c>"`)
+	tx, _ := postProcessExtract(expr)
+
+	// Only one space-separated token survives: the matcher captures
+	// `one` for `<a>` and stops (no more space-literals to anchor on),
+	// returning a single capture per Matches' early-return.
+	_, gotLabels := tx("one", map[string]string{"job": "api"})
+	if got := gotLabels["a"]; got != "one" {
+		t.Errorf("first capture should be `one`; got %q", got)
+	}
+	if _, ok := gotLabels["b"]; ok {
+		t.Errorf("unmatched `b` should not be present; got %q", gotLabels["b"])
+	}
+}
+
+// TestPattern_DuplicateSuffix — a capture that collides with a stream
+// label gets `_extracted` suffixed, same as unpack and Loki's contract.
+func TestPattern_DuplicateSuffix(t *testing.T) {
+	t.Parallel()
+
+	expr, _ := syntax.ParseExpr(`{job="api"} | pattern "<job> <_>"`)
+	tx, _ := postProcessExtract(expr)
+
+	_, gotLabels := tx("other rest", map[string]string{"job": "api"})
+	if gotLabels["job"] != "api" {
+		t.Errorf("stream label `job` should be preserved; got %q", gotLabels["job"])
+	}
+	if gotLabels["job_extracted"] != "other" {
+		t.Errorf("capture clash should land in `job_extracted`; got %q",
+			gotLabels["job_extracted"])
+	}
+}
+
+// TestPattern_BadPatternStringIsParseError — the upstream Loki parser
+// rejects malformed patterns at ParseExpr-time. Cerberus relies on
+// that and never observes a malformed pattern itself; the test pins
+// the contract.
+func TestPattern_BadPatternStringIsParseError(t *testing.T) {
+	t.Parallel()
+
+	// A pattern with no captures is invalid per Loki's grammar.
+	if _, err := syntax.ParseExpr(`{job="api"} | pattern "just literal"`); err == nil {
+		t.Fatalf("expected ParseExpr to reject capture-less pattern; got nil")
+	}
+}
+
+// TestPatternUnpackCompose — `| unpack | pattern` chains: unpack
+// rewrites the line from `_entry`, pattern then runs against the new
+// line. Mirrors the line_format/decolorize compose test.
+func TestPatternUnpackCompose(t *testing.T) {
+	t.Parallel()
+
+	expr, err := syntax.ParseExpr(`{job="api"} | unpack | pattern "<method> <path>"`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	tx, err := postProcessExtract(expr)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+
+	line := `{"_entry":"GET /healthz","pod":"web-1"}`
+	gotLine, gotLabels := tx(line, map[string]string{"job": "api"})
+	if gotLine != "GET /healthz" {
+		t.Errorf("line should be the unpacked _entry; got %q", gotLine)
+	}
+	want := map[string]string{
+		"job":    "api",
+		"pod":    "web-1",
+		"method": "GET",
+		"path":   "/healthz",
+	}
+	if !reflect.DeepEqual(gotLabels, want) {
+		t.Errorf("compose mismatch\n got %#v\nwant %#v", gotLabels, want)
+	}
+}

--- a/internal/logql/lower.go
+++ b/internal/logql/lower.go
@@ -108,7 +108,19 @@ func lowerStage(stage syntax.StageExpr, s schema.Logs) (chplan.Expr, error) {
 		// parsed expression on the handler side.
 		return nil, nil
 	case *syntax.LineParserExpr:
-		return nil, fmt.Errorf("logql: parser stage `| %s` is not yet supported (json/logfmt/regexp/pattern parsers deferred from M3.2; revisit in RC3 alongside chsql JSONExtract/extractKeyValuePairs helpers)", st.Op)
+		// `| unpack` and `| pattern` are parser stages that extract
+		// labels from the line in Go after the rows return — they have
+		// no SQL impact (lowering returns no predicate). The API handler
+		// pulls them out of the parsed expression via postProcessExtract
+		// and applies them per row.
+		//
+		// Other parser stages (`| json`, `| logfmt`, `| regexp`) stay
+		// deferred to RC3 alongside `chsql` JSONExtract helpers.
+		switch st.Op {
+		case syntax.OpParserTypeUnpack, syntax.OpParserTypePattern:
+			return nil, nil
+		}
+		return nil, fmt.Errorf("logql: parser stage `| %s` is not yet supported (json/logfmt/regexp parsers deferred from M3.2; revisit in RC3 alongside chsql JSONExtract/extractKeyValuePairs helpers)", st.Op)
 	case *syntax.LogfmtParserExpr:
 		return nil, fmt.Errorf("logql: `| logfmt` parser is not yet supported (deferred from M3.2; revisit in RC3)")
 	case *syntax.JSONExpressionParserExpr:

--- a/internal/logql/unpack_pattern_test.go
+++ b/internal/logql/unpack_pattern_test.go
@@ -1,0 +1,135 @@
+package logql_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/logql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestLowerUnpackPattern_NoSQLImpact pins the contract that `| unpack`
+// and `| pattern` are post-fetch stages: they extract labels in Go
+// after the rows return, so the lowered SQL contains exactly the same
+// predicates as the equivalent query without the parser stage.
+//
+// This mirrors the existing decolorize / line_format / label_format
+// stages — see internal/logql/lower.go for the dispatch.
+func TestLowerUnpackPattern_NoSQLImpact(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelLogs()
+	cases := []struct {
+		name string
+		// `with` includes the parser stage; `without` strips it. Both
+		// should lower to the same SQL.
+		with    string
+		without string
+	}{
+		{
+			name:    "unpack on bare selector",
+			with:    `{job="api"} | unpack`,
+			without: `{job="api"}`,
+		},
+		{
+			name:    "unpack after line filter",
+			with:    `{job="api"} |= "packed" | unpack`,
+			without: `{job="api"} |= "packed"`,
+		},
+		{
+			name:    "unpack before label filter",
+			with:    `{job="api"} | unpack | level="error"`,
+			without: `{job="api"} | level="error"`,
+		},
+		{
+			name:    "pattern on bare selector",
+			with:    `{job="api"} | pattern "<ip> <_> <method> <path>"`,
+			without: `{job="api"}`,
+		},
+		{
+			name:    "pattern after line filter",
+			with:    `{job="api"} |= "GET" | pattern "<ip> <_> <method> <path>"`,
+			without: `{job="api"} |= "GET"`,
+		},
+		{
+			name:    "pattern before label filter",
+			with:    `{job="api"} | pattern "<_> <level> <msg>" | level="error"`,
+			without: `{job="api"} | level="error"`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gotWith := emitSQL(t, tc.with, s)
+			gotWithout := emitSQL(t, tc.without, s)
+			if gotWith != gotWithout {
+				t.Errorf("parser stage altered SQL\nwith stage:    %s\nwithout stage: %s",
+					gotWith, gotWithout)
+			}
+		})
+	}
+}
+
+// TestLowerUnpackPattern_StillRejectsOtherParsers pins that we didn't
+// accidentally light up `| json` / `| logfmt` / `| regexp` while
+// enabling unpack + pattern — those stay deferred to RC3.
+func TestLowerUnpackPattern_StillRejectsOtherParsers(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelLogs()
+	cases := []string{
+		`{job="api"} | json`,
+		`{job="api"} | logfmt`,
+		`{job="api"} | regexp "(?P<status>\\d+)"`,
+	}
+	for _, q := range cases {
+		t.Run(q, func(t *testing.T) {
+			t.Parallel()
+			expr, err := syntax.ParseExpr(q)
+			if err != nil {
+				t.Fatalf("ParseExpr: %v", err)
+			}
+			if _, err := logql.Lower(expr, s); err == nil {
+				t.Errorf("expected Lower(%q) to error; got nil", q)
+			}
+		})
+	}
+}
+
+// TestParserMalformedPattern — Loki's upstream parser is responsible
+// for rejecting malformed patterns (it panics inside ParseExpr with a
+// ParseError). Cerberus relies on that; the test pins the contract so
+// we notice if upstream relaxes it.
+func TestParserMalformedPattern(t *testing.T) {
+	t.Parallel()
+
+	// `bar` has no captures — invalid pattern per Loki's own rules.
+	_, err := syntax.ParseExpr(`{job="api"} | pattern "bar"`)
+	if err == nil {
+		t.Fatalf("expected ParseExpr to reject `| pattern \"bar\"`; got nil error")
+	}
+	if !strings.Contains(err.Error(), "pattern") {
+		t.Errorf("error message should mention `pattern`; got: %v", err)
+	}
+}
+
+func emitSQL(t *testing.T, q string, s schema.Logs) string {
+	t.Helper()
+	expr, err := syntax.ParseExpr(q)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", q, err)
+	}
+	plan, err := logql.Lower(expr, s)
+	if err != nil {
+		t.Fatalf("Lower(%q): %v", q, err)
+	}
+	sqlStr, _, err := chsql.Emit(plan)
+	if err != nil {
+		t.Fatalf("Emit(%q): %v", q, err)
+	}
+	return sqlStr
+}

--- a/test/spec/logql/pattern.txtar
+++ b/test/spec/logql/pattern.txtar
@@ -1,0 +1,7 @@
+-- query.logql --
+{job="api"} | pattern "<ip> <_> <method> <path>"
+-- args --
+[0] string = "job"
+[1] string = "api"
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_logs`) WHERE (`ResourceAttributes`[?] = ?)

--- a/test/spec/logql/pattern_after_line_filter.txtar
+++ b/test/spec/logql/pattern_after_line_filter.txtar
@@ -1,0 +1,8 @@
+-- query.logql --
+{job="api"} |= "GET" | pattern "<ip> <_> <method> <path>"
+-- args --
+[0] string = "job"
+[1] string = "api"
+[2] string = "GET"
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_logs`) WHERE ((`ResourceAttributes`[?] = ?) AND (position(`Body`, ?) > 0))

--- a/test/spec/logql/pattern_then_line_format.txtar
+++ b/test/spec/logql/pattern_then_line_format.txtar
@@ -1,0 +1,7 @@
+-- query.logql --
+{job="api"} | pattern "<ip> <_> <method> <path>" | line_format "{{.method}} {{.path}}"
+-- args --
+[0] string = "job"
+[1] string = "api"
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_logs`) WHERE (`ResourceAttributes`[?] = ?)

--- a/test/spec/logql/pattern_with_label_filter.txtar
+++ b/test/spec/logql/pattern_with_label_filter.txtar
@@ -1,0 +1,9 @@
+-- query.logql --
+{job="api"} | pattern "<_> <level> <msg>" | level="error"
+-- args --
+[0] string = "job"
+[1] string = "api"
+[2] string = "level"
+[3] string = "error"
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_logs`) WHERE ((`ResourceAttributes`[?] = ?) AND (`ResourceAttributes`[?] = ?))

--- a/test/spec/logql/unpack.txtar
+++ b/test/spec/logql/unpack.txtar
@@ -1,0 +1,7 @@
+-- query.logql --
+{job="api"} | unpack
+-- args --
+[0] string = "job"
+[1] string = "api"
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_logs`) WHERE (`ResourceAttributes`[?] = ?)

--- a/test/spec/logql/unpack_after_line_filter.txtar
+++ b/test/spec/logql/unpack_after_line_filter.txtar
@@ -1,0 +1,8 @@
+-- query.logql --
+{job="api"} |= "packed" | unpack
+-- args --
+[0] string = "job"
+[1] string = "api"
+[2] string = "packed"
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_logs`) WHERE ((`ResourceAttributes`[?] = ?) AND (position(`Body`, ?) > 0))

--- a/test/spec/logql/unpack_then_line_format.txtar
+++ b/test/spec/logql/unpack_then_line_format.txtar
@@ -1,0 +1,7 @@
+-- query.logql --
+{job="api"} | unpack | line_format "[{{.pod}}] {{__line__}}"
+-- args --
+[0] string = "job"
+[1] string = "api"
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_logs`) WHERE (`ResourceAttributes`[?] = ?)

--- a/test/spec/logql/unpack_with_label_filter.txtar
+++ b/test/spec/logql/unpack_with_label_filter.txtar
@@ -1,0 +1,9 @@
+-- query.logql --
+{job="api"} | unpack | level="error"
+-- args --
+[0] string = "job"
+[1] string = "api"
+[2] string = "level"
+[3] string = "error"
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_logs`) WHERE ((`ResourceAttributes`[?] = ?) AND (`ResourceAttributes`[?] = ?))


### PR DESCRIPTION
## Summary
- Adds LogQL `| unpack` and `| pattern` parser stages — both were rejected at lowering until now.
- `| unpack`: parses each line as a JSON object emitted by Promtail's `pack` stage. String-valued keys become labels; the special `_entry` key replaces the line. Non-JSON / non-object payloads pass through silently.
- `| pattern`: reuses Loki's own `log/pattern.Matcher`, so named-capture semantics (including `<_>` skips and inter-literal anchoring) match Loki exactly. Malformed pattern strings are rejected by upstream `ParseExpr` before lowering ever sees them.
- Both stages are post-fetch transforms, modelled the same way as `| line_format`, `| decolorize`, and `| label_format` — lowering returns no SQL impact, the loki handler's `postProcessExtract` stages a per-row transform.
- Captures / unpack keys that collide with a stream label get the `_extracted` suffix, mirroring Loki's disambiguation contract.
- No new chsql.Builder paths needed (parser stages don't emit SQL), so the RC6 raw-SQL ban doesn't apply here.

## Test plan
- [x] `go test ./internal/logql/...` passes (126 tests).
- [x] `go test ./test/spec/logql/...` (via `internal/logql/lower_test.go`) passes against 4 new unpack + 4 new pattern fixtures.
- [x] `go test ./internal/api/loki/...` passes — 8 new post-process tests (extract-labels-and-entry, duplicate-suffix disambiguation, non-JSON pass-through, non-string skip, named captures, partial capture, unpack→pattern compose).
- [x] `go vet ./internal/logql/... ./internal/api/loki/...` clean.
- [x] `gofumpt -l internal/` clean.
- [x] `golangci-lint run ./internal/logql/... ./internal/api/loki/...` 0 issues.
- [x] Full unit suite: `go test ./internal/... ./test/spec/...` — 803 passed in 13 packages.

Roadmap: [`docs/roadmap.md` line 109](docs/roadmap.md#L109) — RC2 LogQL `| unpack`, `| pattern`.