### PR TITLE
feat(harness/tempo-compatibility): TXTAR corpus + JSON differ + smoke diff

### DIFF
--- a/.github/workflows/tempo-compatibility.yml
+++ b/.github/workflows/tempo-compatibility.yml
@@ -1,12 +1,12 @@
 name: tempo-compatibility
 
-# Status: PR 3 of docs/tempo-compliance-plan.md. The driver this
-# workflow invokes is a real seeder (PR 3) that pushes OTLP into
-# reference Tempo + INSERTs into ClickHouse for cerberus + smokes
-# /api/traces/<id> on both backends. continue-on-error is preserved
-# at the job level so the workflow stays an informational baseline
-# until PR 7 promotes it to a required check (per the rollout in the
-# plan doc).
+# Status: PR 4 of docs/tempo-compliance-plan.md. The driver this
+# workflow invokes runs both subcommands in sequence: seed (push OTLP
+# into Tempo + INSERT into ClickHouse for cerberus + smoke
+# /api/traces/<id>) then diff (TXTAR corpus through /api/search +
+# /api/traces; markdown report under reports/). continue-on-error is
+# preserved at the job level so the workflow stays an informational
+# baseline until PR 7 promotes it to a required check.
 #
 # Triggers:
 #   * workflow_dispatch  — manual runs from the GH UI.
@@ -53,13 +53,15 @@ jobs:
     name: tempo/compatibility
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # Informational baseline for PR 2 — the stub driver always exits 0,
-    # but the Compose lifecycle (pull tempo image, build cerberus image,
-    # build driver image, wait for healthchecks) can legitimately fail
-    # under runner flake. continue-on-error keeps the workflow badge
-    # green during the rollout. PR 7 of the plan promotes this to a
-    # gated required check once nightly is stable for 7 consecutive
-    # runs (per docs/tempo-compliance-plan.md "Per-PR breakdown").
+    # Informational baseline through PR 6. The Compose lifecycle (pull
+    # tempo image, build cerberus image, build driver image, wait for
+    # healthchecks) can legitimately fail under runner flake, and the
+    # PR-4 differ runs without --fail-on-diff so a per-case structural
+    # regression also stays informational. continue-on-error keeps the
+    # workflow badge green during the rollout. PR 7 of the plan
+    # promotes this to a gated required check once nightly is stable
+    # for 7 consecutive runs (per docs/tempo-compliance-plan.md
+    # "Per-PR breakdown").
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6
@@ -80,8 +82,9 @@ jobs:
 
       - name: Upload report
         # `if: always()` so we capture whatever the driver wrote even
-        # when the harness step failed. PR 3's seeder doesn't write a
-        # report (smoke is in-process); PR 4's differ populates this dir.
+        # when the harness step failed. PR 4 wires up the differ which
+        # writes diff.md under this directory; the seeder leaves it
+        # empty.
         if: always()
         uses: actions/upload-artifact@v7
         with:

--- a/harness/tempo-compatibility/README.md
+++ b/harness/tempo-compatibility/README.md
@@ -1,14 +1,15 @@
 # Tempo / TraceQL compatibility harness
 
-> Status: **PR 3 (seeder)** of the rollout described in
-> [`docs/tempo-compliance-plan.md`](../../docs/tempo-compliance-plan.md).
+> Status: **PR 4 (read corpus + smoke diff)** of the rollout described
+> in [`docs/tempo-compliance-plan.md`](../../docs/tempo-compliance-plan.md).
 > This directory holds the vendored snapshot from PR 1 (`upstream/`),
 > the Docker Compose stack standing up reference Tempo + cerberus +
-> ClickHouse, the driver binary with a `seed` subcommand that pushes a
-> deterministic OTLP batch to both backends and asserts
-> `/api/traces/<id>` returns matching span counts on both, and a
-> nightly / `workflow_dispatch` GitHub Actions lane (informational, not
-> a required check). The diff driver follows in PR 4.
+> ClickHouse, the driver binary with two subcommands — `seed` (push
+> deterministic OTLP batch to both backends, smoke `/api/traces/<id>`)
+> and `diff` (run the TXTAR corpus through both backends, write a
+> markdown diff report) — and a nightly / `workflow_dispatch` GitHub
+> Actions lane (informational, not a required check). Metrics and tag
+> endpoints land in PRs 5-6.
 >
 > ## Ingest path (PR 3 vs the original plan)
 >
@@ -38,20 +39,24 @@ See [`docs/tempo-compliance-plan.md`](../../docs/tempo-compliance-plan.md)
 for the full landscape analysis, the per-PR breakdown, and the diff
 strategy.
 
-## Layout (current — PR 3)
+## Layout (current — PR 4)
 
 ```text
 harness/tempo-compatibility/
   README.md             this file
-  docker-compose.yml    tempo + cerberus + clickhouse + seeder driver
+  docker-compose.yml    tempo + cerberus + clickhouse + driver
   tempo-config.yaml     reference Tempo (local block storage)
   scripts/
-    run-tempo-compatibility.sh  `docker compose up --wait` + driver + teardown
+    run-tempo-compatibility.sh  `docker compose up --wait` + seed + diff + teardown
   driver/                       cerberus-owned driver binary
     Dockerfile          repo-root context multi-stage build
-    main.go             PR 3 — subcommand dispatcher (seed / diff)
-    seeder.go           PR 3 — OTLP push to Tempo + CH INSERT for cerberus
-    corpus/.gitkeep     PR 4+ corpus dir placeholder
+    main.go             subcommand dispatcher (seed / diff)
+    seeder.go           OTLP push to Tempo + CH INSERT for cerberus
+    corpus.go           TXTAR corpus loader (PR 4)
+    differ.go           canonical-key + relative-epsilon diff (PR 4)
+    diff.go             `diff` subcommand: HTTP fetch + assertions + report (PR 4)
+    corpus/
+      smoke.txtar       ~20 cases lifted from shadow corpus (PR 4)
   reports/              driver report output (gitignored)
   upstream/             PR 1 — vendored snapshot (read-only reference)
     LICENSE             AGPL-3.0, copied verbatim from grafana/tempo
@@ -60,23 +65,39 @@ harness/tempo-compatibility/
     pkg/httpclient/     Tempo HTTP client; reused by the future driver
 ```
 
-## Layout (planned — PRs 4-7)
-
-PRs 4-7 grow the driver from seeder into the real differ:
+## Layout (planned — PRs 5-7)
 
 ```text
 harness/tempo-compatibility/
   driver/
-    main.go             PR 3+ — subcommand dispatcher (seed / diff)
-    seeder.go           PR 3  — push OTLP to tempo + CH INSERT for cerberus
-    corpus.go           PR 4  — TXTAR corpus loader
-    differ.go           PR 4  — JSON-shape diff
-    report.go           PR 4  — markdown report writer
     corpus/
-      smoke.txtar       PR 4  — 10-query smoke set
-      coverage.txtar    PR 5  — ~40 queries, one per TraceQL feature
-  expected-failures.json  PR 4+
+      coverage.txtar    PR 5/6 — full coverage (metrics + tags + values)
+  expected-failures.json  PR 5+
 ```
