### PR TITLE
fix(compatibility): real CH healthcheck + unmask job failure

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -32,9 +32,23 @@ jobs:
     name: prometheus/compliance
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # Informational until M6 — set up the harness now so each M1.x can use it,
-    # gate it on the required-status-checks list at RC1 cut.
-    continue-on-error: true
+    # NOTE: job-level `continue-on-error: true` was REMOVED here on
+    # purpose. Previously it combined with `if: always()` on Summarise
+    # / Upload to make every job-level failure (e.g. CH container
+    # unhealthy → `docker compose up` aborts) report a green workflow
+    # conclusion. 20+ consecutive main pushes ran red-at-job /
+    # green-at-workflow before this was caught.
+    #
+    # The new contract: the workflow conclusion MUST track the job
+    # conclusion. Summary + artifact upload still run on failure
+    # (`if: always()` on those steps), but the explicit
+    # "Fail job if compatibility step failed" step at the end
+    # re-raises a non-zero exit when the harness step diverged or
+    # crashed, so the workflow badge / GH Project status correctly
+    # turns red.
+    #
+    # Promoting this to a required PR check at RC1 cut is a separate
+    # decision tracked in docs/roadmap.md.
     steps:
       - uses: actions/checkout@v6
         with:
@@ -51,6 +65,11 @@ jobs:
           tool: just
 
       - name: Run compatibility harness
+        id: compat
+        # IMPORTANT: do NOT add `continue-on-error: true` here.
+        # We rely on this step's outcome to drive the workflow's
+        # red/green state. `id: compat` lets later steps inspect
+        # `steps.compat.outcome` without masking the failure.
         env:
           # The tester binary needs Go 1.21+; we already have it from setup-go.
           # The seed window anchors at 2026-05-11T00:00:00Z (see
@@ -70,7 +89,7 @@ jobs:
               unexpected_failures: ([.results[]? | select(.unexpectedFailure != null)] | length)
             }' harness/compatibility/report.json
           else
-            echo "no report produced"
+            echo "no report produced (harness step likely failed before tester ran)"
           fi
 
       - name: Upload report
@@ -81,3 +100,13 @@ jobs:
           path: harness/compatibility/report.json
           if-no-files-found: warn
           retention-days: 30
+
+      - name: Fail job if compatibility step failed
+        # Last step in the job. Re-raises the harness step's failure
+        # AFTER the summary and artifact have been emitted, so the
+        # workflow conclusion mirrors the harness outcome instead of
+        # being masked by `if: always()` housekeeping above.
+        if: always() && steps.compat.outcome == 'failure'
+        run: |
+          echo "::error title=compatibility suite failed::compatibility harness (steps.compat) exited non-zero — see the 'Run compatibility harness' step log and the uploaded compatibility-report artifact"
+          exit 1

--- a/harness/compatibility/docker-compose.yml
+++ b/harness/compatibility/docker-compose.yml
@@ -23,17 +23,30 @@ name: cerberus-compatibility
 
 services:
   clickhouse:
-    image: clickhouse/clickhouse-server:24.8-alpine
+    # Use the Ubuntu-base image, NOT -alpine. Per PR #245's finding,
+    # `clickhouse/clickhouse-server:24.8-alpine` on GH Actions runners
+    # stalls in the entrypoint script for 5+ min (never starts the
+    # server, never binds 8123). The Ubuntu-base variant boots in
+    # ~10-20s on the same runners. A future maintainer: do not
+    # innocently switch back to -alpine here without re-validating
+    # against the GH-runner musl/scheduling regression.
+    image: clickhouse/clickhouse-server:24.8
     environment:
       CLICKHOUSE_DB: otel
       CLICKHOUSE_USER: cerberus
       CLICKHOUSE_PASSWORD: cerberus
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: "1"
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:8123/ping"]
-      interval: 2s
-      timeout: 2s
-      retries: 30
+      # `clickhouse-client --query 'SELECT 1'` is more reliable than
+      # `wget /ping`: the HTTP listener (:8123) binds slightly before
+      # the SQL engine is ready to answer queries. Talking SQL over the
+      # local unix socket as the default user proves end-to-end
+      # readiness (matches the pattern PR #245 used for startup-bench).
+      test: ["CMD-SHELL", "clickhouse-client --query 'SELECT 1' 2>/dev/null || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 36
+      start_period: 30s
     ports:
       - "29000:9000"
       - "28123:8123"


### PR DESCRIPTION
## Summary

The compatibility lane has been silently failing for ~14 hours (20+ consecutive main pushes). RC1 exit criterion ("compatibility corpora pass") was silently unverified. **GA blocker.**

Two defects compounded:

1. **CH container never became healthy.** `harness/compatibility/docker-compose.yml` ran `clickhouse/clickhouse-server:24.8-alpine` with a `wget /ping` healthcheck. Per PR #245, the alpine variant stalls in its entrypoint script for 5+ min on GH Actions runners — never binds 8123, so the healthcheck never passes, so `docker compose up --wait` aborts with `dependency failed: container cerberus-compatibility-clickhouse-1 is unhealthy` and the harness step exits non-zero.

2. **Job-level failures were invisible at the workflow level.** `.github/workflows/compatibility.yml` had `continue-on-error: true` at the job level AND `if: always()` on Summarise / Upload. The combination caused the workflow conclusion to report GREEN despite the harness step failing — hiding the regression at the run-summary, branch-badge, and GH Projects level.

## Changes

### Fix 1 — CH actually healthy (`harness/compatibility/docker-compose.yml`)

- swap `clickhouse-server:24.8-alpine` → `clickhouse-server:24.8` (Ubuntu base; boots in ~10-20s on GH runners per PR #245)
- swap `wget /ping` healthcheck → `clickhouse-client --query 'SELECT 1'` over the local socket (matches PR #245's startup-bench pattern; proves the SQL engine, not just the HTTP listener, is ready)
- widen the poll budget to `start_period: 30s` + `36 × 5s` retries = ~3 min total, comfortably above the observed Ubuntu boot window
- inline comment captures why ` -alpine` is not safe here

### Fix 2 — failures visible again (`.github/workflows/compatibility.yml`)

- remove `continue-on-error: true` from the job
- give the harness step `id: compat` so later steps can inspect its outcome
- keep `if: always()` on Summarise / Upload so reports still publish on failure
- add a terminal `Fail job if compatibility step failed` step that re-raises the harness outcome AFTER housekeeping, so the workflow conclusion mirrors the job conclusion
- inline comment captures why `continue-on-error: true` was removed

New contract: **harness step failure → job failure → workflow failure → red badge.** No more `if: always()` masking.

## RC1 follow-up (deferred)

The repo's CLAUDE.md says *"Compatibility is the source of truth for PromQL."* At RC1 cut, branch protection should require the `compatibility / prometheus/compliance` check. That's a one-line `branch_protection` update on the maintainer's side after merging this — out of scope for this PR but mentioned in the workflow comments.

## Test plan

- [x] PR `check` + `lint` go green.
- [ ] Manually dispatch the workflow on this branch (`gh workflow run compatibility.yml --ref fix/compatibility-ch-healthcheck-visibility`); verify:
  - CH container becomes healthy in well under 180s
  - workflow conclusion mirrors the harness step's outcome (no more green-on-failure)
- [ ] After merge, the next main-push run is either truly green (suite passed) or correctly red (real divergence to fix) — never the previous green-but-broken state.