### PR TITLE
test(spec/traceql): wire chplan snapshots into 107-fixture corpus

### DIFF
--- a/internal/traceql/lower_test.go
+++ b/internal/traceql/lower_test.go
@@ -46,8 +46,9 @@ func TestLower(t *testing.T) {
 		}
 
 		spec.Match(t, c, map[string]string{
-			"sql":  sqlStr,
-			"args": formatArgs(args),
+			"sql":    sqlStr,
+			"args":   formatArgs(args),
+			"chplan": spec.PrintChplan(plan),
 		})
 	})
 }

--- a/test/spec/traceql/and_or_combined.txtar
+++ b/test/spec/traceql/and_or_combined.txtar
@@ -23,3 +23,6 @@ INSERT INTO otel_traces (Duration) VALUES
   [50000000],
   [150000000]
 ]
+-- chplan --
+Filter predicate=((ResourceAttributes["service.name"] = "frontend") AND ((Duration > 100000000) OR (toFloat64(SpanAttributes["http.status_code"]) >= 500)))
+  Scan(otel_traces)

--- a/test/spec/traceql/and_two_attrs.txtar
+++ b/test/spec/traceql/and_two_attrs.txtar
@@ -20,3 +20,6 @@ INSERT INTO otel_traces (Duration) VALUES
   [120000000],
   [150000000]
 ]
+-- chplan --
+Filter predicate=((ResourceAttributes["service.name"] = "frontend") AND (Duration > 100000000))
+  Scan(otel_traces)

--- a/test/spec/traceql/attribute_arithmetic_add.txtar
+++ b/test/spec/traceql/attribute_arithmetic_add.txtar
@@ -16,3 +16,6 @@ INSERT INTO otel_traces (_idx) VALUES (0), (1);
 [
   [0]
 ]
+-- chplan --
+Filter predicate=((toFloat64(SpanAttributes["a"]) + toFloat64(SpanAttributes["b"])) > 10)
+  Scan(otel_traces)

--- a/test/spec/traceql/attribute_arithmetic_mul.txtar
+++ b/test/spec/traceql/attribute_arithmetic_mul.txtar
@@ -16,3 +16,6 @@ INSERT INTO otel_traces (_idx) VALUES (0), (1);
 [
   [0]
 ]
+-- chplan --
+Filter predicate=((toFloat64(SpanAttributes["a"]) * 2) > 10)
+  Scan(otel_traces)

--- a/test/spec/traceql/avg_duration.txtar
+++ b/test/spec/traceql/avg_duration.txtar
@@ -20,3 +20,8 @@ INSERT INTO otel_traces VALUES
 [
   [80000000.0]
 ]
+-- chplan --
+Filter predicate=(Value > 50000000)
+  Aggregate groupBy=[] funcs=[avg(Duration) AS Value]
+    Filter predicate=(ResourceAttributes["service.name"] = "frontend")
+      Scan(otel_traces)

--- a/test/spec/traceql/bool_attr.txtar
+++ b/test/spec/traceql/bool_attr.txtar
@@ -5,3 +5,6 @@ SELECT * FROM `otel_traces` WHERE (`SpanAttributes`[?] = ?)
 -- args --
 [0] string = "cache.hit"
 [1] bool = true
+-- chplan --
+Filter predicate=(SpanAttributes["cache.hit"] = true)
+  Scan(otel_traces)

--- a/test/spec/traceql/by_intrinsic_and_attr.txtar
+++ b/test/spec/traceql/by_intrinsic_and_attr.txtar
@@ -21,3 +21,7 @@ INSERT INTO otel_traces VALUES
 [
   ["Client", "frontend", 4]
 ]
+-- chplan --
+MetricsAggregate op=count_over_time groupBy=[SpanKind AS kind, ResourceAttributes["service.name"] AS service.name] valueAlias=Value
+  Filter predicate=true
+    Scan(otel_traces)

--- a/test/spec/traceql/by_mixed_scopes.txtar
+++ b/test/spec/traceql/by_mixed_scopes.txtar
@@ -22,3 +22,7 @@ INSERT INTO otel_traces VALUES
 [
   ["frontend", "GET", 100000000]
 ]
+-- chplan --
+MetricsAggregate op=max_over_time attr=Duration groupBy=[ResourceAttributes["service.name"] AS service.name, SpanAttributes["http.method"] AS http.method] valueAlias=Value
+  Filter predicate=true
+    Scan(otel_traces)

--- a/test/spec/traceql/by_multi_attribute.txtar
+++ b/test/spec/traceql/by_multi_attribute.txtar
@@ -22,3 +22,7 @@ INSERT INTO otel_traces VALUES
 [
   ["frontend", "200", 3]
 ]
+-- chplan --
+MetricsAggregate op=count_over_time groupBy=[ResourceAttributes["service.name"] AS service.name, SpanAttributes["http.status_code"] AS http.status_code] valueAlias=Value
+  Filter predicate=true
+    Scan(otel_traces)

--- a/test/spec/traceql/by_three_attributes.txtar
+++ b/test/spec/traceql/by_three_attributes.txtar
@@ -26,3 +26,7 @@ INSERT INTO otel_traces VALUES
 [
   ["frontend", "Client", "GET", 5]
 ]
+-- chplan --
+MetricsAggregate op=rate groupBy=[ResourceAttributes["service.name"] AS service.name, SpanAttributes["kind"] AS kind, SpanAttributes["http.method"] AS http.method] valueAlias=Value
+  Filter predicate=true
+    Scan(otel_traces)

--- a/test/spec/traceql/child_of.txtar
+++ b/test/spec/traceql/child_of.txtar
@@ -7,3 +7,9 @@ SELECT R.* FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)
 [1] string = "api"
 [2] string = "service.name"
 [3] string = "frontend"
+-- chplan --
+StructuralJoin op=<
+  Filter predicate=(ResourceAttributes["service.name"] = "api")
+    Scan(otel_traces)
+  Filter predicate=(ResourceAttributes["service.name"] = "frontend")
+    Scan(otel_traces)

--- a/test/spec/traceql/coalesce_simple.txtar
+++ b/test/spec/traceql/coalesce_simple.txtar
@@ -17,3 +17,7 @@ INSERT INTO otel_traces VALUES
 [
   ["a0000000000000000000000000000001", "0000000000000001", "2026-01-01T00:00:00Z"]
 ]
+-- chplan --
+Aggregate groupBy=[TraceId AS TraceId, SpanId AS SpanId] funcs=[min(Timestamp) AS Timestamp]
+  Filter predicate=true
+    Scan(otel_traces)

--- a/test/spec/traceql/count.txtar
+++ b/test/spec/traceql/count.txtar
@@ -20,3 +20,8 @@ INSERT INTO otel_traces VALUES
 [
   [3]
 ]
+-- chplan --
+Filter predicate=(Value > 0)
+  Aggregate groupBy=[] funcs=[count(1) AS Value]
+    Filter predicate=(ResourceAttributes["service.name"] = "frontend")
+      Scan(otel_traces)

--- a/test/spec/traceql/count_eq_zero.txtar
+++ b/test/spec/traceql/count_eq_zero.txtar
@@ -19,3 +19,8 @@ INSERT INTO otel_traces VALUES
 [
   [0]
 ]
+-- chplan --
+Filter predicate=(Value = 0)
+  Aggregate groupBy=[] funcs=[count(1) AS Value]
+    Filter predicate=(ResourceAttributes["service.name"] = "frontend")
+      Scan(otel_traces)

--- a/test/spec/traceql/count_ge_threshold.txtar
+++ b/test/spec/traceql/count_ge_threshold.txtar
@@ -22,3 +22,8 @@ INSERT INTO otel_traces VALUES
 [
   [5]
 ]
+-- chplan --
+Filter predicate=(Value >= 5)
+  Aggregate groupBy=[] funcs=[count(1) AS Value]
+    Filter predicate=(ResourceAttributes["service.name"] = "frontend")
+      Scan(otel_traces)

