### PR TITLE
chore(audit): retire TODO/FIXME markers from code

### DIFF
--- a/internal/api/loki/patterns.go
+++ b/internal/api/loki/patterns.go
@@ -26,15 +26,14 @@ type Pattern struct {
 // handlePatterns implements GET /loki/api/v1/patterns.
 //
 // Upstream Loki 3.x exposes a pattern-discovery subsystem (drain3-style
-// log template extraction) on this endpoint. Cerberus defers that
-// subsystem to a follow-up workstream — the algorithm is its own beast
-// and Grafana's pattern panel renders an empty result gracefully.
-//
-// TODO(RC3+): implement pattern discovery (likely drain3-equivalent
-// running over the same peek-window used by /detected_fields). For now
-// the endpoint exists so Grafana's panel doesn't 404; it validates the
+// log template extraction) on this endpoint. Cerberus does not run a
+// pattern-discovery algorithm itself today — the algorithm is its own
+// beast and Grafana's pattern panel renders an empty result gracefully.
+// The endpoint exists so Grafana's panel doesn't 404; it validates the
 // caller's parameters (so a broken `query` still returns 400) and then
-// emits {status:"success", data:{patterns:[]}}.
+// emits {status:"success", data:{patterns:[]}}. A future release can
+// run a drain3-equivalent over the same peek-window used by
+// /detected_fields if there's demand.
 func (h *Handler) handlePatterns(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query().Get("query")
 	if q == "" {

--- a/internal/api/prom/exemplars.go
+++ b/internal/api/prom/exemplars.go
@@ -43,13 +43,12 @@ type Exemplar struct {
 // error envelopes on bad probes, then return `{status:"success",
 // data:[]}` so the exemplars probe doesn't crash the dashboard.
 //
-// TODO(RC2/RC3 schema): once `internal/schema/otel.go` exposes an
-// exemplars column (or a sibling-table join target), wire the SQL via
-// `internal/chsql.Builder` — extract VectorSelector matchers from the
-// parsed PromQL expression, build a SELECT against the metric's
+// A future release can wire the SQL via `internal/chsql.Builder` once
+// `internal/schema/otel.go` exposes an exemplars column (or a
+// sibling-table join target) — extract VectorSelector matchers from
+// the parsed PromQL expression, build a SELECT against the metric's
 // exemplars source with the matcher predicates in WHERE, time-bounded
 // on `[start, end]`, and shape the result rows into ExemplarSeries.
-// See `docs/roadmap.md § RC2 PromQL HTTP APIs`.
 func (h *Handler) handleQueryExemplars(w http.ResponseWriter, r *http.Request) {
 	if r.Method == http.MethodPost {
 		_ = r.ParseForm()
@@ -90,7 +89,7 @@ func (h *Handler) handleQueryExemplars(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Empty-data path — see the schema TODO on the function docstring.
+	// Empty-data path — see the schema note on the function docstring.
 	// Return `[]ExemplarSeries{}` (not nil) so the JSON envelope renders
 	// as `"data":[]` rather than `"data":null`; Grafana's exemplars probe
 	// distinguishes the two.

--- a/internal/api/prom/exemplars_test.go
+++ b/internal/api/prom/exemplars_test.go
@@ -23,11 +23,11 @@ type exemplarsResponse struct {
 
 // TestQueryExemplars — table-test for /api/v1/query_exemplars.
 //
-// The RC2 schema doesn't expose exemplars yet so the success path always
+// The current schema doesn't expose exemplars so the success path always
 // returns `data:[]`; the cases below pin every other observable: input
 // validation (missing / unparseable / bogus-time params), HTTP-method
-// support (GET + POST), and the empty-array envelope shape. Once the
-// schema TODO in exemplars.go lands, the fixtures here grow to cover
+// support (GET + POST), and the empty-array envelope shape. When the
+// schema gains an exemplars column, the fixtures here can grow to cover
 // single-series + multi-series results without changing the input wiring.
 func TestQueryExemplars(t *testing.T) {
 	t.Parallel()
@@ -158,8 +158,7 @@ func TestQueryExemplars(t *testing.T) {
 			if parsed.Status != "success" {
 				t.Fatalf("status: got %q, want success; err=%s", parsed.Status, parsed.Error)
 			}
-			// The schema-TODO empty-data path returns an empty slice, not
-			// a null. Both decode to len(Data)==0 in Go, so verify the raw
+			// The empty-data path returns an empty slice, not a null. Both decode to len(Data)==0 in Go, so verify the raw
 			// JSON shape too.
 			if len(parsed.Data) != 0 {
 				t.Fatalf("expected empty data slice, got %d entries", len(parsed.Data))
@@ -176,8 +175,8 @@ func TestQueryExemplars(t *testing.T) {
 	}
 }
 
-// TestQueryExemplars_EnvelopeShape — pin the data array shape for when
-// the schema TODO lands. The empty-data path serialises as
+// TestQueryExemplars_EnvelopeShape — pin the data array shape so a
+// future implementation can't drift. The empty-data path serialises as
 // `data:[]`, and the field-name vocabulary (`seriesLabels` /
 // `exemplars` / `labels` / `value` / `timestamp`) matches Prom's
 // documented response shape verbatim.

--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -451,8 +451,8 @@ func toTraceSummaries(samples []chclient.Sample) []TraceSummary {
 		// The TraceID lives in the row's labels under a synthetic key —
 		// for the search projection we don't pull it out (handler hits
 		// `/search/tags` defer); instead each unique sample is one span,
-		// and we use the MetricName + Timestamp to summarise.
-		// TODO(M4.5 follow-up): include TraceId in projection.
+		// and we use the MetricName + Timestamp to summarise. A future
+		// release can include TraceId in the projection if needed.
 		key := s.MetricName + "|" + s.Timestamp.Format("20060102150405.000000000")
 		a, ok := byTrace[key]
 		if !ok {


### PR DESCRIPTION
## Summary

Pre-release audit cleanup. The repo had four lingering TODO comments naming defunct milestones (`TODO(RC3+)`, `TODO(RC2/RC3 schema)`, `TODO(M4.5 follow-up)`). For v1.0.0-GA the prose is rewritten to describe the current behaviour and to note "a future release can…" for genuinely deferred work — no release-flavoured tags survive in code.

- `internal/api/loki/patterns.go` — drain3-style pattern discovery stays an empty `data:[]` response; the prose now says so as a stable doc note rather than as an aspirational TODO.
- `internal/api/prom/exemplars.go` + `_test.go` — same treatment. Exemplars endpoint returns `data:[]` until the schema exposes an exemplars source.
- `internal/api/tempo/handler.go` — search-projection TraceId note rewritten as a doc comment rather than a TODO.

Verified via:

```sh
grep -rEn 'TODO|FIXME|XXX|HACK' --include='*.go' internal/ cmd/
```

returns no hits. The endpoints' observable behaviour is unchanged; this is comment-only cleanup. The genuinely deferred surface (Loki pattern discovery + Prom exemplars source) will be filed as POST-1.0.0 project items.

Part of the v1.0.0-GA pre-release audit (item `PVTI_lAHOAAHeQ84BXZ2VzgsrQ9c`).

## Test plan

- [ ] CI green (`check` + `lint`) before auto-merge fires
- [x] No behavioural changes — every diff is a doc comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)