### PR TITLE
fix(promql,chsql): topk/bottomk select per-step in range mode

### DIFF
--- a/internal/api/prom/handler_chdb_range_mode_test.go
+++ b/internal/api/prom/handler_chdb_range_mode_test.go
@@ -1171,6 +1171,207 @@ func TestQueryRange_RangeMode_VVOnCompareGroupLeft_ChDB(t *testing.T) {
 	}
 }
 
+// TestQueryRange_RangeMode_TopK_ChDB pins `topk(K, v)` / `bottomk(K, v)`
+// per-step semantics under `/api/v1/query_range`. Bucket 5 of the
+// post-#350 compat residual audit (docs/compat-residual-audit-
+// 25898791664.md) flagged 8 diffs traceable to the partition list on
+// chplan.TopK omitting the per-step anchor. Pre-fix, the emitter
+// rendered `LIMIT K BY <user-partition>` which collapses N anchors ×
+// M series into a single K-row global window; Prom's semantics select
+// K series per anchor.
+//
+// The fix threads `TimeUnix` (the per-step anchor re-aliased by
+// wrapRangeLatestPerSeries) into TopK.By for range mode, so the
+// emitter renders `LIMIT K BY (..., TimeUnix)` and the per-step matrix
+// surfaces the correct K-per-anchor subset.
+//
+// Seed: 6 distinct series ranked by ascending Value (10, 20, 30, 40,
+// 50, 60). Each series has one sample per step. The bare topk(3, v)
+// should keep the top 3 (Value 60, 50, 40) at EVERY anchor — 3 series
+// × N anchors = 3*N matrix rows. The bottomk(3, v) should keep (10,
+// 20, 30) at every anchor. `topk by(group)` partitions by an extra
+// label so K-per-group-per-step holds; the `without` variants exercise
+// the MapWithoutKeys partition shape.
+func TestQueryRange_RangeMode_TopK_ChDB(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(5 * time.Minute)
+	step := 30 * time.Second
+	const wantSamples = 11
+
+	// Seed: 6 distinct series. Series 1-3 are in group=a (values 10,
+	// 20, 30); series 4-6 are in group=b (values 40, 50, 60). One
+	// sample per series per step (constant value across the time
+	// range so the per-step rank is deterministic).
+	seedRows := make([]string, 0, wantSamples*6)
+	for i := 0; i < wantSamples; i++ {
+		ts := start.Add(time.Duration(i) * step).Format("2006-01-02 15:04:05.000000000")
+		seedRows = append(seedRows,
+			fmt.Sprintf(`('demo_memory_usage_bytes', map('instance', 's1', 'group', 'a'), toDateTime64('%s', 9), 10.0)`, ts),
+			fmt.Sprintf(`('demo_memory_usage_bytes', map('instance', 's2', 'group', 'a'), toDateTime64('%s', 9), 20.0)`, ts),
+			fmt.Sprintf(`('demo_memory_usage_bytes', map('instance', 's3', 'group', 'a'), toDateTime64('%s', 9), 30.0)`, ts),
+			fmt.Sprintf(`('demo_memory_usage_bytes', map('instance', 's4', 'group', 'b'), toDateTime64('%s', 9), 40.0)`, ts),
+			fmt.Sprintf(`('demo_memory_usage_bytes', map('instance', 's5', 'group', 'b'), toDateTime64('%s', 9), 50.0)`, ts),
+			fmt.Sprintf(`('demo_memory_usage_bytes', map('instance', 's6', 'group', 'b'), toDateTime64('%s', 9), 60.0)`, ts),
+		)
+	}
+	seed := gaugeDDL + "\nINSERT INTO otel_metrics_gauge VALUES\n  " +
+		strings.Join(seedRows, ",\n  ") + ";"
+	srv, _ := newChDBServer(t, seed)
+
+	// Pre-fix: cerberus emitted `LIMIT 3` (or LIMIT K BY <user> alone)
+	// → the whole-query window collapsed to 3 rows TOTAL, leaving
+	// fewer than `wantSamples` distinct anchors in the matrix pivot.
+	// Post-fix: 3 series × N anchors = correct per-step shape.
+	t.Run("topk_bare", func(t *testing.T) {
+		matrix := runRangeModeQueryRange(t, srv.URL,
+			"topk(3, demo_memory_usage_bytes)", start, end, step)
+		// 3 series × N anchors → 3 series in the matrix (each with N
+		// samples). The top-3 by Value are s4 (40), s5 (50), s6 (60).
+		if len(matrix) != 3 {
+			t.Fatalf("topk bare: expected 3 series, got %d: %+v",
+				len(matrix), matrix)
+		}
+		wantInstances := map[string]string{"s4": "40", "s5": "50", "s6": "60"}
+		for _, ms := range matrix {
+			inst := ms.Metric["instance"]
+			want, ok := wantInstances[inst]
+			if !ok {
+				t.Errorf("topk bare: unexpected series instance=%q: %+v", inst, ms.Metric)
+				continue
+			}
+			if len(ms.Values) != wantSamples {
+				t.Errorf("topk bare: instance=%s: expected %d samples per step, got %d (pre-fix would collapse to a global subset): %+v",
+					inst, wantSamples, len(ms.Values), ms.Values)
+				continue
+			}
+			for i, v := range ms.Values {
+				if got := v[1]; got != want {
+					t.Errorf("topk bare: instance=%s step %d: value=%q want=%q (full row: %+v)",
+						inst, i, got, want, v)
+				}
+			}
+		}
+	})
+
+	t.Run("bottomk_bare", func(t *testing.T) {
+		matrix := runRangeModeQueryRange(t, srv.URL,
+			"bottomk(3, demo_memory_usage_bytes)", start, end, step)
+		// Bottom 3 by Value: s1 (10), s2 (20), s3 (30).
+		if len(matrix) != 3 {
+			t.Fatalf("bottomk bare: expected 3 series, got %d: %+v",
+				len(matrix), matrix)
+		}
+		wantInstances := map[string]string{"s1": "10", "s2": "20", "s3": "30"}
+		for _, ms := range matrix {
+			inst := ms.Metric["instance"]
+			want, ok := wantInstances[inst]
+			if !ok {
+				t.Errorf("bottomk bare: unexpected series instance=%q: %+v", inst, ms.Metric)
+				continue
+			}
+			if len(ms.Values) != wantSamples {
+				t.Errorf("bottomk bare: instance=%s: expected %d samples per step, got %d: %+v",
+					inst, wantSamples, len(ms.Values), ms.Values)
+				continue
+			}
+			for i, v := range ms.Values {
+				if got := v[1]; got != want {
+					t.Errorf("bottomk bare: instance=%s step %d: value=%q want=%q (full row: %+v)",
+						inst, i, got, want, v)
+				}
+			}
+		}
+	})
+
+	t.Run("topk_by_group", func(t *testing.T) {
+		// `topk by(group) (2, ...)` keeps the top-2 per `group`. group=a
+		// has values (10, 20, 30) → top-2 = (20, 30); group=b has
+		// values (40, 50, 60) → top-2 = (50, 60). At every anchor we
+		// expect exactly 4 series in the matrix.
+		matrix := runRangeModeQueryRange(t, srv.URL,
+			"topk by(group) (2, demo_memory_usage_bytes)", start, end, step)
+		if len(matrix) != 4 {
+			t.Fatalf("topk by(group): expected 4 series (top-2 per of 2 groups), got %d: %+v",
+				len(matrix), matrix)
+		}
+		wantInstances := map[string]string{"s2": "20", "s3": "30", "s5": "50", "s6": "60"}
+		for _, ms := range matrix {
+			inst := ms.Metric["instance"]
+			want, ok := wantInstances[inst]
+			if !ok {
+				t.Errorf("topk by(group): unexpected series instance=%q: %+v", inst, ms.Metric)
+				continue
+			}
+			if len(ms.Values) != wantSamples {
+				t.Errorf("topk by(group): instance=%s: expected %d samples per step, got %d: %+v",
+					inst, wantSamples, len(ms.Values), ms.Values)
+				continue
+			}
+			for i, v := range ms.Values {
+				if got := v[1]; got != want {
+					t.Errorf("topk by(group): instance=%s step %d: value=%q want=%q (full row: %+v)",
+						inst, i, got, want, v)
+				}
+			}
+		}
+	})
+
+	t.Run("bottomk_without_empty", func(t *testing.T) {
+		// `bottomk(K, v) without()` partitions by the full Attributes
+		// map (per-series). Each (series, step) tuple sits in its own
+		// partition, so `LIMIT K BY (Attributes, TimeUnix)` keeps 1
+		// row per partition — every (series, step) survives. The matrix
+		// therefore has 6 series × N anchors.
+		matrix := runRangeModeQueryRange(t, srv.URL,
+			"bottomk without() (5, demo_memory_usage_bytes)", start, end, step)
+		if len(matrix) != 6 {
+			t.Fatalf("bottomk without(): expected 6 series (per-series partitions), got %d: %+v",
+				len(matrix), matrix)
+		}
+		for _, ms := range matrix {
+			if len(ms.Values) != wantSamples {
+				t.Errorf("bottomk without(): instance=%s: expected %d per-step samples, got %d: %+v",
+					ms.Metric["instance"], wantSamples, len(ms.Values), ms.Values)
+			}
+		}
+	})
+
+	t.Run("topk_without_instance", func(t *testing.T) {
+		// `topk without(instance) (2, ...)` strips `instance` from the
+		// partition shape — partition keys collapse to {group}.
+		// Equivalent to grouping by everything except `instance`, which
+		// here yields 2 groups (a, b). Top-2 per group → 4 series in
+		// the matrix.
+		matrix := runRangeModeQueryRange(t, srv.URL,
+			"topk without(instance) (2, demo_memory_usage_bytes)", start, end, step)
+		if len(matrix) != 4 {
+			t.Fatalf("topk without(instance): expected 4 series, got %d: %+v",
+				len(matrix), matrix)
+		}
+		wantInstances := map[string]string{"s2": "20", "s3": "30", "s5": "50", "s6": "60"}
+		for _, ms := range matrix {
+			inst := ms.Metric["instance"]
+			want, ok := wantInstances[inst]
+			if !ok {
+				t.Errorf("topk without(instance): unexpected series instance=%q: %+v",
+					inst, ms.Metric)
+				continue
+			}
+			if len(ms.Values) != wantSamples {
+				t.Errorf("topk without(instance): instance=%s: expected %d samples per step, got %d: %+v",
+					inst, wantSamples, len(ms.Values), ms.Values)
+				continue
+			}
+			for i, v := range ms.Values {
+				if got := v[1]; got != want {
+					t.Errorf("topk without(instance): instance=%s step %d: value=%q want=%q (full row: %+v)",
+						inst, i, got, want, v)
+				}
+			}
+		}
+	})
+}
+
 // runRangeModeQueryRange is the test helper shared across the Pool-AK
 // range-mode regression cases. Mirrors `runStepLoopRange` but lives
 // in this file so the Pool-AK suite is self-contained for any future

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -867,6 +867,16 @@ func tryStringLiteral(e parser.Expr) (string, bool) {
 // degenerate `without ()` case (empty Grouping) means "remove nothing",
 // equivalent to partitioning by the full Attributes map; emit a bare
 // ColumnRef so we don't render an empty IN-list (CH rejects that).
+//
+// Range mode (ctx.step > 0): PromQL's topk/bottomk selects K series
+// **per evaluation step**, not K across the whole time range. The inner
+// plan (`wrapRangeLatestPerSeries`) re-aliases the per-step anchor onto
+// `TimeUnix`, so by appending TimeUnix to the partition list the
+// emitter's `LIMIT K BY (<user-partition>, TimeUnix)` selects K rows
+// per anchor — matching Prom's per-step semantics. Without this thread,
+// `LIMIT K BY <user-partition>` collapses every (series, step) pair
+// into a single K-row global window and the matrix pivot loses every
+// step beyond the K-th overall.
 func lowerTopK(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
 	kF, ok := tryScalarLiteral(a.Param)
 	if !ok {
@@ -910,6 +920,15 @@ func lowerTopK(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) (chplan.
 				Key: &chplan.LitString{V: label},
 			})
 		}
+	}
+
+	// Range mode: thread the per-step anchor (TimeUnix re-aliased from
+	// anchor_ts by the inner wrapRangeLatestPerSeries) into the partition
+	// list so `LIMIT K BY (..., TimeUnix)` fires per anchor. The instant
+	// path (ctx.step == 0) keeps the original partition shape so the
+	// existing instant-mode fixtures stay byte-stable.
+	if ctx.step > 0 {
+		by = append(by, &chplan.ColumnRef{Name: s.TimestampColumn})
 	}
 
 	return &chplan.TopK{

--- a/test/spec/promql/bottomk_range_bare.txtar
+++ b/test/spec/promql/bottomk_range_bare.txtar
@@ -1,0 +1,18 @@
+-- query.promql --
+bottomk(5, demo_memory_usage_bytes)
+-- range_step --
+30s
+-- args --
+[0] string = "demo_memory_usage_bytes"
+[1] int64 = 300000000000
+-- chplan --
+TopK k=5 sort=Value ASC by=[TimeUnix] columns=[MetricName, Attributes, TimeUnix, Value]
+  Project [MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS anchor_ts] funcs=[argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=((TimeUnix <= anchor_ts) AND (TimeUnix > (anchor_ts - toIntervalNanosecond(300000000000))))
+        CrossJoin
+          StepGrid start=2026-01-01T00:00:00.000000000Z end=2026-01-01T00:05:00.000000000Z step=30s
+          Filter predicate=(MetricName = "demo_memory_usage_bytes")
+            Scan(otel_metrics_gauge)
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `anchor_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT * FROM (SELECT arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:00:00.000000000', 9) + toIntervalNanosecond(i * 30000000000), range(0, 11))) AS `anchor_ts`) AS L CROSS JOIN (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) AS R) WHERE ((`TimeUnix` <= `anchor_ts`) AND (`TimeUnix` > (`anchor_ts` - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`, `anchor_ts`)) ORDER BY `Value` LIMIT 5 BY `TimeUnix`)

