### PR TITLE
refactor(e2e/startup-bench): drop redundant RUN_STARTUP_BENCH env gate

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -362,7 +362,7 @@ e2e-run:
 # vars; see test/e2e/startup_bench_test.go for the full list.
 startup-bench:
     @echo "==> startup-speed benchmark (target < 2 s to /healthz)"
-    RUN_STARTUP_BENCH=1 go test -tags=startup_bench -v -count=1 -run TestStartupSpeed ./test/e2e/...
+    go test -tags=startup_bench -v -count=1 -run TestStartupSpeed ./test/e2e/...
 
 # Run the Grafana playwright smoke (lands in M0.2).
 e2e-playwright:

--- a/docs/health.md
+++ b/docs/health.md
@@ -121,13 +121,13 @@ Run it locally with:
 just startup-bench
 ```
 
-The benchmark is build-tagged (`startup_bench`) and `RUN_STARTUP_BENCH`-
-gated, so regular `just test` skips it. CI runs it as an informational
-job in `.github/workflows/e2e.yml` (`startup-bench` job) on push-to-main,
-nightly, and manual dispatch — it is **not** a required PR gate, so a
-slow VM doesn't block merges, but a real regression (e.g. a new
-synchronous startup hook that blocks the listener bind) shows up on the
-very next merge.
+The benchmark is build-tagged (`startup_bench`), so regular `just test`
+skips it (the file isn't compiled without the tag). CI runs it as an
+informational job in `.github/workflows/e2e.yml` (`startup-bench` job)
+on push-to-main, nightly, and manual dispatch — it is **not** a required
+PR gate, so a slow VM doesn't block merges, but a real regression (e.g.
+a new synchronous startup hook that blocks the listener bind) shows up
+on the very next merge.
 
 When `CERBERUS_AUTO_CREATE_SCHEMA=true`, the startup hook that applies
 the OTel ClickHouse DDL runs synchronously **before** the listener

--- a/test/e2e/startup_bench_test.go
+++ b/test/e2e/startup_bench_test.go
@@ -8,10 +8,10 @@
 // CI scheduler jitter while still catching real regressions (e.g. a new
 // startup hook that blocks the listener bind).
 //
-// Build-tagged + env-gated so regular `go test ./...` doesn't pull in
-// the build step. Run via `just startup-bench` or:
+// Build-tagged so regular `go test ./...` doesn't pull in the build
+// step. Run via `just startup-bench` or:
 //
-//	RUN_STARTUP_BENCH=1 go test -tags=startup_bench ./test/e2e/...
+//	go test -tags=startup_bench ./test/e2e/...
 //
 // Prerequisites:
 //   - ClickHouse reachable at $CH_ADDR (default 127.0.0.1:9000), already
@@ -49,10 +49,6 @@ const (
 )
 
 func TestStartupSpeed_HealthzUnder2s(t *testing.T) {
-	if os.Getenv("RUN_STARTUP_BENCH") != "1" {
-		t.Skip("set RUN_STARTUP_BENCH=1 to run the startup benchmark")
-	}
-
 	binary := os.Getenv("CERBERUS_BIN")
 	if binary == "" {
 		binary = buildCerberus(t)


### PR DESCRIPTION
## Summary

- `test/e2e/startup_bench_test.go` is already gated by the `//go:build startup_bench` tag — without `-tags=startup_bench` the file isn't compiled at all, so `go test ./...` never sees it. The additional `RUN_STARTUP_BENCH=1` env-var skip was belt-and-suspenders that complicated the on-ramp (two flags to remember, only one caller).
- Drop the `t.Skip` + the now-redundant `RUN_STARTUP_BENCH=1` prefix from the `just startup-bench` recipe and update the `docs/health.md` description.
- Kept as `*testing.T`, not converted to `*testing.B`: the test asserts a hard 2500 ms ceiling via `t.Fatalf` (a 12-factor disposability regression guard), which doesn't map onto a benchmark's per-iteration ns/op cost model. CI's `startup-bench` job at `.github/workflows/e2e.yml` continues to invoke `just startup-bench` unchanged.

## Test plan

- [x] `commitlint` clears (Conventional Commit subject)
- [ ] `check` job passes — should be a no-op since the file is build-tagged
- [ ] `lint` job passes — gofumpt/goimports unchanged
- [ ] `startup-bench` informational job (push-to-main) still completes when this lands