### PR TITLE
fix(promql): absent_over_time synthesizes matcher labels per Prom

### DIFF
--- a/internal/chplan/absent_over_time.go
+++ b/internal/chplan/absent_over_time.go
@@ -1,0 +1,150 @@
+package chplan
+
+import "time"
+
+// SynthLabel is a single (key, value) entry on the synthesised label
+// set emitted by AbsentOverTime for the per-anchor absence rows. The
+// pair is rendered as two consecutive arguments to ClickHouse's `map(
+// k1, v1, k2, v2, ...)` constructor.
+type SynthLabel struct {
+	Key   string
+	Value string
+}
+
+// AbsentOverTime is the dedicated plan node for PromQL
+// `absent_over_time(<vector-selector>[<range>])`. It mirrors the
+// instant-vector `absent(...)` lowering (see internal/promql/absent.go)
+// but operates per evaluation anchor: for every step anchor that has
+// zero matching samples in the lookback window `(anchor - Range,
+// anchor]`, emit one row with the matcher-derived synthesised label
+// set, the anchor timestamp on TimestampColumn, and a constant value
+// of 1 on ValueColumn.
+//
+// Per Prometheus's `funcAbsentOverTime` (see
+// prometheus/promql/functions.go), the output is a SINGLE synthesised
+// series (not one per input series): the label set is constructed
+// only from the equality matchers explicitly named on the input
+// selector (mirroring `createLabelsForAbsentFunction`). The samples
+// of that single series are placed at exactly the anchors where the
+// underlying selector has zero matching samples in its lookback
+// window. Anchors with any sample contribute no output.
+//
+// Cerberus's previous implementation routed `absent_over_time` through
+// the regular per-series RangeWindow path which emitted one row per
+// (input series, anchor) with `if(length(window_vals) > 0, NaN, 1.0)`
+// as the value — carrying the original series labels instead of the
+// matcher-derived synthesised labels. That produced six diffs in the
+// prometheus/compliance lane (see Bucket 4 of
+// docs/compat-residual-audit-25898791664.md): wrong labels AND extra
+// per-series NaN rows the matrix pivot didn't drop.
+//
+// The shape this node renders:
+//
+//	SELECT '' AS MetricName,
+//	       <synth-labels-map> AS Attributes,
+//	       anchor_ts AS TimeUnix,
+//	       toFloat64(1) AS Value
+//	FROM (
+//	    SELECT arrayJoin(<step grid>) AS anchor_ts, sample_ts_arr
+//	    FROM (
+//	        SELECT groupArray(`TimeUnix`) AS sample_ts_arr
+//	        FROM (<matcher-filtered scan>)
+//	        WHERE TimeUnix > '<start - range>' AND TimeUnix <= '<end>'
+//	    )
+//	) WHERE arrayCount(t -> t > anchor_ts - toIntervalNanosecond(<range_ns>)
+//	                        AND t <= anchor_ts,
+//	                   sample_ts_arr) = 0
+//
+// The inner `groupArray(TimeUnix) FROM (<scan>) GROUP BY ()` always
+// produces exactly one row — including the case where the matcher
+// scan returns zero rows, which yields `sample_ts_arr = []` and lets
+// every step anchor in the outer arrayJoin survive the WHERE clause.
+// Without that 1-row guarantee, a totally absent metric would CROSS
+// JOIN-collapse to zero output rows and we'd lose the "absent at
+// every anchor" signal Prom synthesises.
+type AbsentOverTime struct {
+	// Input is the matcher-filtered scan (Filter wrapping Scan in the
+	// canonical case). The emitter wraps it in a `SELECT groupArray(
+	// TimestampColumn) FROM (<Input>) WHERE TimestampColumn IN [Start
+	// - Range, End]` and projects the resulting `sample_ts_arr` array
+	// across the step grid.
+	Input Node
+
+	// SynthLabels is the matcher-derived label set rendered onto every
+	// emitted output row. Built by the lowering via the same rule
+	// `absentAttrsMap` uses for instant `absent(...)`: include only
+	// equality matchers, skip `__name__`, drop labels appearing more
+	// than once. Empty SynthLabels render as `CAST(map(), 'Map(String,
+	// String)')` — the canonical empty-attrs map shape.
+	SynthLabels []SynthLabel
+
+	// Range is the PromQL `[range]` window. The per-anchor lookback
+	// is `(anchor - Range, anchor]`.
+	Range time.Duration
+
+	// Start / End define the query evaluation grid. For range queries
+	// the emitter walks anchors `Start, Start+Step, …, End` (inclusive);
+	// for instant queries Start == End == eval-anchor and Step is 0.
+	Start, End time.Time
+
+	// Step is the eval-grid spacing. Zero means instant mode — the
+	// emitter emits a single anchor at End.
+	Step time.Duration
+
+	// Offset is the PromQL `offset` modifier shifted onto the inner
+	// VectorSelector. Subtracted from each anchor at emit time so the
+	// window becomes `(anchor - Offset - Range, anchor - Offset]`.
+	Offset time.Duration
+
+	// TimestampColumn names the column carrying the per-sample
+	// timestamp on Input (typically `TimeUnix` for OTel-CH).
+	TimestampColumn string
+
+	// ValueColumn names the value column emitted on the output row
+	// (typically `Value` for OTel-CH). The value itself is the
+	// constant 1.0, wrapped in `toFloat64(...)` so the driver projects
+	// Float64 on the wire (mirrors the instant `absent` lowering).
+	ValueColumn string
+
+	// MetricNameColumn names the column carrying the metric name on
+	// the output sample shape (typically `MetricName` for OTel-CH).
+	// Always projected as the empty string — Prom's funcAbsentOverTime
+	// drops `__name__` from the synthesised output.
+	MetricNameColumn string
+
+	// AttributesColumn names the column carrying the label map on
+	// the output sample shape (typically `Attributes` for OTel-CH).
+	AttributesColumn string
+}
+
+func (*AbsentOverTime) planNode() {}
+
+func (a *AbsentOverTime) Children() []Node { return []Node{a.Input} }
+
+func (a *AbsentOverTime) Equal(other Node) bool {
+	o, ok := other.(*AbsentOverTime)
+	if !ok {
+		return false
+	}
+	if a.Range != o.Range || a.Step != o.Step || a.Offset != o.Offset {
+		return false
+	}
+	if !a.Start.Equal(o.Start) || !a.End.Equal(o.End) {
+		return false
+	}
+	if a.TimestampColumn != o.TimestampColumn ||
+		a.ValueColumn != o.ValueColumn ||
+		a.MetricNameColumn != o.MetricNameColumn ||
+		a.AttributesColumn != o.AttributesColumn {
+		return false
+	}
+	if len(a.SynthLabels) != len(o.SynthLabels) {
+		return false
+	}
+	for i := range a.SynthLabels {
+		if a.SynthLabels[i] != o.SynthLabels[i] {
+			return false
+		}
+	}
+	return a.Input.Equal(o.Input)
+}

