### PR TITLE
fix(compatibility): wire cerberus --version flag for docker healthcheck

### DIFF
--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -30,7 +30,30 @@ import (
 // Version is set at build time by goreleaser.
 var Version = "dev"
 
+// isVersionFlag reports whether argv requests a version dump. cerberus
+// is otherwise env-driven and ignores argv, but `--version` / `-v` /
+// `version` are wired so docker + k8s healthchecks can probe the
+// binary cheaply: the distroless runtime image has no shell, no wget,
+// and no curl, so invoking the binary itself is the only viable
+// healthcheck path. Exported via a function (not inlined in main) so
+// the same dispatch is verified by main_test.go.
+func isVersionFlag(args []string) bool {
+	if len(args) < 2 {
+		return false
+	}
+	switch args[1] {
+	case "--version", "-v", "version":
+		return true
+	}
+	return false
+}
+
 func main() {
+	if isVersionFlag(os.Args) {
+		fmt.Fprintln(os.Stdout, Version)
+		return
+	}
+
 	// Bootstrap logger used only until config.FromEnv returns and the
 	// configured logger replaces it. Text + info matches the configured
 	// defaults so the upgrade is invisible when env vars are unset.

--- a/cmd/cerberus/main_test.go
+++ b/cmd/cerberus/main_test.go
@@ -1,0 +1,37 @@
+package main
+
+import "testing"
+
+// TestIsVersionFlag pins the argv shapes recognized by the
+// `--version` pre-flight. The cerberus container in
+// harness/compatibility/docker-compose.yml uses this exact path as
+// its docker healthcheck because the distroless runtime image has no
+// shell / wget / curl; a regression here would silently re-break the
+// compatibility lane's "container ... is unhealthy" failure mode
+// (see PR #297 + follow-up).
+func TestIsVersionFlag(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{"empty argv (nil)", nil, false},
+		{"empty argv (slice)", []string{}, false},
+		{"binary only — server mode", []string{"cerberus"}, false},
+		{"long form --version", []string{"cerberus", "--version"}, true},
+		{"short form -v", []string{"cerberus", "-v"}, true},
+		{"subcommand-style version", []string{"cerberus", "version"}, true},
+		{"unrelated flag falls through", []string{"cerberus", "--help"}, false},
+		{"unrelated subcommand falls through", []string{"cerberus", "serve"}, false},
+		{"version with trailing junk still recognized", []string{"cerberus", "--version", "extra"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isVersionFlag(tc.args); got != tc.want {
+				t.Fatalf("isVersionFlag(%v) = %v, want %v", tc.args, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #297. PR #297 unmasked the compatibility lane:
- ClickHouse now boots healthy in ~6 s (Ubuntu image + `clickhouse-client` healthcheck)
- workflow conclusion now correctly tracks the job conclusion (no more `if: always()` masking)

…but the lane is **still red** because `docker compose up --wait cerberus` reports `container cerberus-compatibility-cerberus-1 is unhealthy` after 60 s.

## Root cause

`harness/compatibility/docker-compose.yml` has used this healthcheck since the harness was introduced:

```yaml
healthcheck:
  test: ["CMD", "/usr/local/bin/cerberus", "--version"]
```

…but `cerberus` has never recognized `--version`. `cmd/cerberus/main.go` ignored argv entirely and fell through to `config.FromEnv()` + a real server start. Inside the healthcheck context the binary therefore either:
- ran forever (server up, healthcheck hit its 2 s `timeout` retry-after-retry), or
- exited non-zero (config issue)

Either way the healthcheck never returned 0, so `depends_on: cerberus.condition: service_healthy` blocked.

This never surfaced before because:
1. Pre-#297, the job-level `continue-on-error: true` + step-level `if: always()` masked the failure entirely
2. Pre-#297, the CH healthcheck failed first, so cerberus's healthcheck never even got a chance to run

## Changes

- `cmd/cerberus/main.go`: add `isVersionFlag(args)` pre-flight that prints `Version` and exits 0 when argv[1] is `--version`, `-v`, or `version`. Short-circuits before logger / config / OTel setup so it's cheap.
- `cmd/cerberus/main_test.go`: pin every recognized shape (plus fall-through cases) so a future refactor can't quietly re-break the compatibility healthcheck. The test header references this PR + #297 so the link to the harness is discoverable.

## Why a flag, not a different healthcheck

The runtime image is `distroless/static-debian12:nonroot` — no shell, no wget, no curl. The only viable healthcheck path inside the container is to invoke the cerberus binary itself. The compose file's contract (`cerberus --version`) is therefore the cleanest fix; the cost is 15 lines of arg parsing.

## Test plan

- [x] PR `check` + `lint` go green (the new `TestIsVersionFlag` runs as part of `check`).
- [ ] After merge, the next main-push compatibility run is either:
  - truly green (CH healthy + cerberus healthy + tester reports zero diffs), or
  - correctly red with a real divergence report (CH healthy + cerberus healthy + tester reports legit PromQL gaps to file in `expected-failures.json`)
- [ ] No more `is unhealthy` failures in the run summary.