### PR TITLE
fix(test/spec): coerce all integer widths in normalizeValue

### DIFF
--- a/test/spec/runner_chdb.go
+++ b/test/spec/runner_chdb.go
@@ -453,7 +453,19 @@ func normalizeValue(v any) any {
 	switch x := v.(type) {
 	case int:
 		return float64(x)
+	case int8:
+		return float64(x)
+	case int16:
+		return float64(x)
+	case int32:
+		return float64(x)
 	case int64:
+		return float64(x)
+	case uint8:
+		return float64(x)
+	case uint16:
+		return float64(x)
+	case uint32:
 		return float64(x)
 	case uint64:
 		return float64(x)


### PR DESCRIPTION
## Summary

- `TestRoundTripChDB/sgn_metric` failed because chDB returns `Int8` from CH's `sign()` and `normalizeValue` only coerced `int`, `int64`, `uint64`, `float32` to `float64`.
- Add cases for `int8`, `int16`, `int32`, `uint8`, `uint16`, `uint32` so all common integer widths normalize symmetrically with JSON-decoded `expected_rows`.

## Test plan

- [x] `go test -tags chdb -run 'TestRoundTripChDB/sgn_metric' ./test/spec/promql/...`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>