### PR TITLE
feat(promql,chplan,chsql): label_replace + label_join via Map rewrite

### DIFF
--- a/internal/api/prom/lang_test.go
+++ b/internal/api/prom/lang_test.go
@@ -77,26 +77,26 @@ func TestLang_Parse_ParseError(t *testing.T) {
 }
 
 // TestLang_Parse_LowerError — a parseable but unsupported PromQL form
-// (`label_replace`, currently not lowered) surfaces as a
-// parseStageError tagged "lower". Verifies the parse → lower split is
-// preserved through the adapter.
+// (`sort`, currently not lowered) surfaces as a parseStageError tagged
+// "lower". Verifies the parse → lower split is preserved through the
+// adapter.
 func TestLang_Parse_LowerError(t *testing.T) {
 	t.Parallel()
 
 	l := langForTest()
-	_, _, err := l.Parse(context.Background(), `label_replace(up, "x", "$1", "instance", "(.*)")`)
+	_, _, err := l.Parse(context.Background(), `sort(up)`)
 	if err == nil {
-		t.Fatalf("Parse(label_replace): expected lower failure, got nil")
+		t.Fatalf("Parse(sort): expected lower failure, got nil")
 	}
 	var ps *parseStageError
 	if !errors.As(err, &ps) {
-		t.Fatalf("Parse(label_replace): err type = %T, want *parseStageError; err=%v", err, err)
+		t.Fatalf("Parse(sort): err type = %T, want *parseStageError; err=%v", err, err)
 	}
 	if ps.stage != "lower" {
 		t.Errorf("parseStageError.stage: got %q, want %q (got err=%v)", ps.stage, "lower", err)
 	}
-	if !strings.Contains(err.Error(), "label_replace") {
-		t.Errorf("err message: got %q, want it to mention label_replace", err.Error())
+	if !strings.Contains(err.Error(), "sort") {
+		t.Errorf("err message: got %q, want it to mention sort", err.Error())
 	}
 }
 

--- a/internal/chplan/label_join.go
+++ b/internal/chplan/label_join.go
@@ -1,0 +1,44 @@
+package chplan
+
+import "slices"
+
+// LabelJoin is a Map-valued expression that concatenates the values of
+// named source labels with a separator and binds the result to a
+// destination label. Matches PromQL's
+// `label_join(v, dst, separator, src1, src2, ...)`:
+//
+//   - For each input series, evaluate `arrayStringConcat([map[src1],
+//     map[src2], ...], separator)` and bind it to `dst` in the output
+//     Map(String, String).
+//   - If every src label is absent (map returns the empty string for
+//     missing keys), the joined value is just the separator repeated;
+//     the emitter wraps the result with the standard empty-value drop
+//     so the dst label disappears when the join is fully empty.
+//
+// Lowering:
+//
+//	mapFilter((k, v) -> v != '',
+//	    mapUpdate(<map>, map(<dst>, arrayStringConcat([<map>[<src1>], <map>[<src2>], ...], <separator>))))
+//
+// `Map` is the input Map(String, String) expression (typically the
+// Attributes column ref). `Dst`, `Separator`, and `Srcs` are the PromQL-
+// static string arguments captured during lowering.
+type LabelJoin struct {
+	Map       Expr
+	Dst       string
+	Separator string
+	Srcs      []string
+}
+
+func (*LabelJoin) exprNode() {}
+
+func (l *LabelJoin) Equal(other Expr) bool {
+	o, ok := other.(*LabelJoin)
+	if !ok {
+		return false
+	}
+	return l.Dst == o.Dst &&
+		l.Separator == o.Separator &&
+		slices.Equal(l.Srcs, o.Srcs) &&
+		l.Map.Equal(o.Map)
+}

--- a/internal/chplan/label_replace.go
+++ b/internal/chplan/label_replace.go
@@ -12,7 +12,7 @@ package chplan
 //     unchanged — `dst` keeps whatever value it had (often "absent").
 //
 // PromQL also drops labels whose value is the empty string; the emitter
-// wraps the resulting map with `mapFilter((k, v) -> v != '', …)` so
+// wraps the resulting map with `mapFilter((k, v) -> v != ”, …)` so
 // `label_replace(m, "dst", "", "src", ".*")` correctly removes the dst
 // label when present, matching ref Prometheus.
 //

--- a/internal/chplan/label_replace.go
+++ b/internal/chplan/label_replace.go
@@ -1,0 +1,49 @@
+package chplan
+
+// LabelReplace is a Map-valued expression that rewrites a single label
+// inside an Attributes-shaped Map(String, String). It matches PromQL's
+// `label_replace(v, dst, replacement, src, regex)`:
+//
+//   - if `regex` matches the entire value of `src` inside the map, bind
+//     `dst` to the regex-substituted `replacement` (CH's `replaceRegexpOne`
+//     anchored with `^…$`);
+//   - if the regex does not match (including when `src` is absent in the
+//     map and thus reads as the empty string), the map is returned
+//     unchanged — `dst` keeps whatever value it had (often "absent").
+//
+// PromQL also drops labels whose value is the empty string; the emitter
+// wraps the resulting map with `mapFilter((k, v) -> v != '', …)` so
+// `label_replace(m, "dst", "", "src", ".*")` correctly removes the dst
+// label when present, matching ref Prometheus.
+//
+// Lowering:
+//
+//	mapFilter((k, v) -> v != '',
+//	    if(match(<map>[<src>], '^<regex>$'),
+//	       mapUpdate(<map>, map(<dst>, replaceRegexpOne(<map>[<src>], <regex>, <replacement>))),
+//	       <map>))
+//
+// `Map` is the input Map(String, String) expression (typically the
+// Attributes column ref). `Dst`, `Src`, `Replacement`, `Regex` are the
+// PromQL-static string arguments captured during lowering.
+type LabelReplace struct {
+	Map         Expr
+	Dst         string
+	Replacement string
+	Src         string
+	Regex       string
+}
+
+func (*LabelReplace) exprNode() {}
+
+func (l *LabelReplace) Equal(other Expr) bool {
+	o, ok := other.(*LabelReplace)
+	if !ok {
+		return false
+	}
+	return l.Dst == o.Dst &&
+		l.Replacement == o.Replacement &&
+		l.Src == o.Src &&
+		l.Regex == o.Regex &&
+		l.Map.Equal(o.Map)
+}

--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -248,6 +248,10 @@ func (b *Builder) Expr(x chplan.Expr) error {
 		return b.exprMapWithoutKeys(v)
 	case *chplan.MapWithoutEmptyValues:
 		return b.exprMapWithoutEmptyValues(v)
+	case *chplan.LabelReplace:
+		return b.exprLabelReplace(v)
+	case *chplan.LabelJoin:
+		return b.exprLabelJoin(v)
 	case *chplan.LineContent:
 		return b.exprLineContent(v)
 	case *chplan.FieldAccess:
@@ -384,6 +388,94 @@ func (b *Builder) exprMapWithoutEmptyValues(m *chplan.MapWithoutEmptyValues) err
 		return err
 	}
 	b.sb.WriteByte(')')
+	return nil
+}
+
+// exprLabelReplace renders PromQL `label_replace(v, dst, replacement, src, regex)`
+// over a CH Map(String, String). The PromQL semantics are:
+//
+//   - if `regex` matches the FULL value of `src` (Prom anchors with `^…$`),
+//     bind `dst` to the regex-substituted `replacement`;
+//   - otherwise leave `dst` unchanged.
+//
+// Lowers to:
+//
+//	mapFilter((k, v) -> v != '',
+//	    if(match(<map>[?src], ?anchoredRegex),
+//	       mapUpdate(<map>, map(?dst, replaceRegexpOne(<map>[?src], ?anchoredRegex, ?replacement))),
+//	       <map>))
+//
+// `anchoredRegex` is `^<regex>$` so the match is full-string, matching
+// Prometheus's `RE2 ^…$` anchoring rule. The outer mapFilter drops the
+// dst label when the substituted replacement is the empty string —
+// Prom's "labels set to empty values are dropped" rule.
+func (b *Builder) exprLabelReplace(l *chplan.LabelReplace) error {
+	anchored := "^" + l.Regex + "$"
+	b.sb.WriteString("mapFilter((k, v) -> v != '', if(match(")
+	if err := b.Expr(l.Map); err != nil {
+		return err
+	}
+	b.sb.WriteByte('[')
+	b.Arg(l.Src)
+	b.sb.WriteString("], ")
+	b.Arg(anchored)
+	b.sb.WriteString("), mapUpdate(")
+	if err := b.Expr(l.Map); err != nil {
+		return err
+	}
+	b.sb.WriteString(", map(")
+	b.Arg(l.Dst)
+	b.sb.WriteString(", replaceRegexpOne(")
+	if err := b.Expr(l.Map); err != nil {
+		return err
+	}
+	b.sb.WriteByte('[')
+	b.Arg(l.Src)
+	b.sb.WriteString("], ")
+	b.Arg(anchored)
+	b.sb.WriteString(", ")
+	b.Arg(l.Replacement)
+	b.sb.WriteString("))), ")
+	if err := b.Expr(l.Map); err != nil {
+		return err
+	}
+	b.sb.WriteString("))")
+	return nil
+}
+
+// exprLabelJoin renders PromQL `label_join(v, dst, separator, src1, src2, ...)`
+// over a CH Map(String, String):
+//
+//	mapFilter((k, v) -> v != '',
+//	    mapUpdate(<map>, map(?dst, arrayStringConcat([<map>[?src1], <map>[?src2], ...], ?separator))))
+//
+// Missing source labels read as the empty string from CH's Map default;
+// the empty-value mapFilter wrapper then drops `dst` if the joined
+// result is entirely empty (e.g. join of all-absent labels with an
+// empty separator). The match to Prom semantics is: Prom canonicalises
+// empty-valued labels to "absent", same as our drop.
+func (b *Builder) exprLabelJoin(l *chplan.LabelJoin) error {
+	b.sb.WriteString("mapFilter((k, v) -> v != '', mapUpdate(")
+	if err := b.Expr(l.Map); err != nil {
+		return err
+	}
+	b.sb.WriteString(", map(")
+	b.Arg(l.Dst)
+	b.sb.WriteString(", arrayStringConcat([")
+	for i, src := range l.Srcs {
+		if i > 0 {
+			b.sb.WriteString(", ")
+		}
+		if err := b.Expr(l.Map); err != nil {
+			return err
+		}
+		b.sb.WriteByte('[')
+		b.Arg(src)
+		b.sb.WriteByte(']')
+	}
+	b.sb.WriteString("], ")
+	b.Arg(l.Separator)
+	b.sb.WriteString("))))")
 	return nil
 }
 