--- a/test/spec/promql/bottomk_range_by_instance.txtar
+++ b/test/spec/promql/bottomk_range_by_instance.txtar
@@ -1,0 +1,19 @@
+-- query.promql --
+bottomk by(instance) (5, demo_memory_usage_bytes)
+-- range_step --
+30s
+-- args --
+[0] string = "demo_memory_usage_bytes"
+[1] int64 = 300000000000
+[2] string = "instance"
+-- chplan --
+TopK k=5 sort=Value ASC by=[Attributes["instance"], TimeUnix] columns=[MetricName, Attributes, TimeUnix, Value]
+  Project [MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS anchor_ts] funcs=[argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=((TimeUnix <= anchor_ts) AND (TimeUnix > (anchor_ts - toIntervalNanosecond(300000000000))))
+        CrossJoin
+          StepGrid start=2026-01-01T00:00:00.000000000Z end=2026-01-01T00:05:00.000000000Z step=30s
+          Filter predicate=(MetricName = "demo_memory_usage_bytes")
+            Scan(otel_metrics_gauge)
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `anchor_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT * FROM (SELECT arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:00:00.000000000', 9) + toIntervalNanosecond(i * 30000000000), range(0, 11))) AS `anchor_ts`) AS L CROSS JOIN (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) AS R) WHERE ((`TimeUnix` <= `anchor_ts`) AND (`TimeUnix` > (`anchor_ts` - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`, `anchor_ts`)) ORDER BY `Value` LIMIT 5 BY `Attributes`[?], `TimeUnix`)

