### PR TITLE
feat(traceql): MetricsPipeline lowering — rate/*_over_time → Aggregate(Scan(traces)) (RC2)

### DIFF
--- a/internal/api/loki/detected_fields.go
+++ b/internal/api/loki/detected_fields.go
@@ -141,7 +141,7 @@ func buildDetectedFieldsSQL(s schema.Logs, matchers []*labels.Matcher, start, en
 		sb.Where(timeBoundFrag(s.TimestampColumn, "<=", end))
 	}
 	sb.OrderBy(chsql.Col(s.TimestampColumn), true).
-		Limit(lineLimit)
+		Limit(int64(lineLimit))
 
 	sqlStr, args := sb.Build()
 	return sqlStr, args, nil

--- a/internal/traceql/lower.go
+++ b/internal/traceql/lower.go
@@ -15,12 +15,20 @@ import (
 )
 
 // Lower turns a parsed TraceQL expression into a chplan tree.
+//
+// When `expr.MetricsPipeline` is non-nil the query is a metrics
+// aggregation (`{ ... } | rate()`, `{ ... } | sum_over_time(attr)`,
+// etc.). The spanset prefix in `expr.Pipeline.Elements` (typically a
+// single `{ ... }` selector) lowers to a Scan/Filter tree, then
+// lowerMetricsPipeline wraps it with a chplan.Aggregate carrying the
+// CH aggregate function + group-by labels. The query time range itself
+// is supplied by the HTTP /api/metrics/query_range handler (which
+// wraps the returned tree with a chplan.RangeWindow) — TraceQL's
+// grammar doesn't carry the range argument in the AST. See
+// docs/fork-tempo-plan.md § 2c.
 func Lower(expr *traceql.RootExpr, s schema.Traces) (chplan.Node, error) {
 	if expr == nil {
 		return nil, fmt.Errorf("traceql: nil RootExpr")
-	}
-	if expr.MetricsPipeline != nil {
-		return nil, fmt.Errorf("traceql: metrics pipelines (`| count()`, `| rate()`) are not yet supported (lands with M4.3)")
 	}
 	if len(expr.Pipeline.Elements) == 0 {
 		return nil, fmt.Errorf("traceql: empty pipeline")
@@ -42,6 +50,16 @@ func Lower(expr *traceql.RootExpr, s schema.Traces) (chplan.Node, error) {
 			return nil, err
 		}
 		plan = next
+	}
+
+	if expr.MetricsPipeline != nil {
+		plan, err = lowerMetricsPipeline(plan, expr.MetricsPipeline, s)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if expr.MetricsSecondStage != nil {
+		return nil, fmt.Errorf("traceql: metrics second-stage operators (`| topk`, `| bottomk`, `| > N`) are not yet supported")
 	}
 	return plan, nil
 }

--- a/internal/traceql/metrics_pipeline.go
+++ b/internal/traceql/metrics_pipeline.go
@@ -1,0 +1,186 @@
+package traceql
+
+import (
+	"fmt"
+
+	"github.com/grafana/tempo/pkg/traceql"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// metricsValueAlias is the column alias the lowered Aggregate gives the
+// metric output. Matches the alias used by `| count()`, `| sum(...)` &c.
+// in aggregate.go so downstream code (the upcoming
+// /api/metrics/query_range handler) can refer to it uniformly.
+const metricsValueAlias = "Value"
+
+// lowerMetricsPipeline lowers `RootExpr.MetricsPipeline` — i.e. the
+// `rate()` / `count_over_time()` / `*_over_time(attr)` / `quantile_over_time`
+// metrics aggregators — into a chplan `Aggregate(<spanset-tree>)`
+// subtree.
+//
+// The TraceQL grammar does NOT carry the time range in the AST; the
+// query range comes from the HTTP `/api/metrics/query_range` request
+// (start/end/step). The handler PR wraps the returned Aggregate with a
+// `chplan.RangeWindow` carrying that range; this lowering is purely the
+// inner reducer + spanset selection tree.
+//
+// Shape:
+//
+//	Aggregate{ AggFuncs: [<chFunc>(<arg>) AS Value],
+//	           GroupBy: <by(...) attributes>,
+//	           Input: <spanset Scan/Filter tree> }
+//
+// `prev` is the lowered spanset prefix — typically a `Scan(otel_traces)`
+// or `Filter(<predicate>, Scan)` produced by lowerPipelineElement /
+// lowerSpansetFilter — supplied by Lower() so the spanset matchers from
+// the query's `{ ... }` selector survive into the SQL.
+func lowerMetricsPipeline(prev chplan.Node, mp traceql.FirstStageElement, s schema.Traces) (chplan.Node, error) {
+	if v, ok := mp.(*traceql.MetricsAggregate); ok {
+		return lowerMetricsAggregate(prev, v, s)
+	}
+	// Tempo parses `| avg_over_time(attr)` into an unexported
+	// `*averageOverTimeAggregator` rather than a `*MetricsAggregate`
+	// (see pkg/traceql/engine_metrics_average.go). The fork hasn't
+	// exposed accessors on that type yet; rather than reach for
+	// reflect/unsafe (forbidden post-#148), surface a clean
+	// not-yet-supported error here. A follow-up fork patch can add
+	// `Attribute()` / `GroupBy()` accessors and a small adapter; the
+	// CH aggregate it would lower to (`avg`) is already wired in
+	// mapMetricsAggregateOp below.
+	return nil, fmt.Errorf("traceql: metrics pipeline element %T is not yet supported", mp)
+}
+
+// lowerMetricsAggregate maps a single `MetricsAggregate` (rate / sum /
+// avg / min / max / count / quantile over_time) onto a chplan.Aggregate.
+//
+// Per fork-tempo-plan.md § 2c, `rate()` and `count_over_time()` both
+// reduce to a row-count at this layer (CH `count(1)`); the
+// per-evaluation-step rate normalisation lives on the wrapping
+// `chplan.RangeWindow` the handler attaches, not here.
+//
+// `quantile_over_time(attr, q1, q2, ...)` is supported only for a
+// single quantile (the common Grafana case). Multi-quantile queries
+// surface a clean "not yet supported" error so the caller can decide
+// whether to split into N queries.
+//
+// `histogram_over_time(attr)` is deferred — the lowering would need a
+// chplan node distinct from a scalar Aggregate, and the
+// `/api/metrics/query_range` handler shape for histogram series has not
+// landed yet.
+func lowerMetricsAggregate(prev chplan.Node, agg *traceql.MetricsAggregate, s schema.Traces) (chplan.Node, error) {
+	op := agg.Op()
+	chFunc, params, err := mapMetricsAggregateOp(op, agg.Quantiles())
+	if err != nil {
+		return nil, err
+	}
+
+	args, err := metricsAggregateArgs(op, agg.Attribute(), s)
+	if err != nil {
+		return nil, err
+	}
+
+	groupBy, groupAliases, err := lowerMetricsGroupBy(agg.GroupBy(), s)
+	if err != nil {
+		return nil, err
+	}
+
+	return &chplan.Aggregate{
+		Input:          prev,
+		GroupBy:        groupBy,
+		GroupByAliases: groupAliases,
+		AggFuncs: []chplan.AggFunc{{
+			Name:   chFunc,
+			Params: params,
+			Args:   args,
+			Alias:  metricsValueAlias,
+		}},
+	}, nil
+}
+
+// mapMetricsAggregateOp turns a TraceQL MetricsAggregateOp into the CH
+// aggregate-function name + parameter list (for parameterised aggregates
+// like `quantile(0.95)(value)`).
+//
+// rate / count_over_time both lower to `count` — the handler-side
+// RangeWindow.Func discriminates them when it picks the per-step
+// normalisation (rate divides by the window's seconds; count_over_time
+// does not).
+func mapMetricsAggregateOp(op traceql.MetricsAggregateOp, qs []float64) (name string, params []chplan.Expr, err error) {
+	switch op {
+	case traceql.MetricsAggregateRate, traceql.MetricsAggregateCountOverTime:
+		return "count", nil, nil
+	case traceql.MetricsAggregateSumOverTime:
+		return "sum", nil, nil
+	case traceql.MetricsAggregateAvgOverTime:
+		return "avg", nil, nil
+	case traceql.MetricsAggregateMinOverTime:
+		return "min", nil, nil
+	case traceql.MetricsAggregateMaxOverTime:
+		return "max", nil, nil
+	case traceql.MetricsAggregateQuantileOverTime:
+		if len(qs) == 0 {
+			return "", nil, fmt.Errorf("traceql: quantile_over_time requires at least one quantile")
+		}
+		if len(qs) > 1 {
+			return "", nil, fmt.Errorf("traceql: multi-quantile quantile_over_time is not yet supported (got %d quantiles)", len(qs))
+		}
+		return "quantile", []chplan.Expr{&chplan.LitFloat{V: qs[0]}}, nil
+	case traceql.MetricsAggregateHistogramOverTime:
+		return "", nil, fmt.Errorf("traceql: histogram_over_time is not yet supported")
+	}
+	return "", nil, fmt.Errorf("traceql: metrics aggregate op %s is not yet supported", op)
+}
+
+// metricsAggregateArgs picks the inner expression list for the CH
+// aggregate.
+//
+//   - rate / count_over_time: `count(1)` — there is no operand in the
+//     TraceQL source; we count rows.
+//   - *_over_time(attr) and quantile_over_time(attr, q): the lowered
+//     attribute reference.
+//
+// The "no attribute supplied" sentinel is the zero-value `Attribute{}`
+// (same convention Tempo's runtime uses at
+// ast_metrics.go: `a.attr != (Attribute{})`).
+func metricsAggregateArgs(op traceql.MetricsAggregateOp, attr traceql.Attribute, s schema.Traces) ([]chplan.Expr, error) {
+	switch op {
+	case traceql.MetricsAggregateRate, traceql.MetricsAggregateCountOverTime:
+		// `count(1)` — keeps the parameterised form symmetrical with the
+		// `count()` aggregate produced by lowerAggregate in aggregate.go.
+		return []chplan.Expr{&chplan.LitInt{V: 1}}, nil
+	}
+	if attr == (traceql.Attribute{}) {
+		return nil, fmt.Errorf("traceql: %s requires an attribute operand", op)
+	}
+	return []chplan.Expr{lowerAttribute(attr, s)}, nil
+}
+
+// lowerMetricsGroupBy turns a TraceQL `by (<attr>, <attr>, ...)` list
+// into the chplan grouping expressions + parallel alias slice.
+//
+// Each `by` attribute lowers via the same accessor lowerAttribute uses
+// for spanset matchers, so resource.* / span.* / intrinsics all resolve
+// to the right carrier (column ref for intrinsics, FieldAccess for map
+// keys). The alias is the attribute's TraceQL name — that lets the
+// /api/metrics/query_range handler decode the SELECT row back into a
+// labelled series without re-parsing the source.
+//
+// Returns (nil, nil, nil) when the `by(...)` list is empty — that
+// matches chplan.Aggregate's convention for "no grouping".
+func lowerMetricsGroupBy(attrs []traceql.Attribute, s schema.Traces) ([]chplan.Expr, []string, error) {
+	if len(attrs) == 0 {
+		return nil, nil, nil
+	}
+	exprs := make([]chplan.Expr, 0, len(attrs))
+	aliases := make([]string, 0, len(attrs))
+	for _, a := range attrs {
+		if a == (traceql.Attribute{}) {
+			return nil, nil, fmt.Errorf("traceql: empty by(...) group key")
+		}
+		exprs = append(exprs, lowerAttribute(a, s))
+		aliases = append(aliases, a.Name)
+	}
+	return exprs, aliases, nil
+}

--- a/internal/traceql/metrics_pipeline_test.go
+++ b/internal/traceql/metrics_pipeline_test.go
@@ -1,0 +1,204 @@
+package traceql_test
+
+import (
+	"strings"
+	"testing"
+
+	tempo "github.com/grafana/tempo/pkg/traceql"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/traceql"
+)
+
+// TestLowerMetricsPipeline exercises the MetricsPipeline lowering
+// directly: parse a TraceQL metrics query, lower it, and walk the
+// resulting chplan tree to confirm the expected Aggregate(Scan)
+// shape, group-by labels, and CH aggregate function name.
+//
+// Range / step intentionally aren't part of the lowered tree —
+// the /api/metrics/query_range handler wraps with chplan.RangeWindow
+// at request time (see docs/fork-tempo-plan.md § 2c).
+func TestLowerMetricsPipeline(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelTraces()
+
+	cases := []struct {
+		name      string
+		query     string
+		wantAgg   string // CH aggregate function on the outer node
+		wantArgs  int    // number of Args on the AggFunc
+		wantGroup int    // number of GroupBy expressions
+		hasFilter bool   // whether the spanset selector produces a Filter
+	}{
+		{
+			name:    "rate_no_selector",
+			query:   "{} | rate()",
+			wantAgg: "count", wantArgs: 1, wantGroup: 0, hasFilter: true,
+		},
+		{
+			name:    "count_over_time_with_selector",
+			query:   `{ resource.service.name = "frontend" } | count_over_time()`,
+			wantAgg: "count", wantArgs: 1, wantGroup: 0, hasFilter: true,
+		},
+		{
+			name:    "sum_over_time_attr",
+			query:   `{} | sum_over_time(duration)`,
+			wantAgg: "sum", wantArgs: 1, wantGroup: 0, hasFilter: true,
+		},
+		{
+			name:    "min_over_time_attr",
+			query:   `{} | min_over_time(duration)`,
+			wantAgg: "min", wantArgs: 1, wantGroup: 0, hasFilter: true,
+		},
+		{
+			name:    "max_over_time_attr",
+			query:   `{} | max_over_time(duration)`,
+			wantAgg: "max", wantArgs: 1, wantGroup: 0, hasFilter: true,
+		},
+		{
+			name:    "rate_by_label",
+			query:   `{} | rate() by (resource.service.name)`,
+			wantAgg: "count", wantArgs: 1, wantGroup: 1, hasFilter: true,
+		},
+		{
+			name:    "quantile_over_time_single",
+			query:   `{} | quantile_over_time(duration, 0.95)`,
+			wantAgg: "quantile", wantArgs: 1, wantGroup: 0, hasFilter: true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			expr, err := tempo.Parse(tc.query)
+			if err != nil {
+				t.Fatalf("Parse(%q): %v", tc.query, err)
+			}
+			plan, err := traceql.Lower(expr, s)
+			if err != nil {
+				t.Fatalf("Lower(%q): %v", tc.query, err)
+			}
+
+			agg, ok := plan.(*chplan.Aggregate)
+			if !ok {
+				t.Fatalf("expected outermost node to be *chplan.Aggregate, got %T", plan)
+			}
+			if len(agg.AggFuncs) != 1 {
+				t.Fatalf("expected exactly 1 AggFunc, got %d", len(agg.AggFuncs))
+			}
+			af := agg.AggFuncs[0]
+			if af.Name != tc.wantAgg {
+				t.Errorf("AggFunc.Name = %q, want %q", af.Name, tc.wantAgg)
+			}
+			if af.Alias != "Value" {
+				t.Errorf("AggFunc.Alias = %q, want %q", af.Alias, "Value")
+			}
+			if len(af.Args) != tc.wantArgs {
+				t.Errorf("len(AggFunc.Args) = %d, want %d", len(af.Args), tc.wantArgs)
+			}
+			if len(agg.GroupBy) != tc.wantGroup {
+				t.Errorf("len(Aggregate.GroupBy) = %d, want %d", len(agg.GroupBy), tc.wantGroup)
+			}
+			if len(agg.GroupBy) != len(agg.GroupByAliases) {
+				t.Errorf("GroupBy/GroupByAliases length mismatch: %d vs %d", len(agg.GroupBy), len(agg.GroupByAliases))
+			}
+
+			// Walk the inner subtree: Scan, optionally wrapped by Filter.
+			inner := agg.Input
+			if tc.hasFilter {
+				f, ok := inner.(*chplan.Filter)
+				if !ok {
+					t.Fatalf("expected Aggregate.Input to be *chplan.Filter, got %T", inner)
+				}
+				inner = f.Input
+			}
+			scan, ok := inner.(*chplan.Scan)
+			if !ok {
+				t.Fatalf("expected Aggregate.Input innermost to be *chplan.Scan, got %T", inner)
+			}
+			if scan.Table != s.SpansTable {
+				t.Errorf("Scan.Table = %q, want %q", scan.Table, s.SpansTable)
+			}
+
+			// Quantile case: Params carry the quantile literal.
+			if tc.wantAgg == "quantile" {
+				if len(af.Params) != 1 {
+					t.Fatalf("expected 1 quantile Param, got %d", len(af.Params))
+				}
+				lf, ok := af.Params[0].(*chplan.LitFloat)
+				if !ok {
+					t.Fatalf("expected Param[0] to be *chplan.LitFloat, got %T", af.Params[0])
+				}
+				if lf.V != 0.95 {
+					t.Errorf("quantile = %v, want 0.95", lf.V)
+				}
+			}
+		})
+	}
+}
+
+// TestLowerMetricsPipelineUnsupported documents the cases that
+// surface as clean errors rather than panicking.
+//
+// `avg_over_time(...)` is deferred because Tempo parses it into an
+// unexported `*averageOverTimeAggregator` rather than a
+// `*MetricsAggregate` — the cerberus-accessors fork hasn't exposed
+// accessors on that type yet, and the post-#148 rule forbids
+// reflect/unsafe on parser AST.
+//
+// `| > 0` (MetricsSecondStage) is deferred until the second-stage
+// filter / topk lowering lands.
+func TestLowerMetricsPipelineUnsupported(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelTraces()
+
+	cases := []struct {
+		name       string
+		query      string
+		wantSubstr string
+	}{
+		{
+			name:       "avg_over_time_deferred",
+			query:      `{} | avg_over_time(duration)`,
+			wantSubstr: "not yet supported",
+		},
+		{
+			name:       "histogram_over_time_deferred",
+			query:      `{} | histogram_over_time(duration)`,
+			wantSubstr: "histogram_over_time is not yet supported",
+		},
+		{
+			name:       "quantile_over_time_multi_deferred",
+			query:      `{} | quantile_over_time(duration, 0.5, 0.9, 0.99)`,
+			wantSubstr: "multi-quantile",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			expr, err := tempo.Parse(tc.query)
+			if err != nil {
+				// Some forms may fail to parse upstream — the test
+				// is documenting what cerberus surfaces, so a parser
+				// error is acceptable for these deferred forms.
+				return
+			}
+			_, err = traceql.Lower(expr, s)
+			if err == nil {
+				t.Fatalf("Lower(%q): expected error, got nil", tc.query)
+			}
+			if !strings.Contains(err.Error(), tc.wantSubstr) {
+				t.Errorf("Lower(%q) error = %q, want substring %q",
+					tc.query, err.Error(), tc.wantSubstr)
+			}
+		})
+	}
+}

--- a/test/spec/traceql/metrics_count_over_time.txtar
+++ b/test/spec/traceql/metrics_count_over_time.txtar
@@ -1,0 +1,8 @@
+-- query.traceql --
+{ resource.service.name = "frontend" } | count_over_time()
+-- sql --
+SELECT count(?) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`ResourceAttributes`[?] = ?))
+-- args --
+[0] int64 = 1
+[1] string = "service.name"
+[2] string = "frontend"

--- a/test/spec/traceql/metrics_max_over_time.txtar
+++ b/test/spec/traceql/metrics_max_over_time.txtar
@@ -1,0 +1,6 @@
+-- query.traceql --
+{} | max_over_time(duration)
+-- sql --
+SELECT max(`Duration`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_traces`) WHERE ?)
+-- args --
+[0] bool = true

--- a/test/spec/traceql/metrics_min_over_time.txtar
+++ b/test/spec/traceql/metrics_min_over_time.txtar
@@ -1,0 +1,6 @@
+-- query.traceql --
+{} | min_over_time(duration)
+-- sql --
+SELECT min(`Duration`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_traces`) WHERE ?)
+-- args --
+[0] bool = true

--- a/test/spec/traceql/metrics_quantile_over_time.txtar
+++ b/test/spec/traceql/metrics_quantile_over_time.txtar
@@ -1,0 +1,7 @@
+-- query.traceql --
+{} | quantile_over_time(duration, 0.95)
+-- sql --
+SELECT quantile(?)(`Duration`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_traces`) WHERE ?)
+-- args --
+[0] float64 = 0.95
+[1] bool = true

--- a/test/spec/traceql/metrics_rate.txtar
+++ b/test/spec/traceql/metrics_rate.txtar
@@ -1,0 +1,7 @@
+-- query.traceql --
+{} | rate()
+-- sql --
+SELECT count(?) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_traces`) WHERE ?)
+-- args --
+[0] int64 = 1
+[1] bool = true

--- a/test/spec/traceql/metrics_rate_by.txtar
+++ b/test/spec/traceql/metrics_rate_by.txtar
@@ -1,0 +1,9 @@
+-- query.traceql --
+{} | rate() by (resource.service.name)
+-- sql --
+SELECT `ResourceAttributes`[?] AS `service.name`, count(?) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_traces`) WHERE ?) GROUP BY `ResourceAttributes`[?]
+-- args --
+[0] string = "service.name"
+[1] int64 = 1
+[2] bool = true
+[3] string = "service.name"

--- a/test/spec/traceql/metrics_sum_over_time.txtar
+++ b/test/spec/traceql/metrics_sum_over_time.txtar
@@ -1,0 +1,6 @@
+-- query.traceql --
+{} | sum_over_time(duration)
+-- sql --
+SELECT sum(`Duration`) AS `Value` FROM (SELECT * FROM (SELECT * FROM `otel_traces`) WHERE ?)
+-- args --
+[0] bool = true


### PR DESCRIPTION
## Summary
- Implements `MetricsPipeline` lowering in `internal/traceql/`: `rate()`, `count_over_time()`, `sum_over_time()`, `min_over_time()`, `max_over_time()`, `quantile_over_time(attr, q)` lower to `Aggregate(<op>, <spanset-tree>(otel_traces))`, carrying `GroupBy` labels from `by (...)` and an optional `Filter` for the spanset selector.
- Removes the explicit \"not yet supported\" guard in `lower.go`; routes a non-nil `expr.MetricsPipeline` to a new `lowerMetricsPipeline` after the spanset pipeline is lowered.
- Uses the `tsouza/tempo:cerberus-accessors` fork's `MetricsAggregate.{Op,Attribute,GroupBy,Quantiles}` accessors and `MetricsAggregate*` constants. Zero `unsafe` / `reflect` (the post-#148 rule).
- **Range parameter intentionally NOT in the lowered tree** — TraceQL doesn't carry the range in the AST; it comes from the HTTP `/api/metrics/query_range` request. The handler PR (follow-up to this one) wraps the lowered `Aggregate(...)` with `chplan.RangeWindow` to apply the per-step window.
- 7 new TXTAR fixtures under `test/spec/traceql/metrics_*` pin lowered SQL shape for each aggregator + the `by (...)` and `quantile(0.95)` cases.

### Deferred (clean errors, not panics)
- `avg_over_time(attr)` — Tempo's parser routes this through an unexported `*averageOverTimeAggregator` rather than `*MetricsAggregate`. The fork hasn't exposed accessors on that type yet, and the post-#148 rule forbids reflect/unsafe on the parser AST. Mapping table in `mapMetricsAggregateOp` is wired (`AvgOverTime → \"avg\"`) so a future fork patch that adds an `*averageOverTimeAggregator` adapter only needs a single type-switch addition.
- `histogram_over_time(attr)` — needs a different chplan shape than scalar `Aggregate`; the `/api/metrics/query_range` histogram-series wire-format hasn't landed yet.
- Multi-quantile `quantile_over_time(attr, q1, q2, ...)` — surfaces a clean \"multi-quantile … is not yet supported\" error; single-quantile is the common Grafana case.
- `MetricsSecondStage` (`| > N`, `| topk(N)`, `| bottomk(N)`) — `Lower()` surfaces a clean not-yet-supported error.

### chplan additions
None. `chplan.Aggregate` already uses string CH function names (`count` / `sum` / `avg` / `min` / `max` / `quantile`) plus a `Params` slot for parameterised aggregates, so no enum additions or new node types were needed.

### Out-of-scope fix piggy-backed
Includes a one-line `int → int64` cast in `internal/api/loki/detected_fields.go` so the `check` + `lint` required CI jobs go green. Origin/main is currently red on that file (run `25790341717`); without this cast my branch's CI would fail on the same unrelated typecheck error. Happy to split into a precursor PR if preferred.

## Test plan
- [x] `go build ./...` clean.
- [x] `go test ./internal/traceql/...` passes; new lowering tests cover rate / count / sum / min / max / quantile + group-by + the deferred-error paths.
- [x] `go test ./...` passes (940 tests, 18 packages).
- [x] TXTAR fixtures under `test/spec/traceql/metrics_*` pin lowered SQL — `count(1)` for rate/count_over_time, `sum/min/max(\`Duration\`)` for the *_over_time(attr) cases, `quantile(0.95)(\`Duration\`)` for the quantile case, `GROUP BY \`ResourceAttributes\`[?]` for the by-label case.
- [x] `grep -RIn 'unsafe\\|reflect' internal/traceql/metrics_pipeline.go` returns only comment-level mentions.
- [x] `go vet ./internal/traceql/...` clean.
- [x] `gofumpt -l internal/traceql/` empty.
- [x] `golangci-lint run ./...` clean.

Roadmap: PR #C from `docs/fork-tempo-plan.md` migration sequence (PR #A `#143` + PR #B `#149` are on main). Unblocks the `/api/metrics/query_range` handler (follow-up).