### PR TITLE
feat(engine): scaffolding (Engine + Lang + Meta + Result)

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1,0 +1,215 @@
+// Package engine orchestrates the shared cerberus query pipeline:
+//
+//	parse → lower (inside Lang.Parse) → wrap-projection → optimize →
+//	emit → execute
+//
+// The three per-API handlers (prom / loki / tempo) each used to inline
+// this loop with copy-pasted telemetry plumbing. Engine extracts the
+// loop so the handlers shrink to (a) HTTP routing, (b) per-language
+// adapter wiring, and (c) the response-shape pivot.
+//
+// Per-language differences live behind the Lang interface: the parser
+// type stays inside the adapter, lowering happens inside Lang.Parse,
+// and the sample-row reshaping that used to live in each handler's
+// wrapWithSampleProjection helper moves behind Lang.ProjectSamples.
+//
+// This scaffolding is intentionally additive — the handlers continue
+// to orchestrate the pipeline directly until per-head port milestones
+// rewrite them against Engine.
+package engine
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/cerbtrace"
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/optimizer"
+	"github.com/tsouza/cerberus/internal/telemetry"
+)
+
+// Querier is the subset of *chclient.Client Engine needs. Each handler
+// already declares a (broader) Querier in its own package; Engine
+// requires only the row-returning Query method since adapters lower to
+// a plan that emits chclient.Sample rows. Streaming / strings /
+// label-set callers go straight to their handler's Querier — the
+// engine's surface is intentionally narrow for now.
+type Querier interface {
+	Query(ctx context.Context, sql string, args ...any) ([]chclient.Sample, error)
+}
+
+// Engine owns the shared dependencies (optimizer, ClickHouse client)
+// and runs the pipeline loop. One Engine instance lives in each
+// handler; the per-language differences are supplied by the Lang
+// argument to each Query / QueryPlan call.
+type Engine struct {
+	// Optimizer rewrites the post-projection plan. Required.
+	Optimizer *optimizer.Driver
+	// Client executes the emitted ClickHouse SQL. Required.
+	Client Querier
+}
+
+// Lang adapts a query-language head (PromQL / LogQL / TraceQL) to
+// Engine. The parser type and the lowering call stay inside the
+// adapter — Engine sees only a plan plus a Meta carrying the
+// per-language flags downstream rendering needs.
+type Lang interface {
+	// Name identifies the QL for spans, progress-context keying, and
+	// logs. Stable strings: "promql", "logql", "traceql".
+	Name() string
+
+	// Parse runs the upstream parser, lowers the AST into a chplan
+	// tree, and returns the plan plus any per-language semantic flags
+	// the engine cannot infer from the plan alone. Parse SHOULD open
+	// the cerbtrace.SpanParse / SpanLower spans itself so trace
+	// shapes match what the per-handler pipelines emit today.
+	Parse(ctx context.Context, query string) (chplan.Node, Meta, error)
+
+	// ProjectSamples wraps plan with whatever projection the adapter
+	// needs so that the executed SQL emits rows in the canonical
+	// chclient.Sample shape — (MetricName, Attributes, TimeUnix,
+	// Value). Each existing handler hand-rolls this; the adapter
+	// owns it after the port.
+	ProjectSamples(plan chplan.Node, meta Meta) chplan.Node
+}
+
+// Meta carries per-query semantic flags the engine needs but cannot
+// infer from the plan. Adapters populate it during Parse / when
+// building a plan directly for QueryPlan.
+type Meta struct {
+	// IsMetric distinguishes matrix-shaped responses (PromQL always;
+	// LogQL when the query is a metric query rather than a log
+	// stream). The handler-side response pivot reads it.
+	IsMetric bool
+	// IsTraceByID flags the Tempo /traces/{id} short-circuit: the
+	// plan is built without a parser and the optimizer is skipped
+	// because the row-by-id fetch has no rewrites worth running.
+	IsTraceByID bool
+	// ResponseShape is the handler-side pivot key — one of
+	// "prom-vector" / "prom-matrix" / "loki-streams" / "tempo-traces"
+	// etc. The engine doesn't read it; it's threaded through Result
+	// so the handler can switch on it without re-deriving.
+	ResponseShape string
+	// Extra is an adapter-specific bag so per-language knobs can ride
+	// through Meta without bloating the type. Engine doesn't read it.
+	Extra map[string]any
+}
+
+// Result is what Engine.Query / Engine.QueryPlan return on success.
+type Result struct {
+	// Samples is the row stream from ClickHouse decoded as
+	// chclient.Sample. Handlers pivot it into the upstream wire
+	// shape (Prom vector / matrix, Loki streams, Tempo trace
+	// summaries).
+	Samples []chclient.Sample
+	// SQL is the parameterised ClickHouse SQL the engine emitted.
+	// Surfaced for debug logging and the future
+	// X-Cerberus-SQL-Length header.
+	SQL string
+	// Args is the positional argument list bound to SQL's `?`
+	// placeholders.
+	Args []any
+	// Strategy is a free-form label for the execution path taken —
+	// reserved for the shadow-mode / fallback-evaluator work. Empty
+	// today.
+	Strategy string
+	// CHMillis is the wall-clock time spent in Client.Query, in
+	// milliseconds. Replaces the per-handler chMillisCounter for
+	// loki / tempo (prom keeps its middleware until the port).
+	CHMillis int64
+	// PlanNodeCount is the optimised plan's node count, surfaced
+	// for the X-Cerberus-Plan-Nodes header.
+	PlanNodeCount int
+	// Headers is a bag of HTTP response headers the engine wants
+	// the handler to stamp on the response — keeps the engine free
+	// of http.ResponseWriter. Empty today; populated as the
+	// per-head ports move the X-Cerberus-* headers off the
+	// handlers.
+	Headers map[string]string
+	// Meta is the per-language Meta the adapter returned from
+	// Parse (or that QueryPlan was called with), threaded through
+	// so the handler-side response pivot can switch on it.
+	Meta Meta
+}
+
+// Query runs the full pipeline for an upstream query string: it asks
+// the Lang adapter to parse + lower, then delegates to QueryPlan.
+//
+// Returns a wrapped error from each pipeline stage so callers can
+// errors.Is / errors.As to classify (parse → bad-data, emit →
+// internal, execute → bad-gateway, etc.).
+func (e *Engine) Query(ctx context.Context, lang Lang, query string) (Result, error) {
+	if lang == nil {
+		return Result{}, fmt.Errorf("engine: nil Lang")
+	}
+	plan, meta, err := lang.Parse(ctx, query)
+	if err != nil {
+		return Result{}, fmt.Errorf("engine: parse: %w", err)
+	}
+	return e.QueryPlan(ctx, lang, plan, meta)
+}
+
+// QueryPlan runs the post-parse half of the pipeline for a plan the
+// adapter built directly. The Tempo /traces/{id} path is the canonical
+// caller: it hand-rolls a plan instead of running a TraceQL parser, so
+// Engine.Query is skipped and QueryPlan is entered with
+// Meta.IsTraceByID = true.
+//
+// IsTraceByID also short-circuits the optimizer pass — the row-by-id
+// fetch has no rewrites worth running and skipping the pass keeps the
+// trace flat (no `optimize` span on a probe that ought to be one
+// SELECT against the spans table).
+func (e *Engine) QueryPlan(ctx context.Context, lang Lang, plan chplan.Node, meta Meta) (Result, error) {
+	if lang == nil {
+		return Result{}, fmt.Errorf("engine: nil Lang")
+	}
+	if plan == nil {
+		return Result{}, fmt.Errorf("engine: nil plan")
+	}
+
+	// Wrap-projection. The adapter owns the per-language switch
+	// (canonical vs. derived vs. structural-join shape); the engine
+	// applies it unconditionally.
+	plan = lang.ProjectSamples(plan, meta)
+
+	// Optimize — unless the adapter signalled a fetch-by-id where
+	// rewriting buys nothing. Each branch keeps the rest of the
+	// pipeline identical.
+	if !meta.IsTraceByID {
+		optT := telemetry.ObserveStage(telemetry.StageOptimize)
+		plan = e.Optimizer.Run(ctx, plan)
+		optT.Done(ctx)
+	}
+
+	// Emit.
+	emitT := telemetry.ObserveStage(telemetry.StageEmit)
+	sql, args, err := chsql.Emit(ctx, plan)
+	emitT.Done(ctx)
+	if err != nil {
+		return Result{}, fmt.Errorf("engine: emit: %w", err)
+	}
+
+	// Execute. The progress-context key matches the upstream QL so
+	// the cerberus.clickhouse.{rows,bytes}_read histograms keep
+	// their per-head labels.
+	execT := telemetry.ObserveStage(telemetry.StageExecute)
+	start := time.Now()
+	samples, err := e.Client.Query(chclient.WithProgressFor(ctx, lang.Name()), sql, args...)
+	chMillis := time.Since(start).Milliseconds()
+	execT.Done(ctx)
+	if err != nil {
+		return Result{}, fmt.Errorf("engine: execute: %w", err)
+	}
+
+	return Result{
+		Samples:       samples,
+		SQL:           sql,
+		Args:          args,
+		CHMillis:      chMillis,
+		PlanNodeCount: cerbtrace.CountNodes(plan),
+		Meta:          meta,
+	}, nil
+}

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1,0 +1,317 @@
+package engine_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/engine"
+	"github.com/tsouza/cerberus/internal/optimizer"
+)
+
+// fakeLang is a stand-in for a real per-language adapter. Each callback
+// is a hook the tests can rebind to exercise specific pipeline stages.
+type fakeLang struct {
+	name         string
+	parseFn      func(ctx context.Context, q string) (chplan.Node, engine.Meta, error)
+	projectFn    func(plan chplan.Node, meta engine.Meta) chplan.Node
+	parseCalls   int
+	projectCalls int
+}
+
+func (f *fakeLang) Name() string { return f.name }
+
+func (f *fakeLang) Parse(ctx context.Context, query string) (chplan.Node, engine.Meta, error) {
+	f.parseCalls++
+	if f.parseFn != nil {
+		return f.parseFn(ctx, query)
+	}
+	return &chplan.Scan{Table: "otel_metrics_gauge"}, engine.Meta{IsMetric: true, ResponseShape: "prom-vector"}, nil
+}
+
+func (f *fakeLang) ProjectSamples(plan chplan.Node, meta engine.Meta) chplan.Node {
+	f.projectCalls++
+	if f.projectFn != nil {
+		return f.projectFn(plan, meta)
+	}
+	return plan
+}
+
+// fakeQuerier captures the SQL the engine emitted and returns a fixed
+// row set. It also remembers how many times it was called so the
+// short-circuit tests can assert it was bypassed.
+type fakeQuerier struct {
+	rows    []chclient.Sample
+	err     error
+	gotSQL  string
+	gotArgs []any
+	calls   int
+}
+
+func (f *fakeQuerier) Query(_ context.Context, sql string, args ...any) ([]chclient.Sample, error) {
+	f.calls++
+	f.gotSQL = sql
+	f.gotArgs = args
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.rows, nil
+}
+
+func newEngine(q *fakeQuerier) *engine.Engine {
+	return &engine.Engine{
+		Optimizer: optimizer.Default(),
+		Client:    q,
+	}
+}
+
+func TestEngine_Query_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	rows := []chclient.Sample{
+		{MetricName: "up", Labels: map[string]string{"job": "a"}, Timestamp: time.Unix(1, 0), Value: 1},
+		{MetricName: "up", Labels: map[string]string{"job": "b"}, Timestamp: time.Unix(2, 0), Value: 0},
+	}
+	q := &fakeQuerier{rows: rows}
+	lang := &fakeLang{name: "promql"}
+	eng := newEngine(q)
+
+	res, err := eng.Query(context.Background(), lang, "up")
+	if err != nil {
+		t.Fatalf("Query: unexpected err: %v", err)
+	}
+
+	if got := len(res.Samples); got != 2 {
+		t.Errorf("Samples len: got %d, want 2", got)
+	}
+	if res.SQL == "" {
+		t.Errorf("SQL: empty, want non-empty emitted SQL")
+	}
+	if !strings.Contains(res.SQL, "otel_metrics_gauge") {
+		t.Errorf("SQL: missing scan table; got %q", res.SQL)
+	}
+	if got := res.PlanNodeCount; got != 1 {
+		t.Errorf("PlanNodeCount: got %d, want 1 (Scan only — fakeLang.ProjectSamples is identity)", got)
+	}
+	if res.Meta.ResponseShape != "prom-vector" {
+		t.Errorf("Meta.ResponseShape: got %q, want %q", res.Meta.ResponseShape, "prom-vector")
+	}
+	if !res.Meta.IsMetric {
+		t.Errorf("Meta.IsMetric: false, want true (threaded through from Parse)")
+	}
+	if res.CHMillis < 0 {
+		t.Errorf("CHMillis: got %d, want non-negative", res.CHMillis)
+	}
+
+	// Pipeline-stage call order: Parse fired once, ProjectSamples
+	// fired once, Querier.Query fired once.
+	if lang.parseCalls != 1 {
+		t.Errorf("Lang.Parse calls: got %d, want 1", lang.parseCalls)
+	}
+	if lang.projectCalls != 1 {
+		t.Errorf("Lang.ProjectSamples calls: got %d, want 1", lang.projectCalls)
+	}
+	if q.calls != 1 {
+		t.Errorf("Querier.Query calls: got %d, want 1", q.calls)
+	}
+}
+
+func TestEngine_QueryPlan_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	q := &fakeQuerier{rows: []chclient.Sample{{MetricName: "x"}}}
+	lang := &fakeLang{name: "traceql"}
+	eng := newEngine(q)
+
+	plan := &chplan.Scan{Table: "otel_traces"}
+	res, err := eng.QueryPlan(context.Background(), lang, plan, engine.Meta{ResponseShape: "tempo-traces"})
+	if err != nil {
+		t.Fatalf("QueryPlan: unexpected err: %v", err)
+	}
+	if lang.parseCalls != 0 {
+		t.Errorf("Lang.Parse calls: got %d, want 0 (QueryPlan bypasses parse)", lang.parseCalls)
+	}
+	if lang.projectCalls != 1 {
+		t.Errorf("Lang.ProjectSamples calls: got %d, want 1", lang.projectCalls)
+	}
+	if !strings.Contains(res.SQL, "otel_traces") {
+		t.Errorf("SQL: missing scan table; got %q", res.SQL)
+	}
+	if got := len(res.Samples); got != 1 {
+		t.Errorf("Samples len: got %d, want 1", got)
+	}
+}
+
+// TestEngine_QueryPlan_IsTraceByID_SkipsOptimizer verifies the
+// optimizer-skip branch through an observable side-effect: a custom
+// rule that rewrites every Scan into a different Scan only fires when
+// the optimizer runs. With IsTraceByID = true the engine must
+// short-circuit, so the post-pipeline SQL references the original
+// table; with the flag cleared, the rewritten table appears.
+func TestEngine_QueryPlan_IsTraceByID_SkipsOptimizer(t *testing.T) {
+	t.Parallel()
+
+	const originalTable = "otel_traces"
+	const rewrittenTable = "otel_traces_rewritten"
+
+	rewrite := optimizer.NewWithBatches(optimizer.Batch{
+		Name:     "test.scan-rewrite",
+		Strategy: optimizer.Once(),
+		Rules: []optimizer.Rule{
+			scanRewriteRule{from: originalTable, to: rewrittenTable},
+		},
+	})
+
+	t.Run("flag_set_skips_optimizer", func(t *testing.T) {
+		q := &fakeQuerier{}
+		eng := &engine.Engine{Optimizer: rewrite, Client: q}
+		lang := &fakeLang{name: "traceql"}
+
+		plan := &chplan.Scan{Table: originalTable}
+		res, err := eng.QueryPlan(context.Background(), lang, plan, engine.Meta{IsTraceByID: true})
+		if err != nil {
+			t.Fatalf("QueryPlan: unexpected err: %v", err)
+		}
+		if strings.Contains(res.SQL, rewrittenTable) {
+			t.Errorf("SQL: contains rewritten table %q; optimizer should have been skipped. SQL=%q",
+				rewrittenTable, res.SQL)
+		}
+		if !strings.Contains(res.SQL, originalTable) {
+			t.Errorf("SQL: missing original table %q; got %q", originalTable, res.SQL)
+		}
+	})
+
+	t.Run("flag_cleared_runs_optimizer", func(t *testing.T) {
+		q := &fakeQuerier{}
+		eng := &engine.Engine{Optimizer: rewrite, Client: q}
+		lang := &fakeLang{name: "traceql"}
+
+		plan := &chplan.Scan{Table: originalTable}
+		res, err := eng.QueryPlan(context.Background(), lang, plan, engine.Meta{IsTraceByID: false})
+		if err != nil {
+			t.Fatalf("QueryPlan: unexpected err: %v", err)
+		}
+		if !strings.Contains(res.SQL, rewrittenTable) {
+			t.Errorf("SQL: missing rewritten table %q; optimizer should have run. SQL=%q",
+				rewrittenTable, res.SQL)
+		}
+	})
+}
+
+func TestEngine_Query_ParseError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("syntax: unexpected token")
+	q := &fakeQuerier{}
+	lang := &fakeLang{
+		name: "promql",
+		parseFn: func(_ context.Context, _ string) (chplan.Node, engine.Meta, error) {
+			return nil, engine.Meta{}, wantErr
+		},
+	}
+	eng := newEngine(q)
+
+	_, err := eng.Query(context.Background(), lang, "garbage")
+	if err == nil {
+		t.Fatalf("Query: expected error, got nil")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Errorf("Query: err = %v, want wrap of %v", err, wantErr)
+	}
+	if !strings.Contains(err.Error(), "parse") {
+		t.Errorf("Query: err = %q, want prefix mentioning parse stage", err.Error())
+	}
+	if q.calls != 0 {
+		t.Errorf("Querier.Query: got %d calls, want 0 (parse failure must short-circuit)", q.calls)
+	}
+}
+
+func TestEngine_QueryPlan_EmitError(t *testing.T) {
+	t.Parallel()
+
+	q := &fakeQuerier{}
+	lang := &fakeLang{name: "promql"}
+	eng := newEngine(q)
+
+	// A Filter with a nil Predicate trips chsql.Emit (Builder.Expr
+	// hits its default branch and returns ErrUnsupported). The
+	// IsTraceByID flag is set so the optimizer pass doesn't see the
+	// invalid node — we want the failure to land at emit, not
+	// inside optimizer rules that don't tolerate nil predicates.
+	plan := &chplan.Filter{Input: &chplan.Scan{Table: "t"}, Predicate: nil}
+	_, err := eng.QueryPlan(context.Background(), lang, plan, engine.Meta{IsTraceByID: true})
+	if err == nil {
+		t.Fatalf("QueryPlan: expected emit error, got nil")
+	}
+	if !strings.Contains(err.Error(), "emit") {
+		t.Errorf("QueryPlan: err = %q, want prefix mentioning emit stage", err.Error())
+	}
+	if q.calls != 0 {
+		t.Errorf("Querier.Query: got %d calls, want 0 (emit failure must short-circuit)", q.calls)
+	}
+}
+
+func TestEngine_QueryPlan_ExecuteError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("clickhouse: connection refused")
+	q := &fakeQuerier{err: wantErr}
+	lang := &fakeLang{name: "promql"}
+	eng := newEngine(q)
+
+	plan := &chplan.Scan{Table: "otel_metrics_gauge"}
+	_, err := eng.QueryPlan(context.Background(), lang, plan, engine.Meta{})
+	if err == nil {
+		t.Fatalf("QueryPlan: expected execute error, got nil")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Errorf("QueryPlan: err = %v, want wrap of %v", err, wantErr)
+	}
+	if !strings.Contains(err.Error(), "execute") {
+		t.Errorf("QueryPlan: err = %q, want prefix mentioning execute stage", err.Error())
+	}
+}
+
+func TestEngine_Query_NilLang(t *testing.T) {
+	t.Parallel()
+
+	eng := newEngine(&fakeQuerier{})
+	if _, err := eng.Query(context.Background(), nil, "x"); err == nil {
+		t.Errorf("Query(nil lang): expected error")
+	}
+	if _, err := eng.QueryPlan(context.Background(), nil, &chplan.Scan{Table: "t"}, engine.Meta{}); err == nil {
+		t.Errorf("QueryPlan(nil lang): expected error")
+	}
+}
+
+func TestEngine_QueryPlan_NilPlan(t *testing.T) {
+	t.Parallel()
+
+	eng := newEngine(&fakeQuerier{})
+	lang := &fakeLang{name: "promql"}
+	if _, err := eng.QueryPlan(context.Background(), lang, nil, engine.Meta{}); err == nil {
+		t.Errorf("QueryPlan(nil plan): expected error")
+	}
+}
+
+// scanRewriteRule is a probe rule for the IsTraceByID test: it
+// rewrites every Scan whose Table equals `from` into a Scan against
+// `to`. We use a real optimizer pass with just this rule so the test
+// can observe whether the engine ran the optimizer.
+type scanRewriteRule struct {
+	from, to string
+}
+
+func (scanRewriteRule) Name() string { return "test.scan-rewrite" }
+
+func (r scanRewriteRule) Apply(n chplan.Node) (chplan.Node, bool) {
+	scan, ok := n.(*chplan.Scan)
+	if !ok || scan.Table != r.from {
+		return n, false
+	}
+	return &chplan.Scan{Table: r.to, Columns: scan.Columns}, true
+}


