### PR TITLE
test(spec/traceql): cover scalar/spanset/pipeline lowering paths

### DIFF
--- a/internal/traceql/lower_pointer_dispatch_test.go
+++ b/internal/traceql/lower_pointer_dispatch_test.go
@@ -1,0 +1,194 @@
+package traceql_test
+
+import (
+	"context"
+	"testing"
+
+	tempo "github.com/grafana/tempo/pkg/traceql"
+
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/traceql"
+)
+
+// TestLowerPointerFormDispatch pins the pointer-form arms in the
+// lowering dispatchers (lowerPipelineElement / lowerFollowingElement /
+// lowerSpansetExpr). Tempo's parser emits these AST nodes by value, so
+// the pointer arms are defensive — they only fire when a caller hand-
+// builds the AST. This test reaches them by reparsing each shape,
+// extracting the parser-produced value-form element, wrapping it in a
+// pointer, and re-running Lower on the rewritten RootExpr.
+//
+// Without this test, the pointer arms are dead code from coverage's
+// perspective; with it, a future change that drops one of those arms
+// (or breaks pointer dispatch) shows up as a test failure rather than
+// a coverage regression that audit tooling alone has to surface.
+func TestLowerPointerFormDispatch(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelTraces()
+
+	t.Run("pipeline_element_spanset_op_pointer", func(t *testing.T) {
+		t.Parallel()
+		// `{ a } && { b }` parses with Pipeline[0] = traceql.SpansetOperation (value).
+		// Wrapping it in a pointer hits lowerPipelineElement's
+		// `*traceql.SpansetOperation` arm.
+		expr := mustParse(t, `{ resource.service.name = "a" } && { resource.service.name = "b" }`)
+		op, ok := expr.Pipeline.Elements[0].(tempo.SpansetOperation)
+		if !ok {
+			t.Fatalf("Pipeline[0] = %T; want SpansetOperation (value)", expr.Pipeline.Elements[0])
+		}
+		expr.Pipeline.Elements[0] = &op
+		if _, err := traceql.Lower(context.Background(), expr, s); err != nil {
+			t.Fatalf("Lower(*SpansetOperation): %v", err)
+		}
+	})
+
+	t.Run("spanset_expr_spanset_op_pointer", func(t *testing.T) {
+		t.Parallel()
+		// `({ a } && { b }) >> { c }` parses with the LHS of the outer
+		// SpansetOperation being a value-form SpansetOperation. Wrapping
+		// the inner LHS in a pointer hits lowerSpansetExpr's
+		// `*traceql.SpansetOperation` arm.
+		expr := mustParse(t, `({ resource.service.name = "a" } && { resource.service.name = "b" }) >> { resource.service.name = "c" }`)
+		outer, ok := expr.Pipeline.Elements[0].(tempo.SpansetOperation)
+		if !ok {
+			t.Fatalf("Pipeline[0] = %T; want SpansetOperation (value)", expr.Pipeline.Elements[0])
+		}
+		inner, ok := outer.LHS.(tempo.SpansetOperation)
+		if !ok {
+			t.Fatalf("outer.LHS = %T; want SpansetOperation (value)", outer.LHS)
+		}
+		outer.LHS = &inner
+		expr.Pipeline.Elements[0] = outer
+		if _, err := traceql.Lower(context.Background(), expr, s); err != nil {
+			t.Fatalf("Lower(SpansetOperation with *SpansetOperation LHS): %v", err)
+		}
+	})
+
+	t.Run("following_aggregate_pointer", func(t *testing.T) {
+		t.Parallel()
+		// `{ a } | count() > 0` parses as Pipeline = [SpansetFilter,
+		// ScalarFilter]. The ScalarFilter's LHS is an Aggregate (value).
+		// Wrap that Aggregate in a pointer and stuff it in the Pipeline
+		// directly: the result is Pipeline = [SpansetFilter, *Aggregate]
+		// which exercises lowerFollowingElement's `*traceql.Aggregate`
+		// arm. (The grammar doesn't write a bare aggregate to a pipeline
+		// element, but the dispatcher allows for it.)
+		expr := mustParse(t, `{ resource.service.name = "a" } | count() > 0`)
+		sf, ok := expr.Pipeline.Elements[1].(tempo.ScalarFilter)
+		if !ok {
+			t.Fatalf("Pipeline[1] = %T; want ScalarFilter", expr.Pipeline.Elements[1])
+		}
+		agg, ok := sf.LHS.(tempo.Aggregate)
+		if !ok {
+			t.Fatalf("ScalarFilter.LHS = %T; want Aggregate", sf.LHS)
+		}
+		expr.Pipeline.Elements[1] = &agg
+		if _, err := traceql.Lower(context.Background(), expr, s); err != nil {
+			t.Fatalf("Lower(*Aggregate as pipeline tail): %v", err)
+		}
+	})
+
+	t.Run("following_scalar_filter_pointer", func(t *testing.T) {
+		t.Parallel()
+		// Parsed ScalarFilter is value-form; wrap in pointer to hit the
+		// pointer arm.
+		expr := mustParse(t, `{ resource.service.name = "a" } | count() > 0`)
+		sf, ok := expr.Pipeline.Elements[1].(tempo.ScalarFilter)
+		if !ok {
+			t.Fatalf("Pipeline[1] = %T; want ScalarFilter (value)", expr.Pipeline.Elements[1])
+		}
+		expr.Pipeline.Elements[1] = &sf
+		if _, err := traceql.Lower(context.Background(), expr, s); err != nil {
+			t.Fatalf("Lower(*ScalarFilter): %v", err)
+		}
+	})
+
+	t.Run("following_select_pointer", func(t *testing.T) {
+		t.Parallel()
+		expr := mustParse(t, `{ resource.service.name = "a" } | select(.foo, .bar)`)
+		sel, ok := expr.Pipeline.Elements[1].(tempo.SelectOperation)
+		if !ok {
+			t.Fatalf("Pipeline[1] = %T; want SelectOperation (value)", expr.Pipeline.Elements[1])
+		}
+		expr.Pipeline.Elements[1] = &sel
+		if _, err := traceql.Lower(context.Background(), expr, s); err != nil {
+			t.Fatalf("Lower(*SelectOperation): %v", err)
+		}
+	})
+
+	t.Run("following_group_pointer", func(t *testing.T) {
+		t.Parallel()
+		expr := mustParse(t, `{ resource.service.name = "a" } | by(resource.service.name)`)
+		grp, ok := expr.Pipeline.Elements[1].(tempo.GroupOperation)
+		if !ok {
+			t.Fatalf("Pipeline[1] = %T; want GroupOperation (value)", expr.Pipeline.Elements[1])
+		}
+		expr.Pipeline.Elements[1] = &grp
+		if _, err := traceql.Lower(context.Background(), expr, s); err != nil {
+			t.Fatalf("Lower(*GroupOperation): %v", err)
+		}
+	})
+
+	t.Run("following_coalesce_pointer", func(t *testing.T) {
+		t.Parallel()
+		expr := mustParse(t, `{ resource.service.name = "a" } | coalesce()`)
+		co, ok := expr.Pipeline.Elements[1].(tempo.CoalesceOperation)
+		if !ok {
+			t.Fatalf("Pipeline[1] = %T; want CoalesceOperation (value)", expr.Pipeline.Elements[1])
+		}
+		expr.Pipeline.Elements[1] = &co
+		if _, err := traceql.Lower(context.Background(), expr, s); err != nil {
+			t.Fatalf("Lower(*CoalesceOperation): %v", err)
+		}
+	})
+
+	t.Run("scalar_expr_aggregate_pointer", func(t *testing.T) {
+		t.Parallel()
+		// ScalarFilter LHS is an Aggregate (value). Wrap as pointer to
+		// hit lowerScalarExpr's `*traceql.Aggregate` arm.
+		expr := mustParse(t, `{ resource.service.name = "a" } | count() > 0`)
+		sf, ok := expr.Pipeline.Elements[1].(tempo.ScalarFilter)
+		if !ok {
+			t.Fatalf("Pipeline[1] = %T; want ScalarFilter", expr.Pipeline.Elements[1])
+		}
+		agg, ok := sf.LHS.(tempo.Aggregate)
+		if !ok {
+			t.Fatalf("ScalarFilter.LHS = %T; want Aggregate (value)", sf.LHS)
+		}
+		sf.LHS = &agg
+		expr.Pipeline.Elements[1] = sf
+		if _, err := traceql.Lower(context.Background(), expr, s); err != nil {
+			t.Fatalf("Lower(ScalarFilter with *Aggregate LHS): %v", err)
+		}
+	})
+
+	t.Run("scalar_expr_static_pointer", func(t *testing.T) {
+		t.Parallel()
+		// ScalarFilter RHS is a Static (value). Wrap as pointer to hit
+		// lowerScalarExpr's `*traceql.Static` arm.
+		expr := mustParse(t, `{ resource.service.name = "a" } | count() > 0`)
+		sf, ok := expr.Pipeline.Elements[1].(tempo.ScalarFilter)
+		if !ok {
+			t.Fatalf("Pipeline[1] = %T; want ScalarFilter", expr.Pipeline.Elements[1])
+		}
+		st, ok := sf.RHS.(tempo.Static)
+		if !ok {
+			t.Fatalf("ScalarFilter.RHS = %T; want Static (value)", sf.RHS)
+		}
+		sf.RHS = &st
+		expr.Pipeline.Elements[1] = sf
+		if _, err := traceql.Lower(context.Background(), expr, s); err != nil {
+			t.Fatalf("Lower(ScalarFilter with *Static RHS): %v", err)
+		}
+	})
+}
+
+func mustParse(t *testing.T, q string) *tempo.RootExpr {
+	t.Helper()
+	expr, err := tempo.Parse(q)
+	if err != nil {
+		t.Fatalf("Parse(%q): %v", q, err)
+	}
+	return expr
+}

