### PR TITLE
fix(harness): seed 15s spacing per comment (was 1s; only 4min of data)

### DIFF
--- a/harness/prometheus-compliance/cmd/seed/main.go
+++ b/harness/prometheus-compliance/cmd/seed/main.go
@@ -196,7 +196,7 @@ var fixtureInserts = []namedStmt{
             'seconds',
             map('instance', instance, 'job', 'demo', 'mode', mode),
             toDateTime64({anchor:String}, 9),
-            toDateTime64({anchor:String}, 9) + INTERVAL step SECOND,
+            toDateTime64({anchor:String}, 9) + INTERVAL step * 15 SECOND,
             toFloat64(step + (instance_idx * 1000) + (mode_idx * 100)),
             0,
             2,
@@ -231,7 +231,7 @@ var fixtureInserts = []namedStmt{
             'bytes',
             map('instance', instance, 'job', 'demo', 'type', type),
             toDateTime64({anchor:String}, 9),
-            toDateTime64({anchor:String}, 9) + INTERVAL step SECOND,
+            toDateTime64({anchor:String}, 9) + INTERVAL step * 15 SECOND,
             toFloat64(2 * 1024 * 1024 * 1024 + (step * 1024) + (instance_idx * 10000000) + (type_idx * 1000000))
         FROM (
             SELECT step, instance, instance_idx, type, type_idx
@@ -266,7 +266,7 @@ var fixtureInserts = []namedStmt{
             map('instance', instance, 'job', 'demo',
                 'method', method, 'path', path, 'status', status),
             toDateTime64({anchor:String}, 9),
-            toDateTime64({anchor:String}, 9) + INTERVAL step SECOND,
+            toDateTime64({anchor:String}, 9) + INTERVAL step * 15 SECOND,
             if(step < 120,
                 toFloat64(step * 10 + (instance_idx * 1000) + (method_idx * 500) + (path_idx * 250) + (status_idx * 100)),
                 toFloat64((step - 120) * 10 + (instance_idx * 1000) + (method_idx * 500) + (path_idx * 250) + (status_idx * 100))),
@@ -307,7 +307,7 @@ var fixtureInserts = []namedStmt{
             'bytes',
             map('instance', instance, 'job', 'demo', 'device', device),
             toDateTime64({anchor:String}, 9),
-            toDateTime64({anchor:String}, 9) + INTERVAL step SECOND,
+            toDateTime64({anchor:String}, 9) + INTERVAL step * 15 SECOND,
             toFloat64(10 * 1024 * 1024 * 1024 + step * (device_idx + 1) * 1024 + (instance_idx * 4096))
         FROM (
             SELECT step, instance, instance_idx, device, device_idx
@@ -335,7 +335,7 @@ var fixtureInserts = []namedStmt{
             'bytes',
             map('instance', instance, 'job', 'demo', 'device', device),
             toDateTime64({anchor:String}, 9),
-            toDateTime64({anchor:String}, 9) + INTERVAL step SECOND,
+            toDateTime64({anchor:String}, 9) + INTERVAL step * 15 SECOND,
             toFloat64(100 * 1024 * 1024 * 1024)
         FROM (
             SELECT step, instance, device
@@ -367,7 +367,7 @@ var fixtureInserts = []namedStmt{
             '1',
             map('instance', instance, 'job', 'demo'),
             toDateTime64({anchor:String}, 9),
-            toDateTime64({anchor:String}, 9) + INTERVAL step SECOND,
+            toDateTime64({anchor:String}, 9) + INTERVAL step * 15 SECOND,
             4.0
         FROM (
             SELECT step, instance
@@ -392,7 +392,7 @@ var fixtureInserts = []namedStmt{
             '1',
             map('instance', instance, 'job', 'demo'),
             toDateTime64({anchor:String}, 9),
-            toDateTime64({anchor:String}, 9) + INTERVAL step SECOND,
+            toDateTime64({anchor:String}, 9) + INTERVAL step * 15 SECOND,
             1.0
         FROM (
             SELECT step, instance


### PR DESCRIPTION
## Summary

The compat seed comment claims `240 × 15s = 1h — matches TESTER_RANGE=3600`, but every `INSERT INTO` emits `INTERVAL step SECOND` instead of `INTERVAL step * 15 SECOND`. Result: 240 rows × 1s = **4 minutes of data**, not 1 hour.

## Why it didn't surface until now

Pre-#338, Prom had no fixture. Most metric queries returned `{}` on both Prom and cerberus → tautological matches.

After #338 (remote_write fan-out) + #342 (PromLabs schema relabel) + #344 (drop should_fail), Prom genuinely has 1h of data via remote_write. Cerberus's LWR 5-minute staleness window finds no data for ~95% of eval timestamps in the 1h range → cerberus returns empty → 387 shape-diffs in the post-#344 baseline (148/536 passing).

## Fix

Every `INTERVAL step SECOND` → `INTERVAL step * 15 SECOND` in `harness/prometheus-compliance/cmd/seed/main.go`. 7 INSERT blocks updated.

Seed now spans 0..3585s = 59m45s, within cerberus's LWR window throughout the 1h `TESTER_RANGE`. Both sides see the same data; comparisons against real data become meaningful.

## Expected after merge

Next compat run should jump significantly above 148/536. Some genuine cerberus-vs-Prom semantic diffs may still remain (e.g. counter-rate edge cases) but the bulk-empty-results storm should resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>