### PR TITLE
fix(traceql): toFloat64 cast on numeric literal comparison against Map

### DIFF
--- a/internal/traceql/lower.go
+++ b/internal/traceql/lower.go
@@ -447,12 +447,11 @@ func isComparisonOp(op chplan.BinaryOp) bool {
 // keeps `{ name = "checkout" }` (string intrinsic) from incorrectly
 // triggering toFloat64 wraps on the literal side.
 func isNumericExpr(expr chplan.Expr) bool {
+	if b, ok := expr.(*chplan.Binary); ok {
+		return isArithmeticOp(b.Op)
+	}
 	switch expr.(type) {
-	case *chplan.LitInt, *chplan.LitFloat:
-		return true
-	case *chplan.Binary:
-		return isArithmeticOp(expr.(*chplan.Binary).Op)
-	case *chplan.FuncCall:
+	case *chplan.LitInt, *chplan.LitFloat, *chplan.FuncCall:
 		return true
 	}
 	return false

--- a/internal/traceql/lower.go
+++ b/internal/traceql/lower.go
@@ -347,7 +347,115 @@ func lowerBinaryOperation(b *traceql.BinaryOperation, s schema.Traces) (chplan.E
 	if err != nil {
 		return nil, err
 	}
+	// Map(String, String) coercion: SpanAttributes / ResourceAttributes
+	// are typed Map(String, String) in OTel-CH, so a bare
+	// `SpanAttributes['http.status_code'] >= 500` comparison fails in
+	// ClickHouse with NO_COMMON_TYPE ("there is no supertype for types
+	// String, UInt8"). When the lowered Binary has numeric semantics
+	// (arithmetic op, or comparison whose peer is a numeric expression)
+	// we wrap any FieldAccess child in `toFloat64(...)` so the cast
+	// happens server-side. Float64 widens both int and float literals
+	// without precision loss for the magnitudes typical of attribute
+	// values (HTTP status codes, percentages, sizes).
+	lhs, rhs = coerceNumericFieldAccess(op, lhs, rhs)
 	return &chplan.Binary{Op: op, Left: lhs, Right: rhs}, nil
+}
+
+// coerceNumericFieldAccess wraps FieldAccess children in toFloat64(...)
+// when the parent Binary needs numeric semantics:
+//
+//   - Arithmetic ops (+ / - / * / / / % / ^) always coerce both sides,
+//     recursing into nested arithmetic so a chain like `.a + .b + .c`
+//     yields `toFloat64(.a) + toFloat64(.b) + toFloat64(.c)`.
+//
+//   - Comparison ops (= / != / < / <= / > / >=) coerce both sides only
+//     when at least one side is a numeric expression (literal int /
+//     float, an arithmetic Binary, or an already-coerced FuncCall).
+//     The "both sides" rule covers commutative comparisons where the
+//     literal appears on the left (`500 <= span.http.status_code`).
+//
+//   - Regex / logical ops (=~ / !~ / AND / OR) leave both sides alone
+//     because their operands are strings or booleans.
+//
+// FieldAccess that resolves to an intrinsic column (e.g. Duration,
+// already Int64) doesn't reach this path — intrinsics lower to a
+// ColumnRef, not a FieldAccess. So the wrap is restricted to the
+// Map(String, String) carriers by construction.
+func coerceNumericFieldAccess(op chplan.BinaryOp, lhs, rhs chplan.Expr) (chplan.Expr, chplan.Expr) {
+	if isArithmeticOp(op) {
+		return coerceFieldAccess(lhs), coerceFieldAccess(rhs)
+	}
+	if isComparisonOp(op) && (isNumericExpr(lhs) || isNumericExpr(rhs)) {
+		return coerceFieldAccess(lhs), coerceFieldAccess(rhs)
+	}
+	return lhs, rhs
+}
+
+// coerceFieldAccess wraps every FieldAccess inside expr in
+// toFloat64(...), recursing into arithmetic Binary nodes so a nested
+// `.a + .b` becomes `toFloat64(.a) + toFloat64(.b)`. Non-arithmetic
+// sub-expressions (literals, ColumnRefs, FuncCalls already produced by
+// a deeper coercion) pass through unchanged.
+func coerceFieldAccess(expr chplan.Expr) chplan.Expr {
+	switch v := expr.(type) {
+	case *chplan.FieldAccess:
+		return &chplan.FuncCall{Name: "toFloat64", Args: []chplan.Expr{v}}
+	case *chplan.Binary:
+		if isArithmeticOp(v.Op) {
+			return &chplan.Binary{
+				Op:    v.Op,
+				Left:  coerceFieldAccess(v.Left),
+				Right: coerceFieldAccess(v.Right),
+			}
+		}
+	}
+	return expr
+}
+
+// isArithmeticOp reports whether op is one of the numeric arithmetic
+// operators where both operands must compute as numbers.
+func isArithmeticOp(op chplan.BinaryOp) bool {
+	switch op {
+	case chplan.OpAdd, chplan.OpSub, chplan.OpMul, chplan.OpDiv, chplan.OpMod, chplan.OpPow:
+		return true
+	}
+	return false
+}
+
+// isComparisonOp reports whether op is one of the value-comparison
+// operators eligible for numeric-attribute coercion. Excludes regex
+// (=~ / !~) which operate on strings, and AND / OR which compose
+// booleans.
+func isComparisonOp(op chplan.BinaryOp) bool {
+	switch op {
+	case chplan.OpEq, chplan.OpNe, chplan.OpLt, chplan.OpLe, chplan.OpGt, chplan.OpGe:
+		return true
+	}
+	return false
+}
+
+// isNumericExpr reports whether expr has numeric semantics on the CH
+// side — a numeric literal, an arithmetic Binary, or a FuncCall
+// (which in this lowering only comes from a prior toFloat64 wrap).
+// Used to decide whether a comparison's "other side" needs a numeric
+// peer, which is what triggers FieldAccess coercion.
+//
+// ColumnRef deliberately does NOT count as numeric here: the only
+// intrinsic ColumnRef that's numeric in OTel-CH is Duration, and a
+// `Duration > 100ms` comparison doesn't need attribute coercion (both
+// sides are already typed Int64). Treating ColumnRef as non-numeric
+// keeps `{ name = "checkout" }` (string intrinsic) from incorrectly
+// triggering toFloat64 wraps on the literal side.
+func isNumericExpr(expr chplan.Expr) bool {
+	switch expr.(type) {
+	case *chplan.LitInt, *chplan.LitFloat:
+		return true
+	case *chplan.Binary:
+		return isArithmeticOp(expr.(*chplan.Binary).Op)
+	case *chplan.FuncCall:
+		return true
+	}
+	return false
 }
 
 // lowerNestedAttrBinary recognises the

--- a/internal/traceql/numeric_coercion_test.go
+++ b/internal/traceql/numeric_coercion_test.go
@@ -1,0 +1,116 @@
+package traceql_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tempo "github.com/grafana/tempo/pkg/traceql"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/traceql"
+)
+
+// TestNumericAttrCoercion pins the toFloat64(...) wrap that lower.go
+// emits around FieldAccess children of arithmetic / numeric-comparison
+// Binary nodes. SpanAttributes / ResourceAttributes are
+// Map(String, String) in OTel-CH, so without the wrap CH rejects
+// numeric-literal comparisons with NO_COMMON_TYPE
+// ("there is no supertype for types String, UInt8").
+//
+// The test asserts the rendered SQL substring so the wrap can't
+// regress without a visible golden bump, and keeps the negative cases
+// (string equality, regex, AND-tree of string predicates) as anchors
+// that the coercion only fires when the comparison peer is numeric.
+func TestNumericAttrCoercion(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelTraces()
+
+	cases := []struct {
+		name       string
+		query      string
+		wantSubstr string
+		// notSubstr is non-empty when the coercion must NOT fire — the
+		// test asserts the rendered SQL doesn't contain toFloat64. This
+		// pins the negative half of the rule (string equality leaves the
+		// FieldAccess as a bare map lookup).
+		notSubstr string
+	}{
+		{
+			name:       "int_eq_wraps_field_access",
+			query:      `{ .attempt = 1 }`,
+			wantSubstr: "toFloat64(`SpanAttributes`[?]) = ?",
+		},
+		{
+			name:       "int_ge_wraps_field_access",
+			query:      `{ span.http.status_code >= 500 }`,
+			wantSubstr: "toFloat64(`SpanAttributes`[?]) >= ?",
+		},
+		{
+			name:       "float_gt_wraps_field_access",
+			query:      `{ span.cpu.usage > 0.5 }`,
+			wantSubstr: "toFloat64(`SpanAttributes`[?]) > ?",
+		},
+		{
+			name:       "resource_attr_coerces",
+			query:      `{ resource.replicas <= 5 }`,
+			wantSubstr: "toFloat64(`ResourceAttributes`[?]) <= ?",
+		},
+		{
+			name:       "arithmetic_add_coerces_both_sides",
+			query:      `{ .a + .b > 10 }`,
+			wantSubstr: "(toFloat64(`SpanAttributes`[?]) + toFloat64(`SpanAttributes`[?])) > ?",
+		},
+		{
+			name:       "arithmetic_mul_with_literal_coerces_field",
+			query:      `{ .a * 2 > 10 }`,
+			wantSubstr: "(toFloat64(`SpanAttributes`[?]) * ?) > ?",
+		},
+		{
+			name:       "string_eq_leaves_field_access_bare",
+			query:      `{ resource.service.name = "frontend" }`,
+			notSubstr:  "toFloat64(",
+		},
+		{
+			name:       "regex_match_leaves_field_access_bare",
+			query:      `{ .service.name =~ "front.*" }`,
+			notSubstr:  "toFloat64(",
+		},
+		{
+			name: "intrinsic_duration_not_double_wrapped",
+			// Duration is already Int64 in OTel-CH; the coercion guard
+			// (FieldAccess-only, not ColumnRef) keeps the intrinsic
+			// untouched even when the comparison is numeric.
+			query:      `{ duration > 100ms }`,
+			wantSubstr: "`Duration` > ?",
+			notSubstr:  "toFloat64(`Duration`",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := tempo.Parse(tc.query)
+			if err != nil {
+				t.Fatalf("Parse(%q): %v", tc.query, err)
+			}
+			plan, err := traceql.Lower(context.Background(), expr, s)
+			if err != nil {
+				t.Fatalf("Lower(%q): %v", tc.query, err)
+			}
+			sql, _, err := chsql.Emit(context.Background(), plan)
+			if err != nil {
+				t.Fatalf("Emit: %v", err)
+			}
+			if tc.wantSubstr != "" && !strings.Contains(sql, tc.wantSubstr) {
+				t.Fatalf("SQL missing wanted substring\n  want: %s\n   sql: %s", tc.wantSubstr, sql)
+			}
+			if tc.notSubstr != "" && strings.Contains(sql, tc.notSubstr) {
+				t.Fatalf("SQL contains forbidden substring\n  not: %s\n  sql: %s", tc.notSubstr, sql)
+			}
+		})
+	}
+}

