### PR TITLE
fix(chsql): cast Tempo metrics matrix Value column to Float64

### DIFF
--- a/internal/chsql/range_window.go
+++ b/internal/chsql/range_window.go
@@ -674,6 +674,17 @@ func windowValsFrag() Frag {
 // emission path. rate normalises `count(1)` by dividing through the
 // range duration in seconds (rendered as a literal — duration constants
 // are query-shape, not user-data).
+//
+// The reducer is always wrapped in `toFloat64(...)` so the projected
+// `Value` column has a uniform Float64 wire type — `chclient.Sample.Value`
+// is `float64`, and the CH Go driver refuses to coerce UInt64 (the
+// natural type of `count()`) or Int64 (the natural type of
+// `sum/min/max(Duration)`) into `*float64` at Scan time. Without the
+// cast, `| count_over_time() by (...)` against a real ClickHouse
+// surfaces as `engine: execute: chclient: scan: (Value) converting
+// UInt64 to *float64 is unsupported`. The rate case keeps the cast as
+// well even though `count() / N` already promotes to Float64 in CH —
+// the uniform wrap is cheaper to reason about than a per-op exception.
 func metricsReducerFrag(op chplan.MetricsOp, chName string, params, args []chplan.Expr, rangeSeconds float64) Frag {
 	// Translate Attr operand to a metric_arg reference (the alias the
 	// inner SELECT projects under) for *_over_time cases.
@@ -698,13 +709,16 @@ func metricsReducerFrag(op chplan.MetricsOp, chName string, params, args []chpla
 	switch op {
 	case chplan.MetricsOpRate:
 		return func(b *Builder) {
+			b.sb.WriteString("toFloat64(")
 			b.ParamAgg(chName, paramFrags, argFrags)
-			b.sb.WriteString(" / ")
+			b.sb.WriteString(") / ")
 			b.sb.WriteString(strconv.FormatFloat(rangeSeconds, 'f', -1, 64))
 		}
 	}
 	return func(b *Builder) {
+		b.sb.WriteString("toFloat64(")
 		b.ParamAgg(chName, paramFrags, argFrags)
+		b.sb.WriteByte(')')
 	}
 }
 

--- a/internal/chsql/range_window_metrics_test.go
+++ b/internal/chsql/range_window_metrics_test.go
@@ -51,9 +51,13 @@ func TestRangeWindowMetricsExplicitTimeGrid(t *testing.T) {
 	if !strings.Contains(sql, "range(0, 6)") {
 		t.Errorf("expected range(0, 6), SQL=%s", sql)
 	}
-	// Rate reducer normalises by range_seconds (60s).
-	if !strings.Contains(sql, "count(?) / 60") {
-		t.Errorf("expected `count(?) / 60`, SQL=%s", sql)
+	// Rate reducer normalises by range_seconds (60s); the count(?)
+	// aggregate is wrapped in toFloat64 so the Value column has the
+	// uniform Float64 wire type chclient.Sample.Value expects (UInt64
+	// → *float64 ScanRow conversion is unsupported by the CH Go
+	// driver). The substring is "toFloat64(count(?)) / 60".
+	if !strings.Contains(sql, "toFloat64(count(?)) / 60") {
+		t.Errorf("expected `toFloat64(count(?)) / 60`, SQL=%s", sql)
 	}
 	// args has the LitInt{1} bound by count(1).
 	if len(args) != 1 {
@@ -138,6 +142,63 @@ func TestMetricsAggregateRequiresAttr(t *testing.T) {
 			_, _, err := chsql.Emit(context.Background(), plan)
 			if err == nil {
 				t.Fatalf("expected error for %s without Attr", op)
+			}
+		})
+	}
+}
+
+// TestRangeWindowMetricsReducerIsFloat64 pins the Value-column type
+// invariant: every metrics-pipeline op in the matrix path must wrap the
+// per-bucket reducer in `toFloat64(...)` so chclient.Sample.Value
+// (a `float64`) can be Scan'd directly out of the row stream. Without
+// the wrap, `| count_over_time()` (CH `count()` → UInt64) and
+// `| {sum,min,max}_over_time(duration)` (CH aggregate over Int64 →
+// Int64) both surface as `engine: execute: chclient: scan: (Value)
+// converting UInt64 to *float64 is unsupported` against a real
+// ClickHouse — the bug fixed in #(this PR).
+//
+// The stubQuerier-backed handler test (metrics_query_range_test.go)
+// can't catch this because it returns pre-typed Go []chclient.Sample
+// values; the ScanRow conversion path is bypassed.
+func TestRangeWindowMetricsReducerIsFloat64(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		op   chplan.MetricsOp
+		attr chplan.Expr
+		q    []float64
+	}{
+		{name: "rate", op: chplan.MetricsOpRate},
+		{name: "count_over_time", op: chplan.MetricsOpCountOverTime},
+		{name: "sum_over_time", op: chplan.MetricsOpSumOverTime, attr: &chplan.ColumnRef{Name: "Duration"}},
+		{name: "avg_over_time", op: chplan.MetricsOpAvgOverTime, attr: &chplan.ColumnRef{Name: "Duration"}},
+		{name: "min_over_time", op: chplan.MetricsOpMinOverTime, attr: &chplan.ColumnRef{Name: "Duration"}},
+		{name: "max_over_time", op: chplan.MetricsOpMaxOverTime, attr: &chplan.ColumnRef{Name: "Duration"}},
+		{name: "quantile_over_time", op: chplan.MetricsOpQuantileOverTime, attr: &chplan.ColumnRef{Name: "Duration"}, q: []float64{0.95}},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			plan := &chplan.RangeWindow{
+				Input: &chplan.MetricsAggregate{
+					Op:         c.op,
+					Attr:       c.attr,
+					Quantiles:  c.q,
+					ValueAlias: "Value",
+					Inner:      &chplan.Scan{Table: "otel_traces"},
+				},
+				Step:            time.Minute,
+				OuterRange:      5 * time.Minute,
+				TimestampColumn: "Timestamp",
+			}
+			sql, _, err := chsql.Emit(context.Background(), plan)
+			if err != nil {
+				t.Fatalf("Emit %s: %v", c.name, err)
+			}
+			if !strings.Contains(sql, "toFloat64(") {
+				t.Errorf("%s reducer must wrap in toFloat64(...) so the Value column scans into chclient.Sample.Value (float64); SQL=%s", c.name, sql)
 			}
 		})
 	}

