### PR TITLE
fix(promql,chclient): wrap synthesised Value in toFloat64 (driver UInt scan reject)

### DIFF
--- a/internal/promql/absent.go
+++ b/internal/promql/absent.go
@@ -110,7 +110,16 @@ func lowerAbsent(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, e
 	//   MetricName=''                                  (absent drops __name__)
 	//   Attributes=map(<eq-matchers from v>)           (Prom funcAbsent label rule)
 	//   TimeUnix=<eval anchor>                         (now64(9) or literal eval ts)
-	//   Value=1.0                                      (Prom's spec value)
+	//   Value=toFloat64(1)                             (Prom's spec value)
+	//
+	// The Value expression is wrapped in `toFloat64(...)` because the
+	// clickhouse-go/v2 driver renders Go `float64(1.0)` as the SQL
+	// literal `1` (no decimal), and CH narrows that to `UInt8`. The
+	// downstream cursor scans into `*float64`, and the driver refuses
+	// to convert UInt8 → *float64 (errors with `converting UInt8 to
+	// *float64 is unsupported`). Wrapping in `toFloat64(?)` forces
+	// CH to project Float64 on the wire regardless of the bound
+	// literal's inferred type.
 	timeExpr := anchorBaseExpr(evalAnchor{End: ctx.end.UTC()})
 	if ctx.end.IsZero() {
 		timeExpr = anchorBaseExpr(evalAnchor{})
@@ -121,7 +130,7 @@ func lowerAbsent(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, e
 			{Expr: &chplan.LitString{V: ""}, Alias: s.MetricNameColumn},
 			{Expr: absentAttrsMap(vs.LabelMatchers), Alias: s.AttributesColumn},
 			{Expr: timeExpr, Alias: s.TimestampColumn},
-			{Expr: &chplan.LitFloat{V: 1.0}, Alias: s.ValueColumn},
+			{Expr: &chplan.FuncCall{Name: "toFloat64", Args: []chplan.Expr{&chplan.LitFloat{V: 1.0}}}, Alias: s.ValueColumn},
 		},
 	}, nil
 }

