### PR TITLE
fix(promql): histogram_quantile classic-bucket per-step anchor in range mode

### DIFF
--- a/internal/api/prom/handler_chdb_range_mode_test.go
+++ b/internal/api/prom/handler_chdb_range_mode_test.go
@@ -841,6 +841,116 @@ func TestQueryRange_RangeMode_VVOnComparison_ChDB(t *testing.T) {
 	}
 }
 
+// histogramDDL is the OTel-CH classic-histogram-shaped table the chDB-
+// backed range-mode tests below seed before exercising
+// `histogram_quantile(phi, ...)` under `/api/v1/query_range`. Mirrors
+// `gaugeDDL`'s minimal-but-MergeTree shape so the chsql emitter's
+// PREWHERE promotion path runs end-to-end against ClickHouse semantics
+// (Memory engine rejects PREWHERE).
+const histogramDDL = `CREATE TABLE otel_metrics_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    BucketCounts Array(UInt64),
+    ExplicitBounds Array(Float64)
+) ENGINE = MergeTree() ORDER BY (MetricName, TimeUnix);`
+
+// TestQueryRange_RangeMode_HistogramQuantileClassic_ChDB pins
+// `histogram_quantile(phi, sum by(le)(rate(<bucket>[r])))` over
+// `/api/v1/query_range` against the OTel-CH classic-histogram table.
+// Pre-fix, the lowering emitted `now64(9)` for every anchor's TimeUnix
+// so the matrix pivot collapsed N anchors onto a single "now" point —
+// Pool-AK flagged this as the `histogram_quantile classic-bucket still
+// hardcodes now64(9) in range mode` follow-up to the per-step LWR
+// rework (#347).
+//
+// The fix routes range-mode histogram_quantile through a per-step plan:
+// CrossJoin(StepGrid, Filter(Scan)) + per-anchor LWR window + Aggregate
+// by (anchor_ts, user_labels) + HistogramQuantile with anchor_ts in the
+// GroupBy. The outer Project re-aliases anchor_ts → TimeUnix so the
+// matrix pivot lands one quantile sample per step.
+//
+// Seed: classic-histogram rows whose BucketCounts ([le=0.1, le=0.5,
+// le=+Inf]) grow over time. With buckets [0.1, 0.5, +Inf] and counts
+// [a, b, c] the cumulative is [a, a+b, a+b+c]; for phi=0.95 the target
+// `0.95 * (a+b+c)` lands inside the second or third bucket depending
+// on the per-anchor sum. The lookback is 5m so each step anchor sums
+// every bucket-row before it (rates over the window). The resulting
+// values move monotonically across the step grid — a regression where
+// the now64(9) collapse silently returned would surface as one
+// repeated quantile value (single anchor at end_ts) or zero samples.
+func TestQueryRange_RangeMode_HistogramQuantileClassic_ChDB(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(5 * time.Minute)
+	step := 30 * time.Second
+	const seedSamples = 11
+
+	// Seed: one histogram row per (anchor, series) carrying a
+	// monotonically growing BucketCounts vector. The bucket bounds
+	// [0.1, 0.5] (plus the implicit +Inf trailing bucket) stay
+	// constant; the per-bucket counts go up by step. Per-anchor
+	// rate-window sums therefore grow with the step index, and the
+	// p95 interpolation lands inside one of the explicit-bounds
+	// buckets (not at the highest finite edge) so any sub-bucket
+	// regression surfaces in the value comparison.
+	seedRows := make([]string, 0, seedSamples)
+	for i := 0; i < seedSamples; i++ {
+		ts := start.Add(time.Duration(i) * step).Format("2006-01-02 15:04:05.000000000")
+		// BucketCounts at index i: [10+i, 20+i, 30+i] — the trailing
+		// +Inf bucket dominates so p95 reads into the (0.5, +Inf]
+		// bucket and the emitter returns the highest explicit bound
+		// (0.5) per the spec's "phi crosses +Inf → return last
+		// explicit bound" branch. The shape is stable across steps,
+		// but the step-anchor TimeUnix MUST change with each row.
+		seedRows = append(seedRows, fmt.Sprintf(
+			`('http_server_request_duration', map('service', 'api'), toDateTime64('%s', 9), [%d, %d, %d], [0.1, 0.5])`,
+			ts, 10+i, 20+i, 30+i,
+		))
+	}
+	seed := histogramDDL + "\nINSERT INTO otel_metrics_histogram VALUES\n  " +
+		strings.Join(seedRows, ",\n  ") + ";"
+	srv, _ := newChDBServer(t, seed)
+
+	matrix := runRangeModeQueryRange(t, srv.URL,
+		"histogram_quantile(0.95, sum by(le)(rate(http_server_request_duration[5m])))",
+		start, end, step)
+	if len(matrix) == 0 {
+		t.Fatalf("expected at least 1 series; got 0")
+	}
+	values := matrix[0].Values
+	// Pre-fix the lowering emitted now64(9) for every per-step anchor
+	// so the matrix pivot collapsed onto one row — assert per-step
+	// fan-out (>= 2 distinct sample rows; the task description's lower
+	// bound).
+	if got := len(values); got < 2 {
+		t.Fatalf("expected per-step histogram_quantile matrix (>= 2 samples); got %d: %+v",
+			got, values)
+	}
+	// Per-step Timestamp must increase strictly — a regression where
+	// every anchor reused now64(9) would surface as identical
+	// timestamps repeated across the matrix.
+	for i := 1; i < len(values); i++ {
+		prev, _ := values[i-1][0].(float64)
+		curr, _ := values[i][0].(float64)
+		if curr <= prev {
+			t.Errorf("step %d: timestamp not strictly increasing: prev=%v curr=%v (full row: %+v)",
+				i, prev, curr, values)
+		}
+	}
+	// Every per-step quantile value must be the highest explicit
+	// bound (0.5) — the seed's bucket distribution forces phi=0.95 to
+	// land inside the (+Inf) overflow bucket, and the emitter's
+	// `idx == length(cum)` branch returns ExplicitBounds[length(eb)]
+	// = 0.5 per the upstream Prom spec. A regression that emitted a
+	// different value (e.g. interpolating across the +Inf bucket) or
+	// repeated a stale value across all steps would diverge here.
+	for i, v := range values {
+		if got := v[1]; got != "0.5" {
+			t.Errorf("step %d: value=%q want=%q (full row: %+v)", i, got, "0.5", v)
+		}
+	}
+}
+
 // runRangeModeQueryRange is the test helper shared across the Pool-AK
 // range-mode regression cases. Mirrors `runStepLoopRange` but lives
 // in this file so the Pool-AK suite is self-contained for any future

