### PR TITLE
test(api/loki): mutex-guard stubQuerier shared by parallel subtests

### DIFF
--- a/internal/api/loki/conformance_test.go
+++ b/internal/api/loki/conformance_test.go
@@ -779,10 +779,10 @@ func TestConformance_LokiAdmitSerialReleasesSlot(t *testing.T) {
 // doesn't affect prom/tempo because each handler owns its own. Wire a
 // loki handler with no limiter; every request passes.
 //
-// Issued serially because `stubQuerier` mutates `lastSQL`/`lastArgs`
-// without locking — a concurrent goroutine fan-out would trip the
-// race detector on those writes, which is incidental to the property
-// under test (nil-limiter = always-admit).
+// Issued serially: keeps the assertion simple ("n requests, n
+// admits"). `stubQuerier` now mutex-guards lastSQL/lastArgs, so a
+// concurrent fan-out would also be race-clean — but the serial loop
+// gives us a deterministic counter.
 func TestConformance_LokiAdmitIndependentFromOthers(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/loki/detected_fields_test.go
+++ b/internal/api/loki/detected_fields_test.go
@@ -63,11 +63,12 @@ func TestDetectedFields_JSON(t *testing.T) {
 	}
 
 	// SQL sanity: ordering by Timestamp DESC + LIMIT.
-	if !strings.Contains(q.lastSQL, "ORDER BY `Timestamp` DESC") {
-		t.Errorf("missing ORDER BY DESC: %q", q.lastSQL)
+	lastSQL := q.LastSQL()
+	if !strings.Contains(lastSQL, "ORDER BY `Timestamp` DESC") {
+		t.Errorf("missing ORDER BY DESC: %q", lastSQL)
 	}
-	if !strings.Contains(q.lastSQL, "LIMIT 1000") {
-		t.Errorf("missing default LIMIT 1000: %q", q.lastSQL)
+	if !strings.Contains(lastSQL, "LIMIT 1000") {
+		t.Errorf("missing default LIMIT 1000: %q", lastSQL)
 	}
 }
 

--- a/internal/api/loki/handler_test.go
+++ b/internal/api/loki/handler_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -15,7 +16,15 @@ import (
 	"github.com/tsouza/cerberus/internal/schema"
 )
 
+// stubQuerier is a shared in-package test fixture for the loki HTTP
+// handlers. A single stub is sometimes wired into a server that fans a
+// request out across parallel subtests (see TestConformance_LokiLabelValuesWire
+// and TestConformance_LokiSeriesWire), so every field accessed inside a
+// Query* method is guarded by mu. Tests that read lastSQL / lastArgs
+// after a request returns must do so via LastSQL() / LastArgs() so the
+// race detector sees the happens-before edge.
 type stubQuerier struct {
+	mu       sync.Mutex
 	samples  []chclient.Sample
 	err      error
 	lastSQL  string
@@ -41,48 +50,83 @@ type stubQuerier struct {
 }
 
 func (s *stubQuerier) Query(_ context.Context, sql string, args ...any) ([]chclient.Sample, error) {
+	s.mu.Lock()
 	s.lastSQL = sql
 	s.lastArgs = args
-	if s.err != nil {
-		return nil, s.err
+	samples, err := s.samples, s.err
+	s.mu.Unlock()
+	if err != nil {
+		return nil, err
 	}
-	return s.samples, nil
+	return samples, nil
 }
 
 func (s *stubQuerier) QueryIndexStats(_ context.Context, sql string, args ...any) (chclient.IndexStatsRow, error) {
+	s.mu.Lock()
 	s.lastSQL = sql
 	s.lastArgs = args
-	if s.statsErr != nil {
-		return chclient.IndexStatsRow{}, s.statsErr
+	row, err := s.statsRow, s.statsErr
+	s.mu.Unlock()
+	if err != nil {
+		return chclient.IndexStatsRow{}, err
 	}
-	return s.statsRow, nil
+	return row, nil
 }
 
 func (s *stubQuerier) QueryIndexVolume(_ context.Context, sql string, args ...any) ([]chclient.IndexVolumeRow, error) {
+	s.mu.Lock()
 	s.lastSQL = sql
 	s.lastArgs = args
-	if s.volumeErr != nil {
-		return nil, s.volumeErr
+	rows, err := s.volumeRows, s.volumeErr
+	s.mu.Unlock()
+	if err != nil {
+		return nil, err
 	}
-	return s.volumeRows, nil
+	return rows, nil
 }
 
 func (s *stubQuerier) QueryStrings(_ context.Context, sql string, args ...any) ([]string, error) {
+	s.mu.Lock()
 	s.lastSQL = sql
 	s.lastArgs = args
-	if s.stringsErr != nil {
-		return nil, s.stringsErr
+	rows, err := s.stringRows, s.stringsErr
+	s.mu.Unlock()
+	if err != nil {
+		return nil, err
 	}
-	return s.stringRows, nil
+	return rows, nil
 }
 
 func (s *stubQuerier) QueryLabelSets(_ context.Context, sql string, args ...any) ([]map[string]string, error) {
+	s.mu.Lock()
 	s.lastSQL = sql
 	s.lastArgs = args
-	if s.labelSetsErr != nil {
-		return nil, s.labelSetsErr
+	rows, err := s.labelSets, s.labelSetsErr
+	s.mu.Unlock()
+	if err != nil {
+		return nil, err
 	}
-	return s.labelSets, nil
+	return rows, nil
+}
+
+// LastSQL returns the SQL passed to the most recent Query* call. Locked
+// because writers run on HTTP-handler goroutines and readers run on the
+// test goroutine after the request returns; the race detector needs the
+// explicit happens-before that the mutex provides.
+func (s *stubQuerier) LastSQL() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastSQL
+}
+
+// LastArgs returns the positional args of the most recent Query* call.
+// Returns the slice header by value (the underlying backing array is
+// not mutated after a Query* call returns, so callers may iterate it
+// without further locking).
+func (s *stubQuerier) LastArgs() []any {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastArgs
 }
 
 func newServer(q loki.Querier) *httptest.Server {
@@ -241,18 +285,20 @@ func TestQueryRange_PushesStartEndToSQL(t *testing.T) {
 		t.Fatalf("status=%d", resp.StatusCode)
 	}
 
-	if !strings.Contains(q.lastSQL, "`Timestamp` >=") || !strings.Contains(q.lastSQL, "`Timestamp` <=") {
-		t.Fatalf("expected Timestamp BETWEEN predicate in SQL; got: %s", q.lastSQL)
+	lastSQL := q.LastSQL()
+	lastArgs := q.LastArgs()
+	if !strings.Contains(lastSQL, "`Timestamp` >=") || !strings.Contains(lastSQL, "`Timestamp` <=") {
+		t.Fatalf("expected Timestamp BETWEEN predicate in SQL; got: %s", lastSQL)
 	}
 	// The bound is rendered as toDateTime64('YYYY-MM-DD HH:MM:SS.fffffffff', 9)
 	// so both bound strings must appear as positional args.
 	const wantStart = "2026-05-14 12:03:20.000000000"
 	const wantEnd = "2026-05-14 12:05:00.000000000"
-	if !containsArg(q.lastArgs, wantStart) {
-		t.Errorf("expected args to contain start bound %q; got: %#v", wantStart, q.lastArgs)
+	if !containsArg(lastArgs, wantStart) {
+		t.Errorf("expected args to contain start bound %q; got: %#v", wantStart, lastArgs)
 	}
-	if !containsArg(q.lastArgs, wantEnd) {
-		t.Errorf("expected args to contain end bound %q; got: %#v", wantEnd, q.lastArgs)
+	if !containsArg(lastArgs, wantEnd) {
+		t.Errorf("expected args to contain end bound %q; got: %#v", wantEnd, lastArgs)
 	}
 }
 
@@ -280,16 +326,18 @@ func TestQuery_PushesInstantWindowToSQL(t *testing.T) {
 		t.Fatalf("status=%d", resp.StatusCode)
 	}
 
-	if !strings.Contains(q.lastSQL, "`Timestamp` >=") || !strings.Contains(q.lastSQL, "`Timestamp` <=") {
-		t.Fatalf("expected Timestamp BETWEEN predicate in SQL; got: %s", q.lastSQL)
+	lastSQL := q.LastSQL()
+	lastArgs := q.LastArgs()
+	if !strings.Contains(lastSQL, "`Timestamp` >=") || !strings.Contains(lastSQL, "`Timestamp` <=") {
+		t.Fatalf("expected Timestamp BETWEEN predicate in SQL; got: %s", lastSQL)
 	}
 	const wantStart = "2026-05-14 12:00:00.000000000"
 	const wantEnd = "2026-05-14 12:05:00.000000000"
-	if !containsArg(q.lastArgs, wantStart) {
-		t.Errorf("expected args to contain start bound %q; got: %#v", wantStart, q.lastArgs)
+	if !containsArg(lastArgs, wantStart) {
+		t.Errorf("expected args to contain start bound %q; got: %#v", wantStart, lastArgs)
 	}
-	if !containsArg(q.lastArgs, wantEnd) {
-		t.Errorf("expected args to contain end bound %q; got: %#v", wantEnd, q.lastArgs)
+	if !containsArg(lastArgs, wantEnd) {
+		t.Errorf("expected args to contain end bound %q; got: %#v", wantEnd, lastArgs)
 	}
 }
 

--- a/internal/api/loki/index_stats_test.go
+++ b/internal/api/loki/index_stats_test.go
@@ -48,14 +48,15 @@ func TestIndexStats_HappyPath(t *testing.T) {
 	// SQL sanity: the matcher predicate must end up in the rendered SQL,
 	// going through the Builder (no fmt.Sprintf string concatenation),
 	// and the time bounds must be present as DateTime64 literals.
-	if !strings.Contains(q.lastSQL, "uniqExact(`ResourceAttributes`)") {
-		t.Errorf("missing uniqExact in SQL: %q", q.lastSQL)
+	lastSQL := q.LastSQL()
+	if !strings.Contains(lastSQL, "uniqExact(`ResourceAttributes`)") {
+		t.Errorf("missing uniqExact in SQL: %q", lastSQL)
 	}
-	if !strings.Contains(q.lastSQL, "sum(length(`Body`))") {
-		t.Errorf("missing bytes agg in SQL: %q", q.lastSQL)
+	if !strings.Contains(lastSQL, "sum(length(`Body`))") {
+		t.Errorf("missing bytes agg in SQL: %q", lastSQL)
 	}
-	if !strings.Contains(q.lastSQL, "toDateTime64(") {
-		t.Errorf("missing time bounds in SQL: %q", q.lastSQL)
+	if !strings.Contains(lastSQL, "toDateTime64(") {
+		t.Errorf("missing time bounds in SQL: %q", lastSQL)
 	}
 }
 

--- a/internal/api/loki/index_volume_test.go
+++ b/internal/api/loki/index_volume_test.go
@@ -59,17 +59,18 @@ func TestIndexVolume_HappyPath(t *testing.T) {
 	// SQL sanity: GROUP BY + ORDER BY bytes DESC + LIMIT must all be
 	// present; bytes column aggregates via length(Body); labels grouping
 	// uses the full ResourceAttributes map when targetLabels is absent.
-	if !strings.Contains(q.lastSQL, "GROUP BY") {
-		t.Errorf("missing GROUP BY: %q", q.lastSQL)
+	lastSQL := q.LastSQL()
+	if !strings.Contains(lastSQL, "GROUP BY") {
+		t.Errorf("missing GROUP BY: %q", lastSQL)
 	}
-	if !strings.Contains(q.lastSQL, "ORDER BY `bytes` DESC") {
-		t.Errorf("missing ORDER BY bytes DESC: %q", q.lastSQL)
+	if !strings.Contains(lastSQL, "ORDER BY `bytes` DESC") {
+		t.Errorf("missing ORDER BY bytes DESC: %q", lastSQL)
 	}
-	if !strings.Contains(q.lastSQL, "LIMIT 100") {
-		t.Errorf("default limit absent: %q", q.lastSQL)
+	if !strings.Contains(lastSQL, "LIMIT 100") {
+		t.Errorf("default limit absent: %q", lastSQL)
 	}
-	if !strings.Contains(q.lastSQL, "`ResourceAttributes` AS `labels`") {
-		t.Errorf("default group key should be full RA map: %q", q.lastSQL)
+	if !strings.Contains(lastSQL, "`ResourceAttributes` AS `labels`") {
+		t.Errorf("default group key should be full RA map: %q", lastSQL)
 	}
 }
 
@@ -92,15 +93,17 @@ func TestIndexVolume_TargetLabels(t *testing.T) {
 		t.Fatalf("status=%d", resp.StatusCode)
 	}
 
-	if !strings.Contains(q.lastSQL, "mapFilter((k, v) -> k IN (") {
-		t.Errorf("missing mapFilter for targetLabels: %q", q.lastSQL)
+	lastSQL := q.LastSQL()
+	lastArgs := q.LastArgs()
+	if !strings.Contains(lastSQL, "mapFilter((k, v) -> k IN (") {
+		t.Errorf("missing mapFilter for targetLabels: %q", lastSQL)
 	}
 	// Args carry the target-label keys (sorted): env, job, plus the
 	// original "job" matcher value pair (job, api) ahead of those. The
 	// exact positions track the SQL stream — we just confirm the keys
 	// landed in the slice.
 	want := map[string]bool{"job": false, "env": false, "api": false}
-	for _, a := range q.lastArgs {
+	for _, a := range lastArgs {
 		if s, ok := a.(string); ok {
 			if _, present := want[s]; present {
 				want[s] = true
@@ -109,7 +112,7 @@ func TestIndexVolume_TargetLabels(t *testing.T) {
 	}
 	for k, seen := range want {
 		if !seen {
-			t.Errorf("expected arg %q not bound; args=%v", k, q.lastArgs)
+			t.Errorf("expected arg %q not bound; args=%v", k, lastArgs)
 		}
 	}
 }
@@ -132,8 +135,9 @@ func TestIndexVolume_Limit(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status=%d", resp.StatusCode)
 	}
-	if !strings.Contains(q.lastSQL, "LIMIT 25") {
-		t.Errorf("expected LIMIT 25 in SQL: %q", q.lastSQL)
+	lastSQL := q.LastSQL()
+	if !strings.Contains(lastSQL, "LIMIT 25") {
+		t.Errorf("expected LIMIT 25 in SQL: %q", lastSQL)
 	}
 
 	// bad input

--- a/internal/api/loki/label_values_test.go
+++ b/internal/api/loki/label_values_test.go
@@ -44,21 +44,23 @@ func TestLabelValues_HappyPath(t *testing.T) {
 
 	// SQL sanity: the map-access form is present and uses positional
 	// `?` for the label name (never spliced into the SQL).
-	if !strings.Contains(q.lastSQL, "`ResourceAttributes`[?]") {
-		t.Errorf("missing map-access in SQL: %q", q.lastSQL)
+	lastSQL := q.LastSQL()
+	lastArgs := q.LastArgs()
+	if !strings.Contains(lastSQL, "`ResourceAttributes`[?]") {
+		t.Errorf("missing map-access in SQL: %q", lastSQL)
 	}
-	if strings.Contains(q.lastSQL, "'job'") {
-		t.Errorf("label name leaked into SQL: %q", q.lastSQL)
+	if strings.Contains(lastSQL, "'job'") {
+		t.Errorf("label name leaked into SQL: %q", lastSQL)
 	}
 	// And it must show up as an arg.
 	foundJob := false
-	for _, a := range q.lastArgs {
+	for _, a := range lastArgs {
 		if s, ok := a.(string); ok && s == "job" {
 			foundJob = true
 		}
 	}
 	if !foundJob {
-		t.Errorf("label name not in args: %v", q.lastArgs)
+		t.Errorf("label name not in args: %v", lastArgs)
 	}
 }
 
@@ -82,8 +84,9 @@ func TestLabelValues_Selector(t *testing.T) {
 		t.Fatalf("status=%d", resp.StatusCode)
 	}
 	// Selector binds `job` as a key + `api` as a value.
+	lastArgs := q.LastArgs()
 	hasJob, hasAPI := false, false
-	for _, a := range q.lastArgs {
+	for _, a := range lastArgs {
 		if s, ok := a.(string); ok {
 			if s == "job" {
 				hasJob = true
@@ -94,7 +97,7 @@ func TestLabelValues_Selector(t *testing.T) {
 		}
 	}
 	if !hasJob || !hasAPI {
-		t.Errorf("missing selector args (job=%v, api=%v): %v", hasJob, hasAPI, q.lastArgs)
+		t.Errorf("missing selector args (job=%v, api=%v): %v", hasJob, hasAPI, lastArgs)
 	}
 }
 

--- a/internal/api/loki/labels_test.go
+++ b/internal/api/loki/labels_test.go
@@ -48,11 +48,12 @@ func TestLabels_HappyPath(t *testing.T) {
 	}
 
 	// SQL sanity: arrayJoin(mapKeys(...)) must be present.
-	if !strings.Contains(q.lastSQL, "arrayJoin(mapKeys(`ResourceAttributes`))") {
-		t.Errorf("missing arrayJoin(mapKeys()) in SQL: %q", q.lastSQL)
+	lastSQL := q.LastSQL()
+	if !strings.Contains(lastSQL, "arrayJoin(mapKeys(`ResourceAttributes`))") {
+		t.Errorf("missing arrayJoin(mapKeys()) in SQL: %q", lastSQL)
 	}
-	if !strings.Contains(q.lastSQL, "toDateTime64(") {
-		t.Errorf("missing time bounds in SQL: %q", q.lastSQL)
+	if !strings.Contains(lastSQL, "toDateTime64(") {
+		t.Errorf("missing time bounds in SQL: %q", lastSQL)
 	}
 }
 

--- a/internal/api/loki/series_test.go
+++ b/internal/api/loki/series_test.go
@@ -48,11 +48,12 @@ func TestSeries_HappyPath(t *testing.T) {
 	}
 
 	// SQL sanity: GROUP BY labels + two predicate groups OR'd.
-	if !strings.Contains(q.lastSQL, "GROUP BY") {
-		t.Errorf("missing GROUP BY in SQL: %q", q.lastSQL)
+	lastSQL := q.LastSQL()
+	if !strings.Contains(lastSQL, "GROUP BY") {
+		t.Errorf("missing GROUP BY in SQL: %q", lastSQL)
 	}
-	if !strings.Contains(q.lastSQL, " OR ") {
-		t.Errorf("missing OR between selectors in SQL: %q", q.lastSQL)
+	if !strings.Contains(lastSQL, " OR ") {
+		t.Errorf("missing OR between selectors in SQL: %q", lastSQL)
 	}
 }
 
@@ -74,8 +75,9 @@ func TestSeries_NoMatch(t *testing.T) {
 	}
 	// SQL must not contain " OR " (no selector groups) but must still
 	// have a GROUP BY.
-	if !strings.Contains(q.lastSQL, "GROUP BY") {
-		t.Errorf("missing GROUP BY: %q", q.lastSQL)
+	lastSQL := q.LastSQL()
+	if !strings.Contains(lastSQL, "GROUP BY") {
+		t.Errorf("missing GROUP BY: %q", lastSQL)
 	}
 }
 

--- a/internal/api/loki/tail_test.go
+++ b/internal/api/loki/tail_test.go
@@ -60,19 +60,31 @@ func (s *tailStubQuerier) Query(_ context.Context, sql string, args ...any) ([]c
 	return out, nil
 }
 
+// The remaining Querier methods are not exercised by /tail itself, but
+// the package shares this stub across other tests via the loki.Querier
+// interface. Lock every accessor so future test wiring that fans these
+// out across parallel goroutines is race-clean by construction.
 func (s *tailStubQuerier) QueryIndexStats(_ context.Context, _ string, _ ...any) (chclient.IndexStatsRow, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.statsRow, s.statsErr
 }
 
 func (s *tailStubQuerier) QueryIndexVolume(_ context.Context, _ string, _ ...any) ([]chclient.IndexVolumeRow, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.volumeRows, s.volumeErr
 }
 
 func (s *tailStubQuerier) QueryStrings(_ context.Context, _ string, _ ...any) ([]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.stringRows, s.stringsErr
 }
 
 func (s *tailStubQuerier) QueryLabelSets(_ context.Context, _ string, _ ...any) ([]map[string]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.labelSets, s.labelSetsErr
 }
 


### PR DESCRIPTION
## Summary

Closes pre-existing `-race` intermittent in Loki API tests (task #75). Test-fixture-only fix; production code (`internal/api/loki/tail.go`) was already correct.

## Root cause

`TestConformance_LokiLabelValuesWire` and `TestConformance_LokiSeriesWire` share ONE `stubQuerier` across parallel subtests. Each subtest fires an HTTP request that races on `s.lastSQL = sql; s.lastArgs = args` (writer-writer race in the test fixture). Under `-race`, Go marks all parallel siblings failed once any race fires — so the `TestTail_*` failures were cascade fallout. With `-run Tail` in isolation the suite was already clean.

## Fix

- Added `sync.Mutex` to `stubQuerier`, locked all 5 `Query*` writers.
- Added `LastSQL()` / `LastArgs()` accessors.
- Mutex-covered remaining `tailStubQuerier` getters.
- Converted 55 direct `q.lastSQL` / `q.lastArgs` reads across 6 `*_test.go` files to use accessors.

## Test plan

- [x] `go test -race -count=50 ./internal/api/loki/... -run Tail` → ok, exit 0 (101s)
- [x] Full package `go test -race -count=10 ./internal/api/loki/` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>