### PR TITLE
fix(promql,chsql): drop narrow window for irate/idelta/deriv/predict_linear

### DIFF
--- a/internal/api/prom/handler_chdb_range_mode_test.go
+++ b/internal/api/prom/handler_chdb_range_mode_test.go
@@ -1618,3 +1618,80 @@ func runRangeModeQueryRange(t *testing.T, baseURL, query string, start, end time
 	}
 	return matrix
 }
+
+// TestQueryRange_RangeMode_SubScrape_ChDB pins the sub-scrape window
+// behaviour for the `instantValue` / `simpleLinearRegression` family:
+// `irate` / `idelta` / `deriv` / `predict_linear` over query_range
+// with a `[15s]` range against a 30s-scrape series. Each per-step
+// window `(anchor - 15s, anchor]` holds at most one sample, and
+// Prom's funcIrate / funcIdelta / funcDeriv / funcPredictLinear all
+// short-circuit on "< 2 float points" — the matrix MUST contain no
+// samples for any series. Cerberus mirrors via the
+// `WHERE length(window_pairs|window_vals) >= 2` outer guard on the
+// matrix-mode emit path.
+//
+// Pool-BD #366 followup — the `extrapolatedRate` boundary correction
+// covered `rate` / `increase` / `delta`; this test pins the parallel
+// drop semantics for the `instantValue` / `simpleLinearRegression`
+// path so the sub-scrape variants flagged in Pool-AU's Bucket 3 audit
+// (#355) stay green.
+func TestQueryRange_RangeMode_SubScrape_ChDB(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(5 * time.Minute)
+	step := 30 * time.Second
+	const seedSamples = 11
+
+	// Scrape every 30s — same cadence as the step. With range = 15s,
+	// each per-step window `(anchor - 15s, anchor]` captures at most
+	// one sample regardless of phase alignment.
+	scrape := 30 * time.Second
+	gaugeRows := make([]string, 0, seedSamples)
+	sumRows := make([]string, 0, seedSamples)
+	for i := 0; i < seedSamples; i++ {
+		ts := start.Add(time.Duration(i) * scrape).Format("2006-01-02 15:04:05.000000000")
+		gaugeRows = append(gaugeRows, fmt.Sprintf(
+			`('demo_disk_usage_bytes', map('instance', 'demo'), toDateTime64('%s', 9), %d.0)`,
+			ts, 100+i,
+		))
+		sumRows = append(sumRows, fmt.Sprintf(
+			`('demo_cpu_usage_seconds_total', map('instance', 'demo'), toDateTime64('%s', 9), %d.0)`,
+			ts, 100+i,
+		))
+	}
+	sumDDL := strings.ReplaceAll(gaugeDDL, "otel_metrics_gauge", "otel_metrics_sum")
+	seed := gaugeDDL + "\nINSERT INTO otel_metrics_gauge VALUES\n  " +
+		strings.Join(gaugeRows, ",\n  ") + ";\n" +
+		sumDDL + "\nINSERT INTO otel_metrics_sum VALUES\n  " +
+		strings.Join(sumRows, ",\n  ") + ";"
+	srv, _ := newChDBServer(t, seed)
+
+	cases := []struct {
+		name  string
+		query string
+	}{
+		// irate / idelta — Prom's funcIrate / funcIdelta delegate to
+		// instantValue, which short-circuits when `len(samples) < 2`.
+		{"irate", "irate(demo_cpu_usage_seconds_total[15s])"},
+		{"idelta", "idelta(demo_disk_usage_bytes[15s])"},
+		// deriv / predict_linear — Prom's funcDeriv / funcPredictLinear
+		// each guard `len(samples.Floats) < 2`. simpleLinearRegression
+		// requires ≥2 points to fit a line.
+		{"deriv", "deriv(demo_disk_usage_bytes[15s])"},
+		{"predict_linear", "predict_linear(demo_disk_usage_bytes[15s], 600)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			matrix := runRangeModeQueryRange(t, srv.URL, tc.query, start, end, step)
+			// Every anchor's window holds ≤ 1 sample, so the outer
+			// `WHERE length(window_pairs|window_vals) >= 2` drops every
+			// (series, anchor) row. Prom returns an empty matrix in this
+			// scenario; cerberus must agree.
+			for _, series := range matrix {
+				if len(series.Values) != 0 {
+					t.Fatalf("expected zero samples for sub-scrape window (got %d for series %+v): %+v",
+						len(series.Values), series.Metric, series.Values)
+				}
+			}
+		})
+	}
+}