--- a/test/spec/promql/bottomk_range_without_empty.txtar
+++ b/test/spec/promql/bottomk_range_without_empty.txtar
@@ -1,0 +1,18 @@
+-- query.promql --
+bottomk without() (5, demo_memory_usage_bytes)
+-- range_step --
+30s
+-- args --
+[0] string = "demo_memory_usage_bytes"
+[1] int64 = 300000000000
+-- chplan --
+TopK k=5 sort=Value ASC by=[Attributes, TimeUnix] columns=[MetricName, Attributes, TimeUnix, Value]
+  Project [MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS anchor_ts] funcs=[argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=((TimeUnix <= anchor_ts) AND (TimeUnix > (anchor_ts - toIntervalNanosecond(300000000000))))
+        CrossJoin
+          StepGrid start=2026-01-01T00:00:00.000000000Z end=2026-01-01T00:05:00.000000000Z step=30s
+          Filter predicate=(MetricName = "demo_memory_usage_bytes")
+            Scan(otel_metrics_gauge)
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `anchor_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT * FROM (SELECT arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:00:00.000000000', 9) + toIntervalNanosecond(i * 30000000000), range(0, 11))) AS `anchor_ts`) AS L CROSS JOIN (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) AS R) WHERE ((`TimeUnix` <= `anchor_ts`) AND (`TimeUnix` > (`anchor_ts` - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`, `anchor_ts`)) ORDER BY `Value` LIMIT 5 BY `Attributes`, `TimeUnix`)