--- a/internal/traceql/numeric_coercion_test.go
+++ b/internal/traceql/numeric_coercion_test.go
@@ -69,14 +69,14 @@ func TestNumericAttrCoercion(t *testing.T) {
 			wantSubstr: "(toFloat64(`SpanAttributes`[?]) * ?) > ?",
 		},
 		{
-			name:       "string_eq_leaves_field_access_bare",
-			query:      `{ resource.service.name = "frontend" }`,
-			notSubstr:  "toFloat64(",
+			name:      "string_eq_leaves_field_access_bare",
+			query:     `{ resource.service.name = "frontend" }`,
+			notSubstr: "toFloat64(",
 		},
 		{
-			name:       "regex_match_leaves_field_access_bare",
-			query:      `{ .service.name =~ "front.*" }`,
-			notSubstr:  "toFloat64(",
+			name:      "regex_match_leaves_field_access_bare",
+			query:     `{ .service.name =~ "front.*" }`,
+			notSubstr: "toFloat64(",
 		},
 		{
 			name: "intrinsic_duration_not_double_wrapped",

--- a/test/spec/traceql/and_or_combined.txtar
+++ b/test/spec/traceql/and_or_combined.txtar
@@ -1,17 +1,25 @@
-# TODO(traceql-numeric-attr-coercion): SQL emits `SpanAttributes[?] >= ?`
-# with an int64 arg, but `SpanAttributes` is `Map(String, String)` in
-# production OTel-CH — CH refuses `String >= UInt16` with NO_COMMON_TYPE.
-# The chDB round-trip lane was therefore dropped here (seed + expected_rows
-# removed); this fixture currently exercises only the text-equality `sql:`
-# golden until the TraceQL lowering casts numeric literals on attribute
-# comparisons (or wraps the map lookup in a toFloat64/toInt64 cast).
 -- query.traceql --
 { resource.service.name = "frontend" && (duration > 100ms || span.http.status_code >= 500) }
 -- sql --
-SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?) AND ((`Duration` > ?) OR (`SpanAttributes`[?] >= ?))
+SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?) AND ((`Duration` > ?) OR (toFloat64(`SpanAttributes`[?]) >= ?))
 -- args --
 [0] string = "service.name"
 [1] string = "frontend"
 [2] int64 = 100000000
 [3] string = "http.status_code"
 [4] int64 = 500