+
+## Differ design (PR 4)
+
+The differ runs each corpus case against both Tempo and cerberus via
+`/api/search` (and `/api/traces/<id>` for per-id smoke cases), then
+compares the responses. Two complications drive the diff strategy:
+
+1. **Cerberus's `TraceSummary.TraceID` is synthetic today.** See
+   `internal/api/tempo/handler.go::toTraceSummaries` — the stub key is
+   `MetricName + "|" + Timestamp`, not the real OTLP trace ID hex
+   Tempo returns. A literal byte-equal would false-positive on every
+   case. The differ canonicalises each summary via
+   `H(rootServiceName || rootTraceName)` and compares the canonical-key
+   multisets, exactly the plan's "hash trace IDs deterministically
+   (different orderings of equal sets don't false-positive)" prescription.
+2. **Per-case expectations are orthogonal to differential equality.** A
+   case like `{ resource.service.name = "checkout" }` can carry an
+   `expected_min_traces: 1` assertion ("each backend, on its own, must
+   return at least one trace") AND still be subject to the structural
+   diff between the two responses. The driver reports both in the
+   markdown summary so a single regression doesn't mask the other.
+
+Numeric fields (durationMs, startTimeUnixNano) compare under a 1e-9
+relative epsilon — same defaults as `harness/prometheus-compliance/shadow`.
 
 ## What's in `upstream/`
 

--- a/harness/tempo-compatibility/docker-compose.yml
+++ b/harness/tempo-compatibility/docker-compose.yml
@@ -128,17 +128,18 @@ services:
       retries: 30
 
   tempo-compat-driver:
-    # PR 3: the driver is no longer a stub — it's a real binary with
-    # `seed` (this PR) and `diff` (pending in PR 4) subcommands. The
-    # default command runs `seed`; the smoke + run-tempo-compatibility
-    # script invokes `docker compose run --rm tempo-compat-driver seed`
-    # explicitly so the contract is stable across PRs.
+    # PR 4: the driver now exposes two real subcommands — `seed` (push
+    # fixture into both backends) and `diff` (run TXTAR corpus, write
+    # markdown report). The run-tempo-compatibility script invokes
+    # them in sequence; the default `command:` keeps `seed` so an ad-hoc
+    # `docker compose run --rm tempo-compat-driver` still does the
+    # right thing during local debugging.
     #
     # Build context widened from `./driver` to the repo root so the
     # driver can `import "github.com/tsouza/cerberus/internal/schema/ddl"`
     # and the OTLP gRPC client types via cerberus's go.mod. Mirrors
     # how Dockerfile.local builds the cerberus binary.
-    image: cerberus-tempo-compat-driver:pr3
+    image: cerberus-tempo-compat-driver:pr4
     build:
       context: ../..
       dockerfile: harness/tempo-compatibility/driver/Dockerfile
@@ -164,7 +165,10 @@ services:
       clickhouse:
         condition: service_healthy
     volumes:
-      # `reports/` is mounted ahead of PR 4 so the diff subcommand can
-      # write the markdown report once it lands. The seeder doesn't
-      # write to this dir; the mount is forward-compat only.
+      # `reports/` receives the differ's markdown output (PR 4). The
+      # seeder doesn't write here; the mount is mandatory for `diff`.
       - ./reports:/reports
+      # `corpus/` is the TXTAR source the differ reads. Mount read-only
+      # so a defensive write in the driver can't accidentally rewrite
+      # the source-of-truth corpus from inside the container.
+      - ./driver/corpus:/corpus:ro

--- a/harness/tempo-compatibility/driver/Dockerfile
+++ b/harness/tempo-compatibility/driver/Dockerfile
@@ -1,21 +1,24 @@
 # syntax=docker/dockerfile:1
 # Multi-stage build for the Tempo / TraceQL compatibility driver.
 #
-# Status: PR 3 of docs/tempo-compliance-plan.md. The driver grew from
-# stdlib-only stub (PR 2) into a real seeder that imports
-# `internal/schema/ddl` and `go.opentelemetry.io/proto/otlp/...`. To
-# compile against cerberus's go.mod we must build with a repo-root
-# context (same shape as Dockerfile.local for the cerberus binary).
+# Status: PR 4 of docs/tempo-compliance-plan.md. The driver exposes
+# `seed` (PR 3) + `diff` (PR 4) subcommands; both compile from the same
+# binary so the compose image is stable across PR-level rollout. The
+# repo-root build context lets the driver import
+# `internal/schema/ddl` and the OTLP gRPC client types via cerberus's
+# go.mod (same shape as Dockerfile.local for the cerberus binary).
 #
 # Build:
 #   docker compose build tempo-compat-driver
 # Run:
 #   docker compose run --rm tempo-compat-driver seed
+#   docker compose run --rm tempo-compat-driver diff [--fail-on-diff]
 #
 # Subcommands (see driver/main.go):
 #   seed   PR 3 — push OTLP to Tempo + INSERT into ClickHouse +
 #                 smoke-poll /api/traces on both backends.
-#   diff   PR 4 — corpus + markdown report (not implemented yet).
+#   diff   PR 4 — read TXTAR corpus, run TraceQL through both backends
+#                 via /api/search + /api/traces, write markdown report.
 
 FROM golang:1.26 AS build
 WORKDIR /src
@@ -37,7 +40,7 @@ RUN CGO_ENABLED=0 go build \
 FROM gcr.io/distroless/static-debian12:nonroot
 
 LABEL org.opencontainers.image.title="cerberus-tempo-compat-driver"
-LABEL org.opencontainers.image.description="Tempo / TraceQL compatibility driver (seeder in PR 3; differ lands in PR 4)"
+LABEL org.opencontainers.image.description="Tempo / TraceQL compatibility driver (seed + diff subcommands)"
 LABEL org.opencontainers.image.licenses="MIT"
 
 COPY --from=build /out/driver /usr/local/bin/driver

--- a/harness/tempo-compatibility/driver/corpus.go
+++ b/harness/tempo-compatibility/driver/corpus.go
@@ -1,0 +1,340 @@
+// Corpus loader for the Tempo / TraceQL compatibility differ
+// (PR 4 of docs/tempo-compliance-plan.md).
+//
+// The format is a lightweight TXTAR variant — same shape as
+// harness/prometheus-compliance/shadow/corpus.go — so the parser
+// looks at single-line `-- section --` headers and treats every
+// non-header line as section body. The supported sections:
+//
+//	-- name --                  short identifier, used in the report
+//	-- query --                 the TraceQL expression
+//	-- endpoint --              one of: search | search_recent | traces
+//	-- traceid_template --      a template like "{svc}/{idx}" (only for `traces`)
+//	-- expected_min_traces --   integer; minimum traces both sides must return
+//	-- expected_max_traces --   integer; maximum traces either side may return
+//	-- expected_services --     newline-separated list of `service.name` values
+//	                            that should appear in `rootServiceName`
+//	-- expected_root_name_re -- Go regexp; every returned trace's rootTraceName
+//	                            must match
+//	-- skip_reason --           if non-empty, the case is parsed but skipped
+//	                            (e.g. `metrics endpoint — lands in PR 5`)
+//
+// Cases are separated by the next `-- name --` header. Lines starting
+// with `#` outside section bodies are comments. Inside a section body,
+// `#`-prefixed lines are also stripped before the body is interpreted
+// so a corpus author can group related cases with header comments
+// between them without the trailing case's last section accidentally
+// swallowing the comment.
+//
+// Why a custom shape (and not lift `harness/prometheus-compliance/shadow`'s
+// loader)? The sibling loader is PromQL-specific (it has a
+// `-- expected_strategy --` slot that means nothing for TraceQL). The
+// section-header machinery is trivially small (~80 lines) so duplicating
+// is cheaper than carving a generic core out of the prom shadow corpus.
+// If we ever need a third copy, factor a small `txtar.Parser` then.
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// CorpusCase is one entry parsed out of the TXTAR file.
+//
+// Every field except Name + Query + Endpoint is optional; the differ
+// applies whichever assertions are populated and skips the rest. That
+// keeps the corpus author free to add narrow per-case assertions without
+// having to populate the whole schema.
+type CorpusCase struct {
+	// Name is a short identifier surfaced in the markdown report.
+	Name string
+
+	// Query is the raw TraceQL expression. It is sent to both backends
+	// verbatim (URL-encoded by the differ) so a deliberate parser-only
+	// query (no result expected) round-trips through the same code path
+	// as a normal corpus case.
+	Query string
+
+	// Endpoint selects the HTTP path the differ hits:
+	//
+	//   * search         GET /api/search?q=<TraceQL>
+	//   * search_recent  GET /api/search/recent (TraceQL ignored)
+	//   * traces         GET /api/traces/<id>   (TraceIDTemplate populated)
+	//
+	// The seeder pushes data with deterministic trace IDs derived from
+	// (service, traceIdx); see TraceIDTemplate below for the format.
+	Endpoint string
+
+	// TraceIDTemplate is only consulted when Endpoint == "traces".
+	// Format: "<svc>/<idx>" — the differ derives the byte-identical
+	// 16-byte trace ID via the same hash the seeder uses, hex-encodes
+	// it, and substitutes it into the URL. Decoupling the template
+	// from the binary trace ID keeps the corpus file human-editable.
+	TraceIDTemplate string
+
+	// SkipReason, when non-empty, makes the case parse but skip during
+	// diffing. Used to declare PR-5-shaped cases (metrics endpoints)
+	// in the smoke corpus so the file stays the single source of truth
+	// for the eventual full corpus while keeping PR 4's CI green.
+	SkipReason string
+
+	// ExpectedMinTraces / ExpectedMaxTraces bound the cardinality both
+	// backends must agree with. Zero (the default) disables the bound.
+	ExpectedMinTraces int
+	ExpectedMaxTraces int
+
+	// ExpectedServices is a set membership assertion: every value listed
+	// here must appear in at least one returned trace's rootServiceName.
+	// Empty disables the assertion.
+	ExpectedServices []string
+
+	// ExpectedRootNameRE is a compiled regexp; if non-nil every returned
+	// trace's rootTraceName must match. Compiled at parse time so the
+	// differ runs without per-case regex cost.
+	ExpectedRootNameRE *regexp.Regexp
+}
+
+// LoadCorpus opens a corpus file and parses it into CorpusCases.
+// Errors carry the source path + line number for the failing entry so a
+// hand-edit typo in the TXTAR shows up with actionable context.
+func LoadCorpus(path string) ([]CorpusCase, error) {
+	f, err := os.Open(path) //nolint:gosec // G304: corpus path is a trusted CLI argument
+	if err != nil {
+		return nil, fmt.Errorf("open corpus %q: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	return parseCorpus(f, path)
+}
+
+// Section keywords recognized by the corpus parser. Kept as package-level
+// constants so the parser + the header-validation helpers share a single
+// source of truth and so unit tests can name them directly.
+const (
+	secName            = "name"
+	secQuery           = "query"
+	secEndpoint        = "endpoint"
+	secTraceIDTemplate = "traceid_template"
+	secSkipReason      = "skip_reason"
+	secMinTraces       = "expected_min_traces"
+	secMaxTraces       = "expected_max_traces"
+	secServices        = "expected_services"
+	secRootNameRE      = "expected_root_name_re"
+)
+
+// stripCommentLines returns the body with comment-only lines (`# ...`
+// after trimming) removed. Comment lines between two cases are
+// expected to be ignored (the corpus author wants to group related
+// cases with a header comment) but they end up inside the previous
+// case's last section body because the section closes only on the
+// next `-- name --`. The same trick lets a section body legitimately
+// contain a query that includes `#` — at the start of a line — though
+// no current case does.
+func stripCommentLines(raw string) string {
+	var bodyLines []string
+	for _, line := range strings.Split(raw, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+		bodyLines = append(bodyLines, line)
+	}
+	return strings.TrimSpace(strings.Join(bodyLines, "\n"))
+}
+
+// applySection routes a flushed section body to the right field on
+// `cur`. The integer / regexp parsers wrap their errors with the
+// section name so the caller can prefix source:line.
+func applySection(cur *CorpusCase, section, body string) error {
+	switch section {
+	case secName:
+		cur.Name = body
+	case secQuery:
+		cur.Query = body
+	case secEndpoint:
+		cur.Endpoint = body
+	case secTraceIDTemplate:
+		cur.TraceIDTemplate = body
+	case secSkipReason:
+		cur.SkipReason = body
+	case secMinTraces:
+		return applyIntSection(body, "expected_min_traces", &cur.ExpectedMinTraces)
+	case secMaxTraces:
+		return applyIntSection(body, "expected_max_traces", &cur.ExpectedMaxTraces)
+	case secServices:
+		if body == "" {
+			return nil
+		}
+		for _, line := range strings.Split(body, "\n") {
+			if s := strings.TrimSpace(line); s != "" {
+				cur.ExpectedServices = append(cur.ExpectedServices, s)
+			}
+		}
+	case secRootNameRE:
+		if body == "" {
+			return nil
+		}
+		re, err := regexp.Compile(body)
+		if err != nil {
+			return fmt.Errorf("expected_root_name_re: compile %q: %w", body, err)
+		}
+		cur.ExpectedRootNameRE = re
+	}
+	return nil
+}
+
+func applyIntSection(body, name string, dst *int) error {
+	if body == "" {
+		return nil
+	}
+	n, err := strconv.Atoi(body)
+	if err != nil {
+		return fmt.Errorf("%s: parse %q: %w", name, body, err)
+	}
+	*dst = n
+	return nil
+}
+
+// validateCase checks the assembled case for required-field violations.
+// Returns the case (with defaulted endpoint) ready to append.
+func validateCase(cur CorpusCase, ord int) (CorpusCase, error) {
+	if cur.Name == "" {
+		return cur, fmt.Errorf("case missing -- name -- (case #%d)", ord)
+	}
+	if cur.Query == "" && cur.Endpoint != "search_recent" {
+		return cur, fmt.Errorf("case %q missing -- query -- (search_recent is the only endpoint that may omit it)", cur.Name)
+	}
+	if cur.Endpoint == "" {
+		cur.Endpoint = "search"
+	}
+	switch cur.Endpoint {
+	case "search", "search_recent", "traces":
+	default:
+		return cur, fmt.Errorf("case %q: unknown endpoint %q (want search | search_recent | traces)", cur.Name, cur.Endpoint)
+	}
+	if cur.Endpoint == "traces" && cur.TraceIDTemplate == "" {
+		return cur, fmt.Errorf("case %q: endpoint=traces requires -- traceid_template --", cur.Name)
+	}
+	return cur, nil
+}
+
+// isKnownSection reports whether the given header name is a recognized
+// body section (anything other than `name`, which is the case
+// boundary).
+func isKnownSection(name string) bool {
+	switch name {
+	case secQuery, secEndpoint, secTraceIDTemplate, secSkipReason,
+		secMinTraces, secMaxTraces, secServices, secRootNameRE:
+		return true
+	}
+	return false
+}
+
+// parseCorpus is the unit-testable inner driver. Mirrors the shape of
+// harness/prometheus-compliance/shadow/corpus.go::parseCorpus so the
+// two loaders evolve in step.
+func parseCorpus(r io.Reader, source string) ([]CorpusCase, error) {
+	var (
+		out      []CorpusCase
+		current  CorpusCase
+		section  string
+		buf      strings.Builder
+		haveOpen bool
+		lineNum  int
+	)
+
+	flushSection := func() error {
+		body := stripCommentLines(buf.String())
+		buf.Reset()
+		return applySection(&current, section, body)
+	}
+
+	flushCase := func() error {
+		if !haveOpen {
+			return nil
+		}
+		v, err := validateCase(current, len(out)+1)
+		if err != nil {
+			return err
+		}
+		out = append(out, v)
+		current = CorpusCase{}
+		haveOpen = false
+		return nil
+	}
+
+	handleHeader := func(name string) error {
+		if haveOpen {
+			if err := flushSection(); err != nil {
+				return err
+			}
+		}
+		switch {
+		case name == secName:
+			// New case starts. The `name` section is the canonical
+			// case boundary (the first non-comment header).
+			if err := flushCase(); err != nil {
+				return err
+			}
+			haveOpen = true
+			section = secName
+		case isKnownSection(name):
+			if !haveOpen {
+				return fmt.Errorf("section %q outside a case (start with -- name --)", name)
+			}
+			section = name
+		default:
+			return fmt.Errorf("unknown section %q", name)
+		}
+		return nil
+	}
+
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		lineNum++
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+
+		if strings.HasPrefix(trimmed, "-- ") && strings.HasSuffix(trimmed, " --") {
+			name := strings.TrimSpace(trimmed[3 : len(trimmed)-3])
+			if err := handleHeader(name); err != nil {
+				return nil, fmt.Errorf("%s:%d: %w", source, lineNum, err)
+			}
+			continue
+		}
+
+		if !haveOpen {
+			// Skip leading comments / blank lines until the first `-- name --`.
+			if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+				continue
+			}
+			return nil, fmt.Errorf("%s:%d: content before first '-- name --' header", source, lineNum)
+		}
+
+		buf.WriteString(line)
+		buf.WriteByte('\n')
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read corpus %q: %w", source, err)
+	}
+
+	// Final flushes.
+	if haveOpen {
+		if err := flushSection(); err != nil {
+			return nil, fmt.Errorf("%s: trailing section: %w", source, err)
+		}
+		if err := flushCase(); err != nil {
+			return nil, err
+		}
+	}
+
+	if len(out) == 0 {
+		return nil, fmt.Errorf("%s: corpus is empty", source)
+	}
+	return out, nil
+}

--- a/harness/tempo-compatibility/driver/corpus/.gitkeep
+++ b/harness/tempo-compatibility/driver/corpus/.gitkeep
@@ -1,3 +1,0 @@
-# PR 4 of docs/tempo-compliance-plan.md will populate this directory with
-# TXTAR corpus files (smoke.txtar, coverage.txtar). Kept empty in PR 2
-# so the docker-compose `:/corpus:ro` bind mount has a valid target.

--- a/harness/tempo-compatibility/driver/corpus/smoke.txtar
+++ b/harness/tempo-compatibility/driver/corpus/smoke.txtar
@@ -1,0 +1,292 @@
+# Tempo / TraceQL compatibility smoke corpus (PR 4).
+#
+# Lifted-and-adapted from harness/prometheus-compliance/shadow/
+# traceql_shadow_test.go::traceqlInstantCases() (~20 hand-translated
+# cases). The shadow test runs the SAME 20 categories against a fake
+# in-process span set; this corpus runs the SAME categories against
+# real Tempo + real cerberus, fed by harness/.../driver/seeder.go's
+# deterministic OTLP push.
+#
+# Seeder fixture shape (see seeder.go):
+#   * 4 services: checkout, payments, search, shipping
+#   * 25 traces per service (100 traces total)
+#   * Each trace: 1 root span (Server, "GET /api/<svc>/<idx>", 150ms)
+#     + 2-4 children (rotating kinds, every 5th child = ERROR)
+#   * Resource attrs: service.name, deployment.env="compat-test",
+#     telemetry.sdk="cerberus-tempo-compat-seeder", trace.fixture="pr3"
+#   * Span attrs (root): http.method=GET, http.target=/api/<svc>/<idx>,
+#     trace.index=<idx>
+#   * Span attrs (child): child.index, kind
+#   * Status: Ok (default), Error for every 5th child
+#   * Anchor: 2026-05-11T00:00:00Z; each trace shifted by (svcIdx*25 +
+#     traceIdx) seconds — last trace lands ~400s after anchor
+#
+# Diff strategy reminder (see differ.go top-of-file):
+#   * Trace IDs are canonicalised via H(rootServiceName||rootTraceName)
+#     so cerberus's currently-synthetic TraceID doesn't false-positive.
+#   * Numeric fields compare under 1e-9 relative epsilon.
+#   * Cardinality is reported as a reason but every key-level miss is
+#     also surfaced under missing_in_a / missing_in_b.
+#
+# Cases below cover the 7 shadow categories: attribute matchers per
+# scope (5), intrinsics (4), structural ops (4), set ops (3), inner
+# aggregates (2), and metrics pipeline (2). PR 5 will flip the metrics
+# pipeline cases from `skip_reason` to active.
+
+# --- Attribute matchers per scope (5) ---
+
+-- name --
+resource_service_name_eq_checkout
+-- query --
+{ resource.service.name = "checkout" }
+-- endpoint --
+search
+-- expected_min_traces --
+1
+-- expected_max_traces --
+200
+-- expected_services --
+checkout
+
+-- name --
+resource_service_name_neq_checkout
+-- query --
+{ resource.service.name != "checkout" }
+-- endpoint --
+search
+-- expected_min_traces --
+1
+-- expected_max_traces --
+200
+
+-- name --
+resource_service_name_regex_shipping
+-- query --
+{ resource.service.name =~ "ship.*" }
+-- endpoint --
+search
+-- expected_min_traces --
+1
+-- expected_max_traces --
+200
+-- expected_services --
+shipping
+
+-- name --
+resource_deployment_env_eq_compat_test
+-- query --
+{ resource.deployment.env = "compat-test" }
+-- endpoint --
+search
+-- expected_min_traces --
+1
+-- expected_max_traces --
+500
+
+-- name --
+span_http_method_eq_get
+-- query --
+{ span.http.method = "GET" }
+-- endpoint --
+search
+-- expected_min_traces --
+1
+-- expected_max_traces --
+500
+
+# --- Intrinsics (4) ---
+
+-- name --
+duration_gt_100ms
+-- query --
+{ duration > 100ms }
+-- endpoint --
+search
+-- expected_min_traces --
+1
+-- expected_max_traces --
+500
+
+-- name --
+duration_lt_300ms
+-- query --
+{ duration < 300ms }
+-- endpoint --
+search
+-- expected_min_traces --
+1
+-- expected_max_traces --
+500
+
+-- name --
+kind_eq_server
+-- query --
+{ kind = server }
+-- endpoint --
+search
+-- expected_min_traces --
+1
+-- expected_max_traces --
+500
+
+-- name --
+status_eq_error
+-- query --
+{ status = error }
+-- endpoint --
+search
+# Every 5th child reports error; ~80 error spans across the fixture.
+-- expected_min_traces --
+1
+-- expected_max_traces --
+500
+
+# --- Structural ops (4) ---
+
+-- name --
+descendant_op_payments_to_consumer
+-- query --
+{ resource.service.name = "payments" } > { kind = consumer }
+-- endpoint --
+search
+-- expected_min_traces --
+0
+-- expected_max_traces --
+500
+
+-- name --
+ancestor_op_consumer_under_payments
+-- query --
+{ kind = consumer } < { resource.service.name = "payments" }
+-- endpoint --
+search
+-- expected_min_traces --
+0
+-- expected_max_traces --
+500
+
+-- name --
+direct_parent_op_checkout_to_child
+-- query --
+{ resource.service.name = "checkout" } >> { kind = client }
+-- endpoint --
+search
+-- expected_min_traces --
+0
+-- expected_max_traces --
+500
+
+-- name --
+direct_child_op_client_under_checkout
+-- query --
+{ kind = client } << { resource.service.name = "checkout" }
+-- endpoint --
+search
+-- expected_min_traces --
+0
+-- expected_max_traces --
+500
+
+# --- Set ops (3) ---
+
+-- name --
+set_and_checkout_and_status_error
+-- query --
+{ resource.service.name = "checkout" && status = error }
+-- endpoint --
+search
+-- expected_min_traces --
+0
+-- expected_max_traces --
+500
+
+-- name --
+set_or_two_services
+-- query --
+{ resource.service.name = "checkout" } || { resource.service.name = "payments" }
+-- endpoint --
+search
+-- expected_min_traces --
+1
+-- expected_max_traces --
+500
+
+-- name --
+set_or_two_kinds
+-- query --
+{ kind = server } || { kind = internal }
+-- endpoint --
+search
+-- expected_min_traces --
+1
+-- expected_max_traces --
+500
+
+# --- Inner aggregates (2) ---
+# Inner aggregations run through /api/search today (no metrics
+# endpoint required); they're listed as a separate category because
+# the wire shape is the same SearchResponse envelope but the row
+# semantics differ (group-by-trace vs per-span).
+
+-- name --
+count_spans_per_trace
+-- query --
+{ resource.service.name =~ ".+" } | count() > 0
+-- endpoint --
+search
+-- expected_min_traces --
+0
+-- expected_max_traces --
+500
+
+-- name --
+avg_duration_per_trace_status_ok
+-- query --
+{ status = ok } | avg(duration) > 0
+-- endpoint --
+search
+-- expected_min_traces --
+0
+-- expected_max_traces --
+500
+
+# --- MetricsPipeline (2) — DEFERRED to PR 5 ---
+# These are wire-shape-different from /api/search (they hit
+# /api/metrics/query_range and return Prom-shape series). Listed here
+# so the smoke set documents the eventual full coverage map; the
+# differ skips them by checking SkipReason.
+
+-- name --
+metrics_rate_over_status_error
+-- query --
+{ status = error } | rate()
+-- endpoint --
+search
+-- skip_reason --
+metrics endpoint — lands in PR 5 (docs/tempo-compliance-plan.md)
+
+-- name --
+metrics_quantile_p95_duration
+-- query --
+{ duration > 0 } | quantile_over_time(duration, .95)
+-- endpoint --
+search
+-- skip_reason --
+metrics endpoint — lands in PR 5 (docs/tempo-compliance-plan.md)
+
+# --- Per-id smoke (1) ---
+# Doesn't map back to a shadow case (the shadow tests evaluate against
+# a synthetic in-process span set, never against /api/traces/<id>).
+# Lifted from the seeder's smoke step: PR 3 confirmed both backends
+# resolve the first checkout/0 trace; PR 4 reuses that wiring as a
+# distinct corpus shape so the differ exercises both /api/search and
+# /api/traces/<id> code paths in one run.
+
+-- name --
+trace_by_id_first_checkout
+-- query --
+{ }
+-- endpoint --
+traces
+-- traceid_template --
+checkout/0

--- a/harness/tempo-compatibility/driver/corpus_test.go
+++ b/harness/tempo-compatibility/driver/corpus_test.go
@@ -1,0 +1,210 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseCorpus_Basic(t *testing.T) {
+	t.Parallel()
+	in := `# leading comment
+-- name --
+attr_eq
+-- query --
+{ resource.service.name = "checkout" }
+-- endpoint --
+search
+-- expected_min_traces --
+1
+-- expected_max_traces --
+200
+-- expected_services --
+checkout
+-- name --
+status_error
+-- query --
+{ status = error }
+-- endpoint --
+search
+-- expected_min_traces --
+0
+-- skip_reason --
+metrics endpoint
+`
+	got, err := parseCorpus(strings.NewReader(in), "test")
+	if err != nil {
+		t.Fatalf("parseCorpus: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 cases, got %d", len(got))
+	}
+	if got[0].Name != "attr_eq" || got[0].Query != `{ resource.service.name = "checkout" }` {
+		t.Fatalf("case[0] = %+v", got[0])
+	}
+	if got[0].Endpoint != "search" {
+		t.Fatalf("case[0] endpoint = %q", got[0].Endpoint)
+	}
+	if got[0].ExpectedMinTraces != 1 || got[0].ExpectedMaxTraces != 200 {
+		t.Fatalf("case[0] bounds = %d..%d", got[0].ExpectedMinTraces, got[0].ExpectedMaxTraces)
+	}
+	if len(got[0].ExpectedServices) != 1 || got[0].ExpectedServices[0] != "checkout" {
+		t.Fatalf("case[0] services = %v", got[0].ExpectedServices)
+	}
+	if got[1].SkipReason != "metrics endpoint" {
+		t.Fatalf("case[1] skip = %q", got[1].SkipReason)
+	}
+}
+
+func TestParseCorpus_DefaultEndpointIsSearch(t *testing.T) {
+	t.Parallel()
+	in := `-- name --
+default_ep
+-- query --
+{ duration > 100ms }
+`
+	got, err := parseCorpus(strings.NewReader(in), "test")
+	if err != nil {
+		t.Fatalf("parseCorpus: %v", err)
+	}
+	if got[0].Endpoint != "search" {
+		t.Fatalf("expected default endpoint = search, got %q", got[0].Endpoint)
+	}
+}
+
+func TestParseCorpus_TracesEndpointRequiresTemplate(t *testing.T) {
+	t.Parallel()
+	in := `-- name --
+trace_by_id
+-- query --
+{ }
+-- endpoint --
+traces
+`
+	if _, err := parseCorpus(strings.NewReader(in), "test"); err == nil {
+		t.Fatal("expected error: traces endpoint without traceid_template")
+	}
+}
+
+func TestParseCorpus_TracesEndpointWithTemplateOK(t *testing.T) {
+	t.Parallel()
+	in := `-- name --
+trace_by_id
+-- query --
+{ }
+-- endpoint --
+traces
+-- traceid_template --
+checkout/0
+`
+	got, err := parseCorpus(strings.NewReader(in), "test")
+	if err != nil {
+		t.Fatalf("parseCorpus: %v", err)
+	}
+	if got[0].TraceIDTemplate != "checkout/0" {
+		t.Fatalf("traceid_template = %q", got[0].TraceIDTemplate)
+	}
+}
+
+func TestParseCorpus_RootNameRECompiles(t *testing.T) {
+	t.Parallel()
+	in := `-- name --
+re
+-- query --
+{ resource.service.name = "checkout" }
+-- expected_root_name_re --
+^GET /api/[a-z]+/[0-9]+$
+`
+	got, err := parseCorpus(strings.NewReader(in), "test")
+	if err != nil {
+		t.Fatalf("parseCorpus: %v", err)
+	}
+	if got[0].ExpectedRootNameRE == nil {
+		t.Fatal("expected_root_name_re did not compile")
+	}
+	if !got[0].ExpectedRootNameRE.MatchString("GET /api/checkout/3") {
+		t.Fatalf("regex did not match expected fixture root name")
+	}
+}
+
+func TestParseCorpus_BadRegexFails(t *testing.T) {
+	t.Parallel()
+	in := `-- name --
+re
+-- query --
+{ }
+-- expected_root_name_re --
+[unclosed
+`
+	if _, err := parseCorpus(strings.NewReader(in), "test"); err == nil {
+		t.Fatal("expected error on bad regex")
+	}
+}
+
+func TestParseCorpus_UnknownSectionFails(t *testing.T) {
+	t.Parallel()
+	in := `-- name --
+x
+-- query --
+{ }
+-- bogus --
+y
+`
+	if _, err := parseCorpus(strings.NewReader(in), "test"); err == nil {
+		t.Fatal("expected error on unknown section")
+	}
+}
+
+func TestParseCorpus_EmptyFails(t *testing.T) {
+	t.Parallel()
+	if _, err := parseCorpus(strings.NewReader("# only comments\n"), "test"); err == nil {
+		t.Fatal("expected error on empty corpus")
+	}
+}
+
+func TestParseCorpus_ContentBeforeFirstHeaderFails(t *testing.T) {
+	t.Parallel()
+	in := `not a header
+-- name --
+x
+-- query --
+{ }
+`
+	if _, err := parseCorpus(strings.NewReader(in), "test"); err == nil {
+		t.Fatal("expected error on content before first header")
+	}
+}
+
+func TestParseCorpus_UnknownEndpointFails(t *testing.T) {
+	t.Parallel()
+	in := `-- name --
+x
+-- query --
+{ }
+-- endpoint --
+bogus
+`
+	if _, err := parseCorpus(strings.NewReader(in), "test"); err == nil {
+		t.Fatal("expected error on unknown endpoint")
+	}
+}
+
+func TestSmokeCorpus_LoadsAndMeetsFloor(t *testing.T) {
+	t.Parallel()
+	cases, err := LoadCorpus(filepath.Join("corpus", "smoke.txtar"))
+	if err != nil {
+		t.Fatalf("LoadCorpus: %v", err)
+	}
+	if len(cases) < 20 {
+		t.Fatalf("smoke corpus shrunk: got %d, want >= 20", len(cases))
+	}
+	// Every active case has a non-empty query.
+	for _, c := range cases {
+		if c.SkipReason != "" {
+			continue
+		}
+		if c.Query == "" && c.Endpoint != "search_recent" {
+			t.Fatalf("case %q: empty query but endpoint=%q", c.Name, c.Endpoint)
+		}
+	}
+}

--- a/harness/tempo-compatibility/driver/diff.go
+++ b/harness/tempo-compatibility/driver/diff.go
@@ -1,0 +1,479 @@
+// Diff subcommand: drives the TraceQL corpus through both backends,
+// applies per-case assertions, computes the structural diff, and
+// emits a markdown report.
+//
+// PR 4 of docs/tempo-compliance-plan.md. Smoke is the only corpus
+// shipped today (~20 cases lifted from the in-tree shadow corpus);
+// metrics endpoints + tag endpoints land in PRs 5+6. The subcommand
+// is wired into main.go's switch on os.Args[1].
+//
+// Flag surface mirrors the seeder so a script that scripts the seeder
+// can re-target the differ with the same env-or-flag triple.
+
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// runDiff is the subcommand entry point. Wired from main.go.
+func runDiff(args []string) error {
+	fs := flag.NewFlagSet("diff", flag.ContinueOnError)
+	var (
+		corpusPath  = fs.String("corpus", envOr("CORPUS_PATH", "/corpus/smoke.txtar"), "path to the TXTAR corpus file")
+		tempoHTTP   = fs.String("tempo-http", envOr("TEMPO_HTTP_URL", "http://tempo:3200"), "Tempo HTTP base URL")
+		cerberusURL = fs.String("cerberus", envOr("CERBERUS_URL", "http://cerberus-tempo:29092"), "cerberus HTTP base URL")
+		reportPath  = fs.String("report", envOr("REPORT_PATH", "/reports/diff.md"), "markdown report output path")
+		overall     = fs.Duration("timeout", 5*time.Minute, "overall driver timeout")
+		perReq      = fs.Duration("request-timeout", 30*time.Second, "per-HTTP-request timeout")
+		failOnDiff  = fs.Bool("fail-on-diff", false, "exit non-zero if any case reports a diff (otherwise just write report)")
+		searchLimit = fs.Int("search-limit", 200, "Tempo /api/search ?limit= value")
+		anchorIn    = fs.String("anchor", anchor, "fixture anchor RFC3339; used to compute search start/end window")
+	)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	ctx, cancel := context.WithTimeout(context.Background(), *overall)
+	defer cancel()
+
+	cases, err := LoadCorpus(*corpusPath)
+	if err != nil {
+		return fmt.Errorf("load corpus: %w", err)
+	}
+	if len(cases) < 20 {
+		// Same shape as harness/.../shadow/traceql_shadow_test.go's
+		// `len(cases) < 20` guard — protects against a corpus author
+		// accidentally trimming the smoke set below the agreed floor.
+		return fmt.Errorf("smoke corpus shrunk: got %d cases, want >= 20", len(cases))
+	}
+	logger.Info("loaded corpus", "path", *corpusPath, "cases", len(cases))
+
+	anchorTS, err := time.Parse(time.RFC3339, *anchorIn)
+	if err != nil {
+		return fmt.Errorf("parse anchor %q: %w", *anchorIn, err)
+	}
+	// Search window: one hour either side of the anchor. The seeder
+	// pushes traces at anchor + (svcIdx*25 + traceIdx) seconds, so the
+	// last span lands at anchor + ~400s; ±1h is generous slack.
+	startTS := anchorTS.Add(-1 * time.Hour)
+	endTS := anchorTS.Add(1 * time.Hour)
+
+	client := &http.Client{Timeout: *perReq}
+	opts := caseOpts{
+		tempoHTTP:   *tempoHTTP,
+		cerberusURL: *cerberusURL,
+		startTS:     startTS,
+		endTS:       endTS,
+		searchLimit: *searchLimit,
+	}
+	results := make([]CaseResult, 0, len(cases))
+
+	for _, tc := range cases {
+		tc := tc
+		if tc.SkipReason != "" {
+			logger.Info("skipping case", "name", tc.Name, "reason", tc.SkipReason)
+			results = append(results, CaseResult{Case: tc, Skipped: true})
+			continue
+		}
+		logger.Info("diffing case", "name", tc.Name, "endpoint", tc.Endpoint)
+		results = append(results, diffCase(ctx, client, tc, opts))
+	}
+
+	if err := writeReport(*reportPath, results); err != nil {
+		return fmt.Errorf("write report: %w", err)
+	}
+	logger.Info("wrote markdown report", "path", *reportPath)
+
+	// Per the plan: PR 4 is informational only (continue-on-error at
+	// the workflow level). The differ still respects --fail-on-diff so
+	// a local repro can hard-fail on a regression.
+	if *failOnDiff {
+		for _, r := range results {
+			if r.Skipped {
+				continue
+			}
+			if r.HardError != "" || !r.Diff.Equal || len(r.Assertions) > 0 {
+				return fmt.Errorf("diffs reported; see %s", *reportPath)
+			}
+		}
+	}
+	return nil
+}
+
+// CaseResult is one corpus case's outcome. Populated incrementally
+// (HTTP first, assertions next, diff last) so the report can show
+// partial info when a step failed.
+type CaseResult struct {
+	Case CorpusCase
+
+	// Skipped means the case carried a SkipReason; the report lists
+	// these in a separate section.
+	Skipped bool
+
+	// HardError is set when the case failed before the diff could run
+	// (URL build, HTTP error, non-2xx status). Mutually exclusive with
+	// Diff / Assertions being meaningful.
+	HardError string
+
+	TempoStatus    int
+	CerberusStatus int
+
+	// Assertions is the union of per-side assertion failures (tempo's
+	// list, then cerberus's). Empty means both sides met the case's
+	// expectations.
+	Assertions []DiffReason
+
+	// Diff is the structural diff between the two response bodies. Its
+	// Equal field is true when the canonical-key sets agreed and every
+	// matched entry passed field-by-field tolerance.
+	Diff Diff
+}
+
+// caseOpts bundles the per-run URL / window inputs threaded through
+// every corpus case. Pulled out of runDiff's loop to keep that function
+// under funlen and to make the per-case driver (diffCase) trivially
+// testable.
+type caseOpts struct {
+	tempoHTTP   string
+	cerberusURL string
+	startTS     time.Time
+	endTS       time.Time
+	searchLimit int
+}
+
+// diffCase executes a single corpus case end-to-end (URL build → HTTP
+// fetch on both sides → per-side assertions → structural diff). The
+// returned CaseResult is populated incrementally so a hard error at any
+// step short-circuits but still surfaces partial context.
+func diffCase(ctx context.Context, client *http.Client, tc CorpusCase, opts caseOpts) CaseResult {
+	res := CaseResult{Case: tc}
+
+	tempoURL, err := buildURL(opts.tempoHTTP, tc, "tempo", opts.startTS, opts.endTS, opts.searchLimit)
+	if err != nil {
+		res.HardError = fmt.Sprintf("build tempo url: %v", err)
+		return res
+	}
+	cerbURL, err := buildURL(opts.cerberusURL, tc, "cerberus", opts.startTS, opts.endTS, opts.searchLimit)
+	if err != nil {
+		res.HardError = fmt.Sprintf("build cerberus url: %v", err)
+		return res
+	}
+
+	tempoBody, tempoStatus, terr := fetchJSON(ctx, client, tempoURL)
+	cerbBody, cerbStatus, cerr := fetchJSON(ctx, client, cerbURL)
+	res.TempoStatus = tempoStatus
+	res.CerberusStatus = cerbStatus
+	if terr != nil {
+		res.HardError = fmt.Sprintf("tempo fetch: %v", terr)
+	}
+	if cerr != nil {
+		if res.HardError == "" {
+			res.HardError = fmt.Sprintf("cerberus fetch: %v", cerr)
+		} else {
+			res.HardError = res.HardError + "; cerberus fetch: " + cerr.Error()
+		}
+	}
+	// /api/search returns 200 on empty matches; treat any non-2xx
+	// as a hard error since the harness's assertion checks expect
+	// a well-formed envelope.
+	if res.HardError == "" && (tempoStatus/100 != 2 || cerbStatus/100 != 2) {
+		res.HardError = fmt.Sprintf("non-2xx: tempo=%d cerberus=%d", tempoStatus, cerbStatus)
+	}
+	if res.HardError != "" {
+		return res
+	}
+
+	// Per-side assertions first. They are cheap and surface
+	// "cerberus returned 0 rows where corpus said >=N" before the
+	// diff complains about cardinality.
+	tempoReasons, err := AssertCase(tc, tempoBody, "tempo")
+	if err != nil {
+		res.HardError = fmt.Sprintf("assert tempo: %v", err)
+		return res
+	}
+	cerbReasons, err := AssertCase(tc, cerbBody, "cerberus")
+	if err != nil {
+		res.HardError = fmt.Sprintf("assert cerberus: %v", err)
+		return res
+	}
+	res.Assertions = append(res.Assertions, tempoReasons...)
+	res.Assertions = append(res.Assertions, cerbReasons...)
+
+	// Differential diff. The case sets some upper bound on what we
+	// can expect to agree on; the structural diff is independent.
+	d, err := Compare(tempoBody, cerbBody, "tempo", "cerberus", DefaultDiffOptions())
+	if err != nil {
+		res.HardError = fmt.Sprintf("diff: %v", err)
+		return res
+	}
+	res.Diff = d
+	return res
+}
+
+// buildURL composes the per-endpoint URL for a corpus case. The
+// `backend` argument is purely for error messages.
+func buildURL(base string, tc CorpusCase, backend string, startTS, endTS time.Time, searchLimit int) (string, error) {
+	u, err := url.Parse(strings.TrimRight(base, "/"))
+	if err != nil {
+		return "", fmt.Errorf("%s base url: %w", backend, err)
+	}
+	q := url.Values{}
+	switch tc.Endpoint {
+	case "search":
+		u.Path += "/api/search"
+		q.Set("q", tc.Query)
+		q.Set("limit", fmt.Sprintf("%d", searchLimit))
+		q.Set("start", fmt.Sprintf("%d", startTS.Unix()))
+		q.Set("end", fmt.Sprintf("%d", endTS.Unix()))
+	case "search_recent":
+		u.Path += "/api/search/recent"
+		q.Set("limit", fmt.Sprintf("%d", searchLimit))
+	case "traces":
+		id, err := deriveTraceIDFromTemplate(tc.TraceIDTemplate)
+		if err != nil {
+			return "", err
+		}
+		u.Path += "/api/traces/" + id
+	default:
+		return "", fmt.Errorf("unsupported endpoint %q", tc.Endpoint)
+	}
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+// deriveTraceIDFromTemplate converts a corpus template like
+// "checkout/3" into the hex-encoded 16-byte trace ID the seeder used.
+// Mirrors seeder.go::deriveTraceID byte-for-byte (intentionally
+// duplicates the hash logic so the corpus file authors don't need to
+// reach into the seeder's internals).
+func deriveTraceIDFromTemplate(tmpl string) (string, error) {
+	parts := strings.SplitN(tmpl, "/", 2)
+	if len(parts) != 2 {
+		return "", fmt.Errorf("traceid_template %q: want <service>/<idx>", tmpl)
+	}
+	svc := parts[0]
+	var idx int
+	if _, err := fmt.Sscanf(parts[1], "%d", &idx); err != nil {
+		return "", fmt.Errorf("traceid_template %q: parse idx: %w", tmpl, err)
+	}
+	var b [8]byte
+	binary.BigEndian.PutUint64(b[:], uint64(idx)) //nolint:gosec // idx non-negative by construction
+	h := sha256.Sum256(append([]byte("cerberus-tempo-trace:"+svc+":"), b[:]...))
+	return hex.EncodeToString(h[:16]), nil
+}
+
+// fetchJSON GETs a URL with the Accept: application/json header and
+// returns the body + status. Errors include the response body (up to
+// 2KB) so a CH error message lands in the report.
+func fetchJSON(ctx context.Context, client *http.Client, urlStr string) ([]byte, int, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlStr, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 16<<20))
+	if err != nil {
+		return nil, resp.StatusCode, fmt.Errorf("read body: %w", err)
+	}
+	if resp.StatusCode/100 != 2 {
+		// Surface a snippet of the error body in the error string so
+		// the report explains the 4xx/5xx without forcing the caller
+		// to grep container logs.
+		snippet := body
+		if len(snippet) > 2048 {
+			snippet = snippet[:2048]
+		}
+		return body, resp.StatusCode, fmt.Errorf("status %d: %s", resp.StatusCode, string(snippet))
+	}
+	return body, resp.StatusCode, nil
+}
+
+// writeReport renders the case-by-case markdown summary. The format is
+// deliberately simple — a top-level summary line + per-case sections —
+// so the report renders well as a GH Actions artefact preview and is
+// readable as plaintext in the terminal.
+func writeReport(path string, results []CaseResult) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return fmt.Errorf("mkdir report dir: %w", err)
+	}
+	f, err := os.Create(path) //nolint:gosec // G304: report path is a trusted CLI argument
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	return renderReport(f, results)
+}
+
+func renderReport(w io.Writer, results []CaseResult) error {
+	var total, passed, diffed, asserted, skipped, hardErr int
+	for _, r := range results {
+		total++
+		switch {
+		case r.Skipped:
+			skipped++
+		case r.HardError != "":
+			hardErr++
+		case !r.Diff.Equal:
+			diffed++
+		case len(r.Assertions) > 0:
+			asserted++
+		default:
+			passed++
+		}
+	}
+
+	if _, err := fmt.Fprintln(w, "# Tempo / TraceQL compatibility — diff report"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "Generated at %s\n\n", time.Now().UTC().Format(time.RFC3339)); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "## Summary"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "- Cases: %d\n", total); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "- Passed: %d\n", passed); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "- Skipped: %d\n", skipped); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "- Diff: %d\n", diffed); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "- Assertion failures: %d\n", asserted); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "- Hard errors: %d\n", hardErr); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w); err != nil {
+		return err
+	}
+
+	// Sort by name so the report is reproducible across runs and a
+	// reviewer can scan section ordering for regressions without
+	// re-ordering the diff in the head.
+	sorted := append([]CaseResult(nil), results...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Case.Name < sorted[j].Case.Name })
+
+	if _, err := fmt.Fprintln(w, "## Cases"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w); err != nil {
+		return err
+	}
+	for _, r := range sorted {
+		if err := renderCase(w, r); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func renderCase(w io.Writer, r CaseResult) error {
+	if _, err := fmt.Fprintf(w, "### `%s`\n\n", r.Case.Name); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "- endpoint: `%s`\n", r.Case.Endpoint); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "- query: `%s`\n", strings.ReplaceAll(r.Case.Query, "`", "\\`")); err != nil {
+		return err
+	}
+	switch {
+	case r.Skipped:
+		if _, err := fmt.Fprintf(w, "- status: SKIPPED (%s)\n", r.Case.SkipReason); err != nil {
+			return err
+		}
+	case r.HardError != "":
+		if _, err := fmt.Fprintf(w, "- status: ERROR — %s\n", r.HardError); err != nil {
+			return err
+		}
+	case !r.Diff.Equal:
+		if _, err := fmt.Fprintf(w, "- status: DIFF (%d reasons)\n", len(r.Diff.Reasons)); err != nil {
+			return err
+		}
+	case len(r.Assertions) > 0:
+		if _, err := fmt.Fprintf(w, "- status: ASSERTION (%d reasons)\n", len(r.Assertions)); err != nil {
+			return err
+		}
+	default:
+		if _, err := fmt.Fprintln(w, "- status: PASS"); err != nil {
+			return err
+		}
+	}
+	if !r.Skipped && r.HardError == "" {
+		if _, err := fmt.Fprintf(w, "- tempo HTTP: %d  cerberus HTTP: %d\n", r.TempoStatus, r.CerberusStatus); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(w, "- matched canonical-key entries: %d\n", r.Diff.MatchedCount); err != nil {
+			return err
+		}
+	}
+	if len(r.Assertions) > 0 {
+		if _, err := fmt.Fprintln(w); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintln(w, "#### Assertion reasons"); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintln(w); err != nil {
+			return err
+		}
+		for _, reason := range r.Assertions {
+			if _, err := fmt.Fprintf(w, "- [%s] %s\n", reason.Kind, reason.Detail); err != nil {
+				return err
+			}
+		}
+	}
+	if !r.Diff.Equal && len(r.Diff.Reasons) > 0 {
+		if _, err := fmt.Fprintln(w); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintln(w, "#### Diff reasons"); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintln(w); err != nil {
+			return err
+		}
+		for _, reason := range r.Diff.Reasons {
+			if _, err := fmt.Fprintf(w, "- [%s] %s\n", reason.Kind, reason.Detail); err != nil {
+				return err
+			}
+		}
+	}
+	if _, err := fmt.Fprintln(w); err != nil {
+		return err
+	}
+	return nil
+}