--- a/internal/chsql/prewhere.go
+++ b/internal/chsql/prewhere.go
@@ -44,6 +44,12 @@ func collectColumnRefs(e chplan.Expr) []string {
 			walk(v.Key)
 		case *chplan.MapWithoutKeys:
 			walk(v.Map)
+		case *chplan.MapWithoutEmptyValues:
+			walk(v.Map)
+		case *chplan.LabelReplace:
+			walk(v.Map)
+		case *chplan.LabelJoin:
+			walk(v.Map)
 		case *chplan.LineContent:
 			walk(v.Source)
 		case *chplan.FieldAccess:
@@ -88,7 +94,7 @@ func isCheapPredicate(e chplan.Expr) bool {
 		return isCheapPredicate(v.Source)
 	case *chplan.FieldAccess:
 		return isCheapPredicate(v.Source)
-	case *chplan.MapWithoutKeys, *chplan.FuncCall, *chplan.NestedArrayExists:
+	case *chplan.MapWithoutKeys, *chplan.MapWithoutEmptyValues, *chplan.LabelReplace, *chplan.LabelJoin, *chplan.FuncCall, *chplan.NestedArrayExists:
 		return false
 	}
 	return false

--- a/internal/promql/label_fns.go
+++ b/internal/promql/label_fns.go
@@ -1,0 +1,143 @@
+package promql
+
+import (
+	"fmt"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// lowerLabelReplace lowers
+//
+//	label_replace(v, dst, replacement, src, regex)
+//
+// into a Project that rewrites the Attributes Map(String, String) via a
+// chplan.LabelReplace expression. PromQL's parser already validates the
+// arg shape (5 args; arg 0 is an instant-vector; args 1..4 are
+// StringLiterals), but the parser's static check lives behind
+// `parser.Check` which `parser.ParseExpr` does not run on lone Calls in
+// every code path — so we re-assert the StringLiteral shape here with
+// clear errors instead of panicking on a bad cast.
+func lowerLabelReplace(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	if len(c.Args) != 5 {
+		return nil, fmt.Errorf("promql: label_replace expects 5 arguments, got %d", len(c.Args))
+	}
+	dst, err := stringArg(c.Args[1], "label_replace", "dst_label")
+	if err != nil {
+		return nil, err
+	}
+	replacement, err := stringArg(c.Args[2], "label_replace", "replacement")
+	if err != nil {
+		return nil, err
+	}
+	src, err := stringArg(c.Args[3], "label_replace", "src_label")
+	if err != nil {
+		return nil, err
+	}
+	regex, err := stringArg(c.Args[4], "label_replace", "regex")
+	if err != nil {
+		return nil, err
+	}
+
+	inner, err := lower(c.Args[0], s, ctx)
+	if err != nil {
+		return nil, err
+	}
+	attrs := &chplan.LabelReplace{
+		Map:         &chplan.ColumnRef{Name: s.AttributesColumn},
+		Dst:         dst,
+		Replacement: replacement,
+		Src:         src,
+		Regex:       regex,
+	}
+	return projectAttributesOverInner(inner, s, attrs), nil
+}
+
+// lowerLabelJoin lowers
+//
+//	label_join(v, dst, separator, src1, src2, ...)
+//
+// into a Project that rewrites Attributes via a chplan.LabelJoin
+// expression. PromQL allows zero src labels (the parser flags this as
+// `Variadic: -1` on top of the 4 fixed args); the spec then says the
+// joined value is the empty string, which our emit path drops via the
+// outer mapFilter — leaving the dst label absent on the wire.
+func lowerLabelJoin(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	if len(c.Args) < 3 {
+		return nil, fmt.Errorf("promql: label_join expects at least 3 arguments (v, dst, separator[, src…]), got %d", len(c.Args))
+	}
+	dst, err := stringArg(c.Args[1], "label_join", "dst_label")
+	if err != nil {
+		return nil, err
+	}
+	separator, err := stringArg(c.Args[2], "label_join", "separator")
+	if err != nil {
+		return nil, err
+	}
+	srcs := make([]string, 0, len(c.Args)-3)
+	for i := 3; i < len(c.Args); i++ {
+		src, err := stringArg(c.Args[i], "label_join", fmt.Sprintf("src_label_%d", i-2))
+		if err != nil {
+			return nil, err
+		}
+		srcs = append(srcs, src)
+	}
+
+	inner, err := lower(c.Args[0], s, ctx)
+	if err != nil {
+		return nil, err
+	}
+	attrs := &chplan.LabelJoin{
+		Map:       &chplan.ColumnRef{Name: s.AttributesColumn},
+		Dst:       dst,
+		Separator: separator,
+		Srcs:      srcs,
+	}
+	return projectAttributesOverInner(inner, s, attrs), nil
+}
+
+// stringArg extracts a static string literal from a Call argument,
+// returning a clear error pointing at the call and parameter when the
+// argument isn't a parser.StringLiteral. PromQL's parser only accepts
+// static strings for these positions, so this guards against an
+// upstream parser shape change without panicking.
+func stringArg(e parser.Expr, fnName, paramName string) (string, error) {
+	sl, ok := e.(*parser.StringLiteral)
+	if !ok {
+		return "", fmt.Errorf("promql: %s(%s) requires a string literal, got %T", fnName, paramName, e)
+	}
+	return sl.Val, nil
+}
+
+// projectAttributesOverInner wraps inner with a Project that keeps every
+// other column and replaces only Attributes with the new attrs
+// expression. Mirrors projectValueOverInner (instant_fns.go) but
+// targets the Attributes column instead of Value.
+//
+// When inner is a RangeWindow, MetricName / TimeUnix don't survive the
+// windowed groupArray and the projection lists only Attributes + Value.
+// Every other inner shape (Scan / Filter / Project / Aggregate / LWR)
+// keeps the full Sample-row schema, so we forward all four canonical
+// columns.
+func projectAttributesOverInner(inner chplan.Node, s schema.Metrics, attrs chplan.Expr) chplan.Node {
+	if _, ok := inner.(*chplan.RangeWindow); ok {
+		return &chplan.Project{
+			Input: inner,
+			Projections: []chplan.Projection{
+				{Expr: attrs, Alias: s.AttributesColumn},
+				{Expr: &chplan.ColumnRef{Name: s.ValueColumn}},
+			},
+		}
+	}
+	return &chplan.Project{
+		Input: inner,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.ColumnRef{Name: s.MetricNameColumn}},
+			{Expr: attrs, Alias: s.AttributesColumn},
+			{Expr: &chplan.ColumnRef{Name: s.TimestampColumn}},
+			{Expr: &chplan.ColumnRef{Name: s.ValueColumn}},
+		},
+	}
+}

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -378,6 +378,10 @@ func lowerCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, err
 		return lowerClamp(c, s, ctx)
 	case "histogram_quantile":
 		return lowerHistogramQuantile(c, s, ctx)