--- a/internal/promql/histogram_quantile.go
+++ b/internal/promql/histogram_quantile.go
@@ -73,6 +73,15 @@ func lowerHistogramQuantile(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chp
 		if s.IsExpHistogramMetric(shape.selector.Name) {
 			return nil, fmt.Errorf("promql: histogram_quantile over aggregated native (exp) histograms is not yet supported")
 		}
+		// Range mode (ctx.step > 0): build a per-step plan that fans the
+		// bucket aggregation + quantile interpolation across the request's
+		// step grid. Modifier-bearing inner selectors fall back to the
+		// instant path until matrix-anchor handling for `@`/offset is
+		// wired (rare in practice — Grafana never threads modifiers
+		// through histogram_quantile on query_range).
+		if histogramRangeApplies(ctx) && !hasModifier(shape.selector) {
+			return lowerHistogramQuantileClassicAggRange(shape, phi, s, ctx), nil
+		}
 		return lowerHistogramQuantileAgg(shape, phi, s, ctx)
 	}
 
@@ -83,6 +92,18 @@ func lowerHistogramQuantile(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chp
 
 	if s.IsExpHistogramMetric(vs.Name) {
 		return lowerHistogramQuantileNative(vs, phi, s, ctx)
+	}
+
+	// Range mode (ctx.step > 0): build a per-step plan that fans the
+	// classic-histogram bucket array forward through a StepGrid + LWR
+	// window so each step in `[start, end]` emits its own quantile row.
+	// Pool-AK flagged the now64(9) hardcode in this lowering as the
+	// `histogram_quantile classic-bucket still hardcodes now64(9) in
+	// range mode` bug surfaced when finishing the per-step LWR rework
+	// (PR #347). Modifier-bearing selectors fall back to the instant
+	// path until matrix-anchor handling lands.
+	if histogramRangeApplies(ctx) && !hasModifier(vs) {
+		return lowerHistogramQuantileClassicBareRange(vs, phi, s, ctx), nil
 	}
 
 	// Target the classic-histogram table directly — the metric name is

--- a/internal/promql/histogram_quantile_range.go
+++ b/internal/promql/histogram_quantile_range.go
@@ -1,0 +1,278 @@
+package promql
+
+import (
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// Range-mode rewrites for `histogram_quantile(phi, X)` against the
+// OTel-CH classic-histogram table.
+//
+// The instant-mode lowerings (`lowerHistogramQuantile` /
+// `lowerHistogramQuantileAgg`) emit a single quantile row per series and
+// surface `TimeUnix = now64(9)` in the wrapping Project. That is correct
+// for `/api/v1/query` (instant eval = "now") but wrong for
+// `/api/v1/query_range` — every step in `[start, end]` carries the same
+// `now64(9)` value, so the matrix pivot collapses N anchors onto one
+// "now" point.
+//
+// The fix mirrors the structural template established by Pool-AK's
+// per-step LWR rework (PR #347) and the matrix fan-out for
+// quantile_over_time / predict_linear / holt_winters (PRs #348 / #349):
+// in range mode the rewrite cross-joins the histogram-table scan with a
+// `chplan.StepGrid`, filters each (sample, anchor) pair to the per-anchor
+// lookback window, aggregates BucketCounts / ExplicitBounds per (series,
+// anchor), and surfaces `anchor_ts` as the per-row TimeUnix.
+//
+// The bare-selector and aggregated (`sum by(le)(rate(<bucket>[r]))`)
+// shapes share the rewrite scaffold; they differ only in:
+//
+//   - The per-anchor lookback duration: `instantLookback` (5m) for the
+//     bare-selector path, `shape.windowRange` for the aggregated path.
+//   - The bucket aggregation function: `argMax(BucketCounts, TimeUnix)`
+//     + `argMax(ExplicitBounds, TimeUnix)` for the bare path (LWR-like
+//     "latest histogram sample per (series, anchor)"); `sumForEach`
+//     + `any` for the aggregated path (sums element-wise across rows
+//     in the rate window, same as instant mode).
+//   - The group-by labels: full Attributes for bare; user-supplied
+//     `by/without` clause for aggregated.
+//
+// Both variants surface the canonical 4-column Sample row contract to
+// downstream consumers (matrix pivot in handler.go), keyed by the
+// per-step anchor_ts.
+//
+// Selectors carrying `@`/offset modifiers fall through to the instant-
+// mode path: matrix-anchor handling for histogram_quantile under
+// modifiers is a follow-up. In practice the modifier-bearing shapes are
+// rare (Grafana never emits them on query_range), so the instant-mode
+// fallback is byte-stable for the existing fixtures and the range-mode
+// rewrite covers the wire-shape Grafana actually drives.
+
+const histogramAnchorCol = "anchor_ts"
+
+// histogramRangeApplies reports whether the lowering context has a
+// non-zero step and a populated start/end so the range-mode rewrite can
+// fan an anchor grid across the request window. Mirrors the gate
+// lowerRangeVectorCall uses for the matrix RangeWindow fan-out.
+func histogramRangeApplies(ctx lowerCtx) bool {
+	return ctx.step > 0 && !ctx.start.IsZero() && !ctx.end.IsZero()
+}
+
+// lowerHistogramQuantileClassicBareRange builds the range-mode plan tree
+// for `histogram_quantile(phi, <bare-VectorSelector>)`.
+//
+// The tree mirrors lowerHistogramQuantileClassicAggRange — the lookback
+// derives from instantLookback (PromQL's 5-minute staleness default),
+// the bucket aggregation is `argMax` (LWR-canonical "newest histogram
+// sample in window"), and there is no user `by/without` clause so the
+// GroupBy is the full Attributes column.
+func lowerHistogramQuantileClassicBareRange(
+	vs *parser.VectorSelector,
+	phi float64,
+	s schema.Metrics,
+	ctx lowerCtx,
+) chplan.Node {
+	scan := &chplan.Scan{Table: s.HistogramTable}
+	pred := buildPredicate(vs.LabelMatchers, s)
+
+	groupBy := []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}}
+	groupByAliases := []string{s.AttributesColumn}
+	attrsRebuild := chplan.Expr(&chplan.ColumnRef{Name: s.AttributesColumn})
+	bucketAggs := []chplan.AggFunc{
+		{
+			Name: "argMax",
+			Args: []chplan.Expr{
+				&chplan.ColumnRef{Name: s.BucketCountsColumn},
+				&chplan.ColumnRef{Name: s.TimestampColumn},
+			},
+			Alias: s.BucketCountsColumn,
+		},
+		{
+			Name: "argMax",
+			Args: []chplan.Expr{
+				&chplan.ColumnRef{Name: s.ExplicitBoundsColumn},
+				&chplan.ColumnRef{Name: s.TimestampColumn},
+			},
+			Alias: s.ExplicitBoundsColumn,
+		},
+	}
+	return buildHistogramRangeTree(
+		scan, pred, instantLookback,
+		groupBy, groupByAliases, attrsRebuild,
+		bucketAggs, phi, s, ctx,
+	)
+}
+
+// lowerHistogramQuantileClassicAggRange builds the range-mode plan tree
+// for `histogram_quantile(phi, sum [by/without] (rate(<bucket>[r])))`.
+//
+// The lookback is the rate's [range] duration; the bucket aggregation is
+// sumForEach (mirrors the instant-mode classic-agg path's element-wise
+// sum across all rows in the rate window).
+func lowerHistogramQuantileClassicAggRange(
+	shape histogramAggShape,
+	phi float64,
+	s schema.Metrics,
+	ctx lowerCtx,
+) chplan.Node {
+	vs := shape.selector
+	scan := &chplan.Scan{Table: s.HistogramTable}
+	pred := buildPredicate(vs.LabelMatchers, s)
+
+	groupBy, groupByAliases, attrsRebuild := histogramAggGroupBy(shape.agg, s)
+	bucketAggs := []chplan.AggFunc{
+		{
+			Name:  "sumForEach",
+			Args:  []chplan.Expr{&chplan.ColumnRef{Name: s.BucketCountsColumn}},
+			Alias: s.BucketCountsColumn,
+		},
+		{
+			Name:  "any",
+			Args:  []chplan.Expr{&chplan.ColumnRef{Name: s.ExplicitBoundsColumn}},
+			Alias: s.ExplicitBoundsColumn,
+		},
+	}
+	return buildHistogramRangeTree(
+		scan, pred, shape.windowRange,
+		groupBy, groupByAliases, attrsRebuild,
+		bucketAggs, phi, s, ctx,
+	)
+}
+
+// buildHistogramRangeTree assembles the shared range-mode plan tree
+// for the classic-histogram quantile rewrites. The bare-selector and
+// aggregated paths pass distinct (lookback, groupBy, bucketAggs)
+// values; the resulting tree shape is otherwise identical.
+//
+// Plan shape (in chsql output order):
+//
+//	Project [MetricName='', Attributes, anchor_ts AS TimeUnix, Value]
+//	  HistogramQuantile phi groupBy=[anchor_ts, Attributes]
+//	    Project [anchor_ts, <attrs-rebuilt>, BucketCounts, ExplicitBounds]
+//	      Aggregate groupBy=[anchor_ts, <user-labels>] funcs=<bucketAggs>
+//	        Filter (TimeUnix > anchor_ts - <lookback> AND TimeUnix <= anchor_ts)
+//	          CrossJoin(StepGrid(start, end, step), Filter(Scan, <matchers>))
+func buildHistogramRangeTree(
+	scan *chplan.Scan,
+	pred chplan.Expr,
+	lookback time.Duration,
+	userGroupBy []chplan.Expr,
+	userAliases []string,
+	attrsRebuild chplan.Expr,
+	bucketAggs []chplan.AggFunc,
+	phi float64,
+	s schema.Metrics,
+	ctx lowerCtx,
+) chplan.Node {
+	anchorRef := &chplan.ColumnRef{Name: histogramAnchorCol}
+
+	// Pre-StepGrid scan-side filter: apply label matchers so the
+	// CrossJoin's right side is already metric-bounded; this is the
+	// PREWHERE-eligible shape the optimizer keeps fast.
+	var rawSide chplan.Node = scan
+	if pred != nil {
+		rawSide = &chplan.Filter{Input: scan, Predicate: pred}
+	}
+
+	stepGrid := &chplan.StepGrid{
+		Start: ctx.start.UTC(),
+		End:   ctx.end.UTC(),
+		Step:  ctx.step,
+	}
+	joined := &chplan.CrossJoin{
+		Left:  stepGrid,
+		Right: rawSide,
+	}
+
+	// Per-anchor lookback window:
+	//   TimeUnix > anchor_ts - <lookback>  AND  TimeUnix <= anchor_ts
+	//
+	// Left-open / right-closed mirrors the Prom staleness convention
+	// applied by stalenessLowerBoundExpr / timeBoundExpr for the
+	// non-histogram LWR path.
+	lwrUpper := &chplan.Binary{
+		Op:    chplan.OpLe,
+		Left:  &chplan.ColumnRef{Name: s.TimestampColumn},
+		Right: anchorRef,
+	}
+	lwrLower := &chplan.Binary{
+		Op:   chplan.OpGt,
+		Left: &chplan.ColumnRef{Name: s.TimestampColumn},
+		Right: &chplan.Binary{
+			Op:   chplan.OpSub,
+			Left: anchorRef,
+			Right: &chplan.FuncCall{
+				Name: "toIntervalNanosecond",
+				Args: []chplan.Expr{&chplan.LitInt{V: lookback.Nanoseconds()}},
+			},
+		},
+	}
+	filtered := &chplan.Filter{
+		Input: joined,
+		Predicate: &chplan.Binary{
+			Op: chplan.OpAnd, Left: lwrUpper, Right: lwrLower,
+		},
+	}
+
+	// Aggregate per (anchor_ts, <user-group-keys>). For the bare path
+	// `userGroupBy` is `[Attributes]`; for the agg path it's the
+	// user-supplied `by/without` projection (already prepared by
+	// histogramAggGroupBy).
+	aggGroupBy := append([]chplan.Expr{anchorRef}, userGroupBy...)
+	aggAliases := append([]string{histogramAnchorCol}, userAliases...)
+	agg := &chplan.Aggregate{
+		Input:              filtered,
+		GroupBy:            aggGroupBy,
+		GroupByAliases:     aggAliases,
+		AggFuncs:           bucketAggs,
+		DropEmptyOnNoGroup: true,
+	}
+
+	// Reshape the aggregate output into the histogram-row contract
+	// HistogramQuantile consumes (Attributes + BucketCounts + ExplicitBounds)
+	// while preserving anchor_ts as a passthrough column so the
+	// downstream HistogramQuantile GroupBy can pick it up.
+	rebuilt := &chplan.Project{
+		Input: agg,
+		Projections: []chplan.Projection{
+			{Expr: anchorRef, Alias: histogramAnchorCol},
+			{Expr: attrsRebuild, Alias: s.AttributesColumn},
+			{Expr: &chplan.ColumnRef{Name: s.BucketCountsColumn}, Alias: s.BucketCountsColumn},
+			{Expr: &chplan.ColumnRef{Name: s.ExplicitBoundsColumn}, Alias: s.ExplicitBoundsColumn},
+		},
+	}
+
+	// HistogramQuantile emits one row per (anchor, series). The
+	// emitter's SELECT projects each GroupBy entry (anchor_ts +
+	// Attributes) then the per-row quantile-interpolation expression as
+	// `Value`. The outer Project re-aliases anchor_ts → TimeUnix so the
+	// canonical Sample contract holds for the matrix pivot.
+	hq := &chplan.HistogramQuantile{
+		Input:                rebuilt,
+		Phi:                  phi,
+		BucketCountsColumn:   s.BucketCountsColumn,
+		ExplicitBoundsColumn: s.ExplicitBoundsColumn,
+		GroupBy: []chplan.Expr{
+			anchorRef,
+			&chplan.ColumnRef{Name: s.AttributesColumn},
+		},
+		GroupByAliases:   []string{histogramAnchorCol, s.AttributesColumn},
+		MetricNameColumn: s.MetricNameColumn,
+		AttributesColumn: s.AttributesColumn,
+		TimestampColumn:  s.TimestampColumn,
+	}
+
+	return &chplan.Project{
+		Input: hq,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.LitString{V: ""}, Alias: s.MetricNameColumn},
+			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
+			{Expr: anchorRef, Alias: s.TimestampColumn},
+			{Expr: &chplan.ColumnRef{Name: s.ValueColumn}, Alias: s.ValueColumn},
+		},
+	}
+}

