### PR TITLE
feat(promql): date functions year/month/day_of_month/day_of_week/days_in_month/hour/minute/timestamp

### DIFF
--- a/internal/chplan/scan.go
+++ b/internal/chplan/scan.go
@@ -3,9 +3,16 @@ package chplan
 // Scan reads rows from a single ClickHouse table. If Columns is empty, the
 // emitter projects `*` and downstream Project nodes can narrow it; otherwise
 // only the listed columns are read.
+//
+// Database is optional; when non-empty the emitter renders the table
+// reference as `<Database>`.`<Table>` (both parts backtick-quoted) — used
+// for synthetic single-row sources like `system.one` that the no-arg
+// date functions scan. Empty Database emits just the bare table name,
+// matching the original behaviour for every user-facing table.
 type Scan struct {
-	Table   string
-	Columns []string
+	Database string
+	Table    string
+	Columns  []string
 }
 
 func (*Scan) planNode() {}
@@ -14,7 +21,7 @@ func (*Scan) Children() []Node { return nil }
 
 func (s *Scan) Equal(other Node) bool {
 	o, ok := other.(*Scan)
-	if !ok || s.Table != o.Table || len(s.Columns) != len(o.Columns) {
+	if !ok || s.Database != o.Database || s.Table != o.Table || len(s.Columns) != len(o.Columns) {
 		return false
 	}
 	for i := range s.Columns {

--- a/internal/chsql/emit_node.go
+++ b/internal/chsql/emit_node.go
@@ -61,7 +61,7 @@ func (e *emitter) splice(b *Builder) {
 }
 
 func (e *emitter) emitScan(s *chplan.Scan) error {
-	sb := NewQuery().From(Col(s.Table))
+	sb := NewQuery().From(scanTableFrag(s))
 	if len(s.Columns) > 0 {
 		cols := make([]Frag, 0, len(s.Columns))
 		for _, c := range s.Columns {
@@ -88,6 +88,18 @@ func (e *emitter) emitOneRow(_ *chplan.OneRow) error {
 	sb := NewQuery().Select(InlineLit(int64(1)))
 	e.emitSelect(sb)
 	return nil
+}
+
+// scanTableFrag returns the Frag that renders the Scan's table reference.
+// When Database is empty (the common case) it's just the bare backtick-
+// quoted table name; when Database is non-empty (synthetic single-row
+// sources like `system.one`) it emits the qualified `<db>`.`<tbl>` shape
+// so CH resolves the system database directly.
+func scanTableFrag(s *chplan.Scan) Frag {
+	if s.Database != "" {
+		return Qual(s.Database, s.Table)
+	}
+	return Col(s.Table)
 }
 
 func (e *emitter) emitFilter(f *chplan.Filter) error {
@@ -141,7 +153,7 @@ func (e *emitter) emitFilterScan(f *chplan.Filter, scan *chplan.Scan) error {
 		whereExprs = conjuncts
 	}
 
-	sb := NewQuery().From(Col(scan.Table))
+	sb := NewQuery().From(scanTableFrag(scan))
 	if len(scan.Columns) > 0 {
 		cols := make([]Frag, 0, len(scan.Columns))
 		for _, c := range scan.Columns {

--- a/internal/promql/date_fns.go
+++ b/internal/promql/date_fns.go
@@ -98,7 +98,7 @@ func lowerDateFnNoArg(name string, s schema.Metrics) (chplan.Node, error) {
 //
 // Returns nil when name is not a recognised date function — caller
 // translates that into a "not yet supported" error.
-func dateFnExpr(name string, valueDT chplan.Expr, tsRef chplan.Expr) chplan.Expr {
+func dateFnExpr(name string, valueDT, tsRef chplan.Expr) chplan.Expr {
 	switch name {
 	case "year":
 		return &chplan.FuncCall{Name: "toYear", Args: []chplan.Expr{valueDT}}

--- a/internal/promql/date_fns.go
+++ b/internal/promql/date_fns.go
@@ -1,0 +1,162 @@
+package promql
+
+import (
+	"fmt"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// lowerDateFn maps PromQL date-component functions to their ClickHouse
+// equivalents. Each function takes one instant-vector argument whose
+// `Value` column is interpreted as a Unix timestamp in seconds — except
+// `timestamp(v)`, which reads each sample's `TimeUnix` column and
+// converts it to float seconds.
+//
+// When called without an argument the PromQL spec defaults the input to
+// `vector(time())` — a single instant-vector entry whose value is the
+// current evaluation timestamp in seconds. cerberus lowers that to a
+// degenerate scan over `system.one` (CH's one-row table) projecting
+// `(MetricName='', Attributes={}, TimeUnix=now64(9), Value=<fn>(now()))`.
+// The `timestamp` function does NOT have a zero-arg form in upstream
+// PromQL — Prometheus rejects it during parsing — so the no-arg branch
+// is unreachable for that name; we keep the same shape anyway for
+// uniformity in case upstream relaxes the rule.
+//
+// Semantic notes:
+//
+//   - PromQL `day_of_week` returns 0-6 with Sunday=0; ClickHouse
+//     `toDayOfWeek(d)` returns 1-7 with Monday=1, Sunday=7. We lower as
+//     `toDayOfWeek(d) % 7` which yields Mon=1, Tue=2, …, Sat=6, Sun=0 —
+//     exactly the PromQL semantics.
+//
+//   - `days_in_month` lowers to `toDayOfMonth(toLastDayOfMonth(d))`
+//     because CH has no direct `daysInMonth` builtin; the day-of-month
+//     of the last day in the month is the day count for that month.
+//
+//   - `timestamp(v)` ignores `Value` and reads the sample's TimeUnix
+//     column instead, converting the DateTime64(9) to fractional Unix
+//     seconds via `toUnixTimestamp64Nano(TimeUnix) / 1e9`.
+func lowerDateFn(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	if len(c.Args) > 1 {
+		return nil, fmt.Errorf("promql: %s expects 0 or 1 argument, got %d", c.Func.Name, len(c.Args))
+	}
+
+	if len(c.Args) == 0 {
+		return lowerDateFnNoArg(c.Func.Name, s)
+	}
+
+	inner, err := lower(c.Args[0], s, ctx)
+	if err != nil {
+		return nil, err
+	}
+	newValue := dateFnExpr(c.Func.Name, valueAsDateTime(s), &chplan.ColumnRef{Name: s.TimestampColumn})
+	if newValue == nil {
+		return nil, fmt.Errorf("promql: unknown date function %s", c.Func.Name)
+	}
+	return projectValueOverInner(inner, s, newValue), nil
+}
+
+// lowerDateFnNoArg synthesises a single-row constant instant vector for
+// the no-arg form of a date function. PromQL spec: `year()` ≡
+// `year(vector(time()))`. The result is a one-row vector with the time
+// component of the current eval timestamp as its sample value.
+//
+// We emit `Scan(system.one)` (CH's single-row builtin) wrapped in a
+// Project that builds the canonical Sample shape:
+//
+//	MetricName  = ''
+//	Attributes  = CAST(map(), 'Map(String,String)')
+//	TimeUnix    = now64(9)
+//	Value       = <date-fn>(now())
+//
+// — matching the shape produced by an unaggregated PromQL aggregation
+// over the same single instant vector.
+func lowerDateFnNoArg(name string, s schema.Metrics) (chplan.Node, error) {
+	now := &chplan.FuncCall{Name: "now"}
+	expr := dateFnExpr(name, now, now)
+	if expr == nil {
+		return nil, fmt.Errorf("promql: unknown date function %s", name)
+	}
+	return &chplan.Project{
+		Input: &chplan.Scan{Database: "system", Table: "one"},
+		Projections: []chplan.Projection{
+			{Expr: &chplan.LitString{V: ""}, Alias: s.MetricNameColumn},
+			{Expr: emptyAttrsMap(), Alias: s.AttributesColumn},
+			{Expr: &chplan.FuncCall{Name: "now64", Args: []chplan.Expr{&chplan.LitInt{V: 9}}}, Alias: s.TimestampColumn},
+			{Expr: expr, Alias: s.ValueColumn},
+		},
+	}, nil
+}
+
+// dateFnExpr returns the CH expression that computes the date-component
+// for the given PromQL function name. valueDT is the DateTime expression
+// derived from the input sample's Value (interpreted as Unix seconds);
+// tsRef is the raw `TimeUnix` column reference used by `timestamp(v)`.
+//
+// Returns nil when name is not a recognised date function — caller
+// translates that into a "not yet supported" error.
+func dateFnExpr(name string, valueDT chplan.Expr, tsRef chplan.Expr) chplan.Expr {
+	switch name {
+	case "year":
+		return &chplan.FuncCall{Name: "toYear", Args: []chplan.Expr{valueDT}}
+	case "month":
+		return &chplan.FuncCall{Name: "toMonth", Args: []chplan.Expr{valueDT}}
+	case "day_of_month":
+		return &chplan.FuncCall{Name: "toDayOfMonth", Args: []chplan.Expr{valueDT}}
+	case "day_of_week":
+		// CH toDayOfWeek default returns Mon=1..Sun=7 (ISO).
+		// PromQL day_of_week returns Sun=0..Sat=6 (US).
+		// `toDayOfWeek(d) % 7` maps 7→0 and leaves 1..6 unchanged,
+		// yielding the PromQL semantics directly.
+		return &chplan.Binary{
+			Op:    chplan.OpMod,
+			Left:  &chplan.FuncCall{Name: "toDayOfWeek", Args: []chplan.Expr{valueDT}},
+			Right: &chplan.LitInt{V: 7},
+		}
+	case "days_in_month":
+		// CH has no direct daysInMonth; the day-of-month of the last
+		// day in the month IS the day count for that month.
+		return &chplan.FuncCall{
+			Name: "toDayOfMonth",
+			Args: []chplan.Expr{
+				&chplan.FuncCall{Name: "toLastDayOfMonth", Args: []chplan.Expr{valueDT}},
+			},
+		}
+	case "hour":
+		return &chplan.FuncCall{Name: "toHour", Args: []chplan.Expr{valueDT}}
+	case "minute":
+		return &chplan.FuncCall{Name: "toMinute", Args: []chplan.Expr{valueDT}}
+	case "timestamp":
+		// `timestamp(v)` returns each sample's TimeUnix as float
+		// seconds — NOT a function of Value. Convert the DateTime64(9)
+		// column to nanoseconds (Int64) and divide by 1e9 to get
+		// fractional seconds.
+		return &chplan.Binary{
+			Op:    chplan.OpDiv,
+			Left:  &chplan.FuncCall{Name: "toUnixTimestamp64Nano", Args: []chplan.Expr{tsRef}},
+			Right: &chplan.LitFloat{V: 1e9},
+		}
+	}
+	return nil
+}
+
+// valueAsDateTime renders `toDateTime(toInt64(Value), 'UTC')` — the
+// PromQL convention that Value is Unix seconds, which CH's date-component
+// functions consume after a cast through Int64 → DateTime. We pin the
+// timezone to UTC explicitly so the returned components don't drift with
+// the server's default timezone (PromQL specifies UTC).
+func valueAsDateTime(s schema.Metrics) chplan.Expr {
+	return &chplan.FuncCall{
+		Name: "toDateTime",
+		Args: []chplan.Expr{
+			&chplan.FuncCall{
+				Name: "toInt64",
+				Args: []chplan.Expr{&chplan.ColumnRef{Name: s.ValueColumn}},
+			},
+			&chplan.LitString{V: "UTC"},
+		},
+	}
+}

--- a/internal/promql/date_fns.go
+++ b/internal/promql/date_fns.go
@@ -19,7 +19,7 @@ import (
 // `vector(time())` — a single instant-vector entry whose value is the
 // current evaluation timestamp in seconds. cerberus lowers that to a
 // degenerate scan over `system.one` (CH's one-row table) projecting
-// `(MetricName='', Attributes={}, TimeUnix=now64(9), Value=<fn>(now()))`.
+// `(MetricName=”, Attributes={}, TimeUnix=now64(9), Value=<fn>(now()))`.
 // The `timestamp` function does NOT have a zero-arg form in upstream
 // PromQL — Prometheus rejects it during parsing — so the no-arg branch
 // is unreachable for that name; we keep the same shape anyway for

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -386,6 +386,9 @@ func lowerCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, err
 		return lowerTime(c, s, ctx)
 	case "vector":
 		return lowerVector(c, s, ctx)
+	case "year", "month", "day_of_month", "day_of_week",
+		"days_in_month", "hour", "minute", "timestamp":
+		return lowerDateFn(c, s, ctx)
 	}
 	if chFn, ok := instantFnCH[c.Func.Name]; ok {
 		return lowerInstantFn(c, s, chFn, ctx)

--- a/test/spec/chplan_print.go
+++ b/test/spec/chplan_print.go
@@ -38,10 +38,14 @@ func printNode(b *strings.Builder, n chplan.Node, depth int) {
 	}
 	switch v := n.(type) {
 	case *chplan.Scan:
+		tbl := v.Table
+		if v.Database != "" {
+			tbl = v.Database + "." + v.Table
+		}
 		if len(v.Columns) == 0 {
-			fmt.Fprintf(b, "%sScan(%s)\n", indent, v.Table)
+			fmt.Fprintf(b, "%sScan(%s)\n", indent, tbl)
 		} else {
-			fmt.Fprintf(b, "%sScan(%s, columns=[%s])\n", indent, v.Table, strings.Join(v.Columns, ", "))
+			fmt.Fprintf(b, "%sScan(%s, columns=[%s])\n", indent, tbl, strings.Join(v.Columns, ", "))
 		}
 	case *chplan.OneRow:
 		fmt.Fprintf(b, "%sOneRow\n", indent)

--- a/test/spec/promql/day_of_month_of_vector.txtar
+++ b/test/spec/promql/day_of_month_of_vector.txtar
@@ -1,0 +1,31 @@
+-- query.promql --
+day_of_month(unix_seconds)
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('unix_seconds', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 1700000000);
+-- expected_rows --
+[
+  ["unix_seconds", {"host": "a"}, "2026-01-01T00:00:00Z", 14.0]
+]
+-- args --
+[0] string = "UTC"
+[1] string = "unix_seconds"
+[2] string = "2026-01-01 00:00:01.000000000"
+[3] int64 = 9
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] int64 = 300000000000
+-- chplan --
+Project [MetricName, Attributes, TimeUnix, toDayOfMonth(toDateTime(toInt64(Value), "UTC")) AS Value]
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "unix_seconds") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, toDayOfMonth(toDateTime(toInt64(`Value`), ?)) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))

--- a/test/spec/promql/day_of_week_offset.txtar
+++ b/test/spec/promql/day_of_week_offset.txtar
@@ -1,0 +1,32 @@
+-- query.promql --
+day_of_week(weekday_marker)
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('weekday_marker', map('host', 'sun'), toDateTime64('2026-01-01 00:00:00', 9), 1700956800);
+-- expected_rows --
+[
+  ["weekday_marker", {"host": "sun"}, "2026-01-01T00:00:00Z", 0.0]
+]
+-- args --
+[0] string = "UTC"
+[1] int64 = 7
+[2] string = "weekday_marker"
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] string = "2026-01-01 00:00:01.000000000"
+[6] int64 = 9
+[7] int64 = 300000000000
+-- chplan --
+Project [MetricName, Attributes, TimeUnix, (toDayOfWeek(toDateTime(toInt64(Value), "UTC")) % 7) AS Value]
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "weekday_marker") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, (toDayOfWeek(toDateTime(toInt64(`Value`), ?)) % ?) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))

--- a/test/spec/promql/days_in_month_of_vector.txtar
+++ b/test/spec/promql/days_in_month_of_vector.txtar
@@ -1,0 +1,31 @@
+-- query.promql --
+days_in_month(unix_seconds)
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('unix_seconds', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 1700000000);
+-- expected_rows --
+[
+  ["unix_seconds", {"host": "a"}, "2026-01-01T00:00:00Z", 30.0]
+]
+-- args --
+[0] string = "UTC"
+[1] string = "unix_seconds"
+[2] string = "2026-01-01 00:00:01.000000000"
+[3] int64 = 9
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] int64 = 300000000000
+-- chplan --
+Project [MetricName, Attributes, TimeUnix, toDayOfMonth(toLastDayOfMonth(toDateTime(toInt64(Value), "UTC"))) AS Value]
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "unix_seconds") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, toDayOfMonth(toLastDayOfMonth(toDateTime(toInt64(`Value`), ?))) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))

--- a/test/spec/promql/hour_of_vector.txtar
+++ b/test/spec/promql/hour_of_vector.txtar
@@ -1,0 +1,31 @@
+-- query.promql --
+hour(unix_seconds)
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('unix_seconds', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 1700000000);
+-- expected_rows --
+[
+  ["unix_seconds", {"host": "a"}, "2026-01-01T00:00:00Z", 22.0]
+]
+-- args --
+[0] string = "UTC"
+[1] string = "unix_seconds"
+[2] string = "2026-01-01 00:00:01.000000000"
+[3] int64 = 9
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] int64 = 300000000000
+-- chplan --
+Project [MetricName, Attributes, TimeUnix, toHour(toDateTime(toInt64(Value), "UTC")) AS Value]
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "unix_seconds") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, toHour(toDateTime(toInt64(`Value`), ?)) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))

