### PR TITLE
fix(promql): fold synthetic-scalar V-V binops (time() + time(), etc.)

### DIFF
--- a/internal/api/prom/handler_chdb_step_loop_test.go
+++ b/internal/api/prom/handler_chdb_step_loop_test.go
@@ -34,6 +34,7 @@ package prom_test
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -137,6 +138,162 @@ func TestQueryRange_StepLoop_NoDrivingVector_ChDB(t *testing.T) {
 			// Assert per-bucket values match the Prom semantics:
 			// each step emits one sample of the expression evaluated
 			// at that step's timestamp.
+			for i, v := range values {
+				want := tc.wantValue(i)
+				if got := v[1]; got != want {
+					t.Errorf("step %d: value=%q want=%q (full row: %+v)",
+						i, got, want, v)
+				}
+			}
+		})
+	}
+}
+
+// TestQueryRange_StepLoop_TimeTime_ChDB walks the 12 `time() OP time()`
+// shapes Pool-Z surfaced (all 6 arithmetic + 6 bool comparisons). Each
+// is a V-V binop where BOTH legs are synthetic-scalar plans — pre-fix
+// these routed through chplan.VectorJoin and the per-side argMax
+// collapse reduced each leg to one row before joining, leaving the
+// matrix with 1×1 rows instead of N rows per step. Compatibility run
+// surfaced these as 12 shape-diffs in the compat lane.
+//
+// The fix detects "both legs are synthetic-scalar plans" inside
+// lowerBinary and folds to a single Project over the shared StepGrid
+// source (the equivalent of TryFoldScalar's literal-literal fold one
+// level up). This test pins the runtime matrix shape end-to-end:
+// each query must surface N samples on the requested step grid, with
+// the expected per-step value derived from the step's `anchor_ts`.
+func TestQueryRange_StepLoop_TimeTime_ChDB(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(5 * time.Minute)
+	step := 30 * time.Second
+	const wantSamples = 11
+
+	// time() at step i is `start.Unix() + i*30`. The test seeds nothing
+	// because synthetic-scalar plans don't read from any table, but
+	// applySeed requires a non-empty seed string — pick a no-op
+	// CREATE TABLE so the chdb session has something to ingest. The
+	// query under test doesn't read from this table.
+	seed := gaugeDDL
+	srv, _ := newChDBServer(t, seed)
+
+	// timeOf returns time() (Unix seconds) at step i, as a float so the
+	// expected-value formatting matches the wire shape.
+	timeOf := func(i int) float64 {
+		return float64(start.Unix() + int64(i)*30)
+	}
+	fmtF := func(f float64) string {
+		return strconv.FormatFloat(f, 'f', -1, 64)
+	}
+
+	cases := []struct {
+		name      string
+		query     string
+		wantValue func(i int) string
+	}{
+		// 6 arithmetic ops: time() <OP> time() — both legs equal at
+		// each step so SUB / MOD yield 0, MUL/POW square, DIV/ADD
+		// double/scale.
+		{
+			name:  "add",
+			query: "time() + time()",
+			wantValue: func(i int) string {
+				return fmtF(2 * timeOf(i))
+			},
+		},
+		{
+			name:  "sub",
+			query: "time() - time()",
+			wantValue: func(_ int) string {
+				return "0"
+			},
+		},
+		{
+			name:  "mul",
+			query: "time() * time()",
+			wantValue: func(i int) string {
+				return fmtF(timeOf(i) * timeOf(i))
+			},
+		},
+		{
+			name:  "div",
+			query: "time() / time()",
+			wantValue: func(_ int) string {
+				return "1"
+			},
+		},
+		{
+			name:  "mod",
+			query: "time() % time()",
+			wantValue: func(_ int) string {
+				return "0"
+			},
+		},
+		{
+			name:  "pow",
+			query: "time() ^ time()",
+			wantValue: func(i int) string {
+				return fmtF(math.Pow(timeOf(i), timeOf(i)))
+			},
+		},
+		// 6 bool comparisons: time() <CMP> bool time() — both legs are
+		// equal at every step so `== bool` and `<= bool` and `>= bool`
+		// yield 1.0; `!= bool`, `< bool`, `> bool` yield 0.0.
+		{
+			name:  "eq-bool",
+			query: "time() == bool time()",
+			wantValue: func(_ int) string {
+				return "1"
+			},
+		},
+		{
+			name:  "ne-bool",
+			query: "time() != bool time()",
+			wantValue: func(_ int) string {
+				return "0"
+			},
+		},
+		{
+			name:  "lt-bool",
+			query: "time() < bool time()",
+			wantValue: func(_ int) string {
+				return "0"
+			},
+		},
+		{
+			name:  "le-bool",
+			query: "time() <= bool time()",
+			wantValue: func(_ int) string {
+				return "1"
+			},
+		},
+		{
+			name:  "gt-bool",
+			query: "time() > bool time()",
+			wantValue: func(_ int) string {
+				return "0"
+			},
+		},
+		{
+			name:  "ge-bool",
+			query: "time() >= bool time()",
+			wantValue: func(_ int) string {
+				return "1"
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			matrix := runStepLoopRange(t, srv.URL, tc.query, start, end, step)
+			if len(matrix) != 1 {
+				t.Fatalf("expected exactly 1 series in matrix, got %d: %+v", len(matrix), matrix)
+			}
+			values := matrix[0].Values
+			if len(values) != wantSamples {
+				t.Fatalf("expected %d samples (one per step), got %d: %+v",
+					wantSamples, len(values), values)
+			}
 			for i, v := range values {
 				want := tc.wantValue(i)
 				if got := v[1]; got != want {

--- a/internal/promql/binary.go
+++ b/internal/promql/binary.go
@@ -124,6 +124,27 @@ func lowerVectorVector(b *parser.BinaryExpr, s schema.Metrics, op chplan.BinaryO
 		return nil, err
 	}
 
+	// Synthetic-scalar fold: when BOTH legs lower to the canonical
+	// 4-slot synthetic-vector shape ([syntheticScalarVector]), the
+	// VectorJoin emit path collapses each side to one row via the
+	// per-side argMax wrap and then joins on (MetricName, Attributes)
+	// — yielding 1 × 1 = 1 row instead of Prom's N rows per step.
+	// This shows up as 12 compat-lane shape-diffs for the
+	// `time() OP time()` family (all 6 arithmetic + 6 bool comparisons).
+	// The fix mirrors the literal-literal fold one level above: rebuild
+	// a single Project over the shared synthetic source with the
+	// combined value expression, skipping VectorJoin entirely.
+	//
+	// Gated on default matching (no on/ignoring/group_left/group_right
+	// modifiers) — two empty-label legs only join correctly via the
+	// full-Attributes intersection, and any `on(<label>)` / Include
+	// shape against empty Attributes is semantically incoherent (Prom
+	// errors out). Keeping the gate narrow means anything cardinality-
+	// modifier-shaped still flows through the existing V-V path.
+	if isSyntheticScalarPlan(left, s) && isSyntheticScalarPlan(right, s) && isDefaultMatching(b.VectorMatching) {
+		return foldSyntheticBinary(left, right, op, b.ReturnBool, s), nil
+	}
+
 	match := chplan.VectorMatch{}
 	if b.VectorMatching != nil {
 		match.Labels = append([]string(nil), b.VectorMatching.MatchingLabels...)
@@ -143,6 +164,89 @@ func lowerVectorVector(b *parser.BinaryExpr, s schema.Metrics, op chplan.BinaryO
 		TimestampColumn:  s.TimestampColumn,
 		ValueColumn:      s.ValueColumn,
 	}, nil
+}
+
+// isDefaultMatching reports whether the parser's VectorMatching slot
+// is the "no explicit matching modifier" shape — nil, or set to the
+// default one-to-one card with no matching labels / no include labels.
+// The synthetic-scalar fold only fires for this shape; anything more
+// specific (on/ignoring/group_left/group_right) flows through the
+// regular VectorJoin path so cardinality / include semantics still
+// route through the V-V emitter.
+func isDefaultMatching(vm *parser.VectorMatching) bool {
+	if vm == nil {
+		return true
+	}
+	return vm.Card == parser.CardOneToOne &&
+		len(vm.MatchingLabels) == 0 &&
+		len(vm.Include) == 0 &&
+		!vm.On
+}
+
+// foldSyntheticBinary builds the combined Project for a V-V binop
+// where both legs are synthetic-scalar shapes. The returned plan is a
+// single 4-slot Project over the shared `OneRow` / `StepGrid` source
+// with the per-leg Value expressions woven together.
+//
+// The MetricName + Attributes + TimeUnix slots reuse the left leg's
+// expressions verbatim — both legs lowered through
+// [syntheticScalarVector] so the timestamp expression already
+// reflects the requested instant (`now64(9)` / a literal anchor) or
+// the per-step `anchor_ts` column. Choosing the left leg's timestamp
+// over the right's is arbitrary; the values are equal by construction
+// (both threaded from the same lowerCtx).
+//
+// Op-by-op Value shape:
+//
+//   - Arithmetic op: `(lhs_value OP rhs_value)`.
+//   - Comparison op + `bool` modifier: `toFloat64(lhs_value OP rhs_value)`
+//     (1.0 / 0.0 per step, matching PromQL's vector-bool semantics).
+//   - Comparison op WITHOUT `bool`: Prom's V-V comparison-as-filter rule
+//     applies — preserve LHS Value where the comparison holds, drop
+//     rows where it doesn't. We keep `lhs_value` in the Value slot and
+//     wrap the Project in a Filter on the comparison expression so
+//     the rendered SQL drops non-matching rows at the WHERE level.
+//     None of the 12 reported compat shape-diffs hit this branch
+//     (all of them carry the `bool` modifier when comparing two
+//     scalars), but we round it out for completeness — without the
+//     modifier the Prom parser permits the shape and the comparator
+//     in the harness would otherwise see another diff.
+func foldSyntheticBinary(left, right chplan.Node, op chplan.BinaryOp, returnBool bool, s schema.Metrics) chplan.Node {
+	lhsVal := syntheticValueExpr(left)
+	rhsVal := syntheticValueExpr(right)
+	cmpExpr := chplan.Expr(&chplan.Binary{Op: op, Left: lhsVal, Right: rhsVal})
+	leftProject := left.(*chplan.Project)
+
+	var newValue chplan.Expr
+	switch {
+	case isComparison(op) && returnBool:
+		newValue = &chplan.FuncCall{Name: "toFloat64", Args: []chplan.Expr{cmpExpr}}
+	case isComparison(op):
+		// Bare V-V comparison: Value is the LHS sample value (Prom's
+		// "preserve LHS where comparison holds" rule); the Filter
+		// below drops non-matching rows.
+		newValue = lhsVal
+	default:
+		newValue = cmpExpr
+	}
+
+	combined := &chplan.Project{
+		Input: syntheticSource(left),
+		Projections: []chplan.Projection{
+			leftProject.Projections[0], // "" AS MetricName
+			leftProject.Projections[1], // <empty-map> AS Attributes
+			leftProject.Projections[2], // <ts_expr> AS TimeUnix
+			{Expr: newValue, Alias: s.ValueColumn},
+		},
+	}
+
+	if isComparison(op) && !returnBool {
+		return &chplan.Filter{
+			Input:     combined,
+			Predicate: cmpExpr,
+		}
+	}
+	return combined
 }
 
 // promBinaryOp maps a PromQL parser op to the chplan op. Arithmetic and

--- a/internal/promql/synthetic.go
+++ b/internal/promql/synthetic.go
@@ -72,6 +72,94 @@ func syntheticScalarVector(valueExpr, timeExpr chplan.Expr, s schema.Metrics, ct
 	}
 }
 
+// isSyntheticScalarPlan reports whether plan is the shape produced by
+// [syntheticScalarVector]: a `Project` whose source is `OneRow` /
+// `StepGrid` and whose projections match the canonical 4-slot synthetic
+// vector layout — `LitString("") AS MetricName`, `<empty-map> AS
+// Attributes`, `<ts_expr> AS TimeUnix`, `<value_expr> AS Value`.
+//
+// Synthetic-scalar lowerings (`time()`, `vector(scalar)`, zero-arg
+// date functions) emit this exact shape: a one-per-step (range mode)
+// or one-row (instant mode) "constant per step" stream with no input
+// data dependency. When BOTH legs of a vector-vector binop lower to
+// this shape, the [lowerVectorVector] path would join two N-row
+// per-step streams via an INNER JOIN keyed on
+// `(MetricName, Attributes)` — and because the per-side argMax wrap
+// collapses each side to one row first, the join degenerates to
+// 1-row × 1-row even though Prom would emit N rows. The fix is to
+// detect this pair and fold to a single `Project` over a shared
+// `StepGrid` / `OneRow` source, mirroring how [TryFoldScalar] folds
+// pure literal-literal binops.
+//
+// The predicate is intentionally narrow: it matches only the shape
+// `syntheticScalarVector` writes. Any callsite that mints a Project
+// with a non-empty literal `MetricName`, a non-empty Attributes map,
+// or a different projection order falls through to the regular
+// V-V join path.
+func isSyntheticScalarPlan(plan chplan.Node, s schema.Metrics) bool {
+	p, ok := plan.(*chplan.Project)
+	if !ok {
+		return false
+	}
+	switch p.Input.(type) {
+	case *chplan.OneRow, *chplan.StepGrid:
+	default:
+		return false
+	}
+	if len(p.Projections) != 4 {
+		return false
+	}
+	// Projection 0 — MetricName slot: must be `LitString("")` aliased
+	// to the metric-name column. Any other shape (e.g. a CAST or a
+	// non-empty literal) means the plan carries identifying labels
+	// the fold would erase.
+	mn := p.Projections[0]
+	if mn.Alias != s.MetricNameColumn {
+		return false
+	}
+	if lit, ok := mn.Expr.(*chplan.LitString); !ok || lit.V != "" {
+		return false
+	}
+	// Projection 1 — Attributes slot: must be the canonical empty-map
+	// expression. We compare against a freshly-built emptyAttrsMap()
+	// to avoid coupling to its internal shape (CAST(map(),
+	// 'Map(String,String)')).
+	at := p.Projections[1]
+	if at.Alias != s.AttributesColumn {
+		return false
+	}
+	if !at.Expr.Equal(emptyAttrsMap()) {
+		return false
+	}
+	// Projection 2 — TimeUnix slot: alias-only check (the value
+	// expression varies between `now64(9)` / a `toDateTime64` literal
+	// / a `ColumnRef{anchor_ts}` depending on instant/range mode).
+	if p.Projections[2].Alias != s.TimestampColumn {
+		return false
+	}
+	// Projection 3 — Value slot: alias-only check (the value
+	// expression is exactly what we want to extract).
+	return p.Projections[3].Alias == s.ValueColumn
+}
+
+// syntheticValueExpr returns the Value-slot expression from a plan
+// previously matched by [isSyntheticScalarPlan]. The caller MUST gate
+// on `isSyntheticScalarPlan(plan, s) == true` before invoking —
+// otherwise the function panics (caller bug).
+func syntheticValueExpr(plan chplan.Node) chplan.Expr {
+	return plan.(*chplan.Project).Projections[3].Expr
+}
+
+// syntheticSource returns the underlying `OneRow` / `StepGrid` source
+// of a plan previously matched by [isSyntheticScalarPlan]. Used by the
+// V-V synthetic-fold path to attach the combined Project to one of
+// the two legs' sources (both legs share identical Start/End/Step in
+// the StepGrid case, since they thread through the same lowerCtx; the
+// instant-mode OneRow has no state).
+func syntheticSource(plan chplan.Node) chplan.Node {
+	return plan.(*chplan.Project).Input
+}
+
 // rewriteAnchorRefs walks expr and replaces every `now64(9)` /
 // `now()` FuncCall with a ColumnRef to `anchor_ts`. Used by the
 // range-mode synthetic-vector lowerings so the per-step value

--- a/internal/promql/synthetic_fold_test.go
+++ b/internal/promql/synthetic_fold_test.go
@@ -1,0 +1,149 @@
+package promql_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestSyntheticFold_TimeTime_Instant pins the lowering+emit shape for
+// `time() OP time()` and the bool-comparison variants in instant mode.
+// Both legs of these binops are synthetic-scalar plans (Project over
+// OneRow with empty MetricName / Attributes); the V-V VectorJoin path
+// collapses each leg to one row via argMax and joins on
+// `(MetricName, Attributes)`, leaving 1 × 1 = 1 row in range mode
+// instead of Prom's N rows per step. The fix detects synthetic-on-both
+// at lowering time and folds to a single Project that skips the join
+// entirely.
+//
+// The instant-mode assertions here check the output SQL has no INNER
+// JOIN (`AS L INNER JOIN`) and surfaces a single FROM (SELECT 1)
+// source — that's the proxy for "the fold fired and the join was
+// elided". Range-mode end-to-end coverage lives in the chDB step-loop
+// test under internal/api/prom.
+func TestSyntheticFold_TimeTime_Instant(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{})
+	instant := time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+
+	cases := []struct {
+		name  string
+		query string
+	}{
+		// 6 arithmetic.
+		{"add", "time() + time()"},
+		{"sub", "time() - time()"},
+		{"mul", "time() * time()"},
+		{"div", "time() / time()"},
+		{"mod", "time() % time()"},
+		{"pow", "time() ^ time()"},
+		// 6 bool comparisons.
+		{"eq_bool", "time() == bool time()"},
+		{"ne_bool", "time() != bool time()"},
+		{"lt_bool", "time() < bool time()"},
+		{"le_bool", "time() <= bool time()"},
+		{"gt_bool", "time() > bool time()"},
+		{"ge_bool", "time() >= bool time()"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr: %v", err)
+			}
+			plan, err := promql.LowerAt(context.Background(), expr, s, instant, instant)
+			if err != nil {
+				t.Fatalf("LowerAt: %v", err)
+			}
+			sql, _, err := chsql.Emit(context.Background(), plan)
+			if err != nil {
+				t.Fatalf("Emit: %v", err)
+			}
+			if strings.Contains(sql, "INNER JOIN") {
+				t.Fatalf("expected synthetic-fold to elide the V-V join; SQL still contains INNER JOIN:\n%s", sql)
+			}
+			if !strings.Contains(sql, "FROM (SELECT 1)") {
+				t.Fatalf("expected folded plan to render over (SELECT 1); SQL:\n%s", sql)
+			}
+		})
+	}
+}
+
+// TestSyntheticFold_TimeTime_Range pins the range-mode shape: the
+// folded plan must thread through to a StepGrid source so each step
+// in [start, end] emits its own row, instead of the 1-row collapse
+// the VectorJoin path produced pre-fix.
+func TestSyntheticFold_TimeTime_Range(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{})
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(5 * time.Minute)
+	step := 30 * time.Second
+
+	expr, err := p.ParseExpr("time() + time()")
+	if err != nil {
+		t.Fatalf("ParseExpr: %v", err)
+	}
+	plan, err := promql.LowerAtRange(context.Background(), expr, s, start, end, step)
+	if err != nil {
+		t.Fatalf("LowerAtRange: %v", err)
+	}
+	sql, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if strings.Contains(sql, "INNER JOIN") {
+		t.Fatalf("expected synthetic-fold to elide the V-V join in range mode; SQL still contains INNER JOIN:\n%s", sql)
+	}
+	// StepGrid emits a per-step `anchor_ts` column.
+	if !strings.Contains(sql, "anchor_ts") {
+		t.Fatalf("expected range-mode plan to reference anchor_ts; SQL:\n%s", sql)
+	}
+}
+
+// TestSyntheticFold_TimeArith_LiteralAndStep keeps the existing
+// time()-vs-literal binop path (lowerVectorScalar) byte-stable: the
+// fold predicate must not misfire for vector-scalar shapes (`1 +
+// time()`, `time() + 1`), which already work via the literal-scalar
+// fold one level up.
+func TestSyntheticFold_TimeArith_LiteralAndStep(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{})
+	instant := time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+
+	// `1 + time()` lowers via lowerVectorScalar; we don't want
+	// the synthetic-fold to interfere with that path (lhs is a
+	// scalar, not a synthetic vector).
+	expr, err := p.ParseExpr("1 + time()")
+	if err != nil {
+		t.Fatalf("ParseExpr: %v", err)
+	}
+	plan, err := promql.LowerAt(context.Background(), expr, s, instant, instant)
+	if err != nil {
+		t.Fatalf("LowerAt: %v", err)
+	}
+	sql, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	// Sanity: existing lowering path produced a single SELECT
+	// without an INNER JOIN.
+	if strings.Contains(sql, "INNER JOIN") {
+		t.Fatalf("`1 + time()` regression: expected no INNER JOIN; SQL:\n%s", sql)
+	}
+}