--- a/test/spec/traceql/flip_event_eq_fallthrough.txtar
+++ b/test/spec/traceql/flip_event_eq_fallthrough.txtar
@@ -1,0 +1,10 @@
+-- query.traceql --
+{ "exception" = event.name }
+-- sql --
+SELECT * FROM `otel_traces` WHERE arrayExists(x -> x[?] = ?, `Events`.`Attributes`)
+-- args --
+[0] string = "name"
+[1] string = "exception"
+-- chplan --
+Filter predicate=nestedArrayExists(Events.Attributes["name"] = "exception")
+  Scan(otel_traces)

--- a/test/spec/traceql/flip_event_ge.txtar
+++ b/test/spec/traceql/flip_event_ge.txtar
@@ -1,0 +1,10 @@
+-- query.traceql --
+{ 500 >= event.code }
+-- sql --
+SELECT * FROM `otel_traces` WHERE arrayExists(x -> x[?] <= ?, `Events`.`Attributes`)
+-- args --
+[0] string = "code"
+[1] int64 = 500
+-- chplan --
+Filter predicate=nestedArrayExists(Events.Attributes["code"] <= 500)
+  Scan(otel_traces)

--- a/test/spec/traceql/flip_event_lt_duration.txtar
+++ b/test/spec/traceql/flip_event_lt_duration.txtar
@@ -1,0 +1,10 @@
+-- query.traceql --
+{ 100ms < event.duration }
+-- sql --
+SELECT * FROM `otel_traces` WHERE arrayExists(x -> x[?] > ?, `Events`.`Attributes`)
+-- args --
+[0] string = "duration"
+[1] int64 = 100000000
+-- chplan --
+Filter predicate=nestedArrayExists(Events.Attributes["duration"] > 100000000)
+  Scan(otel_traces)

