### PR TITLE
test(spec): tighten LogQL+TraceQL tautological round-trip fixtures (P2/P3)

### DIFF
--- a/test/spec/logql/label_filter_chained.txtar
+++ b/test/spec/logql/label_filter_chained.txtar
@@ -13,12 +13,18 @@ SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (position(`Bod
 -- seed --
 CREATE TABLE otel_logs (
     Body String,
-    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api', 'env', 'prod', 'severity', 'high')
+    ResourceAttributes Map(String, String) MATERIALIZED map(
+        'job', 'api',
+        'env', if(Body = 'error: stg-env', 'stg', 'prod'),
+        'severity', if(Body = 'error: low-sev', 'low', 'high')
+    )
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Body) VALUES
     ('error: ouch'),
     ('info: fine'),
-    ('error: again');
+    ('error: again'),
+    ('error: stg-env'),
+    ('error: low-sev');
 -- expected_rows --
 [
   ["error: ouch"],

--- a/test/spec/logql/label_filter_eq.txtar
+++ b/test/spec/logql/label_filter_eq.txtar
@@ -10,9 +10,12 @@ SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (`ResourceAttr
 -- seed --
 CREATE TABLE otel_logs (
     Body String,
-    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api', 'env', 'prod')
+    ResourceAttributes Map(String, String) MATERIALIZED map(
+        'job', 'api',
+        'env', if(Body = 'e3-stg', 'stg', 'prod')
+    )
 ) ENGINE = Memory;
-INSERT INTO otel_logs (Body) VALUES ('e1'), ('e2');
+INSERT INTO otel_logs (Body) VALUES ('e1'), ('e2'), ('e3-stg');
 -- expected_rows --
 [
   ["e1"],

--- a/test/spec/logql/label_filter_or.txtar
+++ b/test/spec/logql/label_filter_or.txtar
@@ -12,9 +12,12 @@ SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND ((`ResourceAtt
 -- seed --
 CREATE TABLE otel_logs (
     Body String,
-    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api', 'env', 'stg')
+    ResourceAttributes Map(String, String) MATERIALIZED map(
+        'job', 'api',
+        'env', if(Body = 'o1', 'prod', if(Body = 'o2', 'stg', 'dev'))
+    )
 ) ENGINE = Memory;
-INSERT INTO otel_logs (Body) VALUES ('o1'), ('o2');
+INSERT INTO otel_logs (Body) VALUES ('o1'), ('o2'), ('o3-dev');
 -- expected_rows --
 [
   ["o1"],

--- a/test/spec/logql/label_filter_regex.txtar
+++ b/test/spec/logql/label_filter_regex.txtar
@@ -10,9 +10,12 @@ SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND match(`Resourc
 -- seed --
 CREATE TABLE otel_logs (
     Body String,
-    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api', 'env', 'prod')
+    ResourceAttributes Map(String, String) MATERIALIZED map(
+        'job', 'api',
+        'env', if(Body = 'r1', 'prod', if(Body = 'r2', 'stg', 'dev'))
+    )
 ) ENGINE = Memory;
-INSERT INTO otel_logs (Body) VALUES ('r1'), ('r2');
+INSERT INTO otel_logs (Body) VALUES ('r1'), ('r2'), ('r3-dev');
 -- expected_rows --
 [
   ["r1"],

--- a/test/spec/logql/level_label_filter.txtar
+++ b/test/spec/logql/level_label_filter.txtar
@@ -10,9 +10,12 @@ SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (`ResourceAttr
 -- seed --
 CREATE TABLE otel_logs (
     Body String,
-    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api', 'level', 'ERROR')
+    ResourceAttributes Map(String, String) MATERIALIZED map(
+        'job', 'api',
+        'level', if(Body = 'info log', 'INFO', 'ERROR')
+    )
 ) ENGINE = Memory;
-INSERT INTO otel_logs (Body) VALUES ('error log one'), ('error log two');
+INSERT INTO otel_logs (Body) VALUES ('error log one'), ('error log two'), ('info log');
 -- expected_rows --
 [
   ["error log one"],

--- a/test/spec/logql/multiple_label_matchers.txtar
+++ b/test/spec/logql/multiple_label_matchers.txtar
@@ -10,9 +10,12 @@ SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (`ResourceAttr
 -- seed --
 CREATE TABLE otel_logs (
     Body String,
-    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api', 'env', 'prod')
+    ResourceAttributes Map(String, String) MATERIALIZED map(
+        'job', if(Body = 'two-other-job', 'web', 'api'),
+        'env', if(Body = 'one-other-env', 'dev', 'prod')
+    )
 ) ENGINE = Memory;
-INSERT INTO otel_logs (Body) VALUES ('one'), ('two');
+INSERT INTO otel_logs (Body) VALUES ('one'), ('two'), ('one-other-env'), ('two-other-job');
 -- expected_rows --
 [
   ["one"],

--- a/test/spec/logql/pattern_with_label_filter.txtar
+++ b/test/spec/logql/pattern_with_label_filter.txtar
@@ -10,9 +10,12 @@ SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (`ResourceAttr
 -- seed --
 CREATE TABLE otel_logs (
     Body String,
-    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api', 'level', 'error')
+    ResourceAttributes Map(String, String) MATERIALIZED map(
+        'job', 'api',
+        'level', if(Body = 'ts info skip', 'info', 'error')
+    )
 ) ENGINE = Memory;
-INSERT INTO otel_logs (Body) VALUES ('ts error oops'), ('ts error retry');
+INSERT INTO otel_logs (Body) VALUES ('ts error oops'), ('ts error retry'), ('ts info skip');
 -- expected_rows --
 [
   ["ts error oops"],

--- a/test/spec/logql/stream_selector.txtar
+++ b/test/spec/logql/stream_selector.txtar
@@ -8,13 +8,12 @@ SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?)
 -- seed --
 CREATE TABLE otel_logs (
     Body String,
-    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api')
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', if(Body = 'beta', 'other', 'api'))
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Body) VALUES ('alpha'), ('beta'), ('gamma');
 -- expected_rows --
 [
   ["alpha"],
-  ["beta"],
   ["gamma"]
 ]
 -- chplan --

--- a/test/spec/logql/stream_with_regex.txtar
+++ b/test/spec/logql/stream_with_regex.txtar
@@ -8,9 +8,9 @@ SELECT * FROM `otel_logs` WHERE match(`ResourceAttributes`[?], ?)
 -- seed --
 CREATE TABLE otel_logs (
     Body String,
-    ResourceAttributes Map(String, String) MATERIALIZED map('env', 'prod')
+    ResourceAttributes Map(String, String) MATERIALIZED map('env', if(Body = 'm1', 'prod', if(Body = 'm2', 'stg', 'dev')))
 ) ENGINE = Memory;
-INSERT INTO otel_logs (Body) VALUES ('m1'), ('m2');
+INSERT INTO otel_logs (Body) VALUES ('m1'), ('m2'), ('m3');
 -- expected_rows --
 [
   ["m1"],

--- a/test/spec/logql/stream_with_two_labels.txtar
+++ b/test/spec/logql/stream_with_two_labels.txtar
@@ -10,9 +10,12 @@ SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (`ResourceAttr
 -- seed --
 CREATE TABLE otel_logs (
     Body String,
-    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api', 'env', 'prod')
+    ResourceAttributes Map(String, String) MATERIALIZED map(
+        'job', if(Body = 'world-other-job', 'web', 'api'),
+        'env', if(Body = 'hello-other-env', 'dev', 'prod')
+    )
 ) ENGINE = Memory;
-INSERT INTO otel_logs (Body) VALUES ('hello'), ('world');
+INSERT INTO otel_logs (Body) VALUES ('hello'), ('world'), ('hello-other-env'), ('world-other-job');
 -- expected_rows --
 [
   ["hello"],

--- a/test/spec/logql/unpack_with_label_filter.txtar
+++ b/test/spec/logql/unpack_with_label_filter.txtar
@@ -10,9 +10,12 @@ SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (`ResourceAttr
 -- seed --
 CREATE TABLE otel_logs (
     Body String,
-    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api', 'level', 'error')
+    ResourceAttributes Map(String, String) MATERIALIZED map(
+        'job', 'api',
+        'level', if(Body = 'packed info skip', 'info', 'error')
+    )
 ) ENGINE = Memory;
-INSERT INTO otel_logs (Body) VALUES ('packed error one'), ('packed error two');
+INSERT INTO otel_logs (Body) VALUES ('packed error one'), ('packed error two'), ('packed info skip');
 -- expected_rows --
 [
   ["packed error one"],

--- a/test/spec/logql/whitespace_in_braces.txtar
+++ b/test/spec/logql/whitespace_in_braces.txtar
@@ -8,9 +8,9 @@ SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?)
 -- seed --
 CREATE TABLE otel_logs (
     Body String,
-    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api')
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', if(Body = 'whitespace', 'api', 'web'))
 ) ENGINE = Memory;
-INSERT INTO otel_logs (Body) VALUES ('whitespace');
+INSERT INTO otel_logs (Body) VALUES ('whitespace'), ('other');
 -- expected_rows --
 [
   ["whitespace"]

--- a/test/spec/roundtrip.go
+++ b/test/spec/roundtrip.go
@@ -43,8 +43,13 @@ import (
 // RoundTripSections is the parsed shape of the optional `seed:` /
 // `expected_rows:` / `sql:` / `args:` sections attached to a fixture.
 //
-// When `Seed` or `ExpectedRows` is empty, the fixture has not opted
-// into round-trip execution. Callers should check IsRoundTrip().
+// When `Seed` is empty or `expected_rows:` is missing, the fixture
+// has not opted into round-trip execution. Callers should check
+// IsRoundTrip(). An explicit empty array (`[]`) IS a valid opt-in
+// — it asserts the predicate filters all rows out, which is the
+// only way to make post-aggregation predicate boundaries (e.g.
+// `| count() > 0` against zero matching rows) discriminating in the
+// round-trip layer.
 type RoundTripSections struct {
 	// Seed is the CH DDL+INSERT script that populates the in-process
 	// chDB session. The runner splits on semicolons and runs each
@@ -55,7 +60,8 @@ type RoundTripSections struct {
 	// ExpectedRows is the parsed JSON content of `expected_rows:`.
 	// Each row is a slice of `any` mirroring the emitted SQL's
 	// SELECT projection. Map columns are unmarshalled as
-	// map[string]any.
+	// map[string]any. Stays nil when the section is absent; becomes
+	// `[][]any{}` (non-nil, len 0) when the section is `[]`.
 	ExpectedRows [][]any
 
 	// SQL is the raw `sql:` section (after normalization). The
@@ -66,12 +72,19 @@ type RoundTripSections struct {
 	// Args is the bound []any matching the `?` placeholders in SQL,
 	// parsed from the `args:` text format the emitter writes.
 	Args []any
+
+	// expectedRowsPresent records whether the fixture authored an
+	// `expected_rows:` section at all (even an empty `[]`), so
+	// IsRoundTrip can distinguish "no opt-in" from "opt-in,
+	// asserts zero rows".
+	expectedRowsPresent bool
 }
 
 // IsRoundTrip reports whether the fixture opted into the
-// seed+expected_rows assertion path.
+// seed+expected_rows assertion path. An explicit `expected_rows: []`
+// counts as opt-in.
 func (r *RoundTripSections) IsRoundTrip() bool {
-	return strings.TrimSpace(r.Seed) != "" && len(r.ExpectedRows) > 0
+	return strings.TrimSpace(r.Seed) != "" && r.expectedRowsPresent
 }
 
 // LoadRoundTrip extracts `seed:` / `expected_rows:` / `sql:` / `args:`
@@ -86,8 +99,16 @@ func LoadRoundTrip(c *Case) (*RoundTripSections, error) {
 	if v, ok := c.Section("expected_rows"); ok {
 		v = strings.TrimSpace(v)
 		if v != "" {
+			out.expectedRowsPresent = true
 			if err := json.Unmarshal([]byte(v), &out.ExpectedRows); err != nil {
 				return nil, fmt.Errorf("expected_rows JSON: %w", err)
+			}
+			if out.ExpectedRows == nil {
+				// `[]` unmarshals to a nil slice in some Go
+				// versions; normalize to non-nil empty slice so
+				// reflect.DeepEqual against the runner's empty
+				// `got` slice succeeds.
+				out.ExpectedRows = [][]any{}
 			}
 		}
 	}

--- a/test/spec/traceql/count.txtar
+++ b/test/spec/traceql/count.txtar
@@ -12,14 +12,11 @@ CREATE TABLE otel_traces (
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_traces VALUES
-    (map('service.name', 'frontend')),
-    (map('service.name', 'frontend')),
-    (map('service.name', 'frontend')),
-    (map('service.name', 'backend'));
+    (map('service.name', 'backend')),
+    (map('service.name', 'db')),
+    (map('service.name', 'cache'));
 -- expected_rows --
-[
-  [3]
-]
+[]
 -- chplan --
 Filter predicate=(Value > 0)
   Aggregate groupBy=[] funcs=[count(1) AS Value]

--- a/test/spec/traceql/count_eq_zero.txtar
+++ b/test/spec/traceql/count_eq_zero.txtar
@@ -12,13 +12,11 @@ CREATE TABLE otel_traces (
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_traces VALUES
-    (map('service.name', 'backend')),
-    (map('service.name', 'db')),
-    (map('service.name', 'cache'));
+    (map('service.name', 'frontend')),
+    (map('service.name', 'frontend')),
+    (map('service.name', 'backend'));
 -- expected_rows --
-[
-  [0]
-]
+[]
 -- chplan --
 Filter predicate=(Value = 0)
   Aggregate groupBy=[] funcs=[count(1) AS Value]

--- a/test/spec/traceql/count_ge_threshold.txtar
+++ b/test/spec/traceql/count_ge_threshold.txtar
@@ -15,13 +15,9 @@ INSERT INTO otel_traces VALUES
     (map('service.name', 'frontend')),
     (map('service.name', 'frontend')),
     (map('service.name', 'frontend')),
-    (map('service.name', 'frontend')),
-    (map('service.name', 'frontend')),
     (map('service.name', 'backend'));
 -- expected_rows --
-[
-  [5]
-]
+[]
 -- chplan --
 Filter predicate=(Value >= 5)
   Aggregate groupBy=[] funcs=[count(1) AS Value]

--- a/test/spec/traceql/count_lt_threshold.txtar
+++ b/test/spec/traceql/count_lt_threshold.txtar
@@ -15,11 +15,18 @@ INSERT INTO otel_traces VALUES
     (map('service.name', 'frontend')),
     (map('service.name', 'frontend')),
     (map('service.name', 'frontend')),
+    (map('service.name', 'frontend')),
+    (map('service.name', 'frontend')),
+    (map('service.name', 'frontend')),
+    (map('service.name', 'frontend')),
+    (map('service.name', 'frontend')),
+    (map('service.name', 'frontend')),
+    (map('service.name', 'frontend')),
+    (map('service.name', 'frontend')),
+    (map('service.name', 'frontend')),
     (map('service.name', 'backend'));
 -- expected_rows --
-[
-  [3]
-]
+[]
 -- chplan --
 Filter predicate=(Value < 10)
   Aggregate groupBy=[] funcs=[count(1) AS Value]


### PR DESCRIPTION
## Summary

Closes Pool-AR's audit follow-up (PR #352, `docs/test-spec-audit.md`)
for the **P2 (LogQL)** and **P3 (TraceQL)** tautology categories.
Both classes had round-trip assertions that were tautological — the
seed pre-satisfied (or didn't yet violate) the predicate being
tested, so the chDB round-trip layer couldn't distinguish "filter
works" from "filter dropped" even though the lower→SQL text golden
still caught a fully dropped predicate.

### What changed

- **P2 — 12 LogQL fixtures** (stream-selector + label-filter
  family): seed now materialises non-matching rows so the WHERE
  clause actually filters during chDB execution. Materialised
  expressions stay parameterised by `Body` content so the existing
  `SELECT *` → `Body String` projection shape is preserved.
- **P3 — 4 TraceQL `count_*` fixtures**: seed now produces a count
  value the outer `WHERE Value op ?` filters out, asserting
  `expected_rows: []`. Without the WHERE the query would return
  `[[count_value]]` so the round-trip diff is loud.
- **`test/spec/roundtrip.go`**: `IsRoundTrip()` used to require
  non-empty `ExpectedRows`, silently skipping fixtures authored
  with `expected_rows: []`. Track section presence with a private
  `expectedRowsPresent` bool so explicit empty `[]` becomes a valid
  opt-in (needed by the P3 fixtures).

### LogQL fixtures touched (12)

Stream-selector:
- `stream_selector` — adds `job=other` row
- `stream_with_regex` — adds `env=dev` row
- `stream_with_two_labels` — adds rows failing each matcher
- `multiple_label_matchers` — adds rows failing each matcher
- `whitespace_in_braces` — adds `job=web` row

Label-filter:
- `label_filter_eq` — adds `env=stg` row
- `label_filter_or` — adds `env=dev` row
- `label_filter_regex` — adds `env=dev` row
- `label_filter_chained` — adds rows failing each clause individually
- `level_label_filter` — adds `level=INFO` row
- `pattern_with_label_filter` — adds `level=info` row
- `unpack_with_label_filter` — adds `level=info` row

### TraceQL fixtures touched (4)

- `count` (`count() > 0`) — 3 non-frontend rows → count=0 → `[]`
- `count_eq_zero` (`count() = 0`) — 2 frontend rows → count=2 → `[]`
- `count_ge_threshold` (`count() >= 5`) — 3 frontend rows → count=3 → `[]`
- `count_lt_threshold` (`count() < 10`) — 12 frontend rows → count=12 → `[]`

### What is intentionally NOT touched

The 8 post-fetch-no-op LogQL stages (`pattern`, `unpack`, `decolorize`,
`label_format`, `line_format`, `line_format_compose`,
`pattern_then_line_format`, `unpack_then_line_format`) are
lowering-no-ops in `internal/logql/lower.go` — their behaviour lives
in `internal/api/loki/post_process.go` and is covered there. The
audit (#352) called these out as "flagged for completeness; not a
bug". Untouched.

The TraceQL P1 (chplan parity gap — 0 of 107 TraceQL fixtures carry
`chplan` snapshots) was already shipped in #354. This PR covers
P2 + P3 only.

### Sanity check

Manually verified discrimination by:

1. **LogQL** — dropped the `WHERE` clause from `stream_selector.txtar`'s
   `sql:` section, re-ran `go test -tags chdb`; round-trip failed with
   `got=3 rows, want=2 rows` (alpha+gamma matched, beta filtered).
2. **TraceQL** — dropped the outer `WHERE Value >= ?` from
   `count_ge_threshold.txtar`, re-ran; round-trip failed with
   `got=[[3]], want=[]`.

Both reverted before commit.

## Test plan

- [x] `go test -tags chdb -count=1 ./test/spec/...` (377 PASS across all 4 spec packages)
- [x] `go test -count=1 ./internal/{logql,traceql,promql}/ ./test/spec/...` (971 PASS — SQL/chplan goldens unchanged)
- [x] Sanity check: dropping `WHERE` clause from one LogQL + one TraceQL fixture makes round-trip fail with the expected diff
- [ ] CI (`check` + `lint`)