### PR TITLE
feat(chsql): typed RangeWindowFilter + CounterDelta + IfNonZero (RC6 R6.13)

### DIFF
--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -759,8 +759,8 @@ func If(cond, thenF, elseF Frag) Frag {
 // Lambda1 returns a Frag rendering "<param> -> <body>" — a CH
 // single-parameter lambda (no parens around the parameter, matching
 // CH's conventional shape for `arrayMap(x -> ..., arr)`). For multi-
-// parameter lambdas use Builder.Lambda directly (it wraps params in
-// parens).
+// parameter lambdas use Lambda2 (or Builder.Lambda for the general
+// N-arity case — it wraps params in parens).
 //
 // param is emitted via BareIdent's trust contract: must be a CH-safe
 // bare identifier (`[a-zA-Z_][a-zA-Z0-9_]*`); the caller is responsible.
@@ -770,6 +770,114 @@ func Lambda1(param string, body Frag) Frag {
 		b.sb.WriteString(" -> ")
 		body(b)
 	}
+}
+
+// Lambda2 returns a Frag rendering "(<p1>, <p2>) -> <body>" — a CH
+// two-parameter lambda, the shape `arrayMap` / `arrayFilter` /
+// `arrayFold` use for paired-array operations like
+// `arrayMap((p, c) -> if(c < p, c, c - p), prev, curr)`. Both
+// parameter names follow BareIdent's trust contract.
+func Lambda2(p1, p2 string, body Frag) Frag {
+	return func(b *Builder) {
+		b.sb.WriteByte('(')
+		b.sb.WriteString(p1)
+		b.sb.WriteString(", ")
+		b.sb.WriteString(p2)
+		b.sb.WriteString(") -> ")
+		body(b)
+	}
+}
+
+// RangeWindowFilter renders
+//
+//	arrayFilter(p -> tupleElement(p, 1) >= <start>
+//	              AND tupleElement(p, 1) <= <end>,
+//	            <series>)
+//
+// — the per-series clamp to the [start, end] window used by every
+// range-window emitter. series is a CH array of (Timestamp, Value)
+// tuples (typically the `series_array` alias projected by the
+// innermost groupArray + arraySort layer). The lambda parameter `p`
+// binds each tuple; `tupleElement(p, 1)` extracts the timestamp.
+//
+// Composed entirely from typed primitives — no raw SQL writes — so
+// the audit grep for clause-keyword cosplay stays clean. The
+// start / end / series Frags emit their own `?` placeholders if
+// present; bound args land in start → end → series order.
+func RangeWindowFilter(start, end, series Frag) Frag {
+	tsElem := Call("tupleElement", BareIdent("p"), InlineLit(int64(1)))
+	body := And(Gte(tsElem, start), Lte(tsElem, end))
+	return Call("arrayFilter", Lambda1("p", body), series)
+}
+
+// CounterDelta renders
+//
+//	arrayMap((p, c) -> if(c < p, c, c - p),
+//	         arrayPopBack(arrayMap(x -> tupleElement(x, 2), <seriesArr>)),
+//	         arrayPopFront(arrayMap(x -> tupleElement(x, 2), <seriesArr>)))
+//
+// — the counter-reset-aware pair-wise delta over the values of a CH
+// array of (Timestamp, Value) tuples. arrayPopBack drops the last
+// element to yield the `prev` sample list; arrayPopFront drops the
+// first to yield the `curr` sample list; the lambda pairs them and
+// emits `curr - prev` for monotonic moves or `curr` itself when a
+// counter reset (curr < prev) is detected.
+//
+// The result is an Array(Float64); callers typically wrap it in
+// `arraySum(...)` to reduce to the scalar delta over the window.
+// CounterDelta is intentionally not pre-wrapped so the typed surface
+// stays compositional (an emitter that wants the array form — e.g.
+// for cumulative-delta debugging — can drop the arraySum).
+//
+// seriesArr is rendered twice (once into each arrayPopBack /
+// arrayPopFront branch). For callers passing a Frag with `?`
+// bindings this would double-bind; in practice the emitter always
+// passes a bare alias reference (`BareIdent("window_pairs")`) which
+// has no args.
+func CounterDelta(seriesArr Frag) Frag {
+	valsArr := func() Frag {
+		return Call(
+			"arrayMap",
+			Lambda1("x", Call("tupleElement", BareIdent("x"), InlineLit(int64(2)))),
+			seriesArr,
+		)
+	}
+	lambdaBody := If(
+		Lt(BareIdent("c"), BareIdent("p")),
+		BareIdent("c"),
+		Sub(BareIdent("c"), BareIdent("p")),
+	)
+	return Call(
+		"arrayMap",
+		Lambda2("p", "c", lambdaBody),
+		Call("arrayPopBack", valsArr()),
+		Call("arrayPopFront", valsArr()),
+	)
+}
+
+// IfNonZero renders
+//
+//	if(length(window_vals) > 0, <num> / <denom>, 0.0)
+//
+// — the divide-by-zero guard used by the LogQL log-rate window
+// reducer (and any future *_over_time / *_rate reducer that maps an
+// empty window to 0.0 rather than NaN).
+//
+// The predicate is hard-wired to `length(window_vals) > 0` because
+// every callsite operates against the synthetic `window_vals` alias
+// the windowed-array emitter projects in its middle layer; threading
+// the predicate as a third Frag would just push that constant up to
+// every callsite for no structural gain.
+func IfNonZero(num, denom Frag) Frag {
+	return If(
+		Gt(Call("length", BareIdent("window_vals")), InlineLit(int64(0))),
+		Div(num, denom),
+		// `0.0` is the existing emitter's literal for the empty-window
+		// fallback; InlineLit(0.0) would render as `0` (FormatFloat's
+		// canonical form) and drift goldens. verbatim is the in-package
+		// escape for emitter-pinned synthetic tokens.
+		verbatim("0.0"),
+	)
 }
 
 // Subqueryable is anything that renders as a parameterised SQL