--- a/harness/tempo-compatibility/driver/diff_test.go
+++ b/harness/tempo-compatibility/driver/diff_test.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuildURL_Search(t *testing.T) {
+	t.Parallel()
+	tc := CorpusCase{
+		Name:     "x",
+		Query:    `{ resource.service.name = "checkout" }`,
+		Endpoint: "search",
+	}
+	start := time.Unix(1000, 0)
+	end := time.Unix(2000, 0)
+	u, err := buildURL("http://tempo:3200", tc, "tempo", start, end, 200)
+	if err != nil {
+		t.Fatalf("buildURL: %v", err)
+	}
+	if !strings.HasPrefix(u, "http://tempo:3200/api/search?") {
+		t.Fatalf("unexpected url: %s", u)
+	}
+	if !strings.Contains(u, "limit=200") {
+		t.Fatalf("missing limit: %s", u)
+	}
+	if !strings.Contains(u, "start=1000") || !strings.Contains(u, "end=2000") {
+		t.Fatalf("missing start/end: %s", u)
+	}
+	if !strings.Contains(u, "q=") {
+		t.Fatalf("missing q= param: %s", u)
+	}
+}
+
+func TestBuildURL_SearchRecent(t *testing.T) {
+	t.Parallel()
+	tc := CorpusCase{Name: "x", Endpoint: "search_recent"}
+	u, err := buildURL("http://tempo:3200", tc, "tempo", time.Unix(0, 0), time.Unix(0, 0), 20)
+	if err != nil {
+		t.Fatalf("buildURL: %v", err)
+	}
+	if !strings.HasPrefix(u, "http://tempo:3200/api/search/recent?") {
+		t.Fatalf("unexpected url: %s", u)
+	}
+}
+
+func TestBuildURL_TracesByID(t *testing.T) {
+	t.Parallel()
+	tc := CorpusCase{
+		Name:            "x",
+		Endpoint:        "traces",
+		TraceIDTemplate: "checkout/0",
+	}
+	u, err := buildURL("http://tempo:3200", tc, "tempo", time.Unix(0, 0), time.Unix(0, 0), 20)
+	if err != nil {
+		t.Fatalf("buildURL: %v", err)
+	}
+	if !strings.HasPrefix(u, "http://tempo:3200/api/traces/") {
+		t.Fatalf("unexpected url: %s", u)
+	}
+	// Hex-encoded 16-byte ID = 32 hex chars; verify the URL contains a
+	// 32-hex-char suffix so the differ derived a real ID.
+	parts := strings.Split(u, "/")
+	id := parts[len(parts)-1]
+	if len(id) != 32 {
+		t.Fatalf("trace id length = %d, want 32 (hex of 16 bytes): %q", len(id), id)
+	}
+	for _, c := range id {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			t.Fatalf("non-hex char in trace id: %q", id)
+		}
+	}
+}
+
+func TestDeriveTraceIDFromTemplate_DeterministicAcrossCalls(t *testing.T) {
+	t.Parallel()
+	a, err := deriveTraceIDFromTemplate("checkout/0")
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	b, err := deriveTraceIDFromTemplate("checkout/0")
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	if a != b {
+		t.Fatalf("non-deterministic derivation: %s vs %s", a, b)
+	}
+	c, err := deriveTraceIDFromTemplate("checkout/1")
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	if a == c {
+		t.Fatal("trace IDs for checkout/0 and checkout/1 collided")
+	}
+}
+
+func TestDeriveTraceIDFromTemplate_MatchesSeederHash(t *testing.T) {
+	t.Parallel()
+	// The seeder's deriveTraceID (in seeder.go) is the canonical hash;
+	// the differ's deriveTraceIDFromTemplate must produce byte-identical
+	// output for the same (svc, idx) pair or /api/traces/<id> will 404
+	// against the real Tempo backend.
+	gotDiffer, err := deriveTraceIDFromTemplate("checkout/0")
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	// Compute the seeder's hash directly.
+	seederID := deriveTraceID("checkout", 0)
+	wantHex := ""
+	for _, b := range seederID[:] {
+		const hexDigits = "0123456789abcdef"
+		wantHex += string(hexDigits[b>>4]) + string(hexDigits[b&0xf])
+	}
+	if gotDiffer != wantHex {
+		t.Fatalf("differ trace ID = %s, seeder trace ID = %s — these MUST match", gotDiffer, wantHex)
+	}
+}
+
+func TestDeriveTraceIDFromTemplate_BadFormatFails(t *testing.T) {
+	t.Parallel()
+	if _, err := deriveTraceIDFromTemplate("missing-slash"); err == nil {
+		t.Fatal("expected error on missing slash")
+	}
+	if _, err := deriveTraceIDFromTemplate("svc/notanumber"); err == nil {
+		t.Fatal("expected error on non-numeric idx")
+	}
+}

