### PR TITLE
test(spec/logql): cover vector-vector binary ops + literal-vector paths

### DIFF
--- a/test/spec/logql/binop_literal_vector.txtar
+++ b/test/spec/logql/binop_literal_vector.txtar
@@ -1,0 +1,41 @@
+-- query.logql --
+vector(5) * on() count_over_time({service_name="api"}[5m])
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
+    (toDateTime64('2025-12-31 23:58:00', 9), 'a', map('service_name', 'api')),
+    (toDateTime64('2025-12-31 23:59:00', 9), 'b', map('service_name', 'api')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'c', map('service_name', 'api'));
+-- expected_rows --
+[
+  ["", {}, "2026-01-01T00:00:01Z", 15.0]
+]
+-- args --
+[0] string = ""
+[1] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[2] string = ""
+[3] int64 = 9
+[4] string = "Map(String,String)"
+[5] float64 = 5
+[6] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[7] string = ""
+[8] int64 = 9
+[9] int64 = 1
+[10] string = "service_name"
+[11] string = "api"
+-- chplan --
+VectorJoin op=* match=on() card=one-to-one
+  Project ["" AS MetricName, ResourceAttributes AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+    Project [CAST(map(), "Map(String,String)") AS ResourceAttributes, 5 AS Value]
+      OneRow
+  Project ["" AS MetricName, ResourceAttributes AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+    RangeWindow func=count_over_time range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
+      Project [ResourceAttributes, Timestamp, 1 AS Value]
+        Filter predicate=(ResourceAttributes["service_name"] = "api")
+          Scan(otel_logs)
+-- sql --
+SELECT ? AS `MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` * R.`Value`) AS `Value` FROM (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT ? AS `MetricName`, `ResourceAttributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT CAST(map(), ?) AS `ResourceAttributes`, ? AS `Value` FROM (SELECT 1))) GROUP BY tuple())) AS L INNER JOIN (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT ? AS `MetricName`, `ResourceAttributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1)) GROUP BY tuple())) AS R ON 1 = 1

--- a/test/spec/logql/binop_vv_add_on.txtar
+++ b/test/spec/logql/binop_vv_add_on.txtar
@@ -1,0 +1,50 @@
+-- query.logql --
+rate({service_name="api"}[5m]) + on(service_name) rate({service_name="api"}[5m])
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
+    (toDateTime64('2025-12-31 23:58:00', 9), 'a', map('service_name', 'api')),
+    (toDateTime64('2025-12-31 23:59:00', 9), 'b', map('service_name', 'api')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'c', map('service_name', 'api'));
+-- expected_rows --
+[
+  ["", {"service_name": "api"}, "2026-01-01T00:00:01Z", 0.02]
+]
+-- args --
+[0] string = ""
+[1] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[2] string = ""
+[3] int64 = 9
+[4] float64 = 300
+[5] int64 = 1
+[6] string = "service_name"
+[7] string = "api"
+[8] string = "service_name"
+[9] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[10] string = ""
+[11] int64 = 9
+[12] float64 = 300
+[13] int64 = 1
+[14] string = "service_name"
+[15] string = "api"
+[16] string = "service_name"
+[17] string = "service_name"
+[18] string = "service_name"
+-- chplan --
+VectorJoin op=+ match=on(service_name) card=one-to-one
+  Project ["" AS MetricName, ResourceAttributes AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+    RangeWindow func=log_rate range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
+      Project [ResourceAttributes, Timestamp, 1 AS Value]
+        Filter predicate=(ResourceAttributes["service_name"] = "api")
+          Scan(otel_logs)
+  Project ["" AS MetricName, ResourceAttributes AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+    RangeWindow func=log_rate range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
+      Project [ResourceAttributes, Timestamp, 1 AS Value]
+        Filter predicate=(ResourceAttributes["service_name"] = "api")
+          Scan(otel_logs)
+-- sql --
+SELECT ? AS `MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` + R.`Value`) AS `Value` FROM (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT ? AS `MetricName`, `ResourceAttributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))))) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`))) AS L INNER JOIN (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT ? AS `MetricName`, `ResourceAttributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))))) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`))) AS R ON L.`Attributes`[?] = R.`Attributes`[?]

