### PR TITLE
feat(harness/tempo-compatibility): compose + stub driver + nightly workflow

### DIFF
--- a/.github/workflows/tempo-compatibility.yml
+++ b/.github/workflows/tempo-compatibility.yml
@@ -1,0 +1,90 @@
+name: tempo-compatibility
+
+# Status: PR 2 of docs/tempo-compliance-plan.md. The driver this
+# workflow invokes is a STUB that always exits 0. The workflow's job
+# in PR 2 is to prove the Compose stack stands up under GitHub Actions
+# and to wire the dispatch / cron / on-push triggers so PRs 3-4 can
+# focus on the seeder + differ without also debugging CI plumbing.
+#
+# Triggers:
+#   * workflow_dispatch  — manual runs from the GH UI.
+#   * schedule           — nightly (offset from sibling harnesses to
+#                          spread runner load).
+#   * push to main       — informational only. continue-on-error keeps
+#                          the workflow conclusion green so this is not
+#                          a required check by accident; promotion to a
+#                          required PR check is PR 7 of the rollout.
+#
+# Per ~/.claude/CI_STEPS.md, every step uses an official / well-known
+# Action — no `curl | sh` installs. Actions used here:
+#   * actions/checkout@v6        — stdlib.
+#   * docker/setup-buildx-action@v3  — buildkit-backed `docker build`.
+#   * actions/upload-artifact@v7 — report artifact upload.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Nightly at 04:23 UTC. Offset from compatibility.yml (04:11) and
+    # the e2e dashboard run so concurrent runs don't fight for the
+    # ubuntu-latest pool.
+    - cron: '23 4 * * *'
+  push:
+    branches: [main]
+    paths:
+      # Only re-run on changes that could affect the harness wiring.
+      # Cerberus code changes are already covered by the prom + shadow
+      # gates; this harness is about tempo-specific drift.
+      - 'internal/api/tempo/**'
+      - 'internal/traceql/**'
+      - 'harness/tempo-compatibility/**'
+      - '.github/workflows/tempo-compatibility.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tempo-compatibility-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  tempo-compatibility:
+    name: tempo/compatibility
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Informational baseline for PR 2 — the stub driver always exits 0,
+    # but the Compose lifecycle (pull tempo image, build cerberus image,
+    # build driver image, wait for healthchecks) can legitimately fail
+    # under runner flake. continue-on-error keeps the workflow badge
+    # green during the rollout. PR 7 of the plan promotes this to a
+    # gated required check once nightly is stable for 7 consecutive
+    # runs (per docs/tempo-compliance-plan.md "Per-PR breakdown").
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+
+      # Buildx gives the Compose build cache, multi-arch support, and a
+      # consistent build backend. The harness uses local build contexts
+      # (cerberus + driver), so no remote registry login is needed.
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Run tempo-compatibility harness
+        id: harness
+        # The script handles its own teardown (cleanup trap on EXIT),
+        # so no explicit `docker compose down` step is needed even on
+        # failure. The continue-on-error at job level keeps a non-zero
+        # rc from turning the workflow conclusion red while we're in
+        # informational mode.
+        run: ./harness/tempo-compatibility/scripts/run-tempo-compatibility.sh
+
+      - name: Upload report
+        # `if: always()` so we capture whatever the driver wrote even
+        # when the harness step failed. In PR 2 the stub doesn't write
+        # a report, so this will typically warn "if-no-files-found";
+        # PRs 3-4 will populate the dir.
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: tempo-compatibility-report
+          path: harness/tempo-compatibility/reports/
+          if-no-files-found: warn
+          retention-days: 30

--- a/Justfile
+++ b/Justfile
@@ -419,6 +419,24 @@ loki-compatibility-keep:
 # Tear down the Loki compatibility stack manually.
 loki-compatibility-down:
     cd harness/loki-compatibility && docker compose down -v
