### PR TITLE
fix(promql): time() in arithmetic/comparison with vector evaluates per-step

### DIFF
--- a/internal/api/prom/handler_chdb_step_loop_test.go
+++ b/internal/api/prom/handler_chdb_step_loop_test.go
@@ -305,6 +305,141 @@ func TestQueryRange_StepLoop_TimeTime_ChDB(t *testing.T) {
 	}
 }
 
+// TestQueryRange_StepLoop_TimeMetric_ChDB walks the `time() OP metric`
+// shapes from Bucket 6 of the residual-audit doc — the asymmetric
+// counterpart to TestQueryRange_StepLoop_TimeTime_ChDB. Pre-fix these
+// routed through chplan.VectorJoin and the per-side argMax keyed on
+// (MetricName="", Attributes={}) vs the metric's real labels collapsed
+// to zero matches; the result was an empty matrix. The asymmetric
+// synthetic fold in lowerVectorVector splices the time-value
+// expression (which references `anchor_ts` in range mode) into the
+// metric leg's per-step Project, rewriting ColumnRef{anchor_ts} →
+// ColumnRef{TimeUnix} so the spliced expression resolves against the
+// metric leg's outer-projection column shape.
+//
+// Window: start=T0, end=T0+5m, step=30s → 11 anchors at T0+i*30
+// for i = 0..10. The seed lands one sample at each step with
+// Value=100+i so the LWR pick at step i is the sample at step i
+// (the per-step anchor + 5-min lookback both include it).
+//
+// Each operation pins both directions (synth-on-left and synth-on-
+// right) so non-commutative ops (SUB / DIV / LT / GT) surface
+// failures independently of the commutative variants.
+func TestQueryRange_StepLoop_TimeMetric_ChDB(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(5 * time.Minute)
+	step := 30 * time.Second
+	const wantSamples = 11
+
+	seedRows := make([]string, 0, wantSamples)
+	for i := 0; i < wantSamples; i++ {
+		ts := start.Add(time.Duration(i) * step).Format("2006-01-02 15:04:05.000000000")
+		seedRows = append(seedRows, fmt.Sprintf(
+			`('demo_memory_usage_bytes', map('instance', 'demo'), toDateTime64('%s', 9), %d.0)`,
+			ts, 100+i,
+		))
+	}
+	seed := gaugeDDL + "\nINSERT INTO otel_metrics_gauge VALUES\n  " +
+		strings.Join(seedRows, ",\n  ") + ";"
+	srv, _ := newChDBServer(t, seed)
+
+	// timeOf returns time() (Unix seconds) at step i.
+	timeOf := func(i int) float64 {
+		return float64(start.Unix() + int64(i)*30)
+	}
+	// metricOf returns the demo metric value at step i (the per-step
+	// LWR picks the seeded sample at step i with Value=100+i).
+	metricOf := func(i int) float64 {
+		return float64(100 + i)
+	}
+	fmtF := func(f float64) string {
+		return strconv.FormatFloat(f, 'f', -1, 64)
+	}
+
+	cases := []struct {
+		name      string
+		query     string
+		wantValue func(i int) string
+	}{
+		// Arithmetic — both directions for non-commutative ops so the
+		// scalarOnLeft flag is exercised. ADD/MUL are commutative so
+		// one direction is sufficient.
+		{
+			name:  "time-plus-metric",
+			query: "time() + demo_memory_usage_bytes",
+			wantValue: func(i int) string {
+				return fmtF(timeOf(i) + metricOf(i))
+			},
+		},
+		{
+			name:  "metric-minus-time",
+			query: "demo_memory_usage_bytes - time()",
+			wantValue: func(i int) string {
+				return fmtF(metricOf(i) - timeOf(i))
+			},
+		},
+		{
+			name:  "time-minus-metric",
+			query: "time() - demo_memory_usage_bytes",
+			wantValue: func(i int) string {
+				return fmtF(timeOf(i) - metricOf(i))
+			},
+		},
+		{
+			name:  "time-times-metric",
+			query: "time() * demo_memory_usage_bytes",
+			wantValue: func(i int) string {
+				return fmtF(timeOf(i) * metricOf(i))
+			},
+		},
+		{
+			name:  "metric-div-time",
+			query: "demo_memory_usage_bytes / time()",
+			wantValue: func(i int) string {
+				return fmtF(metricOf(i) / timeOf(i))
+			},
+		},
+		// Bool comparisons — time() >> metric values at every step
+		// (time is ~1.7e9, metric is ~100), so `time > bool metric`
+		// is always 1, `time < bool metric` is always 0.
+		{
+			name:  "time-gt-bool-metric",
+			query: "time() > bool demo_memory_usage_bytes",
+			wantValue: func(_ int) string {
+				return "1"
+			},
+		},
+		{
+			name:  "metric-lt-bool-time",
+			query: "demo_memory_usage_bytes < bool time()",
+			wantValue: func(_ int) string {
+				return "1"
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			matrix := runStepLoopRange(t, srv.URL, tc.query, start, end, step)
+			if len(matrix) != 1 {
+				t.Fatalf("expected exactly 1 series in matrix, got %d: %+v", len(matrix), matrix)
+			}
+			values := matrix[0].Values
+			if len(values) != wantSamples {
+				t.Fatalf("expected %d samples (one per step), got %d: %+v",
+					wantSamples, len(values), values)
+			}
+			for i, v := range values {
+				want := tc.wantValue(i)
+				if got := v[1]; got != want {
+					t.Errorf("step %d: value=%q want=%q (full row: %+v)",
+						i, got, want, v)
+				}
+			}
+		})
+	}
+}
+
 // TestQueryRange_StepLoop_DrivingVector_ChDB pins the control case:
 // a driving-vector query (`avg_over_time(demo_memory_usage_bytes[1m])`)
 // must keep emitting per-step samples from the input data, NOT N rows