--- a/test/spec/promql/bottomk_range_without_instance.txtar
+++ b/test/spec/promql/bottomk_range_without_instance.txtar
@@ -1,0 +1,19 @@
+-- query.promql --
+bottomk without(instance) (5, demo_memory_usage_bytes)
+-- range_step --
+30s
+-- args --
+[0] string = "demo_memory_usage_bytes"
+[1] int64 = 300000000000
+[2] string = "instance"
+-- chplan --
+TopK k=5 sort=Value ASC by=[mapWithout(Attributes, [instance]), TimeUnix] columns=[MetricName, Attributes, TimeUnix, Value]
+  Project [MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS anchor_ts] funcs=[argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=((TimeUnix <= anchor_ts) AND (TimeUnix > (anchor_ts - toIntervalNanosecond(300000000000))))
+        CrossJoin
+          StepGrid start=2026-01-01T00:00:00.000000000Z end=2026-01-01T00:05:00.000000000Z step=30s
+          Filter predicate=(MetricName = "demo_memory_usage_bytes")
+            Scan(otel_metrics_gauge)
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `anchor_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT * FROM (SELECT arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:00:00.000000000', 9) + toIntervalNanosecond(i * 30000000000), range(0, 11))) AS `anchor_ts`) AS L CROSS JOIN (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) AS R) WHERE ((`TimeUnix` <= `anchor_ts`) AND (`TimeUnix` > (`anchor_ts` - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`, `anchor_ts`)) ORDER BY `Value` LIMIT 5 BY mapFilter((k, v) -> NOT (k IN (?)), `Attributes`), `TimeUnix`)

