### PR TITLE
fix(promql): last_over_time / first_over_time preserve __name__

### DIFF
--- a/internal/api/prom/handler_chdb_range_mode_test.go
+++ b/internal/api/prom/handler_chdb_range_mode_test.go
@@ -1596,6 +1596,92 @@ func TestQueryRange_RangeMode_AtModifier_Collapse_ChDB(t *testing.T) {
 	}
 }
 
+// TestQueryRange_RangeMode_LastOverTime_PreservesName_ChDB pins
+// Prom's `dropName=false` semantics for `last_over_time` (and, by
+// symmetry, `first_over_time`) under `/api/v1/query_range`. Prom's
+// engine special-cases these two range functions out of the
+// `dropName` default for every other range-vector fn:
+//
+//	prometheus/prometheus@cerberus-parser/promql/engine.go:2114
+//	`dropName := (e.Func.Name != "last_over_time" && e.Func.Name != "first_over_time")`
+//
+// They're position-shift reducers (pick a single sample from the
+// window), so the emitted sample carries the source metric's name
+// — distinct from `rate`/`sum_over_time`/etc. which produce
+// genuinely derived samples and drop `__name__`.
+//
+// Pre-fix the bare-range-fn lowering emitted a RangeWindow whose
+// output schema is `(Attributes, [anchor_ts,] Value)` — MetricName
+// is dropped by the windowed-array GROUP BY Attributes. The HTTP
+// layer's `wrapWithSampleProjection` then classified the plan as
+// derived-shape and synthesised `LitString{""} AS MetricName`, so
+// the wire response omitted `__name__` for every
+// `last_over_time(metric[range])` query. The PromLabs compat lane
+// surfaced this as 6 diffs on `last_over_time(demo_memory_usage_bytes[1s|15s|1m|5m|15m|1h])`
+// (cerberus `Metric: {...}` vs Prom `Metric: demo_memory_usage_bytes{...}`)
+// in run 25901406046.
+//
+// The fix wraps the RangeWindow at lowering with a canonical
+// 4-column Project that pins MetricName to the matcher literal;
+// the HTTP-layer `projectionExposesCanonical` recognises the shape
+// and the literal flows through to `__name__` on the wire.
+func TestQueryRange_RangeMode_LastOverTime_PreservesName_ChDB(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(5 * time.Minute)
+	step := 30 * time.Second
+	const seedSamples = 11
+
+	seedRows := make([]string, 0, seedSamples)
+	for i := 0; i < seedSamples; i++ {
+		ts := start.Add(time.Duration(i) * step).Format("2006-01-02 15:04:05.000000000")
+		seedRows = append(seedRows, fmt.Sprintf(
+			`('demo_memory_usage_bytes', map('instance', 'demo', 'job', 'api'), toDateTime64('%s', 9), %d.0)`,
+			ts, 100+i,
+		))
+	}
+	seed := gaugeDDL + "\nINSERT INTO otel_metrics_gauge VALUES\n  " +
+		strings.Join(seedRows, ",\n  ") + ";"
+	srv, _ := newChDBServer(t, seed)
+
+	matrix := runRangeModeQueryRange(t, srv.URL,
+		"last_over_time(demo_memory_usage_bytes[5m])", start, end, step)
+	if len(matrix) != 1 {
+		t.Fatalf("expected exactly 1 series, got %d: %+v", len(matrix), matrix)
+	}
+	// `__name__` MUST be present and equal to the matcher literal —
+	// Prom's `dropName=false` for `last_over_time`. This is the
+	// regression contract: pre-fix, the matrix sample omitted
+	// `__name__` entirely (synthesised as `""`).
+	name, hasName := matrix[0].Metric["__name__"]
+	if !hasName {
+		t.Fatalf("expected __name__ on last_over_time output, got missing (full metric: %+v)",
+			matrix[0].Metric)
+	}
+	if name != "demo_memory_usage_bytes" {
+		t.Errorf("__name__: got %q, want %q (full metric: %+v)",
+			name, "demo_memory_usage_bytes", matrix[0].Metric)
+	}
+	// Series labels still flow through unchanged — `last_over_time`
+	// only drops samples outside the window; the label set is
+	// preserved (just like instant `metric` would).
+	if got := matrix[0].Metric["instance"]; got != "demo" {
+		t.Errorf("instance: got %q, want %q (full metric: %+v)",
+			got, "demo", matrix[0].Metric)
+	}
+	if got := matrix[0].Metric["job"]; got != "api" {
+		t.Errorf("job: got %q, want %q (full metric: %+v)",
+			got, "api", matrix[0].Metric)
+	}
+	// `last_over_time(metric[5m])` at each step anchor returns the
+	// latest sample within `(anchor - 5m, anchor]`. The seed has one
+	// sample per step at the step boundary, so each anchor's window
+	// terminates on a fresh sample whose value matches `100 + i`.
+	if got := len(matrix[0].Values); got < 5 {
+		t.Fatalf("expected per-step last_over_time matrix (>= 5 samples); got %d: %+v",
+			got, matrix[0].Values)
+	}
+}
+
 // runRangeModeQueryRange is the test helper shared across the Pool-AK
 // range-mode regression cases. Mirrors `runStepLoopRange` but lives
 // in this file so the Pool-AK suite is self-contained for any future

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -756,7 +756,77 @@ func lowerRangeVectorCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chpla
 		rw.Step = ctx.step
 		rw.OuterRange = ctx.end.Sub(ctx.start)
 	}
