### PR TITLE
feat(promql): group_left/group_right cardinality + extra-label edges (RC2)

### DIFF
--- a/internal/chplan/node_test.go
+++ b/internal/chplan/node_test.go
@@ -93,6 +93,33 @@ func TestEqual(t *testing.T) {
 		t.Fatalf("VectorJoin: on(job) vs ignoring(job) should not be Equal")
 	}
 
+	// Card and Include must round-trip through Equal — the RC2
+	// cardinality-edge fields are observably different plans.
+	vjGroupLeft := *vjSame
+	vjGroupLeft.Card = chplan.CardManyToOne
+	vjGroupLeft.Include = []string{"env"}
+	vjGroupLeftSame := *vjSame
+	vjGroupLeftSame.Card = chplan.CardManyToOne
+	vjGroupLeftSame.Include = []string{"env"}
+	vjGroupRight := *vjSame
+	vjGroupRight.Card = chplan.CardOneToMany
+	vjGroupRight.Include = []string{"env"}
+	vjGroupLeftDiffInclude := *vjSame
+	vjGroupLeftDiffInclude.Card = chplan.CardManyToOne
+	vjGroupLeftDiffInclude.Include = []string{"region"}
+	if !vjGroupLeft.Equal(&vjGroupLeftSame) {
+		t.Fatalf("VectorJoin: identical group_left trees should be Equal")
+	}
+	if vjGroupLeft.Equal(&vjGroupRight) {
+		t.Fatalf("VectorJoin: group_left vs group_right should not be Equal")
+	}
+	if vjGroupLeft.Equal(&vjGroupLeftDiffInclude) {
+		t.Fatalf("VectorJoin: differing Include label sets should not be Equal")
+	}
+	if vj.Equal(&vjGroupLeft) {
+		t.Fatalf("VectorJoin: one-to-one vs group_left should not be Equal")
+	}
+
 	rw := &chplan.RangeWindow{
 		Input: &chplan.Scan{Table: "otel_metrics_sum"},
 		Func:  "rate",

--- a/internal/chplan/vector_join.go
+++ b/internal/chplan/vector_join.go
@@ -17,19 +17,59 @@ func (m VectorMatch) Equal(other VectorMatch) bool {
 	return m.On == other.On && slices.Equal(m.Labels, other.Labels)
 }
 
+// VectorCard captures the cardinality modifier on a PromQL vector-vector
+// binary expression — the `group_left` / `group_right` family.
+//
+// Default is one-to-one: each row on each side must match exactly one row
+// on the other side under the matching key. Many-to-one (`group_left`)
+// allows multiple rows on the left side to share one row on the right;
+// one-to-many (`group_right`) mirrors the other way. The chsql emitter
+// uses Card to shape its per-side aggregation + cardinality check;
+// `group_left(...)` / `group_right(...)` Include labels surface as extra
+// columns in the output via `Include`.
+type VectorCard int
+
+const (
+	// CardOneToOne is the default vector-matching cardinality: each
+	// matching-key value must appear at most once on each side. The
+	// emitter wraps each side with a runtime throwIf-count check so
+	// many-to-many ambiguity surfaces as a CH error rather than a
+	// silent cross-product.
+	CardOneToOne VectorCard = iota
+	// CardManyToOne is the `group_left` shape: the left side is the
+	// "many" and the right side is the "one". Include labels copy
+	// onto the output from the right side.
+	CardManyToOne
+	// CardOneToMany is the `group_right` shape: the right side is the
+	// "many" and the left side is the "one". Include labels copy onto
+	// the output from the left side.
+	CardOneToMany
+)
+
 // VectorJoin produces the per-pair binary-op result of matching two vector
 // inputs by labels. The emitter renders an INNER JOIN of per-series latest
 // samples (argMax(Value, TimeUnix) grouped by series-identity columns),
 // then evaluates `(L.Value <Op> R.Value)` on the joined rows.
 //
-// `group_left` / `group_right` (many-to-one / one-to-many) cardinality
-// modifiers are intentionally out of scope here and surface as a lowering
-// error from internal/promql.
+// Card + Include capture the `group_left(...)` / `group_right(...)`
+// cardinality modifier. Default (CardOneToOne, Include nil) is the
+// one-to-one match shape; the emitter enforces uniqueness on the
+// matching key at runtime via a throwIf-count guard. With CardManyToOne
+// the right side is the "one"; the emitter aggregates the right side by
+// the matching key (carrying the Include labels), and the output's
+// Attributes map merges the right's Include values onto the left's
+// Attributes. CardOneToMany mirrors the orientation.
 type VectorJoin struct {
 	Left  Node
 	Right Node
 	Op    BinaryOp
 	Match VectorMatch
+
+	// Card is the cardinality modifier; default CardOneToOne.
+	Card VectorCard
+	// Include is the `group_left(<labels>)` / `group_right(<labels>)`
+	// extra-label list. Nil/empty when no Include was specified.
+	Include []string
 
 	MetricNameColumn string
 	AttributesColumn string
@@ -47,6 +87,9 @@ func (v *VectorJoin) Equal(other Node) bool {
 		return false
 	}
 	if v.Op != o.Op || !v.Match.Equal(o.Match) {
+		return false
+	}
+	if v.Card != o.Card || !slices.Equal(v.Include, o.Include) {
 		return false
 	}
 	if v.MetricNameColumn != o.MetricNameColumn ||

--- a/internal/chsql/vector_join.go
+++ b/internal/chsql/vector_join.go
@@ -7,53 +7,75 @@ import (
 )
 
 // emitVectorJoin renders a PromQL vector-vector binary expression as an
-// INNER JOIN of per-series latest samples. Shape:
+// INNER JOIN of per-series latest samples. The shape depends on the
+// `Card` modifier:
 //
-//	SELECT
-//	    L.<MetricName>, L.<Attributes>, L.<TimeUnix>,
-//	    (L.<Value> <Op> R.<Value>) AS <Value>
-//	FROM (
-//	    SELECT <MetricName>, <Attributes>,
-//	           max(<TimeUnix>) AS <TimeUnix>,
-//	           argMax(<Value>, <TimeUnix>) AS <Value>
-//	    FROM (<left>) GROUP BY <MetricName>, <Attributes>
-//	) AS L
-//	INNER JOIN (
-//	    SELECT <MetricName>, <Attributes>,
-//	           max(<TimeUnix>) AS <TimeUnix>,
-//	           argMax(<Value>, <TimeUnix>) AS <Value>
-//	    FROM (<right>) GROUP BY <MetricName>, <Attributes>
-//	) AS R
-//	ON <match-key-on-L> = <match-key-on-R>
+//   - CardOneToOne (default): both sides aggregate to one row per
+//     matching key, with a `throwIf(uniqExact(Attributes) > 1, ...)`
+//     side-effect column that fails the query at execution time when
+//     the matching key collapses multiple distinct series ("many-to-
+//     many matching not allowed: matching labels must be unique on one
+//     side"). Output Attributes preserves the left side's full label
+//     set (one representative series per match key, picked via
+//     argMax(Attributes, TimeUnix)).
 //
-// The match-key expression depends on `Match`:
-//   - default (Labels empty, On false) → `L.Attributes = R.Attributes`
-//   - on(labels)                       → AND of `L.Attributes['lbl'] = R.Attributes['lbl']`
-//   - ignoring(labels)                 → mapFilter-stripped Attributes equality
+//   - CardManyToOne (`group_left(<labels>)`): left side keeps
+//     per-series granularity (the "many"); right side aggregates per
+//     matching key with the same uniqueness throwIf guard (the "one").
+//     Output Attributes = left.Attributes merged with right's Include
+//     labels overlaid via `mapConcat` — CH's later-key-wins map merge.
+//
+//   - CardOneToMany (`group_right(<labels>)`): mirror of CardManyToOne.
+//
+// All new SQL flows through chsql.Builder; the legacy emitter.b buffer
+// receives only the rendered fragments via splice.
 func (e *emitter) emitVectorJoin(j *chplan.VectorJoin) error {
 	if err := e.validateVectorJoinCols(j); err != nil {
 		return err
 	}
 
-	attrsCol := quoteIdent(j.AttributesColumn)
-	metricCol := quoteIdent(j.MetricNameColumn)
-	tsCol := quoteIdent(j.TimestampColumn)
-	valCol := quoteIdent(j.ValueColumn)
+	leftRole, rightRole := vectorJoinRoles(j)
+	outerSide := "L"
+	if j.Card == chplan.CardOneToMany {
+		// group_right — the "many" side is R; the output's
+		// representative MetricName + TimeUnix come from there.
+		outerSide = "R"
+	}
 
-	// Outer SELECT.
-	fmt.Fprintf(&e.b, "SELECT L.%s, L.%s, L.%s, (L.%s %s R.%s) AS %s FROM ",
-		metricCol, attrsCol, tsCol, valCol, string(j.Op), valCol, valCol)
+	// Outer SELECT prefix — composed via Builder, then spliced.
+	header := NewBuilder()
+	header.WriteSQL("SELECT ")
+	writeSideCol(header, outerSide, j.MetricNameColumn)
+	header.WriteSQL(", ")
+	writeOutputAttributes(header, j)
+	header.WriteSQL(", ")
+	writeSideCol(header, outerSide, j.TimestampColumn)
+	header.WriteSQL(", (")
+	writeSideCol(header, "L", j.ValueColumn)
+	header.WriteSQL(" " + string(j.Op) + " ")
+	writeSideCol(header, "R", j.ValueColumn)
+	header.WriteSQL(") AS ")
+	header.Ident(j.ValueColumn)
+	header.WriteSQL(" FROM ")
+	e.splice(header)
 
-	// Left side — argMax per series.
-	if err := e.emitLatestPerSeries(j.Left, metricCol, attrsCol, tsCol, valCol); err != nil {
+	// Left side — aggregation shape depends on its role.
+	if err := e.emitVectorJoinSide(j, j.Left, leftRole); err != nil {
 		return err
 	}
-	e.b.WriteString(" AS L INNER JOIN ")
-	if err := e.emitLatestPerSeries(j.Right, metricCol, attrsCol, tsCol, valCol); err != nil {
+	mid := NewBuilder()
+	mid.WriteSQL(" AS L INNER JOIN ")
+	e.splice(mid)
+
+	if err := e.emitVectorJoinSide(j, j.Right, rightRole); err != nil {
 		return err
 	}
-	e.b.WriteString(" AS R ON ")
-	return e.writeVectorMatchPredicate(j.Match, attrsCol)
+
+	tail := NewBuilder()
+	tail.WriteSQL(" AS R ON ")
+	writeVectorMatchPredicate(tail, j.Match, j.AttributesColumn)
+	e.splice(tail)
+	return nil
 }
 
 func (e *emitter) validateVectorJoinCols(j *chplan.VectorJoin) error {
@@ -70,62 +92,275 @@ func (e *emitter) validateVectorJoinCols(j *chplan.VectorJoin) error {
 	return nil
 }
 
-// emitLatestPerSeries wraps a subquery in a per-series latest aggregation:
-// (SELECT metric, attrs, max(ts) AS ts, argMax(value, ts) AS value FROM <n>
+// sideRole describes the per-side aggregation shape: "many" keeps
+// per-series granularity, "one" collapses to one row per matching key
+// with a runtime uniqueness guard.
+type sideRole int
+
+const (
+	// roleMany keeps per-series granularity: argMax over
+	// (MetricName, Attributes). Used for the "many" side of
+	// group_left/right, and for both sides of one-to-one when the
+	// matching key is the full Attributes map (uniqueness is then
+	// guaranteed by construction).
+	roleMany sideRole = iota
+	// roleOne collapses to one row per matching key with a runtime
+	// throwIf(uniqExact(Attributes) > 1, ...) guard. Used for the
+	// "one" side of group_left/right and for both sides of
+	// one-to-one when matching is on a subset of labels
+	// (on(...) / ignoring(...)) where many-to-many ambiguity is
+	// possible.
+	roleOne
+)
+
+// vectorJoinRoles resolves the per-side aggregation roles for the join.
 //
-//	GROUP BY metric, attrs).
-func (e *emitter) emitLatestPerSeries(n chplan.Node, metricCol, attrsCol, tsCol, valCol string) error {
-	e.b.WriteByte('(')
-	fmt.Fprintf(&e.b, "SELECT %s, %s, max(%s) AS %s, argMax(%s, %s) AS %s FROM ",
-		metricCol, attrsCol, tsCol, tsCol, valCol, tsCol, valCol)
+//   - CardManyToOne (`group_left`)   → L is many, R is one.
+//   - CardOneToMany (`group_right`)  → R is many, L is one.
+//   - CardOneToOne with subset match → both sides are "one"
+//     (uniqueness must be enforced at runtime).
+//   - CardOneToOne with full-Attributes match → both sides are
+//     "many"; the per-series aggregation already guarantees one row
+//     per matching key.
+func vectorJoinRoles(j *chplan.VectorJoin) (left, right sideRole) {
+	switch j.Card {
+	case chplan.CardManyToOne:
+		return roleMany, roleOne
+	case chplan.CardOneToMany:
+		return roleOne, roleMany
+	}
+	if len(j.Match.Labels) == 0 && !j.Match.On {
+		return roleMany, roleMany
+	}
+	return roleOne, roleOne
+}
+
+// emitVectorJoinSide renders one side of the join as a parenthesised
+// subquery. roleMany keeps per-series granularity (one row per
+// `(MetricName, Attributes)` group). roleOne collapses to one row
+// per matching key with a `throwIf(uniqExact(Attributes) > 1, ...)`
+// side-effect column — the "many-to-many matching not allowed"
+// Prometheus error surfaces at CH query-execution time rather than
+// as a silent cross-product.
+func (e *emitter) emitVectorJoinSide(j *chplan.VectorJoin, n chplan.Node, role sideRole) error {
+	b := NewBuilder()
+	b.WriteSQL("(SELECT ")
+	if role == roleMany {
+		b.Ident(j.MetricNameColumn)
+		b.WriteSQL(", ")
+		b.Ident(j.AttributesColumn)
+		b.WriteSQL(", max(")
+		b.Ident(j.TimestampColumn)
+		b.WriteSQL(") AS ")
+		b.Ident(j.TimestampColumn)
+		b.WriteSQL(", argMax(")
+		b.Ident(j.ValueColumn)
+		b.WriteSQL(", ")
+		b.Ident(j.TimestampColumn)
+		b.WriteSQL(") AS ")
+		b.Ident(j.ValueColumn)
+		b.WriteSQL(" FROM ")
+		e.splice(b)
+		if err := e.emitSubquery(n); err != nil {
+			return err
+		}
+		grp := NewBuilder()
+		grp.WriteSQL(" GROUP BY ")
+		grp.Ident(j.MetricNameColumn)
+		grp.WriteSQL(", ")
+		grp.Ident(j.AttributesColumn)
+		grp.WriteSQL(")")
+		e.splice(grp)
+		return nil
+	}
+
+	// "one" side — aggregate by matching key with a runtime uniqueness
+	// guard. argMax(Attributes, TimeUnix) picks one representative
+	// series per match key; throwIf fires when there's more than one.
+	b.WriteSQL("argMax(")
+	b.Ident(j.MetricNameColumn)
+	b.WriteSQL(", ")
+	b.Ident(j.TimestampColumn)
+	b.WriteSQL(") AS ")
+	b.Ident(j.MetricNameColumn)
+	b.WriteSQL(", argMax(")
+	b.Ident(j.AttributesColumn)
+	b.WriteSQL(", ")
+	b.Ident(j.TimestampColumn)
+	b.WriteSQL(") AS ")
+	b.Ident(j.AttributesColumn)
+	b.WriteSQL(", max(")
+	b.Ident(j.TimestampColumn)
+	b.WriteSQL(") AS ")
+	b.Ident(j.TimestampColumn)
+	b.WriteSQL(", argMax(")
+	b.Ident(j.ValueColumn)
+	b.WriteSQL(", ")
+	b.Ident(j.TimestampColumn)
+	b.WriteSQL(") AS ")
+	b.Ident(j.ValueColumn)
+	b.WriteSQL(", throwIf(uniqExact(")
+	b.Ident(j.AttributesColumn)
+	b.WriteSQL(") > 1, ")
+	b.Arg("many-to-many matching not allowed: matching labels must be unique on one side")
+	b.WriteSQL(") AS _cerberus_match_check FROM ")
+	e.splice(b)
 	if err := e.emitSubquery(n); err != nil {
 		return err
 	}
-	fmt.Fprintf(&e.b, " GROUP BY %s, %s)", metricCol, attrsCol)
+	grp := NewBuilder()
+	grp.WriteSQL(" GROUP BY ")
+	writeMatchKeyGroupExpr(grp, j.Match, j.AttributesColumn)
+	grp.WriteSQL(")")
+	e.splice(grp)
 	return nil
 }
 
-func (e *emitter) writeVectorMatchPredicate(m chplan.VectorMatch, attrsCol string) error {
-	// Default: full-Attributes equality.
+// writeMatchKeyGroupExpr emits the GROUP BY expression that collapses
+// rows onto a single matching key. For default matching (full
+// Attributes) this is just the Attributes column; for on(labels) it's
+// `mapFilter((k,v) -> k IN (...), Attributes)`; for ignoring(labels)
+// it's the complementary mapFilter.
+func writeMatchKeyGroupExpr(b *Builder, m chplan.VectorMatch, attrsCol string) {
 	if len(m.Labels) == 0 && !m.On {
-		fmt.Fprintf(&e.b, "L.%s = R.%s", attrsCol, attrsCol)
-		return nil
+		b.Ident(attrsCol)
+		return
 	}
-
+	if m.On && len(m.Labels) == 0 {
+		// on() with no labels — group everything onto a single
+		// match-key. CH doesn't allow an empty IN list, so emit a
+		// constant tuple.
+		b.WriteSQL("tuple()")
+		return
+	}
 	if m.On {
-		// on(l1, l2): conjunction of per-label key equalities.
+		b.WriteSQL("mapFilter((k, v) -> k IN (")
 		for i, lbl := range m.Labels {
 			if i > 0 {
-				e.b.WriteString(" AND ")
+				b.WriteSQL(", ")
 			}
-			fmt.Fprintf(&e.b, "L.%s[", attrsCol)
-			if err := e.bindArg(lbl); err != nil {
-				return err
-			}
-			fmt.Fprintf(&e.b, "] = R.%s[", attrsCol)
-			if err := e.bindArg(lbl); err != nil {
-				return err
-			}
-			e.b.WriteByte(']')
+			b.Arg(lbl)
 		}
-		return nil
+		b.WriteSQL("), ")
+		b.Ident(attrsCol)
+		b.WriteSQL(")")
+		return
+	}
+	b.MapFilterExcept(attrsCol, m.Labels...)
+}
+
+// writeOutputAttributes emits the output Attributes expression for the
+// join. For CardOneToOne the output equals L.Attributes. For
+// group_left(<labels>) the output merges the named labels from
+// R.Attributes onto L.Attributes via mapConcat (CH's later-key-wins
+// map merge). group_right mirrors with roles swapped.
+//
+// When no Include labels are present (bare `group_left` without an
+// explicit label list, which is uncommon but parser-legal), the
+// "many" side's Attributes flows through unchanged — this matches
+// Prometheus's behaviour where bare group_left/right copies nothing
+// beyond the matching key.
+func writeOutputAttributes(b *Builder, j *chplan.VectorJoin) {
+	manySide := ""
+	switch j.Card {
+	case chplan.CardManyToOne:
+		manySide = "L"
+	case chplan.CardOneToMany:
+		manySide = "R"
+	}
+	if manySide == "" || len(j.Include) == 0 {
+		// Either CardOneToOne or bare group_left/right — output is
+		// the "many" side's Attributes (L for OneToOne and ManyToOne,
+		// R for OneToMany).
+		side := "L"
+		if manySide == "R" {
+			side = "R"
+		}
+		writeSideCol(b, side, j.AttributesColumn)
+		return
 	}
 
-	// ignoring(l1, l2): mapFilter-stripped Attributes equality on each side.
-	for _, side := range []string{"L", "R"} {
-		if side == "R" {
-			e.b.WriteString(" = ")
+	// group_left/right with Include labels — overlay the "one" side's
+	// matching labels onto the "many" side's full Attributes. Use
+	// mapConcat: the later argument's keys overwrite the earlier's.
+	oneSide := "R"
+	if manySide == "R" {
+		oneSide = "L"
+	}
+	b.WriteSQL("mapConcat(")
+	writeSideCol(b, manySide, j.AttributesColumn)
+	b.WriteSQL(", mapFilter((k, v) -> k IN (")
+	for i, lbl := range j.Include {
+		if i > 0 {
+			b.WriteSQL(", ")
 		}
-		fmt.Fprintf(&e.b, "mapFilter((k, v) -> NOT (k IN (")
+		b.Arg(lbl)
+	}
+	b.WriteSQL("), ")
+	writeSideCol(b, oneSide, j.AttributesColumn)
+	b.WriteSQL(")) AS ")
+	b.Ident(j.AttributesColumn)
+}
+
+// writeSideCol emits `<side>.<col>` where <side> is the unquoted alias
+// (L or R) and <col> is the backtick-quoted column identifier. The
+// unquoted alias matches the legacy emitter's output so existing
+// fixtures that pre-date the Builder port stay stable.
+func writeSideCol(b *Builder, side, col string) {
+	b.WriteSQL(side)
+	b.WriteSQL(".")
+	b.Ident(col)
+}
+
+// writeVectorMatchPredicate emits the ON clause for the join.
+//
+//   - default (Labels empty, On false) → L.Attributes = R.Attributes
+//   - on(l1, l2)                       → AND of L.Attributes[k] = R.Attributes[k]
+//   - ignoring(l1, l2)                 → mapFilter-stripped equality
+func writeVectorMatchPredicate(b *Builder, m chplan.VectorMatch, attrsCol string) {
+	if len(m.Labels) == 0 && !m.On {
+		writeSideCol(b, "L", attrsCol)
+		b.WriteSQL(" = ")
+		writeSideCol(b, "R", attrsCol)
+		return
+	}
+	if m.On && len(m.Labels) == 0 {
+		// on() with no labels — every row on the left pairs with
+		// every row on the right. The per-side aggregation already
+		// collapses each side to one row via the throwIf-guard, so
+		// the join condition is just a constant TRUE.
+		b.WriteSQL("1 = 1")
+		return
+	}
+	if m.On {
 		for i, lbl := range m.Labels {
 			if i > 0 {
-				e.b.WriteString(", ")
+				b.WriteSQL(" AND ")
 			}
-			if err := e.bindArg(lbl); err != nil {
-				return err
-			}
+			writeSideCol(b, "L", attrsCol)
+			b.WriteSQL("[")
+			b.Arg(lbl)
+			b.WriteSQL("] = ")
+			writeSideCol(b, "R", attrsCol)
+			b.WriteSQL("[")
+			b.Arg(lbl)
+			b.WriteSQL("]")
 		}
-		fmt.Fprintf(&e.b, ")), %s.%s)", side, attrsCol)
+		return
 	}
-	return nil
+	for i, side := range []string{"L", "R"} {
+		if i == 1 {
+			b.WriteSQL(" = ")
+		}
+		b.WriteSQL("mapFilter((k, v) -> NOT (k IN (")
+		for j, lbl := range m.Labels {
+			if j > 0 {
+				b.WriteSQL(", ")
+			}
+			b.Arg(lbl)
+		}
+		b.WriteSQL(")), ")
+		writeSideCol(b, side, attrsCol)
+		b.WriteSQL(")")
+	}
 }

--- a/internal/promql/binary.go
+++ b/internal/promql/binary.go
@@ -19,10 +19,10 @@ import (
 //     the comparison (bool modifier off) or Project producing 1.0/0.0
 //     (bool modifier on)
 //   - vector OP vector → VectorJoin with default / `on(...)` /
-//     `ignoring(...)` matching (M1.6)
+//     `ignoring(...)` matching (M1.6) plus `group_left(...)` /
+//     `group_right(...)` cardinality modifiers (RC2 cardinality edges)
 //
-// `group_left` / `group_right` cardinality and logical ops (and/or/unless)
-// defer to M1.7 follow-ups.
+// Logical ops (`and`/`or`/`unless`) defer to a later milestone.
 func lowerBinary(b *parser.BinaryExpr, s schema.Metrics) (chplan.Node, error) {
 	op, err := promBinaryOp(b.Op)
 	if err != nil {
@@ -48,21 +48,42 @@ func lowerBinary(b *parser.BinaryExpr, s schema.Metrics) (chplan.Node, error) {
 // Node, and the result is a VectorJoin that the emitter renders as an
 // INNER JOIN of per-series latest samples.
 //
-// `group_left` / `group_right` are rejected here — cardinality enforcement
-// needs additional output-shape work and is intentionally deferred.
+// Cardinality modifiers (`group_left` / `group_right`) and Include labels
+// thread through to chplan.VectorJoin; the chsql emitter shapes the
+// per-side aggregation accordingly. `CardManyToMany` is rejected — the
+// parser only sets it for set operators (`and`/`or`/`unless`), which
+// promBinaryOp doesn't yet support anyway, but we surface a clean
+// "many-to-many matching not allowed" error to match Prometheus's wording
+// rather than the lower-level "binary op not yet supported".
 func lowerVectorVector(b *parser.BinaryExpr, s schema.Metrics, op chplan.BinaryOp) (chplan.Node, error) {
-	if b.VectorMatching != nil && (b.VectorMatching.Card == parser.CardManyToOne || b.VectorMatching.Card == parser.CardOneToMany) {
-		side := "left"
-		if b.VectorMatching.Card == parser.CardOneToMany {
-			side = "right"
-		}
-		return nil, fmt.Errorf("promql: group_%s vector matching is not yet supported (cardinality enforcement lands with M1.7 result shaping)", side)
-	}
-	if b.VectorMatching != nil && len(b.VectorMatching.Include) > 0 {
-		return nil, fmt.Errorf("promql: group_left/right with `include(...)` is not yet supported")
-	}
 	if b.ReturnBool {
 		return nil, fmt.Errorf("promql: 'bool' modifier on vector-vector binary ops is not yet supported")
+	}
+
+	card := chplan.CardOneToOne
+	var include []string
+	if b.VectorMatching != nil {
+		switch b.VectorMatching.Card {
+		case parser.CardOneToOne:
+			card = chplan.CardOneToOne
+		case parser.CardManyToOne:
+			card = chplan.CardManyToOne
+		case parser.CardOneToMany:
+			card = chplan.CardOneToMany
+		case parser.CardManyToMany:
+			return nil, fmt.Errorf("promql: many-to-many matching not allowed: matching labels must be unique on one side")
+		default:
+			return nil, fmt.Errorf("promql: unsupported vector-matching cardinality %d", b.VectorMatching.Card)
+		}
+		if len(b.VectorMatching.Include) > 0 {
+			if card == chplan.CardOneToOne {
+				return nil, fmt.Errorf("promql: many-to-many matching not allowed: matching labels must be unique on one side; use group_left/group_right when projecting include labels")
+			}
+			include = append([]string(nil), b.VectorMatching.Include...)
+		}
+		// group_left/right without explicit on/ignoring is allowed
+		// (matches the full-Attributes intersection, which the
+		// emitter's "many" aggregation handles by construction).
 	}
 
 	left, err := lower(b.LHS, s)
@@ -85,6 +106,8 @@ func lowerVectorVector(b *parser.BinaryExpr, s schema.Metrics, op chplan.BinaryO
 		Right:            right,
 		Op:               op,
 		Match:            match,
+		Card:             card,
+		Include:          include,
 		MetricNameColumn: s.MetricNameColumn,
 		AttributesColumn: s.AttributesColumn,
 		TimestampColumn:  s.TimestampColumn,

--- a/internal/promql/binary_test.go
+++ b/internal/promql/binary_test.go
@@ -11,10 +11,14 @@ import (
 	"github.com/tsouza/cerberus/internal/schema"
 )
 
-// TestLower_Binary_Errors covers the cases lowerBinary rejects today —
-// vector/vector (deferred to M1.6 vector matching), the `bool` modifier
-// on comparisons, and pure scalar/scalar (deferred until scalars are
-// first-class chplan nodes).
+// TestLower_Binary_Errors covers the binary-expression shapes lowerBinary
+// still rejects: pure scalar/scalar (deferred until scalars are first-class
+// chplan nodes), logical ops (`and`/`or`/`unless`, deferred to a later
+// milestone), and the `bool` modifier on vector-vector ops.
+//
+// group_left / group_right are no longer rejected — RC2 cardinality-edge
+// support added them with explicit cardinality enforcement; see
+// vector_match_test.go for the lowering coverage.
 func TestLower_Binary_Errors(t *testing.T) {
 	t.Parallel()
 
@@ -27,16 +31,6 @@ func TestLower_Binary_Errors(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name:    "group_left deferred",
-			query:   `up * on(job) group_left up`,
-			wantErr: "group_left vector matching is not yet supported",
-		},
-		{
-			name:    "group_right deferred",
-			query:   `up * on(job) group_right up`,
-			wantErr: "group_right vector matching is not yet supported",
-		},
-		{
 			name:    "scalar OP scalar deferred",
 			query:   `1 + 2`,
 			wantErr: "scalar-only binary expressions not yet lowered",
@@ -45,6 +39,11 @@ func TestLower_Binary_Errors(t *testing.T) {
 			name:    "logical and deferred",
 			query:   `up and up`,
 			wantErr: "binary op and not yet supported",
+		},
+		{
+			name:    "bool modifier on vector-vector rejected",
+			query:   `up == bool up`,
+			wantErr: "'bool' modifier on vector-vector binary ops is not yet supported",
 		},
 	}
 	for _, tc := range cases {

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -23,8 +23,7 @@ import (
 //
 // Deferred to RC3 / later milestones: nested subqueries, subquery
 // over AggregateExpr, subquery `@ start()`/`@ end()`, native-histogram
-// `histogram_quantile`, `predict_linear`/`holt_winters`,
-// `group_left`/`group_right` cardinality edges, exemplars.
+// `histogram_quantile`, `predict_linear`/`holt_winters`, exemplars.
 func Lower(expr parser.Expr, s schema.Metrics) (chplan.Node, error) {
 	return lower(expr, s)
 }

--- a/internal/promql/vector_match_test.go
+++ b/internal/promql/vector_match_test.go
@@ -1,0 +1,291 @@
+package promql_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestLower_VectorMatch_Cardinality covers the RC2 group_left /
+// group_right cardinality + extra-label edges:
+//
+//   - group_left(<labels>) populates chplan.VectorJoin.Card +
+//     Include and routes the named labels from the right side onto
+//     the output via mapConcat at SQL emission time.
+//   - group_right is the mirror.
+//   - One-to-one matching on a subset of labels (`on(...)` or
+//     `ignoring(...)`) embeds the runtime "many-to-many matching
+//     not allowed" guard via throwIf(uniqExact(Attributes) > 1, ...)
+//     so the cardinality violation surfaces as a CH error rather
+//     than a silent cross-product.
+//   - Default (full-Attributes) matching skips the runtime guard —
+//     uniqueness is guaranteed by construction.
+func TestLower_VectorMatch_Cardinality(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{})
+
+	t.Run("group_left populates Card + Include", func(t *testing.T) {
+		t.Parallel()
+		expr, err := p.ParseExpr(`up * on(job) group_left(env) info_metric`)
+		if err != nil {
+			t.Fatalf("ParseExpr: %v", err)
+		}
+		plan, err := promql.Lower(expr, s)
+		if err != nil {
+			t.Fatalf("Lower: %v", err)
+		}
+		vj, ok := plan.(*chplan.VectorJoin)
+		if !ok {
+			t.Fatalf("expected *chplan.VectorJoin, got %T", plan)
+		}
+		if vj.Card != chplan.CardManyToOne {
+			t.Errorf("Card = %v, want CardManyToOne", vj.Card)
+		}
+		if got, want := vj.Include, []string{"env"}; !equalStrings(got, want) {
+			t.Errorf("Include = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("group_right populates Card + Include (mirror)", func(t *testing.T) {
+		t.Parallel()
+		expr, err := p.ParseExpr(`info_metric * on(job) group_right(env) up`)
+		if err != nil {
+			t.Fatalf("ParseExpr: %v", err)
+		}
+		plan, err := promql.Lower(expr, s)
+		if err != nil {
+			t.Fatalf("Lower: %v", err)
+		}
+		vj, ok := plan.(*chplan.VectorJoin)
+		if !ok {
+			t.Fatalf("expected *chplan.VectorJoin, got %T", plan)
+		}
+		if vj.Card != chplan.CardOneToMany {
+			t.Errorf("Card = %v, want CardOneToMany", vj.Card)
+		}
+		if got, want := vj.Include, []string{"env"}; !equalStrings(got, want) {
+			t.Errorf("Include = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("group_left with multiple include labels", func(t *testing.T) {
+		t.Parallel()
+		expr, err := p.ParseExpr(`up * on(job) group_left(env, region) info_metric`)
+		if err != nil {
+			t.Fatalf("ParseExpr: %v", err)
+		}
+		plan, err := promql.Lower(expr, s)
+		if err != nil {
+			t.Fatalf("Lower: %v", err)
+		}
+		vj := plan.(*chplan.VectorJoin)
+		if got, want := vj.Include, []string{"env", "region"}; !equalStrings(got, want) {
+			t.Errorf("Include = %v, want %v", got, want)
+		}
+
+		sql, args, err := chsql.Emit(plan)
+		if err != nil {
+			t.Fatalf("Emit: %v", err)
+		}
+		// Include labels surface as a mapConcat overlay onto the
+		// left side's Attributes.
+		if !strings.Contains(sql, "mapConcat(L.`Attributes`, mapFilter((k, v) -> k IN (?, ?), R.`Attributes`))") {
+			t.Errorf("expected mapConcat overlay in SQL; got:\n%s", sql)
+		}
+		// Bound args carry both include labels.
+		argStrs := stringArgs(args)
+		if !containsAll(argStrs, []string{"env", "region"}) {
+			t.Errorf("expected args to include env + region; got %v", argStrs)
+		}
+	})
+
+	t.Run("on(...) one-to-one embeds runtime cardinality guard", func(t *testing.T) {
+		t.Parallel()
+		expr, err := p.ParseExpr(`up * on(job) up`)
+		if err != nil {
+			t.Fatalf("ParseExpr: %v", err)
+		}
+		plan, err := promql.Lower(expr, s)
+		if err != nil {
+			t.Fatalf("Lower: %v", err)
+		}
+		sql, args, err := chsql.Emit(plan)
+		if err != nil {
+			t.Fatalf("Emit: %v", err)
+		}
+		if !strings.Contains(sql, "throwIf(uniqExact(`Attributes`) > 1, ?)") {
+			t.Errorf("expected throwIf-uniqExact guard in SQL; got:\n%s", sql)
+		}
+		const wantMsg = "many-to-many matching not allowed: matching labels must be unique on one side"
+		argStrs := stringArgs(args)
+		if !containsAll(argStrs, []string{wantMsg}) {
+			t.Errorf("expected throwIf message in args; got %v", argStrs)
+		}
+	})
+
+	t.Run("ignoring(...) one-to-one embeds runtime cardinality guard", func(t *testing.T) {
+		t.Parallel()
+		expr, err := p.ParseExpr(`up - ignoring(instance) up`)
+		if err != nil {
+			t.Fatalf("ParseExpr: %v", err)
+		}
+		plan, err := promql.Lower(expr, s)
+		if err != nil {
+			t.Fatalf("Lower: %v", err)
+		}
+		sql, _, err := chsql.Emit(plan)
+		if err != nil {
+			t.Fatalf("Emit: %v", err)
+		}
+		if !strings.Contains(sql, "throwIf(uniqExact(`Attributes`) > 1, ?)") {
+			t.Errorf("expected throwIf-uniqExact guard in SQL; got:\n%s", sql)
+		}
+	})
+
+	t.Run("default full-Attributes match skips runtime guard", func(t *testing.T) {
+		t.Parallel()
+		expr, err := p.ParseExpr(`up + up`)
+		if err != nil {
+			t.Fatalf("ParseExpr: %v", err)
+		}
+		plan, err := promql.Lower(expr, s)
+		if err != nil {
+			t.Fatalf("Lower: %v", err)
+		}
+		sql, _, err := chsql.Emit(plan)
+		if err != nil {
+			t.Fatalf("Emit: %v", err)
+		}
+		// Per-series argMax by full Attributes guarantees uniqueness;
+		// no throwIf guard needed.
+		if strings.Contains(sql, "throwIf") {
+			t.Errorf("did not expect throwIf for full-Attributes match; got:\n%s", sql)
+		}
+	})
+
+	t.Run("group_left on the many side keeps per-series granularity", func(t *testing.T) {
+		t.Parallel()
+		expr, err := p.ParseExpr(`up * on(job) group_left(env) info_metric`)
+		if err != nil {
+			t.Fatalf("ParseExpr: %v", err)
+		}
+		plan, err := promql.Lower(expr, s)
+		if err != nil {
+			t.Fatalf("Lower: %v", err)
+		}
+		sql, _, err := chsql.Emit(plan)
+		if err != nil {
+			t.Fatalf("Emit: %v", err)
+		}
+		// The "many" (left) side aggregates over (MetricName, Attributes).
+		if !strings.Contains(sql, "GROUP BY `MetricName`, `Attributes`) AS L") {
+			t.Errorf("expected left side per-series aggregation; got:\n%s", sql)
+		}
+		// The "one" (right) side aggregates by the matching key with
+		// a uniqueness guard.
+		if !strings.Contains(sql, "throwIf(uniqExact(`Attributes`) > 1, ?)") {
+			t.Errorf("expected right-side cardinality guard; got:\n%s", sql)
+		}
+	})
+
+	t.Run("group_right swaps the per-side aggregation roles", func(t *testing.T) {
+		t.Parallel()
+		expr, err := p.ParseExpr(`info_metric * on(job) group_right(env) up`)
+		if err != nil {
+			t.Fatalf("ParseExpr: %v", err)
+		}
+		plan, err := promql.Lower(expr, s)
+		if err != nil {
+			t.Fatalf("Lower: %v", err)
+		}
+		sql, _, err := chsql.Emit(plan)
+		if err != nil {
+			t.Fatalf("Emit: %v", err)
+		}
+		// Right side is the "many" → per-series aggregation.
+		if !strings.Contains(sql, "GROUP BY `MetricName`, `Attributes`) AS R") {
+			t.Errorf("expected right side per-series aggregation; got:\n%s", sql)
+		}
+		// Output MetricName / TimeUnix come from R (the many side).
+		if !strings.Contains(sql, "SELECT R.`MetricName`,") {
+			t.Errorf("expected output to project R.MetricName; got:\n%s", sql)
+		}
+		if !strings.Contains(sql, "R.`TimeUnix`") {
+			t.Errorf("expected output to project R.TimeUnix; got:\n%s", sql)
+		}
+	})
+}
+
+// TestLower_VectorMatch_ManyToMany asserts that a CardManyToMany
+// VectorMatching (the parser-internal flag for set ops, but also
+// reachable when the upstream parser ever surfaces it for arithmetic)
+// errors with Prometheus's canonical "many-to-many matching not
+// allowed" wording. The arithmetic-op path never produces
+// CardManyToMany today; we drive the error path by hand-building a
+// BinaryExpr with the flag set.
+func TestLower_VectorMatch_ManyToMany(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{})
+
+	// Parse a vector/vector expression and tweak its VectorMatching.
+	expr, err := p.ParseExpr(`up + up`)
+	if err != nil {
+		t.Fatalf("ParseExpr: %v", err)
+	}
+	bin, ok := expr.(*parser.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *parser.BinaryExpr, got %T", expr)
+	}
+	bin.VectorMatching = &parser.VectorMatching{Card: parser.CardManyToMany}
+
+	if _, err := promql.Lower(expr, s); err == nil {
+		t.Fatal("expected many-to-many error, got nil")
+	} else if !strings.Contains(err.Error(), "many-to-many matching not allowed") {
+		t.Errorf("error %q does not contain 'many-to-many matching not allowed'", err.Error())
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func stringArgs(args []any) []string {
+	out := make([]string, 0, len(args))
+	for _, a := range args {
+		if s, ok := a.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func containsAll(haystack, needles []string) bool {
+	set := make(map[string]bool, len(haystack))
+	for _, h := range haystack {
+		set[h] = true
+	}
+	for _, n := range needles {
+		if !set[n] {
+			return false
+		}
+	}
+	return true
+}

--- a/test/spec/chsql/vector_join_ignoring_instance.txtar
+++ b/test/spec/chsql/vector_join_ignoring_instance.txtar
@@ -1,5 +1,9 @@
 -- sql --
-SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` - R.`Value`) AS `Value` FROM (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge`) GROUP BY `MetricName`, `Attributes`) AS L INNER JOIN (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT * FROM `otel_metrics_sum`) GROUP BY `MetricName`, `Attributes`) AS R ON mapFilter((k, v) -> NOT (k IN (?)), L.`Attributes`) = mapFilter((k, v) -> NOT (k IN (?)), R.`Attributes`)
+SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` - R.`Value`) AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT * FROM `otel_metrics_gauge`) GROUP BY mapFilter((k, v) -> NOT (k IN (?)), `Attributes`)) AS L INNER JOIN (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT * FROM `otel_metrics_sum`) GROUP BY mapFilter((k, v) -> NOT (k IN (?)), `Attributes`)) AS R ON mapFilter((k, v) -> NOT (k IN (?)), L.`Attributes`) = mapFilter((k, v) -> NOT (k IN (?)), R.`Attributes`)
 -- args --
-[0] string = "instance"
+[0] string = "many-to-many matching not allowed: matching labels must be unique on one side"
 [1] string = "instance"
+[2] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[3] string = "instance"
+[4] string = "instance"
+[5] string = "instance"

--- a/test/spec/chsql/vector_join_on_job.txtar
+++ b/test/spec/chsql/vector_join_on_job.txtar
@@ -1,5 +1,9 @@
 -- sql --
-SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` + R.`Value`) AS `Value` FROM (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge`) GROUP BY `MetricName`, `Attributes`) AS L INNER JOIN (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT * FROM `otel_metrics_sum`) GROUP BY `MetricName`, `Attributes`) AS R ON L.`Attributes`[?] = R.`Attributes`[?]
+SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` + R.`Value`) AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT * FROM `otel_metrics_gauge`) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`)) AS L INNER JOIN (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT * FROM `otel_metrics_sum`) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`)) AS R ON L.`Attributes`[?] = R.`Attributes`[?]
 -- args --
-[0] string = "job"
+[0] string = "many-to-many matching not allowed: matching labels must be unique on one side"
 [1] string = "job"
+[2] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[3] string = "job"
+[4] string = "job"
+[5] string = "job"

--- a/test/spec/chsql/vector_join_set_and.txtar
+++ b/test/spec/chsql/vector_join_set_and.txtar
@@ -1,5 +1,9 @@
 -- sql --
-SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` AND R.`Value`) AS `Value` FROM (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge`) GROUP BY `MetricName`, `Attributes`) AS L INNER JOIN (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT * FROM `otel_metrics_sum`) GROUP BY `MetricName`, `Attributes`) AS R ON L.`Attributes`[?] = R.`Attributes`[?]
+SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` AND R.`Value`) AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT * FROM `otel_metrics_gauge`) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`)) AS L INNER JOIN (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT * FROM `otel_metrics_sum`) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`)) AS R ON L.`Attributes`[?] = R.`Attributes`[?]
 -- args --
-[0] string = "job"
+[0] string = "many-to-many matching not allowed: matching labels must be unique on one side"
 [1] string = "job"
+[2] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[3] string = "job"
+[4] string = "job"
+[5] string = "job"

--- a/test/spec/promql/empty_on_join.txtar
+++ b/test/spec/promql/empty_on_join.txtar
@@ -1,7 +1,9 @@
 -- query.promql --
 up + on() up
 -- sql --
-SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` + R.`Value`) AS `Value` FROM (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?)) GROUP BY `MetricName`, `Attributes`) AS L INNER JOIN (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?)) GROUP BY `MetricName`, `Attributes`) AS R ON 
+SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` + R.`Value`) AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?)) GROUP BY tuple()) AS L INNER JOIN (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?)) GROUP BY tuple()) AS R ON 1 = 1
 -- args --
-[0] string = "up"
+[0] string = "many-to-many matching not allowed: matching labels must be unique on one side"
 [1] string = "up"
+[2] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[3] string = "up"

--- a/test/spec/promql/vector_group_left.txtar
+++ b/test/spec/promql/vector_group_left.txtar
@@ -1,0 +1,12 @@
+-- query.promql --
+http_requests_total * on(job) group_left(env) machine_role
+-- sql --
+SELECT L.`MetricName`, mapConcat(L.`Attributes`, mapFilter((k, v) -> k IN (?), R.`Attributes`)) AS `Attributes`, L.`TimeUnix`, (L.`Value` * R.`Value`) AS `Value` FROM (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_sum`) WHERE (`MetricName` = ?)) GROUP BY `MetricName`, `Attributes`) AS L INNER JOIN (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?)) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`)) AS R ON L.`Attributes`[?] = R.`Attributes`[?]
+-- args --
+[0] string = "env"
+[1] string = "http_requests_total"
+[2] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[3] string = "machine_role"
+[4] string = "job"
+[5] string = "job"
+[6] string = "job"

--- a/test/spec/promql/vector_group_left_ignoring.txtar
+++ b/test/spec/promql/vector_group_left_ignoring.txtar
@@ -1,0 +1,12 @@
+-- query.promql --
+http_requests_total * ignoring(instance) group_left(env) machine_role
+-- sql --
+SELECT L.`MetricName`, mapConcat(L.`Attributes`, mapFilter((k, v) -> k IN (?), R.`Attributes`)) AS `Attributes`, L.`TimeUnix`, (L.`Value` * R.`Value`) AS `Value` FROM (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_sum`) WHERE (`MetricName` = ?)) GROUP BY `MetricName`, `Attributes`) AS L INNER JOIN (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?)) GROUP BY mapFilter((k, v) -> NOT (k IN (?)), `Attributes`)) AS R ON mapFilter((k, v) -> NOT (k IN (?)), L.`Attributes`) = mapFilter((k, v) -> NOT (k IN (?)), R.`Attributes`)
+-- args --
+[0] string = "env"
+[1] string = "http_requests_total"
+[2] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[3] string = "machine_role"
+[4] string = "instance"
+[5] string = "instance"
+[6] string = "instance"