--- a/test/spec/promql/topk_range_bare.txtar
+++ b/test/spec/promql/topk_range_bare.txtar
@@ -1,0 +1,18 @@
+-- query.promql --
+topk(5, demo_memory_usage_bytes)
+-- range_step --
+30s
+-- args --
+[0] string = "demo_memory_usage_bytes"
+[1] int64 = 300000000000
+-- chplan --
+TopK k=5 sort=Value DESC by=[TimeUnix] columns=[MetricName, Attributes, TimeUnix, Value]
+  Project [MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS anchor_ts] funcs=[argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=((TimeUnix <= anchor_ts) AND (TimeUnix > (anchor_ts - toIntervalNanosecond(300000000000))))
+        CrossJoin
+          StepGrid start=2026-01-01T00:00:00.000000000Z end=2026-01-01T00:05:00.000000000Z step=30s
+          Filter predicate=(MetricName = "demo_memory_usage_bytes")
+            Scan(otel_metrics_gauge)
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `anchor_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT * FROM (SELECT arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:00:00.000000000', 9) + toIntervalNanosecond(i * 30000000000), range(0, 11))) AS `anchor_ts`) AS L CROSS JOIN (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) AS R) WHERE ((`TimeUnix` <= `anchor_ts`) AND (`TimeUnix` > (`anchor_ts` - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`, `anchor_ts`)) ORDER BY `Value` DESC LIMIT 5 BY `TimeUnix`)

