### PR TITLE
test(spec/logql): add chDB roundtrip to 39 fixtures

### DIFF
--- a/test/spec/logql/bytes_over_time.txtar
+++ b/test/spec/logql/bytes_over_time.txtar
@@ -5,3 +5,17 @@ SELECT `ResourceAttributes`, arraySum(window_vals) AS `value` FROM (SELECT `Reso
 -- args --
 [0] string = "job"
 [1] string = "api"
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
+    (now64(9), 'abcde', map('job', 'api')),
+    (now64(9), 'fghij', map('job', 'api')),
+    (now64(9), 'klmno', map('job', 'api'));
+-- expected_rows --
+[
+  [{"job": "api"}, 15.0]
+]

--- a/test/spec/logql/bytes_over_time_query.txtar
+++ b/test/spec/logql/bytes_over_time_query.txtar
@@ -5,3 +5,16 @@ SELECT `ResourceAttributes`, arraySum(window_vals) AS `value` FROM (SELECT `Reso
 -- args --
 [0] string = "job"
 [1] string = "api"
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
+    (now64(9), 'xx', map('job', 'api')),
+    (now64(9), 'yyyy', map('job', 'api'));
+-- expected_rows --
+[
+  [{"job": "api"}, 6.0]
+]

--- a/test/spec/logql/bytes_rate.txtar
+++ b/test/spec/logql/bytes_rate.txtar
@@ -6,3 +6,17 @@ SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) /
 [0] float64 = 60
 [1] string = "job"
 [2] string = "api"
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
+    (now64(9), '1234567890', map('job', 'api')),
+    (now64(9), '1234567890', map('job', 'api')),
+    (now64(9), '1234567890', map('job', 'api'));
+-- expected_rows --
+[
+  [{"job": "api"}, 0.5]
+]

--- a/test/spec/logql/bytes_rate_query.txtar
+++ b/test/spec/logql/bytes_rate_query.txtar
@@ -6,3 +6,20 @@ SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) /
 [0] float64 = 300
 [1] string = "job"
 [2] string = "api"
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
+    (now64(9), 'aaaaaaaaaaaaaaaaaaaaaaaaa', map('job', 'api')),
+    (now64(9), 'bbbbbbbbbbbbbbbbbbbbbbbbb', map('job', 'api')),
+    (now64(9), 'ccccccccccccccccccccccccc', map('job', 'api')),
+    (now64(9), 'ddddddddddddddddddddddddd', map('job', 'api')),
+    (now64(9), 'eeeeeeeeeeeeeeeeeeeeeeeee', map('job', 'api')),
+    (now64(9), 'fffffffffffffffffffffffff', map('job', 'api'));
+-- expected_rows --
+[
+  [{"job": "api"}, 0.5]
+]

--- a/test/spec/logql/count_over_time.txtar
+++ b/test/spec/logql/count_over_time.txtar
@@ -6,3 +6,17 @@ SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `value` FROM (SEL
 [0] int64 = 1
 [1] string = "job"
 [2] string = "api"
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
+    (now64(9), 'a', map('job', 'api')),
+    (now64(9), 'b', map('job', 'api')),
+    (now64(9), 'c', map('job', 'api'));
+-- expected_rows --
+[
+  [{"job": "api"}, 3.0]
+]

--- a/test/spec/logql/decolorize.txtar
+++ b/test/spec/logql/decolorize.txtar
@@ -5,3 +5,13 @@ SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?)
 -- args --
 [0] string = "job"
 [1] string = "api"
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES ('plain text');
+-- expected_rows --
+[
+  ["plain text"]
+]

