### PR TITLE
ci(gremlins): phases 3 + 4 — optimizer @70%, parsers @65%

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -17,8 +17,9 @@ jobs:
     # single package with its own --threshold-efficacy bar. The bar in
     # `.gremlins.yaml` (currently 80) is the floor for the unscoped
     # whole-repo `just mutate` invocation only — the matrix below
-    # overrides it per phase. All phases are informational until phase
-    # 4; the workflow stays on push-to-main + nightly + dispatch.
+    # overrides it per phase. All matrix entries stay informational
+    # until all four phases stay green for a week of nightly runs; the
+    # workflow stays on push-to-main + nightly + dispatch.
     name: gremlins ${{ matrix.phase }} (${{ matrix.scope }} @ ${{ matrix.efficacy }}%)
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -32,6 +33,18 @@ jobs:
           - phase: phase2
             scope: ./internal/chsql/...
             efficacy: 75
+          - phase: phase3-optimizer
+            scope: ./internal/optimizer/...
+            efficacy: 70
+          - phase: phase4-promql
+            scope: ./internal/promql/...
+            efficacy: 65
+          - phase: phase4-logql
+            scope: ./internal/logql/...
+            efficacy: 65
+          - phase: phase4-traceql
+            scope: ./internal/traceql/...
+            efficacy: 65
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6

--- a/.gremlins.yaml
+++ b/.gremlins.yaml
@@ -37,12 +37,12 @@ excluded-files:
 # package dense enough to meet an 80% efficacy bar. The other
 # kill-zone packages onboard once their coverage catches up:
 #
-#   Phase 1 (PR #260):      internal/chplan       @ 80% efficacy — DONE
-#   Phase 2 (this PR):      internal/chsql        @ 75% efficacy — NEW
-#   Phase 3 (pending #266): internal/optimizer    @ 70% efficacy
-#                           (waits on Layer 4 chDB property tests)
-#   Phase 4 (planned):      QL parsers + lower    @ 65% efficacy
-#                           (waits on Layer 2b coverage)
+#   Phase 1 (PR #260):      internal/chplan       @ 80% efficacy — ROLLED OUT
+#   Phase 2 (PR #268):      internal/chsql        @ 75% efficacy — ROLLED OUT
+#   Phase 3 (PR #273):      internal/optimizer    @ 70% efficacy — ROLLED OUT
+#                           (Layer 4 chDB property tests landed via #266)
+#   Phase 4 (PR #273):      QL parsers + lower    @ 65% efficacy — ROLLED OUT
+#                           (Layer 2b lowering coverage landed)
 #
 # Promotion to a required CI gate happens after all four phases stay
 # stable for a week.
@@ -54,6 +54,7 @@ excluded-files:
 # ./internal/<pkg>/...` once per phase, scoped to a single package
 # at a time so the slower packages don't drag the bar down. The
 # values below are the floor for the unscoped whole-repo
-# `just mutate` invocation and stay informational until phase 4.
+# `just mutate` invocation; the per-phase matrix entries are
+# informational until all four phases stay green for a week.
 threshold-efficacy: 80
 threshold-mcover: 50

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -35,18 +35,22 @@ inside each layer.
 
 ## CI gates
 