+	case "label_replace":
+		return lowerLabelReplace(c, s, ctx)
+	case "label_join":
+		return lowerLabelJoin(c, s, ctx)
 	}
 	if chFn, ok := instantFnCH[c.Func.Name]; ok {
 		return lowerInstantFn(c, s, chFn, ctx)

--- a/test/spec/chplan_print.go
+++ b/test/spec/chplan_print.go
@@ -275,6 +275,14 @@ func printExpr(e chplan.Expr) string {
 		return fmt.Sprintf("%s[%q]", printExpr(v.Source), v.Path)
 	case *chplan.MapWithoutKeys:
 		return fmt.Sprintf("mapWithout(%s, [%s])", printExpr(v.Map), strings.Join(v.Keys, ", "))
+	case *chplan.MapWithoutEmptyValues:
+		return fmt.Sprintf("mapWithoutEmpty(%s)", printExpr(v.Map))
+	case *chplan.LabelReplace:
+		return fmt.Sprintf("labelReplace(%s, dst=%q, replacement=%q, src=%q, regex=%q)",
+			printExpr(v.Map), v.Dst, v.Replacement, v.Src, v.Regex)
+	case *chplan.LabelJoin:
+		return fmt.Sprintf("labelJoin(%s, dst=%q, separator=%q, srcs=[%s])",
+			printExpr(v.Map), v.Dst, v.Separator, strings.Join(v.Srcs, ", "))
 	case *chplan.LineContent:
 		flags := ""
 		if v.IsRegex {

--- a/test/spec/promql/edge_ceil_over_sum_by.txtar
+++ b/test/spec/promql/edge_ceil_over_sum_by.txtar
@@ -16,7 +16,7 @@ ceil(sum by (job) (up))
 SELECT `MetricName`, `Attributes`, `TimeUnix`, ceil(`Value`) AS `Value` FROM (SELECT ? AS `MetricName`, mapFilter((k, v) -> v != '', map(?, `gkey_0`)) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes`[?] AS `gkey_0`, sum(`Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY `Attributes`[?]))
 -- chplan --
 Project [MetricName, Attributes, TimeUnix, ceil(Value) AS Value]
-  Project ["" AS MetricName, <unknown:*chplan.MapWithoutEmptyValues> AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+  Project ["" AS MetricName, mapWithoutEmpty(map("job", gkey_0)) AS Attributes, now64(9) AS TimeUnix, Value AS Value]
     Aggregate groupBy=[Attributes["job"] AS gkey_0] funcs=[sum(Value) AS Value]
       Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
         Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]

--- a/test/spec/promql/group_by_job.txtar
+++ b/test/spec/promql/group_by_job.txtar
@@ -32,7 +32,7 @@ INSERT INTO otel_metrics_gauge VALUES
   ["", {"job": "web"}, "2026-01-01T00:00:01Z", 1.0]
 ]
 -- chplan --
-Project ["" AS MetricName, <unknown:*chplan.MapWithoutEmptyValues> AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+Project ["" AS MetricName, mapWithoutEmpty(map("job", gkey_0)) AS Attributes, now64(9) AS TimeUnix, Value AS Value]
   Aggregate groupBy=[Attributes["job"] AS gkey_0] funcs=[any(1) AS Value]
     Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
       Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]

--- a/test/spec/promql/label_join_two_labels.txtar
+++ b/test/spec/promql/label_join_two_labels.txtar
@@ -1,0 +1,34 @@
+-- query.promql --
+label_join(temperature, "id", "-", "instance", "job")
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('temperature', map('instance', 'a', 'job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 22.5);
+-- expected_rows --
+[
+  ["temperature", {"id": "a-api", "instance": "a", "job": "api"}, "2026-01-01T00:00:00Z", 22.5]
+]
+-- args --
+[0] string = "id"
+[1] string = "instance"
+[2] string = "job"
+[3] string = "-"
+[4] string = "temperature"
+[5] string = "2026-01-01 00:00:01.000000000"
+[6] int64 = 9
+[7] string = "2026-01-01 00:00:01.000000000"
+[8] int64 = 9
+[9] int64 = 300000000000
+-- chplan --
+Project [MetricName, labelJoin(Attributes, dst="id", separator="-", srcs=[instance, job]) AS Attributes, TimeUnix, Value]
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "temperature") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)
+-- sql --
+SELECT `MetricName`, mapFilter((k, v) -> v != '', mapUpdate(`Attributes`, map(?, arrayStringConcat([`Attributes`[?], `Attributes`[?]], ?)))) AS `Attributes`, `TimeUnix`, `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))

--- a/test/spec/promql/label_join_with_separator.txtar
+++ b/test/spec/promql/label_join_with_separator.txtar
@@ -1,0 +1,35 @@
+-- query.promql --
+label_join(temperature, "fqdn", "/", "namespace", "service", "pod")
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('temperature', map('namespace', 'prod', 'service', 'api', 'pod', 'api-0'), toDateTime64('2026-01-01 00:00:00', 9), 22.5);
+-- expected_rows --
+[
+  ["temperature", {"fqdn": "prod/api/api-0", "namespace": "prod", "pod": "api-0", "service": "api"}, "2026-01-01T00:00:00Z", 22.5]
+]
+-- args --
+[0] string = "fqdn"
+[1] string = "namespace"
+[2] string = "service"
+[3] string = "pod"
+[4] string = "/"
+[5] string = "temperature"
+[6] string = "2026-01-01 00:00:01.000000000"
+[7] int64 = 9
+[8] string = "2026-01-01 00:00:01.000000000"
+[9] int64 = 9
+[10] int64 = 300000000000
+-- chplan --
+Project [MetricName, labelJoin(Attributes, dst="fqdn", separator="/", srcs=[namespace, service, pod]) AS Attributes, TimeUnix, Value]
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "temperature") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)
+-- sql --
+SELECT `MetricName`, mapFilter((k, v) -> v != '', mapUpdate(`Attributes`, map(?, arrayStringConcat([`Attributes`[?], `Attributes`[?], `Attributes`[?]], ?)))) AS `Attributes`, `TimeUnix`, `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))

