### PR TITLE
feat(traceql): link traversal + span event queries (RC2)

### DIFF
--- a/internal/chplan/nested_array_exists.go
+++ b/internal/chplan/nested_array_exists.go
@@ -1,0 +1,44 @@
+package chplan
+
+// NestedArrayExists is a predicate over a ClickHouse `Nested` column's
+// parallel-array layout. TraceQL link / event spanset filters
+// (`{ link.span_id = "abc" }`, `{ event.exception.type = "x" }`) lower to
+// this shape: the OTel-CH `Links` / `Events` Nested columns expose each
+// sub-field as an Array, and we filter by checking whether *any* row in
+// the nested array's attribute map matches.
+//
+// Column is the Nested parent column name ("Links" or "Events" in the
+// default OTel-CH schema). SubField is the sub-column under it (always
+// "Attributes" today; future expansions may target "Name" for the
+// event-name intrinsic). Key is the attribute key looked up inside each
+// row's map; Op + Value form the comparison.
+//
+// The emitter renders this as:
+//
+//	arrayExists(x -> x[?] <op> ?, `<Column>`.`<SubField>`)
+//
+// Both Key and Value bind as positional `?` parameters so the values are
+// driver-parameterised, not splice into the SQL.
+type NestedArrayExists struct {
+	Column   string
+	SubField string
+	Key      string
+	Op       BinaryOp
+	Value    Expr
+}
+
+func (*NestedArrayExists) exprNode() {}
+
+func (n *NestedArrayExists) Equal(other Expr) bool {
+	o, ok := other.(*NestedArrayExists)
+	if !ok {
+		return false
+	}
+	if n.Column != o.Column || n.SubField != o.SubField || n.Key != o.Key || n.Op != o.Op {
+		return false
+	}
+	if n.Value == nil || o.Value == nil {
+		return n.Value == o.Value
+	}
+	return n.Value.Equal(o.Value)
+}

--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -258,9 +258,32 @@ func (b *Builder) Expr(x chplan.Expr) error {
 		return b.exprLineContent(v)
 	case *chplan.FieldAccess:
 		return b.exprFieldAccess(v)
+	case *chplan.NestedArrayExists:
+		return b.exprNestedArrayExists(v)
 	default:
 		return fmt.Errorf("%w: expr %T", ErrUnsupported, x)
 	}