--- a/internal/chplan/equal_invariants_test.go
+++ b/internal/chplan/equal_invariants_test.go
@@ -449,6 +449,67 @@ func TestRangeWindow_Equal_Negative_StartEnd(t *testing.T) {
 	}
 }
 
+func TestAbsentOverTime_Equal_Positive(t *testing.T) {
+	t.Parallel()
+	build := func() *chplan.AbsentOverTime {
+		return &chplan.AbsentOverTime{
+			Input:            &chplan.Scan{Table: "otel_metrics_gauge"},
+			SynthLabels:      []chplan.SynthLabel{{Key: "job", Value: "x"}},
+			Range:            5 * time.Minute,
+			Step:             time.Minute,
+			TimestampColumn:  "TimeUnix",
+			ValueColumn:      "Value",
+			MetricNameColumn: "MetricName",
+			AttributesColumn: "Attributes",
+		}
+	}
+	if !build().Equal(build()) {
+		t.Fatalf("identical AbsentOverTime trees should be Equal")
+	}
+}
+
+func TestAbsentOverTime_Equal_Negative_Range(t *testing.T) {
+	t.Parallel()
+	a := &chplan.AbsentOverTime{Input: &chplan.Scan{Table: "t"}, Range: time.Minute}
+	b := &chplan.AbsentOverTime{Input: &chplan.Scan{Table: "t"}, Range: 5 * time.Minute}
+	if a.Equal(b) {
+		t.Errorf("different Range should not be Equal")
+	}
+}
+
+func TestAbsentOverTime_Equal_Negative_Step(t *testing.T) {
+	t.Parallel()
+	a := &chplan.AbsentOverTime{Input: &chplan.Scan{Table: "t"}, Step: time.Minute}
+	b := &chplan.AbsentOverTime{Input: &chplan.Scan{Table: "t"}, Step: time.Second}
+	if a.Equal(b) {
+		t.Errorf("different Step should not be Equal")
+	}
+}
+
+func TestAbsentOverTime_Equal_Negative_SynthLabels(t *testing.T) {
+	t.Parallel()
+	a := &chplan.AbsentOverTime{
+		Input:       &chplan.Scan{Table: "t"},
+		SynthLabels: []chplan.SynthLabel{{Key: "job", Value: "x"}},
+	}
+	b := &chplan.AbsentOverTime{
+		Input:       &chplan.Scan{Table: "t"},
+		SynthLabels: []chplan.SynthLabel{{Key: "job", Value: "y"}},
+	}
+	if a.Equal(b) {
+		t.Errorf("different SynthLabels should not be Equal")
+	}
+}
+
+func TestAbsentOverTime_Equal_Negative_Input(t *testing.T) {
+	t.Parallel()
+	a := &chplan.AbsentOverTime{Input: &chplan.Scan{Table: "a"}}
+	b := &chplan.AbsentOverTime{Input: &chplan.Scan{Table: "b"}}
+	if a.Equal(b) {
+		t.Errorf("different Input should not be Equal")
+	}
+}
+
 func TestLimit_Equal_Positive(t *testing.T) {
 	t.Parallel()
 	a := &chplan.Limit{Input: &chplan.Scan{Table: "t"}, Count: 100}

--- a/internal/chsql/absent_over_time.go
+++ b/internal/chsql/absent_over_time.go
@@ -1,0 +1,211 @@
+package chsql
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// emitAbsentOverTime renders the SQL for PromQL `absent_over_time(
+// <vector-selector>[<range>])`. Mirrors the instant `absent(...)`
+// lowering (see internal/promql/absent.go) but threads a per-anchor
+// lookback-window check: emit one row PER STEP ANCHOR whose
+// `(anchor - Range, anchor]` window has zero matching samples, with
+// the matcher-derived synthesised labels lifted onto the output series.
+//
+// SQL shape (range mode — Step > 0):
+//
+//	SELECT '' AS `MetricName`,
+//	       <synthesised-attributes-map> AS `Attributes`,
+//	       `anchor_ts` AS `TimeUnix`,
+//	       toFloat64(?) AS `Value`
+//	FROM (
+//	    SELECT `anchor_ts`
+//	    FROM (
+//	        SELECT arrayJoin(arrayMap(i -> '<start>' + i * <step_ns>,
+//	                                  range(0, <N>))) AS `anchor_ts`,
+//	               `sample_ts_arr`
+//	        FROM (
+//	            SELECT groupArray(`TimeUnix`) AS `sample_ts_arr`
+//	            FROM (<matcher-filtered scan>)
+//	            WHERE `TimeUnix` > '<global-start - range>'
+//	              AND `TimeUnix` <= '<global-end>'
+//	        )
+//	    )
+//	    WHERE arrayCount(t -> t > `anchor_ts` - toIntervalNanosecond(<range_ns>)
+//	                            AND t <= `anchor_ts`,
+//	                     `sample_ts_arr`) = 0
+//	)
+//
+// The inner `groupArray + GROUP BY ()` always emits exactly one row —
+// even when the matcher scan returns zero rows, in which case
+// `sample_ts_arr = []` and every anchor in the outer arrayJoin
+// survives the WHERE clause (the desired "absent at every anchor"
+// signal).
+//
+// SQL shape (instant mode — Step == 0): same structure but the
+// `anchor_ts` projection is the single `<end>` literal (no arrayJoin
+// fanout) and the WHERE filters one row at most.
+//
+// The output is the canonical 4-column Sample shape (MetricName,
+// Attributes, TimeUnix, Value) so it streams through the cursor and
+// matrix pivot like any other PromQL plan. MetricName is always the
+// empty string (Prom's funcAbsentOverTime drops `__name__`).
+//
+// All bound args ride positional `?` placeholders; the inline literals
+// (anchor base, step / range / offset in nanoseconds, anchor count)
+// are part of the query SHAPE — CH's sort-key pruning needs them
+// visible to the planner and parameterising them would force CH to
+// re-plan per request.
+func (e *emitter) emitAbsentOverTime(a *chplan.AbsentOverTime) error {
+	inner, err := e.subqueryFrag(a.Input)
+	if err != nil {
+		return err
+	}
+
+	rangeNS := a.Range.Nanoseconds()
+	offsetNS := a.Offset.Nanoseconds()
+
+	// `endFrag` is the upper bookend of the global window (latest
+	// anchor); `prefilterStartFrag` is the LOWER bookend the global
+	// prefilter uses to bound the inner scan to a range relevant to
+	// any anchor's lookback. In range mode that's `a.Start` (the
+	// earliest anchor); in instant mode there is only one anchor at
+	// `a.End`, so the prefilter's lower bound is `a.End - Range`.
+	endFrag := absentOverTimeBookendFrag(a.End, offsetNS)
+	prefilterStartFrag := endFrag
+	if a.Step > 0 {
+		prefilterStartFrag = absentOverTimeBookendFrag(a.Start, offsetNS)
+	}
+
+	// Step grid: in range mode (Step > 0) emit one row per anchor via
+	// arrayJoin(arrayMap(i -> start + i*step, range(0, N))); in
+	// instant mode (Step == 0) emit a single anchor at End.
+	var anchorFrag Frag
+	if a.Step > 0 {
+		stepNS := a.Step.Nanoseconds()
+		numAnchors := a.End.Sub(a.Start).Nanoseconds()/stepNS + 1
+		if numAnchors < 1 {
+			numAnchors = 1
+		}
+		// The arrayJoin fanout walks the step grid starting from
+		// `a.Start` (offset-adjusted by prefilterStartFrag); see
+		// absentOverTimeAnchorRangeFrag.
+		anchorFrag = absentOverTimeAnchorRangeFrag(prefilterStartFrag, stepNS, numAnchors)
+	} else {
+		anchorFrag = endFrag
+	}
+
+	// Innermost: groupArray of the per-sample timestamps, prefiltered
+	// to the global window `(<prefilterStart> - Range, <end>]`. The
+	// 1-row Aggregate (no GROUP BY) is emitted directly here rather
+	// than going through chplan.Aggregate because we want CH's default
+	// 1-row-of-empty-array shape on an empty input (groupArray over no
+	// rows = `[]`).
+	innermost := NewQuery().
+		From(inner).
+		Select(As(Call("groupArray", Col(a.TimestampColumn)), "sample_ts_arr")).
+		Where(And(
+			Gt(Col(a.TimestampColumn),
+				Sub(prefilterStartFrag, Call("toIntervalNanosecond", InlineLit(rangeNS)))),
+			Lte(Col(a.TimestampColumn), endFrag),
+		))
+
+	// Anchor fanout: project anchor_ts (literal in instant mode,
+	// arrayJoin'd step grid in range mode) alongside the single-row
+	// `sample_ts_arr`.
+	fanout := NewQuery().
+		From(innermost.Frag()).
+		Select(As(anchorFrag, "anchor_ts")).
+		Select(BareIdent("sample_ts_arr"))
+
+	// Outer filter: keep only anchors whose lookback window has zero
+	// matching samples. The lambda body is `t > anchor_ts -
+	// toIntervalNanosecond(<rangeNS>) AND t <= anchor_ts`.
+	windowLambda := Lambda1("t", And(
+		Gt(BareIdent("t"),
+			Sub(BareIdent("anchor_ts"),
+				Call("toIntervalNanosecond", InlineLit(rangeNS)))),
+		Lte(BareIdent("t"), BareIdent("anchor_ts")),
+	))
+	emptyWindow := NewQuery().
+		From(fanout.Frag()).
+		Select(BareIdent("anchor_ts")).
+		Where(Eq(
+			Call("arrayCount", windowLambda, BareIdent("sample_ts_arr")),
+			InlineLit(int64(0)),
+		))
+
+	// Synth Project: re-shape to the canonical Sample 4-column output.
+	// MetricName is bound as a `?` placeholder so the driver sees a
+	// String column on the wire (Prom drops `__name__` from
+	// funcAbsentOverTime). The Attributes map is built from the
+	// matcher-derived synth-labels; an empty list renders as the
+	// canonical `CAST(map(), 'Map(String,String)')` shape.
+	outer := NewQuery().
+		From(emptyWindow.Frag()).
+		Select(As(Lit(""), a.MetricNameColumn)).
+		Select(As(synthAttrsMapFrag(a.SynthLabels), a.AttributesColumn)).
+		Select(As(BareIdent("anchor_ts"), a.TimestampColumn)).
+		Select(As(Call("toFloat64", Lit(float64(1))), a.ValueColumn))
+
+	e.emitSelect(outer)
+	return nil
+}
+
+// absentOverTimeBookendFrag returns a Frag rendering the eval-grid
+// bookend `t` with the PromQL `offset` modifier folded in. Zero `t`
+// falls back to `now64(9)`. A non-zero offsetNS wraps the bookend in
+// `(<bookend> - toIntervalNanosecond(<offsetNS>))`.
+func absentOverTimeBookendFrag(t time.Time, offsetNS int64) Frag {
+	base := timeOrNowFrag(t)
+	if offsetNS == 0 {
+		return base
+	}
+	return func(b *Builder) {
+		b.sb.WriteByte('(')
+		base(b)
+		b.sb.WriteString(" - toIntervalNanosecond(")
+		b.sb.WriteString(strconv.FormatInt(offsetNS, 10))
+		b.sb.WriteString("))")
+	}
+}
+
+// absentOverTimeAnchorRangeFrag returns a Frag rendering
+// `arrayJoin(arrayMap(i -> <start> + i * <stepNS>, range(0, <N>)))`
+// — the step-grid fan-out for the range-mode absent_over_time
+// emission. The anchor base is `<start>` (NOT `<end>`), matching the
+// Prom range-query convention where anchors walk forward from the
+// query's `start` to its `end`.
+func absentOverTimeAnchorRangeFrag(start Frag, stepNS, numAnchors int64) Frag {
+	return func(b *Builder) {
+		b.sb.WriteString("arrayJoin(arrayMap(i -> ")
+		start(b)
+		b.sb.WriteString(" + toIntervalNanosecond(i * ")
+		b.sb.WriteString(strconv.FormatInt(stepNS, 10))
+		b.sb.WriteString("), range(0, ")
+		b.sb.WriteString(strconv.FormatInt(numAnchors, 10))
+		b.sb.WriteString(")))")
+	}
+}
+
+// synthAttrsMapFrag renders the matcher-derived label set as a CH
+// `Map(String, String)` value. Mirrors `internal/promql/lower.go`'s
+// `emptyAttrsMap` shape: an empty list yields `CAST(map(), ?)` with
+// the type name `'Map(String,String)'` parameterised as a `?`-bound
+// string (chDB accepts the two-arg `CAST(value, type)` shape; the
+// SQL-standard `CAST(value AS type)` syntax requires the type-name
+// to be an unquoted identifier which the parameter binding path
+// can't supply). Non-empty labels emit `map(?, ?, ?, ?, ...)` with
+// each key + value parameterised as `?`.
+func synthAttrsMapFrag(labels []chplan.SynthLabel) Frag {
+	if len(labels) == 0 {
+		return Call("CAST", Call("map"), Lit("Map(String,String)"))
+	}
+	args := make([]Frag, 0, len(labels)*2)
+	for _, kv := range labels {
+		args = append(args, Lit(kv.Key), Lit(kv.Value))
+	}
+	return Call("map", args...)
+}

--- a/internal/chsql/emit.go
+++ b/internal/chsql/emit.go
@@ -80,6 +80,8 @@ func (e *emitter) emitNode(n chplan.Node) error {
 		return e.emitMetricsHistogramOverTime(v)
 	case *chplan.RangeWindow:
 		return e.emitRangeWindow(v)
+	case *chplan.AbsentOverTime:
+		return e.emitAbsentOverTime(v)
 	case *chplan.HistogramQuantile:
 		return e.emitHistogramQuantile(v)
 	case *chplan.HistogramQuantileNative:

--- a/internal/chsql/range_window.go
+++ b/internal/chsql/range_window.go
@@ -176,8 +176,6 @@ func (e *emitter) emitRangeWindow(r *chplan.RangeWindow) error {
 		return e.emitRangeWindowPredictLinear(r)
 	case "holt_winters":
 		return e.emitRangeWindowHoltWinters(r)
-	case "absent_over_time":
-		return e.emitRangeWindowAbsentOverTime(r)
 	case "deriv":
 		return e.emitRangeWindowDeriv(r)
 	case "resets":
@@ -1002,34 +1000,6 @@ func (e *emitter) emitRangeWindowOverTime(r *chplan.RangeWindow) error {
 	// short-circuit on zero samples). The outer SELECT gets
 	// `WHERE length(window_vals) >= 1`.
 	return e.emitWindowedArray(r, verbatim(inner), 1)
-}
-
-// emitRangeWindowAbsentOverTime emits SQL for `absent_over_time(v[range])`.
-//
-// PromQL semantics: returns 1 (with synthesised labels derived from the
-// selector matchers) when the lookback window contains zero samples;
-// returns no result when any sample is present.
-//
-// The fully-faithful "synthesise labels for the empty-input case" path
-// requires post-emit engine handling (Prom's funcAbsentOverTime is one
-// of three engine-specialised functions, alongside absent and present_
-// over_time — see internal/engine.go's `absent_over_time` switch in
-// the upstream parser). At the per-series RangeWindow layer the most
-// we can do is emit `1.0` for series whose window happens to be empty
-// (matching Prom's per-series no-data path) and NaN for series with at
-// least one sample (engine layer treats NaN as drop). The "no series at
-// all" case (where Prom synthesises the matcher-derived labels) lands
-// alongside the engine-side absent() implementation.
-//
-// minWindowSize stays at 0 so empty windows DO emit a row — the very
-// shape we want for the "absent" branch to materialise.
-func (e *emitter) emitRangeWindowAbsentOverTime(r *chplan.RangeWindow) error {
-	value := If(
-		Gt(Call("length", BareIdent("window_vals")), InlineLit(int64(0))),
-		verbatim("nan"),
-		verbatim("1.0"),
-	)
-	return e.emitWindowedArray(r, value, 0)
 }
 
 // emitRangeWindowDeriv emits SQL for `deriv(v[range])`.

--- a/internal/chsql/range_window_test.go
+++ b/internal/chsql/range_window_test.go
@@ -10,9 +10,13 @@ import (
 )
 
 // TestRangeWindowGapFunctionsEmit asserts the per-function value
-// expression for the five compatibility-lane gaps closed in this PR:
+// expression for the four compatibility-lane gaps closed in the
+// original five-function batch that this test was carved out of.
+// `absent_over_time` graduated to a dedicated chplan.AbsentOverTime
+// node (see TestAbsentOverTimeEmit) because the per-series RangeWindow
+// shape can't synthesise the matcher-derived label set Prom's
+// funcAbsentOverTime emits.
 //
-//   - absent_over_time → if(length(window_vals) > 0, nan, 1.0)
 //   - stdvar_over_time → arrayReduce('varPop', window_vals)
 //   - deriv            → tupleElement(arrayReduce('simpleLinearRegression', xs, ys), 1)
 //   - resets           → count of adjacent pairs where curr < prev
@@ -40,17 +44,6 @@ func TestRangeWindowGapFunctionsEmit(t *testing.T) {
 		fn          string
 		wantSubstrs []string
 	}{
-		{
-			name: "absent_over_time",
-			fn:   "absent_over_time",
-			wantSubstrs: []string{
-				// Per-series guard: empty window → 1.0, populated window → nan.
-				"if(length(window_vals) > 0, nan, 1.0)",
-				// minWindowSize=0 — empty windows DO produce a row;
-				// the outer SELECT must NOT carry a WHERE filter.
-				// Spot-check that no `WHERE length(...)` clause appears.
-			},
-		},
 		{
 			name: "stdvar_over_time",
 			fn:   "stdvar_over_time",
@@ -119,29 +112,5 @@ func TestRangeWindowGapFunctionsEmit(t *testing.T) {
 				}
 			}
 		})
-	}
-}
-
-// TestRangeWindowAbsentOverTimeNoWindowFilter pins the minWindowSize=0
-// contract for absent_over_time: the outer SELECT must NOT carry a
-// `WHERE length(window_vals) >= N` filter, because the entire point of
-// the function is to project a value when the window is empty. Every
-// other RangeWindow function has the filter on; this test guards that
-// inversion.
-func TestRangeWindowAbsentOverTimeNoWindowFilter(t *testing.T) {
-	t.Parallel()
-	plan := &chplan.RangeWindow{
-		Input:           &chplan.Scan{Table: "otel_metrics_gauge"},
-		Func:            "absent_over_time",
-		TimestampColumn: "TimeUnix",
-		ValueColumn:     "Value",
-		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
-	}
-	sql, _, err := chsql.Emit(context.Background(), plan)
-	if err != nil {
-		t.Fatalf("Emit: %v", err)
-	}
-	if strings.Contains(sql, "WHERE length(") {
-		t.Errorf("absent_over_time must not filter empty windows out; SQL=%s", sql)
 	}
 }

