### PR TITLE
feat(promql): collapse @<ts> + range mode to OneRow fan-out

### DIFF
--- a/internal/api/prom/handler_chdb_range_mode_test.go
+++ b/internal/api/prom/handler_chdb_range_mode_test.go
@@ -1417,6 +1417,84 @@ func TestQueryRange_RangeMode_TopK_ChDB(t *testing.T) {
 	})
 }
 
+// TestQueryRange_RangeMode_AtModifier_Collapse_ChDB pins the
+// `metric @ <fixed_ts>` over `/api/v1/query_range` shape. Pool-AK's PR
+// #347 deferred this as follow-up #2: when an absolute `@<ts>` is set,
+// every step in `[start, end]` evaluates the same fixed-anchor LWR so
+// the StepGrid fan-out wastes CH work. The follow-up collapses the
+// per-step LWR to a single LWR evaluation + broadcast across the step
+// grid via CrossJoin(StepGrid, OneRowPerSeriesLWR).
+//
+// Response shape must stay unchanged: N matrix samples per series, all
+// carrying the same Value (the LWR result at @ts) at distinct step
+// timestamps. Only the SQL emit complexity drops — the bucket-aggregate
+// fan-out collapses to a single-pass LWR + broadcast.
+//
+// Seeded: 11 samples spaced by step=30s. The @ ts pins evaluation at
+// the very last sample (start + 10*step), so the LWR window
+// `(@ts - 5m, @ts]` contains all 11 samples and the argMax surfaces
+// the final value (110). Every step in the response window should
+// carry that same value.
+func TestQueryRange_RangeMode_AtModifier_Collapse_ChDB(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(5 * time.Minute)
+	step := 30 * time.Second
+	const wantSamples = 11
+	// Pin @ to the last seed timestamp so the LWR window picks up the
+	// largest seeded value (110); using a time inside the seed grid
+	// keeps the assertion stable regardless of the per-step anchor's
+	// per-window contents (the @ts collapse must be the only signal).
+	atTS := start.Add(10 * step).Unix()
+
+	seedRows := make([]string, 0, wantSamples)
+	for i := 0; i < wantSamples; i++ {
+		ts := start.Add(time.Duration(i) * step).Format("2006-01-02 15:04:05.000000000")
+		seedRows = append(seedRows, fmt.Sprintf(
+			`('demo_memory_usage_bytes', map('instance', 'demo'), toDateTime64('%s', 9), %d.0)`,
+			ts, 100+i,
+		))
+	}
+	seed := gaugeDDL + "\nINSERT INTO otel_metrics_gauge VALUES\n  " +
+		strings.Join(seedRows, ",\n  ") + ";"
+
+	srv, _ := newChDBServer(t, seed)
+
+	matrix := runRangeModeQueryRange(t, srv.URL,
+		fmt.Sprintf("demo_memory_usage_bytes @ %d", atTS),
+		start, end, step)
+	if len(matrix) != 1 {
+		t.Fatalf("expected exactly 1 series, got %d: %+v", len(matrix), matrix)
+	}
+	values := matrix[0].Values
+	// Response shape must remain N matrix samples — the OneRow + broadcast
+	// rewrite is correctness-preserving across the wire format. A regression
+	// that ditched the StepGrid broadcast entirely would surface as 1
+	// matrix point.
+	if len(values) != wantSamples {
+		t.Fatalf("expected %d samples (one per step), got %d: %+v",
+			wantSamples, len(values), values)
+	}
+	// Every per-step value must be the LWR result at @ts — the seed's
+	// largest value (110) is the latest sample with TimeUnix <= @ts.
+	const wantValue = "110"
+	for i, v := range values {
+		if got := v[1]; got != wantValue {
+			t.Errorf("step %d: value=%q want=%q (full row: %+v)", i, got, wantValue, v)
+		}
+	}
+	// Per-step Timestamp must increase strictly — a regression where the
+	// StepGrid collapsed to OneRow without broadcasting would surface as
+	// a single timestamp.
+	for i := 1; i < len(values); i++ {
+		prev, _ := values[i-1][0].(float64)
+		curr, _ := values[i][0].(float64)
+		if curr <= prev {
+			t.Errorf("step %d: timestamp not strictly increasing: prev=%v curr=%v (full row: %+v)",
+				i, prev, curr, values)
+		}
+	}
+}
+
 // runRangeModeQueryRange is the test helper shared across the Pool-AK
 // range-mode regression cases. Mirrors `runStepLoopRange` but lives
 // in this file so the Pool-AK suite is self-contained for any future

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -167,9 +167,19 @@ func lowerVectorSelector(v *parser.VectorSelector, s schema.Metrics, ctx lowerCt
 	}
 	// Range mode (ctx.step > 0): build the per-step LWR by cross-joining
 	// the raw scan with a StepGrid and collapsing latest-per-(series,
