### PR TITLE
test(e2e/playwright): add ~50 UX flows across Prom/Loki/Tempo + cross-DS

### DIFF
--- a/test/e2e/playwright/cross_datasource.spec.ts
+++ b/test/e2e/playwright/cross_datasource.spec.ts
@@ -1,0 +1,154 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Cross-datasource UX flows.
+ *
+ * These specs validate the "jump from datasource X to datasource Y"
+ * flows Grafana users rely on — log↔trace derived fields, span↔logs
+ * shortcut, metric↔logs context, trace↔service metrics — by issuing
+ * the same datasource-proxy calls each side of the jump would.
+ *
+ * Important seed-shape note (test/e2e/seed/cmd/seed/main.go):
+ *   • otel_logs.TraceId values are `lpad(number%4, 32, '0')` — i.e.
+ *     `00000000000000000000000000000000…0003`.
+ *   • otel_traces.TraceId values are `a0000000000000000000000000000001…0003`.
+ *   These do NOT overlap. So a "click traceID in log → open trace"
+ *   round-trip with the actual seed data would 404. We assert the
+ *   endpoint contract (the wire format the Grafana derived-field
+ *   link follows) on both sides — but pin the trace lookup to a
+ *   seeded ID so the spec stays deterministic.
+ */
+
+const promProxy = '/api/datasources/proxy/uid/cerberus-prometheus/api/v1';
+const lokiProxy = '/api/datasources/proxy/uid/cerberus-loki/loki/api/v1';
+const tempoProxy = '/api/datasources/proxy/uid/cerberus-tempo/api';
+
+test.describe('Cross-datasource — derived-field & shortcut flows', () => {
+  test('log → trace: log line carries traceID, trace endpoint accepts a (seeded) ID', async ({
+    request,
+  }) => {
+    // Step 1: fetch a Loki line. Cerberus surfaces TraceId either as a
+    // stream label or embedded in the line payload — either way the
+    // derived-field regex in Grafana extracts the hex blob and uses
+    // it as the `${__value.raw}` substitution in the trace URL.
+    const q = encodeURIComponent('{service_name="api"}');
+    const lokiResp = await request.get(`${lokiProxy}/query?query=${q}`);
+    expect(lokiResp.status(), 'log fetch 200').toBe(200);
+    const lokiBody = await lokiResp.json();
+    expect(lokiBody.data.resultType).toBe('streams');
+    expect(lokiBody.data.result.length, '≥1 stream returned').toBeGreaterThan(0);
+
+    // Step 2: the trace-lookup endpoint resolves a seeded trace ID
+    // (we don't reuse the actual log TraceId because the seed
+    // intentionally doesn't align them — see file header).
+    const seededTrace = 'a0000000000000000000000000000001';
+    const tempoResp = await request.get(`${tempoProxy}/traces/${seededTrace}`);
+    expect(tempoResp.status(), 'trace lookup 200').toBe(200);
+    const tempoBody = await tempoResp.json();
+    expect(Array.isArray(tempoBody.batches), 'batches array').toBe(true);
+    expect(tempoBody.batches.length, '≥1 batch').toBeGreaterThan(0);
+  });
+
+  test('span → logs: a seeded trace yields spans → Loki filter by trace = traceID works', async ({
+    request,
+  }) => {
+    // Step 1: fetch a trace's spans.
+    const tempoResp = await request.get(
+      `${tempoProxy}/traces/a0000000000000000000000000000001`,
+    );
+    expect(tempoResp.status()).toBe(200);
+    const tempoBody = await tempoResp.json();
+    expect(tempoBody.batches.length, '≥1 batch in trace').toBeGreaterThan(0);
+
+    // Step 2: simulate the "Logs for this trace" shortcut Grafana
+    // builds — a LogQL stream selector with the trace_id matcher.
+    // Because the seed deliberately doesn't align log/trace IDs, we
+    // confirm the endpoint accepts the well-formed query (200) — not
+    // that it returns rows.
+    const q = encodeURIComponent(
+      '{service_name="api"} |= "trace_id=a0000000000000000000000000000001"',
+    );
+    const lokiResp = await request.get(`${lokiProxy}/query?query=${q}`);
+    expect(lokiResp.status(), 'shortcut query 200').toBe(200);
+    const lokiBody = await lokiResp.json();
+    expect(lokiBody.status).toBe('success');
+  });
+
+  test('metric → logs: spike in `up` → Loki context query for the same service', async ({
+    request,
+  }) => {
+    // Grafana's "view logs for this metric" context menu opens an
+    // Explore Logs view with a stream selector built from the
+    // hovered metric's labels. The seed has up{job="api"} and
+    // log lines with {service_name="api"}.
+    const promResp = await request.get(`${promProxy}/query?query=up%7Bjob%3D%22api%22%7D`);
+    expect(promResp.status()).toBe(200);
+    const promBody = await promResp.json();
+    expect(promBody.data.result.length, '≥1 up series').toBeGreaterThan(0);
+    // The matching log query Grafana would open.
+    const q = encodeURIComponent('{service_name="api"}');
+    const lokiResp = await request.get(`${lokiProxy}/query?query=${q}`);
+    expect(lokiResp.status()).toBe(200);
+    const lokiBody = await lokiResp.json();
+    expect(lokiBody.data.result.length, '≥1 log stream for api').toBeGreaterThan(0);
+  });
+
+  test('trace → metrics: from a trace, the service’s `up` metric is queryable', async ({
+    request,
+  }) => {
+    // Grafana's "Service metrics" link from the trace panel builds
+    // a /api/v1/query targeting the same service label as the trace.
+    const tempoResp = await request.get(
+      `${tempoProxy}/traces/a0000000000000000000000000000001`,
+    );
+    expect(tempoResp.status()).toBe(200);
+
+    // Pivot — Grafana would build a query like `up{job="api"}` from
+    // the resource.service.name attribute.
+    const promResp = await request.get(`${promProxy}/query?query=up%7Bjob%3D%22api%22%7D`);
+    expect(promResp.status()).toBe(200);
+    const promBody = await promResp.json();
+    expect(promBody.status).toBe('success');
+    expect(promBody.data.result.length, '≥1 api up series').toBeGreaterThan(0);
+  });
+
+  test('three-datasource burst: all healthy under concurrent load', async ({ request }) => {
+    // A Grafana dashboard panel mix can fire 3+ parallel calls
+    // across the three datasources. Cerberus is a single backend
+    // serving all three, so we assert health isn't a function of
+    // concurrent multi-DS load.
+    const probes = [
+      request.get(`${promProxy}/query?query=1%2B1`),
+      request.get(`${promProxy}/query?query=up`),
+      request.get(`${lokiProxy}/labels`),
+      request.get(`${lokiProxy}/query?query=${encodeURIComponent('{service_name="api"}')}`),
+      request.get(`${tempoProxy}/echo`),
+      request.get(`${tempoProxy}/status/version`),
+    ];
+    const results = await Promise.all(probes);
+    for (const r of results) {
+      expect(r.status(), `parallel probe ${r.url()} → 200`).toBe(200);
+    }
+  });
+
+  test('datasource health: re-running the three Grafana probes is idempotent', async ({
+    request,
+  }) => {
+    // Each of these is what Grafana fires when the user clicks
+    // "Test datasource" in the settings page. Run twice to confirm
+    // the probe is stateless (no first-call caching, no second-call
+    // failure).
+    for (let i = 0; i < 2; i++) {
+      const prom = await request.get(`${promProxy}/query?query=1%2B1`);
+      expect(prom.status(), `prom probe attempt ${i + 1}`).toBe(200);
+      const promBody = await prom.json();
+      expect(promBody.data.resultType).toBe('scalar');
+
+      const loki = await request.get(`${lokiProxy}/labels`);
+      expect(loki.status(), `loki probe attempt ${i + 1}`).toBe(200);
+
+      const tempo = await request.get(`${tempoProxy}/echo`);
+      expect(tempo.status(), `tempo probe attempt ${i + 1}`).toBe(200);
+    }
+  });
+});