--- a/internal/promql/date_fns.go
+++ b/internal/promql/date_fns.go
@@ -18,8 +18,8 @@ import (
 // When called without an argument the PromQL spec defaults the input to
 // `vector(time())` — a single instant-vector entry whose value is the
 // current evaluation timestamp in seconds. cerberus lowers that to a
-// degenerate scan over `system.one` (CH's one-row table) projecting
-// `(MetricName=”, Attributes={}, TimeUnix=now64(9), Value=<fn>(now()))`.
+// degenerate `OneRow` source projecting
+// `(MetricName=”, Attributes={}, TimeUnix=now64(9), Value=toFloat64(<fn>(now())))`.
 // The `timestamp` function does NOT have a zero-arg form in upstream
 // PromQL — Prometheus rejects it during parsing — so the no-arg branch
 // is unreachable for that name; we keep the same shape anyway for
@@ -39,6 +39,17 @@ import (
 //   - `timestamp(v)` ignores `Value` and reads the sample's TimeUnix
 //     column instead, converting the DateTime64(9) to fractional Unix
 //     seconds via `toUnixTimestamp64Nano(TimeUnix) / 1e9`.
+//
+// Type-coercion note: every CH date-component function (`toYear`,
+// `toMonth`, `toDayOfMonth`, `toDayOfWeek`, `toHour`, `toMinute`)
+// returns a small integer (`UInt8` / `UInt16`). The cerberus Sample
+// row is decoded into `*float64`, and clickhouse-go/v2 refuses to
+// convert a UInt8/UInt16 column into `*float64` (errors with
+// `converting UInt16 to *float64 is unsupported`). Wrap every emit
+// in `toFloat64(...)` so the Value column lands as Float64 on the
+// wire — this is the same shape every other Float-typed Value
+// projection ends up with. `timestamp(v)` is already Float64 (it
+// divides by `1e9`) but wrapping it is harmless.
 func lowerDateFn(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
 	if len(c.Args) > 1 {
 		return nil, fmt.Errorf("promql: %s expects 0 or 1 argument, got %d", c.Func.Name, len(c.Args))
@@ -56,7 +67,7 @@ func lowerDateFn(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, e
 	if newValue == nil {
 		return nil, fmt.Errorf("promql: unknown date function %s", c.Func.Name)
 	}
-	return projectValueOverInner(inner, s, newValue), nil
+	return projectValueOverInner(inner, s, asFloat64(newValue)), nil
 }
 
 // lowerDateFnNoArg synthesises a single-row constant instant vector for
@@ -64,16 +75,29 @@ func lowerDateFn(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, e
 // `year(vector(time()))`. The result is a one-row vector with the time
 // component of the current eval timestamp as its sample value.
 //
-// We emit `Scan(system.one)` (CH's single-row builtin) wrapped in a
+// We emit `OneRow` (cerberus's no-FROM `SELECT 1` source) wrapped in a
 // Project that builds the canonical Sample shape:
 //
 //	MetricName  = ''
 //	Attributes  = CAST(map(), 'Map(String,String)')
 //	TimeUnix    = now64(9)
-//	Value       = <date-fn>(now())
+//	Value       = toFloat64(<date-fn>(now()))
 //
 // — matching the shape produced by an unaggregated PromQL aggregation
-// over the same single instant vector.
+// over the same single instant vector. The `toFloat64` wrap is
+// load-bearing: see the type-coercion note on `lowerDateFn` for the
+// rationale (the CH date-component builtins return UInt8/UInt16 and
+// clickhouse-go/v2 refuses to scan those into `*float64`).
+//
+// Historical note: this previously emitted `Scan{Database:"system",
+// Table:"one"}` — a qualified scan over CH's standard one-row table.
+// The SQL works against real CH 24.x, but using the dedicated
+// `chplan.OneRow` source is cleaner: it bypasses the qualified-table
+// emit path entirely and reuses the same `SELECT 1` shape that
+// `time()` / `vector(scalar)` already rely on. The `Scan{Database:...}`
+// shape now has no remaining callers in the PromQL head; the
+// emitter's `scanTableFrag` qualified branch can be retired in a
+// follow-up cleanup.
 func lowerDateFnNoArg(name string, s schema.Metrics) (chplan.Node, error) {
 	now := &chplan.FuncCall{Name: "now"}
 	expr := dateFnExpr(name, now, now)
@@ -81,14 +105,24 @@ func lowerDateFnNoArg(name string, s schema.Metrics) (chplan.Node, error) {
 		return nil, fmt.Errorf("promql: unknown date function %s", name)
 	}
 	return &chplan.Project{
-		Input: &chplan.Scan{Database: "system", Table: "one"},
+		Input: &chplan.OneRow{},
 		Projections: []chplan.Projection{
 			{Expr: &chplan.LitString{V: ""}, Alias: s.MetricNameColumn},
 			{Expr: emptyAttrsMap(), Alias: s.AttributesColumn},
 			{Expr: &chplan.FuncCall{Name: "now64", Args: []chplan.Expr{&chplan.LitInt{V: 9}}}, Alias: s.TimestampColumn},
-			{Expr: expr, Alias: s.ValueColumn},
+			{Expr: asFloat64(expr), Alias: s.ValueColumn},
 		},
 	}, nil
+}
+
+// asFloat64 wraps e in `toFloat64(...)`. Used by the date-function
+// lowerings to coerce CH integer return types (toYear → UInt16,
+// toMonth/toHour/etc → UInt8) into Float64, matching the Sample.Value
+// column type the cursor decodes into. Idempotent for Float64 inputs
+// (CH's `toFloat64` is a no-op identity on Float64) so the wrap is
+// safe even on the `timestamp(v)` path that already yields Float64.
+func asFloat64(e chplan.Expr) chplan.Expr {
+	return &chplan.FuncCall{Name: "toFloat64", Args: []chplan.Expr{e}}
 }
 
 // dateFnExpr returns the CH expression that computes the date-component

--- a/test/spec/promql/absent_no_matchers.txtar
+++ b/test/spec/promql/absent_no_matchers.txtar
@@ -1,0 +1,54 @@
+# `absent(<bare-name>)` — the no-matcher case from the compat lane
+# (`absent(nonexistent_metric_name)`). The argument is a bare metric
+# name with no equality matchers, so the synthesised output row has
+# an empty Attributes map.
+#
+# The chplan stack is:
+#
+#   Project ["", CAST(map(), 'Map(String,String)'),
+#            <eval-ts>, toFloat64(1)]
+#     Filter (_cerb_n = 0)
+#       Aggregate count() AS _cerb_n   (DropEmptyOnNoGroup=false)
+#         Filter (MetricName = "nonexistent_metric_name")
+#           Scan(otel_metrics_gauge)
+#
+# The inner Filter (metric name match) returns 0 rows; the Aggregate
+# with DropEmptyOnNoGroup=false still emits one row (count=0); the
+# outer Filter passes it through; the Project synthesises the absent
+# row with the bare Value=1 (wrapped in toFloat64 so the cursor scan
+# into *float64 doesn't crash — clickhouse-go/v2 binds float64(1.0)
+# as the SQL literal `1` which CH narrows to UInt8).
+
+-- query.promql --
+absent(nonexistent_metric_name)
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- Only an unrelated metric is present — the filtered Scan above
+-- produces 0 rows for `nonexistent_metric_name`.
+INSERT INTO otel_metrics_gauge VALUES
+    ('temperature', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 42.0);
+-- expected_rows --
+[
+  ["", {}, "2026-01-01T00:00:01Z", 1.0]
+]
+-- args --
+[0] string = ""
+[1] string = "Map(String,String)"
+[2] string = "2026-01-01 00:00:01.000000000"
+[3] int64 = 9
+[4] float64 = 1
+[5] string = "nonexistent_metric_name"
+[6] int64 = 0
+-- chplan --
+Project ["" AS MetricName, CAST(map(), "Map(String,String)") AS Attributes, toDateTime64("2026-01-01 00:00:01.000000000", 9) AS TimeUnix, toFloat64(1) AS Value]
+  Filter predicate=(_cerb_n = 0)
+    Aggregate groupBy=[] funcs=[count() AS _cerb_n]
+      Filter predicate=(MetricName = "nonexistent_metric_name")
+        Scan(otel_metrics_gauge)
+-- sql --
+SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, toDateTime64(?, ?) AS `TimeUnix`, toFloat64(?) AS `Value` FROM (SELECT * FROM (SELECT count() AS `_cerb_n` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))) WHERE (`_cerb_n` = ?))

--- a/test/spec/promql/absent_no_series.txtar
+++ b/test/spec/promql/absent_no_series.txtar
@@ -43,10 +43,10 @@ INSERT INTO otel_metrics_gauge VALUES
 [8] string = "x"
 [9] int64 = 0
 -- chplan --
-Project ["" AS MetricName, map("job", "x") AS Attributes, toDateTime64("2026-01-01 00:00:01.000000000", 9) AS TimeUnix, 1 AS Value]
+Project ["" AS MetricName, map("job", "x") AS Attributes, toDateTime64("2026-01-01 00:00:01.000000000", 9) AS TimeUnix, toFloat64(1) AS Value]
   Filter predicate=(_cerb_n = 0)
     Aggregate groupBy=[] funcs=[count() AS _cerb_n]
       Filter predicate=((Attributes["job"] = "x") AND (MetricName = "nonexistent_metric_name"))
         Scan(otel_metrics_gauge)
 -- sql --
-SELECT ? AS `MetricName`, map(?, ?) AS `Attributes`, toDateTime64(?, ?) AS `TimeUnix`, ? AS `Value` FROM (SELECT * FROM (SELECT count() AS `_cerb_n` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`Attributes`[?] = ?))) WHERE (`_cerb_n` = ?))
+SELECT ? AS `MetricName`, map(?, ?) AS `Attributes`, toDateTime64(?, ?) AS `TimeUnix`, toFloat64(?) AS `Value` FROM (SELECT * FROM (SELECT count() AS `_cerb_n` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`Attributes`[?] = ?))) WHERE (`_cerb_n` = ?))