--- a/test/spec/traceql/count_lt_threshold.txtar
+++ b/test/spec/traceql/count_lt_threshold.txtar
@@ -20,3 +20,8 @@ INSERT INTO otel_traces VALUES
 [
   [3]
 ]
+-- chplan --
+Filter predicate=(Value < 10)
+  Aggregate groupBy=[] funcs=[count(1) AS Value]
+    Filter predicate=(ResourceAttributes["service.name"] = "frontend")
+      Scan(otel_traces)

--- a/test/spec/traceql/duration_ge.txtar
+++ b/test/spec/traceql/duration_ge.txtar
@@ -17,3 +17,6 @@ INSERT INTO otel_traces VALUES
   [1000000000],
   [2000000000]
 ]
+-- chplan --
+Filter predicate=(Duration >= 1000000000)
+  Scan(otel_traces)

--- a/test/spec/traceql/duration_gt.txtar
+++ b/test/spec/traceql/duration_gt.txtar
@@ -18,3 +18,6 @@ INSERT INTO otel_traces VALUES
   [150000000],
   [250000000]
 ]
+-- chplan --
+Filter predicate=(Duration > 100000000)
+  Scan(otel_traces)

--- a/test/spec/traceql/duration_lt.txtar
+++ b/test/spec/traceql/duration_lt.txtar
@@ -16,3 +16,6 @@ INSERT INTO otel_traces VALUES
 [
   [10000000]
 ]
+-- chplan --
+Filter predicate=(Duration < 50000000)
+  Scan(otel_traces)

--- a/test/spec/traceql/edge_attr_default_ge.txtar
+++ b/test/spec/traceql/edge_attr_default_ge.txtar
@@ -5,3 +5,6 @@
 [1] int64 = 100
 -- sql --
 SELECT * FROM `otel_traces` WHERE (toFloat64(`SpanAttributes`[?]) >= ?)
+-- chplan --
+Filter predicate=(toFloat64(SpanAttributes["timeout"]) >= 100)
+  Scan(otel_traces)

--- a/test/spec/traceql/edge_attr_default_regex.txtar
+++ b/test/spec/traceql/edge_attr_default_regex.txtar
@@ -5,3 +5,6 @@
 [1] string = "/api/.*"
 -- sql --
 SELECT * FROM `otel_traces` WHERE match(`SpanAttributes`[?], ?)
+-- chplan --
+Filter predicate=(SpanAttributes["path"] =~ "/api/.*")
+  Scan(otel_traces)

--- a/test/spec/traceql/edge_attr_resource_le.txtar
+++ b/test/spec/traceql/edge_attr_resource_le.txtar
@@ -5,3 +5,6 @@
 [1] int64 = 5
 -- sql --
 SELECT * FROM `otel_traces` WHERE (toFloat64(`ResourceAttributes`[?]) <= ?)
+-- chplan --
+Filter predicate=(toFloat64(ResourceAttributes["replicas"]) <= 5)
+  Scan(otel_traces)

--- a/test/spec/traceql/edge_attr_resource_not_regex.txtar
+++ b/test/spec/traceql/edge_attr_resource_not_regex.txtar
@@ -5,3 +5,6 @@
 [1] string = "test.*"
 -- sql --
 SELECT * FROM `otel_traces` WHERE NOT match(`ResourceAttributes`[?], ?)
+-- chplan --
+Filter predicate=(ResourceAttributes["service.name"] !~ "test.*")
+  Scan(otel_traces)

--- a/test/spec/traceql/edge_attr_span_gt.txtar
+++ b/test/spec/traceql/edge_attr_span_gt.txtar
@@ -5,3 +5,6 @@
 [1] int64 = 1024
 -- sql --
 SELECT * FROM `otel_traces` WHERE (toFloat64(`SpanAttributes`[?]) > ?)
+-- chplan --
+Filter predicate=(toFloat64(SpanAttributes["size"]) > 1024)
+  Scan(otel_traces)

--- a/test/spec/traceql/edge_attr_span_lt.txtar
+++ b/test/spec/traceql/edge_attr_span_lt.txtar
@@ -5,3 +5,6 @@
 [1] int64 = 500
 -- sql --
 SELECT * FROM `otel_traces` WHERE (toFloat64(`SpanAttributes`[?]) < ?)
+-- chplan --
+Filter predicate=(toFloat64(SpanAttributes["http.status_code"]) < 500)
+  Scan(otel_traces)

--- a/test/spec/traceql/edge_catchall_compound_count.txtar
+++ b/test/spec/traceql/edge_catchall_compound_count.txtar
@@ -9,3 +9,8 @@
 [5] int64 = 10
 -- sql --
 SELECT * FROM (SELECT toFloat64(count(?)) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?) AND (toFloat64(`SpanAttributes`[?]) > ?))) WHERE (`Value` > ?)
+-- chplan --
+Filter predicate=(Value > 10)
+  Aggregate groupBy=[] funcs=[count(1) AS Value]
+    Filter predicate=((ResourceAttributes["service.name"] = "x") AND (toFloat64(SpanAttributes["http.status_code"]) > 200))
+      Scan(otel_traces)

--- a/test/spec/traceql/edge_catchall_pipeline_avg.txtar
+++ b/test/spec/traceql/edge_catchall_pipeline_avg.txtar
@@ -7,3 +7,8 @@
 [3] int64 = 500000000
 -- sql --
 SELECT * FROM (SELECT avg(`Duration`) AS `Value` FROM (SELECT * FROM `otel_traces` PREWHERE (`StatusCode` = ?) WHERE (`ResourceAttributes`[?] = ?))) WHERE (`Value` > ?)
+-- chplan --
+Filter predicate=(Value > 500000000)
+  Aggregate groupBy=[] funcs=[avg(Duration) AS Value]
+    Filter predicate=((ResourceAttributes["service.name"] = "x") AND (StatusCode = "Error"))
+      Scan(otel_traces)

--- a/test/spec/traceql/edge_chain_ancestor_3.txtar
+++ b/test/spec/traceql/edge_chain_ancestor_3.txtar
@@ -9,3 +9,12 @@
 [5] string = "root"
 -- sql --
 SELECT R.* FROM (WITH RECURSIVE _struct_closure AS (SELECT `TraceId`, `SpanId`, `ParentSpanId`, 0 AS _depth FROM (SELECT R.* FROM (WITH RECURSIVE _struct_closure AS (SELECT `TraceId`, `SpanId`, `ParentSpanId`, 0 AS _depth FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) AS _seed UNION ALL SELECT t.`TraceId`, t.`SpanId`, t.`ParentSpanId`, c._depth + 1 FROM `otel_traces` AS t INNER JOIN _struct_closure AS c ON t.`TraceId` = c.`TraceId` AND t.`SpanId` = c.`ParentSpanId`) SELECT DISTINCT `TraceId`, `SpanId` FROM _struct_closure WHERE _depth > 0) AS L INNER JOIN (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) AS R ON L.`TraceId` = R.`TraceId` AND L.`SpanId` = R.`SpanId`) AS _seed UNION ALL SELECT t.`TraceId`, t.`SpanId`, t.`ParentSpanId`, c._depth + 1 FROM `otel_traces` AS t INNER JOIN _struct_closure AS c ON t.`TraceId` = c.`TraceId` AND t.`SpanId` = c.`ParentSpanId`) SELECT DISTINCT `TraceId`, `SpanId` FROM _struct_closure WHERE _depth > 0) AS L INNER JOIN (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) AS R ON L.`TraceId` = R.`TraceId` AND L.`SpanId` = R.`SpanId`
+-- chplan --
+StructuralJoin op=<<
+  StructuralJoin op=<<
+    Filter predicate=(ResourceAttributes["service.name"] = "leaf")
+      Scan(otel_traces)
+    Filter predicate=(ResourceAttributes["service.name"] = "mid")
+      Scan(otel_traces)
+  Filter predicate=(ResourceAttributes["service.name"] = "root")
+    Scan(otel_traces)

