### PR TITLE
fix(compatibility): POST-form handler + curated queries + jq null-vs-empty

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -81,12 +81,18 @@ jobs:
       - name: Summarise report
         if: always()
         run: |
+          # Compatibility-tester results encode "no error" as an empty
+          # string, not JSON null — the JSON shape is `"diff": ""` and
+          # `"unexpectedFailure": ""` for a passing query. The earlier
+          # `== null` checks counted passes as failures and vice versa.
+          # `// ""` normalises both null + empty to "" so the partition
+          # is consistent.
           if [ -f harness/compatibility/report.json ]; then
             jq '{
               total: ([.results[]?] | length),
-              passed: ([.results[]? | select(.unexpectedFailure == null and .diff == null)] | length),
-              diffs: ([.results[]? | select(.diff != null)] | length),
-              unexpected_failures: ([.results[]? | select(.unexpectedFailure != null)] | length)
+              passed: ([.results[]? | select((.unexpectedFailure // "") == "" and (.diff // "") == "")] | length),
+              diffs: ([.results[]? | select((.diff // "") != "")] | length),
+              unexpected_failures: ([.results[]? | select((.unexpectedFailure // "") != "")] | length)
             }' harness/compatibility/report.json
           else
             echo "no report produced (harness step likely failed before tester ran)"

--- a/harness/compatibility/cerberus-test-queries.yml
+++ b/harness/compatibility/cerberus-test-queries.yml
@@ -1,0 +1,255 @@
+# Cerberus-side curated PromQL test queries for the compatibility harness.
+#
+# This file is a near-verbatim copy of
+# harness/compatibility/upstream/promql/promql-test-queries.yml
+# (prometheus/compliance @ 7e28242) with a small set of edits:
+#
+# 1. The PromLabs "demo service" preamble (lines 1-31 of the upstream file)
+#    is stripped — it documents docker-run instructions for the prometheus-
+#    demo-service that the OTel-seeded harness doesn't use.
+#
+# 2. Three queries are REMOVED:
+#
+#        label_replace(demo_num_cpus, "~invalid", "", "src", "(.*)")
+#        should_fail: true
+#
+#        label_replace(demo_num_cpus, "instance", "", "", "")
+#        should_fail: true
+#
+#        label_join(demo_num_cpus, "~invalid", "-", "instance")
+#        should_fail: true
+#
+#    Background: upstream annotates each as `should_fail: true` because
+#    Prom rejects either an invalid destination label name or a
+#    duplicated-output-label-set construction. BUT the failure path is
+#    only hit when the metric (`demo_num_cpus`) actually returns data —
+#    with an empty input vector, Prom's executor short-circuits and
+#    returns success-with-empty BEFORE the validation check fires. Our
+#    OTel seed corpus does not populate `demo_num_cpus`, so all three
+#    return empty-success, and the upstream `promql-compliance-tester`
+#    `log.Fatalf`'s on the first one ("expected reference API query …
+#    to fail, but succeeded"), aborting the entire run. Removing the
+#    entries lets the harness run to completion. When the seed corpus
+#    grows to include `demo_num_cpus`, restore the queries in M1.x.
+#
+# All other entries (including queries that reference demo metrics not yet
+# in the seed) are preserved verbatim: when both ref Prom and cerberus
+# return empty results for a missing-metric query, the tester records that
+# as PASS (zero diff), which is acceptable noise for the RC1 baseline.
+#
+# Pointer-to-upstream: re-sync this file by re-copying the upstream and
+# re-applying the edit above. Track in a follow-up M1.x ticket so this
+# divergence stays auditable.
+
+test_cases:
+  # Scalar literals.
+  - query: '42'
+  - query: '1.234'
+  - query: '.123'
+  - query: '1.23e-3'
+  - query: '0x3d'
+  - query: 'Inf'
+  - query: '+Inf'
+  - query: '-Inf'
+  - query: 'NaN'
+
+  # Vector selectors.
+  # TODO: Add tests for staleness support.
+  - query: 'demo_memory_usage_bytes'
+  - query: '{__name__="demo_memory_usage_bytes"}'
+  - query: 'demo_memory_usage_bytes{type="free"}'
+  - query: 'demo_memory_usage_bytes{type!="free"}'
+  - query: 'demo_memory_usage_bytes{instance=~"demo.promlabs.com:.*"}'
+  - query: 'demo_memory_usage_bytes{instance=~"host"}'
+  - query: 'demo_memory_usage_bytes{instance!~".*:10000"}'
+  - query: 'demo_memory_usage_bytes{type="free", instance!="demo.promlabs.com:10000"}'
+  - query: '{type="free", instance!="demo.promlabs.com:10000"}'
+  - query: '{__name__=~".*"}'
+    should_fail: true
+  - query: "nonexistent_metric_name"
+  - query: 'demo_memory_usage_bytes offset {{.offset}}'
+    variant_args: ['offset']
+  - query: 'demo_memory_usage_bytes offset -{{.offset}}'
+    variant_args: ['offset']
+  # Test staleness handling.
+  - query: demo_intermittent_metric
+
+  # Aggregation operators.
+  - query: '{{.simpleAggrOp}}(demo_memory_usage_bytes)'
+    variant_args: ['simpleAggrOp']
+  - query: '{{.simpleAggrOp}}(nonexistent_metric_name)'
+    variant_args: ['simpleAggrOp']
+  - query: '{{.simpleAggrOp}} by() (demo_memory_usage_bytes)'
+    variant_args: ['simpleAggrOp']
+  - query: '{{.simpleAggrOp}} by(instance) (demo_memory_usage_bytes)'
+    variant_args: ['simpleAggrOp']
+  - query: '{{.simpleAggrOp}} by(instance, type) (demo_memory_usage_bytes)'
+    variant_args: ['simpleAggrOp']
+  - query: '{{.simpleAggrOp}} by(nonexistent) (demo_memory_usage_bytes)'
+    variant_args: ['simpleAggrOp']
+  - query: '{{.simpleAggrOp}} without() (demo_memory_usage_bytes)'
+    variant_args: ['simpleAggrOp']
+  - query: '{{.simpleAggrOp}} without(instance) (demo_memory_usage_bytes)'
+    variant_args: ['simpleAggrOp']
+  - query: '{{.simpleAggrOp}} without(instance, type) (demo_memory_usage_bytes)'
+    variant_args: ['simpleAggrOp']
+  - query: '{{.simpleAggrOp}} without(nonexistent) (demo_memory_usage_bytes)'
+    variant_args: ['simpleAggrOp']
+  - query: '{{.topBottomOp}} (3, demo_memory_usage_bytes)'
+    variant_args: ['topBottomOp']
+  - query: '{{.topBottomOp}} by(instance) (2, demo_memory_usage_bytes)'
+    variant_args: ['topBottomOp']
+  - query: '{{.topBottomOp}} without(instance) (2, demo_memory_usage_bytes)'
+    variant_args: ['topBottomOp']
+  - query: '{{.topBottomOp}} without() (2, demo_memory_usage_bytes)'
+    variant_args: ['topBottomOp']
+  - query: 'quantile({{.quantile}}, demo_memory_usage_bytes)'
+    variant_args: ['quantile']
+  - query: 'avg(max by(type) (demo_memory_usage_bytes))'
+
+  # Binary operators.
+  - query: '1 * 2 + 4 / 6 - 10 % 2 ^ 2'
+  - query: 'demo_num_cpus + (1 {{.compBinOp}} bool 2)'
+    variant_args: ['compBinOp']
+  - query: 'demo_memory_usage_bytes {{.binOp}} 1.2345'
+    variant_args: ['binOp']
+  - query: 'demo_memory_usage_bytes {{.compBinOp}} bool 1.2345'
+    variant_args: ['compBinOp']
+  - query: '1.2345 {{.compBinOp}} bool demo_memory_usage_bytes'
+    variant_args: ['compBinOp']
+  - query: '0.12345 {{.binOp}} demo_memory_usage_bytes'
+    variant_args: ['binOp']
+  - query: '(1 * 2 + 4 / 6 - (10%7)^2) {{.binOp}} demo_memory_usage_bytes'
+    variant_args: ['binOp']
+  - query: 'demo_memory_usage_bytes {{.binOp}} (1 * 2 + 4 / 6 - 10)'
+    variant_args: ['binOp']
+    # Check that vector-scalar binops set output timestamps correctly.
+  - query: 'timestamp(demo_memory_usage_bytes * 1)'
+    # Check that unary minus sets timestamps correctly.
+    # TODO: Check this more systematically for every node type?
+  - query: 'timestamp(-demo_memory_usage_bytes)'
+  - query: 'demo_memory_usage_bytes {{.binOp}} on(instance, job, type) demo_memory_usage_bytes'
+    variant_args: ['binOp']
+  - query: 'sum by(instance, type) (demo_memory_usage_bytes) {{.binOp}} on(instance, type) group_left(job) demo_memory_usage_bytes'
+    variant_args: ['binOp']
+  - query: 'demo_memory_usage_bytes {{.compBinOp}} bool on(instance, job, type) demo_memory_usage_bytes'
+    variant_args: ['compBinOp']
+    # Check that __name__ is always dropped, even if it's part of the matching labels.
+  - query: 'demo_memory_usage_bytes / on(instance, job, type, __name__) demo_memory_usage_bytes'
+  - query: 'sum without(job) (demo_memory_usage_bytes) / on(instance, type) demo_memory_usage_bytes'
+  - query: 'sum without(job) (demo_memory_usage_bytes) / on(instance, type) group_left demo_memory_usage_bytes'
+  - query: 'sum without(job) (demo_memory_usage_bytes) / on(instance, type) group_left(job) demo_memory_usage_bytes'
+  - query: 'demo_memory_usage_bytes / on(instance, job) group_left demo_num_cpus'
+  - query: 'demo_memory_usage_bytes / on(instance, type, job, non_existent) demo_memory_usage_bytes'
+  # TODO: Add non-explicit many-to-one / one-to-many that errors.
+  # TODO: Add many-to-many match that errors.
+
+  # NaN/Inf/-Inf support.
+  - query: 'demo_num_cpus * Inf'
+  - query: 'demo_num_cpus * -Inf'
+  - query: 'demo_num_cpus * NaN'
+
+  # Unary expressions.
+  - query: 'demo_memory_usage_bytes + -(1)'
+  - query: '-demo_memory_usage_bytes'
+    # Check precedence.
+  - query: -1 ^ 2
+
+  # Binops involving non-const scalars.
+  - query: '1 {{.arithBinOp}} time()'
+    variant_args: ['arithBinOp']
+  - query: 'time() {{.arithBinOp}} 1'
+    variant_args: ['arithBinOp']
+  - query: 'time() {{.compBinOp}} bool 1'
+    variant_args: ['compBinOp']
+  - query: '1 {{.compBinOp}} bool time()'
+    variant_args: ['compBinOp']
+  - query: 'time() {{.arithBinOp}} time()'
+    variant_args: ['arithBinOp']
+  - query: 'time() {{.compBinOp}} bool time()'
+    variant_args: ['compBinOp']
+  - query: 'time() {{.binOp}} demo_memory_usage_bytes'
+    variant_args: ['binOp']
+  - query: 'demo_memory_usage_bytes {{.binOp}} time()'
+    variant_args: ['binOp']
+
+  # Functions.
+  - query: '{{.simpleTimeAggrOp}}_over_time(demo_memory_usage_bytes[{{.range}}])'
+    variant_args: ['simpleTimeAggrOp', 'range']
+  - query: 'quantile_over_time({{.quantile}}, demo_memory_usage_bytes[{{.range}}])'
+    variant_args: ['quantile', 'range']
+  - query: 'timestamp(demo_num_cpus)'
+  - query: 'timestamp(timestamp(demo_num_cpus))'
+  - query: '{{.simpleMathFunc}}(demo_memory_usage_bytes)'
+    variant_args: ['simpleMathFunc']
+  - query: '{{.simpleMathFunc}}(-demo_memory_usage_bytes)'
+    variant_args: ['simpleMathFunc']
+  - query: '{{.extrapolatedRateFunc}}(nonexistent_metric[5m])'
+    variant_args: ['extrapolatedRateFunc']
+  - query: '{{.extrapolatedRateFunc}}(demo_cpu_usage_seconds_total[{{.range}}])'
+    variant_args: ['extrapolatedRateFunc', 'range']
+  - query: 'deriv(demo_disk_usage_bytes[{{.range}}])'
+    variant_args: ['range']
+  - query: 'predict_linear(demo_disk_usage_bytes[{{.range}}], 600)'
+    variant_args: ['range']
+  - query: 'time()'
+    # label_replace does a full-string match and replace.
+  - query: 'label_replace(demo_num_cpus, "job", "destination-value-$1", "instance", "demo.promlabs.com:(.*)")'
+    # label_replace does not do a sub-string match.
+  - query: 'label_replace(demo_num_cpus, "job", "destination-value-$1", "instance", "host:(.*)")'
+    # label_replace works with multiple capture groups.
+  - query: 'label_replace(demo_num_cpus, "job", "$1-$2", "instance", "local(.*):(.*)")'
+    # label_replace does not overwrite the destination label if the source label does not exist.
+  - query: 'label_replace(demo_num_cpus, "job", "value-$1", "nonexistent-src", "source-value-(.*)")'
+    # label_replace overwrites the destination label if the source label is empty, but matched.
+  - query: 'label_replace(demo_num_cpus, "job", "value-$1", "nonexistent-src", "(.*)")'
+    # label_replace does not overwrite the destination label if the source label is not matched.
+  - query: 'label_replace(demo_num_cpus, "job", "value-$1", "instance", "non-matching-regex")'
+    # label_replace drops labels that are set to empty values.
+  - query: 'label_replace(demo_num_cpus, "job", "", "dst", ".*")'
+    # label_replace fails when the regex is invalid.
+  - query: 'label_replace(demo_num_cpus, "job", "value-$1", "src", "(.*")'
+    should_fail: true
+    # NOTE: 3 upstream entries with `should_fail: true` are intentionally
+    # OMITTED here — see the file header for rationale. They were:
+    #   label_replace(demo_num_cpus, "~invalid", "", "src", "(.*)")  should_fail: true
+    #   label_replace(demo_num_cpus, "instance", "", "", "")         should_fail: true
+    #   label_join(demo_num_cpus, "~invalid", "-", "instance")       should_fail: true
+    # All three depend on demo_num_cpus being non-empty for Prom to hit
+    # the failure path. With our seed corpus, ref Prom returns empty
+    # success and the upstream tester log.Fatalf's.
+  - query: 'label_join(demo_num_cpus, "new_label", "-", "instance", "job")'
+  - query: 'label_join(demo_num_cpus, "job", "-", "instance", "job")'
+  - query: 'label_join(demo_num_cpus, "job", "-", "instance")'
+  - query: '{{.dateFunc}}()'
+    variant_args: ['dateFunc']
+  - query: '{{.dateFunc}}(demo_batch_last_success_timestamp_seconds offset {{.offset}})'
+    variant_args: ['dateFunc', 'offset']
+  - query: '{{.instantRateFunc}}(demo_cpu_usage_seconds_total[{{.range}}])'
+    variant_args: ['instantRateFunc', 'range']
+  - query: '{{.clampFunc}}(demo_memory_usage_bytes, 2)'
+    variant_args: ['clampFunc']
+  - query: 'clamp(demo_memory_usage_bytes, 0, 1)'
+  - query: 'clamp(demo_memory_usage_bytes, 0, 1000000000000)'
+  - query: 'clamp(demo_memory_usage_bytes, 1000000000000, 0)'
+  - query: 'clamp(demo_memory_usage_bytes, 1000000000000, 1000000000000)'
+  - query: 'resets(demo_cpu_usage_seconds_total[{{.range}}])'
+    variant_args: ['range']
+  - query: 'changes(demo_batch_last_success_timestamp_seconds[{{.range}}])'
+    variant_args: ['range']
+  - query: 'vector(1.23)'
+  - query: 'vector(time())'
+  - query: 'histogram_quantile({{.quantile}}, rate(demo_api_request_duration_seconds_bucket[1m]))'
+    variant_args: ['quantile']
+  - query: 'histogram_quantile(0.9, nonexistent_metric)'
+  - # Missing "le" label.
+    query: 'histogram_quantile(0.9, demo_memory_usage_bytes)'
+  - # Missing "le" label only in some series of the same grouping.
+    query: 'histogram_quantile(0.9, {__name__=~"demo_api_request_duration_seconds_.+"})'
+  - query: 'count_values("value", demo_api_request_duration_seconds_bucket)'
+  - query: 'absent(demo_memory_usage_bytes)'
+  - query: 'absent(nonexistent_metric_name)'
+
+  # Subqueries.
+  - query: 'max_over_time((time() - max(demo_batch_last_success_timestamp_seconds) < 1000)[5m:10s] offset 5m)'
+  - query: 'avg_over_time(rate(demo_cpu_usage_seconds_total[1m])[2m:10s])'

--- a/harness/compatibility/scripts/run-compatibility.sh
+++ b/harness/compatibility/scripts/run-compatibility.sh
@@ -16,7 +16,10 @@
 #
 # Env:
 #   TESTER_OUTPUT     report file path (default: harness/compatibility/report.json)
-#   TESTER_QUERIES    queries yaml (default: upstream/promql/promql-test-queries.yml)
+#   TESTER_QUERIES    queries yaml (default: harness/compatibility/cerberus-test-queries.yml,
+#                     a curated copy of upstream/promql/promql-test-queries.yml
+#                     with corpus-incompatible should_fail entries removed —
+#                     see the file header for the policy)
 #   TESTER_END_TIME   compatibility end timestamp (default: 2026-05-11T01:00:00Z)
 #   TESTER_RANGE      range in seconds (default: 3600 = 1h, matches seed window)
 #
@@ -38,7 +41,7 @@ ROOT_DIR=$(cd "$(dirname "$0")/.." && pwd)
 cd "$ROOT_DIR"
 
 OUTPUT=${TESTER_OUTPUT:-"$ROOT_DIR/report.json"}
-QUERIES=${TESTER_QUERIES:-"$ROOT_DIR/upstream/promql/promql-test-queries.yml"}
+QUERIES=${TESTER_QUERIES:-"$ROOT_DIR/cerberus-test-queries.yml"}
 END_TIME=${TESTER_END_TIME:-"2026-05-11T01:00:00Z"}
 RANGE=${TESTER_RANGE:-3600}
 
@@ -60,7 +63,24 @@ TESTER_BIN="$ROOT_DIR/upstream/promql/cmd/promql-compliance-tester/promql-compli
 # overlay carries CI-volatile values (END_TIME / RANGE) which are
 # expected to differ per local invocation and per CI dispatch.
 OVERLAY=$(mktemp -t cerberus-compat-overlay.XXXXXX.yml)
-trap 'rm -f "$OVERLAY"' EXIT
+
+# Consolidated cleanup: remove the overlay AND tear down the compose
+# stack on every exit path (success, tester failure, set -e abort,
+# manual SIGINT). Without this, a non-zero tester exit propagated by
+# `set -e` would leak the stack across re-runs — local repros, in
+# particular, would inherit dirty CH state and confuse subsequent
+# debugging.
+cleanup() {
+    rc=$?
+    rm -f "$OVERLAY"
+    if [ -z "${COMPOSE_KEEP:-}" ]; then
+        echo "==> tearing down (set COMPOSE_KEEP=1 to leave running)"
+        docker compose down -v || true
+    fi
+    exit "$rc"
+}
+trap cleanup EXIT
+
 cat > "$OVERLAY" <<EOF
 query_time_parameters:
   end_time: '${END_TIME}'
@@ -68,25 +88,26 @@ query_time_parameters:
 EOF
 
 echo "==> running tester"
-# Note: NO `|| true` here. A non-zero exit from the tester is meaningful:
-#   - flag parsing / config errors (exit 2) → real harness bug
-#   - per-query divergences are emitted INSIDE the JSON report, not via
-#     exit code — the tester exits 0 even when individual queries
-#     diverge, so we lose no signal by failing-fast on a non-zero exit.
-# Stdout (the JSON report) and stderr (operator-readable log lines from
-# the tester) are split so the report file stays parseable while errors
-# remain visible in CI logs.
+# Note: NO `|| true` here. The tester's exit code is meaningful:
+#   - 0 → every test passed (no diffs, no unexpected failures)
+#   - 1 → at least one diff / unexpected failure (allSuccess=false in
+#         the tester's main.go), OR log.Fatalf on a corpus-vs-tester
+#         mismatch (e.g. should_fail entry that no longer fails)
+#   - 2 → flag parse / config load / build error
+# The `set +e` window is just wide enough to capture the exit code so
+# we can emit the report summary before propagating the failure. The
+# cleanup trap tears down the compose stack on every exit path.
+set +e
 "$TESTER_BIN" \
     -config-file "$ROOT_DIR/test-cerberus.yml" \
     -config-file "$QUERIES" \
     -config-file "$OVERLAY" \
     -output-format json > "$OUTPUT"
+TESTER_RC=$?
+set -e
 
 echo "==> report written to $OUTPUT"
 echo "==> summary:"
-jq '{total: (.totalResults // (.results | length)), passed: ([.results[]? | select(.unexpectedFailure == null and .diff == null)] | length)}' "$OUTPUT" 2>/dev/null || echo "(install jq for summary)"
+jq '{total: ([.results[]?] | length), passed: ([.results[]? | select((.unexpectedFailure // "") == "" and (.diff // "") == "")] | length), diffs: ([.results[]? | select((.diff // "") != "")] | length), unexpected_failures: ([.results[]? | select((.unexpectedFailure // "") != "")] | length)}' "$OUTPUT" 2>/dev/null || echo "(install jq for summary)"
 
-if [ -z "${COMPOSE_KEEP:-}" ]; then
-    echo "==> tearing down (set COMPOSE_KEEP=1 to leave running)"
-    docker compose down -v
-fi
+exit "$TESTER_RC"

--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -175,12 +175,16 @@ func (h *Handler) handleParseQuery(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) handleQuery(w http.ResponseWriter, r *http.Request) {
-	q := r.URL.Query().Get("query")
+	// r.FormValue merges URL query params with POST form-encoded body
+	// (auto-calling ParseForm). Upstream Prometheus accepts `query=...`
+	// in either; Grafana + the prometheus/client_golang library POST
+	// with application/x-www-form-urlencoded for instant queries.
+	q := r.FormValue("query")
 	if q == "" {
 		writeError(w, http.StatusBadRequest, ErrBadData, errors.New("missing query parameter"))
 		return
 	}
-	ts, err := format.ParseTimeProm(r.URL.Query().Get("time"), time.Now())
+	ts, err := format.ParseTimeProm(r.FormValue("time"), time.Now())
 	if err != nil {
 		writeError(w, http.StatusBadRequest, ErrBadData, err)
 		return
@@ -215,22 +219,27 @@ func (h *Handler) handleQuery(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) handleQueryRange(w http.ResponseWriter, r *http.Request) {
-	q := r.URL.Query().Get("query")
+	// r.FormValue merges URL query params with POST form-encoded body
+	// (auto-calling ParseForm). Upstream Prometheus accepts these in
+	// either form, and the prometheus/client_golang library defaults
+	// to POST application/x-www-form-urlencoded for range queries
+	// (see DoGetFallback in client_golang/api/prometheus/v1/api.go).
+	q := r.FormValue("query")
 	if q == "" {
 		writeError(w, http.StatusBadRequest, ErrBadData, errors.New("missing query parameter"))
 		return
 	}
-	start, err := format.ParseTimeProm(r.URL.Query().Get("start"), time.Time{})
+	start, err := format.ParseTimeProm(r.FormValue("start"), time.Time{})
 	if err != nil || start.IsZero() {
 		writeError(w, http.StatusBadRequest, ErrBadData, errors.New("missing or invalid 'start' parameter"))
 		return
 	}
-	end, err := format.ParseTimeProm(r.URL.Query().Get("end"), time.Time{})
+	end, err := format.ParseTimeProm(r.FormValue("end"), time.Time{})
 	if err != nil || end.IsZero() {
 		writeError(w, http.StatusBadRequest, ErrBadData, errors.New("missing or invalid 'end' parameter"))
 		return
 	}
-	step, err := format.ParseDuration(r.URL.Query().Get("step"))
+	step, err := format.ParseDuration(r.FormValue("step"))
 	if err != nil || step <= 0 {
 		writeError(w, http.StatusBadRequest, ErrBadData, errors.New("missing or invalid 'step' parameter"))
 		return

--- a/internal/api/prom/handler_error_paths_test.go
+++ b/internal/api/prom/handler_error_paths_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"testing"
@@ -11,12 +12,72 @@ import (
 	"github.com/tsouza/cerberus/internal/api/prom"
 )
 
-// POST-form tests for /api/v1/query and /api/v1/query_range are
-// intentionally absent until cerberus's handler reads from
-// r.FormValue() / r.PostFormValue() instead of r.URL.Query() (today's
-// implementation reads URL query string only, so POST form bodies are
-// silently ignored — a real gap vs upstream Prometheus). When the
-// handler is fixed, re-add TestQuery_POST + TestQueryRange_POST here.
+// TestQueryPOSTForm + TestQueryRangePOSTForm pin the handler's POST-form
+// behaviour. Background: prior to this fix, the handlers read `query` /
+// `start` / `end` / `step` / `time` only from `r.URL.Query()`, so a POST
+// request with an `application/x-www-form-urlencoded` body had its params
+// silently ignored and the handler returned `400 missing query parameter`.
+// This is the request shape that the prometheus/client_golang library
+// (and therefore the upstream `promql-compliance-tester` driving the
+// compatibility harness) uses by default — DoGetFallback in
+// api/prometheus/v1/api.go POSTs form-encoded by default and only falls
+// back to GET on a 405/501. The handlers now use `r.FormValue` which
+// merges URL query + parsed POST form, matching upstream Prometheus.
+func TestQueryPOSTForm(t *testing.T) {
+	t.Parallel()
+
+	srv := newServer(&stubQuerier{})
+	t.Cleanup(srv.Close)
+
+	// `1+1` is a scalar PromQL — the scalar-fold path short-circuits
+	// before the stub is exercised, so we don't have to load any data.
+	form := url.Values{}
+	form.Set("query", "1+1")
+	form.Set("time", "1700000000")
+	resp, err := http.PostForm(srv.URL+"/api/v1/query", form)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", resp.StatusCode, body)
+	}
+	var env prom.Response
+	if err := json.Unmarshal([]byte(body), &env); err != nil {
+		t.Fatalf("body not JSON: %v; body=%s", err, body)
+	}
+	if env.Status != "success" {
+		t.Errorf("body.status: got %q, want success; body=%s", env.Status, body)
+	}
+}
+
+func TestQueryRangePOSTForm(t *testing.T) {
+	t.Parallel()
+
+	srv := newServer(&stubQuerier{})
+	t.Cleanup(srv.Close)
+
+	form := url.Values{}
+	form.Set("query", "1+1")
+	form.Set("start", "1700000000")
+	form.Set("end", "1700003600")
+	form.Set("step", "60s")
+	resp, err := http.PostForm(srv.URL+"/api/v1/query_range", form)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", resp.StatusCode, body)
+	}
+	var env prom.Response
+	if err := json.Unmarshal([]byte(body), &env); err != nil {
+		t.Fatalf("body not JSON: %v; body=%s", err, body)
+	}
+	if env.Status != "success" {
+		t.Errorf("body.status: got %q, want success; body=%s", env.Status, body)
+	}
+}
 
 // TestErrorResponse_ShapeAndContentType verifies that every error
 // response from cerberus carries:


### PR DESCRIPTION
## Summary

Three compounding defects kept the compatibility harness from running to completion after PRs #297 / #298 / #301 fixed the surface-level infra issues.

### Defect 1 — `/api/v1/query` + `/api/v1/query_range` only read `r.URL.Query()`

The upstream `prometheus/client_golang` library defaults to POST `application/x-www-form-urlencoded` for both endpoints (see `DoGetFallback` in `api/prometheus/v1/api.go`) and only falls back to GET on a 405/501. The handlers silently dropped the form body and returned `400 bad_data: missing query parameter` on every test — the compliance tester drives the harness through the prometheus client, so **all 534 non-`should_fail` queries failed with that single canned error**.

Fix: switch the two handlers to `r.FormValue` (auto-`ParseForm` + URL-query merge, matching upstream Prom). The smaller `handleFormatQuery` + `handleParseQuery` already had a manual POST-form fallback and are left as-is.

### Defect 2 — three `should_fail: true` upstream queries crash the tester

Upstream `promql-test-queries.yml` annotates `label_replace(demo_num_cpus, "~invalid", …)`, `label_replace(demo_num_cpus, "instance", "", "", "")`, and `label_join(demo_num_cpus, "~invalid", …)` as `should_fail: true`. Each only hits the validation-error path when the input vector is non-empty — Prom's executor short-circuits empty results before the label validation runs. The OTel seed corpus does **not** populate `demo_num_cpus`, so ref Prom returns empty success and the upstream tester `log.Fatalf`'s on the first mismatch (`expected reference API query … to fail, but succeeded`), aborting before recording a single diff.

Fix: drop those three entries into `harness/compatibility/cerberus-test-queries.yml`, a curated copy of the upstream file with policy + omissions documented in its header. The script defaults to this file (override remains via `TESTER_QUERIES`). Restoring the queries is M1.x scope, gated on the seed growing to cover `demo_num_cpus`.

### Defect 3 — jq filter counts `unexpectedFailure == null` but tester writes `""`

The upstream tester writes empty strings, not JSON null. `select(.unexpectedFailure == null)` was therefore never true, and the Summarise step + script summary both reported `passed: 0` regardless of how many queries actually passed. Fix: `(.unexpectedFailure // "") == ""` in both call sites.

### Bonus: compose-stack cleanup on tester failure

The previous `if [ -z \"\$COMPOSE_KEEP\" ]; then docker compose down -v; fi` sat *below* the tester call. With `set -e`, a failing tester aborted the script before reaching the cleanup block, leaking the compose stack across local re-runs. Extending the existing `trap` to tear down the stack on every exit path fixes that.

## Manual-run verification (local `just compatibility` on this branch)

```
==> running tester
536 / 536 [-------------------------------------------------] 100.00% 616 p/s
==> report written to harness/compatibility/report.json
==> summary:
{
  \"total\": 536,
  \"passed\": 327,
  \"diffs\": 0,
  \"unexpected_failures\": 209
}
```

The 209 remaining failures are **real cerberus PromQL gaps** surfaced for the first time — `function time is not yet supported`, `scalar-only binary expressions not yet lowered`, `'bool' modifier on vector-vector binops is not yet supported`, missing date/time functions, etc. Each is a legitimate compatibility delta and lands as a per-function PR in RC1/RC2. None of them are caused by this change.

## Stop-conditions reconciliation

- Compatibility harness runs to completion with cerberus container healthy: **yes** (536/536 queries processed)
- Manual workflow dispatch on the branch is green: **no, and intentionally so** — the workflow is red because the 209 PromQL gaps are real failures the harness now correctly surfaces. Making the workflow green would require either (a) wiring `expected-failures.json` reconciliation (M1.x scope), or (b) re-adding masking (explicitly forbidden by the task). This PR makes the harness *honest*; turning red→green is the next-RC follow-up.
- No masking added: **confirmed.** No `|| true`, no `if: always()` on the fail-gate step, no `continue-on-error`.

## Test plan

- [x] `TestQueryPOSTForm` / `TestQueryRangePOSTForm` pin the POST-form contract.
- [x] `just compatibility` locally: 327 passes, 0 diffs, 209 unexpected_failures (real PromQL gaps); harness runs to completion.
- [ ] Post-merge `compatibility` workflow on main shows 327 passed / 209 unexpected_failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)