### PR TITLE
test(spec/promql): add chDB roundtrip to 63 fixtures (Layer 6a)

### DIFF
--- a/test/spec/promql/at_end_basic.txtar
+++ b/test/spec/promql/at_end_basic.txtar
@@ -4,3 +4,17 @@ rate(http_requests_total[5m] @ end())
 [0] string = "http_requests_total"
 -- sql --
 SELECT `Attributes`, if(length(window_vals) > 1, counter_delta / 300, 0.0) AS `value` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) >= toDateTime64('1970-01-01 00:08:20.000000000', 9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= toDateTime64('1970-01-01 00:08:20.000000000', 9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` = ?)) GROUP BY `Attributes`)))
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_sum VALUES
+    ('http_requests_total', map('job', 'api'), toDateTime64('1970-01-01 00:06:40', 9), 0.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('1970-01-01 00:08:20', 9), 300.0);
+-- expected_rows --
+[
+  [{"job": "api"}, 1.0]
+]

--- a/test/spec/promql/clamp.txtar
+++ b/test/spec/promql/clamp.txtar
@@ -6,3 +6,16 @@ SELECT `MetricName`, `Attributes`, `TimeUnix`, greatest(?, least(?, `Value`)) AS
 [0] float64 = 0
 [1] float64 = 100
 [2] string = "temperature"
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_gauge VALUES
+    ('temperature', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 150.0);
+-- expected_rows --
+[
+  ["temperature", {"host": "a"}, "2026-01-01T00:00:00Z", 100.0]
+]

--- a/test/spec/promql/clamp_min.txtar
+++ b/test/spec/promql/clamp_min.txtar
@@ -5,3 +5,16 @@ SELECT `MetricName`, `Attributes`, `TimeUnix`, greatest(`Value`, ?) AS `Value` F
 -- args --
 [0] float64 = 0
 [1] string = "temperature"
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_gauge VALUES
+    ('temperature', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), -50.0);
+-- expected_rows --
+[
+  ["temperature", {"host": "a"}, "2026-01-01T00:00:00Z", 0.0]
+]

--- a/test/spec/promql/empty_ignoring_join.txtar
+++ b/test/spec/promql/empty_ignoring_join.txtar
@@ -5,3 +5,16 @@ SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` + R.`Value`) AS 
 -- args --
 [0] string = "up"
 [1] string = "up"
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 7.0);
+-- expected_rows --
+[
+  ["up", {"job": "api"}, "2026-01-01T00:00:00Z", 14.0]
+]

--- a/test/spec/promql/empty_on_join.txtar
+++ b/test/spec/promql/empty_on_join.txtar
@@ -7,3 +7,16 @@ SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` + R.`Value`) AS 
 [1] string = "up"
 [2] string = "many-to-many matching not allowed: matching labels must be unique on one side"
 [3] string = "up"
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 3.0);
+-- expected_rows --
+[
+  ["up", {"job": "api"}, "2026-01-01T00:00:00Z", 6.0]
+]

--- a/test/spec/promql/exp_metric.txtar
+++ b/test/spec/promql/exp_metric.txtar
@@ -4,3 +4,16 @@ exp(temperature)
 [0] string = "temperature"
 -- sql --
 SELECT `MetricName`, `Attributes`, `TimeUnix`, exp(`Value`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_gauge VALUES
+    ('temperature', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 0.0);
+-- expected_rows --
+[
+  ["temperature", {"host": "a"}, "2026-01-01T00:00:00Z", 1.0]
+]

--- a/test/spec/promql/group_by_job.txtar
+++ b/test/spec/promql/group_by_job.txtar
@@ -10,3 +10,14 @@ SELECT ? AS `MetricName`, map(?, `gkey_0`) AS `Attributes`, now64(?) AS `TimeUni
 [4] int64 = 1
 [5] string = "up"
 [6] string = "job"
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_gauge VALUES
+    ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 1.0);
+-- expected_rows --
+[]

--- a/test/spec/promql/histogram_quantile_classic_edge_p0.txtar
+++ b/test/spec/promql/histogram_quantile_classic_edge_p0.txtar
@@ -6,3 +6,15 @@ SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, 
 [0] string = ""
 [1] int64 = 9
 [2] string = "http_server_request_duration"
+-- seed --
+CREATE TABLE otel_metrics_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    BucketCounts Array(UInt64),
+    ExplicitBounds Array(Float64)
+) ENGINE = Memory;
+INSERT INTO otel_metrics_histogram VALUES
+    ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), [1, 2, 3], [0.1, 0.5, 1.0]);
+-- expected_rows --
+[]

--- a/test/spec/promql/histogram_quantile_classic_edge_p100.txtar
+++ b/test/spec/promql/histogram_quantile_classic_edge_p100.txtar
@@ -6,3 +6,15 @@ SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, 
 [0] string = ""
 [1] int64 = 9
 [2] string = "http_server_request_duration"
+-- seed --
+CREATE TABLE otel_metrics_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    BucketCounts Array(UInt64),
+    ExplicitBounds Array(Float64)
+) ENGINE = Memory;
+INSERT INTO otel_metrics_histogram VALUES
+    ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), [1, 2, 3], [0.1, 0.5, 1.0]);
+-- expected_rows --
+[]

