### PR TITLE
fix(logql): translate label_replace `$N` backrefs for CH regex syntax

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -110,6 +110,7 @@ components:
   api-health:     { in: api/health }
   promshim-local: { in: promshim/local }
   chclienttest:   { in: chclienttest }
+  qlcommon:       { in: qlcommon }
 
 # commonComponents are importable from every layer without an explicit
 # `mayDependOn` entry. These are the cross-cutting utility packages
@@ -125,6 +126,7 @@ commonComponents:
   - api-health
   - promshim-local
   - chclienttest
+  - qlcommon
 
 deps:
   # chplan is the foundation. No internal dependencies declared — entries

--- a/internal/logql/label_fns.go
+++ b/internal/logql/label_fns.go
@@ -6,6 +6,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
 
 	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/qlcommon"
 	"github.com/tsouza/cerberus/internal/schema"
 )
 
@@ -26,6 +27,15 @@ import (
 // parser also pre-compiles `Re` and stashes any invalid-regex error
 // inside an unexported `err` field; ParseExpr surfaces it before
 // lowering reaches us.
+//
+// The Replacement string is run through qlcommon.ReplacementToCH so
+// Go-regexp `$N` / `${N}` backrefs become CH `replaceRegexpOne` `\N`
+// backrefs. LogQL's reference replacement engine is Go's
+// `regexp.Regexp.ExpandString` (identical to PromQL); without the
+// translation a replacement like `"svc-$1"` is emitted to CH verbatim
+// and treated as the literal string `svc-$1` instead of a capture
+// substitution. See internal/qlcommon/label_replace.go for the rule
+// table.
 func lowerLabelReplace(e *syntax.LabelReplaceExpr, s schema.Logs, lc lowerCtx) (chplan.Node, error) {
 	if e.Left == nil {
 		return nil, fmt.Errorf("logql: label_replace has nil inner")
@@ -39,7 +49,7 @@ func lowerLabelReplace(e *syntax.LabelReplaceExpr, s schema.Logs, lc lowerCtx) (
 	attrs := &chplan.LabelReplace{
 		Map:         &chplan.ColumnRef{Name: s.ResourceAttributesColumn},
 		Dst:         e.Dst,
-		Replacement: e.Replacement,
+		Replacement: qlcommon.ReplacementToCH(e.Replacement, e.Regex),
 		Src:         e.Src,
 		Regex:       e.Regex,
 	}

--- a/internal/promql/label_fns.go
+++ b/internal/promql/label_fns.go
@@ -2,12 +2,11 @@ package promql
 
 import (
 	"fmt"
-	"regexp"
-	"strings"
 
 	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/qlcommon"
 	"github.com/tsouza/cerberus/internal/schema"
 )
 
@@ -50,136 +49,11 @@ func lowerLabelReplace(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.N
 	attrs := &chplan.LabelReplace{
 		Map:         &chplan.ColumnRef{Name: s.AttributesColumn},
 		Dst:         dst,
-		Replacement: promReplacementToCH(replacement, regex),
+		Replacement: qlcommon.ReplacementToCH(replacement, regex),
 		Src:         src,
 		Regex:       regex,
 	}
 	return projectAttributesOverInner(inner, s, attrs), nil
-}
-
-// promReplacementToCH translates a PromQL `label_replace` replacement
-// template (Go-regexp `$1` / `${1}` / `$$` syntax) into the equivalent
-// ClickHouse `replaceRegexpOne` replacement (`\1` / `\\` syntax).
-//
-// Reference Prometheus runs the replacement through Go's
-// `regexp.Regexp.ExpandString`, which treats:
-//
-//   - `$$`            → literal `$`
-//   - `$N` / `${N}`   → numbered capture group N
-//   - `$name` / `${name}` → named capture group
-//
-// ClickHouse's `replaceRegexpOne` uses backslash escapes instead:
-//
-//   - `\\`            → literal backslash
-//   - `\0` … `\9`     → numbered capture group (`\0` = whole match)
-//
-// Without translation, a PromQL replacement like `"svc-$1"` is passed
-// to CH verbatim and emitted as the literal string `svc-$1` — the
-// capture group is never substituted.
-//
-// Translation rules implemented here (single-digit captures only — the
-// upstream PromQL `funcLabelReplace` doesn't constrain the index but
-// CH's backref syntax tops out at `\9`; multi-digit / named captures
-// are not used by any test or compatibility fixture and would need a
-// separate emit path):
-//
-//   - Pre-escape every existing `\` in the input to `\\`, so any
-//     literal backslash in the PromQL template survives as a literal
-//     backslash in CH (and is not re-interpreted as a CH backref by
-//     the digits we're about to introduce).
-//   - `$$` → `$` (literal dollar).
-//   - `$N` for a single ASCII digit (0-9) → `\N`.
-//   - `${N}` for a single ASCII digit (0-9) → `\N`.
-//   - Any other `$<x>` (including bare `$` at end-of-string, `$<letter>`,
-//     `${name}`, `$10` etc.) is preserved verbatim so we don't silently
-//     mistranslate a shape we don't fully support.
-//
-// regex is the regex string the replacement will be applied against;
-// it's used to count capture groups so out-of-range backrefs can be
-// rewritten to the empty string. CH validates `replaceRegexpOne`'s
-// substitution string against the regex's capture-group count at SQL-
-// parse time and rejects backrefs that exceed it (Code 36, BAD_ARGUMENTS)
-// — even on rows where match() short-circuits the if-branch that owns
-// the replaceRegexpOne call. PromQL's funcLabelReplace silently
-// substitutes the empty string for missing groups (Go's ExpandString
-// semantics); replacing the backref with "" preserves that observable
-// behaviour on the (unreachable) hot path and unblocks the SQL parser
-// on the (very-much-reachable) cold path where the regex doesn't match
-// anything.
-func promReplacementToCH(repl, regex string) string {
-	// First pass: double every literal backslash so CH sees them as
-	// "literal backslash" (`\\`) rather than the start of its own
-	// backref escape sequence after we splice `\N` in below.
-	escaped := strings.ReplaceAll(repl, `\`, `\\`)
-
-	// Count capture groups in the anchored regex (the same anchoring
-	// the SQL emitter applies). Best-effort: if Go's parser can't
-	// compile the regex, fall back to allowing every single-digit
-	// backref — the emit-path will surface the compile error to the
-	// client via CH's own parse stage.
-	const maxBackref = 9
-	allowed := maxBackref
-	if compiled, err := regexp.Compile("^" + regex + "$"); err == nil {
-		allowed = compiled.NumSubexp()
-	}
-
-	var b strings.Builder
-	b.Grow(len(escaped))
-	for i := 0; i < len(escaped); i++ {
-		c := escaped[i]
-		if c != '$' {
-			b.WriteByte(c)
-			continue
-		}
-		// Lone `$` at end of string — preserve.
-		if i+1 >= len(escaped) {
-			b.WriteByte('$')
-			continue
-		}
-		next := escaped[i+1]
-		switch {
-		case next == '$':
-			// `$$` → literal `$`.
-			b.WriteByte('$')
-			i++
-		case next >= '0' && next <= '9':
-			// `$N` → `\N` (single digit only — `$10` is preserved
-			// verbatim per upstream Go regexp semantics, but CH
-			// has no `\10`, so we'd mistranslate either way; preserving
-			// keeps the failure visible rather than silently wrong).
-			if i+2 < len(escaped) && escaped[i+2] >= '0' && escaped[i+2] <= '9' {
-				b.WriteByte('$')
-				continue
-			}
-			n := int(next - '0')
-			// `\0` references the whole match and is always valid; for
-			// numbered captures, only emit `\N` if the regex actually
-			// has N capture groups. Out-of-range refs are dropped so
-			// CH's substitution validator stays happy.
-			if n == 0 || n <= allowed {
-				b.WriteByte('\\')
-				b.WriteByte(next)
-			}
-			i++
-		case next == '{':
-			// `${N}` (single digit) → `\N`. Anything else (named
-			// captures, multi-digit indices) is preserved verbatim.
-			if i+3 < len(escaped) && escaped[i+2] >= '0' && escaped[i+2] <= '9' && escaped[i+3] == '}' {
-				n := int(escaped[i+2] - '0')
-				if n == 0 || n <= allowed {
-					b.WriteByte('\\')
-					b.WriteByte(escaped[i+2])
-				}
-				i += 3
-				continue
-			}
-			b.WriteByte('$')
-		default:
-			// `$<letter>` etc. — preserve verbatim.
-			b.WriteByte('$')
-		}
-	}
-	return b.String()
 }
 
 // lowerLabelJoin lowers

--- a/internal/qlcommon/label_replace.go
+++ b/internal/qlcommon/label_replace.go
@@ -1,0 +1,138 @@
+// Package qlcommon hosts small, lowering-layer helpers shared across
+// the PromQL / LogQL / TraceQL heads. Functions here translate
+// upstream-QL semantics into shapes the shared chplan IR + the chsql
+// emitter expect, so each language's lowering can stay focused on its
+// own AST.
+package qlcommon
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ReplacementToCH translates a Go-`regexp` replacement template
+// (`$1` / `${1}` / `$$` syntax — used by both PromQL's
+// `label_replace` and LogQL's `label_replace` per their reference
+// implementations) into the equivalent ClickHouse `replaceRegexpOne`
+// replacement (`\1` / `\\` syntax).
+//
+// PromQL runs the replacement through Go's `regexp.Regexp.ExpandString`;
+// LogQL's `label_replace` does the same. Both treat:
+//
+//   - `$$`            → literal `$`
+//   - `$N` / `${N}`   → numbered capture group N
+//   - `$name` / `${name}` → named capture group
+//
+// ClickHouse's `replaceRegexpOne` uses backslash escapes instead:
+//
+//   - `\\`            → literal backslash
+//   - `\0` … `\9`     → numbered capture group (`\0` = whole match)
+//
+// Without translation, a replacement like `"svc-$1"` is passed to CH
+// verbatim and emitted as the literal string `svc-$1` — the capture
+// group is never substituted.
+//
+// Translation rules implemented here (single-digit captures only — the
+// upstream label_replace functions don't constrain the index but CH's
+// backref syntax tops out at `\9`; multi-digit / named captures are
+// not used by any test or compatibility fixture and would need a
+// separate emit path):
+//
+//   - Pre-escape every existing `\` in the input to `\\`, so any
+//     literal backslash in the QL template survives as a literal
+//     backslash in CH (and is not re-interpreted as a CH backref by
+//     the digits we're about to introduce).
+//   - `$$` → `$` (literal dollar).
+//   - `$N` for a single ASCII digit (0-9) → `\N`.
+//   - `${N}` for a single ASCII digit (0-9) → `\N`.
+//   - Any other `$<x>` (including bare `$` at end-of-string, `$<letter>`,
+//     `${name}`, `$10` etc.) is preserved verbatim so we don't silently
+//     mistranslate a shape we don't fully support.
+//
+// regex is the regex string the replacement will be applied against;
+// it's used to count capture groups so out-of-range backrefs can be
+// rewritten to the empty string. CH validates `replaceRegexpOne`'s
+// substitution string against the regex's capture-group count at SQL-
+// parse time and rejects backrefs that exceed it (Code 36, BAD_ARGUMENTS)
+// — even on rows where match() short-circuits the if-branch that owns
+// the replaceRegexpOne call. The upstream QL semantics silently
+// substitute the empty string for missing groups (Go's ExpandString
+// semantics); replacing the backref with "" preserves that observable
+// behaviour on the (unreachable) hot path and unblocks the SQL parser
+// on the (very-much-reachable) cold path where the regex doesn't match
+// anything.
+func ReplacementToCH(repl, regex string) string {
+	// First pass: double every literal backslash so CH sees them as
+	// "literal backslash" (`\\`) rather than the start of its own
+	// backref escape sequence after we splice `\N` in below.
+	escaped := strings.ReplaceAll(repl, `\`, `\\`)
+
+	// Count capture groups in the anchored regex (the same anchoring
+	// the SQL emitter applies). Best-effort: if Go's parser can't
+	// compile the regex, fall back to allowing every single-digit
+	// backref — the emit-path will surface the compile error to the
+	// client via CH's own parse stage.
+	const maxBackref = 9
+	allowed := maxBackref
+	if compiled, err := regexp.Compile("^" + regex + "$"); err == nil {
+		allowed = compiled.NumSubexp()
+	}
+
+	var b strings.Builder
+	b.Grow(len(escaped))
+	for i := 0; i < len(escaped); i++ {
+		c := escaped[i]
+		if c != '$' {
+			b.WriteByte(c)
+			continue
+		}
+		// Lone `$` at end of string — preserve.
+		if i+1 >= len(escaped) {
+			b.WriteByte('$')
+			continue
+		}
+		next := escaped[i+1]
+		switch {
+		case next == '$':
+			// `$$` → literal `$`.
+			b.WriteByte('$')
+			i++
+		case next >= '0' && next <= '9':
+			// `$N` → `\N` (single digit only — `$10` is preserved
+			// verbatim per upstream Go regexp semantics, but CH
+			// has no `\10`, so we'd mistranslate either way; preserving
+			// keeps the failure visible rather than silently wrong).
+			if i+2 < len(escaped) && escaped[i+2] >= '0' && escaped[i+2] <= '9' {
+				b.WriteByte('$')
+				continue
+			}
+			n := int(next - '0')
+			// `\0` references the whole match and is always valid; for
+			// numbered captures, only emit `\N` if the regex actually
+			// has N capture groups. Out-of-range refs are dropped so
+			// CH's substitution validator stays happy.
+			if n == 0 || n <= allowed {
+				b.WriteByte('\\')
+				b.WriteByte(next)
+			}
+			i++
+		case next == '{':
+			// `${N}` (single digit) → `\N`. Anything else (named
+			// captures, multi-digit indices) is preserved verbatim.
+			if i+3 < len(escaped) && escaped[i+2] >= '0' && escaped[i+2] <= '9' && escaped[i+3] == '}' {
+				n := int(escaped[i+2] - '0')
+				if n == 0 || n <= allowed {
+					b.WriteByte('\\')
+					b.WriteByte(escaped[i+2])
+				}
+				i += 3
+				continue
+			}
+			b.WriteByte('$')
+		default:
+			// `$<letter>` etc. — preserve verbatim.
+			b.WriteByte('$')
+		}
+	}
+	return b.String()
+}

--- a/internal/qlcommon/label_replace_test.go
+++ b/internal/qlcommon/label_replace_test.go
@@ -1,4 +1,4 @@
-package promql
+package qlcommon
 
 import "testing"
 
@@ -8,14 +8,14 @@ import "testing"
 // because this regex has all 9 groups.
 const nineCaptureRegex = `(.)(.)(.)(.)(.)(.)(.)(.)(.)`
 
-// TestPromReplacementToCH locks down the PromQL → ClickHouse replacement
-// template rewrite that label_replace relies on. PromQL uses Go's
-// `regexp.Regexp.ExpandString` syntax (`$1`, `${1}`, `$$`); CH's
-// `replaceRegexpOne` uses backslash escapes (`\1`, `\\`). Without the
-// rewrite, capture-group references are emitted as literal `$N` text and
-// the substituted label value is wrong (e.g., `svc-$1` instead of
-// `svc-prod`).
-func TestPromReplacementToCH(t *testing.T) {
+// TestReplacementToCH locks down the QL → ClickHouse replacement
+// template rewrite that PromQL + LogQL `label_replace` both rely on.
+// Both QLs use Go's `regexp.Regexp.ExpandString` syntax (`$1`,
+// `${1}`, `$$`); CH's `replaceRegexpOne` uses backslash escapes
+// (`\1`, `\\`). Without the rewrite, capture-group references are
+// emitted as literal `$N` text and the substituted label value is
+// wrong (e.g., `svc-$1` instead of `svc-prod`).
+func TestReplacementToCH(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -41,7 +41,7 @@ func TestPromReplacementToCH(t *testing.T) {
 		{"existing_backslash_escaped", `\1`, nineCaptureRegex, `\\1`},
 		{"existing_backslash_and_backref", `\$1`, nineCaptureRegex, `\\\1`},
 		// Out-of-range backrefs drop. The regex has 0 capture groups,
-		// so `$1` (the PromQL backref) has no source — Prom's
+		// so `$1` (the QL backref) has no source — Prom/Loki's
 		// ExpandString substitutes the empty string. CH's
 		// replaceRegexpOne rejects `\1` against a 0-group regex at
 		// SQL-parse time even when match() short-circuits the call,
@@ -63,9 +63,9 @@ func TestPromReplacementToCH(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got := promReplacementToCH(tc.in, tc.regex)
+			got := ReplacementToCH(tc.in, tc.regex)
 			if got != tc.want {
-				t.Fatalf("promReplacementToCH(%q, %q): got %q, want %q",
+				t.Fatalf("ReplacementToCH(%q, %q): got %q, want %q",
 					tc.in, tc.regex, got, tc.want)
 			}
 		})

--- a/test/spec/logql/label_replace_basic.txtar
+++ b/test/spec/logql/label_replace_basic.txtar
@@ -6,7 +6,7 @@ label_replace(count_over_time({service_name="api"}[5m]), "newlabel", "$1", "serv
 [2] string = "newlabel"
 [3] string = "service_name"
 [4] string = "^(.+)$"
-[5] string = "$1"
+[5] string = "\\1"
 [6] int64 = 1
 [7] string = "service_name"
 [8] string = "api"
@@ -25,7 +25,7 @@ INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
   [{"service_name": "api", "newlabel": "api"}, 3.0]
 ]
 -- chplan --
-Project [labelReplace(ResourceAttributes, dst="newlabel", replacement="$1", src="service_name", regex="(.+)") AS ResourceAttributes, Value]
+Project [labelReplace(ResourceAttributes, dst="newlabel", replacement="\\1", src="service_name", regex="(.+)") AS ResourceAttributes, Value]
   RangeWindow func=count_over_time range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
     Project [ResourceAttributes, Timestamp, 1 AS Value]
       Filter predicate=(ResourceAttributes["service_name"] = "api")


### PR DESCRIPTION
## Summary

`test/spec/logql/label_replace_basic.txtar` has been failing on `main` for a while — confirmed by two prior pool investigations (Pool-AN, Pool-AP) that ran into it as an unrelated pre-existing failure. Root cause: LogQL's `label_replace` lowering passes the replacement string raw to ClickHouse, but PromQL's `label_replace` uses Go-regexp `$N` backrefs while CH's `replaceRegexpOne` uses `\N`. PromQL got the fix in #316 (first cut) and #349 (capture-count-aware drop of out-of-range backrefs); **LogQL never received the same translation** — so a query like `label_replace(count_over_time({...}[5m]), "newlabel", "$1", "service_name", "(.+)")` emitted `replaceRegexpOne(..., '(.+)', '$1')` and CH treated `$1` as the literal two-character string `$1`, never as capture group 1.

This PR ports the existing PromQL translator to LogQL, extracting it to a shared helper so neither head re-implements it.

- New package `internal/qlcommon` hosts `ReplacementToCH(repl, regex string) string` — the same body as PromQL's old unexported `promReplacementToCH`. The table-driven test moves with it (renamed `TestReplacementToCH`).
- `internal/promql/label_fns.go::lowerLabelReplace` now calls `qlcommon.ReplacementToCH` instead of the local copy.
- `internal/logql/label_fns.go::lowerLabelReplace` calls the same helper. Loki's parser already pre-extracts the four `label_replace` strings (`Dst`, `Replacement`, `Src`, `Regex`) on `syntax.LabelReplaceExpr`, so the wiring is a one-line change at the IR-build site.

The translator handles the full Go-`regexp.Regexp.ExpandString` shape both PromQL and LogQL reference impls use:
- `$$` → literal `$`
- `$N` / `${N}` (single digit) → `\N`
- Out-of-range backrefs drop (PromQL precedent in #349 — CH's `replaceRegexpOne` substitution validator rejects backrefs that exceed the regex's capture count at SQL-parse time, even on rows where `match()` short-circuits)
- Literal `\` survives intact (pre-escaped to `\\`)
- Named / multi-digit captures preserved verbatim (no QL fixture uses them)

## Before / after for `label_replace_basic.txtar`

Query: `label_replace(count_over_time({service_name="api"}[5m]), "newlabel", "$1", "service_name", "(.+)")`

The SQL shape is unchanged — `replaceRegexpOne(\`ResourceAttributes\`[?], ?, ?)` — but the `?` for the replacement string is bound to a different value:

**Before** (recorded `args` section):
```
[5] string = "$1"
```

CH parses `$1` as the literal characters `$` + `1` and the substituted label value is wrong.

**After**:
```
[5] string = "\\1"
```

CH sees `\1` and substitutes capture group 1. The chplan IR rendering moves in lock-step: `replacement="$1"` → `replacement="\\1"`.

The chDB roundtrip (which previously failed because the literal `$1` substitution produced `{"newlabel": "$1"}` instead of `{"newlabel": "api"}`) now passes.

## Test plan

- [x] `go test ./internal/qlcommon/...` — 21 PASS (the moved + renamed table-driven coverage of every PromQL/LogQL backref shape).
- [x] `go test ./internal/promql/...` — 519 PASS (the existing PromQL lower + label_fns coverage stays green after the refactor).
- [x] `go test ./internal/logql/...` — 188 PASS (the LogQL spec walker now passes `label_replace_basic` — previously failed on `args` section mismatch).
- [x] `go test -tags chdb ./test/spec/logql/` — 69 PASS (the chDB roundtrip lane for every LogQL fixture; `label_replace_basic` was the failing case and now passes end-to-end seed → SQL → expected rows).
- [x] `go test -tags chdb ./test/spec/promql/` — 194 PASS.
- [x] `go test -tags chdb ./internal/api/loki/ ./internal/api/prom/` — 390 PASS.