### PR TITLE
fix(logql): sampleShapeOverLogInner reads Attributes when inner is vector-agg

### DIFF
--- a/internal/logql/binary.go
+++ b/internal/logql/binary.go
@@ -318,14 +318,51 @@ func projectValueOverLogInner(inner chplan.Node, s schema.Logs, newValue chplan.
 // The function is only called from [lowerVectorVector] — every other
 // LogQL binop path operates on the inner LogQL shape directly without
 // the VectorJoin canonical-shape requirement.
+//
+// Inner shape selector:
+//
+//   - vector-aggregation leg (e.g. `sum by (svc) (count_over_time(...))`):
+//     `wrapVectorAggregateForSample` has already projected the row into
+//     the (MetricName, Attributes, TimeUnix, Value) Sample contract, so
+//     the `ResourceAttributes` column no longer exists. Reading it would
+//     surface as `UNKNOWN_IDENTIFIER: ResourceAttributes` at chDB.
+//     Forward the existing `Attributes` column verbatim instead.
+//   - every other leg shape (RangeWindow, lowerLiteral / lowerVector
+//     synthetic, label_replace wrap): the column carrying stream
+//     identity is `ResourceAttributes` — rename it to `Attributes`
+//     under the projection.
 func sampleShapeOverLogInner(inner chplan.Node, s schema.Logs) chplan.Node {
+	attrsCol := s.ResourceAttributesColumn
+	if isVectorAggregateSampleShape(inner) {
+		attrsCol = "Attributes"
+	}
 	return &chplan.Project{
 		Input: inner,
 		Projections: []chplan.Projection{
 			{Expr: &chplan.LitString{V: ""}, Alias: "MetricName"},
-			{Expr: &chplan.ColumnRef{Name: s.ResourceAttributesColumn}, Alias: "Attributes"},
+			{Expr: &chplan.ColumnRef{Name: attrsCol}, Alias: "Attributes"},
 			{Expr: &chplan.FuncCall{Name: "now64", Args: []chplan.Expr{&chplan.LitInt{V: 9}}}, Alias: "TimeUnix"},
 			{Expr: &chplan.ColumnRef{Name: rangeAggSynthValueColumn}, Alias: rangeAggSynthValueColumn},
 		},
 	}
+}
+
+// isVectorAggregateSampleShape reports whether inner already carries the
+// canonical Sample contract — i.e. came out of
+// [wrapVectorAggregateForSample]. The signal is a top-level
+// `*chplan.Project` whose alias list includes `Attributes`; that's the
+// only LogQL lowering that produces an `Attributes`-aliased projection
+// (RangeWindow / lowerLiteral / lowerVector / label_replace all alias
+// `ResourceAttributes`).
+func isVectorAggregateSampleShape(n chplan.Node) bool {
+	p, ok := n.(*chplan.Project)
+	if !ok {
+		return false
+	}
+	for _, proj := range p.Projections {
+		if proj.Alias == "Attributes" {
+			return true
+		}
+	}
+	return false
 }

--- a/test/spec/logql/binop_vv_group_left_with_agg_legs.txtar
+++ b/test/spec/logql/binop_vv_group_left_with_agg_legs.txtar
@@ -1,0 +1,64 @@
+-- query.logql --
+sum by (svc) (count_over_time({app="x"}[5m])) / on(svc) group_left(env) sum by (svc) (count_over_time({app="y"}[5m]))
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
+    (toDateTime64('2025-12-31 23:58:00', 9), 'a', map('app', 'x', 'svc', 'api', 'env', 'prod')),
+    (toDateTime64('2025-12-31 23:59:00', 9), 'b', map('app', 'x', 'svc', 'api', 'env', 'prod')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'c', map('app', 'x', 'svc', 'api', 'env', 'prod')),
+    (toDateTime64('2025-12-31 23:58:00', 9), 'd', map('app', 'y', 'svc', 'api', 'env', 'prod')),
+    (toDateTime64('2025-12-31 23:59:00', 9), 'e', map('app', 'y', 'svc', 'api', 'env', 'prod')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'f', map('app', 'y', 'svc', 'api', 'env', 'prod'));
+-- expected_rows --
+[
+  ["", {"svc": "api"}, "2026-01-01T00:00:01Z", 1]
+]
+-- args --
+[0] string = ""
+[1] string = "env"
+[2] string = ""
+[3] int64 = 9
+[4] string = ""
+[5] string = "svc"
+[6] int64 = 9
+[7] string = "svc"
+[8] int64 = 1
+[9] string = "app"
+[10] string = "x"
+[11] string = "svc"
+[12] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[13] string = ""
+[14] int64 = 9
+[15] string = ""
+[16] string = "svc"
+[17] int64 = 9
+[18] string = "svc"
+[19] int64 = 1
+[20] string = "app"
+[21] string = "y"
+[22] string = "svc"
+[23] string = "svc"
+[24] string = "svc"
+[25] string = "svc"
+-- chplan --
+VectorJoin op=/ match=on(svc) card=many-to-one include=[env]
+  Project ["" AS MetricName, Attributes AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+    Project ["" AS MetricName, map("svc", gkey_0) AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+      Aggregate groupBy=[ResourceAttributes["svc"] AS gkey_0] funcs=[sum(Value) AS Value]
+        RangeWindow func=count_over_time range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
+          Project [ResourceAttributes, Timestamp, 1 AS Value]
+            Filter predicate=(ResourceAttributes["app"] = "x")
+              Scan(otel_logs)
+  Project ["" AS MetricName, Attributes AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+    Project ["" AS MetricName, map("svc", gkey_0) AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+      Aggregate groupBy=[ResourceAttributes["svc"] AS gkey_0] funcs=[sum(Value) AS Value]
+        RangeWindow func=count_over_time range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
+          Project [ResourceAttributes, Timestamp, 1 AS Value]
+            Filter predicate=(ResourceAttributes["app"] = "y")
+              Scan(otel_logs)
+-- sql --
+SELECT ? AS `MetricName`, mapConcat(L.`Attributes`, mapFilter((k, v) -> k IN (?), R.`Attributes`)) AS `Attributes`, L.`TimeUnix`, (L.`Value` / R.`Value`) AS `Value` FROM (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT `MetricName` AS `_join_MetricName`, `Attributes` AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value` FROM (SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT ? AS `MetricName`, map(?, `gkey_0`) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`[?] AS `gkey_0`, sum(`Value`) AS `Value` FROM (SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1) GROUP BY `ResourceAttributes`[?]))) GROUP BY `MetricName`, `Attributes`)) AS L INNER JOIN (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT ? AS `MetricName`, map(?, `gkey_0`) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`[?] AS `gkey_0`, sum(`Value`) AS `Value` FROM (SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1) GROUP BY `ResourceAttributes`[?]))) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`))) AS R ON L.`Attributes`[?] = R.`Attributes`[?]


