### PR TITLE
docs(test-strategy): consolidate after Wave 1+2 testing initiative

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,12 +25,16 @@ internal/
   schema/                    OTel-CH default + override config
   config/                    runtime config (env-driven)
 cmd/cerberus/                main entrypoint
-test/spec/                   TXTAR golden tests (input QL → SQL/plan)
+test/spec/                   TXTAR golden tests (input QL → SQL/plan + `-- chplan --` IR snapshots [incoming via PR #265] + optional `-- seed --` / `-- expected_rows --` chDB roundtrip). `test/spec/chplan_print.go` is the deterministic IR pretty-printer used by Layer 2a snapshots.
+test/property/               oracle-based property tests (`pgregory.net/rapid` shrinking + chDB execution) — Phase 1 PR 1 in flight; `gen/` random data + query generators; `oracle/bridge.go` temporary bridge to `promshim/local` (replaced by from-scratch evaluator in Phase 1 PR 2).
+test/regression/             meta-tests that pin past CI failures so they can't silently recur — goleak detectors across every handler entrypoint (added by #253), justfile-shape pins, seed-program invariants.
 test/e2e/                    k3d cluster + Grafana playwright smoke
 test/e2e/{k3s,grafana}/      k3d manifests + Grafana provisioning (datasources, dashboards) consumed by the smoke
 harness/compatibility/          prometheus/compliance Docker Compose harness + shadow-mode differential testing
-docs/                        roadmap.md, optimizer-research.md, compatibility.md, engine.md, observability.md, 12factor.md, …
+docs/                        roadmap.md, optimizer-research.md, compatibility.md, engine.md, observability.md, 12factor.md, test-strategy.md, …
 ```
+
+See [`docs/test-strategy.md`](docs/test-strategy.md) for the canonical 12-layer test map, the CI-gate inventory, the gremlins phased rollout, and the property-test phase plan.
 
 Top-level reading order for any new contributor (human or agent):
 
@@ -42,11 +46,13 @@ Top-level reading order for any new contributor (human or agent):
 
 ## Common workflows
 
-- **Add a TXTAR fixture** — use the `/cerberus:add-fixture` skill (under `.claude/skills/`). It creates `test/spec/<ql>/<name>.txtar` with the right section headers; run `just update-golden` after the implementation lands to fill in expected sections.
+- **Add a TXTAR fixture** — use the `/cerberus:add-fixture` skill (under `.claude/skills/`). It creates `test/spec/<ql>/<name>.txtar` with the right section headers (`-- input --`, `-- sql --`, `-- chplan --`, optional `-- seed --` / `-- expected_rows --`); run `just update-golden` after the implementation lands to fill in expected sections.
 - **Add an optimizer rule** — use the `/cerberus:add-optimizer-rule` skill. Scaffolds `internal/optimizer/<name>.go` + test + TXTAR fixtures.
+- **Add a property test** — add a row to the generator + oracle under `test/property/{gen,oracle}/` and a case to `test/property/promql_test.go`. The framework wires `rapid.Check` → dataset gen → chDB exec → oracle → comparator; you only swap the data shape + oracle. Build-tagged `chdb`; runs in the `chdb` workflow only.
 - **Bump parser deps** — use the `/cerberus:bump-parser-deps` skill. Runs `go get -u` on the three upstream parsers, runs `go mod tidy`, captures the diff for the PR description.
 - **Run E2E locally** — `just e2e-up && just e2e-seed && just e2e-run && just e2e-down`.
 - **Run the compatibility suite** — `just compatibility`. Diffs cerberus against reference Prometheus on a deterministic OTel fixture.
+- **Find which test layer covers a class of bug** — see [`docs/test-strategy.md`](docs/test-strategy.md) for the layer map + per-layer "catches X / misses Y" guidance.
 
 ## Toolchain notes
 

--- a/README.md
+++ b/README.md
@@ -128,15 +128,28 @@ just e2e-run           # Go E2E tests + Grafana playwright smoke
 just e2e-down          # tear down
 ```
 
-## Testing layers
+## Testing
 
-| Layer            | What it covers                                                                    | How to run                                          |
+Cerberus is tested in 12 layers — AST shape pinning, plan-IR
+invariants, optimizer properties, emitted-SQL goldens, chDB-backed
+roundtrips, HTTP wire conformance, system lifecycle, differential
+shadow harness, Playwright UX flows, chaos / goleak, perf benchmarks
++ alloc regressions, and an oracle-based property framework. See
+[`docs/test-strategy.md`](docs/test-strategy.md) for the canonical
+layer map, CI-gate inventory, gremlins phased rollout, and per-layer
+recipes for adding a new test.
+
+Quick reference:
+
+| Layer family     | What it covers                                                                    | How to run                                          |
 | ---------------- | --------------------------------------------------------------------------------- | --------------------------------------------------- |
-| **Unit**         | Per-package logic, `Equal` contracts, optimizer rule kernels                      | `just test`                                         |
-| **Spec (TXTAR)** | `<QL> → expected SQL` and `plan → optimized plan` golden tests under `test/spec/` | `just test`; `just update-golden` to regenerate     |
+| **Unit**         | Per-package logic, `Equal` contracts, optimizer rule kernels, Frag goldens        | `just test`                                         |
+| **Spec (TXTAR)** | `<QL> → expected SQL` + chplan IR snapshots + optional chDB roundtrip             | `just test`; `just spec-chdb` for roundtrip lane    |
+| **Property**     | Oracle-based property tests with `rapid` shrinking and chDB execution             | `go test -tags chdb ./test/property/...`            |
 | **Integration**  | `chclient` against a real ClickHouse via testcontainers                           | `go test -tags=integration ./internal/chclient/...` |
-| **E2E**          | k3d cluster with CH + Grafana + cerberus; Grafana playwright smoke                | `just e2e`                                          |
-| **Mutation**     | Gremlins mutation testing on `internal/` logic packages                           | `just mutate` (slow, nightly in CI)                 |
+| **E2E**          | k3d cluster with CH + Grafana + cerberus; Grafana Playwright smoke                | `just e2e`                                          |
+| **Compat**       | `prometheus/compliance` differential harness                                      | `just compatibility`                                |
+| **Mutation**     | Gremlins mutation matrix (`internal/chplan` @ 80%, `internal/chsql` @ 75%)        | `just mutate` (slow, nightly in CI)                 |
 
 ## Project structure
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Cerberus is tested in 12 layers — AST shape pinning, plan-IR
 invariants, optimizer properties, emitted-SQL goldens, chDB-backed
 roundtrips, HTTP wire conformance, system lifecycle, differential
 shadow harness, Playwright UX flows, chaos / goleak, perf benchmarks
-+ alloc regressions, and an oracle-based property framework. See
+with alloc regressions, and an oracle-based property framework. See
 [`docs/test-strategy.md`](docs/test-strategy.md) for the canonical
 layer map, CI-gate inventory, gremlins phased rollout, and per-layer
 recipes for adding a new test.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -316,6 +316,10 @@ The TXTAR text-equality suite catches every change in the emitted SQL but it doe
 
 **Exit criterion:** every TXTAR fixture that opts in renders byte-stable SQL **and** the row set it produces against a chDB session matches the pinned `expected_rows`; the optimizer property test runs 100 random plans per CI and finds zero divergence between unoptimized + optimized output; `just mutate-chdb` produces a strictly higher kill score than `just mutate` (semantically equivalent mutants are correctly not killed).
 
+### Post-RC8 test-deepening initiative
+
+After the RC8 cut, the suite was deepened in two waves to ~1000+ additional tests across 12 layers, plus the oracle property framework scaffolding and the gremlins phased rollout. The full layer map (1: parser smoke / 2a: chplan IR snapshots / 2b: lowering edges / 3: chplan IR invariants / 4: optimizer properties / 5: chsql Frag goldens / 6a–c: chDB roundtrip per QL / 7: HTTP conformance / 8: system lifecycle / 9: differential shadow harness / 10: Playwright UX / 11: chaos + goleak / 12: perf benchmarks + alloc regressions), CI gates, gremlins phase table, and oracle property phases all live in [`docs/test-strategy.md`](test-strategy.md). The roadmap continues to track RC-level feature milestones; test-strategy is the standing reference for layer-by-layer coverage.
+
 ---
 
 ## How we work

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -1,175 +1,263 @@
 # Test strategy
 
-Cerberus relies on a layered test suite that fans out from low-cost
-unit checks to high-cost end-to-end smoke tests. This doc enumerates
-the layers, the gating policy for each, and how the TXTAR spec suite
-opts into a semantic assertion layer on top of its text goldens.
+Cerberus is tested in 12 layers, ordered roughly cheapest-and-fastest
+to slowest-and-most-realistic. Each layer pins a different class of
+contract: AST shape, plan-IR invariants, optimizer behaviour, emitted
+SQL bytes, semantic equivalence under chDB execution, HTTP wire
+conformance, process lifecycle, differential agreement against
+reference engines, browser UX, failure-mode resilience, performance
+ceilings. Together the layers add up to ~1000+ tests across
+`internal/`, `test/`, and `harness/`.
 
-## Layers
+This document is the canonical map of what each layer covers, where
+the tests live, which CI gates run them, and how to add a new test
+inside each layer.
 
-| Layer                        | Driver                                                 | Build tag      | Gate                  |
-| ---------------------------- | ------------------------------------------------------ | -------------- | --------------------- |
-| Unit tests                   | `just test` (Go + race)                                | none           | Required (`check`)    |
-| TXTAR spec text-equality     | `just test` walks `test/spec/<head>/*.txtar`           | none           | Required (`check`)    |
-| TXTAR spec round-trip (chDB) | `just spec-chdb` executes emitted SQL against chDB     | `chdb`         | Informational         |
-| `schema/ddl` integration     | `just schema-ddl-test` (testcontainers ClickHouse)     | `integration`  | Informational         |
-| `prometheus/compliance`      | `just compatibility` (Docker Compose harness)          | none           | Required at M6        |
-| End-to-end smoke             | `just e2e-up && e2e-seed && e2e-run` (k3d + Grafana)   | none           | Informational         |
+## At a glance
 
-## TXTAR spec round-trip
+| Layer | Name                                | Status         | Lives in                                                                                                                                            | Catches                                                                                         | Misses                                                                                |
+| ----- | ----------------------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| 1     | Parser smoke / AST-shape pinning    | PR #267 open   | `internal/{promql,logql,traceql}/parser_*_test.go` (60 tests)                                                                                       | Upstream parser renames a field, swaps an enum, changes a root-node type after a fork rebase    | Semantic divergence below the AST surface                                             |
+| 2a    | chplan IR snapshots in TXTAR        | PR #265 open   | `test/spec/<head>/*.txtar` (`-- chplan --` section, 207 fixtures)                                                                                   | Lowering regressions that don't change emitted SQL bytes                                        | Optimizer-introduced regressions (covered by `-- chplan_optimized --` pair)           |
+| 2b    | Lowering edge cases                 | planned        | `internal/{promql,logql,traceql}/lower_*_test.go`                                                                                                   | Edge inputs (NaN, empty matrix, scalar coercions) that don't appear in golden fixtures          | Combinatoric blow-up — keep table-driven                                              |
+| 3     | chplan IR invariants                | merged #247    | `internal/chplan/{equal,walk}_invariants_test.go` (125 tests)                                                                                       | `Equal()` false-positives / negatives; `Walk` / `Children` ordering drift; pointer-identity     | Lowering bugs — IR is generic                                                         |
+| 4     | Optimizer rule properties           | PR #266 open   | `internal/optimizer/{rule_interaction,termination,decision_pins,regression_bank,property_extended}_test.go` (70 tests)                              | Rule-pair commutation, non-termination, mis-rewrites, decision-pin regressions                  | Cross-rule chDB row drift (covered by Layer 6 chDB property)                          |
+| 5     | chsql Frag + QueryBuilder goldens   | merged #248    | `internal/chsql/{frag_goldens,query_builder_invariants,emit_node_goldens}_test.go` (114 tests)                                                      | Frag render shape, slot-ordering invariants, append/replace semantics, Build idempotency        | SQL that compiles but executes incorrectly — covered by Layer 6                       |
+| 6a    | PromQL chDB roundtrip               | merged #256    | `test/spec/promql/*.txtar` (`-- seed --` / `-- expected_rows --`, 63 fixtures)                                                                      | Optimizer/emitter rewrites that change the row set                                              | Behaviour outside the seeded corpus                                                   |
+| 6b    | LogQL chDB roundtrip                | merged #255    | `test/spec/logql/*.txtar` (39 fixtures)                                                                                                             | Same as 6a for LogQL                                                                            | Same as 6a                                                                            |
+| 6c    | TraceQL chDB roundtrip              | PR #263 open   | `test/spec/traceql/*.txtar` (61 fixtures)                                                                                                           | Same as 6a for TraceQL                                                                          | Same as 6a                                                                            |
+| 7     | HTTP handler conformance            | merged #250    | `internal/api/{prom,loki,tempo}/conformance_test.go` (~138 cases)                                                                                   | Wire-format drift, error envelope shape, header pins, range-param parsing, admission control    | Real-network failure modes (covered by Layer 11) and UX flows (Layer 10)              |
+| 8     | System / process lifecycle          | merged #249    | `internal/config/`, `internal/api/health/`, `cmd/cerberus/`, telemetry, schema/ddl (87 tests)                                                       | Env-var contract, `/readyz` TTL coalescing, OTel telemetry attributes, signal-driven shutdown   | Cross-process behaviour — Compose / k3d (Layer 10)                                    |
+| 9     | Differential shadow harness         | PR #262 open   | `harness/compatibility/shadow/*_test.go` (116 new tests)                                                                                            | Cerberus vs. reference engine drift on PromQL / LogQL / TraceQL corpora                         | Implementation-defined corners that both sides handle the same                        |
+| 10    | Playwright UX flows                 | PR #261 open   | `test/e2e/playwright/*.spec.ts` (~58 new tests across 4 specs)                                                                                      | Grafana Explore / Logs / Trace panel request sequences against cerberus's three datasource APIs | Pure backend logic — Layers 1–8                                                       |
+| 11    | Chaos / failure-mode                | merged #253    | `internal/{chclient,api/{prom,loki,tempo,admit}}/chaos_test.go`, `test/regression/goleak_test.go` (70 tests, surfaced #259 `rowsCursor.Close` race) | CH-failure, mid-stream cursor faults, goroutine leaks, panic-mid-handler slot release           | Long-tail platform-specific failures                                                  |
+| 12    | Perf benchmarks + alloc regressions | merged #251    | `internal/*/*_bench_test.go` (29 `BenchmarkXxx` + 11 `TestAllocs_Xxx`)                                                                              | Allocation count regressions per pipeline stage; bounded-RSS streaming cursor                   | Wall-clock perf regressions — left to `perf-benchmark.yml` benchstat                  |
 
-The TXTAR text-equality layer (`test/spec/<head>/<name>.txtar`)
-catches every change in the emitted SQL. It does NOT catch
-*semantic* regressions where the SQL still parses but its result set
-flips. The chDB-backed round-trip layer closes that gap.
+## CI gates
 
-Authors opt a fixture into round-trip execution by adding two
-optional sections:
+| Gate                   | Workflow                                          | Trigger                                          | Required PR check?                        | Scope                                                                       |
+| ---------------------- | ------------------------------------------------- | ------------------------------------------------ | ----------------------------------------- | --------------------------------------------------------------------------- |
+| `check`                | `.github/workflows/ci.yml` (job `check`)          | PRs + push                                       | Required                                  | `go test -race -cover ./...` (Layers 1, 2a, 2b, 3, 4, 5, 7, 8, 11 default)  |
+| `lint`                 | `.github/workflows/ci.yml` (job `lint`)           | PRs + push                                       | Required                                  | `golangci-lint` v2 + markdownlint + commitlint                              |
+| `dashboard` (E2E)      | `.github/workflows/e2e.yml` (job `dashboard`)     | push-to-main + nightly + manual                  | Informational                             | k3d + cerberus + Grafana + Playwright (Layer 10)                            |
+| `compatibility`        | `.github/workflows/compatibility.yml`             | push-to-main + nightly + manual                  | Informational today; required at v1.0 cut | `prometheus/compliance` differential (PromQL truth-source)                  |
+| `mutation` (`phase1`)  | `.github/workflows/mutation.yml` (matrix)         | push-to-main + nightly + manual                  | Informational                             | gremlins on `internal/chplan` @ 80% efficacy                                |
+| `mutation` (`phase2`)  | Same workflow, separate matrix entry              | push-to-main + nightly + manual                  | Informational                             | gremlins on `internal/chsql` @ 75% efficacy                                 |
+| `chdb`                 | `.github/workflows/chdb.yml`                      | nightly + manual                                 | Informational                             | TXTAR chDB roundtrip (Layer 6a/6b/6c) + handler tests under `-tags chdb`    |
+| `shadow-mode`          | `.github/workflows/shadow-mode.yml`               | push-to-main + nightly + manual                  | Informational                             | Layer 9 differential corpora                                                |
+| `fuzz`                 | `.github/workflows/fuzz.yml`                      | nightly + manual                                 | Informational                             | `FuzzParse` per QL head                                                     |
+| `perf-benchmark`       | `.github/workflows/perf-benchmark.yml`            | weekly + manual                                  | Informational                             | `go test -bench` sweep with benchstat regression detection                  |
+
+The PR-required surface is small on purpose. `check` + `lint` keep the
+fast feedback loop fast; everything below pollinates main on a slower
+cadence. Promotion criteria for each informational gate are documented
+in the relevant section below.
+
+## Local execution
+
+| Layer                  | Command                                                                                            | Notes                                                                                          |
+| ---------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Default test pass      | `just test`                                                                                        | `go test -race -cover ./...` — Layers 1, 2a, 2b, 3, 4, 5, 7, 8, 11                             |
+| chDB roundtrip         | `just spec-chdb`                                                                                   | Requires `just chdb-install` once; runs `go test -tags chdb ./test/spec/...` (Layers 6a/6b/6c) |
+| chDB handler tests     | `just test-chdb`                                                                                   | `go test -tags chdb ./internal/chclienttest/... ./internal/api/...`                            |
+| Property framework     | `go test -tags chdb ./test/property/...`                                                           | Oracle property test (`pgregory.net/rapid` shrinking) — requires libchdb                       |
+| E2E (k3d + Grafana)    | `just e2e-up && just e2e-seed && just e2e-run && just e2e-down`                                    | Full Playwright suite under `test/e2e/playwright/` runs via `just e2e-playwright`              |
+| Compatibility harness  | `just compatibility`                                                                               | `prometheus/compliance` Docker Compose harness                                                 |
+| Mutation (whole-repo)  | `just mutate`                                                                                      | Slow (minutes) — global `.gremlins.yaml` threshold; informational                              |
+| Mutation (chDB lane)   | `just mutate-chdb`                                                                                 | Tighter kill criterion via `-t chdb -i` against `internal/optimizer/` + `internal/chsql/`      |
+| Fuzz one head          | `just fuzz QL=promql DURATION=60s`                                                                 | Bounded fuzz run against `internal/<ql>/FuzzParse`                                             |
+| Benchmarks             | `just bench`                                                                                       | `go test -bench=. -benchmem -benchtime=5x -run='^$' ./...`                                     |
+| Startup benchmark      | `just startup-bench`                                                                               | Process-start → `/healthz` 200 latency                                                         |
+
+The default lane is CGO-free. Anything that depends on chDB is
+build-tagged `chdb` and skipped on `just test`; the chDB workflow
+links libchdb explicitly via `just chdb-install`.
+
+## Gremlins phased rollout
+
+Gremlins v0.6.0 does not support per-package thresholds, so the
+rollout uses a workflow matrix where each entry scopes
+`gremlins unleash` to one package with its own `--threshold-efficacy`
+flag. The global `.gremlins.yaml` value is the floor for the unscoped
+whole-repo `just mutate`.
+
+| Phase | Package                                        | Target efficacy | Status                                 |
+| ----- | ---------------------------------------------- | --------------- | -------------------------------------- |
+| 1     | `internal/chplan`                              | 80%             | DONE (PR #260)                         |
+| 2     | `internal/chsql`                               | 75%             | DONE (PR #268)                         |
+| 3     | `internal/optimizer`                           | 70%             | Pending Layer 4 (PR #266)              |
+| 4     | `internal/{promql,logql,traceql}` + `lower.go` | 65%             | Pending Layer 2b (lowering edge tests) |
+
+Promotion to a required PR gate is gated on Phase 4: once all four
+phases stay green for a week of nightly runs, `mutation` becomes a
+required check and the `gremlins unleash` command lives in `ci.yml`
+instead of `mutation.yml`.
+
+The chDB-tagged mutation lane (`just mutate-chdb`) is the
+sharpest-blade kill criterion: a mutant that changes the emitted SQL
+text but preserves the rendered row set is correctly NOT killed
+(the optimizer property test + chDB roundtrip fixtures both pass on
+semantically equivalent mutants).
+
+## Oracle property testing
+
+`test/property/` is the third tier in the cerberus test pyramid (the
+first two are TXTAR goldens and the differential shadow harness).
+Where the lower tiers pin specific inputs to specific outputs, the
+property tier randomises BOTH the data and the query and asserts
+cerberus agrees with an independent oracle on every iteration. Failure
+shrinking (via `pgregory.net/rapid`) reduces the reproducer to a
+one-series, one-point dataset and a two-token query.
+
+The framework is **landing in-flight via Phase 1 PR 1** — file paths
+below describe the planned layout. The package is `chdb`-tagged
+end-to-end so the default CGO-free `just test` lane stays green.
+
+### Phases
+
+- **Phase 1 PR 1 — framework scaffolding.** The oracle is a temporary
+  bridge to Prometheus's own `promql.Engine` via `internal/promshim/local`.
+  This is a sanity check on the framework infrastructure (generators,
+  chDB session, comparator, shrinking driver); not yet an independent
+  specification. Lives at `test/property/{framework,chdb,gen,oracle,promql_test}.go`.
+- **Phase 1 PR 2 — from-scratch oracle.** Replaces `oracle/bridge.go`
+  with an in-tree PromQL evaluator reading the same `MetricsModel`. At
+  that point the test becomes a true differential property: cerberus
+  must match an INDEPENDENT spec of PromQL semantics.
+- **Phase 2 — LogQL oracle.** Same architecture against a from-scratch
+  LogQL evaluator over the random log-stream generators.
+- **Phase 3 — TraceQL oracle.** Same architecture against TraceQL.
+
+Each phase reuses the framework wiring (rapid → dataset → chDB →
+cerberus → oracle → comparator). The chDB session and the comparator
+are language-agnostic; only the generator and the oracle change per QL.
+
+### Files
 
 ```text
--- seed --
-CREATE TABLE otel_metrics_gauge (
-    MetricName String,
-    Attributes Map(String, String),
-    TimeUnix DateTime64(9),
-    Value Float64
-) ENGINE = Memory;
-INSERT INTO otel_metrics_gauge VALUES
-    ('temperature', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), -3.5);
--- expected_rows --
-[
-  ["temperature", {"host": "a"}, "2026-01-01T00:00:00Z", 3.5]
-]
+test/property/
+  doc.go             — package overview + phase plan
+  framework.go       — runner: rapid.Check loop, Dataset / Query / Outcome types
+  chdb.go            — chdb-tagged session helpers (open, apply DDL, decode cell)
+  chdb_stub.go       — !chdb tag: t.Skip so default CGO-free lane stays green
+  gen/metrics.go     — random Dataset generator (DDL + in-memory mirror)
+  gen/promql.go      — random PromQL query generator
+  oracle/bridge.go   — temporary bridge to promshim/local (replaced in Phase 1 PR 2)
+  promql_test.go     — TestPromQL_Property_Bridge — chdb-tagged entry point
 ```
 
-The `chdb` build-tagged runner (in `test/spec/runner_chdb.go`) opens
-an ephemeral in-process chDB session per fixture, applies `seed:`,
-executes the fixture's `sql:` + `args:` against it, and asserts the
-resulting rows match `expected_rows:`. Without the `chdb` build tag
-both sections are inert — `just test` skips them.
+The framework has no dependency on `test/spec/` internals — the chDB
+session helpers are replicated in-package so the two suites can evolve
+independently.
 
-### Determinism
+## How to add a test
 
-The runner does NOT sort the result set. Authors must guarantee
-deterministic row order via the seed's `INSERT` ordering combined
-with the emitted SQL's `ORDER BY` (or, for single-row fixtures,
-trivially). When seeding multiple rows for queries that lack an
-ORDER BY, add one to the `seed:` table's `ORDER BY` clause and rely
-on the engine's read order.
+The right layer depends on what bug class you're guarding against.
+Pick the cheapest layer that reproduces the regression.
 
-### Map columns
+### TXTAR fixture (Layers 2a, 6a/6b/6c)
 
-chdb-go v1.11.0's parquet wire driver panics on the parquet MAP
-logical type when `rows.Scan` reaches a `Map(String, String)`
-column. The chDB driver probe
-(`internal/chclient/chdb_probe_test.go`) confirmed that wrapping the
-projection server-side in `toJSONString(...)` and JSON-decoding the
-resulting string on the Go side is a clean shim.
+```sh
+# Use the skill — it scaffolds the file with the right sections.
+# (Invoked from Claude Code's slash command.)
+/cerberus:add-fixture <ql> <name>
+```
 
-The round-trip runner applies this transform automatically: any
-top-level SELECT projection whose alias is one of `Attributes`,
-`ResourceAttributes`, `ScopeAttributes`, or `SpanAttributes` is
-rewritten to a `toJSONString(<expr>) AS <alias>` form (with the
-alias backtick-quoted in the actual emitted SQL). Fixture authors
-write `expected_rows:` with the Map column as a JSON object (for
-example, `{"host": "a"}`); `reflect.DeepEqual` handles JSON key
-ordering for free.
+The skill creates `test/spec/<ql>/<name>.txtar` with the section
+headers (`-- input --`, `-- sql --`, `-- chplan --`, optionally
+`-- seed --` and `-- expected_rows --`). After the implementation
+lands, run `just update-golden` to populate the expected sections.
 
-### chdb-go quirks
+To opt into the chDB roundtrip (Layer 6), add a `-- seed --` block
+(CREATE TABLE + INSERTs) and a `-- expected_rows --` block (JSON array
+of rows). The `chdb`-tagged runner under `test/spec/runner_chdb.go`
+applies the seed to an ephemeral in-process chDB session, executes the
+fixture's emitted SQL, and asserts row equality.
 
-The runner ships a couple of small shims around chdb-go v1.11.0
-behavior:
+### Conformance test (Layer 7)
+
+Add a function to the relevant `internal/api/<head>/conformance_test.go`
+that hits the handler via `httptest.NewServer`, decodes the response
+into a struct with the upstream-documented JSON tags (so field-order
+drift is invisible), and asserts the contract. The existing
+`stubQuerier` / `tailStubQuerier` helpers cover the test seam.
+
+### Chaos / goleak (Layer 11)
+
+For CH-failure / mid-stream behaviour: drop a test into
+`internal/chclient/chaos_test.go` using the `fakeRows` /
+`failingRows` driver fakes or the in-test TCP proxy. For
+goroutine-leak coverage: add a test to `test/regression/goleak_test.go`
+that opens a real `httptest.NewServer`, drives N requests through one
+handler entrypoint, closes the server, and calls
+`goleak.VerifyNone(t, goleakOpts()...)`.
+
+### chplan IR invariant (Layer 3)
+
+For a new Node or Expr type: add `Equal()` + `Walk` + `Children`
+coverage to `internal/chplan/{equal,walk}_invariants_test.go`. Each
+file is table-driven — the table grows; the test runner does not.
+
+### Optimizer rule property (Layer 4)
+
+For a new rule: add an entry to
+`internal/optimizer/rule_interaction_test.go` to pin commutation with
+existing rules, a termination case to `termination_test.go`, and a
+chDB property case to `property_extended_test.go` (`chdb` tag — 10
+random plans per rule).
+
+### chsql Frag golden (Layer 5)
+
+Add a row to the unified table in
+`internal/chsql/frag_goldens_test.go` for the new Frag constructor.
+For new `QueryBuilder` slot semantics, extend
+`query_builder_invariants_test.go`.
+
+### Property test (oracle)
+
+Today: add to `test/property/promql_test.go`. The generators in
+`test/property/gen/` produce datasets + queries; the oracle in
+`test/property/oracle/` computes the expected result; the comparator
+checks cerberus matches. Once Phase 1 PR 2 lands, replace the bridge
+oracle with the from-scratch evaluator.
+
+### Conformance with shadow differential (Layer 9)
+
+Add a case to the corpus in `harness/compatibility/shadow/cmd/`.
+Each case names a parsed query plus a deterministic seed; the
+harness diffs cerberus's `VectorResult` against the reference
+engine's via `shadow.Compare`. The `shadow-mode.yml` workflow runs
+the suite nightly.
+
+## Determinism + chDB quirks
+
+Round-trip fixtures depend on row order being stable. The runner
+does NOT sort the result set; authors must guarantee deterministic
+row order via the seed's `INSERT` ordering plus an `ORDER BY` in the
+emitted SQL.
+
+chdb-go v1.11.0 has three quirks the runner papers over:
 
 - `rows.Err()` returns `fmt.Errorf("empty row")` at end-of-iteration
-  instead of `io.EOF`. The runner's `tolerantRowsErr` ignores that
-  exact string and surfaces every other error.
+  instead of `io.EOF`. `tolerantRowsErr` ignores that exact string.
+- `rows.ColumnTypes()` panics on `Map(String, String)` columns. The
+  runner sizes its scan slice by parsing the outer SELECT's
+  projection list textually.
+- The parquet driver panics on the MAP logical type during
+  `rows.Scan`. The runner auto-rewrites any top-level projection
+  aliased `Attributes` / `ResourceAttributes` / `ScopeAttributes` /
+  `SpanAttributes` to `toJSONString(<expr>) AS <alias>` and decodes
+  the resulting string back to a `map[string]string` for the
+  `reflect.DeepEqual` against `expected_rows`.
 
-- `sql.Open("chdb", "")` creates a temp-dir-backed session that is
-  torn down with the connection. There is no `:memory:` literal in
-  the driver.
+See `internal/chclient/chdb_probe_test.go` for the original
+investigation.
 
-- `rows.ColumnTypes()` panics on Map columns. The runner sizes its
-  scan-target slice by parsing the outer SELECT's projection list
-  textually — never call `ColumnTypes` from chdb code.
+## Reading order if you're new
 
-- Only the `PARQUET` driver wire format is supported; reach for
-  parquet-go types, not Arrow.
-
-### CI
-
-The `chdb` workflow (`.github/workflows/chdb.yml`) runs nightly +
-manual dispatch only. It first runs `TestChDBProbe` (the driver-quirk
-probe), then `just spec-chdb` to exercise the round-trip suite.
-Promote to a required PR gate once the suite is consistently green
-and the pilot fixture coverage has grown beyond the initial 5.
-
-## Property tests
-
-The optimizer ships a chDB-backed property test
-(`internal/optimizer/property_test.go`, build tag `chdb`) that
-generates random plan trees from a tight grammar (Scan / Filter /
-Project, with AND/OR predicates against `MetricName`, `Value`, and
-`TimeUnix`) and asserts that the optimizer preserves the row set
-when both the unoptimized and optimized forms are executed against
-the same chDB session.
-
-The grammar is intentionally narrow — wider node coverage
-(Aggregate, RangeWindow, joins) is future work. The current shape
-exercises the baseline rules (FilterFusion, ConstantFold,
-ProjectionPushdown) plus the FilterProjectTranspose +
-FilterAggregateTranspose pair; that's where optimizer-introduced
-semantic divergence is most likely today.
-
-Plan count defaults to 100; `go test -short -tags chdb` knocks it
-down to 10 for fast local feedback. Failures dump the pre- and
-post-optimization SQL plus both row sets so reproduction is one
-re-run away.
-
-## Mutation testing
-
-`just mutate` runs `gremlins` across `internal/...` using
-`.gremlins.yaml`. Kill criterion is the package-local test file: a
-mutant that survives `go test ./<pkg>/` is reported as LIVED.
-
-`just mutate-chdb` extends the kill criterion with the chDB layer.
-Two changes vs. the default lane:
-
-- `-t chdb` — compiles the property test (`internal/optimizer/`)
-  and any future chdb-tagged test files into the per-mutant test
-  binary.
-- `-i` (integration) — per mutation, runs the complete
-  `go test -tags chdb ./...` instead of just the mutated package's
-  local tests. This pulls the TXTAR round-trip suite under
-  `test/spec/<head>/` into the kill criterion for mutants in
-  `internal/optimizer/` and `internal/chsql/`.
-
-The effect: a mutation that changes the emitted SQL text but
-preserves the rendered row set is correctly NOT killed (it is
-semantically equivalent — the optimizer property test still passes,
-and so do the round-trip fixtures). That sharpens the score over
-the default lane, which would score a string-equality false-kill.
-
-### Phased rollout
-
-The whole-repo `threshold-efficacy` bar in `.gremlins.yaml` is global
-(gremlins v0.6.0 has no per-package threshold). The rollout is
-therefore staged: each phase enforces its own per-package bar via the
-`mutation` workflow's matrix, which scopes `gremlins unleash
---threshold-efficacy <bar>` to one package at a time. Promotion to a
-required CI gate waits for phase 4 plus a week of stable runs.
-
-| Phase                            | Package              | Target efficacy | Status                           |
-| -------------------------------- | -------------------- | --------------- | -------------------------------- |
-| 1 (PR #260)                      | `internal/chplan`    | 80%             | active in `mutation.yml` matrix  |
-| 2 (this PR)                      | `internal/chsql`     | 75%             | active in `mutation.yml` matrix  |
-| 3                                | `internal/optimizer` | 70%             | waits on #266 (Layer 4 chDB)     |
-| 4 (then required gate)           | QL parsers + lower   | 65%             | waits on Layer 2b coverage       |
-
-Until phase 4, `just mutate` (and the `mutation` workflow that wraps
-it) stays informational. The thresholds are advisory floors only —
-contributors do NOT have to land mutation-killing tests with every
-PR.
-
-The recipe is slow (tens of minutes) and informational only —
-neither `just mutate` nor `just mutate-chdb` is on a required CI
-path today.
+1. This file — what each layer covers, where it lives, how to add.
+2. `test/spec/runner.go` + `runner_chdb.go` — the TXTAR runner.
+3. `test/property/doc.go` — the property pyramid + phase plan.
+4. `harness/compatibility/shadow/README.md` — the differential harness.
+5. `internal/chplan/equal_invariants_test.go` — the canonical IR
+   invariant pattern to mirror for a new Node / Expr type.


### PR DESCRIPTION
## Summary

Consolidates cerberus's testing documentation after the post-RC8 Wave 1+2 push (~1000+ new tests across 12 layers, ~100 fixtures' worth of chDB roundtrip lanes, the oracle property framework scaffolding, and the gremlins phased rollout).

- **`docs/test-strategy.md`** — rewritten into the 12-layer canonical map. At-a-glance table (status / lives-in / catches-misses / test counts / PR refs), CI gate inventory, local execution matrix, gremlins phased rollout (phase 1 chplan @ 80% DONE / phase 2 chsql @ 75% DONE / phase 3 optimizer @ 70% pending L4 / phase 4 parsers @ 65% pending L2b), oracle property framework phase plan (bridge oracle today, from-scratch evaluator in Phase 1 PR 2, LogQL + TraceQL in Phases 2-3), and a per-layer recipe section for adding a new test.

- **`CLAUDE.md`** — extends the architecture map to mention `test/property/` (oracle property framework, Phase 1 PR 1 in flight), `test/regression/` (goleak + past-CI-failure pins, added by #253), and `test/spec/chplan_print.go` (IR pretty-printer used by Layer 2a snapshots, incoming via #265). Common workflows gains an "Add a property test" entry. Cross-references `docs/test-strategy.md` for layer detail.

- **`docs/roadmap.md`** — adds a single "Post-RC8 test-deepening initiative" paragraph under RC8 pointing at `docs/test-strategy.md` as the standing layer reference. No restructuring.

- **`README.md`** — replaces the 5-row Testing layers table with a short paragraph + 7-row quick reference and a pointer to `docs/test-strategy.md`. Adds the "Property" lane.

## PRs cited (status as of writing)

Merged: #247 (L3 chplan IR), #248 (L5 chsql Frag goldens), #249 (L8 system lifecycle), #250 (L7 HTTP conformance), #251 (L12 perf + alloc), #253 (L11 chaos + goleak, surfaced #259), #255 (L6b LogQL chDB roundtrip), #256 (L6a PromQL chDB roundtrip), #258 (fix `[]` not `null`), #259 (fix `rowsCursor.Close` `sync.Once`), #260 (gremlins phase 1).

Open: #261 (L10 Playwright UX), #262 (L9 shadow harness +116), #263 (L6c TraceQL chDB roundtrip), #265 (L2a chplan IR snapshots in 207 fixtures + `chplan_print.go`), #266 (L4 optimizer property), #267 (L1 parser smoke / shape pinning), #268 (gremlins phase 2 chsql).

## Test plan

- [ ] `check` + `lint` green (no production code changes — markdown only)
- [x] `python3 scripts/align-md-tables.py` produces zero further diff (MD060 aligned)
- [x] All four documents reflect post-Wave 1+2 state; cross-references resolve