### PR TITLE
test(parsers): pin AST shape + error preservation for 3 upstream parsers

### DIFF
--- a/internal/logql/parser_shape_test.go
+++ b/internal/logql/parser_shape_test.go
@@ -1,0 +1,390 @@
+package logql
+
+import (
+	"strings"
+	"testing"
+
+	loglib "github.com/grafana/loki/v3/pkg/logql/log"
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+// TestParserShape_* tests pin specific properties of the parsed Loki
+// AST so we catch silent breakage when the upstream parser bumps. The
+// asserted fields mirror what cerberus's lowering layer reads in
+// internal/logql/{lower,range_aggregation,vector_aggregation}.go.
+//
+// Pure acceptance / rejection is already covered by TestParserSmoke
+// / TestParserSmoke_Rejected.
+
+func mustParseLogQL(t *testing.T, q string) syntax.Expr {
+	t.Helper()
+	expr, err := syntax.ParseExpr(q)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", q, err)
+	}
+	if expr == nil {
+		t.Fatalf("ParseExpr(%q) returned nil", q)
+	}
+	return expr
+}
+
+// TestParserShape_StreamSelector pins the *MatchersExpr root + matcher
+// shape for `{app="api"}`.
+func TestParserShape_StreamSelector(t *testing.T) {
+	t.Parallel()
+	expr := mustParseLogQL(t, `{app="api"}`)
+	me, ok := expr.(*syntax.MatchersExpr)
+	if !ok {
+		t.Fatalf("expected *MatchersExpr, got %T", expr)
+	}
+	if len(me.Mts) != 1 {
+		t.Fatalf("len(Mts) = %d; want 1", len(me.Mts))
+	}
+	m := me.Mts[0]
+	if m.Name != "app" {
+		t.Errorf("matcher Name = %q; want %q", m.Name, "app")
+	}
+	if m.Value != "api" {
+		t.Errorf("matcher Value = %q; want %q", m.Value, "api")
+	}
+	if m.Type != labels.MatchEqual {
+		t.Errorf("matcher Type = %v; want MatchEqual", m.Type)
+	}
+}
+
+// TestParserShape_LineFilter pins the *PipelineExpr / *LineFilterExpr
+// shape for `{app="api"} |= "error"`.
+func TestParserShape_LineFilter(t *testing.T) {
+	t.Parallel()
+	expr := mustParseLogQL(t, `{app="api"} |= "error"`)
+	pe, ok := expr.(*syntax.PipelineExpr)
+	if !ok {
+		t.Fatalf("expected *PipelineExpr, got %T", expr)
+	}
+	if pe.Left == nil {
+		t.Fatal("PipelineExpr.Left is nil; expected stream selector")
+	}
+	if len(pe.MultiStages) != 1 {
+		t.Fatalf("len(MultiStages) = %d; want 1", len(pe.MultiStages))
+	}
+	lf, ok := pe.MultiStages[0].(*syntax.LineFilterExpr)
+	if !ok {
+		t.Fatalf("stage = %T; want *LineFilterExpr", pe.MultiStages[0])
+	}
+	if lf.Match != "error" {
+		t.Errorf("LineFilter.Match = %q; want %q", lf.Match, "error")
+	}
+	if lf.Ty != loglib.LineMatchEqual {
+		t.Errorf("LineFilter.Ty = %v; want LineMatchEqual", lf.Ty)
+	}
+}
+
+// TestParserShape_JSONAndLabelFilter pins the `*LineParserExpr` (json)
+// plus following `*LabelFilterExpr` shape.
+func TestParserShape_JSONAndLabelFilter(t *testing.T) {
+	t.Parallel()
+	expr := mustParseLogQL(t, `{app="api"} | json | level="error"`)
+	pe, ok := expr.(*syntax.PipelineExpr)
+	if !ok {
+		t.Fatalf("expected *PipelineExpr, got %T", expr)
+	}
+	if len(pe.MultiStages) != 2 {
+		t.Fatalf("len(MultiStages) = %d; want 2 (json + label filter)", len(pe.MultiStages))
+	}
+	js, ok := pe.MultiStages[0].(*syntax.LineParserExpr)
+	if !ok {
+		t.Fatalf("stage[0] = %T; want *LineParserExpr", pe.MultiStages[0])
+	}
+	if js.Op != syntax.OpParserTypeJSON {
+		t.Errorf("LineParserExpr.Op = %q; want %q", js.Op, syntax.OpParserTypeJSON)
+	}
+	if _, ok := pe.MultiStages[1].(*syntax.LabelFilterExpr); !ok {
+		t.Errorf("stage[1] = %T; want *LabelFilterExpr", pe.MultiStages[1])
+	}
+}
+
+// TestParserShape_RegexLineFilter pins LineMatchRegexp on `|~`.
+func TestParserShape_RegexLineFilter(t *testing.T) {
+	t.Parallel()
+	expr := mustParseLogQL(t, `{app="api"} |~ "(?i)error"`)
+	pe, ok := expr.(*syntax.PipelineExpr)
+	if !ok {
+		t.Fatalf("expected *PipelineExpr, got %T", expr)
+	}
+	lf, ok := pe.MultiStages[0].(*syntax.LineFilterExpr)
+	if !ok {
+		t.Fatalf("stage[0] = %T; want *LineFilterExpr", pe.MultiStages[0])
+	}
+	if lf.Ty != loglib.LineMatchRegexp {
+		t.Errorf("LineFilter.Ty = %v; want LineMatchRegexp", lf.Ty)
+	}
+	if lf.Match != "(?i)error" {
+		t.Errorf("LineFilter.Match = %q; want %q", lf.Match, "(?i)error")
+	}
+}
+
+// TestParserShape_RateMetric pins the *RangeAggregationExpr root for
+// `rate({app="api"}[5m])`.
+func TestParserShape_RateMetric(t *testing.T) {
+	t.Parallel()
+	expr := mustParseLogQL(t, `rate({app="api"}[5m])`)
+	rae, ok := expr.(*syntax.RangeAggregationExpr)
+	if !ok {
+		t.Fatalf("expected *RangeAggregationExpr, got %T", expr)
+	}
+	if rae.Operation != syntax.OpRangeTypeRate {
+		t.Errorf("Operation = %q; want %q", rae.Operation, syntax.OpRangeTypeRate)
+	}
+	if rae.Left == nil {
+		t.Fatal("Left (LogRangeExpr) is nil")
+	}
+	if rae.Left.Interval.Minutes() != 5 {
+		t.Errorf("Interval = %v; want 5m", rae.Left.Interval)
+	}
+	if rae.Left.Unwrap != nil {
+		t.Errorf("Unwrap = %v; want nil for line-counter rate", rae.Left.Unwrap)
+	}
+}
+
+// TestParserShape_SumByCountOverTime pins the
+// *VectorAggregationExpr(*RangeAggregationExpr) chain for the canonical
+// `sum by(level)(count_over_time({app="api"}[1m]))` query.
+func TestParserShape_SumByCountOverTime(t *testing.T) {
+	t.Parallel()
+	expr := mustParseLogQL(t, `sum by(level)(count_over_time({app="api"}[1m]))`)
+	va, ok := expr.(*syntax.VectorAggregationExpr)
+	if !ok {
+		t.Fatalf("expected *VectorAggregationExpr, got %T", expr)
+	}
+	if va.Operation != syntax.OpTypeSum {
+		t.Errorf("Operation = %q; want %q", va.Operation, syntax.OpTypeSum)
+	}
+	if va.Grouping == nil {
+		t.Fatal("Grouping is nil; want non-nil with [level]")
+	}
+	if va.Grouping.Without {
+		t.Error("Grouping.Without = true; want false")
+	}
+	if got, want := va.Grouping.Groups, []string{"level"}; !equalStrings(got, want) {
+		t.Errorf("Grouping.Groups = %v; want %v", got, want)
+	}
+	inner, ok := va.Left.(*syntax.RangeAggregationExpr)
+	if !ok {
+		t.Fatalf("Left = %T; want *RangeAggregationExpr", va.Left)
+	}
+	if inner.Operation != syntax.OpRangeTypeCount {
+		t.Errorf("inner Operation = %q; want %q", inner.Operation, syntax.OpRangeTypeCount)
+	}
+}
+
+// TestParserShape_LogfmtLineFormat pins the `*LogfmtParserExpr` +
+// `*LineFmtExpr` stage chain.
+func TestParserShape_LogfmtLineFormat(t *testing.T) {
+	t.Parallel()
+	expr := mustParseLogQL(t, `{app="api"} | logfmt | line_format "{{.msg}}"`)
+	pe, ok := expr.(*syntax.PipelineExpr)
+	if !ok {
+		t.Fatalf("expected *PipelineExpr, got %T", expr)
+	}
+	if len(pe.MultiStages) != 2 {
+		t.Fatalf("len(MultiStages) = %d; want 2", len(pe.MultiStages))
+	}
+	if _, ok := pe.MultiStages[0].(*syntax.LogfmtParserExpr); !ok {
+		t.Errorf("stage[0] = %T; want *LogfmtParserExpr", pe.MultiStages[0])
+	}
+	lfm, ok := pe.MultiStages[1].(*syntax.LineFmtExpr)
+	if !ok {
+		t.Fatalf("stage[1] = %T; want *LineFmtExpr", pe.MultiStages[1])
+	}
+	if lfm.Value != "{{.msg}}" {
+		t.Errorf("LineFmtExpr.Value = %q; want %q", lfm.Value, "{{.msg}}")
+	}
+}
+
+// TestParserShape_UnpackStage pins `*LineParserExpr{Op:
+// OpParserTypeUnpack}` for `| unpack`.
+func TestParserShape_UnpackStage(t *testing.T) {
+	t.Parallel()
+	expr := mustParseLogQL(t, `{app="api"} | unpack`)
+	pe, ok := expr.(*syntax.PipelineExpr)
+	if !ok {
+		t.Fatalf("expected *PipelineExpr, got %T", expr)
+	}
+	if len(pe.MultiStages) != 1 {
+		t.Fatalf("len(MultiStages) = %d; want 1", len(pe.MultiStages))
+	}
+	lp, ok := pe.MultiStages[0].(*syntax.LineParserExpr)
+	if !ok {
+		t.Fatalf("stage[0] = %T; want *LineParserExpr", pe.MultiStages[0])
+	}
+	if lp.Op != syntax.OpParserTypeUnpack {
+		t.Errorf("LineParserExpr.Op = %q; want %q", lp.Op, syntax.OpParserTypeUnpack)
+	}
+	if lp.Param != "" {
+		t.Errorf("LineParserExpr.Param = %q; want \"\" (unpack takes no param)", lp.Param)
+	}
+}
+
+// TestParserShape_PatternStage pins `*LineParserExpr{Op: pattern, Param:
+// "<...>"}`.
+func TestParserShape_PatternStage(t *testing.T) {
+	t.Parallel()
+	expr := mustParseLogQL(t, `{app="api"} | pattern "<_> <method> <_>"`)
+	pe, ok := expr.(*syntax.PipelineExpr)
+	if !ok {
+		t.Fatalf("expected *PipelineExpr, got %T", expr)
+	}
+	lp, ok := pe.MultiStages[0].(*syntax.LineParserExpr)
+	if !ok {
+		t.Fatalf("stage[0] = %T; want *LineParserExpr", pe.MultiStages[0])
+	}
+	if lp.Op != syntax.OpParserTypePattern {
+		t.Errorf("LineParserExpr.Op = %q; want %q", lp.Op, syntax.OpParserTypePattern)
+	}
+	if lp.Param != "<_> <method> <_>" {
+		t.Errorf("LineParserExpr.Param = %q; want %q", lp.Param, "<_> <method> <_>")
+	}
+}
+
+// TestParserShape_BytesRate pins `*RangeAggregationExpr{Operation:
+// OpRangeTypeBytesRate}` so the byte-counting code path stays
+// observable.
+func TestParserShape_BytesRate(t *testing.T) {
+	t.Parallel()
+	expr := mustParseLogQL(t, `bytes_rate({app="api"}[5m])`)
+	rae, ok := expr.(*syntax.RangeAggregationExpr)
+	if !ok {
+		t.Fatalf("expected *RangeAggregationExpr, got %T", expr)
+	}
+	if rae.Operation != syntax.OpRangeTypeBytesRate {
+		t.Errorf("Operation = %q; want %q", rae.Operation, syntax.OpRangeTypeBytesRate)
+	}
+	if rae.Left.Interval.Minutes() != 5 {
+		t.Errorf("Interval = %v; want 5m", rae.Left.Interval)
+	}
+}
+
+// Helper: assert two []string slices are equal by element.
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestParserError_* tests pin the error message substrings cerberus's
+// /loki HTTP handlers translate into LogQL error responses.
+
+func errContainsAny(err error, wants ...string) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, w := range wants {
+		if strings.Contains(msg, strings.ToLower(w)) {
+			return true
+		}
+	}
+	return false
+}
+
+func parseShouldFailLogQL(t *testing.T, q string) error {
+	t.Helper()
+	_, err := syntax.ParseExpr(q)
+	if err == nil {
+		t.Fatalf("ParseExpr(%q): expected error, got nil", q)
+	}
+	return err
+}
+
+func TestParserError_UnterminatedSelector(t *testing.T) {
+	t.Parallel()
+	err := parseShouldFailLogQL(t, `{`)
+	if !errContainsAny(err, "parse", "unexpected", "EOF", "syntax", "}") {
+		t.Errorf("err = %q; want substring indicating unterminated selector", err)
+	}
+}
+
+func TestParserError_MissingMatcherValue(t *testing.T) {
+	t.Parallel()
+	err := parseShouldFailLogQL(t, `{app=}`)
+	if !errContainsAny(err, "parse", "unexpected", "syntax", "expected", "value") {
+		t.Errorf("err = %q; want substring rejecting missing matcher value", err)
+	}
+}
+
+func TestParserError_LineFilterMissingPattern(t *testing.T) {
+	t.Parallel()
+	err := parseShouldFailLogQL(t, `{app="x"} |= `)
+	if !errContainsAny(err, "parse", "unexpected", "syntax", "EOF", "expected") {
+		t.Errorf("err = %q; want substring rejecting missing line filter pattern", err)
+	}
+}
+
+func TestParserError_UnknownParserStage(t *testing.T) {
+	t.Parallel()
+	err := parseShouldFailLogQL(t, `{app="x"} | invalid_stage`)
+	if !errContainsAny(err, "parse", "unexpected", "syntax", "invalid_stage", "expected") {
+		t.Errorf("err = %q; want substring rejecting unknown parser stage", err)
+	}
+}
+
+func TestParserError_RateMissingRange(t *testing.T) {
+	t.Parallel()
+	err := parseShouldFailLogQL(t, `rate({app="x"})`)
+	if !errContainsAny(err, "parse", "unexpected", "range", "syntax", "expected", "log range") {
+		t.Errorf("err = %q; want substring rejecting missing range vector", err)
+	}
+}
+
+func TestParserError_EmptyMatcherSet(t *testing.T) {
+	t.Parallel()
+	// Loki rejects fully-empty matcher sets at parse / validation time.
+	err := parseShouldFailLogQL(t, `{}`)
+	if !errContainsAny(err, "matcher", "empty", "regexp", "equality", "matchers") {
+		t.Errorf("err = %q; want substring rejecting empty matcher set", err)
+	}
+}
+
+func TestParserError_UnterminatedString(t *testing.T) {
+	t.Parallel()
+	err := parseShouldFailLogQL(t, `{app="api`)
+	if !errContainsAny(err, "parse", "unexpected", "syntax", "EOF", "string", "expected") {
+		t.Errorf("err = %q; want substring rejecting unterminated string", err)
+	}
+}
+
+func TestParserError_UnterminatedRange(t *testing.T) {
+	t.Parallel()
+	err := parseShouldFailLogQL(t, `rate({app="api"}[`)
+	if !errContainsAny(err, "parse", "unexpected", "syntax", "EOF", "duration", "expected") {
+		t.Errorf("err = %q; want substring rejecting unterminated range", err)
+	}
+}
+
+func TestParserError_AggregationWithoutUnwrap(t *testing.T) {
+	t.Parallel()
+	// Loki rejects unwrap-required range aggregations (`avg_over_time`,
+	// `quantile_over_time`, `sum_over_time`, …) when there is no
+	// `| unwrap` stage. cerberus depends on this validation to keep
+	// its lowering simple — if upstream loosens it, the typed-value path
+	// could be reached with a nil unwrap.
+	err := parseShouldFailLogQL(t, `avg_over_time({app="x"}[5m])`)
+	if !errContainsAny(err, "unwrap", "invalid aggregation", "parse", "without") {
+		t.Errorf("err = %q; want substring rejecting unwrap-less typed aggregation", err)
+	}
+}
+
+func TestParserError_MissingMatcherName(t *testing.T) {
+	t.Parallel()
+	err := parseShouldFailLogQL(t, `{="api"}`)
+	if !errContainsAny(err, "parse", "unexpected", "syntax", "expected", "matcher") {
+		t.Errorf("err = %q; want substring rejecting missing matcher name", err)
+	}
+}