--- a/harness/tempo-compatibility/driver/differ.go
+++ b/harness/tempo-compatibility/driver/differ.go
@@ -1,0 +1,431 @@
+// Differ for the Tempo / TraceQL compatibility harness
+// (PR 4 of docs/tempo-compliance-plan.md).
+//
+// The differ runs each corpus case against both backends (reference
+// Tempo + cerberus) and produces a structured Diff describing what
+// the two sides agreed / disagreed on. The diff is intentionally
+// granular: every category of mismatch is reported as its own
+// `DiffReason`, never collapsed into a single boolean, so the markdown
+// report can surface actionable detail per case.
+//
+// Why not byte-equal? Cerberus's `TraceSummary.TraceID` is synthetic
+// today (see internal/api/tempo/handler.go::toTraceSummaries — the
+// stub key is `MetricName + "|" + Timestamp`, not the real 16-byte
+// OTLP trace ID hex). Tempo's TraceID is the real hex. A literal
+// byte-equal would false-positive on every case until cerberus
+// projects the real TraceId column through to the search summary —
+// outside PR 4's scope. The plan calls this out explicitly:
+// "hash trace IDs deterministically (different orderings of equal
+// sets don't false-positive)".
+//
+// So the differ:
+//
+//   1. Canonicalises each TraceSummary by deriving a stable key
+//      `H(rootServiceName || rootTraceName)`. Both backends produce
+//      the same hash for the same trace because they read the same
+//      seeded fixture.
+//   2. Sorts the trace list by the canonical key on each side.
+//   3. Diffs the canonical-key multisets (matches "different
+//      orderings of equal sets don't false-positive").
+//   4. For matched entries, diffs the per-summary fields under a
+//      relative-epsilon tolerance for `DurationMs` (clock vs
+//      duration-column drift across backends is real).
+//
+// The differ is pure: a string of bytes (the two HTTP responses) goes
+// in, a Diff comes out. Network + retry logic lives in main.go.
+
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// SearchResponse is the minimal subset of Tempo's / cerberus's
+// /api/search payload the differ needs. Field tags use the documented
+// camelCase shape; both backends emit this.
+//
+// We define a private copy (rather than depending on
+// internal/api/tempo/types.go) so the driver stays in `package main`
+// without bridging through cerberus's API package. The shape is small
+// and stable — TraceID, RootServiceName, RootTraceName, StartTime,
+// DurationMs is the contract Grafana parses, so all three (Tempo,
+// cerberus, the differ) read the same fields.
+type SearchResponse struct {
+	Traces  []TraceSummary `json:"traces"`
+	Metrics any            `json:"metrics,omitempty"` // ignored by differ
+}
+
+// TraceSummary mirrors Tempo's /api/search trace element. All fields
+// optional — Tempo sometimes omits StartTimeUnixNano + DurationMs in
+// older builds; cerberus sometimes omits RootServiceName / RootTraceName
+// when projections drop them. The differ tolerates either side missing
+// fields by skipping that field's compare and recording a reason.
+type TraceSummary struct {
+	TraceID           string `json:"traceID"`
+	RootServiceName   string `json:"rootServiceName,omitempty"`
+	RootTraceName     string `json:"rootTraceName,omitempty"`
+	StartTimeUnixNano string `json:"startTimeUnixNano,omitempty"`
+	DurationMs        int    `json:"durationMs,omitempty"`
+}
+
+// CanonicalKey is the per-trace hash used to align the two backends'
+// trace lists. Format: hex(SHA-256(rootServiceName + "\x00" +
+// rootTraceName)) truncated to 16 hex chars (8 bytes of entropy is
+// plenty: 100 traces would collide with p ≈ 100²/(2·2⁶⁴) ≈ 2.7e-16).
+//
+// Truncation keeps the key short in the markdown report. The full
+// 64-hex hash is fine too — only readability suffers.
+func CanonicalKey(t TraceSummary) string {
+	h := sha256.Sum256([]byte(t.RootServiceName + "\x00" + t.RootTraceName))
+	return hex.EncodeToString(h[:8])
+}
+
+// DiffOptions controls numeric-field tolerance. Mirrors the prom
+// shadow differ's shape so an eventual unifier has a clear migration
+// target.
+type DiffOptions struct {
+	// AbsEpsilon: absolute tolerance for fields near zero.
+	AbsEpsilon float64
+	// RelEpsilon: relative tolerance for non-zero fields.
+	RelEpsilon float64
+}
+
+// DefaultDiffOptions returns 1e-9 abs + rel — same defaults as the
+// PromQL shadow harness so the two converge if/when we factor a
+// shared `compat/differ`.
+func DefaultDiffOptions() DiffOptions {
+	return DiffOptions{AbsEpsilon: 1e-9, RelEpsilon: 1e-9}
+}
+
+// DiffReason is one structured complaint surfaced by Compare. Kept as
+// a struct (not a free-form string) so the markdown report can
+// group / filter by Kind without parsing strings.
+type DiffReason struct {
+	Kind   string // "cardinality" | "missing_in_a" | "missing_in_b" | "field_mismatch"
+	Detail string // human-readable; safe to embed in the markdown body
+}
+
+// Diff is the structured outcome of comparing two parsed
+// SearchResponse bodies.
+type Diff struct {
+	// Equal is true iff the two sides match within tolerances.
+	Equal bool
+	// MatchedCount is the number of canonical-key intersections that
+	// survived field-level diffing.
+	MatchedCount int
+	// Reasons enumerates every mismatch in deterministic order.
+	Reasons []DiffReason
+}
+
+// Compare diffs two raw HTTP response bodies. `aLabel` / `bLabel` are
+// embedded in the human-readable reasons so the report distinguishes
+// "missing on tempo side" from "missing on cerberus side".
+func Compare(aBody, bBody []byte, aLabel, bLabel string, opts DiffOptions) (Diff, error) {
+	if opts.AbsEpsilon == 0 && opts.RelEpsilon == 0 {
+		opts = DefaultDiffOptions()
+	}
+
+	a, err := decodeSearch(aBody)
+	if err != nil {
+		return Diff{}, fmt.Errorf("%s: %w", aLabel, err)
+	}
+	b, err := decodeSearch(bBody)
+	if err != nil {
+		return Diff{}, fmt.Errorf("%s: %w", bLabel, err)
+	}
+
+	out := Diff{Equal: true}
+
+	// Cardinality is reported as a reason but does not by itself drive
+	// Equal=false — the per-key intersection / extras below already
+	// surface what's actually missing; reporting cardinality on top
+	// keeps the high-level metric visible in the markdown summary
+	// without double-counting against Equal.
+	if len(a.Traces) != len(b.Traces) {
+		out.Equal = false
+		out.Reasons = append(out.Reasons, DiffReason{
+			Kind:   "cardinality",
+			Detail: fmt.Sprintf("%s=%d traces, %s=%d traces", aLabel, len(a.Traces), bLabel, len(b.Traces)),
+		})
+	}
+
+	aByKey := indexByKey(a.Traces)
+	bByKey := indexByKey(b.Traces)
+
+	var missingInA, missingInB []string
+	for key := range bByKey {
+		if _, ok := aByKey[key]; !ok {
+			missingInA = append(missingInA, key)
+		}
+	}
+	for key := range aByKey {
+		if _, ok := bByKey[key]; !ok {
+			missingInB = append(missingInB, key)
+		}
+	}
+	sort.Strings(missingInA)
+	sort.Strings(missingInB)
+	for _, key := range missingInA {
+		out.Equal = false
+		out.Reasons = append(out.Reasons, DiffReason{
+			Kind:   "missing_in_a",
+			Detail: fmt.Sprintf("key %s present in %s but missing in %s (rootServiceName=%q rootTraceName=%q)", key, bLabel, aLabel, bByKey[key].RootServiceName, bByKey[key].RootTraceName),
+		})
+	}
+	for _, key := range missingInB {
+		out.Equal = false
+		out.Reasons = append(out.Reasons, DiffReason{
+			Kind:   "missing_in_b",
+			Detail: fmt.Sprintf("key %s present in %s but missing in %s (rootServiceName=%q rootTraceName=%q)", key, aLabel, bLabel, aByKey[key].RootServiceName, aByKey[key].RootTraceName),
+		})
+	}
+
+	// Intersection — diff every per-summary field that both sides
+	// populate. Skipping a side's blank field keeps the differ from
+	// false-positing on optional-field omission (Tempo and cerberus
+	// can each legitimately omit StartTimeUnixNano in some builds).
+	matched := make([]string, 0, len(aByKey))
+	for key := range aByKey {
+		if _, ok := bByKey[key]; ok {
+			matched = append(matched, key)
+		}
+	}
+	sort.Strings(matched)
+
+	for _, key := range matched {
+		as := aByKey[key]
+		bs := bByKey[key]
+		reasons := compareSummary(key, as, bs, aLabel, bLabel, opts)
+		if len(reasons) > 0 {
+			out.Equal = false
+			out.Reasons = append(out.Reasons, reasons...)
+			continue
+		}
+		out.MatchedCount++
+	}
+
+	return out, nil
+}
+
+func decodeSearch(body []byte) (SearchResponse, error) {
+	var out SearchResponse
+	if err := json.Unmarshal(body, &out); err != nil {
+		return SearchResponse{}, fmt.Errorf("decode /api/search response: %w", err)
+	}
+	return out, nil
+}
+
+// indexByKey deduplicates by CanonicalKey, keeping the first occurrence
+// — a single backend should never return two traces with the same
+// (rootServiceName, rootTraceName) for the corpus shapes we ship in
+// PR 4 (the seeder gives every trace a unique name); if it does, the
+// per-field diff will catch any inconsistency in the second copy.
+func indexByKey(ts []TraceSummary) map[string]TraceSummary {
+	out := make(map[string]TraceSummary, len(ts))
+	for _, t := range ts {
+		k := CanonicalKey(t)
+		if _, dup := out[k]; dup {
+			continue
+		}
+		out[k] = t
+	}
+	return out
+}
+
+// compareSummary diffs two same-canonical-key TraceSummaries. The
+// `aLabel` / `bLabel` strings end up in the reasons so a downstream
+// reader knows which side reported which value.
+func compareSummary(key string, a, b TraceSummary, aLabel, bLabel string, opts DiffOptions) []DiffReason {
+	var reasons []DiffReason
+
+	if a.RootServiceName != b.RootServiceName {
+		// CanonicalKey hashes (rootServiceName, rootTraceName), so a
+		// mismatch here only happens on hash collision — but we still
+		// report it because a future canonical-key change would surface
+		// here first.
+		reasons = append(reasons, DiffReason{
+			Kind:   "field_mismatch",
+			Detail: fmt.Sprintf("key %s: rootServiceName %s=%q vs %s=%q", key, aLabel, a.RootServiceName, bLabel, b.RootServiceName),
+		})
+	}
+	if a.RootTraceName != b.RootTraceName {
+		reasons = append(reasons, DiffReason{
+			Kind:   "field_mismatch",
+			Detail: fmt.Sprintf("key %s: rootTraceName %s=%q vs %s=%q", key, aLabel, a.RootTraceName, bLabel, b.RootTraceName),
+		})
+	}
+
+	// Numeric fields tolerate the configured epsilon. DurationMs varies
+	// because Tempo computes it from wall-clock span boundaries and
+	// cerberus reads the Duration column directly; on a fresh seed the
+	// two should agree to the nanosecond, but float jitter in repeated
+	// runs is real.
+	if a.DurationMs != 0 || b.DurationMs != 0 {
+		if !valuesClose(float64(a.DurationMs), float64(b.DurationMs), opts) {
+			reasons = append(reasons, DiffReason{
+				Kind:   "field_mismatch",
+				Detail: fmt.Sprintf("key %s: durationMs %s=%d vs %s=%d", key, aLabel, a.DurationMs, bLabel, b.DurationMs),
+			})
+		}
+	}
+
+	// StartTimeUnixNano is a string in the JSON shape; treat blank on
+	// either side as a non-comparison rather than a mismatch so older
+	// Tempo builds (which omit this field) don't false-positive.
+	if a.StartTimeUnixNano != "" && b.StartTimeUnixNano != "" && a.StartTimeUnixNano != b.StartTimeUnixNano {
+		// Allow the configured epsilon on the parsed value to absorb
+		// quantization differences between block-flush vs in-memory
+		// reads.
+		an, errA := strconv.ParseFloat(a.StartTimeUnixNano, 64)
+		bn, errB := strconv.ParseFloat(b.StartTimeUnixNano, 64)
+		if errA != nil || errB != nil || !valuesClose(an, bn, opts) {
+			reasons = append(reasons, DiffReason{
+				Kind:   "field_mismatch",
+				Detail: fmt.Sprintf("key %s: startTimeUnixNano %s=%q vs %s=%q", key, aLabel, a.StartTimeUnixNano, bLabel, b.StartTimeUnixNano),
+			})
+		}
+	}
+
+	return reasons
+}
+
+// valuesClose mirrors harness/prometheus-compliance/shadow/differ.go's
+// helper so the two harnesses share semantics.
+func valuesClose(a, b float64, opts DiffOptions) bool {
+	if math.IsNaN(a) && math.IsNaN(b) {
+		return true
+	}
+	if math.IsInf(a, 0) || math.IsInf(b, 0) {
+		return a == b
+	}
+	delta := math.Abs(a - b)
+	if delta <= opts.AbsEpsilon {
+		return true
+	}
+	scale := math.Max(math.Abs(a), math.Abs(b))
+	return delta <= opts.RelEpsilon*scale
+}
+
+// AssertCase checks one backend's parsed response against the corpus
+// case's expectations. Separate from Compare because per-side
+// assertions ("at least N traces", "root names match regex X") are
+// orthogonal to differential equality between backends.
+//
+// Returns reasons for every expectation that failed. An empty slice
+// means all expectations passed.
+func AssertCase(tc CorpusCase, body []byte, backendLabel string) ([]DiffReason, error) {
+	var reasons []DiffReason
+	a, err := decodeSearch(body)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", backendLabel, err)
+	}
+	if tc.ExpectedMinTraces > 0 && len(a.Traces) < tc.ExpectedMinTraces {
+		reasons = append(reasons, DiffReason{
+			Kind:   "assertion",
+			Detail: fmt.Sprintf("%s: got %d traces, want >= %d", backendLabel, len(a.Traces), tc.ExpectedMinTraces),
+		})
+	}
+	if tc.ExpectedMaxTraces > 0 && len(a.Traces) > tc.ExpectedMaxTraces {
+		reasons = append(reasons, DiffReason{
+			Kind:   "assertion",
+			Detail: fmt.Sprintf("%s: got %d traces, want <= %d", backendLabel, len(a.Traces), tc.ExpectedMaxTraces),
+		})
+	}
+	if len(tc.ExpectedServices) > 0 {
+		seen := map[string]bool{}
+		for _, t := range a.Traces {
+			seen[t.RootServiceName] = true
+		}
+		for _, svc := range tc.ExpectedServices {
+			if !seen[svc] {
+				reasons = append(reasons, DiffReason{
+					Kind:   "assertion",
+					Detail: fmt.Sprintf("%s: expected rootServiceName=%q to appear in results", backendLabel, svc),
+				})
+			}
+		}
+	}
+	if tc.ExpectedRootNameRE != nil {
+		for _, t := range a.Traces {
+			if !tc.ExpectedRootNameRE.MatchString(t.RootTraceName) {
+				reasons = append(reasons, DiffReason{
+					Kind:   "assertion",
+					Detail: fmt.Sprintf("%s: rootTraceName %q does not match /%s/", backendLabel, t.RootTraceName, tc.ExpectedRootNameRE.String()),
+				})
+				break // one report is enough; the report should highlight failures, not enumerate every span
+			}
+		}
+	}
+	return reasons, nil
+}
+
+// canonicalizeJSON re-marshals a JSON blob with sorted object keys so
+// future call sites can byte-compare the canonicalised form. Kept here
+// (vs in main.go) because the differ owns the canonicalisation policy
+// for the entire harness.
+//
+// The function is generic over the body shape — it does NOT assume the
+// /api/search envelope — so it remains usable for /api/traces/<id>
+// when that endpoint gets diffed in a follow-up.
+func canonicalizeJSON(body []byte) ([]byte, error) {
+	var v any
+	if err := json.Unmarshal(body, &v); err != nil {
+		return nil, fmt.Errorf("canonicalize: parse: %w", err)
+	}
+	return marshalCanonical(v)
+}
+
+func marshalCanonical(v any) ([]byte, error) {
+	switch t := v.(type) {
+	case map[string]any:
+		keys := make([]string, 0, len(t))
+		for k := range t {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		var b strings.Builder
+		b.WriteByte('{')
+		for i, k := range keys {
+			if i > 0 {
+				b.WriteByte(',')
+			}
+			kb, err := json.Marshal(k)
+			if err != nil {
+				return nil, err
+			}
+			b.Write(kb)
+			b.WriteByte(':')
+			vb, err := marshalCanonical(t[k])
+			if err != nil {
+				return nil, err
+			}
+			b.Write(vb)
+		}
+		b.WriteByte('}')
+		return []byte(b.String()), nil
+	case []any:
+		var b strings.Builder
+		b.WriteByte('[')
+		for i, e := range t {
+			if i > 0 {
+				b.WriteByte(',')
+			}
+			vb, err := marshalCanonical(e)
+			if err != nil {
+				return nil, err
+			}
+			b.Write(vb)
+		}
+		b.WriteByte(']')
+		return []byte(b.String()), nil
+	default:
+		return json.Marshal(t)
+	}
+}

--- a/harness/tempo-compatibility/driver/differ_test.go
+++ b/harness/tempo-compatibility/driver/differ_test.go
@@ -1,0 +1,279 @@
+package main
+
+import (
+	"bytes"
+	"math"
+	"strings"
+	"testing"
+)
+
+func TestCompare_Identical(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"traces":[
+        {"traceID":"abc","rootServiceName":"checkout","rootTraceName":"GET /api/checkout/0","durationMs":150,"startTimeUnixNano":"1000"}
+    ]}`)
+	d, err := Compare(body, body, "tempo", "cerberus", DefaultDiffOptions())
+	if err != nil {
+		t.Fatalf("Compare: %v", err)
+	}
+	if !d.Equal {
+		t.Fatalf("expected Equal, got %+v", d)
+	}
+	if d.MatchedCount != 1 {
+		t.Fatalf("MatchedCount = %d, want 1", d.MatchedCount)
+	}
+}
+
+func TestCompare_IgnoresTraceIDDifference(t *testing.T) {
+	t.Parallel()
+	// Tempo returns a real trace ID; cerberus today returns a synthetic
+	// key. The differ canonicalises on (rootServiceName, rootTraceName)
+	// so the two should still match.
+	a := []byte(`{"traces":[
+        {"traceID":"aaaaaaaaaaaaaaaa","rootServiceName":"checkout","rootTraceName":"GET /api/checkout/0","durationMs":150,"startTimeUnixNano":"1000"}
+    ]}`)
+	b := []byte(`{"traces":[
+        {"traceID":"synthetic|key","rootServiceName":"checkout","rootTraceName":"GET /api/checkout/0","durationMs":150,"startTimeUnixNano":"1000"}
+    ]}`)
+	d, err := Compare(a, b, "tempo", "cerberus", DefaultDiffOptions())
+	if err != nil {
+		t.Fatalf("Compare: %v", err)
+	}
+	if !d.Equal {
+		t.Fatalf("expected canonical-key match, got reasons=%v", d.Reasons)
+	}
+}
+
+func TestCompare_CardinalityMismatch(t *testing.T) {
+	t.Parallel()
+	a := []byte(`{"traces":[
+        {"traceID":"a","rootServiceName":"checkout","rootTraceName":"R"},
+        {"traceID":"b","rootServiceName":"payments","rootTraceName":"R"}
+    ]}`)
+	b := []byte(`{"traces":[
+        {"traceID":"a","rootServiceName":"checkout","rootTraceName":"R"}
+    ]}`)
+	d, err := Compare(a, b, "tempo", "cerberus", DefaultDiffOptions())
+	if err != nil {
+		t.Fatalf("Compare: %v", err)
+	}
+	if d.Equal {
+		t.Fatal("expected Equal=false")
+	}
+	foundCard := false
+	foundMissing := false
+	for _, r := range d.Reasons {
+		if r.Kind == "cardinality" {
+			foundCard = true
+		}
+		if r.Kind == "missing_in_b" {
+			foundMissing = true
+		}
+	}
+	if !foundCard {
+		t.Fatalf("expected cardinality reason, got %+v", d.Reasons)
+	}
+	if !foundMissing {
+		t.Fatalf("expected missing_in_b reason, got %+v", d.Reasons)
+	}
+}
+
+func TestCompare_FieldMismatchDuration(t *testing.T) {
+	t.Parallel()
+	a := []byte(`{"traces":[
+        {"traceID":"a","rootServiceName":"s","rootTraceName":"n","durationMs":150}
+    ]}`)
+	b := []byte(`{"traces":[
+        {"traceID":"a","rootServiceName":"s","rootTraceName":"n","durationMs":175}
+    ]}`)
+	d, err := Compare(a, b, "tempo", "cerberus", DefaultDiffOptions())
+	if err != nil {
+		t.Fatalf("Compare: %v", err)
+	}
+	if d.Equal {
+		t.Fatal("expected Equal=false on duration drift")
+	}
+	found := false
+	for _, r := range d.Reasons {
+		if r.Kind == "field_mismatch" && strings.Contains(r.Detail, "durationMs") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected durationMs reason, got %+v", d.Reasons)
+	}
+}
+
+func TestCompare_EpsilonAbsorbsIdenticalFields(t *testing.T) {
+	t.Parallel()
+	a := []byte(`{"traces":[
+        {"traceID":"a","rootServiceName":"s","rootTraceName":"n","durationMs":150,"startTimeUnixNano":"1000000"}
+    ]}`)
+	b := []byte(`{"traces":[
+        {"traceID":"a","rootServiceName":"s","rootTraceName":"n","durationMs":150,"startTimeUnixNano":"1000000"}
+    ]}`)
+	d, err := Compare(a, b, "tempo", "cerberus", DefaultDiffOptions())
+	if err != nil {
+		t.Fatalf("Compare: %v", err)
+	}
+	if !d.Equal {
+		t.Fatalf("expected equal at identity, got %+v", d.Reasons)
+	}
+}
+
+func TestCompare_InvalidJSONFails(t *testing.T) {
+	t.Parallel()
+	a := []byte(`{not json`)
+	b := []byte(`{"traces":[]}`)
+	if _, err := Compare(a, b, "tempo", "cerberus", DefaultDiffOptions()); err == nil {
+		t.Fatal("expected decode error")
+	}
+}
+
+func TestCanonicalKey_DeterministicAcrossInvocations(t *testing.T) {
+	t.Parallel()
+	t1 := TraceSummary{RootServiceName: "checkout", RootTraceName: "GET /api/checkout/0"}
+	t2 := TraceSummary{RootServiceName: "checkout", RootTraceName: "GET /api/checkout/0"}
+	if CanonicalKey(t1) != CanonicalKey(t2) {
+		t.Fatal("expected identical canonical key for identical inputs")
+	}
+	t3 := TraceSummary{RootServiceName: "checkout", RootTraceName: "GET /api/checkout/1"}
+	if CanonicalKey(t1) == CanonicalKey(t3) {
+		t.Fatal("expected different canonical keys for different root names")
+	}
+}
+
+func TestAssertCase_MinTraces(t *testing.T) {
+	t.Parallel()
+	tc := CorpusCase{Name: "t", Query: "x", Endpoint: "search", ExpectedMinTraces: 5}
+	body := []byte(`{"traces":[{"traceID":"a","rootServiceName":"s","rootTraceName":"n"}]}`)
+	reasons, err := AssertCase(tc, body, "cerberus")
+	if err != nil {
+		t.Fatalf("AssertCase: %v", err)
+	}
+	if len(reasons) == 0 || !strings.Contains(reasons[0].Detail, "want >= 5") {
+		t.Fatalf("expected min-traces reason, got %+v", reasons)
+	}
+}
+
+func TestAssertCase_MaxTraces(t *testing.T) {
+	t.Parallel()
+	tc := CorpusCase{Name: "t", Query: "x", Endpoint: "search", ExpectedMaxTraces: 1}
+	body := []byte(`{"traces":[
+        {"traceID":"a","rootServiceName":"s","rootTraceName":"n"},
+        {"traceID":"b","rootServiceName":"s","rootTraceName":"m"}
+    ]}`)
+	reasons, err := AssertCase(tc, body, "tempo")
+	if err != nil {
+		t.Fatalf("AssertCase: %v", err)
+	}
+	if len(reasons) == 0 || !strings.Contains(reasons[0].Detail, "want <= 1") {
+		t.Fatalf("expected max-traces reason, got %+v", reasons)
+	}
+}
+
+func TestAssertCase_ExpectedServicesMet(t *testing.T) {
+	t.Parallel()
+	tc := CorpusCase{Name: "t", Query: "x", Endpoint: "search", ExpectedServices: []string{"checkout"}}
+	body := []byte(`{"traces":[
+        {"traceID":"a","rootServiceName":"checkout","rootTraceName":"n"},
+        {"traceID":"b","rootServiceName":"payments","rootTraceName":"m"}
+    ]}`)
+	reasons, err := AssertCase(tc, body, "tempo")
+	if err != nil {
+		t.Fatalf("AssertCase: %v", err)
+	}
+	if len(reasons) != 0 {
+		t.Fatalf("expected no reasons, got %+v", reasons)
+	}
+}
+
+func TestAssertCase_ExpectedServicesMissing(t *testing.T) {
+	t.Parallel()
+	tc := CorpusCase{Name: "t", Query: "x", Endpoint: "search", ExpectedServices: []string{"shipping"}}
+	body := []byte(`{"traces":[
+        {"traceID":"a","rootServiceName":"checkout","rootTraceName":"n"}
+    ]}`)
+	reasons, err := AssertCase(tc, body, "tempo")
+	if err != nil {
+		t.Fatalf("AssertCase: %v", err)
+	}
+	if len(reasons) == 0 || !strings.Contains(reasons[0].Detail, "shipping") {
+		t.Fatalf("expected reason flagging shipping, got %+v", reasons)
+	}
+}
+
+func TestValuesClose_NaNEqualsNaN(t *testing.T) {
+	t.Parallel()
+	if !valuesClose(math.NaN(), math.NaN(), DefaultDiffOptions()) {
+		t.Fatal("NaN should compare equal to NaN under shadow semantics")
+	}
+}
+
+func TestCanonicalizeJSON_StableKeyOrder(t *testing.T) {
+	t.Parallel()
+	a := []byte(`{"z":1,"a":2,"m":{"y":3,"b":4}}`)
+	b := []byte(`{"a":2,"m":{"b":4,"y":3},"z":1}`)
+	ca, err := canonicalizeJSON(a)
+	if err != nil {
+		t.Fatalf("canonicalizeJSON(a): %v", err)
+	}
+	cb, err := canonicalizeJSON(b)
+	if err != nil {
+		t.Fatalf("canonicalizeJSON(b): %v", err)
+	}
+	if !bytes.Equal(ca, cb) {
+		t.Fatalf("canonical forms differ:\n  a=%s\n  b=%s", string(ca), string(cb))
+	}
+}
+
+func TestRenderReport_Roundtrip(t *testing.T) {
+	t.Parallel()
+	results := []CaseResult{
+		{
+			Case:           CorpusCase{Name: "pass_case", Endpoint: "search", Query: "{ x = 1 }"},
+			TempoStatus:    200,
+			CerberusStatus: 200,
+			Diff:           Diff{Equal: true, MatchedCount: 3},
+		},
+		{
+			Case:       CorpusCase{Name: "diff_case", Endpoint: "search", Query: "{ y = 2 }"},
+			Diff:       Diff{Equal: false, Reasons: []DiffReason{{Kind: "cardinality", Detail: "tempo=5 cerberus=4"}}},
+			Assertions: []DiffReason{{Kind: "assertion", Detail: "got 4, want >= 5"}},
+		},
+		{
+			Case:    CorpusCase{Name: "skip_case", Endpoint: "search", Query: "{ z = 3 }", SkipReason: "pr5"},
+			Skipped: true,
+		},
+		{
+			Case:      CorpusCase{Name: "err_case", Endpoint: "search", Query: "{ q = 4 }"},
+			HardError: "tempo fetch: connection refused",
+		},
+	}
+	var buf bytes.Buffer
+	if err := renderReport(&buf, results); err != nil {
+		t.Fatalf("renderReport: %v", err)
+	}
+	report := buf.String()
+	for _, want := range []string{
+		"# Tempo / TraceQL compatibility — diff report",
+		"## Summary",
+		"- Cases: 4",
+		"- Passed: 1",
+		"- Skipped: 1",
+		"- Diff: 1",
+		"- Hard errors: 1",
+		"### `pass_case`",
+		"### `diff_case`",
+		"### `skip_case`",
+		"### `err_case`",
+		"status: PASS",
+		"status: DIFF (1 reasons)",
+		"status: SKIPPED (pr5)",
+		"status: ERROR — tempo fetch: connection refused",
+	} {
+		if !strings.Contains(report, want) {
+			t.Errorf("report missing %q\n%s", want, report)
+		}
+	}
+}

--- a/harness/tempo-compatibility/driver/main.go
+++ b/harness/tempo-compatibility/driver/main.go
@@ -3,16 +3,19 @@
 // stack has a single binary with a stable flag surface; behaviour is
 // selected via the first positional argument (the "subcommand"):
 //
-//   - `seed`    (PR 3 — this PR) writes the same deterministic OTLP
-//     batch to the reference Tempo (via OTLP gRPC :4317) and to
-//     ClickHouse's `otel_traces` table (the read path cerberus uses to
-//     answer Tempo HTTP queries). After both writes complete it polls
+//   - `seed`    (PR 3) writes the same deterministic OTLP batch to
+//     the reference Tempo (via OTLP gRPC :4317) and to ClickHouse's
+//     `otel_traces` table (the read path cerberus uses to answer Tempo
+//     HTTP queries). After both writes complete it polls
 //     `/api/traces/<first-id>` on both backends and reports the per-
-//     backend span count. The PR-3 contract is: stack comes up, seed
+//     backend span count. The contract is: stack comes up, seed
 //     pushes to both targets, the smoke trace-id resolves on both.
-//   - `diff`    (PR 4 — pending) will run the TraceQL corpus through
-//     both backends and emit a markdown report. The subcommand is
-//     not implemented yet; invoking it exits with rc=2.
+//   - `diff`    (PR 4 — this PR) reads a TXTAR corpus, runs every
+//     TraceQL query through both backends via /api/search (and
+//     /api/traces/<id> for the per-id smoke cases), applies per-side
+//     assertions, computes the structural diff, and emits a markdown
+//     report under /reports/. Returns 0 (informational baseline) by
+//     default; pass --fail-on-diff to make any diff non-zero.
 //
 // The two-way "OTLP into Tempo, INSERT into CH" split is documented in
 // docs/tempo-compliance-plan.md's "Open question 1": cerberus is
@@ -38,7 +41,7 @@ import (
 
 // version is stamped on driver output so a reader scanning CI logs can
 // tell at a glance which PR's behaviour they're looking at.
-const version = "pr3-seeder"
+const version = "pr4-differ"
 
 func main() {
 	if len(os.Args) < 2 {
@@ -55,8 +58,10 @@ func main() {
 			os.Exit(1)
 		}
 	case "diff":
-		fmt.Fprintln(os.Stderr, "tempo-compat-driver diff: not implemented yet — lands in PR 4")
-		os.Exit(2)
+		if err := runDiff(args); err != nil {
+			fmt.Fprintf(os.Stderr, "tempo-compat-driver diff: %v\n", err)
+			os.Exit(1)
+		}
 	case "-h", "--help", "help":
 		usage()
 	default:
@@ -78,6 +83,8 @@ subcommands:
           equivalent rows into ClickHouse otel_traces; smoke-poll
           /api/traces/<id> on both backends.
   diff    run the TraceQL corpus through both backends, emit a
-          markdown diff report. (PR 4 — not implemented yet)
+          markdown diff report under /reports/. Default exit code is
+          0 (informational); pass --fail-on-diff to bubble per-case
+          regressions up to a non-zero rc.
 `, version)
 }

