### PR TITLE
test(cerberus): cover system/process lifecycle (Layer 8)

### DIFF
--- a/cmd/cerberus/lifecycle_test.go
+++ b/cmd/cerberus/lifecycle_test.go
@@ -1,0 +1,462 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os/signal"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// Server-lifecycle tests live alongside otel.go in cmd/cerberus.
+//
+// run() in main.go is not directly callable here (it owns os.Stderr, a
+// real config.FromEnv read, and a CH client built off env vars). The
+// behaviors we *can* exercise are the building blocks the lifecycle is
+// composed of: signal.NotifyContext fan-out, http.Server.Shutdown
+// semantics under context expiry, the in-flight-request drain, and the
+// goroutine accounting around them. Those building blocks ARE the
+// lifecycle — if they hold, run() composes them and inherits the
+// behavior.
+//
+// If you find yourself wanting to test run() directly here, the
+// architectural fix is to split run() into a Process struct with
+// injectable Pinger / Shutdowner deps. That's out-of-scope for this
+// PR (Layer 8 is tests-only); see the PR body for the seam list.
+
+// TestSignalNotifyContext_TerminatesOnSIGTERM verifies the OS-signal
+// fan-out that main.go uses: signal.NotifyContext(SIGINT, SIGTERM)
+// produces a Done context whose Err() is context.Canceled. The
+// underlying behavior is the load-bearing primitive for graceful
+// shutdown — main blocks on this context and starts srv.Shutdown when
+// it fires.
+func TestSignalNotifyContext_TerminatesOnSIGTERM(t *testing.T) {
+	ctx, stop := signalNotifyContext()
+	defer stop()
+
+	if err := syscall.Kill(syscall.Getpid(), syscall.SIGTERM); err != nil {
+		t.Fatalf("send SIGTERM: %v", err)
+	}
+
+	select {
+	case <-ctx.Done():
+		if !errors.Is(ctx.Err(), context.Canceled) {
+			t.Errorf("ctx.Err() = %v; want context.Canceled", ctx.Err())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("SIGTERM did not cancel context within deadline")
+	}
+}
+
+// TestSignalNotifyContext_TerminatesOnSIGINT mirrors the SIGTERM path
+// for the SIGINT signal (Ctrl+C in an interactive shell). Both should
+// take the exact same shutdown path.
+func TestSignalNotifyContext_TerminatesOnSIGINT(t *testing.T) {
+	ctx, stop := signalNotifyContext()
+	defer stop()
+
+	if err := syscall.Kill(syscall.Getpid(), syscall.SIGINT); err != nil {
+		t.Fatalf("send SIGINT: %v", err)
+	}
+
+	select {
+	case <-ctx.Done():
+		// good
+	case <-time.After(2 * time.Second):
+		t.Fatal("SIGINT did not cancel context within deadline")
+	}
+}
+
+// TestSignalNotifyContext_StopReleasesHandler confirms the deferred
+// stop() unhooks the signal handler so a second test in the same
+// process doesn't see stray cancellations from the first test's
+// signal.
+func TestSignalNotifyContext_StopReleasesHandler(t *testing.T) {
+	ctx, stop := signalNotifyContext()
+	stop()
+	// The context is cancelled after stop().
+	select {
+	case <-ctx.Done():
+		// expected
+	case <-time.After(100 * time.Millisecond):
+		t.Error("stop() did not cancel the context")
+	}
+}
+
+// TestHTTPServer_GracefulShutdown_DrainsInflightRequest models the
+// "SIGTERM during in-flight query" case. We start an httptest server
+// whose handler blocks until the test releases it, fire a client
+// request, then call srv.Shutdown. Shutdown must wait for the
+// in-flight handler to return before completing.
+func TestHTTPServer_GracefulShutdown_DrainsInflightRequest(t *testing.T) {
+	release := make(chan struct{})
+	mux := http.NewServeMux()
+	var entered atomic.Bool
+	mux.HandleFunc("/slow", func(w http.ResponseWriter, _ *http.Request) {
+		entered.Store(true)
+		<-release // wait for the test to release us
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("done"))
+	})
+
+	srv := &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: time.Second,
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	go func() { _ = srv.Serve(ln) }()
+	defer func() { _ = srv.Close() }()
+
+	// Fire the slow request.
+	clientDone := make(chan error, 1)
+	go func() {
+		resp, err := http.Get("http://" + ln.Addr().String() + "/slow")
+		if err != nil {
+			clientDone <- err
+			return
+		}
+		_ = resp.Body.Close()
+		clientDone <- nil
+	}()
+
+	// Wait until the handler is actually executing — otherwise we'd
+	// race the Shutdown.
+	for !entered.Load() {
+		time.Sleep(time.Millisecond)
+	}
+
+	shutdownDone := make(chan error, 1)
+	go func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		shutdownDone <- srv.Shutdown(shutdownCtx)
+	}()
+
+	// Shutdown must not complete while the handler is still blocked.
+	select {
+	case err := <-shutdownDone:
+		t.Fatalf("Shutdown returned before handler completed: %v", err)
+	case <-time.After(100 * time.Millisecond):
+		// expected — still waiting
+	}
+
+	close(release) // let handler finish
+
+	select {
+	case err := <-shutdownDone:
+		if err != nil {
+			t.Errorf("Shutdown: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Shutdown did not return after handler released")
+	}
+	if err := <-clientDone; err != nil {
+		t.Errorf("client: %v", err)
+	}
+}
+
+// TestHTTPServer_GracefulShutdown_ContextDeadlineExceededForcesClose:
+// when the shutdown context expires before the handler returns,
+// Shutdown surfaces context.DeadlineExceeded. main.go propagates this
+// as "graceful shutdown: ..." so the operator sees the deadline.
+func TestHTTPServer_GracefulShutdown_ContextDeadlineExceededForcesClose(t *testing.T) {
+	release := make(chan struct{})
+	defer close(release)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/stuck", func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-release:
+			w.WriteHeader(http.StatusOK)
+		}
+	})
+
+	srv := &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: time.Second,
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	go func() { _ = srv.Serve(ln) }()
+	defer func() { _ = srv.Close() }()
+
+	// Fire one stuck request.
+	go func() {
+		resp, err := http.Get("http://" + ln.Addr().String() + "/stuck")
+		if err == nil {
+			_ = resp.Body.Close()
+		}
+	}()
+	time.Sleep(50 * time.Millisecond)
+
+	// Now Shutdown with a very tight deadline — the handler is stuck,
+	// so Shutdown must return DeadlineExceeded.
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	err = srv.Shutdown(shutdownCtx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("Shutdown err = %v; want context.DeadlineExceeded", err)
+	}
+}
+
+// TestHTTPServer_HealthRoutesStillRespondPreShutdown documents the
+// happy-path: /healthz returns 200 before any shutdown fires. Anchor
+// for the "/healthz returns 503 during shutdown" downstream story —
+// this is the baseline.
+func TestHTTPServer_HealthRoutesStillRespondPreShutdown(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/healthz")
+	if err != nil {
+		t.Fatalf("GET /healthz: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d; want 200", resp.StatusCode)
+	}
+}
+
+// TestHTTPServer_ListenAndServeErrServerClosed: after a normal shutdown,
+// ListenAndServe must return http.ErrServerClosed. main.go relies on
+// errors.Is(err, http.ErrServerClosed) to distinguish a planned
+// shutdown from a real failure.
+func TestHTTPServer_ListenAndServeErrServerClosed(t *testing.T) {
+	srv := &http.Server{
+		Handler:           http.NewServeMux(),
+		ReadHeaderTimeout: time.Second,
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- srv.Serve(ln)
+	}()
+
+	// Give the goroutine a tick to enter Serve.
+	time.Sleep(50 * time.Millisecond)
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	select {
+	case got := <-serveErr:
+		if !errors.Is(got, http.ErrServerClosed) {
+			t.Errorf("Serve err = %v; want http.ErrServerClosed", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Serve did not return after Shutdown")
+	}
+}
+
+// TestHTTPServer_Shutdown_BlocksNewConnections: a request issued
+// *after* Shutdown returned must fail to connect (the listener is
+// closed). Pin the contract that distinguishes Shutdown from a
+// keep-alive drain.
+func TestHTTPServer_Shutdown_BlocksNewConnections(t *testing.T) {
+	srv := &http.Server{
+		Handler:           http.NewServeMux(),
+		ReadHeaderTimeout: time.Second,
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	go func() { _ = srv.Serve(ln) }()
+
+	// Sanity-check the listener is up.
+	conn, err := net.DialTimeout("tcp", addr, 500*time.Millisecond)
+	if err != nil {
+		t.Fatalf("dial before shutdown: %v", err)
+	}
+	_ = conn.Close()
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	// After Shutdown the listener is closed; a fresh dial errors.
+	if _, err := net.DialTimeout("tcp", addr, 250*time.Millisecond); err == nil {
+		t.Errorf("dial after shutdown succeeded; want refused/timeout")
+	}
+}
+
+// TestHTTPServer_GoroutineDeltaWithinBound is a lightweight goroutine-leak
+// guard for the listener path. We capture a baseline, start + shutdown a
+// server with one in-flight handler, and confirm the goroutine count
+// returns near the baseline. Not a substitute for goleak — but cheap
+// and dependency-free.
+func TestHTTPServer_GoroutineDeltaWithinBound(t *testing.T) {
+	// Stabilise the runtime — let any GC sweeper goroutines settle.
+	runtime.GC()
+	time.Sleep(20 * time.Millisecond)
+	baseline := runtime.NumGoroutine()
+
+	for i := 0; i < 3; i++ {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/echo", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+		srv := &http.Server{
+			Handler:           mux,
+			ReadHeaderTimeout: time.Second,
+		}
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("listen: %v", err)
+		}
+		serveErr := make(chan error, 1)
+		go func() { serveErr <- srv.Serve(ln) }()
+
+		resp, err := http.Get("http://" + ln.Addr().String() + "/echo")
+		if err != nil {
+			t.Fatalf("GET: %v", err)
+		}
+		_ = resp.Body.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		if err := srv.Shutdown(ctx); err != nil {
+			t.Fatalf("Shutdown: %v", err)
+		}
+		cancel()
+		<-serveErr
+	}
+
+	// After three cycles, allow for some scheduling slack. A small
+	// constant delta is fine (the test runtime itself spawns watchers);
+	// we just guard against linear growth proportional to the loop count.
+	runtime.GC()
+	time.Sleep(20 * time.Millisecond)
+	after := runtime.NumGoroutine()
+	if delta := after - baseline; delta > 8 {
+		t.Errorf("goroutine delta = %d; baseline=%d after=%d (suspicious leak)", delta, baseline, after)
+	}
+}
+
+// TestHTTPServer_ConcurrentRequestsDuringShutdown ensures the drain
+// path handles multiple in-flight requests simultaneously. main.go's
+// 10s shutdown deadline must accommodate all of them.
+func TestHTTPServer_ConcurrentRequestsDuringShutdown(t *testing.T) {
+	release := make(chan struct{})
+	var inflight atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/slow", func(w http.ResponseWriter, _ *http.Request) {
+		inflight.Add(1)
+		defer inflight.Add(-1)
+		<-release
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv := &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: time.Second,
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	go func() { _ = srv.Serve(ln) }()
+
+	const N = 5
+	var wg sync.WaitGroup
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			resp, err := http.Get("http://" + ln.Addr().String() + "/slow")
+			if err == nil {
+				_ = resp.Body.Close()
+			}
+		}()
+	}
+
+	// Wait for every request to enter the handler before triggering
+	// shutdown — otherwise we'd race the goroutine spawning.
+	for inflight.Load() < int32(N) {
+		time.Sleep(time.Millisecond)
+	}
+
+	shutdownDone := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		shutdownDone <- srv.Shutdown(ctx)
+	}()
+
+	// Shutdown must wait for every handler to finish.
+	close(release)
+	select {
+	case err := <-shutdownDone:
+		if err != nil {
+			t.Errorf("Shutdown: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Shutdown blocked > 5s with all handlers released")
+	}
+	wg.Wait()
+}
+
+// TestHTTPServer_ShutdownNeverPanicsOnDoubleClose: a second srv.Close
+// after a clean Shutdown must not panic. main.go's defer client.Close
+// + Shutdown ordering produces this pattern under panic-recovery.
+func TestHTTPServer_ShutdownNeverPanicsOnDoubleClose(t *testing.T) {
+	srv := &http.Server{
+		Handler:           http.NewServeMux(),
+		ReadHeaderTimeout: time.Second,
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	go func() { _ = srv.Serve(ln) }()
+	time.Sleep(20 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := srv.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	// Calling Close on an already-shut-down server must be harmless.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Close panicked: %v", r)
+		}
+	}()
+	_ = srv.Close()
+}
+
+// signalNotifyContext mirrors the exact construction main.go uses to
+// produce its shutdown context. Sharing the helper across lifecycle
+// tests keeps the construction in one place and lets the production
+// code stay agnostic about test wiring.
+//
+// Hardcodes the (SIGINT, SIGTERM) pair main.go listens for. A runtime
+// helper exported from main.go would violate the no-prod-changes rule.
+func signalNotifyContext() (context.Context, context.CancelFunc) {
+	return signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+}