--- a/internal/promql/parser_shape_test.go
+++ b/internal/promql/parser_shape_test.go
@@ -1,0 +1,463 @@
+package promql
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+// TestParserShape_* tests pin specific properties of the parsed AST so we
+// catch silent breakage when the upstream Prometheus parser bumps. Each
+// test parses a representative query and asserts the concrete root-node
+// type plus the field values cerberus's lowering actually reads (see
+// internal/promql/lower.go, internal/promql/binary.go,
+// internal/promql/subquery.go).
+//
+// The intent is shape pinning, not parser coverage — generic acceptance
+// is already covered by TestParserSmoke / TestParserSmoke_Rejected.
+//
+// If upstream renames a field or changes a type, these tests fail loudly.
+// If upstream just adds a new field, these tests stay green.
+
+func mustParse(t *testing.T, q string) parser.Expr {
+	t.Helper()
+	p := parser.NewParser(parser.Options{})
+	expr, err := p.ParseExpr(q)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", q, err)
+	}
+	if expr == nil {
+		t.Fatalf("ParseExpr(%q) returned nil", q)
+	}
+	return expr
+}
+
+// TestParserShape_InstantSelector pins the VectorSelector root + the
+// __name__ matcher promotion the parser performs for `up`.
+func TestParserShape_InstantSelector(t *testing.T) {
+	t.Parallel()
+	expr := mustParse(t, `up`)
+	vs, ok := expr.(*parser.VectorSelector)
+	if !ok {
+		t.Fatalf("expected *VectorSelector, got %T", expr)
+	}
+	if vs.Name != "up" {
+		t.Errorf("Name = %q; want %q", vs.Name, "up")
+	}
+	if len(vs.LabelMatchers) == 0 {
+		t.Fatal("LabelMatchers is empty; expected synthesised __name__ matcher")
+	}
+	// The parser synthesises a __name__=="up" matcher from the bare name.
+	var nameMatcher *labels.Matcher
+	for _, m := range vs.LabelMatchers {
+		if m.Name == labels.MetricName {
+			nameMatcher = m
+			break
+		}
+	}
+	if nameMatcher == nil {
+		t.Fatal("no __name__ matcher in LabelMatchers")
+	}
+	if nameMatcher.Type != labels.MatchEqual {
+		t.Errorf("__name__ matcher Type = %v; want MatchEqual", nameMatcher.Type)
+	}
+	if nameMatcher.Value != "up" {
+		t.Errorf("__name__ matcher Value = %q; want %q", nameMatcher.Value, "up")
+	}
+}
+
+// TestParserShape_RateOverMatrix pins the Call(rate, MatrixSelector(VS))
+// shape — the canonical range-vector function form rate / increase /
+// *_over_time take.
+func TestParserShape_RateOverMatrix(t *testing.T) {
+	t.Parallel()
+	expr := mustParse(t, `rate(http_requests_total[5m])`)
+	call, ok := expr.(*parser.Call)
+	if !ok {
+		t.Fatalf("expected *Call, got %T", expr)
+	}
+	if call.Func == nil {
+		t.Fatal("Call.Func is nil")
+	}
+	if call.Func.Name != "rate" {
+		t.Errorf("Func.Name = %q; want %q", call.Func.Name, "rate")
+	}
+	if len(call.Args) != 1 {
+		t.Fatalf("len(Args) = %d; want 1", len(call.Args))
+	}
+	ms, ok := call.Args[0].(*parser.MatrixSelector)
+	if !ok {
+		t.Fatalf("Args[0] = %T; want *MatrixSelector", call.Args[0])
+	}
+	if ms.Range.String() != "5m0s" && ms.Range.Minutes() != 5 {
+		t.Errorf("Range = %v; want 5m", ms.Range)
+	}
+	vs, ok := ms.VectorSelector.(*parser.VectorSelector)
+	if !ok {
+		t.Fatalf("MatrixSelector.VectorSelector = %T; want *VectorSelector", ms.VectorSelector)
+	}
+	if vs.Name != "http_requests_total" {
+		t.Errorf("inner Name = %q; want %q", vs.Name, "http_requests_total")
+	}
+}
+
+// TestParserShape_AggregationBy pins the AggregateExpr root + the
+// Grouping / Without contract for `sum by(job)(rate(...))`.
+func TestParserShape_AggregationBy(t *testing.T) {
+	t.Parallel()
+	expr := mustParse(t, `sum by(job)(rate(http_requests_total[5m]))`)
+	agg, ok := expr.(*parser.AggregateExpr)
+	if !ok {
+		t.Fatalf("expected *AggregateExpr, got %T", expr)
+	}
+	if agg.Op != parser.SUM {
+		t.Errorf("Op = %v; want SUM", agg.Op)
+	}
+	if got, want := agg.Grouping, []string{"job"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("Grouping = %v; want %v", got, want)
+	}
+	if agg.Without {
+		t.Error("Without = true; want false (we used `by`)")
+	}
+	if _, ok := agg.Expr.(*parser.Call); !ok {
+		t.Errorf("inner Expr = %T; want *Call", agg.Expr)
+	}
+	if agg.Param != nil {
+		t.Errorf("Param = %v; want nil for non-parameterised SUM", agg.Param)
+	}
+}
+
+// TestParserShape_NestedAggregation pins the histogram_quantile shape:
+// outer Call wrapping inner AggregateExpr by (le).
+func TestParserShape_NestedAggregation(t *testing.T) {
+	t.Parallel()
+	expr := mustParse(t, `histogram_quantile(0.95, sum by(le)(rate(http_request_duration_seconds_bucket[5m])))`)
+	call, ok := expr.(*parser.Call)
+	if !ok {
+		t.Fatalf("expected *Call, got %T", expr)
+	}
+	if call.Func.Name != "histogram_quantile" {
+		t.Errorf("Func.Name = %q; want histogram_quantile", call.Func.Name)
+	}
+	if len(call.Args) != 2 {
+		t.Fatalf("len(Args) = %d; want 2", len(call.Args))
+	}
+	if _, ok := call.Args[0].(*parser.NumberLiteral); !ok {
+		t.Errorf("Args[0] = %T; want *NumberLiteral", call.Args[0])
+	}
+	inner, ok := call.Args[1].(*parser.AggregateExpr)
+	if !ok {
+		t.Fatalf("Args[1] = %T; want *AggregateExpr", call.Args[1])
+	}
+	if inner.Op != parser.SUM {
+		t.Errorf("inner Op = %v; want SUM", inner.Op)
+	}
+	if got, want := inner.Grouping, []string{"le"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("inner Grouping = %v; want %v", got, want)
+	}
+}
+
+// TestParserShape_MatcherAndOffset pins both label-matcher decoding and
+// the OriginalOffset field cerberus reads in anchorFromSelector.
+func TestParserShape_MatcherAndOffset(t *testing.T) {
+	t.Parallel()
+	expr := mustParse(t, `up{job="prom"} offset 5m`)
+	vs, ok := expr.(*parser.VectorSelector)
+	if !ok {
+		t.Fatalf("expected *VectorSelector, got %T", expr)
+	}
+	// We expect a __name__=up matcher AND a job=prom matcher.
+	var jobMatcher *labels.Matcher
+	for _, m := range vs.LabelMatchers {
+		if m.Name == "job" {
+			jobMatcher = m
+			break
+		}
+	}
+	if jobMatcher == nil {
+		t.Fatal("no job matcher in LabelMatchers")
+	}
+	if jobMatcher.Type != labels.MatchEqual {
+		t.Errorf("job matcher Type = %v; want MatchEqual", jobMatcher.Type)
+	}
+	if jobMatcher.Value != "prom" {
+		t.Errorf("job matcher Value = %q; want %q", jobMatcher.Value, "prom")
+	}
+	if vs.OriginalOffset.Minutes() != 5 {
+		t.Errorf("OriginalOffset = %v; want 5m", vs.OriginalOffset)
+	}
+}
+
+// TestParserShape_BinaryVectorMatch pins the BinaryExpr + VectorMatching
+// shape for `a + on(job) b`.
+func TestParserShape_BinaryVectorMatch(t *testing.T) {
+	t.Parallel()
+	expr := mustParse(t, `a + on(job) b`)
+	bin, ok := expr.(*parser.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *BinaryExpr, got %T", expr)
+	}
+	if bin.Op != parser.ADD {
+		t.Errorf("Op = %v; want ADD", bin.Op)
+	}
+	if bin.ReturnBool {
+		t.Error("ReturnBool = true; want false (no bool modifier)")
+	}
+	if bin.VectorMatching == nil {
+		t.Fatal("VectorMatching = nil; want non-nil for `on(job)`")
+	}
+	vm := bin.VectorMatching
+	if !vm.On {
+		t.Error("VectorMatching.On = false; want true for `on(job)`")
+	}
+	if got, want := vm.MatchingLabels, []string{"job"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("MatchingLabels = %v; want %v", got, want)
+	}
+	if vm.Card != parser.CardOneToOne {
+		t.Errorf("Card = %v; want CardOneToOne (no group_left/right)", vm.Card)
+	}
+}
+
+// TestParserShape_ComparisonBool pins ReturnBool propagation for
+// `up == bool 0`.
+func TestParserShape_ComparisonBool(t *testing.T) {
+	t.Parallel()
+	expr := mustParse(t, `up == bool 0`)
+	bin, ok := expr.(*parser.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *BinaryExpr, got %T", expr)
+	}
+	if bin.Op != parser.EQLC {
+		t.Errorf("Op = %v; want EQLC", bin.Op)
+	}
+	if !bin.ReturnBool {
+		t.Error("ReturnBool = false; want true (we used `bool`)")
+	}
+	// LHS is the vector, RHS is the scalar literal 0.
+	if _, ok := bin.LHS.(*parser.VectorSelector); !ok {
+		t.Errorf("LHS = %T; want *VectorSelector", bin.LHS)
+	}
+	rhs, ok := bin.RHS.(*parser.NumberLiteral)
+	if !ok {
+		t.Fatalf("RHS = %T; want *NumberLiteral", bin.RHS)
+	}
+	if rhs.Val != 0 {
+		t.Errorf("RHS.Val = %v; want 0", rhs.Val)
+	}
+}
+
+// TestParserShape_Subquery pins the SubqueryExpr root + Range / Step
+// fields cerberus reads in subquery.go.
+func TestParserShape_Subquery(t *testing.T) {
+	t.Parallel()
+	expr := mustParse(t, `max_over_time(rate(m[1m])[5m:30s])`)
+	outer, ok := expr.(*parser.Call)
+	if !ok {
+		t.Fatalf("expected outer *Call, got %T", expr)
+	}
+	if outer.Func.Name != "max_over_time" {
+		t.Errorf("outer Func.Name = %q; want max_over_time", outer.Func.Name)
+	}
+	if len(outer.Args) != 1 {
+		t.Fatalf("outer len(Args) = %d; want 1", len(outer.Args))
+	}
+	sub, ok := outer.Args[0].(*parser.SubqueryExpr)
+	if !ok {
+		t.Fatalf("outer Args[0] = %T; want *SubqueryExpr", outer.Args[0])
+	}
+	if sub.Range.Minutes() != 5 {
+		t.Errorf("Subquery.Range = %v; want 5m", sub.Range)
+	}
+	if sub.Step.Seconds() != 30 {
+		t.Errorf("Subquery.Step = %v; want 30s", sub.Step)
+	}
+	innerCall, ok := sub.Expr.(*parser.Call)
+	if !ok {
+		t.Fatalf("Subquery.Expr = %T; want *Call (rate)", sub.Expr)
+	}
+	if innerCall.Func.Name != "rate" {
+		t.Errorf("inner Call Func.Name = %q; want rate", innerCall.Func.Name)
+	}
+}
+
+// TestParserShape_GroupLeftInclude pins the cardinality modifier on
+// BinaryExpr.VectorMatching: Card == CardManyToOne and Include set.
+func TestParserShape_GroupLeftInclude(t *testing.T) {
+	t.Parallel()
+	expr := mustParse(t, `m1 / on(le) group_left(method) m2`)
+	bin, ok := expr.(*parser.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *BinaryExpr, got %T", expr)
+	}
+	if bin.Op != parser.DIV {
+		t.Errorf("Op = %v; want DIV", bin.Op)
+	}
+	if bin.VectorMatching == nil {
+		t.Fatal("VectorMatching = nil; want non-nil for `on(le) group_left(method)`")
+	}
+	vm := bin.VectorMatching
+	if vm.Card != parser.CardManyToOne {
+		t.Errorf("Card = %v; want CardManyToOne (group_left)", vm.Card)
+	}
+	if !vm.On {
+		t.Error("On = false; want true for `on(le)`")
+	}
+	if got, want := vm.MatchingLabels, []string{"le"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("MatchingLabels = %v; want %v", got, want)
+	}
+	if got, want := vm.Include, []string{"method"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("Include = %v; want %v", got, want)
+	}
+}
+
+// TestParserShape_ScalarArithmetic pins the ParenExpr + nested
+// BinaryExpr shape for `(1 + 2) * 3`. cerberus's tryScalarLiteral walks
+// ParenExpr / UnaryExpr / NumberLiteral; pinning the root type as
+// *BinaryExpr (the outer `*`) and its LHS as *ParenExpr ensures that
+// walk stays valid.
+func TestParserShape_ScalarArithmetic(t *testing.T) {
+	t.Parallel()
+	expr := mustParse(t, `(1 + 2) * 3`)
+	bin, ok := expr.(*parser.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *BinaryExpr, got %T", expr)
+	}
+	if bin.Op != parser.MUL {
+		t.Errorf("Op = %v; want MUL", bin.Op)
+	}
+	paren, ok := bin.LHS.(*parser.ParenExpr)
+	if !ok {
+		t.Fatalf("LHS = %T; want *ParenExpr", bin.LHS)
+	}
+	inner, ok := paren.Expr.(*parser.BinaryExpr)
+	if !ok {
+		t.Fatalf("ParenExpr.Expr = %T; want *BinaryExpr", paren.Expr)
+	}
+	if inner.Op != parser.ADD {
+		t.Errorf("inner Op = %v; want ADD", inner.Op)
+	}
+	rhsLit, ok := bin.RHS.(*parser.NumberLiteral)
+	if !ok {
+		t.Fatalf("RHS = %T; want *NumberLiteral", bin.RHS)
+	}
+	if rhsLit.Val != 3 {
+		t.Errorf("RHS.Val = %v; want 3", rhsLit.Val)
+	}
+}
+
+// TestParserError_* tests pin the error message substrings cerberus's
+// HTTP handlers translate into PromQL error responses. If upstream
+// changes a message, these tests catch the drift before users see a
+// different errorType bubble up.
+
+// errContainsAny returns true when err's message contains at least one
+// of the supplied substrings (case-insensitive).
+func errContainsAny(err error, wants ...string) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, w := range wants {
+		if strings.Contains(msg, strings.ToLower(w)) {
+			return true
+		}
+	}
+	return false
+}
+
+func parseShouldFail(t *testing.T, q string) error {
+	t.Helper()
+	p := parser.NewParser(parser.Options{})
+	_, err := p.ParseExpr(q)
+	if err == nil {
+		t.Fatalf("ParseExpr(%q): expected error, got nil", q)
+	}
+	return err
+}
+
+func TestParserError_UnterminatedSelector(t *testing.T) {
+	t.Parallel()
+	err := parseShouldFail(t, `up{`)
+	if !errContainsAny(err, "unexpected", "EOF", "}", "expected") {
+		t.Errorf("err = %q; want substring indicating an unterminated selector", err)
+	}
+}
+
+func TestParserError_UnclosedRangeCall(t *testing.T) {
+	t.Parallel()
+	err := parseShouldFail(t, `rate(`)
+	if !errContainsAny(err, "unexpected", "EOF", "expected", "unclosed", "parenthesis") {
+		t.Errorf("err = %q; want substring indicating an unclosed call", err)
+	}
+}
+
+func TestParserError_MissingRightOperand(t *testing.T) {
+	t.Parallel()
+	err := parseShouldFail(t, `1 +`)
+	if !errContainsAny(err, "unexpected", "EOF", "expected") {
+		t.Errorf("err = %q; want substring indicating missing rhs", err)
+	}
+}
+
+func TestParserError_MissingFunctionArg(t *testing.T) {
+	t.Parallel()
+	err := parseShouldFail(t, `histogram_quantile(0.95)`)
+	// Upstream surfaces a wrong-number-of-args message; pin the
+	// signal so the API layer's translation stays observable.
+	if !errContainsAny(err, "argument", "expected", "wrong", "got") {
+		t.Errorf("err = %q; want substring indicating arg-count mismatch", err)
+	}
+}
+
+func TestParserError_BadOffsetLiteral(t *testing.T) {
+	t.Parallel()
+	err := parseShouldFail(t, `up offset abc`)
+	if !errContainsAny(err, "unexpected", "duration", "abc", "expected") {
+		t.Errorf("err = %q; want substring indicating bad offset value", err)
+	}
+}
+
+func TestParserError_UnknownFunction(t *testing.T) {
+	t.Parallel()
+	err := parseShouldFail(t, `unknown_function(up)`)
+	if !errContainsAny(err, "unknown function", "unknown_function", "unexpected") {
+		t.Errorf("err = %q; want substring naming the unknown function", err)
+	}
+}
+
+func TestParserError_NegativeSubqueryStep(t *testing.T) {
+	t.Parallel()
+	err := parseShouldFail(t, `up[5m:-5s]`)
+	if !errContainsAny(err, "negative", "positive", "step", "unexpected", "duration", "greater than 0") {
+		t.Errorf("err = %q; want substring rejecting a negative step", err)
+	}
+}
+
+func TestParserError_UnterminatedString(t *testing.T) {
+	t.Parallel()
+	err := parseShouldFail(t, `up{label="`)
+	if !errContainsAny(err, "unterminated", "string", "EOF", "unexpected") {
+		t.Errorf("err = %q; want substring indicating unterminated string literal", err)
+	}
+}
+
+func TestParserError_MismatchedParen(t *testing.T) {
+	t.Parallel()
+	err := parseShouldFail(t, `((1)`)
+	if !errContainsAny(err, "unexpected", "EOF", "expected", "paren", ")") {
+		t.Errorf("err = %q; want substring indicating mismatched parens", err)
+	}
+}
+
+func TestParserError_AtNow(t *testing.T) {
+	t.Parallel()
+	// `up @ now` — `@` expects a numeric timestamp or start()/end(),
+	// not a bare identifier. Upstream rejects this.
+	err := parseShouldFail(t, `up @ now`)
+	if !errContainsAny(err, "unexpected", "expected", "@", "now") {
+		t.Errorf("err = %q; want substring rejecting `@ now`", err)
+	}
+}

