### PR TITLE
feat(ci/loki): informational loki-compatibility lane (push + nightly + dispatch)

### DIFF
--- a/.github/workflows/loki-compatibility.yml
+++ b/.github/workflows/loki-compatibility.yml
@@ -1,0 +1,115 @@
+name: loki-compatibility
+
+# Status: PR 4 of docs/loki-compliance-plan.md. The diff driver this
+# workflow invokes (built by harness/loki-compatibility/scripts/run-
+# loki-compatibility.sh from the vendored grafana/loki:pkg/logql/bench
+# subtree) lands in PR 3 (#387) on top of the corpus from PR 2 (#369).
+# The PR-1 scaffold (#368) already provided the docker-compose stack +
+# seeder this workflow boots.
+#
+# Like the prometheus/compliance and tempo/compatibility siblings, this
+# lane is informational — the LogQL surface is still landing and the
+# upstream selector vocabulary intentionally mismatches cerberus's
+# seeded fixture today, so a non-zero diff exit is expected. Promotion
+# to a required PR check tracks PR 5 of the plan (cerberus-owned
+# driver with report-format parity) and the wider LogQL milestone
+# graduation in docs/roadmap.md.
+#
+# Triggers:
+#   * push to main       — informational only. The job-level
+#                          continue-on-error keeps the workflow
+#                          conclusion green so this is not a required
+#                          check by accident. Path filter scoped to
+#                          inputs that can affect parity drift.
+#   * schedule           — nightly cron, offset from sibling harnesses
+#                          to spread runner load (compatibility 04:11,
+#                          tempo-compatibility 04:23, this one 04:37).
+#   * workflow_dispatch  — manual runs from the GH UI.
+#
+# Per ~/.claude/CI_STEPS.md, every step uses a first-party / well-known
+# Action — no `curl | sh` installs. Actions used here:
+#   * actions/checkout@v6           — stdlib.
+#   * actions/setup-go@v6           — `go run ./cmd/seed` + `go test -c`
+#                                     for the vendored bench driver.
+#   * docker/setup-buildx-action@v3 — buildkit-backed compose build
+#                                     (clickhouse + reference Loki +
+#                                     cerberus image).
+#   * actions/upload-artifact@v7    — diff report.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      # Restrict to changes that can plausibly shift LogQL parity.
+      # Cerberus-wide refactors are already covered by ci.yml + the
+      # PromQL compatibility lane.
+      - 'internal/api/loki/**'
+      - 'internal/logql/**'
+      - 'harness/loki-compatibility/**'
+      - '.github/workflows/loki-compatibility.yml'
+  schedule:
+    # Nightly at 04:37 UTC. Offset from compatibility.yml (04:11),
+    # tempo-compatibility.yml (04:23) and the e2e dashboard run so
+    # concurrent runs don't fight for the ubuntu-latest pool.
+    - cron: '37 4 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: loki-compatibility-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  loki-compatibility:
+    name: loki/compatibility
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Informational baseline. The run-loki-compatibility.sh script
+    # exits non-zero on any diff (per its documented exit table in
+    # PR 387: rc=1 on diff, rc>=2 on harness failure), and today's
+    # seeded fixture does not satisfy the upstream ${SELECTOR}
+    # vocabulary — see harness/loki-compatibility/cerberus-test-
+    # queries.yml. continue-on-error keeps the workflow badge green
+    # while we're in informational mode. Promotion to a required PR
+    # check tracks PR 5 of the rollout (cerberus-owned driver) and
+    # docs/roadmap.md.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+
+      # The run script does `go run ./cmd/seed` + `go test -tags=
+      # remote_correctness -c` of the vendored bench driver, so we
+      # need a Go toolchain. setup-go honours go.mod's `go` directive
+      # and pulls the matching toolchain.
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      # Buildx gives the Compose build cache + a consistent backend
+      # for the local cerberus image context.
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Run loki-compatibility harness
+        id: harness
+        # The script handles its own teardown via an EXIT trap
+        # (compose down -v + go.mod / go.sum revert), so no explicit
+        # cleanup step is needed even on failure. job-level
+        # continue-on-error keeps a non-zero rc informational.
+        run: ./harness/loki-compatibility/scripts/run-loki-compatibility.sh
+
+      - name: Upload report
+        # `if: always()` so we capture whatever the driver wrote even
+        # when the harness step failed. The script writes the raw
+        # `go test -v` stream to harness/loki-compatibility/reports/
+        # diff.json (PR 3 contract); PR 5 of the rollout will swap in
+        # a cerberus-owned report shape that matches the Prom harness.
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: loki-compatibility-report
+          path: harness/loki-compatibility/reports/
+          if-no-files-found: warn
+          retention-days: 30