+# === Tempo / TraceQL compatibility harness ===
+
+# Run the Tempo / TraceQL compatibility harness end-to-end. Slow; expect
+# minutes. Sets up the Docker Compose stack (reference Tempo +
+# cerberus + CH + stub driver), runs the driver, writes reports under
+# harness/tempo-compatibility/reports/. PR 2 of
+# docs/tempo-compliance-plan.md — the driver is a stub until PRs 3-4
+# wire the real seeder + differ.
+tempo-compatibility:
+    ./harness/tempo-compatibility/scripts/run-tempo-compatibility.sh
+
+# Keep the tempo-compatibility stack running after the driver finishes (for debugging).
+tempo-compatibility-keep:
+    COMPOSE_KEEP=1 ./harness/tempo-compatibility/scripts/run-tempo-compatibility.sh
+
+# Tear down the tempo-compatibility stack manually.
+tempo-compatibility-down:
+    cd harness/tempo-compatibility && docker compose down -v
 
 # === Shadow-mode differential testing (RC3 R3.9) ===
 

--- a/harness/tempo-compatibility/README.md
+++ b/harness/tempo-compatibility/README.md
@@ -1,10 +1,12 @@
 # Tempo / TraceQL compatibility harness
 
-> Status: **PR 1 (vendor)** of the rollout described in
-> [`docs/tempo-compliance-plan.md`](../../docs/tempo-compliance-plan.md).
-> This directory currently holds **only** a vendored snapshot of
-> `cmd/tempo-vulture/` + `pkg/httpclient/`. There is no Compose stack,
-> no driver, and no CI yet — those follow in PRs 2-7.
+> Status: **PR 2 (compose + stub driver + nightly workflow)** of the
+> rollout described in [`docs/tempo-compliance-plan.md`](../../docs/tempo-compliance-plan.md).
+> This directory holds the vendored snapshot from PR 1 (`upstream/`),
+> the Docker Compose stack standing up reference Tempo + cerberus +
+> ClickHouse, a STUB driver that exits 0, and a nightly /
+> `workflow_dispatch` GitHub Actions lane (informational, not a
+> required check). The real seeder + diff driver follow in PRs 3-4.
 
 ## Why this harness exists
 
@@ -20,39 +22,41 @@ See [`docs/tempo-compliance-plan.md`](../../docs/tempo-compliance-plan.md)
 for the full landscape analysis, the per-PR breakdown, and the diff
 strategy.
 
-## Layout (current — PR 1)
+## Layout (current — PR 2)
 
 ```text
 harness/tempo-compatibility/
   README.md             this file
-  upstream/             vendored snapshot, see ./upstream/README intent below
+  docker-compose.yml    PR 2 — tempo + cerberus + clickhouse + stub driver
+  tempo-config.yaml     PR 2 — reference Tempo (local block storage)
+  scripts/
+    run-tempo-compatibility.sh  PR 2 — `docker compose up --wait` + driver + teardown
+  driver/                       PR 2 — STUB; PRs 3-4 wire the real seeder + differ
+    Dockerfile          PR 2 — multi-stage build of the driver binary
+    main.go             PR 2 — flag-only stub, prints banner + exits 0
+  upstream/             PR 1 — vendored snapshot (read-only reference)
     LICENSE             AGPL-3.0, copied verbatim from grafana/tempo
     VERSION             exact upstream coordinates of the snapshot
     cmd/tempo-vulture/  long-running canary; reused as seeder pattern
     pkg/httpclient/     Tempo HTTP client; reused by the future driver
 ```
 
-## Layout (planned — PRs 2-7)
+## Layout (planned — PRs 3-7)
 
-PRs 2-7 land the Compose stack + cerberus-owned diff driver alongside
-the vendored snapshot:
+PRs 3-7 grow the driver from stub into the real differ:
 
 ```text
 harness/tempo-compatibility/
-  docker-compose.yml          PR 2 — tempo + cerberus + clickhouse + driver
-  tempo-config.yaml           PR 2 — reference Tempo (local block storage)
-  scripts/                    PR 2 — run-tempo-compatibility.sh
-  driver/                     PR 3+ — cerberus-owned (NOT a fork of vulture)
-    main.go
-    seeder.go
-    corpus.go
-    differ.go
-    report.go
+  driver/
+    main.go             PR 3+ — orchestrator (parses flags, dispatches)
+    seeder.go           PR 3  — push OTLP batches to tempo + cerberus
+    corpus.go           PR 4  — TXTAR loader
+    differ.go           PR 4  — JSON-shape diff
+    report.go           PR 4  — markdown report writer
     corpus/
-      smoke.txtar
-      coverage.txtar
-  expected-failures.json      PR 4+
-  upstream/                   PR 1 — already vendored (this PR)
+      smoke.txtar       PR 4  — 10-query smoke set
+      coverage.txtar    PR 5  — ~40 queries, one per TraceQL feature
+  expected-failures.json  PR 4+
 ```
 
 ## What's in `upstream/`