--- a/test/spec/promql/label_replace_basic.txtar
+++ b/test/spec/promql/label_replace_basic.txtar
@@ -1,0 +1,36 @@
+-- query.promql --
+label_replace(temperature, "new", "$1", "host", "(.*)")
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('temperature', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 22.5);
+-- expected_rows --
+[
+  ["temperature", {"host": "a", "new": "a"}, "2026-01-01T00:00:00Z", 22.5]
+]
+-- args --
+[0] string = "host"
+[1] string = "^(.*)$"
+[2] string = "new"
+[3] string = "host"
+[4] string = "^(.*)$"
+[5] string = "$1"
+[6] string = "temperature"
+[7] string = "2026-01-01 00:00:01.000000000"
+[8] int64 = 9
+[9] string = "2026-01-01 00:00:01.000000000"
+[10] int64 = 9
+[11] int64 = 300000000000
+-- chplan --
+Project [MetricName, labelReplace(Attributes, dst="new", replacement="$1", src="host", regex="(.*)") AS Attributes, TimeUnix, Value]
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "temperature") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)
+-- sql --
+SELECT `MetricName`, mapFilter((k, v) -> v != '', if(match(`Attributes`[?], ?), mapUpdate(`Attributes`, map(?, replaceRegexpOne(`Attributes`[?], ?, ?))), `Attributes`)) AS `Attributes`, `TimeUnix`, `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))

--- a/test/spec/promql/label_replace_no_match.txtar
+++ b/test/spec/promql/label_replace_no_match.txtar
@@ -1,0 +1,36 @@
+-- query.promql --
+label_replace(temperature, "dst", "renamed", "host", "nomatch-(.*)")
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('temperature', map('host', 'a', 'dst', 'original'), toDateTime64('2026-01-01 00:00:00', 9), 22.5);
+-- expected_rows --
+[
+  ["temperature", {"dst": "original", "host": "a"}, "2026-01-01T00:00:00Z", 22.5]
+]
+-- args --
+[0] string = "host"
+[1] string = "^nomatch-(.*)$"
+[2] string = "dst"
+[3] string = "host"
+[4] string = "^nomatch-(.*)$"
+[5] string = "renamed"
+[6] string = "temperature"
+[7] string = "2026-01-01 00:00:01.000000000"
+[8] int64 = 9
+[9] string = "2026-01-01 00:00:01.000000000"
+[10] int64 = 9
+[11] int64 = 300000000000
+-- chplan --
+Project [MetricName, labelReplace(Attributes, dst="dst", replacement="renamed", src="host", regex="nomatch-(.*)") AS Attributes, TimeUnix, Value]
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "temperature") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)
+-- sql --
+SELECT `MetricName`, mapFilter((k, v) -> v != '', if(match(`Attributes`[?], ?), mapUpdate(`Attributes`, map(?, replaceRegexpOne(`Attributes`[?], ?, ?))), `Attributes`)) AS `Attributes`, `TimeUnix`, `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))