--- a/test/spec/promql/minute_of_vector.txtar
+++ b/test/spec/promql/minute_of_vector.txtar
@@ -1,0 +1,31 @@
+-- query.promql --
+minute(unix_seconds)
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('unix_seconds', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 1700000000);
+-- expected_rows --
+[
+  ["unix_seconds", {"host": "a"}, "2026-01-01T00:00:00Z", 13.0]
+]
+-- args --
+[0] string = "UTC"
+[1] string = "unix_seconds"
+[2] string = "2026-01-01 00:00:01.000000000"
+[3] int64 = 9
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] int64 = 300000000000
+-- chplan --
+Project [MetricName, Attributes, TimeUnix, toMinute(toDateTime(toInt64(Value), "UTC")) AS Value]
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "unix_seconds") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, toMinute(toDateTime(toInt64(`Value`), ?)) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))

--- a/test/spec/promql/month_of_vector.txtar
+++ b/test/spec/promql/month_of_vector.txtar
@@ -1,0 +1,31 @@
+-- query.promql --
+month(unix_seconds)
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('unix_seconds', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 1700000000);
+-- expected_rows --
+[
+  ["unix_seconds", {"host": "a"}, "2026-01-01T00:00:00Z", 11.0]
+]
+-- args --
+[0] string = "UTC"
+[1] string = "unix_seconds"
+[2] string = "2026-01-01 00:00:01.000000000"
+[3] int64 = 9
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] int64 = 300000000000
+-- chplan --
+Project [MetricName, Attributes, TimeUnix, toMonth(toDateTime(toInt64(Value), "UTC")) AS Value]
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "unix_seconds") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, toMonth(toDateTime(toInt64(`Value`), ?)) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))

