### PR TITLE
fix(promql): drop __name__ from time() + metric synthetic-fold output

### DIFF
--- a/internal/promql/binary.go
+++ b/internal/promql/binary.go
@@ -307,15 +307,21 @@ func foldSyntheticBinary(left, right chplan.Node, op chplan.BinaryOp, returnBool
 //
 // The result shape mirrors [lowerVectorScalar]:
 //
-//   - Arithmetic op: Project [MetricName, Attributes, TimeUnix,
-//     (<synth_val> OP Value) AS Value] over the vec leg.
+//   - Arithmetic op: Project ["" AS MetricName, Attributes, TimeUnix,
+//     (<synth_val> OP Value) AS Value] over the vec leg. The
+//     MetricName column is rewritten to an empty literal per Prom's
+//     derived-sample rule (`time() <op> metric` is not the same
+//     series as `metric`, so `__name__` drops). Same rule as #359
+//     applied to instant fns / scalar-vec binops / V-V binops.
 //   - Comparison op + `bool` modifier: Project with
-//     `toFloat64(<synth_val> OP Value) AS Value`.
+//     `toFloat64(<synth_val> OP Value) AS Value`; MetricName is
+//     likewise emptied (bool-compared rows are derived samples).
 //   - Comparison op WITHOUT `bool`: Filter on `<synth_val> OP Value`
 //     keeping the vec leg's columns intact (Prom's "preserve LHS
 //     where comparison holds" rule reduces here to "preserve vec
 //     rows where comparison holds" since the synthetic side has no
-//     labels of its own to keep).
+//     labels of its own to keep — and Prom's bare-comparison rule
+//     preserves __name__ when the op filters rather than transforms).
 //
 // Range mode rewiring: the synthetic leg's Value expression may
 // reference `ColumnRef{anchor_ts}` (the per-step anchor introduced by
@@ -349,7 +355,7 @@ func foldSyntheticVectorBinary(synth, vec chplan.Node, op chplan.BinaryOp, scala
 	return &chplan.Project{
 		Input: vec,
 		Projections: []chplan.Projection{
-			{Expr: &chplan.ColumnRef{Name: s.MetricNameColumn}},
+			{Expr: &chplan.LitString{V: ""}, Alias: s.MetricNameColumn},
 			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}},
 			{Expr: &chplan.ColumnRef{Name: s.TimestampColumn}},
 			{Expr: newValue, Alias: s.ValueColumn},

--- a/test/spec/promql/binop_metric_minus_time.txtar
+++ b/test/spec/promql/binop_metric_minus_time.txtar
@@ -20,23 +20,24 @@ INSERT INTO otel_metrics_sum VALUES
     ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 1767226000.0);
 -- expected_rows --
 [
-  ["http_requests_total", {"job": "api"}, "2026-01-01T00:00:00Z", 399.0]
+  ["", {"job": "api"}, "2026-01-01T00:00:00Z", 399]
 ]
 -- args --
-[0] string = "2026-01-01 00:00:01.000000000"
-[1] int64 = 9
-[2] int64 = 1000000000
-[3] string = "http_requests_total"
-[4] string = "2026-01-01 00:00:01.000000000"
-[5] int64 = 9
-[6] string = "2026-01-01 00:00:01.000000000"
-[7] int64 = 9
-[8] int64 = 300000000000
+[0] string = ""
+[1] string = "2026-01-01 00:00:01.000000000"
+[2] int64 = 9
+[3] int64 = 1000000000
+[4] string = "http_requests_total"
+[5] string = "2026-01-01 00:00:01.000000000"
+[6] int64 = 9
+[7] string = "2026-01-01 00:00:01.000000000"
+[8] int64 = 9
+[9] int64 = 300000000000
 -- chplan --
-Project [MetricName, Attributes, TimeUnix, (Value - toFloat64((toUnixTimestamp64Nano(toDateTime64("2026-01-01 00:00:01.000000000", 9)) / 1000000000))) AS Value]
+Project ["" AS MetricName, Attributes, TimeUnix, (Value - toFloat64((toUnixTimestamp64Nano(toDateTime64("2026-01-01 00:00:01.000000000", 9)) / 1000000000))) AS Value]
   Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
     Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
       Filter predicate=(((MetricName = "http_requests_total") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
         Scan(otel_metrics_sum)
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, (`Value` - toFloat64((toUnixTimestamp64Nano(toDateTime64(?, ?)) / ?))) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_sum` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
+SELECT ? AS `MetricName`, `Attributes`, `TimeUnix`, (`Value` - toFloat64((toUnixTimestamp64Nano(toDateTime64(?, ?)) / ?))) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_sum` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))

--- a/test/spec/promql/binop_time_arith_range.txtar
+++ b/test/spec/promql/binop_time_arith_range.txtar
@@ -13,11 +13,12 @@ time() + http_requests_total
 -- range_step --
 30s
 -- args --
-[0] int64 = 1000000000
-[1] string = "http_requests_total"
-[2] int64 = 300000000000
+[0] string = ""
+[1] int64 = 1000000000
+[2] string = "http_requests_total"
+[3] int64 = 300000000000
 -- chplan --
-Project [MetricName, Attributes, TimeUnix, (toFloat64((toUnixTimestamp64Nano(TimeUnix) / 1000000000)) + Value) AS Value]
+Project ["" AS MetricName, Attributes, TimeUnix, (toFloat64((toUnixTimestamp64Nano(TimeUnix) / 1000000000)) + Value) AS Value]
   Project [MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS TimeUnix, lwr_value AS Value]
     Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS anchor_ts] funcs=[argMax(Value, TimeUnix) AS lwr_value]
       Filter predicate=((TimeUnix <= anchor_ts) AND (TimeUnix > (anchor_ts - toIntervalNanosecond(300000000000))))
