### PR TITLE
fix(chclient): drop testing.Short skip in cursor chaos sweep

### DIFF
--- a/internal/chclient/cursor_chaos_test.go
+++ b/internal/chclient/cursor_chaos_test.go
@@ -24,11 +24,11 @@ import (
 //
 // Bound: 32 MiB. A regression that buffers every row internally would
 // blow this; the streaming path keeps it well below.
+//
+// Runtime: the generator-backed rows yield one sample per Next, so the
+// 1M-iteration sweep finishes in <100ms (≈400ms under -race). Cheap
+// enough to always run; no -short skip.
 func TestStreamingCursor_Bounded_1M_Points(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping 1M-row sweep in short mode")
-	}
-
 	const N = 1_000_000
 
 	rows := newGenRows(N)


### PR DESCRIPTION
## Summary

- The 1M-row streaming-cursor sweep in `internal/chclient/cursor_chaos_test.go` was gated on `testing.Short()` — but the generator-backed fake rows (`genRows`) yield one sample per `Next` with no real I/O, so the full drain finishes in <100ms (~400ms under `-race`). Cheap enough to always run.
- Dropped the `t.Skip` and replaced it with a one-paragraph runtime note in the test docstring.
- Continues the cleanup started in #302 (eliminating misc `t.Skip`s).

## Test plan

- [x] `go test -count=1 -run TestStreamingCursor_Bounded_1M_Points ./internal/chclient/` — 0.09s, passes
- [x] `go test -count=1 -race -run TestStreamingCursor_Bounded_1M_Points ./internal/chclient/` — 0.40s, passes
- [x] `go test -count=1 -race ./internal/chclient/` (full package) — 1.5s, passes
- [ ] CI `check` + `lint` green

Generated with [Claude Code](https://claude.com/claude-code)