--- a/test/spec/logql/filter_with_or_alt.txtar
+++ b/test/spec/logql/filter_with_or_alt.txtar
@@ -7,3 +7,18 @@ SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND ((position(`Bo
 [1] string = "api"
 [2] string = "error"
 [3] string = "warn"
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES
+    ('info: ok'),
+    ('error: db'),
+    ('warn: high load'),
+    ('debug: trace');
+-- expected_rows --
+[
+  ["error: db"],
+  ["warn: high load"]
+]

--- a/test/spec/logql/label_filter_chained.txtar
+++ b/test/spec/logql/label_filter_chained.txtar
@@ -10,3 +10,17 @@ SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (position(`Bod
 [4] string = "prod"
 [5] string = "severity"
 [6] string = "high"
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api', 'env', 'prod', 'severity', 'high')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES
+    ('error: ouch'),
+    ('info: fine'),
+    ('error: again');
+-- expected_rows --
+[
+  ["error: ouch"],
+  ["error: again"]
+]

--- a/test/spec/logql/label_filter_eq.txtar
+++ b/test/spec/logql/label_filter_eq.txtar
@@ -7,3 +7,14 @@ SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (`ResourceAttr
 [1] string = "api"
 [2] string = "env"
 [3] string = "prod"
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api', 'env', 'prod')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES ('e1'), ('e2');
+-- expected_rows --
+[
+  ["e1"],
+  ["e2"]
+]

--- a/test/spec/logql/label_filter_or.txtar
+++ b/test/spec/logql/label_filter_or.txtar
@@ -9,3 +9,14 @@ SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND ((`ResourceAtt
 [3] string = "prod"
 [4] string = "env"
 [5] string = "stg"
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api', 'env', 'stg')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES ('o1'), ('o2');
+-- expected_rows --
+[
+  ["o1"],
+  ["o2"]
+]

--- a/test/spec/logql/label_filter_regex.txtar
+++ b/test/spec/logql/label_filter_regex.txtar
@@ -7,3 +7,14 @@ SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND match(`Resourc
 [1] string = "api"
 [2] string = "env"
 [3] string = "prod|stg"
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api', 'env', 'prod')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES ('r1'), ('r2');
+-- expected_rows --
+[
+  ["r1"],
+  ["r2"]
+]

--- a/test/spec/logql/label_format.txtar
+++ b/test/spec/logql/label_format.txtar
@@ -5,3 +5,13 @@ SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?)
 -- args --
 [0] string = "job"
 [1] string = "api"
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES ('lf1');
+-- expected_rows --
+[
+  ["lf1"]
+]

--- a/test/spec/logql/level_label_filter.txtar
+++ b/test/spec/logql/level_label_filter.txtar
@@ -7,3 +7,14 @@ SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (`ResourceAttr
 [1] string = "api"
 [2] string = "level"
 [3] string = "ERROR"
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api', 'level', 'ERROR')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES ('error log one'), ('error log two');
+-- expected_rows --
+[
+  ["error log one"],
+  ["error log two"]
+]

--- a/test/spec/logql/line_filter_chained.txtar
+++ b/test/spec/logql/line_filter_chained.txtar
@@ -7,3 +7,18 @@ SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (position(`Bod
 [1] string = "api"
 [2] string = "error"
 [3] string = "5[0-9]{2}"
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES
+    ('error 500 db'),
+    ('error 200 fine'),
+    ('warning 503 slow'),
+    ('error 504 timeout');
+-- expected_rows --
+[
+  ["error 500 db"],
+  ["error 504 timeout"]
+]

--- a/test/spec/logql/line_filter_contains.txtar
+++ b/test/spec/logql/line_filter_contains.txtar
@@ -6,3 +6,18 @@ SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (position(`Bod
 [0] string = "job"
 [1] string = "api"
 [2] string = "error"
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES
+    ('this is an error'),
+    ('debug message'),
+    ('another error occurred'),
+    ('info: all good');
+-- expected_rows --
+[
+  ["this is an error"],
+  ["another error occurred"]
+]

--- a/test/spec/logql/line_filter_not_contains.txtar
+++ b/test/spec/logql/line_filter_not_contains.txtar
@@ -6,3 +6,17 @@ SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (position(`Bod
 [0] string = "job"
 [1] string = "api"
 [2] string = "debug"
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES
+    ('info: ready'),
+    ('debug: trace'),
+    ('warn: slow');
+-- expected_rows --
+[
+  ["info: ready"],
+  ["warn: slow"]
+]

--- a/test/spec/logql/line_filter_not_regex.txtar
+++ b/test/spec/logql/line_filter_not_regex.txtar
@@ -6,3 +6,17 @@ SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND NOT match(`Bod
 [0] string = "job"
 [1] string = "api"
 [2] string = "health"
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES
+    ('GET /index'),
+    ('GET /health'),
+    ('POST /api');
+-- expected_rows --
+[
+  ["GET /index"],
+  ["POST /api"]
+]

--- a/test/spec/logql/line_filter_regex.txtar
+++ b/test/spec/logql/line_filter_regex.txtar
@@ -6,3 +6,17 @@ SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND match(`Body`, 
 [0] string = "job"
 [1] string = "api"
 [2] string = "(?i)error|fatal"
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES
+    ('Error: db down'),
+    ('info: ok'),
+    ('FATAL crash');
+-- expected_rows --
+[
+  ["Error: db down"],
+  ["FATAL crash"]
+]

--- a/test/spec/logql/line_format.txtar
+++ b/test/spec/logql/line_format.txtar
@@ -5,3 +5,13 @@ SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?)
 -- args --
 [0] string = "job"
 [1] string = "api"
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES ('original line');
+-- expected_rows --
+[
+  ["original line"]
+]

--- a/test/spec/logql/line_format_after_line_filter.txtar
+++ b/test/spec/logql/line_format_after_line_filter.txtar
@@ -6,3 +6,17 @@ SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (position(`Bod
 [0] string = "job"
 [1] string = "api"
 [2] string = "error"
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES
+    ('error happened'),
+    ('all good'),
+    ('error retry');
+-- expected_rows --
+[
+  ["error happened"],
+  ["error retry"]
+]

--- a/test/spec/logql/line_format_compose.txtar
+++ b/test/spec/logql/line_format_compose.txtar
@@ -5,3 +5,13 @@ SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?)
 -- args --
 [0] string = "job"
 [1] string = "api"
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES ('compose line');
+-- expected_rows --
+[
+  ["compose line"]
+]

--- a/test/spec/logql/multiple_label_matchers.txtar
+++ b/test/spec/logql/multiple_label_matchers.txtar
@@ -7,3 +7,14 @@ SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (`ResourceAttr
 [1] string = "api"
 [2] string = "env"
 [3] string = "prod"
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api', 'env', 'prod')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES ('one'), ('two');
+-- expected_rows --
+[
+  ["one"],
+  ["two"]
+]

--- a/test/spec/logql/not_eq_matcher.txtar
+++ b/test/spec/logql/not_eq_matcher.txtar
@@ -7,3 +7,14 @@ SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (`ResourceAttr
 [1] string = "api"
 [2] string = "env"
 [3] string = "prod"
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api', 'env', 'stg')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES ('row-a'), ('row-b');
+-- expected_rows --
+[
+  ["row-a"],
+  ["row-b"]
+]

--- a/test/spec/logql/pattern.txtar
+++ b/test/spec/logql/pattern.txtar
@@ -5,3 +5,13 @@
 [1] string = "api"
 -- sql --
 SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?)
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES ('1.2.3.4 - GET /a');
+-- expected_rows --
+[
+  ["1.2.3.4 - GET /a"]
+]

--- a/test/spec/logql/pattern_after_line_filter.txtar
+++ b/test/spec/logql/pattern_after_line_filter.txtar
@@ -6,3 +6,17 @@
 [2] string = "GET"
 -- sql --
 SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (position(`Body`, ?) > 0)
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES
+    ('1.2.3.4 - GET /a'),
+    ('5.6.7.8 - POST /b'),
+    ('9.9.9.9 - GET /c');
+-- expected_rows --
+[
+  ["1.2.3.4 - GET /a"],
+  ["9.9.9.9 - GET /c"]
+]

--- a/test/spec/logql/pattern_then_line_format.txtar
+++ b/test/spec/logql/pattern_then_line_format.txtar
@@ -5,3 +5,13 @@
 [1] string = "api"
 -- sql --
 SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?)
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES ('1.2.3.4 - POST /b');
+-- expected_rows --
+[
+  ["1.2.3.4 - POST /b"]
+]

--- a/test/spec/logql/pattern_with_label_filter.txtar
+++ b/test/spec/logql/pattern_with_label_filter.txtar
@@ -7,3 +7,14 @@
 [3] string = "error"
 -- sql --
 SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (`ResourceAttributes`[?] = ?)
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api', 'level', 'error')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES ('ts error oops'), ('ts error retry');
+-- expected_rows --
+[
+  ["ts error oops"],
+  ["ts error retry"]
+]

--- a/test/spec/logql/rate.txtar
+++ b/test/spec/logql/rate.txtar
@@ -7,3 +7,29 @@ SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) /
 [1] int64 = 1
 [2] string = "job"
 [3] string = "api"
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
+    (now64(9), 'a', map('job', 'api')),
+    (now64(9), 'b', map('job', 'api')),
+    (now64(9), 'c', map('job', 'api')),
+    (now64(9), 'd', map('job', 'api')),
+    (now64(9), 'e', map('job', 'api')),
+    (now64(9), 'f', map('job', 'api')),
+    (now64(9), 'g', map('job', 'api')),
+    (now64(9), 'h', map('job', 'api')),
+    (now64(9), 'i', map('job', 'api')),
+    (now64(9), 'j', map('job', 'api')),
+    (now64(9), 'k', map('job', 'api')),
+    (now64(9), 'l', map('job', 'api')),
+    (now64(9), 'm', map('job', 'api')),
+    (now64(9), 'n', map('job', 'api')),
+    (now64(9), 'o', map('job', 'api'));
+-- expected_rows --
+[
+  [{"job": "api"}, 0.25]
+]

--- a/test/spec/logql/rate_with_filter.txtar
+++ b/test/spec/logql/rate_with_filter.txtar
@@ -8,3 +8,18 @@ SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) /
 [2] string = "job"
 [3] string = "api"
 [4] string = "error"
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
+    (now64(9), 'error 1', map('job', 'api')),
+    (now64(9), 'info 1', map('job', 'api')),
+    (now64(9), 'error 2', map('job', 'api')),
+    (now64(9), 'error 3', map('job', 'api'));
+-- expected_rows --
+[
+  [{"job": "api"}, 0.01]
+]

--- a/test/spec/logql/regex_alternation_filter.txtar
+++ b/test/spec/logql/regex_alternation_filter.txtar
@@ -6,3 +6,18 @@ SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND match(`Body`, 
 [0] string = "job"
 [1] string = "api"
 [2] string = "(error|warn)"
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES
+    ('info: hello'),
+    ('error: oops'),
+    ('warn: oh'),
+    ('debug');
+-- expected_rows --
+[
+  ["error: oops"],
+  ["warn: oh"]
+]

--- a/test/spec/logql/roundtrip_chdb_test.go
+++ b/test/spec/logql/roundtrip_chdb_test.go
@@ -1,0 +1,32 @@
+//go:build chdb
+
+// Package logql_spec_test — chDB-backed round-trip pass over the
+// LogQL TXTAR fixtures.
+//
+// This test is gated behind the `chdb` build tag. It walks every
+// *.txtar fixture under test/spec/logql/ and, for fixtures that
+// declare both `seed:` and `expected_rows:`, executes the stored
+// `sql:` + `args:` against an ephemeral in-process chDB session and
+// asserts the resulting rows match `expected_rows:`.
+//
+// Fixtures without those sections are skipped (the default text-
+// equality check in internal/logql/lower_test.go still gates them).
+package logql_spec_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/tsouza/cerberus/test/spec"
+)
+
+func TestRoundTripChDB(t *testing.T) {
+	t.Parallel()
+
+	dir := filepath.Join(".")
+	spec.Walk(t, dir, func(t *testing.T, c *spec.Case) {
+		// LoadRoundTrip + IsRoundTrip is the opt-in gate; fixtures
+		// without seed/expected_rows are silent no-ops.
+		spec.RunRoundTrip(t, c)
+	})
+}

--- a/test/spec/logql/stream_selector.txtar
+++ b/test/spec/logql/stream_selector.txtar
@@ -5,3 +5,15 @@ SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?)
 -- args --
 [0] string = "job"
 [1] string = "api"
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES ('alpha'), ('beta'), ('gamma');
+-- expected_rows --
+[
+  ["alpha"],
+  ["beta"],
+  ["gamma"]
+]

--- a/test/spec/logql/stream_with_regex.txtar
+++ b/test/spec/logql/stream_with_regex.txtar
@@ -5,3 +5,14 @@ SELECT * FROM `otel_logs` WHERE match(`ResourceAttributes`[?], ?)
 -- args --
 [0] string = "env"
 [1] string = "prod|stg"
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('env', 'prod')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES ('m1'), ('m2');
+-- expected_rows --
+[
+  ["m1"],
+  ["m2"]
+]

--- a/test/spec/logql/stream_with_two_labels.txtar
+++ b/test/spec/logql/stream_with_two_labels.txtar
@@ -7,3 +7,14 @@ SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (`ResourceAttr
 [1] string = "api"
 [2] string = "env"
 [3] string = "prod"
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api', 'env', 'prod')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES ('hello'), ('world');
+-- expected_rows --
+[
+  ["hello"],
+  ["world"]
+]

--- a/test/spec/logql/three_filter_chain.txtar
+++ b/test/spec/logql/three_filter_chain.txtar
@@ -8,3 +8,18 @@ SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (position(`Bod
 [2] string = "a"
 [3] string = "b"
 [4] string = "c"
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES
+    ('apple_c'),
+    ('apple_bc'),
+    ('xxxc'),
+    ('a-c');
+-- expected_rows --
+[
+  ["apple_c"],
+  ["a-c"]
+]

--- a/test/spec/logql/unpack.txtar
+++ b/test/spec/logql/unpack.txtar
@@ -5,3 +5,13 @@
 [1] string = "api"
 -- sql --
 SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?)
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES ('packed log');
+-- expected_rows --
+[
+  ["packed log"]
+]

--- a/test/spec/logql/unpack_after_line_filter.txtar
+++ b/test/spec/logql/unpack_after_line_filter.txtar
@@ -6,3 +6,17 @@
 [2] string = "packed"
 -- sql --
 SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (position(`Body`, ?) > 0)
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES
+    ('packed payload 1'),
+    ('plain log'),
+    ('packed payload 2');
+-- expected_rows --
+[
+  ["packed payload 1"],
+  ["packed payload 2"]
+]

--- a/test/spec/logql/unpack_then_line_format.txtar
+++ b/test/spec/logql/unpack_then_line_format.txtar
@@ -5,3 +5,13 @@
 [1] string = "api"
 -- sql --
 SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?)
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES ('packed body');
+-- expected_rows --
+[
+  ["packed body"]
+]

--- a/test/spec/logql/unpack_with_label_filter.txtar
+++ b/test/spec/logql/unpack_with_label_filter.txtar
@@ -7,3 +7,14 @@
 [3] string = "error"
 -- sql --
 SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (`ResourceAttributes`[?] = ?)
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api', 'level', 'error')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES ('packed error one'), ('packed error two');
+-- expected_rows --
+[
+  ["packed error one"],
+  ["packed error two"]
+]

--- a/test/spec/logql/whitespace_in_braces.txtar
+++ b/test/spec/logql/whitespace_in_braces.txtar
@@ -5,3 +5,13 @@ SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?)
 -- args --
 [0] string = "job"
 [1] string = "api"
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES ('whitespace');
+-- expected_rows --
+[
+  ["whitespace"]
+]


### PR DESCRIPTION
## Summary

Layer 6b of the test-coverage backfill. Adds `seed:` + `expected_rows:` sections to **39 of 43 LogQL TXTAR fixtures** (plus the `test/spec/logql/roundtrip_chdb_test.go` walker), opting them in to the chDB-backed roundtrip pass that runs under the `chdb` build tag.

LogQL is the lowest-density-tested package in cerberus (0.90% tests/LoC); this commit closes that gap by validating that the SQL the lowering emits actually returns the rows we expect when executed against a real in-process ClickHouse via chDB.

## Coverage

- **Stream selectors** (=, !=, =~, !~), single + multi + whitespace.
- **Line filters** (|=, !=, |~, !~) including chained N-deep variants and `|= "x" or "y"` alternation.
- **Label filters** (string equality, regex, or-alternation, chained).
- **Pipeline stages**: `| decolorize`, `| line_format`, `| label_format`, `| pattern`, `| unpack` and their compositions.
- **Metric-form windows**: `rate(...)`, `count_over_time(...)`, `bytes_over_time(...)`, `bytes_rate(...)` across 1m / 5m / 1h ranges, with and without line-filter.

## Implementation tricks

Two structural patterns make `SELECT *`-style fixtures roundtrippable against the chDB runner whose `extractProjectionCount` sees `SELECT *` as 1 column:

1. **`SELECT *` fixtures**: seed creates `otel_logs` with a single visible `Body` column and a `MATERIALIZED ResourceAttributes`. CH's MATERIALIZED semantics exclude RA from `SELECT *` while still allowing WHERE clauses to reference `RA[?]`. The runner scans exactly one column (matching count=1) while the WHERE matchers still discriminate via the materialised map literal.
2. **Metric-form fixtures** with explicit outer projection (`ResourceAttributes, value`): seed exposes Timestamp + Body + ResourceAttributes as real columns; the runner's `rewriteMapProjections` wraps the top-level `ResourceAttributes` in `toJSONString(...)` so the Map column never reaches the parquet scan. INSERT uses `now64(9)` so the arrayFilter window always includes the seeded rows.

The 4 fixtures NOT roundtripped (`avg_count_over_time`, `sum_rate`, `sum_by_job_rate`, `sum_without_pod`) emit an outer projection containing `now64(?) AS TimeUnix`, which makes `expected_rows` time-dependent.

## Test plan

- [ ] CI `check` + `lint` green on this branch
- [ ] Nightly chDB roundtrip job exercises the new fixtures and stays green