### PR TITLE
fix(promql): round half-to-even + label_replace non-existent src residual

### DIFF
--- a/harness/prometheus-compliance/docker-compose.yml
+++ b/harness/prometheus-compliance/docker-compose.yml
@@ -52,7 +52,16 @@ services:
       - "28123:8123"
 
   prometheus:
-    image: prom/prometheus:v3.0.1
+    # v3.11.3 (latest stable) over v3.0.1: v3.0.1 ships an upstream bug
+    # where `round(...)` doesn't drop `__name__` from its output series,
+    # diverging from PromQL semantics. Fixed in upstream PR #15250
+    # (https://github.com/prometheus/prometheus/pull/15250) which landed
+    # post-v3.0.1. cerberus already implements the spec-correct behaviour
+    # (`internal/promql/instant_fns.go::projectValueOverInner` emits
+    # `'' AS MetricName` for derived samples per PR #359 / #376), so
+    # pinning to a fixed-upstream tag closes the compat-lane diff
+    # without touching cerberus's own semantics.
+    image: prom/prometheus:v3.11.3
     command:
       - --config.file=/etc/prometheus/prometheus.yml
       - --storage.tsdb.path=/prometheus

--- a/internal/chplan/label_replace.go
+++ b/internal/chplan/label_replace.go
@@ -8,8 +8,15 @@ package chplan
 //     `dst` to the regex-substituted `replacement` (CH's `replaceRegexpOne`
 //     anchored with `^…$`);
 //   - if the regex does not match (including when `src` is absent in the
-//     map and thus reads as the empty string), the map is returned
-//     unchanged — `dst` keeps whatever value it had (often "absent").
+//     map and thus reads as the empty string AND the regex doesn't
+//     match the empty string), the map is returned unchanged — `dst`
+//     keeps whatever value it had (often "absent").
+//   - if `src` is empty but the regex DOES match the empty string (e.g.
+//     `(.*)`), `dst` is bound to `EmptyReplacement` — the build-time
+//     pre-computed result of substituting every capture group with "".
+//     This is the Prom-spec branch for "source label absent but regex
+//     matches": Prom emits the literal portion of the replacement (e.g.
+//     `"value-$1"` against an empty match → `"value-"`).
 //
 // PromQL also drops labels whose value is the empty string; the emitter
 // wraps the resulting map with `mapFilter((k, v) -> v != ”, …)` so
@@ -20,18 +27,27 @@ package chplan
 //
 //	mapFilter((k, v) -> v != '',
 //	    if(match(<map>[<src>], '^<regex>$'),
-//	       mapUpdate(<map>, map(<dst>, replaceRegexpOne(<map>[<src>], <regex>, <replacement>))),
+//	       mapUpdate(<map>, map(<dst>,
+//	          if(empty(<map>[<src>]),
+//	             <emptyReplacement>,
+//	             replaceRegexpOne(<map>[<src>], <regex>, <replacement>)))),
 //	       <map>))
 //
 // `Map` is the input Map(String, String) expression (typically the
 // Attributes column ref). `Dst`, `Src`, `Replacement`, `Regex` are the
 // PromQL-static string arguments captured during lowering.
+// `EmptyReplacement` is the build-time pre-computed result of
+// substituting every capture group with `""` (see
+// `qlcommon.EmptyCapturesReplacement`); it works around CH ≤ 24.8's
+// `replaceRegexpOne(”, '^(.*)$', 'value-\1')` returning `""` instead
+// of the spec-correct `"value-"`.
 type LabelReplace struct {
-	Map         Expr
-	Dst         string
-	Replacement string
-	Src         string
-	Regex       string
+	Map              Expr
+	Dst              string
+	Replacement      string
+	Src              string
+	Regex            string
+	EmptyReplacement string
 }
 
 func (*LabelReplace) exprNode() {}
