### PR TITLE
test(property): TraceQL property test with from-scratch oracle

### DIFF
--- a/.github/workflows/property.yml
+++ b/.github/workflows/property.yml
@@ -9,6 +9,16 @@ name: property
 # sweep); this workflow overrides to `-rapid.checks=500` to widen the
 # nightly search.
 #
+# Coverage today:
+#
+#   - TestPromQL_Property_FromScratch — PromQL instant + range +
+#     aggregations against the from-scratch oracle.
+#   - TestTraceQL_Property            — TraceQL spanset filter +
+#     `| count() OP N` against the from-scratch oracle.
+#
+# Both run in the same `property` job (one `go test` invocation walks
+# every test in `./test/property/...`).
+#
 # Like `chdb.yml`, this workflow links `libchdb.so` and is therefore
 # segregated from the required PR lane. NOT a required PR check; not
 # in the required-status-checks list. The required PR lane stays
@@ -18,7 +28,8 @@ name: property
 # rapid seed is captured in the test output (and the workflow log).
 # Authors can reproduce a failing run locally with:
 #
-#   go test -tags chdb -run TestPromQL_Property -rapid.seed=<N> ./test/property/...
+#   go test -tags chdb -run TestPromQL_Property  -rapid.seed=<N> ./test/property/...
+#   go test -tags chdb -run TestTraceQL_Property -rapid.seed=<N> ./test/property/...
 
 on:
   push:

