### PR TITLE
ci(gremlins): phase 2 — chsql kill-zone @ 75% efficacy

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -12,19 +12,36 @@ permissions:
 
 jobs:
   mutate:
-    name: gremlins unleash
+    # Per-phase mutation kill-zone. gremlins v0.6.0 has no per-package
+    # threshold, so each phase runs as its own matrix entry scoped to a
+    # single package with its own --threshold-efficacy bar. The bar in
+    # `.gremlins.yaml` (currently 80) is the floor for the unscoped
+    # whole-repo `just mutate` invocation only — the matrix below
+    # overrides it per phase. All phases are informational until phase
+    # 4; the workflow stays on push-to-main + nightly + dispatch.
+    name: gremlins ${{ matrix.phase }} (${{ matrix.scope }} @ ${{ matrix.efficacy }}%)
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - phase: phase1
+            scope: ./internal/chplan/...
+            efficacy: 80
+          - phase: phase2
+            scope: ./internal/chsql/...
+            efficacy: 75
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
           cache: true
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: just
       - name: Install gremlins
         run: go install github.com/go-gremlins/gremlins/cmd/gremlins@v0.6.0
-      - name: just mutate
-        run: just mutate
+      - name: gremlins unleash
+        run: |
+          gremlins unleash \
+            --threshold-efficacy ${{ matrix.efficacy }} \
+            ${{ matrix.scope }}

--- a/.gremlins.yaml
+++ b/.gremlins.yaml
@@ -33,23 +33,27 @@ excluded-files:
   - "**/doc.go"
 
 # Phased mutation-testing rollout. Layer 3 (PR #247) added ~125
-# invariant tests across internal/chplan, so chplan is the first
+# invariant tests across internal/chplan, so chplan was the first
 # package dense enough to meet an 80% efficacy bar. The other
 # kill-zone packages onboard once their coverage catches up:
 #
-#   Phase 1 (this file):    internal/chplan       @ 80% efficacy
-#   Phase 2 (planned):      internal/chsql        @ 75% efficacy
-#   Phase 3 (planned):      internal/optimizer    @ 70% efficacy
+#   Phase 1 (PR #260):      internal/chplan       @ 80% efficacy — DONE
+#   Phase 2 (this PR):      internal/chsql        @ 75% efficacy — NEW
+#   Phase 3 (pending #266): internal/optimizer    @ 70% efficacy
+#                           (waits on Layer 4 chDB property tests)
 #   Phase 4 (planned):      QL parsers + lower    @ 65% efficacy
-#                           then promote gremlins to a required gate.
+#                           (waits on Layer 2b coverage)
+#
+# Promotion to a required CI gate happens after all four phases stay
+# stable for a week.
 #
 # The thresholds below are GLOBAL (gremlins v0.6.0 does not support
-# per-package thresholds — see `gremlins unleash --help`). To enforce
-# the per-phase bar without dragging the slower packages down, run
-# gremlins scoped to one package at a time in CI via
-# `gremlins unleash --threshold-efficacy <bar> ./internal/<pkg>/...`
-# in the workflow rather than the global config. The values below are
-# the floor for the whole-repo `just mutate` invocation and stay
-# informational until phase 4.
+# per-package thresholds — see `gremlins unleash --help`). The
+# per-phase bar is enforced in `.github/workflows/mutation.yml` via a
+# matrix that runs `gremlins unleash --threshold-efficacy <bar>
+# ./internal/<pkg>/...` once per phase, scoped to a single package
+# at a time so the slower packages don't drag the bar down. The
+# values below are the floor for the unscoped whole-repo
+# `just mutate` invocation and stay informational until phase 4.
 threshold-efficacy: 80
 threshold-mcover: 50

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -151,17 +151,19 @@ the default lane, which would score a string-equality false-kill.
 
 ### Phased rollout
 