--- a/test/spec/chsql/range_window_metrics_count_over_time_by.txtar
+++ b/test/spec/chsql/range_window_metrics_count_over_time_by.txtar
@@ -1,7 +1,7 @@
 -- args --
 [0] int64 = 1
 -- sql --
-SELECT `service`, `anchor_ts`, count(?) AS `Value` FROM (SELECT `ServiceName` AS `service`, `Timestamp` AS `ts`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 11))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) WHERE ts >= anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts GROUP BY `service`, `anchor_ts`
+SELECT `service`, `anchor_ts`, toFloat64(count(?)) AS `Value` FROM (SELECT `ServiceName` AS `service`, `Timestamp` AS `ts`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 11))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) WHERE ts >= anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts GROUP BY `service`, `anchor_ts`
 -- chplan --
 RangeWindow func= range=0s step=1m0s outerRange=10m0s ts=Timestamp
   MetricsAggregate op=count_over_time groupBy=[ServiceName AS service] valueAlias=Value

--- a/test/spec/chsql/range_window_metrics_quantile_over_time_attr.txtar
+++ b/test/spec/chsql/range_window_metrics_quantile_over_time_attr.txtar
@@ -1,7 +1,7 @@
 -- args --
 [0] float64 = 0.95
 -- sql --
-SELECT `anchor_ts`, quantile(?)(`metric_arg`) AS `Value` FROM (SELECT `Timestamp` AS `ts`, `Duration` AS `metric_arg`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) WHERE ts >= anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts GROUP BY `anchor_ts`
+SELECT `anchor_ts`, toFloat64(quantile(?)(`metric_arg`)) AS `Value` FROM (SELECT `Timestamp` AS `ts`, `Duration` AS `metric_arg`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) WHERE ts >= anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts GROUP BY `anchor_ts`
 -- chplan --
 RangeWindow func= range=0s step=1m0s outerRange=5m0s ts=Timestamp
   MetricsAggregate op=quantile_over_time attr=Duration quantiles=[0.95] valueAlias=Value

--- a/test/spec/chsql/range_window_metrics_rate.txtar
+++ b/test/spec/chsql/range_window_metrics_rate.txtar
@@ -1,7 +1,7 @@
 -- args --
 [0] int64 = 1
 -- sql --
