### PR TITLE
fix(chclient): wrap rowsCursor.Close in sync.Once

### DIFF
--- a/internal/chclient/cursor.go
+++ b/internal/chclient/cursor.go
@@ -3,6 +3,7 @@ package chclient
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"go.opentelemetry.io/otel/trace"
@@ -45,6 +46,12 @@ type rowsCursor struct {
 	// observe the per-query total exactly once — irrespective of how
 	// long the caller takes to drain rows.
 	rec *progressRecorder
+	// closeOnce serialises Close() so the span / rec / rows nil-outs
+	// happen exactly once, even under concurrent Close calls (e.g. a
+	// caller's `defer cursor.Close()` racing a context-cancellation
+	// path that also calls Close).
+	closeOnce sync.Once
+	closeErr  error
 }
 
 // Next advances the cursor to the next row. Returns false when the
@@ -81,32 +88,36 @@ func (c *rowsCursor) Sample() Sample { return c.cur }
 func (c *rowsCursor) Err() error { return c.err }
 
 // Close releases the underlying driver.Rows. Safe to call multiple
-// times; subsequent calls are no-ops once the resource is released.
+// times AND from multiple goroutines concurrently; the underlying
+// teardown runs exactly once via sync.Once, and subsequent calls return
+// the same error the first call returned.
 //
 // The first call also flushes the progress recorder so the per-query
 // rows/bytes histograms see the totals exactly once. Subsequent calls
-// skip the flush (rec is nil'd after the first run).
+// are no-ops.
 func (c *rowsCursor) Close() error {
-	if c.span != nil {
-		if c.err != nil {
-			c.span.RecordError(c.err)
+	c.closeOnce.Do(func() {
+		if c.span != nil {
+			if c.err != nil {
+				c.span.RecordError(c.err)
+			}
+			c.span.End()
+			c.span = nil
 		}
-		c.span.End()
-		c.span = nil
-	}
-	if c.rec != nil {
-		c.rec.flush()
-		c.rec = nil
-	}
-	if c.rows == nil {
-		return nil
-	}
-	err := c.rows.Close()
-	c.rows = nil
-	if err != nil {
-		return fmt.Errorf("chclient: rows.Close: %w", err)
-	}
-	return nil
+		if c.rec != nil {
+			c.rec.flush()
+			c.rec = nil
+		}
+		if c.rows == nil {
+			return
+		}
+		err := c.rows.Close()
+		c.rows = nil
+		if err != nil {
+			c.closeErr = fmt.Errorf("chclient: rows.Close: %w", err)
+		}
+	})
+	return c.closeErr
 }
 
 // QueryCursor runs sql with positional args and returns a forward-only

--- a/internal/chclient/cursor_chaos_test.go
+++ b/internal/chclient/cursor_chaos_test.go
@@ -1,0 +1,70 @@
+package chclient
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// closeCounterRows is a driver.Rows fake whose Close counts invocations.
+// Used to assert that under N concurrent rowsCursor.Close() callers, the
+// underlying driver.Rows.Close is invoked exactly once — the sync.Once
+// contract on rowsCursor.
+type closeCounterRows struct {
+	fakeRows
+	closeCalls atomic.Int32
+}
+
+func (r *closeCounterRows) Close() error {
+	r.closeCalls.Add(1)
+	return r.fakeRows.Close()
+}
+
+// TestCursor_ConcurrentClose stresses rowsCursor.Close from many
+// goroutines simultaneously. Without sync.Once, the body would race the
+// nil-outs of c.rows / c.span / c.rec and (under -race) the race
+// detector would fire. With sync.Once, the body runs exactly once and
+// every concurrent caller observes the same closeErr return.
+//
+// Layer 11 (chaos / failure-mode) regression coverage.
+func TestCursor_ConcurrentClose(t *testing.T) {
+	t.Parallel()
+
+	const goroutines = 64
+
+	rows := &closeCounterRows{}
+	cursor := &rowsCursor{rows: rows}
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	start := make(chan struct{})
+	errs := make([]error, goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			<-start
+			errs[idx] = cursor.Close()
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	// Every caller must see the same outcome — here, nil.
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("goroutine %d: Close: %v", i, err)
+		}
+	}
+
+	if got := rows.closeCalls.Load(); got != 1 {
+		t.Errorf("underlying rows.Close: got %d calls, want 1", got)
+	}
+
+	// A subsequent serial Close must still be a no-op (idempotent).
+	if err := cursor.Close(); err != nil {
+		t.Errorf("post-race Close: %v", err)
+	}
+	if got := rows.closeCalls.Load(); got != 1 {
+		t.Errorf("after post-race Close: got %d calls, want 1", got)
+	}
+}


### PR DESCRIPTION
## Summary

`rowsCursor.Close()` nil-outs `c.rows` / `c.span` / `c.rec` without a mutex (`internal/chclient/cursor.go`). Concurrent `Close()` calls — for example a caller's `defer cursor.Close()` racing a context-cancellation path that also closes — race on those fields and on the underlying `driver.Rows.Close()` invocation. Under `go test -race` this fires the race detector.

Wraps the `Close` body in `sync.Once` and latches the resulting error in a new `closeErr` field so every caller observes the same outcome. The underlying `rows.Close` now runs exactly once, and `span.End` / `rec.flush` are guaranteed to fire at most once for the per-query rows/bytes_read histograms.

## Test

Adds `internal/chclient/cursor_chaos_test.go::TestCursor_ConcurrentClose` (Layer 11 chaos / failure-mode coverage). Fires 64 goroutines at `Close` simultaneously; a counter-fake `driver.Rows` asserts the underlying `Close` runs exactly once. Without `sync.Once`, `go test -race` would flag the field nil-out races.

## Test plan
- [x] `TestCursor_ConcurrentClose` passes under `-race`
- [ ] CI `check` + `lint` green