### PR TITLE
refactor(chsql): port join/set-op Raw+Concat to typed Frags (RC6 R6.12.e)

### DIFF
--- a/internal/chsql/range_window.go
+++ b/internal/chsql/range_window.go
@@ -990,12 +990,3 @@ func (e *emitter) collectGroupByFrags(group []chplan.Expr) ([]Frag, error) {
 	return out, nil
 }
 
-// quoteIdent backtick-quotes a CH identifier. Retained for the
-// grandfathered emitters in structural_join.go (R6.6) that still
-// compose SQL fragments through free-standing strings before
-// flushing to the emitter; the RangeWindow port no longer calls it.
-func quoteIdent(name string) string {
-	b := &Builder{}
-	b.Ident(name)
-	return b.String()
-}

--- a/internal/chsql/range_window.go
+++ b/internal/chsql/range_window.go
@@ -989,4 +989,3 @@ func (e *emitter) collectGroupByFrags(group []chplan.Expr) ([]Frag, error) {
 	}
 	return out, nil
 }
-

--- a/internal/chsql/set_op.go
+++ b/internal/chsql/set_op.go
@@ -50,7 +50,7 @@ func (e *emitter) emitSetOperation(s *chplan.SetOperation) error {
 			b.QualIdent("R", spanID)
 		}
 		sb := NewQuery().
-			Select(Raw("L.*")).
+			Select(verbatim("L.*")).
 			From(As(leftFrag, "L")).
 			Join(InnerJoin, As(rightFrag, "R"), on)
 		e.emitSelect(sb)

--- a/internal/chsql/structural_join.go
+++ b/internal/chsql/structural_join.go
@@ -7,6 +7,27 @@ import (
 	"github.com/tsouza/cerberus/internal/chplan"
 )
 
+// verbatim returns a Frag that emits sql as an unquoted token sequence.
+// Used in this file for synthetic emitter-chosen identifiers — local
+// CTE names (`_struct_closure`, `_seed`), the unquoted `_depth` alias,
+// and the qualifier-prefixed `c._depth` / `t.<col>` references that
+// the recursive CTE walks — none of which take user input. The
+// surrounding shape (alias names, the `_depth` column) is fixed by
+// the emitter and pinned by the TraceQL golden fixtures, so the
+// unquoted form is deliberate.
+//
+// This is the in-package writeSQL drop the R6.12.e brief sanctions for
+// shapes that don't fit a typed Frag constructor. R6.12.f deletes
+// chsql.Raw; the structural-CTE shapes here keep needing one of:
+// (a) unquoted alias support on As (the `_depth` literal), (b) an
+// unquoted-qualifier helper for `c.<unquoted-alias>` references,
+// (c) a literal-int Frag for inline depth bounds. Until those land
+// the verbatim escape keeps the typed-Frag rewrite local without
+// growing builder.go's public surface for one-off CTE plumbing.
+func verbatim(sql string) Frag {
+	return func(b *Builder) { b.sb.WriteString(sql) }
+}
+
 // emitStructuralJoin renders a TraceQL structural relation against
 // the otel_traces span table. The result projects the right-hand
 // span's columns (TraceQL convention: `A > B` returns the matched B
@@ -68,7 +89,7 @@ func (e *emitter) emitStructuralDirectJoin(j *chplan.StructuralJoin) error {
 	}
 
 	sb := NewQuery().
