### PR TITLE
chore(ci): teach Dependabot to track tsouza/* forks for otelc

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,10 +13,18 @@ updates:
     labels:
       - dependencies
       - go
-    # Grouping minor + patch bumps reduces PR noise. The three parsers
+    # Grouping minor + patch bumps reduces PR noise. The four parsers
     # share state via dskit/memberlist; bumping them individually
     # produces partial-tree builds that fail the dashboard job. Group
     # them so a single PR triggers a full CI matrix.
+    #
+    # All four parser modules are routed through tsouza/* forks via
+    # `replace` directives in go.mod. Dependabot tracks new tags on the
+    # fork repos and updates both the `require` version and the
+    # `replace` target. The forks-monitor cron at
+    # tsouza/cerberus-forks-monitor only mints a new tag when commits
+    # touch the narrow subtree cerberus consumes, so the Dependabot
+    # stream stays focused. See docs/upstream-forks.md.
     groups:
       upstream-parsers:
         applies-to: version-updates
@@ -26,6 +34,7 @@ updates:
           - "github.com/grafana/tempo*"
           - "github.com/grafana/dskit*"
           - "github.com/hashicorp/memberlist*"
+          - "github.com/open-telemetry/opentelemetry-collector-contrib/*"
         update-types:
           - patch
           - minor
@@ -39,6 +48,7 @@ updates:
           - "github.com/grafana/tempo*"
           - "github.com/grafana/dskit*"
           - "github.com/hashicorp/memberlist*"
+          - "github.com/open-telemetry/opentelemetry-collector-contrib/*"
         update-types:
           - patch
           - minor

--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -56,6 +56,12 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Patch-only auto-merge covers the modules that flow through
+      # tsouza/* forks. The forks-monitor cron only mints tags when
+      # commits touch the narrow cerberus subtree, so any tag-bump PR
+      # opened by Dependabot here is by construction "an upstream change
+      # that affects us". CI ( `check` + `lint` ) is still the merge
+      # gate via branch protection.
       - name: Enable auto-merge for trusted patch-only bumps
         if: |
           (steps.meta.outputs.update-type == 'version-update:semver-patch' &&
@@ -63,6 +69,10 @@ jobs:
              contains(steps.meta.outputs.dependency-names, 'github.com/grafana/loki/v3') ||
              contains(steps.meta.outputs.dependency-names, 'github.com/grafana/tempo') ||
              contains(steps.meta.outputs.dependency-names, 'github.com/grafana/dskit') ||
+             contains(steps.meta.outputs.dependency-names, 'github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter') ||
+             contains(steps.meta.outputs.dependency-names, 'github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal') ||
+             contains(steps.meta.outputs.dependency-names, 'github.com/open-telemetry/opentelemetry-collector-contrib/pkg/core/xidutils') ||
+             contains(steps.meta.outputs.dependency-names, 'github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger') ||
              contains(steps.meta.outputs.dependency-names, '@playwright/test')))
           ||
           (steps.meta.outputs.package-ecosystem == 'github_actions' &&


### PR DESCRIPTION
## Summary

- Extend the `upstream-parsers` Dependabot group to cover `github.com/open-telemetry/opentelemetry-collector-contrib/*`, matching the other three fork-routed parsers (prometheus, loki, tempo).
- Extend the patch-only auto-merge allowlist in `.github/workflows/auto-merge-deps.yml` with the four otelc submodules cerberus imports (clickhouseexporter, coreinternal, xidutils, jaeger translator).

This is the second of three PRs in the unified fork strategy. PR 1 (#252) swapped all four upstream parsers to fork-tagged replaces; this PR brings Dependabot's view in line so a fork tag bump produces one grouped PR per upstream change. PR 3 will document the maintainer flow.

## Test plan

- [ ] Dependabot dry-run (next daily window) shows one grouped PR opens against the new tags rather than four separate PRs.
- [ ] `check` + `lint` jobs pass on this PR.