### PR TITLE
chore(lint): forbid unsafe.Pointer + reflect.FieldByName in internal/traceql, internal/api/tempo

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,6 +23,12 @@ linters:
     #   `fmt.Errorf("...: %w", err)` which gives consumers structured
     #   error handling.
     - errorlint
+    # forbidigo: bans `unsafe.Pointer` and `reflect.Value.FieldByName`
+    #   inside `internal/traceql/` + `internal/api/tempo/` so the
+    #   parser-internal shim retired in #148 cannot be reintroduced.
+    #   See docs/fork-tempo-plan.md § "Cerberus PR #D". Scoped to those
+    #   two dirs via `exclusions.rules[].path-except` below.
+    - forbidigo
   settings:
     revive:
       rules:
@@ -36,6 +42,16 @@ linters:
       errorf: true
       asserts: true
       comparison: true
+    forbidigo:
+      # analyze-types: true → forbidigo resolves identifiers through the
+      #   type checker, so the rules match the canonical `unsafe.Pointer`
+      #   and `reflect.Value.FieldByName` even under aliased imports.
+      analyze-types: true
+      forbid:
+        - pattern: '^unsafe\.Pointer$'
+          msg: 'unsafe.Pointer is forbidden in internal/traceql/ and internal/api/tempo/ — use the tsouza/tempo:cerberus-accessors fork accessors instead. See docs/fork-tempo-plan.md.'
+        - pattern: '^reflect\.Value\.FieldByName$'
+          msg: 'reflect.FieldByName on parser AST is forbidden — use the upstream-fork accessors instead.'
   exclusions:
     rules:
       - path: _test\.go
@@ -49,6 +65,11 @@ linters:
         linters:
           - revive
           - errcheck
+      # forbidigo fires ONLY inside internal/traceql/ + internal/api/tempo/
+      # — invert via `path-except` so every other path is excluded.
+      - linters:
+          - forbidigo
+        path-except: '^internal/(traceql|api/tempo)/'
 
 formatters:
   enable:

--- a/docs/fork-tempo-plan.md
+++ b/docs/fork-tempo-plan.md
@@ -1,7 +1,9 @@
 # Fork Tempo — concrete plan to retire the `unsafe.Pointer` shim
 
-**Status:** investigation / plan. Execution is a follow-up PR. Authored as
-input to RC2 hardening — supersedes the "Forks" section of
+**Status:** PR #A (`go.mod` replace), PR #B (retire shim), and PR #D
+(forbidigo lint gate) have landed. PR #C (TraceQL MetricsPipeline
+lowering) is the remaining work item. Originally authored as input to
+RC2 hardening — supersedes the "Forks" section of
 [`docs/upstream-tracking.md`](upstream-tracking.md) with concrete API
 shapes, file-level diff estimates, and a per-PR migration sequence.
 
@@ -397,7 +399,16 @@ Four PRs, in order:
 - **Risk:** medium. New SQL emission path; relies on the fork having
   the MetricsPipeline accessors. Gated by PR #A landing first.
 
-### Cerberus PR #D — "lint gate against new `unsafe.Pointer`"
+### Cerberus PR #D — "lint gate against new `unsafe.Pointer`" — **LANDED**
+
+Implemented in `.golangci.yml` via `forbidigo` (the recommended
+option below), scoped to `internal/traceql/` + `internal/api/tempo/`
+through an inverted `exclusions.rules[].path-except` filter. Note:
+forbidigo with `analyze-types: true` matches `unsafe.Pointer` as a
+declared type (e.g. `var p unsafe.Pointer`) but not as a conversion
+call (`unsafe.Pointer(&x)`); the latter shape is already caught by
+`gosec` G103 (enabled repo-wide), so the combination covers the
+shim shape retired in PR #B without leaving a hole.
 
 - **Scope:** add a CI guard preventing `unsafe.Pointer` and
   `reflect.Value.FieldByName` from reappearing in