--- a/test/spec/promql/timestamp_of_metric.txtar
+++ b/test/spec/promql/timestamp_of_metric.txtar
@@ -1,0 +1,31 @@
+-- query.promql --
+timestamp(any_metric)
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('any_metric', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 42.0);
+-- expected_rows --
+[
+  ["any_metric", {"host": "a"}, "2026-01-01T00:00:00Z", 1767225600.0]
+]
+-- args --
+[0] float64 = 1e+09
+[1] string = "any_metric"
+[2] string = "2026-01-01 00:00:01.000000000"
+[3] int64 = 9
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] int64 = 300000000000
+-- chplan --
+Project [MetricName, Attributes, TimeUnix, (toUnixTimestamp64Nano(TimeUnix) / 1e+09) AS Value]
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "any_metric") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, (toUnixTimestamp64Nano(`TimeUnix`) / ?) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))

--- a/test/spec/promql/year_default.txtar
+++ b/test/spec/promql/year_default.txtar
@@ -1,0 +1,11 @@
+-- query.promql --
+year()
+-- args --
+[0] string = ""
+[1] string = "Map(String,String)"
+[2] int64 = 9
+-- chplan --
+Project ["" AS MetricName, CAST(map(), "Map(String,String)") AS Attributes, now64(9) AS TimeUnix, toYear(now()) AS Value]
+  Scan(system.one)
+-- sql --
+SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, toYear(now()) AS `Value` FROM (SELECT * FROM `system`.`one`)