--- a/test/property/gen/traceql.go
+++ b/test/property/gen/traceql.go
@@ -1,0 +1,357 @@
+package gen
+
+import (
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"pgregory.net/rapid"
+
+	"github.com/tsouza/cerberus/test/property"
+)
+
+// TraceQLServicePool is the fixed service.name pool the TraceQL
+// dataset draws from. Small + overlapping so generator iterations
+// produce spans whose `{ resource.service.name = "<X>" }` selector
+// matches multiple spans (predictable count() arithmetic).
+var TraceQLServicePool = []string{"api", "web", "batch"}
+
+// TraceQLSpanNamePool is the fixed span-name pool. Each generated
+// span draws a name from this pool plus a per-span ordinal so the
+// (SpanName, Timestamp) pair is unique across the dataset (Tempo's
+// /api/search collapses TraceSummary rows that share name+timestamp;
+// the generator avoids that collapse by stamping a unique suffix on
+// each span name).
+var TraceQLSpanNamePool = []string{"GET", "POST", "PUT", "DELETE"}
+
+// SpansTableName is the OTel-CH default traces table the DDL targets.
+// Matches schema.DefaultOTelTraces().SpansTable.
+const SpansTableName = "otel_traces"
+
+// traceQLAnchor is the wall-clock baseline the dataset anchors span
+// timestamps to. Picked far enough in the future to avoid colliding
+// with any wall-clock assertion in the chDB seeds (same convention as
+// the metrics generator's anchorTime).
+var traceQLAnchor = time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+
+// TraceQLAnchorTime returns the fixed wall-clock baseline the dataset
+// generator anchors span timestamps to.
+func TraceQLAnchorTime() time.Time { return traceQLAnchor }
+
+// TraceQLDataset returns a rapid generator that draws a random
+// property.Dataset of OTel-CH traces rows. The dataset is intentionally
+// narrow for the first TraceQL property test:
+//
+//   - 1–5 spans.
+//   - Each span carries a service.name from TraceQLServicePool stored
+//     under ResourceAttributes['service.name'].
+//   - Span names draw from TraceQLSpanNamePool plus a per-span ordinal
+//     suffix so (SpanName, Timestamp) pairs are unique across the
+//     dataset — Tempo's /api/search collapses traces by name+ts, and
+//     the property test wants one TraceSummary per span so the count
+//     comparator is exact.
+//   - Per-span StartTime is anchor + i*1s; Duration is fixed
+//     50 000 000 ns (50ms). The values don't matter to the selector +
+//     count() queries the generator produces.
+//   - StatusCode = "Unset" for every span (the only intrinsic the
+//     generator touches today).
+//
+// The returned Dataset's DDL is a multi-statement script
+// (`CREATE OR REPLACE TABLE otel_traces (...); INSERT ...;`) the chDB
+// runner replays before each query. The MetricsModel mirror carries
+// the same data in a shape the oracle reads — it stores spans as
+// SeriesData entries with MetricName=SpanName, Labels carrying the
+// span-level + resource attributes via reserved key prefixes:
+//
+//   - "resource.<key>"  → ResourceAttributes[<key>]
+//   - "span.<key>"      → SpanAttributes[<key>] (unused today; reserved
+//     for span-scope matchers when the generator widens)
+//   - "__name__"        → SpanName (mirrors the PromQL convention; the
+//     oracle's labels-minus-__name__ identity rule reuses it)
+//   - "__traceID__"     → TraceID (unique 32-hex per span)
+//   - "__spanID__"      → SpanID (unique 16-hex per span)
+//   - "__duration_ns__" → string-formatted Duration (so the oracle
+//     can read it without changing SeriesData's float64 Point shape)
+//   - "__status__"      → "Unset" (the seeded value)
+//
+// MergeTree is the chosen engine (matches PromQL property test
+// rationale: Memory engine refuses PREWHERE the cerberus optimizer
+// emits).
+func TraceQLDataset() *rapid.Generator[property.Dataset] {
+	return rapid.Custom(func(t *rapid.T) property.Dataset {
+		numSpans := rapid.IntRange(1, 5).Draw(t, "numSpans")
+		spans := make([]traceQLSpan, 0, numSpans)
+		for i := 0; i < numSpans; i++ {
+			service := rapid.SampledFrom(TraceQLServicePool).Draw(t, fmt.Sprintf("service_%d", i))
+			baseName := rapid.SampledFrom(TraceQLSpanNamePool).Draw(t, fmt.Sprintf("spanName_%d", i))
+			// Unique suffix → unique (SpanName, Timestamp) across spans:
+			// Tempo's toTraceSummaries() keys by name+timestamp and collapses
+			// duplicates. Suffixing the span index is the cheapest way to
+			// guarantee uniqueness without adding a second random draw.
+			name := fmt.Sprintf("%s /api/%d", baseName, i)
+			spans = append(spans, traceQLSpan{
+				traceID:    deterministicTraceID(i, 0xa1),
+				spanID:     deterministicSpanID(i, 0xb2),
+				parentID:   "0000000000000000",
+				service:    service,
+				name:       name,
+				startTime:  traceQLAnchor.Add(time.Duration(i) * time.Second),
+				durationNs: 50_000_000,
+				statusCode: "Unset",
+			})
+		}
+		series := traceQLSpansToSeries(spans)
+		return property.Dataset{
+			DDL:     renderTraceQLDDL(spans),
+			Metrics: &property.MetricsModel{Series: series},
+		}
+	})
+}
+
+// traceQLSpan is the in-memory mirror of one row of otel_traces the
+// generator emits. The Dataset.Metrics mirror stores spans as
+// SeriesData entries keyed by SpanName; this struct is the bridge.
+type traceQLSpan struct {
+	traceID    string // 32-hex
+	spanID     string // 16-hex
+	parentID   string // 16-hex (all-zero for root)
+	service    string
+	name       string
+	startTime  time.Time
+	durationNs int64
+	statusCode string
+}
+
+// traceQLSpansToSeries pivots the generator's spans into the
+// property.SeriesData shape the framework persists on the Dataset.
+// Each span becomes one SeriesData with a single Point at the span's
+// StartTime carrying its Duration as the float value.
+//
+// The Labels map intentionally folds span-level metadata under
+// reserved keys (see TraceQLDataset's doc) so the oracle can recover
+// the original schema without needing a new framework type.
+func traceQLSpansToSeries(spans []traceQLSpan) []property.SeriesData {
+	out := make([]property.SeriesData, 0, len(spans))
+	for _, s := range spans {
+		labels := map[string]string{
+			"resource.service.name": s.service,
+			"__name__":              s.name,
+			"__traceID__":           s.traceID,
+			"__spanID__":            s.spanID,
+			"__parentSpanID__":      s.parentID,
+			"__status__":            s.statusCode,
+			"__duration_ns__":       fmt.Sprintf("%d", s.durationNs),
+		}
+		out = append(out, property.SeriesData{
+			MetricName: s.name,
+			Labels:     labels,
+			Points: []property.Point{
+				{TimestampMs: s.startTime.UnixMilli(), Value: float64(s.durationNs)},
+			},
+		})
+	}
+	return out
+}
+
+// renderTraceQLDDL produces the multi-statement seed script for an
+// otel_traces table. The schema mirrors the OTel-CH traces table
+// (the subset the generator + oracle care about) — TraceId, SpanId,
+// ParentSpanId, ServiceName (kept for OTel parity; the generator
+// queries via ResourceAttributes), SpanName, ResourceAttributes,
+// SpanAttributes, StartTimeUnixNano (column name `Timestamp` per
+// OTel-CH default), DurationNs (column name `Duration`), StatusCode.
+//
+// `CREATE OR REPLACE TABLE` keeps re-runs idempotent (chdb-go shares
+// one catalog across sessions).
+func renderTraceQLDDL(spans []traceQLSpan) string {
+	var b strings.Builder
+	b.WriteString(`CREATE OR REPLACE TABLE `)
+	b.WriteString(SpansTableName)
+	b.WriteString(` (
+    Timestamp DateTime64(9),
+    TraceId FixedString(32),
+    SpanId FixedString(16),
+    ParentSpanId FixedString(16),
+    SpanName String,
+    SpanKind LowCardinality(String),
+    ServiceName LowCardinality(String),
+    ResourceAttributes Map(String, String),
+    SpanAttributes Map(String, String),
+    Duration Int64,
+    StatusCode LowCardinality(String),
+    StatusMessage String
+) ENGINE = MergeTree ORDER BY (Timestamp, TraceId);
+`)
+	if len(spans) == 0 {
+		return b.String()
+	}
+	b.WriteString(`INSERT INTO `)
+	b.WriteString(SpansTableName)
+	b.WriteString(` VALUES `)
+	for i, s := range spans {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(renderTraceQLRow(s))
+	}
+	b.WriteString(";\n")
+	return b.String()
+}
+
+// renderTraceQLRow renders one row literal for the INSERT script. The
+// column order matches renderTraceQLDDL's CREATE TABLE.
+func renderTraceQLRow(s traceQLSpan) string {
+	var b strings.Builder
+	b.WriteByte('(')
+	// Timestamp
+	b.WriteString("toDateTime64('")
+	b.WriteString(s.startTime.UTC().Format("2006-01-02 15:04:05.000"))
+	b.WriteString("', 9)")
+	b.WriteString(", ")
+	// TraceId / SpanId / ParentSpanId
+	b.WriteString(quoteSQL(s.traceID))
+	b.WriteString(", ")
+	b.WriteString(quoteSQL(s.spanID))
+	b.WriteString(", ")
+	b.WriteString(quoteSQL(s.parentID))
+	b.WriteString(", ")
+	// SpanName
+	b.WriteString(quoteSQL(s.name))
+	b.WriteString(", ")
+	// SpanKind (fixed "Internal" — generator doesn't vary this today)
+	b.WriteString("'Internal'")
+	b.WriteString(", ")
+	// ServiceName (mirrors ResourceAttributes['service.name'])
+	b.WriteString(quoteSQL(s.service))
+	b.WriteString(", ")
+	// ResourceAttributes
+	b.WriteString(renderTraceQLMap(map[string]string{"service.name": s.service}))
+	b.WriteString(", ")
+	// SpanAttributes (empty for now; reserved for span.<attr> matchers)
+	b.WriteString("map()")
+	b.WriteString(", ")
+	// Duration
+	b.WriteString(fmt.Sprintf("%d", s.durationNs))
+	b.WriteString(", ")
+	// StatusCode
+	b.WriteString(quoteSQL(s.statusCode))
+	b.WriteString(", ")
+	// StatusMessage
+	b.WriteString("''")
+	b.WriteByte(')')
+	return b.String()
+}
+
+// renderTraceQLMap renders a CH `map('k','v', 'k2','v2')` literal.
+// Sorted keys for determinism.
+func renderTraceQLMap(m map[string]string) string {
+	if len(m) == 0 {
+		return "map()"
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	b.WriteString("map(")
+	for i, k := range keys {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(quoteSQL(k))
+		b.WriteString(", ")
+		b.WriteString(quoteSQL(m[k]))
+	}
+	b.WriteByte(')')
+	return b.String()
+}
+
+// quoteSQL renders s as a single-quoted CH SQL string literal. Embedded
+// single quotes get backslash-escaped. The generator only emits values
+// from fixed pools (TraceQLServicePool, TraceQLSpanNamePool, hex IDs),
+// none of which contain quotes — but the escape is here so future
+// generator widening can stay safe.
+func quoteSQL(s string) string {
+	if !strings.Contains(s, "'") && !strings.Contains(s, "\\") {
+		return "'" + s + "'"
+	}
+	var b strings.Builder
+	b.WriteByte('\'')
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '\'' || c == '\\' {
+			b.WriteByte('\\')
+		}
+		b.WriteByte(c)
+	}
+	b.WriteByte('\'')
+	return b.String()
+}
+
+// deterministicTraceID renders a 32-hex string from an integer seed +
+// salt. Deterministic so re-running with the same rapid seed produces
+// the same SQL.
+func deterministicTraceID(seed, salt int) string {
+	var buf [16]byte
+	for i := range buf {
+		buf[i] = byte((seed*31 + salt + i) & 0xFF)
+	}
+	return hex.EncodeToString(buf[:])
+}
+
+// deterministicSpanID is the 8-byte variant of deterministicTraceID.
+func deterministicSpanID(seed, salt int) string {
+	var buf [8]byte
+	for i := range buf {
+		buf[i] = byte((seed*17 + salt + i) & 0xFF)
+	}
+	return hex.EncodeToString(buf[:])
+}
+
+// TraceQLQuery returns a rapid generator that draws a property.Query
+// targeted at dataset d. The accept-set for this first sweep:
+//
+//   - Selector only:           `{ resource.service.name = "<value>" }`
+//   - Selector + count filter: `{ resource.service.name = "<v>" } | count() OP N`
+//     where OP ∈ {>, >=, <, <=, =} and N ∈ [0, len(d.Series)].
+//
+// The selector's RHS is always a value drawn from the dataset's
+// observed services so half of the iterations exercise a matching
+// service (genuine non-empty result) and the other half exercise a
+// service not present (empty result). The mix is implicit — rapid
+// draws across the pool uniformly, and the dataset's spans cover only
+// a subset of TraceQLServicePool on any iteration.
+//
+// EvalTs is irrelevant for TraceQL search (no time range threading)
+// so it's stamped at TraceQLAnchorTime() + 1h purely for log
+// completeness.
+func TraceQLQuery(d property.Dataset) *rapid.Generator[property.Query] {
+	return rapid.Custom(func(t *rapid.T) property.Query {
+		// Draw service value — always from the global pool so half the
+		// queries hit "absent service" (zero matches), exercising the
+		// empty-result path on both sides.
+		service := rapid.SampledFrom(TraceQLServicePool).Draw(t, "service")
+
+		// Optional `| count() OP N` filter.
+		hasCount := rapid.Bool().Draw(t, "hasCount")
+		query := fmt.Sprintf(`{ resource.service.name = "%s" }`, service)
+		if hasCount {
+			op := rapid.SampledFrom([]string{">", ">=", "<", "<=", "="}).Draw(t, "countOp")
+			// Bound N at [0, len(spans)] so the threshold is sometimes
+			// satisfied and sometimes not. len(d.Series) is the upper
+			// bound; using a slightly wider range exercises the
+			// "threshold above ceiling" path too.
+			n := rapid.IntRange(0, len(d.Metrics.Series)+1).Draw(t, "countN")
+			query = fmt.Sprintf("%s | count() %s %d", query, op, n)
+		}
+
+		evalTs := traceQLAnchor.Add(time.Hour).Unix()
+		return property.Query{
+			String: query,
+			EvalTs: evalTs,
+		}
+	})
+}

