### PR TITLE
feat(optimizer): FilterProjectTranspose + FilterAggregateTranspose pattern rules (R3.2)

### DIFF
--- a/internal/optimizer/filter_aggregate_transpose.go
+++ b/internal/optimizer/filter_aggregate_transpose.go
@@ -1,0 +1,113 @@
+package optimizer
+
+import "github.com/tsouza/cerberus/internal/chplan"
+
+// FilterAggregateTranspose rewrites `Filter(Aggregate(X), p)` →
+// `Aggregate(Filter(X, p))` when the Filter's predicate references only
+// columns that appear, unchanged, as group-by keys.
+//
+// Lineage: Calcite's `FilterAggregateTransposeRule` — see
+// https://calcite.apache.org/javadocAggregate/org/apache/calcite/rel/rules/FilterAggregateTransposeRule.html.
+// The motivating case is `sum by (job) (m{job="x"})`: the `job="x"`
+// predicate over the Aggregate result is equivalent to the same
+// predicate applied to the rows feeding the Aggregate. Pushing it
+// underneath dramatically shrinks the rows the GROUP BY has to chew
+// through, and exposes the predicate to PREWHERE promotion (R3.4)
+// once it reaches the Scan.
+//
+// Safety. The Filter sees two flavours of output column on the
+// Aggregate: the group-by keys (`Aggregate.GroupBy`, optionally renamed
+// by `GroupByAliases`) and the aggregate output columns
+// (`Aggregate.AggFuncs[i].Alias`). Only the first flavour exists in the
+// Aggregate's input. We allow the rewrite only when every `ColumnRef`
+// in the predicate names a bare group-by key — i.e. there is a
+// `GroupBy[i]` that is itself a `*ColumnRef{Name: N}` (no qualifier),
+// and the matching `GroupByAliases[i]` (if any) is empty or equal to
+// `N`. Predicates referencing aggregate outputs (sum_value, count, …)
+// or renamed group keys are left alone.
+//
+// Conservative cases the rule leaves alone:
+//
+//   - Empty `GroupBy` — nothing is passthrough.
+//   - `GroupBy[i]` that is not a bare `ColumnRef` (e.g. a function
+//     call or arithmetic) — could be substituted into the predicate,
+//     but that's a more involved rewrite.
+//   - `GroupByAliases[i]` that renames the key.
+//   - `ColumnRef` with a non-empty Qualifier in the predicate.
+//
+// Built on the `PatternRule` scaffold introduced in R3.1.
+func FilterAggregateTranspose() Rule {
+	return &PatternRule{
+		RuleName: "filter-aggregate-transpose",
+		Match: WithChildren(
+			Capture("filter", Kind(KindFilter)),
+			Capture("aggregate", Kind(KindAggregate)),
+		),
+		Transform: transposeFilterAggregate,
+	}
+}
+
+func transposeFilterAggregate(b Bindings) chplan.Node {
+	fNode, ok := b.Get("filter")
+	if !ok {
+		return nil
+	}
+	aNode, ok := b.Get("aggregate")
+	if !ok {
+		return nil
+	}
+	f, ok := fNode.(*chplan.Filter)
+	if !ok {
+		return nil
+	}
+	a, ok := aNode.(*chplan.Aggregate)
+	if !ok {
+		return nil
+	}
+
+	passthrough := passthroughGroupKeys(a)
+	if passthrough == nil {
+		return nil
+	}
+	if !onlyReferencesPassthrough(f.Predicate, passthrough) {
+		return nil
+	}
+
+	newFilter := &chplan.Filter{
+		Input:     a.Input,
+		Predicate: f.Predicate,
+	}
+	newAgg := *a
+	newAgg.Input = newFilter
+	return &newAgg
+}
+
+// passthroughGroupKeys returns the set of bare-column group keys whose
+// names survive into the Aggregate's output unchanged, or nil to signal
+// "this Aggregate has no passthrough keys — decline the rewrite". An
+// alias that renames a key removes it from the passthrough set; the
+// emitter would expose the key only under the alias, so the original
+// name doesn't exist in the Aggregate's output anyway.
+func passthroughGroupKeys(a *chplan.Aggregate) map[string]struct{} {
+	if len(a.GroupBy) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{}, len(a.GroupBy))
+	for i, g := range a.GroupBy {
+		cr, ok := g.(*chplan.ColumnRef)
+		if !ok || cr.Qualifier != "" {
+			continue
+		}
+		if i < len(a.GroupByAliases) {
+			alias := a.GroupByAliases[i]
+			if alias != "" && alias != cr.Name {
+				continue
+			}
+		}
+		out[cr.Name] = struct{}{}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/internal/optimizer/filter_aggregate_transpose_test.go
+++ b/internal/optimizer/filter_aggregate_transpose_test.go
@@ -1,0 +1,189 @@
+package optimizer_test
+
+import (
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/optimizer"
+)
+
+// TestFilterAggregateTranspose_GroupKey fires on
+// `Filter(Aggregate(Scan, GROUP BY job), job = "api")`
+// and expects the Filter to land under the Aggregate.
+func TestFilterAggregateTranspose_GroupKey(t *testing.T) {
+	t.Parallel()
+
+	scan := &chplan.Scan{Table: "otel_metrics_gauge"}
+	pred := &chplan.Binary{
+		Op:    chplan.OpEq,
+		Left:  &chplan.ColumnRef{Name: "job"},
+		Right: &chplan.LitString{V: "api"},
+	}
+	input := &chplan.Filter{
+		Input: &chplan.Aggregate{
+			Input:   scan,
+			GroupBy: []chplan.Expr{&chplan.ColumnRef{Name: "job"}},
+			AggFuncs: []chplan.AggFunc{
+				{Name: "sum", Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}, Alias: "sum_value"},
+			},
+		},
+		Predicate: pred,
+	}
+
+	expected := &chplan.Aggregate{
+		Input: &chplan.Filter{
+			Input:     scan,
+			Predicate: pred,
+		},
+		GroupBy: []chplan.Expr{&chplan.ColumnRef{Name: "job"}},
+		AggFuncs: []chplan.AggFunc{
+			{Name: "sum", Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}, Alias: "sum_value"},
+		},
+	}
+
+	out := optimizer.New(optimizer.FilterAggregateTranspose()).Run(input)
+	if !out.Equal(expected) {
+		t.Fatalf("FilterAggregateTranspose did not fire:\n got: %#v\nwant: %#v", out, expected)
+	}
+}
+
+// TestFilterAggregateTranspose_BlockedByAggOutput leaves the Filter
+// above when the predicate touches the aggregate output column (here
+// `sum_value`), which doesn't exist below the Aggregate.
+func TestFilterAggregateTranspose_BlockedByAggOutput(t *testing.T) {
+	t.Parallel()
+
+	scan := &chplan.Scan{Table: "otel_metrics_gauge"}
+	input := &chplan.Filter{
+		Input: &chplan.Aggregate{
+			Input:   scan,
+			GroupBy: []chplan.Expr{&chplan.ColumnRef{Name: "job"}},
+			AggFuncs: []chplan.AggFunc{
+				{Name: "sum", Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}, Alias: "sum_value"},
+			},
+		},
+		Predicate: &chplan.Binary{
+			Op:    chplan.OpGt,
+			Left:  &chplan.ColumnRef{Name: "sum_value"},
+			Right: &chplan.LitFloat{V: 0},
+		},
+	}
+
+	out := optimizer.New(optimizer.FilterAggregateTranspose()).Run(input)
+	if !out.Equal(input) {
+		t.Fatalf("rule fired despite aggregate-output reference:\n got: %#v", out)
+	}
+}
+
+// TestFilterAggregateTranspose_BlockedByRenamedKey leaves the Filter
+// above when the matched group key has been renamed via GroupByAliases
+// and the predicate references the alias.
+func TestFilterAggregateTranspose_BlockedByRenamedKey(t *testing.T) {
+	t.Parallel()
+
+	scan := &chplan.Scan{Table: "otel_metrics_gauge"}
+	input := &chplan.Filter{
+		Input: &chplan.Aggregate{
+			Input:          scan,
+			GroupBy:        []chplan.Expr{&chplan.ColumnRef{Name: "job"}},
+			GroupByAliases: []string{"renamed_job"},
+			AggFuncs: []chplan.AggFunc{
+				{Name: "count", Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}, Alias: "n"},
+			},
+		},
+		Predicate: &chplan.Binary{
+			Op:    chplan.OpEq,
+			Left:  &chplan.ColumnRef{Name: "renamed_job"},
+			Right: &chplan.LitString{V: "api"},
+		},
+	}
+
+	out := optimizer.New(optimizer.FilterAggregateTranspose()).Run(input)
+	if !out.Equal(input) {
+		t.Fatalf("rule fired despite renamed group key:\n got: %#v", out)
+	}
+}
+
+// TestFilterAggregateTranspose_BlockedByComputedGroupKey skips Aggregates
+// whose group keys are not bare ColumnRefs (e.g. `GROUP BY substr(X, 1)`).
+func TestFilterAggregateTranspose_BlockedByComputedGroupKey(t *testing.T) {
+	t.Parallel()
+
+	scan := &chplan.Scan{Table: "otel_metrics_gauge"}
+	input := &chplan.Filter{
+		Input: &chplan.Aggregate{
+			Input: scan,
+			GroupBy: []chplan.Expr{
+				&chplan.FuncCall{
+					Name: "substr",
+					Args: []chplan.Expr{&chplan.ColumnRef{Name: "MetricName"}, &chplan.LitInt{V: 1}},
+				},
+			},
+			AggFuncs: []chplan.AggFunc{
+				{Name: "count", Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}, Alias: "n"},
+			},
+		},
+		Predicate: &chplan.Binary{
+			Op:    chplan.OpEq,
+			Left:  &chplan.ColumnRef{Name: "MetricName"},
+			Right: &chplan.LitString{V: "up"},
+		},
+	}
+
+	out := optimizer.New(optimizer.FilterAggregateTranspose()).Run(input)
+	if !out.Equal(input) {
+		t.Fatalf("rule fired despite computed group key:\n got: %#v", out)
+	}
+}
+
+// TestFilterAggregateTranspose_AliasMatchesName allows the rewrite when
+// the alias matches the underlying column name — that's a no-op rename.
+func TestFilterAggregateTranspose_AliasMatchesName(t *testing.T) {
+	t.Parallel()
+
+	scan := &chplan.Scan{Table: "otel_metrics_gauge"}
+	input := &chplan.Filter{
+		Input: &chplan.Aggregate{
+			Input:          scan,
+			GroupBy:        []chplan.Expr{&chplan.ColumnRef{Name: "job"}},
+			GroupByAliases: []string{"job"},
+			AggFuncs: []chplan.AggFunc{
+				{Name: "count", Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}, Alias: "n"},
+			},
+		},
+		Predicate: &chplan.Binary{
+			Op:    chplan.OpEq,
+			Left:  &chplan.ColumnRef{Name: "job"},
+			Right: &chplan.LitString{V: "api"},
+		},
+	}
+
+	out := optimizer.New(optimizer.FilterAggregateTranspose()).Run(input)
+	agg, ok := out.(*chplan.Aggregate)
+	if !ok {
+		t.Fatalf("expected Aggregate at root, got %T", out)
+	}
+	if _, ok := agg.Input.(*chplan.Filter); !ok {
+		t.Fatalf("expected Filter under Aggregate, got %T", agg.Input)
+	}
+}
+
+// TestFilterAggregateTranspose_NoMatchOnOtherShape leaves Filter(Scan)
+// alone.
+func TestFilterAggregateTranspose_NoMatchOnOtherShape(t *testing.T) {
+	t.Parallel()
+
+	input := &chplan.Filter{
+		Input: &chplan.Scan{Table: "otel_metrics_gauge"},
+		Predicate: &chplan.Binary{
+			Op:    chplan.OpEq,
+			Left:  &chplan.ColumnRef{Name: "MetricName"},
+			Right: &chplan.LitString{V: "up"},
+		},
+	}
+
+	out := optimizer.New(optimizer.FilterAggregateTranspose()).Run(input)
+	if !out.Equal(input) {
+		t.Fatalf("rule fired on Filter(Scan): %#v", out)
+	}
+}