--- a/test/spec/promql/deriv_subscrape_drops.txtar
+++ b/test/spec/promql/deriv_subscrape_drops.txtar
@@ -1,0 +1,31 @@
+# Sub-scrape range — `deriv(metric[15s])` against a 30s-scrape series.
+# The window `(end-15s, end]` captures at most one sample, so Prom's
+# funcDeriv ("< 2 float points") drops the series. Cerberus mirrors via
+# the `WHERE length(window_pairs) >= 2` guard on the outer SELECT —
+# simpleLinearRegression requires 2 points to fit a line. Pool-BD #366
+# followup — simpleLinearRegression-path companion to the
+# extrapolatedRate boundary correction.
+
+-- query.promql --
+deriv(disk_used_bytes[15s] @ end())
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('disk_used_bytes', map('host', 'a'), toDateTime64('1970-01-01 00:07:30', 9), 100.0),
+    ('disk_used_bytes', map('host', 'a'), toDateTime64('1970-01-01 00:08:00', 9), 200.0),
+    ('disk_used_bytes', map('host', 'a'), toDateTime64('1970-01-01 00:08:20', 9), 300.0);
+-- expected_rows --
+[]
+-- args --
+[0] string = "disk_used_bytes"
+-- chplan --
+RangeWindow func=deriv range=15s step=0s ts=TimeUnix value=Value groupBy=[Attributes] start=0001-01-01T00:00:00Z end=1970-01-01T00:08:20Z
+  Filter predicate=(MetricName = "disk_used_bytes")
+    Scan(otel_metrics_gauge)
+-- sql --
+SELECT `Attributes`, if(length(window_pairs) > 1, tupleElement(arrayReduce('simpleLinearRegression', arrayMap(p -> dateDiff('second', toDateTime64('1970-01-01 00:08:20.000000000', 9), tupleElement(p, 1)), window_pairs), arrayMap(p -> tupleElement(p, 2), window_pairs)), 1), nan) AS Value FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) > toDateTime64('1970-01-01 00:08:20.000000000', 9) - toIntervalNanosecond(15000000000) AND tupleElement(p, 1) <= toDateTime64('1970-01-01 00:08:20.000000000', 9), series_array) AS window_pairs FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS series_array FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY `Attributes`)) WHERE length(`window_pairs`) >= 2

--- a/test/spec/promql/idelta_subscrape_drops.txtar
+++ b/test/spec/promql/idelta_subscrape_drops.txtar
@@ -1,0 +1,30 @@
+# Sub-scrape range — `idelta(metric[15s])` against a 30s-scrape series.
+# The window `(end-15s, end]` captures at most one sample, so Prom's
+# funcIdelta → instantValue("< 2 samples") drops the series. Cerberus
+# mirrors via the `WHERE length(window_vals) >= 2` guard on the outer
+# SELECT. Pool-BD #366 followup — instantValue path companion to the
+# extrapolatedRate boundary correction.
+
+-- query.promql --
+idelta(temperature[15s] @ end())
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('temperature', map('host', 'a'), toDateTime64('1970-01-01 00:07:30', 9), -3.0),
+    ('temperature', map('host', 'a'), toDateTime64('1970-01-01 00:08:00', 9), 5.0),
+    ('temperature', map('host', 'a'), toDateTime64('1970-01-01 00:08:20', 9), 10.0);
+-- expected_rows --
+[]
+-- args --
+[0] string = "temperature"
+-- chplan --
+RangeWindow func=idelta range=15s step=0s ts=TimeUnix value=Value groupBy=[Attributes] start=0001-01-01T00:00:00Z end=1970-01-01T00:08:20Z
+  Filter predicate=(MetricName = "temperature")
+    Scan(otel_metrics_gauge)
+-- sql --
+SELECT `Attributes`, if(length(window_vals) > 1, window_vals[length(window_vals)] - window_vals[length(window_vals) - 1], nan) AS `Value` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) > toDateTime64('1970-01-01 00:08:20.000000000', 9) - toIntervalNanosecond(15000000000) AND tupleElement(p, 1) <= toDateTime64('1970-01-01 00:08:20.000000000', 9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY `Attributes`))) WHERE length(`window_vals`) >= 2

