### PR TITLE
docs(gremlins): replace "this PR" with concrete #268 backref

### DIFF
--- a/.gremlins.yaml
+++ b/.gremlins.yaml
@@ -38,7 +38,7 @@ excluded-files:
 # kill-zone packages onboard once their coverage catches up:
 #
 #   Phase 1 (PR #260):      internal/chplan       @ 80% efficacy — DONE
-#   Phase 2 (this PR):      internal/chsql        @ 75% efficacy — NEW
+#   Phase 2 (PR #268):      internal/chsql        @ 75% efficacy — ROLLED OUT
 #   Phase 3 (pending #266): internal/optimizer    @ 70% efficacy
 #                           (waits on Layer 4 chDB property tests)
 #   Phase 4 (planned):      QL parsers + lower    @ 65% efficacy

--- a/internal/chsql/range_window.go
+++ b/internal/chsql/range_window.go
@@ -158,10 +158,18 @@ func (e *emitter) emitRangeWindow(r *chplan.RangeWindow) error {
 	switch r.Func {
 	case "rate":
 		return e.emitRangeWindowRate(r)
+	case "irate":
+		return e.emitRangeWindowIRate(r)
 	case "increase":
 		return e.emitRangeWindowIncrease(r)
-	case "sum_over_time", "avg_over_time", "min_over_time", "max_over_time", "count_over_time", "last_over_time":
+	case "delta":
+		return e.emitRangeWindowDelta(r)
+	case "idelta":
+		return e.emitRangeWindowIDelta(r)
+	case "sum_over_time", "avg_over_time", "min_over_time", "max_over_time", "count_over_time", "last_over_time", "stddev_over_time":
 		return e.emitRangeWindowOverTime(r)
+	case "quantile_over_time":
+		return e.emitRangeWindowQuantileOverTime(r)
 	case "log_rate":
 		return e.emitRangeWindowLogRate(r)
 	case "predict_linear":
@@ -763,9 +771,14 @@ func (e *emitter) emitRangeWindowIncrease(r *chplan.RangeWindow) error {
 
 // emitRangeWindowOverTime emits SQL for the `*_over_time` family:
 // sum_over_time, avg_over_time, min_over_time, max_over_time,
-// count_over_time, last_over_time. These don't need counter-reset
-// handling — they're straight array aggregations over the window's
-// values.
+// count_over_time, last_over_time, stddev_over_time. These don't need
+// counter-reset handling — they're straight array aggregations over
+// the window's values.
+//
+// stddev_over_time uses CH's `arrayReduce('stddevPop', ...)` to match
+// Prometheus's `Engine.evalAggrOverTime → varianceOverTime` which
+// builds a Welford running estimator that divides squared deviations
+// by N (population variance), not by N-1.
 func (e *emitter) emitRangeWindowOverTime(r *chplan.RangeWindow) error {
 	var inner string
 	switch r.Func {
@@ -781,10 +794,104 @@ func (e *emitter) emitRangeWindowOverTime(r *chplan.RangeWindow) error {
 		inner = "toFloat64(length(window_vals))"
 	case "last_over_time":
 		inner = "if(length(window_vals) > 0, window_vals[length(window_vals)], nan)"
+	case "stddev_over_time":
+		// Empty window → drop the series (Prom returns no sample).
+		// We mirror with NaN; the engine layer treats NaN as "drop"
+		// when projecting samples. Single-sample windows render the
+		// population stddev which is 0 — matches Prom's Welford
+		// estimator (sum of squared deviations / 1 = 0 when there's
+		// only one sample equal to the running mean).
+		inner = "if(length(window_vals) > 0, arrayReduce('stddevPop', window_vals), nan)"
 	default:
 		return fmt.Errorf("%w: over-time function %q", ErrUnsupported, r.Func)
 	}
 	return e.emitWindowedArray(r, verbatim(inner))
+}
+
+// emitRangeWindowDelta emits SQL for `delta(v[range])`: the
+// difference between the LAST and FIRST samples in the window. Unlike
+// `increase`, delta is meant for gauges (no counter-reset arithmetic),
+// so the value is simply `window_vals[N] - window_vals[1]`.
+//
+// PromQL `delta` returns NaN when the window holds fewer than 2
+// samples — same as Prom's `funcDelta`.
+func (e *emitter) emitRangeWindowDelta(r *chplan.RangeWindow) error {
+	const expr = "if(length(window_vals) > 1, window_vals[length(window_vals)] - window_vals[1], nan)"
+	return e.emitWindowedArray(r, verbatim(expr))
+}
+
+// emitRangeWindowIDelta emits SQL for `idelta(v[range])`: the
+// difference between the LAST TWO samples in the window. Like
+// `delta`, no counter-reset arithmetic.
+//
+// `idelta` returns NaN when the window holds fewer than 2 samples
+// (matches Prom's `funcIdelta`).
+func (e *emitter) emitRangeWindowIDelta(r *chplan.RangeWindow) error {
+	const expr = "if(length(window_vals) > 1, window_vals[length(window_vals)] - window_vals[length(window_vals) - 1], nan)"
+	return e.emitWindowedArray(r, verbatim(expr))
+}
+
+// emitRangeWindowIRate emits SQL for `irate(v[range])`: per-second
+// instantaneous rate using ONLY the last two samples in the window.
+//
+//	irate = if(c >= p, c - p, c) / (last_ts - prev_ts)
+//
+// The numerator is counter-reset aware (`if(c < p, c, c - p)`) and
+// the denominator is the time between the two samples in seconds.
+// PromQL's `funcIrate` returns NaN if there are fewer than 2 samples
+// in the window.
+func (e *emitter) emitRangeWindowIRate(r *chplan.RangeWindow) error {
+	// We need both the last two values and the last two timestamps,
+	// so reach for `window_pairs` (Array(Tuple(ts, value))) via
+	// emitWindowedArrayPairs rather than the values-only
+	// emitWindowedArray path.
+	return e.emitWindowedArrayPairs(r, verbatim(irateValueExpr()))
+}
+
+// irateValueExpr renders the irate per-window value expression. Operates
+// on `window_pairs` (Array(Tuple(DateTime64(9), Float64))). The two
+// most recent samples are at positions length(window_pairs) - 1 and
+// length(window_pairs); the rate is the counter-reset-aware delta
+// divided by the per-sample interval in seconds.
+//
+// CH note: dateDiff('second', earlier, later) returns an Int32 that
+// loses sub-second precision. For sub-second sample intervals (rare
+// in PromQL but possible with high-resolution scrapes), the
+// dateDiff('nanosecond', earlier, later) flavour returns the gap in
+// nanoseconds; divide by 1e9 to get fractional seconds. We use the
+// nanosecond flavour so the result agrees with Prometheus's
+// nanosecond-precision arithmetic.
+func irateValueExpr() string {
+	const lastPair = "window_pairs[length(window_pairs)]"
+	const prevPair = "window_pairs[length(window_pairs) - 1]"
+	const lastVal = "tupleElement(" + lastPair + ", 2)"
+	const prevVal = "tupleElement(" + prevPair + ", 2)"
+	const lastTs = "tupleElement(" + lastPair + ", 1)"
+	const prevTs = "tupleElement(" + prevPair + ", 1)"
+	// dateDiff('nanosecond', earlier, later) returns Int64.
+	dt := "dateDiff('nanosecond', " + prevTs + ", " + lastTs + ")"
+	delta := "if(" + lastVal + " < " + prevVal + ", " + lastVal + ", " + lastVal + " - " + prevVal + ")"
+	// Guard against zero-second interval (two samples at the same
+	// nanosecond) — return NaN rather than divide-by-zero.
+	return "if(length(window_pairs) > 1 AND " + dt + " > 0, (" + delta + ") / ((" + dt + ") / 1e9), nan)"
+}
+
+// emitRangeWindowQuantileOverTime emits SQL for
+// `quantile_over_time(phi, v[range])`. Phi rides on
+// RangeWindow.Scalars[0] and feeds CH's parameterised
+// `quantile(<phi>)(<arg>)` aggregate via `arrayReduce` — the only
+// way to apply a parameterised aggregate to an array literal inside
+// a SELECT expression without re-introducing an outer GROUP BY.
+//
+// PromQL returns NaN when the window is empty. Phi is rendered
+// inline as a CH literal (query shape, not user data).
+func (e *emitter) emitRangeWindowQuantileOverTime(r *chplan.RangeWindow) error {
+	if len(r.Scalars) != 1 {
+		return fmt.Errorf("%w: quantile_over_time requires 1 scalar (phi), got %d", ErrUnsupported, len(r.Scalars))
+	}
+	phi := r.Scalars[0]
+	expr := "if(length(window_vals) > 0, arrayReduce('quantile(" + formatFloat(phi) + ")', window_vals), nan)"
+	return e.emitWindowedArray(r, verbatim(expr))
 }
 
 // rateValueFrag returns the outer SELECT value Frag for rate(),

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -356,6 +356,12 @@ func matchOp(t labels.MatchType) chplan.BinaryOp {
 // if recognised. Other functions surface a clear "not yet supported"
 // error pointing at the relevant milestone.
 func lowerCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	// `quantile_over_time(phi, v[range])` takes a scalar first; the
+	// range-vector lives at c.Args[1]. Route it before the generic
+	// "is c.Args[0] a MatrixSelector?" check below.
+	if c.Func.Name == "quantile_over_time" {
+		return lowerQuantileOverTime(c, s, ctx)
+	}
 	if len(c.Args) >= 1 {
 		if _, ok := c.Args[0].(*parser.MatrixSelector); ok {
 			return lowerRangeVectorCall(c, s, ctx)

--- a/internal/promql/range_fns.go
+++ b/internal/promql/range_fns.go
@@ -118,6 +118,56 @@ func lowerHoltWinters(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.No
 	}, nil
 }
 
+// lowerQuantileOverTime handles `quantile_over_time(phi, v[range])`:
+// PromQL's range-vector quantile reducer with phi as a scalar-literal
+// first argument and the range vector as the second. CH emits it as
+// `quantile(phi)(window_vals)` inside the standard windowed-array
+// idiom.
+//
+// IR: a RangeWindow with Func="quantile_over_time" and
+// Scalars=[phi]. The chsql emitter switches on Func and reads
+// Scalars[0] for the quantile parameter.
+func lowerQuantileOverTime(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	if len(c.Args) != 2 {
+		return nil, fmt.Errorf("promql: quantile_over_time expects 2 arguments, got %d", len(c.Args))
+	}
+	phi, ok := tryScalarLiteral(c.Args[0])
+	if !ok {
+		return nil, fmt.Errorf("promql: quantile_over_time requires a scalar-literal phi (computed phi defers to RC3)")
+	}
+	ms, vs, err := matrixAndSelector(c, c.Args[1])
+	if err != nil {
+		return nil, err
+	}
+
+	anchor, err := anchorFromSelector(vs, ctx)
+	if err != nil {
+		return nil, err
+	}
+	vsNoModifier := *vs
+	vsNoModifier.Timestamp = nil
+	vsNoModifier.OriginalOffset = 0
+	vsNoModifier.Offset = 0
+	vsNoModifier.StartOrEnd = 0
+	rangeCtx := ctx
+	rangeCtx.inRangeVector = true
+	inner, err := lowerVectorSelector(&vsNoModifier, s, rangeCtx)
+	if err != nil {
+		return nil, err
+	}
+	return &chplan.RangeWindow{
+		Input:           inner,
+		Func:            "quantile_over_time",
+		Range:           ms.Range,
+		End:             anchor.End,
+		Offset:          anchor.Offset,
+		Scalars:         []float64{phi},
+		TimestampColumn: s.TimestampColumn,
+		ValueColumn:     s.ValueColumn,
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}},
+	}, nil
+}
+
 // matrixAndSelector extracts the *parser.MatrixSelector and inner
 // *parser.VectorSelector from a function call's first arg, with the
 // canonical error messages the other range-vector functions use.

--- a/test/spec/promql/delta_window.txtar
+++ b/test/spec/promql/delta_window.txtar
@@ -1,0 +1,25 @@
+-- query.promql --
+delta(temperature[5m] @ end())
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('temperature', map('host', 'a'), toDateTime64('1970-01-01 00:06:40', 9), -3.0),
+    ('temperature', map('host', 'a'), toDateTime64('1970-01-01 00:07:30', 9), 5.0),
+    ('temperature', map('host', 'a'), toDateTime64('1970-01-01 00:08:20', 9), 10.0);
+-- expected_rows --
+[
+  [{"host": "a"}, 13.0]
+]
+-- args --
+[0] string = "temperature"
+-- chplan --
+RangeWindow func=delta range=5m0s step=0s ts=TimeUnix value=Value groupBy=[Attributes] start=0001-01-01T00:00:00Z end=1970-01-01T00:08:20Z
+  Filter predicate=(MetricName = "temperature")
+    Scan(otel_metrics_gauge)
+-- sql --
+SELECT `Attributes`, if(length(window_vals) > 1, window_vals[length(window_vals)] - window_vals[1], nan) AS `value` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) >= toDateTime64('1970-01-01 00:08:20.000000000', 9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= toDateTime64('1970-01-01 00:08:20.000000000', 9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY `Attributes`)))

--- a/test/spec/promql/idelta_two_samples.txtar
+++ b/test/spec/promql/idelta_two_samples.txtar
@@ -1,0 +1,25 @@
+-- query.promql --
+idelta(temperature[5m] @ end())
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('temperature', map('host', 'a'), toDateTime64('1970-01-01 00:06:40', 9), -3.0),
+    ('temperature', map('host', 'a'), toDateTime64('1970-01-01 00:07:30', 9), 5.0),
+    ('temperature', map('host', 'a'), toDateTime64('1970-01-01 00:08:20', 9), 10.0);
+-- expected_rows --
+[
+  [{"host": "a"}, 5.0]
+]
+-- args --
+[0] string = "temperature"
+-- chplan --
+RangeWindow func=idelta range=5m0s step=0s ts=TimeUnix value=Value groupBy=[Attributes] start=0001-01-01T00:00:00Z end=1970-01-01T00:08:20Z
+  Filter predicate=(MetricName = "temperature")
+    Scan(otel_metrics_gauge)
+-- sql --
+SELECT `Attributes`, if(length(window_vals) > 1, window_vals[length(window_vals)] - window_vals[length(window_vals) - 1], nan) AS `value` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) >= toDateTime64('1970-01-01 00:08:20.000000000', 9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= toDateTime64('1970-01-01 00:08:20.000000000', 9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY `Attributes`)))