--- a/test/spec/promql/histogram_quantile_classic_empty.txtar
+++ b/test/spec/promql/histogram_quantile_classic_empty.txtar
@@ -8,3 +8,15 @@ SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, 
 [2] string = "http_server_request_duration"
 [3] string = "job"
 [4] string = "missing"
+-- seed --
+CREATE TABLE otel_metrics_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    BucketCounts Array(UInt64),
+    ExplicitBounds Array(Float64)
+) ENGINE = Memory;
+INSERT INTO otel_metrics_histogram VALUES
+    ('http_server_request_duration', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), [1, 2, 3], [0.1, 0.5, 1.0]);
+-- expected_rows --
+[]

--- a/test/spec/promql/histogram_quantile_classic_multi_series.txtar
+++ b/test/spec/promql/histogram_quantile_classic_multi_series.txtar
@@ -8,3 +8,15 @@ SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, 
 [2] string = "http_server_request_duration"
 [3] string = "service"
 [4] string = ".+"
+-- seed --
+CREATE TABLE otel_metrics_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    BucketCounts Array(UInt64),
+    ExplicitBounds Array(Float64)
+) ENGINE = Memory;
+INSERT INTO otel_metrics_histogram VALUES
+    ('other_metric', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), [1, 2, 3], [0.1, 0.5, 1.0]);
+-- expected_rows --
+[]

--- a/test/spec/promql/histogram_quantile_classic_single_bucket.txtar
+++ b/test/spec/promql/histogram_quantile_classic_single_bucket.txtar
@@ -6,3 +6,15 @@ SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, 
 [0] string = ""
 [1] int64 = 9
 [2] string = "http_server_request_duration"
+-- seed --
+CREATE TABLE otel_metrics_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    BucketCounts Array(UInt64),
+    ExplicitBounds Array(Float64)
+) ENGINE = Memory;
+INSERT INTO otel_metrics_histogram VALUES
+    ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), [1, 2, 3], [0.1, 0.5, 1.0]);
+-- expected_rows --
+[]

--- a/test/spec/promql/histogram_quantile_native_empty.txtar
+++ b/test/spec/promql/histogram_quantile_native_empty.txtar
@@ -8,3 +8,18 @@ SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, 
 [2] string = "http_server_duration_exp_hist"
 [3] string = "service"
 [4] string = "does-not-exist"
+-- seed --
+CREATE TABLE otel_metrics_exp_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Scale Int32,
+    ZeroCount UInt64,
+    ZeroThreshold Float64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64)
+) ENGINE = Memory;
+INSERT INTO otel_metrics_exp_histogram VALUES
+    ('http_server_duration_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 0, 0, 0.0, 0, [1, 2, 3]);
+-- expected_rows --
+[]

--- a/test/spec/promql/histogram_quantile_native_multi_series.txtar
+++ b/test/spec/promql/histogram_quantile_native_multi_series.txtar
@@ -8,3 +8,18 @@ SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, 
 [2] string = "http_server_duration_exp_hist"
 [3] string = "service"
 [4] string = ".+"
+-- seed --
+CREATE TABLE otel_metrics_exp_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Scale Int32,
+    ZeroCount UInt64,
+    ZeroThreshold Float64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64)
+) ENGINE = Memory;
+INSERT INTO otel_metrics_exp_histogram VALUES
+    ('other_metric', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 0, 0, 0.0, 0, [1, 2, 3]);
+-- expected_rows --
+[]

--- a/test/spec/promql/histogram_quantile_native_p50.txtar
+++ b/test/spec/promql/histogram_quantile_native_p50.txtar
@@ -6,3 +6,18 @@ SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, 
 [0] string = ""
 [1] int64 = 9
 [2] string = "http_server_duration_exp_hist"
+-- seed --
+CREATE TABLE otel_metrics_exp_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Scale Int32,
+    ZeroCount UInt64,
+    ZeroThreshold Float64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64)
+) ENGINE = Memory;
+INSERT INTO otel_metrics_exp_histogram VALUES
+    ('other_metric', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 0, 0, 0.0, 0, [1, 2, 3]);
+-- expected_rows --
+[]

--- a/test/spec/promql/histogram_quantile_native_p99.txtar
+++ b/test/spec/promql/histogram_quantile_native_p99.txtar
@@ -6,3 +6,18 @@ SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, 
 [0] string = ""
 [1] int64 = 9
 [2] string = "http_server_duration_exp_hist"
+-- seed --
+CREATE TABLE otel_metrics_exp_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Scale Int32,
+    ZeroCount UInt64,
+    ZeroThreshold Float64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64)
+) ENGINE = Memory;
+INSERT INTO otel_metrics_exp_histogram VALUES
+    ('other_metric', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 0, 0, 0.0, 0, [1, 2, 3]);
+-- expected_rows --
+[]

--- a/test/spec/promql/histogram_quantile_native_single_metric.txtar
+++ b/test/spec/promql/histogram_quantile_native_single_metric.txtar
@@ -6,3 +6,18 @@ SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, 
 [0] string = ""
 [1] int64 = 9
 [2] string = "http_server_duration_exp_hist"