### PR DESCRIPTION
**PR 4** of the rollout in [`docs/loki-compliance-plan.md`](docs/loki-compliance-plan.md):

> **PR 4 — informational lane** in `.github/workflows/loki-compatibility.yml`. Trigger: `push: main` + nightly cron + `workflow_dispatch`. Report uploaded as artifact. Initially NOT a required check (matches Prom precedent).

## Depends on (stack ordering)

The lane invokes `harness/loki-compatibility/scripts/run-loki-compatibility.sh`. The script's PR-3 contract (build the diff driver from the vendored `pkg/logql/bench` subtree, run `TestRemoteStorageEquality`, write `reports/diff.json`) is delivered by:

- #368 (PR 1) — compose + seeder scaffold. **Merged.**
- #369 (PR 2) — vendor `pkg/logql/bench` corpus + driver shell. **Open.**
- #387 (PR 3) — wire diff driver + Justfile recipe + report writing. **Open** (stacked on #369).

This PR (PR 4) is independent of the chsql / Go code paths and only touches `.github/workflows/`. It can land before #369 / #387 — until those merge, the run script (still on the PR-1 contract on `main`) executes the smoke and the workflow uploads whatever the seeder produces. Once #369 + #387 land, subsequent runs pick up the new script transparently. The path filter (`harness/loki-compatibility/**`) means PR 369 / 387 will re-trigger the lane on merge.

## Summary

- Mirrors the **tempo-compatibility precedent** (`.github/workflows/tempo-compatibility.yml`, merged via #370) — same informational stance, same `continue-on-error: true` shape, same `upload-artifact + if: always()` pattern.
- Triggers: `push: main` (path-filtered to `internal/api/loki/**`, `internal/logql/**`, `harness/loki-compatibility/**`, and the workflow itself) + `schedule` (nightly cron at **04:37 UTC**, offset from `compatibility.yml` 04:11 and `tempo-compatibility.yml` 04:23 to spread runner load) + `workflow_dispatch`.
- Steps use first-party Actions only per `~/.claude/CI_STEPS.md`:
  - `actions/checkout@v6`
  - `actions/setup-go@v6` (`go-version-file: go.mod`, `cache: true`) — the run script does `go run ./cmd/seed` + `go test -tags=remote_correctness -c`.
  - `docker/setup-buildx-action@v3` — Compose builds the local cerberus image context.
  - `actions/upload-artifact@v7` — `harness/loki-compatibility/reports/`, `if: always()`, 30-day retention.
- Job-level `continue-on-error: true` keeps the workflow conclusion green while we're in informational mode (matches the upstream `${SELECTOR}` / fixture mismatch documented in `harness/loki-compatibility/cerberus-test-queries.yml`).
- No required-check change. Promotion tracks PR 5 of the rollout (cerberus-owned driver) and the wider LogQL milestone graduation in `docs/roadmap.md`.

## Constraints honoured

- chsql Builder discipline — N/A; workflow YAML only.
- No `t.Skip` introduced — N/A; no Go test changes.
- No MD060 disable.
- No Co-Authored-By trailer.
- First-party Actions for every step (no `curl | sh`).

## Test plan

- [ ] After merge, `Actions` tab shows the `loki-compatibility` workflow registered.
- [ ] `workflow_dispatch` from the UI runs end-to-end on `main` and uploads a `loki-compatibility-report` artifact.
- [ ] First nightly run (04:37 UTC) lands a fresh artifact.
- [ ] Status is informational only — branch protection on `main` continues to require `check` + `lint` and nothing else.