### PR TITLE
test(traceql): multi-attribute by() chDB roundtrip fixtures

### DIFF
--- a/internal/traceql/metrics_pipeline_test.go
+++ b/internal/traceql/metrics_pipeline_test.go
@@ -64,6 +64,28 @@ func TestLowerMetricsPipeline(t *testing.T) {
 			wantOp: chplan.MetricsOpRate, wantAttr: false, wantGroup: 1, hasFilter: true,
 		},
 		{
+			// Multi-attribute `by (...)` — every element of the
+			// upstream MetricsAggregate.GroupBy() list must survive
+			// into chplan.MetricsAggregate.GroupBy (and the parallel
+			// GroupByAliases). Locks in the contract the chDB
+			// roundtrip fixtures `by_multi_attribute`,
+			// `by_three_attributes`, `by_mixed_scopes`, and
+			// `by_intrinsic_and_attr` rely on.
+			name:   "rate_by_two_labels",
+			query:  `{} | rate() by (resource.service.name, span.http.status_code)`,
+			wantOp: chplan.MetricsOpRate, wantAttr: false, wantGroup: 2, hasFilter: true,
+		},
+		{
+			name:   "rate_by_three_labels",
+			query:  `{} | rate() by (resource.service.name, span.kind, span.http.method)`,
+			wantOp: chplan.MetricsOpRate, wantAttr: false, wantGroup: 3, hasFilter: true,
+		},
+		{
+			name:   "count_over_time_by_intrinsic_and_attr",
+			query:  `{} | count_over_time() by (kind, resource.service.name)`,
+			wantOp: chplan.MetricsOpCountOverTime, wantAttr: false, wantGroup: 2, hasFilter: true,
+		},
+		{
 			name:   "quantile_over_time_single",
 			query:  `{} | quantile_over_time(duration, 0.95)`,
 			wantOp: chplan.MetricsOpQuantileOverTime, wantAttr: true, wantGroup: 0, hasFilter: true,

--- a/test/spec/traceql/by_intrinsic_and_attr.txtar
+++ b/test/spec/traceql/by_intrinsic_and_attr.txtar
@@ -1,0 +1,23 @@
+-- query.traceql --
+{} | count_over_time() by (kind, resource.service.name)
+-- sql --
+SELECT `SpanKind` AS `kind`, `ResourceAttributes`[?] AS `service.name`, count(?) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE ?) GROUP BY `SpanKind`, `ResourceAttributes`[?]
+-- args --
+[0] string = "service.name"
+[1] int64 = 1
+[2] bool = true
+[3] string = "service.name"
+-- seed --
+CREATE TABLE otel_traces (
+    ResourceAttributes Map(String, String),
+    SpanKind String
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    (map('service.name', 'frontend'), 'Client'),
+    (map('service.name', 'frontend'), 'Client'),
+    (map('service.name', 'frontend'), 'Client'),
+    (map('service.name', 'frontend'), 'Client');
+-- expected_rows --
+[
+  ["Client", "frontend", 4]
+]

--- a/test/spec/traceql/by_mixed_scopes.txtar
+++ b/test/spec/traceql/by_mixed_scopes.txtar
@@ -1,0 +1,24 @@
+-- query.traceql --
+{} | max_over_time(duration) by (resource.service.name, span.http.method)
+-- sql --
+SELECT `ResourceAttributes`[?] AS `service.name`, `SpanAttributes`[?] AS `http.method`, max(`Duration`) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE ?) GROUP BY `ResourceAttributes`[?], `SpanAttributes`[?]
+-- args --
+[0] string = "service.name"
+[1] string = "http.method"
+[2] bool = true
+[3] string = "service.name"
+[4] string = "http.method"
+-- seed --
+CREATE TABLE otel_traces (
+    ResourceAttributes Map(String, String),
+    SpanAttributes Map(String, String),
+    Duration UInt64
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    (map('service.name', 'frontend'), map('http.method', 'GET'),  50000000),
+    (map('service.name', 'frontend'), map('http.method', 'GET'), 100000000),
+    (map('service.name', 'frontend'), map('http.method', 'GET'),  75000000);
+-- expected_rows --
+[
+  ["frontend", "GET", 100000000]
+]

--- a/test/spec/traceql/by_multi_attribute.txtar
+++ b/test/spec/traceql/by_multi_attribute.txtar
@@ -1,0 +1,24 @@
+-- query.traceql --
+{} | count_over_time() by (resource.service.name, span.http.status_code)
+-- sql --
+SELECT `ResourceAttributes`[?] AS `service.name`, `SpanAttributes`[?] AS `http.status_code`, count(?) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE ?) GROUP BY `ResourceAttributes`[?], `SpanAttributes`[?]
+-- args --
+[0] string = "service.name"
+[1] string = "http.status_code"
+[2] int64 = 1
+[3] bool = true
+[4] string = "service.name"
+[5] string = "http.status_code"
+-- seed --
+CREATE TABLE otel_traces (
+    ResourceAttributes Map(String, String),
+    SpanAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    (map('service.name', 'frontend'), map('http.status_code', '200')),
+    (map('service.name', 'frontend'), map('http.status_code', '200')),
+    (map('service.name', 'frontend'), map('http.status_code', '200'));
+-- expected_rows --
+[
+  ["frontend", "200", 3]
+]

--- a/test/spec/traceql/by_three_attributes.txtar
+++ b/test/spec/traceql/by_three_attributes.txtar
@@ -1,0 +1,28 @@
+-- query.traceql --
+{} | rate() by (resource.service.name, span.kind, span.http.method)
+-- sql --
+SELECT `ResourceAttributes`[?] AS `service.name`, `SpanAttributes`[?] AS `kind`, `SpanAttributes`[?] AS `http.method`, count(?) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE ?) GROUP BY `ResourceAttributes`[?], `SpanAttributes`[?], `SpanAttributes`[?]
+-- args --
+[0] string = "service.name"
+[1] string = "kind"
+[2] string = "http.method"
+[3] int64 = 1
+[4] bool = true
+[5] string = "service.name"
+[6] string = "kind"
+[7] string = "http.method"
+-- seed --
+CREATE TABLE otel_traces (
+    ResourceAttributes Map(String, String),
+    SpanAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    (map('service.name', 'frontend'), map('kind', 'Client', 'http.method', 'GET')),
+    (map('service.name', 'frontend'), map('kind', 'Client', 'http.method', 'GET')),
+    (map('service.name', 'frontend'), map('kind', 'Client', 'http.method', 'GET')),
+    (map('service.name', 'frontend'), map('kind', 'Client', 'http.method', 'GET')),
+    (map('service.name', 'frontend'), map('kind', 'Client', 'http.method', 'GET'));
+-- expected_rows --
+[
+  ["frontend", "Client", "GET", 5]
+]


### PR DESCRIPTION
## Summary

- Adds four chDB roundtrip TXTAR fixtures exercising multi-attribute `by(...)` on the TraceQL metrics-aggregator pipeline form: 2-attr, 3-attr, span+resource scope mix, and intrinsic+attribute combination.
- Adds unit-test cases under `TestLowerMetricsPipeline` asserting `len(GroupBy)={2,3,2}` and the parallel `GroupBy` / `GroupByAliases` length invariant, locking the multi-attribute contract in so future refactors can't silently regress to a single-attribute path.
- No lowering change: `lowerMetricsGroupBy` already iterates over `MetricsAggregate.GroupBy()` and `chsql` emits N-element `GROUP BY` correctly; this PR is pure test coverage.

## TraceQL parser-shape note

Standalone `| by(...)` (TraceQL's `GroupOperation`) grammatically takes a **single** `FieldExpression` — not a list — so `{} | by(a, b)` is a parser error in upstream Tempo. Multi-attribute grouping in TraceQL only exists on the inline metrics-aggregator form `| <rate|count_over_time|max_over_time|...>() by (a, b, c)`, parsed as `MetricsAggregate.GroupBy() []Attribute`. All four fixtures use that form, matching upstream semantics.

## Test plan

- [x] `go test ./internal/traceql/...` (246 tests pass, 4 new chDB fixtures + 3 new unit cases)
- [x] `go test -tags chdb -run TestRoundTripChDB/by_ ./test/spec/traceql/...` — 4/4 fixtures pass chDB roundtrip
- [x] Existing TXTAR text-golden coverage via `TestLower` unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)