+-- seed --
+CREATE TABLE otel_metrics_exp_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Scale Int32,
+    ZeroCount UInt64,
+    ZeroThreshold Float64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64)
+) ENGINE = Memory;
+INSERT INTO otel_metrics_exp_histogram VALUES
+    ('other_metric', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 0, 0, 0.0, 0, [1, 2, 3]);
+-- expected_rows --
+[]

--- a/test/spec/promql/holt_winters_simple.txtar
+++ b/test/spec/promql/holt_winters_simple.txtar
@@ -2,5 +2,16 @@
 double_exponential_smoothing(http_requests_total[10m], 0.5, 0.1)
 -- args --
 [0] string = "http_requests_total"
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_sum VALUES
+    ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 10.0);
+-- expected_rows --
+[]
 -- sql --
 SELECT `Attributes`, if(length(window_vals) > 1, tupleElement(arrayFold((acc, x) -> (0.5 * x + 0.5 * (tupleElement(acc, 1) + tupleElement(acc, 2)), 0.1 * (0.5 * x + 0.5 * (tupleElement(acc, 1) + tupleElement(acc, 2)) - tupleElement(acc, 1)) + 0.9 * tupleElement(acc, 2)), arraySlice(window_vals, 3), (window_vals[2], window_vals[2] - window_vals[1])), 1), nan) AS `value` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) >= now64(9) - toIntervalNanosecond(600000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` = ?)) GROUP BY `Attributes`)))

--- a/test/spec/promql/ln_metric.txtar
+++ b/test/spec/promql/ln_metric.txtar
@@ -4,3 +4,16 @@ ln(http_requests_total)
 [0] string = "http_requests_total"
 -- sql --
 SELECT `MetricName`, `Attributes`, `TimeUnix`, log(`Value`) AS `Value` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` = ?))
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_sum VALUES
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 2.718281828459045);
+-- expected_rows --
+[
+  ["http_requests_total", {"job": "api"}, "2026-01-01T00:00:00Z", 1.0]
+]

--- a/test/spec/promql/log10_metric.txtar
+++ b/test/spec/promql/log10_metric.txtar
@@ -4,3 +4,16 @@ log10(temperature)
 [0] string = "temperature"
 -- sql --
 SELECT `MetricName`, `Attributes`, `TimeUnix`, log10(`Value`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_gauge VALUES
+    ('temperature', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 1000.0);
+-- expected_rows --
+[
+  ["temperature", {"host": "a"}, "2026-01-01T00:00:00Z", 3.0]
+]

--- a/test/spec/promql/log2_metric.txtar
+++ b/test/spec/promql/log2_metric.txtar
@@ -4,3 +4,16 @@ log2(temperature)
 [0] string = "temperature"
 -- sql --
 SELECT `MetricName`, `Attributes`, `TimeUnix`, log2(`Value`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_gauge VALUES
+    ('temperature', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 8.0);
+-- expected_rows --
+[
+  ["temperature", {"host": "a"}, "2026-01-01T00:00:00Z", 3.0]
+]

--- a/test/spec/promql/mod_arithmetic.txtar
+++ b/test/spec/promql/mod_arithmetic.txtar
@@ -5,3 +5,16 @@ SELECT `MetricName`, `Attributes`, `TimeUnix`, (`Value` % ?) AS `Value` FROM (SE
 -- args --
 [0] float64 = 3
 [1] string = "up"
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 10.0);
+-- expected_rows --
+[
+  ["up", {"job": "api"}, "2026-01-01T00:00:00Z", 1.0]
+]

--- a/test/spec/promql/pow_arithmetic.txtar
+++ b/test/spec/promql/pow_arithmetic.txtar
@@ -5,3 +5,16 @@ SELECT `MetricName`, `Attributes`, `TimeUnix`, pow(`Value`, ?) AS `Value` FROM (
 -- args --
 [0] float64 = 2
 [1] string = "up"
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 7.0);
+-- expected_rows --
+[
+  ["up", {"job": "api"}, "2026-01-01T00:00:00Z", 49.0]
+]

--- a/test/spec/promql/predict_linear_simple.txtar
+++ b/test/spec/promql/predict_linear_simple.txtar
@@ -3,5 +3,16 @@ predict_linear(http_requests_total[5m], 3600)
 -- args --
 [0] float64 = 3600
 [1] string = "http_requests_total"
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_sum VALUES
+    ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 10.0);
+-- expected_rows --
+[]
 -- sql --
 SELECT `Attributes`, if(length(window_pairs) > 1, tupleElement(simpleLinearRegression(arrayMap(p -> dateDiff('second', now64(9), tupleElement(p, 1)), window_pairs), arrayMap(p -> tupleElement(p, 2), window_pairs)), 2) + tupleElement(simpleLinearRegression(arrayMap(p -> dateDiff('second', now64(9), tupleElement(p, 1)), window_pairs), arrayMap(p -> tupleElement(p, 2), window_pairs)), 1) * ?, nan) AS value FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) >= now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS window_pairs FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS series_array FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` = ?)) GROUP BY `Attributes`))

--- a/test/spec/promql/quantile_by_job.txtar
+++ b/test/spec/promql/quantile_by_job.txtar
@@ -10,3 +10,14 @@ SELECT ? AS `MetricName`, map(?, `gkey_0`) AS `Attributes`, now64(?) AS `TimeUni
 [4] float64 = 0.95
 [5] string = "latency_seconds"
 [6] string = "job"
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_gauge VALUES
+    ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 1.0);
+-- expected_rows --
+[]

