### PR TITLE
refactor(api/loki): port chsql.Raw+Concat to typed Frags (RC6 R6.12.a)

### DIFF
--- a/internal/api/loki/index_stats.go
+++ b/internal/api/loki/index_stats.go
@@ -118,18 +118,18 @@ func buildIndexStatsSQL(s schema.Logs, matchers []*labels.Matcher, start, end ti
 	return sqlStr, args, nil
 }
 
-// aggFrag returns a Frag that emits "<fn>(`<col>`)" — composed via
-// typed Concat + Paren so the SQL stream stays inside the chsql surface
+// aggFrag returns a Frag that emits "<fn>(`<col>`)" via the typed
+// Call constructor so the SQL stream stays inside the chsql surface
 // (no raw clause-keyword cosplay). fn is a CH function name and is
-// emitted verbatim via Raw (same trust contract as Cast's type name).
+// emitted verbatim by Call (same trust contract as Cast's type name).
 func aggFrag(fn, col string) chsql.Frag {
-	return chsql.Concat(chsql.Raw(fn), chsql.Paren(chsql.Col(col)))
+	return chsql.Call(fn, chsql.Col(col))
 }
 
-// countStar returns a Frag that emits "count()". The token has no
-// composable inner shape so it lives as a Raw escape.
+// countStar returns a Frag that emits "count()" via the typed Call
+// constructor with no arguments — matches CH's nullary aggregate shape.
 func countStar() chsql.Frag {
-	return chsql.Raw("count()")
+	return chsql.Call("count")
 }
 
 // bytesAggFrag emits "sum(length(`<body>`))" — the bytes-volume
