### PR TITLE
fix(chsql): emit ±Inf / NaN inline as (±1.0/0) / (0.0/0)

### DIFF
--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -2,6 +2,7 @@ package chsql
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -80,6 +81,33 @@ func (b *Builder) QualIdent(qualifier, name string) {
 func (b *Builder) Arg(v any) {
 	b.sb.WriteByte('?')
 	b.args = append(b.args, v)
+}
+
+// writeInlineNonFinite emits ±Inf / NaN inline as a CH-portable
+// arithmetic literal and returns true; finite floats return false and
+// nothing is written. PromQL's `quantile()` helper returns ±Inf for phi
+// outside [0, 1] (see prometheus/promql/quantile.go) and the lowerer
+// post-Projects the Value column with such a literal — but clickhouse-go
+// and chdb-go both render Go's `math.Inf(±1)` / `math.NaN()` as the
+// mixed-case strings `+Inf` / `-Inf` / `NaN` when binding `?`, and real
+// CH 24.x parses only the lowercase forms (`inf` / `-inf` / `nan`),
+// surfacing on the wire as `Unknown identifier 'Inf'` → 502. The
+// division forms `1.0/0` / `-1.0/0` / `0.0/0` fold to the same IEEE
+// special values on the CH side and don't depend on the lexer's
+// case-sensitivity for the identifier path.
+func writeInlineNonFinite(b *Builder, v float64) bool {
+	switch {
+	case math.IsNaN(v):
+		b.sb.WriteString("(0.0/0)")
+		return true
+	case math.IsInf(v, +1):
+		b.sb.WriteString("(1.0/0)")
+		return true
+	case math.IsInf(v, -1):
+		b.sb.WriteString("(-1.0/0)")
+		return true
+	}
+	return false
 }
 
 // MapAt appends "<col>[?]" and binds key as a positional argument —
@@ -233,6 +261,21 @@ func (b *Builder) Expr(x chplan.Expr) error {
 		b.Arg(v.V)
 		return nil
 	case *chplan.LitFloat:
+		// Non-finite float64 values (±Inf / NaN) cannot ride the
+		// positional `?` parameter slot: clickhouse-go and chdb-go
+		// both render them via fmt.Sprint / strconv.AppendFloat,
+		// which emit the literal strings `+Inf` / `-Inf` / `NaN`
+		// (mixed case). Real CH 24.x parses the lowercase forms
+		// (`inf` / `-inf` / `nan`) but rejects mixed-case `Inf` /
+		// `NaN` as an unknown identifier, surfacing as the wire
+		// 502 cerberus sees on `quantile_over_time(-0.5, ...)`
+		// post-#322. Emit the value inline as a CH-portable
+		// division form (`1.0/0`, `-1.0/0`, `0.0/0`) so the
+		// driver never sees a non-finite arg and CH's parser
+		// never sees the case-sensitive identifier path.
+		if writeInlineNonFinite(b, v.V) {
+			return nil
+		}
 		b.Arg(v.V)
 		return nil
 	case *chplan.LitBool:
@@ -601,6 +644,13 @@ func InlineLit(v any) Frag {
 		case int:
 			b.sb.WriteString(strconv.FormatInt(int64(x), 10))
 		case float64:
+			// Mirror the LitFloat path in Builder.Expr: emit ±Inf
+			// / NaN as a CH-portable division form so the SQL the
+			// driver assembles never carries the mixed-case
+			// identifier strings real CH 24.x rejects.
+			if writeInlineNonFinite(b, x) {
+				break
+			}
 			b.sb.WriteString(strconv.FormatFloat(x, 'f', -1, 64))
 		case string:
 			b.sb.WriteByte('\'')

--- a/test/spec/promql/quantile_over_time_q_above_one.txtar
+++ b/test/spec/promql/quantile_over_time_q_above_one.txtar
@@ -24,12 +24,11 @@ INSERT INTO otel_metrics_gauge VALUES
   [{"endpoint": "/api/v1"}, "+Inf"]
 ]
 -- args --
-[0] float64 = +Inf
-[1] string = "latency_ms"
+[0] string = "latency_ms"
 -- chplan --
 Project [Attributes, +Inf AS Value]
   RangeWindow func=quantile_over_time range=5m0s step=0s ts=TimeUnix value=Value groupBy=[Attributes] scalars=[0.5] start=0001-01-01T00:00:00Z end=1970-01-01T00:08:20Z
     Filter predicate=(MetricName = "latency_ms")
       Scan(otel_metrics_gauge)
 -- sql --
-SELECT `Attributes`, ? AS `Value` FROM (SELECT `Attributes`, if(length(window_vals) > 0, arrayReduce('quantile(0.5)', window_vals), nan) AS `Value` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) >= toDateTime64('1970-01-01 00:08:20.000000000', 9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= toDateTime64('1970-01-01 00:08:20.000000000', 9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY `Attributes`))) WHERE length(`window_vals`) >= 1)
+SELECT `Attributes`, (1.0/0) AS `Value` FROM (SELECT `Attributes`, if(length(window_vals) > 0, arrayReduce('quantile(0.5)', window_vals), nan) AS `Value` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) >= toDateTime64('1970-01-01 00:08:20.000000000', 9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= toDateTime64('1970-01-01 00:08:20.000000000', 9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY `Attributes`))) WHERE length(`window_vals`) >= 1)

