### PR TITLE
feat(promql): lower absent() via OneRow + per-series existence check

### DIFF
--- a/internal/promql/absent.go
+++ b/internal/promql/absent.go
@@ -1,0 +1,204 @@
+package promql
+
+import (
+	"fmt"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// lowerAbsent implements PromQL `absent(v instant-vector)`. The function
+// returns:
+//
+//   - an empty vector when `v` has any sample matching its label matchers,
+//     and
+//   - a single 1-row vector whose Value is 1.0 and whose label set is the
+//     set of equality matchers explicitly named on `v` (mirroring Prom's
+//     `createLabelsForAbsentFunction` in promql/functions.go), when `v`
+//     has no matching samples.
+//
+// The chplan tree:
+//
+//	Project [synthesised Sample columns]
+//	  Filter predicate=(_cerb_n = 0)
+//	    Aggregate groupBy=[] funcs=[count() AS _cerb_n]   (DropEmptyOnNoGroup=false)
+//	      Filter? predicate=<v's matchers>                (omitted when no
+//	                                                       matchers — bare
+//	                                                       Scan)
+//	        Scan(<table>)
+//
+// The inner Aggregate sets `DropEmptyOnNoGroup=false` deliberately:
+// CH's "1-row-per-aggregate-only-query" semantics emit a single
+// `count = 0` row even when the filtered scan is empty, which is
+// exactly the signal the outer Filter / Project chain needs to flip
+// from "no result" to "synthesised absent row".
+//
+// Compared to Prom's `funcAbsent`, this lowering checks for the
+// existence of *any* sample matching `v`'s matchers in the configured
+// metric table — it does not (yet) apply the same instant-vector
+// staleness window the bare-selector LWR wrap uses. That tightening is
+// safe to layer on later: for the compatibility-harness fixtures and
+// the OTel-CH gauge tables, "metric has zero rows in the table" is the
+// signal that matters.
+func lowerAbsent(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	if len(c.Args) != 1 {
+		return nil, fmt.Errorf("promql: absent() expects 1 argument, got %d", len(c.Args))
+	}
+	// Unwrap `absent((v))` — the parser surfaces redundant parens as
+	// ParenExpr nodes that the bare-selector check below would
+	// otherwise reject.
+	arg := unwrapParens(c.Args[0])
+	vs, ok := arg.(*parser.VectorSelector)
+	if !ok {
+		return nil, fmt.Errorf("promql: absent() argument must be an instant-vector selector, got %T", c.Args[0])
+	}
+
+	// Build the inner filtered Scan via the standard selector
+	// lowering with the range-vector flag set: that path skips the
+	// LWR wrap and only applies the matchers (plus the @/offset time
+	// bound when present). The wrapping Aggregate doesn't need a
+	// per-series collapse — it just counts rows.
+	//
+	// Strip the modifier so the inner Filter doesn't carry a
+	// duplicate time-bound predicate; absent() doesn't currently
+	// honour the @/offset modifiers (parity with the surrounding
+	// instant-vector callsites that the count-only check makes
+	// semantically equivalent until LWR is plumbed in).
+	vsNoMod := *vs
+	vsNoMod.Timestamp = nil
+	vsNoMod.OriginalOffset = 0
+	vsNoMod.Offset = 0
+	vsNoMod.StartOrEnd = 0
+	rangeCtx := ctx
+	rangeCtx.inRangeVector = true
+	inner, err := lowerVectorSelector(&vsNoMod, s, rangeCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	const cntAlias = "_cerb_n"
+	agg := &chplan.Aggregate{
+		Input:   inner,
+		GroupBy: nil,
+		AggFuncs: []chplan.AggFunc{{
+			Name:  "count",
+			Args:  nil,
+			Alias: cntAlias,
+		}},
+		// FALSE so an empty filtered scan still produces the 1-row
+		// `count = 0` we need to drive the no-series branch. With TRUE
+		// the emitter would wrap the aggregate in `WHERE _cerb_n > 0`,
+		// stripping the no-series row before the outer Filter ever
+		// sees it.
+		DropEmptyOnNoGroup: false,
+	}
+
+	onlyEmpty := &chplan.Filter{
+		Input: agg,
+		Predicate: &chplan.Binary{
+			Op:    chplan.OpEq,
+			Left:  &chplan.ColumnRef{Name: cntAlias},
+			Right: &chplan.LitInt{V: 0},
+		},
+	}
+
+	// Synthesise the canonical Sample-row contract:
+	//   MetricName=''                                  (absent drops __name__)
+	//   Attributes=map(<eq-matchers from v>)           (Prom funcAbsent label rule)
+	//   TimeUnix=<eval anchor>                         (now64(9) or literal eval ts)
+	//   Value=1.0                                      (Prom's spec value)
+	timeExpr := anchorBaseExpr(evalAnchor{End: ctx.end.UTC()})
+	if ctx.end.IsZero() {
+		timeExpr = anchorBaseExpr(evalAnchor{})
+	}
+	return &chplan.Project{
+		Input: onlyEmpty,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.LitString{V: ""}, Alias: s.MetricNameColumn},
+			{Expr: absentAttrsMap(vs.LabelMatchers), Alias: s.AttributesColumn},
+			{Expr: timeExpr, Alias: s.TimestampColumn},
+			{Expr: &chplan.LitFloat{V: 1.0}, Alias: s.ValueColumn},
+		},
+	}, nil
+}
+
+// absentAttrsMap renders the absent-output label set as a CH
+// Map(String, String) literal, mirroring Prom's
+// `createLabelsForAbsentFunction` rules:
+//
+//   - skip `__name__` (absent always drops the metric name);
+//   - include only equality matchers (regex / not-equal don't pin a
+//     unique label value, so Prom skips them);
+//   - duplicate-name matchers (`up{job="a", job="b"}`) drop the
+//     label entirely — the `has` map tracks the first name seen and
+//     a second occurrence triggers a delete.
+//
+// Returns the canonical empty-map literal (`CAST(map(), 'Map(String,
+// String)')`) when no eligible equality matchers exist, matching the
+// shape used by time() / vector() / aggregations-without-by.
+func absentAttrsMap(matchers []*labels.Matcher) chplan.Expr {
+	type kv struct {
+		k, v string
+	}
+	has := make(map[string]bool, len(matchers))
+	order := make([]string, 0, len(matchers))
+	values := make(map[string]string, len(matchers))
+	for _, m := range matchers {
+		if m.Name == model.MetricNameLabel {
+			continue
+		}
+		if m.Type != labels.MatchEqual {
+			// Non-equality matchers don't pin a unique value; drop
+			// the label so the output reflects "only the explicitly-
+			// set equality matchers" rule.
+			if has[m.Name] {
+				delete(values, m.Name)
+			}
+			continue
+		}
+		if has[m.Name] {
+			// Duplicate name with equality matchers — Prom drops the
+			// label entirely. (`absent(x{job="a",job="b"})` returns
+			// `{} 1`.)
+			delete(values, m.Name)
+			continue
+		}
+		has[m.Name] = true
+		values[m.Name] = m.Value
+		order = append(order, m.Name)
+	}
+	pairs := make([]kv, 0, len(order))
+	for _, name := range order {
+		v, ok := values[name]
+		if !ok {
+			continue
+		}
+		pairs = append(pairs, kv{k: name, v: v})
+	}
+	if len(pairs) == 0 {
+		return emptyAttrsMap()
+	}
+	args := make([]chplan.Expr, 0, len(pairs)*2)
+	for _, p := range pairs {
+		args = append(args, &chplan.LitString{V: p.k}, &chplan.LitString{V: p.v})
+	}
+	return &chplan.FuncCall{Name: "map", Args: args}
+}
+
+// unwrapParens peels off any wrapping ParenExpr nodes. PromQL's parser
+// preserves syntactic parens as ParenExpr; absent() expects a bare
+// instant-vector selector underneath but the user may write
+// `absent((up))`.
+func unwrapParens(e parser.Expr) parser.Expr {
+	for {
+		p, ok := e.(*parser.ParenExpr)
+		if !ok {
+			return e
+		}
+		e = p.Expr
+	}
+}

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -374,6 +374,8 @@ func lowerCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, err
 		}
 	}
 	switch c.Func.Name {
+	case "absent":
+		return lowerAbsent(c, s, ctx)
 	case "clamp", "clamp_min", "clamp_max":
 		return lowerClamp(c, s, ctx)
 	case "histogram_quantile":

--- a/test/spec/promql/absent_no_series.txtar
+++ b/test/spec/promql/absent_no_series.txtar
@@ -1,0 +1,52 @@
+# absent() over a metric the table doesn't contain — Prom returns a
+# 1-row vector with the equality-matcher labels lifted onto the
+# synthesised output sample. The chplan is a 4-layer stack:
+#
+#   Project ["", map(<eq-matchers>), <eval ts>, 1.0]
+#     Filter (_cerb_n = 0)
+#       Aggregate count() AS _cerb_n   (DropEmptyOnNoGroup=false)
+#         Filter (MetricName = "nonexistent_metric_name") AND (Attributes['job'] = "x")
+#           Scan(otel_metrics_gauge)
+#
+# The inner Filter (matchers) yields 0 rows because the only seeded
+# row belongs to a different metric; the Aggregate with
+# DropEmptyOnNoGroup=false still emits one row of zeros (count=0); the
+# outer Filter passes it through; the Project synthesises the absent
+# row with `job=x` lifted from the equality matcher.
+
+-- query.promql --
+absent(nonexistent_metric_name{job="x"})
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- Only an unrelated metric is present — the filtered Scan above
+-- produces 0 rows for `nonexistent_metric_name`.
+INSERT INTO otel_metrics_gauge VALUES
+    ('temperature', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 42.0);
+-- expected_rows --
+[
+  ["", {"job": "x"}, "2026-01-01T00:00:01Z", 1.0]
+]
+-- args --
+[0] string = ""
+[1] string = "job"
+[2] string = "x"
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] float64 = 1
+[6] string = "nonexistent_metric_name"
+[7] string = "job"
+[8] string = "x"
+[9] int64 = 0
+-- chplan --
+Project ["" AS MetricName, map("job", "x") AS Attributes, toDateTime64("2026-01-01 00:00:01.000000000", 9) AS TimeUnix, 1 AS Value]
+  Filter predicate=(_cerb_n = 0)
+    Aggregate groupBy=[] funcs=[count() AS _cerb_n]
+      Filter predicate=((Attributes["job"] = "x") AND (MetricName = "nonexistent_metric_name"))
+        Scan(otel_metrics_gauge)
+-- sql --
+SELECT ? AS `MetricName`, map(?, ?) AS `Attributes`, toDateTime64(?, ?) AS `TimeUnix`, ? AS `Value` FROM (SELECT * FROM (SELECT count() AS `_cerb_n` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`Attributes`[?] = ?))) WHERE (`_cerb_n` = ?))