--- a/internal/chsql/builder_test.go
+++ b/internal/chsql/builder_test.go
@@ -1409,3 +1409,123 @@ func TestBetween(t *testing.T) {
 		t.Errorf("Args = %v; want %v", args, wantArgs)
 	}
 }
+
+// TestLambda2_RendersParensAroundParams — Lambda2 renders
+// "(<p1>, <p2>) -> <body>", the paired-array lambda shape used by
+// arrayMap / arrayFold across two source arrays.
+func TestLambda2_RendersParensAroundParams(t *testing.T) {
+	t.Parallel()
+
+	b := NewBuilder()
+	Lambda2("p", "c", Sub(BareIdent("c"), BareIdent("p")))(b)
+	if got, want := b.String(), "(p, c) -> c - p"; got != want {
+		t.Errorf("Lambda2 SQL = %q; want %q", got, want)
+	}
+}
+
+// TestRangeWindowFilter_Basic — RangeWindowFilter renders the
+// arrayFilter(p -> ts>=start AND ts<=end, series) shape with
+// timestamps extracted via tupleElement(p, 1).
+func TestRangeWindowFilter_Basic(t *testing.T) {
+	t.Parallel()
+
+	b := NewBuilder()
+	RangeWindowFilter(
+		BareIdent("anchor_ts - toIntervalNanosecond(300000000000)"),
+		BareIdent("anchor_ts"),
+		BareIdent("series_array"),
+	)(b)
+	want := "arrayFilter(p -> tupleElement(p, 1) >= anchor_ts - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= anchor_ts, series_array)"
+	if got := b.String(); got != want {
+		t.Errorf("RangeWindowFilter SQL = %q; want %q", got, want)
+	}
+}
+
+// TestRangeWindowFilter_BindsArgsInOrder — Frag inputs that emit `?`
+// placeholders bind in start → end → series order.
+func TestRangeWindowFilter_BindsArgsInOrder(t *testing.T) {
+	t.Parallel()
+
+	b := NewBuilder()
+	RangeWindowFilter(Lit("S"), Lit("E"), Lit("A"))(b)
+	sql, args := b.Build()
+	want := "arrayFilter(p -> tupleElement(p, 1) >= ? AND tupleElement(p, 1) <= ?, ?)"
+	if sql != want {
+		t.Errorf("RangeWindowFilter SQL = %q; want %q", sql, want)
+	}
+	if !reflect.DeepEqual(args, []any{"S", "E", "A"}) {
+		t.Errorf("Args = %v; want [S E A]", args)
+	}
+}
+
+// TestCounterDelta_Basic — CounterDelta renders the 5-function pair-
+// wise delta sandwich without an enclosing arraySum; the caller wraps
+// in arraySum when reducing to a scalar.
+func TestCounterDelta_Basic(t *testing.T) {
+	t.Parallel()
+
+	b := NewBuilder()
+	CounterDelta(BareIdent("window_pairs"))(b)
+	want := "arrayMap((p, c) -> if(c < p, c, c - p), " +
+		"arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), " +
+		"arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))"
+	if got := b.String(); got != want {
+		t.Errorf("CounterDelta SQL = %q; want %q", got, want)
+	}
+}
+
+// TestCounterDelta_ArraySumWrap — CounterDelta is intentionally not
+// pre-wrapped; composing under arraySum produces the canonical
+// rate/increase delta-reducer shape.
+func TestCounterDelta_ArraySumWrap(t *testing.T) {
+	t.Parallel()
+
+	b := NewBuilder()
+	Call("arraySum", CounterDelta(BareIdent("window_pairs")))(b)
+	want := "arraySum(arrayMap((p, c) -> if(c < p, c, c - p), " +
+		"arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), " +
+		"arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs))))"
+	if got := b.String(); got != want {
+		t.Errorf("arraySum(CounterDelta) SQL = %q; want %q", got, want)
+	}
+}
+
+// TestIfNonZero_Basic — IfNonZero renders the
+// if(length(window_vals) > 0, <num>/<denom>, 0.0) guard with the
+// `0.0` literal preserved (FormatFloat would emit `0` and drift
+// goldens).
+func TestIfNonZero_Basic(t *testing.T) {
+	t.Parallel()
+
+	b := NewBuilder()
+	IfNonZero(
+		Call("arraySum", BareIdent("window_vals")),
+		Lit(60.0),
+	)(b)
+	sql, args := b.Build()
+	want := "if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0)"
+	if sql != want {
+		t.Errorf("IfNonZero SQL = %q; want %q", sql, want)
+	}
+	if !reflect.DeepEqual(args, []any{60.0}) {
+		t.Errorf("Args = %v; want [60]", args)
+	}
+}
+
+// TestIfNonZero_InlineDenom — when denom is an inline numeric
+// literal (no `?` binding), the rendered SQL has no placeholders.
+// Covers the edge case where the divisor is part of the query shape.
+func TestIfNonZero_InlineDenom(t *testing.T) {
+	t.Parallel()
+
+	b := NewBuilder()
+	IfNonZero(BareIdent("window_vals"), BareIdent("range_seconds"))(b)
+	sql, args := b.Build()
+	want := "if(length(window_vals) > 0, window_vals / range_seconds, 0.0)"
+	if sql != want {
+		t.Errorf("IfNonZero SQL = %q; want %q", sql, want)
+	}
+	if len(args) != 0 {
+		t.Errorf("Args = %v; want empty", args)
+	}
+}

