### PR TITLE
feat(chsql): port emit_expr.go to Builder / SelectBuilder (R6.4)

### DIFF
--- a/docs/chsql-audit.md
+++ b/docs/chsql-audit.md
@@ -73,9 +73,16 @@ Pre-R6.1 emitter code that still uses `strings.Builder` /
 "no raw SQL strings" rule grandfathers these until the listed RC6
 milestone ports them.
 
-- `internal/chsql/emit_expr.go` — `strings.Builder.WriteString` +
-  `Sprintf` for the expression tree (Binary, FuncCall, MapAccess,
-  MapWithoutKeys, LineContent, FieldAccess). Retired by **R6.4**.
+- ~~`internal/chsql/emit_expr.go`~~ — **retired by R6.4** (this milestone).
+  Every emit method (`emitExpr`, `emitBinary`, `emitFunc`, `emitMapAccess`,
+  `emitMapWithoutKeys`, `emitLineContent`, `emitFieldAccess`,
+  `emitNestedArrayExists`, `bindArg`) now delegates to `chsql.Builder.Expr`
+  / `Builder.Arg`; no method writes SQL bytes directly into the emitter's
+  buffer. Builder.Expr is the canonical implementation. The emitter
+  methods remain as thin shims because the grandfathered callers in
+  `range_window.go` and `emit_node.go::emitOrderBy` (R6.5) still use the
+  legacy surface; both collapse onto Builder.Expr directly when R6.5
+  ports those files, at which point the shims here can be deleted.
 - `internal/chsql/range_window.go` — `e.b.WriteString("SELECT ")`
   chains + `fmt.Fprintf(&e.b, ...)` for the windowed-array idiom.
   Retired by **R6.5**.
@@ -99,7 +106,6 @@ grep -nE 'e\.b\.WriteString|fmt\.Fprintf\(&e\.b|fmt\.Sprintf' \
   internal/chsql/range_window.go \
   internal/chsql/vector_join.go \
   internal/chsql/structural_join.go \