--- a/internal/optimizer/rule.go
+++ b/internal/optimizer/rule.go
@@ -281,6 +281,14 @@ func rewriteChildren(n chplan.Node, fn func(chplan.Node) (chplan.Node, bool)) (c
 		cp := *v
 		cp.Input = newInput
 		return &cp, true
+	case *chplan.AbsentOverTime:
+		newInput, ch := fn(v.Input)
+		if !ch {
+			return v, false
+		}
+		cp := *v
+		cp.Input = newInput
+		return &cp, true
 	case *chplan.Limit:
 		newInput, ch := fn(v.Input)
 		if !ch {

--- a/internal/promql/absent.go
+++ b/internal/promql/absent.go
@@ -154,6 +154,145 @@ func lowerAbsent(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, e
 	}, nil
 }
 
+// lowerAbsentOverTime implements PromQL `absent_over_time(v[range])`.
+// The function emits the absence-indicator series whose labels are
+// derived from the input vector-selector's equality matchers (same
+// rule as instant `absent(...)`, mirroring Prom's
+// `createLabelsForAbsentFunction`). Samples are placed at every
+// per-step anchor whose `(anchor - range, anchor]` lookback window
+// has zero matching samples in the table; anchors with any matching
+// sample contribute no output.
+//
+// Lowered shape:
+//
+//	AbsentOverTime synth=<matcher-eq-set> range=<R> step=<step>
+//	               start=<start> end=<end> offset=<offset>
+//	  Filter? predicate=<v's matchers without the time bound>
+//	    Scan(<table>)
+//
+// The chsql emitter for AbsentOverTime renders the per-anchor lookback
+// check via a groupArray of the per-sample timestamps + arrayCount(t
+// -> in_window, sample_ts_arr). See
+// internal/chsql/absent_over_time.go for the SQL skeleton.
+//
+// Cerberus previously routed `absent_over_time` through the regular
+// per-series RangeWindow path which emitted `if(length(window_vals) >
+// 0, NaN, 1.0)` per (series, anchor) — wrong labels (original series
+// labels, not the matcher-synthesised set) AND wrong shape (per-series
+// NaN rows the matrix pivot didn't drop). Bucket 4 of
+// docs/compat-residual-audit-25898791664.md attributes 6 compat lane
+// diffs to this divergence; replacing the lowering with the dedicated
+// AbsentOverTime node closes those diffs by emitting Prom's
+// single-synthesised-series shape directly.
+func lowerAbsentOverTime(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	if len(c.Args) != 1 {
+		return nil, fmt.Errorf("promql: absent_over_time() expects 1 argument, got %d", len(c.Args))
+	}
+	ms, ok := c.Args[0].(*parser.MatrixSelector)
+	if !ok {
+		return nil, fmt.Errorf("promql: absent_over_time() argument must be a range-vector selector, got %T", c.Args[0])
+	}
+	vs, ok := ms.VectorSelector.(*parser.VectorSelector)
+	if !ok {
+		return nil, fmt.Errorf("promql: matrix selector's inner must be a VectorSelector, got %T", ms.VectorSelector)
+	}
+
+	anchor, err := anchorFromSelector(vs, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build the inner filtered Scan with the modifier stripped — the
+	// AbsentOverTime node embeds its own per-anchor window bound, and
+	// any duplicate time predicate on the inner Filter would over-narrow
+	// the global prefilter the emitter applies above the inner scan.
+	vsNoMod := *vs
+	vsNoMod.Timestamp = nil
+	vsNoMod.OriginalOffset = 0
+	vsNoMod.Offset = 0
+	vsNoMod.StartOrEnd = 0
+	rangeCtx := ctx
+	rangeCtx.inRangeVector = true
+	inner, err := lowerVectorSelector(&vsNoMod, s, rangeCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Resolve the eval anchor: a non-zero `@`/`@start`/`@end` modifier
+	// pins `anchor.End` directly; otherwise fall through to ctx.end (the
+	// query's eval time for instant queries). Zero ctx.end + zero
+	// anchor.End falls back to CH's `now64(9)` at emit time — mirrors
+	// the lowerAbsent instant-mode contract.
+	endTime := anchor.End
+	if endTime.IsZero() && !ctx.end.IsZero() {
+		endTime = ctx.end.UTC()
+	}
+
+	a := &chplan.AbsentOverTime{
+		Input:            inner,
+		SynthLabels:      synthLabelsFromMatchers(vs.LabelMatchers),
+		Range:            ms.Range,
+		End:              endTime,
+		Offset:           anchor.Offset,
+		TimestampColumn:  s.TimestampColumn,
+		ValueColumn:      s.ValueColumn,
+		MetricNameColumn: s.MetricNameColumn,
+		AttributesColumn: s.AttributesColumn,
+	}
+	// In range mode (Pool-AK's per-anchor query_range plumbing) fan the
+	// per-anchor lookback check across the request's step grid. The
+	// emitter pivots between the single-anchor (Step == 0) and
+	// arrayJoin-fanout (Step > 0) shapes via this Step value.
+	if ctx.step > 0 && !ctx.start.IsZero() && !ctx.end.IsZero() {
+		a.Start = ctx.start.UTC()
+		a.End = ctx.end.UTC()
+		a.Step = ctx.step
+	}
+	return a, nil
+}
+
+// synthLabelsFromMatchers builds the matcher-derived label set Prom's
+// funcAbsentOverTime / funcAbsent lift onto the synthesised output
+// series. Reuses the same rules `absentAttrsMap` applies but returns
+// the ordered (key, value) pair list directly so the chsql emitter can
+// thread each kv through `Lit(...)` for `?`-bound rendering.
+//
+// Skip `__name__`; include only equality matchers; drop labels appearing
+// more than once on the same name (`absent_over_time(x{job="a",
+// job="b"}[5m])` → `{}`).
+func synthLabelsFromMatchers(matchers []*labels.Matcher) []chplan.SynthLabel {
+	has := make(map[string]bool, len(matchers))
+	order := make([]string, 0, len(matchers))
+	values := make(map[string]string, len(matchers))
+	for _, m := range matchers {
+		if m.Name == model.MetricNameLabel {
+			continue
+		}
+		if m.Type != labels.MatchEqual {
+			if has[m.Name] {
+				delete(values, m.Name)
+			}
+			continue
+		}
+		if has[m.Name] {
+			delete(values, m.Name)
+			continue
+		}
+		has[m.Name] = true
+		values[m.Name] = m.Value
+		order = append(order, m.Name)
+	}
+	out := make([]chplan.SynthLabel, 0, len(order))
+	for _, name := range order {
+		v, ok := values[name]
+		if !ok {
+			continue
+		}
+		out = append(out, chplan.SynthLabel{Key: name, Value: v})
+	}
+	return out
+}
+
 // absentAttrsMap renders the absent-output label set as a CH
 // Map(String, String) literal, mirroring Prom's
 // `createLabelsForAbsentFunction` rules:

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -578,6 +578,8 @@ func lowerRangeVectorCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chpla
 		return lowerPredictLinear(c, s, ctx)
 	case "holt_winters", "double_exponential_smoothing":
 		return lowerHoltWinters(c, s, ctx)
+	case "absent_over_time":
+		return lowerAbsentOverTime(c, s, ctx)
 	}
 	if len(c.Args) != 1 {
 		return nil, fmt.Errorf("promql: %s expects exactly 1 argument, got %d", c.Func.Name, len(c.Args))

--- a/test/spec/chplan_print.go
+++ b/test/spec/chplan_print.go
@@ -244,6 +244,35 @@ func printNode(b *strings.Builder, n chplan.Node, depth int) {
 		if v.Inner != nil {
 			printNode(b, v.Inner, depth+1)
 		}
+	case *chplan.AbsentOverTime:
+		fmt.Fprintf(b, "%sAbsentOverTime range=%s step=%s", indent, v.Range, v.Step)
+		if v.Offset != 0 {
+			fmt.Fprintf(b, " offset=%s", v.Offset)
+		}
+		if v.TimestampColumn != "" {
+			fmt.Fprintf(b, " ts=%s", v.TimestampColumn)
+		}
+		if v.ValueColumn != "" {
+			fmt.Fprintf(b, " value=%s", v.ValueColumn)
+		}
+		if v.MetricNameColumn != "" {
+			fmt.Fprintf(b, " name=%s", v.MetricNameColumn)
+		}
+		if v.AttributesColumn != "" {
+			fmt.Fprintf(b, " attrs=%s", v.AttributesColumn)
+		}
+		if len(v.SynthLabels) > 0 {
+			parts := make([]string, len(v.SynthLabels))
+			for i, kv := range v.SynthLabels {
+				parts[i] = fmt.Sprintf("%s=%q", kv.Key, kv.Value)
+			}
+			fmt.Fprintf(b, " synth=[%s]", strings.Join(parts, ", "))
+		}
+		if !v.Start.IsZero() || !v.End.IsZero() {
+			fmt.Fprintf(b, " start=%s end=%s", v.Start.UTC().Format("2006-01-02T15:04:05Z"), v.End.UTC().Format("2006-01-02T15:04:05Z"))
+		}
+		b.WriteString("\n")
+		printNode(b, v.Input, depth+1)
 	case *chplan.HistogramQuantile:
 		gb := make([]string, len(v.GroupBy))
 		for i, e := range v.GroupBy {

--- a/test/spec/promql/absent_over_time_empty_window.txtar
+++ b/test/spec/promql/absent_over_time_empty_window.txtar
@@ -1,8 +1,13 @@
-# Window covers [00:00:01 - 5m, 00:00:01] = [23:55:01, 00:00:01], but the
-# seed only has samples earlier than that. The series exists in the source
-# data — so the per-series RangeWindow output emits 1.0 for the empty
-# window (per absent_over_time semantics). Engine-side label synthesis
-# for the truly-no-input case is a follow-up.
+# Lookback window `(eval - 5m, eval]` contains zero matching samples for
+# `temperature` — the seeded row at 2025-12-31 23:40:00 pre-dates the
+# window's lower bound at 2025-12-31 23:55:01. AbsentOverTime synthesises
+# a single output row at the eval anchor with the matcher-derived label
+# set (empty here — the input has no non-__name__ equality matchers, so
+# `synthLabelsFromMatchers` returns the empty slice and the emitter
+# renders `CAST(map(), 'Map(String,String)')`).
+#
+# This is the instant-mode path (Step == 0). The matrix-mode fanout is
+# exercised by absent_over_time_range_step_synth_labels.txtar.
 
 -- query.promql --
 absent_over_time(temperature[5m])
@@ -14,18 +19,21 @@ CREATE TABLE otel_metrics_gauge (
     Value Float64
 ) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 -- Sample is well outside the [23:55:01, 00:00:01] window: it pre-dates
--- 23:55:01 so the per-series window_pairs array stays empty.
+-- 23:55:01 so `sample_ts_arr` after the global prefilter stays empty.
 INSERT INTO otel_metrics_gauge VALUES
     ('temperature', map('host', 'a'), toDateTime64('2025-12-31 23:40:00', 9), 42.0);
 -- expected_rows --
 [
-  [{"host": "a"}, 1.0]
+  ["", {}, "2026-01-01T00:00:01Z", 1.0]
 ]
 -- args --
-[0] string = "temperature"
+[0] string = ""
+[1] string = "Map(String,String)"
+[2] float64 = 1
+[3] string = "temperature"
 -- chplan --
-RangeWindow func=absent_over_time range=5m0s step=0s ts=TimeUnix value=Value groupBy=[Attributes]
+AbsentOverTime range=5m0s step=0s ts=TimeUnix value=Value name=MetricName attrs=Attributes start=0001-01-01T00:00:00Z end=2026-01-01T00:00:01Z
   Filter predicate=(MetricName = "temperature")
     Scan(otel_metrics_gauge)
 -- sql --
-SELECT `Attributes`, if(length(window_vals) > 0, nan, 1.0) AS `Value` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY `Attributes`)))
+SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, anchor_ts AS `TimeUnix`, toFloat64(?) AS `Value` FROM (SELECT anchor_ts FROM (SELECT toDateTime64('2026-01-01 00:00:01.000000000', 9) AS `anchor_ts`, sample_ts_arr FROM (SELECT groupArray(`TimeUnix`) AS `sample_ts_arr` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) WHERE `TimeUnix` > toDateTime64('2026-01-01 00:00:01.000000000', 9) - toIntervalNanosecond(300000000000) AND `TimeUnix` <= toDateTime64('2026-01-01 00:00:01.000000000', 9))) WHERE arrayCount(t -> t > anchor_ts - toIntervalNanosecond(300000000000) AND t <= anchor_ts, sample_ts_arr) = 0)

--- a/test/spec/promql/absent_over_time_range_step_synth_labels.txtar
+++ b/test/spec/promql/absent_over_time_range_step_synth_labels.txtar
@@ -1,0 +1,59 @@
+# absent_over_time(<metric>{<eq-matchers>}[range]) over query_range —
+# fans the per-anchor lookback check across the step grid `[2026-01-01
+# 00:00:00, 00:05:00]` spaced by 30s (11 anchors total, end-inclusive).
+# The matcher-filtered scan returns zero rows because no
+# `nonexistent_metric` series exists in the seed; the
+# `sample_ts_arr = []` plumbed through the inner subquery makes every
+# anchor pass the `arrayCount(...) = 0` filter. Output: 11 rows, one
+# per anchor, each carrying the matcher-synthesised label map
+# (`{job: "x", instance: "host-1"}` — drop `__name__`, lift the two
+# equality matchers).
+
+-- query.promql --
+absent_over_time(nonexistent_metric{job="x",instance="host-1"}[5m])
+-- range_step --
+30s
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- Only an unrelated metric is present. The matcher-filtered scan
+-- yields zero rows, so every per-anchor lookback window sees an empty
+-- sample_ts_arr.
+INSERT INTO otel_metrics_gauge VALUES
+    ('temperature', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 42.0);
+-- expected_rows --
+[
+  ["", {"instance": "host-1", "job": "x"}, "2026-01-01T00:00:00Z", 1.0],
+  ["", {"instance": "host-1", "job": "x"}, "2026-01-01T00:00:30Z", 1.0],
+  ["", {"instance": "host-1", "job": "x"}, "2026-01-01T00:01:00Z", 1.0],
+  ["", {"instance": "host-1", "job": "x"}, "2026-01-01T00:01:30Z", 1.0],
+  ["", {"instance": "host-1", "job": "x"}, "2026-01-01T00:02:00Z", 1.0],
+  ["", {"instance": "host-1", "job": "x"}, "2026-01-01T00:02:30Z", 1.0],
+  ["", {"instance": "host-1", "job": "x"}, "2026-01-01T00:03:00Z", 1.0],
+  ["", {"instance": "host-1", "job": "x"}, "2026-01-01T00:03:30Z", 1.0],
+  ["", {"instance": "host-1", "job": "x"}, "2026-01-01T00:04:00Z", 1.0],
+  ["", {"instance": "host-1", "job": "x"}, "2026-01-01T00:04:30Z", 1.0],
+  ["", {"instance": "host-1", "job": "x"}, "2026-01-01T00:05:00Z", 1.0]
+]
+-- args --
+[0] string = ""
+[1] string = "job"
+[2] string = "x"
+[3] string = "instance"
+[4] string = "host-1"
+[5] float64 = 1
+[6] string = "nonexistent_metric"
+[7] string = "job"
+[8] string = "x"
+[9] string = "instance"
+[10] string = "host-1"
+-- chplan --
+AbsentOverTime range=5m0s step=30s ts=TimeUnix value=Value name=MetricName attrs=Attributes synth=[job="x", instance="host-1"] start=2026-01-01T00:00:00Z end=2026-01-01T00:05:00Z
+  Filter predicate=(((Attributes["job"] = "x") AND (Attributes["instance"] = "host-1")) AND (MetricName = "nonexistent_metric"))
+    Scan(otel_metrics_gauge)
+-- sql --
+SELECT ? AS `MetricName`, map(?, ?, ?, ?) AS `Attributes`, anchor_ts AS `TimeUnix`, toFloat64(?) AS `Value` FROM (SELECT anchor_ts FROM (SELECT arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:00:00.000000000', 9) + toIntervalNanosecond(i * 30000000000), range(0, 11))) AS `anchor_ts`, sample_ts_arr FROM (SELECT groupArray(`TimeUnix`) AS `sample_ts_arr` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) AND (`Attributes`[?] = ?) WHERE (`Attributes`[?] = ?)) WHERE `TimeUnix` > toDateTime64('2026-01-01 00:00:00.000000000', 9) - toIntervalNanosecond(300000000000) AND `TimeUnix` <= toDateTime64('2026-01-01 00:05:00.000000000', 9))) WHERE arrayCount(t -> t > anchor_ts - toIntervalNanosecond(300000000000) AND t <= anchor_ts, sample_ts_arr) = 0)

--- a/test/spec/promql/absent_over_time_synth_labels.txtar
+++ b/test/spec/promql/absent_over_time_synth_labels.txtar
@@ -1,0 +1,50 @@
+# absent_over_time(<metric>{<eq-matchers>}[range]) — the matcher-derived
+# label synthesis path. The input selector has TWO equality matchers
+# (`job="x"`, `instance="host-1"`) on top of `__name__`. Per Prom's
+# funcAbsentOverTime (which delegates label construction to
+# `createLabelsForAbsentFunction`), the absence-indicator series carries
+# `__name__` dropped + the equality matchers lifted onto the output.
+#
+# The seed contains only an unrelated metric, so the matcher-filtered
+# scan returns zero rows and every step anchor in the eval grid
+# survives the per-anchor lookback check. The chplan/sql sections
+# auto-fill on `GOLDEN_UPDATE=1`; the expected_rows section pins the
+# observable wire shape: one row at the eval anchor with the
+# matcher-synthesised label map.
+
+-- query.promql --
+absent_over_time(nonexistent_metric{job="x",instance="host-1"}[5m])
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- Only an unrelated metric is present. The matcher-filtered scan
+-- yields zero rows, so sample_ts_arr is empty and every step anchor
+-- passes the arrayCount = 0 filter.
+INSERT INTO otel_metrics_gauge VALUES
+    ('temperature', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 42.0);
+-- expected_rows --
+[
+  ["", {"instance": "host-1", "job": "x"}, "2026-01-01T00:00:01Z", 1.0]
+]
+-- args --
+[0] string = ""
+[1] string = "job"
+[2] string = "x"
+[3] string = "instance"
+[4] string = "host-1"
+[5] float64 = 1
+[6] string = "nonexistent_metric"
+[7] string = "job"
+[8] string = "x"
+[9] string = "instance"
+[10] string = "host-1"
+-- chplan --
+AbsentOverTime range=5m0s step=0s ts=TimeUnix value=Value name=MetricName attrs=Attributes synth=[job="x", instance="host-1"] start=0001-01-01T00:00:00Z end=2026-01-01T00:00:01Z
+  Filter predicate=(((Attributes["job"] = "x") AND (Attributes["instance"] = "host-1")) AND (MetricName = "nonexistent_metric"))
+    Scan(otel_metrics_gauge)
+-- sql --
+SELECT ? AS `MetricName`, map(?, ?, ?, ?) AS `Attributes`, anchor_ts AS `TimeUnix`, toFloat64(?) AS `Value` FROM (SELECT anchor_ts FROM (SELECT toDateTime64('2026-01-01 00:00:01.000000000', 9) AS `anchor_ts`, sample_ts_arr FROM (SELECT groupArray(`TimeUnix`) AS `sample_ts_arr` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) AND (`Attributes`[?] = ?) WHERE (`Attributes`[?] = ?)) WHERE `TimeUnix` > toDateTime64('2026-01-01 00:00:01.000000000', 9) - toIntervalNanosecond(300000000000) AND `TimeUnix` <= toDateTime64('2026-01-01 00:00:01.000000000', 9))) WHERE arrayCount(t -> t > anchor_ts - toIntervalNanosecond(300000000000) AND t <= anchor_ts, sample_ts_arr) = 0)

--- a/test/spec/promql/absent_over_time_with_data.txtar
+++ b/test/spec/promql/absent_over_time_with_data.txtar
@@ -1,22 +1,34 @@
-# When the lookback window contains at least one sample, absent_over_time
-# returns "no result" — at this RangeWindow layer the per-series value
-# expression projects NaN; the engine wrap converts NaN-rows to dropped
-# rows before reaching the API layer. (Compare to Prom's
-# `funcAbsentOverTime` — engine.go specialises the matrix output for
-# absent_over_time to synthesise / suppress the result series.)
-#
-# This fixture pins the SQL + chplan shape only. The chDB round-trip
-# is opt-in by including `seed:` + `expected_rows:` — both intentionally
-# omitted here because the NaN-row interaction with the chDB
-# float-comparison path is engine-layer concern, not RangeWindow emit.
+# When the lookback window contains at least one matching sample,
+# absent_over_time emits NO output row — Prom's funcAbsentOverTime
+# suppresses anchors where any series has any sample in the window.
+# The seeded `temperature` row at 2026-01-01 00:00:00 lands inside the
+# 5-minute lookback ending at 2026-01-01 00:00:01, so the per-anchor
+# arrayCount returns 1, the outer WHERE filter drops the anchor, and
+# the SELECT returns zero rows.
 
 -- query.promql --
 absent_over_time(temperature[5m])
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- Sample sits inside the lookback window so the anchor's arrayCount
+-- returns 1, suppressing the absence-indicator output.
+INSERT INTO otel_metrics_gauge VALUES
+    ('temperature', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 42.0);
+-- expected_rows --
+[]
 -- args --
-[0] string = "temperature"
+[0] string = ""
+[1] string = "Map(String,String)"
+[2] float64 = 1
+[3] string = "temperature"
 -- chplan --
-RangeWindow func=absent_over_time range=5m0s step=0s ts=TimeUnix value=Value groupBy=[Attributes]
+AbsentOverTime range=5m0s step=0s ts=TimeUnix value=Value name=MetricName attrs=Attributes start=0001-01-01T00:00:00Z end=2026-01-01T00:00:01Z
   Filter predicate=(MetricName = "temperature")
     Scan(otel_metrics_gauge)
 -- sql --
-SELECT `Attributes`, if(length(window_vals) > 0, nan, 1.0) AS `Value` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY `Attributes`)))
+SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, anchor_ts AS `TimeUnix`, toFloat64(?) AS `Value` FROM (SELECT anchor_ts FROM (SELECT toDateTime64('2026-01-01 00:00:01.000000000', 9) AS `anchor_ts`, sample_ts_arr FROM (SELECT groupArray(`TimeUnix`) AS `sample_ts_arr` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) WHERE `TimeUnix` > toDateTime64('2026-01-01 00:00:01.000000000', 9) - toIntervalNanosecond(300000000000) AND `TimeUnix` <= toDateTime64('2026-01-01 00:00:01.000000000', 9))) WHERE arrayCount(t -> t > anchor_ts - toIntervalNanosecond(300000000000) AND t <= anchor_ts, sample_ts_arr) = 0)