+-- seed --
+CREATE TABLE otel_traces (
+    Duration UInt64,
+    ResourceAttributes Map(String, String) MATERIALIZED map('service.name', if(Duration = 80000000, 'backend', 'frontend')),
+    SpanAttributes Map(String, String) MATERIALIZED map('http.status_code', if(Duration = 50000000, '500', '200'))
+) ENGINE = MergeTree ORDER BY Duration;
+INSERT INTO otel_traces (Duration) VALUES
+    (50000000),
+    (80000000),
+    (150000000);
+-- expected_rows --
+[
+  [50000000],
+  [150000000]
+]

--- a/test/spec/traceql/attribute_arithmetic_add.txtar
+++ b/test/spec/traceql/attribute_arithmetic_add.txtar
@@ -1,15 +1,18 @@
-# TODO(traceql-numeric-attr-coercion): SQL emits arithmetic over two
-# `SpanAttributes[?]` map lookups, but `SpanAttributes` is `Map(String,
-# String)` in production OTel-CH — CH refuses `String + String` with
-# ILLEGAL_TYPE_OF_ARGUMENT. The chDB round-trip lane was therefore dropped
-# here (seed + expected_rows removed); this fixture currently exercises
-# only the text-equality `sql:` golden until the TraceQL lowering wraps
-# attribute lookups in toFloat64 casts when used as arithmetic operands.
 -- query.traceql --
 { .a + .b > 10 }
 -- sql --
