### PR TITLE
test(chsql): add typed Frag goldens + QueryBuilder slot invariants

### DIFF
--- a/internal/chsql/emit_node_goldens_test.go
+++ b/internal/chsql/emit_node_goldens_test.go
@@ -1,0 +1,642 @@
+package chsql_test
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+)
+
+// TestEmitNode_Scan_NoColumns — a Scan with an empty Columns slice
+// renders `SELECT * FROM <table>`. The lowering pass relies on this
+// default when a head doesn't pin a projection list.
+func TestEmitNode_Scan_NoColumns(t *testing.T) {
+	t.Parallel()
+
+	sql, args, err := chsql.Emit(context.Background(), &chplan.Scan{Table: "otel_metrics_gauge"})
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if want := "SELECT * FROM `otel_metrics_gauge`"; sql != want {
+		t.Errorf("SQL = %q; want %q", sql, want)
+	}
+	if args != nil {
+		t.Errorf("Args = %v; want nil", args)
+	}
+}
+
+// TestEmitNode_Scan_WithColumns — a Scan with Columns renders the
+// projection list in order, all backtick-quoted.
+func TestEmitNode_Scan_WithColumns(t *testing.T) {
+	t.Parallel()
+
+	sql, _, err := chsql.Emit(context.Background(), &chplan.Scan{
+		Table:   "otel_metrics_gauge",
+		Columns: []string{"TimeUnix", "Value", "Attributes"},
+	})
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	want := "SELECT `TimeUnix`, `Value`, `Attributes` FROM `otel_metrics_gauge`"
+	if sql != want {
+		t.Errorf("SQL = %q; want %q", sql, want)
+	}
+}
+
+// TestEmitNode_Limit_ZeroCount — a Limit with Count == 0 omits the
+// LIMIT clause entirely (zero means "no limit", matching the QueryBuilder
+// slot semantics).
+func TestEmitNode_Limit_ZeroCount(t *testing.T) {
+	t.Parallel()
+
+	sql, _, err := chsql.Emit(context.Background(), &chplan.Limit{
+		Input: &chplan.Scan{Table: "otel_logs"},
+		Count: 0,
+	})
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if strings.Contains(sql, "LIMIT") {
+		t.Errorf("Limit{Count:0} emitted LIMIT clause: %q", sql)
+	}
+}
+
+// TestEmitNode_Limit_NegativeCount — same as zero: no LIMIT clause.
+func TestEmitNode_Limit_NegativeCount(t *testing.T) {
+	t.Parallel()
+
+	sql, _, err := chsql.Emit(context.Background(), &chplan.Limit{
+		Input: &chplan.Scan{Table: "otel_logs"},
+		Count: -1,
+	})
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if strings.Contains(sql, "LIMIT") {
+		t.Errorf("Limit{Count:-1} emitted LIMIT clause: %q", sql)
+	}
+}
+
+// TestEmitNode_Limit_PositiveCount — the canonical case: a non-zero
+// Count wraps the input in `SELECT * FROM (<input>) LIMIT N`.
+func TestEmitNode_Limit_PositiveCount(t *testing.T) {
+	t.Parallel()
+
+	sql, _, err := chsql.Emit(context.Background(), &chplan.Limit{
+		Input: &chplan.Scan{Table: "otel_logs"},
+		Count: 1000,
+	})
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if !strings.Contains(sql, "LIMIT 1000") {
+		t.Errorf("Limit{Count:1000} did not emit LIMIT 1000: %q", sql)
+	}
+}
+
+// TestEmitNode_OrderBy_NoKeys — OrderBy with no keys is a programmer
+// error and must produce ErrUnsupported. Silently dropping the sort
+// intent would corrupt query results in subtle ways.
+func TestEmitNode_OrderBy_NoKeys(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := chsql.Emit(context.Background(), &chplan.OrderBy{
+		Input: &chplan.Scan{Table: "otel_logs"},
+		Keys:  nil,
+	})
+	if err == nil {
+		t.Fatal("OrderBy with no keys did not error")
+	}
+	if !errors.Is(err, chsql.ErrUnsupported) {
+		t.Errorf("err = %v; want wrapped ErrUnsupported", err)
+	}
+}
+
+// TestEmitNode_OrderBy_SingleKeyAscIsImplicit — Desc=false renders no
+// "ASC" keyword; CH defaults to ascending so the absence of "DESC" is
+// the implicit ASC.
+func TestEmitNode_OrderBy_SingleKeyAscIsImplicit(t *testing.T) {
+	t.Parallel()
+
+	sql, _, err := chsql.Emit(context.Background(), &chplan.OrderBy{
+		Input: &chplan.Scan{Table: "otel_logs"},
+		Keys: []chplan.OrderKey{
+			{Expr: &chplan.ColumnRef{Name: "Timestamp"}, Desc: false},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if !strings.Contains(sql, "ORDER BY `Timestamp`") {
+		t.Errorf("missing ORDER BY clause in %q", sql)
+	}
+	if strings.Contains(sql, "ASC") {
+		t.Errorf("implicit ASC should not render as keyword: %q", sql)
+	}
+	if strings.Contains(sql, "DESC") {
+		t.Errorf("desc=false should not render DESC: %q", sql)
+	}
+}
+
+// TestEmitNode_OrderBy_DescRendersKeyword — Desc=true renders "DESC"
+// after the key expression.
+func TestEmitNode_OrderBy_DescRendersKeyword(t *testing.T) {
+	t.Parallel()
+
+	sql, _, err := chsql.Emit(context.Background(), &chplan.OrderBy{
+		Input: &chplan.Scan{Table: "otel_logs"},
+		Keys: []chplan.OrderKey{
+			{Expr: &chplan.ColumnRef{Name: "Timestamp"}, Desc: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if !strings.Contains(sql, "ORDER BY `Timestamp` DESC") {
+		t.Errorf("missing 'ORDER BY `Timestamp` DESC' in %q", sql)
+	}
+}
+
+// TestEmitNode_Project_EmptyProjections — a Project with no projection
+// expressions renders the input wrapped in `SELECT * FROM (<input>)`.
+// The Project slot collapses to a passthrough wrapper.
+func TestEmitNode_Project_EmptyProjections(t *testing.T) {
+	t.Parallel()
+
+	sql, _, err := chsql.Emit(context.Background(), &chplan.Project{
+		Input:       &chplan.Scan{Table: "otel_logs"},
+		Projections: nil,
+	})
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if !strings.HasPrefix(sql, "SELECT * FROM (") {
+		t.Errorf("expected SELECT * FROM (...) passthrough; got %q", sql)
+	}
+}
+
+// TestEmitNode_Project_PreservesProjectionOrder — Projections emit in
+// slice order; aliases are backtick-quoted.
+func TestEmitNode_Project_PreservesProjectionOrder(t *testing.T) {
+	t.Parallel()
+
+	sql, _, err := chsql.Emit(context.Background(), &chplan.Project{
+		Input: &chplan.Scan{Table: "otel_metrics_gauge"},
+		Projections: []chplan.Projection{
+			{Expr: &chplan.ColumnRef{Name: "TimeUnix"}, Alias: "t"},
+			{Expr: &chplan.ColumnRef{Name: "Value"}, Alias: "v"},
+			{Expr: &chplan.ColumnRef{Name: "MetricName"}, Alias: "n"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	want := "SELECT `TimeUnix` AS `t`, `Value` AS `v`, `MetricName` AS `n` FROM"
+	if !strings.Contains(sql, want) {
+		t.Errorf("expected %q in emitted SQL; got %q", want, sql)
+	}
+}
+
+// TestEmitNode_Filter_PropagatesChildError — when the Filter's Input
+// child triggers an error during emit, the Filter emitter must surface
+// that error rather than swallowing it.
+func TestEmitNode_Filter_PropagatesChildError(t *testing.T) {
+	t.Parallel()
+
+	// A nested OrderBy with no keys triggers ErrUnsupported. Wrapping
+	// it in a Filter exercises the child-error propagation path.
+	plan := &chplan.Filter{
+		Input: &chplan.OrderBy{
+			Input: &chplan.Scan{Table: "otel_logs"},
+			Keys:  nil,
+		},
+		Predicate: &chplan.Binary{
+			Op:    chplan.OpEq,
+			Left:  &chplan.ColumnRef{Name: "Body"},
+			Right: &chplan.LitString{V: "x"},
+		},
+	}
+	_, _, err := chsql.Emit(context.Background(), plan)
+	if err == nil {
+		t.Fatal("expected error from nested OrderBy{keys:nil}; got nil")
+	}
+	if !errors.Is(err, chsql.ErrUnsupported) {
+		t.Errorf("err = %v; want wrapped ErrUnsupported", err)
+	}
+}
+
+// TestEmitNode_Limit_PropagatesChildError — same propagation contract
+// for Limit (its emitSubqueryFrag path must surface child errors, not
+// produce malformed SQL).
+func TestEmitNode_Limit_PropagatesChildError(t *testing.T) {
+	t.Parallel()
+
+	plan := &chplan.Limit{
+		Input: &chplan.OrderBy{
+			Input: &chplan.Scan{Table: "otel_logs"},
+			Keys:  nil,
+		},
+		Count: 10,
+	}
+	_, _, err := chsql.Emit(context.Background(), plan)
+	if err == nil {
+		t.Fatal("expected error from nested OrderBy{keys:nil}; got nil")
+	}
+	if !errors.Is(err, chsql.ErrUnsupported) {
+		t.Errorf("err = %v; want wrapped ErrUnsupported", err)
+	}
+}
+
+// TestEmitNode_Project_PropagatesChildError — same propagation contract
+// for Project.
+func TestEmitNode_Project_PropagatesChildError(t *testing.T) {
+	t.Parallel()
+
+	plan := &chplan.Project{
+		Input: &chplan.OrderBy{
+			Input: &chplan.Scan{Table: "otel_logs"},
+			Keys:  nil,
+		},
+		Projections: []chplan.Projection{
+			{Expr: &chplan.ColumnRef{Name: "Value"}, Alias: "v"},
+		},
+	}
+	_, _, err := chsql.Emit(context.Background(), plan)
+	if err == nil {
+		t.Fatal("expected error from nested OrderBy{keys:nil}; got nil")
+	}
+	if !errors.Is(err, chsql.ErrUnsupported) {
+		t.Errorf("err = %v; want wrapped ErrUnsupported", err)
+	}
+}
+
+// TestEmitNode_Aggregate_PropagatesChildError — same propagation
+// contract for Aggregate.
+func TestEmitNode_Aggregate_PropagatesChildError(t *testing.T) {
+	t.Parallel()
+
+	plan := &chplan.Aggregate{
+		Input: &chplan.OrderBy{
+			Input: &chplan.Scan{Table: "otel_metrics_gauge"},
+			Keys:  nil,
+		},
+		AggFuncs: []chplan.AggFunc{
+			{Name: "sum", Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}, Alias: "total"},
+		},
+	}
+	_, _, err := chsql.Emit(context.Background(), plan)
+	if err == nil {
+		t.Fatal("expected error from nested OrderBy{keys:nil}; got nil")
+	}
+	if !errors.Is(err, chsql.ErrUnsupported) {
+		t.Errorf("err = %v; want wrapped ErrUnsupported", err)
+	}
+}
+
+// TestEmitNode_SetOperation_Intersect — TraceQL `A && B` lowers to
+// `SELECT L.* FROM (<A>) AS L INNER JOIN (<B>) AS R
+//
+//	ON L.TraceId = R.TraceId AND L.SpanId = R.SpanId`.
+//
+// Both sides are emitted as subqueries; the ON predicate is composed
+// from the configured (TraceID, SpanID) column names. The chsql
+// package has no Go-level test for this shape (only the per-head
+// traceql lowering test), so this is the first emit-level pin.
+func TestEmitNode_SetOperation_Intersect(t *testing.T) {
+	t.Parallel()
+
+	plan := &chplan.SetOperation{
+		Left:          &chplan.Scan{Table: "otel_traces"},
+		Right:         &chplan.Scan{Table: "otel_traces"},
+		Op:            chplan.SetIntersect,
+		TraceIDColumn: "TraceId",
+		SpanIDColumn:  "SpanId",
+	}
+	sql, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	// Verify the structural shape: SELECT L.*, INNER JOIN, ON predicate.
+	for _, frag := range []string{
+		"SELECT L.*",
+		"INNER JOIN",
+		"`L`.`TraceId` = `R`.`TraceId`",
+		"`L`.`SpanId` = `R`.`SpanId`",
+		"AS `L`",
+		"AS `R`",
+	} {
+		if !strings.Contains(sql, frag) {
+			t.Errorf("SetIntersect SQL missing fragment %q; got %q", frag, sql)
+		}
+	}
+	if args != nil {
+		t.Errorf("Args = %v; want nil (no `?` in this shape)", args)
+	}
+}
+
+// TestEmitNode_SetOperation_Union — TraceQL `A || B` lowers to
+// `(<A>) UNION DISTINCT (<B>)`. Both arms render as parenthesised
+// subqueries with the UNION DISTINCT keyword between them.
+func TestEmitNode_SetOperation_Union(t *testing.T) {
+	t.Parallel()
+
+	plan := &chplan.SetOperation{
+		Left:          &chplan.Scan{Table: "otel_traces"},
+		Right:         &chplan.Scan{Table: "otel_traces"},
+		Op:            chplan.SetUnion,
+		TraceIDColumn: "TraceId",
+		SpanIDColumn:  "SpanId",
+	}
+	sql, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if !strings.Contains(sql, "UNION DISTINCT") {
+		t.Errorf("SetUnion did not emit UNION DISTINCT: %q", sql)
+	}
+	// Both arms should be wrapped in parens — UNION DISTINCT is a
+	// SELECT-level binary, each arm is a complete SELECT.
+	if !strings.Contains(sql, "(SELECT * FROM `otel_traces`)") {
+		t.Errorf("SetUnion arms not parenthesised: %q", sql)
+	}
+	if args != nil {
+		t.Errorf("Args = %v; want nil", args)
+	}
+}
+
+// TestEmitNode_SetOperation_MissingColumns — the SetOperation emitter
+// validates that TraceIDColumn / SpanIDColumn are non-empty. Without
+// them the JOIN predicate would reference empty identifiers and
+// produce a CH syntax error at runtime.
+func TestEmitNode_SetOperation_MissingColumns(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		plan *chplan.SetOperation
+	}{
+		{
+			"both columns unset",
+			&chplan.SetOperation{
+				Left:  &chplan.Scan{Table: "otel_traces"},
+				Right: &chplan.Scan{Table: "otel_traces"},
+				Op:    chplan.SetIntersect,
+			},
+		},
+		{
+			"trace id unset",
+			&chplan.SetOperation{
+				Left:         &chplan.Scan{Table: "otel_traces"},
+				Right:        &chplan.Scan{Table: "otel_traces"},
+				Op:           chplan.SetIntersect,
+				SpanIDColumn: "SpanId",
+			},
+		},
+		{
+			"span id unset",
+			&chplan.SetOperation{
+				Left:          &chplan.Scan{Table: "otel_traces"},
+				Right:         &chplan.Scan{Table: "otel_traces"},
+				Op:            chplan.SetIntersect,
+				TraceIDColumn: "TraceId",
+			},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, _, err := chsql.Emit(context.Background(), tc.plan)
+			if err == nil {
+				t.Fatalf("SetOperation %s did not error", tc.name)
+			}
+			if !errors.Is(err, chsql.ErrUnsupported) {
+				t.Errorf("err = %v; want wrapped ErrUnsupported", err)
+			}
+		})
+	}
+}
+
+// TestEmitNode_SetOperation_UnknownOp — a SetOperation whose Op is
+// neither SetIntersect nor SetUnion must surface ErrUnsupported rather
+// than producing arbitrary SQL.
+func TestEmitNode_SetOperation_UnknownOp(t *testing.T) {
+	t.Parallel()
+
+	plan := &chplan.SetOperation{
+		Left:          &chplan.Scan{Table: "otel_traces"},
+		Right:         &chplan.Scan{Table: "otel_traces"},
+		Op:            chplan.SetOp("??"),
+		TraceIDColumn: "TraceId",
+		SpanIDColumn:  "SpanId",
+	}
+	_, _, err := chsql.Emit(context.Background(), plan)
+	if err == nil {
+		t.Fatal("unknown SetOp did not error")
+	}
+	if !errors.Is(err, chsql.ErrUnsupported) {
+		t.Errorf("err = %v; want wrapped ErrUnsupported", err)
+	}
+}
+
+// TestEmitNode_SetOperation_LeftErrorPropagates — a child error on
+// the Left arm surfaces from Emit (catches a regression that swallows
+// errors after the first subquery render).
+func TestEmitNode_SetOperation_LeftErrorPropagates(t *testing.T) {
+	t.Parallel()
+
+	plan := &chplan.SetOperation{
+		Left: &chplan.OrderBy{
+			Input: &chplan.Scan{Table: "otel_traces"},
+			Keys:  nil,
+		},
+		Right:         &chplan.Scan{Table: "otel_traces"},
+		Op:            chplan.SetIntersect,
+		TraceIDColumn: "TraceId",
+		SpanIDColumn:  "SpanId",
+	}
+	_, _, err := chsql.Emit(context.Background(), plan)
+	if err == nil {
+		t.Fatal("expected error from left-arm child; got nil")
+	}
+	if !errors.Is(err, chsql.ErrUnsupported) {
+		t.Errorf("err = %v; want wrapped ErrUnsupported", err)
+	}
+}
+
+// TestEmitNode_SetOperation_RightErrorPropagates — same for the right arm.
+func TestEmitNode_SetOperation_RightErrorPropagates(t *testing.T) {
+	t.Parallel()
+
+	plan := &chplan.SetOperation{
+		Left: &chplan.Scan{Table: "otel_traces"},
+		Right: &chplan.OrderBy{
+			Input: &chplan.Scan{Table: "otel_traces"},
+			Keys:  nil,
+		},
+		Op:            chplan.SetIntersect,
+		TraceIDColumn: "TraceId",
+		SpanIDColumn:  "SpanId",
+	}
+	_, _, err := chsql.Emit(context.Background(), plan)
+	if err == nil {
+		t.Fatal("expected error from right-arm child; got nil")
+	}
+	if !errors.Is(err, chsql.ErrUnsupported) {
+		t.Errorf("err = %v; want wrapped ErrUnsupported", err)
+	}
+}
+
+// TestEmitNode_NestedScans_BindArgsInOrder — a Filter wrapping a Scan
+// (the PREWHERE-eligible shape) binds the predicate arg at the WHERE
+// position. Pinning this confirms args land at `?` positions across
+// the typed Frag emission, not at some other position.
+func TestEmitNode_NestedScans_BindArgsInOrder(t *testing.T) {
+	t.Parallel()
+
+	plan := &chplan.Filter{
+		Input: &chplan.Scan{Table: "otel_metrics_gauge"},
+		Predicate: &chplan.Binary{
+			Op:    chplan.OpEq,
+			Left:  &chplan.ColumnRef{Name: "MetricName"},
+			Right: &chplan.LitString{V: "http_requests_total"},
+		},
+	}
+	_, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if want := []any{"http_requests_total"}; !reflect.DeepEqual(args, want) {
+		t.Errorf("Args = %v; want %v", args, want)
+	}
+}
+
+// TestEmitNode_Filter_NonScanInput — a Filter whose Input is NOT a
+// Scan falls back to the historical `SELECT * FROM (<subq>) WHERE …`
+// shape (PREWHERE only applies above a Scan).
+func TestEmitNode_Filter_NonScanInput(t *testing.T) {
+	t.Parallel()
+
+	plan := &chplan.Filter{
+		Input: &chplan.Limit{
+			Input: &chplan.Scan{Table: "otel_logs"},
+			Count: 100,
+		},
+		Predicate: &chplan.Binary{
+			Op:    chplan.OpEq,
+			Left:  &chplan.ColumnRef{Name: "Body"},
+			Right: &chplan.LitString{V: "x"},
+		},
+	}
+	sql, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	// Must NOT contain PREWHERE — that's a Filter-over-Scan exclusive shape.
+	if strings.Contains(sql, "PREWHERE") {
+		t.Errorf("Filter(Limit(Scan)) emitted PREWHERE — only Filter(Scan) qualifies: %q", sql)
+	}
+	if !strings.HasPrefix(sql, "SELECT * FROM (") {
+		t.Errorf("Filter(Limit) did not wrap subquery: %q", sql)
+	}
+	if want := []any{"x"}; !reflect.DeepEqual(args, want) {
+		t.Errorf("Args = %v; want %v", args, want)
+	}
+}
+
+// TestEmitNode_Limit_OverOrderBy — the canonical Tempo `/api/search`
+// shape: Limit(OrderBy(Scan, ts DESC), N). Confirms the two passthrough
+// emitters chain cleanly, producing a single SELECT with both clauses
+// flattened.
+func TestEmitNode_Limit_OverOrderBy(t *testing.T) {
+	t.Parallel()
+
+	plan := &chplan.Limit{
+		Input: &chplan.OrderBy{
+			Input: &chplan.Scan{Table: "otel_traces"},
+			Keys: []chplan.OrderKey{
+				{Expr: &chplan.ColumnRef{Name: "Timestamp"}, Desc: true},
+			},
+		},
+		Count: 20,
+	}
+	sql, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	// Both clauses must appear; LIMIT must come after ORDER BY in any
+	// nested wrapping.
+	if !strings.Contains(sql, "ORDER BY") || !strings.Contains(sql, "LIMIT 20") {
+		t.Errorf("expected both ORDER BY and LIMIT 20 in %q", sql)
+	}
+	orderIdx := strings.Index(sql, "ORDER BY")
+	limitIdx := strings.Index(sql, "LIMIT 20")
+	if orderIdx > limitIdx {
+		t.Errorf("LIMIT appeared before ORDER BY in %q", sql)
+	}
+}
+
+// TestEmitNode_OrderBy_MultiKey — two keys in OrderBy emit a
+// comma-separated list with per-key direction. ASC keys render
+// without keyword; DESC keys render with the trailing keyword.
+func TestEmitNode_OrderBy_MultiKey(t *testing.T) {
+	t.Parallel()
+
+	plan := &chplan.OrderBy{
+		Input: &chplan.Scan{Table: "otel_traces"},
+		Keys: []chplan.OrderKey{
+			{Expr: &chplan.ColumnRef{Name: "ServiceName"}, Desc: false},
+			{Expr: &chplan.ColumnRef{Name: "Timestamp"}, Desc: true},
+		},
+	}
+	sql, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if !strings.Contains(sql, "ORDER BY `ServiceName`, `Timestamp` DESC") {
+		t.Errorf("composite ORDER BY missing or malformed: %q", sql)
+	}
+}
+
+// TestEmitNode_Scan_BackticksEmbeddedBackticks — Scan with a table
+// name containing a backtick character must double-escape the
+// backtick to satisfy CH's identifier-quoting rules. This is a
+// table-name surface for the existing Ident-doubling contract.
+func TestEmitNode_Scan_BackticksEmbeddedBackticks(t *testing.T) {
+	t.Parallel()
+
+	sql, _, err := chsql.Emit(context.Background(), &chplan.Scan{Table: "weird`table"})
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if want := "SELECT * FROM `weird``table`"; sql != want {
+		t.Errorf("SQL = %q; want %q (backtick must be doubled)", sql, want)
+	}
+}
+
+// TestEmitNode_PreservesSQLLength — Emit reports a non-zero SQL length
+// to its span (we observe this via the rendered byte length here, since
+// span attributes aren't directly inspectable). A regression that
+// returns an empty SQL string but no error would surface as a zero
+// length.
+func TestEmitNode_PreservesSQLLength(t *testing.T) {
+	t.Parallel()
+
+	sql, _, err := chsql.Emit(context.Background(), &chplan.Scan{Table: "otel_logs"})
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if len(sql) == 0 {
+		t.Error("Emit returned empty SQL with no error")
+	}
+}
+
+// Note: the `chplan.Node` interface is sealed by an unexported
+// `planNode()` marker, so we can't construct an out-of-package Node
+// implementation to exercise the emitter's default-case error path.
+// TestEmit_NilNode in emit_negatives_test.go covers the analogous
+// "no recognised node type" branch via the nil path.

--- a/internal/chsql/frag_goldens_test.go
+++ b/internal/chsql/frag_goldens_test.go
@@ -326,7 +326,7 @@ func TestFrag_Goldens(t *testing.T) {
 				t.Errorf("SQL = %q; want %q", gotSQL, tc.wantSQL)
 			}
 			if tc.wantArgs == nil {
-				if gotArgs != nil && len(gotArgs) != 0 {
+				if len(gotArgs) != 0 {
 					t.Errorf("Args = %v; want nil/empty", gotArgs)
 				}
 				return
@@ -447,7 +447,9 @@ func TestFrag_InlineLit_PanicMessage(t *testing.T) {
 			t.Errorf("panic value = %v; want message mentioning 'bool'", r)
 		}
 	}()
-	InlineLit(true)
+	// InlineLit returns a closure; the panic fires only when the closure
+	// runs against a Builder. Invoke it here to surface the panic.
+	InlineLit(true)(NewBuilder())
 }
 
 // TestFrag_Array_BindsAtPosition — Array elements emit their args

--- a/internal/chsql/frag_goldens_test.go
+++ b/internal/chsql/frag_goldens_test.go
@@ -1,0 +1,513 @@
+package chsql
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestFrag_Goldens is the unified golden table for every public Frag
+// constructor in builder.go. The existing tests in builder_test.go cover
+// individual Frags at a per-constructor granularity; this table-driven
+// aggregator pins one canonical shape per Frag so a regression in any
+// single constructor surfaces in one place rather than scattered across
+// dozens of bespoke tests.
+//
+// Each entry builds the Frag, runs it through a fresh Builder, and
+// asserts both the rendered SQL string and the bound args slice.
+// Constructors that panic on bad input have their own dedicated tests
+// in builder_test.go — this table covers the happy path only.
+func TestFrag_Goldens(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		frag     Frag
+		wantSQL  string
+		wantArgs []any
+	}{
+		// ── Basic identifier / literal Frags ──────────────────────────
+		{name: "Col", frag: Col("Value"), wantSQL: "`Value`"},
+		{name: "Col_embedded_backtick", frag: Col("weird`name"), wantSQL: "`weird``name`"},
+		{name: "Qual", frag: Qual("L", "Value"), wantSQL: "`L`.`Value`"},
+		{name: "Lit_string", frag: Lit("api"), wantSQL: "?", wantArgs: []any{"api"}},
+		{name: "Lit_int", frag: Lit(42), wantSQL: "?", wantArgs: []any{42}},
+		{name: "Lit_float", frag: Lit(0.5), wantSQL: "?", wantArgs: []any{0.5}},
+		{name: "BareIdent", frag: BareIdent("k"), wantSQL: "k"},
+		{name: "BareIdent_dotted", frag: BareIdent("c._depth"), wantSQL: "c._depth"},
+		{name: "InlineLit_int", frag: InlineLit(7), wantSQL: "7"},
+		{name: "InlineLit_int64", frag: InlineLit(int64(9)), wantSQL: "9"},
+		{name: "InlineLit_float", frag: InlineLit(3.14), wantSQL: "3.14"},
+		{name: "InlineLit_string", frag: InlineLit("foo"), wantSQL: "'foo'"},
+		{name: "InlineLit_string_escapes", frag: InlineLit(`a'b\c`), wantSQL: `'a\'b\\c'`},
+		{name: "Star", frag: Star(), wantSQL: "*"},
+		{name: "QualStar", frag: QualStar("L"), wantSQL: "`L`.*"},
+		{name: "Distinct", frag: Distinct(Col("Value")), wantSQL: "DISTINCT `Value`"},
+
+		// ── Comparison binary operators ───────────────────────────────
+		{
+			name:     "Eq",
+			frag:     Eq(Col("MetricName"), Lit("http_requests_total")),
+			wantSQL:  "`MetricName` = ?",
+			wantArgs: []any{"http_requests_total"},
+		},
+		{
+			name:     "Neq",
+			frag:     Neq(Col("MetricName"), Lit("up")),
+			wantSQL:  "`MetricName` != ?",
+			wantArgs: []any{"up"},
+		},
+		{
+			name:     "Lt",
+			frag:     Lt(Col("Value"), Lit(0.5)),
+			wantSQL:  "`Value` < ?",
+			wantArgs: []any{0.5},
+		},
+		{
+			name:     "Lte",
+			frag:     Lte(Col("Value"), Lit(1.0)),
+			wantSQL:  "`Value` <= ?",
+			wantArgs: []any{1.0},
+		},
+		{
+			name:     "Gt",
+			frag:     Gt(Col("Value"), Lit(0.0)),
+			wantSQL:  "`Value` > ?",
+			wantArgs: []any{0.0},
+		},
+		{
+			name:     "Gte",
+			frag:     Gte(Col("Value"), Lit(0.1)),
+			wantSQL:  "`Value` >= ?",
+			wantArgs: []any{0.1},
+		},
+		{
+			name:     "Like",
+			frag:     Like(Col("Body"), Lit("%err%")),
+			wantSQL:  "`Body` LIKE ?",
+			wantArgs: []any{"%err%"},
+		},
+		{
+			name:     "NotLike",
+			frag:     NotLike(Col("Body"), Lit("%ok%")),
+			wantSQL:  "`Body` NOT LIKE ?",
+			wantArgs: []any{"%ok%"},
+		},
+
+		// ── Logical combinators ───────────────────────────────────────
+		{
+			name:     "And_two",
+			frag:     And(Eq(Col("a"), Lit(1)), Eq(Col("b"), Lit(2))),
+			wantSQL:  "`a` = ? AND `b` = ?",
+			wantArgs: []any{1, 2},
+		},
+		{
+			name:     "And_three",
+			frag:     And(Eq(Col("a"), Lit(1)), Eq(Col("b"), Lit(2)), Eq(Col("c"), Lit(3))),
+			wantSQL:  "`a` = ? AND `b` = ? AND `c` = ?",
+			wantArgs: []any{1, 2, 3},
+		},
+		{
+			name:     "Or_two",
+			frag:     Or(Eq(Col("a"), Lit(1)), Eq(Col("b"), Lit(2))),
+			wantSQL:  "`a` = ? OR `b` = ?",
+			wantArgs: []any{1, 2},
+		},
+		{
+			name:    "Not",
+			frag:    Not(Col("active")),
+			wantSQL: "NOT `active`",
+		},
+		{
+			name:    "IsNull",
+			frag:    IsNull(Col("Value")),
+			wantSQL: "`Value` IS NULL",
+		},
+		{
+			name:    "IsNotNull",
+			frag:    IsNotNull(Col("Value")),
+			wantSQL: "`Value` IS NOT NULL",
+		},
+
+		// ── Arithmetic operators ──────────────────────────────────────
+		{
+			name:    "Add",
+			frag:    Add(Col("x"), Col("y")),
+			wantSQL: "`x` + `y`",
+		},
+		{
+			name:    "Sub",
+			frag:    Sub(Col("x"), Col("y")),
+			wantSQL: "`x` - `y`",
+		},
+		{
+			name:    "Mul",
+			frag:    Mul(Col("x"), Col("y")),
+			wantSQL: "`x` * `y`",
+		},
+		{
+			name:    "Div",
+			frag:    Div(Col("x"), Col("y")),
+			wantSQL: "`x` / `y`",
+		},
+		{
+			name:    "Mod",
+			frag:    Mod(Col("x"), Col("y")),
+			wantSQL: "`x` % `y`",
+		},
+		{
+			name:    "Neg",
+			frag:    Neg(Col("Value")),
+			wantSQL: "-`Value`",
+		},
+		{
+			name:    "Paren_wraps_no_inner_ws",
+			frag:    Paren(Add(Col("x"), Col("y"))),
+			wantSQL: "(`x` + `y`)",
+		},
+
+		// ── Set membership / type / range ─────────────────────────────
+		{
+			name:     "In_single",
+			frag:     In(Col("Status"), Lit("ok")),
+			wantSQL:  "`Status` IN (?)",
+			wantArgs: []any{"ok"},
+		},
+		{
+			name:     "In_multiple",
+			frag:     In(Col("Status"), Lit("ok"), Lit("warn"), Lit("err")),
+			wantSQL:  "`Status` IN (?, ?, ?)",
+			wantArgs: []any{"ok", "warn", "err"},
+		},
+		{
+			name:     "Between",
+			frag:     Between(Col("Value"), Lit(0.0), Lit(1.0)),
+			wantSQL:  "`Value` BETWEEN ? AND ?",
+			wantArgs: []any{0.0, 1.0},
+		},
+		{
+			name:    "Cast_basic",
+			frag:    Cast(Col("Value"), "Float64"),
+			wantSQL: "CAST(`Value` AS Float64)",
+		},
+		{
+			name:     "Cast_with_lit",
+			frag:     Cast(Lit("3.14"), "Float64"),
+			wantSQL:  "CAST(? AS Float64)",
+			wantArgs: []any{"3.14"},
+		},
+
+		// ── Calls / arrays / tuples / subscripts ──────────────────────
+		{name: "Call_nullary", frag: Call("now"), wantSQL: "now()"},
+		{
+			name:    "Call_single_arg",
+			frag:    Call("length", Col("Body")),
+			wantSQL: "length(`Body`)",
+		},
+		{
+			name:     "Call_multi_arg",
+			frag:     Call("concat", Lit("a"), Lit("b"), Lit("c")),
+			wantSQL:  "concat(?, ?, ?)",
+			wantArgs: []any{"a", "b", "c"},
+		},
+		{
+			name:     "Parametric_one_param_one_arg",
+			frag:     Parametric("quantile", []Frag{Lit(0.5)}, Col("Value")),
+			wantSQL:  "quantile(?)(`Value`)",
+			wantArgs: []any{0.5},
+		},
+		{
+			name:     "Parametric_multi_param_multi_arg",
+			frag:     Parametric("quantilesExact", []Frag{Lit(0.5), Lit(0.9)}, Col("a"), Col("b")),
+			wantSQL:  "quantilesExact(?, ?)(`a`, `b`)",
+			wantArgs: []any{0.5, 0.9},
+		},
+		{
+			name:    "Array_empty",
+			frag:    Array(),
+			wantSQL: "[]",
+		},
+		{
+			name:    "Array_inlines",
+			frag:    Array(InlineLit(int64(0)), InlineLit(int64(1)), InlineLit(int64(2))),
+			wantSQL: "[0, 1, 2]",
+		},
+		{
+			name:     "Array_with_lits",
+			frag:     Array(Lit("a"), Lit("b")),
+			wantSQL:  "[?, ?]",
+			wantArgs: []any{"a", "b"},
+		},
+		{
+			name:    "Tuple_two",
+			frag:    Tuple(Col("a"), Col("b")),
+			wantSQL: "(`a`, `b`)",
+		},
+		{
+			name:     "Subscript_with_arg",
+			frag:     Subscript(Col("Attributes"), Lit("service.name")),
+			wantSQL:  "`Attributes`[?]",
+			wantArgs: []any{"service.name"},
+		},
+
+		// ── Higher-order: If / Lambda / As ────────────────────────────
+		{
+			name:    "If",
+			frag:    If(Eq(Col("a"), Col("b")), Col("a"), Col("b")),
+			wantSQL: "if(`a` = `b`, `a`, `b`)",
+		},
+		{
+			name:    "Lambda1",
+			frag:    Lambda1("x", Add(BareIdent("x"), InlineLit(int64(1)))),
+			wantSQL: "x -> x + 1",
+		},
+		{
+			name:    "Lambda2",
+			frag:    Lambda2("k", "v", Eq(BareIdent("k"), Lit("job"))),
+			wantSQL: "(k, v) -> k = ?", wantArgs: []any{"job"},
+		},
+		{
+			name:    "As_aliased",
+			frag:    As(Col("Value"), "v"),
+			wantSQL: "`Value` AS `v`",
+		},
+		{
+			name:    "As_empty_alias_passthrough",
+			frag:    As(Col("Value"), ""),
+			wantSQL: "`Value`",
+		},
+
+		// ── Set ops at Frag level ─────────────────────────────────────
+		{
+			name:    "UnionAll_two",
+			frag:    UnionAll(NewQuery().From(Col("a")).Frag(), NewQuery().From(Col("b")).Frag()),
+			wantSQL: "(SELECT * FROM `a`) UNION ALL (SELECT * FROM `b`)",
+		},
+		{
+			name:    "UnionDistinct_two",
+			frag:    UnionDistinct(NewQuery().From(Col("a")).Frag(), NewQuery().From(Col("b")).Frag()),
+			wantSQL: "(SELECT * FROM `a`) UNION DISTINCT (SELECT * FROM `b`)",
+		},
+		{
+			name:    "UnionAll_single_no_keyword",
+			frag:    UnionAll(NewQuery().From(Col("a")).Frag()),
+			wantSQL: "(SELECT * FROM `a`)",
+		},
+
+		// ── Subquery wrapping ─────────────────────────────────────────
+		{
+			name:     "Subquery_QueryBuilder_inlines_parens_and_args",
+			frag:     Subquery(NewQuery().Select(Col("Value")).From(Col("t")).Where(Eq(Col("x"), Lit(1)))),
+			wantSQL:  "(SELECT `Value` FROM `t` WHERE `x` = ?)",
+			wantArgs: []any{1},
+		},
+		{
+			name:     "Subquery_PreRenderedSQL",
+			frag:     Subquery(PreRenderedSQL{SQL: "SELECT 1", Args: []any{}}),
+			wantSQL:  "(SELECT 1)",
+			wantArgs: nil,
+		},
+		{
+			name:     "Subquery_PreRenderedSQL_with_args",
+			frag:     Subquery(PreRenderedSQL{SQL: "SELECT ?", Args: []any{42}}),
+			wantSQL:  "(SELECT ?)",
+			wantArgs: []any{42},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			b := NewBuilder()
+			tc.frag(b)
+			gotSQL, gotArgs := b.Build()
+			if gotSQL != tc.wantSQL {
+				t.Errorf("SQL = %q; want %q", gotSQL, tc.wantSQL)
+			}
+			if tc.wantArgs == nil {
+				if gotArgs != nil && len(gotArgs) != 0 {
+					t.Errorf("Args = %v; want nil/empty", gotArgs)
+				}
+				return
+			}
+			if !reflect.DeepEqual(gotArgs, tc.wantArgs) {
+				t.Errorf("Args = %v; want %v", gotArgs, tc.wantArgs)
+			}
+		})
+	}
+}
+
+// TestFrag_NestedComposition pins a deeper expression tree to ensure
+// that the Frag combinators compose lossless-ly: a nested `And(Or(Eq,
+// Neq), Not(In(...)))` shape renders top-down with correct precedence
+// (no auto-parenthesisation; callers wrap with Paren) and binds args in
+// emission order.
+func TestFrag_NestedComposition(t *testing.T) {
+	t.Parallel()
+
+	expr := And(
+		Paren(Or(Eq(Col("a"), Lit(1)), Neq(Col("b"), Lit(2)))),
+		Not(In(Col("c"), Lit("x"), Lit("y"))),
+	)
+	b := NewBuilder()
+	expr(b)
+	sql, args := b.Build()
+	want := "(`a` = ? OR `b` != ?) AND NOT `c` IN (?, ?)"
+	if sql != want {
+		t.Errorf("SQL = %q; want %q", sql, want)
+	}
+	if w := []any{1, 2, "x", "y"}; !reflect.DeepEqual(args, w) {
+		t.Errorf("Args = %v; want %v", args, w)
+	}
+}
+
+// TestFrag_ArgOrderingAcrossSlots — once a Frag is plugged into a
+// QueryBuilder, the bound args interleave across slots in the SQL's
+// `?` order: SELECT args, then FROM (subquery) args, then JOIN ON
+// args, then PREWHERE, then WHERE, then HAVING-less, then GROUP BY,
+// then ORDER BY. This is the contract that nested subqueries depend
+// on; it deserves a dedicated assertion.
+func TestFrag_ArgOrderingAcrossSlots(t *testing.T) {
+	t.Parallel()
+
+	inner := NewQuery().
+		Select(Col("MetricName"), Col("Value")).
+		From(Col("otel_metrics_gauge")).
+		Where(Eq(Col("MetricName"), Lit("inner_metric")))
+
+	sql, args := NewQuery().
+		Select(As(Lit("outer_proj_arg"), "p")).
+		From(inner.Frag()).
+		Where(Eq(Col("Value"), Lit(0.5))).
+		OrderBy(Col("Value"), true).
+		Limit(10).
+		Build()
+
+	wantSQL := "SELECT ? AS `p` FROM (" +
+		"SELECT `MetricName`, `Value` FROM `otel_metrics_gauge`" +
+		" WHERE `MetricName` = ?" +
+		") WHERE `Value` = ? ORDER BY `Value` DESC LIMIT 10"
+	if sql != wantSQL {
+		t.Errorf("SQL = %q; want %q", sql, wantSQL)
+	}
+	// SELECT alias arg, inner WHERE arg, outer WHERE arg — in that
+	// exact textual order.
+	if w := []any{"outer_proj_arg", "inner_metric", 0.5}; !reflect.DeepEqual(args, w) {
+		t.Errorf("Args = %v; want %v", args, w)
+	}
+}
+
+// TestFrag_InlineLit_StringEscapesPreserveBytes pins the byte-level
+// escape policy: single-quote and backslash both get a backslash prefix,
+// every other byte (including unicode) passes through verbatim. CH
+// accepts the resulting string literal byte-for-byte.
+func TestFrag_InlineLit_StringEscapesPreserveBytes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in, want string
+	}{
+		{`hello`, `'hello'`},
+		{`it's`, `'it\'s'`},
+		{`a\b`, `'a\\b'`},
+		{`mixed'\path`, `'mixed\'\\path'`},
+		// Non-ASCII passes through (UTF-8 bytes don't include `'` or `\`).
+		{`café`, `'café'`},
+		{"", `''`},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.in, func(t *testing.T) {
+			t.Parallel()
+			b := NewBuilder()
+			InlineLit(tc.in)(b)
+			if got := b.String(); got != tc.want {
+				t.Errorf("InlineLit(%q) = %q; want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFrag_InlineLit_PanicMessage — the panic message includes the
+// rejected Go type so a wrong callsite is easy to locate.
+func TestFrag_InlineLit_PanicMessage(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("InlineLit(bool) did not panic")
+		}
+		msg, _ := r.(string)
+		if !strings.Contains(msg, "InlineLit unsupported type") {
+			t.Errorf("panic value = %v; want message mentioning 'InlineLit unsupported type'", r)
+		}
+		if !strings.Contains(msg, "bool") {
+			t.Errorf("panic value = %v; want message mentioning 'bool'", r)
+		}
+	}()
+	InlineLit(true)
+}
+
+// TestFrag_Array_BindsAtPosition — Array elements emit their args
+// in element order, then any subsequent Frag's args land after. This is
+// the array literal companion to TestFrag_HelpersBindAtPosition.
+func TestFrag_Array_BindsAtPosition(t *testing.T) {
+	t.Parallel()
+
+	b := NewBuilder()
+	Array(Lit(1), Lit(2), Lit(3))(b)
+	b.writeSQL(", ")
+	Lit(4)(b)
+	sql, args := b.Build()
+	if want := "[?, ?, ?], ?"; sql != want {
+		t.Errorf("SQL = %q; want %q", sql, want)
+	}
+	if w := []any{1, 2, 3, 4}; !reflect.DeepEqual(args, w) {
+		t.Errorf("Args = %v; want %v", args, w)
+	}
+}
+
+// TestFrag_Call_BindsAtPosition — Call args emit their bindings in
+// argument order; an outer expression composing Call(…) with another
+// arg-bearing Frag interleaves correctly.
+func TestFrag_Call_BindsAtPosition(t *testing.T) {
+	t.Parallel()
+
+	b := NewBuilder()
+	// concat(?, ?) , ?
+	Call("concat", Lit("a"), Lit("b"))(b)
+	b.writeSQL(", ")
+	Lit("c")(b)
+	sql, args := b.Build()
+	if want := "concat(?, ?), ?"; sql != want {
+		t.Errorf("SQL = %q; want %q", sql, want)
+	}
+	if w := []any{"a", "b", "c"}; !reflect.DeepEqual(args, w) {
+		t.Errorf("Args = %v; want %v", args, w)
+	}
+}
+
+// TestFrag_PrecedenceContract — the Frag surface deliberately does not
+// auto-parenthesise. `And(a, Or(b, c))` therefore renders as
+// `a AND b OR c`; the caller wraps the Or in Paren if SQL precedence
+// requires it. Pin that contract so future "helpful" auto-paren changes
+// surface as a test break.
+func TestFrag_PrecedenceContract(t *testing.T) {
+	t.Parallel()
+
+	noParen := And(Eq(Col("a"), Lit(1)), Or(Eq(Col("b"), Lit(2)), Eq(Col("c"), Lit(3))))
+	b1 := NewBuilder()
+	noParen(b1)
+	if got, want := b1.String(), "`a` = ? AND `b` = ? OR `c` = ?"; got != want {
+		t.Errorf("no-paren = %q; want %q", got, want)
+	}
+
+	withParen := And(Eq(Col("a"), Lit(1)), Paren(Or(Eq(Col("b"), Lit(2)), Eq(Col("c"), Lit(3)))))
+	b2 := NewBuilder()
+	withParen(b2)
+	if got, want := b2.String(), "`a` = ? AND (`b` = ? OR `c` = ?)"; got != want {
+		t.Errorf("with-paren = %q; want %q", got, want)
+	}
+}

--- a/internal/chsql/query_builder_invariants_test.go
+++ b/internal/chsql/query_builder_invariants_test.go
@@ -1,0 +1,391 @@
+package chsql
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestQueryBuilder_SlotOrdering_CallOrderIndependent verifies that the
+// fluent-API call order does NOT influence the rendered SQL: assembling
+// the same slots in different sequences must produce byte-identical
+// SQL. The contract is that QueryBuilder owns the canonical clause
+// order at render time; the caller is free to chain Select/From/Where/
+// GroupBy/OrderBy/Limit in whatever order is readable at the call site.
+func TestQueryBuilder_SlotOrdering_CallOrderIndependent(t *testing.T) {
+	t.Parallel()
+
+	build1, _ := NewQuery().
+		Select(Col("Value")).
+		From(Col("t")).
+		Where(Eq(Col("MetricName"), Lit("x"))).
+		GroupBy(Col("Attributes")).
+		OrderBy(Col("Value"), true).
+		Limit(10).
+		Build()
+	build2, _ := NewQuery().
+		Limit(10).
+		OrderBy(Col("Value"), true).
+		GroupBy(Col("Attributes")).
+		Where(Eq(Col("MetricName"), Lit("x"))).
+		From(Col("t")).
+		Select(Col("Value")).
+		Build()
+	build3, _ := NewQuery().
+		From(Col("t")).
+		Limit(10).
+		Select(Col("Value")).
+		OrderBy(Col("Value"), true).
+		Where(Eq(Col("MetricName"), Lit("x"))).
+		GroupBy(Col("Attributes")).
+		Build()
+
+	if build1 != build2 {
+		t.Errorf("permutation 1 vs 2 differs:\n  build1 = %q\n  build2 = %q", build1, build2)
+	}
+	if build1 != build3 {
+		t.Errorf("permutation 1 vs 3 differs:\n  build1 = %q\n  build3 = %q", build1, build3)
+	}
+}
+
+// TestQueryBuilder_SlotOrdering_CanonicalClauseOrder pins the exact
+// emission order against the ClickHouse SELECT grammar:
+//
+//	WITH RECURSIVE … SELECT … FROM … JOIN … PREWHERE … WHERE … GROUP BY … ORDER BY … LIMIT …
+//
+// Every slot is populated and the rendered string is asserted as one
+// long literal. A regression in any slot's emission order surfaces here
+// as a single-test break.
+func TestQueryBuilder_SlotOrdering_CanonicalClauseOrder(t *testing.T) {
+	t.Parallel()
+
+	// Minimal recursive CTE: anchor + step.
+	anchor := NewQuery().Select(Col("id")).From(Col("nodes"))
+	step := NewQuery().Select(Col("id")).From(Col("nodes"))
+
+	sql, args := NewQuery().
+		WithRecursive("closure", anchor, step).
+		Select(Col("id")).
+		From(Col("closure")).
+		Join(InnerJoin, As(Col("nodes"), "n"), Eq(Qual("closure", "id"), Qual("n", "id"))).
+		Prewhere(Eq(Col("ServiceName"), Lit("api"))).
+		Where(Gt(Col("Value"), Lit(0))).
+		GroupBy(Col("Attributes")).
+		OrderBy(Col("Value"), true).
+		Limit(100).
+		Build()
+
+	wantSQL := "WITH RECURSIVE closure AS (" +
+		"SELECT `id` FROM `nodes` UNION ALL SELECT `id` FROM `nodes`" +
+		") SELECT `id` FROM `closure`" +
+		" INNER JOIN `nodes` AS `n` ON `closure`.`id` = `n`.`id`" +
+		" PREWHERE `ServiceName` = ?" +
+		" WHERE `Value` > ?" +
+		" GROUP BY `Attributes`" +
+		" ORDER BY `Value` DESC" +
+		" LIMIT 100"
+	if sql != wantSQL {
+		t.Errorf("SQL = %q\nwant %q", sql, wantSQL)
+	}
+	// PREWHERE arg comes before WHERE arg, matching emission order.
+	if want := []any{"api", 0}; !reflect.DeepEqual(args, want) {
+		t.Errorf("Args = %v; want %v", args, want)
+	}
+}
+
+// TestQueryBuilder_Select_AppendsNotReplaces — successive Select calls
+// accumulate into a single comma-separated list. The fluent API is
+// additive on every slot except From and Limit; Select MUST append so
+// the lower-level emitter can do `sb.Select(g)` then `sb.Select(agg)`
+// to build the GROUP BY-style select list piecewise.
+func TestQueryBuilder_Select_AppendsNotReplaces(t *testing.T) {
+	t.Parallel()
+
+	sql, _ := NewQuery().
+		Select(Col("a")).
+		Select(Col("b"), Col("c")).
+		From(Col("t")).
+		Build()
+	if want := "SELECT `a`, `b`, `c` FROM `t`"; sql != want {
+		t.Errorf("multi-call Select = %q; want %q", sql, want)
+	}
+}
+
+// TestQueryBuilder_Where_AppendsNotReplaces — Where appends; multiple
+// calls produce `cond1 AND cond2 AND …`. Same shape as a single
+// call passing all conds as variadics.
+func TestQueryBuilder_Where_AppendsNotReplaces(t *testing.T) {
+	t.Parallel()
+
+	sql1, _ := NewQuery().
+		From(Col("t")).
+		Where(Eq(Col("a"), Lit(1))).
+		Where(Eq(Col("b"), Lit(2))).
+		Build()
+	sql2, _ := NewQuery().
+		From(Col("t")).
+		Where(Eq(Col("a"), Lit(1)), Eq(Col("b"), Lit(2))).
+		Build()
+	if sql1 != sql2 {
+		t.Errorf("multi-Where vs variadic-Where differ:\n  multi   = %q\n  variadic = %q", sql1, sql2)
+	}
+	if want := "SELECT * FROM `t` WHERE `a` = ? AND `b` = ?"; sql1 != want {
+		t.Errorf("multi-Where = %q; want %q", sql1, want)
+	}
+}
+
+// TestQueryBuilder_From_ReplacesNotAppends — From has a single slot;
+// calling From twice retains only the last value. This is the
+// asymmetry vs Select / Where / GroupBy: there's only one FROM source
+// per SELECT, and the emitter relies on the "last write wins" shape so
+// rewrites can update it without explicit reset plumbing.
+func TestQueryBuilder_From_ReplacesNotAppends(t *testing.T) {
+	t.Parallel()
+
+	sql, _ := NewQuery().
+		From(Col("first")).
+		From(Col("second")).
+		Build()
+	if want := "SELECT * FROM `second`"; sql != want {
+		t.Errorf("repeated From = %q; want %q (last wins)", sql, want)
+	}
+}
+
+// TestQueryBuilder_Limit_ReplacesNotAppends — Limit has a single
+// scalar slot; the last call wins. n <= 0 turns the slot off (no LIMIT
+// clause emitted).
+func TestQueryBuilder_Limit_ReplacesNotAppends(t *testing.T) {
+	t.Parallel()
+
+	sql, _ := NewQuery().From(Col("t")).Limit(10).Limit(100).Build()
+	if want := "SELECT * FROM `t` LIMIT 100"; sql != want {
+		t.Errorf("repeated Limit = %q; want %q (last wins)", sql, want)
+	}
+
+	// Zero (or negative) Limit disables the slot.
+	sql0, _ := NewQuery().From(Col("t")).Limit(100).Limit(0).Build()
+	if want := "SELECT * FROM `t`"; sql0 != want {
+		t.Errorf("Limit(0) after Limit(100) = %q; want %q (slot disabled)", sql0, want)
+	}
+
+	// Negative Limit also disables.
+	sqlNeg, _ := NewQuery().From(Col("t")).Limit(-1).Build()
+	if want := "SELECT * FROM `t`"; sqlNeg != want {
+		t.Errorf("Limit(-1) = %q; want %q (no LIMIT emitted)", sqlNeg, want)
+	}
+}
+
+// TestQueryBuilder_GroupBy_Appends — GroupBy appends. The emitter
+// composes piecewise (one expression per call) when lowering Aggregate.
+func TestQueryBuilder_GroupBy_Appends(t *testing.T) {
+	t.Parallel()
+
+	sql, _ := NewQuery().
+		Select(Col("ServiceName"), Col("MetricName"), Call("sum", Col("Value"))).
+		From(Col("t")).
+		GroupBy(Col("ServiceName")).
+		GroupBy(Col("MetricName")).
+		Build()
+	want := "SELECT `ServiceName`, `MetricName`, sum(`Value`) FROM `t` GROUP BY `ServiceName`, `MetricName`"
+	if sql != want {
+		t.Errorf("multi-call GroupBy = %q; want %q", sql, want)
+	}
+}
+
+// TestQueryBuilder_OrderBy_Appends — OrderBy appends; each call adds
+// one sort key in the slot order it arrived. (Note: OrderBy takes one
+// key per call, unlike GroupBy / Where which take variadics; the per-
+// key direction is part of the call so a single variadic shape would
+// be awkward.)
+func TestQueryBuilder_OrderBy_Appends(t *testing.T) {
+	t.Parallel()
+
+	sql, _ := NewQuery().
+		From(Col("t")).
+		OrderBy(Col("ServiceName"), false).
+		OrderBy(Col("Timestamp"), true).
+		Build()
+	want := "SELECT * FROM `t` ORDER BY `ServiceName`, `Timestamp` DESC"
+	if sql != want {
+		t.Errorf("multi-OrderBy = %q; want %q", sql, want)
+	}
+}
+
+// TestQueryBuilder_Prewhere_Appends — Prewhere appends in the same
+// shape as Where. The two slots are independent: predicates added to
+// Prewhere never bleed into Where and vice-versa.
+func TestQueryBuilder_Prewhere_Appends(t *testing.T) {
+	t.Parallel()
+
+	sql, _ := NewQuery().
+		From(Col("t")).
+		Prewhere(Eq(Col("ServiceName"), Lit("api"))).
+		Prewhere(Gt(Col("SeverityNumber"), Lit(5))).
+		Build()
+	want := "SELECT * FROM `t` PREWHERE `ServiceName` = ? AND `SeverityNumber` > ?"
+	if sql != want {
+		t.Errorf("multi-Prewhere = %q; want %q", sql, want)
+	}
+}
+
+// TestQueryBuilder_WithRecursive_Multiple — multiple WithRecursive
+// calls chain into a single `WITH RECURSIVE n1 AS (...), n2 AS (...)`
+// head. Each CTE renders independently with its own anchor + recursive
+// arms.
+func TestQueryBuilder_WithRecursive_Multiple(t *testing.T) {
+	t.Parallel()
+
+	a1 := NewQuery().Select(Col("id")).From(Col("t1"))
+	r1 := NewQuery().Select(Col("id")).From(Col("t1"))
+	a2 := NewQuery().Select(Col("id")).From(Col("t2"))
+	r2 := NewQuery().Select(Col("id")).From(Col("t2"))
+
+	sql, _ := NewQuery().
+		WithRecursive("c1", a1, r1).
+		WithRecursive("c2", a2, r2).
+		Select(Col("id")).
+		From(Col("c1")).
+		Build()
+	want := "WITH RECURSIVE c1 AS (" +
+		"SELECT `id` FROM `t1` UNION ALL SELECT `id` FROM `t1`" +
+		"), c2 AS (" +
+		"SELECT `id` FROM `t2` UNION ALL SELECT `id` FROM `t2`" +
+		") SELECT `id` FROM `c1`"
+	if sql != want {
+		t.Errorf("multi-CTE = %q; want %q", sql, want)
+	}
+}
+
+// TestQueryBuilder_EmptySelectList_RendersStar — leaving Select
+// unset renders `SELECT *`. The lowering pass relies on this default
+// when a Scan has no Columns slice.
+func TestQueryBuilder_EmptySelectList_RendersStar(t *testing.T) {
+	t.Parallel()
+
+	sql, _ := NewQuery().From(Col("t")).Build()
+	if want := "SELECT * FROM `t`"; sql != want {
+		t.Errorf("empty select list = %q; want %q", sql, want)
+	}
+}
+
+// TestQueryBuilder_NoFrom_RendersWithoutFromKeyword — leaving From
+// unset omits the FROM clause entirely (no dangling "FROM" keyword).
+// CH accepts `SELECT 1` style.
+func TestQueryBuilder_NoFrom_RendersWithoutFromKeyword(t *testing.T) {
+	t.Parallel()
+
+	sql, _ := NewQuery().Select(InlineLit(int64(1))).Build()
+	if want := "SELECT 1"; sql != want {
+		t.Errorf("no-FROM = %q; want %q", sql, want)
+	}
+}
+
+// TestQueryBuilder_Frag_WrapsWithParens — QueryBuilder.Frag() emits the
+// rendered SELECT wrapped in `(...)` and threads the inner args into the
+// outer Builder's args slice at the position the Frag is written. This
+// is the contract Subquery / From-as-subquery depend on.
+func TestQueryBuilder_Frag_WrapsWithParens(t *testing.T) {
+	t.Parallel()
+
+	inner := NewQuery().
+		Select(Col("Value")).
+		From(Col("t")).
+		Where(Eq(Col("k"), Lit("v")))
+
+	outer := NewBuilder()
+	inner.Frag()(outer)
+	sql, args := outer.Build()
+	if want := "(SELECT `Value` FROM `t` WHERE `k` = ?)"; sql != want {
+		t.Errorf("Frag wrap = %q; want %q", sql, want)
+	}
+	if w := []any{"v"}; !reflect.DeepEqual(args, w) {
+		t.Errorf("Args = %v; want %v", args, w)
+	}
+}
+
+// TestQueryBuilder_JoinChain_PreservesOrder — multiple Join calls
+// chain in call order, rendered after FROM and before PREWHERE /
+// WHERE. Each ON predicate's args interleave at its position.
+func TestQueryBuilder_JoinChain_PreservesOrder(t *testing.T) {
+	t.Parallel()
+
+	sql, args := NewQuery().
+		Select(Qual("L", "id"), Qual("M", "id"), Qual("R", "id")).
+		From(As(Col("a"), "L")).
+		Join(InnerJoin, As(Col("b"), "M"), Eq(Qual("L", "k"), Lit("m_key"))).
+		Join(LeftJoin, As(Col("c"), "R"), Eq(Qual("M", "k"), Lit("r_key"))).
+		Where(Eq(Qual("L", "active"), Lit(true))).
+		Build()
+	wantSQL := "SELECT `L`.`id`, `M`.`id`, `R`.`id` FROM `a` AS `L`" +
+		" INNER JOIN `b` AS `M` ON `L`.`k` = ?" +
+		" LEFT JOIN `c` AS `R` ON `M`.`k` = ?" +
+		" WHERE `L`.`active` = ?"
+	if sql != wantSQL {
+		t.Errorf("SQL = %q\nwant %q", sql, wantSQL)
+	}
+	// L→M ON, M→R ON, WHERE args, in that emission order.
+	if w := []any{"m_key", "r_key", true}; !reflect.DeepEqual(args, w) {
+		t.Errorf("Args = %v; want %v", args, w)
+	}
+}
+
+// TestQueryBuilder_FluentReturnsSelf — every slot setter returns the
+// receiver so the fluent chain is unbroken. A regression to a
+// pass-by-value receiver would surface as a "lost" slot in a chain.
+func TestQueryBuilder_FluentReturnsSelf(t *testing.T) {
+	t.Parallel()
+
+	q := NewQuery()
+	if got := q.Select(Col("x")); got != q {
+		t.Errorf("Select returned %p; want receiver %p", got, q)
+	}
+	if got := q.SelectAs(Col("y"), "y"); got != q {
+		t.Errorf("SelectAs returned %p; want receiver %p", got, q)
+	}
+	if got := q.From(Col("t")); got != q {
+		t.Errorf("From returned %p; want receiver %p", got, q)
+	}
+	if got := q.Where(Eq(Col("k"), Lit(1))); got != q {
+		t.Errorf("Where returned %p; want receiver %p", got, q)
+	}
+	if got := q.Prewhere(Eq(Col("k"), Lit(1))); got != q {
+		t.Errorf("Prewhere returned %p; want receiver %p", got, q)
+	}
+	if got := q.GroupBy(Col("k")); got != q {
+		t.Errorf("GroupBy returned %p; want receiver %p", got, q)
+	}
+	if got := q.OrderBy(Col("k"), true); got != q {
+		t.Errorf("OrderBy returned %p; want receiver %p", got, q)
+	}
+	if got := q.Limit(1); got != q {
+		t.Errorf("Limit returned %p; want receiver %p", got, q)
+	}
+	if got := q.Join(CrossJoin, Col("t2"), nil); got != q {
+		t.Errorf("Join returned %p; want receiver %p", got, q)
+	}
+	a := NewQuery()
+	r := NewQuery()
+	if got := q.WithRecursive("c", a, r); got != q {
+		t.Errorf("WithRecursive returned %p; want receiver %p", got, q)
+	}
+}
+
+// TestQueryBuilder_Build_IsIdempotent — calling Build twice on the
+// same QueryBuilder yields byte-identical SQL and matching args. The
+// builder must not consume / mutate its slot state on Build, so a
+// caller can render twice without surprises.
+func TestQueryBuilder_Build_IsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	q := NewQuery().
+		Select(Col("Value")).
+		From(Col("t")).
+		Where(Eq(Col("k"), Lit("v")))
+	sql1, args1 := q.Build()
+	sql2, args2 := q.Build()
+	if sql1 != sql2 {
+		t.Errorf("Build #1 = %q; #2 = %q (should be identical)", sql1, sql2)
+	}
+	if !reflect.DeepEqual(args1, args2) {
+		t.Errorf("Args differ: %v vs %v", args1, args2)
+	}
+}


### PR DESCRIPTION
## Summary

Layer 5 of the multi-layer test-deepening sweep. Adds three new test files under `internal/chsql/` that pin the typed Builder / QueryBuilder / Emit surface at the unit level. No production code changes.

- **`internal/chsql/frag_goldens_test.go`** (~70 tests) — unified table-driven golden for every public Frag constructor. Pins the canonical render shape for `Col` / `Qual` / `Lit` / `BareIdent` / `InlineLit` / `Star` / `QualStar` / `Distinct` / comparison + arithmetic operators / `And` / `Or` / `Not` / `IsNull` / `IsNotNull` / `In` / `Between` / `Cast` / `Call` / `Parametric` / `Array` / `Tuple` / `Subscript` / `If` / `Lambda1` / `Lambda2` / `As` / `UnionAll` / `UnionDistinct` / `Subquery` (both `*QueryBuilder` and `PreRenderedSQL` paths). Plus arg-ordering across slots, nested-composition, precedence-contract (no auto-paren), and `InlineLit` string escape rules.

- **`internal/chsql/query_builder_invariants_test.go`** (~16 tests) — slot-ordering / clause-order invariants. Covers:
  - **Permutation independence**: fluent-call order doesn't affect rendered SQL.
  - **Canonical clause order**: `WITH RECURSIVE ... SELECT ... FROM ... JOIN ... PREWHERE ... WHERE ... GROUP BY ... ORDER BY ... LIMIT`.
  - **Append vs replace semantics**: `Select` / `Where` / `Prewhere` / `GroupBy` / `OrderBy` / `Join` / `WithRecursive` append; `From` / `Limit` replace.
  - **Limit edge cases**: zero / negative disables the slot.
  - **Fluent identity**: every setter returns the receiver.
  - **Build idempotency**: calling `Build` twice yields identical SQL + args.

- **`internal/chsql/emit_node_goldens_test.go`** (~28 tests) — per-chplan-node Emit-level goldens for `Scan` / `Limit` / `OrderBy` / `Project` / `Filter` / `Aggregate` / `SetOperation`. Includes the first chsql-level emit test for `SetOperation` (`SetIntersect` + `SetUnion`), child-error propagation paths through every wrapper node, and edge cases (empty `Columns`, ASC implicit keyword, `Filter` over non-`Scan` input doesn't emit `PREWHERE`, `Limit` over `OrderBy` interleaving, embedded backticks in table names).

Total new test count: ~114 distinct test points across the three files (well above the ~90 target).

### Notes for reviewers

- The `unsupportedNode` default-case test was scoped out: `chplan.Node` is sealed by an unexported `planNode()` marker, so out-of-package test types can't satisfy the interface. The existing `TestEmit_NilNode` in `emit_negatives_test.go` covers the analogous "no recognised node" path.
- No production code changes. No Frag bugs surfaced during writing — every existing constructor renders the documented shape on the happy paths covered here.

## Test plan

- [ ] `check` CI job (race + golden) passes
- [ ] `lint` CI job (`golangci-lint`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)