### PR TITLE
chore(repo): drop empty pkg/ — cerberus is a service, not a library

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,7 +13,7 @@ This document is the public-facing narrative for the path to `v1.0.0`. Status by
 | **v1.0.0-RC5** | 12-factor compatibility + scale-out polish                                            | `/readyz` pings CH, admission control, HPA recipe, dev `docker-compose.yml`, schema overrides     |
 | **v1.0.0-RC6** | Type-safe SQL via custom `internal/chsql.Builder` (R6.0 evaluation → R6.1–R6.10 port) | No `fmt.Sprintf`-on-SQL anywhere; typed builder with CH-specific helpers; lint enforcement        |
 | **v1.0.0-RC7** | `internal/engine/` ExecutionEngine framework (R7.0 evaluation → R7.1–R7.8 port)       | One pipeline owner; handlers under ~150 LoC each; shared format + httperr helpers                 |
-| **v1.0.0**     | Tag the last green RC                                                                 | All RCs stable; HTTP wire protocols (Prom / Loki / Tempo) are the public surface — no Go `pkg/` API |
+| **v1.0.0**     | Tag the last green RC                                                                 | All RCs stable; HTTP wire protocols are the public surface, not a Go API                          |
 
 The existing **3-rule optimizer** (filter-fusion, constant-fold, projection-pushdown) ships unchanged through RC1 and RC2. **No new optimizer work happens before RC3** — its full backlog lives in [`docs/optimizer-research.md`](optimizer-research.md).
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,7 +13,7 @@ This document is the public-facing narrative for the path to `v1.0.0`. Status by
 | **v1.0.0-RC5** | 12-factor compatibility + scale-out polish                                            | `/readyz` pings CH, admission control, HPA recipe, dev `docker-compose.yml`, schema overrides     |
 | **v1.0.0-RC6** | Type-safe SQL via custom `internal/chsql.Builder` (R6.0 evaluation → R6.1–R6.10 port) | No `fmt.Sprintf`-on-SQL anywhere; typed builder with CH-specific helpers; lint enforcement        |
 | **v1.0.0-RC7** | `internal/engine/` ExecutionEngine framework (R7.0 evaluation → R7.1–R7.8 port)       | One pipeline owner; handlers under ~150 LoC each; shared format + httperr helpers                 |
-| **v1.0.0**     | Tag the last green RC                                                                 | All RCs stable; public API frozen in `pkg/`                                                       |
+| **v1.0.0**     | Tag the last green RC                                                                 | All RCs stable; HTTP wire protocols (Prom / Loki / Tempo) are the public surface — no Go `pkg/` API |
 
 The existing **3-rule optimizer** (filter-fusion, constant-fold, projection-pushdown) ships unchanged through RC1 and RC2. **No new optimizer work happens before RC3** — its full backlog lives in [`docs/optimizer-research.md`](optimizer-research.md).
 


### PR DESCRIPTION
## Summary
- Removes the empty `pkg/` directory (only a `.gitkeep`) — cerberus's public surface is the **Prom / Loki / Tempo HTTP wire protocols**, not a Go API.
- Updates `docs/roadmap.md`'s v1.0.0 row to remove the misleading "public API frozen in `pkg/`" exit criterion.

## Why
Scaffolded `pkg/` was a remnant from project-template defaults. A service that exists to terminate HTTP from Grafana shouldn't advertise a Go-import surface — that would mean other Go projects could embed cerberus as a library, which isn't a use case anyone has and which would constrain refactoring across `internal/` for no benefit.

## Test plan
- [ ] CI `check` + `lint` pass (no code touched; only docs + filesystem).