--- a/test/spec/traceql/flip_link_ge.txtar
+++ b/test/spec/traceql/flip_link_ge.txtar
@@ -1,0 +1,10 @@
+-- query.traceql --
+{ "warn" >= link.severity }
+-- sql --
+SELECT * FROM `otel_traces` WHERE arrayExists(x -> x[?] <= ?, `Links`.`Attributes`)
+-- args --
+[0] string = "severity"
+[1] string = "warn"
+-- chplan --
+Filter predicate=nestedArrayExists(Links.Attributes["severity"] <= "warn")
+  Scan(otel_traces)

--- a/test/spec/traceql/flip_link_gt.txtar
+++ b/test/spec/traceql/flip_link_gt.txtar
@@ -1,0 +1,20 @@
+-- query.traceql --
+{ "warn" > link.severity }
+-- sql --
+SELECT * FROM `otel_traces` WHERE arrayExists(x -> x[?] < ?, `Links`.`Attributes`)
+-- args --
+[0] string = "severity"
+[1] string = "warn"
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    `Links.Attributes` Array(Map(String, String)) MATERIALIZED if(_idx = 0, [map('severity', 'info')], [map('severity', 'warn')])
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1);
+-- expected_rows --
+[
+  [0]
+]
+-- chplan --
+Filter predicate=nestedArrayExists(Links.Attributes["severity"] < "warn")
+  Scan(otel_traces)