--- a/test/spec/promql/vector_group_left_multi_include.txtar
+++ b/test/spec/promql/vector_group_left_multi_include.txtar
@@ -1,0 +1,13 @@
+-- query.promql --
+http_requests_total * on(job) group_left(env, region) machine_role
+-- sql --
+SELECT L.`MetricName`, mapConcat(L.`Attributes`, mapFilter((k, v) -> k IN (?, ?), R.`Attributes`)) AS `Attributes`, L.`TimeUnix`, (L.`Value` * R.`Value`) AS `Value` FROM (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_sum`) WHERE (`MetricName` = ?)) GROUP BY `MetricName`, `Attributes`) AS L INNER JOIN (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?)) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`)) AS R ON L.`Attributes`[?] = R.`Attributes`[?]
+-- args --
+[0] string = "env"
+[1] string = "region"
+[2] string = "http_requests_total"
+[3] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[4] string = "machine_role"
+[5] string = "job"
+[6] string = "job"
+[7] string = "job"

--- a/test/spec/promql/vector_group_right.txtar
+++ b/test/spec/promql/vector_group_right.txtar
@@ -1,0 +1,12 @@
+-- query.promql --
+machine_role * on(job) group_right(env) http_requests_total
+-- sql --
+SELECT R.`MetricName`, mapConcat(R.`Attributes`, mapFilter((k, v) -> k IN (?), L.`Attributes`)) AS `Attributes`, R.`TimeUnix`, (L.`Value` * R.`Value`) AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?)) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`)) AS L INNER JOIN (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_sum`) WHERE (`MetricName` = ?)) GROUP BY `MetricName`, `Attributes`) AS R ON L.`Attributes`[?] = R.`Attributes`[?]
+-- args --
+[0] string = "env"
+[1] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[2] string = "machine_role"
+[3] string = "job"
+[4] string = "http_requests_total"
+[5] string = "job"
+[6] string = "job"

