### PR TITLE
feat(promql): topk/bottomk without(...) via MapWithoutKeys partition

### DIFF
--- a/internal/promql/aggregate_test.go
+++ b/internal/promql/aggregate_test.go
@@ -13,10 +13,10 @@ import (
 
 // TestLower_Aggregate_Errors covers the aggregate paths whose error
 // messages are observable contract (param / no-param mismatch, computed
-// quantile phi, topk/bottomk/count_values argument-shape rejections).
-// The previously-deferred `changes output shape` errors landed in PR
-// (topk/bottomk → chplan.TopK; count_values → Aggregate + Project) and
-// no longer surface here.
+// quantile phi, count_values argument-shape rejections). topk/bottomk
+// now accept `without(...)` (lowered into a MapWithoutKeys partition
+// expression on chplan.TopK.By); count_values `without` is still
+// deferred.
 func TestLower_Aggregate_Errors(t *testing.T) {
 	t.Parallel()
 
@@ -28,11 +28,6 @@ func TestLower_Aggregate_Errors(t *testing.T) {
 		query   string
 		wantErr string
 	}{
-		{
-			name:    "topk without not yet supported",
-			query:   `topk(3, up) without (instance)`,
-			wantErr: "without(...) is not yet supported",
-		},
 		{
 			name:    "topk K must be scalar literal",
 			query:   `topk(scalar(up), latency_seconds)`,

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -664,14 +664,14 @@ func tryStringLiteral(e parser.Expr) (string, bool) {
 // an error since the SQL `LIMIT 0` shape is degenerate and the
 // fixture-driven flow keeps a positive K invariant on the plan tree.
 //
-// `without(...)` is rejected: the spec allows it, but partitioning
-// "by every label except <these>" expands to `LIMIT K BY <full
-// Attributes minus listed keys>`, which is a different rewrite
-// than the by-list path and lands as a follow-up.
+// `without (l1, l2, ...)` partitions by "every label except <these>".
+// We emit a single `MapWithoutKeys` Expr into the `By` slot — it lowers
+// to CH's `mapFilter((k, v) -> NOT (k IN (?,...)), Attributes)`, which
+// is exactly the per-series partition key we want for LIMIT K BY. The
+// degenerate `without ()` case (empty Grouping) means "remove nothing",
+// equivalent to partitioning by the full Attributes map; emit a bare
+// ColumnRef so we don't render an empty IN-list (CH rejects that).
 func lowerTopK(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
-	if a.Without {
-		return nil, fmt.Errorf("promql: %s without(...) is not yet supported (use by(...) or no grouping)", a.Op.String())
-	}
 	kF, ok := tryScalarLiteral(a.Param)
 	if !ok {
 		return nil, fmt.Errorf("promql: %s requires a scalar literal K (computed K is not yet supported)", a.Op.String())
@@ -692,12 +692,28 @@ func lowerTopK(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) (chplan.
 		return nil, err
 	}
 
-	by := make([]chplan.Expr, 0, len(a.Grouping))
-	for _, label := range a.Grouping {
-		by = append(by, &chplan.MapAccess{
-			Map: &chplan.ColumnRef{Name: s.AttributesColumn},
-			Key: &chplan.LitString{V: label},
-		})
+	var by []chplan.Expr
+	switch {
+	case a.Without && len(a.Grouping) == 0:
+		// `topk(K, v) without ()` — partition by the full Attributes map.
+		by = []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}}
+	case a.Without:
+		// `topk(K, v) without (l1, l2)` — partition by `Attributes` with
+		// the listed labels stripped via mapFilter. Single MapWithoutKeys
+		// Expr keeps the per-series partition shape symmetric with the
+		// non-shape-changing aggregation path (`aggregateGroupBy`).
+		by = []chplan.Expr{&chplan.MapWithoutKeys{
+			Map:  &chplan.ColumnRef{Name: s.AttributesColumn},
+			Keys: append([]string(nil), a.Grouping...),
+		}}
+	default:
+		by = make([]chplan.Expr, 0, len(a.Grouping))
+		for _, label := range a.Grouping {
+			by = append(by, &chplan.MapAccess{
+				Map: &chplan.ColumnRef{Name: s.AttributesColumn},
+				Key: &chplan.LitString{V: label},
+			})
+		}
 	}
 
 	return &chplan.TopK{

--- a/internal/promql/lower_test.go
+++ b/internal/promql/lower_test.go
@@ -87,45 +87,12 @@ func TestLower(t *testing.T) {
 	})
 }
 
-// TestLower_errors covers the unsupported-PromQL paths so regressions in
-// the error message remain visible.
-func TestLower_errors(t *testing.T) {
-	t.Parallel()
-
-	s := schema.DefaultOTelMetrics()
-	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
-
-	cases := []struct {
-		name    string
-		query   string
-		wantErr string
-	}{
-		{
-			name:    "topk without is not yet supported",
-			query:   `topk(5, up) without (instance)`,
-			wantErr: "without(...) is not yet supported",
-		},
-		// Note: 'without' now lowers (M1.4) for non-shape-changing aggs;
-		// topk/bottomk/count_values landed via chplan.TopK + Aggregate
-		// reshape; BinaryExpr vector+vector rejection moved to
-		// binary_test.go; arithmetic ops are lowered for the
-		// scalar-vector case (M1.2).
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			expr, err := p.ParseExpr(tc.query)
-			if err != nil {
-				t.Fatalf("ParseExpr: %v", err)
-			}
-			if _, err := promql.Lower(context.Background(), expr, s); err == nil {
-				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
-			} else if !strings.Contains(err.Error(), tc.wantErr) {
-				t.Fatalf("error %q does not contain %q", err.Error(), tc.wantErr)
-			}
-		})
-	}
-}
+// Per-op error-path coverage lives in op-specific *_test.go files now —
+// see aggregate_test.go (topk/bottomk/count_values argument shapes) and
+// binary_test.go (BinaryExpr vector-vector rejection paths). The
+// previously-tested "topk without" rejection no longer exists: as of
+// the topk/bottomk without(...) lowering, `topk(K, v) without (l)`
+// lowers into chplan.TopK with a MapWithoutKeys partition expression.
 
 func formatArgs(args []any) string {
 	if len(args) == 0 {

--- a/test/spec/promql/bottomk_without_basic.txtar
+++ b/test/spec/promql/bottomk_without_basic.txtar
@@ -1,0 +1,39 @@
+-- query.promql --
+bottomk(2, up) without (instance)
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api', 'instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 0.1),
+    ('up', map('job', 'api', 'instance', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 0.5),
+    ('up', map('job', 'api', 'instance', 'c'), toDateTime64('2026-01-01 00:00:00', 9), 0.9),
+    ('up', map('job', 'api', 'instance', 'd'), toDateTime64('2026-01-01 00:00:00', 9), 0.7),
+    ('up', map('job', 'web', 'instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 0.3),
+    ('up', map('job', 'web', 'instance', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 0.8);
+-- expected_rows --
+[
+  ["up", {"instance": "a", "job": "api"}, "2026-01-01T00:00:00Z", 0.1],
+  ["up", {"instance": "b", "job": "api"}, "2026-01-01T00:00:00Z", 0.5],
+  ["up", {"instance": "a", "job": "web"}, "2026-01-01T00:00:00Z", 0.3],
+  ["up", {"instance": "b", "job": "web"}, "2026-01-01T00:00:00Z", 0.8]
+]
+-- args --
+[0] string = "up"
+[1] string = "2026-01-01 00:00:01.000000000"
+[2] int64 = 9
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] int64 = 300000000000
+[6] string = "instance"
+-- chplan --
+TopK k=2 sort=Value ASC by=[mapWithout(Attributes, [instance])] columns=[MetricName, Attributes, TimeUnix, Value]
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) ORDER BY `Value` LIMIT 2 BY mapFilter((k, v) -> NOT (k IN (?)), `Attributes`))

--- a/test/spec/promql/topk_without_basic.txtar
+++ b/test/spec/promql/topk_without_basic.txtar
@@ -1,0 +1,39 @@
+-- query.promql --
+topk(2, up) without (instance)
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api', 'instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 0.1),
+    ('up', map('job', 'api', 'instance', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 0.5),
+    ('up', map('job', 'api', 'instance', 'c'), toDateTime64('2026-01-01 00:00:00', 9), 0.9),
+    ('up', map('job', 'api', 'instance', 'd'), toDateTime64('2026-01-01 00:00:00', 9), 0.7),
+    ('up', map('job', 'web', 'instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 0.3),
+    ('up', map('job', 'web', 'instance', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 0.8);
+-- expected_rows --
+[
+  ["up", {"instance": "c", "job": "api"}, "2026-01-01T00:00:00Z", 0.9],
+  ["up", {"instance": "d", "job": "api"}, "2026-01-01T00:00:00Z", 0.7],
+  ["up", {"instance": "b", "job": "web"}, "2026-01-01T00:00:00Z", 0.8],
+  ["up", {"instance": "a", "job": "web"}, "2026-01-01T00:00:00Z", 0.3]
+]
+-- args --
+[0] string = "up"
+[1] string = "2026-01-01 00:00:01.000000000"
+[2] int64 = 9
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] int64 = 300000000000
+[6] string = "instance"
+-- chplan --
+TopK k=2 sort=Value DESC by=[mapWithout(Attributes, [instance])] columns=[MetricName, Attributes, TimeUnix, Value]
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) ORDER BY `Value` DESC LIMIT 2 BY mapFilter((k, v) -> NOT (k IN (?)), `Attributes`))


### PR DESCRIPTION
## Summary

Closes 4 prometheus/compliance gaps — `topk without(...)` + `bottomk without(...)` previously rejected with `not yet supported (use by(...) or no grouping)`.

## Approach

No new chplan node needed. `chplan.TopK.By` is `[]chplan.Expr` (polymorphic). `chplan.MapWithoutKeys` already renders as `mapFilter((k, v) -> NOT (k IN (?,...)), Attributes)` via `Builder.exprMapWithoutKeys`. So `without(l1, l2)` lowers into `By: [MapWithoutKeys{Map: Attributes, Keys: [l1, l2]}]` — exactly the partition expression CH wants.

Mirrors the symmetry with `aggregateGroupBy`'s `without` path. Degenerate `without()` short-circuits to a bare `ColumnRef{Attributes}` so we don't emit an empty IN-list.

## Test plan

- [x] `go test ./internal/{promql,chsql,chplan}/` — 1062 pass
- [x] `go test -tags chdb ./test/spec/promql/ -run "topk|bottomk"` — 5 pass (3 existing + 2 new)
- [x] `go test ./internal/optimizer/ ./internal/api/prom/` — 310 pass

## Files (+115 / -61)

- `internal/promql/lower.go` — `lowerTopK` rewrite
- `internal/promql/aggregate_test.go` — drop obsolete reject case
- `internal/promql/lower_test.go` — remove now-empty `TestLower_errors`
- `test/spec/promql/{topk,bottomk}_without_basic.txtar` — new

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>