@@ -45,5 +61,6 @@ func (l *LabelReplace) Equal(other Expr) bool {
 		l.Replacement == o.Replacement &&
 		l.Src == o.Src &&
 		l.Regex == o.Regex &&
+		l.EmptyReplacement == o.EmptyReplacement &&
 		l.Map.Equal(o.Map)
 }

--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -445,13 +445,29 @@ func (b *Builder) exprMapWithoutEmptyValues(m *chplan.MapWithoutEmptyValues) err
 //
 //	mapFilter((k, v) -> v != '',
 //	    if(match(<map>[?src], ?anchoredRegex),
-//	       mapUpdate(<map>, map(?dst, replaceRegexpOne(<map>[?src], ?anchoredRegex, ?replacement))),
+//	       mapUpdate(<map>, map(?dst,
+//	          if(empty(<map>[?src]),
+//	             ?emptyReplacement,
+//	             replaceRegexpOne(<map>[?src], ?anchoredRegex, ?replacement)))),
 //	       <map>))
 //
 // `anchoredRegex` is `^<regex>$` so the match is full-string, matching
 // Prometheus's `RE2 ^…$` anchoring rule. The outer mapFilter drops the
 // dst label when the substituted replacement is the empty string —
 // Prom's "labels set to empty values are dropped" rule.
+//
+// The inner `if(empty(src), emptyReplacement, replaceRegexpOne(…))`
+// short-circuit patches CH ≤ 24.8's divergent behaviour where
+// `replaceRegexpOne(”, '^(.*)$', 'value-\1')` returns the empty
+// string (the input is silently passed through) instead of the
+// spec-correct `"value-"`. The build-time pre-computed
+// `emptyReplacement` substitutes every capture group with "" — the
+// value Go's `ExpandString` (Prom's reference impl) produces against
+// an empty match. CH ≥ 25.8 honours `replaceRegexpOne` on empty
+// inputs natively; the conditional collapses harmlessly in that
+// regime (both branches produce the same string). The compose
+// harness's reference Prom is on CH 24.8 so the short-circuit is
+// load-bearing on the compatibility lane.
 func (b *Builder) exprLabelReplace(l *chplan.LabelReplace) error {
 	anchored := "^" + l.Regex + "$"
 	b.sb.WriteString("mapFilter((k, v) -> v != '', if(match(")
@@ -468,6 +484,14 @@ func (b *Builder) exprLabelReplace(l *chplan.LabelReplace) error {
 	}
 	b.sb.WriteString(", map(")
 	b.Arg(l.Dst)
+	b.sb.WriteString(", if(empty(")
+	if err := b.Expr(l.Map); err != nil {
+		return err
+	}
+	b.sb.WriteByte('[')
+	b.Arg(l.Src)
+	b.sb.WriteString("]), ")
+	b.Arg(l.EmptyReplacement)
 	b.sb.WriteString(", replaceRegexpOne(")
 	if err := b.Expr(l.Map); err != nil {
 		return err
@@ -478,7 +502,7 @@ func (b *Builder) exprLabelReplace(l *chplan.LabelReplace) error {
 	b.Arg(anchored)
 	b.sb.WriteString(", ")
 	b.Arg(l.Replacement)
-	b.sb.WriteString("))), ")
+	b.sb.WriteString(")))), ")
 	if err := b.Expr(l.Map); err != nil {
 		return err
 	}

--- a/internal/logql/label_fns.go
+++ b/internal/logql/label_fns.go
@@ -47,11 +47,12 @@ func lowerLabelReplace(e *syntax.LabelReplaceExpr, s schema.Logs, lc lowerCtx) (
 	}
 
 	attrs := &chplan.LabelReplace{
-		Map:         &chplan.ColumnRef{Name: s.ResourceAttributesColumn},
-		Dst:         e.Dst,
-		Replacement: qlcommon.ReplacementToCH(e.Replacement, e.Regex),
-		Src:         e.Src,
-		Regex:       e.Regex,
+		Map:              &chplan.ColumnRef{Name: s.ResourceAttributesColumn},
+		Dst:              e.Dst,
+		Replacement:      qlcommon.ReplacementToCH(e.Replacement, e.Regex),
+		Src:              e.Src,
+		Regex:            e.Regex,
+		EmptyReplacement: qlcommon.EmptyCapturesReplacement(e.Replacement),
 	}
 	return projectResourceAttributesOverInner(inner, s, attrs), nil
 }

--- a/internal/promql/label_fns.go
+++ b/internal/promql/label_fns.go
@@ -47,11 +47,12 @@ func lowerLabelReplace(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.N
 		return nil, err
 	}
 	attrs := &chplan.LabelReplace{
-		Map:         &chplan.ColumnRef{Name: s.AttributesColumn},
-		Dst:         dst,
-		Replacement: qlcommon.ReplacementToCH(replacement, regex),
-		Src:         src,
-		Regex:       regex,
+		Map:              &chplan.ColumnRef{Name: s.AttributesColumn},
+		Dst:              dst,
+		Replacement:      qlcommon.ReplacementToCH(replacement, regex),
+		Src:              src,
+		Regex:            regex,
+		EmptyReplacement: qlcommon.EmptyCapturesReplacement(replacement),
 	}
 	return projectAttributesOverInner(inner, s, attrs), nil
 }

--- a/internal/qlcommon/label_replace.go
+++ b/internal/qlcommon/label_replace.go
@@ -136,3 +136,81 @@ func ReplacementToCH(repl, regex string) string {
 	}
 	return b.String()
 }