--- a/test/spec/traceql/edge_chain_child_5.txtar
+++ b/test/spec/traceql/edge_chain_child_5.txtar
@@ -13,3 +13,18 @@
 [9] string = "e"
 -- sql --
 SELECT R.* FROM (SELECT R.* FROM (SELECT R.* FROM (SELECT R.* FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) AS L INNER JOIN (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) AS R ON L.`TraceId` = R.`TraceId` AND L.`SpanId` = R.`ParentSpanId`) AS L INNER JOIN (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) AS R ON L.`TraceId` = R.`TraceId` AND L.`SpanId` = R.`ParentSpanId`) AS L INNER JOIN (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) AS R ON L.`TraceId` = R.`TraceId` AND L.`SpanId` = R.`ParentSpanId`) AS L INNER JOIN (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) AS R ON L.`TraceId` = R.`TraceId` AND L.`SpanId` = R.`ParentSpanId`
+-- chplan --
+StructuralJoin op=>
+  StructuralJoin op=>
+    StructuralJoin op=>
+      StructuralJoin op=>
+        Filter predicate=(ResourceAttributes["service.name"] = "a")
+          Scan(otel_traces)
+        Filter predicate=(ResourceAttributes["service.name"] = "b")
+          Scan(otel_traces)
+      Filter predicate=(ResourceAttributes["service.name"] = "c")
+        Scan(otel_traces)
+    Filter predicate=(ResourceAttributes["service.name"] = "d")
+      Scan(otel_traces)
+  Filter predicate=(ResourceAttributes["service.name"] = "e")
+    Scan(otel_traces)

--- a/test/spec/traceql/edge_chain_descendant_3.txtar
+++ b/test/spec/traceql/edge_chain_descendant_3.txtar
@@ -9,3 +9,12 @@
 [5] string = "c"
 -- sql --
 SELECT R.* FROM (WITH RECURSIVE _struct_closure AS (SELECT `TraceId`, `SpanId`, `ParentSpanId`, 0 AS _depth FROM (SELECT R.* FROM (WITH RECURSIVE _struct_closure AS (SELECT `TraceId`, `SpanId`, `ParentSpanId`, 0 AS _depth FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) AS _seed UNION ALL SELECT t.`TraceId`, t.`SpanId`, t.`ParentSpanId`, c._depth + 1 FROM `otel_traces` AS t INNER JOIN _struct_closure AS c ON t.`TraceId` = c.`TraceId` AND t.`ParentSpanId` = c.`SpanId`) SELECT DISTINCT `TraceId`, `SpanId` FROM _struct_closure WHERE _depth > 0) AS L INNER JOIN (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) AS R ON L.`TraceId` = R.`TraceId` AND L.`SpanId` = R.`SpanId`) AS _seed UNION ALL SELECT t.`TraceId`, t.`SpanId`, t.`ParentSpanId`, c._depth + 1 FROM `otel_traces` AS t INNER JOIN _struct_closure AS c ON t.`TraceId` = c.`TraceId` AND t.`ParentSpanId` = c.`SpanId`) SELECT DISTINCT `TraceId`, `SpanId` FROM _struct_closure WHERE _depth > 0) AS L INNER JOIN (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) AS R ON L.`TraceId` = R.`TraceId` AND L.`SpanId` = R.`SpanId`
+-- chplan --
+StructuralJoin op=>>
+  StructuralJoin op=>>
+    Filter predicate=(ResourceAttributes["service.name"] = "a")
+      Scan(otel_traces)
+    Filter predicate=(ResourceAttributes["service.name"] = "b")
+      Scan(otel_traces)
+  Filter predicate=(ResourceAttributes["service.name"] = "c")
+    Scan(otel_traces)

--- a/test/spec/traceql/edge_chain_mixed_5.txtar
+++ b/test/spec/traceql/edge_chain_mixed_5.txtar
@@ -13,3 +13,18 @@
 [9] string = "e"
 -- sql --
 SELECT R.* FROM (WITH RECURSIVE _struct_closure AS (SELECT `TraceId`, `SpanId`, `ParentSpanId`, 0 AS _depth FROM (SELECT R.* FROM (SELECT R.* FROM (WITH RECURSIVE _struct_closure AS (SELECT `TraceId`, `SpanId`, `ParentSpanId`, 0 AS _depth FROM (SELECT R.* FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) AS L INNER JOIN (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) AS R ON L.`TraceId` = R.`TraceId` AND L.`SpanId` = R.`ParentSpanId`) AS _seed UNION ALL SELECT t.`TraceId`, t.`SpanId`, t.`ParentSpanId`, c._depth + 1 FROM `otel_traces` AS t INNER JOIN _struct_closure AS c ON t.`TraceId` = c.`TraceId` AND t.`ParentSpanId` = c.`SpanId`) SELECT DISTINCT `TraceId`, `SpanId` FROM _struct_closure WHERE _depth > 0) AS L INNER JOIN (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) AS R ON L.`TraceId` = R.`TraceId` AND L.`SpanId` = R.`SpanId`) AS L INNER JOIN (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) AS R ON L.`TraceId` = R.`TraceId` AND L.`SpanId` = R.`ParentSpanId`) AS _seed UNION ALL SELECT t.`TraceId`, t.`SpanId`, t.`ParentSpanId`, c._depth + 1 FROM `otel_traces` AS t INNER JOIN _struct_closure AS c ON t.`TraceId` = c.`TraceId` AND t.`ParentSpanId` = c.`SpanId`) SELECT DISTINCT `TraceId`, `SpanId` FROM _struct_closure WHERE _depth > 0) AS L INNER JOIN (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) AS R ON L.`TraceId` = R.`TraceId` AND L.`SpanId` = R.`SpanId`
+-- chplan --
+StructuralJoin op=>>
+  StructuralJoin op=>
+    StructuralJoin op=>>
+      StructuralJoin op=>
+        Filter predicate=(ResourceAttributes["service.name"] = "a")
+          Scan(otel_traces)
+        Filter predicate=(ResourceAttributes["service.name"] = "b")
+          Scan(otel_traces)
+      Filter predicate=(ResourceAttributes["service.name"] = "c")
+        Scan(otel_traces)
+    Filter predicate=(ResourceAttributes["service.name"] = "d")
+      Scan(otel_traces)
+  Filter predicate=(ResourceAttributes["service.name"] = "e")
+    Scan(otel_traces)

--- a/test/spec/traceql/edge_event_name_match.txtar
+++ b/test/spec/traceql/edge_event_name_match.txtar
@@ -5,3 +5,6 @@
 [1] string = "exception"
 -- sql --
 SELECT * FROM `otel_traces` WHERE arrayExists(x -> x[?] = ?, `Events`.`Attributes`)
+-- chplan --
+Filter predicate=nestedArrayExists(Events.Attributes["name"] = "exception")
+  Scan(otel_traces)

--- a/test/spec/traceql/edge_group_by_span_attr.txtar
+++ b/test/spec/traceql/edge_group_by_span_attr.txtar
@@ -6,3 +6,7 @@
 [2] string = "http.method"
 -- sql --
 SELECT `SpanAttributes`[?] AS `GroupKey`, any(`TraceId`) AS `TraceId`, any(`SpanId`) AS `SpanId`, min(`Timestamp`) AS `Timestamp` FROM (SELECT * FROM `otel_traces` WHERE ?) GROUP BY `SpanAttributes`[?]
+-- chplan --
+Aggregate groupBy=[SpanAttributes["http.method"] AS GroupKey] funcs=[any(TraceId) AS TraceId, any(SpanId) AS SpanId, min(Timestamp) AS Timestamp]
+  Filter predicate=true
+    Scan(otel_traces)

