### PR TITLE
fix(compatibility): use upstream tester's current CLI + drop || true mask

### DIFF
--- a/harness/compatibility/scripts/run-compatibility.sh
+++ b/harness/compatibility/scripts/run-compatibility.sh
@@ -19,6 +19,18 @@
 #   TESTER_QUERIES    queries yaml (default: upstream/promql/promql-test-queries.yml)
 #   TESTER_END_TIME   compatibility end timestamp (default: 2026-05-11T01:00:00Z)
 #   TESTER_RANGE      range in seconds (default: 3600 = 1h, matches seed window)
+#
+# Upstream tester invocation (post-PR #298 / #300 audit):
+#   The upstream `promql-compliance-tester` only accepts `-config-file`
+#   (repeatable), `-output-format`, `-output-html-template`,
+#   `-output-passing`, `-query-parallelism`. Older legacy flags
+#   `-query-file`, `-end`, `-range` were silently rejected with
+#   "flag provided but not defined" — the script previously masked
+#   that with `|| true`, so the suite produced a zero-byte report and
+#   the workflow reported success despite never running a single query.
+#   The flags now flow through repeated `-config-file` args; time
+#   parameters are injected via a generated overlay yaml so this stays
+#   driven from the workflow env.
 
 set -eu -o pipefail
 
@@ -40,13 +52,35 @@ TESTER_DIR="$ROOT_DIR/upstream/promql/cmd/promql-compliance-tester"
 TESTER_BIN="$ROOT_DIR/upstream/promql/cmd/promql-compliance-tester/promql-compliance-tester"
 (cd "$TESTER_DIR" && go build -o promql-compliance-tester .)
 
+# Materialise the time-window overlay. The upstream tester reads
+# `query_time_parameters.end_time` + `range_in_seconds` from one of
+# its `-config-file` inputs (it concatenates all of them before YAML
+# parsing). Keeping the overlay ephemeral keeps test-cerberus.yml
+# clean — that file declares stable wiring (URLs + tweaks); the
+# overlay carries CI-volatile values (END_TIME / RANGE) which are
+# expected to differ per local invocation and per CI dispatch.
+OVERLAY=$(mktemp -t cerberus-compat-overlay.XXXXXX.yml)
+trap 'rm -f "$OVERLAY"' EXIT
+cat > "$OVERLAY" <<EOF
+query_time_parameters:
+  end_time: '${END_TIME}'
+  range_in_seconds: ${RANGE}
+EOF
+
 echo "==> running tester"
+# Note: NO `|| true` here. A non-zero exit from the tester is meaningful:
+#   - flag parsing / config errors (exit 2) → real harness bug
+#   - per-query divergences are emitted INSIDE the JSON report, not via
+#     exit code — the tester exits 0 even when individual queries
+#     diverge, so we lose no signal by failing-fast on a non-zero exit.
+# Stdout (the JSON report) and stderr (operator-readable log lines from
+# the tester) are split so the report file stays parseable while errors
+# remain visible in CI logs.
 "$TESTER_BIN" \
     -config-file "$ROOT_DIR/test-cerberus.yml" \
-    -query-file "$QUERIES" \
-    -end "$END_TIME" \
-    -range "${RANGE}s" \
-    -output-format json > "$OUTPUT" || true
+    -config-file "$QUERIES" \
+    -config-file "$OVERLAY" \
+    -output-format json > "$OUTPUT"
 
 echo "==> report written to $OUTPUT"
 echo "==> summary:"


### PR DESCRIPTION
## Summary

Third and (likely) final masking layer in the compatibility lane. PRs #297 and #298 unmasked the infra side: CH boots healthy, cerberus passes its docker healthcheck, workflow conclusion mirrors job conclusion. With infra working, the **previous green-on-failure run** (https://github.com/tsouza/cerberus/actions/runs/25870414440) revealed the next layer:

```
==> running tester
flag provided but not defined: -query-file
Usage of .../promql-compliance-tester:
  -config-file value
  -output-format string
  ...
==> report written to .../report.json
==> summary:
==> tearing down
```

i.e. **zero queries ran**, the "report" was a zero-byte file, and the script still exited 0. The workflow reported success.

## Root causes

`harness/compatibility/scripts/run-compatibility.sh`:

1. **Stale CLI flags.** The script passed `-query-file`, `-end`, `-range`, but the upstream `promql-compliance-tester` only accepts `-config-file` (repeatable), `-output-format`, `-output-html-template`, `-output-passing`, `-query-parallelism`. Test cases and time params now flow through YAML configs, not flags.

2. **`|| true` swallowing the tester's failure.** The call was

   ```bash
   "$TESTER_BIN" ... > "$OUTPUT" || true
   ```

   so a "flag not defined" exit was swallowed silently. Combined with the previous workflow-level masking, the harness produced an empty file and the suite reported success without ever evaluating a query.

## Changes

`harness/compatibility/scripts/run-compatibility.sh`:

- pass `test-cerberus.yml` + `promql-test-queries.yml` + an ephemeral overlay yaml (all via repeated `-config-file`; upstream concatenates them before YAML parsing)
- drop `-query-file`, `-end`, `-range` (no longer flags)
- materialise the overlay from `TESTER_END_TIME` / `TESTER_RANGE` env vars so the workflow's tuning surface (already wired in `compatibility.yml`) stays intact; the overlay is `mktemp` + `trap rm -f` so we don't litter the repo with a CI-volatile file
- remove `|| true` from the tester invocation. Upstream emits per-query divergences **inside** the JSON report and exits 0 even when individual queries diverge — so a non-zero exit unambiguously means "harness bug" (flag parse / config / connect) and must propagate to the workflow

The script's header comment now captures the rationale referencing #297 + #298 + this PR so a future maintainer doesn't innocently re-add `|| true` or a removed flag.

## Why this needed a third PR

The earlier two PRs surface this failure mode. Without #297 + #298, the workflow reported green even with the tester broken; with them, this PR's failure mode would have been a real visible red on `main` 30 minutes ago and forced a fix. The three PRs are independent and each gates the next.

## Test plan

- [x] PR `check` + `lint` go green (no Go code touched).
- [ ] After merge, the next main-push compatibility run reports a non-zero `total` in the Summarise step (proving queries actually ran) and a real diff/passed breakdown.
- [ ] If the tester surfaces legitimate PromQL gaps now that it actually runs, follow-ups go in `expected-failures.json` with the upstream-vs-CH semantic rationale (per CLAUDE.md).