### PR TITLE
feat(schema): env-driven table/database overrides

### DIFF
--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -21,7 +21,6 @@ import (
 	"github.com/tsouza/cerberus/internal/api/tempo"
 	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/config"
-	"github.com/tsouza/cerberus/internal/schema"
 	"github.com/tsouza/cerberus/internal/schema/ddl"
 	"github.com/tsouza/cerberus/internal/telemetry"
 )
@@ -97,10 +96,10 @@ func run() error {
 	promHandler := prom.New(client, cfg.Schema, logger.With("api", "prom"))
 	promHandler.Mount(traceMux)
 
-	lokiHandler := loki.New(client, schema.DefaultOTelLogs(), logger.With("api", "loki"))
+	lokiHandler := loki.New(client, cfg.Logs, logger.With("api", "loki"))
 	lokiHandler.Mount(traceMux)
 
-	tempoHandler := tempo.New(client, schema.DefaultOTelTraces(), Version, logger.With("api", "tempo"))
+	tempoHandler := tempo.New(client, cfg.Traces, Version, logger.With("api", "tempo"))
 	tempoHandler.Mount(traceMux)
 
 	// Install the W3C+Baggage propagator and build OTel providers from

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -80,6 +80,35 @@ time=2026-05-13T10:14:01.000Z level=INFO msg="cerberus starting" version=v1.0.0-
 {"time":"2026-05-13T10:14:01Z","level":"INFO","msg":"cerberus starting","version":"v1.0.0-RC4","http_addr":":8080","ch_addr":"clickhouse:9000","ch_db":"otel","log_format":"json","log_level":"INFO"}
 ```
 
+## Schema-shape overrides
+
+Cerberus reads the OpenTelemetry ClickHouse Exporter layout by default
+(table names + column names mirror the upstream
+`clickhouseexporter` DDL — see [`docs/upstream-forks.md`](upstream-forks.md)).
+Deployments with a customised CH layout — renamed tables, sharded
+clusters, alternate database conventions — override the table names via
+env vars at startup; nothing rebuild-related is required.
+
+| Variable                                      | Default                      | Effect                                                        |
+| --------------------------------------------- | ---------------------------- | ------------------------------------------------------------- |
+| `CERBERUS_SCHEMA_METRICS_GAUGE_TABLE`         | `otel_metrics_gauge`         | Gauge-metrics table name.                                     |
+| `CERBERUS_SCHEMA_METRICS_SUM_TABLE`           | `otel_metrics_sum`           | Sum / counter metrics table name.                             |
+| `CERBERUS_SCHEMA_METRICS_HISTOGRAM_TABLE`     | `otel_metrics_histogram`     | Classic histogram metrics table name.                         |
+| `CERBERUS_SCHEMA_METRICS_EXP_HISTOGRAM_TABLE` | `otel_metrics_exp_histogram` | Exponential / native histogram metrics table name.            |
+| `CERBERUS_SCHEMA_METRICS_SUMMARY_TABLE`       | `otel_metrics_summary`       | Summary metrics table name.                                   |
+| `CERBERUS_SCHEMA_LOGS_TABLE`                  | `otel_logs`                  | Logs table name read by the Loki API.                         |
+| `CERBERUS_SCHEMA_TRACES_TABLE`                | `otel_traces`                | Spans table name read by the Tempo API.                       |
+
+The active ClickHouse **database** is set by `CERBERUS_CH_DATABASE`
+(default `otel`) — that single knob covers both the connection's
+default schema and the database the auto-create DDL targets, so no
+separate `CERBERUS_SCHEMA_DATABASE` is required.
+
+Whitespace-only values (e.g. an empty `""` or a value with stray
+newlines) are treated as unset and fall back to the default. Non-empty
+values are trimmed before use. Column-name overrides are not in the
+current surface — open a tracking issue if a deployment needs them.
+
 ## Tracing + metrics export (R4.5, shipped)
 
 Cerberus emits structured logs, spans, and self-metrics so an operator can

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,14 @@ type Config struct {
 	HTTPAddr   string
 	ClickHouse chclient.Config
 	Schema     schema.Metrics
+	// Logs is the OTel logs schema (table + columns the Loki API reads).
+	// Defaults to schema.DefaultOTelLogs() with any CERBERUS_SCHEMA_LOGS_*
+	// env overrides applied.
+	Logs schema.Logs
+	// Traces is the OTel traces schema (table + columns the Tempo API
+	// reads). Defaults to schema.DefaultOTelTraces() with any
+	// CERBERUS_SCHEMA_TRACES_* env overrides applied.
+	Traces schema.Traces
 
 	// AutoCreateSchema, when true, instructs cerberus to run the OTel
 	// ClickHouse Exporter DDL (via internal/schema/ddl) against the
@@ -97,6 +105,16 @@ type OTLPConfig struct {
 //
 // Standard OTEL_EXPORTER_OTLP_* env vars are also honored by the OTel
 // Go SDK and complement these — see docs/observability.md.
+//
+// Schema-shape overrides (see internal/schema for the full env-var list):
+//
+//	CERBERUS_SCHEMA_METRICS_GAUGE_TABLE         default "otel_metrics_gauge"
+//	CERBERUS_SCHEMA_METRICS_SUM_TABLE           default "otel_metrics_sum"
+//	CERBERUS_SCHEMA_METRICS_HISTOGRAM_TABLE     default "otel_metrics_histogram"
+//	CERBERUS_SCHEMA_METRICS_EXP_HISTOGRAM_TABLE default "otel_metrics_exp_histogram"
+//	CERBERUS_SCHEMA_METRICS_SUMMARY_TABLE       default "otel_metrics_summary"
+//	CERBERUS_SCHEMA_LOGS_TABLE                  default "otel_logs"
+//	CERBERUS_SCHEMA_TRACES_TABLE                default "otel_traces"
 func FromEnv() (Config, error) {
 	dial, err := time.ParseDuration(envDefault("CERBERUS_CH_DIAL_TIMEOUT", "5s"))
 	if err != nil {
@@ -123,7 +141,9 @@ func FromEnv() (Config, error) {
 			Password:    envDefault("CERBERUS_CH_PASSWORD", ""),
 			DialTimeout: dial,
 		},
-		Schema:           schema.DefaultOTelMetrics(),
+		Schema:           schema.DefaultOTelMetricsFromEnv(),
+		Logs:             schema.DefaultOTelLogsFromEnv(),
+		Traces:           schema.DefaultOTelTracesFromEnv(),
 		AutoCreateSchema: autoCreate,
 		Log:              logCfg,
 		OTLP:             otlp,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,8 @@ package config
 import (
 	"testing"
 	"time"
+
+	"github.com/tsouza/cerberus/internal/schema"
 )
 
 // TestFromEnv_AutoCreateSchema_Default confirms the new flag defaults to
@@ -152,5 +154,63 @@ func TestFromEnv_OTLP_EndpointTrimmed(t *testing.T) {
 	}
 	if got, want := cfg.OTLP.Endpoint, "collector:4317"; got != want {
 		t.Errorf("Endpoint = %q; want %q", got, want)
+	}
+}
+
+// TestFromEnv_SchemaDefaults confirms that with no schema env vars set
+// the resolved Config.Schema / Logs / Traces match the defaults-only
+// factories exactly. The override path is additive — a deploy that
+// touches nothing keeps the upstream OTel CH layout.
+func TestFromEnv_SchemaDefaults(t *testing.T) {
+	for _, key := range []string{
+		schema.EnvMetricsGaugeTable,
+		schema.EnvMetricsSumTable,
+		schema.EnvMetricsHistogramTable,
+		schema.EnvMetricsExpHistogramTable,
+		schema.EnvMetricsSummaryTable,
+		schema.EnvLogsTable,
+		schema.EnvTracesTable,
+	} {
+		t.Setenv(key, "")
+	}
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if cfg.Schema.SumTable != schema.DefaultOTelMetrics().SumTable {
+		t.Errorf("Schema.SumTable: got %q, want default", cfg.Schema.SumTable)
+	}
+	if cfg.Logs.LogsTable != schema.DefaultOTelLogs().LogsTable {
+		t.Errorf("Logs.LogsTable: got %q, want default", cfg.Logs.LogsTable)
+	}
+	if cfg.Traces.SpansTable != schema.DefaultOTelTraces().SpansTable {
+		t.Errorf("Traces.SpansTable: got %q, want default", cfg.Traces.SpansTable)
+	}
+}
+
+// TestFromEnv_SchemaOverrides confirms env-var overrides reach the
+// resolved Config struct. Covers one knob per signal — the per-field
+// override matrix is exhaustively covered in internal/schema/env_test.go.
+func TestFromEnv_SchemaOverrides(t *testing.T) {
+	t.Setenv(schema.EnvMetricsSumTable, "custom_metrics_sum")
+	t.Setenv(schema.EnvLogsTable, "custom_logs")
+	t.Setenv(schema.EnvTracesTable, "custom_spans")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if cfg.Schema.SumTable != "custom_metrics_sum" {
+		t.Errorf("Schema.SumTable: got %q, want %q", cfg.Schema.SumTable, "custom_metrics_sum")
+	}
+	if cfg.Logs.LogsTable != "custom_logs" {
+		t.Errorf("Logs.LogsTable: got %q, want %q", cfg.Logs.LogsTable, "custom_logs")
+	}
+	if cfg.Traces.SpansTable != "custom_spans" {
+		t.Errorf("Traces.SpansTable: got %q, want %q", cfg.Traces.SpansTable, "custom_spans")
+	}
+	// Sanity: non-overridden fields stay defaulted (column names are not
+	// part of the override surface in this milestone).
+	if cfg.Schema.GaugeTable != schema.DefaultOTelMetrics().GaugeTable {
+		t.Errorf("Schema.GaugeTable should be unchanged: got %q", cfg.Schema.GaugeTable)
 	}
 }

--- a/internal/schema/env.go
+++ b/internal/schema/env.go
@@ -1,0 +1,71 @@
+package schema
+
+import (
+	"os"
+	"strings"
+)
+
+// Env var names recognised by the FromEnv factories. Listed as exported
+// constants so docs / tests can reference them without re-typing the
+// string and risking drift.
+const (
+	// EnvMetricsGaugeTable overrides Metrics.GaugeTable.
+	EnvMetricsGaugeTable = "CERBERUS_SCHEMA_METRICS_GAUGE_TABLE"
+	// EnvMetricsSumTable overrides Metrics.SumTable.
+	EnvMetricsSumTable = "CERBERUS_SCHEMA_METRICS_SUM_TABLE"
+	// EnvMetricsHistogramTable overrides Metrics.HistogramTable.
+	EnvMetricsHistogramTable = "CERBERUS_SCHEMA_METRICS_HISTOGRAM_TABLE"
+	// EnvMetricsExpHistogramTable overrides Metrics.ExpHistogramTable.
+	EnvMetricsExpHistogramTable = "CERBERUS_SCHEMA_METRICS_EXP_HISTOGRAM_TABLE"
+	// EnvMetricsSummaryTable overrides Metrics.SummaryTable.
+	EnvMetricsSummaryTable = "CERBERUS_SCHEMA_METRICS_SUMMARY_TABLE"
+	// EnvLogsTable overrides Logs.LogsTable.
+	EnvLogsTable = "CERBERUS_SCHEMA_LOGS_TABLE"
+	// EnvTracesTable overrides Traces.SpansTable.
+	EnvTracesTable = "CERBERUS_SCHEMA_TRACES_TABLE"
+)
+
+// envOverride returns the trimmed value of key when set to a non-empty
+// string, else def. An env var set to whitespace-only is treated as
+// unset — operators paste values with stray newlines often enough that
+// silently honouring them would produce table names like
+// "otel_metrics_sum\n" that fail at query time with cryptic CH errors.
+func envOverride(key, def string) string {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return def
+	}
+	return v
+}
+
+// DefaultOTelMetricsFromEnv returns DefaultOTelMetrics() with any
+// CERBERUS_SCHEMA_METRICS_*_TABLE env overrides applied. Unset or
+// whitespace-only values leave the corresponding field at its default.
+// Non-table fields (column names, rollups, suffixes) are not yet
+// overridable — extend the surface here if a deployment demonstrates
+// the need.
+func DefaultOTelMetricsFromEnv() Metrics {
+	m := DefaultOTelMetrics()
+	m.GaugeTable = envOverride(EnvMetricsGaugeTable, m.GaugeTable)
+	m.SumTable = envOverride(EnvMetricsSumTable, m.SumTable)
+	m.HistogramTable = envOverride(EnvMetricsHistogramTable, m.HistogramTable)
+	m.ExpHistogramTable = envOverride(EnvMetricsExpHistogramTable, m.ExpHistogramTable)
+	m.SummaryTable = envOverride(EnvMetricsSummaryTable, m.SummaryTable)
+	return m
+}
+
+// DefaultOTelLogsFromEnv returns DefaultOTelLogs() with the
+// CERBERUS_SCHEMA_LOGS_TABLE override applied (if set).
+func DefaultOTelLogsFromEnv() Logs {
+	l := DefaultOTelLogs()
+	l.LogsTable = envOverride(EnvLogsTable, l.LogsTable)
+	return l
+}
+
+// DefaultOTelTracesFromEnv returns DefaultOTelTraces() with the
+// CERBERUS_SCHEMA_TRACES_TABLE override applied (if set).
+func DefaultOTelTracesFromEnv() Traces {
+	t := DefaultOTelTraces()
+	t.SpansTable = envOverride(EnvTracesTable, t.SpansTable)
+	return t
+}

--- a/internal/schema/env_test.go
+++ b/internal/schema/env_test.go
@@ -1,0 +1,130 @@
+package schema
+
+import "testing"
+
+// TestDefaultOTelMetricsFromEnv_Unset confirms that with no env vars
+// set, the env-aware factory returns the exact same value as the
+// defaults-only factory. The override mechanism is additive: a deploy
+// that sets nothing must see the upstream OTel CH Exporter layout.
+func TestDefaultOTelMetricsFromEnv_Unset(t *testing.T) {
+	for _, key := range []string{
+		EnvMetricsGaugeTable,
+		EnvMetricsSumTable,
+		EnvMetricsHistogramTable,
+		EnvMetricsExpHistogramTable,
+		EnvMetricsSummaryTable,
+	} {
+		t.Setenv(key, "")
+	}
+	got := DefaultOTelMetricsFromEnv()
+	want := DefaultOTelMetrics()
+	if got.GaugeTable != want.GaugeTable ||
+		got.SumTable != want.SumTable ||
+		got.HistogramTable != want.HistogramTable ||
+		got.ExpHistogramTable != want.ExpHistogramTable ||
+		got.SummaryTable != want.SummaryTable {
+		t.Errorf("FromEnv() with no overrides should equal Default(); got %+v, want %+v", got, want)
+	}
+	// Non-overridable fields must also pass through.
+	if got.MetricNameColumn != want.MetricNameColumn {
+		t.Errorf("MetricNameColumn drifted: got %q, want %q", got.MetricNameColumn, want.MetricNameColumn)
+	}
+	if len(got.MetricsRollups) != len(want.MetricsRollups) {
+		t.Errorf("MetricsRollups length drifted: got %d, want %d", len(got.MetricsRollups), len(want.MetricsRollups))
+	}
+}
+
+// TestDefaultOTelMetricsFromEnv_Overrides walks every overridable
+// table field, sets the env var, and confirms only that field changes.
+func TestDefaultOTelMetricsFromEnv_Overrides(t *testing.T) {
+	cases := []struct {
+		env   string
+		value string
+		pick  func(Metrics) string
+	}{
+		{EnvMetricsGaugeTable, "custom_gauge", func(m Metrics) string { return m.GaugeTable }},
+		{EnvMetricsSumTable, "custom_sum", func(m Metrics) string { return m.SumTable }},
+		{EnvMetricsHistogramTable, "custom_hist", func(m Metrics) string { return m.HistogramTable }},
+		{EnvMetricsExpHistogramTable, "custom_exp", func(m Metrics) string { return m.ExpHistogramTable }},
+		{EnvMetricsSummaryTable, "custom_summary", func(m Metrics) string { return m.SummaryTable }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.env, func(t *testing.T) {
+			t.Setenv(tc.env, tc.value)
+			got := DefaultOTelMetricsFromEnv()
+			if g := tc.pick(got); g != tc.value {
+				t.Errorf("%s: got %q, want %q", tc.env, g, tc.value)
+			}
+		})
+	}
+}
+
+// TestDefaultOTelMetricsFromEnv_WhitespaceTreatedAsUnset confirms that
+// whitespace-only values fall back to the default rather than producing
+// table names with stray characters. Operators paste values with
+// trailing newlines often enough that silently honouring them would
+// surface as cryptic CH errors at query time.
+func TestDefaultOTelMetricsFromEnv_WhitespaceTreatedAsUnset(t *testing.T) {
+	t.Setenv(EnvMetricsSumTable, "   \n\t  ")
+	got := DefaultOTelMetricsFromEnv()
+	if got.SumTable != "otel_metrics_sum" {
+		t.Errorf("whitespace override should fall back to default; got %q", got.SumTable)
+	}
+}
+
+// TestDefaultOTelMetricsFromEnv_TrimsValue confirms surrounding
+// whitespace is stripped from a non-empty override (same operator
+// paste-with-newline scenario as the bool parsing).
+func TestDefaultOTelMetricsFromEnv_TrimsValue(t *testing.T) {
+	t.Setenv(EnvMetricsSumTable, "  custom_sum\n")
+	got := DefaultOTelMetricsFromEnv()
+	if got.SumTable != "custom_sum" {
+		t.Errorf("trimmed override: got %q, want %q", got.SumTable, "custom_sum")
+	}
+}
+
+// TestDefaultOTelLogsFromEnv_Unset / _Override mirror the metrics
+// coverage for the logs surface.
+func TestDefaultOTelLogsFromEnv_Unset(t *testing.T) {
+	t.Setenv(EnvLogsTable, "")
+	got := DefaultOTelLogsFromEnv()
+	want := DefaultOTelLogs()
+	if got.LogsTable != want.LogsTable {
+		t.Errorf("LogsTable drift: got %q, want %q", got.LogsTable, want.LogsTable)
+	}
+	if got.BodyColumn != want.BodyColumn {
+		t.Errorf("BodyColumn drift: got %q, want %q", got.BodyColumn, want.BodyColumn)
+	}
+}
+
+func TestDefaultOTelLogsFromEnv_Override(t *testing.T) {
+	t.Setenv(EnvLogsTable, "custom_logs")
+	got := DefaultOTelLogsFromEnv()
+	if got.LogsTable != "custom_logs" {
+		t.Errorf("LogsTable override: got %q, want %q", got.LogsTable, "custom_logs")
+	}
+	// Column names must pass through unchanged.
+	if got.BodyColumn != "Body" {
+		t.Errorf("BodyColumn drifted while overriding LogsTable: got %q", got.BodyColumn)
+	}
+}
+
+func TestDefaultOTelTracesFromEnv_Unset(t *testing.T) {
+	t.Setenv(EnvTracesTable, "")
+	got := DefaultOTelTracesFromEnv()
+	want := DefaultOTelTraces()
+	if got.SpansTable != want.SpansTable {
+		t.Errorf("SpansTable drift: got %q, want %q", got.SpansTable, want.SpansTable)
+	}
+}
+
+func TestDefaultOTelTracesFromEnv_Override(t *testing.T) {
+	t.Setenv(EnvTracesTable, "custom_spans")
+	got := DefaultOTelTracesFromEnv()
+	if got.SpansTable != "custom_spans" {
+		t.Errorf("SpansTable override: got %q, want %q", got.SpansTable, "custom_spans")
+	}
+	if got.TraceIDColumn != "TraceId" {
+		t.Errorf("TraceIDColumn drifted while overriding SpansTable: got %q", got.TraceIDColumn)
+	}
+}


### PR DESCRIPTION
## Summary

Cerberus's OTel ClickHouse schema is loaded from baked-in defaults
(via `schema.DefaultOTel*()` — see [`docs/upstream-forks.md`](../blob/main/docs/upstream-forks.md)).
This PR adds env-driven overrides so deployments with renamed tables /
sharded clusters / alternative naming conventions can adjust the layout
at startup, in keeping with 12-factor.

- New env vars (seven total — five metrics tables + logs + traces):
  - `CERBERUS_SCHEMA_METRICS_GAUGE_TABLE`
  - `CERBERUS_SCHEMA_METRICS_SUM_TABLE`
  - `CERBERUS_SCHEMA_METRICS_HISTOGRAM_TABLE`
  - `CERBERUS_SCHEMA_METRICS_EXP_HISTOGRAM_TABLE`
  - `CERBERUS_SCHEMA_METRICS_SUMMARY_TABLE`
  - `CERBERUS_SCHEMA_LOGS_TABLE`
  - `CERBERUS_SCHEMA_TRACES_TABLE`
- `internal/schema/env.go` adds `DefaultOTel{Metrics,Logs,Traces}FromEnv`
  factories that layer overrides on top of the existing defaults-only
  factories.
- `Config` grows `Logs` + `Traces` fields; `cmd/cerberus/main.go` now
  reads from those instead of calling `schema.DefaultOTel{Logs,Traces}()`
  directly, so overrides actually reach the Loki / Tempo handlers.
- Whitespace-only values are treated as unset (operators paste env vars
  with stray newlines often enough that silently honouring them would
  surface as cryptic CH errors at query time).
- No separate `CERBERUS_SCHEMA_DATABASE` — `CERBERUS_CH_DATABASE`
  already covers the active database for both the connection and DDL.
- Column-name overrides intentionally skipped (env-var bloat not yet
  justified — see code comments + the new doc section).

## Test plan

- [x] `go test ./internal/schema/... ./internal/config/... ./cmd/cerberus/...` — pass
- [x] Defaults-unchanged regression: `FromEnv` with all schema vars
      unset returns the same shape as the defaults-only factories.
- [x] Override regression: per-field tests for each new env var.
- [x] Whitespace-only override falls back to default.
- [x] Value with surrounding whitespace is trimmed.
- [x] `go build ./...` clean.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>