+}
+
+// exprNestedArrayExists renders
+//
+//	arrayExists(x -> x[?] <op> ?, `<Column>`.`<SubField>`)
+//
+// against the public Builder helpers. Mirrors the legacy
+// emitter.emitNestedArrayExists so both paths produce byte-identical SQL.
+func (b *Builder) exprNestedArrayExists(n *chplan.NestedArrayExists) error {
+	b.sb.WriteString("arrayExists(x -> x[")
+	b.Arg(n.Key)
+	b.sb.WriteString("] ")
+	b.sb.WriteString(string(n.Op))
+	b.sb.WriteByte(' ')
+	if err := b.Expr(n.Value); err != nil {
+		return err
+	}
+	b.sb.WriteString(", ")
+	b.QualIdent(n.Column, n.SubField)
+	b.sb.WriteByte(')')
+	return nil
 }
 
 func (b *Builder) exprBinary(bx *chplan.Binary) error {

--- a/internal/chsql/builder_test.go
+++ b/internal/chsql/builder_test.go
@@ -567,6 +567,33 @@ func TestBuilder_Expr(t *testing.T) {
 			wantSQL: "match(`ServiceName`, ?)",
 			wantArg: []any{"^api-.*"},
 		},
+		{
+			// TraceQL link / event spanset filters lower to this shape
+			// (see chplan.NestedArrayExists). Key + Value bind through
+			// Arg, so the rendered SQL carries two parameter slots.
+			name: "nested_array_exists_eq",
+			expr: &chplan.NestedArrayExists{
+				Column:   "Links",
+				SubField: "Attributes",
+				Key:      "span_id",
+				Op:       chplan.OpEq,
+				Value:    &chplan.LitString{V: "abc"},
+			},
+			wantSQL: "arrayExists(x -> x[?] = ?, `Links`.`Attributes`)",
+			wantArg: []any{"span_id", "abc"},
+		},
+		{
+			name: "nested_array_exists_ne",
+			expr: &chplan.NestedArrayExists{
+				Column:   "Events",
+				SubField: "Attributes",
+				Key:      "severity",
+				Op:       chplan.OpNe,
+				Value:    &chplan.LitString{V: "info"},
+			},
+			wantSQL: "arrayExists(x -> x[?] != ?, `Events`.`Attributes`)",
+			wantArg: []any{"severity", "info"},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/chsql/emit_expr.go
+++ b/internal/chsql/emit_expr.go
@@ -35,9 +35,37 @@ func (e *emitter) emitExpr(x chplan.Expr) error {
 		return e.emitLineContent(v)
 	case *chplan.FieldAccess:
 		return e.emitFieldAccess(v)
+	case *chplan.NestedArrayExists:
+		return e.emitNestedArrayExists(v)
 	default:
 		return fmt.Errorf("%w: expr %T", ErrUnsupported, x)
 	}
+}
+
+// emitNestedArrayExists renders
+//
+//	arrayExists(x -> x[?] <op> ?, `<Column>`.`<SubField>`)
+//
+// for TraceQL link / event attribute filters against the OTel-CH Nested
+// columns. The key + value bind through bindArg so both are driver
+// parameters, not spliced into the SQL.
+func (e *emitter) emitNestedArrayExists(n *chplan.NestedArrayExists) error {
+	e.b.WriteString("arrayExists(x -> x[")
+	if err := e.bindArg(n.Key); err != nil {
+		return err
+	}
+	e.b.WriteString("] ")
+	e.b.WriteString(string(n.Op))
+	e.b.WriteByte(' ')
+	if err := e.emitExpr(n.Value); err != nil {
+		return err
+	}
+	e.b.WriteString(", ")
+	writeIdent(&e.b, n.Column)
+	e.b.WriteByte('.')
+	writeIdent(&e.b, n.SubField)
+	e.b.WriteByte(')')
+	return nil
 }
 
 func (e *emitter) emitFieldAccess(f *chplan.FieldAccess) error {

--- a/internal/traceql/link_event_test.go
+++ b/internal/traceql/link_event_test.go
@@ -1,0 +1,218 @@
+package traceql_test
+
+import (
+	"strings"
+	"testing"
+
+	tempo "github.com/grafana/tempo/pkg/traceql"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/traceql"
+)
+
+// TestLowerLinkAndEvent pins the lowering of TraceQL link-traversal and
+// span-event spanset filters onto chplan.NestedArrayExists. The TXTAR
+// fixtures under test/spec/traceql/ (link_*.txtar, event_*.txtar) cover
+// the same shapes end-to-end; this file asserts the IR + SQL directly
+// so failures point at the structural mistake rather than a fixture
+// diff.
+func TestLowerLinkAndEvent(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelTraces()
+
+	cases := []struct {
+		name       string
+		query      string
+		wantCol    string
+		wantKey    string
+		wantOp     chplan.BinaryOp
+		wantValStr string
+		wantSQL    string
+	}{
+		{
+			name:       "link_span_id",
+			query:      `{ link.span_id = "abc" }`,
+			wantCol:    "Links",
+			wantKey:    "span_id",
+			wantOp:     chplan.OpEq,
+			wantValStr: "abc",
+			wantSQL:    "SELECT * FROM (SELECT * FROM `otel_traces`) WHERE arrayExists(x -> x[?] = ?, `Links`.`Attributes`)",
+		},
+		{
+			name:       "link_trace_id",
+			query:      `{ link.trace_id = "deadbeef" }`,
+			wantCol:    "Links",
+			wantKey:    "trace_id",
+			wantOp:     chplan.OpEq,
+			wantValStr: "deadbeef",
+			wantSQL:    "SELECT * FROM (SELECT * FROM `otel_traces`) WHERE arrayExists(x -> x[?] = ?, `Links`.`Attributes`)",
+		},
+		{
+			name:       "link_attribute",
+			query:      `{ link.environment = "prod" }`,
+			wantCol:    "Links",
+			wantKey:    "environment",
+			wantOp:     chplan.OpEq,
+			wantValStr: "prod",
+			wantSQL:    "SELECT * FROM (SELECT * FROM `otel_traces`) WHERE arrayExists(x -> x[?] = ?, `Links`.`Attributes`)",
+		},
+		{
+			name:       "event_name",
+			query:      `{ event.name = "exception" }`,
+			wantCol:    "Events",
+			wantKey:    "name",
+			wantOp:     chplan.OpEq,
+			wantValStr: "exception",
+			wantSQL:    "SELECT * FROM (SELECT * FROM `otel_traces`) WHERE arrayExists(x -> x[?] = ?, `Events`.`Attributes`)",
+		},
+		{
+			name:       "event_dotted_attribute",
+			query:      `{ event.exception.type = "ConnectionError" }`,
+			wantCol:    "Events",
+			wantKey:    "exception.type",
+			wantOp:     chplan.OpEq,
+			wantValStr: "ConnectionError",
+			wantSQL:    "SELECT * FROM (SELECT * FROM `otel_traces`) WHERE arrayExists(x -> x[?] = ?, `Events`.`Attributes`)",
+		},
+		{
+			name:       "event_attribute_inequality",
+			query:      `{ event.severity != "info" }`,
+			wantCol:    "Events",
+			wantKey:    "severity",
+			wantOp:     chplan.OpNe,
+			wantValStr: "info",
+			wantSQL:    "SELECT * FROM (SELECT * FROM `otel_traces`) WHERE arrayExists(x -> x[?] != ?, `Events`.`Attributes`)",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			expr, err := tempo.Parse(tc.query)
+			if err != nil {
+				t.Fatalf("Parse(%q): %v", tc.query, err)
+			}
+			plan, err := traceql.Lower(expr, s)
+			if err != nil {
+				t.Fatalf("Lower(%q): %v", tc.query, err)
+			}
+			pred := filterPredicate(t, plan)
+			n, ok := pred.(*chplan.NestedArrayExists)
+			if !ok {
+				t.Fatalf("predicate type = %T, want *chplan.NestedArrayExists", pred)
+			}
+			if n.Column != tc.wantCol {
+				t.Errorf("Column = %q, want %q", n.Column, tc.wantCol)
+			}
+			if n.SubField != "Attributes" {
+				t.Errorf("SubField = %q, want %q", n.SubField, "Attributes")
+			}
+			if n.Key != tc.wantKey {
+				t.Errorf("Key = %q, want %q", n.Key, tc.wantKey)
+			}
+			if n.Op != tc.wantOp {
+				t.Errorf("Op = %q, want %q", n.Op, tc.wantOp)
+			}
+			gotVal, ok := n.Value.(*chplan.LitString)
+			if !ok {
+				t.Fatalf("Value type = %T, want *chplan.LitString", n.Value)
+			}
+			if gotVal.V != tc.wantValStr {
+				t.Errorf("Value = %q, want %q", gotVal.V, tc.wantValStr)
+			}
+
+			sqlStr, args, err := chsql.Emit(plan)
+			if err != nil {
+				t.Fatalf("Emit: %v", err)
+			}
+			if sqlStr != tc.wantSQL {
+				t.Errorf("sql mismatch\n got: %s\nwant: %s", sqlStr, tc.wantSQL)
+			}
+			if len(args) != 2 {
+				t.Fatalf("args len = %d, want 2", len(args))
+			}
+			if got, _ := args[0].(string); got != tc.wantKey {
+				t.Errorf("args[0] = %v, want %q", args[0], tc.wantKey)
+			}
+			if got, _ := args[1].(string); got != tc.wantValStr {
+				t.Errorf("args[1] = %v, want %q", args[1], tc.wantValStr)
+			}
+		})
+	}
+}
+
+// TestLowerLinkEventScalarUseRejected pins the guard against using a
+// link- / event-scoped attribute outside a comparison. Today the only
+// supported shapes are equality / inequality / regex filters; reaching
+// the scalar path silently would dereference SpanAttributes (wrong
+// column) so the lowering errors instead.
+func TestLowerLinkEventScalarUseRejected(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelTraces()
+
+	// Compose the scalar-use shape directly via the AST: a SpansetFilter
+	// whose expression is a bare link-scoped Attribute. Going through
+	// the parser is unreliable here — TraceQL's grammar may or may not
+	// accept `{ link.foo }` depending on its bool-coercion rules, and
+	// the guard we want to pin is about the lowering, not the parser.
+	root := &tempo.RootExpr{
+		Pipeline: tempo.Pipeline{
+			Elements: []tempo.PipelineElement{
+				&tempo.SpansetFilter{Expression: tempo.NewScopedAttribute(tempo.AttributeScopeLink, false, "span_id")},
+			},
+		},
+	}
+	_, err := traceql.Lower(root, s)
+	if err == nil {
+		t.Fatal("Lower returned nil error for scalar link.span_id use; want error")
+	}
+	if !strings.Contains(err.Error(), "outside a comparison") {
+		t.Errorf("error message = %q, want it to mention 'outside a comparison'", err.Error())
+	}
+}
+
+// TestLowerNestedArrayExistsEqual exercises the Expr.Equal contract for
+// the new chplan type — defensive coverage against future refactors
+// that re-use Expr.Equal in optimizer rewrites.
+func TestLowerNestedArrayExistsEqual(t *testing.T) {
+	t.Parallel()
+
+	a := &chplan.NestedArrayExists{Column: "Links", SubField: "Attributes", Key: "k", Op: chplan.OpEq, Value: &chplan.LitString{V: "v"}}
+	b := &chplan.NestedArrayExists{Column: "Links", SubField: "Attributes", Key: "k", Op: chplan.OpEq, Value: &chplan.LitString{V: "v"}}
+	if !a.Equal(b) {
+		t.Error("Equal returned false for structurally identical NestedArrayExists")
+	}
+
+	differ := []chplan.Expr{
+		&chplan.NestedArrayExists{Column: "Events", SubField: "Attributes", Key: "k", Op: chplan.OpEq, Value: &chplan.LitString{V: "v"}},
+		&chplan.NestedArrayExists{Column: "Links", SubField: "Other", Key: "k", Op: chplan.OpEq, Value: &chplan.LitString{V: "v"}},
+		&chplan.NestedArrayExists{Column: "Links", SubField: "Attributes", Key: "other", Op: chplan.OpEq, Value: &chplan.LitString{V: "v"}},
+		&chplan.NestedArrayExists{Column: "Links", SubField: "Attributes", Key: "k", Op: chplan.OpNe, Value: &chplan.LitString{V: "v"}},
+		&chplan.NestedArrayExists{Column: "Links", SubField: "Attributes", Key: "k", Op: chplan.OpEq, Value: &chplan.LitString{V: "other"}},
+		&chplan.LitString{V: "v"},
+	}
+	for i, d := range differ {
+		if a.Equal(d) {
+			t.Errorf("case %d: Equal returned true for differing expr %T", i, d)
+		}
+	}
+}
+
+// filterPredicate extracts the predicate of the top-level chplan.Filter
+// (or t.Fatal if the plan isn't shaped as Filter(Scan)). Centralises the
+// type assertions used by every test case in this file.
+func filterPredicate(t *testing.T, plan chplan.Node) chplan.Expr {
+	t.Helper()
+	f, ok := plan.(*chplan.Filter)
+	if !ok {
+		t.Fatalf("plan = %T, want *chplan.Filter", plan)
+	}
+	return f.Predicate
+}
+

--- a/internal/traceql/link_event_test.go
+++ b/internal/traceql/link_event_test.go
@@ -215,4 +215,3 @@ func filterPredicate(t *testing.T, plan chplan.Node) chplan.Expr {
 	}
 	return f.Predicate
 }
