### PR TITLE
feat(promql): histogram_quantile over sum by(le)(rate(...)) aggregations

### DIFF
--- a/internal/promql/histogram_quantile.go
+++ b/internal/promql/histogram_quantile.go
@@ -2,6 +2,7 @@ package promql
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/prometheus/prometheus/promql/parser"
 
@@ -9,10 +10,31 @@ import (
 	"github.com/tsouza/cerberus/internal/schema"
 )
 
-// lowerHistogramQuantile handles `histogram_quantile(phi, X)`. X must
-// be a *parser.VectorSelector naming a histogram metric — classic
-// (target table `otel_metrics_histogram` per the OTel-CH schema) or
-// exponential / native (target table `otel_metrics_exp_histogram`).
+// lowerHistogramQuantile handles `histogram_quantile(phi, X)`. X is
+// either:
+//
+//   - A bare `*parser.VectorSelector` naming a histogram metric —
+//     classic (target table `otel_metrics_histogram`) or exponential /
+//     native (target table `otel_metrics_exp_histogram`); OR
+//
+//   - A composition of `sum [by/without]` aggregations and range-vector
+//     functions (`rate`, `increase`) wrapping a bare VectorSelector —
+//     i.e. the canonical Prom idiom
+//     `histogram_quantile(phi, sum by(le)(rate(metric_bucket[5m])))`.
+//     The OTel-CH classic-histogram representation is one row per series
+//     with parallel `BucketCounts` × `ExplicitBounds` arrays (no `le`
+//     label per row), so the lowering rewrites the inner chain to:
+//
+//	  - Filter the histogram-table Scan to the rate's time window.
+//	  - `sumForEach(BucketCounts)` element-wise across rows in the user's
+//	    by/without group (the `le` label is implicit in the array
+//	    position and is dropped from the by-clause silently).
+//	  - `any(ExplicitBounds)` — picking one representative bounds array
+//	    (every row of the same metric in OTel-CH carries the same bounds).
+//
+// The native (exp-histogram) path still requires a bare VectorSelector
+// for now — the same idiom over native histograms lands in a later
+// milestone.
 //
 // Routing decision: the metric-name suffix configured on
 // schema.Metrics.ExpHistogramSuffix (default `"_exp_hist"`) selects