--- a/internal/promql/binary.go
+++ b/internal/promql/binary.go
@@ -145,6 +145,37 @@ func lowerVectorVector(b *parser.BinaryExpr, s schema.Metrics, op chplan.BinaryO
 		return foldSyntheticBinary(left, right, op, b.ReturnBool, s), nil
 	}
 
+	// Asymmetric synthetic fold: when EXACTLY ONE leg is the synthetic-
+	// scalar shape and the other is a real metric vector, the
+	// VectorJoin's per-side argMax wrap would key the synthetic side on
+	// (MetricName="", Attributes={}) and the metric side on its real
+	// (MetricName, {instance, job, ...}) — the INNER JOIN on full
+	// Attributes finds zero matches and the result is empty. Prom's
+	// semantics broadcast the synthetic scalar across every (series,
+	// step) row of the real side. We rebuild that here by promoting
+	// the synthetic's Value expression into a per-step / per-row scalar
+	// and routing through the vector-scalar binop shape (Project Value
+	// through the op, or Filter for bare-comparison). The synthetic
+	// side's Value expression may reference `anchor_ts` (range mode);
+	// the metric side's outer projection re-aliases `anchor_ts` →
+	// TimeUnix, so we rewrite ColumnRef{anchor_ts} → ColumnRef{TimeUnix}
+	// before splicing.
+	//
+	// Bucket 6 from docs/compat-residual-audit-25898791664.md: the
+	// `time() <op> metric` and `metric <op> time()` shapes collapse to
+	// empty without this. Gated on default matching for the same
+	// reasons as the both-synthetic fold above.
+	if isDefaultMatching(b.VectorMatching) {
+		lSynth := isSyntheticScalarPlan(left, s)
+		rSynth := isSyntheticScalarPlan(right, s)
+		switch {
+		case lSynth && !rSynth:
+			return foldSyntheticVectorBinary(left, right, op, true /*scalarOnLeft*/, b.ReturnBool, s), nil
+		case !lSynth && rSynth:
+			return foldSyntheticVectorBinary(right, left, op, false /*scalarOnLeft*/, b.ReturnBool, s), nil
+		}
+	}
+
 	match := chplan.VectorMatch{}
 	if b.VectorMatching != nil {
 		match.Labels = append([]string(nil), b.VectorMatching.MatchingLabels...)
@@ -259,6 +290,108 @@ func foldSyntheticBinary(left, right chplan.Node, op chplan.BinaryOp, returnBool
 		}
 	}
 	return combined
