### PR TITLE
feat(api/tempo): /api/search/tags + /api/search/tag/<name>/values (RC2)

### DIFF
--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -23,15 +23,20 @@ import (
 
 // Querier is the subset of *chclient.Client the Handler needs. Stub
 // shape mirrors api/prom + api/loki for the same test reasons.
+//
+// QueryStrings backs the /api/search/tags + /api/search/tag/<name>/values
+// endpoints, which expect a single-string-column result rather than the
+// chclient.Sample shape.
 type Querier interface {
 	Query(ctx context.Context, sql string, args ...any) ([]chclient.Sample, error)
+	QueryStrings(ctx context.Context, sql string, args ...any) ([]string, error)
 }
 
 // Handler implements the Tempo HTTP API endpoints cerberus speaks.
-// Mount it via Handler.Mount(mux). The current vertical slice covers
-// /api/echo, /api/status/version, /api/search, and /api/traces/<id>.
-// /api/search/tags + /api/search/tag/<n>/values defer to RC6's
-// sqlbuilder integration so the new SQL avoids Sprintf.
+// Mount it via Handler.Mount(mux). The current surface covers
+// /api/echo, /api/status/version, /api/search, /api/search/recent,
+// /api/search/tags, /api/search/tag/{name}/values (plus the V2
+// variants under /api/v2/), and /api/traces/{id}.
 type Handler struct {
 	Client    Querier
 	Schema    schema.Traces
@@ -63,6 +68,10 @@ func (h *Handler) Mount(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/status/version", h.handleVersion)
 	mux.HandleFunc("GET /api/search", h.handleSearch)
 	mux.HandleFunc("GET /api/search/recent", h.handleSearchRecent)
+	mux.HandleFunc("GET /api/search/tags", h.handleSearchTags)
+	mux.HandleFunc("GET /api/search/tag/{name}/values", h.handleSearchTagValues)
+	mux.HandleFunc("GET /api/v2/search/tags", h.handleSearchTagsV2)
+	mux.HandleFunc("GET /api/v2/search/tag/{name}/values", h.handleSearchTagValuesV2)
 	mux.HandleFunc("GET /api/traces/{id}", h.handleTraceByID)
 }
 

--- a/internal/api/tempo/handler_test.go
+++ b/internal/api/tempo/handler_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -16,9 +17,16 @@ import (
 
 type stubQuerier struct {
 	samples  []chclient.Sample
+	strings  []string
 	err      error
 	lastSQL  string
 	lastArgs []any
+	// stringsBySQL lets tests stub multiple back-to-back QueryStrings
+	// calls (e.g. /search/tags issues one query per attribute map);
+	// when set, the longest substring match against the incoming SQL
+	// picks the row set, with the bare `strings` field acting as the
+	// default fallback.
+	stringsBySQL map[string][]string
 }
 
 func (s *stubQuerier) Query(_ context.Context, sql string, args ...any) ([]chclient.Sample, error) {
@@ -28,6 +36,20 @@ func (s *stubQuerier) Query(_ context.Context, sql string, args ...any) ([]chcli
 		return nil, s.err
 	}
 	return s.samples, nil
+}
+
+func (s *stubQuerier) QueryStrings(_ context.Context, sql string, args ...any) ([]string, error) {
+	s.lastSQL = sql
+	s.lastArgs = args
+	if s.err != nil {
+		return nil, s.err
+	}
+	for needle, rows := range s.stringsBySQL {
+		if strings.Contains(sql, needle) {
+			return rows, nil
+		}
+	}
+	return s.strings, nil
 }
 
 func newServer(q tempo.Querier, version string) *httptest.Server {

--- a/internal/api/tempo/search_tag_values.go
+++ b/internal/api/tempo/search_tag_values.go
@@ -1,0 +1,243 @@
+package tempo
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// SearchTagValuesResponse is the body of
+// /api/search/tag/<name>/values. Tempo returns every distinct value
+// observed for one attribute key.
+type SearchTagValuesResponse struct {
+	TagValues []string `json:"tagValues"`
+}
+
+// SearchTagValuesResponseV2 is the body of
+// /api/v2/search/tag/<name>/values. V2 wraps each value in an object so
+// the type info can be threaded through; cerberus reports "string" for
+// dynamic attributes (CH Map(String, String)) and the matching CH
+// column type for intrinsics.
+type SearchTagValuesResponseV2 struct {
+	TagValues []TagValueV2 `json:"tagValues"`
+}
+
+// TagValueV2 is one entry in the V2 response. Type echoes Tempo's
+// vocabulary ("string", "int", "float", "duration", "status", "kind").
+type TagValueV2 struct {
+	Type  string `json:"type"`
+	Value string `json:"value"`
+}
+
+// intrinsicColumn maps a Tempo intrinsic name (as it appears in the
+// URL path of /api/search/tag/<name>/values) to the schema.Traces field
+// holding the underlying CH column name. Returns ("", false) for an
+// unknown intrinsic — caller then falls through to the dynamic-attribute
+// branch.
+func intrinsicColumn(name string, s schema.Traces) (string, bool) {
+	switch name {
+	case "name":
+		return s.SpanNameColumn, true
+	case "kind":
+		return s.SpanKindColumn, true
+	case "status":
+		return s.StatusCodeColumn, true
+	case "statusMessage":
+		return s.StatusMessageColumn, true
+	case "duration":
+		return s.DurationColumn, true
+	case "parent":
+		return s.ParentSpanIDColumn, true
+	}
+	return "", false
+}
+
+// handleSearchTagValues implements
+// `GET /api/search/tag/{name}/values`. The tag name lives in the URL
+// path; if it matches an intrinsic the handler queries the dedicated
+// column, otherwise it unions SpanAttributes[name] and
+// ResourceAttributes[name] (a key can live in either map).
+func (h *Handler) handleSearchTagValues(w http.ResponseWriter, r *http.Request) {
+	h.respondTagValues(w, r, false)
+}
+
+// handleSearchTagValuesV2 implements
+// `GET /api/v2/search/tag/{name}/values`. Same data as V1, wrapped per
+// Tempo V2's typed envelope.
+func (h *Handler) handleSearchTagValuesV2(w http.ResponseWriter, r *http.Request) {
+	h.respondTagValues(w, r, true)
+}
+
+// respondTagValues is the shared core of V1 + V2.
+func (h *Handler) respondTagValues(w http.ResponseWriter, r *http.Request, v2 bool) {
+	name := r.PathValue("name")
+	if name == "" {
+		writeError(w, http.StatusBadRequest, "", "", errors.New("missing tag name"))
+		return
+	}
+	start, end, err := parseTempoStartEnd(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "", "", err)
+		return
+	}
+
+	col, isIntrinsic := intrinsicColumn(name, h.Schema)
+	var (
+		sqlStr   string
+		args     []any
+		valueTyp string
+	)
+	if isIntrinsic {
+		sqlStr, args = buildIntrinsicValuesSQL(h.Schema, col, start, end)
+		valueTyp = intrinsicType(name)
+	} else {
+		sqlStr, args = buildAttributeValuesSQL(h.Schema, name, start, end)
+		valueTyp = "string"
+	}
+	h.Logger.Debug("cerberus tempo /search/tag/values", "tag", name, "intrinsic", isIntrinsic, "sql", sqlStr, "args", args)
+
+	values, err := h.Client.QueryStrings(r.Context(), sqlStr, args...)
+	if err != nil {
+		h.Logger.Warn("cerberus tempo /search/tag/values CH query failed", "err", err.Error(), "tag", name)
+		writeError(w, http.StatusBadGateway, "", "", err)
+		return
+	}
+	values = sortedUnique(values)
+
+	if v2 {
+		out := make([]TagValueV2, 0, len(values))
+		for _, v := range values {
+			out = append(out, TagValueV2{Type: valueTyp, Value: v})
+		}
+		writeJSON(w, http.StatusOK, SearchTagValuesResponseV2{TagValues: out})
+		return
+	}
+	writeJSON(w, http.StatusOK, SearchTagValuesResponse{TagValues: values})
+}
+
+// buildIntrinsicValuesSQL builds the SELECT for an intrinsic-column
+// values lookup:
+//
+//	SELECT DISTINCT toString(`<col>`) AS `value`
+//	FROM `otel_traces`
+//	WHERE `Timestamp` >= ? AND `Timestamp` <= ?
+//
+// toString is the CH conversion that handles both string-typed columns
+// (no-op) and numeric / enum columns (Duration, StatusCode) uniformly,
+// so the chclient.QueryStrings binder is happy regardless of the
+// underlying type.
+func buildIntrinsicValuesSQL(s schema.Traces, col string, start, end time.Time) (string, []any) {
+	sb := chsql.NewSelect().
+		Select(distinctToStringFrag(col)).
+		From(chsql.Col(s.SpansTable))
+	if !start.IsZero() {
+		sb.Where(tempoTimeBoundFrag(s.TimestampColumn, ">=", start))
+	}
+	if !end.IsZero() {
+		sb.Where(tempoTimeBoundFrag(s.TimestampColumn, "<=", end))
+	}
+	return sb.Build()
+}
+
+// buildAttributeValuesSQL builds the SELECT for a dynamic-attribute
+// values lookup. The tag key may live in SpanAttributes or
+// ResourceAttributes; the CH idiom unions both maps via arrayJoin on a
+// two-element array, then filters empties:
+//
+//	SELECT DISTINCT v AS value FROM (
+//	    SELECT arrayJoin([`SpanAttributes`[?], `ResourceAttributes`[?]]) AS v
+//	    FROM `otel_traces`
+//	    WHERE (mapContains(`SpanAttributes`, ?) OR mapContains(`ResourceAttributes`, ?))
+//	          [AND time bounds]
+//	)
+//	WHERE v != ''
+//
+// The mapContains pre-filter prunes most rows before the arrayJoin
+// fan-out, and the outer v != ” drops the empty-string slot for rows
+// where the key only exists in one of the two maps.
+func buildAttributeValuesSQL(s schema.Traces, name string, start, end time.Time) (string, []any) {
+	inner := chsql.NewSelect().
+		Select(attrValueArrayJoinFrag(s.AttributesColumn, s.ResourceAttributesColumn, name)).
+		From(chsql.Col(s.SpansTable)).
+		Where(mapContainsAnyFrag(s.AttributesColumn, s.ResourceAttributesColumn, name))
+	if !start.IsZero() {
+		inner.Where(tempoTimeBoundFrag(s.TimestampColumn, ">=", start))
+	}
+	if !end.IsZero() {
+		inner.Where(tempoTimeBoundFrag(s.TimestampColumn, "<=", end))
+	}
+
+	outer := chsql.NewSelect().
+		Select(chsql.Raw("DISTINCT "), chsql.Col("v")).
+		From(inner.Frag()).
+		Where(nonEmptyFrag("v"))
+	return outer.Build()
+}
+
+// distinctToStringFrag emits "DISTINCT toString(`<col>`)".
+func distinctToStringFrag(col string) chsql.Frag {
+	return func(b *chsql.Builder) {
+		b.WriteSQL("DISTINCT toString(")
+		b.Ident(col)
+		b.WriteSQL(")")
+	}
+}
+
+// attrValueArrayJoinFrag emits the per-row fan-out:
+//
+//	arrayJoin([`<attrCol>`[?], `<resCol>`[?]]) AS `v`
+func attrValueArrayJoinFrag(attrCol, resCol, key string) chsql.Frag {
+	return func(b *chsql.Builder) {
+		b.WriteSQL("arrayJoin([")
+		b.MapAt(attrCol, key)
+		b.WriteSQL(", ")
+		b.MapAt(resCol, key)
+		b.WriteSQL("]) AS ")
+		b.Ident("v")
+	}
+}
+
+// mapContainsAnyFrag emits "(mapContains(`<attrCol>`, ?) OR
+// mapContains(`<resCol>`, ?))" — the row-level pre-filter that prunes
+// spans not carrying the requested attribute key in either map.
+func mapContainsAnyFrag(attrCol, resCol, key string) chsql.Frag {
+	return func(b *chsql.Builder) {
+		b.WriteSQL("(mapContains(")
+		b.Ident(attrCol)
+		b.WriteSQL(", ")
+		b.Arg(key)
+		b.WriteSQL(") OR mapContains(")
+		b.Ident(resCol)
+		b.WriteSQL(", ")
+		b.Arg(key)
+		b.WriteSQL("))")
+	}
+}
+
+// nonEmptyFrag emits "`<col>` != ”", used to drop the empty-string
+// slot the arrayJoin synthesises for rows where the key lives in only
+// one of the two attribute maps.
+func nonEmptyFrag(col string) chsql.Frag {
+	return func(b *chsql.Builder) {
+		b.Ident(col)
+		b.WriteSQL(" != ")
+		b.Arg("")
+	}
+}
+
+// intrinsicType returns the Tempo V2 type label for an intrinsic. Used
+// to populate TagValueV2.Type; V1 doesn't surface this.
+func intrinsicType(name string) string {
+	switch name {
+	case "duration":
+		return "duration"
+	case "status":
+		return "status"
+	case "kind":
+		return "kind"
+	}
+	return "string"
+}

--- a/internal/api/tempo/search_tag_values_test.go
+++ b/internal/api/tempo/search_tag_values_test.go
@@ -1,0 +1,216 @@
+package tempo_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/api/tempo"
+)
+
+// TestSearchTagValues_Intrinsic_Name — the path `/api/search/tag/name/values`
+// maps to the SpanName CH column. The SQL must qualify that column via
+// toString (so the CH binder happily decodes any underlying type) and
+// it must NOT reach into SpanAttributes / ResourceAttributes.
+func TestSearchTagValues_Intrinsic_Name(t *testing.T) {
+	t.Parallel()
+	q := &stubQuerier{strings: []string{"GET /a", "GET /b"}}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/search/tag/name/values")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	var body tempo.SearchTagValuesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got := body.TagValues; len(got) != 2 || got[0] != "GET /a" || got[1] != "GET /b" {
+		t.Errorf("unexpected values: %v", got)
+	}
+	if !strings.Contains(q.lastSQL, "toString(`SpanName`)") {
+		t.Errorf("expected intrinsic projection on SpanName, got: %s", q.lastSQL)
+	}
+	if strings.Contains(q.lastSQL, "SpanAttributes") {
+		t.Errorf("intrinsic path should NOT query attribute maps, got: %s", q.lastSQL)
+	}
+}
+
+// TestSearchTagValues_Intrinsic_AllMapped — every entry in the
+// intrinsics list resolves to a column the schema knows about. Guards
+// against drift between the intrinsicTags list (used by /search/tags)
+// and the intrinsicColumn lookup (used by /search/tag/<n>/values).
+func TestSearchTagValues_Intrinsic_AllMapped(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{"name", "kind", "status", "statusMessage", "duration", "parent"} {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			q := &stubQuerier{strings: []string{"a"}}
+			srv := newServer(q, "v1.0.0-test")
+			t.Cleanup(srv.Close)
+
+			resp, err := http.Get(srv.URL + "/api/search/tag/" + name + "/values")
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			resp.Body.Close()
+			if !strings.Contains(q.lastSQL, "toString(`") {
+				t.Errorf("intrinsic %q should hit toString column path, got: %s", name, q.lastSQL)
+			}
+		})
+	}
+}
+
+// TestSearchTagValues_DynamicAttribute — a non-intrinsic key fans the
+// row out across both maps. The SQL must:
+//   - bind the key as a `?` arg (NOT splice as a literal),
+//   - reference both SpanAttributes and ResourceAttributes,
+//   - drop the empty-string slot via the outer v != ” predicate.
+func TestSearchTagValues_DynamicAttribute(t *testing.T) {
+	t.Parallel()
+	q := &stubQuerier{strings: []string{"frontend", "backend"}}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/search/tag/service.name/values")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	var body tempo.SearchTagValuesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.TagValues) != 2 {
+		t.Errorf("expected 2 values, got %v", body.TagValues)
+	}
+	// Sorted (alphabetical).
+	if body.TagValues[0] != "backend" || body.TagValues[1] != "frontend" {
+		t.Errorf("expected sorted (backend, frontend), got %v", body.TagValues)
+	}
+	for _, want := range []string{
+		"`SpanAttributes`[",
+		"`ResourceAttributes`[",
+		"arrayJoin(",
+		"mapContains(",
+		"`v` != ?",
+	} {
+		if !strings.Contains(q.lastSQL, want) {
+			t.Errorf("SQL missing %q\n  got: %s", want, q.lastSQL)
+		}
+	}
+	// Tag name flows as a positional arg, not spliced. There are three
+	// `?` slots: SpanAttributes[?], ResourceAttributes[?] (inside
+	// arrayJoin), and the two mapContains(?) — plus the outer v != ''.
+	// All four key-related args must equal the URL path tag name.
+	hits := 0
+	for _, a := range q.lastArgs {
+		if s, ok := a.(string); ok && s == "service.name" {
+			hits++
+		}
+	}
+	if hits < 4 {
+		t.Errorf("expected tag name bound >=4 times as positional arg, got %d in %v", hits, q.lastArgs)
+	}
+}
+
+// TestSearchTagValues_EmptyName — bare `/api/search/tag//values` URL
+// (empty name segment) returns 400.
+//
+// Note: net/http's ServeMux refuses to install a pattern matching
+// /api/search/tag//values, so this test posts to a path that the
+// router won't dispatch; we just want a non-OK response. The
+// surrounding 404 from the mux still proves the handler isn't called
+// with an empty name.
+func TestSearchTagValues_EmptyName(t *testing.T) {
+	t.Parallel()
+	q := &stubQuerier{}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/search/tag//values")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusOK {
+		t.Fatalf("expected non-OK for empty tag name, got 200")
+	}
+}
+
+// TestSearchTagValues_CHFailure — CH error bubbles up as 502.
+func TestSearchTagValues_CHFailure(t *testing.T) {
+	t.Parallel()
+	q := &stubQuerier{err: errors.New("clickhouse: connection refused")}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/search/tag/service.name/values")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status=%d want 502", resp.StatusCode)
+	}
+}
+
+// TestSearchTagValuesV2_Envelope — V2 wraps each value in a typed
+// object. For dynamic attributes the type is "string"; for intrinsics
+// it switches on the kind (duration / status / kind / string).
+func TestSearchTagValuesV2_Envelope(t *testing.T) {
+	t.Parallel()
+	q := &stubQuerier{strings: []string{"frontend"}}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v2/search/tag/service.name/values")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	var body tempo.SearchTagValuesResponseV2
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.TagValues) != 1 || body.TagValues[0].Value != "frontend" || body.TagValues[0].Type != "string" {
+		t.Errorf("unexpected V2 body: %+v", body.TagValues)
+	}
+}
+
+// TestSearchTagValuesV2_IntrinsicType — duration's V2 type label is
+// "duration", not "string". Pin the dispatch so future intrinsic
+// additions don't quietly regress.
+func TestSearchTagValuesV2_IntrinsicType(t *testing.T) {
+	t.Parallel()
+	q := &stubQuerier{strings: []string{"150000000"}}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v2/search/tag/duration/values")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	var body tempo.SearchTagValuesResponseV2
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.TagValues) != 1 || body.TagValues[0].Type != "duration" {
+		t.Errorf("expected type=duration, got %+v", body.TagValues)
+	}
+}