--- a/test/spec/promql/time_eq_bool_time_range.txtar
+++ b/test/spec/promql/time_eq_bool_time_range.txtar
@@ -1,0 +1,24 @@
+# `time() == bool time()` — synthetic-scalar V-V fold (bool
+# comparison). The `bool` modifier wraps the comparison in
+# `toFloat64(...)` so every matched pair surfaces as 1.0 / 0.0
+# rather than letting the comparison drop non-matching rows.
+# Companion to time_plus_time_range; pins the lowered chplan + SQL
+# for the equality-bool variant. See time_plus_time_range.txtar
+# for the fold's rationale.
+-- query.promql --
+time() == bool time()
+-- args --
+[0] string = ""
+[1] string = "Map(String,String)"
+[2] int64 = 9
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] int64 = 1000000000
+[6] string = "2026-01-01 00:00:01.000000000"
+[7] int64 = 9
+[8] int64 = 1000000000
+-- chplan --
+Project ["" AS MetricName, CAST(map(), "Map(String,String)") AS Attributes, now64(9) AS TimeUnix, toFloat64((toFloat64((toUnixTimestamp64Nano(toDateTime64("2026-01-01 00:00:01.000000000", 9)) / 1000000000)) = toFloat64((toUnixTimestamp64Nano(toDateTime64("2026-01-01 00:00:01.000000000", 9)) / 1000000000)))) AS Value]
+  OneRow
+-- sql --
+SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64((toFloat64((toUnixTimestamp64Nano(toDateTime64(?, ?)) / ?)) = toFloat64((toUnixTimestamp64Nano(toDateTime64(?, ?)) / ?)))) AS `Value` FROM (SELECT 1)