--- a/test/spec/promql/absent_with_series.txtar
+++ b/test/spec/promql/absent_with_series.txtar
@@ -26,10 +26,10 @@ INSERT INTO otel_metrics_gauge VALUES
 [5] string = "temperature"
 [6] int64 = 0
 -- chplan --
-Project ["" AS MetricName, CAST(map(), "Map(String,String)") AS Attributes, toDateTime64("2026-01-01 00:00:01.000000000", 9) AS TimeUnix, 1 AS Value]
+Project ["" AS MetricName, CAST(map(), "Map(String,String)") AS Attributes, toDateTime64("2026-01-01 00:00:01.000000000", 9) AS TimeUnix, toFloat64(1) AS Value]
   Filter predicate=(_cerb_n = 0)
     Aggregate groupBy=[] funcs=[count() AS _cerb_n]
       Filter predicate=(MetricName = "temperature")
         Scan(otel_metrics_gauge)
 -- sql --
-SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, toDateTime64(?, ?) AS `TimeUnix`, ? AS `Value` FROM (SELECT * FROM (SELECT count() AS `_cerb_n` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))) WHERE (`_cerb_n` = ?))
+SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, toDateTime64(?, ?) AS `TimeUnix`, toFloat64(?) AS `Value` FROM (SELECT * FROM (SELECT count() AS `_cerb_n` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?))) WHERE (`_cerb_n` = ?))