--- a/internal/optimizer/filter_project_transpose.go
+++ b/internal/optimizer/filter_project_transpose.go
@@ -1,0 +1,138 @@
+package optimizer
+
+import "github.com/tsouza/cerberus/internal/chplan"
+
+// FilterProjectTranspose rewrites `Filter(Project(X), p)` → `Project(Filter(X, p))`
+// when the Filter's predicate references only columns that the Project
+// passes through unchanged from X.
+//
+// Lineage: Calcite's `FilterProjectTransposeRule` — see
+// https://calcite.apache.org/javadocAggregate/org/apache/calcite/rel/rules/FilterProjectTransposeRule.html.
+// The shape unlocks downstream rules: pushing the Filter under a Project
+// lets `ProjectionPushdown` (currently fires on `Project(Scan)` only) see
+// the new `Project(Filter(...))` chain through a future column-set pass,
+// and exposes the Filter to `PREWHERE` promotion (R3.4) once the Scan
+// becomes the Filter's immediate input again.
+//
+// Safety. The Filter sees the Project's *output* columns. Pushing it
+// underneath the Project means the same predicate must be evaluable
+// against the Project's *input* columns. We allow the rewrite only when
+// every `ColumnRef` the predicate touches refers to a name that the
+// Project passes through unchanged — i.e. there is a `Projection` whose
+// `Expr` is `*ColumnRef{Name: N}` (same name as the predicate
+// reference, no qualifier) and whose `Alias` is empty or equal to `N`.
+//
+// Conservative cases the rule leaves alone:
+//
+//   - Empty Projections (`SELECT *`) — could be safely pushed, but the
+//     emitter renders that as a no-op layer; flatening is out of scope here.
+//   - Projections that rename (`X AS Y`) — a predicate on `Y` cannot
+//     be pushed past the rename without rewriting the predicate.
+//   - Projections that compute (`X + 1 AS Y`) — same as above; future
+//     work can substitute, but the seed rule stays conservative.
+//   - `ColumnRef` with a non-empty `Qualifier` — qualifier semantics
+//     belong to joins, which are not in scope for filter-project
+//     transposition.
+//
+// Built on the `PatternRule` scaffold introduced in R3.1 — declarative
+// `Match` / `Transform` rather than the legacy `Rule.Apply` type-switch.
+// FilterProjectTranspose is exposed as a constructor returning a `Rule`
+// so callers can register it alongside the legacy three rules.
+func FilterProjectTranspose() Rule {
+	return &PatternRule{
+		RuleName: "filter-project-transpose",
+		Match: WithChildren(
+			Capture("filter", Kind(KindFilter)),
+			Capture("project", Kind(KindProject)),
+		),
+		Transform: transposeFilterProject,
+	}
+}
+
+func transposeFilterProject(b Bindings) chplan.Node {
+	fNode, ok := b.Get("filter")
+	if !ok {
+		return nil
+	}
+	pNode, ok := b.Get("project")
+	if !ok {
+		return nil
+	}
+	f, ok := fNode.(*chplan.Filter)
+	if !ok {
+		return nil
+	}
+	p, ok := pNode.(*chplan.Project)
+	if !ok {
+		return nil
+	}
+
+	passthrough := passthroughColumns(p.Projections)
+	if passthrough == nil {
+		// `nil` (not "empty") means "the Project has a renaming or
+		// computed entry" — bail. An *empty* but non-nil set is
+		// returned only when the Project has zero entries (`SELECT *`),
+		// which we also decline to handle in this seed rule.
+		return nil
+	}
+	if !onlyReferencesPassthrough(f.Predicate, passthrough) {
+		return nil
+	}
+
+	newFilter := &chplan.Filter{
+		Input:     p.Input,
+		Predicate: f.Predicate,
+	}
+	newProject := *p
+	newProject.Input = newFilter
+	return &newProject
+}
+
+// passthroughColumns returns the set of column names a Project passes
+// through unchanged, or nil to signal "this Project has a non-passthrough
+// entry, decline the rewrite outright".
+//
+// An empty (but non-nil) Projections slice — the `SELECT *` shape —
+// returns nil too: the rule declines to handle it because the emitter's
+// `*` semantics make the column set indeterminate at the IR level.
+func passthroughColumns(projs []chplan.Projection) map[string]struct{} {
+	if len(projs) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{}, len(projs))
+	for _, p := range projs {
+		cr, ok := p.Expr.(*chplan.ColumnRef)
+		if !ok {
+			return nil
+		}
+		if cr.Qualifier != "" {
+			return nil
+		}
+		if p.Alias != "" && p.Alias != cr.Name {
+			return nil
+		}
+		out[cr.Name] = struct{}{}
+	}
+	return out
+}
+
+// onlyReferencesPassthrough reports whether every `*ColumnRef` reachable
+// from e is bare (empty Qualifier) and names a column in the supplied
+// passthrough set.
+func onlyReferencesPassthrough(e chplan.Expr, passthrough map[string]struct{}) bool {
+	ok := true
+	walkExpr(e, func(sub chplan.Expr) {
+		cr, isCol := sub.(*chplan.ColumnRef)
+		if !isCol {
+			return
+		}
+		if cr.Qualifier != "" {
+			ok = false
+			return
+		}
+		if _, found := passthrough[cr.Name]; !found {
+			ok = false
+		}
+	})
+	return ok
+}

