### PR TITLE
feat(chclient,api/prom): streaming query_range cursor (R3.12)

### DIFF
--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -24,6 +24,7 @@ import (
 // it makes unit tests possible without a live ClickHouse.
 type Querier interface {
 	Query(ctx context.Context, sql string, args ...any) ([]chclient.Sample, error)
+	QueryCursor(ctx context.Context, sql string, args ...any) (chclient.Cursor, error)
 	QueryStrings(ctx context.Context, sql string, args ...any) ([]string, error)
 	QueryLabelSets(ctx context.Context, sql string, args ...any) ([]map[string]string, error)
 	QueryMetricMeta(ctx context.Context, sql, metricType string, args ...any) ([]chclient.MetricMetaRow, error)
@@ -211,13 +212,20 @@ func (h *Handler) handleQueryRange(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	samples, err := h.executeInstant(r.Context(), q, start, end)
+	cursor, err := h.executeRangeStreaming(r.Context(), q, start, end)
 	if err != nil {
 		h.respondError(w, err)
 		return
 	}
+	defer func() {
+		_ = cursor.Close()
+	}()
 
-	result := toMatrixStepGrid(samples, start, end, step)
+	result, err := matrixFromCursor(cursor, start, end, step)
+	if err != nil {
+		h.respondError(w, &apiError{kind: ErrInternal, err: err, status: http.StatusBadGateway})
+		return
+	}
 	writeJSON(w, http.StatusOK, Response{
 		Status: "success",
 		Data:   &QueryData{ResultType: "matrix", Result: result},
@@ -257,6 +265,46 @@ func scalarMatrix(v float64, start, end time.Time, step time.Duration) []MatrixS
 		values = append(values, scalarPoint(ts, v))
 	}
 	return []MatrixSample{{Metric: map[string]string{}, Values: values}}
+}
+
+// executeRangeStreaming is the streaming counterpart to executeInstant
+// used by /api/v1/query_range. The SQL emission is identical — same
+// lowering, same optimizer pass, same wrapWithSampleProjection — but
+// rather than draining the result into a []chclient.Sample slice it
+// returns a chclient.Cursor so the response builder can pivot rows into
+// the matrix shape one at a time. For a wide-range / fine-step query
+// this is the difference between O(rows) and O(rows-per-series)
+// resident memory.
+func (h *Handler) executeRangeStreaming(
+	ctx context.Context,
+	query string,
+	start, end time.Time,
+) (chclient.Cursor, error) {
+	expr, err := h.parser.ParseExpr(query)
+	if err != nil {
+		return nil, &apiError{kind: ErrBadData, err: err, status: http.StatusBadRequest}
+	}
+	plan, err := promql.LowerAt(expr, h.Schema, start, end)
+	if err != nil {
+		return nil, &apiError{kind: ErrExecution, err: err, status: http.StatusUnprocessableEntity}
+	}
+
+	plan = wrapWithSampleProjection(plan, h.Schema)
+	plan = h.Optimizer.Run(plan)
+
+	sql, args, err := chsql.Emit(plan)
+	if err != nil {
+		return nil, &apiError{kind: ErrInternal, err: err, status: http.StatusInternalServerError}
+	}
+	h.Logger.Debug("cerberus query_range (stream)", "promql", query, "sql", sql, "args", args)
+
+	cursor, err := timeCH(ctx, func() (chclient.Cursor, error) {
+		return h.Client.QueryCursor(ctx, sql, args...)
+	})
+	if err != nil {
+		return nil, &apiError{kind: ErrInternal, err: err, status: http.StatusBadGateway}
+	}
+	return cursor, nil
 }
 
 // executeInstant lowers a PromQL string to chplan, wraps with a Project
@@ -404,6 +452,80 @@ func toVector(samples []chclient.Sample, ts time.Time) []VectorSample {
 		})
 	}
 	return out
+}
+
+// matrixFromCursor is the streaming counterpart to toMatrixStepGrid: it
+// drains the cursor row-by-row instead of consuming a pre-materialised
+// []chclient.Sample slice. Per-series buffers (timestamps + values) live
+// in a map keyed by canonicalKey; once the cursor is fully drained we
+// pivot each buffer onto the step grid using the same latest-at-step
+// semantics toMatrixStepGrid implements.
+//
+// Memory complexity: O(rows) total in the per-series buffers — but with
+// the master []chclient.Sample slice gone, peak resident bytes shrink
+// roughly 2x (no parallel copy) and the gc churn from growing one big
+// slice disappears. The eventual fully-streaming variant (one series at
+// a time, flushed on canonicalKey boundary changes) requires the SQL
+// emission to ORDER BY (series_key, ts) — that lands as a separate
+// follow-up so this PR stays scoped to the API surface change.
+func matrixFromCursor(
+	cursor chclient.Cursor,
+	start, end time.Time,
+	step time.Duration,
+) ([]MatrixSample, error) {
+	type seriesState struct {
+		labels map[string]string
+		rows   []chclient.Sample
+	}
+
+	bySeries := map[string]*seriesState{}
+	for cursor.Next() {
+		s := cursor.Sample()
+		labels := withMetricName(s.Labels, s.MetricName)
+		key := canonicalKey(labels)
+		st, ok := bySeries[key]
+		if !ok {
+			st = &seriesState{labels: labels}
+			bySeries[key] = st
+		}
+		st.rows = append(st.rows, s)
+	}
+	if err := cursor.Err(); err != nil {
+		return nil, err
+	}
+
+	const lookback = 5 * time.Minute
+	out := make([]MatrixSample, 0, len(bySeries))
+	for _, st := range bySeries {
+		// Inline insertion sort by Timestamp ascending — rows are
+		// typically already nearly sorted from CH.
+		for i := 1; i < len(st.rows); i++ {
+			for j := i; j > 0 && st.rows[j-1].Timestamp.After(st.rows[j].Timestamp); j-- {
+				st.rows[j-1], st.rows[j] = st.rows[j], st.rows[j-1]
+			}
+		}
+
+		ms := MatrixSample{Metric: st.labels}
+		row := 0
+		for t := start; !t.After(end); t = t.Add(step) {
+			for row < len(st.rows) && !st.rows[row].Timestamp.After(t) {
+				row++
+			}
+			if row == 0 {
+				continue
+			}
+			latest := st.rows[row-1]
+			if t.Sub(latest.Timestamp) > lookback {
+				continue
+			}
+			stamp := float64(t.UnixMilli()) / 1e3
+			ms.Values = append(ms.Values, Sample{stamp, strconv.FormatFloat(latest.Value, 'f', -1, 64)})
+		}
+		if len(ms.Values) > 0 {
+			out = append(out, ms)
+		}
+	}
+	return out, nil
 }
 
 // toMatrixStepGrid pivots the sample stream into the Prom matrix shape.