--- a/test/spec/promql/day_of_month_default.txtar
+++ b/test/spec/promql/day_of_month_default.txtar
@@ -1,0 +1,18 @@
+# `day_of_month()` — the zero-arg form. PromQL spec:
+# `day_of_month()` ≡ `day_of_month(vector(time()))`. cerberus lowers
+# it to a OneRow source projecting Value=toFloat64(toDayOfMonth(now())).
+# The `toFloat64` wrap forces CH's UInt8 `toDayOfMonth` return into
+# Float64 so the cursor decode into `*float64` doesn't error with
+# `converting UInt8 to *float64 is unsupported`.
+
+-- query.promql --
+day_of_month()
+-- args --
+[0] string = ""
+[1] string = "Map(String,String)"
+[2] int64 = 9
+-- chplan --
+Project ["" AS MetricName, CAST(map(), "Map(String,String)") AS Attributes, now64(9) AS TimeUnix, toFloat64(toDayOfMonth(now())) AS Value]
+  OneRow
+-- sql --
+SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(toDayOfMonth(now())) AS `Value` FROM (SELECT 1)

--- a/test/spec/promql/day_of_month_of_vector.txtar
+++ b/test/spec/promql/day_of_month_of_vector.txtar
@@ -22,10 +22,10 @@ INSERT INTO otel_metrics_gauge VALUES
 [5] int64 = 9
 [6] int64 = 300000000000
 -- chplan --
-Project [MetricName, Attributes, TimeUnix, toDayOfMonth(toDateTime(toInt64(Value), "UTC")) AS Value]
+Project [MetricName, Attributes, TimeUnix, toFloat64(toDayOfMonth(toDateTime(toInt64(Value), "UTC"))) AS Value]
   Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
     Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
       Filter predicate=(((MetricName = "unix_seconds") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
         Scan(otel_metrics_gauge)
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, toDayOfMonth(toDateTime(toInt64(`Value`), ?)) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, toFloat64(toDayOfMonth(toDateTime(toInt64(`Value`), ?))) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))