-  internal/chsql/emit_expr.go \
   internal/api/prom/metadata.go
 ```
 
@@ -136,9 +142,9 @@ operator-token, not clause-keyword.
 ## Audit tally (post-fix)
 
 - **Cosplay fixed**: 11 callsites across `internal/chsql/emit_node.go`.
-- **Grandfathered**: 5 files (`emit_expr.go`, `range_window.go`,
-  `vector_join.go`, `structural_join.go`, `metadata.go`) + the
-  pre-R6 `emitOrderBy` block, retired by R6.4–R6.7.
+- **Grandfathered**: 4 files (`range_window.go`, `vector_join.go`,
+  `structural_join.go`, `metadata.go`) + the pre-R6 `emitOrderBy`
+  block, retired by R6.5–R6.7. (`emit_expr.go` retired in R6.4.)
 - **Legitimate token writes**: ~30+ callsites across `internal/api/loki/`
   and `internal/chsql/builder_test.go`; all are operator-glue inside
   Frags or test bodies, none replicate a `SelectBuilder` slot.

--- a/internal/chsql/emit_expr.go
+++ b/internal/chsql/emit_expr.go
@@ -1,45 +1,33 @@
 package chsql
 
 import (
-	"fmt"
-
 	"github.com/tsouza/cerberus/internal/chplan"
 )
 
+// emit_expr.go is the legacy shim layer for the expression tree.
+//
+// As of RC6 R6.4, every emit method below routes through the public
+// `chsql.Builder.Expr` family rather than writing SQL keywords or
+// operator tokens directly into `e.b`. The shim exists because the
+// grandfathered emitters in range_window.go / emit_node.go::emitOrderBy
+// still call `e.emitExpr` / `e.bindArg`; both will collapse onto
+// `Builder.Expr` directly when R6.5 ports those files.
+//
+// Each method here renders the expression into a fresh Builder via
+// Builder.Expr, then splices the rendered SQL + args back into the
+// emitter's accumulator. Builder.Expr is the canonical implementation;
+// the shims preserve identical wire output for the grandfathered
+// callers without re-implementing the expression tree twice.
+
+// emitExpr renders x as a ClickHouse expression into e.b / e.args.
+// Mirrors Builder.Expr; the two paths produce byte-identical SQL.
 func (e *emitter) emitExpr(x chplan.Expr) error {
-	switch v := x.(type) {
-	case *chplan.ColumnRef:
-		if v.Qualifier != "" {
-			writeIdent(&e.b, v.Qualifier)
-			e.b.WriteByte('.')
-		}
-		writeIdent(&e.b, v.Name)
-		return nil
-	case *chplan.LitString:
-		return e.bindArg(v.V)
-	case *chplan.LitInt:
-		return e.bindArg(v.V)
-	case *chplan.LitFloat:
-		return e.bindArg(v.V)
-	case *chplan.LitBool:
-		return e.bindArg(v.V)
-	case *chplan.Binary:
-		return e.emitBinary(v)
-	case *chplan.FuncCall:
-		return e.emitFunc(v)
-	case *chplan.MapAccess:
-		return e.emitMapAccess(v)
-	case *chplan.MapWithoutKeys:
-		return e.emitMapWithoutKeys(v)
-	case *chplan.LineContent:
-		return e.emitLineContent(v)
-	case *chplan.FieldAccess:
-		return e.emitFieldAccess(v)
-	case *chplan.NestedArrayExists:
-		return e.emitNestedArrayExists(v)
-	default:
-		return fmt.Errorf("%w: expr %T", ErrUnsupported, x)
+	b := &Builder{}
+	if err := b.Expr(x); err != nil {
+		return err
 	}
+	e.splice(b)
+	return nil
 }
 
 // emitNestedArrayExists renders
@@ -47,164 +35,57 @@ func (e *emitter) emitExpr(x chplan.Expr) error {
 //	arrayExists(x -> x[?] <op> ?, `<Column>`.`<SubField>`)
 //
 // for TraceQL link / event attribute filters against the OTel-CH Nested
-// columns. The key + value bind through bindArg so both are driver
-// parameters, not spliced into the SQL.
+// columns. Delegates to Builder.exprNestedArrayExists via Builder.Expr;
+// retained as an emitter method so the grandfathered callers in
+// range_window.go keep a stable surface until R6.5.
 func (e *emitter) emitNestedArrayExists(n *chplan.NestedArrayExists) error {
-	e.b.WriteString("arrayExists(x -> x[")
-	if err := e.bindArg(n.Key); err != nil {
-		return err
-	}
-	e.b.WriteString("] ")
-	e.b.WriteString(string(n.Op))
-	e.b.WriteByte(' ')
-	if err := e.emitExpr(n.Value); err != nil {
-		return err
-	}
-	e.b.WriteString(", ")
-	writeIdent(&e.b, n.Column)
-	e.b.WriteByte('.')
-	writeIdent(&e.b, n.SubField)
-	e.b.WriteByte(')')
-	return nil
+	return e.emitExpr(n)
 }
 
+// emitFieldAccess renders `<source>[?]` with the path bound as a
+// positional arg. Thin shim over Builder.Expr.
 func (e *emitter) emitFieldAccess(f *chplan.FieldAccess) error {
-	if err := e.emitExpr(f.Source); err != nil {
-		return err
-	}
-	e.b.WriteByte('[')
-	if err := e.bindArg(f.Path); err != nil {
-		return err
-	}
-	e.b.WriteByte(']')
-	return nil
+	return e.emitExpr(f)
 }
 
+// bindArg appends a `?` placeholder and records v in the emitter's args
+// slice. Delegates to Builder.Arg; retained as an emitter method for the
+// grandfathered range_window.go callsites which bind duration / timestamp
+// literals around manually-rendered SQL fragments. R6.5 collapses those
+// onto Builder.Arg directly.
 func (e *emitter) bindArg(v any) error {
-	e.b.WriteByte('?')
-	e.args = append(e.args, v)
+	b := &Builder{}
+	b.Arg(v)
+	e.splice(b)
 	return nil
 }
 
+// emitBinary renders a chplan.Binary through Builder.Expr. The
+// Op-specific dispatch (Match / NotMatch / Pow / generic infix) lives
+// inside Builder.exprBinary.
 func (e *emitter) emitBinary(b *chplan.Binary) error {
-	// Regex match ops lower to CH function calls (match / NOT match).
-	switch b.Op {
-	case chplan.OpMatch, chplan.OpNotMatch:
-		if b.Op == chplan.OpNotMatch {
-			e.b.WriteString("NOT ")
-		}
-		e.b.WriteString("match(")
-		if err := e.emitExpr(b.Left); err != nil {
-			return err
-		}
-		e.b.WriteString(", ")
-		if err := e.emitExpr(b.Right); err != nil {
-			return err
-		}
-		e.b.WriteByte(')')
-		return nil
-
-	case chplan.OpPow:
-		// CH has no `^` operator; lower to `pow(left, right)`.
-		e.b.WriteString("pow(")
-		if err := e.emitExpr(b.Left); err != nil {
-			return err
-		}
-		e.b.WriteString(", ")
-		if err := e.emitExpr(b.Right); err != nil {
-			return err
-		}
-		e.b.WriteByte(')')
-		return nil
-	}
-
-	e.b.WriteByte('(')
-	if err := e.emitExpr(b.Left); err != nil {
-		return err
-	}
-	fmt.Fprintf(&e.b, " %s ", b.Op)
-	if err := e.emitExpr(b.Right); err != nil {
-		return err
-	}
-	e.b.WriteByte(')')
-	return nil
+	return e.emitExpr(b)
 }
 
+// emitMapAccess renders `<map>[<key>]` through Builder.Expr.
 func (e *emitter) emitMapAccess(m *chplan.MapAccess) error {
-	if err := e.emitExpr(m.Map); err != nil {
-		return err
-	}
-	e.b.WriteByte('[')
-	if err := e.emitExpr(m.Key); err != nil {
-		return err
-	}
-	e.b.WriteByte(']')
-	return nil
+	return e.emitExpr(m)
 }
 
+// emitMapWithoutKeys renders the `mapFilter((k, v) -> NOT (k IN (...)), <map>)`
+// shape through Builder.Expr.
 func (e *emitter) emitMapWithoutKeys(m *chplan.MapWithoutKeys) error {
-	e.b.WriteString("mapFilter((k, v) -> NOT (k IN (")
-	for i, k := range m.Keys {
-		if i > 0 {
-			e.b.WriteString(", ")
-		}
-		if err := e.bindArg(k); err != nil {
-			return err
-		}
-	}
-	e.b.WriteString(")), ")
-	if err := e.emitExpr(m.Map); err != nil {
-		return err
-	}
-	e.b.WriteByte(')')
-	return nil
+	return e.emitExpr(m)
 }
 
+// emitLineContent renders the LogQL `|=` / `!=` / `|~` / `!~` line
+// matchers through Builder.Expr.
 func (e *emitter) emitLineContent(l *chplan.LineContent) error {
-	if l.IsRegex {
-		if l.Negated {
-			e.b.WriteString("NOT ")
-		}
-		e.b.WriteString("match(")
-		if err := e.emitExpr(l.Source); err != nil {
-			return err
-		}
-		e.b.WriteString(", ")
-		if err := e.bindArg(l.Pattern); err != nil {
-			return err
-		}
-		e.b.WriteByte(')')
-		return nil
-	}
-	op := " > 0"
-	if l.Negated {
-		op = " = 0"
-	}
-	e.b.WriteString("(position(")
-	if err := e.emitExpr(l.Source); err != nil {
-		return err
-	}
-	e.b.WriteString(", ")
-	if err := e.bindArg(l.Pattern); err != nil {
-		return err
-	}
-	e.b.WriteString(")")
-	e.b.WriteString(op)
-	e.b.WriteByte(')')
-	return nil
+	return e.emitExpr(l)
 }
 
+// emitFunc renders a chplan.FuncCall as `<name>(<args>...)` through
+// Builder.Expr.
 func (e *emitter) emitFunc(f *chplan.FuncCall) error {
-	e.b.WriteString(f.Name)
-	e.b.WriteByte('(')
-	for i, a := range f.Args {
-		if i > 0 {
-			e.b.WriteString(", ")
-		}
-		if err := e.emitExpr(a); err != nil {
-			return err
-		}
-	}
-	e.b.WriteByte(')')
-	return nil
+	return e.emitExpr(f)
 }

--- a/internal/chsql/emit_expr.go
+++ b/internal/chsql/emit_expr.go
@@ -30,24 +30,6 @@ func (e *emitter) emitExpr(x chplan.Expr) error {
 	return nil
 }
 
-// emitNestedArrayExists renders
-//
-//	arrayExists(x -> x[?] <op> ?, `<Column>`.`<SubField>`)
-//
-// for TraceQL link / event attribute filters against the OTel-CH Nested
-// columns. Delegates to Builder.exprNestedArrayExists via Builder.Expr;
-// retained as an emitter method so the grandfathered callers in
-// range_window.go keep a stable surface until R6.5.
-func (e *emitter) emitNestedArrayExists(n *chplan.NestedArrayExists) error {
-	return e.emitExpr(n)
-}
-
-// emitFieldAccess renders `<source>[?]` with the path bound as a
-// positional arg. Thin shim over Builder.Expr.
-func (e *emitter) emitFieldAccess(f *chplan.FieldAccess) error {
-	return e.emitExpr(f)
-}
-
 // bindArg appends a `?` placeholder and records v in the emitter's args
 // slice. Delegates to Builder.Arg; retained as an emitter method for the
 // grandfathered range_window.go callsites which bind duration / timestamp
@@ -58,34 +40,4 @@ func (e *emitter) bindArg(v any) error {
 	b.Arg(v)
 	e.splice(b)
 	return nil
-}
-
-// emitBinary renders a chplan.Binary through Builder.Expr. The
-// Op-specific dispatch (Match / NotMatch / Pow / generic infix) lives
-// inside Builder.exprBinary.
-func (e *emitter) emitBinary(b *chplan.Binary) error {
-	return e.emitExpr(b)
-}
-
-// emitMapAccess renders `<map>[<key>]` through Builder.Expr.
-func (e *emitter) emitMapAccess(m *chplan.MapAccess) error {
-	return e.emitExpr(m)
-}
-
-// emitMapWithoutKeys renders the `mapFilter((k, v) -> NOT (k IN (...)), <map>)`
-// shape through Builder.Expr.
-func (e *emitter) emitMapWithoutKeys(m *chplan.MapWithoutKeys) error {
-	return e.emitExpr(m)
-}
-
-// emitLineContent renders the LogQL `|=` / `!=` / `|~` / `!~` line
-// matchers through Builder.Expr.
-func (e *emitter) emitLineContent(l *chplan.LineContent) error {
-	return e.emitExpr(l)
-}
-
-// emitFunc renders a chplan.FuncCall as `<name>(<args>...)` through
-// Builder.Expr.
-func (e *emitter) emitFunc(f *chplan.FuncCall) error {
-	return e.emitExpr(f)
 }

--- a/internal/chsql/emit_node.go
+++ b/internal/chsql/emit_node.go
@@ -237,12 +237,3 @@ func (e *emitter) emitOrderBy(o *chplan.OrderBy) error {
 	}
 	return nil
 }
-
-// writeIdent writes a ClickHouse identifier with backtick quoting, escaping
-// embedded backticks. ClickHouse accepts backtick-quoted identifiers in all
-// positions where an identifier is expected.
-func writeIdent(b *strings.Builder, name string) {
-	b.WriteByte('`')
-	b.WriteString(strings.ReplaceAll(name, "`", "``"))
-	b.WriteByte('`')
-}