--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -248,7 +248,7 @@ func (h *Handler) tryScalarFold(query string) (float64, bool, error) {
 
 // scalarPoint renders the [<unix_seconds_float>, "<value_string>"]
 // pair Prometheus uses for both scalar and matrix sample wire shapes,
-// matching the format toVector / toMatrixStepGrid already use.
+// matching the format toVector + the matrix pivot already use.
 func scalarPoint(ts time.Time, v float64) Sample {
 	return Sample{float64(ts.UnixMilli()) / 1e3, strconv.FormatFloat(v, 'f', -1, 64)}
 }
@@ -454,12 +454,12 @@ func toVector(samples []chclient.Sample, ts time.Time) []VectorSample {
 	return out
 }
 
-// matrixFromCursor is the streaming counterpart to toMatrixStepGrid: it
+// matrixFromCursor is the streaming pivot from the cursor: it
 // drains the cursor row-by-row instead of consuming a pre-materialised
 // []chclient.Sample slice. Per-series buffers (timestamps + values) live
 // in a map keyed by canonicalKey; once the cursor is fully drained we
 // pivot each buffer onto the step grid using the same latest-at-step
-// semantics toMatrixStepGrid implements.
+// semantics PromQL uses (latest sample at-or-before step, within lookback delta).
 //
 // Memory complexity: O(rows) total in the per-series buffers — but with
 // the master []chclient.Sample slice gone, peak resident bytes shrink
@@ -526,75 +526,6 @@ func matrixFromCursor(
 		}
 	}
 	return out, nil
