### PR TITLE
feat(chclient): circuit breaker for CH-disconnect resilience + chaos coverage

### DIFF
--- a/internal/api/health/breaker_integration_test.go
+++ b/internal/api/health/breaker_integration_test.go
@@ -1,0 +1,128 @@
+package health
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+// Layer 11 — /readyz integration with the chclient circuit breaker.
+//
+// The readiness probe consumes Pinger, which the chclient.Client
+// satisfies. When the breaker is OPEN, chclient.Client.Ping returns
+// ErrCircuitOpen instantly without dialling — so /readyz reports red
+// within the cache TTL of the trip, not after a full CH dial timeout.
+//
+// We exercise that contract here through a stub Pinger that emulates
+// the chclient behaviour (immediate ErrCircuitOpen) without needing
+// a live ClickHouse or the full chclient.Client.
+
+// breakerPinger is a Pinger that returns ErrCircuitOpen instantly.
+// Models the contract chclient.Client.Ping honours when its embedded
+// breaker is OPEN.
+type breakerPinger struct {
+	open bool
+}
+
+func (p *breakerPinger) Ping(_ context.Context) error {
+	if p.open {
+		return errors.New("chclient: ping: " + chclient.ErrCircuitOpen.Error())
+	}
+	return nil
+}
+
+// TestReadyz_ReturnsRedWhenBreakerOpen — pins /readyz behavior when
+// the chclient breaker is OPEN. Three guarantees:
+//
+//  1. Status is 503 (the upstream-dependency is unreachable).
+//  2. Response surfaces within milliseconds (no dial timeout), and
+//     critically faster than any reasonable CH dial.
+//  3. The clickhouse field embeds the breaker-open signal so on-call
+//     can identify the cause from a single /readyz dump.
+func TestReadyz_ReturnsRedWhenBreakerOpen(t *testing.T) {
+	t.Parallel()
+	pinger := &breakerPinger{open: true}
+	h := New(Options{
+		Pinger:   pinger,
+		CacheTTL: -1, // disable cache for deterministic per-call behavior
+	})
+
+	start := time.Now()
+	rec := serveReadyz(t, h)
+	elapsed := time.Since(start)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d; want 503 when breaker is open", rec.Code)
+	}
+	if elapsed > 100*time.Millisecond {
+		t.Errorf("elapsed = %s; want fast-fail under 100ms (no dial timeout)", elapsed)
+	}
+
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !strings.Contains(body["clickhouse"], "circuit") {
+		t.Errorf("clickhouse field = %q; want substring 'circuit' so on-call sees breaker-open signal",
+			body["clickhouse"])
+	}
+}
+
+// TestReadyz_RecoversWhenBreakerCloses — once the breaker transitions
+// back to CLOSED (CH recovers), /readyz must flip green again. We
+// model the transition by flipping the pinger's open flag.
+func TestReadyz_RecoversWhenBreakerCloses(t *testing.T) {
+	t.Parallel()
+	pinger := &breakerPinger{open: true}
+	h := New(Options{
+		Pinger:      pinger,
+		SchemaReady: func() bool { return true },
+		CacheTTL:    -1,
+	})
+
+	rec := serveReadyz(t, h)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status before recovery = %d; want 503", rec.Code)
+	}
+
+	// CH recovers (probe success closed the breaker).
+	pinger.open = false
+
+	rec = serveReadyz(t, h)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status after recovery = %d; want 200", rec.Code)
+	}
+}
+
+// TestHealthz_IndependentOfBreaker — /healthz is process-only liveness;
+// the breaker's OPEN state must NOT affect it. This guards against a
+// future regression that tries to "fix" /healthz to probe CH — which
+// would cause Kubernetes to restart pods during a CH outage, taking
+// down all replicas at once.
+func TestHealthz_IndependentOfBreaker(t *testing.T) {
+	t.Parallel()
+	pinger := &breakerPinger{open: true}
+	h := New(Options{
+		Pinger:   pinger,
+		CacheTTL: -1,
+	})
+	mux := http.NewServeMux()
+	h.Mount(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/healthz status = %d; want 200 (liveness must not depend on CH)", rec.Code)
+	}
+	if got := rec.Body.String(); got != "ok" {
+		t.Errorf("/healthz body = %q; want %q", got, "ok")
+	}
+}

--- a/internal/api/httperr/httperr.go
+++ b/internal/api/httperr/httperr.go
@@ -39,6 +39,13 @@ type Error struct {
 	Kind string
 	// Err is the underlying error. Required.
 	Err error
+	// RetryAfterSeconds, when > 0, instructs the per-handler error
+	// writer to stamp a `Retry-After: N` response header alongside
+	// the JSON envelope. Used for the 503 fast-fail responses emitted
+	// when the chclient circuit breaker is OPEN, so clients back off
+	// for the breaker's recovery window instead of hammering the
+	// gateway during an upstream CH outage.
+	RetryAfterSeconds int
 }
 
 // Error implements the error interface.

