### PR TITLE
feat(api/health): /readyz distinct from /healthz with CH dependency check

### DIFF
--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -9,9 +9,11 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"sync/atomic"
 	"syscall"
 	"time"
 
+	"github.com/tsouza/cerberus/internal/api/health"
 	"github.com/tsouza/cerberus/internal/api/loki"
 	"github.com/tsouza/cerberus/internal/api/prom"
 	"github.com/tsouza/cerberus/internal/api/tempo"
@@ -57,6 +59,10 @@ func run(logger *slog.Logger) error {
 		_ = client.Close()
 	}()
 
+	// schemaReady tracks whether the auto-create-schema startup hook
+	// has finished at least once. When auto-create is off the readiness
+	// probe should not gate on it, so we seed it true.
+	var schemaReady atomic.Bool
 	if cfg.AutoCreateSchema {
 		logger.Info("auto-creating OTel ClickHouse schema",
 			"database", cfg.ClickHouse.Database,
@@ -67,36 +73,51 @@ func run(logger *slog.Logger) error {
 			return fmt.Errorf("auto-create schema: %w", err)
 		}
 		logger.Info("OTel ClickHouse schema ready")
+		schemaReady.Store(true)
+	} else {
+		schemaReady.Store(true)
 	}
 
-	mux := http.NewServeMux()
-	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("ok"))
-	})
+	// The trace mux carries the three Prom/Loki/Tempo APIs and is
+	// wrapped with otelhttp so every request becomes a server span.
+	traceMux := http.NewServeMux()
 
 	promHandler := prom.New(client, cfg.Schema, logger.With("api", "prom"))
-	promHandler.Mount(mux)
+	promHandler.Mount(traceMux)
 
 	lokiHandler := loki.New(client, schema.DefaultOTelLogs(), logger.With("api", "loki"))
-	lokiHandler.Mount(mux)
+	lokiHandler.Mount(traceMux)
 
 	tempoHandler := tempo.New(client, schema.DefaultOTelTraces(), Version, logger.With("api", "tempo"))
-	tempoHandler.Mount(mux)
+	tempoHandler.Mount(traceMux)
 
 	// RC4 R4.2: install the W3C+Baggage propagator and a no-op
 	// tracer-provider (real OTLP exporters arrive in R4.5), then wrap
-	// the whole mux with otelhttp so every Prom/Loki/Tempo request gets
+	// the API mux with otelhttp so every Prom/Loki/Tempo request gets
 	// a server span named after the matched route. Wrapping at the mux
 	// level — instead of per-handler — keeps the propagator code path
 	// uniform across all three APIs and lets the span name formatter
 	// pull r.Pattern after the mux has resolved the route.
 	installOTel(nil)