--- a/test/spec/promql/topk_range_by_instance.txtar
+++ b/test/spec/promql/topk_range_by_instance.txtar
@@ -1,0 +1,19 @@
+-- query.promql --
+topk by(instance) (5, demo_memory_usage_bytes)
+-- range_step --
+30s
+-- args --
+[0] string = "demo_memory_usage_bytes"
+[1] int64 = 300000000000
+[2] string = "instance"
+-- chplan --
+TopK k=5 sort=Value DESC by=[Attributes["instance"], TimeUnix] columns=[MetricName, Attributes, TimeUnix, Value]
+  Project [MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS anchor_ts] funcs=[argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=((TimeUnix <= anchor_ts) AND (TimeUnix > (anchor_ts - toIntervalNanosecond(300000000000))))
+        CrossJoin
+          StepGrid start=2026-01-01T00:00:00.000000000Z end=2026-01-01T00:05:00.000000000Z step=30s
+          Filter predicate=(MetricName = "demo_memory_usage_bytes")
+            Scan(otel_metrics_gauge)
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `anchor_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT * FROM (SELECT arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:00:00.000000000', 9) + toIntervalNanosecond(i * 30000000000), range(0, 11))) AS `anchor_ts`) AS L CROSS JOIN (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) AS R) WHERE ((`TimeUnix` <= `anchor_ts`) AND (`TimeUnix` > (`anchor_ts` - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`, `anchor_ts`)) ORDER BY `Value` DESC LIMIT 5 BY `Attributes`[?], `TimeUnix`)

--- a/test/spec/promql/topk_range_without_empty.txtar
+++ b/test/spec/promql/topk_range_without_empty.txtar
@@ -1,0 +1,18 @@
+-- query.promql --
+topk without() (5, demo_memory_usage_bytes)
+-- range_step --
+30s
+-- args --
+[0] string = "demo_memory_usage_bytes"
+[1] int64 = 300000000000
+-- chplan --
+TopK k=5 sort=Value DESC by=[Attributes, TimeUnix] columns=[MetricName, Attributes, TimeUnix, Value]
+  Project [MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS anchor_ts] funcs=[argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=((TimeUnix <= anchor_ts) AND (TimeUnix > (anchor_ts - toIntervalNanosecond(300000000000))))
+        CrossJoin
+          StepGrid start=2026-01-01T00:00:00.000000000Z end=2026-01-01T00:05:00.000000000Z step=30s
+          Filter predicate=(MetricName = "demo_memory_usage_bytes")
+            Scan(otel_metrics_gauge)
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `anchor_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT * FROM (SELECT arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:00:00.000000000', 9) + toIntervalNanosecond(i * 30000000000), range(0, 11))) AS `anchor_ts`) AS L CROSS JOIN (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) AS R) WHERE ((`TimeUnix` <= `anchor_ts`) AND (`TimeUnix` > (`anchor_ts` - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`, `anchor_ts`)) ORDER BY `Value` DESC LIMIT 5 BY `Attributes`, `TimeUnix`)

--- a/test/spec/promql/topk_range_without_instance.txtar
+++ b/test/spec/promql/topk_range_without_instance.txtar
@@ -1,0 +1,19 @@
+-- query.promql --
+topk without(instance) (5, demo_memory_usage_bytes)
+-- range_step --
+30s
+-- args --
+[0] string = "demo_memory_usage_bytes"
+[1] int64 = 300000000000
+[2] string = "instance"
+-- chplan --
+TopK k=5 sort=Value DESC by=[mapWithout(Attributes, [instance]), TimeUnix] columns=[MetricName, Attributes, TimeUnix, Value]
+  Project [MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS anchor_ts] funcs=[argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=((TimeUnix <= anchor_ts) AND (TimeUnix > (anchor_ts - toIntervalNanosecond(300000000000))))
+        CrossJoin
+          StepGrid start=2026-01-01T00:00:00.000000000Z end=2026-01-01T00:05:00.000000000Z step=30s
+          Filter predicate=(MetricName = "demo_memory_usage_bytes")
+            Scan(otel_metrics_gauge)
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `anchor_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT * FROM (SELECT arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:00:00.000000000', 9) + toIntervalNanosecond(i * 30000000000), range(0, 11))) AS `anchor_ts`) AS L CROSS JOIN (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) AS R) WHERE ((`TimeUnix` <= `anchor_ts`) AND (`TimeUnix` > (`anchor_ts` - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`, `anchor_ts`)) ORDER BY `Value` DESC LIMIT 5 BY mapFilter((k, v) -> NOT (k IN (?)), `Attributes`), `TimeUnix`)