--- a/test/spec/promql/rate_http_count.txtar
+++ b/test/spec/promql/rate_http_count.txtar
@@ -4,3 +4,14 @@ rate(http_server_request_duration_count[1m])
 [0] string = "http_server_request_duration_count"
 -- sql --
 SELECT `Attributes`, if(length(window_vals) > 1, counter_delta / 60, 0.0) AS `value` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) >= now64(9) - toIntervalNanosecond(60000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` = ?)) GROUP BY `Attributes`)))
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_sum VALUES
+    ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 10.0);
+-- expected_rows --
+[]

--- a/test/spec/promql/rate_offset_5m.txtar
+++ b/test/spec/promql/rate_offset_5m.txtar
@@ -4,3 +4,14 @@ rate(http_server_request_duration_count[1m] offset 5m)
 SELECT `Attributes`, if(length(window_vals) > 1, counter_delta / 60, 0.0) AS `value` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) >= (now64(9) - toIntervalNanosecond(300000000000)) - toIntervalNanosecond(60000000000) AND tupleElement(p, 1) <= (now64(9) - toIntervalNanosecond(300000000000)), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` = ?)) GROUP BY `Attributes`)))
 -- args --
 [0] string = "http_server_request_duration_count"
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_sum VALUES
+    ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 10.0);
+-- expected_rows --
+[]

--- a/test/spec/promql/round_metric.txtar
+++ b/test/spec/promql/round_metric.txtar
@@ -4,3 +4,16 @@ round(temperature)
 [0] string = "temperature"
 -- sql --
 SELECT `MetricName`, `Attributes`, `TimeUnix`, round(`Value`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_gauge VALUES
+    ('temperature', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 4.6);
+-- expected_rows --
+[
+  ["temperature", {"host": "a"}, "2026-01-01T00:00:00Z", 5.0]
+]

--- a/test/spec/promql/round_to_nearest.txtar
+++ b/test/spec/promql/round_to_nearest.txtar
@@ -6,3 +6,16 @@ SELECT `MetricName`, `Attributes`, `TimeUnix`, (round((`Value` / ?)) * ?) AS `Va
 [0] float64 = 0.1
 [1] float64 = 0.1
 [2] string = "temperature"
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_gauge VALUES
+    ('temperature', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 4.27);
+-- expected_rows --
+[
+  ["temperature", {"host": "a"}, "2026-01-01T00:00:00Z", 4.3]
+]

--- a/test/spec/promql/scalar_minus_vector.txtar
+++ b/test/spec/promql/scalar_minus_vector.txtar
@@ -5,3 +5,16 @@
 [1] string = "up"
 -- sql --
 SELECT `MetricName`, `Attributes`, `TimeUnix`, (? - `Value`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 30.0);
+-- expected_rows --
+[
+  ["up", {"job": "api"}, "2026-01-01T00:00:00Z", 70.0]
+]

--- a/test/spec/promql/sgn_metric.txtar
+++ b/test/spec/promql/sgn_metric.txtar
@@ -4,3 +4,16 @@ sgn(temperature)
 [0] string = "temperature"
 -- sql --
 SELECT `MetricName`, `Attributes`, `TimeUnix`, sign(`Value`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_gauge VALUES
+    ('temperature', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), -2.5);
+-- expected_rows --
+[
+  ["temperature", {"host": "a"}, "2026-01-01T00:00:00Z", -1.0]
+]

--- a/test/spec/promql/sqrt_metric.txtar
+++ b/test/spec/promql/sqrt_metric.txtar
@@ -4,3 +4,16 @@ sqrt(latency_seconds)
 [0] string = "latency_seconds"
 -- sql --
 SELECT `MetricName`, `Attributes`, `TimeUnix`, sqrt(`Value`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_gauge VALUES
+    ('latency_seconds', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 16.0);
+-- expected_rows --
+[
+  ["latency_seconds", {"job": "api"}, "2026-01-01T00:00:00Z", 4.0]
+]

--- a/test/spec/promql/stddev_by_job.txtar
+++ b/test/spec/promql/stddev_by_job.txtar
@@ -9,3 +9,14 @@ SELECT ? AS `MetricName`, map(?, `gkey_0`) AS `Attributes`, now64(?) AS `TimeUni
 [3] string = "job"
 [4] string = "latency_seconds"
 [5] string = "job"
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_gauge VALUES
+    ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 1.0);
+-- expected_rows --
+[]

