### PR TITLE
refactor(traceql): retire unsafe.Pointer + reflect shims via tsouza/tempo accessors

### DIFF
--- a/internal/traceql/aggregate.go
+++ b/internal/traceql/aggregate.go
@@ -1,9 +1,11 @@
+// This file (and select.go) read parser AST nodes exclusively via the
+// upstream-fork-exposed accessors on github.com/tsouza/tempo:cerberus-accessors
+// — no reflection, no pointer aliasing tricks. See docs/fork-tempo-plan.md.
+
 package traceql
 
 import (
 	"fmt"
-	"reflect"
-	"unsafe"
 
 	"github.com/grafana/tempo/pkg/traceql"
 
@@ -14,15 +16,11 @@ import (
 // lowerAggregate handles `| count()`, `| sum(...)`, `| avg(...)`,
 // `| max(...)`, `| min(...)`. count() has no inner expression — we
 // aggregate the constant 1 per row. The other four read the inner
-// FieldExpression from Tempo's unexported `e` field via the
-// readAggregateExpr unsafe shim (see comment below for the why).
+// FieldExpression via the upstream-fork-exposed Aggregate.InnerExpr()
+// accessor (github.com/tsouza/tempo:cerberus-accessors) — see
+// docs/fork-tempo-plan.md.
 func lowerAggregate(prev chplan.Node, agg traceql.Aggregate, s schema.Traces) (chplan.Node, error) {
-	op := readAggregateFields(agg)
-	if op == "" {
-		return nil, fmt.Errorf("traceql: aggregate operator not extractable from parser AST")
-	}
-
-	chFunc, err := mapAggregateOp(op)
+	chFunc, err := mapAggregateOp(agg.Op())
 	if err != nil {
 		return nil, err
 	}
@@ -30,7 +28,7 @@ func lowerAggregate(prev chplan.Node, agg traceql.Aggregate, s schema.Traces) (c
 	const valueAlias = "Value"
 
 	// count() takes no inner expression — aggregate a constant.
-	if op == "count" {
+	if agg.Op() == traceql.AggregateCount {
 		return &chplan.Aggregate{
 			Input: prev,
 			AggFuncs: []chplan.AggFunc{{
@@ -41,13 +39,11 @@ func lowerAggregate(prev chplan.Node, agg traceql.Aggregate, s schema.Traces) (c
 		}, nil
 	}
 
-	// sum/avg/max/min — extract the inner FieldExpression and lower it.
-	inner, err := readAggregateExpr(agg)
-	if err != nil {
-		return nil, err
-	}
+	// sum/avg/max/min — read the inner FieldExpression via the fork
+	// accessor and lower it.
+	inner := agg.InnerExpr()
 	if inner == nil {
-		return nil, fmt.Errorf("traceql: aggregate `%s` has nil inner expression", op)
+		return nil, fmt.Errorf("traceql: aggregate `%s` has nil inner expression", agg.Op())
 	}
 	arg, err := lowerFieldExpr(inner, s)
 	if err != nil {
@@ -64,77 +60,20 @@ func lowerAggregate(prev chplan.Node, agg traceql.Aggregate, s schema.Traces) (c
 	}, nil
 }
 
-// readAggregateExpr reads Tempo's unexported `e` field on a
-// traceql.Aggregate. Tempo doesn't ship an accessor (no `Expr()`
-// method, no public field) and reflect.Value.Interface() panics on
-// unexported fields, so we take the value's address and reconstruct a
-// typed pointer through unsafe.Pointer.
-//
-// Safe because: agg is passed by value, so &agg is a valid pointer to
-// a local for this function's lifetime; the field offset is fixed by
-// the pinned Tempo dependency in go.mod; the read is type-safe
-// (FieldExpression is an interface, same width as the underlying
-// itab+data tuple).
-func readAggregateExpr(agg traceql.Aggregate) (traceql.FieldExpression, error) {
-	v := reflect.ValueOf(&agg).Elem()
-	field := v.FieldByName("e")
-	if !field.IsValid() {
-		return nil, fmt.Errorf("traceql: Aggregate has no `e` field (Tempo internal layout changed?)")
-	}
-	// #nosec G103 — intentional unsafe.Pointer to read Tempo's unexported
-	// FieldExpression field. Safety justification is documented above.
-	ptr := unsafe.Pointer(field.UnsafeAddr())
-	expr := *(*traceql.FieldExpression)(ptr)
-	return expr, nil
-}
-
-// readAggregateFields reflects Aggregate's unexported `op` field.
-// Tempo's parser doesn't expose an accessor (no Op() method, no public
-// field), so we map the enum's int value back to its name via the
-// fixed iota order in aggregateOpName.
-//
-// The companion `e` field (inner FieldExpression) is read via
-// readAggregateExpr below — same unexported-field problem, harder shim.
-func readAggregateFields(agg traceql.Aggregate) string {
-	v := reflect.ValueOf(agg)
-	if v.Kind() != reflect.Struct {
-		return ""
-	}
-	opField := v.FieldByName("op")
-	if !opField.IsValid() {
-		return ""
-	}
-	return aggregateOpName(opField.Int())
-}
-
-// aggregateOpName mirrors Tempo's enum_aggregates.go iota order:
-//
-//	count(0), max(1), min(2), sum(3), avg(4)
-//
-// It's the only safe way to map back since the constants are
-// unexported.
-func aggregateOpName(i int64) string {
-	switch i {
-	case 0:
-		return "count"
-	case 1:
-		return "max"
-	case 2:
-		return "min"
-	case 3:
-		return "sum"
-	case 4:
-		return "avg"
-	}
-	return ""
-}
-
-// mapAggregateOp turns a TraceQL aggregate op name into the CH agg
-// function name. count / max / min / sum / avg map 1:1.
-func mapAggregateOp(op string) (string, error) {
+// mapAggregateOp turns a TraceQL AggregateOp into the CH agg function
+// name. count / max / min / sum / avg map 1:1.
+func mapAggregateOp(op traceql.AggregateOp) (string, error) {
 	switch op {
-	case "count", "max", "min", "sum", "avg":
-		return op, nil
+	case traceql.AggregateCount:
+		return "count", nil
+	case traceql.AggregateMax:
+		return "max", nil
+	case traceql.AggregateMin:
+		return "min", nil
+	case traceql.AggregateSum:
+		return "sum", nil
+	case traceql.AggregateAvg:
+		return "avg", nil
 	}
 	return "", fmt.Errorf("traceql: aggregate op %q is not yet supported", op)
 }

--- a/internal/traceql/select.go
+++ b/internal/traceql/select.go
@@ -1,8 +1,10 @@
+// See aggregate.go for the no-reflection / no-pointer-aliasing rule
+// covering this file.
+
 package traceql
 
 import (
 	"fmt"
-	"reflect"
 
 	"github.com/grafana/tempo/pkg/traceql"
 
@@ -11,19 +13,17 @@ import (
 )
 
 // lowerSelect handles `| select(.attr1, .attr2, ...)` projection.
-// Tempo's SelectOperation keeps its attribute list on an unexported
-// field; we reflect over it to read the slice elements without
-// calling .Interface() (which panics on unexported fields).
+// The attribute list is read via the upstream-fork-exposed
+// SelectOperation.Attrs() accessor
+// (github.com/tsouza/tempo:cerberus-accessors) — see
+// docs/fork-tempo-plan.md.
 //
 // Output: a chplan.Project that emits the standard span-identity
 // columns (TraceId, SpanId, Timestamp) plus the selected attribute
 // expressions, so downstream search results can render exactly the
 // columns the caller asked for.
 func lowerSelect(prev chplan.Node, sel traceql.SelectOperation, s schema.Traces) (chplan.Node, error) {
-	attrs, err := readSelectAttrs(sel, s)
-	if err != nil {
-		return nil, err
-	}
+	attrs := sel.Attrs()
 	if len(attrs) == 0 {
 		return nil, fmt.Errorf("traceql: `| select(...)` requires at least one attribute")
 	}
@@ -43,40 +43,4 @@ func lowerSelect(prev chplan.Node, sel traceql.SelectOperation, s schema.Traces)
 		})
 	}
 	return &chplan.Project{Input: prev, Projections: projections}, nil
-}
-
-// readSelectAttrs reflects out SelectOperation's unexported `attrs`
-// slice. We iterate via reflect.Value.Index() and read each Attribute's
-// exported fields (Name, Scope, Parent, Intrinsic) directly — no
-// .Interface() call so the unexported-field protection doesn't fire.
-func readSelectAttrs(sel traceql.SelectOperation, _ schema.Traces) ([]traceql.Attribute, error) {
-	v := reflect.ValueOf(sel)
-	if v.Kind() != reflect.Struct {
-		return nil, fmt.Errorf("traceql: SelectOperation is not a struct (parser changed?)")
-	}
-	field := v.FieldByName("attrs")
-	if !field.IsValid() {
-		return nil, fmt.Errorf("traceql: SelectOperation.attrs not extractable from parser AST")
-	}
-
-	out := make([]traceql.Attribute, field.Len())
-	for i := 0; i < field.Len(); i++ {
-		elem := field.Index(i)
-		// AttributeScope and Intrinsic are int8 on Tempo's side; reflect
-		// hands us int64 from .Int() — narrowing is safe here (the values
-		// are bounded enums) but gosec flags the conversion. The bounds
-		// check below makes the narrowing explicit.
-		scope := elem.FieldByName("Scope").Int()
-		intrinsic := elem.FieldByName("Intrinsic").Int()
-		if scope < -128 || scope > 127 || intrinsic < -128 || intrinsic > 127 {
-			return nil, fmt.Errorf("traceql: SelectOperation Attribute fields out of int8 range — parser changed?")
-		}
-		out[i] = traceql.Attribute{
-			Name:      elem.FieldByName("Name").String(),
-			Scope:     traceql.AttributeScope(int8(scope)),
-			Parent:    elem.FieldByName("Parent").Bool(),
-			Intrinsic: traceql.Intrinsic(int8(intrinsic)),
-		}
-	}
-	return out, nil
 }


### PR DESCRIPTION
## Summary
- `internal/traceql/aggregate.go`: replaces `readAggregateExpr` (unsafe.Pointer reading Aggregate.e) with `Aggregate.InnerExpr()`; replaces reflect-based operator lookup with `Aggregate.Op()` + typed `traceql.Aggregate{Count,Max,Min,Sum,Avg}` constants. `unsafe` import dropped; the iota-indexed `aggregateOpName` table deleted.
- `internal/traceql/select.go`: replaces the `reflect.Value.FieldByName("attrs")` loop with `op.Attrs()`. `reflect` import dropped.
- Net diff: +34 / -131 (net -97 LoC). All TXTAR fixtures byte-identical.
- This is PR #B from `docs/fork-tempo-plan.md` — accessors live on the fork branch `tsouza/tempo:cerberus-accessors`, wired via `go.mod` replace landed in #143.

## Test plan
- [x] `go test ./internal/traceql/...` passes.
- [x] `grep -RIn 'unsafe' internal/traceql/` returns empty (the project-wide goal of the no-unsafe rule).
- [x] `just update-golden` produces zero diff.

## Why
Maintainer rule (2026-05-13): no new `unsafe.Pointer` shims against upstream parser unexported fields. The plan was to fork upstream Tempo, add narrow exported accessors, and retire the shims. The fork is live (PR #143); this PR is the consumer-side retirement.

Follow-ups: PR #C (TraceQL MetricsPipeline lowering — `rate() / *_over_time() → RangeWindow(Aggregate(Scan(traces)))`) is the next milestone; PR #D adds a `forbidigo` lint gate banning `unsafe.Pointer` regression in `internal/traceql/`.