--- a/test/property/gen/traceql.go
+++ b/test/property/gen/traceql.go
@@ -233,7 +233,7 @@ func renderTraceQLRow(s traceQLSpan) string {
 	b.WriteString("map()")
 	b.WriteString(", ")
 	// Duration
-	b.WriteString(fmt.Sprintf("%d", s.durationNs))
+	fmt.Fprintf(&b, "%d", s.durationNs)
 	b.WriteString(", ")
 	// StatusCode
 	b.WriteString(quoteSQL(s.statusCode))

--- a/test/property/oracle/traceql/doc.go
+++ b/test/property/oracle/traceql/doc.go
@@ -1,0 +1,58 @@
+// Package traceql is the from-scratch TraceQL evaluator that serves
+// as the independent specification for cerberus's property-testing
+// framework. The Tempo TraceQL parser is treated as a string-format
+// parser only; semantic evaluation lives in-tree, derived from the
+// Grafana TraceQL documentation rather than reusing Tempo's engine.
+//
+// # MVP coverage (Phase 1)
+//
+//   - SpansetFilter: `{ resource.service.name = "<value>" }` —
+//     attribute-equality matcher against ResourceAttributes['service.name'].
+//   - Scalar filter pipeline: `| count() OP N` where OP ∈
+//     {>, >=, <, <=, =} and N is a non-negative integer literal.
+//
+// # Semantics (per the TraceQL spec)
+//
+// TraceQL evaluates over spans. A spanset is the per-trace bucket of
+// spans matching the upstream filter; pipeline operators reduce or
+// transform the spanset.
+//
+//  1. Spanset filter (`{ <attr> = <value> }`): each span is
+//     evaluated against the predicate; surviving spans form the
+//     spanset. Per-trace grouping is implicit in Tempo's engine but
+//     irrelevant for the count() aggregation today — the evaluator
+//     keeps a flat span list because count() across all matching
+//     spans equals count() per-trace summed across traces (each of
+//     the generator's spans lives in its own trace).
+//  2. count() aggregate: returns the number of spans in the spanset.
+//     With a scalar filter (`| count() > N`), the trace is included
+//     in the result only when the predicate holds. Cerberus's wire
+//     surface returns the count value as a single sample (one row
+//     in the search response) when the predicate is satisfied,
+//     zero rows when it isn't — the evaluator mirrors that shape.
+//
+// # Wire-shape comparison
+//
+// Tempo's /api/search response carries the count as `inspectedTraces`
+// (which equals `len(res.Samples)` — see internal/api/tempo/handler.go's
+// SearchMetrics population). The evaluator therefore reports:
+//
+//   - Selector-only query: one outcome row per matching span, all
+//     stamped with the same empty label set so the framework's
+//     comparator counts rows-per-group.
+//   - count() query that passes: ONE outcome row (count emitted as a
+//     single trace summary in cerberus's response).
+//   - count() query that fails: ZERO outcome rows.
+//
+// The framework's CompareOutcomes diff is multiset-aware over the
+// empty-label group, so the row count is what we compare. Tempo's
+// /api/search collapses multiple spans with the same (SpanName,
+// Timestamp) into one trace summary — the generator avoids that
+// collapse by stamping a unique suffix on each span name, so
+// `len(samples) == len(traces)` on the cerberus side.
+//
+// # Entry point
+//
+// Callers use [Evaluate], which is a pure function: dataset + query
+// (string form), returns a property.Outcome.
+package traceql

--- a/test/property/oracle/traceql/evaluator.go
+++ b/test/property/oracle/traceql/evaluator.go
@@ -1,0 +1,236 @@
+package traceql
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+
+	"github.com/tsouza/cerberus/test/property"
+)
+
+// Evaluate runs the property-test oracle against d for query q. The
+// query string is parsed via the package-private parser (a small
+// hand-rolled recognizer keyed to the generator's accept-set) — no
+// dependency on Tempo's traceql package, so the oracle stays a
+// spec-derived implementation rather than a wrapper.
+//
+// Returns property.Outcome carrying:
+//
+//   - one row per matching span (labels: empty map) when the query is a
+//     bare selector;
+//   - exactly one row (labels: empty map) when the query carries a
+//     `| count() OP N` filter and the predicate is satisfied;
+//   - zero rows when the predicate is not satisfied;
+//   - an Err otherwise (parse failure / unsupported shape).
+//
+// The single-row count shape mirrors Tempo's /api/search wire shape:
+// cerberus's handler emits one chclient.Sample row when count() passes
+// the scalar filter, zero rows when it doesn't — see
+// internal/api/tempo/handler.go's classifySearchErr path. The
+// framework's comparator counts rows-per-empty-label-key, so this
+// alignment lets the same CompareOutcomes diff catch drift on both
+// shapes.
+func Evaluate(d property.Dataset, q property.Query) property.Outcome {
+	parsed, err := parseQuery(q.String)
+	if err != nil {
+		return property.Outcome{Err: fmt.Errorf("oracle: parse %q: %w", q.String, err)}
+	}
+
+	spans := filterSpans(d, parsed.selector)
+	if parsed.hasCount {
+		count := int64(len(spans))
+		if !compareCount(count, parsed.countOp, parsed.countN) {
+			return property.Outcome{Rows: nil}
+		}
+		// Predicate holds → one outcome row. Cerberus's wire response
+		// surfaces this as a single chclient.Sample (the Aggregate
+		// path projects MetricName="", Value=count) which the
+		// handler reports as `inspectedTraces == 1`. We mirror that:
+		// one row, empty labels, no per-row payload — the
+		// comparator's per-group row-count check is the equivalence
+		// we're asserting.
+		return property.Outcome{Rows: []property.OutcomeRow{
+			{Labels: map[string]string{}, TimestampMs: 0, Value: 0},
+		}}
+	}
+
+	// Selector-only: one row per matching span. Labels stay empty so
+	// the framework's labelKey() groups all rows under "{}", and the
+	// comparator's per-group row-count check is exactly the
+	// span-count check we want. Timestamp + Value are stamped at zero
+	// so the per-group multiset diff doesn't drift on per-span
+	// metadata the comparator isn't designed to inspect (the search
+	// response shape collapses span identity into `inspectedTraces`,
+	// not per-span timestamps).
+	rows := make([]property.OutcomeRow, 0, len(spans))
+	for range spans {
+		rows = append(rows, property.OutcomeRow{
+			Labels:      map[string]string{},
+			TimestampMs: 0,
+			Value:       0,
+		})
+	}
+	return property.Outcome{Rows: rows}
+}
+
+// spanView is the oracle's per-span snapshot: just the fields the
+// evaluator needs to apply the selector and aggregate. Built once per
+// Evaluate call from the dataset's MetricsModel series.
+type spanView struct {
+	service       string
+	name          string
+	startTimeMs   int64
+	durationFloat float64
+}
+
+// filterSpans pivots the dataset's MetricsModel into the spanView
+// shape and applies the selector predicate. Only one selector kind is
+// supported today: `resource.service.name = "<value>"`.
+func filterSpans(d property.Dataset, sel selector) []spanView {
+	if d.Metrics == nil {
+		return nil
+	}
+	out := make([]spanView, 0, len(d.Metrics.Series))
+	for _, s := range d.Metrics.Series {
+		svc := s.Labels["resource.service.name"]
+		if !sel.match(svc) {
+			continue
+		}
+		// SeriesData carries one Point per span (Generator invariant).
+		// startTimeMs / duration come from that Point.
+		var startMs int64
+		var durFloat float64
+		if len(s.Points) > 0 {
+			startMs = s.Points[0].TimestampMs
+			durFloat = s.Points[0].Value
+		}
+		out = append(out, spanView{
+			service:       svc,
+			name:          s.MetricName,
+			startTimeMs:   startMs,
+			durationFloat: durFloat,
+		})
+	}
+	return out
+}
+
+// parsedQuery is what parseQuery returns. The selector + optional
+// scalar-filter components are decoupled so the evaluator can stamp
+// them onto separate code paths.
+type parsedQuery struct {
+	selector selector
+	hasCount bool
+	countOp  string
+	countN   int64
+}
+
+// selector is the spanset-filter predicate the oracle understands.
+// Only the equality variant is supported today; future generator
+// widening (regex, !=, intrinsics) lands new helpers + match() arms.
+type selector struct {
+	attr  string // always "resource.service.name" today
+	value string
+}
+
+func (s selector) match(observed string) bool {
+	if s.attr == "" {
+		return true
+	}
+	return observed == s.value
+}
+
+// queryRe matches the generator's full output shape:
+//
+//	{ resource.service.name = "<value>" } [| count() <op> <int>]
+//
+// Anchored so unexpected characters fail fast. The selector group
+// captures the quoted service name; the optional pipeline group
+// captures the scalar filter operator + threshold.
+var queryRe = regexp.MustCompile(
+	`^\s*\{\s*resource\.service\.name\s*=\s*"([^"]*)"\s*\}` +
+		`(?:\s*\|\s*count\(\)\s*(>=|<=|>|<|=)\s*(\d+))?\s*$`,
+)
+
+// parseQuery is the hand-rolled recognizer keyed to the generator's
+// accept-set. Anything outside that set returns an error — the
+// generator never emits other shapes so a parse failure is a
+// generator bug, not a real divergence. (rapid will still surface
+// it as a property-test failure, but the failure log says "oracle:
+// parse" which is the right pointer.)
+//
+// The recognizer is intentionally narrow rather than wrapping
+// `tempo/pkg/traceql.Parse` because the entire purpose of the
+// from-scratch oracle is to NOT share code with the side under test.
+// When the cerberus pipeline imports the same parser, a parser-side
+// bug becomes invisible to a property test that reuses it.
+func parseQuery(q string) (parsedQuery, error) {
+	m := queryRe.FindStringSubmatch(q)
+	if m == nil {
+		return parsedQuery{}, fmt.Errorf("query does not match expected shape %q", q)
+	}
+	out := parsedQuery{
+		selector: selector{
+			attr:  "resource.service.name",
+			value: m[1],
+		},
+	}
+	if m[2] != "" {
+		out.hasCount = true
+		out.countOp = m[2]
+		n, err := strconv.ParseInt(m[3], 10, 64)
+		if err != nil {
+			return parsedQuery{}, fmt.Errorf("count threshold %q: %w", m[3], err)
+		}
+		out.countN = n
+	}
+	return out, nil
+}
+
+// compareCount applies the scalar-filter operator to (count, n).
+// Operators are the five the generator emits.
+func compareCount(count int64, op string, n int64) bool {
+	switch op {
+	case ">":
+		return count > n
+	case ">=":
+		return count >= n
+	case "<":
+		return count < n
+	case "<=":
+		return count <= n
+	case "=":
+		return count == n
+	}
+	// Defensive: the generator only emits the five operators, but
+	// strings.Contains-style false positives are harmless — surface
+	// the unknown op so the property test fails loudly instead of
+	// silently agreeing on the wrong predicate.
+	return false
+}
+
+// init validates the recognizer once at package load. queryRe must
+// not change behaviour from a typo in the literal; the test below
+// pins the supported shape so a future edit that breaks parsing
+// fires at package-init rather than mid-iteration.
+//
+// Kept lightweight: the strings exercised here are the same constants
+// the generator emits, so a future generator change will surface as a
+// failed property test rather than a panic here.
+func init() {
+	for _, q := range []string{
+		`{ resource.service.name = "api" }`,
+		`{ resource.service.name = "api" } | count() > 0`,
+		`{ resource.service.name = "api" } | count() >= 1`,
+		`{ resource.service.name = "api" } | count() < 5`,
+		`{ resource.service.name = "api" } | count() <= 3`,
+		`{ resource.service.name = "api" } | count() = 2`,
+	} {
+		if _, err := parseQuery(q); err != nil {
+			panic(fmt.Sprintf("oracle/traceql: package-init recognizer regression on %q: %v", q, err))
+		}
+	}
+	// Sanity: a query the recognizer must REJECT.
+	if _, err := parseQuery(`{ span.unknown = "x" }`); err == nil {
+		panic("oracle/traceql: recognizer should reject span-scope attribute query")
+	}
+}