-		Select(Raw("R.*")).
+		Select(verbatim("R.*")).
 		From(aliasedFrag(leftSub, "L")).
 		Join(
 			InnerJoin,
@@ -201,7 +222,7 @@ func (e *emitter) emitStructuralRecursive(j *chplan.StructuralJoin) error {
 			Col(j.TraceIDColumn),
 			Col(j.SpanIDColumn),
 			Col(j.ParentSpanIDColumn),
-			Raw("0 AS _depth"),
+			verbatim("0 AS _depth"),
 		).
 		From(aliasedFrag(leftSub, "_seed"))
 
@@ -216,12 +237,12 @@ func (e *emitter) emitStructuralRecursive(j *chplan.StructuralJoin) error {
 			qualColFrag("t", j.TraceIDColumn),
 			qualColFrag("t", j.SpanIDColumn),
 			qualColFrag("t", j.ParentSpanIDColumn),
-			Raw("c._depth + 1"),
+			verbatim("c._depth + 1"),
 		).
 		From(aliasedFrag(Col(table), "t")).
 		Join(
 			InnerJoin,
-			aliasedFrag(Raw("_struct_closure"), "c"),
+			aliasedFrag(verbatim("_struct_closure"), "c"),
 			stepOn,
 		)
 	if j.MaxDepth > 0 {
@@ -229,18 +250,18 @@ func (e *emitter) emitStructuralRecursive(j *chplan.StructuralJoin) error {
 		// integer — depth bounds are part of the query shape, not
 		// user data, and CH's recursive-CTE planner needs them
 		// visible (not parameterised).
-		step.Where(Raw("c._depth < " + strconv.Itoa(j.MaxDepth)))
+		step.Where(verbatim("c._depth < " + strconv.Itoa(j.MaxDepth)))
 	}
 
 	// Closure subquery: WITH RECURSIVE _struct_closure AS (<anchor> UNION ALL <step>) SELECT DISTINCT TraceId, SpanId FROM _struct_closure WHERE _depth > 0.
 	closure := NewQuery().
 		WithRecursive("_struct_closure", anchor, step).
 		Select(
-			Raw("DISTINCT "+quoteIdent(j.TraceIDColumn)),
+			Distinct(Col(j.TraceIDColumn)),
 			Col(j.SpanIDColumn),
 		).
-		From(Raw("_struct_closure")).
-		Where(Raw("_depth > 0"))
+		From(verbatim("_struct_closure")).
+		Where(verbatim("_depth > 0"))
 
 	// Outer SELECT R.* FROM (<closure>) AS L INNER JOIN (<R>) AS R ON L.TraceId = R.TraceId AND L.SpanId = R.SpanId.
 	onClause := func(b *Builder) {
@@ -249,7 +270,7 @@ func (e *emitter) emitStructuralRecursive(j *chplan.StructuralJoin) error {
 		spanIDPairFrag("L", j.SpanIDColumn, "R", j.SpanIDColumn)(b)
 	}
 	sb := NewQuery().
-		Select(Raw("R.*")).
+		Select(verbatim("R.*")).
 		From(aliasedFrag(closure.Frag(), "L")).
 		Join(InnerJoin, aliasedFrag(rightSub, "R"), onClause)
 	e.emitSelect(sb)


### PR DESCRIPTION
## Summary

Ports `internal/chsql/{vector_join,structural_join,set_op}.go` from `chsql.Raw + chsql.Concat` to typed Frag constructors landed in R6.12.0 (#197), per the R6.12.e slice.

- **vector_join.go**: already Raw/Concat-free as of R6.6 (verified via `grep -n 'chsql.Raw\|chsql.Concat\|\.Raw(\|\.Concat(' internal/chsql/vector_join.go` → 0 matches). No edits.
- **structural_join.go**: 9 Raw callsites ported. 1 → `Distinct(Col(...))` (typed). 8 → in-package `verbatim` helper (`b.sb.WriteString`).
- **set_op.go**: 1 Raw callsite ported via the same `verbatim` helper.

## Per-file delta

| File | Raw→typed | Raw→verbatim |
|---|---:|---:|
| vector_join.go | 0 | 0 (already clean) |
| structural_join.go | 1 (`Distinct(Col)`) | 8 |
| set_op.go | 0 | 1 |

## Why `verbatim` (sanctioned in-package writeSQL) instead of more typed Frags?

The structural recursive-CTE shape pins **unquoted synthetic identifiers** that the traceql golden fixtures lock byte-for-byte:

- `R.*` / `L.*` — bare alias `.*` projection. `QualStar("R")` would emit `` `R`.* `` (backtick-quoted via `Ident`), breaking every traceql structural fixture (`recursive_descendant.txtar`, `recursive_ancestor.txtar`, `recursive_mixed.txtar`, `structural_join_*.txtar`, `set_intersect_simple.txtar`).
- `0 AS _depth` — literal int with unquoted alias. `As(Lit(0), "_depth")` would emit `? AS \`_depth\`` (the `0` becomes a `?` arg, alias gets backticked).
- `c._depth + 1` / `c._depth < N` / `_depth > 0` — qualifier-prefixed unquoted-alias references. No typed wrapper covers `<qual>.<unquoted-alias>` arithmetic/predicates.
- `_struct_closure` — bare CTE identifier. `Col(name)` would backtick-quote it.

The R6.12.e brief explicitly allows in-package `b.sb.WriteString(...)` for shapes that don't fit a typed Frag constructor. The `verbatim` helper (local to `structural_join.go`, doc-commented) is exactly that drop — synthetic emitter-chosen identifiers, none of which take user input.

## Tiny typed wrappers that would eliminate the verbatim sites (follow-up, post-R6.12.f)

If we want to retire `verbatim` entirely after `Raw + Concat` deletion (R6.12.f), three small typed helpers would do it:

1. **`UnquotedAs(expr Frag, alias string)`** — `<expr> AS <alias>` with the alias rendered bare. Handles `0 AS _depth`, and the existing `aliasedFrag` (vector_join.go) could re-route through it.
2. **`UnquotedQualCol(qual, col string)`** — `<qual>.<col>` with both parts bare. Handles `c._depth` / `t.<alias>` walks in recursive CTEs. The existing `aliasedFrag(Raw("_struct_closure"), "c")` would also use this together with (1).
3. **`IntLit(n int)`** — literal int (no `?` arg), for inline depth bounds and the seed `0`. The CH recursive-CTE planner needs depth bounds visible (not parameterised), so this is a real gap.

I'd rather flag these as a small RC6.12.f-or-later wrapper PR than grow `builder.go` mid-port — the surface needs to settle once the rest of the codebase is fully ported and the `verbatim` callsites are easier to count.

## Test plan

- [x] `go build ./internal/chsql/...` — clean
- [x] `go test ./internal/chsql/... ./internal/traceql/... ./internal/logql/... ./internal/promql/... ./internal/optimizer/...` — all green, zero golden drift (no `GOLDEN_UPDATE=1` needed)
- [ ] CI `check` + `lint` green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)