### PR TITLE
fix(promql,chsql): step-align V-V on(...) joins + range-mode matrix fan-out

### DIFF
--- a/internal/api/prom/handler_chdb_range_mode_test.go
+++ b/internal/api/prom/handler_chdb_range_mode_test.go
@@ -302,6 +302,178 @@ INSERT INTO otel_metrics_gauge VALUES
 	}
 }
 
+// TestQueryRange_RangeMode_RateMatrix_ChDB pins `rate(metric[5m])`
+// over `/api/v1/query_range`. The matrix-RangeWindow path emits one
+// row per anchor in [start, end] spaced by step. The pre-Pool-AL bug:
+// some matrix-RangeWindow lowerings forgot to thread ctx.step into the
+// chplan.RangeWindow, so the emitter defaulted to a single anchor at
+// end_ts and the matrix pivot delivered a single repeated value. This
+// test pins the per-anchor fan-out and the per-step rate variation.
+//
+// Seeded: a monotonically-increasing counter starting at 0, increasing
+// by 60 every 30s (i.e. constant 2/s rate). At each step anchor the
+// rate over the prior 5m sees the linear ramp and emits 2.0 (modulo
+// boundary effects on the first few anchors when the window holds
+// fewer than 2 samples). The metric name is gauge-routed (no `_total`
+// suffix) so the seed lives in `otel_metrics_gauge` alongside the
+// other range-mode fixtures.
+func TestQueryRange_RangeMode_RateMatrix_ChDB(t *testing.T) {
+	end := time.Now().UTC()
+	start := end.Add(-5 * time.Minute)
+	step := 30 * time.Second
+	const seedSamples = 11
+
+	seedRows := make([]string, 0, seedSamples)
+	for i := 0; i < seedSamples; i++ {
+		ts := start.Add(time.Duration(i) * step).Format("2006-01-02 15:04:05.000000000")
+		seedRows = append(seedRows, fmt.Sprintf(
+			`('demo_cpu_usage_seconds', map('job', 'api'), toDateTime64('%s', 9), %d.0)`,
+			ts, i*60,
+		))
+	}
+	seed := gaugeDDL + "\nINSERT INTO otel_metrics_gauge VALUES\n  " +
+		strings.Join(seedRows, ",\n  ") + ";"
+	srv, _ := newChDBServer(t, seed)
+
+	matrix := runRangeModeQueryRange(t, srv.URL,
+		"rate(demo_cpu_usage_seconds[5m])", start, end, step)
+	if len(matrix) == 0 {
+		t.Fatalf("expected at least 1 series for rate matrix; got 0")
+	}
+	// Pre-Pool-AL the matrix RangeWindow path could degenerate to a
+	// single anchor when Step / OuterRange weren't threaded. Assert
+	// multi-anchor fan-out so the regression is pinned without
+	// coupling to the exact per-anchor count (which depends on the
+	// 2-sample minWindowSize gate for rate).
+	if got := len(matrix[0].Values); got < 5 {
+		t.Fatalf("expected per-step rate matrix (>= 5 samples); got %d: %+v",
+			got, matrix[0].Values)
+	}
+}
+
+// TestQueryRange_RangeMode_SumOverTimeMatrix_ChDB pins
+// `sum_over_time(metric[5m])` over `/api/v1/query_range`. Same matrix
+// fan-out story as rate, but for the *_over_time family. Each anchor
+// reduces the prior 5-minute window via arraySum.
+//
+// Seeded: 11 samples of constant value 10 at 30s spacing. Each
+// anchor's window holds an increasing subset of those samples; the
+// per-step sum grows from 10 (1 sample in window) to 110 (11 samples
+// in window).
+func TestQueryRange_RangeMode_SumOverTimeMatrix_ChDB(t *testing.T) {
+	end := time.Now().UTC()
+	start := end.Add(-5 * time.Minute)
+	step := 30 * time.Second
+	const seedSamples = 11
+
+	seedRows := make([]string, 0, seedSamples)
+	for i := 0; i < seedSamples; i++ {
+		ts := start.Add(time.Duration(i) * step).Format("2006-01-02 15:04:05.000000000")
+		seedRows = append(seedRows,
+			fmt.Sprintf(`('demo_memory_usage_bytes', map('job', 'api'), toDateTime64('%s', 9), 10.0)`,
+				ts))
+	}
+	seed := gaugeDDL + "\nINSERT INTO otel_metrics_gauge VALUES\n  " +
+		strings.Join(seedRows, ",\n  ") + ";"
+	srv, _ := newChDBServer(t, seed)
+
+	matrix := runRangeModeQueryRange(t, srv.URL,
+		"sum_over_time(demo_memory_usage_bytes[5m])", start, end, step)
+	if len(matrix) == 0 {
+		t.Fatalf("expected at least 1 series for sum_over_time matrix; got 0")
+	}
+	// Per-step fan-out: expect at least 5 distinct anchors in the
+	// 5-minute query window (step=30s, 11 candidate anchors).
+	if got := len(matrix[0].Values); got < 5 {
+		t.Fatalf("expected per-step sum_over_time matrix (>= 5 samples); got %d: %+v",
+			got, matrix[0].Values)
+	}
+	// Per-step variation: as anchors advance through the seed, the
+	// 5-minute window picks up more samples and the sum grows. A
+	// regression where every step carried the same value would surface
+	// as first == last.
+	first := matrix[0].Values[0][1]
+	last := matrix[0].Values[len(matrix[0].Values)-1][1]
+	if first == last {
+		t.Errorf("expected per-step variation across the sum_over_time matrix; got first=last=%q (full row: %+v)",
+			first, matrix[0].Values)
+	}
+}
+
+// TestQueryRange_RangeMode_VVOnComparison_ChDB pins the 502 the
+// compat lane caught for V-V `==/!=/<=` etc. with `on(...)` matching
+// under query_range. The pre-Pool-AL emitter aggregated each side by
+// the match key WITHOUT bucketing on anchor_ts, so the per-anchor
+// matrix collapsed to a single row per match-key. With multiple
+// distinct series sharing the on-key (e.g. instance + job + type),
+// the runtime uniqueness throwIf fired and CH surfaced it as a 502.
+//
+// Seeded: two series with the same {instance, job, type} on-key but
+// disjoint extra labels (the on() collapse). Without StepAligned the
+// throwIf fires (the match key sees 2 distinct Attributes maps per
+// anchor); with StepAligned the per-(match-key, anchor) bucket sees
+// exactly one Attributes map AT EACH anchor, and the comparison
+// surfaces all-true (the metric equals itself element-wise).
+//
+// Use the same metric on both sides — `metric == on(k...) metric` is
+// the canonical Prom self-comparison. With identical values per
+// (series, anchor) the result is 1.0 per matched pair when ReturnBool
+// is set, or the LHS value where the comparison holds when not.
+func TestQueryRange_RangeMode_VVOnComparison_ChDB(t *testing.T) {
+	end := time.Now().UTC()
+	start := end.Add(-5 * time.Minute)
+	step := 30 * time.Second
+	const seedSamples = 11
+
+	// Two series share (instance, job, type) but differ in another
+	// label — the on() collapse would normally fold them onto the
+	// same match-key row and trip the throwIf without step alignment.
+	// We pick a single Attributes map for each side because the
+	// comparison `metric == on(k) metric` evaluates per-anchor: the
+	// surviving rows are those whose (instance, job, type) tuple
+	// matches across the two legs. With one tuple per series and
+	// identical values, the comparison surfaces 1.0 per surviving
+	// pair (the bool-mode variant of `==`).
+	seedRows := make([]string, 0, seedSamples)
+	for i := 0; i < seedSamples; i++ {
+		ts := start.Add(time.Duration(i) * step).Format("2006-01-02 15:04:05.000000000")
+		seedRows = append(seedRows, fmt.Sprintf(
+			`('demo_memory_usage_bytes', map('instance', 'demo', 'job', 'app', 'type', 'rss'), toDateTime64('%s', 9), %d.0)`,
+			ts, 100+i,
+		))
+	}
+	seed := gaugeDDL + "\nINSERT INTO otel_metrics_gauge VALUES\n  " +
+		strings.Join(seedRows, ",\n  ") + ";"
+	srv, _ := newChDBServer(t, seed)
+
+	// Use `== bool` so each matched pair emits 1.0 — easier to assert
+	// than relying on the bare-`==` filter-mode preserving the LHS
+	// value, and matches what the compat-lane queries actually
+	// requested (the 12 case-class includes bool variants).
+	matrix := runRangeModeQueryRange(t, srv.URL,
+		"demo_memory_usage_bytes == bool on(instance, job, type) demo_memory_usage_bytes",
+		start, end, step)
+	if len(matrix) == 0 {
+		t.Fatalf("pre-Pool-AL: V-V `on(...)` over query_range surfaces 502 / 0 series; got 0 series")
+	}
+	// One series (one match-key tuple) with N per-step samples.
+	values := matrix[0].Values
+	if got := len(values); got < 5 {
+		t.Fatalf("expected per-step V-V comparison matrix (>= 5 samples); got %d: %+v",
+			got, values)
+	}
+	// Each surviving pair compares the metric to itself → bool-1 per
+	// step. No "1.0" because bool comparisons in Prom emit the integer
+	// 1 (rendered by the cerberus pipeline as "1" — same shape as the
+	// existing `bool_vv_eq.txtar` fixture's expected_rows).
+	for i, v := range values {
+		if got := v[1]; got != "1" {
+			t.Errorf("step %d: V-V `== bool` value=%q want=%q (full row: %+v)",
+				i, got, "1", v)
+		}
+	}
+}
+
 // runRangeModeQueryRange is the test helper shared across the Pool-AK
 // range-mode regression cases. Mirrors `runStepLoopRange` but lives
 // in this file so the Pool-AK suite is self-contained for any future