--- a/internal/chsql/range_window.go
+++ b/internal/chsql/range_window.go
@@ -593,25 +593,20 @@ func groupArrayPairFrag(tsCol, valCol string) Frag {
 	}
 }
 
-// windowFilterPairsFrag returns a Frag rendering
+// windowFilterPairsFrag returns a Frag rendering the per-series
+// arrayFilter clamp to the [end-range, end] window over the
+// `series_array` alias. Thin wrapper over chsql.RangeWindowFilter
+// (R6.13's typed compound-idiom helper); kept as a local helper so
+// the rangeNS-arithmetic stays a single inline literal rather than
+// repeated `Sub(end, Call("toIntervalNanosecond", …))` boilerplate
+// at every callsite.
 //
-//	arrayFilter(p -> tupleElement(p, 1) >= <end> - toIntervalNanosecond(<range_ns>)
-//	              AND tupleElement(p, 1) <= <end>,
-//	            series_array)
-//
-// — the per-series window restriction. end may render arbitrary CH
-// expressions (DateTime64 literal, now64(9), or `anchor_ts` in the
-// matrix path); the rangeNS bound is inline.
+// end may render arbitrary CH expressions (DateTime64 literal,
+// `now64(9)`, or `anchor_ts` in the matrix path); the rangeNS bound
+// is inline.
 func windowFilterPairsFrag(end Frag, rangeNS int64) Frag {
-	return func(b *Builder) {
-		b.sb.WriteString("arrayFilter(p -> tupleElement(p, 1) >= ")
-		end(b)
-		b.sb.WriteString(" - toIntervalNanosecond(")
-		b.sb.WriteString(strconv.FormatInt(rangeNS, 10))
-		b.sb.WriteString(") AND tupleElement(p, 1) <= ")
-		end(b)
-		b.sb.WriteString(", series_array)")
-	}
+	start := Sub(end, Call("toIntervalNanosecond", InlineLit(rangeNS)))
+	return RangeWindowFilter(start, end, BareIdent("series_array"))
 }
 
 // counterDeltaFrag returns a Frag rendering
