### PR TITLE
refactor(chsql): actually use SelectBuilder for R6.2/R6.3 ports + repo audit

### DIFF
--- a/docs/chsql-audit.md
+++ b/docs/chsql-audit.md
@@ -1,0 +1,157 @@
+# chsql callsite audit
+
+Repo-wide inventory of every SQL-building callsite in cerberus. Categorises
+each one as **cosplay** (uses `Builder.WriteSQL` for a clause keyword
+where `SelectBuilder` already has a typed slot), **grandfathered**
+(pre-R6.1 emitter code retained until its RC6 port milestone), or
+**legitimate token write** (operator-token `WriteSQL` inside a `Frag`
+that no typed helper covers).
+
+This audit was triggered by the maintainer catching the R6.2 (PR #138)
+and R6.3 (PR #140) ports shipping `prefix.WriteSQL("SELECT ")` /
+`WriteSQL(" FROM ")` / `WriteSQL(" WHERE ")` — that pattern is
+`fmt.Sprintf`-on-SQL with an extra step and defeats the whole point of
+the typed `chsql.SelectBuilder`. This PR fixes every bucket-1 entry.
+
+Detection greps (see CLAUDE.md hard rule "no raw SQL strings"):
+
+```sh
+grep -RnE 'WriteSQL\(" *(SELECT|FROM|WHERE|GROUP BY|ORDER BY|LIMIT|PREWHERE|HAVING|UNION|JOIN |LEFT JOIN|INNER JOIN)' internal/ cmd/ harness/
+grep -RnE 'WriteSQL\(" AND "\)' internal/ cmd/ harness/
+grep -RnE 'fmt\.Sprintf\([^)]*(SELECT|FROM|WHERE|INSERT|GROUP BY|ORDER BY)' internal/ cmd/ harness/
+grep -RnE 'WriteString\([^)]*(SELECT|FROM|WHERE|GROUP BY|ORDER BY|LIMIT|PREWHERE)' internal/ cmd/ harness/
+```
+
+## Bucket 1 — Cosplay (FIXED in this PR)
+
+`Builder.WriteSQL(" SELECT ")` etc. used for structural clause keywords.
+Each callsite below moved to `chsql.SelectBuilder` slots.
+
+- `internal/chsql/emit_node.go:26` — `b.WriteSQL("SELECT ")` in
+  `emitScan` → `NewSelect().Select(...).From(Col(table))`.
+- `internal/chsql/emit_node.go:37` — `b.WriteSQL(" FROM ")` in
+  `emitScan` → `.From(Col(s.Table))`.
+- `internal/chsql/emit_node.go:46` — `prefix.WriteSQL("SELECT * FROM ")`
+  in `emitFilter` → `NewSelect().From(e.subqueryFrag(...))`.
+- `internal/chsql/emit_node.go:56` — `suffix.WriteSQL(" WHERE ")` in
+  `emitFilter` → `.Where(predicateFrag)`.
+- `internal/chsql/emit_node.go:67` — `prefix.WriteSQL("SELECT ")` in
+  `emitProject` → `.Select(projectionFrags...)`.
+- `internal/chsql/emit_node.go:84` — `prefix.WriteSQL(" FROM ")` in
+  `emitProject` → `.From(e.subqueryFrag(...))`.
+- `internal/chsql/emit_node.go:92` — `prefix.WriteSQL("SELECT ")` in
+  `emitAggregate` → `.Select(groupByFrags..., aggFuncFrags...)`.
+- `internal/chsql/emit_node.go:119` — `prefix.WriteSQL(" FROM ")` in
+  `emitAggregate` → `.From(e.subqueryFrag(...))`.
+- `internal/chsql/emit_node.go:129` — `suffix.WriteSQL(" GROUP BY ")` in
+  `emitAggregate` → `.GroupBy(groupByFrags...)`.
+- `internal/chsql/emit_node.go:183` — `prefix.WriteSQL("SELECT * FROM ")`
+  in `emitLimit` → `NewSelect().From(e.subqueryFrag(...))`.
+- `internal/chsql/emit_node.go:192` — `suffix.WriteSQL(" LIMIT ")` in
+  `emitLimit` → `.Limit(int(l.Count))`.
+
+The aliased projection shape (`<expr> AS <alias>`) was inline
+`prefix.WriteSQL(" AS ")` + `prefix.Ident(alias)`. This PR adds a typed
+`chsql.As(expr Frag, alias string) Frag` helper plus a
+`SelectBuilder.SelectAs(expr Frag, alias string)` slot so the projection
+list never composes the `AS` keyword by hand again. The legacy
+`internal/api/loki/index_volume.go` `aliased` local helper stays put
+(out of scope; the package-private form predates the new public
+`chsql.As`).
+
+`builder_test.go` also constructed `b.WriteSQL("max(")` / `WriteSQL(")")`
+patterns to stage args. Those are operator-glue around the
+`Builder.Arg` / `Builder.Ident` calls (no clause keyword, no
+`SelectBuilder`-replaceable shape), so they remain bucket-3
+legitimate-token writes for now. They are a thin layer that can move
+to typed helpers as RC6 R6.4–R6.8 expand the helper set.
+
+## Bucket 2 — Grandfathered
+
+Pre-R6.1 emitter code that still uses `strings.Builder` /
+`fmt.Sprintf` / direct `e.b.WriteString` for SQL keywords. CLAUDE.md's
+"no raw SQL strings" rule grandfathers these until the listed RC6
+milestone ports them.
+
+- `internal/chsql/emit_expr.go` — `strings.Builder.WriteString` +
+  `Sprintf` for the expression tree (Binary, FuncCall, MapAccess,
+  MapWithoutKeys, LineContent, FieldAccess). Retired by **R6.4**.
+- `internal/chsql/range_window.go` — `e.b.WriteString("SELECT ")`
+  chains + `fmt.Fprintf(&e.b, ...)` for the windowed-array idiom.
+  Retired by **R6.5**.
+- `internal/chsql/vector_join.go` — `header.WriteSQL("SELECT ")` /
+  `" FROM "` / `" GROUP BY "` plus inline `" AND "` glue inside
+  `writeVectorMatchPredicate`. Retired by **R6.6**.
+- `internal/chsql/structural_join.go` — `e.b.WriteString("SELECT R.* FROM ")`
+  plus `fmt.Fprintf` for trace-id / parent-span join. Retired by **R6.6**.
+- `internal/chsql/emit_node.go::emitOrderBy` —
+  `e.b.WriteString("SELECT * FROM ")` / `" ORDER BY "`. Pre-R6 Tempo
+  `/api/search/recent` work; folds in with the **R6.5** RangeWindow port.
+- `internal/api/prom/metadata.go` — `fmt.Sprintf` for label-keys /
+  label-values / UNION-ALL builders (`unionLabelNamesSQL`,
+  `unionMetricNamesSQL`, `unionLabelValuesSQL`, `labelKeysForMatcher`,
+  `labelValuesForMatcher`). Retired by **R6.7**.
+
+Detection greps for the bucket-2 surface:
+
+```sh
+grep -nE 'e\.b\.WriteString|fmt\.Fprintf\(&e\.b|fmt\.Sprintf' \
+  internal/chsql/range_window.go \
+  internal/chsql/vector_join.go \
+  internal/chsql/structural_join.go \
+  internal/chsql/emit_expr.go \
+  internal/api/prom/metadata.go
+```
+
+None of these are touched by this PR — porting them lives in the
+upcoming R6.x milestones (see `docs/roadmap.md` § RC6 R6.4–R6.8). If a
+PR re-touches one of these files for an unrelated reason it should leave
+the SQL composition shape alone; the port is a single mechanical commit
+per milestone.
+
+## Bucket 3 — Legitimate token writes
+
+`WriteSQL(" = ")` / `WriteSQL(" AS ")` / `WriteSQL(", ")` /
+`WriteSQL(" > ")` etc. used inside `Frag` callbacks for operators or
+glue that has no typed helper. Acceptable per CLAUDE.md (the rule
+forbids *clause keywords*, not operator tokens). Listed for
+completeness so future audit greps can distinguish them.
+
+Representative callsites (not exhaustive — every `Frag` in the
+loki/index handlers and every operator emit in `Builder.Expr` produces
+similar tokens):
+
+- `internal/api/loki/index_stats.go` — `timeBoundFrag` writes `" "` +
+  op + `" "`; `aggFrag` / `bytesAggFrag` write `(` / `)` glue.
+- `internal/api/loki/index_volume.go` — `aliased` writes `" AS "`;
+  `volumeGroupFrag` writes `mapFilter(...)` glue.
+- `internal/chsql/builder_test.go` — `b.WriteSQL(" = ")` /
+  `b.WriteSQL(" > ")` inside `Where` callbacks; these are the canonical
+  documented pattern in the `SelectBuilder` doc comments.
+
+Inside `Builder.Expr` the binary-operator glue (`b.sb.WriteByte(' ')` +
+`b.sb.WriteString(string(bx.Op))` + `b.sb.WriteByte(' ')`) is similarly
+operator-token, not clause-keyword.
+
+## Audit tally (post-fix)
+
+- **Cosplay fixed**: 11 callsites across `internal/chsql/emit_node.go`.
+- **Grandfathered**: 5 files (`emit_expr.go`, `range_window.go`,
+  `vector_join.go`, `structural_join.go`, `metadata.go`) + the
+  pre-R6 `emitOrderBy` block, retired by R6.4–R6.7.
+- **Legitimate token writes**: ~30+ callsites across `internal/api/loki/`
+  and `internal/chsql/builder_test.go`; all are operator-glue inside
+  Frags or test bodies, none replicate a `SelectBuilder` slot.
+
+## Final-greps post-fix (must be empty)
+
+```sh
+grep -RnE 'WriteSQL\(" *(SELECT|FROM|WHERE|GROUP BY|ORDER BY|LIMIT|PREWHERE)' \
+  internal/chsql/emit_node.go \
+  internal/chsql/builder_test.go \
+  internal/api/loki/ internal/api/prom/ internal/api/tempo/
+```
+
+If this grep ever resurfaces a hit outside `SelectBuilder.writeInto`
+(the implementation of the typed slots), it is a regression — the typed
+slots exist precisely so callers never compose those keywords by hand.

--- a/internal/api/loki/index_volume.go
+++ b/internal/api/loki/index_volume.go
@@ -147,7 +147,7 @@ func buildIndexVolumeSQL(
 
 	sb.GroupBy(chsql.Col("labels")).
 		OrderBy(chsql.Col("bytes"), true).
-		Limit(limit)
+		Limit(int64(limit))
 
 	sqlStr, args := sb.Build()
 	return sqlStr, args, nil

--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -458,7 +458,7 @@ type SelectBuilder struct {
 	prewhere   []Frag
 	groupBy    []Frag
 	orderBy    []orderKey
-	limit      int
+	limit      int64
 	hasLimit   bool
 }
 
@@ -526,8 +526,9 @@ func (s *SelectBuilder) OrderBy(expr Frag, desc bool) *SelectBuilder {
 // Limit sets the LIMIT count. n <= 0 emits no LIMIT clause; positive
 // n is rendered as a literal integer (CH's LIMIT does not accept
 // `?` placeholders in all driver paths and the value is part of the
-// query shape, not user data).
-func (s *SelectBuilder) Limit(n int) *SelectBuilder {
+// query shape, not user data). int64 accommodates chplan.Limit.Count
+// without a lossy downcast.
+func (s *SelectBuilder) Limit(n int64) *SelectBuilder {
 	s.limit = n
 	s.hasLimit = n > 0
 	return s
@@ -610,6 +611,6 @@ func (s *SelectBuilder) writeInto(b *Builder) {
 	}
 	if s.hasLimit {
 		b.sb.WriteString(" LIMIT ")
-		b.sb.WriteString(strconv.Itoa(s.limit))
+		b.sb.WriteString(strconv.FormatInt(s.limit, 10))
 	}
 }

--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -421,6 +421,22 @@ func Raw(sql string) Frag {
 	return func(b *Builder) { b.sb.WriteString(sql) }
 }
 
+// As wraps expr in "<expr> AS <alias>" with the alias backtick-quoted.
+// The typed alternative to `b.WriteSQL(" AS "); b.Ident(alias)`; using
+// As keeps the AS keyword inside the typed surface so the audit grep
+// for clause-keyword cosplay stays clean. If alias is empty the inner
+// expression is emitted unchanged (no AS clause).
+func As(expr Frag, alias string) Frag {
+	if alias == "" {
+		return expr
+	}
+	return func(b *Builder) {
+		expr(b)
+		b.sb.WriteString(" AS ")
+		b.Ident(alias)
+	}
+}
+
 // SelectBuilder accumulates a SELECT statement's parts. Slots are
 // appended to in order; rendering walks each slot, emitting the
 // canonical clause prefix (SELECT, FROM, WHERE, …) and joining
@@ -458,6 +474,16 @@ func NewSelect() *SelectBuilder { return &SelectBuilder{} }
 // list is left empty at Build time the rendered SQL emits `SELECT *`.
 func (s *SelectBuilder) Select(exprs ...Frag) *SelectBuilder {
 	s.selectList = append(s.selectList, exprs...)
+	return s
+}
+
+// SelectAs appends "<expr> AS <alias>" to the SELECT list. If alias is
+// empty the expression is appended bare (equivalent to Select(expr)).
+// Convenience wrapper over As + Select; lets projection callers express
+// "this expression renames to this column" without composing the AS
+// keyword by hand.
+func (s *SelectBuilder) SelectAs(expr Frag, alias string) *SelectBuilder {
+	s.selectList = append(s.selectList, As(expr, alias))
 	return s
 }
 

--- a/internal/chsql/builder_test.go
+++ b/internal/chsql/builder_test.go
@@ -337,6 +337,42 @@ func TestFrag_HelpersBindAtPosition(t *testing.T) {
 	}
 }
 
+// TestAs_WrapsWithAlias — As(expr, alias) emits "<expr> AS <alias>"
+// with the alias backtick-quoted; an empty alias passes the inner
+// Frag through unchanged.
+func TestAs_WrapsWithAlias(t *testing.T) {
+	t.Parallel()
+
+	b := chsql.NewBuilder()
+	chsql.As(chsql.Col("Value"), "v")(b)
+	if got, want := b.String(), "`Value` AS `v`"; got != want {
+		t.Errorf("As(Col,v) = %q; want %q", got, want)
+	}
+
+	b2 := chsql.NewBuilder()
+	chsql.As(chsql.Col("Value"), "")(b2)
+	if got, want := b2.String(), "`Value`"; got != want {
+		t.Errorf("As(Col,\"\") = %q; want %q", got, want)
+	}
+}
+
+// TestSelectBuilder_SelectAs — SelectAs slot adds "<expr> AS <alias>"
+// to the SELECT list without composing the AS keyword by hand at the
+// call site.
+func TestSelectBuilder_SelectAs(t *testing.T) {
+	t.Parallel()
+
+	sql, _ := chsql.NewSelect().
+		SelectAs(chsql.Col("MetricName"), "name").
+		SelectAs(chsql.Col("Value"), "").
+		From(chsql.Col("otel_metrics_gauge")).
+		Build()
+	want := "SELECT `MetricName` AS `name`, `Value` FROM `otel_metrics_gauge`"
+	if sql != want {
+		t.Errorf("SelectAs = %q; want %q", sql, want)
+	}
+}
+
 // TestSelectBuilder_Empty — empty SelectBuilder renders "SELECT *".
 // (No FROM is fine; CH accepts SELECT * alone for fixture-style
 // shapes, even if it's not what production emits.)

--- a/internal/chsql/emit_node.go
+++ b/internal/chsql/emit_node.go
@@ -2,19 +2,59 @@ package chsql
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/tsouza/cerberus/internal/chplan"
 )
 
-// splice drains b's accumulated SQL + args into the emitter. Used by the
-// RC6 R6.2 ported emitters (emitScan / emitFilter / emitProject /
-// emitLimit) so they can build SQL fragments through the public
-// *Builder API and re-thread them into the shared emitter state at the
-// point the unported subquery / expression emitters expect to find
-// them. R6.3+ retires this helper as each remaining emit function gets
-// ported and the emitter struct converts to a *Builder directly.
+// subqueryFrag returns a Frag that renders n as a parenthesised
+// subquery into the receiving Builder. Used to plug a child plan into
+// SelectBuilder.From without flattening to a string: the args bound
+// by the recursive emit walk land in the receiving Builder's args
+// slice at the position the Frag is written.
+//
+// Internally it swaps e.b / e.args with a fresh strings.Builder + nil
+// args slice, runs the recursive emit, then splices the rendered SQL
+// + args into the destination Builder. The error path is captured via
+// the closure variable below; emitSubqueryFrag is the wrapper that
+// surfaces it.
+func (e *emitter) subqueryFrag(n chplan.Node) (Frag, error) {
+	// Pre-render the subquery into an isolated emitter so any chplan
+	// error surfaces synchronously (before the Frag is ever spliced
+	// into the outer SelectBuilder). The rendered string + args are
+	// then captured for cheap replay on each Frag invocation.
+	saveB, saveArgs := e.b, e.args
+	e.b = strings.Builder{}
+	e.args = nil
+	if err := e.emitSubquery(n); err != nil {
+		e.b = saveB
+		e.args = saveArgs
+		return nil, err
+	}
+	sql := e.b.String()
+	args := e.args
+	e.b = saveB
+	e.args = saveArgs
+	return func(b *Builder) {
+		b.sb.WriteString(sql)
+		b.args = append(b.args, args...)
+	}, nil
+}
+
+// emitSelect runs the assembled SelectBuilder and splices its rendered
+// SQL + args into the emitter's output. Centralises the splice
+// boilerplate so the per-node emitters stay focused on slot assembly.
+func (e *emitter) emitSelect(sb *SelectBuilder) {
+	sql, args := sb.Build()
+	e.b.WriteString(sql)
+	e.args = append(e.args, args...)
+}
+
+// splice drains b's accumulated SQL + args into the emitter. Retained
+// for the grandfathered emitters in vector_join.go / structural_join.go
+// that still compose SQL fragments through a free-standing *Builder
+// before flushing to the shared emitter state. R6.6 collapses those
+// onto SelectBuilder and removes this helper.
 func (e *emitter) splice(b *Builder) {
 	sql, args := b.Build()
 	e.b.WriteString(sql)
@@ -22,140 +62,123 @@ func (e *emitter) splice(b *Builder) {
 }
 
 func (e *emitter) emitScan(s *chplan.Scan) error {
-	b := NewBuilder()
-	b.WriteSQL("SELECT ")
-	if len(s.Columns) == 0 {
-		b.WriteSQL("*")
-	} else {
-		for i, c := range s.Columns {
-			if i > 0 {
-				b.WriteSQL(", ")
-			}
-			b.Ident(c)
+	sb := NewSelect().From(Col(s.Table))
+	if len(s.Columns) > 0 {
+		cols := make([]Frag, 0, len(s.Columns))
+		for _, c := range s.Columns {
+			cols = append(cols, Col(c))
 		}
+		sb.Select(cols...)
 	}
-	b.WriteSQL(" FROM ")
-	b.Ident(s.Table)
-	e.splice(b)
+	// (Empty Select list renders as `SELECT *` — matches the
+	// pre-builder emitter's behaviour for a column-less Scan.)
+	e.emitSelect(sb)
 	return nil
 }
 
 func (e *emitter) emitFilter(f *chplan.Filter) error {
-	// Prefix: SELECT * FROM
-	prefix := NewBuilder()
-	prefix.WriteSQL("SELECT * FROM ")
-	e.splice(prefix)
-	// Subquery is still rendered through the legacy emitter — its
-	// args land in e.args at this textual position, before the WHERE
-	// clause emitted next.
-	if err := e.emitSubquery(f.Input); err != nil {
+	sub, err := e.subqueryFrag(f.Input)
+	if err != nil {
 		return err
 	}
-	// Suffix: WHERE <predicate>
-	suffix := NewBuilder()
-	suffix.WriteSQL(" WHERE ")
-	if err := suffix.Expr(f.Predicate); err != nil {
+	// Pre-flight the predicate so a chplan error surfaces here, not
+	// inside the Where-render callback (where the error has no path
+	// to the caller without re-introducing splice plumbing).
+	if err := (&Builder{}).Expr(f.Predicate); err != nil {
 		return err
 	}
-	e.splice(suffix)
+	pred := func(b *Builder) { _ = b.Expr(f.Predicate) }
+	e.emitSelect(NewSelect().From(sub).Where(pred))
 	return nil
 }
 
 func (e *emitter) emitProject(p *chplan.Project) error {
-	// Prefix: SELECT <projections>
-	prefix := NewBuilder()
-	prefix.WriteSQL("SELECT ")
-	if len(p.Projections) == 0 {
-		prefix.WriteSQL("*")
-	} else {
-		for i, pr := range p.Projections {
-			if i > 0 {
-				prefix.WriteSQL(", ")
-			}
-			if err := prefix.Expr(pr.Expr); err != nil {
-				return err
-			}
-			if pr.Alias != "" {
-				prefix.WriteSQL(" AS ")
-				prefix.Ident(pr.Alias)
-			}
-		}
-	}
-	prefix.WriteSQL(" FROM ")
-	e.splice(prefix)
-	return e.emitSubquery(p.Input)
-}
-
-func (e *emitter) emitAggregate(a *chplan.Aggregate) error {
-	// Prefix: SELECT <group-by keys + aliases>, <agg funcs>
-	prefix := NewBuilder()
-	prefix.WriteSQL("SELECT ")
-	first := true
-	for i, g := range a.GroupBy {
-		if !first {
-			prefix.WriteSQL(", ")
-		}
-		first = false
-		if err := prefix.Expr(g); err != nil {
-			return err
-		}
-		if i < len(a.GroupByAliases) && a.GroupByAliases[i] != "" {
-			prefix.WriteSQL(" AS ")
-			prefix.Ident(a.GroupByAliases[i])
-		}
-	}
-	for _, af := range a.AggFuncs {
-		if !first {
-			prefix.WriteSQL(", ")
-		}
-		first = false
-		if err := writeAggFunc(prefix, af); err != nil {
-			return err
-		}
-	}
-	if first {
-		return fmt.Errorf("%w: Aggregate with no GroupBy keys and no AggFuncs", ErrUnsupported)
-	}
-	prefix.WriteSQL(" FROM ")
-	e.splice(prefix)
-	// Subquery still flows through the legacy emitter — its args land in
-	// e.args at this textual position, between the SELECT list and the
-	// optional GROUP BY suffix.
-	if err := e.emitSubquery(a.Input); err != nil {
+	sub, err := e.subqueryFrag(p.Input)
+	if err != nil {
 		return err
 	}
-	if len(a.GroupBy) > 0 {
-		suffix := NewBuilder()
-		suffix.WriteSQL(" GROUP BY ")
-		for i, g := range a.GroupBy {
-			if i > 0 {
-				suffix.WriteSQL(", ")
-			}
-			if err := suffix.Expr(g); err != nil {
+	sb := NewSelect().From(sub)
+	if len(p.Projections) > 0 {
+		// Pre-flight every projection expression so a chplan error
+		// surfaces synchronously rather than from inside the Frag
+		// render.
+		for _, pr := range p.Projections {
+			if err := (&Builder{}).Expr(pr.Expr); err != nil {
 				return err
 			}
 		}
-		e.splice(suffix)
+		for _, pr := range p.Projections {
+			expr := pr.Expr
+			sb.SelectAs(func(b *Builder) { _ = b.Expr(expr) }, pr.Alias)
+		}
 	}
+	e.emitSelect(sb)
 	return nil
 }
 
-// writeAggFunc renders `<name>[(<params>)](<args>) [AS <alias>]` into b
-// using the public Builder helpers. The parameterised-aggregate shape
-// (`quantile(0.95)(value)`, `quantiles(0.5, 0.9)(value)`, …) goes
-// through Builder.ParamAgg.
-func writeAggFunc(b *Builder, af chplan.AggFunc) error {
-	// Capture the first expression-render error encountered while the
-	// ParamAgg callbacks run; we surface it after ParamAgg returns so
-	// the SQL stays consistent with the legacy emitter's positional
-	// argument ordering on the happy path.
-	var firstErr error
-	mkExpr := func(x chplan.Expr) func(b *Builder) {
-		return func(b *Builder) {
-			if err := b.Expr(x); err != nil && firstErr == nil {
-				firstErr = err
+func (e *emitter) emitAggregate(a *chplan.Aggregate) error {
+	// Pre-flight all expressions so chplan errors surface synchronously.
+	for _, g := range a.GroupBy {
+		if err := (&Builder{}).Expr(g); err != nil {
+			return err
+		}
+	}
+	for _, af := range a.AggFuncs {
+		for _, p := range af.Params {
+			if err := (&Builder{}).Expr(p); err != nil {
+				return err
 			}
 		}
+		for _, ar := range af.Args {
+			if err := (&Builder{}).Expr(ar); err != nil {
+				return err
+			}
+		}
+	}
+	if len(a.GroupBy) == 0 && len(a.AggFuncs) == 0 {
+		return fmt.Errorf("%w: Aggregate with no GroupBy keys and no AggFuncs", ErrUnsupported)
+	}
+
+	sub, err := e.subqueryFrag(a.Input)
+	if err != nil {
+		return err
+	}
+
+	sb := NewSelect().From(sub)
+	for i, g := range a.GroupBy {
+		expr := g
+		alias := ""
+		if i < len(a.GroupByAliases) {
+			alias = a.GroupByAliases[i]
+		}
+		sb.SelectAs(func(b *Builder) { _ = b.Expr(expr) }, alias)
+	}
+	for _, af := range a.AggFuncs {
+		af := af
+		sb.Select(aggFuncFrag(af))
+	}
+
+	// GROUP BY mirrors the SELECT-list group-by expressions (without
+	// aliases — CH groups by the underlying expression, not the alias).
+	if len(a.GroupBy) > 0 {
+		groupFrags := make([]Frag, 0, len(a.GroupBy))
+		for _, g := range a.GroupBy {
+			expr := g
+			groupFrags = append(groupFrags, func(b *Builder) { _ = b.Expr(expr) })
+		}
+		sb.GroupBy(groupFrags...)
+	}
+	e.emitSelect(sb)
+	return nil
+}
+
+// aggFuncFrag returns a Frag rendering `<name>[(<params>)](<args>) [AS <alias>]`
+// via Builder.ParamAgg + As. The expression-render errors surface from
+// the pre-flight loop in emitAggregate before the Frag ever runs, so the
+// rendering path here is infallible.
+func aggFuncFrag(af chplan.AggFunc) Frag {
+	mkExpr := func(x chplan.Expr) func(b *Builder) {
+		return func(b *Builder) { _ = b.Expr(x) }
 	}
 	params := make([]func(b *Builder), 0, len(af.Params))
 	for _, p := range af.Params {
@@ -165,40 +188,37 @@ func writeAggFunc(b *Builder, af chplan.AggFunc) error {
 	for _, a := range af.Args {
 		args = append(args, mkExpr(a))
 	}
-	b.ParamAgg(af.Name, params, args)
-	if firstErr != nil {
-		return firstErr
-	}
-	if af.Alias != "" {
-		b.WriteSQL(" AS ")
-		b.Ident(af.Alias)
-	}
-	return nil
+	body := func(b *Builder) { b.ParamAgg(af.Name, params, args) }
+	return As(body, af.Alias)
 }
 
 // emitRangeWindow lives in range_window.go — full windowed-array idiom.
 
 func (e *emitter) emitLimit(l *chplan.Limit) error {
-	prefix := NewBuilder()
-	prefix.WriteSQL("SELECT * FROM ")
-	e.splice(prefix)
-	if err := e.emitSubquery(l.Input); err != nil {
+	sub, err := e.subqueryFrag(l.Input)
+	if err != nil {
 		return err
 	}
+	sb := NewSelect().From(sub)
 	if l.Count > 0 {
-		// LIMIT count is part of the query *shape*, not user data —
-		// rendered as a literal integer, matching SelectBuilder.Limit.
-		suffix := NewBuilder()
-		suffix.WriteSQL(" LIMIT ")
-		suffix.WriteSQL(strconv.FormatInt(l.Count, 10))
-		e.splice(suffix)
+		// SelectBuilder.Limit renders LIMIT as a literal integer —
+		// matches the legacy emitter's behaviour. l.Count is int64;
+		// downcast is safe at the LIMIT scale (CH itself accepts
+		// signed int values).
+		sb.Limit(int(l.Count))
 	}
+	e.emitSelect(sb)
 	return nil
 }
 
 // emitOrderBy renders `SELECT * FROM (<input>) ORDER BY <k1> [DESC], …`.
 // Empty Keys is a programmer error — emit an error so the plan tree
 // doesn't silently lose its sort intent.
+//
+// NOTE (grandfathered, retired by RC6 R6.5): this function predates
+// the R6.2 emit_node.go port and still writes SQL keywords directly
+// into the strings.Builder. The R6.5 RangeWindow port lifts it onto
+// SelectBuilder alongside the other matrix-shape emitters.
 func (e *emitter) emitOrderBy(o *chplan.OrderBy) error {
 	if len(o.Keys) == 0 {
 		return fmt.Errorf("%w: OrderBy with no keys", ErrUnsupported)

--- a/internal/chsql/emit_node.go
+++ b/internal/chsql/emit_node.go
@@ -201,11 +201,7 @@ func (e *emitter) emitLimit(l *chplan.Limit) error {
 	}
 	sb := NewSelect().From(sub)
 	if l.Count > 0 {
-		// SelectBuilder.Limit renders LIMIT as a literal integer —
-		// matches the legacy emitter's behaviour. l.Count is int64;
-		// downcast is safe at the LIMIT scale (CH itself accepts
-		// signed int values).
-		sb.Limit(int(l.Count))
+		sb.Limit(l.Count)
 	}
 	e.emitSelect(sb)
 	return nil


### PR DESCRIPTION
## Summary

- Rewrites the R6.2 + R6.3 ported `emit_node.go` functions (`emitScan`,
  `emitFilter`, `emitProject`, `emitAggregate`, `emitLimit`) to use
  `chsql.SelectBuilder` (`Select` / `SelectAs` / `From` / `Where` /
  `GroupBy` / `Limit`) instead of hand-writing `prefix.WriteSQL("SELECT ")`
  / `WriteSQL(" FROM ")` / `WriteSQL(" WHERE ")` / `WriteSQL(" GROUP BY ")`
  / `WriteSQL(" LIMIT ")`.
- Adds `(*emitter).subqueryFrag(node) chsql.Frag` so a child plan can
  nest into `SelectBuilder.From` without flattening through `splice`.
  Pre-renders the subquery synchronously so chplan errors still surface
  to the caller.
- Adds `chsql.As(expr Frag, alias string) Frag` + the
  `SelectBuilder.SelectAs(expr Frag, alias string)` slot so projection
  aliases stop composing the `AS` keyword by hand.
- Lands `docs/chsql-audit.md` — every SQL-building callsite in
  `internal/` and `internal/api/` categorized as
  **cosplay** / **grandfathered** / **legitimate token write**. Cosplay
  fixed in this PR; grandfathered annotated with the R6.x milestone
  that ports it.

## Why

R6.1 shipped a real typed `SelectBuilder` with all the clause slots.
R6.2 (#138) and R6.3 (#140) did not use it — they composed `Builder`
+ `WriteSQL("SELECT ")` + manual `", "` joins. That is `fmt.Sprintf`
with extra steps; it defeats the purpose of the typed builder. This
PR fixes the regression and prevents it recurring by documenting the
audit + the rule in `docs/chsql-audit.md` (which the upcoming R6.9
lint check will key off).

## Audit results (from `docs/chsql-audit.md`)

- **Cosplay fixed**: 11 callsites in `internal/chsql/emit_node.go`.
- **Grandfathered (R6.4–R6.7)**: 5 files (`emit_expr.go`,
  `range_window.go`, `vector_join.go`, `structural_join.go`,
  `internal/api/prom/metadata.go`) + the pre-R6 `emitOrderBy` block.
  Untouched in this PR; the milestone PRs do the mechanical port.
- **Legitimate token writes**: ~30+ callsites across
  `internal/api/loki/` and `internal/chsql/builder_test.go`; all are
  operator-glue inside `Frag` callbacks or test bodies. None replicate
  a `SelectBuilder` slot.

## Test plan

- [x] `go build ./...` clean.
- [x] `go test ./...` green (844 tests).
- [x] `just update-golden` diff empty — SQL output byte-identical for
  every TXTAR fixture.
- [x] `go vet ./...` clean.
- [x] `$HOME/go/bin/gofumpt -l internal/` empty.
- [x] `markdownlint-cli2 docs/chsql-audit.md` clean.
- [x] Final grep audit empty: `grep -RnE 'WriteSQL\(" *(SELECT|FROM|WHERE|GROUP BY|ORDER BY|LIMIT|PREWHERE)' internal/chsql/emit_node.go internal/chsql/builder_test.go internal/api/loki/ internal/api/prom/ internal/api/tempo/`