### PR TITLE
feat(harness/loki-compatibility): scaffold compose + seed + run script

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -402,6 +402,24 @@ compatibility-keep:
 compatibility-down:
     cd harness/prometheus-compliance && docker compose down -v
 
+# === Compatibility (LogQL — Loki compatibility harness, scaffold) ===
+
+# Run the LogQL compatibility scaffold smoke. PR 1 of the rollout plan
+# in docs/loki-compliance-plan.md: brings up reference Loki + cerberus +
+# CH, seeds both, asserts /labels is non-empty on each. Corpus + diff
+# driver land in PR 2-3.
+loki-compatibility:
+    ./harness/loki-compatibility/scripts/run-loki-compatibility.sh
+
+# Keep the Loki compatibility stack running after the smoke finishes
+# (for debugging /loki/api/v1/* + ClickHouse manually).
+loki-compatibility-keep:
+    COMPOSE_KEEP=1 ./harness/loki-compatibility/scripts/run-loki-compatibility.sh
+
+# Tear down the Loki compatibility stack manually.
+loki-compatibility-down:
+    cd harness/loki-compatibility && docker compose down -v
+
 # === Shadow-mode differential testing (RC3 R3.9) ===
 
 # Build + run the shadow-mode harness against a corpus.

--- a/harness/loki-compatibility/README.md
+++ b/harness/loki-compatibility/README.md
@@ -1,0 +1,100 @@
+# LogQL compatibility harness
+
+Mirrors [`harness/prometheus-compliance/`](../prometheus-compliance/) for the
+LogQL side. Stands up reference Grafana Loki and cerberus side-by-side,
+seeds both with the same deterministic log stream, and (in later PRs)
+diffs query results between the two.
+
+This directory currently contains **PR 1 of 6**: the scaffold.
+
+## What's here (PR 1)
+
+```text
+harness/loki-compatibility/
+  README.md                            this file
+  docker-compose.yml                   clickhouse + loki (reference) + cerberus
+  loki-config.yaml                     single-binary Loki, filesystem backend
+  cmd/seed/                            deterministic CH + Loki dual-write seeder
+  scripts/run-loki-compatibility.sh    compose up --wait, run seeder, tear down
+```
+
+## What's deferred
+
+Per [`docs/loki-compliance-plan.md`](../../docs/loki-compliance-plan.md):
+
+- **PR 2** vendors `grafana/loki:pkg/logql/bench/` under `upstream/loki-bench/`
+  and adds `cerberus-test-queries.yml` (curated YAML corpus overlay) and
+  `dataset_metadata.json`.
+- **PR 3** ports the upstream `TestRemoteStorageEquality` diff driver +
+  wires `scripts/run-loki-compatibility.sh` to invoke it (initially just
+  builds + runs the diff loop against the seeded fixture).
+- **PR 4** adds the `.github/workflows/loki-compatibility.yml` informational
+  CI lane (push-to-main + nightly + manual dispatch).
+- **PR 5** ports the diff driver to cerberus-owned code under
+  `cmd/loki-compliance-tester/` for report-format parity with the Prom
+  harness.
+- **PR 6** expands the corpus into `queries/regression/` + slices of
+  `queries/exhaustive/`.
+
+## Usage
+
+From the repo root:
+
+```sh
+just loki-compatibility            # compose up, seed, smoke /labels, tear down
+just loki-compatibility-keep       # same, but leave the stack running
+just loki-compatibility-down       # tear down a stack left running by -keep
+```
+
+Or directly:
+
+```sh
+./harness/loki-compatibility/scripts/run-loki-compatibility.sh
+```
+
+## Endpoints (when the stack is up)
+
+| Service    | Host:port                | Role                                    |
+| ---------- | ------------------------ | --------------------------------------- |
+| ClickHouse | `localhost:28000` (TCP)  | OTel-schema, `otel_logs`                |
+|            | `localhost:28223` (HTTP) | same                                    |
+| Loki       | `localhost:23100`        | reference target                        |
+| cerberus   | `localhost:29092`        | test target (LogQL on `/loki/api/v1/*`) |
+
+Port allocation is offset from the prometheus-compliance harness so the
+two stacks can coexist on the same dev host.
+
+## Seeder
+
+`cmd/seed/` writes the same deterministic fixture to both targets:
+
+- **ClickHouse** — `INSERT INTO otel_logs` with the column layout from
+  the upstream OTel-CH Exporter DDL (`internal/schema/ddl`).
+- **Loki** — HTTP POST to `/loki/api/v1/push` with `{streams:[...]}`.
+
+Fixture shape: 4 services × 600 entries × 1 entry/sec = 10 minutes of
+deterministic log data anchored at `2026-05-11T00:00:00Z`. Both writes
+use the same anchor + same line bodies, so diff output in PR 3+ will
+surface genuine LogQL semantic gaps, not data asymmetry.
+
+Smoke contract: after the seeder runs, `GET /loki/api/v1/labels` MUST
+return non-empty on BOTH `:23100` (reference Loki) and `:29092`
+(cerberus), and `SELECT count() FROM otel_logs` on the CH side MUST
+return > 0. The seeder polls each target and fails fast if any
+condition isn't met within 30s.
+
+The /labels probe passes a wide `[start, end]` window covering the
+fixture anchor plus a buffer on each side — cerberus reads from CH
+via `Timestamp BETWEEN ...`, so a window-less /labels call returns
+empty. The wide window also absorbs the (system clock vs anchor)
+skew that arises when CI runs days after the anchor date. PR 3's
+diff driver will thread tighter per-query windows for the actual
+result comparisons; the smoke just needs both endpoints alive.
+
+## License
+
+Cerberus itself is MIT. PR 2 will vendor an AGPLv3 corpus from
+`grafana/loki:pkg/logql/bench/` under `upstream/loki-bench/` with the
+upstream LICENSE preserved — same posture as
+[`harness/prometheus-compliance/upstream/promql/`](../prometheus-compliance/upstream/promql/).
+PR 1 vendors nothing, so the AGPL note only applies once PR 2 lands.