--- a/test/spec/promql/absent_with_series.txtar
+++ b/test/spec/promql/absent_with_series.txtar
@@ -1,0 +1,35 @@
+# absent() over a metric the table DOES contain — Prom returns an
+# empty vector (no row). At this layer the inner Filter matches at
+# least one Scan row, so count() returns > 0; the outer
+# `_cerb_n = 0` filter drops the candidate sample, the surrounding
+# Project produces zero output rows.
+
+-- query.promql --
+absent(temperature)
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('temperature', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 42.0);
+-- expected_rows --
+[]
+-- args --
+[0] string = ""
+[1] string = "Map(String,String)"
+[2] string = "2026-01-01 00:00:01.000000000"
+[3] int64 = 9
+[4] float64 = 1
+[5] string = "temperature"
+[6] int64 = 0
+-- chplan --
+Project ["" AS MetricName, CAST(map(), "Map(String,String)") AS Attributes, toDateTime64("2026-01-01 00:00:01.000000000", 9) AS TimeUnix, 1 AS Value]
+  Filter predicate=(_cerb_n = 0)
+    Aggregate groupBy=[] funcs=[count() AS _cerb_n]
+      Filter predicate=(MetricName = "temperature")
+        Scan(otel_metrics_gauge)
+-- sql --
+SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, toDateTime64(?, ?) AS `TimeUnix`, ? AS `Value` FROM (SELECT * FROM (SELECT count() AS `_cerb_n` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))) WHERE (`_cerb_n` = ?))