-SELECT * FROM `otel_traces` WHERE ((`SpanAttributes`[?] + `SpanAttributes`[?]) > ?)
+SELECT * FROM `otel_traces` WHERE ((toFloat64(`SpanAttributes`[?]) + toFloat64(`SpanAttributes`[?])) > ?)
 -- args --
 [0] string = "a"
 [1] string = "b"
 [2] int64 = 10
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    SpanAttributes Map(String, String) MATERIALIZED map('a', if(_idx = 0, '7', '3'), 'b', if(_idx = 0, '8', '4'))
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1);
+-- expected_rows --
+[
+  [0]
+]

--- a/test/spec/traceql/attribute_arithmetic_mul.txtar
+++ b/test/spec/traceql/attribute_arithmetic_mul.txtar
@@ -1,16 +1,18 @@
-# TODO(traceql-numeric-attr-coercion): SQL emits arithmetic over a
-# `SpanAttributes[?]` map lookup and a numeric literal, but
-# `SpanAttributes` is `Map(String, String)` in production OTel-CH — CH
-# refuses `String * UInt8` with ILLEGAL_TYPE_OF_ARGUMENT. The chDB
-# round-trip lane was therefore dropped here (seed + expected_rows
-# removed); this fixture currently exercises only the text-equality
-# `sql:` golden until the TraceQL lowering wraps attribute lookups in
-# toFloat64 casts when used as arithmetic operands.
 -- query.traceql --
 { .a * 2 > 10 }
 -- sql --
