### PR TITLE
fix(api/prom): empty label/values/series responses return [], not null

### DIFF
--- a/internal/api/prom/conformance_test.go
+++ b/internal/api/prom/conformance_test.go
@@ -276,9 +276,6 @@ func TestConformance_LabelValuesWire(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			if tc.name == "label_empty_result" {
-				t.Skip("TODO: handler returns `null` instead of `[]` when no values match; handler-side fix follow-up")
-			}
 			srv := newServer(&stubQuerier{strings: tc.rows})
 			t.Cleanup(srv.Close)
 

--- a/internal/api/prom/metadata.go
+++ b/internal/api/prom/metadata.go
@@ -40,6 +40,12 @@ func (h *Handler) handleLabels(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Wire-format contract: Prometheus emits `"data":[]` (not null) when
+	// the result set is empty. JSON-marshalling a nil []string yields
+	// `null`, which Grafana's discovery probes reject.
+	if names == nil {
+		names = []string{}
+	}
 	writeJSON(w, http.StatusOK, Response{
 		Status: "success",
 		Data:   names,
@@ -80,6 +86,12 @@ func (h *Handler) handleLabelValues(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Wire-format contract: Prometheus emits `"data":[]` (not null) when
+	// no values match. JSON-marshalling a nil []string yields `null`,
+	// which Grafana's label/values probe rejects.
+	if values == nil {
+		values = []string{}
+	}
 	writeJSON(w, http.StatusOK, Response{
 		Status: "success",
 		Data:   values,


### PR DESCRIPTION
## Summary

Prometheus wire-format requires `"data":[]` (non-null JSON array) when the result set is empty. JSON-marshalling a nil `[]string` yields `null`, which Grafana's discovery probes reject.

Normalises `handleLabels` and `handleLabelValues` (`internal/api/prom/metadata.go`) to convert a nil slice returned from `fetchLabelNames` / `fetchLabelValues` into `[]string{}` before rendering the response. The nil bubbles up from `chclient.QueryStrings`, which appends to a nil slice and therefore returns nil on empty result sets.

`handleSeries` already pre-allocates with `make([]map[string]string, 0, len(seen))`, so its empty-result path renders as `[]` correctly. No change there.

## Test

Un-skips `TestConformance_LabelValuesWire/label_empty_result` in `internal/api/prom/conformance_test.go` (was skipped with a TODO referencing this exact fix). The test asserts that `env.Data == nil` is an error — i.e. `"data":null` on the wire would fail.

## Test plan
- [x] `TestConformance_LabelValuesWire/label_empty_result` passes locally (covered by CI `check`)
- [ ] CI `check` + `lint` green