--- a/internal/promql/lower_test.go
+++ b/internal/promql/lower_test.go
@@ -50,6 +50,12 @@ func TestLower(t *testing.T) {
 	// start == end == eval_ts.
 	instantEval := time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
 
+	// Deterministic range-mode anchor used by fixtures that opt into the
+	// `range_step` section. The window `[2026-01-01 00:00:00, 00:05:00]`
+	// keeps the SQL literals short and the step grid deterministic.
+	rangeStart := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	rangeEnd := rangeStart.Add(5 * time.Minute)
+
 	spec.Walk(t, fixtureDir, func(t *testing.T, c *spec.Case) {
 		query, ok := c.Section("query.promql")
 		if !ok {
@@ -65,11 +71,27 @@ func TestLower(t *testing.T) {
 		// special fixed range; every other fixture lowers with the
 		// deterministic instant-eval anchor so the LWR staleness
 		// predicate produces stable SQL literals.
+		//
+		// A `range_step:` section opts the fixture into range mode: the
+		// section value is a duration parsed by time.ParseDuration, and
+		// the lowering uses LowerAtRange with the deterministic
+		// rangeStart/rangeEnd window. This is the fixture-side mechanism
+		// for exercising query_range lowerings (histogram_quantile per-
+		// step anchor, etc.) without requiring per-test Go scaffolding.
 		var plan chplan.Node
-		if strings.Contains(query, "@ start()") || strings.Contains(query, "@ end()") {
+		switch {
+		case strings.Contains(query, "@ start()") || strings.Contains(query, "@ end()"):
 			plan, err = promql.LowerAt(context.Background(), expr, s, start, end)
-		} else {
-			plan, err = promql.LowerAt(context.Background(), expr, s, instantEval, instantEval)
+		default:
+			if rs, ok := c.Section("range_step"); ok {
+				stepDur, perr := time.ParseDuration(strings.TrimSpace(rs))
+				if perr != nil {
+					t.Fatalf("fixture %s: parse range_step %q: %v", c.Name, rs, perr)
+				}
+				plan, err = promql.LowerAtRange(context.Background(), expr, s, rangeStart, rangeEnd, stepDur)
+			} else {
+				plan, err = promql.LowerAt(context.Background(), expr, s, instantEval, instantEval)
+			}
 		}
 		if err != nil {
 			t.Fatalf("Lower(%q): %v", query, err)

--- a/test/spec/promql/histogram_quantile_classic_range_step.txtar
+++ b/test/spec/promql/histogram_quantile_classic_range_step.txtar
@@ -1,0 +1,21 @@
+-- query.promql --
+histogram_quantile(0.95, sum by(le)(rate(http_server_request_duration[5m])))
+-- range_step --
+30s
+-- args --
+[0] string = ""
+[1] string = "Map(String,String)"
+[2] string = "http_server_request_duration"
+[3] int64 = 300000000000
+-- chplan --
+Project ["" AS MetricName, Attributes AS Attributes, anchor_ts AS TimeUnix, Value AS Value]
+  HistogramQuantile phi=0.95 groupBy=[anchor_ts AS anchor_ts, Attributes AS Attributes]
+    Project [anchor_ts AS anchor_ts, CAST(map(), "Map(String,String)") AS Attributes, BucketCounts AS BucketCounts, ExplicitBounds AS ExplicitBounds]
+      Aggregate groupBy=[anchor_ts AS anchor_ts] funcs=[sumForEach(BucketCounts) AS BucketCounts, any(ExplicitBounds) AS ExplicitBounds]
+        Filter predicate=((TimeUnix <= anchor_ts) AND (TimeUnix > (anchor_ts - toIntervalNanosecond(300000000000))))
+          CrossJoin
+            StepGrid start=2026-01-01T00:00:00.000000000Z end=2026-01-01T00:05:00.000000000Z step=30s
+            Filter predicate=(MetricName = "http_server_request_duration")
+              Scan(otel_metrics_histogram)
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `anchor_ts` AS `anchor_ts`, `Attributes` AS `Attributes`, if(length(`BucketCounts`) = 0, nan, if(arraySum(arrayMap(x -> toFloat64(x), `BucketCounts`)) = 0, nan, if(0.95 <= 0, 0.0, if(0.95 >= 1, `ExplicitBounds`[length(`ExplicitBounds`)], if(arrayFirstIndex(c -> c >= (0.95 * arraySum(arrayMap(x -> toFloat64(x), `BucketCounts`))), arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`))) = length(arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`))), `ExplicitBounds`[length(`ExplicitBounds`)], (if(arrayFirstIndex(c -> c >= (0.95 * arraySum(arrayMap(x -> toFloat64(x), `BucketCounts`))), arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`))) = 1, 0.0, `ExplicitBounds`[arrayFirstIndex(c -> c >= (0.95 * arraySum(arrayMap(x -> toFloat64(x), `BucketCounts`))), arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`))) - 1]) + (`ExplicitBounds`[arrayFirstIndex(c -> c >= (0.95 * arraySum(arrayMap(x -> toFloat64(x), `BucketCounts`))), arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`)))] - if(arrayFirstIndex(c -> c >= (0.95 * arraySum(arrayMap(x -> toFloat64(x), `BucketCounts`))), arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`))) = 1, 0.0, `ExplicitBounds`[arrayFirstIndex(c -> c >= (0.95 * arraySum(arrayMap(x -> toFloat64(x), `BucketCounts`))), arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`))) - 1])) * ((0.95 * arraySum(arrayMap(x -> toFloat64(x), `BucketCounts`))) - if(arrayFirstIndex(c -> c >= (0.95 * arraySum(arrayMap(x -> toFloat64(x), `BucketCounts`))), arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`))) = 1, 0.0, arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`))[arrayFirstIndex(c -> c >= (0.95 * arraySum(arrayMap(x -> toFloat64(x), `BucketCounts`))), arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`))) - 1])) / (arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`))[arrayFirstIndex(c -> c >= (0.95 * arraySum(arrayMap(x -> toFloat64(x), `BucketCounts`))), arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`)))] - if(arrayFirstIndex(c -> c >= (0.95 * arraySum(arrayMap(x -> toFloat64(x), `BucketCounts`))), arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`))) = 1, 0.0, arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`))[arrayFirstIndex(c -> c >= (0.95 * arraySum(arrayMap(x -> toFloat64(x), `BucketCounts`))), arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`))) - 1])))))))) AS `Value` FROM (SELECT `anchor_ts` AS `anchor_ts`, CAST(map(), ?) AS `Attributes`, `BucketCounts` AS `BucketCounts`, `ExplicitBounds` AS `ExplicitBounds` FROM (SELECT `anchor_ts` AS `anchor_ts`, sumForEach(`BucketCounts`) AS `BucketCounts`, any(`ExplicitBounds`) AS `ExplicitBounds` FROM (SELECT * FROM (SELECT * FROM (SELECT arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:00:00.000000000', 9) + toIntervalNanosecond(i * 30000000000), range(0, 11))) AS `anchor_ts`) AS L CROSS JOIN (SELECT * FROM `otel_metrics_histogram` WHERE (`MetricName` = ?)) AS R) WHERE ((`TimeUnix` <= `anchor_ts`) AND (`TimeUnix` > (`anchor_ts` - toIntervalNanosecond(?))))) GROUP BY `anchor_ts`)))

--- a/test/spec/promql/histogram_quantile_classic_range_step_bare.txtar
+++ b/test/spec/promql/histogram_quantile_classic_range_step_bare.txtar
@@ -1,0 +1,22 @@
+-- query.promql --
+histogram_quantile(0.95, http_server_request_duration{service="api"})
+-- range_step --
+30s
+-- args --
+[0] string = ""
+[1] string = "http_server_request_duration"
+[2] string = "service"
+[3] string = "api"
+[4] int64 = 300000000000
+-- chplan --
+Project ["" AS MetricName, Attributes AS Attributes, anchor_ts AS TimeUnix, Value AS Value]
+  HistogramQuantile phi=0.95 groupBy=[anchor_ts AS anchor_ts, Attributes AS Attributes]
+    Project [anchor_ts AS anchor_ts, Attributes AS Attributes, BucketCounts AS BucketCounts, ExplicitBounds AS ExplicitBounds]
+      Aggregate groupBy=[anchor_ts AS anchor_ts, Attributes AS Attributes] funcs=[argMax(BucketCounts, TimeUnix) AS BucketCounts, argMax(ExplicitBounds, TimeUnix) AS ExplicitBounds]
+        Filter predicate=((TimeUnix <= anchor_ts) AND (TimeUnix > (anchor_ts - toIntervalNanosecond(300000000000))))
+          CrossJoin
+            StepGrid start=2026-01-01T00:00:00.000000000Z end=2026-01-01T00:05:00.000000000Z step=30s
+            Filter predicate=((Attributes["service"] = "api") AND (MetricName = "http_server_request_duration"))
+              Scan(otel_metrics_histogram)
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `anchor_ts` AS `anchor_ts`, `Attributes` AS `Attributes`, if(length(`BucketCounts`) = 0, nan, if(arraySum(arrayMap(x -> toFloat64(x), `BucketCounts`)) = 0, nan, if(0.95 <= 0, 0.0, if(0.95 >= 1, `ExplicitBounds`[length(`ExplicitBounds`)], if(arrayFirstIndex(c -> c >= (0.95 * arraySum(arrayMap(x -> toFloat64(x), `BucketCounts`))), arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`))) = length(arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`))), `ExplicitBounds`[length(`ExplicitBounds`)], (if(arrayFirstIndex(c -> c >= (0.95 * arraySum(arrayMap(x -> toFloat64(x), `BucketCounts`))), arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`))) = 1, 0.0, `ExplicitBounds`[arrayFirstIndex(c -> c >= (0.95 * arraySum(arrayMap(x -> toFloat64(x), `BucketCounts`))), arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`))) - 1]) + (`ExplicitBounds`[arrayFirstIndex(c -> c >= (0.95 * arraySum(arrayMap(x -> toFloat64(x), `BucketCounts`))), arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`)))] - if(arrayFirstIndex(c -> c >= (0.95 * arraySum(arrayMap(x -> toFloat64(x), `BucketCounts`))), arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`))) = 1, 0.0, `ExplicitBounds`[arrayFirstIndex(c -> c >= (0.95 * arraySum(arrayMap(x -> toFloat64(x), `BucketCounts`))), arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`))) - 1])) * ((0.95 * arraySum(arrayMap(x -> toFloat64(x), `BucketCounts`))) - if(arrayFirstIndex(c -> c >= (0.95 * arraySum(arrayMap(x -> toFloat64(x), `BucketCounts`))), arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`))) = 1, 0.0, arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`))[arrayFirstIndex(c -> c >= (0.95 * arraySum(arrayMap(x -> toFloat64(x), `BucketCounts`))), arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`))) - 1])) / (arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`))[arrayFirstIndex(c -> c >= (0.95 * arraySum(arrayMap(x -> toFloat64(x), `BucketCounts`))), arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`)))] - if(arrayFirstIndex(c -> c >= (0.95 * arraySum(arrayMap(x -> toFloat64(x), `BucketCounts`))), arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`))) = 1, 0.0, arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`))[arrayFirstIndex(c -> c >= (0.95 * arraySum(arrayMap(x -> toFloat64(x), `BucketCounts`))), arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`))) - 1])))))))) AS `Value` FROM (SELECT `anchor_ts` AS `anchor_ts`, `Attributes` AS `Attributes`, `BucketCounts` AS `BucketCounts`, `ExplicitBounds` AS `ExplicitBounds` FROM (SELECT `anchor_ts` AS `anchor_ts`, `Attributes` AS `Attributes`, argMax(`BucketCounts`, `TimeUnix`) AS `BucketCounts`, argMax(`ExplicitBounds`, `TimeUnix`) AS `ExplicitBounds` FROM (SELECT * FROM (SELECT * FROM (SELECT arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:00:00.000000000', 9) + toIntervalNanosecond(i * 30000000000), range(0, 11))) AS `anchor_ts`) AS L CROSS JOIN (SELECT * FROM `otel_metrics_histogram` PREWHERE (`MetricName` = ?) WHERE (`Attributes`[?] = ?)) AS R) WHERE ((`TimeUnix` <= `anchor_ts`) AND (`TimeUnix` > (`anchor_ts` - toIntervalNanosecond(?))))) GROUP BY `anchor_ts`, `Attributes`)))


### PR DESCRIPTION
## Summary

Pool-AK flagged the `now64(9)` hardcode in classic-histogram
`histogram_quantile` lowering as a follow-up to the per-step LWR rework
(#347): every step in `/api/v1/query_range` emitted the same `now64(9)`
TimeUnix, collapsing N anchors onto one matrix point.

Route range-mode `histogram_quantile` through a per-step plan: cross-
join the histogram-table scan with a `chplan.StepGrid`, filter to the
per-anchor lookback window, aggregate `BucketCounts` / `ExplicitBounds`
per (anchor_ts, series), evaluate `HistogramQuantile` per row, and
re-alias `anchor_ts → TimeUnix` in the outer Project so the matrix
pivot lands one quantile sample per step. Mirrors the structural
template established for `quantile_over_time` / `predict_linear` /
`holt_winters` (#348) and `deriv` / `irate` (#349).

- Bare-selector path: `argMax(BucketCounts, TimeUnix)` (LWR-canonical
  "latest histogram sample per anchor").
- Aggregated idiom `histogram_quantile(phi, sum by(le)(rate(<bucket>[r])))`:
  `sumForEach(BucketCounts)` + `any(ExplicitBounds)` over the rate
  window.
- Instant mode (`ctx.step == 0`) keeps the existing SQL byte-stable;
  modifier-bearing (`@`/offset) selectors fall back to the instant path
  until matrix-anchor handling for those modifiers lands.

## Before / after chplan

Input: `histogram_quantile(0.95, sum by(le)(rate(http_server_request_duration[5m])))` over a 5-minute window at 30-second step.

**Before (range mode rendered the same shape as instant mode — anchor_ts absent):**

```
Project ["" AS MetricName, Attributes AS Attributes, now64(9) AS TimeUnix, Value AS Value]
  HistogramQuantile phi=0.95 groupBy=[Attributes AS Attributes]
    Project [CAST(map(), "Map(String,String)") AS Attributes, BucketCounts AS BucketCounts, ExplicitBounds AS ExplicitBounds]
      Aggregate groupBy=[] funcs=[sumForEach(BucketCounts) AS BucketCounts, any(ExplicitBounds) AS ExplicitBounds]
        Filter predicate=(<matchers> AND TimeUnix <= now64(9) AND TimeUnix > (now64(9) - toIntervalNanosecond(300000000000)))
          Scan(otel_metrics_histogram)
```

The inner bucket-row Filter binds to `now64(9)` — every per-step
anchor pulls from the same window, the outer Project emits the same
`TimeUnix` for every output row, and the matrix pivot's row → sample
copy keyed on TimeUnix folds N anchors onto a single sample.

**After (range mode threads anchor_ts through StepGrid + LWR + Aggregate):**

```
Project ["" AS MetricName, Attributes AS Attributes, anchor_ts AS TimeUnix, Value AS Value]
  HistogramQuantile phi=0.95 groupBy=[anchor_ts AS anchor_ts, Attributes AS Attributes]
    Project [anchor_ts AS anchor_ts, CAST(map(), "Map(String,String)") AS Attributes, BucketCounts AS BucketCounts, ExplicitBounds AS ExplicitBounds]
      Aggregate groupBy=[anchor_ts AS anchor_ts] funcs=[sumForEach(BucketCounts) AS BucketCounts, any(ExplicitBounds) AS ExplicitBounds]
        Filter predicate=((TimeUnix <= anchor_ts) AND (TimeUnix > (anchor_ts - toIntervalNanosecond(300000000000))))
          CrossJoin
            StepGrid start=2026-01-01T00:00:00.000000000Z end=2026-01-01T00:05:00.000000000Z step=30s
            Filter predicate=(MetricName = "http_server_request_duration")
              Scan(otel_metrics_histogram)
```

The bucket-row Filter now binds to `anchor_ts` (one per step) — every
per-step anchor sees its own LWR window, the Aggregate groups per
(anchor_ts), `HistogramQuantile` emits one row per (anchor_ts,
series), and the outer Project surfaces `anchor_ts AS TimeUnix` so
the matrix pivot lands one quantile sample per step.

## Tests

- `test/spec/promql/histogram_quantile_classic_range_step.txtar` —
  TXTAR fixture for the aggregated idiom (`sum by(le)(rate(...))`)
  over a 5-minute window at 30-second step.
- `test/spec/promql/histogram_quantile_classic_range_step_bare.txtar` —
  TXTAR fixture for the bare-selector path with the same window/step.
- `TestQueryRange_RangeMode_HistogramQuantileClassic_ChDB` in
  `internal/api/prom/handler_chdb_range_mode_test.go` — chDB
  regression: seeds classic-histogram rows whose BucketCounts grow per
  step, asserts ≥2 per-step samples, strictly-increasing per-step
  TimeUnix, and per-step quantile values matching the spec-expected
  highest explicit bound (phi=0.95 lands in the +Inf overflow bucket).

A new `range_step:` fixture section opts a TXTAR fixture into range
mode (drives `TestLower` through `LowerAtRange` with a deterministic
[2026-01-01 00:00:00, 00:05:00] window). Other fixtures keep the
existing instant-eval anchor; their SQL stays byte-stable.

## Test plan

- [x] `go build ./...`
- [x] `go test -count=1 ./internal/promql/ ./internal/chsql/ ./internal/chplan/ ./internal/optimizer/` (1273 pass)
- [x] `go test -tags chdb -count=1 ./internal/promql/ ./internal/api/prom/ ./test/spec/promql/` (948 pass)
- [x] `go test -tags chdb -count=1 -run "HistogramQuantile" ./internal/api/prom/ ./test/spec/promql/` (new tests pass)
- [x] Rebased on `origin/main` at 5b65352

## Scope notes

- Native exp-histogram path (`lowerHistogramQuantileNative`) is **not**
  changed in this PR — `histogram_quantile` over aggregated native
  histograms is already explicitly rejected, and the bare-selector
  native path follows the same `now64(9)` template; it can be patched
  with the same scaffold in a follow-up.
- Modifier-bearing selectors (`@<ts>` / `offset`) in range mode still
  fall back to the instant path. Matrix-anchor handling for those
  shapes is a follow-up; in practice Grafana never threads modifiers
  through `histogram_quantile` on `query_range`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)