-SELECT * FROM `otel_traces` WHERE ((`SpanAttributes`[?] * ?) > ?)
+SELECT * FROM `otel_traces` WHERE ((toFloat64(`SpanAttributes`[?]) * ?) > ?)
 -- args --
 [0] string = "a"
 [1] int64 = 2
 [2] int64 = 10
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    SpanAttributes Map(String, String) MATERIALIZED map('a', if(_idx = 0, '7', '3'))
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1);
+-- expected_rows --
+[
+  [0]
+]

--- a/test/spec/traceql/edge_attr_default_ge.txtar
+++ b/test/spec/traceql/edge_attr_default_ge.txtar
@@ -4,4 +4,4 @@
 [0] string = "timeout"
 [1] int64 = 100
 -- sql --
-SELECT * FROM `otel_traces` WHERE (`SpanAttributes`[?] >= ?)
+SELECT * FROM `otel_traces` WHERE (toFloat64(`SpanAttributes`[?]) >= ?)

--- a/test/spec/traceql/edge_attr_resource_le.txtar
+++ b/test/spec/traceql/edge_attr_resource_le.txtar
@@ -4,4 +4,4 @@
 [0] string = "replicas"
 [1] int64 = 5
 -- sql --
-SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] <= ?)
+SELECT * FROM `otel_traces` WHERE (toFloat64(`ResourceAttributes`[?]) <= ?)

--- a/test/spec/traceql/edge_attr_span_gt.txtar
+++ b/test/spec/traceql/edge_attr_span_gt.txtar
@@ -4,4 +4,4 @@
 [0] string = "size"
 [1] int64 = 1024
 -- sql --
-SELECT * FROM `otel_traces` WHERE (`SpanAttributes`[?] > ?)
+SELECT * FROM `otel_traces` WHERE (toFloat64(`SpanAttributes`[?]) > ?)

--- a/test/spec/traceql/edge_attr_span_lt.txtar
+++ b/test/spec/traceql/edge_attr_span_lt.txtar
@@ -4,4 +4,4 @@
 [0] string = "http.status_code"
 [1] int64 = 500
 -- sql --
-SELECT * FROM `otel_traces` WHERE (`SpanAttributes`[?] < ?)
+SELECT * FROM `otel_traces` WHERE (toFloat64(`SpanAttributes`[?]) < ?)

--- a/test/spec/traceql/edge_catchall_compound_count.txtar
+++ b/test/spec/traceql/edge_catchall_compound_count.txtar
@@ -8,4 +8,4 @@
 [4] int64 = 200
 [5] int64 = 10
 -- sql --
-SELECT * FROM (SELECT count(?) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?) AND (`SpanAttributes`[?] > ?))) WHERE (`Value` > ?)
+SELECT * FROM (SELECT count(?) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?) AND (toFloat64(`SpanAttributes`[?]) > ?))) WHERE (`Value` > ?)

--- a/test/spec/traceql/float_attr.txtar
+++ b/test/spec/traceql/float_attr.txtar
@@ -1,14 +1,17 @@
-# TODO(traceql-numeric-attr-coercion): SQL emits `SpanAttributes[?] > ?` with
-# a float64 arg, but `SpanAttributes` is `Map(String, String)` in production
-# OTel-CH — CH refuses `String > Float64` with NO_COMMON_TYPE. The chDB
-# round-trip lane was therefore dropped here (seed + expected_rows removed);
-# this fixture currently exercises only the text-equality `sql:` golden
-# until the TraceQL lowering casts numeric literals on attribute
-# comparisons (or wraps the map lookup in a toFloat64 cast).
 -- query.traceql --
 { span.cpu.usage > 0.5 }
 -- sql --
-SELECT * FROM `otel_traces` WHERE (`SpanAttributes`[?] > ?)
+SELECT * FROM `otel_traces` WHERE (toFloat64(`SpanAttributes`[?]) > ?)
 -- args --
 [0] string = "cpu.usage"
 [1] float64 = 0.5
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    SpanAttributes Map(String, String) MATERIALIZED map('cpu.usage', if(_idx = 0, '0.7', '0.3'))
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1);
+-- expected_rows --
+[
+  [0]
+]

