### PR TITLE
feat(traceql): set ops (&&, ||, ~) + group / coalesce pipeline elements (RC2)

### DIFF
--- a/internal/chplan/set_op.go
+++ b/internal/chplan/set_op.go
@@ -1,0 +1,45 @@
+package chplan
+
+// SetOp identifies a TraceQL spanset set-operation: `A && B` (intersect)
+// or `A || B` (union). Spanset boundaries collapse to a flat row stream
+// keyed on (TraceID, SpanID); SetIntersect keeps rows that appear on
+// both sides, SetUnion concatenates while deduping on the identity key.
+type SetOp string
+
+const (
+	// SetIntersect — `A && B` — keep rows whose (TraceID, SpanID) appears
+	// on both sides. Lowers to an INNER JOIN on the identity key.
+	SetIntersect SetOp = "&&"
+	// SetUnion — `A || B` — keep rows appearing on either side. Lowers
+	// to a UNION DISTINCT of the two subqueries.
+	SetUnion SetOp = "||"
+)
+
+// SetOperation models a TraceQL spanset set-op (`A && B`, `A || B`).
+// Both sides produce span rows from the same traces table; the result
+// is keyed on (TraceIDColumn, SpanIDColumn) for dedup / intersect.
+type SetOperation struct {
+	Left, Right Node
+	Op          SetOp
+
+	TraceIDColumn string
+	SpanIDColumn  string
+}
+
+func (*SetOperation) planNode() {}
+
+func (s *SetOperation) Children() []Node { return []Node{s.Left, s.Right} }
+
+func (s *SetOperation) Equal(other Node) bool {
+	o, ok := other.(*SetOperation)
+	if !ok {
+		return false
+	}
+	if s.Op != o.Op {
+		return false
+	}
+	if s.TraceIDColumn != o.TraceIDColumn || s.SpanIDColumn != o.SpanIDColumn {
+		return false
+	}
+	return s.Left.Equal(o.Left) && s.Right.Equal(o.Right)
+}

--- a/internal/chplan/structural_join.go
+++ b/internal/chplan/structural_join.go
@@ -6,10 +6,12 @@ package chplan
 //	StructuralDescendant — `A >> B`: A is an ancestor of B         (return B rows)
 //	StructuralParent    — `A < B`  : A is the direct child of B   (return B rows)
 //	StructuralAncestor  — `A << B` : A is a descendant of B        (return B rows)
+//	StructuralSibling   — `A ~ B`  : A and B share the same parent (return B rows)
 //
 // `>>` and `<<` need recursive CTE / multi-level joins; the seed
 // (M4.2) emits `>` and `<` and rejects the recursive forms with a