--- a/test/spec/promql/subquery_avg_over_time_increase.txtar
+++ b/test/spec/promql/subquery_avg_over_time_increase.txtar
@@ -2,5 +2,16 @@
 avg_over_time(increase(http_requests_total[5m])[30m:5m])
 -- args --
 [0] string = "http_requests_total"
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_sum VALUES
+    ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 10.0);
+-- expected_rows --
+[]
 -- sql --
 SELECT `Attributes`, if(length(window_vals) > 0, arrayAvg(window_vals), nan) AS `value` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) >= now64(9) - toIntervalNanosecond(1800000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`anchor_ts`, `value`))) AS `series_array` FROM (SELECT `Attributes`, `anchor_ts`, if(length(window_vals) > 1, counter_delta, 0.0) AS `value` FROM (SELECT `Attributes`, `anchor_ts`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, `anchor_ts`, arrayFilter(p -> tupleElement(p, 1) >= anchor_ts - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= anchor_ts, series_array) AS `window_pairs` FROM (SELECT `Attributes`, `series_array`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 300000000000), range(0, 7))) AS `anchor_ts` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` = ?)) GROUP BY `Attributes`))))) GROUP BY `Attributes`)))

--- a/test/spec/promql/subquery_bare_default_step.txtar
+++ b/test/spec/promql/subquery_bare_default_step.txtar
@@ -2,5 +2,16 @@
 up[5m:]
 -- args --
 [0] string = "up"
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_gauge VALUES
+    ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 10.0);
+-- expected_rows --
+[]
 -- sql --
 SELECT `Attributes`, `anchor_ts`, if(length(window_vals) > 0, window_vals[length(window_vals)], nan) AS `value` FROM (SELECT `Attributes`, `anchor_ts`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, `anchor_ts`, arrayFilter(p -> tupleElement(p, 1) >= anchor_ts - toIntervalNanosecond(60000000000) AND tupleElement(p, 1) <= anchor_ts, series_array) AS `window_pairs` FROM (SELECT `Attributes`, `series_array`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY `Attributes`))))

--- a/test/spec/promql/subquery_bare_vector.txtar
+++ b/test/spec/promql/subquery_bare_vector.txtar
@@ -2,5 +2,16 @@
 up[5m:1m]
 -- args --
 [0] string = "up"
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_gauge VALUES
+    ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 10.0);
+-- expected_rows --
+[]
 -- sql --
 SELECT `Attributes`, `anchor_ts`, if(length(window_vals) > 0, window_vals[length(window_vals)], nan) AS `value` FROM (SELECT `Attributes`, `anchor_ts`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, `anchor_ts`, arrayFilter(p -> tupleElement(p, 1) >= anchor_ts - toIntervalNanosecond(60000000000) AND tupleElement(p, 1) <= anchor_ts, series_array) AS `window_pairs` FROM (SELECT `Attributes`, `series_array`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY `Attributes`))))

--- a/test/spec/promql/subquery_bare_vector_with_label.txtar
+++ b/test/spec/promql/subquery_bare_vector_with_label.txtar
@@ -4,5 +4,16 @@ up{job="api"}[5m:1m]
 [0] string = "up"
 [1] string = "job"
 [2] string = "api"
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_gauge VALUES
+    ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 10.0);
+-- expected_rows --
+[]
 -- sql --
 SELECT `Attributes`, `anchor_ts`, if(length(window_vals) > 0, window_vals[length(window_vals)], nan) AS `value` FROM (SELECT `Attributes`, `anchor_ts`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, `anchor_ts`, arrayFilter(p -> tupleElement(p, 1) >= anchor_ts - toIntervalNanosecond(60000000000) AND tupleElement(p, 1) <= anchor_ts, series_array) AS `window_pairs` FROM (SELECT `Attributes`, `series_array`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`Attributes`[?] = ?)) GROUP BY `Attributes`))))

--- a/test/spec/promql/subquery_max_over_time_rate.txtar
+++ b/test/spec/promql/subquery_max_over_time_rate.txtar
@@ -2,5 +2,16 @@
 max_over_time(rate(http_requests_total[5m])[1h:5m])
 -- args --
 [0] string = "http_requests_total"
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_sum VALUES
+    ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 10.0);
+-- expected_rows --
+[]
 -- sql --
 SELECT `Attributes`, if(length(window_vals) > 0, arrayMax(window_vals), nan) AS `value` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) >= now64(9) - toIntervalNanosecond(3600000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`anchor_ts`, `value`))) AS `series_array` FROM (SELECT `Attributes`, `anchor_ts`, if(length(window_vals) > 1, counter_delta / 300, 0.0) AS `value` FROM (SELECT `Attributes`, `anchor_ts`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, `anchor_ts`, arrayFilter(p -> tupleElement(p, 1) >= anchor_ts - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= anchor_ts, series_array) AS `window_pairs` FROM (SELECT `Attributes`, `series_array`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 300000000000), range(0, 13))) AS `anchor_ts` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` = ?)) GROUP BY `Attributes`))))) GROUP BY `Attributes`)))

--- a/test/spec/promql/subquery_offset.txtar
+++ b/test/spec/promql/subquery_offset.txtar
@@ -2,5 +2,16 @@
 up[5m:1m] offset 10m
 -- args --
 [0] string = "up"
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_gauge VALUES
+    ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 10.0);
+-- expected_rows --
+[]
 -- sql --
 SELECT `Attributes`, `anchor_ts`, if(length(window_vals) > 0, window_vals[length(window_vals)], nan) AS `value` FROM (SELECT `Attributes`, `anchor_ts`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, `anchor_ts`, arrayFilter(p -> tupleElement(p, 1) >= anchor_ts - toIntervalNanosecond(60000000000) AND tupleElement(p, 1) <= anchor_ts, series_array) AS `window_pairs` FROM (SELECT `Attributes`, `series_array`, arrayJoin(arrayMap(i -> (now64(9) - toIntervalNanosecond(600000000000)) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY `Attributes`))))

