### PR TITLE
fix(promql,chsql): clamp quantile phi out of [0,1] per Prom semantics

### DIFF
--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -498,7 +498,23 @@ func lowerAggregate(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) (ch
 		AggFuncs:           []chplan.AggFunc{aggFunc},
 		DropEmptyOnNoGroup: true,
 	}
-	return wrapAggregateForSample(agg, a, s, aliases), nil
+	wrapped := wrapAggregateForSample(agg, a, s, aliases)
+	// quantile(phi, V) with phi outside [0, 1] is well-defined in
+	// PromQL — see prometheus/promql/quantile.go: phi<0 → -Inf,
+	// phi>1 → +Inf. CH's `quantile` aggregate rejects out-of-range
+	// phi at the wire layer, so buildAggFunc has already clamped
+	// the emitted phi to 0.5; here we wrap the Aggregate output in
+	// a Project that overrides Value with the PromQL-spec Inf
+	// constant. The per-group identity (MetricName / Attributes /
+	// TimeUnix) carries through unchanged from the inner Project.
+	if a.Op == parser.QUANTILE {
+		if phi, ok := tryScalarLiteral(a.Param); ok {
+			if infValue, outOfRange := outOfRangePhiInf(phi); outOfRange {
+				wrapped = projectValueOverInner(wrapped, s, &chplan.LitFloat{V: infValue})
+			}
+		}
+	}
+	return wrapped, nil
 }
 
 // lowerCountValues lowers `count_values("label", expr) [by(g)]`. The
