### PR TITLE
fix(promql): instant selector returns latest-per-series within eval_ts window

### DIFF
--- a/internal/api/prom/handler_test.go
+++ b/internal/api/prom/handler_test.go
@@ -144,12 +144,21 @@ func TestQuery_Vector(t *testing.T) {
 	}
 
 	// The lowered SQL should reference the gauge table and bind the metric
-	// name as an arg.
+	// name as an arg. The bare-selector path appends LWR + eval-ts /
+	// staleness predicates after the MetricName equality, so "up" lands
+	// somewhere in lastArgs rather than at the tail.
 	if !strings.Contains(q.lastSQL, "otel_metrics_gauge") {
 		t.Errorf("expected SQL to mention otel_metrics_gauge; got %q", q.lastSQL)
 	}
-	if len(q.lastArgs) == 0 || q.lastArgs[len(q.lastArgs)-1] != "up" {
-		t.Errorf("expected last arg %q, got %v", "up", q.lastArgs)
+	foundUp := false
+	for _, a := range q.lastArgs {
+		if a == "up" {
+			foundUp = true
+			break
+		}
+	}
+	if !foundUp {
+		t.Errorf("expected %q among bound args, got %v", "up", q.lastArgs)
 	}
 }
 

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -89,6 +89,19 @@ func lower(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, error
 // lowerVectorSelector turns `metric{label="val"}` into Scan + Filter.
 // `@` and `offset` modifiers add a `Timestamp <= anchor` predicate so the
 // instant evaluation reflects the requested shifted time.
+//
+// When ctx.inRangeVector is false (the default — top-level selector,
+// under aggregations, or inside instant arithmetic) cerberus also
+// applies PromQL's Latest-With-Respect-to-T (LWR) rule: filter the
+// scan to samples with `Timestamp <= anchor` AND
+// `anchor - Timestamp < 5m` (Prom's default staleness window), then
+// collapse to one row per series via `argMax(Value, TimeUnix)` /
+// `max(TimeUnix)` grouped by `(MetricName, Attributes)`. That's the
+// per-series-latest-within-lookback contract any downstream aggregation
+// must aggregate over. Range-vector consumers (rate / *_over_time /
+// subqueries) bypass the LWR wrap by setting `inRangeVector` before
+// recursing — the RangeWindow node owns the in-window aggregation
+// itself.
 func lowerVectorSelector(v *parser.VectorSelector, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
 	metricName := metricNameFromMatchers(v.LabelMatchers)
 	table := s.GaugeTable
@@ -99,22 +112,178 @@ func lowerVectorSelector(v *parser.VectorSelector, s schema.Metrics, ctx lowerCt
 	scan := &chplan.Scan{Table: table}
 
 	pred := buildPredicate(v.LabelMatchers, s)
-	if hasModifier(v) {
-		anchor, err := anchorFromSelector(v, ctx)
-		if err != nil {
-			return nil, err
+
+	// Resolve the effective evaluation anchor for this selector.
+	// `@`/offset modifiers shadow the surrounding ctx; absent a
+	// modifier we pick up ctx.end (the query's eval timestamp) so
+	// the LWR predicate below has something to compare against.
+	anchor, err := selectorAnchor(v, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if ctx.inRangeVector {
+		// Inside a range vector / subquery the surrounding node owns
+		// the per-window aggregation. We still apply the modifier's
+		// `Timestamp <= anchor` bound when present (matching the pre-
+		// LWR behaviour) so the range-vector pipeline only sees
+		// samples up to the requested instant.
+		if hasModifier(v) {
+			timeBound := timeBoundExpr(s.TimestampColumn, anchor)
+			if pred == nil {
+				pred = timeBound
+			} else {
+				pred = &chplan.Binary{Op: chplan.OpAnd, Left: pred, Right: timeBound}
+			}
 		}
-		timeBound := timeBoundExpr(s.TimestampColumn, anchor)
 		if pred == nil {
-			pred = timeBound
-		} else {
-			pred = &chplan.Binary{Op: chplan.OpAnd, Left: pred, Right: timeBound}
+			return scan, nil
 		}
+		return &chplan.Filter{Input: scan, Predicate: pred}, nil
 	}
-	if pred == nil {
-		return scan, nil
+	// Instant-vector context: the LWR wrapper applies both the
+	// `Timestamp <= anchor` upper bound and the staleness lower
+	// bound, so we DON'T pre-add the modifier's timeBoundExpr here —
+	// that would duplicate the upper-bound predicate.
+	return wrapInstantLatestPerSeries(scan, pred, anchor, s), nil
+}
+
+// wrapInstantLatestPerSeries adds the LWR + staleness predicates on
+// top of (scan, pred) and collapses to one row per `(MetricName,
+// Attributes)` series via `argMax(Value, TimeUnix)`. The output
+// preserves the canonical Sample-row schema — MetricName, Attributes,
+// TimeUnix, Value — so the surrounding plan tree (Aggregate, Project,
+// Filter, ...) keeps consuming the same column shape it did before
+// the LWR wrap landed.
+//
+// Schema-preservation is what lets `wrapWithSampleProjection` upstream
+// keep its non-derived-shape path: the root after this wrap is a
+// chplan.Project whose output columns match the table's canonical
+// names, so `isDerivedShape` returns false and the handler-side
+// projection is a pass-through.
+//
+// Aliasing detail: the inner Aggregate projects the per-series TimeUnix
+// + Value pair through temporary aliases (`lwr_ts`, `lwr_value`) so
+// `argMax(Value, TimeUnix)` is unambiguous. CH otherwise rejects the
+// query with ILLEGAL_AGGREGATION on the (TimeUnix-the-alias /
+// TimeUnix-the-column) shadow inside the same SELECT projection list.
+// The outer Project re-aliases back to the canonical names so the
+// surrounding plan tree continues to see the same `MetricName /
+// Attributes / TimeUnix / Value` shape.
+func wrapInstantLatestPerSeries(scan *chplan.Scan, pred chplan.Expr, anchor evalAnchor, s schema.Metrics) chplan.Node {
+	lwr := timeBoundExpr(s.TimestampColumn, anchor)
+	staleness := stalenessLowerBoundExpr(s.TimestampColumn, anchor, instantLookback)
+	combined := pred
+	for _, p := range []chplan.Expr{lwr, staleness} {
+		if combined == nil {
+			combined = p
+			continue
+		}
+		combined = &chplan.Binary{Op: chplan.OpAnd, Left: combined, Right: p}
 	}
-	return &chplan.Filter{Input: scan, Predicate: pred}, nil
+	filtered := &chplan.Filter{Input: scan, Predicate: combined}
+
+	const (
+		lwrTsAlias    = "lwr_ts"
+		lwrValueAlias = "lwr_value"
+	)
+
+	agg := &chplan.Aggregate{
+		Input: filtered,
+		GroupBy: []chplan.Expr{
+			&chplan.ColumnRef{Name: s.MetricNameColumn},
+			&chplan.ColumnRef{Name: s.AttributesColumn},
+		},
+		GroupByAliases: []string{s.MetricNameColumn, s.AttributesColumn},
+		AggFuncs: []chplan.AggFunc{
+			{
+				Name:  "max",
+				Args:  []chplan.Expr{&chplan.ColumnRef{Name: s.TimestampColumn}},
+				Alias: lwrTsAlias,
+			},
+			{
+				Name: "argMax",
+				Args: []chplan.Expr{
+					&chplan.ColumnRef{Name: s.ValueColumn},
+					&chplan.ColumnRef{Name: s.TimestampColumn},
+				},
+				Alias: lwrValueAlias,
+			},
+		},
+	}
+
+	return &chplan.Project{
+		Input: agg,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.ColumnRef{Name: s.MetricNameColumn}, Alias: s.MetricNameColumn},
+			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
+			{Expr: &chplan.ColumnRef{Name: lwrTsAlias}, Alias: s.TimestampColumn},
+			{Expr: &chplan.ColumnRef{Name: lwrValueAlias}, Alias: s.ValueColumn},
+		},
+	}
+}
+
+// selectorAnchor resolves the effective evaluation anchor for a vector
+// selector, threading through `@` / offset / start() / end() modifiers
+// and falling back to the surrounding query's end timestamp. The zero
+// anchor means "use `now64(9)` at the SQL level" — picked up by
+// `timeBoundExpr` callers.
+//
+// `@<ts>` and `@ start()/@ end()` set the absolute anchor directly;
+// `offset` shifts the anchor by a fixed delta and keeps whatever base
+// anchor the rest of the resolution produced. So `up offset 5m`
+// against a query with eval_ts = T anchors at `(T, offset=5m)` —
+// `timeBoundExpr` then renders `Timestamp <= T - 5m` and the
+// staleness predicate renders `Timestamp > T - 5m - lookback`.
+func selectorAnchor(vs *parser.VectorSelector, ctx lowerCtx) (evalAnchor, error) {
+	if hasModifier(vs) {
+		a, err := anchorFromSelector(vs, ctx)
+		if err != nil {
+			return evalAnchor{}, err
+		}
+		// `up offset 5m` (no `@`) leaves anchorFromSelector with
+		// `End == zero` because the selector itself doesn't pin an
+		// absolute time. Without threading ctx.end through, the SQL
+		// renders `now64(9)` and the LWR window would skew off the
+		// real eval timestamp — bug-shaped for instant queries that
+		// resolve eval_ts in the API layer. So back-fill End from
+		// the surrounding query whenever an offset would otherwise
+		// land on a zero anchor.
+		if a.End.IsZero() && !ctx.end.IsZero() {
+			a.End = ctx.end.UTC()
+		}
+		return a, nil
+	}
+	// No modifier — anchor the LWR window to the surrounding query's
+	// end time when threaded through LowerAt. Otherwise leave the
+	// anchor zero so the SQL renders `now64(9)`.
+	if !ctx.end.IsZero() {
+		return evalAnchor{End: ctx.end.UTC()}, nil
+	}
+	return evalAnchor{}, nil
+}
+
+// stalenessLowerBoundExpr renders the strict-lower-bound half of the
+// LWR window:  `<col> > (<anchor> - <lookback>)`. Combined with the
+// non-strict upper bound `<col> <= <anchor>` (from timeBoundExpr), the
+// pair matches Prometheus's `Timestamp <= T AND T - Timestamp <
+// lookback` rule.
+func stalenessLowerBoundExpr(col string, a evalAnchor, lookback time.Duration) chplan.Expr {
+	anchor := anchorBaseExpr(a)
+	offsetNs := lookback.Nanoseconds() + a.Offset.Nanoseconds()
+	right := &chplan.Binary{
+		Op:   chplan.OpSub,
+		Left: anchor,
+		Right: &chplan.FuncCall{
+			Name: "toIntervalNanosecond",
+			Args: []chplan.Expr{&chplan.LitInt{V: offsetNs}},
+		},
+	}
+	return &chplan.Binary{
+		Op:    chplan.OpGt,
+		Left:  &chplan.ColumnRef{Name: col},
+		Right: right,
+	}
 }
 
 // metricNameFromMatchers returns the value of the __name__ matcher (if any
@@ -242,12 +411,16 @@ func lowerRangeVectorCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chpla
 	// The RangeWindow already encodes the window's eval anchor; emitting a
 	// duplicate time-bound predicate on the inner Filter would double-count.
 	// Build the inner Scan/Filter without the modifier-derived bound here.
+	// The inRangeVector flag also suppresses the bare-selector LWR wrap so
+	// every in-window sample reaches the RangeWindow node.
 	vsNoModifier := *vs
 	vsNoModifier.Timestamp = nil
 	vsNoModifier.OriginalOffset = 0
 	vsNoModifier.Offset = 0
 	vsNoModifier.StartOrEnd = 0
-	inner, err := lowerVectorSelector(&vsNoModifier, s, ctx)
+	rangeCtx := ctx
+	rangeCtx.inRangeVector = true
+	inner, err := lowerVectorSelector(&vsNoModifier, s, rangeCtx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/promql/lower_bench_test.go
+++ b/internal/promql/lower_bench_test.go
@@ -110,13 +110,19 @@ func TestAllocs_Lower(t *testing.T) {
 		query  string
 		maxAvg float64 // ceiling on allocs/op
 	}{
-		// Baselines (recorded on a 1M-row test host): 13 / 17 / 27 /
-		// 40 / 21. Ceilings = baseline × ~3 to keep the test
-		// regression-focused; a 3× spike means somebody slipped a
-		// heap allocation into a fast path.
-		{"instant", `up`, 40},
+		// Baselines (recorded on a 1M-row test host):
+		// instant 48 (was 13 before LWR landed; instant selectors
+		//   now build Project(Aggregate(Filter(Scan))) instead of
+		//   Filter(Scan) to implement PromQL's Latest-With-Respect-to-T
+		//   semantics — fix for sum-over-stored-samples + eval-ts-
+		//   boundary bugs in the bare-selector path).
+		// range 17 / binary 27 / aggregation 40 / subquery 21.
+		// Ceilings = baseline × ~2-3 to keep the test regression-
+		// focused; a multi-× spike means somebody slipped a heap
+		// allocation into a fast path.
+		{"instant", `up`, 70},
 		{"range", `rate(http_requests_total[5m])`, 60},
-		{"binary", `(up * 2) > 1`, 90},
+		{"binary", `(up * 2) > 1`, 130},
 		{"aggregation", `sum by (le)(rate(http_request_duration_seconds_bucket[1m]))`, 130},
 		{"subquery", `max_over_time(rate(http_requests_total[1m])[5m:30s])`, 70},
 	}

--- a/internal/promql/lower_test.go
+++ b/internal/promql/lower_test.go
@@ -33,14 +33,22 @@ func TestLower(t *testing.T) {
 
 	// Fixed start/end used when a fixture's query contains `@ start()`
 	// or `@ end()`. Picking small Unix-epoch values keeps the generated
-	// SQL literals short and deterministic. Detected by string match;
-	// fixtures without those modifiers use plain Lower (no range).
+	// SQL literals short and deterministic.
 	const (
 		fixtureStartUnix = int64(100)
 		fixtureEndUnix   = int64(500)
 	)
 	start := time.Unix(fixtureStartUnix, 0).UTC()
 	end := time.Unix(fixtureEndUnix, 0).UTC()
+
+	// Every other fixture uses a deterministic instant-eval anchor
+	// just after the seed timestamps (the round-trip fixtures all use
+	// `toDateTime64('2026-01-01 00:00:00', 9)`). One second after that
+	// keeps the seed inside the 5-minute LWR staleness window the
+	// instant-selector lowering applies. This is what gets passed to
+	// LowerAt as both start and end — instant queries have
+	// start == end == eval_ts.
+	instantEval := time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
 
 	spec.Walk(t, fixtureDir, func(t *testing.T, c *spec.Case) {
 		query, ok := c.Section("query.promql")
@@ -54,14 +62,14 @@ func TestLower(t *testing.T) {
 			t.Fatalf("ParseExpr(%q): %v", query, err)
 		}
 		// Fixtures that exercise `@ start()` / `@ end()` need the
-		// time-aware lowering entrypoint; everything else uses plain
-		// Lower so existing fixtures stay deterministic regardless of
-		// the fixed range.
+		// special fixed range; every other fixture lowers with the
+		// deterministic instant-eval anchor so the LWR staleness
+		// predicate produces stable SQL literals.
 		var plan chplan.Node
 		if strings.Contains(query, "@ start()") || strings.Contains(query, "@ end()") {
 			plan, err = promql.LowerAt(context.Background(), expr, s, start, end)
 		} else {
-			plan, err = promql.Lower(context.Background(), expr, s)
+			plan, err = promql.LowerAt(context.Background(), expr, s, instantEval, instantEval)
 		}
 		if err != nil {
 			t.Fatalf("Lower(%q): %v", query, err)

--- a/internal/promql/modifiers.go
+++ b/internal/promql/modifiers.go
@@ -27,10 +27,27 @@ type evalAnchor struct {
 // lowerings (`@ start()` / `@ end()`). Zero-value start/end means "no
 // range threaded", and the start/end modifier path returns an error so
 // callers see the misconfiguration rather than a silently wrong query.
+//
+// inRangeVector marks recursive descents into a range-vector context
+// (under a matrix selector wrapped by rate / *_over_time / subquery).
+// `lowerVectorSelector` checks the flag to decide whether to apply
+// PromQL's instant-vector Latest-With-Respect-to-T (LWR) projection:
+// at the top level (and under aggregations / arithmetic on instant
+// vectors) we collapse to one row per series with the latest sample
+// within the staleness window; under a range vector we leave every
+// in-window sample for the RangeWindow node to consume.
 type lowerCtx struct {
-	start time.Time
-	end   time.Time
+	start         time.Time
+	end           time.Time
+	inRangeVector bool
 }
+
+// instantLookback is the default Prometheus staleness window applied
+// when an instant-vector selector picks the latest sample per series.
+// Prom defaults to 5 minutes; cerberus matches the upstream constant
+// rather than reading a per-deployment override so the LWR predicate
+// behaves predictably across environments.
+const instantLookback = 5 * time.Minute
 
 func anchorFromSelector(vs *parser.VectorSelector, ctx lowerCtx) (evalAnchor, error) {
 	a := evalAnchor{Offset: vs.OriginalOffset}
@@ -69,21 +86,7 @@ func hasModifier(vs *parser.VectorSelector) bool {
 // VectorSelector with `@` or `offset`. The anchor is `now64(9)` (or a
 // literal toDateTime64) optionally minus a nanosecond interval.
 func timeBoundExpr(col string, a evalAnchor) chplan.Expr {
-	var base chplan.Expr
-	if a.End.IsZero() {
-		base = &chplan.FuncCall{
-			Name: "now64",
-			Args: []chplan.Expr{&chplan.LitInt{V: 9}},
-		}
-	} else {
-		base = &chplan.FuncCall{
-			Name: "toDateTime64",
-			Args: []chplan.Expr{
-				&chplan.LitString{V: a.End.Format("2006-01-02 15:04:05.000000000")},
-				&chplan.LitInt{V: 9},
-			},
-		}
-	}
+	base := anchorBaseExpr(a)
 	bound := base
 	if a.Offset > 0 {
 		bound = &chplan.Binary{
@@ -99,5 +102,27 @@ func timeBoundExpr(col string, a evalAnchor) chplan.Expr {
 		Op:    chplan.OpLe,
 		Left:  &chplan.ColumnRef{Name: col},
 		Right: bound,
+	}
+}
+
+// anchorBaseExpr returns the SQL expression for an `evalAnchor`'s
+// reference time. Zero anchor renders as `now64(9)`; an absolute
+// anchor renders as `toDateTime64('YYYY-MM-DD HH:MM:SS.fffffffff',
+// 9)`. The Offset field is NOT applied here — callers compose the
+// subtract themselves (timeBoundExpr applies an offset; the LWR
+// staleness predicate composes its own offset+lookback delta).
+func anchorBaseExpr(a evalAnchor) chplan.Expr {
+	if a.End.IsZero() {
+		return &chplan.FuncCall{
+			Name: "now64",
+			Args: []chplan.Expr{&chplan.LitInt{V: 9}},
+		}
+	}
+	return &chplan.FuncCall{
+		Name: "toDateTime64",
+		Args: []chplan.Expr{
+			&chplan.LitString{V: a.End.Format("2006-01-02 15:04:05.000000000")},
+			&chplan.LitInt{V: 9},
+		},
 	}
 }

--- a/internal/promql/range_fns.go
+++ b/internal/promql/range_fns.go
@@ -39,7 +39,9 @@ func lowerPredictLinear(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.
 	vsNoModifier.OriginalOffset = 0
 	vsNoModifier.Offset = 0
 	vsNoModifier.StartOrEnd = 0
-	inner, err := lowerVectorSelector(&vsNoModifier, s, ctx)
+	rangeCtx := ctx
+	rangeCtx.inRangeVector = true
+	inner, err := lowerVectorSelector(&vsNoModifier, s, rangeCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +95,9 @@ func lowerHoltWinters(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.No
 	vsNoModifier.OriginalOffset = 0
 	vsNoModifier.Offset = 0
 	vsNoModifier.StartOrEnd = 0
-	inner, err := lowerVectorSelector(&vsNoModifier, s, ctx)
+	rangeCtx := ctx
+	rangeCtx.inRangeVector = true
+	inner, err := lowerVectorSelector(&vsNoModifier, s, rangeCtx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/promql/subquery.go
+++ b/internal/promql/subquery.go
@@ -92,12 +92,16 @@ func lowerSubqueryOverCall(
 	}
 
 	// Strip the inner VS modifier — the subquery's own modifier shadows it.
+	// inRangeVector also suppresses the bare-selector LWR wrap so every
+	// in-window sample reaches the surrounding RangeWindow.
 	vsNoModifier := *vs
 	vsNoModifier.Timestamp = nil
 	vsNoModifier.OriginalOffset = 0
 	vsNoModifier.Offset = 0
 	vsNoModifier.StartOrEnd = 0
-	inner, err := lowerVectorSelector(&vsNoModifier, s, ctx)
+	rangeCtx := ctx
+	rangeCtx.inRangeVector = true
+	inner, err := lowerVectorSelector(&vsNoModifier, s, rangeCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +144,9 @@ func lowerSubqueryOverVectorSelector(
 	vsNoModifier.OriginalOffset = 0
 	vsNoModifier.Offset = 0
 	vsNoModifier.StartOrEnd = 0
-	inner, err := lowerVectorSelector(&vsNoModifier, s, ctx)
+	rangeCtx := ctx
+	rangeCtx.inRangeVector = true
+	inner, err := lowerVectorSelector(&vsNoModifier, s, rangeCtx)
 	if err != nil {
 		return nil, err
 	}

--- a/test/spec/promql/abs_metric.txtar
+++ b/test/spec/promql/abs_metric.txtar
@@ -2,15 +2,20 @@
 abs(temperature)
 -- args --
 [0] string = "temperature"
+[1] string = "2026-01-01 00:00:01.000000000"
+[2] int64 = 9
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] int64 = 300000000000
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, abs(`Value`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, abs(`Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_gauge VALUES
     ('temperature', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), -3.5);
 -- expected_rows --
@@ -19,5 +24,7 @@ INSERT INTO otel_metrics_gauge VALUES
 ]
 -- chplan --
 Project [MetricName, Attributes, TimeUnix, abs(Value) AS Value]
-  Filter predicate=(MetricName = "temperature")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "temperature") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/at_end_basic.txtar
+++ b/test/spec/promql/at_end_basic.txtar
@@ -10,7 +10,7 @@ CREATE TABLE otel_metrics_sum (
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_sum VALUES
     ('http_requests_total', map('job', 'api'), toDateTime64('1970-01-01 00:06:40', 9), 0.0),
     ('http_requests_total', map('job', 'api'), toDateTime64('1970-01-01 00:08:20', 9), 300.0);

--- a/test/spec/promql/at_start_basic.txtar
+++ b/test/spec/promql/at_start_basic.txtar
@@ -4,8 +4,13 @@ up @ start()
 [0] string = "up"
 [1] string = "1970-01-01 00:01:40.000000000"
 [2] int64 = 9
+[3] string = "1970-01-01 00:01:40.000000000"
+[4] int64 = 9
+[5] int64 = 300000000000
 -- sql --
-SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?))
+SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)
 -- chplan --
-Filter predicate=((MetricName = "up") AND (TimeUnix <= toDateTime64("1970-01-01 00:01:40.000000000", 9)))
-  Scan(otel_metrics_gauge)
+Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+  Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+    Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("1970-01-01 00:01:40.000000000", 9))) AND (TimeUnix > (toDateTime64("1970-01-01 00:01:40.000000000", 9) - toIntervalNanosecond(300000000000))))
+      Scan(otel_metrics_gauge)

--- a/test/spec/promql/bool_lt.txtar
+++ b/test/spec/promql/bool_lt.txtar
@@ -1,17 +1,22 @@
 -- query.promql --
 up < bool 1
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, toFloat64((`Value` < ?)) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, toFloat64((`Value` < ?)) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
 -- args --
 [0] float64 = 1
 [1] string = "up"
+[2] string = "2026-01-01 00:00:01.000000000"
+[3] int64 = 9
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] int64 = 300000000000
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_gauge VALUES
     ('up', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 0.0),
     ('down', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 0.0);
@@ -21,5 +26,7 @@ INSERT INTO otel_metrics_gauge VALUES
 ]
 -- chplan --
 Project [MetricName, Attributes, TimeUnix, toFloat64((Value < 1)) AS Value]
-  Filter predicate=(MetricName = "up")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/ceil_metric.txtar
+++ b/test/spec/promql/ceil_metric.txtar
@@ -2,15 +2,20 @@
 ceil(temperature)
 -- args --
 [0] string = "temperature"
+[1] string = "2026-01-01 00:00:01.000000000"
+[2] int64 = 9
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] int64 = 300000000000
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, ceil(`Value`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, ceil(`Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_gauge VALUES
     ('temperature', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 2.3);
 -- expected_rows --
@@ -19,5 +24,7 @@ INSERT INTO otel_metrics_gauge VALUES
 ]
 -- chplan --
 Project [MetricName, Attributes, TimeUnix, ceil(Value) AS Value]
-  Filter predicate=(MetricName = "temperature")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "temperature") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/chained_filter.txtar
+++ b/test/spec/promql/chained_filter.txtar
@@ -1,13 +1,20 @@
 -- query.promql --
 up{job="api",env!="prod"}
 -- sql --
-SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) AND (`Attributes`[?] = ?) WHERE (`Attributes`[?] != ?)
+SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) AND (`Attributes`[?] = ?) AND (`Attributes`[?] != ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)
 -- args --
 [0] string = "up"
 [1] string = "job"
 [2] string = "api"
 [3] string = "env"
 [4] string = "prod"
+[5] string = "2026-01-01 00:00:01.000000000"
+[6] int64 = 9
+[7] string = "2026-01-01 00:00:01.000000000"
+[8] int64 = 9
+[9] int64 = 300000000000
 -- chplan --
-Filter predicate=(((Attributes["job"] = "api") AND (Attributes["env"] != "prod")) AND (MetricName = "up"))
-  Scan(otel_metrics_gauge)
+Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+  Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+    Filter predicate=(((((Attributes["job"] = "api") AND (Attributes["env"] != "prod")) AND (MetricName = "up")) AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+      Scan(otel_metrics_gauge)

--- a/test/spec/promql/clamp.txtar
+++ b/test/spec/promql/clamp.txtar
@@ -1,18 +1,23 @@
 -- query.promql --
 clamp(temperature, 0, 100)
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, greatest(?, least(?, `Value`)) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, greatest(?, least(?, `Value`)) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
 -- args --
 [0] float64 = 0
 [1] float64 = 100
 [2] string = "temperature"
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] string = "2026-01-01 00:00:01.000000000"
+[6] int64 = 9
+[7] int64 = 300000000000
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_gauge VALUES
     ('temperature', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 150.0);
 -- expected_rows --
@@ -21,5 +26,7 @@ INSERT INTO otel_metrics_gauge VALUES
 ]
 -- chplan --
 Project [MetricName, Attributes, TimeUnix, greatest(0, least(100, Value)) AS Value]
-  Filter predicate=(MetricName = "temperature")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "temperature") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/clamp_max.txtar
+++ b/test/spec/promql/clamp_max.txtar
@@ -1,17 +1,22 @@
 -- query.promql --
 clamp_max(temperature, 100)
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, least(`Value`, ?) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, least(`Value`, ?) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
 -- args --
 [0] float64 = 100
 [1] string = "temperature"
+[2] string = "2026-01-01 00:00:01.000000000"
+[3] int64 = 9
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] int64 = 300000000000
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_gauge VALUES
     ('temperature', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 150.0);
 -- expected_rows --
@@ -20,5 +25,7 @@ INSERT INTO otel_metrics_gauge VALUES
 ]
 -- chplan --
 Project [MetricName, Attributes, TimeUnix, least(Value, 100) AS Value]
-  Filter predicate=(MetricName = "temperature")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "temperature") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/clamp_min.txtar
+++ b/test/spec/promql/clamp_min.txtar
@@ -1,17 +1,22 @@
 -- query.promql --
 clamp_min(temperature, 0)
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, greatest(`Value`, ?) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, greatest(`Value`, ?) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
 -- args --
 [0] float64 = 0
 [1] string = "temperature"
+[2] string = "2026-01-01 00:00:01.000000000"
+[3] int64 = 9
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] int64 = 300000000000
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_gauge VALUES
     ('temperature', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), -50.0);
 -- expected_rows --
@@ -20,5 +25,7 @@ INSERT INTO otel_metrics_gauge VALUES
 ]
 -- chplan --
 Project [MetricName, Attributes, TimeUnix, greatest(Value, 0) AS Value]
-  Filter predicate=(MetricName = "temperature")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "temperature") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/comparison_arithmetic.txtar
+++ b/test/spec/promql/comparison_arithmetic.txtar
@@ -1,13 +1,20 @@
 -- query.promql --
 (up * 2) > 1
 -- sql --
-SELECT * FROM (SELECT `MetricName`, `Attributes`, `TimeUnix`, (`Value` * ?) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))) WHERE (`Value` > ?)
+SELECT * FROM (SELECT `MetricName`, `Attributes`, `TimeUnix`, (`Value` * ?) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))) WHERE (`Value` > ?)
 -- args --
 [0] float64 = 2
 [1] string = "up"
-[2] float64 = 1
+[2] string = "2026-01-01 00:00:01.000000000"
+[3] int64 = 9
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] int64 = 300000000000
+[7] float64 = 1
 -- chplan --
 Filter predicate=(Value > 1)
   Project [MetricName, Attributes, TimeUnix, (Value * 2) AS Value]
-    Filter predicate=(MetricName = "up")
-      Scan(otel_metrics_gauge)
+    Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+      Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+        Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+          Scan(otel_metrics_gauge)

--- a/test/spec/promql/count_no_group.txtar
+++ b/test/spec/promql/count_no_group.txtar
@@ -5,10 +5,17 @@ count(up)
 [1] string = "Map(String,String)"
 [2] int64 = 9
 [3] string = "up"
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] string = "2026-01-01 00:00:01.000000000"
+[7] int64 = 9
+[8] int64 = 300000000000
 -- sql --
-SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT count(`Value`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)))
+SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT count(`Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)))
 -- chplan --
 Project ["" AS MetricName, CAST(map(), "Map(String,String)") AS Attributes, now64(9) AS TimeUnix, Value AS Value]
   Aggregate groupBy=[] funcs=[count(Value) AS Value]
-    Filter predicate=(MetricName = "up")
-      Scan(otel_metrics_gauge)
+    Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+      Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+        Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+          Scan(otel_metrics_gauge)

--- a/test/spec/promql/edge_at_then_offset_neg.txtar
+++ b/test/spec/promql/edge_at_then_offset_neg.txtar
@@ -4,8 +4,13 @@ up @ 1700000000 offset -3m
 [0] string = "up"
 [1] string = "2023-11-14 22:13:20.000000000"
 [2] int64 = 9
+[3] string = "2023-11-14 22:13:20.000000000"
+[4] int64 = 9
+[5] int64 = 120000000000
 -- sql --
-SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?))
+SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)
 -- chplan --
-Filter predicate=((MetricName = "up") AND (TimeUnix <= toDateTime64("2023-11-14 22:13:20.000000000", 9)))
-  Scan(otel_metrics_gauge)
+Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+  Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+    Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2023-11-14 22:13:20.000000000", 9))) AND (TimeUnix > (toDateTime64("2023-11-14 22:13:20.000000000", 9) - toIntervalNanosecond(120000000000))))
+      Scan(otel_metrics_gauge)

--- a/test/spec/promql/edge_bool_eq.txtar
+++ b/test/spec/promql/edge_bool_eq.txtar
@@ -3,9 +3,16 @@ up == bool 1
 -- args --
 [0] float64 = 1
 [1] string = "up"
+[2] string = "2026-01-01 00:00:01.000000000"
+[3] int64 = 9
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] int64 = 300000000000
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, toFloat64((`Value` = ?)) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, toFloat64((`Value` = ?)) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
 -- chplan --
 Project [MetricName, Attributes, TimeUnix, toFloat64((Value = 1)) AS Value]
-  Filter predicate=(MetricName = "up")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/edge_bool_ge.txtar
+++ b/test/spec/promql/edge_bool_ge.txtar
@@ -3,9 +3,16 @@ up >= bool 1
 -- args --
 [0] float64 = 1
 [1] string = "up"
+[2] string = "2026-01-01 00:00:01.000000000"
+[3] int64 = 9
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] int64 = 300000000000
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, toFloat64((`Value` >= ?)) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, toFloat64((`Value` >= ?)) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
 -- chplan --
 Project [MetricName, Attributes, TimeUnix, toFloat64((Value >= 1)) AS Value]
-  Filter predicate=(MetricName = "up")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/edge_bool_le.txtar
+++ b/test/spec/promql/edge_bool_le.txtar
@@ -3,9 +3,16 @@ up <= bool 1
 -- args --
 [0] float64 = 1
 [1] string = "up"
+[2] string = "2026-01-01 00:00:01.000000000"
+[3] int64 = 9
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] int64 = 300000000000
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, toFloat64((`Value` <= ?)) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, toFloat64((`Value` <= ?)) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
 -- chplan --
 Project [MetricName, Attributes, TimeUnix, toFloat64((Value <= 1)) AS Value]
-  Filter predicate=(MetricName = "up")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/edge_bool_ne.txtar
+++ b/test/spec/promql/edge_bool_ne.txtar
@@ -3,9 +3,16 @@ up != bool 0
 -- args --
 [0] float64 = 0
 [1] string = "up"
+[2] string = "2026-01-01 00:00:01.000000000"
+[3] int64 = 9
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] int64 = 300000000000
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, toFloat64((`Value` != ?)) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, toFloat64((`Value` != ?)) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
 -- chplan --
 Project [MetricName, Attributes, TimeUnix, toFloat64((Value != 0)) AS Value]
-  Filter predicate=(MetricName = "up")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/edge_ceil_over_sum_by.txtar
+++ b/test/spec/promql/edge_ceil_over_sum_by.txtar
@@ -6,12 +6,19 @@ ceil(sum by (job) (up))
 [2] int64 = 9
 [3] string = "job"
 [4] string = "up"
-[5] string = "job"
+[5] string = "2026-01-01 00:00:01.000000000"
+[6] int64 = 9
+[7] string = "2026-01-01 00:00:01.000000000"
+[8] int64 = 9
+[9] int64 = 300000000000
+[10] string = "job"
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, ceil(`Value`) AS `Value` FROM (SELECT ? AS `MetricName`, map(?, `gkey_0`) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes`[?] AS `gkey_0`, sum(`Value`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY `Attributes`[?]))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, ceil(`Value`) AS `Value` FROM (SELECT ? AS `MetricName`, map(?, `gkey_0`) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes`[?] AS `gkey_0`, sum(`Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY `Attributes`[?]))
 -- chplan --
 Project [MetricName, Attributes, TimeUnix, ceil(Value) AS Value]
   Project ["" AS MetricName, map("job", gkey_0) AS Attributes, now64(9) AS TimeUnix, Value AS Value]
     Aggregate groupBy=[Attributes["job"] AS gkey_0] funcs=[sum(Value) AS Value]
