### PR TITLE
feat(chsql): typed Frag constructors for operators (RC6 R6.11a)

### DIFF
--- a/cmd/check-sql/allowlist.txt
+++ b/cmd/check-sql/allowlist.txt
@@ -13,7 +13,7 @@
 # QueryBuilder.writeInto — the legitimate renderer. Every clause keyword
 # (SELECT / FROM / WHERE / GROUP BY / ORDER BY / LIMIT / PREWHERE /
 # WITH RECURSIVE / JOIN variants) is emitted from here and only here.
-internal/chsql/builder.go:717-811
+internal/chsql/builder.go:890-984
 
 # chsql.UnionAll / UnionDistinct Frags — the typed UNION constructors.
 # The keyword lives here so callers compose unions via Frag composition

--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -507,6 +507,179 @@ func As(expr Frag, alias string) Frag {
 	}
 }
 
+// binOp returns a Frag that renders "<l> <op> <r>" with single spaces
+// around op. Shared shape for the comparison + arithmetic operator
+// constructors below — each typed wrapper just supplies its op token.
+func binOp(op string, l, r Frag) Frag {
+	return func(b *Builder) {
+		l(b)
+		b.sb.WriteByte(' ')
+		b.sb.WriteString(op)
+		b.sb.WriteByte(' ')
+		r(b)
+	}
+}
+
+// Eq returns a Frag rendering "<l> = <r>".
+func Eq(l, r Frag) Frag { return binOp("=", l, r) }
+
+// Neq returns a Frag rendering "<l> != <r>".
+func Neq(l, r Frag) Frag { return binOp("!=", l, r) }
+
+// Gt returns a Frag rendering "<l> > <r>".
+func Gt(l, r Frag) Frag { return binOp(">", l, r) }
+
+// Gte returns a Frag rendering "<l> >= <r>".
+func Gte(l, r Frag) Frag { return binOp(">=", l, r) }
+
+// Lt returns a Frag rendering "<l> < <r>".
+func Lt(l, r Frag) Frag { return binOp("<", l, r) }
+
+// Lte returns a Frag rendering "<l> <= <r>".
+func Lte(l, r Frag) Frag { return binOp("<=", l, r) }
+
+// Like returns a Frag rendering "<l> LIKE <r>".
+func Like(l, r Frag) Frag { return binOp("LIKE", l, r) }
+
+// NotLike returns a Frag rendering "<l> NOT LIKE <r>".
+func NotLike(l, r Frag) Frag { return binOp("NOT LIKE", l, r) }
+
+// And returns a Frag joining parts with " AND ". Panics if parts is empty.
+func And(parts ...Frag) Frag {
+	if len(parts) == 0 {
+		panic("chsql: And requires at least one part")
+	}
+	return func(b *Builder) {
+		for i, p := range parts {
+			if i > 0 {
+				b.sb.WriteString(" AND ")
+			}
+			p(b)
+		}
+	}
+}
+
+// Or returns a Frag joining parts with " OR ". Panics if parts is empty.
+func Or(parts ...Frag) Frag {
+	if len(parts) == 0 {
+		panic("chsql: Or requires at least one part")
+	}
+	return func(b *Builder) {
+		for i, p := range parts {
+			if i > 0 {
+				b.sb.WriteString(" OR ")
+			}
+			p(b)
+		}
+	}
+}
+
+// Not returns a Frag rendering "NOT <f>". No parens are added — the
+// caller wraps with Paren if precedence requires it.
+func Not(f Frag) Frag {
+	return func(b *Builder) {
+		b.sb.WriteString("NOT ")
+		f(b)
+	}
+}
+
+// Add returns a Frag rendering "<l> + <r>".
+func Add(l, r Frag) Frag { return binOp("+", l, r) }
+
+// Sub returns a Frag rendering "<l> - <r>".
+func Sub(l, r Frag) Frag { return binOp("-", l, r) }
+
+// Mul returns a Frag rendering "<l> * <r>".
+func Mul(l, r Frag) Frag { return binOp("*", l, r) }
+
+// Div returns a Frag rendering "<l> / <r>".
+func Div(l, r Frag) Frag { return binOp("/", l, r) }
+
+// Mod returns a Frag rendering "<l> % <r>".
+func Mod(l, r Frag) Frag { return binOp("%", l, r) }
+
+// Neg returns a Frag rendering "-<f>" (no space between the minus and
+// the operand).
+func Neg(f Frag) Frag {
+	return func(b *Builder) {
+		b.sb.WriteByte('-')
+		f(b)
+	}
+}
+
+// Paren returns a Frag rendering "(<f>)" with no inner whitespace.
+func Paren(f Frag) Frag {
+	return func(b *Builder) {
+		b.sb.WriteByte('(')
+		f(b)
+		b.sb.WriteByte(')')
+	}
+}
+
+// Tuple returns a Frag rendering "(<p0>, <p1>, ...)". Panics if parts
+// is empty (an empty tuple is a CH syntax error).
+func Tuple(parts ...Frag) Frag {
+	if len(parts) == 0 {
+		panic("chsql: Tuple requires at least one part")
+	}
+	return func(b *Builder) {
+		b.sb.WriteByte('(')
+		for i, p := range parts {
+			if i > 0 {
+				b.sb.WriteString(", ")
+			}
+			p(b)
+		}
+		b.sb.WriteByte(')')
+	}
+}
+
+// Cast returns a Frag rendering "CAST(<f> AS <typ>)". typ is a CH type
+// name (e.g. "Float64") and is emitted verbatim — same trust contract
+// as Raw, the caller is responsible for ensuring it is a safe literal.
+func Cast(f Frag, typ string) Frag {
+	return func(b *Builder) {
+		b.sb.WriteString("CAST(")
+		f(b)
+		b.sb.WriteString(" AS ")
+		b.sb.WriteString(typ)
+		b.sb.WriteByte(')')
+	}
+}
+
+// Concat returns a Frag rendering parts back-to-back with no separator.
+// For arbitrary glue when callers compose Frags whose internal
+// whitespace they already control. Panics if parts is empty.
+func Concat(parts ...Frag) Frag {
+	if len(parts) == 0 {
+		panic("chsql: Concat requires at least one part")
+	}
+	return func(b *Builder) {
+		for _, p := range parts {
+			p(b)
+		}
+	}
+}
+
+// In returns a Frag rendering "<left> IN (<r0>, <r1>, ...)". Panics if
+// right is empty (an empty IN list is a CH syntax error).
+func In(left Frag, right ...Frag) Frag {
+	if len(right) == 0 {
+		panic("chsql: In requires at least one right-hand part")
+	}
+	return func(b *Builder) {
+		left(b)
+		b.sb.WriteString(" IN (")
+		for i, r := range right {
+			if i > 0 {
+				b.sb.WriteString(", ")
+			}
+			r(b)
+		}
+		b.sb.WriteByte(')')
+	}
+}
+
 // JoinKind identifies a SQL JOIN flavour. The constants render as
 // their literal SQL keywords (e.g. "INNER JOIN") and flow through
 // QueryBuilder.Join's typed slot so callers never compose the join