--- a/test/spec/promql/time_minus_time_range.txtar
+++ b/test/spec/promql/time_minus_time_range.txtar
@@ -1,0 +1,21 @@
+# `time() - time()` — synthetic-scalar V-V fold (arithmetic SUB).
+# Companion to time_plus_time_range; pins the lowered chplan + SQL
+# for the subtract variant. See time_plus_time_range.txtar for the
+# fold's rationale.
+-- query.promql --
+time() - time()
+-- args --
+[0] string = ""
+[1] string = "Map(String,String)"
+[2] int64 = 9
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] int64 = 1000000000
+[6] string = "2026-01-01 00:00:01.000000000"
+[7] int64 = 9
+[8] int64 = 1000000000
+-- chplan --
+Project ["" AS MetricName, CAST(map(), "Map(String,String)") AS Attributes, now64(9) AS TimeUnix, (toFloat64((toUnixTimestamp64Nano(toDateTime64("2026-01-01 00:00:01.000000000", 9)) / 1000000000)) - toFloat64((toUnixTimestamp64Nano(toDateTime64("2026-01-01 00:00:01.000000000", 9)) / 1000000000))) AS Value]
+  OneRow
+-- sql --
+SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, (toFloat64((toUnixTimestamp64Nano(toDateTime64(?, ?)) / ?)) - toFloat64((toUnixTimestamp64Nano(toDateTime64(?, ?)) / ?))) AS `Value` FROM (SELECT 1)

