### PR TITLE
fix(harness): re-label seed to PromLabs demo schema (instance/job/type)

### DIFF
--- a/harness/prometheus-compliance/cerberus-test-queries.yml
+++ b/harness/prometheus-compliance/cerberus-test-queries.yml
@@ -2,40 +2,24 @@
 #
 # This file is a near-verbatim copy of
 # harness/prometheus-compliance/upstream/promql/promql-test-queries.yml
-# (prometheus/compliance @ 7e28242) with a small set of edits:
+# (prometheus/compliance @ 7e28242) with one edit:
 #
 # 1. The PromLabs "demo service" preamble (lines 1-31 of the upstream file)
 #    is stripped — it documents docker-run instructions for the prometheus-
 #    demo-service that the OTel-seeded harness doesn't use.
 #
-# 2. Three queries are REMOVED:
+# Series schema: the harness seeds a fixture that mirrors PromLabs's demo
+# service labels (`instance` / `job` / `type` / `mode` / `method` / `path`
+# / `status` / `device`). `instance` values are `demo.promlabs.com:10000`
+# / `:10001` / `:10002`; every series carries `job=demo`. See
+# `cmd/seed/main.go::fixtureInserts` for the canonical label sets.
 #
-#        label_replace(demo_num_cpus, "~invalid", "", "src", "(.*)")
-#        should_fail: true
-#
-#        label_replace(demo_num_cpus, "instance", "", "", "")
-#        should_fail: true
-#
-#        label_join(demo_num_cpus, "~invalid", "-", "instance")
-#        should_fail: true
-#
-#    Background: upstream annotates each as `should_fail: true` because
-#    Prom rejects either an invalid destination label name or a
-#    duplicated-output-label-set construction. BUT the failure path is
-#    only hit when the metric (`demo_num_cpus`) actually returns data —
-#    with an empty input vector, Prom's executor short-circuits and
-#    returns success-with-empty BEFORE the validation check fires. Our
-#    OTel seed corpus does not populate `demo_num_cpus`, so all three
-#    return empty-success, and the upstream `promql-compliance-tester`
-#    `log.Fatalf`'s on the first one ("expected reference API query …
-#    to fail, but succeeded"), aborting the entire run. Removing the
-#    entries lets the harness run to completion. When the seed corpus
-#    grows to include `demo_num_cpus`, restore the queries in M1.x.
-#
-# All other entries (including queries that reference demo metrics not yet
-# in the seed) are preserved verbatim: when both ref Prom and cerberus
-# return empty results for a missing-metric query, the tester records that
-# as PASS (zero diff), which is acceptable noise for the RC1 baseline.
+# Some metric families referenced by individual queries are NOT yet in
+# the seed (e.g. `demo_api_request_duration_seconds_bucket`,
+# `demo_batch_last_success_timestamp_seconds`, `demo_intermittent_metric`).
+# When both ref Prom and cerberus return empty results for a missing-metric
+# query, the tester records that as PASS (zero diff) — acceptable noise
+# for the RC1 baseline.
 #
 # Pointer-to-upstream: re-sync this file by re-copying the upstream and
 # re-applying the edit above. Track in a follow-up M1.x ticket so this
@@ -210,14 +194,16 @@ test_cases:
     # label_replace fails when the regex is invalid.
   - query: 'label_replace(demo_num_cpus, "job", "value-$1", "src", "(.*")'
     should_fail: true
-    # NOTE: 3 upstream entries with `should_fail: true` are intentionally
-    # OMITTED here — see the file header for rationale. They were:
-    #   label_replace(demo_num_cpus, "~invalid", "", "src", "(.*)")  should_fail: true
-    #   label_replace(demo_num_cpus, "instance", "", "", "")         should_fail: true
-    #   label_join(demo_num_cpus, "~invalid", "-", "instance")       should_fail: true
-    # All three depend on demo_num_cpus being non-empty for Prom to hit
-    # the failure path. With our seed corpus, ref Prom returns empty
-    # success and the upstream tester log.Fatalf's.
+    # label_replace fails when the destination label name is invalid.
+  - query: 'label_replace(demo_num_cpus, "~invalid", "", "src", "(.*)")'
+    should_fail: true
+    # label_replace fails when the source label is empty and would produce
+    # a duplicate output label set.
+  - query: 'label_replace(demo_num_cpus, "instance", "", "", "")'
+    should_fail: true
+    # label_join fails when the destination label name is invalid.
+  - query: 'label_join(demo_num_cpus, "~invalid", "-", "instance")'
+    should_fail: true
   - query: 'label_join(demo_num_cpus, "new_label", "-", "instance", "job")'
   - query: 'label_join(demo_num_cpus, "job", "-", "instance", "job")'
   - query: 'label_join(demo_num_cpus, "job", "-", "instance")'