--- a/internal/optimizer/filter_project_transpose_test.go
+++ b/internal/optimizer/filter_project_transpose_test.go
@@ -1,0 +1,189 @@
+package optimizer_test
+
+import (
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/optimizer"
+)
+
+// TestFilterProjectTranspose_Passthrough fires the rule on
+// `Filter(Project([X, Y], Scan), X = "v")` and expects
+// `Project([X, Y], Filter(Scan, X = "v"))`.
+func TestFilterProjectTranspose_Passthrough(t *testing.T) {
+	t.Parallel()
+
+	scan := &chplan.Scan{Table: "otel_metrics_gauge"}
+	pred := &chplan.Binary{
+		Op:    chplan.OpEq,
+		Left:  &chplan.ColumnRef{Name: "MetricName"},
+		Right: &chplan.LitString{V: "up"},
+	}
+	input := &chplan.Filter{
+		Input: &chplan.Project{
+			Input: scan,
+			Projections: []chplan.Projection{
+				{Expr: &chplan.ColumnRef{Name: "MetricName"}},
+				{Expr: &chplan.ColumnRef{Name: "Value"}},
+			},
+		},
+		Predicate: pred,
+	}
+
+	expected := &chplan.Project{
+		Input: &chplan.Filter{
+			Input:     scan,
+			Predicate: pred,
+		},
+		Projections: []chplan.Projection{
+			{Expr: &chplan.ColumnRef{Name: "MetricName"}},
+			{Expr: &chplan.ColumnRef{Name: "Value"}},
+		},
+	}
+
+	out := optimizer.New(optimizer.FilterProjectTranspose()).Run(input)
+	if !out.Equal(expected) {
+		t.Fatalf("FilterProjectTranspose did not fire:\n got: %#v\nwant: %#v", out, expected)
+	}
+}
+
+// TestFilterProjectTranspose_Aliased confirms the rule still fires when
+// the Project carries an alias matching the column name (a no-op rename
+// from CH's perspective).
+func TestFilterProjectTranspose_Aliased(t *testing.T) {
+	t.Parallel()
+
+	scan := &chplan.Scan{Table: "otel_metrics_gauge"}
+	pred := &chplan.Binary{
+		Op:    chplan.OpEq,
+		Left:  &chplan.ColumnRef{Name: "MetricName"},
+		Right: &chplan.LitString{V: "up"},
+	}
+	input := &chplan.Filter{
+		Input: &chplan.Project{
+			Input: scan,
+			Projections: []chplan.Projection{
+				{Expr: &chplan.ColumnRef{Name: "MetricName"}, Alias: "MetricName"},
+				{Expr: &chplan.ColumnRef{Name: "Value"}},
+			},
+		},
+		Predicate: pred,
+	}
+
+	out := optimizer.New(optimizer.FilterProjectTranspose()).Run(input)
+	proj, ok := out.(*chplan.Project)
+	if !ok {
+		t.Fatalf("expected Project at root, got %T", out)
+	}
+	if _, ok := proj.Input.(*chplan.Filter); !ok {
+		t.Fatalf("expected Filter under Project, got %T", proj.Input)
+	}
+}
+
+// TestFilterProjectTranspose_BlockedByRename keeps the Filter above the
+// Project when the predicate references a renamed alias — the source
+// column name doesn't exist below the Project.
+func TestFilterProjectTranspose_BlockedByRename(t *testing.T) {
+	t.Parallel()
+
+	scan := &chplan.Scan{Table: "otel_metrics_gauge"}
+	input := &chplan.Filter{
+		Input: &chplan.Project{
+			Input: scan,
+			Projections: []chplan.Projection{
+				{Expr: &chplan.ColumnRef{Name: "MetricName"}, Alias: "metric"},
+			},
+		},
+		// Predicate references the *alias* `metric`, which does not
+		// exist below the Project.
+		Predicate: &chplan.Binary{
+			Op:    chplan.OpEq,
+			Left:  &chplan.ColumnRef{Name: "metric"},
+			Right: &chplan.LitString{V: "up"},
+		},
+	}
+
+	out := optimizer.New(optimizer.FilterProjectTranspose()).Run(input)
+	if !out.Equal(input) {
+		t.Fatalf("rule fired despite alias-renamed reference:\n got: %#v", out)
+	}
+}
+
+// TestFilterProjectTranspose_BlockedByComputed keeps the Filter when
+// the Project introduces a computed column the predicate then mentions.
+func TestFilterProjectTranspose_BlockedByComputed(t *testing.T) {
+	t.Parallel()
+
+	scan := &chplan.Scan{Table: "otel_metrics_gauge"}
+	input := &chplan.Filter{
+		Input: &chplan.Project{
+			Input: scan,
+			Projections: []chplan.Projection{
+				// computed column `doubled = Value * 2`
+				{
+					Expr: &chplan.Binary{
+						Op:    chplan.OpMul,
+						Left:  &chplan.ColumnRef{Name: "Value"},
+						Right: &chplan.LitInt{V: 2},
+					},
+					Alias: "doubled",
+				},
+				{Expr: &chplan.ColumnRef{Name: "MetricName"}},
+			},
+		},
+		Predicate: &chplan.Binary{
+			Op:    chplan.OpGt,
+			Left:  &chplan.ColumnRef{Name: "doubled"},
+			Right: &chplan.LitInt{V: 10},
+		},
+	}
+
+	out := optimizer.New(optimizer.FilterProjectTranspose()).Run(input)
+	if !out.Equal(input) {
+		t.Fatalf("rule fired despite computed-column reference:\n got: %#v", out)
+	}
+}
+
+// TestFilterProjectTranspose_BlockedByStarProject is conservative: an
+// empty Projections slice (`SELECT *`) declines the rewrite. The
+// emitter renders it as a no-op subselect anyway, so the rule's
+// abstention has no practical cost.
+func TestFilterProjectTranspose_BlockedByStarProject(t *testing.T) {
+	t.Parallel()
+
+	scan := &chplan.Scan{Table: "otel_metrics_gauge"}
+	input := &chplan.Filter{
+		Input: &chplan.Project{Input: scan},
+		Predicate: &chplan.Binary{
+			Op:    chplan.OpEq,
+			Left:  &chplan.ColumnRef{Name: "MetricName"},
+			Right: &chplan.LitString{V: "up"},
+		},
+	}
+
+	out := optimizer.New(optimizer.FilterProjectTranspose()).Run(input)
+	if !out.Equal(input) {
+		t.Fatalf("rule fired on SELECT-* Project:\n got: %#v", out)
+	}
+}
+
+// TestFilterProjectTranspose_NoMatchOnOtherShape leaves a Filter
+// directly over a Scan alone — the pattern requires Filter(Project(...))
+// specifically.
+func TestFilterProjectTranspose_NoMatchOnOtherShape(t *testing.T) {
+	t.Parallel()
+
+	input := &chplan.Filter{
+		Input: &chplan.Scan{Table: "otel_metrics_gauge"},
+		Predicate: &chplan.Binary{
+			Op:    chplan.OpEq,
+			Left:  &chplan.ColumnRef{Name: "MetricName"},
+			Right: &chplan.LitString{V: "up"},
+		},
+	}
+
+	out := optimizer.New(optimizer.FilterProjectTranspose()).Run(input)
+	if !out.Equal(input) {
+		t.Fatalf("rule fired on Filter(Scan): %#v", out)
+	}
+}