--- a/internal/api/health/lifecycle_test.go
+++ b/internal/api/health/lifecycle_test.go
@@ -1,0 +1,310 @@
+package health
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestReadyz_OKBodyShape pins the JSON shape /readyz returns on the
+// happy path. Grafana and load balancers rely on the {clickhouse,schema}
+// keys.
+func TestReadyz_OKBodyShape(t *testing.T) {
+	h := New(Options{
+		Pinger:      &stubPinger{},
+		SchemaReady: func() bool { return true },
+		CacheTTL:    -1,
+	})
+
+	rec := serveReadyz(t, h)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("Content-Type = %q; want application/json", ct)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// Exactly two keys; no extra fields that would surprise dashboards.
+	if len(body) != 2 {
+		t.Errorf("body keys = %v; want exactly clickhouse + schema", body)
+	}
+	if body["clickhouse"] != "ok" || body["schema"] != "ready" {
+		t.Errorf("body = %v; want {clickhouse:ok, schema:ready}", body)
+	}
+}
+
+// TestReadyz_CHDownSurfacesPingTimeout: a pinger that returns immediately
+// with an error reaches the 503 response within the (CacheTTL +
+// PingTimeout) envelope. Deterministic without a clock injection: the
+// stub does not block.
+func TestReadyz_CHDownSurfacesPingTimeout(t *testing.T) {
+	pinger := &stubPinger{err: errors.New("dial tcp: i/o timeout")}
+	h := New(Options{
+		Pinger:      pinger,
+		PingTimeout: 50 * time.Millisecond,
+		CacheTTL:    -1,
+	})
+
+	start := time.Now()
+	rec := serveReadyz(t, h)
+	elapsed := time.Since(start)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d; want 503", rec.Code)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("elapsed = %v; expected sub-second 503 from a synchronous failure", elapsed)
+	}
+	var body map[string]string
+	_ = json.Unmarshal(rec.Body.Bytes(), &body)
+	if !strings.Contains(body["clickhouse"], "i/o timeout") {
+		t.Errorf("clickhouse = %q; want substring 'i/o timeout'", body["clickhouse"])
+	}
+}
+
+// TestReadyz_SchemaPendingBodyShape covers the mixed state: CH up, schema
+// still bootstrapping. Body must report "ok"/"pending" with 503 — Grafana
+// surfaces "schema not ready" rather than a bogus "CH down" alert.
+func TestReadyz_SchemaPendingBodyShape(t *testing.T) {
+	h := New(Options{
+		Pinger:      &stubPinger{},
+		SchemaReady: func() bool { return false },
+		CacheTTL:    -1,
+	})
+	rec := serveReadyz(t, h)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d; want 503", rec.Code)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body["clickhouse"] != "ok" {
+		t.Errorf("clickhouse = %q; want ok", body["clickhouse"])
+	}
+	if body["schema"] != "pending" {
+		t.Errorf("schema = %q; want pending (auto-create still running)", body["schema"])
+	}
+}
+
+// TestReadyz_NilSchemaReadyTreatedAsReady documents the documented
+// fallback: when SchemaReady is nil the probe ignores it and only gates
+// on the CH ping. Matches main.go's wiring when AutoCreateSchema is
+// false.
+func TestReadyz_NilSchemaReadyTreatedAsReady(t *testing.T) {
+	h := New(Options{
+		Pinger:      &stubPinger{},
+		SchemaReady: nil, // intentionally unset
+		CacheTTL:    -1,
+	})
+	rec := serveReadyz(t, h)
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d; want 200 when SchemaReady is nil", rec.Code)
+	}
+	var body map[string]string
+	_ = json.Unmarshal(rec.Body.Bytes(), &body)
+	if body["schema"] != "ready" {
+		t.Errorf("schema = %q; want ready", body["schema"])
+	}
+}
+
+// TestReadyz_CacheCoalesces_ConcurrentProbes hammers /readyz from N
+// goroutines inside a single TTL window and confirms exactly one
+// underlying CH ping is issued. The mutex around the cache + ping path
+// is what makes this hold — without it the cache would still coalesce
+// the *result* but multiple pings could race in.
+func TestReadyz_CacheCoalesces_ConcurrentProbes(t *testing.T) {
+	pinger := &stubPinger{}
+	now := time.Unix(1_700_000_100, 0)
+	clock := func() time.Time { return now }
+
+	h := New(Options{
+		Pinger:   pinger,
+		CacheTTL: time.Second,
+		Now:      clock,
+	})
+
+	const N = 32
+	var wg sync.WaitGroup
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = serveReadyz(t, h)
+		}()
+	}
+	wg.Wait()
+
+	if got := pinger.calls.Load(); got != 1 {
+		t.Errorf("Ping calls = %d; want exactly 1 (cache must coalesce concurrent probes)", got)
+	}
+}
+
+// TestReadyz_CacheInvalidatesAfterTTL: after the TTL elapses, a probe
+// triggers a fresh CH ping. Combined with the previous test this pins
+// the cache-window semantics.
+func TestReadyz_CacheInvalidatesAfterTTL(t *testing.T) {
+	pinger := &stubPinger{}
+	now := time.Unix(1_700_000_200, 0)
+	clock := func() time.Time { return now }
+
+	h := New(Options{
+		Pinger:   pinger,
+		CacheTTL: 100 * time.Millisecond,
+		Now:      clock,
+	})
+
+	_ = serveReadyz(t, h)
+	if got := pinger.calls.Load(); got != 1 {
+		t.Fatalf("initial ping count = %d; want 1", got)
+	}
+	now = now.Add(150 * time.Millisecond)
+	_ = serveReadyz(t, h)
+	if got := pinger.calls.Load(); got != 2 {
+		t.Errorf("ping count after TTL expiry = %d; want 2 (cache evicted)", got)
+	}
+}
+
+// TestHealthz_NeverTouchesCH proves the liveness probe is downstream-
+// agnostic: a CH that always errors must not produce a non-200 here.
+func TestHealthz_NeverTouchesCH(t *testing.T) {
+	pinger := &stubPinger{err: errors.New("permanent failure")}
+	h := New(Options{Pinger: pinger})
+
+	mux := http.NewServeMux()
+	h.Mount(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d; want 200 even with CH down", rec.Code)
+	}
+	if got := pinger.calls.Load(); got != 0 {
+		t.Errorf("Ping calls = %d; want 0 (healthz must not touch CH)", got)
+	}
+}
+
+// TestHealthz_BodyOK pins the exact response body "ok". Some uptime
+// probes assert on it.
+func TestHealthz_BodyOK(t *testing.T) {
+	h := New(Options{Pinger: &stubPinger{}})
+	mux := http.NewServeMux()
+	h.Mount(mux)
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if got := rec.Body.String(); got != "ok" {
+		t.Errorf("body = %q; want ok", got)
+	}
+}
+
+// TestProbes_Concurrent_NoPanics fires /healthz and /readyz from many
+// goroutines simultaneously, confirming nothing panics, racey, or
+// deadlocks. Stress test for the cache mutex + the response writer paths.
+func TestProbes_Concurrent_NoPanics(t *testing.T) {
+	pinger := &stubPinger{}
+	h := New(Options{Pinger: pinger, CacheTTL: 10 * time.Millisecond})
+
+	mux := http.NewServeMux()
+	h.Mount(mux)
+
+	const N = 200
+	var wg sync.WaitGroup
+	for i := 0; i < N; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+		}()
+		go func() {
+			defer wg.Done()
+			req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+		}()
+	}
+	wg.Wait()
+}
+
+// TestReadyz_PingTimeoutDefaults documents the default 1-second
+// PingTimeout when the option is left zero — protects against a future
+// change that silently drops the safety net.
+func TestReadyz_PingTimeoutDefaults(t *testing.T) {
+	h := New(Options{Pinger: &stubPinger{}, CacheTTL: -1})
+	if h.pingTimeout != time.Second {
+		t.Errorf("pingTimeout default = %v; want 1s", h.pingTimeout)
+	}
+}
+
+// TestReadyz_CacheTTLDefaults documents the default 2-second CacheTTL
+// when the option is left zero.
+func TestReadyz_CacheTTLDefaults(t *testing.T) {
+	h := New(Options{Pinger: &stubPinger{}})
+	if h.cacheTTL != 2*time.Second {
+		t.Errorf("cacheTTL default = %v; want 2s", h.cacheTTL)
+	}
+}
+
+// TestReadyz_NegativeCacheTTLDisablesCaching: a probe -> error -> probe
+// sequence must surface the recovered state on the third probe when
+// caching is disabled. Anchors the "tests can opt out of coalescing"
+// contract.
+func TestReadyz_NegativeCacheTTLDisablesCaching(t *testing.T) {
+	pinger := &stubPinger{err: errors.New("first")}
+	h := New(Options{Pinger: pinger, CacheTTL: -1})
+
+	rec := serveReadyz(t, h)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("first probe: status = %d; want 503", rec.Code)
+	}
+	pinger.setErr(nil)
+	rec = serveReadyz(t, h)
+	if rec.Code != http.StatusOK {
+		t.Errorf("second probe: status = %d; want 200 (cache disabled)", rec.Code)
+	}
+}
+
+// TestReadyz_ContextCancelledPropagates: a cancelled request context
+// must propagate into the ping call so callers can shed load fast.
+type cancelObservingPinger struct{}
+
+func (p *cancelObservingPinger) Ping(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func TestReadyz_ContextCancelledPropagates(t *testing.T) {
+	pinger := &cancelObservingPinger{}
+	h := New(Options{
+		Pinger:   pinger,
+		CacheTTL: -1,
+	})
+
+	mux := http.NewServeMux()
+	h.Mount(mux)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/readyz", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d; want 503 when request context was cancelled", rec.Code)
+	}
+}

