### PR TITLE
feat(cmd): CERBERUS_AUTO_CREATE_SCHEMA env-gated startup hook (RC2 schema D)

### DIFF
--- a/cmd/cerberus/auto_create_integration_test.go
+++ b/cmd/cerberus/auto_create_integration_test.go
@@ -1,0 +1,134 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	tcclickhouse "github.com/testcontainers/testcontainers-go/modules/clickhouse"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/schema/ddl"
+)
+
+// TestAutoCreateSchema_StartupWiring exercises the exact wiring main.go
+// uses when CERBERUS_AUTO_CREATE_SCHEMA=true: dial ClickHouse via
+// chclient.New, pull the underlying driver.Conn via Client.Conn(), and
+// hand it to ddl.ApplyWithConfig together with the configured database
+// name. After the call the upstream OTel exporter table set must exist.
+//
+// Gated by the `integration` build tag — needs Docker. Regular `just
+// test` skips it; CI's schema-ddl-test recipe (or its successor) picks it
+// up via `go test -tags=integration ./...`.
+func TestAutoCreateSchema_StartupWiring(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	container, err := tcclickhouse.Run(ctx,
+		"clickhouse/clickhouse-server:24.8-alpine",
+		tcclickhouse.WithUsername("cerberus"),
+		tcclickhouse.WithPassword("cerberus"),
+		tcclickhouse.WithDatabase("otel"),
+	)
+	if err != nil {
+		t.Fatalf("start clickhouse: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = container.Terminate(context.Background())
+	})
+
+	host, err := container.Host(ctx)
+	if err != nil {
+		t.Fatalf("host: %v", err)
+	}
+	port, err := container.MappedPort(ctx, "9000/tcp")
+	if err != nil {
+		t.Fatalf("port: %v", err)
+	}
+
+	client, err := chclient.New(ctx, chclient.Config{
+		Addr:        fmt.Sprintf("%s:%s", host, port.Port()),
+		Database:    "otel",
+		Username:    "cerberus",
+		Password:    "cerberus",
+		DialTimeout: 10 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("chclient.New: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = client.Close()
+	})
+
+	// This mirrors the exact call sequence main.go uses when the env
+	// flag is true.
+	applyCfg := ddl.Config{Database: "otel"}
+	if err := ddl.ApplyWithConfig(ctx, client.Conn(), applyCfg, ddl.All); err != nil {
+		t.Fatalf("ddl.ApplyWithConfig: %v", err)
+	}
+
+	got := listTables(ctx, t, client, "otel")
+	want := []string{
+		"otel_logs",
+		"otel_metrics_exp_histogram",
+		"otel_metrics_gauge",
+		"otel_metrics_histogram",
+		"otel_metrics_sum",
+		"otel_metrics_summary",
+		"otel_traces",
+		"otel_traces_trace_id_ts",
+		"otel_traces_trace_id_ts_mv",
+	}
+	if !equalStrings(got, want) {
+		t.Errorf("tables after auto-create:\n got: %v\nwant: %v", got, want)
+	}
+
+	// Re-run to confirm idempotency from the cerberus startup angle —
+	// a process restart against an already-populated database must not
+	// error out.
+	if err := ddl.ApplyWithConfig(ctx, client.Conn(), applyCfg, ddl.All); err != nil {
+		t.Fatalf("ddl.ApplyWithConfig (rerun): %v", err)
+	}
+}
+
+// listTables reads the configured database's table list via the same
+// chclient pool the startup hook uses — proves Client.Conn() exposes a
+// usable driver.Conn.
+func listTables(ctx context.Context, t *testing.T, client *chclient.Client, database string) []string {
+	t.Helper()
+	rows, err := client.Conn().Query(ctx,
+		fmt.Sprintf("SELECT name FROM system.tables WHERE database = '%s' ORDER BY name", database))
+	if err != nil {
+		t.Fatalf("query tables: %v", err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var n string
+		if err := rows.Scan(&n); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		out = append(out, n)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows.Err: %v", err)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/config"
 	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/schema/ddl"
 )
 
 // Version is set at build time by goreleaser.
@@ -55,6 +56,18 @@ func run(logger *slog.Logger) error {
 	defer func() {
 		_ = client.Close()
 	}()
+
+	if cfg.AutoCreateSchema {
+		logger.Info("auto-creating OTel ClickHouse schema",
+			"database", cfg.ClickHouse.Database,
+			"signals", "metrics,logs,traces",
+		)
+		applyCfg := ddl.Config{Database: cfg.ClickHouse.Database}
+		if err := ddl.ApplyWithConfig(ctx, client.Conn(), applyCfg, ddl.All); err != nil {
+			return fmt.Errorf("auto-create schema: %w", err)
+		}
+		logger.Info("OTel ClickHouse schema ready")
+	}
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/chclient/client.go
+++ b/internal/chclient/client.go
@@ -54,6 +54,16 @@ func New(ctx context.Context, cfg Config) (*Client, error) {
 	return &Client{conn: conn}, nil
 }
 
+// Conn returns the underlying clickhouse-go/v2 driver connection. It is
+// exposed so packages that need the raw driver — notably
+// internal/schema/ddl, which calls driver.Conn.Exec on the upstream OTel
+// exporter DDL templates — can share the same pool the API layer uses,
+// instead of opening a second connection. Callers should treat the
+// returned connection as read-only (do not close it; rely on Client.Close).
+func (c *Client) Conn() driver.Conn {
+	return c.conn
+}
+
 // Close releases all pooled connections.
 func (c *Client) Close() error {
 	if c.conn == nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,8 @@ package config
 import (
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/tsouza/cerberus/internal/chclient"
@@ -17,21 +19,35 @@ type Config struct {
 	HTTPAddr   string
 	ClickHouse chclient.Config
 	Schema     schema.Metrics
+
+	// AutoCreateSchema, when true, instructs cerberus to run the OTel
+	// ClickHouse Exporter DDL (via internal/schema/ddl) against the
+	// configured ClickHouse connection at startup, before HTTP serving
+	// begins. Default is false — production deploys stay explicit and
+	// keep the operator-runs-DDL contract. The DDL itself is idempotent
+	// (every statement carries CREATE TABLE IF NOT EXISTS) so enabling
+	// the flag on an already-populated ClickHouse is a no-op.
+	AutoCreateSchema bool
 }
 
 // FromEnv reads configuration from environment variables, falling back to
 // reasonable defaults for local development.
 //
-//	CERBERUS_HTTP_ADDR        default ":8080"
-//	CERBERUS_CH_ADDR          default "localhost:9000"
-//	CERBERUS_CH_DATABASE      default "otel"
-//	CERBERUS_CH_USERNAME      default "default"
-//	CERBERUS_CH_PASSWORD      default ""
-//	CERBERUS_CH_DIAL_TIMEOUT  default "5s"
+//	CERBERUS_HTTP_ADDR             default ":8080"
+//	CERBERUS_CH_ADDR               default "localhost:9000"
+//	CERBERUS_CH_DATABASE           default "otel"
+//	CERBERUS_CH_USERNAME           default "default"
+//	CERBERUS_CH_PASSWORD           default ""
+//	CERBERUS_CH_DIAL_TIMEOUT       default "5s"
+//	CERBERUS_AUTO_CREATE_SCHEMA    default "false"
 func FromEnv() (Config, error) {
 	dial, err := time.ParseDuration(envDefault("CERBERUS_CH_DIAL_TIMEOUT", "5s"))
 	if err != nil {
 		return Config{}, fmt.Errorf("CERBERUS_CH_DIAL_TIMEOUT: %w", err)
+	}
+	autoCreate, err := envBool("CERBERUS_AUTO_CREATE_SCHEMA", false)
+	if err != nil {
+		return Config{}, fmt.Errorf("CERBERUS_AUTO_CREATE_SCHEMA: %w", err)
 	}
 	return Config{
 		HTTPAddr: envDefault("CERBERUS_HTTP_ADDR", ":8080"),
@@ -42,7 +58,8 @@ func FromEnv() (Config, error) {
 			Password:    envDefault("CERBERUS_CH_PASSWORD", ""),
 			DialTimeout: dial,
 		},
-		Schema: schema.DefaultOTelMetrics(),
+		Schema:           schema.DefaultOTelMetrics(),
+		AutoCreateSchema: autoCreate,
 	}, nil
 }
 
@@ -51,4 +68,20 @@ func envDefault(key, def string) string {
 		return v
 	}
 	return def
+}
+
+// envBool parses a boolean env var. Accepts the standard strconv.ParseBool
+// vocabulary: "1"/"0", "t"/"f", "true"/"false", "TRUE"/"FALSE",
+// case-insensitive. An unset or empty value returns def. Anything else is
+// rejected with an error so misconfiguration fails fast at startup.
+func envBool(key string, def bool) (bool, error) {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return def, nil
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return false, fmt.Errorf("invalid boolean %q: %w", v, err)
+	}
+	return b, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,73 @@
+package config
+
+import (
+	"testing"
+)
+
+// TestFromEnv_AutoCreateSchema_Default confirms the new flag defaults to
+// false when CERBERUS_AUTO_CREATE_SCHEMA is unset — production deploys
+// keep the operator-runs-DDL contract.
+func TestFromEnv_AutoCreateSchema_Default(t *testing.T) {
+	t.Setenv("CERBERUS_AUTO_CREATE_SCHEMA", "")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if cfg.AutoCreateSchema {
+		t.Errorf("AutoCreateSchema = true; want false (default)")
+	}
+}
+
+// TestFromEnv_AutoCreateSchema_Parsing covers the strconv.ParseBool
+// vocabulary cerberus accepts for the flag — true/false/1/0/etc.
+func TestFromEnv_AutoCreateSchema_Parsing(t *testing.T) {
+	cases := []struct {
+		val  string
+		want bool
+	}{
+		{"true", true},
+		{"TRUE", true},
+		{"True", true},
+		{"1", true},
+		{"t", true},
+		{"false", false},
+		{"FALSE", false},
+		{"0", false},
+		{"f", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.val, func(t *testing.T) {
+			t.Setenv("CERBERUS_AUTO_CREATE_SCHEMA", tc.val)
+			cfg, err := FromEnv()
+			if err != nil {
+				t.Fatalf("FromEnv: %v", err)
+			}
+			if cfg.AutoCreateSchema != tc.want {
+				t.Errorf("AutoCreateSchema = %v; want %v", cfg.AutoCreateSchema, tc.want)
+			}
+		})
+	}
+}
+
+// TestFromEnv_AutoCreateSchema_Invalid confirms a bad boolean string
+// surfaces as a startup error rather than silently defaulting — fail-fast
+// on misconfiguration.
+func TestFromEnv_AutoCreateSchema_Invalid(t *testing.T) {
+	t.Setenv("CERBERUS_AUTO_CREATE_SCHEMA", "yes-please")
+	if _, err := FromEnv(); err == nil {
+		t.Fatal("FromEnv: want error for invalid bool, got nil")
+	}
+}
+
+// TestFromEnv_AutoCreateSchema_Whitespace confirms surrounding whitespace
+// is trimmed before parsing (operators often paste values with newlines).
+func TestFromEnv_AutoCreateSchema_Whitespace(t *testing.T) {
+	t.Setenv("CERBERUS_AUTO_CREATE_SCHEMA", "  true  ")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if !cfg.AutoCreateSchema {
+		t.Errorf("AutoCreateSchema = false; want true (trimmed)")
+	}
+}


### PR DESCRIPTION
## Summary

PR D of the OTel-CH schema source-of-truth sequence (plan: `.claude/plans/can-you-tell-me-merry-thunder.md`). Wires an env-gated startup hook so cerberus can optionally apply the upstream OTel ClickHouse Exporter DDL itself, rather than requiring the operator to seed schema out-of-band.

When `CERBERUS_AUTO_CREATE_SCHEMA=true`:

- After the ClickHouse connection is dialed by `chclient.New` and before HTTP serving begins, `ddl.ApplyWithConfig(ctx, client.Conn(), {Database: cfg.ClickHouse.Database}, ddl.All)` runs.
- An `Apply` failure surfaces as a startup error (`auto-create schema: ...`); cerberus never serves a half-initialised schema.
- Default is `false`, preserving the operator-runs-DDL contract for production deploys.

## Env var

| Name | Default | Accepts |
|---|---|---|
| `CERBERUS_AUTO_CREATE_SCHEMA` | `false` | `strconv.ParseBool` vocabulary (`true`/`false`/`1`/`0`/`t`/`f`/`TRUE`/...), whitespace-trimmed; invalid values fail fast at startup |

## Idempotency

All upstream templates carry `CREATE TABLE IF NOT EXISTS`, verified by `TestApply_Idempotent` in `internal/schema/ddl/ddl_integration_test.go` (PR C). The new integration test in `cmd/cerberus/auto_create_integration_test.go` also re-runs `Apply` to confirm the startup path is restart-safe.

## Sequencing

- **Depends on #161** (`internal/schema/ddl/` package on main) — already merged.
- Does NOT depend on #158 directly (consumes table names from upstream defaults, not `schema.Metrics`).
- Unblocks PR E (`refactor/e2e-seed-via-ddl-package`) and PR F (compatibility seed migration); both can land in parallel with this.

## Files

- `internal/config/config.go` — adds `Config.AutoCreateSchema bool` + `envBool` parser.
- `internal/config/config_test.go` — covers default, ParseBool vocabulary, whitespace, invalid-value-fails-fast.
- `cmd/cerberus/main.go` — calls `ddl.ApplyWithConfig` between `chclient.New` and HTTP listener startup when the flag is true.
- `cmd/cerberus/auto_create_integration_test.go` — `integration`-tagged test that spins a real ClickHouse via testcontainers, runs the exact startup wiring, and asserts all 9 upstream tables exist (plus a re-run idempotency check).
- `internal/chclient/client.go` — adds `Client.Conn() driver.Conn` accessor so `ddl.Apply` can share the existing pool instead of opening a second connection.

## Test plan

- [ ] CI `check` + `lint` pass.
- [ ] `just schema-ddl-test` continues to pass (PR C's integration suite untouched).
- [ ] Manual: `CERBERUS_AUTO_CREATE_SCHEMA=true cerberus serve` against an empty ClickHouse creates all 9 tables; with the flag unset behaviour is identical to today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)