### PR TITLE
feat(optimizer): widen ProjectionPushdown + MVSubstitution; remove non-commutativity skips

### DIFF
--- a/internal/optimizer/mv_substitution.go
+++ b/internal/optimizer/mv_substitution.go
@@ -107,10 +107,6 @@ func (r *mvSubstitutionRule) Apply(n chplan.Node) (chplan.Node, bool) {
 	if !ok {
 		return n, false
 	}
-	scan, ok := rw.Input.(*chplan.Scan)
-	if !ok {
-		return n, false
-	}
 	if len(r.rollups) == 0 {
 		return n, false
 	}
@@ -119,6 +115,45 @@ func (r *mvSubstitutionRule) Apply(n chplan.Node) (chplan.Node, bool) {
 	// MetricsAggregate input). Those windows route through a different
 	// emitter and the rollup table doesn't help them.
 	if rw.ValueColumn == "" || rw.ValueColumn != r.baseValueColumn {
+		return n, false
+	}
+
+	// Match two shapes:
+	//
+	//  1. `RangeWindow(Scan)` — the seed pattern. Substitute directly.
+	//  2. `RangeWindow(Filter(Scan))` — the widened pattern. Safe iff
+	//     the Filter's predicate references ONLY series-identifying
+	//     bare-column GroupBy keys on the RangeWindow. Those columns
+	//     are preserved (with the same names) on the rollup table by
+	//     the upstream OTel exporter (the rollup MV's GROUP BY is the
+	//     base table's series-identity columns + the bucketed
+	//     timestamp). Any predicate touching the windowed value, the
+	//     timestamp, or a non-passthrough column would silently change
+	//     row counts when applied to a rolled-up table, so reject.
+	//
+	// Shape (2) is what `FilterRangeWindowTranspose` produces when it
+	// pushes a Filter under a RangeWindow — without this widening the
+	// `RangeWindow(Filter(Scan))` chain is order-dependent against
+	// the transpose rule. See `rule_interaction_test.go` Pair 27 for
+	// the commutativity check that this widening unlocks.
+	var (
+		scan       *chplan.Scan
+		filterNode *chplan.Filter
+	)
+	switch inner := rw.Input.(type) {
+	case *chplan.Scan:
+		scan = inner
+	case *chplan.Filter:
+		s, ok := inner.Input.(*chplan.Scan)
+		if !ok {
+			return n, false
+		}
+		if !filterIsRollupSafe(inner.Predicate, rw) {
+			return n, false
+		}
+		scan = s
+		filterNode = inner
+	default:
 		return n, false
 	}
 
@@ -147,10 +182,40 @@ func (r *mvSubstitutionRule) Apply(n chplan.Node) (chplan.Node, bool) {
 	// passes will re-narrow against the rollup's actual columns.
 	newScan.Columns = nil
 
+	var newInput chplan.Node = &newScan
+	if filterNode != nil {
+		// Preserve the safe Filter around the rewritten Scan. The
+		// predicate stays referring to the same series-identity column
+		// names, which the rollup table also exposes — see the doc
+		// comment above for why this is correct.
+		newFilter := *filterNode
+		newFilter.Input = &newScan
+		newInput = &newFilter
+	}
+
 	newRW := *rw
-	newRW.Input = &newScan
+	newRW.Input = newInput
 	newRW.ValueColumn = picked.ValueColumn
 	return &newRW, true
+}
+
+// filterIsRollupSafe reports whether every column the predicate
+// references is a bare series-identity key on the enclosing RangeWindow
+// (i.e. appears in `rw.GroupBy` as a `*chplan.ColumnRef` with no
+// qualifier). Predicates that touch the windowed value, the timestamp,
+// the per-sample value, or a non-GroupBy column return false — the rule
+// declines rather than risk emitting a substitution that changes row
+// counts against the rolled-up table.
+//
+// Mirrors the safety reasoning in `seriesIdentifyingColumns` used by
+// `FilterRangeWindowTranspose`: the two rules agree on which predicates
+// are safe to live under a RangeWindow's row shape.
+func filterIsRollupSafe(pred chplan.Expr, rw *chplan.RangeWindow) bool {
+	passthrough := seriesIdentifyingColumns(rw)
+	if passthrough == nil {
+		return false
+	}
+	return onlyReferencesPassthrough(pred, passthrough)
 }
 
 // rollupApplies checks the four safety conditions documented on

--- a/internal/optimizer/optimizer_test.go
+++ b/internal/optimizer/optimizer_test.go
@@ -387,6 +387,92 @@ var inputs = map[string]chplan.Node{
 		ValueColumn:     "Value",
 		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
 	},
+
+	// pushdown_through_filter: Project(Filter(Scan)) — pushdown's
+	// widened pattern narrows the inner Scan's column list to the
+	// union of refs(Projections) ∪ refs(Filter.Predicate). The
+	// Filter stays in place between the (narrowed) Scan and the
+	// Project. Locks the v0.2 widening of ProjectionPushdown that
+	// removes the rule-interaction skip with FilterProjectTranspose.
+	"pushdown_through_filter": &chplan.Project{
+		Input: &chplan.Filter{
+			Input: &chplan.Scan{Table: "otel_metrics_gauge"},
+			Predicate: &chplan.Binary{
+				Op:    chplan.OpEq,
+				Left:  &chplan.ColumnRef{Name: "MetricName"},
+				Right: &chplan.LitString{V: "up"},
+			},
+		},
+		Projections: []chplan.Projection{
+			{Expr: &chplan.ColumnRef{Name: "Value"}, Alias: "v"},
+			{Expr: &chplan.ColumnRef{Name: "TimeUnix"}, Alias: "t"},
+		},
+	},
+
+	// mv_sub_through_safe_filter: Filter(RangeWindow(Scan), pred)
+	// where pred references only the series-identity GroupBy column
+	// (`Attributes`). After predicate-pushdown transposes the Filter
+	// under the RangeWindow (`RangeWindow(Filter(Scan), pred)`), the
+	// widened MVSubstitution pattern matches and substitutes the
+	// rollup table + ValueColumn. Locks the v0.2 widening of
+	// MVSubstitution that removes the rule-interaction skip with
+	// FilterRangeWindowTranspose.
+	"mv_sub_through_safe_filter": &chplan.Filter{
+		Input: &chplan.RangeWindow{
+			Input:           &chplan.Scan{Table: "otel_metrics_sum"},
+			Func:            "sum_over_time",
+			Range:           time.Hour,
+			Step:            5 * time.Minute,
+			TimestampColumn: "TimeUnix",
+			ValueColumn:     "Value",
+			GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+		},
+		Predicate: &chplan.Binary{
+			Op: chplan.OpEq,
+			Left: &chplan.MapAccess{
+				Map: &chplan.ColumnRef{Name: "Attributes"},
+				Key: &chplan.LitString{V: "job"},
+			},
+			Right: &chplan.LitString{V: "api"},
+		},
+	},
+
+	// mv_sub_blocked_by_unsafe_filter: RangeWindow(Filter(Scan), pred)
+	// where pred references the per-sample `Value` column — NOT a
+	// series-identity GroupBy column. The widened MVSubstitution must
+	// refuse: applying the predicate against the rollup table would
+	// look up a column whose semantics (a per-sample value) don't
+	// match the rolled-up shape. Pins the safety guard on the widened
+	// MVSubstitution pattern.
+	//
+	// Note. The input starts already in `RangeWindow(Filter(Scan))`
+	// shape rather than `Filter(RangeWindow(Scan))`. If the test
+	// started with the outer-Filter shape, predicate-pushdown's
+	// FilterRangeWindowTranspose would decline (Value is not
+	// passthrough), the Filter would stay above the RangeWindow, and
+	// MVSubstitution's seed `RangeWindow(Scan)` pattern would then
+	// substitute the rollup — which is correct, because the Filter is
+	// above the RangeWindow and applies to the windowed output, not
+	// the rolled-up rows. The case this fixture pins is the orthogonal
+	// one: the Filter is *between* the RangeWindow and the Scan, so
+	// it would apply to the rollup's row shape, where `Value` doesn't
+	// exist with the same semantics.
+	"mv_sub_blocked_by_unsafe_filter": &chplan.RangeWindow{
+		Input: &chplan.Filter{
+			Input: &chplan.Scan{Table: "otel_metrics_sum"},
+			Predicate: &chplan.Binary{
+				Op:    chplan.OpGt,
+				Left:  &chplan.ColumnRef{Name: "Value"},
+				Right: &chplan.LitFloat{V: 0},
+			},
+		},
+		Func:            "sum_over_time",
+		Range:           time.Hour,
+		Step:            5 * time.Minute,
+		TimestampColumn: "TimeUnix",
+		ValueColumn:     "Value",
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+	},
 }
 
 func TestOptimizer(t *testing.T) {

--- a/internal/optimizer/projection_pushdown.go
+++ b/internal/optimizer/projection_pushdown.go
@@ -7,13 +7,28 @@ import (
 )
 
 // ProjectionPushdown narrows a Scan's column list to the union of columns
-// referenced by an immediately-enclosing Project. With the OTel CH schema's
-// wide tables (~10+ columns including resource attributes), this is a real
-// win: only the columns the plan actually consumes get read.
+// referenced by an immediately-enclosing Project (and any intervening
+// Filter). With the OTel CH schema's wide tables (~10+ columns including
+// resource attributes), this is a real win: only the columns the plan
+// actually consumes get read.
 //
-// v0.1 limitation: only fires for `Project(Scan)` directly. The
-// `Project(Filter(Scan))` shape will be handled once we have a column-set
-// analysis pass that flows down through Filter/Aggregate/RangeWindow.
+// Two shapes match:
+//
+//  1. `Project(Scan)` — narrow Scan.Columns to the column refs the
+//     Projections touch.
+//  2. `Project(Filter(Scan))` — push the projection THROUGH the Filter
+//     down to the Scan. Safe iff Scan.Columns is empty (the Filter's
+//     predicate evaluates on Scan's row shape, which after narrowing
+//     must still include every column the predicate touches). The
+//     narrowed Scan.Columns is the UNION of refs(Projections) ∪
+//     refs(Filter.Predicate); the Filter stays in place between the
+//     Project and the (now-narrowed) Scan.
+//
+// Shape (2) is what `FilterProjectTranspose` produces when it pushes a
+// Filter under a Project — without this widening the
+// `Project(Filter(Scan))` chain is order-dependent against the
+// transpose rule. See `rule_interaction_test.go` Pair 21 for the
+// commutativity check that this widening unlocks.
 type ProjectionPushdown struct{}
 
 func (ProjectionPushdown) Name() string { return "projection-pushdown" }
@@ -23,22 +38,92 @@ func (ProjectionPushdown) Apply(n chplan.Node) (chplan.Node, bool) {
 	if !ok {
 		return n, false
 	}
-	s, ok := p.Input.(*chplan.Scan)
-	if !ok || len(s.Columns) > 0 {
+	switch child := p.Input.(type) {
+	case *chplan.Scan:
+		return applyProjectScan(p, child)
+	case *chplan.Filter:
+		return applyProjectFilterScan(p, child)
+	default:
 		return n, false
 	}
+}
 
+// applyProjectScan handles the seed `Project(Scan)` shape.
+func applyProjectScan(p *chplan.Project, s *chplan.Scan) (chplan.Node, bool) {
+	if len(s.Columns) > 0 {
+		return p, false
+	}
 	cols := referencedColumns(p.Projections)
 	if len(cols) == 0 {
-		return n, false
+		return p, false
 	}
-
 	newScan := *s
 	newScan.Columns = cols
-
 	newProject := *p
 	newProject.Input = &newScan
 	return &newProject, true
+}
+
+// applyProjectFilterScan handles `Project(Filter(Scan))`: push the
+// projection's column set THROUGH the Filter down to the Scan, unioning
+// in any columns the Filter's predicate references so the predicate
+// remains evaluable on the narrowed row shape.
+func applyProjectFilterScan(p *chplan.Project, f *chplan.Filter) (chplan.Node, bool) {
+	s, ok := f.Input.(*chplan.Scan)
+	if !ok || len(s.Columns) > 0 {
+		return p, false
+	}
+	projCols := referencedColumns(p.Projections)
+	if len(projCols) == 0 {
+		return p, false
+	}
+	cols := unionSortedColumns(projCols, predicateColumns(f.Predicate))
+
+	newScan := *s
+	newScan.Columns = cols
+	newFilter := *f
+	newFilter.Input = &newScan
+	newProject := *p
+	newProject.Input = &newFilter
+	return &newProject, true
+}
+
+// predicateColumns returns the set of ColumnRef names the predicate
+// references, deduped and sorted. Bare-column refs only — qualified
+// refs (joins, not in scope here) are not expected on a Filter directly
+// over a Scan.
+func predicateColumns(e chplan.Expr) []string {
+	seen := map[string]struct{}{}
+	walkExpr(e, func(sub chplan.Expr) {
+		if cr, ok := sub.(*chplan.ColumnRef); ok {
+			seen[cr.Name] = struct{}{}
+		}
+	})
+	out := make([]string, 0, len(seen))
+	for name := range seen {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// unionSortedColumns merges two already-sorted, deduped column-name
+// slices into a single sorted+deduped slice. Stable, deterministic
+// output keeps Scan.Columns reproducible across runs.
+func unionSortedColumns(a, b []string) []string {
+	seen := make(map[string]struct{}, len(a)+len(b))
+	for _, n := range a {
+		seen[n] = struct{}{}
+	}
+	for _, n := range b {
+		seen[n] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for n := range seen {
+		out = append(out, n)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // referencedColumns returns the set of ColumnRef names referenced anywhere

--- a/internal/optimizer/rule_interaction_test.go
+++ b/internal/optimizer/rule_interaction_test.go
@@ -513,29 +513,37 @@ func TestRuleInteraction_FilterProjectTranspose_x_FilterRangeWindowTranspose(t *
 
 // --- Pair 21: FilterProjectTranspose × ProjectionPushdown.
 //
-// Order-dependent: ProjectionPushdown only matches `Project(Scan)`
-// directly (projection_pushdown.go's documented v0.1 limitation
-// — see the package comment: "The `Project(Filter(Scan))` shape
-// will be handled once we have a column-set analysis pass that
-// flows down through Filter/Aggregate/RangeWindow").
+// Commutativity unlocked by widening `ProjectionPushdown` to match
+// `Project(Filter(Scan))` in addition to `Project(Scan)` (see
+// projection_pushdown.go). With that widening:
 //
-// Consequence on a `Filter(Project(Scan))` plan:
 //   - (Pushdown, TransposeFilter): pushdown narrows the inner Scan
 //     before transpose moves the Filter; final shape is
-//     `Project([cols], Filter(Scan(narrowed), pred))`.
+//     `Project([cols], Filter(Scan(narrowed=projCols∪predCols), pred))`.
 //   - (TransposeFilter, Pushdown): transpose first leaves
-//     `Project(Filter(Scan))`, which pushdown's pattern doesn't
-//     match. Final shape is
-//     `Project([cols], Filter(Scan(empty cols), pred))`.
+//     `Project(Filter(Scan))`; the widened pushdown then narrows the
+//     inner Scan against `projCols ∪ predCols`. Final shape:
+//     `Project([cols], Filter(Scan(narrowed=projCols∪predCols), pred))`.
 //
-// The two converged trees are semantically equivalent (both emit
-// the same rows) but structurally divergent — Scan.Columns differs.
-// This is the canonical "pushdown limitation" gap; we t.Skip with
-// a TODO so the test surfaces the moment pushdown grows the wider
-// pattern match.
+// The two final trees are now structurally identical because both
+// orderings narrow the Scan to the same union set; the predicate stays
+// in the Filter slot above the Scan in both.
 func TestRuleInteraction_FilterProjectTranspose_x_ProjectionPushdown(t *testing.T) {
 	t.Parallel()
-	t.Skip("ProjectionPushdown's `Project(Scan)`-only match makes this pair order-dependent; see projection_pushdown.go limitation note + this test's package comment for the design rationale. Unskip once ProjectionPushdown handles `Project(Filter(Scan))`.")
+	plan := &chplan.Filter{
+		Input: &chplan.Project{
+			Input: &chplan.Scan{Table: "otel_metrics_gauge"},
+			Projections: []chplan.Projection{
+				{Expr: &chplan.ColumnRef{Name: "MetricName"}},
+				{Expr: &chplan.ColumnRef{Name: "Value"}},
+			},
+		},
+		Predicate: labelFilter("MetricName", "up"),
+	}
+	twoRuleConverge(t, "proj-transpose×proj-pushdown", plan,
+		optimizer.FilterProjectTranspose(),
+		optimizer.ProjectionPushdown{},
+	)
 }
 
 // --- Pair 22: FilterProjectTranspose × MVSubstitution.
@@ -659,11 +667,12 @@ func TestRuleInteraction_FilterRangeWindowTranspose_x_ProjectionPushdown(t *test
 
 // --- Pair 27: FilterRangeWindowTranspose × MVSubstitution.
 //
-// Order-dependent: MVSubstitution's match pattern requires
-// `RangeWindow(Scan)` with Scan as the immediate child of the
-// RangeWindow. Once FilterRangeWindowTranspose has pushed a Filter
-// under the RangeWindow, the inner shape becomes
-// `RangeWindow(Filter(Scan))` and MVSubstitution can no longer fire.
+// Commutativity unlocked by widening `MVSubstitution` to match
+// `RangeWindow(Filter(Scan))` in addition to `RangeWindow(Scan)`
+// (see mv_substitution.go). The Filter is required to reference only
+// series-identity columns on the RangeWindow's `GroupBy` slot —
+// columns the rollup table preserves with the same names — so the
+// rewrite keeps the Filter alive around the substituted Scan.
 //
 // On a `Filter(RangeWindow(Scan), pred=Attributes=v1)` plan:
 //   - (MV, RWTranspose): MV substitutes Scan.Table → rollup (and
@@ -671,23 +680,32 @@ func TestRuleInteraction_FilterRangeWindowTranspose_x_ProjectionPushdown(t *test
 //     Filter under. Final shape:
 //     `RW(Filter(Scan(rollup), pred))` with ValueColumn="Sum".
 //   - (RWTranspose, MV): RWTranspose pushes Filter under first,
-//     leaving `RW(Filter(Scan))`. MV's pattern doesn't match
-//     because rw.Input is Filter, not Scan. Final shape:
-//     `RW(Filter(Scan(base), pred))` with ValueColumn="Value".
+//     leaving `RW(Filter(Scan(base)), pred)`. MV's widened pattern
+//     matches — `pred=Attributes=v1` is rollup-safe (Attributes is
+//     a series-identity GroupBy column) — and substitutes the inner
+//     Scan + RangeWindow.ValueColumn. Final shape:
+//     `RW(Filter(Scan(rollup), pred))` with ValueColumn="Sum".
 //
-// Both trees are *semantically* equivalent against the base table
-// (no rollup substitution happens in order 2), but Order 1 is
-// strictly cheaper. The optimizer's default batch ordering
-// (predicate-pushdown → mv-substitution) deliberately runs
-// transposes FIRST, then mv-sub — which means in practice the
-// default driver hits Order 2 unless the predicate doesn't push.
-//
-// t.Skip with a TODO so the test surfaces once MVSubstitution
-// grows a wider pattern (e.g. matching `RangeWindow(Filter(Scan))`
-// and lifting the Filter when substituting).
+// Both orderings converge to the same tree.
 func TestRuleInteraction_FilterRangeWindowTranspose_x_MVSubstitution(t *testing.T) {
 	t.Parallel()
-	t.Skip("MVSubstitution's `RangeWindow(Scan)`-only match makes this pair order-dependent against a transposed Filter (`RangeWindow(Filter(Scan))` blocks the substitution). See mv_substitution.go's first-step guard for the design constraint; unskip once MVSubstitution supports the wider pattern.")
+	rw := &chplan.RangeWindow{
+		Input:           &chplan.Scan{Table: "otel_metrics_sum"},
+		Func:            "sum_over_time",
+		Range:           time.Hour,
+		Step:            5 * time.Minute,
+		TimestampColumn: "TimeUnix",
+		ValueColumn:     "Value",
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+	}
+	plan := &chplan.Filter{
+		Input:     rw,
+		Predicate: labelFilter("Attributes", "v1"),
+	}
+	twoRuleConverge(t, "rw-transpose×mv-sub", plan,
+		optimizer.FilterRangeWindowTranspose(),
+		optimizer.MVSubstitution([]schema.Rollup{sumRollupForInteraction}, "Value"),
+	)
 }
 
 // --- Pair 28: ProjectionPushdown × MVSubstitution.

--- a/test/spec/optimizer/filter_project_transpose_passes.txtar
+++ b/test/spec/optimizer/filter_project_transpose_passes.txtar
@@ -1,11 +1,11 @@
 -- optimized --
-SELECT `MetricName`, `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+SELECT `MetricName`, `Value` FROM (SELECT `MetricName`, `Value` FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
 -- unoptimized --
 SELECT * FROM (SELECT `MetricName`, `Value` FROM (SELECT * FROM `otel_metrics_gauge`)) WHERE (`MetricName` = ?)
 -- chplan_optimized --
 Project [MetricName, Value]
   Filter predicate=(MetricName = "up")
-    Scan(otel_metrics_gauge)
+    Scan(otel_metrics_gauge, columns=[MetricName, Value])
 -- chplan_unoptimized --
 Filter predicate=(MetricName = "up")
   Project [MetricName, Value]

--- a/test/spec/optimizer/mv_sub_blocked_by_unsafe_filter.txtar
+++ b/test/spec/optimizer/mv_sub_blocked_by_unsafe_filter.txtar
@@ -1,0 +1,12 @@
+-- unoptimized --
+SELECT `Attributes`, arraySum(window_vals) AS `value` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) >= now64(9) - toIntervalNanosecond(3600000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`Value` > ?)) GROUP BY `Attributes`))) WHERE length(`window_vals`) >= 1
+-- optimized --
+SELECT `Attributes`, arraySum(window_vals) AS `value` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) >= now64(9) - toIntervalNanosecond(3600000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`Value` > ?)) GROUP BY `Attributes`))) WHERE length(`window_vals`) >= 1
+-- chplan_unoptimized --
+RangeWindow func=sum_over_time range=1h0m0s step=5m0s ts=TimeUnix value=Value groupBy=[Attributes]
+  Filter predicate=(Value > 0)
+    Scan(otel_metrics_sum)
+-- chplan_optimized --
+RangeWindow func=sum_over_time range=1h0m0s step=5m0s ts=TimeUnix value=Value groupBy=[Attributes]
+  Filter predicate=(Value > 0)
+    Scan(otel_metrics_sum)

--- a/test/spec/optimizer/mv_sub_through_safe_filter.txtar
+++ b/test/spec/optimizer/mv_sub_through_safe_filter.txtar
@@ -1,0 +1,12 @@
+-- unoptimized --
+SELECT * FROM (SELECT `Attributes`, arraySum(window_vals) AS `value` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) >= now64(9) - toIntervalNanosecond(3600000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_sum`) GROUP BY `Attributes`))) WHERE length(`window_vals`) >= 1) WHERE (`Attributes`[?] = ?)
+-- optimized --
+SELECT `Attributes`, arraySum(window_vals) AS `value` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) >= now64(9) - toIntervalNanosecond(3600000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Sum`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_sum_5m` WHERE (`Attributes`[?] = ?)) GROUP BY `Attributes`))) WHERE length(`window_vals`) >= 1
+-- chplan_unoptimized --
+Filter predicate=(Attributes["job"] = "api")
+  RangeWindow func=sum_over_time range=1h0m0s step=5m0s ts=TimeUnix value=Value groupBy=[Attributes]
+    Scan(otel_metrics_sum)
+-- chplan_optimized --
+RangeWindow func=sum_over_time range=1h0m0s step=5m0s ts=TimeUnix value=Sum groupBy=[Attributes]
+  Filter predicate=(Attributes["job"] = "api")
+    Scan(otel_metrics_sum_5m)

--- a/test/spec/optimizer/pushdown_through_filter.txtar
+++ b/test/spec/optimizer/pushdown_through_filter.txtar
@@ -1,0 +1,12 @@
+-- unoptimized --
+SELECT `Value` AS `v`, `TimeUnix` AS `t` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+-- optimized --
+SELECT `Value` AS `v`, `TimeUnix` AS `t` FROM (SELECT `MetricName`, `TimeUnix`, `Value` FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))
+-- chplan_unoptimized --
+Project [Value AS v, TimeUnix AS t]
+  Filter predicate=(MetricName = "up")
+    Scan(otel_metrics_gauge)
+-- chplan_optimized --
+Project [Value AS v, TimeUnix AS t]
+  Filter predicate=(MetricName = "up")
+    Scan(otel_metrics_gauge, columns=[MetricName, TimeUnix, Value])


### PR DESCRIPTION
## Summary

GA blocker — eliminates the 2 `t.Skip` calls in `internal/optimizer/rule_interaction_test.go` by **widening** the underlying rule patterns.

- **ProjectionPushdown** now matches `Project(Filter(Scan))` in addition to `Project(Scan)`. Scan.Columns is narrowed to `refs(Projections) union refs(Filter.Predicate)` so the predicate stays evaluable.
- **MVSubstitution** now matches `RangeWindow(Filter(Scan))` in addition to `RangeWindow(Scan)`. The Filter is preserved around the rewritten rollup Scan iff its predicate references only bare series-identity GroupBy keys (same passthrough check as `FilterRangeWindowTranspose`); predicates that touch the windowed value, the per-sample timestamp, or any non-GroupBy column reject the substitution.
- Both widenings unlock previously order-dependent rule pairs. The 2 `t.Skip` lines in `rule_interaction_test.go` (Pair 21 + Pair 27) are gone; the tests now run live and converge to the same tree in both orderings.
- 3 new TXTAR fixtures land under `test/spec/optimizer/`:
  - `pushdown_through_filter.txtar` — positive Pushdown widening.
  - `mv_sub_through_safe_filter.txtar` — positive MV-sub widening (safe Filter on `Attributes`).
  - `mv_sub_blocked_by_unsafe_filter.txtar` — negative MV-sub safety guard (Filter on `Value` blocks).
- `filter_project_transpose_passes.txtar` is updated to reflect the now-narrowed `Scan.Columns` (the prior fixture captured the pre-widening limitation).

No `t.Skip` calls added. All 28 rule-interaction tests pass; full repo test suite green.

## Test plan
- [x] `go test ./internal/optimizer/...` passes
- [x] `go test ./...` passes (no regressions outside optimizer)
- [x] No `t.Skip` calls anywhere in `rule_interaction_test.go`
- [x] 3 new fixtures land + 1 existing fixture updated to reflect widening

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>