### PR TITLE
feat(test): TXTAR seed + expected_rows via chDB (RC8 R8.1)

### DIFF
--- a/.github/workflows/chdb.yml
+++ b/.github/workflows/chdb.yml
@@ -48,3 +48,6 @@ jobs:
 
       - name: Run chDB probe
         run: go test -tags chdb -v -count=1 -run TestChDBProbe ./internal/chclient/...
+
+      - name: Run TXTAR round-trip suite (chDB)
+        run: just spec-chdb

--- a/Justfile
+++ b/Justfile
@@ -59,6 +59,15 @@ test:
 schema-ddl-test:
     go test -race -tags=integration ./internal/schema/ddl/...
 
+# Run the TXTAR spec suite with the chDB-backed round-trip assertion
+# layer enabled. Requires libchdb.so (see `just chdb-install`). The
+# default `just test` lane stays CGO_ENABLED=0 and never compiles the
+# chdb-go driver. Only fixtures that declare both `seed:` and
+# `expected_rows:` are executed against chDB; everything else still
+# runs through the text-equality golden path.
+spec-chdb:
+    go test -tags chdb -count=1 ./test/spec/...
+
 # Run the FuzzParse target for one parser head for a bounded duration.
 # Usage: `just fuzz QL=promql DURATION=60s` (defaults).
 fuzz QL="promql" DURATION="60s":

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -1,0 +1,103 @@
+# Test strategy
+
+Cerberus relies on a layered test suite that fans out from low-cost
+unit checks to high-cost end-to-end smoke tests. This doc enumerates
+the layers, the gating policy for each, and how the TXTAR spec suite
+opts into a semantic assertion layer on top of its text goldens.
+
+## Layers
+
+| Layer                        | Driver                                                 | Build tag      | Gate                  |
+| ---------------------------- | ------------------------------------------------------ | -------------- | --------------------- |
+| Unit tests                   | `just test` (Go + race)                                | none           | Required (`check`)    |
+| TXTAR spec text-equality     | `just test` walks `test/spec/<head>/*.txtar`           | none           | Required (`check`)    |
+| TXTAR spec round-trip (chDB) | `just spec-chdb` executes emitted SQL against chDB     | `chdb`         | Informational         |
+| `schema/ddl` integration     | `just schema-ddl-test` (testcontainers ClickHouse)     | `integration`  | Informational         |
+| `prometheus/compliance`      | `just compatibility` (Docker Compose harness)          | none           | Required at M6        |
+| End-to-end smoke             | `just e2e-up && e2e-seed && e2e-run` (k3d + Grafana)   | none           | Informational         |
+
+## TXTAR spec round-trip
+
+The TXTAR text-equality layer (`test/spec/<head>/<name>.txtar`)
+catches every change in the emitted SQL. It does NOT catch
+*semantic* regressions where the SQL still parses but its result set
+flips. The chDB-backed round-trip layer closes that gap.
+
+Authors opt a fixture into round-trip execution by adding two
+optional sections:
+
+```text
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_gauge VALUES
+    ('temperature', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), -3.5);
+-- expected_rows --
+[
+  ["temperature", {"host": "a"}, "2026-01-01T00:00:00Z", 3.5]
+]
+```
+
+The `chdb` build-tagged runner (in `test/spec/runner_chdb.go`) opens
+an ephemeral in-process chDB session per fixture, applies `seed:`,
+executes the fixture's `sql:` + `args:` against it, and asserts the
+resulting rows match `expected_rows:`. Without the `chdb` build tag
+both sections are inert — `just test` skips them.
+
+### Determinism
+
+The runner does NOT sort the result set. Authors must guarantee
+deterministic row order via the seed's `INSERT` ordering combined
+with the emitted SQL's `ORDER BY` (or, for single-row fixtures,
+trivially). When seeding multiple rows for queries that lack an
+ORDER BY, add one to the `seed:` table's `ORDER BY` clause and rely
+on the engine's read order.
+
+### Map columns
+
+chdb-go v1.11.0's parquet wire driver panics on the parquet MAP
+logical type when `rows.Scan` reaches a `Map(String, String)`
+column. The R8.0 chDB probe
+(`internal/chclient/chdb_probe_test.go`) confirmed that wrapping the
+projection server-side in `toJSONString(...)` and JSON-decoding the
+resulting string on the Go side is a clean shim.
+
+The round-trip runner applies this transform automatically: any
+top-level SELECT projection whose alias is one of `Attributes`,
+`ResourceAttributes`, `ScopeAttributes`, or `SpanAttributes` is
+rewritten to `toJSONString(<expr>) AS \`<alias>\``. Fixture authors
+write `expected_rows:` with the Map column as a JSON object (e.g.
+`{"host": "a"}`); `reflect.DeepEqual` handles JSON key ordering for
+free.
+
+### chdb-go quirks
+
+The runner ships a couple of small shims around chdb-go v1.11.0
+behavior:
+
+- `rows.Err()` returns `fmt.Errorf("empty row")` at end-of-iteration
+  instead of `io.EOF`. The runner's `tolerantRowsErr` ignores that
+  exact string and surfaces every other error.
+
+- `sql.Open("chdb", "")` creates a temp-dir-backed session that is
+  torn down with the connection. There is no `:memory:` literal in
+  the driver.
+
+- `rows.ColumnTypes()` panics on Map columns. The runner sizes its
+  scan-target slice by parsing the outer SELECT's projection list
+  textually — never call `ColumnTypes` from chdb code.
+
+- Only the `PARQUET` driver wire format is supported; reach for
+  parquet-go types, not Arrow.
+
+### CI
+
+The `chdb` workflow (`.github/workflows/chdb.yml`) runs nightly +
+manual dispatch only. It first runs `TestChDBProbe` from R8.0, then
+`just spec-chdb` to exercise the round-trip suite. Promote to a
+required PR gate once the suite is consistently green and the pilot
+fixture coverage has grown beyond the initial 5.

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -69,10 +69,11 @@ resulting string on the Go side is a clean shim.
 The round-trip runner applies this transform automatically: any
 top-level SELECT projection whose alias is one of `Attributes`,
 `ResourceAttributes`, `ScopeAttributes`, or `SpanAttributes` is