--- a/test/spec/traceql/http_status_int.txtar
+++ b/test/spec/traceql/http_status_int.txtar
@@ -1,14 +1,17 @@
-# TODO(traceql-numeric-attr-coercion): SQL emits `SpanAttributes[?] >= ?`
-# with an int64 arg, but `SpanAttributes` is `Map(String, String)` in
-# production OTel-CH — CH refuses `String >= UInt16` with NO_COMMON_TYPE.
-# The chDB round-trip lane was therefore dropped here (seed + expected_rows
-# removed); this fixture currently exercises only the text-equality `sql:`
-# golden until the TraceQL lowering casts numeric literals on attribute
-# comparisons (or wraps the map lookup in a toFloat64/toInt64 cast).
 -- query.traceql --
 { span.http.status_code >= 500 }
 -- sql --
-SELECT * FROM `otel_traces` WHERE (`SpanAttributes`[?] >= ?)
+SELECT * FROM `otel_traces` WHERE (toFloat64(`SpanAttributes`[?]) >= ?)
 -- args --
 [0] string = "http.status_code"
 [1] int64 = 500
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    SpanAttributes Map(String, String) MATERIALIZED map('http.status_code', if(_idx = 0, '500', if(_idx = 1, '404', '200')))
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1), (2);
+-- expected_rows --
+[
+  [0]
+]

--- a/test/spec/traceql/multi_attr_compound.txtar
+++ b/test/spec/traceql/multi_attr_compound.txtar
@@ -1,17 +1,25 @@
-# TODO(traceql-numeric-attr-coercion): SQL emits `SpanAttributes[?] = ?` with
-# an int64 arg, but `SpanAttributes` is `Map(String, String)` in production
-# OTel-CH — CH refuses `String = UInt16` with NO_COMMON_TYPE. The chDB
-# round-trip lane was therefore dropped here (seed + expected_rows removed);
-# this fixture currently exercises only the text-equality `sql:` golden
-# until the TraceQL lowering casts numeric literals on attribute
-# comparisons (or wraps the map lookup in a toFloat64/toInt64 cast).
 -- query.traceql --
 { resource.service.name = "frontend" && span.http.status_code = 500 && duration > 100ms }
 -- sql --
-SELECT * FROM `otel_traces` PREWHERE (`Duration` > ?) WHERE (`ResourceAttributes`[?] = ?) AND (`SpanAttributes`[?] = ?)
+SELECT * FROM `otel_traces` PREWHERE (`Duration` > ?) WHERE (`ResourceAttributes`[?] = ?) AND (toFloat64(`SpanAttributes`[?]) = ?)
 -- args --
 [0] int64 = 100000000
 [1] string = "service.name"
 [2] string = "frontend"
 [3] string = "http.status_code"
 [4] int64 = 500
+-- seed --
+CREATE TABLE otel_traces (
+    Duration UInt64,
+    ResourceAttributes Map(String, String) MATERIALIZED map('service.name', 'frontend'),
+    SpanAttributes Map(String, String) MATERIALIZED map('http.status_code', if(Duration > 100000000, '500', '200'))
+) ENGINE = MergeTree ORDER BY Duration;
+INSERT INTO otel_traces (Duration) VALUES
+    (50000000),
+    (150000000),
+    (250000000);
+-- expected_rows --
+[
+  [150000000],
+  [250000000]
+]

--- a/test/spec/traceql/static_float.txtar
+++ b/test/spec/traceql/static_float.txtar
@@ -1,14 +1,17 @@
-# TODO(traceql-numeric-attr-coercion): SQL emits `SpanAttributes[?] = ?` with
-# a float64 arg, but `SpanAttributes` is `Map(String, String)` in production
-# OTel-CH — CH refuses `String = Float64` with NO_COMMON_TYPE. The chDB
-# round-trip lane was therefore dropped here (seed + expected_rows removed);
-# this fixture currently exercises only the text-equality `sql:` golden
-# until the TraceQL lowering casts numeric literals on attribute
-# comparisons (or wraps the map lookup in a toFloat64 cast).
 -- query.traceql --
 { .ratio = 0.95 }
 -- sql --
-SELECT * FROM `otel_traces` WHERE (`SpanAttributes`[?] = ?)
+SELECT * FROM `otel_traces` WHERE (toFloat64(`SpanAttributes`[?]) = ?)
 -- args --
 [0] string = "ratio"
 [1] float64 = 0.95
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    SpanAttributes Map(String, String) MATERIALIZED map('ratio', if(_idx = 0, '0.95', '0.5'))
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1);
+-- expected_rows --
+[
+  [0]
+]

