### PR TITLE
feat(engine): X-Cerberus-* response headers across heads (RC7 R7.7)

### DIFF
--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -150,6 +150,7 @@ func (h *Handler) handleQuery(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	writeEngineHeaders(w, res.Headers)
 	writeJSON(w, http.StatusOK, Response{
 		Status: "success",
 		Data:   data,
@@ -197,10 +198,25 @@ func (h *Handler) handleQueryRange(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	writeEngineHeaders(w, res.Headers)
 	writeJSON(w, http.StatusOK, Response{
 		Status: "success",
 		Data:   data,
 	})
+}
+
+// writeEngineHeaders stamps the X-Cerberus-* response headers populated
+// by engine.Engine.Query / QueryPlan onto w before the response body
+// fires. Safe to call with a nil / empty map (no-op).
+//
+// Each handler calls this once per successful query — the engine
+// populates the canonical bag (Strategy / Plan-Nodes / CH-Millis) so
+// adding a new engine-level header (e.g. SQL-Length) requires no
+// per-handler change.
+func writeEngineHeaders(w http.ResponseWriter, hdr map[string]string) {
+	for k, v := range hdr {
+		w.Header().Set(k, v)
+	}
 }
 
 // classifyEngineErr maps the error chains engine.Engine returns onto

--- a/internal/api/loki/handler_test.go
+++ b/internal/api/loki/handler_test.go
@@ -178,6 +178,38 @@ func TestQuery_MetricVector(t *testing.T) {
 	}
 }
 
+// TestResponseHeaders_EngineInstrumentation covers the R7.7 contract on
+// the Loki head: every successful /query response carries the three
+// canonical X-Cerberus-* headers populated by engine.Engine.
+func TestResponseHeaders_EngineInstrumentation(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+	q := &stubQuerier{
+		samples: []chclient.Sample{
+			{MetricName: "hello", Labels: map[string]string{"job": "api"}, Timestamp: ts},
+		},
+	}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + `/loki/api/v1/query?query=%7Bjob%3D%22api%22%7D`)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if got := resp.Header.Get("X-Cerberus-Strategy"); got != "native" {
+		t.Errorf("X-Cerberus-Strategy: got %q, want native", got)
+	}
+	if got := resp.Header.Get("X-Cerberus-Plan-Nodes"); got == "" {
+		t.Errorf("X-Cerberus-Plan-Nodes: missing")
+	}
+	if got := resp.Header.Get("X-Cerberus-CH-Millis"); got == "" {
+		t.Errorf("X-Cerberus-CH-Millis: missing")
+	}
+}
+
 // TestQueryRange_BadInput covers the validation contract on
 // /loki/api/v1/query_range.
 func TestQueryRange_BadInput(t *testing.T) {

--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -200,13 +200,14 @@ func (h *Handler) handleQuery(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	samples, err := h.executeInstant(r.Context(), q, ts, ts)
+	samples, hdr, err := h.executeInstant(r.Context(), q, ts, ts)
 	if err != nil {
 		h.respondError(w, err)
 		return
 	}
 
 	result := toVector(samples, ts)
+	writeEngineHeaders(w, hdr)
 	writeJSON(w, http.StatusOK, Response{
 		Status: "success",
 		Data:   &QueryData{ResultType: "vector", Result: result},
@@ -253,7 +254,7 @@ func (h *Handler) handleQueryRange(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cursor, err := h.executeRangeStreaming(r.Context(), q, start, end)
+	cursor, hdr, err := h.executeRangeStreaming(r.Context(), q, start, end)
 	if err != nil {
 		h.respondError(w, err)
 		return
@@ -267,6 +268,7 @@ func (h *Handler) handleQueryRange(w http.ResponseWriter, r *http.Request) {
 		h.respondError(w, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusBadGateway})
 		return
 	}
+	writeEngineHeaders(w, hdr)
 	writeJSON(w, http.StatusOK, Response{
 		Status: "success",
 		Data:   &QueryData{ResultType: "matrix", Result: result},
@@ -333,7 +335,7 @@ func (h *Handler) executeRangeStreaming(
 	ctx context.Context,
 	query string,
 	start, end time.Time,
-) (chclient.Cursor, error) {
+) (chclient.Cursor, map[string]string, error) {
 	l := &lang{Parser: h.parser, Schema: h.Schema, Start: start, End: end}
 	// Time the entire QueryCursor entry so the cursor-open round-trip
 	// is billed to X-Cerberus-CH-Millis the same way timeCH did pre-
@@ -346,10 +348,10 @@ func (h *Handler) executeRangeStreaming(
 		c.add(time.Since(chStart))
 	}
 	if err != nil {
-		return nil, classifyEngineError(err)
+		return nil, nil, classifyEngineError(err)
 	}
 	h.Logger.Debug("cerberus query_range (stream)", "promql", query, "sql", res.SQL, "args", res.Args)
-	return res.Cursor, nil
+	return res.Cursor, res.Headers, nil
 }
 
 // executeInstant runs a PromQL query through engine.Engine and returns
@@ -357,20 +359,40 @@ func (h *Handler) executeRangeStreaming(
 // threaded into the Lang adapter so `@ start()` / `@ end()` modifiers
 // resolve against them. For instant queries the caller passes
 // start == end == ts.
-func (h *Handler) executeInstant(ctx context.Context, query string, start, end time.Time) ([]chclient.Sample, error) {
+func (h *Handler) executeInstant(ctx context.Context, query string, start, end time.Time) ([]chclient.Sample, map[string]string, error) {
 	l := &lang{Parser: h.parser, Schema: h.Schema, Start: start, End: end}
 	res, err := h.Engine.Query(ctx, l, query)
 	if err != nil {
-		return nil, classifyEngineError(err)
+		return nil, nil, classifyEngineError(err)
 	}
 	h.Logger.Debug("cerberus query", "promql", query, "sql", res.SQL, "args", res.Args)
 	// Engine times the execute stage uniformly; surface that to the
 	// per-request chMillisCounter so the X-Cerberus-CH-Millis header
-	// keeps reporting CH wall-clock.
+	// keeps reporting CH wall-clock. The middleware-driven counter is
+	// retained alongside the engine's per-Result.Headers stamp so the
+	// error-path response (no engine.Result) still gets a sensible
+	// (zero) X-Cerberus-CH-Millis stamped by the middleware.
 	if c := ctxCounter(ctx); c != nil {
 		c.add(time.Duration(res.CHMillis) * time.Millisecond)
 	}
-	return res.Samples, nil
+	return res.Samples, res.Headers, nil
+}
+
+// writeEngineHeaders stamps the X-Cerberus-* response headers populated
+// by engine.Engine.Query / QueryCursor onto w before the response body
+// fires. Safe to call with a nil / empty map (no-op).
+//
+// The middleware-driven X-Cerberus-CH-Millis stamp still runs after the
+// handler returns (see middleware.go); when the engine populated
+// res.Headers[X-Cerberus-CH-Millis] we Set the same key here first and
+// the middleware's later Set is a no-op overwrite with the equivalent
+// value (engine CH timing is also written into the per-request counter
+// in executeInstant). The middleware path stays as a safety net for
+// error responses where the engine never produced a Result.
+func writeEngineHeaders(w http.ResponseWriter, hdr map[string]string) {
+	for k, v := range hdr {
+		w.Header().Set(k, v)
+	}
 }
 
 // classifyEngineError maps engine.Query / engine.QueryCursor errors to

--- a/internal/api/prom/handler_test.go
+++ b/internal/api/prom/handler_test.go
@@ -300,6 +300,12 @@ func TestResponseHeaders_PromVersionAndCHMillis(t *testing.T) {
 	if got := resp.Header.Get("X-Cerberus-CH-Millis"); got == "" {
 		t.Errorf("X-Cerberus-CH-Millis: missing")
 	}
+	if got := resp.Header.Get("X-Cerberus-Strategy"); got != "native" {
+		t.Errorf("X-Cerberus-Strategy: got %q, want native", got)
+	}
+	if got := resp.Header.Get("X-Cerberus-Plan-Nodes"); got == "" {
+		t.Errorf("X-Cerberus-Plan-Nodes: missing")
+	}
 }
 
 // TestQuery_ScalarFold — Grafana's `?query=1+1` health probe. The fold

--- a/internal/api/prom/metadata.go
+++ b/internal/api/prom/metadata.go
@@ -427,7 +427,7 @@ func (h *Handler) fetchSeries(ctx context.Context, matcher string) ([]map[string
 	// literal @<ts> still resolves but the start()/end() variants surface
 	// as errors at lowering time.
 	now := time.Now()
-	samples, err := h.executeInstant(ctx, matcher, now, now)
+	samples, _, err := h.executeInstant(ctx, matcher, now, now)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -159,10 +159,21 @@ func (h *Handler) handleSearch(w http.ResponseWriter, r *http.Request) {
 	}
 	h.Logger.Debug("cerberus tempo search", "traceql", q, "sql", res.SQL, "args", res.Args)
 
+	writeEngineHeaders(w, res.Headers)
 	writeJSON(w, http.StatusOK, SearchResponse{
 		Traces:  toTraceSummaries(res.Samples),
 		Metrics: SearchMetrics{InspectedTraces: len(res.Samples)},
 	})
+}
+
+// writeEngineHeaders stamps the X-Cerberus-* response headers populated
+// by engine.Engine.Query / QueryPlan onto w before the response body
+// fires. Safe to call with a nil / empty map (no-op). See the matching
+// helper in internal/api/loki/handler.go for the full rationale.
+func writeEngineHeaders(w http.ResponseWriter, hdr map[string]string) {
+	for k, v := range hdr {
+		w.Header().Set(k, v)
+	}
 }
 
 // classifySearchErr maps an engine.Query error to the HTTP status the
@@ -229,6 +240,7 @@ func (h *Handler) handleSearchRecent(w http.ResponseWriter, r *http.Request) {
 	}
 	h.Logger.Debug("cerberus tempo search/recent", "limit", limit, "sql", res.SQL, "args", res.Args)
 
+	writeEngineHeaders(w, res.Headers)
 	writeJSON(w, http.StatusOK, SearchResponse{
 		Traces:  toTraceSummaries(res.Samples),
 		Metrics: SearchMetrics{InspectedTraces: len(res.Samples)},
@@ -268,6 +280,7 @@ func (h *Handler) handleTraceByID(w http.ResponseWriter, r *http.Request) {
 	}
 	h.Logger.Debug("cerberus tempo traceByID", "trace_id", traceID, "sql", res.SQL, "args", res.Args)
 
+	writeEngineHeaders(w, res.Headers)
 	if len(res.Samples) == 0 {
 		// Tempo's "trace not found" shape — Grafana renders the right UI.
 		writeJSON(w, http.StatusNotFound, ErrorResponse{

--- a/internal/api/tempo/handler_test.go
+++ b/internal/api/tempo/handler_test.go
@@ -221,3 +221,58 @@ func TestTraceByID_Found(t *testing.T) {
 		t.Fatalf("expected 1 span, got %d", len(tr.Batches[0].Spans))
 	}
 }
+
+// TestResponseHeaders_EngineInstrumentation covers the R7.7 contract
+// on the Tempo head: /api/search returns Strategy=native; /api/traces/{id}
+// returns Strategy=trace-by-id (engine.Meta.IsTraceByID short-circuits
+// the optimizer and tags the response).
+func TestResponseHeaders_EngineInstrumentation(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{
+		samples: []chclient.Sample{
+			{
+				MetricName: "GET /api/users",
+				Labels:     map[string]string{"service.name": "frontend"},
+				Timestamp:  time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC),
+				Value:      150_000_000,
+			},
+		},
+	}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	t.Run("search_native", func(t *testing.T) {
+		resp, err := http.Get(srv.URL + "/api/search?q=%7B%20resource.service.name%20%3D%20%22frontend%22%20%7D")
+		if err != nil {
+			t.Fatalf("GET: %v", err)
+		}
+		defer resp.Body.Close()
+		if got := resp.Header.Get("X-Cerberus-Strategy"); got != "native" {
+			t.Errorf("X-Cerberus-Strategy: got %q, want native", got)
+		}
+		if got := resp.Header.Get("X-Cerberus-Plan-Nodes"); got == "" {
+			t.Errorf("X-Cerberus-Plan-Nodes: missing")
+		}
+		if got := resp.Header.Get("X-Cerberus-CH-Millis"); got == "" {
+			t.Errorf("X-Cerberus-CH-Millis: missing")
+		}
+	})
+
+	t.Run("traceByID_short_circuit", func(t *testing.T) {
+		resp, err := http.Get(srv.URL + "/api/traces/abc123")
+		if err != nil {
+			t.Fatalf("GET: %v", err)
+		}
+		defer resp.Body.Close()
+		if got := resp.Header.Get("X-Cerberus-Strategy"); got != "trace-by-id" {
+			t.Errorf("X-Cerberus-Strategy: got %q, want trace-by-id", got)
+		}
+		if got := resp.Header.Get("X-Cerberus-Plan-Nodes"); got == "" {
+			t.Errorf("X-Cerberus-Plan-Nodes: missing")
+		}
+		if got := resp.Header.Get("X-Cerberus-CH-Millis"); got == "" {
+			t.Errorf("X-Cerberus-CH-Millis: missing")
+		}
+	})
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -21,6 +21,7 @@ package engine
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/tsouza/cerberus/internal/cerbtrace"
@@ -30,6 +31,37 @@ import (
 	"github.com/tsouza/cerberus/internal/optimizer"
 	"github.com/tsouza/cerberus/internal/telemetry"
 )
+
+// Canonical X-Cerberus-* response-header names the engine populates on
+// every Result / CursorResult.Headers map. Handlers iterate the bag and
+// stamp each (k, v) onto w.Header() before WriteHeader fires.
+//
+//   - HeaderStrategy   — execution-path label. "trace-by-id" for the
+//     Tempo /traces/{id} short-circuit, "native" otherwise. Reserved
+//     values for future strategies: "mv-substituted" (R3.6) and
+//     "shadow-fallback" (R3.9+).
+//   - HeaderPlanNodes  — post-optimize plan node count (chplan tree
+//     walked depth-first). Useful for debug dashboards + cost-shape
+//     telemetry.
+//   - HeaderCHMillis   — ClickHouse execute wall-clock in milliseconds.
+//     Only stamped on the eager Result (not CursorResult — the cursor
+//     keeps the connection open and the wall-clock isn't known until
+//     the caller drains).
+const (
+	HeaderStrategy  = "X-Cerberus-Strategy"
+	HeaderPlanNodes = "X-Cerberus-Plan-Nodes"
+	HeaderCHMillis  = "X-Cerberus-CH-Millis"
+)
+
+// strategyFor picks the canonical Strategy label from meta. Centralised
+// so Result and CursorResult agree on the value and so future strategies
+// (mv-substituted, shadow-fallback) have one place to land.
+func strategyFor(meta Meta) string {
+	if meta.IsTraceByID {
+		return "trace-by-id"
+	}
+	return "native"
+}
 
 // Querier is the subset of *chclient.Client Engine needs. Each handler
 // already declares a (broader) Querier in its own package; Engine
@@ -214,13 +246,21 @@ func (e *Engine) QueryPlan(ctx context.Context, lang Lang, plan chplan.Node, met
 		return Result{}, fmt.Errorf("engine: execute: %w", err)
 	}
 
+	nodes := cerbtrace.CountNodes(plan)
+	strategy := strategyFor(meta)
 	return Result{
 		Samples:       samples,
 		SQL:           sql,
 		Args:          args,
+		Strategy:      strategy,
 		CHMillis:      chMillis,
-		PlanNodeCount: cerbtrace.CountNodes(plan),
-		Meta:          meta,
+		PlanNodeCount: nodes,
+		Headers: map[string]string{
+			HeaderStrategy:  strategy,
+			HeaderPlanNodes: strconv.Itoa(nodes),
+			HeaderCHMillis:  strconv.FormatInt(chMillis, 10),
+		},
+		Meta: meta,
 	}, nil
 }
 
@@ -298,11 +338,23 @@ func (e *Engine) QueryPlanCursor(ctx context.Context, lang Lang, plan chplan.Nod
 		return CursorResult{}, fmt.Errorf("engine: execute: %w", err)
 	}
 
+	nodes := cerbtrace.CountNodes(plan)
+	strategy := strategyFor(meta)
 	return CursorResult{
 		Cursor:        cursor,
 		SQL:           sql,
 		Args:          args,
-		PlanNodeCount: cerbtrace.CountNodes(plan),
-		Meta:          meta,
+		Strategy:      strategy,
+		PlanNodeCount: nodes,
+		Headers: map[string]string{
+			HeaderStrategy:  strategy,
+			HeaderPlanNodes: strconv.Itoa(nodes),
+			// CH-Millis is omitted on the cursor path — wall-clock for
+			// the execute stage isn't known until the caller drains
+			// the cursor + Close()s it. Streaming consumers that want
+			// per-request CH timing should plug into the
+			// cerberus.clickhouse.* histograms instead.
+		},
+		Meta: meta,
 	}, nil
 }

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -120,6 +120,63 @@ func TestEngine_Query_HappyPath(t *testing.T) {
 	}
 }
 
+// TestEngine_Query_HeadersPopulated covers the R7.7 contract: every
+// successful Result carries the canonical X-Cerberus-* response-header
+// bag (Strategy / Plan-Nodes / CH-Millis), and the Strategy field on
+// Result agrees with the header value.
+func TestEngine_Query_HeadersPopulated(t *testing.T) {
+	t.Parallel()
+
+	q := &fakeQuerier{rows: []chclient.Sample{{MetricName: "up"}}}
+	lang := &fakeLang{name: "promql"}
+	eng := newEngine(q)
+
+	res, err := eng.Query(context.Background(), lang, "up")
+	if err != nil {
+		t.Fatalf("Query: unexpected err: %v", err)
+	}
+
+	if got, want := res.Strategy, "native"; got != want {
+		t.Errorf("Result.Strategy: got %q, want %q", got, want)
+	}
+	if res.Headers == nil {
+		t.Fatalf("Result.Headers: nil, want populated bag")
+	}
+	if got, want := res.Headers[engine.HeaderStrategy], "native"; got != want {
+		t.Errorf("Headers[%s]: got %q, want %q", engine.HeaderStrategy, got, want)
+	}
+	if got := res.Headers[engine.HeaderPlanNodes]; got == "" {
+		t.Errorf("Headers[%s]: empty, want numeric", engine.HeaderPlanNodes)
+	}
+	if got := res.Headers[engine.HeaderCHMillis]; got == "" {
+		t.Errorf("Headers[%s]: empty, want numeric", engine.HeaderCHMillis)
+	}
+}
+
+// TestEngine_QueryPlan_IsTraceByID_StrategyHeader verifies the
+// trace-by-id short-circuit also flips the Strategy label so debug
+// dashboards can distinguish the row-by-id path from the optimised
+// native path.
+func TestEngine_QueryPlan_IsTraceByID_StrategyHeader(t *testing.T) {
+	t.Parallel()
+
+	q := &fakeQuerier{}
+	lang := &fakeLang{name: "traceql"}
+	eng := newEngine(q)
+
+	plan := &chplan.Scan{Table: "otel_traces"}
+	res, err := eng.QueryPlan(context.Background(), lang, plan, engine.Meta{IsTraceByID: true})
+	if err != nil {
+		t.Fatalf("QueryPlan: unexpected err: %v", err)
+	}
+	if got, want := res.Strategy, "trace-by-id"; got != want {
+		t.Errorf("Result.Strategy: got %q, want %q", got, want)
+	}
+	if got, want := res.Headers[engine.HeaderStrategy], "trace-by-id"; got != want {
+		t.Errorf("Headers[%s]: got %q, want %q", engine.HeaderStrategy, got, want)
+	}
+}
+
 func TestEngine_QueryPlan_HappyPath(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Engine stamps a canonical `X-Cerberus-Strategy` / `X-Cerberus-Plan-Nodes` / `X-Cerberus-CH-Millis` bag on every `Result.Headers` (cursor variant omits CH-Millis since wall-clock isn't known until the caller drains).
- Strategy = `"trace-by-id"` for the Tempo `/traces/{id}` short-circuit, `"native"` otherwise. Centralised in one helper so future strategies (`mv-substituted`, `shadow-fallback`) land in one place.
- Each handler iterates `res.Headers` and stamps the bag onto `w.Header()` before the response body fires. Prom keeps the `chMillisCounter` middleware as a safety net on error paths.

## Test plan

- [x] `go test ./internal/engine/... ./internal/api/...` — all green
- [x] New engine tests: `TestEngine_Query_HeadersPopulated`, `TestEngine_QueryPlan_IsTraceByID_StrategyHeader`
- [x] New per-handler header tests: prom `TestResponseHeaders_PromVersionAndCHMillis` (extended), loki `TestResponseHeaders_EngineInstrumentation`, tempo `TestResponseHeaders_EngineInstrumentation` (covers `native` for `/api/search` and `trace-by-id` for `/api/traces/{id}`)
- [x] Response body bytes unchanged (headers are additive only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)