-      Filter predicate=(MetricName = "up")
-        Scan(otel_metrics_gauge)
+      Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+        Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+          Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+            Scan(otel_metrics_gauge)

--- a/test/spec/promql/edge_clamp_neg_to_pos.txtar
+++ b/test/spec/promql/edge_clamp_neg_to_pos.txtar
@@ -4,9 +4,16 @@ clamp(temperature, -100, 100)
 [0] float64 = -100
 [1] float64 = 100
 [2] string = "temperature"
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] string = "2026-01-01 00:00:01.000000000"
+[6] int64 = 9
+[7] int64 = 300000000000
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, greatest(?, least(?, `Value`)) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, greatest(?, least(?, `Value`)) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
 -- chplan --
 Project [MetricName, Attributes, TimeUnix, greatest(-100, least(100, Value)) AS Value]
-  Filter predicate=(MetricName = "temperature")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "temperature") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/edge_join_ignoring_extra.txtar
+++ b/test/spec/promql/edge_join_ignoring_extra.txtar
@@ -3,16 +3,30 @@ up * ignoring(pod) group_left(env) machine_role
 -- args --
 [0] string = "env"
 [1] string = "up"
-[2] string = "many-to-many matching not allowed: matching labels must be unique on one side"
-[3] string = "machine_role"
-[4] string = "pod"
-[5] string = "pod"
-[6] string = "pod"
+[2] string = "2026-01-01 00:00:01.000000000"
+[3] int64 = 9
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] int64 = 300000000000
+[7] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[8] string = "machine_role"
+[9] string = "2026-01-01 00:00:01.000000000"
+[10] int64 = 9
+[11] string = "2026-01-01 00:00:01.000000000"
+[12] int64 = 9
+[13] int64 = 300000000000
+[14] string = "pod"
+[15] string = "pod"
+[16] string = "pod"
 -- sql --
