### PR TITLE
fix(lint): pin MD060 style to aligned

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -23,3 +23,9 @@ MD024:
 # code blocks.
 MD046:
   style: fenced
+
+# MD060 — table-column-style: pin "aligned" explicitly. The default
+# "consistent" mode picks style from the first table in each file, which
+# breaks when concurrent PRs add tables in mixed styles.
+MD060:
+  style: aligned


### PR DESCRIPTION
Default 'consistent' mode picks the style from the first table in each file, which breaks reliably when concurrent PRs add tables in mixed styles. Pin to 'aligned' so all tables must pad cells to the widest entry.