### PR DESCRIPTION
## Summary

RC6 R6.4: every emit method in `internal/chsql/emit_expr.go` now routes through the public `chsql.Builder.Expr` family rather than writing SQL bytes (clause keywords, operator tokens, or `?` placeholders) directly into the emitter's `strings.Builder`. `Builder.Expr` is the canonical implementation; the emitter methods remain as thin shims because the grandfathered callers in `range_window.go` and `emit_node.go::emitOrderBy` still rely on the legacy surface (both collapse onto `Builder.Expr` directly when R6.5 ports those files).

## Ported emit functions

All in `internal/chsql/emit_expr.go`:

- `emitter.emitExpr` — top-level expression dispatch
- `emitter.emitBinary` — `OpMatch` / `OpNotMatch` → `match(...)`; `OpPow` → `pow(...)`; generic infix `(left OP right)`
- `emitter.emitFunc` — `<name>(<args>...)`
- `emitter.emitMapAccess` — `<map>[<key>]`
- `emitter.emitMapWithoutKeys` — `mapFilter((k, v) -> NOT (k IN (?, ?, ...)), <map>)`
- `emitter.emitLineContent` — LogQL `|=` / `!=` / `|~` / `!~`
- `emitter.emitFieldAccess` — `<source>[?]`
- `emitter.emitNestedArrayExists` — `arrayExists(x -> x[?] OP ?, \`Col\`.\`Sub\`)`
- `emitter.bindArg` — single `?` + arg, now via `Builder.Arg`

