### PR TITLE
fix(logql,api/prom): wire-wrap column refs match RangeWindow emit shape

### DIFF
--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -466,10 +466,12 @@ func errContainsStage(msg, stage string) bool {
 //  2. RangeWindow / Aggregate / Filter(Aggregate) — derived shapes
 //     whose inner SELECT exposes only (group-keys…, s.ValueColumn).
 //     The canonical MetricName doesn't exist in that scope; synthesise
-//     it as empty string. The matrix RangeWindow projects anchor_ts AS
-//     s.TimestampColumn on its outermost SELECT so the per-row timestamp
-//     flows through under the canonical name; the instant case has to
-//     synthesise via now64().
+//     it as empty string. The matrix RangeWindow exposes the per-row
+//     anchor as the literal column `anchor_ts` (no inner alias to
+//     s.TimestampColumn — emitWindowedArrayMatrix emits it raw); this
+//     Project renames `anchor_ts` → s.TimestampColumn on the way out via
+//     the projection's own Alias. The instant case has to synthesise
+//     via now64().
 func wrapWithSampleProjection(plan chplan.Node, s schema.Metrics) chplan.Node {
 	projections := []chplan.Projection{
 		{Expr: &chplan.ColumnRef{Name: s.MetricNameColumn}},
@@ -479,12 +481,13 @@ func wrapWithSampleProjection(plan chplan.Node, s schema.Metrics) chplan.Node {
 	}
 	if isDerivedShape(plan) {
 		// TimeUnix source: matrix-shape RangeWindow exposes a real
-		// per-row timestamp under s.TimestampColumn (one row per anchor
-		// across the subquery's outer range); the instant case has to
-		// synthesise via now64().
+		// per-row timestamp under the literal column `anchor_ts` (one
+		// row per anchor across the subquery's outer range); the outer
+		// Projection's own Alias renames it back to s.TimestampColumn
+		// on emit. The instant case has to synthesise via now64().
 		var tsExpr chplan.Expr
 		if isMatrixRangeWindow(plan) {
-			tsExpr = &chplan.ColumnRef{Name: s.TimestampColumn}
+			tsExpr = &chplan.ColumnRef{Name: "anchor_ts"}
 		} else {
 			tsExpr = synthesizedAnchor()
 		}

--- a/internal/api/prom/handler_chdb_subquery_test.go
+++ b/internal/api/prom/handler_chdb_subquery_test.go
@@ -1,0 +1,138 @@
+//go:build chdb
+
+// chDB-backed regression coverage for the prom handler's
+// subquery-bare-vector wire-wrap. PR #310 collapsed the rename Project
+// layer that swallowed the matrix RangeWindow's per-row anchor column,
+// and `internal/api/prom/handler.go::wrapWithSampleProjection`'s matrix
+// branch was the one callsite that still wired its outer Project to the
+// pre-#310 alias (`s.TimestampColumn`). The fix points the ColumnRef at
+// `anchor_ts` directly (matching the emitter's outer SELECT) and lets
+// the projection's own Alias rename it back to s.TimestampColumn on the
+// way out.
+//
+// This file's test pins the regression end-to-end (handler → engine →
+// chDB) so a future refactor that re-flips the alias gets caught before
+// the e2e `TestPromQuerySubqueryBareVector` failure surfaces against
+// `/api/v1/query` with `query=up[1m:30s]`.
+
+package prom_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestQueryRange_SubqueryBareVector_ChDB exercises `up[1m:30s]` on
+// `/api/v1/query` end-to-end against an in-process chDB session. Pins
+// the Regression B failure (`wrapWithSampleProjection`'s matrix branch
+// ColumnRef'd `s.TimestampColumn` — a column the emitWindowedArrayMatrix
+// outer SELECT does NOT expose; the fix points it at `anchor_ts`).
+//
+// Mirrors `TestQueryRange_Matrix_ChDB`'s shape but uses the
+// subquery-bare-vector instant-query route the e2e harness exercises.
+// The assertion set is intentionally minimal — HTTP 200 + status
+// success + non-empty result — because the per-step values depend on
+// `now64()` (no `@` modifier) and the synthesised seed window has to
+// straddle CH-now to surface any data. Pinning a wire-shape regression
+// rather than a value regression keeps the test stable across time.
+func TestQueryRange_SubqueryBareVector_ChDB(t *testing.T) {
+	// Seed five `up` gauge samples spaced 30s apart, ending close to
+	// "now" so the matrix RangeWindow's `End = now64(9)` (no `@`
+	// modifier on the subquery) catches them in its [end-1m, end]
+	// window across at least one anchor.
+	//
+	// The exact-timestamp granularity isn't load-bearing — the
+	// regression we're pinning is wire-format (which column the outer
+	// Project ColumnRefs), not arithmetic.
+	now := time.Now().UTC()
+	seedRows := make([]string, 0, 5)
+	for i := 0; i < 5; i++ {
+		// Anchor each sample at (now - i*30s); five samples, 30s apart,
+		// span 2 minutes — wide enough that the matrix's 1m window
+		// catches at least one per anchor.
+		ts := now.Add(-time.Duration(i) * 30 * time.Second).Format("2006-01-02 15:04:05.000")
+		seedRows = append(seedRows, fmt.Sprintf(
+			`('up', map('job', 'api'), toDateTime64('%s', 9), 1.0)`, ts,
+		))
+	}
+	seed := gaugeDDL + "\nINSERT INTO otel_metrics_gauge VALUES\n  " +
+		strings.Join(seedRows, ",\n  ") + ";"
+
+	srv, _ := newChDBServer(t, seed)
+
+	// `up[1m:30s]` is a SubqueryExpr — Prom's range-vector form usable
+	// in an instant query. The handler emits a vector envelope around
+	// the matrix RangeWindow rows (cerberus's pivot rule for
+	// /api/v1/query). The wire test we want to pin runs entirely on
+	// the underlying matrix RangeWindow's `anchor_ts` projection — if
+	// the wire-wrap ColumnRef'd the wrong column, chDB would 502 with
+	// `UNKNOWN_IDENTIFIER` long before any data shape mismatch.
+	url := srv.URL + "/api/v1/query?query=" + escape("up[1m:30s]")
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+
+	var parsed queryResponse
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v\nbody=%s", err, body)
+	}
+	if parsed.Status != "success" {
+		t.Fatalf("status: got %q (errorType=%q error=%q), want success "+
+			"(pre-fix Regression B path: 502 from chDB "+
+			"UNKNOWN_IDENTIFIER: 'TimeUnix' on the outer matrix Project)",
+			parsed.Status, parsed.ErrorType, parsed.Error)
+	}
+
+	// The result is wrapped as a JSON array (cerberus pivots subquery
+	// matrix output to vector samples via toVector). Decode raw and
+	// assert non-empty — anything in the result array proves the
+	// matrix RangeWindow SQL executed without hitting an
+	// UNKNOWN_IDENTIFIER on the wire-wrap.
+	rawResult, _ := json.Marshal(parsed.Data.Result)
+	var result []any
+	if err := json.Unmarshal(rawResult, &result); err != nil {
+		t.Fatalf("decode result: %v (raw=%s)", err, rawResult)
+	}
+	if len(result) == 0 {
+		t.Fatalf("expected non-empty result (matrix RangeWindow over 5 "+
+			"seeded samples must surface at least one anchor); got: %s",
+			rawResult)
+	}
+}
+
+// escape is `url.QueryEscape` minus the import — kept local to this
+// file so the small test stays focused. Mirrors what the test runner
+// would emit for `?query=<x>` with `<x>` containing `[`, `]`, and `:`.
+func escape(q string) string {
+	var b strings.Builder
+	for _, r := range q {
+		switch {
+		case r == ' ':
+			b.WriteByte('+')
+		case r == '[':
+			b.WriteString("%5B")
+		case r == ']':
+			b.WriteString("%5D")
+		case r == ':':
+			b.WriteString("%3A")
+		case r == '{':
+			b.WriteString("%7B")
+		case r == '}':
+			b.WriteString("%7D")
+		case r == '"':
+			b.WriteString("%22")
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}

--- a/internal/logql/lang.go
+++ b/internal/logql/lang.go
@@ -108,9 +108,15 @@ func (l *Lang) ProjectSamples(plan chplan.Node, meta engine.Meta) chplan.Node {
 	s := l.Schema
 	if meta.IsMetric {
 		// Metric queries lower to RangeWindow / Aggregate / Filter(Aggregate),
-		// whose output is just (group-keys…, value). MetricName + TimeUnix
+		// whose output is (group-keys…, <metric-value>). MetricName + TimeUnix
 		// don't exist in that scope — synthesise them so the chclient
 		// Sample scanner has the four positional columns it expects.
+		//
+		// The metric-value column is the canonical PascalCase `Value` (the
+		// alias the RangeWindow / Aggregate emitters project at every outer
+		// SELECT site since #310 collapsed the rename Project layer); mirror
+		// it here so the wire-wrap doesn't ColumnRef the pre-#310 lowercase
+		// alias.
 		return &chplan.Project{
 			Input: plan,
 			Projections: []chplan.Projection{
@@ -124,7 +130,7 @@ func (l *Lang) ProjectSamples(plan chplan.Node, meta engine.Meta) chplan.Node {
 					Left:  &chplan.FuncCall{Name: "now64", Args: []chplan.Expr{&chplan.LitInt{V: 9}}},
 					Right: &chplan.FuncCall{Name: "toIntervalNanosecond", Args: []chplan.Expr{&chplan.LitInt{V: 5_000_000_000}}},
 				}, Alias: "TimeUnix"},
-				{Expr: &chplan.ColumnRef{Name: "value"}, Alias: "Value"},
+				{Expr: &chplan.ColumnRef{Name: rangeAggSynthValueColumn}, Alias: "Value"},
 			},
 		}
 	}

--- a/internal/logql/lang_test.go
+++ b/internal/logql/lang_test.go
@@ -1,0 +1,108 @@
+package logql_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/engine"
+	"github.com/tsouza/cerberus/internal/logql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestProjectSamples_MetricBranchRefsValueColumn pins the metric-branch
+// wire-wrap against a post-#310 regression — the e2e
+// `TestLokiQueryRangeCountOverTime` failure root cause.
+//
+// Before #310 the chsql RangeWindow emitter projected its windowed value
+// under the lowercase alias `value`, and `Lang.ProjectSamples` ColumnRef'd
+// `"value"` to match. #310 collapsed that lowercase-rename Project layer
+// across PromQL / LogQL / chsql, leaving every RangeWindow emitter to
+// expose its value column under the canonical PascalCase alias `Value`
+// (kept in sync via `rangeAggSynthValueColumn` in
+// `internal/logql/range_aggregation.go`).
+//
+// The LogQL adapter's `Lang.ProjectSamples` metric branch was the one
+// site outside the instant-fn / aggregate paths that #310 missed; its
+// ColumnRef stayed wired to the dead lowercase alias, so any LogQL
+// metric query whose plan wraps a RangeWindow (rate / count_over_time /
+// bytes_rate / bytes_over_time) emitted CH SQL that resolved
+// `UNKNOWN_IDENTIFIER: 'value'. Maybe you meant: ['Value']` and returned
+// a 500 on the wire.
+//
+// The test is parser/lowering-free on purpose — it constructs a synthetic
+// `*chplan.RangeWindow` directly so the assertion pins the exact column
+// the wire-wrap ColumnRefs without depending on the upstream LogQL parser
+// or the lowering path that produces the RangeWindow.
+func TestProjectSamples_MetricBranchRefsValueColumn(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelLogs()
+	l := &logql.Lang{Schema: s}
+
+	// Synthetic plan shaped like LogQL's range-aggregation lowering output
+	// (see `lowerRangeAggregation` in `range_aggregation.go`): a RangeWindow
+	// whose ValueColumn is the canonical "Value" emitted at the outer
+	// SELECT site since #310. ProjectSamples doesn't inspect the inner Scan,
+	// so a `nil` Input field would be acceptable too — a synthetic Scan
+	// just keeps the plan structurally valid for any future invariant
+	// check that walks Children().
+	plan := &chplan.RangeWindow{
+		Input:           &chplan.Scan{Table: s.LogsTable},
+		Func:            "count_over_time",
+		Range:           time.Minute,
+		TimestampColumn: s.TimestampColumn,
+		ValueColumn:     "Value",
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: s.ResourceAttributesColumn}},
+	}
+
+	wrapped := l.ProjectSamples(plan, engine.Meta{IsMetric: true})
+
+	proj, ok := wrapped.(*chplan.Project)
+	if !ok {
+		t.Fatalf("ProjectSamples returned %T, want *chplan.Project", wrapped)
+	}
+	if len(proj.Projections) != 4 {
+		t.Fatalf("ProjectSamples returned %d projections, want 4 (MetricName, Attributes, TimeUnix, Value); got %+v",
+			len(proj.Projections), proj.Projections)
+	}
+
+	// The 4th projection (positional Sample.Value slot) must:
+	//   - alias as "Value" (the chclient.Sample scanner reads positionally,
+	//     but the alias is what surfaces in golden SQL — pin it explicitly)
+	//   - reference the canonical column the inner RangeWindow / Aggregate
+	//     emit (post-#310: literal "Value")
+	valueSlot := proj.Projections[3]
+	if valueSlot.Alias != "Value" {
+		t.Errorf("value slot alias: got %q, want %q", valueSlot.Alias, "Value")
+	}
+	colRef, ok := valueSlot.Expr.(*chplan.ColumnRef)
+	if !ok {
+		t.Fatalf("value slot expr: got %T, want *chplan.ColumnRef (a literal "+
+			"or computation here would mean the wire-wrap is reshaping data "+
+			"that should already be wired)", valueSlot.Expr)
+	}
+	// Post-#310: the inner emitter aliases its windowed value as
+	// "Value" (PascalCase canonical). Pre-#310 callers ColumnRef'd
+	// "value" — this assertion is the regression checkpoint.
+	if colRef.Name != "Value" {
+		t.Errorf("value slot ColumnRef.Name: got %q, want %q (post-#310 "+
+			"canonical alias the inner RangeWindow / Aggregate emit at the "+
+			"outer SELECT site; lowercase \"value\" is the dead pre-#310 alias)",
+			colRef.Name, "Value")
+	}
+
+	// Sibling sanity: the Attributes slot must reference the schema's
+	// ResourceAttributesColumn (not a hardcoded literal); pinning this
+	// catches the symmetric "hardcoded constant drifted from schema"
+	// failure mode in the same wire-wrap.
+	attrsSlot := proj.Projections[1]
+	attrsRef, ok := attrsSlot.Expr.(*chplan.ColumnRef)
+	if !ok {
+		t.Fatalf("attributes slot expr: got %T, want *chplan.ColumnRef", attrsSlot.Expr)
+	}
+	if attrsRef.Name != s.ResourceAttributesColumn {
+		t.Errorf("attributes slot ColumnRef.Name: got %q, want %q (schema's ResourceAttributesColumn)",
+			attrsRef.Name, s.ResourceAttributesColumn)
+	}
+}

--- a/internal/logql/range_aggregation.go
+++ b/internal/logql/range_aggregation.go
@@ -43,13 +43,12 @@ func lowerRangeAggregation(e *syntax.RangeAggregationExpr, s schema.Logs, lc low
 		return nil, err
 	}
 
-	const synthValue = "Value"
 	projected := &chplan.Project{
 		Input: inner,
 		Projections: []chplan.Projection{
 			{Expr: &chplan.ColumnRef{Name: s.ResourceAttributesColumn}},
 			{Expr: &chplan.ColumnRef{Name: s.TimestampColumn}},
-			{Expr: value, Alias: synthValue},
+			{Expr: value, Alias: rangeAggSynthValueColumn},
 		},
 	}
 
@@ -64,10 +63,19 @@ func lowerRangeAggregation(e *syntax.RangeAggregationExpr, s schema.Logs, lc low
 		Range:           e.Left.Interval,
 		Offset:          e.Left.Offset,
 		TimestampColumn: s.TimestampColumn,
-		ValueColumn:     synthValue,
+		ValueColumn:     rangeAggSynthValueColumn,
 		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: s.ResourceAttributesColumn}},
 	}, nil
 }