-SELECT L.`MetricName`, mapConcat(L.`Attributes`, mapFilter((k, v) -> k IN (?), R.`Attributes`)) AS `Attributes`, L.`TimeUnix`, (L.`Value` * R.`Value`) AS `Value` FROM (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY `MetricName`, `Attributes`) AS L INNER JOIN (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY mapFilter((k, v) -> NOT (k IN (?)), `Attributes`)) AS R ON mapFilter((k, v) -> NOT (k IN (?)), L.`Attributes`) = mapFilter((k, v) -> NOT (k IN (?)), R.`Attributes`)
+SELECT L.`MetricName`, mapConcat(L.`Attributes`, mapFilter((k, v) -> k IN (?), R.`Attributes`)) AS `Attributes`, L.`TimeUnix`, (L.`Value` * R.`Value`) AS `Value` FROM (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY `MetricName`, `Attributes`) AS L INNER JOIN (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY mapFilter((k, v) -> NOT (k IN (?)), `Attributes`)) AS R ON mapFilter((k, v) -> NOT (k IN (?)), L.`Attributes`) = mapFilter((k, v) -> NOT (k IN (?)), R.`Attributes`)
 -- chplan --
 VectorJoin op=* match=ignoring(pod) card=many-to-one include=[env]
-  Filter predicate=(MetricName = "up")
-    Scan(otel_metrics_gauge)
-  Filter predicate=(MetricName = "machine_role")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "machine_role") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/edge_join_ignoring_group_right.txtar
+++ b/test/spec/promql/edge_join_ignoring_group_right.txtar
@@ -4,15 +4,29 @@ machine_role * ignoring(instance) group_right(env) up
 [0] string = "env"
 [1] string = "many-to-many matching not allowed: matching labels must be unique on one side"
 [2] string = "machine_role"
-[3] string = "instance"
-[4] string = "up"
-[5] string = "instance"
-[6] string = "instance"
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] string = "2026-01-01 00:00:01.000000000"
+[6] int64 = 9
+[7] int64 = 300000000000
+[8] string = "instance"
+[9] string = "up"
+[10] string = "2026-01-01 00:00:01.000000000"
+[11] int64 = 9
+[12] string = "2026-01-01 00:00:01.000000000"
+[13] int64 = 9
+[14] int64 = 300000000000
+[15] string = "instance"
+[16] string = "instance"
 -- sql --
-SELECT R.`MetricName`, mapConcat(R.`Attributes`, mapFilter((k, v) -> k IN (?), L.`Attributes`)) AS `Attributes`, R.`TimeUnix`, (L.`Value` * R.`Value`) AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY mapFilter((k, v) -> NOT (k IN (?)), `Attributes`)) AS L INNER JOIN (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY `MetricName`, `Attributes`) AS R ON mapFilter((k, v) -> NOT (k IN (?)), L.`Attributes`) = mapFilter((k, v) -> NOT (k IN (?)), R.`Attributes`)
+SELECT R.`MetricName`, mapConcat(R.`Attributes`, mapFilter((k, v) -> k IN (?), L.`Attributes`)) AS `Attributes`, R.`TimeUnix`, (L.`Value` * R.`Value`) AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY mapFilter((k, v) -> NOT (k IN (?)), `Attributes`)) AS L INNER JOIN (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY `MetricName`, `Attributes`) AS R ON mapFilter((k, v) -> NOT (k IN (?)), L.`Attributes`) = mapFilter((k, v) -> NOT (k IN (?)), R.`Attributes`)
 -- chplan --
 VectorJoin op=* match=ignoring(instance) card=one-to-many include=[env]
-  Filter predicate=(MetricName = "machine_role")
-    Scan(otel_metrics_gauge)
-  Filter predicate=(MetricName = "up")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "machine_role") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/edge_join_on_extra_labels.txtar
+++ b/test/spec/promql/edge_join_on_extra_labels.txtar
@@ -5,16 +5,30 @@ up * on(job) group_left(env, region, svc) machine_role
 [1] string = "region"
 [2] string = "svc"
 [3] string = "up"
-[4] string = "many-to-many matching not allowed: matching labels must be unique on one side"
-[5] string = "machine_role"
-[6] string = "job"
-[7] string = "job"
-[8] string = "job"
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] string = "2026-01-01 00:00:01.000000000"
+[7] int64 = 9
+[8] int64 = 300000000000
+[9] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[10] string = "machine_role"
+[11] string = "2026-01-01 00:00:01.000000000"
+[12] int64 = 9
+[13] string = "2026-01-01 00:00:01.000000000"
+[14] int64 = 9
+[15] int64 = 300000000000
+[16] string = "job"
+[17] string = "job"
+[18] string = "job"
 -- sql --
-SELECT L.`MetricName`, mapConcat(L.`Attributes`, mapFilter((k, v) -> k IN (?, ?, ?), R.`Attributes`)) AS `Attributes`, L.`TimeUnix`, (L.`Value` * R.`Value`) AS `Value` FROM (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY `MetricName`, `Attributes`) AS L INNER JOIN (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`)) AS R ON L.`Attributes`[?] = R.`Attributes`[?]
+SELECT L.`MetricName`, mapConcat(L.`Attributes`, mapFilter((k, v) -> k IN (?, ?, ?), R.`Attributes`)) AS `Attributes`, L.`TimeUnix`, (L.`Value` * R.`Value`) AS `Value` FROM (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY `MetricName`, `Attributes`) AS L INNER JOIN (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`)) AS R ON L.`Attributes`[?] = R.`Attributes`[?]
 -- chplan --
 VectorJoin op=* match=on(job) card=many-to-one include=[env, region, svc]
-  Filter predicate=(MetricName = "up")
-    Scan(otel_metrics_gauge)
-  Filter predicate=(MetricName = "machine_role")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "machine_role") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/edge_join_on_three_keys.txtar
+++ b/test/spec/promql/edge_join_on_three_keys.txtar
@@ -3,25 +3,39 @@ up * on(job, env, svc) machine_role
 -- args --
 [0] string = "many-to-many matching not allowed: matching labels must be unique on one side"
 [1] string = "up"
-[2] string = "job"
-[3] string = "env"
-[4] string = "svc"
-[5] string = "many-to-many matching not allowed: matching labels must be unique on one side"
-[6] string = "machine_role"
+[2] string = "2026-01-01 00:00:01.000000000"
+[3] int64 = 9
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] int64 = 300000000000
 [7] string = "job"
 [8] string = "env"
 [9] string = "svc"
-[10] string = "job"
-[11] string = "job"
-[12] string = "env"
-[13] string = "env"
-[14] string = "svc"
-[15] string = "svc"
+[10] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[11] string = "machine_role"
+[12] string = "2026-01-01 00:00:01.000000000"
+[13] int64 = 9
+[14] string = "2026-01-01 00:00:01.000000000"
+[15] int64 = 9
+[16] int64 = 300000000000
+[17] string = "job"
+[18] string = "env"
+[19] string = "svc"
+[20] string = "job"
+[21] string = "job"
+[22] string = "env"
+[23] string = "env"
+[24] string = "svc"
+[25] string = "svc"
 -- sql --
-SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` * R.`Value`) AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY mapFilter((k, v) -> k IN (?, ?, ?), `Attributes`)) AS L INNER JOIN (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY mapFilter((k, v) -> k IN (?, ?, ?), `Attributes`)) AS R ON L.`Attributes`[?] = R.`Attributes`[?] AND L.`Attributes`[?] = R.`Attributes`[?] AND L.`Attributes`[?] = R.`Attributes`[?]
+SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` * R.`Value`) AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY mapFilter((k, v) -> k IN (?, ?, ?), `Attributes`)) AS L INNER JOIN (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY mapFilter((k, v) -> k IN (?, ?, ?), `Attributes`)) AS R ON L.`Attributes`[?] = R.`Attributes`[?] AND L.`Attributes`[?] = R.`Attributes`[?] AND L.`Attributes`[?] = R.`Attributes`[?]
 -- chplan --
 VectorJoin op=* match=on(job,env,svc) card=one-to-one
-  Filter predicate=(MetricName = "up")
-    Scan(otel_metrics_gauge)
-  Filter predicate=(MetricName = "machine_role")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "machine_role") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/edge_neg_scalar_minus_vector.txtar
+++ b/test/spec/promql/edge_neg_scalar_minus_vector.txtar
@@ -3,9 +3,16 @@
 -- args --
 [0] float64 = -5
 [1] string = "up"