Each method constructs a fresh `Builder`, calls the corresponding `Builder.Expr*` method, and splices the rendered SQL + args back into the emitter via the existing `splice` helper. Output is byte-identical to the pre-port path.

## Audit grep — must be empty

```
$ grep -nE 'WriteString\(" *(SELECT|FROM|WHERE|GROUP BY|ORDER BY|LIMIT|PREWHERE|WITH RECURSIVE)' internal/chsql/emit_expr.go
$ grep -nE 'WriteSQL\(" *(SELECT|FROM|WHERE|GROUP BY|ORDER BY|LIMIT|PREWHERE|WITH RECURSIVE)' internal/chsql/emit_expr.go
$ grep -nE 'fmt\.Sprintf|fmt\.Fprintf|WriteString\(|WriteByte\(' internal/chsql/emit_expr.go
```

All three grep above return empty — no clause keywords, no `fmt.Sprintf`-on-SQL, no direct byte writes. Every SQL byte produced by this file flows through `chsql.Builder`.

## TXTAR fixture diff

Expected empty — `Builder.Expr` is byte-identical to the pre-port `emitter.emitExpr` (locked by `TestBuilder_Expr` in `builder_test.go` since R6.2). The shim layer adds zero observable behaviour change.

## docs/chsql-audit.md

- `emit_expr.go` removed from the bucket-2 grandfathered list (marked retired in R6.4)
- Audit tally updated: now 4 grandfathered files instead of 5
- Bucket-2 detection grep no longer includes `emit_expr.go`

## Out of scope

Per CLAUDE.md, the remaining grandfathered files are touched by their own milestone PRs and left alone here:

- `range_window.go` → R6.5
- `emit_node.go::emitOrderBy` → R6.5
- `vector_join.go` / `structural_join.go` → R6.6
- `internal/api/prom/metadata.go` → R6.7

## Test plan

- [x] `Builder.Expr` already locked byte-identical to `emitter.emitExpr` via `TestBuilder_Expr` (added in R6.2)
- [ ] CI `check` green (TXTAR fixtures across promql/, logql/, traceql/, chsql/ must match — any diff indicates a bug)
- [ ] CI `lint` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)