--- a/test/spec/logql/binop_vv_compare_filter.txtar
+++ b/test/spec/logql/binop_vv_compare_filter.txtar
@@ -1,0 +1,42 @@
+-- query.logql --
+rate({service_name="api"}[5m]) > rate({service_name="api"}[5m])
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
+    (toDateTime64('2025-12-31 23:58:00', 9), 'a', map('service_name', 'api')),
+    (toDateTime64('2025-12-31 23:59:00', 9), 'b', map('service_name', 'api')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'c', map('service_name', 'api'));
+-- expected_rows --
+[]
+-- args --
+[0] string = ""
+[1] string = ""
+[2] int64 = 9
+[3] float64 = 300
+[4] int64 = 1
+[5] string = "service_name"
+[6] string = "api"
+[7] string = ""
+[8] int64 = 9
+[9] float64 = 300
+[10] int64 = 1
+[11] string = "service_name"
+[12] string = "api"
+-- chplan --
+VectorJoin op=> match=default card=one-to-one
+  Project ["" AS MetricName, ResourceAttributes AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+    RangeWindow func=log_rate range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
+      Project [ResourceAttributes, Timestamp, 1 AS Value]
+        Filter predicate=(ResourceAttributes["service_name"] = "api")
+          Scan(otel_logs)
+  Project ["" AS MetricName, ResourceAttributes AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+    RangeWindow func=log_rate range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
+      Project [ResourceAttributes, Timestamp, 1 AS Value]
+        Filter predicate=(ResourceAttributes["service_name"] = "api")
+          Scan(otel_logs)
+-- sql --
+SELECT ? AS `MetricName`, L.`Attributes`, L.`TimeUnix`, L.`Value` AS `Value` FROM (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT `MetricName` AS `_join_MetricName`, `Attributes` AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value` FROM (SELECT ? AS `MetricName`, `ResourceAttributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))))) GROUP BY `MetricName`, `Attributes`)) AS L INNER JOIN (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT `MetricName` AS `_join_MetricName`, `Attributes` AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value` FROM (SELECT ? AS `MetricName`, `ResourceAttributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))))) GROUP BY `MetricName`, `Attributes`)) AS R ON L.`Attributes` = R.`Attributes` WHERE (L.`Value` > R.`Value`)

--- a/test/spec/logql/binop_vv_div_ignoring.txtar
+++ b/test/spec/logql/binop_vv_div_ignoring.txtar
@@ -1,0 +1,52 @@
+-- query.logql --
+rate({service_name="api"}[5m]) / ignoring(level) rate({service_name="api", level="info"}[5m])
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
+    (toDateTime64('2025-12-31 23:58:00', 9), 'a', map('service_name', 'api', 'level', 'info')),
+    (toDateTime64('2025-12-31 23:59:00', 9), 'b', map('service_name', 'api', 'level', 'info')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'c', map('service_name', 'api', 'level', 'info'));
+-- expected_rows --
+[
+  ["", {"level": "info", "service_name": "api"}, "2026-01-01T00:00:01Z", 1]
+]
+-- args --
+[0] string = ""
+[1] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[2] string = ""
+[3] int64 = 9
+[4] float64 = 300
+[5] int64 = 1
+[6] string = "service_name"
+[7] string = "api"
+[8] string = "level"
+[9] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[10] string = ""
+[11] int64 = 9
+[12] float64 = 300
+[13] int64 = 1
+[14] string = "service_name"
+[15] string = "api"
+[16] string = "level"
+[17] string = "info"
+[18] string = "level"
+[19] string = "level"
+[20] string = "level"
+-- chplan --
+VectorJoin op=/ match=ignoring(level) card=one-to-one
+  Project ["" AS MetricName, ResourceAttributes AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+    RangeWindow func=log_rate range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
+      Project [ResourceAttributes, Timestamp, 1 AS Value]
+        Filter predicate=(ResourceAttributes["service_name"] = "api")
+          Scan(otel_logs)
+  Project ["" AS MetricName, ResourceAttributes AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+    RangeWindow func=log_rate range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
+      Project [ResourceAttributes, Timestamp, 1 AS Value]
+        Filter predicate=((ResourceAttributes["service_name"] = "api") AND (ResourceAttributes["level"] = "info"))
+          Scan(otel_logs)
+-- sql --
+SELECT ? AS `MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` / R.`Value`) AS `Value` FROM (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT ? AS `MetricName`, `ResourceAttributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))))) GROUP BY mapFilter((k, v) -> NOT (k IN (?)), `Attributes`))) AS L INNER JOIN (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT ? AS `MetricName`, `ResourceAttributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))))) GROUP BY mapFilter((k, v) -> NOT (k IN (?)), `Attributes`))) AS R ON mapFilter((k, v) -> NOT (k IN (?)), L.`Attributes`) = mapFilter((k, v) -> NOT (k IN (?)), R.`Attributes`)