-	handler := wrapWithOTel(mux, "cerberus")
+	tracedAPI := wrapWithOTel(traceMux, "cerberus")
+
+	// /healthz and /readyz live on a separate sub-mux that bypasses
+	// otelhttp: k8s probes hit at multi-Hz rates and would otherwise
+	// flood the trace backend with no-op spans. The readiness handler
+	// memoises results behind a TTL cache so concurrent probes coalesce
+	// into a single ClickHouse ping per window.
+	healthHandler := health.New(health.Options{
+		Pinger:      client,
+		SchemaReady: schemaReady.Load,
+	})
+
+	rootMux := http.NewServeMux()
+	healthHandler.Mount(rootMux)
+	rootMux.Handle("/", tracedAPI)
 
 	srv := &http.Server{
 		Addr:              cfg.HTTPAddr,
-		Handler:           handler,
+		Handler:           rootMux,
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 

--- a/deploy/k3s/cerberus.yaml
+++ b/deploy/k3s/cerberus.yaml
@@ -66,12 +66,19 @@ spec:
               memory: 64Mi
             limits:
               memory: 256Mi
+          # /readyz pings ClickHouse (with a small TTL cache so this
+          # probe doesn't hammer CH) and reports the auto-create-schema
+          # invariant. A failure removes the pod from the Service
+          # endpoints without restarting it — backpressure, not crash.
           readinessProbe:
             httpGet:
-              path: /healthz
+              path: /readyz
               port: http
             initialDelaySeconds: 2
             periodSeconds: 3
+            timeoutSeconds: 2
+          # /healthz is intentionally dependency-free: a failure here
+          # means the process is wedged and k8s should restart the pod.
           livenessProbe:
             httpGet:
               path: /healthz

--- a/docs/health.md
+++ b/docs/health.md
@@ -60,9 +60,9 @@ Content-Type: application/json
 
 ### Response shape
 
-| Field        | Type    | Values                                                        |
-| ------------ | ------- | ------------------------------------------------------------- |
-| `clickhouse` | string  | `"ok"` on success, `"error: <reason>"` on a failed ping.      |
+| Field        | Type    | Values                                                                                                                                        |
+| ------------ | ------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `clickhouse` | string  | `"ok"` on success, `"error: <reason>"` on a failed ping.                                                                                      |
 | `schema`     | string  | `"ready"` when the auto-create hook is done (or disabled), `"pending"` while it is still running, `"unknown"` when the CH ping itself failed. |
 
 ### HTTP status codes

--- a/docs/health.md
+++ b/docs/health.md
@@ -1,0 +1,111 @@
+# Cerberus health probes
+
+Cerberus exposes two HTTP endpoints intended for orchestrator probes
+(Kubernetes, Nomad, Docker healthchecks, …). They follow the standard
+12-factor distinction between *liveness* (is the process alive?) and
+*readiness* (is this instance ready to serve traffic?).
+
+Both endpoints live on the same HTTP listener as the Prom/Loki/Tempo
+APIs (`CERBERUS_HTTP_ADDR`, default `:8080`) and are deliberately served
+**outside** the OpenTelemetry middleware so high-frequency probe traffic
+does not flood the trace backend.
+
+## `/healthz` — liveness
+
+```text
+GET /healthz
+200 OK
+Content-Type: text/plain; charset=utf-8
+
+ok
+```
+
+- Returns `200 OK` as long as the process is alive and the HTTP listener
+  is accepting connections.
+- Does **not** touch ClickHouse, the schema layer, or any other
+  downstream dependency.
+- A failure means the process is wedged and the orchestrator should
+  restart the container.
+
+## `/readyz` — readiness
+
+```text
+GET /readyz
+200 OK
+Content-Type: application/json
+
+{"clickhouse":"ok","schema":"ready"}
+```
+
+On failure:
+
+```text
+GET /readyz
+503 Service Unavailable
+Content-Type: application/json
+
+{"clickhouse":"error: dial tcp clickhouse:9000: connect: connection refused","schema":"unknown"}
+```
+
+- Pings ClickHouse via the configured `chclient.Client` connection
+  pool. The ping is capped at 1 second.
+- When `CERBERUS_AUTO_CREATE_SCHEMA=true`, also waits for the startup
+  hook that bootstraps the OTel ClickHouse tables to have completed at
+  least once.
+- Results are memoised behind a **2-second TTL cache** so the typical
+  3-second Kubernetes probe period coalesces into roughly one
+  ClickHouse ping per probe.
+- A failure removes the pod from the Service endpoints but does **not**
+  cause a restart.
+
+### Response shape
+
+| Field        | Type    | Values                                                        |
+| ------------ | ------- | ------------------------------------------------------------- |
+| `clickhouse` | string  | `"ok"` on success, `"error: <reason>"` on a failed ping.      |
+| `schema`     | string  | `"ready"` when the auto-create hook is done (or disabled), `"pending"` while it is still running, `"unknown"` when the CH ping itself failed. |
+
+### HTTP status codes
+
+| Status | Meaning                                                       |
+| ------ | ------------------------------------------------------------- |
+| 200    | Both ClickHouse and the schema invariant report healthy.      |
+| 503    | At least one dependency is not yet ready.                     |
+
+## Kubernetes probe configuration
+
+The shipped `deploy/k3s/cerberus.yaml` wires the probes as follows:
+
+```yaml
+readinessProbe:
+  httpGet:
+    path: /readyz
+    port: http
+  initialDelaySeconds: 2
+  periodSeconds: 3
+  timeoutSeconds: 2
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 10
+```
+
+### Recommended defaults
+
+- **Readiness** — `periodSeconds: 3`, `timeoutSeconds: 2`. The TTL cache
+  bounds the actual CH ping rate to ~1 per 2 seconds regardless of
+  probe frequency.
+- **Liveness** — `periodSeconds: 10`. Liveness probes are cheap (no CH
+  call), so the period is set by container-restart sensitivity rather
+  than by CH load.
+- **Startup** — none needed today; `initialDelaySeconds: 2` on the
+  readiness probe is enough for cerberus to bind its listener.
+
+## Implementation pointers
+
+- Endpoint code: `internal/api/health/health.go`.
+- Wire-up: `cmd/cerberus/main.go` (separate sub-mux so probes bypass
+  the otelhttp wrapper).
+- ClickHouse ping: `internal/chclient/client.go` — `(*Client).Ping`.

--- a/internal/api/health/doc.go
+++ b/internal/api/health/doc.go
@@ -1,0 +1,13 @@
+// Package health implements the cerberus liveness (/healthz) and
+// readiness (/readyz) HTTP probes.
+//
+// /healthz is intentionally minimal: it returns 200 as long as the
+// process is alive. Kubernetes uses it as the livenessProbe and a
+// failure means the orchestrator restarts the pod, so it must not
+// depend on any downstream service.
+//
+// /readyz is the readinessProbe: it pings ClickHouse and reports the
+// auto-create-schema invariant when CERBERUS_AUTO_CREATE_SCHEMA is on.
+// Probes hit at multi-Hz rates, so the result is memoised behind a
+// small TTL so the readiness handler does not hammer ClickHouse.
+package health

--- a/internal/api/health/health.go
+++ b/internal/api/health/health.go
@@ -1,0 +1,168 @@
+package health
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// Pinger is the subset of *chclient.Client the readiness probe needs.
+// Stubbing it makes the unit test pure — no live ClickHouse required.
+type Pinger interface {
+	Ping(ctx context.Context) error
+}
+
+// SchemaReadyFunc reports whether the auto-create-schema startup hook
+// has finished at least one successful run. When auto-create is off
+// the wiring passes a func that returns true so readiness only gates
+// on the ClickHouse ping.
+type SchemaReadyFunc func() bool
+
+// Options configure Handler.
+type Options struct {
+	// Pinger is the ClickHouse health check. Required.
+	Pinger Pinger
+
+	// SchemaReady is consulted on every readiness check. When nil the
+	// schema status is treated as ready (i.e. only the CH ping matters).
+	SchemaReady SchemaReadyFunc
+
+	// PingTimeout caps the per-probe ClickHouse ping. Defaults to 1s.
+	PingTimeout time.Duration
+
+	// CacheTTL coalesces probe results so high-frequency Kubernetes
+	// probes (default 5Hz) do not run a fresh CH ping on every call.
+	// Defaults to 2s. Set < 0 to disable caching (tests).
+	CacheTTL time.Duration
+
+	// Now is the time source. Defaults to time.Now. Tests inject a
+	// fake clock to verify TTL behavior deterministically.
+	Now func() time.Time
+}
+
+// Handler exposes /healthz (liveness) and /readyz (readiness) HTTP
+// handlers. Construct via New and register via Mount.
+type Handler struct {
+	pinger      Pinger
+	schemaReady SchemaReadyFunc
+	pingTimeout time.Duration
+	cacheTTL    time.Duration
+	now         func() time.Time
+
+	mu         sync.Mutex
+	cachedAt   time.Time
+	cachedResp readyResponse
+	cachedCode int
+}
+
+// readyResponse is the JSON shape /readyz returns.
+type readyResponse struct {
+	ClickHouse string `json:"clickhouse"`
+	Schema     string `json:"schema"`
+}
+
+// New builds a Handler with the given options. A nil Pinger is allowed
+// — the readiness probe will always report 503 in that case, which is
+// the safe default if startup wiring forgot to plug a real client in.
+func New(opts Options) *Handler {
+	h := &Handler{
+		pinger:      opts.Pinger,
+		schemaReady: opts.SchemaReady,
+		pingTimeout: opts.PingTimeout,
+		cacheTTL:    opts.CacheTTL,
+		now:         opts.Now,
+	}
+	if h.pingTimeout <= 0 {
+		h.pingTimeout = time.Second
+	}
+	if h.cacheTTL == 0 {
+		// 2s lines up with the typical k8s probe period (5Hz on the
+		// hot path; ~3s for cerberus' own readinessProbe in
+		// deploy/k3s/cerberus.yaml). Two seconds of coalescing keeps
+		// CH load near zero while still surfacing outages within one
+		// probe period.
+		h.cacheTTL = 2 * time.Second
+	}
+	if h.now == nil {
+		h.now = time.Now
+	}
+	return h
+}
+
+// Mount registers /healthz and /readyz on mux.
+func (h *Handler) Mount(mux *http.ServeMux) {
+	mux.HandleFunc("GET /healthz", h.handleHealthz)
+	mux.HandleFunc("GET /readyz", h.handleReadyz)
+}
+
+// handleHealthz is the liveness probe. It must not touch any external
+// dependency: a failure here causes k8s to restart the pod.
+func (h *Handler) handleHealthz(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok"))
+}
+
+// handleReadyz is the readiness probe. Coalesces concurrent probes via
+// a small TTL cache, then writes a JSON body describing the CH ping
+// and the schema-startup invariant.
+func (h *Handler) handleReadyz(w http.ResponseWriter, r *http.Request) {
+	resp, code := h.checkReady(r.Context())
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// checkReady returns the response body + HTTP status code. Cached for
+// up to cacheTTL; an in-flight probe holds the mutex so concurrent
+// callers see one CH ping per TTL window.
+func (h *Handler) checkReady(ctx context.Context) (readyResponse, int) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.cacheTTL > 0 && !h.cachedAt.IsZero() {
+		if h.now().Sub(h.cachedAt) < h.cacheTTL {
+			return h.cachedResp, h.cachedCode
+		}
+	}
+
+	resp, code := h.runCheck(ctx)
+
+	h.cachedResp = resp
+	h.cachedCode = code
+	h.cachedAt = h.now()
+	return resp, code
+}
+
+// runCheck performs the actual ping + schema-ready evaluation.
+func (h *Handler) runCheck(ctx context.Context) (readyResponse, int) {
+	if h.pinger == nil {
+		return readyResponse{
+			ClickHouse: "error: no clickhouse client configured",
+			Schema:     "unknown",
+		}, http.StatusServiceUnavailable
+	}
+
+	pingCtx, cancel := context.WithTimeout(ctx, h.pingTimeout)
+	defer cancel()
+
+	if err := h.pinger.Ping(pingCtx); err != nil {
+		return readyResponse{
+			ClickHouse: "error: " + err.Error(),
+			Schema:     "unknown",
+		}, http.StatusServiceUnavailable
+	}
+
+	if h.schemaReady != nil && !h.schemaReady() {
+		return readyResponse{
+			ClickHouse: "ok",
+			Schema:     "pending",
+		}, http.StatusServiceUnavailable
+	}
+
+	return readyResponse{
+		ClickHouse: "ok",
+		Schema:     "ready",
+	}, http.StatusOK
+}

--- a/internal/api/health/health_test.go
+++ b/internal/api/health/health_test.go
@@ -1,0 +1,255 @@
+package health
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// stubPinger implements Pinger with a swappable error + atomic call
+// counter so tests can observe coalescing.
+type stubPinger struct {
+	mu    sync.Mutex
+	err   error
+	calls atomic.Int64
+}
+
+func (s *stubPinger) Ping(_ context.Context) error {
+	s.calls.Add(1)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.err
+}
+
+func (s *stubPinger) setErr(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.err = err
+}
+
+// TestHealthz_AlwaysOK confirms the liveness probe is dependency-free.
+func TestHealthz_AlwaysOK(t *testing.T) {
+	h := New(Options{
+		Pinger: &stubPinger{err: errors.New("CH unreachable")},
+	})
+	mux := http.NewServeMux()
+	h.Mount(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200", rec.Code)
+	}
+	if got := rec.Body.String(); got != "ok" {
+		t.Errorf("body = %q; want %q", got, "ok")
+	}
+}
+
+// TestReadyz_OK exercises the happy path: CH ping passes and the
+// schema startup hook reports ready.
+func TestReadyz_OK(t *testing.T) {
+	h := New(Options{
+		Pinger:      &stubPinger{},
+		SchemaReady: func() bool { return true },
+		CacheTTL:    -1, // disable caching
+	})
+
+	rec := serveReadyz(t, h)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200", rec.Code)
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if resp["clickhouse"] != "ok" {
+		t.Errorf("clickhouse = %q; want ok", resp["clickhouse"])
+	}
+	if resp["schema"] != "ready" {
+		t.Errorf("schema = %q; want ready", resp["schema"])
+	}
+}
+
+// TestReadyz_CHFailure: CH ping returns an error → 503 with the error
+// reason embedded in the clickhouse field.
+func TestReadyz_CHFailure(t *testing.T) {
+	pinger := &stubPinger{err: errors.New("connection refused")}
+	h := New(Options{
+		Pinger:   pinger,
+		CacheTTL: -1,
+	})
+
+	rec := serveReadyz(t, h)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d; want 503", rec.Code)
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if !strings.Contains(resp["clickhouse"], "connection refused") {
+		t.Errorf("clickhouse = %q; want substring 'connection refused'", resp["clickhouse"])
+	}
+}
+
+// TestReadyz_SchemaPending: CH ok but schema not finished bootstrapping.
+func TestReadyz_SchemaPending(t *testing.T) {
+	h := New(Options{
+		Pinger:      &stubPinger{},
+		SchemaReady: func() bool { return false },
+		CacheTTL:    -1,
+	})
+
+	rec := serveReadyz(t, h)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d; want 503", rec.Code)
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if resp["clickhouse"] != "ok" {
+		t.Errorf("clickhouse = %q; want ok", resp["clickhouse"])
+	}
+	if resp["schema"] != "pending" {
+		t.Errorf("schema = %q; want pending", resp["schema"])
+	}
+}
+
+// TestReadyz_NilPinger: defensive — if startup forgot the client, fail
+// closed (503), don't false-positive.
+func TestReadyz_NilPinger(t *testing.T) {
+	h := New(Options{CacheTTL: -1})
+	rec := serveReadyz(t, h)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d; want 503", rec.Code)
+	}
+}
+
+// TestReadyz_TTLCaches verifies repeated probes inside the cache window
+// don't trigger fresh Ping() calls, and that a forward clock advance
+// past the TTL re-runs the check.
+func TestReadyz_TTLCaches(t *testing.T) {
+	pinger := &stubPinger{}
+	now := time.Unix(1_700_000_000, 0)
+	clock := func() time.Time { return now }
+
+	h := New(Options{
+		Pinger:   pinger,
+		CacheTTL: 2 * time.Second,
+		Now:      clock,
+	})
+
+	// First probe: warms the cache.
+	rec := serveReadyz(t, h)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("probe 1 status = %d; want 200", rec.Code)
+	}
+	if got := pinger.calls.Load(); got != 1 {
+		t.Fatalf("ping calls after probe 1 = %d; want 1", got)
+	}
+
+	// Advance 1s — inside the TTL window: cached, no new ping.
+	now = now.Add(time.Second)
+	rec = serveReadyz(t, h)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("probe 2 status = %d; want 200", rec.Code)
+	}
+	if got := pinger.calls.Load(); got != 1 {
+		t.Errorf("ping calls after probe 2 = %d; want 1 (cached)", got)
+	}
+
+	// Switch the upstream to failing — cached response still wins.
+	pinger.setErr(errors.New("boom"))
+	rec = serveReadyz(t, h)
+	if rec.Code != http.StatusOK {
+		t.Errorf("probe 3 status = %d; want 200 (still cached)", rec.Code)
+	}
+
+	// Advance past the TTL — fresh probe, surfaces the failure.
+	now = now.Add(3 * time.Second)
+	rec = serveReadyz(t, h)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("probe 4 status = %d; want 503 (cache expired)", rec.Code)
+	}
+	if got := pinger.calls.Load(); got != 2 {
+		t.Errorf("ping calls after probe 4 = %d; want 2 (one cached, one fresh)", got)
+	}
+}
+
+// slowPinger blocks until released so the timeout test deterministically
+// triggers context deadline.
+type slowPinger struct {
+	release chan struct{}
+}
+
+func (s *slowPinger) Ping(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-s.release:
+		return nil
+	}
+}
+
+// TestReadyz_PingTimeout: the configured PingTimeout caps how long the
+// probe waits on a slow CH.
+func TestReadyz_PingTimeout(t *testing.T) {
+	pinger := &slowPinger{release: make(chan struct{})}
+	t.Cleanup(func() { close(pinger.release) })
+
+	h := New(Options{
+		Pinger:      pinger,
+		PingTimeout: 20 * time.Millisecond,
+		CacheTTL:    -1,
+	})
+
+	start := time.Now()
+	rec := serveReadyz(t, h)
+	elapsed := time.Since(start)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d; want 503", rec.Code)
+	}
+	if elapsed > time.Second {
+		t.Errorf("elapsed = %s; expected to honor 20ms timeout", elapsed)
+	}
+}
+
+// TestMount_RoutesRegistered confirms both endpoints land on the mux.
+func TestMount_RoutesRegistered(t *testing.T) {
+	h := New(Options{Pinger: &stubPinger{}, CacheTTL: -1})
+	mux := http.NewServeMux()
+	h.Mount(mux)
+
+	for _, path := range []string{"/healthz", "/readyz"} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		if rec.Code == http.StatusNotFound {
+			t.Errorf("%s: route not registered (got 404)", path)
+		}
+	}
+}
+
+func serveReadyz(t *testing.T, h *Handler) *httptest.ResponseRecorder {
+	t.Helper()
+	mux := http.NewServeMux()
+	h.Mount(mux)
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	return rec
+}

