### PR TITLE
feat(promql): subquery body may be a BinaryExpr

### DIFF
--- a/internal/promql/subquery.go
+++ b/internal/promql/subquery.go
@@ -53,6 +53,8 @@ func lowerSubquery(e *parser.SubqueryExpr, s schema.Metrics, ctx lowerCtx) (chpl
 		return lowerSubquery(&inner2, s, ctx)
 	case *parser.AggregateExpr:
 		return lowerSubqueryOverAggregate(e, inner, step, s, ctx)
+	case *parser.BinaryExpr:
+		return lowerSubqueryOverBinary(e, inner, step, s, ctx)
 	case *parser.SubqueryExpr:
 		return nil, fmt.Errorf("promql: nested subqueries are not yet supported (deferred to RC3)")
 	}
@@ -120,6 +122,57 @@ func lowerSubqueryOverCall(
 		Input:           inner,
 		Func:            call.Func.Name,
 		Range:           ms.Range,
+		OuterRange:      sub.Range,
+		Step:            step,
+		End:             anchor.End,
+		Offset:          anchor.Offset,
+		TimestampColumn: s.TimestampColumn,
+		ValueColumn:     s.ValueColumn,
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}},
+	}, nil
+}
+
+// lowerSubqueryOverBinary — `(<vec> op <scalar>)[range:step]` /
+// `(<vec> op <vec>)[range:step]` lowering. The inner BinaryExpr is
+// lowered in range-vector context so the LWR collapse is suppressed
+// and every in-window sample reaches the wrapping matrix RangeWindow.
+// The wrapping RangeWindow uses `Identity=true` — same shape as the
+// bare-vector subquery case — to emit the "last value in window" per
+// anchor across `[End - sub.Range, End]` spaced by `step`. Subquery
+// `@`/`offset` modifiers thread onto the wrapper via subqueryAnchor.
+//
+// PromQL evaluates `(<expr>)[range:step]` by re-evaluating `<expr>`
+// at each anchor; the BinaryExpr's per-sample `(Value op scalar)` /
+// `(Value_L op Value_R)` rewrite or comparison-Filter drop is applied
+// to every sample inside the window, and the wrapper picks the most
+// recent one. Comparison ops without `bool` modifier still resolve to
+// a Filter on the un-projected value, so the matrix RangeWindow sees
+// only samples that satisfied the predicate — matching Prom's "drop
+// non-matching samples then take the latest" semantics for
+// `(up > 0.5)[5m:1m]`.
+func lowerSubqueryOverBinary(
+	sub *parser.SubqueryExpr,
+	b *parser.BinaryExpr,
+	step time.Duration,
+	s schema.Metrics,
+	ctx lowerCtx,
+) (chplan.Node, error) {
+	rangeCtx := ctx
+	rangeCtx.inRangeVector = true
+	inner, err := lowerBinary(b, s, rangeCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	anchor, err := subqueryAnchor(sub, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &chplan.RangeWindow{
+		Input:           inner,
+		Identity:        true,
+		Range:           step, // per-anchor lookback = subquery step
 		OuterRange:      sub.Range,
 		Step:            step,
 		End:             anchor.End,

--- a/test/spec/promql/subquery_over_binexpr.txtar
+++ b/test/spec/promql/subquery_over_binexpr.txtar
@@ -1,0 +1,30 @@
+-- query.promql --
+max_over_time((up - 0.5 > 0)[1m:30s])
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api'), toDateTime64('2025-12-31 23:59:00', 9), 1.0),
+    ('up', map('job', 'api'), toDateTime64('2025-12-31 23:59:30', 9), 1.0),
+    ('up', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 1.0);
+-- expected_rows --
+[
+  [{"job": "api"}, 0.5]
+]
+-- args --
+[0] float64 = 0.5
+[1] string = "up"
+[2] float64 = 0
+-- chplan --
+RangeWindow func=max_over_time range=1m0s step=0s ts=anchor_ts value=Value groupBy=[Attributes]
+  RangeWindow func= range=30s step=30s outerRange=1m0s identity=true ts=TimeUnix value=Value groupBy=[Attributes]
+    Filter predicate=(Value > 0)
+      Project [MetricName, Attributes, TimeUnix, (Value - 0.5) AS Value]
+        Filter predicate=(MetricName = "up")
+          Scan(otel_metrics_gauge)
+-- sql --
+SELECT `Attributes`, if(length(window_vals) > 0, arrayMax(window_vals), nan) AS `Value` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) >= now64(9) - toIntervalNanosecond(60000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`anchor_ts`, `Value`))) AS `series_array` FROM (SELECT `Attributes`, `anchor_ts`, if(length(window_vals) > 0, window_vals[length(window_vals)], nan) AS `Value` FROM (SELECT `Attributes`, `anchor_ts`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, `anchor_ts`, arrayFilter(p -> tupleElement(p, 1) >= anchor_ts - toIntervalNanosecond(30000000000) AND tupleElement(p, 1) <= anchor_ts, series_array) AS `window_pairs` FROM (SELECT `Attributes`, `series_array`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 30000000000), range(0, 3))) AS `anchor_ts` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM (SELECT `MetricName`, `Attributes`, `TimeUnix`, (`Value` - ?) AS `Value` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))) WHERE (`Value` > ?)) GROUP BY `Attributes`)))) WHERE length(`window_vals`) >= 1) GROUP BY `Attributes`))) WHERE length(`window_vals`) >= 1


### PR DESCRIPTION
## Summary

Closes the 1 prometheus/compliance case `subquery over *parser.BinaryExpr is not yet supported`. Reproducer: `max_over_time((up - 0.5 > 0)[1m:30s])`.

## Implementation

`lowerSubquery`'s type switch already handles `VectorSelector` / `Call` / `ParenExpr` / `AggregateExpr` / nested `SubqueryExpr`. Added `*parser.BinaryExpr` via new `lowerSubqueryOverBinary`:

- Lower the BinaryExpr via existing `lowerBinary` with `inRangeVector=true` (LWR collapse suppressed so all in-window samples reach the wrapper).
- Wrap with the same `Identity=true` matrix RangeWindow used by `lowerSubqueryOverVectorSelector`.

Scalar-vector arithmetic produces a `Project` replacing Value; comparison ops without `bool` produce a `Filter` on Value — both compatible with the matrix RangeWindow's `(TimeUnix, Value)` per-series shape.

## chplan tree (sanity check for `max_over_time((up - 0.5 > 0)[1m:30s])`)

```
RangeWindow func=max_over_time range=1m0s step=0s
  RangeWindow identity=true range=30s step=30s outerRange=1m0s
    Filter (Value > 0)
      Project [MetricName, Attributes, TimeUnix, (Value - 0.5) AS Value]
        Filter (MetricName = "up")
          Scan(otel_metrics_gauge)
```

## Test plan

- [x] `go test ./internal/promql/ ./internal/chsql/` — 859 pass
- [x] `go test -tags chdb ./test/spec/promql/ -run subquery` — 17 pass incl. new fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>