### PR TITLE
feat(promql,chplan,chsql): bool modifier on V-V + empty without()

### DIFF
--- a/internal/chplan/vector_join.go
+++ b/internal/chplan/vector_join.go
@@ -59,6 +59,16 @@ const (
 // the matching key (carrying the Include labels), and the output's
 // Attributes map merges the right's Include values onto the left's
 // Attributes. CardOneToMany mirrors the orientation.
+//
+// ReturnBool models PromQL's `bool` modifier on a comparison op. When
+// the input op is one of the six comparison ops (=, !=, <, <=, >, >=)
+// and ReturnBool is true, the emitter produces `toFloat64(L.Value <Op>
+// R.Value)` instead of the default `(L.Value <Op> R.Value)` so the
+// join keeps every matched pair (emitting 1.0 / 0.0 per pair) rather
+// than letting the comparison drop non-matching rows the way the
+// default V-V comparison shape would in Prometheus. The flag has no
+// effect for non-comparison ops; lowerings set it only for ops where
+// `isComparison(Op)` holds.
 type VectorJoin struct {
 	Left  Node
 	Right Node
@@ -70,6 +80,12 @@ type VectorJoin struct {
 	// Include is the `group_left(<labels>)` / `group_right(<labels>)`
 	// extra-label list. Nil/empty when no Include was specified.
 	Include []string
+	// ReturnBool models PromQL's `bool` modifier on a comparison op
+	// (`lhs > bool rhs`). Only meaningful when `Op` is a comparison op;
+	// the emitter wraps the per-pair binary result with `toFloat64(...)`
+	// so every matched pair surfaces as 1.0 / 0.0 rather than being
+	// filtered out by the comparison.
+	ReturnBool bool
 
 	MetricNameColumn string
 	AttributesColumn string
@@ -90,6 +106,9 @@ func (v *VectorJoin) Equal(other Node) bool {
 		return false
 	}
 	if v.Card != o.Card || !slices.Equal(v.Include, o.Include) {
+		return false
+	}
+	if v.ReturnBool != o.ReturnBool {
 		return false
 	}
 	if v.MetricNameColumn != o.MetricNameColumn ||

--- a/internal/chsql/vector_join.go
+++ b/internal/chsql/vector_join.go
@@ -345,16 +345,20 @@ func writeOutputAttributes(b *Builder, j *chplan.VectorJoin) {
 }
 
 // vectorJoinValueExprFrag returns a Frag for the joined value
-// expression: `(L.<val> <op> R.<val>) AS <val>`.
+// expression. The default shape is `(L.<val> <op> R.<val>) AS <val>`.
+//
+// When ReturnBool is set on a comparison op (PromQL `lhs > bool rhs`),
+// the binary result is wrapped with `toFloat64(...)` so every matched
+// pair emits 1.0 or 0.0 instead of being dropped by the comparison —
+// matching Prometheus's `bool` semantics for V-V comparisons.
 func vectorJoinValueExprFrag(j *chplan.VectorJoin) Frag {
-	return func(b *Builder) {
-		b.writeSQL("(")
-		writeSideCol(b, "L", j.ValueColumn)
-		b.writeSQL(" " + string(j.Op) + " ")
-		writeSideCol(b, "R", j.ValueColumn)
-		b.writeSQL(") AS ")
-		b.Ident(j.ValueColumn)
+	left := qualColFrag("L", j.ValueColumn)
+	right := qualColFrag("R", j.ValueColumn)
+	inner := Paren(binOp(string(j.Op), left, right))
+	if j.ReturnBool {
+		inner = Call("toFloat64", inner)
 	}
+	return As(inner, j.ValueColumn)
 }
 
 // qualColFrag returns a Frag for `<bareSide>.<col>` — the bare-alias

--- a/internal/promql/binary.go
+++ b/internal/promql/binary.go
@@ -55,9 +55,16 @@ func lowerBinary(b *parser.BinaryExpr, s schema.Metrics, ctx lowerCtx) (chplan.N
 // promBinaryOp doesn't yet support anyway, but we surface a clean
 // "many-to-many matching not allowed" error to match Prometheus's wording
 // rather than the lower-level "binary op not yet supported".
+//
+// The `bool` modifier on a comparison op (`lhs > bool rhs`) threads into
+// `chplan.VectorJoin.ReturnBool`; the emitter wraps the per-pair binary
+// result in `toFloat64(...)` so every matched pair surfaces as 1.0 / 0.0
+// rather than the comparison dropping non-matching rows. The modifier is
+// rejected for non-comparison ops to match Prometheus's parser-level
+// guard ("bool modifier is only allowed for comparison operators").
 func lowerVectorVector(b *parser.BinaryExpr, s schema.Metrics, op chplan.BinaryOp, ctx lowerCtx) (chplan.Node, error) {
-	if b.ReturnBool {
-		return nil, fmt.Errorf("promql: 'bool' modifier on vector-vector binary ops is not yet supported")
+	if b.ReturnBool && !isComparison(op) {
+		return nil, fmt.Errorf("promql: 'bool' modifier is only allowed on comparison binary ops")
 	}
 
 	card := chplan.CardOneToOne
@@ -108,6 +115,7 @@ func lowerVectorVector(b *parser.BinaryExpr, s schema.Metrics, op chplan.BinaryO
 		Match:            match,
 		Card:             card,
 		Include:          include,
+		ReturnBool:       b.ReturnBool,
 		MetricNameColumn: s.MetricNameColumn,
 		AttributesColumn: s.AttributesColumn,
 		TimestampColumn:  s.TimestampColumn,

--- a/internal/promql/binary_test.go
+++ b/internal/promql/binary_test.go
@@ -14,12 +14,15 @@ import (
 
 // TestLower_Binary_Errors covers the binary-expression shapes lowerBinary
 // still rejects: pure scalar/scalar (deferred until scalars are first-class
-// chplan nodes), logical ops (`and`/`or`/`unless`, deferred to a later
-// milestone), and the `bool` modifier on vector-vector ops.
+// chplan nodes) and logical ops (`and`/`or`/`unless`, deferred to a later
+// milestone).
 //
 // group_left / group_right are no longer rejected — RC2 cardinality-edge
 // support added them with explicit cardinality enforcement; see
-// vector_match_test.go for the lowering coverage.
+// vector_match_test.go for the lowering coverage. The `bool` modifier on
+// vector-vector binops is also no longer rejected — see TestLower_Binary_VV_Bool
+// below for the happy path, and the dedicated V-V `bool` TXTAR fixtures
+// (bool_vv_*.txtar) for end-to-end SQL coverage.
 func TestLower_Binary_Errors(t *testing.T) {
 	t.Parallel()
 
@@ -40,11 +43,6 @@ func TestLower_Binary_Errors(t *testing.T) {
 			name:    "logical and deferred",
 			query:   `up and up`,
 			wantErr: "binary op and not yet supported",
-		},
-		{
-			name:    "bool modifier on vector-vector rejected",
-			query:   `up == bool up`,
-			wantErr: "'bool' modifier on vector-vector binary ops is not yet supported",
 		},
 	}
 	for _, tc := range cases {
@@ -98,6 +96,64 @@ func TestLower_Binary_VectorScalar(t *testing.T) {
 			name:      "negated scalar unwraps",
 			query:     `up * -1`,
 			wantInSQL: []string{"`Value` * ?"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr: %v", err)
+			}
+			plan, err := promql.Lower(context.Background(), expr, s)
+			if err != nil {
+				t.Fatalf("Lower: %v", err)
+			}
+			sql, _, err := chsql.Emit(context.Background(), plan)
+			if err != nil {
+				t.Fatalf("Emit: %v", err)
+			}
+			for _, want := range tc.wantInSQL {
+				if !strings.Contains(sql, want) {
+					t.Errorf("expected SQL to contain %q; full SQL:\n%s", want, sql)
+				}
+			}
+		})
+	}
+}
+
+// TestLower_Binary_VV_Bool covers the happy path for the `bool` modifier
+// on vector-vector comparison ops. The emitter must wrap the per-pair
+// binary result in `toFloat64(...)` so non-matching pairs surface as 0.0
+// rather than being dropped by the comparison.
+//
+// Non-comparison ops with `bool` come back as a clear "only allowed on
+// comparison ops" error, matching Prometheus's parser-level guard.
+func TestLower_Binary_VV_Bool(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{})
+
+	cases := []struct {
+		name      string
+		query     string
+		wantInSQL []string
+	}{
+		{
+			name:      "gt bool vv",
+			query:     `up > bool up`,
+			wantInSQL: []string{"toFloat64((L.`Value` > R.`Value`)) AS `Value`"},
+		},
+		{
+			name:      "eq bool vv",
+			query:     `up == bool up`,
+			wantInSQL: []string{"toFloat64((L.`Value` = R.`Value`)) AS `Value`"},
+		},
+		{
+			name:      "ne bool vv on labels",
+			query:     `up != bool on(instance) up`,
+			wantInSQL: []string{"toFloat64((L.`Value` != R.`Value`)) AS `Value`"},
 		},
 	}
 	for _, tc := range cases {

--- a/internal/promql/histogram_quantile.go
+++ b/internal/promql/histogram_quantile.go
@@ -369,7 +369,15 @@ func histogramAggGroupBy(agg *parser.AggregateExpr, s schema.Metrics) ([]chplan.
 	if agg.Without {
 		// `sum without (...)` — single group key derived from
 		// mapFilter on Attributes. `le` doesn't exist in OTel-CH but
-		// listing it is harmless (no-op key removal).
+		// listing it is harmless (no-op key removal). Empty `without ()`
+		// is the degenerate "remove nothing" shape: group by the full
+		// Attributes map directly (CH rejects mapFilter with an empty
+		// IN list as a syntax error).
+		if len(agg.Grouping) == 0 {
+			return []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}},
+				[]string{"gkey_0"},
+				&chplan.ColumnRef{Name: "gkey_0"}
+		}
 		return []chplan.Expr{
 				&chplan.MapWithoutKeys{
 					Map:  &chplan.ColumnRef{Name: s.AttributesColumn},

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -562,8 +562,23 @@ func emptyAttrsMap() chplan.Expr {
 // `by (...)` it returns one MapAccess per named label; for `without (...)`
 // it returns a single MapWithoutKeys spanning the full Attributes map with
 // the named labels stripped.
+//
+// `without ()` (empty Grouping list) is the degenerate "remove nothing"
+// shape — equivalent to grouping by the full Attributes map. Emitting a
+// MapWithoutKeys{Keys: []} would lower to `mapFilter((k, v) -> NOT (k
+// IN ()), Attributes)`, which CH rejects as a syntax error (empty IN
+// list). Short-circuit to a bare ColumnRef so the GroupBy slot
+// references `Attributes` directly. Semantics match Prometheus's
+// `aggregators.test` "Empty without" case: one output row per unique
+// input label set, with all labels preserved (aggregation drops only
+// `__name__`, which the OTel-CH Attributes map never contains).
 func aggregateGroupBy(a *parser.AggregateExpr, s schema.Metrics) ([]chplan.Expr, error) {
 	if a.Without {
+		if len(a.Grouping) == 0 {
+			return []chplan.Expr{
+				&chplan.ColumnRef{Name: s.AttributesColumn},
+			}, nil
+		}
 		return []chplan.Expr{
 			&chplan.MapWithoutKeys{
 				Map:  &chplan.ColumnRef{Name: s.AttributesColumn},

--- a/test/spec/chplan_print.go
+++ b/test/spec/chplan_print.go
@@ -134,6 +134,9 @@ func printNode(b *strings.Builder, n chplan.Node, depth int) {
 		if len(v.Include) > 0 {
 			fmt.Fprintf(b, " include=[%s]", strings.Join(v.Include, ", "))
 		}
+		if v.ReturnBool {
+			b.WriteString(" bool")
+		}
 		b.WriteString("\n")
 		printNode(b, v.Left, depth+1)
 		printNode(b, v.Right, depth+1)

--- a/test/spec/promql/bool_vv_eq.txtar
+++ b/test/spec/promql/bool_vv_eq.txtar
@@ -1,0 +1,54 @@
+-- query.promql --
+up{job="prom"} == bool on(instance) up{job="node"}
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'prom', 'instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('up', map('job', 'prom', 'instance', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('up', map('job', 'node', 'instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('up', map('job', 'node', 'instance', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 0.0);
+-- expected_rows --
+[
+  ["up", {"instance": "a", "job": "prom"}, "2026-01-01T00:00:00Z", 1.0],
+  ["up", {"instance": "b", "job": "prom"}, "2026-01-01T00:00:00Z", 0.0]
+]
+-- args --
+[0] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[1] string = "up"
+[2] string = "job"
+[3] string = "prom"
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] string = "2026-01-01 00:00:01.000000000"
+[7] int64 = 9
+[8] int64 = 300000000000
+[9] string = "instance"
+[10] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[11] string = "up"
+[12] string = "job"
+[13] string = "node"
+[14] string = "2026-01-01 00:00:01.000000000"
+[15] int64 = 9
+[16] string = "2026-01-01 00:00:01.000000000"
+[17] int64 = 9
+[18] int64 = 300000000000
+[19] string = "instance"
+[20] string = "instance"
+[21] string = "instance"
+-- chplan --
+VectorJoin op== match=on(instance) card=one-to-one bool
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=((((Attributes["job"] = "prom") AND (MetricName = "up")) AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=((((Attributes["job"] = "node") AND (MetricName = "up")) AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)
+-- sql --
+SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, toFloat64((L.`Value` = R.`Value`)) AS `Value` FROM (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) AND (`Attributes`[?] = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`))) AS L INNER JOIN (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) AND (`Attributes`[?] = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`))) AS R ON L.`Attributes`[?] = R.`Attributes`[?]

--- a/test/spec/promql/bool_vv_gt.txtar
+++ b/test/spec/promql/bool_vv_gt.txtar
@@ -1,0 +1,54 @@
+-- query.promql --
+up{job="prom"} > bool on(instance) up{job="node"}
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'prom', 'instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 5.0),
+    ('up', map('job', 'prom', 'instance', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('up', map('job', 'node', 'instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 3.0),
+    ('up', map('job', 'node', 'instance', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 4.0);
+-- expected_rows --
+[
+  ["up", {"instance": "a", "job": "prom"}, "2026-01-01T00:00:00Z", 1.0],
+  ["up", {"instance": "b", "job": "prom"}, "2026-01-01T00:00:00Z", 0.0]
+]
+-- args --
+[0] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[1] string = "up"
+[2] string = "job"
+[3] string = "prom"
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] string = "2026-01-01 00:00:01.000000000"
+[7] int64 = 9
+[8] int64 = 300000000000
+[9] string = "instance"
+[10] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[11] string = "up"
+[12] string = "job"
+[13] string = "node"
+[14] string = "2026-01-01 00:00:01.000000000"
+[15] int64 = 9
+[16] string = "2026-01-01 00:00:01.000000000"
+[17] int64 = 9
+[18] int64 = 300000000000
+[19] string = "instance"
+[20] string = "instance"
+[21] string = "instance"
+-- chplan --
+VectorJoin op=> match=on(instance) card=one-to-one bool
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=((((Attributes["job"] = "prom") AND (MetricName = "up")) AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=((((Attributes["job"] = "node") AND (MetricName = "up")) AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)
+-- sql --
+SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, toFloat64((L.`Value` > R.`Value`)) AS `Value` FROM (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) AND (`Attributes`[?] = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`))) AS L INNER JOIN (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) AND (`Attributes`[?] = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`))) AS R ON L.`Attributes`[?] = R.`Attributes`[?]

--- a/test/spec/promql/sum_without_empty.txtar
+++ b/test/spec/promql/sum_without_empty.txtar
@@ -1,0 +1,37 @@
+-- query.promql --
+sum without () (up)
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api', 'instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('up', map('job', 'api', 'instance', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('up', map('job', 'web', 'instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 1.0);
+-- expected_rows --
+[
+  ["", {"instance": "a", "job": "api"}, "2026-01-01T00:00:01Z", 1.0],
+  ["", {"instance": "a", "job": "web"}, "2026-01-01T00:00:01Z", 1.0],
+  ["", {"instance": "b", "job": "api"}, "2026-01-01T00:00:01Z", 1.0]
+]
+-- args --
+[0] string = ""
+[1] int64 = 9
+[2] string = "up"
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] string = "2026-01-01 00:00:01.000000000"
+[6] int64 = 9
+[7] int64 = 300000000000
+-- chplan --
+Project ["" AS MetricName, gkey_0 AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+  Aggregate groupBy=[Attributes AS gkey_0] funcs=[sum(Value) AS Value]
+    Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+      Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+        Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+          Scan(otel_metrics_gauge)
+-- sql --
+SELECT ? AS `MetricName`, `gkey_0` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes` AS `gkey_0`, sum(`Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY `Attributes`)


### PR DESCRIPTION
## Summary

Closes 13 prometheus/compliance gaps:
- 6 × `'bool' modifier on vector-vector binary ops` cases
- 7 × `sum/avg/max/min/count without ()` cases

## Bug 1 — bool on V-V

PromQL `lhs > bool rhs` (vector-vector) should emit `1.0` if comparison holds, `0.0` otherwise — instead of dropping non-matching samples like the default V-V comparison.

**Fix**: added `ReturnBool` field to `chplan.VectorJoin`. PromQL binary lowering threads it through. chsql VectorJoin emit wraps the result in `toFloat64(<binOp>(p.Value, q.Value))` when set; default shape unchanged.

## Bug 2 — empty `without ()`

`sum without () (up)` was emitting invalid SQL: `mapFilter((k, v) -> NOT (k IN ()), Attributes)` — empty `IN ()` is a CH syntax error.

**Fix**: empty `without()` short-circuits to `ColumnRef{Attributes}` directly. Same fix in `histogram_quantile.go::histogramAggGroupBy`.

**Semantic note**: empty `without()` does NOT degenerate to ungrouped (verified against `prometheus/prometheus` `promqltest/testdata/aggregators.test`). It preserves all input labels — one row per unique label set. The original assumption was wrong; the txtar roundtrip confirms 3 rows for 3 distinct series.

## Test plan

- [x] `go test -count=1 ./internal/{promql,chsql,chplan}/` — 987 pass
- [x] `go test -tags chdb -count=1 ./test/spec/promql/` — 141 pass (incl. 3 new fixtures)
- [x] Broader `./internal/...` + `./test/...` — 2422 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>