-}
-
-// toMatrixStepGrid pivots the sample stream into the Prom matrix shape.
-// For each evaluation step T in [start, end] (inclusive, spaced by step),
-// each series emits one Sample: the value of the latest input row whose
-// timestamp <= T (the standard PromQL latest-sample-at-eval-time
-// semantics). Series with no eligible samples for a given step are
-// represented as a stale-marker gap (the step is simply skipped in the
-// Values slice — Prometheus permits this).
-//
-// Lookback delta: a hard 5-minute lookback by default; older samples are
-// considered stale. Future work threads the API's `lookback_delta`
-// param through here.
-func toMatrixStepGrid(samples []chclient.Sample, start, end time.Time, step time.Duration) []MatrixSample {
-	const lookback = 5 * time.Minute
-
-	type seriesState struct {
-		labels map[string]string
-		// rows holds the sorted (ascending) timestamps + values for this
-		// series; we walk the row cursor forward as we advance through
-		// the step grid.
-		rows []chclient.Sample
-	}
-
-	bySeries := map[string]*seriesState{}
-	for _, s := range samples {
-		labels := withMetricName(s.Labels, s.MetricName)
-		key := canonicalKey(labels)
-		st, ok := bySeries[key]
-		if !ok {
-			st = &seriesState{labels: labels}
-			bySeries[key] = st
-		}
-		st.rows = append(st.rows, s)
-	}
-	for _, st := range bySeries {
-		// Inline insertion sort by Timestamp ascending — samples are
-		// typically already nearly sorted from CH.
-		for i := 1; i < len(st.rows); i++ {
-			for j := i; j > 0 && st.rows[j-1].Timestamp.After(st.rows[j].Timestamp); j-- {
-				st.rows[j-1], st.rows[j] = st.rows[j], st.rows[j-1]
-			}
-		}
-	}
-
-	out := make([]MatrixSample, 0, len(bySeries))
-	for _, st := range bySeries {
-		ms := MatrixSample{Metric: st.labels}
-		cursor := 0
-		for t := start; !t.After(end); t = t.Add(step) {
-			// Advance cursor as long as the next row's ts <= t.
-			for cursor < len(st.rows) && !st.rows[cursor].Timestamp.After(t) {
-				cursor++
-			}
-			if cursor == 0 {
-				continue // no row at-or-before this step yet
-			}
-			latest := st.rows[cursor-1]
-			if t.Sub(latest.Timestamp) > lookback {
-				continue // older than the lookback window; stale
-			}
-			stamp := float64(t.UnixMilli()) / 1e3
-			ms.Values = append(ms.Values, Sample{stamp, strconv.FormatFloat(latest.Value, 'f', -1, 64)})
-		}
-		if len(ms.Values) > 0 {
-			out = append(out, ms)
-		}
-	}
-	return out
 }
 
 // parseDuration parses a Prom-style step / range duration. Accepts plain

--- a/internal/api/prom/handler_test.go
+++ b/internal/api/prom/handler_test.go
@@ -36,6 +36,15 @@ func (s *stubQuerier) Query(_ context.Context, sql string, args ...any) ([]chcli
 	return s.samples, nil
 }
 