--- a/test/spec/promql/quantile_over_time_q_above_one_no_modifier.txtar
+++ b/test/spec/promql/quantile_over_time_q_above_one_no_modifier.txtar
@@ -1,0 +1,33 @@
+# Sibling to quantile_over_time_q_negative_no_modifier.txtar: covers
+# the phi > 1 path (`quantile_over_time(1.5, ...)`) the compat lane
+# expands across six ranges. Pre-fix the wire SQL carried `+Inf` as a
+# positional arg, which clickhouse-go rendered as the mixed-case
+# literal `+Inf` and real CH 24.x parsed as `+(Inf)` → unknown
+# identifier → 502. Post-fix the Project Value column is the inline
+# division `(1.0/0)` so the parser never sees a non-finite identifier.
+-- query.promql --
+quantile_over_time(1.5, latency_ms[1s])
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('latency_ms', map('endpoint', '/api/v1'), toDateTime64('2026-01-01 00:00:00.000000000', 9), 100.0),
+    ('latency_ms', map('endpoint', '/api/v1'), toDateTime64('2026-01-01 00:00:00.500000000', 9), 200.0),
+    ('latency_ms', map('endpoint', '/api/v1'), toDateTime64('2026-01-01 00:00:01.000000000', 9), 300.0);
+-- expected_rows --
+[
+  [{"endpoint": "/api/v1"}, "+Inf"]
+]
+-- args --
+[0] string = "latency_ms"
+-- chplan --
+Project [Attributes, +Inf AS Value]
+  RangeWindow func=quantile_over_time range=1s step=0s ts=TimeUnix value=Value groupBy=[Attributes] scalars=[0.5]
+    Filter predicate=(MetricName = "latency_ms")
+      Scan(otel_metrics_gauge)
+-- sql --
+SELECT `Attributes`, (1.0/0) AS `Value` FROM (SELECT `Attributes`, if(length(window_vals) > 0, arrayReduce('quantile(0.5)', window_vals), nan) AS `Value` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) >= now64(9) - toIntervalNanosecond(1000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY `Attributes`))) WHERE length(`window_vals`) >= 1)

--- a/test/spec/promql/quantile_over_time_q_negative.txtar
+++ b/test/spec/promql/quantile_over_time_q_negative.txtar
@@ -24,12 +24,11 @@ INSERT INTO otel_metrics_gauge VALUES
   [{"endpoint": "/api/v1"}, "-Inf"]
 ]
 -- args --
-[0] float64 = -Inf
-[1] string = "latency_ms"
+[0] string = "latency_ms"
 -- chplan --
 Project [Attributes, -Inf AS Value]
   RangeWindow func=quantile_over_time range=5m0s step=0s ts=TimeUnix value=Value groupBy=[Attributes] scalars=[0.5] start=0001-01-01T00:00:00Z end=1970-01-01T00:08:20Z
     Filter predicate=(MetricName = "latency_ms")
       Scan(otel_metrics_gauge)
 -- sql --
-SELECT `Attributes`, ? AS `Value` FROM (SELECT `Attributes`, if(length(window_vals) > 0, arrayReduce('quantile(0.5)', window_vals), nan) AS `Value` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) >= toDateTime64('1970-01-01 00:08:20.000000000', 9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= toDateTime64('1970-01-01 00:08:20.000000000', 9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY `Attributes`))) WHERE length(`window_vals`) >= 1)
+SELECT `Attributes`, (-1.0/0) AS `Value` FROM (SELECT `Attributes`, if(length(window_vals) > 0, arrayReduce('quantile(0.5)', window_vals), nan) AS `Value` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) >= toDateTime64('1970-01-01 00:08:20.000000000', 9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= toDateTime64('1970-01-01 00:08:20.000000000', 9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY `Attributes`))) WHERE length(`window_vals`) >= 1)

