### PR TITLE
feat(promql): lower subquery-over-aggregate via recursive inner-expression lowering

### DIFF
--- a/internal/promql/subquery.go
+++ b/internal/promql/subquery.go
@@ -52,7 +52,7 @@ func lowerSubquery(e *parser.SubqueryExpr, s schema.Metrics, ctx lowerCtx) (chpl
 		inner2.Expr = inner.Expr
 		return lowerSubquery(&inner2, s, ctx)
 	case *parser.AggregateExpr:
-		return nil, fmt.Errorf("promql: subquery over aggregated expression is not yet supported (deferred from P0 4 — `max_over_time(sum by(...) (rate(...))[1h:5m])` needs chained RangeWindow over Aggregate output, landing in RC3)")
+		return lowerSubqueryOverAggregate(e, inner, step, s, ctx)
 	case *parser.SubqueryExpr:
 		return nil, fmt.Errorf("promql: nested subqueries are not yet supported (deferred to RC3)")
 	}
@@ -79,6 +79,11 @@ func lowerSubqueryOverCall(
 	if len(call.Args) != 1 {
 		return nil, fmt.Errorf("promql: subquery inner %s expects exactly 1 argument, got %d",
 			call.Func.Name, len(call.Args))
+	}
+	if innerSub, ok := call.Args[0].(*parser.SubqueryExpr); ok {
+		// Nested subquery: `<fn>(<inner-sub>)[<outer-range>:<step>]`.
+		// e.g. `max_over_time(rate(m[1m])[5m:30s])[1h:5m]`.
+		return lowerSubqueryOverCallSubquery(sub, call, innerSub, step, s, ctx)
 	}
 	ms, ok := call.Args[0].(*parser.MatrixSelector)
 	if !ok {
@@ -258,4 +263,254 @@ func subqueryAnchor(e *parser.SubqueryExpr, ctx lowerCtx) (evalAnchor, error) {
 		a.End = time.UnixMilli(*e.Timestamp).UTC()
 	}
 	return a, nil
+}
+
+// lowerSubqueryOverAggregate — `<sum/avg/...>(<inner>)[<outer_range>:<step>]`.
+//
+// The canonical Grafana shape is
+// `max_over_time(sum by(job)(rate(http_requests_total[1m]))[1h:30s])` —
+// at each anchor `t` across `[End - sub.Range, End]` spaced by `step`,
+// evaluate `sum by(job)(rate(http_requests_total[1m]))` at `t`.
+//
+// The lowered tree is a Project[Aggregate[matrix-RangeWindow]]:
+//
+//	Project[Attributes = map('<label>', gkey_0, ...), anchor_ts, value]
+//	  Aggregate[GroupBy: [<by-keys via Attributes['<label>'] AS gkey_N>, anchor_ts], AggFuncs: [<op>(value) AS value]]
+//	    RangeWindow[matrix shape: per-(series, anchor) Inner-call output]
+//	      <Filter/Scan from the AggregateExpr.Expr lowering>
+//
+// The outer Project re-exposes the canonical (Attributes, anchor_ts,
+// value) shape so a wrapping RangeWindow (the `max_over_time(...)`)
+// can group by Attributes and window over anchor_ts/value without
+// caring that the underlying series identity came from a `by(...)`
+// clause rather than the raw scan's Attributes map.
+//
+// Only `by(...)` aggregations are supported here. `without(...)`
+// would need the matrix RangeWindow to expose every label that wasn't
+// removed, which the current matrix lowering doesn't do (it groups by
+// the full Attributes map only). Same restriction as the parameterised
+// aggregates QUANTILE / TOPK / BOTTOMK / COUNT_VALUES that change
+// output shape — left to the next milestone.
+func lowerSubqueryOverAggregate(
+	sub *parser.SubqueryExpr,
+	agg *parser.AggregateExpr,
+	step time.Duration,
+	s schema.Metrics,
+	ctx lowerCtx,
+) (chplan.Node, error) {
+	if agg.Without {
+		return nil, fmt.Errorf("promql: subquery over `without(...)` aggregation is not yet supported")
+	}
+	switch agg.Op {
+	case parser.SUM, parser.COUNT, parser.AVG, parser.MIN, parser.MAX:
+		// Supported per-bucket reducers — sum/count/avg/min/max over the
+		// matrix value column produce one value per (anchor, by-key) row.
+	default:
+		return nil, fmt.Errorf("promql: subquery over %s aggregation is not yet supported",
+			agg.Op.String())
+	}
+
+	// Lower the aggregate's inner argument as a matrix-shape subquery
+	// (OuterRange + Step set). Produces (Attributes, anchor_ts, value)
+	// rows — one per (series, anchor) bucket — that the wrapping
+	// Aggregate groups across.
+	matrix, err := lowerSubqueryInnerMatrix(sub, agg.Expr, step, s, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build the Aggregate's GroupBy: one MapAccess per `by(...)` label
+	// PLUS the per-anchor key so the reducer fires once per (anchor,
+	// label-tuple).
+	groupBy := make([]chplan.Expr, 0, len(agg.Grouping)+1)
+	groupAliases := make([]string, 0, len(agg.Grouping)+1)
+	for i, label := range agg.Grouping {
+		groupBy = append(groupBy, &chplan.MapAccess{
+			Map: &chplan.ColumnRef{Name: s.AttributesColumn},
+			Key: &chplan.LitString{V: label},
+		})
+		groupAliases = append(groupAliases, fmt.Sprintf("gkey_%d", i))
+	}
+	groupBy = append(groupBy, &chplan.ColumnRef{Name: "anchor_ts"})
+	groupAliases = append(groupAliases, "anchor_ts")
+
+	// Build the AggFunc. `value` (lowercase) is the matrix
+	// RangeWindow's output column. The Aggregate's output column reuses
+	// the same alias so the outer RangeWindow can reference it
+	// transparently via its ValueColumn = "value".
+	aggFunc, err := buildSubqueryAggFunc(agg, "value")
+	if err != nil {
+		return nil, err
+	}
+
+	innerAgg := &chplan.Aggregate{
+		Input:          matrix,
+		GroupBy:        groupBy,
+		GroupByAliases: groupAliases,
+		AggFuncs:       []chplan.AggFunc{aggFunc},
+	}
+
+	// Rebuild Attributes from the gkey aliases so the outer
+	// RangeWindow's `GroupBy: [ColumnRef("Attributes")]` lights up
+	// without further plumbing. anchor_ts + value pass through as
+	// matching aliases. Value is cast to Float64 so the outer
+	// RangeWindow's counter_delta arithmetic (always emitted even by
+	// arrayAvg / arrayMax / arrayMin reducers) can do `c - p` without
+	// hitting CH's NO_COMMON_TYPE error on count's UInt64 result.
+	attrsExpr := buildAttributesFromAggregate(agg, groupAliases[:len(agg.Grouping)])
+	return &chplan.Project{
+		Input: innerAgg,
+		Projections: []chplan.Projection{
+			{Expr: attrsExpr, Alias: s.AttributesColumn},
+			{Expr: &chplan.ColumnRef{Name: "anchor_ts"}, Alias: "anchor_ts"},
+			{
+				Expr: &chplan.FuncCall{
+					Name: "toFloat64",
+					Args: []chplan.Expr{&chplan.ColumnRef{Name: "value"}},
+				},
+				Alias: "value",
+			},
+		},
+	}, nil
+}
+
+// lowerSubqueryInnerMatrix produces a matrix-shape RangeWindow for the
+// expression that lives inside an `<agg>[range:step]` clause's
+// aggregate. Recurses through ParenExpr; dispatches Call /
+// VectorSelector to the same matrix-emitting helpers
+// lowerSubqueryOverCall / lowerSubqueryOverVectorSelector use.
+//
+// Only shapes that already produce per-anchor matrix output are
+// supported — extending coverage to BinaryExpr / nested aggregations
+// would need additional plan-tree shaping the matrix emitter can't
+// currently consume.
+func lowerSubqueryInnerMatrix(
+	sub *parser.SubqueryExpr,
+	expr parser.Expr,
+	step time.Duration,
+	s schema.Metrics,
+	ctx lowerCtx,
+) (chplan.Node, error) {
+	switch inner := expr.(type) {
+	case *parser.ParenExpr:
+		return lowerSubqueryInnerMatrix(sub, inner.Expr, step, s, ctx)
+	case *parser.Call:
+		return lowerSubqueryOverCall(sub, inner, step, s, ctx)
+	case *parser.VectorSelector:
+		return lowerSubqueryOverVectorSelector(sub, inner, step, s, ctx)
+	}
+	return nil, fmt.Errorf("promql: subquery over aggregation of %T is not yet supported", expr)
+}
+
+// buildSubqueryAggFunc maps a PromQL AggregateExpr to the chplan
+// AggFunc that runs INSIDE the subquery-over-aggregate pipeline.
+// Mirrors buildAggFunc but takes the input column name as a parameter
+// (the matrix RangeWindow emits lowercase `value`, not s.ValueColumn).
+func buildSubqueryAggFunc(a *parser.AggregateExpr, inCol string) (chplan.AggFunc, error) {
+	valueArg := &chplan.ColumnRef{Name: inCol}
+	switch a.Op {
+	case parser.SUM:
+		return chplan.AggFunc{Name: "sum", Args: []chplan.Expr{valueArg}, Alias: "value"}, nil
+	case parser.COUNT:
+		return chplan.AggFunc{Name: "count", Args: []chplan.Expr{valueArg}, Alias: "value"}, nil
+	case parser.AVG:
+		return chplan.AggFunc{Name: "avg", Args: []chplan.Expr{valueArg}, Alias: "value"}, nil
+	case parser.MIN:
+		return chplan.AggFunc{Name: "min", Args: []chplan.Expr{valueArg}, Alias: "value"}, nil
+	case parser.MAX:
+		return chplan.AggFunc{Name: "max", Args: []chplan.Expr{valueArg}, Alias: "value"}, nil
+	}
+	return chplan.AggFunc{}, fmt.Errorf("promql: subquery over %s aggregation is not yet supported", a.Op.String())
+}
+
+// buildAttributesFromAggregate rebuilds an Attributes map literal from
+// the gkey_N aliases produced by the subquery's inner Aggregate. The
+// result lets a wrapping RangeWindow group by `Attributes` without
+// needing to know that the underlying identity came from a `by(...)`
+// clause.
+//
+// `by(label1, label2)` → `map('label1', gkey_0, 'label2', gkey_1)`.
+// `by()` (no labels) → empty `Map(String,String)` literal.
+func buildAttributesFromAggregate(agg *parser.AggregateExpr, gkeyAliases []string) chplan.Expr {
+	if len(agg.Grouping) == 0 {
+		return &chplan.FuncCall{
+			Name: "CAST",
+			Args: []chplan.Expr{
+				&chplan.FuncCall{Name: "map", Args: nil},
+				&chplan.LitString{V: "Map(String,String)"},
+			},
+		}
+	}
+	args := make([]chplan.Expr, 0, len(agg.Grouping)*2)
+	for i, label := range agg.Grouping {
+		args = append(args,
+			&chplan.LitString{V: label},
+			&chplan.ColumnRef{Name: gkeyAliases[i]},
+		)
+	}
+	return &chplan.FuncCall{Name: "map", Args: args}
+}
+
+// lowerSubqueryOverCallSubquery handles the nested-subquery shape
+// `<outer-fn>(<inner-sub>)[<outer-range>:<step>]`. Canonical example:
+// `max_over_time(rate(m[1m])[5m:30s])[1h:5m]`.
+//
+// Conceptual evaluation: at each outer anchor `t_outer` ∈
+// `[End - sub.Range, End]` spaced by `step`, evaluate
+// `<outer-fn>(<inner-sub>)` at `t_outer` — which is itself
+// `<outer-fn>` over `<inner-sub>` evaluated at the inner anchors
+// across `[t_outer - innerSub.Range, t_outer]` spaced by
+// `innerSub.Step`.
+//
+// We widen the inner subquery's `Range` to cover the union of both
+// outer + inner ranges, then wrap with a matrix RangeWindow that
+// reduces per outer anchor. The widened inner emits one row per
+// (series, t_inner) at innerSub.Step resolution across
+// `[End - (sub.Range + innerSub.Range), End]`; the outer matrix
+// groupArrays per Attributes and arrayFilters to
+// `[t_outer - innerSub.Range, t_outer]` per outer anchor before
+// applying the outer-fn reducer.
+func lowerSubqueryOverCallSubquery(
+	sub *parser.SubqueryExpr,
+	call *parser.Call,
+	innerSub *parser.SubqueryExpr,
+	step time.Duration,
+	s schema.Metrics,
+	ctx lowerCtx,
+) (chplan.Node, error) {
+	if _, ok := rangeVectorFn[call.Func.Name]; !ok {
+		return nil, fmt.Errorf("promql: %s does not accept a subquery argument", call.Func.Name)
+	}
+	if innerSub.Range <= 0 {
+		return nil, fmt.Errorf("promql: inner subquery range must be positive, got %s", innerSub.Range)
+	}
+
+	// Widen the inner subquery to cover the outer range PLUS the inner
+	// range so every outer anchor's lookback finds inner anchors. Each
+	// per-outer-anchor reduction then arrayFilters to the inner-range
+	// window — see emitWindowedArrayMatrix.
+	widened := *innerSub
+	widened.Range = sub.Range + innerSub.Range
+	wideInner, err := lowerSubquery(&widened, s, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	anchor, err := subqueryAnchor(sub, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &chplan.RangeWindow{
+		Input:           wideInner,
+		Func:            call.Func.Name,
+		Range:           innerSub.Range,
+		OuterRange:      sub.Range,
+		Step:            step,
+		End:             anchor.End,
+		Offset:          anchor.Offset,
+		TimestampColumn: "anchor_ts",
+		ValueColumn:     "value",
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}},
+	}, nil
 }

--- a/test/spec/promql/subquery_nested.txtar
+++ b/test/spec/promql/subquery_nested.txtar
@@ -1,0 +1,27 @@
+-- query.promql --
+max_over_time(max_over_time(rate(m[1m])[5m:30s])[1h:5m])
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('m', map('job', 'api'), toDateTime64('2025-12-31 23:59:30', 9), 100.0),
+    ('m', map('job', 'api'), toDateTime64('2025-12-31 23:59:45', 9), 110.0),
+    ('m', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 120.0);
+-- expected_rows --
+[
+  [{"job": "api"}, 0.3333333333333333]
+]
+-- args --
+[0] string = "m"
+-- chplan --
+RangeWindow func=max_over_time range=1h0m0s step=0s ts=anchor_ts value=value groupBy=[Attributes]
+  RangeWindow func=max_over_time range=5m0s step=5m0s outerRange=1h0m0s ts=anchor_ts value=value groupBy=[Attributes]
+    RangeWindow func=rate range=1m0s step=30s outerRange=1h5m0s ts=TimeUnix value=Value groupBy=[Attributes]
+      Filter predicate=(MetricName = "m")
+        Scan(otel_metrics_gauge)
+-- sql --
+SELECT `Attributes`, if(length(window_vals) > 0, arrayMax(window_vals), nan) AS `value` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) >= now64(9) - toIntervalNanosecond(3600000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`anchor_ts`, `value`))) AS `series_array` FROM (SELECT `Attributes`, `anchor_ts`, if(length(window_vals) > 0, arrayMax(window_vals), nan) AS `value` FROM (SELECT `Attributes`, `anchor_ts`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, `anchor_ts`, arrayFilter(p -> tupleElement(p, 1) >= anchor_ts - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= anchor_ts, series_array) AS `window_pairs` FROM (SELECT `Attributes`, `series_array`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 300000000000), range(0, 13))) AS `anchor_ts` FROM (SELECT `Attributes`, arraySort(groupArray((`anchor_ts`, `value`))) AS `series_array` FROM (SELECT `Attributes`, `anchor_ts`, if(length(window_vals) > 1, counter_delta / 60, 0.0) AS `value` FROM (SELECT `Attributes`, `anchor_ts`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, `anchor_ts`, arrayFilter(p -> tupleElement(p, 1) >= anchor_ts - toIntervalNanosecond(60000000000) AND tupleElement(p, 1) <= anchor_ts, series_array) AS `window_pairs` FROM (SELECT `Attributes`, `series_array`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 30000000000), range(0, 131))) AS `anchor_ts` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY `Attributes`)))) WHERE length(`window_vals`) >= 2) GROUP BY `Attributes`)))) WHERE length(`window_vals`) >= 1) GROUP BY `Attributes`))) WHERE length(`window_vals`) >= 1