--- a/internal/chplan/vector_join.go
+++ b/internal/chplan/vector_join.go
@@ -87,6 +87,28 @@ type VectorJoin struct {
 	// filtered out by the comparison.
 	ReturnBool bool
 
+	// StepAligned reports whether the join must step-align on the
+	// per-anchor TimestampColumn. Set by the PromQL binary lowering
+	// when ctx.step > 0 (range mode) and one or both sides produce a
+	// per-step matrix (via wrapRangeLatestPerSeries / matrix
+	// RangeWindow). The emitter then:
+	//
+	//   - adds TimestampColumn to each per-side aggregation's GROUP BY
+	//     so each (series, anchor) row survives instead of being
+	//     collapsed to a single per-series row, and
+	//   - ANDs `L.TimestampColumn = R.TimestampColumn` into the JOIN's
+	//     ON clause so the per-pair comparison fires per anchor.
+	//
+	// Without this flag, the per-side aggregation collapses N anchors
+	// onto a single match-key, the `on(...)` join finds N×N matches
+	// (or a single per-match-key row in roleOne), and the comparison
+	// either fails the runtime uniqueness guard or silently degenerates
+	// into a cartesian product across anchors.
+	//
+	// Default false preserves the instant-mode shape; the existing
+	// V-V fixtures stay byte-stable.
+	StepAligned bool
+
 	MetricNameColumn string
 	AttributesColumn string
 	TimestampColumn  string
@@ -109,6 +131,9 @@ func (v *VectorJoin) Equal(other Node) bool {
 		return false
 	}
 	if v.ReturnBool != o.ReturnBool {
+		return false
+	}
+	if v.StepAligned != o.StepAligned {
 		return false
 	}
 	if v.MetricNameColumn != o.MetricNameColumn ||

--- a/internal/chsql/vector_join.go
+++ b/internal/chsql/vector_join.go
@@ -65,7 +65,7 @@ func (e *emitter) emitVectorJoin(j *chplan.VectorJoin) error {
 		Join(
 			InnerJoin,
 			aliasedFrag(rightFrag, "R"),
-			vectorMatchPredicateFrag(j.Match, j.AttributesColumn),
+			vectorMatchPredicateFrag(j.Match, j.AttributesColumn, j.TimestampColumn, j.StepAligned),
 		)
 	e.emitSelect(sb)
 	return nil
@@ -158,27 +158,60 @@ func (e *emitter) vectorJoinSideFrag(j *chplan.VectorJoin, n chplan.Node, role s
 	}
 	inner := NewQuery().From(sub)
 	if role == roleMany {
-		inner.Select(
-			As(Col(j.MetricNameColumn), joinAlias(j.MetricNameColumn)),
-			As(Col(j.AttributesColumn), joinAlias(j.AttributesColumn)),
-			aggMaxAs(j.TimestampColumn, joinAlias(j.TimestampColumn)),
-			argMaxAs(j.ValueColumn, j.TimestampColumn, joinAlias(j.ValueColumn)),
-		).GroupBy(
-			Col(j.MetricNameColumn),
-			Col(j.AttributesColumn),
-		)
+		// Step-aligned ("range mode") joins keep TimeUnix in the
+		// per-side group key so the per-(series, anchor) row survives
+		// instead of being collapsed to one row per series. The
+		// selector projects TimeUnix directly (it's a group key,
+		// already unique within the group). Instant mode leaves
+		// TimeUnix off the GROUP BY and uses max(TimeUnix) to pick
+		// the latest LWR sample — byte-stable for the existing
+		// fixtures.
+		if j.StepAligned {
+			inner.Select(
+				As(Col(j.MetricNameColumn), joinAlias(j.MetricNameColumn)),
+				As(Col(j.AttributesColumn), joinAlias(j.AttributesColumn)),
+				As(Col(j.TimestampColumn), joinAlias(j.TimestampColumn)),
+				argMaxAs(j.ValueColumn, j.TimestampColumn, joinAlias(j.ValueColumn)),
+			).GroupBy(
+				Col(j.MetricNameColumn),
+				Col(j.AttributesColumn),
+				Col(j.TimestampColumn),
+			)
+		} else {
+			inner.Select(
+				As(Col(j.MetricNameColumn), joinAlias(j.MetricNameColumn)),
+				As(Col(j.AttributesColumn), joinAlias(j.AttributesColumn)),
+				aggMaxAs(j.TimestampColumn, joinAlias(j.TimestampColumn)),
+				argMaxAs(j.ValueColumn, j.TimestampColumn, joinAlias(j.ValueColumn)),
+			).GroupBy(
+				Col(j.MetricNameColumn),
+				Col(j.AttributesColumn),
+			)
+		}
 	} else {
 		// "one" side — aggregate by matching key with a runtime
 		// uniqueness guard. argMax(Attributes, TimeUnix) picks one
 		// representative series per match key; throwIf fires when
 		// there's more than one.
+		//
+		// Step-aligned joins extend the match key with TimeUnix so
+		// each (match-key, anchor) gets its own row and the throwIf
+		// uniqueness guard fires per-anchor rather than across the
+		// full per-step matrix. The selector keeps argMax /
+		// max(TimeUnix) for symmetry with instant mode — within a
+		// single (match-key, anchor) group all rows share the same
+		// TimeUnix by construction.
+		groupFrags := []Frag{matchKeyGroupExprFrag(j.Match, j.AttributesColumn)}
+		if j.StepAligned {
+			groupFrags = append(groupFrags, Col(j.TimestampColumn))
+		}
 		inner.Select(
 			argMaxAs(j.MetricNameColumn, j.TimestampColumn, joinAlias(j.MetricNameColumn)),
 			argMaxAs(j.AttributesColumn, j.TimestampColumn, joinAlias(j.AttributesColumn)),
 			aggMaxAs(j.TimestampColumn, joinAlias(j.TimestampColumn)),
 			argMaxAs(j.ValueColumn, j.TimestampColumn, joinAlias(j.ValueColumn)),
 			matchCheckFrag(j.AttributesColumn),
-		).GroupBy(matchKeyGroupExprFrag(j.Match, j.AttributesColumn))
+		).GroupBy(groupFrags...)
 	}
 
 	// Outer Project: rename `_join_*` back to canonical column names
@@ -408,11 +441,31 @@ func writeSideCol(b *Builder, side, col string) {
 //   - ignoring(l1, l2)                 → mapFilter-stripped equality
 //   - on() with no labels              → 1 = 1 (per-side aggregation
 //     already collapses to one row via the throwIf guard).
-func vectorMatchPredicateFrag(m chplan.VectorMatch, attrsCol string) Frag {
-	return func(b *Builder) { writeVectorMatchPredicate(b, m, attrsCol) }
+//
+// When stepAligned is true the rendered predicate additionally ANDs in
+// `L.<tsCol> = R.<tsCol>` so each anchor joins its own per-anchor
+// pair — required when both sides emit a per-step matrix (range mode).
+// Without that conjunct the join would degenerate into a full cross
+// across anchors (roleMany) or fold the matrix down to a single per-
+// match-key row at the surviving anchor (roleOne).
+func vectorMatchPredicateFrag(m chplan.VectorMatch, attrsCol, tsCol string, stepAligned bool) Frag {
+	return func(b *Builder) { writeVectorMatchPredicate(b, m, attrsCol, tsCol, stepAligned) }
 }
 
-func writeVectorMatchPredicate(b *Builder, m chplan.VectorMatch, attrsCol string) {
+func writeVectorMatchPredicate(b *Builder, m chplan.VectorMatch, attrsCol, tsCol string, stepAligned bool) {
+	writeMatchKeyPredicate(b, m, attrsCol)
+	if stepAligned {
+		b.writeSQL(" AND ")
+		writeSideCol(b, "L", tsCol)
+		b.writeSQL(" = ")
+		writeSideCol(b, "R", tsCol)
+	}
+}
+
+// writeMatchKeyPredicate renders just the label-matching half of the
+// join's ON clause — extracted so the step-alignment AND can be
+// composed on top without copying the per-shape branches.
+func writeMatchKeyPredicate(b *Builder, m chplan.VectorMatch, attrsCol string) {
 	if len(m.Labels) == 0 && !m.On {
 		writeSideCol(b, "L", attrsCol)
 		b.writeSQL(" = ")

--- a/internal/promql/binary.go
+++ b/internal/promql/binary.go
@@ -151,6 +151,17 @@ func lowerVectorVector(b *parser.BinaryExpr, s schema.Metrics, op chplan.BinaryO
 		match.On = b.VectorMatching.On
 	}
 
+	// Range mode (ctx.step > 0): both sides materialise per-step rows
+	// (one per series × anchor) via wrapRangeLatestPerSeries / the
+	// matrix RangeWindow. The V-V join must step-align so each anchor
+	// joins its own pair, otherwise the per-side aggregation collapses
+	// N anchors onto a single match-key (roleOne) or the join finds N×N
+	// matches per series (roleMany). Lifting `StepAligned` onto the
+	// VectorJoin lets the emitter add TimestampColumn to both the
+	// per-side GROUP BY and the JOIN's ON clause; instant mode keeps
+	// the byte-stable shape (StepAligned=false default).
+	stepAligned := ctx.step > 0
+
 	return &chplan.VectorJoin{
 		Left:             left,
 		Right:            right,
@@ -159,6 +170,7 @@ func lowerVectorVector(b *parser.BinaryExpr, s schema.Metrics, op chplan.BinaryO
 		Card:             card,
 		Include:          include,
 		ReturnBool:       b.ReturnBool,
+		StepAligned:      stepAligned,
 		MetricNameColumn: s.MetricNameColumn,
 		AttributesColumn: s.AttributesColumn,
 		TimestampColumn:  s.TimestampColumn,

--- a/internal/promql/range_fns.go
+++ b/internal/promql/range_fns.go
@@ -46,7 +46,7 @@ func lowerPredictLinear(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.
 	if err != nil {
 		return nil, err
 	}
-	return &chplan.RangeWindow{
+	rw := &chplan.RangeWindow{
 		Input:           inner,
 		Func:            "predict_linear",
 		Range:           ms.Range,
@@ -56,7 +56,19 @@ func lowerPredictLinear(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.
 		TimestampColumn: s.TimestampColumn,
 		ValueColumn:     s.ValueColumn,
 		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}},
-	}, nil
+	}
+	// Range mode (ctx.step > 0): fan across the request's step grid so
+	// each anchor in [start, end] emits its own per-window prediction.
+	// Mirrors lowerRangeVectorCall — without this gate the outer
+	// `RangeWindow` defaults to Step=0 and the matrix pivot collapses
+	// every step bucket onto a single anchor at end_ts.
+	if ctx.step > 0 && !ctx.start.IsZero() && !ctx.end.IsZero() {
+		rw.Start = ctx.start.UTC()
+		rw.End = ctx.end.UTC()
+		rw.Step = ctx.step
+		rw.OuterRange = ctx.end.Sub(ctx.start)
+	}
+	return rw, nil
 }
 
 // lowerHoltWinters handles `holt_winters(v range-vector, sf scalar, tf
@@ -102,7 +114,7 @@ func lowerHoltWinters(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.No
 	if err != nil {
 		return nil, err
 	}
-	return &chplan.RangeWindow{
+	rw := &chplan.RangeWindow{
 		Input: inner,
 		// Use the canonical "holt_winters" name in the IR regardless
 		// of whether the source query used the legacy name or the new
@@ -116,7 +128,17 @@ func lowerHoltWinters(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.No
 		TimestampColumn: s.TimestampColumn,
 		ValueColumn:     s.ValueColumn,
 		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}},
-	}, nil
+	}
+	// Range mode (ctx.step > 0): fan across the request's step grid so
+	// each anchor in [start, end] emits its own per-window smoothed
+	// value (matches the lowerRangeVectorCall matrix gate).
+	if ctx.step > 0 && !ctx.start.IsZero() && !ctx.end.IsZero() {
+		rw.Start = ctx.start.UTC()
+		rw.End = ctx.end.UTC()
+		rw.Step = ctx.step
+		rw.OuterRange = ctx.end.Sub(ctx.start)
+	}
+	return rw, nil
 }
 
 // lowerQuantileOverTime handles `quantile_over_time(phi, v[range])`:
@@ -192,6 +214,15 @@ func lowerQuantileOverTime(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chpl
 		TimestampColumn: s.TimestampColumn,
 		ValueColumn:     s.ValueColumn,
 		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}},
+	}
+	// Range mode (ctx.step > 0): fan across the request's step grid so
+	// each anchor in [start, end] emits its own per-window quantile
+	// (matches the lowerRangeVectorCall matrix gate).
+	if ctx.step > 0 && !ctx.start.IsZero() && !ctx.end.IsZero() {
+		window.Start = ctx.start.UTC()
+		window.End = ctx.end.UTC()
+		window.Step = ctx.step
+		window.OuterRange = ctx.end.Sub(ctx.start)
 	}
 	if !replaceValue {
 		return window, nil

--- a/internal/promql/subquery.go
+++ b/internal/promql/subquery.go
@@ -271,14 +271,29 @@ func lowerOuterRangeFnOverSubquery(
 		return nil, err
 	}
 
-	return &chplan.RangeWindow{
+	rw := &chplan.RangeWindow{
 		Input:           inner,
 		Func:            outer.Func.Name,
 		Range:           sub.Range,
 		TimestampColumn: "anchor_ts",
 		ValueColumn:     s.ValueColumn,
 		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}},
-	}, nil
+	}
+	// Range mode: the outer reducer in `max_over_time(rate(m[5m])[1h:5m])`
+	// must fan across the request's step grid so each anchor in
+	// [start, end] emits its own per-window reduction. Without this the
+	// outer RangeWindow keeps Step=0 and collapses to a single anchor at
+	// end_ts (compat-lane: 502 / single-point matrix). Mirrors the
+	// `lowerRangeVectorCall` matrix fan-out introduced for bare
+	// range-vector calls — the same gate (ctx.step > 0 with start/end
+	// threaded through LowerAtRange) applies here.
+	if ctx.step > 0 && !ctx.start.IsZero() && !ctx.end.IsZero() {
+		rw.Start = ctx.start.UTC()
+		rw.End = ctx.end.UTC()
+		rw.Step = ctx.step
+		rw.OuterRange = ctx.end.Sub(ctx.start)
+	}
+	return rw, nil
 }
 
 // rangeVectorFn is the set of PromQL functions cerberus's emitter


### PR DESCRIPTION
## Summary

Two fixes from the post-#347 compat baseline:

### Fix 1 — V-V `on(...)` 502s (12 cases)

After #347's per-step LWR rework, both sides of a V-V binary in range mode emit one row per (series, anchor_ts). The emitter (`internal/chsql/vector_join.go`) aggregated each side by the match key WITHOUT bucketing on `anchor_ts`, collapsing N anchors onto one match-key row. For `metric == on(instance,job,type) metric` with 12 series sharing each on-key, the runtime `throwIf(uniqExact(Attributes) > 1, ...)` guard fires → CH 502.

**Fix**: new `chplan.VectorJoin.StepAligned` flag. `lowerBinary` sets it when `ctx.step > 0`. Emitter then:
- Adds `TimestampColumn` to both per-side GROUP BYs so per-(series, anchor) rows survive.
- ANDs `L.TimeUnix = R.TimeUnix` into the JOIN's ON clause.

Instant mode keeps byte-stable shape — 17 V-V txtar fixtures unchanged.

### Fix 2 — Range-mode matrix fan-out (30+ diffs)

`lowerRangeVectorCall` threads `ctx.step/start/end/OuterRange` for bare `rate(m[5m])` etc., but four sibling lowerings defaulted to `Step=0` (single anchor at end_ts):

- `lowerOuterRangeFnOverSubquery` (subquery.go:259)
- `lowerPredictLinear` (range_fns.go:21)
- `lowerHoltWinters` (range_fns.go:70)
- `lowerQuantileOverTime` (range_fns.go:142)

**Fix**: mirrored the `lowerRangeVectorCall` gate in each — when `ctx.step > 0 && !ctx.start.IsZero() && !ctx.end.IsZero()`, set `Start/End/Step/OuterRange = end - start`.

## Test plan

- [x] `go test ./...` — 2705 pass (35 packages)
- [x] `go test -tags chdb ./internal/api/prom/` — 205 pass (incl. 3 new range-mode regressions: rate matrix, sum_over_time variation, V-V on(...) comparison)
- [x] `go test -tags chdb ./test/spec/promql/` — 194 pass
- [x] `go vet ./...` clean

6 files, +328 / -20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>