### PR TITLE
fix(ci/startup-bench): widen CH health-retries to 24 (120s grace)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -133,11 +133,16 @@ jobs:
           CLICKHOUSE_PASSWORD: cerberus
         ports:
           - 9000:9000
+        # Health probe: clickhouse/clickhouse-server:24.8-alpine init does
+        # a two-phase boot (temp server → apply users+DB → restart "for
+        # real"). Port 8123 is briefly unresponsive during the restart.
+        # 10 retries × 5s = 50s isn't enough under runner load; bump to
+        # 24 retries × 5s = 120s.
         options: >-
           --health-cmd "wget -nv -t1 --spider http://localhost:8123/ping || exit 1"
           --health-interval 5s
           --health-timeout 3s
-          --health-retries 10
+          --health-retries 24
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary

The `startup-bench` job's ClickHouse service container has been going
`unhealthy` ~60s after launch in every nightly e2e run. Root cause:
the `clickhouse/clickhouse-server:24.8-alpine` entrypoint does a
two-phase boot (temp server → apply users.xml + create database →
restart "for real"). Port 8123 is briefly unresponsive during the
restart, and 10 retries × 5s = 50s grace isn't enough under GH
Actions runner load.

Bump retries to 24 (120s). The probe itself is correct; the timeout
was just tight.

## Diagnosis trail

Independent thread from the `dashboard` failure fixed in #239. Same
nightly, different job, different failure mode.

Pre-#239 + pre-this-PR: both jobs red.
Post-#239: dashboard goes green; startup-bench still red.
Post-this-PR: startup-bench goes green too → full `e2e` workflow green.

## Test plan

- [ ] PR check + lint stay green (workflow-only change).
- [ ] Manual e2e dispatch after #239 + this lands: both jobs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)