--- a/internal/optimizer/optimizer_test.go
+++ b/internal/optimizer/optimizer_test.go
@@ -142,6 +142,82 @@ var inputs = map[string]chplan.Node{
 		},
 	},
 
+	// filter_project_transpose_passes: Filter over Project([X, Y], Scan)
+	// where the predicate references a passthrough column. The R3.2
+	// rule pushes the Filter under the Project; the optimized SQL
+	// shows the Filter wrapping the Scan with the Project on top.
+	"filter_project_transpose_passes": &chplan.Filter{
+		Input: &chplan.Project{
+			Input: &chplan.Scan{Table: "otel_metrics_gauge"},
+			Projections: []chplan.Projection{
+				{Expr: &chplan.ColumnRef{Name: "MetricName"}},
+				{Expr: &chplan.ColumnRef{Name: "Value"}},
+			},
+		},
+		Predicate: &chplan.Binary{
+			Op:    chplan.OpEq,
+			Left:  &chplan.ColumnRef{Name: "MetricName"},
+			Right: &chplan.LitString{V: "up"},
+		},
+	},
+
+	// filter_project_transpose_blocked: Project renames `MetricName`
+	// to `metric`; the Filter touches the *alias*. The R3.2 rule
+	// declines (alias has no source-side column). ProjectionPushdown
+	// still fires on the inner Project(Scan) and narrows the scan's
+	// column list — a benign side effect that the fixture records.
+	"filter_project_transpose_blocked": &chplan.Filter{
+		Input: &chplan.Project{
+			Input: &chplan.Scan{Table: "otel_metrics_gauge"},
+			Projections: []chplan.Projection{
+				{Expr: &chplan.ColumnRef{Name: "MetricName"}, Alias: "metric"},
+			},
+		},
+		Predicate: &chplan.Binary{
+			Op:    chplan.OpEq,
+			Left:  &chplan.ColumnRef{Name: "metric"},
+			Right: &chplan.LitString{V: "up"},
+		},
+	},
+
+	// filter_aggregate_transpose_passes: Filter over Aggregate where
+	// the predicate references a bare group-by column (`job`). The
+	// R3.2 rule pushes the Filter under the Aggregate; the optimized
+	// SQL shows the WHERE clause inside the GROUP BY's FROM subquery.
+	"filter_aggregate_transpose_passes": &chplan.Filter{
+		Input: &chplan.Aggregate{
+			Input:   &chplan.Scan{Table: "otel_metrics_gauge"},
+			GroupBy: []chplan.Expr{&chplan.ColumnRef{Name: "job"}},
+			AggFuncs: []chplan.AggFunc{
+				{Name: "sum", Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}, Alias: "sum_value"},
+			},
+		},
+		Predicate: &chplan.Binary{
+			Op:    chplan.OpEq,
+			Left:  &chplan.ColumnRef{Name: "job"},
+			Right: &chplan.LitString{V: "api"},
+		},
+	},
+
+	// filter_aggregate_transpose_blocked: predicate touches the
+	// aggregate-output column `sum_value`, which doesn't exist in the
+	// Aggregate's input. The R3.2 rule declines; optimized SQL is
+	// byte-identical to unoptimized.
+	"filter_aggregate_transpose_blocked": &chplan.Filter{
+		Input: &chplan.Aggregate{
+			Input:   &chplan.Scan{Table: "otel_metrics_gauge"},
+			GroupBy: []chplan.Expr{&chplan.ColumnRef{Name: "job"}},
+			AggFuncs: []chplan.AggFunc{
+				{Name: "sum", Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}, Alias: "sum_value"},
+			},
+		},
+		Predicate: &chplan.Binary{
+			Op:    chplan.OpGt,
+			Left:  &chplan.ColumnRef{Name: "sum_value"},
+			Right: &chplan.LitFloat{V: 0},
+		},
+	},
+
 	// subquery_matrix_opaque: a matrix-shape RangeWindow with a
 	// FilterFusion-friendly nested Filter underneath. The optimizer
 	// should fuse the inner two Filters but NOT alter the matrix