--- a/test/spec/promql/day_of_week_default.txtar
+++ b/test/spec/promql/day_of_week_default.txtar
@@ -1,0 +1,24 @@
+# `day_of_week()` — the zero-arg form. PromQL spec:
+# `day_of_week()` ≡ `day_of_week(vector(time()))`. cerberus lowers
+# it to a OneRow source. CH's `toDayOfWeek` returns 1-7 (Mon=1..Sun=7);
+# PromQL `day_of_week` returns 0-6 (Sun=0..Sat=6) — `toDayOfWeek(d) % 7`
+# bridges the gap.
+#
+# The result is wrapped in `toFloat64(...)`: `toDayOfWeek` returns
+# UInt8, and the cursor decodes into `*float64`. Without the wrap
+# the clickhouse-go/v2 driver errors with
+# `converting UInt8 to *float64 is unsupported`. With the wrap CH
+# projects the column as Float64 on the wire.
+
+-- query.promql --
+day_of_week()
+-- args --
+[0] string = ""
+[1] string = "Map(String,String)"
+[2] int64 = 9
+[3] int64 = 7
+-- chplan --
+Project ["" AS MetricName, CAST(map(), "Map(String,String)") AS Attributes, now64(9) AS TimeUnix, toFloat64((toDayOfWeek(now()) % 7)) AS Value]
+  OneRow
+-- sql --
+SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64((toDayOfWeek(now()) % ?)) AS `Value` FROM (SELECT 1)

--- a/test/spec/promql/day_of_week_offset.txtar
+++ b/test/spec/promql/day_of_week_offset.txtar
@@ -23,10 +23,10 @@ INSERT INTO otel_metrics_gauge VALUES
 [6] int64 = 9
 [7] int64 = 300000000000
 -- chplan --
-Project [MetricName, Attributes, TimeUnix, (toDayOfWeek(toDateTime(toInt64(Value), "UTC")) % 7) AS Value]
+Project [MetricName, Attributes, TimeUnix, toFloat64((toDayOfWeek(toDateTime(toInt64(Value), "UTC")) % 7)) AS Value]
   Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
     Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
       Filter predicate=(((MetricName = "weekday_marker") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
         Scan(otel_metrics_gauge)
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, (toDayOfWeek(toDateTime(toInt64(`Value`), ?)) % ?) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, toFloat64((toDayOfWeek(toDateTime(toInt64(`Value`), ?)) % ?)) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))

--- a/test/spec/promql/days_in_month_default.txtar
+++ b/test/spec/promql/days_in_month_default.txtar
@@ -1,0 +1,21 @@
+# `days_in_month()` — the zero-arg form. CH has no direct
+# `daysInMonth` builtin; cerberus lowers via
+# `toDayOfMonth(toLastDayOfMonth(now()))` (the day-of-month of the
+# last day in the month IS the day count for that month).
+#
+# The OneRow source supplies the single row. The outer `toFloat64`
+# wrap is load-bearing: `toDayOfMonth` returns UInt8 and the cursor
+# decodes into `*float64` (errors with `converting UInt8 to *float64
+# is unsupported` without it).
+
+-- query.promql --
+days_in_month()
+-- args --
+[0] string = ""
+[1] string = "Map(String,String)"
+[2] int64 = 9
+-- chplan --
+Project ["" AS MetricName, CAST(map(), "Map(String,String)") AS Attributes, now64(9) AS TimeUnix, toFloat64(toDayOfMonth(toLastDayOfMonth(now()))) AS Value]
+  OneRow
+-- sql --
+SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(toDayOfMonth(toLastDayOfMonth(now()))) AS `Value` FROM (SELECT 1)

--- a/test/spec/promql/days_in_month_of_vector.txtar
+++ b/test/spec/promql/days_in_month_of_vector.txtar
@@ -22,10 +22,10 @@ INSERT INTO otel_metrics_gauge VALUES
 [5] int64 = 9
 [6] int64 = 300000000000
 -- chplan --