--- a/test/spec/promql/label_replace_regex_capture.txtar
+++ b/test/spec/promql/label_replace_regex_capture.txtar
@@ -1,0 +1,36 @@
+-- query.promql --
+label_replace(temperature, "service", "svc-$1", "host", "host-(.*)")
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('temperature', map('host', 'host-prod'), toDateTime64('2026-01-01 00:00:00', 9), 22.5);
+-- expected_rows --
+[
+  ["temperature", {"host": "host-prod", "service": "svc-prod"}, "2026-01-01T00:00:00Z", 22.5]
+]
+-- args --
+[0] string = "host"
+[1] string = "^host-(.*)$"
+[2] string = "service"
+[3] string = "host"
+[4] string = "^host-(.*)$"
+[5] string = "svc-$1"
+[6] string = "temperature"
+[7] string = "2026-01-01 00:00:01.000000000"
+[8] int64 = 9
+[9] string = "2026-01-01 00:00:01.000000000"
+[10] int64 = 9
+[11] int64 = 300000000000
+-- chplan --
+Project [MetricName, labelReplace(Attributes, dst="service", replacement="svc-$1", src="host", regex="host-(.*)") AS Attributes, TimeUnix, Value]
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "temperature") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)
+-- sql --
+SELECT `MetricName`, mapFilter((k, v) -> v != '', if(match(`Attributes`[?], ?), mapUpdate(`Attributes`, map(?, replaceRegexpOne(`Attributes`[?], ?, ?))), `Attributes`)) AS `Attributes`, `TimeUnix`, `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))

--- a/test/spec/promql/quantile_by_job.txtar
+++ b/test/spec/promql/quantile_by_job.txtar
@@ -34,7 +34,7 @@ INSERT INTO otel_metrics_gauge VALUES
   ["", {"job": "web"}, "2026-01-01T00:00:01Z", 14.5]
 ]
 -- chplan --
-Project ["" AS MetricName, <unknown:*chplan.MapWithoutEmptyValues> AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+Project ["" AS MetricName, mapWithoutEmpty(map("job", gkey_0)) AS Attributes, now64(9) AS TimeUnix, Value AS Value]
   Aggregate groupBy=[Attributes["job"] AS gkey_0] funcs=[quantile(0.95)(Value) AS Value]
     Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
       Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]

--- a/test/spec/promql/stddev_by_job.txtar
+++ b/test/spec/promql/stddev_by_job.txtar
@@ -32,7 +32,7 @@ INSERT INTO otel_metrics_gauge VALUES
   ["", {"job": "web"}, "2026-01-01T00:00:01Z", 5.0]
 ]
 -- chplan --
-Project ["" AS MetricName, <unknown:*chplan.MapWithoutEmptyValues> AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+Project ["" AS MetricName, mapWithoutEmpty(map("job", gkey_0)) AS Attributes, now64(9) AS TimeUnix, Value AS Value]
   Aggregate groupBy=[Attributes["job"] AS gkey_0] funcs=[stddevPop(Value) AS Value]
     Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
       Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]

--- a/test/spec/promql/sum_by_job.txtar
+++ b/test/spec/promql/sum_by_job.txtar
@@ -31,7 +31,7 @@ INSERT INTO otel_metrics_gauge VALUES
 -- sql --
 SELECT ? AS `MetricName`, mapFilter((k, v) -> v != '', map(?, `gkey_0`)) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes`[?] AS `gkey_0`, sum(`Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY `Attributes`[?])
 -- chplan --
-Project ["" AS MetricName, <unknown:*chplan.MapWithoutEmptyValues> AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+Project ["" AS MetricName, mapWithoutEmpty(map("job", gkey_0)) AS Attributes, now64(9) AS TimeUnix, Value AS Value]
   Aggregate groupBy=[Attributes["job"] AS gkey_0] funcs=[sum(Value) AS Value]
     Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
       Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]


### PR DESCRIPTION
## Summary

Closes 10 prometheus/compliance gaps (7 × label_replace + 3 × label_join).

## Implementation

Two new chplan IR nodes (`LabelReplace`, `LabelJoin`) + chsql emit via typed Frag API. No raw SQL.

**SQL shapes:**
- `label_replace`: `mapFilter((k,v) -> v != '', if(match(<map>[?src], ?^regex$), mapUpdate(<map>, map(?dst, replaceRegexpOne(<map>[?src], ?^regex$, ?replacement))), <map>))`. Regex anchored `^…$` to match Prom's full-string-match rule. Outer `mapFilter` drops dst when substitution yields empty.
- `label_join`: `mapFilter((k,v) -> v != '', mapUpdate(<map>, map(?dst, arrayStringConcat([<map>[?src1], ...], ?separator))))`. Missing source labels default to empty string from CH Map default.

## Test plan

- [x] `go test -count=1 ./internal/{promql,chsql,chplan}/` — 986 pass
- [x] `go test ./...` — 2578 pass
- [x] 5 new TXTAR fixtures (basic, regex capture, no-match, two-labels, with-separator)
- [x] Existing chplan_print + prewhere helpers extended for the new node types

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>