### PR TITLE
feat(api): admission control / per-handler concurrency cap

### DIFF
--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -15,6 +15,7 @@ import (
 
 	"go.opentelemetry.io/otel"
 
+	"github.com/tsouza/cerberus/internal/api/admit"
 	"github.com/tsouza/cerberus/internal/api/health"
 	"github.com/tsouza/cerberus/internal/api/loki"
 	"github.com/tsouza/cerberus/internal/api/prom"
@@ -89,28 +90,12 @@ func run() error {
 		schemaReady.Store(true)
 	}
 
-	// The trace mux carries the three Prom/Loki/Tempo APIs and is
-	// wrapped with otelhttp so every request becomes a server span.
-	traceMux := http.NewServeMux()
-
-	promHandler := prom.New(client, cfg.Schema, logger.With("api", "prom"))
-	promHandler.Mount(traceMux)
-
-	lokiHandler := loki.New(client, cfg.Logs, logger.With("api", "loki"))
-	lokiHandler.Mount(traceMux)
-
-	tempoHandler := tempo.New(client, cfg.Traces, Version, logger.With("api", "tempo"))
-	tempoHandler.Mount(traceMux)
-
 	// Install the W3C+Baggage propagator and build OTel providers from
 	// the OTLP env config. When CERBERUS_OTLP_ENDPOINT is empty the
 	// telemetry package returns noop providers, so cerberus stays a
-	// zero-collector-dependency binary by default. Wrapping the API
-	// mux with otelhttp gives every Prom/Loki/Tempo request a server
-	// span named after the matched route. Wrapping at the mux level —
-	// instead of per-handler — keeps the propagator code path uniform
-	// across all three APIs and lets the span name formatter pull
-	// r.Pattern after the mux has resolved the route.
+	// zero-collector-dependency binary by default. The providers are
+	// installed BEFORE handler.Mount so the per-head admit limiters
+	// build their rejected-counter against the right meter provider.
 	providers, err := telemetry.New(ctx, telemetry.Config{
 		Endpoint:       cfg.OTLP.Endpoint,
 		Insecure:       cfg.OTLP.Insecure,
@@ -130,6 +115,46 @@ func run() error {
 			"insecure", cfg.OTLP.Insecure,
 		)
 	}
+
+	// Build per-head admission-control limiters. When
+	// CERBERUS_ADMIT_DISABLED=true every limiter is nil and the
+	// middleware short-circuits to a pass-through wrapper. Otherwise
+	// each cap comes from CERBERUS_ADMIT_{PROM,LOKI,TEMPO} (or the
+	// conservative defaults — see internal/config.admitFromEnv).
+	var promLimiter, lokiLimiter, tempoLimiter *admit.Limiter
+	if !cfg.Admit.Disabled {
+		promLimiter = admit.New("prom", cfg.Admit.MaxInflightProm)
+		lokiLimiter = admit.New("loki", cfg.Admit.MaxInflightLoki)
+		tempoLimiter = admit.New("tempo", cfg.Admit.MaxInflightTempo)
+		logger.Info("admission control enabled",
+			"prom", cfg.Admit.MaxInflightProm,
+			"loki", cfg.Admit.MaxInflightLoki,
+			"tempo", cfg.Admit.MaxInflightTempo,
+		)
+	} else {
+		logger.Info("admission control disabled (CERBERUS_ADMIT_DISABLED=true)")
+	}
+
+	// The trace mux carries the three Prom/Loki/Tempo APIs and is
+	// wrapped with otelhttp so every request becomes a server span.
+	// Wrapping at the mux level — instead of per-handler — keeps the
+	// propagator code path uniform across all three APIs and lets the
+	// span name formatter pull r.Pattern after the mux has resolved
+	// the route.
+	traceMux := http.NewServeMux()
+
+	promHandler := prom.New(client, cfg.Schema, logger.With("api", "prom"))
+	promHandler.Limiter = promLimiter
+	promHandler.Mount(traceMux)
+
+	lokiHandler := loki.New(client, cfg.Logs, logger.With("api", "loki"))
+	lokiHandler.Limiter = lokiLimiter
+	lokiHandler.Mount(traceMux)
+
+	tempoHandler := tempo.New(client, cfg.Traces, Version, logger.With("api", "tempo"))
+	tempoHandler.Limiter = tempoLimiter
+	tempoHandler.Mount(traceMux)
+
 	tracedAPI := wrapWithOTel(traceMux, "cerberus")
 
 	// /healthz and /readyz live on a separate sub-mux that bypasses

--- a/docs/12factor.md
+++ b/docs/12factor.md
@@ -75,6 +75,10 @@ The canonical list:
 | `CERBERUS_OTLP_INSECURE`      | `false`           | Dial OTLP endpoint without TLS.                                      |
 | `CERBERUS_OTLP_HEADERS`       | (empty)           | Comma-separated `key=value` gRPC metadata (e.g. auth tokens).        |
 | `CERBERUS_OTLP_TIMEOUT`       | `10s`             | Per-request OTLP roundtrip timeout.                                  |
+| `CERBERUS_ADMIT_DISABLED`     | `false`           | Disable per-handler concurrency caps (see Factor VIII).              |
+| `CERBERUS_ADMIT_PROM`         | `64`              | Max simultaneous in-flight Prom API requests.                        |
+| `CERBERUS_ADMIT_LOKI`         | `64`              | Max simultaneous in-flight Loki API requests.                        |
+| `CERBERUS_ADMIT_TEMPO`        | `32`              | Max simultaneous in-flight Tempo API requests.                       |
 
 Misconfigured values fail fast: an unparseable duration, an unknown
 log level, or a malformed OTLP header list aborts startup with a clear
@@ -179,6 +183,39 @@ A single cerberus process is itself concurrent: the standard
 `net/http` server multiplexes goroutines per request, and the
 ClickHouse driver pool serves them from a shared connection set.
 There is no `--workers` flag because there is no need for one.
+
+### Per-handler concurrency caps (admission control)
+
+To keep a single replica from saturating ClickHouse during traffic
+spikes, cerberus enforces a per-handler concurrency cap via a counted
+semaphore in `internal/api/admit`. Each API head (Prom / Loki /
+Tempo) gets its own limiter; requests above the cap are rejected
+immediately with HTTP `503 Service Unavailable` and a
+`Retry-After: 1` header so well-behaved clients back off rather than
+piling onto an already-overloaded ClickHouse.
+
+| Variable                   | Default | Meaning                                                                                  |
+| -------------------------- | ------- | ---------------------------------------------------------------------------------------- |
+| `CERBERUS_ADMIT_DISABLED`  | `false` | When `true`, removes admission control entirely. Useful for local dev / load tests.      |
+| `CERBERUS_ADMIT_PROM`      | `64`    | Maximum simultaneous in-flight Prom API requests. `0` disables this head specifically.   |
+| `CERBERUS_ADMIT_LOKI`      | `64`    | Maximum simultaneous in-flight Loki API requests. `0` disables this head specifically.   |
+| `CERBERUS_ADMIT_TEMPO`     | `32`    | Maximum simultaneous in-flight Tempo API requests. Lower than Prom/Loki because trace queries are typically heavier. |
+
+Rejections are emitted on the `cerberus.admit.rejected_total` OTel
+counter (labelled by `cerberus.admit.head`) so dashboards can alert
+on a steady-state non-zero rejection rate — the signal that an
+operator should either lift the cap (if CH has headroom) or scale
+the cerberus replica count out (if it doesn't). Admitted requests
+continue to be counted on `cerberus.queries.total`; the two
+counters are deliberately disjoint so a "total inbound" view sums
+both.
+
+The defaults are deliberately conservative — easy to lift via env,
+hard to accidentally deny-of-service legitimate traffic out of the
+box. A four-replica deployment at default caps gives 256 concurrent
+Prom queries and 128 concurrent Tempo queries before any client
+sees a 503; that is more than enough for most Grafana dashboards
+while still capping the worst-case fan-out into ClickHouse.
 
 ### Kubernetes HorizontalPodAutoscaler
 

--- a/docs/12factor.md
+++ b/docs/12factor.md
@@ -194,11 +194,11 @@ immediately with HTTP `503 Service Unavailable` and a
 `Retry-After: 1` header so well-behaved clients back off rather than
 piling onto an already-overloaded ClickHouse.
 
-| Variable                   | Default | Meaning                                                                                  |
-| -------------------------- | ------- | ---------------------------------------------------------------------------------------- |
-| `CERBERUS_ADMIT_DISABLED`  | `false` | When `true`, removes admission control entirely. Useful for local dev / load tests.      |
-| `CERBERUS_ADMIT_PROM`      | `64`    | Maximum simultaneous in-flight Prom API requests. `0` disables this head specifically.   |
-| `CERBERUS_ADMIT_LOKI`      | `64`    | Maximum simultaneous in-flight Loki API requests. `0` disables this head specifically.   |
+| Variable                   | Default | Meaning                                                                                                              |
+| -------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------- |
+| `CERBERUS_ADMIT_DISABLED`  | `false` | When `true`, removes admission control entirely. Useful for local dev / load tests.                                  |
+| `CERBERUS_ADMIT_PROM`      | `64`    | Maximum simultaneous in-flight Prom API requests. `0` disables this head specifically.                               |
+| `CERBERUS_ADMIT_LOKI`      | `64`    | Maximum simultaneous in-flight Loki API requests. `0` disables this head specifically.                               |
 | `CERBERUS_ADMIT_TEMPO`     | `32`    | Maximum simultaneous in-flight Tempo API requests. Lower than Prom/Loki because trace queries are typically heavier. |
 
 Rejections are emitted on the `cerberus.admit.rejected_total` OTel

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
+	golang.org/x/sync v0.20.0
 	golang.org/x/tools v0.45.0
 )
 
@@ -202,7 +203,6 @@ require (
 	golang.org/x/mod v0.36.0 // indirect
 	golang.org/x/net v0.54.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.44.0 // indirect
 	golang.org/x/term v0.43.0 // indirect
 	golang.org/x/text v0.37.0 // indirect

--- a/internal/api/admit/admit.go
+++ b/internal/api/admit/admit.go
@@ -1,0 +1,166 @@
+// Package admit provides per-handler concurrency caps for cerberus's
+// HTTP listener. Each cerberus replica accepts unlimited inbound
+// requests by default; under sustained load that fans out into
+// hundreds of slow ClickHouse queries running in parallel, which
+// exhausts CH's thread pool and drags every concurrent request's
+// latency down with the saturated ones.
+//
+// A Limiter caps the number of in-flight handler invocations for a
+// given API head (Prom / Loki / Tempo). When a new request arrives at
+// the cap, the limiter rejects it immediately with HTTP 503 and a
+// `Retry-After: 1` header so well-behaved clients back off and retry
+// — fail-fast on the slow few rather than degrading service for
+// everyone.
+//
+// The limiter is opt-out (`CERBERUS_ADMIT_DISABLED=true`) for local /
+// dev workflows where artificial caps get in the way; in production
+// it should always be on.
+package admit
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"golang.org/x/sync/semaphore"
+)
+
+// meterName is the instrumentation-scope identifier stamped on the
+// admit.rejected_total counter. Distinct from internal/telemetry's
+// scope so dashboards can pivot on the admit-specific scope when
+// drilling into rejection events.
+const meterName = "github.com/tsouza/cerberus/internal/api/admit"
+
+// attrHead labels the rejection counter with the API head whose
+// limiter rejected the request — "prom" / "loki" / "tempo". The
+// values match the head identifiers used elsewhere in cerberus so
+// dashboards can join admit rejections against query totals.
+const attrHead = attribute.Key("cerberus.admit.head")
+
+// Limiter caps concurrent in-flight requests for one API head. The
+// zero value is unusable; build via New. A nil *Limiter is a sentinel
+// meaning "admission control disabled" — every call to Acquire
+// succeeds with a no-op release closure, and the HTTP wrapper passes
+// every request through without bookkeeping.
+//
+// Acquire takes a non-blocking weighted-semaphore slot. When the
+// semaphore is full the function returns false; the caller then maps
+// that into a 503 response. The semaphore choice (over a buffered
+// channel) keeps the door open for future weighted admission — heavy
+// `query_range` queries could cost more than label-list calls — but
+// every callsite today uses weight 1.
+type Limiter struct {
+	head     string
+	sem      *semaphore.Weighted
+	rejected metric.Int64Counter
+}
+
+// New constructs a Limiter for head with the given cap. head is the
+// API identifier ("prom" / "loki" / "tempo") used to label the
+// rejection counter; cap is the maximum number of concurrent
+// in-flight requests. A cap of 0 or less returns nil — the caller
+// treats that as "admission control disabled for this head", which
+// makes config wiring symmetric across the enabled / disabled cases.
+//
+// The rejection counter is built off the OTel global MeterProvider at
+// the moment of construction; install the cerberus telemetry provider
+// (via cmd/cerberus/main.go) before building limiters so the counter
+// flows to the configured OTLP exporter.
+func New(head string, cap int) *Limiter {
+	return newWithProvider(head, cap, otel.GetMeterProvider())
+}
+
+// newWithProvider is the test seam New() funnels through. Lets unit
+// tests construct a Limiter whose rejected counter targets a manual
+// reader without racing with parallel tests that use the global
+// provider.
+func newWithProvider(head string, cap int, mp metric.MeterProvider) *Limiter {
+	if cap <= 0 {
+		return nil
+	}
+	meter := mp.Meter(meterName)
+	rejected, err := meter.Int64Counter(
+		"cerberus.admit.rejected_total",
+		metric.WithDescription("Requests rejected by the per-handler concurrency cap."),
+		metric.WithUnit("{request}"),
+	)
+	if err != nil {
+		// Instrument validation only fails on a misconfigured
+		// MeterProvider; surface loudly rather than silently dropping
+		// the counter.
+		panic("admit: build rejected counter: " + err.Error())
+	}
+	return &Limiter{
+		head:     head,
+		sem:      semaphore.NewWeighted(int64(cap)),
+		rejected: rejected,
+	}
+}
+
+// Acquire tries to take a slot without blocking. Returns a release
+// closure (always non-nil) and a boolean — true when the slot was
+// acquired, false when the limiter is saturated. The release closure
+// is idempotent and safe to call even after a rejection (it's a
+// no-op then). A nil receiver returns (no-op, true) so the disabled
+// path is allocation-free.
+func (l *Limiter) Acquire(ctx context.Context) (release func(), ok bool) {
+	if l == nil {
+		return func() {}, true
+	}
+	if !l.sem.TryAcquire(1) {
+		l.rejected.Add(ctx, 1, metric.WithAttributes(attrHead.String(l.head)))
+		return func() {}, false
+	}
+	released := false
+	return func() {
+		if released {
+			return
+		}
+		released = true
+		l.sem.Release(1)
+	}, true
+}
+
+// Middleware wraps next so every request first tries to acquire a
+// slot from l. On rejection the wrapper writes a 503 with
+// `Retry-After: 1` and drops the request without invoking next. On
+// success the wrapper invokes next inside an Acquire/release pair so
+// the slot is returned even if next panics (defer ordering with the
+// release closure).
+//
+// A nil *Limiter falls through to next directly — handy for the
+// `CERBERUS_ADMIT_DISABLED=true` case where main.go passes nil into
+// every register call. retryAfterSeconds is the value cerberus
+// stamps into the `Retry-After` header; pass 0 to suppress the
+// header entirely.
+func (l *Limiter) Middleware(retryAfterSeconds int, next http.Handler) http.Handler {
+	if l == nil {
+		return next
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		release, ok := l.Acquire(r.Context())
+		if !ok {
+			if retryAfterSeconds > 0 {
+				w.Header().Set("Retry-After", strconv.Itoa(retryAfterSeconds))
+			}
+			http.Error(w, "admission control: server saturated", http.StatusServiceUnavailable)
+			return
+		}
+		defer release()
+		next.ServeHTTP(w, r)
+	})
+}
+
+// Head returns the API-head identifier this Limiter labels its
+// rejection counter with. Useful for log lines that need to identify
+// the limiter on rejection.
+func (l *Limiter) Head() string {
+	if l == nil {
+		return ""
+	}
+	return l.head
+}

--- a/internal/api/admit/admit_test.go
+++ b/internal/api/admit/admit_test.go
@@ -1,0 +1,286 @@
+package admit_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/tsouza/cerberus/internal/api/admit"
+)
+
+func TestAcquireBelowCap(t *testing.T) {
+	t.Parallel()
+	l := admit.New("prom", 3)
+	rel1, ok := l.Acquire(t.Context())
+	if !ok {
+		t.Fatalf("acquire 1: want ok, got reject")
+	}
+	rel2, ok := l.Acquire(t.Context())
+	if !ok {
+		t.Fatalf("acquire 2: want ok, got reject")
+	}
+	rel1()
+	rel2()
+}
+
+func TestAcquireAtCapRejects(t *testing.T) {
+	t.Parallel()
+	l := admit.New("prom", 1)
+	rel, ok := l.Acquire(t.Context())
+	if !ok {
+		t.Fatalf("acquire 1: want ok, got reject")
+	}
+	defer rel()
+	if _, ok := l.Acquire(t.Context()); ok {
+		t.Fatalf("acquire 2: want reject, got ok")
+	}
+}
+
+func TestReleaseAllowsNext(t *testing.T) {
+	t.Parallel()
+	l := admit.New("prom", 1)
+	rel, ok := l.Acquire(t.Context())
+	if !ok {
+		t.Fatalf("acquire 1: want ok")
+	}
+	rel()
+	rel2, ok := l.Acquire(t.Context())
+	if !ok {
+		t.Fatalf("acquire after release: want ok, got reject")
+	}
+	rel2()
+}
+
+func TestReleaseIdempotent(t *testing.T) {
+	t.Parallel()
+	l := admit.New("prom", 1)
+	rel, ok := l.Acquire(t.Context())
+	if !ok {
+		t.Fatalf("acquire: want ok")
+	}
+	rel()
+	rel() // second call must not panic, must not double-release
+	rel2, ok := l.Acquire(t.Context())
+	if !ok {
+		t.Fatalf("re-acquire: want ok")
+	}
+	// If double-release wrongly returned a second token, cap=1 would
+	// still allow another acquire here. Verify the slot is taken.
+	if _, ok := l.Acquire(t.Context()); ok {
+		t.Fatalf("re-acquire 2: want reject, got ok — double-release corrupted the semaphore")
+	}
+	rel2()
+}
+
+func TestNilLimiterAlwaysAdmits(t *testing.T) {
+	t.Parallel()
+	var l *admit.Limiter
+	for range 100 {
+		rel, ok := l.Acquire(t.Context())
+		if !ok {
+			t.Fatalf("nil limiter must always admit")
+		}
+		rel()
+	}
+}
+
+func TestNewZeroCapReturnsNil(t *testing.T) {
+	t.Parallel()
+	if l := admit.New("prom", 0); l != nil {
+		t.Fatalf("cap=0: want nil limiter, got %v", l)
+	}
+	if l := admit.New("prom", -1); l != nil {
+		t.Fatalf("cap=-1: want nil limiter, got %v", l)
+	}
+}
+
+func TestMiddlewareBelowCap(t *testing.T) {
+	t.Parallel()
+	l := admit.New("prom", 2)
+	var hits atomic.Int32
+	h := l.Middleware(1, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	for range 5 {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("want 200, got %d", rec.Code)
+		}
+	}
+	if hits.Load() != 5 {
+		t.Fatalf("want 5 handler hits, got %d", hits.Load())
+	}
+}
+
+func TestMiddlewareRejectsAtCap(t *testing.T) {
+	t.Parallel()
+	l := admit.New("prom", 1)
+	// Hold the slot so the next request through the middleware hits
+	// the cap.
+	rel, ok := l.Acquire(t.Context())
+	if !ok {
+		t.Fatalf("setup acquire: want ok")
+	}
+	defer rel()
+
+	h := l.Middleware(1, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Fatalf("handler must not run when limiter is full")
+	}))
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("want 503, got %d", rec.Code)
+	}
+	if got := rec.Header().Get("Retry-After"); got != "1" {
+		t.Fatalf("Retry-After: want \"1\", got %q", got)
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "admission control") {
+		t.Fatalf("body should mention admission control, got %q", body)
+	}
+}
+
+func TestMiddlewareNilLimiterPassesThrough(t *testing.T) {
+	t.Parallel()
+	var l *admit.Limiter
+	var hits atomic.Int32
+	h := l.Middleware(1, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	for range 10 {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("want 200, got %d", rec.Code)
+		}
+	}
+	if hits.Load() != 10 {
+		t.Fatalf("want 10 hits, got %d", hits.Load())
+	}
+}
+
+func TestMiddlewareNoRetryAfterWhenZero(t *testing.T) {
+	t.Parallel()
+	l := admit.New("prom", 1)
+	rel, _ := l.Acquire(t.Context())
+	defer rel()
+
+	h := l.Middleware(0, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("want 503, got %d", rec.Code)
+	}
+	if got := rec.Header().Get("Retry-After"); got != "" {
+		t.Fatalf("Retry-After: want empty (suppressed), got %q", got)
+	}
+}
+
+func TestConcurrentAcquireRespectsCap(t *testing.T) {
+	t.Parallel()
+	const cap, workers = 4, 64
+	l := admit.New("prom", cap)
+
+	var (
+		inflight    atomic.Int32
+		maxInflight atomic.Int32
+		admitted    atomic.Int32
+		rejected    atomic.Int32
+		wg          sync.WaitGroup
+		start       = make(chan struct{})
+	)
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			<-start
+			rel, ok := l.Acquire(t.Context())
+			if !ok {
+				rejected.Add(1)
+				return
+			}
+			admitted.Add(1)
+			cur := inflight.Add(1)
+			for {
+				maxObserved := maxInflight.Load()
+				if cur <= maxObserved || maxInflight.CompareAndSwap(maxObserved, cur) {
+					break
+				}
+			}
+			inflight.Add(-1)
+			rel()
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if got := maxInflight.Load(); got > int32(cap) {
+		t.Fatalf("max concurrent in-flight %d exceeded cap %d", got, cap)
+	}
+	if admitted.Load()+rejected.Load() != workers {
+		t.Fatalf("accounting mismatch: admitted=%d rejected=%d workers=%d",
+			admitted.Load(), rejected.Load(), workers)
+	}
+}
+
+func TestRejectedCounter(t *testing.T) {
+	t.Parallel()
+	// Use the test-only NewWithProvider so this limiter's rejection
+	// counter targets *our* manual reader exclusively. Routing through
+	// the OTel global would cross-count with the limiters built by
+	// parallel tests, which all share that global.
+	reader := metric.NewManualReader()
+	mp := metric.NewMeterProvider(metric.WithReader(reader))
+
+	l := admit.NewWithProvider("prom", 1, mp)
+	rel, _ := l.Acquire(t.Context())
+	defer rel()
+
+	// Drive two rejections through Acquire.
+	if _, ok := l.Acquire(t.Context()); ok {
+		t.Fatalf("acquire 2: want reject")
+	}
+	if _, ok := l.Acquire(t.Context()); ok {
+		t.Fatalf("acquire 3: want reject")
+	}
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(t.Context(), &rm); err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	var found bool
+	var sum int64
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "cerberus.admit.rejected_total" {
+				continue
+			}
+			found = true
+			sumData, ok := m.Data.(metricdata.Sum[int64])
+			if !ok {
+				t.Fatalf("rejected_total data: want Sum[int64], got %T", m.Data)
+			}
+			for _, dp := range sumData.DataPoints {
+				sum += dp.Value
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("cerberus.admit.rejected_total not exported")
+	}
+	if sum != 2 {
+		t.Fatalf("rejected_total: want 2, got %d", sum)
+	}
+}