--- a/test/spec/traceql/edge_inner_max_attr.txtar
+++ b/test/spec/traceql/edge_inner_max_attr.txtar
@@ -7,3 +7,8 @@
 [3] int64 = 100
 -- sql --
 SELECT * FROM (SELECT max(`SpanAttributes`[?]) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?))) WHERE (`Value` > ?)
+-- chplan --
+Filter predicate=(Value > 100)
+  Aggregate groupBy=[] funcs=[max(SpanAttributes["latency_ms"]) AS Value]
+    Filter predicate=(ResourceAttributes["service.name"] = "x")
+      Scan(otel_traces)

--- a/test/spec/traceql/edge_inner_min_attr.txtar
+++ b/test/spec/traceql/edge_inner_min_attr.txtar
@@ -7,3 +7,8 @@
 [3] int64 = 3
 -- sql --
 SELECT * FROM (SELECT min(`SpanAttributes`[?]) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?))) WHERE (`Value` < ?)
+-- chplan --
+Filter predicate=(Value < 3)
+  Aggregate groupBy=[] funcs=[min(SpanAttributes["attempts"]) AS Value]
+    Filter predicate=(ResourceAttributes["service.name"] = "x")
+      Scan(otel_traces)

--- a/test/spec/traceql/edge_inner_sum_attr.txtar
+++ b/test/spec/traceql/edge_inner_sum_attr.txtar
@@ -7,3 +7,8 @@
 [3] int64 = 1000
 -- sql --
 SELECT * FROM (SELECT sum(`SpanAttributes`[?]) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?))) WHERE (`Value` > ?)
+-- chplan --
+Filter predicate=(Value > 1000)
+  Aggregate groupBy=[] funcs=[sum(SpanAttributes["size"]) AS Value]
+    Filter predicate=(ResourceAttributes["service.name"] = "x")
+      Scan(otel_traces)

--- a/test/spec/traceql/edge_intr_duration_eq.txtar
+++ b/test/spec/traceql/edge_intr_duration_eq.txtar
@@ -4,3 +4,6 @@
 [0] int64 = 1000000000
 -- sql --
 SELECT * FROM `otel_traces` WHERE (`Duration` = ?)
+-- chplan --
+Filter predicate=(Duration = 1000000000)
+  Scan(otel_traces)

--- a/test/spec/traceql/edge_intr_kind_consumer.txtar
+++ b/test/spec/traceql/edge_intr_kind_consumer.txtar
@@ -4,3 +4,6 @@
 [0] string = "Consumer"
 -- sql --
 SELECT * FROM `otel_traces` WHERE (`SpanKind` = ?)
+-- chplan --
+Filter predicate=(SpanKind = "Consumer")
+  Scan(otel_traces)

--- a/test/spec/traceql/edge_intr_name_regex.txtar
+++ b/test/spec/traceql/edge_intr_name_regex.txtar
@@ -4,3 +4,6 @@
 [0] string = "GET.*"
 -- sql --
 SELECT * FROM `otel_traces` WHERE match(`SpanName`, ?)
+-- chplan --
+Filter predicate=(SpanName =~ "GET.*")
+  Scan(otel_traces)

--- a/test/spec/traceql/edge_intr_parent_with_attrs.txtar
+++ b/test/spec/traceql/edge_intr_parent_with_attrs.txtar
@@ -5,3 +5,6 @@
 [1] string = "api"
 -- sql --
 SELECT * FROM `otel_traces` PREWHERE `ParentSpanId` WHERE (`ResourceAttributes`[?] = ?)
+-- chplan --
+Filter predicate=(ParentSpanId AND (ResourceAttributes["service.name"] = "api"))
+  Scan(otel_traces)

--- a/test/spec/traceql/edge_intr_span_id_eq.txtar
+++ b/test/spec/traceql/edge_intr_span_id_eq.txtar
@@ -4,3 +4,6 @@
 [0] string = "deadbeef"
 -- sql --
 SELECT * FROM `otel_traces` WHERE (`SpanId` = ?)
+-- chplan --
+Filter predicate=(SpanId = "deadbeef")
+  Scan(otel_traces)

--- a/test/spec/traceql/edge_intr_status_message_regex.txtar
+++ b/test/spec/traceql/edge_intr_status_message_regex.txtar
@@ -4,3 +4,6 @@
 [0] string = "timeout.*"
 -- sql --
 SELECT * FROM `otel_traces` WHERE match(`StatusMessage`, ?)
+-- chplan --
+Filter predicate=(StatusMessage =~ "timeout.*")
+  Scan(otel_traces)

--- a/test/spec/traceql/edge_intr_trace_id_eq.txtar
+++ b/test/spec/traceql/edge_intr_trace_id_eq.txtar
@@ -4,3 +4,6 @@
 [0] string = "abc123"
 -- sql --
 SELECT * FROM `otel_traces` WHERE (`TraceId` = ?)
+-- chplan --
+Filter predicate=(TraceId = "abc123")
+  Scan(otel_traces)

--- a/test/spec/traceql/edge_kind_producer.txtar
+++ b/test/spec/traceql/edge_kind_producer.txtar
@@ -4,3 +4,6 @@
 [0] string = "Producer"
 -- sql --
 SELECT * FROM `otel_traces` WHERE (`SpanKind` = ?)
+-- chplan --
+Filter predicate=(SpanKind = "Producer")
+  Scan(otel_traces)

--- a/test/spec/traceql/edge_link_combined_attr.txtar
+++ b/test/spec/traceql/edge_link_combined_attr.txtar
@@ -7,3 +7,6 @@
 [3] string = "staging"
 -- sql --
 SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?) AND arrayExists(x -> x[?] = ?, `Links`.`Attributes`)
+-- chplan --
+Filter predicate=((ResourceAttributes["service.name"] = "x") AND nestedArrayExists(Links.Attributes["environment"] = "staging"))
+  Scan(otel_traces)

--- a/test/spec/traceql/edge_pipeline_coalesce_filter.txtar
+++ b/test/spec/traceql/edge_pipeline_coalesce_filter.txtar
@@ -5,3 +5,7 @@
 [1] string = "x"
 -- sql --
 SELECT `TraceId` AS `TraceId`, `SpanId` AS `SpanId`, min(`Timestamp`) AS `Timestamp` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) GROUP BY `TraceId`, `SpanId`
+-- chplan --
+Aggregate groupBy=[TraceId AS TraceId, SpanId AS SpanId] funcs=[min(Timestamp) AS Timestamp]
+  Filter predicate=(ResourceAttributes["service.name"] = "x")
+    Scan(otel_traces)

--- a/test/spec/traceql/edge_set_intersect_3.txtar
+++ b/test/spec/traceql/edge_set_intersect_3.txtar
@@ -7,3 +7,12 @@
 [3] string = "Error"
 -- sql --
 SELECT L.* FROM (SELECT L.* FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) AS `L` INNER JOIN (SELECT * FROM `otel_traces` WHERE (`Duration` > ?)) AS `R` ON `L`.`TraceId` = `R`.`TraceId` AND `L`.`SpanId` = `R`.`SpanId`) AS `L` INNER JOIN (SELECT * FROM `otel_traces` WHERE (`StatusCode` = ?)) AS `R` ON `L`.`TraceId` = `R`.`TraceId` AND `L`.`SpanId` = `R`.`SpanId`
+-- chplan --
+SetOperation op=&&
+  SetOperation op=&&
+    Filter predicate=(ResourceAttributes["service.name"] = "a")
+      Scan(otel_traces)
+    Filter predicate=(Duration > 1000000000)
+      Scan(otel_traces)
+  Filter predicate=(StatusCode = "Error")
+    Scan(otel_traces)

--- a/test/spec/traceql/edge_set_union_3.txtar
+++ b/test/spec/traceql/edge_set_union_3.txtar
@@ -9,3 +9,12 @@
 [5] string = "c"
 -- sql --
 ((SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) UNION DISTINCT (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?))) UNION DISTINCT (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?))