+[2] string = "2026-01-01 00:00:01.000000000"
+[3] int64 = 9
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] int64 = 300000000000
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, (? - `Value`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, (? - `Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
 -- chplan --
 Project [MetricName, Attributes, TimeUnix, (-5 - Value) AS Value]
-  Filter predicate=(MetricName = "up")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/edge_paren_chain_arith.txtar
+++ b/test/spec/promql/edge_paren_chain_arith.txtar
@@ -5,11 +5,18 @@
 [1] float64 = 1
 [2] float64 = 2
 [3] string = "up"
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] string = "2026-01-01 00:00:01.000000000"
+[7] int64 = 9
+[8] int64 = 300000000000
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, (`Value` / ?) AS `Value` FROM (SELECT `MetricName`, `Attributes`, `TimeUnix`, (`Value` + ?) AS `Value` FROM (SELECT `MetricName`, `Attributes`, `TimeUnix`, (`Value` * ?) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, (`Value` / ?) AS `Value` FROM (SELECT `MetricName`, `Attributes`, `TimeUnix`, (`Value` + ?) AS `Value` FROM (SELECT `MetricName`, `Attributes`, `TimeUnix`, (`Value` * ?) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))))
 -- chplan --
 Project [MetricName, Attributes, TimeUnix, (Value / 3) AS Value]
   Project [MetricName, Attributes, TimeUnix, (Value + 1) AS Value]
     Project [MetricName, Attributes, TimeUnix, (Value * 2) AS Value]
-      Filter predicate=(MetricName = "up")
-        Scan(otel_metrics_gauge)
+      Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+        Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+          Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+            Scan(otel_metrics_gauge)

--- a/test/spec/promql/edge_round_step_half.txtar
+++ b/test/spec/promql/edge_round_step_half.txtar
@@ -4,9 +4,16 @@ round(temperature, 0.5)
 [0] float64 = 0.5
 [1] float64 = 0.5
 [2] string = "temperature"
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] string = "2026-01-01 00:00:01.000000000"
+[6] int64 = 9
+[7] int64 = 300000000000
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, (round((`Value` / ?)) * ?) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, (round((`Value` / ?)) * ?) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
 -- chplan --
 Project [MetricName, Attributes, TimeUnix, (round((Value / 0.5)) * 0.5) AS Value]
-  Filter predicate=(MetricName = "temperature")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "temperature") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/edge_sqrt_over_aggregate.txtar
+++ b/test/spec/promql/edge_sqrt_over_aggregate.txtar
@@ -5,11 +5,18 @@ sqrt(avg(latency_seconds))
 [1] string = "Map(String,String)"
 [2] int64 = 9
 [3] string = "latency_seconds"
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] string = "2026-01-01 00:00:01.000000000"
+[7] int64 = 9
+[8] int64 = 300000000000
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, sqrt(`Value`) AS `Value` FROM (SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT avg(`Value`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, sqrt(`Value`) AS `Value` FROM (SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT avg(`Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))))
 -- chplan --
 Project [MetricName, Attributes, TimeUnix, sqrt(Value) AS Value]
   Project ["" AS MetricName, CAST(map(), "Map(String,String)") AS Attributes, now64(9) AS TimeUnix, Value AS Value]
     Aggregate groupBy=[] funcs=[avg(Value) AS Value]
-      Filter predicate=(MetricName = "latency_seconds")
-        Scan(otel_metrics_gauge)
+      Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+        Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+          Filter predicate=(((MetricName = "latency_seconds") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+            Scan(otel_metrics_gauge)

--- a/test/spec/promql/empty_ignoring_join.txtar
+++ b/test/spec/promql/empty_ignoring_join.txtar
@@ -1,17 +1,27 @@
 -- query.promql --
 up + ignoring() up
 -- sql --
-SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` + R.`Value`) AS `Value` FROM (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY `MetricName`, `Attributes`) AS L INNER JOIN (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY `MetricName`, `Attributes`) AS R ON L.`Attributes` = R.`Attributes`
+SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` + R.`Value`) AS `Value` FROM (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY `MetricName`, `Attributes`) AS L INNER JOIN (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY `MetricName`, `Attributes`) AS R ON L.`Attributes` = R.`Attributes`
 -- args --
 [0] string = "up"
-[1] string = "up"
+[1] string = "2026-01-01 00:00:01.000000000"
+[2] int64 = 9
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] int64 = 300000000000
+[6] string = "up"
+[7] string = "2026-01-01 00:00:01.000000000"
+[8] int64 = 9
+[9] string = "2026-01-01 00:00:01.000000000"
+[10] int64 = 9
+[11] int64 = 300000000000
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_gauge VALUES
     ('up', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 7.0);
 -- expected_rows --
@@ -20,7 +30,11 @@ INSERT INTO otel_metrics_gauge VALUES
 ]
 -- chplan --
 VectorJoin op=+ match=default card=one-to-one
-  Filter predicate=(MetricName = "up")
-    Scan(otel_metrics_gauge)
-  Filter predicate=(MetricName = "up")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/empty_on_join.txtar
+++ b/test/spec/promql/empty_on_join.txtar
@@ -1,19 +1,29 @@
 -- query.promql --
 up + on() up
 -- sql --
-SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` + R.`Value`) AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY tuple()) AS L INNER JOIN (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY tuple()) AS R ON 1 = 1
+SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` + R.`Value`) AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY tuple()) AS L INNER JOIN (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY tuple()) AS R ON 1 = 1
 -- args --
 [0] string = "many-to-many matching not allowed: matching labels must be unique on one side"
 [1] string = "up"
-[2] string = "many-to-many matching not allowed: matching labels must be unique on one side"
-[3] string = "up"
+[2] string = "2026-01-01 00:00:01.000000000"
+[3] int64 = 9
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] int64 = 300000000000
+[7] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[8] string = "up"
+[9] string = "2026-01-01 00:00:01.000000000"
+[10] int64 = 9
+[11] string = "2026-01-01 00:00:01.000000000"
+[12] int64 = 9
+[13] int64 = 300000000000
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_gauge VALUES
     ('up', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 3.0);
 -- expected_rows --
@@ -22,7 +32,11 @@ INSERT INTO otel_metrics_gauge VALUES
 ]
 -- chplan --
 VectorJoin op=+ match=on() card=one-to-one
-  Filter predicate=(MetricName = "up")
-    Scan(otel_metrics_gauge)
-  Filter predicate=(MetricName = "up")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/exp_metric.txtar
+++ b/test/spec/promql/exp_metric.txtar
@@ -2,15 +2,20 @@
 exp(temperature)
 -- args --
 [0] string = "temperature"
+[1] string = "2026-01-01 00:00:01.000000000"
+[2] int64 = 9
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] int64 = 300000000000
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, exp(`Value`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, exp(`Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_gauge VALUES
     ('temperature', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 0.0);
 -- expected_rows --
@@ -19,5 +24,7 @@ INSERT INTO otel_metrics_gauge VALUES
 ]
 -- chplan --
 Project [MetricName, Attributes, TimeUnix, exp(Value) AS Value]
-  Filter predicate=(MetricName = "temperature")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "temperature") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/floor_metric.txtar
+++ b/test/spec/promql/floor_metric.txtar
@@ -2,15 +2,20 @@
 floor(temperature)
 -- args --
 [0] string = "temperature"
+[1] string = "2026-01-01 00:00:01.000000000"
+[2] int64 = 9
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] int64 = 300000000000
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, floor(`Value`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, floor(`Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_gauge VALUES
     ('temperature', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 7.8);
 -- expected_rows --
@@ -19,5 +24,7 @@ INSERT INTO otel_metrics_gauge VALUES
 ]
 -- chplan --
 Project [MetricName, Attributes, TimeUnix, floor(Value) AS Value]
-  Filter predicate=(MetricName = "temperature")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "temperature") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/group_by_job.txtar
+++ b/test/spec/promql/group_by_job.txtar
@@ -1,7 +1,7 @@
 -- query.promql --
 group by (job) (up)
 -- sql --
-SELECT ? AS `MetricName`, map(?, `gkey_0`) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes`[?] AS `gkey_0`, any(?) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY `Attributes`[?])
+SELECT ? AS `MetricName`, map(?, `gkey_0`) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes`[?] AS `gkey_0`, any(?) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY `Attributes`[?])
 -- args --
 [0] string = ""
 [1] string = "job"
@@ -9,14 +9,19 @@ SELECT ? AS `MetricName`, map(?, `gkey_0`) AS `Attributes`, now64(?) AS `TimeUni
 [3] string = "job"
 [4] int64 = 1
 [5] string = "up"
-[6] string = "job"
+[6] string = "2026-01-01 00:00:01.000000000"
+[7] int64 = 9
+[8] string = "2026-01-01 00:00:01.000000000"
+[9] int64 = 9
+[10] int64 = 300000000000
+[11] string = "job"
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_gauge VALUES
     ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 1.0);
 -- expected_rows --
@@ -24,5 +29,7 @@ INSERT INTO otel_metrics_gauge VALUES
 -- chplan --
 Project ["" AS MetricName, map("job", gkey_0) AS Attributes, now64(9) AS TimeUnix, Value AS Value]
   Aggregate groupBy=[Attributes["job"] AS gkey_0] funcs=[any(1) AS Value]
-    Filter predicate=(MetricName = "up")
-      Scan(otel_metrics_gauge)
+    Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+      Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+        Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+          Scan(otel_metrics_gauge)

--- a/test/spec/promql/histogram_quantile_classic_edge_p0.txtar
+++ b/test/spec/promql/histogram_quantile_classic_edge_p0.txtar
@@ -13,7 +13,7 @@ CREATE TABLE otel_metrics_histogram (
     TimeUnix DateTime64(9),
     BucketCounts Array(UInt64),
     ExplicitBounds Array(Float64)
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_histogram VALUES
     ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), [1, 2, 3], [0.1, 0.5, 1.0]);
 -- expected_rows --

--- a/test/spec/promql/histogram_quantile_classic_edge_p100.txtar
+++ b/test/spec/promql/histogram_quantile_classic_edge_p100.txtar
@@ -13,7 +13,7 @@ CREATE TABLE otel_metrics_histogram (
     TimeUnix DateTime64(9),
     BucketCounts Array(UInt64),
     ExplicitBounds Array(Float64)
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_histogram VALUES
     ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), [1, 2, 3], [0.1, 0.5, 1.0]);
 -- expected_rows --

--- a/test/spec/promql/histogram_quantile_classic_empty.txtar
+++ b/test/spec/promql/histogram_quantile_classic_empty.txtar
@@ -15,7 +15,7 @@ CREATE TABLE otel_metrics_histogram (
     TimeUnix DateTime64(9),
     BucketCounts Array(UInt64),
     ExplicitBounds Array(Float64)
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_histogram VALUES
     ('http_server_request_duration', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), [1, 2, 3], [0.1, 0.5, 1.0]);
 -- expected_rows --

--- a/test/spec/promql/histogram_quantile_classic_multi_series.txtar
+++ b/test/spec/promql/histogram_quantile_classic_multi_series.txtar
@@ -15,7 +15,7 @@ CREATE TABLE otel_metrics_histogram (
     TimeUnix DateTime64(9),
     BucketCounts Array(UInt64),
     ExplicitBounds Array(Float64)
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_histogram VALUES
     ('other_metric', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), [1, 2, 3], [0.1, 0.5, 1.0]);
 -- expected_rows --

--- a/test/spec/promql/histogram_quantile_classic_single_bucket.txtar
+++ b/test/spec/promql/histogram_quantile_classic_single_bucket.txtar
@@ -13,7 +13,7 @@ CREATE TABLE otel_metrics_histogram (
     TimeUnix DateTime64(9),
     BucketCounts Array(UInt64),
     ExplicitBounds Array(Float64)
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_histogram VALUES
     ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), [1, 2, 3], [0.1, 0.5, 1.0]);
 -- expected_rows --

--- a/test/spec/promql/histogram_quantile_native_empty.txtar
+++ b/test/spec/promql/histogram_quantile_native_empty.txtar
@@ -18,7 +18,7 @@ CREATE TABLE otel_metrics_exp_histogram (
     ZeroThreshold Float64,
     PositiveOffset Int32,
     PositiveBucketCounts Array(UInt64)
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_exp_histogram VALUES
     ('http_server_duration_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 0, 0, 0.0, 0, [1, 2, 3]);
 -- expected_rows --

--- a/test/spec/promql/histogram_quantile_native_multi_series.txtar
+++ b/test/spec/promql/histogram_quantile_native_multi_series.txtar
@@ -18,7 +18,7 @@ CREATE TABLE otel_metrics_exp_histogram (
     ZeroThreshold Float64,
     PositiveOffset Int32,
     PositiveBucketCounts Array(UInt64)
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_exp_histogram VALUES
     ('other_metric', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 0, 0, 0.0, 0, [1, 2, 3]);
 -- expected_rows --

--- a/test/spec/promql/histogram_quantile_native_p50.txtar
+++ b/test/spec/promql/histogram_quantile_native_p50.txtar
@@ -16,7 +16,7 @@ CREATE TABLE otel_metrics_exp_histogram (
     ZeroThreshold Float64,
     PositiveOffset Int32,
     PositiveBucketCounts Array(UInt64)
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_exp_histogram VALUES
     ('other_metric', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 0, 0, 0.0, 0, [1, 2, 3]);
 -- expected_rows --

--- a/test/spec/promql/histogram_quantile_native_p99.txtar
+++ b/test/spec/promql/histogram_quantile_native_p99.txtar
@@ -16,7 +16,7 @@ CREATE TABLE otel_metrics_exp_histogram (
     ZeroThreshold Float64,
     PositiveOffset Int32,
     PositiveBucketCounts Array(UInt64)
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_exp_histogram VALUES
     ('other_metric', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 0, 0, 0.0, 0, [1, 2, 3]);
 -- expected_rows --

--- a/test/spec/promql/histogram_quantile_native_single_metric.txtar
+++ b/test/spec/promql/histogram_quantile_native_single_metric.txtar
@@ -16,7 +16,7 @@ CREATE TABLE otel_metrics_exp_histogram (
     ZeroThreshold Float64,
     PositiveOffset Int32,
     PositiveBucketCounts Array(UInt64)
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_exp_histogram VALUES
     ('other_metric', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 0, 0, 0.0, 0, [1, 2, 3]);
 -- expected_rows --

--- a/test/spec/promql/holt_winters_simple.txtar
+++ b/test/spec/promql/holt_winters_simple.txtar
@@ -8,7 +8,7 @@ CREATE TABLE otel_metrics_sum (
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_sum VALUES
     ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 10.0);
 -- expected_rows --

--- a/test/spec/promql/ln_metric.txtar
+++ b/test/spec/promql/ln_metric.txtar
@@ -2,15 +2,20 @@
 ln(http_requests_total)
 -- args --
 [0] string = "http_requests_total"
+[1] string = "2026-01-01 00:00:01.000000000"
+[2] int64 = 9
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] int64 = 300000000000
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, log(`Value`) AS `Value` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` = ?))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, log(`Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_sum` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
 -- seed --
 CREATE TABLE otel_metrics_sum (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_sum VALUES
     ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 2.718281828459045);
 -- expected_rows --
@@ -19,5 +24,7 @@ INSERT INTO otel_metrics_sum VALUES
 ]
 -- chplan --
 Project [MetricName, Attributes, TimeUnix, log(Value) AS Value]