### PR DESCRIPTION
## Summary

Fixes the prod-bug that PR #383 documented but deferred: when a
vector-vector binary expression has a vector-aggregation leg, the
inner plan has already been re-shaped into the canonical Sample
contract by `wrapVectorAggregateForSample` — the `ResourceAttributes`
column no longer exists. `sampleShapeOverLogInner` was nonetheless
unconditionally referencing `ResourceAttributes`, so shapes like

```logql
sum by(svc) (count_over_time({app="x"}[5m]))
  / on(svc) group_left(env)
sum by(svc) (count_over_time({app="y"}[5m]))
```

failed at chDB with `UNKNOWN_IDENTIFIER: ResourceAttributes`.

## Fix

`sampleShapeOverLogInner` now detects the post-aggregate Sample shape
via a top-level `*chplan.Project` whose alias list includes
`Attributes` (the canonical Sample-contract alias). On that shape it
forwards the existing `Attributes` column verbatim; every other leg
shape (RangeWindow, synthetic literal / vector, label_replace) still
goes through the `ResourceAttributes -> Attributes` rename path.

## Fixture

`test/spec/logql/binop_vv_group_left_with_agg_legs.txtar` exercises
the exact shape from #383's deferred fixture draft end-to-end through
chDB. Before this PR the query errored at SQL execution; after, it
emits the right SQL and returns rows.

## Refs

- Pool-DA #383: documented the bug + sidestepped with bare
  `count_over_time` legs.

## Test plan

- [x] `go test ./internal/logql/` -- 189 pass (incl. existing
  binop_scalar_vector / binop_vector_vector_bool unaffected)
- [x] `go test -tags chdb ./test/spec/logql/` -- 70 pass (incl. the
  new vector-aggregation-leg fixture)