### PR TITLE
fix(chsql): vector-vector ^ emits pow() not bitwise XOR

### DIFF
--- a/internal/chsql/emit_test.go
+++ b/internal/chsql/emit_test.go
@@ -527,6 +527,36 @@ var plans = map[string]chplan.Node{
 		ValueColumn:      "Value",
 	},
 
+	// vector_join_pow_on: VectorJoin with OpPow over an `on(...)` match
+	// — pins that the emitter renders `pow(L.Value, R.Value)` rather
+	// than `(L.Value ^ R.Value)`. CH's `^` is bitwise XOR (integer-
+	// only), so the raw-op shape would yield a CH 502 on Float64
+	// columns (the compat-lane failure that motivated this fix).
+	"vector_join_pow_on": &chplan.VectorJoin{
+		Left:             &chplan.Scan{Table: "otel_metrics_gauge"},
+		Right:            &chplan.Scan{Table: "otel_metrics_sum"},
+		Op:               chplan.OpPow,
+		Match:            chplan.VectorMatch{Labels: []string{"job"}, On: true},
+		MetricNameColumn: "MetricName",
+		AttributesColumn: "Attributes",
+		TimestampColumn:  "TimeUnix",
+		ValueColumn:      "Value",
+	},
+	// vector_join_pow_group_left: VectorJoin with OpPow + group_left
+	// — the second compat-lane failure shape.
+	"vector_join_pow_group_left": &chplan.VectorJoin{
+		Left:             &chplan.Scan{Table: "otel_metrics_gauge"},
+		Right:            &chplan.Scan{Table: "otel_metrics_sum"},
+		Op:               chplan.OpPow,
+		Match:            chplan.VectorMatch{Labels: []string{"instance", "type"}, On: true},
+		Card:             chplan.CardManyToOne,
+		Include:          []string{"job"},
+		MetricNameColumn: "MetricName",
+		AttributesColumn: "Attributes",
+		TimestampColumn:  "TimeUnix",
+		ValueColumn:      "Value",
+	},
+
 	// func_call_zero_args: CH function with no arguments — `now()`.
 	"project_func_call_zero_args": &chplan.Project{
 		Input: &chplan.Scan{Table: "otel_metrics_gauge"},

--- a/internal/chsql/vector_join.go
+++ b/internal/chsql/vector_join.go
@@ -347,6 +347,13 @@ func writeOutputAttributes(b *Builder, j *chplan.VectorJoin) {
 // vectorJoinValueExprFrag returns a Frag for the joined value
 // expression. The default shape is `(L.<val> <op> R.<val>) AS <val>`.
 //
+// PromQL `^` (exponentiation) is special-cased: in ClickHouse the `^`
+// token is bitwise-XOR (integer-only), not exponentiation, so emitting
+// it directly against Float64 columns yields a CH ILLEGAL_TYPE_OF_ARGUMENT
+// error (HTTP 502 at the compat lane). PromQL semantics call for
+// floating-point exponentiation, which CH spells `pow(x, y)` — matching
+// the scalar `exprBinary` path's special case for OpPow.
+//
 // When ReturnBool is set on a comparison op (PromQL `lhs > bool rhs`),
 // the binary result is wrapped with `toFloat64(...)` so every matched
 // pair emits 1.0 or 0.0 instead of being dropped by the comparison —
@@ -354,7 +361,12 @@ func writeOutputAttributes(b *Builder, j *chplan.VectorJoin) {
 func vectorJoinValueExprFrag(j *chplan.VectorJoin) Frag {
 	left := qualColFrag("L", j.ValueColumn)
 	right := qualColFrag("R", j.ValueColumn)
-	inner := Paren(binOp(string(j.Op), left, right))
+	var inner Frag
+	if j.Op == chplan.OpPow {
+		inner = Call("pow", left, right)
+	} else {
+		inner = Paren(binOp(string(j.Op), left, right))
+	}
 	if j.ReturnBool {
 		inner = Call("toFloat64", inner)
 	}

--- a/test/spec/chsql/vector_join_pow_group_left.txtar
+++ b/test/spec/chsql/vector_join_pow_group_left.txtar
@@ -1,0 +1,15 @@
+-- sql --
+SELECT L.`MetricName`, mapConcat(L.`Attributes`, mapFilter((k, v) -> k IN (?), R.`Attributes`)) AS `Attributes`, L.`TimeUnix`, pow(L.`Value`, R.`Value`) AS `Value` FROM (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT `MetricName` AS `_join_MetricName`, `Attributes` AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value` FROM (SELECT * FROM `otel_metrics_gauge`) GROUP BY `MetricName`, `Attributes`)) AS L INNER JOIN (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT * FROM `otel_metrics_sum`) GROUP BY mapFilter((k, v) -> k IN (?, ?), `Attributes`))) AS R ON L.`Attributes`[?] = R.`Attributes`[?] AND L.`Attributes`[?] = R.`Attributes`[?]
+-- args --
+[0] string = "job"
+[1] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[2] string = "instance"
+[3] string = "type"
+[4] string = "instance"
+[5] string = "instance"
+[6] string = "type"
+[7] string = "type"
+-- chplan --
+VectorJoin op=^ match=on(instance,type) card=many-to-one include=[job]
+  Scan(otel_metrics_gauge)
+  Scan(otel_metrics_sum)

--- a/test/spec/chsql/vector_join_pow_on.txtar
+++ b/test/spec/chsql/vector_join_pow_on.txtar
@@ -1,0 +1,13 @@
+-- sql --
+SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, pow(L.`Value`, R.`Value`) AS `Value` FROM (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT * FROM `otel_metrics_gauge`) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`))) AS L INNER JOIN (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT * FROM `otel_metrics_sum`) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`))) AS R ON L.`Attributes`[?] = R.`Attributes`[?]
+-- args --
+[0] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[1] string = "job"
+[2] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[3] string = "job"
+[4] string = "job"
+[5] string = "job"
+-- chplan --
+VectorJoin op=^ match=on(job) card=one-to-one
+  Scan(otel_metrics_gauge)
+  Scan(otel_metrics_sum)

--- a/test/spec/promql/power_op_basic.txtar
+++ b/test/spec/promql/power_op_basic.txtar
@@ -1,0 +1,31 @@
+-- query.promql --
+up ^ 2
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, pow(`Value`, ?) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
+-- args --
+[0] float64 = 2
+[1] string = "up"
+[2] string = "2026-01-01 00:00:01.000000000"
+[3] int64 = 9
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] int64 = 300000000000
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 3.0);
+-- expected_rows --
+[
+  ["up", {"job": "api"}, "2026-01-01T00:00:00Z", 9.0]
+]
+-- chplan --
+Project [MetricName, Attributes, TimeUnix, (Value ^ 2) AS Value]
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)

--- a/test/spec/promql/power_op_vv.txtar
+++ b/test/spec/promql/power_op_vv.txtar
@@ -1,0 +1,46 @@
+-- query.promql --
+up ^ on(instance) up
+-- sql --
+SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, pow(L.`Value`, R.`Value`) AS `Value` FROM (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`))) AS L INNER JOIN (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`))) AS R ON L.`Attributes`[?] = R.`Attributes`[?]
+-- args --
+[0] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[1] string = "up"
+[2] string = "2026-01-01 00:00:01.000000000"
+[3] int64 = 9
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] int64 = 300000000000
+[7] string = "instance"
+[8] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[9] string = "up"
+[10] string = "2026-01-01 00:00:01.000000000"
+[11] int64 = 9
+[12] string = "2026-01-01 00:00:01.000000000"
+[13] int64 = 9
+[14] int64 = 300000000000
+[15] string = "instance"
+[16] string = "instance"
+[17] string = "instance"
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('instance', 'host-a'), toDateTime64('2026-01-01 00:00:00', 9), 4.0);
+-- expected_rows --
+[
+  ["up", {"instance": "host-a"}, "2026-01-01T00:00:00Z", 256.0]
+]
+-- chplan --
+VectorJoin op=^ match=on(instance) card=one-to-one
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)


### PR DESCRIPTION
## Summary

Closes 2 prometheus/compliance 502 cases involving `^` on vector-vector with `on(...)` / `group_left(...)`:
- `demo_memory_usage_bytes ^ on(instance, job, type) demo_memory_usage_bytes`
- `sum by(instance, type) (demo_memory_usage_bytes) ^ on(instance, type) group_left(job) demo_memory_usage_bytes`

## Bug

`internal/chsql/vector_join.go:357` rendered V-V `^` via `Paren(binOp(string(OpPow), ...))` → `(L.Value ^ R.Value)`. CH's `^` is bitwise XOR (integer-only) → `ILLEGAL_TYPE_OF_ARGUMENT` on Float64 → HTTP 502.

The scalar path in `exprBinary` already special-cased `OpPow` to emit `pow(L, R)`; the vector-join path missed it.

## Fix

Special-case `chplan.OpPow` in `vectorJoinValueExprFrag` to emit `Call("pow", left, right)` via typed Frag. Audited all other `string(.Op)` emit sites — `exprNestedArrayExists` and `exprBinary` (the latter already correct).

## Test plan

- [x] `go test ./internal/promql/ ./internal/chsql/` — pass
- [x] `go test -tags chdb ./test/spec/promql/ -run "power"` — power_op_basic (3^2=9), power_op_vv (4^4=256) both pass
- [x] 4 new fixtures: 2 chsql goldens + 2 promql chDB roundtrips

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>