### PR TITLE
chore(audit): strip internal roadmap-ID refs from code comments

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -4,8 +4,6 @@ name: fuzz
 # targets in `internal/{promql,logql,traceql}` for a bounded duration each.
 # Any crash is uploaded as a `testdata/fuzz/...` corpus artifact so the
 # triggering input can be replayed locally with `go test -run=<TestName>/<hash>`.
-#
-# RC3 R3.11 scaffold. PR-comment + corpus-promotion polish lands later.
 
 on:
   schedule:

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -3,8 +3,6 @@ name: perf-benchmark
 # Weekly perf-regression sweep. Runs `go test -bench=.` against `main` and
 # against the trigger ref, then diffs the two with benchstat. Both raw
 # outputs and the benchstat diff are uploaded as artifacts.
-#
-# RC3 R3.11 scaffold. PR-comment integration lands as RC3 polish.
 
 on:
   schedule:

--- a/.github/workflows/shadow-mode.yml
+++ b/.github/workflows/shadow-mode.yml
@@ -1,9 +1,10 @@
 name: shadow-mode
 
-# RC3 R3.9 — shadow-mode differential testing harness.
+# Shadow-mode differential testing harness.
 #
-# Scaffold only. The oracle (`internal/promshim/local/`) lands in R3.10, so
-# this workflow runs on manual dispatch only. Once R3.10 merges, we will:
+# The oracle (`internal/promshim/local/`) is built but not yet wired
+# into the shadow CLI; this workflow runs on manual dispatch only. Once
+# the oracle is wired:
 #   * flip the strategy default to force-native,
 #   * add `schedule:` (nightly) + `push:` (main, scoped paths) triggers,
 #   * remove `continue-on-error`.
@@ -32,9 +33,9 @@ jobs:
     name: shadow-mode
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # Informational until R3.10 lands. The noop oracle marks every query
-    # "oracle skipped"; under `prefer-native` the harness still exits 0 but
-    # we keep this guard so a future strategy bump doesn't immediately fail
+    # Informational. The noop oracle marks every query "oracle skipped";
+    # under `prefer-native` the harness still exits 0 but we keep this
+    # guard so a future strategy bump doesn't immediately fail
     # required-checks.
     continue-on-error: true
     steps:
@@ -58,14 +59,14 @@ jobs:
         env:
           # No real cerberus is started here yet; with the noop oracle the
           # harness will report native HTTP errors per query, which is the
-          # expected shape until R3.10 wires the in-process oracle.
+          # expected shape until the in-process oracle is wired.
           CERBERUS_URL: ${{ vars.SHADOW_CERBERUS_URL || 'http://localhost:9090' }}
         run: |
           ./bin/shadow \
             --corpus "${{ github.event.inputs.corpus }}" \
             --strategy "${{ github.event.inputs.strategy }}" \
             --report shadow-report.json \
-            || echo "shadow-mode exited non-zero (expected pre-R3.10)"
+            || echo "shadow-mode exited non-zero (expected without a wired oracle)"
 
       - name: Summarise report
         if: always()