+func (s *stubQuerier) QueryCursor(_ context.Context, sql string, args ...any) (chclient.Cursor, error) {
+	s.lastSQL = sql
+	s.lastArgs = args
+	if s.err != nil {
+		return nil, s.err
+	}
+	return newSliceCursor(s.samples), nil
+}
+
 func (s *stubQuerier) QueryStrings(_ context.Context, sql string, args ...any) ([]string, error) {
 	s.lastSQL = sql
 	s.lastArgs = args
@@ -441,6 +450,83 @@ func TestQuery_UpstreamError(t *testing.T) {
 	if resp.StatusCode != http.StatusBadGateway {
 		t.Fatalf("expected 502, got %d body=%s", resp.StatusCode, readBody(t, resp))
 	}
+}
+
+// BenchmarkExecuteRangeStreaming exercises the streaming path against a
+// 100k-sample synthetic result set spread across 100 series and reports
+// allocated bytes per request. The cursor variant should keep the peak
+// resident slice (the master []chclient.Sample copy) out of the
+// allocation profile.
+func BenchmarkExecuteRangeStreaming(b *testing.B) {
+	const (
+		seriesCount     = 100
+		samplesPerSerie = 1000
+	)
+	start := time.Unix(1717995600, 0).UTC()
+	step := time.Second
+	end := start.Add(time.Duration(samplesPerSerie-1) * step)
+
+	samples := make([]chclient.Sample, 0, seriesCount*samplesPerSerie)
+	for i := 0; i < seriesCount; i++ {
+		labels := map[string]string{"job": "api", "instance": fmt.Sprintf("host-%d", i)}
+		for j := 0; j < samplesPerSerie; j++ {
+			samples = append(samples, chclient.Sample{
+				MetricName: "up",
+				Labels:     labels,
+				Timestamp:  start.Add(time.Duration(j) * step),
+				Value:      float64(j),
+			})
+		}
+	}
+
+	q := &stubQuerier{samples: samples}
+	srv := newServer(q)
+	b.Cleanup(srv.Close)
+	url := fmt.Sprintf("%s/api/v1/query_range?query=up&start=%d&end=%d&step=1",
+		srv.URL, start.Unix(), end.Unix())
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		resp, err := http.Get(url)
+		if err != nil {
+			b.Fatalf("GET: %v", err)
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}
+}
+
+// sliceCursor is the in-memory chclient.Cursor used by stubQuerier so
+// tests don't need a live ClickHouse for /api/v1/query_range. Mirrors
+// the production cursor's lifecycle: Next advances, Sample yields the
+// current row, Err reports any saved error, Close is idempotent.
+type sliceCursor struct {
+	samples []chclient.Sample
+	idx     int
+	cur     chclient.Sample
+	closed  bool
+}
+
+func newSliceCursor(samples []chclient.Sample) *sliceCursor {
+	return &sliceCursor{samples: samples, idx: -1}
+}
+
+func (c *sliceCursor) Next() bool {
+	c.idx++
+	if c.idx >= len(c.samples) {
+		return false
+	}
+	c.cur = c.samples[c.idx]
+	return true
+}
+
+func (c *sliceCursor) Sample() chclient.Sample { return c.cur }
+func (c *sliceCursor) Err() error              { return nil }
+
+func (c *sliceCursor) Close() error {
+	c.closed = true
+	return nil
 }
 
 func readBody(t *testing.T, resp *http.Response) string {

--- a/internal/chclient/client.go
+++ b/internal/chclient/client.go
@@ -97,27 +97,26 @@ func (c *Client) Exec(ctx context.Context, sql string, args ...any) error {
 //
 // For v0.1 the API layer ensures this projection shape via the chplan
 // Project node wrapped around lowered PromQL output.
+//
+// Query is a thin wrapper around QueryCursor that drains the cursor into
+// a slice. Callers that may return millions of rows (notably
+// /api/v1/query_range) should use QueryCursor directly to keep memory
+// bounded — see R3.12 in docs/roadmap.md.
 func (c *Client) Query(ctx context.Context, sql string, args ...any) ([]Sample, error) {
-	rows, err := c.conn.Query(ctx, sql, args...)
+	cursor, err := c.QueryCursor(ctx, sql, args...)
 	if err != nil {
-		return nil, fmt.Errorf("chclient: query: %w", err)
+		return nil, err
 	}
 	defer func() {
-		_ = rows.Close()
+		_ = cursor.Close()
 	}()
 
 	var out []Sample
-	for rows.Next() {
-		var s Sample
-		var labels map[string]string
-		if err := rows.Scan(&s.MetricName, &labels, &s.Timestamp, &s.Value); err != nil {
-			return nil, fmt.Errorf("chclient: scan: %w", err)
-		}
-		s.Labels = labels
-		out = append(out, s)
+	for cursor.Next() {
+		out = append(out, cursor.Sample())
 	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("chclient: rows.Err: %w", err)
+	if err := cursor.Err(); err != nil {
+		return nil, err
 	}
 	return out, nil
 }

--- a/internal/chclient/cursor.go
+++ b/internal/chclient/cursor.go
@@ -1,0 +1,101 @@
+package chclient
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+)
+
+// Cursor is a forward-only iterator over a Sample result set. Use it to
+// stream rows out of ClickHouse without materialising the full slice in
+// process memory — the canonical pattern for `query_range` matrix
+// responses, where a long-window / fine-step query can produce millions
+// of rows.
+//
+// Lifecycle: call Next() in a loop; while it returns true, Sample()
+// yields the current row. When Next() returns false, check Err() — a
+// non-nil value means the iterator terminated due to a decode or
+// transport error rather than end-of-stream. Close() releases the
+// underlying CH resources and MUST be called exactly once, typically via
+// `defer cursor.Close()` immediately after a successful QueryCursor.
+type Cursor interface {
+	Next() bool
+	Sample() Sample
+	Err() error
+	Close() error
+}
+
+// rowsCursor wraps a driver.Rows and decodes each row positionally into a
+// Sample. The driver's Rows is itself an iterator over the wire stream,
+// so allocations per row stay bounded — only the current Sample is kept
+// in memory.
+type rowsCursor struct {
+	rows driver.Rows
+	cur  Sample
+	err  error
+}
+
+// Next advances the cursor to the next row. Returns false when the
+// stream is exhausted or when a decode error occurred; in the error case
+// Err() returns the cause.
+func (c *rowsCursor) Next() bool {
+	if c.err != nil {
+		return false
+	}
+	if !c.rows.Next() {
+		if err := c.rows.Err(); err != nil {
+			c.err = fmt.Errorf("chclient: rows.Err: %w", err)
+		}
+		return false
+	}
+	var s Sample
+	var labels map[string]string
+	if err := c.rows.Scan(&s.MetricName, &labels, &s.Timestamp, &s.Value); err != nil {
+		c.err = fmt.Errorf("chclient: scan: %w", err)
+		return false
+	}
+	s.Labels = labels
+	c.cur = s
+	return true
+}
+
+// Sample returns the row that the most recent Next() call landed on.
+// Calling Sample before Next, or after Next has returned false, yields
+// the zero value.
+func (c *rowsCursor) Sample() Sample { return c.cur }
+
+// Err returns any non-EOF error that terminated iteration. It is safe to
+// call after Close.
+func (c *rowsCursor) Err() error { return c.err }
+
+// Close releases the underlying driver.Rows. Safe to call multiple
+// times; subsequent calls are no-ops once the resource is released.
+func (c *rowsCursor) Close() error {
+	if c.rows == nil {
+		return nil
+	}
+	err := c.rows.Close()
+	c.rows = nil
+	if err != nil {
+		return fmt.Errorf("chclient: rows.Close: %w", err)
+	}
+	return nil
+}
+
+// QueryCursor runs sql with positional args and returns a forward-only
+// Cursor over the result set. The SQL must project (MetricName,
+// Attributes, TimeUnix, Value) in that order — Scan binds positionally,
+// matching Client.Query.
+//
+// Compared to Query, QueryCursor keeps only one Sample resident in
+// process memory at a time, which is the only way to keep RAM bounded
+// for long-window `query_range` requests. Callers MUST Close the cursor
+// to return its connection to the pool.
+func (c *Client) QueryCursor(ctx context.Context, sql string, args ...any) (Cursor, error) {
+	rows, err := c.conn.Query(ctx, sql, args...)
+	if err != nil {
+		return nil, fmt.Errorf("chclient: query: %w", err)
+	}
+	return &rowsCursor{rows: rows}, nil
+}

--- a/internal/chclient/cursor_test.go
+++ b/internal/chclient/cursor_test.go
@@ -1,0 +1,149 @@
+package chclient
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+)
+
+// fakeRows implements driver.Rows over an in-memory slice so the cursor
+// can be exercised without a live ClickHouse. Only the methods the
+// cursor actually calls (Next / Scan / Close / Err) carry real
+// behaviour; the rest satisfy the interface as no-ops.
+type fakeRows struct {
+	samples []Sample
+	idx     int
+	scanErr error
+	rowsErr error
+	closed  bool
+}
+
+func (r *fakeRows) Next() bool {
+	if r.idx >= len(r.samples) {
+		return false
+	}
+	r.idx++
+	return true
+}
+
+func (r *fakeRows) Scan(dest ...any) error {
+	if r.scanErr != nil {
+		return r.scanErr
+	}
+	if len(dest) != 4 {
+		return errors.New("fakeRows.Scan: want 4 destinations")
+	}
+	s := r.samples[r.idx-1]
+	if p, ok := dest[0].(*string); ok {
+		*p = s.MetricName
+	}
+	if p, ok := dest[1].(*map[string]string); ok {
+		*p = s.Labels
+	}
+	if p, ok := dest[2].(*time.Time); ok {
+		*p = s.Timestamp
+	}
+	if p, ok := dest[3].(*float64); ok {
+		*p = s.Value
+	}
+	return nil
+}
+
+func (r *fakeRows) ScanStruct(any) error    { return errors.New("not implemented") }
+func (r *fakeRows) ColumnTypes() []driver.ColumnType { return nil }
+func (r *fakeRows) Totals(...any) error              { return nil }
+func (r *fakeRows) Columns() []string                { return nil }
+func (r *fakeRows) Err() error                       { return r.rowsErr }
+func (r *fakeRows) HasData() bool                    { return len(r.samples) > 0 }
+
+func (r *fakeRows) Close() error {
+	r.closed = true
+	return nil
+}
+
+func TestRowsCursor_StreamsSamples(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	want := []Sample{
+		{MetricName: "up", Labels: map[string]string{"job": "api"}, Timestamp: ts, Value: 1.0},
+		{MetricName: "up", Labels: map[string]string{"job": "db"}, Timestamp: ts.Add(time.Minute), Value: 0.0},
+	}
+	rows := &fakeRows{samples: want}
+	cursor := &rowsCursor{rows: rows}
+
+	var got []Sample
+	for cursor.Next() {
+		got = append(got, cursor.Sample())
+	}
+	if err := cursor.Err(); err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("samples: got %+v, want %+v", got, want)
+	}
+	if err := cursor.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !rows.closed {
+		t.Fatal("underlying rows.Close was not invoked")
+	}
+	// Idempotent Close.
+	if err := cursor.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+}
+
+func TestRowsCursor_EmptyResultSet(t *testing.T) {
+	t.Parallel()
+
+	rows := &fakeRows{}
+	cursor := &rowsCursor{rows: rows}
+	if cursor.Next() {
+		t.Fatal("Next on empty cursor should return false")
+	}
+	if err := cursor.Err(); err != nil {
+		t.Fatalf("Err on empty: %v", err)
+	}
+	if err := cursor.Close(); err != nil {
+		t.Fatalf("Close on empty: %v", err)
+	}
+}
+
+func TestRowsCursor_ScanErrorTerminatesIteration(t *testing.T) {
+	t.Parallel()
+
+	rows := &fakeRows{
+		samples: []Sample{{MetricName: "up", Value: 1}},
+		scanErr: errors.New("decode boom"),
+	}
+	cursor := &rowsCursor{rows: rows}
+
+	if cursor.Next() {
+		t.Fatal("Next should return false when Scan fails")
+	}
+	if err := cursor.Err(); err == nil {
+		t.Fatal("Err: want non-nil on scan failure")
+	}
+	// Subsequent Next must keep returning false (no infinite loop).
+	if cursor.Next() {
+		t.Fatal("Next must stay false after error")
+	}
+}
+
+func TestRowsCursor_RowsErrSurfacesAfterEnd(t *testing.T) {
+	t.Parallel()
+
+	rows := &fakeRows{rowsErr: errors.New("transport boom")}
+	cursor := &rowsCursor{rows: rows}
+
+	if cursor.Next() {
+		t.Fatal("Next should return false on empty + rowsErr")
+	}
+	if err := cursor.Err(); err == nil {
+		t.Fatal("Err: want non-nil when rows.Err() is set")
+	}
+}

--- a/internal/chclient/cursor_test.go
+++ b/internal/chclient/cursor_test.go
@@ -52,7 +52,7 @@ func (r *fakeRows) Scan(dest ...any) error {
 	return nil
 }
 
-func (r *fakeRows) ScanStruct(any) error    { return errors.New("not implemented") }
+func (r *fakeRows) ScanStruct(any) error             { return errors.New("not implemented") }
 func (r *fakeRows) ColumnTypes() []driver.ColumnType { return nil }
 func (r *fakeRows) Totals(...any) error              { return nil }
 func (r *fakeRows) Columns() []string                { return nil }


### PR DESCRIPTION
## Summary

- New `chclient.Cursor` interface (`Next` / `Sample` / `Err` / `Close`) and `Client.QueryCursor`, a thin wrapper over `clickhouse-go/v2`'s `driver.Rows` that decodes one `Sample` at a time.
- Refactors `api/prom`'s `/api/v1/query_range` to consume the cursor via a new `executeRangeStreaming` + `matrixFromCursor`. Same SQL, same optimizer, same matrix shape — the master `[]chclient.Sample` slice is gone, so a wide-range / fine-step query no longer carries an O(N) parallel copy.
- `Client.Query` is retained for callers that genuinely want a slice (instant queries, tests) and is now a thin drain over `QueryCursor`.

## Memory complexity claim

Before this PR: `chclient.Query` materialises every row, the matrix pivot then re-buckets them into the per-series map → peak resident bytes ≈ `2 × O(total_rows × sizeof(Sample))` until the slice can be GC'd.

After this PR: the cursor streams row-by-row directly into the per-series buffer, so the per-series buckets are the only resident copy → peak resident bytes ≈ `O(total_rows × sizeof(Sample))` (no parallel slice).

A future follow-up that pushes `ORDER BY (series_key, ts)` into the emitted SQL can flush series buffers on `canonicalKey` change and bring peak to `O(rows_per_series)` — out of scope for this PR per the R3.12 brief.

## Benchmark

`BenchmarkExecuteRangeStreaming` exercises the streaming path against a 100k-sample synthetic result (100 series × 1k samples) end-to-end through `httptest`. Reports allocated bytes per request. Not invoked in CI (no `bench` job today) — kept as a local microbench for the follow-up profiling pass.

## Scope intentionally left for follow-ups

- LogQL / Tempo handlers still consume `[]chclient.Sample` via `Client.Query`. Porting them to `QueryCursor` is a straightforward mirror of this change; deferred so this PR stays scoped.
- One-series-at-a-time flush (true `O(rows_per_series)` memory) requires ordering the SQL by `(series_key, ts)` — that lands as its own PR.

## Test plan

- [x] `internal/chclient/cursor_test.go` — fake `driver.Rows`, asserts iteration, empty result, scan error, transport error, idempotent Close.
- [x] Existing `internal/api/prom/handler_test.go` matrix tests still pass via a slice-backed in-memory cursor (`sliceCursor`) on the stubQuerier.
- [ ] CI `check` + `lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)