@@ -850,9 +866,18 @@ func buildAggFunc(a *parser.AggregateExpr, s schema.Metrics) (chplan.AggFunc, er
 		if !ok {
 			return chplan.AggFunc{}, fmt.Errorf("promql: quantile(phi, ...) requires a scalar literal phi (computed phi defers to M1.7)")
 		}
+		// CH's `quantile(phi)` aggregate errors on phi outside
+		// [0, 1]; clamp the emitted phi to a safe sentinel (0.5)
+		// for those cases. lowerAggregate post-Projects the Value
+		// column to ±Inf (matching Prom's funcQuantile semantics)
+		// so the clamped value is never observed.
+		emitPhi := phi
+		if _, outOfRange := outOfRangePhiInf(phi); outOfRange {
+			emitPhi = 0.5
+		}
 		return chplan.AggFunc{
 			Name:   "quantile",
-			Params: []chplan.Expr{&chplan.LitFloat{V: phi}},
+			Params: []chplan.Expr{&chplan.LitFloat{V: emitPhi}},
 			Args:   []chplan.Expr{valueArg},
 			Alias:  s.ValueColumn,
 		}, nil

--- a/internal/promql/range_fns.go
+++ b/internal/promql/range_fns.go
@@ -2,6 +2,7 @@ package promql
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/prometheus/prometheus/promql/parser"
 
@@ -127,6 +128,17 @@ func lowerHoltWinters(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.No
 // IR: a RangeWindow with Func="quantile_over_time" and
 // Scalars=[phi]. The chsql emitter switches on Func and reads
 // Scalars[0] for the quantile parameter.
+//
+// Out-of-range phi: PromQL's funcQuantileOverTime delegates to the
+// shared `quantile()` helper, which returns -Inf for phi < 0 and +Inf
+// for phi > 1 (see prometheus/promql/quantile.go). ClickHouse's
+// `quantile` aggregate rejects phi outside [0, 1], so the lowerer
+// detects the out-of-range case at compile time, builds the
+// RangeWindow with phi clamped to a valid sentinel (0.5 — the actual
+// computed value is discarded), and post-Projects the Value column to
+// +Inf / -Inf. The empty-window branch still produces NaN per Prom
+// semantics (matching the unconditional `if(length(...) > 0, ..., nan)`
+// the emitter already writes).
 func lowerQuantileOverTime(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
 	if len(c.Args) != 2 {
 		return nil, fmt.Errorf("promql: quantile_over_time expects 2 arguments, got %d", len(c.Args))
@@ -155,17 +167,61 @@ func lowerQuantileOverTime(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chpl
 	if err != nil {
 		return nil, err
 	}
-	return &chplan.RangeWindow{
+
+	// Detect compile-time out-of-range phi. CH's quantile aggregate
+	// errors on phi outside [0, 1]; substitute a safe phi for the
+	// inner aggregate and post-Project the Value column to the
+	// PromQL-spec Inf-valued constant. NaN phi rides the same path
+	// (CH would also error on `quantile(NaN)`) and is materialised
+	// as a NaN literal in the post-Project — empty windows still
+	// produce `nan` via the emitter's length-guarded `if`.
+	infValue, replaceValue := outOfRangePhiInf(phi)
+
+	emitPhi := phi
+	if replaceValue {
+		emitPhi = 0.5
+	}
+
+	window := &chplan.RangeWindow{
 		Input:           inner,
 		Func:            "quantile_over_time",
 		Range:           ms.Range,
 		End:             anchor.End,
 		Offset:          anchor.Offset,
-		Scalars:         []float64{phi},
+		Scalars:         []float64{emitPhi},
 		TimestampColumn: s.TimestampColumn,
 		ValueColumn:     s.ValueColumn,
 		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}},
-	}, nil
+	}
+	if !replaceValue {
+		return window, nil
+	}
+	return projectValueOverInner(window, s, &chplan.LitFloat{V: infValue}), nil
+}
+
+// outOfRangePhiInf reports whether phi falls outside PromQL's valid
+// quantile range [0, 1] and returns the PromQL-spec replacement value:
+//
+//   - phi < 0  → (-Inf, true)
+//   - phi > 1  → (+Inf, true)
+//   - NaN       → (NaN,  true)   (mirrors Prom's `quantile()` helper)
+//   - otherwise → (0,    false)
+//
+// Callers fold a `true` result into a post-Project on the aggregate /
+// range-window output so CH's `quantile()` aggregate never sees an
+// out-of-range phi (CH errors on phi outside [0, 1]). The two phi-
+// taking call sites — `quantile_over_time(phi, v[range])` and
+// `quantile(phi, V)` aggregator — share this single fold.
+func outOfRangePhiInf(phi float64) (float64, bool) {
+	switch {
+	case math.IsNaN(phi):
+		return math.NaN(), true
+	case phi < 0:
+		return math.Inf(-1), true
+	case phi > 1:
+		return math.Inf(+1), true
+	}
+	return 0, false
 }
 
 // matrixAndSelector extracts the *parser.MatrixSelector and inner

--- a/test/spec/promql/quantile_over_time_q_above_one.txtar
+++ b/test/spec/promql/quantile_over_time_q_above_one.txtar
@@ -1,0 +1,35 @@
+# PromQL `quantile_over_time(phi, ...)` with phi > 1 yields +Inf
+# per Prom's `quantile()` helper (see prometheus/promql/quantile.go).
+# ClickHouse's `quantile` aggregate rejects phi outside [0, 1], so the
+# lowerer detects the out-of-range phi at compile time, builds the
+# RangeWindow with a clamped sentinel (0.5), and post-Projects the
+# Value column to +Inf.
+-- query.promql --
+quantile_over_time(1.5, latency_ms[5m] @ end())
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('latency_ms', map('endpoint', '/api/v1'), toDateTime64('1970-01-01 00:06:40', 9), 100.0),
+    ('latency_ms', map('endpoint', '/api/v1'), toDateTime64('1970-01-01 00:07:00', 9), 100.0),
+    ('latency_ms', map('endpoint', '/api/v1'), toDateTime64('1970-01-01 00:07:30', 9), 100.0),
+    ('latency_ms', map('endpoint', '/api/v1'), toDateTime64('1970-01-01 00:08:00', 9), 100.0),
+    ('latency_ms', map('endpoint', '/api/v1'), toDateTime64('1970-01-01 00:08:20', 9), 100.0);
+-- expected_rows --
+[
+  [{"endpoint": "/api/v1"}, "+Inf"]
+]
+-- args --
+[0] float64 = +Inf
+[1] string = "latency_ms"
+-- chplan --
+Project [Attributes, +Inf AS Value]
+  RangeWindow func=quantile_over_time range=5m0s step=0s ts=TimeUnix value=Value groupBy=[Attributes] scalars=[0.5] start=0001-01-01T00:00:00Z end=1970-01-01T00:08:20Z
+    Filter predicate=(MetricName = "latency_ms")
+      Scan(otel_metrics_gauge)
+-- sql --
+SELECT `Attributes`, ? AS `Value` FROM (SELECT `Attributes`, if(length(window_vals) > 0, arrayReduce('quantile(0.5)', window_vals), nan) AS `Value` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) >= toDateTime64('1970-01-01 00:08:20.000000000', 9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= toDateTime64('1970-01-01 00:08:20.000000000', 9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY `Attributes`))) WHERE length(`window_vals`) >= 1)

