### PR TITLE
chore(lefthook): add markdown table aligner pre-commit step

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -19,6 +19,13 @@ pre-commit:
       stage_fixed: true
       run: |
         goimports -w {staged_files}
+    md-table-align:
+      # MD060 (table-column-style: aligned) has no auto-fixer in
+      # markdownlint-cli2 — pad cell widths before --fix sees the file.
+      glob: "*.md"
+      stage_fixed: true
+      run: |
+        python3 scripts/align-md-tables.py {staged_files}
     markdownlint:
       glob: "*.md"
       stage_fixed: true

--- a/scripts/align-md-tables.py
+++ b/scripts/align-md-tables.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Align markdown tables in-place so MD060 (table-column-style: aligned) passes.
+
+markdownlint's MD060 measures pipe positions by Unicode display width via the
+`string-width` npm package, not bytes or codepoints. For the cerberus repo
+every char in every table is display-width 1 (or whitespace), so codepoint
+counting matches display width exactly. If that ever stops being true
+(emoji or CJK in tables), swap `len(stripped)` for `wcwidth.wcswidth(stripped)`.
+
+Usage: align-md-tables.py FILE [FILE ...]
+"""
+
+import re
+import sys
+
+
+def align_table(table_lines: list[str]) -> list[str]:
+    rows = []
+    for line in table_lines:
+        s = line.rstrip("\n").strip()
+        if not s.startswith("|") or not s.endswith("|"):
+            return table_lines
+        rows.append([c for c in s[1:-1].split("|")])
+    if not rows:
+        return table_lines
+    n_cols = len(rows[0])
+    widths = [0] * n_cols
+    sep_idx = None
+    for i, row in enumerate(rows):
+        if len(row) != n_cols:
+            return table_lines
+        for j, cell in enumerate(row):
+            stripped = cell.strip()
+            if re.fullmatch(r":?-+:?", stripped):
+                sep_idx = i
+            w = len(stripped)
+            if w > widths[j]:
+                widths[j] = w
+    out = []
+    for i, row in enumerate(rows):
+        cells = []
+        for j, cell in enumerate(row):
+            stripped = cell.strip()
+            if i == sep_idx:
+                cells.append(" " + "-" * widths[j] + " ")
+            else:
+                pad = widths[j] - len(stripped)
+                cells.append(" " + stripped + " " * pad + " ")
+        out.append("|" + "|".join(cells) + "|\n")
+    return out
+
+
+def align_file(path: str) -> bool:
+    with open(path, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+    out = []
+    i = 0
+    while i < len(lines):
+        if lines[i].lstrip().startswith("|") and lines[i].rstrip().endswith("|"):
+            j = i
+            while (
+                j < len(lines)
+                and lines[j].lstrip().startswith("|")
+                and lines[j].rstrip().endswith("|")
+            ):
+                j += 1
+            out.extend(align_table(lines[i:j]))
+            i = j
+        else:
+            out.append(lines[i])
+            i += 1
+    if out != lines:
+        with open(path, "w", encoding="utf-8") as f:
+            f.writelines(out)
+        return True
+    return False
+
+
+def main() -> int:
+    changed = False
+    for path in sys.argv[1:]:
+        if not path.endswith(".md"):
+            continue
+        if align_file(path):
+            changed = True
+    return 0 if not changed else 0  # always exit 0; lefthook stages fixed files
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Add a pre-commit aligner that pads markdown table cells so `MD060`
(`table-column-style: aligned`) passes by the time `markdownlint-cli2
--fix` sees the file. The recurring `lint` CI failures in this
session were all the same shape: agent edits a table, columns no
longer line up, `markdownlint-cli2 --fix` has no fixer for MD060,
push fails CI. This closes the workflow gap.

## Why MD060 needed a custom step

I read `markdownlint-cli2`'s rule sources. `MD060`'s implementation
in `lib/md060.mjs` measures pipe positions via the `string-width`
npm package (Unicode terminal display width) and reports
mismatches — but it doesn't ship a fixer. `--fix` is a no-op for
this rule. The pin `MD060: style: aligned` in `.markdownlint.yaml`
(PR #213) is necessary but not sufficient.

## What the aligner does

- Walks each `*.md` argv, finds contiguous blocks of `|`-bracketed
  lines, normalises cell widths per column.
- Counts codepoints (`len(stripped)`). For every cerberus markdown
  table today, every char is display-width 1, so codepoints match
  `string-width`. The docstring spells out the upgrade path to
  `wcwidth.wcswidth()` if CJK/emoji ever land in a table.
- Exits 0 always; lefthook's `stage_fixed: true` restages anything
  the script rewrites.
- Wired to run *before* `markdownlint-cli2 --fix` so the linter
  sees a rule-clean file (and its other fixers still get to run).

## Test plan

- [x] `python3 scripts/align-md-tables.py docs/roadmap.md CLAUDE.md README.md` produces no diff (current tables already pass MD060).
- [x] Aligner is exit-0 even on no-op input.
- [ ] CI `lint` job stays green on this PR (and the hook will fire on every future markdown commit locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)