--- a/internal/optimizer/rule.go
+++ b/internal/optimizer/rule.go
@@ -38,11 +38,15 @@ func New(rules ...Rule) *Driver {
 // Default returns a Driver configured with all the seed v0.1 rules in a
 // sensible order. The order matters: constant folding may unlock filter
 // fusion (e.g. by collapsing `true AND X` → `X`), which may unlock projection
-// pushdown.
+// pushdown. The two Calcite-style transpose rules added in RC3 R3.2 run
+// after fusion so that adjacent Filters are folded first (giving the
+// transpose a single Filter to push through Project / Aggregate).
 func Default() *Driver {
 	return New(
 		ConstantFold{},
 		FilterFusion{},
+		FilterProjectTranspose(),
+		FilterAggregateTranspose(),
 		ProjectionPushdown{},
 	)
 }

--- a/test/spec/optimizer/filter_aggregate_transpose_blocked.txtar
+++ b/test/spec/optimizer/filter_aggregate_transpose_blocked.txtar
@@ -1,0 +1,4 @@
+-- optimized --
+SELECT * FROM (SELECT `job`, sum(`Value`) AS `sum_value` FROM (SELECT * FROM `otel_metrics_gauge`) GROUP BY `job`) WHERE (`sum_value` > ?)
+-- unoptimized --
+SELECT * FROM (SELECT `job`, sum(`Value`) AS `sum_value` FROM (SELECT * FROM `otel_metrics_gauge`) GROUP BY `job`) WHERE (`sum_value` > ?)

--- a/test/spec/optimizer/filter_aggregate_transpose_passes.txtar
+++ b/test/spec/optimizer/filter_aggregate_transpose_passes.txtar
@@ -1,0 +1,4 @@
+-- optimized --
+SELECT `job`, sum(`Value`) AS `sum_value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`job` = ?)) GROUP BY `job`
+-- unoptimized --
+SELECT * FROM (SELECT `job`, sum(`Value`) AS `sum_value` FROM (SELECT * FROM `otel_metrics_gauge`) GROUP BY `job`) WHERE (`job` = ?)

--- a/test/spec/optimizer/filter_project_transpose_blocked.txtar
+++ b/test/spec/optimizer/filter_project_transpose_blocked.txtar
@@ -1,0 +1,4 @@
+-- optimized --
+SELECT * FROM (SELECT `MetricName` AS `metric` FROM (SELECT `MetricName` FROM `otel_metrics_gauge`)) WHERE (`metric` = ?)
+-- unoptimized --
+SELECT * FROM (SELECT `MetricName` AS `metric` FROM (SELECT * FROM `otel_metrics_gauge`)) WHERE (`metric` = ?)

--- a/test/spec/optimizer/filter_project_transpose_passes.txtar
+++ b/test/spec/optimizer/filter_project_transpose_passes.txtar
@@ -1,0 +1,4 @@
+-- optimized --
+SELECT `MetricName`, `Value` FROM (SELECT * FROM (SELECT * FROM `otel_metrics_gauge`) WHERE (`MetricName` = ?))
+-- unoptimized --
+SELECT * FROM (SELECT `MetricName`, `Value` FROM (SELECT * FROM `otel_metrics_gauge`)) WHERE (`MetricName` = ?)


### PR DESCRIPTION
## Summary

Ships the first two Calcite-style transpose rules on top of the R3.1 `PatternRule` scaffold, per [roadmap.md § RC3 R3.2](docs/roadmap.md). Both rules push a `Filter` past an immediate `Project` / `Aggregate` when the predicate references only passthrough columns of the upstream operator.

- **`FilterProjectTranspose`** — `Filter(Project(X), p)` → `Project(Filter(X, p))`. Lineage: Calcite's [`FilterProjectTransposeRule`](https://calcite.apache.org/javadocAggregate/org/apache/calcite/rel/rules/FilterProjectTransposeRule.html). Lives in `internal/optimizer/filter_project_transpose.go`.
- **`FilterAggregateTranspose`** — `Filter(Aggregate(X), p)` → `Aggregate(Filter(X, p))`. Lineage: Calcite's [`FilterAggregateTransposeRule`](https://calcite.apache.org/javadocAggregate/org/apache/calcite/rel/rules/FilterAggregateTransposeRule.html). Lives in `internal/optimizer/filter_aggregate_transpose.go`.

Built with `PatternRule` (declarative `Match` / `Transform`), not the legacy `Rule.Apply` type-switch — concretely, `WithChildren(Capture("filter", Kind(KindFilter)), Capture("project|aggregate", Kind(...)))`. The R3.1 combinators (`Pattern`, `Kind`, `Capture`, `WithChildren`, `Any`, `Bindings`) covered both rules with no additions.

## Safety conditions

**`FilterProjectTranspose`** allows the rewrite only when every `*chplan.ColumnRef` in the predicate names a column the Project passes through unchanged. Concretely: there must be a `Projection` whose `Expr` is `*chplan.ColumnRef{Name: N}` (no qualifier) and whose `Alias` is empty or equal to `N`. Computed expressions, renamed aliases, qualified column refs, and the empty (`SELECT *`) Project shape all block the rule.

**`FilterAggregateTranspose`** allows the rewrite only when every `*chplan.ColumnRef` in the predicate names a bare group-by key — a `GroupBy[i]` that is itself `*chplan.ColumnRef{Name: N}` (no qualifier), with `GroupByAliases[i]` (if any) empty or equal to `N`. Predicates referencing aggregate-output columns (`sum`, `count`, …) or renamed group keys block the rule. Computed group keys (`substr(X, 1)` etc.) also block.

Predicate column-set traversal reuses the existing `walkExpr` helper in `internal/optimizer/projection_pushdown.go` — no new traversal infrastructure.

## Fixture coverage

Per-rule unit tests in `internal/optimizer/filter_project_transpose_test.go` + `filter_aggregate_transpose_test.go`:

- Passthrough column → rule fires, tree rewrites.
- Project-introduced alias / computed column → rule declines.
- Aggregate-output / renamed group key → rule declines.
- Filter directly over a Scan → no match.
- Alias-matches-name → still fires (no-op rename).

Four TXTAR fixtures under `test/spec/optimizer/` exercise the rules through `optimizer.Default()`:

- `filter_project_transpose_passes.txtar`
- `filter_project_transpose_blocked.txtar`
- `filter_aggregate_transpose_passes.txtar`
- `filter_aggregate_transpose_blocked.txtar`

Each fixture's input plan is wired into the `inputs` map in `optimizer_test.go`. The blocked fixtures' `optimized` SQL is byte-identical to `unoptimized` (or differs only by an orthogonal `ProjectionPushdown` side effect on an inner `Project(Scan)` chain, which is recorded in the fixture).

## Registration

`optimizer.Default()` in `internal/optimizer/rule.go` now registers the two new rules between `FilterFusion` and `ProjectionPushdown`, so adjacent Filters fuse first (single Filter to push) and the seed `ProjectionPushdown` runs last. The three legacy rules (`FilterFusion`, `ConstantFold`, `ProjectionPushdown`) are **untouched** — RC3 R3.5 (analyzer-split) or a separate port lands their migration to `PatternRule`.

## Test plan

- [ ] `check` CI job — `internal/optimizer` unit tests + the four new TXTAR fixtures pass.
- [ ] `lint` CI job — gofumpt + golangci-lint clean.
- [ ] No regression on existing TXTAR fixtures: the new rules only fire on Filter-over-Project / Filter-over-Aggregate shapes, and grep confirms no existing fixture pre-dates that pattern with a passthrough-column predicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)