### PR TITLE
feat(cerberus): env-configurable slog format/level + audit (RC4 R4.1)

### DIFF
--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -27,25 +27,34 @@ import (
 var Version = "dev"
 
 func main() {
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
-	slog.SetDefault(logger)
+	// Bootstrap logger used only until config.FromEnv returns and the
+	// configured logger replaces it. Text + info matches the configured
+	// defaults so the upgrade is invisible when env vars are unset.
+	bootstrap := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	slog.SetDefault(bootstrap)
 
-	if err := run(logger); err != nil {
-		logger.Error("cerberus exited with error", "err", err)
+	if err := run(); err != nil {
+		slog.Default().Error("cerberus exited with error", "err", err)
 		os.Exit(1)
 	}
 }
 
-func run(logger *slog.Logger) error {
+func run() error {
 	cfg, err := config.FromEnv()
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}
+
+	logger := config.NewLogger(os.Stderr, cfg.Log)
+	slog.SetDefault(logger)
+
 	logger.Info("cerberus starting",
 		"version", Version,
 		"http_addr", cfg.HTTPAddr,
 		"ch_addr", cfg.ClickHouse.Addr,
 		"ch_db", cfg.ClickHouse.Database,
+		"log_format", cfg.Log.Format,
+		"log_level", cfg.Log.Level.String(),
 	)
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,81 @@
+# Observability
+
+Cerberus is its own first-class observability customer: it queries OTel-CH
+metrics + logs + traces, and it ships the same shape of telemetry back into
+that store so a self-dashboard works against a running cluster.
+
+The full self-observability stack lands across **RC4**:
+
+| Item | Status | Notes |
+| ---- | ------ | ----- |
+| R4.1 — slog quality pass + env-configurable format / level | landed | this doc |
+| R4.2 — `otelhttp.NewHandler` wraps the Prom / Loki / Tempo handlers | planned | adds one span per HTTP request |
+| R4.3 — Custom spans around parse / lower / optimize / emit / execute | planned | pipeline stage timings |
+| R4.4 — Self-metrics: request count + latency + CH roundtrip + in-flight gauge | planned | HPA-consumable |
+| R4.5 — OTLP exporters wired (`CERBERUS_OTEL_ENDPOINT` / `_INSECURE` / `_SAMPLER` / `_SERVICE_NAME`) | planned | graceful no-op when endpoint unreachable |
+| R4.6 — `deploy/k3s/otel-collector.yaml` + `deploy/grafana/dashboards/cerberus-self.json` | planned | wires the export path end-to-end |
+
+This page only covers what has already shipped. The remaining rows are
+expanded as the milestones land.
+
+## Logging (R4.1, shipped)
+
+Cerberus uses the standard library's [`log/slog`](https://pkg.go.dev/log/slog)
+for structured logging. Two env vars steer the handler:
+
+| Env var               | Default | Allowed values                          | Effect                                   |
+| --------------------- | ------- | --------------------------------------- | ---------------------------------------- |
+| `CERBERUS_LOG_FORMAT` | `text`  | `text`, `json` (case-insensitive)       | slog handler kind                        |
+| `CERBERUS_LOG_LEVEL`  | `info`  | `debug`, `info`, `warn`, `error` (+ `warning` alias) | Minimum level retained by the handler |
+
+Invalid values surface as a startup error rather than silently downgrading
+observability — a typo never ships to prod undetected.
+
+### Format choice
+
+- **`text`** is the local-dev default. Produces a `time=… level=… msg=… key=value …`
+  stream that tails cleanly under `kubectl logs` or `docker logs`.
+- **`json`** is the recommended setting for any deployment with a log
+  aggregator (Loki, GCP Logging, ECS, Splunk). Each record is one
+  newline-delimited JSON object, ready for ingest.
+
+### Level vocabulary in cerberus code
+
+- **`Debug`** — per-request SQL + arg traces. Off in prod by default; flip to
+  `debug` to capture the lowered SQL for a complaint window.
+- **`Info`** — lifecycle events only (`cerberus starting`, `HTTP listener
+  ready`, `signal received, shutting down`, `cerberus stopped`).
+- **`Warn`** — recoverable conditions where the request can still be served
+  meaningfully or the client is at fault (e.g. WebSocket upgrade rejected
+  by the peer in the Loki `/tail` handler).
+- **`Error`** — handler-level failures that produce a 5xx (CH connection
+  reset, plan emission internal error). The bridge to alerting.
+
+### Attribute conventions
+
+The codebase follows a small set of consistent keys so a future query
+across `otel_logs` can filter without guessing:
+
+| Key       | Type   | Notes                                                  |
+| --------- | ------ | ------------------------------------------------------ |
+| `api`     | string | `prom` / `loki` / `tempo`, set on the per-handler logger via `.With("api", ...)` in `cmd/cerberus/main.go` |
+| `promql` / `logql` / `traceql` | string | The query text as received |
+| `sql`     | string | The emitted ClickHouse SQL                             |
+| `args`    | []any  | Parameterised SQL args                                 |
+| `err`     | error  | Native `error` value — slog encodes via `.Error()` for json + `%v` for text |
+| `trace_id`| string | Tempo `traceByID` handler only                         |
+| `tag`     | string | Tempo tag-values handler                               |
+
+Always pass the native `error` as `"err", err` rather than `err.Error()`
+so a future `slog.Handler` middleware can branch on `errors.As` /
+`errors.Is`.
+
+### Examples
+
+```text
+# CERBERUS_LOG_FORMAT=text CERBERUS_LOG_LEVEL=info (defaults)
+time=2026-05-13T10:14:01.000Z level=INFO msg="cerberus starting" version=v1.0.0-RC4 http_addr=:8080 ch_addr=clickhouse:9000 ch_db=otel log_format=text log_level=INFO
+
+# CERBERUS_LOG_FORMAT=json
+{"time":"2026-05-13T10:14:01Z","level":"INFO","msg":"cerberus starting","version":"v1.0.0-RC4","http_addr":":8080","ch_addr":"clickhouse:9000","ch_db":"otel","log_format":"json","log_level":"INFO"}
+```

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -6,14 +6,14 @@ that store so a self-dashboard works against a running cluster.
 
 The full self-observability stack lands across **RC4**:
 
-| Item | Status | Notes |
-| ---- | ------ | ----- |
-| R4.1 — slog quality pass + env-configurable format / level | landed | this doc |
-| R4.2 — `otelhttp.NewHandler` wraps the Prom / Loki / Tempo handlers | planned | adds one span per HTTP request |
-| R4.3 — Custom spans around parse / lower / optimize / emit / execute | planned | pipeline stage timings |
-| R4.4 — Self-metrics: request count + latency + CH roundtrip + in-flight gauge | planned | HPA-consumable |
+| Item                                                                                                  | Status  | Notes                                    |
+| ----------------------------------------------------------------------------------------------------- | ------- | ---------------------------------------- |
+| R4.1 — slog quality pass + env-configurable format / level                                          | landed  | this doc                                 |
+| R4.2 — `otelhttp.NewHandler` wraps the Prom / Loki / Tempo handlers                                 | planned | adds one span per HTTP request           |
+| R4.3 — Custom spans around parse / lower / optimize / emit / execute                                | planned | pipeline stage timings                   |
+| R4.4 — Self-metrics: request count + latency + CH roundtrip + in-flight gauge                       | planned | HPA-consumable                           |
 | R4.5 — OTLP exporters wired (`CERBERUS_OTEL_ENDPOINT` / `_INSECURE` / `_SAMPLER` / `_SERVICE_NAME`) | planned | graceful no-op when endpoint unreachable |
-| R4.6 — `deploy/k3s/otel-collector.yaml` + `deploy/grafana/dashboards/cerberus-self.json` | planned | wires the export path end-to-end |
+| R4.6 — `deploy/k3s/otel-collector.yaml` + `deploy/grafana/dashboards/cerberus-self.json`            | planned | wires the export path end-to-end         |
 
 This page only covers what has already shipped. The remaining rows are
 expanded as the milestones land.
@@ -23,10 +23,10 @@ expanded as the milestones land.
 Cerberus uses the standard library's [`log/slog`](https://pkg.go.dev/log/slog)
 for structured logging. Two env vars steer the handler:
 
-| Env var               | Default | Allowed values                          | Effect                                   |
-| --------------------- | ------- | --------------------------------------- | ---------------------------------------- |
-| `CERBERUS_LOG_FORMAT` | `text`  | `text`, `json` (case-insensitive)       | slog handler kind                        |
-| `CERBERUS_LOG_LEVEL`  | `info`  | `debug`, `info`, `warn`, `error` (+ `warning` alias) | Minimum level retained by the handler |
+| Env var               | Default | Allowed values                                       | Effect                                   |
+| --------------------- | ------- | ---------------------------------------------------- | ---------------------------------------- |
+| `CERBERUS_LOG_FORMAT` | `text`  | `text`, `json` (case-insensitive)                    | slog handler kind                        |
+| `CERBERUS_LOG_LEVEL`  | `info`  | `debug`, `info`, `warn`, `error` (+ `warning` alias) | Minimum level retained by the handler    |
 
 Invalid values surface as a startup error rather than silently downgrading
 observability — a typo never ships to prod undetected.
@@ -56,15 +56,15 @@ observability — a typo never ships to prod undetected.
 The codebase follows a small set of consistent keys so a future query
 across `otel_logs` can filter without guessing:
 
-| Key       | Type   | Notes                                                  |
-| --------- | ------ | ------------------------------------------------------ |
-| `api`     | string | `prom` / `loki` / `tempo`, set on the per-handler logger via `.With("api", ...)` in `cmd/cerberus/main.go` |
-| `promql` / `logql` / `traceql` | string | The query text as received |
-| `sql`     | string | The emitted ClickHouse SQL                             |
-| `args`    | []any  | Parameterised SQL args                                 |
-| `err`     | error  | Native `error` value — slog encodes via `.Error()` for json + `%v` for text |
-| `trace_id`| string | Tempo `traceByID` handler only                         |
-| `tag`     | string | Tempo tag-values handler                               |
+| Key                            | Type   | Notes                                                                                                      |
+| ------------------------------ | ------ | ---------------------------------------------------------------------------------------------------------- |
+| `api`                          | string | `prom` / `loki` / `tempo`, set on the per-handler logger via `.With("api", ...)` in `cmd/cerberus/main.go` |
+| `promql` / `logql` / `traceql` | string | The query text as received                                                                                 |
+| `sql`                          | string | The emitted ClickHouse SQL                                                                                 |
+| `args`                         | []any  | Parameterised SQL args                                                                                     |
+| `err`                          | error  | Native `error` value — slog encodes via `.Error()` for json + `%v` for text                              |
+| `trace_id`                     | string | Tempo `traceByID` handler only                                                                             |
+| `tag`                          | string | Tempo tag-values handler                                                                                   |
 
 Always pass the native `error` as `"err", err` rather than `err.Error()`
 so a future `slog.Handler` middleware can branch on `errors.As` /

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -8,12 +8,12 @@ The full self-observability stack lands across **RC4**:
 
 | Item                                                                                                  | Status  | Notes                                    |
 | ----------------------------------------------------------------------------------------------------- | ------- | ---------------------------------------- |
-| R4.1 — slog quality pass + env-configurable format / level                                          | landed  | this doc                                 |
-| R4.2 — `otelhttp.NewHandler` wraps the Prom / Loki / Tempo handlers                                 | planned | adds one span per HTTP request           |
-| R4.3 — Custom spans around parse / lower / optimize / emit / execute                                | planned | pipeline stage timings                   |
-| R4.4 — Self-metrics: request count + latency + CH roundtrip + in-flight gauge                       | planned | HPA-consumable                           |
-| R4.5 — OTLP exporters wired (`CERBERUS_OTEL_ENDPOINT` / `_INSECURE` / `_SAMPLER` / `_SERVICE_NAME`) | planned | graceful no-op when endpoint unreachable |
-| R4.6 — `deploy/k3s/otel-collector.yaml` + `deploy/grafana/dashboards/cerberus-self.json`            | planned | wires the export path end-to-end         |
+| R4.1 — slog quality pass + env-configurable format / level                                            | landed  | this doc                                 |
+| R4.2 — `otelhttp.NewHandler` wraps the Prom / Loki / Tempo handlers                                   | planned | adds one span per HTTP request           |
+| R4.3 — Custom spans around parse / lower / optimize / emit / execute                                  | planned | pipeline stage timings                   |
+| R4.4 — Self-metrics: request count + latency + CH roundtrip + in-flight gauge                         | planned | HPA-consumable                           |
+| R4.5 — OTLP exporters wired (`CERBERUS_OTEL_ENDPOINT` / `_INSECURE` / `_SAMPLER` / `_SERVICE_NAME`)   | planned | graceful no-op when endpoint unreachable |
+| R4.6 — `deploy/k3s/otel-collector.yaml` + `deploy/grafana/dashboards/cerberus-self.json`              | planned | wires the export path end-to-end         |
 
 This page only covers what has already shipped. The remaining rows are
 expanded as the milestones land.
@@ -62,7 +62,7 @@ across `otel_logs` can filter without guessing:
 | `promql` / `logql` / `traceql` | string | The query text as received                                                                                 |
 | `sql`                          | string | The emitted ClickHouse SQL                                                                                 |
 | `args`                         | []any  | Parameterised SQL args                                                                                     |
-| `err`                          | error  | Native `error` value — slog encodes via `.Error()` for json + `%v` for text                              |
+| `err`                          | error  | Native `error` value — slog encodes via `.Error()` for json + `%v` for text                                |
 | `trace_id`                     | string | Tempo `traceByID` handler only                                                                             |
 | `tag`                          | string | Tempo tag-values handler                                                                                   |
 

--- a/internal/api/loki/detected_fields.go
+++ b/internal/api/loki/detected_fields.go
@@ -94,7 +94,7 @@ func (h *Handler) handleDetectedFields(w http.ResponseWriter, r *http.Request) {
 
 	lines, err := h.Client.QueryStrings(r.Context(), sqlStr, args...)
 	if err != nil {
-		h.Logger.Warn("cerberus loki detected_fields CH query failed", "err", err.Error(), "sql", sqlStr)
+		h.Logger.Error("cerberus loki detected_fields CH query failed", "err", err, "sql", sqlStr)
 		h.respondError(w, &apiError{kind: ErrInternal, err: err, status: http.StatusBadGateway})
 		return
 	}

--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -216,7 +216,7 @@ func (h *Handler) execute(ctx context.Context, expr syntax.Expr) ([]chclient.Sam
 
 	samples, err := h.Client.Query(ctx, sqlStr, args...)
 	if err != nil {
-		h.Logger.Warn("cerberus loki CH query failed", "err", err.Error(), "sql", sqlStr)
+		h.Logger.Error("cerberus loki CH query failed", "err", err, "sql", sqlStr)
 		return nil, &apiError{kind: ErrInternal, err: err, status: http.StatusBadGateway}
 	}
 	return samples, nil

--- a/internal/api/loki/index_stats.go
+++ b/internal/api/loki/index_stats.go
@@ -61,7 +61,7 @@ func (h *Handler) handleIndexStats(w http.ResponseWriter, r *http.Request) {
 
 	row, err := h.Client.QueryIndexStats(r.Context(), sqlStr, args...)
 	if err != nil {
-		h.Logger.Warn("cerberus loki index_stats CH query failed", "err", err.Error(), "sql", sqlStr)
+		h.Logger.Error("cerberus loki index_stats CH query failed", "err", err, "sql", sqlStr)
 		h.respondError(w, &apiError{kind: ErrInternal, err: err, status: http.StatusBadGateway})
 		return
 	}

--- a/internal/api/loki/index_volume.go
+++ b/internal/api/loki/index_volume.go
@@ -70,7 +70,7 @@ func (h *Handler) handleIndexVolume(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := h.Client.QueryIndexVolume(r.Context(), sqlStr, args...)
 	if err != nil {
-		h.Logger.Warn("cerberus loki index_volume CH query failed", "err", err.Error(), "sql", sqlStr)
+		h.Logger.Error("cerberus loki index_volume CH query failed", "err", err, "sql", sqlStr)
 		h.respondError(w, &apiError{kind: ErrInternal, err: err, status: http.StatusBadGateway})
 		return
 	}

--- a/internal/api/loki/label_values.go
+++ b/internal/api/loki/label_values.go
@@ -54,7 +54,7 @@ func (h *Handler) handleLabelValues(w http.ResponseWriter, r *http.Request) {
 
 	vals, err := h.Client.QueryStrings(r.Context(), sqlStr, args...)
 	if err != nil {
-		h.Logger.Warn("cerberus loki label values CH query failed", "err", err.Error(), "sql", sqlStr)
+		h.Logger.Error("cerberus loki label values CH query failed", "err", err, "sql", sqlStr)
 		h.respondError(w, &apiError{kind: ErrInternal, err: err, status: http.StatusBadGateway})
 		return
 	}

--- a/internal/api/loki/labels.go
+++ b/internal/api/loki/labels.go
@@ -49,7 +49,7 @@ func (h *Handler) handleLabels(w http.ResponseWriter, r *http.Request) {
 
 	vals, err := h.Client.QueryStrings(r.Context(), sqlStr, args...)
 	if err != nil {
-		h.Logger.Warn("cerberus loki labels CH query failed", "err", err.Error(), "sql", sqlStr)
+		h.Logger.Error("cerberus loki labels CH query failed", "err", err, "sql", sqlStr)
 		h.respondError(w, &apiError{kind: ErrInternal, err: err, status: http.StatusBadGateway})
 		return
 	}

--- a/internal/api/loki/series.go
+++ b/internal/api/loki/series.go
@@ -62,7 +62,7 @@ func (h *Handler) handleSeries(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := h.Client.QueryLabelSets(r.Context(), sqlStr, args...)
 	if err != nil {
-		h.Logger.Warn("cerberus loki series CH query failed", "err", err.Error(), "sql", sqlStr)
+		h.Logger.Error("cerberus loki series CH query failed", "err", err, "sql", sqlStr)
 		h.respondError(w, &apiError{kind: ErrInternal, err: err, status: http.StatusBadGateway})
 		return
 	}

--- a/internal/api/loki/tail.go
+++ b/internal/api/loki/tail.go
@@ -132,7 +132,7 @@ func (h *Handler) handleTail(w http.ResponseWriter, r *http.Request) {
 	conn, err := tailUpgrader.Upgrade(w, r, nil)
 	if err != nil {
 		// Upgrade has already written the HTTP error response; just log.
-		h.Logger.Warn("cerberus loki tail upgrade failed", "err", err.Error())
+		h.Logger.Warn("cerberus loki tail upgrade failed", "err", err)
 		return
 	}
 	defer func() { _ = conn.Close() }()
@@ -212,13 +212,13 @@ func (h *Handler) runTailLoop(ctx context.Context, conn *websocket.Conn, cfg tai
 
 		sqlStr, args, err := buildTailSQL(cfg.schema, cfg.matchers, cursor, end, cfg.limit)
 		if err != nil {
-			h.Logger.Warn("cerberus loki tail buildSQL failed", "err", err.Error())
+			h.Logger.Error("cerberus loki tail buildSQL failed", "err", err)
 			return
 		}
 
 		samples, err := h.Client.Query(loopCtx, sqlStr, args...)
 		if err != nil {
-			h.Logger.Warn("cerberus loki tail CH query failed", "err", err.Error())
+			h.Logger.Error("cerberus loki tail CH query failed", "err", err)
 			return
 		}
 
@@ -246,7 +246,7 @@ func (h *Handler) runTailLoop(ctx context.Context, conn *websocket.Conn, cfg tai
 		if err := writeTailChunk(conn, streams); err != nil {
 			// Write failure usually means client disconnected; bail
 			// cleanly so the deferred Close runs.
-			h.Logger.Debug("cerberus loki tail write failed", "err", err.Error())
+			h.Logger.Debug("cerberus loki tail write failed", "err", err)
 			return
 		}
 	}

--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -143,7 +143,7 @@ func (h *Handler) handleSearch(w http.ResponseWriter, r *http.Request) {
 
 	samples, err := h.Client.Query(ctx, sqlStr, args...)
 	if err != nil {
-		h.Logger.Warn("cerberus tempo search CH query failed", "err", err.Error(), "sql", sqlStr)
+		h.Logger.Error("cerberus tempo search CH query failed", "err", err, "sql", sqlStr)
 		writeError(w, http.StatusBadGateway, "", "", err)
 		return
 	}
@@ -195,7 +195,7 @@ func (h *Handler) handleSearchRecent(w http.ResponseWriter, r *http.Request) {
 
 	samples, err := h.Client.Query(ctx, sqlStr, args...)
 	if err != nil {
-		h.Logger.Warn("cerberus tempo search/recent CH query failed", "err", err.Error(), "sql", sqlStr)
+		h.Logger.Error("cerberus tempo search/recent CH query failed", "err", err, "sql", sqlStr)
 		writeError(w, http.StatusBadGateway, "", "", err)
 		return
 	}
@@ -232,7 +232,7 @@ func (h *Handler) handleTraceByID(w http.ResponseWriter, r *http.Request) {
 
 	samples, err := h.Client.Query(r.Context(), sqlStr, args...)
 	if err != nil {
-		h.Logger.Warn("cerberus tempo traceByID CH query failed", "err", err.Error(), "trace_id", traceID, "sql", sqlStr)
+		h.Logger.Error("cerberus tempo traceByID CH query failed", "err", err, "trace_id", traceID, "sql", sqlStr)
 		writeError(w, http.StatusBadGateway, traceID, "", err)
 		return
 	}

--- a/internal/api/tempo/search_tag_values.go
+++ b/internal/api/tempo/search_tag_values.go
@@ -101,7 +101,7 @@ func (h *Handler) respondTagValues(w http.ResponseWriter, r *http.Request, v2 bo
 
 	values, err := h.Client.QueryStrings(r.Context(), sqlStr, args...)
 	if err != nil {
-		h.Logger.Warn("cerberus tempo /search/tag/values CH query failed", "err", err.Error(), "tag", name)
+		h.Logger.Error("cerberus tempo /search/tag/values CH query failed", "err", err, "tag", name)
 		writeError(w, http.StatusBadGateway, "", "", err)
 		return
 	}

--- a/internal/api/tempo/search_tags.go
+++ b/internal/api/tempo/search_tags.go
@@ -92,13 +92,13 @@ func (h *Handler) respondTags(w http.ResponseWriter, r *http.Request, v2 bool) {
 
 	resourceTags, err := h.fetchTagKeys(r.Context(), h.Schema.ResourceAttributesColumn, start, end)
 	if err != nil {
-		h.Logger.Warn("cerberus tempo /search/tags resource CH query failed", "err", err.Error())
+		h.Logger.Error("cerberus tempo /search/tags resource CH query failed", "err", err)
 		writeError(w, http.StatusBadGateway, "", "", err)
 		return
 	}
 	spanTags, err := h.fetchTagKeys(r.Context(), h.Schema.AttributesColumn, start, end)
 	if err != nil {
-		h.Logger.Warn("cerberus tempo /search/tags span CH query failed", "err", err.Error())
+		h.Logger.Error("cerberus tempo /search/tags span CH query failed", "err", err)
 		writeError(w, http.StatusBadGateway, "", "", err)
 		return
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,8 @@ package config
 
 import (
 	"fmt"
+	"io"
+	"log/slog"
 	"os"
 	"strconv"
 	"strings"
@@ -28,6 +30,23 @@ type Config struct {
 	// (every statement carries CREATE TABLE IF NOT EXISTS) so enabling
 	// the flag on an already-populated ClickHouse is a no-op.
 	AutoCreateSchema bool
+
+	// Log configures cerberus's own structured logging (stdlib log/slog).
+	// See LogConfig for the env-var contract.
+	Log LogConfig
+}
+
+// LogConfig controls the slog setup applied at startup.
+//
+//   - Format is the slog handler kind. "text" produces a human-readable
+//     stream suited to local development; "json" produces newline-delimited
+//     JSON suited to log aggregators (Loki / ECS / GCP).
+//   - Level is the minimum level recorded; lower-severity records are
+//     dropped at the handler. Supported: "debug", "info" (default),
+//     "warn", "error".
+type LogConfig struct {
+	Format string
+	Level  slog.Level
 }
 
 // FromEnv reads configuration from environment variables, falling back to
@@ -40,6 +59,8 @@ type Config struct {
 //	CERBERUS_CH_PASSWORD           default ""
 //	CERBERUS_CH_DIAL_TIMEOUT       default "5s"
 //	CERBERUS_AUTO_CREATE_SCHEMA    default "false"
+//	CERBERUS_LOG_FORMAT            default "text"  ("text" | "json")
+//	CERBERUS_LOG_LEVEL             default "info"  ("debug" | "info" | "warn" | "error")
 func FromEnv() (Config, error) {
 	dial, err := time.ParseDuration(envDefault("CERBERUS_CH_DIAL_TIMEOUT", "5s"))
 	if err != nil {
@@ -48,6 +69,10 @@ func FromEnv() (Config, error) {
 	autoCreate, err := envBool("CERBERUS_AUTO_CREATE_SCHEMA", false)
 	if err != nil {
 		return Config{}, fmt.Errorf("CERBERUS_AUTO_CREATE_SCHEMA: %w", err)
+	}
+	logCfg, err := envLog()
+	if err != nil {
+		return Config{}, err
 	}
 	return Config{
 		HTTPAddr: envDefault("CERBERUS_HTTP_ADDR", ":8080"),
@@ -60,7 +85,25 @@ func FromEnv() (Config, error) {
 		},
 		Schema:           schema.DefaultOTelMetrics(),
 		AutoCreateSchema: autoCreate,
+		Log:              logCfg,
 	}, nil
+}
+
+// NewLogger builds a *slog.Logger from a LogConfig writing to w. The
+// caller is responsible for installing the result as the slog default
+// (e.g. via slog.SetDefault) if global propagation is desired. Accepting
+// io.Writer keeps the helper trivially testable (a *bytes.Buffer drops
+// straight in).
+func NewLogger(w io.Writer, cfg LogConfig) *slog.Logger {
+	opts := &slog.HandlerOptions{Level: cfg.Level}
+	var h slog.Handler
+	switch cfg.Format {
+	case "json":
+		h = slog.NewJSONHandler(w, opts)
+	default:
+		h = slog.NewTextHandler(w, opts)
+	}
+	return slog.New(h)
 }
 
 func envDefault(key, def string) string {
@@ -84,4 +127,31 @@ func envBool(key string, def bool) (bool, error) {
 		return false, fmt.Errorf("invalid boolean %q: %w", v, err)
 	}
 	return b, nil
+}
+
+// envLog parses CERBERUS_LOG_FORMAT + CERBERUS_LOG_LEVEL into a LogConfig.
+// Unset values default to "text" / "info"; invalid values fail fast at
+// startup so a typo never silently downgrades observability.
+func envLog() (LogConfig, error) {
+	format := strings.ToLower(strings.TrimSpace(envDefault("CERBERUS_LOG_FORMAT", "text")))
+	switch format {
+	case "text", "json":
+	default:
+		return LogConfig{}, fmt.Errorf("CERBERUS_LOG_FORMAT: invalid value %q (want \"text\" or \"json\")", format)
+	}
+	levelStr := strings.ToLower(strings.TrimSpace(envDefault("CERBERUS_LOG_LEVEL", "info")))
+	var level slog.Level
+	switch levelStr {
+	case "debug":
+		level = slog.LevelDebug
+	case "info":
+		level = slog.LevelInfo
+	case "warn", "warning":
+		level = slog.LevelWarn
+	case "error":
+		level = slog.LevelError
+	default:
+		return LogConfig{}, fmt.Errorf("CERBERUS_LOG_LEVEL: invalid value %q (want \"debug\", \"info\", \"warn\", or \"error\")", levelStr)
+	}
+	return LogConfig{Format: format, Level: level}, nil
 }

--- a/internal/config/log_test.go
+++ b/internal/config/log_test.go
@@ -1,0 +1,164 @@
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// TestFromEnv_Log_Defaults confirms the slog format/level defaults match
+// the documented contract — text + info when neither env var is set, so
+// dev shells produce a human-readable stream and prod overrides flip to
+// json.
+func TestFromEnv_Log_Defaults(t *testing.T) {
+	t.Setenv("CERBERUS_LOG_FORMAT", "")
+	t.Setenv("CERBERUS_LOG_LEVEL", "")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if cfg.Log.Format != "text" {
+		t.Errorf("Log.Format = %q; want %q", cfg.Log.Format, "text")
+	}
+	if cfg.Log.Level != slog.LevelInfo {
+		t.Errorf("Log.Level = %v; want %v", cfg.Log.Level, slog.LevelInfo)
+	}
+}
+
+// TestFromEnv_Log_FormatParsing covers the accepted format vocabulary
+// (case-insensitive, whitespace trimmed) and the reject path.
+func TestFromEnv_Log_FormatParsing(t *testing.T) {
+	good := []struct {
+		val  string
+		want string
+	}{
+		{"text", "text"},
+		{"json", "json"},
+		{"TEXT", "text"},
+		{"JSON", "json"},
+		{"  json  ", "json"},
+	}
+	for _, tc := range good {
+		t.Run("ok/"+tc.val, func(t *testing.T) {
+			t.Setenv("CERBERUS_LOG_FORMAT", tc.val)
+			cfg, err := FromEnv()
+			if err != nil {
+				t.Fatalf("FromEnv: %v", err)
+			}
+			if cfg.Log.Format != tc.want {
+				t.Errorf("Log.Format = %q; want %q", cfg.Log.Format, tc.want)
+			}
+		})
+	}
+	t.Run("reject/yaml", func(t *testing.T) {
+		t.Setenv("CERBERUS_LOG_FORMAT", "yaml")
+		if _, err := FromEnv(); err == nil {
+			t.Fatal("FromEnv: want error for invalid format, got nil")
+		}
+	})
+}
+
+// TestFromEnv_Log_LevelParsing covers every accepted level keyword + the
+// reject path. The "warning" alias is accepted because slog itself prints
+// the level as "WARN" — operators sometimes type the full word.
+func TestFromEnv_Log_LevelParsing(t *testing.T) {
+	good := []struct {
+		val  string
+		want slog.Level
+	}{
+		{"debug", slog.LevelDebug},
+		{"DEBUG", slog.LevelDebug},
+		{"info", slog.LevelInfo},
+		{"warn", slog.LevelWarn},
+		{"warning", slog.LevelWarn},
+		{"error", slog.LevelError},
+		{"  ERROR  ", slog.LevelError},
+	}
+	for _, tc := range good {
+		t.Run("ok/"+tc.val, func(t *testing.T) {
+			t.Setenv("CERBERUS_LOG_LEVEL", tc.val)
+			cfg, err := FromEnv()
+			if err != nil {
+				t.Fatalf("FromEnv: %v", err)
+			}
+			if cfg.Log.Level != tc.want {
+				t.Errorf("Log.Level = %v; want %v", cfg.Log.Level, tc.want)
+			}
+		})
+	}
+	t.Run("reject/trace", func(t *testing.T) {
+		t.Setenv("CERBERUS_LOG_LEVEL", "trace")
+		if _, err := FromEnv(); err == nil {
+			t.Fatal("FromEnv: want error for invalid level, got nil")
+		}
+	})
+}
+
+// TestNewLogger_JSON confirms the json format emits one valid JSON
+// object per record so log aggregators can parse the stream — this is
+// the load-bearing property of the format flag.
+func TestNewLogger_JSON(t *testing.T) {
+	var buf bytes.Buffer
+	logger := NewLogger(&buf, LogConfig{Format: "json", Level: slog.LevelInfo})
+	logger.Info("hello", "k", "v", "n", 7)
+
+	line := strings.TrimSpace(buf.String())
+	var out map[string]any
+	if err := json.Unmarshal([]byte(line), &out); err != nil {
+		t.Fatalf("json.Unmarshal(%q): %v", line, err)
+	}
+	if got := out["msg"]; got != "hello" {
+		t.Errorf("msg = %v; want %q", got, "hello")
+	}
+	if got := out["k"]; got != "v" {
+		t.Errorf("k = %v; want %q", got, "v")
+	}
+	if got, ok := out["n"].(float64); !ok || got != 7 {
+		t.Errorf("n = %v; want 7", out["n"])
+	}
+	if got := out["level"]; got != "INFO" {
+		t.Errorf("level = %v; want %q", got, "INFO")
+	}
+}
+
+// TestNewLogger_Text confirms the text handler produces a human-readable
+// "key=value" stream — the default for local dev.
+func TestNewLogger_Text(t *testing.T) {
+	var buf bytes.Buffer
+	logger := NewLogger(&buf, LogConfig{Format: "text", Level: slog.LevelInfo})
+	logger.Info("hello", "k", "v")
+	if !strings.Contains(buf.String(), "msg=hello") || !strings.Contains(buf.String(), "k=v") {
+		t.Errorf("text output missing expected fields: %q", buf.String())
+	}
+}
+
+// TestNewLogger_LevelFilter confirms records below the configured level
+// are dropped at the handler — operators flip the level to silence debug
+// in prod and trust nothing slips through.
+func TestNewLogger_LevelFilter(t *testing.T) {
+	var buf bytes.Buffer
+	logger := NewLogger(&buf, LogConfig{Format: "text", Level: slog.LevelWarn})
+	logger.Info("dropped")
+	logger.Warn("kept")
+	out := buf.String()
+	if strings.Contains(out, "dropped") {
+		t.Errorf("info record leaked under warn level: %q", out)
+	}
+	if !strings.Contains(out, "kept") {
+		t.Errorf("warn record missing under warn level: %q", out)
+	}
+}
+
+// TestNewLogger_UnknownFormatFallsBackToText guards against a future
+// caller passing an unvalidated LogConfig — NewLogger should never panic
+// or return nil. Unknown formats fall through to the text handler.
+func TestNewLogger_UnknownFormatFallsBackToText(t *testing.T) {
+	var buf bytes.Buffer
+	logger := NewLogger(&buf, LogConfig{Format: "yaml", Level: slog.LevelInfo})
+	logger.Info("hi")
+	if !strings.Contains(buf.String(), "msg=hi") {
+		t.Errorf("unknown format did not fall back to text: %q", buf.String())
+	}
+}


### PR DESCRIPTION
## Summary

Cerberus's RC4 observability story starts here. Two env knobs make the
slog setup production-grade, and a quality pass on existing log callsites
sharpens the structured-attr / level discipline before the upcoming OTel
exporters (R4.5) start ingesting these records into the same OTel-CH
store cerberus queries.

## Why

- Today \`cmd/cerberus/main.go\` hard-codes a text handler at info — fine
  for dev, useless for any deployment with a log aggregator. R4.1 lifts
  format + level out into env vars (\`CERBERUS_LOG_FORMAT\`,
  \`CERBERUS_LOG_LEVEL\`).
- Existing handler logs use a few patterns that work but lose signal once
  records hit a structured pipeline:
  - \`\"err\", err.Error()\` strings the error early, so a future
    slog middleware can't \`errors.As\` / \`errors.Is\` on it. slog
    encodes \`error\` natively.
  - Every CH-query failure logs at **Warn** — but they all return 5xx
    (BadGateway). Warn masks the alertable bucket. Bumped to **Error**.
  - Loki \`/tail\` buildSQL + CH query failures: each terminates the
    WebSocket stream cleanly — those are Errors. Upgrade + write
    failures stay at Warn / Debug (client disconnects).

## What changed

- \`internal/config/config.go\` — adds \`LogConfig\` (format + level) and
  \`NewLogger(io.Writer, LogConfig) *slog.Logger\`. \`FromEnv\` parses
  \`CERBERUS_LOG_FORMAT\` (\`text\` | \`json\`, default \`text\`) and
  \`CERBERUS_LOG_LEVEL\` (\`debug\` | \`info\` | \`warn\` | \`error\`,
  default \`info\`). Invalid values fail fast at startup.
- \`cmd/cerberus/main.go\` — installs a bootstrap logger up to
  \`config.FromEnv\`, then \`config.NewLogger\` + \`slog.SetDefault\`
  takes over. Startup record now carries the resolved \`log_format\` +
  \`log_level\` so operators can see what cerberus actually picked.
- \`internal/api/{loki,tempo}/*.go\` — 17 log callsites audited. Every CH
  query failure is now an Error with the native error attached, not a
  Warn with a stringified error.
- \`docs/observability.md\` — landing page for the wider RC4 stack;
  R4.1 documented now, R4.2 – R4.7 listed as planned.
- \`internal/config/log_test.go\` — covers env defaults, format/level
  parsing (case-insensitive, whitespace-trimmed, reject paths), JSON +
  text output shape, level filtering, and the unknown-format
  fallback-to-text guard.

## Design forks taken

- Kept slog setup in \`internal/config\` rather than splitting an
  \`internal/log/\` package — only \`cmd/cerberus\` builds the logger;
  handlers receive one via \`logger.With(\"api\", …)\` exactly as
  before. A dedicated package would only earn its keep once R4.3
  introduces a request-context handler wrapper.
- \`NewLogger\` takes \`io.Writer\` (not \`*os.File\`) so the tests can
  hand a \`*bytes.Buffer\` directly. Cheap genericity, no runtime cost.
- Did **not** rewrite the existing \`logger.With(\"api\", \"prom\" | …)\`
  pattern into a context-propagating handler. That's R4.3's job once
  spans are wired.

## Test plan

- [x] \`/home/thiago/.local/go/bin/go test ./internal/config/... ./cmd/cerberus/...\` green
- [x] \`go build ./...\` clean
- [x] \`go vet ./internal/api/... ./internal/config/... ./cmd/cerberus/...\` clean
- [ ] CI \`check\` + \`lint\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)