-  Filter predicate=(MetricName = "http_requests_total")
-    Scan(otel_metrics_sum)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "http_requests_total") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_sum)

--- a/test/spec/promql/log10_metric.txtar
+++ b/test/spec/promql/log10_metric.txtar
@@ -2,15 +2,20 @@
 log10(temperature)
 -- args --
 [0] string = "temperature"
+[1] string = "2026-01-01 00:00:01.000000000"
+[2] int64 = 9
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] int64 = 300000000000
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, log10(`Value`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, log10(`Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_gauge VALUES
     ('temperature', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 1000.0);
 -- expected_rows --
@@ -19,5 +24,7 @@ INSERT INTO otel_metrics_gauge VALUES
 ]
 -- chplan --
 Project [MetricName, Attributes, TimeUnix, log10(Value) AS Value]
-  Filter predicate=(MetricName = "temperature")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "temperature") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/log2_metric.txtar
+++ b/test/spec/promql/log2_metric.txtar
@@ -2,15 +2,20 @@
 log2(temperature)
 -- args --
 [0] string = "temperature"
+[1] string = "2026-01-01 00:00:01.000000000"
+[2] int64 = 9
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] int64 = 300000000000
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, log2(`Value`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, log2(`Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_gauge VALUES
     ('temperature', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 8.0);
 -- expected_rows --
@@ -19,5 +24,7 @@ INSERT INTO otel_metrics_gauge VALUES
 ]
 -- chplan --
 Project [MetricName, Attributes, TimeUnix, log2(Value) AS Value]
-  Filter predicate=(MetricName = "temperature")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "temperature") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/lwr_bare_selector_eval_ts_boundary.txtar
+++ b/test/spec/promql/lwr_bare_selector_eval_ts_boundary.txtar
@@ -1,5 +1,5 @@
 -- query.promql --
-up offset 0s
+up
 -- args --
 [0] string = "up"
 [1] string = "2026-01-01 00:00:01.000000000"
@@ -7,6 +7,20 @@ up offset 0s
 [3] string = "2026-01-01 00:00:01.000000000"
 [4] int64 = 9
 [5] int64 = 300000000000
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 5.0),
+    ('up', map('job', 'api'), toDateTime64('2026-01-01 00:00:30', 9), 99.0);
+-- expected_rows --
+[
+  ["up", {"job": "api"}, "2026-01-01T00:00:00Z", 5.0]
+]
 -- sql --
 SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)
 -- chplan --

--- a/test/spec/promql/lwr_bare_selector_latest_per_series.txtar
+++ b/test/spec/promql/lwr_bare_selector_latest_per_series.txtar
@@ -1,5 +1,5 @@
 -- query.promql --
-up offset 0s
+up
 -- args --
 [0] string = "up"
 [1] string = "2026-01-01 00:00:01.000000000"
@@ -7,6 +7,21 @@ up offset 0s
 [3] string = "2026-01-01 00:00:01.000000000"
 [4] int64 = 9
 [5] int64 = 300000000000
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api'), toDateTime64('2025-12-31 23:59:55', 9), 1.0),
+    ('up', map('job', 'api'), toDateTime64('2025-12-31 23:59:58', 9), 7.0),
+    ('up', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 9.0);
+-- expected_rows --
+[
+  ["up", {"job": "api"}, "2026-01-01T00:00:00Z", 9.0]
+]
 -- sql --
 SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)
 -- chplan --

--- a/test/spec/promql/lwr_bare_selector_staleness_window.txtar
+++ b/test/spec/promql/lwr_bare_selector_staleness_window.txtar
@@ -1,5 +1,5 @@
 -- query.promql --
-up offset 0s
+up
 -- args --
 [0] string = "up"
 [1] string = "2026-01-01 00:00:01.000000000"
@@ -7,6 +7,20 @@ up offset 0s
 [3] string = "2026-01-01 00:00:01.000000000"
 [4] int64 = 9
 [5] int64 = 300000000000
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'stale'),  toDateTime64('2025-12-31 23:54:00', 9), 50.0),
+    ('up', map('job', 'fresh'),  toDateTime64('2026-01-01 00:00:00', 9), 12.0);
+-- expected_rows --
+[
+  ["up", {"job": "fresh"}, "2026-01-01T00:00:00Z", 12.0]
+]
 -- sql --
 SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)
 -- chplan --

--- a/test/spec/promql/mod_arithmetic.txtar
+++ b/test/spec/promql/mod_arithmetic.txtar
@@ -1,17 +1,22 @@
 -- query.promql --
 up % 3
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, (`Value` % ?) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, (`Value` % ?) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
 -- args --
 [0] float64 = 3
 [1] string = "up"
+[2] string = "2026-01-01 00:00:01.000000000"
+[3] int64 = 9
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] int64 = 300000000000
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_gauge VALUES
     ('up', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 10.0);
 -- expected_rows --
@@ -20,5 +25,7 @@ INSERT INTO otel_metrics_gauge VALUES
 ]
 -- chplan --
 Project [MetricName, Attributes, TimeUnix, (Value % 3) AS Value]
-  Filter predicate=(MetricName = "up")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/multiple_matchers.txtar
+++ b/test/spec/promql/multiple_matchers.txtar
@@ -1,13 +1,20 @@
 -- query.promql --
 up{job="api",env="prod"}
 -- sql --
-SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) AND (`Attributes`[?] = ?) WHERE (`Attributes`[?] = ?)
+SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) AND (`Attributes`[?] = ?) AND (`Attributes`[?] = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)
 -- args --
 [0] string = "up"
 [1] string = "job"
 [2] string = "api"
 [3] string = "env"
 [4] string = "prod"
+[5] string = "2026-01-01 00:00:01.000000000"
+[6] int64 = 9
+[7] string = "2026-01-01 00:00:01.000000000"
+[8] int64 = 9
+[9] int64 = 300000000000
 -- chplan --
-Filter predicate=(((Attributes["job"] = "api") AND (Attributes["env"] = "prod")) AND (MetricName = "up"))
-  Scan(otel_metrics_gauge)
+Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+  Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+    Filter predicate=(((((Attributes["job"] = "api") AND (Attributes["env"] = "prod")) AND (MetricName = "up")) AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+      Scan(otel_metrics_gauge)

--- a/test/spec/promql/negative_at.txtar
+++ b/test/spec/promql/negative_at.txtar
@@ -1,11 +1,16 @@
 -- query.promql --
 up @ 100
 -- sql --
-SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?))
+SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)
 -- args --
 [0] string = "up"
 [1] string = "1970-01-01 00:01:40.000000000"
 [2] int64 = 9
+[3] string = "1970-01-01 00:01:40.000000000"
+[4] int64 = 9
+[5] int64 = 300000000000
 -- chplan --
-Filter predicate=((MetricName = "up") AND (TimeUnix <= toDateTime64("1970-01-01 00:01:40.000000000", 9)))
-  Scan(otel_metrics_gauge)
+Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+  Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+    Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("1970-01-01 00:01:40.000000000", 9))) AND (TimeUnix > (toDateTime64("1970-01-01 00:01:40.000000000", 9) - toIntervalNanosecond(300000000000))))
+      Scan(otel_metrics_gauge)

--- a/test/spec/promql/negative_offset.txtar
+++ b/test/spec/promql/negative_offset.txtar
@@ -1,10 +1,16 @@
 -- query.promql --
 up offset -7m
 -- sql --
-SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= now64(?))
+SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)
 -- args --
 [0] string = "up"
-[1] int64 = 9
+[1] string = "2026-01-01 00:00:01.000000000"
+[2] int64 = 9
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] int64 = -120000000000
 -- chplan --
-Filter predicate=((MetricName = "up") AND (TimeUnix <= now64(9)))
-  Scan(otel_metrics_gauge)
+Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+  Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+    Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(-120000000000))))
+      Scan(otel_metrics_gauge)

--- a/test/spec/promql/not_regex_label.txtar
+++ b/test/spec/promql/not_regex_label.txtar
@@ -1,11 +1,18 @@
 -- query.promql --
 up{job!~"backend.*"}
 -- sql --
-SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE NOT match(`Attributes`[?], ?)
+SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) AND NOT match(`Attributes`[?], ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)
 -- args --
 [0] string = "up"
 [1] string = "job"
 [2] string = "backend.*"
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] string = "2026-01-01 00:00:01.000000000"
+[6] int64 = 9
+[7] int64 = 300000000000
 -- chplan --
-Filter predicate=((Attributes["job"] !~ "backend.*") AND (MetricName = "up"))
-  Scan(otel_metrics_gauge)
+Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+  Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+    Filter predicate=((((Attributes["job"] !~ "backend.*") AND (MetricName = "up")) AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+      Scan(otel_metrics_gauge)

--- a/test/spec/promql/pow_arithmetic.txtar
+++ b/test/spec/promql/pow_arithmetic.txtar
@@ -1,17 +1,22 @@
 -- query.promql --
 up ^ 2
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, pow(`Value`, ?) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, pow(`Value`, ?) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
 -- args --
 [0] float64 = 2
 [1] string = "up"
+[2] string = "2026-01-01 00:00:01.000000000"
+[3] int64 = 9
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] int64 = 300000000000
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_gauge VALUES
     ('up', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 7.0);
 -- expected_rows --
@@ -20,5 +25,7 @@ INSERT INTO otel_metrics_gauge VALUES
 ]
 -- chplan --
 Project [MetricName, Attributes, TimeUnix, (Value ^ 2) AS Value]
-  Filter predicate=(MetricName = "up")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/predict_linear_simple.txtar
+++ b/test/spec/promql/predict_linear_simple.txtar
@@ -9,7 +9,7 @@ CREATE TABLE otel_metrics_sum (
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_sum VALUES
     ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 10.0);
 -- expected_rows --

--- a/test/spec/promql/quantile_by_job.txtar
+++ b/test/spec/promql/quantile_by_job.txtar
@@ -1,7 +1,7 @@
 -- query.promql --
 quantile(0.95, latency_seconds) by (job)
 -- sql --
-SELECT ? AS `MetricName`, map(?, `gkey_0`) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes`[?] AS `gkey_0`, quantile(?)(`Value`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY `Attributes`[?])
+SELECT ? AS `MetricName`, map(?, `gkey_0`) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes`[?] AS `gkey_0`, quantile(?)(`Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY `Attributes`[?])
 -- args --
 [0] string = ""
 [1] string = "job"
@@ -9,14 +9,19 @@ SELECT ? AS `MetricName`, map(?, `gkey_0`) AS `Attributes`, now64(?) AS `TimeUni
 [3] string = "job"
 [4] float64 = 0.95
 [5] string = "latency_seconds"
-[6] string = "job"
+[6] string = "2026-01-01 00:00:01.000000000"
+[7] int64 = 9
+[8] string = "2026-01-01 00:00:01.000000000"
+[9] int64 = 9
+[10] int64 = 300000000000
+[11] string = "job"
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_gauge VALUES
     ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 1.0);
 -- expected_rows --
@@ -24,5 +29,7 @@ INSERT INTO otel_metrics_gauge VALUES
 -- chplan --
 Project ["" AS MetricName, map("job", gkey_0) AS Attributes, now64(9) AS TimeUnix, Value AS Value]
   Aggregate groupBy=[Attributes["job"] AS gkey_0] funcs=[quantile(0.95)(Value) AS Value]
-    Filter predicate=(MetricName = "latency_seconds")
-      Scan(otel_metrics_gauge)
+    Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+      Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+        Filter predicate=(((MetricName = "latency_seconds") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+          Scan(otel_metrics_gauge)

--- a/test/spec/promql/rate_http_count.txtar
+++ b/test/spec/promql/rate_http_count.txtar
@@ -10,7 +10,7 @@ CREATE TABLE otel_metrics_sum (
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_sum VALUES
     ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 10.0);
 -- expected_rows --

--- a/test/spec/promql/rate_offset_5m.txtar
+++ b/test/spec/promql/rate_offset_5m.txtar
@@ -10,7 +10,7 @@ CREATE TABLE otel_metrics_sum (
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_sum VALUES
     ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 10.0);
 -- expected_rows --

--- a/test/spec/promql/regex_alternation.txtar
+++ b/test/spec/promql/regex_alternation.txtar
@@ -1,11 +1,18 @@
 -- query.promql --
 up{job=~"api|web"}
 -- sql --
-SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE match(`Attributes`[?], ?)
+SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) AND match(`Attributes`[?], ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)
 -- args --
 [0] string = "up"
 [1] string = "job"
 [2] string = "api|web"
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] string = "2026-01-01 00:00:01.000000000"
+[6] int64 = 9
+[7] int64 = 300000000000
 -- chplan --
-Filter predicate=((Attributes["job"] =~ "api|web") AND (MetricName = "up"))
-  Scan(otel_metrics_gauge)
+Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+  Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+    Filter predicate=((((Attributes["job"] =~ "api|web") AND (MetricName = "up")) AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+      Scan(otel_metrics_gauge)

--- a/test/spec/promql/regex_anchored.txtar
+++ b/test/spec/promql/regex_anchored.txtar
@@ -1,11 +1,18 @@
 -- query.promql --
 up{job=~"^api$"}
 -- sql --
-SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE match(`Attributes`[?], ?)
+SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) AND match(`Attributes`[?], ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)
 -- args --
 [0] string = "up"
 [1] string = "job"
 [2] string = "^api$"
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] string = "2026-01-01 00:00:01.000000000"
+[6] int64 = 9
+[7] int64 = 300000000000
 -- chplan --
