### PR TITLE
feat(chplan,chsql,traceql): MetricsAggregate IR + RangeWindow over metric-shape input (RC2)

### DIFF
--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -334,6 +334,10 @@ func isAggregateShape(plan chplan.Node) bool {
 	switch v := plan.(type) {
 	case *chplan.Aggregate:
 		return true
+	case *chplan.MetricsAggregate:
+		// TraceQL metrics-pipeline output: same SELECT-list shape as
+		// chplan.Aggregate (group-keys + Value alias).
+		return true
 	case *chplan.Filter:
 		return isAggregateShape(v.Input)
 	case *chplan.Project:

--- a/internal/chplan/metrics_aggregate.go
+++ b/internal/chplan/metrics_aggregate.go
@@ -1,0 +1,165 @@
+package chplan
+
+// MetricsOp is the TraceQL metrics-pipeline operator that produced a
+// MetricsAggregate node. Carries the semantic distinction collapsed by
+// the previous lowering (which used a bare chplan.Aggregate and mapped
+// rate / count_over_time to the same CH `count`): when a RangeWindow
+// wraps a MetricsAggregate the emitter needs to discriminate the
+// per-bucket normalisation (rate divides by the bucket's seconds,
+// count_over_time does not).
+type MetricsOp int
+
+const (
+	// MetricsOpInvalid is the zero value; surfaces as an emitter error.
+	MetricsOpInvalid MetricsOp = iota
+	// MetricsOpRate corresponds to TraceQL `| rate()` — count of spans
+	// per bucket divided by the bucket duration (seconds).
+	MetricsOpRate
+	// MetricsOpCountOverTime corresponds to TraceQL `| count_over_time()` —
+	// raw count of spans per bucket.
+	MetricsOpCountOverTime
+	// MetricsOpSumOverTime corresponds to TraceQL
+	// `| sum_over_time(<attr>)`.
+	MetricsOpSumOverTime
+	// MetricsOpAvgOverTime corresponds to TraceQL
+	// `| avg_over_time(<attr>)` (deferred at the lowering layer until
+	// the upstream fork exposes accessors).
+	MetricsOpAvgOverTime
+	// MetricsOpMinOverTime corresponds to TraceQL
+	// `| min_over_time(<attr>)`.
+	MetricsOpMinOverTime
+	// MetricsOpMaxOverTime corresponds to TraceQL
+	// `| max_over_time(<attr>)`.
+	MetricsOpMaxOverTime
+	// MetricsOpQuantileOverTime corresponds to TraceQL
+	// `| quantile_over_time(<attr>, q)`; the quantile values are
+	// carried on MetricsAggregate.Quantiles.
+	MetricsOpQuantileOverTime
+)
+
+// String returns the TraceQL-source name of the operator (`rate`,
+// `count_over_time`, etc.). Useful for error messages.
+func (o MetricsOp) String() string {
+	switch o {
+	case MetricsOpRate:
+		return "rate"
+	case MetricsOpCountOverTime:
+		return "count_over_time"
+	case MetricsOpSumOverTime:
+		return "sum_over_time"
+	case MetricsOpAvgOverTime:
+		return "avg_over_time"
+	case MetricsOpMinOverTime:
+		return "min_over_time"
+	case MetricsOpMaxOverTime:
+		return "max_over_time"
+	case MetricsOpQuantileOverTime:
+		return "quantile_over_time"
+	}
+	return "invalid"
+}
+
+// MetricsAggregate is the TraceQL metrics-pipeline aggregate: the lowered
+// form of `| rate() / *_over_time(<attr>) [by(<labels>)]`. Distinct from
+// chplan.Aggregate because:
+//
+//  1. The CH aggregate function picked at emit time depends on Op
+//     (rate / count_over_time → count; *_over_time → the matching CH
+//     aggregate). The previous lowering collapsed this distinction
+//     into a bare Aggregate with `count` for both rate and
+//     count_over_time, losing the per-step normalisation needed by a
+//     wrapping RangeWindow.
+//
+//  2. A wrapping chplan.RangeWindow can plug a MetricsAggregate into
+//     its Input slot (alongside the row-shape PromQL path) and the
+//     emitter renders a time-bucketed matrix: one row per
+//     (group-by-labels, anchor) tuple across [Start, End] spaced by
+//     Step. See internal/chsql/range_window.go for the SQL skeleton.
+//
+// When emitted standalone (no RangeWindow wrapper), the SQL shape is
+// the same as the bare Aggregate the previous lowering produced —
+// keeps the TraceQL instant-metric fixtures byte-identical across the
+// IR change.
+//
+// Fields:
+//
+//   - Op: the source TraceQL operator (rate / count_over_time / *_over_time
+//     / quantile_over_time).
+//   - Attr: the operand expression for *_over_time / quantile_over_time
+//     (the lowered `duration` / `span.<attr>` / `resource.<attr>` reference).
+//     Nil for rate and count_over_time (no operand at the source).
+//   - GroupBy: the `by(...)` label expressions; parallel to GroupByAliases
+//     for SELECT-list aliasing (mirrors chplan.Aggregate).
+//   - Quantiles: the quantile values for MetricsOpQuantileOverTime;
+//     today the lowering accepts a single quantile, so len(Quantiles)
+//     is always 1 for that op. Empty for all other ops.
+//   - ValueAlias: the SELECT-list alias for the metric output column
+//     (today always "Value" from metricsValueAlias in
+//     internal/traceql/metrics_pipeline.go).
+//   - Inner: the underlying spanset relation — typically
+//     Scan(<traces-table>) or Filter(<predicate>, Scan(<traces-table>)).
+//
+// For the matrix path (wrapping RangeWindow), the emitter also reads
+// the underlying timestamp column from the wrapping RangeWindow's
+// TimestampColumn slot; the per-span Timestamp column is the matrix
+// shape's bucket key.
+type MetricsAggregate struct {
+	Op             MetricsOp
+	Attr           Expr
+	GroupBy        []Expr
+	GroupByAliases []string
+	Quantiles      []float64
+	ValueAlias     string
+	Inner          Node
+}
+
+func (*MetricsAggregate) planNode() {}
+
+func (m *MetricsAggregate) Children() []Node { return []Node{m.Inner} }
+
+func (m *MetricsAggregate) Equal(other Node) bool {
+	o, ok := other.(*MetricsAggregate)
+	if !ok {
+		return false
+	}
+	if m.Op != o.Op || m.ValueAlias != o.ValueAlias {
+		return false
+	}
+	if (m.Attr == nil) != (o.Attr == nil) {
+		return false
+	}
+	if m.Attr != nil && !m.Attr.Equal(o.Attr) {
+		return false
+	}
+	if len(m.GroupBy) != len(o.GroupBy) {
+		return false
+	}
+	for i := range m.GroupBy {
+		if !m.GroupBy[i].Equal(o.GroupBy[i]) {
+			return false
+		}
+	}
+	if len(m.GroupByAliases) != len(o.GroupByAliases) {
+		return false
+	}
+	for i := range m.GroupByAliases {
+		if m.GroupByAliases[i] != o.GroupByAliases[i] {
+			return false
+		}
+	}
+	if len(m.Quantiles) != len(o.Quantiles) {
+		return false
+	}
+	for i := range m.Quantiles {
+		if m.Quantiles[i] != o.Quantiles[i] {
+			return false
+		}
+	}
+	if (m.Inner == nil) != (o.Inner == nil) {
+		return false
+	}
+	if m.Inner == nil {
+		return true
+	}
+	return m.Inner.Equal(o.Inner)
+}

--- a/internal/chplan/metrics_aggregate_test.go
+++ b/internal/chplan/metrics_aggregate_test.go
@@ -1,0 +1,174 @@
+package chplan_test
+
+import (
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// TestMetricsAggregateEqual exercises structural equality across the
+// node's fields — Op, Attr, GroupBy, GroupByAliases, Quantiles,
+// ValueAlias, Inner.
+func TestMetricsAggregateEqual(t *testing.T) {
+	t.Parallel()
+
+	base := &chplan.MetricsAggregate{
+		Op:             chplan.MetricsOpRate,
+		GroupBy:        []chplan.Expr{&chplan.ColumnRef{Name: "ServiceName"}},
+		GroupByAliases: []string{"service"},
+		ValueAlias:     "Value",
+		Inner:          &chplan.Scan{Table: "otel_traces"},
+	}
+	same := &chplan.MetricsAggregate{
+		Op:             chplan.MetricsOpRate,
+		GroupBy:        []chplan.Expr{&chplan.ColumnRef{Name: "ServiceName"}},
+		GroupByAliases: []string{"service"},
+		ValueAlias:     "Value",
+		Inner:          &chplan.Scan{Table: "otel_traces"},
+	}
+	if !base.Equal(same) {
+		t.Fatalf("identical MetricsAggregate trees should be Equal")
+	}
+
+	// Different Op.
+	diffOp := *same
+	diffOp.Op = chplan.MetricsOpCountOverTime
+	if base.Equal(&diffOp) {
+		t.Errorf("different Op should not be Equal")
+	}
+
+	// Different ValueAlias.
+	diffAlias := *same
+	diffAlias.ValueAlias = "other"
+	if base.Equal(&diffAlias) {
+		t.Errorf("different ValueAlias should not be Equal")
+	}
+
+	// Attr presence diff.
+	withAttr := &chplan.MetricsAggregate{
+		Op:         chplan.MetricsOpSumOverTime,
+		Attr:       &chplan.ColumnRef{Name: "Duration"},
+		ValueAlias: "Value",
+		Inner:      &chplan.Scan{Table: "otel_traces"},
+	}
+	withoutAttr := &chplan.MetricsAggregate{
+		Op:         chplan.MetricsOpSumOverTime,
+		ValueAlias: "Value",
+		Inner:      &chplan.Scan{Table: "otel_traces"},
+	}
+	if withAttr.Equal(withoutAttr) {
+		t.Errorf("Attr presence should differentiate Equal")
+	}
+	if withoutAttr.Equal(withAttr) {
+		t.Errorf("Attr presence should differentiate Equal (other side)")
+	}
+
+	// Attr value diff.
+	otherAttr := *withAttr
+	otherAttr.Attr = &chplan.ColumnRef{Name: "Other"}
+	if withAttr.Equal(&otherAttr) {
+		t.Errorf("different Attr exprs should not be Equal")
+	}
+
+	// Quantile diff.
+	q1 := &chplan.MetricsAggregate{
+		Op:         chplan.MetricsOpQuantileOverTime,
+		Attr:       &chplan.ColumnRef{Name: "Duration"},
+		Quantiles:  []float64{0.95},
+		ValueAlias: "Value",
+		Inner:      &chplan.Scan{Table: "otel_traces"},
+	}
+	q2 := *q1
+	q2.Quantiles = []float64{0.99}
+	if q1.Equal(&q2) {
+		t.Errorf("different Quantiles should not be Equal")
+	}
+
+	// GroupByAliases diff.
+	diffGroupAlias := *same
+	diffGroupAlias.GroupByAliases = []string{"other"}
+	if base.Equal(&diffGroupAlias) {
+		t.Errorf("different GroupByAliases should not be Equal")
+	}
+
+	// GroupBy len diff.
+	moreGroup := *same
+	moreGroup.GroupBy = append([]chplan.Expr{}, same.GroupBy...)
+	moreGroup.GroupBy = append(moreGroup.GroupBy, &chplan.ColumnRef{Name: "Host"})
+	moreGroup.GroupByAliases = []string{"service", "host"}
+	if base.Equal(&moreGroup) {
+		t.Errorf("different GroupBy length should not be Equal")
+	}
+
+	// Inner diff.
+	diffInner := *same
+	diffInner.Inner = &chplan.Scan{Table: "other_traces"}
+	if base.Equal(&diffInner) {
+		t.Errorf("different Inner should not be Equal")
+	}
+
+	// Different node type.
+	scan := &chplan.Scan{Table: "otel_traces"}
+	if base.Equal(scan) {
+		t.Errorf("MetricsAggregate.Equal of *Scan should be false")
+	}
+}
+
+// TestMetricsAggregateChildren confirms Walk descends through Inner.
+func TestMetricsAggregateChildren(t *testing.T) {
+	t.Parallel()
+
+	scan := &chplan.Scan{Table: "otel_traces"}
+	ma := &chplan.MetricsAggregate{
+		Op:    chplan.MetricsOpRate,
+		Inner: scan,
+	}
+	kids := ma.Children()
+	if len(kids) != 1 {
+		t.Fatalf("expected 1 child, got %d", len(kids))
+	}
+	if kids[0] != scan {
+		t.Errorf("Children[0] should be the Inner scan, got %T", kids[0])
+	}
+
+	var visited []string
+	chplan.Walk(ma, func(n chplan.Node) bool {
+		switch n.(type) {
+		case *chplan.MetricsAggregate:
+			visited = append(visited, "MetricsAggregate")
+		case *chplan.Scan:
+			visited = append(visited, "Scan")
+		}
+		return true
+	})
+	want := []string{"MetricsAggregate", "Scan"}
+	if len(visited) != len(want) {
+		t.Fatalf("Walk visited %v, want %v", visited, want)
+	}
+	for i := range want {
+		if visited[i] != want[i] {
+			t.Errorf("Walk[%d] = %s, want %s", i, visited[i], want[i])
+		}
+	}
+}
+
+// TestMetricsOpString round-trips the enum to its TraceQL-source name.
+func TestMetricsOpString(t *testing.T) {
+	t.Parallel()
+
+	cases := map[chplan.MetricsOp]string{
+		chplan.MetricsOpInvalid:          "invalid",
+		chplan.MetricsOpRate:             "rate",
+		chplan.MetricsOpCountOverTime:    "count_over_time",
+		chplan.MetricsOpSumOverTime:      "sum_over_time",
+		chplan.MetricsOpAvgOverTime:      "avg_over_time",
+		chplan.MetricsOpMinOverTime:      "min_over_time",
+		chplan.MetricsOpMaxOverTime:      "max_over_time",
+		chplan.MetricsOpQuantileOverTime: "quantile_over_time",
+	}
+	for op, want := range cases {
+		if got := op.String(); got != want {
+			t.Errorf("MetricsOp(%d).String() = %q, want %q", op, got, want)
+		}
+	}
+}

--- a/internal/chplan/range_window.go
+++ b/internal/chplan/range_window.go
@@ -7,10 +7,27 @@ import "time"
 // timestamp lies within [step-Range, step]. Used to lower expressions like
 // `rate(metric[5m])` and `sum_over_time(metric[1h])`.
 //
-// The emitter (internal/chsql/range_window.go) produces ClickHouse SQL
-// using the windowed-array idiom: GROUP BY series, build a sorted
-// (ts, value) array via groupArray + arraySort, arrayFilter to the
-// per-step window, then apply the function-specific aggregation.
+// Input shapes (the emitter discriminates at render time):
+//
+//   - Row-shape relation (PromQL / LogQL): every row carries the
+//     per-sample (TimestampColumn, ValueColumn) pair plus the GroupBy
+//     series identity. The emitter (internal/chsql/range_window.go)
+//     produces ClickHouse SQL using the windowed-array idiom: GROUP BY
+//     series, build a sorted (ts, value) array via groupArray +
+//     arraySort, arrayFilter to the per-step window, then apply the
+//     function-specific aggregation. Func names the PromQL operator
+//     (`rate`, `*_over_time`, …); TimestampColumn / ValueColumn are
+//     required.
+//
+//   - MetricsAggregate input (TraceQL): the underlying relation is a
+//     chplan.MetricsAggregate whose Inner is a per-span Scan/Filter
+//     tree. Func is ignored — MetricsAggregate.Op carries the
+//     per-bucket reducer. The emitter renders a time-bucketed matrix
+//     via arrayJoin(range(...)) over [Start, End] spaced by Step,
+//     applying the Op-specific CH aggregate per bucket. TimestampColumn
+//     is required (it names the per-span Timestamp on Inner);
+//     ValueColumn is unused (the metric value is the reduce of Attr).
+//     Step must be > 0 in this mode.
 type RangeWindow struct {
 	Input Node
 

--- a/internal/chsql/emit.go
+++ b/internal/chsql/emit.go
@@ -50,6 +50,8 @@ func (e *emitter) emitNode(n chplan.Node) error {
 		return e.emitProject(v)
 	case *chplan.Aggregate:
 		return e.emitAggregate(v)
+	case *chplan.MetricsAggregate:
+		return e.emitMetricsAggregate(v)
 	case *chplan.RangeWindow:
 		return e.emitRangeWindow(v)
 	case *chplan.Limit:

--- a/internal/chsql/emit_test.go
+++ b/internal/chsql/emit_test.go
@@ -409,6 +409,80 @@ var plans = map[string]chplan.Node{
 		},
 	},
 
+	// MetricsAggregate (bare emission, no wrapping RangeWindow) — the
+	// TraceQL instant-metric shape. SQL is byte-equivalent to a plain
+	// chplan.Aggregate with the per-Op CH function name.
+	"metrics_aggregate_rate_bare": &chplan.MetricsAggregate{
+		Op:         chplan.MetricsOpRate,
+		ValueAlias: "Value",
+		Inner:      &chplan.Scan{Table: "otel_traces"},
+	},
+	"metrics_aggregate_sum_over_time_bare": &chplan.MetricsAggregate{
+		Op:         chplan.MetricsOpSumOverTime,
+		Attr:       &chplan.ColumnRef{Name: "Duration"},
+		ValueAlias: "Value",
+		Inner:      &chplan.Scan{Table: "otel_traces"},
+	},
+	"metrics_aggregate_quantile_over_time_bare": &chplan.MetricsAggregate{
+		Op:         chplan.MetricsOpQuantileOverTime,
+		Attr:       &chplan.ColumnRef{Name: "Duration"},
+		Quantiles:  []float64{0.95},
+		ValueAlias: "Value",
+		Inner:      &chplan.Scan{Table: "otel_traces"},
+	},
+
+	// RangeWindow wrapping MetricsAggregate — the matrix shape used
+	// by TraceQL's /api/metrics/query_range handler. Each per-span row
+	// is fanned across the N evaluation anchors via arrayJoin(range())
+	// and the outer SELECT applies the Op-specific reducer per
+	// (group-by, anchor) bucket.
+	"range_window_metrics_rate": &chplan.RangeWindow{
+		Input: &chplan.MetricsAggregate{
+			Op:         chplan.MetricsOpRate,
+			ValueAlias: "Value",
+			Inner:      &chplan.Scan{Table: "otel_traces"},
+		},
+		Range:           5 * time.Minute,
+		Step:            time.Minute,
+		OuterRange:      time.Hour,
+		TimestampColumn: "Timestamp",
+	},
+	"range_window_metrics_count_over_time_by": &chplan.RangeWindow{
+		Input: &chplan.MetricsAggregate{
+			Op:             chplan.MetricsOpCountOverTime,
+			GroupBy:        []chplan.Expr{&chplan.ColumnRef{Name: "ServiceName"}},
+			GroupByAliases: []string{"service"},
+			ValueAlias:     "Value",
+			Inner:          &chplan.Scan{Table: "otel_traces"},
+		},
+		Step:            time.Minute,
+		OuterRange:      10 * time.Minute,
+		TimestampColumn: "Timestamp",
+	},
+	"range_window_metrics_sum_over_time_attr": &chplan.RangeWindow{
+		Input: &chplan.MetricsAggregate{
+			Op:         chplan.MetricsOpSumOverTime,
+			Attr:       &chplan.ColumnRef{Name: "Duration"},
+			ValueAlias: "Value",
+			Inner:      &chplan.Scan{Table: "otel_traces"},
+		},
+		Step:            time.Minute,
+		OuterRange:      5 * time.Minute,
+		TimestampColumn: "Timestamp",
+	},
+	"range_window_metrics_quantile_over_time_attr": &chplan.RangeWindow{
+		Input: &chplan.MetricsAggregate{
+			Op:         chplan.MetricsOpQuantileOverTime,
+			Attr:       &chplan.ColumnRef{Name: "Duration"},
+			Quantiles:  []float64{0.95},
+			ValueAlias: "Value",
+			Inner:      &chplan.Scan{Table: "otel_traces"},
+		},
+		Step:            time.Minute,
+		OuterRange:      5 * time.Minute,
+		TimestampColumn: "Timestamp",
+	},
+
 	// vector_join_set_and: VectorJoin with OpAnd (set-intersection
 	// shape). Unusual operator on this node but the IR allows it.
 	"vector_join_set_and": &chplan.VectorJoin{

--- a/internal/chsql/range_window.go
+++ b/internal/chsql/range_window.go
@@ -8,6 +8,113 @@ import (
 	"github.com/tsouza/cerberus/internal/chplan"
 )
 
+// emitMetricsAggregate renders a chplan.MetricsAggregate as a single-row
+// aggregate when it sits at the root of the plan tree (no wrapping
+// RangeWindow). The SQL shape mirrors chplan.Aggregate so the TraceQL
+// instant-metric fixtures stay byte-identical across the IR change
+// from bare Aggregate → MetricsAggregate.
+//
+// When a RangeWindow wraps a MetricsAggregate the matrix path is taken
+// instead (see emitWindowedArrayMatrixMetrics).
+func (e *emitter) emitMetricsAggregate(m *chplan.MetricsAggregate) error {
+	name, params, args, err := metricsAggregateCH(m)
+	if err != nil {
+		return err
+	}
+	// Pre-flight expressions so chplan errors surface synchronously
+	// (mirrors emitAggregate's pre-flight loop).
+	for _, g := range m.GroupBy {
+		if err := (&Builder{}).Expr(g); err != nil {
+			return err
+		}
+	}
+	for _, p := range params {
+		if err := (&Builder{}).Expr(p); err != nil {
+			return err
+		}
+	}
+	for _, a := range args {
+		if err := (&Builder{}).Expr(a); err != nil {
+			return err
+		}
+	}
+	if m.Inner == nil {
+		return fmt.Errorf("%w: MetricsAggregate.Inner is nil", ErrUnsupported)
+	}
+
+	sub, err := e.subqueryFrag(m.Inner)
+	if err != nil {
+		return err
+	}
+
+	sb := NewSelect().From(sub)
+	for i, g := range m.GroupBy {
+		expr := g
+		alias := ""
+		if i < len(m.GroupByAliases) {
+			alias = m.GroupByAliases[i]
+		}
+		sb.SelectAs(func(b *Builder) { _ = b.Expr(expr) }, alias)
+	}
+	af := chplan.AggFunc{Name: name, Params: params, Args: args, Alias: m.ValueAlias}
+	sb.Select(aggFuncFrag(af))
+	if len(m.GroupBy) > 0 {
+		groupFrags := make([]Frag, 0, len(m.GroupBy))
+		for _, g := range m.GroupBy {
+			expr := g
+			groupFrags = append(groupFrags, func(b *Builder) { _ = b.Expr(expr) })
+		}
+		sb.GroupBy(groupFrags...)
+	}
+	e.emitSelect(sb)
+	return nil
+}
+
+// metricsAggregateCH maps a MetricsAggregate.Op to the CH aggregate
+// function name + parameter list + argument list. Centralises the
+// per-Op switch so both the bare-emission path and the matrix path
+// agree on the per-bucket reducer.
+//
+// rate / count_over_time → `count(1)` (the rate-specific per-bucket
+// division by seconds lives on the matrix-path emitter, not here).
+// *_over_time(attr) → the matching CH aggregate over Attr.
+// quantile_over_time(attr, q) → `quantile(q)(Attr)`.
+func metricsAggregateCH(m *chplan.MetricsAggregate) (name string, params []chplan.Expr, args []chplan.Expr, err error) {
+	switch m.Op {
+	case chplan.MetricsOpRate, chplan.MetricsOpCountOverTime:
+		return "count", nil, []chplan.Expr{&chplan.LitInt{V: 1}}, nil
+	case chplan.MetricsOpSumOverTime:
+		if m.Attr == nil {
+			return "", nil, nil, fmt.Errorf("%w: %s requires Attr", ErrUnsupported, m.Op)
+		}
+		return "sum", nil, []chplan.Expr{m.Attr}, nil
+	case chplan.MetricsOpAvgOverTime:
+		if m.Attr == nil {
+			return "", nil, nil, fmt.Errorf("%w: %s requires Attr", ErrUnsupported, m.Op)
+		}
+		return "avg", nil, []chplan.Expr{m.Attr}, nil
+	case chplan.MetricsOpMinOverTime:
+		if m.Attr == nil {
+			return "", nil, nil, fmt.Errorf("%w: %s requires Attr", ErrUnsupported, m.Op)
+		}
+		return "min", nil, []chplan.Expr{m.Attr}, nil
+	case chplan.MetricsOpMaxOverTime:
+		if m.Attr == nil {
+			return "", nil, nil, fmt.Errorf("%w: %s requires Attr", ErrUnsupported, m.Op)
+		}
+		return "max", nil, []chplan.Expr{m.Attr}, nil
+	case chplan.MetricsOpQuantileOverTime:
+		if m.Attr == nil {
+			return "", nil, nil, fmt.Errorf("%w: %s requires Attr", ErrUnsupported, m.Op)
+		}
+		if len(m.Quantiles) != 1 {
+			return "", nil, nil, fmt.Errorf("%w: MetricsAggregate quantile expects exactly 1 quantile, got %d", ErrUnsupported, len(m.Quantiles))
+		}
+		return "quantile", []chplan.Expr{&chplan.LitFloat{V: m.Quantiles[0]}}, []chplan.Expr{m.Attr}, nil
+	}
+	return "", nil, nil, fmt.Errorf("%w: MetricsAggregate op %s", ErrUnsupported, m.Op)
+}
+
 // emitRangeWindow lowers a chplan.RangeWindow to ClickHouse SQL using the
 // windowed-array idiom inspired by promshim-clickhouse:
 //
@@ -34,6 +141,9 @@ import (
 // the last sample in the window — used by bare-vector subqueries like
 // `up[5m:1m]`.
 func (e *emitter) emitRangeWindow(r *chplan.RangeWindow) error {
+	if m, ok := r.Input.(*chplan.MetricsAggregate); ok {
+		return e.emitRangeWindowMetrics(r, m)
+	}
 	if r.Identity {
 		return e.emitRangeWindowIdentity(r)
 	}
@@ -236,6 +346,250 @@ func anchorExpr(r *chplan.RangeWindow) string {
 // strconv.FormatFloat(v, 'f', -1, 64) does.
 func formatFloat(v float64) string {
 	return strconv.FormatFloat(v, 'f', -1, 64)
+}
+
+// emitRangeWindowMetrics renders a RangeWindow wrapping a
+// MetricsAggregate — the TraceQL `/api/metrics/query_range` shape.
+// Each per-span row out of m.Inner is fanned across the N evaluation
+// anchors via arrayJoin(range(0, N)); the outer SELECT applies the
+// Op-specific CH aggregate per (group-by, anchor) bucket.
+//
+// SQL skeleton (N = (End-Start)/Step + 1 or OuterRange/Step + 1):
+//
+//	SELECT [<group cols>,] anchor_ts, <reducer> AS value
+//	FROM (
+//	  SELECT [<group cols>,] <TimestampColumn> AS ts, [<Attr> AS metric_arg,]
+//	         arrayJoin(arrayMap(i -> <anchor_base> - toIntervalNanosecond(i * <step_ns>), range(0, <N>))) AS anchor_ts
+//	  FROM (<Inner>)
+//	)
+//	WHERE ts >= anchor_ts - toIntervalNanosecond(<range_ns>)
+//	  AND ts <= anchor_ts
+//	GROUP BY [<group cols>,] anchor_ts
+//
+// `<reducer>` depends on m.Op:
+//
+//   - Rate: `count(1) / <range_seconds>`
+//   - CountOverTime: `count(1)`
+//   - Sum/Min/Max/AvgOverTime: `sum/min/max/avg(metric_arg)`
+//   - QuantileOverTime: `quantile(q)(metric_arg)`
+//
+// `<anchor_base>` is r.End (or now64(9) for the zero-time fixture).
+// Range defaults to Step when r.Range is zero (matches Tempo's TraceQL
+// metrics semantics: each bucket covers exactly its Step width).
+func (e *emitter) emitRangeWindowMetrics(r *chplan.RangeWindow, m *chplan.MetricsAggregate) error {
+	if r.TimestampColumn == "" {
+		return fmt.Errorf("%w: RangeWindow.TimestampColumn unset (required for MetricsAggregate input)", ErrUnsupported)
+	}
+	if r.Step <= 0 {
+		return fmt.Errorf("%w: RangeWindow wrapping MetricsAggregate requires Step > 0", ErrUnsupported)
+	}
+	chName, params, args, err := metricsAggregateCH(m)
+	if err != nil {
+		return err
+	}
+
+	// Pre-flight all expressions so chplan errors surface synchronously.
+	for _, g := range m.GroupBy {
+		if err := (&Builder{}).Expr(g); err != nil {
+			return err
+		}
+	}
+	for _, p := range params {
+		if err := (&Builder{}).Expr(p); err != nil {
+			return err
+		}
+	}
+	for _, a := range args {
+		if err := (&Builder{}).Expr(a); err != nil {
+			return err
+		}
+	}
+
+	endExpr := timeOrNow(r.End)
+	if r.Offset > 0 {
+		endExpr = "(" + endExpr + " - toIntervalNanosecond(" + strconv.FormatInt(r.Offset.Nanoseconds(), 10) + "))"
+	}
+	stepNS := r.Step.Nanoseconds()
+	// Range defaults to Step (per-bucket = per-step). When r.Range is
+	// set explicitly (e.g. a future rate-over-Range(Step)), use it
+	// verbatim.
+	rangeDur := r.Range
+	if rangeDur == 0 {
+		rangeDur = r.Step
+	}
+	rangeNS := rangeDur.Nanoseconds()
+	rangeSeconds := rangeDur.Seconds()
+
+	// Anchor count: end-inclusive grid across [End-Span, End] spaced by
+	// Step. When OuterRange > 0 use it (PromQL subquery semantics);
+	// otherwise derive from [Start, End].
+	var numAnchors int64
+	switch {
+	case r.OuterRange > 0:
+		numAnchors = r.OuterRange.Nanoseconds()/stepNS + 1
+	case !r.Start.IsZero() && !r.End.IsZero():
+		span := r.End.Sub(r.Start).Nanoseconds()
+		if span < 0 {
+			return fmt.Errorf("%w: RangeWindow.Start > End", ErrUnsupported)
+		}
+		numAnchors = span/stepNS + 1
+	default:
+		// Instant fallback — single anchor at End.
+		numAnchors = 1
+	}
+
+	// Build the per-span anchor-fanout subquery via SelectBuilder so
+	// args bound by GroupBy expressions land in the right position.
+	// We then wrap it in the outer SELECT (the bucket reducer) by
+	// hand because the WHERE clause references `anchor_ts` (the
+	// arrayJoined column from the subquery) — a structure SelectBuilder
+	// handles naturally via Frag callbacks.
+
+	inner, err := e.subqueryFrag(m.Inner)
+	if err != nil {
+		return err
+	}
+
+	// Inner SELECT: fan each Inner row across N anchors, projecting
+	// group-by cols, the timestamp as `ts`, [the metric operand as
+	// metric_arg,] and the anchor_ts. Group-by columns are aliased
+	// so the outer SELECT / WHERE / GROUP BY can reference them by
+	// a stable name regardless of whether the source expression was
+	// a bare ColumnRef or a Map lookup.
+	groupAliases := outerGroupAliases(m.GroupBy, m.GroupByAliases)
+	innerSb := NewSelect().From(inner)
+	for i, g := range m.GroupBy {
+		expr := g
+		alias := groupAliases[i]
+		innerSb.SelectAs(func(b *Builder) { _ = b.Expr(expr) }, alias)
+	}
+	tsCol := r.TimestampColumn
+	innerSb.SelectAs(func(b *Builder) { b.Ident(tsCol) }, "ts")
+	if m.Op != chplan.MetricsOpRate && m.Op != chplan.MetricsOpCountOverTime && m.Attr != nil {
+		attr := m.Attr
+		innerSb.SelectAs(func(b *Builder) { _ = b.Expr(attr) }, "metric_arg")
+	}
+	innerSb.SelectAs(
+		anchorFanoutFrag(endExpr, stepNS, numAnchors),
+		"anchor_ts",
+	)
+
+	// Outer SELECT: GROUP BY group cols + anchor_ts; apply the
+	// per-bucket reducer.
+	outerSb := NewSelect().From(innerSb.Frag())
+
+	// Group-by columns in the outer SELECT-list are referenced by the
+	// stable inner-SELECT aliases (set above).
+	for _, alias := range groupAliases {
+		a := alias
+		outerSb.Select(func(b *Builder) { b.Ident(a) })
+	}
+	outerSb.Select(Col("anchor_ts"))
+	reducerFrag := metricsReducerFrag(m.Op, chName, params, args, rangeSeconds)
+	outerSb.Select(As(reducerFrag, m.ValueAlias))
+
+	// WHERE: ts ∈ [anchor_ts - range, anchor_ts].
+	tsRangeNS := rangeNS
+	outerSb.Where(
+		func(b *Builder) {
+			b.sb.WriteString("ts >= anchor_ts - toIntervalNanosecond(")
+			b.sb.WriteString(strconv.FormatInt(tsRangeNS, 10))
+			b.sb.WriteByte(')')
+		},
+		func(b *Builder) {
+			b.sb.WriteString("ts <= anchor_ts")
+		},
+	)
+
+	// GROUP BY group aliases + anchor_ts.
+	groupFrags := make([]Frag, 0, len(groupAliases)+1)
+	for _, alias := range groupAliases {
+		a := alias
+		groupFrags = append(groupFrags, func(b *Builder) { b.Ident(a) })
+	}
+	groupFrags = append(groupFrags, Col("anchor_ts"))
+	outerSb.GroupBy(groupFrags...)
+
+	e.emitSelect(outerSb)
+	return nil
+}
+
+// anchorFanoutFrag returns a Frag rendering
+// `arrayJoin(arrayMap(i -> <endExpr> - toIntervalNanosecond(i * <stepNS>), range(0, <N>)))`.
+// Used by the matrix-shape RangeWindow emitter to fan each Inner row
+// across N anchors in a single CH pass.
+//
+// endExpr is rendered verbatim (the CH expression for the eval-grid
+// anchor base — typically a DateTime64 literal or `now64(9)`); stepNS
+// and N are inline integer literals.
+func anchorFanoutFrag(endExpr string, stepNS, numAnchors int64) Frag {
+	return func(b *Builder) {
+		b.sb.WriteString("arrayJoin(arrayMap(i -> ")
+		b.sb.WriteString(endExpr)
+		b.sb.WriteString(" - toIntervalNanosecond(i * ")
+		b.sb.WriteString(strconv.FormatInt(stepNS, 10))
+		b.sb.WriteString("), range(0, ")
+		b.sb.WriteString(strconv.FormatInt(numAnchors, 10))
+		b.sb.WriteString(")))")
+	}
+}
+
+// metricsReducerFrag returns the per-bucket reducer Frag for the matrix
+// emission path. rate normalises `count(1)` by dividing through the
+// range duration in seconds (rendered as a literal — duration constants
+// are query-shape, not user-data).
+func metricsReducerFrag(op chplan.MetricsOp, chName string, params, args []chplan.Expr, rangeSeconds float64) Frag {
+	// Translate Attr operand to a metric_arg reference (the alias the
+	// inner SELECT projects under) for *_over_time cases.
+	argFrags := make([]func(b *Builder), 0, len(args))
+	for range args {
+		argFrags = append(argFrags, func(b *Builder) { b.Ident("metric_arg") })
+	}
+	if op == chplan.MetricsOpRate || op == chplan.MetricsOpCountOverTime {
+		// args is [LitInt{1}] — pass through verbatim so we emit count(?).
+		argFrags = argFrags[:0]
+		for _, a := range args {
+			expr := a
+			argFrags = append(argFrags, func(b *Builder) { _ = b.Expr(expr) })
+		}
+	}
+	paramFrags := make([]func(b *Builder), 0, len(params))
+	for _, p := range params {
+		expr := p
+		paramFrags = append(paramFrags, func(b *Builder) { _ = b.Expr(expr) })
+	}
+
+	switch op {
+	case chplan.MetricsOpRate:
+		return func(b *Builder) {
+			b.ParamAgg(chName, paramFrags, argFrags)
+			b.sb.WriteString(" / ")
+			b.sb.WriteString(strconv.FormatFloat(rangeSeconds, 'f', -1, 64))
+		}
+	}
+	return func(b *Builder) {
+		b.ParamAgg(chName, paramFrags, argFrags)
+	}
+}
+
+// outerGroupAliases returns the SELECT-list aliases used to refer to
+// group-by columns in the outer matrix SELECT. Falls back to a
+// "g0", "g1", ... synthetic alias when the source GroupByAliases is
+// empty (chplan permits unaliased groups; the matrix shape needs a
+// stable handle to thread between subquery and GROUP BY).
+func outerGroupAliases(groupBy []chplan.Expr, aliases []string) []string {
+	if len(groupBy) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(groupBy))
+	for i := range groupBy {
+		if i < len(aliases) && aliases[i] != "" {
+			out = append(out, aliases[i])
+			continue
+		}
+		out = append(out, "g"+strconv.Itoa(i))
+	}
+	return out
 }
 
 // emitRangeWindowIdentity emits the "last value in window" shape used

--- a/internal/chsql/range_window.go
+++ b/internal/chsql/range_window.go
@@ -79,7 +79,12 @@ func (e *emitter) emitMetricsAggregate(m *chplan.MetricsAggregate) error {
 // division by seconds lives on the matrix-path emitter, not here).
 // *_over_time(attr) → the matching CH aggregate over Attr.
 // quantile_over_time(attr, q) → `quantile(q)(Attr)`.
-func metricsAggregateCH(m *chplan.MetricsAggregate) (name string, params []chplan.Expr, args []chplan.Expr, err error) {
+func metricsAggregateCH(m *chplan.MetricsAggregate) (
+	name string,
+	params []chplan.Expr,
+	args []chplan.Expr,
+	err error,
+) {
 	switch m.Op {
 	case chplan.MetricsOpRate, chplan.MetricsOpCountOverTime:
 		return "count", nil, []chplan.Expr{&chplan.LitInt{V: 1}}, nil

--- a/internal/chsql/range_window_metrics_test.go
+++ b/internal/chsql/range_window_metrics_test.go
@@ -1,0 +1,143 @@
+package chsql_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+)
+
+// TestRangeWindowMetricsExplicitTimeGrid exercises the matrix-shape
+// emission with an explicit Start / End grid (the shape the
+// /api/metrics/query_range handler will produce). Confirms that:
+//
+//   - the anchor count is computed from (End-Start)/Step + 1, not
+//     OuterRange (which is zero here);
+//   - the anchor base is a DateTime64 literal, not now64();
+//   - the rate reducer divides through range_seconds.
+func TestRangeWindowMetricsExplicitTimeGrid(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 5, 13, 12, 5, 0, 0, time.UTC)
+
+	plan := &chplan.RangeWindow{
+		Input: &chplan.MetricsAggregate{
+			Op:         chplan.MetricsOpRate,
+			ValueAlias: "Value",
+			Inner:      &chplan.Scan{Table: "otel_traces"},
+		},
+		Step:            time.Minute,
+		Range:           time.Minute,
+		Start:           start,
+		End:             end,
+		TimestampColumn: "Timestamp",
+	}
+
+	sql, args, err := chsql.Emit(plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	// Anchor base: explicit DateTime64 literal at end.
+	if !strings.Contains(sql, "toDateTime64('2026-05-13 12:05:00.000000000', 9)") {
+		t.Errorf("expected DateTime64 anchor base, SQL=%s", sql)
+	}
+	// 5-minute span / 1-minute step = 6 anchors (end-inclusive).
+	if !strings.Contains(sql, "range(0, 6)") {
+		t.Errorf("expected range(0, 6), SQL=%s", sql)
+	}
+	// Rate reducer normalises by range_seconds (60s).
+	if !strings.Contains(sql, "count(?) / 60") {
+		t.Errorf("expected `count(?) / 60`, SQL=%s", sql)
+	}
+	// args has the LitInt{1} bound by count(1).
+	if len(args) != 1 {
+		t.Fatalf("expected 1 arg (count operand), got %d: %v", len(args), args)
+	}
+	if v, ok := args[0].(int64); !ok || v != 1 {
+		t.Errorf("expected args[0] = int64(1), got %T(%v)", args[0], args[0])
+	}
+}
+
+// TestRangeWindowMetricsRejectsZeroStep guards the matrix path's
+// Step > 0 invariant — without it the inner arrayJoin range would
+// divide by zero.
+func TestRangeWindowMetricsRejectsZeroStep(t *testing.T) {
+	t.Parallel()
+
+	plan := &chplan.RangeWindow{
+		Input: &chplan.MetricsAggregate{
+			Op:         chplan.MetricsOpRate,
+			ValueAlias: "Value",
+			Inner:      &chplan.Scan{Table: "otel_traces"},
+		},
+		TimestampColumn: "Timestamp",
+		// Step zero — should error.
+	}
+	_, _, err := chsql.Emit(plan)
+	if err == nil {
+		t.Fatalf("expected error for Step=0, got nil")
+	}
+	if !errors.Is(err, chsql.ErrUnsupported) {
+		t.Errorf("expected ErrUnsupported, got %v", err)
+	}
+}
+
+// TestRangeWindowMetricsRejectsBadStartEnd guards against End < Start
+// in the explicit-grid path; the resulting anchor count would be
+// negative.
+func TestRangeWindowMetricsRejectsBadStartEnd(t *testing.T) {
+	t.Parallel()
+
+	plan := &chplan.RangeWindow{
+		Input: &chplan.MetricsAggregate{
+			Op:         chplan.MetricsOpRate,
+			ValueAlias: "Value",
+			Inner:      &chplan.Scan{Table: "otel_traces"},
+		},
+		Step:            time.Minute,
+		Start:           time.Date(2026, 5, 13, 12, 5, 0, 0, time.UTC),
+		End:             time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC),
+		TimestampColumn: "Timestamp",
+	}
+	_, _, err := chsql.Emit(plan)
+	if err == nil {
+		t.Fatalf("expected error for End < Start, got nil")
+	}
+}
+
+// TestMetricsAggregateRequiresAttr surfaces the chplan-level invariant
+// that the *_over_time / quantile_over_time ops carry an Attr operand.
+func TestMetricsAggregateRequiresAttr(t *testing.T) {
+	t.Parallel()
+
+	cases := []chplan.MetricsOp{
+		chplan.MetricsOpSumOverTime,
+		chplan.MetricsOpAvgOverTime,
+		chplan.MetricsOpMinOverTime,
+		chplan.MetricsOpMaxOverTime,
+		chplan.MetricsOpQuantileOverTime,
+	}
+	for _, op := range cases {
+		op := op
+		t.Run(op.String(), func(t *testing.T) {
+			t.Parallel()
+			plan := &chplan.MetricsAggregate{
+				Op:         op,
+				ValueAlias: "Value",
+				Inner:      &chplan.Scan{Table: "otel_traces"},
+			}
+			if op == chplan.MetricsOpQuantileOverTime {
+				plan.Quantiles = []float64{0.95}
+			}
+			_, _, err := chsql.Emit(plan)
+			if err == nil {
+				t.Fatalf("expected error for %s without Attr", op)
+			}
+		})
+	}
+}

--- a/internal/traceql/metrics_pipeline.go
+++ b/internal/traceql/metrics_pipeline.go
@@ -53,12 +53,17 @@ func lowerMetricsPipeline(prev chplan.Node, mp traceql.FirstStageElement, s sche
 }
 
 // lowerMetricsAggregate maps a single `MetricsAggregate` (rate / sum /
-// avg / min / max / count / quantile over_time) onto a chplan.Aggregate.
+// avg / min / max / count / quantile over_time) onto a
+// chplan.MetricsAggregate.
 //
-// Per fork-tempo-plan.md § 2c, `rate()` and `count_over_time()` both
-// reduce to a row-count at this layer (CH `count(1)`); the
-// per-evaluation-step rate normalisation lives on the wrapping
-// `chplan.RangeWindow` the handler attaches, not here.
+// The IR carries the source TraceQL op symbolically (chplan.MetricsOp)
+// rather than collapsing to a CH aggregate name at lowering time. This
+// preserves the rate vs count_over_time distinction the wrapping
+// chplan.RangeWindow needs for per-bucket normalisation in the
+// `/api/metrics/query_range` matrix path; bare emission (no
+// RangeWindow wrapper) still produces SQL byte-identical to the prior
+// chplan.Aggregate shape via internal/chsql/range_window.go's
+// emitMetricsAggregate.
 //
 // `quantile_over_time(attr, q1, q2, ...)` is supported only for a
 // single quantile (the common Grafana case). Multi-quantile queries
@@ -66,17 +71,17 @@ func lowerMetricsPipeline(prev chplan.Node, mp traceql.FirstStageElement, s sche
 // whether to split into N queries.
 //
 // `histogram_over_time(attr)` is deferred — the lowering would need a
-// chplan node distinct from a scalar Aggregate, and the
+// chplan node distinct from a scalar MetricsAggregate, and the
 // `/api/metrics/query_range` handler shape for histogram series has not
 // landed yet.
 func lowerMetricsAggregate(prev chplan.Node, agg *traceql.MetricsAggregate, s schema.Traces) (chplan.Node, error) {
 	op := agg.Op()
-	chFunc, params, err := mapMetricsAggregateOp(op, agg.Quantiles())
+	cop, err := mapMetricsAggregateOp(op)
 	if err != nil {
 		return nil, err
 	}
 
-	args, err := metricsAggregateArgs(op, agg.Attribute(), s)
+	attr, err := metricsAggregateAttr(op, agg.Attribute(), s)
 	if err != nil {
 		return nil, err
 	}
@@ -86,75 +91,75 @@ func lowerMetricsAggregate(prev chplan.Node, agg *traceql.MetricsAggregate, s sc
 		return nil, err
 	}
 
-	return &chplan.Aggregate{
-		Input:          prev,
+	var quantiles []float64
+	if op == traceql.MetricsAggregateQuantileOverTime {
+		qs := agg.Quantiles()
+		if len(qs) == 0 {
+			return nil, fmt.Errorf("traceql: quantile_over_time requires at least one quantile")
+		}
+		if len(qs) > 1 {
+			return nil, fmt.Errorf("traceql: multi-quantile quantile_over_time is not yet supported (got %d quantiles)", len(qs))
+		}
+		quantiles = []float64{qs[0]}
+	}
+
+	return &chplan.MetricsAggregate{
+		Op:             cop,
+		Attr:           attr,
 		GroupBy:        groupBy,
 		GroupByAliases: groupAliases,
-		AggFuncs: []chplan.AggFunc{{
-			Name:   chFunc,
-			Params: params,
-			Args:   args,
-			Alias:  metricsValueAlias,
-		}},
+		Quantiles:      quantiles,
+		ValueAlias:     metricsValueAlias,
+		Inner:          prev,
 	}, nil
 }
 
-// mapMetricsAggregateOp turns a TraceQL MetricsAggregateOp into the CH
-// aggregate-function name + parameter list (for parameterised aggregates
-// like `quantile(0.95)(value)`).
-//
-// rate / count_over_time both lower to `count` — the handler-side
-// RangeWindow.Func discriminates them when it picks the per-step
-// normalisation (rate divides by the window's seconds; count_over_time
-// does not).
-func mapMetricsAggregateOp(op traceql.MetricsAggregateOp, qs []float64) (name string, params []chplan.Expr, err error) {
+// mapMetricsAggregateOp turns a TraceQL MetricsAggregateOp into the
+// chplan.MetricsOp enum the IR carries. The previous version returned
+// a CH aggregate-function name directly — that mapping now lives in
+// internal/chsql/range_window.go's metricsAggregateCH so the emitter
+// can also pick the per-bucket reducer for the matrix path.
+func mapMetricsAggregateOp(op traceql.MetricsAggregateOp) (chplan.MetricsOp, error) {
 	switch op {
-	case traceql.MetricsAggregateRate, traceql.MetricsAggregateCountOverTime:
-		return "count", nil, nil
+	case traceql.MetricsAggregateRate:
+		return chplan.MetricsOpRate, nil
+	case traceql.MetricsAggregateCountOverTime:
+		return chplan.MetricsOpCountOverTime, nil
 	case traceql.MetricsAggregateSumOverTime:
-		return "sum", nil, nil
+		return chplan.MetricsOpSumOverTime, nil
 	case traceql.MetricsAggregateAvgOverTime:
-		return "avg", nil, nil
+		return chplan.MetricsOpAvgOverTime, nil
 	case traceql.MetricsAggregateMinOverTime:
-		return "min", nil, nil
+		return chplan.MetricsOpMinOverTime, nil
 	case traceql.MetricsAggregateMaxOverTime:
-		return "max", nil, nil
+		return chplan.MetricsOpMaxOverTime, nil
 	case traceql.MetricsAggregateQuantileOverTime:
-		if len(qs) == 0 {
-			return "", nil, fmt.Errorf("traceql: quantile_over_time requires at least one quantile")
-		}
-		if len(qs) > 1 {
-			return "", nil, fmt.Errorf("traceql: multi-quantile quantile_over_time is not yet supported (got %d quantiles)", len(qs))
-		}
-		return "quantile", []chplan.Expr{&chplan.LitFloat{V: qs[0]}}, nil
+		return chplan.MetricsOpQuantileOverTime, nil
 	case traceql.MetricsAggregateHistogramOverTime:
-		return "", nil, fmt.Errorf("traceql: histogram_over_time is not yet supported")
+		return chplan.MetricsOpInvalid, fmt.Errorf("traceql: histogram_over_time is not yet supported")
 	}
-	return "", nil, fmt.Errorf("traceql: metrics aggregate op %s is not yet supported", op)
+	return chplan.MetricsOpInvalid, fmt.Errorf("traceql: metrics aggregate op %s is not yet supported", op)
 }
 
-// metricsAggregateArgs picks the inner expression list for the CH
-// aggregate.
+// metricsAggregateAttr picks the chplan.Expr for the metric operand.
 //
-//   - rate / count_over_time: `count(1)` — there is no operand in the
-//     TraceQL source; we count rows.
+//   - rate / count_over_time: nil (no operand in the TraceQL source;
+//     the emitter renders `count(1)`).
 //   - *_over_time(attr) and quantile_over_time(attr, q): the lowered
 //     attribute reference.
 //
 // The "no attribute supplied" sentinel is the zero-value `Attribute{}`
 // (same convention Tempo's runtime uses at
 // ast_metrics.go: `a.attr != (Attribute{})`).
-func metricsAggregateArgs(op traceql.MetricsAggregateOp, attr traceql.Attribute, s schema.Traces) ([]chplan.Expr, error) {
+func metricsAggregateAttr(op traceql.MetricsAggregateOp, attr traceql.Attribute, s schema.Traces) (chplan.Expr, error) {
 	switch op {
 	case traceql.MetricsAggregateRate, traceql.MetricsAggregateCountOverTime:
-		// `count(1)` — keeps the parameterised form symmetrical with the
-		// `count()` aggregate produced by lowerAggregate in aggregate.go.
-		return []chplan.Expr{&chplan.LitInt{V: 1}}, nil
+		return nil, nil
 	}
 	if attr == (traceql.Attribute{}) {
 		return nil, fmt.Errorf("traceql: %s requires an attribute operand", op)
 	}
-	return []chplan.Expr{lowerAttribute(attr, s)}, nil
+	return lowerAttribute(attr, s), nil
 }
 
 // lowerMetricsGroupBy turns a TraceQL `by (<attr>, <attr>, ...)` list

--- a/internal/traceql/metrics_pipeline_test.go
+++ b/internal/traceql/metrics_pipeline_test.go
@@ -13,8 +13,8 @@ import (
 
 // TestLowerMetricsPipeline exercises the MetricsPipeline lowering
 // directly: parse a TraceQL metrics query, lower it, and walk the
-// resulting chplan tree to confirm the expected Aggregate(Scan)
-// shape, group-by labels, and CH aggregate function name.
+// resulting chplan tree to confirm the expected MetricsAggregate(Scan)
+// shape, group-by labels, and chplan MetricsOp.
 //
 // Range / step intentionally aren't part of the lowered tree —
 // the /api/metrics/query_range handler wraps with chplan.RangeWindow
@@ -27,45 +27,45 @@ func TestLowerMetricsPipeline(t *testing.T) {
 	cases := []struct {
 		name      string
 		query     string
-		wantAgg   string // CH aggregate function on the outer node
-		wantArgs  int    // number of Args on the AggFunc
-		wantGroup int    // number of GroupBy expressions
-		hasFilter bool   // whether the spanset selector produces a Filter
+		wantOp    chplan.MetricsOp
+		wantAttr  bool // whether MetricsAggregate.Attr is non-nil
+		wantGroup int  // number of GroupBy expressions
+		hasFilter bool // whether the spanset selector produces a Filter
 	}{
 		{
-			name:    "rate_no_selector",
-			query:   "{} | rate()",
-			wantAgg: "count", wantArgs: 1, wantGroup: 0, hasFilter: true,
+			name:   "rate_no_selector",
+			query:  "{} | rate()",
+			wantOp: chplan.MetricsOpRate, wantAttr: false, wantGroup: 0, hasFilter: true,
 		},
 		{
-			name:    "count_over_time_with_selector",
-			query:   `{ resource.service.name = "frontend" } | count_over_time()`,
-			wantAgg: "count", wantArgs: 1, wantGroup: 0, hasFilter: true,
+			name:   "count_over_time_with_selector",
+			query:  `{ resource.service.name = "frontend" } | count_over_time()`,
+			wantOp: chplan.MetricsOpCountOverTime, wantAttr: false, wantGroup: 0, hasFilter: true,
 		},
 		{
-			name:    "sum_over_time_attr",
-			query:   `{} | sum_over_time(duration)`,
-			wantAgg: "sum", wantArgs: 1, wantGroup: 0, hasFilter: true,
+			name:   "sum_over_time_attr",
+			query:  `{} | sum_over_time(duration)`,
+			wantOp: chplan.MetricsOpSumOverTime, wantAttr: true, wantGroup: 0, hasFilter: true,
 		},
 		{
-			name:    "min_over_time_attr",
-			query:   `{} | min_over_time(duration)`,
-			wantAgg: "min", wantArgs: 1, wantGroup: 0, hasFilter: true,
+			name:   "min_over_time_attr",
+			query:  `{} | min_over_time(duration)`,
+			wantOp: chplan.MetricsOpMinOverTime, wantAttr: true, wantGroup: 0, hasFilter: true,
 		},
 		{
-			name:    "max_over_time_attr",
-			query:   `{} | max_over_time(duration)`,
-			wantAgg: "max", wantArgs: 1, wantGroup: 0, hasFilter: true,
+			name:   "max_over_time_attr",
+			query:  `{} | max_over_time(duration)`,
+			wantOp: chplan.MetricsOpMaxOverTime, wantAttr: true, wantGroup: 0, hasFilter: true,
 		},
 		{
-			name:    "rate_by_label",
-			query:   `{} | rate() by (resource.service.name)`,
-			wantAgg: "count", wantArgs: 1, wantGroup: 1, hasFilter: true,
+			name:   "rate_by_label",
+			query:  `{} | rate() by (resource.service.name)`,
+			wantOp: chplan.MetricsOpRate, wantAttr: false, wantGroup: 1, hasFilter: true,
 		},
 		{
-			name:    "quantile_over_time_single",
-			query:   `{} | quantile_over_time(duration, 0.95)`,
-			wantAgg: "quantile", wantArgs: 1, wantGroup: 0, hasFilter: true,
+			name:   "quantile_over_time_single",
+			query:  `{} | quantile_over_time(duration, 0.95)`,
+			wantOp: chplan.MetricsOpQuantileOverTime, wantAttr: true, wantGroup: 0, hasFilter: true,
 		},
 	}
 
@@ -83,58 +83,50 @@ func TestLowerMetricsPipeline(t *testing.T) {
 				t.Fatalf("Lower(%q): %v", tc.query, err)
 			}
 
-			agg, ok := plan.(*chplan.Aggregate)
+			ma, ok := plan.(*chplan.MetricsAggregate)
 			if !ok {
-				t.Fatalf("expected outermost node to be *chplan.Aggregate, got %T", plan)
+				t.Fatalf("expected outermost node to be *chplan.MetricsAggregate, got %T", plan)
 			}
-			if len(agg.AggFuncs) != 1 {
-				t.Fatalf("expected exactly 1 AggFunc, got %d", len(agg.AggFuncs))
+			if ma.Op != tc.wantOp {
+				t.Errorf("MetricsAggregate.Op = %v, want %v", ma.Op, tc.wantOp)
 			}
-			af := agg.AggFuncs[0]
-			if af.Name != tc.wantAgg {
-				t.Errorf("AggFunc.Name = %q, want %q", af.Name, tc.wantAgg)
+			if ma.ValueAlias != "Value" {
+				t.Errorf("MetricsAggregate.ValueAlias = %q, want %q", ma.ValueAlias, "Value")
 			}
-			if af.Alias != "Value" {
-				t.Errorf("AggFunc.Alias = %q, want %q", af.Alias, "Value")
+			if (ma.Attr != nil) != tc.wantAttr {
+				t.Errorf("MetricsAggregate.Attr non-nil = %v, want %v", ma.Attr != nil, tc.wantAttr)
 			}
-			if len(af.Args) != tc.wantArgs {
-				t.Errorf("len(AggFunc.Args) = %d, want %d", len(af.Args), tc.wantArgs)
+			if len(ma.GroupBy) != tc.wantGroup {
+				t.Errorf("len(MetricsAggregate.GroupBy) = %d, want %d", len(ma.GroupBy), tc.wantGroup)
 			}
-			if len(agg.GroupBy) != tc.wantGroup {
-				t.Errorf("len(Aggregate.GroupBy) = %d, want %d", len(agg.GroupBy), tc.wantGroup)
-			}
-			if len(agg.GroupBy) != len(agg.GroupByAliases) {
-				t.Errorf("GroupBy/GroupByAliases length mismatch: %d vs %d", len(agg.GroupBy), len(agg.GroupByAliases))
+			if len(ma.GroupBy) != len(ma.GroupByAliases) {
+				t.Errorf("GroupBy/GroupByAliases length mismatch: %d vs %d", len(ma.GroupBy), len(ma.GroupByAliases))
 			}
 
 			// Walk the inner subtree: Scan, optionally wrapped by Filter.
-			inner := agg.Input
+			inner := ma.Inner
 			if tc.hasFilter {
 				f, ok := inner.(*chplan.Filter)
 				if !ok {
-					t.Fatalf("expected Aggregate.Input to be *chplan.Filter, got %T", inner)
+					t.Fatalf("expected MetricsAggregate.Inner to be *chplan.Filter, got %T", inner)
 				}
 				inner = f.Input
 			}
 			scan, ok := inner.(*chplan.Scan)
 			if !ok {
-				t.Fatalf("expected Aggregate.Input innermost to be *chplan.Scan, got %T", inner)
+				t.Fatalf("expected MetricsAggregate.Inner innermost to be *chplan.Scan, got %T", inner)
 			}
 			if scan.Table != s.SpansTable {
 				t.Errorf("Scan.Table = %q, want %q", scan.Table, s.SpansTable)
 			}
 
-			// Quantile case: Params carry the quantile literal.
-			if tc.wantAgg == "quantile" {
-				if len(af.Params) != 1 {
-					t.Fatalf("expected 1 quantile Param, got %d", len(af.Params))
+			// Quantile case: Quantiles carries the literal.
+			if tc.wantOp == chplan.MetricsOpQuantileOverTime {
+				if len(ma.Quantiles) != 1 {
+					t.Fatalf("expected 1 quantile, got %d", len(ma.Quantiles))
 				}
-				lf, ok := af.Params[0].(*chplan.LitFloat)
-				if !ok {
-					t.Fatalf("expected Param[0] to be *chplan.LitFloat, got %T", af.Params[0])
-				}
-				if lf.V != 0.95 {
-					t.Errorf("quantile = %v, want 0.95", lf.V)
+				if ma.Quantiles[0] != 0.95 {
+					t.Errorf("Quantiles[0] = %v, want 0.95", ma.Quantiles[0])
 				}
 			}
 		})

--- a/test/spec/chsql/metrics_aggregate_quantile_over_time_bare.txtar
+++ b/test/spec/chsql/metrics_aggregate_quantile_over_time_bare.txtar
@@ -1,0 +1,4 @@
+-- args --
+[0] float64 = 0.95
+-- sql --
+SELECT quantile(?)(`Duration`) AS `Value` FROM (SELECT * FROM `otel_traces`)

--- a/test/spec/chsql/metrics_aggregate_rate_bare.txtar
+++ b/test/spec/chsql/metrics_aggregate_rate_bare.txtar
@@ -1,0 +1,4 @@
+-- args --
+[0] int64 = 1
+-- sql --
+SELECT count(?) AS `Value` FROM (SELECT * FROM `otel_traces`)

--- a/test/spec/chsql/metrics_aggregate_sum_over_time_bare.txtar
+++ b/test/spec/chsql/metrics_aggregate_sum_over_time_bare.txtar
@@ -1,0 +1,4 @@
+-- args --
+(none)
+-- sql --
+SELECT sum(`Duration`) AS `Value` FROM (SELECT * FROM `otel_traces`)

--- a/test/spec/chsql/range_window_metrics_count_over_time_by.txtar
+++ b/test/spec/chsql/range_window_metrics_count_over_time_by.txtar
@@ -1,0 +1,4 @@
+-- args --
+[0] int64 = 1
+-- sql --
+SELECT `service`, `anchor_ts`, count(?) AS `Value` FROM (SELECT `ServiceName` AS `service`, `Timestamp` AS `ts`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 11))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) WHERE ts >= anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts GROUP BY `service`, `anchor_ts`

--- a/test/spec/chsql/range_window_metrics_quantile_over_time_attr.txtar
+++ b/test/spec/chsql/range_window_metrics_quantile_over_time_attr.txtar
@@ -1,0 +1,4 @@
+-- args --
+[0] float64 = 0.95
+-- sql --
+SELECT `anchor_ts`, quantile(?)(`metric_arg`) AS `Value` FROM (SELECT `Timestamp` AS `ts`, `Duration` AS `metric_arg`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) WHERE ts >= anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts GROUP BY `anchor_ts`

--- a/test/spec/chsql/range_window_metrics_rate.txtar
+++ b/test/spec/chsql/range_window_metrics_rate.txtar
@@ -1,0 +1,4 @@
+-- args --
+[0] int64 = 1
+-- sql --
+SELECT `anchor_ts`, count(?) / 300 AS `Value` FROM (SELECT `Timestamp` AS `ts`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 61))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) WHERE ts >= anchor_ts - toIntervalNanosecond(300000000000) AND ts <= anchor_ts GROUP BY `anchor_ts`

--- a/test/spec/chsql/range_window_metrics_sum_over_time_attr.txtar
+++ b/test/spec/chsql/range_window_metrics_sum_over_time_attr.txtar
@@ -1,0 +1,4 @@
+-- args --
+(none)
+-- sql --
+SELECT `anchor_ts`, sum(`metric_arg`) AS `Value` FROM (SELECT `Timestamp` AS `ts`, `Duration` AS `metric_arg`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) WHERE ts >= anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts GROUP BY `anchor_ts`


### PR DESCRIPTION
## Summary
Precursor PR that unblocks \`/api/metrics/query_range\` handler (deferred from agent a115098f). The lowered \`Aggregate(Scan(traces))\` from #153 couldn't be wrapped by \`RangeWindow\` and emitted as a matrix because \`range_window.go\` hard-coded row-shape \`Input\` with per-span \`(Timestamp, Value)\`.

Changes:
- New \`chplan.MetricsAggregate{Op, Attr, GroupBy, GroupByAliases, Quantiles, ValueAlias, Inner}\` IR node + \`chplan.MetricsOp\` enum (rate / count_over_time / *_over_time / quantile_over_time).
- \`internal/traceql/metrics_pipeline.go\` lowering now returns \`MetricsAggregate\` (typed Op marker + operand fields) instead of a bare \`Aggregate\` with collapsed semantics — rate and count_over_time stop sharing the same CH \`count\` mapping at lowering time.
- \`internal/chsql/range_window.go\` emitter:
  - \`emitMetricsAggregate\` — standalone (no RangeWindow wrapper) emits SQL byte-identical to the prior \`Aggregate\` shape (existing TraceQL fixtures stay untouched).
  - \`emitRangeWindowMetrics\` — new matrix path; \`arrayJoin(range(0, N))\` step-grid + per-bucket reducer per \`MetricsOp\`.
- \`internal/api/tempo/handler.go\` \`isAggregateShape\` recognises \`MetricsAggregate\`.
- TXTAR fixtures regenerated: 3 bare-form + 4 matrix-shape fixtures pin the new SQL output.

## Test plan
- [x] \`go test ./internal/traceql/... ./internal/chsql/... ./internal/chplan/...\` passes.
- [x] \`just test\` (race + cover) passes (990 tests across 18 packages).
- [x] \`go vet ./internal/...\` clean.
- [x] \`gofumpt -l internal/\` empty.
- [x] \`golangci-lint run\` clean.
- [x] TXTAR fixtures lock the new matrix SQL output.
- [x] PromQL row-shape \`RangeWindow\` path unaffected — \`range_window_rate*\`, \`range_window_*_over_time\`, \`range_window_matrix_*\`, \`range_window_identity\`, \`range_window_log_rate\`, \`range_window_rate_offset\` fixtures all byte-identical to main.

Follow-up: thin \`/api/metrics/query_range\` handler PR consumes this contract.