--- a/test/spec/promql/time_plus_time_range.txtar
+++ b/test/spec/promql/time_plus_time_range.txtar
@@ -1,0 +1,29 @@
+# `time() + time()` — synthetic-scalar V-V fold. Pre-fix this lowered
+# to a VectorJoin whose per-side argMax collapse produced 1×1 rows;
+# in range mode that surfaced as 12 compat-lane shape-diffs because
+# Prom emits one row per (start, end, step) step. The fix detects
+# "both legs are synthetic-scalar plans" at lowering time and folds
+# to a single Project over the shared OneRow / StepGrid source —
+# mirroring how TryFoldScalar folds literal-literal binops.
+#
+# Instant-mode shape here pins the fold's chplan + SQL: a single
+# 4-slot Project over (SELECT 1) with Value = (left_time + right_time).
+# Range mode (StepGrid source) exercised by the chDB step-loop test
+# under internal/api/prom/handler_chdb_step_loop_test.go.
+-- query.promql --
+time() + time()
+-- args --
+[0] string = ""
+[1] string = "Map(String,String)"
+[2] int64 = 9
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] int64 = 1000000000
+[6] string = "2026-01-01 00:00:01.000000000"
+[7] int64 = 9
+[8] int64 = 1000000000
+-- chplan --
+Project ["" AS MetricName, CAST(map(), "Map(String,String)") AS Attributes, now64(9) AS TimeUnix, (toFloat64((toUnixTimestamp64Nano(toDateTime64("2026-01-01 00:00:01.000000000", 9)) / 1000000000)) + toFloat64((toUnixTimestamp64Nano(toDateTime64("2026-01-01 00:00:01.000000000", 9)) / 1000000000))) AS Value]
+  OneRow
+-- sql --
+SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, (toFloat64((toUnixTimestamp64Nano(toDateTime64(?, ?)) / ?)) + toFloat64((toUnixTimestamp64Nano(toDateTime64(?, ?)) / ?))) AS `Value` FROM (SELECT 1)