--- a/internal/config/matrix_test.go
+++ b/internal/config/matrix_test.go
@@ -1,0 +1,433 @@
+package config
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestFromEnv_HTTPAddr_Default confirms the documented :8080 fallback
+// when CERBERUS_HTTP_ADDR is unset.
+func TestFromEnv_HTTPAddr_Default(t *testing.T) {
+	t.Setenv("CERBERUS_HTTP_ADDR", "")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if cfg.HTTPAddr != ":8080" {
+		t.Errorf("HTTPAddr = %q; want :8080", cfg.HTTPAddr)
+	}
+}
+
+// TestFromEnv_HTTPAddr_Override verifies a custom listen address flows
+// through end-to-end.
+func TestFromEnv_HTTPAddr_Override(t *testing.T) {
+	t.Setenv("CERBERUS_HTTP_ADDR", "127.0.0.1:9090")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if cfg.HTTPAddr != "127.0.0.1:9090" {
+		t.Errorf("HTTPAddr = %q; want 127.0.0.1:9090", cfg.HTTPAddr)
+	}
+}
+
+// TestFromEnv_CHAddr_Default confirms the localhost:9000 fallback used
+// for local dev / k3d.
+func TestFromEnv_CHAddr_Default(t *testing.T) {
+	t.Setenv("CERBERUS_CH_ADDR", "")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if cfg.ClickHouse.Addr != "localhost:9000" {
+		t.Errorf("CH.Addr = %q; want localhost:9000", cfg.ClickHouse.Addr)
+	}
+}
+
+// TestFromEnv_CHAddr_Override verifies a deployed CH endpoint sticks.
+func TestFromEnv_CHAddr_Override(t *testing.T) {
+	t.Setenv("CERBERUS_CH_ADDR", "clickhouse.observability.svc:9000")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if cfg.ClickHouse.Addr != "clickhouse.observability.svc:9000" {
+		t.Errorf("CH.Addr = %q; want clickhouse.observability.svc:9000", cfg.ClickHouse.Addr)
+	}
+}
+
+// TestFromEnv_CHDatabase_DefaultAndOverride covers the documented
+// otel default + arbitrary override.
+func TestFromEnv_CHDatabase_DefaultAndOverride(t *testing.T) {
+	t.Setenv("CERBERUS_CH_DATABASE", "")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv default: %v", err)
+	}
+	if cfg.ClickHouse.Database != "otel" {
+		t.Errorf("CH.Database default = %q; want otel", cfg.ClickHouse.Database)
+	}
+	t.Setenv("CERBERUS_CH_DATABASE", "tenant_a")
+	cfg, err = FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv override: %v", err)
+	}
+	if cfg.ClickHouse.Database != "tenant_a" {
+		t.Errorf("CH.Database override = %q; want tenant_a", cfg.ClickHouse.Database)
+	}
+}
+
+// TestFromEnv_CHCredentials_DefaultAndOverride covers username/password.
+// Empty password is the explicit default and must not be coerced to a
+// fake value.
+func TestFromEnv_CHCredentials_DefaultAndOverride(t *testing.T) {
+	t.Setenv("CERBERUS_CH_USERNAME", "")
+	t.Setenv("CERBERUS_CH_PASSWORD", "")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if cfg.ClickHouse.Username != "default" {
+		t.Errorf("Username default = %q; want default", cfg.ClickHouse.Username)
+	}
+	if cfg.ClickHouse.Password != "" {
+		t.Errorf("Password default = %q; want empty", cfg.ClickHouse.Password)
+	}
+	t.Setenv("CERBERUS_CH_USERNAME", "cerberus")
+	t.Setenv("CERBERUS_CH_PASSWORD", "s3cret!")
+	cfg, err = FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv override: %v", err)
+	}
+	if cfg.ClickHouse.Username != "cerberus" {
+		t.Errorf("Username = %q; want cerberus", cfg.ClickHouse.Username)
+	}
+	if cfg.ClickHouse.Password != "s3cret!" {
+		t.Errorf("Password = %q; want s3cret!", cfg.ClickHouse.Password)
+	}
+}
+
+// TestFromEnv_CHDialTimeout_Default confirms the 5s default falls
+// through cleanly.
+func TestFromEnv_CHDialTimeout_Default(t *testing.T) {
+	t.Setenv("CERBERUS_CH_DIAL_TIMEOUT", "")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if cfg.ClickHouse.DialTimeout != 5*time.Second {
+		t.Errorf("DialTimeout = %v; want 5s", cfg.ClickHouse.DialTimeout)
+	}
+}
+
+// TestFromEnv_CHDialTimeout_OverrideFormats walks accepted duration
+// formats — the same Go time.ParseDuration vocabulary that powers the
+// OTLP timeout.
+func TestFromEnv_CHDialTimeout_OverrideFormats(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want time.Duration
+	}{
+		{"3s", 3 * time.Second},
+		{"1500ms", 1500 * time.Millisecond},
+		{"2.5s", 2500 * time.Millisecond},
+		{"30s", 30 * time.Second},
+		{"1m", time.Minute},
+	}
+	for _, tc := range cases {
+		t.Run(tc.raw, func(t *testing.T) {
+			t.Setenv("CERBERUS_CH_DIAL_TIMEOUT", tc.raw)
+			cfg, err := FromEnv()
+			if err != nil {
+				t.Fatalf("FromEnv: %v", err)
+			}
+			if cfg.ClickHouse.DialTimeout != tc.want {
+				t.Errorf("DialTimeout = %v; want %v", cfg.ClickHouse.DialTimeout, tc.want)
+			}
+		})
+	}
+}
+
+// TestFromEnv_CHDialTimeout_Invalid rejects garbage strings rather than
+// silently falling back — operators get a fast startup error.
+func TestFromEnv_CHDialTimeout_Invalid(t *testing.T) {
+	t.Setenv("CERBERUS_CH_DIAL_TIMEOUT", "not-a-duration")
+	if _, err := FromEnv(); err == nil {
+		t.Fatal("FromEnv: want error for bad timeout, got nil")
+	}
+}
+
+// TestFromEnv_OTLP_TimeoutFormats walks the documented duration grammar
+// per the OTel timeout spec. The OTel SDK still does the actual gRPC
+// deadline wrap; this just confirms cerberus parses the env correctly.
+func TestFromEnv_OTLP_TimeoutFormats(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want time.Duration
+	}{
+		{"5s", 5 * time.Second},
+		{"500ms", 500 * time.Millisecond},
+		{"1.5s", 1500 * time.Millisecond},
+		{"0s", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.raw, func(t *testing.T) {
+			t.Setenv("CERBERUS_OTLP_TIMEOUT", tc.raw)
+			cfg, err := FromEnv()
+			if err != nil {
+				t.Fatalf("FromEnv(%s): %v", tc.raw, err)
+			}
+			if cfg.OTLP.Timeout != tc.want {
+				t.Errorf("Timeout = %v; want %v", cfg.OTLP.Timeout, tc.want)
+			}
+		})
+	}
+}
+
+// TestFromEnv_OTLP_HeadersEmptyAndWhitespace verifies the documented
+// "empty/whitespace = no headers" contract and dropped-empty-entry
+// behavior.
+func TestFromEnv_OTLP_HeadersEmptyAndWhitespace(t *testing.T) {
+	cases := []string{"", "  ", "\n\n", " , , "}
+	for _, raw := range cases {
+		t.Run(raw, func(t *testing.T) {
+			t.Setenv("CERBERUS_OTLP_HEADERS", raw)
+			cfg, err := FromEnv()
+			if err != nil {
+				t.Fatalf("FromEnv(%q): %v", raw, err)
+			}
+			if len(cfg.OTLP.Headers) != 0 {
+				t.Errorf("Headers = %v; want empty", cfg.OTLP.Headers)
+			}
+		})
+	}
+}
+
+// TestFromEnv_OTLP_HeadersDuplicates: a duplicated key keeps the last
+// value (map semantics). Documenting it so operators can rely on the
+// behavior.
+func TestFromEnv_OTLP_HeadersDuplicates(t *testing.T) {
+	t.Setenv("CERBERUS_OTLP_HEADERS", "x-tenant=a, x-tenant=b")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if got := cfg.OTLP.Headers["x-tenant"]; got != "b" {
+		t.Errorf("Headers[x-tenant] = %q; want b (last wins)", got)
+	}
+}
+
+// TestFromEnv_OTLP_HeadersValueWithEqualSign verifies values that
+// themselves contain "=" survive the parser intact — Bearer tokens,
+// base64-padded values, etc.
+func TestFromEnv_OTLP_HeadersValueWithEqualSign(t *testing.T) {
+	t.Setenv("CERBERUS_OTLP_HEADERS", "authorization=Bearer abc=def==,x-tenant=acme")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if cfg.OTLP.Headers["authorization"] != "Bearer abc=def==" {
+		t.Errorf("Headers[authorization] = %q; want preserved", cfg.OTLP.Headers["authorization"])
+	}
+}
+
+// TestFromEnv_OTLP_HeadersEmptyValueAccepted confirms an explicit
+// empty-string value is allowed (and survives) — gRPC permits empty
+// metadata.
+func TestFromEnv_OTLP_HeadersEmptyValueAccepted(t *testing.T) {
+	t.Setenv("CERBERUS_OTLP_HEADERS", "x-feature=")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if v, ok := cfg.OTLP.Headers["x-feature"]; !ok || v != "" {
+		t.Errorf("Headers[x-feature] = %q (ok=%v); want empty string present", v, ok)
+	}
+}
+
+// TestFromEnv_OTLP_HeadersEmptyKeyRejected: a leading `=value` is a
+// typo; reject so we never silently drop it.
+func TestFromEnv_OTLP_HeadersEmptyKeyRejected(t *testing.T) {
+	t.Setenv("CERBERUS_OTLP_HEADERS", "=value")
+	if _, err := FromEnv(); err == nil {
+		t.Fatal("FromEnv: want error for empty key, got nil")
+	}
+}
+
+// TestFromEnv_OTLP_Insecure_Defaults verifies the secure-by-default
+// stance — TLS unless the operator opts out.
+func TestFromEnv_OTLP_Insecure_Defaults(t *testing.T) {
+	t.Setenv("CERBERUS_OTLP_INSECURE", "")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if cfg.OTLP.Insecure {
+		t.Errorf("Insecure default = true; want false")
+	}
+}
+
+// TestFromEnv_OTLP_InsecureGarbage rejects unparseable booleans.
+func TestFromEnv_OTLP_InsecureGarbage(t *testing.T) {
+	t.Setenv("CERBERUS_OTLP_INSECURE", "yes-please")
+	if _, err := FromEnv(); err == nil {
+		t.Fatal("FromEnv: want error for invalid bool, got nil")
+	}
+}
+
+// TestFromEnv_OTLP_InsecureBoolVocabulary spot-checks the full strconv
+// vocabulary cerberus accepts for the insecure flag.
+func TestFromEnv_OTLP_InsecureBoolVocabulary(t *testing.T) {
+	cases := []struct {
+		val  string
+		want bool
+	}{
+		{"true", true},
+		{"TRUE", true},
+		{"1", true},
+		{"t", true},
+		{"false", false},
+		{"0", false},
+		{"f", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.val, func(t *testing.T) {
+			t.Setenv("CERBERUS_OTLP_INSECURE", tc.val)
+			cfg, err := FromEnv()
+			if err != nil {
+				t.Fatalf("FromEnv: %v", err)
+			}
+			if cfg.OTLP.Insecure != tc.want {
+				t.Errorf("Insecure(%q) = %v; want %v", tc.val, cfg.OTLP.Insecure, tc.want)
+			}
+		})
+	}
+}
+
+// TestFromEnv_Log_LevelErrorMessageMentionsKey ensures a level typo
+// surfaces the env-var name so operators can locate the bad setting.
+func TestFromEnv_Log_LevelErrorMessageMentionsKey(t *testing.T) {
+	t.Setenv("CERBERUS_LOG_LEVEL", "tracee")
+	_, err := FromEnv()
+	if err == nil {
+		t.Fatal("FromEnv: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "CERBERUS_LOG_LEVEL") {
+		t.Errorf("error %q must mention CERBERUS_LOG_LEVEL", err.Error())
+	}
+}
+
+// TestFromEnv_Log_FormatErrorMessageMentionsKey ensures a format typo
+// surfaces the env-var name so operators can locate the bad setting.
+func TestFromEnv_Log_FormatErrorMessageMentionsKey(t *testing.T) {
+	t.Setenv("CERBERUS_LOG_FORMAT", "xml")
+	_, err := FromEnv()
+	if err == nil {
+		t.Fatal("FromEnv: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "CERBERUS_LOG_FORMAT") {
+		t.Errorf("error %q must mention CERBERUS_LOG_FORMAT", err.Error())
+	}
+}
+
+// TestFromEnv_AdmitDisabled_DoesNotCascadeToCaps confirms setting
+// CERBERUS_ADMIT_DISABLED=true leaves the per-head caps intact in the
+// resolved Config. The wiring in main.go is responsible for skipping
+// limiter construction — the config layer just reports both signals.
+func TestFromEnv_AdmitDisabled_DoesNotCascadeToCaps(t *testing.T) {
+	t.Setenv("CERBERUS_ADMIT_DISABLED", "true")
+	t.Setenv("CERBERUS_ADMIT_PROM", "256")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if !cfg.Admit.Disabled {
+		t.Errorf("Disabled = false; want true")
+	}
+	if cfg.Admit.MaxInflightProm != 256 {
+		t.Errorf("MaxInflightProm = %d; want 256 (caps reported even when disabled)", cfg.Admit.MaxInflightProm)
+	}
+}
+
+// TestFromEnv_AdmitZeroIsAllowed pins the "zero disables this head"
+// contract — the config layer accepts 0 (only negative values fail).
+func TestFromEnv_AdmitZeroIsAllowed(t *testing.T) {
+	t.Setenv("CERBERUS_ADMIT_LOKI", "0")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv with zero loki: %v", err)
+	}
+	if cfg.Admit.MaxInflightLoki != 0 {
+		t.Errorf("MaxInflightLoki = %d; want 0", cfg.Admit.MaxInflightLoki)
+	}
+}
+
+// TestFromEnv_AdmitLargeValueRoundtrip confirms large but valid ints
+// survive the parser (no premature overflow check).
+func TestFromEnv_AdmitLargeValueRoundtrip(t *testing.T) {
+	t.Setenv("CERBERUS_ADMIT_TEMPO", "100000")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if cfg.Admit.MaxInflightTempo != 100000 {
+		t.Errorf("MaxInflightTempo = %d; want 100000", cfg.Admit.MaxInflightTempo)
+	}
+}
+
+// TestFromEnv_AdmitTempoNegative ensures every per-head cap reports
+// negative values consistently. (The existing Prom-specific test
+// confirms the symmetric path.)
+func TestFromEnv_AdmitTempoNegative(t *testing.T) {
+	t.Setenv("CERBERUS_ADMIT_TEMPO", "-5")
+	if _, err := FromEnv(); err == nil {
+		t.Fatal("FromEnv: want error for negative tempo, got nil")
+	}
+}
+
+// TestFromEnv_AdmitLokiNegative covers the loki-cap negative-path
+// symmetry.
+func TestFromEnv_AdmitLokiNegative(t *testing.T) {
+	t.Setenv("CERBERUS_ADMIT_LOKI", "-10")
+	if _, err := FromEnv(); err == nil {
+		t.Fatal("FromEnv: want error for negative loki, got nil")
+	}
+}
+
+// TestParseHeaders_StrictModeBlocksGarbage drives the underlying parser
+// with several invalid shapes that must all fail.
+func TestParseHeaders_StrictModeBlocksGarbage(t *testing.T) {
+	cases := []string{
+		"no-equals-sign",
+		"first=ok, no-equals",
+		" =starts-with-equals ",
+	}
+	for _, raw := range cases {
+		t.Run(raw, func(t *testing.T) {
+			t.Setenv("CERBERUS_OTLP_HEADERS", raw)
+			if _, err := FromEnv(); err == nil {
+				t.Fatalf("FromEnv(%q): want error, got nil", raw)
+			}
+		})
+	}
+}
+
+// TestNewLogger_TextLevelLineThroughDebug walks every accepted log
+// level through NewLogger and confirms the level keyword affects
+// suppression. Anchor for the cmd/ wiring that calls NewLogger after
+// FromEnv resolves.
+func TestNewLogger_TextLevelLineThroughDebug(t *testing.T) {
+	t.Setenv("CERBERUS_LOG_LEVEL", "debug")
+	t.Setenv("CERBERUS_LOG_FORMAT", "text")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	var buf strings.Builder
+	logger := NewLogger(&buf, cfg.Log)
+	logger.Debug("debug-msg")
+	if !strings.Contains(buf.String(), "debug-msg") {
+		t.Errorf("debug record missing under debug level: %q", buf.String())
+	}
+}

--- a/internal/schema/ddl/idempotency_test.go
+++ b/internal/schema/ddl/idempotency_test.go
@@ -1,6 +1,7 @@
 package ddl
 
 import (
+	"context"
 	"strings"
 	"sync"
 	"testing"
@@ -286,10 +287,10 @@ func TestApply_Idempotent_NoOpWhenSignalsEmpty(t *testing.T) {
 	// Apply iterates signals and only calls conn.Exec inside the loop;
 	// with no signals, conn must never be touched, so a nil conn is
 	// safe.
-	if err := Apply(nil, nil, nil); err != nil {
+	if err := Apply(context.TODO(), nil, nil); err != nil {
 		t.Errorf("Apply with no signals: %v; want nil (no-op)", err)
 	}
-	if err := ApplyWithConfig(nil, nil, Config{}, []Signal{}); err != nil {
+	if err := ApplyWithConfig(context.TODO(), nil, Config{}, []Signal{}); err != nil {
 		t.Errorf("ApplyWithConfig with no signals: %v; want nil (no-op)", err)
 	}
 }

--- a/internal/schema/ddl/idempotency_test.go
+++ b/internal/schema/ddl/idempotency_test.go
@@ -1,0 +1,330 @@
+package ddl
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestRenderSignal_AllTablesCarryIfNotExists is the rendering-layer
+// equivalent of the Apply-twice integration test: every CREATE
+// statement under every signal must carry an IF NOT EXISTS clause so a
+// second Apply against an already-populated CH is a no-op. The
+// integration test asserts the end-to-end behavior; this test pins the
+// contract at the template-render boundary so a future template bump
+// can't silently drop the clause.
+func TestRenderSignal_AllTablesCarryIfNotExists(t *testing.T) {
+	cfg := Config{}.withDefaults()
+	for _, sig := range All {
+		stmts, err := renderSignal(cfg, sig)
+		if err != nil {
+			t.Fatalf("renderSignal(%s): %v", sig, err)
+		}
+		for i, stmt := range stmts {
+			if !strings.Contains(stmt, "IF NOT EXISTS") {
+				t.Errorf("%s[%d]: missing IF NOT EXISTS — re-apply would fail:\n%s", sig, i, stmt)
+			}
+		}
+	}
+}
+
+// TestRenderSignal_LogsOnlySubset emulates a deployment that only wants
+// the logs signal. The render layer must produce the single logs
+// statement and nothing else — Apply iterates per-signal so any
+// "metrics tables leak when only Logs requested" regression surfaces
+// here.
+func TestRenderSignal_LogsOnlySubset(t *testing.T) {
+	cfg := Config{}.withDefaults()
+	stmts, err := renderSignal(cfg, Logs)
+	if err != nil {
+		t.Fatalf("renderSignal(Logs): %v", err)
+	}
+	if len(stmts) != 1 {
+		t.Fatalf("logs subset: got %d statements; want 1", len(stmts))
+	}
+	if !strings.Contains(stmts[0], "otel_logs") {
+		t.Errorf("logs subset[0]: missing otel_logs table name")
+	}
+	if strings.Contains(stmts[0], "otel_metrics") || strings.Contains(stmts[0], "otel_traces") {
+		t.Errorf("logs subset[0]: leaked unrelated tables:\n%s", stmts[0])
+	}
+}
+
+// TestRenderSignal_TracesOnlySubset confirms the three traces statements
+// (spans table, lookup table, MV) render together and nothing else.
+// Order matters because the MV references the lookup table.
+func TestRenderSignal_TracesOnlySubset(t *testing.T) {
+	cfg := Config{}.withDefaults()
+	stmts, err := renderSignal(cfg, Traces)
+	if err != nil {
+		t.Fatalf("renderSignal(Traces): %v", err)
+	}
+	if len(stmts) != 3 {
+		t.Fatalf("traces subset: got %d statements; want 3", len(stmts))
+	}
+	// Statement order is load-bearing: the MV (stmts[2]) selects FROM
+	// the spans table (stmts[0]) and writes INTO the lookup table
+	// (stmts[1]). Reverse order would error on CH.
+	if !strings.Contains(stmts[0], "CREATE TABLE IF NOT EXISTS") {
+		t.Errorf("traces[0] should be the spans table CREATE")
+	}
+	if !strings.Contains(stmts[1], "otel_traces_trace_id_ts") || strings.Contains(stmts[1], "MATERIALIZED VIEW") {
+		t.Errorf("traces[1] should be the lookup table:\n%s", stmts[1])
+	}
+	if !strings.Contains(stmts[2], "CREATE MATERIALIZED VIEW IF NOT EXISTS") {
+		t.Errorf("traces[2] should be the MV CREATE")
+	}
+}
+
+// TestRenderSignal_MetricsOnlySubset confirms the five metrics statements
+// render without leaking logs or traces tables.
+func TestRenderSignal_MetricsOnlySubset(t *testing.T) {
+	cfg := Config{}.withDefaults()
+	stmts, err := renderSignal(cfg, Metrics)
+	if err != nil {
+		t.Fatalf("renderSignal(Metrics): %v", err)
+	}
+	if len(stmts) != 5 {
+		t.Fatalf("metrics subset: got %d statements; want 5", len(stmts))
+	}
+	for i, stmt := range stmts {
+		if strings.Contains(stmt, "otel_logs") || strings.Contains(stmt, "otel_traces") {
+			t.Errorf("metrics[%d] leaked an unrelated table:\n%s", i, stmt)
+		}
+	}
+}
+
+// TestRenderSignal_CustomDatabasePropagates verifies that an override
+// flows through *every* statement under *every* signal — this is the
+// contract main.go relies on when an operator sets
+// CERBERUS_CH_DATABASE to a non-default value.
+func TestRenderSignal_CustomDatabasePropagates(t *testing.T) {
+	cfg := Config{Database: "tenant_alpha"}.withDefaults()
+	for _, sig := range All {
+		stmts, _ := renderSignal(cfg, sig)
+		for i, stmt := range stmts {
+			if !strings.Contains(stmt, "tenant_alpha") {
+				t.Errorf("%s[%d]: custom database not rendered:\n%s", sig, i, stmt)
+			}
+			if strings.Contains(stmt, `"default"`) && !strings.Contains(stmt, "tenant_alpha") {
+				t.Errorf("%s[%d]: leaked default DB literal:\n%s", sig, i, stmt)
+			}
+		}
+	}
+}
+
+// TestRenderSignal_CustomTablesPropagate verifies per-table-name
+// overrides reach the rendered DDL for every signal. This pins the
+// schema-rename contract: an operator who wants their tables called
+// e.g. `acme_logs` instead of `otel_logs` can do so without forking the
+// upstream templates.
+func TestRenderSignal_CustomTablesPropagate(t *testing.T) {
+	cfg := Config{
+		Tables: Tables{
+			Logs:                "acme_logs",
+			Traces:              "acme_traces",
+			MetricsGauge:        "acme_gauge",
+			MetricsSum:          "acme_sum",
+			MetricsHistogram:    "acme_histogram",
+			MetricsExpHistogram: "acme_exp_histogram",
+			MetricsSummary:      "acme_summary",
+		},
+	}.withDefaults()
+
+	// Logs: single statement.
+	logs, _ := renderSignal(cfg, Logs)
+	if !strings.Contains(logs[0], "acme_logs") {
+		t.Errorf("logs override leaked: %s", logs[0])
+	}
+	// Metrics: 5 statements, each with its own custom name.
+	metrics, _ := renderSignal(cfg, Metrics)
+	wantMetrics := []string{"acme_gauge", "acme_sum", "acme_histogram", "acme_exp_histogram", "acme_summary"}
+	for i, w := range wantMetrics {
+		if !strings.Contains(metrics[i], w) {
+			t.Errorf("metrics[%d]: missing custom name %q in:\n%s", i, w, metrics[i])
+		}
+	}
+	// Traces: 3 statements, all referencing acme_traces in some
+	// shape (the lookup uses the base name as a prefix).
+	traces, _ := renderSignal(cfg, Traces)
+	for i, stmt := range traces {
+		if !strings.Contains(stmt, "acme_traces") {
+			t.Errorf("traces[%d]: missing custom base name:\n%s", i, stmt)
+		}
+	}
+}
+
+// TestRenderSignal_TablesEmptyFallBackToDefaults pins withDefaults's
+// per-field semantics: leaving any Tables field empty must fall back to
+// the upstream name. Half-overridden configs (a common deployment style
+// where only a few names diverge) must not silently zero the others.
+func TestRenderSignal_TablesEmptyFallBackToDefaults(t *testing.T) {
+	cfg := Config{Tables: Tables{Logs: "shiny_logs"}}.withDefaults()
+	logs, _ := renderSignal(cfg, Logs)
+	if !strings.Contains(logs[0], "shiny_logs") {
+		t.Errorf("logs override missing: %s", logs[0])
+	}
+	metrics, _ := renderSignal(cfg, Metrics)
+	// Metrics names left empty in the override must still surface as
+	// the upstream defaults.
+	for _, want := range []string{
+		"otel_metrics_gauge",
+		"otel_metrics_sum",
+		"otel_metrics_histogram",
+		"otel_metrics_exp_histogram",
+		"otel_metrics_summary",
+	} {
+		found := false
+		for _, stmt := range metrics {
+			if strings.Contains(stmt, want) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("metrics: default %q leaked into a non-default name", want)
+		}
+	}
+}
+
+// TestRenderSignal_ConcurrentRendersDoNotRace fires many parallel
+// renderSignal calls. The package keeps no mutable global state (every
+// withDefaults call returns a copy) so racing through the function
+// must not produce stale strings or panics. Run with `-race` to make
+// the assertion teeth.
+func TestRenderSignal_ConcurrentRendersDoNotRace(t *testing.T) {
+	const N = 32
+	var wg sync.WaitGroup
+	cfg := Config{Database: "ddl_concurrent"}.withDefaults()
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for _, sig := range All {
+				stmts, err := renderSignal(cfg, sig)
+				if err != nil {
+					t.Errorf("renderSignal(%s): %v", sig, err)
+					return
+				}
+				for _, stmt := range stmts {
+					if !strings.Contains(stmt, "ddl_concurrent") {
+						t.Errorf("%s: lost custom DB in concurrent render:\n%s", sig, stmt)
+					}
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// TestRenderSignal_TTLZeroSkipsTTLClause: the documented "no TTL" path
+// produces statements without a TTL keyword. Cerberus's default leaves
+// retention to the operator.
+func TestRenderSignal_TTLZeroSkipsTTLClause(t *testing.T) {
+	cfg := Config{TTL: 0}.withDefaults()
+	for _, sig := range All {
+		stmts, _ := renderSignal(cfg, sig)
+		for i, stmt := range stmts {
+			// The traces MV doesn't carry a TTL clause but contains
+			// other "TTL" substrings; check we don't see "TTL toDate..."
+			// which is what the rendered TTL expression looks like.
+			if strings.Contains(stmt, "TTL toDateTime") || strings.Contains(stmt, "TTL TimestampTime") {
+				t.Errorf("%s[%d]: zero TTL rendered an expression:\n%s", sig, i, stmt)
+			}
+		}
+	}
+}
+
+// TestRenderSignal_TTLAppliesCorrectTimeFieldPerSignal: the time field
+// the TTL expression uses must match what the upstream exporter expects
+// — Logs uses TimestampTime, Traces use toDateTime(Timestamp), Metrics
+// use toDateTime(TimeUnix). A swap would silently render valid SQL
+// against the wrong column.
+func TestRenderSignal_TTLAppliesCorrectTimeFieldPerSignal(t *testing.T) {
+	cfg := Config{TTL: 24 * time.Hour}.withDefaults()
+	logs, _ := renderSignal(cfg, Logs)
+	if !strings.Contains(logs[0], "TTL TimestampTime") {
+		t.Errorf("logs TTL: missing TimestampTime field:\n%s", logs[0])
+	}
+	metrics, _ := renderSignal(cfg, Metrics)
+	for i, stmt := range metrics {
+		if !strings.Contains(stmt, "TTL toDateTime(TimeUnix)") {
+			t.Errorf("metrics[%d] TTL: missing toDateTime(TimeUnix):\n%s", i, stmt)
+		}
+	}
+	traces, _ := renderSignal(cfg, Traces)
+	if !strings.Contains(traces[0], "TTL toDateTime(Timestamp)") {
+		t.Errorf("traces[0] TTL: missing toDateTime(Timestamp):\n%s", traces[0])
+	}
+	if !strings.Contains(traces[1], "TTL toDateTime(Start)") {
+		t.Errorf("traces[1] TTL: missing toDateTime(Start):\n%s", traces[1])
+	}
+}
+
+// TestRenderSignal_ClusterClauseRenderedAndQuoted documents the
+// quoting contract: cluster names land in `ON CLUSTER "<name>"` with
+// the name wrapped in CH-safe double quotes so special characters
+// (rare in practice, but possible) don't escape the template.
+func TestRenderSignal_ClusterClauseRenderedAndQuoted(t *testing.T) {
+	cfg := Config{Cluster: "ch-prod"}.withDefaults()
+	for _, sig := range All {
+		stmts, _ := renderSignal(cfg, sig)
+		for i, stmt := range stmts {
+			if !strings.Contains(stmt, `ON CLUSTER "ch-prod"`) {
+				t.Errorf("%s[%d]: cluster clause missing or unquoted:\n%s", sig, i, stmt)
+			}
+		}
+	}
+}
+
+// TestApply_Idempotent_NoOpWhenSignalsEmpty: invoking Apply with an
+// empty signal slice is a no-op that returns nil. Mirrors the contract
+// the cmd/cerberus wiring depends on when the caller's signal selector
+// resolves to nothing.
+func TestApply_Idempotent_NoOpWhenSignalsEmpty(t *testing.T) {
+	// Apply iterates signals and only calls conn.Exec inside the loop;
+	// with no signals, conn must never be touched, so a nil conn is
+	// safe.
+	if err := Apply(nil, nil, nil); err != nil {
+		t.Errorf("Apply with no signals: %v; want nil (no-op)", err)
+	}
+	if err := ApplyWithConfig(nil, nil, Config{}, []Signal{}); err != nil {
+		t.Errorf("ApplyWithConfig with no signals: %v; want nil (no-op)", err)
+	}
+}
+
+// TestSignalString_StableValuesForDashboards pins the human-readable
+// signal names. Cerberus surfaces these in startup logs and error
+// messages — a rename here would silently move dashboards.
+func TestSignalString_StableValuesForDashboards(t *testing.T) {
+	got := []string{Metrics.String(), Logs.String(), Traces.String()}
+	want := []string{"metrics", "logs", "traces"}
+	for i, s := range got {
+		if s != want[i] {
+			t.Errorf("Signal[%d].String() = %q; want %q", i, s, want[i])
+		}
+	}
+}
+
+// TestRenderSignal_DefaultEngineMergeTree documents the cerberus default
+// (single-node MergeTree). Operators running ReplicatedMergeTree will
+// override but we pin the default so cerberus stays "drop in" for a
+// fresh CH single-node deploy.
+func TestRenderSignal_DefaultEngineMergeTree(t *testing.T) {
+	cfg := Config{}.withDefaults()
+	for _, sig := range All {
+		stmts, _ := renderSignal(cfg, sig)
+		// Only table CREATEs care about the engine; the MV statement
+		// for traces does not include an ENGINE = clause. Skip lines
+		// without the substring to avoid false positives.
+		for i, stmt := range stmts {
+			if !strings.Contains(stmt, "ENGINE = ") {
+				continue
+			}
+			if !strings.Contains(stmt, "MergeTree()") {
+				t.Errorf("%s[%d]: default engine missing:\n%s", sig, i, stmt)
+			}
+		}
+	}
+}

--- a/internal/telemetry/contract_test.go
+++ b/internal/telemetry/contract_test.go
@@ -1,0 +1,298 @@
+package telemetry_test
+
+import (
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/tsouza/cerberus/internal/telemetry"
+)
+
+// TestMetricNames_PublicContract pins every metric name cerberus exposes
+// over OTLP. Dashboards + alerting rules reference these by exact name;
+// any rename is a breaking change for downstream consumers. If you
+// genuinely need to rename a metric add the new instrument first and
+// keep the old one for one release.
+func TestMetricNames_PublicContract(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	telemetry.Install(mp)
+	t.Cleanup(func() { telemetry.Install(nil) })
+
+	telemetry.ObserveQuery("promql", "GET /api/v1/query").Done(t.Context(), telemetry.ResultOK)
+	telemetry.ObserveStage(telemetry.StageParse).Done(t.Context())
+	telemetry.ObserveStage(telemetry.StageLower).Done(t.Context())
+	telemetry.ObserveStage(telemetry.StageOptimize).Done(t.Context())
+	telemetry.ObserveStage(telemetry.StageEmit).Done(t.Context())
+	telemetry.ObserveStage(telemetry.StageExecute).Done(t.Context())
+	telemetry.RecordRulesApplied(t.Context(), 1)
+	telemetry.RecordClickHouseProgress(t.Context(), "promql", 100, 2000)
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(t.Context(), &rm); err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+
+	want := map[string]bool{
+		"cerberus.queries.total":                   false,
+		"cerberus.queries.duration.seconds":        false,
+		"cerberus.pipeline.stage.duration.seconds": false,
+		"cerberus.optimizer.rules_applied":         false,
+		"cerberus.clickhouse.rows_read":            false,
+		"cerberus.clickhouse.bytes_read":           false,
+	}
+	for _, sm := range rm.ScopeMetrics {
+		if !strings.HasSuffix(sm.Scope.Name, "internal/telemetry") {
+			continue
+		}
+		for _, m := range sm.Metrics {
+			if _, ok := want[m.Name]; ok {
+				want[m.Name] = true
+			}
+		}
+	}
+	for name, seen := range want {
+		if !seen {
+			t.Errorf("metric %q not emitted; rename breaks dashboards", name)
+		}
+	}
+}
+
+// TestMetricUnits_PublicContract pins the unit field per metric. The
+// OTel SDK propagates the unit into the OTLP wire format and downstream
+// systems (Prometheus, Mimir, vendors) bucket by unit when deriving rate
+// vs. count semantics. Changing a unit is a breaking change.
+func TestMetricUnits_PublicContract(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	telemetry.Install(mp)
+	t.Cleanup(func() { telemetry.Install(nil) })
+
+	telemetry.ObserveQuery("promql", "GET /api/v1/query").Done(t.Context(), telemetry.ResultOK)
+	telemetry.ObserveStage(telemetry.StageParse).Done(t.Context())
+	telemetry.RecordRulesApplied(t.Context(), 1)
+	telemetry.RecordClickHouseProgress(t.Context(), "promql", 100, 2000)
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(t.Context(), &rm); err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+
+	wantUnits := map[string]string{
+		"cerberus.queries.total":                   "{query}",
+		"cerberus.queries.duration.seconds":        "s",
+		"cerberus.pipeline.stage.duration.seconds": "s",
+		"cerberus.optimizer.rules_applied":         "{rule}",
+		"cerberus.clickhouse.rows_read":            "{row}",
+		"cerberus.clickhouse.bytes_read":           "By",
+	}
+	for _, sm := range rm.ScopeMetrics {
+		if !strings.HasSuffix(sm.Scope.Name, "internal/telemetry") {
+			continue
+		}
+		for _, m := range sm.Metrics {
+			want, ok := wantUnits[m.Name]
+			if !ok {
+				continue
+			}
+			if m.Unit != want {
+				t.Errorf("metric %q unit = %q; want %q", m.Name, m.Unit, want)
+			}
+		}
+	}
+}
+
+// TestAttributeKeys_PublicContract documents the per-metric attribute
+// keys downstream dashboards pivot on. cerberus.ql / cerberus.route /
+// result on the query counter; stage on the stage histogram.
+func TestAttributeKeys_PublicContract(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	telemetry.Install(mp)
+	t.Cleanup(func() { telemetry.Install(nil) })
+
+	telemetry.ObserveQuery("logql", "GET /loki/api/v1/query_range").
+		Done(t.Context(), telemetry.ResultOK)
+	telemetry.ObserveStage(telemetry.StageEmit).Done(t.Context())
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(t.Context(), &rm); err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+
+	for _, sm := range rm.ScopeMetrics {
+		if !strings.HasSuffix(sm.Scope.Name, "internal/telemetry") {
+			continue
+		}
+		for _, m := range sm.Metrics {
+			switch m.Name {
+			case "cerberus.queries.total":
+				sum := m.Data.(metricdata.Sum[int64])
+				if len(sum.DataPoints) == 0 {
+					t.Fatalf("queries.total: empty")
+				}
+				attrs := sum.DataPoints[0].Attributes
+				for _, key := range []attribute.Key{"cerberus.ql", "cerberus.route", "result"} {
+					if _, ok := attrs.Value(key); !ok {
+						t.Errorf("queries.total: missing attr %q", key)
+					}
+				}
+			case "cerberus.pipeline.stage.duration.seconds":
+				hist := m.Data.(metricdata.Histogram[float64])
+				if len(hist.DataPoints) == 0 {
+					t.Fatalf("stage.duration: empty")
+				}
+				if _, ok := hist.DataPoints[0].Attributes.Value("stage"); !ok {
+					t.Errorf("stage.duration: missing stage attr")
+				}
+			}
+		}
+	}
+}
+
+// TestStageNames_PublicContract pins the exact stage values dashboards
+// filter on — parse / lower / optimize / emit / execute.
+func TestStageNames_PublicContract(t *testing.T) {
+	want := map[string]string{
+		"parse":    telemetry.StageParse,
+		"lower":    telemetry.StageLower,
+		"optimize": telemetry.StageOptimize,
+		"emit":     telemetry.StageEmit,
+		"execute":  telemetry.StageExecute,
+	}
+	for v, got := range want {
+		if got != v {
+			t.Errorf("stage const for %q = %q; want %q", v, got, v)
+		}
+	}
+}
+
+// TestResultValues_PublicContract pins the bucket labels for the result
+// attribute. dashboards group on these literal strings.
+func TestResultValues_PublicContract(t *testing.T) {
+	if telemetry.ResultOK != "ok" {
+		t.Errorf("ResultOK = %q; want ok", telemetry.ResultOK)
+	}
+	if telemetry.ResultError != "error" {
+		t.Errorf("ResultError = %q; want error", telemetry.ResultError)
+	}
+}
+
+// TestGet_NoopMeterProviderProducesNonNilInstruments confirms Get() is
+// usable even with a noop provider — callers don't have to guard
+// against nil instruments. Anchor for the auto-install path that goes
+// noop when no OTLP endpoint is configured.
+func TestGet_NoopMeterProviderProducesNonNilInstruments(t *testing.T) {
+	telemetry.Install(nil)
+	t.Cleanup(func() { telemetry.Install(nil) })
+
+	inst := telemetry.Get()
+	if inst == nil {
+		t.Fatal("Get = nil under noop provider")
+	}
+	if inst.QueriesTotal == nil || inst.QueryDuration == nil ||
+		inst.StageDuration == nil || inst.RulesApplied == nil ||
+		inst.ClickHouseRowsRead == nil || inst.ClickHouseBytesRead == nil {
+		t.Error("noop instrument set has a nil field")
+	}
+}
+
+// TestReset_RebuildsInstrumentsAgainstNewProvider verifies the
+// Reset()-after-Install contract used by tests. Install resets the
+// cache; subsequent Get() builds against the freshly-installed
+// MeterProvider.
+func TestReset_RebuildsInstrumentsAgainstNewProvider(t *testing.T) {
+	reader1 := sdkmetric.NewManualReader()
+	mp1 := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader1))
+	telemetry.Install(mp1)
+
+	telemetry.ObserveQuery("promql", "GET /api/v1/query").Done(t.Context(), telemetry.ResultOK)
+
+	// Re-install with a fresh reader; the next observation must land
+	// on it, not the previous one.
+	reader2 := sdkmetric.NewManualReader()
+	mp2 := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader2))
+	telemetry.Install(mp2)
+	t.Cleanup(func() { telemetry.Install(nil) })
+
+	telemetry.ObserveQuery("logql", "GET /loki/api/v1/query").Done(t.Context(), telemetry.ResultOK)
+
+	var rm metricdata.ResourceMetrics
+	if err := reader2.Collect(t.Context(), &rm); err != nil {
+		t.Fatalf("collect reader2: %v", err)
+	}
+	foundLoki := false
+	for _, sm := range rm.ScopeMetrics {
+		if !strings.HasSuffix(sm.Scope.Name, "internal/telemetry") {
+			continue
+		}
+		for _, m := range sm.Metrics {
+			if m.Name != "cerberus.queries.total" {
+				continue
+			}
+			sum := m.Data.(metricdata.Sum[int64])
+			for _, dp := range sum.DataPoints {
+				if v, _ := dp.Attributes.Value("cerberus.ql"); v.AsString() == "logql" {
+					foundLoki = true
+				}
+			}
+		}
+	}
+	if !foundLoki {
+		t.Error("reader2 missing logql observation — Install did not reset cache")
+	}
+}
+
+// TestObserveQuery_RoutePopulatedFromExplicitArgument anchors the
+// QueryMiddleware-bypass path: callers that call ObserveQuery directly
+// must see the route they passed survive to the metric attributes.
+func TestObserveQuery_RoutePopulatedFromExplicitArgument(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	telemetry.Install(mp)
+	t.Cleanup(func() { telemetry.Install(nil) })
+
+	telemetry.ObserveQuery("traceql", "GET /api/traces/{id}").
+		Done(t.Context(), telemetry.ResultError)
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(t.Context(), &rm); err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	for _, sm := range rm.ScopeMetrics {
+		if !strings.HasSuffix(sm.Scope.Name, "internal/telemetry") {
+			continue
+		}
+		for _, m := range sm.Metrics {
+			if m.Name != "cerberus.queries.total" {
+				continue
+			}
+			sum := m.Data.(metricdata.Sum[int64])
+			if len(sum.DataPoints) != 1 {
+				t.Fatalf("queries.total DPs: got %d want 1", len(sum.DataPoints))
+			}
+			route, _ := sum.DataPoints[0].Attributes.Value("cerberus.route")
+			if route.AsString() != "GET /api/traces/{id}" {
+				t.Errorf("route attr = %q; want %q", route.AsString(), "GET /api/traces/{id}")
+			}
+		}
+	}
+}
+
+// TestStageTimer_DoneOnNilReceiverIsSafe pins the nil-safe defer
+// contract used by handlers.
+func TestStageTimer_DoneOnNilReceiverIsSafe(t *testing.T) {
+	var st *telemetry.StageTimer
+	st.Done(t.Context()) // must not panic
+}
+
+// TestQueryTimer_DoneOnNilReceiverIsSafe mirrors the above for the
+// query timer.
+func TestQueryTimer_DoneOnNilReceiverIsSafe(t *testing.T) {
+	var qt *telemetry.QueryTimer
+	qt.Done(t.Context(), telemetry.ResultOK) // must not panic
+}
+

--- a/internal/telemetry/contract_test.go
+++ b/internal/telemetry/contract_test.go
@@ -295,4 +295,3 @@ func TestQueryTimer_DoneOnNilReceiverIsSafe(t *testing.T) {
 	var qt *telemetry.QueryTimer
 	qt.Done(t.Context(), telemetry.ResultOK) // must not panic
 }
-

--- a/internal/telemetry/lifecycle_test.go
+++ b/internal/telemetry/lifecycle_test.go
@@ -1,0 +1,251 @@
+package telemetry
+
+import (
+	"context"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/resource"
+)
+
+// TestBuildResource_DefaultsServiceName confirms an empty ServiceName
+// in Config still produces "cerberus" on the resource. Anchors the
+// invariant cerberus dashboards rely on (service.name=cerberus).
+func TestBuildResource_DefaultsServiceName(t *testing.T) {
+	res, err := buildResource(t.Context(), Config{})
+	if err != nil {
+		t.Fatalf("buildResource: %v", err)
+	}
+	if got := attr(res, "service.name"); got != "cerberus" {
+		t.Errorf("service.name = %q; want cerberus", got)
+	}
+}
+
+// TestBuildResource_DefaultsServiceVersion confirms an empty
+// ServiceVersion in Config falls back to "dev".
+func TestBuildResource_DefaultsServiceVersion(t *testing.T) {
+	res, err := buildResource(t.Context(), Config{})
+	if err != nil {
+		t.Fatalf("buildResource: %v", err)
+	}
+	if got := attr(res, "service.version"); got != "dev" {
+		t.Errorf("service.version = %q; want dev", got)
+	}
+}
+
+// TestBuildResource_AppliesConfiguredVersion confirms a populated
+// ServiceVersion surfaces on the resource — this is how goreleaser-built
+// binaries propagate their version to the OTLP backend.
+func TestBuildResource_AppliesConfiguredVersion(t *testing.T) {
+	res, err := buildResource(t.Context(), Config{
+		ServiceName:    "cerberus",
+		ServiceVersion: "v1.2.3",
+	})
+	if err != nil {
+		t.Fatalf("buildResource: %v", err)
+	}
+	if got := attr(res, "service.version"); got != "v1.2.3" {
+		t.Errorf("service.version = %q; want v1.2.3", got)
+	}
+}
+
+// TestBuildResource_IncludesServiceInstanceID confirms the
+// service.instance.id attribute is always present (so per-pod metrics
+// disambiguate). The value is either the hostname or a random fallback
+// — both non-empty.
+func TestBuildResource_IncludesServiceInstanceID(t *testing.T) {
+	res, err := buildResource(t.Context(), Config{})
+	if err != nil {
+		t.Fatalf("buildResource: %v", err)
+	}
+	if got := attr(res, "service.instance.id"); got == "" {
+		t.Errorf("service.instance.id = empty; want non-empty")
+	}
+}
+
+// TestBuildResource_InstanceIDMatchesHostnameWhenAvailable: when
+// os.Hostname succeeds, the resource attribute should match.
+func TestBuildResource_InstanceIDMatchesHostnameWhenAvailable(t *testing.T) {
+	host, err := os.Hostname()
+	if err != nil || host == "" {
+		t.Skip("hostname unavailable on this host; skipping")
+	}
+	res, err := buildResource(t.Context(), Config{})
+	if err != nil {
+		t.Fatalf("buildResource: %v", err)
+	}
+	if got := attr(res, "service.instance.id"); got != host {
+		t.Errorf("service.instance.id = %q; want %q", got, host)
+	}
+}
+
+// TestRandomInstanceID_NotEmpty pins the fallback path — even when
+// rand.Read failed we should still get a non-panicking sentinel.
+func TestRandomInstanceID_NotEmpty(t *testing.T) {
+	v := randomInstanceID()
+	if v == "" {
+		t.Error("randomInstanceID = empty; want sentinel or hex string")
+	}
+}
+
+// TestNew_NoopShutdownIdempotent: the noop providers' Shutdown is safe
+// to call multiple times. Cerberus's main wraps the shutdown into a
+// defer + a signal-driven path; both can hit it.
+func TestNew_NoopShutdownIdempotent(t *testing.T) {
+	providers, err := New(t.Context(), Config{Endpoint: ""})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	for i := 0; i < 3; i++ {
+		if err := providers.Shutdown(t.Context()); err != nil {
+			t.Errorf("Shutdown #%d: %v", i, err)
+		}
+	}
+}
+
+// TestNew_SDKShutdownHonorsContextDeadline: a populated endpoint pointing
+// at nothing must still let Shutdown return when the context expires.
+// Critical for the main.go path that bounds shutdown to 10s.
+func TestNew_SDKShutdownHonorsContextDeadline(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	_ = ln.Close()
+
+	providers, err := New(t.Context(), Config{
+		Endpoint:       addr,
+		Insecure:       true,
+		Timeout:        50 * time.Millisecond,
+		ServiceName:    "cerberus",
+		ServiceVersion: "test",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		_ = providers.Shutdown(ctx)
+		close(done)
+	}()
+	select {
+	case <-done:
+		// Shutdown returned within the test envelope — good.
+	case <-time.After(5 * time.Second):
+		t.Fatal("Shutdown did not return inside the deadline")
+	}
+}
+
+// TestProviders_HandsOutUsableTracer confirms the TracerProvider's
+// Tracer() call returns a non-nil tracer that can mint a span without
+// erroring. Sanity check that the SDK plumbing is wired correctly.
+func TestProviders_HandsOutUsableTracer(t *testing.T) {
+	providers, err := New(t.Context(), Config{Endpoint: ""})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	tr := providers.TracerProvider.Tracer("test")
+	if tr == nil {
+		t.Fatal("Tracer = nil")
+	}
+	_, span := tr.Start(t.Context(), "noop-span")
+	span.End()
+}
+
+// TestProviders_HandsOutUsableMeter mirrors the tracer sanity above for
+// the metric path. Even on noop providers, Meter() must hand out a
+// working meter.
+func TestProviders_HandsOutUsableMeter(t *testing.T) {
+	providers, err := New(t.Context(), Config{Endpoint: ""})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	m := providers.MeterProvider.Meter("test")
+	if m == nil {
+		t.Fatal("Meter = nil")
+	}
+	if _, err := m.Int64Counter("smoke"); err != nil {
+		t.Errorf("Int64Counter on noop: %v", err)
+	}
+}
+
+// TestNew_PropagatesHeadersToExporter: when CERBERUS_OTLP_HEADERS is
+// translated into Config.Headers and an endpoint is set, the SDK
+// provider should still construct without error. The exporter respects
+// the headers via grpc.WithMetadata internally — we can't inspect it
+// from outside, but we can guard the no-panic contract.
+func TestNew_PropagatesHeadersToExporter(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	_ = ln.Close()
+
+	providers, err := New(t.Context(), Config{
+		Endpoint: addr,
+		Insecure: true,
+		Headers:  map[string]string{"authorization": "Bearer abc", "x-tenant": "ut"},
+		Timeout:  500 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = providers.Shutdown(ctx)
+	})
+	if providers.TracerProvider == nil {
+		t.Error("TracerProvider nil after Headers config")
+	}
+	if providers.MeterProvider == nil {
+		t.Error("MeterProvider nil after Headers config")
+	}
+}
+
+// TestNew_SDKConstructorWithoutTimeout: zero Timeout must not be a
+// fatal error — the SDK still works, it just uses its own default.
+func TestNew_SDKConstructorWithoutTimeout(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	_ = ln.Close()
+
+	providers, err := New(t.Context(), Config{
+		Endpoint: addr,
+		Insecure: true,
+		Timeout:  0,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = providers.Shutdown(ctx)
+	})
+}
+
+// attr returns the string value of the named attribute on res, or ""
+// when missing. Resource attributes don't expose a direct lookup — we
+// scan once.
+func attr(res *resource.Resource, key string) string {
+	for _, kv := range res.Attributes() {
+		if string(kv.Key) == key {
+			if kv.Value.Type() == attribute.STRING {
+				return kv.Value.AsString()
+			}
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary

Layer 8 of the system test grid — ~75 tests across config / api/health /
telemetry / schema/ddl / cmd/cerberus pinning the lifecycle and
configuration invariants the production code already implements.

- **config matrix (27)** — every documented `CERBERUS_*` env var has a
  default + override case, plus the error paths for malformed values
  (bool vocabulary, duration formats, OTLP header parsing edge cases
  including escaped \`=\`, duplicates, empty keys / values).
- **api/health (13)** — body shape on the happy path, ping-timeout
  envelope on CH down, schema-pending bucket, TTL coalescing under
  concurrent probes, TTL invalidation, healthz never touches CH,
  request-context cancellation propagation, defaults for PingTimeout +
  CacheTTL.
- **schema/ddl (14)** — render-layer idempotency: every CREATE under
  every signal carries IF NOT EXISTS; subset Apply doesn't leak
  unrelated tables; statement order for Traces is preserved; custom
  DB / cluster / TTL / per-signal table overrides propagate; concurrent
  renderers don't race.
- **telemetry (22 across two files)** — BuildResource service.name /
  service.version / service.instance.id defaults; SDK shutdown honors
  context deadline; metric name + unit + attribute keys public
  contract (load-bearing for dashboards / alerting rules); Install
  reset semantics; nil-receiver safety.
- **cmd/cerberus (11)** — SIGINT / SIGTERM cancel the shutdown context;
  http.Server.Shutdown drains in-flight requests; deadline-exceeded
  forces close; \`http.ErrServerClosed\` is the documented Serve return;
  listener refuses new connections post-Shutdown; lightweight
  goroutine-delta leak guard.

### Test seams left on the table

A few of the originally-requested lifecycle behaviors need a
production-code seam to test directly. Deferred to a follow-up
refactor (no prod changes in this PR):

- *Direct \`run()\` invocation* — main's \`run()\` reads
  \`config.FromEnv\`, dials a real CH client, and installs OTel
  globals. A \`Process\` struct with injectable Pinger / Shutdowner
  deps would let tests drive these paths without a live CH.
- *OTLP exporter flush before exit* — needs \`run()\` access (or an
  exported \`Run(opts)\` form) so the test can swap the OTLP endpoint
  for a stub gRPC server.
- *CH connection \`Close()\` on exit* — same seam constraint.
- */healthz returns 503 during shutdown* — currently /healthz is
  unconditional 200; adding a "drain mode" toggle would be a prod
  code change.

### Out-of-scope (already covered upstream)

The chDB-integration tests for \`internal/schema/ddl\` already live in
\`ddl_integration_test.go\` (build tag \`integration\`) and exercise
the Apply -> CH -> system.tables flow. The new
\`idempotency_test.go\` covers the render layer (no CH required) so
the \`check\` CI lane catches regressions.

## Test plan

- [ ] \`check\` (race + cover) passes — verifies every new test
  compiles and the package-level invariants hold.
- [ ] \`lint\` passes — gofumpt / goimports formatting + golangci-lint
  rules.
- [ ] Manual: \`runtime.NumGoroutine()\` leak guard in
  \`cmd/cerberus/lifecycle_test.go\` may need tuning if CI's
  goroutine baseline drifts; the threshold is \`delta > 8\` after
  three create/shutdown cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)