-Filter predicate=((Attributes["job"] =~ "^api$") AND (MetricName = "up"))
-  Scan(otel_metrics_gauge)
+Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+  Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+    Filter predicate=((((Attributes["job"] =~ "^api$") AND (MetricName = "up")) AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+      Scan(otel_metrics_gauge)

--- a/test/spec/promql/round_metric.txtar
+++ b/test/spec/promql/round_metric.txtar
@@ -2,15 +2,20 @@
 round(temperature)
 -- args --
 [0] string = "temperature"
+[1] string = "2026-01-01 00:00:01.000000000"
+[2] int64 = 9
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] int64 = 300000000000
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, round(`Value`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, round(`Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_gauge VALUES
     ('temperature', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 4.6);
 -- expected_rows --
@@ -19,5 +24,7 @@ INSERT INTO otel_metrics_gauge VALUES
 ]
 -- chplan --
 Project [MetricName, Attributes, TimeUnix, round(Value) AS Value]
-  Filter predicate=(MetricName = "temperature")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "temperature") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/round_to_nearest.txtar
+++ b/test/spec/promql/round_to_nearest.txtar
@@ -1,18 +1,23 @@
 -- query.promql --
 round(temperature, 0.1)
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, (round((`Value` / ?)) * ?) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, (round((`Value` / ?)) * ?) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
 -- args --
 [0] float64 = 0.1
 [1] float64 = 0.1
 [2] string = "temperature"
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] string = "2026-01-01 00:00:01.000000000"
+[6] int64 = 9
+[7] int64 = 300000000000
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_gauge VALUES
     ('temperature', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 4.27);
 -- expected_rows --
@@ -21,5 +26,7 @@ INSERT INTO otel_metrics_gauge VALUES
 ]
 -- chplan --
 Project [MetricName, Attributes, TimeUnix, (round((Value / 0.1)) * 0.1) AS Value]
-  Filter predicate=(MetricName = "temperature")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "temperature") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/scalar_lt_vector.txtar
+++ b/test/spec/promql/scalar_lt_vector.txtar
@@ -1,11 +1,18 @@
 -- query.promql --
 100 < temperature
 -- sql --
-SELECT * FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) WHERE (? < `Value`)
+SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) WHERE (? < `Value`)
 -- args --
 [0] string = "temperature"
-[1] float64 = 100
+[1] string = "2026-01-01 00:00:01.000000000"
+[2] int64 = 9
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] int64 = 300000000000
+[6] float64 = 100
 -- chplan --
 Filter predicate=(100 < Value)
-  Filter predicate=(MetricName = "temperature")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "temperature") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/scalar_minus_vector.txtar
+++ b/test/spec/promql/scalar_minus_vector.txtar
@@ -3,15 +3,20 @@
 -- args --
 [0] float64 = 100
 [1] string = "up"
+[2] string = "2026-01-01 00:00:01.000000000"
+[3] int64 = 9
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] int64 = 300000000000
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, (? - `Value`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, (? - `Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_gauge VALUES
     ('up', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 30.0);
 -- expected_rows --
@@ -20,5 +25,7 @@ INSERT INTO otel_metrics_gauge VALUES
 ]
 -- chplan --
 Project [MetricName, Attributes, TimeUnix, (100 - Value) AS Value]
-  Filter predicate=(MetricName = "up")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/scientific_threshold.txtar
+++ b/test/spec/promql/scientific_threshold.txtar
@@ -1,11 +1,18 @@
 -- query.promql --
 up > 1e3
 -- sql --
-SELECT * FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) WHERE (`Value` > ?)
+SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) WHERE (`Value` > ?)
 -- args --
 [0] string = "up"
-[1] float64 = 1000
+[1] string = "2026-01-01 00:00:01.000000000"
+[2] int64 = 9
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] int64 = 300000000000
+[6] float64 = 1000
 -- chplan --
 Filter predicate=(Value > 1000)
-  Filter predicate=(MetricName = "up")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/sgn_metric.txtar
+++ b/test/spec/promql/sgn_metric.txtar
@@ -2,15 +2,20 @@
 sgn(temperature)
 -- args --
 [0] string = "temperature"
+[1] string = "2026-01-01 00:00:01.000000000"
+[2] int64 = 9
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] int64 = 300000000000
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, sign(`Value`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, sign(`Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_gauge VALUES
     ('temperature', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), -2.5);
 -- expected_rows --
@@ -19,5 +24,7 @@ INSERT INTO otel_metrics_gauge VALUES
 ]
 -- chplan --
 Project [MetricName, Attributes, TimeUnix, sign(Value) AS Value]
-  Filter predicate=(MetricName = "temperature")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "temperature") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/sqrt_metric.txtar
+++ b/test/spec/promql/sqrt_metric.txtar
@@ -2,15 +2,20 @@
 sqrt(latency_seconds)
 -- args --
 [0] string = "latency_seconds"
+[1] string = "2026-01-01 00:00:01.000000000"
+[2] int64 = 9
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] int64 = 300000000000
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, sqrt(`Value`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, sqrt(`Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_gauge VALUES
     ('latency_seconds', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 16.0);
 -- expected_rows --
@@ -19,5 +24,7 @@ INSERT INTO otel_metrics_gauge VALUES
 ]
 -- chplan --
 Project [MetricName, Attributes, TimeUnix, sqrt(Value) AS Value]
-  Filter predicate=(MetricName = "latency_seconds")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "latency_seconds") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/stddev_by_job.txtar
+++ b/test/spec/promql/stddev_by_job.txtar
@@ -1,21 +1,26 @@
 -- query.promql --
 stddev by (job) (latency_seconds)
 -- sql --
-SELECT ? AS `MetricName`, map(?, `gkey_0`) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes`[?] AS `gkey_0`, stddevPop(`Value`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY `Attributes`[?])
+SELECT ? AS `MetricName`, map(?, `gkey_0`) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes`[?] AS `gkey_0`, stddevPop(`Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY `Attributes`[?])
 -- args --
 [0] string = ""
 [1] string = "job"
 [2] int64 = 9
 [3] string = "job"
 [4] string = "latency_seconds"
-[5] string = "job"
+[5] string = "2026-01-01 00:00:01.000000000"
+[6] int64 = 9
+[7] string = "2026-01-01 00:00:01.000000000"
+[8] int64 = 9
+[9] int64 = 300000000000
+[10] string = "job"
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_gauge VALUES
     ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 1.0);
 -- expected_rows --
@@ -23,5 +28,7 @@ INSERT INTO otel_metrics_gauge VALUES
 -- chplan --
 Project ["" AS MetricName, map("job", gkey_0) AS Attributes, now64(9) AS TimeUnix, Value AS Value]
   Aggregate groupBy=[Attributes["job"] AS gkey_0] funcs=[stddevPop(Value) AS Value]
-    Filter predicate=(MetricName = "latency_seconds")
-      Scan(otel_metrics_gauge)
+    Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+      Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+        Filter predicate=(((MetricName = "latency_seconds") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+          Scan(otel_metrics_gauge)

--- a/test/spec/promql/stdvar_no_group.txtar
+++ b/test/spec/promql/stdvar_no_group.txtar
@@ -1,14 +1,21 @@
 -- query.promql --
 stdvar(latency_seconds)
 -- sql --
-SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT varPop(`Value`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)))
+SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT varPop(`Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)))
 -- args --
 [0] string = ""
 [1] string = "Map(String,String)"
 [2] int64 = 9
 [3] string = "latency_seconds"
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] string = "2026-01-01 00:00:01.000000000"
+[7] int64 = 9
+[8] int64 = 300000000000
 -- chplan --
 Project ["" AS MetricName, CAST(map(), "Map(String,String)") AS Attributes, now64(9) AS TimeUnix, Value AS Value]
   Aggregate groupBy=[] funcs=[varPop(Value) AS Value]
