### PR TITLE
fix(promql,chsql): V-V on(...) comparison binop step-aligned join

### DIFF
--- a/internal/api/prom/handler_chdb_range_mode_test.go
+++ b/internal/api/prom/handler_chdb_range_mode_test.go
@@ -951,6 +951,226 @@ func TestQueryRange_RangeMode_HistogramQuantileClassic_ChDB(t *testing.T) {
 	}
 }
 
+// TestQueryRange_RangeMode_VVOnCompare_ChDB pins the bare V-V
+// `on(...)` comparison binop family (==, !=, <, >, <=, >=) under
+// `/api/v1/query_range` — the no-`bool`-modifier sibling of
+// TestQueryRange_RangeMode_VVOnComparison_ChDB. Before this fix every
+// shape in the family returned `server_error: 502` because the
+// comparison emit path projected the per-pair comparison result
+// `(L.Value <op> R.Value)` — a CH UInt8 — into the canonical Value
+// column, and clickhouse-go's scan into `*float64` rejected the type
+// with the 502 surfacing as 12 compat-lane failures on the
+// `demo_memory_usage_bytes` selector (six bare ops × two LHS shapes —
+// bare selector and `sum by()` `group_left(job)` join).
+//
+// The fix routes plain V-V comparisons through the existing step-
+// aligned VectorJoin (PR #348's StepAligned conjunct) and projects
+// `L.Value` into the output column with a `WHERE (L.Value <op>
+// R.Value)` predicate so Prom's "preserve LHS where comparison
+// holds" semantics fire and the output Value stays Float64. This
+// test seeds two series with comparable values, runs every op, and
+// asserts each step's matrix-output value is one of the LHS sample
+// values that satisfied the per-anchor comparison.
+//
+// The chDB lane is the right home: this is a wire-format regression
+// (clickhouse-go scan refusing UInt8 → *float64), not a SQL-shape
+// regression, so the stub lane wouldn't catch a future regression
+// that breaks only the scan path.
+func TestQueryRange_RangeMode_VVOnCompare_ChDB(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(5 * time.Minute)
+	step := 30 * time.Second
+	const wantSamples = 11
+
+	// Two series with constant per-step values (100, 200). Comparing
+	// each series with itself across the on(instance, job, type)
+	// match yields rows where L.Value == R.Value (always true), so
+	// `==` keeps every pair, `<`/`>` drop everything, and `<=`/`>=`
+	// behave like `==`. Mirrors the compatibility lane's PromLabs
+	// demo seed (instance/job/type labels).
+	seedRows := make([]string, 0, wantSamples*2)
+	for i := 0; i < wantSamples; i++ {
+		ts := start.Add(time.Duration(i) * step).Format("2006-01-02 15:04:05.000000000")
+		seedRows = append(seedRows,
+			fmt.Sprintf(`('demo_memory_usage_bytes', map('instance', 'a', 'job', 'demo', 'type', 'used'), toDateTime64('%s', 9), 100.0)`, ts),
+			fmt.Sprintf(`('demo_memory_usage_bytes', map('instance', 'b', 'job', 'demo', 'type', 'used'), toDateTime64('%s', 9), 200.0)`, ts),
+		)
+	}
+	seed := gaugeDDL + "\nINSERT INTO otel_metrics_gauge VALUES\n  " +
+		strings.Join(seedRows, ",\n  ") + ";"
+	srv, _ := newChDBServer(t, seed)
+
+	// Each entry pins the per-pair filter behaviour of one of the
+	// 12 compat-lane shapes (the 6 bare comparison ops, all over the
+	// same on(instance, job, type) shape). When the comparison
+	// passes, the LHS Value flows through; when it fails, no row is
+	// emitted at that step.
+	type vvCmpCase struct {
+		// name is the t.Run subtest name and doubles as the trace tag.
+		name string
+		// query is the PromQL expression executed against the seeded
+		// matrix. The bare comparison without `bool` triggers
+		// Prom's V-V comparison filter rule.
+		query string
+		// wantSeriesCount is the number of distinct series the
+		// matrix should carry after the filter.
+		wantSeriesCount int
+		// wantValuePerSeries is the per-instance Value sample we
+		// expect at each step in the result series. Each series
+		// must carry exactly `wantSamples` rows of the matching
+		// value when the comparison passes (== / <= / >=).
+		wantValuePerSeries map[string]string
+	}
+	for _, tc := range []vvCmpCase{
+		{
+			name:               "eq",
+			query:              `demo_memory_usage_bytes == on(instance, job, type) demo_memory_usage_bytes`,
+			wantSeriesCount:    2,
+			wantValuePerSeries: map[string]string{"a": "100", "b": "200"},
+		},
+		{
+			name:               "le",
+			query:              `demo_memory_usage_bytes <= on(instance, job, type) demo_memory_usage_bytes`,
+			wantSeriesCount:    2,
+			wantValuePerSeries: map[string]string{"a": "100", "b": "200"},
+		},
+		{
+			name:               "ge",
+			query:              `demo_memory_usage_bytes >= on(instance, job, type) demo_memory_usage_bytes`,
+			wantSeriesCount:    2,
+			wantValuePerSeries: map[string]string{"a": "100", "b": "200"},
+		},
+		{
+			name:               "ne",
+			query:              `demo_memory_usage_bytes != on(instance, job, type) demo_memory_usage_bytes`,
+			wantSeriesCount:    0,
+			wantValuePerSeries: nil,
+		},
+		{
+			name:               "lt",
+			query:              `demo_memory_usage_bytes < on(instance, job, type) demo_memory_usage_bytes`,
+			wantSeriesCount:    0,
+			wantValuePerSeries: nil,
+		},
+		{
+			name:               "gt",
+			query:              `demo_memory_usage_bytes > on(instance, job, type) demo_memory_usage_bytes`,
+			wantSeriesCount:    0,
+			wantValuePerSeries: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			matrix := runRangeModeQueryRange(t, srv.URL,
+				tc.query, start, end, step)
+			if len(matrix) != tc.wantSeriesCount {
+				t.Fatalf("query=%q: expected %d series, got %d: %+v",
+					tc.query, tc.wantSeriesCount, len(matrix), matrix)
+			}
+			if tc.wantSeriesCount == 0 {
+				// Filtered-out shape — nothing more to check.
+				return
+			}
+			for _, ms := range matrix {
+				inst := ms.Metric["instance"]
+				want, ok := tc.wantValuePerSeries[inst]
+				if !ok {
+					t.Errorf("unexpected series instance=%q: %+v", inst, ms.Metric)
+					continue
+				}
+				if len(ms.Values) != wantSamples {
+					t.Errorf("instance=%s: expected %d samples, got %d: %+v",
+						inst, wantSamples, len(ms.Values), ms.Values)
+					continue
+				}
+				for i, v := range ms.Values {
+					if got := v[1]; got != want {
+						t.Errorf("instance=%s step %d: value=%q want=%q (full row: %+v)",
+							inst, i, got, want, v)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestQueryRange_RangeMode_VVOnCompareGroupLeft_ChDB pins the
+// `sum by(instance, type) (metric) <cmp> on(instance, type)
+// group_left(job) metric` family (the second LHS shape in the
+// compat-lane's 12-failure batch). The `group_left(job)` modifier
+// copies the `job` label onto the LHS-derived output rows.
+//
+// Pre-fix: the emit path projected `(L.Value <op> R.Value)` as the
+// Value column → UInt8 → clickhouse-go scan failure → 502.
+//
+// Post-fix: the bare comparison routes through `WHERE (L.Value <op>
+// R.Value)` with `L.Value AS Value`; the matrix output carries the
+// LHS aggregate value where the comparison holds.
+//
+// Seeded: two `(instance, type)` groups (a/b × used) with a single
+// job per group. The LHS aggregate `sum by(instance, type)` folds
+// the per-group rows down to one value; the RHS bare selector
+// preserves the job label. `group_left(job)` then copies the job
+// label onto the LHS output without trip the uniqueness throwIf
+// (one row per (instance, type, job) tuple on each side).
+func TestQueryRange_RangeMode_VVOnCompareGroupLeft_ChDB(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(5 * time.Minute)
+	step := 30 * time.Second
+	const wantSamples = 11
+
+	// Two (instance, type) groups, each with a single demo job. The
+	// LHS `sum by(instance, type)` produces one row per group (same
+	// value as the single underlying row); the RHS bare selector
+	// produces one row per group with `job=demo`. `group_left(job)`
+	// copies `job` from RHS onto the LHS output.
+	seedRows := make([]string, 0, wantSamples*2)
+	for i := 0; i < wantSamples; i++ {
+		ts := start.Add(time.Duration(i) * step).Format("2006-01-02 15:04:05.000000000")
+		seedRows = append(seedRows,
+			fmt.Sprintf(`('demo_memory_usage_bytes', map('instance', 'a', 'job', 'demo', 'type', 'used'), toDateTime64('%s', 9), 100.0)`, ts),
+			fmt.Sprintf(`('demo_memory_usage_bytes', map('instance', 'b', 'job', 'demo', 'type', 'used'), toDateTime64('%s', 9), 200.0)`, ts),
+		)
+	}
+	seed := gaugeDDL + "\nINSERT INTO otel_metrics_gauge VALUES\n  " +
+		strings.Join(seedRows, ",\n  ") + ";"
+	srv, _ := newChDBServer(t, seed)
+
+	// `sum by(instance, type) (metric)` folds the per-group rows
+	// down to one value per (instance, type); comparing that against
+	// the bare selector on the same data with `on(instance, type)`
+	// always holds for `==`.
+	query := `sum by(instance, type) (demo_memory_usage_bytes) == on(instance, type) group_left(job) demo_memory_usage_bytes`
+	matrix := runRangeModeQueryRange(t, srv.URL, query, start, end, step)
+	if len(matrix) != 2 {
+		t.Fatalf("expected 2 series (one per (instance, type) group), got %d: %+v",
+			len(matrix), matrix)
+	}
+	wantPerInstance := map[string]string{"a": "100", "b": "200"}
+	for _, ms := range matrix {
+		inst := ms.Metric["instance"]
+		want, ok := wantPerInstance[inst]
+		if !ok {
+			t.Errorf("unexpected series instance=%q: %+v", inst, ms.Metric)
+			continue
+		}
+		if got := ms.Metric["job"]; got != "demo" {
+			t.Errorf("instance=%s: expected job=demo (group_left copy), got job=%q (full metric: %+v)",
+				inst, got, ms.Metric)
+		}
+		if len(ms.Values) != wantSamples {
+			t.Errorf("instance=%s: expected %d samples, got %d: %+v",
+				inst, wantSamples, len(ms.Values), ms.Values)
+			continue
+		}
+		for i, v := range ms.Values {
+			if got := v[1]; got != want {
+				t.Errorf("instance=%s step %d: value=%q want=%q (full row: %+v)",
+					inst, i, got, want, v)
+			}
+		}
+	}
+}
+
 // runRangeModeQueryRange is the test helper shared across the Pool-AK
 // range-mode regression cases. Mirrors `runStepLoopRange` but lives
 // in this file so the Pool-AK suite is self-contained for any future

--- a/internal/chsql/vector_join.go
+++ b/internal/chsql/vector_join.go
@@ -67,6 +67,22 @@ func (e *emitter) emitVectorJoin(j *chplan.VectorJoin) error {
 			aliasedFrag(rightFrag, "R"),
 			vectorMatchPredicateFrag(j.Match, j.AttributesColumn, j.TimestampColumn, j.StepAligned),
 		)
+	// Bare V-V comparison (no `bool` modifier): PromQL's
+	// "preserve LHS where comparison holds" rule applies. The Value
+	// expression (set by vectorJoinValueExprFrag) already projects
+	// `L.Value` for this case, so add the comparison as a WHERE filter
+	// so rows where the comparison is false are dropped. Without the
+	// filter the join keeps every matched pair, producing rows whose
+	// Value is the LHS even when the comparison would have dropped
+	// them in Prometheus.
+	//
+	// Without `bool` the emit would otherwise project a UInt8 column
+	// (CH's `Float64 <cmp> Float64` return type) into Value, which
+	// clickhouse-go cannot scan into `*float64` — surfacing as a 502
+	// at the compat lane for every plain V-V comparison with `on(...)`.
+	if isComparisonOp(j.Op) && !j.ReturnBool {
+		sb.Where(vectorJoinCompareFilterFrag(j))
+	}
 	e.emitSelect(sb)
 	return nil
 }
@@ -391,9 +407,26 @@ func writeOutputAttributes(b *Builder, j *chplan.VectorJoin) {
 // the binary result is wrapped with `toFloat64(...)` so every matched
 // pair emits 1.0 or 0.0 instead of being dropped by the comparison —
 // matching Prometheus's `bool` semantics for V-V comparisons.
+//
+// Bare comparison op (no `bool` modifier): Prom's V-V comparison-as-
+// filter rule applies — preserve the LHS sample value where the
+// comparison holds and drop rows where it doesn't. emitVectorJoin
+// pairs this projection with a `WHERE (L.Value <op> R.Value)` clause
+// via vectorJoinCompareFilterFrag; here we project `L.Value` directly
+// rather than the comparison expression so the surviving rows carry
+// the LHS sample value (Float64) rather than a UInt8 comparison
+// result. Without the LHS projection the rendered Value column would
+// be `Float64 <cmp> Float64` → UInt8, which clickhouse-go cannot scan
+// into `*float64` (the 502 the compat lane surfaces).
 func vectorJoinValueExprFrag(j *chplan.VectorJoin) Frag {
 	left := qualColFrag("L", j.ValueColumn)
 	right := qualColFrag("R", j.ValueColumn)
+	if isComparisonOp(j.Op) && !j.ReturnBool {
+		// Plain V-V comparison: filter wraps the join via the WHERE
+		// clause; the Value column carries the LHS sample value
+		// (Float64) to satisfy the scan contract.
+		return As(left, j.ValueColumn)
+	}
 	var inner Frag
 	if j.Op == chplan.OpPow {
 		inner = Call("pow", left, right)
@@ -404,6 +437,32 @@ func vectorJoinValueExprFrag(j *chplan.VectorJoin) Frag {
 		inner = Call("toFloat64", inner)
 	}
 	return As(inner, j.ValueColumn)
+}
+
+// vectorJoinCompareFilterFrag returns the WHERE-clause Frag used for
+// bare V-V comparisons (no `bool` modifier). PromQL's semantics keep
+// LHS samples where `L.Value <op> R.Value` holds and drop the rest;
+// the comparison expression is emitted as a WHERE predicate so CH
+// drops the non-matching rows at the join's output level.
+//
+// PromQL's vector-vector comparison ops are limited to the six listed
+// in [isComparisonOp]; OpPow (a special case in the value expression)
+// is intentionally not a comparison so this branch never sees it.
+func vectorJoinCompareFilterFrag(j *chplan.VectorJoin) Frag {
+	left := qualColFrag("L", j.ValueColumn)
+	right := qualColFrag("R", j.ValueColumn)
+	return Paren(binOp(string(j.Op), left, right))
+}
+
+// isComparisonOp reports whether op is one of PromQL's six comparison
+// binary ops. Kept local to the emitter so the chsql package doesn't
+// take a dep on internal/promql for the BinaryOp predicate.
+func isComparisonOp(op chplan.BinaryOp) bool {
+	switch op {
+	case chplan.OpEq, chplan.OpNe, chplan.OpLt, chplan.OpLe, chplan.OpGt, chplan.OpGe:
+		return true
+	}
+	return false
 }
 
 // qualColFrag returns a Frag for `<bareSide>.<col>` — the bare-alias

--- a/test/spec/promql/binop_vv_on_compare_eq.txtar
+++ b/test/spec/promql/binop_vv_on_compare_eq.txtar
@@ -1,0 +1,56 @@
+-- query.promql --
+demo_memory_usage_bytes == on(instance, job, type) demo_memory_usage_bytes
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('demo_memory_usage_bytes', map('instance', 'a', 'job', 'demo', 'type', 'used'), toDateTime64('2026-01-01 00:00:00', 9), 100.0),
+    ('demo_memory_usage_bytes', map('instance', 'b', 'job', 'demo', 'type', 'used'), toDateTime64('2026-01-01 00:00:00', 9), 200.0);
+-- expected_rows --
+[
+  ["demo_memory_usage_bytes", {"instance": "a", "job": "demo", "type": "used"}, "2026-01-01T00:00:00Z", 100.0],
+  ["demo_memory_usage_bytes", {"instance": "b", "job": "demo", "type": "used"}, "2026-01-01T00:00:00Z", 200.0]
+]
+-- args --
+[0] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[1] string = "demo_memory_usage_bytes"
+[2] string = "2026-01-01 00:00:01.000000000"
+[3] int64 = 9
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] int64 = 300000000000
+[7] string = "instance"
+[8] string = "job"
+[9] string = "type"
+[10] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[11] string = "demo_memory_usage_bytes"
+[12] string = "2026-01-01 00:00:01.000000000"
+[13] int64 = 9
+[14] string = "2026-01-01 00:00:01.000000000"
+[15] int64 = 9
+[16] int64 = 300000000000
+[17] string = "instance"
+[18] string = "job"
+[19] string = "type"
+[20] string = "instance"
+[21] string = "instance"
+[22] string = "job"
+[23] string = "job"
+[24] string = "type"
+[25] string = "type"
+-- chplan --
+VectorJoin op== match=on(instance,job,type) card=one-to-one
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "demo_memory_usage_bytes") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "demo_memory_usage_bytes") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)
+-- sql --
+SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, L.`Value` AS `Value` FROM (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY mapFilter((k, v) -> k IN (?, ?, ?), `Attributes`))) AS L INNER JOIN (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY mapFilter((k, v) -> k IN (?, ?, ?), `Attributes`))) AS R ON L.`Attributes`[?] = R.`Attributes`[?] AND L.`Attributes`[?] = R.`Attributes`[?] AND L.`Attributes`[?] = R.`Attributes`[?] WHERE (L.`Value` = R.`Value`)

--- a/test/spec/promql/binop_vv_on_compare_lt.txtar
+++ b/test/spec/promql/binop_vv_on_compare_lt.txtar
@@ -1,0 +1,53 @@
+-- query.promql --
+demo_memory_usage_bytes < on(instance, job, type) demo_memory_usage_bytes
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('demo_memory_usage_bytes', map('instance', 'a', 'job', 'demo', 'type', 'used'), toDateTime64('2026-01-01 00:00:00', 9), 100.0),
+    ('demo_memory_usage_bytes', map('instance', 'b', 'job', 'demo', 'type', 'used'), toDateTime64('2026-01-01 00:00:00', 9), 200.0);
+-- expected_rows --
+[]
+-- args --
+[0] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[1] string = "demo_memory_usage_bytes"
+[2] string = "2026-01-01 00:00:01.000000000"
+[3] int64 = 9
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] int64 = 300000000000
+[7] string = "instance"
+[8] string = "job"
+[9] string = "type"
+[10] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[11] string = "demo_memory_usage_bytes"
+[12] string = "2026-01-01 00:00:01.000000000"
+[13] int64 = 9
+[14] string = "2026-01-01 00:00:01.000000000"
+[15] int64 = 9
+[16] int64 = 300000000000
+[17] string = "instance"
+[18] string = "job"
+[19] string = "type"
+[20] string = "instance"
+[21] string = "instance"
+[22] string = "job"
+[23] string = "job"
+[24] string = "type"
+[25] string = "type"
+-- chplan --
+VectorJoin op=< match=on(instance,job,type) card=one-to-one
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "demo_memory_usage_bytes") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "demo_memory_usage_bytes") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_gauge)
+-- sql --
+SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, L.`Value` AS `Value` FROM (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY mapFilter((k, v) -> k IN (?, ?, ?), `Attributes`))) AS L INNER JOIN (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY mapFilter((k, v) -> k IN (?, ?, ?), `Attributes`))) AS R ON L.`Attributes`[?] = R.`Attributes`[?] AND L.`Attributes`[?] = R.`Attributes`[?] AND L.`Attributes`[?] = R.`Attributes`[?] WHERE (L.`Value` < R.`Value`)


