### PR TITLE
refactor(api): extract internal/api/httperr/ for shared error helpers (RC7 R7.6)

### DIFF
--- a/internal/api/httperr/httperr.go
+++ b/internal/api/httperr/httperr.go
@@ -1,0 +1,59 @@
+// Package httperr provides the shared HTTP-error primitives used by the
+// prom / loki / tempo handlers.
+//
+// Each upstream API has its own JSON error envelope (Prom and Loki share
+// `{status, errorType, error}`; Tempo uses `{traceID, spanID, error,
+// message}`), so envelope shaping stays per-handler. What this package
+// owns is the typed [Error] carrier that handlers raise through their
+// internal call graph and the byte-identical [WriteJSON] response
+// writer. The per-handler `respondError` shims unwrap [*Error] via
+// [errors.As] and pass the status / kind / message into their own
+// envelope-shaping helper.
+//
+// Design choice: this package intentionally does NOT own a generic
+// `RespondError` that picks an envelope based on a flag, because the
+// envelope is a wire-format invariant — Grafana parses each shape
+// directly — and bundling all three shapes into one helper would force
+// every handler to import a struct that only one of them uses.
+package httperr
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// Error carries an HTTP status code plus a machine-parsable error-type
+// string (Prom-vocabulary: "bad_data", "execution", "internal", ...)
+// through a handler's internal error path. Handlers raise it from
+// validation / execution helpers; the top-level respondError shim
+// extracts it via [errors.As].
+//
+// The zero value is not useful; callers always construct a pointer
+// literal: `&httperr.Error{Status: 400, Kind: ErrBadData, Err: err}`.
+type Error struct {
+	// Status is the HTTP status code to send (e.g. http.StatusBadRequest).
+	Status int
+	// Kind is the upstream-API error-type string. Prom and Loki use the
+	// same vocabulary ("bad_data", "execution", "internal", "timeout",
+	// "canceled"); Tempo doesn't surface a kind so callers pass "".
+	Kind string
+	// Err is the underlying error. Required.
+	Err error
+}
+
+// Error implements the error interface.
+func (e *Error) Error() string { return e.Err.Error() }
+
+// Unwrap exposes the underlying error so callers can use
+// [errors.Is] / [errors.As] across the boundary.
+func (e *Error) Unwrap() error { return e.Err }
+
+// WriteJSON writes `body` as JSON with the given HTTP status. The
+// Content-Type is set to `application/json` before WriteHeader, and the
+// encoder's error is intentionally discarded — at that point the status
+// is already on the wire and there's nothing the caller can do.
+func WriteJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}

