### PR TITLE
test: eliminate 4 misc t.Skips (chaos x 2, lifecycle, shadow experimental)

### DIFF
--- a/harness/compatibility/shadow/promql_shadow_test.go
+++ b/harness/compatibility/shadow/promql_shadow_test.go
@@ -678,14 +678,14 @@ func promqlRangeFnCases() []promqlShadowCase {
 		},
 		{
 			name: "holt_winters_node_load1_api_0",
-			// holt_winters was renamed to double_exponential_smoothing in Prometheus
-			// 3.x and is gated behind EnableExperimentalFunctions, which the local
-			// shim does not toggle on (intentionally — cerberus inherits the same
-			// default). Skip with a clear note; reinstate once cerberus exposes the
-			// feature flag.
-			skipReason: "double_exponential_smoothing is experimental; tracked alongside Prometheus 3.x feature-flag rollout",
-			query:      `double_exponential_smoothing(node_load1{job="api",instance="0"}[5m], 0.8, 0.3)`,
-			evalAt:     promqlInstantTS,
+			// holt_winters was renamed to double_exponential_smoothing in
+			// Prometheus 3.x and is gated behind EnableExperimentalFunctions.
+			// The local promshim engine flips that flag on (see
+			// internal/promshim/local/engine.go) so the shadow oracle stays
+			// aligned with cerberus's own parser, which already accepts
+			// experimental functions (internal/api/prom.New).
+			query:  `double_exponential_smoothing(node_load1{job="api",instance="0"}[5m], 0.8, 0.3)`,
+			evalAt: promqlInstantTS,
 			expected: VectorResult{Series: []Series{
 				promqlAt5m(21, "job", "api", "instance", "0"),
 			}},

--- a/internal/chclient/chaos_test.go
+++ b/internal/chclient/chaos_test.go
@@ -110,6 +110,53 @@ func (r *chaosRows) Close() error {
 	return nil
 }
 
+// chaosConn is a fault-injecting driver.Conn used to drive the chaos
+// path through QueryCursor / Query / Exec without standing up a real
+// CH server. The only knob currently exercised is queryErr — every
+// Query / QueryRow / Select / Exec call surfaces it. Extend the knob
+// set if a future test needs a happy-path Query + chaotic Rows.
+type chaosConn struct {
+	queryErr error
+}
+
+func (c *chaosConn) Contributors() []string { return nil }
+
+func (c *chaosConn) ServerVersion() (*driver.ServerVersion, error) {
+	return &driver.ServerVersion{}, nil
+}
+
+func (c *chaosConn) Select(context.Context, any, string, ...any) error { return c.queryErr }
+
+func (c *chaosConn) Query(context.Context, string, ...any) (driver.Rows, error) {
+	if c.queryErr != nil {
+		return nil, c.queryErr
+	}
+	return &chaosRows{}, nil
+}
+
+func (c *chaosConn) QueryRow(context.Context, string, ...any) driver.Row {
+	return chaosRow{c.queryErr}
+}
+
+func (c *chaosConn) PrepareBatch(context.Context, string, ...driver.PrepareBatchOption) (driver.Batch, error) {
+	return nil, c.queryErr
+}
+
+func (c *chaosConn) Exec(context.Context, string, ...any) error { return c.queryErr }
+
+func (c *chaosConn) AsyncInsert(context.Context, string, bool, ...any) error { return c.queryErr }
+func (c *chaosConn) Ping(context.Context) error                              { return c.queryErr }
+func (c *chaosConn) Stats() driver.Stats                                     { return driver.Stats{} }
+func (c *chaosConn) Close() error                                            { return nil }
+
+// chaosRow satisfies driver.Row for chaosConn.QueryRow; we never look at
+// its decoded value — the tests only consume the error path.
+type chaosRow struct{ err error }
+
+func (r chaosRow) Err() error           { return r.err }
+func (r chaosRow) Scan(...any) error    { return r.err }
+func (r chaosRow) ScanStruct(any) error { return r.err }
+
 func mkSamples(n int) []Sample {
 	ts := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
 	out := make([]Sample, n)
@@ -273,18 +320,24 @@ func TestCursor_CloseFreesRowsHandle(t *testing.T) {
 
 // TestQueryCursor_OpenError — when the underlying driver returns an
 // error from conn.Query (e.g. connection refused), QueryCursor must
-// propagate it and the execute span must be closed.
-//
-// Drives this through a stub Client whose conn is a fakeConn that
-// returns an error from Query.
+// propagate it as a chclient: query: ... error. Driven via the
+// test-only newWithConn seam against a fault-injecting fake driver.Conn.
 func TestQueryCursor_OpenError(t *testing.T) {
 	t.Parallel()
-	// We don't have a public Client constructor that injects driver.Conn;
-	// the chaos path here is the same one exercised by the higher-level
-	// handler tests (stubQuerier with err != nil). Skip with a TODO
-	// pointing at the handler-side chaos tests where this lives end-to-
-	// end.
-	t.Skip("covered by internal/api/{prom,loki,tempo} chaos_test.go via stubQuerier{err:...}")
+	want := errors.New("clickhouse: connection refused")
+	client := newWithConn(&chaosConn{queryErr: want})
+
+	cursor, err := client.QueryCursor(context.Background(), "SELECT 1")
+	if cursor != nil {
+		t.Errorf("QueryCursor: got non-nil cursor on open error")
+		_ = cursor.Close()
+	}
+	if err == nil {
+		t.Fatal("QueryCursor: nil error, want propagated query error")
+	}
+	if !errors.Is(err, want) {
+		t.Errorf("QueryCursor: err=%v; want wrap of %v", err, want)
+	}
 }
 
 // TestCursor_Cancellation_StopsDrain — when the caller cancels the
@@ -330,15 +383,11 @@ func TestCursor_Cancellation_StopsDrain(t *testing.T) {
 // not deadlock and must not double-release the underlying rows. The
 // idempotency invariant.
 //
-// TODO(prod-bug): the current rowsCursor.Close path is not goroutine-safe
-// — it reads + nils c.rows / c.span without a mutex. Production callers
-// only Close once (via `defer cursor.Close()` in the handler), so the
-// race isn't observable today, but a future change that fans Close
-// across goroutines would tickle it. Race detected under `go test
-// -race`; skipping until the production code grows a sync.Once
-// guard around Close (or callers document single-Close-only).
+// The cursor wraps its teardown in sync.Once, so concurrent Close
+// callers all observe the same close error (nil on the happy path) and
+// the underlying rows.Close fires exactly once. Race-detector clean
+// under `go test -race`.
 func TestCursor_ConcurrentClose(t *testing.T) {
-	t.Skip("TODO(prod-bug): rowsCursor.Close is not goroutine-safe; data race under -race. See test comment.")
 	t.Parallel()
 	rows := &chaosRows{samples: mkSamples(50)}
 	cursor := &rowsCursor{rows: rows}
@@ -352,8 +401,8 @@ func TestCursor_ConcurrentClose(t *testing.T) {
 		}()
 	}
 	wg.Wait()
-	if rows.closeCalled.Load() < 1 {
-		t.Fatal("rows.Close: not invoked")
+	if got := rows.closeCalled.Load(); got != 1 {
+		t.Fatalf("rows.Close: got %d invocations, want exactly 1 (sync.Once)", got)
 	}
 }
 

--- a/internal/chclient/client.go
+++ b/internal/chclient/client.go
@@ -93,6 +93,20 @@ func (c *Client) Conn() driver.Conn {
 	return c.conn
 }
 
+// newWithConn returns a *Client wrapping the supplied driver.Conn. It is
+// a test-only seam used by the chaos / failure-mode tests in this package
+// to drive the cursor / Exec / Query paths against a fault-injecting fake
+// driver.Conn without standing up a real ClickHouse server.
+//
+// Production callers MUST use New, which goes through clickhouse.Open and
+// performs the connectivity Ping. This constructor bypasses both — it is
+// unexported and intentionally narrow.
+//
+//nolint:revive // test-only seam; production code must use New.
+func newWithConn(conn driver.Conn) *Client {
+	return &Client{conn: conn}
+}
+
 // Close releases all pooled connections.
 func (c *Client) Close() error {
 	if c.conn == nil {

--- a/internal/promshim/local/engine.go
+++ b/internal/promshim/local/engine.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/parser"
 )
 
 // Options configures a local PromQL evaluator. Zero-valued fields fall back to
@@ -28,7 +29,12 @@ type Engine struct {
 
 // NewEngine constructs a local PromQL evaluator with the provided options.
 // The wrapped promql.Engine has @ modifier and negative offsets enabled to
-// mirror modern Prometheus defaults.
+// mirror modern Prometheus defaults. The parser is constructed with
+// EnableExperimentalFunctions=true so the shadow-mode oracle exercises
+// Prometheus 3.x experimental functions (e.g. double_exponential_smoothing)
+// that cerberus's own parser already accepts (see internal/api/prom.New).
+// Keeping the oracle aligned with cerberus's parser is the whole point of
+// the local promshim.
 func NewEngine(opts Options) *Engine {
 	if opts.MaxSamples == 0 {
 		opts.MaxSamples = 50_000_000
@@ -46,6 +52,7 @@ func NewEngine(opts Options) *Engine {
 			LookbackDelta:        opts.LookbackDelta,
 			EnableAtModifier:     true,
 			EnableNegativeOffset: true,
+			Parser:               parser.NewParser(parser.Options{EnableExperimentalFunctions: true}),
 		}),
 	}
 }

--- a/internal/telemetry/lifecycle_test.go
+++ b/internal/telemetry/lifecycle_test.go
@@ -2,8 +2,8 @@ package telemetry
 
 import (
 	"context"
+	"errors"
 	"net"
-	"os"
 	"testing"
 	"time"
 
@@ -15,7 +15,7 @@ import (
 // in Config still produces "cerberus" on the resource. Anchors the
 // invariant cerberus dashboards rely on (service.name=cerberus).
 func TestBuildResource_DefaultsServiceName(t *testing.T) {
-	res, err := buildResource(t.Context(), Config{})
+	res, err := buildResource(t.Context(), Config{}, nil)
 	if err != nil {
 		t.Fatalf("buildResource: %v", err)
 	}
@@ -27,7 +27,7 @@ func TestBuildResource_DefaultsServiceName(t *testing.T) {
 // TestBuildResource_DefaultsServiceVersion confirms an empty
 // ServiceVersion in Config falls back to "dev".
 func TestBuildResource_DefaultsServiceVersion(t *testing.T) {
-	res, err := buildResource(t.Context(), Config{})
+	res, err := buildResource(t.Context(), Config{}, nil)
 	if err != nil {
 		t.Fatalf("buildResource: %v", err)
 	}
@@ -43,7 +43,7 @@ func TestBuildResource_AppliesConfiguredVersion(t *testing.T) {
 	res, err := buildResource(t.Context(), Config{
 		ServiceName:    "cerberus",
 		ServiceVersion: "v1.2.3",
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("buildResource: %v", err)
 	}
@@ -57,7 +57,7 @@ func TestBuildResource_AppliesConfiguredVersion(t *testing.T) {
 // disambiguate). The value is either the hostname or a random fallback
 // — both non-empty.
 func TestBuildResource_IncludesServiceInstanceID(t *testing.T) {
-	res, err := buildResource(t.Context(), Config{})
+	res, err := buildResource(t.Context(), Config{}, nil)
 	if err != nil {
 		t.Fatalf("buildResource: %v", err)
 	}
@@ -66,19 +66,43 @@ func TestBuildResource_IncludesServiceInstanceID(t *testing.T) {
 	}
 }
 
-// TestBuildResource_InstanceIDMatchesHostnameWhenAvailable: when
-// os.Hostname succeeds, the resource attribute should match.
+// TestBuildResource_InstanceIDMatchesHostnameWhenAvailable: when the
+// supplied hostname resolver succeeds, the resource attribute should
+// match it. The test drives buildResource through a deterministic
+// hostnameFunc stub so the assertion holds on every host — scratch
+// containers, CI sandboxes and developer laptops alike. The production
+// path (os.Hostname) is still the New() default; the defensive
+// randomInstanceID fallback is exercised by
+// TestBuildResource_InstanceIDFallsBackOnHostnameError below.
 func TestBuildResource_InstanceIDMatchesHostnameWhenAvailable(t *testing.T) {
-	host, err := os.Hostname()
-	if err != nil || host == "" {
-		t.Skip("hostname unavailable on this host; skipping")
-	}
-	res, err := buildResource(t.Context(), Config{})
+	const want = "test-host"
+	stub := func() (string, error) { return want, nil }
+	res, err := buildResource(t.Context(), Config{}, stub)
 	if err != nil {
 		t.Fatalf("buildResource: %v", err)
 	}
-	if got := attr(res, "service.instance.id"); got != host {
-		t.Errorf("service.instance.id = %q; want %q", got, host)
+	if got := attr(res, "service.instance.id"); got != want {
+		t.Errorf("service.instance.id = %q; want %q", got, want)
+	}
+}
+
+// TestBuildResource_InstanceIDFallsBackOnHostnameError pins the
+// defensive path: when the hostname resolver errors out (the original
+// reason the test above had a t.Skip), buildResource falls back to a
+// random 16-byte hex string rather than emitting an empty
+// service.instance.id.
+func TestBuildResource_InstanceIDFallsBackOnHostnameError(t *testing.T) {
+	stub := func() (string, error) { return "", errors.New("hostname unavailable") }
+	res, err := buildResource(t.Context(), Config{}, stub)
+	if err != nil {
+		t.Fatalf("buildResource: %v", err)
+	}
+	got := attr(res, "service.instance.id")
+	if got == "" {
+		t.Fatal("service.instance.id = empty; want random fallback")
+	}
+	if got == "test-host" {
+		t.Fatalf("service.instance.id = %q; expected random fallback, not stubbed hostname", got)
 	}
 }
 

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -79,7 +79,7 @@ func New(ctx context.Context, cfg Config) (*Providers, error) {
 		}, nil
 	}
 
-	res, err := buildResource(ctx, cfg)
+	res, err := buildResource(ctx, cfg, os.Hostname)
 	if err != nil {
 		return nil, fmt.Errorf("build resource: %w", err)
 	}
@@ -167,15 +167,25 @@ func newMeterProvider(ctx context.Context, cfg Config, res *resource.Resource) (
 	return mp, mp.Shutdown, nil
 }
 
+// hostnameFunc resolves the hostname used for service.instance.id. The
+// production path is os.Hostname; tests inject a deterministic stub to
+// avoid host-environment dependence (scratch containers, sandboxed CI
+// runners and Linux netns-isolated test pods can all return empty or
+// errored hostnames).
+type hostnameFunc func() (string, error)
+
 // buildResource composes the resource attached to every exported span
 // and metric. Attribute fallbacks:
 //
 //   - service.name        ← cfg.ServiceName  (defaults to "cerberus" if blank)
 //   - service.version     ← cfg.ServiceVersion (defaults to "dev" if blank)
-//   - service.instance.id ← os.Hostname()    (falls back to a random 16-byte
+//   - service.instance.id ← hostname()        (falls back to a random 16-byte
 //     hex string when hostname lookup errors out — common in scratch
 //     containers)
-func buildResource(ctx context.Context, cfg Config) (*resource.Resource, error) {
+//
+// hostname is parameterised for testability — production callers pass
+// os.Hostname; tests supply a stub. Nil is treated as os.Hostname.
+func buildResource(ctx context.Context, cfg Config, hostname hostnameFunc) (*resource.Resource, error) {
 	name := cfg.ServiceName
 	if name == "" {
 		name = "cerberus"
@@ -184,7 +194,10 @@ func buildResource(ctx context.Context, cfg Config) (*resource.Resource, error) 
 	if version == "" {
 		version = "dev"
 	}
-	instance, err := os.Hostname()
+	if hostname == nil {
+		hostname = os.Hostname
+	}
+	instance, err := hostname()
 	if err != nil || instance == "" {
 		instance = randomInstanceID()
 	}


### PR DESCRIPTION
## Summary

GA blocker — no t.Skip allowed. Eliminates 4 miscellaneous `t.Skip` calls across `internal/chclient`, `internal/telemetry`, and `harness/compatibility/shadow` in one PR.

## Skip-by-skip

- `internal/chclient/chaos_test.go::TestQueryCursor_OpenError` — pointed at handler-side chaos tests because there was no public Client constructor that injected a `driver.Conn`. Added an unexported test-only seam `newWithConn(conn driver.Conn) *Client` to `internal/chclient/client.go` and drove the chaos path locally via a fault-injecting `chaosConn` that returns a configured error from `Query`. `errors.Is` now confirms `QueryCursor` wraps the propagated driver error.
- `internal/chclient/chaos_test.go::TestCursor_ConcurrentClose` — skipped on a stale TODO. `rowsCursor.Close` already wraps teardown in `sync.Once` (see `internal/chclient/cursor.go`). Removed the skip and tightened the assertion to require exactly **one** `rows.Close` invocation across 16 racing goroutines. Race-detector clean.
- `internal/telemetry/lifecycle_test.go::TestBuildResource_InstanceIDMatchesHostnameWhenAvailable` — skipped when `os.Hostname()` failed/empty. Refactored `buildResource` to accept a `hostnameFunc` parameter (nil falls back to `os.Hostname`, preserving production behaviour from `New`). The test now drives a deterministic `func() (string, error) { return "test-host", nil }` stub. Added a companion `TestBuildResource_InstanceIDFallsBackOnHostnameError` to pin the random-hex fallback path in isolation.
- `harness/compatibility/shadow/promql_shadow_test.go::holt_winters_node_load1_api_0` — `skipReason` because the shadow oracle's `promql.Engine` did not enable experimental functions, so the parser rejected `double_exponential_smoothing`. `internal/api/prom.New` already enables them; the shadow oracle exists to mirror cerberus's parser. Constructed the local promshim engine with `Parser: parser.NewParser(parser.Options{EnableExperimentalFunctions: true})` and dropped the `skipReason`.

## Test plan

- [x] `go test -race ./internal/chclient/` — 26 pass
- [x] `go test -race ./internal/telemetry/` — 34 pass
- [x] `go test -race ./harness/compatibility/shadow/` — 130 pass (incl. the previously-skipped `holt_winters_node_load1_api_0`)
- [x] No new `t.Skip` introduced; `grep -n "t.Skip\|skipReason"` clean in all 4 target files
- [x] `go build ./...` and `go vet ./...` clean

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