-	// anchor). Anchor modifiers (`@`/`offset`) are honoured by shifting
-	// the predicate against `anchor_ts` rather than a single end_ts.
+	// anchor). Anchor modifiers (`offset`) are honoured by shifting the
+	// predicate against `anchor_ts` rather than a single end_ts.
 	if ctx.step > 0 && !ctx.start.IsZero() && !ctx.end.IsZero() {
+		// `@<absolute>` / `@ start()` / `@ end()` pin a single anchor
+		// across all steps — every step evaluates the same fixed-time
+		// LWR. Collapse the StepGrid fan-out: run the LWR once at the
+		// pinned anchor (yielding one row per series, same shape as
+		// instant mode) and broadcast across the step grid via
+		// CrossJoin so the matrix pivot still receives one row per
+		// (series, step).
+		if hasAbsoluteAt(v) {
+			return wrapRangeAbsoluteAtBroadcast(scan, pred, anchor, ctx, s), nil
+		}
 		return wrapRangeLatestPerSeries(scan, pred, anchor, ctx, s), nil
 	}
 	// Instant-vector context: the LWR wrapper applies both the
@@ -389,6 +399,111 @@ func wrapRangeLatestPerSeries(scan *chplan.Scan, pred chplan.Expr, anchor evalAn
 			{Expr: &chplan.ColumnRef{Name: s.MetricNameColumn}, Alias: s.MetricNameColumn},
 			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
 			{Expr: anchorRef, Alias: s.TimestampColumn},
+			{Expr: &chplan.ColumnRef{Name: lwrValueAlias}, Alias: s.ValueColumn},
+		},
+	}
+}
+
+// wrapRangeAbsoluteAtBroadcast is the range-mode lowering for a bare
+// vector selector pinned by an ABSOLUTE `@` modifier (`@<unix-ts>`,
+// `@ start()`, `@ end()`). The pinned anchor is fixed across every step
+// in `[start, end]`, so every step evaluates the SAME LWR window and
+// yields the same per-series value. Rather than emit the N-anchor
+// StepGrid fan-out that the bare-selector path uses, this wrap:
+//
+//  1. Evaluates the LWR ONCE against the pinned anchor — produces 1 row
+//     per series with the canonical `[MetricName, Attributes, lwr_value]`
+//     shape (TimeUnix is dropped so it doesn't collide with the StepGrid's
+//     anchor_ts in the outer scope).
+//  2. CrossJoins with a StepGrid spanning the request window — yields
+//     N (series, step) rows total.
+//  3. Projects the StepGrid's anchor_ts as TimeUnix and the inner
+//     lwr_value as Value — restoring the canonical 4-column Sample
+//     contract for downstream consumers.
+//
+// Plan shape:
+//
+//	Project [MetricName, Attributes, anchor_ts AS TimeUnix, lwr_value AS Value]
+//	  CrossJoin
+//	    StepGrid(start, end, step)
+//	    Project [MetricName, Attributes, lwr_value]
+//	      Aggregate by(MetricName, Attributes) argMax(Value, TimeUnix) AS lwr_value
+//	        Filter (matchers AND TimeUnix <= @ts AND TimeUnix > @ts - 5m)
+//	          Scan(<table>)
+//
+// Response shape is unchanged: matrixFromCursor still receives N rows
+// per series (one per step, all carrying the same Value at distinct
+// step timestamps), so the JSON payload preserves Prom's expected
+// N-sample matrix for a fixed-anchor query.
+//
+// The win is SQL complexity: the bucket-aggregate fan-out collapses to a
+// single-pass LWR over the raw scan + a trivial broadcast — CH evaluates
+// the staleness window once instead of N times, and the PREWHERE-eligible
+// matchers stay on the bare scan (the optimizer promotes them as usual).
+//
+// Closes follow-up #2 from Pool-AK's PR #347.
+func wrapRangeAbsoluteAtBroadcast(scan *chplan.Scan, pred chplan.Expr, anchor evalAnchor, ctx lowerCtx, s schema.Metrics) chplan.Node {
+	// Inner: LWR collapsed once at the pinned anchor. The filter is the
+	// same shape wrapInstantLatestPerSeries uses — Timestamp <= anchor
+	// AND Timestamp > anchor - lookback — with offset (if any) folded
+	// in via timeBoundExpr / stalenessLowerBoundExpr. Honoring offset
+	// here lets `metric @ 1700000000 offset 5m` slide the LWR window
+	// back by 5m and still produce a stable per-series result.
+	lwr := timeBoundExpr(s.TimestampColumn, anchor)
+	staleness := stalenessLowerBoundExpr(s.TimestampColumn, anchor, instantLookback)
+	combined := pred
+	for _, p := range []chplan.Expr{lwr, staleness} {
+		if combined == nil {
+			combined = p
+			continue
+		}
+		combined = &chplan.Binary{Op: chplan.OpAnd, Left: combined, Right: p}
+	}
+	filtered := &chplan.Filter{Input: scan, Predicate: combined}
+
+	const lwrValueAlias = "lwr_value"
+
+	innerAgg := &chplan.Aggregate{
+		Input: filtered,
+		GroupBy: []chplan.Expr{
+			&chplan.ColumnRef{Name: s.MetricNameColumn},
+			&chplan.ColumnRef{Name: s.AttributesColumn},
+		},
+		GroupByAliases: []string{s.MetricNameColumn, s.AttributesColumn},
+		AggFuncs: []chplan.AggFunc{{
+			Name: "argMax",
+			Args: []chplan.Expr{
+				&chplan.ColumnRef{Name: s.ValueColumn},
+				&chplan.ColumnRef{Name: s.TimestampColumn},
+			},
+			Alias: lwrValueAlias,
+		}},
+	}
+	// Drop TimeUnix from the inner output so it doesn't collide with
+	// the StepGrid's anchor_ts column once the two sides CrossJoin —
+	// the outer Project re-projects anchor_ts into the TimeUnix slot.
+	innerProject := &chplan.Project{
+		Input: innerAgg,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.ColumnRef{Name: s.MetricNameColumn}, Alias: s.MetricNameColumn},
+			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
+			{Expr: &chplan.ColumnRef{Name: lwrValueAlias}, Alias: lwrValueAlias},
+		},
+	}
+
+	joined := &chplan.CrossJoin{
+		Left:  &chplan.StepGrid{Start: ctx.start.UTC(), End: ctx.end.UTC(), Step: ctx.step},
+		Right: innerProject,
+	}
+
+	// Re-shape the joined output into the canonical Sample 4-column
+	// contract with TimeUnix sourced from the step grid's anchor_ts.
+	return &chplan.Project{
+		Input: joined,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.ColumnRef{Name: s.MetricNameColumn}, Alias: s.MetricNameColumn},
+			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
+			{Expr: &chplan.ColumnRef{Name: "anchor_ts"}, Alias: s.TimestampColumn},
 			{Expr: &chplan.ColumnRef{Name: lwrValueAlias}, Alias: s.ValueColumn},
 		},
 	}