-Project [MetricName, Attributes, TimeUnix, toDayOfMonth(toLastDayOfMonth(toDateTime(toInt64(Value), "UTC"))) AS Value]
+Project [MetricName, Attributes, TimeUnix, toFloat64(toDayOfMonth(toLastDayOfMonth(toDateTime(toInt64(Value), "UTC")))) AS Value]
   Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
     Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
       Filter predicate=(((MetricName = "unix_seconds") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
         Scan(otel_metrics_gauge)
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, toDayOfMonth(toLastDayOfMonth(toDateTime(toInt64(`Value`), ?))) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, toFloat64(toDayOfMonth(toLastDayOfMonth(toDateTime(toInt64(`Value`), ?)))) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))

--- a/test/spec/promql/hour_default.txtar
+++ b/test/spec/promql/hour_default.txtar
@@ -1,0 +1,20 @@
+# `hour()` — the zero-arg form. PromQL spec:
+# `hour()` ≡ `hour(vector(time()))`. cerberus lowers to a OneRow
+# source projecting Value=toFloat64(toHour(now())).
+#
+# The `toFloat64` wrap is load-bearing: CH's `toHour` returns UInt8
+# (0-23), and the cursor decodes Sample.Value into `*float64`.
+# clickhouse-go/v2 refuses the conversion (`converting UInt8 to
+# *float64 is unsupported`) without the wrap.
+
+-- query.promql --
+hour()
+-- args --
+[0] string = ""
+[1] string = "Map(String,String)"
+[2] int64 = 9
+-- chplan --
+Project ["" AS MetricName, CAST(map(), "Map(String,String)") AS Attributes, now64(9) AS TimeUnix, toFloat64(toHour(now())) AS Value]
+  OneRow
+-- sql --
+SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(toHour(now())) AS `Value` FROM (SELECT 1)

--- a/test/spec/promql/hour_of_vector.txtar
+++ b/test/spec/promql/hour_of_vector.txtar
@@ -22,10 +22,10 @@ INSERT INTO otel_metrics_gauge VALUES
 [5] int64 = 9
 [6] int64 = 300000000000
 -- chplan --
-Project [MetricName, Attributes, TimeUnix, toHour(toDateTime(toInt64(Value), "UTC")) AS Value]
+Project [MetricName, Attributes, TimeUnix, toFloat64(toHour(toDateTime(toInt64(Value), "UTC"))) AS Value]
   Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
     Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
       Filter predicate=(((MetricName = "unix_seconds") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
         Scan(otel_metrics_gauge)
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, toHour(toDateTime(toInt64(`Value`), ?)) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, toFloat64(toHour(toDateTime(toInt64(`Value`), ?))) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))

--- a/test/spec/promql/minute_default.txtar
+++ b/test/spec/promql/minute_default.txtar
@@ -1,0 +1,20 @@
+# `minute()` — the zero-arg form. PromQL spec:
+# `minute()` ≡ `minute(vector(time()))`. cerberus lowers to a OneRow
+# source projecting Value=toFloat64(toMinute(now())).
+#
+# The `toFloat64` wrap is load-bearing: CH's `toMinute` returns
+# UInt8 (0-59), and the cursor decodes Sample.Value into `*float64`.
+# Without the wrap the driver errors with `converting UInt8 to
+# *float64 is unsupported`.
+
+-- query.promql --
+minute()
+-- args --
+[0] string = ""
+[1] string = "Map(String,String)"
+[2] int64 = 9
+-- chplan --
+Project ["" AS MetricName, CAST(map(), "Map(String,String)") AS Attributes, now64(9) AS TimeUnix, toFloat64(toMinute(now())) AS Value]
+  OneRow
+-- sql --
+SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(toMinute(now())) AS `Value` FROM (SELECT 1)

