### PR TITLE
feat(deploy): repo-root docker-compose.yml for one-command local dev (RC5 R5.2)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,42 @@
+# Keep the Docker build context small (matters for Dockerfile.local, which
+# copies the whole tree). Mirrors .gitignore plus a few build-only artifacts
+# that .gitignore tolerates but Docker should never see.
+
+.git
+.github
+.claude
+.envrc
+.golangci.yml
+.gremlins.yaml
+.goreleaser.yml
+.markdownlint.yaml
+.markdownlintignore
+.editorconfig
+.commitlintrc.json
+lefthook.yml
+
+# Build outputs
+bin/
+dist/
+coverage.out
+coverage.html
+
+# Editor / IDE
+.idea/
+.vscode/
+*.swp
+
+# Test artifacts
+test/e2e/playwright/node_modules/
+test/e2e/playwright/test-results/
+test/e2e/playwright/playwright-report/
+
+# Documentation / contributor surface — never affects the build.
+docs/
+*.md
+LICENSE
+
+# Compose / k8s / harness — image build does not need these.
+docker-compose.yml
+deploy/
+harness/

--- a/README.md
+++ b/README.md
@@ -64,6 +64,20 @@ Schema defaults to the [OpenTelemetry ClickHouse Exporter](https://github.com/op
 
 ## Quick start
 
+### Docker Compose (one-command local dev)
+
+```sh
+git clone https://github.com/tsouza/cerberus.git && cd cerberus
+docker compose up --wait
+open http://localhost:3000   # Grafana (admin/admin); cerberus on :8080
+```
+
+The stack builds cerberus from the repo, boots a single-node ClickHouse,
+loads the deterministic OTel fixture (logs / traces / metrics), and brings
+up Grafana pre-provisioned with cerberus as three datasources (Prom +
+Loki + Tempo). ClickHouse data persists in a named volume; use
+`docker compose down -v` to wipe it.
+
 ### From a published release
 
 Pull the container image (pin to a specific RC — `:latest` is **only**

--- a/deploy/grafana/compose/datasources/cerberus.yaml
+++ b/deploy/grafana/compose/datasources/cerberus.yaml
@@ -1,0 +1,28 @@
+# Grafana datasource provisioning for the repo-root docker-compose.yml stack.
+#
+# Cerberus exposes three Grafana-facing APIs on a single HTTP port — Prom,
+# Loki and Tempo — so all three datasources point at the same URL. The k3s
+# manifest at deploy/k3s/grafana.yaml mirrors this layout.
+apiVersion: 1
+datasources:
+  - name: Cerberus-Prometheus
+    uid: cerberus-prometheus
+    type: prometheus
+    access: proxy
+    url: http://cerberus:8080
+    isDefault: true
+    editable: false
+    jsonData:
+      timeInterval: 15s
+  - name: Cerberus-Loki
+    uid: cerberus-loki
+    type: loki
+    access: proxy
+    url: http://cerberus:8080
+    editable: false
+  - name: Cerberus-Tempo
+    uid: cerberus-tempo
+    type: tempo
+    access: proxy
+    url: http://cerberus:8080
+    editable: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,140 @@
+# One-command local dev stack for cerberus.
+#
+#   docker compose up --wait
+#   open http://localhost:3000   # Grafana (admin/admin)
+#
+# Services:
+#   clickhouse   single-node CH server, OTel-aware (db=otel, user/pass=cerberus).
+#                Named volume `clickhouse-data` survives `docker compose down`
+#                so seed rows persist across restarts. Use `down -v` to wipe.
+#   cerberus     built from the repo-root `Dockerfile.local` (same image the
+#                k3d E2E uses). Auto-creates the OTel-CH schema on startup via
+#                CERBERUS_AUTO_CREATE_SCHEMA=true, so no separate init job.
+#   seed         one-shot Go program that inserts the deterministic OTel
+#                fixture rows from test/e2e/seed/cmd/seed. Exits after a
+#                successful run; doesn't block the long-lived services from
+#                being ready.
+#   grafana      pre-provisioned with cerberus as three datasources
+#                (Prometheus / Loki / Tempo). Provisioning files live under
+#                `deploy/grafana/compose/`.
+#
+# The OTLP exporter wiring (cerberus -> OTel Collector -> CH) is intentionally
+# omitted: the self-telemetry OTLP code path and the cerberus-self dashboard
+# both land later in RC4. Add an `otel-collector` service alongside cerberus
+# once those land — see deploy/k3s/otel-collector.yaml for the config shape.
+#
+# Default host port map:
+#   3000  -> grafana
+#   8080  -> cerberus (Prom + Loki + Tempo HTTP APIs)
+#   8123  -> clickhouse HTTP
+#   9000  -> clickhouse native protocol
+
+name: cerberus
+
+networks:
+  cerberus-dev:
+    driver: bridge
+
+volumes:
+  clickhouse-data:
+  go-mod-cache:
+
+services:
+  clickhouse:
+    image: clickhouse/clickhouse-server:24.8-alpine
+    networks: [cerberus-dev]
+    environment:
+      CLICKHOUSE_DB: otel
+      CLICKHOUSE_USER: cerberus
+      CLICKHOUSE_PASSWORD: cerberus
+      CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: "1"
+    volumes:
+      - clickhouse-data:/var/lib/clickhouse
+    ports:
+      - "8123:8123"
+      - "9000:9000"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8123/ping"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+
+  cerberus:
+    image: cerberus:dev
+    pull_policy: build
+    build:
+      context: .
+      dockerfile: Dockerfile.local
+    networks: [cerberus-dev]
+    environment:
+      # CERBERUS_HTTP_ADDR    HTTP listen addr for Prom/Loki/Tempo APIs.
+      CERBERUS_HTTP_ADDR: ":8080"
+      # CERBERUS_CH_*         ClickHouse connection inputs.
+      CERBERUS_CH_ADDR: "clickhouse:9000"
+      CERBERUS_CH_DATABASE: "otel"
+      CERBERUS_CH_USERNAME: "cerberus"
+      CERBERUS_CH_PASSWORD: "cerberus"
+      CERBERUS_CH_DIAL_TIMEOUT: "10s"
+      # CERBERUS_AUTO_CREATE_SCHEMA   apply the OTel-CH DDL on startup so a
+      # fresh CH volume is queryable without a separate migration step.
+      CERBERUS_AUTO_CREATE_SCHEMA: "true"
+    depends_on:
+      clickhouse:
+        condition: service_healthy
+    ports:
+      - "8080:8080"
+    healthcheck:
+      # Distroless image has no shell or wget. Use the cerberus binary's
+      # own `--version` flag as a liveness signal until /readyz lands and
+      # we can shell out to a probe sidecar.
+      test: ["CMD", "/usr/local/bin/cerberus", "--version"]
+      interval: 5s
+      timeout: 2s
+      retries: 12
+      start_period: 5s
+
+  seed:
+    # Runs the same Go seeder the k3d E2E uses, against the compose CH.
+    # One-shot: exits 0 after inserting the deterministic fixture rows.
+    # Re-run with `docker compose run --rm seed` to re-apply on a fresh volume.
+    image: golang:1.26
+    networks: [cerberus-dev]
+    working_dir: /src
+    volumes:
+      - .:/src
+      - go-mod-cache:/go/pkg/mod
+    environment:
+      CH_ADDR: "clickhouse:9000"
+      CH_DATABASE: "otel"
+      CH_USERNAME: "cerberus"
+      CH_PASSWORD: "cerberus"
+      GOTOOLCHAIN: "auto"
+    command: ["go", "run", "./test/e2e/seed/cmd/seed"]
+    depends_on:
+      clickhouse:
+        condition: service_healthy
+    restart: "no"
+
+  grafana:
+    image: grafana/grafana:11.4.0
+    networks: [cerberus-dev]
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Viewer
+      GF_USERS_DEFAULT_THEME: dark
+      GF_FEATURE_TOGGLES_ENABLE: traceqlSearch
+    volumes:
+      - ./deploy/grafana/compose/datasources:/etc/grafana/provisioning/datasources:ro
+    ports:
+      - "3000:3000"
+    depends_on:
+      cerberus:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3000/api/health || exit 1"]
+      interval: 5s
+      timeout: 2s
+      retries: 12
+


### PR DESCRIPTION
## Summary

Adds a top-level \`docker-compose.yml\` so a new contributor can clone the repo and run cerberus + ClickHouse + Grafana + seed data with a single command:

\`\`\`sh
git clone https://github.com/tsouza/cerberus.git && cd cerberus
docker compose up --wait
open http://localhost:3000   # Grafana (admin/admin); cerberus on :8080
\`\`\`

Services included:

- **clickhouse** — single-node CH (24.8-alpine, OTel-aware) on a named volume.
- **cerberus** — built from \`Dockerfile.local\` (same image \`just e2e-up\` uses). Auto-creates the OTel-CH schema via \`CERBERUS_AUTO_CREATE_SCHEMA=true\`.
- **seed** — one-shot \`go run ./test/e2e/seed/cmd/seed\` against the compose CH; exits 0 after inserting the deterministic OTel fixture.
- **grafana** — pre-provisioned with cerberus as three datasources (Prom + Loki + Tempo) via \`deploy/grafana/compose/datasources/cerberus.yaml\`.

The OTel-collector service is intentionally **omitted** until R4.5 (OTLP exporter env vars on cerberus side) and R4.6 (cerberus-self dashboard) land — neither exists in main yet. A follow-up will add an \`otel-collector\` service mirroring \`deploy/k3s/otel-collector.yaml\`.

Healthchecks:

- \`clickhouse\` — \`wget http://localhost:8123/ping\`.
- \`cerberus\` — \`cerberus --version\` (distroless image, no shell; switch to a \`/readyz\` HTTP probe once R5.1 lands).
- \`grafana\` — \`/api/health\`.
- \`cerberus depends_on clickhouse: service_healthy\`; \`grafana depends_on cerberus: service_healthy\`.

Default host port map:

| Port | Service |
| ---- | ------- |
| 3000 | Grafana |
| 8080 | cerberus (Prom + Loki + Tempo HTTP) |
| 8123 | ClickHouse HTTP |
| 9000 | ClickHouse native |

README quick-start gets a new "Docker Compose (one-command local dev)" subsection at the top of the Quick start block.

A new \`.dockerignore\` keeps the \`Dockerfile.local\` build context lean (excludes \`.git\`, \`.github\`, \`.claude\`, \`docs/\`, \`deploy/\`, \`harness/\`, \`*.md\`, IDE / coverage artifacts).

## Rebase notes vs R4.5 / R4.6 / R5.1

- **R4.5 / R4.6** (cerberus OTLP exporter + self-dashboard) — not landed; \`otel-collector\` service deferred to a follow-up PR. No env stubs added so the compose file works today.
- **R5.1** (\`/readyz\`) — not landed; \`cerberus --version\` used as the healthcheck for now. Switch to \`wget http://localhost:8080/readyz\` (via a probe sidecar, since distroless has no shell) once R5.1 ships.

## Test plan

- [ ] \`docker compose up --wait\` brings all services healthy on a clean machine.
- [ ] \`open http://localhost:3000\` shows Grafana with all three cerberus datasources, marked "saved & working" on probe.
- [ ] PromQL / LogQL / TraceQL "Explore" queries return the seeded fixture rows.
- [ ] \`docker compose down\` followed by \`docker compose up --wait\` preserves seed data (volume).
- [ ] \`docker compose down -v\` wipes the volume; subsequent \`up\` re-seeds.
- [ ] \`check\` + \`lint\` CI green.