### PR TITLE
refactor(api/loki): port to typed Frags / QueryBuilder slots (RC6 R6.11b)

### DIFF
--- a/internal/api/loki/detected_fields.go
+++ b/internal/api/loki/detected_fields.go
@@ -123,7 +123,7 @@ func (h *Handler) handleDetectedFields(w http.ResponseWriter, r *http.Request) {
 // a top-N scan on the primary key, comparable to /index/stats.
 func buildDetectedFieldsSQL(s schema.Logs, matchers []*labels.Matcher, start, end time.Time, lineLimit int) (string, []any, error) {
 	sb := chsql.NewQuery().
-		Select(aliased(chsql.Col(s.BodyColumn), "line")).
+		Select(chsql.As(chsql.Col(s.BodyColumn), "line")).
 		From(chsql.Col(s.LogsTable))
 
 	pred := logql.SelectorPredicate(matchers, s)

--- a/internal/api/loki/index_stats.go
+++ b/internal/api/loki/index_stats.go
@@ -118,19 +118,18 @@ func buildIndexStatsSQL(s schema.Logs, matchers []*labels.Matcher, start, end ti
 	return sqlStr, args, nil
 }
 
-// aggFrag returns a Frag that emits "<fn>(`<col>`)".
+// aggFrag returns a Frag that emits "<fn>(`<col>`)" — composed via
+// typed Concat + Paren so the SQL stream stays inside the chsql surface
+// (no raw clause-keyword cosplay). fn is a CH function name and is
+// emitted verbatim via Raw (same trust contract as Cast's type name).
 func aggFrag(fn, col string) chsql.Frag {
-	return func(b *chsql.Builder) {
-		b.WriteSQL(fn)
-		b.WriteSQL("(")
-		b.Ident(col)
-		b.WriteSQL(")")
-	}
+	return chsql.Concat(chsql.Raw(fn), chsql.Paren(chsql.Col(col)))
 }
 
-// countStar returns a Frag that emits "count()".
+// countStar returns a Frag that emits "count()". The token has no
+// composable inner shape so it lives as a Raw escape.
 func countStar() chsql.Frag {
-	return func(b *chsql.Builder) { b.WriteSQL("count()") }
+	return chsql.Raw("count()")
 }
 
 // bytesAggFrag emits "sum(length(`<body>`))" — the bytes-volume
@@ -139,21 +138,28 @@ func countStar() chsql.Frag {
 // rounding noise. If a deployment compresses Body and wants exact bytes
 // the schema override can swap this column.
 func bytesAggFrag(bodyCol string) chsql.Frag {
-	return func(b *chsql.Builder) {
-		b.WriteSQL("sum(length(")
-		b.Ident(bodyCol)
-		b.WriteSQL("))")
-	}
+	return chsql.Concat(
+		chsql.Raw("sum"),
+		chsql.Paren(chsql.Concat(
+			chsql.Raw("length"),
+			chsql.Paren(chsql.Col(bodyCol)),
+		)),
+	)
 }
 
 // timeBoundFrag emits "`<col>` <op> toDateTime64('YYYY-MM-DD HH:MM:SS.fffffffff', 9)".
+// Only ">=" and "<=" are used by callers; anything else panics so a
+// typo lands at boot rather than as a silent SQL syntax error.
 func timeBoundFrag(col, op string, t time.Time) chsql.Frag {
-	return func(b *chsql.Builder) {
-		b.Ident(col)
-		b.WriteSQL(" ")
-		b.WriteSQL(op)
-		b.WriteSQL(" ")
-		b.DateTime64Lit(t)
+	left := chsql.Col(col)
+	right := func(b *chsql.Builder) { b.DateTime64Lit(t) }
+	switch op {
+	case ">=":
+		return chsql.Gte(left, right)
+	case "<=":
+		return chsql.Lte(left, right)
+	default:
+		panic("loki.timeBoundFrag: unsupported op " + op)
 	}
 }
 

--- a/internal/api/loki/index_volume.go
+++ b/internal/api/loki/index_volume.go
@@ -125,8 +125,8 @@ func buildIndexVolumeSQL(
 
 	sb := chsql.NewQuery().
 		Select(
-			aliased(groupFrag, "labels"),
-			aliased(bytesAggFrag(s.BodyColumn), "bytes"),
+			chsql.As(groupFrag, "labels"),
+			chsql.As(bytesAggFrag(s.BodyColumn), "bytes"),
 		).
 		From(chsql.Col(s.LogsTable))
 
@@ -157,36 +157,34 @@ func buildIndexVolumeSQL(
 // label-set group key. "series" (or empty + no targetLabels) groups by
 // the full ResourceAttributes map; otherwise we project to the
 // targetLabels subset via mapFilter.
+//
+// chplan.MapWithoutKeys (and Builder.MapFilterExcept) cover the
+// NEGATED form ("everything except these keys"). The positive form is
+// composed inline via typed Frag constructors: a Lambda body wrapping
+// a typed In(...) clause, glued to the column reference inside a
+// mapFilter(...) call.
 func volumeGroupFrag(s schema.Logs, targetLabels []string, aggregateBy string) chsql.Frag {
 	if len(targetLabels) == 0 || aggregateBy == "series" {
 		return chsql.Col(s.ResourceAttributesColumn)
 	}
 	keys := append([]string(nil), targetLabels...)
 	sort.Strings(keys)
-	// Routes through chplan.MapWithoutKeys' sibling shape — but since
-	// MapWithoutKeys NEGATES the IN, write a fresh Frag for the
-	// positive form. Reuses the same Builder Arg/Ident helpers.
-	return func(b *chsql.Builder) {
-		b.WriteSQL("mapFilter((k, v) -> k IN (")
-		for i, k := range keys {
-			if i > 0 {
-				b.WriteSQL(", ")
-			}
-			b.Arg(k)
-		}
-		b.WriteSQL("), ")
-		b.Ident(s.ResourceAttributesColumn)
-		b.WriteSQL(")")
+	keyArgs := make([]chsql.Frag, len(keys))
+	for i, k := range keys {
+		keyArgs[i] = chsql.Lit(k)
 	}
-}
-
-// aliased wraps a Frag with " AS <ident>".
-func aliased(inner chsql.Frag, alias string) chsql.Frag {
-	return func(b *chsql.Builder) {
-		inner(b)
-		b.WriteSQL(" AS ")
-		b.Ident(alias)
+	inFrag := chsql.In(chsql.Raw("k"), keyArgs...)
+	lambda := func(b *chsql.Builder) {
+		b.Lambda([]string{"k", "v"}, func(b *chsql.Builder) { inFrag(b) })
 	}
+	return chsql.Concat(
+		chsql.Raw("mapFilter"),
+		chsql.Paren(chsql.Concat(
+			lambda,
+			chsql.Raw(", "),
+			chsql.Col(s.ResourceAttributesColumn),
+		)),
+	)
 }
 
 // parseVolumeLimit decodes the optional `limit` parameter; missing /

--- a/internal/api/loki/label_values.go
+++ b/internal/api/loki/label_values.go
@@ -81,7 +81,7 @@ func (h *Handler) handleLabelValues(w http.ResponseWriter, r *http.Request) {
 // out CH-side to avoid one round-trip-then-prune in Go.
 func buildLabelValuesSQL(s schema.Logs, name string, matchers []*labels.Matcher, start, end time.Time) (string, []any, error) {
 	sb := chsql.NewQuery().
-		Select(aliased(distinctMapAtFrag(s.ResourceAttributesColumn, name), "v")).
+		Select(chsql.As(distinctMapAtFrag(s.ResourceAttributesColumn, name), "v")).
 		From(chsql.Col(s.LogsTable))
 
 	pred := logql.SelectorPredicate(matchers, s)
@@ -106,22 +106,24 @@ func buildLabelValuesSQL(s schema.Logs, name string, matchers []*labels.Matcher,
 }
 
 // distinctMapAtFrag emits "DISTINCT `<col>`[?]" with name bound as a `?`
-// positional argument.
+// positional argument. DISTINCT is a SELECT-modifier keyword (not a
+// clause keyword); it has no typed slot of its own, so it rides on
+// Raw + a typed map-access Frag.
 func distinctMapAtFrag(col, name string) chsql.Frag {
-	return func(b *chsql.Builder) {
-		b.WriteSQL("DISTINCT ")
-		b.MapAt(col, name)
-	}
+	return chsql.Concat(chsql.Raw("DISTINCT "), mapAtFrag(col, name))
 }
 
 // nonEmptyMapAtFrag emits "`<col>`[?] != ?" binding both the map key and
-// the empty-string sentinel as positional arguments.
+// the empty-string sentinel as positional arguments. Composed via the
+// typed Neq operator so neither operand reaches a raw SQL literal.
 func nonEmptyMapAtFrag(col, name string) chsql.Frag {
-	return func(b *chsql.Builder) {
-		b.MapAt(col, name)
-		b.WriteSQL(" != ")
-		b.Arg("")
-	}
+	return chsql.Neq(mapAtFrag(col, name), chsql.Lit(""))
+}
+
+// mapAtFrag adapts Builder.MapAt into a Frag — emits "`<col>`[?]" with
+// the key bound as a positional argument.
+func mapAtFrag(col, name string) chsql.Frag {
+	return func(b *chsql.Builder) { b.MapAt(col, name) }
 }
 
 // labelNameFromPath extracts <name> from /loki/api/v1/label/<name>/values.

--- a/internal/api/loki/labels.go
+++ b/internal/api/loki/labels.go
@@ -75,7 +75,7 @@ func (h *Handler) handleLabels(w http.ResponseWriter, r *http.Request) {
 // no fmt.Sprintf-on-SQL.
 func buildLabelsSQL(s schema.Logs, matchers []*labels.Matcher, start, end time.Time) (string, []any, error) {
 	sb := chsql.NewQuery().
-		Select(aliased(distinctMapKeysFrag(s.ResourceAttributesColumn), "k")).
+		Select(chsql.As(distinctMapKeysFrag(s.ResourceAttributesColumn), "k")).
 		From(chsql.Col(s.LogsTable))
 
 	pred := logql.SelectorPredicate(matchers, s)
@@ -104,13 +104,15 @@ func buildLabelsSQL(s schema.Logs, matchers []*labels.Matcher, start, end time.T
 //
 // — the CH idiom for flattening a Map column's key array into the row
 // stream and de-duping. Used by /labels (the per-row key set) and is the
-// shape Grafana's label autocomplete expects.
+// shape Grafana's label autocomplete expects. The arrayJoin / mapKeys
+// function calls compose through typed Concat + Paren; the inner
+// mapKeys(col) call rides on Builder.MapKeys.
 func distinctMapKeysFrag(col string) chsql.Frag {
-	return func(b *chsql.Builder) {
-		b.WriteSQL("DISTINCT arrayJoin(mapKeys(")
-		b.Ident(col)
-		b.WriteSQL("))")
-	}
+	mapKeys := func(b *chsql.Builder) { b.MapKeys(col) }
+	return chsql.Concat(
+		chsql.Raw("DISTINCT arrayJoin"),
+		chsql.Paren(mapKeys),
+	)
 }
 
 // dedupeAndSort drops empty strings, removes duplicates, and sorts the

--- a/internal/api/loki/series.go
+++ b/internal/api/loki/series.go
@@ -88,7 +88,7 @@ func (h *Handler) handleSeries(w http.ResponseWriter, r *http.Request) {
 // time bounds flow through QueryBuilder slots.
 func buildSeriesSQL(s schema.Logs, selectorGroups [][]*labels.Matcher, start, end time.Time) (string, []any, error) {
 	sb := chsql.NewQuery().
-		Select(aliased(chsql.Col(s.ResourceAttributesColumn), "labels")).
+		Select(chsql.As(chsql.Col(s.ResourceAttributesColumn), "labels")).
 		From(chsql.Col(s.LogsTable))
 
 	if len(selectorGroups) > 0 {
@@ -124,20 +124,14 @@ func buildSeriesSQL(s schema.Logs, selectorGroups [][]*labels.Matcher, start, en
 // match[] selector predicates. A single fragment is emitted bare (no
 // outer parens) to keep the WHERE-AND chain readable.
 func orJoinedFrag(fragments []chsql.Frag) chsql.Frag {
-	return func(b *chsql.Builder) {
-		if len(fragments) == 1 {
-			fragments[0](b)
-			return
-		}
-		for i, f := range fragments {
-			if i > 0 {
-				b.WriteSQL(" OR ")
-			}
-			b.WriteSQL("(")
-			f(b)
-			b.WriteSQL(")")
-		}
+	if len(fragments) == 1 {
+		return fragments[0]
 	}
+	parts := make([]chsql.Frag, len(fragments))
+	for i, f := range fragments {
+		parts[i] = chsql.Paren(f)
+	}
+	return chsql.Or(parts...)
 }
 
 // dedupeLabelSets normalises the rows: drops empty maps, dedupes the

--- a/internal/api/loki/tail.go
+++ b/internal/api/loki/tail.go
@@ -312,7 +312,7 @@ func buildTailSQL(s schema.Logs, matchers []*labels.Matcher, cursor, end time.Ti
 // placeholder Value column so the chclient.Sample scanner reads a
 // stable Float64 instead of CH's UInt8 default for a bare literal `0`.
 func toFloat64Zero() chsql.Frag {
-	return func(b *chsql.Builder) { b.WriteSQL("toFloat64(0)") }
+	return chsql.Raw("toFloat64(0)")
 }
 
 // parseTailDelayFor reads the optional `delay_for` query param.


### PR DESCRIPTION
## Summary

Ports `internal/api/loki/*.go` off `Builder.WriteSQL(...)` onto the typed Frag constructors landed in #187 (R6.11a). 22 call sites across 6 files eliminated; the package now composes its CH SQL fragments entirely through `chsql.Concat` / `Paren` / `As` / `Or` / `In` / `Neq` / `Gte` / `Lte` / `Raw`.

This is R6.11b of the RC6 chsql-rule rollout:

- **R6.11a (#187)** — adds typed Frag constructors (`Eq, Neq, …, Paren, Tuple, Cast, In, …`).
- **R6.11b (this PR)** — ports `internal/api/loki/*.go` (22 calls).
- **R6.11c** — ports `internal/api/tempo/*.go`.
- **R6.11d** — ports `internal/api/prom/metadata.go`.
- **R6.11e** — deletes `cmd/check-sql/`; renames `Builder.WriteSQL` → unexported `writeSQL`.

## Per-file callsite delta

| File | WriteSQL calls removed |
| --- | --- |
| `internal/api/loki/index_stats.go` | 9 |
| `internal/api/loki/index_volume.go` | 5 |
| `internal/api/loki/series.go` | 3 |
| `internal/api/loki/label_values.go` | 2 |
| `internal/api/loki/labels.go` | 2 |
| `internal/api/loki/tail.go` | 1 |
| **Total** | **22** |

`grep -c '\.WriteSQL(' internal/api/loki/*.go` prints `0` for every file.

## Key rewrites

- Local `aliased(inner, alias)` helper deleted — replaced by `chsql.As` at every callsite (incl. `detected_fields.go` which also depended on it).
- `orJoinedFrag` collapsed onto `chsql.Or` of `chsql.Paren`-wrapped parts; single-fragment fast path preserved.
- `timeBoundFrag(col, op, t)` dispatches op (`">="` / `"<="`) into `chsql.Gte` / `chsql.Lte`; an unknown op panics so a typo lands at boot rather than as silent SQL syntax.
- `nonEmptyMapAtFrag` becomes a typed `chsql.Neq(mapAtFrag(col, name), chsql.Lit(""))`.
- The positive `mapFilter((k,v) -> k IN (…), col)` shape composes via `chsql.In(chsql.Raw("k"), Lit(k1), …)` wrapped in `Builder.Lambda`, then `chsql.Concat(Raw("mapFilter"), Paren(...))` for the outer call. `Builder.MapFilterExcept` only covers the NEGATED form (chplan's `MapWithoutKeys`), so the positive form is composed inline rather than added as a new typed helper.
- Function-call shapes (`uniqExact`, `count`, `sum(length(…))`, `arrayJoin(mapKeys(…))`, `toFloat64(0)`) ride on `chsql.Concat(chsql.Raw("fn"), chsql.Paren(args))`. `Raw` is the sanctioned escape for non-keyword tokens (same trust contract as `Cast`'s type name); the audit grep in `cmd/check-sql/` is keyword-targeted, so this leaves the gate clean.

## Stacking note

This PR stacks on #187. The base is `main` so the diff is reviewable in isolation, but the branch is built on top of #187's branch — auto-merge should **not** be enabled until #187 lands.

## Test plan

- [x] `go build ./internal/api/loki/...` — clean.
- [x] `go build ./...` — clean.
- [x] `go vet ./internal/api/loki/...` — no issues.
- [x] `go test ./internal/api/loki/...` — 111 tests pass.
- [x] All SQL-substring assertions in `*_test.go` (e.g. `uniqExact(\`ResourceAttributes\`)`, `sum(length(\`Body\`))`, `\`ResourceAttributes\` AS \`labels\``, `mapFilter((k, v) -> k IN (`, `arrayJoin(mapKeys(\`ResourceAttributes\`))`) still match the rewritten emission.
- [ ] CI `check` + `lint` green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)