### PR DESCRIPTION
## Summary

Closes 2 prometheus/compliance gaps — `function absent is not yet supported`. Mirrors Prom's `funcAbsent` semantics: returns a 1-row vector `{<eq-matchers>} 1` when no series match, empty otherwise.

## Implementation

New `lowerAbsent` (`internal/promql/absent.go`). Plan tree:

```
Project ["", map(<eq-matchers>), <eval ts>, 1.0]
  Filter (_cerb_n = 0)
    Aggregate groupBy=[] funcs=[count() AS _cerb_n]   (DropEmptyOnNoGroup=false)
      Filter <v matchers>
        Scan(<table>)
```

`absentAttrsMap` mirrors Prom's `createLabelsForAbsentFunction`: walks `v.LabelMatchers`, skips `__name__`, keeps only `MatchEqual`, drops labels appearing twice (Prom's has-map). Falls back to `CAST(map(), 'Map(String,String)')` when no eligible matchers remain.

`DropEmptyOnNoGroup=false` is key — we WANT the 1-row count=0 over empty input so the outer Filter can detect "no series" and the Project synthesizes the constant-1 output.

## Test plan

- [x] `go test ./internal/promql/ ./internal/chsql/` — 877 pass
- [x] `go test -tags chdb ./test/spec/promql/ -run "TestRoundTripChDB/absent"` — 3 pass
- [x] 2 new fixtures (no-series → 1-row; with-series → empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>