@@ -622,13 +617,15 @@ func windowFilterPairsFrag(end Frag, rangeNS int64) Frag {
 //
 // — the counter-reset-aware delta over the window's values. Used by
 // the rate / increase value expressions.
+//
+// The inner 5-function sandwich (the two arrayPopBack/Front layers
+// over the value-projection arrayMap, paired by the outer arrayMap)
+// is delegated to chsql.CounterDelta — R6.13's typed compound-idiom
+// helper. The outer arraySum stays here because rate / increase
+// reduce the per-pair delta array to a scalar; emitters that wanted
+// the raw delta array could call CounterDelta directly.
 func counterDeltaFrag() Frag {
-	return func(b *Builder) {
-		b.sb.WriteString("arraySum(arrayMap((p, c) -> if(c < p, c, c - p), ")
-		b.sb.WriteString("arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), ")
-		b.sb.WriteString("arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs))")
-		b.sb.WriteString("))")
-	}
+	return Call("arraySum", CounterDelta(BareIdent("window_pairs")))
 }
 
 // windowValsFrag returns a Frag rendering
@@ -711,13 +708,13 @@ func (e *emitter) emitRangeWindowIdentity(r *chplan.RangeWindow) error {
 //
 // range_seconds binds as a parameter via the value-writer callback so
 // the emitter stays free of new Sprintf-on-SQL instances (RC6 rule).
+// The empty-window guard is delegated to chsql.IfNonZero (R6.13).
 func (e *emitter) emitRangeWindowLogRate(r *chplan.RangeWindow) error {
 	rangeSeconds := r.Range.Seconds()
-	return e.emitWindowedArray(r, func(b *Builder) {
-		b.sb.WriteString("if(length(window_vals) > 0, arraySum(window_vals) / ")
-		b.Arg(rangeSeconds)
-		b.sb.WriteString(", 0.0)")
-	})
+	return e.emitWindowedArray(r, IfNonZero(
+		Call("arraySum", BareIdent("window_vals")),
+		Lit(rangeSeconds),
+	))
 }
 
 // emitRangeWindowRate emits SQL for `rate(metric[range])`.


### PR DESCRIPTION
## Summary

Three compound CH-SQL idioms hoisted into typed Frag constructors:

- **`RangeWindowFilter(start, end, series)`** — `arrayFilter` clamp over a `(ts, value)` tuple array; composed via `Call` / `Lambda1` / `And` / `Gte` / `Lte` / `tupleElement`.
- **`CounterDelta(seriesArr)`** — 5-function pair-wise delta sandwich (`arrayMap` over `arrayPopBack` / `arrayPopFront` of `arrayMap(tupleElement(…, 2))`). Not pre-wrapped in `arraySum` so the typed surface stays compositional — callers wrap when reducing to a scalar.
- **`IfNonZero(num, denom)`** — empty-window guard `if(length(window_vals) > 0, num/denom, 0.0)`. Predicate hard-wired to the synthetic `window_vals` alias the windowed-array emitter pins.

Plus `Lambda2(p1, p2, body)` for the paired-array lambda shape (`(p, c) -> if(c < p, c, c - p)`) — the typed companion to `Lambda1`.

## Callsites ported

- `internal/chsql/range_window.go::windowFilterPairsFrag` — now a thin wrapper over `RangeWindowFilter(Sub(end, Call("toIntervalNanosecond", InlineLit(rangeNS))), end, BareIdent("series_array"))`.
- `internal/chsql/range_window.go::counterDeltaFrag` — now `Call("arraySum", CounterDelta(BareIdent("window_pairs")))`.
- `internal/chsql/range_window.go::emitRangeWindowLogRate` — value writer now `IfNonZero(Call("arraySum", BareIdent("window_vals")), Lit(rangeSeconds))`.

The previous `if(length(window_vals) > 0, ..., 0.0)` path used a literal `0.0` in the rendered SQL. `InlineLit(0.0)` would render as `0` (Go's `FormatFloat(-1, 64)` canonical form) and drift goldens — so `IfNonZero` uses the in-package `verbatim("0.0")` escape for that one synthetic token. Documented inline.

## Test plan

- [x] `go test ./internal/chsql/...` — green (new tests: `Lambda2_RendersParensAroundParams`, `RangeWindowFilter_Basic`, `RangeWindowFilter_BindsArgsInOrder`, `CounterDelta_Basic`, `CounterDelta_ArraySumWrap`, `IfNonZero_Basic`, `IfNonZero_InlineDenom`).
- [x] `go test ./internal/...` — all packages green.
- [x] `GOLDEN_UPDATE=1 go test ./internal/chsql/... ./internal/promql/... ./internal/logql/... ./internal/traceql/...` — zero drift in `test/spec/` (verified via `git diff --stat test/spec/`).