### PR TITLE
test(spec/traceql): add chDB roundtrip to 61 fixtures

### DIFF
--- a/test/spec/traceql/and_or_combined.txtar
+++ b/test/spec/traceql/and_or_combined.txtar
@@ -8,3 +8,18 @@ SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?) AND ((`Duration`
 [2] int64 = 100000000
 [3] string = "http.status_code"
 [4] int64 = 500
+-- seed --
+CREATE TABLE otel_traces (
+    Duration UInt64,
+    ResourceAttributes Map(String, String) MATERIALIZED map('service.name', if(Duration = 80000000, 'backend', 'frontend')),
+    SpanAttributes Map(String, String) MATERIALIZED map('http.status_code', if(Duration = 50000000, '500', '200'))
+) ENGINE = MergeTree ORDER BY Duration;
+INSERT INTO otel_traces (Duration) VALUES
+    (50000000),
+    (80000000),
+    (150000000);
+-- expected_rows --
+[
+  [50000000],
+  [150000000]
+]

--- a/test/spec/traceql/and_two_attrs.txtar
+++ b/test/spec/traceql/and_two_attrs.txtar
@@ -6,3 +6,17 @@ SELECT * FROM `otel_traces` PREWHERE (`Duration` > ?) WHERE (`ResourceAttributes
 [0] int64 = 100000000
 [1] string = "service.name"
 [2] string = "frontend"
+-- seed --
+CREATE TABLE otel_traces (
+    Duration UInt64,
+    ResourceAttributes Map(String, String) MATERIALIZED map('service.name', 'frontend')
+) ENGINE = MergeTree ORDER BY Duration;
+INSERT INTO otel_traces (Duration) VALUES
+    (50000000),
+    (120000000),
+    (150000000);
+-- expected_rows --
+[
+  [120000000],
+  [150000000]
+]

--- a/test/spec/traceql/attribute_arithmetic_add.txtar
+++ b/test/spec/traceql/attribute_arithmetic_add.txtar
@@ -6,3 +6,13 @@ SELECT * FROM `otel_traces` WHERE ((`SpanAttributes`[?] + `SpanAttributes`[?]) >
 [0] string = "a"
 [1] string = "b"
 [2] int64 = 10
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    SpanAttributes Map(String, String) MATERIALIZED map('a', if(_idx = 0, '7', '3'), 'b', if(_idx = 0, '8', '4'))
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1);
+-- expected_rows --
+[
+  [0]
+]

--- a/test/spec/traceql/attribute_arithmetic_mul.txtar
+++ b/test/spec/traceql/attribute_arithmetic_mul.txtar
@@ -6,3 +6,13 @@ SELECT * FROM `otel_traces` WHERE ((`SpanAttributes`[?] * ?) > ?)
 [0] string = "a"
 [1] int64 = 2
 [2] int64 = 10
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    SpanAttributes Map(String, String) MATERIALIZED map('a', if(_idx = 0, '7', '3'))
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1);
+-- expected_rows --
+[
+  [0]
+]

--- a/test/spec/traceql/avg_duration.txtar
+++ b/test/spec/traceql/avg_duration.txtar
@@ -6,3 +6,17 @@ SELECT * FROM (SELECT avg(`Duration`) AS `Value` FROM (SELECT * FROM `otel_trace
 [0] string = "service.name"
 [1] string = "frontend"
 [2] int64 = 50000000
+-- seed --
+CREATE TABLE otel_traces (
+    ResourceAttributes Map(String, String),
+    Duration UInt64
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    (map('service.name', 'frontend'), 60000000),
+    (map('service.name', 'frontend'), 80000000),
+    (map('service.name', 'frontend'), 100000000),
+    (map('service.name', 'backend'),  10000000);
+-- expected_rows --
+[
+  [80000000.0]
+]

--- a/test/spec/traceql/coalesce_simple.txtar
+++ b/test/spec/traceql/coalesce_simple.txtar
@@ -4,3 +4,16 @@
 SELECT `TraceId` AS `TraceId`, `SpanId` AS `SpanId`, min(`Timestamp`) AS `Timestamp` FROM (SELECT * FROM `otel_traces` WHERE ?) GROUP BY `TraceId`, `SpanId`
 -- args --
 [0] bool = true
+-- seed --
+CREATE TABLE otel_traces (
+    TraceId String,
+    SpanId String,
+    Timestamp DateTime64(9)
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    ('a0000000000000000000000000000001', '0000000000000001', toDateTime64('2026-01-01 00:00:00', 9)),
+    ('a0000000000000000000000000000001', '0000000000000001', toDateTime64('2026-01-01 00:00:05', 9));
+-- expected_rows --
+[
+  ["a0000000000000000000000000000001", "0000000000000001", "2026-01-01T00:00:00Z"]
+]

--- a/test/spec/traceql/count.txtar
+++ b/test/spec/traceql/count.txtar
@@ -7,3 +7,16 @@ SELECT * FROM (SELECT count(?) AS `Value` FROM (SELECT * FROM `otel_traces` WHER
 [1] string = "service.name"
 [2] string = "frontend"
 [3] int64 = 0
+-- seed --
+CREATE TABLE otel_traces (
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    (map('service.name', 'frontend')),
+    (map('service.name', 'frontend')),
+    (map('service.name', 'frontend')),
+    (map('service.name', 'backend'));
+-- expected_rows --
+[
+  [3]
+]

--- a/test/spec/traceql/count_eq_zero.txtar
+++ b/test/spec/traceql/count_eq_zero.txtar
@@ -7,3 +7,15 @@ SELECT * FROM (SELECT count(?) AS `Value` FROM (SELECT * FROM `otel_traces` WHER
 [1] string = "service.name"
 [2] string = "frontend"
 [3] int64 = 0
+-- seed --
+CREATE TABLE otel_traces (
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    (map('service.name', 'backend')),
+    (map('service.name', 'db')),
+    (map('service.name', 'cache'));
+-- expected_rows --
+[
+  [0]
+]

--- a/test/spec/traceql/count_ge_threshold.txtar
+++ b/test/spec/traceql/count_ge_threshold.txtar
@@ -7,3 +7,18 @@ SELECT * FROM (SELECT count(?) AS `Value` FROM (SELECT * FROM `otel_traces` WHER
 [1] string = "service.name"
 [2] string = "frontend"
 [3] int64 = 5
+-- seed --
+CREATE TABLE otel_traces (
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    (map('service.name', 'frontend')),
+    (map('service.name', 'frontend')),
+    (map('service.name', 'frontend')),
+    (map('service.name', 'frontend')),
+    (map('service.name', 'frontend')),
+    (map('service.name', 'backend'));
+-- expected_rows --
+[
+  [5]
+]

--- a/test/spec/traceql/count_lt_threshold.txtar
+++ b/test/spec/traceql/count_lt_threshold.txtar
@@ -7,3 +7,16 @@ SELECT * FROM (SELECT count(?) AS `Value` FROM (SELECT * FROM `otel_traces` WHER
 [1] string = "service.name"
 [2] string = "frontend"
 [3] int64 = 10
+-- seed --
+CREATE TABLE otel_traces (
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    (map('service.name', 'frontend')),
+    (map('service.name', 'frontend')),
+    (map('service.name', 'frontend')),
+    (map('service.name', 'backend'));
+-- expected_rows --
+[
+  [3]
+]

--- a/test/spec/traceql/duration_ge.txtar
+++ b/test/spec/traceql/duration_ge.txtar
@@ -4,3 +4,16 @@
 SELECT * FROM `otel_traces` WHERE (`Duration` >= ?)
 -- args --
 [0] int64 = 1000000000
+-- seed --
+CREATE TABLE otel_traces (
+    Duration UInt64
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    (500000000),
+    (1000000000),
+    (2000000000);
+-- expected_rows --
+[
+  [1000000000],
+  [2000000000]
+]

--- a/test/spec/traceql/duration_gt.txtar
+++ b/test/spec/traceql/duration_gt.txtar
@@ -4,3 +4,17 @@
 SELECT * FROM `otel_traces` WHERE (`Duration` > ?)
 -- args --
 [0] int64 = 100000000
+-- seed --
+CREATE TABLE otel_traces (
+    Duration UInt64
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    (50000000),
+    (100000000),
+    (150000000),
+    (250000000);
+-- expected_rows --
+[
+  [150000000],
+  [250000000]
+]

--- a/test/spec/traceql/duration_lt.txtar
+++ b/test/spec/traceql/duration_lt.txtar
@@ -4,3 +4,15 @@
 SELECT * FROM `otel_traces` WHERE (`Duration` < ?)
 -- args --
 [0] int64 = 50000000
+-- seed --
+CREATE TABLE otel_traces (
+    Duration UInt64
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    (10000000),
+    (50000000),
+    (100000000);
+-- expected_rows --
+[
+  [10000000]
+]

--- a/test/spec/traceql/event_attribute.txtar
+++ b/test/spec/traceql/event_attribute.txtar
@@ -5,3 +5,13 @@ SELECT * FROM `otel_traces` WHERE arrayExists(x -> x[?] = ?, `Events`.`Attribute
 -- args --
 [0] string = "exception.type"
 [1] string = "ConnectionError"
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    `Events.Attributes` Array(Map(String, String)) MATERIALIZED if(_idx = 0, [map('exception.type', 'ConnectionError')], [map('exception.type', 'TimeoutError')])
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1);
+-- expected_rows --
+[
+  [0]
+]

--- a/test/spec/traceql/event_name.txtar
+++ b/test/spec/traceql/event_name.txtar
@@ -5,3 +5,13 @@ SELECT * FROM `otel_traces` WHERE arrayExists(x -> x[?] = ?, `Events`.`Attribute
 -- args --
 [0] string = "name"
 [1] string = "exception"
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    `Events.Attributes` Array(Map(String, String)) MATERIALIZED if(_idx = 0, [map('name', 'exception')], [map('name', 'other')])
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1);
+-- expected_rows --
+[
+  [0]
+]

--- a/test/spec/traceql/float_attr.txtar
+++ b/test/spec/traceql/float_attr.txtar
@@ -5,3 +5,13 @@ SELECT * FROM `otel_traces` WHERE (`SpanAttributes`[?] > ?)
 -- args --
 [0] string = "cpu.usage"
 [1] float64 = 0.5
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    SpanAttributes Map(String, String) MATERIALIZED map('cpu.usage', if(_idx = 0, '0.7', '0.3'))
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1);
+-- expected_rows --
+[
+  [0]
+]

--- a/test/spec/traceql/group_by_attr.txtar
+++ b/test/spec/traceql/group_by_attr.txtar
@@ -6,3 +6,16 @@ SELECT `ResourceAttributes`[?] AS `GroupKey`, any(`TraceId`) AS `TraceId`, any(`
 [0] string = "service.name"
 [1] bool = true
 [2] string = "service.name"
+-- seed --
+CREATE TABLE otel_traces (
+    TraceId String,
+    SpanId String,
+    Timestamp DateTime64(9),
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    ('a0000000000000000000000000000001', '0000000000000001', toDateTime64('2026-01-01 00:00:00', 9), map('service.name', 'frontend'));
+-- expected_rows --
+[
+  ["frontend", "a0000000000000000000000000000001", "0000000000000001", "2026-01-01T00:00:00Z"]
+]

--- a/test/spec/traceql/http_status_int.txtar
+++ b/test/spec/traceql/http_status_int.txtar
@@ -5,3 +5,13 @@ SELECT * FROM `otel_traces` WHERE (`SpanAttributes`[?] >= ?)
 -- args --
 [0] string = "http.status_code"
 [1] int64 = 500
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    SpanAttributes Map(String, String) MATERIALIZED map('http.status_code', if(_idx = 0, '500', if(_idx = 1, '404', '200')))
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1), (2);
+-- expected_rows --
+[
+  [0]
+]

--- a/test/spec/traceql/kind_eq_client.txtar
+++ b/test/spec/traceql/kind_eq_client.txtar
@@ -4,3 +4,15 @@
 SELECT * FROM `otel_traces` WHERE (`SpanKind` = ?)
 -- args --
 [0] string = "Client"
+-- seed --
+CREATE TABLE otel_traces (
+    SpanKind String
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    ('Server'),
+    ('Client'),
+    ('Internal');
+-- expected_rows --
+[
+  ["Client"]
+]

--- a/test/spec/traceql/kind_eq_server.txtar
+++ b/test/spec/traceql/kind_eq_server.txtar
@@ -4,3 +4,15 @@
 SELECT * FROM `otel_traces` WHERE (`SpanKind` = ?)
 -- args --
 [0] string = "Server"
+-- seed --
+CREATE TABLE otel_traces (
+    SpanKind String
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    ('Client'),
+    ('Server'),
+    ('Internal');
+-- expected_rows --
+[
+  ["Server"]
+]

--- a/test/spec/traceql/kind_intrinsic.txtar
+++ b/test/spec/traceql/kind_intrinsic.txtar
@@ -4,3 +4,15 @@
 SELECT * FROM `otel_traces` WHERE (`SpanKind` = ?)
 -- args --
 [0] string = "client"
+-- seed --
+CREATE TABLE otel_traces (
+    SpanKind String
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    ('Server'),
+    ('client'),
+    ('Internal');
+-- expected_rows --
+[
+  ["client"]
+]

--- a/test/spec/traceql/link_attribute.txtar
+++ b/test/spec/traceql/link_attribute.txtar
@@ -5,3 +5,13 @@ SELECT * FROM `otel_traces` WHERE arrayExists(x -> x[?] = ?, `Links`.`Attributes
 -- args --
 [0] string = "environment"
 [1] string = "prod"
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    `Links.Attributes` Array(Map(String, String)) MATERIALIZED if(_idx = 0, [map('environment', 'prod')], [map('environment', 'dev')])
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1);
+-- expected_rows --
+[
+  [0]
+]

--- a/test/spec/traceql/link_span_id.txtar
+++ b/test/spec/traceql/link_span_id.txtar
@@ -5,3 +5,13 @@ SELECT * FROM `otel_traces` WHERE arrayExists(x -> x[?] = ?, `Links`.`Attributes
 -- args --
 [0] string = "span_id"
 [1] string = "abc"
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    `Links.Attributes` Array(Map(String, String)) MATERIALIZED if(_idx = 0, [map('span_id', 'abc')], [map('span_id', 'def')])
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1);
+-- expected_rows --
+[
+  [0]
+]

--- a/test/spec/traceql/max_duration.txtar
+++ b/test/spec/traceql/max_duration.txtar
@@ -6,3 +6,17 @@ SELECT * FROM (SELECT max(`Duration`) AS `Value` FROM (SELECT * FROM `otel_trace
 [0] string = "service.name"
 [1] string = "frontend"
 [2] int64 = 500000000
+-- seed --
+CREATE TABLE otel_traces (
+    ResourceAttributes Map(String, String),
+    Duration UInt64
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    (map('service.name', 'frontend'), 200000000),
+    (map('service.name', 'frontend'), 600000000),
+    (map('service.name', 'frontend'), 400000000),
+    (map('service.name', 'backend'),  900000000);
+-- expected_rows --
+[
+  [600000000]
+]

--- a/test/spec/traceql/metrics_count_over_time.txtar
+++ b/test/spec/traceql/metrics_count_over_time.txtar
@@ -6,3 +6,15 @@ SELECT count(?) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAtt
 [0] int64 = 1
 [1] string = "service.name"
 [2] string = "frontend"
+-- seed --
+CREATE TABLE otel_traces (
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    (map('service.name', 'frontend')),
+    (map('service.name', 'frontend')),
+    (map('service.name', 'backend'));
+-- expected_rows --
+[
+  [2]
+]

--- a/test/spec/traceql/metrics_histogram_over_time_attr.txtar
+++ b/test/spec/traceql/metrics_histogram_over_time_attr.txtar
@@ -5,3 +5,15 @@ SELECT log2(`Duration`) / 1000000000 AS `__bucket`, count(?) AS `Value` FROM (SE
 -- args --
 [0] int64 = 1
 [1] bool = true
+-- seed --
+CREATE TABLE otel_traces (
+    Duration UInt64
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    (1024),
+    (1024),
+    (1024);
+-- expected_rows --
+[
+  [1.0e-08, 3]
+]

--- a/test/spec/traceql/metrics_histogram_over_time_by.txtar
+++ b/test/spec/traceql/metrics_histogram_over_time_by.txtar
@@ -7,3 +7,16 @@ SELECT `ResourceAttributes`[?] AS `service.name`, log2(`Duration`) / 1000000000 
 [1] int64 = 1
 [2] bool = true
 [3] string = "service.name"
+-- seed --
+CREATE TABLE otel_traces (
+    ResourceAttributes Map(String, String),
+    Duration UInt64
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    (map('service.name', 'frontend'), 1024),
+    (map('service.name', 'frontend'), 1024),
+    (map('service.name', 'frontend'), 1024);
+-- expected_rows --
+[
+  ["frontend", 1.0e-08, 3]
+]

--- a/test/spec/traceql/metrics_histogram_over_time_empty.txtar
+++ b/test/spec/traceql/metrics_histogram_over_time_empty.txtar
@@ -6,3 +6,16 @@ SELECT log2(`Duration`) / 1000000000 AS `__bucket`, count(?) AS `Value` FROM (SE
 [0] int64 = 1
 [1] string = "service.name"
 [2] string = "frontend"
+-- seed --
+CREATE TABLE otel_traces (
+    ResourceAttributes Map(String, String),
+    Duration UInt64
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    (map('service.name', 'frontend'), 1024),
+    (map('service.name', 'frontend'), 1024),
+    (map('service.name', 'backend'),  4096);
+-- expected_rows --
+[
+  [1.0e-08, 2]
+]

--- a/test/spec/traceql/metrics_max_over_time.txtar
+++ b/test/spec/traceql/metrics_max_over_time.txtar
@@ -4,3 +4,15 @@
 SELECT max(`Duration`) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE ?)
 -- args --
 [0] bool = true
+-- seed --
+CREATE TABLE otel_traces (
+    Duration UInt64
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    (50000000),
+    (200000000),
+    (100000000);
+-- expected_rows --
+[
+  [200000000]
+]

--- a/test/spec/traceql/metrics_min_over_time.txtar
+++ b/test/spec/traceql/metrics_min_over_time.txtar
@@ -4,3 +4,15 @@
 SELECT min(`Duration`) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE ?)
 -- args --
 [0] bool = true
+-- seed --
+CREATE TABLE otel_traces (
+    Duration UInt64
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    (200000000),
+    (50000000),
+    (100000000);
+-- expected_rows --
+[
+  [50000000]
+]

--- a/test/spec/traceql/metrics_quantile_over_time.txtar
+++ b/test/spec/traceql/metrics_quantile_over_time.txtar
@@ -5,3 +5,17 @@ SELECT quantile(?)(`Duration`) AS `Value` FROM (SELECT * FROM `otel_traces` WHER
 -- args --
 [0] float64 = 0.95
 [1] bool = true
+-- seed --
+CREATE TABLE otel_traces (
+    Duration UInt64
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    (100000000),
+    (100000000),
+    (100000000),
+    (100000000),
+    (100000000);
+-- expected_rows --
+[
+  [100000000.0]
+]

--- a/test/spec/traceql/metrics_rate.txtar
+++ b/test/spec/traceql/metrics_rate.txtar
@@ -5,3 +5,16 @@ SELECT count(?) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE ?)
 -- args --
 [0] int64 = 1
 [1] bool = true
+-- seed --
+CREATE TABLE otel_traces (
+    Duration UInt64
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    (50000000),
+    (100000000),
+    (200000000),
+    (300000000);
+-- expected_rows --
+[
+  [4]
+]

--- a/test/spec/traceql/metrics_rate_by.txtar
+++ b/test/spec/traceql/metrics_rate_by.txtar
@@ -7,3 +7,15 @@ SELECT `ResourceAttributes`[?] AS `service.name`, count(?) AS `Value` FROM (SELE
 [1] int64 = 1
 [2] bool = true
 [3] string = "service.name"
+-- seed --
+CREATE TABLE otel_traces (
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    (map('service.name', 'frontend')),
+    (map('service.name', 'frontend')),
+    (map('service.name', 'frontend'));
+-- expected_rows --
+[
+  ["frontend", 3]
+]

--- a/test/spec/traceql/metrics_sum_over_time.txtar
+++ b/test/spec/traceql/metrics_sum_over_time.txtar
@@ -4,3 +4,15 @@
 SELECT sum(`Duration`) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE ?)
 -- args --
 [0] bool = true
+-- seed --
+CREATE TABLE otel_traces (
+    Duration UInt64
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    (50000000),
+    (100000000),
+    (200000000);
+-- expected_rows --
+[
+  [350000000]
+]

--- a/test/spec/traceql/min_duration.txtar
+++ b/test/spec/traceql/min_duration.txtar
@@ -6,3 +6,17 @@ SELECT * FROM (SELECT min(`Duration`) AS `Value` FROM (SELECT * FROM `otel_trace
 [0] string = "service.name"
 [1] string = "frontend"
 [2] int64 = 10000000
+-- seed --
+CREATE TABLE otel_traces (
+    ResourceAttributes Map(String, String),
+    Duration UInt64
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    (map('service.name', 'frontend'), 30000000),
+    (map('service.name', 'frontend'), 50000000),
+    (map('service.name', 'frontend'), 80000000),
+    (map('service.name', 'backend'),   5000000);
+-- expected_rows --
+[
+  [30000000]
+]

--- a/test/spec/traceql/multi_attr_compound.txtar
+++ b/test/spec/traceql/multi_attr_compound.txtar
@@ -8,3 +8,18 @@ SELECT * FROM `otel_traces` PREWHERE (`Duration` > ?) WHERE (`ResourceAttributes
 [2] string = "frontend"
 [3] string = "http.status_code"
 [4] int64 = 500
+-- seed --
+CREATE TABLE otel_traces (
+    Duration UInt64,
+    ResourceAttributes Map(String, String) MATERIALIZED map('service.name', 'frontend'),
+    SpanAttributes Map(String, String) MATERIALIZED map('http.status_code', if(Duration > 100000000, '500', '200'))
+) ENGINE = MergeTree ORDER BY Duration;
+INSERT INTO otel_traces (Duration) VALUES
+    (50000000),
+    (150000000),
+    (250000000);
+-- expected_rows --
+[
+  [150000000],
+  [250000000]
+]

--- a/test/spec/traceql/name_intrinsic.txtar
+++ b/test/spec/traceql/name_intrinsic.txtar
@@ -4,3 +4,15 @@
 SELECT * FROM `otel_traces` WHERE (`SpanName` = ?)
 -- args --
 [0] string = "GET /api/users"
+-- seed --
+CREATE TABLE otel_traces (
+    SpanName String
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    ('GET /home'),
+    ('GET /api/users'),
+    ('POST /checkout');
+-- expected_rows --
+[
+  ["GET /api/users"]
+]

--- a/test/spec/traceql/not_eq_attr.txtar
+++ b/test/spec/traceql/not_eq_attr.txtar
@@ -5,3 +5,14 @@ SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] != ?)
 -- args --
 [0] string = "service.name"
 [1] string = "backend"
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    ResourceAttributes Map(String, String) MATERIALIZED map('service.name', if(_idx = 0, 'frontend', if(_idx = 1, 'backend', 'db')))
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1), (2);
+-- expected_rows --
+[
+  [0],
+  [2]
+]

--- a/test/spec/traceql/not_regex_attr.txtar
+++ b/test/spec/traceql/not_regex_attr.txtar
@@ -5,3 +5,14 @@ SELECT * FROM `otel_traces` WHERE NOT match(`ResourceAttributes`[?], ?)
 -- args --
 [0] string = "service.name"
 [1] string = "back.*"
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    ResourceAttributes Map(String, String) MATERIALIZED map('service.name', if(_idx = 0, 'frontend', if(_idx = 1, 'backend', 'db')))
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1), (2);
+-- expected_rows --
+[
+  [0],
+  [2]
+]

--- a/test/spec/traceql/or_two_attrs.txtar
+++ b/test/spec/traceql/or_two_attrs.txtar
@@ -6,3 +6,17 @@ SELECT * FROM `otel_traces` WHERE ((`ResourceAttributes`[?] = ?) OR (`Duration` 
 [0] string = "service.name"
 [1] string = "frontend"
 [2] int64 = 100000000
+-- seed --
+CREATE TABLE otel_traces (
+    Duration UInt64,
+    ResourceAttributes Map(String, String) MATERIALIZED map('service.name', if(Duration = 50000000, 'frontend', 'backend'))
+) ENGINE = MergeTree ORDER BY Duration;
+INSERT INTO otel_traces (Duration) VALUES
+    (50000000),
+    (80000000),
+    (150000000);
+-- expected_rows --
+[
+  [50000000],
+  [150000000]
+]

--- a/test/spec/traceql/parent_intrinsic.txtar
+++ b/test/spec/traceql/parent_intrinsic.txtar
@@ -4,3 +4,15 @@
 SELECT * FROM `otel_traces` WHERE (`ParentSpanId` = ?)
 -- args --
 [0] string = "fedcba9876543210"
+-- seed --
+CREATE TABLE otel_traces (
+    ParentSpanId String
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    (''),
+    ('fedcba9876543210'),
+    ('0123456789abcdef');
+-- expected_rows --
+[
+  ["fedcba9876543210"]
+]

--- a/test/spec/traceql/regex_attr.txtar
+++ b/test/spec/traceql/regex_attr.txtar
@@ -5,3 +5,14 @@ SELECT * FROM `otel_traces` WHERE match(`ResourceAttributes`[?], ?)
 -- args --
 [0] string = "service.name"
 [1] string = "front.*"
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    ResourceAttributes Map(String, String) MATERIALIZED map('service.name', if(_idx = 0, 'frontend', if(_idx = 1, 'backend', 'frontline')))
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1), (2);
+-- expected_rows --
+[
+  [0],
+  [2]
+]

--- a/test/spec/traceql/roundtrip_chdb_test.go
+++ b/test/spec/traceql/roundtrip_chdb_test.go
@@ -1,0 +1,32 @@
+//go:build chdb
+
+// Package traceql_spec_test — chDB-backed round-trip pass over the
+// TraceQL TXTAR fixtures.
+//
+// This test is gated behind the `chdb` build tag. It walks every
+// *.txtar fixture under test/spec/traceql/ and, for fixtures that
+// declare both `seed:` and `expected_rows:`, executes the stored
+// `sql:` + `args:` against an ephemeral in-process chDB session and
+// asserts the resulting rows match `expected_rows:`.
+//
+// Fixtures without those sections are skipped (the default text-
+// equality check in internal/traceql/lower_test.go still gates them).
+package traceql_spec_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/tsouza/cerberus/test/spec"
+)
+
+func TestRoundTripChDB(t *testing.T) {
+	t.Parallel()
+
+	dir := filepath.Join(".")
+	spec.Walk(t, dir, func(t *testing.T, c *spec.Case) {
+		// LoadRoundTrip + IsRoundTrip is the opt-in gate; fixtures
+		// without seed/expected_rows are silent no-ops.
+		spec.RunRoundTrip(t, c)
+	})
+}

--- a/test/spec/traceql/select_attrs.txtar
+++ b/test/spec/traceql/select_attrs.txtar
@@ -7,3 +7,18 @@ SELECT `TraceId`, `SpanId`, `Timestamp`, `SpanAttributes`[?] AS `http.method`, `
 [1] string = "http.status_code"
 [2] string = "service.name"
 [3] string = "frontend"
+-- seed --
+CREATE TABLE otel_traces (
+    TraceId String,
+    SpanId String,
+    Timestamp DateTime64(9),
+    SpanAttributes Map(String, String),
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    ('a0000000000000000000000000000001', '0000000000000001', toDateTime64('2026-01-01 00:00:00', 9), map('http.method', 'GET', 'http.status_code', '200'), map('service.name', 'frontend')),
+    ('a0000000000000000000000000000002', '0000000000000002', toDateTime64('2026-01-01 00:00:01', 9), map('http.method', 'POST', 'http.status_code', '500'), map('service.name', 'backend'));
+-- expected_rows --
+[
+  ["a0000000000000000000000000000001", "0000000000000001", "2026-01-01T00:00:00Z", "GET", "200"]
+]

--- a/test/spec/traceql/select_one_attr.txtar
+++ b/test/spec/traceql/select_one_attr.txtar
@@ -6,3 +6,18 @@ SELECT `TraceId`, `SpanId`, `Timestamp`, `SpanAttributes`[?] AS `http.method` FR
 [0] string = "http.method"
 [1] string = "service.name"
 [2] string = "frontend"
+-- seed --
+CREATE TABLE otel_traces (
+    TraceId String,
+    SpanId String,
+    Timestamp DateTime64(9),
+    SpanAttributes Map(String, String),
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    ('a0000000000000000000000000000001', '0000000000000001', toDateTime64('2026-01-01 00:00:00', 9), map('http.method', 'GET'), map('service.name', 'frontend')),
+    ('a0000000000000000000000000000002', '0000000000000002', toDateTime64('2026-01-01 00:00:01', 9), map('http.method', 'POST'), map('service.name', 'backend'));
+-- expected_rows --
+[
+  ["a0000000000000000000000000000001", "0000000000000001", "2026-01-01T00:00:00Z", "GET"]
+]

--- a/test/spec/traceql/select_resource_attrs.txtar
+++ b/test/spec/traceql/select_resource_attrs.txtar
@@ -7,3 +7,17 @@ SELECT `TraceId`, `SpanId`, `Timestamp`, `ResourceAttributes`[?] AS `service.nam
 [1] string = "k8s.cluster.name"
 [2] string = "service.name"
 [3] string = "frontend"
+-- seed --
+CREATE TABLE otel_traces (
+    TraceId String,
+    SpanId String,
+    Timestamp DateTime64(9),
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    ('a0000000000000000000000000000001', '0000000000000001', toDateTime64('2026-01-01 00:00:00', 9), map('service.name', 'frontend', 'service.namespace', 'web', 'k8s.cluster.name', 'prod')),
+    ('a0000000000000000000000000000002', '0000000000000002', toDateTime64('2026-01-01 00:00:01', 9), map('service.name', 'backend',  'service.namespace', 'api', 'k8s.cluster.name', 'stg'));
+-- expected_rows --
+[
+  ["a0000000000000000000000000000001", "0000000000000001", "2026-01-01T00:00:00Z", "web", "prod"]
+]

--- a/test/spec/traceql/service_name_eq.txtar
+++ b/test/spec/traceql/service_name_eq.txtar
@@ -5,3 +5,13 @@ SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)
 -- args --
 [0] string = "service.name"
 [1] string = "frontend"
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    ResourceAttributes Map(String, String) MATERIALIZED map('service.name', if(_idx = 0, 'frontend', if(_idx = 1, 'backend', 'db')))
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1), (2);
+-- expected_rows --
+[
+  [0]
+]

--- a/test/spec/traceql/span_attr_default.txtar
+++ b/test/spec/traceql/span_attr_default.txtar
@@ -5,3 +5,13 @@ SELECT * FROM `otel_traces` WHERE (`SpanAttributes`[?] = ?)
 -- args --
 [0] string = "http.method"
 [1] string = "GET"
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    SpanAttributes Map(String, String) MATERIALIZED map('http.method', if(_idx = 0, 'GET', 'POST'))
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1);
+-- expected_rows --
+[
+  [0]
+]

--- a/test/spec/traceql/span_attr_explicit.txtar
+++ b/test/spec/traceql/span_attr_explicit.txtar
@@ -5,3 +5,13 @@ SELECT * FROM `otel_traces` WHERE (`SpanAttributes`[?] = ?)
 -- args --
 [0] string = "http.method"
 [1] string = "GET"
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    SpanAttributes Map(String, String) MATERIALIZED map('http.method', if(_idx = 0, 'GET', 'POST'))
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1);
+-- expected_rows --
+[
+  [0]
+]

--- a/test/spec/traceql/span_id_intrinsic.txtar
+++ b/test/spec/traceql/span_id_intrinsic.txtar
@@ -4,3 +4,15 @@
 SELECT * FROM `otel_traces` WHERE (`SpanId` = ?)
 -- args --
 [0] string = "0123456789abcdef"
+-- seed --
+CREATE TABLE otel_traces (
+    SpanId String
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    ('0000000000000001'),
+    ('0123456789abcdef'),
+    ('fedcba9876543210');
+-- expected_rows --
+[
+  ["0123456789abcdef"]
+]

--- a/test/spec/traceql/static_float.txtar
+++ b/test/spec/traceql/static_float.txtar
@@ -5,3 +5,13 @@ SELECT * FROM `otel_traces` WHERE (`SpanAttributes`[?] = ?)
 -- args --
 [0] string = "ratio"
 [1] float64 = 0.95
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    SpanAttributes Map(String, String) MATERIALIZED map('ratio', if(_idx = 0, '0.95', '0.5'))
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1);
+-- expected_rows --
+[
+  [0]
+]

--- a/test/spec/traceql/static_int.txtar
+++ b/test/spec/traceql/static_int.txtar
@@ -5,3 +5,13 @@ SELECT * FROM `otel_traces` WHERE (`SpanAttributes`[?] = ?)
 -- args --
 [0] string = "attempt"
 [1] int64 = 1
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    SpanAttributes Map(String, String) MATERIALIZED map('attempt', if(_idx = 0, '1', '2'))
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1);
+-- expected_rows --
+[
+  [0]
+]

--- a/test/spec/traceql/status_and_kind_combined.txtar
+++ b/test/spec/traceql/status_and_kind_combined.txtar
@@ -5,3 +5,16 @@ SELECT * FROM `otel_traces` PREWHERE (`StatusCode` = ?) WHERE (`SpanKind` = ?)
 -- args --
 [0] string = "Error"
 [1] string = "Server"
+-- seed --
+CREATE TABLE otel_traces (
+    StatusCode String,
+    SpanKind String MATERIALIZED if(StatusCode = 'Error', 'Server', 'Client')
+) ENGINE = MergeTree ORDER BY StatusCode;
+INSERT INTO otel_traces (StatusCode) VALUES
+    ('Error'),
+    ('Ok'),
+    ('Unset');
+-- expected_rows --
+[
+  ["Error"]
+]

--- a/test/spec/traceql/status_code_eq.txtar
+++ b/test/spec/traceql/status_code_eq.txtar
@@ -5,3 +5,13 @@ SELECT * FROM `otel_traces` WHERE (`SpanAttributes`[?] = ?)
 -- args --
 [0] string = "http.status_code"
 [1] int64 = 200
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    SpanAttributes Map(String, String) MATERIALIZED map('http.status_code', if(_idx = 0, '200', if(_idx = 1, '404', '500')))
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1), (2);
+-- expected_rows --
+[
+  [0]
+]

--- a/test/spec/traceql/status_code_ge.txtar
+++ b/test/spec/traceql/status_code_ge.txtar
@@ -5,3 +5,14 @@ SELECT * FROM `otel_traces` WHERE (`SpanAttributes`[?] >= ?)
 -- args --
 [0] string = "http.status_code"
 [1] int64 = 500
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    SpanAttributes Map(String, String) MATERIALIZED map('http.status_code', if(_idx = 0, '500', if(_idx = 1, '503', '200')))
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1), (2);
+-- expected_rows --
+[
+  [0],
+  [1]
+]

--- a/test/spec/traceql/status_eq_error.txtar
+++ b/test/spec/traceql/status_eq_error.txtar
@@ -4,3 +4,15 @@
 SELECT * FROM `otel_traces` WHERE (`StatusCode` = ?)
 -- args --
 [0] string = "Error"
+-- seed --
+CREATE TABLE otel_traces (
+    StatusCode String
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    ('Ok'),
+    ('Error'),
+    ('Unset');
+-- expected_rows --
+[
+  ["Error"]
+]

--- a/test/spec/traceql/status_message.txtar
+++ b/test/spec/traceql/status_message.txtar
@@ -4,3 +4,15 @@
 SELECT * FROM `otel_traces` WHERE (`StatusMessage` = ?)
 -- args --
 [0] string = "internal server error"
+-- seed --
+CREATE TABLE otel_traces (
+    StatusMessage String
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    (''),
+    ('internal server error'),
+    ('timeout');
+-- expected_rows --
+[
+  ["internal server error"]
+]

--- a/test/spec/traceql/status_neq_ok.txtar
+++ b/test/spec/traceql/status_neq_ok.txtar
@@ -4,3 +4,16 @@
 SELECT * FROM `otel_traces` WHERE (`StatusCode` != ?)
 -- args --
 [0] string = "Ok"
+-- seed --
+CREATE TABLE otel_traces (
+    StatusCode String
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    ('Ok'),
+    ('Error'),
+    ('Unset');
+-- expected_rows --
+[
+  ["Error"],
+  ["Unset"]
+]

--- a/test/spec/traceql/status_unset.txtar
+++ b/test/spec/traceql/status_unset.txtar
@@ -4,3 +4,15 @@
 SELECT * FROM `otel_traces` WHERE (`StatusCode` = ?)
 -- args --
 [0] string = "Unset"
+-- seed --
+CREATE TABLE otel_traces (
+    StatusCode String
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    ('Ok'),
+    ('Error'),
+    ('Unset');
+-- expected_rows --
+[
+  ["Unset"]
+]

--- a/test/spec/traceql/sum_duration.txtar
+++ b/test/spec/traceql/sum_duration.txtar
@@ -6,3 +6,17 @@ SELECT * FROM (SELECT sum(`Duration`) AS `Value` FROM (SELECT * FROM `otel_trace
 [0] string = "service.name"
 [1] string = "frontend"
 [2] int64 = 100000000
+-- seed --
+CREATE TABLE otel_traces (
+    ResourceAttributes Map(String, String),
+    Duration UInt64
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    (map('service.name', 'frontend'), 50000000),
+    (map('service.name', 'frontend'), 80000000),
+    (map('service.name', 'frontend'), 120000000),
+    (map('service.name', 'backend'),  900000000);
+-- expected_rows --
+[
+  [250000000]
+]

--- a/test/spec/traceql/sum_span_attr.txtar
+++ b/test/spec/traceql/sum_span_attr.txtar
@@ -7,3 +7,15 @@ SELECT * FROM (SELECT sum(`SpanAttributes`[?]) AS `Value` FROM (SELECT * FROM `o
 [1] string = "http.status_code"
 [2] int64 = 400
 [3] int64 = 0
+-- seed --
+CREATE TABLE otel_traces (
+    SpanAttributes Map(String, UInt64)
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    (map('http.status_code', 500)),
+    (map('http.status_code', 404)),
+    (map('http.status_code', 200));
+-- expected_rows --
+[
+  [904]
+]

--- a/test/spec/traceql/trace_id_intrinsic.txtar
+++ b/test/spec/traceql/trace_id_intrinsic.txtar
@@ -4,3 +4,15 @@
 SELECT * FROM `otel_traces` WHERE (`TraceId` = ?)
 -- args --
 [0] string = "abcdef0123456789"
+-- seed --
+CREATE TABLE otel_traces (
+    TraceId String
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    ('0123456789abcdef'),
+    ('abcdef0123456789'),
+    ('fedcba9876543210');
+-- expected_rows --
+[
+  ["abcdef0123456789"]
+]


### PR DESCRIPTION
## Summary

- Add `seed:` + `expected_rows:` sections to 61 TraceQL TXTAR fixtures so the `chdb`-tagged round-trip runner exercises each emitted query against an ephemeral in-process chDB.
- Add `test/spec/traceql/roundtrip_chdb_test.go` mirroring the PromQL/LogQL layer-6 drivers.
- Coverage hits every shape the runner can express: intrinsics (duration, name, kind, status, statusMessage, trace:id, span:id, parent), attribute matchers on every scope, status/kind enum statics, multi-attribute compound predicates, inner attribute aggregates, the full MetricsPipeline (rate, *_over_time, histogram_over_time + by), span event/link attribute matchers (via the dotted-name Array(Map) column trick), group/coalesce, and select projections.

## What stays unrounded

- Joins (child_of, parent_of, recursive_*, multi_hop_chain, sibling_simple, set_intersect_simple) and the top-level UNION (set_union_simple) — the runner's textual `extractProjectionCount` cannot tell that `SELECT R.*` over a subquery expands to N columns, so the scan target slice is sized to 1 and Scan rejects the row.
- `bool_attr` (`= true` on a Map(String,String) value) — CH refuses to compare String to Bool without an explicit cast, and we can't reshape the emitted SQL.

## Trick used

For fixtures that ran `SELECT * FROM otel_traces WHERE <Map subscript>` the table is shaped as a single visible scalar plus the Map column(s) declared `MATERIALIZED`. `SELECT *` skips materialized columns by default, so the projection-count constraint is satisfied while the WHERE still gets a fully-functional Map to subscript into. PREWHERE fixtures use MergeTree (the only engine that accepts PREWHERE); everything else stays on Memory.

## Test plan

- [ ] CI `check` + `lint` lanes pass (no semantic change to non-chDB paths).
- [ ] Nightly `chdb` workflow (`just spec-chdb`) executes the 61 round-trips and reports green.