### PR TITLE
feat(ci): quality-metric linters + arch-lint for coupling enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,16 @@ jobs:
           # Honours .golangci.yml; runs across the whole module.
           args: ./...
 
+      # go-arch-lint enforces the cerberus layering (parse → lower →
+      # optimize → emit → execute) declared in .go-arch-lint.yml.
+      # No first-party Action exists; install via `go install` so it
+      # reuses setup-go's module cache.
+      - name: install go-arch-lint
+        run: go install github.com/fe3dback/go-arch-lint@v1.15.0
+
+      - name: go-arch-lint
+        run: go-arch-lint check
+
       - name: commitlint
         if: github.event_name == 'pull_request'
         uses: wagoid/commitlint-github-action@v6

--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -1,0 +1,223 @@
+# Architectural-coupling rules for cerberus, enforced by `go-arch-lint`.
+#
+# The intent is the project's core layering, as described in CLAUDE.md:
+#
+#     parse → lower → optimize → emit → execute
+#
+# Concretely, the domain layers (lowest to highest) are:
+#
+#     chplan          — shared plan IR (no dependencies)
+#     ql              — promql / logql / traceql parsers + lowering
+#     optimizer       — rule-based plan rewrites
+#     chsql           — plan → ClickHouse SQL emitter
+#     chclient        — CH driver wrapper
+#     engine          — query pipeline orchestrator
+#     api             — HTTP handlers per upstream wire format
+#
+# Cross-cutting utility packages (declared as `commonComponents` so any
+# layer may import them) are:
+#
+#     schema          — OTel-CH default + override config; QL lowerings,
+#                       optimizer MV rules, and chsql emitters all need
+#                       column-name access.
+#     cerbtrace       — typed OTel span helpers (depends only on chplan).
+#     telemetry       — OTel SDK setup + meter registry.
+#     httperr         — typed HTTP-error carrier. Despite its location
+#                       under internal/api/, this package owns the
+#                       typed error value that engine adapters raise so
+#                       handlers can `errors.As` into the right wire
+#                       envelope. It is not part of the HTTP-handler
+#                       layer in the dependency graph; it is a leaf type
+#                       package. See its package doc-comment.
+#     api-admit       — shared admission-control middleware.
+#     api-format      — wire-format helpers shared across handlers.
+#     api-health      — readiness probe.
+#     promshim-local  — Prometheus-engine reference shim for property
+#                       tests (test-only consumer).
+#     schema-ddl      — OTel-CH DDL helpers (config consumes; isolated).
+#     chclienttest    — chclient test helpers.
+#
+# Deviations from the strictest "domain layers only" interpretation of
+# the proposed rules:
+#
+#   - `optimizer` is allowed to import `chplan`, `schema`, and the
+#     utility components. The `schema` dep is load-bearing: the
+#     MV-substitution rule resolves materialised-view column names
+#     against the schema.
+#   - QL packages (`promql`, `logql`, `traceql`) import `chplan` and
+#     `schema`. `logql` additionally imports `httperr` + `engine`
+#     because the LogQL adapter implements `engine.Lang` and returns
+#     `*httperr.Error` values for the parse/lower error stages so the
+#     downstream handler can `errors.As` into the wire envelope. The
+#     same shape applies to `promql` and `traceql` once they migrate
+#     to the engine.Lang surface — keep parity for all three.
+#   - `api/loki`, `api/prom`, `api/tempo` import `optimizer` to wire
+#     a per-handler driver instance into the request pipeline. This is
+#     composition (the handler owns the driver), not violation of the
+#     "optimize sits below api" intuition.
+#   - `engine` imports `optimizer` + `chsql` + `chclient` because it
+#     is the orchestrator that walks parse → optimize → emit → execute.
+#     It does NOT import `promql` / `logql` / `traceql` directly; those
+#     are wired in through the `engine.Lang` interface at the handler
+#     layer.
+#
+# If you tighten any of these, expect a measurable refactor (the
+# adapter / handler wiring would need a different seam).
+
+version: 3
+
+# Bound the linter to the in-repo Go packages. test/, harness/, cmd/
+# code is checked by golangci-lint but exempt from arch-lint — they
+# legitimately reach across the IR / SQL / driver layers for fixtures
+# and entrypoints.
+workdir: internal
+
+# Enforce only internal component-layering rules. Vendor (third-party
+# import) checks are off — the heads legitimately consume their
+# upstream parsers and we don't want to maintain a vendor allow-list
+# for every transitively-pulled OTel / Loki / Prom subpackage.
+allow:
+  depOnAnyVendor: true
+
+# Skip *_test.go files. Tests legitimately reach across layer
+# boundaries to set up fixtures; arch-lint enforces the production
+# import graph.
+excludeFiles:
+  - ".*_test\\.go$"
+
+components:
+  # Domain layers.
+  chplan:    { in: chplan }
+  promql:    { in: promql }
+  logql:     { in: logql }
+  traceql:   { in: traceql }
+  optimizer: { in: optimizer }
+  chsql:     { in: chsql }
+  chclient:  { in: chclient }
+  engine:    { in: engine }
+  config:    { in: config }
+  api-loki:  { in: api/loki }
+  api-prom:  { in: api/prom }
+  api-tempo: { in: api/tempo }
+  # Cross-cutting utility packages — see commonComponents below.
+  schema:         { in: schema }
+  schema-ddl:     { in: schema/ddl }
+  cerbtrace:      { in: cerbtrace }
+  telemetry:      { in: telemetry }
+  httperr:        { in: api/httperr }
+  api-admit:      { in: api/admit }
+  api-format:     { in: api/format }
+  api-health:     { in: api/health }
+  promshim-local: { in: promshim/local }
+  chclienttest:   { in: chclienttest }
+
+# commonComponents are importable from every layer without an explicit
+# `mayDependOn` entry. These are the cross-cutting utility packages
+# documented in the header.
+commonComponents:
+  - schema
+  - schema-ddl
+  - cerbtrace
+  - telemetry
+  - httperr
+  - api-admit
+  - api-format
+  - api-health
+  - promshim-local
+  - chclienttest
+
+deps:
+  # chplan is the foundation. No internal dependencies declared — entries
+  # are omitted for leaf components since go-arch-lint requires every
+  # listed `mayDependOn` to be non-empty. Omitting the entry implicitly
+  # forbids all internal imports, which is what we want.
+
+  # QL layers parse upstream syntax and lower to chplan. The LogQL
+  # adapter has migrated to the engine.Lang interface, so it depends
+  # on `engine` for the typed contracts (engine.Meta etc); promql and
+  # traceql remain on the older shape and import only chplan + the
+  # utility commons. Mirror logql's surface in the next RC when the
+  # other two adapt to engine.Lang.
+  promql:
+    mayDependOn:
+      - chplan
+  logql:
+    mayDependOn:
+      - chplan
+      - engine
+  traceql:
+    mayDependOn:
+      - chplan
+
+  # The optimizer rewrites plans in place. It must not know about SQL
+  # emission, the CH driver, or HTTP handlers. (It may read schema via
+  # the commonComponents allowance for MV substitution.)
+  optimizer:
+    mayDependOn:
+      - chplan
+
+  # chsql lowers plans to SQL. It needs chplan (to walk). schema is
+  # available via commonComponents for column-name access. It must not
+  # import QL parsers or handlers.
+  chsql:
+    mayDependOn:
+      - chplan
+
+  # chclient is the CH driver wrapper. Pure execution layer.
+  # (mayDependOn intentionally omitted — see chplan comment.)
+
+  # engine is the orchestrator: parse → optimize → emit → execute.
+  # It does NOT import QL packages directly — QL adapters implement
+  # engine.Lang and are injected at construction time.
+  engine:
+    mayDependOn:
+      - chplan
+      - chsql
+      - chclient
+      - optimizer
+
+  # config is wired from cmd/ to build chclient + schema at boot.
+  config:
+    mayDependOn:
+      - chclient
+
+  # Handlers compose the full stack: QL parser, optimizer, engine,
+  # SQL emitter, CH driver. Each handler imports exactly its own
+  # language layer.
+  api-loki:
+    mayDependOn:
+      - chplan
+      - chsql
+      - chclient
+      - engine
+      - optimizer
+      - logql
+  api-prom:
+    mayDependOn:
+      - chplan
+      - chsql
+      - chclient
+      - engine
+      - optimizer
+      - promql
+  api-tempo:
+    mayDependOn:
+      - chplan
+      - chsql
+      - chclient
+      - engine
+      - optimizer
+      - traceql
+
+  # Utility components — `cerbtrace` pulls in `chplan`, `chclienttest`
+  # is a build-tagged (`chdb`) test helper that wraps chclient so each
+  # handler's test suite can drive a chDB session via the production
+  # Querier surface; the rest are leaves. Empty `mayDependOn` entries
+  # are omitted; commonComponents flow naturally so leaves don't need
+  # an entry here.
+  cerbtrace:
+    mayDependOn:
+      - chplan
+  chclienttest:
+    mayDependOn:
+      - chclient

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,54 @@
+# ---------------------------------------------------------------------------
+# Quality-metric linters (see `enable:` block below).
+#
+# Each linter measures a structural code-quality signal and is configured
+# with a threshold tuned to pass current main with headroom — the point is
+# enforcement going forward (block PRs that introduce new violations), not
+# punitive retroactive cleanup. Thresholds may be tightened later as the
+# called-out hotspots are refactored; raising thresholds is fine when a new
+# pattern needs it, but lowering should be the gradient.
+#
+# - gocognit (cognitive complexity per function). Counts how hard a fn is
+#   to read: nesting, switches, jumps. Threshold 60 covers the SQL emitter
+#   dispatcher (`(*QueryBuilder).writeInto`, 59) which is intrinsically
+#   shaped like a big switch over node kinds. TODO: tighten to 30 once
+#   writeInto is broken up by emit_node.go.
+#
+# - cyclop (cyclomatic complexity per function + package average). Counts
+#   branches. `max-complexity: 32` covers `writeInto` (30); `package-average:
+#   10.0` covers `engine` at ~4 with room. TODO: tighten max-complexity to
+#   25 once writeInto is decomposed.
+#
+# - funlen (function length: lines + statements). Catches the "this got
+#   too long, split it" review comment. 150 lines / 80 statements clears
+#   the biggest production fn (`histogramQuantileValueFrag`, 91 lines /
+#   79 stmts) with breathing room.
+#
+# - nestif (max nested-if depth). Currently max 5; threshold 6 leaves a
+#   one-step buffer.
+#
+# - dupl (token-stream duplication). Threshold 220 tokens. The 200 floor
+#   would fire on a near-identical pair of constant-fold helpers in
+#   `internal/optimizer/constant_fold.go` (lines 124-164 ↔ 170-210, ~210
+#   tokens) — duplication acknowledged in the fold-by-type design.
+#   TODO: deduplicate the per-type fold helpers and tighten back to 200.
+#
+# - maintidx (composite Maintainability Index). Halstead-based score;
+#   warns when a fn's MI < 20. Production minimum currently 47 (no fires).
+#
+# - lll (line length). 280 chars. Cerberus emits long CH SQL strings and
+#   `INSERT VALUES` seed data in `test/e2e/seed/cmd/seed/main.go` reaches
+#   264 chars. 140 would fire on ~30 legitimate SQL/seed lines; 280 keeps
+#   the linter useful for accidental 500-char monsters without rewriting
+#   readable SQL.
+#
+# The `test/spec/` and `test/property/` paths are excluded from the
+# complexity linters because they hold deterministic-IR pretty-printers
+# (`chplan_print.go`, 142 cognitive complexity by design — covers every
+# IR node) and oracle evaluators that mirror PromQL semantics; they're
+# test infrastructure, not production code.
+# ---------------------------------------------------------------------------
+
 version: "2"
 
 run:
@@ -29,6 +80,14 @@ linters:
     #   See docs/upstream-forks.md. Scoped to those
     #   two dirs via `exclusions.rules[].path-except` below.
     - forbidigo
+    # Quality-metric linters — see header comment.
+    - gocognit
+    - cyclop
+    - funlen
+    - nestif
+    - dupl
+    - maintidx
+    - lll
   settings:
     revive:
       rules:
@@ -52,6 +111,22 @@ linters:
           msg: 'unsafe.Pointer is forbidden in internal/traceql/ and internal/api/tempo/ — use the tsouza/tempo:cerberus-accessors fork accessors instead. See docs/upstream-forks.md.'
         - pattern: '^reflect\.Value\.FieldByName$'
           msg: 'reflect.FieldByName on parser AST is forbidden — use the upstream-fork accessors instead.'
+    gocognit:
+      min-complexity: 60
+    cyclop:
+      max-complexity: 32
+      package-average: 10.0
+    funlen:
+      lines: 150
+      statements: 80
+    nestif:
+      min-complexity: 6
+    dupl:
+      threshold: 220
+    maintidx:
+      under: 20
+    lll:
+      line-length: 280
   exclusions:
     rules:
       - path: _test\.go
@@ -61,6 +136,13 @@ linters:
           - errcheck
           - bodyclose
           - errorlint