+	// `last_over_time` and `first_over_time` preserve `__name__`
+	// per Prometheus semantics — they're position-shift reducers that
+	// pick a single sample from the window, so the emitted sample carries
+	// the source metric's name. Every other range-vector fn (rate,
+	// increase, delta, sum_over_time, ...) produces a derived sample
+	// and Prom drops `__name__` for them. See upstream:
+	//
+	//	prometheus/prometheus@cerberus-parser/promql/engine.go:2114
+	//	`dropName := (e.Func.Name != "last_over_time" && e.Func.Name != "first_over_time")`
+	//
+	// The RangeWindow output schema is (Attributes, [anchor_ts,] Value)
+	// — MetricName is dropped by the windowed-array GROUP BY Attributes.
+	// To preserve `__name__` we wrap the RangeWindow with a canonical
+	// 4-column Project that pins MetricName to the matcher's literal
+	// name. The HTTP-layer `wrapWithSampleProjection` recognises this
+	// shape (via `projectionExposesCanonical`) and skips its
+	// derived-shape `LitString{""} AS MetricName` synthesis, so the
+	// literal flows through and `__name__` appears on the wire.
+	//
+	// The matcher's `__name__` value must be a single equality matcher
+	// (`metric_name{...}`) for `metricNameFromMatchers` to return a
+	// non-empty string. Regex `__name__=~"foo|bar"` falls through to
+	// the existing empty-MetricName behaviour — the structural fix to
+	// thread per-series names through the windowed aggregation is a
+	// larger change deferred until a query in that shape surfaces in
+	// the compat lane.
+	if c.Func.Name == "last_over_time" || c.Func.Name == "first_over_time" {
+		return wrapRangeWindowPreserveName(rw, s, metricNameFromMatchers(vs.LabelMatchers)), nil
+	}
 	return rw, nil