+-- chplan --
+SetOperation op=||
+  SetOperation op=||
+    Filter predicate=(ResourceAttributes["service.name"] = "a")
+      Scan(otel_traces)
+    Filter predicate=(ResourceAttributes["service.name"] = "b")
+      Scan(otel_traces)
+  Filter predicate=(ResourceAttributes["service.name"] = "c")
+    Scan(otel_traces)

--- a/test/spec/traceql/edge_sibling_with_attrs.txtar
+++ b/test/spec/traceql/edge_sibling_with_attrs.txtar
@@ -8,3 +8,9 @@
 [4] string = "y"
 -- sql --
 SELECT R.* FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) AS L INNER JOIN (SELECT * FROM `otel_traces` PREWHERE (`Duration` > ?) WHERE (`ResourceAttributes`[?] = ?)) AS R ON L.`TraceId` = R.`TraceId` AND L.`ParentSpanId` = R.`ParentSpanId` AND L.`SpanId` != R.`SpanId`
+-- chplan --
+StructuralJoin op=~
+  Filter predicate=(ResourceAttributes["service.name"] = "x")
+    Scan(otel_traces)
+  Filter predicate=((ResourceAttributes["service.name"] = "y") AND (Duration > 1000000000))
+    Scan(otel_traces)

--- a/test/spec/traceql/edge_status_eq_ok.txtar
+++ b/test/spec/traceql/edge_status_eq_ok.txtar
@@ -4,3 +4,6 @@
 [0] string = "Ok"
 -- sql --
 SELECT * FROM `otel_traces` WHERE (`StatusCode` = ?)
+-- chplan --
+Filter predicate=(StatusCode = "Ok")
+  Scan(otel_traces)

--- a/test/spec/traceql/event_attribute.txtar
+++ b/test/spec/traceql/event_attribute.txtar
@@ -15,3 +15,6 @@ INSERT INTO otel_traces (_idx) VALUES (0), (1);
 [
   [0]
 ]
+-- chplan --
+Filter predicate=nestedArrayExists(Events.Attributes["exception.type"] = "ConnectionError")
+  Scan(otel_traces)

--- a/test/spec/traceql/event_name.txtar
+++ b/test/spec/traceql/event_name.txtar
@@ -15,3 +15,6 @@ INSERT INTO otel_traces (_idx) VALUES (0), (1);
 [
   [0]
 ]
+-- chplan --
+Filter predicate=nestedArrayExists(Events.Attributes["name"] = "exception")
+  Scan(otel_traces)

--- a/test/spec/traceql/float_attr.txtar
+++ b/test/spec/traceql/float_attr.txtar
@@ -15,3 +15,6 @@ INSERT INTO otel_traces (_idx) VALUES (0), (1);
 [
   [0]
 ]
+-- chplan --
+Filter predicate=(toFloat64(SpanAttributes["cpu.usage"]) > 0.5)
+  Scan(otel_traces)

--- a/test/spec/traceql/group_by_attr.txtar
+++ b/test/spec/traceql/group_by_attr.txtar
@@ -19,3 +19,7 @@ INSERT INTO otel_traces VALUES
 [
   ["frontend", "a0000000000000000000000000000001", "0000000000000001", "2026-01-01T00:00:00Z"]
 ]
+-- chplan --
+Aggregate groupBy=[ResourceAttributes["service.name"] AS GroupKey] funcs=[any(TraceId) AS TraceId, any(SpanId) AS SpanId, min(Timestamp) AS Timestamp]
+  Filter predicate=true
+    Scan(otel_traces)

--- a/test/spec/traceql/http_status_int.txtar
+++ b/test/spec/traceql/http_status_int.txtar
@@ -15,3 +15,6 @@ INSERT INTO otel_traces (_idx) VALUES (0), (1), (2);
 [
   [0]
 ]
+-- chplan --
+Filter predicate=(toFloat64(SpanAttributes["http.status_code"]) >= 500)
+  Scan(otel_traces)

--- a/test/spec/traceql/kind_eq_client.txtar
+++ b/test/spec/traceql/kind_eq_client.txtar
@@ -16,3 +16,6 @@ INSERT INTO otel_traces VALUES
 [
   ["Client"]
 ]
+-- chplan --
+Filter predicate=(SpanKind = "Client")
+  Scan(otel_traces)

--- a/test/spec/traceql/kind_eq_server.txtar
+++ b/test/spec/traceql/kind_eq_server.txtar
@@ -16,3 +16,6 @@ INSERT INTO otel_traces VALUES
 [
   ["Server"]
 ]
+-- chplan --
+Filter predicate=(SpanKind = "Server")
+  Scan(otel_traces)

--- a/test/spec/traceql/kind_intrinsic.txtar
+++ b/test/spec/traceql/kind_intrinsic.txtar
@@ -16,3 +16,6 @@ INSERT INTO otel_traces VALUES
 [
   ["client"]
 ]
+-- chplan --
+Filter predicate=(SpanKind = "client")
+  Scan(otel_traces)

--- a/test/spec/traceql/link_attribute.txtar
+++ b/test/spec/traceql/link_attribute.txtar
@@ -15,3 +15,6 @@ INSERT INTO otel_traces (_idx) VALUES (0), (1);
 [
   [0]
 ]
+-- chplan --
+Filter predicate=nestedArrayExists(Links.Attributes["environment"] = "prod")
+  Scan(otel_traces)

--- a/test/spec/traceql/link_span_id.txtar
+++ b/test/spec/traceql/link_span_id.txtar
@@ -15,3 +15,6 @@ INSERT INTO otel_traces (_idx) VALUES (0), (1);
 [
   [0]
 ]
+-- chplan --
+Filter predicate=nestedArrayExists(Links.Attributes["span_id"] = "abc")
+  Scan(otel_traces)

--- a/test/spec/traceql/max_duration.txtar
+++ b/test/spec/traceql/max_duration.txtar
@@ -20,3 +20,8 @@ INSERT INTO otel_traces VALUES
 [
   [600000000]
 ]
+-- chplan --
+Filter predicate=(Value > 500000000)
+  Aggregate groupBy=[] funcs=[max(Duration) AS Value]
+    Filter predicate=(ResourceAttributes["service.name"] = "frontend")
+      Scan(otel_traces)

--- a/test/spec/traceql/metrics_count_over_time.txtar
+++ b/test/spec/traceql/metrics_count_over_time.txtar
@@ -18,3 +18,7 @@ INSERT INTO otel_traces VALUES
 [
   [2]
 ]
+-- chplan --
+MetricsAggregate op=count_over_time valueAlias=Value
+  Filter predicate=(ResourceAttributes["service.name"] = "frontend")
+    Scan(otel_traces)

--- a/test/spec/traceql/metrics_count_over_time_by_multi_service.txtar
+++ b/test/spec/traceql/metrics_count_over_time_by_multi_service.txtar
@@ -22,3 +22,7 @@ INSERT INTO otel_traces VALUES
   ["backend", 2],
   ["frontend", 3]
 ]
+-- chplan --
+MetricsAggregate op=count_over_time groupBy=[ResourceAttributes["service.name"] AS service.name] valueAlias=Value
+  Filter predicate=true
+    Scan(otel_traces)

--- a/test/spec/traceql/metrics_histogram_over_time_attr.txtar
+++ b/test/spec/traceql/metrics_histogram_over_time_attr.txtar
@@ -17,3 +17,7 @@ INSERT INTO otel_traces VALUES
 [
   [1.0e-08, 3]
 ]
+-- chplan --
+MetricsHistogramOverTime attr=Duration duration=true bucketAlias=__bucket valueAlias=Value
+  Filter predicate=true
+    Scan(otel_traces)

--- a/test/spec/traceql/metrics_histogram_over_time_by.txtar
+++ b/test/spec/traceql/metrics_histogram_over_time_by.txtar
@@ -20,3 +20,7 @@ INSERT INTO otel_traces VALUES
 [
   ["frontend", 1.0e-08, 3]
 ]