-SELECT `anchor_ts`, count(?) / 300 AS `Value` FROM (SELECT `Timestamp` AS `ts`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 61))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) WHERE ts >= anchor_ts - toIntervalNanosecond(300000000000) AND ts <= anchor_ts GROUP BY `anchor_ts`
+SELECT `anchor_ts`, toFloat64(count(?)) / 300 AS `Value` FROM (SELECT `Timestamp` AS `ts`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 61))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) WHERE ts >= anchor_ts - toIntervalNanosecond(300000000000) AND ts <= anchor_ts GROUP BY `anchor_ts`
 -- chplan --
 RangeWindow func= range=5m0s step=1m0s outerRange=1h0m0s ts=Timestamp
   MetricsAggregate op=rate valueAlias=Value

--- a/test/spec/chsql/range_window_metrics_sum_over_time_attr.txtar
+++ b/test/spec/chsql/range_window_metrics_sum_over_time_attr.txtar
@@ -1,7 +1,7 @@
 -- args --
 (none)
 -- sql --
-SELECT `anchor_ts`, sum(`metric_arg`) AS `Value` FROM (SELECT `Timestamp` AS `ts`, `Duration` AS `metric_arg`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) WHERE ts >= anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts GROUP BY `anchor_ts`
+SELECT `anchor_ts`, toFloat64(sum(`metric_arg`)) AS `Value` FROM (SELECT `Timestamp` AS `ts`, `Duration` AS `metric_arg`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) WHERE ts >= anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts GROUP BY `anchor_ts`
 -- chplan --
 RangeWindow func= range=0s step=1m0s outerRange=5m0s ts=Timestamp
   MetricsAggregate op=sum_over_time attr=Duration valueAlias=Value


### PR DESCRIPTION
## Root cause

The `dashboard` e2e job on `main` at sha 330fb058 ([run 25866322622](https://github.com/tsouza/cerberus/actions/runs/25866322622)) failed because the unskipped Playwright spec from PR #291 — `service graph: tempo metrics_query_range returns matrix envelope` — got HTTP 502 from cerberus instead of 200.

Cerberus's actual response body (recovered from the Playwright trace artifact):

```json
{"traceID":"","spanID":"","error":true,
 "message":"engine: execute: chclient: scan: clickhouse [ScanRow]: (Value) converting UInt64 to *float64 is unsupported. try using *uint64"}
```

The matrix-shape `RangeWindow{MetricsAggregate}` emitter
(`internal/chsql/range_window.go: emitRangeWindowMetrics`) projects the
per-bucket reducer as bare `count(?)` for `rate` / `count_over_time` and
bare `sum/min/max(metric_arg)` for the `*_over_time` family. Against a real
ClickHouse, `count()` returns `UInt64` and `sum/min/max(Duration)` returns
`Int64` (Duration is `Int64` in the OTel-CH schema). Each row is Scan'd
into a `chclient.Sample` whose `Value` field is `float64`, and the
clickhouse-go driver refuses both conversions at ScanRow time.

So every `count_over_time()` / `count_over_time() by (...)` request from
Grafana's service-graph panel returned 502.

The Go unit tests in `internal/api/tempo/metrics_query_range_test.go`
missed this because they use a `stubQuerier` that returns pre-typed
`[]chclient.Sample` values — the ScanRow path is bypassed.

## Fix

Wrap the per-bucket reducer in `toFloat64(...)` inside `metricsReducerFrag`
so every metrics op projects a uniform Float64 Value column. The `rate`
path keeps the cast even though `count() / N` already promotes to Float64
in CH — the uniform wrap is cheaper to reason about than a per-op
exception.

## Tests

- Updated the four chsql-direct goldens under `test/spec/chsql/`
  (`range_window_metrics_{rate,count_over_time_by,sum_over_time_attr,quantile_over_time_attr}.txtar`)
  to the new `toFloat64(...)` shape.
- Tightened `TestRangeWindowMetricsExplicitTimeGrid` to assert
  `toFloat64(count(?)) / 60` instead of `count(?) / 60`.
- Added `TestRangeWindowMetricsReducerIsFloat64` that iterates every
  supported `MetricsOp` and asserts the emitted SQL contains `toFloat64(`,
  so the next reducer addition gets the cast for free.

Bare-emission TXTARs under `test/spec/traceql/` are untouched — they
route through `emitMetricsAggregate` (the non-matrix path), which is
exercised only by chDB roundtrip and does NOT bridge through
`chclient.Sample`.

## Verification

The Playwright spec at `test/e2e/playwright/tempo_ux.spec.ts:274` exercises
the exact code path that was broken; once the `dashboard` job runs on
this PR's merge it will be green. The new unit test pins the SQL shape
against a future regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)