### PR TITLE
feat(cerberus): OTLP exporters for traces + metrics (RC4 R4.5)

### DIFF
--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -21,6 +21,8 @@ import (
 	"github.com/tsouza/cerberus/internal/config"
 	"github.com/tsouza/cerberus/internal/schema"
 	"github.com/tsouza/cerberus/internal/schema/ddl"
+	"github.com/tsouza/cerberus/internal/telemetry"
+	"go.opentelemetry.io/otel"
 )
 
 // Version is set at build time by goreleaser.
@@ -100,14 +102,34 @@ func run() error {
 	tempoHandler := tempo.New(client, schema.DefaultOTelTraces(), Version, logger.With("api", "tempo"))
 	tempoHandler.Mount(traceMux)
 
-	// RC4 R4.2: install the W3C+Baggage propagator and a no-op
-	// tracer-provider (real OTLP exporters arrive in R4.5), then wrap
-	// the API mux with otelhttp so every Prom/Loki/Tempo request gets
-	// a server span named after the matched route. Wrapping at the mux
-	// level — instead of per-handler — keeps the propagator code path
-	// uniform across all three APIs and lets the span name formatter
-	// pull r.Pattern after the mux has resolved the route.
-	installOTel(nil)
+	// Install the W3C+Baggage propagator and build OTel providers from
+	// the OTLP env config. When CERBERUS_OTLP_ENDPOINT is empty the
+	// telemetry package returns noop providers, so cerberus stays a
+	// zero-collector-dependency binary by default. Wrapping the API
+	// mux with otelhttp gives every Prom/Loki/Tempo request a server
+	// span named after the matched route. Wrapping at the mux level —
+	// instead of per-handler — keeps the propagator code path uniform
+	// across all three APIs and lets the span name formatter pull
+	// r.Pattern after the mux has resolved the route.
+	providers, err := telemetry.New(ctx, telemetry.Config{
+		Endpoint:       cfg.OTLP.Endpoint,
+		Insecure:       cfg.OTLP.Insecure,
+		Headers:        cfg.OTLP.Headers,
+		Timeout:        cfg.OTLP.Timeout,
+		ServiceName:    "cerberus",
+		ServiceVersion: Version,
+	})
+	if err != nil {
+		return fmt.Errorf("init telemetry: %w", err)
+	}
+	installOTel(providers.TracerProvider)
+	otel.SetMeterProvider(providers.MeterProvider)
+	if cfg.OTLP.Endpoint != "" {
+		logger.Info("OTLP exporters enabled",
+			"endpoint", cfg.OTLP.Endpoint,
+			"insecure", cfg.OTLP.Insecure,
+		)
+	}
 	tracedAPI := wrapWithOTel(traceMux, "cerberus")
 
 	// /healthz and /readyz live on a separate sub-mux that bypasses
@@ -149,6 +171,11 @@ func run() error {
 	defer cancel()
 	if err := srv.Shutdown(shutdownCtx); err != nil {
 		return fmt.Errorf("graceful shutdown: %w", err)
+	}
+	// Flush any pending OTLP batches before the process exits. Noop
+	// when telemetry was disabled (Endpoint == "").
+	if err := providers.Shutdown(shutdownCtx); err != nil {
+		logger.Warn("telemetry shutdown returned error", "err", err)
 	}
 	logger.Info("cerberus stopped")
 	return nil

--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -13,6 +13,8 @@ import (
 	"syscall"
 	"time"
 
+	"go.opentelemetry.io/otel"
+
 	"github.com/tsouza/cerberus/internal/api/health"
 	"github.com/tsouza/cerberus/internal/api/loki"
 	"github.com/tsouza/cerberus/internal/api/prom"
@@ -22,7 +24,6 @@ import (
 	"github.com/tsouza/cerberus/internal/schema"
 	"github.com/tsouza/cerberus/internal/schema/ddl"
 	"github.com/tsouza/cerberus/internal/telemetry"
-	"go.opentelemetry.io/otel"
 )
 
 // Version is set at build time by goreleaser.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -2,21 +2,23 @@
 
 Cerberus is its own first-class observability customer: it queries OTel-CH
 metrics + logs + traces, and it ships the same shape of telemetry back into
-that store. A self-dashboard then works against any running cluster — the
-dogfood loop.
+that store so a self-dashboard works against a running cluster.
 
-## What cerberus instruments
+The full self-observability stack lands across **RC4**:
 
-| Signal                  | Source                                                                                     |
-| ----------------------- | ------------------------------------------------------------------------------------------ |
-| Structured logs         | `log/slog` (stdlib structured logger, JSON / text via env)                                 |
-| HTTP server spans       | `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp` around the API mux         |
-| Pipeline spans          | manual spans around parse / lower / optimize / emit / execute                              |
-| Self-metrics            | OTel SDK metrics: query count + latency, per-stage latency, CH rows/bytes, in-flight gauge |
-| OTLP export             | `go.opentelemetry.io/otel/exporters/otlp/{otlpmetricgrpc,otlptracegrpc}`                   |
-| Collector + dashboard   | `deploy/k3s/otel-collector.yaml` + `deploy/grafana/dashboards/cerberus-self.json`          |
+| Item                                                                                                  | Status  | Notes                                    |
+| ----------------------------------------------------------------------------------------------------- | ------- | ---------------------------------------- |
+| R4.1 — slog quality pass + env-configurable format / level                                            | landed  | this doc                                 |
+| R4.2 — `otelhttp.NewHandler` wraps the Prom / Loki / Tempo handlers                                   | planned | adds one span per HTTP request           |
+| R4.3 — Custom spans around parse / lower / optimize / emit / execute                                  | planned | pipeline stage timings                   |
+| R4.4 — Self-metrics: request count + latency + CH roundtrip + in-flight gauge                         | planned | HPA-consumable                           |
+| R4.5 — OTLP exporters wired (`CERBERUS_OTLP_ENDPOINT` / `_INSECURE` / `_HEADERS` / `_TIMEOUT`)         | landed  | graceful no-op when endpoint unreachable |
+| R4.6 — `deploy/k3s/otel-collector.yaml` + `deploy/grafana/dashboards/cerberus-self.json`              | planned | wires the export path end-to-end         |
 
-## Structured logging
+This page only covers what has already shipped. The remaining rows are
+expanded as the milestones land.
+
+## Logging (R4.1, shipped)
 
 Cerberus uses the standard library's [`log/slog`](https://pkg.go.dev/log/slog)
 for structured logging. Two env vars steer the handler:
@@ -37,7 +39,7 @@ observability — a typo never ships to prod undetected.
   aggregator (Loki, GCP Logging, ECS, Splunk). Each record is one
   newline-delimited JSON object, ready for ingest.
 
-### Level vocabulary
+### Level vocabulary in cerberus code
 
 - **`Debug`** — per-request SQL + arg traces. Off in prod by default; flip to
   `debug` to capture the lowered SQL for a complaint window.
@@ -51,201 +53,94 @@ observability — a typo never ships to prod undetected.
 
 ### Attribute conventions
 
-The codebase follows a small set of consistent keys so a query against
-`otel_logs` can filter without guessing:
+The codebase follows a small set of consistent keys so a future query
+across `otel_logs` can filter without guessing:
 
-| Key                            | Type   | Notes                                                                                |
-| ------------------------------ | ------ | ------------------------------------------------------------------------------------ |
-| `api`                          | string | `prom` / `loki` / `tempo`, set on the per-handler logger via `.With("api", ...)`     |
-| `promql` / `logql` / `traceql` | string | The query text as received                                                           |
-| `sql`                          | string | The emitted ClickHouse SQL                                                           |
-| `args`                         | []any  | Parameterised SQL args                                                               |
-| `err`                          | error  | Native `error` value — slog encodes via `.Error()` for json + `%v` for text          |
-| `trace_id`                     | string | Tempo `traceByID` handler only                                                       |
-| `tag`                          | string | Tempo tag-values handler                                                             |
+| Key                            | Type   | Notes                                                                                                      |
+| ------------------------------ | ------ | ---------------------------------------------------------------------------------------------------------- |
+| `api`                          | string | `prom` / `loki` / `tempo`, set on the per-handler logger via `.With("api", ...)` in `cmd/cerberus/main.go` |
+| `promql` / `logql` / `traceql` | string | The query text as received                                                                                 |
+| `sql`                          | string | The emitted ClickHouse SQL                                                                                 |
+| `args`                         | []any  | Parameterised SQL args                                                                                     |
+| `err`                          | error  | Native `error` value — slog encodes via `.Error()` for json + `%v` for text                                |
+| `trace_id`                     | string | Tempo `traceByID` handler only                                                                             |
+| `tag`                          | string | Tempo tag-values handler                                                                                   |
 
-Always pass the native `error` as `"err", err` rather than `err.Error()` so
-a future `slog.Handler` middleware can branch on `errors.As` / `errors.Is`.
+Always pass the native `error` as `"err", err` rather than `err.Error()`
+so a future `slog.Handler` middleware can branch on `errors.As` /
+`errors.Is`.
 
 ### Examples
 
 ```text
 # CERBERUS_LOG_FORMAT=text CERBERUS_LOG_LEVEL=info (defaults)
-time=2026-05-13T10:14:01.000Z level=INFO msg="cerberus starting" version=v1.0.0 http_addr=:8080 ch_addr=clickhouse:9000 ch_db=otel log_format=text log_level=INFO
+time=2026-05-13T10:14:01.000Z level=INFO msg="cerberus starting" version=v1.0.0-RC4 http_addr=:8080 ch_addr=clickhouse:9000 ch_db=otel log_format=text log_level=INFO
 
 # CERBERUS_LOG_FORMAT=json
-{"time":"2026-05-13T10:14:01Z","level":"INFO","msg":"cerberus starting","version":"v1.0.0","http_addr":":8080","ch_addr":"clickhouse:9000","ch_db":"otel","log_format":"json","log_level":"INFO"}
+{"time":"2026-05-13T10:14:01Z","level":"INFO","msg":"cerberus starting","version":"v1.0.0-RC4","http_addr":":8080","ch_addr":"clickhouse:9000","ch_db":"otel","log_format":"json","log_level":"INFO"}
 ```
 
-## Traces
+## Tracing + metrics export (R4.5, shipped)
 
-Cerberus emits two layers of spans for every query:
+Cerberus emits structured logs, spans, and self-metrics so an operator can
+see what the gateway is doing in production.
 
-- **HTTP server spans.** The API mux is wrapped with `otelhttp.NewHandler`, so
-  every Prom / Loki / Tempo request becomes a server span whose name is the
-  matched `http.ServeMux` pattern (e.g. `GET /api/v1/query`). Unmatched
-  requests fall back to `HTTP <METHOD>` to keep span cardinality bounded by
-  the route set rather than the URL space. The `/healthz` and `/readyz`
-  probes bypass `otelhttp` so multi-Hz Kubernetes probing doesn't flood the
-  trace backend with no-op spans.
-- **Pipeline spans.** Manual spans wrap each pipeline stage —
-  `parse` / `lower` / `optimize` / `emit` / `execute` — as a child of the
-  HTTP request span. The result is a clean stage breakdown in any trace
-  viewer: parse cost, lowering cost, optimizer cost, SQL emission cost, and
-  ClickHouse roundtrip cost, all attributable to one user query.
-
-Incoming `traceparent` / `baggage` headers are honored: the W3C TraceContext
-and Baggage propagators are installed as process globals so a Grafana span
-becomes the parent of cerberus's HTTP span, which becomes the parent of the
-pipeline spans.
-
-## Self-metrics
-
-The OTel SDK metrics path emits a small set of cerberus-specific counters,
-histograms, and gauges. They are HPA-consumable: the in-flight gauge is the
-recommended autoscaler signal.
-
-| Instrument                                   | Kind      | Labels                                | Notes                                                       |
-| -------------------------------------------- | --------- | ------------------------------------- | ----------------------------------------------------------- |
-| `cerberus_queries_total`                     | counter   | `api`, `result` (`ok` / `error`)      | One increment per Prom / Loki / Tempo query handled         |
-| `cerberus_queries_duration_seconds`          | histogram | `api`, `result`                       | Wall-clock per query, end-to-end                            |
-| `cerberus_pipeline_stage_duration_seconds`   | histogram | `api`, `stage`                        | Per-stage timing: parse / lower / optimize / emit / execute |
-| `cerberus_ch_rows_read_total`                | counter   | `api`                                 | Rows read from ClickHouse, summed over the query            |
-| `cerberus_ch_bytes_read_total`               | counter   | `api`                                 | Bytes read from ClickHouse, summed over the query           |
-| `cerberus_http_requests_in_flight`           | gauge     | `route`                               | Currently-executing requests (HPA target)                   |
-
-## OTLP exporters
-
-Cerberus exports its own logs + metrics + traces via OTLP/gRPC. Configuration
-is env-driven (see `internal/config/`):
-
-| Variable                     | Default                        | Effect                                                                             |
-| ---------------------------- | ------------------------------ | ---------------------------------------------------------------------------------- |
-| `CERBERUS_OTEL_ENDPOINT`     | empty (export disabled)        | OTLP/gRPC endpoint (host:port). Empty makes the process a zero-collector binary.   |
-| `CERBERUS_OTEL_INSECURE`     | `false`                        | Set `true` for in-cluster plaintext OTLP. The k3s manifests default to `true`.     |
-| `CERBERUS_OTEL_SERVICE_NAME` | `cerberus`                     | Becomes the OTel-CH `ServiceName` column. The Grafana dashboard filters on it.     |
-| `CERBERUS_OTEL_SAMPLER`      | `parentbased_traceidratio:0.1` | Tracing sampler spec. `always_on` / `always_off` / `parentbased_traceidratio:<r>`. |
-
-Setting `CERBERUS_OTEL_ENDPOINT=""` reduces cerberus to a
-zero-collector-dependency binary: no OTLP exporters are constructed, the
-metric SDK uses the no-op meter provider, and pipeline spans are recorded
-against a no-op tracer. HTTP handlers continue to serve PromQL / LogQL /
-TraceQL exactly as before. The self-dashboard simply shows no data — it is
-not an error. This is the supported posture for users who want cerberus's
-query gateway behaviour but not its self-observability stack.
-
-When the endpoint is set but unreachable at startup, the exporters install
-in a queued state rather than failing the process. Cerberus keeps serving
-queries; the OTel SDK retries delivery in the background. Telemetry loss is
-a soft failure by design.
-
-## Dogfood loop
-
-Cerberus ships its own telemetry into the **same** `otel_metrics_*`,
-`otel_logs`, and `otel_traces*` tables it serves over the Prometheus /
-Loki / Tempo HTTP APIs. The result is a closed dogfood loop: cerberus
-observes itself by querying its own metrics out of ClickHouse — and
-Grafana, sitting on top, never sees anything but cerberus's three upstream
-APIs.
+### Topology
 
 ```text
-            ┌─────────────────────────────────────────────────────┐
-            │                                                     │
-            ▼                                                     │
-     ┌────────────┐   PromQL / LogQL / TraceQL              ┌─────┴────┐
-     │  Grafana   │ ──────────────────────────────────────▶ │ cerberus │
-     └────────────┘                                          └─────┬────┘
-                                                                   │
-                                                                   │ ClickHouse SQL
-                                                                   ▼
-                                                            ┌────────────┐
-                                                            │ ClickHouse │
-                                                            └─────┬──────┘
-                                                                  ▲
-                                                                  │ clickhouseexporter
-                                                                  │
-                                                            ┌─────┴──────┐
-                                            OTLP/gRPC       │ OTel       │
-                            ┌──────────────────────────────▶│ Collector  │
-                            │                                │ (gateway)  │
-                            │                                └────────────┘
-                      ┌─────┴────┐
-                      │ cerberus │   (OTLP exporter)
-                      └──────────┘
+cerberus ──OTLP gRPC──▶ OTel Collector ──CH exporter──▶ ClickHouse
+                                                              │
+                                                              ▼
+                                                       Grafana ◀── cerberus (query)
 ```
 
-Cerberus emits OTLP to the in-cluster OTel Collector gateway. The gateway
-writes to ClickHouse via the OTel-Contrib `clickhouseexporter` — the same
-exporter whose DDL templates cerberus's `internal/schema/` package imports
-as the schema source-of-truth, so the schema cannot drift between the
-writer and the reader. Grafana, provisioned with the `Cerberus-Prometheus`
-datasource, then queries cerberus's own metrics back through cerberus.
+The same `otel_traces` / `otel_metrics_*` tables cerberus queries on the
+Grafana-facing side are also the ones its own telemetry lands in — the
+deployment dogfoods itself.
 
-## OTel Collector — `deploy/k3s/otel-collector.yaml`
+### Environment variables
 
-Two collector roles run in-cluster (one image, two configs):
+All OTel knobs are optional. With no env vars set, cerberus installs
+no-op trace and meter providers and runs as a zero-collector-dependency
+binary.
 
-- **Gateway** (Deployment). Accepts OTLP from cerberus and the agent
-  DaemonSet, runs `k8s_cluster` + `k8s_events` for cluster-wide signals,
-  writes everything to ClickHouse via `clickhouseexporter`
-  (`create_schema: true`).
-- **Agent** (DaemonSet). Runs `kubeletstats` (node/pod/container metrics)
-  and `filelog` (container stdout/stderr from `/var/log/pods/*`), forwards
-  OTLP to the gateway.
+| Variable                 | Default | Meaning                                                                                          |
+| ------------------------ | ------- | ------------------------------------------------------------------------------------------------ |
+| `CERBERUS_OTLP_ENDPOINT` | `""`    | gRPC target, e.g. `otel-collector.observability.svc:4317`. Empty disables both exporters.        |
+| `CERBERUS_OTLP_INSECURE` | `false` | When `true`, dial the endpoint without TLS. Use for local dev / k3d only.                        |
+| `CERBERUS_OTLP_HEADERS`  | `""`    | Comma-separated `key=value` list attached as gRPC metadata (e.g. `authorization=Bearer abc...`). |
+| `CERBERUS_OTLP_TIMEOUT`  | `10s`   | Per-request OTLP roundtrip timeout (`time.ParseDuration` syntax).                                |
 
-Both use `otel/opentelemetry-collector-contrib:0.116.1` — the Contrib
-distribution, **not** the upstream Apache 2 core image, because we need
-`clickhouseexporter`, `kubeletstats`, `filelog`, `k8s_cluster`, and
-`k8s_events`. The image version is kept in lockstep with the OTel-CH
-schema fork pinned in `go.mod`
-(`tsouza/opentelemetry-collector-contrib:cerberus-ddl`) so the schema
-templates the gateway renders match what cerberus reads.
+Standard OTel SDK env vars (`OTEL_EXPORTER_OTLP_ENDPOINT`,
+`OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_RESOURCE_ATTRIBUTES`, …) are read by
+the SDK on top of the cerberus-specific knobs above. When both are set,
+the `CERBERUS_OTLP_*` value wins for that field because cerberus passes
+it explicitly to the exporter constructor.
 
-### Deploy
+### Resource attributes
 
-`just e2e-up` applies the whole `deploy/k3s/kustomization.yaml` into a
-fresh k3d cluster. The flow:
+Every exported span and metric carries:
 
-1. `clickhouse.yaml` brings up single-node ClickHouse.
-2. `cerberus.yaml` deploys cerberus, with `CERBERUS_OTEL_ENDPOINT`
-   pointing at `otel-collector-gateway.cerberus.svc:4317`.
-3. `otel-collector.yaml` brings up the gateway Deployment + agent
-   DaemonSet, RBAC, and the two ConfigMaps.
-4. `grafana.yaml` + `grafana-dashboards.yaml` provision the three
-   cerberus datasources and the `Cerberus self-observability` dashboard.
-5. `sample-app.yaml` runs three `telemetrygen` workloads (traces /
-   metrics / logs) targeting the gateway so the tables never run empty.
+| Attribute             | Source                                                                                                  |
+| --------------------- | ------------------------------------------------------------------------------------------------------- |
+| `service.name`        | Hard-coded to `cerberus`.                                                                               |
+| `service.version`     | The `Version` var in `cmd/cerberus` (set to `dev` by default, injected at release time via `-ldflags`). |
+| `service.instance.id` | `os.Hostname()`, falling back to a random 16-byte hex string.                                           |
 
-## Cerberus self-dashboard
+### Shutdown
 
-`deploy/grafana/dashboards/cerberus-self.json` ships as a provisioned
-JSON model. It is auto-loaded under the **Cerberus** folder in Grafana
-by the file provider declared in `deploy/k3s/grafana-dashboards.yaml`.
+On SIGINT / SIGTERM, cerberus:
 
-| Panel | What it shows                                                                             | Metric                                                         |
-| ----- | ----------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
-| 1     | Per-second query rate, broken down by upstream language (`promql` / `logql` / `traceql`). | `cerberus_queries_total`                                       |
-| 2     | P50 / P95 / P99 query latency across all three heads.                                     | `cerberus_queries_duration_seconds_bucket`                     |
-| 3     | Per-stage latency (parse / lower / optimize / emit / execute), stacked.                   | `cerberus_pipeline_stage_duration_seconds_bucket`              |
-| 4     | ClickHouse rows + bytes read per second, summed across all queries.                       | `cerberus_ch_rows_read_total` / `cerberus_ch_bytes_read_total` |
-| 5     | Error rate by language (`result="error"` / total), with 1% / 5% threshold lines.          | `cerberus_queries_total{result="error"}` / total               |
+1. Stops accepting new HTTP connections (`http.Server.Shutdown`).
+2. Flushes pending OTLP batches and tears the providers down
+   (`Providers.Shutdown`) inside the same 10s shutdown context.
 
-All panels target the `cerberus-prometheus` datasource and filter on
-`service_name="cerberus"` so a multi-tenant gateway (one collector fed
-by many cerberus replicas) still attributes data correctly.
+If the collector is unreachable during shutdown the OTLP exporter logs
+the error and returns — cerberus still exits cleanly rather than
+hanging.
 
-### Import outside the k3s stack
+### Disabling telemetry
 
-If you run cerberus + Grafana some other way (standalone Docker,
-docker-compose, or a separate cluster):
-
-1. Make sure Grafana has a Prometheus-type datasource pointing at
-   cerberus's `:8080`.
-2. Either:
-   - Drop `deploy/grafana/dashboards/cerberus-self.json` into a
-     provisioned dashboards folder, or
-   - In the Grafana UI, **Dashboards → New → Import**, upload the JSON,
-     and pick the cerberus Prometheus datasource at the prompt.
-3. If your datasource UID differs from `cerberus-prometheus`, edit the
-   JSON's `datasource.uid` fields (or use the per-panel datasource
-   picker after import).
+Leave `CERBERUS_OTLP_ENDPOINT` unset (or set to the empty string). The
+process installs no-op providers; otelhttp middleware still wraps the
+mux but every span is silently dropped.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -12,7 +12,7 @@ The full self-observability stack lands across **RC4**:
 | R4.2 — `otelhttp.NewHandler` wraps the Prom / Loki / Tempo handlers                                   | planned | adds one span per HTTP request           |
 | R4.3 — Custom spans around parse / lower / optimize / emit / execute                                  | planned | pipeline stage timings                   |
 | R4.4 — Self-metrics: request count + latency + CH roundtrip + in-flight gauge                         | planned | HPA-consumable                           |
-| R4.5 — OTLP exporters wired (`CERBERUS_OTLP_ENDPOINT` / `_INSECURE` / `_HEADERS` / `_TIMEOUT`)         | landed  | graceful no-op when endpoint unreachable |
+| R4.5 — OTLP exporters wired (`CERBERUS_OTLP_ENDPOINT` / `_INSECURE` / `_HEADERS` / `_TIMEOUT`)        | landed  | graceful no-op when endpoint unreachable |
 | R4.6 — `deploy/k3s/otel-collector.yaml` + `deploy/grafana/dashboards/cerberus-self.json`              | planned | wires the export path end-to-end         |
 
 This page only covers what has already shipped. The remaining rows are

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,12 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/clickhouse v0.42.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0
 	go.opentelemetry.io/otel v1.43.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0
+	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
+	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
 	golang.org/x/tools v0.45.0
 )
@@ -177,19 +182,14 @@ require (
 	go.opentelemetry.io/otel/exporters/jaeger v1.17.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.19.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.19.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.43.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.65.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdoutlog v0.19.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.43.0 // indirect
 	go.opentelemetry.io/otel/log v0.19.0 // indirect
-	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/sdk/log v0.19.0 // indirect
-	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,6 +34,15 @@ type Config struct {
 	// Log configures cerberus's own structured logging (stdlib log/slog).
 	// See LogConfig for the env-var contract.
 	Log LogConfig
+
+	// OTLP is the OpenTelemetry exporter configuration. When
+	// OTLP.Endpoint is empty cerberus installs no-op trace and meter
+	// providers (zero-collector-dependency binary). When set, cerberus
+	// builds gRPC OTLP exporters that ship spans + self-metrics to that
+	// endpoint. Standard OTEL_EXPORTER_OTLP_* env vars also work — the
+	// OTel Go SDK reads them by default and they merge with whatever
+	// these cerberus-specific values resolve to.
+	OTLP OTLPConfig
 }
 
 // LogConfig controls the slog setup applied at startup.
@@ -49,6 +58,26 @@ type LogConfig struct {
 	Level  slog.Level
 }
 
+// OTLPConfig holds OTLP gRPC exporter settings shared by the trace and
+// metric exporters. An empty Endpoint disables exporters entirely.
+type OTLPConfig struct {
+	// Endpoint is the gRPC target, e.g. "otel-collector.observability.svc:4317".
+	// Empty disables the exporters (noop providers installed).
+	Endpoint string
+
+	// Insecure, when true, dials the endpoint without TLS (handy for
+	// local dev / k3d where the collector listens on plain gRPC).
+	Insecure bool
+
+	// Headers are passed to every OTLP request as gRPC metadata
+	// (typically used for auth bearer tokens).
+	Headers map[string]string
+
+	// Timeout caps a single OTLP request roundtrip. Applies to both
+	// the trace and metric exporters.
+	Timeout time.Duration
+}
+
 // FromEnv reads configuration from environment variables, falling back to
 // reasonable defaults for local development.
 //
@@ -61,6 +90,13 @@ type LogConfig struct {
 //	CERBERUS_AUTO_CREATE_SCHEMA    default "false"
 //	CERBERUS_LOG_FORMAT            default "text"  ("text" | "json")
 //	CERBERUS_LOG_LEVEL             default "info"  ("debug" | "info" | "warn" | "error")
+//	CERBERUS_OTLP_ENDPOINT         default ""   (empty → exporters disabled)
+//	CERBERUS_OTLP_INSECURE         default "false"
+//	CERBERUS_OTLP_HEADERS          default ""   ("k=v,k2=v2" comma-separated)
+//	CERBERUS_OTLP_TIMEOUT          default "10s"
+//
+// Standard OTEL_EXPORTER_OTLP_* env vars are also honored by the OTel
+// Go SDK and complement these — see docs/observability.md.
 func FromEnv() (Config, error) {
 	dial, err := time.ParseDuration(envDefault("CERBERUS_CH_DIAL_TIMEOUT", "5s"))
 	if err != nil {
@@ -71,6 +107,10 @@ func FromEnv() (Config, error) {
 		return Config{}, fmt.Errorf("CERBERUS_AUTO_CREATE_SCHEMA: %w", err)
 	}
 	logCfg, err := envLog()
+	if err != nil {
+		return Config{}, err
+	}
+	otlp, err := otlpFromEnv()
 	if err != nil {
 		return Config{}, err
 	}
@@ -86,6 +126,7 @@ func FromEnv() (Config, error) {
 		Schema:           schema.DefaultOTelMetrics(),
 		AutoCreateSchema: autoCreate,
 		Log:              logCfg,
+		OTLP:             otlp,
 	}, nil
 }
 
@@ -104,6 +145,59 @@ func NewLogger(w io.Writer, cfg LogConfig) *slog.Logger {
 		h = slog.NewTextHandler(w, opts)
 	}
 	return slog.New(h)
+}
+
+// otlpFromEnv parses the CERBERUS_OTLP_* env vars into an OTLPConfig.
+// Empty endpoint is the documented "disabled" state and not an error —
+// the caller installs noop providers in that case.
+func otlpFromEnv() (OTLPConfig, error) {
+	timeout, err := time.ParseDuration(envDefault("CERBERUS_OTLP_TIMEOUT", "10s"))
+	if err != nil {
+		return OTLPConfig{}, fmt.Errorf("CERBERUS_OTLP_TIMEOUT: %w", err)
+	}
+	insecure, err := envBool("CERBERUS_OTLP_INSECURE", false)
+	if err != nil {
+		return OTLPConfig{}, fmt.Errorf("CERBERUS_OTLP_INSECURE: %w", err)
+	}
+	headers, err := parseHeaders(os.Getenv("CERBERUS_OTLP_HEADERS"))
+	if err != nil {
+		return OTLPConfig{}, fmt.Errorf("CERBERUS_OTLP_HEADERS: %w", err)
+	}
+	return OTLPConfig{
+		Endpoint: strings.TrimSpace(os.Getenv("CERBERUS_OTLP_ENDPOINT")),
+		Insecure: insecure,
+		Headers:  headers,
+		Timeout:  timeout,
+	}, nil
+}
+
+// parseHeaders splits a "k=v,k2=v2" string into a map. Empty input
+// returns nil, mirroring the noop default. Whitespace around keys and
+// values is trimmed. Entries without "=" are rejected so a typo doesn't
+// silently drop an auth header.
+func parseHeaders(raw string) (map[string]string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	out := map[string]string{}
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		eq := strings.IndexByte(part, '=')
+		if eq < 0 {
+			return nil, fmt.Errorf("entry %q: missing '='", part)
+		}
+		k := strings.TrimSpace(part[:eq])
+		v := strings.TrimSpace(part[eq+1:])
+		if k == "" {
+			return nil, fmt.Errorf("entry %q: empty key", part)
+		}
+		out[k] = v
+	}
+	return out, nil
 }
 
 func envDefault(key, def string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"testing"
+	"time"
 )
 
 // TestFromEnv_AutoCreateSchema_Default confirms the new flag defaults to
@@ -69,5 +70,87 @@ func TestFromEnv_AutoCreateSchema_Whitespace(t *testing.T) {
 	}
 	if !cfg.AutoCreateSchema {
 		t.Errorf("AutoCreateSchema = false; want true (trimmed)")
+	}
+}
+
+// TestFromEnv_OTLP_Default confirms the disabled-by-default contract:
+// no env vars set → empty endpoint, default timeout, no headers. The
+// empty endpoint is what installs noop providers in main.
+func TestFromEnv_OTLP_Default(t *testing.T) {
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if cfg.OTLP.Endpoint != "" {
+		t.Errorf("OTLP.Endpoint = %q; want empty", cfg.OTLP.Endpoint)
+	}
+	if cfg.OTLP.Insecure {
+		t.Errorf("OTLP.Insecure = true; want false")
+	}
+	if got, want := cfg.OTLP.Timeout, 10*time.Second; got != want {
+		t.Errorf("OTLP.Timeout = %v; want %v", got, want)
+	}
+	if cfg.OTLP.Headers != nil {
+		t.Errorf("OTLP.Headers = %v; want nil", cfg.OTLP.Headers)
+	}
+}
+
+// TestFromEnv_OTLP_Populated walks every OTLP env var through the
+// parser. Endpoint + insecure flag + custom timeout + headers map.
+func TestFromEnv_OTLP_Populated(t *testing.T) {
+	t.Setenv("CERBERUS_OTLP_ENDPOINT", "otel-collector.observability.svc:4317")
+	t.Setenv("CERBERUS_OTLP_INSECURE", "true")
+	t.Setenv("CERBERUS_OTLP_TIMEOUT", "3s")
+	t.Setenv("CERBERUS_OTLP_HEADERS", "authorization=Bearer abc, x-tenant=acme")
+
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if got, want := cfg.OTLP.Endpoint, "otel-collector.observability.svc:4317"; got != want {
+		t.Errorf("Endpoint = %q; want %q", got, want)
+	}
+	if !cfg.OTLP.Insecure {
+		t.Errorf("Insecure = false; want true")
+	}
+	if got, want := cfg.OTLP.Timeout, 3*time.Second; got != want {
+		t.Errorf("Timeout = %v; want %v", got, want)
+	}
+	if got, want := cfg.OTLP.Headers["authorization"], "Bearer abc"; got != want {
+		t.Errorf("Headers[authorization] = %q; want %q", got, want)
+	}
+	if got, want := cfg.OTLP.Headers["x-tenant"], "acme"; got != want {
+		t.Errorf("Headers[x-tenant] = %q; want %q", got, want)
+	}
+}
+
+// TestFromEnv_OTLP_InvalidHeaders rejects a header entry without "=" so
+// a typo never silently drops an auth token.
+func TestFromEnv_OTLP_InvalidHeaders(t *testing.T) {
+	t.Setenv("CERBERUS_OTLP_HEADERS", "authorization Bearer abc")
+	if _, err := FromEnv(); err == nil {
+		t.Fatal("FromEnv: want error for headers missing '=', got nil")
+	}
+}
+
+// TestFromEnv_OTLP_InvalidTimeout surfaces a bad duration as a startup
+// error rather than silently falling back to the default.
+func TestFromEnv_OTLP_InvalidTimeout(t *testing.T) {
+	t.Setenv("CERBERUS_OTLP_TIMEOUT", "not-a-duration")
+	if _, err := FromEnv(); err == nil {
+		t.Fatal("FromEnv: want error for bad timeout, got nil")
+	}
+}
+
+// TestFromEnv_OTLP_EndpointTrimmed trims whitespace from the endpoint
+// value — operators sometimes paste with stray newlines / spaces.
+func TestFromEnv_OTLP_EndpointTrimmed(t *testing.T) {
+	t.Setenv("CERBERUS_OTLP_ENDPOINT", "  collector:4317\n")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if got, want := cfg.OTLP.Endpoint, "collector:4317"; got != want {
+		t.Errorf("Endpoint = %q; want %q", got, want)
 	}
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -26,8 +26,8 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/metric"
 	metricnoop "go.opentelemetry.io/otel/metric/noop"
-	"go.opentelemetry.io/otel/sdk/resource"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"go.opentelemetry.io/otel/trace"
@@ -188,7 +188,8 @@ func buildResource(ctx context.Context, cfg Config) (*resource.Resource, error) 
 	if err != nil || instance == "" {
 		instance = randomInstanceID()
 	}
-	return resource.New(ctx,
+	return resource.New(
+		ctx,
 		resource.WithAttributes(
 			semconv.ServiceName(name),
 			semconv.ServiceVersion(version),

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -1,0 +1,206 @@
+// Package telemetry builds the OpenTelemetry tracer- and meter-provider
+// pair cerberus installs as the OTel process globals.
+//
+// When the supplied endpoint is empty, telemetry returns noop providers
+// — the zero-collector-dependency default that keeps cerberus runnable
+// without any OTel infrastructure. When the endpoint is set, telemetry
+// builds gRPC OTLP exporters (one for traces, one for metrics), wraps
+// them in the SDK trace/metric providers, and tags every export with a
+// resource carrying `service.name`, `service.version`, and
+// `service.instance.id`.
+//
+// The OTel Go SDK also reads standard `OTEL_EXPORTER_OTLP_*` env vars on
+// its own; cerberus's CERBERUS_OTLP_* knobs apply on top of those.
+package telemetry
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"time"
+
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/metric"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	"go.opentelemetry.io/otel/trace"
+	tracenoop "go.opentelemetry.io/otel/trace/noop"
+)
+
+// Config holds the runtime OTLP settings cerberus passes into the
+// provider builders. Mirrors internal/config.OTLPConfig but stays
+// dependency-free so this package can be reused by tests.
+type Config struct {
+	Endpoint string
+	Insecure bool
+	Headers  map[string]string
+	Timeout  time.Duration
+
+	ServiceName    string
+	ServiceVersion string
+}
+
+// Providers bundles the trace + meter providers cerberus installed as
+// globals plus a Shutdown closure that flushes both. Shutdown is safe
+// to call multiple times; the first call wins.
+type Providers struct {
+	TracerProvider trace.TracerProvider
+	MeterProvider  metric.MeterProvider
+
+	shutdown func(context.Context) error
+}
+
+// Shutdown flushes any pending spans / metric batches and tears down
+// the providers. Always returns nil for the noop case.
+func (p *Providers) Shutdown(ctx context.Context) error {
+	if p == nil || p.shutdown == nil {
+		return nil
+	}
+	return p.shutdown(ctx)
+}
+
+// New builds the OTel providers cerberus uses at runtime. An empty
+// cfg.Endpoint returns noop providers and a no-op Shutdown — the safe
+// "OTel disabled" default. A non-empty endpoint builds real gRPC OTLP
+// exporters; resource attributes are filled from cfg.ServiceName,
+// cfg.ServiceVersion, and the local hostname (with a random fallback).
+func New(ctx context.Context, cfg Config) (*Providers, error) {
+	if cfg.Endpoint == "" {
+		return &Providers{
+			TracerProvider: tracenoop.NewTracerProvider(),
+			MeterProvider:  metricnoop.NewMeterProvider(),
+		}, nil
+	}
+
+	res, err := buildResource(ctx, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("build resource: %w", err)
+	}
+
+	tp, traceShutdown, err := newTracerProvider(ctx, cfg, res)
+	if err != nil {
+		return nil, fmt.Errorf("trace exporter: %w", err)
+	}
+
+	mp, metricShutdown, err := newMeterProvider(ctx, cfg, res)
+	if err != nil {
+		// Roll back the trace provider so we don't leak a goroutine
+		// when only one of the two could be built.
+		_ = traceShutdown(ctx)
+		return nil, fmt.Errorf("metric exporter: %w", err)
+	}
+
+	return &Providers{
+		TracerProvider: tp,
+		MeterProvider:  mp,
+		shutdown: func(ctx context.Context) error {
+			// Best-effort: try both, return the first error so the
+			// operator still sees a signal but neither half blocks
+			// the other.
+			tErr := traceShutdown(ctx)
+			mErr := metricShutdown(ctx)
+			if tErr != nil {
+				return tErr
+			}
+			return mErr
+		},
+	}, nil
+}
+
+func newTracerProvider(ctx context.Context, cfg Config, res *resource.Resource) (
+	*sdktrace.TracerProvider, func(context.Context) error, error,
+) {
+	opts := []otlptracegrpc.Option{
+		otlptracegrpc.WithEndpoint(cfg.Endpoint),
+	}
+	if cfg.Insecure {
+		opts = append(opts, otlptracegrpc.WithInsecure())
+	}
+	if len(cfg.Headers) > 0 {
+		opts = append(opts, otlptracegrpc.WithHeaders(cfg.Headers))
+	}
+	if cfg.Timeout > 0 {
+		opts = append(opts, otlptracegrpc.WithTimeout(cfg.Timeout))
+	}
+	client := otlptracegrpc.NewClient(opts...)
+	exp, err := otlptrace.New(ctx, client)
+	if err != nil {
+		return nil, nil, err
+	}
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exp),
+		sdktrace.WithResource(res),
+	)
+	return tp, tp.Shutdown, nil
+}
+
+func newMeterProvider(ctx context.Context, cfg Config, res *resource.Resource) (
+	*sdkmetric.MeterProvider, func(context.Context) error, error,
+) {
+	opts := []otlpmetricgrpc.Option{
+		otlpmetricgrpc.WithEndpoint(cfg.Endpoint),
+	}
+	if cfg.Insecure {
+		opts = append(opts, otlpmetricgrpc.WithInsecure())
+	}
+	if len(cfg.Headers) > 0 {
+		opts = append(opts, otlpmetricgrpc.WithHeaders(cfg.Headers))
+	}
+	if cfg.Timeout > 0 {
+		opts = append(opts, otlpmetricgrpc.WithTimeout(cfg.Timeout))
+	}
+	exp, err := otlpmetricgrpc.New(ctx, opts...)
+	if err != nil {
+		return nil, nil, err
+	}
+	mp := sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(exp)),
+		sdkmetric.WithResource(res),
+	)
+	return mp, mp.Shutdown, nil
+}
+
+// buildResource composes the resource attached to every exported span
+// and metric. Attribute fallbacks:
+//
+//   - service.name        ← cfg.ServiceName  (defaults to "cerberus" if blank)
+//   - service.version     ← cfg.ServiceVersion (defaults to "dev" if blank)
+//   - service.instance.id ← os.Hostname()    (falls back to a random 16-byte
+//     hex string when hostname lookup errors out — common in scratch
+//     containers)
+func buildResource(ctx context.Context, cfg Config) (*resource.Resource, error) {
+	name := cfg.ServiceName
+	if name == "" {
+		name = "cerberus"
+	}
+	version := cfg.ServiceVersion
+	if version == "" {
+		version = "dev"
+	}
+	instance, err := os.Hostname()
+	if err != nil || instance == "" {
+		instance = randomInstanceID()
+	}
+	return resource.New(ctx,
+		resource.WithAttributes(
+			semconv.ServiceName(name),
+			semconv.ServiceVersion(version),
+			semconv.ServiceInstanceID(instance),
+		),
+	)
+}
+
+func randomInstanceID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "unknown"
+	}
+	return hex.EncodeToString(b[:])
+}

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -1,0 +1,114 @@
+package telemetry
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/metric"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+	tracenoop "go.opentelemetry.io/otel/trace/noop"
+)
+
+// TestNew_NoopWhenEndpointEmpty pins the zero-collector-dependency
+// default: an empty endpoint installs noop providers and Shutdown is a
+// no-op. This is the production-safe path that ships when an operator
+// hasn't pointed cerberus at a collector yet.
+func TestNew_NoopWhenEndpointEmpty(t *testing.T) {
+	providers, err := New(t.Context(), Config{Endpoint: ""})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if _, isSDK := providers.TracerProvider.(*sdktrace.TracerProvider); isSDK {
+		t.Errorf("TracerProvider is SDK provider; want noop")
+	}
+	if _, isSDK := providers.MeterProvider.(*sdkmetric.MeterProvider); isSDK {
+		t.Errorf("MeterProvider is SDK provider; want noop")
+	}
+	// Smoke: both providers can still hand out a tracer/meter.
+	_ = providers.TracerProvider.Tracer("test")
+	_ = providers.MeterProvider.Meter("test")
+
+	if err := providers.Shutdown(t.Context()); err != nil {
+		t.Errorf("Shutdown: %v", err)
+	}
+}
+
+// TestNew_BuildsSDKProvidersWhenEndpointSet verifies that a populated
+// endpoint produces SDK-backed providers (real exporters) instead of
+// the noop pair. We don't dial the endpoint here — gRPC client creation
+// is lazy, so New returns synchronously with a working provider even
+// without a listener. Shutdown afterward must not block indefinitely;
+// we bound it with a short context.
+func TestNew_BuildsSDKProvidersWhenEndpointSet(t *testing.T) {
+	// Reserve a port nothing is listening on. We immediately close the
+	// listener so the OTLP client's eventual connect attempt fails fast,
+	// but the SDK provider construction itself doesn't care.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	_ = ln.Close()
+
+	providers, err := New(t.Context(), Config{
+		Endpoint:       addr,
+		Insecure:       true,
+		Timeout:        1 * time.Second,
+		ServiceName:    "cerberus",
+		ServiceVersion: "test",
+		Headers:        map[string]string{"x-tenant": "ut"},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if _, ok := providers.TracerProvider.(*sdktrace.TracerProvider); !ok {
+		t.Errorf("TracerProvider type = %T; want *sdktrace.TracerProvider", providers.TracerProvider)
+	}
+	if _, ok := providers.MeterProvider.(*sdkmetric.MeterProvider); !ok {
+		t.Errorf("MeterProvider type = %T; want *sdkmetric.MeterProvider", providers.MeterProvider)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := providers.Shutdown(ctx); err != nil {
+		// Shutdown may report a connection error since nothing's
+		// listening — that's fine, the contract is "best effort flush
+		// + tear down, return what you saw". The test just guards
+		// against a panic or hang.
+		t.Logf("Shutdown error (expected when no listener): %v", err)
+	}
+}
+
+// TestProviders_ShutdownNil makes sure the nil-receiver path doesn't
+// panic — exercised by callers that bail out before New succeeds.
+func TestProviders_ShutdownNil(t *testing.T) {
+	var p *Providers
+	if err := p.Shutdown(t.Context()); err != nil {
+		t.Errorf("nil Shutdown: %v", err)
+	}
+}
+
+// TestProviders_NoopInterfaceSatisfied confirms the noop providers we
+// hand back implement the OTel interfaces the rest of cerberus depends
+// on (otel.SetTracerProvider / otel.SetMeterProvider expect those
+// exact interface types).
+func TestProviders_NoopInterfaceSatisfied(t *testing.T) {
+	providers, err := New(t.Context(), Config{Endpoint: ""})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	var _ trace.TracerProvider = providers.TracerProvider
+	var _ metric.MeterProvider = providers.MeterProvider
+
+	if _, ok := providers.TracerProvider.(tracenoop.TracerProvider); !ok {
+		t.Errorf("TracerProvider not noop type: %T", providers.TracerProvider)
+	}
+	if _, ok := providers.MeterProvider.(metricnoop.MeterProvider); !ok {
+		t.Errorf("MeterProvider not noop type: %T", providers.MeterProvider)
+	}
+}

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -6,11 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"go.opentelemetry.io/otel/metric"
 	metricnoop "go.opentelemetry.io/otel/metric/noop"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	"go.opentelemetry.io/otel/trace"
 	tracenoop "go.opentelemetry.io/otel/trace/noop"
 )
 
@@ -102,9 +100,6 @@ func TestProviders_NoopInterfaceSatisfied(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	var _ trace.TracerProvider = providers.TracerProvider
-	var _ metric.MeterProvider = providers.MeterProvider
-
 	if _, ok := providers.TracerProvider.(tracenoop.TracerProvider); !ok {
 		t.Errorf("TracerProvider not noop type: %T", providers.TracerProvider)
 	}


### PR DESCRIPTION
## Summary

- Swap the no-op tracer/meter providers (installed in #204) for real OTLP gRPC exporters wrapped in SDK trace and meter providers via a new `internal/telemetry` package.
- New `CERBERUS_OTLP_*` env block in `internal/config`: `_ENDPOINT` / `_INSECURE` / `_HEADERS` / `_TIMEOUT`. Empty endpoint keeps cerberus a zero-collector-dependency binary.
- Resource attributes attached to every export: `service.name=cerberus`, `service.version=<cmd/cerberus.Version, defaults to "dev">`, `service.instance.id=<os.Hostname() or random hex>`.
- Graceful shutdown path flushes pending OTLP batches inside the existing 10s shutdown context.
- New `docs/observability.md` documents env vars, the noop default, the shutdown path, and OTel SDK env-var interop.

## Env vars added

| Var | Default | Purpose |
| --- | --- | --- |
| `CERBERUS_OTLP_ENDPOINT` | `""` | gRPC target (empty disables exporters) |
| `CERBERUS_OTLP_INSECURE` | `false` | Skip TLS (local dev / k3d) |
| `CERBERUS_OTLP_HEADERS`  | `""` | Comma-separated `k=v` gRPC metadata |
| `CERBERUS_OTLP_TIMEOUT`  | `10s` | Per-request OTLP timeout |

Standard `OTEL_EXPORTER_OTLP_*` env vars continue to work through the OTel Go SDK.

## R4.6 contract

R4.6 (k8s manifest) will set `CERBERUS_OTLP_ENDPOINT=otel-collector.observability.svc:4317` and `CERBERUS_OTLP_INSECURE=true` against the in-cluster collector.

## Test plan

- [x] `go test ./internal/config/... ./internal/telemetry/... ./cmd/cerberus/...` passes locally
- [ ] CI `check` + `lint` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)