--- a/internal/chsql/builder_test.go
+++ b/internal/chsql/builder_test.go
@@ -868,3 +868,238 @@ func TestBuilder_Expr(t *testing.T) {
 		})
 	}
 }
+
+// --- typed operator / punctuation Frag constructors (R6.11a) -----------
+
+// TestOperatorFrags_BinaryOps — each comparison + arithmetic operator
+// renders "<l> <op> <r>" with single spaces around the op token, and
+// the Lit-bound argument lands in the args slice in emission order.
+func TestOperatorFrags_BinaryOps(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		frag    chsql.Frag
+		wantSQL string
+	}{
+		{"Eq", chsql.Eq(chsql.Col("a"), chsql.Lit(int64(1))), "`a` = ?"},
+		{"Neq", chsql.Neq(chsql.Col("a"), chsql.Lit(int64(1))), "`a` != ?"},
+		{"Gt", chsql.Gt(chsql.Col("a"), chsql.Lit(int64(1))), "`a` > ?"},
+		{"Gte", chsql.Gte(chsql.Col("a"), chsql.Lit(int64(1))), "`a` >= ?"},
+		{"Lt", chsql.Lt(chsql.Col("a"), chsql.Lit(int64(1))), "`a` < ?"},
+		{"Lte", chsql.Lte(chsql.Col("a"), chsql.Lit(int64(1))), "`a` <= ?"},
+		{"Like", chsql.Like(chsql.Col("a"), chsql.Lit("x%")), "`a` LIKE ?"},
+		{"NotLike", chsql.NotLike(chsql.Col("a"), chsql.Lit("x%")), "`a` NOT LIKE ?"},
+		{"Add", chsql.Add(chsql.Col("a"), chsql.Lit(int64(1))), "`a` + ?"},
+		{"Sub", chsql.Sub(chsql.Col("a"), chsql.Lit(int64(1))), "`a` - ?"},
+		{"Mul", chsql.Mul(chsql.Col("a"), chsql.Lit(int64(2))), "`a` * ?"},
+		{"Div", chsql.Div(chsql.Col("a"), chsql.Lit(int64(2))), "`a` / ?"},
+		{"Mod", chsql.Mod(chsql.Col("a"), chsql.Lit(int64(2))), "`a` % ?"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			b := chsql.NewBuilder()
+			tc.frag(b)
+			if got := b.String(); got != tc.wantSQL {
+				t.Errorf("%s SQL = %q; want %q", tc.name, got, tc.wantSQL)
+			}
+			if len(b.Args()) != 1 {
+				t.Errorf("%s args len = %d; want 1", tc.name, len(b.Args()))
+			}
+		})
+	}
+}
+
+// TestAnd_JoinsParts — And joins predicates with " AND " and binds
+// args in left-to-right order.
+func TestAnd_JoinsParts(t *testing.T) {
+	t.Parallel()
+
+	b := chsql.NewBuilder()
+	chsql.And(
+		chsql.Eq(chsql.Col("a"), chsql.Lit(int64(1))),
+		chsql.Eq(chsql.Col("b"), chsql.Lit(int64(2))),
+		chsql.Eq(chsql.Col("c"), chsql.Lit(int64(3))),
+	)(b)
+	sql, args := b.Build()
+	want := "`a` = ? AND `b` = ? AND `c` = ?"
+	if sql != want {
+		t.Errorf("And SQL = %q; want %q", sql, want)
+	}
+	if !reflect.DeepEqual(args, []any{int64(1), int64(2), int64(3)}) {
+		t.Errorf("And args = %v", args)
+	}
+}
+
+// TestAnd_PanicsOnEmpty — And() with zero parts is a programmer error.
+func TestAnd_PanicsOnEmpty(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic on And()")
+		}
+	}()
+	chsql.And()
+}
+
+// TestOr_JoinsParts — Or joins predicates with " OR ".
+func TestOr_JoinsParts(t *testing.T) {
+	t.Parallel()
+
+	b := chsql.NewBuilder()
+	chsql.Or(
+		chsql.Eq(chsql.Col("a"), chsql.Lit(int64(1))),
+		chsql.Eq(chsql.Col("b"), chsql.Lit(int64(2))),
+	)(b)
+	if got, want := b.String(), "`a` = ? OR `b` = ?"; got != want {
+		t.Errorf("Or SQL = %q; want %q", got, want)
+	}
+}
+
+// TestOr_PanicsOnEmpty — Or() with zero parts is a programmer error.
+func TestOr_PanicsOnEmpty(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic on Or()")
+		}
+	}()
+	chsql.Or()
+}
+
+// TestNot_Prefixes — Not emits "NOT " before the inner Frag and does
+// not add parens; precedence is the caller's responsibility.
+func TestNot_Prefixes(t *testing.T) {
+	t.Parallel()
+
+	b := chsql.NewBuilder()
+	chsql.Not(chsql.Eq(chsql.Col("a"), chsql.Lit(int64(1))))(b)
+	if got, want := b.String(), "NOT `a` = ?"; got != want {
+		t.Errorf("Not SQL = %q; want %q", got, want)
+	}
+}
+
+// TestNeg_Prefixes — Neg emits "-" with no space before the operand.
+func TestNeg_Prefixes(t *testing.T) {
+	t.Parallel()
+
+	b := chsql.NewBuilder()
+	chsql.Neg(chsql.Col("a"))(b)
+	if got, want := b.String(), "-`a`"; got != want {
+		t.Errorf("Neg SQL = %q; want %q", got, want)
+	}
+}
+
+// TestParen_Wraps — Paren wraps the inner Frag with no inner spaces.
+func TestParen_Wraps(t *testing.T) {
+	t.Parallel()
+
+	b := chsql.NewBuilder()
+	chsql.Paren(chsql.Or(
+		chsql.Eq(chsql.Col("a"), chsql.Lit(int64(1))),
+		chsql.Eq(chsql.Col("b"), chsql.Lit(int64(2))),
+	))(b)
+	if got, want := b.String(), "(`a` = ? OR `b` = ?)"; got != want {
+		t.Errorf("Paren SQL = %q; want %q", got, want)
+	}
+}
+
+// TestTuple_RendersCommaSeparated — Tuple emits "(<p0>, <p1>, ...)".
+func TestTuple_RendersCommaSeparated(t *testing.T) {
+	t.Parallel()
+
+	b := chsql.NewBuilder()
+	chsql.Tuple(chsql.Lit(int64(1)), chsql.Lit(int64(2)), chsql.Lit(int64(3)))(b)
+	sql, args := b.Build()
+	if got, want := sql, "(?, ?, ?)"; got != want {
+		t.Errorf("Tuple SQL = %q; want %q", got, want)
+	}
+	if !reflect.DeepEqual(args, []any{int64(1), int64(2), int64(3)}) {
+		t.Errorf("Tuple args = %v", args)
+	}
+}
+
+// TestTuple_PanicsOnEmpty — Tuple() with zero parts is a programmer
+// error.
+func TestTuple_PanicsOnEmpty(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic on Tuple()")
+		}
+	}()
+	chsql.Tuple()
+}
+
+// TestCast_Wraps — Cast renders "CAST(<f> AS <typ>)" with the type
+// name emitted verbatim (no quoting).
+func TestCast_Wraps(t *testing.T) {
+	t.Parallel()
+
+	b := chsql.NewBuilder()
+	chsql.Cast(chsql.Col("a"), "Float64")(b)
+	if got, want := b.String(), "CAST(`a` AS Float64)"; got != want {
+		t.Errorf("Cast SQL = %q; want %q", got, want)
+	}
+}
+
+// TestConcat_NoSeparator — Concat emits parts back-to-back without
+// any glue. Args bind in emission order.
+func TestConcat_NoSeparator(t *testing.T) {
+	t.Parallel()
+
+	b := chsql.NewBuilder()
+	chsql.Concat(
+		chsql.Col("a"),
+		chsql.Raw(" = "),
+		chsql.Lit(int64(1)),
+	)(b)
+	sql, args := b.Build()
+	if got, want := sql, "`a` = ?"; got != want {
+		t.Errorf("Concat SQL = %q; want %q", got, want)
+	}
+	if !reflect.DeepEqual(args, []any{int64(1)}) {
+		t.Errorf("Concat args = %v", args)
+	}
+}
+
+// TestConcat_PanicsOnEmpty — Concat() with zero parts is a programmer
+// error.
+func TestConcat_PanicsOnEmpty(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic on Concat()")
+		}
+	}()
+	chsql.Concat()
+}
+
+// TestIn_RendersList — In emits "<left> IN (<r0>, <r1>, ...)" and
+// binds Lit args in emission order.
+func TestIn_RendersList(t *testing.T) {
+	t.Parallel()
+
+	b := chsql.NewBuilder()
+	chsql.In(chsql.Col("a"), chsql.Lit("x"), chsql.Lit("y"), chsql.Lit("z"))(b)
+	sql, args := b.Build()
+	if got, want := sql, "`a` IN (?, ?, ?)"; got != want {
+		t.Errorf("In SQL = %q; want %q", got, want)
+	}
+	if !reflect.DeepEqual(args, []any{"x", "y", "z"}) {
+		t.Errorf("In args = %v", args)
+	}
+}
+
+// TestIn_PanicsOnEmpty — In with no right-hand parts is a programmer
+// error (empty IN list is a CH syntax error).
+func TestIn_PanicsOnEmpty(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic on In() with empty right")
+		}
+	}()
+	chsql.In(chsql.Col("a"))
+}