--- a/harness/tempo-compatibility/docker-compose.yml
+++ b/harness/tempo-compatibility/docker-compose.yml
@@ -1,0 +1,153 @@
+# Docker Compose stack for the TraceQL / Tempo compatibility harness.
+#
+# Status: PR 2 of the rollout described in docs/tempo-compliance-plan.md.
+# This file stands up the Compose stack and wires a STUB driver that just
+# exits 0. The real seeder + diff driver land in PRs 3-4.
+#
+# Services:
+#   clickhouse           OTel-schema CH instance (auth: cerberus/cerberus,
+#                        db: otel). Matches harness/prometheus-compliance's
+#                        Ubuntu-base image choice — see the inline note on
+#                        the alpine variant regression.
+#   tempo                Reference grafana/tempo single-binary, listens on
+#                        :3200 (HTTP) and :4317 (OTLP gRPC). Pinned to the
+#                        commit-hash tag that matches the tsouza/tempo
+#                        replace target in go.mod — see the inline note
+#                        on the version pin.
+#   cerberus-tempo       cerberus under test, listens on :29092. Same
+#                        Dockerfile.local image as the prom harness; the
+#                        cerberus binary serves Prom/Loki/Tempo on the
+#                        same CERBERUS_HTTP_ADDR.
+#   tempo-compat-driver  STUB driver (./driver). Reads -tempo / -cerberus /
+#                        -corpus / -report flags, prints "stub" and exits 0.
+#                        Replaced by PRs 3-4 with the real seeder + differ.
+#
+# Usage:
+#   ./scripts/run-tempo-compatibility.sh
+# or:
+#   docker compose up --wait
+#   docker compose run --rm tempo-compat-driver
+#   docker compose down -v
+
+name: cerberus-tempo-compatibility
+
+services:
+  clickhouse:
+    # Use the Ubuntu-base image, NOT -alpine. Per PR #245's finding on
+    # the sibling prometheus-compliance harness, the alpine variant on
+    # GH Actions runners stalls in the entrypoint for 5+ min (never
+    # starts the server, never binds 8123). The Ubuntu-base variant
+    # boots in ~10-20s on the same runners. A future maintainer: do
+    # NOT innocently switch to -alpine here without re-validating
+    # against the GH-runner musl/scheduling regression that bit the
+    # PromQL harness.
+    image: clickhouse/clickhouse-server:24.8
+    environment:
+      CLICKHOUSE_DB: otel
+      CLICKHOUSE_USER: cerberus
+      CLICKHOUSE_PASSWORD: cerberus
+      CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: "1"
+    healthcheck:
+      # Talking SQL over the local CH client is more reliable than
+      # `wget /ping`: the HTTP listener (:8123) binds slightly before
+      # the SQL engine is ready to answer queries. Matches the pattern
+      # PR #245 settled on for the PromQL harness.
+      test: ["CMD-SHELL", "clickhouse-client --query 'SELECT 1' 2>/dev/null || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 36
+      start_period: 30s
+    ports:
+      - "29100:9000"
+      - "28124:8123"
+
+  tempo:
+    # Pin to the commit-hash tag that matches the tsouza/tempo replace
+    # target in go.mod. Reasoning:
+    #
+    #   go.mod replace: github.com/grafana/tempo =>
+    #       github.com/tsouza/tempo v0.0.1-cerberus-accessors
+    #
+    #   tsouza/tempo cerberus-accessors branches from grafana/tempo
+    #   commit 2f74ea818de1377e6ac9dd15117fa284c9c6ba36
+    #   (= `v3.0.0-rc.1-7-g2f74ea818`, see harness/.../upstream/VERSION).
+    #
+    # Tempo's pkg/traceql parser ships in the server binary, so a Docker
+    # image that lags or leads the fork's branch point will diff against
+    # cerberus for purely-parser reasons. `grafana/tempo:main-2f74ea8`
+    # is built from that exact upstream commit, so it is the precisely-
+    # matching image. When the tsouza/tempo replace tag bumps, bump the
+    # tag here in lock-step (the procedure is documented in
+    # harness/tempo-compatibility/README.md alongside the vendor bump).
+    #
+    # See docs/tempo-compliance-plan.md "Open question 2" for the
+    # version-drift discussion.
+    image: grafana/tempo:main-2f74ea8
+    command: ["-config.file=/etc/tempo.yaml"]
+    volumes:
+      - ./tempo-config.yaml:/etc/tempo.yaml:ro
+    ports:
+      # Host port offsets keep this harness coexistable with the
+      # sibling PromQL harness and the e2e k3d stack without port
+      # collisions on the developer machine.
+      - "23200:3200"  # HTTP (query API)
+      - "24317:4317"  # OTLP gRPC ingest (used by PR 3's seeder)
+    healthcheck:
+      # /ready returns 200 only once Tempo has loaded its config AND
+      # opened the listeners. Reliable single-binary probe.
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3200/ready || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 10s
+
+  cerberus-tempo:
+    image: cerberus:tempo-compatibility
+    build:
+      context: ../..
+      dockerfile: Dockerfile.local
+    environment:
+      CERBERUS_HTTP_ADDR: ":29092"
+      CERBERUS_CH_ADDR: "clickhouse:9000"
+      CERBERUS_CH_DATABASE: "otel"
+      CERBERUS_CH_USERNAME: "cerberus"
+      CERBERUS_CH_PASSWORD: "cerberus"
+      CERBERUS_CH_DIAL_TIMEOUT: "10s"
+    depends_on:
+      clickhouse:
+        condition: service_healthy
+    ports:
+      - "29092:29092"
+    healthcheck:
+      # Matches the prom harness: probing `--version` proves the binary
+      # is reachable in the container without depending on schema /
+      # network state.
+      test: ["CMD", "/usr/local/bin/cerberus", "--version"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+
+  tempo-compat-driver:
+    build:
+      context: ./driver
+    # The stub driver prints a banner and exits 0. PRs 3-4 will wire the
+    # real seeder + differ; the flag surface is already wired here so
+    # the Compose contract is stable across the rollout.
+    command:
+      - "-tempo=http://tempo:3200"
+      - "-cerberus=http://cerberus-tempo:29092"
+      - "-corpus=/corpus/smoke.txtar"
+      - "-report=/reports/diff.json"
+    depends_on:
+      tempo:
+        condition: service_healthy
+      cerberus-tempo:
+        condition: service_healthy
+      clickhouse:
+        condition: service_healthy
+    volumes:
+      # The corpus + reports dirs don't exist yet (PRs 3-4 populate them).
+      # The driver stub tolerates missing files so the Compose run is a
+      # smoke for wiring, not data.
+      - ./driver/corpus:/corpus:ro
+      - ./reports:/reports

--- a/harness/tempo-compatibility/driver/Dockerfile
+++ b/harness/tempo-compatibility/driver/Dockerfile
@@ -1,0 +1,45 @@
+# syntax=docker/dockerfile:1
+# Multi-stage build for the Tempo / TraceQL compatibility driver.
+#
+# Status: PR 2 of docs/tempo-compliance-plan.md. The driver is a stub
+# (main.go uses stdlib only), so the build context is tiny — no
+# vendor dir, no module-path tricks. PRs 3-4 will likely grow this
+# to pull in harness/tempo-compatibility/upstream/pkg/httpclient and
+# the OTLP gRPC SDK; when that happens, the build context will need
+# to widen to the repo root for module-aware compilation, and this
+# Dockerfile will need a corresponding rewrite.
+#
+# Build:
+#   docker compose build tempo-compat-driver
+# Run:
+#   docker compose run --rm tempo-compat-driver
+
+FROM golang:1.26 AS build
+WORKDIR /src
+
+# Stub-only build: copy the driver source and compile it as a
+# standalone main package. The driver lives inside the cerberus
+# module on disk (so `go build ./...` from the repo root also
+# compiles it), but inside this image we build it in isolation with
+# a synthetic `go.mod` — that keeps the Docker build context small
+# and decoupled from cerberus's go.sum. The `-trimpath` flag is kept
+# for parity with cerberus's release builds.
+#
+# When PRs 3-4 grow the driver beyond stdlib, this image will need
+# to switch to a repo-root build context (like Dockerfile.local) so
+# the real go.mod is in scope.
+COPY main.go ./
+RUN go mod init tempo-compat-driver \
+    && CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/driver .
+
+FROM gcr.io/distroless/static-debian12:nonroot
+
+LABEL org.opencontainers.image.title="cerberus-tempo-compat-driver"
+LABEL org.opencontainers.image.description="Tempo / TraceQL compatibility diff driver for cerberus (stub in PR 2; real differ lands in PRs 3-4)"
+LABEL org.opencontainers.image.licenses="MIT"
+
+COPY --from=build /out/driver /usr/local/bin/driver
+
+USER nonroot:nonroot
+
+ENTRYPOINT ["/usr/local/bin/driver"]

--- a/harness/tempo-compatibility/driver/corpus/.gitkeep
+++ b/harness/tempo-compatibility/driver/corpus/.gitkeep
@@ -1,0 +1,3 @@
+# PR 4 of docs/tempo-compliance-plan.md will populate this directory with
+# TXTAR corpus files (smoke.txtar, coverage.txtar). Kept empty in PR 2
+# so the docker-compose `:/corpus:ro` bind mount has a valid target.

--- a/harness/tempo-compatibility/driver/main.go
+++ b/harness/tempo-compatibility/driver/main.go
@@ -1,0 +1,57 @@
+// Command tempo-compat-driver is a STUB for PR 2 of the Tempo / TraceQL
+// compatibility harness rollout (docs/tempo-compliance-plan.md). It
+// exists so the docker-compose stack has a well-typed flag surface to
+// invoke from day one; PRs 3-4 replace the body with the real seeder +
+// differ:
+//
+//   - PR 3: implement seeder.go (push identical OTLP batches to
+//     reference Tempo's :4317 and cerberus's OTLP ingest, wait for
+//     replication, smoke that /api/traces/<id> returns equal span
+//     counts on both backends).
+//   - PR 4: implement corpus.go + differ.go (load TXTAR corpus, fan
+//     each query at both backends, write a markdown diff report).
+//
+// Until then this binary parses the same flags PRs 3-4 will use,
+// prints a banner naming the stub, and exits 0. Keeping the flag
+// surface stable means scripts/run-tempo-compatibility.sh and
+// docker-compose.yml don't need to change when the real driver lands.
+//
+// Implementation deliberately uses stdlib only (no anthrosphere SDKs,
+// no Tempo httpclient yet). PR 3 will pull in the vendored
+// harness/tempo-compatibility/upstream/pkg/httpclient as the read
+// client and the OTLP gRPC SDK for the write side.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+// version is stamped on driver-stub output so a reader scanning CI
+// logs can tell at a glance whether they're looking at the PR-2 stub
+// or the real differ that lands in PR 4.
+const version = "stub-pr2"
+
+func main() {
+	tempoURL := flag.String("tempo", "http://tempo:3200",
+		"reference Tempo HTTP base URL (PR 3-4: read-back endpoint for diffs)")
+	cerberusURL := flag.String("cerberus", "http://cerberus-tempo:29092",
+		"cerberus-under-test HTTP base URL (PR 3-4: read-back endpoint for diffs)")
+	corpusPath := flag.String("corpus", "/corpus/smoke.txtar",
+		"TXTAR corpus path (PR 4: query corpus to fan at both backends)")
+	reportPath := flag.String("report", "/reports/diff.json",
+		"output report path (PR 4: per-query diff results in JSON)")
+
+	flag.Parse()
+
+	// Output is line-prefixed with the binary name so it's grep-able in
+	// the compose log stream alongside Tempo / cerberus / ClickHouse.
+	_, _ = fmt.Fprintf(os.Stdout, "tempo-compat-driver %s\n", version)
+	_, _ = fmt.Fprintf(os.Stdout, "tempo-compat-driver  tempo    = %s\n", *tempoURL)
+	_, _ = fmt.Fprintf(os.Stdout, "tempo-compat-driver  cerberus = %s\n", *cerberusURL)
+	_, _ = fmt.Fprintf(os.Stdout, "tempo-compat-driver  corpus   = %s\n", *corpusPath)
+	_, _ = fmt.Fprintf(os.Stdout, "tempo-compat-driver  report   = %s\n", *reportPath)
+	_, _ = fmt.Fprintln(os.Stdout, "tempo-compat-driver stub: no seeder, no differ — PRs 3-4 will fill this in")
+	_, _ = fmt.Fprintln(os.Stdout, "tempo-compat-driver exit 0")
+}

--- a/harness/tempo-compatibility/reports/.gitignore
+++ b/harness/tempo-compatibility/reports/.gitignore
@@ -1,0 +1,5 @@
+# Runtime artefacts only; the dir itself is tracked (via .gitkeep) so
+# the docker-compose `:/reports` bind mount has a valid target.
+*
+!.gitignore
+!.gitkeep

--- a/harness/tempo-compatibility/reports/.gitkeep
+++ b/harness/tempo-compatibility/reports/.gitkeep
@@ -1,0 +1,3 @@
+# Driver report output dir. Populated at runtime by the harness driver;
+# PR 4 of docs/tempo-compliance-plan.md wires the first writer
+# (diff.json). PR 2's stub driver does not write anything here.

--- a/harness/tempo-compatibility/scripts/run-tempo-compatibility.sh
+++ b/harness/tempo-compatibility/scripts/run-tempo-compatibility.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Tempo / TraceQL compatibility harness entry point.
+#
+# Status: PR 2 of docs/tempo-compliance-plan.md. Brings up the
+# docker-compose stack (reference Tempo + cerberus + ClickHouse +
+# STUB driver), invokes the stub, and tears down. The real seeder +
+# diff driver land in PRs 3-4; the stub already accepts the full flag
+# surface so this script's contract is stable across the rollout.
+#
+# Usage:
+#   ./harness/tempo-compatibility/scripts/run-tempo-compatibility.sh        full lifecycle
+#   COMPOSE_KEEP=1 ./...                                                    leave stack up after run
+#
+# Env:
+#   REPORT_DIR    where the driver writes diff.json (default:
+#                 harness/tempo-compatibility/reports/). The directory
+#                 is created on first run.
+#
+# Exit codes (driver passthrough):
+#   0  driver exited 0  (in PR 2: stub always exits 0)
+#   non-zero  stack failed to come up OR driver exited non-zero
+
+set -eu -o pipefail
+
+ROOT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+cd "$ROOT_DIR"
+
+REPORT_DIR=${REPORT_DIR:-"$ROOT_DIR/reports"}
+mkdir -p "$REPORT_DIR"
+
+# Consolidated cleanup: tear down the compose stack on every exit path
+# (success, driver failure, set -e abort, SIGINT). Without this, a
+# non-zero driver exit propagated by `set -e` would leak the stack
+# across re-runs — local repros, in particular, would inherit dirty
+# Tempo block storage and confuse subsequent debugging. Same pattern
+# as harness/prometheus-compliance/scripts/run-compatibility.sh.
+cleanup() {
+    rc=$?
+    if [ -z "${COMPOSE_KEEP:-}" ]; then
+        echo "==> tearing down (set COMPOSE_KEEP=1 to leave running)"
+        docker compose down -v || true
+    fi
+    exit "$rc"
+}
+trap cleanup EXIT
+
+echo "==> bringing up tempo-compatibility stack"
+# --wait blocks until each service's healthcheck reports `healthy`.
+# 5min compose-level timeout (`--wait-timeout 300`) is generous: the
+# CH boot can take 30-60s on a cold runner, Tempo single-binary boots
+# in <10s, cerberus is <2s. If we time out, the issue is at the
+# infrastructure layer (image pull, cgroup, etc.), not the harness.
+docker compose up -d --build --wait --wait-timeout 300 \
+    clickhouse tempo cerberus-tempo
+
+echo "==> running tempo-compat-driver (stub in PR 2)"
+# `docker compose run --rm` invokes the driver and removes the
+# container afterwards. The stub prints a banner and exits 0; PRs 3-4
+# will replace it with the real seed → query → diff pipeline.
+#
+# Note: NO `|| true` here. The driver's exit code is meaningful —
+# masking it would let regressions land green (this is the same trap
+# that bit the PromQL harness pre-#298). The cleanup trap still tears
+# down the stack on a non-zero exit.
+set +e
+docker compose run --rm tempo-compat-driver
+DRIVER_RC=$?
+set -e
+
+echo "==> driver exited with rc=$DRIVER_RC"
+echo "==> reports under $REPORT_DIR (empty until PR 4 lands the differ)"
+
+exit "$DRIVER_RC"

--- a/harness/tempo-compatibility/tempo-config.yaml
+++ b/harness/tempo-compatibility/tempo-config.yaml
@@ -1,0 +1,72 @@
+# Minimal single-binary Tempo config for the compatibility harness.
+#
+# Status: PR 2 of docs/tempo-compliance-plan.md. This file pairs with
+# docker-compose.yml — the `tempo` service mounts it at /etc/tempo.yaml.
+#
+# Design notes:
+#
+#   * Single-binary mode (every component in one process). Compatibility
+#     differential testing wants the simplest possible reference Tempo;
+#     a distributor / ingester / compactor split would buy us nothing
+#     here and would make PR 3's deterministic-seed flow harder to
+#     reason about.
+#
+#   * Local block storage under /var/tempo. No S3 / GCS / MinIO — we
+#     deliberately avoid object-storage dependencies; the harness is
+#     about query parity, not durability or scale.
+#
+#   * Receivers: OTLP gRPC + HTTP only. PR 3's seeder fans the same
+#     OTLP batch into Tempo's :4317 and into cerberus's ingest path,
+#     so we only need OTLP. No Jaeger / Zipkin / Kafka receivers.
+#
+#   * No multitenancy. `multitenancy_enabled: false` (the default)
+#     means the harness driver doesn't have to thread X-Scope-OrgID
+#     through every request. Mirrors how the prom harness skips
+#     tenant headers.
+#
+# When the tempo image pin in docker-compose.yml bumps (in lock-step
+# with the tsouza/tempo go.mod replace), revisit this config: Tempo's
+# config schema occasionally renames fields between minor versions.
+
+server:
+  http_listen_port: 3200
+  grpc_listen_port: 9095
+
+# OTLP-only ingest. PR 3 will push identical OTLP batches to this
+# endpoint and to cerberus's OTLP ingest so the read-back diff has
+# a deterministic shared input.
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+
+# Snappy compression keeps the WAL + block sizes small without buying
+# a dep on cgo zstd. Matches upstream Tempo's "getting started"
+# example values.
+ingester:
+  max_block_duration: 5m
+
+compactor:
+  compaction:
+    block_retention: 1h
+
+storage:
+  trace:
+    backend: local
+    wal:
+      path: /var/tempo/wal
+    local:
+      path: /var/tempo/blocks
+    pool:
+      max_workers: 2
+      queue_depth: 100
+
+# Tempo refuses to start if `metrics_generator` is configured without
+# a remote_write target. The compatibility harness doesn't exercise
+# the metrics-generator path (PR 5 will add TraceQL metrics queries,
+# but those query against pre-ingested spans). Omit the block entirely
+# so the server starts clean.


### PR DESCRIPTION
## Summary

PR 2 of the Tempo compliance harness rollout per [`docs/tempo-compliance-plan.md`](docs/tempo-compliance-plan.md) ("Per-PR breakdown", item 2):

> **PR 2 (compose)**: `docker-compose.yml`, `tempo-config.yaml`, `scripts/run-tempo-compatibility.sh`. Driver is a stub returning 0. Wires `.github/workflows/tempo-compatibility.yml` with `workflow_dispatch` + nightly only.

Builds on #367 (PR 1, vendor snapshot). PRs 3-4 will land the real seeder + differ on top of this stable compose / flag / workflow contract.

## What lands

- **`harness/tempo-compatibility/docker-compose.yml`** — 4-service stack:
  - `clickhouse/clickhouse-server:24.8` (Ubuntu, not -alpine; same GH-runner stall regression that bit the PromQL harness — comments inline).
  - `grafana/tempo:main-2f74ea8` — the precise commit-hash image that matches the `tsouza/tempo` `go.mod` replace target. `v0.0.1-cerberus-accessors` branches off `grafana/tempo` commit `2f74ea818de1` (`v3.0.0-rc.1-7-g2f74ea818`), per `harness/tempo-compatibility/upstream/VERSION` from #367.
  - `cerberus:tempo-compatibility` built from `Dockerfile.local`, listening on `:29092`.
  - `tempo-compat-driver` built from `./driver`. Stub package `main`; accepts `-tempo` / `-cerberus` / `-corpus` / `-report` flags so PRs 3-4 land on a stable contract.
- **`harness/tempo-compatibility/tempo-config.yaml`** — minimal single-binary Tempo config (OTLP receivers, local block storage under `/var/tempo`, no multitenancy, no metrics_generator).
- **`harness/tempo-compatibility/scripts/run-tempo-compatibility.sh`** — `docker compose up --wait` (5min timeout) + driver invocation + cleanup trap teardown. Same lifecycle shape as `harness/prometheus-compliance/scripts/run-compatibility.sh`.
- **`harness/tempo-compatibility/driver/{main.go,Dockerfile}`** — stdlib-only stub. Dockerfile builds it in isolation with a synthetic `go.mod` so the Docker context stays tiny; PRs 3-4 will switch to a repo-root context when they pull in vendored `pkg/httpclient` + OTLP gRPC.
- **`harness/tempo-compatibility/{driver/corpus,reports}/.gitkeep`** — keep the bind-mount targets valid until PR 4 populates them.
- **`.github/workflows/tempo-compatibility.yml`** — triggers: `workflow_dispatch`, `schedule` (nightly 04:23 UTC), `push:main` (paths-filtered to the harness + tempo head). `continue-on-error: true` at job level so this is NOT a required PR check by accident — promotion to a required check is PR 7. First-party Actions only per `~/.claude/CI_STEPS.md` (`actions/checkout@v6`, `docker/setup-buildx-action@v3`, `actions/upload-artifact@v7`).
- **`Justfile`** — `just tempo-compatibility` / `-keep` / `-down`, mirroring the prom harness recipe shape.

## Tempo version pin reasoning

The plan said "pin to the tag matching the `tsouza/tempo` fork lineage — check `go.mod` for the exact version that maps to `v0.0.1-cerberus-accessors`". Walking it through:

- `go.mod`: `replace github.com/grafana/tempo => github.com/tsouza/tempo v0.0.1-cerberus-accessors`.
- `harness/tempo-compatibility/upstream/VERSION` (from #367): `upstream_commit: 2f74ea818de1377e6ac9dd15117fa284c9c6ba36`, `upstream_describe: v3.0.0-rc.1-7-g2f74ea818`.
- Published Docker tag `grafana/tempo:main-2f74ea8` is built from that exact commit (verified via Docker Hub).

So `main-2f74ea8` is the precisely-matching image, not the nearest `v2.9.0` / `v3.0.0-rc.1` semver tag. When the `tsouza/tempo` replace bumps, bump this in lock-step (procedure documented in the inline tempo-config + the harness README bump-procedure section).

## Test plan

- [x] `docker compose config` validates the YAML (`docker compose config` returns rc 0 with the expected service / volume / port set).
- [x] Driver stub compiles + runs locally with stdlib only (`go build ./harness/tempo-compatibility/driver/` is clean; `./driver -h` shows the four flags; running with defaults prints the banner and exits 0).
- [x] Driver also compiles inside Docker via the multi-stage Dockerfile (synthetic `go.mod` build path).
- [ ] CI `check` + `lint` pass on this PR (required PR checks).
- [ ] Manual `workflow_dispatch` of `.github/workflows/tempo-compatibility.yml` proves the stack stands up on a GH runner once merged (or earlier via the PR branch).
- [ ] Nightly schedule fires at 04:23 UTC; informational (continue-on-error) so a flake won't turn the main badge red.

## Constraints honoured

- No `t.Skip` (no test files in this PR).
- No `Co-Authored-By` trailers per repo style (`git log --oneline -10`).
- First-party / well-known Actions only per `~/.claude/CI_STEPS.md` — no `curl | sh` installs.
- Stub driver — no diff logic. That's PR 3 (seeder) + PR 4 (corpus + diff).