### PR TITLE
feat(harness/loki-compatibility): vendor pkg/logql/bench corpus

### DIFF
--- a/harness/loki-compatibility/README.md
+++ b/harness/loki-compatibility/README.md
@@ -73,6 +73,43 @@ upstream `${SELECTOR}` / `${LABEL_*}` templates resolve against real
 data (the current overlay marks every `fast/` entry as skipped pending
 that work).
 
+## Upstream corpus (PR 2)
+
+PR 2 (#369) introduced the AGPL-scoped vendor under
+`upstream/loki-bench/`. The snapshot pins `grafana/loki` directly (the
+`tsouza/loki` fork watches only `pkg/logql/syntax/`, `pkg/logql/log/`,
+and `pkg/logqlmodel/`, so `pkg/logql/bench/` is outside the fork
+boundary). PR 2 vendored:
+
+- `pkg/logql/bench/queries/fast/*.yaml` — minimal-coverage corpus
+  (basic-selectors, simple-metrics, structured-metadata).
+- `pkg/logql/bench/queries/schema.json` — JSON Schema the YAMLs
+  validate against.
+- `pkg/logql/bench/query_registry.go` — `QueryRegistry` plus the
+  `${SELECTOR}` / `${LABEL_NAME}` / `${LABEL_VALUE}` template
+  expander.
+- `pkg/logql/bench/remote_test.go` — upstream `TestRemoteStorageEquality`,
+  build-tagged `remote_correctness`. PR 5 supersedes it with the
+  cerberus-owned driver, but the file remains as upstream reference.
+- `LICENSE` — AGPL-3.0, copied verbatim from the upstream repo root
+  and scoped to the `upstream/loki-bench/` subtree only.
+- `VERSION` — exact upstream coordinates (tag + commit SHA + the
+  `vendored_paths:` block that doubles as the bump-procedure
+  inventory).
+
+The PR 2 commit also widened `.github/workflows/ci.yml`'s `forbid-skip`
+git ls-files pathspec to exclude `harness/*/upstream/**`. The vendored
+`remote_test.go` has two `t.Skip()` calls (legitimate "flag not set"
+gating that's part of upstream's driver protocol); the forbid-skip
+rule applies to cerberus-authored tests and is preserved everywhere
+else.
+
+PR 3 (#387) expanded the snapshot to include the support files
+(`metadata.go`, `metadata_resolver.go`, `testcase.go`,
+`assertions_test.go`, `convert_test.go`, `generator.go`, `faker.go`)
+so `go test -c` resolves cleanly without sanitising upstream sources.
+See the section below for the full current inventory.
+
 ## What's in `upstream/loki-bench/`
 
 A pure, unmodified snapshot of these paths from `grafana/loki` at the
@@ -111,7 +148,7 @@ tracks `pkg/logql/syntax/`, `pkg/logql/log/`, and `pkg/logqlmodel/` —
 `pkg/logql/bench/` is outside the fork's watch boundary, so the
 snapshot here pins `grafana/loki` directly rather than the fork tag.
 
-### Why vendor, not import via `go.mod`?
+### Why vendor, not import via `go.mod`
 
 Same reasoning as `harness/tempo-compatibility/upstream/` (see PR #367):
 


### PR DESCRIPTION
## Summary

PR 2 of the Loki compliance harness rollout per [`docs/loki-compliance-plan.md`](docs/loki-compliance-plan.md). Snapshots `grafana/loki:pkg/logql/bench/` (queries/fast + schema.json + query_registry.go + remote_test.go) under `harness/loki-compatibility/upstream/loki-bench/` (AGPL-3.0). The vendor is excluded from the module graph via `go.mod`'s `ignore` directive (Go 1.25+) so `go build` / `go test` / `go vet` skip it until PR 3 wires the driver. **No driver / Compose / CI lane yet — those follow in PRs 3-4.**

**Depends on #368** (PR 1: scaffold compose + seed + run script). This PR is **draft** until #368 lands — the rebase after #368 merges may move the `harness/loki-compatibility/` directory shape (e.g. if PR 1 introduces a different README layout or a new sibling file the vendor needs to coexist with).

## Snapshot coordinates

Recorded in [`harness/loki-compatibility/upstream/loki-bench/VERSION`](harness/loki-compatibility/upstream/loki-bench/VERSION):

| Field | Value |
| ----- | ----- |
| upstream repo | `github.com/grafana/loki` |
| upstream tag | `v3.7.0` |
| upstream commit | `3361de24b692875d77bd7433cd6baa7c68dc0ef9` |

### Why not pin the `tsouza/loki` fork?

Cerberus's `tsouza/loki` fork (the `go.mod` replace target) scopes to `pkg/logql/syntax/` + `pkg/logql/log/` + `pkg/logqlmodel/` only — that's the parser surface cerberus calls into. `pkg/logql/bench/` lives outside the fork's watch boundary, so the snapshot pins `grafana/loki` directly rather than the fork tag. (Tempo PR #367 pinned both fork + upstream because the watched paths were byte-identical between fork tag and upstream base; that doesn't apply here.)

## Vendor footprint

- 3 YAML files in `queries/fast/` (208 LoC) — basic-selectors, simple-metrics, structured-metadata
- 1 JSON schema (252 LoC)
- 1 Go file `query_registry.go` (399 LoC) — `QueryRegistry` + `${SELECTOR}` / `${LABEL_NAME}` / `${LABEL_VALUE}` template expander
- 1 Go test file `remote_test.go` (203 LoC) — `TestRemoteStorageEquality`, build-tagged `remote_correctness`
- LICENSE (AGPL-3.0, 661 LoC) + VERSION + README scaffolding

Total: **~1062 LoC vendored** under `harness/loki-compatibility/upstream/loki-bench/`.

## Why `go.mod ignore` instead of build tags

The vendor's imports (`github.com/grafana/loki/v3/pkg/logcli/client`, `github.com/grafana/loki/v3/pkg/loghttp`, etc.) would pull heavy transitive deps just to run the diff loop. Until PR 3 wires the driver, the snapshot is reference material, not a build dependency. The added directive mirrors PR #367's posture:

```
ignore ./harness/loki-compatibility/upstream
```

`go list ./harness/loki-compatibility/upstream/...` correctly reports "matched no packages" — verified locally.

## CI gate adjustments

- **markdownlint exclusion** (`.github/workflows/ci.yml` + `.markdownlintignore`): mirrors the `harness/prometheus-compliance/upstream/**` + `harness/tempo-compatibility/upstream/**` patterns; reviewer-vetted by PRs #336 + #367.
- **forbid-skip exclusion** (`.github/workflows/ci.yml`): the vendored `remote_test.go` has two `t.Skip()` calls (legitimate "flag not set" gating — `--addr-1` / `--metadata-dir` are required for the test to do meaningful work, but `go test` invokes `TestMain` unconditionally). The `forbid-skip` "no t.Skip" rule applies to cerberus-authored tests, not vendored upstream snapshots; the pathspec now excludes `harness/*/upstream/**`. PR #367's tempo vendor didn't hit this gate because `cmd/tempo-vulture/main_test.go` doesn't call `t.Skip()`; Loki's `remote_test.go` does, hence the extension.

## Cerberus overlay files

Two cerberus-owned files at the harness root capture configuration that lives OUTSIDE the AGPL `upstream/` boundary:

- **`cerberus-test-queries.yml`** — overlay applied on top of the vendored corpus. The `should_skip:` list documents which queries exercise LogQL features cerberus doesn't implement. PR #338 closed all the RC2 LogQL gaps the minimal corpus would hit (`| unpack`, `| pattern`, `| line_format`, `| decolorize`, `| label_format` with Loki template funcs), so the initial list is **empty**; reviewers add entries as PR 4's CI lane surfaces real gaps.
- **`dataset_metadata.json`** — pinned dataset metadata for `${SELECTOR}` / `${LABEL_NAME}` / `${LABEL_VALUE}` template expansion. **Placeholder** with OTel-shape defaults (cluster=`cerberus-loki-bench`, three service streams) and a `_pr_dependency:` TODO comment pointing at PR #368. Once PR 1 lands, this file gets regenerated against the actual seeded fixture.

## Licensing note

Upstream Loki is **AGPL-3.0** ([upstream LICENSE](https://github.com/grafana/loki/blob/main/LICENSE)). The vendored LICENSE under `upstream/loki-bench/` is the verbatim AGPL-3.0 copy. Cerberus's own LICENSE is unchanged; AGPL terms apply only to the subtree under `harness/loki-compatibility/upstream/loki-bench/`. The driver scripts that land in PRs 3-4 live OUTSIDE `upstream/` (under `scripts/` + `cmd/`) and are cerberus-licensed.

## Test plan

- [x] `diff -r upstream/loki-bench/queries/fast /tmp/loki-upstream/pkg/logql/bench/queries/fast` — vendor byte-identical to upstream
- [x] `go vet ./...` clean
- [x] `go list ./harness/loki-compatibility/upstream/...` reports "matched no packages" (ignore directive working)
- [x] Updated `forbid-skip` pathspec produces zero matches (vendor `t.Skip()` correctly excluded)
- [x] Old `forbid-skip` pathspec would catch the vendor (regression-proof: confirmed the exclusion is doing real work)
- [ ] CI `check` + `lint` green
- [ ] PR #368 merges, then rebase + un-draft