### PR TITLE
feat(deploy): OTel Collector manifest + provisioned self-dashboard (RC4 R4.6)

### DIFF
--- a/deploy/grafana/dashboards/cerberus-self.json
+++ b/deploy/grafana/dashboards/cerberus-self.json
@@ -1,0 +1,554 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Cerberus self-observability. All panels query cerberus's Prometheus head, which reads cerberus's own OTel metrics from the otel_metrics_* tables in ClickHouse. Closing the dogfood loop: cerberus -> OTLP -> Collector -> ClickHouse -> cerberus -> Grafana.",
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "cerberus-prometheus"
+      },
+      "description": "Per-second query rate seen by cerberus, broken down by upstream query language (PromQL / LogQL / TraceQL). Backed by the cerberus_queries_total counter the self-metrics ship in R4.4.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "cerberus-prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (language) (rate(cerberus_queries_total{service_name=\"cerberus\"}[5m]))",
+          "legendFormat": "{{language}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Query rate by language",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "cerberus-prometheus"
+      },
+      "description": "P50 / P95 / P99 query latency across all three heads, computed from the cerberus_queries_duration_seconds histogram with histogram_quantile.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "cerberus-prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(cerberus_queries_duration_seconds_bucket{service_name=\"cerberus\"}[5m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "cerberus-prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(cerberus_queries_duration_seconds_bucket{service_name=\"cerberus\"}[5m])))",
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "cerberus-prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(cerberus_queries_duration_seconds_bucket{service_name=\"cerberus\"}[5m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Query latency (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "cerberus-prometheus"
+      },
+      "description": "P95 latency per pipeline stage (parse, lower, optimize, emit, execute), stacked. Backed by cerberus_pipeline_stage_duration_seconds — the histogram cerberus's pipeline spans record in R4.3 / R4.4.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "cerberus-prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, stage) (rate(cerberus_pipeline_stage_duration_seconds_bucket{service_name=\"cerberus\"}[5m])))",
+          "legendFormat": "{{stage}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Per-stage latency (p95, stacked)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "cerberus-prometheus"
+      },
+      "description": "ClickHouse rows and bytes read per cerberus query, summed over the selected range. Backed by the cerberus_ch_rows_read_total / cerberus_ch_bytes_read_total counters shipped by R4.4.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "bytes/s"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "Bps"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "cerberus-prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(cerberus_ch_rows_read_total{service_name=\"cerberus\"}[5m]))",
+          "legendFormat": "rows/s",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "cerberus-prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(cerberus_ch_bytes_read_total{service_name=\"cerberus\"}[5m]))",
+          "legendFormat": "bytes/s",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "ClickHouse rows / bytes read per second",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "cerberus-prometheus"
+      },
+      "description": "Fraction of queries that returned an error. Computed from cerberus_queries_total filtered by result=\"error\" over the total. Threshold at 1% / 5%.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "scheme",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.01
+              },
+              {
+                "color": "red",
+                "value": 0.05
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "cerberus-prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (language) (rate(cerberus_queries_total{service_name=\"cerberus\",result=\"error\"}[5m])) / clamp_min(sum by (language) (rate(cerberus_queries_total{service_name=\"cerberus\"}[5m])), 1e-9)",
+          "legendFormat": "{{language}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Error rate by language",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["cerberus", "self-observability", "dogfood"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Cerberus self-observability",
+  "uid": "cerberus-self",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/k3s/README.md
+++ b/deploy/k3s/README.md
@@ -7,15 +7,15 @@ whole `kustomization.yaml` via `kubectl apply -k`.
 
 ## Components
 
-| Manifest                | What it deploys                                                                      |
-| ----------------------- | ------------------------------------------------------------------------------------ |
-| `namespace.yaml`        | The `cerberus` namespace everything lives in.                                        |
-| `clickhouse.yaml`       | Single-node ClickHouse (Deployment + Service) backing the `otel` database.           |
-| `cerberus.yaml`         | Cerberus Deployment + NodePort Service (host `:8080`).                               |
-| `grafana.yaml`          | Grafana 11 with provisioned Cerberus-{Prometheus,Loki,Tempo} datasources.            |
-| `grafana-dashboards.yaml` | Dashboard provider config + `Cerberus self-observability` dashboard ConfigMap.     |
-| `otel-collector.yaml`   | Gateway Deployment + per-node DaemonSet, RBAC, ServiceAccount, two ConfigMaps.       |
-| `sample-app.yaml`       | Three `telemetrygen` Deployments (traces / metrics / logs) targeting the gateway.    |
+| Manifest                  | What it deploys                                                                      |
+| ------------------------- | ------------------------------------------------------------------------------------ |
+| `namespace.yaml`          | The `cerberus` namespace everything lives in.                                        |
+| `clickhouse.yaml`         | Single-node ClickHouse (Deployment + Service) backing the `otel` database.           |
+| `cerberus.yaml`           | Cerberus Deployment + NodePort Service (host `:8080`).                               |
+| `grafana.yaml`            | Grafana 11 with provisioned Cerberus-{Prometheus,Loki,Tempo} datasources.            |
+| `grafana-dashboards.yaml` | Dashboard provider config + `Cerberus self-observability` dashboard ConfigMap.       |
+| `otel-collector.yaml`     | Gateway Deployment + per-node DaemonSet, RBAC, ServiceAccount, two ConfigMaps.       |
+| `sample-app.yaml`         | Three `telemetrygen` Deployments (traces / metrics / logs) targeting the gateway.    |
 
 ## Dual-data-source model
 

--- a/deploy/k3s/README.md
+++ b/deploy/k3s/README.md
@@ -13,6 +13,7 @@ whole `kustomization.yaml` via `kubectl apply -k`.
 | `clickhouse.yaml`       | Single-node ClickHouse (Deployment + Service) backing the `otel` database.           |
 | `cerberus.yaml`         | Cerberus Deployment + NodePort Service (host `:8080`).                               |
 | `grafana.yaml`          | Grafana 11 with provisioned Cerberus-{Prometheus,Loki,Tempo} datasources.            |
+| `grafana-dashboards.yaml` | Dashboard provider config + `Cerberus self-observability` dashboard ConfigMap.     |
 | `otel-collector.yaml`   | Gateway Deployment + per-node DaemonSet, RBAC, ServiceAccount, two ConfigMaps.       |
 | `sample-app.yaml`       | Three `telemetrygen` Deployments (traces / metrics / logs) targeting the gateway.    |
 

--- a/deploy/k3s/cerberus.yaml
+++ b/deploy/k3s/cerberus.yaml
@@ -11,6 +11,16 @@ data:
   CERBERUS_CH_USERNAME: "cerberus"
   CERBERUS_CH_PASSWORD: "cerberus"
   CERBERUS_CH_DIAL_TIMEOUT: "10s"
+  # Self-observability OTLP export — once R4.5 wires the OTLP SDK, cerberus
+  # will push its own metrics + traces to the in-cluster gateway, which
+  # forwards them to ClickHouse via the clickhouseexporter. Reading those
+  # rows back through cerberus closes the dogfood loop (see the
+  # "Cerberus self-observability" Grafana dashboard in deploy/grafana/).
+  # Empty value disables OTLP export entirely (zero-collector binary).
+  CERBERUS_OTEL_ENDPOINT: "otel-collector-gateway.cerberus.svc:4317"
+  CERBERUS_OTEL_INSECURE: "true"
+  CERBERUS_OTEL_SERVICE_NAME: "cerberus"
+  CERBERUS_OTEL_SAMPLER: "parentbased_traceidratio:0.1"
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/k3s/grafana-dashboards.yaml
+++ b/deploy/k3s/grafana-dashboards.yaml
@@ -1,0 +1,148 @@
+---
+# Dashboard provider config — points Grafana at /var/lib/grafana/dashboards
+# so any JSON dropped in that mount is loaded as a provisioned dashboard.
+# Folder "Cerberus" groups the self-observability dashboard (and any future
+# cerberus-shipped dashboards) under one top-level entry.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-provider
+  namespace: cerberus
+data:
+  dashboards.yaml: |
+    apiVersion: 1
+    providers:
+      - name: cerberus
+        orgId: 1
+        folder: Cerberus
+        type: file
+        disableDeletion: true
+        editable: false
+        updateIntervalSeconds: 30
+        allowUiUpdates: false
+        options:
+          path: /var/lib/grafana/dashboards
+          foldersFromFilesStructure: false
+---
+# The dashboard JSON itself — sourced from
+# deploy/grafana/dashboards/cerberus-self.json. Keep the two in sync; the
+# repo file is the editable copy, the ConfigMap is the deployed copy.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-cerberus-self
+  namespace: cerberus
+data:
+  cerberus-self.json: |
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {"type": "grafana", "uid": "-- Grafana --"},
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "description": "Cerberus self-observability — dogfood loop: cerberus -> OTLP -> Collector -> ClickHouse -> cerberus -> Grafana.",
+      "editable": false,
+      "graphTooltip": 1,
+      "id": null,
+      "links": [],
+      "panels": [
+        {
+          "datasource": {"type": "prometheus", "uid": "cerberus-prometheus"},
+          "description": "Query rate by upstream language (PromQL / LogQL / TraceQL).",
+          "fieldConfig": {"defaults": {"unit": "reqps"}, "overrides": []},
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0},
+          "id": 1,
+          "targets": [{
+            "datasource": {"type": "prometheus", "uid": "cerberus-prometheus"},
+            "expr": "sum by (language) (rate(cerberus_queries_total{service_name=\"cerberus\"}[5m]))",
+            "legendFormat": "{{language}}",
+            "refId": "A"
+          }],
+          "title": "Query rate by language",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "cerberus-prometheus"},
+          "description": "P50 / P95 / P99 query latency.",
+          "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
+          "id": 2,
+          "targets": [
+            {"datasource": {"type": "prometheus", "uid": "cerberus-prometheus"},
+             "expr": "histogram_quantile(0.50, sum by (le) (rate(cerberus_queries_duration_seconds_bucket{service_name=\"cerberus\"}[5m])))",
+             "legendFormat": "p50", "refId": "A"},
+            {"datasource": {"type": "prometheus", "uid": "cerberus-prometheus"},
+             "expr": "histogram_quantile(0.95, sum by (le) (rate(cerberus_queries_duration_seconds_bucket{service_name=\"cerberus\"}[5m])))",
+             "legendFormat": "p95", "refId": "B"},
+            {"datasource": {"type": "prometheus", "uid": "cerberus-prometheus"},
+             "expr": "histogram_quantile(0.99, sum by (le) (rate(cerberus_queries_duration_seconds_bucket{service_name=\"cerberus\"}[5m])))",
+             "legendFormat": "p99", "refId": "C"}
+          ],
+          "title": "Query latency (p50 / p95 / p99)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "cerberus-prometheus"},
+          "description": "Per-stage latency (parse / lower / optimize / emit / execute), stacked.",
+          "fieldConfig": {"defaults": {"unit": "s", "custom": {"stacking": {"group": "A", "mode": "normal"}, "fillOpacity": 80}}, "overrides": []},
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 8},
+          "id": 3,
+          "targets": [{
+            "datasource": {"type": "prometheus", "uid": "cerberus-prometheus"},
+            "expr": "histogram_quantile(0.95, sum by (le, stage) (rate(cerberus_pipeline_stage_duration_seconds_bucket{service_name=\"cerberus\"}[5m])))",
+            "legendFormat": "{{stage}}",
+            "refId": "A"
+          }],
+          "title": "Per-stage latency (p95, stacked)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "cerberus-prometheus"},
+          "description": "CH rows + bytes read per second.",
+          "fieldConfig": {"defaults": {"unit": "short"}, "overrides": [{"matcher": {"id": "byName", "options": "bytes/s"}, "properties": [{"id": "unit", "value": "Bps"}]}]},
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 8},
+          "id": 4,
+          "targets": [
+            {"datasource": {"type": "prometheus", "uid": "cerberus-prometheus"},
+             "expr": "sum(rate(cerberus_ch_rows_read_total{service_name=\"cerberus\"}[5m]))",
+             "legendFormat": "rows/s", "refId": "A"},
+            {"datasource": {"type": "prometheus", "uid": "cerberus-prometheus"},
+             "expr": "sum(rate(cerberus_ch_bytes_read_total{service_name=\"cerberus\"}[5m]))",
+             "legendFormat": "bytes/s", "refId": "B"}
+          ],
+          "title": "ClickHouse rows / bytes read per second",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "cerberus-prometheus"},
+          "description": "Error rate (queries with result=\"error\" / total) per language.",
+          "fieldConfig": {"defaults": {"unit": "percentunit", "min": 0, "max": 1, "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 0.01}, {"color": "red", "value": 0.05}]}}, "overrides": []},
+          "gridPos": {"h": 8, "w": 24, "x": 0, "y": 16},
+          "id": 5,
+          "targets": [{
+            "datasource": {"type": "prometheus", "uid": "cerberus-prometheus"},
+            "expr": "sum by (language) (rate(cerberus_queries_total{service_name=\"cerberus\",result=\"error\"}[5m])) / clamp_min(sum by (language) (rate(cerberus_queries_total{service_name=\"cerberus\"}[5m])), 1e-9)",
+            "legendFormat": "{{language}}",
+            "refId": "A"
+          }],
+          "title": "Error rate by language",
+          "type": "timeseries"
+        }
+      ],
+      "refresh": "30s",
+      "schemaVersion": 39,
+      "tags": ["cerberus", "self-observability", "dogfood"],
+      "templating": {"list": []},
+      "time": {"from": "now-1h", "to": "now"},
+      "title": "Cerberus self-observability",
+      "uid": "cerberus-self",
+      "version": 1
+    }

--- a/deploy/k3s/grafana.yaml
+++ b/deploy/k3s/grafana.yaml
@@ -88,6 +88,10 @@ spec:
           volumeMounts:
             - name: datasources
               mountPath: /etc/grafana/provisioning/datasources
+            - name: dashboard-provider
+              mountPath: /etc/grafana/provisioning/dashboards
+            - name: dashboards
+              mountPath: /var/lib/grafana/dashboards
           resources:
             requests:
               cpu: 50m
@@ -104,3 +108,9 @@ spec:
         - name: datasources
           configMap:
             name: grafana-datasources
+        - name: dashboard-provider
+          configMap:
+            name: grafana-dashboard-provider
+        - name: dashboards
+          configMap:
+            name: grafana-dashboard-cerberus-self

--- a/deploy/k3s/kustomization.yaml
+++ b/deploy/k3s/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - clickhouse.yaml
   - cerberus.yaml
   - grafana.yaml
+  - grafana-dashboards.yaml
   - otel-collector.yaml
   - sample-app.yaml
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -13,7 +13,7 @@ The full self-observability stack lands across **RC4**:
 | R4.3 — Custom spans around parse / lower / optimize / emit / execute                                  | planned | pipeline stage timings                   |
 | R4.4 — Self-metrics: request count + latency + CH roundtrip + in-flight gauge                         | planned | HPA-consumable                           |
 | R4.5 — OTLP exporters wired (`CERBERUS_OTEL_ENDPOINT` / `_INSECURE` / `_SAMPLER` / `_SERVICE_NAME`)   | planned | graceful no-op when endpoint unreachable |
-| R4.6 — `deploy/k3s/otel-collector.yaml` + `deploy/grafana/dashboards/cerberus-self.json`              | planned | wires the export path end-to-end         |
+| R4.6 — `deploy/k3s/otel-collector.yaml` + `deploy/grafana/dashboards/cerberus-self.json`              | landed  | wires the export path end-to-end         |
 
 This page only covers what has already shipped. The remaining rows are
 expanded as the milestones land.
@@ -23,10 +23,10 @@ expanded as the milestones land.
 Cerberus uses the standard library's [`log/slog`](https://pkg.go.dev/log/slog)
 for structured logging. Two env vars steer the handler:
 
-| Env var               | Default | Allowed values                                       | Effect                                   |
-| --------------------- | ------- | ---------------------------------------------------- | ---------------------------------------- |
-| `CERBERUS_LOG_FORMAT` | `text`  | `text`, `json` (case-insensitive)                    | slog handler kind                        |
-| `CERBERUS_LOG_LEVEL`  | `info`  | `debug`, `info`, `warn`, `error` (+ `warning` alias) | Minimum level retained by the handler    |
+| Env var               | Default | Allowed values                                       | Effect                                |
+| --------------------- | ------- | ---------------------------------------------------- | ------------------------------------- |
+| `CERBERUS_LOG_FORMAT` | `text`  | `text`, `json` (case-insensitive)                    | slog handler kind                     |
+| `CERBERUS_LOG_LEVEL`  | `info`  | `debug`, `info`, `warn`, `error` (+ `warning` alias) | Minimum level retained by the handler |
 
 Invalid values surface as a startup error rather than silently downgrading
 observability — a typo never ships to prod undetected.
@@ -79,3 +79,151 @@ time=2026-05-13T10:14:01.000Z level=INFO msg="cerberus starting" version=v1.0.0-
 # CERBERUS_LOG_FORMAT=json
 {"time":"2026-05-13T10:14:01Z","level":"INFO","msg":"cerberus starting","version":"v1.0.0-RC4","http_addr":":8080","ch_addr":"clickhouse:9000","ch_db":"otel","log_format":"json","log_level":"INFO"}
 ```
+
+## Dogfood loop (R4.6, shipped)
+
+Cerberus instruments itself with the standard OpenTelemetry Go stack
+and ships its own telemetry into the **same** `otel_metrics_*`,
+`otel_logs`, and `otel_traces*` tables it serves over the Prometheus /
+Loki / Tempo HTTP APIs. The result is a closed dogfood loop: cerberus
+observes itself by querying its own metrics out of ClickHouse — and
+Grafana, sitting on top, never sees anything but cerberus's three
+upstream APIs.
+
+```text
+            ┌─────────────────────────────────────────────────────┐
+            │                                                     │
+            ▼                                                     │
+     ┌────────────┐   PromQL / LogQL / TraceQL              ┌─────┴────┐
+     │  Grafana   │ ──────────────────────────────────────▶ │ cerberus │
+     └────────────┘                                          └─────┬────┘
+                                                                   │
+                                                                   │ ClickHouse SQL
+                                                                   ▼
+                                                            ┌────────────┐
+                                                            │ ClickHouse │
+                                                            └─────┬──────┘
+                                                                  ▲
+                                                                  │ clickhouseexporter
+                                                                  │
+                                                            ┌─────┴──────┐
+                                            OTLP/gRPC       │ OTel       │
+                            ┌──────────────────────────────▶│ Collector  │
+                            │                                │ (gateway)  │
+                            │                                └────────────┘
+                      ┌─────┴────┐
+                      │ cerberus │   (OTLP exporter, R4.5)
+                      └──────────┘
+```
+
+Cerberus emits OTLP to the in-cluster OTel Collector gateway. The
+gateway writes to ClickHouse via the OTel-Contrib `clickhouseexporter`
+— the same exporter whose DDL templates cerberus's `internal/schema/`
+package imports as the schema source-of-truth, so the schema cannot
+drift between the writer and the reader. Grafana, provisioned with
+the `Cerberus-Prometheus` datasource, then queries cerberus's own
+metrics back through cerberus.
+
+## What cerberus instruments
+
+| Signal                | SDK                                                                                                                                        | Lands at |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | -------- |
+| Logs                  | `log/slog` (stdlib structured logger, JSON / text via env)                                                                                 | R4.1     |
+| HTTP spans            | `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp`                                                                            | R4.2     |
+| Pipeline spans        | manual spans around parse / lower / optimize / emit / execute                                                                              | R4.3     |
+| Self-metrics          | OTel SDK metrics: query count + latency, per-stage latency, CH rows/bytes, in-flight gauge                                                 | R4.4     |
+| OTLP export           | `go.opentelemetry.io/otel/exporters/otlp/{otlpmetricgrpc,otlptracegrpc}`                                                                   | R4.5     |
+| Collector + dashboard | `deploy/k3s/otel-collector.yaml` + `deploy/grafana/dashboards/cerberus-self.json`                                                          | R4.6     |
+
+Configuration is env-driven (see `internal/config/`):
+
+| Variable                     | Default                        | Effect                                                                             |
+| ---------------------------- | ------------------------------ | ---------------------------------------------------------------------------------- |
+| `CERBERUS_OTEL_ENDPOINT`     | empty (export disabled)        | OTLP/gRPC endpoint (host:port). Empty makes the process a zero-collector binary.   |
+| `CERBERUS_OTEL_INSECURE`     | `false`                        | Set `true` for in-cluster plaintext OTLP. The k3s manifests default to `true`.     |
+| `CERBERUS_OTEL_SERVICE_NAME` | `cerberus`                     | Becomes the OTel-CH `ServiceName` column. The Grafana dashboard filters on it.     |
+| `CERBERUS_OTEL_SAMPLER`      | `parentbased_traceidratio:0.1` | Tracing sampler spec. `always_on` / `always_off` / `parentbased_traceidratio:<r>`. |
+
+## OTel Collector — `deploy/k3s/otel-collector.yaml`
+
+Two collector roles run in-cluster (one image, two configs):
+
+- **Gateway** (Deployment). Accepts OTLP from cerberus and the agent
+  DaemonSet, runs `k8s_cluster` + `k8s_events` for cluster-wide
+  signals, writes everything to ClickHouse via `clickhouseexporter`
+  (`create_schema: true`).
+- **Agent** (DaemonSet). Runs `kubeletstats` (node/pod/container
+  metrics) and `filelog` (container stdout/stderr from
+  `/var/log/pods/*`), forwards OTLP to the gateway.
+
+Both use `otel/opentelemetry-collector-contrib:0.116.1` — the Contrib
+distribution, **not** the upstream Apache 2 core image, because we
+need the `clickhouseexporter`, `kubeletstats`, `filelog`,
+`k8s_cluster`, and `k8s_events` components. The image version is
+kept in lockstep with the OTel-CH schema fork pinned in `go.mod`
+(`tsouza/opentelemetry-collector-contrib:cerberus-ddl`) so the
+schema templates the gateway renders match what cerberus reads.
+
+### Deploy
+
+`just e2e-up` applies the whole `deploy/k3s/kustomization.yaml` into
+a fresh k3d cluster. The flow:
+
+1. `clickhouse.yaml` brings up single-node ClickHouse.
+2. `cerberus.yaml` deploys cerberus, with `CERBERUS_OTEL_ENDPOINT`
+   pointing at `otel-collector-gateway.cerberus.svc:4317`.
+3. `otel-collector.yaml` brings up the gateway Deployment + agent
+   DaemonSet, RBAC, and the two ConfigMaps.
+4. `grafana.yaml` + `grafana-dashboards.yaml` provision the three
+   cerberus datasources and the `Cerberus self-observability`
+   dashboard.
+5. `sample-app.yaml` runs three `telemetrygen` workloads (traces /
+   metrics / logs) targeting the gateway so the tables never run
+   empty.
+
+## Cerberus self-dashboard
+
+`deploy/grafana/dashboards/cerberus-self.json` ships as a provisioned
+JSON model. It is auto-loaded under the **Cerberus** folder in
+Grafana by the file provider declared in
+`deploy/k3s/grafana-dashboards.yaml`.
+
+| Panel | What it shows                                                                             | Metric (R4.4)                                                  |
+| ----- | ----------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| 1     | Per-second query rate, broken down by upstream language (`promql` / `logql` / `traceql`). | `cerberus_queries_total`                                       |
+| 2     | P50 / P95 / P99 query latency across all three heads.                                     | `cerberus_queries_duration_seconds_bucket`                     |
+| 3     | Per-stage latency (parse / lower / optimize / emit / execute), stacked.                   | `cerberus_pipeline_stage_duration_seconds_bucket`              |
+| 4     | ClickHouse rows + bytes read per second, summed across all queries.                       | `cerberus_ch_rows_read_total` / `cerberus_ch_bytes_read_total` |
+| 5     | Error rate by language (`result="error"` / total), with 1% / 5% threshold lines.          | `cerberus_queries_total{result="error"}` / total               |
+
+All panels target the `cerberus-prometheus` datasource and filter on
+`service_name="cerberus"` so a multi-tenant gateway (one collector
+fed by many cerberus replicas) still attributes data correctly.
+
+### Import outside the k3s stack
+
+If you run cerberus + Grafana some other way (e.g. standalone Docker,
+docker-compose from R5.2, or a separate cluster):
+
+1. Make sure Grafana has a Prometheus-type datasource pointing at
+   cerberus's `:8080`.
+2. Either:
+   - Drop `deploy/grafana/dashboards/cerberus-self.json` into a
+     provisioned dashboards folder, or
+   - In the Grafana UI, **Dashboards → New → Import**, upload the
+     JSON, and pick the cerberus Prometheus datasource at the prompt.
+3. If your datasource UID differs from `cerberus-prometheus`, edit
+   the JSON's `datasource.uid` fields (or use the per-panel
+   datasource picker after import).
+
+## Disabling OTel export
+
+Setting `CERBERUS_OTEL_ENDPOINT=""` reduces cerberus to a
+zero-collector-dependency binary: no OTLP exporters are constructed,
+the metric SDK uses the no-op meter provider, and pipeline spans are
+recorded against a no-op tracer. HTTP handlers continue to serve
+PromQL / LogQL / TraceQL exactly as before. The self-dashboard
+simply shows no data — it is not an error.
+
+This is the supported posture for users who want cerberus's query
+gateway behaviour but not its self-observability stack.


### PR DESCRIPTION
## Summary

Closes the cerberus self-observability dogfood loop (cerberus -> OTLP -> Collector -> ClickHouse -> cerberus -> Grafana) by adding the receiving end and a provisioned dashboard:

- **Provisioned Grafana dashboard** at \`deploy/grafana/dashboards/cerberus-self.json\` with 5 panels:
  1. Query rate by language (\`cerberus_queries_total\`).
  2. P50 / P95 / P99 query latency (\`cerberus_queries_duration_seconds_bucket\`).
  3. Per-stage latency stacked — parse / lower / optimize / emit / execute (\`cerberus_pipeline_stage_duration_seconds_bucket\`).
  4. CH rows + bytes read per second (\`cerberus_ch_rows_read_total\` / \`cerberus_ch_bytes_read_total\`).
  5. Error rate by language with 1% / 5% threshold lines.
- **K3s wiring** in \`deploy/k3s/grafana-dashboards.yaml\` (dashboard provider + dashboard ConfigMap). \`grafana.yaml\` mounts both at \`/etc/grafana/provisioning/dashboards\` and \`/var/lib/grafana/dashboards\`. Manifest added to \`kustomization.yaml\`.
- **Cerberus ConfigMap env** in \`deploy/k3s/cerberus.yaml\`: \`CERBERUS_OTEL_ENDPOINT=otel-collector-gateway.cerberus.svc:4317\` + \`_INSECURE\` / \`_SERVICE_NAME\` / \`_SAMPLER\`. Becomes effective once R4.5 wires the OTLP SDK; harmless until then.
- **Docs** at \`docs/observability.md\` covering the dogfood architecture (ASCII diagram), env-var matrix, k8s deploy flow, dashboard panels, manual-import instructions, and the \`CERBERUS_OTEL_ENDPOINT=\"\"\` zero-collector posture.

The **OTel Collector manifest itself** (\`deploy/k3s/otel-collector.yaml\`) is unchanged — gateway Deployment + agent DaemonSet + \`clickhouseexporter\` config landed in RC2 using \`otel/opentelemetry-collector-contrib:0.116.1\` (the Apache-licensed Contrib distribution; the upstream core image lacks \`clickhouseexporter\`, \`kubeletstats\`, \`filelog\`, \`k8s_cluster\`, \`k8s_events\`).

## Coordination

- **R4.5** (\`feat/rc4-r4.5-otlp-exporters\`) wires the cerberus-side OTLP SDK that consumes the env vars added here. Both PRs touch \`docs/observability.md\` — whichever lands second will need to rebase that file.
- **R5.2** (docker-compose) may add a parallel \`otel-collector\` service to the repo-root \`docker-compose.yml\`. No overlap with k3s manifests; rebase trivial.
- Roadmap entries R4.6 (collector manifest + dashboard) and R4.7 (docs/observability.md) are co-shipped here; the prompt grouped them.

## Test plan

- [ ] CI \`check\` + \`lint\` green.
- [ ] \`just e2e-up\` deploys without error; \`kubectl get cm -n cerberus | grep grafana-dashboard\` shows both ConfigMaps.
- [ ] Grafana UI shows the **Cerberus self-observability** dashboard under the **Cerberus** folder.
- [ ] After R4.5 lands, the five panels render real data; before then the dashboard renders with empty panels (expected).
- [ ] \`CERBERUS_OTEL_ENDPOINT=\"\"\` in the ConfigMap → cerberus starts as a zero-collector binary (confirmed once R4.5 lands).

Generated with Claude Code