--- a/internal/api/httperr/httperr_test.go
+++ b/internal/api/httperr/httperr_test.go
@@ -1,0 +1,86 @@
+package httperr_test
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/api/httperr"
+)
+
+// TestError_ErrorAndUnwrap — *Error.Error() returns the wrapped
+// message, and Unwrap exposes the underlying error so errors.As works
+// across a wrapping boundary.
+func TestError_ErrorAndUnwrap(t *testing.T) {
+	t.Parallel()
+
+	inner := errors.New("boom")
+	e := &httperr.Error{Status: http.StatusBadRequest, Kind: "bad_data", Err: inner}
+
+	if got := e.Error(); got != "boom" {
+		t.Errorf("Error(): got %q, want %q", got, "boom")
+	}
+	if got := errors.Unwrap(e); got != inner {
+		t.Errorf("Unwrap(): got %v, want %v", got, inner)
+	}
+
+	// errors.As through a wrapping fmt.Errorf chain.
+	wrapped := fmt.Errorf("context: %w", e)
+	var asErr *httperr.Error
+	if !errors.As(wrapped, &asErr) {
+		t.Fatalf("errors.As: did not match *Error in wrapped chain")
+	}
+	if asErr.Status != http.StatusBadRequest || asErr.Kind != "bad_data" {
+		t.Errorf("recovered Error fields: got status=%d kind=%q, want 400/bad_data",
+			asErr.Status, asErr.Kind)
+	}
+}
+
+// TestWriteJSON_ShapeAndHeader — WriteJSON sets Content-Type before the
+// status line, writes the status, and emits the body using the standard
+// JSON encoder (which terminates with a newline).
+func TestWriteJSON_ShapeAndHeader(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	httperr.WriteJSON(rec, http.StatusTeapot, map[string]any{
+		"status": "error", "errorType": "bad_data", "error": "nope",
+	})
+
+	res := rec.Result()
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusTeapot {
+		t.Fatalf("status: got %d, want %d", res.StatusCode, http.StatusTeapot)
+	}
+	if ct := res.Header.Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type: got %q, want application/json", ct)
+	}
+
+	var body map[string]any
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["status"] != "error" || body["errorType"] != "bad_data" || body["error"] != "nope" {
+		t.Errorf("body: %+v", body)
+	}
+}
+
+// TestWriteJSON_TrailingNewline — json.Encoder.Encode appends a "\n";
+// the existing handler-side snapshots depend on that, so lock it in.
+func TestWriteJSON_TrailingNewline(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	httperr.WriteJSON(rec, http.StatusOK, struct {
+		OK bool `json:"ok"`
+	}{OK: true})
+
+	if !strings.HasSuffix(rec.Body.String(), "\n") {
+		t.Errorf("body: missing trailing newline, got %q", rec.Body.String())
+	}
+}

--- a/internal/api/loki/detected_fields.go
+++ b/internal/api/loki/detected_fields.go
@@ -87,7 +87,7 @@ func (h *Handler) handleDetectedFields(w http.ResponseWriter, r *http.Request) {
 
 	sqlStr, args, err := buildDetectedFieldsSQL(h.Schema, matchers, start, end, lineLimit)
 	if err != nil {
-		h.respondError(w, &apiError{kind: ErrInternal, err: err, status: http.StatusInternalServerError})
+		h.respondError(w, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusInternalServerError})
 		return
 	}
 	h.Logger.Debug("cerberus loki detected_fields", "logql", q, "sql", sqlStr, "args", args)
@@ -95,7 +95,7 @@ func (h *Handler) handleDetectedFields(w http.ResponseWriter, r *http.Request) {
 	lines, err := h.Client.QueryStrings(r.Context(), sqlStr, args...)
 	if err != nil {
 		h.Logger.Error("cerberus loki detected_fields CH query failed", "err", err, "sql", sqlStr)
-		h.respondError(w, &apiError{kind: ErrInternal, err: err, status: http.StatusBadGateway})
+		h.respondError(w, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusBadGateway})
 		return
 	}
 

--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -2,7 +2,6 @@ package loki
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"log/slog"
 	"net/http"