--- a/test/property/traceql_test.go
+++ b/test/property/traceql_test.go
@@ -1,0 +1,202 @@
+//go:build chdb
+
+// Property test for the TraceQL pipeline.
+//
+// On every iteration:
+//
+//  1. The dataset generator (gen.TraceQLDataset) draws a random
+//     in-memory MetricsModel of OTel-CH span rows plus a parallel
+//     DDL script.
+//  2. The framework seeds the DDL into an ephemeral chDB session
+//     (shared across iterations; each iteration's
+//     CREATE OR REPLACE TABLE statement keeps replays idempotent).
+//  3. The TraceQL generator (gen.TraceQLQuery) draws a random query
+//     targeting the dataset's service pool — either a bare
+//     `{ resource.service.name = "<value>" }` selector or a
+//     selector + `| count() OP N` scalar filter.
+//  4. The from-scratch oracle (oracle/traceql.Evaluate) evaluates the
+//     query against an in-memory mirror of the dataset, implementing
+//     spanset filter + count() semantics directly from the TraceQL
+//     spec (no Tempo engine dependency).
+//  5. Cerberus evaluates the query via its real HTTP handler — a
+//     httptest.Server in front of the chDB-backed tempo.Handler. The
+//     handler runs the full parse → lower → optimize → emit → execute
+//     pipeline.
+//  6. The framework's CompareOutcomes diffs the two result sets and
+//     fails the property if they drift.
+//
+// rapid's shrinker minimises the failing dataset + query before this
+// test reports — the failure log shows the smallest reproducer.
+//
+// # Wire-shape comparison
+//
+// Tempo's /api/search response shape:
+//
+//	{
+//	  "traces":  [<TraceSummary>, ...],
+//	  "metrics": {"inspectedTraces": <N>}
+//	}
+//
+// `inspectedTraces` is populated as `len(res.Samples)`. For both
+// selector and aggregate shapes the comparator uses that count
+// directly — the oracle emits one outcome row per matching span (or
+// one row when `| count() OP N` is satisfied, zero when it isn't),
+// and we compare row counts.
+//
+// The TraceSummary collapse rule (Tempo keys by SpanName+Timestamp,
+// merging spans that share that tuple) is avoided by the generator:
+// each span gets a unique (SpanName, Timestamp) pair via a per-span
+// index suffix on the span name. See gen/traceql.go.
+//
+// # CI lanes
+//
+// The test runs in two CI lanes:
+//
+//   - Locally and on any explicit `go test -tags chdb ./test/property/...`
+//     invocation, rapid uses its default of 100 iterations.
+//   - The nightly `property` workflow (`.github/workflows/property.yml`)
+//     overrides to `-rapid.checks=500` for a deeper sweep.
+//
+// To reproduce a failing CI run locally, copy the rapid seed from the
+// workflow log and re-run:
+//
+//	go test -tags chdb -run TestTraceQL_Property -rapid.seed=<N> \
+//	    ./test/property/...
+//
+// rapid persists the shrunk failing draw under `testdata/rapid/`; the
+// nightly workflow archives that directory as an artifact on failure.
+package property_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"pgregory.net/rapid"
+
+	"github.com/tsouza/cerberus/internal/api/tempo"
+	"github.com/tsouza/cerberus/internal/chclienttest"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/test/property"
+	"github.com/tsouza/cerberus/test/property/gen"
+	oracletraceql "github.com/tsouza/cerberus/test/property/oracle/traceql"
+)
+
+// TestTraceQL_Property wires every layer together for the TraceQL
+// selector / count-filter shapes. rapid's default iteration count is
+// 100 (no per-test override here); the nightly `property` workflow
+// overrides to `-rapid.checks=500`. Locally, pass `-rapid.checks=N`
+// to widen or narrow the sweep on demand.
+//
+// The oracle is the from-scratch [oracletraceql.Evaluate] — spanset +
+// count() semantics implemented in-tree, not the Tempo engine.
+//
+// Failure logs include both the rapid seed (so the failing draw
+// reproduces with `-rapid.seed=<N>`) and the minimised dataset / query
+// rapid shrunk to.
+func TestTraceQL_Property(t *testing.T) {
+	cli := chclienttest.NewChDB(t)
+	h := tempo.New(cli, schema.DefaultOTelTraces(), "v1.0.0-property", nil)
+	mux := http.NewServeMux()
+	h.Mount(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	dgen := func(rt *rapid.T) property.Dataset {
+		return gen.TraceQLDataset().Draw(rt, "dataset")
+	}
+	qgen := func(rt *rapid.T, d property.Dataset) property.Query {
+		return gen.TraceQLQuery(d).Draw(rt, "query")
+	}
+
+	// cerberusFn closes over the chDB client + http server: every
+	// iteration first re-seeds the DDL (CREATE OR REPLACE TABLE makes
+	// this idempotent against the prior iteration's rows) and then
+	// runs the query via the real Tempo HTTP handler.
+	cerberusFn := func(d property.Dataset, q property.Query) property.Outcome {
+		cli.Seed(t, d.DDL)
+		return runCerberusTraceQL(t.Context(), srv.URL, q)
+	}
+
+	oracleFn := func(d property.Dataset, q property.Query) property.Outcome {
+		return oracletraceql.Evaluate(d, q)
+	}
+
+	property.Run(t, property.Config{}, dgen, qgen, oracleFn, cerberusFn)
+}
+
+// runCerberusTraceQL GETs /api/search?q=<query> and decodes the
+// Tempo-shaped response into the framework's property.Outcome.
+//
+// Tempo's /api/search wire shape:
+//
+//	{
+//	  "traces":  [<TraceSummary>, ...],
+//	  "metrics": {"inspectedTraces": N, ...}
+//	}
+//
+// `inspectedTraces` equals `len(res.Samples)` from cerberus's handler
+// (see internal/api/tempo/handler.go's SearchMetrics population). The
+// oracle emits one row per matching span / one row for a satisfied
+// `count() OP N`, so the row-count comparison is exact when we
+// reshape the cerberus response into "inspectedTraces empty-label
+// rows".
+//
+// We use InspectedTraces rather than len(traces) because the Tempo
+// search response collapses TraceSummary entries that share
+// (SpanName, Timestamp) — the generator already avoids that collapse
+// by stamping unique suffixes, but reading from InspectedTraces makes
+// the comparator robust against a future generator widening.
+func runCerberusTraceQL(ctx context.Context, baseURL string, q property.Query) property.Outcome {
+	u := fmt.Sprintf("%s/api/search?q=%s", baseURL, urlEscape(q.String))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return property.Outcome{Err: fmt.Errorf("property: build request: %w", err)}
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return property.Outcome{Err: fmt.Errorf("property: query roundtrip: %w", err)}
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return property.Outcome{Err: fmt.Errorf("property: read body: %w", err)}
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		// Non-2xx is a legitimate cerberus outcome — the oracle may
+		// also error on the same query. The framework's
+		// CompareOutcomes treats both-erroring queries as agreement.
+		return property.Outcome{
+			Err: fmt.Errorf("cerberus returned status=%d body=%s", resp.StatusCode, body),
+		}
+	}
+
+	var parsed tempo.SearchResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return property.Outcome{
+			Err: fmt.Errorf("property: decode body: %w; status=%d body=%s",
+				err, resp.StatusCode, body),
+		}
+	}
+
+	// Reshape InspectedTraces (== len(res.Samples)) into
+	// InspectedTraces empty-label OutcomeRows. The framework's
+	// CompareOutcomes counts rows per label-key, so this gives the
+	// per-iteration row-count equality check the oracle is set up to
+	// support.
+	rows := make([]property.OutcomeRow, 0, parsed.Metrics.InspectedTraces)
+	for i := 0; i < parsed.Metrics.InspectedTraces; i++ {
+		rows = append(rows, property.OutcomeRow{
+			Labels:      map[string]string{},
+			TimestampMs: 0,
+			Value:       0,
+		})
+	}
+	return property.Outcome{Rows: rows}
+}