--- a/test/spec/promql/vector_ignoring_instance.txtar
+++ b/test/spec/promql/vector_ignoring_instance.txtar
@@ -1,9 +1,13 @@
 -- query.promql --
 http_server_request_duration_count - ignoring(instance) http_server_request_duration_count
 -- sql --
-SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` - R.`Value`) AS `Value` FROM (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_sum`) WHERE (`MetricName` = ?)) GROUP BY `MetricName`, `Attributes`) AS L INNER JOIN (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_sum`) WHERE (`MetricName` = ?)) GROUP BY `MetricName`, `Attributes`) AS R ON mapFilter((k, v) -> NOT (k IN (?)), L.`Attributes`) = mapFilter((k, v) -> NOT (k IN (?)), R.`Attributes`)
+SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` - R.`Value`) AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT * FROM (SELECT * FROM `otel_metrics_sum`) WHERE (`MetricName` = ?)) GROUP BY mapFilter((k, v) -> NOT (k IN (?)), `Attributes`)) AS L INNER JOIN (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT * FROM (SELECT * FROM `otel_metrics_sum`) WHERE (`MetricName` = ?)) GROUP BY mapFilter((k, v) -> NOT (k IN (?)), `Attributes`)) AS R ON mapFilter((k, v) -> NOT (k IN (?)), L.`Attributes`) = mapFilter((k, v) -> NOT (k IN (?)), R.`Attributes`)
 -- args --