+}
+
+// foldSyntheticVectorBinary handles the asymmetric case where one leg
+// of a vector-vector binop is a synthetic-scalar shape (e.g. `time()`,
+// `vector(N)`, zero-arg date fn) and the other is a real metric vector.
+// The synthetic side acts as a per-step / per-row scalar broadcast
+// across every (series, step) row of the metric side — matching
+// Prom's semantics for `time() + metric`, `metric > time()`, etc.
+//
+// synth is the synthetic-scalar leg; vec is the real-vector leg.
+// scalarOnLeft tracks the original PromQL operand order so non-
+// commutative ops (SUB, DIV, MOD, POW) and comparisons preserve
+// orientation. returnBool wraps comparison ops in `toFloat64(...)`
+// for the 1.0 / 0.0 vector-bool result.
+//
+// The result shape mirrors [lowerVectorScalar]:
+//
+//   - Arithmetic op: Project [MetricName, Attributes, TimeUnix,
+//     (<synth_val> OP Value) AS Value] over the vec leg.
+//   - Comparison op + `bool` modifier: Project with
+//     `toFloat64(<synth_val> OP Value) AS Value`.
+//   - Comparison op WITHOUT `bool`: Filter on `<synth_val> OP Value`
+//     keeping the vec leg's columns intact (Prom's "preserve LHS
+//     where comparison holds" rule reduces here to "preserve vec
+//     rows where comparison holds" since the synthetic side has no
+//     labels of its own to keep).
+//
+// Range mode rewiring: the synthetic leg's Value expression may
+// reference `ColumnRef{anchor_ts}` (the per-step anchor introduced by
+// [syntheticScalarVector] via [rewriteAnchorRefs]); the vec leg's
+// outer projection from [wrapRangeLatestPerSeries] re-aliases
+// `anchor_ts` → TimeUnix, so we rewrite ColumnRef{anchor_ts} →
+// ColumnRef{TimeUnix} before splicing the synthetic value into the
+// vec leg's row stream. Instant-mode synthetic Values are pure
+// literal expressions (`toFloat64(toUnixTimestamp64Nano(<lit>) /
+// 1e9)`) with no ColumnRefs, so the rewrite is a no-op there.
+func foldSyntheticVectorBinary(synth, vec chplan.Node, op chplan.BinaryOp, scalarOnLeft, returnBool bool, s schema.Metrics) chplan.Node {
+	synthVal := rewriteAnchorToTimeUnix(syntheticValueExpr(synth), s)
+	vecValue := chplan.Expr(&chplan.ColumnRef{Name: s.ValueColumn})
+
+	var lhs, rhs chplan.Expr
+	if scalarOnLeft {
+		lhs, rhs = synthVal, vecValue
+	} else {
+		lhs, rhs = vecValue, synthVal
+	}
+	opExpr := &chplan.Binary{Op: op, Left: lhs, Right: rhs}
+
+	if isComparison(op) && !returnBool {
+		return &chplan.Filter{Input: vec, Predicate: opExpr}
+	}
+
+	var newValue chplan.Expr = opExpr
+	if isComparison(op) && returnBool {
+		newValue = &chplan.FuncCall{Name: "toFloat64", Args: []chplan.Expr{opExpr}}
+	}
+	return &chplan.Project{
+		Input: vec,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.ColumnRef{Name: s.MetricNameColumn}},
+			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}},
+			{Expr: &chplan.ColumnRef{Name: s.TimestampColumn}},
+			{Expr: newValue, Alias: s.ValueColumn},
+		},
+	}
+}
+
+// rewriteAnchorToTimeUnix walks expr and replaces every
+// `ColumnRef{anchor_ts}` with `ColumnRef{<TimestampColumn>}`. Used by
+// [foldSyntheticVectorBinary] to thread a synthetic-leg Value
+// expression (which references `anchor_ts` in range mode) onto the
+// vector leg, whose outer projection has already renamed the per-step
+// anchor column to the canonical TimeUnix slot.
+//
+// The walk covers FuncCall args and Binary children — the shape
+// [syntheticScalarVector] / [rewriteAnchorRefs] produce. Other Expr
+// types (literals, MapAccess, etc.) don't carry anchor_ts references
+// in the synthetic-scalar shape and pass through unchanged.
+func rewriteAnchorToTimeUnix(expr chplan.Expr, s schema.Metrics) chplan.Expr {
+	if expr == nil {
+		return nil
+	}
+	switch v := expr.(type) {
+	case *chplan.ColumnRef:
+		if v.Name == "anchor_ts" && v.Qualifier == "" {
+			return &chplan.ColumnRef{Name: s.TimestampColumn}
+		}
+		return expr
+	case *chplan.FuncCall:
+		newArgs := make([]chplan.Expr, len(v.Args))
+		for i, a := range v.Args {
+			newArgs[i] = rewriteAnchorToTimeUnix(a, s)
+		}
+		return &chplan.FuncCall{Name: v.Name, Args: newArgs}
+	case *chplan.Binary:
+		return &chplan.Binary{
+			Op:    v.Op,
+			Left:  rewriteAnchorToTimeUnix(v.Left, s),
+			Right: rewriteAnchorToTimeUnix(v.Right, s),
+		}
+	}
+	return expr
 }
 
 // promBinaryOp maps a PromQL parser op to the chplan op. Arithmetic and

