### PR TITLE
feat(promql,api/prom): per-step range-mode lowering (LWR via StepGrid cross-join)

### DIFF
--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -671,24 +671,38 @@ func toVector(samples []chclient.Sample, ts time.Time) []VectorSample {
 	return out
 }
 
-// matrixFromCursor is the streaming pivot from the cursor: it
-// drains the cursor row-by-row instead of consuming a pre-materialised
-// []chclient.Sample slice. Per-series buffers (timestamps + values) live
-// in a map keyed by canonicalKey; once the cursor is fully drained we
-// pivot each buffer onto the step grid using the same latest-at-step
-// semantics PromQL uses (latest sample at-or-before step, within lookback delta).
+// matrixFromCursor drains the cursor row-by-row and emits one Matrix
+// sample per row at the row's TimeUnix.
 //
-// Memory complexity: O(rows) total in the per-series buffers — but with
-// the master []chclient.Sample slice gone, peak resident bytes shrink
-// roughly 2x (no parallel copy) and the gc churn from growing one big
-// slice disappears. The eventual fully-streaming variant (one series at
-// a time, flushed on canonicalKey boundary changes) requires the SQL
-// emission to ORDER BY (series_key, ts) — that lands as a separate
-// follow-up so this PR stays scoped to the API surface change.
+// The Pool-AK range-mode rework makes every PromQL `query_range`
+// plan emit one row per (series, step anchor) on the SQL side —
+// each row already carries the per-step LWR-resolved value at the
+// correct anchor timestamp. The matrix-shape RangeWindow path (rate
+// / *_over_time / subquery) follows the same per-anchor contract.
+// So the matrix pivot is now a trivial row → sample copy keyed by
+// canonical series key, with no step-grid iteration or carry-forward
+// dance.
+//
+// Empty-window anchors are dropped by the SQL itself (the per-step
+// LWR yields no row when no sample falls in `(anchor-5m, anchor]`;
+// the matrix RangeWindow's `length(window_vals) >= N` predicate
+// drops empty rate / *_over_time windows). The pivot mirrors that
+// behaviour by simply not emitting a sample at an anchor for which
+// no row was returned — preserving Prom's "no sample for an empty
+// staleness window" rule end-to-end.
+//
+// Rows whose Timestamp falls outside `[start, end]` are clipped so a
+// drifted server-side `now64(9)` (legacy bare-selector instant
+// shapes) never lands a stray point past the request window.
+//
+// Memory complexity: O(rows) total in the per-series buffers. The
+// eventual fully-streaming variant (one series at a time, flushed on
+// canonicalKey boundary changes) requires the SQL emission to
+// ORDER BY (series_key, ts).
 func matrixFromCursor(
 	cursor chclient.Cursor,
 	start, end time.Time,
-	step time.Duration,
+	_ time.Duration,
 ) ([]MatrixSample, error) {
 	type seriesState struct {
 		labels map[string]string
@@ -711,11 +725,12 @@ func matrixFromCursor(
 		return nil, err
 	}
 
-	const lookback = 5 * time.Minute
 	out := make([]MatrixSample, 0, len(bySeries))
 	for _, st := range bySeries {
 		// Inline insertion sort by Timestamp ascending — rows are
-		// typically already nearly sorted from CH.
+		// typically already nearly sorted from CH but the CrossJoin
+		// + Aggregate plan shapes the rework introduces do not
+		// guarantee row order across (series, anchor) pairs.
 		for i := 1; i < len(st.rows); i++ {
 			for j := i; j > 0 && st.rows[j-1].Timestamp.After(st.rows[j].Timestamp); j-- {
 				st.rows[j-1], st.rows[j] = st.rows[j], st.rows[j-1]
@@ -723,20 +738,12 @@ func matrixFromCursor(
 		}
 
 		ms := MatrixSample{Metric: st.labels}
-		row := 0
-		for t := start; !t.After(end); t = t.Add(step) {
-			for row < len(st.rows) && !st.rows[row].Timestamp.After(t) {
-				row++
-			}
-			if row == 0 {
+		for _, r := range st.rows {
+			if r.Timestamp.Before(start) || r.Timestamp.After(end) {
 				continue
 			}
-			latest := st.rows[row-1]
-			if t.Sub(latest.Timestamp) > lookback {
-				continue
-			}
-			stamp := float64(t.UnixMilli()) / 1e3
-			ms.Values = append(ms.Values, Sample{stamp, strconv.FormatFloat(latest.Value, 'f', -1, 64)})
+			stamp := float64(r.Timestamp.UnixMilli()) / 1e3
+			ms.Values = append(ms.Values, Sample{stamp, strconv.FormatFloat(r.Value, 'f', -1, 64)})
 		}
 		if len(ms.Values) > 0 {
 			out = append(out, ms)

--- a/internal/api/prom/handler_chdb_range_mode_test.go
+++ b/internal/api/prom/handler_chdb_range_mode_test.go
@@ -1,0 +1,341 @@
+//go:build chdb
+
+// chDB-backed regression coverage for the Pool-AK range-mode rework.
+//
+// Before this rework, `/api/v1/query_range` lowerings for bare
+// vector selectors and aggregations applied PromQL's Latest-With-
+// Respect-to-T (LWR) collapse once at the request's end_ts, producing
+// a single row per series. The matrix-pivot step loop in the handler
+// then dropped every step outside the 5-minute staleness window — for
+// a 1-hour range query at step=30s, fewer than ~10 of the requested
+// 121 step buckets actually received data. Pool-AI's compatibility
+// run surfaced this family as 363+ shape-diffs.
+//
+// The fix: in range mode (request `step > 0`) the bare-selector
+// lowering builds a per-step LWR by cross-joining the raw scan with a
+// `chplan.StepGrid` anchor source, filtering per-anchor to the
+// `(anchor_ts - 5m, anchor_ts]` window, and collapsing
+// `argMax(Value, TimeUnix) GROUP BY (series, anchor_ts)`. The outer
+// Project re-aliases `anchor_ts → TimeUnix` so the canonical Sample
+// contract holds for downstream consumers (aggregations, instant fns,
+// arithmetic). Aggregations gain an extra `TimeUnix` group key so
+// `sum(metric)` over query_range produces per-step aggregates.
+//
+// These tests pin the end-to-end matrix shape against chDB for the
+// shapes Pool-AI identified as compatibility blockers:
+//
+//   - Bare selector over query_range → N samples per series matching
+//     the step grid.
+//   - `sum(metric)` over query_range → N per-step aggregates.
+//   - `rate(metric[5m])` over query_range → matrix path via
+//     RangeWindow's OuterRange + Step fan-out (RC-critical control
+//     for the matrix RangeWindow change in lowerRangeVectorCall).
+//   - Empty-window cases drop the step.
+
+package prom_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/api/prom"
+)
+
+// TestQueryRange_RangeMode_BareSelector_ChDB pins the bare-selector
+// `/api/v1/query_range` path. Pool-AK's rework emits one row per
+// (series, step anchor) where the LWR window has data; the matrix
+// pivot then renders one sample per step in the requested range.
+//
+// Seeded: a single `demo_memory_usage_bytes` sample per step (every
+// 30s) for 5 minutes; expected: 11 samples per series at each step.
+func TestQueryRange_RangeMode_BareSelector_ChDB(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(5 * time.Minute)
+	step := 30 * time.Second
+	const wantSamples = 11
+
+	seedRows := make([]string, 0, wantSamples)
+	for i := 0; i < wantSamples; i++ {
+		ts := start.Add(time.Duration(i) * step).Format("2006-01-02 15:04:05.000000000")
+		seedRows = append(seedRows, fmt.Sprintf(
+			`('demo_memory_usage_bytes', map('instance', 'demo'), toDateTime64('%s', 9), %d.0)`,
+			ts, 100+i,
+		))
+	}
+	seed := gaugeDDL + "\nINSERT INTO otel_metrics_gauge VALUES\n  " +
+		strings.Join(seedRows, ",\n  ") + ";"
+
+	srv, _ := newChDBServer(t, seed)
+
+	matrix := runRangeModeQueryRange(t, srv.URL,
+		"demo_memory_usage_bytes", start, end, step)
+	if len(matrix) != 1 {
+		t.Fatalf("expected exactly 1 series, got %d: %+v", len(matrix), matrix)
+	}
+	values := matrix[0].Values
+	if len(values) != wantSamples {
+		t.Fatalf("expected %d samples (one per step), got %d: %+v",
+			wantSamples, len(values), values)
+	}
+	for i, v := range values {
+		// Each step's sample is the LWR-collapsed value at that anchor;
+		// with one sample per step the LWR collapses to that sample.
+		wantVal := strconv.FormatFloat(float64(100+i), 'f', -1, 64)
+		if got := v[1]; got != wantVal {
+			t.Errorf("step %d: value=%q want=%q (full row: %+v)", i, got, wantVal, v)
+		}
+	}
+}
+
+// TestQueryRange_RangeMode_SumAggregation_ChDB pins the
+// `sum(metric)` path under `/api/v1/query_range`. The rework injects
+// `TimeUnix` into the Aggregate's GROUP BY so each step bucket
+// produces its own per-step aggregate row.
+//
+// Two series with values `(100+i, 200+i)` at each of 11 step
+// anchors → `sum` over the full set should be `300 + 2*i` at step i.
+func TestQueryRange_RangeMode_SumAggregation_ChDB(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(5 * time.Minute)
+	step := 30 * time.Second
+	const wantSamples = 11
+
+	seedRows := make([]string, 0, wantSamples*2)
+	for i := 0; i < wantSamples; i++ {
+		ts := start.Add(time.Duration(i) * step).Format("2006-01-02 15:04:05.000000000")
+		seedRows = append(seedRows,
+			fmt.Sprintf(`('demo_memory_usage_bytes', map('instance', 'a'), toDateTime64('%s', 9), %d.0)`,
+				ts, 100+i),
+			fmt.Sprintf(`('demo_memory_usage_bytes', map('instance', 'b'), toDateTime64('%s', 9), %d.0)`,
+				ts, 200+i),
+		)
+	}
+	seed := gaugeDDL + "\nINSERT INTO otel_metrics_gauge VALUES\n  " +
+		strings.Join(seedRows, ",\n  ") + ";"
+	srv, _ := newChDBServer(t, seed)
+
+	matrix := runRangeModeQueryRange(t, srv.URL,
+		"sum(demo_memory_usage_bytes)", start, end, step)
+	if len(matrix) != 1 {
+		t.Fatalf("expected exactly 1 series from sum (no by/without), got %d: %+v",
+			len(matrix), matrix)
+	}
+	values := matrix[0].Values
+	if len(values) != wantSamples {
+		t.Fatalf("expected %d per-step aggregates, got %d: %+v",
+			wantSamples, len(values), values)
+	}
+	for i, v := range values {
+		want := strconv.FormatFloat(float64(300+2*i), 'f', -1, 64)
+		if got := v[1]; got != want {
+			t.Errorf("step %d: value=%q want=%q (full row: %+v)", i, got, want, v)
+		}
+	}
+}
+
+// TestQueryRange_RangeMode_SumByLabel_ChDB pins `sum by (job) (metric)`
+// over query_range. Two distinct `job` series with three instances
+// each — `sum by(job)` over query_range should emit 2 series × N
+// per-step samples.
+func TestQueryRange_RangeMode_SumByLabel_ChDB(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(5 * time.Minute)
+	step := 30 * time.Second
+	const wantSamples = 11
+
+	// Seed: job=api {a, b, c}; job=db {a, b}. Values constant per
+	// (job, instance) — the per-step sum within each job is then a
+	// stable constant across all 11 anchors.
+	seedRows := []string{}
+	for i := 0; i < wantSamples; i++ {
+		ts := start.Add(time.Duration(i) * step).Format("2006-01-02 15:04:05.000000000")
+		// api job — 3 instances, each Value=1.0 → sum=3.0
+		seedRows = append(seedRows,
+			fmt.Sprintf(`('up', map('job', 'api', 'instance', 'a'), toDateTime64('%s', 9), 1.0)`, ts),
+			fmt.Sprintf(`('up', map('job', 'api', 'instance', 'b'), toDateTime64('%s', 9), 1.0)`, ts),
+			fmt.Sprintf(`('up', map('job', 'api', 'instance', 'c'), toDateTime64('%s', 9), 1.0)`, ts),
+			// db job — 2 instances, each Value=1.0 → sum=2.0
+			fmt.Sprintf(`('up', map('job', 'db', 'instance', 'a'), toDateTime64('%s', 9), 1.0)`, ts),
+			fmt.Sprintf(`('up', map('job', 'db', 'instance', 'b'), toDateTime64('%s', 9), 1.0)`, ts),
+		)
+	}
+	seed := gaugeDDL + "\nINSERT INTO otel_metrics_gauge VALUES\n  " +
+		strings.Join(seedRows, ",\n  ") + ";"
+	srv, _ := newChDBServer(t, seed)
+
+	matrix := runRangeModeQueryRange(t, srv.URL,
+		"sum by (job) (up)", start, end, step)
+	if len(matrix) != 2 {
+		t.Fatalf("expected 2 series (one per distinct job), got %d: %+v",
+			len(matrix), matrix)
+	}
+	wantPerJob := map[string]string{"api": "3", "db": "2"}
+	for _, ms := range matrix {
+		job := ms.Metric["job"]
+		want, ok := wantPerJob[job]
+		if !ok {
+			t.Errorf("unexpected series: %+v", ms.Metric)
+			continue
+		}
+		if len(ms.Values) != wantSamples {
+			t.Errorf("job=%s: expected %d samples, got %d: %+v",
+				job, wantSamples, len(ms.Values), ms.Values)
+			continue
+		}
+		for i, v := range ms.Values {
+			if got := v[1]; got != want {
+				t.Errorf("job=%s step %d: value=%q want=%q", job, i, got, want)
+			}
+		}
+	}
+}
+
+// TestQueryRange_RangeMode_AvgOverTime_ChDB pins
+// `avg_over_time(metric[5m])` under query_range. The rework also
+// routes range-vector lowerings to the matrix path (OuterRange + Step
+// set) so each step anchor emits its own per-window aggregation.
+//
+// Seeded: a single demo_memory_usage_bytes gauge sample at each step.
+// Anchors land at `end - i*step` for i in `[0, 10]` (11 total); the
+// matrix-RangeWindow `length(window_vals) >= 1` predicate drops any
+// anchor whose 5-minute lookback window held no sample. Pinning to
+// "at least multiple per-step rows" rather than an exact count keeps
+// the test resilient to per-CI-clock sub-second drift (seed rows are
+// anchored on `time.Now()` which has nanosecond precision while
+// `start.Unix()` truncates to seconds).
+func TestQueryRange_RangeMode_AvgOverTime_ChDB(t *testing.T) {
+	end := time.Now().UTC()
+	start := end.Add(-5 * time.Minute)
+	step := 30 * time.Second
+	const seedSamples = 11
+
+	seedRows := make([]string, 0, seedSamples)
+	for i := 0; i < seedSamples; i++ {
+		ts := start.Add(time.Duration(i) * step).Format("2006-01-02 15:04:05.000000000")
+		seedRows = append(seedRows, fmt.Sprintf(
+			`('demo_memory_usage_bytes', map('job', 'api'), toDateTime64('%s', 9), %d.0)`,
+			ts, 100+i,
+		))
+	}
+	seed := gaugeDDL + "\nINSERT INTO otel_metrics_gauge VALUES\n  " +
+		strings.Join(seedRows, ",\n  ") + ";"
+	srv, _ := newChDBServer(t, seed)
+
+	matrix := runRangeModeQueryRange(t, srv.URL,
+		"avg_over_time(demo_memory_usage_bytes[5m])", start, end, step)
+	if len(matrix) == 0 {
+		t.Fatalf("expected at least 1 series; got 0")
+	}
+	// Pre-Pool-AK the matrix RangeWindow path defaulted to a single
+	// anchor (Step=0, OuterRange=0) and the matrix pivot extended its
+	// one row across the step grid — surfaced as one repeated value
+	// for the whole window. With the rework, the SQL fans out per
+	// anchor on the step grid: assert > 1 distinct sample point so
+	// the regression is pinned without coupling to clock drift.
+	if got := len(matrix[0].Values); got < 5 {
+		t.Fatalf("expected per-step avg_over_time matrix (>= 5 samples); got %d: %+v",
+			got, matrix[0].Values)
+	}
+	// Per-step values must be monotonically non-decreasing in this
+	// seed (each subsequent anchor's window includes one more sample
+	// at the high end). A regression where every step carried the
+	// same value would surface as all-equal values.
+	first := matrix[0].Values[0][1]
+	last := matrix[0].Values[len(matrix[0].Values)-1][1]
+	if first == last {
+		t.Errorf("expected per-step variation across the matrix; got first=last=%q (full row: %+v)",
+			first, matrix[0].Values)
+	}
+}
+
+// TestQueryRange_RangeMode_EmptyWindow_ChDB pins the "no samples in
+// LWR window" behaviour for the bare-selector range-mode path. The
+// data is seeded only at the very start; later anchors whose window
+// `(t-5m, t]` contains no sample MUST not emit a matrix point.
+//
+// With a 12-minute query span at step=1m, the first 6 anchors (0–5m)
+// have the seed sample inside their LWR window; the remaining 7
+// anchors (6m–12m) do not. The matrix must therefore expose exactly
+// 6 sample points — the Pool-AK guarantee that per-step LWR
+// faithfully reflects "Prom drops empty windows".
+func TestQueryRange_RangeMode_EmptyWindow_ChDB(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(12 * time.Minute)
+	step := time.Minute
+
+	// One sample at `start`; nothing else.
+	ts := start.Format("2006-01-02 15:04:05.000000000")
+	seed := gaugeDDL + fmt.Sprintf(`
+INSERT INTO otel_metrics_gauge VALUES
+    ('sparse_metric', map('instance', 'demo'), toDateTime64('%s', 9), 42.0);`, ts)
+	srv, _ := newChDBServer(t, seed)
+
+	matrix := runRangeModeQueryRange(t, srv.URL,
+		"sparse_metric", start, end, step)
+	if len(matrix) != 1 {
+		t.Fatalf("expected exactly 1 series, got %d: %+v", len(matrix), matrix)
+	}
+	values := matrix[0].Values
+	// LWR window is strict-lower-bound (`>` not `>=`) on the lower
+	// side, so the sample at exactly anchor=start IS in its own
+	// window `(start-5m, start]`. Subsequent anchors at start+i*step
+	// see the sample in their window as long as `start > t - 5m`
+	// (strict), i.e., `t - start < 5m`. With step=1m the qualifying
+	// anchors are t = start, start+1m, ..., start+4m (5 anchors —
+	// start+5m fails `t - start < 5m`).
+	const wantSamples = 5
+	if got := len(values); got != wantSamples {
+		t.Fatalf("expected %d samples for sparse seed (within-lookback anchors); got %d: %+v",
+			wantSamples, got, values)
+	}
+	// Every emitted sample carries the same Value (the only seed row).
+	for i, v := range values {
+		if got := v[1]; got != "42" {
+			t.Errorf("step %d: value=%q want=%q (full row: %+v)", i, got, "42", v)
+		}
+	}
+}
+
+// runRangeModeQueryRange is the test helper shared across the Pool-AK
+// range-mode regression cases. Mirrors `runStepLoopRange` but lives
+// in this file so the Pool-AK suite is self-contained for any future
+// reviewer auditing the per-step matrix contract end-to-end.
+func runRangeModeQueryRange(t *testing.T, baseURL, query string, start, end time.Time, step time.Duration) []prom.MatrixSample {
+	t.Helper()
+	reqURL := fmt.Sprintf(
+		"%s/api/v1/query_range?query=%s&start=%d&end=%d&step=%d",
+		baseURL, url.QueryEscape(query), start.Unix(), end.Unix(), int(step.Seconds()),
+	)
+	resp, err := http.Get(reqURL)
+	if err != nil {
+		t.Fatalf("GET %s: %v", reqURL, err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s (pre-Pool-AK: empty matrix or near-empty matrix)",
+			resp.StatusCode, body)
+	}
+	var parsed queryResponse
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v\nbody=%s", err, body)
+	}
+	if parsed.Status != "success" {
+		t.Fatalf("status: got %q (errorType=%q error=%q), want success",
+			parsed.Status, parsed.ErrorType, parsed.Error)
+	}
+	if parsed.Data.ResultType != "matrix" {
+		t.Fatalf("resultType: got %q, want matrix", parsed.Data.ResultType)
+	}
+	rawResult, _ := json.Marshal(parsed.Data.Result)
+	var matrix []prom.MatrixSample
+	if err := json.Unmarshal(rawResult, &matrix); err != nil {
+		t.Fatalf("decode matrix: %v (raw=%s)", err, rawResult)
+	}
+	return matrix
+}

--- a/internal/api/prom/handler_test.go
+++ b/internal/api/prom/handler_test.go
@@ -165,15 +165,20 @@ func TestQuery_Vector(t *testing.T) {
 func TestQueryRange_Matrix(t *testing.T) {
 	t.Parallel()
 
-	// Three samples spaced 30s apart in the requested [start, end] window;
-	// step=60s should produce 5 evaluation points (start, +60, +120, +180, end).
+	// Post Pool-AK rework: matrix pivot is a row → sample copy keyed
+	// by canonical series. The SQL handed back is responsible for the
+	// per-step LWR (bare selector path) or per-anchor windowing
+	// (matrix RangeWindow path) — the pivot no longer iterates the
+	// step grid or carries values forward. Stub three rows at distinct
+	// step anchors and assert the matrix surfaces them verbatim, in
+	// timestamp order, with no carry-forward of stale values.
 	start := time.Unix(1717995600, 0).UTC()
 	end := start.Add(4 * time.Minute) // 1717995840
 	q := &stubQuerier{
 		samples: []chclient.Sample{
 			{MetricName: "up", Labels: map[string]string{"job": "api"}, Timestamp: start, Value: 1.0},
-			{MetricName: "up", Labels: map[string]string{"job": "api"}, Timestamp: start.Add(90 * time.Second), Value: 2.0},
-			{MetricName: "up", Labels: map[string]string{"job": "api"}, Timestamp: start.Add(180 * time.Second), Value: 3.0},
+			{MetricName: "up", Labels: map[string]string{"job": "api"}, Timestamp: start.Add(2 * time.Minute), Value: 2.0},
+			{MetricName: "up", Labels: map[string]string{"job": "api"}, Timestamp: start.Add(3 * time.Minute), Value: 3.0},
 		},
 	}
 
@@ -207,15 +212,17 @@ func TestQueryRange_Matrix(t *testing.T) {
 	if len(matrix) != 1 {
 		t.Fatalf("expected 1 series, got %d", len(matrix))
 	}
-	// 5 step points expected for [start..start+4m] step=60s.
-	if got := len(matrix[0].Values); got != 5 {
-		t.Fatalf("expected 5 sample points in matrix, got %d: %+v", got, matrix[0].Values)
+	if got := len(matrix[0].Values); got != 3 {
+		t.Fatalf("expected 3 sample points (one per stubbed row), got %d: %+v",
+			got, matrix[0].Values)
 	}
-	// Latest-at-step values: [1, 1, 2, 3, 3] for steps [0, 60, 120, 180, 240].
-	wantValues := []string{"1", "1", "2", "3", "3"}
+	// Values appear in the order the SQL returned them — the rows the
+	// stub yields land at start + (0, 2, 3) minutes with values
+	// (1, 2, 3) — verbatim.
+	wantValues := []string{"1", "2", "3"}
 	for i, want := range wantValues {
 		if got := matrix[0].Values[i][1]; got != want {
-			t.Errorf("step %d: got value %q, want %q", i, got, want)
+			t.Errorf("row %d: got value %q, want %q", i, got, want)
 		}
 	}
 }

--- a/internal/promql/instant_fns.go
+++ b/internal/promql/instant_fns.go
@@ -163,13 +163,26 @@ func lowerClamp(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, er
 // e.g. `edge_abs_over_rate.txtar` (instant fn over rate) and
 // `unary_minus_rate.txtar` (unary minus over rate).
 func projectValueOverInner(inner chplan.Node, s schema.Metrics, newValue chplan.Expr) chplan.Node {
-	if _, ok := inner.(*chplan.RangeWindow); ok {
+	if rw, ok := inner.(*chplan.RangeWindow); ok {
+		projections := []chplan.Projection{
+			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}},
+		}
+		// Matrix-shape RangeWindow (range-mode subqueries + range-mode
+		// `rate`/`*_over_time` queries with Step > 0) exposes
+		// `anchor_ts` as the per-row per-anchor timestamp. The outer
+		// wrapWithSampleProjection reads it back through this Project
+		// (when `isMatrixRangeWindow` walks past the value-rewrite
+		// Project layer); forwarding the column keeps the per-anchor
+		// time-bucketing intact for callers like `abs(avg_over_time(…))`.
+		if rw.OuterRange > 0 {
+			projections = append(projections, chplan.Projection{
+				Expr: &chplan.ColumnRef{Name: "anchor_ts"},
+			})
+		}
+		projections = append(projections, chplan.Projection{Expr: newValue, Alias: s.ValueColumn})
 		return &chplan.Project{
-			Input: inner,
-			Projections: []chplan.Projection{
-				{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}},
-				{Expr: newValue, Alias: s.ValueColumn},
-			},
+			Input:       inner,
+			Projections: projections,
 		}
 	}
 	return &chplan.Project{

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -165,6 +165,13 @@ func lowerVectorSelector(v *parser.VectorSelector, s schema.Metrics, ctx lowerCt
 		}
 		return &chplan.Filter{Input: scan, Predicate: pred}, nil
 	}
+	// Range mode (ctx.step > 0): build the per-step LWR by cross-joining
+	// the raw scan with a StepGrid and collapsing latest-per-(series,
+	// anchor). Anchor modifiers (`@`/`offset`) are honoured by shifting
+	// the predicate against `anchor_ts` rather than a single end_ts.
+	if ctx.step > 0 && !ctx.start.IsZero() && !ctx.end.IsZero() {
+		return wrapRangeLatestPerSeries(scan, pred, anchor, ctx, s), nil
+	}
 	// Instant-vector context: the LWR wrapper applies both the
 	// `Timestamp <= anchor` upper bound and the staleness lower
 	// bound, so we DON'T pre-add the modifier's timeBoundExpr here —
@@ -242,6 +249,139 @@ func wrapInstantLatestPerSeries(scan *chplan.Scan, pred chplan.Expr, anchor eval
 			{Expr: &chplan.ColumnRef{Name: s.MetricNameColumn}, Alias: s.MetricNameColumn},
 			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
 			{Expr: &chplan.ColumnRef{Name: lwrTsAlias}, Alias: s.TimestampColumn},
+			{Expr: &chplan.ColumnRef{Name: lwrValueAlias}, Alias: s.ValueColumn},
+		},
+	}
+}
+
+// wrapRangeLatestPerSeries builds the per-step LWR for a vector
+// selector evaluated over a query_range window. The shape is:
+//
+//	Project [MetricName, Attributes, anchor_ts AS TimeUnix, lwr_value AS Value]
+//	  Aggregate by (MetricName, Attributes, anchor_ts) funcs=[argMax(Value, TimeUnix) AS lwr_value]
+//	    Filter (anchor_ts - <offset> >= TimeUnix AND TimeUnix > anchor_ts - <offset> - 5m)
+//	      CrossJoin(StepGrid(start, end, step), Scan + matchers_filter)
+//
+// At each step `t = start, start+step, ..., end` the StepGrid emits one
+// `anchor_ts = t` row; the CrossJoin pairs that with every raw sample row,
+// the Filter trims to the per-step LWR window `(t-offset-5m, t-offset]`,
+// the Aggregate collapses to one row per (series, anchor) carrying the
+// latest-in-window Value, and the outer Project exposes the canonical
+// (MetricName, Attributes, TimeUnix, Value) shape with TimeUnix = anchor_ts.
+//
+// Output schema preservation lets the surrounding plan tree (aggregations,
+// arithmetic, instant fns) keep consuming the same column shape it did
+// before — the difference vs the instant LWR wrap is that each (series)
+// produces N rows (one per step inside `[start, end]` that had data) rather
+// than a single row at `end_ts`.
+func wrapRangeLatestPerSeries(scan *chplan.Scan, pred chplan.Expr, anchor evalAnchor, ctx lowerCtx, s schema.Metrics) chplan.Node {
+	const (
+		anchorCol     = "anchor_ts"
+		lwrValueAlias = "lwr_value"
+	)
+	anchorRef := &chplan.ColumnRef{Name: anchorCol}
+	// `@`/offset modifiers shift the LWR window against the per-step
+	// anchor: `up offset 5m` over a step at `t` evaluates the latest
+	// sample in `(t-5m-5m, t-5m]`. The shift is `(anchor_ts - offset)`
+	// for the upper bound and `(anchor_ts - offset - lookback)` for the
+	// strict lower bound.
+	//
+	// When the modifier is `@<absolute>` (no offset, ctx.end ignored)
+	// the per-step semantics still apply — Prom queries with `@ start()`
+	// over a range query keep a single anchor across all steps. That
+	// shape is rare enough that the wrap below falls back to a per-step
+	// anchor (i.e., the user's intent is preserved when they don't pin
+	// the absolute @ modifier).
+	var upperBound chplan.Expr = anchorRef
+	if anchor.Offset > 0 {
+		upperBound = &chplan.Binary{
+			Op:   chplan.OpSub,
+			Left: anchorRef,
+			Right: &chplan.FuncCall{
+				Name: "toIntervalNanosecond",
+				Args: []chplan.Expr{&chplan.LitInt{V: anchor.Offset.Nanoseconds()}},
+			},
+		}
+	}
+	// `TimeUnix <= anchor_ts - offset` (non-strict upper)
+	lwrUpper := &chplan.Binary{
+		Op:    chplan.OpLe,
+		Left:  &chplan.ColumnRef{Name: s.TimestampColumn},
+		Right: upperBound,
+	}
+	// `TimeUnix > anchor_ts - offset - lookback` (strict lower)
+	lookbackNs := instantLookback.Nanoseconds() + anchor.Offset.Nanoseconds()
+	lowerBound := &chplan.Binary{
+		Op:   chplan.OpSub,
+		Left: anchorRef,
+		Right: &chplan.FuncCall{
+			Name: "toIntervalNanosecond",
+			Args: []chplan.Expr{&chplan.LitInt{V: lookbackNs}},
+		},
+	}
+	lwrLower := &chplan.Binary{
+		Op:    chplan.OpGt,
+		Left:  &chplan.ColumnRef{Name: s.TimestampColumn},
+		Right: lowerBound,
+	}
+
+	// Inner Scan/Filter — apply matchers via PREWHERE-eligible filter
+	// the optimizer already promotes. The `(scan, pred)` split keeps the
+	// downstream PREWHERE path unchanged; when pred is nil (no matchers)
+	// the scan flows directly into the CrossJoin.
+	var rawSide chplan.Node = scan
+	if pred != nil {
+		rawSide = &chplan.Filter{Input: scan, Predicate: pred}
+	}
+
+	stepGrid := &chplan.StepGrid{
+		Start: ctx.start.UTC(),
+		End:   ctx.end.UTC(),
+		Step:  ctx.step,
+	}
+	joined := &chplan.CrossJoin{
+		Left:  stepGrid,
+		Right: rawSide,
+	}
+
+	// Filter to the per-step LWR window.
+	filterPred := chplan.Expr(&chplan.Binary{
+		Op: chplan.OpAnd, Left: lwrUpper, Right: lwrLower,
+	})
+	filtered := &chplan.Filter{Input: joined, Predicate: filterPred}
+
+	// Aggregate per (MetricName, Attributes, anchor_ts) collapsing to
+	// the latest sample in the per-step window. The argMax over
+	// TimeUnix gives the LWR-canonical "newest sample in window".
+	agg := &chplan.Aggregate{
+		Input: filtered,
+		GroupBy: []chplan.Expr{
+			&chplan.ColumnRef{Name: s.MetricNameColumn},
+			&chplan.ColumnRef{Name: s.AttributesColumn},
+			anchorRef,
+		},
+		GroupByAliases: []string{s.MetricNameColumn, s.AttributesColumn, anchorCol},
+		AggFuncs: []chplan.AggFunc{
+			{
+				Name: "argMax",
+				Args: []chplan.Expr{
+					&chplan.ColumnRef{Name: s.ValueColumn},
+					&chplan.ColumnRef{Name: s.TimestampColumn},
+				},
+				Alias: lwrValueAlias,
+			},
+		},
+	}
+
+	// Outer Project re-aliases anchor_ts → TimeUnix so the canonical
+	// 4-column Sample contract holds for downstream consumers
+	// (aggregations, arithmetic, instant fns, the handler-side pivot).
+	return &chplan.Project{
+		Input: agg,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.ColumnRef{Name: s.MetricNameColumn}, Alias: s.MetricNameColumn},
+			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
+			{Expr: anchorRef, Alias: s.TimestampColumn},
 			{Expr: &chplan.ColumnRef{Name: lwrValueAlias}, Alias: s.ValueColumn},
 		},
 	}
@@ -467,7 +607,7 @@ func lowerRangeVectorCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chpla
 	if err != nil {
 		return nil, err
 	}
-	return &chplan.RangeWindow{
+	rw := &chplan.RangeWindow{
 		Input:           inner,
 		Func:            c.Func.Name,
 		Range:           ms.Range,
@@ -476,7 +616,23 @@ func lowerRangeVectorCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chpla
 		TimestampColumn: s.TimestampColumn,
 		ValueColumn:     s.ValueColumn,
 		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}},
-	}, nil
+	}
+	// In range mode, fan the range function across the request's step
+	// grid: each anchor in [start, end] (spaced by step) emits one row
+	// per series with the per-anchor function value. The emitter
+	// already supports this via OuterRange + Step (the matrix path used
+	// by subqueries); we just need to flip the switch when LowerAtRange
+	// threaded a non-zero step. Without this, `rate(m[5m])` over
+	// query_range degenerates to a single anchor at end_ts and the
+	// matrix pivot only sees one sample per series — the same root
+	// cause as the bare-selector range-mode bug Pool-AK is fixing.
+	if ctx.step > 0 && !ctx.start.IsZero() && !ctx.end.IsZero() {
+		rw.Start = ctx.start.UTC()
+		rw.End = ctx.end.UTC()
+		rw.Step = ctx.step
+		rw.OuterRange = ctx.end.Sub(ctx.start)
+	}
+	return rw, nil
 }
 
 // lowerAggregate handles `sum by (job) (...)`, `sum without (instance) (...)`,
@@ -515,6 +671,18 @@ func lowerAggregate(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) (ch
 	}
 
 	aliases := groupKeyAliases(len(groupBy))
+	// In range mode the input plan exposes a per-step TimeUnix
+	// (anchor_ts re-aliased by wrapRangeLatestPerSeries). Aggregations
+	// must group by the per-step bucket in addition to the user's
+	// `by/without` keys — otherwise CH would collapse N anchors into one
+	// row per series-set. Inject TimeUnix as an extra group key with a
+	// stable alias (`bucket_ts`) the wrap can reference.
+	const bucketAlias = "bucket_ts"
+	rangeBucketed := ctx.step > 0
+	if rangeBucketed {
+		groupBy = append(groupBy, &chplan.ColumnRef{Name: s.TimestampColumn})
+		aliases = append(aliases, bucketAlias)
+	}
 	agg := &chplan.Aggregate{
 		Input:              input,
 		GroupBy:            groupBy,
@@ -522,7 +690,13 @@ func lowerAggregate(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) (ch
 		AggFuncs:           []chplan.AggFunc{aggFunc},
 		DropEmptyOnNoGroup: true,
 	}
-	wrapped := wrapAggregateForSample(agg, a, s, aliases)
+	// The wrap re-projects the bucket alias onto TimeUnix so range-mode
+	// aggregations expose per-step rows on the canonical column shape.
+	userAliases := aliases
+	if rangeBucketed {
+		userAliases = aliases[:len(aliases)-1]
+	}
+	wrapped := wrapAggregateForSample(agg, a, s, userAliases, rangeBucketed, bucketAlias)
 	// quantile(phi, V) with phi outside [0, 1] is well-defined in
 	// PromQL — see prometheus/promql/quantile.go: phi<0 → -Inf,
 	// phi>1 → +Inf. CH's `quantile` aggregate rejects out-of-range
@@ -775,9 +949,15 @@ func groupKeyAliases(n int) []string {
 //	Attributes  = map('lbl0', gkey_0, ...)    for `by (lbl0, lbl1, ...)`
 //	            | gkey_0                       for `without (...)` (mapFilter output)
 //	            | empty Map(String,String)     for unaggregated forms
-//	TimeUnix    = now64(9)                    (eval time)
+//	TimeUnix    = now64(9)                    (instant mode — eval time)
+//	            | <bucketAlias>                (range mode — per-step anchor)
 //	Value       = <aggFunc alias>             (sum / avg / quantile / ...)
-func wrapAggregateForSample(agg *chplan.Aggregate, a *parser.AggregateExpr, s schema.Metrics, aliases []string) chplan.Node {
+//
+// rangeBucketed reflects whether the underlying Aggregate carries an
+// extra TimeUnix group key (range mode); when true the projection's
+// TimeUnix slot references the bucket alias the Aggregate exposed so
+// per-step aggregation rows propagate onto the canonical column shape.
+func wrapAggregateForSample(agg *chplan.Aggregate, a *parser.AggregateExpr, s schema.Metrics, aliases []string, rangeBucketed bool, bucketAlias string) chplan.Node {
 	var attrs chplan.Expr
 	switch {
 	case len(aliases) == 0:
@@ -805,12 +985,17 @@ func wrapAggregateForSample(agg *chplan.Aggregate, a *parser.AggregateExpr, s sc
 		}
 	}
 
+	tsExpr := chplan.Expr(&chplan.FuncCall{Name: "now64", Args: []chplan.Expr{&chplan.LitInt{V: 9}}})
+	if rangeBucketed {
+		tsExpr = &chplan.ColumnRef{Name: bucketAlias}
+	}
+
 	return &chplan.Project{
 		Input: agg,
 		Projections: []chplan.Projection{
 			{Expr: &chplan.LitString{V: ""}, Alias: s.MetricNameColumn},
 			{Expr: attrs, Alias: s.AttributesColumn},
-			{Expr: &chplan.FuncCall{Name: "now64", Args: []chplan.Expr{&chplan.LitInt{V: 9}}}, Alias: s.TimestampColumn},
+			{Expr: tsExpr, Alias: s.TimestampColumn},
 			{Expr: &chplan.ColumnRef{Name: s.ValueColumn}, Alias: s.ValueColumn},
 		},
 	}

--- a/test/spec/chplan_print.go
+++ b/test/spec/chplan_print.go
@@ -50,6 +50,14 @@ func printNode(b *strings.Builder, n chplan.Node, depth int) {
 	case *chplan.OneRow:
 		fmt.Fprintf(b, "%sOneRow\n", indent)
 		_ = v
+	case *chplan.StepGrid:
+		fmt.Fprintf(b, "%sStepGrid start=%s end=%s step=%s\n",
+			indent, v.Start.Format("2006-01-02T15:04:05.000000000Z"),
+			v.End.Format("2006-01-02T15:04:05.000000000Z"), v.Step)
+	case *chplan.CrossJoin:
+		fmt.Fprintf(b, "%sCrossJoin\n", indent)
+		printNode(b, v.Left, depth+1)
+		printNode(b, v.Right, depth+1)
 	case *chplan.Filter:
 		fmt.Fprintf(b, "%sFilter predicate=%s\n", indent, printExpr(v.Predicate))
 		printNode(b, v.Input, depth+1)


### PR DESCRIPTION
## Summary

Closes the architectural root cause Pool-AI identified: cerberus evaluates `/api/v1/query_range` only at `end_ts` (PR #275's instant-LWR collapse fires in range mode too), returning ~2 samples per series instead of N. Drives the 363 shape-diffs in the post-#345 compat baseline.

## Approach (Option A from Pool-AK's plan)

Built once, reused for bare selectors + aggregations + matrix range-vector fns. Per-step LWR via `StepGrid` cross-join — same primitive #337 introduced for synthetic vectors, now generalised.

## chplan tree for `sum(demo_memory_usage_bytes)` over range

```
Project ["", map(), bucket_ts AS TimeUnix, Value]
  Aggregate by(bucket_ts) sum(Value)
    Project [MetricName, Attributes, anchor_ts AS TimeUnix, lwr_value AS Value]
      Aggregate by(MetricName, Attributes, anchor_ts) argMax(Value, TimeUnix) AS lwr_value
        Filter (TimeUnix <= anchor_ts AND anchor_ts - TimeUnix < 5m)
          CrossJoin
            StepGrid start=... end=... step=30s
            Filter (MetricName = "demo_memory_usage_bytes")
              Scan(otel_metrics_gauge)
```

Bare selectors use the inner Project; aggregations group by `(bucket_ts, gkeys)` on top of it naturally.

## Files (6, +611/-50)

- `internal/promql/lower.go` (+197): new `wrapRangeLatestPerSeries`, range-mode branch in `lowerVectorSelector`, TimeUnix group key injection in `lowerAggregate`, matrix path in `lowerRangeVectorCall`.
- `internal/promql/instant_fns.go` (+25/-10): `projectValueOverInner` forwards `anchor_ts` for matrix-RangeWindow inputs.
- `internal/api/prom/handler.go` (+34/-29): `matrixFromCursor` simplified to row→sample copy with `[start, end]` clip (per-step pivot is done in the lowering now).
- `internal/api/prom/handler_test.go` (+17/-10): `TestQueryRange_Matrix` updated for new no-carry-forward pivot.
- `internal/api/prom/handler_chdb_range_mode_test.go` (new, +341): 5 chDB regressions pinning per-step output: bare selector, sum(), sum by(job), avg_over_time matrix, empty-window drop.
- `test/spec/chplan_print.go` (+8): print CrossJoin + StepGrid nodes.

## Test plan

- [x] `go test ./internal/...` — 2480 pass
- [x] `go test -tags chdb ./internal/{api/prom,promql}/...` — 735 pass
- [x] `go test -tags chdb ./test/spec/...` — 421/423 pass (2 pre-existing logql label_replace `$1`-backref failures unrelated; tracked separately)
- [x] 5 new chDB regression tests pin the per-step semantics

## Out-of-scope follow-ups (not in this PR, flagged for next dispatch)

1. **`histogram_quantile` classic-bucket path** still emits `now64(9)` for TimeUnix in range mode. Bespoke wrap bypasses `wrapAggregateForSample`. Not in the 363-diff family.
2. **`@<absolute>` modifier in range mode** preserves anchor.Offset correctly but doesn't collapse to OneRow when `@ start()/@ end()` is set.
3. **`lowerOuterRangeFnOverSubquery`** (nested-RangeWindow shape for `max_over_time(rate(m[5m])[1h:5m])`) outer reducer still Step=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>