--- a/docs/upstream-tracking.md
+++ b/docs/upstream-tracking.md
@@ -75,10 +75,14 @@ releases, hot-fixes within days).
 ## Forks: when upstream's API isn't enough
 
 The parsers ship AST node types where **important fields are
-unexported** with no public accessors. Cerberus reads them anyway via
-reflection or `unsafe.Pointer` shims — see
-`internal/traceql/aggregate.go`'s `readAggregateExpr` for the canonical
-example (added for P0 #7 in RC2).
+unexported** with no public accessors. Cerberus used to read them
+via reflection or `unsafe.Pointer` shims; the canonical example was
+`internal/traceql/aggregate.go`'s `readAggregateExpr` (added for
+P0 #7 in RC2). That shim has since been retired against the
+`github.com/tsouza/tempo` fork (`cerberus-accessors` branch); see
+[`docs/fork-tempo-plan.md`](fork-tempo-plan.md). A `forbidigo` rule
+in `.golangci.yml` prevents either pattern from being reintroduced
+under `internal/traceql/` or `internal/api/tempo/`.
 
 The shim works but is **fragile** in three ways:
 
@@ -174,6 +178,9 @@ then we'll know which additional accessors we need.
 - `.github/dependabot.yml` — the daily-grouped config described above.
 - `.github/workflows/auto-merge-deps.yml` — auto-merge on green CI for
   trusted patch-only bumps.
-- `internal/traceql/aggregate.go` — `readAggregateExpr` is the current
-  unsafe shim this strategy eventually replaces.
+- `internal/traceql/aggregate.go` — historically housed
+  `readAggregateExpr` (the `unsafe.Pointer` shim this strategy replaced);
+  now uses fork accessors from `tsouza/tempo:cerberus-accessors`.
+- `.golangci.yml` — the `forbidigo` rule blocking `unsafe.Pointer` /
+  `reflect.Value.FieldByName` from being reintroduced.
 - `docs/roadmap.md` — RC2 backlog references this doc.


### PR DESCRIPTION
## Summary
- Adds a `forbidigo` rule to `.golangci.yml` banning `unsafe.Pointer` and `reflect.Value.FieldByName` in `internal/traceql/` and `internal/api/tempo/` (scoped via inverted `linters.exclusions.rules[].path-except`).
- Locks in the cleanup PR #148 just landed against the `tsouza/tempo:cerberus-accessors` fork — future agents that try to add a new unsafe shim against the upstream parser will fail the `lint` required check.
- Updates `docs/fork-tempo-plan.md` and `docs/upstream-tracking.md` to reflect the lint gate landing.

### Coverage note
`forbidigo` with `analyze-types: true` matches `unsafe.Pointer` as a declared *type* (`var p unsafe.Pointer`, struct fields, etc.). It does **not** match the conversion-call shape `unsafe.Pointer(&x)` — that shape is already caught by `gosec` G103, which is enabled repo-wide. The two together cover the exact shim shape retired in PR #B (#148): a `unsafe.Pointer(field.UnsafeAddr())` conversion would now fail under gosec, while a `var ptr unsafe.Pointer` declaration would fail under our new forbidigo rule.

## Test plan
- [x] `golangci-lint run ./...` clean on `main` after rebase (rule does not fire on existing code).
- [x] Manually verified the rule fires inside `internal/traceql/` and `internal/api/tempo/` by dropping a probe file with `var p unsafe.Pointer` + `v.FieldByName("A")` — both findings reported under `forbidigo`.
- [x] Manually verified the rule stays silent outside the two scoped dirs (probe file in `internal/api/prom/` reports zero forbidigo findings).
- [x] `go vet ./...` clean.
- [x] `markdownlint-cli2` clean on the two updated docs.

Roadmap: PR #D from [`docs/fork-tempo-plan.md`](https://github.com/tsouza/cerberus/blob/main/docs/fork-tempo-plan.md#cerberus-pr-d--lint-gate-against-new-unsafepointer--landed) migration sequence.