--- a/test/spec/promql/binop_metric_minus_time.txtar
+++ b/test/spec/promql/binop_metric_minus_time.txtar
@@ -1,0 +1,42 @@
+# `metric - time()` — Bucket 6 (companion to binop_time_plus_metric).
+# Pins the metric-on-left direction of the asymmetric synthetic fold.
+# Pre-fix the V-V join collapsed to empty for the same reason as the
+# scalar-on-left variant.
+#
+# `scalarOnLeft=false` flips the operand order in the Value
+# expression so the subtraction is `(Value - <time_value>)` (non-
+# commutative). The metric leg's columns flow through unchanged via
+# the inner Project re-aliasing.
+-- query.promql --
+http_requests_total - time()
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 1767226000.0);
+-- expected_rows --
+[
+  ["http_requests_total", {"job": "api"}, "2026-01-01T00:00:00Z", 399.0]
+]
+-- args --
+[0] string = "2026-01-01 00:00:01.000000000"
+[1] int64 = 9
+[2] int64 = 1000000000
+[3] string = "http_requests_total"
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] string = "2026-01-01 00:00:01.000000000"
+[7] int64 = 9
+[8] int64 = 300000000000
+-- chplan --
+Project [MetricName, Attributes, TimeUnix, (Value - toFloat64((toUnixTimestamp64Nano(toDateTime64("2026-01-01 00:00:01.000000000", 9)) / 1000000000))) AS Value]
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "http_requests_total") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_sum)
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, (`Value` - toFloat64((toUnixTimestamp64Nano(toDateTime64(?, ?)) / ?))) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_sum` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))

--- a/test/spec/promql/binop_time_arith_range.txtar
+++ b/test/spec/promql/binop_time_arith_range.txtar
@@ -1,0 +1,29 @@
+# `time() + metric` in range mode — Bucket 6.
+# Pins the chplan + SQL for the asymmetric synthetic fold under
+# query_range. The synthetic side's Value expression references
+# `anchor_ts` (via [rewriteAnchorRefs]); the metric side's outer
+# Project from [wrapRangeLatestPerSeries] re-aliases anchor_ts →
+# TimeUnix, so the fold rewrites ColumnRef{anchor_ts} →
+# ColumnRef{TimeUnix} before splicing the time-value expression
+# into the metric leg's per-step Project. The end-to-end runtime
+# shape under chDB is pinned by handler_chdb_step_loop_test.go
+# (TestQueryRange_StepLoop_TimeMetric_ChDB).
+-- query.promql --
+time() + http_requests_total
+-- range_step --
+30s
+-- args --
+[0] int64 = 1000000000
+[1] string = "http_requests_total"
+[2] int64 = 300000000000
+-- chplan --
+Project [MetricName, Attributes, TimeUnix, (toFloat64((toUnixTimestamp64Nano(TimeUnix) / 1000000000)) + Value) AS Value]
+  Project [MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS anchor_ts] funcs=[argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=((TimeUnix <= anchor_ts) AND (TimeUnix > (anchor_ts - toIntervalNanosecond(300000000000))))
+        CrossJoin
+          StepGrid start=2026-01-01T00:00:00.000000000Z end=2026-01-01T00:05:00.000000000Z step=30s
+          Filter predicate=(MetricName = "http_requests_total")
+            Scan(otel_metrics_sum)
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, (toFloat64((toUnixTimestamp64Nano(`TimeUnix`) / ?)) + `Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `anchor_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT * FROM (SELECT arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:00:00.000000000', 9) + toIntervalNanosecond(i * 30000000000), range(0, 11))) AS `anchor_ts`) AS L CROSS JOIN (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` = ?)) AS R) WHERE ((`TimeUnix` <= `anchor_ts`) AND (`TimeUnix` > (`anchor_ts` - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`, `anchor_ts`))

--- a/test/spec/promql/binop_time_lt_bool_metric.txtar
+++ b/test/spec/promql/binop_time_lt_bool_metric.txtar
@@ -1,0 +1,41 @@
+# `time() < bool metric` — Bucket 6 (bool comparison shape).
+# The `bool` modifier wraps the comparison in `toFloat64(...)` so every
+# row surfaces as 1.0 / 0.0 instead of filtering. Pre-fix the V-V join
+# collapsed to empty; the asymmetric synthetic fold emits a Project
+# producing `toFloat64(<time_value> < Value) AS Value` over every vec
+# row.
+-- query.promql --
+time() < bool http_requests_total
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 9999999999.0),
+    ('http_requests_total', map('job', 'db'), toDateTime64('2026-01-01 00:00:00', 9), 5.0);
+-- expected_rows --
+[
+  ["http_requests_total", {"job": "api"}, "2026-01-01T00:00:00Z", 1.0],
+  ["http_requests_total", {"job": "db"}, "2026-01-01T00:00:00Z", 0.0]
+]
+-- args --
+[0] string = "2026-01-01 00:00:01.000000000"
+[1] int64 = 9
+[2] int64 = 1000000000
+[3] string = "http_requests_total"
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] string = "2026-01-01 00:00:01.000000000"
+[7] int64 = 9
+[8] int64 = 300000000000
+-- chplan --
+Project [MetricName, Attributes, TimeUnix, toFloat64((toFloat64((toUnixTimestamp64Nano(toDateTime64("2026-01-01 00:00:01.000000000", 9)) / 1000000000)) < Value)) AS Value]
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "http_requests_total") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_sum)
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, toFloat64((toFloat64((toUnixTimestamp64Nano(toDateTime64(?, ?)) / ?)) < `Value`)) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_sum` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))

--- a/test/spec/promql/binop_time_lt_metric.txtar
+++ b/test/spec/promql/binop_time_lt_metric.txtar
@@ -1,0 +1,33 @@
+# `time() < http_requests_total` — Bucket 6 (bare comparison shape).
+# Without the `bool` modifier the V-V comparison-as-filter rule
+# applies: rows where the predicate holds survive, values are
+# preserved from the vector leg. Pre-fix the V-V join's empty-label
+# match collapsed the result; the asymmetric synthetic fold here
+# emits a Filter on `(<time_value> < Value)` over the vec subtree.
+# Runtime values pinned end-to-end by
+# TestQueryRange_StepLoop_TimeMetric_ChDB; this fixture pins the
+# chplan + SQL shape only (Filter wraps the metric leg's outer
+# Project, so the emitted SQL is `SELECT * FROM (<vec>) WHERE
+# (<time_value> < Value)` — `SELECT *` skips the chDB Map rewrite
+# and the runtime cell shape is asserted in the chDB step-loop
+# test instead).
+-- query.promql --
+time() < http_requests_total
+-- args --
+[0] string = "http_requests_total"
+[1] string = "2026-01-01 00:00:01.000000000"
+[2] int64 = 9
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] int64 = 300000000000
+[6] string = "2026-01-01 00:00:01.000000000"
+[7] int64 = 9
+[8] int64 = 1000000000
+-- chplan --
+Filter predicate=(toFloat64((toUnixTimestamp64Nano(toDateTime64("2026-01-01 00:00:01.000000000", 9)) / 1000000000)) < Value)
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "http_requests_total") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_sum)
+-- sql --
+SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_sum` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) WHERE (toFloat64((toUnixTimestamp64Nano(toDateTime64(?, ?)) / ?)) < `Value`)

--- a/test/spec/promql/binop_time_plus_metric.txtar
+++ b/test/spec/promql/binop_time_plus_metric.txtar
@@ -1,0 +1,46 @@
+# `time() + metric` — Bucket 6 from
+# docs/compat-residual-audit-25898791664.md. Pre-fix this lowered to a
+# VectorJoin keyed on (MetricName, Attributes); the synthetic time()
+# leg has MetricName="" and Attributes={} so the INNER JOIN against
+# the real metric's {instance, job, ...} attributes found zero
+# matches and the result was empty. Prom treats `time()` as a scalar
+# that broadcasts across every (series, step) row of the metric.
+#
+# Instant-mode shape here pins the asymmetric synthetic fold: the
+# value expression splices time()'s `toFloat64(toUnixTimestamp64Nano(
+# <eval_ts>) / 1e9)` directly into the metric leg's Project, producing
+# `(<time_value> + Value) AS Value`. Range mode (StepGrid source)
+# exercised by handler_chdb_step_loop_test.go.
+-- query.promql --
+time() + http_requests_total
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 5000.0);
+-- expected_rows --
+[
+  ["http_requests_total", {"job": "api"}, "2026-01-01T00:00:00Z", 1767230601.0]
+]
+-- args --
+[0] string = "2026-01-01 00:00:01.000000000"
+[1] int64 = 9
+[2] int64 = 1000000000
+[3] string = "http_requests_total"
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] string = "2026-01-01 00:00:01.000000000"
+[7] int64 = 9
+[8] int64 = 300000000000
+-- chplan --
+Project [MetricName, Attributes, TimeUnix, (toFloat64((toUnixTimestamp64Nano(toDateTime64("2026-01-01 00:00:01.000000000", 9)) / 1000000000)) + Value) AS Value]
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "http_requests_total") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_sum)
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, (toFloat64((toUnixTimestamp64Nano(toDateTime64(?, ?)) / ?)) + `Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_sum` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))