@@ -16,6 +15,7 @@ import (
 
 	"github.com/tsouza/cerberus/internal/api/admit"
 	"github.com/tsouza/cerberus/internal/api/format"
+	"github.com/tsouza/cerberus/internal/api/httperr"
 	"github.com/tsouza/cerberus/internal/cerbtrace"
 	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/chplan"
@@ -229,7 +229,7 @@ func (h *Handler) execute(ctx context.Context, expr syntax.Expr) ([]chclient.Sam
 	plan, err := logql.Lower(ctx, expr, h.Schema)
 	lowerT.Done(ctx)
 	if err != nil {
-		return nil, &apiError{kind: ErrExecution, err: err, status: http.StatusUnprocessableEntity}
+		return nil, &apiError{Kind: ErrExecution, Err: err, Status: http.StatusUnprocessableEntity}
 	}
 
 	plan = wrapWithLogSampleProjection(plan, h.Schema, expr)
@@ -241,7 +241,7 @@ func (h *Handler) execute(ctx context.Context, expr syntax.Expr) ([]chclient.Sam
 	sqlStr, args, err := chsql.Emit(ctx, plan)
 	emitT.Done(ctx)
 	if err != nil {
-		return nil, &apiError{kind: ErrInternal, err: err, status: http.StatusInternalServerError}
+		return nil, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusInternalServerError}
 	}
 	h.Logger.Debug("cerberus loki query", "logql", expr.String(), "sql", sqlStr, "args", args)
 
@@ -250,7 +250,7 @@ func (h *Handler) execute(ctx context.Context, expr syntax.Expr) ([]chclient.Sam
 	execT.Done(ctx)
 	if err != nil {
 		h.Logger.Error("cerberus loki CH query failed", "err", err, "sql", sqlStr)
-		return nil, &apiError{kind: ErrInternal, err: err, status: http.StatusBadGateway}
+		return nil, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusBadGateway}
 	}
 	return samples, nil
 }
@@ -329,7 +329,7 @@ func buildInstantData(expr syntax.Expr, samples []chclient.Sample, ts time.Time,
 	}
 	tx, err := postProcessExtract(expr)
 	if err != nil {
-		return nil, &apiError{kind: ErrBadData, err: err, status: http.StatusBadRequest}
+		return nil, &apiError{Kind: ErrBadData, Err: err, Status: http.StatusBadRequest}
 	}
 	return &QueryData{
 		ResultType: "streams",
@@ -349,7 +349,7 @@ func buildRangeData(expr syntax.Expr, samples []chclient.Sample, start, end time
 	}
 	tx, err := postProcessExtract(expr)
 	if err != nil {
-		return nil, &apiError{kind: ErrBadData, err: err, status: http.StatusBadRequest}
+		return nil, &apiError{Kind: ErrBadData, Err: err, Status: http.StatusBadRequest}
 	}
 	return &QueryData{
 		ResultType: "streams",
@@ -479,34 +479,31 @@ func toStreamsWithTransform(samples []chclient.Sample, tx lineTransform) []Strea
 	return out
 }
 
-// apiError carries the Loki errorType + an HTTP status code through the
-// internal error path.
-type apiError struct {
-	kind   string
-	err    error
-	status int
-}
-
-func (e *apiError) Error() string { return e.err.Error() }
-func (e *apiError) Unwrap() error { return e.err }
+// apiError is a package-local alias for the shared [httperr.Error]
+// carrier so the existing in-package callsites can stay literal.
+type apiError = httperr.Error
 
 func (h *Handler) respondError(w http.ResponseWriter, err error) {
 	var apiErr *apiError
 	if errors.As(err, &apiErr) {
-		writeError(w, apiErr.status, apiErr.kind, apiErr.err)
+		writeError(w, apiErr.Status, apiErr.Kind, apiErr.Err)
 		return
 	}
 	writeError(w, http.StatusInternalServerError, ErrInternal, err)
 }
 
+// writeJSON wraps [httperr.WriteJSON] so package-local callsites stay
+// unqualified. The shared helper handles Content-Type + status + body
+// encoding identically across all three handlers.
 func writeJSON(w http.ResponseWriter, status int, body any) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(body)
+	httperr.WriteJSON(w, status, body)
 }
 
+// writeError emits the Loki JSON envelope `{status, errorType, error}`.
+// Loki and Prom share the same wire format here; the envelope is still
+// shaped per-handler so each package owns its own `Response` type.
 func writeError(w http.ResponseWriter, status int, kind string, err error) {
-	writeJSON(w, status, Response{
+	httperr.WriteJSON(w, status, Response{
 		Status:    "error",
 		ErrorType: kind,
 		Error:     err.Error(),

--- a/internal/api/loki/index_stats.go
+++ b/internal/api/loki/index_stats.go
@@ -55,7 +55,7 @@ func (h *Handler) handleIndexStats(w http.ResponseWriter, r *http.Request) {
 
 	sqlStr, args, err := buildIndexStatsSQL(h.Schema, matchers, start, end)
 	if err != nil {
-		h.respondError(w, &apiError{kind: ErrInternal, err: err, status: http.StatusInternalServerError})
+		h.respondError(w, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusInternalServerError})
 		return
 	}
 	h.Logger.Debug("cerberus loki index_stats", "logql", q, "sql", sqlStr, "args", args)
@@ -63,7 +63,7 @@ func (h *Handler) handleIndexStats(w http.ResponseWriter, r *http.Request) {
 	row, err := h.Client.QueryIndexStats(r.Context(), sqlStr, args...)
 	if err != nil {
 		h.Logger.Error("cerberus loki index_stats CH query failed", "err", err, "sql", sqlStr)
-		h.respondError(w, &apiError{kind: ErrInternal, err: err, status: http.StatusBadGateway})
+		h.respondError(w, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusBadGateway})
 		return
 	}
 

--- a/internal/api/loki/index_volume.go
+++ b/internal/api/loki/index_volume.go
@@ -63,7 +63,7 @@ func (h *Handler) handleIndexVolume(w http.ResponseWriter, r *http.Request) {
 
 	sqlStr, args, err := buildIndexVolumeSQL(h.Schema, matchers, start, end, limit, targetLabels, aggregateBy)
 	if err != nil {
-		h.respondError(w, &apiError{kind: ErrInternal, err: err, status: http.StatusInternalServerError})
+		h.respondError(w, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusInternalServerError})
 		return
 	}
 	h.Logger.Debug("cerberus loki index_volume", "logql", q, "sql", sqlStr, "args", args)
@@ -71,7 +71,7 @@ func (h *Handler) handleIndexVolume(w http.ResponseWriter, r *http.Request) {
 	rows, err := h.Client.QueryIndexVolume(r.Context(), sqlStr, args...)
 	if err != nil {
 		h.Logger.Error("cerberus loki index_volume CH query failed", "err", err, "sql", sqlStr)
-		h.respondError(w, &apiError{kind: ErrInternal, err: err, status: http.StatusBadGateway})
+		h.respondError(w, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusBadGateway})
 		return
 	}
 

--- a/internal/api/loki/label_values.go
+++ b/internal/api/loki/label_values.go
@@ -47,7 +47,7 @@ func (h *Handler) handleLabelValues(w http.ResponseWriter, r *http.Request) {
 
 	sqlStr, args, err := buildLabelValuesSQL(h.Schema, name, matchers, start, end)
 	if err != nil {
-		h.respondError(w, &apiError{kind: ErrInternal, err: err, status: http.StatusInternalServerError})
+		h.respondError(w, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusInternalServerError})
 		return
 	}
 	h.Logger.Debug("cerberus loki label values", "name", name, "sql", sqlStr, "args", args)
@@ -55,7 +55,7 @@ func (h *Handler) handleLabelValues(w http.ResponseWriter, r *http.Request) {
 	vals, err := h.Client.QueryStrings(r.Context(), sqlStr, args...)
 	if err != nil {
 		h.Logger.Error("cerberus loki label values CH query failed", "err", err, "sql", sqlStr)
-		h.respondError(w, &apiError{kind: ErrInternal, err: err, status: http.StatusBadGateway})
+		h.respondError(w, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusBadGateway})
 		return
 	}
 

--- a/internal/api/loki/labels.go
+++ b/internal/api/loki/labels.go
@@ -42,7 +42,7 @@ func (h *Handler) handleLabels(w http.ResponseWriter, r *http.Request) {
 
 	sqlStr, args, err := buildLabelsSQL(h.Schema, matchers, start, end)
 	if err != nil {
-		h.respondError(w, &apiError{kind: ErrInternal, err: err, status: http.StatusInternalServerError})
+		h.respondError(w, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusInternalServerError})
 		return
 	}
 	h.Logger.Debug("cerberus loki labels", "sql", sqlStr, "args", args)
@@ -50,7 +50,7 @@ func (h *Handler) handleLabels(w http.ResponseWriter, r *http.Request) {
 	vals, err := h.Client.QueryStrings(r.Context(), sqlStr, args...)
 	if err != nil {
 		h.Logger.Error("cerberus loki labels CH query failed", "err", err, "sql", sqlStr)
-		h.respondError(w, &apiError{kind: ErrInternal, err: err, status: http.StatusBadGateway})
+		h.respondError(w, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusBadGateway})
 		return
 	}
 

--- a/internal/api/loki/series.go
+++ b/internal/api/loki/series.go
@@ -56,7 +56,7 @@ func (h *Handler) handleSeries(w http.ResponseWriter, r *http.Request) {
 
 	sqlStr, args, err := buildSeriesSQL(h.Schema, selectorGroups, start, end)
 	if err != nil {
-		h.respondError(w, &apiError{kind: ErrInternal, err: err, status: http.StatusInternalServerError})
+		h.respondError(w, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusInternalServerError})
 		return
 	}
 	h.Logger.Debug("cerberus loki series", "selectors", len(selectorGroups), "sql", sqlStr, "args", args)
@@ -64,7 +64,7 @@ func (h *Handler) handleSeries(w http.ResponseWriter, r *http.Request) {
 	rows, err := h.Client.QueryLabelSets(r.Context(), sqlStr, args...)
 	if err != nil {
 		h.Logger.Error("cerberus loki series CH query failed", "err", err, "sql", sqlStr)
-		h.respondError(w, &apiError{kind: ErrInternal, err: err, status: http.StatusBadGateway})
+		h.respondError(w, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusBadGateway})
 		return
 	}
 

--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -2,7 +2,6 @@ package prom
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -16,6 +15,7 @@ import (
 
 	"github.com/tsouza/cerberus/internal/api/admit"
 	"github.com/tsouza/cerberus/internal/api/format"
+	"github.com/tsouza/cerberus/internal/api/httperr"
 	"github.com/tsouza/cerberus/internal/cerbtrace"
 	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/chplan"
@@ -254,7 +254,7 @@ func (h *Handler) handleQueryRange(w http.ResponseWriter, r *http.Request) {
 
 	result, err := matrixFromCursor(cursor, start, end, step)
 	if err != nil {
-		h.respondError(w, &apiError{kind: ErrInternal, err: err, status: http.StatusBadGateway})
+		h.respondError(w, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusBadGateway})
 		return
 	}
 	writeJSON(w, http.StatusOK, Response{
@@ -271,7 +271,7 @@ func (h *Handler) handleQueryRange(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) tryScalarFold(ctx context.Context, query string) (float64, bool, error) {
 	expr, err := h.parseExpr(ctx, query)
 	if err != nil {
-		return 0, false, &apiError{kind: ErrBadData, err: err, status: http.StatusBadRequest}
+		return 0, false, &apiError{Kind: ErrBadData, Err: err, Status: http.StatusBadRequest}
 	}
 	val, ok := promql.TryFoldScalar(expr)
 	return val, ok, nil
@@ -330,13 +330,13 @@ func (h *Handler) executeRangeStreaming(
 	expr, err := h.parseExpr(ctx, query)
 	parseT.Done(ctx)
 	if err != nil {
-		return nil, &apiError{kind: ErrBadData, err: err, status: http.StatusBadRequest}
+		return nil, &apiError{Kind: ErrBadData, Err: err, Status: http.StatusBadRequest}
 	}
 	lowerT := telemetry.ObserveStage(telemetry.StageLower)
 	plan, err := promql.LowerAt(ctx, expr, h.Schema, start, end)
 	lowerT.Done(ctx)
 	if err != nil {
-		return nil, &apiError{kind: ErrExecution, err: err, status: http.StatusUnprocessableEntity}
+		return nil, &apiError{Kind: ErrExecution, Err: err, Status: http.StatusUnprocessableEntity}
 	}
 
 	plan = wrapWithSampleProjection(plan, h.Schema)
@@ -348,7 +348,7 @@ func (h *Handler) executeRangeStreaming(
 	sql, args, err := chsql.Emit(ctx, plan)
 	emitT.Done(ctx)
 	if err != nil {
-		return nil, &apiError{kind: ErrInternal, err: err, status: http.StatusInternalServerError}
+		return nil, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusInternalServerError}
 	}
 	h.Logger.Debug("cerberus query_range (stream)", "promql", query, "sql", sql, "args", args)
 
@@ -358,7 +358,7 @@ func (h *Handler) executeRangeStreaming(
 	})
 	execT.Done(ctx)
 	if err != nil {
-		return nil, &apiError{kind: ErrInternal, err: err, status: http.StatusBadGateway}
+		return nil, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusBadGateway}
 	}
 	return cursor, nil
 }
@@ -375,13 +375,13 @@ func (h *Handler) executeInstant(ctx context.Context, query string, start, end t
 	expr, err := h.parseExpr(ctx, query)
 	parseT.Done(ctx)
 	if err != nil {
-		return nil, &apiError{kind: ErrBadData, err: err, status: http.StatusBadRequest}
+		return nil, &apiError{Kind: ErrBadData, Err: err, Status: http.StatusBadRequest}
 	}
 	lowerT := telemetry.ObserveStage(telemetry.StageLower)
 	plan, err := promql.LowerAt(ctx, expr, h.Schema, start, end)
 	lowerT.Done(ctx)
 	if err != nil {
-		return nil, &apiError{kind: ErrExecution, err: err, status: http.StatusUnprocessableEntity}
+		return nil, &apiError{Kind: ErrExecution, Err: err, Status: http.StatusUnprocessableEntity}
 	}
 
 	plan = wrapWithSampleProjection(plan, h.Schema)
@@ -393,7 +393,7 @@ func (h *Handler) executeInstant(ctx context.Context, query string, start, end t
 	sql, args, err := chsql.Emit(ctx, plan)
 	emitT.Done(ctx)
 	if err != nil {
-		return nil, &apiError{kind: ErrInternal, err: err, status: http.StatusInternalServerError}
+		return nil, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusInternalServerError}
 	}
 	h.Logger.Debug("cerberus query", "promql", query, "sql", sql, "args", args)
 
@@ -403,7 +403,7 @@ func (h *Handler) executeInstant(ctx context.Context, query string, start, end t
 	})
 	execT.Done(ctx)
 	if err != nil {
-		return nil, &apiError{kind: ErrInternal, err: err, status: http.StatusBadGateway}
+		return nil, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusBadGateway}
 	}
 	return samples, nil
 }
@@ -594,34 +594,31 @@ func matrixFromCursor(
 	return out, nil
 }
 
-// apiError carries the Prom errorType + an HTTP status code through the
-// internal error path.
-type apiError struct {
-	kind   string
-	err    error
-	status int
-}
-
-func (e *apiError) Error() string { return e.err.Error() }
-func (e *apiError) Unwrap() error { return e.err }
+// apiError is a package-local alias for the shared [httperr.Error]
+// carrier so the existing in-package callsites can stay literal.
+type apiError = httperr.Error
 
 func (h *Handler) respondError(w http.ResponseWriter, err error) {
 	var apiErr *apiError
 	if errors.As(err, &apiErr) {
-		writeError(w, apiErr.status, apiErr.kind, apiErr.err)
+		writeError(w, apiErr.Status, apiErr.Kind, apiErr.Err)
 		return
 	}
 	writeError(w, http.StatusInternalServerError, ErrInternal, err)
 }
 
+// writeJSON wraps [httperr.WriteJSON] so package-local callsites stay
+// unqualified. The shared helper handles Content-Type + status + body
+// encoding identically across all three handlers.
 func writeJSON(w http.ResponseWriter, status int, body any) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(body)
+	httperr.WriteJSON(w, status, body)
 }
 
+// writeError emits the Prom JSON envelope `{status, errorType, error}`.
+// The envelope shape is wire-format invariant — Grafana parses it
+// directly — so it stays per-handler rather than living in httperr.
 func writeError(w http.ResponseWriter, status int, kind string, err error) {
-	writeJSON(w, status, Response{
+	httperr.WriteJSON(w, status, Response{
 		Status:    "error",
 		ErrorType: kind,
 		Error:     err.Error(),

--- a/internal/api/prom/metadata.go
+++ b/internal/api/prom/metadata.go
@@ -152,7 +152,7 @@ func (h *Handler) fetchMetricMeta(ctx context.Context, metricName string) ([]chc
 		sql, args := h.metricMetaSQL(spec.table, metricName)
 		rows, err := h.Client.QueryMetricMeta(ctx, sql, spec.kind, args...)
 		if err != nil {
-			return nil, &apiError{kind: ErrInternal, err: err, status: http.StatusBadGateway}
+			return nil, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusBadGateway}
 		}
 		out = append(out, rows...)
 	}
@@ -270,7 +270,7 @@ func (h *Handler) fetchLabelNames(ctx context.Context) ([]string, error) {
 		return h.Client.QueryStrings(ctx, sql)
 	})
 	if err != nil {
-		return nil, &apiError{kind: ErrInternal, err: err, status: http.StatusBadGateway}
+		return nil, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusBadGateway}
 	}
 	out := append([]string{model.MetricNameLabel}, names...)
 	sort.Strings(out)
@@ -284,7 +284,7 @@ func (h *Handler) fetchLabelValues(ctx context.Context, name string) ([]string, 
 			return h.Client.QueryStrings(ctx, sql)
 		})
 		if err != nil {
-			return nil, &apiError{kind: ErrInternal, err: err, status: http.StatusBadGateway}
+			return nil, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusBadGateway}
 		}
 		sort.Strings(values)
 		return values, nil
@@ -294,7 +294,7 @@ func (h *Handler) fetchLabelValues(ctx context.Context, name string) ([]string, 
 		return h.Client.QueryStrings(ctx, sql, args...)
 	})
 	if err != nil {
-		return nil, &apiError{kind: ErrInternal, err: err, status: http.StatusBadGateway}
+		return nil, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusBadGateway}
 	}
 	sort.Strings(values)
 	return values, nil
@@ -404,16 +404,16 @@ func (h *Handler) labelValuesForMatcher(ctx context.Context, name, matcher strin
 func (h *Handler) matcherSQL(ctx context.Context, matcher string) (string, []any, error) {
 	expr, err := h.parseExpr(ctx, matcher)
 	if err != nil {
-		return "", nil, &apiError{kind: ErrBadData, err: err, status: http.StatusBadRequest}
+		return "", nil, &apiError{Kind: ErrBadData, Err: err, Status: http.StatusBadRequest}
 	}
 	plan, err := promql.Lower(ctx, expr, h.Schema)
 	if err != nil {
-		return "", nil, &apiError{kind: ErrBadData, err: err, status: http.StatusBadRequest}
+		return "", nil, &apiError{Kind: ErrBadData, Err: err, Status: http.StatusBadRequest}
 	}
 	plan = h.Optimizer.Run(ctx, plan)
 	sql, args, err := chsql.Emit(ctx, plan)
 	if err != nil {
-		return "", nil, &apiError{kind: ErrInternal, err: err, status: http.StatusInternalServerError}
+		return "", nil, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusInternalServerError}
 	}
 	return sql, args, nil
 }

--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -2,7 +2,6 @@ package tempo
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -16,6 +15,7 @@ import (
 
 	"github.com/tsouza/cerberus/internal/api/admit"
 	"github.com/tsouza/cerberus/internal/api/format"
+	"github.com/tsouza/cerberus/internal/api/httperr"
 	"github.com/tsouza/cerberus/internal/cerbtrace"
 	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/chplan"
@@ -276,9 +276,7 @@ func (h *Handler) handleTraceByID(w http.ResponseWriter, r *http.Request) {
 	}
 	if len(samples) == 0 {
 		// Tempo's "trace not found" shape — Grafana renders the right UI.
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusNotFound)
-		_ = json.NewEncoder(w).Encode(ErrorResponse{
+		writeJSON(w, http.StatusNotFound, ErrorResponse{
 			TraceID: traceID, SpanID: "", Error: true,
 			Message: fmt.Sprintf("trace not found: %s", traceID),
 		})
@@ -488,16 +486,20 @@ func groupBatches(samples []chclient.Sample) []ResourceSpans {
 	return out
 }
 
+// writeJSON wraps [httperr.WriteJSON] so package-local callsites stay
+// unqualified. The shared helper handles Content-Type + status + body
+// encoding identically across all three handlers.
 func writeJSON(w http.ResponseWriter, status int, body any) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(body)
+	httperr.WriteJSON(w, status, body)
 }
 
-// writeError returns Tempo's distinct error shape so Grafana renders
-// the right UI (vs generic JSON error).
+// writeError emits Tempo's distinct error envelope
+// `{traceID, spanID, error, message}` (vs Prom's
+// `{status, errorType, error}`) so Grafana renders the right UI. The
+// envelope shape is wire-format invariant — it stays per-handler rather
+// than living in httperr.
 func writeError(w http.ResponseWriter, status int, traceID, spanID string, err error) {
-	writeJSON(w, status, ErrorResponse{
+	httperr.WriteJSON(w, status, ErrorResponse{
 		TraceID: traceID, SpanID: spanID, Error: true,
 		Message: err.Error(),
 	})


### PR DESCRIPTION
## Summary

Consolidate the four near-identical HTTP error-handling helpers that lived in each handler (`prom`, `loki`, `tempo`) into a new shared package `internal/api/httperr/`.

R7.0's `docs/engine-evaluation.md` flagged this as a duplicate-code site: `apiError`, `writeJSON`, `writeError`, `respondError` were each copy-pasted across all three handlers.

## What moved

- **`httperr.Error`** — the typed carrier (Status / Kind / Err) that handlers raise through their internal call graph. Same shape that was previously copy-pasted three times. Each handler now aliases it locally (`type apiError = httperr.Error`) so the ~34 existing literal callsites stay readable.
- **`httperr.WriteJSON`** — the byte-identical JSON response writer (Content-Type + status + encoder). Previously copy-pasted three times.

## What stayed per-handler (by design)

- **`writeError`** — the Prom/Loki envelope is `{status, errorType, error}`; Tempo's is `{traceID, spanID, error, message}`. Wire-format invariant — Grafana parses each shape directly — so each handler keeps a thin shim around `httperr.WriteJSON` that types its own `Response` / `ErrorResponse` envelope. Bundling all three shapes behind a flag would obscure the contract.
- **`respondError`** — Prom + Loki only. Unwraps `*httperr.Error` via `errors.As` and falls back to 500. Tempo doesn't have one (its error path threads traceID / spanID directly into `writeError`).

## Numbers

- `internal/api/httperr/httperr.go` — 59 LoC (incl. doc comments).
- `internal/api/httperr/httperr_test.go` — 86 LoC (Error wrapping/unwrap, WriteJSON status/header/body shape, trailing newline).
- Diff stat: +219 / −76 across 12 files (net +143; the new test file is most of that).
- Sites consolidated: 2 fully (`apiError` struct × 3, `writeJSON` body × 3), 2 left as per-API shims (`writeError`, `respondError`) as called out in the R7.0 audit (\"Tempo keeps a thin handler-side shim for its distinct envelope\").

## Coordination

- Independent of R7.1 (engine scaffolding) — engine returns `Result`, error handling stays in handlers.
- Independent of R7.5 (format extraction) — different package, no conflict.

## Test plan

- [x] `go test ./internal/api/httperr/...` — new unit tests for `Error` wrap/unwrap (incl. `errors.As` through `fmt.Errorf("%w")`), `WriteJSON` Content-Type, status code, body decode, and trailing newline lock-in.
- [x] `go test ./internal/api/{prom,loki,tempo}/...` — all existing handler tests (incl. `handler_error_paths_test.go` in each) pass byte-identical against the per-handler envelope shape.
- [x] `go build ./...` clean.
- [ ] CI `check` + `lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)