### PR DESCRIPTION
## Summary

Introduces `internal/engine` — the shared pipeline orchestrator the prom / loki / tempo handlers will plug into next. The package owns the `parse → wrap-projection → optimize → emit → execute` loop and exposes two entry points (`Engine.Query` for the full pipeline, `Engine.QueryPlan` for the Tempo /traces/{id}-style plan-built-by-hand path). Per-language differences live behind `Lang` (`Name`, `Parse`, `ProjectSamples`); `Meta` carries the semantic flags the engine cannot infer from the plan (`IsMetric` / `IsTraceByID` / `ResponseShape` / `Extra`); `Result` carries samples + SQL + args + CH wall-clock millis + plan-node count + the threaded `Meta`.

Pure scaffolding — no handler is touched. Existing `prom/handler.go`, `loki/handler.go`, `tempo/handler.go` continue to orchestrate the pipeline directly until the per-head port milestones rewrite them against `Engine`.

## What's interesting

- **`Meta.IsTraceByID` short-circuits the optimizer pass.** A row-by-id fetch has no rewrites worth running and skipping the pass keeps the span tree flat — observable via a probe rule in the tests.
- **Progress-context key comes from `Lang.Name()`.** `cerberus.clickhouse.{rows,bytes}_read` histograms keep their per-head labels without the engine knowing any QL.
- **Errors wrap with the stage name** (`engine: parse: …` / `engine: emit: …` / `engine: execute: …`) so callers can `errors.Is` / `errors.As` to classify into bad-data / internal / bad-gateway.
- **`Querier` interface is intentionally narrow** — just `Query`. Streaming / strings / label-set callers stay against the handler's own broader Querier until the cursor entry point lands.

## Test plan

- [x] `go test ./internal/engine/...` — 8 test funcs / 10 subtests, all green
- [x] Happy path: `fakeLang` returns a `Scan`, `Result` carries 2 rows + non-empty SQL referencing the scan table + `PlanNodeCount == 1` + threaded `Meta.IsMetric` + `Meta.ResponseShape`
- [x] `QueryPlan` happy path: `parseCalls == 0` (bypass), `projectCalls == 1`
- [x] `IsTraceByID` skip-optimizer branch verified via a probe rule that rewrites `Scan{Table: X}` → `Scan{Table: X_rewritten}`; with the flag set the SQL contains the original table, with the flag cleared the SQL contains the rewritten table
- [x] Parse-error / emit-error / execute-error propagation each surface as a wrapped error with the stage name in the message
- [x] Nil-lang + nil-plan guards return an error

## Follow-ups

The handler-level ports (RC7 R7.2 prom / R7.3 loki / R7.4 tempo) consume this scaffolding; they're scoped as separate PRs per the [engine evaluation doc](https://github.com/tsouza/cerberus/blob/main/docs/engine-evaluation.md#phasing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)