+          - gocognit
+          - cyclop
+          - funlen
+          - nestif
+          - dupl
+          - maintidx
+          - lll
       - path: cmd/
         linters:
           - revive
@@ -70,6 +152,28 @@ linters:
       - linters:
           - forbidigo
         path-except: '^internal/(traceql|api/tempo)/'
+      # test/spec/ holds the deterministic IR pretty-printer + roundtrip
+      # runner; test/property/ holds the rapid oracle evaluators. Both are
+      # test infrastructure whose structure mirrors the IR / PromQL surface
+      # — they're allowed to be large by design.
+      - path: test/spec/
+        linters:
+          - gocognit
+          - cyclop
+          - funlen
+          - nestif
+          - dupl
+          - maintidx
+          - lll
+      - path: test/property/
+        linters:
+          - gocognit
+          - cyclop
+          - funlen
+          - nestif
+          - dupl
+          - maintidx
+          - lll
 
 formatters:
   enable:


### PR DESCRIPTION
## Summary

Adds two layers of automated software-engineering-quality enforcement to CI:

1. **`.golangci.yml` extension** — 7 quality-metric linters with cerberus-tuned thresholds (passes current main with documented headroom).
2. **`.go-arch-lint.yml` + new lint step** — declarative layering rules pinned for the parse → lower → optimize → emit → execute pipeline.