### PR DESCRIPTION
## Summary

Closes 12 of the remaining compat-lane shape-diffs — all `time() OP time()` variants (6 arithmetic + 6 bool comparisons).

## Root cause

After #337 (engine step-loop drives from start/end/step), both legs of `time() + time()` synthesise an N-row Project over `chplan.StepGrid` with `MetricName=""`, `Attributes=map()`. The V-V binop wraps them in a `chplan.VectorJoin`, which collapses each leg via per-series argMax-over-TimeUnix to ONE row per (MetricName, Attributes). Both sides reduce to 1 row → join yields 1 row instead of N.

## Fix (lowering-time fold)

Detect when both legs are "synthetic scalar plans" — Project over OneRow/StepGrid with the canonical 4-projection shape (MetricName, Attributes, TimeUnix, Value) — and combine them into a single Project over the shared source with `Value = <op>(lhs_value, rhs_value)`. VectorJoin is skipped entirely.

```go
func isSyntheticScalarPlan(plan chplan.Node, s schema.Metrics) bool
```

Mirrors #316's `TryFoldScalar` extension; covers both instant (OneRow) and range (StepGrid) modes.

## Before / after for `time() + time()` over 3 steps

**Before** — `VectorJoin op=+ match=default card=one-to-one` over two argMax-collapsed legs = 1 row.

**After** — `Project[..., (toFloat64(toUnixTimestamp64Nano(anchor_ts)/1e9) + toFloat64(toUnixTimestamp64Nano(anchor_ts)/1e9)) AS Value]` over `StepGrid(3 anchors)` = 3 rows.

## Test plan

- [x] `go test ./internal/{promql,chsql,chplan}/` — 1089 pass
- [x] `go test -tags chdb ./internal/api/prom/ -run TestQueryRange_StepLoop` — 20 pass (incl. 12 new TimeTime_ChDB subtests covering add/sub/mul/div/mod/pow + 6 bool comparisons)
- [x] `go test ./...` — 2687 pass, no regressions
- [x] 3 new TXTAR fixtures: `time_plus_time_range`, `time_minus_time_range`, `time_eq_bool_time_range`

7 files, +572 LoC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>