### PR TITLE
fix(ci/property): place rapid flags after package list

### DIFF
--- a/.github/workflows/property.yml
+++ b/.github/workflows/property.yml
@@ -63,15 +63,23 @@ jobs:
         # draw before the test gives up.
         # `-v` surfaces the rapid seed in the workflow log so a failure
         # is reproducible with `-rapid.seed=<N>`.
+        #
+        # Flag ordering matters: rapid's flags (`-rapid.checks`,
+        # `-rapid.shrinktime`) are registered by the rapid library, not
+        # by `go test`. `go test` only recognises them as test-binary
+        # flags when they appear AFTER the package list — otherwise the
+        # toolchain misparses them as build flags, drops the package
+        # path, and falls back to `.` (the module root), which has no
+        # Go files and aborts with `FAIL . [setup failed]`.
         run: |
           go test \
             -tags chdb \
             -count=1 \
             -v \
             -timeout=20m \
+            ./test/property/... \
             -rapid.checks=500 \
-            -rapid.shrinktime=5m \
-            ./test/property/...
+            -rapid.shrinktime=5m
 
       - name: Upload rapid failure artifacts
         if: failure()


### PR DESCRIPTION
## Summary

The `Run property tests` step in `.github/workflows/property.yml` (added by #280) emitted `FAIL . [setup failed] / no Go files in /home/runner/work/cerberus/cerberus` on the first push-to-main trigger ([run 25861737903](https://github.com/tsouza/cerberus/actions/runs/25861737903)).

Root cause is **flag ordering**, not libchdb wiring. `libchdb.so` does install correctly via `just chdb-install` (the existing recipe is identical to `chdb.yml`'s and the install step's output confirms `==> libchdb v4.0.2 installed`). The test-binary flags were the issue:

```
go test \
  -tags chdb \
  -count=1 \
  -v \
  -timeout=20m \
  -rapid.checks=500 \      # BEFORE the package list
  -rapid.shrinktime=5m \   # BEFORE the package list
  ./test/property/...
```

`go test` only recognises arbitrary test-binary flags (rapid's `-rapid.*` are registered via the rapid library's own `flag.Parse()` inside the test binary) when they appear **after** the package list. When they precede the package list, the toolchain misparses them, drops `./test/property/...`, and falls back to `.` — the module root has no Go files (it's only directories), so the build aborts with `setup failed` before the test binary is linked.

Fix: move the rapid flags after the package path:

```
go test \
  -tags chdb \
  -count=1 \
  -v \
  -timeout=20m \
  ./test/property/... \
  -rapid.checks=500 \
  -rapid.shrinktime=5m
```

Comment in the workflow explains the constraint so the next editor doesn't reintroduce it.

## Repro

The buggy invocation reproduces locally:

```
$ go test -tags chdb -count=1 -timeout=20m -rapid.checks=10 ./test/property/...
# .
no Go files in /home/thiago/workspace/cerberus
FAIL    . [setup failed]
```

The corrected invocation links and executes:

```
$ go test -tags chdb -count=1 -v -timeout=20m ./test/property/... -rapid.checks=10 -rapid.shrinktime=5m
...
ok      github.com/tsouza/cerberus/test/property/oracle/promql  0.069s
FAIL
```

(The remaining `FAIL` is a real property drift in `TestPromQL_Property_Bridge` — out of scope for this workflow fix; the goal here is "no setup failure" so the test even runs.)

## Test plan

- [ ] CI runs the `property` workflow to completion against the fix branch (manual dispatch from the PR).
- [ ] Test binary links and rapid sweep proceeds (oracle failures are surfaced as real test failures, not `setup failed`).