--- a/test/spec/promql/subquery_over_avg_count.txtar
+++ b/test/spec/promql/subquery_over_avg_count.txtar
@@ -1,0 +1,59 @@
+-- query.promql --
+avg_over_time(count by(level)(rate(log_lines_total[5m]))[30m:1m])
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('log_lines_total', map('level', 'info'), toDateTime64('2025-12-31 23:30:00', 9), 0.0),
+    ('log_lines_total', map('level', 'info'), toDateTime64('2025-12-31 23:31:00', 9), 1.0),
+    ('log_lines_total', map('level', 'info'), toDateTime64('2025-12-31 23:32:00', 9), 2.0),
+    ('log_lines_total', map('level', 'info'), toDateTime64('2025-12-31 23:33:00', 9), 3.0),
+    ('log_lines_total', map('level', 'info'), toDateTime64('2025-12-31 23:34:00', 9), 4.0),
+    ('log_lines_total', map('level', 'info'), toDateTime64('2025-12-31 23:35:00', 9), 5.0),
+    ('log_lines_total', map('level', 'info'), toDateTime64('2025-12-31 23:36:00', 9), 6.0),
+    ('log_lines_total', map('level', 'info'), toDateTime64('2025-12-31 23:37:00', 9), 7.0),
+    ('log_lines_total', map('level', 'info'), toDateTime64('2025-12-31 23:38:00', 9), 8.0),
+    ('log_lines_total', map('level', 'info'), toDateTime64('2025-12-31 23:39:00', 9), 9.0),
+    ('log_lines_total', map('level', 'info'), toDateTime64('2025-12-31 23:40:00', 9), 10.0),
+    ('log_lines_total', map('level', 'info'), toDateTime64('2025-12-31 23:41:00', 9), 11.0),
+    ('log_lines_total', map('level', 'info'), toDateTime64('2025-12-31 23:42:00', 9), 12.0),
+    ('log_lines_total', map('level', 'info'), toDateTime64('2025-12-31 23:43:00', 9), 13.0),
+    ('log_lines_total', map('level', 'info'), toDateTime64('2025-12-31 23:44:00', 9), 14.0),
+    ('log_lines_total', map('level', 'info'), toDateTime64('2025-12-31 23:45:00', 9), 15.0),
+    ('log_lines_total', map('level', 'info'), toDateTime64('2025-12-31 23:46:00', 9), 16.0),
+    ('log_lines_total', map('level', 'info'), toDateTime64('2025-12-31 23:47:00', 9), 17.0),
+    ('log_lines_total', map('level', 'info'), toDateTime64('2025-12-31 23:48:00', 9), 18.0),
+    ('log_lines_total', map('level', 'info'), toDateTime64('2025-12-31 23:49:00', 9), 19.0),
+    ('log_lines_total', map('level', 'info'), toDateTime64('2025-12-31 23:50:00', 9), 20.0),
+    ('log_lines_total', map('level', 'info'), toDateTime64('2025-12-31 23:51:00', 9), 21.0),
+    ('log_lines_total', map('level', 'info'), toDateTime64('2025-12-31 23:52:00', 9), 22.0),
+    ('log_lines_total', map('level', 'info'), toDateTime64('2025-12-31 23:53:00', 9), 23.0),
+    ('log_lines_total', map('level', 'info'), toDateTime64('2025-12-31 23:54:00', 9), 24.0),
+    ('log_lines_total', map('level', 'info'), toDateTime64('2025-12-31 23:55:00', 9), 25.0),
+    ('log_lines_total', map('level', 'info'), toDateTime64('2025-12-31 23:56:00', 9), 26.0),
+    ('log_lines_total', map('level', 'info'), toDateTime64('2025-12-31 23:57:00', 9), 27.0),
+    ('log_lines_total', map('level', 'info'), toDateTime64('2025-12-31 23:58:00', 9), 28.0),
+    ('log_lines_total', map('level', 'info'), toDateTime64('2025-12-31 23:59:00', 9), 29.0),
+    ('log_lines_total', map('level', 'info'), toDateTime64('2026-01-01 00:00:00', 9), 30.0);
+-- expected_rows --
+[
+  [{"level": "info"}, 1.0]
+]
+-- args --
+[0] string = "level"
+[1] string = "level"
+[2] string = "log_lines_total"
+[3] string = "level"
+-- chplan --
+RangeWindow func=avg_over_time range=30m0s step=0s ts=anchor_ts value=value groupBy=[Attributes]
+  Project [map("level", gkey_0) AS Attributes, anchor_ts AS anchor_ts, toFloat64(value) AS value]
+    Aggregate groupBy=[Attributes["level"] AS gkey_0, anchor_ts AS anchor_ts] funcs=[count(value) AS value]
+      RangeWindow func=rate range=5m0s step=1m0s outerRange=30m0s ts=TimeUnix value=Value groupBy=[Attributes]
+        Filter predicate=(MetricName = "log_lines_total")
+          Scan(otel_metrics_sum)
+-- sql --
+SELECT `Attributes`, if(length(window_vals) > 0, arrayAvg(window_vals), nan) AS `value` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) >= now64(9) - toIntervalNanosecond(1800000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`anchor_ts`, `value`))) AS `series_array` FROM (SELECT map(?, `gkey_0`) AS `Attributes`, `anchor_ts` AS `anchor_ts`, toFloat64(`value`) AS `value` FROM (SELECT `Attributes`[?] AS `gkey_0`, `anchor_ts` AS `anchor_ts`, count(`value`) AS `value` FROM (SELECT `Attributes`, `anchor_ts`, if(length(window_vals) > 1, counter_delta / 300, 0.0) AS `value` FROM (SELECT `Attributes`, `anchor_ts`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, `anchor_ts`, arrayFilter(p -> tupleElement(p, 1) >= anchor_ts - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= anchor_ts, series_array) AS `window_pairs` FROM (SELECT `Attributes`, `series_array`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 31))) AS `anchor_ts` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` = ?)) GROUP BY `Attributes`)))) WHERE length(`window_vals`) >= 2) GROUP BY `Attributes`[?], `anchor_ts`)) GROUP BY `Attributes`))) WHERE length(`window_vals`) >= 1

--- a/test/spec/promql/subquery_over_sum_rate.txtar
+++ b/test/spec/promql/subquery_over_sum_rate.txtar
@@ -1,0 +1,31 @@
+-- query.promql --
+max_over_time(sum by(job)(rate(http_requests_total[1m]))[1h:30s])
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('http_requests_total', map('job', 'api'), toDateTime64('2025-12-31 23:59:30', 9), 100.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2025-12-31 23:59:45', 9), 110.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 120.0);
+-- expected_rows --
+[
+  [{"job": "api"}, 0.3333333333333333]
+]
+-- args --
+[0] string = "job"
+[1] string = "job"
+[2] string = "http_requests_total"
+[3] string = "job"
+-- chplan --
+RangeWindow func=max_over_time range=1h0m0s step=0s ts=anchor_ts value=value groupBy=[Attributes]
+  Project [map("job", gkey_0) AS Attributes, anchor_ts AS anchor_ts, toFloat64(value) AS value]
+    Aggregate groupBy=[Attributes["job"] AS gkey_0, anchor_ts AS anchor_ts] funcs=[sum(value) AS value]
+      RangeWindow func=rate range=1m0s step=30s outerRange=1h0m0s ts=TimeUnix value=Value groupBy=[Attributes]
+        Filter predicate=(MetricName = "http_requests_total")
+          Scan(otel_metrics_sum)
+-- sql --
+SELECT `Attributes`, if(length(window_vals) > 0, arrayMax(window_vals), nan) AS `value` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) >= now64(9) - toIntervalNanosecond(3600000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`anchor_ts`, `value`))) AS `series_array` FROM (SELECT map(?, `gkey_0`) AS `Attributes`, `anchor_ts` AS `anchor_ts`, toFloat64(`value`) AS `value` FROM (SELECT `Attributes`[?] AS `gkey_0`, `anchor_ts` AS `anchor_ts`, sum(`value`) AS `value` FROM (SELECT `Attributes`, `anchor_ts`, if(length(window_vals) > 1, counter_delta / 60, 0.0) AS `value` FROM (SELECT `Attributes`, `anchor_ts`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, `anchor_ts`, arrayFilter(p -> tupleElement(p, 1) >= anchor_ts - toIntervalNanosecond(60000000000) AND tupleElement(p, 1) <= anchor_ts, series_array) AS `window_pairs` FROM (SELECT `Attributes`, `series_array`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 30000000000), range(0, 121))) AS `anchor_ts` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` = ?)) GROUP BY `Attributes`)))) WHERE length(`window_vals`) >= 2) GROUP BY `Attributes`[?], `anchor_ts`)) GROUP BY `Attributes`))) WHERE length(`window_vals`) >= 1