--- a/test/spec/traceql/static_int.txtar
+++ b/test/spec/traceql/static_int.txtar
@@ -1,14 +1,17 @@
-# TODO(traceql-numeric-attr-coercion): SQL emits `SpanAttributes[?] = ?` with
-# an int64 arg, but `SpanAttributes` is `Map(String, String)` in production
-# OTel-CH — CH refuses `String = UInt8` with NO_COMMON_TYPE. The chDB
-# round-trip lane was therefore dropped here (seed + expected_rows removed);
-# this fixture currently exercises only the text-equality `sql:` golden
-# until the TraceQL lowering casts numeric literals on attribute
-# comparisons (or wraps the map lookup in a toFloat64/toInt64 cast).
 -- query.traceql --
 { .attempt = 1 }
 -- sql --
-SELECT * FROM `otel_traces` WHERE (`SpanAttributes`[?] = ?)
+SELECT * FROM `otel_traces` WHERE (toFloat64(`SpanAttributes`[?]) = ?)
 -- args --
 [0] string = "attempt"
 [1] int64 = 1
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    SpanAttributes Map(String, String) MATERIALIZED map('attempt', if(_idx = 0, '1', '2'))
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1);
+-- expected_rows --
+[
+  [0]
+]

--- a/test/spec/traceql/status_code_eq.txtar
+++ b/test/spec/traceql/status_code_eq.txtar
@@ -1,14 +1,17 @@
-# TODO(traceql-numeric-attr-coercion): SQL emits `SpanAttributes[?] = ?` with
-# an int64 arg, but `SpanAttributes` is `Map(String, String)` in production
-# OTel-CH — CH refuses `String = UInt8` with NO_COMMON_TYPE. The chDB
-# round-trip lane was therefore dropped here (seed + expected_rows removed);
-# this fixture currently exercises only the text-equality `sql:` golden
-# until the TraceQL lowering casts numeric literals on attribute
-# comparisons (or wraps the map lookup in a toFloat64/toInt64 cast).
 -- query.traceql --
 { span.http.status_code = 200 }
 -- sql --
-SELECT * FROM `otel_traces` WHERE (`SpanAttributes`[?] = ?)
+SELECT * FROM `otel_traces` WHERE (toFloat64(`SpanAttributes`[?]) = ?)
 -- args --
 [0] string = "http.status_code"
 [1] int64 = 200
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    SpanAttributes Map(String, String) MATERIALIZED map('http.status_code', if(_idx = 0, '200', if(_idx = 1, '404', '500')))
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1), (2);
+-- expected_rows --
+[
+  [0]
+]

--- a/test/spec/traceql/status_code_ge.txtar
+++ b/test/spec/traceql/status_code_ge.txtar
@@ -1,14 +1,18 @@
-# TODO(traceql-numeric-attr-coercion): SQL emits `SpanAttributes[?] >= ?`
-# with an int64 arg, but `SpanAttributes` is `Map(String, String)` in
-# production OTel-CH — CH refuses `String >= UInt16` with NO_COMMON_TYPE.
-# The chDB round-trip lane was therefore dropped here (seed + expected_rows
-# removed); this fixture currently exercises only the text-equality `sql:`
-# golden until the TraceQL lowering casts numeric literals on attribute
-# comparisons (or wraps the map lookup in a toFloat64/toInt64 cast).
 -- query.traceql --
 { span.http.status_code >= 500 }
 -- sql --
-SELECT * FROM `otel_traces` WHERE (`SpanAttributes`[?] >= ?)
+SELECT * FROM `otel_traces` WHERE (toFloat64(`SpanAttributes`[?]) >= ?)
 -- args --
 [0] string = "http.status_code"
 [1] int64 = 500
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    SpanAttributes Map(String, String) MATERIALIZED map('http.status_code', if(_idx = 0, '500', if(_idx = 1, '503', '200')))
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1), (2);
+-- expected_rows --
+[
+  [0],
+  [1]
+]

