### PR TITLE
fix(chsql): drop __name__ from V-V bare-comparison on(...) output

### DIFF
--- a/internal/api/prom/handler_chdb_range_mode_test.go
+++ b/internal/api/prom/handler_chdb_range_mode_test.go
@@ -1208,6 +1208,14 @@ func TestQueryRange_RangeMode_VVOnCompare_ChDB(t *testing.T) {
 					t.Errorf("unexpected series instance=%q: %+v", inst, ms.Metric)
 					continue
 				}
+				// V-V bare comparison is a transformation, not a
+				// passthrough — Prom drops `__name__` from the output
+				// (same rule that fires for arithmetic + `bool`-modified
+				// compare). The matrix series must not carry it.
+				if name, hasName := ms.Metric["__name__"]; hasName {
+					t.Errorf("instance=%s: expected __name__ dropped on bare comparison, got %q (full metric: %+v)",
+						inst, name, ms.Metric)
+				}
 				if len(ms.Values) != wantSamples {
 					t.Errorf("instance=%s: expected %d samples, got %d: %+v",
 						inst, wantSamples, len(ms.Values), ms.Values)
@@ -1287,6 +1295,13 @@ func TestQueryRange_RangeMode_VVOnCompareGroupLeft_ChDB(t *testing.T) {
 		if got := ms.Metric["job"]; got != "demo" {
 			t.Errorf("instance=%s: expected job=demo (group_left copy), got job=%q (full metric: %+v)",
 				inst, got, ms.Metric)
+		}
+		// V-V bare comparison drops `__name__` even when group_left
+		// copies labels onto the output — the join is still a
+		// transformation, not a passthrough.
+		if name, hasName := ms.Metric["__name__"]; hasName {
+			t.Errorf("instance=%s: expected __name__ dropped on bare comparison, got %q (full metric: %+v)",
+				inst, name, ms.Metric)
 		}
 		if len(ms.Values) != wantSamples {
 			t.Errorf("instance=%s: expected %d samples, got %d: %+v",

--- a/internal/chsql/vector_join.go
+++ b/internal/chsql/vector_join.go
@@ -394,21 +394,24 @@ func writeOutputAttributes(b *Builder, j *chplan.VectorJoin) {
 }
 
 // outputMetricNameFrag returns a Frag for the joined output's
-// MetricName slot. PromQL's V-V binop rule:
+// MetricName slot. PromQL's V-V binop rule, per Prometheus's reference
+// implementation: every V-V binop is a transformation — the output
+// sample is derived, not a passthrough of the LHS sample. So
+// `__name__` is dropped for every shape:
 //
-//   - Arithmetic op (any non-comparison): always drops `__name__`.
+//   - Arithmetic op (any non-comparison): drops `__name__`.
 //   - Comparison op with `bool` modifier (`ReturnBool == true`):
 //     drops `__name__` — the result is a 1.0/0.0 derived sample.
-//   - Bare comparison op: preserves the LHS metric name (PromQL's
-//     "comparison-as-filter" rule keeps the LHS sample's full label
-//     set, including `__name__`).
+//   - Bare comparison op: also drops `__name__`. Although LHS labels
+//     other than `__name__` survive the comparison-as-filter, Prom
+//     still strips the metric name from the output — comparing two
+//     time series is a transformation, not a passthrough.
 //
 // The dropped case emits a parameterised empty string aliased back to
-// the MetricName column; the preserved case projects the outer side's
-// qualified MetricName directly. See Pool-AU's audit (#355) — this
-// site accounts for ~15 of the 107 compat-lane `__name__`-retention
-// diffs (V-V arithmetic with `on(...)` + V-V `bool` compare with
-// `on(...)` + the `group_left` variants).
+// the MetricName column. See Pool-AU's audit (#355) and Pool-AT's
+// #356 — this site accounts for ~18 of the 107 compat-lane
+// `__name__`-retention diffs across V-V arithmetic / `bool`-compare /
+// bare-compare + group_left variants.
 func outputMetricNameFrag(j *chplan.VectorJoin, outerSide string) Frag {
 	if vectorJoinDropsName(j) {
 		return As(func(b *Builder) { b.Arg("") }, j.MetricNameColumn)
@@ -417,14 +420,10 @@ func outputMetricNameFrag(j *chplan.VectorJoin, outerSide string) Frag {
 }
 
 // vectorJoinDropsName reports whether the V-V binop output drops
-// `__name__`. PromQL's rule: arithmetic ops always drop, comparison
-// ops drop only with the `bool` modifier (otherwise the comparison
-// acts as a filter and LHS labels survive).
-func vectorJoinDropsName(j *chplan.VectorJoin) bool {
-	switch j.Op {
-	case chplan.OpEq, chplan.OpNe, chplan.OpLt, chplan.OpLe, chplan.OpGt, chplan.OpGe:
-		return j.ReturnBool
-	}
+// `__name__`. Prometheus drops the metric name for every V-V binop
+// — arithmetic, comparison-with-bool, and bare comparison alike,
+// because each is a transformation rather than a passthrough.
+func vectorJoinDropsName(_ *chplan.VectorJoin) bool {
 	return true
 }
 

--- a/test/spec/promql/binop_vv_on_compare_eq.txtar
+++ b/test/spec/promql/binop_vv_on_compare_eq.txtar
@@ -12,36 +12,37 @@ INSERT INTO otel_metrics_gauge VALUES
     ('demo_memory_usage_bytes', map('instance', 'b', 'job', 'demo', 'type', 'used'), toDateTime64('2026-01-01 00:00:00', 9), 200.0);
 -- expected_rows --
 [
-  ["demo_memory_usage_bytes", {"instance": "a", "job": "demo", "type": "used"}, "2026-01-01T00:00:00Z", 100.0],
-  ["demo_memory_usage_bytes", {"instance": "b", "job": "demo", "type": "used"}, "2026-01-01T00:00:00Z", 200.0]
+  ["", {"instance": "a", "job": "demo", "type": "used"}, "2026-01-01T00:00:00Z", 100.0],
+  ["", {"instance": "b", "job": "demo", "type": "used"}, "2026-01-01T00:00:00Z", 200.0]
 ]
 -- args --
-[0] string = "many-to-many matching not allowed: matching labels must be unique on one side"
-[1] string = "demo_memory_usage_bytes"
-[2] string = "2026-01-01 00:00:01.000000000"
-[3] int64 = 9
-[4] string = "2026-01-01 00:00:01.000000000"
-[5] int64 = 9
-[6] int64 = 300000000000
-[7] string = "instance"
-[8] string = "job"
-[9] string = "type"
-[10] string = "many-to-many matching not allowed: matching labels must be unique on one side"
-[11] string = "demo_memory_usage_bytes"
-[12] string = "2026-01-01 00:00:01.000000000"
-[13] int64 = 9
-[14] string = "2026-01-01 00:00:01.000000000"
-[15] int64 = 9
-[16] int64 = 300000000000
-[17] string = "instance"
-[18] string = "job"
-[19] string = "type"
-[20] string = "instance"
+[0] string = ""
+[1] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[2] string = "demo_memory_usage_bytes"
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] string = "2026-01-01 00:00:01.000000000"
+[6] int64 = 9
+[7] int64 = 300000000000
+[8] string = "instance"
+[9] string = "job"
+[10] string = "type"
+[11] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[12] string = "demo_memory_usage_bytes"
+[13] string = "2026-01-01 00:00:01.000000000"
+[14] int64 = 9
+[15] string = "2026-01-01 00:00:01.000000000"
+[16] int64 = 9
+[17] int64 = 300000000000
+[18] string = "instance"
+[19] string = "job"
+[20] string = "type"
 [21] string = "instance"
-[22] string = "job"
+[22] string = "instance"
 [23] string = "job"
-[24] string = "type"
+[24] string = "job"
 [25] string = "type"
+[26] string = "type"
 -- chplan --
 VectorJoin op== match=on(instance,job,type) card=one-to-one
   Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
@@ -53,4 +54,4 @@ VectorJoin op== match=on(instance,job,type) card=one-to-one
       Filter predicate=(((MetricName = "demo_memory_usage_bytes") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
         Scan(otel_metrics_gauge)
 -- sql --
-SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, L.`Value` AS `Value` FROM (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY mapFilter((k, v) -> k IN (?, ?, ?), `Attributes`))) AS L INNER JOIN (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY mapFilter((k, v) -> k IN (?, ?, ?), `Attributes`))) AS R ON L.`Attributes`[?] = R.`Attributes`[?] AND L.`Attributes`[?] = R.`Attributes`[?] AND L.`Attributes`[?] = R.`Attributes`[?] WHERE (L.`Value` = R.`Value`)
+SELECT ? AS `MetricName`, L.`Attributes`, L.`TimeUnix`, L.`Value` AS `Value` FROM (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY mapFilter((k, v) -> k IN (?, ?, ?), `Attributes`))) AS L INNER JOIN (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY mapFilter((k, v) -> k IN (?, ?, ?), `Attributes`))) AS R ON L.`Attributes`[?] = R.`Attributes`[?] AND L.`Attributes`[?] = R.`Attributes`[?] AND L.`Attributes`[?] = R.`Attributes`[?] WHERE (L.`Value` = R.`Value`)

--- a/test/spec/promql/binop_vv_on_compare_lt.txtar
+++ b/test/spec/promql/binop_vv_on_compare_lt.txtar
@@ -13,32 +13,33 @@ INSERT INTO otel_metrics_gauge VALUES
 -- expected_rows --
 []
 -- args --
-[0] string = "many-to-many matching not allowed: matching labels must be unique on one side"
-[1] string = "demo_memory_usage_bytes"
-[2] string = "2026-01-01 00:00:01.000000000"
-[3] int64 = 9
-[4] string = "2026-01-01 00:00:01.000000000"
-[5] int64 = 9
-[6] int64 = 300000000000
-[7] string = "instance"
-[8] string = "job"
-[9] string = "type"
-[10] string = "many-to-many matching not allowed: matching labels must be unique on one side"
-[11] string = "demo_memory_usage_bytes"
-[12] string = "2026-01-01 00:00:01.000000000"
-[13] int64 = 9
-[14] string = "2026-01-01 00:00:01.000000000"
-[15] int64 = 9
-[16] int64 = 300000000000
-[17] string = "instance"
-[18] string = "job"
-[19] string = "type"
-[20] string = "instance"
+[0] string = ""
+[1] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[2] string = "demo_memory_usage_bytes"
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] string = "2026-01-01 00:00:01.000000000"
+[6] int64 = 9
+[7] int64 = 300000000000
+[8] string = "instance"
+[9] string = "job"
+[10] string = "type"
+[11] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[12] string = "demo_memory_usage_bytes"
+[13] string = "2026-01-01 00:00:01.000000000"
+[14] int64 = 9
+[15] string = "2026-01-01 00:00:01.000000000"
+[16] int64 = 9
+[17] int64 = 300000000000
+[18] string = "instance"
+[19] string = "job"
+[20] string = "type"
 [21] string = "instance"
-[22] string = "job"
+[22] string = "instance"
 [23] string = "job"
-[24] string = "type"
+[24] string = "job"
 [25] string = "type"
+[26] string = "type"
 -- chplan --
 VectorJoin op=< match=on(instance,job,type) card=one-to-one
   Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
@@ -50,4 +51,4 @@ VectorJoin op=< match=on(instance,job,type) card=one-to-one
       Filter predicate=(((MetricName = "demo_memory_usage_bytes") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
         Scan(otel_metrics_gauge)
 -- sql --
-SELECT L.`MetricName`, L.`Attributes`, L.`TimeUnix`, L.`Value` AS `Value` FROM (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY mapFilter((k, v) -> k IN (?, ?, ?), `Attributes`))) AS L INNER JOIN (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY mapFilter((k, v) -> k IN (?, ?, ?), `Attributes`))) AS R ON L.`Attributes`[?] = R.`Attributes`[?] AND L.`Attributes`[?] = R.`Attributes`[?] AND L.`Attributes`[?] = R.`Attributes`[?] WHERE (L.`Value` < R.`Value`)
+SELECT ? AS `MetricName`, L.`Attributes`, L.`TimeUnix`, L.`Value` AS `Value` FROM (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY mapFilter((k, v) -> k IN (?, ?, ?), `Attributes`))) AS L INNER JOIN (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY mapFilter((k, v) -> k IN (?, ?, ?), `Attributes`))) AS R ON L.`Attributes`[?] = R.`Attributes`[?] AND L.`Attributes`[?] = R.`Attributes`[?] AND L.`Attributes`[?] = R.`Attributes`[?] WHERE (L.`Value` < R.`Value`)


### PR DESCRIPTION
## Summary

Pool-AT's #356 fixed the V-V `on()` bare-comparison 502 by routing
through `emitVectorJoin` + a `WHERE` filter so the surviving rows
carry `L.Value` (Float64) instead of the per-pair comparison's
`UInt8` result. The fix preserved the LHS sample value correctly,
but the output SELECT still projected `L.MetricName` — which
contradicts Prometheus's V-V binop rule:

> Every V-V binop is a transformation, not a passthrough. The
> output sample is derived; `__name__` is dropped on **every**
> shape — arithmetic, comparison-with-`bool`, **and bare
> comparison**.

Pool-AX's #359 covered the `bool`-comparison + arithmetic paths but
left the bare-comparison branch projecting `L.MetricName` because
the docstring incorrectly claimed LHS labels survive verbatim. They
don't — Prom strips `__name__` from the output even when the rest
of the LHS label set survives the comparison-as-filter.

## Change

- `internal/chsql/vector_join.go`:
  - `vectorJoinDropsName` now always returns `true` for V-V binops.
    The op-specific switch is gone; the docstring explains why.
  - `outputMetricNameFrag`'s docstring updated to reflect the
    transformation semantics.
- `internal/api/prom/handler_chdb_range_mode_test.go`:
  - `TestQueryRange_RangeMode_VVOnCompare_ChDB` and
    `TestQueryRange_RangeMode_VVOnCompareGroupLeft_ChDB` now assert
    `ms.Metric` does not carry `__name__`. Pool-AT's existing
    semantic checks (per-instance Value, `group_left(job)` copy)
    stay intact.
- `test/spec/promql/binop_vv_on_compare_{eq,lt}.txtar`:
  - SQL section regenerated — SELECT projects `? AS MetricName`
    (parameterised empty string) instead of `L.MetricName`.
  - `args[0]` is now `""` (the new positional argument).
  - `binop_vv_on_compare_eq.txtar`'s `expected_rows` updated to
    carry `""` as the metric name.

## Compat-run impact

Closes ~3 of the 46 residual diffs from compat run 25901406046 —
the `==` / `<=` / `>=` shapes on
`demo_memory_usage_bytes == on(instance, job, type) demo_memory_usage_bytes`
where cerberus retained `demo_memory_usage_bytes{...}` on the
output and Prom emitted `{...}`.

## References

- #356 (Pool-AT): bare-compare 502 fix, kept `L.MetricName`.
- #359 (Pool-AX): added `outputMetricNameFrag` for the
  `bool`-compare + arithmetic shapes; this PR extends it to bare
  compare.
- Compat run 25901406046.

## Test plan

- [x] `go test ./internal/chsql/ -count=1` — 392 passed
- [x] `go test ./internal/promql/... -count=1` — 541 passed
- [x] `go vet ./internal/{chsql,promql,api/prom}/...` — clean
- [x] `go build ./...` — clean
- [ ] CI `check` + `lint` green
- [ ] Nightly compat run resolves the 3 listed shapes