+
+// EmptyCapturesReplacement returns the result of substituting Go's
+// regex `ExpandString` template `repl` against an EMPTY source string
+// that matched the regex via a match where every capture group binds
+// to "". This matches the semantics of `label_replace(m, dst, repl,
+// src, regex)` when `src` is absent from the input series labels (Prom
+// reads missing labels as the empty string) AND the regex matches that
+// empty string — e.g. `(.*)`, `.*`, `^()$` all match `""` with
+// every group capturing `""`.
+//
+// Why we need a separate path:
+//
+//	CH ≤ 24.8's `replaceRegexpOne('', '^(.*)$', 'value-\1')` returns
+//	`""` (the empty input is passed through verbatim, regardless of
+//	the replacement template), instead of the spec-correct `"value-"`.
+//	The outer `mapFilter((k, v) -> v != '', …)` then drops the dst
+//	label entirely, diverging from reference Prom which emits
+//	`dst="value-"`. CH ≥ 25.8 honours the replacement on empty inputs,
+//	but the cerberus deployment lane targets CH 24.8 (the OTel
+//	collector's pinned LTS), so we patch the divergence at SQL build
+//	time by pre-computing the empty-captures result and using it as a
+//	short-circuit when the source value is empty at row time.
+//
+// Substitution rules (mirror `ReplacementToCH` but resolve each
+// backref to the empty string instead of CH's `\N` form):
+//
+//   - `$$`                → literal `$`
+//   - `$N` / `${N}`       → empty string (the N-th capture binds to ""
+//     when the full match was "")
+//   - Any other `$<x>`    → preserved verbatim (named groups,
+//     multi-digit indices — same opt-out as `ReplacementToCH`)
+func EmptyCapturesReplacement(repl string) string {
+	var b strings.Builder
+	b.Grow(len(repl))
+	for i := 0; i < len(repl); i++ {
+		c := repl[i]
+		if c != '$' {
+			b.WriteByte(c)
+			continue
+		}
+		// Lone `$` at end of string — preserve.
+		if i+1 >= len(repl) {
+			b.WriteByte('$')
+			continue
+		}
+		next := repl[i+1]
+		switch {
+		case next == '$':
+			// `$$` → literal `$`.
+			b.WriteByte('$')
+			i++
+		case next >= '0' && next <= '9':
+			// `$N` → "" (capture N is empty for an empty-string match).
+			// Two-digit `$10`+ is preserved verbatim — `ReplacementToCH`
+			// makes the same opt-out, so the regex compile / CH parse
+			// error surfaces consistently.
+			if i+2 < len(repl) && repl[i+2] >= '0' && repl[i+2] <= '9' {
+				b.WriteByte('$')
+				continue
+			}
+			// Single-digit numbered capture → empty. Skip past the digit.
+			i++
+		case next == '{':
+			// `${N}` (single digit) → "". Anything else (named captures,
+			// multi-digit indices) is preserved verbatim — same opt-out
+			// as `ReplacementToCH`.
+			if i+3 < len(repl) && repl[i+2] >= '0' && repl[i+2] <= '9' && repl[i+3] == '}' {
+				i += 3
+				continue
+			}
+			b.WriteByte('$')
+		default:
+			// `$<letter>` etc. — preserve verbatim.
+			b.WriteByte('$')
+		}
+	}
+	return b.String()
+}

