### PR TITLE
feat(api/tempo): /api/metrics/query_range handler (RC2)

### DIFF
--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -62,7 +62,10 @@ func New(client Querier, s schema.Traces, version string, logger *slog.Logger) *
 // Mount registers the Tempo-compatible endpoints under /api/ on mux.
 // /api/echo + /api/status/version satisfy Grafana's datasource health
 // check; /api/search runs a TraceQL query; /api/traces/{id} fetches a
-// single trace by ID.
+// single trace by ID; /api/metrics/query_range runs a TraceQL metrics
+// pipeline (`| rate()`, `| count_over_time()`, `| *_over_time(...)`)
+// against the spans table and returns the matrix in Tempo's
+// series-of-samples envelope.
 func (h *Handler) Mount(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/echo", h.handleEcho)
 	mux.HandleFunc("GET /api/status/version", h.handleVersion)
@@ -73,6 +76,7 @@ func (h *Handler) Mount(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/v2/search/tags", h.handleSearchTagsV2)
 	mux.HandleFunc("GET /api/v2/search/tag/{name}/values", h.handleSearchTagValuesV2)
 	mux.HandleFunc("GET /api/traces/{id}", h.handleTraceByID)
+	mux.HandleFunc("GET /api/metrics/query_range", h.handleMetricsQueryRange)
 }
 
 func (h *Handler) handleEcho(w http.ResponseWriter, _ *http.Request) {

--- a/internal/api/tempo/metrics_query_range.go
+++ b/internal/api/tempo/metrics_query_range.go
@@ -1,0 +1,347 @@
+package tempo
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/grafana/tempo/pkg/traceql"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	traceql_lower "github.com/tsouza/cerberus/internal/traceql"
+)
+
+// MetricsQueryRangeResponse is the body of `GET /api/metrics/query_range`.
+// Mirrors Tempo's native shape: one MetricsSeries per (group-by labels)
+// tuple, each with the per-anchor samples sorted ascending by timestamp.
+type MetricsQueryRangeResponse struct {
+	Series []MetricsSeries `json:"series"`
+}
+
+// MetricsSeries is one entry of MetricsQueryRangeResponse.Series.
+type MetricsSeries struct {
+	Labels  []MetricsLabel  `json:"labels"`
+	Samples []MetricsSample `json:"samples"`
+}
+
+// MetricsLabel is one (key, value) pair in MetricsSeries.Labels.
+type MetricsLabel struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// MetricsSample is one point in MetricsSeries.Samples — timestamp in
+// milliseconds (Tempo's wire unit) plus the per-bucket float value.
+type MetricsSample struct {
+	TimestampMs int64   `json:"timestampMs"`
+	Value       float64 `json:"value"`
+}
+
+// handleMetricsQueryRange implements `GET /api/metrics/query_range`.
+//
+// Parses the TraceQL metrics-pipeline query, lowers it to a chplan
+// MetricsAggregate (optionally wrapped in a single Filter), wraps that
+// with a RangeWindow carrying the request's start / end / step, runs
+// the resulting SQL, and reshapes the matrix rows into Tempo's
+// series-of-samples envelope.
+//
+// Contract: `q` = TraceQL metrics query, `start`/`end` = unix nanos
+// (parseTempoStartEnd accepts seconds / nanos / RFC3339), `step` =
+// Prom-style duration (`30s`, `1m`, ...).
+func (h *Handler) handleMetricsQueryRange(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query().Get("q")
+	if q == "" {
+		writeError(w, http.StatusBadRequest, "", "", errors.New("missing 'q' parameter"))
+		return
+	}
+	start, end, err := parseTempoStartEnd(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "", "", err)
+		return
+	}
+	if start.IsZero() || end.IsZero() {
+		writeError(w, http.StatusBadRequest, "", "", errors.New("'start' and 'end' parameters are required"))
+		return
+	}
+	stepStr := r.URL.Query().Get("step")
+	if stepStr == "" {
+		writeError(w, http.StatusBadRequest, "", "", errors.New("missing 'step' parameter"))
+		return
+	}
+	step, err := parseMetricsStep(stepStr)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "", "", err)
+		return
+	}
+
+	expr, err := traceql.Parse(q)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "", "", err)
+		return
+	}
+	plan, err := traceql_lower.Lower(expr, h.Schema)
+	if err != nil {
+		writeError(w, http.StatusUnprocessableEntity, "", "", err)
+		return
+	}
+
+	metrics, ok := unwrapMetricsAggregate(plan)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "", "",
+			fmt.Errorf("query %q is not a TraceQL metrics-pipeline expression — /api/metrics/query_range requires `| rate()`, `| count_over_time()`, `| *_over_time(...)` or `| quantile_over_time(...)`", q))
+		return
+	}
+
+	// Wrap the lowered plan with a RangeWindow carrying the request's
+	// eval grid. Range = Step so each bucket covers exactly one step
+	// width (matches Tempo's reference TraceQL metrics semantics, where
+	// `count_over_time` over a step-sized bucket is the per-step count).
+	rw := &chplan.RangeWindow{
+		Input:           plan,
+		Range:           step,
+		Step:            step,
+		Start:           start,
+		End:             end,
+		TimestampColumn: h.Schema.TimestampColumn,
+	}
+
+	// Wrap with the Sample-shape projection so chclient.Sample decoding
+	// works. anchor_ts becomes TimeUnix; the group-by columns become
+	// keys of the Attributes map (one map entry per by(...) label).
+	wrapped := wrapMetricsForSample(rw, metrics)
+	wrapped = h.Optimizer.Run(wrapped)
+
+	sqlStr, args, err := chsql.Emit(wrapped)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "", "", err)
+		return
+	}
+	h.Logger.Debug("cerberus tempo metrics_query_range",
+		"traceql", q, "start", start, "end", end, "step", step,
+		"sql", sqlStr, "args", args)
+
+	samples, err := h.Client.Query(r.Context(), sqlStr, args...)
+	if err != nil {
+		h.Logger.Warn("cerberus tempo metrics_query_range CH query failed",
+			"err", err.Error(), "sql", sqlStr)
+		writeError(w, http.StatusBadGateway, "", "", err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, MetricsQueryRangeResponse{
+		Series: toMetricsSeries(samples, metrics),
+	})
+}
+
+// parseMetricsStep parses the `step` query parameter — Prom-style
+// duration ("30s", "1m", "1h"), plain integer seconds, or a float
+// number of seconds. Returns an error if the parsed duration is
+// non-positive (zero would lock the matrix at a single anchor).
+func parseMetricsStep(raw string) (time.Duration, error) {
+	if f, err := strconv.ParseFloat(raw, 64); err == nil {
+		d := time.Duration(f * float64(time.Second))
+		if d <= 0 {
+			return 0, errors.New("'step' must be > 0")
+		}
+		return d, nil
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("'step' is not a valid duration: %w", err)
+	}
+	if d <= 0 {
+		return 0, errors.New("'step' must be > 0")
+	}
+	return d, nil
+}
+
+// unwrapMetricsAggregate accepts a lowered TraceQL plan and returns the
+// MetricsAggregate at its root (or directly under a single Filter
+// wrapper). Returns ok=false for any other shape — the trigger for the
+// handler's "not a metrics query" 400.
+//
+// Filter(MetricsAggregate) is currently unreachable from the lowering
+// (the spanset predicate becomes Filter inside MetricsAggregate.Inner),
+// but kept here for forward-compat with a future scalar-filter step
+// that wraps the aggregate.
+func unwrapMetricsAggregate(plan chplan.Node) (*chplan.MetricsAggregate, bool) {
+	switch v := plan.(type) {
+	case *chplan.MetricsAggregate:
+		return v, true
+	case *chplan.Filter:
+		if inner, ok := v.Input.(*chplan.MetricsAggregate); ok {
+			return inner, true
+		}
+	}
+	return nil, false
+}
+
+// wrapMetricsForSample is the projection that maps the matrix-shape
+// RangeWindow's outer SELECT (g0/<alias>..., anchor_ts, Value) into
+// chclient.Sample's positional shape (MetricName, Attributes,
+// TimeUnix, Value).
+//
+// Attributes is a Map(String,String) constructed inline:
+//
+//	map('<label1>', toString(<alias1>), '<label2>', toString(<alias2>), ...)
+//
+// When MetricsAggregate has no GroupBy, the map is empty (CAST to
+// Map(String,String) so CH accepts the Attributes column type).
+//
+// MetricName is the empty string (TraceQL metrics aggregations don't
+// carry a name like PromQL's `__name__`). anchor_ts arrives as
+// DateTime64(9); the CH driver maps it to time.Time on the wire.
+func wrapMetricsForSample(rw *chplan.RangeWindow, m *chplan.MetricsAggregate) chplan.Node {
+	attrAliases := metricsOuterGroupAliases(m.GroupBy, m.GroupByAliases)
+	labelNames := metricsLabelNames(m.GroupByAliases, len(m.GroupBy))
+
+	var attrs chplan.Expr
+	if len(m.GroupBy) == 0 {
+		attrs = emptyAttrsMap()
+	} else {
+		args := make([]chplan.Expr, 0, len(m.GroupBy)*2)
+		for i := range m.GroupBy {
+			args = append(args,
+				&chplan.LitString{V: labelNames[i]},
+				&chplan.FuncCall{
+					Name: "toString",
+					Args: []chplan.Expr{&chplan.ColumnRef{Name: attrAliases[i]}},
+				},
+			)
+		}
+		attrs = &chplan.FuncCall{Name: "map", Args: args}
+	}
+
+	return &chplan.Project{
+		Input: rw,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.LitString{V: ""}, Alias: "MetricName"},
+			{Expr: attrs, Alias: "Attributes"},
+			{Expr: &chplan.ColumnRef{Name: "anchor_ts"}, Alias: "TimeUnix"},
+			{Expr: &chplan.ColumnRef{Name: m.ValueAlias}, Alias: "Value"},
+		},
+	}
+}
+
+// metricsOuterGroupAliases mirrors the unexported chsql.outerGroupAliases:
+// for each MetricsAggregate.GroupBy entry, return the SELECT-list alias
+// used in the matrix-shape outer SELECT. Falls back to "g0", "g1", ...
+// for missing / empty aliases — the chsql emitter applies the same rule.
+func metricsOuterGroupAliases(groupBy []chplan.Expr, aliases []string) []string {
+	if len(groupBy) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(groupBy))
+	for i := range groupBy {
+		if i < len(aliases) && aliases[i] != "" {
+			out = append(out, aliases[i])
+			continue
+		}
+		out = append(out, "g"+strconv.Itoa(i))
+	}
+	return out
+}
+
+// metricsLabelNames returns the user-facing label names the response's
+// {key,value} pairs surface. Today identical to the lowering's
+// GroupByAliases (each by(...) attribute's Name); the helper exists so
+// a fallback name ("group_0", ...) is used when an alias is empty —
+// keeps the response self-describing for any future call-site that
+// constructs a MetricsAggregate without aliases.
+func metricsLabelNames(aliases []string, n int) []string {
+	out := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		if i < len(aliases) && aliases[i] != "" {
+			out = append(out, aliases[i])
+			continue
+		}
+		out = append(out, "group_"+strconv.Itoa(i))
+	}
+	return out
+}
+
+// toMetricsSeries pivots a flat sample stream into the Tempo
+// series-of-samples envelope. Samples sharing an identical Labels map
+// are coalesced into one series; each series' samples are sorted
+// ascending by timestamp.
+//
+// The Labels slice's order within a series mirrors m.GroupByAliases
+// (the TraceQL by(...) order). The series slice itself is sorted by
+// the canonical (sorted-keys) label-set string so callers see a
+// deterministic ordering.
+func toMetricsSeries(samples []chclient.Sample, m *chplan.MetricsAggregate) []MetricsSeries {
+	labelNames := metricsLabelNames(m.GroupByAliases, len(m.GroupBy))
+
+	type bucket struct {
+		labels  []MetricsLabel
+		samples []MetricsSample
+	}
+	byKey := map[string]*bucket{}
+
+	for _, s := range samples {
+		key := canonicalKey(s.Labels)
+		b, ok := byKey[key]
+		if !ok {
+			b = &bucket{labels: labelsFromSample(s.Labels, labelNames)}
+			byKey[key] = b
+		}
+		b.samples = append(b.samples, MetricsSample{
+			TimestampMs: s.Timestamp.UnixMilli(),
+			Value:       s.Value,
+		})
+	}
+
+	keys := make([]string, 0, len(byKey))
+	for k := range byKey {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	out := make([]MetricsSeries, 0, len(byKey))
+	for _, k := range keys {
+		b := byKey[k]
+		sort.Slice(b.samples, func(i, j int) bool {
+			return b.samples[i].TimestampMs < b.samples[j].TimestampMs
+		})
+		out = append(out, MetricsSeries{
+			Labels:  b.labels,
+			Samples: b.samples,
+		})
+	}
+	return out
+}
+
+// labelsFromSample materialises the {key,value} pair slice for one
+// row's Attributes map. labelNames is the preferred ordering (the
+// by(...) order); any keys present in the Sample's Labels but not in
+// labelNames are appended afterwards in ASCII order — defensive against
+// the SQL projection returning a label the handler didn't expect.
+func labelsFromSample(attrs map[string]string, labelNames []string) []MetricsLabel {
+	out := make([]MetricsLabel, 0, len(attrs))
+	seen := make(map[string]struct{}, len(labelNames))
+	for _, name := range labelNames {
+		v, ok := attrs[name]
+		if !ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, MetricsLabel{Key: name, Value: v})
+	}
+	extras := make([]string, 0)
+	for k := range attrs {
+		if _, ok := seen[k]; ok {
+			continue
+		}
+		extras = append(extras, k)
+	}
+	sort.Strings(extras)
+	for _, k := range extras {
+		out = append(out, MetricsLabel{Key: k, Value: attrs[k]})
+	}
+	return out
+}