+
+// rangeAggSynthValueColumn is the column name LogQL's range-aggregation
+// lowering synthesises for the per-row metric value (constant 1 for line
+// counts; length(Body) for byte counts). Shared with [Lang.ProjectSamples]
+// so the engine's metric-branch wire-wrap can `chplan.ColumnRef` the same
+// alias the inner RangeWindow / Aggregate emit at their outer SELECT site
+// since #310. Pinning this in one place keeps the two layers from drifting
+// like they did between #310 and the e2e-failures it surfaced.
+const rangeAggSynthValueColumn = "Value"
 
 // rangeValueExpr returns the per-row Value the RangeWindow aggregates.
 // Line-counting ops use constant 1; byte-counting ops use length(Body).


### PR DESCRIPTION
## Summary

Closes the two e2e regressions from #310:
- `TestLokiQueryRangeCountOverTime` — `count_over_time({...}[5m])` over `/loki/api/v1/query_range`
- `TestPromQuerySubqueryBareVector` — `up[1m:30s]` over `/api/v1/query`

## Fix

**LogQL** (`internal/logql/lang.go`): `Lang.ProjectSamples` metric branch referenced literal `"value"`. Post-#310 the RangeWindow emits PascalCase `Value`. Replaced with new package-level constant `rangeAggSynthValueColumn` (promoted from a local in `range_aggregation.go`) so both files share one source of truth.

**PromQL** (`internal/api/prom/handler.go`): matrix branch of `wrapWithSampleProjection` referenced `s.TimestampColumn` (= "TimeUnix"), but the RangeWindow matrix emitter only projects `Attributes`, `anchor_ts`, `Value`. Changed to reference `anchor_ts` directly; the outer Project's `Alias: s.TimestampColumn` renames it back to TimeUnix on the way out. Tempo's `metrics_query_range.go:251` already uses this exact pattern.

## Tests

- `TestProjectSamples_MetricBranchRefsValueColumn` — verified catches the regression by reverting the fix (gets `value` vs want `Value`).
- `TestQueryRange_SubqueryBareVector_ChDB` — verified catches the regression by reverting the fix (gets 502 with the matrix RangeWindow's anchor SQL in the error).
- Full package: 334 untagged pass, 350 chdb-tagged pass (2 pre-existing local-env PREWHERE failures unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>