--- a/test/spec/runner_chdb.go
+++ b/test/spec/runner_chdb.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -32,6 +33,20 @@ import (
 // `parquet.go`: `return fmt.Errorf("empty row")`). It surfaces on
 // rows.Err() and must be ignored — any other error is real.
 const chdbEOFSentinel = "empty row"
+
+// nowAnchorLiteral is the deterministic CH literal we splice in place
+// of every `now64(...)` reference in the emitted SQL. It mirrors the
+// instant-eval anchor `internal/promql/lower_test.go` feeds into
+// `LowerAt` (`time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)`), so each
+// round-trip fixture sees the same wall-clock the lowering pass used
+// to compute filter bounds. Keeping this in lock-step with the
+// lowering anchor lets `expected_rows:` cells pin the TimeUnix column
+// to a fixed string instead of chasing wall-clock noise.
+//
+// The third arg (`'UTC'`) is mandatory: chDB's parser treats the
+// timezone slot positionally and rejects `toDateTime64(str, 9)` when
+// the literal has fractional seconds.
+const nowAnchorLiteral = "toDateTime64('2026-01-01 00:00:01.000000000', 9, 'UTC')"
 
 // tolerantRowsErr matches the helper used by the chDB probe in
 // internal/chclient/chdb_probe_test.go.
@@ -229,6 +244,144 @@ func extractProjectionCount(query string) int {
 	return len(splitProjections(head))
 }
 
+// substituteNow64 rewrites every `now64(...)` reference in the emitted
+// SQL to the deterministic [nowAnchorLiteral] so instant queries that
+// project the wall-clock as `TimeUnix` (PromQL aggregations, histogram
+// quantiles, subqueries, predict_linear, holt_winters) produce a
+// repeatable cell in `expected_rows:`. Without this, the outer
+// projection would scan as the wall-clock at test execution time and
+// never match a written-in-stone fixture row.
+//
+// Two shapes appear in the corpus:
+//
+//   - `now64(?)` — parameterized; the trailing `?` is bound to an
+//     int64 precision arg in `args:`. We strip the corresponding
+//     positional slot from args alongside the SQL rewrite so the
+//     remaining `?` placeholders re-index correctly.
+//
+//   - `now64(9)` / `now64(<int>)` — emitted as a literal in subquery,
+//     predict_linear, and holt_winters lowerings. No args slot to
+//     consume.
+//
+// The function tracks `?` placeholder offsets while scanning so the
+// args list is mutated in lock-step. This is a test-infra workaround
+// for the inherent non-determinism of wall-clock projections in
+// instant queries — production code path is untouched. See PR #288's
+// audit note ("seed/metric mismatch + non-deterministic now64") and
+// the follow-up that lands seed alignment + this substitution
+// together.
+func substituteNow64(query string, args []any) (string, []any) {
+	// Fast-path: nothing to do when neither shape is present.
+	if !strings.Contains(query, "now64(") {
+		return query, args
+	}
+
+	var (
+		out      strings.Builder
+		newArgs  = make([]any, 0, len(args))
+		argIdx   int
+		inStr    byte
+	)
+	out.Grow(len(query))
+
+	for i := 0; i < len(query); i++ {
+		c := query[i]
+		// Track string literals so a stray `?` or `now64(` inside
+		// quotes is left alone. CH SQL uses single-quotes; backticks
+		// quote identifiers, not strings, so they don't interfere
+		// with placeholder counting.
+		if inStr != 0 {
+			out.WriteByte(c)
+			if c == inStr {
+				inStr = 0
+			}
+			continue
+		}
+		if c == '\'' {
+			inStr = c
+			out.WriteByte(c)
+			continue
+		}
+
+		// Match `now64(?)` — substitute literal and consume one arg.
+		if c == 'n' && strings.HasPrefix(query[i:], "now64(?)") {
+			out.WriteString(nowAnchorLiteral)
+			// Skip the consumed arg slot. argIdx is the next-to-bind
+			// index; it points at the `?` inside `now64(?)` which we
+			// are about to drop. Advance past it without copying.
+			argIdx++
+			i += len("now64(?)") - 1
+			continue
+		}
+
+		// Match `now64(<int>)` — substitute literal, no args change.
+		if c == 'n' && strings.HasPrefix(query[i:], "now64(") {
+			// Find the matching `)` at depth 0 starting after the `(`.
+			rest := query[i+len("now64("):]
+			depth := 1
+			j := 0
+			for ; j < len(rest); j++ {
+				if rest[j] == '(' {
+					depth++
+				} else if rest[j] == ')' {
+					depth--
+					if depth == 0 {
+						break
+					}
+				}
+			}
+			if j < len(rest) {
+				inner := strings.TrimSpace(rest[:j])
+				// Only substitute when the body is a bare numeric
+				// literal (the precision arg). Anything else (no
+				// known cases today) passes through to surface a
+				// real failure rather than silently mis-rewrite.
+				if isIntLiteral(inner) {
+					out.WriteString(nowAnchorLiteral)
+					i += len("now64(") + j // jump past the closing `)`
+					continue
+				}
+			}
+		}
+
+		// Generic `?` placeholder: copy the arg through.
+		if c == '?' {
+			out.WriteByte(c)
+			if argIdx < len(args) {
+				newArgs = append(newArgs, args[argIdx])
+			}
+			argIdx++
+			continue
+		}
+
+		out.WriteByte(c)
+	}
+
+	return out.String(), newArgs
+}
+
+// isIntLiteral reports whether s is a non-empty run of ASCII digits
+// (optionally prefixed by `-`). Used by substituteNow64 to recognise
+// the precision literal in `now64(9)` without pulling in strconv.
+func isIntLiteral(s string) bool {
+	if s == "" {
+		return false
+	}
+	i := 0
+	if s[0] == '-' {
+		i = 1
+		if len(s) == 1 {
+			return false
+		}
+	}
+	for ; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
 // openChDB returns a fresh ephemeral chDB session. The empty DSN
 // triggers a temp-dir-backed session that's torn down with the
 // connection — there is no `:memory:` literal in chdb-go.
@@ -324,9 +477,12 @@ func splitStatements(s string) []string {
 // `expected_rows:`. Caller passes the loaded fixture; if it's not a
 // round-trip fixture, the call is a no-op.
 //
-// Determinism contract: the fixture's `sql:` (or the seed's INSERT
-// ordering combined with a server-side ORDER BY in the emitted SQL)
-// MUST produce a stable row order — RunRoundTrip does NOT sort rows.
+// Determinism contract: cerberus's emitted instant-query SQL does not
+// carry a top-level ORDER BY (PromQL's instant-query result is a set
+// of (labels, value) pairs — no order is promised by the wire shape),
+// so RunRoundTrip canonicalises both sides through [sortRows] before
+// `reflect.DeepEqual`. Fixtures that rely on a stable order must
+// emit one explicitly in the seed/SQL — none do today.
 // Map column comparison uses reflect.DeepEqual on map[string]any so
 // JSON key ordering is irrelevant.
 func RunRoundTrip(t *testing.T, c *Case) {
@@ -345,16 +501,22 @@ func RunRoundTrip(t *testing.T, c *Case) {
 	db := openChDB(t)
 	applySeed(t, db, rt.Seed)
 
-	query := rewriteMapProjections(rt.SQL)
+	// substituteNow64 must run BEFORE rewriteMapProjections so the
+	// `now64(?)`-consumed args are dropped before the Map rewrite
+	// inspects the SQL. The two passes are independent textually but
+	// the args side is global, and ordering them this way keeps the
+	// argIdx accounting in substituteNow64 simple.
+	query, queryArgs := substituteNow64(rt.SQL, rt.Args)
+	query = rewriteMapProjections(query)
 	colCount := extractProjectionCount(query)
 	if colCount == 0 {
 		t.Fatalf("fixture %s: cannot determine SELECT projection count from sql", c.Name)
 	}
 
-	rows, err := db.Query(query, rt.Args...)
+	rows, err := db.Query(query, queryArgs...)
 	if err != nil {
 		t.Fatalf("query failed:\n--- query ---\n%s\n--- args ---\n%#v\n--- err ---\n%v",
-			query, rt.Args, err)
+			query, queryArgs, err)
 	}
 	defer func() { _ = rows.Close() }()
 
@@ -390,10 +552,28 @@ func RunRoundTrip(t *testing.T, c *Case) {
 	want := normalizeExpected(rt.ExpectedRows)
 	gotNorm := normalizeExpected(got)
 
+	// PromQL instant-query results are sets — the chDB engine is
+	// free to return groups in any order when the emitted SQL lacks
+	// a top-level ORDER BY (which it does). Sort both sides through
+	// the same canonical form so DeepEqual reflects set-equality.
+	sortRows(want)
+	sortRows(gotNorm)
+
 	if !reflect.DeepEqual(gotNorm, want) {
 		t.Fatalf("round-trip mismatch (fixture %s)\n got = %s\nwant = %s",
 			c.Name, mustJSON(gotNorm), mustJSON(want))
 	}
+}
+
+// sortRows canonicalises a result set by sorting rows in-place on the
+// JSON encoding of their cells. The encoding is deterministic for the
+// types the runner emits (string, float64, bool, nil, []any,
+// map[string]any), so any two row sets that compare set-equal end up
+// with identical post-sort orderings.
+func sortRows(rows [][]any) {
+	sort.Slice(rows, func(i, j int) bool {
+		return mustJSON(rows[i]) < mustJSON(rows[j])
+	})
 }
 
 // decodeCell turns a chdb-go driver-native value into the Go value


### PR DESCRIPTION
## Summary

Closes the last remaining L2b gap surfaced by PR #288's audit: `max_over_time(sum by(job)(rate(http_requests_total[1m]))[1h:30s])` now lowers cleanly instead of erroring with `subquery over aggregate not supported`.

Three new lowering paths in `internal/promql/subquery.go`:

- `lowerSubqueryOverAggregate` — handles `<sum/avg/count/min/max by(...)>[range:step]` by recursively lowering the inner expression as a matrix-RangeWindow, wrapping in `chplan.Aggregate` keyed on `(Attributes['<label>'] AS gkey_N, anchor_ts)` so each `(anchor, group-tuple)` bucket reduces independently, then re-projecting Attributes from the gkey aliases so a wrapping `RangeWindow` can groupBy=Attributes transparently. value is cast to `toFloat64` to keep CH's NO_COMMON_TYPE error away from count's UInt64 result vs the outer windowed-array's `counter_delta` arithmetic.
- `lowerSubqueryInnerMatrix` — dispatcher that recurses through ParenExpr; dispatches Call / VectorSelector to the existing matrix-emitting helpers.
- `lowerSubqueryOverCallSubquery` — handles the nested shape `<outer-fn>(<inner-sub>)[<outer-range>:<step>]` (e.g. `max_over_time(rate(m[1m])[5m:30s])[1h:5m]`) by widening the inner subquery's Range to cover both outer + inner ranges before wrapping in a matrix RangeWindow that reduces per outer anchor.

Three new chDB roundtrip fixtures under `test/spec/promql/` exercise the three shapes end-to-end:

- `subquery_over_sum_rate.txtar` — `max_over_time(sum by(job)(rate(http_requests_total[1m]))[1h:30s])` → `[{"job": "api"}, 0.333…]`.
- `subquery_over_avg_count.txtar` — `avg_over_time(count by(level)(rate(log_lines_total[5m]))[30m:1m])` → `[{"level": "info"}, 1.0]`.
- `subquery_nested.txtar` — `max_over_time(max_over_time(rate(m[1m])[5m:30s])[1h:5m])` → `[{"job": "api"}, 0.333…]`.

## Test plan

- [x] `go test ./internal/promql/...` — 434 pass (+2 over the baseline)
- [x] `go test -tags chdb ./test/spec/promql/...` — 138 pass (+3 new fixtures)
- [x] Three new fixtures roundtrip-pass against an in-process chDB session with real `(labels, value)` cells in `expected_rows`.
- [x] No regressions in existing subquery / *_over_time fixtures.
- [x] No raw SQL strings — all new chplan/Frag construction goes through typed builders.

## Notes for reviewer

- `test/spec/runner_chdb.go` gains `substituteNow64` + `sortRows`, mirroring what PR #293 already proposes for its own fixture audit. The two changes are textually identical (cherry-picked from #293's commit) so whichever lands first will auto-merge with the other. Necessary for my fixtures to produce deterministic `expected_rows` on a wall-clock shifting CI.
- `count(value)` returns UInt64; the outer windowed-array idiom unconditionally emits `counter_delta` arithmetic with `c - p`, which CH rejects for mixed signed/unsigned. The fix is a `toFloat64(value)` projection between the inner Aggregate and the outer matrix RangeWindow.
- `without(...)` aggregations and parameterised aggregates (QUANTILE / TOPK / BOTTOMK / COUNT_VALUES) under a subquery still return a clear "not yet supported" error — left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)