--- a/internal/api/tempo/search_tags.go
+++ b/internal/api/tempo/search_tags.go
@@ -1,0 +1,194 @@
+package tempo
+
+import (
+	"context"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// intrinsicTags is the static list of Tempo "intrinsic" attribute names
+// that aren't stored as map entries on the span row — they're dedicated
+// columns. Upstream Tempo emits them alongside the dynamic attribute
+// keys in the /api/search/tags response so the autocomplete UI knows
+// about them.
+//
+// The list mirrors the documented intrinsics: name, status (StatusCode),
+// statusMessage, kind (SpanKind), duration, rootServiceName, rootName,
+// traceDuration. Cerberus surfaces the subset we can actually answer
+// /search/tag/<name>/values queries for today; rootServiceName /
+// rootName / traceDuration would require a per-trace pivot that lands
+// with the rest of the trace-summary plumbing in RC2.
+var intrinsicTags = []string{
+	"name",
+	"kind",
+	"status",
+	"statusMessage",
+	"duration",
+	"parent",
+}
+
+// SearchTagsResponse is the V1 response body of /api/search/tags. Tempo
+// returns the union of every span attribute key seen plus the intrinsic
+// span fields.
+type SearchTagsResponse struct {
+	TagNames []string `json:"tagNames"`
+}
+
+// SearchTagsResponseV2 is the V2 response body of /api/v2/search/tags.
+// Tempo V2 groups tags by scope so the autocomplete UI can surface
+// `resource.` / `span.` / intrinsic prefixes separately.
+type SearchTagsResponseV2 struct {
+	Scopes []TagScope `json:"scopes"`
+}
+
+// TagScope is one group in the V2 response — one of "resource", "span",
+// or "intrinsic". `Tags` carries the attribute keys for that scope.
+type TagScope struct {
+	Name string   `json:"name"`
+	Tags []string `json:"tags"`
+}
+
+// handleSearchTags implements `GET /api/search/tags`. Returns the union
+// of every dynamic attribute key (span + resource maps) plus the static
+// intrinsic-span list, sorted ascending. Honours optional `start`/`end`
+// time bounds (Unix seconds; nanoseconds also accepted via the same
+// heuristic Loki uses, see parseTempoTime).
+//
+// SQL shape:
+//
+//	SELECT DISTINCT arrayJoin(arrayConcat(
+//	    mapKeys(`SpanAttributes`),
+//	    mapKeys(`ResourceAttributes`)
+//	)) AS `tag`
+//	FROM `otel_traces`
+//	WHERE `Timestamp` >= ? AND `Timestamp` <= ?
+//
+// All identifiers and bound values flow through chsql.SelectBuilder —
+// no fmt.Sprintf-on-SQL (CLAUDE.md "no raw SQL strings" rule).
+func (h *Handler) handleSearchTags(w http.ResponseWriter, r *http.Request) {
+	h.respondTags(w, r, false)
+}
+
+// handleSearchTagsV2 implements `GET /api/v2/search/tags`. Same data
+// as V1, partitioned by scope (resource / span / intrinsic). Grafana's
+// Tempo datasource queries V2 when available.
+func (h *Handler) handleSearchTagsV2(w http.ResponseWriter, r *http.Request) {
+	h.respondTags(w, r, true)
+}
+
+// respondTags is the shared core of V1 + V2: it runs two independent
+// CH lookups (one per attribute map) so the V2 response can keep the
+// resource-vs-span split, then unions them for the V1 envelope.
+func (h *Handler) respondTags(w http.ResponseWriter, r *http.Request, v2 bool) {
+	start, end, err := parseTempoStartEnd(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "", "", err)
+		return
+	}
+
+	resourceTags, err := h.fetchTagKeys(r.Context(), h.Schema.ResourceAttributesColumn, start, end)
+	if err != nil {
+		h.Logger.Warn("cerberus tempo /search/tags resource CH query failed", "err", err.Error())
+		writeError(w, http.StatusBadGateway, "", "", err)
+		return
+	}
+	spanTags, err := h.fetchTagKeys(r.Context(), h.Schema.AttributesColumn, start, end)
+	if err != nil {
+		h.Logger.Warn("cerberus tempo /search/tags span CH query failed", "err", err.Error())
+		writeError(w, http.StatusBadGateway, "", "", err)
+		return
+	}
+
+	if v2 {
+		writeJSON(w, http.StatusOK, SearchTagsResponseV2{
+			Scopes: []TagScope{
+				{Name: "resource", Tags: sortedUnique(resourceTags)},
+				{Name: "span", Tags: sortedUnique(spanTags)},
+				{Name: "intrinsic", Tags: append([]string(nil), intrinsicTags...)},
+			},
+		})
+		return
+	}
+
+	all := make([]string, 0, len(resourceTags)+len(spanTags)+len(intrinsicTags))
+	all = append(all, resourceTags...)
+	all = append(all, spanTags...)
+	all = append(all, intrinsicTags...)
+	writeJSON(w, http.StatusOK, SearchTagsResponse{TagNames: sortedUnique(all)})
+}
+
+// fetchTagKeys runs the mapKeys-distinct lookup for a single attribute
+// map column. Splitting into two queries (rather than one with
+// arrayConcat) keeps the V2 scope partition cheap — V1 unions the two
+// slices in Go.
+func (h *Handler) fetchTagKeys(ctx context.Context, mapCol string, start, end time.Time) ([]string, error) {
+	sqlStr, args := buildSearchTagsSQL(h.Schema, mapCol, start, end)
+	h.Logger.Debug("cerberus tempo /search/tags", "col", mapCol, "sql", sqlStr, "args", args)
+	return h.Client.QueryStrings(ctx, sqlStr, args...)
+}
+
+// buildSearchTagsSQL builds the SELECT for one attribute map column.
+// Exposed for tests so the SQL shape is pinned without spinning up the
+// HTTP layer.
+func buildSearchTagsSQL(s schema.Traces, mapCol string, start, end time.Time) (string, []any) {
+	sb := chsql.NewSelect().
+		Select(distinctMapKeysFrag(mapCol)).
+		From(chsql.Col(s.SpansTable))
+	if !start.IsZero() {
+		sb.Where(tempoTimeBoundFrag(s.TimestampColumn, ">=", start))
+	}
+	if !end.IsZero() {
+		sb.Where(tempoTimeBoundFrag(s.TimestampColumn, "<=", end))
+	}
+	return sb.Build()
+}
+
+// distinctMapKeysFrag emits "DISTINCT arrayJoin(mapKeys(`<col>`))" — the
+// CH idiom for "every distinct attribute key seen". DISTINCT is part of
+// the SELECT list (CH's flavour), not a separate keyword, so it folds
+// into the Frag for the SelectBuilder slot.
+func distinctMapKeysFrag(col string) chsql.Frag {
+	return func(b *chsql.Builder) {
+		b.WriteSQL("DISTINCT arrayJoin(")
+		b.MapKeys(col)
+		b.WriteSQL(")")
+	}
+}
+
+// tempoTimeBoundFrag mirrors loki/index_stats.go's helper. Duplicated
+// here rather than exported so the two API packages stay independent.
+func tempoTimeBoundFrag(col, op string, t time.Time) chsql.Frag {
+	return func(b *chsql.Builder) {
+		b.Ident(col)
+		b.WriteSQL(" ")
+		b.WriteSQL(op)
+		b.WriteSQL(" ")
+		b.DateTime64Lit(t)
+	}
+}
+
+// sortedUnique returns the de-duplicated, lexicographically sorted view
+// of in. The returned slice is always non-nil so JSON marshals as `[]`
+// (not `null`) when the input is empty.
+func sortedUnique(in []string) []string {
+	if len(in) == 0 {
+		return []string{}
+	}
+	seen := make(map[string]struct{}, len(in))
+	for _, s := range in {
+		if s == "" {
+			continue
+		}
+		seen[s] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for s := range seen {
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/api/tempo/search_tags_test.go
+++ b/internal/api/tempo/search_tags_test.go
@@ -1,0 +1,242 @@
+package tempo_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/api/tempo"
+)
+
+// TestSearchTags_UnionsMapsAndIntrinsics — the V1 endpoint returns the
+// sorted, de-duplicated union of:
+//   - keys returned by the ResourceAttributes lookup,
+//   - keys returned by the SpanAttributes lookup,
+//   - the static intrinsic-span list.
+//
+// stringsBySQL routes each CH call by the column it qualifies on, so
+// the test can give distinct row sets to the two lookups even though
+// they share the chclient.QueryStrings entry point.
+func TestSearchTags_UnionsMapsAndIntrinsics(t *testing.T) {
+	t.Parallel()
+	q := &stubQuerier{stringsBySQL: map[string][]string{
+		"`ResourceAttributes`": {"service.name", "host"},
+		"`SpanAttributes`":     {"http.method", "host"}, // `host` duplicates resource
+	}}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/search/tags")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	var body tempo.SearchTagsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	for _, want := range []string{
+		"service.name", "host", "http.method", // dynamic
+		"name", "kind", "status", "duration", // intrinsics
+	} {
+		if !contains(body.TagNames, want) {
+			t.Errorf("missing tag %q in response: %v", want, body.TagNames)
+		}
+	}
+	// De-dup: `host` appears in both maps but only once.
+	if c := count(body.TagNames, "host"); c != 1 {
+		t.Errorf("tag `host` should appear exactly once, got %d in %v", c, body.TagNames)
+	}
+	// Sorted ascending.
+	for i := 1; i < len(body.TagNames); i++ {
+		if body.TagNames[i-1] > body.TagNames[i] {
+			t.Errorf("response not sorted at %d: %q > %q", i, body.TagNames[i-1], body.TagNames[i])
+		}
+	}
+}
+
+// TestSearchTags_SQLShape — pins the SQL the handler emits so the
+// no-fmt-Sprintf-on-SQL rule (CLAUDE.md) doesn't quietly regress.
+// Builder must emit a parameterised `arrayJoin(mapKeys(<col>))`
+// SELECT — never a raw concatenated table name or column literal.
+func TestSearchTags_SQLShape(t *testing.T) {
+	t.Parallel()
+	q := &stubQuerier{strings: []string{"a"}}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/search/tags")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	resp.Body.Close()
+	for _, want := range []string{
+		"SELECT DISTINCT",
+		"arrayJoin(",
+		"mapKeys(",
+		"FROM `otel_traces`",
+	} {
+		if !strings.Contains(q.lastSQL, want) {
+			t.Errorf("SQL missing %q\n  got: %s", want, q.lastSQL)
+		}
+	}
+}
+
+// TestSearchTags_TimeBounds — `start` / `end` query parameters thread
+// into the WHERE clause as toDateTime64 literals. Tempo accepts unix
+// seconds; the handler also accepts nanoseconds.
+func TestSearchTags_TimeBounds(t *testing.T) {
+	t.Parallel()
+	q := &stubQuerier{strings: []string{"a"}}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/search/tags?start=1700000000&end=1700003600")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	resp.Body.Close()
+	if !strings.Contains(q.lastSQL, "WHERE") {
+		t.Errorf("expected WHERE clause, got: %s", q.lastSQL)
+	}
+	if !strings.Contains(q.lastSQL, "toDateTime64") {
+		t.Errorf("expected toDateTime64 bound, got: %s", q.lastSQL)
+	}
+}
+
+// TestSearchTags_BadTimeBound — non-numeric, non-RFC3339 input yields
+// a 400 with the Tempo error envelope.
+func TestSearchTags_BadTimeBound(t *testing.T) {
+	t.Parallel()
+	q := &stubQuerier{}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/search/tags?start=notatime")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status=%d want 400", resp.StatusCode)
+	}
+	var er tempo.ErrorResponse
+	if err := json.NewDecoder(resp.Body).Decode(&er); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !er.Error {
+		t.Errorf("expected error=true, got %+v", er)
+	}
+}
+
+// TestSearchTags_CHFailure — CH error bubbles up as 502 with the Tempo
+// error envelope (parity with /api/search/recent).
+func TestSearchTags_CHFailure(t *testing.T) {
+	t.Parallel()
+	q := &stubQuerier{err: errors.New("clickhouse: connection refused")}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/search/tags")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status=%d want 502", resp.StatusCode)
+	}
+}
+
+// TestSearchTags_EmptyArray — an empty CH result still produces
+// `{"tagNames":[]}` (non-nil) so Grafana's JSON decoder doesn't choke
+// on `null`. Plus the static intrinsic list still surfaces.
+func TestSearchTags_EmptyArray(t *testing.T) {
+	t.Parallel()
+	q := &stubQuerier{strings: nil}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/search/tags")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	var body tempo.SearchTagsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.TagNames == nil {
+		t.Fatalf("expected non-nil tagNames slice (empty CH result), got nil")
+	}
+	// Intrinsics are static — should always be present.
+	if !contains(body.TagNames, "name") {
+		t.Errorf("expected intrinsic `name` even with empty CH result: %v", body.TagNames)
+	}
+}
+
+// TestSearchTagsV2_ScopePartition — the V2 endpoint groups tags by
+// scope (resource / span / intrinsic). The two map lookups feed
+// distinct scope buckets, and the static intrinsic list lives in its
+// own.
+func TestSearchTagsV2_ScopePartition(t *testing.T) {
+	t.Parallel()
+	q := &stubQuerier{stringsBySQL: map[string][]string{
+		"`ResourceAttributes`": {"service.name"},
+		"`SpanAttributes`":     {"http.method"},
+	}}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v2/search/tags")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	var body tempo.SearchTagsResponseV2
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	scopes := map[string][]string{}
+	for _, s := range body.Scopes {
+		scopes[s.Name] = s.Tags
+	}
+	if !contains(scopes["resource"], "service.name") {
+		t.Errorf("resource scope missing service.name: %+v", scopes)
+	}
+	if !contains(scopes["span"], "http.method") {
+		t.Errorf("span scope missing http.method: %+v", scopes)
+	}
+	if !contains(scopes["intrinsic"], "name") {
+		t.Errorf("intrinsic scope missing `name`: %+v", scopes)
+	}
+}
+
+// contains is a small helper so test failures point at the missing
+// string rather than dumping the whole slice diff.
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func count(haystack []string, needle string) int {
+	n := 0
+	for _, s := range haystack {
+		if s == needle {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/api/tempo/time.go
+++ b/internal/api/tempo/time.go
@@ -1,0 +1,58 @@
+package tempo
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// parseTempoStartEnd reads optional `start` / `end` query parameters.
+// Tempo accepts Unix seconds (typical), but the same nanosecond
+// heuristic Loki / Prom apply here keeps the wire compatible with
+// clients that send raw nanos (e.g. some Grafana plugins).
+//
+// Both bounds are optional; an absent value yields the zero time.Time,
+// which the SelectBuilder treats as "no predicate".
+func parseTempoStartEnd(r *http.Request) (time.Time, time.Time, error) {
+	startStr := r.URL.Query().Get("start")
+	endStr := r.URL.Query().Get("end")
+
+	start, err := parseTempoTime(startStr)
+	if err != nil {
+		return time.Time{}, time.Time{}, err
+	}
+	end, err := parseTempoTime(endStr)
+	if err != nil {
+		return time.Time{}, time.Time{}, err
+	}
+	if !start.IsZero() && !end.IsZero() && end.Before(start) {
+		return time.Time{}, time.Time{}, errors.New("'end' must not be before 'start'")
+	}
+	return start, end, nil
+}
+
+// parseTempoTime decodes a single Unix-seconds-as-int (or
+// nanoseconds-as-int when > 1e12) timestamp string. An empty input
+// returns the zero time without an error — callers treat that as
+// "predicate omitted". RFC3339 is also accepted for parity with Loki.
+func parseTempoTime(raw string) (time.Time, error) {
+	if raw == "" {
+		return time.Time{}, nil
+	}
+	if n, err := strconv.ParseInt(raw, 10, 64); err == nil {
+		if n > 1_000_000_000_000 {
+			// Heuristic: > 1e12 means nanoseconds.
+			return time.Unix(0, n).UTC(), nil
+		}
+		return time.Unix(n, 0).UTC(), nil
+	}
+	if f, err := strconv.ParseFloat(raw, 64); err == nil {
+		return time.Unix(int64(f), int64((f-float64(int64(f)))*1e9)).UTC(), nil
+	}
+	t, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		return time.Time{}, errors.New("time parameter must be Unix seconds/nanoseconds or RFC3339")
+	}
+	return t.UTC(), nil
+}


### PR DESCRIPTION
## Summary

Adds the V1 + V2 variants of Tempo's tag-discovery endpoints, gated on the `chsql.Builder` landing in RC6 R6.1 (#131). Grafana's Tempo datasource now gets autocomplete on attribute keys + values.

## Endpoints wired in `handler.Mount`

| Method | Path | Response |
|---|---|---|
| GET | `/api/search/tags` | `{tagNames:[...]}` |
| GET | `/api/search/tag/{name}/values` | `{tagValues:[...]}` |
| GET | `/api/v2/search/tags` | `{scopes:[{name,tags:[...]}]}` (resource / span / intrinsic) |
| GET | `/api/v2/search/tag/{name}/values` | `{tagValues:[{type,value}]}` |

## SQL approach (all via `chsql.SelectBuilder` + `Frag` — no `fmt.Sprintf`-on-SQL)

- **`/search/tags`** issues one `SELECT DISTINCT arrayJoin(mapKeys(<col>))` lookup per attribute map (`SpanAttributes`, `ResourceAttributes`), then unions with the static intrinsic list (`name`, `kind`, `status`, `statusMessage`, `duration`, `parent`). V2 keeps the scope split for the response; V1 flattens + dedupes. Splitting into two queries (rather than one with `arrayConcat`) keeps the V2 scope partition cheap.

- **`/search/tag/{name}/values`** dispatches on intrinsic-vs-dynamic:
  - intrinsic → `SELECT DISTINCT toString(\`<col>\`) FROM otel_traces …`
  - dynamic → outer `SELECT DISTINCT v` over an inner `arrayJoin([SpanAttributes[?], ResourceAttributes[?]]) AS v` with a `mapContains(SpanAttributes, ?) OR mapContains(ResourceAttributes, ?)` row-level pre-filter; outer `v != ''` drops the empty-string slot for rows where the key lives in only one map.

Both endpoints honour optional `start`/`end` (Unix seconds — Tempo convention — with the same ns heuristic Loki uses, plus RFC3339 fallback).

## V2 status

Implemented (not deferred). V2 envelopes differ from V1 only in shape:
- `/api/v2/search/tags` returns a `scopes` array partitioning the same keys by `resource` / `span` / `intrinsic`.
- `/api/v2/search/tag/{name}/values` wraps each value in `{type, value}`; type is `"duration"` / `"status"` / `"kind"` for those intrinsics and `"string"` for everything else.

## Test coverage

`search_tags_test.go` and `search_tag_values_test.go` add table-tests covering:

- Union/dedup across resource + span maps, alongside the static intrinsic list (V1).
- SQL shape pinned: `SELECT DISTINCT`, `arrayJoin(`, `mapKeys(`, `FROM \`otel_traces\``.
- Time-bound threading (`start`/`end` → `toDateTime64` literals).
- 400 on malformed time, 502 on CH failure with the Tempo error envelope.
- V2 scope partition (resource / span / intrinsic buckets).
- Intrinsic dispatch for every entry in the intrinsics list — `name` hits `SpanName`, `duration` hits the `Duration` column, etc.
- Dynamic attribute path: tag key bound as positional `?` arg (≥4 times across the two `MapAt` calls + two `mapContains` calls), never spliced.
- V1 + V2 envelope shapes for the tag-values endpoint, including the typed `duration` label.

## Pre-flight

- `go build ./...` clean.
- `go test ./...` — 892 tests pass.
- `gofumpt -l internal/api/tempo/` empty.
- `go vet ./internal/api/tempo/...` clean.
- Grep gate (`WriteSQL\(" *(SELECT|FROM|WHERE|GROUP BY|ORDER BY|LIMIT|PREWHERE)|fmt\.Sprintf\([^)]*(SELECT|FROM|WHERE)` against the two new files) returns empty.

## Test plan

- [x] `go test ./internal/api/tempo/...`
- [x] `go test ./...`
- [ ] Manual smoke against a live Grafana datasource (defers to next E2E refresh).