--- a/test/spec/promql/quantile_over_time_q_negative.txtar
+++ b/test/spec/promql/quantile_over_time_q_negative.txtar
@@ -1,0 +1,35 @@
+# PromQL `quantile_over_time(phi, ...)` with phi < 0 yields -Inf
+# per Prom's `quantile()` helper (see prometheus/promql/quantile.go).
+# ClickHouse's `quantile` aggregate rejects phi outside [0, 1], so the
+# lowerer detects the out-of-range phi at compile time, builds the
+# RangeWindow with a clamped sentinel (0.5), and post-Projects the
+# Value column to -Inf.
+-- query.promql --
+quantile_over_time(-0.5, latency_ms[5m] @ end())
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('latency_ms', map('endpoint', '/api/v1'), toDateTime64('1970-01-01 00:06:40', 9), 100.0),
+    ('latency_ms', map('endpoint', '/api/v1'), toDateTime64('1970-01-01 00:07:00', 9), 100.0),
+    ('latency_ms', map('endpoint', '/api/v1'), toDateTime64('1970-01-01 00:07:30', 9), 100.0),
+    ('latency_ms', map('endpoint', '/api/v1'), toDateTime64('1970-01-01 00:08:00', 9), 100.0),
+    ('latency_ms', map('endpoint', '/api/v1'), toDateTime64('1970-01-01 00:08:20', 9), 100.0);
+-- expected_rows --
+[
+  [{"endpoint": "/api/v1"}, "-Inf"]
+]
+-- args --
+[0] float64 = -Inf
+[1] string = "latency_ms"
+-- chplan --
+Project [Attributes, -Inf AS Value]
+  RangeWindow func=quantile_over_time range=5m0s step=0s ts=TimeUnix value=Value groupBy=[Attributes] scalars=[0.5] start=0001-01-01T00:00:00Z end=1970-01-01T00:08:20Z
+    Filter predicate=(MetricName = "latency_ms")
+      Scan(otel_metrics_gauge)
+-- sql --
+SELECT `Attributes`, ? AS `Value` FROM (SELECT `Attributes`, if(length(window_vals) > 0, arrayReduce('quantile(0.5)', window_vals), nan) AS `Value` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) >= toDateTime64('1970-01-01 00:08:20.000000000', 9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= toDateTime64('1970-01-01 00:08:20.000000000', 9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY `Attributes`))) WHERE length(`window_vals`) >= 1)

