### PR TITLE
ci(gremlins): phase 1 — chplan as kill-zone, threshold 80%

### DIFF
--- a/.gremlins.yaml
+++ b/.gremlins.yaml
@@ -31,5 +31,25 @@ excluded-files:
   - "internal/api/**"
   - "cmd/**"
   - "**/doc.go"
-threshold-efficacy: 60
+
+# Phased mutation-testing rollout. Layer 3 (PR #247) added ~125
+# invariant tests across internal/chplan, so chplan is the first
+# package dense enough to meet an 80% efficacy bar. The other
+# kill-zone packages onboard once their coverage catches up:
+#
+#   Phase 1 (this file):    internal/chplan       @ 80% efficacy
+#   Phase 2 (planned):      internal/chsql        @ 75% efficacy
+#   Phase 3 (planned):      internal/optimizer    @ 70% efficacy
+#   Phase 4 (planned):      QL parsers + lower    @ 65% efficacy
+#                           then promote gremlins to a required gate.
+#
+# The thresholds below are GLOBAL (gremlins v0.6.0 does not support
+# per-package thresholds — see `gremlins unleash --help`). To enforce
+# the per-phase bar without dragging the slower packages down, run
+# gremlins scoped to one package at a time in CI via
+# `gremlins unleash --threshold-efficacy <bar> ./internal/<pkg>/...`
+# in the workflow rather than the global config. The values below are
+# the floor for the whole-repo `just mutate` invocation and stay
+# informational until phase 4.
+threshold-efficacy: 80
 threshold-mcover: 50

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -149,6 +149,25 @@ semantically equivalent — the optimizer property test still passes,
 and so do the round-trip fixtures). That sharpens the score over
 the default lane, which would score a string-equality false-kill.
 
+### Phased rollout
+
+The whole-repo `threshold-efficacy` bar is global (gremlins v0.6.0
+has no per-package threshold). The rollout is therefore staged: each
+phase raises the global bar only once the next-most-covered package
+catches up, and promotion to a required CI gate waits for phase 4.
+
+| Phase                            | Package              | Target efficacy |
+| -------------------------------- | -------------------- | --------------- |
+| 1 (active — `.gremlins.yaml`)    | `internal/chplan`    | 80%             |
+| 2 (planned)                      | `internal/chsql`     | 75%             |
+| 3 (planned)                      | `internal/optimizer` | 70%             |
+| 4 (planned, then required gate)  | QL parsers + lower   | 65%             |
+
+Until phase 4, `just mutate` (and the `mutation` workflow that wraps
+it) stays informational. The thresholds are advisory floors only —
+contributors do NOT have to land mutation-killing tests with every
+PR.
+
 The recipe is slow (tens of minutes) and informational only —
 neither `just mutate` nor `just mutate-chdb` is on a required CI
 path today.


### PR DESCRIPTION
## Summary

Layer 3 (PR #247) added ~125 invariant tests across `internal/chplan` (Equal / Walk / Children, deep-sentinel coverage for two-sided joins, NaN-equals-NaN on `LitFloat`). The package is now dense enough to meet an 80% efficacy bar — enable it as the phase-1 mutation kill-zone.

## Phased rollout

| Phase                            | Package              | Target efficacy |
| -------------------------------- | -------------------- | --------------- |
| 1 (this PR — `.gremlins.yaml`)   | `internal/chplan`    | 80%             |
| 2 (planned)                      | `internal/chsql`     | 75%             |
| 3 (planned)                      | `internal/optimizer` | 70%             |
| 4 (planned, then required gate)  | QL parsers + lower   | 65%             |

Per-package thresholds are NOT supported by gremlins v0.6.0 (`gremlins unleash --help` exposes only global `--threshold-efficacy` / `--threshold-mcover`). The 80% bar therefore lives on the global config field. Future phases will run gremlins scoped to one package at a time in CI via `gremlins unleash --threshold-efficacy <bar> ./internal/<pkg>/...` to enforce per-phase bars without dragging slower packages down — captured as a comment in `.gremlins.yaml` and a phased-rollout section in `docs/test-strategy.md`.

`internal/chplan` is already absent from `excluded-files` (the list excludes `**/*_test.go`, `internal/api/**`, `cmd/**`, `**/doc.go`), so no exclusion changes are needed.

## Workflow status

`.github/workflows/mutation.yml` is unchanged — still push-to-main + nightly + `workflow_dispatch`, informational only. No promotion to a required gate yet (that is phase 4 after all four packages stabilise).

## Test plan
- [x] `gremlins unleash --help` confirms per-package thresholds aren't supported
- [x] `internal/chplan` not in `excluded-files`
- [x] `.github/workflows/mutation.yml` still informational
- [ ] CI `check` + `lint` green