### PR TITLE
chore(audit): strip roadmap-ID narrative from v1.0.0 docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,8 @@ Drop-in **Prometheus / Loki / Tempo** HTTP gateway for **ClickHouse**. Parses ea
 - **Conventional Commits**, enforced by `commitlint` (see `.commitlintrc.json`). The `subject-case` rule is relaxed so Dependabot's `Bump X from Y to Z` subjects pass.
 - **Justfile is the canonical task runner.** `just` lists every recipe. Don't reach for `go test ./...` directly when `just test` exists — the recipe sets the race flag, the cover profile, and the right toolchain.
 - **No local validation; lefthook + CI own it.** Don't run `just test`, `just lint`, `go test`, `golangci-lint run`, `go build`, or `markdownlint-cli2` manually as a pre-flight before pushing. The repo's `lefthook.yml` runs lightweight formatters (`gofumpt` / `goimports` / `markdownlint-cli2 --fix`) on staged files at commit time, and the `commit-msg` hook validates Conventional Commits via `commitlint`. CI (`check` + `lint` jobs) runs the heavy validation. New contributors run `just hooks-install` once after cloning; agents trust the hook + CI and don't pre-flight.
-- **Compatibility is the source of truth for PromQL — at M6.** Until the M5 → M6 cut, `compatibility.yml` runs only on main pushes + nightly + manual dispatch (not on PRs) and acts as an informational baseline. At M6 we re-enable the `pull_request:` trigger and add `prometheus/compliance` to required checks; an entry in `harness/compatibility/expected-failures.json` then requires a comment explaining the upstream rationale.
-- **No raw SQL strings — typed API at RC6.** Use `internal/chsql.Builder` / `chsql.QueryBuilder` — the custom CH-flavored builder API (see [`docs/sql-builder-evaluation.md`](docs/sql-builder-evaluation.md) for the build-vs-buy decision and [`docs/roadmap.md` § RC6](docs/roadmap.md#rc6--type-safe-sql-via-custom-internalchsqlbuilder) for the milestone sequence). Compose clauses via typed `QueryBuilder` slots (`.Select` / `.From` / `.Where` / `.GroupBy` / `.OrderBy` / `.Limit` / `.Prewhere` / `.Join` / `.WithRecursive`) and expressions via typed Frags (`Eq` / `And` / `Or` / `Paren` / `Cast` / `In` / `Like` / `Add` / `Call` / `Array` / `Subscript` / `If` / `Lambda1` / `Subquery` / `BareIdent` / `InlineLit` / etc.). `Builder.WriteSQL` was renamed to unexported `writeSQL` in R6.11e and the `chsql.Raw` / `chsql.Concat` public escape hatches were retired in R6.12 — external packages cannot raw-write SQL by construction. The typed-Frag surface is closed: add new typed constructors when a shape isn't covered, never compose SQL via string concatenation. The Sprintf scanner is gone too; reviewer discipline + the typed API are the enforcement.
+- **Compatibility is the source of truth for PromQL.** `compatibility.yml` runs on main pushes + nightly + manual dispatch and acts as the informational baseline; a future cut can re-enable the `pull_request:` trigger and add `prometheus/compliance` to required checks. An entry in `harness/compatibility/expected-failures.json` requires a comment explaining the upstream rationale.
+- **No raw SQL strings — typed chsql API only.** Use `internal/chsql.Builder` / `chsql.QueryBuilder` — the custom CH-flavored builder API (see [`docs/sql-builder-evaluation.md`](docs/sql-builder-evaluation.md) for the build-vs-buy decision and [`docs/roadmap.md` § RC6](docs/roadmap.md#rc6--type-safe-sql-via-custom-internalchsqlbuilder) for the milestone sequence). Compose clauses via typed `QueryBuilder` slots (`.Select` / `.From` / `.Where` / `.GroupBy` / `.OrderBy` / `.Limit` / `.Prewhere` / `.Join` / `.WithRecursive`) and expressions via typed Frags (`Eq` / `And` / `Or` / `Paren` / `Cast` / `In` / `Like` / `Add` / `Call` / `Array` / `Subscript` / `If` / `Lambda1` / `Subquery` / `BareIdent` / `InlineLit` / etc.). `Builder.writeSQL` is unexported and the `chsql.Raw` / `chsql.Concat` public escape hatches are gone — external packages cannot raw-write SQL by construction. The typed-Frag surface is closed: add new typed constructors when a shape isn't covered, never compose SQL via string concatenation. Reviewer discipline + the typed API are the enforcement.
 
 ## Architecture map
 
@@ -19,7 +19,7 @@ internal/
   api/{prom,loki,tempo}/    HTTP handlers per upstream API
   promql/, logql/, traceql/ three heads: parse + lower
   chplan/                    shared plan IR (Scan, Filter, Project, Aggregate, RangeWindow, Limit + Expr tree)
-  optimizer/                 rule-based, fixpoint driver. RC1 ships 3 rules (filter-fusion, constant-fold, projection-pushdown); RC3 expands.
+  optimizer/                 rule-based, fixpoint driver. Pattern API + analyzer/optimizer rule split; transposes + PREWHERE promotion + MV substitution + late materialisation.
   chsql/                     plan → ClickHouse SQL emitter
   chclient/                  CH driver wrapper (clickhouse-go/v2)
   schema/                    OTel-CH default + override config
@@ -27,15 +27,15 @@ internal/
 cmd/cerberus/                main entrypoint
 test/spec/                   TXTAR golden tests (input QL → SQL/plan)
 test/e2e/                    k3d cluster + Grafana playwright smoke
-harness/compatibility/          prometheus/compliance Docker Compose harness (lands M0.6)
+harness/compatibility/          prometheus/compliance Docker Compose harness + shadow-mode differential testing
 deploy/{k3s,grafana}/        Kubernetes manifests + Grafana Helm values
-docs/                        roadmap.md, optimizer-research.md, compatibility.md (M5.4)
+docs/                        roadmap.md, optimizer-research.md, compatibility.md, engine.md, observability.md, 12factor.md, …
 ```
 
 Top-level reading order for any new contributor (human or agent):
 
 1. `README.md` — what the project is, quick start.
-2. `docs/roadmap.md` — RC1 / RC2 / RC3 plan, milestone tables, exit criteria.
+2. `docs/roadmap.md` — per-RC plan, milestone tables, exit criteria.
 3. `docs/engine.md` — shared query pipeline (`internal/engine/`), the `Lang` contract, and the extension points each new head plugs into.
 4. `docs/optimizer-research.md` — durable optimizer backlog for RC3.
 5. `internal/promql/lower.go` — the canonical lowering pattern; mirror it when adding LogQL / TraceQL slices.
@@ -45,8 +45,8 @@ Top-level reading order for any new contributor (human or agent):
 - **Add a TXTAR fixture** — use the `/cerberus:add-fixture` skill (under `.claude/skills/`). It creates `test/spec/<ql>/<name>.txtar` with the right section headers; run `just update-golden` after the implementation lands to fill in expected sections.
 - **Add an optimizer rule** — use the `/cerberus:add-optimizer-rule` skill. Scaffolds `internal/optimizer/<name>.go` + test + TXTAR fixtures.
 - **Bump parser deps** — use the `/cerberus:bump-parser-deps` skill. Runs `go get -u` on the three upstream parsers, runs `go mod tidy`, captures the diff for the PR description.
-- **Run E2E locally** — `just e2e-up && just e2e-seed && just e2e-run && just e2e-down` (lands in M0.1).
-- **Run the compatibility suite** — `just compatibility` (lands in M0.6). Diffs cerberus against reference Prometheus on a deterministic OTel fixture.
+- **Run E2E locally** — `just e2e-up && just e2e-seed && just e2e-run && just e2e-down`.
+- **Run the compatibility suite** — `just compatibility`. Diffs cerberus against reference Prometheus on a deterministic OTel fixture.
 
 ## Toolchain notes
 
@@ -77,5 +77,5 @@ Local SSH config has two GitHub identities:
 
 - "How does this PR ship?" → branch + push + `gh pr create` → CI must pass → squash-merge with `gh pr merge --squash --delete-branch`.
 - "Where do I add this feature?" → check `docs/roadmap.md` first; the milestone tells you which package + which fixture dir.
-- "Is this RC1 / RC2 / RC3?" → roadmap tables make this explicit. When in doubt, add a comment to the PR asking.
+- "Which RC does this belong to?" → roadmap tables make this explicit. When in doubt, add a comment to the PR asking.
 - "Can I update the Project from a PR?" → yes, the repo is linked. Move the matching draft item to `In Progress` when you start, `Done` when the PR merges (or wire a workflow that does it).

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ ClickHouse is a great single store for all three signals. The only thing missing
 
 ## Status
 
-> 🚧 **`v1.0.0-RC2` candidate** — RC2 closes the advanced-QL backlog on top of RC1: PromQL subqueries (P0 4.1–4.11), `predict_linear` / `holt_winters` / `@start()` / `@end()`, `histogram_quantile` over classic + native (exp) histograms, `group_left` / `group_right` cardinality edges; LogQL `| unpack` / `| pattern` / `| line_format` / `| decolorize` / `| label_format` with Loki template funcs, `bytes_*` alignment, `/api/v1/tail` WebSocket, `/labels`, `/label/values`, `/series`, `/detected_fields`, `/patterns`, `/index/stats`, `/index/volume`; TraceQL set ops, link traversal + span-events, `histogram_over_time`, MetricsPipeline lowering, Tempo `/api/search/recent`, `/api/search/tags`, `/api/search/tag/<n>/values`, `/api/metrics/query_range`. The Tempo `unsafe.Pointer` shim is retired via the [`tsouza/tempo:cerberus-accessors`](https://github.com/tsouza/tempo/tree/cerberus-accessors) fork; the OTel CH Exporter schema is now the source of truth via [`tsouza/opentelemetry-collector-contrib:cerberus-ddl`](https://github.com/tsouza/opentelemetry-collector-contrib/tree/cerberus-ddl). See [`CHANGELOG.md`](CHANGELOG.md) for the full RC2 entry, and [`docs/roadmap.md`](docs/roadmap.md) for the path to v1.0.0.
+> **`v1.0.0` candidate.** Cerberus has shipped the full RC1–RC8 backlog: PromQL / LogQL / TraceQL parse + lowering, the pattern-based optimizer (transposes, PREWHERE promotion, late materialisation, MV substitution), the typed `chsql` SQL emitter, the shared `internal/engine` pipeline, full self-observability (`slog` + OTel traces + OTLP-exported metrics), 12-factor packaging (`/readyz`, admission control, `docker compose up` for one-command local dev), and the chDB-backed round-trip + property test suites. Upstream parser shims are retired via the [`tsouza/tempo:cerberus-accessors`](https://github.com/tsouza/tempo/tree/cerberus-accessors) fork; the schema source of truth is [`tsouza/opentelemetry-collector-contrib:cerberus-ddl`](https://github.com/tsouza/opentelemetry-collector-contrib/tree/cerberus-ddl). See [`CHANGELOG.md`](CHANGELOG.md) for the per-release breakdown.
 
 ## Architecture
 
@@ -91,14 +91,14 @@ Loki + Tempo). ClickHouse data persists in a named volume; use
 
 ### From a published release
 
-Pull the container image (pin to a specific RC — `:latest` is **only**
-advanced by stable releases; RC / alpha / beta tags don't move it):
+Pull the container image (`:latest` is **only** advanced by stable
+releases; RC / alpha / beta tags don't move it):
 
 ```sh
-docker pull ghcr.io/tsouza/cerberus:v1.0.0-RC2
+docker pull ghcr.io/tsouza/cerberus:v1.0.0
 docker run --rm -p 8080:8080 \
   -e CERBERUS_CH_ADDR=clickhouse:9000 \
-  ghcr.io/tsouza/cerberus:v1.0.0-RC2
+  ghcr.io/tsouza/cerberus:v1.0.0
 ```
 
 Or download a prebuilt binary from the [release page](https://github.com/tsouza/cerberus/releases)
@@ -155,14 +155,14 @@ internal/
   config/                # runtime config
 test/
   spec/                  # TXTAR fixture-driven tests
-  e2e/                   # k3d + playwright (PR8)
+  e2e/                   # k3d + playwright
 deploy/k3s/              # Kubernetes manifests
 deploy/grafana/          # provisioned datasources + dashboards
 ```
 
 ## Contributing
 
-Open an issue or a discussion before opening a large PR — the seed is opinionated and the architecture lockdown is recent. Smaller PRs (a new optimizer rule, a new TXTAR fixture, a parser-dep bump) are welcome any time. See [CONTRIBUTING.md](CONTRIBUTING.md) (lands in PR9).
+Open an issue or a discussion before opening a large PR — the seed is opinionated and the architecture lockdown is recent. Smaller PRs (a new optimizer rule, a new TXTAR fixture, a parser-dep bump) are welcome any time. See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 

--- a/docs/chsql-audit.md
+++ b/docs/chsql-audit.md
@@ -1,12 +1,12 @@
 # chsql callsite rulebook
 
-> **Historical document (as of RC6 R6.11e).** The cosplay/grandfathered
-> categorisations below are now of historical interest only:
-> `Builder.WriteSQL` was renamed to the unexported `writeSQL` in R6.11e,
-> so external packages cannot raw-write clause keywords by construction.
-> The Sprintf scanner (`cmd/check-sql/`, R6.9) was retired in the same
-> PR. Reviewer discipline + the typed surface (`QueryBuilder` slots +
-> typed Frag constructors) are the going-forward enforcement.
+> **Historical document.** The cosplay / grandfathered categorisations
+> below are no longer load-bearing: the `Builder.WriteSQL` public method
+> was renamed to the unexported `writeSQL`, so external packages cannot
+> raw-write clause keywords by construction. The `chsql.Raw` / `chsql.Concat`
+> public escape hatches are also gone. Reviewer discipline plus the typed
+> surface (`QueryBuilder` slots + typed Frag constructors) are the
+> going-forward enforcement.
 >
 > The bucket-3 (legitimate operator-token) discussion is still live —
 > it describes the in-package Frag layer, which remains the right shape
@@ -16,15 +16,15 @@ The "no raw SQL strings" hard rule (CLAUDE.md § Hard rules) has one positive di
 
 ## Three buckets (historical categorisation)
 
-- ~~**Bucket 1 — Cosplay (forbidden, fail the lint gate).** `Builder.WriteSQL(" SELECT ")` / `WriteSQL(" FROM ")` / `WriteSQL(" WHERE ")` / `WriteSQL(" GROUP BY ")` / `WriteSQL(" ORDER BY ")` / `WriteSQL(" LIMIT ")` / `WriteSQL(" PREWHERE ")` / `WriteSQL(" JOIN ")` / `WriteSQL(" UNION ")` / `WriteSQL(" HAVING ")` etc. used to compose structural clause keywords.~~ **Retired in R6.11e:** the `WriteSQL` method is now unexported (`writeSQL`); external packages cannot construct this shape at all. Use the typed slots instead: `.Select(...)`, `.From(...)`, `.Where(...)`, `.GroupBy(...)`, `.OrderBy(...)`, `.Limit(...)`, `.Prewhere(...)`, `.Join(kind, src, on)`, `.WithRecursive(name, anchor, recursive)`, plus the `chsql.As(expr, alias)` / `QueryBuilder.SelectAs(expr, alias)` helpers for aliased projections.
+- ~~**Bucket 1 — Cosplay (forbidden, fail the lint gate).** `Builder.WriteSQL(" SELECT ")` / `WriteSQL(" FROM ")` / `WriteSQL(" WHERE ")` / `WriteSQL(" GROUP BY ")` / `WriteSQL(" ORDER BY ")` / `WriteSQL(" LIMIT ")` / `WriteSQL(" PREWHERE ")` / `WriteSQL(" JOIN ")` / `WriteSQL(" UNION ")` / `WriteSQL(" HAVING ")` etc. used to compose structural clause keywords.~~ **Retired:** the `WriteSQL` method is now unexported (`writeSQL`); external packages cannot construct this shape at all. Use the typed slots instead: `.Select(...)`, `.From(...)`, `.Where(...)`, `.GroupBy(...)`, `.OrderBy(...)`, `.Limit(...)`, `.Prewhere(...)`, `.Join(kind, src, on)`, `.WithRecursive(name, anchor, recursive)`, plus the `chsql.As(expr, alias)` / `QueryBuilder.SelectAs(expr, alias)` helpers for aliased projections.
 
-- ~~**Bucket 2 — Grandfathered (empty post-R6.7).**~~ Closed out by R6.7; the file list is preserved here for archaeology: `emit_expr.go` (retired R6.4), `range_window.go` + `emit_node.go::emitOrderBy` (retired R6.5), `vector_join.go` + `structural_join.go` (retired R6.6), `internal/api/prom/metadata.go` (retired R6.7). All four files now flow through `QueryBuilder`.
+- ~~**Bucket 2 — Grandfathered.**~~ Empty; the file list is preserved here for archaeology: `emit_expr.go`, `range_window.go` + `emit_node.go::emitOrderBy`, `vector_join.go` + `structural_join.go`, `internal/api/prom/metadata.go`. All flow through `QueryBuilder`.
 
-- **Bucket 3 — Legitimate token writes (in-package only, allowed).** `writeSQL(" = ")` / `writeSQL(" AS ")` / `writeSQL(", ")` / `writeSQL(" > ")` etc. used inside `Frag` callbacks for operators or glue that has no typed helper. Acceptable per CLAUDE.md (the rule forbids *clause keywords*, not operator tokens). Since `writeSQL` is now unexported, this pattern is confined to `internal/chsql/*.go` — external packages compose operator tokens via the typed `Frag` constructors (`Eq` / `And` / `Or` / `Paren` / `Cast` / `In` / `Like` / `Add` / etc.) instead.
+- **Bucket 3 — Legitimate token writes (in-package only, allowed).** `writeSQL(" = ")` / `writeSQL(" AS ")` / `writeSQL(", ")` / `writeSQL(" > ")` etc. used inside `Frag` callbacks for operators or glue that has no typed helper. Acceptable per CLAUDE.md (the rule forbids *clause keywords*, not operator tokens). Since `writeSQL` is unexported, this pattern is confined to `internal/chsql/*.go` — external packages compose operator tokens via the typed `Frag` constructors (`Eq` / `And` / `Or` / `Paren` / `Cast` / `In` / `Like` / `Add` / etc.) instead.
 
-## R6.12 closer — Raw + Concat retired
+## Raw + Concat retired
 
-R6.12 (executed) retired the public `chsql.Raw(sql string) Frag` escape hatch and the unconstrained `chsql.Concat(parts ...Frag) Frag` joiner. They were the last public surface that accepted opaque SQL bytes from a caller; both are gone. The replacements:
+The public `chsql.Raw(sql string) Frag` escape hatch and the unconstrained `chsql.Concat(parts ...Frag) Frag` joiner are both gone. They were the last public surface that accepted opaque SQL bytes from a caller. The replacements:
 
 - **`chsql.BareIdent(name string)`** — emits `name` verbatim with no backtick quoting. Narrow trust contract: caller guarantees `name` matches `[a-zA-Z_][a-zA-Z0-9_]*`. Used for lambda parameter / synthetic-alias references that the CH parser must read as a bare identifier (`mapFilter((k, v) -> k IN (?), col)` — `k` is not a column).
 - **`chsql.InlineLit(v any)`** — emits an int / int64 / float64 / string literal inline (no `?` binding) with CH-safe quoting. For values that are part of the query *shape* (array literals, default sentinels, lambda predicates). Prefer `Lit` (`?`-bound) when the value is user / plan data.
@@ -33,7 +33,7 @@ R6.12 (executed) retired the public `chsql.Raw(sql string) Frag` escape hatch an
 - **`chsql.If(cond, then, else Frag)`** — CH `if(<cond>, <then>, <else>)` with structural arity (three fixed slots).
 - **`chsql.Lambda1(param string, body Frag)`** — single-parameter lambda `<p> -> <body>` (no parens around the parameter). Multi-parameter lambdas use `Builder.Lambda` directly.
 - **`chsql.Subquery(s Subqueryable)`** — wraps a `Subqueryable` (`*QueryBuilder` or `PreRenderedSQL`) in parens and splices its args at the Frag's position. Used for QueryBuilder-into-QueryBuilder composition and as the documented interop with the legacy string-typed `chsql.Emit`.
-- **`chsql.PreRenderedSQL{SQL, Args}`** — adapter holding an already-rendered (sql, args) pair so legacy `chsql.Emit` output can flow through `Subquery` without raw-string composition. A future R6.x milestone will port `chsql.Emit` to return a `*QueryBuilder` and retire this type.
+- **`chsql.PreRenderedSQL{SQL, Args}`** — adapter holding an already-rendered (sql, args) pair so legacy `chsql.Emit` output can flow through `Subquery` without raw-string composition.
 
 The package-private `verbatim(sql string) Frag` (in `builder.go`) is the in-package successor to `Raw` for synthetic emitter-controlled tokens that don't fit a typed constructor — local CTE / alias names pinned by golden fixtures, qualifier-prefixed references like `c._depth` / `t.<col>` that the recursive CTE walks, and bare references like `anchor_ts` / `ts` inside the range-window emitter's arrayFilter / WHERE clauses. External packages can't reach it; in-package callers use it sparingly.
 
@@ -47,7 +47,7 @@ The only string-typed inputs to the chsql public surface now are:
 
 ## Pointers
 
-- `internal/chsql/builder.go` — the public `Builder` + `QueryBuilder` API, plus the R6.12.f-introduced `BareIdent` / `InlineLit` / `Array` / `Subscript` / `If` / `Lambda1` / `Subquery` / `PreRenderedSQL` constructors.
-- `internal/chsql/builder_test.go` — canonical examples of `Frag` callbacks composing operator tokens (bucket-3 pattern) and the new typed constructors.
-- `docs/roadmap.md` § RC6 — R6.4–R6.7 ports (executed) + R6.9 lint gate + R6.10 docs + R6.12 Raw/Concat retirement.
-- `docs/sql-builder-evaluation.md` — the R6.0 build-vs-buy decision.
+- `internal/chsql/builder.go` — the public `Builder` + `QueryBuilder` API, plus the `BareIdent` / `InlineLit` / `Array` / `Subscript` / `If` / `Lambda1` / `Subquery` / `PreRenderedSQL` constructors.
+- `internal/chsql/builder_test.go` — canonical examples of `Frag` callbacks composing operator tokens (bucket-3 pattern) and the typed constructors.
+- `docs/roadmap.md` § RC6 — the milestone history that led to the current shape.
+- `docs/sql-builder-evaluation.md` — the build-vs-buy decision.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -4,21 +4,20 @@ Cerberus is its own first-class observability customer: it queries OTel-CH
 metrics + logs + traces, and it ships the same shape of telemetry back into
 that store so a self-dashboard works against a running cluster.
 
-The full self-observability stack lands across **RC4**:
+The self-observability stack covers four pillars:
 
-| Item                                                                                                  | Status  | Notes                                    |
-| ----------------------------------------------------------------------------------------------------- | ------- | ---------------------------------------- |
-| R4.1 — slog quality pass + env-configurable format / level                                            | landed  | this doc                                 |
-| R4.2 — `otelhttp.NewHandler` wraps the Prom / Loki / Tempo handlers                                   | planned | adds one span per HTTP request           |
-| R4.3 — Custom spans around parse / lower / optimize / emit / execute                                  | planned | pipeline stage timings                   |
-| R4.4 — Self-metrics: request count + latency + CH roundtrip + in-flight gauge                         | planned | HPA-consumable                           |
-| R4.5 — OTLP exporters wired (`CERBERUS_OTLP_ENDPOINT` / `_INSECURE` / `_HEADERS` / `_TIMEOUT`)        | landed  | graceful no-op when endpoint unreachable |
-| R4.6 — `deploy/k3s/otel-collector.yaml` + `deploy/grafana/dashboards/cerberus-self.json`              | planned | wires the export path end-to-end         |
+| Pillar                | Surface                                                                                          |
+| --------------------- | ------------------------------------------------------------------------------------------------ |
+| Structured logging    | `log/slog`, env-configurable format / level (this page)                                          |
+| HTTP request tracing  | `otelhttp.NewHandler` wraps every Prom / Loki / Tempo endpoint — one span per HTTP request       |
+| Pipeline tracing      | Custom spans around parse / lower / optimize / emit / execute give per-stage timings             |
+| Self-metrics + OTLP   | Request count + latency + CH roundtrip + in-flight gauge, exported via OTLP gRPC                 |
 
-This page only covers what has already shipped. The remaining rows are
-expanded as the milestones land.
+The k3s manifest at `deploy/k3s/otel-collector.yaml` and the provisioned
+`deploy/grafana/dashboards/cerberus-self.json` wire the full export path
+end-to-end against a running cluster.
 
-## Logging (R4.1, shipped)
+## Logging
 
 Cerberus uses the standard library's [`log/slog`](https://pkg.go.dev/log/slog)
 for structured logging. Logs are written as an event stream to `stderr`
@@ -76,10 +75,10 @@ so a future `slog.Handler` middleware can branch on `errors.As` /
 
 ```text
 # CERBERUS_LOG_FORMAT=text CERBERUS_LOG_LEVEL=info (defaults)
-time=2026-05-13T10:14:01.000Z level=INFO msg="cerberus starting" version=v1.0.0-RC4 http_addr=:8080 ch_addr=clickhouse:9000 ch_db=otel log_format=text log_level=INFO
+time=2026-05-13T10:14:01.000Z level=INFO msg="cerberus starting" version=v1.0.0 http_addr=:8080 ch_addr=clickhouse:9000 ch_db=otel log_format=text log_level=INFO
 
 # CERBERUS_LOG_FORMAT=json
-{"time":"2026-05-13T10:14:01Z","level":"INFO","msg":"cerberus starting","version":"v1.0.0-RC4","http_addr":":8080","ch_addr":"clickhouse:9000","ch_db":"otel","log_format":"json","log_level":"INFO"}
+{"time":"2026-05-13T10:14:01Z","level":"INFO","msg":"cerberus starting","version":"v1.0.0","http_addr":":8080","ch_addr":"clickhouse:9000","ch_db":"otel","log_format":"json","log_level":"INFO"}
 ```
 
 ## Schema-shape overrides
@@ -111,7 +110,7 @@ newlines) are treated as unset and fall back to the default. Non-empty
 values are trimmed before use. Column-name overrides are not in the
 current surface — open a tracking issue if a deployment needs them.
 
-## Tracing + metrics export (R4.5, shipped)
+## Tracing + metrics export
 
 Cerberus emits structured logs, spans, and self-metrics so an operator can
 see what the gateway is doing in production.

--- a/docs/optimizer-research.md
+++ b/docs/optimizer-research.md
@@ -73,20 +73,20 @@ When one of these is implemented, open a PR — the reference here is the PR des
 
 - **"An Overview of Query Optimization in Relational Systems."** Chaudhuri, PODS 1998.
   [PDF.](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/pods98-tutorial.pdf)
-  Still the canonical statement of the rule-vs-cost line. Decisions a fixpoint rule set cannot make: (a) join ordering beyond two relations, (b) materialised-view selection among overlapping candidates, (c) predicate ordering when predicates have very different selectivities. Cerberus hit (b) first in RC3 R3.6 — see the Jindal entry below.
+  Still the canonical statement of the rule-vs-cost line. Decisions a fixpoint rule set cannot make: (a) join ordering beyond two relations, (b) materialised-view selection among overlapping candidates, (c) predicate ordering when predicates have very different selectivities. Cerberus hit (b) first with the MV-substitution rule — see the Jindal entry below.
 - **"Selecting Subexpressions to Materialize at Datacenter Scale."** Jindal et al., VLDB 2018.
   [PDF.](http://www.vldb.org/pvldb/vol11/p800-jindal.pdf)
-  The precise problem cerberus faces once multiple OTel rollups (`_5m`, `_1h`, raw) are in play: given a query and overlapping candidate materializations, pick the subset. Section 4 (subexpression matching) and section 6 (cost model) are the parts to read. Addressed in v1 by `internal/optimizer.MVSubstitution` (RC3 R3.6, #201) with a simple-heuristic `firstApplicable` cost model — picks the first registry-listed rollup that passes the four safety conditions (step ≥ window, range a multiple of window, outer aggregate commutes with rollup AggOp, rollup exists for the base table). The `costModel` interface is stubbed so v2 can swap in a real estimator without touching the rule.
+  The precise problem cerberus faces once multiple OTel rollups (`_5m`, `_1h`, raw) are in play: given a query and overlapping candidate materializations, pick the subset. Section 4 (subexpression matching) and section 6 (cost model) are the parts to read. Addressed in v1 by `internal/optimizer.MVSubstitution` (PR #201) with a simple-heuristic `firstApplicable` cost model — picks the first registry-listed rollup that passes the four safety conditions (step ≥ window, range a multiple of window, outer aggregate commutes with rollup AggOp, rollup exists for the base table). The `costModel` interface is stubbed so v2 can swap in a real estimator without touching the rule.
 
 ---
 
 ## Suggested implementation order
 
-1. Port the three Calcite transpose rules (§1) — shipped via #177 (RC3 R3.2).
+1. Port the three Calcite transpose rules (§1) — shipped via #177.
 2. Mirror VictoriaMetrics's `PushdownBinaryOpFilters` test structure (§2) — gives us a known-good fixture pattern.
-3. Adopt Spark Catalyst's `Batch` grouping for the fixpoint driver (§4) — prevents thrashing as the rule set grows. (RC3 R3.3.)
-4. Add a sort-key-aware filter emitter in `internal/chsql` (§3) — first ClickHouse-specific codegen rule. (RC3 R3.4 — PREWHERE promotion.)
-5. Real `RangeWindow` SQL via `groupArray` / ordered-scan patterns (§2 + §5) — shipped through RC1 M1.1 and refined through RC2.
-6. MV substitution for `otel_metrics_*` rollups (§2 Promscale + §6 Jindal) — the milestone where cerberus commits to a cost model. Shipped via #201 (RC3 R3.6) with a simple-heuristic v1; the `costModel` interface stub keeps the seam open for a real estimator in a future RC.
+3. Adopt Spark Catalyst's `Batch` grouping for the fixpoint driver (§4) — prevents thrashing as the rule set grows. Shipped via #191.
+4. Add a sort-key-aware filter emitter in `internal/chsql` (§3) — first ClickHouse-specific codegen rule. PREWHERE promotion shipped via #196.
+5. Real `RangeWindow` SQL via `groupArray` / ordered-scan patterns (§2 + §5) — shipped through RC1 and refined through RC2.
+6. MV substitution for `otel_metrics_*` rollups (§2 Promscale + §6 Jindal) — the milestone where cerberus commits to a cost model. Shipped via #201 with a simple-heuristic v1; the `costModel` interface stub keeps the seam open for a real estimator in a future release.
 
-The pattern-based `Rule` API itself shipped via #135 (RC3 R3.1) — every new rule above lands on top of that API.
+The pattern-based `Rule` API itself shipped via #135 — every new rule above lands on top of that API.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -305,14 +305,14 @@ Decision milestone. Output: `docs/execution-engine-evaluation.md` with a recomme
 
 ## RC8 — chDB-backed semantic test layer
 
-The TXTAR text-equality suite catches every change in the emitted SQL but it doesn't catch *semantic* regressions where the SQL still parses and its result set silently flips. RC8 closes that gap by wiring [chDB](https://github.com/chdb-io/chdb-go) (in-process ClickHouse) into the test layers that benefit from real query execution against deterministic seeds.
+The TXTAR text-equality suite catches every change in the emitted SQL but it doesn't catch _semantic_ regressions where the SQL still parses and its result set silently flips. RC8 closes that gap by wiring [chDB](https://github.com/chdb-io/chdb-go) (in-process ClickHouse) into the test layers that benefit from real query execution against deterministic seeds.
 
 | #    | Item                                                                                                                 | Status           |
 | ---- | -------------------------------------------------------------------------------------------------------------------- | ---------------- |
 | R8.0 | Driver probe: validate `Map(String, String)` scan via `database/sql` + document chdb-go v1.11.0 quirks               | shipped via #221 |
 | R8.1 | TXTAR `-- seed --` / `-- expected_rows --` sections + build-tagged `chdb` runner                                     | shipped via #223 |
 | R8.2 | chDB-backed `Querier` for handler tests (replaces hand-rolled stubs across `internal/api/{prom,loki,tempo}`)         | shipped via #229 |
-| R8.3 | Property test on optimizer rules (`internal/optimizer/property_test.go`) + mutation kill criterion using chDB         | shipped via #233 |
+| R8.3 | Property test on optimizer rules (`internal/optimizer/property_test.go`) + mutation kill criterion using chDB        | shipped via #233 |
 
 **Exit criterion:** every TXTAR fixture that opts in renders byte-stable SQL **and** the row set it produces against a chDB session matches the pinned `expected_rows`; the optimizer property test runs 100 random plans per CI and finds zero divergence between unoptimized + optimized output; `just mutate-chdb` produces a strictly higher kill score than `just mutate` (semantically equivalent mutants are correctly not killed).
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,18 +2,21 @@
 
 This document is the public-facing narrative for the path to `v1.0.0`. Status by milestone lives in the [GitHub Project](https://github.com/users/tsouza/projects) — _Cerberus v1.0.0 Roadmap_. Per-PR-level reasoning lives in the PR descriptions themselves; we don't use GitHub Issues.
 
+> **GA status:** every RC1–RC8 milestone has shipped; the project board is fully drained. The maintainer cuts `v1.0.0` from the last green main after a final pre-release audit.
+
 ## At a glance
 
-| Release        | Theme                                                                                 | What "done" means                                                                                 |
-| -------------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| **v1.0.0-RC1** | Full PromQL / LogQL / TraceQL support + 90% upstream API compatibility                | Compatibility corpora pass; Grafana sees cerberus as drop-in for Prom / Loki / Tempo              |
-| **v1.0.0-RC2** | Advanced QL features + deferred API surface                                           | Subqueries, native-histogram quantiles, structural-chain TraceQL, LogQL `\| unpack`, Loki `tail`… |
-| **v1.0.0-RC3** | Optimizer rewrite + performance + scalability + advanced testing                      | Pattern-based rules, MV substitution, streaming cursor, shadow-mode differential testing          |
-| **v1.0.0-RC4** | Full self-observability                                                               | Cerberus emits its own structured logs (slog), OTel metrics + traces, defaults to the same CH     |
-| **v1.0.0-RC5** | 12-factor compatibility + scale-out polish                                            | `/readyz` pings CH, admission control, HPA recipe, dev `docker-compose.yml`, schema overrides     |
-| **v1.0.0-RC6** | Type-safe SQL via custom `internal/chsql.Builder` (R6.0 evaluation → R6.1–R6.10 port) | No `fmt.Sprintf`-on-SQL anywhere; typed builder with CH-specific helpers; lint enforcement        |
-| **v1.0.0-RC7** | `internal/engine/` ExecutionEngine framework (R7.0 evaluation → R7.1–R7.8 port)       | One pipeline owner; handlers under ~150 LoC each; shared format + httperr helpers                 |
-| **v1.0.0**     | Tag the last green RC                                                                 | All RCs stable; HTTP wire protocols are the public surface, not a Go API                          |
+| Release        | Theme                                                                  | What "done" means                                                                                 |
+| -------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| **v1.0.0-RC1** | Full PromQL / LogQL / TraceQL support + 90% upstream API compatibility | Compatibility corpora pass; Grafana sees cerberus as drop-in for Prom / Loki / Tempo              |
+| **v1.0.0-RC2** | Advanced QL features + deferred API surface                            | Subqueries, native-histogram quantiles, structural-chain TraceQL, LogQL `\| unpack`, Loki `tail`… |
+| **v1.0.0-RC3** | Optimizer rewrite + performance + scalability + advanced testing       | Pattern-based rules, MV substitution, streaming cursor, shadow-mode differential testing          |
+| **v1.0.0-RC4** | Full self-observability                                                | Cerberus emits its own structured logs (slog), OTel metrics + traces, defaults to the same CH     |
+| **v1.0.0-RC5** | 12-factor compatibility + scale-out polish                             | `/readyz` pings CH, admission control, HPA recipe, dev `docker-compose.yml`, schema overrides     |
+| **v1.0.0-RC6** | Type-safe SQL via custom `internal/chsql.Builder`                      | No `fmt.Sprintf`-on-SQL anywhere; typed builder with CH-specific helpers; closed Frag surface     |
+| **v1.0.0-RC7** | `internal/engine/` ExecutionEngine framework                           | One pipeline owner; handlers under ~150 LoC each; shared format + httperr helpers                 |
+| **v1.0.0-RC8** | chDB-backed semantic test layer                                        | TXTAR fixtures opt into in-process chDB execution; optimizer property tests; mutation kill lane   |
+| **v1.0.0**     | Tag the last green RC                                                  | All RCs stable; HTTP wire protocols are the public surface, not a Go API                          |
 
 ---
 
@@ -297,6 +300,21 @@ Decision milestone. Output: `docs/execution-engine-evaluation.md` with a recomme
 | R7.8 | Engine becomes the natural seat for RC3's strategy switch and RC4's OTel hooks. Document the extension points in `docs/engine.md` so RC8+ work plugs in cleanly.                                                                               |
 
 **Exit criterion:** `internal/api/{prom,loki,tempo}/handler.go` are each under ~150 LoC and contain only HTTP wrapping + response shaping; `internal/engine/` carries the pipeline; all three handlers emit `X-Cerberus-CH-Millis`; the existing TXTAR + compatibility + Playwright suites pass without changes (refactor is behavioural-equivalence).
+
+---
+
+## RC8 — chDB-backed semantic test layer
+
+The TXTAR text-equality suite catches every change in the emitted SQL but it doesn't catch *semantic* regressions where the SQL still parses and its result set silently flips. RC8 closes that gap by wiring [chDB](https://github.com/chdb-io/chdb-go) (in-process ClickHouse) into the test layers that benefit from real query execution against deterministic seeds.
+
+| #    | Item                                                                                                                 | Status           |
+| ---- | -------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| R8.0 | Driver probe: validate `Map(String, String)` scan via `database/sql` + document chdb-go v1.11.0 quirks               | shipped via #221 |
+| R8.1 | TXTAR `-- seed --` / `-- expected_rows --` sections + build-tagged `chdb` runner                                     | shipped via #223 |
+| R8.2 | chDB-backed `Querier` for handler tests (replaces hand-rolled stubs across `internal/api/{prom,loki,tempo}`)         | shipped via #229 |
+| R8.3 | Property test on optimizer rules (`internal/optimizer/property_test.go`) + mutation kill criterion using chDB         | shipped via #233 |
+
+**Exit criterion:** every TXTAR fixture that opts in renders byte-stable SQL **and** the row set it produces against a chDB session matches the pinned `expected_rows`; the optimizer property test runs 100 random plans per CI and finds zero divergence between unoptimized + optimized output; `just mutate-chdb` produces a strictly higher kill score than `just mutate` (semantically equivalent mutants are correctly not killed).
 
 ---
 

--- a/docs/sql-builder-evaluation.md
+++ b/docs/sql-builder-evaluation.md
@@ -1,21 +1,21 @@
-# RC6 R6.0 — SQL builder evaluation
+# SQL builder evaluation
 
-**Status:** decision landed; `internal/chsql.Builder` implementation in flight under R6.1–R6.10.
+**Status:** decision landed; `internal/chsql.Builder` ships as the canonical SQL emission surface.
 **Decision:** **(b) Build `internal/chsql.Builder` from scratch.**
 
 ## Decision summary
 
-The CLAUDE.md RC6 hard rule forbids `fmt.Sprintf` (and any string concatenation) for ClickHouse SQL generation. R6.0 weighed three paths:
+The CLAUDE.md hard rule forbids `fmt.Sprintf` (and any string concatenation) for ClickHouse SQL generation. The evaluation weighed three paths:
 
 - **(a)** Adopt [`huandu/go-sqlbuilder`](https://github.com/huandu/go-sqlbuilder) wrapped with a cerberus extension layer.
 - **(b)** Build a custom `internal/chsql.Builder` tailored to chplan IR.
 - **(c)** Defer the migration entirely.
 
-The honest reading of cerberus's state at R6.0:
+The honest reading of cerberus's state at the time of the decision:
 
 - The **security argument** for the migration is weak: every dynamic value already rides through `?` placeholders; the remaining Sprintf surface (`metadata.go` + one `range_window.go` numeric format) uses schema-config identifiers and Go-side floats, not user strings.
-- The **architectural argument** is strong: RC3's optimizer rules (PREWHERE promotion, sort-key reordering, materialised-view substitution, late materialisation) need to compose SQL fragments programmatically, and the Sprintf + `strings.Builder` mixture can't model that cleanly.
-- The **existing chsql emitter is already a custom builder in miniature** — it owns a `strings.Builder` + `[]any` placeholder slice, dispatches per chplan node, handles backtick quoting via `writeIdent`, and renders parameterised aggregates already. RC6 R6.1+ work is to **make that builder a named, public API**, not to rip-and-replace it with a third-party library.
+- The **architectural argument** is strong: optimizer rules (PREWHERE promotion, sort-key reordering, materialised-view substitution, late materialisation) need to compose SQL fragments programmatically, and the Sprintf + `strings.Builder` mixture can't model that cleanly.
+- The **existing chsql emitter is already a custom builder in miniature** — it owns a `strings.Builder` + `[]any` placeholder slice, dispatches per chplan node, handles backtick quoting via `writeIdent`, and renders parameterised aggregates already. The work was to **make that builder a named, public API**, not to rip-and-replace it with a third-party library.
 
 ## Decision matrix
 
@@ -40,11 +40,11 @@ The pivotal axis is **API match to chplan IR**. The existing emitter is structur
 
 ## Why not (c)
 
-- RC3's optimizer rules need fragment composition, and the optimizer rule work overlaps RC2's tail end. Deferring would force RC3 to either grow Sprintf-driven for the new emit code (compounding the migration debt) or defer the optimizer rules themselves.
-- The CLAUDE.md hard rule already states "new emitter code must go through" the builder — without R6.1 landing, every RC2/RC3 PR either violates the rule or postpones the new emit code.
+- Optimizer rules need fragment composition. Deferring would force later RCs to either grow Sprintf-driven for the new emit code (compounding the migration debt) or defer the optimizer rules themselves.
+- The CLAUDE.md hard rule already states "new emitter code must go through" the builder — without the scaffolding landing, every new emit PR either violates the rule or postpones the new emit code.
 
 ## Outcome
 
-Path **(b)** is implemented across R6.1–R6.10 in [`docs/roadmap.md` § RC6](roadmap.md#rc6--type-safe-sql-via-custom-internalchsqlbuilder). R6.1 (#131) landed the scaffolding (`internal/chsql/builder.go`); R6.2 / R6.3 / R6.4 / R6.5 / R6.6 / R6.7 ported the existing emitter file-by-file behind the typed surface; R6.8 wires the remaining loki + tempo helpers; R6.9 lands the lint gate; R6.10 closes out with the CLAUDE.md hard-rule promotion and `docs/sql-style.md`.
+Path **(b)** is implemented; see [`docs/roadmap.md` § RC6](roadmap.md#rc6--type-safe-sql-via-custom-internalchsqlbuilder) for the milestone breakdown. The scaffolding landed first (`internal/chsql/builder.go`); the existing emitter was ported file-by-file behind the typed surface; the remaining loki + tempo helpers were swept into the typed API; a lint gate guards against regressions (later retired once the typed API became the only public emission surface); CLAUDE.md promoted "no raw SQL strings" to a top-level non-negotiable.
 
-Signoff: @tsouza, RC6 cut.
+Signoff: @tsouza.

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -61,7 +61,7 @@ on the engine's read order.
 
 chdb-go v1.11.0's parquet wire driver panics on the parquet MAP
 logical type when `rows.Scan` reaches a `Map(String, String)`
-column. The R8.0 chDB probe
+column. The chDB driver probe
 (`internal/chclient/chdb_probe_test.go`) confirmed that wrapping the
 projection server-side in `toJSONString(...)` and JSON-decoding the
 resulting string on the Go side is a clean shim.
@@ -98,10 +98,10 @@ behavior:
 ### CI
 
 The `chdb` workflow (`.github/workflows/chdb.yml`) runs nightly +
-manual dispatch only. It first runs `TestChDBProbe` from R8.0, then
-`just spec-chdb` to exercise the round-trip suite. Promote to a
-required PR gate once the suite is consistently green and the pilot
-fixture coverage has grown beyond the initial 5.
+manual dispatch only. It first runs `TestChDBProbe` (the driver-quirk
+probe), then `just spec-chdb` to exercise the round-trip suite.
+Promote to a required PR gate once the suite is consistently green
+and the pilot fixture coverage has grown beyond the initial 5.
 
 ## Property tests
 
@@ -115,9 +115,10 @@ the same chDB session.
 
 The grammar is intentionally narrow — wider node coverage
 (Aggregate, RangeWindow, joins) is future work. The current shape
-exercises every RC1 rule (FilterFusion, ConstantFold,
-ProjectionPushdown) plus the R3.2 transposes; that's where
-optimizer-introduced semantic divergence is most likely today.
+exercises the baseline rules (FilterFusion, ConstantFold,
+ProjectionPushdown) plus the FilterProjectTranspose +
+FilterAggregateTranspose pair; that's where optimizer-introduced
+semantic divergence is most likely today.
 
 Plan count defaults to 100; `go test -short -tags chdb` knocks it
 down to 10 for fast local feedback. Failures dump the pre- and


### PR DESCRIPTION
## Summary

Pre-release audit cleanup. The docs were written incrementally during the RC1-RC8 grind; many sections still talk about milestones as "planned" or use internal IDs (`RC4 R4.x`, `R6.11e`, `R8.0 probe`) that have no meaning to a reader of the v1.0.0 codebase. This PR rewrites the prose to describe the current shipped state, not the history of how we got here.

- `docs/observability.md` — the pillar table claimed half the surface was "planned" when every row has shipped. Replaced with an accurate four-pillar description.
- `docs/chsql-audit.md` / `docs/sql-builder-evaluation.md` — drop `R6.x` markers; historical context kept but past-tense.
- `docs/test-strategy.md` — `R8.0 probe` becomes "chDB driver probe".
- `docs/optimizer-research.md` — `(RC3 R3.x)` parentheticals dropped; PR refs kept.
- `CLAUDE.md` — "at RC6", "lands in M0.1", "RC1 ships 3 rules" rewritten.
- `README.md` — Status block now claims v1.0.0; container example pins :v1.0.0; drops `(PR8)` / `(PR9)` stale callouts.
- `docs/roadmap.md` — adds RC8 to the at-a-glance table + RC8 section; adds a GA-status banner.

No code changes. No behavioural changes.

Part of the v1.0.0-GA pre-release audit (item `PVTI_lAHOAAHeQ84BXZ2VzgsrQ9c`).

## Test plan

- [x] `markdownlint-cli2` runs as part of the lint job
- [ ] CI green on this PR before auto-merge fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)