--- a/test/spec/promql/quantile_over_time_q_negative_no_modifier.txtar
+++ b/test/spec/promql/quantile_over_time_q_negative_no_modifier.txtar
@@ -1,0 +1,37 @@
+# Mirrors the compatibility-lane shape: no `@ end()` modifier (so the
+# windowed-array filter binds against `now64(9)` rather than a fixed
+# anchor) and a sub-second range. The compat lane hits this every time
+# it runs `quantile_over_time(-0.5, demo_memory_usage_bytes[1s])` and
+# its 5 longer-range siblings — every case was 502-ing in real CH
+# 24.x post-#322 because the lowerer's `-Inf` LitFloat was riding the
+# positional `?` slot, and clickhouse-go binds `math.Inf(-1)` as the
+# mixed-case literal `-Inf` which CH 24.x parses as `-(Inf)` →
+# `Unknown identifier 'Inf'`. The Builder.Expr fix emits ±Inf / NaN
+# inline as the CH-portable division form `(±1.0/0)` / `(0.0/0)`, so
+# the wire SQL never carries the case-sensitive identifier.
+-- query.promql --
+quantile_over_time(-0.5, latency_ms[1s])
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('latency_ms', map('endpoint', '/api/v1'), toDateTime64('2026-01-01 00:00:00.000000000', 9), 100.0),
+    ('latency_ms', map('endpoint', '/api/v1'), toDateTime64('2026-01-01 00:00:00.500000000', 9), 200.0),
+    ('latency_ms', map('endpoint', '/api/v1'), toDateTime64('2026-01-01 00:00:01.000000000', 9), 300.0);
+-- expected_rows --
+[
+  [{"endpoint": "/api/v1"}, "-Inf"]
+]
+-- args --
+[0] string = "latency_ms"
+-- chplan --
+Project [Attributes, -Inf AS Value]
+  RangeWindow func=quantile_over_time range=1s step=0s ts=TimeUnix value=Value groupBy=[Attributes] scalars=[0.5]
+    Filter predicate=(MetricName = "latency_ms")
+      Scan(otel_metrics_gauge)
+-- sql --
+SELECT `Attributes`, (-1.0/0) AS `Value` FROM (SELECT `Attributes`, if(length(window_vals) > 0, arrayReduce('quantile(0.5)', window_vals), nan) AS `Value` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) >= now64(9) - toIntervalNanosecond(1000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY `Attributes`))) WHERE length(`window_vals`) >= 1)

--- a/test/spec/promql/quantile_q_above_one.txtar
+++ b/test/spec/promql/quantile_q_above_one.txtar
@@ -23,19 +23,18 @@ INSERT INTO otel_metrics_gauge VALUES
   ["", {"job": "web"}, "2026-01-01T00:00:01Z", "+Inf"]
 ]
 -- args --
-[0] float64 = +Inf
-[1] string = ""
-[2] string = "job"
-[3] int64 = 9
-[4] string = "job"
-[5] float64 = 0.5
-[6] string = "up"
-[7] string = "2026-01-01 00:00:01.000000000"
-[8] int64 = 9
-[9] string = "2026-01-01 00:00:01.000000000"
-[10] int64 = 9
-[11] int64 = 300000000000
-[12] string = "job"
+[0] string = ""
+[1] string = "job"
+[2] int64 = 9
+[3] string = "job"
+[4] float64 = 0.5
+[5] string = "up"
+[6] string = "2026-01-01 00:00:01.000000000"
+[7] int64 = 9
+[8] string = "2026-01-01 00:00:01.000000000"
+[9] int64 = 9
+[10] int64 = 300000000000
+[11] string = "job"
 -- chplan --
 Project [MetricName, Attributes, TimeUnix, +Inf AS Value]
   Project ["" AS MetricName, mapWithoutEmpty(map("job", gkey_0)) AS Attributes, now64(9) AS TimeUnix, Value AS Value]
