### PR TITLE
fix(test/property): restore TestPromQL_Property_FromScratch wiring

### DIFF
--- a/test/property/promql_test.go
+++ b/test/property/promql_test.go
@@ -11,10 +11,11 @@
 //     TABLE statement keeps replays idempotent).
 //  3. The PromQL generator (gen.PromQLQuery) draws a random query
 //     targeted at the dataset's metric / label / value pool.
-//  4. The bridge oracle (oracle.BridgePromQLOracle) evaluates the
-//     query against an in-memory SampleStore mirror of the dataset
-//     using Prometheus's promql.Engine. Temporary per Phase 1 PR 1;
-//     replaced by a from-scratch evaluator in PR 2.
+//  4. The from-scratch oracle (oracle/promql.Evaluate) evaluates the
+//     query against an in-memory mirror of the dataset, implementing
+//     PromQL semantics directly off the spec (no delegation to
+//     Prometheus's engine). The bridge oracle is still available as
+//     [oracle.BridgePromQLOracle] but is no longer the default.
 //  5. Cerberus evaluates the query via its real HTTP handler — a
 //     httptest.Server in front of the chDB-backed prom.Handler. The
 //     handler runs the full parse → lower → optimize → emit → execute
@@ -24,6 +25,47 @@
 //
 // rapid's shrinker minimises the failing dataset + query before this
 // test reports — the failure log shows the smallest reproducer.