--- a/test/e2e/playwright/loki_ux.spec.ts
+++ b/test/e2e/playwright/loki_ux.spec.ts
@@ -1,0 +1,249 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * LogQL UX flows.
+ *
+ * Mirrors the request sequence Grafana's Logs panel + Explore Logs UI
+ * issue against a Loki datasource. Each spec exercises a UX flow
+ * (level coloring, line filters, detected fields, patterns, log↔trace
+ * link, histogram, ...) by hitting the cerberus-loki datasource proxy.
+ *
+ * Seed shape (test/e2e/seed/cmd/seed/main.go):
+ *   • otel_logs: 60 rows spaced 1 s apart over the last minute, three
+ *     services (api / frontend / db). SeverityNumber cycles {17, 13, 9}
+ *     and SeverityText cycles {ERROR, WARN, INFO}. Body has the form
+ *     "<message> id=<n>" — useful as a line-filter substring target.
+ */
+
+const lokiProxy = '/api/datasources/proxy/uid/cerberus-loki/loki/api/v1';
+
+// Helper: a fresh "last 5 minutes" window in unix seconds.
+function last5MinWindow(): { start: number; end: number } {
+  const end = Math.floor(Date.now() / 1000);
+  return { start: end - 5 * 60, end };
+}
+
+test.describe('Loki UX — Logs panel flows', () => {
+  test('logs panel: severity is exposed per stream (level coloring source)', async ({
+    request,
+  }) => {
+    // Grafana's logs panel colours rows by detected severity. The
+    // colour mapping reads from a `severity` / `level` / `detected_level`
+    // label or the OTel SeverityText that surfaces as a stream label.
+    const q = encodeURIComponent('{service_name="api"}');
+    const resp = await request.get(`${lokiProxy}/query?query=${q}`);
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(body.data.resultType).toBe('streams');
+    // At least one stream should carry a label (so the panel can group).
+    expect(body.data.result.length).toBeGreaterThan(0);
+    for (const stream of body.data.result) {
+      expect(Object.keys(stream.stream).length, 'stream has ≥1 label').toBeGreaterThan(0);
+    }
+  });
+
+  test('logs panel: line filter `|=` substring narrows results', async ({ request }) => {
+    // Seed body has `... id=<n>` on every row, so the substring
+    // matches every line.
+    const q = encodeURIComponent('{service_name="api"} |= "id="');
+    const resp = await request.get(`${lokiProxy}/query?query=${q}`);
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(body.status).toBe('success');
+    expect(body.data.resultType).toBe('streams');
+    for (const stream of body.data.result) {
+      for (const [, line] of stream.values) {
+        expect(typeof line).toBe('string');
+        expect(line, 'every line contains the filter literal').toContain('id=');
+      }
+    }
+  });
+
+  test('logs panel: negative line filter `!=` excludes substring', async ({ request }) => {
+    // No seed line contains the literal "this-string-does-not-exist",
+    // so the filter is the empty-set case — still a successful empty
+    // streams response, not an error.
+    const q = encodeURIComponent('{service_name="api"} != "id="');
+    const resp = await request.get(`${lokiProxy}/query?query=${q}`);
+    expect(resp.status(), 'negative filter still 200').toBe(200);
+    const body = await resp.json();
+    expect(body.status).toBe('success');
+    // Either zero results or zero values per stream — both fine.
+    let total = 0;
+    for (const s of body.data.result) {
+      total += s.values.length;
+    }
+    expect(total, 'no lines contain "id=" once filtered out').toBe(0);
+  });
+
+  test('logs panel: regex line filter `|~` is a 200 ✓', async ({ request }) => {
+    // Every seed line has the digit pattern `id=<n>` so the regex
+    // `id=\\d+` matches every line.
+    const q = encodeURIComponent('{service_name="api"} |~ "id=\\\\d+"');
+    const resp = await request.get(`${lokiProxy}/query?query=${q}`);
+    expect(resp.status(), 'regex filter status').toBe(200);
+    const body = await resp.json();
+    expect(body.status).toBe('success');
+  });
+
+  test('logs panel: chained line filters compose', async ({ request }) => {
+    // `|= "id="` then `!~ "id=9999"` — the second filter is ineffective
+    // (no seed row has id=9999) but the chain should parse and run.
+    const q = encodeURIComponent('{service_name="api"} |= "id=" !~ "id=9999"');
+    const resp = await request.get(`${lokiProxy}/query?query=${q}`);
+    expect(resp.status(), 'chained filter status').toBe(200);
+    const body = await resp.json();
+    expect(body.status).toBe('success');
+    expect(body.data.result.length, '≥1 stream after chain').toBeGreaterThan(0);
+  });
+
+  test('detected fields: side-panel API returns extractable keys', async ({ request }) => {
+    // The Logs panel "Detected fields" side panel calls
+    // /loki/api/v1/detected_fields. The seed bodies are plain text
+    // (not JSON), so the heuristic should still return a deterministic
+    // (possibly empty) fields array — what matters is the envelope.
+    const { start, end } = last5MinWindow();
+    const q = encodeURIComponent('{service_name="api"}');
+    const url = `${lokiProxy}/detected_fields?query=${q}&start=${start * 1e9}&end=${end * 1e9}`;
+    const resp = await request.get(url);
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(body.status).toBe('success');
+    expect(Array.isArray(body.data.fields), 'data.fields is an array').toBe(true);
+    expect(typeof body.data.limit, 'data.limit is numeric').toBe('number');
+    expect(typeof body.data.line_limit, 'data.line_limit is numeric').toBe('number');
+  });
+
+  test('patterns: the /patterns endpoint returns the data.patterns envelope', async ({
+    request,
+  }) => {
+    // Grafana's "Patterns" tab calls /loki/api/v1/patterns. Cerberus's
+    // first cut returns an empty `patterns: []` envelope (drain3 isn't
+    // wired yet) — the wire-shape assertion still pins the contract.
+    const { start, end } = last5MinWindow();
+    const q = encodeURIComponent('{service_name="api"}');
+    const url = `${lokiProxy}/patterns?query=${q}&start=${start * 1e9}&end=${end * 1e9}`;
+    const resp = await request.get(url);
+    expect(resp.status(), 'patterns status').toBe(200);
+    const body = await resp.json();
+    expect(body.status).toBe('success');
+    expect(Array.isArray(body.data.patterns), 'data.patterns is an array').toBe(true);
+  });
+
+  test('time range: only logs within the start/end window render', async ({ request }) => {
+    // Pick a 30-second window in the very recent past — the seed
+    // packs 60 rows into the last minute so at least some land in it.
+    const end = Math.floor(Date.now() / 1000);
+    const start = end - 30;
+    const q = encodeURIComponent('{service_name="api"}');
+    const url = `${lokiProxy}/query_range?query=${q}&start=${start}&end=${end}&step=10`;
+    const resp = await request.get(url);
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(body.status).toBe('success');
+    // Every value tuple should be a [tsNs, line] pair where tsNs falls
+    // within the window (in nanoseconds).
+    const startNs = start * 1e9;
+    const endNs = end * 1e9;
+    for (const s of body.data.result) {
+      if (!s.values || s.values.length === 0) continue;
+      // Only need to test the metric type (matrix) entries:
+      // for streams, values are [tsNs, line]; for matrix, [tsSec, val].
+      // matrix wraps numbers as strings.
+      const [ts] = s.values[0];
+      if (body.data.resultType === 'streams') {
+        const tsNum = Number(ts);
+        expect(tsNum, 'ts in window').toBeGreaterThanOrEqual(startNs - 1e9);
+        expect(tsNum, 'ts in window').toBeLessThanOrEqual(endNs + 1e9);
+      }
+    }
+  });
+
+  test('logql aggregation: `rate({…}[1m])` produces a matrix not streams', async ({ request }) => {
+    // The metric tab in Explore renders a chart for the rate() result.
+    // The shape must be matrix, not streams.
+    const now = Math.floor(Date.now() / 1000);
+    const start = now - 5 * 60;
+    const q = encodeURIComponent('rate({service_name="api"}[1m])');
+    const url = `${lokiProxy}/query_range?query=${q}&start=${start}&end=${now}&step=30`;
+    const resp = await request.get(url);
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(body.status).toBe('success');
+    expect(body.data.resultType).toBe('matrix');
+    expect(body.data.result.length, '≥1 metric series').toBeGreaterThan(0);
+  });
+
+  test('parser stage `| json` returns 422 (documented deferral until RC3)', async ({ request }) => {
+    // Grafana surfaces this 422 as a yellow "query not yet supported"
+    // warning, not a hard red error. Asserting the contract so when
+    // RC3 lands `| json`, this spec goes red and the deferral marker
+    // can be removed.
+    const q = encodeURIComponent('{service_name="api"} | json');
+    const resp = await request.get(`${lokiProxy}/query?query=${q}`);
+    expect(resp.status(), '422 unprocessable entity').toBe(422);
+    const body = await resp.json();
+    expect(body.status).toBe('error');
+    expect(String(body.error || '').toLowerCase()).toContain('json');
+  });
+
+  test('parser stage `| logfmt` returns 422 (documented deferral)', async ({ request }) => {
+    const q = encodeURIComponent('{service_name="api"} | logfmt');
+    const resp = await request.get(`${lokiProxy}/query?query=${q}`);
+    expect(resp.status()).toBe(422);
+    const body = await resp.json();
+    expect(body.status).toBe('error');
+  });
+
+  test('post-fetch `| line_format` renders templated lines', async ({ request }) => {
+    // line_format is a post-fetch transform — every Body is rewritten
+    // before the streams shape goes out the door.
+    const q = encodeURIComponent('{service_name="api"} | line_format "FMT: {{.__line__}}"');
+    const resp = await request.get(`${lokiProxy}/query?query=${q}`);
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(body.data.resultType).toBe('streams');
+    for (const stream of body.data.result) {
+      for (const [, line] of stream.values) {
+        expect(line, 'line starts with FMT:').toMatch(/^FMT:/);
+      }
+    }
+  });
+
+  test('histogram panel: /loki/api/v1/index/volume returns the volume time series', async ({
+    request,
+  }) => {
+    // The Logs Histogram panel reads /index/volume to render the
+    // "log volume" bar chart above the log lines.
+    const { start, end } = last5MinWindow();
+    const q = encodeURIComponent('{service_name="api"}');
+    const url = `${lokiProxy}/index/volume?query=${q}&start=${start * 1e9}&end=${end * 1e9}`;
+    const resp = await request.get(url);
+    expect(resp.status(), 'index/volume status').toBe(200);
+    const body = await resp.json();
+    expect(body.status).toBe('success');
+    expect(body.data.resultType, 'volume → vector').toBe('vector');
+  });
+
+  test('labels endpoint populates the stream-selector dropdown', async ({ request }) => {
+    // The stream-selector dropdown in Explore Logs reads
+    // /loki/api/v1/labels. The seed populates ResourceAttributes
+    // with `service_name`.
+    const resp = await request.get(`${lokiProxy}/labels`);
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(body.status).toBe('success');
+    expect(body.data, 'service_name in labels').toContain('service_name');
+  });
+
+  test('label values populate the per-label dropdown', async ({ request }) => {
+    const resp = await request.get(`${lokiProxy}/label/service_name/values`);
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(body.status).toBe('success');
+    expect(Array.isArray(body.data)).toBe(true);
+    expect(body.data, 'api in service_name values').toContain('api');
+    // Seed inserts 3 services (api / frontend / db).
+    expect(body.data.length, '3 distinct services').toBeGreaterThanOrEqual(3);
+  });
+});

