### PR TITLE
feat(schema): mirror upstream OTel CH Exporter columns (exp_histogram + missing classic histogram fields)

### DIFF
--- a/internal/schema/logs.go
+++ b/internal/schema/logs.go
@@ -4,6 +4,8 @@ package schema
 // (returned by DefaultOTelLogs) matches the OpenTelemetry ClickHouse
 // Exporter v0.x logs schema; users with custom layouts override
 // individual fields via Config.
+//
+// Column names mirror the upstream `logs_table.sql` template verbatim.
 type Logs struct {
 	// LogsTable is the table holding log records.
 	LogsTable string
@@ -13,13 +15,18 @@ type Logs struct {
 	// SeverityColumn names the column carrying the severity text
 	// (e.g. "INFO", "ERROR").
 	SeverityColumn string
-	// SeverityNumberColumn names the numeric severity column (Int32).
+	// SeverityNumberColumn names the numeric severity column (UInt8 upstream).
 	SeverityNumberColumn string
-	// AttributesColumn names the log-level attribute map.
+	// AttributesColumn names the log-level attribute map. Mirrors the
+	// upstream `LogAttributes` column.
 	AttributesColumn string
 	// ResourceAttributesColumn names the resource attribute map
 	// (carries stream-identity labels like service.name, job, etc.).
 	ResourceAttributesColumn string
+	// ScopeNameColumn names the instrumentation-scope name column.
+	ScopeNameColumn string
+	// ScopeVersionColumn names the instrumentation-scope version column.
+	ScopeVersionColumn string
 	// ScopeAttributesColumn names the instrumentation-scope attribute map.
 	ScopeAttributesColumn string
 	// TimestampColumn names the per-record timestamp column (DateTime64).
@@ -28,8 +35,14 @@ type Logs struct {
 	TraceIDColumn string
 	// SpanIDColumn names the span-id correlation column.
 	SpanIDColumn string
+	// TraceFlagsColumn names the OTel TraceFlags column (UInt8).
+	TraceFlagsColumn string
 	// ServiceNameColumn names the dedicated service name column.
 	ServiceNameColumn string
+	// EventNameColumn names the OTel log-record event name column
+	// (String; populated when the LogRecord carries a structured event
+	// name distinct from the body).
+	EventNameColumn string
 }
 
 // DefaultOTelLogs returns the schema produced by the upstream OTel
@@ -42,10 +55,14 @@ func DefaultOTelLogs() Logs {
 		SeverityNumberColumn:     "SeverityNumber",
 		AttributesColumn:         "LogAttributes",
 		ResourceAttributesColumn: "ResourceAttributes",
+		ScopeNameColumn:          "ScopeName",
+		ScopeVersionColumn:       "ScopeVersion",
 		ScopeAttributesColumn:    "ScopeAttributes",
 		TimestampColumn:          "Timestamp",
 		TraceIDColumn:            "TraceId",
 		SpanIDColumn:             "SpanId",
+		TraceFlagsColumn:         "TraceFlags",
 		ServiceNameColumn:        "ServiceName",
+		EventNameColumn:          "EventName",
 	}
 }

--- a/internal/schema/logs_test.go
+++ b/internal/schema/logs_test.go
@@ -1,0 +1,38 @@
+package schema
+
+import "testing"
+
+// TestDefaultOTelLogsPinsUpstreamColumns pins every column name
+// DefaultOTelLogs() returns against the verbatim string the upstream
+// `clickhouseexporter` writes in its `logs_table.sql` template.
+func TestDefaultOTelLogsPinsUpstreamColumns(t *testing.T) {
+	t.Parallel()
+
+	l := DefaultOTelLogs()
+
+	if l.LogsTable != "otel_logs" {
+		t.Errorf("LogsTable: got %q, want %q", l.LogsTable, "otel_logs")
+	}
+
+	cases := map[string]string{
+		"Body":               l.BodyColumn,
+		"SeverityText":       l.SeverityColumn,
+		"SeverityNumber":     l.SeverityNumberColumn,
+		"LogAttributes":      l.AttributesColumn,
+		"ResourceAttributes": l.ResourceAttributesColumn,
+		"ScopeName":          l.ScopeNameColumn,
+		"ScopeVersion":       l.ScopeVersionColumn,
+		"ScopeAttributes":    l.ScopeAttributesColumn,
+		"Timestamp":          l.TimestampColumn,
+		"TraceId":            l.TraceIDColumn,
+		"SpanId":             l.SpanIDColumn,
+		"TraceFlags":         l.TraceFlagsColumn,
+		"ServiceName":        l.ServiceNameColumn,
+		"EventName":          l.EventNameColumn,
+	}
+	for want, got := range cases {
+		if got != want {
+			t.Errorf("logs column %q: got %q, want %q (mismatch against upstream OTel CH Exporter template)", want, got, want)
+		}
+	}
+}

--- a/internal/schema/otel.go
+++ b/internal/schema/otel.go
@@ -4,13 +4,28 @@ package schema
 // (returned by DefaultOTelMetrics) matches the OpenTelemetry ClickHouse
 // Exporter v0.x schema; users with custom layouts override individual
 // fields via Config.
+//
+// The struct is a flat surface of every column the upstream
+// `clickhouseexporter` writes across the five metrics tables
+// (gauge / sum / histogram / exponential histogram / summary). Each
+// PromQL slice reads the subset relevant to its target table. Adding a
+// field here is cheap: emitters and the future `internal/schema/ddl/`
+// package both look up names by struct field rather than by string
+// constants scattered through the codebase.
 type Metrics struct {
 	// GaugeTable is the table holding gauge metrics.
 	GaugeTable string
 	// SumTable is the table holding sum / counter metrics.
 	SumTable string
-	// HistogramTable is the table holding histogram metrics.
+	// HistogramTable is the table holding classic (explicit-bucket)
+	// histogram metrics.
 	HistogramTable string
+	// ExpHistogramTable is the table holding exponential / native
+	// histogram metrics.
+	ExpHistogramTable string
+	// SummaryTable is the table holding summary metrics
+	// (Prometheus-style quantile samples).
+	SummaryTable string
 
 	// MetricNameColumn names the column holding the metric name.
 	MetricNameColumn string
@@ -20,7 +35,13 @@ type Metrics struct {
 	ResourceAttributesColumn string
 	// TimestampColumn names the timestamp column (DateTime64).
 	TimestampColumn string
-	// ValueColumn names the numeric value column (Float64).
+	// StartTimeColumn names the per-series start-timestamp column
+	// (DateTime64). Used by cumulative-to-rate conversions.
+	StartTimeColumn string
+	// ValueColumn names the numeric value column (Float64). Only the
+	// gauge + sum tables have a Value column; on histogram /
+	// exp-histogram the per-sample value is decomposed into
+	// Count / Sum / BucketCounts / etc.
 	ValueColumn string
 
 	// MetricDescriptionColumn names the column carrying the OTel
@@ -28,22 +49,122 @@ type Metrics struct {
 	MetricDescriptionColumn string
 	// MetricUnitColumn names the column carrying the OTel metric unit.
 	MetricUnitColumn string
+
+	// ServiceNameColumn names the dedicated LowCardinality service.name
+	// column written by the upstream exporter (separate from the
+	// ResourceAttributes map).
+	ServiceNameColumn string
+	// ScopeNameColumn names the instrumentation-scope name column.
+	ScopeNameColumn string
+	// ScopeVersionColumn names the instrumentation-scope version column.
+	ScopeVersionColumn string
+	// ScopeAttributesColumn names the instrumentation-scope attribute map.
+	ScopeAttributesColumn string
+
+	// FlagsColumn names the OTel data-point Flags column (UInt32 bitfield).
+	FlagsColumn string
+
+	// Classic histogram + summary columns.
+
+	// CountColumn names the per-sample observation count
+	// (UInt64; histogram, exp_histogram, summary).
+	CountColumn string
+	// SumColumn names the per-sample observation sum
+	// (Float64; histogram, exp_histogram, summary).
+	SumColumn string
+	// MinColumn names the per-sample observation minimum
+	// (Float64; histogram, exp_histogram).
+	MinColumn string
+	// MaxColumn names the per-sample observation maximum
+	// (Float64; histogram, exp_histogram).
+	MaxColumn string
+	// BucketCountsColumn names the explicit-bucket counts array
+	// (Array(UInt64); classic histogram).
+	BucketCountsColumn string
+	// ExplicitBoundsColumn names the explicit-bucket upper-bound array
+	// (Array(Float64); classic histogram).
+	ExplicitBoundsColumn string
+	// AggregationTemporalityColumn names the AggregationTemporality
+	// enum column (Int32; sum, histogram, exp_histogram).
+	AggregationTemporalityColumn string
+	// IsMonotonicColumn names the IsMonotonic boolean column
+	// (Boolean; sum table only).
+	IsMonotonicColumn string
+
+	// Exponential-histogram columns.
+
+	// ScaleColumn names the OTel exp-histogram scale column (Int32).
+	ScaleColumn string
+	// ZeroCountColumn names the count of observations that landed in
+	// the zero bucket (UInt64).
+	ZeroCountColumn string
+	// PositiveOffsetColumn names the bucket-index offset for the
+	// positive-range buckets (Int32).
+	PositiveOffsetColumn string
+	// PositiveBucketCountsColumn names the positive-range bucket
+	// counts array (Array(UInt64)).
+	PositiveBucketCountsColumn string
+	// NegativeOffsetColumn names the bucket-index offset for the
+	// negative-range buckets (Int32).
+	NegativeOffsetColumn string
+	// NegativeBucketCountsColumn names the negative-range bucket
+	// counts array (Array(UInt64)).
+	NegativeBucketCountsColumn string
+
+	// Summary-specific column.
+
+	// ValueAtQuantilesColumn names the Nested column carrying
+	// (Quantile, Value) pairs for summary metrics.
+	ValueAtQuantilesColumn string
+
+	// Exemplars (Nested) — present on gauge / sum / histogram /
+	// exp_histogram tables. ExemplarsColumn is the Nested column name;
+	// individual sub-fields (FilteredAttributes / TimeUnix / Value /
+	// SpanId / TraceId) follow Nested-access conventions
+	// (`Exemplars.SpanId`, etc.).
+	ExemplarsColumn string
 }
 
 // DefaultOTelMetrics returns the schema produced by the upstream OTel
-// ClickHouse Exporter.
+// ClickHouse Exporter. Column names mirror the upstream
+// `metrics_{gauge,sum,histogram,exp_histogram,summary}_table.sql`
+// templates verbatim.
 func DefaultOTelMetrics() Metrics {
 	return Metrics{
-		GaugeTable:               "otel_metrics_gauge",
-		SumTable:                 "otel_metrics_sum",
-		HistogramTable:           "otel_metrics_histogram",
-		MetricNameColumn:         "MetricName",
-		AttributesColumn:         "Attributes",
-		ResourceAttributesColumn: "ResourceAttributes",
-		TimestampColumn:          "TimeUnix",
-		ValueColumn:              "Value",
-		MetricDescriptionColumn:  "MetricDescription",
-		MetricUnitColumn:         "MetricUnit",
+		GaugeTable:                   "otel_metrics_gauge",
+		SumTable:                     "otel_metrics_sum",
+		HistogramTable:               "otel_metrics_histogram",
+		ExpHistogramTable:            "otel_metrics_exp_histogram",
+		SummaryTable:                 "otel_metrics_summary",
+		MetricNameColumn:             "MetricName",
+		AttributesColumn:             "Attributes",
+		ResourceAttributesColumn:     "ResourceAttributes",
+		TimestampColumn:              "TimeUnix",
+		StartTimeColumn:              "StartTimeUnix",
+		ValueColumn:                  "Value",
+		MetricDescriptionColumn:      "MetricDescription",
+		MetricUnitColumn:             "MetricUnit",
+		ServiceNameColumn:            "ServiceName",
+		ScopeNameColumn:              "ScopeName",
+		ScopeVersionColumn:           "ScopeVersion",
+		ScopeAttributesColumn:        "ScopeAttributes",
+		FlagsColumn:                  "Flags",
+		CountColumn:                  "Count",
+		SumColumn:                    "Sum",
+		MinColumn:                    "Min",
+		MaxColumn:                    "Max",
+		BucketCountsColumn:           "BucketCounts",
+		ExplicitBoundsColumn:         "ExplicitBounds",
+		AggregationTemporalityColumn: "AggregationTemporality",
+		IsMonotonicColumn:            "IsMonotonic",
+		ScaleColumn:                  "Scale",
+		ZeroCountColumn:              "ZeroCount",
+		PositiveOffsetColumn:         "PositiveOffset",
+		PositiveBucketCountsColumn:   "PositiveBucketCounts",
+		NegativeOffsetColumn:         "NegativeOffset",
+		NegativeBucketCountsColumn:   "NegativeBucketCounts",
+		ValueAtQuantilesColumn:       "ValueAtQuantiles",
+		ExemplarsColumn:              "Exemplars",
 	}
 }
 

--- a/internal/schema/otel_test.go
+++ b/internal/schema/otel_test.go
@@ -1,0 +1,113 @@
+package schema
+
+import "testing"
+
+// TestDefaultOTelMetricsPinsUpstreamColumns pins every column name
+// DefaultOTelMetrics() returns against the verbatim string the upstream
+// `clickhouseexporter` writes in its `metrics_*_table.sql` templates.
+// If upstream renames a column we want this test to break loudly — the
+// PR B → PR C → PR D chain depends on the column names matching.
+func TestDefaultOTelMetricsPinsUpstreamColumns(t *testing.T) {
+	t.Parallel()
+
+	m := DefaultOTelMetrics()
+
+	// Table names (a separate axis from column names — they don't
+	// appear inside the CREATE TABLE column list, so they aren't part
+	// of the pinning map below).
+	tables := map[string]string{
+		"GaugeTable":        m.GaugeTable,
+		"SumTable":          m.SumTable,
+		"HistogramTable":    m.HistogramTable,
+		"ExpHistogramTable": m.ExpHistogramTable,
+		"SummaryTable":      m.SummaryTable,
+	}
+	wantTables := map[string]string{
+		"GaugeTable":        "otel_metrics_gauge",
+		"SumTable":          "otel_metrics_sum",
+		"HistogramTable":    "otel_metrics_histogram",
+		"ExpHistogramTable": "otel_metrics_exp_histogram",
+		"SummaryTable":      "otel_metrics_summary",
+	}
+	for name, want := range wantTables {
+		if got := tables[name]; got != want {
+			t.Errorf("table %s: got %q, want %q", name, got, want)
+		}
+	}
+
+	cases := map[string]string{
+		// Identity / resource columns (present on every table).
+		"MetricName":         m.MetricNameColumn,
+		"Attributes":         m.AttributesColumn,
+		"ResourceAttributes": m.ResourceAttributesColumn,
+		"TimeUnix":           m.TimestampColumn,
+		"StartTimeUnix":      m.StartTimeColumn,
+		"MetricDescription":  m.MetricDescriptionColumn,
+		"MetricUnit":         m.MetricUnitColumn,
+		"ServiceName":        m.ServiceNameColumn,
+		"ScopeName":          m.ScopeNameColumn,
+		"ScopeVersion":       m.ScopeVersionColumn,
+		"ScopeAttributes":    m.ScopeAttributesColumn,
+		"Flags":              m.FlagsColumn,
+
+		// Gauge / sum specifically — Value column.
+		"Value": m.ValueColumn,
+
+		// Classic histogram + summary shared columns.
+		"Count":                  m.CountColumn,
+		"Sum":                    m.SumColumn,
+		"Min":                    m.MinColumn,
+		"Max":                    m.MaxColumn,
+		"BucketCounts":           m.BucketCountsColumn,
+		"ExplicitBounds":         m.ExplicitBoundsColumn,
+		"AggregationTemporality": m.AggregationTemporalityColumn,
+		"IsMonotonic":            m.IsMonotonicColumn,
+
+		// Exponential-histogram-specific columns.
+		"Scale":                m.ScaleColumn,
+		"ZeroCount":            m.ZeroCountColumn,
+		"PositiveOffset":       m.PositiveOffsetColumn,
+		"PositiveBucketCounts": m.PositiveBucketCountsColumn,
+		"NegativeOffset":       m.NegativeOffsetColumn,
+		"NegativeBucketCounts": m.NegativeBucketCountsColumn,
+
+		// Summary-specific.
+		"ValueAtQuantiles": m.ValueAtQuantilesColumn,
+
+		// Exemplars (Nested, present on gauge/sum/histogram/exp_histogram).
+		"Exemplars": m.ExemplarsColumn,
+	}
+	for want, got := range cases {
+		if got != want {
+			t.Errorf("metrics column %q: got %q, want %q (mismatch against upstream OTel CH Exporter template)", want, got, want)
+		}
+	}
+
+	// Sanity: every advertised column must be non-empty. A blank
+	// default means a future PR C / PR D will emit unquoted gaps in
+	// the DDL / SELECT list.
+	if m.GaugeTable == "" || m.SumTable == "" || m.HistogramTable == "" ||
+		m.ExpHistogramTable == "" || m.SummaryTable == "" {
+		t.Fatalf("DefaultOTelMetrics(): empty table name in %+v", m)
+	}
+}
+
+// TestDefaultOTelMetricsTableFor pins the existing PromQL routing
+// heuristic so PR C / PR D / PR G refactors can't silently regress it.
+func TestDefaultOTelMetricsTableFor(t *testing.T) {
+	t.Parallel()
+	m := DefaultOTelMetrics()
+	cases := map[string]string{
+		"up":                                  m.GaugeTable,
+		"http_server_request_duration_count":  m.SumTable,
+		"http_server_request_duration_sum":    m.SumTable,
+		"http_server_request_duration_bucket": m.SumTable,
+		"requests_total":                      m.SumTable,
+		"latency":                             m.GaugeTable,
+	}
+	for name, want := range cases {
+		if got := m.TableFor(name); got != want {
+			t.Errorf("TableFor(%q): got %q, want %q", name, got, want)
+		}
+	}
+}

--- a/internal/schema/traces.go
+++ b/internal/schema/traces.go
@@ -4,6 +4,10 @@ package schema
 // (returned by DefaultOTelTraces) matches the OpenTelemetry ClickHouse
 // Exporter v0.x traces schema; users with custom layouts override
 // individual fields.
+//
+// Column names mirror the upstream `traces_table.sql` template
+// verbatim, plus a synthetic `EndTimeColumn` (`Timestamp` — OTel-CH
+// stores duration; end = start + duration) for the TraceQL emitter.
 type Traces struct {
 	// SpansTable is the table holding span records.
 	SpansTable string
@@ -14,6 +18,8 @@ type Traces struct {
 	SpanIDColumn string
 	// ParentSpanIDColumn names the parent-span-id column.
 	ParentSpanIDColumn string
+	// TraceStateColumn names the W3C trace-state column.
+	TraceStateColumn string
 	// SpanNameColumn names the span name column.
 	SpanNameColumn string
 	// SpanKindColumn names the span kind column ("Client", "Server", ...).
@@ -21,11 +27,13 @@ type Traces struct {
 	// ServiceNameColumn names the dedicated service.name column.
 	ServiceNameColumn string
 
-	// DurationColumn names the span-duration column (Int64 nanoseconds).
+	// DurationColumn names the span-duration column (UInt64 nanoseconds).
 	DurationColumn string
 	// StartTimeColumn names the span-start timestamp column.
 	StartTimeColumn string
-	// EndTimeColumn names the span-end timestamp column.
+	// EndTimeColumn is a cerberus synthetic — OTel-CH stores duration;
+	// end-time is derived as `Timestamp + Duration`. The emitter substitutes
+	// the literal computation when this string equals StartTimeColumn.
 	EndTimeColumn string
 
 	// StatusCodeColumn names the status code column ("Unset", "Ok", "Error").
@@ -38,8 +46,23 @@ type Traces struct {
 	// ResourceAttributesColumn names the resource attribute map (carries
 	// service-identity labels).
 	ResourceAttributesColumn string
+	// ScopeNameColumn names the instrumentation-scope name column.
+	ScopeNameColumn string
+	// ScopeVersionColumn names the instrumentation-scope version column.
+	ScopeVersionColumn string
 	// ScopeAttributesColumn names the instrumentation-scope attribute map.
+	// NOTE: the upstream `traces_table.sql` template does not currently
+	// declare a ScopeAttributes column; cerberus carries this field so
+	// custom-schema users can point it at their own column. The default
+	// is the empty string so emitters can skip it when unset.
 	ScopeAttributesColumn string
+
+	// EventsColumn names the Nested span-events column (Timestamp /
+	// Name / Attributes per row).
+	EventsColumn string
+	// LinksColumn names the Nested span-links column (TraceId / SpanId /
+	// TraceState / Attributes per row).
+	LinksColumn string
 
 	// TimestampColumn names the canonical event timestamp column. For
 	// OTel-CH this is the same as StartTimeColumn ("Timestamp" in newer
@@ -55,6 +78,7 @@ func DefaultOTelTraces() Traces {
 		TraceIDColumn:            "TraceId",
 		SpanIDColumn:             "SpanId",
 		ParentSpanIDColumn:       "ParentSpanId",
+		TraceStateColumn:         "TraceState",
 		SpanNameColumn:           "SpanName",
 		SpanKindColumn:           "SpanKind",
 		ServiceNameColumn:        "ServiceName",
@@ -65,7 +89,13 @@ func DefaultOTelTraces() Traces {
 		StatusMessageColumn:      "StatusMessage",
 		AttributesColumn:         "SpanAttributes",
 		ResourceAttributesColumn: "ResourceAttributes",
-		ScopeAttributesColumn:    "ScopeAttributes",
-		TimestampColumn:          "Timestamp",
+		ScopeNameColumn:          "ScopeName",
+		ScopeVersionColumn:       "ScopeVersion",
+		// Upstream traces_table.sql has no ScopeAttributes column; leave
+		// empty so callers that consult it can skip the projection.
+		ScopeAttributesColumn: "",
+		EventsColumn:          "Events",
+		LinksColumn:           "Links",
+		TimestampColumn:       "Timestamp",
 	}
 }

--- a/internal/schema/traces_test.go
+++ b/internal/schema/traces_test.go
@@ -1,0 +1,61 @@
+package schema
+
+import "testing"
+
+// TestDefaultOTelTracesPinsUpstreamColumns pins every column name
+// DefaultOTelTraces() returns against the verbatim string the upstream
+// `clickhouseexporter` writes in its `traces_table.sql` template.
+//
+// Note: the upstream traces DDL does not declare a `ScopeAttributes`
+// column; cerberus carries the field but defaults it to the empty
+// string so emitters can skip it for the upstream layout.
+func TestDefaultOTelTracesPinsUpstreamColumns(t *testing.T) {
+	t.Parallel()
+
+	tr := DefaultOTelTraces()
+
+	if tr.SpansTable != "otel_traces" {
+		t.Errorf("SpansTable: got %q, want %q", tr.SpansTable, "otel_traces")
+	}
+
+	cases := map[string]string{
+		"TraceId":            tr.TraceIDColumn,
+		"SpanId":             tr.SpanIDColumn,
+		"ParentSpanId":       tr.ParentSpanIDColumn,
+		"TraceState":         tr.TraceStateColumn,
+		"SpanName":           tr.SpanNameColumn,
+		"SpanKind":           tr.SpanKindColumn,
+		"ServiceName":        tr.ServiceNameColumn,
+		"Duration":           tr.DurationColumn,
+		"StatusCode":         tr.StatusCodeColumn,
+		"StatusMessage":      tr.StatusMessageColumn,
+		"SpanAttributes":     tr.AttributesColumn,
+		"ResourceAttributes": tr.ResourceAttributesColumn,
+		"ScopeName":          tr.ScopeNameColumn,
+		"ScopeVersion":       tr.ScopeVersionColumn,
+		"Events":             tr.EventsColumn,
+		"Links":              tr.LinksColumn,
+	}
+	for want, got := range cases {
+		if got != want {
+			t.Errorf("traces column %q: got %q, want %q (mismatch against upstream OTel CH Exporter template)", want, got, want)
+		}
+	}
+
+	// Synthetic / cerberus-local fields.
+	if tr.StartTimeColumn != "Timestamp" {
+		t.Errorf("StartTimeColumn: got %q, want %q (OTel-CH stores duration; start == Timestamp)", tr.StartTimeColumn, "Timestamp")
+	}
+	if tr.EndTimeColumn != "Timestamp" {
+		t.Errorf("EndTimeColumn: got %q, want %q (synthetic — emitter derives end as Timestamp + Duration when EndTimeColumn == StartTimeColumn)", tr.EndTimeColumn, "Timestamp")
+	}
+	if tr.TimestampColumn != "Timestamp" {
+		t.Errorf("TimestampColumn: got %q, want %q", tr.TimestampColumn, "Timestamp")
+	}
+
+	// ScopeAttributesColumn is intentionally empty: upstream traces DDL
+	// does not declare it. Custom-schema users may set it explicitly.
+	if tr.ScopeAttributesColumn != "" {
+		t.Errorf("ScopeAttributesColumn: got %q, want %q (upstream traces_table.sql has no ScopeAttributes column)", tr.ScopeAttributesColumn, "")
+	}
+}


### PR DESCRIPTION
## Summary
- Extends `internal/schema/{otel,logs,traces}.go` to surface every column the upstream OTel CH Exporter writes (via the tsouza/opentelemetry-collector-contrib:cerberus-ddl fork wired in #154).
- Adds `ExpHistogramTable` + `SummaryTable` + histogram-specific columns (Count/Sum/Min/Max/BucketCounts/ExplicitBounds/AggregationTemporality/IsMonotonic/Flags) + exp-histogram columns (Scale/ZeroCount/PositiveOffset/PositiveBucketCounts/NegativeOffset/NegativeBucketCounts) + Exemplars (Nested) + ValueAtQuantiles + ServiceName/ScopeName/ScopeVersion/StartTimeUnix.
- Mirrors logs additions: TraceFlags, ScopeName, ScopeVersion, EventName.
- Mirrors traces additions: TraceState, ScopeName, ScopeVersion, Events (Nested), Links (Nested). `ScopeAttributesColumn` defaults to empty for traces because upstream `traces_table.sql` does not declare that column.
- New pinning tests under `internal/schema/{otel,logs,traces}_test.go` assert every default returned by `DefaultOTel*()` matches the verbatim column name in the upstream `sqltemplates/` files.
- No seed SQL changes (PR E); no DDL package wiring (PR C); no auto-create (PR D); no PromQL `histogram_quantile` (PRs G + H).

## Test plan
- [x] `go test ./internal/schema/...` covers new fields.
- [x] `DefaultOTel*()` returns upstream column names exactly (pinning tests).
- [x] `go test ./...` passes (no regression-test field-name changes needed).
- [x] `go vet ./internal/schema/...` clean.
- [x] `gofumpt -l internal/schema/` empty.

Plan: /home/thiago/.claude/plans/can-you-tell-me-merry-thunder.md PR B. Depends on #154 (fork+replace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)