--- a/harness/loki-compatibility/cmd/seed/main.go
+++ b/harness/loki-compatibility/cmd/seed/main.go
@@ -1,0 +1,515 @@
+// Command seed loads the deterministic log fixture used by the LogQL
+// compatibility harness.
+//
+// It does three things:
+//
+//  1. Applies the upstream OTel ClickHouse Exporter DDL (logs signal) via
+//     internal/schema/ddl, so the harness's schema can't drift from what
+//     cerberus's auto-create path produces.
+//  2. Generates a deterministic log stream (3-5 services × ~600 entries
+//     each at 1s spacing, anchored at a fixed timestamp) and fans it out
+//     to both targets:
+//     - ClickHouse via INSERT INTO otel_logs (the path cerberus reads
+//     from when answering LogQL queries).
+//     - Loki via HTTP POST /loki/api/v1/push (the path the reference
+//     target reads from when answering LogQL queries).
+//  3. Polls /loki/api/v1/labels and the CH otel_logs table until both
+//     report non-empty, then prints a summary.
+//
+// The two writes carry the same content modulo each backend's storage
+// shape: same anchor timestamp, same service set, same line bodies.
+// Differences in query results will surface in PR 2's diff driver as
+// genuine LogQL/wire semantics gaps — not as data asymmetry.
+//
+// Replaces no prior file; this is the inaugural Loki-side seeder.
+// Invoked by scripts/run-loki-compatibility.sh against a docker-compose
+// stack exposing CH on localhost:28000 and Loki on localhost:23100
+// (override via CERBERUS_CH_ADDR / LOKI_URL).
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+
+	"github.com/tsouza/cerberus/internal/schema/ddl"
+)
+
+// anchor is the fixture's start timestamp. Every generated log entry
+// sits at anchor + i*1s for i in [0, entriesPerService). Keep this in
+// lock-step with scripts/run-loki-compatibility.sh's TESTER_END_TIME
+// default when that lands in PR 3.
+const anchor = "2026-05-11T00:00:00Z"
+
+// services enumerates the synthetic service names mirrored across both
+// targets. Each becomes one Loki stream (`{service="…"}`) and one
+// ResourceAttributes key (`service.name=…`) on the CH side. The count
+// (3-5) matches the per-PR plan in docs/loki-compliance-plan.md.
+var services = []string{"checkout", "payments", "search", "shipping"}
+
+// entriesPerService is the per-stream line count. 600 × 1s = 10 minutes —
+// the upper bound of the plan's 5-10 minute window. Keeping it at the
+// upper bound gives the future diff driver enough range-query depth.
+const entriesPerService = 600
+
+func main() {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	if err := run(logger); err != nil {
+		logger.Error("seed failed", "err", err)
+		os.Exit(1)
+	}
+}
+
+func run(logger *slog.Logger) error {
+	var (
+		addr     = flag.String("addr", envOr("CERBERUS_CH_ADDR", "localhost:28000"), "ClickHouse host:port")
+		database = flag.String("database", envOr("CERBERUS_CH_DATABASE", "otel"), "ClickHouse database")
+		username = flag.String("user", envOr("CERBERUS_CH_USERNAME", "cerberus"), "ClickHouse username")
+		password = flag.String("password", envOr("CERBERUS_CH_PASSWORD", "cerberus"), "ClickHouse password")
+		lokiURL  = flag.String("loki-url", envOr("LOKI_URL", "http://localhost:23100"), "Reference Loki base URL")
+		cerbURL  = flag.String("cerberus-url", envOr("CERBERUS_URL", "http://localhost:29092"), "cerberus LogQL base URL")
+		timeout  = flag.Duration("timeout", 2*time.Minute, "overall dial + push + verify timeout")
+	)
+	flag.Parse()
+
+	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
+	defer cancel()
+
+	logger.Info("dialing clickhouse", "addr", *addr, "database", *database)
+	conn, err := clickhouse.Open(&clickhouse.Options{
+		Addr: []string{*addr},
+		Auth: clickhouse.Auth{
+			Database: *database,
+			Username: *username,
+			Password: *password,
+		},
+		DialTimeout: 5 * time.Second,
+	})
+	if err != nil {
+		return fmt.Errorf("open: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	if err := waitCHReady(ctx, conn, logger); err != nil {
+		return err
+	}
+
+	logger.Info("applying ddl", "signal", "logs")
+	cfg := ddl.Config{Database: *database}
+	if err := ddl.ApplyWithConfig(ctx, conn, cfg, []ddl.Signal{ddl.Logs}); err != nil {
+		return fmt.Errorf("ddl.Apply: %w", err)
+	}
+
+	start, err := time.Parse(time.RFC3339, anchor)
+	if err != nil {
+		return fmt.Errorf("parse anchor: %w", err)
+	}
+
+	streams := buildStreams(start)
+	totalEntries := 0
+	for _, s := range streams {
+		totalEntries += len(s.entries)
+	}
+	logger.Info("generated fixture",
+		"streams", len(streams),
+		"entries_per_service", entriesPerService,
+		"total_entries", totalEntries,
+		"anchor", anchor,
+		"span_seconds", entriesPerService,
+	)
+
+	logger.Info("inserting into clickhouse otel_logs")
+	if err := insertCHLogs(ctx, conn, streams); err != nil {
+		return fmt.Errorf("insert clickhouse: %w", err)
+	}
+
+	logger.Info("waiting for loki readiness", "url", *lokiURL)
+	if err := waitLokiReady(ctx, *lokiURL, logger); err != nil {
+		return fmt.Errorf("loki not ready: %w", err)
+	}
+
+	logger.Info("pushing into loki", "url", *lokiURL)
+	if err := pushLoki(ctx, *lokiURL, streams); err != nil {
+		return fmt.Errorf("push loki: %w", err)
+	}
+
+	logger.Info("verifying /labels is non-empty on both targets")
+	if err := verifyBothNonEmpty(ctx, conn, *lokiURL, *cerbURL, logger); err != nil {
+		return fmt.Errorf("verify: %w", err)
+	}
+
+	logger.Info("sample log line", "line", streams[0].entries[0].line)
+	logger.Info("seed done",
+		"streams", len(streams),
+		"total_entries", totalEntries,
+	)
+	return nil
+}
+
+// stream is one logical {service=...} stream that fans out to both Loki
+// (as one /push streams entry) and ClickHouse (as N rows in otel_logs).
+type stream struct {
+	service string
+	entries []entry
+}
+
+type entry struct {
+	ts   time.Time
+	line string
+}
+
+// buildStreams generates the deterministic fixture. The output is
+// stable across runs: same anchor, same line ordering, same level
+// rotation — so re-running the seeder against a fresh CH + Loki gives
+// byte-identical content.
+func buildStreams(start time.Time) []stream {
+	levels := []string{"INFO", "WARN", "ERROR", "DEBUG"}
+	templates := []string{
+		"%s service=%s msg=request_received path=/api/v1/items rid=%06d",
+		"%s service=%s msg=cache_hit key=tenant-%d duration_ms=%d",
+		"%s service=%s msg=db_query rows=%d duration_ms=%d",
+		"%s service=%s msg=request_completed status=200 duration_ms=%d rid=%06d",
+	}
+	out := make([]stream, 0, len(services))
+	for si, svc := range services {
+		s := stream{service: svc, entries: make([]entry, 0, entriesPerService)}
+		for i := 0; i < entriesPerService; i++ {
+			ts := start.Add(time.Duration(i) * time.Second)
+			level := levels[i%len(levels)]
+			// rotate template index across services so coverage of
+			// each line shape is spread evenly — service A starts at
+			// template 0, service B at template 1, etc.
+			tmpl := templates[(i+si)%len(templates)]
+			var line string
+			switch (i + si) % len(templates) {
+			case 0:
+				line = fmt.Sprintf(tmpl, level, svc, i)
+			case 1:
+				line = fmt.Sprintf(tmpl, level, svc, i%17, 5+(i%23))
+			case 2:
+				line = fmt.Sprintf(tmpl, level, svc, i%101, 1+(i%19))
+			case 3:
+				line = fmt.Sprintf(tmpl, level, svc, 2+(i%13), i)
+			}
+			s.entries = append(s.entries, entry{ts: ts, line: line})
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+// waitCHReady polls SELECT 1 until ClickHouse answers or ctx expires.
+// The compose healthcheck already gates this, but the seeder may be
+// invoked from run-loki-compatibility.sh against a freshly started
+// container — the extra poll absorbs the ~1s tail where ping passes but
+// Exec doesn't.
+func waitCHReady(ctx context.Context, conn driver.Conn, logger *slog.Logger) error {
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		err := conn.Exec(ctx, "SELECT 1")
+		if err == nil {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("clickhouse not ready: %w", err)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(500 * time.Millisecond):
+		}
+		logger.Debug("waiting for clickhouse", "err", err)
+	}
+}
+
+// waitLokiReady polls Loki /ready until it returns 200. The compose
+// healthcheck already gates this — the extra poll exists for cases
+// where the seeder is invoked directly (e.g. `go run ...` against a
+// hand-started compose stack).
+func waitLokiReady(ctx context.Context, baseURL string, logger *slog.Logger) error {
+	deadline := time.Now().Add(60 * time.Second)
+	url := strings.TrimRight(baseURL, "/") + "/ready"
+	for {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return err
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return nil
+			}
+		}
+		if time.Now().After(deadline) {
+			if err != nil {
+				return fmt.Errorf("loki /ready: %w", err)
+			}
+			return fmt.Errorf("loki /ready returned %d", resp.StatusCode)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(500 * time.Millisecond):
+		}
+		logger.Debug("waiting for loki", "url", url)
+	}
+}
+
+// insertCHLogs writes every (service, entry) pair into otel_logs using
+// a single batched INSERT. The label schema mirrors the OTel-CH Exporter
+// shape: service.name on ResourceAttributes, level on LogAttributes,
+// SeverityText pulled from the line's leading token. TraceId / SpanId
+// stay empty — the fixture is synthetic without trace correlation.
+//
+// Column list / order matches sqltemplates/logs_insert.sql verbatim
+// (TimestampTime is `DEFAULT toDateTime(Timestamp)` so we don't write
+// it explicitly; EventName isn't in the upstream insert).
+func insertCHLogs(ctx context.Context, conn driver.Conn, streams []stream) error {
+	batch, err := conn.PrepareBatch(ctx, `INSERT INTO otel_logs (
+        Timestamp, TraceId, SpanId, TraceFlags,
+        SeverityText, SeverityNumber, ServiceName, Body,
+        ResourceSchemaUrl, ResourceAttributes,
+        ScopeSchemaUrl, ScopeName, ScopeVersion, ScopeAttributes,
+        LogAttributes
+    )`)
+	if err != nil {
+		return fmt.Errorf("prepare batch: %w", err)
+	}
+
+	for _, s := range streams {
+		for _, e := range s.entries {
+			level := strings.SplitN(e.line, " ", 2)[0]
+			if err := batch.Append(
+				e.ts,
+				"",
+				"",
+				uint8(0),
+				level,
+				severityNumber(level),
+				s.service,
+				e.line,
+				"",
+				map[string]string{"service.name": s.service},
+				"",
+				"cerberus-loki-compat-seeder",
+				"1",
+				map[string]string{},
+				map[string]string{"level": level, "service": s.service},
+			); err != nil {
+				return fmt.Errorf("append: %w", err)
+			}
+		}
+	}
+	if err := batch.Send(); err != nil {
+		return fmt.Errorf("send batch: %w", err)
+	}
+	return nil
+}
+
+// severityNumber maps the level token to the OTel-CH SeverityNumber
+// scale (https://opentelemetry.io/docs/specs/otel/logs/data-model/).
+// Return type is uint8 so it matches the otel_logs DDL column type
+// without an extra conversion at the call site.
+func severityNumber(level string) uint8 {
+	switch strings.ToUpper(level) {
+	case "TRACE":
+		return 1
+	case "DEBUG":
+		return 5
+	case "INFO":
+		return 9
+	case "WARN", "WARNING":
+		return 13
+	case "ERROR":
+		return 17
+	case "FATAL":
+		return 21
+	}
+	return 0
+}
+
+// pushLoki POSTs the streams to /loki/api/v1/push as one JSON body. The
+// payload shape matches the Loki ingest contract:
+//
+//	{"streams":[{"stream":{"service":"checkout","level":"info"},
+//	              "values":[["<ns_ts>","<line>"], ...]}]}
+//
+// `values` is ordered oldest-first; Loki accepts either direction but
+// preserves the strictly-increasing ordering the fixture builds.
+func pushLoki(ctx context.Context, baseURL string, streams []stream) error {
+	type pushStream struct {
+		Stream map[string]string `json:"stream"`
+		Values [][2]string       `json:"values"`
+	}
+	type pushBody struct {
+		Streams []pushStream `json:"streams"`
+	}
+
+	body := pushBody{Streams: make([]pushStream, 0, len(streams))}
+	for _, s := range streams {
+		ps := pushStream{
+			Stream: map[string]string{"service": s.service},
+			Values: make([][2]string, 0, len(s.entries)),
+		}
+		for _, e := range s.entries {
+			ps.Values = append(ps.Values, [2]string{
+				fmt.Sprintf("%d", e.ts.UnixNano()),
+				e.line,
+			})
+		}
+		body.Streams = append(body.Streams, ps)
+	}
+
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	url := strings.TrimRight(baseURL, "/") + "/loki/api/v1/push"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(raw))
+	if err != nil {
+		return fmt.Errorf("new request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "cerberus-loki-compat-seeder/1")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("do: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode/100 != 2 {
+		bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("loki returned %d: %s", resp.StatusCode, string(bodyBytes))
+	}
+	return nil
+}
+
+// verifyBothNonEmpty asserts the PR 1 smoke contract: /loki/api/v1/labels
+// returns non-empty on BOTH the reference Loki and the cerberus side, and
+// the CH otel_logs table is non-empty. Each check has its own short poll
+// loop — Loki's index is asynchronous (a /push returning 200 doesn't
+// guarantee /labels sees the new stream immediately), and cerberus may
+// still be warming its CH connection pool right after compose start.
+func verifyBothNonEmpty(ctx context.Context, conn driver.Conn, lokiURL, cerbURL string, logger *slog.Logger) error {
+	// CH side — direct COUNT against otel_logs. Fast and authoritative.
+	var chCount uint64
+	if err := conn.QueryRow(ctx, "SELECT count() FROM otel_logs").Scan(&chCount); err != nil {
+		return fmt.Errorf("ch count: %w", err)
+	}
+	if chCount == 0 {
+		return fmt.Errorf("clickhouse otel_logs is empty after seed")
+	}
+	logger.Info("clickhouse otel_logs row count", "rows", chCount)
+
+	// Build a [start, end] window that brackets the anchor with enough
+	// slack to absorb each backend's quirks:
+	//   - Cerberus scans otel_logs by `Timestamp BETWEEN start AND end`,
+	//     so the window MUST cover the anchor (2026-05-11T00:00:00Z →
+	//     anchor + 10min). Without it cerberus's /labels is empty even
+	//     though CH holds the rows.
+	//   - Reference Loki's index is built async by ingest time. When the
+	//     fixture's anchor is in the past relative to system time (as
+	//     happens during CI runs that don't pin the clock), the
+	//     freshly-pushed chunks aren't yet visible under a narrow
+	//     anchor-aligned window — so we widen to [anchor - 1d, now + 1d]
+	//     to absorb any (system clock vs anchor) skew. PR 3's diff
+	//     driver will need to thread per-query time windows correctly;
+	//     the smoke just needs both endpoints to report non-empty
+	//     /labels.
+	anchorTS, err := time.Parse(time.RFC3339, anchor)
+	if err != nil {
+		return fmt.Errorf("parse anchor: %w", err)
+	}
+	start := anchorTS.Add(-24 * time.Hour)
+	end := time.Now().Add(24 * time.Hour)
+	if end.Before(anchorTS.Add(time.Hour)) {
+		end = anchorTS.Add(time.Hour)
+	}
+	for _, target := range []struct {
+		label, base string
+	}{
+		{"loki", lokiURL},
+		{"cerberus", cerbURL},
+	} {
+		if err := waitLabelsNonEmpty(ctx, target.label, target.base, start, end, logger); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// waitLabelsNonEmpty polls baseURL + /loki/api/v1/labels for up to 30s
+// and returns once the response carries at least one label name. The
+// [start, end] window is passed as `?start=<ns>&end=<ns>` so cerberus's
+// time-windowed label scan covers the seeded fixture.
+func waitLabelsNonEmpty(ctx context.Context, label, baseURL string, start, end time.Time, logger *slog.Logger) error {
+	deadline := time.Now().Add(30 * time.Second)
+	url := fmt.Sprintf("%s/loki/api/v1/labels?start=%d&end=%d",
+		strings.TrimRight(baseURL, "/"), start.UnixNano(), end.UnixNano())
+	for {
+		labels, err := fetchLokiLabels(ctx, url)
+		if err == nil && len(labels) > 0 {
+			sort.Strings(labels)
+			logger.Info("/labels non-empty", "target", label, "url", url, "labels", labels)
+			return nil
+		}
+		if time.Now().After(deadline) {
+			if err != nil {
+				return fmt.Errorf("%s /labels: %w", label, err)
+			}
+			return fmt.Errorf("%s /labels returned 0 labels after 30s", label)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+}
+
+// fetchLokiLabels parses the Loki /labels response shape
+//
+//	{"status":"success","data":["__name__","service",...]}
+func fetchLokiLabels(ctx context.Context, url string) ([]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status %d", resp.StatusCode)
+	}
+	var out struct {
+		Status string   `json:"status"`
+		Data   []string `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+	return out.Data, nil
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/harness/loki-compatibility/docker-compose.yml
+++ b/harness/loki-compatibility/docker-compose.yml
@@ -1,0 +1,93 @@
+# Docker Compose stack for the LogQL compatibility harness.
+#
+# Services:
+#   clickhouse    OTel-schema CH instance (auth: cerberus/cerberus, db: otel)
+#   loki          reference Loki, listens on :23100 (single-binary,
+#                 filesystem backend, no auth — matches the upstream
+#                 quick-start config)
+#   cerberus      cerberus under test, listens on :29092 (matches
+#                 test-cerberus.yml when that lands in PR 2)
+#
+# Seeding is invoked by `go run ./harness/loki-compatibility/cmd/seed/`
+# from scripts/run-loki-compatibility.sh — it pushes the same
+# deterministic log streams to both Loki (/loki/api/v1/push) and the CH
+# `otel_logs` table.
+#
+# Port allocation mirrors the prometheus-compliance harness but offset by
+# one so the two stacks can coexist on the same dev host:
+#   prometheus-compliance  CH 29000/28123, prom :29090, cerberus :29091
+#   loki-compatibility     CH 28000/28223, loki :23100, cerberus :29092
+#
+# Usage:
+#   ./scripts/run-loki-compatibility.sh
+# or:
+#   docker compose up --wait
+#   go run ./harness/loki-compatibility/cmd/seed/
+#   docker compose down -v
+
+name: cerberus-loki-compatibility
+
+services:
+  clickhouse:
+    # Use the Ubuntu-base image, NOT -alpine. Per the prometheus-compliance
+    # harness's PR #245 finding, `clickhouse/clickhouse-server:24.8-alpine`
+    # on GH Actions runners stalls in the entrypoint script for 5+ min
+    # (never starts the server, never binds 8123). The Ubuntu-base variant
+    # boots in ~10-20s on the same runners.
+    image: clickhouse/clickhouse-server:24.8
+    environment:
+      CLICKHOUSE_DB: otel
+      CLICKHOUSE_USER: cerberus
+      CLICKHOUSE_PASSWORD: cerberus
+      CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: "1"
+    healthcheck:
+      # `clickhouse-client --query 'SELECT 1'` is more reliable than
+      # `wget /ping`: the HTTP listener (:8123) binds slightly before
+      # the SQL engine is ready to answer queries.
+      test: ["CMD-SHELL", "clickhouse-client --query 'SELECT 1' 2>/dev/null || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 36
+      start_period: 30s
+    ports:
+      - "28000:9000"
+      - "28223:8123"
+
+  loki:
+    image: grafana/loki:3.7.0
+    command:
+      - -config.file=/etc/loki/loki-config.yaml
+    volumes:
+      - ./loki-config.yaml:/etc/loki/loki-config.yaml:ro
+    ports:
+      - "23100:3100"
+    # No Docker-level healthcheck: the grafana/loki image ships distroless
+    # (no sh / wget / curl), and the loki binary doesn't expose a
+    # self-ping subcommand. Readiness is enforced from the seeder's
+    # `/ready` poll instead — see cmd/seed/main.go's waitLokiReady.
+    # Single-binary Loki also has a ~15s post-start delay before
+    # /ready returns 200 ("waiting for 15s after being ready"), so a
+    # tight interval/retries combo would only flap.
+
+  cerberus:
+    image: cerberus:loki-compatibility
+    build:
+      context: ../..
+      dockerfile: Dockerfile.local
+    environment:
+      CERBERUS_HTTP_ADDR: ":29092"
+      CERBERUS_CH_ADDR: "clickhouse:9000"
+      CERBERUS_CH_DATABASE: "otel"
+      CERBERUS_CH_USERNAME: "cerberus"
+      CERBERUS_CH_PASSWORD: "cerberus"
+      CERBERUS_CH_DIAL_TIMEOUT: "10s"
+    depends_on:
+      clickhouse:
+        condition: service_healthy
+    ports:
+      - "29092:29092"
+    healthcheck:
+      test: ["CMD", "/usr/local/bin/cerberus", "--version"]
+      interval: 2s
+      timeout: 2s
+      retries: 30

--- a/harness/loki-compatibility/loki-config.yaml
+++ b/harness/loki-compatibility/loki-config.yaml
@@ -1,0 +1,62 @@
+# Reference Loki configuration for the LogQL compatibility harness.
+#
+# Single-binary, all-targets, filesystem backend, no auth — matches the
+# upstream Grafana "quick start" yaml. The compatibility tester writes
+# the seeded fixture via /loki/api/v1/push and queries via the standard
+# /loki/api/v1/query{,_range,_labels,_series} endpoints — no clustering,
+# no object storage, no ingester ring tuning needed.
+#
+# Don't promote this config into a "production" template — it's
+# intentionally minimal so reference Loki behaviour stays close to
+# default and the diff against cerberus surfaces real semantic gaps
+# rather than configuration noise.
+
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+  log_level: warn
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /tmp/loki
+  storage:
+    filesystem:
+      chunks_directory: /tmp/loki/chunks
+      rules_directory: /tmp/loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+# Relax the default per-stream / per-tenant ingestion limits enough that
+# the seeder's 3-5 services × ~600 entries/service burst (sent in one
+# /push batch per stream) doesn't get rate-limited. The harness lifecycle
+# is short-lived (compose up → push → query → compose down) so the limits
+# only need to absorb the seed window.
+limits_config:
+  ingestion_rate_mb: 64
+  ingestion_burst_size_mb: 128
+  per_stream_rate_limit: 32MB
+  per_stream_rate_limit_burst: 64MB
+  reject_old_samples: false
+  reject_old_samples_max_age: 168h
+  max_query_lookback: 0s
+  allow_structured_metadata: true
+
+ruler:
+  alertmanager_url: http://localhost:9093
+
+analytics:
+  reporting_enabled: false

--- a/harness/loki-compatibility/scripts/run-loki-compatibility.sh
+++ b/harness/loki-compatibility/scripts/run-loki-compatibility.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# LogQL compatibility harness entry point (PR 1: scaffold smoke).
+#
+# Brings up the docker-compose stack (reference Loki + cerberus +
+# ClickHouse), runs the deterministic seeder against both targets, and
+# verifies /labels is non-empty on the reference Loki side. The diff
+# driver lands in PR 3 — this script's contract for PR 1 is just
+# "stack comes up, seed runs, /labels is non-empty on both endpoints".
+#
+# Usage:
+#   ./harness/loki-compatibility/scripts/run-loki-compatibility.sh   full lifecycle
+#   COMPOSE_KEEP=1 ./...                                             leave stack up after run
+#
+# Env:
+#   COMPOSE_KEEP        non-empty: leave the compose stack running after the
+#                       smoke completes (useful for poking at /loki/api/v1/*
+#                       and ClickHouse manually).
+#
+# Mirrors harness/prometheus-compliance/scripts/run-compatibility.sh's
+# lifecycle: up --wait, run go seeder, tear down on every exit path.
+
+set -eu -o pipefail
+
+ROOT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+cd "$ROOT_DIR"
+
+echo "==> bringing up loki-compatibility stack (compose up --wait)"
+docker compose up -d --build --wait clickhouse loki cerberus
+
+# Consolidated cleanup: tear down the compose stack on every exit path
+# (success, seeder failure, set -e abort, manual SIGINT). Without this,
+# a non-zero seeder exit propagated by `set -e` would leak the stack
+# across re-runs — local repros, in particular, would inherit dirty CH /
+# Loki state and confuse subsequent debugging.
+cleanup() {
+    rc=$?
+    if [ -z "${COMPOSE_KEEP:-}" ]; then
+        echo "==> tearing down (set COMPOSE_KEEP=1 to leave running)"
+        docker compose down -v || true
+    fi
+    exit "$rc"
+}
+trap cleanup EXIT
+
+echo "==> running seeder (go run ./cmd/seed)"
+(cd "$ROOT_DIR/../.." && go run ./harness/loki-compatibility/cmd/seed/)
+
+echo "==> smoke OK — /labels reported non-empty on both targets"
+echo "    (corpus + diff driver land in PR 2+ per docs/loki-compliance-plan.md)"


### PR DESCRIPTION
## Summary

PR 1 of 6 of the Loki/LogQL compliance harness rollout per
[`docs/loki-compliance-plan.md`](https://github.com/tsouza/cerberus/blob/main/docs/loki-compliance-plan.md).
Mirrors `harness/prometheus-compliance/` for the LogQL side.

This scaffold stands up the differential targets but ships no corpus
and no diff driver yet — those land in PRs 2-3.

### What's scaffolded

| File                                                  | Purpose                                                       |
| ----------------------------------------------------- | ------------------------------------------------------------- |
| `harness/loki-compatibility/docker-compose.yml`       | ClickHouse + reference Loki (`:23100`) + cerberus (`:29092`)  |
| `harness/loki-compatibility/loki-config.yaml`         | Single-binary Loki, filesystem backend, no auth               |
| `harness/loki-compatibility/cmd/seed/main.go`         | Deterministic CH (`otel_logs` INSERT) + Loki (`/push`) dual-write seeder, generates 4 services x 600 lines = 2400 entries at 1s spacing anchored at `2026-05-11T00:00:00Z` |
| `harness/loki-compatibility/scripts/run-loki-compatibility.sh` | `docker compose up --wait`, run seeder, smoke `/labels` on both, tear down |
| `harness/loki-compatibility/README.md`                | Layout summary, deferred-work pointer to PRs 2-6              |
| `Justfile`                                            | `just loki-compatibility{,-keep,-down}` recipes               |

### Smoke contract

After `just loki-compatibility`:

- ClickHouse `otel_logs`: 2400 rows.
- `GET :23100/loki/api/v1/labels?start=<wide>&end=<wide>`: returns `[service, service_name]` (reference Loki normalises).
- `GET :29092/loki/api/v1/labels?start=<wide>&end=<wide>`: returns `[service.name]` (cerberus passes OTel keys through verbatim).
- Stack tears down cleanly on every exit path.

Verified locally end-to-end (compose up -> build cerberus image -> seed -> verify -> tear down).

### What's deferred (PRs 2-6)

Per the plan doc:

- **PR 2** vendors `grafana/loki:pkg/logql/bench/` under `upstream/loki-bench/` (AGPL-isolated) + adds `cerberus-test-queries.yml` + `dataset_metadata.json`.
- **PR 3** wires the upstream `TestRemoteStorageEquality` driver into the run script.
- **PR 4** adds the `.github/workflows/loki-compatibility.yml` informational CI lane.
- **PR 5** ports the diff driver to a cerberus-owned `cmd/loki-compliance-tester/`.
- **PR 6** expands the corpus into regression + exhaustive slices.

### Notes for reviewers

- **Port allocation**: prom harness uses CH `29000/28123` + cerberus `:29091`; loki harness uses CH `28000/28223` + cerberus `:29092` so the two stacks coexist.
- **No Loki Docker healthcheck**: the `grafana/loki:3.7.0` image is distroless (no `sh` / `wget`). The seeder polls `/ready` directly, which absorbs the ~15s post-start delay before Loki reports ready.
- **Wide `/labels` window**: the smoke probe uses `[anchor - 1d, now + 1d]` because cerberus reads CH by `Timestamp BETWEEN ...` and reference Loki's async index needs slack when system time has drifted past the anchor. PR 3 will thread tighter per-query windows for the actual diff comparisons.
- **AGPL note**: PR 1 vendors nothing upstream; the AGPL boundary lands in PR 2 under `upstream/loki-bench/`.

## Test plan

- [x] `just loki-compatibility` runs end-to-end (build + up + seed + verify + down).
- [x] `docker compose up --wait` brings reference Loki up at `:23100` and cerberus at `:29092`.
- [x] Seeder pushes 2400 log entries (4 services x 600 entries x 1s spacing).
- [x] `/loki/api/v1/labels` non-empty on both endpoints.