+-- chplan --
+MetricsHistogramOverTime attr=Duration duration=true groupBy=[ResourceAttributes["service.name"] AS service.name] bucketAlias=__bucket valueAlias=Value
+  Filter predicate=true
+    Scan(otel_traces)

--- a/test/spec/traceql/metrics_histogram_over_time_empty.txtar
+++ b/test/spec/traceql/metrics_histogram_over_time_empty.txtar
@@ -19,3 +19,7 @@ INSERT INTO otel_traces VALUES
 [
   [1.0e-08, 2]
 ]
+-- chplan --
+MetricsHistogramOverTime attr=Duration duration=true bucketAlias=__bucket valueAlias=Value
+  Filter predicate=(ResourceAttributes["service.name"] = "frontend")
+    Scan(otel_traces)

--- a/test/spec/traceql/metrics_max_over_time.txtar
+++ b/test/spec/traceql/metrics_max_over_time.txtar
@@ -16,3 +16,7 @@ INSERT INTO otel_traces VALUES
 [
   [200000000]
 ]
+-- chplan --
+MetricsAggregate op=max_over_time attr=Duration valueAlias=Value
+  Filter predicate=true
+    Scan(otel_traces)

--- a/test/spec/traceql/metrics_min_over_time.txtar
+++ b/test/spec/traceql/metrics_min_over_time.txtar
@@ -16,3 +16,7 @@ INSERT INTO otel_traces VALUES
 [
   [50000000]
 ]
+-- chplan --
+MetricsAggregate op=min_over_time attr=Duration valueAlias=Value
+  Filter predicate=true
+    Scan(otel_traces)

--- a/test/spec/traceql/metrics_quantile_over_time.txtar
+++ b/test/spec/traceql/metrics_quantile_over_time.txtar
@@ -19,3 +19,7 @@ INSERT INTO otel_traces VALUES
 [
   [100000000.0]
 ]
+-- chplan --
+MetricsAggregate op=quantile_over_time attr=Duration quantiles=[0.95] valueAlias=Value
+  Filter predicate=true
+    Scan(otel_traces)

--- a/test/spec/traceql/metrics_rate.txtar
+++ b/test/spec/traceql/metrics_rate.txtar
@@ -18,3 +18,7 @@ INSERT INTO otel_traces VALUES
 [
   [4]
 ]
+-- chplan --
+MetricsAggregate op=rate valueAlias=Value
+  Filter predicate=true
+    Scan(otel_traces)

--- a/test/spec/traceql/metrics_rate_by.txtar
+++ b/test/spec/traceql/metrics_rate_by.txtar
@@ -19,3 +19,7 @@ INSERT INTO otel_traces VALUES
 [
   ["frontend", 3]
 ]
+-- chplan --
+MetricsAggregate op=rate groupBy=[ResourceAttributes["service.name"] AS service.name] valueAlias=Value
+  Filter predicate=true
+    Scan(otel_traces)

--- a/test/spec/traceql/metrics_sum_over_time.txtar
+++ b/test/spec/traceql/metrics_sum_over_time.txtar
@@ -16,3 +16,7 @@ INSERT INTO otel_traces VALUES
 [
   [350000000]
 ]
+-- chplan --
+MetricsAggregate op=sum_over_time attr=Duration valueAlias=Value
+  Filter predicate=true
+    Scan(otel_traces)

--- a/test/spec/traceql/min_duration.txtar
+++ b/test/spec/traceql/min_duration.txtar
@@ -20,3 +20,8 @@ INSERT INTO otel_traces VALUES
 [
   [30000000]
 ]
+-- chplan --
+Filter predicate=(Value > 10000000)
+  Aggregate groupBy=[] funcs=[min(Duration) AS Value]
+    Filter predicate=(ResourceAttributes["service.name"] = "frontend")
+      Scan(otel_traces)

--- a/test/spec/traceql/multi_attr_compound.txtar
+++ b/test/spec/traceql/multi_attr_compound.txtar
@@ -23,3 +23,6 @@ INSERT INTO otel_traces (Duration) VALUES
   [150000000],
   [250000000]
 ]
+-- chplan --
+Filter predicate=(((ResourceAttributes["service.name"] = "frontend") AND (toFloat64(SpanAttributes["http.status_code"]) = 500)) AND (Duration > 100000000))
+  Scan(otel_traces)

--- a/test/spec/traceql/multi_hop_chain.txtar
+++ b/test/spec/traceql/multi_hop_chain.txtar
@@ -9,3 +9,12 @@ SELECT R.* FROM (SELECT R.* FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAt
 [3] string = "b"
 [4] string = "service.name"
 [5] string = "c"
+-- chplan --
+StructuralJoin op=>
+  StructuralJoin op=>
+    Filter predicate=(ResourceAttributes["service.name"] = "a")
+      Scan(otel_traces)
+    Filter predicate=(ResourceAttributes["service.name"] = "b")
+      Scan(otel_traces)
+  Filter predicate=(ResourceAttributes["service.name"] = "c")
+    Scan(otel_traces)

--- a/test/spec/traceql/name_intrinsic.txtar
+++ b/test/spec/traceql/name_intrinsic.txtar
@@ -16,3 +16,6 @@ INSERT INTO otel_traces VALUES
 [
   ["GET /api/users"]
 ]
+-- chplan --
+Filter predicate=(SpanName = "GET /api/users")
+  Scan(otel_traces)

--- a/test/spec/traceql/not_eq_attr.txtar
+++ b/test/spec/traceql/not_eq_attr.txtar
@@ -16,3 +16,6 @@ INSERT INTO otel_traces (_idx) VALUES (0), (1), (2);
   [0],
   [2]
 ]
+-- chplan --
+Filter predicate=(ResourceAttributes["service.name"] != "backend")
+  Scan(otel_traces)

--- a/test/spec/traceql/not_regex_attr.txtar
+++ b/test/spec/traceql/not_regex_attr.txtar
@@ -16,3 +16,6 @@ INSERT INTO otel_traces (_idx) VALUES (0), (1), (2);
   [0],
   [2]
 ]
+-- chplan --
+Filter predicate=(ResourceAttributes["service.name"] !~ "back.*")
+  Scan(otel_traces)

--- a/test/spec/traceql/or_two_attrs.txtar
+++ b/test/spec/traceql/or_two_attrs.txtar
@@ -20,3 +20,6 @@ INSERT INTO otel_traces (Duration) VALUES
   [50000000],
   [150000000]
 ]
+-- chplan --
+Filter predicate=((ResourceAttributes["service.name"] = "frontend") OR (Duration > 100000000))
+  Scan(otel_traces)

--- a/test/spec/traceql/parent_intrinsic.txtar
+++ b/test/spec/traceql/parent_intrinsic.txtar
@@ -16,3 +16,6 @@ INSERT INTO otel_traces VALUES
 [
   ["fedcba9876543210"]
 ]
+-- chplan --
+Filter predicate=(ParentSpanId = "fedcba9876543210")
+  Scan(otel_traces)

--- a/test/spec/traceql/parent_of.txtar
+++ b/test/spec/traceql/parent_of.txtar
@@ -7,3 +7,9 @@ SELECT R.* FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)
 [1] string = "frontend"
 [2] string = "service.name"
 [3] string = "api"
+-- chplan --
+StructuralJoin op=>
+  Filter predicate=(ResourceAttributes["service.name"] = "frontend")
+    Scan(otel_traces)
+  Filter predicate=(ResourceAttributes["service.name"] = "api")
+    Scan(otel_traces)