### PR DESCRIPTION
## Summary

- Bucket 4 from [the post-#350 compat residual audit](docs/compat-residual-audit-25898791664.md) (merged via #355): Prom's `absent_over_time(metric{label="value"}[range])` returns the absence-indicator series with labels derived from the input selector's `__name__` + explicit equality matchers. Cerberus was routing the function through the regular per-series RangeWindow path which emitted `if(length(window_vals) > 0, NaN, 1.0)` per (series, anchor) — wrong labels AND wrong shape. 6 compat lane diffs trace to this divergence.
- Replaces the lowering with a dedicated `chplan.AbsentOverTime` node (parallel to the existing instant `absent(...)` lowering) and a custom chsql emit that fans the per-anchor lookback check across the step grid via `arrayJoin(arrayMap(...))` + `groupArray` + `arrayCount`. The output is Prom's single-synthesised-series shape: one row per absent anchor, with `__name__` dropped and equality matchers lifted onto `Attributes`.
- Removes the legacy `emitRangeWindowAbsentOverTime` + its substring test from `internal/chsql/range_window_test.go`; the new path is exercised by the existing `absent_over_time_*.txtar` fixtures plus two new ones for the matcher-synth + range-step paths.

## Plan + emit shape

```
AbsentOverTime synth=<matcher-eq-set> range=<R> step=<step>
               start=<start> end=<end> offset=<offset>
  Filter <v's matchers>
    Scan(<table>)
```

```sql
SELECT '' AS MetricName,
       <synth-labels-map> AS Attributes,
       anchor_ts AS TimeUnix,
       toFloat64(?) AS Value
FROM (SELECT anchor_ts FROM (
        SELECT arrayJoin(arrayMap(i -> <start> + i * <step_ns>, range(0, N))) AS anchor_ts,
               sample_ts_arr
        FROM (SELECT groupArray(TimeUnix) AS sample_ts_arr
              FROM (<matcher-filtered scan>)
              WHERE TimeUnix > <start - range> AND TimeUnix <= <end>))
      WHERE arrayCount(t -> t > anchor_ts - toIntervalNanosecond(<range_ns>)
                            AND t <= anchor_ts,
                       sample_ts_arr) = 0)
```

Instant mode (Step == 0) emits a single anchor at `End` instead of the arrayJoin fanout; the rest of the structure is identical. The inner `groupArray + GROUP BY ()` always emits exactly one row — including the case where the matcher scan returns zero rows, which yields `sample_ts_arr = []` and lets every anchor survive the WHERE clause (the "absent at every anchor" signal Prom synthesises).

## Test plan

- [x] `go test ./...` — 2718 tests pass.
- [x] `go test -tags chdb -count=1 ./test/spec/promql/` — 200 PromQL chDB round-trips pass, including the four `absent_over_time_*` fixtures:
  - `absent_over_time_empty_window` — instant, no equality matchers, empty window → 1 row with `{}`.
  - `absent_over_time_with_data` — instant, sample inside window → 0 rows (suppression).
  - `absent_over_time_synth_labels` — instant, two equality matchers, no data → 1 row with `{job="x",instance="host-1"}`.
  - `absent_over_time_range_step_synth_labels` — range mode, 30s step, all 11 anchors absent → 11 rows with synth labels.
- [ ] Compat lane re-run after merge to confirm the 6 Bucket 4 diffs close.