--- a/test/spec/logql/binop_vv_eq_bool.txtar
+++ b/test/spec/logql/binop_vv_eq_bool.txtar
@@ -1,0 +1,44 @@
+-- query.logql --
+rate({service_name="api"}[5m]) == bool rate({service_name="api"}[5m])
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
+    (toDateTime64('2025-12-31 23:58:00', 9), 'a', map('service_name', 'api')),
+    (toDateTime64('2025-12-31 23:59:00', 9), 'b', map('service_name', 'api')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'c', map('service_name', 'api'));
+-- expected_rows --
+[
+  ["", {"service_name": "api"}, "2026-01-01T00:00:01Z", 1.0]
+]
+-- args --
+[0] string = ""
+[1] string = ""
+[2] int64 = 9
+[3] float64 = 300
+[4] int64 = 1
+[5] string = "service_name"
+[6] string = "api"
+[7] string = ""
+[8] int64 = 9
+[9] float64 = 300
+[10] int64 = 1
+[11] string = "service_name"
+[12] string = "api"
+-- chplan --
+VectorJoin op== match=default card=one-to-one bool
+  Project ["" AS MetricName, ResourceAttributes AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+    RangeWindow func=log_rate range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
+      Project [ResourceAttributes, Timestamp, 1 AS Value]
+        Filter predicate=(ResourceAttributes["service_name"] = "api")
+          Scan(otel_logs)
+  Project ["" AS MetricName, ResourceAttributes AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+    RangeWindow func=log_rate range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
+      Project [ResourceAttributes, Timestamp, 1 AS Value]
+        Filter predicate=(ResourceAttributes["service_name"] = "api")
+          Scan(otel_logs)
+-- sql --
+SELECT ? AS `MetricName`, L.`Attributes`, L.`TimeUnix`, toFloat64((L.`Value` = R.`Value`)) AS `Value` FROM (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT `MetricName` AS `_join_MetricName`, `Attributes` AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value` FROM (SELECT ? AS `MetricName`, `ResourceAttributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))))) GROUP BY `MetricName`, `Attributes`)) AS L INNER JOIN (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT `MetricName` AS `_join_MetricName`, `Attributes` AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value` FROM (SELECT ? AS `MetricName`, `ResourceAttributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))))) GROUP BY `MetricName`, `Attributes`)) AS R ON L.`Attributes` = R.`Attributes`