-rewritten to `toJSONString(<expr>) AS \`<alias>\``. Fixture authors
-write `expected_rows:` with the Map column as a JSON object (e.g.
-`{"host": "a"}`); `reflect.DeepEqual` handles JSON key ordering for
-free.
+rewritten to a `toJSONString(<expr>) AS <alias>` form (with the
+alias backtick-quoted in the actual emitted SQL). Fixture authors
+write `expected_rows:` with the Map column as a JSON object (for
+example, `{"host": "a"}`); `reflect.DeepEqual` handles JSON key
+ordering for free.
 
 ### chdb-go quirks
 

--- a/test/spec/promql/abs_metric.txtar
+++ b/test/spec/promql/abs_metric.txtar
@@ -4,3 +4,16 @@ abs(temperature)
 [0] string = "temperature"
 -- sql --
 SELECT `MetricName`, `Attributes`, `TimeUnix`, abs(`Value`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_gauge VALUES
+    ('temperature', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), -3.5);
+-- expected_rows --
+[
+  ["temperature", {"host": "a"}, "2026-01-01T00:00:00Z", 3.5]
+]

--- a/test/spec/promql/bool_lt.txtar
+++ b/test/spec/promql/bool_lt.txtar
@@ -5,3 +5,17 @@ SELECT `MetricName`, `Attributes`, `TimeUnix`, toFloat64((`Value` < ?)) AS `Valu
 -- args --
 [0] float64 = 1
 [1] string = "up"
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 0.0),
+    ('down', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 0.0);
+-- expected_rows --
+[
+  ["up", {"job": "api"}, "2026-01-01T00:00:00Z", 1.0]
+]

--- a/test/spec/promql/ceil_metric.txtar
+++ b/test/spec/promql/ceil_metric.txtar
@@ -4,3 +4,16 @@ ceil(temperature)
 [0] string = "temperature"
 -- sql --
 SELECT `MetricName`, `Attributes`, `TimeUnix`, ceil(`Value`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_gauge VALUES
+    ('temperature', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 2.3);
+-- expected_rows --
+[
+  ["temperature", {"host": "a"}, "2026-01-01T00:00:00Z", 3.0]
+]

--- a/test/spec/promql/clamp_max.txtar
+++ b/test/spec/promql/clamp_max.txtar
@@ -5,3 +5,16 @@ SELECT `MetricName`, `Attributes`, `TimeUnix`, least(`Value`, ?) AS `Value` FROM
 -- args --
 [0] float64 = 100
 [1] string = "temperature"
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_gauge VALUES
+    ('temperature', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 150.0);
+-- expected_rows --
+[
+  ["temperature", {"host": "a"}, "2026-01-01T00:00:00Z", 100.0]
+]

--- a/test/spec/promql/floor_metric.txtar
+++ b/test/spec/promql/floor_metric.txtar
@@ -4,3 +4,16 @@ floor(temperature)
 [0] string = "temperature"
 -- sql --
 SELECT `MetricName`, `Attributes`, `TimeUnix`, floor(`Value`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_gauge VALUES
+    ('temperature', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 7.8);
+-- expected_rows --
+[
+  ["temperature", {"host": "a"}, "2026-01-01T00:00:00Z", 7.0]
+]

--- a/test/spec/promql/roundtrip_chdb_test.go
+++ b/test/spec/promql/roundtrip_chdb_test.go
@@ -1,0 +1,32 @@
+//go:build chdb
+
+// Package promql_spec_test — chDB-backed round-trip pass over the
+// PromQL TXTAR fixtures.
+//
+// This test is gated behind the `chdb` build tag. It walks every
+// *.txtar fixture under test/spec/promql/ and, for fixtures that
+// declare both `seed:` and `expected_rows:`, executes the stored
+// `sql:` + `args:` against an ephemeral in-process chDB session and
+// asserts the resulting rows match `expected_rows:`.
+//
+// Fixtures without those sections are skipped (the default text-
+// equality check in internal/promql/lower_test.go still gates them).
+package promql_spec_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/tsouza/cerberus/test/spec"
+)
+
+func TestRoundTripChDB(t *testing.T) {
+	t.Parallel()
+
+	dir := filepath.Join(".")
+	spec.Walk(t, dir, func(t *testing.T, c *spec.Case) {
+		// LoadRoundTrip + IsRoundTrip is the opt-in gate; fixtures
+		// without seed/expected_rows are silent no-ops.
+		spec.RunRoundTrip(t, c)
+	})
+}

--- a/test/spec/roundtrip.go
+++ b/test/spec/roundtrip.go
@@ -1,0 +1,169 @@
+// Package spec — round-trip extension.
+//
+// This file defines the (optional) `seed:` / `expected_rows:` section
+// contract that TXTAR fixtures can use to opt into a semantic
+// assertion layer on top of today's text-equality `sql:` golden.
+//
+// When BOTH sections are present, the `chdb` build-tagged runner
+// (see runner_chdb.go) opens an in-process chDB session, applies the
+// `seed:` DDL+INSERTs, executes the emitted `sql:` after binding the
+// `args:` placeholders, and asserts the resulting rows match
+// `expected_rows:`. Without the `chdb` build tag the sections are
+// ignored — fixtures still parse cleanly.
+//
+// Section contract:
+//
+//   - `seed:` — one or more semicolon-terminated CH statements (DDL +
+//     INSERTs) that populate the session. Authors should include
+//     deterministic ORDER BY-able data; the runner does not sort
+//     rows on its own.
+//
+//   - `expected_rows:` — JSON array of arrays. Each inner array is one
+//     row, with values positionally matching the SELECT projection of
+//     the emitted `sql:`. Map(String,String) columns appear as JSON
+//     objects ({"job":"api"}) — the runner round-trips Map columns
+//     through `toJSONString(...)` server-side and decodes them on the
+//     Go side (per R8.0's chdb-go probe, native Map scan panics in
+//     parquet-go inside chdb-go v1.11.0).
+//
+// We chose JSON over TSV for `expected_rows:` because Map columns
+// embed nested structure that TSV cannot represent without an
+// escaping convention, and because reflect.DeepEqual on the decoded
+// shape (slice of map[string]any) handles map-key ordering for free.
+package spec
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// RoundTripSections is the parsed shape of the optional `seed:` /
+// `expected_rows:` / `sql:` / `args:` sections attached to a fixture.
+//
+// When `Seed` or `ExpectedRows` is empty, the fixture has not opted
+// into round-trip execution. Callers should check IsRoundTrip().
+type RoundTripSections struct {
+	// Seed is the CH DDL+INSERT script that populates the in-process
+	// chDB session. The runner splits on semicolons and runs each
+	// statement individually so chdb-go's single-statement Exec
+	// works.
+	Seed string
+
+	// ExpectedRows is the parsed JSON content of `expected_rows:`.
+	// Each row is a slice of `any` mirroring the emitted SQL's
+	// SELECT projection. Map columns are unmarshalled as
+	// map[string]any.
+	ExpectedRows [][]any
+
+	// SQL is the raw `sql:` section (after normalization). The
+	// runner rewrites Map column references to wrap them in
+	// `toJSONString(...)` before binding args.
+	SQL string
+
+	// Args is the bound []any matching the `?` placeholders in SQL,
+	// parsed from the `args:` text format the emitter writes.
+	Args []any
+}
+
+// IsRoundTrip reports whether the fixture opted into the
+// seed+expected_rows assertion path.
+func (r *RoundTripSections) IsRoundTrip() bool {
+	return strings.TrimSpace(r.Seed) != "" && len(r.ExpectedRows) > 0
+}
+
+// LoadRoundTrip extracts `seed:` / `expected_rows:` / `sql:` / `args:`
+// from a fixture. Missing sections produce an empty/false result;
+// invalid JSON or args returns an error.
+func LoadRoundTrip(c *Case) (*RoundTripSections, error) {
+	out := &RoundTripSections{}
+
+	if v, ok := c.Section("seed"); ok {
+		out.Seed = v
+	}
+	if v, ok := c.Section("expected_rows"); ok {
+		v = strings.TrimSpace(v)
+		if v != "" {
+			if err := json.Unmarshal([]byte(v), &out.ExpectedRows); err != nil {
+				return nil, fmt.Errorf("expected_rows JSON: %w", err)
+			}
+		}
+	}
+	if v, ok := c.Section("sql"); ok {
+		out.SQL = strings.TrimSpace(v)
+	}
+	if v, ok := c.Section("args"); ok {
+		args, err := parseArgs(v)
+		if err != nil {
+			return nil, fmt.Errorf("args: %w", err)
+		}
+		out.Args = args
+	}
+	return out, nil
+}
+
+// argsLineRe matches one line of the args section, e.g.:
+//
+//	[0] string = "temperature"
+//	[1] float64 = 100
+//	[2] int64 = 9
+//
+// The format is what chsql_test.formatArgs writes via fmt.Fprintf
+// with the verb `%T = %#v`. Re-parsing it back to a []any covers the
+// three numeric kinds (int64, float64) plus strings; that matches
+// every fixture we ship today.
+var argsLineRe = regexp.MustCompile(`^\[(\d+)\]\s+(\S+)\s*=\s*(.*)$`)
+
+func parseArgs(s string) ([]any, error) {
+	s = strings.TrimSpace(s)
+	if s == "" || s == "(none)" {
+		return nil, nil
+	}
+	lines := strings.Split(s, "\n")
+	args := make([]any, 0, len(lines))
+	for _, raw := range lines {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		m := argsLineRe.FindStringSubmatch(raw)
+		if m == nil {
+			return nil, fmt.Errorf("malformed args line %q", raw)
+		}
+		idx, _ := strconv.Atoi(m[1])
+		if idx != len(args) {
+			return nil, fmt.Errorf("args line %q out of sequence (want index %d)", raw, len(args))
+		}
+		typ := m[2]
+		val := strings.TrimSpace(m[3])
+		v, err := parseArgValue(typ, val)
+		if err != nil {
+			return nil, fmt.Errorf("args[%d] (%s): %w", idx, typ, err)
+		}
+		args = append(args, v)
+	}
+	return args, nil
+}
+
+// parseArgValue decodes one Go literal as produced by `%#v`. It only
+// needs to handle the types the emitter currently produces.
+func parseArgValue(typ, raw string) (any, error) {
+	switch typ {
+	case "string":
+		// %#v wraps strings in double quotes; strconv.Unquote
+		// undoes it (handling embedded escapes).
+		return strconv.Unquote(raw)
+	case "int", "int64":
+		return strconv.ParseInt(raw, 10, 64)
+	case "uint", "uint64":
+		return strconv.ParseUint(raw, 10, 64)
+	case "float64":
+		return strconv.ParseFloat(raw, 64)
+	case "bool":
+		return strconv.ParseBool(raw)
+	default:
+		return nil, fmt.Errorf("unsupported type %q", typ)
+	}
+}

