### PR TITLE
refactor(chsql): port histogram_*.go Raw+Concat to typed Frags (RC6 R6.12.d)

### DIFF
--- a/internal/chsql/histogram_over_time.go
+++ b/internal/chsql/histogram_over_time.go
@@ -112,11 +112,14 @@ func (e *emitter) emitMetricsHistogramOverTime(m *chplan.MetricsHistogramOverTim
 // bound argument: it's part of the query shape, not user data, and the
 // per-attribute bucket arithmetic is otherwise parameter-free.
 func histogramBucketFrag(attr chplan.Expr, isDuration bool) Frag {
+	attrFrag := func(b *Builder) { _ = b.Expr(attr) }
 	return func(b *Builder) {
-		b.sb.WriteString("log2(")
-		_ = b.Expr(attr)
-		b.sb.WriteByte(')')
+		Call("log2", attrFrag)(b)
 		if isDuration {
+			// "/ 1e9" — inline divisor (query-shape constant, not user
+			// data); no typed Frag for inline-int literals so the suffix
+			// is appended via direct write. Flagged for R6.12.f if/when
+			// an InlineLit / RawLit Frag lands.
 			b.sb.WriteString(" / 1000000000")
 		}
 	}

--- a/internal/chsql/histogram_quantile.go
+++ b/internal/chsql/histogram_quantile.go
@@ -85,6 +85,15 @@ func (e *emitter) emitHistogramQuantile(h *chplan.HistogramQuantile) error {
 func histogramQuantileValueFrag(h *chplan.HistogramQuantile) Frag {
 	bc := h.BucketCountsColumn
 	eb := h.ExplicitBoundsColumn
+	// Reusable typed Frags for the function-call shapes; closures below
+	// inline these into the if() chain. The non-Call structure (if()
+	// nesting, "[idx]" array indexing, inline phi formatFloat literal)
+	// keeps the in-package b.writeSQL path — no typed Frag covers those
+	// shapes yet, flagged for R6.12.f.
+	lengthBC := Call("length", Col(bc))
+	lengthEB := Call("length", Col(eb))
+	arraySumBC := Call("arraySum", Col(bc))
+	arrayCumSumBC := Call("arrayCumSum", Col(bc))
 	return func(b *Builder) {
 		// Empty histogram → NaN. arrayCumSum on an empty array is empty;
 		// `length(cum) = 0` and `total = 0`. Guard the divide-by-zero +
@@ -93,9 +102,9 @@ func histogramQuantileValueFrag(h *chplan.HistogramQuantile) Frag {
 		// We emit one binding of phi for the multiply-by-total branch;
 		// the phi-bounds short-circuits below bind it again so each
 		// branch carries its own `?` placeholder.
-		b.writeSQL("if(length(")
-		b.Ident(bc)
-		b.writeSQL(") = 0, nan, ")
+		b.writeSQL("if(")
+		lengthBC(b)
+		b.writeSQL(" = 0, nan, ")
 		// total = cum[length(cum)]; cum = arrayCumSum(bc).
 		// Outer if: total = 0 → NaN. We materialise `cum` and `total`
 		// inline via subexpression rather than CTE to keep the shape flat.
@@ -110,9 +119,9 @@ func histogramQuantileValueFrag(h *chplan.HistogramQuantile) Frag {
 		// edge of bucket 1 is conventionally 0 for non-negative
 		// observations; matches upstream Prom's p0 behavior).
 		// `highest_bound` is the last entry in ExplicitBounds.
-		b.writeSQL("if(arraySum(")
-		b.Ident(bc)
-		b.writeSQL(") = 0, nan, ")
+		b.writeSQL("if(")
+		arraySumBC(b)
+		b.writeSQL(" = 0, nan, ")
 		b.writeSQL("if(")
 		b.writeSQL(formatFloat(h.Phi))
 		b.writeSQL(" <= 0, 0.0, ")
@@ -120,9 +129,9 @@ func histogramQuantileValueFrag(h *chplan.HistogramQuantile) Frag {
 		b.writeSQL(formatFloat(h.Phi))
 		b.writeSQL(" >= 1, ")
 		b.Ident(eb)
-		b.writeSQL("[length(")
-		b.Ident(eb)
-		b.writeSQL(")], ")
+		b.writeSQL("[")
+		lengthEB(b)
+		b.writeSQL("], ")
 		// Interpolation branch.
 		// Bind phi for the target multiplier and build the lookup.
 		// Using CH's let-like binding by re-evaluating subexprs is
@@ -143,19 +152,25 @@ func histogramQuantileValueFrag(h *chplan.HistogramQuantile) Frag {
 		//
 		// `idx` is rendered three times in the sub-expression; we
 		// recompute it each time rather than CTE-ing. CH CSE folds it.
+		// arrayFirstIndex(c -> ..., arrayCumSum(bc)) — the lambda body
+		// uses a bound var `c`; Builder.Lambda emits "(c) -> ..." which
+		// drifts vs. the existing "c -> ..." output, so the in-package
+		// b.writeSQL path is kept for the lambda. Flagged for R6.12.f
+		// if/when a parens-less lambda Frag lands. The outer
+		// arrayFirstIndex call wraps the cum frag via Call once the
+		// lambda is emitted.
 		writeIdx := func() {
 			b.writeSQL("arrayFirstIndex(c -> c >= (")
 			b.writeSQL(formatFloat(h.Phi))
-			b.writeSQL(" * arraySum(")
-			b.Ident(bc)
-			b.writeSQL(")), arrayCumSum(")
-			b.Ident(bc)
-			b.writeSQL("))")
+			b.writeSQL(" * ")
+			arraySumBC(b)
+			b.writeSQL("), ")
+			arrayCumSumBC(b)
+			b.writeSQL(")")
 		}
 		writeCumAt := func(offset string) {
-			b.writeSQL("arrayCumSum(")
-			b.Ident(bc)
-			b.writeSQL(")[")
+			arrayCumSumBC(b)
+			b.writeSQL("[")
 			writeIdx()
 			b.writeSQL(offset)
 			b.writeSQL("]")
@@ -170,13 +185,13 @@ func histogramQuantileValueFrag(h *chplan.HistogramQuantile) Frag {
 		// if(idx = length(cum), highest_bound, interpolate)
 		b.writeSQL("if(")
 		writeIdx()
-		b.writeSQL(" = length(arrayCumSum(")
-		b.Ident(bc)
-		b.writeSQL(")), ")
+		b.writeSQL(" = ")
+		Call("length", arrayCumSumBC)(b)
+		b.writeSQL(", ")
 		b.Ident(eb)
-		b.writeSQL("[length(")
-		b.Ident(eb)
-		b.writeSQL(")], ")
+		b.writeSQL("[")
+		lengthEB(b)
+		b.writeSQL("], ")
 		// Interpolate. bound_lo / cum_lo branch on idx = 1.
 		// bound_hi = ExplicitBounds[idx]; cum_hi = cum[idx].
 		// bound_lo = if(idx = 1, 0, ExplicitBounds[idx - 1]);
@@ -193,9 +208,9 @@ func histogramQuantileValueFrag(h *chplan.HistogramQuantile) Frag {
 		writeBoundAt(" - 1")
 		b.writeSQL(")) * ((")
 		b.writeSQL(formatFloat(h.Phi))
-		b.writeSQL(" * arraySum(")
-		b.Ident(bc)
-		b.writeSQL(")) - if(")
+		b.writeSQL(" * ")
+		arraySumBC(b)
+		b.writeSQL(") - if(")
 		writeIdx()
 		b.writeSQL(" = 1, 0.0, ")
 		writeCumAt(" - 1")

--- a/internal/chsql/histogram_quantile_native.go
+++ b/internal/chsql/histogram_quantile_native.go
@@ -101,28 +101,43 @@ func histogramQuantileNativeValueFrag(h *chplan.HistogramQuantileNative) Frag {
 	return func(b *Builder) {
 		phi := formatFloat(h.Phi)
 		// base = pow(2, pow(2, -Scale)). Re-rendered inline at each
-		// use; CH's planner CSEs.
+		// use; CH's planner CSEs. Inline literal `2` and `arrayConcat`
+		// of `[col]` have no typed Frag (no inline-int / array-literal
+		// helpers), so the in-package b.writeSQL path is kept for the
+		// shape's outer layout; the inner pow/arrayCumSum function
+		// shells use typed Call where they would otherwise duplicate
+		// "fn(" + ... + ")" string fragments.
 		writeBase := func() {
 			b.writeSQL("pow(2, pow(2, -")
 			b.Ident(scale)
 			b.writeSQL("))")
 		}
 		// cum = arrayCumSum(arrayConcat([ZeroCount], PositiveBucketCounts)).
-		writeCum := func() {
-			b.writeSQL("arrayCumSum(arrayConcat([")
+		// The arrayConcat([col], col) shape uses an array-literal "[col]"
+		// which has no typed Frag; structure preserved via b.writeSQL.
+		// The arrayCumSum wrapper is emitted via typed Call once the
+		// arrayConcat body is rendered.
+		cumBody := func(b *Builder) {
+			b.writeSQL("arrayConcat([")
 			b.Ident(zc)
 			b.writeSQL("], ")
 			b.Ident(pbc)
-			b.writeSQL("))")
+			b.writeSQL(")")
+		}
+		writeCum := func() {
+			Call("arrayCumSum", cumBody)(b)
 		}
 		// total = cum[length(cum)] — last element of cum.
 		writeTotal := func() {
 			writeCum()
-			b.writeSQL("[length(")
-			writeCum()
-			b.writeSQL(")]")
+			b.writeSQL("[")
+			Call("length", func(b *Builder) { writeCum() })(b)
+			b.writeSQL("]")
 		}
-		// idx = arrayFirstIndex(c -> c >= phi*total, cum)
+		// idx = arrayFirstIndex(c -> c >= phi*total, cum).
+		// Lambda body uses bound var `c`; Builder.Lambda emits "(c) ->"
+		// which drifts vs. "c ->" output, so the in-package writeSQL
+		// path is kept here. Flagged for R6.12.f.
 		writeIdx := func() {
 			b.writeSQL("arrayFirstIndex(c -> c >= (")
 			b.writeSQL(phi)
@@ -164,9 +179,9 @@ func histogramQuantileNativeValueFrag(h *chplan.HistogramQuantileNative) Frag {
 		writeBase()
 		b.writeSQL(", ")
 		b.Ident(po)
-		b.writeSQL(" + length(")
-		b.Ident(pbc)
-		b.writeSQL(")), ")
+		b.writeSQL(" + ")
+		Call("length", Col(pbc))(b)
+		b.writeSQL("), ")
 		// if(idx = 1, ZeroThreshold, ...
 		b.writeSQL("if(")
 		writeIdx()


### PR DESCRIPTION
## Summary

R6.12.d port for the histogram emitters under `internal/chsql/`.

The scoped audit (`grep 'chsql.Raw\|chsql.Concat' internal/chsql/histogram*.go`) returns **zero** callsites — the three files already use the in-package `b.writeSQL` escape hatch instead of the typed `Raw` / `Concat` Frags. So this port targets the next layer down: convert the function-call shapes that fit R6.12.0's typed constructors (`Call`, `Parametric`, `Star`, `QualStar`, `Distinct`, `IsNull`, `Between`) to those typed Frags, byte-identically.

## Per-file delta

- **`histogram_over_time.go`** — `log2(<attr>)` lifted to `Call("log2", attrFrag)`; `/ 1e9` suffix stays on `b.writeSQL` (inline-int literal, no typed Frag).
- **`histogram_quantile.go`** — `length(bc)`, `length(eb)`, `arraySum(bc)`, `arrayCumSum(bc)`, `length(arrayCumSum(bc))` lifted to typed `Call` Frags, hoisted to package-scope-style reuse inside the closure so each repetition reuses the same Frag.
- **`histogram_quantile_native.go`** — `arrayCumSum(arrayConcat([zc], pbc))`, `length(arrayCumSum(arrayConcat([zc], pbc)))`, `length(pbc)` lifted to typed `Call` Frags. `arrayConcat([zc], pbc)` body still flows through `b.writeSQL` because the `[col]` array-literal has no typed Frag.

## Kept on `b.writeSQL` (flagged for R6.12.f)

These shapes have no current typed Frag and porting them would either drift the byte output or require new constructors:

- Inline-formatted float literals (`formatFloat(h.Phi)`, `"2"`, `"0.0"`, `"nan"`) — `Lit()` binds via `?` placeholder and would change the SQL shape.
- `arr[idx]` array-indexing notation.
- `arrayFirstIndex(c -> …, cum)` lambda body — `Builder.Lambda` emits `(c) ->` while the histogram code emits `c ->`; using it would drift output.
- `arrayConcat([col], col)` `[col]` array-literal.
- `if(cond, then, else)` chained guard expressions.
- ` >= 2` / ` >= 0` / `toIntervalNanosecond(<ns>)` inline numeric suffixes.

## Test plan

- [x] `go test ./internal/chsql/...` — pass
- [x] `go test ./internal/{promql,traceql,logql}/...` (covers histogram_quantile + histogram_over_time spec fixtures) — pass
- [x] `go test ./...` — all packages pass
- [x] Zero golden drift (byte-identical output verified by the spec fixture suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)