--- a/internal/chclient/client.go
+++ b/internal/chclient/client.go
@@ -72,6 +72,20 @@ func (c *Client) Close() error {
 	return c.conn.Close()
 }
 
+// Ping verifies the underlying ClickHouse connection is reachable. It
+// forwards to the clickhouse-go/v2 driver's Ping, which performs a
+// lightweight round-trip on a pooled connection. The readiness probe
+// (internal/api/health) uses it as the downstream-dependency check.
+func (c *Client) Ping(ctx context.Context) error {
+	if c.conn == nil {
+		return fmt.Errorf("chclient: ping: nil connection")
+	}
+	if err := c.conn.Ping(ctx); err != nil {
+		return fmt.Errorf("chclient: ping: %w", err)
+	}
+	return nil
+}
+
 // Sample is one row of metrics data returned by Query. It's the shape the
 // /api/v1/query and /api/v1/query_range handlers expect — see api/prom.
 type Sample struct {


### PR DESCRIPTION
## Summary

Splits the single `/healthz` endpoint into the standard 12-factor pair so Kubernetes can distinguish liveness from readiness:

- **`/healthz`** (liveness, unchanged shape) — returns `200 "ok"`, no downstream dependencies. A failure restarts the pod.
- **`/readyz`** (readiness, new) — pings ClickHouse via a new `chclient.Client.Ping` (1s timeout) and reports the `CERBERUS_AUTO_CREATE_SCHEMA` startup invariant. Returns JSON `{"clickhouse":"ok|error: ...","schema":"ready|pending|unknown"}` with `200` / `503`. A failure removes the pod from Service endpoints but does not restart.

### Architecture notes

- New `internal/api/health` package with a `Pinger` interface so unit tests don't need a live ClickHouse.
- Readiness result memoised behind a **2-second TTL cache** so the typical 3-second k8s probe period coalesces into ~1 CH ping per window. Concurrent probes share the cache via a mutex.
- Per-probe ClickHouse ping bounded at 1s.
- Probe endpoints live on a **separate root sub-mux** that bypasses the `otelhttp` wrapper — k8s probes hit at multi-Hz rates and would otherwise flood the trace backend with no-op spans. The Prom/Loki/Tempo APIs stay wrapped on their own sub-mux.

### Deploy + docs

- `deploy/k3s/cerberus.yaml` `readinessProbe` switched to `/readyz` (period 3s, timeout 2s); `livenessProbe` stays on `/healthz`.
- New `docs/health.md` documents the JSON contract, status codes, and the recommended k8s probe YAML.

### Why now

`docs/roadmap.md` § RC5 (12-factor compatibility) calls out the split so orchestrators can route traffic away from a cerberus instance with an unreachable CH without crash-looping it.

## Test plan

- [x] `go test ./internal/api/health/... ./internal/chclient/... ./cmd/cerberus/...` passes locally
- [x] `go build ./...` clean
- [x] `/healthz` returns 200 even when the pinger errors (liveness must be dependency-free)
- [x] `/readyz` returns 200 with `{"clickhouse":"ok","schema":"ready"}` on the happy path
- [x] `/readyz` returns 503 with the error reason embedded when the CH ping fails
- [x] `/readyz` returns 503 with `schema:"pending"` while auto-create is still running
- [x] TTL cache test: 4 sequential probes with a fake clock show only 2 actual `Ping()` calls
- [x] `PingTimeout` honored against a slow pinger (20ms cap exits in well under a second)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)