### PR TITLE
feat(cerberus): otelhttp middleware on all HTTP handlers (RC4 R4.2)

### DIFF
--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -84,9 +84,19 @@ func run(logger *slog.Logger) error {
 	tempoHandler := tempo.New(client, schema.DefaultOTelTraces(), Version, logger.With("api", "tempo"))
 	tempoHandler.Mount(mux)
 
+	// RC4 R4.2: install the W3C+Baggage propagator and a no-op
+	// tracer-provider (real OTLP exporters arrive in R4.5), then wrap
+	// the whole mux with otelhttp so every Prom/Loki/Tempo request gets
+	// a server span named after the matched route. Wrapping at the mux
+	// level — instead of per-handler — keeps the propagator code path
+	// uniform across all three APIs and lets the span name formatter
+	// pull r.Pattern after the mux has resolved the route.
+	installOTel(nil)
+	handler := wrapWithOTel(mux, "cerberus")
+
 	srv := &http.Server{
 		Addr:              cfg.HTTPAddr,
-		Handler:           mux,
+		Handler:           handler,
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 

--- a/cmd/cerberus/otel.go
+++ b/cmd/cerberus/otel.go
@@ -1,0 +1,70 @@
+// otel.go wires the bare-minimum OpenTelemetry plumbing cerberus needs at
+// RC4 R4.2: a no-op tracer-provider (real exporters land in R4.5), the
+// W3C / Baggage propagator pair so incoming `traceparent` headers are
+// honored, and a helper that wraps an HTTP handler with otelhttp so every
+// request becomes a server span whose name derives from the matched
+// http.ServeMux pattern.
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+	tracenoop "go.opentelemetry.io/otel/trace/noop"
+)
+
+// installOTel installs the default propagator (W3C TraceContext + Baggage)
+// and the supplied tracer provider as process globals. Passing nil for tp
+// installs a no-op provider — the safe default until R4.5 wires real
+// OTLP exporters.
+//
+// Idempotent: safe to call multiple times (e.g. from a test setup helper
+// alongside main's call), the last writer wins. Tests that want to
+// observe spans pass their own recording provider.
+func installOTel(tp trace.TracerProvider) {
+	if tp == nil {
+		tp = tracenoop.NewTracerProvider()
+	}
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+}
+
+// wrapWithOTel wraps next with otelhttp so every request gets a server
+// span. The span name is `<METHOD> <route>` where route is the matched
+// http.ServeMux pattern (Go 1.22+ exposes it via http.Request.Pattern).
+// Falls back to "HTTP <METHOD>" when no pattern matched (e.g. 404), so
+// span cardinality stays bounded by the route set rather than the URL
+// space.
+//
+// `service` becomes the otelhttp operation name — kept stable across all
+// routes; per-route disambiguation lives in the formatter.
+func wrapWithOTel(next http.Handler, service string) http.Handler {
+	return otelhttp.NewHandler(next, service,
+		otelhttp.WithSpanNameFormatter(spanNameFromPattern),
+	)
+}
+
+// spanNameFromPattern derives a clean span name from the matched mux
+// pattern. http.ServeMux populates r.Pattern with the registered string
+// (e.g. "GET /api/v1/query"); when no pattern matched (404) it's empty
+// and we fall back to "HTTP <METHOD>" so we never leak full URLs.
+func spanNameFromPattern(_ string, r *http.Request) string {
+	if r == nil {
+		return "HTTP"
+	}
+	if p := strings.TrimSpace(r.Pattern); p != "" {
+		return p
+	}
+	if r.Method != "" {
+		return fmt.Sprintf("HTTP %s", r.Method)
+	}
+	return "HTTP"
+}

--- a/cmd/cerberus/otel_test.go
+++ b/cmd/cerberus/otel_test.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// TestWrapWithOTel_EmitsRouteSpan exercises the full R4.2 wiring path: a
+// real http.ServeMux with registered patterns, wrapped via wrapWithOTel,
+// served through httptest, and verified via an in-memory span recorder.
+// The assertion is purposefully tight: one span, named after the matched
+// pattern. This is the contract R4.3 depends on when it attaches child
+// spans for parse / lower / optimize / emit.
+func TestWrapWithOTel_EmitsRouteSpan(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	t.Cleanup(func() { _ = tp.Shutdown(t.Context()) })
+
+	// Install our recording provider as the process global — otelhttp
+	// pulls the tracer from there. installOTel also re-installs the
+	// W3C+Baggage propagator (idempotent across tests).
+	installOTel(tp)
+	t.Cleanup(func() { installOTel(nil) })
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/query", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := wrapWithOTel(mux, "cerberus")
+
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/query?query=up")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d want 200", resp.StatusCode)
+	}
+
+	spans := exporter.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("span count: got %d want 1; spans=%v", len(spans), spans)
+	}
+	got := spans[0].Name
+	want := "GET /api/v1/query"
+	if got != want {
+		t.Errorf("span name: got %q want %q", got, want)
+	}
+}
+
+// TestWrapWithOTel_FallbackSpanName covers the 404 / unmatched-route case:
+// http.ServeMux leaves r.Pattern empty, so our formatter must fall back
+// to "HTTP <METHOD>" rather than leak the full URL (high-cardinality
+// trap that would blow up the Tempo backend).
+func TestWrapWithOTel_FallbackSpanName(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	t.Cleanup(func() { _ = tp.Shutdown(t.Context()) })
+	installOTel(tp)
+	t.Cleanup(func() { installOTel(nil) })
+
+	mux := http.NewServeMux() // no routes registered
+	handler := wrapWithOTel(mux, "cerberus")
+
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/no/such/route")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	spans := exporter.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("span count: got %d want 1", len(spans))
+	}
+	if got, want := spans[0].Name, "HTTP GET"; got != want {
+		t.Errorf("span name: got %q want %q", got, want)
+	}
+}
+
+// TestWrapWithOTel_PropagatesTraceContext verifies the second half of
+// R4.2: incoming `traceparent` headers are honored so the handler's
+// http.Request.Context() carries the inbound trace ID. Grafana sets
+// traceparent on every datasource query — without this, cerberus spans
+// would be orphaned from the user-initiated trace.
+func TestWrapWithOTel_PropagatesTraceContext(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	t.Cleanup(func() { _ = tp.Shutdown(t.Context()) })
+	installOTel(tp)
+	t.Cleanup(func() { installOTel(nil) })
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /ping", func(w http.ResponseWriter, r *http.Request) {
+		// The handler must see a context whose span context derives
+		// from the inbound traceparent header.
+		sc := trace.SpanContextFromContext(r.Context())
+		if !sc.IsValid() {
+			t.Errorf("handler context: span context invalid; want propagated trace ID")
+		}
+		if got, want := sc.TraceID().String(), "0af7651916cd43dd8448eb211c80319c"; got != want {
+			t.Errorf("trace ID: got %s want %s", got, want)
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := wrapWithOTel(mux, "cerberus")
+
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/ping", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	// W3C traceparent: version-traceid-spanid-flags.
+	req.Header.Set("traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d want 200", resp.StatusCode)
+	}
+}
+
+// TestInstallOTel_InstallsPropagator pins the propagator contract: after
+// installOTel returns, otel.GetTextMapPropagator must list traceparent +
+// baggage as recognized fields. Guards against an accidental regression
+// that drops one of the two.
+func TestInstallOTel_InstallsPropagator(t *testing.T) {
+	installOTel(nil)
+	t.Cleanup(func() {
+		otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator())
+	})
+
+	prop := otel.GetTextMapPropagator()
+	fields := prop.Fields()
+	joined := strings.Join(fields, ",")
+	if !strings.Contains(joined, "traceparent") {
+		t.Errorf("propagator fields missing traceparent: %v", fields)
+	}
+	if !strings.Contains(joined, "baggage") {
+		t.Errorf("propagator fields missing baggage: %v", fields)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,10 @@ require (
 	github.com/prometheus/common v0.67.5
 	github.com/prometheus/prometheus v0.311.3
 	github.com/testcontainers/testcontainers-go/modules/clickhouse v0.42.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0
+	go.opentelemetry.io/otel v1.43.0
+	go.opentelemetry.io/otel/sdk v1.43.0
+	go.opentelemetry.io/otel/trace v1.43.0
 	golang.org/x/tools v0.45.0
 )
 
@@ -168,10 +172,8 @@ require (
 	go.opentelemetry.io/contrib/exporters/autoexport v0.68.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.68.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.67.0 // indirect
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0 // indirect
 	go.opentelemetry.io/contrib/propagators/jaeger v1.43.0 // indirect
 	go.opentelemetry.io/contrib/samplers/jaegerremote v0.36.0 // indirect
-	go.opentelemetry.io/otel v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/jaeger v1.17.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.19.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.19.0 // indirect
@@ -186,10 +188,8 @@ require (
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.43.0 // indirect
 	go.opentelemetry.io/otel/log v0.19.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.43.0 // indirect
 	go.opentelemetry.io/otel/sdk/log v0.19.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
-	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect


### PR DESCRIPTION
## Summary

RC4 R4.2 — wraps the entire cerberus mux with `otelhttp.NewHandler` so every Prom / Loki / Tempo request becomes an OpenTelemetry server span.

- **Wrapping strategy**: single-mux wrap in `cmd/cerberus/main.go` (not per-route, not per-API). Every handler — `prom.Handler.Mount`, `loki.Handler.Mount`, `tempo.Handler.Mount`, plus `/healthz` — flows through one `otelhttp.NewHandler(mux, "cerberus", WithSpanNameFormatter(...))` so the propagator code path is identical across the three APIs.
- **Span naming**: `WithSpanNameFormatter` pulls `r.Pattern` (populated by `http.ServeMux` post-routing in Go 1.22+) — yields clean names like `GET /api/v1/query`, `POST /loki/api/v1/query_range`, `GET /api/search/tag/{name}/values`. Unmatched routes (404) fall back to `HTTP <METHOD>` rather than leaking the full URL, so span-name cardinality is bounded by the registered route set.
- **Propagator**: `installOTel` registers `propagation.NewCompositeTextMapPropagator(TraceContext{}, Baggage{})` so Grafana's inbound `traceparent` headers are honored — verified by `TestWrapWithOTel_PropagatesTraceContext`.
- **Tracer provider**: stays no-op (`tracenoop.NewTracerProvider()`) until R4.5 wires real OTLP exporters. That swap is a one-line change in `installOTel`.

## Files

- `cmd/cerberus/otel.go` (new) — `installOTel` + `wrapWithOTel` + `spanNameFromPattern`.
- `cmd/cerberus/main.go` — wraps `mux` and installs the propagator before `http.Server` starts.
- `cmd/cerberus/otel_test.go` (new) — 4 tests using `tracetest.NewInMemoryExporter` so they don't depend on an external collector.
- `go.mod` — promotes `otelhttp` / `otel` / `otel/sdk` / `otel/trace` from indirect to direct (versions unchanged).

## Test plan

- [x] `go test ./cmd/cerberus/...` — 4 new tests pass (route span, fallback span name, traceparent propagation, propagator install).
- [x] `go test ./internal/api/...` — no regressions in prom/loki/tempo handler suites.
- [x] `go vet ./cmd/cerberus/... ./internal/api/...` clean.
- [ ] CI `check` + `lint` green.

## Roadmap

[`docs/roadmap.md` § RC4 R4.2](https://github.com/tsouza/cerberus/blob/main/docs/roadmap.md#rc4--full-self-observability). R4.3 (pipeline-stage child spans) consumes the propagated request context this PR sets up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)