--- a/test/spec/traceql/flip_link_le.txtar
+++ b/test/spec/traceql/flip_link_le.txtar
@@ -1,0 +1,10 @@
+-- query.traceql --
+{ "info" <= link.severity }
+-- sql --
+SELECT * FROM `otel_traces` WHERE arrayExists(x -> x[?] >= ?, `Links`.`Attributes`)
+-- args --
+[0] string = "severity"
+[1] string = "info"
+-- chplan --
+Filter predicate=nestedArrayExists(Links.Attributes["severity"] >= "info")
+  Scan(otel_traces)

--- a/test/spec/traceql/flip_link_lt.txtar
+++ b/test/spec/traceql/flip_link_lt.txtar
@@ -1,0 +1,20 @@
+-- query.traceql --
+{ "info" < link.severity }
+-- sql --
+SELECT * FROM `otel_traces` WHERE arrayExists(x -> x[?] > ?, `Links`.`Attributes`)
+-- args --
+[0] string = "severity"
+[1] string = "info"
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    `Links.Attributes` Array(Map(String, String)) MATERIALIZED if(_idx = 0, [map('severity', 'warn')], [map('severity', 'info')])
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1);
+-- expected_rows --
+[
+  [0]
+]
+-- chplan --
+Filter predicate=nestedArrayExists(Links.Attributes["severity"] > "info")
+  Scan(otel_traces)

--- a/test/spec/traceql/flip_link_ne_fallthrough.txtar
+++ b/test/spec/traceql/flip_link_ne_fallthrough.txtar
@@ -1,0 +1,10 @@
+-- query.traceql --
+{ "prod" != link.environment }
+-- sql --
+SELECT * FROM `otel_traces` WHERE arrayExists(x -> x[?] != ?, `Links`.`Attributes`)
+-- args --
+[0] string = "environment"
+[1] string = "prod"
+-- chplan --
+Filter predicate=nestedArrayExists(Links.Attributes["environment"] != "prod")
+  Scan(otel_traces)

--- a/test/spec/traceql/flip_link_numeric.txtar
+++ b/test/spec/traceql/flip_link_numeric.txtar
@@ -1,0 +1,10 @@
+-- query.traceql --
+{ 500 < link.http_status }
+-- sql --
+SELECT * FROM `otel_traces` WHERE arrayExists(x -> x[?] > ?, `Links`.`Attributes`)
+-- args --
+[0] string = "http_status"
+[1] int64 = 500
+-- chplan --
+Filter predicate=nestedArrayExists(Links.Attributes["http_status"] > 500)
+  Scan(otel_traces)

--- a/test/spec/traceql/structural_child_of_union.txtar
+++ b/test/spec/traceql/structural_child_of_union.txtar
@@ -1,0 +1,20 @@
+-- query.traceql --
+{ resource.service.name = "a" } > ({ resource.service.name = "b" } || { resource.service.name = "c" })
+-- sql --
+SELECT R.* FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) AS L INNER JOIN ((SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) UNION DISTINCT (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?))) AS R ON L.`TraceId` = R.`TraceId` AND L.`SpanId` = R.`ParentSpanId`
+-- args --
+[0] string = "service.name"
+[1] string = "a"
+[2] string = "service.name"
+[3] string = "b"
+[4] string = "service.name"
+[5] string = "c"
+-- chplan --
+StructuralJoin op=>
+  Filter predicate=(ResourceAttributes["service.name"] = "a")
+    Scan(otel_traces)
+  SetOperation op=||
+    Filter predicate=(ResourceAttributes["service.name"] = "b")
+      Scan(otel_traces)
+    Filter predicate=(ResourceAttributes["service.name"] = "c")
+      Scan(otel_traces)