--- a/test/spec/promql/minute_of_vector.txtar
+++ b/test/spec/promql/minute_of_vector.txtar
@@ -22,10 +22,10 @@ INSERT INTO otel_metrics_gauge VALUES
 [5] int64 = 9
 [6] int64 = 300000000000
 -- chplan --
-Project [MetricName, Attributes, TimeUnix, toMinute(toDateTime(toInt64(Value), "UTC")) AS Value]
+Project [MetricName, Attributes, TimeUnix, toFloat64(toMinute(toDateTime(toInt64(Value), "UTC"))) AS Value]
   Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
     Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
       Filter predicate=(((MetricName = "unix_seconds") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
         Scan(otel_metrics_gauge)
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, toMinute(toDateTime(toInt64(`Value`), ?)) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, toFloat64(toMinute(toDateTime(toInt64(`Value`), ?))) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))

--- a/test/spec/promql/month_default.txtar
+++ b/test/spec/promql/month_default.txtar
@@ -1,0 +1,20 @@
+# `month()` — the zero-arg form. PromQL spec: `month()` ≡
+# `month(vector(time()))`. cerberus lowers it to a OneRow source
+# projecting (MetricName="", Attributes={}, TimeUnix=now64(9),
+# Value=toFloat64(toMonth(now()))). The `toFloat64` wrap is
+# load-bearing: CH's `toMonth` returns UInt8, and clickhouse-go/v2
+# refuses to scan UInt8 → *float64 (errors with
+# `converting UInt8 to *float64 is unsupported`). See
+# `internal/promql/date_fns.go` for the type-coercion rationale.
+
+-- query.promql --
+month()
+-- args --
+[0] string = ""
+[1] string = "Map(String,String)"
+[2] int64 = 9
+-- chplan --
+Project ["" AS MetricName, CAST(map(), "Map(String,String)") AS Attributes, now64(9) AS TimeUnix, toFloat64(toMonth(now())) AS Value]
+  OneRow
+-- sql --
+SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(toMonth(now())) AS `Value` FROM (SELECT 1)

--- a/test/spec/promql/month_of_vector.txtar
+++ b/test/spec/promql/month_of_vector.txtar
@@ -22,10 +22,10 @@ INSERT INTO otel_metrics_gauge VALUES
 [5] int64 = 9
 [6] int64 = 300000000000
 -- chplan --
-Project [MetricName, Attributes, TimeUnix, toMonth(toDateTime(toInt64(Value), "UTC")) AS Value]
+Project [MetricName, Attributes, TimeUnix, toFloat64(toMonth(toDateTime(toInt64(Value), "UTC"))) AS Value]
   Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
     Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
       Filter predicate=(((MetricName = "unix_seconds") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
         Scan(otel_metrics_gauge)
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, toMonth(toDateTime(toInt64(`Value`), ?)) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, toFloat64(toMonth(toDateTime(toInt64(`Value`), ?))) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))

--- a/test/spec/promql/timestamp_of_metric.txtar
+++ b/test/spec/promql/timestamp_of_metric.txtar
@@ -22,10 +22,10 @@ INSERT INTO otel_metrics_gauge VALUES
 [5] int64 = 9
 [6] int64 = 300000000000
 -- chplan --
-Project [MetricName, Attributes, TimeUnix, (toUnixTimestamp64Nano(TimeUnix) / 1e+09) AS Value]
+Project [MetricName, Attributes, TimeUnix, toFloat64((toUnixTimestamp64Nano(TimeUnix) / 1e+09)) AS Value]
   Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
     Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
       Filter predicate=(((MetricName = "any_metric") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
         Scan(otel_metrics_gauge)
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, (toUnixTimestamp64Nano(`TimeUnix`) / ?) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, toFloat64((toUnixTimestamp64Nano(`TimeUnix`) / ?)) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))

--- a/test/spec/promql/year_default.txtar
+++ b/test/spec/promql/year_default.txtar
@@ -5,7 +5,7 @@ year()
 [1] string = "Map(String,String)"
 [2] int64 = 9
 -- chplan --