--- a/harness/tempo-compatibility/scripts/run-tempo-compatibility.sh
+++ b/harness/tempo-compatibility/scripts/run-tempo-compatibility.sh
@@ -1,29 +1,39 @@
 #!/usr/bin/env bash
 # Tempo / TraceQL compatibility harness entry point.
 #
-# Status: PR 3 of docs/tempo-compliance-plan.md. The driver is now a
-# real seeder (not a stub) — it writes a deterministic OTLP batch into
-# Tempo's :4317 AND inserts the same fixture into ClickHouse so cerberus
-# reads it via the same /api/traces path. The driver's own smoke
-# assertion (poll /api/traces/<id> on both backends and assert non-zero
-# matching span counts) gates this script's exit code.
+# Status: PR 4 of docs/tempo-compliance-plan.md. The driver runs in two
+# phases sequentially:
+#
+#   1. seed — push a deterministic OTLP batch to Tempo's :4317 AND
+#             insert the same fixture into ClickHouse so cerberus reads
+#             it via /api/traces. In-process smoke confirms both
+#             backends resolve the first trace ID with non-zero spans.
+#   2. diff — read the TXTAR corpus, run every TraceQL query through
+#             both backends, write a markdown diff report to
+#             $REPORT_DIR/diff.md. Default: informational (script
+#             returns 0 even if the corpus diffs); set FAIL_ON_DIFF=1
+#             to bubble per-case regressions up to a non-zero rc.
 #
 # Usage:
-#   ./harness/tempo-compatibility/scripts/run-tempo-compatibility.sh   full lifecycle
+#   ./harness/tempo-compatibility/scripts/run-tempo-compatibility.sh   full lifecycle (seed → diff)
 #   COMPOSE_KEEP=1 ./...                                               leave stack up after run
+#   FAIL_ON_DIFF=1 ./...                                               exit non-zero on diffs
 #
 # Env:
-#   REPORT_DIR    where the driver writes diff.json (default:
-#                 harness/tempo-compatibility/reports/). PR 3's seeder
-#                 doesn't write a report — that lands in PR 4.
-#   COMPOSE_KEEP  non-empty: leave the compose stack running after the
-#                 seeder completes (useful for poking at /api/traces and
-#                 the otel_traces table manually).
+#   REPORT_DIR     where the driver writes diff.md (default:
+#                  harness/tempo-compatibility/reports/).
+#   COMPOSE_KEEP   non-empty: leave the compose stack running after the
+#                  differ completes (useful for poking at /api/traces
+#                  and the otel_traces table manually).
+#   FAIL_ON_DIFF   non-empty: forward --fail-on-diff to the differ so
+#                  the script exits non-zero on any case that reported
+#                  a structural diff / assertion / hard error.
 #
-# Exit codes (driver passthrough):
-#   0  seeder + smoke succeeded (both backends returned spans for the
-#      first trace ID with matching counts)
-#   non-zero  stack failed to come up OR seeder/smoke failed.
+# Exit codes:
+#   0  seed + diff completed (informational mode) OR with FAIL_ON_DIFF
+#      set, every corpus case passed.
+#   non-zero  stack failed to come up OR seeder failed OR (with
+#             FAIL_ON_DIFF set) the differ reported a regression.
 
 set -eu -o pipefail
 