--- a/internal/api/admit/export_test.go
+++ b/internal/api/admit/export_test.go
@@ -1,0 +1,10 @@
+package admit
+
+import "go.opentelemetry.io/otel/metric"
+
+// NewWithProvider exposes the unexported constructor for tests that
+// need to point the rejection counter at a manual reader without
+// touching the OTel global (which other parallel tests share).
+func NewWithProvider(head string, cap int, mp metric.MeterProvider) *Limiter {
+	return newWithProvider(head, cap, mp)
+}

--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/tsouza/cerberus/internal/api/admit"
 	"github.com/tsouza/cerberus/internal/cerbtrace"
 	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/chplan"
@@ -67,6 +68,10 @@ type Handler struct {
 	Schema    schema.Logs
 	Optimizer *optimizer.Driver
 	Logger    *slog.Logger
+
+	// Limiter caps in-flight Loki API requests. nil disables the
+	// admission middleware. Wired from CERBERUS_ADMIT_LOKI.
+	Limiter *admit.Limiter
 }
 
 // New constructs a Handler with the seed optimizer wired in.
@@ -95,7 +100,11 @@ func (h *Handler) Mount(mux *http.ServeMux) {
 	// volume bookkeeping; its duration will skew toward the long tail
 	// of the histogram, which is what dashboards want to see anyway.
 	register := func(pattern string, hf http.HandlerFunc) {
-		mux.Handle(pattern, telemetry.QueryMiddleware("logql", hf))
+		// admit.Middleware (outer) → telemetry.QueryMiddleware (inner)
+		// — rejections are accounted on cerberus.admit.rejected_total,
+		// not on cerberus.queries.*. See prom.Handler.Mount for the
+		// full layering note.
+		mux.Handle(pattern, h.Limiter.Middleware(1, telemetry.QueryMiddleware("logql", hf)))
 	}
 	register("GET /loki/api/v1/query", h.handleQuery)
 	register("POST /loki/api/v1/query", h.handleQuery)

--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/tsouza/cerberus/internal/api/admit"
 	"github.com/tsouza/cerberus/internal/cerbtrace"
 	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/chplan"
@@ -47,6 +48,12 @@ type Handler struct {
 	Optimizer *optimizer.Driver
 	Logger    *slog.Logger
 
+	// Limiter caps in-flight Prom API requests. nil disables the
+	// admission middleware (every request flows through). main wires
+	// this from CERBERUS_ADMIT_PROM; tests leave it nil for
+	// unconstrained behaviour.
+	Limiter *admit.Limiter
+
 	parser promparser.Parser
 }
 
@@ -69,11 +76,21 @@ func New(client Querier, s schema.Metrics, logger *slog.Logger) *Handler {
 // `X-Prometheus-API-Version` and `X-Cerberus-CH-Millis`.
 func (h *Handler) Mount(mux *http.ServeMux) {
 	register := func(pattern string, hf http.HandlerFunc) {
-		// RC4 R4.4: wrap each route with the cerberus.queries.* counter
-		// + duration histogram middleware. Layered inside
-		// promHeadersMiddleware so the CH-millis counter (which lives on
-		// r.Context()) is still in scope when the inner handler runs.
-		mux.Handle(pattern, promHeadersMiddleware(telemetry.QueryMiddleware("promql", hf)))
+		// Layering, outermost → innermost:
+		//   admit.Middleware       — reject early when at the cap so
+		//                            the slot is freed before any
+		//                            request-shaped work runs.
+		//   promHeadersMiddleware  — sets Prom response headers + the
+		//                            CH-millis counter on r.Context().
+		//   telemetry.QueryMiddleware — counts every admitted request
+		//                            on cerberus.queries.* with the
+		//                            matched route label.
+		//   hf                     — the actual handler.
+		// Rejections are not counted by QueryMiddleware (the inner
+		// handler never runs); they show up on
+		// cerberus.admit.rejected_total instead.
+		handler := promHeadersMiddleware(telemetry.QueryMiddleware("promql", hf))
+		mux.Handle(pattern, h.Limiter.Middleware(1, handler))
 	}
 	register("GET /api/v1/query", h.handleQuery)
 	register("GET /api/v1/query_range", h.handleQueryRange)

--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -15,6 +15,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/tsouza/cerberus/internal/api/admit"
 	"github.com/tsouza/cerberus/internal/cerbtrace"
 	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/chplan"
@@ -66,6 +67,10 @@ type Handler struct {
 	Optimizer *optimizer.Driver
 	Logger    *slog.Logger
 	Version   string
+
+	// Limiter caps in-flight Tempo API requests. nil disables the
+	// admission middleware. Wired from CERBERUS_ADMIT_TEMPO.
+	Limiter *admit.Limiter
 }
 
 // New constructs a Handler with the seed optimizer wired in.
@@ -92,7 +97,10 @@ func (h *Handler) Mount(mux *http.ServeMux) {
 	// are health-checks and will dominate ResultOK volume — that's fine,
 	// dashboards can split them out via cerberus.route if needed.
 	register := func(pattern string, hf http.HandlerFunc) {
-		mux.Handle(pattern, telemetry.QueryMiddleware("traceql", hf))
+		// admit.Middleware (outer) → telemetry.QueryMiddleware (inner)
+		// — same layering as the Prom + Loki heads. Rejections land
+		// on cerberus.admit.rejected_total, not cerberus.queries.*.
+		mux.Handle(pattern, h.Limiter.Middleware(1, telemetry.QueryMiddleware("traceql", hf)))
 	}
 	register("GET /api/echo", h.handleEcho)
 	register("GET /api/status/version", h.handleVersion)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,6 +51,37 @@ type Config struct {
 	// OTel Go SDK reads them by default and they merge with whatever
 	// these cerberus-specific values resolve to.
 	OTLP OTLPConfig
+
+	// Admit configures per-handler concurrency caps. When Admit.Disabled
+	// is true cerberus skips the admission middleware entirely and every
+	// request is admitted. When false, each API head (Prom / Loki /
+	// Tempo) gets its own counted semaphore — requests above the cap
+	// are rejected with HTTP 503 + Retry-After: 1 so well-behaved
+	// clients back off and CH stays out of overload.
+	Admit AdmitConfig
+}
+
+// AdmitConfig holds the per-handler concurrency cap knobs.
+//
+// Defaults are deliberately conservative — easy to lift via env, hard
+// to accidentally deny-of-service legitimate traffic with the
+// out-of-the-box values. Tempo's default is half of Prom/Loki because
+// trace queries are typically the heaviest per-call (full trace span
+// fetches + tag-value scans across wide column sets).
+type AdmitConfig struct {
+	// Disabled, when true, removes admission control entirely. Handy
+	// for local development where artificial caps mask real
+	// concurrency bugs. Default false (admission control enabled).
+	Disabled bool
+
+	// MaxInflightProm caps simultaneous in-flight Prom API requests.
+	MaxInflightProm int
+
+	// MaxInflightLoki caps simultaneous in-flight Loki API requests.
+	MaxInflightLoki int
+
+	// MaxInflightTempo caps simultaneous in-flight Tempo API requests.
+	MaxInflightTempo int
 }
 
 // LogConfig controls the slog setup applied at startup.
@@ -102,6 +133,10 @@ type OTLPConfig struct {
 //	CERBERUS_OTLP_INSECURE         default "false"
 //	CERBERUS_OTLP_HEADERS          default ""   ("k=v,k2=v2" comma-separated)
 //	CERBERUS_OTLP_TIMEOUT          default "10s"
+//	CERBERUS_ADMIT_DISABLED        default "false"
+//	CERBERUS_ADMIT_PROM            default 64
+//	CERBERUS_ADMIT_LOKI            default 64
+//	CERBERUS_ADMIT_TEMPO           default 32
 //
 // Standard OTEL_EXPORTER_OTLP_* env vars are also honored by the OTel
 // Go SDK and complement these — see docs/observability.md.
@@ -132,6 +167,10 @@ func FromEnv() (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+	admit, err := admitFromEnv()
+	if err != nil {
+		return Config{}, err
+	}
 	return Config{
 		HTTPAddr: envDefault("CERBERUS_HTTP_ADDR", ":8080"),
 		ClickHouse: chclient.Config{
@@ -147,6 +186,56 @@ func FromEnv() (Config, error) {
 		AutoCreateSchema: autoCreate,
 		Log:              logCfg,
 		OTLP:             otlp,
+		Admit:            admit,
+	}, nil
+}
+
+// Default per-handler concurrency caps. Tempo gets a smaller cap
+// because trace queries (search + tag-value scans + per-trace span
+// fetches) are heavier than Prom/Loki metric queries.
+const (
+	defaultAdmitProm  = 64
+	defaultAdmitLoki  = 64
+	defaultAdmitTempo = 32
+)
+
+// admitFromEnv reads CERBERUS_ADMIT_* env vars into an AdmitConfig.
+// Unset values use the conservative defaults above. Setting any cap
+// to 0 disables admission control for that head specifically (a
+// finer-grained alternative to CERBERUS_ADMIT_DISABLED, which kills
+// every head). Negative caps are rejected — they almost certainly
+// mean a typo.
+func admitFromEnv() (AdmitConfig, error) {
+	disabled, err := envBool("CERBERUS_ADMIT_DISABLED", false)
+	if err != nil {
+		return AdmitConfig{}, fmt.Errorf("CERBERUS_ADMIT_DISABLED: %w", err)
+	}
+	prom, err := envInt("CERBERUS_ADMIT_PROM", defaultAdmitProm)
+	if err != nil {
+		return AdmitConfig{}, fmt.Errorf("CERBERUS_ADMIT_PROM: %w", err)
+	}
+	loki, err := envInt("CERBERUS_ADMIT_LOKI", defaultAdmitLoki)
+	if err != nil {
+		return AdmitConfig{}, fmt.Errorf("CERBERUS_ADMIT_LOKI: %w", err)
+	}
+	tempo, err := envInt("CERBERUS_ADMIT_TEMPO", defaultAdmitTempo)
+	if err != nil {
+		return AdmitConfig{}, fmt.Errorf("CERBERUS_ADMIT_TEMPO: %w", err)
+	}
+	for name, v := range map[string]int{
+		"CERBERUS_ADMIT_PROM":  prom,
+		"CERBERUS_ADMIT_LOKI":  loki,
+		"CERBERUS_ADMIT_TEMPO": tempo,
+	} {
+		if v < 0 {
+			return AdmitConfig{}, fmt.Errorf("%s: must be >= 0, got %d", name, v)
+		}
+	}
+	return AdmitConfig{
+		Disabled:         disabled,
+		MaxInflightProm:  prom,
+		MaxInflightLoki:  loki,
+		MaxInflightTempo: tempo,
 	}, nil
 }
 
@@ -225,6 +314,21 @@ func envDefault(key, def string) string {
 		return v
 	}
 	return def
+}
+
+// envInt parses an integer env var. An unset or empty value returns
+// def. Anything that fails strconv.Atoi is rejected with an error so
+// misconfiguration fails fast at startup.
+func envInt(key string, def int) (int, error) {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return def, nil
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return 0, fmt.Errorf("invalid integer %q: %w", v, err)
+	}
+	return n, nil
 }
 
 // envBool parses a boolean env var. Accepts the standard strconv.ParseBool

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -214,3 +214,70 @@ func TestFromEnv_SchemaOverrides(t *testing.T) {
 		t.Errorf("Schema.GaugeTable should be unchanged: got %q", cfg.Schema.GaugeTable)
 	}
 }
+
+// TestFromEnv_Admit_Defaults verifies the conservative defaults for
+// the per-handler concurrency caps when no env vars are set.
+func TestFromEnv_Admit_Defaults(t *testing.T) {
+	t.Setenv("CERBERUS_ADMIT_DISABLED", "")
+	t.Setenv("CERBERUS_ADMIT_PROM", "")
+	t.Setenv("CERBERUS_ADMIT_LOKI", "")
+	t.Setenv("CERBERUS_ADMIT_TEMPO", "")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if cfg.Admit.Disabled {
+		t.Errorf("Admit.Disabled = true; want false")
+	}
+	if cfg.Admit.MaxInflightProm != defaultAdmitProm {
+		t.Errorf("MaxInflightProm = %d; want %d", cfg.Admit.MaxInflightProm, defaultAdmitProm)
+	}
+	if cfg.Admit.MaxInflightLoki != defaultAdmitLoki {
+		t.Errorf("MaxInflightLoki = %d; want %d", cfg.Admit.MaxInflightLoki, defaultAdmitLoki)
+	}
+	if cfg.Admit.MaxInflightTempo != defaultAdmitTempo {
+		t.Errorf("MaxInflightTempo = %d; want %d", cfg.Admit.MaxInflightTempo, defaultAdmitTempo)
+	}
+}
+
+// TestFromEnv_Admit_Overrides confirms env-var overrides flow through.
+func TestFromEnv_Admit_Overrides(t *testing.T) {
+	t.Setenv("CERBERUS_ADMIT_DISABLED", "true")
+	t.Setenv("CERBERUS_ADMIT_PROM", "128")
+	t.Setenv("CERBERUS_ADMIT_LOKI", "16")
+	t.Setenv("CERBERUS_ADMIT_TEMPO", "8")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if !cfg.Admit.Disabled {
+		t.Errorf("Admit.Disabled = false; want true")
+	}
+	if cfg.Admit.MaxInflightProm != 128 {
+		t.Errorf("MaxInflightProm = %d; want 128", cfg.Admit.MaxInflightProm)
+	}
+	if cfg.Admit.MaxInflightLoki != 16 {
+		t.Errorf("MaxInflightLoki = %d; want 16", cfg.Admit.MaxInflightLoki)
+	}
+	if cfg.Admit.MaxInflightTempo != 8 {
+		t.Errorf("MaxInflightTempo = %d; want 8", cfg.Admit.MaxInflightTempo)
+	}
+}
+
+// TestFromEnv_Admit_RejectsNegative ensures a negative cap fails fast
+// at startup rather than silently disabling admission control.
+func TestFromEnv_Admit_RejectsNegative(t *testing.T) {
+	t.Setenv("CERBERUS_ADMIT_PROM", "-1")
+	if _, err := FromEnv(); err == nil {
+		t.Fatalf("FromEnv with CERBERUS_ADMIT_PROM=-1: want error, got nil")
+	}
+}
+
+// TestFromEnv_Admit_RejectsGarbage ensures a non-integer value also
+// fails fast.
+func TestFromEnv_Admit_RejectsGarbage(t *testing.T) {
+	t.Setenv("CERBERUS_ADMIT_PROM", "not-a-number")
+	if _, err := FromEnv(); err == nil {
+		t.Fatalf("FromEnv with CERBERUS_ADMIT_PROM=not-a-number: want error, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

Per-handler concurrency caps so a single cerberus replica can't drag
ClickHouse into overload during traffic spikes. Each API head (Prom /
Loki / Tempo) gets its own counted semaphore in `internal/api/admit`;
requests above the cap are rejected immediately with HTTP `503` +
`Retry-After: 1` instead of queuing up and dragging every concurrent
request's latency down.

- `internal/api/admit` — new package: `Limiter` (counted semaphore via
  `golang.org/x/sync/semaphore`), `Middleware` (HTTP wrapper), OTel
  `cerberus.admit.rejected_total` counter labelled by
  `cerberus.admit.head`.
- Env knobs in `internal/config`: `CERBERUS_ADMIT_DISABLED`,
  `CERBERUS_ADMIT_PROM` (default 64), `CERBERUS_ADMIT_LOKI` (default
  64), `CERBERUS_ADMIT_TEMPO` (default 32). Tempo is half because trace
  queries are typically heavier (full span fetches + tag-value scans).
- Wired into each handler via a new `Limiter` field; main.go builds the
  limiters after OTel provider installation so the counter targets the
  configured MeterProvider.
- `docs/12factor.md` Factor VIII section extended with the new env
  vars + the rationale for fail-fast on saturation.

## Default cap rationale

Conservative-by-default: a 4-replica deployment at defaults still
serves 256 concurrent Prom queries and 128 concurrent Tempo queries
before any client sees a 503. Easy to lift via env when CH has
headroom; hard to accidentally deny-of-service legitimate traffic
out of the box.

## Test plan

- [x] `go test -race ./internal/api/admit/... ./internal/api/...
      ./internal/config/... ./cmd/cerberus/...` — green.
- [x] Below-cap admit, at-cap reject, release-then-admit, idempotent
      release, nil-limiter passthrough, zero/negative cap returns nil.
- [x] Concurrent goroutine stress test (64 workers, cap=4) verifies
      max in-flight never exceeds the cap under the race detector.
- [x] OTel counter assertion: two forced rejections produce
      `rejected_total = 2` on a manual reader.
- [x] HTTP middleware test: 503 + `Retry-After: 1` response shape on
      saturation; pass-through behaviour for nil `*Limiter`.
- [x] `config.FromEnv` parses defaults + overrides; rejects negative
      caps and non-integer values.

## Notes

- The rejection counter is intentionally disjoint from
  `cerberus.queries.total` — rejected requests never run the handler
  pipeline, so they don't show up in the queries counter. A "total
  inbound" view sums both.
- Setting any single cap to 0 disables admission control for that head
  specifically (finer-grained than the global `_DISABLED` switch).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with Claude Code