--- a/test/e2e/playwright/prom_ux.spec.ts
+++ b/test/e2e/playwright/prom_ux.spec.ts
@@ -1,0 +1,280 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * PromQL UX flows.
+ *
+ * Mirrors the request sequence Grafana's Explore page / Dashboard
+ * panels issue when a user interacts with the cerberus-Prometheus
+ * datasource. Each spec exercises a flow shape (label-browser,
+ * metric-picker, query inspector, multi-query, format-as, ...) by
+ * hitting the same datasource-proxy endpoints Grafana hits
+ * internally — same on-the-wire conversation, no real browser.
+ *
+ * Seed shape (test/e2e/seed/cmd/seed/main.go):
+ *   • otel_metrics_gauge: 2× `up` series, Attributes.job ∈ {api, db}
+ *   • otel_metrics_sum:   60× `http_server_request_duration_count`,
+ *                         Attributes.job = api, Attributes.http_status = 200,
+ *                         spaced 1s apart over the last minute.
+ */
+
+const promProxy = '/api/datasources/proxy/uid/cerberus-prometheus/api/v1';
+
+// `cerberus-prometheus` always returns success on a degenerate
+// /api/v1/query?query=up call; reused as a precondition for the few
+// tests that don't open with their own assertion.
+
+test.describe('Prom UX — Explore flows', () => {
+  test('explore: instant query returns a vector', async ({ request }) => {
+    const resp = await request.get(`${promProxy}/query?query=up`);
+    expect(resp.status(), 'instant query status').toBe(200);
+    const body = await resp.json();
+    expect(body.status).toBe('success');
+    expect(body.data.resultType, 'instant → vector').toBe('vector');
+    expect(body.data.result.length).toBeGreaterThan(0);
+  });
+
+  test('explore: switch instant → range yields matrix shape', async ({ request }) => {
+    const now = Math.floor(Date.now() / 1000);
+    const start = now - 5 * 60;
+    const url = `${promProxy}/query_range?query=up&start=${start}&end=${now}&step=30`;
+    const resp = await request.get(url);
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(body.status).toBe('success');
+    expect(body.data.resultType, 'range → matrix').toBe('matrix');
+    expect(body.data.result.length, 'range yields ≥1 series').toBeGreaterThan(0);
+    // Every series should carry a values array of [ts, val] tuples.
+    for (const s of body.data.result) {
+      expect(Array.isArray(s.values)).toBe(true);
+    }
+  });
+
+  test('explore: table-view query (vector resultType is what the Table panel renders)', async ({
+    request,
+  }) => {
+    // Grafana's "Table" format-as for a Prometheus query is exactly an
+    // instant /api/v1/query — same vector shape, different rendering.
+    // We assert the shape Grafana parses into columns.
+    const resp = await request.get(`${promProxy}/query?query=up`);
+    const body = await resp.json();
+    expect(body.data.resultType).toBe('vector');
+    for (const sample of body.data.result) {
+      expect(sample.metric, 'each row has labels').toBeTruthy();
+      expect(Array.isArray(sample.value), 'each row has [ts, val]').toBe(true);
+      expect(sample.value.length).toBe(2);
+    }
+  });
+
+  test('label browser: /api/v1/labels populates the label dropdown', async ({ request }) => {
+    const resp = await request.get(`${promProxy}/labels`);
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(body.status).toBe('success');
+    expect(Array.isArray(body.data)).toBe(true);
+    // The seed inserts `job` and `http_status` as Attributes keys.
+    expect(body.data, 'job in label list').toContain('job');
+    // The synthetic __name__ should always be present.
+    expect(body.data, '__name__ in label list').toContain('__name__');
+  });
+
+  test('metric picker: /api/v1/metadata returns seeded metric descriptions', async ({
+    request,
+  }) => {
+    const resp = await request.get(`${promProxy}/metadata`);
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(body.status).toBe('success');
+    expect(typeof body.data, 'metadata data is an object').toBe('object');
+    // Both seeded metrics should have entries.
+    expect(body.data.up, 'up metric has metadata').toBeTruthy();
+    expect(body.data.http_server_request_duration_count, 'counter has metadata').toBeTruthy();
+    // Type field should be set ("gauge" / "counter").
+    const upEntries = body.data.up;
+    expect(Array.isArray(upEntries)).toBe(true);
+    expect(upEntries[0].type, 'up declared as gauge').toBe('gauge');
+  });
+
+  test('metric picker: selecting metric pre-fills query — /label/__name__/values', async ({
+    request,
+  }) => {
+    // When the user clicks a metric in the picker, Grafana issues the
+    // metric-names probe to confirm it exists before submitting the
+    // first /query. We just verify both seeded metrics are present.
+    const resp = await request.get(`${promProxy}/label/__name__/values`);
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(body.data).toContain('up');
+    expect(body.data).toContain('http_server_request_duration_count');
+  });
+
+  test('time range: relative "Last 5 minutes" (300 s window)', async ({ request }) => {
+    const now = Math.floor(Date.now() / 1000);
+    const start = now - 5 * 60;
+    const url = `${promProxy}/query_range?query=up&start=${start}&end=${now}&step=30`;
+    const resp = await request.get(url);
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(body.status).toBe('success');
+    expect(body.data.result.length).toBeGreaterThan(0);
+  });
+
+  test('time range: relative "Last 1 hour" (3600 s window)', async ({ request }) => {
+    const now = Math.floor(Date.now() / 1000);
+    const start = now - 60 * 60;
+    const url = `${promProxy}/query_range?query=up&start=${start}&end=${now}&step=60`;
+    const resp = await request.get(url);
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(body.status).toBe('success');
+    // Even though the seed only writes "now"-ish samples, the window
+    // is satisfied — the panel renders an empty earlier prefix.
+    expect(body.data.resultType).toBe('matrix');
+  });
+
+  test('time range: absolute start/end (RFC3339-style unix-seconds pin)', async ({ request }) => {
+    // Grafana's absolute picker sends fixed unix-second start/end.
+    const end = Math.floor(Date.now() / 1000);
+    const start = end - 10 * 60;
+    const url = `${promProxy}/query_range?query=up&start=${start}&end=${end}&step=30`;
+    const resp = await request.get(url);
+    expect(resp.status(), 'absolute range status').toBe(200);
+    const body = await resp.json();
+    expect(body.status).toBe('success');
+  });
+
+  test('custom step: 15 s yields a denser matrix than 60 s', async ({ request }) => {
+    const now = Math.floor(Date.now() / 1000);
+    const start = now - 5 * 60;
+    const fine = await request.get(
+      `${promProxy}/query_range?query=up&start=${start}&end=${now}&step=15`,
+    );
+    const coarse = await request.get(
+      `${promProxy}/query_range?query=up&start=${start}&end=${now}&step=60`,
+    );
+    expect(fine.status()).toBe(200);
+    expect(coarse.status()).toBe(200);
+    const fineBody = await fine.json();
+    const coarseBody = await coarse.json();
+    expect(fineBody.status).toBe('success');
+    expect(coarseBody.status).toBe('success');
+    // Both share at least one series (the up gauge).
+    expect(fineBody.data.result.length).toBeGreaterThan(0);
+    expect(coarseBody.data.result.length).toBeGreaterThan(0);
+    // Step grid spacing: timestamps should be ~step seconds apart.
+    if (
+      fineBody.data.result.length > 0 &&
+      fineBody.data.result[0].values &&
+      fineBody.data.result[0].values.length >= 2
+    ) {
+      const [t0] = fineBody.data.result[0].values[0];
+      const [t1] = fineBody.data.result[0].values[1];
+      const gap = Math.round(t1 - t0);
+      // Allow ±2 s slack for boundary alignment.
+      expect(gap, 'fine step ≈ 15 s').toBeGreaterThanOrEqual(13);
+      expect(gap, 'fine step ≈ 15 s').toBeLessThanOrEqual(17);
+    }
+  });
+
+  test('dashboard panel: simulated multi-target panel — both queries succeed', async ({
+    request,
+  }) => {
+    // Dashboard panels with N targets fire N parallel /query calls
+    // through the datasource proxy. We assert both targets succeed.
+    const [r1, r2] = await Promise.all([
+      request.get(`${promProxy}/query?query=up`),
+      request.get(`${promProxy}/query?query=rate(http_server_request_duration_count%5B1m%5D)`),
+    ]);
+    expect(r1.status(), 'target A status').toBe(200);
+    expect(r2.status(), 'target B status').toBe(200);
+    const b1 = await r1.json();
+    const b2 = await r2.json();
+    expect(b1.status).toBe('success');
+    expect(b2.status).toBe('success');
+    expect(b1.data.result.length, 'target A has series').toBeGreaterThan(0);
+    expect(b2.data.result.length, 'target B has series').toBeGreaterThan(0);
+  });
+
+  test('query inspector: X-Cerberus-* headers expose cerberus internals', async ({ request }) => {
+    // The Grafana Query Inspector panel surfaces upstream response
+    // headers under "Response headers". Cerberus exposes Strategy /
+    // Plan-Nodes / CH-Millis there.
+    const resp = await request.get(`${promProxy}/query?query=up`);
+    expect(resp.status()).toBe(200);
+    const strategy = resp.headers()['x-cerberus-strategy'];
+    const planNodes = resp.headers()['x-cerberus-plan-nodes'];
+    const chMillis = resp.headers()['x-cerberus-ch-millis'];
+    expect(strategy, 'X-Cerberus-Strategy present').toBeTruthy();
+    expect(planNodes, 'X-Cerberus-Plan-Nodes present').toBeTruthy();
+    expect(chMillis, 'X-Cerberus-CH-Millis present').toBeTruthy();
+    expect(Number.isFinite(Number(chMillis)), 'CH-Millis is numeric').toBe(true);
+  });
+
+  test('error rendering: bad PromQL returns Prom-shaped error envelope (not raw 502)', async ({
+    request,
+  }) => {
+    // Grafana renders a user-friendly error box when the response
+    // matches {status: "error", error: "<msg>"} with a 4xx code.
+    const resp = await request.get(`${promProxy}/query?query=up%7B%7B%7B`);
+    // Should NOT be 502 — that would be a "Bad gateway" red box.
+    expect(resp.status(), 'parse error → 4xx, not 5xx').toBeLessThan(500);
+    expect(resp.status(), 'parse error → 4xx').toBeGreaterThanOrEqual(400);
+    const body = await resp.json();
+    expect(body.status, 'envelope status').toBe('error');
+    expect(body.error, 'envelope error message').toBeTruthy();
+    expect(typeof body.error).toBe('string');
+  });
+
+  test('legend formatting: query with grouping label produces labelled series', async ({
+    request,
+  }) => {
+    // Grafana's `legendFormat: "{{job}}"` template needs the response
+    // series to carry the `job` label. We assert it survives the query
+    // round-trip.
+    const resp = await request.get(`${promProxy}/query?query=up`);
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    for (const s of body.data.result) {
+      expect(s.metric.job, 'each up series has a job label').toBeTruthy();
+    }
+  });
+
+  test('step grid: query_range timestamps are evenly spaced', async ({ request }) => {
+    const now = Math.floor(Date.now() / 1000);
+    const start = now - 5 * 60;
+    const step = 30;
+    const resp = await request.get(
+      `${promProxy}/query_range?query=up&start=${start}&end=${now}&step=${step}`,
+    );
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    const series = body.data.result[0];
+    expect(series, '≥1 series').toBeTruthy();
+    if (series.values.length < 2) {
+      // Not enough samples to assert spacing — pass trivially.
+      return;
+    }
+    // Each adjacent pair should differ by step (±1 s tolerance).
+    for (let i = 1; i < series.values.length; i++) {
+      const dt = Math.round(series.values[i][0] - series.values[i - 1][0]);
+      expect(dt, `gap[${i}] near step=${step}`).toBeGreaterThanOrEqual(step - 1);
+      expect(dt, `gap[${i}] near step=${step}`).toBeLessThanOrEqual(step + 1);
+    }
+  });
+
+  test('series endpoint: /api/v1/series populates the template-variable picker', async ({
+    request,
+  }) => {
+    // Grafana template variables of type `Series` query this exact
+    // endpoint. The seed inserts `up{job="api"}` + `up{job="db"}`.
+    const resp = await request.get(`${promProxy}/series?match%5B%5D=up`);
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(body.status).toBe('success');
+    expect(Array.isArray(body.data)).toBe(true);
+    expect(body.data.length, '≥1 series in match=up').toBeGreaterThan(0);
+    // Every series in the list should carry __name__=up.
+    for (const entry of body.data) {
+      expect(entry.__name__, 'each series carries __name__').toBe('up');
+    }
+  });
+});

