### PR TITLE
fix(api/prom): paren-wrap UNION ALL when it's a FROM source

### DIFF
--- a/internal/api/prom/metadata.go
+++ b/internal/api/prom/metadata.go
@@ -460,7 +460,7 @@ func (h *Handler) unionLabelNamesSQL() string {
 	}
 	outer := chsql.NewQuery().
 		Select(chsql.As(distinctIdent("name"), "")).
-		From(chsql.UnionAll(parts...)).
+		From(chsql.Paren(chsql.UnionAll(parts...))).
 		OrderBy(chsql.Col("name"), false)
 	sql, _ := outer.Build()
 	return sql
@@ -479,7 +479,7 @@ func (h *Handler) unionMetricNamesSQL() string {
 	}
 	outer := chsql.NewQuery().
 		Select(chsql.As(distinctIdent("value"), "")).
-		From(chsql.UnionAll(parts...)).
+		From(chsql.Paren(chsql.UnionAll(parts...))).
 		OrderBy(chsql.Col("value"), false)
 	sql, _ := outer.Build()
 	return sql
@@ -504,7 +504,7 @@ func (h *Handler) unionLabelValuesSQL(name string) (string, []any) {
 	}
 	outer := chsql.NewQuery().
 		Select(chsql.As(distinctIdent("value"), "")).
-		From(chsql.UnionAll(parts...)).
+		From(chsql.Paren(chsql.UnionAll(parts...))).
 		OrderBy(chsql.Col("value"), false)
 	return outer.Build()
 }


### PR DESCRIPTION
## Summary

The `/api/v1/labels`, `/api/v1/label/__name__/values`, and
`/api/v1/label/<name>/values` handlers in `metadata.go` build SQL of
shape:

```sql
SELECT DISTINCT col
FROM (q1) UNION ALL (q2) UNION ALL (q3)
ORDER BY col
```

ClickHouse parses this as a top-level `UNION ALL` with `ORDER BY`
attached to the last arm — which is a syntax error:

```
code: 62, message: Syntax error: failed at position 285 ('ORDER'):
ORDER BY `name`. Expected one of: UNION, EXCEPT, INTERSECT,
INTO OUTFILE, FORMAT, SETTINGS, end of query
```

Wrap the `UnionAll` in `chsql.Paren` at all three call sites so the
subquery boundary is explicit:

```sql
SELECT DISTINCT col
FROM ((q1) UNION ALL (q2) UNION ALL (q3))
ORDER BY col
```

3-line diff. Smallest possible fix.

## Diagnosis trail

Surfaced by the e2e dispatch I ran post-#239+#240:

```
e2e_prom_test.go:104: GET /api/v1/labels: status 502; body=
  {"status":"error","errorType":"internal",
   "error":"chclient: query: code: 62, …"}
```

No metadata TXTAR fixture today, so unit tests didn't catch it.

## Test plan

- [ ] PR `check` + `lint` stay green.
- [ ] Manual e2e dispatch after merge — `e2e_prom_test.go` labels-related cases turn green.

## Open follow-ups

- `startup-bench` still failing despite the 120s health-retry bump in #240. Different root cause; tracking separately.
- Consider adding a metadata-handler TXTAR fixture or a Go test that asserts on the SQL shape so this regresses with a unit failure rather than only at e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)