### PR DESCRIPTION
## Summary

Adds typed `Frag` constructors to `internal/chsql/builder.go` so callers can compose ClickHouse expressions without reaching for `Builder.WriteSQL("...")`. This is the gating PR for the RC6 R6.11 sequence that ultimately deletes the public `Builder.WriteSQL` method.

### Constructors added (17 total)

- **Comparison binary ops**: `Eq`, `Neq`, `Gt`, `Gte`, `Lt`, `Lte`, `Like`, `NotLike` — render `<l> <op> <r>` with single spaces.
- **Logical**: `And(parts ...)`, `Or(parts ...)` (panic on empty), `Not(f)` (no parens; caller wraps with `Paren` if precedence requires).
- **Arithmetic binary ops**: `Add`, `Sub`, `Mul`, `Div`, `Mod`, `Neg(f)` (no space between minus and operand).
- **Structure**: `Paren(f)`, `Tuple(parts ...)` (panic on empty), `Cast(f, typ)` (`typ` is a trusted literal, same contract as `Raw`), `Concat(parts ...)` (no separator; panic on empty), `In(left, right ...)` (panic on empty `right` — empty `IN` is a CH syntax error).

A shared private `binOp(op, l, r)` helper renders the canonical `<l> <op> <r>` shape so each typed wrapper just supplies its operator token. Variadic constructors mirror the existing `UnionAll` pattern.

### Sequence context (RC6 R6.11)

- **R6.11a (this PR)** — adds the primitives. No callers ported.
- **R6.11b/c/d** — port `internal/api/loki/*`, `internal/api/tempo/*`, `internal/api/prom/metadata.go` onto these helpers.
- **R6.11e** — renames `Builder.WriteSQL` → unexported `writeSQL` and shrinks `cmd/check-sql/` to `fmt.Sprintf`-only scanning.

### Allowlist tweak

`cmd/check-sql/allowlist.txt` range for `QueryBuilder.writeInto` shifts from `717-811` to `890-984` because the new constructors landed above that function. `UnionAll` / `UnionDistinct` exemptions (lines 470 / 487) are unchanged.

## Test plan

- [x] `go build ./internal/chsql/...` — clean.
- [x] `go test ./internal/chsql/...` — 167 passed (15 new test funcs covering every constructor + panic paths for `And`, `Or`, `Tuple`, `Concat`, `In`).
- [x] `go run ./cmd/check-sql/` — clean (no clause-keyword leaks outside `writeInto` / `UnionAll` / `UnionDistinct`).
- [x] `go test ./cmd/check-sql/...` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)