### PR TITLE
fix(deploy/k3s): drop --service flag from sample-app-metrics

### DIFF
--- a/deploy/k3s/sample-app.yaml
+++ b/deploy/k3s/sample-app.yaml
@@ -71,13 +71,16 @@ spec:
         - name: telemetrygen
           image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.116.0
           args:
+            # NOTE: telemetrygen v0.116.0 `metrics` subcommand has no
+            # `--service` flag (unlike `traces`). Pass service.name via
+            # `--otlp-attributes`, same shape as `sample-app-logs`.
             - metrics
             - --otlp-endpoint=otel-collector-gateway:4317
             - --otlp-insecure
             - --duration=24h
             - --rate=2
             - --workers=1
-            - --service=sample-app
+            - --otlp-attributes=service.name="sample-app"
             - --otlp-attributes=service.namespace="cerberus-e2e"
             - --otlp-attributes=deployment.environment="e2e"
           resources:


### PR DESCRIPTION
## Summary

`telemetrygen v0.116.0`'s `metrics` subcommand has no `--service` flag
(only `traces` does). Passing `--service=sample-app` makes the
container exit immediately with `Error: unknown flag: --service`,
which is why `sample-app-metrics` has been in CrashLoopBackOff in
every nightly e2e since #172 landed.

Switch to `--otlp-attributes=service.name="sample-app"` — the same
shape `sample-app-logs` already uses (and works). Comment added so
future telemetrygen bumps don't silently re-introduce the flag.

## Diagnosis trail

This is the fix that #238 unblocked. Until #238 added the
`--previous`-container log dump to the e2e failure step, the crash
output was invisible — every failed nightly was a black box.

The actual crash log (now visible thanks to #238):

```
=== sample-app metrics previous-container logs ===
Error: unknown flag: --service
Usage:
  telemetrygen metrics [flags]
…
```

## Test plan

- [ ] PR check + lint stay green (no Go code changes).
- [ ] Manual e2e dispatch after merge: dashboard job goes green
      (sample-app-metrics no longer crashloops; `kubectl wait` at
      `Justfile:228` returns clean).

## Open follow-ups

- `startup-bench` job is independently failing (CH service container
  goes unhealthy ~60s after start). Tracked separately — different
  failure mode, different fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)