-// pointer to the M4.2 follow-up.
+// pointer to the M4.2 follow-up. `~` (sibling) lands alongside the
+// RC2 set-ops work.
 type StructuralOp string
 
 const (
@@ -17,6 +19,7 @@ const (
 	StructuralParent     StructuralOp = "<"
 	StructuralDescendant StructuralOp = ">>"
 	StructuralAncestor   StructuralOp = "<<"
+	StructuralSibling    StructuralOp = "~"
 )
 
 // StructuralJoin produces the rows from `Right` whose spans satisfy the

--- a/internal/chsql/emit.go
+++ b/internal/chsql/emit.go
@@ -60,6 +60,8 @@ func (e *emitter) emitNode(n chplan.Node) error {
 		return e.emitVectorJoin(v)
 	case *chplan.StructuralJoin:
 		return e.emitStructuralJoin(v)
+	case *chplan.SetOperation:
+		return e.emitSetOperation(v)
 	default:
 		return fmt.Errorf("%w: node %T", ErrUnsupported, n)
 	}

--- a/internal/chsql/set_op.go
+++ b/internal/chsql/set_op.go
@@ -1,0 +1,76 @@
+package chsql
+
+import (
+	"fmt"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// emitSetOperation renders a TraceQL spanset set-op (`A && B`, `A || B`).
+//
+//   - SetIntersect (`&&`): INNER JOIN of the two subqueries on
+//     (TraceID, SpanID); the result projects the left side's columns
+//     (TraceQL convention: the row identity comes from the left
+//     spanset).
+//   - SetUnion     (`||`): `(<left>) UNION DISTINCT (<right>)` — CH
+//     UNION DISTINCT collapses identical rows across the two arms.
+//
+// Both shapes flow through SelectBuilder so the typed slot lifecycle
+// (FROM source, WHERE predicates, etc.) stays intact. UNION is a
+// SELECT-level binary operator, not a clause keyword inside a single
+// SELECT, so the `" UNION DISTINCT "` token sits between two
+// pre-rendered SelectBuilder Frags rather than abusing a clause slot.
+func (e *emitter) emitSetOperation(s *chplan.SetOperation) error {
+	if s.TraceIDColumn == "" || s.SpanIDColumn == "" {
+		return fmt.Errorf("%w: SetOperation column names unset", ErrUnsupported)
+	}
+
+	leftFrag, err := e.subqueryFrag(s.Left)
+	if err != nil {
+		return err
+	}
+	rightFrag, err := e.subqueryFrag(s.Right)
+	if err != nil {
+		return err
+	}
+
+	switch s.Op {
+	case chplan.SetIntersect:
+		// SELECT L.* FROM (<left>) AS L INNER JOIN (<right>) AS R
+		//   ON L.TraceId = R.TraceId AND L.SpanId = R.SpanId
+		traceID := s.TraceIDColumn
+		spanID := s.SpanIDColumn
+		from := func(b *Builder) {
+			leftFrag(b)
+			b.WriteSQL(" AS L INNER JOIN ")
+			rightFrag(b)
+			b.WriteSQL(" AS R ON ")
+			b.QualIdent("L", traceID)
+			b.WriteSQL(" = ")
+			b.QualIdent("R", traceID)
+			b.WriteSQL(" AND ")
+			b.QualIdent("L", spanID)
+			b.WriteSQL(" = ")
+			b.QualIdent("R", spanID)
+		}
+		sb := NewSelect().
+			Select(Raw("L.*")).
+			From(from)
+		e.emitSelect(sb)
+		return nil
+	case chplan.SetUnion:
+		// (<left>) UNION DISTINCT (<right>). CH's UNION DISTINCT
+		// dedupes on the full row tuple, which matches TraceQL's
+		// "spans appearing on either side" semantics for spans drawn
+		// from the same underlying table. Each subquery Frag is
+		// already a `(SELECT ...)` parenthesised form, so the
+		// rendered output is well-formed CH UNION.
+		b := NewBuilder()
+		leftFrag(b)
+		b.WriteSQL(" UNION DISTINCT ")
+		rightFrag(b)
+		e.splice(b)
+		return nil
+	}
+	return fmt.Errorf("%w: set op %q", ErrUnsupported, s.Op)
+}

--- a/internal/chsql/structural_join.go
+++ b/internal/chsql/structural_join.go
@@ -13,6 +13,9 @@ import (
 //
 //	StructuralChild  (`>`):  L.SpanID = R.ParentSpanID  (R's parent matches L)
 //	StructuralParent (`<`):  L.ParentSpanID = R.SpanID  (R is L's parent)
+//	StructuralSibling (`~`): L.ParentSpanID = R.ParentSpanID AND
+//	                        L.SpanID != R.SpanID (same parent, distinct
+//	                        spans)
 //
 // Recursive forms (`>>`, `<<`) need a recursive CTE / multi-level join
 // and surface as ErrUnsupported until the M4.2 follow-up.
@@ -31,6 +34,11 @@ func (e *emitter) emitStructuralJoin(j *chplan.StructuralJoin) error {
 		rel = "L." + spanCol + " = R." + parentCol
 	case chplan.StructuralParent:
 		rel = "L." + parentCol + " = R." + spanCol
+	case chplan.StructuralSibling:
+		// `A ~ B` — same trace, same parent, distinct spans. The
+		// distinct-span clause keeps a row from matching itself when
+		// both sides of the spanset select the same span.
+		rel = "L." + parentCol + " = R." + parentCol + " AND L." + spanCol + " != R." + spanCol
 	case chplan.StructuralDescendant, chplan.StructuralAncestor:
 		// `>>` / `<<` need a recursive walk through the parent chain —
 		// CH's WITH RECURSIVE syntax or a bounded-depth UNION of

--- a/internal/traceql/group_coalesce.go
+++ b/internal/traceql/group_coalesce.go
@@ -1,0 +1,84 @@
+// See aggregate.go for the no-reflection / no-pointer-aliasing rule
+// covering this file. group(...) and coalesce() lower exclusively
+// through the upstream-fork-exposed public fields on
+// traceql.GroupOperation / traceql.CoalesceOperation — no reflect, no
+// unsafe.
+
+package traceql
+
+import (
+	"fmt"
+
+	"github.com/grafana/tempo/pkg/traceql"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// Aliases for the per-group representative columns emitted by
+// `| group(...)` and `| coalesce()`. The /api/search response handler
+// decodes these to rebuild spanset rows.
+const (
+	groupKeyAlias = "GroupKey"
+)
+
+// lowerGroup handles `| group(<field-expr>)` — the TraceQL grouping
+// pipeline element that collapses results into one representative span
+// per group key.
+//
+// SQL shape: Aggregate { Input: prev, GroupBy: [<key-expr>],
+//
+//	AggFuncs: [ any(TraceId) AS TraceId,
+//	            any(SpanId) AS SpanId,
+//	            min(Timestamp) AS Timestamp ] }
+//
+// The earliest span per group (min(Timestamp)) is the natural
+// representative for trace UIs; `any()` for the identity columns picks
+// a deterministic-per-group row (CH's `any` is implementation-defined
+// but stable within a query). Future work: argMin(SpanId, Timestamp)
+// once the optimizer can prove the group-key resolves to a single row.
+func lowerGroup(prev chplan.Node, g traceql.GroupOperation, s schema.Traces) (chplan.Node, error) {
+	if g.Expression == nil {
+		return nil, fmt.Errorf("traceql: `| group(...)` requires a field expression")
+	}
+	key, err := lowerFieldExpr(g.Expression, s)
+	if err != nil {
+		return nil, err
+	}
+
+	return &chplan.Aggregate{
+		Input:          prev,
+		GroupBy:        []chplan.Expr{key},
+		GroupByAliases: []string{groupKeyAlias},
+		AggFuncs: []chplan.AggFunc{
+			{Name: "any", Args: []chplan.Expr{&chplan.ColumnRef{Name: s.TraceIDColumn}}, Alias: s.TraceIDColumn},
+			{Name: "any", Args: []chplan.Expr{&chplan.ColumnRef{Name: s.SpanIDColumn}}, Alias: s.SpanIDColumn},
+			{Name: "min", Args: []chplan.Expr{&chplan.ColumnRef{Name: s.TimestampColumn}}, Alias: s.TimestampColumn},
+		},
+	}, nil
+}
+
+// lowerCoalesce handles `| coalesce()` — Tempo's spanset-flattening
+// pipeline element. In Tempo's runtime, coalesce() merges results that
+// span multiple spansets (typically the output of a set-op like
+// `A || B`) into a single spanset with duplicates removed.
+//
+// In cerberus's flat-row plan model the multi-spanset concept doesn't
+// exist — every prior stage emits rows already. We faithfully model
+// coalesce() as a `DISTINCT (TraceId, SpanId)` dedup via an Aggregate
+// that groups by the span-identity columns and keeps one row per group.
+// For inputs that don't have duplicates (the common single-spanset
+// case) the optimizer can fold the no-op grouping in a later pass.
+func lowerCoalesce(prev chplan.Node, s schema.Traces) (chplan.Node, error) {
+	return &chplan.Aggregate{
+		Input: prev,
+		GroupBy: []chplan.Expr{
+			&chplan.ColumnRef{Name: s.TraceIDColumn},
+			&chplan.ColumnRef{Name: s.SpanIDColumn},
+		},
+		GroupByAliases: []string{s.TraceIDColumn, s.SpanIDColumn},
+		AggFuncs: []chplan.AggFunc{
+			{Name: "min", Args: []chplan.Expr{&chplan.ColumnRef{Name: s.TimestampColumn}}, Alias: s.TimestampColumn},
+		},
+	}, nil
+}

--- a/internal/traceql/group_coalesce_test.go
+++ b/internal/traceql/group_coalesce_test.go
@@ -1,0 +1,96 @@
+package traceql_test
+
+import (
+	"testing"
+
+	tempo "github.com/grafana/tempo/pkg/traceql"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/traceql"
+)
+
+// TestLowerGroupCoalesce covers the `| by(...)` (TraceQL's
+// GroupOperation, conventionally spelled `group()` in user-facing docs
+// but `by()` in the grammar — see Tempo expr.y) and `| coalesce()`
+// pipeline elements. Each lowers to an Aggregate whose Input is the
+// previous stage's plan; the GroupBy / AggFuncs differ.
+func TestLowerGroupCoalesce(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelTraces()
+
+	t.Run("group_by_attr", func(t *testing.T) {
+		t.Parallel()
+		expr, err := tempo.Parse(`{} | by(resource.service.name)`)
+		if err != nil {
+			t.Fatalf("Parse: %v", err)
+		}
+		plan, err := traceql.Lower(expr, s)
+		if err != nil {
+			t.Fatalf("Lower: %v", err)
+		}
+		agg, ok := plan.(*chplan.Aggregate)
+		if !ok {
+			t.Fatalf("expected *chplan.Aggregate, got %T", plan)
+		}
+		if len(agg.GroupBy) != 1 {
+			t.Errorf("len(GroupBy) = %d, want 1", len(agg.GroupBy))
+		}
+		// Three rep AggFuncs: any(TraceId), any(SpanId), min(Timestamp).
+		if len(agg.AggFuncs) != 3 {
+			t.Errorf("len(AggFuncs) = %d, want 3", len(agg.AggFuncs))
+		}
+		seen := map[string]int{}
+		for _, af := range agg.AggFuncs {
+			seen[af.Name]++
+		}
+		if seen["any"] != 2 || seen["min"] != 1 {
+			t.Errorf("AggFunc kind counts = %v, want any=2 min=1", seen)
+		}
+	})
+
+	t.Run("coalesce", func(t *testing.T) {
+		t.Parallel()
+		expr, err := tempo.Parse(`{} | coalesce()`)
+		if err != nil {
+			t.Fatalf("Parse: %v", err)
+		}
+		plan, err := traceql.Lower(expr, s)
+		if err != nil {
+			t.Fatalf("Lower: %v", err)
+		}
+		agg, ok := plan.(*chplan.Aggregate)
+		if !ok {
+			t.Fatalf("expected *chplan.Aggregate, got %T", plan)
+		}
+		// coalesce() groups by (TraceId, SpanId).
+		if len(agg.GroupBy) != 2 {
+			t.Errorf("len(GroupBy) = %d, want 2", len(agg.GroupBy))
+		}
+		if len(agg.GroupByAliases) != 2 {
+			t.Errorf("len(GroupByAliases) = %d, want 2", len(agg.GroupByAliases))
+		}
+		// Aliases should be the trace + span identity columns.
+		if agg.GroupByAliases[0] != s.TraceIDColumn || agg.GroupByAliases[1] != s.SpanIDColumn {
+			t.Errorf("GroupByAliases = %v, want [%q, %q]",
+				agg.GroupByAliases, s.TraceIDColumn, s.SpanIDColumn)
+		}
+	})
+
+	t.Run("group_missing_expr", func(t *testing.T) {
+		t.Parallel()
+		// `by()` with no expression should fail at parse time, but if a
+		// caller hand-builds a GroupOperation with a nil Expression the
+		// lowering surfaces a clean error rather than panicking.
+		_, err := traceql.Lower(&tempo.RootExpr{
+			Pipeline: tempo.Pipeline{Elements: []tempo.PipelineElement{
+				&tempo.SpansetFilter{},
+				tempo.GroupOperation{Expression: nil},
+			}},
+		}, s)
+		if err == nil {
+			t.Fatal("Lower: expected error from nil GroupOperation.Expression, got nil")
+		}
+	})
+}

--- a/internal/traceql/lower.go
+++ b/internal/traceql/lower.go
@@ -65,8 +65,8 @@ func Lower(expr *traceql.RootExpr, s schema.Traces) (chplan.Node, error) {
 }
 
 // lowerFollowingElement layers a pipeline element onto the previous
-// stage's plan. Aggregate / ScalarFilter / SelectOperation are
-// supported; GroupOperation / CoalesceOperation defer to RC2.
+// stage's plan. Aggregate / ScalarFilter / SelectOperation /
+// GroupOperation / CoalesceOperation are supported.
 func lowerFollowingElement(prev chplan.Node, elem traceql.PipelineElement, s schema.Traces) (chplan.Node, error) {
 	switch v := elem.(type) {
 	case traceql.Aggregate:
@@ -81,8 +81,16 @@ func lowerFollowingElement(prev chplan.Node, elem traceql.PipelineElement, s sch
 		return lowerSelect(prev, v, s)
 	case *traceql.SelectOperation:
 		return lowerSelect(prev, *v, s)
+	case traceql.GroupOperation:
+		return lowerGroup(prev, v, s)
+	case *traceql.GroupOperation:
+		return lowerGroup(prev, *v, s)
+	case traceql.CoalesceOperation:
+		return lowerCoalesce(prev, s)
+	case *traceql.CoalesceOperation:
+		return lowerCoalesce(prev, s)
 	}
-	return nil, fmt.Errorf("traceql: pipeline tail element %T is not yet supported (group / coalesce land in RC2)", elem)
+	return nil, fmt.Errorf("traceql: pipeline tail element %T is not yet supported", elem)
 }
 
 // lowerScalarFilter handles `| count() > 0`, `| sum(.duration) >= 1s`,
@@ -150,10 +158,9 @@ func lowerPipelineElement(elem traceql.PipelineElement, s schema.Traces) (chplan
 	return nil, fmt.Errorf("traceql: pipeline element %T is not yet supported", elem)
 }
 
-// lowerSpansetOperation handles structural relations (`A > B`, `A < B`)
-// and set operations (`A && B`, `A || B`). The seed (M4.2) covers
-// direct-parent / direct-child structural ops; recursive forms (`>>`,
-// `<<`) and set ops defer.
+// lowerSpansetOperation handles structural relations (`A > B`, `A < B`,
+// `A ~ B`) and set operations (`A && B`, `A || B`). Recursive structural
+// forms (`>>`, `<<`) and the negated / union-prefixed variants defer.
 func lowerSpansetOperation(op *traceql.SpansetOperation, s schema.Traces) (chplan.Node, error) {
 	left, err := lowerSpansetExpr(op.LHS, s)
 	if err != nil {
@@ -162,6 +169,19 @@ func lowerSpansetOperation(op *traceql.SpansetOperation, s schema.Traces) (chpla
 	right, err := lowerSpansetExpr(op.RHS, s)
 	if err != nil {
 		return nil, err
+	}
+
+	// Set operations (`&&` / `||`) lower to a chplan.SetOperation; the
+	// emitter renders an INNER JOIN (intersect) or UNION DISTINCT (union)
+	// keyed on (TraceID, SpanID).
+	if setOp, ok := mapSetOp(op.Op); ok {
+		return &chplan.SetOperation{
+			Left:          left,
+			Right:         right,
+			Op:            setOp,
+			TraceIDColumn: s.TraceIDColumn,
+			SpanIDColumn:  s.SpanIDColumn,
+		}, nil
 	}
 
 	relation, err := mapStructuralOp(op.Op)
@@ -176,6 +196,19 @@ func lowerSpansetOperation(op *traceql.SpansetOperation, s schema.Traces) (chpla
 		SpanIDColumn:       s.SpanIDColumn,
 		ParentSpanIDColumn: s.ParentSpanIDColumn,
 	}, nil
+}
+
+// mapSetOp identifies the TraceQL operators that lower to a
+// chplan.SetOperation. Returns ok=false for non-set operators so the
+// caller falls back to structural-relation handling.
+func mapSetOp(op traceql.Operator) (chplan.SetOp, bool) {
+	switch op {
+	case traceql.OpSpansetAnd:
+		return chplan.SetIntersect, true
+	case traceql.OpSpansetUnion:
+		return chplan.SetUnion, true
+	}
+	return "", false
 }
 
 // lowerSpansetExpr lowers a TraceQL SpansetExpression (the LHS/RHS of
@@ -205,10 +238,14 @@ func mapStructuralOp(op traceql.Operator) (chplan.StructuralOp, error) {
 		return chplan.StructuralDescendant, nil
 	case traceql.OpSpansetAncestor:
 		return chplan.StructuralAncestor, nil
-	case traceql.OpSpansetAnd, traceql.OpSpansetUnion, traceql.OpSpansetSibling,
-		traceql.OpSpansetNotChild, traceql.OpSpansetNotParent, traceql.OpSpansetNotSibling,
-		traceql.OpSpansetNotAncestor, traceql.OpSpansetNotDescendant:
-		return "", fmt.Errorf("traceql: spanset op %s is not yet supported (set / sibling ops land in M4.2 follow-ups)", op)
+	case traceql.OpSpansetSibling:
+		return chplan.StructuralSibling, nil
+	case traceql.OpSpansetNotChild, traceql.OpSpansetNotParent, traceql.OpSpansetNotSibling,
+		traceql.OpSpansetNotAncestor, traceql.OpSpansetNotDescendant,
+		traceql.OpSpansetUnionChild, traceql.OpSpansetUnionParent,
+		traceql.OpSpansetUnionSibling, traceql.OpSpansetUnionAncestor,
+		traceql.OpSpansetUnionDescendant:
+		return "", fmt.Errorf("traceql: spanset op %s is not yet supported (negated / union-prefixed structural variants defer to RC3)", op)
 	}
 	return "", fmt.Errorf("traceql: spanset op %s is not a structural relation", op)
 }

--- a/internal/traceql/set_ops_test.go
+++ b/internal/traceql/set_ops_test.go
@@ -1,0 +1,129 @@
+package traceql_test
+
+import (
+	"strings"
+	"testing"
+
+	tempo "github.com/grafana/tempo/pkg/traceql"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/traceql"
+)
+
+// TestLowerSetOps exercises the spanset set-op (`&&`, `||`) and the
+// sibling (`~`) lowering directly. Parses each query, lowers it, and
+// walks the resulting chplan tree to confirm the expected node kind +
+// identity columns.
+func TestLowerSetOps(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelTraces()
+
+	t.Run("set_intersect", func(t *testing.T) {
+		t.Parallel()
+		expr, err := tempo.Parse(`{ resource.service.name = "a" } && { duration > 1s }`)
+		if err != nil {
+			t.Fatalf("Parse: %v", err)
+		}
+		plan, err := traceql.Lower(expr, s)
+		if err != nil {
+			t.Fatalf("Lower: %v", err)
+		}
+		so, ok := plan.(*chplan.SetOperation)
+		if !ok {
+			t.Fatalf("expected *chplan.SetOperation, got %T", plan)
+		}
+		if so.Op != chplan.SetIntersect {
+			t.Errorf("Op = %q, want %q", so.Op, chplan.SetIntersect)
+		}
+		if so.TraceIDColumn != s.TraceIDColumn || so.SpanIDColumn != s.SpanIDColumn {
+			t.Errorf("identity columns wrong: TraceID=%q SpanID=%q",
+				so.TraceIDColumn, so.SpanIDColumn)
+		}
+	})
+
+	t.Run("set_union", func(t *testing.T) {
+		t.Parallel()
+		expr, err := tempo.Parse(`{ resource.service.name = "a" } || { resource.service.name = "b" }`)
+		if err != nil {
+			t.Fatalf("Parse: %v", err)
+		}
+		plan, err := traceql.Lower(expr, s)
+		if err != nil {
+			t.Fatalf("Lower: %v", err)
+		}
+		so, ok := plan.(*chplan.SetOperation)
+		if !ok {
+			t.Fatalf("expected *chplan.SetOperation, got %T", plan)
+		}
+		if so.Op != chplan.SetUnion {
+			t.Errorf("Op = %q, want %q", so.Op, chplan.SetUnion)
+		}
+	})
+
+	t.Run("sibling", func(t *testing.T) {
+		t.Parallel()
+		expr, err := tempo.Parse(`{ name = "parent" } ~ { name = "sibling" }`)
+		if err != nil {
+			t.Fatalf("Parse: %v", err)
+		}
+		plan, err := traceql.Lower(expr, s)
+		if err != nil {
+			t.Fatalf("Lower: %v", err)
+		}
+		sj, ok := plan.(*chplan.StructuralJoin)
+		if !ok {
+			t.Fatalf("expected *chplan.StructuralJoin, got %T", plan)
+		}
+		if sj.Op != chplan.StructuralSibling {
+			t.Errorf("Op = %q, want %q", sj.Op, chplan.StructuralSibling)
+		}
+		if sj.ParentSpanIDColumn != s.ParentSpanIDColumn {
+			t.Errorf("ParentSpanIDColumn = %q, want %q",
+				sj.ParentSpanIDColumn, s.ParentSpanIDColumn)
+		}
+	})
+}
+
+// TestLowerSetOpsUnsupported confirms that negated / union-prefixed
+// structural variants surface as clean errors rather than panicking
+// (they're parser-legal but cerberus doesn't lower them yet).
+func TestLowerSetOpsUnsupported(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelTraces()
+
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{"not_child", `{ name = "a" } !> { name = "b" }`},
+		{"not_parent", `{ name = "a" } !< { name = "b" }`},
+		{"not_sibling", `{ name = "a" } !~ { name = "b" }`},
+		{"union_child", `{ name = "a" } &> { name = "b" }`},
+		{"union_sibling", `{ name = "a" } &~ { name = "b" }`},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := tempo.Parse(tc.query)
+			if err != nil {
+				// Some shapes may fail at parse time on certain Tempo
+				// versions; the test documents lowering behavior so a
+				// parse-time rejection is acceptable.
+				return
+			}
+			_, err = traceql.Lower(expr, s)
+			if err == nil {
+				t.Fatalf("Lower(%q): expected error, got nil", tc.query)
+			}
+			if !strings.Contains(err.Error(), "not yet supported") {
+				t.Errorf("Lower(%q) error = %q, want substring %q",
+					tc.query, err.Error(), "not yet supported")
+			}
+		})
+	}
+}

--- a/test/spec/traceql/coalesce_simple.txtar
+++ b/test/spec/traceql/coalesce_simple.txtar
@@ -1,0 +1,6 @@
+-- query.traceql --
+{} | coalesce()
+-- sql --
+SELECT `TraceId` AS `TraceId`, `SpanId` AS `SpanId`, min(`Timestamp`) AS `Timestamp` FROM (SELECT * FROM (SELECT * FROM `otel_traces`) WHERE ?) GROUP BY `TraceId`, `SpanId`
+-- args --
+[0] bool = true

--- a/test/spec/traceql/group_by_attr.txtar
+++ b/test/spec/traceql/group_by_attr.txtar
@@ -1,0 +1,8 @@
+-- query.traceql --
+{} | by(resource.service.name)
+-- sql --
+SELECT `ResourceAttributes`[?] AS `GroupKey`, any(`TraceId`) AS `TraceId`, any(`SpanId`) AS `SpanId`, min(`Timestamp`) AS `Timestamp` FROM (SELECT * FROM (SELECT * FROM `otel_traces`) WHERE ?) GROUP BY `ResourceAttributes`[?]
+-- args --
+[0] string = "service.name"
+[1] bool = true
+[2] string = "service.name"

--- a/test/spec/traceql/set_intersect_simple.txtar
+++ b/test/spec/traceql/set_intersect_simple.txtar
@@ -1,0 +1,8 @@
+-- query.traceql --
+{ resource.service.name = "a" } && { duration > 1s }
+-- sql --
+SELECT L.* FROM (SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`ResourceAttributes`[?] = ?)) AS L INNER JOIN (SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`Duration` > ?)) AS R ON `L`.`TraceId` = `R`.`TraceId` AND `L`.`SpanId` = `R`.`SpanId`
+-- args --
+[0] string = "service.name"
+[1] string = "a"
+[2] int64 = 1000000000

--- a/test/spec/traceql/set_union_simple.txtar
+++ b/test/spec/traceql/set_union_simple.txtar
@@ -1,0 +1,9 @@
+-- query.traceql --
+{ resource.service.name = "a" } || { resource.service.name = "b" }
+-- sql --
+(SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`ResourceAttributes`[?] = ?)) UNION DISTINCT (SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`ResourceAttributes`[?] = ?))
+-- args --
+[0] string = "service.name"
+[1] string = "a"
+[2] string = "service.name"
+[3] string = "b"

