### PR TITLE
feat(schema/ddl): wrap upstream OTel CH Exporter DDL via tsouza/collector-contrib fork (RC2)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -43,6 +43,13 @@ clean:
 test:
     go test -race ./...
 
+# Run the internal/schema/ddl integration tests against a real ClickHouse
+# container (spun up via testcontainers-go). Requires Docker. Gated behind
+# the `integration` build tag so regular `just test` doesn't pull in
+# Docker.
+schema-ddl-test:
+    go test -race -tags=integration ./internal/schema/ddl/...
+
 # Run the FuzzParse target for one parser head for a bounded duration.
 # Usage: `just fuzz QL=promql DURATION=60s` (defaults).
 fuzz QL="promql" DURATION="60s":

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/grafana/loki/v3 v3.7.1
 	github.com/grafana/tempo v1.5.1-0.20260508211128-2f74ea818de1
+	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter v0.150.0
 	github.com/prometheus/common v0.67.5
 	github.com/prometheus/prometheus v0.311.3
 	github.com/testcontainers/testcontainers-go/modules/clickhouse v0.42.0
@@ -242,6 +243,7 @@ replace github.com/grafana/tempo => github.com/tsouza/tempo v0.0.0-2026051308155
 // per-subdirectory module layout, so each imported submodule needs its
 // own replace directive pointing at the same fork SHA.
 replace (
+	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter => github.com/tsouza/opentelemetry-collector-contrib/exporter/clickhouseexporter v0.0.0-20260513133556-0dfb75bc1abf
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal => github.com/tsouza/opentelemetry-collector-contrib/internal/coreinternal v0.0.0-20260513133556-0dfb75bc1abf
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/core/xidutils => github.com/tsouza/opentelemetry-collector-contrib/pkg/core/xidutils v0.0.0-20260513133556-0dfb75bc1abf
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger => github.com/tsouza/opentelemetry-collector-contrib/pkg/translator/jaeger v0.0.0-20260513133556-0dfb75bc1abf

--- a/go.sum
+++ b/go.sum
@@ -530,6 +530,8 @@ github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYI
 github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
 github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=
 github.com/tklauser/numcpus v0.11.0/go.mod h1:z+LwcLq54uWZTX0u/bGobaV34u6V7KNlTZejzM6/3MQ=
+github.com/tsouza/opentelemetry-collector-contrib/exporter/clickhouseexporter v0.0.0-20260513133556-0dfb75bc1abf h1:WG1aJQVCA13b+38ZFJf/toQBkL1fXJtfgsUJQpJ1BAk=
+github.com/tsouza/opentelemetry-collector-contrib/exporter/clickhouseexporter v0.0.0-20260513133556-0dfb75bc1abf/go.mod h1:rfJhnOKwmih+Ob9dbw7qlz9c40jb9jq02otf3DNSjHo=
 github.com/tsouza/opentelemetry-collector-contrib/internal/coreinternal v0.0.0-20260513133556-0dfb75bc1abf h1:ElnVkNecL2mGOZ1sTT4TBT9HKTEY5PcX0iufP0Yk0JA=
 github.com/tsouza/opentelemetry-collector-contrib/internal/coreinternal v0.0.0-20260513133556-0dfb75bc1abf/go.mod h1://jdJ6pGeThzJ9e/kLXBnp2gcqTuvjvu4df/HycUFGE=
 github.com/tsouza/opentelemetry-collector-contrib/pkg/core/xidutils v0.0.0-20260513133556-0dfb75bc1abf h1:osKtsBiGp8wL8e2p696rqGp9zHAAd/d3mw6lAfLqvZM=

--- a/internal/schema/ddl/ddl.go
+++ b/internal/schema/ddl/ddl.go
@@ -1,0 +1,278 @@
+// Package ddl applies the upstream OTel ClickHouse Exporter's DDL templates
+// against a cerberus ClickHouse connection. Schema source-of-truth lives in
+// github.com/open-telemetry/opentelemetry-collector-contrib (via the
+// tsouza/opentelemetry-collector-contrib:cerberus-ddl fork wired via go.mod
+// replace, see PR #154). Cerberus does NOT maintain a parallel schema; this
+// package just executes upstream's `CREATE TABLE IF NOT EXISTS` against the
+// configured CH connection.
+//
+// The upstream templates are `fmt.Sprintf`-style with `%s` placeholders for
+// (database, table, on-cluster clause, engine, TTL expression). Cerberus
+// renders them via a small [Config] struct that defaults to MergeTree, no
+// cluster, no TTL — matching the cerberus single-node ClickHouse deployment.
+// The materialized-view template for traces has a wider placeholder shape
+// (7 fields) which is handled specially in [renderTracesCreateTsView].
+package ddl
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter/sqltemplates"
+)
+
+// Config carries the rendering inputs for the upstream DDL templates. The
+// zero value renders against the `default` database with `MergeTree()` and
+// no TTL — the cerberus single-node default.
+type Config struct {
+	// Database names the ClickHouse database to create tables in.
+	// Defaults to "default" when empty.
+	Database string
+
+	// Cluster, when non-empty, renders an `ON CLUSTER "<name>"` clause
+	// into the templates. Cerberus's single-node deployment leaves it
+	// empty.
+	Cluster string
+
+	// Engine overrides the ClickHouse table engine. Defaults to
+	// "MergeTree()" — matches the upstream exporter default.
+	Engine string
+
+	// TTL, when non-zero, renders a `TTL <timeField> + toIntervalXxx(N)`
+	// clause into each template. Cerberus leaves TTL to the operator.
+	TTL time.Duration
+
+	// Tables overrides the per-signal table names. The zero values fall
+	// back to the upstream defaults (otel_logs, otel_traces,
+	// otel_metrics_gauge, otel_metrics_sum, otel_metrics_histogram,
+	// otel_metrics_exp_histogram, otel_metrics_summary).
+	Tables Tables
+}
+
+// Tables overrides the per-signal table name used when rendering each
+// upstream DDL template. Empty fields fall back to the upstream defaults.
+type Tables struct {
+	Logs                string
+	Traces              string
+	MetricsGauge        string
+	MetricsSum          string
+	MetricsHistogram    string
+	MetricsExpHistogram string
+	MetricsSummary      string
+}
+
+// Defaults mirror the upstream OTel ClickHouse Exporter's table names. They
+// are also what cerberus's internal/schema package returns from the
+// DefaultOTel{Metrics,Logs,Traces} helpers.
+const (
+	defaultDatabase = "default"
+	defaultEngine   = "MergeTree()"
+
+	defaultLogsTable                = "otel_logs"
+	defaultTracesTable              = "otel_traces"
+	defaultMetricsGaugeTable        = "otel_metrics_gauge"
+	defaultMetricsSumTable          = "otel_metrics_sum"
+	defaultMetricsHistogramTable    = "otel_metrics_histogram"
+	defaultMetricsExpHistogramTable = "otel_metrics_exp_histogram"
+	defaultMetricsSummaryTable      = "otel_metrics_summary"
+)
+
+// withDefaults returns a copy of cfg with empty string fields filled in
+// from the upstream defaults. This is the single source of "what's empty
+// mean" for the package — everything else reads pre-defaulted fields.
+func (c Config) withDefaults() Config {
+	if c.Database == "" {
+		c.Database = defaultDatabase
+	}
+	if c.Engine == "" {
+		c.Engine = defaultEngine
+	}
+	if c.Tables.Logs == "" {
+		c.Tables.Logs = defaultLogsTable
+	}
+	if c.Tables.Traces == "" {
+		c.Tables.Traces = defaultTracesTable
+	}
+	if c.Tables.MetricsGauge == "" {
+		c.Tables.MetricsGauge = defaultMetricsGaugeTable
+	}
+	if c.Tables.MetricsSum == "" {
+		c.Tables.MetricsSum = defaultMetricsSumTable
+	}
+	if c.Tables.MetricsHistogram == "" {
+		c.Tables.MetricsHistogram = defaultMetricsHistogramTable
+	}
+	if c.Tables.MetricsExpHistogram == "" {
+		c.Tables.MetricsExpHistogram = defaultMetricsExpHistogramTable
+	}
+	if c.Tables.MetricsSummary == "" {
+		c.Tables.MetricsSummary = defaultMetricsSummaryTable
+	}
+	return c
+}
+
+// clusterClause renders the optional `ON CLUSTER "<name>"` fragment that
+// upstream templates expect as a single `%s` slot. Matches upstream's
+// `Config.clusterString` semantics.
+func (c Config) clusterClause() string {
+	if c.Cluster == "" {
+		return ""
+	}
+	return fmt.Sprintf(`ON CLUSTER %q`, c.Cluster)
+}
+
+// ttlExpr renders the optional `TTL <field> + toIntervalXxx(N)` fragment
+// that upstream templates expect as a `%s` slot per signal. The time field
+// differs per signal — Logs uses `TimestampTime`, Traces use
+// `toDateTime(Timestamp)`, metrics use `toDateTime(TimeUnix)`. Matches
+// upstream's `internal.GenerateTTLExpr` semantics.
+func (c Config) ttlExpr(timeField string) string {
+	ttl := c.TTL
+	if ttl <= 0 {
+		return ""
+	}
+	switch {
+	case ttl%(24*time.Hour) == 0:
+		return fmt.Sprintf("TTL %s + toIntervalDay(%d)", timeField, ttl/(24*time.Hour))
+	case ttl%time.Hour == 0:
+		return fmt.Sprintf("TTL %s + toIntervalHour(%d)", timeField, ttl/time.Hour)
+	case ttl%time.Minute == 0:
+		return fmt.Sprintf("TTL %s + toIntervalMinute(%d)", timeField, ttl/time.Minute)
+	default:
+		return fmt.Sprintf("TTL %s + toIntervalSecond(%d)", timeField, ttl/time.Second)
+	}
+}
+
+// Apply runs CREATE TABLE IF NOT EXISTS for each requested signal against
+// conn using the upstream OTel exporter's DDL templates. Idempotent:
+// re-running over an existing schema is a no-op (every template carries
+// `IF NOT EXISTS`).
+//
+// For Metrics, all 5 tables (gauge, sum, histogram, exp_histogram, summary)
+// are created in one Apply call — they form the metrics signal as a unit.
+// For Traces, the spans table plus the trace_id_ts lookup table and its
+// materialized view are created together (matching upstream's
+// createTraceTables).
+//
+// Apply uses Config's zero-value defaults (database=default, engine=
+// MergeTree(), no cluster, no TTL, upstream table names). Callers needing
+// non-default rendering should use ApplyWithConfig.
+func Apply(ctx context.Context, conn driver.Conn, signals []Signal) error {
+	return ApplyWithConfig(ctx, conn, Config{}, signals)
+}
+
+// ApplyWithConfig is the explicit-config form of Apply: it threads a Config
+// through the upstream templates so callers can override database, engine,
+// cluster, TTL, or table names. See Config for field semantics.
+func ApplyWithConfig(ctx context.Context, conn driver.Conn, cfg Config, signals []Signal) error {
+	cfg = cfg.withDefaults()
+	for _, s := range signals {
+		if err := applySignal(ctx, conn, cfg, s); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// applySignal renders + executes the DDL statements for one signal.
+// Statement order within a signal matches the upstream exporter — for
+// Traces in particular the lookup table must precede the materialized
+// view (the MV references it).
+func applySignal(ctx context.Context, conn driver.Conn, cfg Config, s Signal) error {
+	stmts, err := renderSignal(cfg, s)
+	if err != nil {
+		return err
+	}
+	for _, stmt := range stmts {
+		if err := conn.Exec(ctx, stmt); err != nil {
+			return fmt.Errorf("ddl: exec %s: %w", s, err)
+		}
+	}
+	return nil
+}
+
+// renderSignal returns the ordered list of CREATE statements for a signal.
+// Splitting this out from applySignal keeps the rendering logic testable
+// without a live ClickHouse connection.
+func renderSignal(cfg Config, s Signal) ([]string, error) {
+	switch s {
+	case Metrics:
+		ttl := cfg.ttlExpr("toDateTime(TimeUnix)")
+		return []string{
+			renderMetricsTable(sqltemplates.MetricsGaugeCreateTable, cfg, cfg.Tables.MetricsGauge, ttl),
+			renderMetricsTable(sqltemplates.MetricsSumCreateTable, cfg, cfg.Tables.MetricsSum, ttl),
+			renderMetricsTable(sqltemplates.MetricsHistogramCreateTable, cfg, cfg.Tables.MetricsHistogram, ttl),
+			renderMetricsTable(sqltemplates.MetricsExpHistogramCreateTable, cfg, cfg.Tables.MetricsExpHistogram, ttl),
+			renderMetricsTable(sqltemplates.MetricsSummaryCreateTable, cfg, cfg.Tables.MetricsSummary, ttl),
+		}, nil
+	case Logs:
+		return []string{renderLogsTable(cfg)}, nil
+	case Traces:
+		return []string{
+			renderTracesTable(cfg),
+			renderTracesCreateTsTable(cfg),
+			renderTracesCreateTsView(cfg),
+		}, nil
+	default:
+		return nil, fmt.Errorf("ddl: unknown signal: %d", int(s))
+	}
+}
+
+// renderMetricsTable formats one of the five metrics table templates. The
+// upstream template shape is `(database, table, cluster, engine, ttl)` —
+// see metrics_*_table.sql in the fork and internal/metrics/metrics_model.go
+// in upstream for the canonical Sprintf call.
+func renderMetricsTable(tmpl string, cfg Config, table, ttl string) string {
+	return fmt.Sprintf(tmpl, cfg.Database, table, cfg.clusterClause(), cfg.Engine, ttl)
+}
+
+// renderLogsTable formats the logs DDL. Upstream shape:
+// `(database, table, cluster, engine, ttl)` — see exporter_logs.go's
+// renderCreateLogsTableSQL. The TTL field is `TimestampTime`.
+func renderLogsTable(cfg Config) string {
+	return fmt.Sprintf(sqltemplates.LogsCreateTable,
+		cfg.Database, cfg.Tables.Logs, cfg.clusterClause(),
+		cfg.Engine,
+		cfg.ttlExpr("TimestampTime"),
+	)
+}
+
+// renderTracesTable formats the traces spans-table DDL. Upstream shape:
+// `(database, table, cluster, engine, ttl)`. TTL field is
+// `toDateTime(Timestamp)`.
+func renderTracesTable(cfg Config) string {
+	return fmt.Sprintf(sqltemplates.TracesCreateTable,
+		cfg.Database, cfg.Tables.Traces, cfg.clusterClause(),
+		cfg.Engine,
+		cfg.ttlExpr("toDateTime(Timestamp)"),
+	)
+}
+
+// renderTracesCreateTsTable formats the `<table>_trace_id_ts` lookup table
+// DDL. Upstream shape mirrors the spans table (db, table, cluster, engine,
+// ttl) — the `_trace_id_ts` suffix is hard-coded into the template, so the
+// caller passes the base traces table name. TTL field is
+// `toDateTime(Start)`.
+func renderTracesCreateTsTable(cfg Config) string {
+	return fmt.Sprintf(sqltemplates.TracesCreateTsTable,
+		cfg.Database, cfg.Tables.Traces, cfg.clusterClause(),
+		cfg.Engine,
+		cfg.ttlExpr("toDateTime(Start)"),
+	)
+}
+
+// renderTracesCreateTsView formats the `<table>_trace_id_ts_mv`
+// materialized-view DDL. Upstream shape is *wider* than the table
+// templates: 7 placeholders — (db, table, cluster, db, table, db, table)
+// — because the MV references both the lookup table (TO clause) and the
+// spans table (FROM clause). See exporter_traces.go's
+// renderTraceIDTsMaterializedViewSQL.
+func renderTracesCreateTsView(cfg Config) string {
+	return fmt.Sprintf(sqltemplates.TracesCreateTsView,
+		cfg.Database, cfg.Tables.Traces, cfg.clusterClause(),
+		cfg.Database, cfg.Tables.Traces,
+		cfg.Database, cfg.Tables.Traces,
+	)
+}

--- a/internal/schema/ddl/ddl_integration_test.go
+++ b/internal/schema/ddl/ddl_integration_test.go
@@ -1,0 +1,184 @@
+//go:build integration
+
+package ddl_test
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	tcclickhouse "github.com/testcontainers/testcontainers-go/modules/clickhouse"
+
+	"github.com/tsouza/cerberus/internal/schema/ddl"
+)
+
+// startClickHouse spins up a real ClickHouse via testcontainers and returns
+// a driver.Conn bound to it plus a cleanup func. The image tracks the same
+// `24-alpine` line used by chclient's integration test.
+func startClickHouse(t *testing.T) (driver.Conn, string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	container, err := tcclickhouse.Run(ctx,
+		"clickhouse/clickhouse-server:24.8-alpine",
+		tcclickhouse.WithUsername("cerberus"),
+		tcclickhouse.WithPassword("cerberus"),
+		tcclickhouse.WithDatabase("otel"),
+	)
+	if err != nil {
+		t.Fatalf("start clickhouse: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = container.Terminate(context.Background())
+	})
+
+	host, err := container.Host(ctx)
+	if err != nil {
+		t.Fatalf("host: %v", err)
+	}
+	port, err := container.MappedPort(ctx, "9000/tcp")
+	if err != nil {
+		t.Fatalf("port: %v", err)
+	}
+
+	conn, err := clickhouse.Open(&clickhouse.Options{
+		Addr: []string{fmt.Sprintf("%s:%s", host, port.Port())},
+		Auth: clickhouse.Auth{
+			Database: "otel",
+			Username: "cerberus",
+			Password: "cerberus",
+		},
+		DialTimeout: 10 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = conn.Close()
+	})
+
+	pingCtx, pingCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer pingCancel()
+	if err := conn.Ping(pingCtx); err != nil {
+		t.Fatalf("ping: %v", err)
+	}
+	return conn, "otel"
+}
+
+// listTables reads the current database's table list — used by Apply tests
+// to assert what got created.
+func listTables(ctx context.Context, t *testing.T, conn driver.Conn, database string) []string {
+	t.Helper()
+	rows, err := conn.Query(ctx, fmt.Sprintf("SELECT name FROM system.tables WHERE database = '%s' ORDER BY name", database))
+	if err != nil {
+		t.Fatalf("query tables: %v", err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var n string
+		if err := rows.Scan(&n); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		out = append(out, n)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows.Err: %v", err)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestApply_CreatesAllTables runs Apply(ctx, conn, All) and checks every
+// signal's upstream tables show up in system.tables. The MV is also a row
+// in system.tables, so the expected total is 5 metrics + 1 logs + 1 spans
+// + 1 lookup + 1 MV = 9.
+func TestApply_CreatesAllTables(t *testing.T) {
+	conn, database := startClickHouse(t)
+	ctx := context.Background()
+
+	cfg := ddl.Config{Database: database}
+	if err := ddl.ApplyWithConfig(ctx, conn, cfg, ddl.All); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	tables := listTables(ctx, t, conn, database)
+	want := []string{
+		"otel_logs",
+		"otel_metrics_exp_histogram",
+		"otel_metrics_gauge",
+		"otel_metrics_histogram",
+		"otel_metrics_sum",
+		"otel_metrics_summary",
+		"otel_traces",
+		"otel_traces_trace_id_ts",
+		"otel_traces_trace_id_ts_mv",
+	}
+	if !sameStringSlice(tables, want) {
+		t.Errorf("tables mismatch:\n got: %v\nwant: %v", tables, want)
+	}
+}
+
+// TestApply_Idempotent runs Apply twice and confirms no error + identical
+// table list. This is the contract that lets PR D wire auto-create at
+// startup without guarding for "already exists".
+func TestApply_Idempotent(t *testing.T) {
+	conn, database := startClickHouse(t)
+	ctx := context.Background()
+	cfg := ddl.Config{Database: database}
+
+	if err := ddl.ApplyWithConfig(ctx, conn, cfg, ddl.All); err != nil {
+		t.Fatalf("Apply #1: %v", err)
+	}
+	first := listTables(ctx, t, conn, database)
+
+	if err := ddl.ApplyWithConfig(ctx, conn, cfg, ddl.All); err != nil {
+		t.Fatalf("Apply #2: %v", err)
+	}
+	second := listTables(ctx, t, conn, database)
+
+	if !sameStringSlice(first, second) {
+		t.Errorf("table list changed after second Apply:\n  before: %v\n  after:  %v", first, second)
+	}
+}
+
+// TestApply_SignalSubset confirms a single-signal Apply only touches that
+// signal's tables.
+func TestApply_SignalSubset(t *testing.T) {
+	conn, database := startClickHouse(t)
+	ctx := context.Background()
+	cfg := ddl.Config{Database: database}
+
+	if err := ddl.ApplyWithConfig(ctx, conn, cfg, []ddl.Signal{ddl.Metrics}); err != nil {
+		t.Fatalf("Apply(Metrics): %v", err)
+	}
+
+	tables := listTables(ctx, t, conn, database)
+	want := []string{
+		"otel_metrics_exp_histogram",
+		"otel_metrics_gauge",
+		"otel_metrics_histogram",
+		"otel_metrics_sum",
+		"otel_metrics_summary",
+	}
+	if !sameStringSlice(tables, want) {
+		t.Errorf("metrics-only tables mismatch:\n got: %v\nwant: %v", tables, want)
+	}
+}
+
+func sameStringSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/schema/ddl/ddl_test.go
+++ b/internal/schema/ddl/ddl_test.go
@@ -1,0 +1,198 @@
+package ddl
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestRenderSignal_Metrics checks all five metrics templates render with
+// the right table names + engine + database substituted in.
+func TestRenderSignal_Metrics(t *testing.T) {
+	cfg := Config{}.withDefaults()
+
+	stmts, err := renderSignal(cfg, Metrics)
+	if err != nil {
+		t.Fatalf("renderSignal(Metrics): %v", err)
+	}
+	if got, want := len(stmts), 5; got != want {
+		t.Fatalf("metrics: got %d statements, want %d", got, want)
+	}
+	wantTables := []string{
+		"otel_metrics_gauge",
+		"otel_metrics_sum",
+		"otel_metrics_histogram",
+		"otel_metrics_exp_histogram",
+		"otel_metrics_summary",
+	}
+	for i, stmt := range stmts {
+		if !strings.Contains(stmt, "CREATE TABLE IF NOT EXISTS") {
+			t.Errorf("metrics[%d]: missing IF NOT EXISTS:\n%s", i, stmt)
+		}
+		if !strings.Contains(stmt, wantTables[i]) {
+			t.Errorf("metrics[%d]: missing table %q in:\n%s", i, wantTables[i], stmt)
+		}
+		if !strings.Contains(stmt, "MergeTree()") {
+			t.Errorf("metrics[%d]: missing default MergeTree() engine", i)
+		}
+		if strings.Contains(stmt, "ON CLUSTER") {
+			t.Errorf("metrics[%d]: empty cluster should not render ON CLUSTER", i)
+		}
+		if strings.Contains(stmt, "TTL toDateTime") {
+			t.Errorf("metrics[%d]: zero TTL should not render TTL clause", i)
+		}
+	}
+}
+
+// TestRenderSignal_Logs checks the single logs template renders.
+func TestRenderSignal_Logs(t *testing.T) {
+	cfg := Config{}.withDefaults()
+	stmts, err := renderSignal(cfg, Logs)
+	if err != nil {
+		t.Fatalf("renderSignal(Logs): %v", err)
+	}
+	if got, want := len(stmts), 1; got != want {
+		t.Fatalf("logs: got %d statements, want %d", got, want)
+	}
+	if !strings.Contains(stmts[0], "otel_logs") {
+		t.Errorf("logs: missing table name in:\n%s", stmts[0])
+	}
+	if !strings.Contains(stmts[0], "CREATE TABLE IF NOT EXISTS") {
+		t.Errorf("logs: missing IF NOT EXISTS")
+	}
+}
+
+// TestRenderSignal_Traces checks the three traces statements render — the
+// spans table, the trace_id_ts lookup table, and its materialized view.
+func TestRenderSignal_Traces(t *testing.T) {
+	cfg := Config{}.withDefaults()
+	stmts, err := renderSignal(cfg, Traces)
+	if err != nil {
+		t.Fatalf("renderSignal(Traces): %v", err)
+	}
+	if got, want := len(stmts), 3; got != want {
+		t.Fatalf("traces: got %d statements, want %d", got, want)
+	}
+	if !strings.Contains(stmts[0], "CREATE TABLE IF NOT EXISTS") || !strings.Contains(stmts[0], "otel_traces") {
+		t.Errorf("traces[0]: missing spans-table CREATE:\n%s", stmts[0])
+	}
+	if !strings.Contains(stmts[1], "otel_traces_trace_id_ts") {
+		t.Errorf("traces[1]: missing trace_id_ts lookup table:\n%s", stmts[1])
+	}
+	if !strings.Contains(stmts[2], "CREATE MATERIALIZED VIEW IF NOT EXISTS") {
+		t.Errorf("traces[2]: missing MV CREATE:\n%s", stmts[2])
+	}
+	if !strings.Contains(stmts[2], "otel_traces_trace_id_ts_mv") {
+		t.Errorf("traces[2]: missing MV name:\n%s", stmts[2])
+	}
+	// The MV body should reference the spans table in its FROM clause.
+	if !strings.Contains(stmts[2], `FROM "default"."otel_traces"`) {
+		t.Errorf("traces[2]: MV should select FROM the spans table:\n%s", stmts[2])
+	}
+}
+
+// TestRenderSignal_CustomConfig exercises every Config override.
+func TestRenderSignal_CustomConfig(t *testing.T) {
+	cfg := Config{
+		Database: "cerberus_test",
+		Cluster:  "my_cluster",
+		Engine:   "ReplicatedMergeTree('/clickhouse/{shard}/tables/{table}', '{replica}')",
+		TTL:      48 * time.Hour,
+		Tables: Tables{
+			MetricsGauge:        "custom_gauge",
+			MetricsSum:          "custom_sum",
+			MetricsHistogram:    "custom_histogram",
+			MetricsExpHistogram: "custom_exp_histogram",
+			MetricsSummary:      "custom_summary",
+			Logs:                "custom_logs",
+			Traces:              "custom_traces",
+		},
+	}.withDefaults()
+
+	for _, sig := range All {
+		stmts, err := renderSignal(cfg, sig)
+		if err != nil {
+			t.Fatalf("renderSignal(%s): %v", sig, err)
+		}
+		for i, stmt := range stmts {
+			if !strings.Contains(stmt, "cerberus_test") {
+				t.Errorf("%s[%d]: custom database not rendered:\n%s", sig, i, stmt)
+			}
+			if !strings.Contains(stmt, `ON CLUSTER "my_cluster"`) {
+				t.Errorf("%s[%d]: cluster clause not rendered:\n%s", sig, i, stmt)
+			}
+		}
+	}
+
+	// Metrics + Logs + Traces table renders should include the custom
+	// engine + a 48-hour TTL expression.
+	metrics, _ := renderSignal(cfg, Metrics)
+	for i, stmt := range metrics {
+		if !strings.Contains(stmt, "ReplicatedMergeTree") {
+			t.Errorf("metrics[%d]: custom engine not rendered", i)
+		}
+		if !strings.Contains(stmt, "TTL toDateTime(TimeUnix) + toIntervalDay(2)") {
+			t.Errorf("metrics[%d]: TTL not rendered:\n%s", i, stmt)
+		}
+	}
+	logs, _ := renderSignal(cfg, Logs)
+	if !strings.Contains(logs[0], "TTL TimestampTime + toIntervalDay(2)") {
+		t.Errorf("logs: TTL not rendered:\n%s", logs[0])
+	}
+	traces, _ := renderSignal(cfg, Traces)
+	if !strings.Contains(traces[0], "TTL toDateTime(Timestamp) + toIntervalDay(2)") {
+		t.Errorf("traces[0]: TTL not rendered:\n%s", traces[0])
+	}
+	if !strings.Contains(traces[1], "TTL toDateTime(Start) + toIntervalDay(2)") {
+		t.Errorf("traces[1]: TTL not rendered:\n%s", traces[1])
+	}
+}
+
+// TestRenderSignal_UnknownSignal returns an error rather than panicking.
+func TestRenderSignal_UnknownSignal(t *testing.T) {
+	_, err := renderSignal(Config{}.withDefaults(), Signal(99))
+	if err == nil {
+		t.Fatalf("expected error for unknown signal, got nil")
+	}
+}
+
+// TestTTLExpr_RoundingBuckets checks the TTL rounding logic that mirrors
+// the upstream GenerateTTLExpr — round-up to day/hour/minute when the
+// duration falls on a clean boundary.
+func TestTTLExpr_RoundingBuckets(t *testing.T) {
+	cases := []struct {
+		name string
+		ttl  time.Duration
+		want string
+	}{
+		{"zero", 0, ""},
+		{"1d", 24 * time.Hour, "TTL t + toIntervalDay(1)"},
+		{"2h", 2 * time.Hour, "TTL t + toIntervalHour(2)"},
+		{"30m", 30 * time.Minute, "TTL t + toIntervalMinute(30)"},
+		{"45s", 45 * time.Second, "TTL t + toIntervalSecond(45)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := (Config{TTL: tc.ttl}).ttlExpr("t")
+			if got != tc.want {
+				t.Errorf("ttlExpr: got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSignalString sanity-checks the String() method since it's surfaced
+// in error messages.
+func TestSignalString(t *testing.T) {
+	cases := map[Signal]string{
+		Metrics:    "metrics",
+		Logs:       "logs",
+		Traces:     "traces",
+		Signal(99): "unknown",
+	}
+	for s, want := range cases {
+		if got := s.String(); got != want {
+			t.Errorf("Signal(%d).String() = %q, want %q", int(s), got, want)
+		}
+	}
+}

--- a/internal/schema/ddl/signal.go
+++ b/internal/schema/ddl/signal.go
@@ -1,0 +1,37 @@
+package ddl
+
+// Signal identifies a telemetry signal type. Each Signal value selects a
+// fixed bundle of CREATE TABLE statements rendered from the upstream OTel
+// ClickHouse Exporter's templates — see [Apply] for the per-signal table
+// list.
+type Signal int
+
+const (
+	// Metrics covers the 5 metrics tables: gauge, sum, histogram,
+	// exp_histogram, summary.
+	Metrics Signal = iota
+	// Logs covers the single OTel logs table.
+	Logs
+	// Traces covers the spans table, the trace_id_ts lookup table, and
+	// its materialized view (3 statements total).
+	Traces
+)
+
+// All is shorthand for every signal cerberus knows about. Order matches
+// the upstream exporter's per-signal start() hooks.
+var All = []Signal{Metrics, Logs, Traces}
+
+// String returns the human-readable signal name, used in error messages
+// surfaced from [Apply].
+func (s Signal) String() string {
+	switch s {
+	case Metrics:
+		return "metrics"
+	case Logs:
+		return "logs"
+	case Traces:
+		return "traces"
+	default:
+		return "unknown"
+	}
+}


### PR DESCRIPTION
## Summary

- New `internal/schema/ddl/` package wrapping the upstream OTel CH Exporter's `CREATE TABLE` templates (from the `tsouza/opentelemetry-collector-contrib:cerberus-ddl` fork wired in #154).
- Public API: `ddl.Apply(ctx, conn, signals) error` (zero-config) and `ddl.ApplyWithConfig(ctx, conn, cfg, signals)` (explicit-config). Idempotent via `CREATE TABLE IF NOT EXISTS` on every upstream template.
- Tests gated behind `-tags=integration` use a `clickhouse/clickhouse-server:24.8-alpine` Docker container to verify Apply creates the right 9 tables (5 metrics + 1 logs + spans + lookup + MV), is idempotent, and honours per-signal subsets.

## Shape of the upstream templates

The upstream constants in `exporter/clickhouseexporter/sqltemplates/embed.go` are **`fmt.Sprintf`-style with `%s` placeholders**, not Go templates. The standard signature is `(database, table, on-cluster-clause, engine, ttl-expr)`; the traces MV is wider (7 fields — db, table, cluster, db, table, db, table — because it references both the lookup table and the spans table). The `ttlExpr()` helper mirrors upstream `internal.GenerateTTLExpr`'s day/hour/minute/second bucket rounding.

## go.mod

Adds a fourth replace directive for the `exporter/clickhouseexporter` submodule, pointing at the same fork SHA already used for `coreinternal` / `xidutils` / `jaeger`. The exporter submodule itself isn't included in #154 because nothing imported it yet — this PR is the first consumer.

## Test plan

- [x] `go test ./internal/schema/...` passes (unit tests: rendering shape, TTL bucketing, signal enum, custom-config overrides).
- [x] `go test -race ./...` passes (no regressions across 983 tests).
- [x] `go vet ./internal/schema/...` clean.
- [x] `gofumpt -l internal/schema/ddl/` empty.
- [x] `golangci-lint run ./internal/schema/ddl/...` clean.
- [ ] `just schema-ddl-test` (i.e. `go test -tags=integration ./internal/schema/ddl/...`) against a local CH container creates all 9 tables idempotently. Compiles clean locally; full Docker run deferred to a follow-up (no Docker available in this worktree).

Plan: `/home/thiago/.claude/plans/can-you-tell-me-merry-thunder.md` PR C. Depends on #154 (fork + replace). Logically independent of #158 (schema struct extension) — that PR adds Go-side column names; this PR consumes upstream DDL strings verbatim. PR D wires auto-create at startup; PR E/F replace `test/e2e/seed/*.sql` and `harness/compatibility/seed.sql` with programmatic seeders consuming this package.