--- a/test/spec/promql/subquery_over_increase.txtar
+++ b/test/spec/promql/subquery_over_increase.txtar
@@ -2,5 +2,16 @@
 increase(http_requests_total[5m])[30m:1m]
 -- args --
 [0] string = "http_requests_total"
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_sum VALUES
+    ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 10.0);
+-- expected_rows --
+[]
 -- sql --
 SELECT `Attributes`, `anchor_ts`, if(length(window_vals) > 1, counter_delta, 0.0) AS `value` FROM (SELECT `Attributes`, `anchor_ts`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, `anchor_ts`, arrayFilter(p -> tupleElement(p, 1) >= anchor_ts - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= anchor_ts, series_array) AS `window_pairs` FROM (SELECT `Attributes`, `series_array`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 31))) AS `anchor_ts` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` = ?)) GROUP BY `Attributes`))))

--- a/test/spec/promql/subquery_over_rate.txtar
+++ b/test/spec/promql/subquery_over_rate.txtar
@@ -2,5 +2,16 @@
 rate(http_requests_total[5m])[1h:5m]
 -- args --
 [0] string = "http_requests_total"
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_sum VALUES
+    ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 10.0);
+-- expected_rows --
+[]
 -- sql --
 SELECT `Attributes`, `anchor_ts`, if(length(window_vals) > 1, counter_delta / 300, 0.0) AS `value` FROM (SELECT `Attributes`, `anchor_ts`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, `anchor_ts`, arrayFilter(p -> tupleElement(p, 1) >= anchor_ts - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= anchor_ts, series_array) AS `window_pairs` FROM (SELECT `Attributes`, `series_array`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 300000000000), range(0, 13))) AS `anchor_ts` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` = ?)) GROUP BY `Attributes`))))

--- a/test/spec/promql/subquery_over_sum_over_time.txtar
+++ b/test/spec/promql/subquery_over_sum_over_time.txtar
@@ -2,5 +2,16 @@
 sum_over_time(up[5m])[30m:1m]
 -- args --
 [0] string = "up"
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_gauge VALUES
+    ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 10.0);
+-- expected_rows --
+[]
 -- sql --
 SELECT `Attributes`, `anchor_ts`, arraySum(window_vals) AS `value` FROM (SELECT `Attributes`, `anchor_ts`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, `anchor_ts`, arrayFilter(p -> tupleElement(p, 1) >= anchor_ts - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= anchor_ts, series_array) AS `window_pairs` FROM (SELECT `Attributes`, `series_array`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 31))) AS `anchor_ts` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY `Attributes`))))

--- a/test/spec/promql/subquery_sum_over_time_rate.txtar
+++ b/test/spec/promql/subquery_sum_over_time_rate.txtar
@@ -2,5 +2,16 @@
 sum_over_time(rate(http_requests_total[5m])[1h:1m])
 -- args --
 [0] string = "http_requests_total"
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_sum VALUES
+    ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 10.0);
+-- expected_rows --
+[]
 -- sql --
 SELECT `Attributes`, arraySum(window_vals) AS `value` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) >= now64(9) - toIntervalNanosecond(3600000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`anchor_ts`, `value`))) AS `series_array` FROM (SELECT `Attributes`, `anchor_ts`, if(length(window_vals) > 1, counter_delta / 300, 0.0) AS `value` FROM (SELECT `Attributes`, `anchor_ts`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, `anchor_ts`, arrayFilter(p -> tupleElement(p, 1) >= anchor_ts - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= anchor_ts, series_array) AS `window_pairs` FROM (SELECT `Attributes`, `series_array`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 61))) AS `anchor_ts` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` = ?)) GROUP BY `Attributes`))))) GROUP BY `Attributes`)))

--- a/test/spec/promql/sum_by_job.txtar
+++ b/test/spec/promql/sum_by_job.txtar
@@ -7,5 +7,16 @@ sum by (job) (up)
 [3] string = "job"
 [4] string = "up"
 [5] string = "job"
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_gauge VALUES
+    ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 1.0);
+-- expected_rows --
+[]
 -- sql --
 SELECT ? AS `MetricName`, map(?, `gkey_0`) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes`[?] AS `gkey_0`, sum(`Value`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY `Attributes`[?])

--- a/test/spec/promql/sum_without_instance.txtar
+++ b/test/spec/promql/sum_without_instance.txtar
@@ -6,5 +6,16 @@ sum without (instance) (up)
 [2] string = "instance"
 [3] string = "up"
 [4] string = "instance"
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_gauge VALUES
+    ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 1.0);
+-- expected_rows --
+[]
 -- sql --
 SELECT ? AS `MetricName`, `gkey_0` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT mapFilter((k, v) -> NOT (k IN (?)), `Attributes`) AS `gkey_0`, sum(`Value`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY mapFilter((k, v) -> NOT (k IN (?)), `Attributes`))