--- a/test/spec/logql/binop_vv_group_left.txtar
+++ b/test/spec/logql/binop_vv_group_left.txtar
@@ -1,0 +1,52 @@
+-- query.logql --
+count_over_time({service_name="api"}[5m]) / on(service_name) group_left(env) count_over_time({service_name="api", level="meta"}[5m])
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
+    (toDateTime64('2025-12-31 23:58:00', 9), 'a', map('service_name', 'api', 'level', 'info', 'env', 'prod')),
+    (toDateTime64('2025-12-31 23:59:00', 9), 'b', map('service_name', 'api', 'level', 'info', 'env', 'prod')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'c', map('service_name', 'api', 'level', 'info', 'env', 'prod')),
+    (toDateTime64('2025-12-31 23:58:30', 9), 'd', map('service_name', 'api', 'level', 'meta', 'env', 'stage')),
+    (toDateTime64('2025-12-31 23:59:30', 9), 'e', map('service_name', 'api', 'level', 'meta', 'env', 'stage'));
+-- expected_rows --
+[
+  ["", {"env": "stage", "level": "info", "service_name": "api"}, "2026-01-01T00:00:01Z", 1.5],
+  ["", {"env": "stage", "level": "meta", "service_name": "api"}, "2026-01-01T00:00:01Z", 1]
+]
+-- args --
+[0] string = ""
+[1] string = "env"
+[2] string = ""
+[3] int64 = 9
+[4] int64 = 1
+[5] string = "service_name"
+[6] string = "api"
+[7] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[8] string = ""
+[9] int64 = 9
+[10] int64 = 1
+[11] string = "service_name"
+[12] string = "api"
+[13] string = "level"
+[14] string = "meta"
+[15] string = "service_name"
+[16] string = "service_name"
+[17] string = "service_name"
+-- chplan --
+VectorJoin op=/ match=on(service_name) card=many-to-one include=[env]
+  Project ["" AS MetricName, ResourceAttributes AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+    RangeWindow func=count_over_time range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
+      Project [ResourceAttributes, Timestamp, 1 AS Value]
+        Filter predicate=(ResourceAttributes["service_name"] = "api")
+          Scan(otel_logs)
+  Project ["" AS MetricName, ResourceAttributes AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+    RangeWindow func=count_over_time range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
+      Project [ResourceAttributes, Timestamp, 1 AS Value]
+        Filter predicate=((ResourceAttributes["service_name"] = "api") AND (ResourceAttributes["level"] = "meta"))
+          Scan(otel_logs)
+-- sql --
+SELECT ? AS `MetricName`, mapConcat(L.`Attributes`, mapFilter((k, v) -> k IN (?), R.`Attributes`)) AS `Attributes`, L.`TimeUnix`, (L.`Value` / R.`Value`) AS `Value` FROM (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT `MetricName` AS `_join_MetricName`, `Attributes` AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value` FROM (SELECT ? AS `MetricName`, `ResourceAttributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1)) GROUP BY `MetricName`, `Attributes`)) AS L INNER JOIN (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT ? AS `MetricName`, `ResourceAttributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1)) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`))) AS R ON L.`Attributes`[?] = R.`Attributes`[?]


### PR DESCRIPTION
## Summary

Refs Pool-CI coverage audit (PR #375 / Round 1, top fill #1).

Adds 6 TXTAR fixtures for the LogQL vector-vector binary-op family
that the audit flagged at 0-46% coverage. Each fixture pairs Layer 2b
(text-equality SQL/chplan golden) with Layer 6b (chDB seed +
expected_rows roundtrip).

## Fixtures

- `binop_vv_add_on`            -- `rate(...) + on(svc) rate(...)`
- `binop_vv_div_ignoring`      -- `rate(...) / ignoring(level) rate(...)`
- `binop_vv_eq_bool`           -- `rate(...) == bool rate(...)`
- `binop_vv_compare_filter`    -- `rate(...) > rate(...)` (bare cmp; filter shape)
- `binop_literal_vector`       -- `vector(5) * on() count_over_time(...)`
- `binop_vv_group_left`        -- `count_over_time(...) / on(svc) group_left(env) count_over_time(...)`

## Coverage delta on `internal/logql`

| Function                  | Before | After   |
| ------------------------- | ------ | ------- |
| (package total)           | 62.5%  | 72.3%   |
| `lowerVectorVector`       | 0.0%   | 71.4%   |
| `vectorMatchingFromOpts`  | 0.0%   | 77.8%   |
| `sampleShapeOverLogInner` | 0.0%   | 100.0%  |
| `lowerVector`             | 0.0%   | 75.0%   |
| `logqlBinaryOp`           | 21.4%  | 42.9%   |

## Out-of-scope (follow-up)

An initial draft of `binop_vv_group_left` used
`sum by (...) (count_over_time(...))` on both legs. That surfaced a
real production bug: `sampleShapeOverLogInner` references
`ResourceAttributes`, but the inner plan from a vector-aggregation
has already projected that column into `Attributes` via
`wrapVectorAggregateForSample`. chDB returns
`UNKNOWN_IDENTIFIER: ResourceAttributes`.

The shipped `binop_vv_group_left` fixture sidesteps this by using
bare `count_over_time(...)` legs (which keep `ResourceAttributes`
intact through to the join wrapper). The underlying inner-shape
mismatch warrants a separate `fix(logql)` PR per the task constraint
("Don't refactor production code unless a fixture surfaces a real
bug -- if so, document + split into a separate PR").

## Test plan

- [x] `go test ./internal/logql/` -- 86 tests pass (+6 new)
- [x] `go test -tags chdb ./test/spec/logql/` -- chDB roundtrip pass on all 6 new fixtures plus the existing corpus
- [x] Coverage delta verified by toggling fixtures in/out
- [x] No production code changed