@@ -73,10 +83,33 @@ echo "==> running tempo-compat-driver seed"
 # non-zero exit.
 set +e
 docker compose run --rm tempo-compat-driver seed
-DRIVER_RC=$?
+SEED_RC=$?
 set -e
 
-echo "==> driver exited with rc=$DRIVER_RC"
-echo "==> reports under $REPORT_DIR (empty until PR 4 lands the differ)"
+echo "==> seeder exited with rc=$SEED_RC"
+if [ "$SEED_RC" -ne 0 ]; then
+    echo "==> seeder failed — skipping diff"
+    exit "$SEED_RC"
+fi
 
-exit "$DRIVER_RC"
+# PR 4: after seed, run the differ against the same backends. The
+# differ emits a markdown report under $REPORT_DIR; in informational
+# mode (default) it returns 0 even if the report contains diffs so
+# the workflow stays a baseline. Set FAIL_ON_DIFF=1 to bubble
+# regressions up to a non-zero rc — useful for `just`-style local
+# repro and for the eventual PR 7 promotion to a required check.
+DIFF_FLAGS=""
+if [ -n "${FAIL_ON_DIFF:-}" ]; then
+    DIFF_FLAGS="--fail-on-diff"
+fi
+
+echo "==> running tempo-compat-driver diff"
+set +e
+docker compose run --rm tempo-compat-driver diff $DIFF_FLAGS
+DIFF_RC=$?
+set -e
+
+echo "==> differ exited with rc=$DIFF_RC"
+echo "==> report at $REPORT_DIR/diff.md"
+
+exit "$DIFF_RC"