-

--- a/internal/traceql/lower.go
+++ b/internal/traceql/lower.go
@@ -274,9 +274,9 @@ func lowerFieldExpr(e traceql.FieldExpression, s schema.Traces) (chplan.Expr, er
 	case *traceql.BinaryOperation:
 		return lowerBinaryOperation(v, s)
 	case *traceql.Attribute:
-		return lowerAttribute(*v, s), nil
+		return lowerAttributeExpr(*v, s)
 	case traceql.Attribute:
-		return lowerAttribute(v, s), nil
+		return lowerAttributeExpr(v, s)
 	case *traceql.Static:
 		return lowerStatic(*v)
 	case traceql.Static:
@@ -285,10 +285,32 @@ func lowerFieldExpr(e traceql.FieldExpression, s schema.Traces) (chplan.Expr, er
 	return nil, fmt.Errorf("traceql: field expression %T is not yet supported", e)
 }
 
+// lowerAttributeExpr wraps lowerAttribute with a guard: link- /
+// event-scoped attributes can only appear inside a comparison
+// (lowerBinaryOperation intercepts them and returns a
+// NestedArrayExists). Reaching this path means the attribute is being
+// used as a scalar value (e.g. `| select(link.span_id)`) which would
+// silently dereference the wrong CH column — error out so the operator
+// can surface the gap rather than ship wrong SQL.
+func lowerAttributeExpr(a traceql.Attribute, s schema.Traces) (chplan.Expr, error) {
+	if a.Scope == traceql.AttributeScopeLink || a.Scope == traceql.AttributeScopeEvent {
+		return nil, fmt.Errorf("traceql: %s.%s used outside a comparison; only equality / inequality / regex filters on link.* and event.* are supported (see RC2 link traversal + span-event queries)", a.Scope, a.Name)
+	}
+	return lowerAttribute(a, s), nil
+}
+
 func lowerBinaryOperation(b *traceql.BinaryOperation, s schema.Traces) (chplan.Expr, error) {
 	op, err := mapBinaryOp(b.Op)
 	if err != nil {
 		return nil, err
+	}
+	// TraceQL link / event spanset filters live on the OTel-CH `Links` /
+	// `Events` Nested columns. Their predicate shape is
+	//   arrayExists(x -> x[<key>] <op> <value>, <Col>.Attributes)
+	// rather than a flat column comparison; capture that as a
+	// NestedArrayExists before generic Binary lowering kicks in.
+	if nested, ok := lowerNestedAttrBinary(b, op, s); ok {
+		return nested, nil
 	}
 	lhs, err := lowerFieldExpr(b.LHS, s)
 	if err != nil {
@@ -299,6 +321,111 @@ func lowerBinaryOperation(b *traceql.BinaryOperation, s schema.Traces) (chplan.E
 		return nil, err
 	}
 	return &chplan.Binary{Op: op, Left: lhs, Right: rhs}, nil
+}
+
+// lowerNestedAttrBinary recognises the
+//   <link|event>.<name> <op> <literal>
+// shape and returns a chplan.NestedArrayExists. The LHS/RHS may be in
+// either order in upstream TraceQL ASTs; we normalise so the attribute
+// reference is always the implicit `x[?]` and the literal is the RHS
+// of the comparison. Returns ok=false when neither side is a link- or
+// event-scoped attribute (the caller falls back to flat Binary lowering).
+func lowerNestedAttrBinary(b *traceql.BinaryOperation, op chplan.BinaryOp, s schema.Traces) (chplan.Expr, bool) {
+	if lhsAttr, ok := nestedScopedAttr(b.LHS); ok {
+		col, key, ok := nestedAttrTarget(lhsAttr, s)
+		if !ok {
+			return nil, false
+		}
+		val, err := lowerFieldExpr(b.RHS, s)
+		if err != nil {
+			return nil, false
+		}
+		return &chplan.NestedArrayExists{
+			Column:   col,
+			SubField: "Attributes",
+			Key:      key,
+			Op:       op,
+			Value:    val,
+		}, true
+	}
+	if rhsAttr, ok := nestedScopedAttr(b.RHS); ok {
+		col, key, ok := nestedAttrTarget(rhsAttr, s)
+		if !ok {
+			return nil, false
+		}
+		val, err := lowerFieldExpr(b.LHS, s)
+		if err != nil {
+			return nil, false
+		}
+		return &chplan.NestedArrayExists{
+			Column:   col,
+			SubField: "Attributes",
+			Key:      key,
+			Op:       flipComparisonOp(op),
+			Value:    val,
+		}, true
+	}
+	return nil, false
+}
+
+// nestedScopedAttr returns the attribute if e is a link- or event-scoped
+// attribute reference (pointer or value form), so callers can branch
+// without re-running the same type-switch twice.
+func nestedScopedAttr(e traceql.FieldExpression) (traceql.Attribute, bool) {
+	switch v := e.(type) {
+	case *traceql.Attribute:
+		if v == nil {
+			return traceql.Attribute{}, false
+		}
+		if v.Scope == traceql.AttributeScopeLink || v.Scope == traceql.AttributeScopeEvent {
+			return *v, true
+		}
+	case traceql.Attribute:
+		if v.Scope == traceql.AttributeScopeLink || v.Scope == traceql.AttributeScopeEvent {
+			return v, true
+		}
+	}
+	return traceql.Attribute{}, false
+}
+
+// nestedAttrTarget maps a link- / event-scoped attribute to the Nested
+// parent column it lives under (LinksColumn or EventsColumn) plus the
+// attribute key to look up inside each row's Attributes map. Returns
+// ok=false when the configured schema has no column for that scope —
+// the caller falls back to the generic lowering and the resulting SQL
+// will error at emit time (better than silently writing the wrong
+// column name).
+func nestedAttrTarget(a traceql.Attribute, s schema.Traces) (col, key string, ok bool) {
+	switch a.Scope {
+	case traceql.AttributeScopeLink:
+		if s.LinksColumn == "" {
+			return "", "", false
+		}
+		return s.LinksColumn, a.Name, true
+	case traceql.AttributeScopeEvent:
+		if s.EventsColumn == "" {
+			return "", "", false
+		}
+		return s.EventsColumn, a.Name, true
+	}
+	return "", "", false
+}
+
+// flipComparisonOp swaps the direction of an asymmetric comparison so
+// `<literal> <op> <attr>` rewrites cleanly to `<attr> <flipped> <literal>`.
+// = / != / AND / OR are symmetric and pass through unchanged.
+func flipComparisonOp(op chplan.BinaryOp) chplan.BinaryOp {
+	switch op {
+	case chplan.OpLt:
+		return chplan.OpGt
+	case chplan.OpLe:
+		return chplan.OpGe
+	case chplan.OpGt:
+		return chplan.OpLt
+	case chplan.OpGe:
+		return chplan.OpLe
+	}
+	return op
 }
 
 // lowerAttribute resolves a TraceQL attribute reference to a chplan

--- a/internal/traceql/lower.go
+++ b/internal/traceql/lower.go
@@ -324,7 +324,9 @@ func lowerBinaryOperation(b *traceql.BinaryOperation, s schema.Traces) (chplan.E
 }
 
 // lowerNestedAttrBinary recognises the
-//   <link|event>.<name> <op> <literal>
+//
+//	<link|event>.<name> <op> <literal>
+//
 // shape and returns a chplan.NestedArrayExists. The LHS/RHS may be in
 // either order in upstream TraceQL ASTs; we normalise so the attribute
 // reference is always the implicit `x[?]` and the literal is the RHS

--- a/test/spec/traceql/event_attribute.txtar
+++ b/test/spec/traceql/event_attribute.txtar
@@ -1,0 +1,7 @@
+-- query.traceql --
+{ event.exception.type = "ConnectionError" }
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE arrayExists(x -> x[?] = ?, `Events`.`Attributes`)
+-- args --
+[0] string = "exception.type"
+[1] string = "ConnectionError"

--- a/test/spec/traceql/event_name.txtar
+++ b/test/spec/traceql/event_name.txtar
@@ -1,0 +1,7 @@
+-- query.traceql --
+{ event.name = "exception" }
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE arrayExists(x -> x[?] = ?, `Events`.`Attributes`)
+-- args --
+[0] string = "name"
+[1] string = "exception"

--- a/test/spec/traceql/link_attribute.txtar
+++ b/test/spec/traceql/link_attribute.txtar
@@ -1,0 +1,7 @@
+-- query.traceql --
+{ link.environment = "prod" }
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE arrayExists(x -> x[?] = ?, `Links`.`Attributes`)
+-- args --
+[0] string = "environment"
+[1] string = "prod"

--- a/test/spec/traceql/link_span_id.txtar
+++ b/test/spec/traceql/link_span_id.txtar
@@ -1,0 +1,7 @@
+-- query.traceql --
+{ link.span_id = "abc" }
+-- sql --
+SELECT * FROM (SELECT * FROM `otel_traces`) WHERE arrayExists(x -> x[?] = ?, `Links`.`Attributes`)
+-- args --
+[0] string = "span_id"
+[1] string = "abc"


### PR DESCRIPTION
## Summary

Lower TraceQL link-traversal and span-event spanset filters onto a new `chplan.NestedArrayExists` expression. The OTel-CH `Links` / `Events` `Nested` columns expose their attributes as parallel arrays, so the cleanest CH predicate is `arrayExists(x -> x[<key>] <op> <value>, <Col>.Attributes)`.

Three of the RC2 item *TraceQL histogram_over_time + link traversal + span-events* are addressed by this PR; `histogram_over_time` is deferred (see below).

## Features shipped

- **Link traversal** — `{ link.span_id = "abc" }`, `{ link.trace_id = "deadbeef" }`, `{ link.environment = "prod" }` and similar attribute matchers now lower without falling back to `SpanAttributes[...]`.
- **Span events** — `{ event.name = "exception" }`, `{ event.exception.type = "ConnectionError" }`, etc. lower the same way against the `Events` Nested column.
- **Scalar-use guard** — using a link- / event-scoped attribute outside a comparison (`| select(link.span_id)`) returns a clear lowering error instead of silently dereferencing `SpanAttributes`.

## Approach

- `chplan.NestedArrayExists{Column, SubField, Key, Op, Value}` is a new `Expr`. `Column` is the parent Nested column (`Links` / `Events`), `SubField` is the sub-array (`Attributes`), `Key` is the attribute key, and `Op` + `Value` form the comparison. Both `Key` and `Value` bind through positional `?` arguments so the driver parameterises them.
- `internal/chsql` adds an `emitNestedArrayExists` in both the legacy emitter and the public `Builder.Expr` path, producing byte-identical SQL.
- `internal/traceql.lowerBinaryOperation` detects when either operand is a link- or event-scoped `Attribute` and routes through `lowerNestedAttrBinary`. The literal can sit on either side of the operator — `flipComparisonOp` normalises the asymmetric comparators (`<`, `<=`, `>`, `>=`).
- Per the upstream Tempo grammar, `event.name` parses as `AttributeScopeEvent` + name `"name"` (it is *not* the `event:name` intrinsic). All `event.X` and `link.X` shapes therefore map uniformly to the attribute-bag form, which matches the CH idiom directly.

## Fixture coverage

New TXTAR fixtures under `test/spec/traceql/`:

- `link_span_id.txtar` — `{ link.span_id = "abc" }`
- `link_attribute.txtar` — `{ link.environment = "prod" }`
- `event_name.txtar` — `{ event.name = "exception" }`
- `event_attribute.txtar` — `{ event.exception.type = "ConnectionError" }`

New table-driven unit test `internal/traceql/link_event_test.go` covers the lowering IR shape, the SQL output, and the scalar-use guard (`link.span_id` outside a comparison errors out). `internal/chsql/builder_test.go` gains `nested_array_exists_eq` / `nested_array_exists_ne` cases to pin the rendered form.

## Deferred: histogram_over_time

`histogram_over_time` is part of the same RC2 backlog item but is deferred to a follow-up: it requires a new `chplan` histogram node (bucketed accumulator distinct from `RangeWindow`) and the corresponding emitter / fixture coverage. Tracked as RC2 follow-up; the two halves landed by this PR unblock the link / event UX paths in Grafana 11's TraceQL Search panel.

## Test plan

- [ ] `check` — `internal/traceql/link_event_test.go` + new fixtures + `chsql.Builder_Expr` cases pass.
- [ ] `lint` — no `fmt.Sprintf`-on-SQL, no `unsafe` / `reflect` in `internal/traceql/`, no `Builder.WriteSQL("SELECT ")` cosplay.
- [ ] Spot-check `test/spec/traceql/link_*.txtar` + `event_*.txtar` end-to-end through `TestLower`.