-    Filter predicate=(MetricName = "latency_seconds")
-      Scan(otel_metrics_gauge)
+    Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+      Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+        Filter predicate=(((MetricName = "latency_seconds") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+          Scan(otel_metrics_gauge)

--- a/test/spec/promql/subquery_avg_over_time_increase.txtar
+++ b/test/spec/promql/subquery_avg_over_time_increase.txtar
@@ -8,7 +8,7 @@ CREATE TABLE otel_metrics_sum (
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_sum VALUES
     ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 10.0);
 -- expected_rows --

--- a/test/spec/promql/subquery_bare_default_step.txtar
+++ b/test/spec/promql/subquery_bare_default_step.txtar
@@ -8,7 +8,7 @@ CREATE TABLE otel_metrics_gauge (
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_gauge VALUES
     ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 10.0);
 -- expected_rows --

--- a/test/spec/promql/subquery_bare_vector.txtar
+++ b/test/spec/promql/subquery_bare_vector.txtar
@@ -8,7 +8,7 @@ CREATE TABLE otel_metrics_gauge (
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_gauge VALUES
     ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 10.0);
 -- expected_rows --

--- a/test/spec/promql/subquery_bare_vector_with_label.txtar
+++ b/test/spec/promql/subquery_bare_vector_with_label.txtar
@@ -10,7 +10,7 @@ CREATE TABLE otel_metrics_gauge (
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_gauge VALUES
     ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 10.0);
 -- expected_rows --

--- a/test/spec/promql/subquery_max_over_time_rate.txtar
+++ b/test/spec/promql/subquery_max_over_time_rate.txtar
@@ -8,7 +8,7 @@ CREATE TABLE otel_metrics_sum (
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_sum VALUES
     ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 10.0);
 -- expected_rows --

--- a/test/spec/promql/subquery_offset.txtar
+++ b/test/spec/promql/subquery_offset.txtar
@@ -8,7 +8,7 @@ CREATE TABLE otel_metrics_gauge (
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_gauge VALUES
     ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 10.0);
 -- expected_rows --

--- a/test/spec/promql/subquery_over_increase.txtar
+++ b/test/spec/promql/subquery_over_increase.txtar
@@ -8,7 +8,7 @@ CREATE TABLE otel_metrics_sum (
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_sum VALUES
     ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 10.0);
 -- expected_rows --

--- a/test/spec/promql/subquery_over_rate.txtar
+++ b/test/spec/promql/subquery_over_rate.txtar
@@ -8,7 +8,7 @@ CREATE TABLE otel_metrics_sum (
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_sum VALUES
     ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 10.0);
 -- expected_rows --

--- a/test/spec/promql/subquery_over_sum_over_time.txtar
+++ b/test/spec/promql/subquery_over_sum_over_time.txtar
@@ -8,7 +8,7 @@ CREATE TABLE otel_metrics_gauge (
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_gauge VALUES
     ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 10.0);
 -- expected_rows --

--- a/test/spec/promql/subquery_sum_over_time_rate.txtar
+++ b/test/spec/promql/subquery_sum_over_time_rate.txtar
@@ -8,7 +8,7 @@ CREATE TABLE otel_metrics_sum (
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_sum VALUES
     ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 10.0);
 -- expected_rows --

--- a/test/spec/promql/sum_by_job.txtar
+++ b/test/spec/promql/sum_by_job.txtar
@@ -6,22 +6,29 @@ sum by (job) (up)
 [2] int64 = 9
 [3] string = "job"
 [4] string = "up"
-[5] string = "job"
+[5] string = "2026-01-01 00:00:01.000000000"
+[6] int64 = 9
+[7] string = "2026-01-01 00:00:01.000000000"
+[8] int64 = 9
+[9] int64 = 300000000000
+[10] string = "job"
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_gauge VALUES
     ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 1.0);
 -- expected_rows --
 []
 -- sql --
-SELECT ? AS `MetricName`, map(?, `gkey_0`) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes`[?] AS `gkey_0`, sum(`Value`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY `Attributes`[?])
+SELECT ? AS `MetricName`, map(?, `gkey_0`) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes`[?] AS `gkey_0`, sum(`Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY `Attributes`[?])
 -- chplan --
 Project ["" AS MetricName, map("job", gkey_0) AS Attributes, now64(9) AS TimeUnix, Value AS Value]
   Aggregate groupBy=[Attributes["job"] AS gkey_0] funcs=[sum(Value) AS Value]
-    Filter predicate=(MetricName = "up")
-      Scan(otel_metrics_gauge)
+    Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+      Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+        Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+          Scan(otel_metrics_gauge)

--- a/test/spec/promql/sum_without_instance.txtar
+++ b/test/spec/promql/sum_without_instance.txtar
@@ -5,22 +5,29 @@ sum without (instance) (up)
 [1] int64 = 9
 [2] string = "instance"
 [3] string = "up"
-[4] string = "instance"
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] string = "2026-01-01 00:00:01.000000000"
+[7] int64 = 9
+[8] int64 = 300000000000
+[9] string = "instance"
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_gauge VALUES
     ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 1.0);
 -- expected_rows --
 []
 -- sql --
-SELECT ? AS `MetricName`, `gkey_0` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT mapFilter((k, v) -> NOT (k IN (?)), `Attributes`) AS `gkey_0`, sum(`Value`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY mapFilter((k, v) -> NOT (k IN (?)), `Attributes`))
+SELECT ? AS `MetricName`, `gkey_0` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT mapFilter((k, v) -> NOT (k IN (?)), `Attributes`) AS `gkey_0`, sum(`Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY mapFilter((k, v) -> NOT (k IN (?)), `Attributes`))
 -- chplan --
 Project ["" AS MetricName, gkey_0 AS Attributes, now64(9) AS TimeUnix, Value AS Value]
   Aggregate groupBy=[mapWithout(Attributes, [instance]) AS gkey_0] funcs=[sum(Value) AS Value]
-    Filter predicate=(MetricName = "up")
-      Scan(otel_metrics_gauge)
+    Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+      Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+        Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+          Scan(otel_metrics_gauge)

--- a/test/spec/promql/sum_without_two_labels.txtar
+++ b/test/spec/promql/sum_without_two_labels.txtar
@@ -1,22 +1,27 @@
 -- query.promql --
 sum without (instance, pod) (up)
 -- sql --
-SELECT ? AS `MetricName`, `gkey_0` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT mapFilter((k, v) -> NOT (k IN (?, ?)), `Attributes`) AS `gkey_0`, sum(`Value`) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY mapFilter((k, v) -> NOT (k IN (?, ?)), `Attributes`))
+SELECT ? AS `MetricName`, `gkey_0` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT mapFilter((k, v) -> NOT (k IN (?, ?)), `Attributes`) AS `gkey_0`, sum(`Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY mapFilter((k, v) -> NOT (k IN (?, ?)), `Attributes`))
 -- args --
 [0] string = ""
 [1] int64 = 9
 [2] string = "instance"
 [3] string = "pod"
 [4] string = "up"
-[5] string = "instance"
-[6] string = "pod"
+[5] string = "2026-01-01 00:00:01.000000000"
+[6] int64 = 9
+[7] string = "2026-01-01 00:00:01.000000000"
+[8] int64 = 9
+[9] int64 = 300000000000
+[10] string = "instance"
+[11] string = "pod"
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_gauge VALUES
     ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 1.0);
 -- expected_rows --
@@ -24,5 +29,7 @@ INSERT INTO otel_metrics_gauge VALUES
 -- chplan --
 Project ["" AS MetricName, gkey_0 AS Attributes, now64(9) AS TimeUnix, Value AS Value]
   Aggregate groupBy=[mapWithout(Attributes, [instance, pod]) AS gkey_0] funcs=[sum(Value) AS Value]
-    Filter predicate=(MetricName = "up")
-      Scan(otel_metrics_gauge)
+    Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+      Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+        Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+          Scan(otel_metrics_gauge)

--- a/test/spec/promql/up.txtar
+++ b/test/spec/promql/up.txtar
@@ -2,8 +2,15 @@
 up
 -- args --
 [0] string = "up"
+[1] string = "2026-01-01 00:00:01.000000000"
+[2] int64 = 9
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] int64 = 300000000000
 -- sql --
-SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)
+SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)
 -- chplan --
-Filter predicate=(MetricName = "up")
-  Scan(otel_metrics_gauge)
+Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+  Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+    Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+      Scan(otel_metrics_gauge)

--- a/test/spec/promql/up_at_offset_combined.txtar
+++ b/test/spec/promql/up_at_offset_combined.txtar
@@ -1,12 +1,17 @@
 -- query.promql --
 up @ 1640995200 offset 5m
 -- sql --
-SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= (toDateTime64(?, ?) - toIntervalNanosecond(?)))
+SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= (toDateTime64(?, ?) - toIntervalNanosecond(?))) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)
 -- args --
 [0] string = "up"
 [1] string = "2022-01-01 00:00:00.000000000"
 [2] int64 = 9
 [3] int64 = 300000000000
+[4] string = "2022-01-01 00:00:00.000000000"
+[5] int64 = 9
+[6] int64 = 600000000000
 -- chplan --
-Filter predicate=((MetricName = "up") AND (TimeUnix <= (toDateTime64("2022-01-01 00:00:00.000000000", 9) - toIntervalNanosecond(300000000000))))
-  Scan(otel_metrics_gauge)
+Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+  Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+    Filter predicate=(((MetricName = "up") AND (TimeUnix <= (toDateTime64("2022-01-01 00:00:00.000000000", 9) - toIntervalNanosecond(300000000000)))) AND (TimeUnix > (toDateTime64("2022-01-01 00:00:00.000000000", 9) - toIntervalNanosecond(600000000000))))
+      Scan(otel_metrics_gauge)

--- a/test/spec/promql/up_at_timestamp.txtar
+++ b/test/spec/promql/up_at_timestamp.txtar
@@ -1,11 +1,16 @@
 -- query.promql --
 up @ 1640995200
 -- sql --
-SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?))
+SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)
 -- args --
 [0] string = "up"
 [1] string = "2022-01-01 00:00:00.000000000"
 [2] int64 = 9
+[3] string = "2022-01-01 00:00:00.000000000"
+[4] int64 = 9
+[5] int64 = 300000000000
 -- chplan --
-Filter predicate=((MetricName = "up") AND (TimeUnix <= toDateTime64("2022-01-01 00:00:00.000000000", 9)))
-  Scan(otel_metrics_gauge)
+Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+  Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+    Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2022-01-01 00:00:00.000000000", 9))) AND (TimeUnix > (toDateTime64("2022-01-01 00:00:00.000000000", 9) - toIntervalNanosecond(300000000000))))
+      Scan(otel_metrics_gauge)

--- a/test/spec/promql/up_gt_bool.txtar
+++ b/test/spec/promql/up_gt_bool.txtar
@@ -1,17 +1,22 @@
 -- query.promql --
 up > bool 0.5
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, toFloat64((`Value` > ?)) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, toFloat64((`Value` > ?)) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
 -- args --
 [0] float64 = 0.5
 [1] string = "up"
+[2] string = "2026-01-01 00:00:01.000000000"
+[3] int64 = 9
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] int64 = 300000000000
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_gauge VALUES
     ('up', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 1.0);
 -- expected_rows --
@@ -20,5 +25,7 @@ INSERT INTO otel_metrics_gauge VALUES
 ]
 -- chplan --
 Project [MetricName, Attributes, TimeUnix, toFloat64((Value > 0.5)) AS Value]
-  Filter predicate=(MetricName = "up")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/up_gt_threshold.txtar
+++ b/test/spec/promql/up_gt_threshold.txtar
@@ -1,11 +1,18 @@
 -- query.promql --
 up > 0.5
 -- sql --
-SELECT * FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) WHERE (`Value` > ?)
+SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) WHERE (`Value` > ?)
 -- args --
 [0] string = "up"
-[1] float64 = 0.5
+[1] string = "2026-01-01 00:00:01.000000000"
+[2] int64 = 9
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] int64 = 300000000000
+[6] float64 = 0.5
 -- chplan --
 Filter predicate=(Value > 0.5)
-  Filter predicate=(MetricName = "up")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/up_ne_zero.txtar
+++ b/test/spec/promql/up_ne_zero.txtar
@@ -1,11 +1,18 @@
 -- query.promql --
 up != 0
 -- sql --
-SELECT * FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) WHERE (`Value` != ?)
+SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) WHERE (`Value` != ?)
 -- args --
 [0] string = "up"
-[1] float64 = 0
+[1] string = "2026-01-01 00:00:01.000000000"
+[2] int64 = 9
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] int64 = 300000000000
+[6] float64 = 0
 -- chplan --
 Filter predicate=(Value != 0)
-  Filter predicate=(MetricName = "up")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/up_offset_5m.txtar
+++ b/test/spec/promql/up_offset_5m.txtar
@@ -1,11 +1,17 @@
 -- query.promql --
 up offset 5m
 -- sql --
-SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= (now64(?) - toIntervalNanosecond(?)))
+SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= (toDateTime64(?, ?) - toIntervalNanosecond(?))) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)
 -- args --
 [0] string = "up"
-[1] int64 = 9
-[2] int64 = 300000000000
+[1] string = "2026-01-01 00:00:01.000000000"
+[2] int64 = 9
+[3] int64 = 300000000000
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] int64 = 600000000000
 -- chplan --
-Filter predicate=((MetricName = "up") AND (TimeUnix <= (now64(9) - toIntervalNanosecond(300000000000))))
-  Scan(otel_metrics_gauge)
+Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+  Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+    Filter predicate=(((MetricName = "up") AND (TimeUnix <= (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000)))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(600000000000))))
+      Scan(otel_metrics_gauge)

--- a/test/spec/promql/up_times_two.txtar
+++ b/test/spec/promql/up_times_two.txtar
@@ -3,15 +3,20 @@ up * 2
 -- args --
 [0] float64 = 2
 [1] string = "up"
+[2] string = "2026-01-01 00:00:01.000000000"
+[3] int64 = 9
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] int64 = 300000000000
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, (`Value` * ?) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, (`Value` * ?) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_gauge VALUES
     ('up', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 3.0);
 -- expected_rows --
@@ -20,5 +25,7 @@ INSERT INTO otel_metrics_gauge VALUES
 ]
 -- chplan --
 Project [MetricName, Attributes, TimeUnix, (Value * 2) AS Value]
-  Filter predicate=(MetricName = "up")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/up_with_label.txtar
+++ b/test/spec/promql/up_with_label.txtar
@@ -4,8 +4,15 @@ up{job="api"}
 [0] string = "up"
 [1] string = "job"
 [2] string = "api"
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] string = "2026-01-01 00:00:01.000000000"
+[6] int64 = 9
+[7] int64 = 300000000000
 -- sql --
-SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`Attributes`[?] = ?)
+SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) AND (`Attributes`[?] = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)
 -- chplan --
-Filter predicate=((Attributes["job"] = "api") AND (MetricName = "up"))
-  Scan(otel_metrics_gauge)
+Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+  Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+    Filter predicate=((((Attributes["job"] = "api") AND (MetricName = "up")) AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+      Scan(otel_metrics_gauge)

--- a/test/spec/promql/up_with_regex.txtar
+++ b/test/spec/promql/up_with_regex.txtar
@@ -4,8 +4,15 @@ up{job=~"api-.*"}
 [0] string = "up"
 [1] string = "job"
 [2] string = "api-.*"
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] string = "2026-01-01 00:00:01.000000000"
+[6] int64 = 9
+[7] int64 = 300000000000
 -- sql --
-SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE match(`Attributes`[?], ?)
+SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) AND match(`Attributes`[?], ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)
 -- chplan --
-Filter predicate=((Attributes["job"] =~ "api-.*") AND (MetricName = "up"))
-  Scan(otel_metrics_gauge)
+Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+  Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+    Filter predicate=((((Attributes["job"] =~ "api-.*") AND (MetricName = "up")) AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+      Scan(otel_metrics_gauge)

--- a/test/spec/promql/vector_div_scalar.txtar
+++ b/test/spec/promql/vector_div_scalar.txtar
@@ -3,15 +3,20 @@ http_requests_total / 1000
 -- args --
 [0] float64 = 1000
 [1] string = "http_requests_total"
+[2] string = "2026-01-01 00:00:01.000000000"
+[3] int64 = 9
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] int64 = 300000000000
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, (`Value` / ?) AS `Value` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` = ?))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, (`Value` / ?) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_sum` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
 -- seed --
 CREATE TABLE otel_metrics_sum (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_sum VALUES
     ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 5000.0);
 -- expected_rows --
@@ -20,5 +25,7 @@ INSERT INTO otel_metrics_sum VALUES
 ]
 -- chplan --
 Project [MetricName, Attributes, TimeUnix, (Value / 1000) AS Value]
-  Filter predicate=(MetricName = "http_requests_total")
-    Scan(otel_metrics_sum)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "http_requests_total") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_sum)

--- a/test/spec/promql/vector_group_left.txtar
+++ b/test/spec/promql/vector_group_left.txtar
@@ -1,28 +1,38 @@
 -- query.promql --
 http_requests_total * on(job) group_left(env) machine_role
 -- sql --
-SELECT L.`MetricName`, mapConcat(L.`Attributes`, mapFilter((k, v) -> k IN (?), R.`Attributes`)) AS `Attributes`, L.`TimeUnix`, (L.`Value` * R.`Value`) AS `Value` FROM (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` = ?)) GROUP BY `MetricName`, `Attributes`) AS L INNER JOIN (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`)) AS R ON L.`Attributes`[?] = R.`Attributes`[?]
+SELECT L.`MetricName`, mapConcat(L.`Attributes`, mapFilter((k, v) -> k IN (?), R.`Attributes`)) AS `Attributes`, L.`TimeUnix`, (L.`Value` * R.`Value`) AS `Value` FROM (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_sum` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY `MetricName`, `Attributes`) AS L INNER JOIN (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`)) AS R ON L.`Attributes`[?] = R.`Attributes`[?]
 -- args --
 [0] string = "env"
 [1] string = "http_requests_total"
-[2] string = "many-to-many matching not allowed: matching labels must be unique on one side"
-[3] string = "machine_role"
-[4] string = "job"
-[5] string = "job"
-[6] string = "job"
+[2] string = "2026-01-01 00:00:01.000000000"
+[3] int64 = 9
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] int64 = 300000000000
+[7] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[8] string = "machine_role"
+[9] string = "2026-01-01 00:00:01.000000000"
+[10] int64 = 9
+[11] string = "2026-01-01 00:00:01.000000000"
+[12] int64 = 9
+[13] int64 = 300000000000
+[14] string = "job"
+[15] string = "job"
+[16] string = "job"
 -- seed --
 CREATE TABLE otel_metrics_sum (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 CREATE TABLE otel_metrics_gauge (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_sum VALUES
     ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 4.0);
 INSERT INTO otel_metrics_gauge VALUES
@@ -33,7 +43,11 @@ INSERT INTO otel_metrics_gauge VALUES
 ]
 -- chplan --
 VectorJoin op=* match=on(job) card=many-to-one include=[env]
-  Filter predicate=(MetricName = "http_requests_total")
-    Scan(otel_metrics_sum)
-  Filter predicate=(MetricName = "machine_role")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "http_requests_total") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_sum)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "machine_role") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/vector_group_left_ignoring.txtar
+++ b/test/spec/promql/vector_group_left_ignoring.txtar
@@ -1,28 +1,38 @@
 -- query.promql --
 http_requests_total * ignoring(instance) group_left(env) machine_role
 -- sql --
-SELECT L.`MetricName`, mapConcat(L.`Attributes`, mapFilter((k, v) -> k IN (?), R.`Attributes`)) AS `Attributes`, L.`TimeUnix`, (L.`Value` * R.`Value`) AS `Value` FROM (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` = ?)) GROUP BY `MetricName`, `Attributes`) AS L INNER JOIN (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY mapFilter((k, v) -> NOT (k IN (?)), `Attributes`)) AS R ON mapFilter((k, v) -> NOT (k IN (?)), L.`Attributes`) = mapFilter((k, v) -> NOT (k IN (?)), R.`Attributes`)
+SELECT L.`MetricName`, mapConcat(L.`Attributes`, mapFilter((k, v) -> k IN (?), R.`Attributes`)) AS `Attributes`, L.`TimeUnix`, (L.`Value` * R.`Value`) AS `Value` FROM (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_sum` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY `MetricName`, `Attributes`) AS L INNER JOIN (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY mapFilter((k, v) -> NOT (k IN (?)), `Attributes`)) AS R ON mapFilter((k, v) -> NOT (k IN (?)), L.`Attributes`) = mapFilter((k, v) -> NOT (k IN (?)), R.`Attributes`)
 -- args --
 [0] string = "env"
 [1] string = "http_requests_total"
-[2] string = "many-to-many matching not allowed: matching labels must be unique on one side"
-[3] string = "machine_role"
-[4] string = "instance"
-[5] string = "instance"
-[6] string = "instance"
+[2] string = "2026-01-01 00:00:01.000000000"
+[3] int64 = 9
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] int64 = 300000000000
+[7] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[8] string = "machine_role"
+[9] string = "2026-01-01 00:00:01.000000000"
+[10] int64 = 9
+[11] string = "2026-01-01 00:00:01.000000000"
+[12] int64 = 9
+[13] int64 = 300000000000
+[14] string = "instance"
+[15] string = "instance"
+[16] string = "instance"
 -- seed --
 CREATE TABLE otel_metrics_sum (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 CREATE TABLE otel_metrics_gauge (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_sum VALUES
     ('http_requests_total', map('job', 'api', 'env', 'prod', 'instance', 'i-1'), toDateTime64('2026-01-01 00:00:00', 9), 4.0);
 INSERT INTO otel_metrics_gauge VALUES
@@ -33,7 +43,11 @@ INSERT INTO otel_metrics_gauge VALUES
 ]
 -- chplan --
 VectorJoin op=* match=ignoring(instance) card=many-to-one include=[env]
-  Filter predicate=(MetricName = "http_requests_total")
-    Scan(otel_metrics_sum)
-  Filter predicate=(MetricName = "machine_role")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "http_requests_total") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_sum)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "machine_role") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/vector_group_left_multi_include.txtar
+++ b/test/spec/promql/vector_group_left_multi_include.txtar
@@ -1,29 +1,39 @@
 -- query.promql --
 http_requests_total * on(job) group_left(env, region) machine_role
 -- sql --
-SELECT L.`MetricName`, mapConcat(L.`Attributes`, mapFilter((k, v) -> k IN (?, ?), R.`Attributes`)) AS `Attributes`, L.`TimeUnix`, (L.`Value` * R.`Value`) AS `Value` FROM (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` = ?)) GROUP BY `MetricName`, `Attributes`) AS L INNER JOIN (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`)) AS R ON L.`Attributes`[?] = R.`Attributes`[?]
+SELECT L.`MetricName`, mapConcat(L.`Attributes`, mapFilter((k, v) -> k IN (?, ?), R.`Attributes`)) AS `Attributes`, L.`TimeUnix`, (L.`Value` * R.`Value`) AS `Value` FROM (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_sum` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY `MetricName`, `Attributes`) AS L INNER JOIN (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`)) AS R ON L.`Attributes`[?] = R.`Attributes`[?]
 -- args --
 [0] string = "env"
 [1] string = "region"
 [2] string = "http_requests_total"
-[3] string = "many-to-many matching not allowed: matching labels must be unique on one side"
-[4] string = "machine_role"
-[5] string = "job"
-[6] string = "job"
-[7] string = "job"
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] string = "2026-01-01 00:00:01.000000000"
+[6] int64 = 9
+[7] int64 = 300000000000
+[8] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[9] string = "machine_role"
+[10] string = "2026-01-01 00:00:01.000000000"
+[11] int64 = 9
+[12] string = "2026-01-01 00:00:01.000000000"
+[13] int64 = 9
+[14] int64 = 300000000000
+[15] string = "job"
+[16] string = "job"
+[17] string = "job"
 -- seed --
 CREATE TABLE otel_metrics_sum (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 CREATE TABLE otel_metrics_gauge (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_sum VALUES
     ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 3.0);
 INSERT INTO otel_metrics_gauge VALUES
@@ -34,7 +44,11 @@ INSERT INTO otel_metrics_gauge VALUES
 ]
 -- chplan --
 VectorJoin op=* match=on(job) card=many-to-one include=[env, region]
-  Filter predicate=(MetricName = "http_requests_total")
-    Scan(otel_metrics_sum)
-  Filter predicate=(MetricName = "machine_role")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "http_requests_total") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_sum)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "machine_role") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/vector_group_right.txtar
+++ b/test/spec/promql/vector_group_right.txtar
@@ -1,28 +1,38 @@
 -- query.promql --
 machine_role * on(job) group_right(env) http_requests_total
 -- sql --
-SELECT R.`MetricName`, mapConcat(R.`Attributes`, mapFilter((k, v) -> k IN (?), L.`Attributes`)) AS `Attributes`, R.`TimeUnix`, (L.`Value` * R.`Value`) AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`)) AS L INNER JOIN (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` = ?)) GROUP BY `MetricName`, `Attributes`) AS R ON L.`Attributes`[?] = R.`Attributes`[?]
+SELECT R.`MetricName`, mapConcat(R.`Attributes`, mapFilter((k, v) -> k IN (?), L.`Attributes`)) AS `Attributes`, R.`TimeUnix`, (L.`Value` * R.`Value`) AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`)) AS L INNER JOIN (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_sum` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY `MetricName`, `Attributes`) AS R ON L.`Attributes`[?] = R.`Attributes`[?]
 -- args --
 [0] string = "env"
 [1] string = "many-to-many matching not allowed: matching labels must be unique on one side"
 [2] string = "machine_role"
-[3] string = "job"
-[4] string = "http_requests_total"
-[5] string = "job"
-[6] string = "job"
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] string = "2026-01-01 00:00:01.000000000"
+[6] int64 = 9
+[7] int64 = 300000000000
+[8] string = "job"
+[9] string = "http_requests_total"
+[10] string = "2026-01-01 00:00:01.000000000"
+[11] int64 = 9
+[12] string = "2026-01-01 00:00:01.000000000"
+[13] int64 = 9
+[14] int64 = 300000000000
+[15] string = "job"
+[16] string = "job"
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 CREATE TABLE otel_metrics_sum (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_gauge VALUES
     ('machine_role', map('job', 'api', 'env', 'prod'), toDateTime64('2026-01-01 00:00:00', 9), 3.0);
 INSERT INTO otel_metrics_sum VALUES
@@ -33,7 +43,11 @@ INSERT INTO otel_metrics_sum VALUES
 ]
 -- chplan --
 VectorJoin op=* match=on(job) card=one-to-many include=[env]
-  Filter predicate=(MetricName = "machine_role")
-    Scan(otel_metrics_gauge)
-  Filter predicate=(MetricName = "http_requests_total")
-    Scan(otel_metrics_sum)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "machine_role") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "http_requests_total") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_sum)

--- a/test/spec/promql/vector_ignoring_instance.txtar
+++ b/test/spec/promql/vector_ignoring_instance.txtar
@@ -1,23 +1,33 @@
 -- query.promql --
 http_server_request_duration_count - ignoring(instance) http_server_request_duration_count
 -- sql --
-SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` - R.`Value`) AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` = ?)) GROUP BY mapFilter((k, v) -> NOT (k IN (?)), `Attributes`)) AS L INNER JOIN (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` = ?)) GROUP BY mapFilter((k, v) -> NOT (k IN (?)), `Attributes`)) AS R ON mapFilter((k, v) -> NOT (k IN (?)), L.`Attributes`) = mapFilter((k, v) -> NOT (k IN (?)), R.`Attributes`)
+SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` - R.`Value`) AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_sum` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY mapFilter((k, v) -> NOT (k IN (?)), `Attributes`)) AS L INNER JOIN (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_sum` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY mapFilter((k, v) -> NOT (k IN (?)), `Attributes`)) AS R ON mapFilter((k, v) -> NOT (k IN (?)), L.`Attributes`) = mapFilter((k, v) -> NOT (k IN (?)), R.`Attributes`)
 -- args --
 [0] string = "many-to-many matching not allowed: matching labels must be unique on one side"
 [1] string = "http_server_request_duration_count"
-[2] string = "instance"
-[3] string = "many-to-many matching not allowed: matching labels must be unique on one side"
-[4] string = "http_server_request_duration_count"
-[5] string = "instance"
-[6] string = "instance"
+[2] string = "2026-01-01 00:00:01.000000000"
+[3] int64 = 9
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] int64 = 300000000000
 [7] string = "instance"
+[8] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[9] string = "http_server_request_duration_count"
+[10] string = "2026-01-01 00:00:01.000000000"
+[11] int64 = 9
+[12] string = "2026-01-01 00:00:01.000000000"
+[13] int64 = 9
+[14] int64 = 300000000000
+[15] string = "instance"
+[16] string = "instance"
+[17] string = "instance"
 -- seed --
 CREATE TABLE otel_metrics_sum (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_sum VALUES
     ('http_server_request_duration_count', map('job', 'api', 'instance', 'i-1'), toDateTime64('2026-01-01 00:00:00', 9), 50.0);
 -- expected_rows --
@@ -26,7 +36,11 @@ INSERT INTO otel_metrics_sum VALUES
 ]
 -- chplan --
 VectorJoin op=- match=ignoring(instance) card=one-to-one
-  Filter predicate=(MetricName = "http_server_request_duration_count")
-    Scan(otel_metrics_sum)
-  Filter predicate=(MetricName = "http_server_request_duration_count")
-    Scan(otel_metrics_sum)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "http_server_request_duration_count") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_sum)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "http_server_request_duration_count") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_sum)

--- a/test/spec/promql/vector_mod_scalar.txtar
+++ b/test/spec/promql/vector_mod_scalar.txtar
@@ -3,15 +3,20 @@ up % 7
 -- args --
 [0] float64 = 7
 [1] string = "up"
+[2] string = "2026-01-01 00:00:01.000000000"
+[3] int64 = 9
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] int64 = 300000000000
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, (`Value` % ?) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, (`Value` % ?) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_gauge VALUES
     ('up', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 23.0);
 -- expected_rows --
@@ -20,5 +25,7 @@ INSERT INTO otel_metrics_gauge VALUES
 ]
 -- chplan --
 Project [MetricName, Attributes, TimeUnix, (Value % 7) AS Value]
-  Filter predicate=(MetricName = "up")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/vector_on_job.txtar
+++ b/test/spec/promql/vector_on_job.txtar
@@ -1,23 +1,33 @@
 -- query.promql --
 http_server_request_duration_count / on(job) http_server_request_duration_sum
 -- sql --
-SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` / R.`Value`) AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` = ?)) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`)) AS L INNER JOIN (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` = ?)) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`)) AS R ON L.`Attributes`[?] = R.`Attributes`[?]
+SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` / R.`Value`) AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_sum` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`)) AS L INNER JOIN (SELECT argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Attributes`, `TimeUnix`) AS `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_sum` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`)) AS R ON L.`Attributes`[?] = R.`Attributes`[?]
 -- args --
 [0] string = "many-to-many matching not allowed: matching labels must be unique on one side"
 [1] string = "http_server_request_duration_count"
-[2] string = "job"
-[3] string = "many-to-many matching not allowed: matching labels must be unique on one side"
-[4] string = "http_server_request_duration_sum"
-[5] string = "job"
-[6] string = "job"
+[2] string = "2026-01-01 00:00:01.000000000"
+[3] int64 = 9
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] int64 = 300000000000
 [7] string = "job"
+[8] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[9] string = "http_server_request_duration_sum"
+[10] string = "2026-01-01 00:00:01.000000000"
+[11] int64 = 9
+[12] string = "2026-01-01 00:00:01.000000000"
+[13] int64 = 9
+[14] int64 = 300000000000
+[15] string = "job"
+[16] string = "job"
+[17] string = "job"
 -- seed --
 CREATE TABLE otel_metrics_sum (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_sum VALUES
     ('http_server_request_duration_count', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 100.0),
     ('http_server_request_duration_sum',   map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 25.0);
@@ -27,7 +37,11 @@ INSERT INTO otel_metrics_sum VALUES
 ]
 -- chplan --
 VectorJoin op=/ match=on(job) card=one-to-one
-  Filter predicate=(MetricName = "http_server_request_duration_count")
-    Scan(otel_metrics_sum)
-  Filter predicate=(MetricName = "http_server_request_duration_sum")
-    Scan(otel_metrics_sum)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "http_server_request_duration_count") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_sum)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "http_server_request_duration_sum") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_sum)

--- a/test/spec/promql/vector_plus_vector.txtar
+++ b/test/spec/promql/vector_plus_vector.txtar
@@ -1,17 +1,27 @@
 -- query.promql --
 http_server_request_duration_count + http_server_request_duration_sum
 -- sql --
-SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` + R.`Value`) AS `Value` FROM (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` = ?)) GROUP BY `MetricName`, `Attributes`) AS L INNER JOIN (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` = ?)) GROUP BY `MetricName`, `Attributes`) AS R ON L.`Attributes` = R.`Attributes`
+SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` + R.`Value`) AS `Value` FROM (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_sum` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY `MetricName`, `Attributes`) AS L INNER JOIN (SELECT `MetricName`, `Attributes`, max(`TimeUnix`) AS `TimeUnix`, argMax(`Value`, `TimeUnix`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_sum` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY `MetricName`, `Attributes`) AS R ON L.`Attributes` = R.`Attributes`
 -- args --
 [0] string = "http_server_request_duration_count"
-[1] string = "http_server_request_duration_sum"
+[1] string = "2026-01-01 00:00:01.000000000"
+[2] int64 = 9
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] int64 = 300000000000
+[6] string = "http_server_request_duration_sum"
+[7] string = "2026-01-01 00:00:01.000000000"
+[8] int64 = 9
+[9] string = "2026-01-01 00:00:01.000000000"
+[10] int64 = 9
+[11] int64 = 300000000000
 -- seed --
 CREATE TABLE otel_metrics_sum (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_sum VALUES
     ('http_server_request_duration_count', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 10.0),
     ('http_server_request_duration_sum',   map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 25.0);
@@ -21,7 +31,11 @@ INSERT INTO otel_metrics_sum VALUES
 ]
 -- chplan --
 VectorJoin op=+ match=default card=one-to-one
-  Filter predicate=(MetricName = "http_server_request_duration_count")
-    Scan(otel_metrics_sum)
-  Filter predicate=(MetricName = "http_server_request_duration_sum")
-    Scan(otel_metrics_sum)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "http_server_request_duration_count") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_sum)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "http_server_request_duration_sum") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_sum)

--- a/test/spec/promql/vector_pow_scalar.txtar
+++ b/test/spec/promql/vector_pow_scalar.txtar
@@ -3,15 +3,20 @@ up ^ 2
 -- args --
 [0] float64 = 2
 [1] string = "up"
+[2] string = "2026-01-01 00:00:01.000000000"
+[3] int64 = 9
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] int64 = 300000000000
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, pow(`Value`, ?) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, pow(`Value`, ?) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_gauge VALUES
     ('up', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 5.0);
 -- expected_rows --
@@ -20,5 +25,7 @@ INSERT INTO otel_metrics_gauge VALUES
 ]
 -- chplan --
 Project [MetricName, Attributes, TimeUnix, (Value ^ 2) AS Value]
-  Filter predicate=(MetricName = "up")
-    Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)


### PR DESCRIPTION
## Summary

Two PromQL semantic bugs at the bare-selector path, surfaced by the oracle property test in PR #272:

- **Bug A — `sum(metric{...})` over-counts**: the bare selector returned every stored sample. `sum(metric)` over a two-sample series returned `s1 + s2` instead of `latest`. Prometheus aggregates the per-series **Latest-With-Respect-to-T (LWR)** sample, then sums.
- **Bug B — eval_ts boundary ignored**: a future-dated sample (timestamp > eval_ts) showed up in an instant query. Prometheus enforces `Timestamp <= T` AND `T - Timestamp < 5m` (the default staleness window).

Both have a single fix: wrap the bare-selector Scan with the LWR + staleness predicates and an `argMax(Value, TimeUnix)` aggregation grouped by `(MetricName, Attributes)`.

## Implementation

`lowerVectorSelector` (when not under a range-vector / subquery descent) now emits:

```sql
SELECT MetricName, Attributes, lwr_ts AS TimeUnix, lwr_value AS Value
FROM (
  SELECT MetricName, Attributes,
         max(TimeUnix)           AS lwr_ts,
         argMax(Value, TimeUnix) AS lwr_value
  FROM <table>
  PREWHERE MetricName = ?
  WHERE TimeUnix <= <eval_ts>
    AND TimeUnix >  <eval_ts> - INTERVAL '5m'
  GROUP BY MetricName, Attributes
)
```

- **Eval anchor**: threaded from `ctx.end` (the handler passes `start == end == ts` for instant queries). `@<ts>` / `@ start()` / `@ end()` modifiers override the anchor. `offset N` shifts both bounds by N.
- **Aliasing**: the inner Aggregate projects through `lwr_ts` / `lwr_value` because CH otherwise rejects `argMax(Value, TimeUnix)` next to `max(TimeUnix) AS TimeUnix` with `ILLEGAL_AGGREGATION` (alias shadows the column inside the same projection list).
- **Range-vector contexts** (`rate`, `*_over_time`, `predict_linear`, `holt_winters`, subqueries) set `lowerCtx.inRangeVector = true` before recursing — `RangeWindow` keeps seeing every in-window sample.
- **Schema preservation**: the output retains the canonical Sample-row shape, so `wrapWithSampleProjection` still treats the root as non-derived and the surrounding plan tree (Aggregate, Project, vector-joins, etc.) consumes the same column layout.

## Test plan

- [ ] `go test ./internal/promql/...` — 403 tests pass.
- [ ] `go test ./internal/api/... ./internal/chsql/... ./internal/optimizer/... ./internal/chplan/... ./internal/engine/...` — 1608 tests pass.
- [ ] `go test -tags chdb ./test/spec/promql/...` — 107 pass / 11 fail (all 11 failures are pre-existing on main: vector_join ILLEGAL_AGGREGATION + sgn type-cast mismatch).
- [ ] Three new TXTAR fixtures pin the fix end-to-end via chDB roundtrip:
  - `lwr_bare_selector_latest_per_series.txtar` — 3 samples per series; bare `up` returns the latest only.
  - `lwr_bare_selector_eval_ts_boundary.txtar` — sample after eval_ts is filtered out.
  - `lwr_bare_selector_staleness_window.txtar` — sample older than 5 minutes is filtered out (series disappears).

## Fixture impact

83 chDB-roundtrip fixtures already seeded at `2026-01-01 00:00:00`; the spec runner now lowers with `LowerAt(eval_ts, eval_ts)` where `eval_ts = 2026-01-01 00:00:01` — 1 second after the seeds, inside the 5-minute LWR window. `ENGINE = Memory` on the seeds is promoted to `MergeTree ORDER BY (MetricName, Attributes, TimeUnix)` because chDB's Memory engine rejects PREWHERE (now that the predicate has multiple conjuncts the partitioner moves MetricName= into PREWHERE and Memory dies).

## Notes

- `TestAllocs_Lower/instant` baseline rises 13 → 48 (the LWR wrap is 4 chplan nodes vs. the prior 1); the ceiling is bumped to 70 to restore the regression-detector slack.
- The property test from #272 (the from-scratch oracle) reproduces the divergence on a one-series, two-point dataset; with this fix landed the property runs cleanly at the default 100 iterations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)