### PR TITLE
feat(deps): wire tsouza/tempo:cerberus-accessors fork via replace directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -224,3 +224,10 @@ require (
 )
 
 replace github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20260410131411-8c2f3bdae9db
+
+// Cerberus needs narrow accessors on top of grafana/tempo's pkg/traceql to
+// retire the unsafe.Pointer + reflect.FieldByName shims in
+// internal/traceql/. The fork (branch `cerberus-accessors`) is purely
+// additive and gets rebased onto each upstream tag we want to absorb. See
+// docs/fork-tempo-plan.md for the migration plan and accessor inventory.
+replace github.com/grafana/tempo => github.com/tsouza/tempo v0.0.0-20260513081550-403b5ff59697

--- a/go.sum
+++ b/go.sum
@@ -274,8 +274,6 @@ github.com/grafana/pyroscope-go/godeltaprof v0.1.9 h1:c1Us8i6eSmkW+Ez05d3co8kasn
 github.com/grafana/pyroscope-go/godeltaprof v0.1.9/go.mod h1:2+l7K7twW49Ct4wFluZD3tZ6e0SjanjcUUBPVD/UuGU=
 github.com/grafana/regexp v0.0.0-20250905093917-f7b3be9d1853 h1:cLN4IBkmkYZNnk7EAJ0BHIethd+J6LqxFNw5mSiI2bM=
 github.com/grafana/regexp v0.0.0-20250905093917-f7b3be9d1853/go.mod h1:+JKpmjMGhpgPL+rXZ5nsZieVzvarn86asRlBg4uNGnk=
-github.com/grafana/tempo v1.5.1-0.20260508211128-2f74ea818de1 h1:FXjxV1CDCrpRaSEwuCC8XyybzzpbXj+RAwNsSFf6nQk=
-github.com/grafana/tempo v1.5.1-0.20260508211128-2f74ea818de1/go.mod h1:tV3Pl9la00Ti1stc4RMsIa41zkx1i3mtxKKy13vXwt4=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 h1:HWRh5R2+9EifMyIHV7ZV+MIZqgz+PMpZ14Jynv3O2Zs=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0/go.mod h1:JfhWUomR1baixubs02l85lZYYOm7LV6om4ceouMv45c=
 github.com/hashicorp/consul/api v1.33.7 h1:apLZVzX7O7BLgHyh4pvczcsBzPmYSVXGKZQbOaA1ae0=
@@ -536,6 +534,8 @@ github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYI
 github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
 github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=
 github.com/tklauser/numcpus v0.11.0/go.mod h1:z+LwcLq54uWZTX0u/bGobaV34u6V7KNlTZejzM6/3MQ=
+github.com/tsouza/tempo v0.0.0-20260513081550-403b5ff59697 h1:fxUP0Bv6ZhrsZt35u9KXPVjTfJ2T+vZSYmczLdjK6n0=
+github.com/tsouza/tempo v0.0.0-20260513081550-403b5ff59697/go.mod h1:tV3Pl9la00Ti1stc4RMsIa41zkx1i3mtxKKy13vXwt4=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/uber/jaeger-client-go v2.30.0+incompatible h1:D6wyKGCecFaSRUpo8lCVbaOOb6ThwMmTEbhRwtKR97o=
 github.com/uber/jaeger-client-go v2.30.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=


### PR DESCRIPTION
## Summary

- Adds `replace github.com/grafana/tempo => github.com/tsouza/tempo v0.0.0-20260513081550-403b5ff59697` to `go.mod`.
- The fork (branch [`cerberus-accessors`](https://github.com/tsouza/tempo/tree/cerberus-accessors) at `403b5ff59697`) adds 11 narrow accessors + 1 docs note per `docs/fork-tempo-plan.md`.
- Cerberus side: zero behavioral change yet. Accessors land here so follow-up PRs #B (retire `unsafe.Pointer` shim) and #C (TraceQL MetricsPipeline lowering) can call them.

## Fork commits

11 accessor commits + 1 docs commit, each one accessor or one rename so they can be upstreamed individually:

1. `feat(traceql): expose Aggregate.InnerExpr() accessor`
2. `feat(traceql): expose Aggregate.Op() accessor`
3. `feat(traceql): export AggregateCount/Max/Min/Sum/Avg constants`
4. `feat(traceql): expose SelectOperation.Attrs() accessor`
5. `feat(traceql): export FirstStageElement interface (RootExpr.MetricsPipeline)`
6. `feat(traceql): export SecondStageElement interface (RootExpr.MetricsSecondStage)`
7. `feat(traceql): expose MetricsAggregate.Op() accessor`
8. `feat(traceql): expose MetricsAggregate.Attribute() accessor`
9. `feat(traceql): expose MetricsAggregate.GroupBy() accessor`
10. `feat(traceql): expose MetricsAggregate.Quantiles() accessor`
11. `feat(traceql): export MetricsAggregate* constants`
12. `docs: explain cerberus-accessors branch purpose`

Fork test suite (`go test ./pkg/traceql/...`) stayed green throughout: 2708 tests passing at HEAD.

## Notes

- The replace points at the **`cerberus-accessors` branch** via a pseudo-version. Future fork rebases produce new pseudo-versions, which Dependabot will pick up under the existing `upstream-parsers` grouping.
- Accessor enum aliases (`AggregateCount`, `MetricsAggregateRate`, etc.) preserve the underlying unexported constants so internal Tempo code is unchanged.
- Interface renames (`firstStageElement` -> `FirstStageElement`, `secondStageElement` -> `SecondStageElement`) touched 8 files inside `pkg/traceql/`; full Tempo module still builds clean.

## Test plan

- [ ] `go build ./...` passes locally and in CI (`check`).
- [ ] `go test ./internal/traceql/...` passes locally and in CI (`check`).
- [ ] `lint` green (no Go source files changed; only `go.mod` + `go.sum`).
- [ ] `dashboard` green (no behavior change expected).

Plan: [`docs/fork-tempo-plan.md`](https://github.com/tsouza/cerberus/blob/main/docs/fork-tempo-plan.md) (lands via #139). Fork: <https://github.com/tsouza/tempo/tree/cerberus-accessors>.