--- a/test/spec/traceql/sibling_simple.txtar
+++ b/test/spec/traceql/sibling_simple.txtar
@@ -1,0 +1,7 @@
+-- query.traceql --
+{ name = "parent" } ~ { name = "sibling" }
+-- sql --
+SELECT R.* FROM (SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`SpanName` = ?)) AS L INNER JOIN (SELECT * FROM (SELECT * FROM `otel_traces`) WHERE (`SpanName` = ?)) AS R ON L.`TraceId` = R.`TraceId` AND L.`ParentSpanId` = R.`ParentSpanId` AND L.`SpanId` != R.`SpanId`
+-- args --
+[0] string = "parent"
+[1] string = "sibling"


### PR DESCRIPTION
## Summary

Lands two bundled RC2 items in `internal/traceql/` — both touch the same lowering surface, so they ship together:

### Part 1 — Spanset set ops + sibling

- `A && B` (intersect) → new `chplan.SetOperation{Op: SetIntersect}`; emits `SELECT L.* FROM (<L>) AS L INNER JOIN (<R>) AS R ON L.TraceId = R.TraceId AND L.SpanId = R.SpanId`.
- `A || B` (union)     → new `chplan.SetOperation{Op: SetUnion}`; emits `(<L>) UNION DISTINCT (<R>)`.
- `A ~ B`  (sibling)   → extends existing `chplan.StructuralJoin` with `StructuralSibling`; emits the same INNER-JOIN shape but joins on `L.ParentSpanId = R.ParentSpanId AND L.SpanId != R.SpanId`.