### PR DESCRIPTION
## Summary

Adds a rapid-based property test for TraceQL paralleling `test/property/promql_test.go`. Real `tempo.Handler` via httptest + from-scratch spanset oracle + chDB roundtrip + rapid shrinking. **No `t.Skip`.**

## Implementation

- `test/property/gen/traceql.go` — `TraceQLDataset` + `TraceQLQuery` generators.
- `test/property/oracle/traceql/{doc,evaluator}.go` — from-scratch spanset evaluator. Does NOT import `tempo/pkg/traceql.Parse` so a Tempo-parser bug stays visible.
- `test/property/traceql_test.go` — chdb-tagged `TestTraceQL_Property`.
- `.github/workflows/property.yml` — picks up the new test via existing `./test/property/...` glob.

## Query shapes generated

- Bare selector: `{ resource.service.name = "<v>" }` where `v ∈ {api, web, batch}`
- Selector + scalar filter: `{ ... } | count() OP N` for `OP ∈ {>, >=, <, <=, =}`, `N ∈ [0, len+1]`

## Oracle correctness

Per Grafana TraceQL spec:
- Spanset filter ([Filtering](https://grafana.com/docs/tempo/latest/traceql/#filtering)): equality against mirrored `ResourceAttributes['service.name']`.
- `count()` aggregate ([Aggregators](https://grafana.com/docs/tempo/latest/traceql/#aggregators)) over the surviving spanset.
- Scalar filter — predicate post-aggregate; matches cerberus's `chplan.Filter(Aggregate)` shape from `internal/traceql/lower.go::lowerScalarFilter`.

## Test plan

- [x] 200 rapid iterations green locally: `go test -tags chdb -count=1 -run TestTraceQL_Property ./test/property/ -rapid.checks=200`

5 files, +866 / -1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>