### PR TITLE
fix(ci/e2e): dump sample-app-metrics + sample-app-logs on failure

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -102,6 +102,15 @@ jobs:
           kubectl -n cerberus logs daemonset/otel-collector-agent --tail 200 || true
           echo "=== sample-app traces logs ==="
           kubectl -n cerberus logs deploy/sample-app-traces --tail 100 || true
+          echo "=== sample-app metrics logs ==="
+          kubectl -n cerberus logs deploy/sample-app-metrics --tail 100 || true
+          echo "=== sample-app metrics previous-container logs ==="
+          kubectl -n cerberus logs deploy/sample-app-metrics --previous --tail 100 || true
+          echo "=== sample-app logs logs ==="
+          kubectl -n cerberus logs deploy/sample-app-logs --tail 100 || true
+          echo "=== sample-app metrics describe ==="
+          kubectl -n cerberus describe deployment/sample-app-metrics || true
+          kubectl -n cerberus describe pod -l app=sample-app,signal=metrics || true
 
       - name: Tear down
         if: always()


### PR DESCRIPTION
## Summary

The nightly `e2e` workflow's `Dump cluster state on failure` step only
logged `deploy/sample-app-traces`. When `sample-app-metrics`
CrashLoopBackOff'd, the actual container output was invisible — every
failed nightly was a black box.

This adds:
- `deploy/sample-app-metrics` current container logs
- `deploy/sample-app-metrics --previous` (the crashloop's *last
  terminated* container, where the real failure output lives — current
  container is often pre-start and produces nothing on stdout)
- `deploy/sample-app-logs` current container logs
- `kubectl describe deployment/sample-app-metrics` + pod describe
  (surfaces event stream and `lastState.terminated.reason`)

Nightly e2e has been red since PR #172 landed sample-app on
2026-05-13 16:39, and no one's been able to see why. This is the
prerequisite for the actual fix — without it the next failed run is
still a black box.

## Test plan

- [ ] PR check + lint stay green (no functional change to code, only
  workflow-step output).
- [ ] Next failed `e2e` run (scheduled or manual dispatch) captures
  the crash output, enabling the follow-up diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)