-| Gate                   | Workflow                                          | Trigger                                          | Required PR check?                        | Scope                                                                       |
-| ---------------------- | ------------------------------------------------- | ------------------------------------------------ | ----------------------------------------- | --------------------------------------------------------------------------- |
-| `check`                | `.github/workflows/ci.yml` (job `check`)          | PRs + push                                       | Required                                  | `go test -race -cover ./...` (Layers 1, 2a, 2b, 3, 4, 5, 7, 8, 11 default)  |
-| `lint`                 | `.github/workflows/ci.yml` (job `lint`)           | PRs + push                                       | Required                                  | `golangci-lint` v2 + markdownlint + commitlint                              |
-| `dashboard` (E2E)      | `.github/workflows/e2e.yml` (job `dashboard`)     | push-to-main + nightly + manual                  | Informational                             | k3d + cerberus + Grafana + Playwright (Layer 10)                            |
-| `compatibility`        | `.github/workflows/compatibility.yml`             | push-to-main + nightly + manual                  | Informational today; required at v1.0 cut | `prometheus/compliance` differential (PromQL truth-source)                  |
-| `mutation` (`phase1`)  | `.github/workflows/mutation.yml` (matrix)         | push-to-main + nightly + manual                  | Informational                             | gremlins on `internal/chplan` @ 80% efficacy                                |
-| `mutation` (`phase2`)  | Same workflow, separate matrix entry              | push-to-main + nightly + manual                  | Informational                             | gremlins on `internal/chsql` @ 75% efficacy                                 |
-| `chdb`                 | `.github/workflows/chdb.yml`                      | nightly + manual                                 | Informational                             | TXTAR chDB roundtrip (Layer 6a/6b/6c) + handler tests under `-tags chdb`    |
-| `shadow-mode`          | `.github/workflows/shadow-mode.yml`               | push-to-main + nightly + manual                  | Informational                             | Layer 9 differential corpora                                                |
-| `fuzz`                 | `.github/workflows/fuzz.yml`                      | nightly + manual                                 | Informational                             | `FuzzParse` per QL head                                                     |
-| `perf-benchmark`       | `.github/workflows/perf-benchmark.yml`            | weekly + manual                                  | Informational                             | `go test -bench` sweep with benchstat regression detection                  |
+| Gate                            | Workflow                                          | Trigger                                          | Required PR check?                        | Scope                                                                       |
+| ------------------------------- | ------------------------------------------------- | ------------------------------------------------ | ----------------------------------------- | --------------------------------------------------------------------------- |
+| `check`                         | `.github/workflows/ci.yml` (job `check`)          | PRs + push                                       | Required                                  | `go test -race -cover ./...` (Layers 1, 2a, 2b, 3, 4, 5, 7, 8, 11 default)  |
+| `lint`                          | `.github/workflows/ci.yml` (job `lint`)           | PRs + push                                       | Required                                  | `golangci-lint` v2 + markdownlint + commitlint                              |
+| `dashboard` (E2E)               | `.github/workflows/e2e.yml` (job `dashboard`)     | push-to-main + nightly + manual                  | Informational                             | k3d + cerberus + Grafana + Playwright (Layer 10)                            |
+| `compatibility`                 | `.github/workflows/compatibility.yml`             | push-to-main + nightly + manual                  | Informational today; required at v1.0 cut | `prometheus/compliance` differential (PromQL truth-source)                  |
+| `mutation` (`phase1`)           | `.github/workflows/mutation.yml` (matrix)         | push-to-main + nightly + manual                  | Informational                             | gremlins on `internal/chplan` @ 80% efficacy                                |
+| `mutation` (`phase2`)           | Same workflow, separate matrix entry              | push-to-main + nightly + manual                  | Informational                             | gremlins on `internal/chsql` @ 75% efficacy                                 |
+| `mutation` (`phase3-optimizer`) | Same workflow, separate matrix entry              | push-to-main + nightly + manual                  | Informational                             | gremlins on `internal/optimizer` @ 70% efficacy                             |
+| `mutation` (`phase4-promql`)    | Same workflow, separate matrix entry              | push-to-main + nightly + manual                  | Informational                             | gremlins on `internal/promql` @ 65% efficacy                                |
+| `mutation` (`phase4-logql`)     | Same workflow, separate matrix entry              | push-to-main + nightly + manual                  | Informational                             | gremlins on `internal/logql` @ 65% efficacy                                 |
+| `mutation` (`phase4-traceql`)   | Same workflow, separate matrix entry              | push-to-main + nightly + manual                  | Informational                             | gremlins on `internal/traceql` @ 65% efficacy                               |
+| `chdb`                          | `.github/workflows/chdb.yml`                      | nightly + manual                                 | Informational                             | TXTAR chDB roundtrip (Layer 6a/6b/6c) + handler tests under `-tags chdb`    |
+| `shadow-mode`                   | `.github/workflows/shadow-mode.yml`               | push-to-main + nightly + manual                  | Informational                             | Layer 9 differential corpora                                                |
+| `fuzz`                          | `.github/workflows/fuzz.yml`                      | nightly + manual                                 | Informational                             | `FuzzParse` per QL head                                                     |
+| `perf-benchmark`                | `.github/workflows/perf-benchmark.yml`            | weekly + manual                                  | Informational                             | `go test -bench` sweep with benchstat regression detection                  |
 
 The PR-required surface is small on purpose. `check` + `lint` keep the
 fast feedback loop fast; everything below pollinates main on a slower
@@ -83,10 +87,10 @@ whole-repo `just mutate`.
 
 | Phase | Package                                        | Target efficacy | Status                                 |
 | ----- | ---------------------------------------------- | --------------- | -------------------------------------- |
-| 1     | `internal/chplan`                              | 80%             | DONE (PR #260)                         |
-| 2     | `internal/chsql`                               | 75%             | DONE (PR #268)                         |
-| 3     | `internal/optimizer`                           | 70%             | Pending Layer 4 (PR #266)              |
-| 4     | `internal/{promql,logql,traceql}` + `lower.go` | 65%             | Pending Layer 2b (lowering edge tests) |
+| 1     | `internal/chplan`                              | 80%             | Rolled out, informational (PR #260)    |
+| 2     | `internal/chsql`                               | 75%             | Rolled out, informational (PR #268)    |
+| 3     | `internal/optimizer`                           | 70%             | Rolled out, informational              |
+| 4     | `internal/{promql,logql,traceql}` + `lower.go` | 65%             | Rolled out, informational              |
 
 Promotion to a required PR gate is gated on Phase 4: once all four
 phases stay green for a week of nightly runs, `mutation` becomes a


### PR DESCRIPTION
## Summary

- Extend `.github/workflows/mutation.yml` matrix with 4 more entries: `phase3-optimizer` (`./internal/optimizer/...` @ 70%), `phase4-promql`/`phase4-logql`/`phase4-traceql` (each at 65%). Workflow now runs 6 independent mutation jobs nightly; each is green/red on its own.
- Layer 4 (optimizer property tests, PR #266) + Layers 1 + 2b (parser smoke + lowering edges, PRs #267 + #270) gave the underlying packages enough coverage to clear the per-phase efficacy bars.
- Sync `.gremlins.yaml`'s phased-rollout comment block + the CI gates and rollout tables in `docs/test-strategy.md` to mark phases 1-4 all rolled out (informational). Promotion to a required PR gate still gated on a week of green nightly runs.

## Test plan

- [ ] `lint` + `check` green on the PR.
- [ ] Next nightly run shows 6 matrix entries (`phase1`, `phase2`, `phase3-optimizer`, `phase4-promql`, `phase4-logql`, `phase4-traceql`) under the `mutation` workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)