--- a/internal/promql/parser_shape_test.go
+++ b/internal/promql/parser_shape_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 )
@@ -53,7 +54,7 @@ func TestParserShape_InstantSelector(t *testing.T) {
 	// The parser synthesises a __name__=="up" matcher from the bare name.
 	var nameMatcher *labels.Matcher
 	for _, m := range vs.LabelMatchers {
-		if m.Name == labels.MetricName {
+		if m.Name == model.MetricNameLabel {
 			nameMatcher = m
 			break
 		}

--- a/internal/traceql/parser_shape_test.go
+++ b/internal/traceql/parser_shape_test.go
@@ -1,0 +1,393 @@
+package traceql
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/grafana/tempo/pkg/traceql"
+)
+
+// TestParserShape_* tests pin specific properties of the parsed Tempo
+// AST so we catch silent breakage when the upstream parser bumps. Each
+// test mirrors what cerberus's lowering layer reads in
+// internal/traceql/{lower,metrics_pipeline,aggregate,set_ops,...}.go.
+//
+// Pure acceptance / rejection is already covered by TestParserSmoke /
+// TestParserSmoke_Rejected.
+
+func mustParseTraceQL(t *testing.T, q string) *traceql.RootExpr {
+	t.Helper()
+	expr, err := traceql.Parse(q)
+	if err != nil {
+		t.Fatalf("Parse(%q): %v", q, err)
+	}
+	if expr == nil {
+		t.Fatalf("Parse(%q) returned nil", q)
+	}
+	return expr
+}
+
+// TestParserShape_EmptySelector pins the `{}` shape: a single
+// *SpansetFilter with Expression == Static{Type: TypeBoolean, Bool: true}.
+// cerberus relies on at least one Pipeline element for any traceql query.
+func TestParserShape_EmptySelector(t *testing.T) {
+	t.Parallel()
+	expr := mustParseTraceQL(t, `{}`)
+	if len(expr.Pipeline.Elements) != 1 {
+		t.Fatalf("Pipeline.Elements length = %d; want 1", len(expr.Pipeline.Elements))
+	}
+	sf, ok := expr.Pipeline.Elements[0].(*traceql.SpansetFilter)
+	if !ok {
+		t.Fatalf("element[0] = %T; want *SpansetFilter", expr.Pipeline.Elements[0])
+	}
+	// Empty `{}` lowers as a `true` Static literal expression.
+	st, ok := sf.Expression.(traceql.Static)
+	if !ok {
+		t.Fatalf("Expression = %T; want traceql.Static for empty {}", sf.Expression)
+	}
+	if st.Type != traceql.TypeBoolean {
+		t.Errorf("Static.Type = %v; want TypeBoolean", st.Type)
+	}
+	b, bOK := st.Bool()
+	if !bOK || !b {
+		t.Errorf("Static.Bool() = (%v, %v); want (true, true)", b, bOK)
+	}
+}
+
+// TestParserShape_IntrinsicName pins the intrinsic-name shape:
+// `{ name = "GET /api" }` lowers to BinaryOperation(=, Attribute{Intrinsic:
+// IntrinsicName}, Static{TypeString}).
+func TestParserShape_IntrinsicName(t *testing.T) {
+	t.Parallel()
+	expr := mustParseTraceQL(t, `{ name = "GET /api" }`)
+	sf := expr.Pipeline.Elements[0].(*traceql.SpansetFilter)
+	bin, ok := sf.Expression.(*traceql.BinaryOperation)
+	if !ok {
+		t.Fatalf("Expression = %T; want *BinaryOperation", sf.Expression)
+	}
+	if bin.Op != traceql.OpEqual {
+		t.Errorf("Op = %v; want OpEqual", bin.Op)
+	}
+	attr, ok := bin.LHS.(traceql.Attribute)
+	if !ok {
+		t.Fatalf("LHS = %T; want traceql.Attribute", bin.LHS)
+	}
+	if attr.Intrinsic != traceql.IntrinsicName {
+		t.Errorf("Attribute.Intrinsic = %v; want IntrinsicName", attr.Intrinsic)
+	}
+	st, ok := bin.RHS.(traceql.Static)
+	if !ok {
+		t.Fatalf("RHS = %T; want traceql.Static", bin.RHS)
+	}
+	if st.Type != traceql.TypeString {
+		t.Errorf("RHS.Type = %v; want TypeString", st.Type)
+	}
+	if got := st.EncodeToString(false); got != "GET /api" {
+		t.Errorf("RHS string = %q; want %q", got, "GET /api")
+	}
+}
+
+// TestParserShape_ResourceAttribute pins
+// `{ resource.service.name = "frontend" }`. LHS Attribute must have Scope
+// == AttributeScopeResource and Name == "service.name".
+func TestParserShape_ResourceAttribute(t *testing.T) {
+	t.Parallel()
+	expr := mustParseTraceQL(t, `{ resource.service.name = "frontend" }`)
+	sf := expr.Pipeline.Elements[0].(*traceql.SpansetFilter)
+	bin := sf.Expression.(*traceql.BinaryOperation)
+	attr, ok := bin.LHS.(traceql.Attribute)
+	if !ok {
+		t.Fatalf("LHS = %T; want traceql.Attribute", bin.LHS)
+	}
+	if attr.Scope != traceql.AttributeScopeResource {
+		t.Errorf("Scope = %v; want AttributeScopeResource", attr.Scope)
+	}
+	if attr.Name != "service.name" {
+		t.Errorf("Name = %q; want %q", attr.Name, "service.name")
+	}
+	if attr.Intrinsic != traceql.IntrinsicNone {
+		t.Errorf("Intrinsic = %v; want IntrinsicNone", attr.Intrinsic)
+	}
+}
+
+// TestParserShape_SpanAttribute pins
+// `{ span.http.status_code = 500 }`. LHS Attribute must have Scope ==
+// AttributeScopeSpan; RHS must be Static{TypeInt, 500}.
+func TestParserShape_SpanAttribute(t *testing.T) {
+	t.Parallel()
+	expr := mustParseTraceQL(t, `{ span.http.status_code = 500 }`)
+	sf := expr.Pipeline.Elements[0].(*traceql.SpansetFilter)
+	bin := sf.Expression.(*traceql.BinaryOperation)
+	attr, ok := bin.LHS.(traceql.Attribute)
+	if !ok {
+		t.Fatalf("LHS = %T; want traceql.Attribute", bin.LHS)
+	}
+	if attr.Scope != traceql.AttributeScopeSpan {
+		t.Errorf("Scope = %v; want AttributeScopeSpan", attr.Scope)
+	}
+	if attr.Name != "http.status_code" {
+		t.Errorf("Name = %q; want %q", attr.Name, "http.status_code")
+	}
+	st, ok := bin.RHS.(traceql.Static)
+	if !ok {
+		t.Fatalf("RHS = %T; want traceql.Static", bin.RHS)
+	}
+	if st.Type != traceql.TypeInt {
+		t.Errorf("RHS Type = %v; want TypeInt", st.Type)
+	}
+	i, ok := st.Int()
+	if !ok || i != 500 {
+		t.Errorf("RHS Int = (%d, %v); want (500, true)", i, ok)
+	}
+}
+
+// TestParserShape_StructuralChild pins SpansetOperation with
+// OpSpansetChild for `A > B`.
+func TestParserShape_StructuralChild(t *testing.T) {
+	t.Parallel()
+	expr := mustParseTraceQL(t, `{ name = "A" } > { name = "B" }`)
+	op, ok := expr.Pipeline.Elements[0].(traceql.SpansetOperation)
+	if !ok {
+		t.Fatalf("element[0] = %T; want traceql.SpansetOperation", expr.Pipeline.Elements[0])
+	}
+	if op.Op != traceql.OpSpansetChild {
+		t.Errorf("Op = %v; want OpSpansetChild", op.Op)
+	}
+	if _, ok := op.LHS.(*traceql.SpansetFilter); !ok {
+		t.Errorf("LHS = %T; want *SpansetFilter", op.LHS)
+	}
+	if _, ok := op.RHS.(*traceql.SpansetFilter); !ok {
+		t.Errorf("RHS = %T; want *SpansetFilter", op.RHS)
+	}
+}
+
+// TestParserShape_StructuralDescendant pins SpansetOperation with
+// OpSpansetDescendant for `A >> B`.
+func TestParserShape_StructuralDescendant(t *testing.T) {
+	t.Parallel()
+	expr := mustParseTraceQL(t, `{ name = "A" } >> { name = "B" }`)
+	op, ok := expr.Pipeline.Elements[0].(traceql.SpansetOperation)
+	if !ok {
+		t.Fatalf("element[0] = %T; want traceql.SpansetOperation", expr.Pipeline.Elements[0])
+	}
+	if op.Op != traceql.OpSpansetDescendant {
+		t.Errorf("Op = %v; want OpSpansetDescendant", op.Op)
+	}
+}
+
+// TestParserShape_SetIntersection pins SpansetOperation with
+// OpSpansetAnd for `A && B`.
+func TestParserShape_SetIntersection(t *testing.T) {
+	t.Parallel()
+	expr := mustParseTraceQL(t, `{ name = "A" } && { name = "B" }`)
+	op, ok := expr.Pipeline.Elements[0].(traceql.SpansetOperation)
+	if !ok {
+		t.Fatalf("element[0] = %T; want traceql.SpansetOperation", expr.Pipeline.Elements[0])
+	}
+	if op.Op != traceql.OpSpansetAnd {
+		t.Errorf("Op = %v; want OpSpansetAnd", op.Op)
+	}
+}
+
+// TestParserShape_StatusEnum pins `{ status = error }`. LHS is the
+// intrinsic status; RHS is Static{TypeStatus, StatusError}.
+func TestParserShape_StatusEnum(t *testing.T) {
+	t.Parallel()
+	expr := mustParseTraceQL(t, `{ status = error }`)
+	sf := expr.Pipeline.Elements[0].(*traceql.SpansetFilter)
+	bin := sf.Expression.(*traceql.BinaryOperation)
+	attr, ok := bin.LHS.(traceql.Attribute)
+	if !ok {
+		t.Fatalf("LHS = %T; want traceql.Attribute", bin.LHS)
+	}
+	if attr.Intrinsic != traceql.IntrinsicStatus {
+		t.Errorf("Attribute.Intrinsic = %v; want IntrinsicStatus", attr.Intrinsic)
+	}
+	st, ok := bin.RHS.(traceql.Static)
+	if !ok {
+		t.Fatalf("RHS = %T; want traceql.Static", bin.RHS)
+	}
+	if st.Type != traceql.TypeStatus {
+		t.Errorf("RHS.Type = %v; want TypeStatus", st.Type)
+	}
+	s, ok := st.Status()
+	if !ok {
+		t.Fatalf("Status() returned ok=false")
+	}
+	if s != traceql.StatusError {
+		t.Errorf("Status() = %v; want StatusError", s)
+	}
+}
+
+// TestParserShape_ScalarFilterCount pins
+// `{ duration > 100ms } | count() > 0` — a two-element Pipeline whose
+// tail element is a ScalarFilter{LHS: Aggregate, RHS: Static}.
+func TestParserShape_ScalarFilterCount(t *testing.T) {
+	t.Parallel()
+	expr := mustParseTraceQL(t, `{ duration > 100ms } | count() > 0`)
+	if len(expr.Pipeline.Elements) != 2 {
+		t.Fatalf("Pipeline.Elements length = %d; want 2", len(expr.Pipeline.Elements))
+	}
+	if _, ok := expr.Pipeline.Elements[0].(*traceql.SpansetFilter); !ok {
+		t.Errorf("element[0] = %T; want *SpansetFilter", expr.Pipeline.Elements[0])
+	}
+	sf, ok := expr.Pipeline.Elements[1].(traceql.ScalarFilter)
+	if !ok {
+		t.Fatalf("element[1] = %T; want traceql.ScalarFilter", expr.Pipeline.Elements[1])
+	}
+	if sf.Op != traceql.OpGreater {
+		t.Errorf("ScalarFilter.Op = %v; want OpGreater", sf.Op)
+	}
+	if _, ok := sf.LHS.(traceql.Aggregate); !ok {
+		t.Errorf("LHS = %T; want traceql.Aggregate", sf.LHS)
+	}
+	if _, ok := sf.RHS.(traceql.Static); !ok {
+		t.Errorf("RHS = %T; want traceql.Static", sf.RHS)
+	}
+	// Also confirm the spanset's duration RHS is a TypeDuration static.
+	specSf := expr.Pipeline.Elements[0].(*traceql.SpansetFilter)
+	bin := specSf.Expression.(*traceql.BinaryOperation)
+	durSt, ok := bin.RHS.(traceql.Static)
+	if !ok {
+		t.Fatalf("SpansetFilter RHS = %T; want traceql.Static", bin.RHS)
+	}
+	if durSt.Type != traceql.TypeDuration {
+		t.Errorf("duration Static.Type = %v; want TypeDuration", durSt.Type)
+	}
+	d, ok := durSt.Duration()
+	if !ok || d != 100*time.Millisecond {
+		t.Errorf("Duration() = (%v, %v); want (100ms, true)", d, ok)
+	}
+}
+
+// TestParserShape_MetricsPipelineRate pins `{} | rate()`. expr.MetricsPipeline
+// must be a *MetricsAggregate whose Op() == MetricsAggregateRate.
+func TestParserShape_MetricsPipelineRate(t *testing.T) {
+	t.Parallel()
+	expr := mustParseTraceQL(t, `{} | rate()`)
+	if expr.MetricsPipeline == nil {
+		t.Fatal("expr.MetricsPipeline = nil; want *MetricsAggregate")
+	}
+	ma, ok := expr.MetricsPipeline.(*traceql.MetricsAggregate)
+	if !ok {
+		t.Fatalf("MetricsPipeline = %T; want *traceql.MetricsAggregate", expr.MetricsPipeline)
+	}
+	if ma.Op() != traceql.MetricsAggregateRate {
+		t.Errorf("Op() = %v; want MetricsAggregateRate", ma.Op())
+	}
+	// `rate()` has no attribute operand — Attribute() should be the zero
+	// value (Tempo's "no-attribute" sentinel).
+	if ma.Attribute() != (traceql.Attribute{}) {
+		t.Errorf("Attribute() = %v; want zero-value Attribute{}", ma.Attribute())
+	}
+}
+
+// TestParserError_* tests pin the error message substrings cerberus's
+// /tempo HTTP handlers translate into TraceQL error responses.
+
+func errContainsAny(err error, wants ...string) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, w := range wants {
+		if strings.Contains(msg, strings.ToLower(w)) {
+			return true
+		}
+	}
+	return false
+}
+
+func parseShouldFailTraceQL(t *testing.T, q string) error {
+	t.Helper()
+	_, err := traceql.Parse(q)
+	if err == nil {
+		t.Fatalf("Parse(%q): expected error, got nil", q)
+	}
+	return err
+}
+
+func TestParserError_MissingMatcherRHS(t *testing.T) {
+	t.Parallel()
+	err := parseShouldFailTraceQL(t, `{ name = }`)
+	if !errContainsAny(err, "parse", "syntax", "unexpected", "}", "expected") {
+		t.Errorf("err = %q; want substring rejecting missing RHS", err)
+	}
+}
+
+func TestParserError_TrailingGreater(t *testing.T) {
+	t.Parallel()
+	err := parseShouldFailTraceQL(t, `{} > `)
+	if !errContainsAny(err, "parse", "syntax", "unexpected", "expected", "$end") {
+		t.Errorf("err = %q; want substring rejecting trailing operator", err)
+	}
+}
+
+func TestParserError_DurationMissingRHS(t *testing.T) {
+	t.Parallel()
+	err := parseShouldFailTraceQL(t, `{ duration > }`)
+	if !errContainsAny(err, "parse", "syntax", "unexpected", "}", "expected") {
+		t.Errorf("err = %q; want substring rejecting missing duration RHS", err)
+	}
+}
+
+func TestParserError_AndMissingRHS(t *testing.T) {
+	t.Parallel()
+	// `a` is not a typed identifier in TraceQL — upstream rejects this
+	// at parse time with "unknown identifier: a". We pin that signal so
+	// the handler's error-class translation stays observable.
+	err := parseShouldFailTraceQL(t, `{ a && }`)
+	if !errContainsAny(err, "unknown identifier", "parse", "syntax", "unexpected", "}", "expected") {
+		t.Errorf("err = %q; want substring rejecting unknown identifier", err)
+	}
+}
+
+func TestParserError_BadOperator(t *testing.T) {
+	t.Parallel()
+	// `<>` is not a valid TraceQL operator.
+	err := parseShouldFailTraceQL(t, `{ 2 <> 3 }`)
+	if !errContainsAny(err, "parse", "syntax", "unexpected", "expected") {
+		t.Errorf("err = %q; want substring rejecting bad operator", err)
+	}
+}
+
+func TestParserError_UnterminatedBrace(t *testing.T) {
+	t.Parallel()
+	err := parseShouldFailTraceQL(t, `{ .a = .b `)
+	if !errContainsAny(err, "parse", "syntax", "unexpected", "EOF", "$end", "expected") {
+		t.Errorf("err = %q; want substring rejecting unterminated brace", err)
+	}
+}
+
+func TestParserError_MalformedExpression(t *testing.T) {
+	t.Parallel()
+	err := parseShouldFailTraceQL(t, `{ + }`)
+	if !errContainsAny(err, "parse", "syntax", "unexpected", "expected") {
+		t.Errorf("err = %q; want substring rejecting malformed expression", err)
+	}
+}
+
+func TestParserError_TrailingPipe(t *testing.T) {
+	t.Parallel()
+	err := parseShouldFailTraceQL(t, `{ .a } | `)
+	if !errContainsAny(err, "parse", "syntax", "unexpected", "EOF", "$end", "expected") {
+		t.Errorf("err = %q; want substring rejecting trailing pipe", err)
+	}
+}
+
+func TestParserError_IncompleteAggregate(t *testing.T) {
+	t.Parallel()
+	err := parseShouldFailTraceQL(t, `{ .a } | count(`)
+	if !errContainsAny(err, "parse", "syntax", "unexpected", "EOF", "$end", "expected") {
+		t.Errorf("err = %q; want substring rejecting incomplete aggregate", err)
+	}
+}
+
+func TestParserError_UnknownTopLevelIdentifier(t *testing.T) {
+	t.Parallel()
+	err := parseShouldFailTraceQL(t, `wharblgarbl`)
+	if !errContainsAny(err, "parse", "syntax", "unexpected", "wharblgarbl", "expected") {
+		t.Errorf("err = %q; want substring rejecting top-level identifier", err)
+	}
+}


### PR DESCRIPTION
## Summary

Layer 1 of the layered-tests rollout — field-level AST shape pinning + parser
error-message preservation for the three upstream parsers cerberus consumes.

The existing `parser_smoke_test.go` files in each package pin acceptance /
rejection only — they catch grammar regressions but **not silent AST shape
changes** (e.g. renamed field, swapped op enum, changed root node type). When
the fork-monitor rebases the `cerberus-*` branches onto upstream `main`, those
AST changes would sneak past the smoke tests and surface much later as
runtime mis-lowering. These new tests pin the field values cerberus's
lowering layer reads.

- `internal/promql/parser_shape_test.go` — 20 tests
- `internal/logql/parser_shape_test.go` — 20 tests
- `internal/traceql/parser_shape_test.go` — 20 tests

**60 tests total**, 10 AST shape + 10 error preservation per parser.

Each shape test asserts the concrete root-node type plus the field values
cerberus's lowering layer in `internal/{promql,logql,traceql}/lower.go`
(and siblings) actually consume. Each error test pins substrings of the
upstream parser's error message so the HTTP handler's `errorType`
translation stays observable when upstream rewords something.

No production code changes.

## Test plan

- [x] `go test ./internal/promql/ ./internal/logql/ ./internal/traceql/`
      passes (743 tests across the 3 packages, 60 of them new)
- [x] `go vet` clean on all three packages
- [x] Each shape test fails loudly if the asserted field is renamed
      or the root type changes; stays green when upstream adds new fields
- [x] Each error test matches multiple plausible substrings so cosmetic
      message rewording doesn't break the pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)