## Threshold table (linter → set → highest observed in prod)

| Linter | Set | Max in prod | Headroom |
|---|---|---|---|
| gocognit | 60 | 59 (`writeInto`) | +1 — TODO tighten to 30 |
| cyclop max | 32 | 30 (`writeInto`) | +2 — TODO 25 |
| cyclop avg | 10.0 | ~4.7 | +5 |
| funlen lines | 150 | 91 | +59 |
| funlen statements | 80 | 79 | +1 |
| nestif | 6 | 5 | +1 |
| dupl | 220 | floor at 210 | +10 |
| maintidx | warn <20 | min 47 in prod | clear |
| lll | 280 | 264 | +16 |

`test/spec/` + `test/property/` excluded from complexity linters (deterministic IR pretty-printer hits the ceiling by design).

## arch-lint rule summary

Domain chain: `chplan` ← `{promql,logql,traceql}` ← `optimizer` ← `chsql` ← `chclient`. `engine` orchestrates; `api/*` composes. `config` ↔ `chclient`.

Common components (importable anywhere): `schema`, `schema-ddl`, `cerbtrace`, `telemetry`, `httperr`, `api-admit`, `api-format`, `api-health`, `promshim-local`, `chclienttest`.

**Reality-modeling deviations from initial proposal** (documented in `.go-arch-lint.yml` header):
- `optimizer → schema` (MV-substitution needs column-name resolution)
- `logql → engine` + `logql → httperr` (Lang impl)
- `api/* → optimizer` (per-handler optimizer composition)
- `engine` does NOT import QL packages (injected via `engine.Lang`)
- `chclient` does not import `chplan`/`schema`

Smoke-tested: temporarily removed `optimizer` from `api-prom`'s allow-list — arch-lint correctly flagged the violation at `handler.go:23`. Reverted.

## Test plan

- [x] `golangci-lint run ./...` — 0 issues
- [x] `go-arch-lint check` — OK
- [x] Rebased on current main; CI's `lint` job picks up both extensions automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>