### PR TITLE
feat(deploy): HPA recipe + scale-out docs

### DIFF
--- a/deploy/k3s/README.md
+++ b/deploy/k3s/README.md
@@ -12,6 +12,7 @@ whole `kustomization.yaml` via `kubectl apply -k`.
 | `namespace.yaml`          | The `cerberus` namespace everything lives in.                                        |
 | `clickhouse.yaml`         | Single-node ClickHouse (Deployment + Service) backing the `otel` database.           |
 | `cerberus.yaml`           | Cerberus Deployment + NodePort Service (host `:8080`).                               |
+| `cerberus-hpa.yaml`       | HorizontalPodAutoscaler scaling cerberus on CPU utilisation (2–10 replicas).         |
 | `grafana.yaml`            | Grafana 11 with provisioned Cerberus-{Prometheus,Loki,Tempo} datasources.            |
 | `grafana-dashboards.yaml` | Dashboard provider config + `Cerberus self-observability` dashboard ConfigMap.       |
 | `otel-collector.yaml`     | Gateway Deployment + per-node DaemonSet, RBAC, ServiceAccount, two ConfigMaps.       |
@@ -87,6 +88,58 @@ gate test execution on the pipeline being live (it usually takes
   pinned in `go.mod`. Bump in lockstep when the fork moves.
 - `ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.116.0`
   — same family, published as a separate image.
+
+## Horizontal scale-out (HPA)
+
+`cerberus-hpa.yaml` ships a `HorizontalPodAutoscaler` targeting the
+`cerberus` Deployment. It is wired into `kustomization.yaml` so
+`just e2e-up` (and any `kubectl apply -k deploy/k3s/`) brings the
+autoscaler up alongside everything else.
+
+Defaults:
+
+- `minReplicas: 2`, `maxReplicas: 10`.
+- Scales on **CPU utilisation** at 70% of the pod's CPU request. The
+  standard `metrics-server` is the only dependency (already present
+  in k3d/k3s). No prometheus-adapter, no prometheus-operator.
+- Scale-up: up to 3 pods per 60s, 30s stabilisation window.
+- Scale-down: 1 pod per 300s, 5-minute stabilisation window.
+
+The Deployment manifest deliberately omits the `replicas:` field so
+the HPA owns the count. Setting both would cause the controllers to
+fight on every reconcile.
+
+### Verifying
+
+```sh
+kubectl -n cerberus get hpa cerberus
+kubectl -n cerberus describe hpa cerberus
+```
+
+The output should show `TARGETS  70%/<current>%` and
+`MINPODS  2`, `MAXPODS  10`. If `TARGETS` is `<unknown>/70%`,
+metrics-server has not reported yet — give it 60 seconds after the
+pods become Ready.
+
+### Tuning
+
+- **Bigger ceiling** — raise `maxReplicas` once the upstream
+  ClickHouse cluster can absorb the parallel query load.
+- **Quieter scale-down** — increase `scaleDown.stabilizationWindowSeconds`
+  for workloads with predictable diurnal dips.
+- **Load-aware scaling** — see the commented block at the bottom of
+  `cerberus-hpa.yaml` for the prometheus-adapter recipe that scales
+  on `rate(cerberus_queries_total[1m])` instead of CPU.
+
+### Pairing with admission caps
+
+When `CERBERUS_MAX_INFLIGHT_PROM` / `_LOKI` / `_TEMPO` / `_TAIL` are
+set, a saturated pod returns `503 Retry-After` immediately rather
+than queuing work that ClickHouse cannot keep up with. Average CPU
+utilisation across the remaining pods stays high, the HPA spawns the
+next replica, and the new pod takes its share of traffic on the
+following load-balancer hash. The admission caps protect ClickHouse
+while the HPA grows the pool.
 
 ## Cleaning up
 

--- a/deploy/k3s/cerberus-hpa.yaml
+++ b/deploy/k3s/cerberus-hpa.yaml
@@ -1,0 +1,108 @@
+---
+# HorizontalPodAutoscaler for the cerberus Deployment.
+#
+# Cerberus is stateless (ClickHouse holds all state), so horizontal scale-out
+# is the right scaling lever — adding replicas behind the Service distributes
+# load without coordination. This manifest ships a CPU-based recipe that
+# works on any Kubernetes cluster with the standard `metrics-server`
+# installed (which k3d/k3s ship by default). For load-aware scaling using
+# the cerberus self-metric `cerberus_queries_total`, see the alternative
+# block at the bottom of this file and `deploy/k3s/README.md`.
+#
+# Why CPU as the default trigger:
+#   - metrics-server is universally available; the prometheus-adapter +
+#     prometheus-operator stack required for custom metrics is not part
+#     of this manifest set today.
+#   - Cerberus's hot path (parse → lower → optimize → emit) is CPU-bound
+#     on the gateway side; ClickHouse handles the heavy I/O. CPU
+#     utilisation is therefore a faithful proxy for query load.
+#
+# Replica bounds:
+#   - minReplicas: 2 — survives a single-pod failure (rolling restarts,
+#     node drains, OOM kills) without dropping below one healthy pod.
+#   - maxReplicas: 10 — conservative ceiling. Operators with larger
+#     ClickHouse clusters can lift this; the gateway itself is cheap
+#     (~64Mi memory request) but the upstream CH cluster must absorb
+#     the parallel query load.
+#
+# Scale behaviour:
+#   - Scale-up is fast: at most 3 pods per 60s window, with a 30s
+#     stabilisation window. Bursty query traffic gets capacity quickly.
+#   - Scale-down is slow: at most 1 pod per 300s window, with a 5-minute
+#     stabilisation window. Avoids thrashing on transient dips.
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: cerberus
+  namespace: cerberus
+  labels:
+    app: cerberus
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: cerberus
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          # 70% of the pod's CPU request (100m in cerberus.yaml) — leaves
+          # headroom for the burst between an HPA scrape and the new pod
+          # becoming Ready.
+          averageUtilization: 70
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 30
+      policies:
+        - type: Pods
+          value: 3
+          periodSeconds: 60
+      selectPolicy: Max
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 300
+      selectPolicy: Max
+# -----------------------------------------------------------------------------
+# Alternative: load-aware scaling on cerberus_queries_total (commented out).
+#
+# When the cluster ships a Prometheus + prometheus-adapter stack that
+# scrapes the OTel Collector's `prometheus` exporter (or scrapes cerberus
+# directly via a future `/metrics` endpoint), the HPA can scale on real
+# query rate instead of CPU. Replace the `metrics:` block above with:
+#
+#   metrics:
+#     - type: Pods
+#       pods:
+#         metric:
+#           name: cerberus_queries_per_second
+#         target:
+#           type: AverageValue
+#           # ~50 queries/sec/pod — tune to the workload. Past this point
+#           # the HPA scales out. Pair with CERBERUS_MAX_INFLIGHT_*
+#           # admission caps so a saturated pod returns 503 Retry-After
+#           # while the HPA spawns its replacement.
+#           averageValue: "50"
+#
+# Wiring sketch:
+#   1. Add a `prometheus` exporter to the OTel Collector gateway config
+#      (deploy/k3s/otel-collector.yaml) so cerberus.queries.total is
+#      exposed in Prometheus exposition format on :8889/metrics.
+#   2. Install the kube-prometheus-stack chart (or prometheus-operator +
+#      prometheus-adapter) in the cluster.
+#   3. Add a ServiceMonitor selecting the otel-collector-gateway service
+#      so Prometheus scrapes the gateway.
+#   4. Configure prometheus-adapter to expose
+#      rate(cerberus_queries_total[1m]) (summed per cerberus pod) as the
+#      external metric `cerberus_queries_per_second`.
+#   5. Switch this HPA's `metrics:` block to the Pods-metric form above.
+#
+# The CPU path keeps working as a safety net while custom metrics are
+# being rolled out — the HPA can carry both metric blocks and will scale
+# on whichever signal demands more replicas.

--- a/deploy/k3s/cerberus.yaml
+++ b/deploy/k3s/cerberus.yaml
@@ -47,7 +47,10 @@ metadata:
   labels:
     app: cerberus
 spec:
-  replicas: 1
+  # replicas is intentionally omitted — the HorizontalPodAutoscaler in
+  # cerberus-hpa.yaml owns this field. Setting it here would cause the
+  # Deployment controller and the HPA to fight over the replica count
+  # on every reconcile. The HPA's minReplicas (2) defines the floor.
   strategy:
     type: RollingUpdate
   selector:

--- a/deploy/k3s/kustomization.yaml
+++ b/deploy/k3s/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - namespace.yaml
   - clickhouse.yaml
   - cerberus.yaml
+  - cerberus-hpa.yaml
   - grafana.yaml
   - grafana-dashboards.yaml
   - otel-collector.yaml

--- a/docs/12factor.md
+++ b/docs/12factor.md
@@ -180,6 +180,42 @@ A single cerberus process is itself concurrent: the standard
 ClickHouse driver pool serves them from a shared connection set.
 There is no `--workers` flag because there is no need for one.
 
+### Kubernetes HorizontalPodAutoscaler
+
+`deploy/k3s/cerberus-hpa.yaml` ships a ready-to-apply HPA recipe that
+makes this concrete:
+
+- **Replica bounds:** `minReplicas: 2` (survives a single-pod failure
+  without dropping below one healthy serving pod) and `maxReplicas: 10`
+  (a conservative ceiling; lift it per cluster as ClickHouse capacity
+  allows).
+- **Scaling signal:** CPU utilisation at 70% of the pod's CPU request.
+  Cerberus's hot path (parse → lower → optimize → emit) is CPU-bound on
+  the gateway side, so CPU is a faithful load proxy. The standard
+  `metrics-server` (bundled with k3d/k3s) is the only dependency —
+  no prometheus-adapter required.
+- **Scale-up is fast, scale-down is slow.** Up to 3 new pods per 60s
+  window with a 30s stabilisation window absorbs bursty traffic
+  quickly; at most 1 pod per 300s window with a 5-minute stabilisation
+  window avoids thrashing on transient dips.
+- **Load-aware alternative.** A commented block in the same manifest
+  documents the prometheus-adapter wiring required to scale on
+  `rate(cerberus_queries_total[1m])` once a cluster ships a Prometheus
+  stack. The CPU path keeps working as a safety net in parallel.
+
+The Deployment manifest deliberately omits the `replicas:` field so
+the HPA owns it — otherwise the Deployment controller and the HPA
+fight on every reconcile. The HPA's `minReplicas` defines the floor.
+
+Per-handler admission control (`CERBERUS_MAX_INFLIGHT_PROM` /
+`_LOKI` / `_TEMPO` / `_TAIL`) pairs naturally with horizontal
+scale-out: once a single pod hits its in-flight cap, it returns `503
+Retry-After` immediately, the average CPU utilisation across the
+remaining pods stays high, and the HPA spawns the next replica. The
+two mechanisms are complementary, not redundant: admission caps
+defend ClickHouse from a thundering herd while the HPA is still
+catching up.
+
 ## Factor IX — Disposability
 
 > Maximize robustness with fast startup and graceful shutdown.


### PR DESCRIPTION
## Summary

- Ships `deploy/k3s/cerberus-hpa.yaml` — a `HorizontalPodAutoscaler` targeting the `cerberus` Deployment. Scales 2–10 replicas on CPU utilisation at 70% of request.
- Wires the manifest into `kustomization.yaml` and drops the static `replicas: 1` from `deploy/k3s/cerberus.yaml` so the HPA owns the field cleanly.
- Documents the scale-out story in `docs/12factor.md` § Factor VIII (Concurrency) and adds an operator install + tuning section to `deploy/k3s/README.md`.

## Why CPU as the default trigger

Cerberus's hot path (parse → lower → optimize → emit) is CPU-bound on the gateway side, so CPU utilisation is a faithful load proxy. The standard `metrics-server` is the only dependency — k3d/k3s ship it by default, and it works on every managed K8s offering. The prometheus-adapter / prometheus-operator stack required for custom-metric scaling is not part of this manifest set today, so the alternative `cerberus_queries_total`-driven recipe is shipped as a commented block at the bottom of the HPA manifest with the wiring sketch documented end-to-end (OTel Collector `prometheus` exporter → ServiceMonitor → prometheus-adapter → external metric). The CPU path keeps working as a safety net once that wiring lands.

## Replica bounds + behaviour

- `minReplicas: 2` — survives a single-pod failure (rolling restarts, node drains, OOM kills) without dropping below one healthy pod.
- `maxReplicas: 10` — conservative; operators with bigger ClickHouse clusters can lift it.
- Scale-up fast: 3 pods / 60s, 30s stabilisation window.
- Scale-down slow: 1 pod / 300s, 5m stabilisation window.

## Admission control pairing

When the in-flight admission caps (`CERBERUS_MAX_INFLIGHT_PROM` / `_LOKI` / `_TEMPO` / `_TAIL`) are set, a saturated pod returns `503 Retry-After` immediately, average CPU stays high across the remaining pods, and the HPA spawns the next replica. Admission caps protect ClickHouse while the HPA grows the pool — the two mechanisms are complementary, not redundant. Documented in both `docs/12factor.md` and `deploy/k3s/README.md`.

## Test plan

- [ ] `check` + `lint` green on this PR.
- [ ] (Informational) `dashboard` E2E job on the post-merge push to `main` brings the stack up via `just e2e-up`; the HPA should appear with `TARGETS  ?%/70%` and `MINPODS  2` once metrics-server reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)