### PR DESCRIPTION
## Summary

Bucket 5 from the post-#350 compatibility residual audit (#355,
[`docs/compat-residual-audit-25898791664.md`](https://github.com/tsouza/cerberus/blob/main/docs/compat-residual-audit-25898791664.md#bucket-5--topk--bottomk-is-global-not-per-step-8-diffs-l)).

PromQL `topk(K, v)` semantics: select the top-K series **per
evaluation step** in `query_range` mode. Pre-fix cerberus emitted
`ORDER BY Value LIMIT K [BY <user-partition>]` which is correct for
instant queries but wrong for range queries — the partition didn't
include the per-step anchor, so the SQL collapsed every (series, step)
pair into a single K-row global window. Result: 8 compat-lane diffs,
one per `{topk,bottomk}` × `{bare, by(instance), without(), without(instance)}`
variant.

The inner of `lowerTopK` already exposes the per-step anchor on the
`TimeUnix` column (`wrapRangeLatestPerSeries` re-aliases `anchor_ts →
TimeUnix`). The fix threads that column into `chplan.TopK.By` when
`ctx.step > 0` so the emitter renders `LIMIT K BY (..., TimeUnix)` —
CH groups by the extended partition list and selects K rows per
(user-partition, step) tuple.

Reuses the per-step StepGrid pattern from Pool-AK (#347), Pool-AL
(#348), and Pool-AP (#353).

## Before / after

`topk(5, demo_memory_usage_bytes)` in range mode:

**Before** (one global LIMIT 5 across the whole time window):

```sql
ORDER BY `Value` DESC LIMIT 5
```

**After** (K per anchor):

```sql
ORDER BY `Value` DESC LIMIT 5 BY `TimeUnix`
```

`topk by(instance) (5, demo_memory_usage_bytes)`:

```sql
ORDER BY `Value` DESC LIMIT 5 BY `Attributes`[?], `TimeUnix`
```

## Surface

- `internal/promql/lower.go` — `lowerTopK` appends `ColumnRef{TimeUnix}`
  to `By` when `ctx.step > 0`. Instant mode untouched.
- `internal/api/prom/handler_chdb_range_mode_test.go` —
  `TestQueryRange_RangeMode_TopK_ChDB` (5 sub-tests: `topk_bare`,
  `bottomk_bare`, `topk_by_group`, `bottomk_without_empty`,
  `topk_without_instance`) pin the matrix shape end-to-end.
- `test/spec/promql/{topk,bottomk}_range_{bare,by_instance,without_empty,without_instance}.txtar` — 8 new TXTAR fixtures, one per failing
  compat pattern.

Instant-mode topk/bottomk fixtures stay byte-stable (gate is
`ctx.step > 0`).

## Test plan

- [x] `go test ./internal/promql/...` → 531 passed
- [x] `go test -tags chdb ./internal/api/prom/...` → 227 passed
- [x] `go test ./test/regression/...` → 17 passed
- [x] `go test ./internal/chplan/... ./internal/chsql/... ./internal/optimizer/... ./test/spec/...` → 731 passed
- [x] `go test -tags chdb ./internal/api/prom/ -run TestQueryRange_RangeMode_TopK_ChDB` → 6 passed
- [x] 4 existing instant-mode topk fixtures remain byte-stable