--- a/test/spec/promql/irate_subscrape_drops.txtar
+++ b/test/spec/promql/irate_subscrape_drops.txtar
@@ -1,0 +1,30 @@
+# Sub-scrape range — `irate(metric[15s])` against a 30s-scrape series.
+# The window `(end-15s, end]` captures at most one sample, so Prom's
+# funcIrate → instantValue("< 2 samples") drops the series. Cerberus
+# mirrors via the `WHERE length(window_pairs) >= 2` guard on the outer
+# SELECT. Pool-BD #366 followup — instantValue path companion to the
+# extrapolatedRate boundary correction.
+
+-- query.promql --
+irate(http_requests_total[15s] @ end())
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('http_requests_total', map('job', 'api'), toDateTime64('1970-01-01 00:07:30', 9), 0.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('1970-01-01 00:08:00', 9), 50.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('1970-01-01 00:08:20', 9), 100.0);
+-- expected_rows --
+[]
+-- args --
+[0] string = "http_requests_total"
+-- chplan --
+RangeWindow func=irate range=15s step=0s ts=TimeUnix value=Value groupBy=[Attributes] start=0001-01-01T00:00:00Z end=1970-01-01T00:08:20Z
+  Filter predicate=(MetricName = "http_requests_total")
+    Scan(otel_metrics_sum)
+-- sql --
+SELECT `Attributes`, if(length(window_pairs) > 1 AND dateDiff('nanosecond', tupleElement(window_pairs[length(window_pairs) - 1], 1), tupleElement(window_pairs[length(window_pairs)], 1)) > 0, (if(tupleElement(window_pairs[length(window_pairs)], 2) < tupleElement(window_pairs[length(window_pairs) - 1], 2), tupleElement(window_pairs[length(window_pairs)], 2), tupleElement(window_pairs[length(window_pairs)], 2) - tupleElement(window_pairs[length(window_pairs) - 1], 2))) / ((dateDiff('nanosecond', tupleElement(window_pairs[length(window_pairs) - 1], 1), tupleElement(window_pairs[length(window_pairs)], 1))) / 1e9), nan) AS Value FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) > toDateTime64('1970-01-01 00:08:20.000000000', 9) - toIntervalNanosecond(15000000000) AND tupleElement(p, 1) <= toDateTime64('1970-01-01 00:08:20.000000000', 9), series_array) AS window_pairs FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS series_array FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` = ?)) GROUP BY `Attributes`)) WHERE length(`window_pairs`) >= 2

--- a/test/spec/promql/predict_linear_subscrape_drops.txtar
+++ b/test/spec/promql/predict_linear_subscrape_drops.txtar
@@ -1,0 +1,32 @@
+# Sub-scrape range — `predict_linear(metric[15s], 600)` against a
+# 30s-scrape series. The window `(end-15s, end]` captures at most one
+# sample, so Prom's funcPredictLinear ("< 2 float points") drops the
+# series. Cerberus mirrors via the `WHERE length(window_pairs) >= 2`
+# guard on the outer SELECT — simpleLinearRegression requires 2 points
+# to fit a line. Pool-BD #366 followup — simpleLinearRegression-path
+# companion to the extrapolatedRate boundary correction.
+
+-- query.promql --
+predict_linear(http_requests_total[15s] @ end(), 600)
+-- args --
+[0] float64 = 600
+[1] string = "http_requests_total"
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('http_requests_total', map('job', 'api'), toDateTime64('1970-01-01 00:07:30', 9), 10.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('1970-01-01 00:08:00', 9), 20.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('1970-01-01 00:08:20', 9), 30.0);
+-- expected_rows --
+[]
+-- sql --
+SELECT `Attributes`, if(length(window_pairs) > 1, tupleElement(arrayReduce('simpleLinearRegression', arrayMap(p -> dateDiff('second', toDateTime64('1970-01-01 00:08:20.000000000', 9), tupleElement(p, 1)), window_pairs), arrayMap(p -> tupleElement(p, 2), window_pairs)), 2) + tupleElement(arrayReduce('simpleLinearRegression', arrayMap(p -> dateDiff('second', toDateTime64('1970-01-01 00:08:20.000000000', 9), tupleElement(p, 1)), window_pairs), arrayMap(p -> tupleElement(p, 2), window_pairs)), 1) * ?, nan) AS Value FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) > toDateTime64('1970-01-01 00:08:20.000000000', 9) - toIntervalNanosecond(15000000000) AND tupleElement(p, 1) <= toDateTime64('1970-01-01 00:08:20.000000000', 9), series_array) AS window_pairs FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS series_array FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` = ?)) GROUP BY `Attributes`)) WHERE length(`window_pairs`) >= 2
+-- chplan --
+RangeWindow func=predict_linear range=15s step=0s ts=TimeUnix value=Value groupBy=[Attributes] scalars=[600] start=0001-01-01T00:00:00Z end=1970-01-01T00:08:20Z
+  Filter predicate=(MetricName = "http_requests_total")
+    Scan(otel_metrics_sum)


