### PR TITLE
test(property): pin RangeWindow case-mismatch seed as regression checkpoint

### DIFF
--- a/test/property/promql_test.go
+++ b/test/property/promql_test.go
@@ -47,30 +47,57 @@
 // # Skip rationale (current state)
 //
 // PR #272 surfaced three cerberus-vs-Prom divergences via the from-
-// scratch oracle. Two were fixed in PRs #275 and #277 (sum-LWR and
-// instant-selector / VectorJoin eval-ts). The third — rate / increase
-// / delta / *_over_time emitting synthetic zero rows for empty
-// windows — was fixed by adding `WHERE length(window_vals) >= N` to
-// the outer SELECT of the windowed-array emitter (see
-// `internal/chsql/range_window.go::emitWindowedArray`).
+// scratch oracle. The original three were all fixed:
+//   - sum-LWR (#275)
+//   - instant-selector / VectorJoin eval-ts (#277)
+//   - rate / increase / delta / *_over_time empty-window zero rows
+//     (#287 — `WHERE length(window_vals) >= N` on the outer SELECT of
+//     `internal/chsql/range_window.go::emitWindowedArray`)
 //
-// Force-running the test with `CERBERUS_PROPERTY_FORCE=1` now
-// surfaces a SEPARATE pre-existing bug that the rate-empty-window
-// fix did not introduce: cerberus's `RangeWindow` emitter projects
-// the windowed value as a lowercase `value` alias, but the parent
-// `Aggregate` references the schema-cased `Value` column. The result
-// is a CH UNKNOWN_IDENTIFIER error on any `sum(rate(...))` /
-// `count(rate(...))` shape against real data. The bug is dormant in
-// the txtar fixtures because none of the aggregate-over-rate cases
-// carry `expected_rows:` — only `histogram_quantile(sum by(le)
-// (rate))` is exercised end-to-end, and it routes through a
-// dedicated histogram code path that bypasses the case mismatch.
+// Force-running the test with `CERBERUS_PROPERTY_FORCE=1` surfaces a
+// SEPARATE pre-existing bug that the rate-empty-window fix did not
+// introduce: cerberus's `RangeWindow` emitter projects the windowed
+// value as a lowercase `value` alias (see line ~353 of
+// `internal/chsql/range_window.go`, the outer SELECT in
+// `emitWindowedArrayPairs`), but the parent `Aggregate` references
+// the schema-cased `Value` column. The result is a CH
+// `UNKNOWN_IDENTIFIER: 'Value'. Maybe you meant: ['value']` error on
+// any `sum(rate(...))` / `count(rate(...))` shape against real data.
+//
+// The bug is dormant in the txtar fixtures because none of the
+// aggregate-over-rate cases carry `expected_rows:` — only
+// `histogram_quantile(sum by(le)(rate))` is exercised end-to-end,
+// and it routes through a dedicated histogram code path that
+// bypasses the case mismatch.
+//
+// # Regression checkpoint
+//
+// As of 2026-05-14 (this branch), a forced run with
+// `-rapid.checks=100` shrinks to the minimal reproducer:
+//
+//	query   sum(rate(up{instance="a"}[1m]))
+//	evalTs  1778673800
+//	dataset 2 series of `up{}`, 6 + 3 points
+//	seed    11512813954976776230 (rapid v0.4.8)
+//
+// Reproduce locally:
+//
+//	CERBERUS_PROPERTY_FORCE=1 go test -tags chdb \
+//	    -run TestPromQL_Property_FromScratch \
+//	    ./test/property/... \
+//	    -rapid.seed=11512813954976776230 -v
+//
+// rapid persists the shrunk failing draw under
+// `test/property/testdata/rapid/TestPromQL_Property_FromScratch/`;
+// the matching `.fail` file is checked in so the property workflow
+// re-runs the same minimised reproducer once the production fix
+// lands and the t.Skip is lifted.
 //
 // TODO: until the RangeWindow emitter projects `Value` (Pascal) — or
 // `lowerRangeVectorCall` interposes a Project that renames `value`