+}
+
+// wrapRangeWindowPreserveName wraps a RangeWindow with a canonical
+// 4-column Project that pins MetricName to a literal so the HTTP-layer
+// `wrapWithSampleProjection` recognises the canonical shape and
+// preserves `__name__` on the wire. Used by `last_over_time` /
+// `first_over_time` to mirror Prom's `dropName=false` for these fns.
+//
+// The matrix-shape RangeWindow (Step > 0) carries per-row anchors in
+// the `anchor_ts` column; the instant shape doesn't expose a real
+// TimeUnix at all (the SQL emits only Attributes + Value), so the
+// projection synthesises one via the same `now64() - 5s` expression
+// the handler uses for derived-shape Projects. The outer
+// `wrapWithSampleProjection` canonical branch reads back the
+// `s.TimestampColumn` alias verbatim either way.
+func wrapRangeWindowPreserveName(rw *chplan.RangeWindow, s schema.Metrics, name string) chplan.Node {
+	var tsExpr chplan.Expr
+	if rw.OuterRange > 0 {
+		tsExpr = &chplan.ColumnRef{Name: "anchor_ts"}
+	} else {
+		// Mirror `synthesizedAnchor()` in internal/api/prom/handler.go:
+		// the instant-shape RangeWindow doesn't expose a real per-row
+		// anchor, so we stamp `now64(9) - toIntervalNanosecond(5e9)`.
+		tsExpr = &chplan.Binary{
+			Op:   chplan.OpSub,
+			Left: &chplan.FuncCall{Name: "now64", Args: []chplan.Expr{&chplan.LitInt{V: 9}}},
+			Right: &chplan.FuncCall{
+				Name: "toIntervalNanosecond",
+				Args: []chplan.Expr{&chplan.LitInt{V: 5_000_000_000}},
+			},
+		}
+	}
+	return &chplan.Project{
+		Input: rw,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.LitString{V: name}, Alias: s.MetricNameColumn},
+			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
+			{Expr: tsExpr, Alias: s.TimestampColumn},
+			{Expr: &chplan.ColumnRef{Name: s.ValueColumn}, Alias: s.ValueColumn},
+		},
+	}
 }
 
 // lowerAggregate handles `sum by (job) (...)`, `sum without (instance) (...)`,

--- a/test/spec/promql/edge_last_over_time.txtar
+++ b/test/spec/promql/edge_last_over_time.txtar
@@ -2,9 +2,13 @@
 last_over_time(up[5m])
 -- args --
 [0] string = "up"
+[1] int64 = 9
+[2] int64 = 5000000000
+[3] string = "up"
 -- sql --