+//
+// # CI lanes (when not t.Skip'd)
+//
+// The test runs in two CI lanes:
+//
+//   - Locally and on any explicit `go test -tags chdb ./test/property/...`
+//     invocation, rapid uses its default of 100 iterations.
+//   - The nightly `property` workflow (`.github/workflows/property.yml`)
+//     overrides to `-rapid.checks=500` for a deeper sweep.
+//
+// To reproduce a failing CI run locally, copy the rapid seed from the
+// workflow log and re-run:
+//
+//	go test -tags chdb -run TestPromQL_Property_FromScratch \
+//	    -rapid.seed=<N> ./test/property/...
+//
+// rapid persists the shrunk failing draw under `testdata/rapid/`; the
+// nightly workflow archives that directory as an artifact on failure.
+//
+// # Skip rationale (current state)
+//
+// PR #272 surfaced two cerberus-vs-Prom divergences via the from-scratch
+// oracle: `sum(metric{...})` aggregating every stored sample's value
+// instead of the LWR per series, and the instant selector not honouring
+// the eval-ts boundary. Both were fixed in PRs #275 and #277. A third
+// divergence — surfaced by the same generator once #272 widened the
+// accept-set to include `rate(...[60s])` and `sum(rate(...[60s]))` —
+// remains: cerberus emits a 0-rate row for series with zero samples in
+// the rate window. PromQL drops the series entirely (and so does the
+// from-scratch oracle). Because the generator's evalTs is fixed at
+// `AnchorTime() + 200s` while series samples span `AnchorTime() + [0,
+// 135s]`, every rate-shaped draw hits this divergence.
+//
+// Until rate-empty-window semantics are fixed in
+// `internal/chsql/range_window.go`'s `rateValueFrag` (or the generator
+// is adjusted to keep evalTs inside the sample span), this test stays
+// t.Skip'd. Run with `CERBERUS_PROPERTY_FORCE=1` to reproduce the
+// remaining divergence locally. Once the production-side fix lands,
+// remove the `t.Skip` — the nightly `property` workflow already runs
+// `./test/property/...` and will pick up the unskipped test
+// automatically.
 package property_test
 
 import (
@@ -33,6 +75,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strconv"
 	"testing"
 
@@ -43,23 +86,31 @@ import (
 	"github.com/tsouza/cerberus/internal/schema"
 	"github.com/tsouza/cerberus/test/property"
 	"github.com/tsouza/cerberus/test/property/gen"
-	"github.com/tsouza/cerberus/test/property/oracle"
+	oraclepromql "github.com/tsouza/cerberus/test/property/oracle/promql"
 )
 
-// TestPromQL_Property_Bridge wires every layer together for the
+// TestPromQL_Property_FromScratch wires every layer together for the
 // instant-query / gauge MVP. rapid's default iteration count is 100
-// (no per-test override here); the nightly `property` workflow
-// (`.github/workflows/property.yml`) overrides to `-rapid.checks=500`
-// for a deeper sweep. Locally, pass `-rapid.checks=N` to widen or
+// (no per-test override here); the nightly `property` workflow overrides
+// to `-rapid.checks=500`. Locally, pass `-rapid.checks=N` to widen or
 // narrow the sweep on demand.
+//
+// The oracle is the from-scratch [oraclepromql.Evaluate] — PromQL
+// semantics implemented in-tree, not the Prom engine.
 //
 // Failure logs include both the rapid seed (so the failing draw
 // reproduces with `-rapid.seed=<N>`) and the minimised dataset / query
-// rapid shrunk to. To reproduce a CI failure locally:
-//
-//	go test -tags chdb -run TestPromQL_Property_Bridge \
-//	    -rapid.seed=<N> ./test/property/...
-func TestPromQL_Property_Bridge(t *testing.T) {
+// rapid shrunk to. See the package-level doc above for the current
+// skip rationale and how to remove it.
+func TestPromQL_Property_FromScratch(t *testing.T) {
+	if os.Getenv("CERBERUS_PROPERTY_FORCE") == "" {
+		t.Skip("property: skipped pending production-side fix for rate(metric[range]) empty-window " +
+			"semantics (cerberus emits 0; PromQL drops the series). PRs #275 + #277 fixed " +
+			"the sum-LWR and instant-selector eval-ts divergences that originally motivated " +
+			"this skip; the rate-empty-window divergence remains. Set CERBERUS_PROPERTY_FORCE=1 " +
+			"once internal/chsql/range_window.go matches PromQL on rate-empty-window.")
+	}
+
 	cli := chclienttest.NewChDB(t)
 	h := prom.New(cli, schema.DefaultOTelMetrics(), nil)
 	mux := http.NewServeMux()
@@ -84,7 +135,7 @@ func TestPromQL_Property_Bridge(t *testing.T) {
 	}
 
 	oracleFn := func(d property.Dataset, q property.Query) property.Outcome {
-		return oracle.BridgePromQLOracle(d, q)
+		return oraclepromql.Evaluate(d, q, oraclepromql.Options{})
 	}
 
 	property.Run(t, property.Config{}, dgen, qgen, oracleFn, cerberusFn)


### PR DESCRIPTION
## Summary

PR #280's auto-merge silently took the Bridge version of `test/property/promql_test.go` over PR #272's FromScratch version when both PRs landed in close succession. Net effect:
- The from-scratch oracle code under `test/property/oracle/promql/*.go` was on `main` but unused (dead code).
- The property test still routed through `oracle.BridgePromQLOracle` (the temporary bridge to Prom's `promql.Engine`) — defeating the whole point of #272.

This PR restores the wiring:
- Switches `TestPromQL_Property_Bridge` back to `TestPromQL_Property_FromScratch` calling `oraclepromql.Evaluate`.
- Reintroduces the `CERBERUS_PROPERTY_FORCE` skip gate so default `go test -tags chdb ./test/property/...` still passes.

## Skip rationale update

PR #272's original skip rationale cited two divergences: sum-LWR (fixed by #275) and the instant-selector eval-ts boundary (fixed by #277). Those are no longer pending.

A third divergence remains: `rate(metric[range])`'s empty-window behaviour. Cerberus emits a 0-rate row when the rate window contains zero samples; PromQL drops the series entirely (and so does the from-scratch oracle). The property test surfaces this on every `rate`-shaped draw under `CERBERUS_PROPERTY_FORCE=1`:

```
--- query ---
rate(up[1m])
evalTs=...
--- diff ---
extra series in got: {instance="a"}
```

Root cause: `internal/chsql/range_window.go`'s `rateValueFrag` emits `if(length(window_vals) > 1, counter_delta / range_seconds, 0.0)` — should be `nan` (and the outer filter should drop NaN rows). Tracked for follow-up.

Why it's universal in the current generator: `gen.PromQLQuery` uses `evalTs = AnchorTime() + 200s`, `[range] = 60s`, and samples span `AnchorTime() + [0, 135s]` — so the rate window `[evalTs - 60s, evalTs] = [140s, 200s]` sits past every sample.

## The nightly `property` workflow keeps working

The workflow added by #280 stays in place; it'll skip the test until the rate-empty-window fix lands and then pick up the unskipped test automatically. No workflow change needed in this PR.

## Test plan

- [x] `go build -tags chdb ./...` clean.
- [x] `go test -tags chdb ./test/property/... -count=1 -v -run TestPromQL_Property` — SKIP with the new rationale.
- [x] `CERBERUS_PROPERTY_FORCE=1 go test -tags chdb ./test/property/... -run TestPromQL_Property` reproduces the rate-empty-window divergence (validates the from-scratch oracle is wired).
- [ ] CI green on `check` + `lint`.