### PR TITLE
ci: forbid t.Skip in test files (gate the GA test-discipline rule)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,3 +74,21 @@ jobs:
             **/*.md
             !harness/compatibility/upstream/**
             !**/node_modules/**
+
+  # `forbid-skip` is the GA test-discipline gate. The maintainer's
+  # NON-NEGOTIABLE rule is "no t.Skip in test files — fix the bug, do
+  # not skip." Greps `*_test.go` for `t.Skip` / `t.Skipf` / `t.SkipNow`
+  # via `git ls-files` (already excludes vendor / .gitignored paths)
+  # and fails the build if any match. Runs in parallel with `check` +
+  # `lint`; flip on as a required status check via branch protection.
+  forbid-skip:
+    name: forbid-skip
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Reject t.Skip in test files
+        run: |
+          if git ls-files -z -- '*_test.go' | xargs -0 grep -nE 't\.Skip[fN]?\(' --; then
+            echo "::error::t.Skip / t.Skipf / t.SkipNow found in test files — fix the bug, do not skip"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Adds a `forbid-skip` job to CI that fails if any `*_test.go` contains `t.Skip` / `t.Skipf` / `t.SkipNow`. Enforces the maintainer's NON-NEGOTIABLE rule mechanically — no future skip can land on `main` without an explicit branch-protection bypass.

## Implementation

- New job inside `.github/workflows/ci.yml` (parallel with `check` + `lint`).
- Body:
  ```sh
  git ls-files -z -- '*_test.go' | xargs -0 grep -nE 't\.Skip[fN]?\(' --
  ```
  `git ls-files` already respects `.gitignore`, so `vendor/`, `.claude/worktrees/`, etc. are excluded for free.

## Why this PR's CI currently FAILS

There is still one `t.Skip` on `main`: `test/property/promql_test.go:139`. That's removed by the in-flight skip-removal PR (`fix/range-window-value-pascalcase` — sum-on-empty fix + property test unskip). Once that merges, rebase this branch onto a skip-free `main` and CI flips green.

Already-landed skip removals:
- #306 `cursor_chaos_test` (testing.Short skip dropped — always runs now)
- #307 shadow tests (skipReason field was dead code, removed)
- #308 startup bench (env-gate dropped — converted to proper Benchmark)

## Branch-protection follow-up (after merge)

```sh
gh api -X PATCH /repos/tsouza/cerberus/branches/main/protection/required_status_checks \
  --input - <<JSON
{"strict": true, "contexts": ["check", "lint", "forbid-skip"]}
JSON
```

## Test plan

- [ ] CI shows \`forbid-skip\` FAIL on this PR (with the single \`test/property/promql_test.go:139\` match — the gate is doing its job).
- [ ] After the property-test PR merges + rebase: CI flips green.
- [ ] Squash-merge; then add \`forbid-skip\` to required status checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>