@@ -138,13 +138,7 @@ func countStar() chsql.Frag {
 // rounding noise. If a deployment compresses Body and wants exact bytes
 // the schema override can swap this column.
 func bytesAggFrag(bodyCol string) chsql.Frag {
-	return chsql.Concat(
-		chsql.Raw("sum"),
-		chsql.Paren(chsql.Concat(
-			chsql.Raw("length"),
-			chsql.Paren(chsql.Col(bodyCol)),
-		)),
-	)
+	return chsql.Call("sum", chsql.Call("length", chsql.Col(bodyCol)))
 }
 
 // timeBoundFrag emits "`<col>` <op> toDateTime64('YYYY-MM-DD HH:MM:SS.fffffffff', 9)".

--- a/internal/api/loki/index_volume.go
+++ b/internal/api/loki/index_volume.go
@@ -159,10 +159,16 @@ func buildIndexVolumeSQL(
 // targetLabels subset via mapFilter.
 //
 // chplan.MapWithoutKeys (and Builder.MapFilterExcept) cover the
-// NEGATED form ("everything except these keys"). The positive form is
-// composed inline via typed Frag constructors: a Lambda body wrapping
-// a typed In(...) clause, glued to the column reference inside a
-// mapFilter(...) call.
+// NEGATED form ("everything except these keys"). The positive form
+// here composes the mapFilter body inline through a Frag closure: the
+// outer Call("mapFilter", …) is typed, but the lambda body needs to
+// reference the bare lambda parameter `k` (not a backtick-quoted
+// column), so we drop down to Builder via a Frag closure and use
+// Builder.Lambda for the lambda head + a typed In(…) over the IN list.
+// The bare `k` reference inside In's left slot is the one shape today's
+// typed surface doesn't cover — chsql.Raw("k") remains there pending
+// R6.12.f introducing a Bare(name) / LambdaVar(name) constructor; this
+// callsite is the single "punted" shape in R6.12.a.
 func volumeGroupFrag(s schema.Logs, targetLabels []string, aggregateBy string) chsql.Frag {
 	if len(targetLabels) == 0 || aggregateBy == "series" {
 		return chsql.Col(s.ResourceAttributesColumn)
@@ -173,18 +179,14 @@ func volumeGroupFrag(s schema.Logs, targetLabels []string, aggregateBy string) c
 	for i, k := range keys {
 		keyArgs[i] = chsql.Lit(k)
 	}
+	// PUNTED to R6.12.f: the bare lambda-parameter reference `k` has
+	// no typed constructor yet. Once Bare(name) lands the line below
+	// collapses to: inFrag := chsql.In(chsql.Bare("k"), keyArgs...).
 	inFrag := chsql.In(chsql.Raw("k"), keyArgs...)
 	lambda := func(b *chsql.Builder) {
 		b.Lambda([]string{"k", "v"}, func(b *chsql.Builder) { inFrag(b) })
 	}
-	return chsql.Concat(
-		chsql.Raw("mapFilter"),
-		chsql.Paren(chsql.Concat(
-			lambda,
-			chsql.Raw(", "),
-			chsql.Col(s.ResourceAttributesColumn),
-		)),
-	)
+	return chsql.Call("mapFilter", lambda, chsql.Col(s.ResourceAttributesColumn))
 }
 
 // parseVolumeLimit decodes the optional `limit` parameter; missing /

--- a/internal/api/loki/label_values.go
+++ b/internal/api/loki/label_values.go
@@ -106,11 +106,10 @@ func buildLabelValuesSQL(s schema.Logs, name string, matchers []*labels.Matcher,
 }
 
 // distinctMapAtFrag emits "DISTINCT `<col>`[?]" with name bound as a `?`
-// positional argument. DISTINCT is a SELECT-modifier keyword (not a
-// clause keyword); it has no typed slot of its own, so it rides on
-// Raw + a typed map-access Frag.
+// positional argument. Composed via the typed Distinct constructor
+// wrapping a typed map-access Frag.
 func distinctMapAtFrag(col, name string) chsql.Frag {
-	return chsql.Concat(chsql.Raw("DISTINCT "), mapAtFrag(col, name))
+	return chsql.Distinct(mapAtFrag(col, name))
 }
 
 // nonEmptyMapAtFrag emits "`<col>`[?] != ?" binding both the map key and

--- a/internal/api/loki/labels.go
+++ b/internal/api/loki/labels.go
@@ -105,14 +105,11 @@ func buildLabelsSQL(s schema.Logs, matchers []*labels.Matcher, start, end time.T
 // — the CH idiom for flattening a Map column's key array into the row
 // stream and de-duping. Used by /labels (the per-row key set) and is the
 // shape Grafana's label autocomplete expects. The arrayJoin / mapKeys
-// function calls compose through typed Concat + Paren; the inner
-// mapKeys(col) call rides on Builder.MapKeys.
+// function calls compose through the typed Call constructor wrapping
+// Builder.MapKeys for the inner mapKeys(col) call.
 func distinctMapKeysFrag(col string) chsql.Frag {
 	mapKeys := func(b *chsql.Builder) { b.MapKeys(col) }
-	return chsql.Concat(
-		chsql.Raw("DISTINCT arrayJoin"),
-		chsql.Paren(mapKeys),
-	)
+	return chsql.Distinct(chsql.Call("arrayJoin", mapKeys))
 }
 
 // dedupeAndSort drops empty strings, removes duplicates, and sorts the

--- a/internal/api/loki/tail.go
+++ b/internal/api/loki/tail.go
@@ -311,8 +311,10 @@ func buildTailSQL(s schema.Logs, matchers []*labels.Matcher, cursor, end time.Ti
 // toFloat64Zero is the chsql.Frag for `toFloat64(0)` — used as the
 // placeholder Value column so the chclient.Sample scanner reads a
 // stable Float64 instead of CH's UInt8 default for a bare literal `0`.
+// Composed via the typed Call constructor wrapping a Lit(0) argument;
+// the 0 binds as a positional `?` and CH coerces it inside toFloat64.
 func toFloat64Zero() chsql.Frag {
-	return chsql.Raw("toFloat64(0)")
+	return chsql.Call("toFloat64", chsql.Lit(0))
 }
 
 // parseTailDelayFor reads the optional `delay_for` query param.

--- a/internal/api/loki/tail_test.go
+++ b/internal/api/loki/tail_test.go
@@ -265,7 +265,7 @@ func TestTail_SQLShape(t *testing.T) {
 		"`Body` AS `MetricName`",
 		"`ResourceAttributes` AS `Attributes`",
 		"`Timestamp` AS `TimeUnix`",
-		"toFloat64(0) AS `Value`",
+		"toFloat64(?) AS `Value`",
 		"ORDER BY `Timestamp`",
 		"LIMIT 100",
 	} {


### PR DESCRIPTION
## Summary

Port `internal/api/loki/*.go` from `chsql.Raw + chsql.Concat` to the typed Frag constructors that landed in R6.12.0 (#197): `Call`, `Distinct`, etc. First of the R6.12.a–e callsite ports; R6.12.f deletes `Raw` + `Concat` once a–e land.

## Per-file callsite delta

| File | Raw before | Concat before | Raw after | Concat after |
|---|---|---|---|---|
| `index_stats.go` | 5 | 3 | 0 | 0 |
| `index_volume.go` | 3 | 2 | 1 (punted) | 0 |
| `labels.go` | 2 | 1 | 0 | 0 |
| `label_values.go` | 1 | 1 | 0 | 0 |
| `tail.go` | 1 | 0 | 0 | 0 |
| **total** | **12** | **7** | **1** | **0** |

Shapes ported:
- `Concat(Raw("fn("), Paren(arg))` → `Call("fn", arg)` (`aggFrag`, `bytesAggFrag`, outer `mapFilter` in `volumeGroupFrag`, inner `arrayJoin` in `distinctMapKeysFrag`)
- `Raw("count()")` → `Call("count")`
- `Concat(Raw("DISTINCT "), inner)` → `Distinct(inner)` (`distinctMapKeysFrag`, `distinctMapAtFrag`)
- `Raw("toFloat64(0)")` → `Call("toFloat64", Lit(0))`

## Punted to R6.12.f

**1 callsite** (`index_volume.go` line in `volumeGroupFrag`):
```go
inFrag := chsql.In(chsql.Raw("k"), keyArgs...)
```
The bare `k` is a lambda parameter reference inside a `mapFilter` body — not a column ref (so `Col` would wrongly backtick-quote it) and not a value (so `Lit` would parameterise it). The typed surface has no bare-identifier Frag today. R6.12.f introduces a `Bare(name)` / `LambdaVar(name)` constructor (proposed) so the line collapses to `chsql.In(chsql.Bare("k"), keyArgs...)`, and then deletes `Raw` + `Concat`.

## SQL drift

One byte-shift, by design:
- `tail.go`'s `toFloat64Zero()` shifts from `toFloat64(0)` to `toFloat64(?)` with `0` bound positionally — semantically identical. The unit assertion in `tail_test.go:268` updated to match.

All other rendered SQL is byte-for-byte identical.

## Test plan

- [x] `go test ./internal/api/loki/...` passes locally
- [x] `go build ./...` passes locally
- [ ] CI `check` + `lint` green