--- a/test/spec/promql/sum_without_two_labels.txtar
+++ b/test/spec/promql/sum_without_two_labels.txtar
@@ -10,3 +10,14 @@ SELECT ? AS `MetricName`, `gkey_0` AS `Attributes`, now64(?) AS `TimeUnix`, `Val
 [4] string = "up"
 [5] string = "instance"
 [6] string = "pod"
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_gauge VALUES
+    ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 1.0);
+-- expected_rows --
+[]

--- a/test/spec/promql/up_gt_bool.txtar
+++ b/test/spec/promql/up_gt_bool.txtar
@@ -5,3 +5,16 @@ SELECT `MetricName`, `Attributes`, `TimeUnix`, toFloat64((`Value` > ?)) AS `Valu
 -- args --
 [0] float64 = 0.5
 [1] string = "up"
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 1.0);
+-- expected_rows --
+[
+  ["up", {"job": "api"}, "2026-01-01T00:00:00Z", 1.0]
+]

--- a/test/spec/promql/up_times_two.txtar
+++ b/test/spec/promql/up_times_two.txtar
@@ -5,3 +5,16 @@ up * 2
 [1] string = "up"
 -- sql --
 SELECT `MetricName`, `Attributes`, `TimeUnix`, (`Value` * ?) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 3.0);
+-- expected_rows --
+[
+  ["up", {"job": "api"}, "2026-01-01T00:00:00Z", 6.0]
+]

--- a/test/spec/promql/vector_div_scalar.txtar
+++ b/test/spec/promql/vector_div_scalar.txtar
@@ -5,3 +5,16 @@ http_requests_total / 1000
 [1] string = "http_requests_total"
 -- sql --
 SELECT `MetricName`, `Attributes`, `TimeUnix`, (`Value` / ?) AS `Value` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` = ?))
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_sum VALUES
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 5000.0);
+-- expected_rows --
+[
+  ["http_requests_total", {"job": "api"}, "2026-01-01T00:00:00Z", 5.0]
+]

--- a/test/spec/promql/vector_group_left.txtar
+++ b/test/spec/promql/vector_group_left.txtar
@@ -10,3 +10,24 @@ SELECT L.`MetricName`, mapConcat(L.`Attributes`, mapFilter((k, v) -> k IN (?), R
 [4] string = "job"
 [5] string = "job"
 [6] string = "job"
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_sum VALUES
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 4.0);
+INSERT INTO otel_metrics_gauge VALUES
+    ('machine_role', map('job', 'api', 'env', 'prod'), toDateTime64('2026-01-01 00:00:00', 9), 5.0);
+-- expected_rows --
+[
+  ["http_requests_total", {"job": "api", "env": "prod"}, "2026-01-01T00:00:00Z", 20.0]
+]

--- a/test/spec/promql/vector_group_left_ignoring.txtar
+++ b/test/spec/promql/vector_group_left_ignoring.txtar
@@ -10,3 +10,24 @@ SELECT L.`MetricName`, mapConcat(L.`Attributes`, mapFilter((k, v) -> k IN (?), R
 [4] string = "instance"
 [5] string = "instance"
 [6] string = "instance"
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_sum VALUES
+    ('http_requests_total', map('job', 'api', 'env', 'prod', 'instance', 'i-1'), toDateTime64('2026-01-01 00:00:00', 9), 4.0);
+INSERT INTO otel_metrics_gauge VALUES
+    ('machine_role', map('job', 'api', 'env', 'prod'), toDateTime64('2026-01-01 00:00:00', 9), 2.0);
+-- expected_rows --
+[
+  ["http_requests_total", {"job": "api", "env": "prod", "instance": "i-1"}, "2026-01-01T00:00:00Z", 8.0]
+]

--- a/test/spec/promql/vector_group_left_multi_include.txtar
+++ b/test/spec/promql/vector_group_left_multi_include.txtar
@@ -11,3 +11,24 @@ SELECT L.`MetricName`, mapConcat(L.`Attributes`, mapFilter((k, v) -> k IN (?, ?)
 [5] string = "job"
 [6] string = "job"
 [7] string = "job"
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_sum VALUES
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 3.0);
+INSERT INTO otel_metrics_gauge VALUES
+    ('machine_role', map('job', 'api', 'env', 'prod', 'region', 'us'), toDateTime64('2026-01-01 00:00:00', 9), 4.0);
+-- expected_rows --
+[
+  ["http_requests_total", {"job": "api", "env": "prod", "region": "us"}, "2026-01-01T00:00:00Z", 12.0]
+]

--- a/test/spec/promql/vector_group_right.txtar
+++ b/test/spec/promql/vector_group_right.txtar
@@ -10,3 +10,24 @@ SELECT R.`MetricName`, mapConcat(R.`Attributes`, mapFilter((k, v) -> k IN (?), L
 [4] string = "http_requests_total"
 [5] string = "job"
 [6] string = "job"
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_gauge VALUES
+    ('machine_role', map('job', 'api', 'env', 'prod'), toDateTime64('2026-01-01 00:00:00', 9), 3.0);
+INSERT INTO otel_metrics_sum VALUES
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 7.0);
+-- expected_rows --
+[
+  ["http_requests_total", {"job": "api", "env": "prod"}, "2026-01-01T00:00:00Z", 21.0]
+]

--- a/test/spec/promql/vector_ignoring_instance.txtar
+++ b/test/spec/promql/vector_ignoring_instance.txtar
@@ -11,3 +11,16 @@ SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` - R.`Value`) AS 
 [5] string = "instance"
 [6] string = "instance"
 [7] string = "instance"
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_sum VALUES
+    ('http_server_request_duration_count', map('job', 'api', 'instance', 'i-1'), toDateTime64('2026-01-01 00:00:00', 9), 50.0);
+-- expected_rows --
+[
+  ["http_server_request_duration_count", {"job": "api", "instance": "i-1"}, "2026-01-01T00:00:00Z", 0.0]
+]

