### PR TITLE
refactor(api/prom): port to engine.Engine (RC7 R7.2)

### DIFF
--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/tsouza/cerberus/internal/api/tempo"
 	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/config"
+	"github.com/tsouza/cerberus/internal/engine"
 	"github.com/tsouza/cerberus/internal/schema/ddl"
 	"github.com/tsouza/cerberus/internal/telemetry"
 )
@@ -143,7 +144,12 @@ func run() error {
 	// the route.
 	traceMux := http.NewServeMux()
 
+	// Prom is the first head ported to the shared engine.Engine
+	// pipeline (RC7 R7.2); the engine is constructed below from the
+	// shared Client + a seed optimizer and assigned onto the handler.
+	// Loki + Tempo follow as RC7 R7.3 / R7.4 ports.
 	promHandler := prom.New(client, cfg.Schema, logger.With("api", "prom"))
+	promHandler.Engine = &engine.Engine{Optimizer: promHandler.Optimizer, Client: client}
 	promHandler.Limiter = promLimiter
 	promHandler.Mount(traceMux)
 

--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -19,7 +19,7 @@ import (
 	"github.com/tsouza/cerberus/internal/cerbtrace"
 	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/chplan"
-	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/engine"
 	"github.com/tsouza/cerberus/internal/optimizer"
 	"github.com/tsouza/cerberus/internal/promql"
 	"github.com/tsouza/cerberus/internal/schema"
@@ -44,8 +44,13 @@ type Querier interface {
 // Handler implements the Prometheus HTTP API endpoints cerberus speaks.
 // Mount it via Handler.Mount(mux).
 type Handler struct {
-	Client    Querier
-	Schema    schema.Metrics
+	Client Querier
+	Schema schema.Metrics
+	// Engine runs the shared parse → lower → optimize → emit → execute
+	// pipeline. Wired by New from the same Client + Optimizer the
+	// handler holds; the indirection keeps the per-request pipeline
+	// orchestration in one place across the three API heads.
+	Engine    *engine.Engine
 	Optimizer *optimizer.Driver
 	Logger    *slog.Logger
 
@@ -58,15 +63,20 @@ type Handler struct {
 	parser promparser.Parser
 }
 
-// New constructs a Handler with the seed optimizer wired in.
+// New constructs a Handler with the seed optimizer wired in plus a
+// matching engine.Engine. The engine + handler share the same Client
+// and Optimizer; the engine owns the pipeline loop, the handler owns
+// HTTP routing + the per-API wire-format pivot.
 func New(client Querier, s schema.Metrics, logger *slog.Logger) *Handler {
 	if logger == nil {
 		logger = slog.Default()
 	}
+	opt := optimizer.Default()
 	return &Handler{
 		Client:    client,
 		Schema:    s,
-		Optimizer: optimizer.Default(),
+		Engine:    &engine.Engine{Optimizer: opt, Client: client},
+		Optimizer: opt,
 		Logger:    logger,
 		parser:    promparser.NewParser(promparser.Options{EnableExperimentalFunctions: true}),
 	}
@@ -314,98 +324,92 @@ func scalarMatrix(v float64, start, end time.Time, step time.Duration) []MatrixS
 }
 
 // executeRangeStreaming is the streaming counterpart to executeInstant
-// used by /api/v1/query_range. The SQL emission is identical — same
-// lowering, same optimizer pass, same wrapWithSampleProjection — but
-// rather than draining the result into a []chclient.Sample slice it
-// returns a chclient.Cursor so the response builder can pivot rows into
-// the matrix shape one at a time. For a wide-range / fine-step query
-// this is the difference between O(rows) and O(rows-per-series)
-// resident memory.
+// used by /api/v1/query_range. The pipeline body (parse → lower →
+// project → optimize → emit → execute) runs through engine.QueryCursor;
+// the handler retains responsibility for the chclient.Cursor →
+// response-shape pivot. For a wide-range / fine-step query this is the
+// difference between O(rows) and O(rows-per-series) resident memory.
 func (h *Handler) executeRangeStreaming(
 	ctx context.Context,
 	query string,
 	start, end time.Time,
 ) (chclient.Cursor, error) {
-	parseT := telemetry.ObserveStage(telemetry.StageParse)
-	expr, err := h.parseExpr(ctx, query)
-	parseT.Done(ctx)
-	if err != nil {
-		return nil, &apiError{Kind: ErrBadData, Err: err, Status: http.StatusBadRequest}
+	l := &lang{Parser: h.parser, Schema: h.Schema, Start: start, End: end}
+	// Time the entire QueryCursor entry so the cursor-open round-trip
+	// is billed to X-Cerberus-CH-Millis the same way timeCH did pre-
+	// port. The execute span the engine opens internally covers the
+	// same wall-clock; this counter is the handler-side header
+	// surface, separate from the OTel span.
+	chStart := time.Now()
+	res, err := h.Engine.QueryCursor(ctx, l, query)
+	if c := ctxCounter(ctx); c != nil {
+		c.add(time.Since(chStart))
 	}
-	lowerT := telemetry.ObserveStage(telemetry.StageLower)
-	plan, err := promql.LowerAt(ctx, expr, h.Schema, start, end)
-	lowerT.Done(ctx)
 	if err != nil {
-		return nil, &apiError{Kind: ErrExecution, Err: err, Status: http.StatusUnprocessableEntity}
+		return nil, classifyEngineError(err)
 	}
-
-	plan = wrapWithSampleProjection(plan, h.Schema)
-	optT := telemetry.ObserveStage(telemetry.StageOptimize)
-	plan = h.Optimizer.Run(ctx, plan)
-	optT.Done(ctx)
-
-	emitT := telemetry.ObserveStage(telemetry.StageEmit)
-	sql, args, err := chsql.Emit(ctx, plan)
-	emitT.Done(ctx)
-	if err != nil {
-		return nil, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusInternalServerError}
-	}
-	h.Logger.Debug("cerberus query_range (stream)", "promql", query, "sql", sql, "args", args)
-
-	execT := telemetry.ObserveStage(telemetry.StageExecute)
-	cursor, err := timeCH(ctx, func() (chclient.Cursor, error) {
-		return h.Client.QueryCursor(chclient.WithProgressFor(ctx, "promql"), sql, args...)
-	})
-	execT.Done(ctx)
-	if err != nil {
-		return nil, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusBadGateway}
-	}
-	return cursor, nil
+	h.Logger.Debug("cerberus query_range (stream)", "promql", query, "sql", res.SQL, "args", res.Args)
+	return res.Cursor, nil
 }
 
-// executeInstant lowers a PromQL string to chplan, wraps with a Project
-// that selects exactly the four columns chclient.Sample expects, optimizes,
-// emits SQL, and runs the query.
-//
-// start / end are the query's evaluation-range bookends, threaded into
-// the lowering layer so `@ start()` / `@ end()` modifiers can resolve
-// against them. For instant queries the caller passes start == end == ts.
+// executeInstant runs a PromQL query through engine.Engine and returns
+// the row slice. start / end are the query's evaluation-range bookends,
+// threaded into the Lang adapter so `@ start()` / `@ end()` modifiers
+// resolve against them. For instant queries the caller passes
+// start == end == ts.
 func (h *Handler) executeInstant(ctx context.Context, query string, start, end time.Time) ([]chclient.Sample, error) {
-	parseT := telemetry.ObserveStage(telemetry.StageParse)
-	expr, err := h.parseExpr(ctx, query)
-	parseT.Done(ctx)
+	l := &lang{Parser: h.parser, Schema: h.Schema, Start: start, End: end}
+	res, err := h.Engine.Query(ctx, l, query)
 	if err != nil {
-		return nil, &apiError{Kind: ErrBadData, Err: err, Status: http.StatusBadRequest}
+		return nil, classifyEngineError(err)
 	}
-	lowerT := telemetry.ObserveStage(telemetry.StageLower)
-	plan, err := promql.LowerAt(ctx, expr, h.Schema, start, end)
-	lowerT.Done(ctx)
-	if err != nil {
-		return nil, &apiError{Kind: ErrExecution, Err: err, Status: http.StatusUnprocessableEntity}
+	h.Logger.Debug("cerberus query", "promql", query, "sql", res.SQL, "args", res.Args)
+	// Engine times the execute stage uniformly; surface that to the
+	// per-request chMillisCounter so the X-Cerberus-CH-Millis header
+	// keeps reporting CH wall-clock.
+	if c := ctxCounter(ctx); c != nil {
+		c.add(time.Duration(res.CHMillis) * time.Millisecond)
 	}
+	return res.Samples, nil
+}
 
-	plan = wrapWithSampleProjection(plan, h.Schema)
-	optT := telemetry.ObserveStage(telemetry.StageOptimize)
-	plan = h.Optimizer.Run(ctx, plan)
-	optT.Done(ctx)
-
-	emitT := telemetry.ObserveStage(telemetry.StageEmit)
-	sql, args, err := chsql.Emit(ctx, plan)
-	emitT.Done(ctx)
-	if err != nil {
-		return nil, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusInternalServerError}
+// classifyEngineError maps engine.Query / engine.QueryCursor errors to
+// the per-stage apiError shape the Prom handler exposes via
+// respondError. The engine wraps each stage's error with an
+// "engine: <stage>:" prefix (parse / emit / execute); the Lang
+// adapter further tags parse-vs-lower failures via parseStageError so
+// the wire-level errorType / HTTP status mirror the pre-port
+// classification.
+func classifyEngineError(err error) error {
+	if err == nil {
+		return nil
 	}
-	h.Logger.Debug("cerberus query", "promql", query, "sql", sql, "args", args)
-
-	execT := telemetry.ObserveStage(telemetry.StageExecute)
-	samples, err := timeCH(ctx, func() ([]chclient.Sample, error) {
-		return h.Client.Query(chclient.WithProgressFor(ctx, "promql"), sql, args...)
-	})
-	execT.Done(ctx)
-	if err != nil {
-		return nil, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusBadGateway}
+	var ps *parseStageError
+	if errors.As(err, &ps) {
+		switch ps.stage {
+		case "parse":
+			return &apiError{Kind: ErrBadData, Err: err, Status: http.StatusBadRequest}
+		case "lower":
+			return &apiError{Kind: ErrExecution, Err: err, Status: http.StatusUnprocessableEntity}
+		}
 	}
-	return samples, nil
+	msg := err.Error()
+	switch {
+	case errContainsStage(msg, "emit"):
+		return &apiError{Kind: ErrInternal, Err: err, Status: http.StatusInternalServerError}
+	case errContainsStage(msg, "execute"):
+		return &apiError{Kind: ErrInternal, Err: err, Status: http.StatusBadGateway}
+	}
+	return &apiError{Kind: ErrInternal, Err: err, Status: http.StatusInternalServerError}
+}
+
+// errContainsStage reports whether msg starts with `engine: <stage>:`.
+// Kept narrow (prefix match against the engine's wrapping format) so a
+// downstream error message that happens to contain "execute" doesn't
+// get mis-classified.
+func errContainsStage(msg, stage string) bool {
+	prefix := "engine: " + stage + ":"
+	return len(msg) >= len(prefix) && msg[:len(prefix)] == prefix
 }
 
 // wrapWithSampleProjection adds a Project on top of plan that emits

--- a/internal/api/prom/lang.go
+++ b/internal/api/prom/lang.go
@@ -1,0 +1,98 @@
+package prom
+
+import (
+	"context"
+	"time"
+
+	promparser "github.com/prometheus/prometheus/promql/parser"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/tsouza/cerberus/internal/cerbtrace"
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/engine"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/telemetry"
+)
+
+// lang is the PromQL adapter for engine.Engine. One value per request
+// (so Start / End can carry the query's evaluation window through to
+// promql.LowerAt for `@ start()` / `@ end()` resolution) — the heavier
+// pieces (Parser, Schema) come from the long-lived Handler.
+//
+// The adapter is intentionally collocated with the Prom handler rather
+// than living under `internal/promql/` because ProjectSamples wraps the
+// plan into the per-handler Sample shape (an HTTP-layer concern); the
+// promql package stays focused on parser → chplan lowering.
+type lang struct {
+	Parser promparser.Parser
+	Schema schema.Metrics
+	Start  time.Time
+	End    time.Time
+}
+
+// Compile-time check that *lang satisfies engine.Lang.
+var _ engine.Lang = (*lang)(nil)
+
+// Name returns the stable QL identifier the engine uses for
+// progress-context keying, telemetry labels, and span attributes.
+func (l *lang) Name() string { return "promql" }
+
+// parseStageError tags an error with the pipeline stage that produced
+// it so the handler-side error mapper can preserve the pre-port
+// errorType / HTTP-status classification (parse → 400 bad_data, lower
+// → 422 execution).
+type parseStageError struct {
+	stage string // "parse" or "lower"
+	err   error
+}
+
+func (e *parseStageError) Error() string { return e.err.Error() }
+func (e *parseStageError) Unwrap() error { return e.err }
+
+// Parse runs the upstream PromQL parser and lowers the AST into a
+// chplan tree. It owns the `parse` + `lower` pipeline-stage spans so
+// the cross-handler trace shape (parse → lower → optimize → emit →
+// execute) matches what the old inline orchestration emitted.
+//
+// Errors are wrapped in parseStageError so the handler can map parse
+// failures to 400 bad_data and lower failures to 422 execution, the
+// classification the inline pipeline used pre-port.
+//
+// Meta.IsMetric is set to true unconditionally — every PromQL query
+// produces matrix / vector / scalar output (the scalar-fold path is
+// short-circuited in the handler before the engine is invoked, so a
+// query reaching here is guaranteed to lower to chplan).
+func (l *lang) Parse(ctx context.Context, query string) (chplan.Node, engine.Meta, error) {
+	parseT := telemetry.ObserveStage(telemetry.StageParse)
+	_, span := tracer.Start(ctx, cerbtrace.SpanParse,
+		trace.WithAttributes(cerbtrace.ParseAttrs("promql", query)...))
+	expr, err := l.Parser.ParseExpr(query)
+	if err != nil {
+		span.RecordError(err)
+		span.End()
+		parseT.Done(ctx)
+		return nil, engine.Meta{}, &parseStageError{stage: "parse", err: err}
+	}
+	span.End()
+	parseT.Done(ctx)
+
+	lowerT := telemetry.ObserveStage(telemetry.StageLower)
+	plan, err := promql.LowerAt(ctx, expr, l.Schema, l.Start, l.End)
+	lowerT.Done(ctx)
+	if err != nil {
+		return nil, engine.Meta{}, &parseStageError{stage: "lower", err: err}
+	}
+	return plan, engine.Meta{IsMetric: true}, nil
+}
+
+// ProjectSamples wraps plan with the Sample-shape Project the Prom
+// handler used to apply inline via wrapWithSampleProjection. The
+// per-handler derived-vs-canonical branch (RangeWindow / Aggregate /
+// Scan / Filter shapes) lives in wrapWithSampleProjection and is
+// re-used verbatim — moving the projection behind Lang keeps the
+// engine generic without forcing prom's per-shape switch into the
+// shared layer.
+func (l *lang) ProjectSamples(plan chplan.Node, _ engine.Meta) chplan.Node {
+	return wrapWithSampleProjection(plan, l.Schema)
+}

--- a/internal/api/prom/lang_test.go
+++ b/internal/api/prom/lang_test.go
@@ -1,0 +1,124 @@
+package prom
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	promparser "github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/engine"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// langForTest is shared scaffolding: a Lang built with the same
+// experimental-functions parser options as the real Handler so the
+// test surfaces match prod, plus a fixed eval window so `@ start() /
+// @ end()` modifiers resolve deterministically when they appear in
+// fixtures.
+func langForTest() *lang {
+	return &lang{
+		Parser: promparser.NewParser(promparser.Options{EnableExperimentalFunctions: true}),
+		Schema: schema.DefaultOTelMetrics(),
+		Start:  time.Unix(1_000, 0).UTC(),
+		End:    time.Unix(2_000, 0).UTC(),
+	}
+}
+
+func TestLang_Name(t *testing.T) {
+	t.Parallel()
+	if got := (&lang{}).Name(); got != "promql" {
+		t.Errorf("Name(): got %q, want %q", got, "promql")
+	}
+}
+
+// TestLang_Parse_SimpleSelector — a bare `up` query lowers to a Scan
+// (no LabelMatchers) wrapped by a Filter (__name__ = "up"). The exact
+// shape isn't asserted to keep the test resilient to lowering tweaks;
+// only "got a plan + IsMetric flag set" is checked.
+func TestLang_Parse_SimpleSelector(t *testing.T) {
+	t.Parallel()
+
+	l := langForTest()
+	plan, meta, err := l.Parse(context.Background(), "up")
+	if err != nil {
+		t.Fatalf("Parse(`up`): unexpected err: %v", err)
+	}
+	if plan == nil {
+		t.Fatalf("Parse(`up`): nil plan")
+	}
+	if !meta.IsMetric {
+		t.Errorf("Meta.IsMetric: got false, want true (every PromQL query is metric-shaped)")
+	}
+}
+
+// TestLang_Parse_ParseError — invalid syntax surfaces as a
+// parseStageError tagged "parse". The handler-side classifier reads
+// that tag to map to 400 bad_data; this test pins the tag itself so
+// the upstream contract is observable.
+func TestLang_Parse_ParseError(t *testing.T) {
+	t.Parallel()
+
+	l := langForTest()
+	_, _, err := l.Parse(context.Background(), "up +")
+	if err == nil {
+		t.Fatalf("Parse(`up +`): expected parser failure, got nil")
+	}
+	var ps *parseStageError
+	if !errors.As(err, &ps) {
+		t.Fatalf("Parse(`up +`): err type = %T, want *parseStageError; err=%v", err, err)
+	}
+	if ps.stage != "parse" {
+		t.Errorf("parseStageError.stage: got %q, want %q", ps.stage, "parse")
+	}
+}
+
+// TestLang_Parse_LowerError — a parseable but unsupported PromQL form
+// (`label_replace`, currently not lowered) surfaces as a
+// parseStageError tagged "lower". Verifies the parse → lower split is
+// preserved through the adapter.
+func TestLang_Parse_LowerError(t *testing.T) {
+	t.Parallel()
+
+	l := langForTest()
+	_, _, err := l.Parse(context.Background(), `label_replace(up, "x", "$1", "instance", "(.*)")`)
+	if err == nil {
+		t.Fatalf("Parse(label_replace): expected lower failure, got nil")
+	}
+	var ps *parseStageError
+	if !errors.As(err, &ps) {
+		t.Fatalf("Parse(label_replace): err type = %T, want *parseStageError; err=%v", err, err)
+	}
+	if ps.stage != "lower" {
+		t.Errorf("parseStageError.stage: got %q, want %q (got err=%v)", ps.stage, "lower", err)
+	}
+	if !strings.Contains(err.Error(), "label_replace") {
+		t.Errorf("err message: got %q, want it to mention label_replace", err.Error())
+	}
+}
+
+// TestLang_ProjectSamples_WrapsCanonicalShape — Scan-rooted plans get
+// the canonical (MetricName / Attributes / TimeUnix / Value) Project
+// wrap. The check is structural: the result must be a *chplan.Project
+// whose Projections slice has four entries.
+func TestLang_ProjectSamples_WrapsCanonicalShape(t *testing.T) {
+	t.Parallel()
+
+	l := langForTest()
+	plan := &chplan.Scan{Table: l.Schema.GaugeTable}
+	wrapped := l.ProjectSamples(plan, engine.Meta{IsMetric: true})
+
+	proj, ok := wrapped.(*chplan.Project)
+	if !ok {
+		t.Fatalf("ProjectSamples: got %T, want *chplan.Project", wrapped)
+	}
+	if got := len(proj.Projections); got != 4 {
+		t.Errorf("Projections len: got %d, want 4 (MetricName/Attributes/TimeUnix/Value)", got)
+	}
+	if proj.Input != plan {
+		t.Errorf("Project.Input: should reference the original plan unchanged")
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -41,6 +41,16 @@ type Querier interface {
 	Query(ctx context.Context, sql string, args ...any) ([]chclient.Sample, error)
 }
 
+// CursorQuerier is the optional streaming sibling of Querier. When the
+// engine's Client implements it, Engine.QueryCursor / QueryPlanCursor
+// route through it for the prom /query_range matrix path; otherwise
+// those entry points return an error. The split keeps the engine's
+// minimum surface narrow (one method on Querier) while still allowing
+// per-language adapters to opt into streaming on a per-call basis.
+type CursorQuerier interface {
+	QueryCursor(ctx context.Context, sql string, args ...any) (chclient.Cursor, error)
+}
+
 // Engine owns the shared dependencies (optimizer, ClickHouse client)
 // and runs the pipeline loop. One Engine instance lives in each
 // handler; the per-language differences are supplied by the Lang
@@ -209,6 +219,89 @@ func (e *Engine) QueryPlan(ctx context.Context, lang Lang, plan chplan.Node, met
 		SQL:           sql,
 		Args:          args,
 		CHMillis:      chMillis,
+		PlanNodeCount: cerbtrace.CountNodes(plan),
+		Meta:          meta,
+	}, nil
+}
+
+// CursorResult is what Engine.QueryCursor / QueryPlanCursor return on
+// success. Mirrors Result but carries a chclient.Cursor instead of a
+// []chclient.Sample slice — the caller drives row consumption and is
+// responsible for cursor.Close(). CHMillis is intentionally absent
+// because the execute stage's wall-clock isn't known until the caller
+// drains the cursor; the chclient.Cursor implementation closes its own
+// `execute` span on Close, so timing instrumentation stays consistent.
+type CursorResult struct {
+	Cursor        chclient.Cursor
+	SQL           string
+	Args          []any
+	Strategy      string
+	PlanNodeCount int
+	Headers       map[string]string
+	Meta          Meta
+}
+
+// QueryCursor runs the full pipeline through emit, then opens a
+// streaming cursor against the emitted SQL instead of draining rows
+// into a slice. Caller MUST defer Cursor.Close() on the returned
+// CursorResult on the happy path. The handler-side /query_range
+// matrix pivot is the canonical consumer.
+//
+// Errors: returns ErrNoCursorQuerier when Engine.Client doesn't
+// implement CursorQuerier (configuration mistake); otherwise the
+// per-stage wrapped errors mirror Query.
+func (e *Engine) QueryCursor(ctx context.Context, lang Lang, query string) (CursorResult, error) {
+	if lang == nil {
+		return CursorResult{}, fmt.Errorf("engine: nil Lang")
+	}
+	plan, meta, err := lang.Parse(ctx, query)
+	if err != nil {
+		return CursorResult{}, fmt.Errorf("engine: parse: %w", err)
+	}
+	return e.QueryPlanCursor(ctx, lang, plan, meta)
+}
+
+// QueryPlanCursor is the streaming sibling of QueryPlan. Same wrap +
+// optimize + emit pipeline; opens a cursor instead of executing
+// eagerly. The IsTraceByID short-circuit (skip optimizer) applies
+// identically.
+func (e *Engine) QueryPlanCursor(ctx context.Context, lang Lang, plan chplan.Node, meta Meta) (CursorResult, error) {
+	if lang == nil {
+		return CursorResult{}, fmt.Errorf("engine: nil Lang")
+	}
+	if plan == nil {
+		return CursorResult{}, fmt.Errorf("engine: nil plan")
+	}
+	cq, ok := e.Client.(CursorQuerier)
+	if !ok {
+		return CursorResult{}, fmt.Errorf("engine: client does not implement CursorQuerier")
+	}
+
+	plan = lang.ProjectSamples(plan, meta)
+	if !meta.IsTraceByID {
+		optT := telemetry.ObserveStage(telemetry.StageOptimize)
+		plan = e.Optimizer.Run(ctx, plan)
+		optT.Done(ctx)
+	}
+
+	emitT := telemetry.ObserveStage(telemetry.StageEmit)
+	sql, args, err := chsql.Emit(ctx, plan)
+	emitT.Done(ctx)
+	if err != nil {
+		return CursorResult{}, fmt.Errorf("engine: emit: %w", err)
+	}
+
+	execT := telemetry.ObserveStage(telemetry.StageExecute)
+	cursor, err := cq.QueryCursor(chclient.WithProgressFor(ctx, lang.Name()), sql, args...)
+	execT.Done(ctx)
+	if err != nil {
+		return CursorResult{}, fmt.Errorf("engine: execute: %w", err)
+	}
+
+	return CursorResult{
+		Cursor:        cursor,
+		SQL:           sql,
+		Args:          args,
 		PlanNodeCount: cerbtrace.CountNodes(plan),
 		Meta:          meta,
 	}, nil


### PR DESCRIPTION
## Summary

- Replaces the Prom handler's inline parse → lower → optimize → emit → execute orchestration with a per-request `engine.Lang` adapter (`internal/api/prom/lang.go`) routed through `engine.Engine`. The handler keeps HTTP routing, request decoding, the scalar-fold short-circuit, and the wire-format pivot (`toVector` / `matrixFromCursor`); pipeline plumbing collapses into one `engine.Query` / `engine.QueryCursor` call.
- Engine grows `QueryCursor` / `QueryPlanCursor` + a `CursorQuerier` capability check so the prom `/query_range` streaming path stays streaming (the doc in `docs/engine-evaluation.md` already called out this as the streaming entry point).
- `Lang.Parse` tags parse-vs-lower failures with a `parseStageError` so the handler preserves the pre-port `errorType` + HTTP status (parse → 400 `bad_data`, lower → 422 `execution`).
- `cmd/cerberus/main.go` now constructs `engine.Engine` explicitly from the shared `Client` + handler's seed `Optimizer`, ready for the Loki / Tempo ports (RC7 R7.3 / R7.4) to share the surface.

## Test plan

- [x] `go test ./internal/engine/... ./internal/promql/... ./internal/api/prom/... ./cmd/cerberus/...` — pass.
- [x] `go test -race` on the same scope — pass.
- [x] `go test ./...` — full module green.
- [x] Wire-format snapshots (`handler_test.go`, `handler_error_paths_test.go`) byte-identical pre/post port.
- [x] Five-stage span chain snapshot (`pipeline_spans_test.go`) preserved (Lang.Parse opens `parse` + `lower` spans + telemetry stages).
- [x] New `internal/api/prom/lang_test.go` covers Lang.Name / Lang.Parse (success + parse-error + lower-error tagging) / Lang.ProjectSamples shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)