--- a/test/e2e/playwright/tempo_ux.spec.ts
+++ b/test/e2e/playwright/tempo_ux.spec.ts
@@ -1,0 +1,287 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * TraceQL UX flows.
+ *
+ * Mirrors the request sequence Grafana's Tempo Search UI + Trace
+ * detail panel issue against a Tempo datasource. Each spec exercises
+ * a UX flow (TraceQL editor, structural ops, set ops, select, span
+ * filters, recent searches, ...) via the cerberus-tempo datasource
+ * proxy.
+ *
+ * Seed shape (test/e2e/seed/cmd/seed/main.go):
+ *   Trace 1 (a0…001): frontend → api
+ *   Trace 2 (a0…002): frontend → api → db  (status_code=500 / Error)
+ *   Trace 3 (a0…003): api → db              (cron.refresh / cache.refresh)
+ *
+ * Span attributes seeded: http.method, http.status_code, db.system,
+ * cron.name. Resource attribute: service.name.
+ */
+
+const tempoProxy = '/api/datasources/proxy/uid/cerberus-tempo/api';
+
+test.describe('Tempo UX — Search flows', () => {
+  test('search: by service.name returns trace summaries', async ({ request }) => {
+    const q = encodeURIComponent('{ resource.service.name = "frontend" }');
+    const resp = await request.get(`${tempoProxy}/search?q=${q}`);
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(Array.isArray(body.traces)).toBe(true);
+    expect(body.traces.length, '≥1 frontend trace').toBeGreaterThan(0);
+    for (const t of body.traces) {
+      expect(t.traceID, 'each summary has a traceID').toBeTruthy();
+    }
+  });
+
+  test('search: by operation name (.name attribute)', async ({ request }) => {
+    // The seed inserts span names like `GET /home`, `POST /checkout`.
+    const q = encodeURIComponent('{ name = "GET /home" }');
+    const resp = await request.get(`${tempoProxy}/search?q=${q}`);
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(Array.isArray(body.traces)).toBe(true);
+    expect(body.traces.length, '≥1 GET /home span').toBeGreaterThan(0);
+  });
+
+  test('search: filter by status (error spans)', async ({ request }) => {
+    // The seed inserts spans with StatusCode = 'Error' on Trace 2.
+    const q = encodeURIComponent('{ status = error }');
+    const resp = await request.get(`${tempoProxy}/search?q=${q}`);
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(Array.isArray(body.traces)).toBe(true);
+    // At least one error-status trace exists (Trace 2).
+    expect(body.traces.length, '≥1 error trace').toBeGreaterThan(0);
+  });
+
+  test('search: by tag — http.status_code = "200"', async ({ request }) => {
+    const q = encodeURIComponent('{ span.http.status_code = "200" }');
+    const resp = await request.get(`${tempoProxy}/search?q=${q}`);
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(Array.isArray(body.traces)).toBe(true);
+  });
+
+  test('search: empty query (Grafana Search-UI first-page-load ping)', async ({ request }) => {
+    // Grafana sometimes pings /api/search with no q as a health-check.
+    // Cerberus returns an empty traces array (not an error envelope).
+    const resp = await request.get(`${tempoProxy}/search?q=`);
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(Array.isArray(body.traces)).toBe(true);
+  });
+
+  test('trace-by-id: paste ID → full waterfall (batches/spans)', async ({ request }) => {
+    const seededID = 'a0000000000000000000000000000001';
+    const resp = await request.get(`${tempoProxy}/traces/${seededID}`);
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(Array.isArray(body.batches)).toBe(true);
+    expect(body.batches.length, '≥1 batch').toBeGreaterThan(0);
+    let totalSpans = 0;
+    for (const b of body.batches) {
+      totalSpans += b.spans?.length ?? 0;
+    }
+    // Trace 1 (a0…001) has 2 spans (frontend GET /home + api GET /api/users).
+    expect(totalSpans, '≥2 spans in waterfall').toBeGreaterThanOrEqual(2);
+  });
+
+  test('trace detail: span attributes panel — http.method present on a seeded span', async ({
+    request,
+  }) => {
+    // Open Trace 1 — the frontend GET /home span has http.method=GET.
+    // Cerberus exposes span.attributes as a flat map[string]string.
+    const resp = await request.get(
+      `${tempoProxy}/traces/a0000000000000000000000000000001`,
+    );
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    // Collect every span-attribute key across every batch.
+    const keys = new Set<string>();
+    for (const b of body.batches) {
+      for (const span of b.spans ?? []) {
+        for (const k of Object.keys(span.attributes ?? {})) {
+          keys.add(k);
+        }
+      }
+    }
+    expect(keys.has('http.method'), 'http.method attribute present').toBe(true);
+  });
+
+  test('trace detail: processes (resource) shows service.name', async ({ request }) => {
+    // Tempo's "Processes" tab reads from batch.resource.attributes —
+    // each batch carries resource.attributes[service.name].
+    const resp = await request.get(
+      `${tempoProxy}/traces/a0000000000000000000000000000001`,
+    );
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    let foundSvc = false;
+    for (const b of body.batches) {
+      const attrs: Record<string, string> = b.resource?.attributes ?? {};
+      if ('service.name' in attrs) {
+        foundSvc = true;
+      }
+    }
+    expect(foundSvc, 'service.name resource attribute present').toBe(true);
+  });
+
+  test('trace detail: span hierarchy via parentSpanId (indentation source)', async ({
+    request,
+  }) => {
+    // The waterfall renders parent-child indentation by reading
+    // parentSpanId off each span. Trace 1 has child span 0002 → 0001.
+    const resp = await request.get(
+      `${tempoProxy}/traces/a0000000000000000000000000000001`,
+    );
+    const body = await resp.json();
+    let foundChild = false;
+    for (const b of body.batches) {
+      for (const span of b.spans ?? []) {
+        // Field name on the wire is `parentSpanId` (json: parentSpanId).
+        const psid: string | undefined = span.parentSpanId;
+        if (psid && psid.length > 0) {
+          foundChild = true;
+        }
+      }
+    }
+    expect(foundChild, '≥1 span has parentSpanId').toBe(true);
+  });
+
+  test('traceql editor: resource.service.name = "api" returns api spans', async ({ request }) => {
+    const q = encodeURIComponent('{ resource.service.name = "api" }');
+    const resp = await request.get(`${tempoProxy}/search?q=${q}`);
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(body.traces.length, '≥1 api trace').toBeGreaterThan(0);
+  });
+
+  test('traceql structural: `{a} > {b}` parent→child chain returns matches', async ({
+    request,
+  }) => {
+    // Trace 1: frontend → api  ⇒ { service=frontend } > { service=api }
+    const q = encodeURIComponent(
+      '{ resource.service.name = "frontend" } > { resource.service.name = "api" }',
+    );
+    const resp = await request.get(`${tempoProxy}/search?q=${q}`);
+    expect(resp.status(), 'structural query status').toBe(200);
+    const body = await resp.json();
+    expect(Array.isArray(body.traces)).toBe(true);
+    // At least one matching trace (Trace 1 or Trace 2).
+    expect(body.traces.length, '≥1 structural match').toBeGreaterThan(0);
+  });
+
+  test('traceql descendant: `{a} >> {b}` deep descendant returns matches', async ({ request }) => {
+    // Trace 2: frontend → api → db ⇒ { frontend } >> { db } via descendant.
+    const q = encodeURIComponent(
+      '{ resource.service.name = "frontend" } >> { resource.service.name = "db" }',
+    );
+    const resp = await request.get(`${tempoProxy}/search?q=${q}`);
+    expect(resp.status(), 'descendant query status').toBe(200);
+    const body = await resp.json();
+    expect(Array.isArray(body.traces)).toBe(true);
+  });
+
+  test('traceql set ops: `{} && {}` intersection narrows to common traces', async ({
+    request,
+  }) => {
+    // `{service=frontend} && {service=api}` ⇒ traces containing BOTH.
+    const q = encodeURIComponent(
+      '{ resource.service.name = "frontend" } && { resource.service.name = "api" }',
+    );
+    const resp = await request.get(`${tempoProxy}/search?q=${q}`);
+    expect(resp.status(), 'set-and query status').toBe(200);
+    const body = await resp.json();
+    expect(Array.isArray(body.traces)).toBe(true);
+  });
+
+  test('traceql set ops: `{} || {}` union widens to either', async ({ request }) => {
+    const q = encodeURIComponent(
+      '{ resource.service.name = "frontend" } || { resource.service.name = "db" }',
+    );
+    const resp = await request.get(`${tempoProxy}/search?q=${q}`);
+    expect(resp.status(), 'set-or query status').toBe(200);
+    const body = await resp.json();
+    expect(Array.isArray(body.traces)).toBe(true);
+    expect(body.traces.length, '≥1 trace in union').toBeGreaterThan(0);
+  });
+
+  test('traceql `| select(...)`: column-pruned result', async ({ request }) => {
+    // The select pipeline restricts the returned column set. We
+    // assert the call is 200 and returns the trace summary envelope.
+    const q = encodeURIComponent(
+      '{ resource.service.name = "frontend" } | select(.http.method)',
+    );
+    const resp = await request.get(`${tempoProxy}/search?q=${q}`);
+    expect(resp.status(), 'select pipeline status').toBe(200);
+    const body = await resp.json();
+    expect(Array.isArray(body.traces)).toBe(true);
+  });
+
+  test('recent searches: /api/search/recent returns the recent-N traces', async ({ request }) => {
+    // Grafana's "Recent" dropdown reads /api/search/recent. The seed
+    // has 3 traces total; default limit is 20.
+    const resp = await request.get(`${tempoProxy}/search/recent`);
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(Array.isArray(body.traces)).toBe(true);
+    expect(body.traces.length, '≥1 recent trace').toBeGreaterThan(0);
+  });
+
+  test('recent searches: ?limit=2 narrows to 2', async ({ request }) => {
+    const resp = await request.get(`${tempoProxy}/search/recent?limit=2`);
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(body.traces.length, '≤2 recent traces').toBeLessThanOrEqual(2);
+  });
+
+  test('search tags: V2 returns scoped tag list (resource / span)', async ({ request }) => {
+    // Grafana's TraceQL Search UI uses /v2/search/tags to populate
+    // its scope-aware tag dropdown.
+    const resp = await request.get(`${tempoProxy}/v2/search/tags`);
+    expect(resp.status(), 'v2 tags status').toBe(200);
+    const body = await resp.json();
+    expect(Array.isArray(body.scopes)).toBe(true);
+    expect(body.scopes.length, '≥1 scope').toBeGreaterThan(0);
+  });
+
+  test('search tag values: span.http.method → ["GET", "POST"]', async ({ request }) => {
+    // V1 endpoint — populates the "value" dropdown after a user picks
+    // a tag. V1 returns {tagValues: string[]}.
+    const resp = await request.get(`${tempoProxy}/search/tag/http.method/values`);
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(Array.isArray(body.tagValues)).toBe(true);
+    // GET and POST both appear in the seed (Traces 1+3 use GET, Trace 2 POST).
+    expect(body.tagValues, 'GET in http.method values').toContain('GET');
+    expect(body.tagValues, 'POST in http.method values').toContain('POST');
+  });
+
+  test('trace not found: Tempo error envelope shape for waterfall renders', async ({
+    request,
+  }) => {
+    // Grafana's "Trace not found" UI keys off the envelope shape
+    // {traceID, spanID, error, message}.
+    const resp = await request.get(
+      `${tempoProxy}/traces/dead00000000000000000000000000ad`,
+    );
+    expect(resp.status()).toBe(404);
+    const body = await resp.json();
+    expect(body.error, 'envelope.error').toBe(true);
+    expect(body.message, 'envelope.message present').toBeTruthy();
+  });
+
+  test('service graph: tempo metrics_query_range endpoint not yet implemented', async ({
+    request,
+  }) => {
+    test.skip(
+      true,
+      'service graph requires /api/metrics/query_range (Tempo metrics_query_range). ' +
+        'Not yet implemented in cerberus tempo handler — RC4 metrics-from-traces work.',
+    );
+    // When implemented, replace with:
+    //   const resp = await request.get(`${tempoProxy}/metrics/query_range?q=...`);
+    //   expect(resp.status()).toBe(200);
+    void request;
+  });
+});


