### PR TITLE
refactor(shadow): drop tc.skipReason — pass or remove, no skip

### DIFF
--- a/harness/compatibility/shadow/logql_shadow_test.go
+++ b/harness/compatibility/shadow/logql_shadow_test.go
@@ -246,9 +246,8 @@ type logqlShadowCase struct {
 	filters    []logFilter
 	metric     metricKind
 	agg        aggregation
-	expected   VectorResult
-	opts       DiffOptions
-	skipReason string
+	expected VectorResult
+	opts     DiffOptions
 }
 
 // evaluateLogQLCase runs the test mini-evaluator and returns a VectorResult
@@ -878,10 +877,6 @@ func TestLogQLShadowDiff(t *testing.T) {
 			// that parses upstream is by construction one cerberus can parse.
 			if _, err := lokisyntax.ParseExpr(tc.query); err != nil {
 				t.Fatalf("upstream Loki parser rejected %q: %v", tc.query, err)
-			}
-
-			if tc.skipReason != "" {
-				t.Skip(tc.skipReason)
 			}
 
 			got := evaluateLogQLCase(tc)

--- a/harness/compatibility/shadow/logql_shadow_test.go
+++ b/harness/compatibility/shadow/logql_shadow_test.go
@@ -240,12 +240,12 @@ type aggregation struct {
 
 // logqlShadowCase is one differential test entry.
 type logqlShadowCase struct {
-	name       string
-	query      string // full LogQL string — must parse via upstream Loki
-	matchers   []streamMatcher
-	filters    []logFilter
-	metric     metricKind
-	agg        aggregation
+	name     string
+	query    string // full LogQL string — must parse via upstream Loki
+	matchers []streamMatcher
+	filters  []logFilter
+	metric   metricKind
+	agg      aggregation
 	expected VectorResult
 	opts     DiffOptions
 }

--- a/harness/compatibility/shadow/promql_shadow_test.go
+++ b/harness/compatibility/shadow/promql_shadow_test.go
@@ -221,8 +221,6 @@ type promqlShadowCase struct {
 	expected VectorResult
 	// opts overrides DefaultDiffOptions when non-zero.
 	opts DiffOptions
-	// skipReason, if set, marks the case as skipped with a TODO note.
-	skipReason string
 }
 
 // promqlInstantTS is the canonical eval timestamp for instant queries:
@@ -947,9 +945,6 @@ func TestPromQLShadowDiff(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			if tc.skipReason != "" {
-				t.Skip(tc.skipReason)
-			}
 
 			res, err := eng.Instant(ctx, store, tc.query, tc.evalAt)
 			if err != nil {

--- a/harness/compatibility/shadow/traceql_shadow_test.go
+++ b/harness/compatibility/shadow/traceql_shadow_test.go
@@ -248,9 +248,8 @@ type traceqlShadowCase struct {
 	pipelineP float64 // quantile parameter
 
 	// expected is the hand-computed result vector.
-	expected   VectorResult
-	opts       DiffOptions
-	skipReason string
+	expected VectorResult
+	opts     DiffOptions
 }
 
 // evalAtMs is the timestamp the evaluator stamps onto every output sample.
@@ -820,10 +819,6 @@ func TestTraceQLShadowDiff(t *testing.T) {
 			// parses upstream by construction parses through the cerberus head.
 			if _, err := traceql.Parse(tc.query); err != nil {
 				t.Fatalf("upstream Tempo parser rejected %q: %v", tc.query, err)
-			}
-
-			if tc.skipReason != "" {
-				t.Skip(tc.skipReason)
 			}
 
 			got := evaluateTraceQLCase(tc)


### PR DESCRIPTION
## Summary

- The PromQL, LogQL, and TraceQL shadow harnesses each carried an unused `skipReason string` field on their case struct plus an `if tc.skipReason != "" { t.Skip(...) }` block in the runner. No case set the field, so the branch was dead — but it invited future drift toward silently skipping differential coverage instead of fixing the underlying gap.
- Per the project rule (every planned shadow case must run + pass, or be formally removed with a roadmap rationale), drop the field + the skip block from all three runners. The struct surface no longer offers a "skip" trapdoor — adding a new case means it must work, end of story.
- No table entries were removed: every shadow case in every file was already running and passing. Coverage in `harness/compatibility/shadow` (baseline 90%, see `docs/coverage-baseline.md`) is unaffected.

Continues the direction of #302 (which eliminated four miscellaneous `t.Skip` calls).

## Test plan

- [ ] `check` CI job green (build + `just test`)
- [ ] `lint` CI job green (`golangci-lint`)
- [ ] No new shadow diffs appear — same case count, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)