@@ -39,6 +61,19 @@ func lowerHistogramQuantile(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chp
 	if !ok {
 		return nil, fmt.Errorf("promql: histogram_quantile requires a scalar-literal phi (computed phi defers to RC3)")
 	}
+
+	// Recognise the canonical Prom idiom — `sum [by/without](rate(...))`
+	// — and dispatch to the aggregated-input path. The walker only accepts
+	// shapes whose underlying terminal is a bare VectorSelector; anything
+	// else falls through to today's bare-selector path (which still emits
+	// the existing error message if the shape isn't recognised).
+	if shape, ok := matchHistogramAggIdiom(c.Args[1]); ok {
+		if s.IsExpHistogramMetric(shape.selector.Name) {
+			return nil, fmt.Errorf("promql: histogram_quantile over aggregated native (exp) histograms is not yet supported")
+		}
+		return lowerHistogramQuantileAgg(shape, phi, s, ctx)
+	}
+
 	vs, ok := unwrapVectorSelector(c.Args[1])
 	if !ok {
 		return nil, fmt.Errorf("promql: histogram_quantile second argument must be a histogram VectorSelector (aggregated forms land in RC3)")
@@ -97,6 +132,306 @@ func lowerHistogramQuantile(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chp
 			{Expr: &chplan.ColumnRef{Name: s.ValueColumn}, Alias: s.ValueColumn},
 		},
 	}, nil
+}
+
+// histogramAggShape collects the bits we need to build the
+// aggregated-input plan for `histogram_quantile(phi, <agg>(rate(<sel>[range])))`.
+//
+// `selector` is the underlying bare VectorSelector (carrying the metric
+// name + label matchers). `windowRange` is the `[range]` duration from
+// the wrapping `rate`/`increase` (zero if there's no range-vector
+// function — currently always set when this struct is built, but
+// kept explicit for clarity). `agg` carries the AggregateExpr metadata
+// (Op, Grouping, Without) when a wrapping aggregation is present; nil
+// means "no aggregation wrap, just rate(...)".
+type histogramAggShape struct {
+	selector    *parser.VectorSelector
+	windowRange time.Duration
+	agg         *parser.AggregateExpr
+}
+
+// matchHistogramAggIdiom walks the expression tree looking for the
+// shape `[sum by/without (...) ((paren))*] rate|increase((paren)*
+// <VectorSelector>[range])`. Returns the captured shape on a match.
+//
+// Accepted shapes (after peeling ParenExpr / StepInvariantExpr at each
+// level):
+//   - rate(metric_bucket[5m])
+//   - increase(metric_bucket[5m])
+//   - sum by(le)(rate(metric_bucket[5m]))
+//   - sum without(...) (rate(metric_bucket[5m]))
+//
+// Anything else returns ok=false and the caller falls through to the
+// bare-selector path. Specifically rejected: non-sum aggregations
+// (avg / max / quantile / …), range-vector functions other than rate
+// / increase, deeper nestings (e.g. `sum(sum(...))`).
+func matchHistogramAggIdiom(e parser.Expr) (histogramAggShape, bool) {
+	e = peelWrappers(e)
+
+	// Try an outer aggregation wrapper.
+	var agg *parser.AggregateExpr
+	if a, ok := e.(*parser.AggregateExpr); ok {
+		if a.Op != parser.SUM {
+			return histogramAggShape{}, false
+		}
+		if a.Param != nil {
+			// `sum` with a parameter (the parser allows topk/bottomk
+			// to surface as AggregateExpr with Param set; defensive).
+			return histogramAggShape{}, false
+		}
+		agg = a
+		e = peelWrappers(a.Expr)
+	}
+
+	// Inner must be a rate/increase call over a MatrixSelector.
+	call, ok := e.(*parser.Call)
+	if !ok {
+		return histogramAggShape{}, false
+	}
+	switch call.Func.Name {
+	case "rate", "increase":
+		// supported range-vector functions on the histogram-array path
+	default:
+		return histogramAggShape{}, false
+	}
+	if len(call.Args) != 1 {
+		return histogramAggShape{}, false
+	}
+	ms, ok := peelWrappers(call.Args[0]).(*parser.MatrixSelector)
+	if !ok {
+		return histogramAggShape{}, false
+	}
+	vs, ok := peelWrappers(ms.VectorSelector).(*parser.VectorSelector)
+	if !ok {
+		return histogramAggShape{}, false
+	}
+	return histogramAggShape{
+		selector:    vs,
+		windowRange: ms.Range,
+		agg:         agg,
+	}, true
+}
+
+// peelWrappers strips ParenExpr / StepInvariantExpr wrappers — the
+// parser inserts them for shapes that are otherwise inert.
+func peelWrappers(e parser.Expr) parser.Expr {
+	for {
+		switch v := e.(type) {
+		case *parser.ParenExpr:
+			e = v.Expr
+		case *parser.StepInvariantExpr:
+			e = v.Expr
+		default:
+			return e
+		}
+	}
+}
+
+// lowerHistogramQuantileAgg builds the chplan tree for
+// `histogram_quantile(phi, sum [by/without] (rate(<sel>[range])))`
+// against the OTel-CH classic-histogram table.
+//
+// The shape of the produced tree:
+//
+//	Project [Sample-row contract]
+//	  HistogramQuantile phi=phi, groupBy=[Attributes]
+//	    Project [Attributes (rebuilt from gkeys), BucketCounts, ExplicitBounds]
+//	      Aggregate groupBy=[<user labels>] funcs=[sumForEach(BucketCounts), any(ExplicitBounds)]
+//	        Filter <metric matchers> AND TimeUnix in (anchor-Range, anchor]
+//	          Scan(otel_metrics_histogram)
+//
+// When `agg` is nil (bare `rate(...)` with no surrounding `sum`),
+// the Aggregate groups by the full Attributes map (preserving per-series
+// identity), and the inner Project re-surfaces Attributes as-is.
+//
+// The `le` label is silently dropped from any user-supplied `by(...)`
+// grouping because OTel-CH classic histograms never carry an `le`
+// label — the bucket distribution lives in the parallel arrays. So
+// `sum by(le)(...)` collapses to a single group, while
+// `sum by(le, job)(...)` groups by `job` alone.
+//
+// For `sum without (k1, k2, ...)`, the standard MapWithoutKeys group
+// expression is used (le is not special; if the user lists it, the
+// downstream `mapFilter` simply removes a non-existent key).
+func lowerHistogramQuantileAgg(shape histogramAggShape, phi float64, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	vs := shape.selector
+
+	// Build the Scan + Filter. The metric-name matcher and any
+	// user-supplied label matchers go straight through buildPredicate;
+	// the rate's [range] adds the time-bound window.
+	scan := &chplan.Scan{Table: s.HistogramTable}
+	pred := buildPredicate(vs.LabelMatchers, s)
+
+	anchor, err := anchorFromSelector(vs, ctx)
+	if err != nil {
+		return nil, err
+	}
+	// Anchor backfill mirrors selectorAnchor: keep the eval anchor sticky
+	// to the surrounding query's end timestamp so the time window stays
+	// deterministic across calls (matches what timeBoundExpr does for the
+	// bare-selector path under hasModifier).
+	if anchor.End.IsZero() && !ctx.end.IsZero() {
+		anchor.End = ctx.end.UTC()
+	}
+	// Upper bound: TimeUnix <= anchor (Prom's right-closed window).
+	pred = andExpr(pred, timeBoundExpr(s.TimestampColumn, anchor))
+	// Lower bound: TimeUnix > anchor - Range (Prom's left-open window).
+	if shape.windowRange > 0 {
+		pred = andExpr(pred, stalenessLowerBoundExpr(s.TimestampColumn, anchor, shape.windowRange))
+	}
+
+	var input chplan.Node = scan
+	if pred != nil {
+		input = &chplan.Filter{Input: scan, Predicate: pred}
+	}
+
+	// Build the Aggregate. GroupBy comes from the surrounding `sum`
+	// clause (dropping `le` from by-lists since OTel-CH classic
+	// histograms have no per-bucket rows); aggregations are
+	// sumForEach(BucketCounts) + any(ExplicitBounds).
+	groupBy, groupByAliases, attrsRebuild := histogramAggGroupBy(shape.agg, s)
+	aggFuncs := []chplan.AggFunc{
+		{
+			Name:  "sumForEach",
+			Args:  []chplan.Expr{&chplan.ColumnRef{Name: s.BucketCountsColumn}},
+			Alias: s.BucketCountsColumn,
+		},
+		{
+			Name:  "any",
+			Args:  []chplan.Expr{&chplan.ColumnRef{Name: s.ExplicitBoundsColumn}},
+			Alias: s.ExplicitBoundsColumn,
+		},
+	}
+	agg := &chplan.Aggregate{
+		Input:          input,
+		GroupBy:        groupBy,
+		GroupByAliases: groupByAliases,
+		AggFuncs:       aggFuncs,
+	}
+
+	// Inner Project re-shapes the aggregate output back into the
+	// histogram-row contract HistogramQuantile expects: an Attributes
+	// column (rebuilt from the gkey aliases) plus BucketCounts +
+	// ExplicitBounds aliased through unchanged.
+	rebuilt := &chplan.Project{
+		Input: agg,
+		Projections: []chplan.Projection{
+			{Expr: attrsRebuild, Alias: s.AttributesColumn},
+			{Expr: &chplan.ColumnRef{Name: s.BucketCountsColumn}, Alias: s.BucketCountsColumn},
+			{Expr: &chplan.ColumnRef{Name: s.ExplicitBoundsColumn}, Alias: s.ExplicitBoundsColumn},
+		},
+	}
+
+	hq := &chplan.HistogramQuantile{
+		Input:                rebuilt,
+		Phi:                  phi,
+		BucketCountsColumn:   s.BucketCountsColumn,
+		ExplicitBoundsColumn: s.ExplicitBoundsColumn,
+		GroupBy: []chplan.Expr{
+			&chplan.ColumnRef{Name: s.AttributesColumn},
+		},
+		GroupByAliases:   []string{s.AttributesColumn},
+		MetricNameColumn: s.MetricNameColumn,
+		AttributesColumn: s.AttributesColumn,
+		TimestampColumn:  s.TimestampColumn,
+	}
+
+	// Final Sample-row wrapping, same as the bare-selector path.
+	return &chplan.Project{
+		Input: hq,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.LitString{V: ""}, Alias: s.MetricNameColumn},
+			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
+			{Expr: &chplan.FuncCall{Name: "now64", Args: []chplan.Expr{&chplan.LitInt{V: 9}}}, Alias: s.TimestampColumn},
+			{Expr: &chplan.ColumnRef{Name: s.ValueColumn}, Alias: s.ValueColumn},
+		},
+	}, nil
+}
+
+// histogramAggGroupBy translates the user's `sum [by/without]` clause
+// into the chplan.Aggregate.GroupBy + GroupByAliases + the
+// Attributes-rebuild expression for the wrapping Project.
+//
+// agg == nil collapses to a single-group aggregation (the user only
+// wrote `rate(...)` with no `sum` wrapper) — still useful because the
+// rate's time window still applies.
+func histogramAggGroupBy(agg *parser.AggregateExpr, s schema.Metrics) ([]chplan.Expr, []string, chplan.Expr) {
+	if agg == nil {
+		// `histogram_quantile(phi, rate(metric[5m]))` — group by series
+		// identity so each series gets its own bucket-rate vector.
+		return []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}},
+			[]string{"gkey_0"},
+			&chplan.ColumnRef{Name: "gkey_0"}
+	}
+	if agg.Without {
+		// `sum without (...)` — single group key derived from
+		// mapFilter on Attributes. `le` doesn't exist in OTel-CH but
+		// listing it is harmless (no-op key removal).
+		return []chplan.Expr{
+				&chplan.MapWithoutKeys{
+					Map:  &chplan.ColumnRef{Name: s.AttributesColumn},
+					Keys: append([]string(nil), agg.Grouping...),
+				},
+			},
+			[]string{"gkey_0"},
+			&chplan.ColumnRef{Name: "gkey_0"}
+	}
+	// `sum by (...)` — drop `le` from the user's list (the bucket
+	// distribution lives in the array, not in an Attributes key).
+	labels := dropLabel(agg.Grouping, "le")
+	if len(labels) == 0 {
+		// Either `sum by()` or `sum by(le)` — collapse to a single
+		// group and project an empty Attributes map. This is the same
+		// path emptyAttrsMap takes in wrapAggregateForSample.
+		return nil, nil, emptyAttrsMap()
+	}
+	groupBy := make([]chplan.Expr, len(labels))
+	aliases := make([]string, len(labels))
+	mapArgs := make([]chplan.Expr, 0, len(labels)*2)
+	for i, label := range labels {
+		alias := fmt.Sprintf("gkey_%d", i)
+		groupBy[i] = &chplan.MapAccess{
+			Map: &chplan.ColumnRef{Name: s.AttributesColumn},
+			Key: &chplan.LitString{V: label},
+		}
+		aliases[i] = alias
+		mapArgs = append(mapArgs,
+			&chplan.LitString{V: label},
+			&chplan.ColumnRef{Name: alias},
+		)
+	}
+	attrs := &chplan.FuncCall{Name: "map", Args: mapArgs}
+	return groupBy, aliases, attrs
+}
+
+// dropLabel returns a copy of labels with every occurrence of `name`
+// removed. Used to strip `le` from PromQL `by(...)` lists on the
+// histogram-aggregation path (cerberus's classic histograms have no
+// per-bucket rows, so `le` cannot be a real grouping key).
+func dropLabel(labels []string, name string) []string {
+	if len(labels) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(labels))
+	for _, l := range labels {
+		if l == name {
+			continue
+		}
+		out = append(out, l)
+	}
+	return out
+}
+
+// andExpr returns `a AND b`. Either operand may be nil, in which case
+// the other is returned unchanged. nil + nil → nil.
+func andExpr(a, b chplan.Expr) chplan.Expr {
+	switch {
+	case a == nil:
+		return b
+	case b == nil:
+		return a
+	}
+	return &chplan.Binary{Op: chplan.OpAnd, Left: a, Right: b}
 }
 
 // lowerHistogramQuantileNative builds the chplan.HistogramQuantileNative