--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -144,10 +144,9 @@ func run() error {
 	// the route.
 	traceMux := http.NewServeMux()
 
-	// Prom is the first head ported to the shared engine.Engine
-	// pipeline (RC7 R7.2); the engine is constructed below from the
-	// shared Client + a seed optimizer and assigned onto the handler.
-	// Loki + Tempo follow as RC7 R7.3 / R7.4 ports.
+	// All three heads run on the shared engine.Engine pipeline; each
+	// engine is constructed below from the shared Client + a seed
+	// optimizer and assigned onto the per-head handler.
 	promHandler := prom.New(client, cfg.Schema, logger.With("api", "prom"))
 	promHandler.Engine = &engine.Engine{Optimizer: promHandler.Optimizer, Client: client}
 	promHandler.Limiter = promLimiter

--- a/cmd/cerberus/otel.go
+++ b/cmd/cerberus/otel.go
@@ -1,9 +1,9 @@
-// otel.go wires the bare-minimum OpenTelemetry plumbing cerberus needs at
-// RC4 R4.2: a no-op tracer-provider (real exporters land in R4.5), the
-// W3C / Baggage propagator pair so incoming `traceparent` headers are
-// honored, and a helper that wraps an HTTP handler with otelhttp so every
-// request becomes a server span whose name derives from the matched
-// http.ServeMux pattern.
+// otel.go wires the OpenTelemetry plumbing cerberus needs: a tracer
+// provider (real OTLP exporters when configured, no-op otherwise),
+// the W3C / Baggage propagator pair so incoming `traceparent` headers
+// are honored, and a helper that wraps an HTTP handler with otelhttp so
+// every request becomes a server span whose name derives from the
+// matched http.ServeMux pattern.
 package main
 
 import (
@@ -20,8 +20,8 @@ import (
 
 // installOTel installs the default propagator (W3C TraceContext + Baggage)
 // and the supplied tracer provider as process globals. Passing nil for tp
-// installs a no-op provider — the safe default until R4.5 wires real
-// OTLP exporters.
+// installs a no-op provider — the safe default when no OTLP endpoint
+// is configured.
 //
 // Idempotent: safe to call multiple times (e.g. from a test setup helper
 // alongside main's call), the last writer wins. Tests that want to

--- a/cmd/cerberus/otel_metrics_test.go
+++ b/cmd/cerberus/otel_metrics_test.go
@@ -23,12 +23,11 @@ func TestTelemetryInstall_NilNoopByDefault(t *testing.T) {
 		Done(t.Context(), telemetry.ResultOK)
 }
 
-// TestTelemetryInstall_ManualReader exercises the integration path the
-// PR description called out: install a sdkmetric.MeterProvider with a
+// TestTelemetryInstall_ManualReader exercises the metric-export
+// integration path: install a sdkmetric.MeterProvider with a
 // ManualReader, drive one query through every instrument, assert the
-// counter incremented and the histograms have data. Mirrors the
-// recipe R4.5 will use when it swaps in the OTLP exporter — the only
-// difference there is the Reader.
+// counter incremented and the histograms have data. The OTLP exporter
+// recipe mirrors this — the only difference is the Reader.
 func TestTelemetryInstall_ManualReader(t *testing.T) {
 	reader := sdkmetric.NewManualReader()
 	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))

--- a/cmd/cerberus/otel_test.go
+++ b/cmd/cerberus/otel_test.go
@@ -13,12 +13,13 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// TestWrapWithOTel_EmitsRouteSpan exercises the full R4.2 wiring path: a
-// real http.ServeMux with registered patterns, wrapped via wrapWithOTel,
-// served through httptest, and verified via an in-memory span recorder.
-// The assertion is purposefully tight: one span, named after the matched
-// pattern. This is the contract R4.3 depends on when it attaches child
-// spans for parse / lower / optimize / emit.
+// TestWrapWithOTel_EmitsRouteSpan exercises the full otelhttp wiring
+// path: a real http.ServeMux with registered patterns, wrapped via
+// wrapWithOTel, served through httptest, and verified via an in-memory
+// span recorder. The assertion is purposefully tight: one span, named
+// after the matched pattern. This is the contract the pipeline-stage
+// spans (parse / lower / optimize / emit / execute) depend on when
+// they attach as children.
 func TestWrapWithOTel_EmitsRouteSpan(t *testing.T) {
 	exporter := tracetest.NewInMemoryExporter()
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
@@ -91,8 +92,8 @@ func TestWrapWithOTel_FallbackSpanName(t *testing.T) {
 	}
 }
 
-// TestWrapWithOTel_PropagatesTraceContext verifies the second half of
-// R4.2: incoming `traceparent` headers are honored so the handler's
+// TestWrapWithOTel_PropagatesTraceContext verifies that incoming
+// `traceparent` headers are honored so the handler's
 // http.Request.Context() carries the inbound trace ID. Grafana sets
 // traceparent on every datasource query — without this, cerberus spans
 // would be orphaned from the user-initiated trace.

--- a/harness/compatibility/shadow/README.md
+++ b/harness/compatibility/shadow/README.md
@@ -1,8 +1,10 @@
 # Shadow-mode differential testing harness
 
-> RC3 R3.9 scaffold. See [`docs/roadmap.md` § RC3](../../../docs/roadmap.md#advanced-testing).
-> Oracle wiring stubbed until [R3.10](../../../docs/roadmap.md#advanced-testing)
-> lands the in-process PromQL evaluator (`internal/promshim/local/`).
+> The CLI + diff machinery is in place. Oracle wiring is currently a
+> noop stub; the in-process PromQL evaluator lives at
+> `internal/promshim/local/` and can be plugged in here when the
+> shadow-mode pipeline is promoted from informational to a required
+> gate. See [`docs/roadmap.md` § RC3](../../../docs/roadmap.md).
 
 ## What "shadow mode" means
 
@@ -59,7 +61,7 @@ the end.
 harness/compatibility/
   docker-compose.yml         <-- existing: reference Prom + cerberus + CH + seeder
   scripts/run-compatibility.sh
-  shadow/                    <-- this directory (RC3 R3.9)
+  shadow/                    <-- this directory
     cmd/shadow/main.go         CLI entry point
     differ.go                  pure diff function
     corpus.go                  TXTAR corpus loader
@@ -67,8 +69,8 @@ harness/compatibility/
 ```
 
 The Docker Compose stack remains the heavyweight reference; shadow mode is the
-in-process companion. They share the corpus format eventually (R3.10 follow-up)
-but ship independently.
+in-process companion. They can share the corpus format in a follow-up,
+but ship independently today.
 
 ## Usage
 
@@ -109,11 +111,11 @@ flips the global flag to `force-native`).
 
 ## Oracle stub
 
-Until R3.10 lands, the binary ships with a `noopOracle` that returns
-`OracleSkipped` for every query. Under `prefer-native` this is fine — the
-native answer is returned and the diff is recorded as "oracle skipped"
-(non-fatal). Under `force-native` or `oracle-only`, the binary exits with
-code `3` to make the missing dependency loud.
+The binary ships with a `noopOracle` that returns `OracleSkipped` for
+every query. Under `prefer-native` this is fine — the native answer is
+returned and the diff is recorded as "oracle skipped" (non-fatal).
+Under `force-native` or `oracle-only`, the binary exits with code `3`
+to make the missing dependency loud.
 
 The wiring point is a single interface:
 
@@ -123,10 +125,11 @@ type OracleProvider interface {
 }
 ```
 
-R3.10 will swap `noopOracle` for `promshimlocal.New(...)`.
+Wiring `internal/promshim/local/` in here (`promshimlocal.New(...)`)
+is the natural next step.
 
 ## Status
 
-**Scaffold only.** Native evaluator wiring is a real HTTP client; oracle is
-stubbed. Workflow is `workflow_dispatch` only — it does not run on PRs or
-nightly until R3.10 unblocks the oracle.
+Native evaluator wiring is a real HTTP client; oracle is stubbed.
+Workflow is `workflow_dispatch` only — it does not run on PRs or
+nightly. Promote to a required gate once the oracle is wired.

--- a/harness/compatibility/shadow/cmd/shadow/main.go
+++ b/harness/compatibility/shadow/cmd/shadow/main.go
@@ -1,9 +1,10 @@
-// Command shadow is the RC3 R3.9 shadow-mode differential testing CLI.
+// Command shadow is the shadow-mode differential testing CLI.
 //
 // It reads a corpus of PromQL queries, evaluates each one against cerberus
 // (native path, over HTTP) and an in-process PromQL oracle, and diffs the
-// two result vectors. The oracle is stubbed until R3.10 lands
-// `internal/promshim/local/`.
+// two result vectors. The oracle is currently a noop stub — the
+// in-process PromQL oracle lives at `internal/promshim/local/` and a
+// future wiring change can plug it in here.
 //
 // See ../../README.md for the strategy matrix, exit codes, and corpus format.
 package main
@@ -41,15 +42,15 @@ const (
 	exitOracleMissing   = 3
 )
 
-// OracleProvider is the seam R3.10 fills. Until then, noopOracle returns
-// ErrOracleSkipped for every query.
+// OracleProvider is the seam an oracle implementation fills. The
+// noopOracle stub returns ErrOracleSkipped for every query.
 type OracleProvider interface {
 	Evaluate(ctx context.Context, expr string) (shadow.VectorResult, error)
 }
 
 // ErrOracleSkipped signals the noop oracle has been invoked. Callers handle
 // per strategy.
-var ErrOracleSkipped = errors.New("oracle: skipped (R3.10 not yet wired)")
+var ErrOracleSkipped = errors.New("oracle: skipped (no oracle wired)")
 
 type noopOracle struct{}
 
@@ -133,7 +134,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 	// Under force-native / oracle-only, an unavailable oracle is fatal up front.
 	if strategy == StrategyForceNative || strategy == StrategyOracleOnly {
 		if _, isNoop := oracle.(noopOracle); isNoop {
-			fmt.Fprintf(stderr, "strategy %q requires an oracle but R3.10 has not landed; aborting\n", strategy)
+			fmt.Fprintf(stderr, "strategy %q requires an oracle but none is wired; aborting\n", strategy)
 			return exitOracleMissing
 		}
 	}

--- a/harness/compatibility/shadow/differ.go
+++ b/harness/compatibility/shadow/differ.go
@@ -1,4 +1,4 @@
-// Package shadow implements the RC3 R3.9 shadow-mode differential testing
+// Package shadow implements the shadow-mode differential testing
 // harness.
 //
 // The harness runs each query through cerberus (native path) and an in-process

--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -90,8 +90,8 @@ func New(client Querier, s schema.Logs, logger *slog.Logger) *Handler {
 // populate label autocomplete, the streams chooser, and the patterns
 // panel.
 func (h *Handler) Mount(mux *http.ServeMux) {
-	// RC4 R4.4: route every endpoint through the cerberus.queries.*
-	// counter + duration middleware. WebSocket /tail is included — a
+	// Route every endpoint through the cerberus.queries.* counter +
+	// duration middleware. WebSocket /tail is included — a
 	// long-lived tail counts as one query for the purposes of total
 	// volume bookkeeping; its duration will skew toward the long tail
 	// of the histogram, which is what dashboards want to see anyway.

--- a/internal/api/loki/handler_test.go
+++ b/internal/api/loki/handler_test.go
@@ -178,9 +178,9 @@ func TestQuery_MetricVector(t *testing.T) {
 	}
 }
 
-// TestResponseHeaders_EngineInstrumentation covers the R7.7 contract on
-// the Loki head: every successful /query response carries the three
-// canonical X-Cerberus-* headers populated by engine.Engine.
+// TestResponseHeaders_EngineInstrumentation covers the Loki head's
+// response-header contract: every successful /query response carries the
+// three canonical X-Cerberus-* headers populated by engine.Engine.
 func TestResponseHeaders_EngineInstrumentation(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/loki/index_volume.go
+++ b/internal/api/loki/index_volume.go
@@ -163,9 +163,9 @@ func buildIndexVolumeSQL(
 // here composes the mapFilter body inline: the outer Call("mapFilter",
 // …) is typed, the lambda head is composed via Builder.Lambda, and
 // the bare lambda-parameter reference `k` inside In's left slot uses
-// chsql.BareIdent (the typed constructor introduced by R6.12.f for
-// CH-safe bare identifiers — narrow trust contract, no backtick
-// quoting). All composition lives inside the typed Frag surface.
+// chsql.BareIdent (the typed constructor for CH-safe bare identifiers
+// — narrow trust contract, no backtick quoting). All composition lives
+// inside the typed Frag surface.
 func volumeGroupFrag(s schema.Logs, targetLabels []string, aggregateBy string) chsql.Frag {
 	if len(targetLabels) == 0 || aggregateBy == "series" {
 		return chsql.Col(s.ResourceAttributesColumn)

--- a/internal/api/prom/metadata.go
+++ b/internal/api/prom/metadata.go
@@ -546,8 +546,8 @@ func distinctMapAtFrag(col, key string) chsql.Frag {
 // and the empty-string sentinel as positional args — the WHERE
 // predicate that drops the empty-string CH returns when a Map key is
 // absent. The empty-string RHS is parameterised through chsql.Lit so
-// the whole expression stays inside the typed Frag surface (R6.12.f
-// retired the Raw / Concat escape hatches).
+// the whole expression stays inside the typed Frag surface (the public
+// Raw / Concat escape hatches were retired).
 func mapAtNotEmptyFrag(col, key string) chsql.Frag {
 	mapAt := chsql.Frag(func(b *chsql.Builder) { b.MapAt(col, key) })
 	return chsql.Neq(mapAt, chsql.Lit(""))

--- a/internal/api/prom/pipeline_spans_test.go
+++ b/internal/api/prom/pipeline_spans_test.go
@@ -20,10 +20,10 @@ import (
 
 // spanRecordingQuerier wraps stubQuerier with the chclient-side
 // `execute` pipeline-stage span so the in-handler-process span chain
-// reaches the full five-stage shape the RC4 R4.3 contract promises.
-// The real chclient package emits this span when it actually calls
-// driver.Conn.Query; tests stub the driver out, so we have to emit it
-// ourselves to keep the assertion meaningful.
+// reaches the full five-stage shape the pipeline-instrumentation contract
+// promises. The real chclient package emits this span when it actually
+// calls driver.Conn.Query; tests stub the driver out, so we have to emit
+// it ourselves to keep the assertion meaningful.
 type spanRecordingQuerier struct {
 	stubQuerier
 }
@@ -59,7 +59,7 @@ func TestMain(m *testing.M) {
 
 // TestPipelineSpans_FiveStageChain asserts that a single /api/v1/query
 // request emits the canonical five-span chain — parse → lower →
-// optimize → emit → execute — that the RC4 R4.3 instrumentation
+// optimize → emit → execute — that the pipeline instrumentation
 // promises.
 func TestPipelineSpans_FiveStageChain(t *testing.T) {
 	pipelineSpanExporter.Reset()

--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -105,8 +105,8 @@ func New(client Querier, s schema.Traces, version string, logger *slog.Logger) *
 // check; /api/search runs a TraceQL query; /api/traces/{id} fetches a
 // single trace by ID.
 func (h *Handler) Mount(mux *http.ServeMux) {
-	// RC4 R4.4: every Tempo endpoint flows through the cerberus.queries.*
-	// counter + duration middleware. /api/echo and /api/status/version
+	// Every Tempo endpoint flows through the cerberus.queries.* counter
+	// + duration middleware. /api/echo and /api/status/version
 	// are health-checks and will dominate ResultOK volume — that's fine,
 	// dashboards can split them out via cerberus.route if needed.
 	register := func(pattern string, hf http.HandlerFunc) {

--- a/internal/api/tempo/handler_test.go
+++ b/internal/api/tempo/handler_test.go
@@ -222,10 +222,10 @@ func TestTraceByID_Found(t *testing.T) {
 	}
 }
 
-// TestResponseHeaders_EngineInstrumentation covers the R7.7 contract
-// on the Tempo head: /api/search returns Strategy=native; /api/traces/{id}
-// returns Strategy=trace-by-id (engine.Meta.IsTraceByID short-circuits
-// the optimizer and tags the response).
+// TestResponseHeaders_EngineInstrumentation covers the Tempo head's
+// response-header contract: /api/search returns Strategy=native;
+// /api/traces/{id} returns Strategy=trace-by-id (engine.Meta.IsTraceByID
+// short-circuits the optimizer and tags the response).
 func TestResponseHeaders_EngineInstrumentation(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/tempo/search_tag_values.go
+++ b/internal/api/tempo/search_tag_values.go
@@ -223,8 +223,8 @@ func mapContainsFrag(col, key string) chsql.Frag {
 
 // mapAtFrag emits "`<col>`[?]" — CH's Map column access shape — with
 // key bound as a positional argument. Composed via the typed
-// chsql.Subscript constructor introduced by R6.12.f, with the column
-// flowing through Col (backtick-quoted) and the key through Lit
+// typed chsql.Subscript constructor, with the column flowing through
+// Col (backtick-quoted) and the key through Lit
 // (`?`-bound). Equivalent to Builder.MapAt but exposed as a typed
 // Frag for QueryBuilder slot composition.
 func mapAtFrag(col, key string) chsql.Frag {

--- a/internal/cerbtrace/cerbtrace.go
+++ b/internal/cerbtrace/cerbtrace.go
@@ -3,8 +3,8 @@
 // Each pipeline stage (parse → lower → optimize → emit → execute) is a
 // short-lived span emitted from the package that performs the work, so a
 // single PromQL/LogQL/TraceQL query — once otelhttp has put its request
-// span on the context (RC4 R4.2) — produces a five-span chain whose
-// shape is uniform across the three heads.
+// span on the context — produces a five-span chain whose shape is
+// uniform across the three heads.
 //
 // Span attribute keys are interned here so the contract is one file
 // long. The keys follow the `cerberus.*` namespace for cerberus-owned

--- a/internal/chclient/client.go
+++ b/internal/chclient/client.go
@@ -147,7 +147,7 @@ func (c *Client) Exec(ctx context.Context, sql string, args ...any) error {
 // Query is a thin wrapper around QueryCursor that drains the cursor into
 // a slice. Callers that may return millions of rows (notably
 // /api/v1/query_range) should use QueryCursor directly to keep memory
-// bounded — see R3.12 in docs/roadmap.md.
+// bounded.
 func (c *Client) Query(ctx context.Context, sql string, args ...any) ([]Sample, error) {
 	cursor, err := c.QueryCursor(ctx, sql, args...)
 	if err != nil {

--- a/internal/chclienttest/doc.go
+++ b/internal/chclienttest/doc.go
@@ -8,9 +8,9 @@
 //
 // The default `just test` lane stays CGO_ENABLED=0 and never compiles
 // this package — every file is gated behind the `chdb` build tag, the
-// same tag the chDB probe (RC8 R8.0) and the TXTAR round-trip runner
-// (RC8 R8.1) use. The `chdb` CI job runs after `just chdb-install` has
-// placed libchdb.so at /usr/local/lib.
+// same tag the chDB driver probe and the TXTAR round-trip runner use.
+// The `chdb` CI job runs after `just chdb-install` has placed
+// libchdb.so at /usr/local/lib.
 //
 // Map column scan: chdb-go v1.11.0's parquet driver panics on the
 // Parquet MAP logical type, so every emitted SQL that projects a

--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -13,15 +13,13 @@ import (
 // positional `?` argument slice that the chclient driver binds.
 //
 // Builder is the public, named version of the private emitter struct in
-// emit.go. As of RC6 R6.1 it is pure scaffolding — no emit_*.go function
-// uses it yet; R6.2–R6.10 port each emit function in turn. The
-// architectural intent (per docs/sql-builder-evaluation.md) is to expose
-// the same `strings.Builder` + `[]any` args primitives the emitter
-// already uses, plus a handful of CH-specific helpers (MapAt, MapKeys,
+// emit.go. The architectural intent (per docs/sql-builder-evaluation.md)
+// is to expose the same `strings.Builder` + `[]any` args primitives the
+// emitter uses, plus a handful of CH-specific helpers (MapAt, MapKeys,
 // MapFilterExcept, Now64, SubtractNanos, DateTime64Lit, Lambda,
 // ParamAgg) and a QueryBuilder with first-class PREWHERE, JOIN, and
-// WITH RECURSIVE slots so the RC3 optimizer rules can compose SQL
-// fragments without re-parsing rendered strings.
+// WITH RECURSIVE slots so the optimizer rules can compose SQL fragments
+// without re-parsing rendered strings.
 //
 // The zero value is ready to use.
 type Builder struct {
@@ -44,9 +42,9 @@ func (b *Builder) Args() []any { return b.args }
 // its positional argument slice.
 func (b *Builder) Build() (string, []any) { return b.sb.String(), b.args }
 
-// writeSQL appends raw SQL text. Unexported as of R6.11e — external
-// packages must use the typed surface (QueryBuilder slots + Frag
-// constructors like Eq / And / Paren / Cast). In-package callers
+// writeSQL appends raw SQL text. Unexported — external packages must
+// use the typed surface (QueryBuilder slots + Frag constructors like
+// Eq / And / Paren / Cast). In-package callers
 // (histogram_quantile.go, vector_join.go, structural_join.go,
 // set_op.go) use this for operator-token-style glue inside Frag
 // callbacks; clause keywords still go through QueryBuilder slots.
@@ -59,8 +57,7 @@ func (b *Builder) writeSQL(s string) { b.sb.WriteString(s) }
 
 // Ident appends a ClickHouse identifier with backtick quoting, doubling
 // any embedded backticks. Mirrors writeIdent in emit_node.go and
-// quoteIdent in range_window.go; R6.2+ replaces both call sites with
-// this method.
+// quoteIdent in range_window.go.
 func (b *Builder) Ident(name string) {
 	b.sb.WriteByte('`')
 	b.sb.WriteString(strings.ReplaceAll(name, "`", "``"))
@@ -111,8 +108,7 @@ func (b *Builder) MapKeys(col string) {
 //
 // binding each key as a positional `?` argument. The shape mirrors
 // emit_expr.go's emitMapWithoutKeys (used by PromQL's ignoring(…)
-// modifier) and vector_join.go's mapFilter for the same purpose;
-// R6.4 / R6.6 collapse both call sites onto this helper.
+// modifier) and vector_join.go's mapFilter for the same purpose.
 //
 // Empty keys is a programmer error and panics: the resulting CH SQL
 // would always pass the filter, which is never the caller's intent
@@ -218,15 +214,9 @@ func (b *Builder) ParamAgg(name string, params, args []func(b *Builder)) {
 }
 
 // Expr renders a chplan.Expr through the Builder using the public
-// Builder helpers (Ident / Arg / etc.). It mirrors the legacy
-// emitter.emitExpr in emit_expr.go; RC6 R6.2 introduces this method so
-// the ported emitFilter / emitProject can emit predicates and
-// projection expressions without reaching into the private emitter.
-//
-// The legacy emitter.emitExpr is intentionally retained — it is the
-// canonical implementation until RC6 R6.4 ports the expression tree.
-// Both paths produce byte-identical SQL for every fixture; once the
-// rest of the emitter migrates, emitExpr collapses into this method.
+// Builder helpers (Ident / Arg / etc.). It is used by the ported
+// emitFilter / emitProject to emit predicates and projection expressions
+// without reaching into the private emitter.
 func (b *Builder) Expr(x chplan.Expr) error {
 	switch v := x.(type) {
 	case *chplan.ColumnRef:
@@ -448,9 +438,9 @@ func Lit(v any) Frag {
 // shape pins their lexical form.
 //
 // This is the package-private successor to the public chsql.Raw that
-// R6.12.f retired. External packages can't call it; in-package
-// callers reach for it sparingly and only for emitter-controlled
-// synthetic tokens. The public typed Frag surface (Call, BareIdent,
+// was retired. External packages can't call it; in-package callers
+// reach for it sparingly and only for emitter-controlled synthetic
+// tokens. The public typed Frag surface (Call, BareIdent,
 // InlineLit, Subscript, Array, If, Lambda1, Subquery, …) covers the
 // general case.
 func verbatim(sql string) Frag {
@@ -896,9 +886,8 @@ type Subqueryable interface {
 //
 // Both *QueryBuilder and the chsql-public PreRenderedSQL adapter
 // satisfy Subqueryable. The latter is the one documented escape for
-// SQL produced by the legacy string emitter (chsql.Emit) until a
-// future R6.x port collapses that emitter into the QueryBuilder
-// surface.
+// SQL produced by the legacy string emitter (chsql.Emit) — a future
+// port can collapse that emitter into the QueryBuilder surface.
 func Subquery(s Subqueryable) Frag {
 	return func(b *Builder) {
 		sql, args := s.Build()
@@ -913,8 +902,8 @@ func Subquery(s Subqueryable) Frag {
 // Subqueryable so it can flow through Subquery without raw-string
 // composition. Holds an opaque CH SQL string plus its positional args;
 // reserved for legacy chsql.Emit output that pre-dates the
-// QueryBuilder migration. A future R6.x milestone will port chsql.Emit
-// to return a *QueryBuilder directly and retire this type.
+// QueryBuilder migration. A future port can move chsql.Emit to return
+// a *QueryBuilder directly and retire this type.
 //
 // Don't reach for this for newly written code — compose with
 // QueryBuilder + typed Frags instead.
@@ -1086,8 +1075,8 @@ type joinClause struct {
 //	WITH RECURSIVE <name> AS (<anchor> UNION ALL <recursive>)
 //
 // Non-recursive CTEs render the anchor alone (no UNION ALL). Only
-// recursive CTEs are wired up at R6.6 — the non-recursive case is
-// reserved for a future R6.x port.
+// recursive CTEs are wired up today — the non-recursive case is
+// reserved for a future port if needed.
 type cteClause struct {
 	Name      string
 	Anchor    *QueryBuilder
@@ -1101,9 +1090,9 @@ type cteClause struct {
 //
 // PREWHERE is a first-class slot, distinct from WHERE. ClickHouse
 // evaluates PREWHERE before WHERE on the primary-key columns,
-// pruning rows before the full row read; RC3's optimizer rules
-// promote predicates from WHERE → PREWHERE when the predicate
-// only references sort-key columns. Modelling PREWHERE separately
+// pruning rows before the full row read; the optimizer's PREWHERE
+// promotion rule moves predicates from WHERE → PREWHERE when the
+// predicate only references sort-key columns. Modelling PREWHERE separately
 // here means those rewrites are slot-level operations rather than
 // string rewrites on rendered SQL.
 //
@@ -1190,8 +1179,8 @@ func (s *QueryBuilder) Join(kind JoinKind, src, on Frag) *QueryBuilder {
 //
 // Multiple WithRecursive calls chain — rendered as a single
 // `WITH RECURSIVE <n1> AS (...), <n2> AS (...)` head per CH syntax.
-// At R6.6 only structural_join.go uses one CTE per emit; the
-// multi-CTE shape is reserved for future ports.
+// Only structural_join.go uses one CTE per emit today; the multi-CTE
+// shape is reserved for future ports.
 //
 // Passing a nil anchor or recursive panics at render time.
 func (s *QueryBuilder) WithRecursive(name string, anchor, recursive *QueryBuilder) *QueryBuilder {

--- a/internal/chsql/builder_test.go
+++ b/internal/chsql/builder_test.go
@@ -26,8 +26,7 @@ func TestBuilder_Empty(t *testing.T) {
 }
 
 // TestBuilder_Ident — backtick quoting with embedded-backtick doubling.
-// Mirrors the existing emit_node.go behaviour so the future R6.2 port
-// is a one-for-one swap.
+// Mirrors the existing emit_node.go behaviour.
 func TestBuilder_Ident(t *testing.T) {
 	t.Parallel()
 
@@ -761,8 +760,8 @@ func TestQueryBuilder_Join_PanicsOnNilON(t *testing.T) {
 
 // TestBuilder_Expr — Builder.Expr renders representative chplan
 // expression shapes with byte-identical output to the legacy
-// emitter.emitExpr. Locked here so the RC6 R6.2 port can't drift from
-// the canonical shape before R6.4 collapses both paths.
+// emitter.emitExpr. Locked here so neither path can drift from the
+// canonical shape.
 func TestBuilder_Expr(t *testing.T) {
 	t.Parallel()
 

--- a/internal/chsql/emit_node.go
+++ b/internal/chsql/emit_node.go
@@ -51,10 +51,9 @@ func (e *emitter) emitSelect(sb *QueryBuilder) {
 }
 
 // splice drains b's accumulated SQL + args into the emitter. Retained
-// for the grandfathered emitters in vector_join.go / structural_join.go
-// that still compose SQL fragments through a free-standing *Builder
-// before flushing to the shared emitter state. R6.6 collapses those
-// onto QueryBuilder and removes this helper.
+// for the emitters in vector_join.go / structural_join.go that still
+// compose SQL fragments through a free-standing *Builder before
+// flushing to the shared emitter state.
 func (e *emitter) splice(b *Builder) {
 	sql, args := b.Build()
 	e.b.WriteString(sql)
@@ -169,7 +168,7 @@ func conjunctionFrag(exprs []chplan.Expr) Frag {
 }
 
 func (e *emitter) emitProject(p *chplan.Project) error {
-	// Late materialisation (RC3 R3.7): when this Project sits atop a
+	// Late materialisation: when this Project sits atop a
 	// Limit(Filter?(Scan)) over a wide-column table AND the projection
 	// references a wide column, emit the two-stage rewrite (inner thin
 	// SELECT + JOIN back for wide columns) instead of the canonical

--- a/internal/chsql/histogram_over_time.go
+++ b/internal/chsql/histogram_over_time.go
@@ -117,9 +117,8 @@ func histogramBucketFrag(attr chplan.Expr, isDuration bool) Frag {
 		Call("log2", attrFrag)(b)
 		if isDuration {
 			// "/ 1e9" — inline divisor (query-shape constant, not user
-			// data); no typed Frag for inline-int literals so the suffix
-			// is appended via direct write. Flagged for R6.12.f if/when
-			// an InlineLit / RawLit Frag lands.
+			// data); appended via direct write because the surrounding
+			// emitter expects a writer callback, not a Frag.
 			b.sb.WriteString(" / 1000000000")
 		}
 	}

--- a/internal/chsql/histogram_quantile.go
+++ b/internal/chsql/histogram_quantile.go
@@ -89,7 +89,7 @@ func histogramQuantileValueFrag(h *chplan.HistogramQuantile) Frag {
 	// inline these into the if() chain. The non-Call structure (if()
 	// nesting, "[idx]" array indexing, inline phi formatFloat literal)
 	// keeps the in-package b.writeSQL path — no typed Frag covers those
-	// shapes yet, flagged for R6.12.f.
+	// shapes yet.
 	lengthBC := Call("length", Col(bc))
 	lengthEB := Call("length", Col(eb))
 	arraySumBC := Call("arraySum", Col(bc))
@@ -155,8 +155,7 @@ func histogramQuantileValueFrag(h *chplan.HistogramQuantile) Frag {
 		// arrayFirstIndex(c -> ..., arrayCumSum(bc)) — the lambda body
 		// uses a bound var `c`; Builder.Lambda emits "(c) -> ..." which
 		// drifts vs. the existing "c -> ..." output, so the in-package
-		// b.writeSQL path is kept for the lambda. Flagged for R6.12.f
-		// if/when a parens-less lambda Frag lands. The outer
+		// b.writeSQL path is kept for the lambda. The outer
 		// arrayFirstIndex call wraps the cum frag via Call once the
 		// lambda is emitted.
 		writeIdx := func() {

--- a/internal/chsql/histogram_quantile_native.go
+++ b/internal/chsql/histogram_quantile_native.go
@@ -137,7 +137,7 @@ func histogramQuantileNativeValueFrag(h *chplan.HistogramQuantileNative) Frag {
 		// idx = arrayFirstIndex(c -> c >= phi*total, cum).
 		// Lambda body uses bound var `c`; Builder.Lambda emits "(c) ->"
 		// which drifts vs. "c ->" output, so the in-package writeSQL
-		// path is kept here. Flagged for R6.12.f.
+		// path is kept here.
 		writeIdx := func() {
 			b.writeSQL("arrayFirstIndex(c -> c >= (")
 			b.writeSQL(phi)

--- a/internal/chsql/late_mat.go
+++ b/internal/chsql/late_mat.go
@@ -5,7 +5,7 @@ import (
 	"github.com/tsouza/cerberus/internal/schema"
 )
 
-// Late materialisation for wide-column scans (RC3 R3.7).
+// Late materialisation for wide-column scans.
 //
 // When a query reads "fat" columns (logs.Body, logs.ResourceAttributes,
 // traces.SpanAttributes, …) but only keeps a small fraction of the rows
@@ -238,8 +238,8 @@ func stringSet(xs []string) map[string]struct{} {
 // ColumnRefs as wide-projection signals is the conservative choice.
 //
 // A future refinement walks ColumnRefs inside arbitrary expressions to
-// widen the rewrite's applicability. R3.7 starts with the simple form
-// so the gate's reasoning is auditable.
+// widen the rewrite's applicability. The current form keeps the gate's
+// reasoning auditable.
 func projectionColumnNames(ps []chplan.Projection) map[string]struct{} {
 	out := map[string]struct{}{}
 	for _, p := range ps {

--- a/internal/chsql/late_mat_spec_test.go
+++ b/internal/chsql/late_mat_spec_test.go
@@ -13,10 +13,10 @@ import (
 )
 
 // lateMatFixtureDir holds the TXTAR goldens for the
-// late-materialisation codegen (RC3 R3.7). Kept separate from the
-// general chsql/ fixture directory so the rewrite's emission shape is
-// easy to scan as a group; the trigger pattern and the no-op
-// fall-through cases live side by side.
+// late-materialisation codegen rewrite. Kept separate from the general
+// chsql/ fixture directory so the rewrite's emission shape is easy to
+// scan as a group; the trigger pattern and the no-op fall-through cases
+// live side by side.
 var lateMatFixtureDir = filepath.Join("..", "..", "test", "spec", "codegen", "late_mat")
 
 // lateMatPlans maps each fixture base name to its source chplan tree.

--- a/internal/chsql/prewhere.go
+++ b/internal/chsql/prewhere.go
@@ -198,7 +198,7 @@ func orderedConjuncts(conjuncts []chplan.Expr, shape TableShape) []chplan.Expr {
 // non-wide-touching predicate is kept in WHERE so CH's executor
 // doesn't degenerate to a no-op WHERE clause. The behaviour is purely
 // cosmetic — CH happily accepts a query with only PREWHERE — but the
-// retained predicate matches the design note in the R3.4 spec.
+// retained predicate matches the PREWHERE-promotion design note.
 //
 // When the shape has no wide columns registered (e.g. an unknown
 // table), partitionPrewhere returns empty PREWHERE and all conjuncts

--- a/internal/chsql/prewhere_spec_test.go
+++ b/internal/chsql/prewhere_spec_test.go
@@ -11,14 +11,14 @@ import (
 	"github.com/tsouza/cerberus/test/spec"
 )
 
-// prewhereFixtureDir is the spec directory for the R3.4 PREWHERE / sort-
+// prewhereFixtureDir is the spec directory for the PREWHERE / sort-
 // key-ordering fixtures. Lives outside test/spec/chsql/ so the chsql
 // emitter golden set and the codegen-rule golden set stay separable —
-// when R3.7 (late materialisation) adds its own fixtures it lands under
-// test/spec/codegen/late_mat/ on the same pattern.
+// late-materialisation fixtures land under test/spec/codegen/late_mat/
+// on the same pattern.
 var prewhereFixtureDir = filepath.Join("..", "..", "test", "spec", "codegen", "prewhere")
 
-// prewherePlans are the chplan trees the R3.4 fixtures pin. The trees
+// prewherePlans are the chplan trees the PREWHERE fixtures pin. The trees
 // are constructed bare (no optimizer pass) so the goldens reflect
 // codegen behaviour exclusively.
 var prewherePlans = map[string]chplan.Node{
@@ -138,8 +138,8 @@ var prewherePlans = map[string]chplan.Node{
 	},
 }
 
-// TestEmit_Prewhere walks the R3.4-specific fixture set. Mirrors the
-// shape of TestEmit so the golden-update loop is the same.
+// TestEmit_Prewhere walks the PREWHERE-specific fixture set. Mirrors
+// the shape of TestEmit so the golden-update loop is the same.
 func TestEmit_Prewhere(t *testing.T) {
 	t.Parallel()
 	spec.Walk(t, prewhereFixtureDir, func(t *testing.T, c *spec.Case) {

--- a/internal/chsql/prewhere_test.go
+++ b/internal/chsql/prewhere_test.go
@@ -298,7 +298,7 @@ func TestProjectionTouchesWide(t *testing.T) {
 }
 
 // TestTableShapeForKnownTables covers the default OTel-CH tables; the
-// codegen depends on these shapes for the R3.4 rewrites.
+// codegen depends on these shapes for the PREWHERE rewrites.
 func TestTableShapeForKnownTables(t *testing.T) {
 	t.Parallel()
 	for _, tbl := range []string{"otel_logs", "otel_traces", "otel_metrics_gauge", "otel_metrics_sum"} {

--- a/internal/chsql/range_window.go
+++ b/internal/chsql/range_window.go
@@ -595,11 +595,11 @@ func groupArrayPairFrag(tsCol, valCol string) Frag {
 
 // windowFilterPairsFrag returns a Frag rendering the per-series
 // arrayFilter clamp to the [end-range, end] window over the
-// `series_array` alias. Thin wrapper over chsql.RangeWindowFilter
-// (R6.13's typed compound-idiom helper); kept as a local helper so
-// the rangeNS-arithmetic stays a single inline literal rather than
-// repeated `Sub(end, Call("toIntervalNanosecond", …))` boilerplate
-// at every callsite.
+// `series_array` alias. Thin wrapper over the chsql.RangeWindowFilter
+// typed compound-idiom helper; kept as a local helper so the
+// rangeNS-arithmetic stays a single inline literal rather than repeated
+// `Sub(end, Call("toIntervalNanosecond", …))` boilerplate at every
+// callsite.
 //
 // end may render arbitrary CH expressions (DateTime64 literal,
 // `now64(9)`, or `anchor_ts` in the matrix path); the rangeNS bound
@@ -620,10 +620,10 @@ func windowFilterPairsFrag(end Frag, rangeNS int64) Frag {
 //
 // The inner 5-function sandwich (the two arrayPopBack/Front layers
 // over the value-projection arrayMap, paired by the outer arrayMap)
-// is delegated to chsql.CounterDelta — R6.13's typed compound-idiom
-// helper. The outer arraySum stays here because rate / increase
-// reduce the per-pair delta array to a scalar; emitters that wanted
-// the raw delta array could call CounterDelta directly.
+// is delegated to chsql.CounterDelta — a typed compound-idiom helper.
+// The outer arraySum stays here because rate / increase reduce the
+// per-pair delta array to a scalar; emitters that wanted the raw delta
+// array could call CounterDelta directly.
 func counterDeltaFrag() Frag {
 	return Call("arraySum", CounterDelta(BareIdent("window_pairs")))
 }
@@ -707,8 +707,8 @@ func (e *emitter) emitRangeWindowIdentity(r *chplan.RangeWindow) error {
 // PromQL's counter `rate`, which uses counter-reset-aware deltas.
 //
 // range_seconds binds as a parameter via the value-writer callback so
-// the emitter stays free of new Sprintf-on-SQL instances (RC6 rule).
-// The empty-window guard is delegated to chsql.IfNonZero (R6.13).
+// the emitter stays free of new Sprintf-on-SQL instances. The
+// empty-window guard is delegated to chsql.IfNonZero.
 func (e *emitter) emitRangeWindowLogRate(r *chplan.RangeWindow) error {
 	rangeSeconds := r.Range.Seconds()
 	return e.emitWindowedArray(r, IfNonZero(

--- a/internal/chsql/structural_join.go
+++ b/internal/chsql/structural_join.go
@@ -31,10 +31,9 @@ import (
 // iteration. MaxDepth (when > 0) caps the iteration count; 0 means
 // unbounded. The final SELECT inner-joins R against the closure.
 //
-// Ported to chsql.QueryBuilder at RC6 R6.6: the direct case uses the
-// new QueryBuilder.Join slot; the recursive case uses the new
-// QueryBuilder.WithRecursive slot for the WITH RECURSIVE … UNION ALL
-// CTE shape.
+// The direct case uses the QueryBuilder.Join slot; the recursive case
+// uses the QueryBuilder.WithRecursive slot for the WITH RECURSIVE …
+// UNION ALL CTE shape.
 func (e *emitter) emitStructuralJoin(j *chplan.StructuralJoin) error {
 	if j.TraceIDColumn == "" || j.SpanIDColumn == "" || j.ParentSpanIDColumn == "" {
 		return fmt.Errorf("%w: StructuralJoin column names unset", ErrUnsupported)

--- a/internal/chsql/tableshape.go
+++ b/internal/chsql/tableshape.go
@@ -124,9 +124,9 @@ func buildDefaultTableShapes() map[string]TableShape {
 	// Attributes, toUnixTimestamp64Nano(TimeUnix)). The schema package
 	// doesn't carry a Metrics.WideColumns field yet, so the wide set is
 	// supplied inline — ResourceAttributes and ScopeAttributes are the
-	// large maps; Exemplars is a Nested column. R3.7 will extend
-	// schema.Metrics with WideColumns + RowKey; this list moves there
-	// at the same time.
+	// large maps; Exemplars is a Nested column. A future refactor can
+	// extend schema.Metrics with WideColumns + RowKey and move this list
+	// there.
 	metricsShape := TableShape{
 		SortColumns: []string{
 			metrics.ServiceNameColumn,

--- a/internal/chsql/vector_join.go
+++ b/internal/chsql/vector_join.go
@@ -27,9 +27,8 @@ import (
 //
 //   - CardOneToMany (`group_right(<labels>)`): mirror of CardManyToOne.
 //
-// Ported to chsql.QueryBuilder at RC6 R6.6: the outer SELECT, each
-// per-side aggregation subquery, and the INNER JOIN slot all flow
-// through typed QueryBuilder slots. The bare-alias glue (`AS L` /
+// The outer SELECT, each per-side aggregation subquery, and the INNER
+// JOIN slot all flow through typed QueryBuilder slots. The bare-alias glue (`AS L` /
 // `AS R`) is operator-token-style writeSQL inside a Frag — CH accepts
 // unquoted single-letter aliases and the existing fixtures pin that
 // shape.

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -38,8 +38,8 @@ import (
 //
 //   - HeaderStrategy   — execution-path label. "trace-by-id" for the
 //     Tempo /traces/{id} short-circuit, "native" otherwise. Reserved
-//     values for future strategies: "mv-substituted" (R3.6) and
-//     "shadow-fallback" (R3.9+).
+//     values for future strategies: "mv-substituted" (when the rule
+//     fires) and "shadow-fallback" (oracle pivot).
 //   - HeaderPlanNodes  — post-optimize plan node count (chplan tree
 //     walked depth-first). Useful for debug dashboards + cost-shape
 //     telemetry.

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -120,10 +120,10 @@ func TestEngine_Query_HappyPath(t *testing.T) {
 	}
 }
 
-// TestEngine_Query_HeadersPopulated covers the R7.7 contract: every
-// successful Result carries the canonical X-Cerberus-* response-header
-// bag (Strategy / Plan-Nodes / CH-Millis), and the Strategy field on
-// Result agrees with the header value.
+// TestEngine_Query_HeadersPopulated covers the response-header contract:
+// every successful Result carries the canonical X-Cerberus-* header bag
+// (Strategy / Plan-Nodes / CH-Millis), and the Strategy field on Result
+// agrees with the header value.
 func TestEngine_Query_HeadersPopulated(t *testing.T) {
 	t.Parallel()
 

--- a/internal/logql/fuzz_test.go
+++ b/internal/logql/fuzz_test.go
@@ -15,7 +15,7 @@ import (
 // panic-freedom: any panic surfaces as a fuzz crash with the offending
 // seed promoted to testdata/fuzz/FuzzParse/.
 //
-// RC3 R3.11 — seed corpus is intentionally small; CI runs `-fuzztime=120s`
+// The seed corpus is intentionally small; CI runs `-fuzztime=120s`
 // per parser weekly to grow the corpus organically.
 func FuzzParse(f *testing.F) {
 	seeds := []string{

--- a/internal/optimizer/analyzer_test.go
+++ b/internal/optimizer/analyzer_test.go
@@ -162,8 +162,8 @@ func TestConstantFoldSemantic_LeavesBoolIdentityAlone(t *testing.T) {
 
 	// `true AND X` is a *heuristic* fold — ConstantFoldSemantic must
 	// NOT collapse it. The boolean identity is the heuristic rule's
-	// territory; mixing the two flavours is exactly the bug R3.5
-	// fixes.
+	// territory; mixing the two flavours is exactly the bug the
+	// analyzer/optimizer split fixes.
 	pred := &chplan.Binary{
 		Op:   chplan.OpAnd,
 		Left: &chplan.LitBool{V: true},

--- a/internal/optimizer/doc.go
+++ b/internal/optimizer/doc.go
@@ -24,8 +24,8 @@
 // rationale and the DataFusion docs at
 // https://docs.rs/datafusion-optimizer/latest/datafusion_optimizer/ for
 // the upstream contract. Spark Catalyst and DuckDB make a similar cut;
-// the Tsinghua "Selective Late Materialization" paper (RC3 R3.7) takes
-// it as a given.
+// the Tsinghua "Selective Late Materialization" paper takes it as a
+// given.
 //
 // Concretely: cerberus's original `ConstantFold` rule conflated two
 // flavours of fold —
@@ -37,7 +37,7 @@
 //     ergonomic — it shrinks emitted SQL but the result is correct
 //     either way.
 //
-// R3.5 splits the conflated rule into ConstantFoldSemantic
+// Today the conflated rule is split into ConstantFoldSemantic
 // (AnalyzerRule, lives in the analyzer batch) and ConstantFoldHeuristic
 // (OptimizerRule, lives in a Once batch right after the analyzer).
 //
@@ -51,8 +51,8 @@
 //     FilterProjectTranspose + FilterAggregateTranspose +
 //     FilterRangeWindowTranspose
 //  4. optimizer.projection (FixedPoint) — ProjectionPushdown
-//  5. optimizer.mv-substitution (FixedPoint) — MVSubstitution
-//     (RC3 R3.6). Runs last so predicate pushdown has already
+//  5. optimizer.mv-substitution (FixedPoint) — MVSubstitution.
+//     Runs last so predicate pushdown has already
 //     surfaced the `RangeWindow(Scan(base))` patterns the rule
 //     matches against. The rule needs a Metrics schema to read its
 //     rollup registry from; Default() binds the default OTel schema,
@@ -65,8 +65,8 @@
 //
 // The MV-substitution batch is the first place cerberus picks among
 // equivalent plans (a rollup-scanned query and a base-scanned query
-// produce the same answer when the substitution is safe). RC3 R3.6
-// ships a deliberately simple cost model — `firstApplicable`, which
+// produce the same answer when the substitution is safe). The current
+// cost model is deliberately simple — `firstApplicable`, which
 // picks the first registry-listed rollup that passes the safety
 // conditions — and an unexported `costModel` interface stub so v2
 // can swap in a real estimator (per Jindal VLDB 2018 §4–§6) without

--- a/internal/optimizer/filter_aggregate_transpose.go
+++ b/internal/optimizer/filter_aggregate_transpose.go
@@ -12,8 +12,8 @@ import "github.com/tsouza/cerberus/internal/chplan"
 // predicate over the Aggregate result is equivalent to the same
 // predicate applied to the rows feeding the Aggregate. Pushing it
 // underneath dramatically shrinks the rows the GROUP BY has to chew
-// through, and exposes the predicate to PREWHERE promotion (R3.4)
-// once it reaches the Scan.
+// through, and exposes the predicate to PREWHERE promotion once it
+// reaches the Scan.
 //
 // Safety. The Filter sees two flavours of output column on the
 // Aggregate: the group-by keys (`Aggregate.GroupBy`, optionally renamed
@@ -35,7 +35,7 @@ import "github.com/tsouza/cerberus/internal/chplan"
 //   - `GroupByAliases[i]` that renames the key.
 //   - `ColumnRef` with a non-empty Qualifier in the predicate.
 //
-// Built on the `PatternRule` scaffold introduced in R3.1.
+// Built on the `PatternRule` scaffold.
 func FilterAggregateTranspose() Rule {
 	return &PatternRule{
 		RuleName: "filter-aggregate-transpose",

--- a/internal/optimizer/filter_project_transpose.go
+++ b/internal/optimizer/filter_project_transpose.go
@@ -11,8 +11,8 @@ import "github.com/tsouza/cerberus/internal/chplan"
 // The shape unlocks downstream rules: pushing the Filter under a Project
 // lets `ProjectionPushdown` (currently fires on `Project(Scan)` only) see
 // the new `Project(Filter(...))` chain through a future column-set pass,
-// and exposes the Filter to `PREWHERE` promotion (R3.4) once the Scan
-// becomes the Filter's immediate input again.
+// and exposes the Filter to `PREWHERE` promotion once the Scan becomes
+// the Filter's immediate input again.
 //
 // Safety. The Filter sees the Project's *output* columns. Pushing it
 // underneath the Project means the same predicate must be evaluable
@@ -34,8 +34,8 @@ import "github.com/tsouza/cerberus/internal/chplan"
 //     belong to joins, which are not in scope for filter-project
 //     transposition.
 //
-// Built on the `PatternRule` scaffold introduced in R3.1 — declarative
-// `Match` / `Transform` rather than the legacy `Rule.Apply` type-switch.
+// Built on the `PatternRule` scaffold — declarative `Match` /
+// `Transform` rather than the legacy `Rule.Apply` type-switch.
 // FilterProjectTranspose is exposed as a constructor returning a `Rule`
 // so callers can register it alongside the legacy three rules.
 func FilterProjectTranspose() Rule {

--- a/internal/optimizer/filter_range_window_transpose.go
+++ b/internal/optimizer/filter_range_window_transpose.go
@@ -15,7 +15,7 @@ import "github.com/tsouza/cerberus/internal/chplan"
 // applied to the per-sample rows feeding the window. Pushing it
 // underneath shrinks the rows the windowed-array idiom has to
 // `groupArray` / `arraySort` / `arrayFilter` through, and exposes the
-// predicate to PREWHERE promotion (R3.4) once it reaches the Scan.
+// predicate to PREWHERE promotion once it reaches the Scan.
 //
 // Safety. The Filter sees three flavours of column on the
 // RangeWindow's output:
@@ -53,7 +53,7 @@ import "github.com/tsouza/cerberus/internal/chplan"
 //     enough in practice that the conservative policy buys safety
 //     without losing much.
 //
-// Built on the `PatternRule` scaffold introduced in R3.1.
+// Built on the `PatternRule` scaffold.
 func FilterRangeWindowTranspose() Rule {
 	return &PatternRule{
 		RuleName: "filter-range-window-transpose",

--- a/internal/optimizer/optimizer_test.go
+++ b/internal/optimizer/optimizer_test.go
@@ -144,9 +144,10 @@ var inputs = map[string]chplan.Node{
 	},
 
 	// filter_project_transpose_passes: Filter over Project([X, Y], Scan)
-	// where the predicate references a passthrough column. The R3.2
-	// rule pushes the Filter under the Project; the optimized SQL
-	// shows the Filter wrapping the Scan with the Project on top.
+	// where the predicate references a passthrough column. The
+	// FilterProjectTranspose rule pushes the Filter under the Project;
+	// the optimized SQL shows the Filter wrapping the Scan with the
+	// Project on top.
 	"filter_project_transpose_passes": &chplan.Filter{
 		Input: &chplan.Project{
 			Input: &chplan.Scan{Table: "otel_metrics_gauge"},
@@ -163,7 +164,7 @@ var inputs = map[string]chplan.Node{
 	},
 
 	// filter_project_transpose_blocked: Project renames `MetricName`
-	// to `metric`; the Filter touches the *alias*. The R3.2 rule
+	// to `metric`; the Filter touches the *alias*. The transpose rule
 	// declines (alias has no source-side column). ProjectionPushdown
 	// still fires on the inner Project(Scan) and narrows the scan's
 	// column list — a benign side effect that the fixture records.
@@ -183,8 +184,9 @@ var inputs = map[string]chplan.Node{
 
 	// filter_aggregate_transpose_passes: Filter over Aggregate where
 	// the predicate references a bare group-by column (`job`). The
-	// R3.2 rule pushes the Filter under the Aggregate; the optimized
-	// SQL shows the WHERE clause inside the GROUP BY's FROM subquery.
+	// FilterAggregateTranspose rule pushes the Filter under the
+	// Aggregate; the optimized SQL shows the WHERE clause inside the
+	// GROUP BY's FROM subquery.
 	"filter_aggregate_transpose_passes": &chplan.Filter{
 		Input: &chplan.Aggregate{
 			Input:   &chplan.Scan{Table: "otel_metrics_gauge"},
@@ -202,7 +204,7 @@ var inputs = map[string]chplan.Node{
 
 	// filter_aggregate_transpose_blocked: predicate touches the
 	// aggregate-output column `sum_value`, which doesn't exist in the
-	// Aggregate's input. The R3.2 rule declines; optimized SQL is
+	// Aggregate's input. The transpose rule declines; optimized SQL is
 	// byte-identical to unoptimized.
 	"filter_aggregate_transpose_blocked": &chplan.Filter{
 		Input: &chplan.Aggregate{
@@ -221,8 +223,8 @@ var inputs = map[string]chplan.Node{
 
 	// filter_range_window_transpose_passes: Filter over RangeWindow
 	// where the predicate references a bare series-identifying group
-	// key (`Attributes`). The R3.8 rule pushes the Filter under the
-	// RangeWindow; the optimized SQL shows the WHERE clause inside the
+	// key (`Attributes`). The FilterRangeWindowTranspose rule pushes
+	// the Filter under the RangeWindow; the optimized SQL shows the WHERE clause inside the
 	// arraySort/groupArray subquery, before the windowed aggregation.
 	"filter_range_window_transpose_passes": &chplan.Filter{
 		Input: &chplan.RangeWindow{
@@ -246,7 +248,7 @@ var inputs = map[string]chplan.Node{
 	// filter_range_window_transpose_blocked: predicate touches the
 	// per-sample `Value` column, which becomes the windowed-function
 	// input (and is not in the RangeWindow's passthrough series-key
-	// set). The R3.8 rule declines; optimized SQL is byte-identical
+	// set). The transpose rule declines; optimized SQL is byte-identical
 	// to unoptimized.
 	"filter_range_window_transpose_blocked": &chplan.Filter{
 		Input: &chplan.RangeWindow{

--- a/internal/optimizer/pattern.go
+++ b/internal/optimizer/pattern.go
@@ -16,9 +16,9 @@ package optimizer
 // node. Bindings flow back to the caller (a `PatternRule`'s `Apply`
 // function) via a `Bindings` map keyed on the names supplied to `Capture`.
 //
-// Scope (RC3 R3.1): scaffold only. The existing three optimizer rules
-// (filter-fusion, constant-fold, projection-pushdown) keep their bespoke
-// type-switch shape. RC3 R3.2 ports them to `PatternRule`.
+// The baseline rules (filter-fusion, constant-fold, projection-pushdown)
+// keep their bespoke type-switch shape; the transpose family and
+// MVSubstitution are built on top of `PatternRule`.
 
 import (
 	"reflect"

--- a/internal/optimizer/property_test.go
+++ b/internal/optimizer/property_test.go
@@ -16,9 +16,10 @@
 //
 //   - Every generated plan emits valid ClickHouse SQL.
 //   - Every predicate references columns that exist in the seed.
-//   - The optimizer's three RC1 rules (FilterFusion, ConstantFold,
-//     ProjectionPushdown) and the R3.2 transposes all have shots at
-//     firing without needing aggregates or windows.
+//   - The optimizer's baseline rules (FilterFusion, ConstantFold,
+//     ProjectionPushdown) and the FilterProjectTranspose /
+//     FilterAggregateTranspose pair all have shots at firing without
+//     needing aggregates or windows.
 //
 // Wider node coverage (Aggregate, RangeWindow, joins) is future work —
 // the property test catches the high-traffic shapes today, and the

--- a/internal/optimizer/rule.go
+++ b/internal/optimizer/rule.go
@@ -98,15 +98,15 @@ func NewWithBatches(batches ...Batch) *Driver {
 //     the identities are ergonomic — they shrink emitted SQL but the
 //     result is correct either way.
 //   - "optimizer.predicate-pushdown" (FixedPoint) — FilterFusion + the
-//     two R3.2 transpose rules can unlock each other: fuse adjacent
-//     filters, transpose the fused filter through Project / Aggregate,
-//     then possibly fuse again as new neighbours appear. Iteration is
+//     transpose rules can unlock each other: fuse adjacent filters,
+//     transpose the fused filter through Project / Aggregate, then
+//     possibly fuse again as new neighbours appear. Iteration is
 //     load-bearing here.
 //   - "optimizer.projection" (FixedPoint) — ProjectionPushdown may
 //     iterate as pushdown unused-column elimination cascades through
 //     nested Projects. Today only one pass changes anything, but the
-//     strategy leaves room for follow-up rules (R3.7) to land in this
-//     batch without changing wiring.
+//     strategy leaves room for follow-up rules to land in this batch
+//     without changing wiring.
 //   - "optimizer.mv-substitution" (FixedPoint) — MVSubstitution
 //     rewrites `RangeWindow(Scan(base))` to `RangeWindow(Scan(rollup))`
 //     when the operator has declared a pre-aggregated rollup whose
@@ -168,13 +168,12 @@ func DefaultWithSchema(metrics schema.Metrics) *Driver {
 // when they rewrite.
 //
 // The ctx parameter carries the parent OpenTelemetry span (typically
-// the otelhttp request span installed in RC4 R4.2). Run wraps the
-// whole pass in an `optimize` pipeline-stage span so a query's flame
-// graph shows how long rule iteration took. The total number of
-// rule-application changes is surfaced as `cerberus.rules_applied`
-// on the span and as the `cerberus.optimizer.rules_applied` histogram
-// (RC4 R4.4) so dashboards can aggregate how much rewriting the
-// optimizer is doing across the fleet.
+// the otelhttp request span). Run wraps the whole pass in an
+// `optimize` pipeline-stage span so a query's flame graph shows how
+// long rule iteration took. The total number of rule-application
+// changes is surfaced as `cerberus.rules_applied` on the span and as
+// the `cerberus.optimizer.rules_applied` histogram so dashboards can
+// aggregate how much rewriting the optimizer is doing across the fleet.
 func (d *Driver) Run(ctx context.Context, plan chplan.Node) chplan.Node {
 	_, span := tracer.Start(ctx, cerbtrace.SpanOptimize)
 	defer span.End()

--- a/internal/optimizer/rule_pattern.go
+++ b/internal/optimizer/rule_pattern.go
@@ -18,8 +18,10 @@ import "github.com/tsouza/cerberus/internal/chplan"
 // both engines schedule rules and let each rule decide whether the
 // candidate node is a match.
 //
-// Scope (RC3 R3.1): the type + driver wiring only. The first batch of
-// rules ported to PatternRule lands in RC3 R3.2.
+// The PatternRule type plus the driver wiring is the canonical shape
+// for new rules. The transpose family (FilterProjectTranspose,
+// FilterAggregateTranspose, FilterRangeWindowTranspose, and MVSubstitution)
+// is built on top.
 type PatternRule struct {
 	// RuleName is the rule's identifier, surfaced via `Rule.Name()` for
 	// debug logging and test fixtures.

--- a/internal/promql/fuzz_test.go
+++ b/internal/promql/fuzz_test.go
@@ -15,7 +15,7 @@ import (
 // panic-freedom: any panic surfaces as a fuzz crash with the offending
 // seed promoted to testdata/fuzz/FuzzParse/.
 //
-// RC3 R3.11 — seed corpus is intentionally small; CI runs `-fuzztime=120s`
+// The seed corpus is intentionally small; CI runs `-fuzztime=120s`
 // per parser weekly to grow the corpus organically.
 func FuzzParse(f *testing.F) {
 	seeds := []string{

--- a/internal/promshim/local/doc.go
+++ b/internal/promshim/local/doc.go
@@ -1,5 +1,5 @@
 // Package local provides an in-process PromQL evaluator intended to serve as
-// the differential-testing oracle for cerberus shadow-mode (RC3 R3.9).
+// the differential-testing oracle for cerberus shadow-mode.
 //
 // The evaluator wraps Prometheus's own promql.Engine and runs queries against
 // an in-memory SampleStore. It performs no ClickHouse I/O; callers seed
@@ -10,7 +10,4 @@
 // project's local evaluator, but is implemented from scratch on top of the
 // Prometheus engine API (no code is ported verbatim, so no attribution is
 // required).
-//
-// Status: scaffold (RC3 R3.10). No callers yet. RC3 R3.9 will wire this into
-// the shadow-mode harness.
 package local

--- a/internal/schema/logs.go
+++ b/internal/schema/logs.go
@@ -47,8 +47,8 @@ type Logs struct {
 	// WideColumns lists the "fat" columns on the logs table — columns
 	// whose per-row payload is large enough that fetching them dominates
 	// the IO cost of a Scan. The chsql late-materialisation rewrite
-	// (RC3 R3.7, see docs/optimizer-research.md § 3) checks this list
-	// when a Project+Limit+Filter+Scan stack lands on this table: if any
+	// (see docs/optimizer-research.md § 3) checks this list when a
+	// Project+Limit+Filter+Scan stack lands on this table: if any
 	// of the projection's columns are wide, the inner SELECT skips them
 	// and an outer JOIN back fetches them only for the surviving rows.
 	//
@@ -58,8 +58,8 @@ type Logs struct {
 
 	// RowKey is the tuple of columns that uniquely identifies a row in
 	// the logs table. Used by the chsql late-materialisation rewrite
-	// (RC3 R3.7) as the JOIN key between the thin inner SELECT and the
-	// outer "fetch wide columns" SELECT. The tuple must be globally
+	// as the JOIN key between the thin inner SELECT and the outer
+	// "fetch wide columns" SELECT. The tuple must be globally
 	// unique — duplicates would yield a row-multiplication bug.
 	//
 	// For the OTel-CH default this is `(Timestamp, TraceId, SpanId)` —
@@ -98,7 +98,7 @@ func DefaultOTelLogs() Logs {
 		ServiceNameColumn:        "ServiceName",
 		EventNameColumn:          "EventName",
 		// Wide columns — large per-row payloads. Late materialisation
-		// (RC3 R3.7) defers fetching these until after filter+limit.
+		// defers fetching these until after filter+limit.
 		WideColumns: []string{"Body", "ResourceAttributes", "LogAttributes"},
 		// (Timestamp, TraceId, SpanId) uniquely identifies an OTel-CH
 		// log row when ingestion carries trace context. See WideColumns

--- a/internal/schema/otel.go
+++ b/internal/schema/otel.go
@@ -132,8 +132,8 @@ type Metrics struct {
 
 	// MetricsRollups declares pre-aggregated rollup tables the
 	// operator has provisioned alongside the base metrics tables. The
-	// optimizer's MV-substitution rule (RC3 R3.6) reads this list to
-	// decide whether a `RangeWindow` over a base table can be rewritten
+	// optimizer's MV-substitution rule reads this list to decide whether
+	// a `RangeWindow` over a base table can be rewritten
 	// to scan the matching rollup instead. The registry is the
 	// operator's contract: cerberus trusts the listed tables exist and
 	// carry the declared (Window, AggOp) semantics. Empty means "no
@@ -179,8 +179,8 @@ const (
 )
 
 // Rollup describes a single pre-aggregated rollup table in the OTel
-// metrics schema. The optimizer's MV-substitution rule (RC3 R3.6)
-// rewrites a `RangeWindow(Scan(BaseTable))` to `RangeWindow(Scan(RollupTable))`
+// metrics schema. The optimizer's MV-substitution rule rewrites a
+// `RangeWindow(Scan(BaseTable))` to `RangeWindow(Scan(RollupTable))`
 // when the query's step + range + aggregate operator are compatible
 // with the rollup's window + commuting aggregate.
 //

--- a/internal/schema/otel_test.go
+++ b/internal/schema/otel_test.go
@@ -117,8 +117,7 @@ func TestDefaultOTelMetricsTableFor(t *testing.T) {
 
 // TestDefaultOTelMetricsRollups pins the canonical OTel sum rollups
 // the upstream exporter writes when rollup tables are enabled. The
-// MV-substitution optimizer rule (RC3 R3.6) reads this list to find
-// candidates; if the upstream exporter ships a new rollup window we
+// MV-substitution optimizer rule reads this list to find candidates; if the upstream exporter ships a new rollup window we
 // add it here so the rule picks it up.
 func TestDefaultOTelMetricsRollups(t *testing.T) {
 	t.Parallel()

--- a/internal/schema/traces.go
+++ b/internal/schema/traces.go
@@ -72,8 +72,8 @@ type Traces struct {
 	// WideColumns lists the "fat" columns on the spans table — columns
 	// whose per-row payload is large enough that fetching them dominates
 	// the IO cost of a Scan. The chsql late-materialisation rewrite
-	// (RC3 R3.7, see docs/optimizer-research.md § 3) checks this list
-	// when a Project+Limit+Filter+Scan stack lands on this table: if any
+	// (see docs/optimizer-research.md § 3) checks this list when a
+	// Project+Limit+Filter+Scan stack lands on this table: if any
 	// of the projection's columns are wide, the inner SELECT skips them
 	// and an outer JOIN back fetches them only for the surviving rows.
 	//
@@ -122,7 +122,7 @@ func DefaultOTelTraces() Traces {
 		LinksColumn:           "Links",
 		TimestampColumn:       "Timestamp",
 		// Wide columns — large per-row payloads. Late materialisation
-		// (RC3 R3.7) defers fetching these until after filter+limit.
+		// defers fetching these until after filter+limit.
 		WideColumns: []string{"SpanAttributes", "ResourceAttributes", "Events", "Links"},
 		// (Timestamp, TraceId, SpanId) — TraceId+SpanId is the OTel
 		// natural key; Timestamp prefix matches the table sort order.

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -3,8 +3,8 @@
 // flowing through the gateway, how long each pipeline stage takes, and
 // how much ClickHouse work each query did.
 //
-// Spans (RC4 R4.2 / R4.3) and metrics (this package, RC4 R4.4) are
-// complementary: spans tell a per-request story (one trace per query),
+// Spans (per-request, owned by cerbtrace) and metrics (this package)
+// are complementary: spans tell a per-request story (one trace per query),
 // metrics aggregate the same events into cheap dashboard-friendly
 // counters / histograms. The two sets share their attribute namespace
 // (`cerberus.*`) so dashboards can pivot on the same fields.
@@ -33,9 +33,8 @@ import (
 // scope is greppable across cerberus's instruments.
 const meterName = "github.com/tsouza/cerberus/internal/telemetry"
 
-// Attribute keys shared with cerbtrace (when R4.3 lands) so dashboards
-// pivot on the same names whether the source is a span attribute or a
-// metric label.
+// Attribute keys shared with cerbtrace so dashboards pivot on the same
+// names whether the source is a span attribute or a metric label.
 const (
 	// AttrQL is the query language: "promql", "logql", or "traceql".
 	AttrQL = attribute.Key("cerberus.ql")
@@ -49,9 +48,9 @@ const (
 	AttrStage = attribute.Key("stage")
 )
 
-// Stage names. Mirrored from R4.3's cerbtrace span names so a dashboard
-// can group histogram buckets by the same stage attribute the trace
-// view uses.
+// Stage names. Mirrored from cerbtrace's span names so a dashboard can
+// group histogram buckets by the same stage attribute the trace view
+// uses.
 const (
 	StageParse    = "parse"
 	StageLower    = "lower"
@@ -196,8 +195,8 @@ func mustBuild(meter metric.Meter) *Instruments {
 }
 
 // Install replaces the process-global MeterProvider with mp. Passing
-// nil installs a no-op provider — the safe default until R4.5 wires
-// real OTLP metric exporters. Mirrors the spirit of cmd/cerberus's
+// nil installs a no-op provider — the safe default when no OTLP
+// exporter is configured. Mirrors the spirit of cmd/cerberus's
 // installOTel for tracer providers, and resets the instrument cache so
 // the next Get() rebuilds against the new provider.
 func Install(mp metric.MeterProvider) {

--- a/internal/traceql/fuzz_test.go
+++ b/internal/traceql/fuzz_test.go
@@ -15,7 +15,7 @@ import (
 // panic-freedom: any panic surfaces as a fuzz crash with the offending
 // seed promoted to testdata/fuzz/FuzzParse/.
 //
-// RC3 R3.11 — seed corpus is intentionally small; CI runs `-fuzztime=120s`
+// The seed corpus is intentionally small; CI runs `-fuzztime=120s`
 // per parser weekly to grow the corpus organically.
 func FuzzParse(f *testing.F) {
 	seeds := []string{

--- a/test/spec/roundtrip.go
+++ b/test/spec/roundtrip.go
@@ -23,7 +23,7 @@
 //     the emitted `sql:`. Map(String,String) columns appear as JSON
 //     objects ({"job":"api"}) — the runner round-trips Map columns
 //     through `toJSONString(...)` server-side and decodes them on the
-//     Go side (per R8.0's chdb-go probe, native Map scan panics in
+//     Go side (per the chDB driver probe, native Map scan panics in
 //     parquet-go inside chdb-go v1.11.0).
 //
 // We chose JSON over TSV for `expected_rows:` because Map columns

--- a/test/spec/runner_chdb.go
+++ b/test/spec/runner_chdb.go
@@ -12,7 +12,7 @@
 // (with `args:` bound), and asserts the resulting rows match the
 // `expected_rows:` JSON. Map columns are wrapped server-side in
 // `toJSONString(...)` to dodge the native parquet Map scan panic
-// documented in chDB probe (RC8 R8.0).
+// documented by the chDB driver probe.
 package spec
 
 import (
@@ -208,7 +208,7 @@ func unquoteBackticks(s string) string {
 // extractProjectionCount counts top-level SELECT projections by
 // re-splitting the outer SELECT's projection list on depth-0 commas.
 // Used to size the scan-target slice without calling
-// rows.ColumnTypes() (which panics on Map columns per the R8.0 probe).
+// rows.ColumnTypes() (which panics on Map columns per the chDB probe).
 func extractProjectionCount(query string) int {
 	head, _ := splitOuterSelect(query)
 	if head == "" {
@@ -352,7 +352,7 @@ func RunRoundTrip(t *testing.T, c *Case) {
 		// native Go value (string, int64, float64, time.Time, []byte)
 		// per chdb/driver/parquet.go's switch table. This sidesteps
 		// rows.ColumnTypes() (which panics on Map columns per the
-		// R8.0 probe).
+		// chDB driver probe).
 		cells := make([]any, colCount)
 		ptrs := make([]any, colCount)
 		for i := range cells {


### PR DESCRIPTION
## Summary

Pre-release audit cleanup. Every code file referencing internal milestone IDs (`RC4 R4.2`, `R6.11e`, `R3.10`, etc.) gets its prose rewritten to describe the current behaviour. A reader of the v1.0.0 codebase has no context for "R6.11e" — the comment was talking to a mid-process maintainer, not to them.

**Changes are comments only — no behavioural changes, no API surface changes, no test changes beyond docstrings.**

Scope covers:
- `internal/api/{prom,loki,tempo}/`
- `internal/chsql/` (builder, emit_node, late_mat, histogram_*, prewhere, range_window, structural_join, tableshape, vector_join)
- `internal/optimizer/` (doc, rule, rule_pattern, pattern, three transposes, three test files)
- `internal/schema/` (otel, logs, traces, otel_test)
- `internal/engine/`, `internal/cerbtrace/`, `internal/telemetry/`, `internal/chclient/`, `internal/chclienttest/`, `internal/promshim/local/`
- Three identical fuzz_test.go seed-corpus comments
- `cmd/cerberus/` (main, otel, otel_test, otel_metrics_test)
- `test/spec/runner_chdb.go` + `roundtrip.go`
- `harness/compatibility/shadow/` (cmd/shadow/main.go, differ.go, README.md)
- `.github/workflows/{fuzz,perf-benchmark,shadow-mode}.yml` headers

Verified clean via the audit's grep recipe.

Part of the v1.0.0-GA pre-release audit (item `PVTI_lAHOAAHeQ84BXZ2VzgsrQ9c`).

## Test plan

- [ ] CI green (`check` + `lint`) before auto-merge fires
- [x] Hand-verified: no functional changes — every diff is a doc-comment, log message, or workflow comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)