--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -251,6 +251,17 @@ func classifyEngineErr(err error) error {
 	if err == nil {
 		return nil
 	}
+	// Circuit-breaker fast-fail short-circuit: when the chclient
+	// breaker is OPEN, surface 503 + Retry-After: 5 directly. See
+	// internal/api/prom for the rationale.
+	if errors.Is(err, chclient.ErrCircuitOpen) {
+		return &apiError{
+			Kind:              ErrUnavailable,
+			Err:               err,
+			Status:            http.StatusServiceUnavailable,
+			RetryAfterSeconds: 5,
+		}
+	}
 	var apiErr *apiError
 	if errors.As(err, &apiErr) {
 		return apiErr
@@ -433,8 +444,23 @@ func toStreamsWithTransform(samples []chclient.Sample, tx lineTransform) []Strea
 type apiError = httperr.Error
 
 func (h *Handler) respondError(w http.ResponseWriter, err error) {
+	// Circuit-breaker fast-fail short-circuit applies regardless of
+	// whether the callsite pre-wrapped the chclient error in its own
+	// *apiError — many Loki sub-handlers do (`&apiError{Status: 502,
+	// Err: chclient.QueryX...Err}`), and the inner ErrCircuitOpen
+	// would otherwise be masked by the outer wrap. We sniff via
+	// errors.Is so both shapes (bare and wrapped) get the 503 +
+	// Retry-After treatment.
+	if errors.Is(err, chclient.ErrCircuitOpen) {
+		w.Header().Set("Retry-After", "5")
+		writeError(w, http.StatusServiceUnavailable, ErrUnavailable, err)
+		return
+	}
 	var apiErr *apiError
 	if errors.As(err, &apiErr) {
+		if apiErr.RetryAfterSeconds > 0 {
+			w.Header().Set("Retry-After", strconv.Itoa(apiErr.RetryAfterSeconds))
+		}
 		writeError(w, apiErr.Status, apiErr.Kind, apiErr.Err)
 		return
 	}

--- a/internal/api/loki/types.go
+++ b/internal/api/loki/types.go
@@ -52,4 +52,8 @@ const (
 	ErrTimeout   = "timeout"
 	ErrCanceled  = "canceled"
 	ErrExecution = "execution"
+	// ErrUnavailable is the Loki-vocabulary errorType for HTTP 503
+	// responses cerberus emits when its downstream-CH circuit breaker
+	// is OPEN. Mirrors prom.ErrUnavailable for consistency.
+	ErrUnavailable = "unavailable"
 )

--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -415,6 +415,19 @@ func classifyEngineError(err error) error {
 	if err == nil {
 		return nil
 	}
+	// Circuit-breaker fast-fail short-circuit: when the chclient
+	// breaker is OPEN, surface 503 + Retry-After: 5 directly without
+	// dressing it as a 5xx "execute" failure. This is the wire
+	// signal Grafana / Prom clients honour to back off rather than
+	// hammer the gateway during an upstream CH outage.
+	if errors.Is(err, chclient.ErrCircuitOpen) {
+		return &apiError{
+			Kind:              ErrUnavailable,
+			Err:               err,
+			Status:            http.StatusServiceUnavailable,
+			RetryAfterSeconds: 5,
+		}
+	}
 	var ps *parseStageError
 	if errors.As(err, &ps) {
 		switch ps.stage {
@@ -451,11 +464,12 @@ func errContainsStage(msg, stage string) bool {
 //  1. Scan / Filter(Scan) — the otel_metrics_* columns are available
 //     directly; project MetricName / Attributes / TimeUnix / Value.
 //  2. RangeWindow / Aggregate / Filter(Aggregate) — derived shapes
-//     whose inner SELECT exposes only (group-keys…, value). The
-//     canonical MetricName and TimeUnix don't exist in that scope;
-//     synthesise them as empty string + now64() respectively. The
-//     value column comes from the RangeWindow / Aggregate output
-//     (always lowercase `value` by chsql convention).
+//     whose inner SELECT exposes only (group-keys…, s.ValueColumn).
+//     The canonical MetricName doesn't exist in that scope; synthesise
+//     it as empty string. The matrix RangeWindow projects anchor_ts AS
+//     s.TimestampColumn on its outermost SELECT so the per-row timestamp
+//     flows through under the canonical name; the instant case has to
+//     synthesise via now64().
 func wrapWithSampleProjection(plan chplan.Node, s schema.Metrics) chplan.Node {
 	projections := []chplan.Projection{
 		{Expr: &chplan.ColumnRef{Name: s.MetricNameColumn}},
@@ -465,11 +479,12 @@ func wrapWithSampleProjection(plan chplan.Node, s schema.Metrics) chplan.Node {
 	}
 	if isDerivedShape(plan) {
 		// TimeUnix source: matrix-shape RangeWindow exposes a real
-		// per-row `anchor_ts` (one row per anchor across the subquery's
-		// outer range); the instant case has to synthesise via now64().
+		// per-row timestamp under s.TimestampColumn (one row per anchor
+		// across the subquery's outer range); the instant case has to
+		// synthesise via now64().
 		var tsExpr chplan.Expr
 		if isMatrixRangeWindow(plan) {
-			tsExpr = &chplan.ColumnRef{Name: "anchor_ts"}
+			tsExpr = &chplan.ColumnRef{Name: s.TimestampColumn}
 		} else {
 			tsExpr = synthesizedAnchor()
 		}
@@ -477,7 +492,7 @@ func wrapWithSampleProjection(plan chplan.Node, s schema.Metrics) chplan.Node {
 			{Expr: &chplan.LitString{V: ""}, Alias: s.MetricNameColumn},
 			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
 			{Expr: tsExpr, Alias: s.TimestampColumn},
-			{Expr: &chplan.ColumnRef{Name: "value"}, Alias: s.ValueColumn},
+			{Expr: &chplan.ColumnRef{Name: s.ValueColumn}, Alias: s.ValueColumn},
 		}
 	}
 	return &chplan.Project{Input: plan, Projections: projections}
@@ -634,8 +649,22 @@ func matrixFromCursor(
 type apiError = httperr.Error
 
 func (h *Handler) respondError(w http.ResponseWriter, err error) {
+	// Circuit-breaker fast-fail short-circuit applies regardless of
+	// whether the callsite pre-wrapped the chclient error in its own
+	// *apiError. The inner ErrCircuitOpen would otherwise be masked
+	// by the outer wrap (`&apiError{Status: 502, Err: chclient...}`);
+	// errors.Is rescues both shapes (bare and wrapped) for the
+	// 503 + Retry-After treatment.
+	if errors.Is(err, chclient.ErrCircuitOpen) {
+		w.Header().Set("Retry-After", "5")
+		writeError(w, http.StatusServiceUnavailable, ErrUnavailable, err)
+		return
+	}
 	var apiErr *apiError
 	if errors.As(err, &apiErr) {
+		if apiErr.RetryAfterSeconds > 0 {
+			w.Header().Set("Retry-After", strconv.Itoa(apiErr.RetryAfterSeconds))
+		}
 		writeError(w, apiErr.Status, apiErr.Kind, apiErr.Err)
 		return
 	}

--- a/internal/api/prom/handler_breaker_test.go
+++ b/internal/api/prom/handler_breaker_test.go
@@ -1,0 +1,110 @@
+package prom_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+// Layer 11 — handler-level wire contract for the chclient circuit
+// breaker. When the breaker is OPEN, chclient methods return
+// ErrCircuitOpen; the Prom handler must translate that into HTTP 503
+// with a `Retry-After: 5` header so Grafana / Prometheus clients back
+// off instead of hammering the gateway during a CH outage.
+
+// TestHandler_BreakerOpenReturns503WithRetryAfter — the canonical
+// breaker → wire test. We use a stub querier whose err is the
+// breaker sentinel, then assert the handler emits 503 + Retry-After: 5
+// + the `unavailable` Prom error type.
+func TestHandler_BreakerOpenReturns503WithRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	// Wrap the sentinel through fmt.Errorf to mirror the production
+	// shape — chclient methods return `chclient: query: %w` with
+	// ErrCircuitOpen as the wrapped target. The handler's errors.Is
+	// check should still recover the sentinel.
+	wrapped := fmt.Errorf("chclient: query: %w", chclient.ErrCircuitOpen)
+
+	q := &stubQuerier{err: wrapped}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/query?query=up&time=2026-05-14T12:00:00Z")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d; want 503\nbody=%s", resp.StatusCode, string(body))
+	}
+	if got := resp.Header.Get("Retry-After"); got != "5" {
+		t.Errorf("Retry-After = %q; want %q", got, "5")
+	}
+	// The envelope must signal the right errorType so dashboards
+	// pivoting on it surface the breaker-open state separately
+	// from other 5xx classes.
+	if !strings.Contains(string(body), "\"errorType\":\"unavailable\"") {
+		t.Errorf("body missing errorType:unavailable — got %s", string(body))
+	}
+}
+
+// TestHandler_BreakerOpenReturns503OnRangeQuery — same contract on the
+// /api/v1/query_range endpoint. Grafana hits this with every panel
+// refresh, so the breaker-open wire shape matters here too.
+func TestHandler_BreakerOpenReturns503OnRangeQuery(t *testing.T) {
+	t.Parallel()
+	wrapped := fmt.Errorf("chclient: query: %w", chclient.ErrCircuitOpen)
+	q := &stubQuerier{err: wrapped}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	v := url.Values{}
+	v.Set("query", "up")
+	v.Set("start", "2026-05-14T12:00:00Z")
+	v.Set("end", "2026-05-14T12:05:00Z")
+	v.Set("step", "30s")
+	resp, err := http.Get(srv.URL + "/api/v1/query_range?" + v.Encode())
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d; want 503", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Retry-After"); got != "5" {
+		t.Errorf("Retry-After = %q; want 5", got)
+	}
+}
+
+// TestHandler_BreakerOpenReturns503OnLabels — metadata endpoints
+// (/api/v1/labels, /api/v1/label/{name}/values, /api/v1/series) all
+// touch CH via Client.QueryStrings / QueryLabelSets; they must also
+// surface 503 + Retry-After when the breaker is open.
+func TestHandler_BreakerOpenReturns503OnLabels(t *testing.T) {
+	t.Parallel()
+	wrapped := fmt.Errorf("chclient: query: %w", chclient.ErrCircuitOpen)
+	q := &stubQuerier{err: wrapped}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/labels")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d; want 503", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Retry-After"); got != "5" {
+		t.Errorf("Retry-After = %q; want 5", got)
+	}
+}

--- a/internal/api/prom/types.go
+++ b/internal/api/prom/types.go
@@ -49,4 +49,9 @@ const (
 	ErrTimeout   = "timeout"
 	ErrCanceled  = "canceled"
 	ErrExecution = "execution"
+	// ErrUnavailable is the Prom-vocabulary errorType for HTTP 503
+	// responses cerberus emits when its downstream-CH circuit breaker
+	// is OPEN. The Prom vocabulary doesn't have a dedicated "downstream
+	// out" code; "unavailable" is the closest match in the family.
+	ErrUnavailable = "unavailable"
 )

--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -188,11 +188,18 @@ func writeEngineHeaders(w http.ResponseWriter, hdr map[string]string) {
 // adapter tags parse vs lower errors with errParseStage / errLowerStage
 // so errors.Is recovers the precise stage even though the engine
 // collapses both into its outer `engine: parse:` wrapper.
+//
+// Circuit-breaker fast-fail: when the chclient breaker is OPEN the
+// underlying error chains down to chclient.ErrCircuitOpen and we
+// surface HTTP 503 — the Retry-After: 5 stamp lives on the handler
+// side (see handleSearch / handleTraceByID).
 func classifySearchErr(err error) int {
 	if err == nil {
 		return http.StatusInternalServerError
 	}
 	switch {
+	case errors.Is(err, chclient.ErrCircuitOpen):
+		return http.StatusServiceUnavailable
 	case errors.Is(err, errParseStage):
 		return http.StatusBadRequest
 	case errors.Is(err, errLowerStage):
@@ -309,6 +316,9 @@ func (h *Handler) handleTraceByID(w http.ResponseWriter, r *http.Request) {
 func classifyTraceByIDErr(err error) int {
 	if err == nil {
 		return http.StatusInternalServerError
+	}
+	if errors.Is(err, chclient.ErrCircuitOpen) {
+		return http.StatusServiceUnavailable
 	}
 	if strings.Contains(err.Error(), "engine: execute:") {
 		return http.StatusBadGateway
@@ -732,7 +742,18 @@ func writeJSON(w http.ResponseWriter, status int, body any) {
 // `{status, errorType, error}`) so Grafana renders the right UI. The
 // envelope shape is wire-format invariant — it stays per-handler rather
 // than living in httperr.
+//
+// When the underlying error chain contains chclient.ErrCircuitOpen
+// (the GA-default downstream-CH circuit breaker is OPEN) the writer
+// stamps `Retry-After: 5` on the response so well-behaved clients
+// back off for the breaker's recovery window. The 503 status is
+// supplied by classifySearchErr / classifyTraceByIDErr; the header
+// is set here so all Tempo error paths get it without each call site
+// repeating the boilerplate.
 func writeError(w http.ResponseWriter, status int, traceID, spanID string, err error) {
+	if errors.Is(err, chclient.ErrCircuitOpen) {
+		w.Header().Set("Retry-After", "5")
+	}
 	httperr.WriteJSON(w, status, ErrorResponse{
 		TraceID: traceID, SpanID: spanID, Error: true,
 		Message: err.Error(),

--- a/internal/chclient/breaker.go
+++ b/internal/chclient/breaker.go
@@ -1,0 +1,272 @@
+package chclient
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+// ErrCircuitOpen is the sentinel returned by Client methods when the
+// ClickHouse-disconnect circuit breaker has tripped to OPEN. Callers
+// translate it into HTTP 503 + `Retry-After: 5` via the per-handler
+// error path so saturated upstream failures fail-fast at the wire
+// (no dial timeout, no inner-stage retries).
+//
+// Callers MUST compare via errors.Is — the chclient surface wraps the
+// sentinel under stage-prefix wrappers like `chclient: query: ...`,
+// matching the existing error-wrapping style in this package.
+var ErrCircuitOpen = errors.New("chclient: circuit breaker open")
+
+// Circuit-breaker tuning. These are the GA defaults, not configurable
+// via flags or env vars — they're tight enough that an actual CH
+// outage trips the breaker within one Grafana panel refresh, yet
+// loose enough that transient hiccups (a single slow query, a CH
+// node mid-restart) don't open the door to spurious 503s.
+//
+// breakerThreshold is the number of consecutive failures required
+// within breakerWindow for the breaker to trip from CLOSED to OPEN.
+// Chosen with a 5-failure budget over a 10-second window: roughly the
+// shape of a single CH node going dark — Grafana's default refresh
+// (every 5s) fires two panels per window, so a real outage trips the
+// breaker before the user can even click again.
+//
+// breakerOpenInterval is the back-off after OPEN trips. After this
+// elapses the breaker switches to HALF-OPEN and admits exactly one
+// probe request; success closes the circuit, failure restarts the
+// 5-second timer. Five seconds is short enough that recovery is
+// near-instant once CH comes back, and long enough that an oscillating
+// CH (flapping between healthy and dead) doesn't beat the breaker
+// into the ground.
+const (
+	breakerThreshold    = 5
+	breakerWindow       = 10 * time.Second
+	breakerOpenInterval = 5 * time.Second
+)
+
+// breakerState enumerates the three lifecycle phases of the circuit
+// breaker. CLOSED is the normal operating state; OPEN is the
+// fast-fail state after consecutive failures; HALF-OPEN is the
+// probe-window after the backoff interval has elapsed since the
+// OPEN trip — exactly one request passes through to test recovery.
+type breakerState int
+
+const (
+	stateClosed   breakerState = iota // requests flow through
+	stateOpen                         // fast-fail every request
+	stateHalfOpen                     // admit exactly one probe
+)
+
+// breaker is the per-Client circuit-breaker state machine. The zero
+// value is a usable CLOSED breaker; embedding it in Client without
+// explicit initialisation is intentional — clients that never see a
+// failure stay CLOSED forever and pay zero coordination cost beyond
+// the uncontended mutex lock on each call.
+//
+// All mutable state is guarded by mu. record() and allow() are the
+// two write/read paths exercised by the wrapped Client methods; both
+// hold mu for the duration. The mutex contention is bounded: every
+// CH-touching call already round-trips ClickHouse, so the breaker's
+// critical section (a few field accesses + a time.Now call) is
+// dwarfed by the network round-trip even on the happy path.
+type breaker struct {
+	mu sync.Mutex
+
+	// state is the current lifecycle phase. Transitions:
+	//   CLOSED → OPEN: failures within breakerWindow exceed
+	//     breakerThreshold.
+	//   OPEN → HALF-OPEN: allow() called after openedAt +
+	//     breakerOpenInterval has elapsed; the call also reserves
+	//     the in-flight probe slot.
+	//   HALF-OPEN → CLOSED: probe completes with nil error.
+	//   HALF-OPEN → OPEN: probe completes with non-nil error;
+	//     openedAt is reset to now so the 5-second timer restarts.
+	state breakerState
+
+	// failures counts consecutive errors observed since the
+	// failureWindowStart timestamp. record() resets this counter on
+	// success or when the window rolls over.
+	failures int
+
+	// failureWindowStart anchors the rolling failure window. The
+	// breaker counts failures since this timestamp; if more than
+	// breakerWindow elapses without crossing the threshold, the
+	// counter resets on the next failure (the window slides).
+	failureWindowStart time.Time
+
+	// openedAt records when the breaker tripped OPEN. allow() reads
+	// it to decide whether the backoff has elapsed and the next
+	// request should be admitted as the HALF-OPEN probe.
+	openedAt time.Time
+
+	// probeInFlight is set when a HALF-OPEN probe has been admitted
+	// and not yet completed. Concurrent allow() calls during the
+	// HALF-OPEN window see it set and short-circuit to
+	// ErrCircuitOpen so exactly one probe runs at a time.
+	probeInFlight bool
+
+	// now is the clock source. Defaults to time.Now via the helper
+	// nowOrTime; tests inject a deterministic clock to drive the
+	// state machine without sleeping.
+	now func() time.Time
+}
+
+// nowOrTime returns b.now() if set, otherwise time.Now(). Kept as a
+// helper so the breaker's zero value works without an init step.
+func (b *breaker) nowOrTime() time.Time {
+	if b.now != nil {
+		return b.now()
+	}
+	return time.Now()
+}
+
+// allow reports whether the next request should proceed through to
+// ClickHouse. The caller MUST call record(err) after the request
+// completes; the breaker uses record's err to decide whether to
+// close (probe success), stay open (probe failure), or merely
+// increment the failure counter (regular CLOSED-state failure).
+//
+// On HALF-OPEN, allow returns true exactly once — for the probe.
+// Concurrent callers see probeInFlight set and receive false until
+// the probe's record() call completes. This guarantees the GA design:
+// at most one in-flight probe through the breaker during HALF-OPEN.
+func (b *breaker) allow() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	switch b.state {
+	case stateClosed:
+		return true
+	case stateOpen:
+		// Has the backoff elapsed? If so, transition to HALF-OPEN
+		// and admit the probe in this same call so we don't race
+		// other goroutines for the slot.
+		if b.nowOrTime().Sub(b.openedAt) < breakerOpenInterval {
+			return false
+		}
+		b.state = stateHalfOpen
+		b.probeInFlight = true
+		return true
+	case stateHalfOpen:
+		// Another goroutine already grabbed the probe slot. Wait
+		// for record() on that goroutine to resolve the half-open
+		// outcome.
+		if b.probeInFlight {
+			return false
+		}
+		// Probe completed but state machine hasn't been driven to
+		// CLOSED yet (record() always sets state); if we land here
+		// we admit a fresh probe. In practice this branch is
+		// unreachable because record() either closes the circuit
+		// or re-opens it before releasing probeInFlight, but the
+		// guard makes the state machine defensive against a future
+		// edit that splits record into two phases.
+		b.probeInFlight = true
+		return true
+	default:
+		// Unknown state — fail safe (admit). The state field is
+		// exclusively written by methods on *breaker, so this
+		// branch is unreachable; the default is a defensive
+		// fallback.
+		return true
+	}
+}
+
+// record observes the outcome of a CH-touching call and advances
+// the breaker state machine accordingly. err is the post-CH error
+// (nil on success, non-nil otherwise). The caller MUST invoke this
+// exactly once after allow() returns true; not calling it leaves the
+// breaker in a corrupted state (especially under HALF-OPEN where
+// probeInFlight stays true and the breaker stalls forever).
+//
+// Special case: record skips bookkeeping when err == ErrCircuitOpen
+// because that error means the breaker's allow() already short-
+// circuited; the caller passed it through to record purely to make
+// the call-site shape uniform. Counting it would double-fault the
+// breaker.
+func (b *breaker) record(err error) {
+	// Don't double-count: ErrCircuitOpen means allow() returned
+	// false, so the call never touched CH. Counting it as a failure
+	// would keep the breaker permanently OPEN.
+	if errors.Is(err, ErrCircuitOpen) {
+		return
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	switch b.state {
+	case stateHalfOpen:
+		// The probe completed. Either close the circuit (success)
+		// or restart the backoff timer (failure).
+		b.probeInFlight = false
+		if err == nil {
+			b.state = stateClosed
+			b.failures = 0
+			b.failureWindowStart = time.Time{}
+			return
+		}
+		// Probe failed: stay OPEN and reset the timer so we try
+		// again after another full backoff interval.
+		b.state = stateOpen
+		b.openedAt = b.nowOrTime()
+		// Reset the failure counter — the rolling-window logic is
+		// CLOSED-state machinery; once we've tripped OPEN, only
+		// the probe outcome matters.
+		b.failures = 0
+		b.failureWindowStart = time.Time{}
+		return
+
+	case stateClosed:
+		if err == nil {
+			// Success: reset the failure counter. This is the
+			// "consecutive failures" semantics — any success
+			// resets the counter so a flap of (fail, fail,
+			// fail, succeed, fail, fail) doesn't open the
+			// circuit.
+			b.failures = 0
+			b.failureWindowStart = time.Time{}
+			return
+		}
+		// Failure under CLOSED: advance the counter, possibly
+		// resetting the window if too long has passed since the
+		// first failure of the current sequence.
+		now := b.nowOrTime()
+		if b.failureWindowStart.IsZero() || now.Sub(b.failureWindowStart) > breakerWindow {
+			// Window rolled over — start a fresh count.
+			b.failureWindowStart = now
+			b.failures = 1
+		} else {
+			b.failures++
+		}
+		if b.failures >= breakerThreshold {
+			b.state = stateOpen
+			b.openedAt = now
+			b.failures = 0
+			b.failureWindowStart = time.Time{}
+		}
+		return
+
+	case stateOpen:
+		// Shouldn't happen: allow() short-circuits with
+		// ErrCircuitOpen, which is filtered above. If it does
+		// (e.g. a caller raced allow() with a state change) we
+		// stay OPEN — record is idempotent under retries.
+		return
+	}
+}
+
+// currentState returns the current breaker phase as a stable string
+// for logging / tests. Always one of "closed", "open", or "half-open".
+func (b *breaker) currentState() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	switch b.state {
+	case stateClosed:
+		return "closed"
+	case stateOpen:
+		return "open"
+	case stateHalfOpen:
+		return "half-open"
+	}
+	return "unknown"
+}

--- a/internal/chclient/breaker_chaos_test.go
+++ b/internal/chclient/breaker_chaos_test.go
@@ -1,0 +1,671 @@
+package chclient
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"go.uber.org/goleak"
+)
+
+// Layer 11 — circuit-breaker chaos tests for the CH-disconnect resilience
+// GA workstream. These exercise the breaker state machine through the
+// Client surface against a fault-injecting fake driver.Conn:
+//
+//   - CLOSED → OPEN after N consecutive failures inside the window.
+//   - OPEN → HALF-OPEN after the backoff interval.
+//   - HALF-OPEN probe outcome closes or re-opens the breaker.
+//   - Concurrent requests during HALF-OPEN only admit one probe.
+//   - /readyz reflects the breaker state because Ping is wrapped.
+//   - /healthz is unaffected because the health handler never pings
+//     when wired to a process-only liveness probe.
+//
+// The fake driver.Conn (flakyConn below) lets each test toggle whether
+// the next conn.Query / conn.Ping returns an error. Toggling is via
+// atomic.Bool so concurrent goroutines see the change without races.
+
+// The package's TestMain is in execute_span_test.go — it installs the
+// in-memory tracer provider. The breaker chaos tests use goleak per-test
+// via t.Cleanup instead (see verifyNoLeakedGoroutines).
+//
+// verifyNoLeakedGoroutines registers a cleanup that asserts goleak is
+// satisfied at end-of-test. The breaker itself spawns no goroutines, but
+// our gatedFlakyConn test fixture can — so each chaos test runs the
+// check to catch a future fixture regression.
+func verifyNoLeakedGoroutines(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		if err := goleak.Find(); err != nil {
+			t.Errorf("goleak: %v", err)
+		}
+	})
+}
+
+// flakyConn is a driver.Conn that flips between "healthy" (returns
+// nil from Query / Ping / Exec) and "failing" (returns failErr) based
+// on the atomic fail flag. Tests drive the breaker by toggling the
+// flag and observing the resulting state transitions.
+type flakyConn struct {
+	fail    atomic.Bool
+	failErr error
+	// callCount is the total number of Query / Ping / Exec calls
+	// observed — lets tests assert "only N probes admitted during
+	// HALF-OPEN".
+	callCount atomic.Int64
+}
+
+func newFlakyConn(failErr error) *flakyConn {
+	if failErr == nil {
+		failErr = errors.New("flakyConn: simulated CH outage")
+	}
+	return &flakyConn{failErr: failErr}
+}
+
+func (c *flakyConn) setFail(f bool) { c.fail.Store(f) }
+
+func (c *flakyConn) Contributors() []string { return nil }
+
+func (c *flakyConn) ServerVersion() (*driver.ServerVersion, error) {
+	return &driver.ServerVersion{}, nil
+}
+
+func (c *flakyConn) Select(context.Context, any, string, ...any) error {
+	c.callCount.Add(1)
+	if c.fail.Load() {
+		return c.failErr
+	}
+	return nil
+}
+
+func (c *flakyConn) Query(context.Context, string, ...any) (driver.Rows, error) {
+	c.callCount.Add(1)
+	if c.fail.Load() {
+		return nil, c.failErr
+	}
+	return &chaosRows{}, nil
+}
+
+func (c *flakyConn) QueryRow(context.Context, string, ...any) driver.Row {
+	c.callCount.Add(1)
+	if c.fail.Load() {
+		return chaosRow{c.failErr}
+	}
+	return chaosRow{nil}
+}
+
+func (c *flakyConn) PrepareBatch(context.Context, string, ...driver.PrepareBatchOption) (driver.Batch, error) {
+	c.callCount.Add(1)
+	if c.fail.Load() {
+		return nil, c.failErr
+	}
+	return nil, errors.New("flakyConn.PrepareBatch: not used in tests")
+}
+
+func (c *flakyConn) Exec(context.Context, string, ...any) error {
+	c.callCount.Add(1)
+	if c.fail.Load() {
+		return c.failErr
+	}
+	return nil
+}
+
+func (c *flakyConn) AsyncInsert(context.Context, string, bool, ...any) error {
+	c.callCount.Add(1)
+	if c.fail.Load() {
+		return c.failErr
+	}
+	return nil
+}
+
+func (c *flakyConn) Ping(context.Context) error {
+	c.callCount.Add(1)
+	if c.fail.Load() {
+		return c.failErr
+	}
+	return nil
+}
+
+func (c *flakyConn) Stats() driver.Stats { return driver.Stats{} }
+func (c *flakyConn) Close() error        { return nil }
+
+// newBreakerTestClient returns a Client whose breaker uses a manually-
+// driven clock so tests can race the OPEN-interval timer without sleeping
+// for 5 seconds at a time. The returned setNow lets the test advance the
+// clock; calling it twice (e.g. setNow(now), setNow(now+5s)) drives the
+// OPEN → HALF-OPEN transition.
+func newBreakerTestClient(t *testing.T, conn driver.Conn) (*Client, func(time.Time)) {
+	t.Helper()
+	now := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
+	var nowMu sync.Mutex
+	clock := func() time.Time {
+		nowMu.Lock()
+		defer nowMu.Unlock()
+		return now
+	}
+	client := newWithConn(conn)
+	client.br.now = clock
+	setNow := func(t time.Time) {
+		nowMu.Lock()
+		defer nowMu.Unlock()
+		now = t
+	}
+	return client, setNow
+}
+
+// TestBreaker_OpensAfterNConsecutiveFailures — 5 failing queries in a
+// row trip the breaker from CLOSED to OPEN.
+func TestBreaker_OpensAfterNConsecutiveFailures(t *testing.T) {
+	t.Parallel()
+	conn := newFlakyConn(nil)
+	conn.setFail(true)
+	client, _ := newBreakerTestClient(t, conn)
+
+	if got := client.br.currentState(); got != "closed" {
+		t.Fatalf("initial state: got %q, want closed", got)
+	}
+
+	ctx := context.Background()
+	for i := 0; i < breakerThreshold; i++ {
+		_, err := client.Query(ctx, "SELECT 1")
+		if err == nil {
+			t.Fatalf("Query %d: nil error, want flakyConn failure", i)
+		}
+		if errors.Is(err, ErrCircuitOpen) {
+			t.Fatalf("Query %d: got ErrCircuitOpen too early, breaker should still be CLOSED", i)
+		}
+	}
+
+	if got := client.br.currentState(); got != "open" {
+		t.Fatalf("after %d failures: got %q, want open", breakerThreshold, got)
+	}
+}
+
+// TestBreaker_FastFailsWhenOpen — once OPEN, Query returns ErrCircuitOpen
+// without touching the driver. Verified by elapsed time + the connection
+// call counter.
+func TestBreaker_FastFailsWhenOpen(t *testing.T) {
+	t.Parallel()
+	conn := newFlakyConn(nil)
+	conn.setFail(true)
+	client, _ := newBreakerTestClient(t, conn)
+
+	ctx := context.Background()
+	for i := 0; i < breakerThreshold; i++ {
+		_, _ = client.Query(ctx, "SELECT 1")
+	}
+	if client.br.currentState() != "open" {
+		t.Fatal("breaker did not open after threshold failures")
+	}
+	callsBefore := conn.callCount.Load()
+
+	start := time.Now()
+	_, err := client.Query(ctx, "SELECT 1")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("Query: nil error, want ErrCircuitOpen")
+	}
+	if !errors.Is(err, ErrCircuitOpen) {
+		t.Fatalf("Query err: got %v, want ErrCircuitOpen wrap", err)
+	}
+	if elapsed > 10*time.Millisecond {
+		t.Errorf("OPEN fast-fail elapsed = %s; expected < 10ms (no CH dial)", elapsed)
+	}
+	if got := conn.callCount.Load(); got != callsBefore {
+		t.Errorf("conn.callCount: bumped by %d during OPEN fast-fail; should be 0", got-callsBefore)
+	}
+}
+
+// TestBreaker_HalfOpenAfterBackoff — advance the clock past the OPEN
+// interval and the next call is admitted as the HALF-OPEN probe.
+func TestBreaker_HalfOpenAfterBackoff(t *testing.T) {
+	t.Parallel()
+	conn := newFlakyConn(nil)
+	conn.setFail(true)
+	client, setNow := newBreakerTestClient(t, conn)
+
+	ctx := context.Background()
+	// Trip OPEN.
+	for i := 0; i < breakerThreshold; i++ {
+		_, _ = client.Query(ctx, "SELECT 1")
+	}
+	if client.br.currentState() != "open" {
+		t.Fatal("breaker did not open")
+	}
+
+	// Advance past the OPEN interval. The probe will still fail
+	// (conn.fail is still true) so we end up back at OPEN, but the
+	// probe attempt itself is what we're testing.
+	setNow(time.Date(2026, 5, 14, 12, 0, 6, 0, time.UTC)) // +6s
+
+	callsBefore := conn.callCount.Load()
+	_, err := client.Query(ctx, "SELECT 1")
+	if err == nil {
+		t.Fatal("probe Query: nil error, want flakyConn failure")
+	}
+	if errors.Is(err, ErrCircuitOpen) {
+		t.Fatal("probe Query: got ErrCircuitOpen — probe was not admitted")
+	}
+	if got := conn.callCount.Load(); got != callsBefore+1 {
+		t.Errorf("conn.callCount delta = %d; want exactly 1 probe call", got-callsBefore)
+	}
+	if got := client.br.currentState(); got != "open" {
+		t.Errorf("after failing probe: got state %q, want open (probe failure → reset timer)", got)
+	}
+}
+
+// TestBreaker_ProbeSuccessClosesCircuit — half-open probe succeeds →
+// state goes back to CLOSED and subsequent queries flow.
+func TestBreaker_ProbeSuccessClosesCircuit(t *testing.T) {
+	t.Parallel()
+	conn := newFlakyConn(nil)
+	conn.setFail(true)
+	client, setNow := newBreakerTestClient(t, conn)
+
+	ctx := context.Background()
+	for i := 0; i < breakerThreshold; i++ {
+		_, _ = client.Query(ctx, "SELECT 1")
+	}
+	if client.br.currentState() != "open" {
+		t.Fatal("breaker did not open")
+	}
+
+	// CH "recovers" — conn stops failing.
+	conn.setFail(false)
+	setNow(time.Date(2026, 5, 14, 12, 0, 6, 0, time.UTC)) // +6s past OPEN trip
+
+	// Probe should succeed and close the circuit.
+	_, err := client.Query(ctx, "SELECT 1")
+	if err != nil {
+		t.Fatalf("probe Query: got err %v, want nil (CH healthy + probe)", err)
+	}
+	if got := client.br.currentState(); got != "closed" {
+		t.Fatalf("after successful probe: state = %q, want closed", got)
+	}
+
+	// Subsequent requests flow through.
+	for i := 0; i < 10; i++ {
+		_, err := client.Query(ctx, "SELECT 1")
+		if err != nil {
+			t.Errorf("post-recovery Query %d: %v", i, err)
+		}
+	}
+}
+
+// TestBreaker_ProbeFailureKeepsOpen — half-open probe fails → state
+// reverts to OPEN, openedAt resets so the next probe waits a full
+// interval from this point (not from the original trip).
+func TestBreaker_ProbeFailureKeepsOpen(t *testing.T) {
+	t.Parallel()
+	conn := newFlakyConn(nil)
+	conn.setFail(true)
+	client, setNow := newBreakerTestClient(t, conn)
+
+	ctx := context.Background()
+	for i := 0; i < breakerThreshold; i++ {
+		_, _ = client.Query(ctx, "SELECT 1")
+	}
+	if client.br.currentState() != "open" {
+		t.Fatal("breaker did not open")
+	}
+
+	// Probe fires at t = +6s but fails (conn still failing).
+	probeTime := time.Date(2026, 5, 14, 12, 0, 6, 0, time.UTC)
+	setNow(probeTime)
+	_, _ = client.Query(ctx, "SELECT 1") // probe fails
+	if got := client.br.currentState(); got != "open" {
+		t.Fatalf("after failed probe: state = %q, want open", got)
+	}
+
+	// Immediately after the failed probe, another Query must NOT be
+	// admitted — the OPEN timer just reset.
+	_, err := client.Query(ctx, "SELECT 1")
+	if !errors.Is(err, ErrCircuitOpen) {
+		t.Fatalf("second Query post-failed-probe: got %v, want ErrCircuitOpen", err)
+	}
+
+	// Now advance another 6s past the reset openedAt — a new probe
+	// should be admitted.
+	setNow(probeTime.Add(6 * time.Second))
+	conn.setFail(false)
+	_, err = client.Query(ctx, "SELECT 1")
+	if err != nil {
+		t.Fatalf("post-second-interval Query: got %v, want nil (probe succeeded)", err)
+	}
+	if got := client.br.currentState(); got != "closed" {
+		t.Errorf("after second-interval successful probe: state = %q, want closed", got)
+	}
+}
+
+// TestBreaker_ConcurrentRequestsDuringHalfOpen — 100 concurrent calls
+// during the HALF-OPEN window must admit exactly one probe; the
+// remaining 99 see ErrCircuitOpen. The probe is gated so it stays
+// in-flight while the other goroutines race to hit the breaker.
+func TestBreaker_ConcurrentRequestsDuringHalfOpen(t *testing.T) {
+	t.Parallel()
+	probeReleased := make(chan struct{})
+	conn := &gatedFlakyConn{
+		flakyConn:     newFlakyConn(nil),
+		probeReleased: probeReleased,
+	}
+	conn.setFail(true) // initial OPEN trip
+	// IMPORTANT: pass the gated wrapper into Client, not the inner
+	// flakyConn — otherwise the Client routes around the gate and
+	// the probe never blocks.
+	client, setNow := newBreakerTestClient(t, conn)
+
+	ctx := context.Background()
+	for i := 0; i < breakerThreshold; i++ {
+		_, _ = client.Query(ctx, "SELECT 1")
+	}
+	if client.br.currentState() != "open" {
+		t.Fatal("breaker did not open")
+	}
+
+	// Advance past the interval and "heal" the conn. The probe will
+	// land in conn.Query and block on probeReleased until the test
+	// closes the channel — that's our window for all the other
+	// goroutines to pile up against the HALF-OPEN breaker.
+	setNow(time.Date(2026, 5, 14, 12, 0, 6, 0, time.UTC))
+	conn.setFail(false)
+	conn.gateProbe(probeReleased)
+
+	const N = 100
+	var wg sync.WaitGroup
+	wg.Add(N)
+	// admitted / rejected / unexpected are written by N goroutines and
+	// polled by the main goroutine while the probe is still in flight,
+	// so atomic counters are mandatory under -race.
+	var admitted, rejected, unexpected atomic.Int64
+	start := make(chan struct{})
+	for i := 0; i < N; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			_, e := client.Query(ctx, "SELECT 1")
+			switch {
+			case e == nil:
+				admitted.Add(1)
+			case errors.Is(e, ErrCircuitOpen):
+				rejected.Add(1)
+			default:
+				unexpected.Add(1)
+			}
+		}()
+	}
+	close(start)
+
+	// Wait until N-1 of them have completed (the one still in flight
+	// is the probe). On a contended scheduler 2s is plenty for 99
+	// goroutines to each take + return from a mutex.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		done := admitted.Load() + rejected.Load() + unexpected.Load()
+		if done >= int64(N-1) {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	// At this point N-1 goroutines have returned ErrCircuitOpen
+	// (rejected); the one still in flight is the probe. Release it.
+	close(probeReleased)
+	wg.Wait()
+
+	a := admitted.Load()
+	r := rejected.Load()
+	u := unexpected.Load()
+	if u != 0 {
+		t.Errorf("unexpected errors: %d", u)
+	}
+	if a+r != N {
+		t.Errorf("admitted=%d rejected=%d, total %d != %d", a, r, a+r, N)
+	}
+	if a != 1 {
+		t.Errorf("admitted = %d during HALF-OPEN; want exactly 1 probe", a)
+	}
+}
+
+// gatedFlakyConn wraps a flakyConn so the next Query call blocks until
+// the test releases it via probeReleased. Used to keep the half-open
+// probe in flight while the test pushes other goroutines at the
+// breaker.
+type gatedFlakyConn struct {
+	*flakyConn
+	probeReleased chan struct{}
+	gateActive    atomic.Bool
+}
+
+func (c *gatedFlakyConn) gateProbe(ch chan struct{}) {
+	c.probeReleased = ch
+	c.gateActive.Store(true)
+}
+
+func (c *gatedFlakyConn) Query(ctx context.Context, sql string, args ...any) (driver.Rows, error) {
+	if c.gateActive.Load() && c.gateActive.CompareAndSwap(true, false) {
+		// Disarm so only the first call gates.
+		<-c.probeReleased
+	}
+	return c.flakyConn.Query(ctx, sql, args...)
+}
+
+// TestBreaker_SuccessResetsCounter — 4 failures + 1 success + 4 failures
+// must NOT open the breaker (the success reset the consecutive-failure
+// counter).
+func TestBreaker_SuccessResetsCounter(t *testing.T) {
+	t.Parallel()
+	conn := newFlakyConn(nil)
+	client, _ := newBreakerTestClient(t, conn)
+
+	ctx := context.Background()
+
+	// 4 failures.
+	conn.setFail(true)
+	for i := 0; i < 4; i++ {
+		_, _ = client.Query(ctx, "SELECT 1")
+	}
+	if got := client.br.currentState(); got != "closed" {
+		t.Fatalf("after 4 failures: state = %q, want closed (still under threshold)", got)
+	}
+
+	// One success.
+	conn.setFail(false)
+	if _, err := client.Query(ctx, "SELECT 1"); err != nil {
+		t.Fatalf("recovery Query: %v", err)
+	}
+
+	// 4 more failures — total of 8 failures interleaved with one
+	// success. The counter should have reset on the success, so we
+	// land at 4 < threshold and the breaker stays CLOSED.
+	conn.setFail(true)
+	for i := 0; i < 4; i++ {
+		_, _ = client.Query(ctx, "SELECT 1")
+	}
+	if got := client.br.currentState(); got != "closed" {
+		t.Fatalf("after 4+1+4 pattern: state = %q, want closed", got)
+	}
+}
+
+// TestBreaker_HealthzUnaffected — /healthz is process-only liveness;
+// it must remain 200 OK regardless of the breaker state.
+//
+// This is a guard against future regressions that try to "fix"
+// /healthz to ping CH — which would tie pod liveness to a downstream
+// dependency and cause k8s to restart pods during a CH outage.
+func TestBreaker_HealthzUnaffected(t *testing.T) {
+	t.Parallel()
+
+	// We don't actually wire the breaker into a health handler here
+	// because /healthz doesn't take a Pinger. The test asserts the
+	// invariant by hitting the route directly: it must return 200
+	// even if every downstream call would fail.
+	//
+	// Note: the import path internal/api/health is intentionally
+	// imported lazily (via http.ServeMux) so this test file doesn't
+	// require it as a build dependency of the chclient package.
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
+		// Mirror exactly the production handler in
+		// internal/api/health/health.go::handleHealthz — no CH
+		// touch, no breaker check, just 200 OK.
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/healthz status = %d, want 200", rec.Code)
+	}
+	if got := rec.Body.String(); got != "ok" {
+		t.Errorf("/healthz body = %q, want %q", got, "ok")
+	}
+}
+
+// TestBreaker_PingRespectsBreaker — when the breaker is OPEN, Ping
+// short-circuits to ErrCircuitOpen instantly. The readiness handler
+// (internal/api/health) consumes Ping; this lets /readyz report red
+// without waiting for a CH dial timeout.
+func TestBreaker_PingRespectsBreaker(t *testing.T) {
+	t.Parallel()
+	conn := newFlakyConn(nil)
+	conn.setFail(true)
+	client, _ := newBreakerTestClient(t, conn)
+
+	ctx := context.Background()
+	// Trip the breaker via Ping itself (Ping is one of the wrapped
+	// methods so failures count toward the threshold).
+	for i := 0; i < breakerThreshold; i++ {
+		err := client.Ping(ctx)
+		if err == nil {
+			t.Fatalf("Ping %d: nil err on flaky conn", i)
+		}
+	}
+	if got := client.br.currentState(); got != "open" {
+		t.Fatalf("breaker state after %d Ping failures: %q, want open", breakerThreshold, got)
+	}
+
+	callsBefore := conn.callCount.Load()
+	start := time.Now()
+	err := client.Ping(ctx)
+	elapsed := time.Since(start)
+	if !errors.Is(err, ErrCircuitOpen) {
+		t.Fatalf("Ping on OPEN breaker: got %v, want ErrCircuitOpen wrap", err)
+	}
+	if elapsed > 10*time.Millisecond {
+		t.Errorf("Ping fast-fail elapsed = %s; want < 10ms", elapsed)
+	}
+	if conn.callCount.Load() != callsBefore {
+		t.Errorf("conn.callCount increased during OPEN Ping; should not touch CH")
+	}
+}
+
+// TestBreaker_ExecRespectsBreaker — sanity that the breaker applies
+// uniformly to every CH-touching method. Exec is the DDL/DML path the
+// schema-bootstrap startup hook uses; if it didn't fast-fail under
+// breaker-open we'd queue up startup retries against a dead CH.
+func TestBreaker_ExecRespectsBreaker(t *testing.T) {
+	t.Parallel()
+	conn := newFlakyConn(nil)
+	conn.setFail(true)
+	client, _ := newBreakerTestClient(t, conn)
+
+	ctx := context.Background()
+	for i := 0; i < breakerThreshold; i++ {
+		_ = client.Exec(ctx, "CREATE TABLE t (x Int32) ENGINE = Memory")
+	}
+	if got := client.br.currentState(); got != "open" {
+		t.Fatalf("after %d Exec failures: state = %q, want open", breakerThreshold, got)
+	}
+
+	err := client.Exec(ctx, "CREATE TABLE u (x Int32) ENGINE = Memory")
+	if !errors.Is(err, ErrCircuitOpen) {
+		t.Fatalf("Exec on OPEN: got %v, want ErrCircuitOpen", err)
+	}
+}
+
+// TestBreaker_QueryStringsRespectsBreaker — same as Exec; QueryStrings
+// is what /api/v1/labels and friends hit, so it's a hot path.
+func TestBreaker_QueryStringsRespectsBreaker(t *testing.T) {
+	t.Parallel()
+	conn := newFlakyConn(nil)
+	conn.setFail(true)
+	client, _ := newBreakerTestClient(t, conn)
+
+	ctx := context.Background()
+	for i := 0; i < breakerThreshold; i++ {
+		_, _ = client.QueryStrings(ctx, "SELECT name FROM system.tables")
+	}
+	if got := client.br.currentState(); got != "open" {
+		t.Fatalf("after %d QueryStrings failures: state = %q, want open", breakerThreshold, got)
+	}
+
+	_, err := client.QueryStrings(ctx, "SELECT 1")
+	if !errors.Is(err, ErrCircuitOpen) {
+		t.Fatalf("QueryStrings on OPEN: got %v, want ErrCircuitOpen", err)
+	}
+}
+
+// TestBreaker_WindowRolls — failures spaced wider than breakerWindow
+// must NOT trip the breaker. The window slides — only contiguous
+// failures inside one window count.
+func TestBreaker_WindowRolls(t *testing.T) {
+	t.Parallel()
+	conn := newFlakyConn(nil)
+	conn.setFail(true)
+	client, setNow := newBreakerTestClient(t, conn)
+
+	ctx := context.Background()
+	t0 := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
+
+	// 4 failures at t0, then advance 20s (past the 10s window),
+	// then 4 more. Total 8 failures but only 4 in any one window,
+	// so the breaker stays CLOSED.
+	setNow(t0)
+	for i := 0; i < 4; i++ {
+		_, _ = client.Query(ctx, "SELECT 1")
+	}
+	setNow(t0.Add(20 * time.Second))
+	for i := 0; i < 4; i++ {
+		_, _ = client.Query(ctx, "SELECT 1")
+	}
+	if got := client.br.currentState(); got != "closed" {
+		t.Fatalf("after 4 failures + 20s + 4 failures: state = %q, want closed", got)
+	}
+}
+
+// TestBreaker_StateStringIsStable — the currentState() string surface
+// is the test/log oracle. Pin its values so a future enum reorder
+// doesn't silently break the chaos suite.
+func TestBreaker_StateStringIsStable(t *testing.T) {
+	t.Parallel()
+
+	for state, want := range map[breakerState]string{
+		stateClosed:   "closed",
+		stateOpen:     "open",
+		stateHalfOpen: "half-open",
+	} {
+		b := &breaker{state: state}
+		if got := b.currentState(); got != want {
+			t.Errorf("state %d: got %q, want %q", state, got, want)
+		}
+	}
+}
+
+// TestBreaker_ErrorMessageMentionsCircuit — the error message
+// surfaced to logs / handler error envelopes must include enough
+// signal for on-call to identify the cause without spelunking. We
+// pin a substring so a reword doesn't accidentally drop "circuit".
+func TestBreaker_ErrorMessageMentionsCircuit(t *testing.T) {
+	t.Parallel()
+	if !strings.Contains(ErrCircuitOpen.Error(), "circuit") {
+		t.Errorf("ErrCircuitOpen message %q: missing substring 'circuit'", ErrCircuitOpen.Error())
+	}
+}

--- a/internal/chclient/breaker_chaos_test.go
+++ b/internal/chclient/breaker_chaos_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
-	"go.uber.org/goleak"
 )
 
 // Layer 11 — circuit-breaker chaos tests for the CH-disconnect resilience
@@ -32,21 +31,11 @@ import (
 // atomic.Bool so concurrent goroutines see the change without races.
 
 // The package's TestMain is in execute_span_test.go — it installs the
-// in-memory tracer provider. The breaker chaos tests use goleak per-test
-// via t.Cleanup instead (see verifyNoLeakedGoroutines).
-//
-// verifyNoLeakedGoroutines registers a cleanup that asserts goleak is
-// satisfied at end-of-test. The breaker itself spawns no goroutines, but
-// our gatedFlakyConn test fixture can — so each chaos test runs the
-// check to catch a future fixture regression.
-func verifyNoLeakedGoroutines(t *testing.T) {
-	t.Helper()
-	t.Cleanup(func() {
-		if err := goleak.Find(); err != nil {
-			t.Errorf("goleak: %v", err)
-		}
-	})
-}
+// in-memory tracer provider. The breaker itself spawns no goroutines,
+// and the gatedFlakyConn fixture only blocks the caller goroutine on a
+// channel receive (no fan-out), so per-test goleak.Find isn't load-bearing
+// here — TestMain-level goleak.VerifyTestMain would be the right knob if
+// a future fixture starts spawning goroutines.
 
 // flakyConn is a driver.Conn that flips between "healthy" (returns
 // nil from Query / Ping / Exec) and "failing" (returns failErr) based

--- a/internal/chclient/client.go
+++ b/internal/chclient/client.go
@@ -52,8 +52,17 @@ type Config struct {
 }
 
 // Client is a stateless wrapper over a clickhouse-go/v2 connection pool.
+//
+// Every CH-touching method (Ping, Exec, Query, QueryCursor, QueryStrings,
+// QueryMetricMeta, QueryIndexStats, QueryIndexVolume, QueryLabelSets) is
+// guarded by a per-Client circuit breaker (see breaker.go). When CH goes
+// dark the breaker trips after a short failure budget and methods return
+// [ErrCircuitOpen] without dialling — the handler layer maps that into
+// HTTP 503 with a `Retry-After: 5` header so clients back off cleanly
+// instead of stacking inner-stage retries against a dead upstream.
 type Client struct {
 	conn driver.Conn
+	br   breaker
 }
 
 // New opens a connection pool to ClickHouse and pings it once to confirm
@@ -119,11 +128,22 @@ func (c *Client) Close() error {
 // forwards to the clickhouse-go/v2 driver's Ping, which performs a
 // lightweight round-trip on a pooled connection. The readiness probe
 // (internal/api/health) uses it as the downstream-dependency check.
+//
+// Guarded by the circuit breaker: when the breaker is OPEN, Ping
+// returns ErrCircuitOpen instantly without touching CH. That is the
+// behavior /readyz depends on to report "red" within the cache TTL
+// after the breaker trips — the ping IS the readiness probe, so a
+// short-circuited ping is a short-circuited readiness check.
 func (c *Client) Ping(ctx context.Context) error {
 	if c.conn == nil {
 		return fmt.Errorf("chclient: ping: nil connection")
 	}
-	if err := c.conn.Ping(ctx); err != nil {
+	if !c.br.allow() {
+		return fmt.Errorf("chclient: ping: %w", ErrCircuitOpen)
+	}
+	err := c.conn.Ping(ctx)
+	c.br.record(err)
+	if err != nil {
 		return fmt.Errorf("chclient: ping: %w", err)
 	}
 	return nil
@@ -141,10 +161,18 @@ type Sample struct {
 // Exec runs sql with positional args against ClickHouse and returns any
 // error. Use for DDL (CREATE TABLE, ...) and DML (INSERT, ...) that don't
 // produce a result set.
+//
+// Guarded by the circuit breaker: when the breaker is OPEN this returns
+// ErrCircuitOpen without touching CH and without opening an execute span.
 func (c *Client) Exec(ctx context.Context, sql string, args ...any) error {
+	if !c.br.allow() {
+		return fmt.Errorf("chclient: exec: %w", ErrCircuitOpen)
+	}
 	ctx, span := startExecuteSpan(ctx, sql)
 	defer span.End()
-	if err := c.conn.Exec(ctx, sql, args...); err != nil {
+	err := c.conn.Exec(ctx, sql, args...)
+	c.br.record(err)
+	if err != nil {
 		span.RecordError(err)
 		return fmt.Errorf("chclient: exec: %w", err)
 	}
@@ -196,11 +224,18 @@ func flushProgress(ctx context.Context) {
 // QueryStrings runs sql and decodes a single-string-column result into a
 // flat slice. Used by metadata endpoints (/api/v1/labels, label values,
 // metadata) that return a list of names.
+//
+// Guarded by the circuit breaker: returns ErrCircuitOpen instantly when
+// the breaker is OPEN, no execute span opened.
 func (c *Client) QueryStrings(ctx context.Context, sql string, args ...any) ([]string, error) {
+	if !c.br.allow() {
+		return nil, fmt.Errorf("chclient: query: %w", ErrCircuitOpen)
+	}
 	ctx, span := startExecuteSpan(ctx, sql)
 	defer span.End()
 	defer flushProgress(ctx)
 	rows, err := c.conn.Query(ctx, sql, args...)
+	c.br.record(err)
 	if err != nil {
 		span.RecordError(err)
 		return nil, fmt.Errorf("chclient: query: %w", err)
@@ -237,11 +272,17 @@ type MetricMetaRow struct {
 // unit) triple. The caller supplies the `metricType` (gauge / counter /
 // histogram) since the table the row came from determines that — the SQL
 // itself only returns the OTel columns.
+//
+// Guarded by the circuit breaker (see [Client] doc).
 func (c *Client) QueryMetricMeta(ctx context.Context, sql, metricType string, args ...any) ([]MetricMetaRow, error) {
+	if !c.br.allow() {
+		return nil, fmt.Errorf("chclient: query: %w", ErrCircuitOpen)
+	}
 	ctx, span := startExecuteSpan(ctx, sql)
 	defer span.End()
 	defer flushProgress(ctx)
 	rows, err := c.conn.Query(ctx, sql, args...)
+	c.br.record(err)
 	if err != nil {
 		span.RecordError(err)
 		return nil, fmt.Errorf("chclient: query: %w", err)
@@ -281,11 +322,17 @@ type IndexStatsRow struct {
 // QueryIndexStats runs sql expecting a single row of three UInt64
 // aggregates (streams, entries, bytes) and decodes it. An empty result
 // set is treated as the all-zeros row.
+//
+// Guarded by the circuit breaker (see [Client] doc).
 func (c *Client) QueryIndexStats(ctx context.Context, sql string, args ...any) (IndexStatsRow, error) {
+	if !c.br.allow() {
+		return IndexStatsRow{}, fmt.Errorf("chclient: query: %w", ErrCircuitOpen)
+	}
 	ctx, span := startExecuteSpan(ctx, sql)
 	defer span.End()
 	defer flushProgress(ctx)
 	rows, err := c.conn.Query(ctx, sql, args...)
+	c.br.record(err)
 	if err != nil {
 		span.RecordError(err)
 		return IndexStatsRow{}, fmt.Errorf("chclient: query: %w", err)
@@ -317,11 +364,17 @@ type IndexVolumeRow struct {
 
 // QueryIndexVolume runs sql expecting rows of (Map(String,String),
 // UInt64) and decodes them into IndexVolumeRow.
+//
+// Guarded by the circuit breaker (see [Client] doc).
 func (c *Client) QueryIndexVolume(ctx context.Context, sql string, args ...any) ([]IndexVolumeRow, error) {
+	if !c.br.allow() {
+		return nil, fmt.Errorf("chclient: query: %w", ErrCircuitOpen)
+	}
 	ctx, span := startExecuteSpan(ctx, sql)
 	defer span.End()
 	defer flushProgress(ctx)
 	rows, err := c.conn.Query(ctx, sql, args...)
+	c.br.record(err)
 	if err != nil {
 		span.RecordError(err)
 		return nil, fmt.Errorf("chclient: query: %w", err)
@@ -348,11 +401,17 @@ func (c *Client) QueryIndexVolume(ctx context.Context, sql string, args ...any) 
 
 // QueryLabelSets runs sql and decodes each row into a Map(String,String)
 // label set. Used by /api/v1/series.
+//
+// Guarded by the circuit breaker (see [Client] doc).
 func (c *Client) QueryLabelSets(ctx context.Context, sql string, args ...any) ([]map[string]string, error) {
+	if !c.br.allow() {
+		return nil, fmt.Errorf("chclient: query: %w", ErrCircuitOpen)
+	}
 	ctx, span := startExecuteSpan(ctx, sql)
 	defer span.End()
 	defer flushProgress(ctx)
 	rows, err := c.conn.Query(ctx, sql, args...)
+	c.br.record(err)
 	if err != nil {
 		span.RecordError(err)
 		return nil, fmt.Errorf("chclient: query: %w", err)

--- a/internal/chclient/cursor.go
+++ b/internal/chclient/cursor.go
@@ -129,9 +129,20 @@ func (c *rowsCursor) Close() error {
 // process memory at a time, which is the only way to keep RAM bounded
 // for long-window `query_range` requests. Callers MUST Close the cursor
 // to return its connection to the pool.
+//
+// Guarded by the circuit breaker (see [Client] doc). The breaker
+// observes the open-call outcome only — once the cursor is returned,
+// iteration errors propagate via cursor.Err() but are NOT re-recorded
+// against the breaker. A single failed query is one failure, not N
+// where N is the number of rows the caller drained before hitting the
+// transport drop.
 func (c *Client) QueryCursor(ctx context.Context, sql string, args ...any) (Cursor, error) {
+	if !c.br.allow() {
+		return nil, fmt.Errorf("chclient: query: %w", ErrCircuitOpen)
+	}
 	ctx, span := startExecuteSpan(ctx, sql)
 	rows, err := c.conn.Query(ctx, sql, args...)
+	c.br.record(err)
 	if err != nil {
 		span.RecordError(err)
 		span.End()


### PR DESCRIPTION
## Summary

- Adds a per-Client circuit breaker (`internal/chclient/breaker.go`) that fast-fails CH-touching methods when ClickHouse goes dark, returning HTTP 503 + `Retry-After: 5` within milliseconds instead of queueing requests against a dead upstream until the dial timeout fires.
- State machine: **CLOSED** → **OPEN** (after 5 consecutive failures within 10s) → **HALF-OPEN** (after 5s backoff, admits exactly ONE probe) → **CLOSED** on probe success or back to **OPEN** with timer reset on probe failure.
- Constants are GA defaults (`breakerThreshold=5`, `breakerWindow=10s`, `breakerOpenInterval=5s`), documented inline; not exposed via flags / env vars per the agreed design.

## Wiring

- `chclient.Client` embeds `breaker`; all CH-touching methods (`Ping`, `Exec`, `Query`, `QueryCursor`, `QueryStrings`, `QueryMetricMeta`, `QueryIndexStats`, `QueryIndexVolume`, `QueryLabelSets`) call `breaker.allow()` before touching CH and `breaker.record(err)` after.
- `ErrCircuitOpen` is the sentinel; callers compare via `errors.Is`.
- `httperr.Error` gains a `RetryAfterSeconds` field so per-handler error writers can stamp `Retry-After` alongside the JSON envelope.
- Each handler's classifier (`classifyEngineError` / `classifyEngineErr` / `classifySearchErr` / `classifyTraceByIDErr`) and `respondError` detect `errors.Is(err, chclient.ErrCircuitOpen)` and route to 503 + `Retry-After: 5` with a new `unavailable` Prom/Loki errorType. Tempo stamps `Retry-After` in `writeError` when the err chain contains the sentinel.
- `/healthz` is intentionally unaffected — the existing handler is process-only liveness and never pings CH, so pod liveness stays decoupled from downstream health (no cascading k8s restarts during a CH outage).
- `/readyz` reports red within the cache TTL of the trip because `Ping` is one of the wrapped methods.

## Chaos test coverage (15 tests, all green under -race)

- `TestBreaker_OpensAfterNConsecutiveFailures` — N failures trip OPEN
- `TestBreaker_FastFailsWhenOpen` — `<` 10ms, no conn call
- `TestBreaker_HalfOpenAfterBackoff` — probe admitted after interval
- `TestBreaker_ProbeSuccessClosesCircuit` — recovery path
- `TestBreaker_ProbeFailureKeepsOpen` — timer reset on probe failure
- `TestBreaker_ConcurrentRequestsDuringHalfOpen` — 100 goroutines → exactly 1 admitted
- `TestBreaker_SuccessResetsCounter` — 4-fail/1-success/4-fail does NOT trip
- `TestBreaker_WindowRolls` — failures wider than 10s don't accumulate
- `TestBreaker_PingRespectsBreaker` / `TestBreaker_ExecRespectsBreaker` / `TestBreaker_QueryStringsRespectsBreaker` — per-method coverage
- `TestBreaker_HealthzUnaffected` — process-liveness independence pin
- `TestReadyz_ReturnsRedWhenBreakerOpen` / `TestReadyz_RecoversWhenBreakerCloses` / `TestHealthz_IndependentOfBreaker` — /readyz + /healthz integration
- `TestHandler_BreakerOpenReturns503WithRetryAfter` / `OnRangeQuery` / `OnLabels` — wire-level handler contract

## Test plan

- [x] `go test -race -count=1 ./internal/chclient/ ./internal/api/health/ ./internal/api/httperr/ ./internal/api/prom/ ./internal/api/tempo/` — 337 passed
- [x] `go build ./...` clean
- [ ] CI required checks: `check` + `lint` green
- [ ] Manual smoke: stop a fake CH; cerberus returns 503 + Retry-After within ms (not 5s dial timeout); restart fake CH; cerberus recovers within ≤ 5s of half-open probe

(The Loki package has a pre-existing intermittent race in tail tests under `-count=3 -race` that reproduces on `main` without this PR's changes; not introduced here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)