@@ -26,4 +27,4 @@ Project [MetricName, Attributes, TimeUnix, (toFloat64((toUnixTimestamp64Nano(Tim
           Filter predicate=(MetricName = "http_requests_total")
             Scan(otel_metrics_sum)
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, (toFloat64((toUnixTimestamp64Nano(`TimeUnix`) / ?)) + `Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `anchor_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT * FROM (SELECT arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:00:00.000000000', 9) + toIntervalNanosecond(i * 30000000000), range(0, 11))) AS `anchor_ts`) AS L CROSS JOIN (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` = ?)) AS R) WHERE ((`TimeUnix` <= `anchor_ts`) AND (`TimeUnix` > (`anchor_ts` - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`, `anchor_ts`))
+SELECT ? AS `MetricName`, `Attributes`, `TimeUnix`, (toFloat64((toUnixTimestamp64Nano(`TimeUnix`) / ?)) + `Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `anchor_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT * FROM (SELECT arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:00:00.000000000', 9) + toIntervalNanosecond(i * 30000000000), range(0, 11))) AS `anchor_ts`) AS L CROSS JOIN (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` = ?)) AS R) WHERE ((`TimeUnix` <= `anchor_ts`) AND (`TimeUnix` > (`anchor_ts` - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`, `anchor_ts`))

--- a/test/spec/promql/binop_time_lt_bool_metric.txtar
+++ b/test/spec/promql/binop_time_lt_bool_metric.txtar
@@ -18,24 +18,25 @@ INSERT INTO otel_metrics_sum VALUES
     ('http_requests_total', map('job', 'db'), toDateTime64('2026-01-01 00:00:00', 9), 5.0);
 -- expected_rows --
 [
-  ["http_requests_total", {"job": "api"}, "2026-01-01T00:00:00Z", 1.0],
-  ["http_requests_total", {"job": "db"}, "2026-01-01T00:00:00Z", 0.0]
+  ["", {"job": "api"}, "2026-01-01T00:00:00Z", 1],
+  ["", {"job": "db"}, "2026-01-01T00:00:00Z", 0]
 ]
 -- args --
-[0] string = "2026-01-01 00:00:01.000000000"
-[1] int64 = 9
-[2] int64 = 1000000000
-[3] string = "http_requests_total"
-[4] string = "2026-01-01 00:00:01.000000000"
-[5] int64 = 9
-[6] string = "2026-01-01 00:00:01.000000000"
-[7] int64 = 9
-[8] int64 = 300000000000
+[0] string = ""
+[1] string = "2026-01-01 00:00:01.000000000"
+[2] int64 = 9
+[3] int64 = 1000000000
+[4] string = "http_requests_total"
+[5] string = "2026-01-01 00:00:01.000000000"
+[6] int64 = 9
+[7] string = "2026-01-01 00:00:01.000000000"
+[8] int64 = 9
+[9] int64 = 300000000000
 -- chplan --
-Project [MetricName, Attributes, TimeUnix, toFloat64((toFloat64((toUnixTimestamp64Nano(toDateTime64("2026-01-01 00:00:01.000000000", 9)) / 1000000000)) < Value)) AS Value]
+Project ["" AS MetricName, Attributes, TimeUnix, toFloat64((toFloat64((toUnixTimestamp64Nano(toDateTime64("2026-01-01 00:00:01.000000000", 9)) / 1000000000)) < Value)) AS Value]
   Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
     Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
       Filter predicate=(((MetricName = "http_requests_total") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
         Scan(otel_metrics_sum)
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, toFloat64((toFloat64((toUnixTimestamp64Nano(toDateTime64(?, ?)) / ?)) < `Value`)) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_sum` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
+SELECT ? AS `MetricName`, `Attributes`, `TimeUnix`, toFloat64((toFloat64((toUnixTimestamp64Nano(toDateTime64(?, ?)) / ?)) < `Value`)) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_sum` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))

--- a/test/spec/promql/binop_time_plus_metric.txtar
+++ b/test/spec/promql/binop_time_plus_metric.txtar
@@ -24,23 +24,24 @@ INSERT INTO otel_metrics_sum VALUES
     ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 5000.0);
 -- expected_rows --
 [
-  ["http_requests_total", {"job": "api"}, "2026-01-01T00:00:00Z", 1767230601.0]
+  ["", {"job": "api"}, "2026-01-01T00:00:00Z", 1767230601]
 ]
 -- args --
-[0] string = "2026-01-01 00:00:01.000000000"
-[1] int64 = 9
-[2] int64 = 1000000000
-[3] string = "http_requests_total"
-[4] string = "2026-01-01 00:00:01.000000000"
-[5] int64 = 9
-[6] string = "2026-01-01 00:00:01.000000000"
-[7] int64 = 9
-[8] int64 = 300000000000
+[0] string = ""
+[1] string = "2026-01-01 00:00:01.000000000"
+[2] int64 = 9
+[3] int64 = 1000000000
+[4] string = "http_requests_total"
+[5] string = "2026-01-01 00:00:01.000000000"
+[6] int64 = 9
+[7] string = "2026-01-01 00:00:01.000000000"
+[8] int64 = 9
+[9] int64 = 300000000000
 -- chplan --
-Project [MetricName, Attributes, TimeUnix, (toFloat64((toUnixTimestamp64Nano(toDateTime64("2026-01-01 00:00:01.000000000", 9)) / 1000000000)) + Value) AS Value]
+Project ["" AS MetricName, Attributes, TimeUnix, (toFloat64((toUnixTimestamp64Nano(toDateTime64("2026-01-01 00:00:01.000000000", 9)) / 1000000000)) + Value) AS Value]
   Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
     Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
       Filter predicate=(((MetricName = "http_requests_total") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
         Scan(otel_metrics_sum)
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, (toFloat64((toUnixTimestamp64Nano(toDateTime64(?, ?)) / ?)) + `Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_sum` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
+SELECT ? AS `MetricName`, `Attributes`, `TimeUnix`, (toFloat64((toUnixTimestamp64Nano(toDateTime64(?, ?)) / ?)) + `Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_sum` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))


### PR DESCRIPTION
## Summary

Pool-BB's #362 added `foldSyntheticVectorBinary` in `internal/promql/binary.go` to broadcast `time()` (and other synthetic-scalar shapes) across every (series, step) row of the real metric leg, fixing `time() + metric`, `metric * time()`, `time() < bool metric`, etc. That spliced `Project` reused the metric leg's `MetricName` column verbatim, but per Prom's derived-sample rule (the same rule already applied in #359 to instant fns / scalar-vec binops / V-V binops), the result of `time() <op> metric` is not the same series as `metric` — `__name__` drops.

Replace the `ColumnRef{MetricName}` projection slot with `LitString{V: ""}` aliased to `MetricName`, identical to the `lowerVectorScalar` (binary.go:491) and `projectValueOverInner` patterns. Bare comparison (no `bool` modifier) still routes through `Filter` and correctly preserves the vec leg's columns intact (Prom's "comparison-as-filter preserves LHS labels" rule), so only the arithmetic + bool-comparison Project branches are affected.

Closes ~12 of the 46 residual diffs from compat run 25901406046 (the `time() <op> metric` family).

## Affected fixtures (4)

Regenerated via `GOLDEN_UPDATE=1 go test ./internal/promql/` (chplan + sql sections) and `CGO_ENABLED=1 GOLDEN_UPDATE=1 go test -tags=chdb ./test/spec/promql/` (chDB `expected_rows`):

- `test/spec/promql/binop_time_plus_metric.txtar` — arithmetic, scalar-on-left
- `test/spec/promql/binop_metric_minus_time.txtar` — arithmetic, scalar-on-right (non-commutative)
- `test/spec/promql/binop_time_arith_range.txtar` — range-mode arithmetic
- `test/spec/promql/binop_time_lt_bool_metric.txtar` — bool-modified comparison

`binop_time_lt_metric.txtar` (bare comparison → `Filter`) is unchanged — correct per Prom.

## References

- #362 (Pool-BB) — introduced `foldSyntheticVectorBinary`.
- #359 — established the `__name__`-drop rule across the four sibling projection sites.
- compat run 25901406046 — residual-diff baseline.

## Test plan

- [x] `GOLDEN_UPDATE=1 go test ./internal/promql/ -run TestLower` regenerates plan / SQL sections (301 fixtures pass).
- [x] `CGO_ENABLED=1 GOLDEN_UPDATE=1 go test -tags=chdb ./test/spec/promql/ -run TestRoundTripChDB` regenerates `expected_rows` cells (216 fixtures pass).
- [ ] CI `check` + `lint` green.
- [ ] Compat run delta resolves the `time() <op> metric` family (~12 diffs).