--- a/internal/api/tempo/metrics_query_range_test.go
+++ b/internal/api/tempo/metrics_query_range_test.go
@@ -1,0 +1,392 @@
+package tempo_test
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/api/tempo"
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+// metricsQueryRangeURL builds the test URL with proper escaping for
+// the TraceQL `q` parameter — TraceQL queries always contain `{`/`}`,
+// quotes, and pipes, so url.QueryEscape is mandatory.
+func metricsQueryRangeURL(base, q string, params map[string]string) string {
+	vals := url.Values{}
+	vals.Set("q", q)
+	for k, v := range params {
+		vals.Set(k, v)
+	}
+	return base + "/api/metrics/query_range?" + vals.Encode()
+}
+
+// TestMetricsQueryRange_SingleSeriesNoGroupBy — a bare `| rate()` over
+// the full spans table returns a single series (no labels). Three
+// anchor rows in, three samples out, sorted by timestamp ascending.
+func TestMetricsQueryRange_SingleSeriesNoGroupBy(t *testing.T) {
+	t.Parallel()
+
+	ts := func(min int) time.Time {
+		return time.Date(2026, 5, 12, 10, min, 0, 0, time.UTC)
+	}
+	q := &stubQuerier{samples: []chclient.Sample{
+		// Intentionally out of order — handler must sort within each series.
+		{MetricName: "", Labels: map[string]string{}, Timestamp: ts(2), Value: 2.0},
+		{MetricName: "", Labels: map[string]string{}, Timestamp: ts(0), Value: 0.5},
+		{MetricName: "", Labels: map[string]string{}, Timestamp: ts(1), Value: 1.5},
+	}}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	u := metricsQueryRangeURL(srv.URL, "{} | rate()", map[string]string{
+		"start": "1747044000", // 2025-05-12T10:00:00Z
+		"end":   "1747044180", // +3m
+		"step":  "60s",
+	})
+
+	resp, err := http.Get(u)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+
+	var body tempo.MetricsQueryRangeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Series) != 1 {
+		t.Fatalf("expected 1 series, got %d: %+v", len(body.Series), body)
+	}
+	s := body.Series[0]
+	if len(s.Labels) != 0 {
+		t.Errorf("expected zero labels for ungrouped query, got %+v", s.Labels)
+	}
+	if len(s.Samples) != 3 {
+		t.Fatalf("expected 3 samples, got %d", len(s.Samples))
+	}
+	// Sorted ascending: 0.5, 1.5, 2.0 in that order.
+	for i, want := range []float64{0.5, 1.5, 2.0} {
+		if s.Samples[i].Value != want {
+			t.Errorf("sample[%d].Value = %v, want %v", i, s.Samples[i].Value, want)
+		}
+	}
+	if s.Samples[0].TimestampMs >= s.Samples[1].TimestampMs ||
+		s.Samples[1].TimestampMs >= s.Samples[2].TimestampMs {
+		t.Errorf("samples not sorted ascending by timestamp: %+v", s.Samples)
+	}
+
+	// The handler should have asked the matrix-shape SQL emitter (an
+	// arrayJoin fanout). Probe a few hallmark substrings to confirm
+	// we're hitting emitRangeWindowMetrics and not a Sprintf fallback.
+	assertSQLContains(t, q.lastSQL, "arrayJoin")
+	assertSQLContains(t, q.lastSQL, "anchor_ts")
+}
+
+// TestMetricsQueryRange_MultiSeriesGroupBy — `| count_over_time() by
+// (service.name)` returns one series per unique service. Labels
+// surface as {key,value} pairs in the response.
+func TestMetricsQueryRange_MultiSeriesGroupBy(t *testing.T) {
+	t.Parallel()
+
+	ts := func(min int) time.Time {
+		return time.Date(2026, 5, 12, 10, min, 0, 0, time.UTC)
+	}
+	q := &stubQuerier{samples: []chclient.Sample{
+		{Labels: map[string]string{"resource.service.name": "frontend"}, Timestamp: ts(0), Value: 12},
+		{Labels: map[string]string{"resource.service.name": "frontend"}, Timestamp: ts(1), Value: 18},
+		{Labels: map[string]string{"resource.service.name": "backend"}, Timestamp: ts(0), Value: 3},
+		{Labels: map[string]string{"resource.service.name": "backend"}, Timestamp: ts(1), Value: 5},
+	}}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	u := metricsQueryRangeURL(srv.URL,
+		"{} | count_over_time() by (resource.service.name)",
+		map[string]string{
+			"start": "1747044000",
+			"end":   "1747044120",
+			"step":  "60s",
+		})
+	resp, err := http.Get(u)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+
+	var body tempo.MetricsQueryRangeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Series) != 2 {
+		t.Fatalf("expected 2 series, got %d: %+v", len(body.Series), body)
+	}
+
+	// Each series should have exactly one label entry whose Key is the
+	// by(...) attribute name (TraceQL: resource.service.name).
+	byService := map[string]tempo.MetricsSeries{}
+	for _, s := range body.Series {
+		if len(s.Labels) != 1 {
+			t.Errorf("expected 1 label per series, got %+v", s.Labels)
+			continue
+		}
+		if s.Labels[0].Key != "resource.service.name" {
+			t.Errorf("expected label key 'resource.service.name', got %q", s.Labels[0].Key)
+		}
+		byService[s.Labels[0].Value] = s
+	}
+	if _, ok := byService["frontend"]; !ok {
+		t.Errorf("missing 'frontend' series: %+v", body.Series)
+	}
+	if _, ok := byService["backend"]; !ok {
+		t.Errorf("missing 'backend' series: %+v", body.Series)
+	}
+	if len(byService["frontend"].Samples) != 2 {
+		t.Errorf("expected 2 samples for frontend, got %d", len(byService["frontend"].Samples))
+	}
+}
+
+// TestMetricsQueryRange_EmptyResult — when CH returns zero rows the
+// response is `{series: []}` (not `null`).
+func TestMetricsQueryRange_EmptyResult(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{samples: nil}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	u := metricsQueryRangeURL(srv.URL, "{} | rate()", map[string]string{
+		"start": "1747044000",
+		"end":   "1747044060",
+		"step":  "30s",
+	})
+	resp, err := http.Get(u)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	var body tempo.MetricsQueryRangeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Series == nil {
+		t.Fatalf("expected non-nil empty Series slice, got nil (JSON null)")
+	}
+	if len(body.Series) != 0 {
+		t.Fatalf("expected 0 series, got %d", len(body.Series))
+	}
+}
+
+// TestMetricsQueryRange_BadInputs covers the 4xx surface: missing or
+// malformed `q` / `start` / `end` / `step`, and a non-metric TraceQL
+// query (one that lowers to a Scan/Filter rather than a
+// MetricsAggregate).
+func TestMetricsQueryRange_BadInputs(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		params  map[string]string
+		wantSub string
+	}{
+		{
+			name:    "missing_q",
+			params:  map[string]string{"start": "1747044000", "end": "1747044060", "step": "30s"},
+			wantSub: "missing 'q'",
+		},
+		{
+			name:    "missing_step",
+			params:  map[string]string{"q": "{} | rate()", "start": "1747044000", "end": "1747044060"},
+			wantSub: "missing 'step'",
+		},
+		{
+			name:    "missing_start",
+			params:  map[string]string{"q": "{} | rate()", "end": "1747044060", "step": "30s"},
+			wantSub: "required",
+		},
+		{
+			name:    "missing_end",
+			params:  map[string]string{"q": "{} | rate()", "start": "1747044000", "step": "30s"},
+			wantSub: "required",
+		},
+		{
+			name: "malformed_step",
+			params: map[string]string{
+				"q":     "{} | rate()",
+				"start": "1747044000",
+				"end":   "1747044060",
+				"step":  "five-minutes",
+			},
+			wantSub: "step",
+		},
+		{
+			name: "zero_step",
+			params: map[string]string{
+				"q":     "{} | rate()",
+				"start": "1747044000",
+				"end":   "1747044060",
+				"step":  "0s",
+			},
+			wantSub: "step",
+		},
+		{
+			name: "malformed_time",
+			params: map[string]string{
+				"q":     "{} | rate()",
+				"start": "not-a-time",
+				"end":   "1747044060",
+				"step":  "30s",
+			},
+			wantSub: "time",
+		},
+		{
+			name: "end_before_start",
+			params: map[string]string{
+				"q":     "{} | rate()",
+				"start": "1747044060",
+				"end":   "1747044000",
+				"step":  "30s",
+			},
+			wantSub: "before",
+		},
+		{
+			name: "parse_error",
+			params: map[string]string{
+				"q":     "this is not traceql {{{",
+				"start": "1747044000",
+				"end":   "1747044060",
+				"step":  "30s",
+			},
+			wantSub: "",
+		},
+		{
+			name: "non_metric_query",
+			params: map[string]string{
+				// Bare spanset with no metrics pipeline — lowers to a
+				// Filter(Scan), not a MetricsAggregate.
+				"q":     `{ resource.service.name = "frontend" }`,
+				"start": "1747044000",
+				"end":   "1747044060",
+				"step":  "30s",
+			},
+			wantSub: "metrics-pipeline",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			q := &stubQuerier{}
+			srv := newServer(q, "v1.0.0-test")
+			t.Cleanup(srv.Close)
+
+			vals := url.Values{}
+			for k, v := range tc.params {
+				vals.Set(k, v)
+			}
+			u := srv.URL + "/api/metrics/query_range?" + vals.Encode()
+
+			resp, err := http.Get(u)
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode < 400 || resp.StatusCode >= 500 {
+				t.Fatalf("expected 4xx, got status=%d body=%s",
+					resp.StatusCode, readBody(t, resp))
+			}
+			var er tempo.ErrorResponse
+			body := readBody(t, resp)
+			if err := json.Unmarshal([]byte(body), &er); err != nil {
+				t.Fatalf("decode: %v body=%s", err, body)
+			}
+			if !er.Error {
+				t.Errorf("expected error=true, got %+v", er)
+			}
+			if tc.wantSub != "" && !strings.Contains(er.Message, tc.wantSub) {
+				t.Errorf("error message missing %q: got %q", tc.wantSub, er.Message)
+			}
+		})
+	}
+}
+
+// TestMetricsQueryRange_CHFailure — a CH-side error surfaces as 502 +
+// the Tempo error envelope.
+func TestMetricsQueryRange_CHFailure(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{err: errors.New("clickhouse: connection refused")}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	u := metricsQueryRangeURL(srv.URL, "{} | rate()", map[string]string{
+		"start": "1747044000",
+		"end":   "1747044060",
+		"step":  "30s",
+	})
+	resp, err := http.Get(u)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status=%d, want 502", resp.StatusCode)
+	}
+	var er tempo.ErrorResponse
+	if err := json.NewDecoder(resp.Body).Decode(&er); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !er.Error || !strings.Contains(er.Message, "connection refused") {
+		t.Errorf("expected error envelope with upstream message; got %+v", er)
+	}
+}
+
+// TestMetricsQueryRange_StepDurationForms — accepts integer seconds,
+// float seconds, and Go duration strings interchangeably. Matches the
+// PromQL handler's tolerance so Grafana's Tempo datasource (which can
+// send either shape) interoperates.
+func TestMetricsQueryRange_StepDurationForms(t *testing.T) {
+	t.Parallel()
+
+	for _, step := range []string{"30s", "0.5m", "30", "1m"} {
+		step := step
+		t.Run(fmt.Sprintf("step=%s", step), func(t *testing.T) {
+			t.Parallel()
+			q := &stubQuerier{samples: []chclient.Sample{{
+				Labels:    map[string]string{},
+				Timestamp: time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC),
+				Value:     1.0,
+			}}}
+			srv := newServer(q, "v1.0.0-test")
+			t.Cleanup(srv.Close)
+			u := metricsQueryRangeURL(srv.URL, "{} | rate()", map[string]string{
+				"start": "1747044000",
+				"end":   "1747044060",
+				"step":  step,
+			})
+			resp, err := http.Get(u)
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Thin HTTP wrapper over the matrix-shape `RangeWindow{Input: MetricsAggregate}` lowering that #160 added. Stacked on top of #160 — once that merges this rebases cleanly onto `main`.

- New file `internal/api/tempo/metrics_query_range.go` mounting `GET /api/metrics/query_range` and the response envelope types (`MetricsQueryRangeResponse` / `MetricsSeries` / `MetricsLabel` / `MetricsSample`).
- Pipeline: parse `q` via `traceql.Parse`, lower via `traceql_lower.Lower`, expect `MetricsAggregate` (or `Filter(MetricsAggregate)`), wrap with `chplan.RangeWindow{Range: step, Step: step, Start: start, End: end, TimestampColumn: schema.TimestampColumn}` — per-bucket = per-step matches Tempo's reference TraceQL metrics semantics — then a Sample-shape `Project` so `chclient.Sample` decoding still works (`Attributes = map('<label>', toString(<g-alias>), ...)`, `TimeUnix = anchor_ts`, `Value = Value`).
- `toMetricsSeries` pivots the flat row stream into Tempo's `{series:[{labels:[{key,value}], samples:[{timestampMs,value}]}]}` envelope, one series per unique label set, samples sorted ascending by timestamp.

## Wrapping note

Step→Range follows Tempo's `count_over_time` per-step semantics (each bucket covers exactly its own step width). The same handler thus serves rate / count_over_time / *_over_time / quantile_over_time without per-op branching at the wrap layer — the per-bucket normalisation lives in `internal/chsql/range_window.go::emitRangeWindowMetrics` (from #160).

## Test plan

Handler-level coverage in `internal/api/tempo/metrics_query_range_test.go`:

- [x] Single series, no group-by — three out-of-order rows in, three samples out, sorted ascending. Asserts the SQL went through the matrix path (`arrayJoin` + `anchor_ts` substrings).
- [x] Multi-series with `by (resource.service.name)` — two distinct series, label key matches the TraceQL by(...) attribute name.
- [x] Empty CH result — response is `{series: []}` (not `null`).
- [x] 4xx surface: missing `q` / `start` / `end` / `step`; malformed step; zero step; malformed time; `end < start`; parse error; non-metric query (clear "not a metrics-pipeline expression" message).
- [x] CH backend failure → 502 + Tempo error envelope.
- [x] Step accepts `30s` / `0.5m` / `30` (plain int seconds) / `1m`.

TXTAR fixtures for the matrix shape live in `test/spec/chsql/range_window_metrics_*.txtar` already (from #160); the handler is end-to-end exercised by the table tests above, so no new TraceQL TXTAR is added here.

## References

- #160 — `MetricsAggregate` IR + `RangeWindow` over metric-shape input (precursor; this PR stacks on top of it).
- #153 — TraceQL metrics-pipeline lowering.
- #123 — `/api/search/recent` (parse / lower / SQL / reshape precedent).
- #150 — `parseTempoStartEnd` helper reused here.