### PR DESCRIPTION
## Summary

PR 4 of [`docs/tempo-compliance-plan.md`](docs/tempo-compliance-plan.md).
**Draft** because this branch stacks on #385 (Pool-DH seeder) — once
#385 merges this needs `git pull --rebase origin main` + force-push,
then mark ready.

- Adds the `diff` subcommand to `tempo-compat-driver`: reads a TXTAR corpus, runs every TraceQL query through both reference Tempo and cerberus via `/api/search` (and `/api/traces/<id>` for the per-id smoke case), applies per-side assertions, computes the canonical-key structural diff, and emits a markdown report under `/reports/`.
- Smoke corpus (`driver/corpus/smoke.txtar`, 20 cases) is lifted-and-adapted from `harness/prometheus-compliance/shadow/traceql_shadow_test.go::traceqlInstantCases()`. Categories: attribute matchers per scope (5), intrinsics (4), structural ops (4), set ops (3), inner aggregates (2), trace-by-id (1). Two metrics-pipeline cases ship with `skip_reason='pr5'` so this single file already documents the eventual full coverage map.
- `run-tempo-compatibility.sh` now runs `seed` then `diff` sequentially. Differ defaults to informational mode (rc=0 even on diffs, matching the workflow's `continue-on-error`); `FAIL_ON_DIFF=1` toggles error-on-diff for local repro / the eventual PR 7 promotion.

### Differ design rationale

Cerberus's `TraceSummary.TraceID` is synthetic today (see `internal/api/tempo/handler.go::toTraceSummaries` — the stub key is `MetricName + "|" + Timestamp`, not the real OTLP hex). A literal byte-equal would false-positive on every case. The differ canonicalises each summary via `H(rootServiceName || rootTraceName)` and compares the canonical-key multisets — exactly the plan's "hash trace IDs deterministically (different orderings of equal sets don't false-positive)" prescription. Numeric fields compare under a 1e-9 relative epsilon (same defaults as the prom shadow differ).

## Test plan

- [x] `go build -o /dev/null ./harness/tempo-compatibility/driver` — clean compile.
- [x] `go vet ./harness/tempo-compatibility/driver/...` — no issues.
- [x] `go test ./harness/tempo-compatibility/driver/...` — 31 unit tests pass (corpus loader, differ, render report, URL builder, traceid template derivation).
- [x] Trace-id template hash matches the seeder's hash byte-for-byte (`TestDeriveTraceIDFromTemplate_MatchesSeederHash`).
- [ ] Smoke locally: `./harness/tempo-compatibility/scripts/run-tempo-compatibility.sh` (deferred until #385 lands so the seeder + diff run against the same image rev).
- [ ] Nightly `tempo-compatibility` workflow run completes green (informational mode).

## Cross-refs

- Depends on #385 (Pool-DH seeder); merge order = #385 → this one.
- Plan doc: [`docs/tempo-compliance-plan.md`](docs/tempo-compliance-plan.md) PR 4 row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)