-// → `Value` — this property test stays t.Skip'd. Set
-// `CERBERUS_PROPERTY_FORCE=1` to reproduce the remaining divergence
-// locally.
+// → `Value` — this property test stays t.Skip'd. Production fix is
+// out of scope for the test branch; tracked as a follow-up under the
+// RC3 property-driven bug backlog.
 package property_test
 
 import (
@@ -109,12 +136,13 @@ import (
 // skip rationale and how to remove it.
 func TestPromQL_Property_FromScratch(t *testing.T) {
 	if os.Getenv("CERBERUS_PROPERTY_FORCE") == "" {
-		t.Skip("property: skipped pending production-side fix for RangeWindow `value` → " +
-			"Aggregate `Value` case mismatch (sum(rate(...))/count(rate(...)) etc. fail at " +
-			"runtime with CH UNKNOWN_IDENTIFIER). The original rate-empty-window divergence " +
-			"was fixed (internal/chsql/range_window.go emitWindowedArray adds " +
-			"`WHERE length(window_vals) >= N`); this is a SEPARATE pre-existing bug " +
-			"surfaced by the same property test. Set CERBERUS_PROPERTY_FORCE=1 to reproduce.")
+		t.Skip("property: skipped pending production-side fix for RangeWindow " +
+			"`value` (lowercase) → Aggregate `Value` (Pascal) case mismatch in " +
+			"internal/chsql/range_window.go::emitWindowedArrayPairs. " +
+			"sum(rate(...))/count(rate(...)) etc. fail at CH execution with " +
+			"UNKNOWN_IDENTIFIER. Reproduce with CERBERUS_PROPERTY_FORCE=1 " +
+			"(seed 11512813954976776230, rapid v0.4.8). See package doc comment " +
+			"for the regression checkpoint + tracked TODO.")
 	}
 
 	cli := chclienttest.NewChDB(t)

--- a/test/property/testdata/rapid/TestPromQL_Property_FromScratch/TestPromQL_Property_FromScratch-20260514153710-913562.fail
+++ b/test/property/testdata/rapid/TestPromQL_Property_FromScratch/TestPromQL_Property_FromScratch-20260514153710-913562.fail
@@ -1,0 +1,66 @@
+# 2026/05/14 15:37:10.983290 [TestPromQL_Property_FromScratch] [rapid] draw dataset: property.Dataset{DDL:"CREATE OR REPLACE TABLE otel_metrics_gauge (\n    MetricName String,\n    Attributes Map(String, String),\n    TimeUnix DateTime64(9),\n    Value Float64\n) ENGINE = MergeTree ORDER BY (MetricName, TimeUnix);\nINSERT INTO otel_metrics_gauge VALUES ('up', map('instance', 'b'), toDateTime64('2026-05-13 12:00:00.000', 9), 0), ('up', map('instance', 'b'), toDateTime64('2026-05-13 12:00:15.000', 9), 0), ('up', map('instance', 'b'), toDateTime64('2026-05-13 12:00:30.000', 9), 0), ('up', map('instance', 'b'), toDateTime64('2026-05-13 12:00:45.000', 9), 0), ('up', map('instance', 'b'), toDateTime64('2026-05-13 12:01:00.000', 9), 0), ('up', map('instance', 'b'), toDateTime64('2026-05-13 12:01:15.000', 9), 0);\nINSERT INTO otel_metrics_gauge VALUES ('up', map('instance', 'a'), toDateTime64('2026-05-13 12:00:00.000', 9), 0), ('up', map('instance', 'a'), toDateTime64('2026-05-13 12:00:15.000', 9), 0), ('up', map('instance', 'a'), toDateTime64('2026-05-13 12:00:30.000', 9), 0);\n", Metrics:(*property.MetricsModel)(0x203d225961e0)}
+# 2026/05/14 15:37:10.983319 [TestPromQL_Property_FromScratch] [rapid] draw query: property.Query{String:"sum(rate(up{instance=\"a\"}[1m]))", EvalTs:1778673800}
+# 2026/05/14 15:37:11.011922 [TestPromQL_Property_FromScratch] property drift
+# --- query ---
+# sum(rate(up{instance="a"}[1m]))
+# evalTs=1778673800
+# --- dataset ---
+# series=2
+#   up{instance="b"} points=6
+#   up{instance="a"} points=3
+# 
+# --- diff ---
+# error mismatch: want_err=<nil> got_err=cerberus returned status="error" errorType="internal" err="engine: execute: chclienttest: query: Code: 47. DB::Exception: Unknown expression or function identifier `Value` in scope SELECT sum(Value) AS Value FROM (SELECT Attributes, if(length(window_vals) > 1, counter_delta / 60, 0.) AS value FROM (SELECT Attributes, arrayMap(p -> (p.2), window_pairs) AS window_vals, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> (x.2), window_pairs)), arrayPopFront(arrayMap(x -> (x.2), window_pairs)))) AS counter_delta FROM (SELECT Attributes, arrayFilter(p -> (((p.1) >= (now64(9) - toIntervalNanosecond(60000000000))) AND ((p.1) <= now64(9))), series_array) AS window_pairs FROM (SELECT Attributes, arraySort(groupArray((TimeUnix, Value))) AS series_array FROM (SELECT * FROM otel_metrics_gauge PREWHERE MetricName = 'up' WHERE (Attributes['instance']) = 'a') GROUP BY Attributes))) WHERE length(window_vals) >= 2). Maybe you meant: ['value']. (UNKNOWN_IDENTIFIER)"
+# 
+v0.4.8#11512813954976776230
+0x0
+0x0
+0x1
+0x0
+0x0
+0x0
+0x0
+0x0
+0x0
+0x1
+0x0
+0x6b74f03291620
+0x5
+0x0
+0x0
+0x0
+0x0
+0x0
+0x0
+0x0
+0x0
+0x0
+0x0
+0x0
+0x0
+0x0
+0x0
+0x0
+0x0
+0x0
+0x0
+0x0
+0x0
+0x38e38e38e38e4
+0x2
+0x0
+0x0
+0x0
+0x0
+0x0
+0x0
+0x0
+0x0
+0x1
+0x0
+0x0
+0x0
+0x0
+0x0
+0x6b74f03291620
+0x4


### PR DESCRIPTION
## Summary

- Ran `TestPromQL_Property_FromScratch` forced via `CERBERUS_PROPERTY_FORCE=1` (rapid N=100, `-tags chdb`, current `main`). It still fails on the same pre-existing RangeWindow `value` (lowercase) -> Aggregate `Value` (Pascal) case mismatch in `internal/chsql/range_window.go::emitWindowedArrayPairs` that the existing skip already cites — _not_ a new divergence.
- Tightened the skip rationale and captured the rapid-shrunk reproducer (seed `11512813954976776230`, rapid v0.4.8; query `sum(rate(up{instance="a"}[1m]))`, dataset `up{}` x2 series, evalTs `1778673800`) as an explicit regression checkpoint in the package doc comment.
- Checked in the rapid `.fail` artifact under `test/property/testdata/rapid/TestPromQL_Property_FromScratch/` so the same minimised draw replays deterministically once the production fix lands and the `t.Skip` is lifted.

## What this is NOT

**No production code changes.** Per task scope, the production fix (RangeWindow emitter projecting `Value` Pascal-cased, or a Project interposer renaming `value` -> `Value`) is tracked as a follow-up under the RC3 property-driven bug backlog. This PR is test-infrastructure-only — it sharpens the skip block, pins a deterministic reproducer, and leaves the production divergence for a separate PR.

## CH error captured in the regression checkpoint

```
Code: 47. DB::Exception: Unknown expression or function identifier `Value` in scope
SELECT sum(Value) AS Value FROM (SELECT Attributes, if(length(window_vals) > 1,
counter_delta / 60, 0.) AS value FROM ...). Maybe you meant: ['value']. (UNKNOWN_IDENTIFIER)
```

## Test plan

- [x] `go test -tags chdb -count=1 -v ./test/property/... -run TestPromQL_Property_FromScratch` (no `CERBERUS_PROPERTY_FORCE`) — skips cleanly with the new rationale message visible.
- [x] `CERBERUS_PROPERTY_FORCE=1 go test -tags chdb ./test/property/... -run TestPromQL_Property_FromScratch -rapid.seed=11512813954976776230 -rapid.checks=1 -v` — reproduces the same `UNKNOWN_IDENTIFIER` failure deterministically from the pinned seed.
- [ ] Required CI: `check` + `lint` (CGO-free; the skip keeps the chdb-tagged test inert).