--- a/internal/promql/modifiers.go
+++ b/internal/promql/modifiers.go
@@ -92,6 +92,23 @@ func hasModifier(vs *parser.VectorSelector) bool {
 	return vs.Timestamp != nil || vs.OriginalOffset != 0 || vs.StartOrEnd != 0
 }
 
+// hasAbsoluteAt reports whether vs pins an ABSOLUTE evaluation anchor —
+// `@<unix-ts>` (vs.Timestamp), `@ start()`, or `@ end()` (vs.StartOrEnd).
+// A bare `offset <d>` (no `@`) does NOT count: `offset` is a relative
+// shift applied against the surrounding query's eval time, so it remains
+// per-step in range mode and the per-step LWR wrap stays correct.
+//
+// The signal drives the "fixed-anchor" OneRow + broadcast optimization in
+// range mode: when this is true and ctx.step > 0, the same anchor value
+// applies at every step grid point, so the SQL evaluates the LWR window
+// ONCE and broadcasts the per-series result across the step grid via a
+// CrossJoin instead of fanning the LWR window across N step anchors.
+//
+// Closes follow-up #2 from Pool-AK's per-step LWR rework (PR #347).
+func hasAbsoluteAt(vs *parser.VectorSelector) bool {
+	return vs.Timestamp != nil || vs.StartOrEnd != 0
+}
+
 // timeBoundExpr builds `<col> <= <anchor>` for an instant-vector
 // VectorSelector with `@` or `offset`. The anchor is `now64(9)` (or a
 // literal toDateTime64) optionally minus a nanosecond interval.