--- a/test/spec/promql/quantile_q_above_one.txtar
+++ b/test/spec/promql/quantile_q_above_one.txtar
@@ -1,0 +1,48 @@
+# PromQL `quantile(phi, V)` with phi > 1 yields +Inf per Prom's
+# `quantile()` helper (see prometheus/promql/quantile.go).
+# ClickHouse's `quantile` aggregate rejects phi outside [0, 1], so
+# buildAggFunc emits a clamped sentinel (0.5) and lowerAggregate
+# wraps the Sample-shape Project in an outer Project that overrides
+# Value with +Inf.
+-- query.promql --
+quantile(1.5, up) by (job)
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api', 'instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('up', map('job', 'api', 'instance', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('up', map('job', 'web', 'instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 1.0);
+-- expected_rows --
+[
+  ["", {"job": "api"}, "2026-01-01T00:00:01Z", "+Inf"],
+  ["", {"job": "web"}, "2026-01-01T00:00:01Z", "+Inf"]
+]
+-- args --
+[0] float64 = +Inf
+[1] string = ""
+[2] string = "job"
+[3] int64 = 9
+[4] string = "job"
+[5] float64 = 0.5
+[6] string = "up"
+[7] string = "2026-01-01 00:00:01.000000000"
+[8] int64 = 9
+[9] string = "2026-01-01 00:00:01.000000000"
+[10] int64 = 9
+[11] int64 = 300000000000
+[12] string = "job"
+-- chplan --
+Project [MetricName, Attributes, TimeUnix, +Inf AS Value]
+  Project ["" AS MetricName, mapWithoutEmpty(map("job", gkey_0)) AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+    Aggregate groupBy=[Attributes["job"] AS gkey_0] funcs=[quantile(0.5)(Value) AS Value]
+      Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+        Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+          Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+            Scan(otel_metrics_gauge)
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, ? AS `Value` FROM (SELECT ? AS `MetricName`, mapFilter((k, v) -> v != '', map(?, `gkey_0`)) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes`[?] AS `gkey_0`, quantile(?)(`Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY `Attributes`[?]))

--- a/test/spec/promql/quantile_q_negative.txtar
+++ b/test/spec/promql/quantile_q_negative.txtar
@@ -1,0 +1,49 @@
+# PromQL `quantile(phi, V)` with phi < 0 yields -Inf per Prom's
+# `quantile()` helper (see prometheus/promql/quantile.go).
+# ClickHouse's `quantile` aggregate rejects phi outside [0, 1], so
+# buildAggFunc emits a clamped sentinel (0.5) and lowerAggregate
+# wraps the Sample-shape Project in an outer Project that overrides
+# Value with -Inf. The per-group identity (MetricName / Attributes /
+# TimeUnix) carries through unchanged.
+-- query.promql --
+quantile(-0.5, up) by (job)
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api', 'instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('up', map('job', 'api', 'instance', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('up', map('job', 'web', 'instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 1.0);
+-- expected_rows --
+[
+  ["", {"job": "api"}, "2026-01-01T00:00:01Z", "-Inf"],
+  ["", {"job": "web"}, "2026-01-01T00:00:01Z", "-Inf"]
+]
+-- args --
+[0] float64 = -Inf
+[1] string = ""
+[2] string = "job"
+[3] int64 = 9
+[4] string = "job"
+[5] float64 = 0.5
+[6] string = "up"
+[7] string = "2026-01-01 00:00:01.000000000"
+[8] int64 = 9
+[9] string = "2026-01-01 00:00:01.000000000"
+[10] int64 = 9
+[11] int64 = 300000000000
+[12] string = "job"
+-- chplan --
+Project [MetricName, Attributes, TimeUnix, -Inf AS Value]
+  Project ["" AS MetricName, mapWithoutEmpty(map("job", gkey_0)) AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+    Aggregate groupBy=[Attributes["job"] AS gkey_0] funcs=[quantile(0.5)(Value) AS Value]
+      Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+        Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+          Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+            Scan(otel_metrics_gauge)
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, ? AS `Value` FROM (SELECT ? AS `MetricName`, mapFilter((k, v) -> v != '', map(?, `gkey_0`)) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes`[?] AS `gkey_0`, quantile(?)(`Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY `Attributes`[?]))

--- a/test/spec/runner_chdb.go
+++ b/test/spec/runner_chdb.go
@@ -19,6 +19,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"math"
 	"reflect"
 	"sort"
 	"strings"
@@ -651,6 +652,24 @@ func normalizeValue(v any) any {
 		return float64(x)
 	case float32:
 		return float64(x)
+	case string:
+		// JSON cannot represent ±Inf / NaN natively (json.Unmarshal
+		// would reject the bare tokens). Fixture authors encode them
+		// as string sentinels in `expected_rows:` so the assertion
+		// path can match a chDB row whose Value column is non-finite
+		// (e.g. PromQL quantile(phi<0, ...) lowers to -Inf). The
+		// CH float64 → Go float64 path returns math.Inf(±1) /
+		// math.NaN() directly, so the expected side must do the
+		// same here.
+		switch x {
+		case "Inf", "+Inf":
+			return math.Inf(+1)
+		case "-Inf":
+			return math.Inf(-1)
+		case "NaN":
+			return math.NaN()
+		}
+		return v
 	case map[string]any:
 		out := make(map[string]any, len(x))
 		for k, vv := range x {
@@ -669,9 +688,46 @@ func normalizeValue(v any) any {
 }
 
 func mustJSON(v any) string {
-	b, err := json.MarshalIndent(v, "", "  ")
+	// json.Marshal rejects non-finite float64 values; route them
+	// through the same sentinel strings normalizeValue accepts on
+	// the read path so sortRows can keep delegating to JSON
+	// without per-call error handling for ±Inf / NaN cells.
+	b, err := json.MarshalIndent(infSafe(v), "", "  ")
 	if err != nil {
 		return fmt.Sprintf("<json err: %v>", err)
 	}
 	return string(b)
+}
+
+// infSafe walks v and substitutes non-finite float64 values with the
+// JSON-friendly string sentinels normalizeValue understands ("+Inf",
+// "-Inf", "NaN"). Other types pass through unchanged. Used only by
+// the mustJSON sort key — the cell values themselves are still
+// compared via reflect.DeepEqual at full float64 precision.
+func infSafe(v any) any {
+	switch x := v.(type) {
+	case float64:
+		switch {
+		case math.IsNaN(x):
+			return "NaN"
+		case math.IsInf(x, +1):
+			return "+Inf"
+		case math.IsInf(x, -1):
+			return "-Inf"
+		}
+		return x
+	case map[string]any:
+		out := make(map[string]any, len(x))
+		for k, vv := range x {
+			out[k] = infSafe(vv)
+		}
+		return out
+	case []any:
+		out := make([]any, len(x))
+		for i, vv := range x {
+			out[i] = infSafe(vv)
+		}
+		return out
+	}
+	return v
 }


### PR DESCRIPTION
## Summary

Closes 14 prometheus/compliance gaps. CH's `quantile` aggregate rejects `phi ∉ [0,1]` → HTTP 502. PromQL spec: `phi < 0` → `-Inf`, `phi > 1` → `+Inf` (see Prom's `funcQuantile`).

## Implementation

Compile-time fold at both lowering points:

- `lowerQuantileOverTime` (`internal/promql/range_fns.go`): RangeWindow path. Clamps emitted phi to 0.5 (so CH accepts) and post-Projects Value to `±Inf` literal.
- `lowerAggregate`'s quantile case (`internal/promql/lower.go`): aggregation path. Same pattern via `wrapAggregateForSample`'s outer Project.

New shared helper `outOfRangePhiInf(phi) → (replaceVal, replace bool)` returns `-Inf`/`+Inf`/`NaN` per Prom semantics.

Empty-window / empty-group semantics unchanged.

## Test plan

- [x] `go test ./internal/promql/ ./internal/chsql/` — 862 pass
- [x] `go test -tags chdb -run TestRoundTripChDB/quantile ./test/spec/promql/` — 21 pass (17 existing + 4 new)
- [x] Extended `test/spec/runner_chdb.go`: `expected_rows` JSON can encode `±Inf`/`NaN` via string sentinels; non-finite-safe sort key

## Touched files

- `internal/promql/lower.go` (+27/-2)
- `internal/promql/range_fns.go` (+59/-3)
- `test/spec/runner_chdb.go` (+51/-1)
- 4 new TXTAR fixtures (~140 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>