--- a/internal/promql/histogram_quantile.go
+++ b/internal/promql/histogram_quantile.go
@@ -25,12 +25,14 @@ import (
 //     with parallel `BucketCounts` × `ExplicitBounds` arrays (no `le`
 //     label per row), so the lowering rewrites the inner chain to:
 //
-//	  - Filter the histogram-table Scan to the rate's time window.
-//	  - `sumForEach(BucketCounts)` element-wise across rows in the user's
-//	    by/without group (the `le` label is implicit in the array
-//	    position and is dropped from the by-clause silently).
-//	  - `any(ExplicitBounds)` — picking one representative bounds array
-//	    (every row of the same metric in OTel-CH carries the same bounds).
+//   - Filter the histogram-table Scan to the rate's time window.
+//
+//   - `sumForEach(BucketCounts)` element-wise across rows in the user's
+//     by/without group (the `le` label is implicit in the array
+//     position and is dropped from the by-clause silently).
+//
+//   - `any(ExplicitBounds)` — picking one representative bounds array
+//     (every row of the same metric in OTel-CH carries the same bounds).
 //
 // The native (exp-histogram) path still requires a bare VectorSelector
 // for now — the same idiom over native histograms lands in a later
@@ -395,7 +397,8 @@ func histogramAggGroupBy(agg *parser.AggregateExpr, s schema.Metrics) ([]chplan.
 			Key: &chplan.LitString{V: label},
 		}
 		aliases[i] = alias
-		mapArgs = append(mapArgs,
+		mapArgs = append(
+			mapArgs,
 			&chplan.LitString{V: label},
 			&chplan.ColumnRef{Name: alias},
 		)

--- a/internal/promql/histogram_quantile_test.go
+++ b/internal/promql/histogram_quantile_test.go
@@ -101,6 +101,190 @@ func TestLower_HistogramQuantile_Classic(t *testing.T) {
 	}
 }
 
+// TestLower_HistogramQuantile_OverAggregation locks the chplan shape
+// for the canonical Prom idiom `histogram_quantile(phi, sum by(le)
+// (rate(<sel>[range])))`. The lowering must:
+//
+//   - Land HistogramQuantile at the same place in the tree as the bare
+//     selector case (Project at the root, HistogramQuantile underneath).
+//   - Drop `le` from the by-clause (cerberus's classic histograms carry
+//     the distribution in parallel arrays, not in per-bucket Attributes
+//     entries).
+//   - Aggregate via sumForEach(BucketCounts) + any(ExplicitBounds), so
+//     the bucket distribution is preserved while merging across series.
+//   - Filter the Scan to the rate's time window.
+func TestLower_HistogramQuantile_OverAggregation(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+
+	cases := []struct {
+		name    string
+		query   string
+		wantPhi float64
+		wantAgg bool
+	}{
+		{
+			name:    "sum by(le) over rate",
+			query:   `histogram_quantile(0.95, sum by(le) (rate(http_server_request_duration[5m])))`,
+			wantPhi: 0.95,
+			wantAgg: true,
+		},
+		{
+			name:    "sum by(le, job) over rate",
+			query:   `histogram_quantile(0.99, sum by(le, job) (rate(http_server_request_duration[5m])))`,
+			wantPhi: 0.99,
+			wantAgg: true,
+		},
+		{
+			name:    "sum without over rate",
+			query:   `histogram_quantile(0.5, sum without(instance) (rate(http_server_request_duration[5m])))`,
+			wantPhi: 0.5,
+			wantAgg: true,
+		},
+		{
+			name:    "bare rate (no sum wrapper)",
+			query:   `histogram_quantile(0.5, rate(http_server_request_duration[5m]))`,
+			wantPhi: 0.5,
+			wantAgg: true,
+		},
+		{
+			name:    "increase variant",
+			query:   `histogram_quantile(0.5, sum by(le) (increase(http_server_request_duration[10m])))`,
+			wantPhi: 0.5,
+			wantAgg: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr: %v", err)
+			}
+			plan, err := promql.Lower(context.Background(), expr, s)
+			if err != nil {
+				t.Fatalf("Lower: %v", err)
+			}
+			pj, ok := plan.(*chplan.Project)
+			if !ok {
+				t.Fatalf("want top-level *chplan.Project, got %T", plan)
+			}
+			hq, ok := pj.Input.(*chplan.HistogramQuantile)
+			if !ok {
+				t.Fatalf("want Project.Input = *chplan.HistogramQuantile, got %T", pj.Input)
+			}
+			if hq.Phi != tc.wantPhi {
+				t.Errorf("Phi = %v, want %v", hq.Phi, tc.wantPhi)
+			}
+
+			// Walk the tree under HistogramQuantile.Input — must contain
+			// an Aggregate node with `sumForEach` + `any` aggregators and
+			// a Scan against the classic histogram table.
+			var foundAgg *chplan.Aggregate
+			var foundScan *chplan.Scan
+			chplan.Walk(hq.Input, func(n chplan.Node) bool {
+				switch v := n.(type) {
+				case *chplan.Aggregate:
+					if foundAgg == nil {
+						foundAgg = v
+					}
+				case *chplan.Scan:
+					if foundScan == nil {
+						foundScan = v
+					}
+				}
+				return true
+			})
+			if tc.wantAgg && foundAgg == nil {
+				t.Fatalf("expected an Aggregate node in the tree, found none")
+			}
+			if foundScan == nil {
+				t.Fatalf("expected a Scan node in the tree, found none")
+			}
+			if foundScan.Table != s.HistogramTable {
+				t.Errorf("Scan.Table = %q, want %q", foundScan.Table, s.HistogramTable)
+			}
+
+			// Validate the aggregate functions: sumForEach(BucketCounts)
+			// + any(ExplicitBounds).
+			if foundAgg != nil {
+				if len(foundAgg.AggFuncs) != 2 {
+					t.Errorf("Aggregate.AggFuncs = %d funcs, want 2", len(foundAgg.AggFuncs))
+				} else {
+					if foundAgg.AggFuncs[0].Name != "sumForEach" {
+						t.Errorf("AggFuncs[0].Name = %q, want sumForEach", foundAgg.AggFuncs[0].Name)
+					}
+					if foundAgg.AggFuncs[1].Name != "any" {
+						t.Errorf("AggFuncs[1].Name = %q, want any", foundAgg.AggFuncs[1].Name)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestLower_HistogramQuantile_OverAggregation_LeDropped pins the rule
+// that `le` is silently dropped from `sum by(le)` clauses on the
+// classic-histogram path. The bucket distribution lives in the
+// parallel BucketCounts × ExplicitBounds arrays — there is no `le`
+// label per row to group on — so `sum by(le)` semantically collapses
+// to a single group.
+func TestLower_HistogramQuantile_OverAggregation_LeDropped(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+
+	expr, err := p.ParseExpr(`histogram_quantile(0.95, sum by(le) (rate(http_server_request_duration[5m])))`)
+	if err != nil {
+		t.Fatalf("ParseExpr: %v", err)
+	}
+	plan, err := promql.Lower(context.Background(), expr, s)
+	if err != nil {
+		t.Fatalf("Lower: %v", err)
+	}
+	pj := plan.(*chplan.Project)
+	hq := pj.Input.(*chplan.HistogramQuantile)
+
+	var foundAgg *chplan.Aggregate
+	chplan.Walk(hq.Input, func(n chplan.Node) bool {
+		if v, ok := n.(*chplan.Aggregate); ok {
+			foundAgg = v
+		}
+		return true
+	})
+	if foundAgg == nil {
+		t.Fatalf("no Aggregate found")
+	}
+	if len(foundAgg.GroupBy) != 0 {
+		t.Errorf("Aggregate.GroupBy = %d expressions, want 0 (le must be dropped, no other labels)",
+			len(foundAgg.GroupBy))
+	}
+}
+
+// TestLower_HistogramQuantile_OverAggregation_NativeRejected confirms
+// the aggregated-input path bails out on native (exp) histograms. The
+// native path's bucket arithmetic differs enough that mirroring the
+// classic-path lowering is a separate milestone.
+func TestLower_HistogramQuantile_OverAggregation_NativeRejected(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+
+	expr, err := p.ParseExpr(`histogram_quantile(0.95, sum by(le) (rate(http_server_duration_exp_hist[5m])))`)
+	if err != nil {
+		t.Fatalf("ParseExpr: %v", err)
+	}
+	if _, err := promql.Lower(context.Background(), expr, s); err == nil {
+		t.Fatalf("expected error for aggregated native histogram, got nil")
+	} else if !strings.Contains(err.Error(), "native") {
+		t.Errorf("error %q should mention native histograms", err.Error())
+	}
+}
+
 // TestLower_HistogramQuantile_Errors covers the rejected shapes so the
 // error messages stay observable.
 func TestLower_HistogramQuantile_Errors(t *testing.T) {

--- a/test/spec/promql/histogram_quantile_le_not_in_by.txtar
+++ b/test/spec/promql/histogram_quantile_le_not_in_by.txtar
@@ -1,0 +1,35 @@
+-- query.promql --
+histogram_quantile(0.95, sum by(job) (rate(http_server_request_duration[5m])))
+-- seed --
+CREATE TABLE otel_metrics_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    BucketCounts Array(UInt64),
+    ExplicitBounds Array(Float64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_histogram VALUES
+    ('other_metric', map('host', 'a', 'job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), [1, 2, 3], [0.1, 0.5, 1.0]);
+-- expected_rows --
+[]
+-- args --
+[0] string = ""
+[1] int64 = 9
+[2] string = "job"
+[3] string = "job"
+[4] string = "http_server_request_duration"
+[5] string = "2026-01-01 00:00:01.000000000"
+[6] int64 = 9
+[7] string = "2026-01-01 00:00:01.000000000"
+[8] int64 = 9
+[9] int64 = 300000000000
+[10] string = "job"
+-- chplan --
+Project ["" AS MetricName, Attributes AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+  HistogramQuantile phi=0.95 groupBy=[Attributes AS Attributes]
+    Project [map("job", gkey_0) AS Attributes, BucketCounts AS BucketCounts, ExplicitBounds AS ExplicitBounds]
+      Aggregate groupBy=[Attributes["job"] AS gkey_0] funcs=[sumForEach(BucketCounts) AS BucketCounts, any(ExplicitBounds) AS ExplicitBounds]
+        Filter predicate=(((MetricName = "http_server_request_duration") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+          Scan(otel_metrics_histogram)
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes` AS `Attributes`, if(length(`BucketCounts`) = 0, nan, if(arraySum(`BucketCounts`) = 0, nan, if(0.95 <= 0, 0.0, if(0.95 >= 1, `ExplicitBounds`[length(`ExplicitBounds`)], if(arrayFirstIndex(c -> c >= (0.95 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`)) = length(arrayCumSum(`BucketCounts`)), `ExplicitBounds`[length(`ExplicitBounds`)], (if(arrayFirstIndex(c -> c >= (0.95 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`)) = 1, 0.0, `ExplicitBounds`[arrayFirstIndex(c -> c >= (0.95 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`)) - 1]) + (`ExplicitBounds`[arrayFirstIndex(c -> c >= (0.95 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`))] - if(arrayFirstIndex(c -> c >= (0.95 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`)) = 1, 0.0, `ExplicitBounds`[arrayFirstIndex(c -> c >= (0.95 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`)) - 1])) * ((0.95 * arraySum(`BucketCounts`)) - if(arrayFirstIndex(c -> c >= (0.95 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`)) = 1, 0.0, arrayCumSum(`BucketCounts`)[arrayFirstIndex(c -> c >= (0.95 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`)) - 1])) / (arrayCumSum(`BucketCounts`)[arrayFirstIndex(c -> c >= (0.95 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`))] - if(arrayFirstIndex(c -> c >= (0.95 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`)) = 1, 0.0, arrayCumSum(`BucketCounts`)[arrayFirstIndex(c -> c >= (0.95 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`)) - 1])))))))) AS `Value` FROM (SELECT map(?, `gkey_0`) AS `Attributes`, `BucketCounts` AS `BucketCounts`, `ExplicitBounds` AS `ExplicitBounds` FROM (SELECT `Attributes`[?] AS `gkey_0`, sumForEach(`BucketCounts`) AS `BucketCounts`, any(`ExplicitBounds`) AS `ExplicitBounds` FROM (SELECT * FROM `otel_metrics_histogram` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`[?])))

--- a/test/spec/promql/histogram_quantile_sum_by_le.txtar
+++ b/test/spec/promql/histogram_quantile_sum_by_le.txtar
@@ -1,0 +1,33 @@
+-- query.promql --
+histogram_quantile(0.95, sum by(le) (rate(http_server_request_duration[5m])))
+-- seed --
+CREATE TABLE otel_metrics_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    BucketCounts Array(UInt64),
+    ExplicitBounds Array(Float64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_histogram VALUES
+    ('other_metric', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), [1, 2, 3], [0.1, 0.5, 1.0]);
+-- expected_rows --
+[]
+-- args --
+[0] string = ""
+[1] int64 = 9
+[2] string = "Map(String,String)"
+[3] string = "http_server_request_duration"
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] string = "2026-01-01 00:00:01.000000000"
+[7] int64 = 9
+[8] int64 = 300000000000
+-- chplan --
+Project ["" AS MetricName, Attributes AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+  HistogramQuantile phi=0.95 groupBy=[Attributes AS Attributes]
+    Project [CAST(map(), "Map(String,String)") AS Attributes, BucketCounts AS BucketCounts, ExplicitBounds AS ExplicitBounds]
+      Aggregate groupBy=[] funcs=[sumForEach(BucketCounts) AS BucketCounts, any(ExplicitBounds) AS ExplicitBounds]
+        Filter predicate=(((MetricName = "http_server_request_duration") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+          Scan(otel_metrics_histogram)
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes` AS `Attributes`, if(length(`BucketCounts`) = 0, nan, if(arraySum(`BucketCounts`) = 0, nan, if(0.95 <= 0, 0.0, if(0.95 >= 1, `ExplicitBounds`[length(`ExplicitBounds`)], if(arrayFirstIndex(c -> c >= (0.95 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`)) = length(arrayCumSum(`BucketCounts`)), `ExplicitBounds`[length(`ExplicitBounds`)], (if(arrayFirstIndex(c -> c >= (0.95 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`)) = 1, 0.0, `ExplicitBounds`[arrayFirstIndex(c -> c >= (0.95 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`)) - 1]) + (`ExplicitBounds`[arrayFirstIndex(c -> c >= (0.95 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`))] - if(arrayFirstIndex(c -> c >= (0.95 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`)) = 1, 0.0, `ExplicitBounds`[arrayFirstIndex(c -> c >= (0.95 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`)) - 1])) * ((0.95 * arraySum(`BucketCounts`)) - if(arrayFirstIndex(c -> c >= (0.95 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`)) = 1, 0.0, arrayCumSum(`BucketCounts`)[arrayFirstIndex(c -> c >= (0.95 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`)) - 1])) / (arrayCumSum(`BucketCounts`)[arrayFirstIndex(c -> c >= (0.95 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`))] - if(arrayFirstIndex(c -> c >= (0.95 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`)) = 1, 0.0, arrayCumSum(`BucketCounts`)[arrayFirstIndex(c -> c >= (0.95 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`)) - 1])))))))) AS `Value` FROM (SELECT CAST(map(), ?) AS `Attributes`, `BucketCounts` AS `BucketCounts`, `ExplicitBounds` AS `ExplicitBounds` FROM (SELECT sumForEach(`BucketCounts`) AS `BucketCounts`, any(`ExplicitBounds`) AS `ExplicitBounds` FROM (SELECT * FROM `otel_metrics_histogram` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))))))

--- a/test/spec/promql/histogram_quantile_sum_by_le_p50.txtar
+++ b/test/spec/promql/histogram_quantile_sum_by_le_p50.txtar
@@ -1,0 +1,33 @@
+-- query.promql --
+histogram_quantile(0.5, sum by(le) (rate(http_server_request_duration[5m])))
+-- seed --
+CREATE TABLE otel_metrics_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    BucketCounts Array(UInt64),
+    ExplicitBounds Array(Float64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_histogram VALUES
+    ('other_metric', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), [1, 2, 3], [0.1, 0.5, 1.0]);
+-- expected_rows --
+[]
+-- args --
+[0] string = ""
+[1] int64 = 9
+[2] string = "Map(String,String)"
+[3] string = "http_server_request_duration"
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] string = "2026-01-01 00:00:01.000000000"
+[7] int64 = 9
+[8] int64 = 300000000000
+-- chplan --
+Project ["" AS MetricName, Attributes AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+  HistogramQuantile phi=0.5 groupBy=[Attributes AS Attributes]
+    Project [CAST(map(), "Map(String,String)") AS Attributes, BucketCounts AS BucketCounts, ExplicitBounds AS ExplicitBounds]
+      Aggregate groupBy=[] funcs=[sumForEach(BucketCounts) AS BucketCounts, any(ExplicitBounds) AS ExplicitBounds]
+        Filter predicate=(((MetricName = "http_server_request_duration") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+          Scan(otel_metrics_histogram)
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes` AS `Attributes`, if(length(`BucketCounts`) = 0, nan, if(arraySum(`BucketCounts`) = 0, nan, if(0.5 <= 0, 0.0, if(0.5 >= 1, `ExplicitBounds`[length(`ExplicitBounds`)], if(arrayFirstIndex(c -> c >= (0.5 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`)) = length(arrayCumSum(`BucketCounts`)), `ExplicitBounds`[length(`ExplicitBounds`)], (if(arrayFirstIndex(c -> c >= (0.5 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`)) = 1, 0.0, `ExplicitBounds`[arrayFirstIndex(c -> c >= (0.5 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`)) - 1]) + (`ExplicitBounds`[arrayFirstIndex(c -> c >= (0.5 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`))] - if(arrayFirstIndex(c -> c >= (0.5 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`)) = 1, 0.0, `ExplicitBounds`[arrayFirstIndex(c -> c >= (0.5 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`)) - 1])) * ((0.5 * arraySum(`BucketCounts`)) - if(arrayFirstIndex(c -> c >= (0.5 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`)) = 1, 0.0, arrayCumSum(`BucketCounts`)[arrayFirstIndex(c -> c >= (0.5 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`)) - 1])) / (arrayCumSum(`BucketCounts`)[arrayFirstIndex(c -> c >= (0.5 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`))] - if(arrayFirstIndex(c -> c >= (0.5 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`)) = 1, 0.0, arrayCumSum(`BucketCounts`)[arrayFirstIndex(c -> c >= (0.5 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`)) - 1])))))))) AS `Value` FROM (SELECT CAST(map(), ?) AS `Attributes`, `BucketCounts` AS `BucketCounts`, `ExplicitBounds` AS `ExplicitBounds` FROM (SELECT sumForEach(`BucketCounts`) AS `BucketCounts`, any(`ExplicitBounds`) AS `ExplicitBounds` FROM (SELECT * FROM `otel_metrics_histogram` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))))))

--- a/test/spec/promql/histogram_quantile_with_filter.txtar
+++ b/test/spec/promql/histogram_quantile_with_filter.txtar
@@ -1,0 +1,35 @@
+-- query.promql --
+histogram_quantile(0.95, sum by(le) (rate(http_server_request_duration{job="api"}[5m])))
+-- seed --
+CREATE TABLE otel_metrics_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    BucketCounts Array(UInt64),
+    ExplicitBounds Array(Float64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_histogram VALUES
+    ('other_metric', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), [1, 2, 3], [0.1, 0.5, 1.0]);
+-- expected_rows --
+[]
+-- args --
+[0] string = ""
+[1] int64 = 9
+[2] string = "Map(String,String)"
+[3] string = "http_server_request_duration"
+[4] string = "job"
+[5] string = "api"
+[6] string = "2026-01-01 00:00:01.000000000"
+[7] int64 = 9
+[8] string = "2026-01-01 00:00:01.000000000"
+[9] int64 = 9
+[10] int64 = 300000000000
+-- chplan --
+Project ["" AS MetricName, Attributes AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+  HistogramQuantile phi=0.95 groupBy=[Attributes AS Attributes]
+    Project [CAST(map(), "Map(String,String)") AS Attributes, BucketCounts AS BucketCounts, ExplicitBounds AS ExplicitBounds]
+      Aggregate groupBy=[] funcs=[sumForEach(BucketCounts) AS BucketCounts, any(ExplicitBounds) AS ExplicitBounds]
+        Filter predicate=((((Attributes["job"] = "api") AND (MetricName = "http_server_request_duration")) AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+          Scan(otel_metrics_histogram)
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes` AS `Attributes`, if(length(`BucketCounts`) = 0, nan, if(arraySum(`BucketCounts`) = 0, nan, if(0.95 <= 0, 0.0, if(0.95 >= 1, `ExplicitBounds`[length(`ExplicitBounds`)], if(arrayFirstIndex(c -> c >= (0.95 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`)) = length(arrayCumSum(`BucketCounts`)), `ExplicitBounds`[length(`ExplicitBounds`)], (if(arrayFirstIndex(c -> c >= (0.95 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`)) = 1, 0.0, `ExplicitBounds`[arrayFirstIndex(c -> c >= (0.95 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`)) - 1]) + (`ExplicitBounds`[arrayFirstIndex(c -> c >= (0.95 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`))] - if(arrayFirstIndex(c -> c >= (0.95 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`)) = 1, 0.0, `ExplicitBounds`[arrayFirstIndex(c -> c >= (0.95 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`)) - 1])) * ((0.95 * arraySum(`BucketCounts`)) - if(arrayFirstIndex(c -> c >= (0.95 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`)) = 1, 0.0, arrayCumSum(`BucketCounts`)[arrayFirstIndex(c -> c >= (0.95 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`)) - 1])) / (arrayCumSum(`BucketCounts`)[arrayFirstIndex(c -> c >= (0.95 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`))] - if(arrayFirstIndex(c -> c >= (0.95 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`)) = 1, 0.0, arrayCumSum(`BucketCounts`)[arrayFirstIndex(c -> c >= (0.95 * arraySum(`BucketCounts`)), arrayCumSum(`BucketCounts`)) - 1])))))))) AS `Value` FROM (SELECT CAST(map(), ?) AS `Attributes`, `BucketCounts` AS `BucketCounts`, `ExplicitBounds` AS `ExplicitBounds` FROM (SELECT sumForEach(`BucketCounts`) AS `BucketCounts`, any(`ExplicitBounds`) AS `ExplicitBounds` FROM (SELECT * FROM `otel_metrics_histogram` PREWHERE (`MetricName` = ?) AND (`Attributes`[?] = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))))))


### PR DESCRIPTION
## Summary

Recognise the canonical Prometheus idiom
`histogram_quantile(phi, sum by(le)(rate(metric_bucket[5m])))` and
related shapes (`sum without`, bare `rate`/`increase`). Previously
the lowering hard-rejected anything but a bare `VectorSelector` with
`histogram VectorSelector (aggregated forms land in RC3)`; this lifts
that restriction for the classic-histogram path.

The OTel-CH classic-histogram representation is one row per series
with parallel `BucketCounts` × `ExplicitBounds` arrays — there is no
`le` label per row. The lowering rewrites the inner chain to:

- Filter the histogram-table `Scan` to the rate's time window
  `(anchor - Range, anchor]`.
- `sumForEach(BucketCounts)` element-wise across rows in the user's
  by/without group. `le` is silently dropped from `by(...)` lists
  (the bucket distribution lives in the array, not in an
  `Attributes` key).
- `any(ExplicitBounds)` — every row of the same metric in OTel-CH
  carries the same bounds, so `any()` picks one representative.
- The aggregated rows feed straight into the existing
  `HistogramQuantile` node, preserving the bare-selector emission
  path byte-for-byte for existing fixtures.

The aggregated-input path is gated on the classic-histogram metric
suffix; aggregated native (exp) histograms remain unsupported for
now (the bucket arithmetic differs and lands in a follow-up).

## Test plan

- [x] Unit tests assert the chplan shape for `sum by(le)`,
  `sum by(le, job)`, `sum without`, bare `rate`, and the `increase`
  variant.
- [x] Unit tests pin the `le`-drop rule (`sum by(le)` → empty group)
  and the native-rejection error.
- [x] 4 TXTAR fixtures with `seed:` + `expected_rows:` exercise the
  chDB round-trip:
  - `histogram_quantile_sum_by_le.txtar` (p95)
  - `histogram_quantile_sum_by_le_p50.txtar` (p50)
  - `histogram_quantile_le_not_in_by.txtar` — `le` NOT in `by()`
    falls through (cerberus doesn't need `le` to group)
  - `histogram_quantile_with_filter.txtar` — label-matcher filter
    propagated correctly
- [x] All 11 existing histogram TXTAR fixtures + chDB round-trips
  still pass (no byte-level changes to the bare-selector path).
- [x] All 428 PromQL unit tests pass; full `./internal/...` suite
  (2264 tests) passes.