--- a/test/spec/traceql/recursive_ancestor.txtar
+++ b/test/spec/traceql/recursive_ancestor.txtar
@@ -7,3 +7,9 @@ SELECT R.* FROM (WITH RECURSIVE _struct_closure AS (SELECT `TraceId`, `SpanId`, 
 [1] string = "leaf"
 [2] string = "service.name"
 [3] string = "root"
+-- chplan --
+StructuralJoin op=<<
+  Filter predicate=(ResourceAttributes["service.name"] = "leaf")
+    Scan(otel_traces)
+  Filter predicate=(ResourceAttributes["service.name"] = "root")
+    Scan(otel_traces)

--- a/test/spec/traceql/recursive_descendant.txtar
+++ b/test/spec/traceql/recursive_descendant.txtar
@@ -7,3 +7,9 @@ SELECT R.* FROM (WITH RECURSIVE _struct_closure AS (SELECT `TraceId`, `SpanId`, 
 [1] string = "root"
 [2] string = "service.name"
 [3] string = "leaf"
+-- chplan --
+StructuralJoin op=>>
+  Filter predicate=(ResourceAttributes["service.name"] = "root")
+    Scan(otel_traces)
+  Filter predicate=(ResourceAttributes["service.name"] = "leaf")
+    Scan(otel_traces)

--- a/test/spec/traceql/recursive_mixed.txtar
+++ b/test/spec/traceql/recursive_mixed.txtar
@@ -9,3 +9,12 @@ SELECT R.* FROM (WITH RECURSIVE _struct_closure AS (SELECT `TraceId`, `SpanId`, 
 [3] string = "b"
 [4] string = "service.name"
 [5] string = "c"
+-- chplan --
+StructuralJoin op=>>
+  StructuralJoin op=>
+    Filter predicate=(ResourceAttributes["service.name"] = "a")
+      Scan(otel_traces)
+    Filter predicate=(ResourceAttributes["service.name"] = "b")
+      Scan(otel_traces)
+  Filter predicate=(ResourceAttributes["service.name"] = "c")
+    Scan(otel_traces)

--- a/test/spec/traceql/regex_attr.txtar
+++ b/test/spec/traceql/regex_attr.txtar
@@ -16,3 +16,6 @@ INSERT INTO otel_traces (_idx) VALUES (0), (1), (2);
   [0],
   [2]
 ]
+-- chplan --
+Filter predicate=(ResourceAttributes["service.name"] =~ "front.*")
+  Scan(otel_traces)

--- a/test/spec/traceql/select_attrs.txtar
+++ b/test/spec/traceql/select_attrs.txtar
@@ -22,3 +22,7 @@ INSERT INTO otel_traces VALUES
 [
   ["a0000000000000000000000000000001", "0000000000000001", "2026-01-01T00:00:00Z", "GET", "200"]
 ]
+-- chplan --
+Project [TraceId, SpanId, Timestamp, SpanAttributes["http.method"] AS http.method, SpanAttributes["http.status_code"] AS http.status_code]
+  Filter predicate=(ResourceAttributes["service.name"] = "frontend")
+    Scan(otel_traces)

--- a/test/spec/traceql/select_one_attr.txtar
+++ b/test/spec/traceql/select_one_attr.txtar
@@ -21,3 +21,7 @@ INSERT INTO otel_traces VALUES
 [
   ["a0000000000000000000000000000001", "0000000000000001", "2026-01-01T00:00:00Z", "GET"]
 ]
+-- chplan --
+Project [TraceId, SpanId, Timestamp, SpanAttributes["http.method"] AS http.method]
+  Filter predicate=(ResourceAttributes["service.name"] = "frontend")
+    Scan(otel_traces)

--- a/test/spec/traceql/select_resource_attrs.txtar
+++ b/test/spec/traceql/select_resource_attrs.txtar
@@ -21,3 +21,7 @@ INSERT INTO otel_traces VALUES
 [
   ["a0000000000000000000000000000001", "0000000000000001", "2026-01-01T00:00:00Z", "web", "prod"]
 ]
+-- chplan --
+Project [TraceId, SpanId, Timestamp, ResourceAttributes["service.namespace"] AS service.namespace, ResourceAttributes["k8s.cluster.name"] AS k8s.cluster.name]
+  Filter predicate=(ResourceAttributes["service.name"] = "frontend")
+    Scan(otel_traces)

--- a/test/spec/traceql/service_name_eq.txtar
+++ b/test/spec/traceql/service_name_eq.txtar
@@ -15,3 +15,6 @@ INSERT INTO otel_traces (_idx) VALUES (0), (1), (2);
 [
   [0]
 ]
+-- chplan --
+Filter predicate=(ResourceAttributes["service.name"] = "frontend")
+  Scan(otel_traces)

--- a/test/spec/traceql/set_intersect_simple.txtar
+++ b/test/spec/traceql/set_intersect_simple.txtar
@@ -6,3 +6,9 @@ SELECT L.* FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)
 [0] string = "service.name"
 [1] string = "a"
 [2] int64 = 1000000000
+-- chplan --
+SetOperation op=&&
+  Filter predicate=(ResourceAttributes["service.name"] = "a")
+    Scan(otel_traces)
+  Filter predicate=(Duration > 1000000000)
+    Scan(otel_traces)

--- a/test/spec/traceql/set_union_simple.txtar
+++ b/test/spec/traceql/set_union_simple.txtar
@@ -7,3 +7,9 @@
 [1] string = "a"
 [2] string = "service.name"
 [3] string = "b"
+-- chplan --
+SetOperation op=||
+  Filter predicate=(ResourceAttributes["service.name"] = "a")
+    Scan(otel_traces)
+  Filter predicate=(ResourceAttributes["service.name"] = "b")
+    Scan(otel_traces)

--- a/test/spec/traceql/sibling_simple.txtar
+++ b/test/spec/traceql/sibling_simple.txtar
@@ -5,3 +5,9 @@ SELECT R.* FROM (SELECT * FROM `otel_traces` WHERE (`SpanName` = ?)) AS L INNER 
 -- args --
 [0] string = "parent"
 [1] string = "sibling"
+-- chplan --
+StructuralJoin op=~
+  Filter predicate=(SpanName = "parent")
+    Scan(otel_traces)
+  Filter predicate=(SpanName = "sibling")
+    Scan(otel_traces)

--- a/test/spec/traceql/span_attr_default.txtar
+++ b/test/spec/traceql/span_attr_default.txtar
@@ -15,3 +15,6 @@ INSERT INTO otel_traces (_idx) VALUES (0), (1);
 [
   [0]
 ]
+-- chplan --
+Filter predicate=(SpanAttributes["http.method"] = "GET")
+  Scan(otel_traces)

--- a/test/spec/traceql/span_attr_explicit.txtar
+++ b/test/spec/traceql/span_attr_explicit.txtar
@@ -15,3 +15,6 @@ INSERT INTO otel_traces (_idx) VALUES (0), (1);
 [
   [0]
 ]
+-- chplan --
+Filter predicate=(SpanAttributes["http.method"] = "GET")
+  Scan(otel_traces)

--- a/test/spec/traceql/span_id_intrinsic.txtar
+++ b/test/spec/traceql/span_id_intrinsic.txtar
@@ -16,3 +16,6 @@ INSERT INTO otel_traces VALUES
 [
   ["0123456789abcdef"]
 ]
+-- chplan --
+Filter predicate=(SpanId = "0123456789abcdef")
+  Scan(otel_traces)

--- a/test/spec/traceql/static_float.txtar
+++ b/test/spec/traceql/static_float.txtar
@@ -15,3 +15,6 @@ INSERT INTO otel_traces (_idx) VALUES (0), (1);
 [
   [0]
 ]
+-- chplan --
+Filter predicate=(toFloat64(SpanAttributes["ratio"]) = 0.95)
+  Scan(otel_traces)

--- a/test/spec/traceql/static_int.txtar
+++ b/test/spec/traceql/static_int.txtar
@@ -15,3 +15,6 @@ INSERT INTO otel_traces (_idx) VALUES (0), (1);
 [
   [0]
 ]
+-- chplan --
+Filter predicate=(toFloat64(SpanAttributes["attempt"]) = 1)
+  Scan(otel_traces)

--- a/test/spec/traceql/status_and_kind_combined.txtar
+++ b/test/spec/traceql/status_and_kind_combined.txtar
@@ -18,3 +18,6 @@ INSERT INTO otel_traces (StatusCode) VALUES
 [
   ["Error"]
 ]
+-- chplan --
+Filter predicate=((StatusCode = "Error") AND (SpanKind = "Server"))
+  Scan(otel_traces)

--- a/test/spec/traceql/status_code_eq.txtar
+++ b/test/spec/traceql/status_code_eq.txtar
@@ -15,3 +15,6 @@ INSERT INTO otel_traces (_idx) VALUES (0), (1), (2);
 [
   [0]
 ]
+-- chplan --
+Filter predicate=(toFloat64(SpanAttributes["http.status_code"]) = 200)
+  Scan(otel_traces)

--- a/test/spec/traceql/status_code_ge.txtar
+++ b/test/spec/traceql/status_code_ge.txtar
@@ -16,3 +16,6 @@ INSERT INTO otel_traces (_idx) VALUES (0), (1), (2);
   [0],
   [1]
 ]
+-- chplan --
+Filter predicate=(toFloat64(SpanAttributes["http.status_code"]) >= 500)
+  Scan(otel_traces)

--- a/test/spec/traceql/status_eq_error.txtar
+++ b/test/spec/traceql/status_eq_error.txtar
@@ -16,3 +16,6 @@ INSERT INTO otel_traces VALUES
 [
   ["Error"]
 ]
+-- chplan --
+Filter predicate=(StatusCode = "Error")
+  Scan(otel_traces)

--- a/test/spec/traceql/status_message.txtar
+++ b/test/spec/traceql/status_message.txtar
@@ -16,3 +16,6 @@ INSERT INTO otel_traces VALUES
 [
   ["internal server error"]
 ]
+-- chplan --
+Filter predicate=(StatusMessage = "internal server error")
+  Scan(otel_traces)

--- a/test/spec/traceql/status_neq_ok.txtar
+++ b/test/spec/traceql/status_neq_ok.txtar
@@ -17,3 +17,6 @@ INSERT INTO otel_traces VALUES
   ["Error"],
   ["Unset"]
 ]
+-- chplan --
+Filter predicate=(StatusCode != "Ok")
+  Scan(otel_traces)

--- a/test/spec/traceql/status_unset.txtar
+++ b/test/spec/traceql/status_unset.txtar
@@ -16,3 +16,6 @@ INSERT INTO otel_traces VALUES
 [
   ["Unset"]
 ]
+-- chplan --
+Filter predicate=(StatusCode = "Unset")
+  Scan(otel_traces)

--- a/test/spec/traceql/sum_duration.txtar
+++ b/test/spec/traceql/sum_duration.txtar
@@ -20,3 +20,8 @@ INSERT INTO otel_traces VALUES
 [
   [250000000]
 ]
+-- chplan --
+Filter predicate=(Value > 100000000)
+  Aggregate groupBy=[] funcs=[sum(Duration) AS Value]
+    Filter predicate=(ResourceAttributes["service.name"] = "frontend")
+      Scan(otel_traces)

--- a/test/spec/traceql/sum_span_attr.txtar
+++ b/test/spec/traceql/sum_span_attr.txtar
@@ -19,3 +19,8 @@ INSERT INTO otel_traces VALUES
 [
   [904]
 ]
+-- chplan --
+Filter predicate=(Value > 0)
+  Aggregate groupBy=[] funcs=[sum(SpanAttributes["http.status_code"]) AS Value]
+    Filter predicate=(toFloat64(SpanAttributes["http.status_code"]) >= 400)
+      Scan(otel_traces)

--- a/test/spec/traceql/trace_id_intrinsic.txtar
+++ b/test/spec/traceql/trace_id_intrinsic.txtar
@@ -16,3 +16,6 @@ INSERT INTO otel_traces VALUES
 [
   ["abcdef0123456789"]
 ]
+-- chplan --
+Filter predicate=(TraceId = "abcdef0123456789")
+  Scan(otel_traces)


### PR DESCRIPTION
## Summary

Closes the audit gap Pool-AR surfaced in #352 (`docs/test-spec-audit.md`):
the TraceQL TXTAR corpus was the only spec-test head with **no chplan
plane** — `internal/traceql/lower_test.go` only matched on `sql` + `args`,
so a wrong lowered plan that happened to emit the same SQL string slipped
through every spec assertion.

LogQL and PromQL already pass `spec.PrintChplan(plan)` into `spec.Match`
under a `chplan` key; this PR mirrors that pattern for TraceQL.

- **Commit 1** — runner plumbing only. Adds the `chplan` key to the
  `spec.Match` map in `internal/traceql/lower_test.go`. Three-line change.
- **Commit 2** — mechanical `GOLDEN_UPDATE=1` regen of all 107 fixtures
  under `test/spec/traceql/`. Every fixture now carries a `-- chplan --`
  section pinning the IR tree produced by `traceql.Lower` (rendered via
  the deterministic pretty-printer at `test/spec/chplan_print.go`).

Verified afterwards: `go test ./internal/traceql/...` passes without
`GOLDEN_UPDATE` (idempotent), and `go build ./...` is green.

### Example non-trivial chplan sections

`test/spec/traceql/and_or_combined.txtar` — boolean operand order is now
fixed by the snapshot, not just inferred from SQL:

```
Filter predicate=((ResourceAttributes["service.name"] = "frontend") AND ((Duration > 100000000) OR (toFloat64(SpanAttributes["http.status_code"]) >= 500)))
  Scan(otel_traces)
```

`test/spec/traceql/edge_chain_mixed_5.txtar` — five-hop structural chain.
The associativity (`(((a > b) >> c) > d) >> e`) is now pinned by the IR
tree, not just by the deeply-nested CTE-recursive SQL:

```
StructuralJoin op=>>
  StructuralJoin op=>
    StructuralJoin op=>>
      StructuralJoin op=>
        Filter predicate=(ResourceAttributes["service.name"] = "a")
          Scan(otel_traces)
        Filter predicate=(ResourceAttributes["service.name"] = "b")
          Scan(otel_traces)
      Filter predicate=(ResourceAttributes["service.name"] = "c")
        Scan(otel_traces)
    Filter predicate=(ResourceAttributes["service.name"] = "d")
      Scan(otel_traces)
  Filter predicate=(ResourceAttributes["service.name"] = "e")
    Scan(otel_traces)
```

`test/spec/traceql/metrics_histogram_over_time_by.txtar` — distinct
chplan node type (`MetricsHistogramOverTime`) with the bucket/value
aliases pinned:

```
MetricsHistogramOverTime attr=Duration duration=true groupBy=[ResourceAttributes["service.name"] AS service.name] bucketAlias=__bucket valueAlias=Value
  Filter predicate=true
    Scan(otel_traces)
```

### Fixtures flagged for follow-up

None. Spot-checked the simplest (Filter+Scan), mid-tier (multi-attribute,
metrics rate/histogram/quantile/sum/min/max), and the most complex (5-hop
mixed-recursive structural chains, 3-way set unions, multi-hop with
group_coalesce). Every lowered tree matches the shape the SQL implies —
nothing structurally suspicious.

The `Filter predicate=true` shape that appears on `{} | …` queries
(e.g. `coalesce_simple`, `metrics_rate`, `group_by_attr`) is the expected
lowering for a wildcard span selector — the SQL counterpart is a literal
`WHERE ?` with `args[i] = bool true`, so the chplan matches the wire.

## Test plan

- [x] `go test ./internal/traceql/...` green (258 tests, includes the
      107-fixture spec runner)
- [x] `go build ./...` green
- [x] Re-running the same suite without `GOLDEN_UPDATE=1` is idempotent
- [x] Spot-checked 8 fixtures by hand for non-trivial, structurally
      correct chplan output
- [ ] CI `check` + `lint` jobs pass

Refs: #352, `docs/test-spec-audit.md`