-Project ["" AS MetricName, CAST(map(), "Map(String,String)") AS Attributes, now64(9) AS TimeUnix, toYear(now()) AS Value]
-  Scan(system.one)
+Project ["" AS MetricName, CAST(map(), "Map(String,String)") AS Attributes, now64(9) AS TimeUnix, toFloat64(toYear(now())) AS Value]
+  OneRow
 -- sql --
-SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, toYear(now()) AS `Value` FROM (SELECT * FROM `system`.`one`)
+SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(toYear(now())) AS `Value` FROM (SELECT 1)

--- a/test/spec/promql/year_of_vector.txtar
+++ b/test/spec/promql/year_of_vector.txtar
@@ -22,10 +22,10 @@ INSERT INTO otel_metrics_gauge VALUES
 [5] int64 = 9
 [6] int64 = 300000000000
 -- chplan --
-Project [MetricName, Attributes, TimeUnix, toYear(toDateTime(toInt64(Value), "UTC")) AS Value]
+Project [MetricName, Attributes, TimeUnix, toFloat64(toYear(toDateTime(toInt64(Value), "UTC"))) AS Value]
   Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
     Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
       Filter predicate=(((MetricName = "unix_seconds") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
         Scan(otel_metrics_gauge)
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, toYear(toDateTime(toInt64(`Value`), ?)) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
+SELECT `MetricName`, `Attributes`, `TimeUnix`, toFloat64(toYear(toDateTime(toInt64(`Value`), ?))) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))


### PR DESCRIPTION
## Summary

Closes the remaining 8 compat-lane 502s: 7 no-arg date funcs + `absent(nonexistent_metric_name)`. Single underlying bug — driver-layer type mismatch, not lowering.

## Root cause

`clickhouse-go/v2` rejects scanning small-int CH column types into `*float64`:

```
clickhouse [ScanRow]: (Value) converting UInt16 to *float64 is unsupported
```

Cerberus's cursor (`internal/chclient/cursor.go:72`) scans `Sample.Value` as `*float64`. Synthesised Value columns that emit as UInt8/UInt16 crash → 502.

- **Date no-arg**: `toYear` returns UInt16; `toMonth` / `toDayOfMonth` / `toDayOfWeek` / `toHour` / `toMinute` return UInt8. With-arg form previously hid this because the harness seed lacks `demo_batch_last_success_timestamp_seconds`, so queries returned empty (no scan).
- **`absent(nonexistent_metric_name)`**: clickhouse-go renders Go `float64(1.0)` as SQL literal `1` (no decimal). CH narrows to UInt8 → same crash.

Verified end-to-end against a live CH 24.8 container reproducing the exact 502.

## Fix

Wrap every synthesised Value in `toFloat64(...)`:
- `internal/promql/absent.go` — wrap `LitFloat{V:1.0}` in `FuncCall{Name:"toFloat64"}` (`absent.go:133`)
- `internal/promql/date_fns.go` — new `asFloat64()` helper applied to both arg + no-arg paths

**Bonus**: switched the no-arg date path from `Scan{Database:"system", Table:"one"}` to `chplan.OneRow` (added by #316). Cleaner; reuses the `SELECT 1` shape `time()` + `vector()` already use. `scanTableFrag` in `internal/chsql/emit_node.go:98` now has no remaining PromQL callers — flagged for follow-up cleanup, not in scope.

## Test plan

- [x] `go test ./internal/...` — 2441 pass (22 pkgs)
- [x] `go test -tags chdb ./test/spec/promql/` — 23/23 affected fixtures pass
- [x] Live CH 24.8 verification: `year()`, `absent(nonexistent_metric_name)`, `year(unix_seconds)` all return correct Float64 rows
- [x] 7 new fixtures: `{month,day_of_month,day_of_week,days_in_month,hour,minute}_default.txtar` + `absent_no_matchers.txtar`
- [x] 11 modified TXTAR goldens regenerated

20 files, +253 / -33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>