### Part 2 — Pipeline elements

- `| by(<field>)` (Tempo's `GroupOperation`; user-facing `group()` in the docs) → `chplan.Aggregate { GroupBy: [<key>], AggFuncs: [any(TraceId), any(SpanId), min(Timestamp)] }` — one representative span per group.
- `| coalesce()` → `chplan.Aggregate { GroupBy: [TraceId, SpanId], AggFuncs: [min(Timestamp)] }` — DISTINCT-on-identity dedup that models Tempo's spanset-flattening semantics in the flat-row plan model.

## IR additions

- `chplan.SetOperation` (new file `internal/chplan/set_op.go`)
- `chplan.SetOp` enum (`SetIntersect`, `SetUnion`)
- `chplan.StructuralSibling` (added to existing `StructuralOp` enum)

## SQL emission

New `internal/chsql/set_op.go` composes the join / union shape through `SelectBuilder` for `SetIntersect`; the `UNION DISTINCT` token sits between two pre-rendered subquery `Frag`s (binary-operator-between-SELECTs, not a clause keyword inside a single SELECT). The grandfathered `structural_join.go` gains a sibling case alongside `Child` / `Parent`.

## Constraints honoured

- No `unsafe.Pointer` / `reflect.*` — every parser-AST read uses the upstream fork's exported `SpansetOperation.{Op,LHS,RHS}` + `GroupOperation.Expression` fields (no new fork accessors required).
- No `Builder.WriteSQL(\"SELECT ...\")` clause cosplay (`grep -RnE 'WriteSQL\(\" *(SELECT|FROM|WHERE|GROUP BY|ORDER BY|LIMIT|PREWHERE)' internal/traceql/ internal/chplan/` returns empty).
- No `fmt.Sprintf`-on-SQL added.

## Test coverage

- `internal/traceql/set_ops_test.go` — direct lowering checks for `&&` / `||` / `~` + negative cases for negated / union-prefixed structural variants (`!>`, `!~`, `&>`, `&~`).
- `internal/traceql/group_coalesce_test.go` — direct lowering checks for `by(...)` + `coalesce()`; nil-expression guard for GroupOperation.
- Five new TXTAR fixtures under `test/spec/traceql/`: `set_intersect_simple`, `set_union_simple`, `sibling_simple`, `group_by_attr`, `coalesce_simple`.

## Test plan

- [x] `go test ./internal/traceql/... ./internal/chplan/... ./internal/chsql/...`
- [x] `go test ./...` (959 passed in 18 packages)
- [x] `$HOME/go/bin/gofumpt -l internal/` (clean)
- [x] `go vet ./internal/traceql/...`
- [x] No unsafe/reflect added (`grep -RIn 'unsafe.Pointer\|reflect\.' internal/traceql/` empty)
- [x] No clause-keyword cosplay added (grep above empty)

## Notes / follow-ups

- The negated / union-prefixed structural variants (`!>`, `!~`, `&>`, `&~`, `&<<`, `&>>`) still surface a "not yet supported" error from `mapStructuralOp`. They're parser-legal but defer to RC3 alongside the recursive `>>` / `<<` rewrite.
- `group()` is spelled `by()` in Tempo's grammar (`expr.y`); the user-facing TraceQL docs use `group()`. The lowering binds to Tempo's `GroupOperation` AST node either way — the fixture uses the grammar's spelling.