### PR TITLE
ci(chdb): promote probe + roundtrip lanes to required PR checks

### DIFF
--- a/.github/workflows/chdb.yml
+++ b/.github/workflows/chdb.yml
@@ -24,28 +24,38 @@ name: chdb
 # code review (e.g. label_replace_basic.txtar landed broken on main via
 # #312 — no workflow caught it).
 #
-# Informational only. NOT a required PR check; not in the
-# required-status-checks list. The required PR lane stays `check` +
-# `lint` and runs CGO-free Go tests — this workflow links libchdb.so
-# and is therefore segregated. Promote to PR-gating later if the lane
-# is consistently green and the runner work depends on it.
+# Required on PRs whose path filter matches (see `paths:` below). The
+# `probe` job and each `roundtrip (<ql>)` matrix entry are entries in
+# the required-status-checks list on `main`. Required-on-match means
+# GitHub's branch protection waits for the workflow to register a
+# context; when the workflow is skipped by the path filter, the check
+# is recorded as `expected` and resolves automatically because no run
+# was created. Promoted from informational after Pool-DD #382 merged
+# while the chDB lane was skipping `internal/api/**` changes and let
+# four broken handler tests through (fixed in #388).
+#
+# If you widen the path filter, audit the required-checks list at the
+# same time — a context that never runs blocks every PR.
 
 on:
   push:
     branches: [main]
   pull_request:
     # Scope the PR trigger to changes that can plausibly affect
-    # SQL emission, plan IR, parser lowering, fixtures, or the chDB
-    # roundtrip plumbing itself. Broad enough that anything touching
+    # SQL emission, plan IR, parser lowering, fixtures, the chDB
+    # roundtrip plumbing, or the HTTP handlers that exercise the
+    # chDB-tagged handler tests. Broad enough that anything touching
     # the round-trip surface fires the lane; tight enough that pure
     # docs / unrelated CI tweaks don't pay the libchdb cost.
     paths:
+      - 'internal/api/**'
       - 'internal/chsql/**'
       - 'internal/promql/**'
       - 'internal/logql/**'
       - 'internal/traceql/**'
       - 'internal/chplan/**'
       - 'internal/optimizer/**'
+      - 'internal/engine/**'
       - 'internal/chclient/**'
       - 'internal/chclienttest/**'
       - 'test/spec/**'


### PR DESCRIPTION
## Summary

Pool-DD's #382 added chDB-tagged handler tests under
`internal/api/prom/` (`TestLabelValues_MatchSelector_{ChDB,Regex_ChDB,
Multiple_ChDB,MetricName_ChDB}` + the metadata-handler chDB tests)
but the **chDB workflow's `pull_request.paths` filter did not list
`internal/api/**`**, so the chDB lane never ran on the PR. The four
handler tests were broken (the matcher lowering's default
`now64(9)` LWR anchor excluded the test's `2026-05-11` seed window),
the chDB lane was informational, and the PR merged with the
regression. Pool-DI patched the actual bug in #388 by threading
`start`/`end` through the matcher lowering.

The slip-through had two root causes — one fixed here, one
maintainer-applied after merge.

### What this PR fixes

`.github/workflows/chdb.yml`:

  - Add `internal/api/**` + `internal/engine/**` to the
    `pull_request.paths` filter. The chDB lane now fires on any PR
    that touches an HTTP handler or the shared engine plumbing — the
    surface that #382 modified and that #388 had to amend.
  - Update the workflow header comment from "informational only" to
    "required on PRs whose path filter matches", with a back-reference
    to the #382 / #388 incident.

### What still needs the maintainer (manual, post-merge)

Branch protection on `main` lives outside the repo tree. Once this
PR is merged, the maintainer (or anyone with admin on the repo)
must add the four chDB contexts to the required-status-checks list:

```sh
gh api -X PATCH repos/tsouza/cerberus/branches/main/protection \
  -F 'required_status_checks[strict]=false' \
  -f 'required_status_checks[contexts][]=check' \
  -f 'required_status_checks[contexts][]=lint' \
  -f 'required_status_checks[contexts][]=forbid-skip' \
  -f 'required_status_checks[contexts][]=probe' \
  -f 'required_status_checks[contexts][]=roundtrip (promql)' \
  -f 'required_status_checks[contexts][]=roundtrip (logql)' \
  -f 'required_status_checks[contexts][]=roundtrip (traceql)'
```

(Or via the GitHub web UI: Settings → Branches → main → Edit →
"Require status checks to pass" → add the four contexts.)

The `pull_request.paths` filter on `chdb.yml` means each context only
fires when the PR touches a relevant path; on PRs that don't, GitHub
records the context as `expected` and resolves it automatically (no
run = no required check failure). This is the standard
"required-on-match" pattern.

### Path filter — before / after

**Before** (missing `internal/api/**`, `internal/engine/**`):

```yaml
paths:
  - 'internal/chsql/**'
  - 'internal/promql/**'
  - 'internal/logql/**'
  - 'internal/traceql/**'
  - 'internal/chplan/**'
  - 'internal/optimizer/**'
  - 'internal/chclient/**'
  - 'internal/chclienttest/**'
  - 'test/spec/**'
  - 'harness/prometheus-compliance/cmd/seed/**'
  - 'go.mod'
  - 'go.sum'
  - '.github/workflows/chdb.yml'
  - 'Justfile'
```

**After** (handler + engine added):

```yaml
paths:
  - 'internal/api/**'           # new
  - 'internal/chsql/**'
  - 'internal/promql/**'
  - 'internal/logql/**'
  - 'internal/traceql/**'
  - 'internal/chplan/**'
  - 'internal/optimizer/**'
  - 'internal/engine/**'        # new
  - 'internal/chclient/**'
  - 'internal/chclienttest/**'
  - 'test/spec/**'
  - 'harness/prometheus-compliance/cmd/seed/**'
  - 'go.mod'
  - 'go.sum'
  - '.github/workflows/chdb.yml'
  - 'Justfile'
```

### Required-checks list — before / after

**Before** (`gh api repos/tsouza/cerberus/branches/main/protection`):

```
check, lint, forbid-skip
```

**After** (target state, applied by maintainer post-merge):

```
check, lint, forbid-skip,
probe,
roundtrip (promql), roundtrip (logql), roundtrip (traceql)
```

Refs #382, #388.

## Test plan

- [ ] `check` + `lint` (CGO-free required gates) green on this PR.
- [ ] The `probe` and three `roundtrip (<ql>)` jobs in the `chdb`
      workflow run on this PR (PR touches `.github/workflows/chdb.yml`,
      which is in the path filter) and are green.
- [ ] After merge, run the `gh api` command above and verify
      `gh api repos/tsouza/cerberus/branches/main/protection` returns
      all seven contexts.
- [ ] Smoke-test the required-on-match behaviour with a docs-only PR
      after the maintainer update — the four chDB contexts should
      resolve automatically without a workflow run.