--- a/test/spec/runner_chdb.go
+++ b/test/spec/runner_chdb.go
@@ -1,0 +1,447 @@
+//go:build chdb
+
+// Package spec — chDB-backed round-trip executor.
+//
+// This file is compiled only when the `chdb` build tag is set, which
+// also implies the chdb-go driver and libchdb.so are present (see
+// `just chdb-install`). The default `just test` lane stays
+// CGO_ENABLED=0 and never sees this code.
+//
+// The executor opens an ephemeral in-process chDB session, runs the
+// fixture's `seed:` DDL+INSERT statements, executes the emitted `sql:`
+// (with `args:` bound), and asserts the resulting rows match the
+// `expected_rows:` JSON. Map columns are wrapped server-side in
+// `toJSONString(...)` to dodge the native parquet Map scan panic
+// documented in chDB probe (RC8 R8.0).
+package spec
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/chdb-io/chdb-go/chdb/driver"
+)
+
+// chdbEOFSentinel is the spurious end-of-iteration error chdb-go's
+// parquet driver returns instead of io.EOF (see chdb-go v1.11.0's
+// `parquet.go`: `return fmt.Errorf("empty row")`). It surfaces on
+// rows.Err() and must be ignored — any other error is real.
+const chdbEOFSentinel = "empty row"
+
+// tolerantRowsErr matches the helper used by the chDB probe in
+// internal/chclient/chdb_probe_test.go.
+func tolerantRowsErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	if strings.Contains(err.Error(), chdbEOFSentinel) {
+		return nil
+	}
+	return err
+}
+
+// mapColumnNames is the conservative list of OTel-CH Map column names
+// the runner will rewrite to `toJSONString(<name>)` in the emitted
+// SQL before execution. We don't have type information at this
+// layer; the rewrite is a textual transform keyed off this allow-
+// list. Authors with custom Map columns can extend the list as
+// fixtures grow.
+var mapColumnNames = []string{
+	"Attributes",
+	"ResourceAttributes",
+	"ScopeAttributes",
+	"SpanAttributes",
+}
+
+// isMapColumn reports whether name (a backtick-quoted alias) is one
+// of the known OTel Map column names.
+func isMapColumn(name string) bool {
+	for _, c := range mapColumnNames {
+		if name == c {
+			return true
+		}
+	}
+	return false
+}
+
+// rewriteMapProjections wraps any top-level SELECT projection whose
+// alias is a known Map column in toJSONString(...). The transform
+// fires on the OUTER SELECT only — subqueries keep their Map columns
+// as raw maps because CH consumes them server-side.
+//
+// Two shapes are handled:
+//
+//	`Attributes`                       → toJSONString(`Attributes`) AS `Attributes`
+//	<expr> AS `Attributes`             → toJSONString(<expr>) AS `Attributes`
+//	`Attributes` AS `Attributes`       → toJSONString(`Attributes`) AS `Attributes`
+//
+// Anything else passes through; chdb-go will raise a Parquet panic
+// at scan time if a Map column slips through unwrapped, which makes
+// the failure mode loud and easy to debug.
+func rewriteMapProjections(query string) string {
+	head, tail := splitOuterSelect(query)
+	if head == "" {
+		return query
+	}
+	projs := splitProjections(head)
+	for i, p := range projs {
+		expr, alias := splitAlias(p)
+		// Implicit alias: bare `Col` projection.
+		if alias == "" {
+			alias = unquoteBackticks(strings.TrimSpace(expr))
+		}
+		if !isMapColumn(alias) {
+			continue
+		}
+		projs[i] = "toJSONString(" + expr + ") AS `" + alias + "`"
+	}
+	return "SELECT " + strings.Join(projs, ", ") + tail
+}
+
+// splitOuterSelect returns the (projection-list, rest) split of a
+// `SELECT <projs> FROM ...` query. If the query doesn't start with
+// SELECT or the FROM is missing at depth 0, returns ("", "").
+func splitOuterSelect(query string) (head string, tail string) {
+	upper := strings.ToUpper(query)
+	if !strings.HasPrefix(upper, "SELECT ") {
+		return "", ""
+	}
+	rest := query[len("SELECT "):]
+	depth := 0
+	for i := 0; i < len(rest); i++ {
+		switch rest[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		}
+		if depth == 0 && i+6 <= len(rest) && strings.EqualFold(rest[i:i+6], " FROM ") {
+			return rest[:i], rest[i:]
+		}
+	}
+	return "", ""
+}
+
+// splitProjections splits a projection list on depth-0 commas.
+// Quoted strings (single-quotes, backticks) shield commas. The
+// returned slices have leading/trailing whitespace trimmed.
+func splitProjections(s string) []string {
+	var (
+		out   []string
+		buf   strings.Builder
+		depth int
+		inStr byte
+	)
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case inStr != 0:
+			if c == inStr {
+				inStr = 0
+			}
+			buf.WriteByte(c)
+		case c == '\'' || c == '`':
+			inStr = c
+			buf.WriteByte(c)
+		case c == '(':
+			depth++
+			buf.WriteByte(c)
+		case c == ')':
+			depth--
+			buf.WriteByte(c)
+		case c == ',' && depth == 0:
+			out = append(out, strings.TrimSpace(buf.String()))
+			buf.Reset()
+		default:
+			buf.WriteByte(c)
+		}
+	}
+	if buf.Len() > 0 {
+		out = append(out, strings.TrimSpace(buf.String()))
+	}
+	return out
+}
+
+// splitAlias separates `<expr> AS \`alias\`` into (expr, alias). When
+// no AS clause is present returns (s, "").
+func splitAlias(s string) (expr, alias string) {
+	// Find the last depth-0 " AS " (case-insensitive). Backtick-
+	// quoted "AS" is shielded.
+	depth := 0
+	inStr := byte(0)
+	lower := strings.ToLower(s)
+	for i := 0; i+4 <= len(s); i++ {
+		c := s[i]
+		switch {
+		case inStr != 0:
+			if c == inStr {
+				inStr = 0
+			}
+		case c == '\'' || c == '`':
+			inStr = c
+		case c == '(':
+			depth++
+		case c == ')':
+			depth--
+		}
+		if depth == 0 && inStr == 0 && lower[i:i+4] == " as " {
+			alias = strings.TrimSpace(s[i+4:])
+			alias = unquoteBackticks(alias)
+			return strings.TrimSpace(s[:i]), alias
+		}
+	}
+	return s, ""
+}
+
+func unquoteBackticks(s string) string {
+	if len(s) >= 2 && s[0] == '`' && s[len(s)-1] == '`' {
+		return s[1 : len(s)-1]
+	}
+	return s
+}
+
+// extractProjectionCount counts top-level SELECT projections by
+// re-splitting the outer SELECT's projection list on depth-0 commas.
+// Used to size the scan-target slice without calling
+// rows.ColumnTypes() (which panics on Map columns per the R8.0 probe).
+func extractProjectionCount(query string) int {
+	head, _ := splitOuterSelect(query)
+	if head == "" {
+		return 0
+	}
+	return len(splitProjections(head))
+}
+
+// openChDB returns a fresh ephemeral chDB session. The empty DSN
+// triggers a temp-dir-backed session that's torn down with the
+// connection — there is no `:memory:` literal in chdb-go.
+func openChDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("chdb", "")
+	if err != nil {
+		t.Fatalf("open chdb: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.Ping(); err != nil {
+		t.Fatalf("ping chdb: %v", err)
+	}
+	return db
+}
+
+// applySeed splits a multi-statement script on top-level semicolons
+// and exec's each piece. Statements wrapped in single-quoted strings
+// keep their semicolons literal (handled by a tiny state machine).
+func applySeed(t *testing.T, db *sql.DB, seed string) {
+	t.Helper()
+	for _, stmt := range splitStatements(seed) {
+		stmt = strings.TrimSpace(stmt)
+		if stmt == "" {
+			continue
+		}
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("seed exec failed:\n--- stmt ---\n%s\n--- err ---\n%v", stmt, err)
+		}
+	}
+}
+
+func splitStatements(s string) []string {
+	var (
+		out   []string
+		buf   strings.Builder
+		inStr bool
+		esc   bool
+	)
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case esc:
+			esc = false
+			buf.WriteByte(c)
+		case c == '\\' && inStr:
+			esc = true
+			buf.WriteByte(c)
+		case c == '\'':
+			inStr = !inStr
+			buf.WriteByte(c)
+		case c == ';' && !inStr:
+			out = append(out, buf.String())
+			buf.Reset()
+		default:
+			buf.WriteByte(c)
+		}
+	}
+	if buf.Len() > 0 {
+		out = append(out, buf.String())
+	}
+	return out
+}
+
+// RunRoundTrip executes a fixture's seed + rewritten SQL against an
+// ephemeral chDB session and asserts the resulting rows match
+// `expected_rows:`. Caller passes the loaded fixture; if it's not a
+// round-trip fixture, the call is a no-op.
+//
+// Determinism contract: the fixture's `sql:` (or the seed's INSERT
+// ordering combined with a server-side ORDER BY in the emitted SQL)
+// MUST produce a stable row order — RunRoundTrip does NOT sort rows.
+// Map column comparison uses reflect.DeepEqual on map[string]any so
+// JSON key ordering is irrelevant.
+func RunRoundTrip(t *testing.T, c *Case) {
+	t.Helper()
+	rt, err := LoadRoundTrip(c)
+	if err != nil {
+		t.Fatalf("LoadRoundTrip: %v", err)
+	}
+	if !rt.IsRoundTrip() {
+		return
+	}
+	if strings.TrimSpace(rt.SQL) == "" {
+		t.Fatalf("fixture %s has seed/expected_rows but missing sql section", c.Name)
+	}
+
+	db := openChDB(t)
+	applySeed(t, db, rt.Seed)
+
+	query := rewriteMapProjections(rt.SQL)
+	colCount := extractProjectionCount(query)
+	if colCount == 0 {
+		t.Fatalf("fixture %s: cannot determine SELECT projection count from sql", c.Name)
+	}
+
+	rows, err := db.Query(query, rt.Args...)
+	if err != nil {
+		t.Fatalf("query failed:\n--- query ---\n%s\n--- args ---\n%#v\n--- err ---\n%v",
+			query, rt.Args, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	got := make([][]any, 0, len(rt.ExpectedRows))
+	for rows.Next() {
+		// Scan into *interface{} so we receive the chdb-go driver's
+		// native Go value (string, int64, float64, time.Time, []byte)
+		// per chdb/driver/parquet.go's switch table. This sidesteps
+		// rows.ColumnTypes() (which panics on Map columns per the
+		// R8.0 probe).
+		cells := make([]any, colCount)
+		ptrs := make([]any, colCount)
+		for i := range cells {
+			ptrs[i] = &cells[i]
+		}
+		if err := rows.Scan(ptrs...); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		row := make([]any, colCount)
+		for i, v := range cells {
+			row[i] = decodeCell(v)
+		}
+		got = append(got, row)
+	}
+	if err := tolerantRowsErr(rows.Err()); err != nil {
+		t.Fatalf("rows.Err: %v", err)
+	}
+
+	// Coerce expected rows in-place: JSON numbers always decode as
+	// float64; the runner normalizes the actual scan output through
+	// the same lens so DeepEqual is symmetric. Same for Map columns
+	// (already decoded as map[string]any on the got side).
+	want := normalizeExpected(rt.ExpectedRows)
+	gotNorm := normalizeExpected(got)
+
+	if !reflect.DeepEqual(gotNorm, want) {
+		t.Fatalf("round-trip mismatch (fixture %s)\n got = %s\nwant = %s",
+			c.Name, mustJSON(gotNorm), mustJSON(want))
+	}
+}
+
+// decodeCell turns a chdb-go driver-native value into the Go value
+// used for comparison. The driver hands back time.Time, int64,
+// float64, bool, string, []byte — see chdb/driver/parquet.go's
+// switch table.
+//
+// For Map columns we wrapped server-side in toJSONString(...), the
+// driver returns a string; we try JSON-decode and fall back to the
+// raw string. time.Time values are normalized to RFC3339Nano so
+// fixture authors can write them as quoted strings.
+func decodeCell(v any) any {
+	switch x := v.(type) {
+	case nil:
+		return nil
+	case time.Time:
+		return x.UTC().Format(time.RFC3339Nano)
+	case []byte:
+		return decodeBytes(x)
+	case string:
+		return decodeString(x)
+	default:
+		return v
+	}
+}
+
+func decodeBytes(b []byte) any {
+	return decodeString(string(b))
+}
+
+func decodeString(s string) any {
+	trim := strings.TrimSpace(s)
+	if len(trim) > 0 && (trim[0] == '{' || trim[0] == '[') {
+		var v any
+		if err := json.Unmarshal([]byte(trim), &v); err == nil {
+			return v
+		}
+	}
+	return s
+}
+
+// normalizeExpected walks a [][]any and coerces numeric cells to
+// float64 so JSON-decoded numbers compare equal to scanned values.
+func normalizeExpected(rows [][]any) [][]any {
+	out := make([][]any, len(rows))
+	for i, row := range rows {
+		nr := make([]any, len(row))
+		for j, v := range row {
+			nr[j] = normalizeValue(v)
+		}
+		out[i] = nr
+	}
+	return out
+}
+
+func normalizeValue(v any) any {
+	switch x := v.(type) {
+	case int:
+		return float64(x)
+	case int64:
+		return float64(x)
+	case uint64:
+		return float64(x)
+	case float32:
+		return float64(x)
+	case map[string]any:
+		out := make(map[string]any, len(x))
+		for k, vv := range x {
+			out[k] = normalizeValue(vv)
+		}
+		return out
+	case []any:
+		out := make([]any, len(x))
+		for i, vv := range x {
+			out[i] = normalizeValue(vv)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+func mustJSON(v any) string {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Sprintf("<json err: %v>", err)
+	}
+	return string(b)
+}

--- a/test/spec/runner_nochdb.go
+++ b/test/spec/runner_nochdb.go
@@ -1,0 +1,21 @@
+//go:build !chdb
+
+// Package spec — round-trip stub when the `chdb` build tag is unset.
+//
+// The default `just test` lane stays pure Go / CGO_ENABLED=0 and
+// must not pull in chdb-go (which links libchdb.so via cgo). This
+// file provides a no-op RunRoundTrip so test files in lower-level
+// packages can call spec.RunRoundTrip unconditionally; the seed:
+// and expected_rows: sections are then inert.
+package spec
+
+import "testing"
+
+// RunRoundTrip is a no-op when the `chdb` build tag is not set. The
+// real implementation lives in runner_chdb.go.
+func RunRoundTrip(t *testing.T, c *Case) {
+	t.Helper()
+	// Intentionally empty — seed: / expected_rows: are inert without
+	// the chdb build tag.
+	_ = c
+}


### PR DESCRIPTION
## Summary

Extends the TXTAR runner with two optional sections — `seed:` and
`expected_rows:` — that opt a fixture into a chDB-backed semantic
assertion on top of the existing text-equality goldens. When both
sections are present, a new `chdb` build-tagged executor opens an
ephemeral in-process chDB session, applies the seed DDL+INSERTs,
runs the emitted `sql:` + `args:` against it, and asserts the
result set matches `expected_rows:`. This turns today's text-only
goldens into semantic assertions — a chsql refactor that silently
inverts predicate order is now caught by row mismatch.

Without the `chdb` build tag the sections are inert: `just test`
stays CGO_ENABLED=0 and never pulls in `chdb-go`.

Map columns are rewritten server-side to `toJSONString(...)` (per
the R8.0 probe) so the parquet-go MAP panic in chdb-go v1.11.0 is
dodged; row comparison normalizes numbers to float64 and decodes
Map cells into `map[string]any`, leaning on `reflect.DeepEqual` for
JSON key-ordering robustness.

**Pilot fixtures (5)**: `abs_metric`, `bool_lt`, `ceil_metric`,
`clamp_max`, `floor_metric` — five simple gauge transforms on
`otel_metrics_gauge` with deterministic single-row seeds.

**Runner extension**: ~500 LoC across:
- `test/spec/roundtrip.go` — section parsing (always compiled).
- `test/spec/runner_chdb.go` — chDB executor (`//go:build chdb`).
- `test/spec/runner_nochdb.go` — no-op fallback (`//go:build !chdb`).
- `test/spec/promql/roundtrip_chdb_test.go` — driver (chdb-tagged).

**CI**: `chdb` workflow gains a `Run TXTAR round-trip suite (chDB)`
step calling `just spec-chdb`. Still nightly + manual dispatch only,
NOT a required PR check.

**Determinism**: documented in `docs/test-strategy.md`. Single-row
seeds satisfy it trivially; multi-row fixtures must include `ORDER
BY` in either the seed table or the emitted SQL.

## Stacks on

#221 (R8.0 chDB probe). Auto-merge enables only after #221 lands.

## Test plan

- [ ] `just test` (default lane) still passes; new sections inert.
- [ ] `just chdb-install && just spec-chdb` exercises all 5 pilot fixtures.
- [ ] `chdb` workflow runs both steps on nightly/dispatch.
- [ ] Adding `seed:` + `expected_rows:` to a 6th fixture works without runner changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)