### PR DESCRIPTION
## Summary

- Bucket 6 from the post-#350 residual-diff audit ([#355](https://github.com/tsouza/cerberus/pull/355) — `docs/compat-residual-audit-25898791664.md`): `time() <op> metric` and `metric <op> time()` collapsed to an empty result in the compat lane.
- Root cause was in `lowerVectorVector`: when one leg is a synthetic-scalar plan (the `time()` / `vector(N)` / zero-arg date-fn shape with empty `MetricName` + empty `Attributes`) and the other is a real metric vector, the V-V `INNER JOIN` keyed on `(MetricName, Attributes)` finds zero matches against the metric's real `{instance, job, ...}` and the result is empty. Prom's semantics broadcast `time()` as a scalar across every `(series, step)` row of the metric.
- Fixes the 9 reported `time() <op> demo_memory_usage_bytes` diffs (one per `+`, `-`, `*`, `/`, `%`, `^`, `!=`, `<`, `<=`) and the symmetrical `metric <op> time()` direction — ~18 of the 185 residual diffs collapse to one.

## What changed

- `internal/promql/binary.go::lowerVectorVector` — detect the asymmetric synthetic-vector / real-vector shape and route through a new fold helper.
- `foldSyntheticVectorBinary` — extracts the synthetic side's `Value` expression, rewrites `ColumnRef{anchor_ts}` → `ColumnRef{TimeUnix}` (the metric leg's outer projection has already re-aliased the per-step anchor), and emits either a `Project` (arithmetic / `bool`-modified comparison) or a `Filter` (bare comparison) over the metric leg. The result mirrors `lowerVectorScalar`'s shape so the broadcast semantics line up.
- `rewriteAnchorToTimeUnix` — local walker that mirrors the `synthetic.go::rewriteAnchorRefs` shape (FuncCall / Binary / ColumnRef) so the spliced expression resolves against the metric leg's outer column.

## Tests

- 5 new TXTAR fixtures under `test/spec/promql/` covering both directions, arithmetic + bool comparison + bare comparison, instant + range mode.
- Extended `internal/api/prom/handler_chdb_step_loop_test.go::TestQueryRange_StepLoop_TimeMetric_ChDB` — pins the end-to-end matrix shape via chDB for 7 representative shapes (3 arithmetic, 2 non-commutative, 2 bool comparisons), one sub-case per row of Bucket 6.

## Test plan

- [x] `go test ./internal/promql/...` — 528 PASS (was 523, +5 fixture cases)
- [x] `go test -tags chdb -run TestRoundTripChDB ./test/spec/promql/...` — 203 PASS
- [x] `go test -tags chdb -run TestQueryRange_StepLoop ./internal/api/prom/...` — 28 PASS (includes new `TestQueryRange_StepLoop_TimeMetric_ChDB` with 7 sub-cases)
- [x] `go test ./...` — 2718 PASS in 36 packages
- [ ] Required CI checks (`check` + `lint`)