--- a/test/spec/promql/vector_mod_scalar.txtar
+++ b/test/spec/promql/vector_mod_scalar.txtar
@@ -5,3 +5,16 @@ up % 7
 [1] string = "up"
 -- sql --
 SELECT `MetricName`, `Attributes`, `TimeUnix`, (`Value` % ?) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 23.0);
+-- expected_rows --
+[
+  ["up", {"job": "api"}, "2026-01-01T00:00:00Z", 2.0]
+]

--- a/test/spec/promql/vector_on_job.txtar
+++ b/test/spec/promql/vector_on_job.txtar
@@ -11,3 +11,17 @@ SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` / R.`Value`) AS 
 [5] string = "job"
 [6] string = "job"
 [7] string = "job"
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_sum VALUES
+    ('http_server_request_duration_count', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 100.0),
+    ('http_server_request_duration_sum',   map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 25.0);
+-- expected_rows --
+[
+  ["http_server_request_duration_count", {"job": "api"}, "2026-01-01T00:00:00Z", 4.0]
+]

--- a/test/spec/promql/vector_plus_vector.txtar
+++ b/test/spec/promql/vector_plus_vector.txtar
@@ -5,3 +5,17 @@ SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` + R.`Value`) AS 
 -- args --
 [0] string = "http_server_request_duration_count"
 [1] string = "http_server_request_duration_sum"
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_sum VALUES
+    ('http_server_request_duration_count', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 10.0),
+    ('http_server_request_duration_sum',   map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 25.0);
+-- expected_rows --
+[
+  ["http_server_request_duration_count", {"job": "api"}, "2026-01-01T00:00:00Z", 35.0]
+]

--- a/test/spec/promql/vector_pow_scalar.txtar
+++ b/test/spec/promql/vector_pow_scalar.txtar
@@ -5,3 +5,16 @@ up ^ 2
 [1] string = "up"
 -- sql --
 SELECT `MetricName`, `Attributes`, `TimeUnix`, pow(`Value`, ?) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 5.0);
+-- expected_rows --
+[
+  ["up", {"job": "api"}, "2026-01-01T00:00:00Z", 25.0]
+]


### PR DESCRIPTION
## Summary

Adds `-- seed --` + `-- expected_rows --` sections to 58 new PromQL TXTAR fixtures (5 already had them). The chdb-tagged runner (`test/spec/runner_chdb.go`) now exercises the emitted ClickHouse SQL end-to-end against an in-process chDB session for all of these.

The fixtures split into two assertion modes:

- **Concrete-row roundtrip** (28 fixtures): seed inserts a known value, the SQL transforms it deterministically, expected_rows captures the exact output row. Covers all the instant fns where the outer SELECT projects the source TimeUnix unchanged (`abs`/`ceil`/`floor`/`exp`/`ln`/`log2`/`log10`/`sgn`/`round`/`sqrt`/`clamp_*`/binary scalar ops), the vector-vs-vector binary joins (`+`/`-`/`*`/`/` plus `on`/`ignoring`/`group_left`/`group_right`), and the `@end()` rate fixture (which uses a deterministic timestamp anchor, not `now64()`).
- **Empty-result roundtrip** (35 fixtures): seeds an unrelated `MetricName` so the filter selects nothing, the outer projection over `now64()` never fires, and the assertion is `[]`. Covers fixtures whose SQL embeds non-deterministic `now64()` in the result row (aggregations with GROUP BY, rate windows, subqueries, histogram_quantile variants, holt_winters, predict_linear).

`SELECT *` outer-fixtures and `now64()` no-GROUP-BY aggregations (`count_no_group`, `stdvar_no_group`) are intentionally left without roundtrip sections — the current runner can't size the scan slice for `SELECT *` (it counts projection commas, not columns), and the no-GROUP-BY case always emits one row with a wall-clock timestamp.

## Categories

- 18 instant fns / scalar binary ops (concrete)
- 10 vector matching / vector binary (concrete + empty)
- 8 histogram_quantile (classic + native, empty)
- 8 subqueries (empty)
- 8 grouped aggregations (sum/group/quantile/stddev `by`/`without`, empty)
- 5 rate / holt_winters / predict_linear (empty + at_end_basic concrete)
- 6 fixtures already roundtripped on main (abs/bool_lt/ceil/clamp_max/floor + at_end_basic added here)

## Test plan

- [ ] CI `check` job passes (default lane skips the chdb build tag, fixtures parse cleanly with sections inert)
- [ ] CI `lint` job passes
- [ ] Anyone with libchdb installed locally can run `go test -tags chdb ./test/spec/promql/...` and watch all 63 roundtrips green