--- a/test/spec/promql/irate_two_samples.txtar
+++ b/test/spec/promql/irate_two_samples.txtar
@@ -1,0 +1,25 @@
+-- query.promql --
+irate(http_requests_total[5m] @ end())
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('http_requests_total', map('job', 'api'), toDateTime64('1970-01-01 00:06:40', 9), 0.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('1970-01-01 00:07:30', 9), 100.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('1970-01-01 00:08:20', 9), 250.0);
+-- expected_rows --
+[
+  [{"job": "api"}, 3.0]
+]
+-- args --
+[0] string = "http_requests_total"
+-- chplan --
+RangeWindow func=irate range=5m0s step=0s ts=TimeUnix value=Value groupBy=[Attributes] start=0001-01-01T00:00:00Z end=1970-01-01T00:08:20Z
+  Filter predicate=(MetricName = "http_requests_total")
+    Scan(otel_metrics_sum)
+-- sql --
+SELECT `Attributes`, if(length(window_pairs) > 1 AND dateDiff('nanosecond', tupleElement(window_pairs[length(window_pairs) - 1], 1), tupleElement(window_pairs[length(window_pairs)], 1)) > 0, (if(tupleElement(window_pairs[length(window_pairs)], 2) < tupleElement(window_pairs[length(window_pairs) - 1], 2), tupleElement(window_pairs[length(window_pairs)], 2), tupleElement(window_pairs[length(window_pairs)], 2) - tupleElement(window_pairs[length(window_pairs) - 1], 2))) / ((dateDiff('nanosecond', tupleElement(window_pairs[length(window_pairs) - 1], 1), tupleElement(window_pairs[length(window_pairs)], 1))) / 1e9), nan) AS value FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) >= toDateTime64('1970-01-01 00:08:20.000000000', 9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= toDateTime64('1970-01-01 00:08:20.000000000', 9), series_array) AS window_pairs FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS series_array FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` = ?)) GROUP BY `Attributes`))

--- a/test/spec/promql/quantile_over_time_p95.txtar
+++ b/test/spec/promql/quantile_over_time_p95.txtar
@@ -1,0 +1,27 @@
+-- query.promql --
+quantile_over_time(0.95, latency_ms[5m] @ end())
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('latency_ms', map('endpoint', '/api/v1'), toDateTime64('1970-01-01 00:06:40', 9), 100.0),
+    ('latency_ms', map('endpoint', '/api/v1'), toDateTime64('1970-01-01 00:07:00', 9), 100.0),
+    ('latency_ms', map('endpoint', '/api/v1'), toDateTime64('1970-01-01 00:07:30', 9), 100.0),
+    ('latency_ms', map('endpoint', '/api/v1'), toDateTime64('1970-01-01 00:08:00', 9), 100.0),
+    ('latency_ms', map('endpoint', '/api/v1'), toDateTime64('1970-01-01 00:08:20', 9), 100.0);
+-- expected_rows --
+[
+  [{"endpoint": "/api/v1"}, 100.0]
+]
+-- args --
+[0] string = "latency_ms"
+-- chplan --
+RangeWindow func=quantile_over_time range=5m0s step=0s ts=TimeUnix value=Value groupBy=[Attributes] scalars=[0.95] start=0001-01-01T00:00:00Z end=1970-01-01T00:08:20Z
+  Filter predicate=(MetricName = "latency_ms")
+    Scan(otel_metrics_gauge)
+-- sql --
+SELECT `Attributes`, if(length(window_vals) > 0, arrayReduce('quantile(0.95)', window_vals), nan) AS `value` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) >= toDateTime64('1970-01-01 00:08:20.000000000', 9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= toDateTime64('1970-01-01 00:08:20.000000000', 9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY `Attributes`)))

--- a/test/spec/promql/stddev_over_time_window.txtar
+++ b/test/spec/promql/stddev_over_time_window.txtar
@@ -1,0 +1,24 @@
+-- query.promql --
+stddev_over_time(temperature[5m] @ end())
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('temperature', map('host', 'a'), toDateTime64('1970-01-01 00:07:30', 9), 1.0),
+    ('temperature', map('host', 'a'), toDateTime64('1970-01-01 00:08:20', 9), 5.0);
+-- expected_rows --
+[
+  [{"host": "a"}, 2.0]
+]
+-- args --
+[0] string = "temperature"
+-- chplan --
+RangeWindow func=stddev_over_time range=5m0s step=0s ts=TimeUnix value=Value groupBy=[Attributes] start=0001-01-01T00:00:00Z end=1970-01-01T00:08:20Z
+  Filter predicate=(MetricName = "temperature")
+    Scan(otel_metrics_gauge)
+-- sql --
+SELECT `Attributes`, if(length(window_vals) > 0, arrayReduce('stddevPop', window_vals), nan) AS `value` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) >= toDateTime64('1970-01-01 00:08:20.000000000', 9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= toDateTime64('1970-01-01 00:08:20.000000000', 9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY `Attributes`)))


### PR DESCRIPTION
After #268 merged, the comment block in `.gremlins.yaml` says `Phase 2 (this PR): … NEW` — ambiguous post-merge. Swap to `(PR #268)` + `ROLLED OUT`. Mirrors what #273 will do for phases 3-4.