--- a/test/spec/traceql/structural_descendant_of_intersect.txtar
+++ b/test/spec/traceql/structural_descendant_of_intersect.txtar
@@ -1,0 +1,20 @@
+-- query.traceql --
+({ resource.service.name = "a" } && { resource.service.name = "b" }) >> { resource.service.name = "c" }
+-- sql --
+SELECT R.* FROM (WITH RECURSIVE _struct_closure AS (SELECT `TraceId`, `SpanId`, `ParentSpanId`, 0 AS _depth FROM (SELECT L.* FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) AS `L` INNER JOIN (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) AS `R` ON `L`.`TraceId` = `R`.`TraceId` AND `L`.`SpanId` = `R`.`SpanId`) AS _seed UNION ALL SELECT t.`TraceId`, t.`SpanId`, t.`ParentSpanId`, c._depth + 1 FROM `otel_traces` AS t INNER JOIN _struct_closure AS c ON t.`TraceId` = c.`TraceId` AND t.`ParentSpanId` = c.`SpanId`) SELECT DISTINCT `TraceId`, `SpanId` FROM _struct_closure WHERE _depth > 0) AS L INNER JOIN (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) AS R ON L.`TraceId` = R.`TraceId` AND L.`SpanId` = R.`SpanId`
+-- args --
+[0] string = "service.name"
+[1] string = "a"
+[2] string = "service.name"
+[3] string = "b"
+[4] string = "service.name"
+[5] string = "c"
+-- chplan --
+StructuralJoin op=>>
+  SetOperation op=&&
+    Filter predicate=(ResourceAttributes["service.name"] = "a")
+      Scan(otel_traces)
+    Filter predicate=(ResourceAttributes["service.name"] = "b")
+      Scan(otel_traces)
+  Filter predicate=(ResourceAttributes["service.name"] = "c")
+    Scan(otel_traces)


### PR DESCRIPTION
## Summary

Fills Pool-CI's Round 2 audit gap (#375) on the TraceQL lowering dispatchers (\`lowerScalarExpr\`, \`lowerSpansetExpr\`, \`lowerPipelineElement\`, \`lowerFollowingElement\`, \`flipComparisonOp\`) — all at 0-60% local coverage on \`main\`.

- **9 new TXTAR fixtures** under \`test/spec/traceql/\` pin every branch of \`flipComparisonOp\` (now 0% -> 100%) by exercising the \`lowerNestedAttrBinary\` RHS-attribute path: \`{ "info" < link.severity }\`, \`{ 500 < link.http_status }\`, \`{ 100ms < event.duration }\`, etc. Two fixtures (\`flip_link_lt\`, \`flip_link_gt\`) include \`seed:\` + \`expected_rows:\` for Layer 6c chDB roundtrip.
- **2 new structural fixtures** pin \`lowerSpansetExpr\`'s recursion into value-form SpansetOperation: \`(A && B) >> C\` and \`A > (B || C)\`.
- **\`internal/traceql/lower_pointer_dispatch_test.go\`** (Layer 2a) covers the parser-unreachable pointer-form arms of every dispatcher by reparsing each shape, rewrapping the value-form AST element in a pointer, then re-running \`Lower\` — 9 subtests, one per pointer arm.

Builds on #354 (chplan snapshot wiring), so each TXTAR fixture also pins the flipped op at the IR level (e.g. source \`< "info"\` -> chplan \`> "info"\`).

## Coverage delta (\`internal/traceql\`, \`-coverpkg=./internal/traceql\`)

| Function | Before | After | Delta |
|---|---|---|---|
| \`flipComparisonOp\` | 0.0% | 100.0% | +100.0 |
| \`lowerScalarExpr\` | 50.0% | 83.3% | +33.3 |
| \`lowerSpansetExpr\` | 60.0% | 80.0% | +20.0 |
| \`lowerPipelineElement\` | 60.0% | 80.0% | +20.0 |
| \`lowerFollowingElement\` | 41.7% | 83.3% | +41.6 |
| **Package total** | 75.9% | 81.7% | **+5.8** |

The 16.7% residual on each dispatcher is the \`default:\` error arm — only reachable by passing an unrecognized concrete \`tempo.PipelineElement\` / \`SpansetExpression\` / \`ScalarExpression\` type. Every Tempo AST node carries unexported state so external callers can't synthesize one cleanly; left as defensive dead code.

## Test plan

- [x] \`go test ./internal/traceql/\` passes without \`GOLDEN_UPDATE\` (idempotent fixtures).
- [x] \`go test -tags=chdb ./test/spec/traceql/\` passes — all flip + structural fixtures roundtrip on chDB.
- [x] Coverage measured before/after via \`go tool cover -func\`; delta reported above.
- [x] \`go vet ./internal/traceql/...\` clean.

Refs #375 (Round 2), #354.