-The whole-repo `threshold-efficacy` bar is global (gremlins v0.6.0
-has no per-package threshold). The rollout is therefore staged: each
-phase raises the global bar only once the next-most-covered package
-catches up, and promotion to a required CI gate waits for phase 4.
+The whole-repo `threshold-efficacy` bar in `.gremlins.yaml` is global
+(gremlins v0.6.0 has no per-package threshold). The rollout is
+therefore staged: each phase enforces its own per-package bar via the
+`mutation` workflow's matrix, which scopes `gremlins unleash
+--threshold-efficacy <bar>` to one package at a time. Promotion to a
+required CI gate waits for phase 4 plus a week of stable runs.
 
-| Phase                            | Package              | Target efficacy |
-| -------------------------------- | -------------------- | --------------- |
-| 1 (active — `.gremlins.yaml`)    | `internal/chplan`    | 80%             |
-| 2 (planned)                      | `internal/chsql`     | 75%             |
-| 3 (planned)                      | `internal/optimizer` | 70%             |
-| 4 (planned, then required gate)  | QL parsers + lower   | 65%             |
+| Phase                            | Package              | Target efficacy | Status                           |
+| -------------------------------- | -------------------- | --------------- | -------------------------------- |
+| 1 (PR #260)                      | `internal/chplan`    | 80%             | active in `mutation.yml` matrix  |
+| 2 (this PR)                      | `internal/chsql`     | 75%             | active in `mutation.yml` matrix  |
+| 3                                | `internal/optimizer` | 70%             | waits on #266 (Layer 4 chDB)     |
+| 4 (then required gate)           | QL parsers + lower   | 65%             | waits on Layer 2b coverage       |
 
 Until phase 4, `just mutate` (and the `mutation` workflow that wraps
 it) stays informational. The thresholds are advisory floors only —


### PR DESCRIPTION
## Summary

Phase 2 of the staged mutation-testing rollout (Phase 1 = PR #260).
Converts `.github/workflows/mutation.yml` from a single global-config
`just mutate` invocation into a matrix that runs `gremlins unleash`
once per phase, scoped to a single package with its own
`--threshold-efficacy` bar.

| Phase | Package           | Efficacy | Status |
| ----- | ----------------- | -------- | ------ |
| 1     | `internal/chplan` | 80%      | active (was PR #260) |
| 2     | `internal/chsql`  | 75%      | NEW (this PR) |

## Why a matrix instead of raising the global bar

gremlins v0.6.0 has no per-package threshold (`gremlins unleash --help`
exposes only the global `--threshold-efficacy` / `--threshold-mcover`).
The `.gremlins.yaml` global bar (still 80) is the advisory floor for
the unscoped whole-repo `just mutate`. Each matrix entry overrides it
per-phase via its own `--threshold-efficacy` flag — that way the chsql
75% bar doesn't drag the chplan 80% bar down, and vice versa, while
slower packages (optimizer, QL parsers) onboard at their own pace.

## Phase status after this PR

- Phase 1 (chplan @ 80%) — DONE (PR #260)
- Phase 2 (chsql  @ 75%) — NEW (this PR)
- Phase 3 (optimizer @ 70%) — pending Layer 4 chDB property tests (#266 in flight)
- Phase 4 (promql / logql / traceql @ 65%) — pending Layer 2b
- Promotion to a required PR gate: after all four phases stay stable for a week

## Workflow status

Both matrix entries stay informational — the workflow still triggers
on push-to-main + nightly + `workflow_dispatch` only. No required-gate
promotion yet (that's Phase 4).

The `taiki-e/install-action` step for `just` is dropped because each
matrix entry now calls `gremlins unleash` directly with its scope +
threshold; we no longer wrap through `just mutate`.

## Files

- `.github/workflows/mutation.yml` — matrix scaffold + per-entry threshold.
- `.gremlins.yaml` — comment block reflects Phase 1 DONE, Phase 2 NEW, Phases 3-4 pending.
- `docs/test-strategy.md` — Phased rollout table updated with status column + matrix mechanics.

No production code changes.

## Test plan
- [x] `gremlins unleash --help` confirms per-package thresholds aren't supported, validating the matrix approach.
- [x] Matrix syntax verified — two `include:` entries, distinct `scope` + `efficacy` per row.
- [x] Phase 1 chplan run continues at 80% (no regression).
- [ ] CI `check` + `lint` green.
- [ ] On merge to main, `mutation` workflow runs the matrix and reports Phase 1 + Phase 2 results independently.