-[0] string = "http_server_request_duration_count"
+[0] string = "many-to-many matching not allowed: matching labels must be unique on one side"
 [1] string = "http_server_request_duration_count"
 [2] string = "instance"
-[3] string = "instance"
+[3] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[4] string = "http_server_request_duration_count"
+[5] string = "instance"
+[6] string = "instance"
+[7] string = "instance"

--- a/test/spec/promql/vector_on_job.txtar
+++ b/test/spec/promql/vector_on_job.txtar
@@ -1,9 +1,13 @@
 -- query.promql --
 http_server_request_duration_count / on(job) http_server_request_duration_sum
 -- sql --
-SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` / R.`Value`) AS `Value` FROM (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_sum`) WHERE (`MetricName` = ?)) GROUP BY `MetricName`, `Attributes`) AS L INNER JOIN (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_sum`) WHERE (`MetricName` = ?)) GROUP BY `MetricName`, `Attributes`) AS R ON L.`Attributes`[?] = R.`Attributes`[?]
+SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` / R.`Value`) AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT * FROM (SELECT * FROM `otel_metrics_sum`) WHERE (`MetricName` = ?)) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`)) AS L INNER JOIN (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT * FROM (SELECT * FROM `otel_metrics_sum`) WHERE (`MetricName` = ?)) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`)) AS R ON L.`Attributes`[?] = R.`Attributes`[?]
 -- args --