--- a/internal/qlcommon/label_replace_test.go
+++ b/internal/qlcommon/label_replace_test.go
@@ -71,3 +71,60 @@ func TestReplacementToCH(t *testing.T) {
 		})
 	}
 }
+
+// TestEmptyCapturesReplacement locks the build-time pre-computation of
+// the "all captures bind to empty" replacement template — the value a
+// PromQL/LogQL `label_replace` should emit when the source label is
+// absent (read as empty from the input map) AND the regex matches that
+// empty string. The whole reason this helper exists is that CH ≤ 24.8's
+// `replaceRegexpOne` silently passes the empty input through (returning
+// `""` instead of substituting the replacement); the emit-time
+// `if(empty(src), <emptyResult>, replaceRegexpOne(…))` short-circuit
+// uses this helper to compute `<emptyResult>` ahead of time.
+func TestEmptyCapturesReplacement(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"literal_no_dollar", "hello", "hello"},
+		// Single-digit numbered captures resolve to "" — the canonical
+		// shape from the compat-residual diff
+		// (`label_replace(m, dst, "value-$1", "nonexistent-src", "(.*)")`
+		// → `dst="value-"`).
+		{"single_digit_backref", "$1", ""},
+		{"prefix_then_backref", "value-$1", "value-"},
+		{"backref_zero_whole_match", "$0", ""},
+		{"two_single_digit_refs", "$1-$2", "-"},
+		{"backref_nine", "$9", ""},
+		// `$$` collapses to a literal `$` (mirrors ExpandString).
+		{"dollar_dollar_literal", "$$", "$"},
+		{"dollar_dollar_then_text", "$$x", "$x"},
+		// Braced single-digit form behaves the same as bare `$N`.
+		{"braced_single_digit", "${1}-suffix", "-suffix"},
+		// Multi-digit indices and named captures are preserved verbatim
+		// — same opt-out as `ReplacementToCH`.
+		{"braced_multi_digit_preserved", "${10}", "${10}"},
+		{"multi_digit_unbraced_preserved", "$10", "$10"},
+		{"named_capture_preserved", "${name}", "${name}"},
+		// Edge cases that ExpandString handles literally.
+		{"lone_dollar_at_end", "abc$", "abc$"},
+		{"dollar_letter_preserved", "$x", "$x"},
+		// Literal backslashes pass through unchanged — only `$`-prefixed
+		// metacharacters are interpreted in the Go regex replacement
+		// template the QLs feed us.
+		{"existing_backslash_preserved", `\1`, `\1`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := EmptyCapturesReplacement(tc.in)
+			if got != tc.want {
+				t.Fatalf("EmptyCapturesReplacement(%q): got %q, want %q",
+					tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/test/spec/chplan_print.go
+++ b/test/spec/chplan_print.go
@@ -343,8 +343,8 @@ func printExpr(e chplan.Expr) string {
 	case *chplan.MapWithoutEmptyValues:
 		return fmt.Sprintf("mapWithoutEmpty(%s)", printExpr(v.Map))
 	case *chplan.LabelReplace:
-		return fmt.Sprintf("labelReplace(%s, dst=%q, replacement=%q, src=%q, regex=%q)",
-			printExpr(v.Map), v.Dst, v.Replacement, v.Src, v.Regex)
+		return fmt.Sprintf("labelReplace(%s, dst=%q, replacement=%q, src=%q, regex=%q, emptyReplacement=%q)",
+			printExpr(v.Map), v.Dst, v.Replacement, v.Src, v.Regex, v.EmptyReplacement)
 	case *chplan.LabelJoin:
 		return fmt.Sprintf("labelJoin(%s, dst=%q, separator=%q, srcs=[%s])",
 			printExpr(v.Map), v.Dst, v.Separator, strings.Join(v.Srcs, ", "))

--- a/test/spec/logql/label_replace_basic.txtar
+++ b/test/spec/logql/label_replace_basic.txtar
@@ -5,11 +5,13 @@ label_replace(count_over_time({service_name="api"}[5m]), "newlabel", "$1", "serv
 [1] string = "^(.+)$"
 [2] string = "newlabel"
 [3] string = "service_name"
-[4] string = "^(.+)$"
-[5] string = "\\1"
-[6] int64 = 1
-[7] string = "service_name"
-[8] string = "api"
+[4] string = ""
+[5] string = "service_name"
+[6] string = "^(.+)$"
+[7] string = "\\1"
+[8] int64 = 1
+[9] string = "service_name"
+[10] string = "api"
 -- seed --
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),
@@ -25,10 +27,10 @@ INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
   [{"service_name": "api", "newlabel": "api"}, 3.0]
 ]
 -- chplan --
-Project [labelReplace(ResourceAttributes, dst="newlabel", replacement="\\1", src="service_name", regex="(.+)") AS ResourceAttributes, Value]
+Project [labelReplace(ResourceAttributes, dst="newlabel", replacement="\\1", src="service_name", regex="(.+)", emptyReplacement="") AS ResourceAttributes, Value]
   RangeWindow func=count_over_time range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
     Project [ResourceAttributes, Timestamp, 1 AS Value]
       Filter predicate=(ResourceAttributes["service_name"] = "api")
         Scan(otel_logs)
 -- sql --
-SELECT mapFilter((k, v) -> v != '', if(match(`ResourceAttributes`[?], ?), mapUpdate(`ResourceAttributes`, map(?, replaceRegexpOne(`ResourceAttributes`[?], ?, ?))), `ResourceAttributes`)) AS `ResourceAttributes`, `Value` FROM (SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1)
+SELECT mapFilter((k, v) -> v != '', if(match(`ResourceAttributes`[?], ?), mapUpdate(`ResourceAttributes`, map(?, if(empty(`ResourceAttributes`[?]), ?, replaceRegexpOne(`ResourceAttributes`[?], ?, ?)))), `ResourceAttributes`)) AS `ResourceAttributes`, `Value` FROM (SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1)

--- a/test/spec/promql/label_replace_basic.txtar
+++ b/test/spec/promql/label_replace_basic.txtar
@@ -18,19 +18,21 @@ INSERT INTO otel_metrics_gauge VALUES
 [1] string = "^(.*)$"
 [2] string = "new"
 [3] string = "host"
-[4] string = "^(.*)$"
-[5] string = "\\1"
-[6] string = "temperature"
-[7] string = "2026-01-01 00:00:01.000000000"
-[8] int64 = 9
+[4] string = ""
+[5] string = "host"
+[6] string = "^(.*)$"
+[7] string = "\\1"
+[8] string = "temperature"
 [9] string = "2026-01-01 00:00:01.000000000"
 [10] int64 = 9
-[11] int64 = 300000000000
+[11] string = "2026-01-01 00:00:01.000000000"
+[12] int64 = 9
+[13] int64 = 300000000000
 -- chplan --
-Project [MetricName, labelReplace(Attributes, dst="new", replacement="\\1", src="host", regex="(.*)") AS Attributes, TimeUnix, Value]
+Project [MetricName, labelReplace(Attributes, dst="new", replacement="\\1", src="host", regex="(.*)", emptyReplacement="") AS Attributes, TimeUnix, Value]
   Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
     Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
       Filter predicate=(((MetricName = "temperature") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
         Scan(otel_metrics_gauge)
 -- sql --
-SELECT `MetricName`, mapFilter((k, v) -> v != '', if(match(`Attributes`[?], ?), mapUpdate(`Attributes`, map(?, replaceRegexpOne(`Attributes`[?], ?, ?))), `Attributes`)) AS `Attributes`, `TimeUnix`, `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
+SELECT `MetricName`, mapFilter((k, v) -> v != '', if(match(`Attributes`[?], ?), mapUpdate(`Attributes`, map(?, if(empty(`Attributes`[?]), ?, replaceRegexpOne(`Attributes`[?], ?, ?)))), `Attributes`)) AS `Attributes`, `TimeUnix`, `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))

--- a/test/spec/promql/label_replace_missing_src_overwrite.txtar
+++ b/test/spec/promql/label_replace_missing_src_overwrite.txtar
@@ -1,16 +1,28 @@
-# `label_replace(metric, "dst", "value-$1", "nonexistent-src", "(.*)")`
-# — Prom semantics treat a missing source label as the empty string, so
-# the regex `(.*)` matches `""` (empty match), capture group $1 binds
-# to `""`, and the dst label is set to the substituted replacement
-# (literal `value-` + empty $1 = `value-`). Cerberus drops the row's
-# dst label entirely pre-fix; the outer `mapFilter((k, v) -> v != '',
-# ...)` was keying off the same closed-over expression as the if-branch
-# rather than the post-mapUpdate Map, so the freshly-added dst entry
-# never survived the filter pass.
+# `label_replace(metric, "job", "value-$1", "nonexistent-src", "(.*)")`
+# — exact shape from compat run 25901406046 (the residual after PR #360's
+# regression coverage landed): the input metric ALREADY carries `job=demo`,
+# and Prom OVERWRITES that to `job="value-"` when src is absent but the
+# regex matches the empty string. Pre-fix cerberus instead dropped the
+# `job` label entirely because CH ≤ 24.8's
+# `replaceRegexpOne('', '^(.*)$', 'value-\\1')` returns the empty string
+# (silent input pass-through), the outer mapFilter then drops the
+# `job=""` entry, and the row loses its overwrite.
 #
-# Bucket 8 from docs/compat-residual-audit-25898791664.md (1 diff).
+# The fix in PR #393 short-circuits the empty-source path at SQL build
+# time:
+#
+#	if(empty(src),
+#	   <emptyCapturesReplacement>,        // pre-computed: "value-"
+#	   replaceRegexpOne(src, regex, repl))
+#
+# `<emptyCapturesReplacement>` is computed by
+# `qlcommon.EmptyCapturesReplacement` — the same Go-regex
+# `ExpandString` semantics Prom uses, applied against an all-empty
+# captures binding. CH ≥ 25.8 honours `replaceRegexpOne` on empty
+# inputs natively (both branches produce `"value-"` there), so the
+# conditional collapses harmlessly outside the 24.8 lane.
 -- query.promql --
-label_replace(temperature, "dst", "value-$1", "nonexistent-src", "(.*)")
+label_replace(temperature, "job", "value-$1", "nonexistent-src", "(.*)")
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,
@@ -19,15 +31,15 @@ CREATE TABLE otel_metrics_gauge (
     Value Float64
 ) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_gauge VALUES
-    ('temperature', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 22.5);
+    ('temperature', map('instance', 'i1', 'job', 'demo'), toDateTime64('2026-01-01 00:00:00', 9), 22.5);
 -- expected_rows --
 [
-  ["temperature", {"host": "a", "dst": "value-"}, "2026-01-01T00:00:00Z", 22.5]
+  ["temperature", {"instance": "i1", "job": "value-"}, "2026-01-01T00:00:00Z", 22.5]
 ]
 -- args --
 [0] string = "nonexistent-src"
 [1] string = "^(.*)$"
-[2] string = "dst"
+[2] string = "job"
 [3] string = "nonexistent-src"
 [4] string = "value-"
 [5] string = "nonexistent-src"
@@ -40,7 +52,7 @@ INSERT INTO otel_metrics_gauge VALUES
 [12] int64 = 9
 [13] int64 = 300000000000
 -- chplan --
-Project [MetricName, labelReplace(Attributes, dst="dst", replacement="value-\\1", src="nonexistent-src", regex="(.*)", emptyReplacement="value-") AS Attributes, TimeUnix, Value]
+Project [MetricName, labelReplace(Attributes, dst="job", replacement="value-\\1", src="nonexistent-src", regex="(.*)", emptyReplacement="value-") AS Attributes, TimeUnix, Value]
   Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
     Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
       Filter predicate=(((MetricName = "temperature") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))

--- a/test/spec/promql/label_replace_no_match.txtar
+++ b/test/spec/promql/label_replace_no_match.txtar
@@ -18,19 +18,21 @@ INSERT INTO otel_metrics_gauge VALUES
 [1] string = "^nomatch-(.*)$"
 [2] string = "dst"
 [3] string = "host"
-[4] string = "^nomatch-(.*)$"
-[5] string = "renamed"
-[6] string = "temperature"
-[7] string = "2026-01-01 00:00:01.000000000"
-[8] int64 = 9
+[4] string = "renamed"
+[5] string = "host"
+[6] string = "^nomatch-(.*)$"
+[7] string = "renamed"
+[8] string = "temperature"
 [9] string = "2026-01-01 00:00:01.000000000"
 [10] int64 = 9
-[11] int64 = 300000000000
+[11] string = "2026-01-01 00:00:01.000000000"
+[12] int64 = 9
+[13] int64 = 300000000000
 -- chplan --
-Project [MetricName, labelReplace(Attributes, dst="dst", replacement="renamed", src="host", regex="nomatch-(.*)") AS Attributes, TimeUnix, Value]
+Project [MetricName, labelReplace(Attributes, dst="dst", replacement="renamed", src="host", regex="nomatch-(.*)", emptyReplacement="renamed") AS Attributes, TimeUnix, Value]
   Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
     Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
       Filter predicate=(((MetricName = "temperature") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
         Scan(otel_metrics_gauge)
 -- sql --
-SELECT `MetricName`, mapFilter((k, v) -> v != '', if(match(`Attributes`[?], ?), mapUpdate(`Attributes`, map(?, replaceRegexpOne(`Attributes`[?], ?, ?))), `Attributes`)) AS `Attributes`, `TimeUnix`, `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
+SELECT `MetricName`, mapFilter((k, v) -> v != '', if(match(`Attributes`[?], ?), mapUpdate(`Attributes`, map(?, if(empty(`Attributes`[?]), ?, replaceRegexpOne(`Attributes`[?], ?, ?)))), `Attributes`)) AS `Attributes`, `TimeUnix`, `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))

--- a/test/spec/promql/label_replace_regex_capture.txtar
+++ b/test/spec/promql/label_replace_regex_capture.txtar
@@ -18,19 +18,21 @@ INSERT INTO otel_metrics_gauge VALUES
 [1] string = "^host-(.*)$"
 [2] string = "service"
 [3] string = "host"
-[4] string = "^host-(.*)$"
-[5] string = "svc-\\1"
-[6] string = "temperature"
-[7] string = "2026-01-01 00:00:01.000000000"
-[8] int64 = 9
+[4] string = "svc-"
+[5] string = "host"
+[6] string = "^host-(.*)$"
+[7] string = "svc-\\1"
+[8] string = "temperature"
 [9] string = "2026-01-01 00:00:01.000000000"
 [10] int64 = 9
-[11] int64 = 300000000000
+[11] string = "2026-01-01 00:00:01.000000000"
+[12] int64 = 9
+[13] int64 = 300000000000
 -- chplan --
-Project [MetricName, labelReplace(Attributes, dst="service", replacement="svc-\\1", src="host", regex="host-(.*)") AS Attributes, TimeUnix, Value]
+Project [MetricName, labelReplace(Attributes, dst="service", replacement="svc-\\1", src="host", regex="host-(.*)", emptyReplacement="svc-") AS Attributes, TimeUnix, Value]
   Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
     Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
       Filter predicate=(((MetricName = "temperature") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
         Scan(otel_metrics_gauge)
 -- sql --
-SELECT `MetricName`, mapFilter((k, v) -> v != '', if(match(`Attributes`[?], ?), mapUpdate(`Attributes`, map(?, replaceRegexpOne(`Attributes`[?], ?, ?))), `Attributes`)) AS `Attributes`, `TimeUnix`, `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
+SELECT `MetricName`, mapFilter((k, v) -> v != '', if(match(`Attributes`[?], ?), mapUpdate(`Attributes`, map(?, if(empty(`Attributes`[?]), ?, replaceRegexpOne(`Attributes`[?], ?, ?)))), `Attributes`)) AS `Attributes`, `TimeUnix`, `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))


### PR DESCRIPTION
## Summary

Closes the two residual non-\`__name__\` diffs from compat run [25901406046](https://github.com/tsouza/cerberus/actions/runs/25901406046):

- `round(demo_memory_usage_bytes)`: upstream Prom v3.0.1 bug — fixed in [prometheus/prometheus#15250](https://github.com/prometheus/prometheus/pull/15250) post-v3.0.1. Bump the compose reference target from `v3.0.1` to `v3.11.3` (LTS-line latest). Cerberus already drops `__name__` correctly via `projectValueOverInner` (#359, #376) — same path abs/ceil/floor use, all of which pass in the same compat run. No cerberus code change here.
- `label_replace(demo_num_cpus, "job", "value-$1", "nonexistent-src", "(.*)")`: residual after #360. CH ≤ 24.8's `replaceRegexpOne('', '^(.*)$', 'value-\1')` silently returns the empty string (input pass-through) instead of `"value-"`, so the outer `mapFilter((k, v) -> v != '', …)` drops the `job` label entirely. Prom and the spec say the row should emit `job="value-"`. #360's chDB regression passed because chDB bundles CH 25.8, which has the upstream fix.

### label_replace fix shape

Precompute the empty-captures replacement template at SQL build time (`qlcommon.EmptyCapturesReplacement`) and short-circuit the empty-source path in the emitted SQL:

```
if(empty(map[src]),
   '<emptyReplacement>',
   replaceRegexpOne(map[src], regex, replacement))
```

For `value-$1` against an empty match the precomputed branch evaluates to `value-`, matching Prom's `regexp.Regexp.ExpandString` semantics (every capture group binds to `""`). CH ≥ 25.8 (chDB lane) honours the replacement natively so both branches converge; the conditional is load-bearing only on the 24.8 deployment lane (the compose target + the default OTel collector LTS pin).

Both PromQL and LogQL `label_replace` lowerings populate the new `chplan.LabelReplace.EmptyReplacement` field; the chsql builder emits the new SQL shape uniformly.

## Predicted compat resolution

Both queries flip from `diff != ""` to clean in compat run after this lands. Other 44 diffs from 25901406046 are tracked by the in-flight pool fixes (time/binop drops landed via #376, V-V on() via #377, etc.).

## Test plan

- [x] `go test ./internal/qlcommon/ ./internal/chsql/ ./internal/chplan/ ./internal/promql/ ./internal/logql/` (worktree)
- [x] `go test -tags chdb -run TestRoundTripChDB/label_replace ./test/spec/promql/ ./test/spec/logql/` (worktree)
- [x] Direct CH 24.8 query against the emitted SQL shape — confirms `job="value-"` lands on the row even with the empty-input replaceRegexpOne bug
- [x] `prom/prometheus:v3.11.3` returns `round(up)` without `__name__`; `v3.0.1` returns it with `__name__`
- [ ] `compatibility.yml` post-merge run: round + nonexistent-src label_replace clean