### PR TITLE
fix(traceql): nil-safe type assertion in lowerScalarFilter (fuzz crash)

### DIFF
--- a/internal/traceql/lower.go
+++ b/internal/traceql/lower.go
@@ -134,14 +134,21 @@ func lowerScalarFilter(prev chplan.Node, sf traceql.ScalarFilter, s schema.Trace
 
 	// rhs is expected to be a chplan.Expr from a Static literal; the
 	// LHS recursed back as a chplan.Node (Aggregate). For the typical
-	// `count() > 0` shape, wrap aggNode with a Filter.
+	// `count() > 0` shape, wrap aggNode with a Filter. The Tempo parser
+	// happily accepts pathological forms like `{} | 0 > 0` (no aggregate
+	// on either side) — type-assert before dereferencing so we return a
+	// structured error instead of panicking.
+	aggPlan, ok := aggNode.(chplan.Node)
+	if !ok {
+		return nil, fmt.Errorf("traceql: scalar-filter LHS must aggregate to a series (count() / sum(...) / avg(...) / min(...) / max(...)), got %T", aggNode)
+	}
 	rhsExpr, ok := rhs.(chplan.Expr)
 	if !ok {
 		return nil, fmt.Errorf("traceql: scalar-filter RHS must be a literal, got %T", rhs)
 	}
 
 	return &chplan.Filter{
-		Input:     aggNode.(chplan.Node),
+		Input:     aggPlan,
 		Predicate: &chplan.Binary{Op: op, Left: &chplan.ColumnRef{Name: "Value"}, Right: rhsExpr},
 	}, nil
 }

--- a/internal/traceql/testdata/fuzz/FuzzParse/ec29f3e4e88c8b28
+++ b/internal/traceql/testdata/fuzz/FuzzParse/ec29f3e4e88c8b28
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("{}|0>0")


### PR DESCRIPTION
## Summary

Closes a TraceQL parser-lowering panic surfaced by the weekly fuzz pass. Input `{}|0>0` panics with `interface conversion: *chplan.LitInt is not chplan.Node: missing method Children` at `internal/traceql/lower.go:144`.

## Root cause

The Tempo parser accepts a `ScalarFilter` whose LHS is a bare `Static` literal (not an `Aggregate`). `lowerScalarExpr` correctly returned `*chplan.LitInt` (a `chplan.Expr`) for the literal `0`, but `lowerScalarFilter` did an unchecked `aggNode.(chplan.Node)` type-assertion — panicking when LHS isn't an aggregate. Only the legitimate `{ ... } | count() > 0` shape was considered.

## Fix

Type-assert `aggNode` to `chplan.Node` before dereferencing — mirrors the existing RHS check immediately below. Returns a structured error pointing at the supported shape (`count() / sum / avg / min / max` LHS, literal RHS). +9/-2 in `internal/traceql/lower.go`. No behaviour change for valid shapes.

## Test plan

- [x] `go test -run FuzzParse/ec29f3e4e88c8b28 -count=1 ./internal/traceql/` — pass (pinned seed)
- [x] `go test -count=1 ./internal/traceql/` — 258 pass
- [x] `go test -fuzz=FuzzParse -fuzztime=30s ./internal/traceql/` — 91,321 execs from 312-seed baseline, no new crashes
- [x] New regression seed pinned: `internal/traceql/testdata/fuzz/FuzzParse/ec29f3e4e88c8b28`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>