-[0] string = "http_server_request_duration_count"
-[1] string = "http_server_request_duration_sum"
+[0] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[1] string = "http_server_request_duration_count"
 [2] string = "job"
-[3] string = "job"
+[3] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[4] string = "http_server_request_duration_sum"
+[5] string = "job"
+[6] string = "job"
+[7] string = "job"


### PR DESCRIPTION
## Summary
- Tightens vector-matching cardinality validation:
  - Errors on many-to-many at lowering time (`CardManyToMany` from
    the parser + `include(...)` without `group_left`/`group_right`)
    with Prometheus's canonical "matching labels must be unique on
    one side" wording.
  - Errors on the one-to-many edge at CH **query time** via an
    embedded `throwIf(uniqExact(Attributes) > 1, ...)` side-effect
    column on the "one" side of every `on(...)` / `ignoring(...)`
    match. Many-to-many ambiguity now surfaces as a CH error
    rather than as a silent cross-product.
- `group_left(<labels>)` projects the named labels from the right
  side onto the output's `Attributes` via `mapConcat` (CH's
  later-key-wins map merge). `group_right` mirrors the orientation
  — the output's `MetricName` + `TimeUnix` come from the right
  side, and Include labels overlay from the left.
- `chplan.VectorJoin` gains `Card` + `Include` fields; structural
  equality plus the optimizer-rule comparison machinery sees the
  new cardinality dimensions.
- All new SQL flows through `chsql.Builder` per the
  no-`fmt.Sprintf`-on-SQL hard rule (CLAUDE.md). The vector_join
  emitter is now Builder-native; the unported expression / subquery
  emitters still feed in via `splice`.

## Test plan
- [x] TXTAR fixtures cover one-to-one (`vector_plus_vector`,
      `vector_on_job`, `vector_ignoring_instance`), `on()` empty
      match (`empty_on_join`), `group_left` (`vector_group_left`,
      `vector_group_left_ignoring`,
      `vector_group_left_multi_include`), and `group_right`
      (`vector_group_right`).
- [x] `internal/promql/vector_match_test.go` unit-tests the
      lowering: Card + Include round-trip, group_left/right surface
      the runtime throwIf guard in SQL + args, default
      full-Attributes match skips the guard, and a hand-built
      `CardManyToMany` BinaryExpr surfaces the canonical error.
- [x] `go test ./...` (802 tests, all green) + `go vet ./...` +
      `gofumpt -l internal/`.

Roadmap: `docs/roadmap.md` RC2 PromQL (`group_left`/`group_right`
cardinality enforcement edge cases).