### PR DESCRIPTION
## Summary

- Adds **58 new Playwright tests** (1 skipped) across 4 new spec files in `test/e2e/playwright/`, mirroring the request sequences Grafana fires from its Explore page / Logs panel / Tempo Search UI against cerberus's three datasource proxies.
- Brings the Playwright suite from 21 → 79 tests; runs inside the `dashboard` job in `.github/workflows/e2e.yml` (informational, not a required PR gate per CLAUDE.md).
- No production code changes. Type-checked locally with \`npx tsc --noEmit\` clean; \`npx playwright test --list\` enumerates all 79 cases.

### Per-section breakdown

| Spec file                         | Tests | Coverage                                                                                                 |
| --------------------------------- | ----- | -------------------------------------------------------------------------------------------------------- |
| \`prom_ux.spec.ts\`                 | 16    | Explore instant/range/table, label browser, \`/metadata\` metric picker, time-range pickers, step grid, multi-target, \`X-Cerberus-*\` headers (query inspector), error envelope, legend, \`/series\` template var |
| \`loki_ux.spec.ts\`                 | 15    | Level coloring, \`|=\`/\`!=\`/\`|~\` filters chained, detected_fields, patterns, time-window, \`rate()\`, parser-stage 422 pin, \`| line_format\`, \`/index/volume\` histogram, labels dropdowns |
| \`tempo_ux.spec.ts\`                | 21    | TraceQL search (service/op/status/tag), structural \`>\`/\`>>\`, set ops \`&&\`/\`||\`, \`| select\`, recent, v2 tags, tag values, span hierarchy, processes attrs, not-found envelope |
| \`cross_datasource.spec.ts\`        | 6     | log→trace shape, span→logs shortcut, metric→logs context, trace→metrics jump, 3-DS burst health, idempotent re-probe |

### Skips

- **\`tempo_ux.spec.ts\` › service graph** — Tempo's \`/api/metrics/query_range\` is not yet exposed by the cerberus Tempo handler (RC4 metrics-from-traces work). Gated via \`test.skip()\` with a TODO that points at the replacement assertion when implemented.

### Constraints worked around (documented inline in the specs)

- **Log↔trace TraceId alignment** — \`otel_logs.TraceId\` (\`00…00\`..\`00…03\`) and \`otel_traces.TraceId\` (\`a0…01\`..\`a0…03\`) in \`test/e2e/seed/cmd/seed/main.go\` are deliberately disjoint. The cross-datasource correlation specs therefore pin the trace lookup to a known-seeded \`a0…01\` ID and assert endpoint contracts on each side (the wire shape Grafana's derived-field follow), not a data-level round-trip.
- **WebSocket live tail** — Grafana datasource proxy WebSocket-upgrade behavior is environment-dependent and would be flaky; tail was not added. The existing in-cerberus Loki tail tests cover the protocol itself.

## Test plan

- [ ] CI \`dashboard\` job (push-to-main / nightly / manual) — informational; verify the 58 new tests are picked up and all pass.
- [ ] \`just e2e-up && just e2e-seed && just e2e-playwright\` locally produces 79 listed tests with the existing seed.
- [ ] Confirm no required-gate CI checks (\`check\`/\`lint\`) are affected (only adds \`.spec.ts\` files under \`test/e2e/playwright/\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)