--- a/test/spec/promql/year_of_vector.txtar
+++ b/test/spec/promql/year_of_vector.txtar
@@ -1,0 +1,31 @@
+-- query.promql --
+year(unix_seconds)
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('unix_seconds', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 1700000000);
+-- expected_rows --
+[
+  ["unix_seconds", {"host": "a"}, "2026-01-01T00:00:00Z", 2023.0]
+]
+-- args --
+[0] string = "UTC"
+[1] string = "unix_seconds"
+[2] string = "2026-01-01 00:00:01.000000000"
+[3] int64 = 9
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] int64 = 300000000000
+-- chplan --
+Project [MetricName, Attributes, TimeUnix, toYear(toDateTime(toInt64(Value), "UTC")) AS Value]
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "unix_seconds") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, toYear(toDateTime(toInt64(`Value`), ?)) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))


### PR DESCRIPTION
## Summary

Closes 32 prometheus/compliance gaps. PromQL date functions lower to ClickHouse's matching `to{Year,Month,DayOfMonth,...}` expressions via typed chsql Frag emission.

## Implementation

- New `internal/promql/date_fns.go` — `lowerDateFn` dispatch + `dateFnExpr` per-function mapping.
- Wired into `lowerCall` for: `year`, `month`, `day_of_month`, `day_of_week`, `days_in_month`, `hour`, `minute`, `timestamp`.
- **day_of_week semantics**: `toDayOfWeek(d) % 7` to convert CH's ISO (Mon=1..Sun=7) to PromQL's (Sun=0..Sat=6). Verified via `day_of_week_offset.txtar` (seeded Sunday 2023-11-26 → returns 0.0).
- No-arg case (`year()` without args) defaults to the eval timestamp via `Scan{Database: "system", Table: "one"}` projected into the canonical Sample shape.
- New `chplan.Scan.Database` field for system table qualification (optional, backward-compatible).

## Test plan

- [x] `go test ./internal/promql/ ./internal/chsql/ ./internal/chplan/ ./internal/optimizer/` — 1150 pass
- [x] `go test ./internal/...` — 2358 pass
- [x] `go test -tags chdb ./test/spec/promql/` — 147 pass (incl. 9 new fixtures)

## Coordination

S2 (`time()` + `vector()`) is still in flight. If S2 lands first with a different `time()` shape, the no-arg date-fn path may need to share that shape. Resolution at main-agent rebase time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>