### PR DESCRIPTION
## Summary

The remaining 12 unexpected failures in the compatibility lane (compat run 25898791664, post-#350) were all bare V-V comparison binops with `on(...)` matching that 502'd on `query_range`:

```
demo_memory_usage_bytes == on(instance, job, type) demo_memory_usage_bytes
demo_memory_usage_bytes != on(instance, job, type) demo_memory_usage_bytes
demo_memory_usage_bytes <  on(instance, job, type) demo_memory_usage_bytes
demo_memory_usage_bytes >  on(instance, job, type) demo_memory_usage_bytes
demo_memory_usage_bytes <= on(instance, job, type) demo_memory_usage_bytes
demo_memory_usage_bytes >= on(instance, job, type) demo_memory_usage_bytes
sum by(instance, type) (demo_memory_usage_bytes) == on(instance, type) group_left(job) demo_memory_usage_bytes
sum by(instance, type) (demo_memory_usage_bytes) != on(instance, type) group_left(job) demo_memory_usage_bytes
sum by(instance, type) (demo_memory_usage_bytes) <  on(instance, type) group_left(job) demo_memory_usage_bytes
sum by(instance, type) (demo_memory_usage_bytes) >  on(instance, type) group_left(job) demo_memory_usage_bytes
sum by(instance, type) (demo_memory_usage_bytes) <= on(instance, type) group_left(job) demo_memory_usage_bytes
sum by(instance, type) (demo_memory_usage_bytes) >= on(instance, type) group_left(job) demo_memory_usage_bytes
```

## Root cause

The `emitVectorJoin` path produced `(L.Value <op> R.Value) AS Value` for the Value column. CH evaluates `Float64 <cmp> Float64` to `UInt8` (0/1). clickhouse-go cannot scan `UInt8` into the handler's `*float64` (the `chclient.Sample.Value` type), so the wire-format conversion fails and the response surfaces as a `server_error: 502`.

The `bool` modifier path already wrapped the comparison in `toFloat64(...)` (PR #348) — which kept it working — but the bare comparison path didn't, AND it was also semantically wrong by Prom's spec (V-V comparison without `bool` should filter, not return 0/1).

## Fix

Extend `emitVectorJoin` in `internal/chsql/vector_join.go`:

- When `isComparisonOp(j.Op) && !j.ReturnBool` (the bare V-V comparison case), `vectorJoinValueExprFrag` now projects `L.Value AS Value` (preserve LHS Float64 sample value).
- `emitVectorJoin` adds `WHERE (L.Value <op> R.Value)` via a new `vectorJoinCompareFilterFrag` so rows where the comparison fails are dropped — matching Prometheus's "preserve LHS where comparison holds" V-V comparison filter semantics.
- The step-aligned join machinery (PR #348's `StepAligned` flag on `chplan.VectorJoin`) is reused as-is — the comparison op doesn't change the per-anchor join shape, only the WHERE/projection.

The `bool` variant path is untouched (existing `bool_vv_*.txtar` fixtures stay byte-stable). The arithmetic/POW paths are untouched.

## Before / after

For `demo_memory_usage_bytes == on(instance, job, type) demo_memory_usage_bytes`:

### chplan

The IR is unchanged (the comparison Op + `ReturnBool=false` already pinned the intent — the bug was in the emitter). The plan is:

```
VectorJoin op== match=on(instance,job,type) card=one-to-one
  Project [...] (LHS LWR)
  Project [...] (RHS LWR)
```

### SQL — before (origin/main; 502)

```sql
SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`,
       (L.`Value` = R.`Value`) AS `Value`  -- UInt8 → 502 scan failure
FROM (LHS_LWR) AS L
INNER JOIN (RHS_LWR) AS R
  ON L.`Attributes`[?] = R.`Attributes`[?]
 AND L.`Attributes`[?] = R.`Attributes`[?]
 AND L.`Attributes`[?] = R.`Attributes`[?]
```

### SQL — after

```sql
SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`,
       L.`Value` AS `Value`  -- LHS Float64 preserved
FROM (LHS_LWR) AS L
INNER JOIN (RHS_LWR) AS R
  ON L.`Attributes`[?] = R.`Attributes`[?]
 AND L.`Attributes`[?] = R.`Attributes`[?]
 AND L.`Attributes`[?] = R.`Attributes`[?]
WHERE (L.`Value` = R.`Value`)  -- Prom's comparison filter
```

The step-aligned `L.TimeUnix = R.TimeUnix` ON-clause conjunct is automatically appended when `StepAligned=true` (range mode) — that machinery was already in place from PR #348.

## Coverage

- `test/spec/promql/binop_vv_on_compare_eq.txtar` — instant-mode TXTAR golden + chDB round-trip (`==` shape, both series surviving).
- `test/spec/promql/binop_vv_on_compare_lt.txtar` — instant-mode TXTAR golden + chDB round-trip (`<` shape, all rows filtered out).
- `internal/api/prom/handler_chdb_range_mode_test.go::TestQueryRange_RangeMode_VVOnCompare_ChDB` — chDB regression covering all six bare comparison ops over `query_range` (the wire-format scan path, which is where the 502 surfaces). 6 t.Run subtests pass.
- `internal/api/prom/handler_chdb_range_mode_test.go::TestQueryRange_RangeMode_VVOnCompareGroupLeft_ChDB` — chDB regression covering the second LHS shape in the 12-failure batch (the `sum by(...) ... == on(...) group_left(...) ...` family).

## Test plan

- [x] `go build ./...`
- [x] `go test -count=1 ./internal/chsql/ ./internal/promql/ ./internal/api/prom/` — all pass.
- [x] `go test -tags chdb -count=1 ./internal/...` — all pass (pre-existing `test/spec/logql/label_replace_basic` failure is unrelated, confirmed against origin/main).
- [x] `go test -tags chdb -count=1 -v -run 'TestQueryRange_RangeMode_VVOnCompar' ./internal/api/prom/` — 8 tests pass (6 comparison ops + 1 group_left + 1 parent test).
- [x] `bool_vv_*.txtar` and other vector-join golden fixtures remain byte-stable (no regression in the existing test surface).
- [ ] Compat lane confirms the 12 unexpected_failures clear on next nightly / manual dispatch.