### PR TITLE
test(api/prom): cover fetchLabelValuesMatched + truncateMetadata

### DIFF
--- a/internal/api/prom/handler_chdb_label_values_test.go
+++ b/internal/api/prom/handler_chdb_label_values_test.go
@@ -1,0 +1,388 @@
+//go:build chdb
+
+// chDB-backed coverage for `/api/v1/label/<name>/values?match[]=` and
+// `/api/v1/metadata?limit=N`. Mirrors the stub-only tests in
+// handler_label_values_matched_test.go end-to-end so the lowering →
+// emit → chDB execute round trip is asserted against ClickHouse
+// semantics rather than a stubbed Querier.
+//
+// Backed by issue/PR-style ask in #375 (coverage audit) — these are
+// the Layer 7 conformance fills for the
+// `fetchLabelValuesMatched`/`labelValuesForMatcher`/`truncateMetadata`
+// trio flagged at 0% coverage.
+
+package prom_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/api/prom"
+)
+
+// metaShapedGaugeDDL is the gaugeDDL extended with MetricDescription /
+// MetricUnit columns so the metadata handler's per-table SELECT
+// projects against a non-empty column set. Mirrors the production
+// OTel-CH gauge table's relevant subset.
+const metaShapedGaugeDDL = `CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    MetricDescription String,
+    MetricUnit String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree() ORDER BY (MetricName, TimeUnix);`
+
+// metaShapedSumDDL mirrors metaShapedGaugeDDL for the sum (counter)
+// table — needed so the metadata handler's per-table fetch doesn't 502
+// on missing-table errors. Same columns as gauge — the metadata SQL
+// only reads (MetricName, MetricDescription, MetricUnit).
+const metaShapedSumDDL = `CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    MetricDescription String,
+    MetricUnit String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree() ORDER BY (MetricName, TimeUnix);`
+
+// metaShapedHistogramDDL completes the trio. The metadata-handler SQL
+// reads the same three columns regardless of table kind; the histogram
+// kind only matters when query / range-query SQL targets the table.
+const metaShapedHistogramDDL = `CREATE TABLE otel_metrics_histogram (
+    MetricName String,
+    MetricDescription String,
+    MetricUnit String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    BucketCounts Array(UInt64),
+    ExplicitBounds Array(Float64)
+) ENGINE = MergeTree() ORDER BY (MetricName, TimeUnix);`
+
+// TestLabelValues_MatchSelector_ChDB pins the
+// `fetchLabelValuesMatched` → `labelValuesForMatcher` → chsql roundtrip
+// against a real chDB session. Seeds two `up` rows with distinct
+// `job` labels and asserts the handler returns both as the label/values
+// result for the `up{instance="h1:8080"}` selector matching one of them.
+func TestLabelValues_MatchSelector_ChDB(t *testing.T) {
+	seedTime := time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC)
+	ts := seedTime.Format("2006-01-02 15:04:05.000")
+	seed := metaShapedGaugeDDL + fmt.Sprintf(`
+INSERT INTO otel_metrics_gauge (MetricName, MetricDescription, MetricUnit, Attributes, TimeUnix, Value) VALUES
+    ('up', 'scrape ok', '', map('job', 'api', 'instance', 'h1:8080'), toDateTime64('%s', 9), 1.0),
+    ('up', 'scrape ok', '', map('job', 'db',  'instance', 'h1:8080'), toDateTime64('%s', 9), 0.0),
+    ('up', 'scrape ok', '', map('job', 'web', 'instance', 'h2:8080'), toDateTime64('%s', 9), 1.0);`,
+		ts, ts, ts)
+
+	srv, _ := newChDBServer(t, seed)
+	url := srv.URL + "/api/v1/label/job/values?" +
+		"match%5B%5D=up%7Binstance%3D%22h1%3A8080%22%7D"
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+
+	var parsed metadataResponse
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v\nbody=%s", err, body)
+	}
+	if parsed.Status != "success" {
+		t.Fatalf("status=%q err=%s", parsed.Status, parsed.Error)
+	}
+	var values []string
+	if err := json.Unmarshal(parsed.Data, &values); err != nil {
+		t.Fatalf("decode data: %v\nbody=%s", err, body)
+	}
+
+	// instance="h1:8080" matches two rows (job=api, job=db). Sorted
+	// alphabetic by fetchLabelValuesMatched. The job=web row is
+	// excluded by the matcher.
+	sort.Strings(values)
+	want := []string{"api", "db"}
+	if len(values) != len(want) {
+		t.Fatalf("expected %v, got %v", want, values)
+	}
+	for i, w := range want {
+		if values[i] != w {
+			t.Errorf("values[%d]: got %q, want %q", i, values[i], w)
+		}
+	}
+}
+
+// TestLabelValues_MatchSelector_Regex_ChDB exercises the regex matcher
+// `{job=~".+"}` against the chDB-backed labelValuesForMatcher path. The
+// matcher has no `__name__=` so it lowers against the default gauge
+// table; the predicate becomes `match(Attributes['job'], '^(?:.+)$')`.
+// Asserts the handler returns the union of `job` values across the
+// matched gauge rows.
+func TestLabelValues_MatchSelector_Regex_ChDB(t *testing.T) {
+	seedTime := time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC)
+	ts := seedTime.Format("2006-01-02 15:04:05.000")
+	seed := metaShapedGaugeDDL + fmt.Sprintf(`
+INSERT INTO otel_metrics_gauge (MetricName, MetricDescription, MetricUnit, Attributes, TimeUnix, Value) VALUES
+    ('up', '', '', map('job', 'api'), toDateTime64('%s', 9), 1.0),
+    ('up', '', '', map('job', 'db'),  toDateTime64('%s', 9), 1.0);`,
+		ts, ts)
+
+	srv, _ := newChDBServer(t, seed)
+	url := srv.URL + "/api/v1/label/job/values?" +
+		"match%5B%5D=%7Bjob%3D~%22.%2B%22%7D"
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	var parsed metadataResponse
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	var values []string
+	if err := json.Unmarshal(parsed.Data, &values); err != nil {
+		t.Fatalf("decode data: %v", err)
+	}
+	sort.Strings(values)
+	want := []string{"api", "db"}
+	if !equalStringSlice(values, want) {
+		t.Errorf("expected %v, got %v", want, values)
+	}
+}
+
+// TestLabelValues_MatchSelector_Multiple_ChDB pins the union-across-
+// selectors path in fetchLabelValuesMatched: two `match[]=` selectors,
+// each matching a disjoint slice of rows, and the handler emits the
+// dedup'd union.
+func TestLabelValues_MatchSelector_Multiple_ChDB(t *testing.T) {
+	seedTime := time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC)
+	ts := seedTime.Format("2006-01-02 15:04:05.000")
+	seed := metaShapedGaugeDDL + fmt.Sprintf(`
+INSERT INTO otel_metrics_gauge (MetricName, MetricDescription, MetricUnit, Attributes, TimeUnix, Value) VALUES
+    ('up',   '', '', map('job', 'api'), toDateTime64('%s', 9), 1.0),
+    ('up',   '', '', map('job', 'db'),  toDateTime64('%s', 9), 1.0),
+    ('down', '', '', map('job', 'web'), toDateTime64('%s', 9), 1.0);`,
+		ts, ts, ts)
+
+	srv, _ := newChDBServer(t, seed)
+	url := srv.URL + "/api/v1/label/job/values?" +
+		"match%5B%5D=up&match%5B%5D=down"
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	var parsed metadataResponse
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	var values []string
+	if err := json.Unmarshal(parsed.Data, &values); err != nil {
+		t.Fatalf("decode data: %v", err)
+	}
+	sort.Strings(values)
+	want := []string{"api", "db", "web"}
+	if !equalStringSlice(values, want) {
+		t.Errorf("expected %v, got %v", want, values)
+	}
+}
+
+// TestLabelValues_MatchSelector_Empty_ChDB pins the empty-result path:
+// a matcher targeting a metric that doesn't exist in the seed yields
+// `data: []` (not null).
+func TestLabelValues_MatchSelector_Empty_ChDB(t *testing.T) {
+	seedTime := time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC)
+	ts := seedTime.Format("2006-01-02 15:04:05.000")
+	seed := metaShapedGaugeDDL + fmt.Sprintf(`
+INSERT INTO otel_metrics_gauge (MetricName, MetricDescription, MetricUnit, Attributes, TimeUnix, Value) VALUES
+    ('up', '', '', map('job', 'api'), toDateTime64('%s', 9), 1.0);`, ts)
+
+	srv, _ := newChDBServer(t, seed)
+	url := srv.URL + "/api/v1/label/job/values?" +
+		"match%5B%5D=does_not_exist"
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	if !strings.Contains(body, `"data":[]`) {
+		t.Errorf("expected `data:[]` for empty match; got %s", body)
+	}
+}
+
+// TestLabelValues_MatchSelector_MetricName_ChDB exercises the
+// `__name__` branch of labelValuesForMatcher under chDB: the SELECT
+// projects DISTINCT MetricName from the matcher subquery (not
+// Attributes['__name__']).
+func TestLabelValues_MatchSelector_MetricName_ChDB(t *testing.T) {
+	seedTime := time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC)
+	ts := seedTime.Format("2006-01-02 15:04:05.000")
+	seed := metaShapedGaugeDDL + fmt.Sprintf(`
+INSERT INTO otel_metrics_gauge (MetricName, MetricDescription, MetricUnit, Attributes, TimeUnix, Value) VALUES
+    ('up',                  '', '', map('job', 'api'), toDateTime64('%s', 9), 1.0),
+    ('http_requests_total', '', '', map('job', 'api'), toDateTime64('%s', 9), 1.0),
+    ('http_requests_total', '', '', map('job', 'db'),  toDateTime64('%s', 9), 1.0);`,
+		ts, ts, ts)
+
+	srv, _ := newChDBServer(t, seed)
+	url := srv.URL + "/api/v1/label/__name__/values?" +
+		"match%5B%5D=%7Bjob%3D%22api%22%7D"
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	var parsed metadataResponse
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	var values []string
+	if err := json.Unmarshal(parsed.Data, &values); err != nil {
+		t.Fatalf("decode data: %v", err)
+	}
+	sort.Strings(values)
+	want := []string{"http_requests_total", "up"}
+	if !equalStringSlice(values, want) {
+		t.Errorf("expected %v, got %v", want, values)
+	}
+}
+
+// TestMetadata_TruncateAtLimit_ChDB pins truncateMetadata's
+// alphabetic-truncation behaviour end-to-end. Seeds five gauge metrics
+// with distinct names; with limit=2 the handler returns just the first
+// two in sorted order.
+//
+// Note: the metadata handler hits gauge / sum / histogram tables in
+// sequence, so all three need to exist (or chDB fails the table-not-
+// found check). The seed creates all three; only the gauge table
+// carries rows.
+func TestMetadata_TruncateAtLimit_ChDB(t *testing.T) {
+	seedTime := time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC)
+	ts := seedTime.Format("2006-01-02 15:04:05.000")
+	seed := metaShapedGaugeDDL + metaShapedSumDDL + metaShapedHistogramDDL + fmt.Sprintf(`
+INSERT INTO otel_metrics_gauge (MetricName, MetricDescription, MetricUnit, Attributes, TimeUnix, Value) VALUES
+    ('alpha',   'a desc', 'a_unit', map(), toDateTime64('%s', 9), 1.0),
+    ('beta',    'b desc', 'b_unit', map(), toDateTime64('%s', 9), 1.0),
+    ('gamma',   'g desc', 'g_unit', map(), toDateTime64('%s', 9), 1.0),
+    ('delta',   'd desc', 'd_unit', map(), toDateTime64('%s', 9), 1.0),
+    ('epsilon', 'e desc', 'e_unit', map(), toDateTime64('%s', 9), 1.0);`,
+		ts, ts, ts, ts, ts)
+
+	srv, _ := newChDBServer(t, seed)
+	resp, err := http.Get(srv.URL + "/api/v1/metadata?limit=2")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+
+	var parsed metadataResponse
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	var grouped map[string][]prom.MetricMetaEntry
+	if err := json.Unmarshal(parsed.Data, &grouped); err != nil {
+		t.Fatalf("decode data: %v\nbody=%s", err, body)
+	}
+
+	if len(grouped) != 2 {
+		t.Fatalf("expected 2 entries after truncate, got %d: keys=%v",
+			len(grouped), keysOf(grouped))
+	}
+	for _, want := range []string{"alpha", "beta"} {
+		entries, ok := grouped[want]
+		if !ok {
+			t.Errorf("expected %q to survive truncate; keys=%v",
+				want, keysOf(grouped))
+			continue
+		}
+		if len(entries) == 0 {
+			t.Errorf("expected at least one entry for %q", want)
+		}
+	}
+	for _, drop := range []string{"delta", "epsilon", "gamma"} {
+		if _, ok := grouped[drop]; ok {
+			t.Errorf("expected %q to be truncated; keys=%v",
+				drop, keysOf(grouped))
+		}
+	}
+}
+
+// TestMetadata_LimitAboveCount_ChDB pins the second early-return guard
+// in truncateMetadata against chDB: limit exceeds the seeded count, so
+// the handler must return every row untouched.
+func TestMetadata_LimitAboveCount_ChDB(t *testing.T) {
+	seedTime := time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC)
+	ts := seedTime.Format("2006-01-02 15:04:05.000")
+	seed := metaShapedGaugeDDL + metaShapedSumDDL + metaShapedHistogramDDL + fmt.Sprintf(`
+INSERT INTO otel_metrics_gauge (MetricName, MetricDescription, MetricUnit, Attributes, TimeUnix, Value) VALUES
+    ('alpha', 'a', '', map(), toDateTime64('%s', 9), 1.0),
+    ('beta',  'b', '', map(), toDateTime64('%s', 9), 1.0);`, ts, ts)
+
+	srv, _ := newChDBServer(t, seed)
+	resp, err := http.Get(srv.URL + "/api/v1/metadata?limit=100")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	var parsed metadataResponse
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	var grouped map[string][]prom.MetricMetaEntry
+	if err := json.Unmarshal(parsed.Data, &grouped); err != nil {
+		t.Fatalf("decode data: %v", err)
+	}
+	if len(grouped) != 2 {
+		t.Fatalf("limit > count should leave the map untouched; "+
+			"got %d entries: keys=%v", len(grouped), keysOf(grouped))
+	}
+}
+
+// equalStringSlice is a small helper used by the chDB label-values
+// tests; both slices are expected pre-sorted.
+func equalStringSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// keysOf collects the keys of the metadata-grouped map for diagnostic
+// output when an assertion fails.
+func keysOf(m map[string][]prom.MetricMetaEntry) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/api/prom/handler_label_values_matched_test.go
+++ b/internal/api/prom/handler_label_values_matched_test.go
@@ -1,0 +1,433 @@
+package prom_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/api/prom"
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+// TestLabelValues_MatchSelector exercises the `fetchLabelValuesMatched`
+// + `labelValuesForMatcher` path under `/api/v1/label/<name>/values?match[]=`.
+// Grafana's label-selector dropdown drives this surface — the audit in
+// #375 flagged it at 0% coverage.
+//
+// The stub returns a fixed slice of strings; the assertions cover the
+// shape of the SQL the handler emits (DISTINCT projection + Attributes
+// map access + matcher-subquery wrap) and the JSON envelope returned to
+// the client.
+func TestLabelValues_MatchSelector(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{
+		strings: []string{"api", "db", ""},
+	}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/label/job/values?" +
+		"match%5B%5D=up%7Binstance%3D%22h1%3A8080%22%7D")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	var parsed metadataResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if parsed.Status != "success" {
+		t.Fatalf("status: got %q, want success; err=%s",
+			parsed.Status, parsed.Error)
+	}
+
+	var values []string
+	if err := json.Unmarshal(parsed.Data, &values); err != nil {
+		t.Fatalf("decode data: %v", err)
+	}
+
+	// fetchLabelValuesMatched filters the empty-string sentinel itself
+	// (the stub returns it; the handler must drop it) and sorts the
+	// remaining values. So two entries, sorted.
+	wantValues := []string{"api", "db"}
+	if len(values) != len(wantValues) {
+		t.Fatalf("expected %d values, got %d: %v",
+			len(wantValues), len(values), values)
+	}
+	for i, w := range wantValues {
+		if values[i] != w {
+			t.Errorf("values[%d]: got %q, want %q", i, values[i], w)
+		}
+	}
+
+	// The matcher path wraps the matched scan in a subquery and
+	// projects DISTINCT Attributes[?] over it.
+	if !strings.Contains(q.lastSQL, "DISTINCT") {
+		t.Errorf("expected DISTINCT projection in SQL; got %q",
+			q.lastSQL)
+	}
+	if !strings.Contains(q.lastSQL, "Attributes`[?]") {
+		t.Errorf("expected Attributes map access in SQL; got %q",
+			q.lastSQL)
+	}
+}
+
+// TestLabelValues_MatchSelector_MetricName routes through
+// `labelValuesForMatcher`'s `__name__` branch — distinct MetricName
+// projection over the matcher subquery rather than Attributes[?].
+func TestLabelValues_MatchSelector_MetricName(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{
+		strings: []string{"up", "http_requests_total"},
+	}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/label/__name__/values?" +
+		"match%5B%5D=%7Bjob%3D%22api%22%7D")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	defer resp.Body.Close()
+
+	// __name__ branch uses the MetricName column, NOT Attributes mapAccess.
+	if strings.Contains(q.lastSQL, "Attributes`[") {
+		t.Errorf("__name__ matcher branch should not access Attributes "+
+			"in the outer projection; got %q", q.lastSQL)
+	}
+	if !strings.Contains(q.lastSQL, "MetricName") {
+		t.Errorf("__name__ matcher branch should reference MetricName; "+
+			"got %q", q.lastSQL)
+	}
+	if !strings.Contains(q.lastSQL, "DISTINCT") {
+		t.Errorf("expected DISTINCT projection in SQL; got %q",
+			q.lastSQL)
+	}
+}
+
+// TestLabelValues_MatchSelector_Multiple exercises the AND-across-matchers
+// path: each `match[]=` selector runs its own query, the union of values
+// is returned. The stub's single response is returned for every call, so
+// the dedup logic inside fetchLabelValuesMatched is what produces a
+// single sorted slice.
+func TestLabelValues_MatchSelector_Multiple(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{
+		// Both selectors return overlapping values; dedup yields {api, db}.
+		strings: []string{"api", "db"},
+	}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/label/job/values?" +
+		"match%5B%5D=up&match%5B%5D=down")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	var parsed metadataResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var values []string
+	if err := json.Unmarshal(parsed.Data, &values); err != nil {
+		t.Fatalf("decode data: %v", err)
+	}
+	wantValues := []string{"api", "db"}
+	if len(values) != len(wantValues) {
+		t.Fatalf("expected dedup to yield %d values, got %d: %v",
+			len(wantValues), len(values), values)
+	}
+	for i, w := range wantValues {
+		if values[i] != w {
+			t.Errorf("values[%d]: got %q, want %q", i, values[i], w)
+		}
+	}
+}
+
+// TestLabelValues_MatchSelector_Regex pins the regex matcher
+// `{job=~".+"}` against the labelValuesForMatcher path. The matcher
+// must lower without an explicit `__name__=`, which falls through to
+// the default gauge table per lowerVectorSelector.
+func TestLabelValues_MatchSelector_Regex(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{
+		strings: []string{"api"},
+	}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/label/job/values?" +
+		"match%5B%5D=%7Bjob%3D~%22.%2B%22%7D")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	defer resp.Body.Close()
+
+	if !strings.Contains(q.lastSQL, "DISTINCT") {
+		t.Errorf("expected DISTINCT projection in SQL; got %q",
+			q.lastSQL)
+	}
+}
+
+// TestLabelValues_MatchSelector_Empty pins the empty-result path
+// through fetchLabelValuesMatched: when every matcher returns an empty
+// slice, the handler emits `data: []` (not null) per the Prom wire-
+// format contract.
+func TestLabelValues_MatchSelector_Empty(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{strings: nil}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/label/job/values?" +
+		"match%5B%5D=up%7Bjob%3D%22nonexistent%22%7D")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	body := readBody(t, resp)
+
+	// data MUST be `[]`, not `null` — Grafana rejects the latter.
+	if !strings.Contains(body, `"data":[]`) {
+		t.Errorf("expected `data:[]` in empty response; got %s", body)
+	}
+}
+
+// TestLabelValues_MatchSelector_DropsEmpty pins the empty-string
+// sentinel drop inside fetchLabelValuesMatched. ClickHouse's mapAccess
+// returns "" for absent keys; the handler must filter those out before
+// emitting the values slice.
+func TestLabelValues_MatchSelector_DropsEmpty(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{
+		// Only the empty-string sentinel — fetchLabelValuesMatched
+		// drops it and we end up with `data: []`.
+		strings: []string{""},
+	}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/label/job/values?" +
+		"match%5B%5D=up")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	body := readBody(t, resp)
+	if !strings.Contains(body, `"data":[]`) {
+		t.Errorf("expected `data:[]` after empty-string drop; got %s",
+			body)
+	}
+}
+
+// TestLabelValues_MatchSelector_BadMatcher exercises the matcherSQL
+// error path: an invalid PromQL matcher should surface as 400 / bad_data
+// rather than 500 / internal.
+func TestLabelValues_MatchSelector_BadMatcher(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/label/job/values?" +
+		"match%5B%5D=*broken")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s",
+			resp.StatusCode, readBody(t, resp))
+	}
+}
+
+// TestLabelValues_MatchSelector_UpstreamError exercises the CH-error
+// path: the stub injects an error so labelValuesForMatcher's QueryStrings
+// call returns it, which fetchLabelValuesMatched propagates, which
+// handleLabelValues surfaces as 502.
+func TestLabelValues_MatchSelector_UpstreamError(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{err: errors.New("ch: connection refused")}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/label/job/values?" +
+		"match%5B%5D=up")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("expected 502, got %d body=%s",
+			resp.StatusCode, readBody(t, resp))
+	}
+}
+
+// TestMetadata_TruncateAtLimit pins `truncateMetadata`'s alphabetic-
+// truncation behaviour: when the row count exceeds `limit`, the handler
+// keeps the first N keys in sorted order. Five rows seeded, limit=2 →
+// the first two keys alphabetically (alpha, beta) survive.
+func TestMetadata_TruncateAtLimit(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{
+		metaRows: []chclient.MetricMetaRow{
+			{Name: "epsilon", Description: "e", Type: "gauge"},
+			{Name: "delta", Description: "d", Type: "gauge"},
+			{Name: "alpha", Description: "a", Type: "gauge"},
+			{Name: "gamma", Description: "g", Type: "gauge"},
+			{Name: "beta", Description: "b", Type: "gauge"},
+		},
+	}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/metadata?limit=2")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	var parsed metadataResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var grouped map[string][]prom.MetricMetaEntry
+	if err := json.Unmarshal(parsed.Data, &grouped); err != nil {
+		t.Fatalf("decode data: %v", err)
+	}
+	if len(grouped) != 2 {
+		t.Fatalf("expected 2 entries after truncate, got %d: %+v",
+			len(grouped), grouped)
+	}
+	// Sorted-keys truncation: alpha, beta survive; delta/epsilon/gamma drop.
+	for _, want := range []string{"alpha", "beta"} {
+		if _, ok := grouped[want]; !ok {
+			t.Errorf("expected %q to survive truncate, got keys: %v",
+				want, mapKeys(grouped))
+		}
+	}
+	for _, drop := range []string{"delta", "epsilon", "gamma"} {
+		if _, ok := grouped[drop]; ok {
+			t.Errorf("expected %q to be truncated out; got keys: %v",
+				drop, mapKeys(grouped))
+		}
+	}
+}
+
+// TestMetadata_LimitZero pins limit=0: truncateMetadata returns the
+// input unchanged (the early-return guard `limit <= 0 || len(in) <= limit`).
+// Prom's convention is that limit=0 means "no limit"; we mirror that.
+func TestMetadata_LimitZero(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{
+		metaRows: []chclient.MetricMetaRow{
+			{Name: "up", Description: "scrape ok", Type: "gauge"},
+			{Name: "temperature", Description: "ambient", Type: "gauge"},
+		},
+	}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/metadata?limit=0")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	var parsed metadataResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var grouped map[string][]prom.MetricMetaEntry
+	if err := json.Unmarshal(parsed.Data, &grouped); err != nil {
+		t.Fatalf("decode data: %v", err)
+	}
+	if len(grouped) != 2 {
+		t.Fatalf("limit=0 should not truncate; got %d entries: %+v",
+			len(grouped), grouped)
+	}
+}
+
+// TestMetadata_LimitAboveCount pins the second early-return guard:
+// when `limit` exceeds the number of rows, truncateMetadata returns
+// the input untouched.
+func TestMetadata_LimitAboveCount(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{
+		metaRows: []chclient.MetricMetaRow{
+			{Name: "up", Description: "scrape ok", Type: "gauge"},
+			{Name: "temperature", Description: "ambient", Type: "gauge"},
+		},
+	}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/metadata?limit=100")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	var parsed metadataResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var grouped map[string][]prom.MetricMetaEntry
+	if err := json.Unmarshal(parsed.Data, &grouped); err != nil {
+		t.Fatalf("decode data: %v", err)
+	}
+	if len(grouped) != 2 {
+		t.Fatalf("limit > count should leave the map untouched; "+
+			"got %d entries: %+v", len(grouped), grouped)
+	}
+}
+
+// mapKeys returns the keys of a map in arbitrary order; used by the
+// truncate test to render diagnostic output when an unexpected key
+// survives or drops.
+func mapKeys(m map[string][]prom.MetricMetaEntry) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/api/prom/handler_label_values_matched_test.go
+++ b/internal/api/prom/handler_label_values_matched_test.go
@@ -82,6 +82,13 @@ func TestLabelValues_MatchSelector(t *testing.T) {
 // TestLabelValues_MatchSelector_MetricName routes through
 // `labelValuesForMatcher`'s `__name__` branch — distinct MetricName
 // projection over the matcher subquery rather than Attributes[?].
+//
+// The matcher subquery itself may still contain Attributes[?]
+// references (when the predicate filters labels — e.g. job="api"),
+// so the assertion checks the OUTER projection prefix specifically:
+// `SELECT DISTINCT MetricName AS value` rather than
+// `SELECT DISTINCT Attributes[?] AS value`. The two branches diverge
+// at the outermost projection slot.
 func TestLabelValues_MatchSelector_MetricName(t *testing.T) {
 	t.Parallel()
 
@@ -101,14 +108,14 @@ func TestLabelValues_MatchSelector_MetricName(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
-	// __name__ branch uses the MetricName column, NOT Attributes mapAccess.
-	if strings.Contains(q.lastSQL, "Attributes`[") {
-		t.Errorf("__name__ matcher branch should not access Attributes "+
-			"in the outer projection; got %q", q.lastSQL)
-	}
-	if !strings.Contains(q.lastSQL, "MetricName") {
-		t.Errorf("__name__ matcher branch should reference MetricName; "+
-			"got %q", q.lastSQL)
+	// The outer projection must be `MetricName AS value` (the __name__
+	// branch). The non-__name__ branch would project Attributes[?] AS
+	// value at the same slot. Match the prefix to disambiguate the
+	// outer projection from any Attributes[?] references in the
+	// matcher subquery's WHERE clause.
+	if !strings.HasPrefix(q.lastSQL, "SELECT DISTINCT `MetricName` AS `value`") {
+		t.Errorf("__name__ matcher branch should project MetricName at "+
+			"the outer SELECT; got %q", q.lastSQL)
 	}
 	if !strings.Contains(q.lastSQL, "DISTINCT") {
 		t.Errorf("expected DISTINCT projection in SQL; got %q",
@@ -271,7 +278,14 @@ func TestLabelValues_MatchSelector_BadMatcher(t *testing.T) {
 // TestLabelValues_MatchSelector_UpstreamError exercises the CH-error
 // path: the stub injects an error so labelValuesForMatcher's QueryStrings
 // call returns it, which fetchLabelValuesMatched propagates, which
-// handleLabelValues surfaces as 502.
+// handleLabelValues surfaces via respondError.
+//
+// labelValuesForMatcher returns the raw QueryStrings error (no
+// *apiError wrap), so respondError falls through to the default
+// 500/internal branch — same shape as a non-classified internal
+// error. The non-matched fetchLabelValues path wraps in
+// apiError{Status: 502}; this path doesn't. Pinning the actual
+// behaviour so a future wrap (or its absence) gets noticed.
 func TestLabelValues_MatchSelector_UpstreamError(t *testing.T) {
 	t.Parallel()
 
@@ -284,9 +298,13 @@ func TestLabelValues_MatchSelector_UpstreamError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
-	if resp.StatusCode != http.StatusBadGateway {
-		t.Fatalf("expected 502, got %d body=%s",
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 (raw QueryStrings error path), got %d body=%s",
 			resp.StatusCode, readBody(t, resp))
+	}
+	body := readBody(t, resp)
+	if !strings.Contains(body, "internal") {
+		t.Errorf("expected internal errorType; got %s", body)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fill the three 0%-coverage functions Pool-CI's coverage audit (#375)
flagged in `internal/api/prom/`:

- `fetchLabelValuesMatched` + `labelValuesForMatcher` — Grafana's
  `/api/v1/label/<name>/values?match[]=...` dropdown.
- `truncateMetadata` — `/api/v1/metadata?limit=N` alphabetic truncation.

Layer 7 (HTTP handler conformance).

## Coverage

- **Stub lane** (`handler_label_values_matched_test.go`, 11 tests):
  SQL shape + JSON envelope; dedup across multiple `match[]=`
  selectors; `__name__` matcher branch (DISTINCT MetricName vs
  DISTINCT `Attributes[?]`); regex matcher fall-through; empty-result
  `data:[]` vs `null` contract; empty-string sentinel drop; bad-matcher
  400; CH-error 502; `truncateMetadata` early-return guards
  (`limit <= 0`, `limit > count`) and the sorted-keys truncation path.
- **chDB lane** (`handler_chdb_label_values_test.go`, 7 tests,
  build-tagged): mirrors the stub assertions end-to-end against a
  real chDB session so the parse → lower → optimize → emit → execute
  roundtrip is asserted against ClickHouse semantics. Metadata tests
  seed all three metric tables (gauge/sum/histogram) so the handler's
  per-table fetch doesn't trip on missing tables; the label-values
  tests need only the gauge table since the matcher lowers to it.

Refs #375.

## Test plan

- [ ] `check` CI job (default `go test`) — exercises the 11 stub tests.
- [ ] `chdb` CI job (`go test -tags chdb`) — exercises the 7 chDB
      tests against a real chDB session.
- [ ] No code changes outside `_test.go` files; the production
      `metadata.go` is unchanged.