### PR TITLE
feat(test): chDB-backed Querier for handler tests (RC8 R8.2)

### DIFF
--- a/.github/workflows/chdb.yml
+++ b/.github/workflows/chdb.yml
@@ -51,3 +51,6 @@ jobs:
 
       - name: Run TXTAR round-trip suite (chDB)
         run: just spec-chdb
+
+      - name: Run handler tests (chDB)
+        run: just test-chdb

--- a/Justfile
+++ b/Justfile
@@ -68,6 +68,12 @@ schema-ddl-test:
 spec-chdb:
     go test -tags chdb -count=1 ./test/spec/...
 
+# Run the chDB-tagged handler tests under internal/api/... plus the
+# chclienttest package itself. Same prerequisite as spec-chdb (libchdb
+# at the default install path). Mirrors the `chdb` CI job.
+test-chdb:
+    go test -tags chdb -count=1 ./internal/chclienttest/... ./internal/api/...
+
 # Run the FuzzParse target for one parser head for a bounded duration.
 # Usage: `just fuzz QL=promql DURATION=60s` (defaults).
 fuzz QL="promql" DURATION="60s":

--- a/internal/api/prom/handler_chdb_test.go
+++ b/internal/api/prom/handler_chdb_test.go
@@ -1,0 +1,358 @@
+//go:build chdb
+
+// chDB-backed mirror of the handler_test.go cases. The default
+// (untagged) test lane uses stubQuerier so it stays CGO-free; this
+// file exercises the same HTTP surface against a real chDB session
+// so the full pipeline (parse → lower → optimize → emit → execute)
+// is asserted end-to-end on every chdb-tagged run.
+//
+// Each test seeds an OTel-metrics-gauge-shaped table inside an
+// ephemeral chDB session, executes the handler, and asserts the
+// envelope returned to the client. The seed values are chosen to
+// match the assertions in the parallel stub-based test verbatim —
+// the SQL the handler emits is therefore exercised end-to-end
+// against ClickHouse semantics rather than against a stubbed-out
+// slice of [chclient.Sample].
+
+package prom_test
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/api/prom"
+	"github.com/tsouza/cerberus/internal/chclienttest"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// gaugeDDL is the OTel-metrics-gauge-shaped table the chDB-backed
+// handler tests seed before exercising the handler. The full upstream
+// OTel exporter DDL has many more columns than the handler reads —
+// this minimal shape covers exactly the four columns the prom
+// emitter's outer Project projects, plus the columns the gauge-table
+// SQL filters on (MetricName). chDB is happy to project a subset of
+// the columns it knows about; missing-column INSERTs would fail.
+const gaugeDDL = `CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;`
+
+func newChDBServer(t *testing.T, ddl string) (*httptest.Server, *chclienttest.Client) {
+	t.Helper()
+	c := chclienttest.NewChDB(t)
+	if ddl != "" {
+		c.Seed(t, ddl)
+	}
+	h := prom.New(c, schema.DefaultOTelMetrics(), nil)
+	mux := http.NewServeMux()
+	h.Mount(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, c
+}
+
+func TestQuery_Vector_ChDB(t *testing.T) {
+	// Two gauge rows for `up`, distinct job labels; the handler will
+	// emit SELECT … FROM otel_metrics_gauge WHERE MetricName=? and
+	// receive both rows back.
+	ts := time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC).Format("2006-01-02 15:04:05.000")
+	seed := gaugeDDL + fmt.Sprintf(`
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api'), toDateTime64('%s', 9), 1.0),
+    ('up', map('job', 'db'),  toDateTime64('%s', 9), 0.0);`, ts, ts)
+
+	srv, _ := newChDBServer(t, seed)
+	resp, err := http.Get(srv.URL + "/api/v1/query?query=up&time=1717999200")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+
+	var parsed queryResponse
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v\nbody=%s", err, body)
+	}
+	if parsed.Status != "success" {
+		t.Fatalf("status=%q err=%s", parsed.Status, parsed.Error)
+	}
+	if parsed.Data.ResultType != "vector" {
+		t.Fatalf("resultType=%q, want vector", parsed.Data.ResultType)
+	}
+
+	rawResult, _ := json.Marshal(parsed.Data.Result)
+	var vec []prom.VectorSample
+	if err := json.Unmarshal(rawResult, &vec); err != nil {
+		t.Fatalf("decode vector: %v", err)
+	}
+	if len(vec) != 2 {
+		t.Fatalf("expected 2 series, got %d: %+v", len(vec), vec)
+	}
+	jobs := map[string]bool{}
+	for _, v := range vec {
+		if v.Metric["__name__"] != "up" {
+			t.Errorf("missing __name__ in %+v", v.Metric)
+		}
+		jobs[v.Metric["job"]] = true
+	}
+	for _, j := range []string{"api", "db"} {
+		if !jobs[j] {
+			t.Errorf("missing series with job=%s; got %+v", j, vec)
+		}
+	}
+}
+
+func TestQueryRange_Matrix_ChDB(t *testing.T) {
+	// Three samples spaced 90s apart over a 4-minute window; step=60s.
+	start := time.Unix(1717995600, 0).UTC()
+	end := start.Add(4 * time.Minute)
+	seedRows := make([]string, 0, 3)
+	for i, off := range []time.Duration{0, 90 * time.Second, 180 * time.Second} {
+		ts := start.Add(off).Format("2006-01-02 15:04:05.000")
+		seedRows = append(seedRows, fmt.Sprintf(
+			`('up', map('job', 'api'), toDateTime64('%s', 9), %d.0)`,
+			ts, i+1,
+		))
+	}
+	seed := gaugeDDL + "\nINSERT INTO otel_metrics_gauge VALUES\n  " +
+		strings.Join(seedRows, ",\n  ") + ";"
+
+	srv, _ := newChDBServer(t, seed)
+
+	url := fmt.Sprintf("%s/api/v1/query_range?query=up&start=%d&end=%d&step=60",
+		srv.URL, start.Unix(), end.Unix())
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+
+	var parsed queryResponse
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if parsed.Data.ResultType != "matrix" {
+		t.Fatalf("resultType=%q, want matrix", parsed.Data.ResultType)
+	}
+
+	rawResult, _ := json.Marshal(parsed.Data.Result)
+	var matrix []prom.MatrixSample
+	if err := json.Unmarshal(rawResult, &matrix); err != nil {
+		t.Fatalf("decode matrix: %v", err)
+	}
+	if len(matrix) != 1 {
+		t.Fatalf("expected 1 series, got %d: %+v", len(matrix), matrix)
+	}
+	// 5 step points expected for [start..start+4m] step=60s.
+	if got := len(matrix[0].Values); got != 5 {
+		t.Fatalf("expected 5 sample points in matrix, got %d: %+v",
+			got, matrix[0].Values)
+	}
+	// Latest-at-step values: [1, 1, 2, 3, 3] for steps
+	// [0, 60, 120, 180, 240].
+	wantValues := []string{"1", "1", "2", "3", "3"}
+	for i, want := range wantValues {
+		if got := matrix[0].Values[i][1]; got != want {
+			t.Errorf("step %d: got value %q, want %q",
+				i, got, want)
+		}
+	}
+}
+
+func TestResponseHeaders_ChDB(t *testing.T) {
+	ts := time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC).Format("2006-01-02 15:04:05.000")
+	seed := gaugeDDL + fmt.Sprintf(`
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api'), toDateTime64('%s', 9), 1.0);`, ts)
+
+	srv, _ := newChDBServer(t, seed)
+	resp, err := http.Get(srv.URL + "/api/v1/query?query=up")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if got := resp.Header.Get("X-Prometheus-API-Version"); got != "v1" {
+		t.Errorf("X-Prometheus-API-Version: got %q, want v1", got)
+	}
+	if got := resp.Header.Get("X-Cerberus-CH-Millis"); got == "" {
+		t.Errorf("X-Cerberus-CH-Millis: missing")
+	}
+}
+
+func TestQuery_ScalarFold_ChDB(t *testing.T) {
+	// Scalar fold short-circuits the CH path. The chDB session is
+	// initialised but never queried — same contract as the stub test.
+	srv, _ := newChDBServer(t, gaugeDDL)
+	resp, err := http.Get(srv.URL + "/api/v1/query?query=1%2B1")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	var parsed queryResponse
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if parsed.Data.ResultType != "scalar" {
+		t.Fatalf("resultType=%q, want scalar", parsed.Data.ResultType)
+	}
+	rawResult, _ := json.Marshal(parsed.Data.Result)
+	var point [2]any
+	if err := json.Unmarshal(rawResult, &point); err != nil {
+		t.Fatalf("decode scalar: %v", err)
+	}
+	if got := point[1]; got != "2" {
+		t.Errorf("folded value: got %v, want \"2\"", got)
+	}
+}
+
+func TestQuery_UpstreamError_ChDB(t *testing.T) {
+	// NewChDBWithError synthesises a Querier that errors every call —
+	// the proxy for an unreachable ClickHouse. The handler should
+	// translate that into a 502.
+	c := chclienttest.NewChDBWithError(t, errors.New("clickhouse: connection refused"))
+	h := prom.New(c, schema.DefaultOTelMetrics(), nil)
+	mux := http.NewServeMux()
+	h.Mount(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/query?query=up")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("expected 502, got %d body=%s",
+			resp.StatusCode, readBody(t, resp))
+	}
+}
+
+func TestQueryRange_BadInput_ChDB(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+	}{
+		{"missing start", "/api/v1/query_range?query=up&end=1717999200&step=60"},
+		{"missing end", "/api/v1/query_range?query=up&start=1717995600&step=60"},
+		{"missing step", "/api/v1/query_range?query=up&start=1717995600&end=1717999200"},
+		{"end before start", "/api/v1/query_range?query=up&start=1717999200&end=1717995600&step=60"},
+		{"zero step", "/api/v1/query_range?query=up&start=1717995600&end=1717999200&step=0"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, _ := newChDBServer(t, gaugeDDL)
+			resp, err := http.Get(srv.URL + tc.url)
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d body=%s",
+					resp.StatusCode, readBody(t, resp))
+			}
+		})
+	}
+}
+
+func TestQuery_BadInput_ChDB(t *testing.T) {
+	cases := []struct {
+		name   string
+		url    string
+		status int
+		errKey string
+	}{
+		{"missing query", "/api/v1/query", http.StatusBadRequest, prom.ErrBadData},
+		{"bad time", "/api/v1/query?query=up&time=tomorrow", http.StatusBadRequest, prom.ErrBadData},
+		{"invalid promql", "/api/v1/query?query=up%20%2B", http.StatusBadRequest, prom.ErrBadData},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, _ := newChDBServer(t, gaugeDDL)
+			resp, err := http.Get(srv.URL + tc.url)
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			body := readBody(t, resp)
+			if resp.StatusCode != tc.status {
+				t.Fatalf("status: got %d, want %d; body=%s",
+					resp.StatusCode, tc.status, body)
+			}
+			var parsed prom.Response
+			if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if parsed.Status != "error" || parsed.ErrorType != tc.errKey {
+				t.Fatalf("got status=%q errorType=%q, want error/%s",
+					parsed.Status, parsed.ErrorType, tc.errKey)
+			}
+		})
+	}
+}
+
+func TestFormatQuery_ChDB(t *testing.T) {
+	srv, _ := newChDBServer(t, gaugeDDL)
+	resp, err := http.Get(srv.URL + "/api/v1/format_query?query=up%2Bup")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	var parsed struct {
+		Status string `json:"status"`
+		Data   string `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if parsed.Status != "success" {
+		t.Fatalf("status=%q", parsed.Status)
+	}
+	if !strings.Contains(parsed.Data, "up") {
+		t.Errorf("expected formatted query to contain up; got %q", parsed.Data)
+	}
+}
+
+func TestParseQuery_ChDB(t *testing.T) {
+	srv, _ := newChDBServer(t, gaugeDDL)
+	resp, err := http.Get(srv.URL + "/api/v1/parse_query?query=up")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	var parsed struct {
+		Status string `json:"status"`
+		Data   struct {
+			Type string `json:"type"`
+			Node string `json:"node"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if parsed.Status != "success" {
+		t.Fatalf("status=%q", parsed.Status)
+	}
+	if parsed.Data.Type == "" || parsed.Data.Node != "up" {
+		t.Errorf("unexpected parse data: %+v", parsed.Data)
+	}
+}

--- a/internal/chclienttest/client.go
+++ b/internal/chclienttest/client.go
@@ -1,0 +1,322 @@
+//go:build chdb
+
+package chclienttest
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	_ "github.com/chdb-io/chdb-go/chdb/driver" // registers "chdb" sql driver
+
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+// Client is a chDB-backed implementation of the Querier interface each
+// handler defines (api/prom.Querier, api/loki.Querier, api/tempo.Querier).
+// All three are subsets of *chclient.Client's surface, so a single struct
+// satisfies them all by method set.
+//
+// Each Client owns one ephemeral chDB session — empty DSN, temp-dir
+// backed — torn down via t.Cleanup when NewChDB returns. Concurrent
+// use across goroutines is safe (database/sql is goroutine-safe), but
+// tests typically don't need that.
+//
+// To inject upstream-error behaviour for negative-path tests use
+// NewChDBWithError instead — that variant returns the stored error
+// from every Querier method without opening a chDB session.
+type Client struct {
+	db  *sql.DB
+	err error // when non-nil every Querier method returns this and bypasses db
+}
+
+// NewChDB opens an ephemeral chDB session bound to t's lifetime and
+// returns a Client that satisfies the prom / loki / tempo Querier
+// interfaces. Each test gets an isolated session — there is no
+// process-wide shared state.
+func NewChDB(t *testing.T) *Client {
+	t.Helper()
+	// Empty DSN -> chdb-go provisions a temp-dir-backed session that
+	// the driver tears down on Close. There is no `:memory:` literal
+	// in chdb-go v1.11.0; the temp-dir behaviour is functionally
+	// equivalent for unit-test isolation.
+	db, err := sql.Open("chdb", "")
+	if err != nil {
+		t.Fatalf("chclienttest: open chdb: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.Ping(); err != nil {
+		t.Fatalf("chclienttest: ping chdb: %v", err)
+	}
+	return &Client{db: db}
+}
+
+// NewChDBWithError returns a Client whose Querier methods all return
+// err. Use it for upstream-error negative-path tests where exercising
+// real CH would be cumbersome (e.g. simulating a connection refused).
+// The returned Client never opens a chDB session.
+func NewChDBWithError(_ *testing.T, err error) *Client {
+	if err == nil {
+		err = fmt.Errorf("chclienttest: injected error")
+	}
+	return &Client{err: err}
+}
+
+// Seed runs ddl (a multi-statement script of `CREATE …; INSERT …;` etc)
+// against the underlying chDB session. The runner splits on top-level
+// semicolons so each statement reaches chdb-go's single-statement
+// Exec individually. Empty statements are skipped. Any failure fails
+// the test fatally — seeding is a test-setup concern, not an
+// assertable behaviour.
+//
+// Cross-test isolation: chdb-go shares one engine across a process, so
+// CREATE TABLE statements from a prior test would collide with this
+// one's seed (chdb-go v1.11.0 has no `:memory:` flavour that resets
+// per-Open — every connection lands in the same shared catalog). The
+// seed-applier therefore promotes bare `CREATE TABLE` to `CREATE OR
+// REPLACE TABLE` so each test's setup is idempotent against whatever
+// the prior test left behind. Authors who want the upstream semantics
+// can opt out by writing `CREATE OR REPLACE TABLE` / `CREATE TABLE IF
+// NOT EXISTS` themselves — the rewrite only fires on the bare form.
+func (c *Client) Seed(t *testing.T, ddl string) {
+	t.Helper()
+	if c.db == nil {
+		t.Fatalf("chclienttest: Seed called on error-only client")
+	}
+	for _, stmt := range splitStatements(ddl) {
+		if isBlank(stmt) {
+			continue
+		}
+		stmt = promoteCreateTable(stmt)
+		if _, err := c.db.Exec(stmt); err != nil {
+			t.Fatalf("chclienttest: seed exec failed:\n--- stmt ---\n%s\n--- err ---\n%v", stmt, err)
+		}
+	}
+}
+
+// Query satisfies the *chclient.Client.Query surface — it runs sql
+// with positional args and decodes each row into a chclient.Sample.
+// The SQL must project (MetricName, Attributes, TimeUnix, Value) in
+// that order; the Attributes column is rewritten to toJSONString(…)
+// before the round-trip and JSON-decoded back to a map[string]string
+// on the Go side.
+func (c *Client) Query(ctx context.Context, query string, args ...any) ([]chclient.Sample, error) {
+	if c.err != nil {
+		return nil, c.err
+	}
+	rewritten := rewriteMapProjections(query)
+	rows, err := c.db.QueryContext(ctx, rewritten, args...)
+	if err != nil {
+		return nil, fmt.Errorf("chclienttest: query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []chclient.Sample
+	for rows.Next() {
+		var (
+			name      string
+			attrsJSON string
+			ts        time.Time
+			value     float64
+		)
+		if err := rows.Scan(&name, &attrsJSON, &ts, &value); err != nil {
+			return nil, fmt.Errorf("chclienttest: scan: %w", err)
+		}
+		labels, err := decodeMapJSON(attrsJSON)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, chclient.Sample{
+			MetricName: name,
+			Labels:     labels,
+			Timestamp:  ts,
+			Value:      value,
+		})
+	}
+	if err := tolerantRowsErr(rows.Err()); err != nil {
+		return nil, fmt.Errorf("chclienttest: rows.Err: %w", err)
+	}
+	return out, nil
+}
+
+// QueryCursor returns a streaming chclient.Cursor over the result
+// set. Internally this drains the underlying database/sql rows into a
+// slice and returns a slice-backed cursor — chdb-go does not surface
+// the same Rows lifetime guarantees clickhouse-go does, and handler
+// tests don't exercise the streaming-memory contract anyway (the
+// allocation benchmark lives in a separate fixture).
+func (c *Client) QueryCursor(ctx context.Context, query string, args ...any) (chclient.Cursor, error) {
+	if c.err != nil {
+		return nil, c.err
+	}
+	samples, err := c.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	return newSliceCursor(samples), nil
+}
+
+// QueryStrings runs sql and decodes a single-string-column result.
+// No Map column is involved so the SQL is passed through verbatim.
+func (c *Client) QueryStrings(ctx context.Context, query string, args ...any) ([]string, error) {
+	if c.err != nil {
+		return nil, c.err
+	}
+	rows, err := c.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("chclienttest: query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []string
+	for rows.Next() {
+		var s string
+		if err := rows.Scan(&s); err != nil {
+			return nil, fmt.Errorf("chclienttest: scan: %w", err)
+		}
+		out = append(out, s)
+	}
+	if err := tolerantRowsErr(rows.Err()); err != nil {
+		return nil, fmt.Errorf("chclienttest: rows.Err: %w", err)
+	}
+	return out, nil
+}
+
+// QueryLabelSets runs sql expecting a single Map(String,String) column
+// per row. The column is rewritten to toJSONString(…) and decoded back
+// on the Go side.
+func (c *Client) QueryLabelSets(ctx context.Context, query string, args ...any) ([]map[string]string, error) {
+	if c.err != nil {
+		return nil, c.err
+	}
+	rewritten := rewriteMapProjections(query)
+	rows, err := c.db.QueryContext(ctx, rewritten, args...)
+	if err != nil {
+		return nil, fmt.Errorf("chclienttest: query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []map[string]string
+	for rows.Next() {
+		var attrsJSON string
+		if err := rows.Scan(&attrsJSON); err != nil {
+			return nil, fmt.Errorf("chclienttest: scan: %w", err)
+		}
+		labels, err := decodeMapJSON(attrsJSON)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, labels)
+	}
+	if err := tolerantRowsErr(rows.Err()); err != nil {
+		return nil, fmt.Errorf("chclienttest: rows.Err: %w", err)
+	}
+	return out, nil
+}
+
+// QueryMetricMeta runs sql expecting (name, description, unit) string
+// triples per row. metricType is stamped onto every returned row, the
+// same convention chclient.Client.QueryMetricMeta uses (the metric
+// type is a property of the table the row came from, not the row).
+func (c *Client) QueryMetricMeta(
+	ctx context.Context, query, metricType string, args ...any,
+) ([]chclient.MetricMetaRow, error) {
+	if c.err != nil {
+		return nil, c.err
+	}
+	rows, err := c.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("chclienttest: query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []chclient.MetricMetaRow
+	for rows.Next() {
+		var r chclient.MetricMetaRow
+		r.Type = metricType
+		if err := rows.Scan(&r.Name, &r.Description, &r.Unit); err != nil {
+			return nil, fmt.Errorf("chclienttest: scan: %w", err)
+		}
+		out = append(out, r)
+	}
+	if err := tolerantRowsErr(rows.Err()); err != nil {
+		return nil, fmt.Errorf("chclienttest: rows.Err: %w", err)
+	}
+	return out, nil
+}
+
+// QueryIndexStats runs sql expecting one (streams, entries, bytes) row.
+// Loki /index/stats consumes this; the prom head doesn't but the
+// signature is here so a single Client covers all three handlers.
+func (c *Client) QueryIndexStats(ctx context.Context, query string, args ...any) (chclient.IndexStatsRow, error) {
+	if c.err != nil {
+		return chclient.IndexStatsRow{}, c.err
+	}
+	rows, err := c.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return chclient.IndexStatsRow{}, fmt.Errorf("chclienttest: query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out chclient.IndexStatsRow
+	if rows.Next() {
+		if err := rows.Scan(&out.Streams, &out.Entries, &out.Bytes); err != nil {
+			return chclient.IndexStatsRow{}, fmt.Errorf("chclienttest: scan: %w", err)
+		}
+	}
+	if err := tolerantRowsErr(rows.Err()); err != nil {
+		return chclient.IndexStatsRow{}, fmt.Errorf("chclienttest: rows.Err: %w", err)
+	}
+	return out, nil
+}
+
+// QueryIndexVolume runs sql expecting (Map(String,String), UInt64)
+// rows. Same Map-column rewrite as QueryLabelSets.
+func (c *Client) QueryIndexVolume(ctx context.Context, query string, args ...any) ([]chclient.IndexVolumeRow, error) {
+	if c.err != nil {
+		return nil, c.err
+	}
+	rewritten := rewriteMapProjections(query)
+	rows, err := c.db.QueryContext(ctx, rewritten, args...)
+	if err != nil {
+		return nil, fmt.Errorf("chclienttest: query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []chclient.IndexVolumeRow
+	for rows.Next() {
+		var (
+			attrsJSON string
+			bytes     uint64
+		)
+		if err := rows.Scan(&attrsJSON, &bytes); err != nil {
+			return nil, fmt.Errorf("chclienttest: scan: %w", err)
+		}
+		labels, err := decodeMapJSON(attrsJSON)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, chclient.IndexVolumeRow{Labels: labels, Bytes: bytes})
+	}
+	if err := tolerantRowsErr(rows.Err()); err != nil {
+		return nil, fmt.Errorf("chclienttest: rows.Err: %w", err)
+	}
+	return out, nil
+}
+
+// decodeMapJSON unmarshals the toJSONString(…) output. An empty
+// payload (Map() literal) decodes to nil to match clickhouse-go's
+// behaviour on an empty Map.
+func decodeMapJSON(s string) (map[string]string, error) {
+	if s == "" || s == "{}" {
+		return nil, nil
+	}
+	out := map[string]string{}
+	if err := json.Unmarshal([]byte(s), &out); err != nil {
+		return nil, fmt.Errorf("chclienttest: decode map %q: %w", s, err)
+	}
+	return out, nil
+}

--- a/internal/chclienttest/cursor.go
+++ b/internal/chclienttest/cursor.go
@@ -1,0 +1,32 @@
+//go:build chdb
+
+package chclienttest
+
+import "github.com/tsouza/cerberus/internal/chclient"
+
+// sliceCursor is the in-memory chclient.Cursor used by Client.QueryCursor.
+// Mirrors the production rowsCursor lifecycle: Next advances, Sample
+// yields the current row, Err reports any saved error, Close is
+// idempotent.
+type sliceCursor struct {
+	samples []chclient.Sample
+	idx     int
+	cur     chclient.Sample
+}
+
+func newSliceCursor(samples []chclient.Sample) *sliceCursor {
+	return &sliceCursor{samples: samples, idx: -1}
+}
+
+func (c *sliceCursor) Next() bool {
+	c.idx++
+	if c.idx >= len(c.samples) {
+		return false
+	}
+	c.cur = c.samples[c.idx]
+	return true
+}
+
+func (c *sliceCursor) Sample() chclient.Sample { return c.cur }
+func (c *sliceCursor) Err() error              { return nil }
+func (c *sliceCursor) Close() error            { return nil }

--- a/internal/chclienttest/doc.go
+++ b/internal/chclienttest/doc.go
@@ -1,0 +1,30 @@
+// Package chclienttest provides a chDB-backed Querier implementation
+// used by handler-level unit tests. The handlers (api/prom, api/loki,
+// api/tempo) each define their own Querier interface as the subset of
+// chclient.Client they consume; this package's Client type satisfies
+// all three of them so any handler test can drop the stub and exercise
+// the full parse → lower → optimize → emit → execute pipeline against
+// real ClickHouse semantics via the in-process chDB engine.
+//
+// The default `just test` lane stays CGO_ENABLED=0 and never compiles
+// this package — every file is gated behind the `chdb` build tag, the
+// same tag the chDB probe (RC8 R8.0) and the TXTAR round-trip runner
+// (RC8 R8.1) use. The `chdb` CI job runs after `just chdb-install` has
+// placed libchdb.so at /usr/local/lib.
+//
+// Map column scan: chdb-go v1.11.0's parquet driver panics on the
+// Parquet MAP logical type, so every emitted SQL that projects a
+// Map(String, String) column has to wrap it in toJSONString(...)
+// server-side. The package rewrites the outer SELECT's projection
+// list before issuing the query, mirroring the rewriter that ships
+// with the spec runner (test/spec/runner_chdb.go). Callers don't see
+// the rewrite — the Querier returns the same shapes the production
+// chclient.Client returns.
+//
+// Lifetime: NewChDB binds the session to the test via t.Cleanup so
+// each test gets an isolated chDB session and the temp directory the
+// driver allocates is torn down with the test. Tests that want to
+// pre-seed the session should call (*Client).Seed before exercising
+// the handler — Seed runs the multi-statement DDL+INSERT script
+// against the same session the handler will read from.
+package chclienttest

--- a/internal/chclienttest/interfaces_test.go
+++ b/internal/chclienttest/interfaces_test.go
@@ -1,0 +1,20 @@
+//go:build chdb
+
+package chclienttest_test
+
+import (
+	"github.com/tsouza/cerberus/internal/api/loki"
+	"github.com/tsouza/cerberus/internal/api/prom"
+	"github.com/tsouza/cerberus/internal/api/tempo"
+	"github.com/tsouza/cerberus/internal/chclienttest"
+)
+
+// Compile-time guard: *chclienttest.Client must satisfy every handler's
+// Querier interface. If any handler grows a method (or one drifts to a
+// different signature) this file fails to build and the divergence is
+// caught at PR time, not at test-run time.
+var (
+	_ prom.Querier  = (*chclienttest.Client)(nil)
+	_ loki.Querier  = (*chclienttest.Client)(nil)
+	_ tempo.Querier = (*chclienttest.Client)(nil)
+)

--- a/internal/chclienttest/rewrite.go
+++ b/internal/chclienttest/rewrite.go
@@ -1,0 +1,233 @@
+//go:build chdb
+
+package chclienttest
+
+import "strings"
+
+// chdbEOFSentinel is the spurious "empty row" error chdb-go's parquet
+// driver returns instead of io.EOF at end-of-iteration (see chdb-go
+// v1.11.0 chdb/driver/parquet.go). tolerantRowsErr swallows it so
+// rows.Err() looks normal to callers. Any other error is real.
+const chdbEOFSentinel = "empty row"
+
+func tolerantRowsErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	if strings.Contains(err.Error(), chdbEOFSentinel) {
+		return nil
+	}
+	return err
+}
+
+// mapColumnNames is the conservative allow-list of OTel Map column
+// names that the rewriter will wrap in toJSONString(...) before issuing
+// the query against chDB. We don't have type information here; the
+// rewrite is a textual transform keyed off this list. Extend the list
+// if a new Map column lands in the schema.
+var mapColumnNames = []string{
+	"Attributes",
+	"ResourceAttributes",
+	"ScopeAttributes",
+	"SpanAttributes",
+}
+
+func isMapColumn(name string) bool {
+	for _, c := range mapColumnNames {
+		if name == c {
+			return true
+		}
+	}
+	return false
+}
+
+// rewriteMapProjections wraps any top-level SELECT projection whose
+// alias is a known Map column in toJSONString(...). Only the outermost
+// SELECT is touched — subqueries keep their Map columns raw because
+// CH consumes them server-side.
+//
+// Recognised shapes (mirrors test/spec/runner_chdb.go):
+//
+//	`Attributes`                       → toJSONString(`Attributes`) AS `Attributes`
+//	<expr> AS `Attributes`             → toJSONString(<expr>) AS `Attributes`
+//	`Attributes` AS `Attributes`       → toJSONString(`Attributes`) AS `Attributes`
+//
+// Anything else passes through. If a Map column slips through unwrapped
+// the chdb-go parquet decoder will panic loudly at scan time, which is
+// the failure mode we want.
+func rewriteMapProjections(query string) string {
+	head, tail := splitOuterSelect(query)
+	if head == "" {
+		return query
+	}
+	projs := splitProjections(head)
+	for i, p := range projs {
+		expr, alias := splitAlias(p)
+		if alias == "" {
+			alias = unquoteBackticks(strings.TrimSpace(expr))
+		}
+		if !isMapColumn(alias) {
+			continue
+		}
+		projs[i] = "toJSONString(" + expr + ") AS `" + alias + "`"
+	}
+	return "SELECT " + strings.Join(projs, ", ") + tail
+}
+
+// splitOuterSelect splits `SELECT <projs> FROM ...` at the depth-0
+// FROM. Returns ("", "") if the query isn't a SELECT or the FROM is
+// missing.
+func splitOuterSelect(query string) (head, tail string) {
+	upper := strings.ToUpper(query)
+	if !strings.HasPrefix(upper, "SELECT ") {
+		return "", ""
+	}
+	rest := query[len("SELECT "):]
+	depth := 0
+	for i := 0; i < len(rest); i++ {
+		switch rest[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		}
+		if depth == 0 && i+6 <= len(rest) && strings.EqualFold(rest[i:i+6], " FROM ") {
+			return rest[:i], rest[i:]
+		}
+	}
+	return "", ""
+}
+
+// splitProjections splits a projection list on depth-0 commas.
+// Single-quoted strings and backticks shield commas.
+func splitProjections(s string) []string {
+	var (
+		out   []string
+		buf   strings.Builder
+		depth int
+		inStr byte
+	)
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case inStr != 0:
+			if c == inStr {
+				inStr = 0
+			}
+			buf.WriteByte(c)
+		case c == '\'' || c == '`':
+			inStr = c
+			buf.WriteByte(c)
+		case c == '(':
+			depth++
+			buf.WriteByte(c)
+		case c == ')':
+			depth--
+			buf.WriteByte(c)
+		case c == ',' && depth == 0:
+			out = append(out, strings.TrimSpace(buf.String()))
+			buf.Reset()
+		default:
+			buf.WriteByte(c)
+		}
+	}
+	if buf.Len() > 0 {
+		out = append(out, strings.TrimSpace(buf.String()))
+	}
+	return out
+}
+
+// splitAlias splits an `<expr> AS <alias>` projection into (expr,
+// alias). When no AS clause is present returns (s, "").
+func splitAlias(s string) (expr, alias string) {
+	depth := 0
+	inStr := byte(0)
+	lower := strings.ToLower(s)
+	for i := 0; i+4 <= len(s); i++ {
+		c := s[i]
+		switch {
+		case inStr != 0:
+			if c == inStr {
+				inStr = 0
+			}
+		case c == '\'' || c == '`':
+			inStr = c
+		case c == '(':
+			depth++
+		case c == ')':
+			depth--
+		}
+		if depth == 0 && inStr == 0 && lower[i:i+4] == " as " {
+			alias = strings.TrimSpace(s[i+4:])
+			alias = unquoteBackticks(alias)
+			return strings.TrimSpace(s[:i]), alias
+		}
+	}
+	return s, ""
+}
+
+func unquoteBackticks(s string) string {
+	if len(s) >= 2 && s[0] == '`' && s[len(s)-1] == '`' {
+		return s[1 : len(s)-1]
+	}
+	return s
+}
+
+// splitStatements splits a multi-statement SQL script on top-level
+// semicolons. Statements inside single-quoted strings keep their
+// semicolons literal. Mirrors test/spec/runner_chdb.go.
+func splitStatements(s string) []string {
+	var (
+		out   []string
+		buf   strings.Builder
+		inStr bool
+		esc   bool
+	)
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case esc:
+			esc = false
+			buf.WriteByte(c)
+		case c == '\\' && inStr:
+			esc = true
+			buf.WriteByte(c)
+		case c == '\'':
+			inStr = !inStr
+			buf.WriteByte(c)
+		case c == ';' && !inStr:
+			out = append(out, buf.String())
+			buf.Reset()
+		default:
+			buf.WriteByte(c)
+		}
+	}
+	if buf.Len() > 0 {
+		out = append(out, buf.String())
+	}
+	return out
+}
+
+func isBlank(s string) bool {
+	return strings.TrimSpace(s) == ""
+}
+
+// promoteCreateTable rewrites a bare `CREATE TABLE …` statement to
+// `CREATE OR REPLACE TABLE …` so re-running a seed against a chDB
+// session that already holds the table is idempotent. Other variants
+// (`CREATE OR REPLACE TABLE`, `CREATE TABLE IF NOT EXISTS`,
+// `CREATE TEMPORARY TABLE`) are left untouched — the rewrite is
+// conservative on purpose. Leading whitespace and comments are
+// preserved verbatim by re-emitting them.
+func promoteCreateTable(stmt string) string {
+	trimmed := strings.TrimLeft(stmt, " \t\n\r")
+	prefix := stmt[:len(stmt)-len(trimmed)]
+	upper := strings.ToUpper(trimmed)
+	// Only touch the bare form. Everything else passes through.
+	const needle = "CREATE TABLE "
+	if !strings.HasPrefix(upper, needle) {
+		return stmt
+	}
+	rest := trimmed[len(needle):]
+	return prefix + "CREATE OR REPLACE TABLE " + rest
+}

--- a/internal/chclienttest/rewrite_test.go
+++ b/internal/chclienttest/rewrite_test.go
@@ -1,0 +1,59 @@
+//go:build chdb
+
+package chclienttest
+
+import "testing"
+
+func TestRewriteMapProjections(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "bare attributes column",
+			in:   "SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value` FROM `otel_metrics_gauge`",
+			want: "SELECT `MetricName`, toJSONString(`Attributes`) AS `Attributes`, `TimeUnix`, `Value` FROM `otel_metrics_gauge`",
+		},
+		{
+			name: "aliased attributes column",
+			in:   "SELECT `MetricName`, `Attributes` AS `Attributes`, `TimeUnix`, abs(`Value`) AS `Value` FROM `otel_metrics_gauge`",
+			want: "SELECT `MetricName`, toJSONString(`Attributes`) AS `Attributes`, `TimeUnix`, abs(`Value`) AS `Value` FROM `otel_metrics_gauge`",
+		},
+		{
+			name: "no map column",
+			in:   "SELECT `MetricName`, `TimeUnix`, `Value` FROM `otel_metrics_gauge`",
+			want: "SELECT `MetricName`, `TimeUnix`, `Value` FROM `otel_metrics_gauge`",
+		},
+		{
+			name: "non-select passthrough",
+			in:   "INSERT INTO `otel_metrics_gauge` VALUES (1)",
+			want: "INSERT INTO `otel_metrics_gauge` VALUES (1)",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := rewriteMapProjections(tc.in)
+			if got != tc.want {
+				t.Errorf("rewrite mismatch\n got: %s\nwant: %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTolerantRowsErr(t *testing.T) {
+	if err := tolerantRowsErr(nil); err != nil {
+		t.Errorf("nil -> %v, want nil", err)
+	}
+	if err := tolerantRowsErr(errString("empty row")); err != nil {
+		t.Errorf("empty row sentinel -> %v, want nil", err)
+	}
+	real := errString("connection refused")
+	if err := tolerantRowsErr(real); err == nil {
+		t.Errorf("real error swallowed")
+	}
+}
+
+type errString string
+
+func (e errString) Error() string { return string(e) }

--- a/test/spec/runner_chdb.go
+++ b/test/spec/runner_chdb.go
@@ -236,6 +236,14 @@ func openChDB(t *testing.T) *sql.DB {
 // applySeed splits a multi-statement script on top-level semicolons
 // and exec's each piece. Statements wrapped in single-quoted strings
 // keep their semicolons literal (handled by a tiny state machine).
+//
+// Cross-fixture isolation: chdb-go shares one engine across a process,
+// so bare `CREATE TABLE foo` from a prior fixture survives to clash
+// with the next. The applier promotes bare `CREATE TABLE` to
+// `CREATE OR REPLACE TABLE` so re-running a fixture in the same
+// process is idempotent. Fixture authors who want strict CH semantics
+// can opt out by writing `CREATE OR REPLACE TABLE` /
+// `CREATE TABLE IF NOT EXISTS` themselves.
 func applySeed(t *testing.T, db *sql.DB, seed string) {
 	t.Helper()
 	for _, stmt := range splitStatements(seed) {
@@ -243,10 +251,28 @@ func applySeed(t *testing.T, db *sql.DB, seed string) {
 		if stmt == "" {
 			continue
 		}
+		stmt = promoteCreateTable(stmt)
 		if _, err := db.Exec(stmt); err != nil {
 			t.Fatalf("seed exec failed:\n--- stmt ---\n%s\n--- err ---\n%v", stmt, err)
 		}
 	}
+}
+
+// promoteCreateTable rewrites a bare `CREATE TABLE …` statement to
+// `CREATE OR REPLACE TABLE …` so re-running a seed against a chDB
+// session that already holds the table is idempotent. Other variants
+// (`CREATE OR REPLACE TABLE`, `CREATE TABLE IF NOT EXISTS`,
+// `CREATE TEMPORARY TABLE`) are left untouched.
+func promoteCreateTable(stmt string) string {
+	trimmed := strings.TrimLeft(stmt, " \t\n\r")
+	prefix := stmt[:len(stmt)-len(trimmed)]
+	upper := strings.ToUpper(trimmed)
+	const needle = "CREATE TABLE "
+	if !strings.HasPrefix(upper, needle) {
+		return stmt
+	}
+	rest := trimmed[len(needle):]
+	return prefix + "CREATE OR REPLACE TABLE " + rest
 }
 
 func splitStatements(s string) []string {


### PR DESCRIPTION
## Summary

- New `internal/chclienttest` package: chDB-backed `Querier` impl that satisfies the prom / loki / tempo handler interfaces (compile-time guarded). `NewChDB(t)` provisions an isolated session per test; `NewChDBWithError` covers upstream-error negative paths without a session.
- Map columns are wrapped server-side in `toJSONString(...)` and JSON-decoded on the Go side — same shim the R8.0 probe and R8.1 spec runner use to work around chdb-go v1.11.0's parquet MAP panic.
- Proof-point migration: `internal/api/prom/handler_chdb_test.go` mirrors every assertion from the stub-backed `handler_test.go` (vector, matrix, scalar-fold, headers, upstream-error, bad-input, format, parse). The stub test stays in place so the default CGO-free lane is unchanged.
- Justfile gains `just test-chdb`; the `chdb` CI workflow gets a `Run handler tests (chDB)` step running the same command.
- Loki + Tempo handler-test migration deferred to a follow-up — their existing tests drive post-processing assertions (search/tags string lists, span attribute decoding) rather than the SQL execution path; migrating them needs realistic OTel traces/logs seeds. The chDB-backed `Querier` already satisfies both interfaces so no scaffolding work blocks that follow-up.
- Side-fix: bare `CREATE TABLE` in fixture seeds collided across tests because chdb-go shares one engine per process. Both seed appliers (`internal/chclienttest` and `test/spec/runner_chdb.go`) now promote bare `CREATE TABLE` to `CREATE OR REPLACE TABLE`.

## Notes on scope

- R7.2 has not landed yet, so this PR targets the current `Querier` interface each handler defines. When R7.2 ports prom to `engine.Engine`, the chDB-backed client will plug into the engine instead — the rewriter + JSON-shim plumbing carries over verbatim.
- `WITH RECURSIVE` is supported by chDB (the spec runner has fixtures exercising it), so the recursive structural-join shape isn't a blocker for the deferred tempo migration.
- All new code is behind `//go:build chdb`. Release binaries stay CGO_ENABLED=0.

## Test plan

- [x] `go build ./...` succeeds without the `chdb` tag
- [x] `go vet ./...` succeeds without the `chdb` tag
- [x] Stub-backed `internal/api/prom/handler_test.go` still passes (49 tests in default lane)
- [x] `just chdb-install` then `just test-chdb` succeeds — 17 new chDB-backed cases under `internal/api/prom/...` plus 6 rewriter unit tests
- [x] `just spec-chdb` succeeds (side-fix unblocks the 5 fixtures that collided)
- [ ] CI `chdb` workflow run is informational only; nightly + manual dispatch