### PR DESCRIPTION
## Summary

- Sub-scrape range `[15s]` against ~15s scrape interval yields ≤1
  sample in the window, but cerberus was emitting a value where Prom
  drops the series. This PR locks down the `≥2-sample` guard per
  Prom's `instantValue` / `simpleLinearRegression` contracts for
  `irate` / `idelta` / `deriv` / `predict_linear`. Follow-up from
  Pool-BD's #366 `extrapolatedRate` work.
- The existing emit paths already render `WHERE
  length(window_pairs|window_vals) >= 2` on the outer SELECT (matches
  funcIrate / funcIdelta → `instantValue("< 2 samples")` and
  funcDeriv / funcPredictLinear's "< 2 float points" guard); this
  change locks the contract down with four TXTAR fixtures that emit
  empty `expected_rows` against a 30s-scrape seed in a 15s window,
  plus a parallel `TestQueryRange_RangeMode_SubScrape_ChDB` regression
  that runs all four functions over `query_range` and asserts every
  per-anchor row drops.

## Refs

- Pool-BD's #366 (extrapolatedRate boundary correction for
  rate/increase/delta). #366 covered the `extrapolatedRate` half of
  Bucket 3; this PR closes the `instantValue` / `simpleLinearRegression`
  half flagged in Pool-BD's report:
  > Sub-scrape `[15s]` variants of `irate` / `idelta` / `deriv` /
  > `predict_linear` flagged by Pool-AU are not covered by this PR —
  > those use `instantValue` / `simpleLinearRegression` (not
  > `extrapolatedRate`) and need their own treatment as a follow-up.
- Refs #355 (Pool-AU's post-#350 residual diff audit, Bucket 3
  sub-scrape rows: `irate(...[15s])`, `idelta(...[15s])`,
  `deriv(...[15s])`, `predict_linear(...[15s], …)`).

## Per-function before/after at the boundary

For `[15s]` range against a 30s-scrape series (one sample per window):

| Function          | Window length | Prom        | Cerberus (this PR) |
| ----------------- | ------------- | ----------- | ------------------ |
| `irate`           | 0 / 1 samples | drop        | drop (via outer `WHERE length(window_pairs) >= 2`) |
| `idelta`          | 0 / 1 samples | drop        | drop (via outer `WHERE length(window_vals) >= 2`)  |
| `deriv`           | 0 / 1 samples | drop        | drop (via outer `WHERE length(window_pairs) >= 2`) |
| `predict_linear`  | 0 / 1 samples | drop        | drop (via outer `WHERE length(window_pairs) >= 2`) |
| `irate` (≥2)      | 2 samples     | rate value  | rate value (matrix path same as instant)          |

## Test plan

- [x] `go test ./internal/promql/...` (305 passed — TXTAR fixtures
  generate the same SQL as the existing irate/idelta/deriv/predict_linear
  shapes with the `[15s]` range substituted)
- [x] `go test -tags chdb ./internal/api/prom/ ./test/spec/promql/`
  (258 passed — includes the new `TestQueryRange_RangeMode_SubScrape_ChDB`
  4-subtest regression and the 4 TXTAR roundtrips against chDB
  returning `[]`)
- [ ] Compat lane (informational on push-to-main) — expect 4 more
  diffs (Bucket 3 sub-scrape rows: `irate[15s]`, `idelta[15s]`,
  `deriv[15s]`, `predict_linear[15s]`) to resolve once the merge
  bumps `main`.