--- a/harness/prometheus-compliance/cmd/seed/main.go
+++ b/harness/prometheus-compliance/cmd/seed/main.go
@@ -163,8 +163,26 @@ type namedStmt struct {
 
 // fixtureInserts is the ordered list of seed INSERTs. Each SQL string is a
 // static literal — see insertFixture's docstring for why.
+//
+// Label schema matches the PromLabs demo service that the upstream
+// `prometheus/compliance/promql/promql-test-queries.yml` was written
+// against. The compatibility tester hits `on(instance, job, type)` and
+// equivalent matchers; series tagged with `host=host-a|host-b` only would
+// share the empty match group `{}` and trip the "duplicate series for the
+// match group" abort in the upstream tester. Canonical instance values
+// are `demo.promlabs.com:10000` / `:10001` / `:10002`; every series
+// carries `job=demo` (the Prom-default label PromLabs's scrape config
+// would inject). `ResourceAttributes` stays `service.name=demo` — that's
+// the OTel resource layer and is unrelated to the Prom-side wire labels
+// the tester matches on.
 var fixtureInserts = []namedStmt{
-	// demo_cpu_usage_seconds_total: 2 hosts × 3 modes, counters.
+	// demo_cpu_usage_seconds_total: 3 instances × 3 modes = 9 series, counters.
+	//
+	// CROSS JOIN the instance + mode dimensions against the step axis so every
+	// (instance, mode) pair gets one sample per step. A `(number % 3)`
+	// derivation for both dimensions would correlate them — only 3 series
+	// (not 9) would land in CH and the suite's `by(instance, mode)` queries
+	// would silently degenerate.
 	{
 		name: "demo_cpu_usage_seconds_total",
 		sql: `INSERT INTO otel_metrics_sum
@@ -176,24 +194,31 @@ var fixtureInserts = []namedStmt{
             'demo_cpu_usage_seconds_total',
             'CPU seconds spent in mode',
             'seconds',
-            map('host', host, 'mode', mode),
+            map('instance', instance, 'job', 'demo', 'mode', mode),
             toDateTime64({anchor:String}, 9),
             toDateTime64({anchor:String}, 9) + INTERVAL step SECOND,
-            toFloat64(step + (host_idx * 100) + (mode_idx * 10)),
+            toFloat64(step + (instance_idx * 1000) + (mode_idx * 100)),
             0,
             2,
             true
         FROM (
-            SELECT
-                number AS step,
-                arrayElement(['host-a','host-b'], (number % 2) + 1) AS host,
-                arrayElement(['user','system','idle'], (number % 3) + 1) AS mode,
-                (number % 2) AS host_idx,
-                (number % 3) AS mode_idx
-            FROM numbers({steps:UInt64})
+            SELECT step, instance, instance_idx, mode, mode_idx
+            FROM (SELECT number AS step FROM numbers({steps:UInt64})) AS s
+            CROSS JOIN (
+                SELECT arrayJoin(
+                    ['demo.promlabs.com:10000','demo.promlabs.com:10001','demo.promlabs.com:10002']
+                ) AS instance,
+                indexOf(
+                    ['demo.promlabs.com:10000','demo.promlabs.com:10001','demo.promlabs.com:10002'],
+                    instance) - 1 AS instance_idx
+            ) AS i
+            CROSS JOIN (
+                SELECT arrayJoin(['user','system','idle']) AS mode,
+                indexOf(['user','system','idle'], mode) - 1 AS mode_idx
+            ) AS m
         )`,
 	},
-	// demo_memory_usage_bytes: 2 hosts, gauge.
+	// demo_memory_usage_bytes: 3 instances × 4 types = 12 series, gauge.
 	{
 		name: "demo_memory_usage_bytes",
 		sql: `INSERT INTO otel_metrics_gauge
@@ -204,19 +229,29 @@ var fixtureInserts = []namedStmt{
             'demo_memory_usage_bytes',
             'Memory in use',
             'bytes',
-            map('host', host),
+            map('instance', instance, 'job', 'demo', 'type', type),
             toDateTime64({anchor:String}, 9),
             toDateTime64({anchor:String}, 9) + INTERVAL step SECOND,
-            toFloat64(2 * 1024 * 1024 * 1024 + (step * 1024) + (host_idx * 512))
+            toFloat64(2 * 1024 * 1024 * 1024 + (step * 1024) + (instance_idx * 10000000) + (type_idx * 1000000))
         FROM (
-            SELECT
-                number AS step,
-                arrayElement(['host-a','host-b'], (number % 2) + 1) AS host,
-                (number % 2) AS host_idx
-            FROM numbers({steps:UInt64})
+            SELECT step, instance, instance_idx, type, type_idx
+            FROM (SELECT number AS step FROM numbers({steps:UInt64})) AS s
+            CROSS JOIN (
+                SELECT arrayJoin(
+                    ['demo.promlabs.com:10000','demo.promlabs.com:10001','demo.promlabs.com:10002']
+                ) AS instance,
+                indexOf(
+                    ['demo.promlabs.com:10000','demo.promlabs.com:10001','demo.promlabs.com:10002'],
+                    instance) - 1 AS instance_idx
+            ) AS i
+            CROSS JOIN (
+                SELECT arrayJoin(['cached','free','buffers','used']) AS type,
+                indexOf(['cached','free','buffers','used'], type) - 1 AS type_idx
+            ) AS t
         )`,
 	},
-	// demo_http_requests_total: 2 routes × 2 statuses, counter reset.
+	// demo_http_requests_total: 2 instances × 2 methods × 2 paths × 2 statuses = 16 series,
+	// counter reset.
 	{
 		name: "demo_http_requests_total",
 		sql: `INSERT INTO otel_metrics_sum
@@ -228,26 +263,38 @@ var fixtureInserts = []namedStmt{
             'demo_http_requests_total',
             'HTTP requests by route + status',
             '1',
-            map('route', route, 'status', status),
+            map('instance', instance, 'job', 'demo',
+                'method', method, 'path', path, 'status', status),
             toDateTime64({anchor:String}, 9),
             toDateTime64({anchor:String}, 9) + INTERVAL step SECOND,
             if(step < 120,
-                toFloat64(step * 10 + (route_idx * 100) + (status_idx * 50)),
-                toFloat64((step - 120) * 10 + (route_idx * 100) + (status_idx * 50))),
+                toFloat64(step * 10 + (instance_idx * 1000) + (method_idx * 500) + (path_idx * 250) + (status_idx * 100)),
+                toFloat64((step - 120) * 10 + (instance_idx * 1000) + (method_idx * 500) + (path_idx * 250) + (status_idx * 100))),
             0,
             2,
             true
         FROM (
-            SELECT
-                number AS step,
-                arrayElement(['/api','/web'], (number % 2) + 1) AS route,
-                arrayElement(['200','500'], (number % 2) + 1) AS status,
-                (number % 2) AS route_idx,
-                (number % 2) AS status_idx
-            FROM numbers({steps:UInt64})
+            SELECT step, instance, instance_idx, method, method_idx, path, path_idx, status, status_idx
+            FROM (SELECT number AS step FROM numbers({steps:UInt64})) AS s
+            CROSS JOIN (
+                SELECT arrayJoin(['demo.promlabs.com:10000','demo.promlabs.com:10001']) AS instance,
+                indexOf(['demo.promlabs.com:10000','demo.promlabs.com:10001'], instance) - 1 AS instance_idx
+            ) AS i
+            CROSS JOIN (
+                SELECT arrayJoin(['GET','POST']) AS method,
+                indexOf(['GET','POST'], method) - 1 AS method_idx
+            ) AS me
+            CROSS JOIN (
+                SELECT arrayJoin(['/api','/web']) AS path,
+                indexOf(['/api','/web'], path) - 1 AS path_idx
+            ) AS p
+            CROSS JOIN (
+                SELECT arrayJoin(['200','500']) AS status,
+                indexOf(['200','500'], status) - 1 AS status_idx
+            ) AS st
         )`,
 	},
-	// demo_disk_usage_bytes: 1 host × 2 mounts, gauge.
+	// demo_disk_usage_bytes: 2 instances × 2 devices = 4 series, gauge.
 	{
 		name: "demo_disk_usage_bytes",
 		sql: `INSERT INTO otel_metrics_gauge
@@ -258,16 +305,21 @@ var fixtureInserts = []namedStmt{
             'demo_disk_usage_bytes',
             'Disk space in use',
             'bytes',
-            map('host', 'host-a', 'mount', mount),
+            map('instance', instance, 'job', 'demo', 'device', device),
             toDateTime64({anchor:String}, 9),
             toDateTime64({anchor:String}, 9) + INTERVAL step SECOND,
-            toFloat64(10 * 1024 * 1024 * 1024 + step * mount_idx * 1024)
+            toFloat64(10 * 1024 * 1024 * 1024 + step * (device_idx + 1) * 1024 + (instance_idx * 4096))
         FROM (
-            SELECT
-                number AS step,
-                arrayElement(['/','/data'], (number % 2) + 1) AS mount,
-                ((number % 2) + 1) AS mount_idx
-            FROM numbers({steps:UInt64})
+            SELECT step, instance, instance_idx, device, device_idx
+            FROM (SELECT number AS step FROM numbers({steps:UInt64})) AS s
+            CROSS JOIN (
+                SELECT arrayJoin(['demo.promlabs.com:10000','demo.promlabs.com:10001']) AS instance,
+                indexOf(['demo.promlabs.com:10000','demo.promlabs.com:10001'], instance) - 1 AS instance_idx
+            ) AS i
+            CROSS JOIN (
+                SELECT arrayJoin(['/dev/sda1','/dev/sda2']) AS device,
+                indexOf(['/dev/sda1','/dev/sda2'], device) - 1 AS device_idx
+            ) AS d
         )`,
 	},
 	// demo_disk_total_bytes: companion to disk_usage_bytes, gauge.
@@ -281,18 +333,53 @@ var fixtureInserts = []namedStmt{
             'demo_disk_total_bytes',
             'Total disk capacity',
             'bytes',
-            map('host', 'host-a', 'mount', mount),
+            map('instance', instance, 'job', 'demo', 'device', device),
             toDateTime64({anchor:String}, 9),
             toDateTime64({anchor:String}, 9) + INTERVAL step SECOND,
             toFloat64(100 * 1024 * 1024 * 1024)
         FROM (
-            SELECT
-                number AS step,
-                arrayElement(['/','/data'], (number % 2) + 1) AS mount
-            FROM numbers({steps:UInt64})
+            SELECT step, instance, device
+            FROM (SELECT number AS step FROM numbers({steps:UInt64})) AS s
+            CROSS JOIN (
+                SELECT arrayJoin(['demo.promlabs.com:10000','demo.promlabs.com:10001']) AS instance
+            ) AS i
+            CROSS JOIN (
+                SELECT arrayJoin(['/dev/sda1','/dev/sda2']) AS device
+            ) AS d
         )`,
 	},
-	// up: 2 instances, both up.
+	// demo_num_cpus: 3 instances, gauge. Value = 4 cores per instance, constant.
+	//
+	// Originally absent from the seed (see the cerberus-test-queries.yml header
+	// for the removal rationale); restored to cover the 28 query mentions in
+	// the test file plus the 3 `should_fail: true` label_replace / label_join
+	// entries that the header documented as gated on this metric returning
+	// non-empty data.
+	{
+		name: "demo_num_cpus",
+		sql: `INSERT INTO otel_metrics_gauge
+            (ResourceAttributes, MetricName, MetricDescription, MetricUnit,
+             Attributes, StartTimeUnix, TimeUnix, Value)
+        SELECT
+            map('service.name', 'demo'),
+            'demo_num_cpus',
+            'Number of CPU cores on the target',
+            '1',
+            map('instance', instance, 'job', 'demo'),
+            toDateTime64({anchor:String}, 9),
+            toDateTime64({anchor:String}, 9) + INTERVAL step SECOND,
+            4.0
+        FROM (
+            SELECT step, instance
+            FROM (SELECT number AS step FROM numbers({steps:UInt64})) AS s
+            CROSS JOIN (
+                SELECT arrayJoin(
+                    ['demo.promlabs.com:10000','demo.promlabs.com:10001','demo.promlabs.com:10002']
+                ) AS instance
+            ) AS i
+        )`,
+	},
+	// up: 3 instances, all up.
 	{
 		name: "up",
 		sql: `INSERT INTO otel_metrics_gauge
@@ -308,10 +395,13 @@ var fixtureInserts = []namedStmt{
             toDateTime64({anchor:String}, 9) + INTERVAL step SECOND,
             1.0
         FROM (
-            SELECT
-                number AS step,
-                arrayElement(['host-a:9100','host-b:9100'], (number % 2) + 1) AS instance
-            FROM numbers({steps:UInt64})
+            SELECT step, instance
+            FROM (SELECT number AS step FROM numbers({steps:UInt64})) AS s
+            CROSS JOIN (
+                SELECT arrayJoin(
+                    ['demo.promlabs.com:10000','demo.promlabs.com:10001','demo.promlabs.com:10002']
+                ) AS instance
+            ) AS i
         )`,
 	},
 }

--- a/harness/prometheus-compliance/cmd/seed/prom_remote.go
+++ b/harness/prometheus-compliance/cmd/seed/prom_remote.go
@@ -79,6 +79,7 @@ var fixtureSources = []fixtureSource{
 	{"demo_http_requests_total", "otel_metrics_sum"},
 	{"demo_disk_usage_bytes", "otel_metrics_gauge"},
 	{"demo_disk_total_bytes", "otel_metrics_gauge"},
+	{"demo_num_cpus", "otel_metrics_gauge"},
 	{"up", "otel_metrics_gauge"},
 }
 


### PR DESCRIPTION
## Summary

Stops the compat-tester from aborting mid-run on `demo_memory_usage_bytes + on(instance, job, type) demo_memory_usage_bytes`: the previous seed labeled with `host` only, so both series shared empty match group `{}` → `many-to-many matching not allowed`.

## Schema diff (was → now)

| Metric | Before | After |
|---|---|---|
| `demo_cpu_usage_seconds_total` | `{host, mode}` (6) | `{instance, job, mode}` (9) |
| `demo_memory_usage_bytes` | `{host}` (2) | `{instance, job, type}` (12, types = cached/free/buffers/used) |
| `demo_http_requests_total` | `{route, status}` (4) | `{instance, job, method, path, status}` (16) |
| `demo_disk_usage_bytes` | `{host, mount}` (2) | `{instance, job, device}` (4) |
| `demo_disk_total_bytes` | same | same (4) |
| `demo_num_cpus` | _absent_ | `{instance, job}` (3, value=4) |
| `up` | `{instance, job}` with host-a/b | `{instance, job}` with PromLabs instances (3) |

3 PromLabs instances: `demo.promlabs.com:10000/10001/10002`. Every series carries `job=demo`.

`ResourceAttributes` stays `service.name=demo` (OTel layer, unchanged).

## Cross-product fix

The old seed used `arrayElement(['x','y'], (number%2)+1)` for multiple dimensions — the modulo correlated `instance` with `mode`, producing only 3 series for a `(instance×mode)` 3×3 product. Replaced with `CROSS JOIN arrayJoin(...)` so independent dimensions actually fan out (3×3 = 9, etc.).

## Coverage check

Every label in `cerberus-test-queries.yml`'s selectors / `on(...)` / `by(...)` / `without(...)` / `group_left(...)` is covered: `instance`, `type`, `mode`, `job`, `__name__`. Deliberately-absent names (`nonexistent`, `non_existent`) preserved.

## Restored queries

- `demo_num_cpus` re-introduced (28 query refs depended on it).
- 3 `should_fail: true` entries (`label_replace(..., "~invalid", ...)`, `label_replace(..., "instance", "", "", "")`, `label_join(..., "~invalid", ...)`) restored — they require `demo_num_cpus` to be non-empty to fail correctly.

Header comment rewritten to reflect the new state.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./harness/prometheus-compliance/...` — ok
- [x] Hand-walked match groups for `demo_memory_usage_bytes + on(instance, job, type) ...` → 12 unique groups, 1-to-1 — no abort.
- Will be validated end-to-end by next compat run

3 files, +207 / -119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>