--- a/test/spec/traceql/sum_span_attr.txtar
+++ b/test/spec/traceql/sum_span_attr.txtar
@@ -1,7 +1,7 @@
 -- query.traceql --
 { span.http.status_code >= 400 } | sum(span.http.status_code) > 0
 -- sql --
-SELECT * FROM (SELECT sum(`SpanAttributes`[?]) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE (`SpanAttributes`[?] >= ?))) WHERE (`Value` > ?)
+SELECT * FROM (SELECT sum(`SpanAttributes`[?]) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE (toFloat64(`SpanAttributes`[?]) >= ?))) WHERE (`Value` > ?)
 -- args --
 [0] string = "http.status_code"
 [1] string = "http.status_code"


### PR DESCRIPTION
## Summary

Fixes the GA-blocking TraceQL production bug PR #299's audit
surfaced. `internal/traceql/lower.go` was emitting bare
`SpanAttributes[?] <op> <numeric>` comparisons, which CH rejects with
`NO_COMMON_TYPE: 'String' and 'Int64'` because OTel-CH ships the map
columns as `Map(String, String)`.

The fix lives at the cleanest emission point: a new
`coerceNumericFieldAccess` pass right after `lowerBinaryOperation`
lowers both sides. It wraps any `FieldAccess` child in
`toFloat64(...)` whenever the parent Binary needs numeric semantics:

- **Arithmetic** (`+ - * / % ^`) — always coerce both sides, recursing
  into nested arithmetic so `.a + .b + .c` becomes
  `toFloat64(.a) + toFloat64(.b) + toFloat64(.c)`.
- **Comparison** (`= != < <= > >=`) — coerce both sides when at least
  one side is a numeric expression (literal int/float, an arithmetic
  Binary, or an already-coerced FuncCall). The two-sided rule covers
  commutative compares like `500 <= span.http.status_code`.
- **Regex / logical** (`=~ !~ AND OR`) — leave both sides alone.

Intrinsic columns (`Duration` / `SpanName` / `SpanKind` / ...) lower
to a `ColumnRef`, not a `FieldAccess`, so the wrap is restricted to
the `Map(String, String)` carriers by construction. `duration > 100ms`
stays a bare `Duration > <int>` comparison.

`toFloat64` was picked over `toInt64` because Float64 widens both int
and float literals losslessly at the magnitudes typical of attribute
values (HTTP status codes, durations, percentages, sizes), and CH
auto-promotes the `?` arg on the other side regardless of bind type.

## Fixture restoration (10 fixtures)

PR #299's audit dropped `-- seed --` + `-- expected_rows --` and added
a `# TODO(traceql-numeric-attr-coercion)` header to:

- ` static_int / static_float / float_attr`
- ` http_status_int / status_code_eq / status_code_ge`
- ` attribute_arithmetic_add / attribute_arithmetic_mul`
- ` and_or_combined / multi_attr_compound`

All 10 are restored with their pre-#299 seeds + expected_rows and the
SQL golden updated to reflect the `toFloat64` wrap. The TODO headers
are gone.

Six additional fixtures pick up an SQL-only golden bump
(`edge_attr_default_ge`, `edge_attr_resource_le`, `edge_attr_span_gt`,
`edge_attr_span_lt`, `edge_catchall_compound_count`, `sum_span_attr`)
— they had non-Map(String,String) toy seeds so chDB was happy without
the cast, but the emitter now wraps them uniformly.

## Tests

`internal/traceql/numeric_coercion_test.go` (new) pins the wrap in
rendered SQL across 10 sub-cases, including negative anchors:

- string equality leaves the FieldAccess bare,
- regex match leaves the FieldAccess bare,
- intrinsic Duration is not double-wrapped.

## Test plan

- [x] `go test ./internal/traceql/` — 257 / 257 pass (was 247; +10
  from new test file)
- [x] `go test -tags chdb ./test/spec/traceql/...` — 108 / 108 pass
  (was 97 + 11 fail; the 10 restored + the 1 sum_span_attr that
  picked up the new wrap)
- [x] `go test ./...` — 2551 / 2551 pass across 33 packages, no
  regressions in optimizer / chsql / api / chplan
- [x] No raw SQL strings — pure typed `chplan.FuncCall` constructor