### PR TITLE
refactor(api/prom): port metadata.go to typed Frags (RC6 R6.11d)

### DIFF
--- a/internal/api/prom/metadata.go
+++ b/internal/api/prom/metadata.go
@@ -167,11 +167,7 @@ func (h *Handler) metricMetaSQL(table, metricName string) (string, []any) {
 	unitCol := h.Schema.MetricUnitColumn
 
 	anyCall := func(col string) chsql.Frag {
-		return func(b *chsql.Builder) {
-			b.WriteSQL("any(")
-			b.Ident(col)
-			b.WriteSQL(")")
-		}
+		return chsql.Concat(chsql.Raw("any("), chsql.Col(col), chsql.Raw(")"))
 	}
 
 	sb := chsql.NewQuery().
@@ -184,11 +180,7 @@ func (h *Handler) metricMetaSQL(table, metricName string) (string, []any) {
 		sql, args := sb.Build()
 		return sql, args
 	}
-	sb.Where(func(b *chsql.Builder) {
-		b.Ident(nameCol)
-		b.WriteSQL(" = ")
-		b.Arg(metricName)
-	})
+	sb.Where(chsql.Eq(chsql.Col(nameCol), chsql.Lit(metricName)))
 	return sb.Build()
 }
 
@@ -534,11 +526,8 @@ func (h *Handler) metricTables() []string {
 // arrayJoinMapKeysFrag emits `arrayJoin(mapKeys(<col>))` — the CH idiom
 // for fanning out a Map column's key set as one row per key.
 func arrayJoinMapKeysFrag(col string) chsql.Frag {
-	return func(b *chsql.Builder) {
-		b.WriteSQL("arrayJoin(")
-		b.MapKeys(col)
-		b.WriteSQL(")")
-	}
+	mapKeys := func(b *chsql.Builder) { b.MapKeys(col) }
+	return chsql.Concat(chsql.Raw("arrayJoin("), mapKeys, chsql.Raw(")"))
 }
 
 // distinctIdent emits `DISTINCT <col>` as a SELECT-list expression. The
@@ -547,20 +536,15 @@ func arrayJoinMapKeysFrag(col string) chsql.Frag {
 // SELECT list and renders identical query plans either way. Putting it
 // in the projection slot keeps it inside the typed Frag surface.
 func distinctIdent(col string) chsql.Frag {
-	return func(b *chsql.Builder) {
-		b.WriteSQL("DISTINCT ")
-		b.Ident(col)
-	}
+	return chsql.Concat(chsql.Raw("DISTINCT "), chsql.Col(col))
 }
 
 // distinctMapAtFrag emits `DISTINCT <col>[?]` and binds key as a
 // positional argument — the projection shape for "distinct values of
 // label <key> stored in the Attributes map".
 func distinctMapAtFrag(col, key string) chsql.Frag {
-	return func(b *chsql.Builder) {
-		b.WriteSQL("DISTINCT ")
-		b.MapAt(col, key)
-	}
+	mapAt := func(b *chsql.Builder) { b.MapAt(col, key) }
+	return chsql.Concat(chsql.Raw("DISTINCT "), mapAt)
 }
 
 // mapAtNotEmptyFrag emits `<col>[?] != ”` — the WHERE predicate that
@@ -570,10 +554,11 @@ func distinctMapAtFrag(col, key string) chsql.Frag {
 // a fixed value, not user data, and CH planner pruning relies on it
 // being visible at plan time.
 func mapAtNotEmptyFrag(col, key string) chsql.Frag {
-	return func(b *chsql.Builder) {
-		b.MapAt(col, key)
-		b.WriteSQL(" != ''")
-	}
+	mapAt := func(b *chsql.Builder) { b.MapAt(col, key) }
+	// The empty-string sentinel CH returns for absent Map keys is part
+	// of the query shape, so the RHS is emitted as the literal `''`
+	// via chsql.Raw rather than parameterised through chsql.Lit.
+	return chsql.Neq(mapAt, chsql.Raw("''"))
 }
 
 // parenRawFrag wraps an already-rendered SQL string in parentheses for
@@ -582,11 +567,7 @@ func mapAtNotEmptyFrag(col, key string) chsql.Frag {
 // caller is responsible for ordering its args ahead of any further
 // `?` bindings the outer QueryBuilder emits.
 func parenRawFrag(sql string) chsql.Frag {
-	return func(b *chsql.Builder) {
-		b.WriteSQL("(")
-		b.WriteSQL(sql)
-		b.WriteSQL(")")
-	}
+	return chsql.Paren(chsql.Raw(sql))
 }
 
 // validLabelName mirrors the Prometheus label-name grammar: [a-zA-Z_][a-zA-Z0-9_]*.


### PR DESCRIPTION
## Summary

Ports `internal/api/prom/metadata.go` off the remaining `Builder.WriteSQL` operator/glue calls onto R6.11a's typed `chsql.Frag` constructors. All 11 `.WriteSQL(` calls in the file are gone.

### Mapping

| Before | After |
| --- | --- |
| `b.WriteSQL(" = ")` between Ident + Arg | `chsql.Eq(chsql.Col(...), chsql.Lit(...))` |
| `b.WriteSQL(" != ''")` after MapAt | `chsql.Neq(mapAt, chsql.Raw("''"))` |
| `b.WriteSQL("("); b.WriteSQL(sql); b.WriteSQL(")")` | `chsql.Paren(chsql.Raw(sql))` |
| `b.WriteSQL("any("); b.Ident(col); b.WriteSQL(")")` | `chsql.Concat(chsql.Raw("any("), chsql.Col(col), chsql.Raw(")"))` |
| `b.WriteSQL("arrayJoin("); b.MapKeys(col); b.WriteSQL(")")` | `chsql.Concat(chsql.Raw("arrayJoin("), <MapKeys-Frag>, chsql.Raw(")"))` |
| `b.WriteSQL("DISTINCT "); b.Ident(col)` | `chsql.Concat(chsql.Raw("DISTINCT "), chsql.Col(col))` |
| `b.WriteSQL("DISTINCT "); b.MapAt(col, key)` | `chsql.Concat(chsql.Raw("DISTINCT "), <MapAt-Frag>)` |

### Notes

- The `MapAt` / `MapKeys` Builder methods are kept as small closure-Frags so their key arg still binds through the typed `Arg` surface — only the surrounding function-name + modifier tokens flow through `chsql.Raw`.
- The empty-string sentinel in `mapAtNotEmptyFrag` stays a literal `''` (via `chsql.Raw`) rather than a `?` bind: it's part of the query shape, not user data.
- No behavior change — pure refactor of the API surface that emits the SQL.

### Context

This file was already on the RC6 grandfather list (originally R6.7 / #180, which retired the clause-keyword `WriteSQL` calls). R6.11d completes the operator/glue layer now that the typed `Eq` / `Neq` / `Paren` / `Concat` constructors from R6.11a (#187) are available.

R6.11a (#187) is already merged, so this PR stacks on `main`. R6.11b (api/loki) and R6.11c (api/tempo) have not yet shipped; this PR is independent of them and can land in any order. R6.11e (delete `cmd/check-sql/` -- actually rename `Builder.WriteSQL` to unexported) will land after b/c/d are all in.

## Test plan

- [x] `go test ./internal/api/prom/...` -- 48 tests pass
- [x] `go run ./cmd/check-sql` -- clean
- [x] `go build ./...` -- clean
- [ ] CI `check` + `lint` green

Diff: `+13 / -32` in one file.

<!-- agent-stack-marker: depends on #187 (merged); do not enable auto-merge until reviewer confirms. -->