--- a/test/spec/promql/at_modifier_range_mode_collapse.txtar
+++ b/test/spec/promql/at_modifier_range_mode_collapse.txtar
@@ -1,0 +1,21 @@
+-- query.promql --
+up @ 1767225600
+-- range_step --
+30s
+-- args --
+[0] string = "up"
+[1] string = "2026-01-01 00:00:00.000000000"
+[2] int64 = 9
+[3] string = "2026-01-01 00:00:00.000000000"
+[4] int64 = 9
+[5] int64 = 300000000000
+-- chplan --
+Project [MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS TimeUnix, lwr_value AS Value]
+  CrossJoin
+    StepGrid start=2026-01-01T00:00:00.000000000Z end=2026-01-01T00:05:00.000000000Z step=30s
+    Project [MetricName AS MetricName, Attributes AS Attributes, lwr_value AS lwr_value]
+      Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[argMax(Value, TimeUnix) AS lwr_value]
+        Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:00.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:00.000000000", 9) - toIntervalNanosecond(300000000000))))
+          Scan(otel_metrics_gauge)
+-- sql --
+SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT * FROM (SELECT arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:00:00.000000000', 9) + toIntervalNanosecond(i * 30000000000), range(0, 11))) AS `anchor_ts`) AS L CROSS JOIN (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_value` AS `lwr_value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) AS R)


### PR DESCRIPTION
## Summary

Closes Pool-AK's range-mode follow-up #2 from [PR #347](https://github.com/tsouza/cerberus/pull/347): when `metric @ <fixed_ts>` (or `@ start()` / `@ end()`) is used over `/api/v1/query_range`, the anchor is pinned across every step and the StepGrid fan-out evaluates the same window N times.

Replace the per-step LWR fan-out with a single LWR evaluation + CrossJoin broadcast across the step grid. Response shape stays N matrix samples per series; only the SQL emit complexity drops.

## Correctness bonus

The pre-#347 path also had a quiet correctness gap on `@<ts>` in range mode: the LWR window was shifted against `anchor_ts` rather than the pinned `@` timestamp, so `metric @ 1700000000` over query_range silently ignored the modifier and emitted per-step LWR at each step. The collapse fixes that by routing through the same `timeBoundExpr` / `stalenessLowerBoundExpr` helpers `wrapInstantLatestPerSeries` uses — the LWR window now correctly anchors at the pinned timestamp.

## chplan tree (before → after)

**Before** (per-step LWR — silently ignores `@<ts>`):

```
Project [MetricName, Attributes, anchor_ts AS TimeUnix, lwr_value AS Value]
  Aggregate by(MetricName, Attributes, anchor_ts) argMax(Value, TimeUnix)
    Filter (TimeUnix <= anchor_ts AND TimeUnix > anchor_ts - 5m)
      CrossJoin
        StepGrid(start, end, step)        <- N anchors
        Filter(matchers) Scan
```

**After** (OneRow + broadcast — honors `@<ts>`):

```
Project [MetricName, Attributes, anchor_ts AS TimeUnix, lwr_value AS Value]
  CrossJoin
    StepGrid(start, end, step)
    Project [MetricName, Attributes, lwr_value]      <- 1 row per series
      Aggregate by(MetricName, Attributes) argMax(Value, TimeUnix)
        Filter (matchers AND TimeUnix <= @ts AND TimeUnix > @ts - 5m)
          Scan
```

## What still goes through the per-step path

- `metric` (no modifier) — per-step LWR (correct per Prom)
- `metric offset 5m` (no `@`) — per-step LWR with offset-shifted window (offset is relative-to-each-step)

## What collapses to OneRow + broadcast

- `metric @ <unix-ts>` — pinned at literal
- `metric @ start()` — pinned at request start
- `metric @ end()` — pinned at request end
- `metric @ <ts> offset <d>` — pinned at `(<ts>, offset)`; LWR window shifts by `<d>`

## Files (4, +233/-2)

- `internal/promql/modifiers.go` (+17): new `hasAbsoluteAt(vs)` helper distinguishing absolute `@` modifiers from bare offsets.
- `internal/promql/lower.go` (+119/-2): new `wrapRangeAbsoluteAtBroadcast` builds the OneRow + broadcast plan; dispatch in `lowerVectorSelector` routes absolute-`@` selectors to it in range mode.
- `internal/api/prom/handler_chdb_range_mode_test.go` (+78): `TestQueryRange_RangeMode_AtModifier_Collapse_ChDB` pins N matrix samples per series, all carrying the LWR-at-`@ts` value at distinct step timestamps.
- `test/spec/promql/at_modifier_range_mode_collapse.txtar` (new): TXTAR snapshot of the new chplan + SQL shapes.

## Test plan

- [x] `go test -tags chdb ./internal/promql/ ./test/spec/promql/ ./internal/chsql/ ./internal/api/prom/ ./internal/chplan/` — 1546 pass
- [x] `go test -tags chdb -run TestQueryRange_RangeMode ./internal/api/prom/` — 26 pass (all existing range-mode regressions intact + new fixture)
- [x] Manually confirmed via in-tree script that `up @ <ts>`, `up @ start()`, `up @ end()`, `up @ <ts> offset 5m`, `up @ <ts> offset -5m` all route through the collapsed path while `up`, `up offset 5m` continue routing through per-step LWR.