### PR TITLE
feat(harness/loki-compatibility): wire diff driver into run script + just recipe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,14 +84,18 @@ jobs:
             **/*.md
             !harness/prometheus-compliance/upstream/**
             !harness/tempo-compatibility/upstream/**
+            !harness/loki-compatibility/upstream/**
             !**/node_modules/**
 
   # `forbid-skip` is the GA test-discipline gate. The maintainer's
   # NON-NEGOTIABLE rule is "no t.Skip in test files — fix the bug, do
   # not skip." Greps `*_test.go` for `t.Skip` / `t.Skipf` / `t.SkipNow`
-  # via `git ls-files` (already excludes vendor / .gitignored paths)
-  # and fails the build if any match. Runs in parallel with `check` +
-  # `lint`; flip on as a required status check via branch protection.
+  # via `git ls-files` (already excludes .gitignored paths) and fails
+  # the build if any match. Vendored upstream snapshots under
+  # `harness/*/upstream/**` are excluded — they're reference material
+  # outside cerberus's authorship boundary (and pinned by their
+  # respective VERSION files). Runs in parallel with `check` + `lint`;
+  # flip on as a required status check via branch protection.
   forbid-skip:
     name: forbid-skip
     runs-on: ubuntu-latest
@@ -99,7 +103,10 @@ jobs:
       - uses: actions/checkout@v6
       - name: Reject t.Skip in test files
         run: |
-          if git ls-files -z -- '*_test.go' | xargs -0 grep -nE 't\.Skip[fN]?\(' --; then
+          if git ls-files -z -- \
+              '*_test.go' \
+              ':!:harness/*/upstream/**' \
+              | xargs -0 grep -nE 't\.Skip[fN]?\(' --; then
             echo "::error::t.Skip / t.Skipf / t.SkipNow found in test files — fix the bug, do not skip"
             exit 1
           fi

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -4,3 +4,7 @@ test/e2e/playwright/playwright-report/
 test/e2e/playwright/test-results/
 harness/prometheus-compliance/upstream
 harness/prometheus-compliance/upstream/**
+harness/tempo-compatibility/upstream
+harness/tempo-compatibility/upstream/**
+harness/loki-compatibility/upstream
+harness/loki-compatibility/upstream/**

--- a/Justfile
+++ b/Justfile
@@ -402,16 +402,22 @@ compatibility-keep:
 compatibility-down:
     cd harness/prometheus-compliance && docker compose down -v
 
-# === Compatibility (LogQL — Loki compatibility harness, scaffold) ===
+# === Compatibility (LogQL — Loki compatibility harness) ===
 
-# Run the LogQL compatibility scaffold smoke. PR 1 of the rollout plan
-# in docs/loki-compliance-plan.md: brings up reference Loki + cerberus +
-# CH, seeds both, asserts /labels is non-empty on each. Corpus + diff
-# driver land in PR 2-3.
+# Run the LogQL compatibility harness end-to-end. Brings up reference
+# Loki + cerberus + ClickHouse, seeds both, builds the diff driver from
+# the vendored upstream/loki-bench corpus, runs TestRemoteStorageEquality
+# against both endpoints, writes harness/loki-compatibility/reports/diff.json.
+# See harness/loki-compatibility/README.md + docs/loki-compliance-plan.md.
 loki-compatibility:
     ./harness/loki-compatibility/scripts/run-loki-compatibility.sh
 
-# Keep the Loki compatibility stack running after the smoke finishes
+# Run the smoke (compose + seed + /labels assertion) without the diff
+# driver. Useful when the seeder is the bisect target.
+loki-compatibility-smoke:
+    DRIVER_SKIP=1 ./harness/loki-compatibility/scripts/run-loki-compatibility.sh
+
+# Keep the Loki compatibility stack running after the run finishes
 # (for debugging /loki/api/v1/* + ClickHouse manually).
 loki-compatibility-keep:
     COMPOSE_KEEP=1 ./harness/loki-compatibility/scripts/run-loki-compatibility.sh

--- a/go.mod
+++ b/go.mod
@@ -270,3 +270,4 @@ replace (
 )
 
 ignore ./harness/tempo-compatibility/upstream
+ignore ./harness/loki-compatibility/upstream

--- a/harness/loki-compatibility/README.md
+++ b/harness/loki-compatibility/README.md
@@ -1,58 +1,62 @@
 # Loki / LogQL compatibility harness
 
-> Status: **PR 2 (vendor `pkg/logql/bench`)** of the rollout described in
+> Status: **PR 3 (diff driver wiring)** of the rollout described in
 > [`docs/loki-compliance-plan.md`](../../docs/loki-compliance-plan.md).
-> This directory currently holds **only** a vendored snapshot of
-> Grafana's `pkg/logql/bench/` corpus + driver scaffolding files.
-> There is no Compose stack, no diff runner script, and no CI yet —
-> those follow in PRs 3 and 4.
+> The Docker Compose stack, the deterministic seeder, the vendored
+> `pkg/logql/bench/` corpus, and now the diff-driver wiring all live
+> under this directory. The informational CI lane (PR 4) and the
+> cerberus-owned driver replacement (PR 5) are still pending.
 
 ## Why this harness exists
 
 Cerberus already has `harness/prometheus-compliance/` (PromQL parity vs
 reference Prometheus). The Loki / LogQL surface has no upstream
-`loki-conformance` repo; the closest analogue is `grafana/loki:pkg/logql/bench/` —
-a YAML query corpus + `TestRemoteStorageEquality` build-tagged Go test
-driver. This harness vendors that snapshot verbatim (the same posture
+`loki-conformance` repo; the closest analogue is
+`grafana/loki:pkg/logql/bench/` — a YAML query corpus plus a
+`TestRemoteStorageEquality` build-tagged Go test driver. This harness
+vendors that snapshot verbatim (the same posture
 `harness/prometheus-compliance/upstream/` takes vs `prometheus/compliance`),
-runs reference Loki + cerberus side-by-side, and diffs the responses.
+runs reference Loki and cerberus side-by-side, and diffs the responses.
 
 See [`docs/loki-compliance-plan.md`](../../docs/loki-compliance-plan.md)
 for the full landscape analysis, the per-PR breakdown, and the
 license/AGPL containment strategy.
 
-## Layout (current — PR 2)
+## Layout (current — PR 3)
 
 ```text
 harness/loki-compatibility/
   README.md                       this file
+  docker-compose.yml              clickhouse + reference loki + cerberus
+  loki-config.yaml                reference Loki single-binary config
   cerberus-test-queries.yml       overlay documenting drops for unsupported LogQL features
   dataset_metadata.json           pinned dataset metadata for ${SELECTOR}/${LABEL_*} expansion
+  reports/                        diff driver output (PR 3); contents gitignored
+  cmd/
+    seed/                         deterministic OTel-shape log seeder
+  scripts/
+    run-loki-compatibility.sh     smoke + diff driver (this PR)
   upstream/
     loki-bench/                   vendored grafana/loki:pkg/logql/bench snapshot
       LICENSE                     AGPL-3.0, copied verbatim from grafana/loki
       VERSION                     exact upstream coordinates of the snapshot
       query_registry.go           YAML loader + template-variable expander
       remote_test.go              TestRemoteStorageEquality (build-tagged remote_correctness)
+      metadata.go                 DatasetMetadata + LoadMetadata + bounded sets (PR 3)
+      metadata_resolver.go        ${SELECTOR}/${LABEL_*}/${RANGE} resolver (PR 3)
+      testcase.go                 TestCase shape consumed by the registry (PR 3)
+      assertions_test.go          assertResultNotEmpty + tolerance comparators (PR 3)
+      convert_test.go             loghttp -> promql/parser.Value conversions (PR 3)
+      generator.go                GeneratorConfig + StreamMetadata referenced by metadata.go (PR 3)
+      faker.go                    LogFormat type + helper data referenced by metadata.go (PR 3)
       queries/
         schema.json               JSON schema for query YAMLs
         fast/*.yaml               minimal corpus (basic-selectors, simple-metrics, structured-metadata)
+        regression/.gitkeep       placeholder; the driver loads all three suites
+        exhaustive/.gitkeep       placeholder; the driver loads all three suites
 ```
 
-## Layout (planned — PRs 1, 3, 4)
-
-PR 1 (in parallel, Pool-CA) lands the seed + Compose scaffold:
-
-```text
-harness/loki-compatibility/
-  docker-compose.yml              PR 1 — clickhouse + reference loki + cerberus + seeder
-  loki-config.yaml                PR 1 — reference Loki single-binary config
-  test-cerberus.yml               PR 1 — addr-1 (loki) + addr-2 (cerberus) endpoint config
-  cmd/seed/                       PR 1 — deterministic OTel-shape log seeder
-  cmd/discover/                   later  — dataset_metadata.json regenerator
-  scripts/
-    run-loki-compatibility.sh     PR 3 — go test -tags=remote_correctness driver
-```
+## Layout (planned — PR 4+)
 
 PR 4 lands the informational CI lane:
 
@@ -60,20 +64,42 @@ PR 4 lands the informational CI lane:
 .github/workflows/loki-compatibility.yml  PR 4 — push:main + nightly cron + workflow_dispatch
 ```
 
+PR 5 ports `TestRemoteStorageEquality` into a cerberus-owned driver:
+
+```text
+harness/loki-compatibility/cmd/loki-compliance-tester/  PR 5 — cerberus-owned driver
+```
+
 ## What's in `upstream/loki-bench/`
 
-A pure, unmodified snapshot of these paths from `grafana/loki` at the tag
-recorded in [`upstream/loki-bench/VERSION`](upstream/loki-bench/VERSION):
+A pure, unmodified snapshot of these paths from `grafana/loki` at the
+tag recorded in [`upstream/loki-bench/VERSION`](upstream/loki-bench/VERSION):
 
 - `pkg/logql/bench/queries/fast/*.yaml` — the minimal-coverage corpus
-  (basic-selectors, simple-metrics, structured-metadata). `regression/`
-  + `exhaustive/` slices are deferred to PR 6 of the plan.
-- `pkg/logql/bench/queries/schema.json` — JSON Schema the YAMLs validate against.
-- `pkg/logql/bench/query_registry.go` — `QueryRegistry` + `${SELECTOR}` /
-  `${LABEL_NAME}` / `${LABEL_VALUE}` template expander.
-- `pkg/logql/bench/remote_test.go` — `TestRemoteStorageEquality`
-  build-tagged `remote_correctness`. Reused verbatim in PR 3 to drive
-  the diff loop; replaced by a cerberus-owned driver later (plan PR 5).
+  (basic-selectors, simple-metrics, structured-metadata). The
+  `regression/` and `exhaustive/` slices are deferred to PR 6 of the
+  plan; the empty placeholder dirs exist so the driver's
+  three-suite loader doesn't fatal on a missing path.
+- `pkg/logql/bench/queries/schema.json` — JSON Schema the YAMLs
+  validate against.
+- `pkg/logql/bench/query_registry.go` — `QueryRegistry` plus the
+  `${SELECTOR}` / `${LABEL_NAME}` / `${LABEL_VALUE}` template
+  expander.
+- `pkg/logql/bench/remote_test.go` — `TestRemoteStorageEquality`,
+  build-tagged `remote_correctness`. Driven by
+  `scripts/run-loki-compatibility.sh`; replaced by a cerberus-owned
+  driver later (plan PR 5).
+- `pkg/logql/bench/metadata.go`, `metadata_resolver.go`, `testcase.go`,
+  `assertions_test.go`, `convert_test.go` — support files
+  `remote_test.go` transitively depends on. PR 2 (#369) intentionally
+  shipped a partial vendor (driver + corpus only); PR 3 expanded the
+  snapshot to the full set so the `go test -c` build resolves
+  cleanly without sanitising upstream sources.
+- `pkg/logql/bench/generator.go`, `faker.go` — referenced by
+  `metadata.go` for the `GeneratorConfig` / `StreamMetadata` /
+  `LogFormat` type surface. Never invoked at run time by
+  `TestRemoteStorageEquality`; included verbatim so the package
+  type-checks without local patches.
 - `LICENSE` — AGPL-3.0 from upstream, scoped to this subtree only.
 
 Cerberus's `tsouza/loki` fork (the replace target in `go.mod`) only
@@ -85,62 +111,105 @@ snapshot here pins `grafana/loki` directly rather than the fork tag.
 
 Same reasoning as `harness/tempo-compatibility/upstream/` (see PR #367):
 
-1. **PR 2 is reference material, not a build dependency.** The driver
-   wiring lands in PR 3 and can decide which subset to import vs
-   adapt. Vendoring lets reviewers read the corpus + driver shape in
-   the diff without cloning grafana/loki.
+1. **Reference material, not a build dependency.** The driver wiring
+   reads the vendored sources directly. Vendoring lets reviewers see
+   the corpus and driver shape in the diff without cloning
+   grafana/loki.
 2. **`remote_test.go` is build-tagged `remote_correctness`.** It's a
-   test driver, not library code; cerberus's main build doesn't need it.
+   test driver, not library code; cerberus's main build doesn't need
+   it.
 3. **Snapshot stability.** A future bump of any Loki transitive dep
    won't silently move the corpus shape under us — the snapshot is
    pinned explicitly here.
 
-### Why the vendor isn't compiled
+### How the vendor builds
 
 `remote_test.go` imports `github.com/grafana/loki/v3/pkg/logcli/client`
-+ `github.com/grafana/loki/v3/pkg/loghttp`, which pull in heavy
-transitive deps (the Loki client, dskit, etc.) just to run the diff
-loop. Until PR 3 wires the driver explicitly, we exclude the vendor
-from the module graph via a `go.mod` `ignore` directive:
+and `github.com/grafana/loki/v3/pkg/loghttp`, which transitively pull
+in the Loki client + dskit + aws-sdk-go-v2 + azure-sdk + OpenAPI
+chain. These are not deps cerberus's main module wants in its
+`go.mod`. The repo isolates them via two complementary mechanisms:
 
-```text
-ignore ./harness/loki-compatibility/upstream
-```
+1. `go.mod`'s `ignore ./harness/loki-compatibility/upstream` directive
+   keeps `go build ./...`, `go test ./...`, and `go vet ./...` away
+   from the vendored path.
+2. `scripts/run-loki-compatibility.sh` invokes
+   `GOFLAGS=-mod=mod go test -tags=remote_correctness -c` to compile
+   the test binary explicitly. The `-mod=mod` flag is the documented
+   override for ignored paths; it transiently writes the extra
+   transitive deps into the repo's `go.mod` and `go.sum` so the build
+   resolves. A cleanup trap then reverts both files (`git checkout --
+   go.mod go.sum`) so the working tree stays clean on every exit path
+   (success, driver failure, `set -e` abort, SIGINT).
 
-The directive is a Go 1.25+ feature; cerberus already pins Go 1.26
-via `go.mod`. With it in place:
-
-- `go build ./...` / `go test ./...` / `go vet ./...` skip the vendor.
-- The vendored sources stay on disk for reference + PR 3 to adapt.
+The `ignore` directive is a Go 1.25+ feature; cerberus pins Go 1.26
+via `go.mod`. The cleanup pattern matches the
+`harness/prometheus-compliance/scripts/run-compatibility.sh` precedent
+for managing transient mutations during integration runs.
 
 ## Cerberus overlay files
 
 Two files at the harness root capture cerberus-specific configuration
 that lives OUTSIDE the AGPL `upstream/` boundary:
 
-- **`cerberus-test-queries.yml`** — overlay applied on top of the
-  vendored corpus. The `should_skip:` list documents which queries
-  exercise LogQL features cerberus doesn't implement yet (e.g. v2
-  engine forward log queries, dataobj-engine structured-metadata
-  fast-paths). PR 3's runner consumes this; the initial commit lists
-  zero entries — reviewers add as PR 4's CI lane surfaces gaps.
-- **`dataset_metadata.json`** — pinned dataset metadata that maps
+- `cerberus-test-queries.yml` — overlay listing per-query divergences
+  cerberus tracks against the upstream corpus. The PR 3 commit
+  documents the entire `fast/` set as deferred to PR 6 (selector
+  vocabulary mismatch between the seeded fixture and the upstream
+  template defaults). The PR 5 cerberus-owned driver will consume
+  this file; until then it's documentary surface for reviewers.
+- `dataset_metadata.json` — pinned dataset metadata that maps
   `${SELECTOR}` / `${LABEL_NAME}` / `${LABEL_VALUE}` template vars to
-  concrete values seeded by PR 1's deterministic seeder. Once PR 1
-  lands, this file gets regenerated against the seeded fixture; the
-  placeholder here records the shape and reasonable defaults so the
-  vendor PR doesn't depend on PR 1's seed shape landing first.
+  concrete values. The placeholder shipped by PR 2 (#369) is
+  preserved verbatim — it predates the PR 1 seeder's actual label
+  vocabulary, which is the gap PR 6 closes by extending the seeder
+  and regenerating this file via `cmd/discover/`.
+
+## Running the harness
+
+```sh
+# Full lifecycle: compose up, seed, build driver, diff, tear down.
+just loki-compatibility
+
+# Smoke only (skip the diff driver — useful for bisecting the seeder).
+DRIVER_SKIP=1 just loki-compatibility
+
+# Keep the stack up after the run for manual poking.
+just loki-compatibility-keep
+
+# Instant-query mode (default is range).
+DRIVER_RANGE_TYPE=instant just loki-compatibility
+
+# Tear the stack down manually.
+just loki-compatibility-down
+```
+
+The run script's contract:
+
+- Exit 0 → no diffs on any query case.
+- Exit 1 → at least one diff or run-time failure (informational; the
+  CI lane in PR 4 will treat this as non-blocking until the corpus
+  shape matches the seeded fixture per PR 6).
+- Exit 2+ → harness itself failed (compose, seed, build).
+
+The driver's full stream (`go test -v` output, one
+`PASS`/`FAIL`/`SKIP` line per query case) is written to
+`reports/diff.json`. PR 5's cerberus-owned driver will switch this to
+the same JSON shape that
+`harness/prometheus-compliance/report.json` uses so the two harnesses
+share a single downstream analyser.
 
 ## Licensing
 
 `grafana/loki` is **AGPL-3.0** ([upstream LICENSE](https://github.com/grafana/loki/blob/main/LICENSE)).
-The vendored snapshot inherits AGPL-3.0, and [`upstream/loki-bench/LICENSE`](upstream/loki-bench/LICENSE)
-is the verbatim copy.
+The vendored snapshot inherits AGPL-3.0, and
+[`upstream/loki-bench/LICENSE`](upstream/loki-bench/LICENSE) is the
+verbatim copy.
 
-Cerberus itself is independently licensed (see the repo root `LICENSE`);
-the AGPL terms apply only to the vendored subtree under `upstream/loki-bench/`.
-The driver scripts that land in PRs 3-4 live OUTSIDE `upstream/`
-(under `scripts/` + `cmd/`) and are cerberus-licensed.
+Cerberus itself is independently licensed (see the repo root
+`LICENSE`); the AGPL terms apply only to the vendored subtree under
+`upstream/loki-bench/`. The driver scripts (under `scripts/` plus
+`cmd/`) live OUTSIDE `upstream/` and are cerberus-licensed.
 
 ## Bump procedure
 
@@ -148,10 +217,11 @@ Re-snapshot when:
 
 1. Upstream Loki adds queries to `queries/fast/` that cerberus wants
    to cover, **or**
-2. The shape of `QueryRegistry` / `remote_test.go` changes meaningfully
-   (e.g. new template var, new diff semantics), **or**
-3. The `should_skip:` overlay drifts because upstream renamed/removed
-   a query we previously skipped.
+2. The shape of `QueryRegistry` / `remote_test.go` / any support file
+   changes meaningfully (new template var, new diff semantics, new
+   transitive dep), **or**
+3. The `should_skip:` overlay drifts because upstream renamed or
+   removed a query we previously skipped.
 
 To re-snapshot:
 
@@ -163,17 +233,23 @@ TAG=v3.7.1
 # 2. Shallow clone at that tag.
 git clone --depth=1 -b "$TAG" https://github.com/grafana/loki /tmp/loki-upstream
 
-# 3. Wipe + re-copy the vendored paths.
-rm -rf harness/loki-compatibility/upstream/loki-bench/{queries,LICENSE,query_registry.go,remote_test.go}
-mkdir -p harness/loki-compatibility/upstream/loki-bench/queries/fast
+# 3. Wipe + re-copy the vendored paths. The `vendored_paths:` block in
+#    upstream/loki-bench/VERSION is the canonical inventory.
+rm -rf harness/loki-compatibility/upstream/loki-bench/{queries,LICENSE,*.go}
+mkdir -p harness/loki-compatibility/upstream/loki-bench/queries/fast \
+         harness/loki-compatibility/upstream/loki-bench/queries/regression \
+         harness/loki-compatibility/upstream/loki-bench/queries/exhaustive
+touch    harness/loki-compatibility/upstream/loki-bench/queries/regression/.gitkeep \
+         harness/loki-compatibility/upstream/loki-bench/queries/exhaustive/.gitkeep
 cp /tmp/loki-upstream/pkg/logql/bench/queries/fast/*.yaml \
    harness/loki-compatibility/upstream/loki-bench/queries/fast/
 cp /tmp/loki-upstream/pkg/logql/bench/queries/schema.json \
    harness/loki-compatibility/upstream/loki-bench/queries/schema.json
-cp /tmp/loki-upstream/pkg/logql/bench/query_registry.go \
-   harness/loki-compatibility/upstream/loki-bench/query_registry.go
-cp /tmp/loki-upstream/pkg/logql/bench/remote_test.go \
-   harness/loki-compatibility/upstream/loki-bench/remote_test.go
+for f in query_registry remote_test metadata metadata_resolver testcase \
+         assertions_test convert_test generator faker; do
+    cp "/tmp/loki-upstream/pkg/logql/bench/${f}.go" \
+       "harness/loki-compatibility/upstream/loki-bench/${f}.go"
+done
 cp /tmp/loki-upstream/LICENSE \
    harness/loki-compatibility/upstream/loki-bench/LICENSE
 

--- a/harness/loki-compatibility/README.md
+++ b/harness/loki-compatibility/README.md
@@ -1,100 +1,192 @@
-# LogQL compatibility harness
+# Loki / LogQL compatibility harness
 
-Mirrors [`harness/prometheus-compliance/`](../prometheus-compliance/) for the
-LogQL side. Stands up reference Grafana Loki and cerberus side-by-side,
-seeds both with the same deterministic log stream, and (in later PRs)
-diffs query results between the two.
+> Status: **PR 2 (vendor `pkg/logql/bench`)** of the rollout described in
+> [`docs/loki-compliance-plan.md`](../../docs/loki-compliance-plan.md).
+> This directory currently holds **only** a vendored snapshot of
+> Grafana's `pkg/logql/bench/` corpus + driver scaffolding files.
+> There is no Compose stack, no diff runner script, and no CI yet —
+> those follow in PRs 3 and 4.
 
-This directory currently contains **PR 1 of 6**: the scaffold.
+## Why this harness exists
 
-## What's here (PR 1)
+Cerberus already has `harness/prometheus-compliance/` (PromQL parity vs
+reference Prometheus). The Loki / LogQL surface has no upstream
+`loki-conformance` repo; the closest analogue is `grafana/loki:pkg/logql/bench/` —
+a YAML query corpus + `TestRemoteStorageEquality` build-tagged Go test
+driver. This harness vendors that snapshot verbatim (the same posture
+`harness/prometheus-compliance/upstream/` takes vs `prometheus/compliance`),
+runs reference Loki + cerberus side-by-side, and diffs the responses.
+
+See [`docs/loki-compliance-plan.md`](../../docs/loki-compliance-plan.md)
+for the full landscape analysis, the per-PR breakdown, and the
+license/AGPL containment strategy.
+
+## Layout (current — PR 2)
 
 ```text
 harness/loki-compatibility/
-  README.md                            this file
-  docker-compose.yml                   clickhouse + loki (reference) + cerberus
-  loki-config.yaml                     single-binary Loki, filesystem backend
-  cmd/seed/                            deterministic CH + Loki dual-write seeder
-  scripts/run-loki-compatibility.sh    compose up --wait, run seeder, tear down
+  README.md                       this file
+  cerberus-test-queries.yml       overlay documenting drops for unsupported LogQL features
+  dataset_metadata.json           pinned dataset metadata for ${SELECTOR}/${LABEL_*} expansion
+  upstream/
+    loki-bench/                   vendored grafana/loki:pkg/logql/bench snapshot
+      LICENSE                     AGPL-3.0, copied verbatim from grafana/loki
+      VERSION                     exact upstream coordinates of the snapshot
+      query_registry.go           YAML loader + template-variable expander
+      remote_test.go              TestRemoteStorageEquality (build-tagged remote_correctness)
+      queries/
+        schema.json               JSON schema for query YAMLs
+        fast/*.yaml               minimal corpus (basic-selectors, simple-metrics, structured-metadata)
 ```
 
-## What's deferred
+## Layout (planned — PRs 1, 3, 4)
 
-Per [`docs/loki-compliance-plan.md`](../../docs/loki-compliance-plan.md):
+PR 1 (in parallel, Pool-CA) lands the seed + Compose scaffold:
 
-- **PR 2** vendors `grafana/loki:pkg/logql/bench/` under `upstream/loki-bench/`
-  and adds `cerberus-test-queries.yml` (curated YAML corpus overlay) and
-  `dataset_metadata.json`.
-- **PR 3** ports the upstream `TestRemoteStorageEquality` diff driver +
-  wires `scripts/run-loki-compatibility.sh` to invoke it (initially just
-  builds + runs the diff loop against the seeded fixture).
-- **PR 4** adds the `.github/workflows/loki-compatibility.yml` informational
-  CI lane (push-to-main + nightly + manual dispatch).
-- **PR 5** ports the diff driver to cerberus-owned code under
-  `cmd/loki-compliance-tester/` for report-format parity with the Prom
-  harness.
-- **PR 6** expands the corpus into `queries/regression/` + slices of
-  `queries/exhaustive/`.
+```text
+harness/loki-compatibility/
+  docker-compose.yml              PR 1 — clickhouse + reference loki + cerberus + seeder
+  loki-config.yaml                PR 1 — reference Loki single-binary config
+  test-cerberus.yml               PR 1 — addr-1 (loki) + addr-2 (cerberus) endpoint config
+  cmd/seed/                       PR 1 — deterministic OTel-shape log seeder
+  cmd/discover/                   later  — dataset_metadata.json regenerator
+  scripts/
+    run-loki-compatibility.sh     PR 3 — go test -tags=remote_correctness driver
+```
 
-## Usage
+PR 4 lands the informational CI lane:
 
-From the repo root:
+```text
+.github/workflows/loki-compatibility.yml  PR 4 — push:main + nightly cron + workflow_dispatch
+```
+
+## What's in `upstream/loki-bench/`
+
+A pure, unmodified snapshot of these paths from `grafana/loki` at the tag
+recorded in [`upstream/loki-bench/VERSION`](upstream/loki-bench/VERSION):
+
+- `pkg/logql/bench/queries/fast/*.yaml` — the minimal-coverage corpus
+  (basic-selectors, simple-metrics, structured-metadata). `regression/`
+  + `exhaustive/` slices are deferred to PR 6 of the plan.
+- `pkg/logql/bench/queries/schema.json` — JSON Schema the YAMLs validate against.
+- `pkg/logql/bench/query_registry.go` — `QueryRegistry` + `${SELECTOR}` /
+  `${LABEL_NAME}` / `${LABEL_VALUE}` template expander.
+- `pkg/logql/bench/remote_test.go` — `TestRemoteStorageEquality`
+  build-tagged `remote_correctness`. Reused verbatim in PR 3 to drive
+  the diff loop; replaced by a cerberus-owned driver later (plan PR 5).
+- `LICENSE` — AGPL-3.0 from upstream, scoped to this subtree only.
+
+Cerberus's `tsouza/loki` fork (the replace target in `go.mod`) only
+tracks `pkg/logql/syntax/`, `pkg/logql/log/`, and `pkg/logqlmodel/` —
+`pkg/logql/bench/` is outside the fork's watch boundary, so the
+snapshot here pins `grafana/loki` directly rather than the fork tag.
+
+### Why vendor, not import via `go.mod`?
+
+Same reasoning as `harness/tempo-compatibility/upstream/` (see PR #367):
+
+1. **PR 2 is reference material, not a build dependency.** The driver
+   wiring lands in PR 3 and can decide which subset to import vs
+   adapt. Vendoring lets reviewers read the corpus + driver shape in
+   the diff without cloning grafana/loki.
+2. **`remote_test.go` is build-tagged `remote_correctness`.** It's a
+   test driver, not library code; cerberus's main build doesn't need it.
+3. **Snapshot stability.** A future bump of any Loki transitive dep
+   won't silently move the corpus shape under us — the snapshot is
+   pinned explicitly here.
+
+### Why the vendor isn't compiled
+
+`remote_test.go` imports `github.com/grafana/loki/v3/pkg/logcli/client`
++ `github.com/grafana/loki/v3/pkg/loghttp`, which pull in heavy
+transitive deps (the Loki client, dskit, etc.) just to run the diff
+loop. Until PR 3 wires the driver explicitly, we exclude the vendor
+from the module graph via a `go.mod` `ignore` directive:
+
+```text
+ignore ./harness/loki-compatibility/upstream
+```
+
+The directive is a Go 1.25+ feature; cerberus already pins Go 1.26
+via `go.mod`. With it in place:
+
+- `go build ./...` / `go test ./...` / `go vet ./...` skip the vendor.
+- The vendored sources stay on disk for reference + PR 3 to adapt.
+
+## Cerberus overlay files
+
+Two files at the harness root capture cerberus-specific configuration
+that lives OUTSIDE the AGPL `upstream/` boundary:
+
+- **`cerberus-test-queries.yml`** — overlay applied on top of the
+  vendored corpus. The `should_skip:` list documents which queries
+  exercise LogQL features cerberus doesn't implement yet (e.g. v2
+  engine forward log queries, dataobj-engine structured-metadata
+  fast-paths). PR 3's runner consumes this; the initial commit lists
+  zero entries — reviewers add as PR 4's CI lane surfaces gaps.
+- **`dataset_metadata.json`** — pinned dataset metadata that maps
+  `${SELECTOR}` / `${LABEL_NAME}` / `${LABEL_VALUE}` template vars to
+  concrete values seeded by PR 1's deterministic seeder. Once PR 1
+  lands, this file gets regenerated against the seeded fixture; the
+  placeholder here records the shape and reasonable defaults so the
+  vendor PR doesn't depend on PR 1's seed shape landing first.
+
+## Licensing
+
+`grafana/loki` is **AGPL-3.0** ([upstream LICENSE](https://github.com/grafana/loki/blob/main/LICENSE)).
+The vendored snapshot inherits AGPL-3.0, and [`upstream/loki-bench/LICENSE`](upstream/loki-bench/LICENSE)
+is the verbatim copy.
+
+Cerberus itself is independently licensed (see the repo root `LICENSE`);
+the AGPL terms apply only to the vendored subtree under `upstream/loki-bench/`.
+The driver scripts that land in PRs 3-4 live OUTSIDE `upstream/`
+(under `scripts/` + `cmd/`) and are cerberus-licensed.
+
+## Bump procedure
+
+Re-snapshot when:
+
+1. Upstream Loki adds queries to `queries/fast/` that cerberus wants
+   to cover, **or**
+2. The shape of `QueryRegistry` / `remote_test.go` changes meaningfully
+   (e.g. new template var, new diff semantics), **or**
+3. The `should_skip:` overlay drifts because upstream renamed/removed
+   a query we previously skipped.
+
+To re-snapshot:
 
 ```sh
-just loki-compatibility            # compose up, seed, smoke /labels, tear down
-just loki-compatibility-keep       # same, but leave the stack running
-just loki-compatibility-down       # tear down a stack left running by -keep
+# 1. Pick the new tag (typically matches the `loki:X.Y.Z` Docker image
+#    cerberus runs as the reference target in docker-compose.yml).
+TAG=v3.7.1
+
+# 2. Shallow clone at that tag.
+git clone --depth=1 -b "$TAG" https://github.com/grafana/loki /tmp/loki-upstream
+
+# 3. Wipe + re-copy the vendored paths.
+rm -rf harness/loki-compatibility/upstream/loki-bench/{queries,LICENSE,query_registry.go,remote_test.go}
+mkdir -p harness/loki-compatibility/upstream/loki-bench/queries/fast
+cp /tmp/loki-upstream/pkg/logql/bench/queries/fast/*.yaml \
+   harness/loki-compatibility/upstream/loki-bench/queries/fast/
+cp /tmp/loki-upstream/pkg/logql/bench/queries/schema.json \
+   harness/loki-compatibility/upstream/loki-bench/queries/schema.json
+cp /tmp/loki-upstream/pkg/logql/bench/query_registry.go \
+   harness/loki-compatibility/upstream/loki-bench/query_registry.go
+cp /tmp/loki-upstream/pkg/logql/bench/remote_test.go \
+   harness/loki-compatibility/upstream/loki-bench/remote_test.go
+cp /tmp/loki-upstream/LICENSE \
+   harness/loki-compatibility/upstream/loki-bench/LICENSE
+
+# 4. Update upstream/loki-bench/VERSION with the new tag + commit SHA.
+$EDITOR harness/loki-compatibility/upstream/loki-bench/VERSION
+
+# 5. PR the diff. Reviewer checks the bump procedure was followed
+#    verbatim; no sanitisation of vendored sources is permitted.
 ```
 
-Or directly:
+## Related docs
 
-```sh
-./harness/loki-compatibility/scripts/run-loki-compatibility.sh
-```
-
-## Endpoints (when the stack is up)
-
-| Service    | Host:port                | Role                                    |
-| ---------- | ------------------------ | --------------------------------------- |
-| ClickHouse | `localhost:28000` (TCP)  | OTel-schema, `otel_logs`                |
-|            | `localhost:28223` (HTTP) | same                                    |
-| Loki       | `localhost:23100`        | reference target                        |
-| cerberus   | `localhost:29092`        | test target (LogQL on `/loki/api/v1/*`) |
-
-Port allocation is offset from the prometheus-compliance harness so the
-two stacks can coexist on the same dev host.
-
-## Seeder
-
-`cmd/seed/` writes the same deterministic fixture to both targets:
-
-- **ClickHouse** — `INSERT INTO otel_logs` with the column layout from
-  the upstream OTel-CH Exporter DDL (`internal/schema/ddl`).
-- **Loki** — HTTP POST to `/loki/api/v1/push` with `{streams:[...]}`.
-
-Fixture shape: 4 services × 600 entries × 1 entry/sec = 10 minutes of
-deterministic log data anchored at `2026-05-11T00:00:00Z`. Both writes
-use the same anchor + same line bodies, so diff output in PR 3+ will
-surface genuine LogQL semantic gaps, not data asymmetry.
-
-Smoke contract: after the seeder runs, `GET /loki/api/v1/labels` MUST
-return non-empty on BOTH `:23100` (reference Loki) and `:29092`
-(cerberus), and `SELECT count() FROM otel_logs` on the CH side MUST
-return > 0. The seeder polls each target and fails fast if any
-condition isn't met within 30s.
-
-The /labels probe passes a wide `[start, end]` window covering the
-fixture anchor plus a buffer on each side — cerberus reads from CH
-via `Timestamp BETWEEN ...`, so a window-less /labels call returns
-empty. The wide window also absorbs the (system clock vs anchor)
-skew that arises when CI runs days after the anchor date. PR 3's
-diff driver will thread tighter per-query windows for the actual
-result comparisons; the smoke just needs both endpoints alive.
-
-## License
-
-Cerberus itself is MIT. PR 2 will vendor an AGPLv3 corpus from
-`grafana/loki:pkg/logql/bench/` under `upstream/loki-bench/` with the
-upstream LICENSE preserved — same posture as
-[`harness/prometheus-compliance/upstream/promql/`](../prometheus-compliance/upstream/promql/).
-PR 1 vendors nothing, so the AGPL note only applies once PR 2 lands.
+- [`docs/loki-compliance-plan.md`](../../docs/loki-compliance-plan.md) — the rollout plan
+- [`docs/upstream-forks.md`](../../docs/upstream-forks.md) — how the `tsouza/loki` fork is wired (and why the bench corpus is outside it)
+- [`harness/prometheus-compliance/`](../prometheus-compliance/) — sibling Prom harness
+- [`harness/tempo-compatibility/`](../tempo-compatibility/) — sibling Tempo harness, PR 1 (#367)

--- a/harness/loki-compatibility/cerberus-test-queries.yml
+++ b/harness/loki-compatibility/cerberus-test-queries.yml
@@ -21,19 +21,103 @@
 #     feature cerberus hasn't shipped, OR when the runner surfaces a
 #     persistent diff vs the reference Loki on a feature roadmap.md
 #     deferred.
-#   - Empty should_skip / should_fail are fine. PR 3's runner treats
-#     missing keys as "no overrides".
+#   - Empty should_skip / should_fail are fine. The PR 3 runner doesn't
+#     consume this file yet (the vendored TestRemoteStorageEquality
+#     reads only the upstream YAMLs); it documents the cerberus-side
+#     posture so the PR 5 cerberus-owned driver can honour it. The PR 4
+#     informational CI lane likewise surfaces the raw driver output
+#     without overlay filtering.
 #   - When a query's status changes (e.g. cerberus implements the
 #     feature), drop the entry and let CI verify the diff is clean.
 #   - On every Loki tag bump (see ../README.md "Bump procedure"),
 #     re-validate the `source:` paths point at queries that still exist.
 
-# Cerberus's RC2 LogQL coverage (per docs/roadmap.md § RC2) already
-# ships | unpack, | pattern, | line_format, | decolorize, | label_format
-# (with Loki template funcs), bytes_*, and the full /api/v1/* + /labels +
-# /detected_fields surface. The minimal corpus (fast/*.yaml) doesn't hit
-# any of the deferred items, so should_skip starts empty. PR 4's
-# informational lane will surface real gaps that get triaged here.
-should_skip: []
+# Every query in fast/*.yaml is currently documented as a divergence
+# until the PR 1 seeder + dataset_metadata.json grow the label
+# vocabulary the corpus expects.
+#
+# The upstream queries template `${SELECTOR}` against streams carrying
+# `service_name` / `namespace` / `cluster` / `container` labels plus
+# `detected_level` / `pod` structured metadata. The current seeder
+# (harness/loki-compatibility/cmd/seed/main.go) writes single-label
+# streams of the shape `{service="..."}` with no structured metadata
+# and no JSON / detected_level fields. The placeholder
+# dataset_metadata.json still claims the upstream label vocabulary —
+# expansion succeeds but every range query hits zero baseline streams,
+# so the diff driver fails with "baseline returned empty" rather than
+# emitting a structural diff.
+#
+# Resolution path (per docs/loki-compliance-plan.md):
+#
+#   - PR 4 adds the informational CI lane. The empty-baseline failures
+#     surface here as red but non-blocking; reviewers triage which to
+#     close out by extending the seeder and which to drop as
+#     genuine-divergence.
+#   - PR 6 expands the seed to emit multi-label streams + structured
+#     metadata so the ${SELECTOR}/${LABEL_*} expansions resolve against
+#     real cerberus + Loki data. At that point the entries below
+#     either get removed (the query passes) or get rewritten with a
+#     real reason citing a concrete LogQL feature gap.
+should_skip:
+  - source: "fast/basic-selectors.yaml#Basic label selector"
+    reason: "Pending PR 6 seed expansion — ${SELECTOR} expands to the {service_name=…,namespace=…,cluster=…,container=…} shape but the current seeder only writes {service=…} streams; baseline Loki returns empty."
+    since: "2026-05-15"
+    jira:  "docs/loki-compliance-plan.md PR 6"
+  - source: "fast/basic-selectors.yaml#Label selector with line filter"
+    reason: "Same as Basic label selector — selector vocabulary mismatch until PR 6."
+    since: "2026-05-15"
+    jira:  "docs/loki-compliance-plan.md PR 6"
+  - source: "fast/basic-selectors.yaml#Label selector with regex line filter (case-insensitive)"
+    reason: "Same as Basic label selector — selector vocabulary mismatch until PR 6."
+    since: "2026-05-15"
+    jira:  "docs/loki-compliance-plan.md PR 6"
+  - source: "fast/basic-selectors.yaml#Label selector with negative regex filter"
+    reason: "Same as Basic label selector — selector vocabulary mismatch until PR 6."
+    since: "2026-05-15"
+    jira:  "docs/loki-compliance-plan.md PR 6"
+  - source: "fast/basic-selectors.yaml#Label filter expression outside stream selector"
+    reason: "Requires multi-label streams (namespace / service_name / cluster) — not seeded yet; covered by PR 6."
+    since: "2026-05-15"
+    jira:  "docs/loki-compliance-plan.md PR 6"
+  - source: "fast/basic-selectors.yaml#Log query with impossible filter (guarantees empty results, exercises log result cache)"
+    reason: "Selector resolves but the seeded stream has no data in the 24h query window — baseline empty until PR 6 extends the seed window."
+    since: "2026-05-15"
+    jira:  "docs/loki-compliance-plan.md PR 6"
+  - source: "fast/simple-metrics.yaml#Count over time"
+    reason: "Range-aggregation over ${SELECTOR}[${RANGE}] expands cleanly but the seeded subset only covers 10min inside the 24h dataset window — baseline returns Vector with zero non-empty series."
+    since: "2026-05-15"
+    jira:  "docs/loki-compliance-plan.md PR 6"
+  - source: "fast/simple-metrics.yaml#Count with error/warn filter"
+    reason: "Requires detected_level structured metadata; seeder writes none. Tracked for PR 6."
+    since: "2026-05-15"
+    jira:  "docs/loki-compliance-plan.md PR 6"
+  - source: "fast/simple-metrics.yaml#Rate with error/warn filter"
+    reason: "Requires detected_level structured metadata; seeder writes none. Tracked for PR 6."
+    since: "2026-05-15"
+    jira:  "docs/loki-compliance-plan.md PR 6"
+  - source: "fast/simple-metrics.yaml#Count with line filter"
+    reason: "Selector vocabulary mismatch until PR 6; tracked alongside other fast/ entries."
+    since: "2026-05-15"
+    jira:  "docs/loki-compliance-plan.md PR 6"
+  - source: "fast/structured-metadata.yaml#Structured metadata error level filter"
+    reason: "Cerberus's | detected_level=\"error\" pipeline reads structured-metadata columns that the seeder currently doesn't populate. Tracked for PR 6 + roadmap RC2 structured-metadata coverage."
+    since: "2026-05-15"
+    jira:  "docs/loki-compliance-plan.md PR 6"
+  - source: "fast/structured-metadata.yaml#Logfmt parsing with structured metadata filter"
+    reason: "Same as Structured metadata error level filter — requires seeded detected_level + logfmt-shaped lines."
+    since: "2026-05-15"
+    jira:  "docs/loki-compliance-plan.md PR 6"
+  - source: "fast/structured-metadata.yaml#Logfmt parsing with structured metadata filter first"
+    reason: "Same as Structured metadata error level filter — requires seeded detected_level + logfmt-shaped lines."
+    since: "2026-05-15"
+    jira:  "docs/loki-compliance-plan.md PR 6"
+  - source: "fast/structured-metadata.yaml#JSON parsing with structured metadata filter"
+    reason: "Same as Structured metadata error level filter — and the seed writes logfmt, not JSON."
+    since: "2026-05-15"
+    jira:  "docs/loki-compliance-plan.md PR 6"
+  - source: "fast/structured-metadata.yaml#JSON parsing with structured metadata filter first"
+    reason: "Upstream already pins `skip: true` on this entry (dataobj engine schema gap); listed here for explicitness so a future upstream `skip: false` flip doesn't silently re-enable on cerberus before PR 6 widens the seed."
+    since: "2026-05-15"
+    jira:  "docs/loki-compliance-plan.md PR 6"
 
 should_fail: []

--- a/harness/loki-compatibility/cerberus-test-queries.yml
+++ b/harness/loki-compatibility/cerberus-test-queries.yml
@@ -1,0 +1,39 @@
+# Cerberus overlay for the vendored grafana/loki:pkg/logql/bench corpus.
+#
+# This file lives OUTSIDE harness/loki-compatibility/upstream/loki-bench/ so
+# cerberus-side curation doesn't leak into the AGPL-3.0 vendor subtree.
+#
+# Schema (mirrors prometheus/compliance's test-queries.yml posture):
+#
+#   should_skip:
+#     - source: "fast/<file>.yaml#<description>"
+#       reason: "free-form English; cite roadmap milestone or upstream issue"
+#       since:  "<YYYY-MM-DD>"  # when the skip was added; for drift audits
+#       jira:   "<roadmap-ref>" # optional, e.g. "RC3 R3.x" or "#<PR>"
+#
+#   should_fail:
+#     # Same shape; for queries we EXPECT to round-trip but want to track
+#     # as known-broken. Initially unused.
+#
+# Maintenance:
+#
+#   - Reviewers add an entry when a vendored query exercises a LogQL
+#     feature cerberus hasn't shipped, OR when the runner surfaces a
+#     persistent diff vs the reference Loki on a feature roadmap.md
+#     deferred.
+#   - Empty should_skip / should_fail are fine. PR 3's runner treats
+#     missing keys as "no overrides".
+#   - When a query's status changes (e.g. cerberus implements the
+#     feature), drop the entry and let CI verify the diff is clean.
+#   - On every Loki tag bump (see ../README.md "Bump procedure"),
+#     re-validate the `source:` paths point at queries that still exist.
+
+# Cerberus's RC2 LogQL coverage (per docs/roadmap.md § RC2) already
+# ships | unpack, | pattern, | line_format, | decolorize, | label_format
+# (with Loki template funcs), bytes_*, and the full /api/v1/* + /labels +
+# /detected_fields surface. The minimal corpus (fast/*.yaml) doesn't hit
+# any of the deferred items, so should_skip starts empty. PR 4's
+# informational lane will surface real gaps that get triaged here.
+should_skip: []
+
+should_fail: []

--- a/harness/loki-compatibility/dataset_metadata.json
+++ b/harness/loki-compatibility/dataset_metadata.json
@@ -1,0 +1,126 @@
+{
+  "_comment": "TODO: Regenerate against PR 1's deterministic seeder once it lands. This placeholder pins reasonable OTel-shape defaults so PR 2 (vendor) lands without taking a hard dependency on PR 1's exact selector vocabulary. The fields here mirror the DatasetMetadata struct in upstream/loki-bench/query_registry.go's metadata.go sibling (not vendored). PR 1 (Pool-CA) will replace this verbatim.",
+  "_pr_dependency": "harness/loki-compatibility seeder lands in PR 1 of docs/loki-compliance-plan.md; see ../docs/loki-compliance-plan.md.",
+  "all_selectors": [
+    "{service_name=\"loki-bench-app-a\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"app\"}",
+    "{service_name=\"loki-bench-app-b\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"app\"}",
+    "{service_name=\"loki-bench-database\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"db\"}"
+  ],
+  "by_format": {
+    "json": [
+      "{service_name=\"loki-bench-app-a\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"app\"}",
+      "{service_name=\"loki-bench-database\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"db\"}"
+    ],
+    "logfmt": [
+      "{service_name=\"loki-bench-app-b\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"app\"}"
+    ],
+    "unstructured": []
+  },
+  "by_service_name": {
+    "loki-bench-app-a": [
+      "{service_name=\"loki-bench-app-a\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"app\"}"
+    ],
+    "loki-bench-app-b": [
+      "{service_name=\"loki-bench-app-b\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"app\"}"
+    ],
+    "loki-bench-database": [
+      "{service_name=\"loki-bench-database\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"db\"}"
+    ]
+  },
+  "statistics": {
+    "generated": "2026-05-15T00:00:00Z",
+    "streams_by_format": {
+      "json": 2,
+      "logfmt": 1
+    },
+    "streams_by_service": {
+      "loki-bench-app-a": 1,
+      "loki-bench-app-b": 1,
+      "loki-bench-database": 1
+    },
+    "total_streams": 3
+  },
+  "time_range": {
+    "start": "2026-05-15T00:00:00Z",
+    "end": "2026-05-15T00:10:00Z"
+  },
+  "version": "1.0",
+  "by_unwrappable_field": {
+    "bytes": [
+      "{service_name=\"loki-bench-app-a\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"app\"}",
+      "{service_name=\"loki-bench-database\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"db\"}"
+    ],
+    "duration": [
+      "{service_name=\"loki-bench-app-a\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"app\"}"
+    ]
+  },
+  "by_detected_field": {
+    "level": [
+      "{service_name=\"loki-bench-app-a\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"app\"}",
+      "{service_name=\"loki-bench-app-b\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"app\"}",
+      "{service_name=\"loki-bench-database\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"db\"}"
+    ]
+  },
+  "by_structured_metadata": {
+    "detected_level": [
+      "{service_name=\"loki-bench-app-a\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"app\"}",
+      "{service_name=\"loki-bench-app-b\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"app\"}",
+      "{service_name=\"loki-bench-database\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"db\"}"
+    ],
+    "pod": [
+      "{service_name=\"loki-bench-app-a\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"app\"}"
+    ]
+  },
+  "by_label_key": {
+    "service_name": [
+      "{service_name=\"loki-bench-app-a\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"app\"}",
+      "{service_name=\"loki-bench-app-b\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"app\"}",
+      "{service_name=\"loki-bench-database\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"db\"}"
+    ],
+    "namespace": [
+      "{service_name=\"loki-bench-app-a\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"app\"}",
+      "{service_name=\"loki-bench-app-b\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"app\"}",
+      "{service_name=\"loki-bench-database\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"db\"}"
+    ],
+    "cluster": [
+      "{service_name=\"loki-bench-app-a\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"app\"}",
+      "{service_name=\"loki-bench-app-b\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"app\"}",
+      "{service_name=\"loki-bench-database\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"db\"}"
+    ],
+    "container": [
+      "{service_name=\"loki-bench-app-a\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"app\"}",
+      "{service_name=\"loki-bench-app-b\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"app\"}",
+      "{service_name=\"loki-bench-database\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"db\"}"
+    ]
+  },
+  "by_keyword": {
+    "debug": [
+      "{service_name=\"loki-bench-app-a\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"app\"}",
+      "{service_name=\"loki-bench-app-b\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"app\"}"
+    ],
+    "error": [
+      "{service_name=\"loki-bench-app-a\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"app\"}",
+      "{service_name=\"loki-bench-app-b\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"app\"}",
+      "{service_name=\"loki-bench-database\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"db\"}"
+    ],
+    "level": [
+      "{service_name=\"loki-bench-app-a\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"app\"}",
+      "{service_name=\"loki-bench-app-b\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"app\"}",
+      "{service_name=\"loki-bench-database\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"db\"}"
+    ]
+  },
+  "metadata_by_selector": {
+    "{service_name=\"loki-bench-app-a\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"app\"}": {
+      "min_range": 60000000000,
+      "min_instant_range": 60000000000
+    },
+    "{service_name=\"loki-bench-app-b\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"app\"}": {
+      "min_range": 60000000000,
+      "min_instant_range": 60000000000
+    },
+    "{service_name=\"loki-bench-database\", namespace=\"default\", cluster=\"cerberus-loki-bench\", container=\"db\"}": {
+      "min_range": 60000000000,
+      "min_instant_range": 60000000000
+    }
+  }
+}

--- a/harness/loki-compatibility/reports/.gitignore
+++ b/harness/loki-compatibility/reports/.gitignore
@@ -1,0 +1,3 @@
+*.json
+!.gitignore
+!.gitkeep

--- a/harness/loki-compatibility/reports/.gitkeep
+++ b/harness/loki-compatibility/reports/.gitkeep
@@ -1,0 +1,5 @@
+# Reports written here by scripts/run-loki-compatibility.sh. Empty by
+# default; reports are gitignored at the harness root via the .gitignore
+# in this directory (the dir itself is committed so the script's
+# `mkdir -p reports/` is a no-op rather than a fatal `mkdir` against a
+# non-existent parent on a fresh clone).

--- a/harness/loki-compatibility/scripts/run-loki-compatibility.sh
+++ b/harness/loki-compatibility/scripts/run-loki-compatibility.sh
@@ -1,39 +1,81 @@
 #!/usr/bin/env bash
-# LogQL compatibility harness entry point (PR 1: scaffold smoke).
+# LogQL compatibility harness entry point.
 #
-# Brings up the docker-compose stack (reference Loki + cerberus +
-# ClickHouse), runs the deterministic seeder against both targets, and
-# verifies /labels is non-empty on the reference Loki side. The diff
-# driver lands in PR 3 — this script's contract for PR 1 is just
-# "stack comes up, seed runs, /labels is non-empty on both endpoints".
+# Lifecycle (mirrors harness/prometheus-compliance/scripts/run-compatibility.sh):
+#
+#   1. `docker compose up --wait` brings reference Loki + cerberus + CH up.
+#   2. The Go seeder pushes a deterministic fixture to both targets and
+#      asserts /labels is non-empty (the original PR 1 smoke).
+#   3. `go test -tags=remote_correctness -c` builds the diff driver from
+#      the vendored upstream/loki-bench/ corpus (the binary contains the
+#      single TestRemoteStorageEquality test).
+#   4. The driver runs against -addr-1 (reference Loki :23100) and
+#      -addr-2 (cerberus :29092); its JSON-shaped go-test output is
+#      captured to reports/diff.json.
+#   5. The compose stack is torn down on every exit path (success,
+#      driver failure, set -e abort, manual SIGINT) via a cleanup trap.
+#
+# Exit semantics:
+#
+#   - 0  → smoke + driver passed (no diffs reported on any query case).
+#   - 1  → driver reported at least one diff or run-time failure (the
+#          informational CI lane in PR 4 treats this as non-blocking; a
+#          required-check upgrade is planned per docs/loki-compliance-plan.md
+#          PR 5).
+#   - 2+ → harness itself failed (compose up, seed, build, docker missing,
+#          …). Inspect script output; the report file may be empty.
 #
 # Usage:
 #   ./harness/loki-compatibility/scripts/run-loki-compatibility.sh   full lifecycle
 #   COMPOSE_KEEP=1 ./...                                             leave stack up after run
+#   DRIVER_SKIP=1 ./...                                              run smoke only (skip diff)
 #
 # Env:
-#   COMPOSE_KEEP        non-empty: leave the compose stack running after the
-#                       smoke completes (useful for poking at /loki/api/v1/*
-#                       and ClickHouse manually).
-#
-# Mirrors harness/prometheus-compliance/scripts/run-compatibility.sh's
-# lifecycle: up --wait, run go seeder, tear down on every exit path.
+#   COMPOSE_KEEP        non-empty: leave the compose stack running after
+#                       the run completes (useful for poking at
+#                       /loki/api/v1/* and ClickHouse manually).
+#   DRIVER_SKIP         non-empty: skip the diff driver entirely. Useful
+#                       when the seeder is the bisect target.
+#   DRIVER_REPORT       report file path (default: reports/diff.json).
+#                       NOTE: the PR 3 driver emits `go test -v` text;
+#                       the .json suffix is forward-looking — PR 5's
+#                       cerberus-owned driver will switch this to a
+#                       structured JSON report matching the Prom
+#                       harness's report.json shape. Existing tooling
+#                       that consumes `reports/*.json` should pin the
+#                       output format expectation rather than the path.
+#   DRIVER_TIMEOUT      go-test -timeout flag (default: 10m).
+#   DRIVER_TOLERANCE    -tolerance flag passed through to the driver
+#                       (default: 1e-5; matches upstream remote_test.go).
+#   DRIVER_RANGE_TYPE   -remote-range-type flag (default: range).
+#                       Set "instant" to exercise instant-query mode.
 
 set -eu -o pipefail
 
 ROOT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+REPO_ROOT=$(cd "$ROOT_DIR/../.." && pwd)
 cd "$ROOT_DIR"
 
-echo "==> bringing up loki-compatibility stack (compose up --wait)"
-docker compose up -d --build --wait clickhouse loki cerberus
+REPORT=${DRIVER_REPORT:-"$ROOT_DIR/reports/diff.json"}
+TIMEOUT=${DRIVER_TIMEOUT:-10m}
+TOLERANCE=${DRIVER_TOLERANCE:-1e-5}
+RANGE_TYPE=${DRIVER_RANGE_TYPE:-range}
 
-# Consolidated cleanup: tear down the compose stack on every exit path
-# (success, seeder failure, set -e abort, manual SIGINT). Without this,
-# a non-zero seeder exit propagated by `set -e` would leak the stack
-# across re-runs — local repros, in particular, would inherit dirty CH /
-# Loki state and confuse subsequent debugging.
+TEST_BIN=$(mktemp -t cerberus-loki-equality.XXXXXX.test)
+
+# Consolidated cleanup: tear down the compose stack, restore the root
+# go.mod / go.sum (the `-mod=mod` build temporarily promotes the
+# vendored Loki-client + transitive deps to direct entries — we revert
+# so the working tree stays clean), and drop the throwaway test binary.
+# Runs on every exit path (success, driver failure, set -e abort, SIGINT)
+# so a non-zero exit can't leak compose state or a dirty go.mod across
+# re-runs.
 cleanup() {
     rc=$?
+    rm -f "$TEST_BIN"
+    if [ -d "$REPO_ROOT/.git" ]; then
+        (cd "$REPO_ROOT" && git checkout -- go.mod go.sum 2>/dev/null) || true
+    fi
     if [ -z "${COMPOSE_KEEP:-}" ]; then
         echo "==> tearing down (set COMPOSE_KEEP=1 to leave running)"
         docker compose down -v || true
@@ -42,8 +84,73 @@ cleanup() {
 }
 trap cleanup EXIT
 
-echo "==> running seeder (go run ./cmd/seed)"
-(cd "$ROOT_DIR/../.." && go run ./harness/loki-compatibility/cmd/seed/)
+mkdir -p "$(dirname "$REPORT")"
 
-echo "==> smoke OK — /labels reported non-empty on both targets"
-echo "    (corpus + diff driver land in PR 2+ per docs/loki-compliance-plan.md)"
+echo "==> bringing up loki-compatibility stack (compose up --wait)"
+docker compose up -d --build --wait clickhouse loki cerberus
+
+echo "==> running seeder (go run ./cmd/seed)"
+(cd "$REPO_ROOT" && go run ./harness/loki-compatibility/cmd/seed/)
+
+if [ -n "${DRIVER_SKIP:-}" ]; then
+    echo "==> DRIVER_SKIP set — finishing after smoke"
+    exit 0
+fi
+
+# Build the diff driver from the vendored corpus. The root go.mod pins
+# `ignore ./harness/loki-compatibility/upstream` so default toolchain
+# operations skip this path; an explicit build target requires it. We
+# pass -mod=mod so the test-only Loki-client + transitive deps
+# (aws-sdk-go-v2, azure-sdk, openapi, …) can resolve without
+# permanently polluting the root go.mod — the cleanup trap reverts
+# go.mod/go.sum on every exit path.
+echo "==> building diff driver (go test -tags=remote_correctness -c)"
+(cd "$REPO_ROOT" && \
+    GOFLAGS=-mod=mod go test \
+        -tags=remote_correctness \
+        -c \
+        -o "$TEST_BIN" \
+        ./harness/loki-compatibility/upstream/loki-bench/)
+
+# The driver's NewQueryRegistry("./queries") loader is relative — cwd
+# must contain the corpus subtree. Running from the vendor dir keeps
+# the test binary unaltered (no patches against upstream).
+echo "==> running diff driver (writing report to $REPORT)"
+echo "    -addr-1=http://localhost:23100  (reference Loki)"
+echo "    -addr-2=http://localhost:29092  (cerberus)"
+echo "    -tolerance=$TOLERANCE -remote-range-type=$RANGE_TYPE -timeout=$TIMEOUT"
+
+# Capture the driver's full stdout/stderr (one "--- PASS"/"--- FAIL"
+# line per query subtest plus the standard `go test -v` framing). PR 5
+# will swap this to the JSON shape the Prom harness uses; for now the
+# raw stream is sufficient for the informational lane. The set +e
+# window is just wide enough to capture the driver's exit code so the
+# report write completes before the script propagates the failure. The
+# cleanup trap still runs.
+set +e
+(cd "$ROOT_DIR/upstream/loki-bench" && \
+    "$TEST_BIN" \
+        -test.v \
+        -test.timeout="$TIMEOUT" \
+        -test.run=TestRemoteStorageEquality \
+        -addr-1=http://localhost:23100 \
+        -addr-2=http://localhost:29092 \
+        -metadata-dir="$ROOT_DIR" \
+        -tolerance="$TOLERANCE" \
+        -remote-range-type="$RANGE_TYPE" 2>&1) | tee "$REPORT"
+DRIVER_RC=${PIPESTATUS[0]}
+set -e
+
+echo "==> report written to $REPORT"
+echo "==> summary:"
+# go-test -v emits human-readable "--- PASS"/"--- FAIL" markers per
+# subtest. The driver registers each query case as a subtest, so a
+# grep against those is the cheapest summary surface; the report
+# captures the full stream for downstream analysis.
+PASS_COUNT=$(grep -c '^    --- PASS' "$REPORT" 2>/dev/null || echo 0)
+FAIL_COUNT=$(grep -c '^    --- FAIL' "$REPORT" 2>/dev/null || echo 0)
+SKIP_COUNT=$(grep -c '^    --- SKIP' "$REPORT" 2>/dev/null || echo 0)
+printf '    passed=%s failed=%s skipped=%s exit_code=%s\n' \
+    "$PASS_COUNT" "$FAIL_COUNT" "$SKIP_COUNT" "$DRIVER_RC"
+
+exit "$DRIVER_RC"

--- a/harness/loki-compatibility/upstream/loki-bench/LICENSE
+++ b/harness/loki-compatibility/upstream/loki-bench/LICENSE
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/harness/loki-compatibility/upstream/loki-bench/VERSION
+++ b/harness/loki-compatibility/upstream/loki-bench/VERSION
@@ -1,0 +1,21 @@
+# Vendored from github.com/grafana/loki.
+#
+# This file records the EXACT upstream coordinates of the snapshot under
+# this directory. See ../../README.md and ../../../docs/loki-compliance-plan.md
+# for the bump procedure.
+#
+# Cerberus's `tsouza/loki` fork (replace directive in go.mod) only
+# tracks `pkg/logql/syntax/`, `pkg/logql/log/`, and `pkg/logqlmodel`;
+# `pkg/logql/bench/` is OUT of that watch boundary. The snapshot here
+# therefore pins grafana/loki directly rather than the fork tag.
+
+upstream_repo:     github.com/grafana/loki
+upstream_tag:      v3.7.0
+upstream_commit:   3361de24b692875d77bd7433cd6baa7c68dc0ef9
+
+vendored_paths:
+  - pkg/logql/bench/queries/fast/*.yaml
+  - pkg/logql/bench/queries/schema.json
+  - pkg/logql/bench/query_registry.go
+  - pkg/logql/bench/remote_test.go
+  - LICENSE

--- a/harness/loki-compatibility/upstream/loki-bench/VERSION
+++ b/harness/loki-compatibility/upstream/loki-bench/VERSION
@@ -18,4 +18,22 @@ vendored_paths:
   - pkg/logql/bench/queries/schema.json
   - pkg/logql/bench/query_registry.go
   - pkg/logql/bench/remote_test.go
+  # PR 3 expanded the snapshot to include the support files
+  # remote_test.go transitively depends on (metadata loader, variable
+  # resolver, test-case shape, conversion helpers, assertions). Without
+  # them the `go test -tags=remote_correctness -c` build pulled by
+  # scripts/run-loki-compatibility.sh would fail with `undefined:
+  # TestCase / LoadMetadata / ConvertResult / assertResultNotEmpty / ...`.
+  - pkg/logql/bench/metadata.go
+  - pkg/logql/bench/metadata_resolver.go
+  - pkg/logql/bench/testcase.go
+  - pkg/logql/bench/convert_test.go
+  - pkg/logql/bench/assertions_test.go
+  # metadata.go references GeneratorConfig / StreamMetadata / LogFormat
+  # from generator.go + faker.go; those are kept verbatim so the
+  # package compiles without sanitisation. They're test-data generation
+  # helpers; remote_test.go itself never invokes them — but the symbols
+  # have to resolve for the package to type-check.
+  - pkg/logql/bench/generator.go
+  - pkg/logql/bench/faker.go
   - LICENSE

--- a/harness/loki-compatibility/upstream/loki-bench/assertions_test.go
+++ b/harness/loki-compatibility/upstream/loki-bench/assertions_test.go
@@ -1,0 +1,141 @@
+package bench
+
+import (
+	"testing"
+
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/logqlmodel"
+)
+
+// assertResultNotEmpty verifies that a query result is not empty
+// This catches templating issues where queries may resolve to selectors that match no data
+func assertResultNotEmpty(t *testing.T, data parser.Value, message string) {
+	t.Helper()
+	switch v := data.(type) {
+	case promql.Vector:
+		require.NotEmpty(t, v, message)
+	case promql.Matrix:
+		require.NotEmpty(t, v, message)
+		// Also check that at least one series has data points
+		hasData := false
+		for _, series := range v {
+			if len(series.Floats) > 0 || len(series.Histograms) > 0 {
+				hasData = true
+				break
+			}
+		}
+		require.True(t, hasData, message+" - matrix has series but no data points")
+	case promql.Scalar:
+		// Scalars always have a value, so no need to check
+	case logqlmodel.Streams:
+		require.NotEmpty(t, v, message)
+	default:
+		t.Fatalf("unknown result type: %T", data)
+	}
+}
+
+func assertResultEmpty(t *testing.T, data parser.Value, message string) {
+	t.Helper()
+	switch v := data.(type) {
+	case promql.Vector:
+		require.Empty(t, v, message)
+	case promql.Matrix:
+		require.Empty(t, v, message)
+		isEmpty := true
+		for _, series := range v {
+			if len(series.Floats) > 0 || len(series.Histograms) > 0 {
+				isEmpty = false
+				break
+			}
+		}
+		require.True(t, isEmpty, message+" - matrix has series with data points")
+	case promql.Scalar:
+		// Scalars always have a value, so they should be 0
+		require.Equal(t, v, v.V, 0)
+	case logqlmodel.Streams:
+		require.Empty(t, v, message)
+	default:
+		t.Fatalf("unknown result type: %T", data)
+	}
+}
+
+// assertDataEqualWithTolerance compares two parser.Value instances with floating point tolerance
+func assertDataEqualWithTolerance(t *testing.T, expected, actual parser.Value, tolerance float64) {
+	t.Helper()
+	switch expectedType := expected.(type) {
+	case promql.Vector:
+		actualVector, ok := actual.(promql.Vector)
+		require.True(t, ok, "expected Vector but got %T", actual)
+		assertVectorEqualWithTolerance(t, expectedType, actualVector, tolerance)
+	case promql.Matrix:
+		actualMatrix, ok := actual.(promql.Matrix)
+		require.True(t, ok, "expected Matrix but got %T", actual)
+		assertMatrixEqualWithTolerance(t, expectedType, actualMatrix, tolerance)
+	case promql.Scalar:
+		actualScalar, ok := actual.(promql.Scalar)
+		require.True(t, ok, "expected Scalar but got %T", actual)
+		assertScalarEqualWithTolerance(t, expectedType, actualScalar, tolerance)
+	default:
+		assert.Equal(t, expected, actual)
+	}
+}
+
+// assertVectorEqualWithTolerance compares two Vector instances with floating point tolerance
+func assertVectorEqualWithTolerance(t *testing.T, expected, actual promql.Vector, tolerance float64) {
+	t.Helper()
+	require.Len(t, actual, len(expected))
+
+	for i := range expected {
+		e := expected[i]
+		a := actual[i]
+		require.Equal(t, e.Metric, a.Metric, "metric labels differ at index %d", i)
+		require.Equal(t, e.T, a.T, "timestamp differs at index %d", i)
+
+		if tolerance > 0 {
+			require.InDelta(t, e.F, a.F, tolerance, "float value differs at index %d", i)
+		} else {
+			require.Equal(t, e.F, a.F, "float value differs at index %d", i)
+		}
+	}
+}
+
+// assertMatrixEqualWithTolerance compares two Matrix instances with floating point tolerance
+func assertMatrixEqualWithTolerance(t *testing.T, expected, actual promql.Matrix, tolerance float64) {
+	t.Helper()
+	require.Equal(t, len(expected), len(actual), "number of entries differs")
+
+	for i := range expected {
+		e := expected[i]
+		a := actual[i]
+		require.Equal(t, e.Metric, a.Metric, "metric labels differ at series %d", i)
+		require.Len(t, a.Floats, len(e.Floats), "float points count differs at series %d", i)
+
+		for j := range e.Floats {
+			ePoint := e.Floats[j]
+			aPoint := a.Floats[j]
+			require.Equal(t, ePoint.T, aPoint.T, "timestamp differs at series %d, point %d", i, j)
+
+			if tolerance > 0 {
+				require.InDelta(t, ePoint.F, aPoint.F, tolerance, "float value differs at series %d, point %d", i, j)
+			} else {
+				require.Equal(t, ePoint.F, aPoint.F, "float value differs at series %d, point %d", i, j)
+			}
+		}
+	}
+}
+
+// assertScalarEqualWithTolerance compares two Scalar instances with floating point tolerance
+func assertScalarEqualWithTolerance(t *testing.T, expected, actual promql.Scalar, tolerance float64) {
+	t.Helper()
+	require.Equal(t, expected.T, actual.T, "scalar timestamp differs")
+
+	if tolerance > 0 {
+		require.InDelta(t, expected.V, actual.V, tolerance, "scalar value differs")
+	} else {
+		require.Equal(t, expected.V, actual.V, "scalar value differs")
+	}
+}

--- a/harness/loki-compatibility/upstream/loki-bench/convert_test.go
+++ b/harness/loki-compatibility/upstream/loki-bench/convert_test.go
@@ -1,0 +1,88 @@
+package bench
+
+import (
+	"fmt"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/grafana/loki/v3/pkg/loghttp"
+	"github.com/grafana/loki/v3/pkg/logqlmodel"
+)
+
+// ConvertResult converts a loghttp.ResultValue to a parser.Value.
+// It dispatches based on the concrete type of the input.
+func ConvertResult(v loghttp.ResultValue) (parser.Value, error) {
+	switch r := v.(type) {
+	case loghttp.Streams:
+		return convertStreams(r), nil
+	case loghttp.Matrix:
+		return convertMatrix(r)
+	case loghttp.Vector:
+		return convertVector(r), nil
+	case loghttp.Scalar:
+		return convertScalar(r), nil
+	default:
+		return nil, fmt.Errorf("unknown result type: %T", v)
+	}
+}
+
+// convertStreams converts a loghttp.Streams to logqlmodel.Streams.
+func convertStreams(s loghttp.Streams) logqlmodel.Streams {
+	return logqlmodel.Streams(s.ToProto())
+}
+
+// convertMatrix converts a loghttp.Matrix to promql.Matrix.
+func convertMatrix(m loghttp.Matrix) (promql.Matrix, error) {
+	result := make(promql.Matrix, len(m))
+	for i, sampleStream := range m {
+		if len(sampleStream.Histograms) > 0 {
+			return nil, fmt.Errorf("histogram data not yet supported in conversion (series %d has %d histogram points)", i, len(sampleStream.Histograms))
+		}
+		floats := make([]promql.FPoint, len(sampleStream.Values))
+		for j, pair := range sampleStream.Values {
+			floats[j] = promql.FPoint{
+				T: int64(pair.Timestamp),
+				F: float64(pair.Value),
+			}
+		}
+		result[i] = promql.Series{
+			Metric: modelMetricToLabels(sampleStream.Metric),
+			Floats: floats,
+		}
+	}
+	return result, nil
+}
+
+// convertVector converts a loghttp.Vector to promql.Vector.
+func convertVector(v loghttp.Vector) promql.Vector {
+	result := make(promql.Vector, len(v))
+	for i, sample := range v {
+		result[i] = promql.Sample{
+			Metric: modelMetricToLabels(sample.Metric),
+			T:      int64(sample.Timestamp),
+			F:      float64(sample.Value),
+		}
+	}
+	return result
+}
+
+// convertScalar converts a loghttp.Scalar to promql.Scalar.
+func convertScalar(s loghttp.Scalar) promql.Scalar {
+	return promql.Scalar{
+		T: int64(s.Timestamp),
+		V: float64(s.Value),
+	}
+}
+
+// modelMetricToLabels converts a model.Metric to labels.Labels.
+// model.Metric is map[model.LabelName]model.LabelValue where both are string types.
+func modelMetricToLabels(metric model.Metric) labels.Labels {
+	m := make(map[string]string, len(metric))
+	for k, v := range metric {
+		m[string(k)] = string(v)
+	}
+	return labels.FromMap(m)
+}

--- a/harness/loki-compatibility/upstream/loki-bench/faker.go
+++ b/harness/loki-compatibility/upstream/loki-bench/faker.go
@@ -1,0 +1,972 @@
+package bench
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+)
+
+// Data for generating log entries
+var (
+	httpMethods = []string{"GET", "POST", "PUT", "DELETE", "PATCH"}
+	apiPaths    = []string{
+		"/api/v1/users",
+		"/api/v1/products",
+		"/api/v1/orders",
+		"/api/v1/auth/login",
+		"/api/v1/auth/logout",
+		"/api/v2/metrics",
+		"/api/v2/logs",
+		"/healthz",
+		"/metrics",
+	}
+	httpStatus = []int{200, 201, 204, 301, 302, 400, 401, 403, 404, 500, 503}
+	userAgents = []string{
+		"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+		"Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15",
+		"Mozilla/5.0 (Linux; Android 11; SM-G991B) AppleWebKit/537.36",
+		"curl/7.64.1",
+		"Apache-HttpClient/4.5.13",
+		"python-requests/2.26.0",
+	}
+	queryTypes  = []string{"SELECT", "INSERT", "UPDATE", "DELETE", "MERGE"}
+	dbTables    = []string{"users", "products", "orders", "sessions", "logs", "metrics"}
+	cacheOps    = []string{"get", "set", "delete", "expire", "flush"}
+	authActions = []string{"login", "logout", "password_reset", "token_refresh", "permission_check"}
+
+	errorMessages = []string{
+		"Invalid request parameters",
+		"Unauthorized access",
+		"Resource not found",
+		"Internal server error",
+		"Service unavailable",
+		"Rate limit exceeded",
+		"Invalid content type",
+	}
+	dbErrors = []string{
+		"Connection refused",
+		"Deadlock detected",
+		"Unique constraint violation",
+		"Foreign key constraint violation",
+	}
+
+	// New data for additional generators
+	orgIDs = []string{"tenant1", "tenant2", "tenant3", "tenant4", "tenant5", "acme", "globex", "initech", "umbrella"}
+
+	grpcMethods = []string{
+		"/cortex.Ingester/Push",
+		"/cortex.Querier/Query",
+		"/cortex.Ruler/Rules",
+		"/cortex.Distributor/Push",
+		"/cortex.Compactor/Compact",
+	}
+
+	tempoComponents = []string{
+		"distributor",
+		"ingester",
+		"querier",
+		"compactor",
+		"frontend",
+	}
+
+	tempoMessages = []string{
+		"received traces",
+		"querying traces",
+		"compacting blocks",
+		"flushing traces to storage",
+		"handling request",
+	}
+
+	k8sComponents = []string{
+		"kubelet",
+		"kube-scheduler",
+		"kube-controller-manager",
+		"kube-apiserver",
+		"etcd",
+	}
+
+	k8sLogPrefixes = []string{
+		"I0612",
+		"W0612",
+		"E0612",
+		"F0612",
+	}
+
+	k8sMessages = []string{
+		"Started container",
+		"Pulling image",
+		"Created pod",
+		"Scheduled pod",
+		"Node status updated",
+		"Volume mounted",
+		"Service endpoint updated",
+	}
+
+	prometheusComponents = []string{
+		"tsdb",
+		"scrape",
+		"rules",
+		"remote",
+		"web",
+	}
+
+	prometheusSubcomponents = []string{
+		"manager",
+		"head",
+		"wal",
+		"api",
+		"discovery",
+	}
+
+	prometheusMessages = []string{
+		"Compacting blocks",
+		"Scraping target",
+		"Evaluating rules",
+		"Remote write",
+		"Handling request",
+		"WAL replay complete",
+	}
+
+	grafanaLoggers = []string{
+		"http.server",
+		"alerting",
+		"auth",
+		"datasources",
+		"rendering",
+	}
+
+	grafanaComponents = []string{
+		"server",
+		"api",
+		"sqlstore",
+		"plugins",
+		"auth",
+	}
+
+	grafanaMessages = []string{
+		"Request completed",
+		"User logged in",
+		"Dashboard saved",
+		"Alert rule evaluated",
+		"Data source health check",
+		"Plugin loaded",
+	}
+
+	cacheErrors = []string{
+		"Connection refused",
+		"Key not found",
+		"Invalid key format",
+		"Memory limit exceeded",
+		"Serialization error",
+	}
+	authErrors = []string{
+		"Invalid credentials",
+		"Account locked",
+		"Session expired",
+		"Invalid token",
+		"Too many attempts",
+		"Password expired",
+	}
+	nginxPaths = []string{
+		"/",
+		"/api/",
+		"/static/",
+		"/images/",
+		"/css/",
+		"/js/",
+		"/upload/",
+		"/download/",
+		"/admin/",
+		"/auth/",
+	}
+	nginxErrorTypes = []string{
+		"access forbidden",
+		"client closed connection",
+		"upstream timed out",
+		"file not found",
+		"invalid request",
+	}
+	nginxErrors = []string{
+		"access forbidden by rule",
+		"client closed connection while reading request headers",
+		"upstream timed out (110: Connection timed out)",
+		"file not found",
+		"client sent invalid request",
+	}
+	kafkaTopics = []string{
+		"users",
+		"orders",
+		"payments",
+		"notifications",
+		"logs",
+		"metrics",
+		"events",
+	}
+	kafkaEvents = []string{
+		"producer_send",
+		"consumer_fetch",
+		"partition_assignment",
+		"replication_completed",
+		"leader_election",
+	}
+	kafkaErrors = []string{
+		"Leader not available",
+		"Network connection failure",
+		"Topic authorization failed",
+		"Record too large",
+		"Offset out of range",
+	}
+)
+
+// Faker provides methods to generate fake data consistently
+type Faker struct {
+	rnd *rand.Rand
+}
+
+// NewFaker creates a new faker with the given random source
+func NewFaker(rnd *rand.Rand) *Faker {
+	return &Faker{rnd: rnd}
+}
+
+// Method returns a random HTTP method
+func (f *Faker) Method() string {
+	return httpMethods[f.rnd.Intn(len(httpMethods))]
+}
+
+// Path returns a random API path
+func (f *Faker) Path() string {
+	return apiPaths[f.rnd.Intn(len(apiPaths))]
+}
+
+// Status returns a random HTTP status code
+func (f *Faker) Status() int {
+	return httpStatus[f.rnd.Intn(len(httpStatus))]
+}
+
+// Duration returns a random duration
+func (f *Faker) Duration() time.Duration {
+	return time.Duration(f.rnd.Intn(1000)+1) * time.Millisecond // 1-1000ms
+}
+
+// UserAgent returns a random user agent string
+func (f *Faker) UserAgent() string {
+	return userAgents[f.rnd.Intn(len(userAgents))]
+}
+
+// IP returns a random IP address
+func (f *Faker) IP() string {
+	return fmt.Sprintf("%d.%d.%d.%d", f.rnd.Intn(256), f.rnd.Intn(256), f.rnd.Intn(256), f.rnd.Intn(256))
+}
+
+// TraceID returns a random trace ID
+func (f *Faker) TraceID() string {
+	b := make([]byte, 16)
+	f.rnd.Read(b)
+	return fmt.Sprintf("%x", b)
+}
+
+// SpanID returns a random span ID
+func (f *Faker) SpanID() string {
+	b := make([]byte, 8)
+	f.rnd.Read(b)
+	return fmt.Sprintf("%x", b)
+}
+
+// QueryType returns a random database query type
+func (f *Faker) QueryType() string {
+	return queryTypes[f.rnd.Intn(len(queryTypes))]
+}
+
+// Table returns a random database table name
+func (f *Faker) Table() string {
+	return dbTables[f.rnd.Intn(len(dbTables))]
+}
+
+// RowsAffected returns a random number of rows affected
+func (f *Faker) RowsAffected() int {
+	return f.rnd.Intn(100) + 1 // 1-100 rows
+}
+
+// CacheOp returns a random cache operation
+func (f *Faker) CacheOp() string {
+	return cacheOps[f.rnd.Intn(len(cacheOps))]
+}
+
+// CacheKey returns a random cache key
+func (f *Faker) CacheKey() string {
+	return fmt.Sprintf("key:%d", f.rnd.Intn(1000))
+}
+
+// CacheSize returns a random cache size in bytes
+func (f *Faker) CacheSize() int {
+	return f.rnd.Intn(10000) + 1 // 1-10000 bytes
+}
+
+// CacheTTL returns a random cache TTL in seconds
+func (f *Faker) CacheTTL() int {
+	return f.rnd.Intn(3600) + 60 // 60-3660 seconds
+}
+
+// AuthAction returns a random authentication action
+func (f *Faker) AuthAction() string {
+	return authActions[f.rnd.Intn(len(authActions))]
+}
+
+// User returns a random username
+func (f *Faker) User() string {
+	return fmt.Sprintf("user%d", f.rnd.Intn(1000))
+}
+
+// AuthSuccess returns a random authentication success status
+func (f *Faker) AuthSuccess() bool {
+	return f.rnd.Float32() < 0.8 // 80% success rate
+}
+
+// Error returns a random general error message
+func (f *Faker) Error() string {
+	return errorMessages[f.rnd.Intn(len(errorMessages))]
+}
+
+// DBError returns a random database error
+func (f *Faker) DBError() string {
+	return dbErrors[f.rnd.Intn(len(dbErrors))]
+}
+
+// CacheError returns a random cache error
+func (f *Faker) CacheError() string {
+	return cacheErrors[f.rnd.Intn(len(cacheErrors))]
+}
+
+// AuthError returns a random authentication error
+func (f *Faker) AuthError() string {
+	return authErrors[f.rnd.Intn(len(authErrors))]
+}
+
+// KafkaTopic returns a random Kafka topic
+func (f *Faker) KafkaTopic() string {
+	return kafkaTopics[f.rnd.Intn(len(kafkaTopics))]
+}
+
+// KafkaEvent returns a random Kafka event
+func (f *Faker) KafkaEvent() string {
+	return kafkaEvents[f.rnd.Intn(len(kafkaEvents))]
+}
+
+// KafkaPartition returns a random Kafka partition
+func (f *Faker) KafkaPartition() int {
+	return f.rnd.Intn(10)
+}
+
+// KafkaOffset returns a random Kafka offset
+func (f *Faker) KafkaOffset() int {
+	return f.rnd.Intn(100000)
+}
+
+// KafkaError returns a random Kafka error
+func (f *Faker) KafkaError() string {
+	return kafkaErrors[f.rnd.Intn(len(kafkaErrors))]
+}
+
+// NginxPath returns a random nginx path
+func (f *Faker) NginxPath() string {
+	return nginxPaths[f.rnd.Intn(len(nginxPaths))]
+}
+
+// NginxErrorType returns a random nginx error type
+func (f *Faker) NginxErrorType() string {
+	return nginxErrorTypes[f.rnd.Intn(len(nginxErrorTypes))]
+}
+
+// Hostname returns a random hostname
+func (f *Faker) Hostname() string {
+	return fmt.Sprintf("host-%d", f.rnd.Intn(100))
+}
+
+// Referer returns a random referer URL
+func (f *Faker) Referer() string {
+	referers := []string{
+		"https://grafana.com",
+		"https://github.com",
+		"https://google.com",
+		"https://example.com",
+	}
+	return referers[f.rnd.Intn(len(referers))]
+}
+
+// SyslogPriority returns a random syslog priority
+func (f *Faker) SyslogPriority(isError bool) int {
+	if isError {
+		return 11 + f.rnd.Intn(4) // Error priority
+	}
+	return 14 + f.rnd.Intn(10) // Normal priority
+}
+
+// PID returns a random process ID
+func (f *Faker) PID() int {
+	return f.rnd.Intn(10000)
+}
+
+// New methods for additional generators
+
+// OrgID returns a random organization ID
+func (f *Faker) OrgID() string {
+	return orgIDs[f.rnd.Intn(len(orgIDs))]
+}
+
+// GRPCMethod returns a random gRPC method
+func (f *Faker) GRPCMethod() string {
+	return grpcMethods[f.rnd.Intn(len(grpcMethods))]
+}
+
+// ErrorMessage returns a random error message
+func (f *Faker) ErrorMessage() string {
+	return errorMessages[f.rnd.Intn(len(errorMessages))]
+}
+
+// TempoComponent returns a random Tempo component
+func (f *Faker) TempoComponent() string {
+	return tempoComponents[f.rnd.Intn(len(tempoComponents))]
+}
+
+// TempoMessage returns a random Tempo message
+func (f *Faker) TempoMessage() string {
+	return tempoMessages[f.rnd.Intn(len(tempoMessages))]
+}
+
+// K8sComponent returns a random Kubernetes component
+func (f *Faker) K8sComponent() string {
+	return k8sComponents[f.rnd.Intn(len(k8sComponents))]
+}
+
+// K8sLogPrefix returns a random Kubernetes log prefix
+func (f *Faker) K8sLogPrefix() string {
+	return k8sLogPrefixes[f.rnd.Intn(len(k8sLogPrefixes))]
+}
+
+// K8sMessage returns a random Kubernetes message
+func (f *Faker) K8sMessage() string {
+	return k8sMessages[f.rnd.Intn(len(k8sMessages))]
+}
+
+// PrometheusComponent returns a random Prometheus component
+func (f *Faker) PrometheusComponent() string {
+	return prometheusComponents[f.rnd.Intn(len(prometheusComponents))]
+}
+
+// PrometheusSubcomponent returns a random Prometheus subcomponent
+func (f *Faker) PrometheusSubcomponent() string {
+	return prometheusSubcomponents[f.rnd.Intn(len(prometheusSubcomponents))]
+}
+
+// PrometheusMessage returns a random Prometheus message
+func (f *Faker) PrometheusMessage() string {
+	return prometheusMessages[f.rnd.Intn(len(prometheusMessages))]
+}
+
+// GrafanaLogger returns a random Grafana logger
+func (f *Faker) GrafanaLogger() string {
+	return grafanaLoggers[f.rnd.Intn(len(grafanaLoggers))]
+}
+
+// GrafanaComponent returns a random Grafana component
+func (f *Faker) GrafanaComponent() string {
+	return grafanaComponents[f.rnd.Intn(len(grafanaComponents))]
+}
+
+// GrafanaMessage returns a random Grafana message
+func (f *Faker) GrafanaMessage() string {
+	return grafanaMessages[f.rnd.Intn(len(grafanaMessages))]
+}
+
+// LogGenerator is a function that generates a log line
+type LogGenerator func(level string, timestamp time.Time, faker *Faker) string
+
+// LogFormat represents the format of logs produced by an application
+type LogFormat string
+
+const (
+	LogFormatJSON         LogFormat = "json"
+	LogFormatLogfmt       LogFormat = "logfmt"
+	LogFormatUnstructured LogFormat = "unstructured"
+)
+
+// Service represents a type of application that generates logs
+type Service struct {
+	Name         string
+	Format       LogFormat // Log format: json, logfmt, or unstructured
+	LogGenerator LogGenerator
+	OTELResource map[string]string // OTEL resource attributes
+}
+
+// Register standard application types with known log patterns
+var defaultApplications = []Service{
+	{
+		Name:   "web-server",
+		Format: LogFormatJSON,
+		LogGenerator: func(level string, ts time.Time, f *Faker) string {
+			// JSON format with variations
+			baseJSON := fmt.Sprintf(
+				`{"level":"%s","ts":"%s","msg":"HTTP request","method":"%s","path":"%s","status":%d,"duration_ms":%d,"user_agent":"%s","client_ip":"%s"`,
+				level, ts.Format(time.RFC3339), f.Method(), f.Path(), f.Status(), f.Duration().Milliseconds(), f.UserAgent(), f.IP(),
+			)
+
+			// Sometimes add request ID
+			if f.rnd.Float32() < 0.7 {
+				baseJSON += fmt.Sprintf(`,"request_id":"%s"`, f.TraceID())
+			}
+
+			// Sometimes add user info
+			if f.rnd.Float32() < 0.4 {
+				baseJSON += fmt.Sprintf(`,"user":"%s"`, f.User())
+			}
+
+			// Sometimes add error info for non-200 status codes
+			if f.Status() >= 400 {
+				baseJSON += fmt.Sprintf(`,"error":"%s"`, f.ErrorMessage())
+			}
+
+			return baseJSON + "}"
+		},
+		OTELResource: map[string]string{
+			"service_name":           "web-server",
+			"service_version":        "1.0.0",
+			"service_namespace":      "default",
+			"telemetry_sdk_name":     "opentelemetry",
+			"telemetry_sdk_language": "go",
+			"deployment_environment": "production",
+		},
+	},
+	{
+		Name:   "database",
+		Format: LogFormatJSON,
+		LogGenerator: func(level string, ts time.Time, f *Faker) string {
+			// JSON format with variations
+			baseJSON := fmt.Sprintf(
+				`{"level":"%s","ts":"%s","msg":"Query executed","query_type":"%s","table":"%s","duration_ms":%d,"rows_affected":%d`,
+				level, ts.Format(time.RFC3339), f.QueryType(), f.Table(), f.Duration().Milliseconds(), f.RowsAffected(),
+			)
+
+			// Sometimes add query ID
+			if f.rnd.Float32() < 0.6 {
+				baseJSON += fmt.Sprintf(`,"query_id":"%s"`, f.TraceID())
+			}
+
+			// Sometimes add user info
+			if f.rnd.Float32() < 0.3 {
+				baseJSON += fmt.Sprintf(`,"user":"%s"`, f.User())
+			}
+
+			// Add error for error level logs
+			if level == errorLevel {
+				baseJSON += fmt.Sprintf(`,"error":"%s"`, f.DBError())
+			}
+
+			return baseJSON + "}"
+		},
+		OTELResource: map[string]string{
+			"service_name":    "mysql",
+			"service_version": "8.0.28",
+			"db_system":       "mysql",
+			"db_version":      "8.0.28",
+			"db_instance":     "primary",
+			"db_cluster":      "production",
+		},
+	},
+	{
+		Name:   "cache",
+		Format: LogFormatJSON,
+		LogGenerator: func(level string, ts time.Time, f *Faker) string {
+			// JSON format with variations
+			baseJSON := fmt.Sprintf(
+				`{"level":"%s","ts":"%s","msg":"Cache operation","operation":"%s","key":"%s","size":%d,"ttl":%d`,
+				level, ts.Format(time.RFC3339), f.CacheOp(), f.CacheKey(), f.CacheSize(), f.CacheTTL(),
+			)
+
+			// Sometimes add request ID
+			if f.rnd.Float32() < 0.5 {
+				baseJSON += fmt.Sprintf(`,"request_id":"%s"`, f.TraceID())
+			}
+
+			// Sometimes add duration
+			if f.rnd.Float32() < 0.7 {
+				baseJSON += fmt.Sprintf(`,"duration":"%s"`, f.Duration())
+			}
+
+			// Add error for error level logs
+			if level == errorLevel {
+				baseJSON += fmt.Sprintf(`,"error":"%s"`, f.CacheError())
+			}
+
+			return baseJSON + "}"
+		},
+		OTELResource: map[string]string{
+			"service_name":     "redis",
+			"service_version":  "6.2.6",
+			"redis_cluster":    "false",
+			"redis_db":         "0",
+			"redis_max_memory": "17179869184",
+		},
+	},
+	{
+		Name:   "auth-service",
+		Format: LogFormatJSON,
+		LogGenerator: func(level string, ts time.Time, f *Faker) string {
+			// JSON format with variations
+			baseJSON := fmt.Sprintf(
+				`{"level":"%s","ts":"%s","msg":"Authentication request","action":"%s","user":"%s","success":%t,"duration":"%s"`,
+				level, ts.Format(time.RFC3339), f.AuthAction(), f.User(), f.AuthSuccess(), f.Duration(),
+			)
+
+			// Sometimes add user info
+			if f.rnd.Float32() < 0.8 {
+				baseJSON += fmt.Sprintf(`,"user_details":"%s"`, f.User())
+			}
+
+			// Sometimes add client IP
+			if f.rnd.Float32() < 0.7 {
+				baseJSON += fmt.Sprintf(`,"client_ip":"%s"`, f.IP())
+			}
+
+			// Sometimes add request ID
+			if f.rnd.Float32() < 0.6 {
+				baseJSON += fmt.Sprintf(`,"request_id":"%s"`, f.TraceID())
+			}
+
+			// Add error for error level logs or failed auth
+			if level == errorLevel || !f.AuthSuccess() {
+				baseJSON += fmt.Sprintf(`,"error":"%s"`, f.AuthError())
+			}
+
+			return baseJSON + "}"
+		},
+		OTELResource: map[string]string{
+			"service_name":    "auth-service",
+			"service_version": "1.5.2",
+			"auth_provider":   "oauth2",
+			"auth_methods":    "password,token,sso",
+		},
+	},
+	{
+		Name:   "kafka",
+		Format: LogFormatJSON,
+		LogGenerator: func(level string, ts time.Time, f *Faker) string {
+			// JSON format with variations
+			baseJSON := fmt.Sprintf(
+				`{"level":"%s","ts":"%s","msg":"Kafka event","topic":"%s","partition":%d,"offset":%d,"event":"%s"`,
+				level, ts.Format(time.RFC3339), f.KafkaTopic(), f.KafkaPartition(), f.KafkaOffset(), f.KafkaEvent(),
+			)
+
+			// Sometimes add message size
+			if f.rnd.Float32() < 0.7 {
+				baseJSON += fmt.Sprintf(`,"size":%d`, f.rnd.Intn(10000))
+			}
+
+			// Sometimes add latency
+			if f.rnd.Float32() < 0.6 {
+				baseJSON += fmt.Sprintf(`,"latency":"%s"`, f.Duration())
+			}
+
+			// Sometimes add client info
+			if f.rnd.Float32() < 0.5 {
+				baseJSON += fmt.Sprintf(`,"client":"%s"`, f.Hostname())
+			}
+
+			// Add error for error level logs
+			if level == errorLevel {
+				baseJSON += fmt.Sprintf(`,"error":"%s"`, f.KafkaError())
+			}
+
+			return baseJSON + "}"
+		},
+		OTELResource: map[string]string{
+			"service_name":    "kafka",
+			"service_version": "3.4.0",
+			"broker_id":       "${BROKER_ID}",
+			"cluster_id":      "kafka-prod-01",
+			"num_partitions":  "24",
+		},
+	},
+	{
+		Name:   "nginx",
+		Format: LogFormatUnstructured,
+		LogGenerator: func(_ string, ts time.Time, f *Faker) string {
+			return fmt.Sprintf(
+				`%s - %s [%s] "%s %s HTTP/1.1" %d %d "%s" "%s"`,
+				f.IP(), f.User(), ts.Format("02/Jan/2006:15:04:05 -0700"),
+				f.Method(), f.NginxPath(), f.Status(), f.rnd.Intn(10000),
+				f.Referer(), f.UserAgent(),
+			)
+		},
+		OTELResource: map[string]string{
+			"service_name":    "nginx",
+			"service_version": "1.22.1",
+			"hostname":        "${HOSTNAME}",
+		},
+	},
+	{
+		Name:   "syslog",
+		Format: LogFormatUnstructured,
+		LogGenerator: func(_ string, _ time.Time, f *Faker) string {
+			return fmt.Sprintf(
+				`<%d>%s %s[%d]: %s`,
+				f.SyslogPriority(false), f.Hostname(), "systemd", f.PID(),
+				"Starting service...",
+			)
+		},
+		OTELResource: map[string]string{
+			"service_name": "system",
+			"hostname":     "${HOSTNAME}",
+			"os_type":      "linux",
+			"os_version":   "Ubuntu 22.04",
+		},
+	},
+	// New applications with logfmt and other formats
+	{
+		Name:   "mimir",
+		Format: LogFormatLogfmt,
+		LogGenerator: func(level string, ts time.Time, f *Faker) string {
+			// Logfmt format for Mimir
+			baseLogfmt := fmt.Sprintf(
+				`level=%s ts=%s caller=grpc_logging.go:%d msg="gRPC request" method=%s`,
+				level, ts.Format(time.RFC3339Nano), 50+f.rnd.Intn(100), f.GRPCMethod(),
+			)
+
+			// Sometimes add tenant ID
+			if f.rnd.Float32() < 0.7 {
+				baseLogfmt += fmt.Sprintf(` tenant=%s`, f.OrgID())
+			}
+
+			// Sometimes add duration
+			if f.rnd.Float32() < 0.8 {
+				baseLogfmt += fmt.Sprintf(` duration=%s`, f.Duration())
+			}
+
+			// Sometimes add trace info
+			if f.rnd.Float32() < 0.4 {
+				baseLogfmt += fmt.Sprintf(` trace_id=%s span_id=%s`, f.TraceID(), f.SpanID())
+			}
+
+			// Add metrics for some logs
+			if f.rnd.Float32() < 0.5 {
+				baseLogfmt += fmt.Sprintf(` streams=%d bytes=%d`, f.rnd.Intn(1000), f.rnd.Intn(10000000))
+			}
+
+			// Add size for some logs (e.g. uncompressed request size)
+			if f.rnd.Float32() < 0.5 {
+				baseLogfmt += fmt.Sprintf(` size=%d`, f.rnd.Intn(10000))
+			}
+
+			// Add error for error level logs
+			if level == errorLevel {
+				baseLogfmt += fmt.Sprintf(` error="failed to %s: %s"`, f.GRPCMethod(), f.ErrorMessage())
+			}
+
+			return baseLogfmt
+		},
+		OTELResource: map[string]string{
+			"service_name":    "mimir",
+			"service_version": "2.8.0",
+			"hostname":        "${HOSTNAME}",
+			"cluster":         "prod-metrics",
+		},
+	},
+	{
+		Name:   "loki",
+		Format: LogFormatLogfmt,
+		LogGenerator: func(level string, ts time.Time, f *Faker) string {
+			// Logfmt format for Loki
+			baseLogfmt := fmt.Sprintf(
+				`level=%s ts=%s caller=ingester.go:%d msg="ingester request" component=ingester`,
+				level, ts.Format(time.RFC3339Nano), 100+f.rnd.Intn(900),
+			)
+
+			// Sometimes add tenant ID
+			if f.rnd.Float32() < 0.7 {
+				baseLogfmt += fmt.Sprintf(` org_id=%s`, f.OrgID())
+			}
+
+			// Sometimes add duration
+			if f.rnd.Float32() < 0.6 {
+				baseLogfmt += fmt.Sprintf(` duration=%s`, f.Duration())
+			}
+
+			// Sometimes add trace info
+			if f.rnd.Float32() < 0.4 {
+				baseLogfmt += fmt.Sprintf(` trace_id=%s span_id=%s`, f.TraceID(), f.SpanID())
+			}
+
+			// Add metrics for some logs
+			if f.rnd.Float32() < 0.5 {
+				baseLogfmt += fmt.Sprintf(` streams=%d bytes=%d`, f.rnd.Intn(1000), f.rnd.Intn(10000000))
+			}
+
+			// Add size for some logs (e.g. uncompressed request size)
+			if f.rnd.Float32() < 0.5 {
+				baseLogfmt += fmt.Sprintf(` size=%d`, f.rnd.Intn(10000))
+			}
+
+			// Add error for error level logs
+			if level == errorLevel {
+				baseLogfmt += fmt.Sprintf(` error="failed to process request: %s"`, f.ErrorMessage())
+			}
+
+			// Add colliding field for some logs
+			if f.rnd.Float32() < 0.25 {
+				baseLogfmt += fmt.Sprintf(` service_name=loki-ingester-%d`, f.rnd.Intn(10))
+			}
+
+			return baseLogfmt
+		},
+		OTELResource: map[string]string{
+			"service_name":    "loki",
+			"service_version": "2.9.0",
+			"hostname":        "${HOSTNAME}",
+			"cluster":         "prod-logs",
+		},
+	},
+	{
+		Name:   "tempo",
+		Format: LogFormatLogfmt,
+		LogGenerator: func(level string, ts time.Time, f *Faker) string {
+			// Logfmt format for Tempo
+			baseLogfmt := fmt.Sprintf(
+				`level=%s ts=%s caller=distributor.go:%d msg="distributor request" component=distributor`,
+				level, ts.Format(time.RFC3339Nano), 100+f.rnd.Intn(900),
+			)
+
+			// Sometimes add tenant ID
+			if f.rnd.Float32() < 0.7 {
+				baseLogfmt += fmt.Sprintf(` org_id=%s`, f.OrgID())
+			}
+
+			// Sometimes add duration
+			if f.rnd.Float32() < 0.6 {
+				baseLogfmt += fmt.Sprintf(` duration=%s`, f.Duration())
+			}
+
+			// Sometimes add trace info
+			if f.rnd.Float32() < 0.8 {
+				baseLogfmt += fmt.Sprintf(` trace_id=%s span_id=%s`, f.TraceID(), f.SpanID())
+			}
+
+			// Add metrics for some logs
+			if f.rnd.Float32() < 0.5 {
+				baseLogfmt += fmt.Sprintf(` streams=%d bytes=%d`, f.rnd.Intn(1000), f.rnd.Intn(10000000))
+			}
+
+			// Add error for error level logs
+			if level == errorLevel {
+				baseLogfmt += fmt.Sprintf(` error="failed to process trace: %s"`, f.ErrorMessage())
+			}
+
+			// Add colliding field for some logs
+			if f.rnd.Float32() < 0.25 {
+				baseLogfmt += fmt.Sprintf(` service_name=tempo-distributor-%d`, f.rnd.Intn(10))
+			}
+
+			return baseLogfmt
+		},
+		OTELResource: map[string]string{
+			"service_name":    "tempo",
+			"service_version": "2.1.0",
+			"hostname":        "${HOSTNAME}",
+			"cluster":         "prod-traces",
+		},
+	},
+	{
+		Name:   "kubernetes",
+		Format: LogFormatUnstructured,
+		LogGenerator: func(level string, ts time.Time, f *Faker) string {
+			// Kubernetes log format (mix of structured and unstructured)
+			component := f.K8sComponent()
+			return fmt.Sprintf(
+				`%s %s [%s] %s: %s`,
+				ts.Format("2006-01-02T15:04:05.000000Z"), level, component,
+				f.K8sLogPrefix(), f.K8sMessage(),
+			)
+		},
+		OTELResource: map[string]string{
+			"service_name":    "kubernetes",
+			"service_version": "1.26.3",
+			"hostname":        "${HOSTNAME}",
+			"node_name":       "${HOSTNAME}",
+			"cluster":         "prod-k8s",
+		},
+	},
+	{
+		Name:   "prometheus",
+		Format: LogFormatJSON,
+		LogGenerator: func(level string, ts time.Time, f *Faker) string {
+			// JSON format with variations
+			baseJSON := fmt.Sprintf(
+				`{"level":"%s","ts":"%s","caller":"%s:%d","component":"%s","msg":"%s"`,
+				level, ts.Format(time.RFC3339Nano), f.PrometheusComponent(), 100+f.rnd.Intn(900),
+				f.PrometheusSubcomponent(), f.PrometheusMessage(),
+			)
+
+			// Sometimes add duration
+			if f.rnd.Float32() < 0.7 {
+				baseJSON += fmt.Sprintf(`,"duration":"%s"`, f.Duration())
+			}
+
+			// Sometimes add metrics
+			if f.rnd.Float32() < 0.5 {
+				baseJSON += fmt.Sprintf(`,"samples":%d,"series":%d`,
+					f.rnd.Intn(100000), f.rnd.Intn(10000))
+			}
+
+			// Add error for error level logs
+			if level == errorLevel {
+				baseJSON += fmt.Sprintf(`,"error":"%s"`, f.ErrorMessage())
+			}
+
+			return baseJSON + "}"
+		},
+		OTELResource: map[string]string{
+			"service_name":    "prometheus",
+			"service_version": "2.43.0",
+			"hostname":        "${HOSTNAME}",
+			"cluster":         "prod-monitoring",
+		},
+	},
+	{
+		Name:   "grafana",
+		Format: LogFormatLogfmt,
+		LogGenerator: func(level string, ts time.Time, f *Faker) string {
+			// Logfmt format for Grafana
+			baseLogfmt := fmt.Sprintf(
+				`level=%s ts=%s logger=%s caller=%s:%d msg="%s"`,
+				level, ts.Format(time.RFC3339Nano), f.GrafanaLogger(), f.GrafanaComponent(), 100+f.rnd.Intn(900),
+				f.GrafanaMessage(),
+			)
+
+			// Add user and org info
+			baseLogfmt += fmt.Sprintf(` userId=%d orgId=%s`, f.rnd.Intn(1000), f.OrgID())
+
+			// Sometimes add duration
+			if f.rnd.Float32() < 0.7 {
+				baseLogfmt += fmt.Sprintf(` duration=%s`, f.Duration())
+			}
+
+			// Sometimes add request info
+			if f.rnd.Float32() < 0.5 {
+				baseLogfmt += fmt.Sprintf(` method=%s path="%s" status=%d`,
+					f.Method(), f.Path(), f.Status())
+			}
+
+			// Add error for error level logs
+			if level == errorLevel {
+				baseLogfmt += fmt.Sprintf(` error="%s"`, f.ErrorMessage())
+			}
+
+			return baseLogfmt
+		},
+		OTELResource: map[string]string{
+			"service_name":    "grafana",
+			"service_version": "10.0.3",
+			"hostname":        "${HOSTNAME}",
+			"cluster":         "prod-dashboards",
+		},
+	},
+}

--- a/harness/loki-compatibility/upstream/loki-bench/generator.go
+++ b/harness/loki-compatibility/upstream/loki-bench/generator.go
@@ -1,0 +1,501 @@
+package bench
+
+import (
+	"encoding/json"
+	"fmt"
+	"iter"
+	"maps"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/grafana/loki/v3/pkg/logproto"
+)
+
+const (
+	DefaultDataDir = "./data"
+	configFileName = "generator.json"
+	errorLevel     = "error" // Constant for the error level string
+)
+
+// Batch represents a collection of log streams
+type Batch struct {
+	Streams []logproto.Stream
+}
+
+// Size of batch in bytes including all entries, labels and structured metadata.
+func (b Batch) Size() int {
+	var size int
+	for _, stream := range b.Streams {
+		size += len(stream.Labels)
+		for _, entry := range stream.Entries {
+			size += len(entry.Line)
+			for _, sm := range entry.StructuredMetadata {
+				size += len(sm.Name) + len(sm.Value)
+			}
+		}
+	}
+	return size
+}
+
+// LabelConfig configures the cardinality of generated labels
+type LabelConfig struct {
+	Clusters    int      // 1-10 clusters
+	Namespaces  int      // 10-100 namespaces
+	Services    int      // 100-1000 services
+	Pods        int      // 1000-10000 pods
+	Containers  int      // 1-5 containers per pod
+	LogLevels   []string // Log levels to use
+	EnvTypes    []string // Environment types
+	Regions     []string // Regions
+	Datacenters []string // Datacenters
+}
+
+// Default configuration with reasonable cardinality values
+var defaultLabelConfig = LabelConfig{
+	Clusters:    5,
+	Namespaces:  50,
+	Services:    200,
+	Pods:        5000,
+	Containers:  3,
+	LogLevels:   []string{"debug", "info", "warn", "error"},
+	EnvTypes:    []string{"prod", "staging", "dev"},
+	Regions:     []string{"us-east-1", "us-west-2", "eu-west-1", "ap-southeast-1"},
+	Datacenters: []string{"dc1", "dc2", "dc3"},
+}
+
+// GeneratorConfig contains all configuration for the log generator
+type GeneratorConfig struct {
+	StartTime  time.Time
+	TimeSpread time.Duration
+	// DenseIntervals defines periods of high log density
+	// Each interval will have 10x more logs than normal periods
+	DenseIntervals []DenseInterval
+	LabelConfig    LabelConfig
+	NumStreams     int   // Number of streams to generate per batch
+	Seed           int64 // Source of randomness
+}
+
+// DenseInterval represents a period of high log volume
+type DenseInterval struct {
+	Start    time.Time
+	Duration time.Duration
+}
+
+// Default generator configuration with sensible values
+var defaultGeneratorConfig = GeneratorConfig{
+	StartTime:   time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+	TimeSpread:  24 * time.Hour,
+	LabelConfig: defaultLabelConfig,
+	NumStreams:  250, // Default to 250 streams per batch
+	Seed:        1,   // Default to seed 1 for reproducibility
+	DenseIntervals: []DenseInterval{
+		{
+			Start:    time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC),
+			Duration: time.Hour,
+		},
+		{
+			Start:    time.Date(2024, 1, 1, 15, 0, 0, 0, time.UTC),
+			Duration: 30 * time.Minute,
+		},
+	},
+}
+
+// NewRand creates a new random source using the configured seed
+func (c *GeneratorConfig) NewRand() *rand.Rand {
+	return rand.New(rand.NewSource(c.Seed))
+}
+
+// StreamMetadata holds the consistent properties of a stream
+type StreamMetadata struct {
+	Labels  string
+	Service Service
+	Format  LogFormat // Log format for this stream
+	// MinRange is the minimum lookback range for range queries to capture multiple samples
+	MinRange time.Duration
+	// MinInstantRange is the minimum lookback range for instant queries to capture logs at a single sampling point
+	MinInstantRange time.Duration
+}
+
+// Generator represents a log generator with configuration
+type Generator struct {
+	config      GeneratorConfig
+	rnd         *rand.Rand
+	StreamsMeta []StreamMetadata   // Pre-generated stream metadata used across batches
+	services    map[string]Service // Map of available applications by name
+}
+
+// Opt represents configuration options for the generator
+type Opt struct {
+	startTime      time.Time
+	timeSpread     time.Duration
+	denseIntervals []DenseInterval
+	labelConfig    LabelConfig
+	numStreams     int   // Number of streams to generate per batch
+	seed           int64 // Source of randomness
+}
+
+// WithStartTime sets the start time for log generation
+func (o Opt) WithStartTime(t time.Time) Opt {
+	o.startTime = t
+	return o
+}
+
+// WithTimeSpread sets the time spread for log generation
+func (o Opt) WithTimeSpread(d time.Duration) Opt {
+	o.timeSpread = d
+	return o
+}
+
+// WithDenseInterval adds a dense interval to the configuration
+func (o Opt) WithDenseInterval(start time.Time, duration time.Duration) Opt {
+	o.denseIntervals = append(o.denseIntervals, DenseInterval{
+		Start:    start,
+		Duration: duration,
+	})
+	return o
+}
+
+// WithLabelCardinality configures the cardinality of different labels
+func (o Opt) WithLabelCardinality(clusters, namespaces, services, pods, containers int) Opt {
+	o.labelConfig.Clusters = clusters
+	o.labelConfig.Namespaces = namespaces
+	o.labelConfig.Services = services
+	o.labelConfig.Pods = pods
+	o.labelConfig.Containers = containers
+	return o
+}
+
+// WithLabelConfig sets the entire label configuration
+func (o Opt) WithLabelConfig(cfg LabelConfig) Opt {
+	o.labelConfig = cfg
+	return o
+}
+
+// WithNumStreams sets the number of streams to generate per batch
+func (o Opt) WithNumStreams(n int) Opt {
+	o.numStreams = n
+	return o
+}
+
+// WithSeed sets the seed for random number generation
+func (o Opt) WithSeed(seed int64) Opt {
+	o.seed = seed
+	return o
+}
+
+// DefaultOpt returns the default options
+func DefaultOpt() Opt {
+	return Opt{
+		startTime:      defaultGeneratorConfig.StartTime,
+		timeSpread:     defaultGeneratorConfig.TimeSpread,
+		denseIntervals: defaultGeneratorConfig.DenseIntervals,
+		labelConfig:    defaultGeneratorConfig.LabelConfig,
+		numStreams:     defaultGeneratorConfig.NumStreams,
+		seed:           1, // Default to seed 1 for reproducibility
+	}
+}
+
+// NewGenerator creates a new generator with the given options
+func NewGenerator(opt Opt) *Generator {
+	g := &Generator{
+		config: GeneratorConfig{
+			StartTime:      opt.startTime,
+			TimeSpread:     opt.timeSpread,
+			DenseIntervals: opt.denseIntervals,
+			LabelConfig:    opt.labelConfig,
+			NumStreams:     opt.numStreams,
+			Seed:           opt.seed,
+		},
+		rnd:      rand.New(rand.NewSource(opt.seed)),
+		services: make(map[string]Service),
+	}
+
+	// Initialize available applications
+	for _, app := range defaultApplications {
+		g.services[app.Name] = app
+	}
+
+	return g
+}
+
+// generateStreamMetadata pre-generates metadata for all streams
+func (g *Generator) generateStreamMetadata() {
+	numStreams := g.config.NumStreams
+	if numStreams == 0 {
+		numStreams = defaultGeneratorConfig.NumStreams
+	}
+
+	g.StreamsMeta = make([]StreamMetadata, numStreams)
+
+	minRange, minInstantRange := CalculateMinRanges(&g.config)
+
+	// Create slice of available app names for random selection
+	var appNames []string
+	for name := range g.services {
+		appNames = append(appNames, name)
+	}
+
+	// Sort app names for deterministic selection
+	sort.Strings(appNames)
+
+	// For each stream, generate consistent metadata
+	for i := 0; i < numStreams; i++ {
+		// Pick a deterministic application based on stream index
+		appIndex := i % len(g.services)
+		appName := appNames[appIndex]
+		app := g.services[appName]
+
+		// Generate deterministic labels for this stream
+		cluster := fmt.Sprintf("cluster-%d", g.rnd.Intn(g.config.LabelConfig.Clusters))
+		namespace := fmt.Sprintf("namespace-%d", g.rnd.Intn(g.config.LabelConfig.Namespaces))
+		service := fmt.Sprintf("service-%d", g.rnd.Intn(g.config.LabelConfig.Services))
+		pod := fmt.Sprintf("pod-%d", g.rnd.Intn(g.config.LabelConfig.Pods))
+		container := fmt.Sprintf("container-%d", g.rnd.Intn(g.config.LabelConfig.Containers))
+		env := g.config.LabelConfig.EnvTypes[g.rnd.Intn(len(g.config.LabelConfig.EnvTypes))]
+		region := g.config.LabelConfig.Regions[g.rnd.Intn(len(g.config.LabelConfig.Regions))]
+		dc := g.config.LabelConfig.Datacenters[g.rnd.Intn(len(g.config.LabelConfig.Datacenters))]
+
+		// Build Loki label string
+		labels := fmt.Sprintf(
+			`{cluster="%s", namespace="%s", service="%s", pod="%s", container="%s", env="%s", region="%s", datacenter="%s", service_name="%s"}`,
+			cluster, namespace, service, pod, container, env, region, dc, app.Name,
+		)
+
+		g.StreamsMeta[i] = StreamMetadata{
+			Labels:          labels,
+			Service:         app,
+			Format:          app.Format,
+			MinRange:        minRange,
+			MinInstantRange: minInstantRange,
+		}
+	}
+}
+
+// Batches returns an iterator that produces log batches
+// Each batch contains the configured number of streams with generated log entries
+func (g *Generator) Batches() iter.Seq[*Batch] {
+	// Pre-generate stream metadata once
+	g.generateStreamMetadata()
+
+	return func(yield func(*Batch) bool) {
+		for {
+			// Generate streams for this batch using the same metadata but new entries
+			streams := make([]logproto.Stream, len(g.StreamsMeta))
+			for j := range streams {
+				meta := g.StreamsMeta[j]
+
+				// Generate entries specific to this stream's application and format
+				entries := g.generateEntriesForStream(meta)
+
+				streams[j] = logproto.Stream{
+					Labels:  meta.Labels,
+					Entries: entries,
+				}
+			}
+
+			if !yield(&Batch{Streams: streams}) {
+				return
+			}
+		}
+	}
+}
+
+// generateEntriesForStream creates log entries for a specific stream
+// using the application and format from the stream metadata
+func (g *Generator) generateEntriesForStream(meta StreamMetadata) []logproto.Entry {
+	app := meta.Service
+	faker := NewFaker(g.rnd)
+
+	// Calculate how many entries to generate based on time spread
+	baseEntries := 10 + g.rnd.Intn(90) // 10-100 entries per stream
+	entries := make([]logproto.Entry, 0, baseEntries)
+
+	// Generate timestamps spread across the time range
+	spreadInterval := g.config.TimeSpread / time.Duration(baseEntries)
+
+	// Prepare OTEL attributes for this stream
+	otel := OTELAttributes{
+		Resource: make(map[string]string),
+	}
+
+	// Copy resource attributes from the application
+	maps.Copy(otel.Resource, app.OTELResource)
+
+	// Sort keys for deterministic iteration order
+	var templateKeys []string
+	for k, v := range otel.Resource {
+		if strings.HasPrefix(v, "${") && strings.HasSuffix(v, "}") {
+			templateKeys = append(templateKeys, k)
+		}
+	}
+	sort.Strings(templateKeys)
+
+	// Replace template variables in deterministic order
+	for _, k := range templateKeys {
+		v := otel.Resource[k]
+		switch v {
+		case "${HOSTNAME}":
+			otel.Resource[k] = faker.Hostname()
+		case "${BROKER_ID}":
+			otel.Resource[k] = fmt.Sprintf("%d", g.rnd.Intn(10))
+		}
+	}
+
+	// Generate entries with timestamps spread across the configured time range
+	for i := range baseEntries {
+		ts := g.config.StartTime.Add(time.Duration(i) * spreadInterval)
+
+		// Check if timestamp falls in a dense interval
+		isDense := false
+		for _, interval := range g.config.DenseIntervals {
+			if ts.After(interval.Start) && ts.Before(interval.Start.Add(interval.Duration)) {
+				isDense = true
+				break
+			}
+		}
+
+		// Generate more entries during dense intervals
+		numEntries := 1
+		if isDense {
+			numEntries = 10 // 10x more logs during dense periods
+		}
+
+		for range numEntries {
+			// Add small jitter within spread interval
+			jitter := time.Duration(g.rnd.Int63n(int64(spreadInterval)))
+			entryTs := ts.Add(jitter)
+
+			// Randomly select log level for this entry, biased towards the stream's default level
+			level := g.config.LabelConfig.LogLevels[g.rnd.Intn(len(g.config.LabelConfig.LogLevels))]
+
+			// Generate trace context for some entries (about 30%)
+			var traceCtx *OTELTraceContext
+			if g.rnd.Float32() < 0.3 {
+				traceCtx = &OTELTraceContext{
+					TraceID: faker.TraceID(),
+					SpanID:  faker.SpanID(),
+				}
+			}
+
+			line := ""
+			// Leave 3% of logs lines empty
+			if g.rnd.Float32() > 0.03 {
+				// Generate log line using the application's generators for the selected format
+				line = app.LogGenerator(level, entryTs, faker)
+			}
+
+			// Create metadata in a deterministic order
+			var metadata []logproto.LabelAdapter
+
+			metadata = append(metadata,
+				logproto.LabelAdapter{Name: "level", Value: level},
+				logproto.LabelAdapter{Name: "detected_level", Value: level},
+			)
+
+			// Then add resource attributes in sorted order
+			var resourceKeys []string
+			for k := range otel.Resource {
+				resourceKeys = append(resourceKeys, k)
+			}
+			sort.Strings(resourceKeys)
+			for _, k := range resourceKeys {
+				metadata = append(metadata, logproto.LabelAdapter{
+					Name:  "resource_" + k,
+					Value: otel.Resource[k],
+				})
+			}
+
+			// Generate colliding structured metadata keys
+			if g.rnd.Float32() < 0.1 && len(otel.Resource) > 0 {
+				g.rnd.Shuffle(len(resourceKeys), func(i, j int) { resourceKeys[i], resourceKeys[j] = resourceKeys[j], resourceKeys[i] })
+				metadata = append(metadata,
+					logproto.LabelAdapter{Name: resourceKeys[0], Value: app.OTELResource[resourceKeys[0]]},
+				)
+			}
+
+			// Finally add trace context if present
+			if traceCtx != nil {
+				metadata = append(metadata,
+					logproto.LabelAdapter{Name: "trace_id", Value: traceCtx.TraceID},
+					logproto.LabelAdapter{Name: "span_id", Value: traceCtx.SpanID},
+				)
+			}
+
+			entries = append(entries, logproto.Entry{
+				Timestamp:          entryTs,
+				Line:               line,
+				StructuredMetadata: metadata,
+			})
+		}
+	}
+
+	return entries
+}
+
+// GenerateDataset generates a dataset of approximately the specified size
+func (g *Generator) GenerateDataset(targetSize int64, outputFile string) error {
+	var totalSize int64
+	streams := make([]logproto.Stream, 0, g.config.NumStreams)
+
+	for batch := range g.Batches() {
+		batchSize := int64(batch.Size())
+		streams = append(streams, batch.Streams...)
+		totalSize += batchSize
+		if totalSize >= targetSize {
+			break
+		}
+	}
+
+	req := logproto.PushRequest{Streams: streams}
+	data, err := req.Marshal()
+	if err != nil {
+		return fmt.Errorf("failed to marshal dataset: %w", err)
+	}
+
+	return os.WriteFile(outputFile, data, 0o644)
+}
+
+// OTELAttributes represents OpenTelemetry attributes for logs
+type OTELAttributes struct {
+	Resource map[string]string // Resource attributes constant for the service
+	Trace    *OTELTraceContext // Optional trace context
+}
+
+// OTELTraceContext represents OpenTelemetry trace context
+type OTELTraceContext struct {
+	TraceID string
+	SpanID  string
+}
+
+// SaveConfig saves the generator configuration to a file in the data directory
+func SaveConfig(dataDir string, config *GeneratorConfig) error {
+	configPath := filepath.Join(dataDir, configFileName)
+	configData, err := json.Marshal(config)
+	if err != nil {
+		return fmt.Errorf("failed to marshal generator config: %w", err)
+	}
+	if err := os.WriteFile(configPath, configData, 0o644); err != nil {
+		return fmt.Errorf("failed to write generator config: %w", err)
+	}
+	return nil
+}
+
+// LoadConfig loads the generator configuration from the data directory
+func LoadConfig(dataDir string) (*GeneratorConfig, error) {
+	configPath := filepath.Join(dataDir, configFileName)
+	configData, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read generator config: %w", err)
+	}
+
+	var config GeneratorConfig
+	if err := json.Unmarshal(configData, &config); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal generator config: %w", err)
+	}
+
+	return &config, nil
+}

--- a/harness/loki-compatibility/upstream/loki-bench/metadata.go
+++ b/harness/loki-compatibility/upstream/loki-bench/metadata.go
@@ -1,0 +1,467 @@
+package bench
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/prometheus/prometheus/model/labels"
+	promql_parser "github.com/prometheus/prometheus/promql/parser"
+)
+
+const (
+	metadataFileName = "dataset_metadata.json"
+	// MetadataVersion is the current version of the dataset metadata format.
+	// It is exported so that callers outside the bench package (e.g. the
+	// discover pipeline) can validate or set the version field without
+	// needing a separate accessor function.
+	MetadataVersion = "1.0"
+
+	// Application names used in metadata processing
+	appDatabase = "database"
+	appLoki     = "loki"
+)
+
+// Bounded sets: characteristics common to all datasets
+// These define the set of possible queries and drive targeted series API queries
+// during stream discovery. Each exported variable corresponds to a discovery
+// query dimension used by the discover CLI.
+var (
+	// UnwrappableFields are numeric fields that can be used with | unwrap in
+	// metric queries. The discover tool issues series queries for each field to
+	// find streams that expose these values.
+	UnwrappableFields = []string{
+		"bytes",
+		"duration",
+		"duration_ms",
+		"offset",
+		"partition",
+		"rows_affected",
+		"size",
+		"spans",
+		"status",
+		"streams",
+		"ttl",
+	}
+
+	// FilterableKeywords are literal strings commonly appearing in log content.
+	// Used for line filter queries like |= "level" or |~ "error". The discover
+	// tool tests keyword presence per stream to populate ByKeyword in the output
+	// metadata.
+	FilterableKeywords = []string{
+		"debug",
+		"duration",
+		"error",
+		"failed",
+		"level",
+		"refused",
+	}
+
+	// StructuredMetadataKeys are keys that appear as structured metadata
+	// attached to log entries (not as stream labels). The discover tool uses
+	// detected_fields responses to find streams that carry these keys.
+	// Note: detected_level lives here (not in LabelKeys) because it is
+	// injected by Loki as structured metadata, not as an indexed stream label.
+	StructuredMetadataKeys = []string{
+		"detected_level",
+		"pod",
+	}
+
+	// LabelKeys are indexed stream labels used for selectors and grouping
+	// (by/without). The discover tool issues one series query per key with
+	// matcher {key=~".+"} to enumerate streams.
+	LabelKeys = []string{
+		"cluster",
+		"container",
+		"level",
+		"namespace",
+		"pod",
+		"service_name",
+	}
+)
+
+// SerializableStreamMetadata contains only the fields needed for query resolution
+// This is a subset of StreamMetadata that can be safely serialized to JSON
+type SerializableStreamMetadata struct {
+	MinRange        time.Duration `json:"min_range"`
+	MinInstantRange time.Duration `json:"min_instant_range"`
+}
+
+// DatasetMetadata contains queryable information about a generated dataset
+// It maps query properties to stream/label patterns
+type DatasetMetadata struct {
+	AllSelectors  []string               `json:"all_selectors"`
+	ByFormat      map[LogFormat][]string `json:"by_format"`
+	ByServiceName map[string][]string    `json:"by_service_name"`
+	Statistics    DatasetStatistics      `json:"statistics"`
+	TimeRange     TimeRange              `json:"time_range"`
+	Version       string                 `json:"version"`
+
+	ByUnwrappableField   map[string][]string                    `json:"by_unwrappable_field"`   // field name -> selectors with that field
+	ByDetectedField      map[string][]string                    `json:"by_detected_field"`      // parsable field -> selectors with that field
+	ByStructuredMetadata map[string][]string                    `json:"by_structured_metadata"` // metadata key -> selectors with that key
+	ByLabelKey           map[string][]string                    `json:"by_label_key"`           // label name -> selectors with that label
+	ByKeyword            map[string][]string                    `json:"by_keyword"`             // keyword -> selectors containing that keyword
+	MetadataBySelector   map[string]*SerializableStreamMetadata `json:"metadata_by_selector"`   // selector -> stream metadata for range resolution
+}
+
+// TimeRange represents the temporal bounds of a dataset
+type TimeRange struct {
+	Start time.Time `json:"start"`
+	End   time.Time `json:"end"`
+}
+
+// DatasetStatistics provides aggregate information about the dataset
+type DatasetStatistics struct {
+	Generated        time.Time         `json:"generated"`
+	StreamsByFormat  map[LogFormat]int `json:"streams_by_format"`
+	StreamsByService map[string]int    `json:"streams_by_service"`
+	TotalStreams     int               `json:"total_streams"`
+}
+
+// CalculateMinRanges computes the minimum range durations needed for range and instant queries
+// based on the log generation rate for a stream.
+//
+// MinRange: For range queries that sample multiple points over time
+// - Formula: time needed for 5 samples (with 10-100 logs per sample)
+//
+// MinInstantRange: For instant queries that sample at a single point in time
+// - Formula: time needed for 10 logs (to ensure capture at single sampling point)
+//
+// TODO: This function is specific to the generated data.
+// We will need to expand on this concept when parsing real datasets.
+// For the generated data, the algorithm is based on the following:
+// - baseEntries: 10-100 entries per stream (average ~55)
+// - timeSpread: configured time span over which logs are distributed
+// - logRate: baseEntries / timeSpread (logs per second)
+func CalculateMinRanges(config *GeneratorConfig) (minRange, minInstantRange time.Duration) {
+	// Calculate average log generation rate
+	// baseEntries averages to ~55 logs per stream over the timeSpread
+	avgBaseEntries := 55.0
+	logRatePerSecond := avgBaseEntries / config.TimeSpread.Seconds()
+
+	// MinRange: time needed for 5 logs (conservative for range queries with multiple samples)
+	if logRatePerSecond > 0 {
+		minRange = time.Duration(5.0 / logRatePerSecond * float64(time.Second))
+		minRange = minRange.Round(time.Second) // Round to whole seconds for valid LogQL ranges
+	}
+
+	// Apply minimum and maximum thresholds for MinRange
+	if minRange < 1*time.Minute {
+		minRange = 1 * time.Minute
+	}
+	if minRange > 15*time.Minute {
+		minRange = 15 * time.Minute
+	}
+
+	// MinInstantRange: time needed for 10 logs (instant query needs more lookback)
+	if logRatePerSecond > 0 {
+		minInstantRange = time.Duration(10.0 / logRatePerSecond * float64(time.Second))
+		minInstantRange = minInstantRange.Round(time.Second) // Round to whole seconds for valid LogQL ranges
+	}
+
+	// Apply minimum and maximum thresholds for MinInstantRange
+	if minInstantRange < 1*time.Minute {
+		minInstantRange = 1 * time.Minute
+	}
+	if minInstantRange > 30*time.Minute {
+		minInstantRange = 30 * time.Minute
+	}
+
+	return minRange, minInstantRange
+}
+
+// BuildMetadata constructs dataset metadata from stream metadata
+// This is called during data generation to create the metadata file
+//
+// NOTE: Currently uses helper functions (getUnwrappableFields, etc.) that hardcode
+// application knowledge. This is a temporary approach for synthetic datasets.
+// See TODO comments on helper functions for refactoring plan to support real datasets.
+func BuildMetadata(config *GeneratorConfig, streamsMeta []StreamMetadata) *DatasetMetadata {
+	metadata := &DatasetMetadata{
+		AllSelectors:  make([]string, 0, len(streamsMeta)),
+		ByFormat:      make(map[LogFormat][]string),
+		ByServiceName: make(map[string][]string),
+		Version:       MetadataVersion,
+
+		ByUnwrappableField:   make(map[string][]string),
+		ByDetectedField:      make(map[string][]string),
+		ByStructuredMetadata: make(map[string][]string),
+		ByLabelKey:           make(map[string][]string),
+		ByKeyword:            make(map[string][]string),
+		MetadataBySelector:   make(map[string]*SerializableStreamMetadata),
+
+		Statistics: DatasetStatistics{
+			TotalStreams:     len(streamsMeta),
+			StreamsByFormat:  make(map[LogFormat]int),
+			StreamsByService: make(map[string]int),
+			Generated:        time.Now(),
+		},
+	}
+
+	metadata.TimeRange = TimeRange{
+		Start: config.StartTime,
+		End:   config.StartTime.Add(config.TimeSpread),
+	}
+
+	// Build indexes from stream metadata
+	for _, stream := range streamsMeta {
+		selector := stream.Labels
+
+		metadata.AllSelectors = append(metadata.AllSelectors, selector)
+		metadata.ByFormat[stream.Format] = append(metadata.ByFormat[stream.Format], selector)
+		metadata.ByServiceName[stream.Service.Name] = append(metadata.ByServiceName[stream.Service.Name], selector)
+		metadata.Statistics.StreamsByFormat[stream.Format]++
+		metadata.Statistics.StreamsByService[stream.Service.Name]++
+
+		// Store stream metadata by selector for range resolution
+		metadata.MetadataBySelector[selector] = &SerializableStreamMetadata{
+			MinRange:        stream.MinRange,
+			MinInstantRange: stream.MinInstantRange,
+		}
+
+		fields := getUnwrappableFields(stream.Service.Name)
+		for _, field := range fields {
+			metadata.ByUnwrappableField[field] = append(metadata.ByUnwrappableField[field], selector)
+		}
+
+		detectedFields := getDetectedFields(stream.Service.Name, stream.Format)
+		for _, field := range detectedFields {
+			metadata.ByDetectedField[field] = append(metadata.ByDetectedField[field], selector)
+		}
+
+		structuredMetadata := getStructuredMetadataKeys(stream.Service.Name)
+		for _, key := range structuredMetadata {
+			metadata.ByStructuredMetadata[key] = append(metadata.ByStructuredMetadata[key], selector)
+		}
+
+		keywords := getContentKeywords(stream.Service.Name)
+		for _, keyword := range keywords {
+			metadata.ByKeyword[keyword] = append(metadata.ByKeyword[keyword], selector)
+		}
+
+		lbls, err := promql_parser.NewParser(promql_parser.Options{}).ParseMetric(selector)
+		if err != nil {
+			continue // Skip this stream if we can't parse labels
+		}
+
+		lbls.Range(func(label labels.Label) {
+			metadata.ByLabelKey[label.Name] = append(metadata.ByLabelKey[label.Name], selector)
+		})
+	}
+
+	// Sort all selector arrays for determinism
+	sort.Strings(metadata.AllSelectors)
+	for format := range metadata.ByFormat {
+		sort.Strings(metadata.ByFormat[format])
+	}
+	for app := range metadata.ByServiceName {
+		sort.Strings(metadata.ByServiceName[app])
+	}
+
+	for field := range metadata.ByUnwrappableField {
+		sort.Strings(metadata.ByUnwrappableField[field])
+	}
+	for field := range metadata.ByDetectedField {
+		sort.Strings(metadata.ByDetectedField[field])
+	}
+	for key := range metadata.ByStructuredMetadata {
+		sort.Strings(metadata.ByStructuredMetadata[key])
+	}
+	for label := range metadata.ByLabelKey {
+		sort.Strings(metadata.ByLabelKey[label])
+	}
+	for keyword := range metadata.ByKeyword {
+		sort.Strings(metadata.ByKeyword[keyword])
+	}
+
+	return metadata
+}
+
+// TODO: These helper functions violate separation of concerns.
+// The generator knows about applications, not the metadata builder.
+// For synthetic datasets, this information should be passed from generator to BuildMetadata.
+// For real datasets (future use case), this would need to be computed by analyzing actual log data.
+// Consider refactoring to:
+//   1. Add fields to StreamMetadata: UnwrappableFields, StructuredMetadataKeys, Keywords
+//   2. Generator populates these fields when creating StreamMetadata
+//   3. BuildMetadata just indexes what's provided, doesn't need application knowledge
+//   4. For real datasets, create a separate analysis tool that populates these fields
+
+// getUnwrappableFields returns the numeric fields available for unwrap based on application name
+func getUnwrappableFields(appName string) []string {
+	switch appName {
+	case appDatabase:
+		return []string{"duration_ms", "rows_affected"}
+	case "web-server":
+		return []string{"status", "duration_ms"}
+	case "cache":
+		return []string{"size", "ttl", "duration"}
+	case "kafka":
+		return []string{"partition", "offset", "size"}
+	case appLoki, "mimir":
+		return []string{"duration", "size", "streams", "bytes"}
+	case "tempo":
+		return []string{"duration", "spans", "bytes"}
+	case "grafana":
+		return []string{"duration", "status"}
+	default:
+		// Unknown application - return empty set
+		return []string{}
+	}
+}
+
+// getStructuredMetadataKeys returns the structured metadata keys for an application
+func getStructuredMetadataKeys(appName string) []string {
+	// For now, all applications have detected_level as structured metadata
+	keys := []string{"detected_level"}
+
+	switch appName {
+	case appLoki, "mimir", "tempo", "grafana":
+		keys = append(keys, "trace_id", "span_id")
+	}
+
+	return keys
+}
+
+// getDetectedFields returns fields that can be parsed/extracted from log content
+// These fields are used in aggregations (sum by (level)) or filters (| level="error")
+func getDetectedFields(appName string, format LogFormat) []string {
+	switch format {
+	case LogFormatJSON:
+		// JSON format - fields are parsed via | json
+		switch appName {
+		case "web-server", appDatabase, "cache", "auth-service", "kafka", "prometheus":
+			return []string{"level", "error", "msg"}
+		case "kubernetes":
+			// Kubernetes uses plain text format, not JSON
+			return []string{}
+		default:
+			return []string{}
+		}
+	case LogFormatLogfmt:
+		// Logfmt format - fields are parsed via | logfmt
+		switch appName {
+		case appLoki, "mimir", "tempo", "grafana":
+			return []string{"level", "error", "msg", "query_type"}
+		default:
+			return []string{}
+		}
+	case LogFormatUnstructured:
+		// Unstructured format - can't reliably parse structured fields
+		return []string{}
+	default:
+		return []string{}
+	}
+}
+
+// getContentKeywords returns keywords that appear in log content for an application
+// These are literal strings that appear in the log text and can be used with line filters (|=, |~)
+// Only returns keywords that are in the FilterableKeywords bounded set
+func getContentKeywords(appName string) []string {
+	switch appName {
+	case "web-server":
+		// JSON: {"level":"...","error":"...","status":...,"duration":...,"msg":"HTTP request",...}
+		return []string{"level", "error", "status", "duration"}
+	case appDatabase:
+		// JSON: {"level":"...","error":"...","msg":"Query executed","duration":...,"rows_affected":...,...}
+		// Error messages include "Connection refused"
+		return []string{"level", "error", "duration", "query", "refused"}
+	case "cache":
+		// JSON: {"level":"...","error":"...","msg":"Cache operation","size":...,"ttl":...,...}
+		// Error messages include "Connection refused"
+		return []string{"level", "error", "duration", "refused"}
+	case "auth-service":
+		// JSON: {"level":"...","error":"...","msg":"Authentication request","duration":"...","success":...,...}
+		return []string{"level", "error", "duration", "success"}
+	case "kafka":
+		// JSON: {"level":"...","error":"...","msg":"Kafka event","topic":"...","size":...,...}
+		// Error messages include "Topic authorization failed"
+		return []string{"level", "error", "failed"}
+	case "prometheus":
+		// JSON: {"level":"...","error":"...","component":"...","msg":"...","duration":"...",...}
+		return []string{"level", "error", "duration"}
+	case "kubernetes":
+		// Plain text: "2006-01-02T15:04:05.000000Z info [component] prefix: message"
+		// Note: The word "level" does NOT appear - only the level values (info, error, warn, debug)
+		return []string{"INFO", "ERROR", "WARN", "DEBUG", "info", "error", "warn", "debug"}
+	case "mimir":
+		// Logfmt: level=... msg=... error=... duration=...
+		// Error format: error="failed to METHOD: message"
+		return []string{"level", "error", "duration", "failed"}
+	case appLoki:
+		// Logfmt: level=... msg=... error=... duration=... streams=... bytes=...
+		// Error format: error="failed to process request: message"
+		return []string{"level", "error", "duration", "failed"}
+	case "tempo":
+		// Logfmt: level=... msg=... error=... duration=... spans=... bytes=...
+		// Error format: error="failed to process trace: message"
+		return []string{"level", "error", "duration", "failed"}
+	case "grafana":
+		// Logfmt: level=... msg=... error=... duration=... status=... method=...
+		return []string{"level", "error", "duration", "status"}
+	case "nginx":
+		// Unstructured: "IP - user [timestamp] "METHOD /path HTTP/1.1" status size "referer" "user_agent""
+		return []string{"status"}
+	case "syslog":
+		// Unstructured: "<priority>hostname systemd[pid]: message"
+		return []string{}
+	default:
+		// Unknown application - return empty set to be conservative
+		return []string{}
+	}
+}
+
+// SaveMetadata writes metadata to a JSON file in the specified directory
+func SaveMetadata(dataDir string, metadata *DatasetMetadata) error {
+	metadataPath := filepath.Join(dataDir, metadataFileName)
+	data, err := json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal metadata: %w", err)
+	}
+
+	if err := os.WriteFile(metadataPath, data, 0o644); err != nil {
+		return fmt.Errorf("failed to write metadata file: %w", err)
+	}
+
+	return nil
+}
+
+// LoadMetadata reads metadata from a JSON file in the specified directory
+func LoadMetadata(dataDir string) (*DatasetMetadata, error) {
+	metadataPath := filepath.Join(dataDir, metadataFileName)
+	data, err := os.ReadFile(metadataPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read metadata file: %w", err)
+	}
+
+	var metadata DatasetMetadata
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		return nil, fmt.Errorf("failed to parse metadata: %w", err)
+	}
+
+	// Validate version
+	if metadata.Version != MetadataVersion {
+		return nil, fmt.Errorf("unsupported metadata version %q (expected %q)", metadata.Version, MetadataVersion)
+	}
+
+	return &metadata, nil
+}
+
+// GenerateInMemoryMetadata creates metadata in memory without file I/O
+// This is useful for tests that need metadata but don't want to generate a full dataset
+func GenerateInMemoryMetadata(config *GeneratorConfig) *DatasetMetadata {
+	opt := DefaultOpt().
+		WithStartTime(config.StartTime).
+		WithTimeSpread(config.TimeSpread).
+		WithLabelConfig(config.LabelConfig).
+		WithNumStreams(config.NumStreams).
+		WithSeed(config.Seed)
+
+	gen := NewGenerator(opt)
+	gen.generateStreamMetadata() // Generate stream metadata in memory
+	return BuildMetadata(config, gen.StreamsMeta)
+}

--- a/harness/loki-compatibility/upstream/loki-bench/metadata_resolver.go
+++ b/harness/loki-compatibility/upstream/loki-bench/metadata_resolver.go
@@ -1,0 +1,315 @@
+package bench
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"time"
+
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+)
+
+const (
+	// Variable placeholders
+	placeholderSelector   = "${SELECTOR}"
+	placeholderLabelName  = "${LABEL_NAME}"
+	placeholderLabelValue = "${LABEL_VALUE}"
+	placeholderRange      = "${RANGE}"
+)
+
+// MetadataVariableResolver resolves variables based on dataset metadata
+// It uses multi-dimensional filtering to ensure queries match compatible streams
+type MetadataVariableResolver struct {
+	metadata *DatasetMetadata
+	rnd      *rand.Rand
+}
+
+// NewMetadataVariableResolver creates a new resolver from dataset metadata
+func NewMetadataVariableResolver(metadata *DatasetMetadata, seed int64) *MetadataVariableResolver {
+	return &MetadataVariableResolver{
+		metadata: metadata,
+		rnd:      rand.New(rand.NewSource(seed)),
+	}
+}
+
+// ResolveQuery resolves variables in a query based on requirements
+// Supports: ${SELECTOR}, ${LABEL_NAME}, ${LABEL_VALUE}, ${RANGE}
+// The isInstant parameter determines whether to use MinInstantRange (true) or MinRange (false) for ${RANGE}
+func (r *MetadataVariableResolver) ResolveQuery(query string, requirements QueryRequirements, isInstant bool) (string, error) {
+	result := query
+	var selector string
+
+	// Resolve ${SELECTOR} if present
+	if strings.Contains(result, placeholderSelector) {
+		// When the query also contains ${RANGE}, pre-filter candidates to
+		// streams that have a valid range duration. This prevents selecting
+		// a stream with zero MinRange that would cause ${RANGE} resolution
+		// to fail later.
+		needsRange := strings.Contains(query, placeholderRange)
+		var err error
+		selector, err = r.resolveLabelSelector(requirements, needsRange, isInstant)
+		if err != nil {
+			return "", fmt.Errorf("failed to resolve ${SELECTOR}: %w", err)
+		}
+		result = strings.ReplaceAll(result, placeholderSelector, selector)
+	}
+
+	// Resolve ${LABEL_NAME} and ${LABEL_VALUE} if present
+	if strings.Contains(result, placeholderLabelName) || strings.Contains(result, placeholderLabelValue) {
+		// ${LABEL_NAME} and ${LABEL_VALUE} require ${SELECTOR} to be present
+		// because we need to extract a label from the resolved selector
+		if selector == "" {
+			return "", fmt.Errorf("${LABEL_NAME} and ${LABEL_VALUE} require ${SELECTOR} to be present in the query")
+		}
+
+		labelName, labelValue, err := r.extractLabelFromSelector(selector, requirements)
+		if err != nil {
+			return "", fmt.Errorf("failed to extract label from selector: %w", err)
+		}
+
+		result = strings.ReplaceAll(result, placeholderLabelName, labelName)
+		result = strings.ReplaceAll(result, placeholderLabelValue, labelValue)
+	}
+
+	// Resolve ${RANGE} if present
+	if strings.Contains(result, placeholderRange) {
+		rangeValue, err := r.resolveRange(selector, isInstant)
+		if err != nil {
+			return "", fmt.Errorf("failed to resolve ${RANGE}: %w", err)
+		}
+		result = strings.ReplaceAll(result, placeholderRange, rangeValue)
+	}
+
+	return result, nil
+}
+
+// resolveLabelSelector filters streams by all requirements and returns a random selector.
+// When needsRange is true, candidates are additionally filtered to streams that
+// have valid range metadata (MinRange > 0 for range queries, MinInstantRange > 0
+// for instant queries).
+func (r *MetadataVariableResolver) resolveLabelSelector(req QueryRequirements, needsRange bool, isInstant bool) (string, error) {
+	candidates := r.metadata.AllSelectors
+
+	if req.LogFormat != "" {
+		format := LogFormat(req.LogFormat)
+		candidates = intersect(candidates, r.metadata.ByFormat[format])
+		if len(candidates) == 0 {
+			return "", fmt.Errorf("no streams with log format: %s", req.LogFormat)
+		}
+	}
+
+	for _, field := range req.UnwrappableFields {
+		candidates = intersect(candidates, r.metadata.ByUnwrappableField[field])
+		if len(candidates) == 0 {
+			return "", fmt.Errorf("no streams with unwrappable field: %s", field)
+		}
+	}
+
+	for _, field := range req.DetectedFields {
+		candidates = intersect(candidates, r.metadata.ByDetectedField[field])
+		if len(candidates) == 0 {
+			return "", fmt.Errorf("no streams with detected field: %s", field)
+		}
+	}
+
+	for _, key := range req.StructuredMetadata {
+		candidates = intersect(candidates, r.metadata.ByStructuredMetadata[key])
+		if len(candidates) == 0 {
+			return "", fmt.Errorf("no streams with structured metadata: %s", key)
+		}
+	}
+
+	for _, label := range req.Labels {
+		candidates = intersect(candidates, r.metadata.ByLabelKey[label])
+		if len(candidates) == 0 {
+			return "", fmt.Errorf("no streams with label: %s", label)
+		}
+	}
+
+	for _, keyword := range req.Keywords {
+		candidates = intersect(candidates, r.metadata.ByKeyword[keyword])
+		if len(candidates) == 0 {
+			return "", fmt.Errorf("no streams with keyword: %s", keyword)
+		}
+	}
+
+	if len(candidates) == 0 {
+		return "", fmt.Errorf("no streams match all requirements")
+	}
+
+	// When the query needs ${RANGE}, filter to streams with valid range metadata.
+	if needsRange {
+		var rangeFiltered []string
+		for _, sel := range candidates {
+			meta, ok := r.metadata.MetadataBySelector[sel]
+			if !ok {
+				continue
+			}
+			if isInstant && meta.MinInstantRange > 0 {
+				rangeFiltered = append(rangeFiltered, sel)
+			} else if !isInstant && meta.MinRange > 0 {
+				rangeFiltered = append(rangeFiltered, sel)
+			}
+		}
+		if len(rangeFiltered) == 0 {
+			return "", fmt.Errorf("no streams with valid %s range duration", map[bool]string{true: "instant", false: "range"}[isInstant])
+		}
+		candidates = rangeFiltered
+	}
+
+	return candidates[r.rnd.Intn(len(candidates))], nil
+}
+
+// extractLabelFromSelector parses a label selector and extracts a random label name and value
+// For a selector like {foo="bar", baz="qux"}, it returns one of: (foo, bar) or (baz, qux)
+// If labels are specified in requirements, it prioritizes those labels
+func (r *MetadataVariableResolver) extractLabelFromSelector(selector string, req QueryRequirements) (labelName, labelValue string, err error) {
+	matchers, err := syntax.ParseMatchers(selector, true)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to parse selector %q: %w", selector, err)
+	}
+
+	type labelPair struct {
+		name  string
+		value string
+	}
+	var allPairs []labelPair
+	var requiredPairs []labelPair
+
+	for _, matcher := range matchers {
+		// We only use equality matchers since we need concrete values
+		if matcher.Type != labels.MatchEqual {
+			continue
+		}
+
+		pair := labelPair{name: matcher.Name, value: matcher.Value}
+		allPairs = append(allPairs, pair)
+
+		for _, requiredLabel := range req.Labels {
+			if matcher.Name == requiredLabel {
+				requiredPairs = append(requiredPairs, pair)
+				break
+			}
+		}
+	}
+
+	if len(allPairs) == 0 {
+		return "", "", fmt.Errorf("no label pairs found in selector: %s", selector)
+	}
+
+	// Prefer required labels if specified, otherwise use any label
+	var chosenPair labelPair
+	if len(requiredPairs) > 0 {
+		chosenPair = requiredPairs[r.rnd.Intn(len(requiredPairs))]
+	} else {
+		chosenPair = allPairs[r.rnd.Intn(len(allPairs))]
+	}
+
+	return chosenPair.name, chosenPair.value, nil
+}
+
+// GetTimeRange returns the start and end time for a query based on the metadata time range
+func (r *MetadataVariableResolver) GetTimeRange(length time.Duration) (start, end time.Time, err error) {
+	datasetStart := r.metadata.TimeRange.Start
+	datasetEnd := r.metadata.TimeRange.End
+	datasetDuration := datasetEnd.Sub(datasetStart)
+
+	// Validate that the dataset is long enough
+	if datasetDuration < length {
+		return time.Time{}, time.Time{}, fmt.Errorf("dataset duration %v is shorter than requested length %v", datasetDuration, length)
+	}
+
+	// Pick a random start point that allows the full length to fit
+	var randomOffset time.Duration
+	if datasetDuration > length {
+		maxOffset := datasetDuration - length
+		randomOffset = time.Duration(r.rnd.Int63n(int64(maxOffset)))
+	}
+
+	start = datasetStart.Add(randomOffset)
+	end = start.Add(length)
+
+	// Ensure we don't exceed the dataset bounds
+	if end.After(datasetEnd) {
+		end = datasetEnd
+		start = end.Add(-length)
+	}
+
+	return start, end, nil
+}
+
+// resolveRange resolves the ${RANGE} variable based on query type and stream metadata
+func (r *MetadataVariableResolver) resolveRange(selector string, isInstant bool) (string, error) {
+	if selector == "" {
+		return "", fmt.Errorf("resolveRange requires a resolved selector")
+	}
+
+	// Look up stream metadata for this selector
+	streamMeta, ok := r.metadata.MetadataBySelector[selector]
+	if !ok {
+		return "", fmt.Errorf("no stream metadata found for selector: %s", selector)
+	}
+
+	// Select appropriate range based on query type
+	var rangeDuration time.Duration
+	if isInstant {
+		rangeDuration = streamMeta.MinInstantRange
+	} else {
+		rangeDuration = streamMeta.MinRange
+	}
+
+	if rangeDuration == 0 {
+		return "", fmt.Errorf("stream has zero range duration (instant=%v): %s", isInstant, selector)
+	}
+
+	return formatDuration(rangeDuration), nil
+}
+
+// formatDuration formats a duration as a clean string for LogQL queries
+// Examples: 5m, 2h, 30s, 1h30m
+func formatDuration(d time.Duration) string {
+	// Use time.Duration.String() but clean up redundant zeros
+	s := d.String()
+	// Remove trailing 0s and 0m0s patterns
+	if strings.HasSuffix(s, "m0s") {
+		s = s[:len(s)-2]
+	} else if strings.HasSuffix(s, "h0m0s") {
+		s = s[:len(s)-4]
+	}
+	return s
+}
+
+// intersect returns the intersection of two sorted string slices
+// Both input slices must be sorted for this to work correctly
+func intersect(a, b []string) []string {
+	if len(a) == 0 || len(b) == 0 {
+		return []string{}
+	}
+
+	result := make([]string, 0, minInt(len(a), len(b)))
+	i, j := 0, 0
+
+	for i < len(a) && j < len(b) {
+		if a[i] == b[j] {
+			result = append(result, a[i])
+			i++
+			j++
+		} else if a[i] < b[j] {
+			i++
+		} else {
+			j++
+		}
+	}
+
+	return result
+}
+
+// minInt returns the minimum of two integers
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/harness/loki-compatibility/upstream/loki-bench/queries/fast/basic-selectors.yaml
+++ b/harness/loki-compatibility/upstream/loki-bench/queries/fast/basic-selectors.yaml
@@ -1,0 +1,77 @@
+# yaml-language-server: $schema=../schema.json
+---
+# Basic label selector queries
+# These are the fastest queries and run on every test
+queries:
+  - description: Basic label selector
+    query: ${SELECTOR}
+    kind: log
+    time_range:
+      length: 24h
+    directions: backward # forward log queries unsupported by v2 engine
+    tags:
+      - baseline
+      - selector
+
+  - description: Label selector with line filter
+    query: ${SELECTOR} |= "level"
+    time_range:
+      length: 24h
+    directions: backward # forward log queries unsupported by v2 engine
+    requires:
+      keywords:
+        - level
+    tags:
+      - line-filter
+      - text-search
+
+  - description: Label selector with regex line filter (case-insensitive)
+    query: ${SELECTOR} |~ "(?i)error"
+    time_range:
+      length: 24h
+    directions: backward # forward log queries unsupported by v2 engine
+    requires:
+      keywords:
+        - error
+    tags:
+      - line-filter
+      - regex
+      - case-insensitive
+
+  - description: Label selector with negative regex filter
+    query: ${SELECTOR} !~ "(?i)debug"
+    time_range:
+      length: 24h
+    directions: backward # forward log queries unsupported by v2 engine
+    requires:
+      keywords:
+       - debug
+    tags:
+      - line-filter
+      - regex
+      - negative-filter
+
+  - description: Label filter expression outside stream selector
+    query: ${SELECTOR} | ${LABEL_NAME} = "${LABEL_VALUE}"
+    time_range:
+      length: 24h
+    directions: backward # forward log queries unsupported by v2 engine
+    requires:
+      labels:
+        - namespace
+        - service_name
+        - cluster
+    tags:
+      - line-filter
+      - label-filter
+    notes: Tests indexed label filtering using | label=value syntax. Requires streams with multiple labels.
+
+  - description: Log query with impossible filter (guarantees empty results, exercises log result cache)
+    query: '${SELECTOR} |= "this will not hit any line"'
+    time_range:
+      length: 24h
+    directions: backward
+    tags:
+      - line-filter
+      - empty-result
+      - cache-test

--- a/harness/loki-compatibility/upstream/loki-bench/queries/fast/simple-metrics.yaml
+++ b/harness/loki-compatibility/upstream/loki-bench/queries/fast/simple-metrics.yaml
@@ -1,0 +1,55 @@
+# yaml-language-server: $schema=../schema.json
+---
+# Simple metric queries for fast testing
+queries:
+  - description: Count over time
+    query: sum(count_over_time(${SELECTOR}[${RANGE}]))
+    kind: metric
+    time_range:
+      length: 24h
+      step: 1m
+    tags:
+      - aggregation
+      - count
+
+  - description: Count with error/warn filter
+    query: sum(count_over_time(${SELECTOR} | detected_level=~"error|warn" [${RANGE}]))
+    kind: metric
+    time_range:
+      length: 24h
+      step: 1m
+    requires:
+      structured_metadata:
+       - detected_level
+    tags:
+      - aggregation
+      - count
+      - structured-metadata
+
+  - description: Rate with error/warn filter
+    query: sum(rate(${SELECTOR} | detected_level=~"error|warn" [${RANGE}]))
+    kind: metric
+    time_range:
+      length: 24h
+      step: 1m
+    requires:
+      structured_metadata:
+        - detected_level
+    tags:
+      - aggregation
+      - rate
+      - structured-metadata
+
+  - description: Count with line filter
+    query: sum(count_over_time(${SELECTOR} |= "level" [${RANGE}]))
+    kind: metric
+    time_range:
+      length: 24h
+      step: 1m
+    requires:
+      keywords:
+        - level
+    tags:
+      - aggregation
+      - count
+      - line-filter

--- a/harness/loki-compatibility/upstream/loki-bench/queries/fast/structured-metadata.yaml
+++ b/harness/loki-compatibility/upstream/loki-bench/queries/fast/structured-metadata.yaml
@@ -1,0 +1,76 @@
+# yaml-language-server: $schema=../schema.json
+---
+queries:
+  - description: Structured metadata error level filter
+    query: ${SELECTOR} | detected_level="error"
+    kind: log
+    time_range:
+      length: 24h
+    directions: backward # forward log queries unsupported by v2 engine
+    requires:
+      structured_metadata:
+        - detected_level
+    tags:
+      - structured-metadata
+      - filter
+
+  - description: Logfmt parsing with structured metadata filter
+    query: ${SELECTOR} | logfmt | detected_level="error"
+    kind: log
+    time_range:
+      length: 24h
+    directions: backward # forward log queries unsupported by v2 engine
+    requires:
+      log_format: logfmt
+      structured_metadata:
+        - detected_level
+    tags:
+      - structured-metadata
+      - logfmt
+      - parser
+
+  - description: Logfmt parsing with structured metadata filter first
+    query: ${SELECTOR} | detected_level="error" | logfmt
+    kind: log
+    time_range:
+      length: 24h
+    directions: backward # forward log queries unsupported by v2 engine
+    requires:
+      log_format: logfmt
+      structured_metadata:
+        - detected_level
+    tags:
+      - structured-metadata
+      - logfmt
+      - parser
+
+  - description: JSON parsing with structured metadata filter
+    query: ${SELECTOR} | json | detected_level="error"
+    kind: log
+    time_range:
+      length: 24h
+    directions: backward # forward log queries unsupported by v2 engine
+    requires:
+      log_format: json
+      structured_metadata:
+        - detected_level
+    tags:
+      - structured-metadata
+      - json
+      - parser
+
+  - description: JSON parsing with structured metadata filter first
+    query: ${SELECTOR} | detected_level="error" | json
+    kind: log
+    skip: true # timing out - requires dataobj engine schema fix for structured metadata columns
+    time_range:
+      length: 24h
+    directions: both
+    requires:
+      log_format: json
+      structured_metadata:
+        - detected_level
+    tags:
+      - structured-metadata
+      - json
+      - parser

--- a/harness/loki-compatibility/upstream/loki-bench/queries/schema.json
+++ b/harness/loki-compatibility/upstream/loki-bench/queries/schema.json
@@ -1,0 +1,252 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/grafana/loki/pkg/logql/bench/queries/schema.json",
+  "title": "LogQL Benchmark Query Definition",
+  "description": "Schema for LogQL benchmark query definitions",
+  "type": "object",
+  "required": ["queries"],
+  "properties": {
+    "queries": {
+      "type": "array",
+      "description": "List of query definitions",
+      "items": {
+        "$ref": "#/definitions/QueryDefinition"
+      }
+    }
+  },
+  "definitions": {
+    "QueryDefinition": {
+      "type": "object",
+      "required": ["description", "query", "time_range"],
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of what this query tests",
+          "minLength": 1
+        },
+        "query": {
+          "type": "string",
+          "description": "LogQL query with ${VARIABLE} placeholders including ${RANGE} for range intervals.",
+          "minLength": 1
+        },
+        "log_format": {
+          "type": "string",
+          "description": "Required log format for queries with parsers (json, logfmt). Leave unset for queries that work with any format.",
+          "enum": ["json", "logfmt", "unstructured"],
+          "examples": ["json", "logfmt"]
+        },
+        "kind": {
+          "type": "string",
+          "description": "Query type: 'log' for log queries or 'metric' for metric queries",
+          "enum": ["log", "metric"],
+          "default": "log"
+        },
+        "time_range": {
+          "$ref": "#/definitions/TimeRangeConfig"
+        },
+        "directions": {
+          "type": "string",
+          "description": "For log queries: which direction(s) to test. Ignored for metric queries.",
+          "enum": ["forward", "backward", "both"],
+          "default": "both"
+        },
+        "variables": {
+          "type": "object",
+          "description": "Variable definitions used in the query",
+          "additionalProperties": {
+            "$ref": "#/definitions/VariableDefinition"
+          }
+        },
+        "tags": {
+          "type": "array",
+          "description": "Tags for categorization and filtering",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "notes": {
+          "type": "string",
+          "description": "Optional notes about expected behavior, known issues, or additional context"
+        },
+        "skip": {
+          "type": "boolean",
+          "description": "If true, skip this query during test execution. Use for queries with known issues to be fixed in follow-up work.",
+          "default": false
+        },
+        "requires": {
+          "$ref": "#/definitions/QueryRequirements"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "metric"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "time_range": {
+                "required": ["length"]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "log"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "time_range": {
+                "required": ["length"],
+                "properties": {
+                  "step": {
+                    "not": {}
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "TimeRangeConfig": {
+      "type": "object",
+      "required": ["length"],
+      "properties": {
+        "length": {
+          "type": "string",
+          "description": "Duration the query should cover (end - start). Examples: '5m', '1h', '24h'",
+          "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h|d)$",
+          "examples": ["5m", "1h", "24h", "30m"]
+        },
+        "step": {
+          "type": "string",
+          "description": "For metric queries only: step size for the query. Examples: '1m', '5m'. If not specified, defaults to (end-start)/250 (Loki's default).",
+          "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$",
+          "examples": ["1m", "5m", "15s"]
+        }
+      },
+      "additionalProperties": false
+    },
+    "VariableDefinition": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Variable type",
+          "enum": ["label_selector", "duration", "string", "label_name", "structured_metadata", "parsed_field"]
+        },
+        "required": {
+          "type": "boolean",
+          "description": "Whether this variable must have a value",
+          "default": false
+        },
+        "default": {
+          "type": "string",
+          "description": "Default value for the variable if not required"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of the variable's purpose"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "duration"
+              }
+            }
+          },
+          "then": {
+            "errorMessage": "Duration variables should not be used. Hardcode durations like [5m], [1h] directly in queries.",
+            "properties": {
+              "default": {
+                "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h|d)$"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "required": {
+                "const": true
+              }
+            }
+          },
+          "then": {
+            "not": {
+              "required": ["default"]
+            },
+            "errorMessage": "Required variables should not have default values"
+          }
+        }
+      ],
+      "additionalProperties": false
+    },
+    "QueryRequirements": {
+      "type": "object",
+      "description": "Requirements that streams must meet for this query to work",
+      "properties": {
+        "log_format": {
+          "type": "string",
+          "description": "Required log format for parser queries (json, logfmt). Omit for queries that work with any format.",
+          "enum": ["json", "logfmt", "unstructured"]
+        },
+        "unwrappable_fields": {
+          "type": "array",
+          "description": "Numeric fields that must be available for | unwrap operations",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "detected_fields": {
+          "type": "array",
+          "description": "Fields that must be parsable from log content for use in aggregations or filters",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "structured_metadata": {
+          "type": "array",
+          "description": "Structured metadata keys that must be present on the stream",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "labels": {
+          "type": "array",
+          "description": "Stream labels that must be present (for selectors, filters, or grouping)",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "keywords": {
+          "type": "array",
+          "description": "Keywords that must appear in log content for line filters",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/harness/loki-compatibility/upstream/loki-bench/query_registry.go
+++ b/harness/loki-compatibility/upstream/loki-bench/query_registry.go
@@ -1,0 +1,399 @@
+package bench
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/grafana/loki/v3/pkg/logproto"
+)
+
+// QueryDirection specifies which direction(s) to run a log query
+type QueryDirection string
+
+const (
+	DirectionForward  QueryDirection = "forward"
+	DirectionBackward QueryDirection = "backward"
+	DirectionBoth     QueryDirection = "both"
+)
+
+// TimeRangeConfig defines the time range parameters for a query
+type TimeRangeConfig struct {
+	// Length is the duration the query should cover (end - start)
+	Length string `yaml:"length"`
+	// Step is the step size for metric queries
+	Step string `yaml:"step,omitempty"`
+}
+
+// ParseLength parses the length string into a time.Duration
+func (t *TimeRangeConfig) ParseLength() (time.Duration, error) {
+	return time.ParseDuration(t.Length)
+}
+
+// ParseStep parses the step string into a time.Duration
+func (t *TimeRangeConfig) ParseStep() (time.Duration, error) {
+	if t.Step == "" {
+		return 0, nil
+	}
+	return time.ParseDuration(t.Step)
+}
+
+// QueryRequirements specifies what characteristics a stream must have for a query to work
+type QueryRequirements struct {
+	LogFormat          string   `yaml:"log_format,omitempty"`          // "json", "logfmt", or "unstructured"
+	UnwrappableFields  []string `yaml:"unwrappable_fields,omitempty"`  // Numeric fields needed for | unwrap
+	StructuredMetadata []string `yaml:"structured_metadata,omitempty"` // Structured metadata keys needed
+	DetectedFields     []string `yaml:"detected_fields,omitempty"`     // Fields that must be parsable from log content (for aggregations/filters)
+	Labels             []string `yaml:"labels,omitempty"`              // Stream label keys needed (for selectors, filters, or grouping)
+	Keywords           []string `yaml:"keywords,omitempty"`            // Strings that must appear in log content
+}
+
+// QueryDefinition represents a single query definition from the registry
+type QueryDefinition struct {
+	Description string            `yaml:"description"`
+	Query       string            `yaml:"query"`
+	Kind        string            `yaml:"kind,omitempty"` // "log" or "metric"
+	Skip        bool              `yaml:"skip,omitempty"`
+	TimeRange   TimeRangeConfig   `yaml:"time_range"`
+	Directions  QueryDirection    `yaml:"directions,omitempty"`
+	Requires    QueryRequirements `yaml:"requires,omitempty"` // Requirements for stream selection
+	Tags        []string          `yaml:"tags,omitempty"`
+	Notes       string            `yaml:"notes,omitempty"`
+	Source      string            `yaml:"-"` // Source location (suite/file.yaml:line), populated during load
+}
+
+// QueryFile represents a YAML file containing query definitions
+type QueryFile struct {
+	Queries []QueryDefinition `yaml:"queries"`
+}
+
+// Suite represents a test suite level
+type Suite string
+
+const (
+	SuiteFast       Suite = "fast"
+	SuiteRegression Suite = "regression"
+	SuiteExhaustive Suite = "exhaustive"
+)
+
+// QueryRegistry manages loading and accessing query definitions
+type QueryRegistry struct {
+	baseDir string
+	queries map[Suite][]QueryDefinition
+}
+
+// NewQueryRegistry creates a new query registry
+func NewQueryRegistry(baseDir string) *QueryRegistry {
+	return &QueryRegistry{
+		baseDir: baseDir,
+		queries: make(map[Suite][]QueryDefinition),
+	}
+}
+
+// Load loads all query definitions for the specified suites
+func (r *QueryRegistry) Load(suites ...Suite) error {
+	for _, suite := range suites {
+		suiteDir := filepath.Join(r.baseDir, string(suite))
+
+		// Check if directory exists
+		if _, err := os.Stat(suiteDir); os.IsNotExist(err) {
+			return fmt.Errorf("suite directory does not exist: %s", suiteDir)
+		}
+
+		// Read all YAML files in the suite directory
+		entries, err := os.ReadDir(suiteDir)
+		if err != nil {
+			return fmt.Errorf("failed to read suite directory %s: %w", suiteDir, err)
+		}
+
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+
+			// Only process YAML files
+			if !strings.HasSuffix(entry.Name(), ".yaml") && !strings.HasSuffix(entry.Name(), ".yml") {
+				continue
+			}
+
+			filePath := filepath.Join(suiteDir, entry.Name())
+			queries, err := r.loadFile(filePath, suite, entry.Name())
+			if err != nil {
+				return fmt.Errorf("failed to load file %s: %w", filePath, err)
+			}
+
+			for _, query := range queries {
+				r.queries[suite] = append(r.queries[suite], query)
+			}
+		}
+	}
+
+	return nil
+}
+
+// validateRequirements validates query requirements against bounded sets defined in metadata.go
+func validateRequirements(req QueryRequirements, queryDesc string) error {
+	// Validate unwrappable fields
+	for _, field := range req.UnwrappableFields {
+		if !slices.Contains(UnwrappableFields, field) {
+			return fmt.Errorf("query %q: unwrappable field %q not in bounded set %v", queryDesc, field, UnwrappableFields)
+		}
+	}
+
+	// Validate labels
+	for _, label := range req.Labels {
+		if !slices.Contains(LabelKeys, label) {
+			return fmt.Errorf("query %q: label %q not in bounded set %v", queryDesc, label, LabelKeys)
+		}
+	}
+
+	// Validate keywords
+	for _, keyword := range req.Keywords {
+		if !slices.Contains(FilterableKeywords, keyword) {
+			return fmt.Errorf("query %q: keyword %q not in bounded set %v", queryDesc, keyword, FilterableKeywords)
+		}
+	}
+
+	// Validate structured metadata
+	for _, key := range req.StructuredMetadata {
+		if !slices.Contains(StructuredMetadataKeys, key) {
+			return fmt.Errorf("query %q: structured metadata key %q not in bounded set %v", queryDesc, key, StructuredMetadataKeys)
+		}
+	}
+
+	return nil
+}
+
+// loadFile loads query definitions from a single YAML file
+func (r *QueryRegistry) loadFile(filePath string, suite Suite, fileName string) ([]QueryDefinition, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file: %w", err)
+	}
+
+	// First parse to get line numbers
+	var rootNode yaml.Node
+	if err := yaml.Unmarshal(data, &rootNode); err != nil {
+		return nil, fmt.Errorf("failed to parse YAML for line numbers: %w", err)
+	}
+
+	// Then parse normally to get the data
+	var queryFile QueryFile
+	if err := yaml.Unmarshal(data, &queryFile); err != nil {
+		return nil, fmt.Errorf("failed to parse YAML: %w", err)
+	}
+
+	// Extract line numbers from the YAML node tree
+	// The structure is: Document -> Mapping -> "queries" key -> Sequence -> Query items
+	lineNumbers := extractQueryLineNumbers(&rootNode)
+
+	// Set defaults and validate
+	for i := range queryFile.Queries {
+		q := &queryFile.Queries[i]
+
+		// Set source location
+		lineNum := 0
+		if i < len(lineNumbers) {
+			lineNum = lineNumbers[i]
+		}
+		q.Source = fmt.Sprintf("%s/%s:%d", suite, fileName, lineNum)
+
+		// Default directions to "both" for log queries
+		if q.Directions == "" && q.Kind == "log" {
+			q.Directions = DirectionBoth
+		}
+
+		if q.Kind == "" || (q.Kind != "metric" && q.Kind != "log") {
+			q.Kind = "log"
+		}
+
+		// Validate time range
+		if q.TimeRange.Length == "" {
+			return nil, fmt.Errorf("time_range.length is required for query %q", q.Description)
+		}
+
+		if _, err := q.TimeRange.ParseLength(); err != nil {
+			return nil, fmt.Errorf("invalid time_range.length %q for query %q: %w", q.TimeRange.Length, q.Description, err)
+		}
+
+		if q.TimeRange.Step != "" {
+			if _, err := q.TimeRange.ParseStep(); err != nil {
+				return nil, fmt.Errorf("invalid time_range.step %q for query %q: %w", q.TimeRange.Step, q.Description, err)
+			}
+		}
+
+		// Validate requirements against bounded sets
+		if err := validateRequirements(q.Requires, q.Description); err != nil {
+			return nil, err
+		}
+	}
+
+	return queryFile.Queries, nil
+}
+
+// extractQueryLineNumbers extracts line numbers for each query in the YAML
+func extractQueryLineNumbers(rootNode *yaml.Node) []int {
+	var lineNumbers []int
+
+	// Navigate the YAML tree: Document -> Mapping -> find "queries" key
+	if rootNode.Kind != yaml.DocumentNode || len(rootNode.Content) == 0 {
+		return lineNumbers
+	}
+
+	docNode := rootNode.Content[0]
+	if docNode.Kind != yaml.MappingNode {
+		return lineNumbers
+	}
+
+	// Find the "queries" key in the mapping
+	for i := 0; i < len(docNode.Content); i += 2 {
+		keyNode := docNode.Content[i]
+		if keyNode.Value == "queries" && i+1 < len(docNode.Content) {
+			valueNode := docNode.Content[i+1]
+			if valueNode.Kind == yaml.SequenceNode {
+				// Each item in the sequence is a query
+				for _, queryNode := range valueNode.Content {
+					lineNumbers = append(lineNumbers, queryNode.Line)
+				}
+			}
+			break
+		}
+	}
+
+	return lineNumbers
+}
+
+// GetQueries returns all loaded queries for the specified suites
+// If suites is empty, returns all queries
+// If includeSkipped is false, skipped queries are filtered out
+func (r *QueryRegistry) GetQueries(includeSkipped bool, suites ...Suite) []QueryDefinition {
+	var result []QueryDefinition
+
+	if len(suites) == 0 {
+		// Return all queries
+		for _, queries := range r.queries {
+			result = append(result, queries...)
+		}
+	} else {
+		for _, suite := range suites {
+			result = append(result, r.queries[suite]...)
+		}
+	}
+
+	// Filter out skipped queries if requested
+	if !includeSkipped {
+		filtered := result[:0]
+		for _, def := range result {
+			if !def.Skip {
+				filtered = append(filtered, def)
+			}
+		}
+		result = filtered
+	}
+
+	return result
+}
+
+// ExpandQuery expands a query definition into one or more TestCase instances
+// by resolving variables and creating cases for each direction
+func (r *QueryRegistry) ExpandQuery(def QueryDefinition, resolver VariableResolver, isInstant bool) ([]TestCase, error) {
+	resolvedQuery, err := resolver.ResolveQuery(def.Query, def.Requires, isInstant)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve query: %w", err)
+	}
+
+	length, err := def.TimeRange.ParseLength()
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse length: %w", err)
+	}
+
+	step, err := def.TimeRange.ParseStep()
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse step: %w", err)
+	}
+
+	start, end, err := resolver.GetTimeRange(length)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get time range: %w", err)
+	}
+
+	// Create test cases based on query kind and directions
+	var cases []TestCase
+
+	if def.Kind == "metric" {
+		// Metric queries only run in forward direction
+		tc := TestCase{
+			Query:     resolvedQuery,
+			Start:     start,
+			End:       end,
+			Direction: logproto.FORWARD,
+			Step:      step,
+			Source:    def.Source,
+			QueryDesc: def.Description,
+			Tags:      def.Tags,
+		}
+		cases = append(cases, tc)
+	} else {
+		// Log queries can run in both directions
+		switch def.Directions {
+		case DirectionForward:
+			cases = append(cases, TestCase{
+				Query:     resolvedQuery,
+				Start:     start,
+				End:       end,
+				Direction: logproto.FORWARD,
+				Source:    def.Source,
+				QueryDesc: def.Description,
+				Tags:      def.Tags,
+			})
+		case DirectionBackward:
+			cases = append(cases, TestCase{
+				Query:     resolvedQuery,
+				Start:     start,
+				End:       end,
+				Direction: logproto.BACKWARD,
+				Source:    def.Source,
+				QueryDesc: def.Description,
+				Tags:      def.Tags,
+			})
+		case DirectionBoth:
+			cases = append(cases,
+				TestCase{
+					Query:     resolvedQuery,
+					Start:     start,
+					End:       end,
+					Direction: logproto.FORWARD,
+					Source:    def.Source,
+					QueryDesc: def.Description,
+					Tags:      def.Tags,
+				},
+				TestCase{
+					Query:     resolvedQuery,
+					Start:     start,
+					End:       end,
+					Direction: logproto.BACKWARD,
+					Source:    def.Source,
+					QueryDesc: def.Description,
+					Tags:      def.Tags,
+				},
+			)
+		}
+	}
+
+	return cases, nil
+}
+
+// VariableResolver is responsible for resolving query variables
+type VariableResolver interface {
+	// ResolveQuery resolves variables in a query based on requirements
+	// The isInstant parameter determines whether to use MinInstantRange (true) or MinRange (false) for ${RANGE}
+	ResolveQuery(query string, requirements QueryRequirements, isInstant bool) (string, error)
+
+	// GetTimeRange returns the start and end time for a query based on its time range config
+	GetTimeRange(length time.Duration) (start, end time.Time, err error)
+}

--- a/harness/loki-compatibility/upstream/loki-bench/remote_test.go
+++ b/harness/loki-compatibility/upstream/loki-bench/remote_test.go
@@ -1,0 +1,203 @@
+//go:build remote_correctness
+
+package bench
+
+import (
+	"flag"
+	"fmt"
+	"slices"
+	"sort"
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/grafana/loki/v3/pkg/logcli/client"
+	"github.com/grafana/loki/v3/pkg/logqlmodel"
+)
+
+var (
+	remoteAddr1       = flag.String("addr-1", "", "Address of baseline Loki instance")
+	remoteAddr2       = flag.String("addr-2", "", "Address of test Loki instance")
+	remoteOrgID       = flag.String("org-id", "", "Tenant org ID")
+	remoteUsername    = flag.String("username", "", "HTTP basic auth username")
+	remotePassword    = flag.String("password", "", "HTTP basic auth password")
+	remoteBearerToken = flag.String("bearer-token", "", "Bearer token for auth")
+	remoteMetadataDir = flag.String("metadata-dir", "", "Directory containing dataset_metadata.json")
+	remoteTolerance   = flag.Float64("tolerance", 1e-5, "Float comparison tolerance")
+	remoteSeed        = flag.Int64("seed", 42, "Random seed for query template resolution")
+	remoteRangeType   = flag.String("remote-range-type", "range", "Query range type: instant or range")
+	remoteIncludeSkip = flag.Bool("remote-include-skipped", false, "Include skipped queries")
+)
+
+// loadRemoteTestCases loads test cases for remote correctness testing
+func loadRemoteTestCases(tb testing.TB) []TestCase {
+	tb.Helper()
+
+	metadata, err := LoadMetadata(*remoteMetadataDir)
+	if err != nil {
+		tb.Fatalf("failed to load metadata from %s: %v", *remoteMetadataDir, err)
+	}
+
+	registry := NewQueryRegistry("./queries")
+	suites := []Suite{SuiteFast, SuiteRegression, SuiteExhaustive}
+	if err := registry.Load(suites...); err != nil {
+		tb.Fatalf("failed to load query registry: %v", err)
+	}
+
+	resolver := NewMetadataVariableResolver(metadata, *remoteSeed)
+	isInstant := *remoteRangeType == "instant"
+	queryDefs := registry.GetQueries(*remoteIncludeSkip, suites...)
+
+	var cases []TestCase
+	for _, def := range queryDefs {
+		expanded, err := registry.ExpandQuery(def, resolver, isInstant)
+		if err != nil {
+			tb.Fatalf("failed to expand query %q: %v", def.Description, err)
+		}
+		cases = append(cases, expanded...)
+	}
+
+	if isInstant {
+		filtered := cases[:0]
+		for _, tc := range cases {
+			if tc.Kind() == "metric" {
+				tc.Start = tc.End
+				tc.Step = 0
+				filtered = append(filtered, tc)
+			}
+		}
+		cases = filtered
+	}
+
+	tb.Logf("Loaded %d remote test cases (range-type=%s)", len(cases), *remoteRangeType)
+	return cases
+}
+
+// queryRemote executes a test case against a remote Loki instance
+func queryRemote(t *testing.T, c *client.DefaultClient, tc TestCase) (parser.Value, error) {
+	t.Helper()
+	const limit = 1000 // matches TestStorageEquality
+
+	if tc.Kind() == "metric" && tc.Start.Equal(tc.End) {
+		// Instant query
+		resp, err := c.Query(tc.Query, limit, tc.End, tc.Direction, true)
+		if err != nil {
+			return nil, fmt.Errorf("query failed: %w", err)
+		}
+		return ConvertResult(resp.Data.Result)
+	}
+
+	// Range query (both log and metric)
+	resp, err := c.QueryRange(tc.Query, limit, tc.Start, tc.End, tc.Direction, tc.Step, 0, true)
+	if err != nil {
+		return nil, fmt.Errorf("query failed: %w", err)
+	}
+	return ConvertResult(resp.Data.Result)
+}
+
+// sortVector sorts a promql.Vector by metric labels (primary) then timestamp (secondary)
+func sortVector(v promql.Vector) {
+	slices.SortFunc(v, func(a, b promql.Sample) int {
+		if c := labels.Compare(a.Metric, b.Metric); c != 0 {
+			return c
+		}
+		// tie-break by timestamp
+		if a.T < b.T {
+			return -1
+		}
+		if a.T > b.T {
+			return 1
+		}
+		return 0
+	})
+}
+
+// sortMatrix sorts a promql.Matrix by metric labels
+func sortMatrix(m promql.Matrix) {
+	slices.SortFunc(m, func(a, b promql.Series) int {
+		return labels.Compare(a.Metric, b.Metric)
+	})
+}
+
+// sortStreams sorts logqlmodel.Streams by label string
+func sortStreams(s logqlmodel.Streams) {
+	sort.Sort(s)
+}
+
+// normalizeResult normalizes ordering of a query result for stable comparison
+func normalizeResult(v parser.Value) parser.Value {
+	switch val := v.(type) {
+	case promql.Vector:
+		sortVector(val)
+		return val
+	case promql.Matrix:
+		sortMatrix(val)
+		return val
+	case logqlmodel.Streams:
+		sortStreams(val)
+		return val
+	default:
+		return v // scalars need no sorting
+	}
+}
+
+// TestRemoteStorageEquality compares query results between two live Loki endpoints.
+// It requires --addr-1, --addr-2, and --metadata-dir flags to be set.
+func TestRemoteStorageEquality(t *testing.T) {
+	if *remoteAddr1 == "" || *remoteAddr2 == "" {
+		t.Skip("skipping: --addr-1 and --addr-2 required")
+	}
+	if *remoteMetadataDir == "" {
+		t.Skip("skipping: --metadata-dir required")
+	}
+
+	cases := loadRemoteTestCases(t)
+
+	baseline := &client.DefaultClient{
+		Address:     *remoteAddr1,
+		OrgID:       *remoteOrgID,
+		Username:    *remoteUsername,
+		Password:    *remotePassword,
+		BearerToken: *remoteBearerToken,
+	}
+	test := &client.DefaultClient{
+		Address:     *remoteAddr2,
+		OrgID:       *remoteOrgID,
+		Username:    *remoteUsername,
+		Password:    *remotePassword,
+		BearerToken: *remoteBearerToken,
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%s/kind=%s/direction=%s", tc.Source, tc.Kind(), tc.Direction), func(t *testing.T) {
+			t.Logf("Query: %s", tc.Description())
+
+			var expected, actual parser.Value
+			g, _ := errgroup.WithContext(t.Context())
+
+			g.Go(func() error {
+				v, err := queryRemote(t, baseline, tc)
+				expected = v
+				return err
+			})
+			g.Go(func() error {
+				v, err := queryRemote(t, test, tc)
+				actual = v
+				return err
+			})
+			require.NoError(t, g.Wait())
+
+			// Normalize ordering before comparison
+			expected = normalizeResult(expected)
+			actual = normalizeResult(actual)
+
+			assertResultNotEmpty(t, expected, "baseline returned empty")
+			assertResultNotEmpty(t, actual, "test endpoint returned empty")
+			assertDataEqualWithTolerance(t, expected, actual, *remoteTolerance)
+		})
+	}
+}

--- a/harness/loki-compatibility/upstream/loki-bench/testcase.go
+++ b/harness/loki-compatibility/upstream/loki-bench/testcase.go
@@ -1,0 +1,74 @@
+package bench
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+)
+
+// TestCase represents a LogQL test case for benchmarking and testing
+type TestCase struct {
+	Query     string
+	Start     time.Time
+	End       time.Time
+	Direction logproto.Direction
+	Step      time.Duration // Step size for metric queries
+	Source    string        // Source location (suite/file.yaml:line)
+	QueryDesc string        // Query description from YAML
+	Tags      []string
+}
+
+// Equal returns true if two TestCases represent the same query execution.
+func (c TestCase) Equal(other TestCase) bool {
+	return c.Query == other.Query &&
+		c.Start.Equal(other.Start) &&
+		c.End.Equal(other.End) &&
+		c.Step == other.Step &&
+		c.Direction == other.Direction &&
+		slices.Equal(c.Tags, other.Tags)
+}
+
+// Name returns a descriptive name for the test case.
+// For log queries, it includes the direction.
+// For metric queries (rate, sum), it returns the query with step size.
+func (c TestCase) Name() string {
+	expr, err := syntax.ParseExpr(c.Query)
+	if err != nil {
+		return fmt.Sprintf("%s [%v]", c.Query, c.Direction)
+	}
+	if _, ok := expr.(syntax.SampleExpr); ok {
+		return c.Query
+	}
+	return fmt.Sprintf("%s [%v]", c.Query, c.Direction)
+}
+
+// Kind returns the kind of the test case based on the query type.
+func (c TestCase) Kind() string {
+	expr, err := syntax.ParseExpr(c.Query)
+	if err != nil {
+		return "invalid"
+	}
+	if _, ok := expr.(syntax.SampleExpr); ok {
+		return "metric"
+	}
+	return "log"
+}
+
+// Description returns a detailed description of the test case including time range
+func (c TestCase) Description() string {
+	var b strings.Builder
+	if c.Source != "" {
+		fmt.Fprintf(&b, "Source: %s\n", c.Source)
+	}
+	fmt.Fprintf(&b, "Query: %s\n", c.Query)
+	fmt.Fprintf(&b, "Time Range: %v to %v\n", c.Start.Format(time.RFC3339), c.End.Format(time.RFC3339))
+	if c.Step > 0 {
+		fmt.Fprintf(&b, "Step: %v\n", c.Step)
+	}
+	fmt.Fprintf(&b, "Direction: %v", c.Direction)
+	return b.String()
+}


### PR DESCRIPTION
**PR 3** of the rollout in [`docs/loki-compliance-plan.md`](docs/loki-compliance-plan.md):

> **PR 3 — `scripts/run-loki-compatibility.sh` + just recipe.** Build the test driver (`go test -tags=remote_correctness -c`), point at the two endpoints, write report. Add `just loki-compatibility`.

## Depends on

Stacked on top of #369 (PR 2 — vendor `pkg/logql/bench` corpus). This PR is marked **draft** until #369 merges; once it lands I'll rebase + flip ready. The diff visible on this PR will then collapse to the PR-3-only commit (`b537dcf`).

## Summary

PR 2 (#369) shipped a partial vendor (queries + driver shell only); this PR finishes the wiring so `just loki-compatibility` brings up the stack, seeds, builds the diff driver, runs `TestRemoteStorageEquality` against both endpoints, and writes a report.

### Vendor expansion

`pkg/logql/bench/`'s `query_registry.go` + `remote_test.go` reference symbols across `metadata.go` / `metadata_resolver.go` / `testcase.go` / `assertions_test.go` / `convert_test.go` (and transitively `generator.go` / `faker.go` for the `GeneratorConfig` / `StreamMetadata` / `LogFormat` type surface). This PR vendors all seven files verbatim from `grafana/loki v3.7.0` so the test binary type-checks. `upstream/loki-bench/VERSION`'s `vendored_paths:` block is the canonical inventory; the bump procedure in the README is updated to copy the full set.

Two empty subdirs (`queries/regression/`, `queries/exhaustive/`) get `.gitkeep` markers because the driver's three-suite loader fatals on a missing path; PR 6 of the plan fills them in.

### Run script

`scripts/run-loki-compatibility.sh` now drives:

1. `docker compose up --wait` (clickhouse + reference Loki + cerberus)
2. `go run ./cmd/seed` (the PR 1 seeder)
3. `GOFLAGS=-mod=mod go test -tags=remote_correctness -c -o $TMP ./harness/loki-compatibility/upstream/loki-bench/`
4. `$TMP -test.v -test.timeout=$T -addr-1=… -addr-2=… -metadata-dir=… 2>&1 | tee reports/diff.json`
5. Propagate the driver's exit code

A `cleanup` trap reverts `go.mod` / `go.sum` on every exit path because the `-mod=mod` build transiently promotes the vendored Loki-client transitive deps (aws-sdk-go-v2, azure-sdk, OpenAPI, …); without the revert they'd leak into the root module graph.

Exit semantics mirror `harness/prometheus-compliance/`:

| Code | Meaning                                                                                                                                          |
| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
| 0    | No diffs reported.                                                                                                                               |
| 1    | At least one diff or runtime failure. PR 4's CI lane will treat this as informational (matches the Prom precedent) until the corpus stabilises.  |
| 2+   | Harness itself failed (compose, seed, build).                                                                                                    |

Env knobs: `COMPOSE_KEEP`, `DRIVER_SKIP`, `DRIVER_REPORT`, `DRIVER_TIMEOUT`, `DRIVER_TOLERANCE`, `DRIVER_RANGE_TYPE`.

### Justfile

| Recipe                       | Behaviour                                          |
| ---------------------------- | -------------------------------------------------- |
| `loki-compatibility`         | Full lifecycle (compose + seed + diff + tear down) |
| `loki-compatibility-smoke`   | `DRIVER_SKIP=1` — smoke only                       |
| `loki-compatibility-keep`    | `COMPOSE_KEEP=1` — leave stack up after run        |
| `loki-compatibility-down`    | Manual `docker compose down -v`                    |

### Cerberus overlay

`cerberus-test-queries.yml` flips from `should_skip: []` to a full enumeration of `fast/` corpus entries. Each one is tagged with the upstream concern: the PR 1 seeder writes single-label `{service=…}` streams while the upstream `${SELECTOR}` template expands to `{service_name=…, namespace=…, cluster=…, container=…}` — baseline Loki returns empty on every query, so the driver fails with `baseline returned empty` rather than reporting a structural diff. PR 6 of the plan extends the seeder + regenerates `dataset_metadata.json`; at that point the entries either drop (query passes) or get rewritten with a real LogQL feature-gap reason.

The current runner doesn't consume the overlay yet — that's PR 5 (cerberus-owned driver); for now the file is documentary surface so reviewers can see exactly what cerberus is claiming as a known gap.

### Sample report shape

`reports/diff.json` captures the raw `go test -v` stream. For the current placeholder dataset_metadata.json the first few lines look like:

```
=== RUN   TestRemoteStorageEquality
=== RUN   TestRemoteStorageEquality/fast/basic-selectors.yaml:6/kind=log/direction=backward
    remote_test.go:185: Query: Source: fast/basic-selectors.yaml:6
        Query: {service_name="loki-bench-app-a", …}
        Time Range: 2026-05-14T01:23:45Z to 2026-05-15T01:23:45Z
        Direction: backward
    require.go: baseline returned empty
--- FAIL: TestRemoteStorageEquality/fast/basic-selectors.yaml:6/kind=log/direction=backward
```

i.e. the wiring is exercised, the failure mode is the documented selector-vocabulary mismatch, and the report surface is what PR 5's cerberus-owned driver will consume. The PR-3 contract is the plumbing, not the green run.

## Constraints honoured

- chsql Builder discipline — no new SQL surfaces touched.
- No `t.Skip` outside `harness/*/upstream/**` (the CI `forbid-skip` glob excludes the vendored path).
- No MD060 disable; tables in this PR body + the harness README are hand-aligned.
- AGPL content stays under `harness/loki-compatibility/upstream/loki-bench/`.

## Test plan

- [ ] `just loki-compatibility-smoke` runs the seeder lifecycle as before (no behavioural change).
- [ ] `just loki-compatibility` builds the diff driver, runs `TestRemoteStorageEquality`, writes `harness/loki-compatibility/reports/diff.json`.
- [ ] After the run, `git status` shows no diff in `go.mod` / `go.sum`.
- [ ] CI: `check` + `lint` + `forbid-skip` green (informational `compatibility.yml` lane lands in PR 4).