@@ -45,4 +44,4 @@ Project [MetricName, Attributes, TimeUnix, +Inf AS Value]
           Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
             Scan(otel_metrics_gauge)
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, ? AS `Value` FROM (SELECT ? AS `MetricName`, mapFilter((k, v) -> v != '', map(?, `gkey_0`)) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes`[?] AS `gkey_0`, quantile(?)(`Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY `Attributes`[?]))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, (1.0/0) AS `Value` FROM (SELECT ? AS `MetricName`, mapFilter((k, v) -> v != '', map(?, `gkey_0`)) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes`[?] AS `gkey_0`, quantile(?)(`Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY `Attributes`[?]))

--- a/test/spec/promql/quantile_q_negative.txtar
+++ b/test/spec/promql/quantile_q_negative.txtar
@@ -24,19 +24,18 @@ INSERT INTO otel_metrics_gauge VALUES
   ["", {"job": "web"}, "2026-01-01T00:00:01Z", "-Inf"]
 ]
 -- args --
-[0] float64 = -Inf
-[1] string = ""
-[2] string = "job"
-[3] int64 = 9
-[4] string = "job"
-[5] float64 = 0.5
-[6] string = "up"
-[7] string = "2026-01-01 00:00:01.000000000"
-[8] int64 = 9
-[9] string = "2026-01-01 00:00:01.000000000"
-[10] int64 = 9
-[11] int64 = 300000000000
-[12] string = "job"
+[0] string = ""
+[1] string = "job"
+[2] int64 = 9
+[3] string = "job"
+[4] float64 = 0.5
+[5] string = "up"
+[6] string = "2026-01-01 00:00:01.000000000"
+[7] int64 = 9
+[8] string = "2026-01-01 00:00:01.000000000"
+[9] int64 = 9
+[10] int64 = 300000000000
+[11] string = "job"
 -- chplan --
 Project [MetricName, Attributes, TimeUnix, -Inf AS Value]
   Project ["" AS MetricName, mapWithoutEmpty(map("job", gkey_0)) AS Attributes, now64(9) AS TimeUnix, Value AS Value]
@@ -46,4 +45,4 @@ Project [MetricName, Attributes, TimeUnix, -Inf AS Value]
           Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
             Scan(otel_metrics_gauge)
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, ? AS `Value` FROM (SELECT ? AS `MetricName`, mapFilter((k, v) -> v != '', map(?, `gkey_0`)) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes`[?] AS `gkey_0`, quantile(?)(`Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY `Attributes`[?]))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, (-1.0/0) AS `Value` FROM (SELECT ? AS `MetricName`, mapFilter((k, v) -> v != '', map(?, `gkey_0`)) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes`[?] AS `gkey_0`, quantile(?)(`Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY `Attributes`[?]))


### PR DESCRIPTION
## Summary

Closes the 20 residual `quantile_over_time(-0.5/1.5, demo_memory_usage_bytes[r])` 502s in the compatibility lane that survived #322.

## Root cause (wire-binding, not lowering)

#322's fold replaced the Value column with a `chplan.LitFloat{V: math.Inf(-1)}`. That literal rode the positional `?` parameter slot. Both `clickhouse-go` and `chdb-go` bind `math.Inf(±1)` / `math.NaN()` via `fmt.Sprint` / `strconv.AppendFloat` — producing mixed-case literals `+Inf` / `-Inf` / `NaN`. Real CH 24.x parses only lowercase `inf` / `-inf` / `nan` and rejects mixed-case `Inf` / `NaN` as an unknown identifier → 502 on the wire.

The `expected_rows` chDB roundtrip in #322 didn't catch it because chDB-go and real CH have different identifier-parsing edge cases — chDB happened to accept the mixed-case form.

## Fix

Emit non-finite floats inline as the CH-portable arithmetic forms `(1.0/0)` / `(-1.0/0)` / `(0.0/0)` from both `Builder.Expr`'s `*chplan.LitFloat` path AND `InlineLit`'s `float64` path. The driver never sees a non-finite arg; CH's parser never walks the case-sensitive identifier route.

## Reproducer fixtures

Two new TXTAR fixtures mirror the compat lane's exact failing shape (no `@ end()` modifier, sub-second range):
- `quantile_over_time_q_negative_no_modifier.txtar`
- `quantile_over_time_q_above_one_no_modifier.txtar`

## Test plan

- [x] `go test ./internal/chsql/ ./internal/promql/` — pass
- [x] `go test -tags chdb ./test/spec/promql/ -run "TestRoundTripChDB/quantile"` — 23/23 pass
- [x] Existing quantile fixtures' SQL goldens updated to reflect the new inline literal shape

7 files, +150 / -34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>