### PR TITLE
feat(api/prom): port metadata.go SQL to Builder / SelectBuilder (R6.7)

### DIFF
--- a/internal/api/prom/metadata.go
+++ b/internal/api/prom/metadata.go
@@ -563,9 +563,9 @@ func distinctMapAtFrag(col, key string) chsql.Frag {
 	}
 }
 
-// mapAtNotEmptyFrag emits `<col>[?] != ''` — the WHERE predicate that
+// mapAtNotEmptyFrag emits `<col>[?] != ”` — the WHERE predicate that
 // drops the empty-string sentinel CH returns when a Map key is absent.
-// The empty string is rendered as a literal `''` (not parameterised)
+// The empty string is rendered as a literal `”` (not parameterised)
 // because it is part of the query shape: the "key-absent" sentinel is
 // a fixed value, not user data, and CH planner pruning relies on it
 // being visible at plan time.
@@ -608,4 +608,3 @@ func validLabelName(s string) bool {
 	}
 	return true
 }
-

--- a/internal/api/prom/metadata.go
+++ b/internal/api/prom/metadata.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"sort"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/prometheus/common/model"
@@ -163,21 +162,34 @@ func (h *Handler) fetchMetricMeta(ctx context.Context, metricName string) ([]chc
 // (MetricName, MetricDescription, MetricUnit). When metricName is empty
 // we list all distinct metrics; otherwise we filter to the named one.
 func (h *Handler) metricMetaSQL(table, metricName string) (string, []any) {
-	nameCol := quoteIdentCH(h.Schema.MetricNameColumn)
-	descCol := quoteIdentCH(h.Schema.MetricDescriptionColumn)
-	unitCol := quoteIdentCH(h.Schema.MetricUnitColumn)
-	tbl := quoteIdentCH(table)
+	nameCol := h.Schema.MetricNameColumn
+	descCol := h.Schema.MetricDescriptionColumn
+	unitCol := h.Schema.MetricUnitColumn
+
+	anyCall := func(col string) chsql.Frag {
+		return func(b *chsql.Builder) {
+			b.WriteSQL("any(")
+			b.Ident(col)
+			b.WriteSQL(")")
+		}
+	}
+
+	sb := chsql.NewSelect().
+		Select(chsql.Col(nameCol), anyCall(descCol), anyCall(unitCol)).
+		From(chsql.Col(table)).
+		GroupBy(chsql.Col(nameCol))
 
 	if metricName == "" {
-		return fmt.Sprintf(
-			"SELECT %s, any(%s), any(%s) FROM %s GROUP BY %s ORDER BY %s",
-			nameCol, descCol, unitCol, tbl, nameCol, nameCol,
-		), nil
+		sb.OrderBy(chsql.Col(nameCol), false)
+		sql, args := sb.Build()
+		return sql, args
 	}
-	return fmt.Sprintf(
-		"SELECT %s, any(%s), any(%s) FROM %s WHERE %s = ? GROUP BY %s",
-		nameCol, descCol, unitCol, tbl, nameCol, nameCol,
-	), []any{metricName}
+	sb.Where(func(b *chsql.Builder) {
+		b.Ident(nameCol)
+		b.WriteSQL(" = ")
+		b.Arg(metricName)
+	})
+	return sb.Build()
 }
 
 // parseLimit decodes the `limit` query parameter — a positive integer.
@@ -348,9 +360,13 @@ func (h *Handler) labelKeysForMatcher(ctx context.Context, matcher string) ([]st
 	if err != nil {
 		return nil, err
 	}
-	attrs := quoteIdentCH(h.Schema.AttributesColumn)
-	sql := fmt.Sprintf("SELECT DISTINCT arrayJoin(mapKeys(%s)) AS name FROM (%s) ORDER BY name",
-		attrs, innerSQL)
+	attrsCol := h.Schema.AttributesColumn
+
+	sb := chsql.NewSelect().
+		Select(chsql.As(arrayJoinMapKeysFrag(attrsCol), "name")).
+		From(parenRawFrag(innerSQL)).
+		OrderBy(chsql.Col("name"), false)
+	sql, _ := sb.Build()
 	return timeCH(ctx, func() ([]string, error) {
 		return h.Client.QueryStrings(ctx, sql, args...)
 	})
@@ -364,19 +380,36 @@ func (h *Handler) labelValuesForMatcher(ctx context.Context, name, matcher strin
 	if err != nil {
 		return nil, err
 	}
-	var sql string
 	if name == model.MetricNameLabel {
-		sql = fmt.Sprintf("SELECT DISTINCT %s AS value FROM (%s) ORDER BY value",
-			quoteIdentCH(h.Schema.MetricNameColumn), innerSQL)
-	} else {
-		attrs := quoteIdentCH(h.Schema.AttributesColumn)
-		sql = fmt.Sprintf("SELECT DISTINCT %s[?] AS value FROM (%s) WHERE %s[?] != '' ORDER BY value",
-			attrs, innerSQL, attrs)
-		args = append([]any{name}, args...)
-		args = append(args, name)
+		sb := chsql.NewSelect().
+			Select(chsql.As(distinctIdent(h.Schema.MetricNameColumn), "value")).
+			From(parenRawFrag(innerSQL)).
+			OrderBy(chsql.Col("value"), false)
+		sql, _ := sb.Build()
+		return timeCH(ctx, func() ([]string, error) {
+			return h.Client.QueryStrings(ctx, sql, args...)
+		})
 	}
+	attrsCol := h.Schema.AttributesColumn
+	sb := chsql.NewSelect().
+		Select(chsql.As(distinctMapAtFrag(attrsCol, name), "value")).
+		From(parenRawFrag(innerSQL)).
+		Where(mapAtNotEmptyFrag(attrsCol, name)).
+		OrderBy(chsql.Col("value"), false)
+	sql, valueArgs := sb.Build()
+	// valueArgs holds the `name` bound twice (SELECT then WHERE);
+	// the matcher's args slot between them at the original order:
+	//   <name (SELECT)>, <matcher args (FROM subquery)>, <name (WHERE)>.
+	// SelectBuilder renders SELECT before FROM before WHERE, so
+	// valueArgs is [name, name] (no `?` inside the FROM subquery raw
+	// text). Splice the matcher args at the FROM position by
+	// reconstructing the final slice.
+	combined := make([]any, 0, len(valueArgs)+len(args))
+	combined = append(combined, valueArgs[0]) // SELECT bind
+	combined = append(combined, args...)      // matcher subquery binds
+	combined = append(combined, valueArgs[1]) // WHERE bind
 	return timeCH(ctx, func() ([]string, error) {
-		return h.Client.QueryStrings(ctx, sql, args...)
+		return h.Client.QueryStrings(ctx, sql, combined...)
 	})
 }
 
@@ -431,26 +464,39 @@ func (h *Handler) fetchSeries(ctx context.Context, matcher string) ([]map[string
 // unionLabelNamesSQL builds a UNION of all metric tables' label keys.
 func (h *Handler) unionLabelNamesSQL() string {
 	tables := h.metricTables()
-	parts := make([]string, 0, len(tables))
-	attrsCol := quoteIdentCH(h.Schema.AttributesColumn)
+	attrsCol := h.Schema.AttributesColumn
+	parts := make([]chsql.Frag, 0, len(tables))
 	for _, t := range tables {
-		parts = append(parts,
-			fmt.Sprintf("SELECT DISTINCT arrayJoin(mapKeys(%s)) AS name FROM %s",
-				attrsCol, quoteIdentCH(t)))
+		arm := chsql.NewSelect().
+			Select(chsql.As(arrayJoinMapKeysFrag(attrsCol), "name")).
+			From(chsql.Col(t))
+		parts = append(parts, arm.Frag())
 	}
-	return "SELECT DISTINCT name FROM (" + strings.Join(parts, " UNION ALL ") + ") ORDER BY name"
+	outer := chsql.NewSelect().
+		Select(chsql.As(distinctIdent("name"), "")).
+		From(chsql.UnionAll(parts...)).
+		OrderBy(chsql.Col("name"), false)
+	sql, _ := outer.Build()
+	return sql
 }
 
 // unionMetricNamesSQL returns the distinct MetricName values across tables.
 func (h *Handler) unionMetricNamesSQL() string {
 	tables := h.metricTables()
-	metricCol := quoteIdentCH(h.Schema.MetricNameColumn)
-	parts := make([]string, 0, len(tables))
+	metricCol := h.Schema.MetricNameColumn
+	parts := make([]chsql.Frag, 0, len(tables))
 	for _, t := range tables {
-		parts = append(parts, fmt.Sprintf("SELECT DISTINCT %s AS value FROM %s",
-			metricCol, quoteIdentCH(t)))
+		arm := chsql.NewSelect().
+			Select(chsql.As(distinctIdent(metricCol), "value")).
+			From(chsql.Col(t))
+		parts = append(parts, arm.Frag())
 	}
-	return "SELECT DISTINCT value FROM (" + strings.Join(parts, " UNION ALL ") + ") ORDER BY value"
+	outer := chsql.NewSelect().
+		Select(chsql.As(distinctIdent("value"), "")).
+		From(chsql.UnionAll(parts...)).
+		OrderBy(chsql.Col("value"), false)
+	sql, _ := outer.Build()
+	return sql
 }
 
 // unionLabelValuesSQL returns the distinct Attributes[?] values across
@@ -459,16 +505,20 @@ func (h *Handler) unionMetricNamesSQL() string {
 // (twice: in SELECT and WHERE) — args lists it 2*N times.
 func (h *Handler) unionLabelValuesSQL(name string) (string, []any) {
 	tables := h.metricTables()
-	attrsCol := quoteIdentCH(h.Schema.AttributesColumn)
-	parts := make([]string, 0, len(tables))
-	args := make([]any, 0, len(tables)*2)
+	attrsCol := h.Schema.AttributesColumn
+	parts := make([]chsql.Frag, 0, len(tables))
 	for _, t := range tables {
-		parts = append(parts,
-			fmt.Sprintf("SELECT DISTINCT %s[?] AS value FROM %s WHERE %s[?] != ''",
-				attrsCol, quoteIdentCH(t), attrsCol))
-		args = append(args, name, name)
+		arm := chsql.NewSelect().
+			Select(chsql.As(distinctMapAtFrag(attrsCol, name), "value")).
+			From(chsql.Col(t)).
+			Where(mapAtNotEmptyFrag(attrsCol, name))
+		parts = append(parts, arm.Frag())
 	}
-	return "SELECT DISTINCT value FROM (" + strings.Join(parts, " UNION ALL ") + ") ORDER BY value", args
+	outer := chsql.NewSelect().
+		Select(chsql.As(distinctIdent("value"), "")).
+		From(chsql.UnionAll(parts...)).
+		OrderBy(chsql.Col("value"), false)
+	return outer.Build()
 }
 
 // metricTables returns the configured metric-table names in a stable
@@ -478,6 +528,64 @@ func (h *Handler) metricTables() []string {
 		h.Schema.GaugeTable,
 		h.Schema.SumTable,
 		h.Schema.HistogramTable,
+	}
+}
+
+// arrayJoinMapKeysFrag emits `arrayJoin(mapKeys(<col>))` — the CH idiom
+// for fanning out a Map column's key set as one row per key.
+func arrayJoinMapKeysFrag(col string) chsql.Frag {
+	return func(b *chsql.Builder) {
+		b.WriteSQL("arrayJoin(")
+		b.MapKeys(col)
+		b.WriteSQL(")")
+	}
+}
+
+// distinctIdent emits `DISTINCT <col>` as a SELECT-list expression. The
+// DISTINCT keyword is a SELECT modifier in standard SQL but ClickHouse
+// (like every modern engine) accepts it inline at the head of the
+// SELECT list and renders identical query plans either way. Putting it
+// in the projection slot keeps it inside the typed Frag surface.
+func distinctIdent(col string) chsql.Frag {
+	return func(b *chsql.Builder) {
+		b.WriteSQL("DISTINCT ")
+		b.Ident(col)
+	}
+}
+
+// distinctMapAtFrag emits `DISTINCT <col>[?]` and binds key as a
+// positional argument — the projection shape for "distinct values of
+// label <key> stored in the Attributes map".
+func distinctMapAtFrag(col, key string) chsql.Frag {
+	return func(b *chsql.Builder) {
+		b.WriteSQL("DISTINCT ")
+		b.MapAt(col, key)
+	}
+}
+
+// mapAtNotEmptyFrag emits `<col>[?] != ''` — the WHERE predicate that
+// drops the empty-string sentinel CH returns when a Map key is absent.
+// The empty string is rendered as a literal `''` (not parameterised)
+// because it is part of the query shape: the "key-absent" sentinel is
+// a fixed value, not user data, and CH planner pruning relies on it
+// being visible at plan time.
+func mapAtNotEmptyFrag(col, key string) chsql.Frag {
+	return func(b *chsql.Builder) {
+		b.MapAt(col, key)
+		b.WriteSQL(" != ''")
+	}
+}
+
+// parenRawFrag wraps an already-rendered SQL string in parentheses for
+// use as a SelectBuilder FROM subquery. The wrapped SQL is treated as
+// opaque text — its own `?` placeholders pass through verbatim and the
+// caller is responsible for ordering its args ahead of any further
+// `?` bindings the outer SelectBuilder emits.
+func parenRawFrag(sql string) chsql.Frag {
+	return func(b *chsql.Builder) {
+		b.WriteSQL("(")
+		b.WriteSQL(sql)
+		b.WriteSQL(")")
 	}
 }
 
@@ -501,12 +609,3 @@ func validLabelName(s string) bool {
 	return true
 }
 
-// quoteIdentCH backtick-quotes a CH identifier; thin local helper since
-// chsql.writeIdent is unexported.
-func quoteIdentCH(name string) string {
-	var b strings.Builder
-	b.WriteByte('`')
-	b.WriteString(strings.ReplaceAll(name, "`", "``"))
-	b.WriteByte('`')
-	return b.String()
-}

--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -444,6 +444,36 @@ func Raw(sql string) Frag {
 	return func(b *Builder) { b.sb.WriteString(sql) }
 }
 
+// UnionAll joins one or more Frags with " UNION ALL " between them. It
+// is the typed alternative to `strings.Join(parts, " UNION ALL ")` —
+// keeping the keyword inside the typed surface so the audit grep for
+// clause-keyword cosplay stays clean. Each part is rendered in order
+// and its `?` args bind at the position they're emitted.
+//
+// UNION is a SELECT-level binary operator (mirrors the SetUnion path
+// in set_op.go), not a clause inside a single SELECT, so it lives as
+// a standalone Frag constructor rather than a SelectBuilder slot.
+//
+// Typical use: pass SelectBuilder.Frag() values as parts so each arm
+// renders as a parenthesised (SELECT …) and the whole UnionAll Frag
+// is plugged into the outer SelectBuilder.From slot.
+//
+// Zero parts is a programmer error and panics; one part is rendered
+// unchanged (no UNION keyword emitted).
+func UnionAll(parts ...Frag) Frag {
+	if len(parts) == 0 {
+		panic("chsql: UnionAll requires at least one part")
+	}
+	return func(b *Builder) {
+		for i, p := range parts {
+			if i > 0 {
+				b.sb.WriteString(" UNION ALL ")
+			}
+			p(b)
+		}
+	}
+}
+
 // As wraps expr in "<expr> AS <alias>" with the alias backtick-quoted.
 // The typed alternative to `b.WriteSQL(" AS "); b.Ident(alias)`; using
 // As keeps the AS keyword inside the typed surface so the audit grep

--- a/internal/chsql/builder_test.go
+++ b/internal/chsql/builder_test.go
@@ -356,6 +356,73 @@ func TestAs_WrapsWithAlias(t *testing.T) {
 	}
 }
 
+// TestUnionAll_JoinsParts — UnionAll joins multiple Frags with the
+// " UNION ALL " keyword in stream order, and args bound inside each
+// part land at the position they're emitted.
+func TestUnionAll_JoinsParts(t *testing.T) {
+	t.Parallel()
+
+	left := chsql.NewSelect().
+		Select(chsql.Col("MetricName")).
+		From(chsql.Col("gauge")).
+		Where(func(b *chsql.Builder) {
+			b.Ident("MetricName")
+			b.WriteSQL(" = ")
+			b.Arg("a")
+		})
+	right := chsql.NewSelect().
+		Select(chsql.Col("MetricName")).
+		From(chsql.Col("sum")).
+		Where(func(b *chsql.Builder) {
+			b.Ident("MetricName")
+			b.WriteSQL(" = ")
+			b.Arg("b")
+		})
+
+	b := chsql.NewBuilder()
+	chsql.UnionAll(left.Frag(), right.Frag())(b)
+	sql, args := b.Build()
+	want := "(SELECT `MetricName` FROM `gauge` WHERE `MetricName` = ?)" +
+		" UNION ALL " +
+		"(SELECT `MetricName` FROM `sum` WHERE `MetricName` = ?)"
+	if sql != want {
+		t.Errorf("UnionAll = %q; want %q", sql, want)
+	}
+	wantArgs := []any{"a", "b"}
+	if !reflect.DeepEqual(args, wantArgs) {
+		t.Errorf("Args = %v; want %v", args, wantArgs)
+	}
+}
+
+// TestUnionAll_SinglePart — one part renders without the UNION ALL
+// keyword (the join separator only applies between parts).
+func TestUnionAll_SinglePart(t *testing.T) {
+	t.Parallel()
+
+	only := chsql.NewSelect().
+		Select(chsql.Col("x")).
+		From(chsql.Col("t"))
+
+	b := chsql.NewBuilder()
+	chsql.UnionAll(only.Frag())(b)
+	if got, want := b.String(), "(SELECT `x` FROM `t`)"; got != want {
+		t.Errorf("UnionAll(single) = %q; want %q", got, want)
+	}
+}
+
+// TestUnionAll_PanicsOnEmpty — UnionAll with zero parts is a
+// programmer error.
+func TestUnionAll_PanicsOnEmpty(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic on UnionAll()")
+		}
+	}()
+	chsql.UnionAll()
+}
+
 // TestSelectBuilder_SelectAs — SelectAs slot adds "<expr> AS <alias>"
 // to the SELECT list without composing the AS keyword by hand at the
 // call site.


### PR DESCRIPTION
## Summary

Retires the last grandfathered `fmt.Sprintf`-on-SQL surface listed in
[`docs/chsql-audit.md` § Bucket 2](../blob/main/docs/chsql-audit.md):
every SELECT / UNION builder in `internal/api/prom/metadata.go` now
flows through `chsql.SelectBuilder` + typed `Frag` helpers. The local
`quoteIdentCH` backtick helper is gone — `Builder.Ident` covers it.

Pulls R6.7 forward (the maintainer wants the entire grandfathered
surface unified now). The remaining grandfathered files
(`emit_expr.go`, `range_window.go`, `vector_join.go`,
`structural_join.go`) are R6.4 / R6.5 / R6.6 and not touched here.

## New typed helper

- **`chsql.UnionAll(parts ...Frag) Frag`** — joins parts with
  `" UNION ALL "`. UNION is a SELECT-level binary operator (mirrors
  the `SetUnion` path in `set_op.go`), so it lives as a standalone
  Frag constructor rather than a `SelectBuilder` slot — each part is
  rendered in order and its `?` args bind at the position they're
  emitted. Zero parts panics; single part renders unchanged.

  Picked the standalone form over a `SelectBuilder.Union(other,
  distinct bool)` method because `SelectBuilder` is the "single
  SELECT" abstraction and `set_op.go` already uses the
  "two-`Frag()`-with-a-keyword-between" idiom for `UNION DISTINCT`.

## Ported functions in metadata.go

- `metricMetaSQL` — `SELECT name, any(desc), any(unit) FROM <tbl>
  [WHERE name = ?] GROUP BY name [ORDER BY name]`
- `unionLabelNamesSQL` — `SELECT DISTINCT name FROM (UNION ALL of
  per-table SELECT DISTINCT arrayJoin(mapKeys(Attributes)) AS name)`
- `unionMetricNamesSQL` — `SELECT DISTINCT value FROM (UNION ALL of
  per-table SELECT DISTINCT MetricName AS value)`
- `unionLabelValuesSQL` — `SELECT DISTINCT value FROM (UNION ALL of
  per-table SELECT DISTINCT Attributes[?] AS value WHERE
  Attributes[?] != '')`
- `labelKeysForMatcher` / `labelValuesForMatcher` — outer projection
  + WHERE wrapping the matcher subquery; matcher SQL is wrapped via a
  local `parenRawFrag` (its own `?` args splice in at the FROM
  position).

The `Attributes[?] != ''` sentinel keeps the empty-string as a SQL
literal (not a positional bind) — the value is part of the query
shape (CH planner pruning sees it at plan time) and the existing
`TestLabelValues_Endpoint` asserts every bound arg equals the label
name; binding `""` separately would have broken that assertion.

## Grep audit (post-fix) — all empty over metadata.go

```sh
grep -nE 'fmt\.Sprintf\([^)]*(SELECT|FROM|WHERE|INSERT|GROUP BY|ORDER BY)' \
  internal/api/prom/metadata.go          # → empty
grep -nE 'WriteSQL\(" *(SELECT|FROM|WHERE|GROUP BY|ORDER BY|LIMIT|PREWHERE|HAVING|UNION|JOIN |LEFT JOIN|INNER JOIN)' \
  internal/api/prom/metadata.go          # → empty
grep -nE 'WriteString\([^)]*(SELECT|FROM|WHERE|GROUP BY|ORDER BY|LIMIT|PREWHERE)' \
  internal/api/prom/metadata.go          # → empty
```

The 8 `fmt.Sprintf` SQL callsites + 3 `WriteString` SQL callsites the
audit flagged are all gone.

## Test plan

- [x] Added `TestUnionAll_JoinsParts` / `TestUnionAll_SinglePart` /
  `TestUnionAll_PanicsOnEmpty` in `internal/chsql/builder_test.go`
  for the new helper.
- [x] Existing `internal/api/prom/metadata_test.go` covers every
  ported callsite (substring asserts on `mapKeys` /
  `arrayJoin(mapKeys` / `` Attributes`[?] `` / `MetricName`; args
  comparison ensures the bound-arg ordering survives).
- [ ] CI `check` + `lint` jobs validate gofumpt / golangci-lint / `go
  test -race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)