-SELECT `Attributes`, if(length(window_vals) > 0, window_vals[length(window_vals)], nan) AS `Value` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY `Attributes`))) WHERE length(`window_vals`) >= 1
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, (now64(?) - toIntervalNanosecond(?)) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes`, if(length(window_vals) > 0, window_vals[length(window_vals)], nan) AS `Value` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY `Attributes`))) WHERE length(`window_vals`) >= 1)
 -- chplan --
-RangeWindow func=last_over_time range=5m0s step=0s ts=TimeUnix value=Value groupBy=[Attributes]
-  Filter predicate=(MetricName = "up")
-    Scan(otel_metrics_gauge)
+Project ["up" AS MetricName, Attributes AS Attributes, (now64(9) - toIntervalNanosecond(5000000000)) AS TimeUnix, Value AS Value]
+  RangeWindow func=last_over_time range=5m0s step=0s ts=TimeUnix value=Value groupBy=[Attributes]
+    Filter predicate=(MetricName = "up")
+      Scan(otel_metrics_gauge)


### PR DESCRIPTION
## Summary

Wrap the bare-range-fn `RangeWindow` lowering for `last_over_time` and `first_over_time` with a canonical 4-column Project that pins `MetricName` to the matcher literal. The HTTP-layer `wrapWithSampleProjection` recognises the canonical-shape Project via `projectionExposesCanonical` and the literal flows through to `__name__` on the wire — mirroring Prom's `dropName=false` special-case for these two range functions.

## Why this is correct (Prom source)

From `tsouza/prometheus:cerberus-parser/promql/engine.go:2114`:

```go
dropName := (e.Func.Name != "last_over_time" && e.Func.Name != "first_over_time")
```

Prom **drops** `__name__` for every range-vector fn EXCEPT these two — they're position-shift reducers (they pick a single sample from the window), so the emitted sample carries the source metric's name. `rate`/`increase`/`delta`/`sum_over_time`/etc. genuinely derive a new sample and Prom drops `__name__` for them.

Pre-fix, cerberus dropped `__name__` for ALL range fns. The bare-range-fn lowering emitted a `RangeWindow` whose output schema is `(Attributes, [anchor_ts,] Value)` (`MetricName` is dropped by the windowed-array `GROUP BY Attributes`), and the HTTP-layer `wrapWithSampleProjection` then classified the plan as derived-shape and synthesised `LitString{V:""} AS MetricName` — wire response omits `__name__`.

## Investigation credit

Pool-BG.1 verified against the upstream parser fork and identified two viable fix paths:

1. **Wrap-side** — detect `last_over_time`/`first_over_time` in `wrapWithSampleProjection` and pin MetricName at the wrap layer.
2. **Lower-side** — wrap the RangeWindow with a 4-column canonical Project at lowering, so `isDerivedShape` classifies it as canonical and the literal flows through.

This PR picks Option 2 because it keeps the IR honest: the plan tree itself encodes the per-function `__name__` semantic, rather than relying on a special-case at the HTTP wrap layer.

## Resolves

~6 compat diffs from run [25901406046](https://github.com/tsouza/cerberus/actions/runs/25901406046) on
`last_over_time(demo_memory_usage_bytes[1s|15s|1m|5m|15m|1h])` — cerberus emitted `Metric: {...}` while reference Prom emitted `Metric: demo_memory_usage_bytes{...}`.

## Scope

- Bare-range-fn lowering only (`lowerRangeVectorCall`). The subquery-flavour and aggregate-flavour paths (`lowerSubquery` / `lowerSubqueryOverAggregate` / `lowerOuterRangeFnOverSubquery`) keep their existing behaviour — no compat-lane diffs flagged them.
- The matcher's `__name__` value must be a single equality matcher (`metric{...}`) for `metricNameFromMatchers` to return a non-empty string. Regex `__name__=~"foo|bar"` falls through to the existing empty-MetricName behaviour — the structural fix to thread per-series names through the windowed aggregation is a larger change deferred until a query in that shape surfaces in the compat lane.
- `first_over_time` isn't yet supported by the emitter; the lowering branch is included for symmetry so the SQL emit error stays the only blocker when adding the function.

## Test plan

- [x] `internal/promql` (`TestLower`) green — fixture regenerated, golden diff shows the new `Project ["up" AS MetricName, Attributes AS Attributes, ... AS TimeUnix, Value AS Value]` wrapping the RangeWindow.
- [x] `internal/api/prom` chDB lane green (244 tests), including the new `TestQueryRange_RangeMode_LastOverTime_PreservesName_ChDB` regression which asserts `__name__ == "demo_memory_usage_bytes"` on the matrix output.
- [x] `test/spec/promql` chDB roundtrip green (220 fixtures).
- [x] Optimizer + engine + chsql + chplan suites green (1429 + 538 across 13 packages).

## Before / after (fixture: `edge_last_over_time.txtar`)

**Before** — `RangeWindow` plan, SQL emits 2-col `(Attributes, Value)`:

```
RangeWindow func=last_over_time range=5m0s step=0s ts=TimeUnix value=Value groupBy=[Attributes]
  Filter predicate=(MetricName = "up")
    Scan(otel_metrics_gauge)
```

**After** — canonical 4-col Project pins `MetricName="up"`, the HTTP wrap layer sees the canonical shape and emits a pass-through canonical Project:

```
Project ["up" AS MetricName, Attributes AS Attributes, (now64(9) - toIntervalNanosecond(5000000000)) AS TimeUnix, Value AS Value]
  RangeWindow func=last_over_time range=5m0s step=0s ts=TimeUnix value=Value groupBy=[Attributes]
    Filter predicate=(MetricName = "up")
      Scan(otel_metrics_gauge)
```