### PR TITLE
feat(harness/loki-compatibility): cerberus-owned compliance tester

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -444,6 +444,18 @@ tempo-compatibility-keep:
 tempo-compatibility-down:
     cd harness/tempo-compatibility && docker compose down -v
 
+# === Compatibility — all three heads ===
+
+# Run all three compatibility harnesses sequentially: PromQL
+# (prometheus/compliance), LogQL (vendored grafana/loki:pkg/logql/bench
+# + cerberus-owned tester), TraceQL (tempo-compatibility stub until
+# docs/tempo-compliance-plan.md PRs 3-4 wire the real differ). Each
+# sub-recipe tears its own compose stack down on every exit path.
+# Slow — expect tens of minutes. Use the per-head recipes for iteration.
+# Exit semantics: fails fast on the first non-zero recipe; the report
+# files for each head land under harness/*/reports/ regardless.
+compatibility-all: compatibility loki-compatibility tempo-compatibility
+
 # === Shadow-mode differential testing (RC3 R3.9) ===
 
 # Build + run the shadow-mode harness against a corpus.

--- a/harness/loki-compatibility/README.md
+++ b/harness/loki-compatibility/README.md
@@ -1,11 +1,14 @@
 # Loki / LogQL compatibility harness
 
-> Status: **PR 3 (diff driver wiring)** of the rollout described in
+> Status: **PR 5 (cerberus-owned driver)** of the rollout described in
 > [`docs/loki-compliance-plan.md`](../../docs/loki-compliance-plan.md).
 > The Docker Compose stack, the deterministic seeder, the vendored
-> `pkg/logql/bench/` corpus, and now the diff-driver wiring all live
-> under this directory. The informational CI lane (PR 4) and the
-> cerberus-owned driver replacement (PR 5) are still pending.
+> `pkg/logql/bench/` corpus, and the cerberus-owned diff driver all
+> live under this directory. The driver emits a JSON report whose
+> shape matches `harness/prometheus-compliance/report.json` so the two
+> harnesses share a single downstream analyser. The informational CI
+> lane (PR 4) and the regression / exhaustive corpus expansion (PR 6)
+> are still pending.
 
 ## Why this harness exists
 
@@ -22,33 +25,34 @@ See [`docs/loki-compliance-plan.md`](../../docs/loki-compliance-plan.md)
 for the full landscape analysis, the per-PR breakdown, and the
 license/AGPL containment strategy.
 
-## Layout (current — PR 3)
+## Layout (current — PR 5)
 
 ```text
 harness/loki-compatibility/
   README.md                       this file
   docker-compose.yml              clickhouse + reference loki + cerberus
   loki-config.yaml                reference Loki single-binary config
-  cerberus-test-queries.yml       overlay documenting drops for unsupported LogQL features
+  cerberus-test-queries.yml       overlay listing per-query drops + reasons
   dataset_metadata.json           pinned dataset metadata for ${SELECTOR}/${LABEL_*} expansion
-  reports/                        diff driver output (PR 3); contents gitignored
+  reports/                        diff driver output; contents gitignored
   cmd/
     seed/                         deterministic OTel-shape log seeder
+    loki-compliance-tester/       cerberus-owned diff driver (PR 5; this PR)
   scripts/
-    run-loki-compatibility.sh     smoke + diff driver (this PR)
+    run-loki-compatibility.sh     smoke + diff driver (drives cmd/loki-compliance-tester/)
   upstream/
     loki-bench/                   vendored grafana/loki:pkg/logql/bench snapshot
       LICENSE                     AGPL-3.0, copied verbatim from grafana/loki
       VERSION                     exact upstream coordinates of the snapshot
       query_registry.go           YAML loader + template-variable expander
-      remote_test.go              TestRemoteStorageEquality (build-tagged remote_correctness)
-      metadata.go                 DatasetMetadata + LoadMetadata + bounded sets (PR 3)
-      metadata_resolver.go        ${SELECTOR}/${LABEL_*}/${RANGE} resolver (PR 3)
-      testcase.go                 TestCase shape consumed by the registry (PR 3)
-      assertions_test.go          assertResultNotEmpty + tolerance comparators (PR 3)
-      convert_test.go             loghttp -> promql/parser.Value conversions (PR 3)
-      generator.go                GeneratorConfig + StreamMetadata referenced by metadata.go (PR 3)
-      faker.go                    LogFormat type + helper data referenced by metadata.go (PR 3)
+      remote_test.go              TestRemoteStorageEquality (vestigial; no longer the driver)
+      metadata.go                 DatasetMetadata + LoadMetadata + bounded sets
+      metadata_resolver.go        ${SELECTOR}/${LABEL_*}/${RANGE} resolver
+      testcase.go                 TestCase shape consumed by the registry
+      assertions_test.go          assertResultNotEmpty + tolerance comparators
+      convert_test.go             loghttp -> promql/parser.Value conversions
+      generator.go                GeneratorConfig + StreamMetadata referenced by metadata.go
+      faker.go                    LogFormat type + helper data referenced by metadata.go
       queries/
         schema.json               JSON schema for query YAMLs
         fast/*.yaml               minimal corpus (basic-selectors, simple-metrics, structured-metadata)
@@ -56,7 +60,7 @@ harness/loki-compatibility/
         exhaustive/.gitkeep       placeholder; the driver loads all three suites
 ```
 
-## Layout (planned — PR 4+)
+## Layout (planned — PR 4 + PR 6)
 
 PR 4 lands the informational CI lane:
 
@@ -64,11 +68,10 @@ PR 4 lands the informational CI lane:
 .github/workflows/loki-compatibility.yml  PR 4 — push:main + nightly cron + workflow_dispatch
 ```
 
-PR 5 ports `TestRemoteStorageEquality` into a cerberus-owned driver:
-
-```text
-harness/loki-compatibility/cmd/loki-compliance-tester/  PR 5 — cerberus-owned driver
-```
+PR 6 widens the seeder + regenerates `dataset_metadata.json` so the
+upstream `${SELECTOR}` / `${LABEL_*}` templates resolve against real
+data (the current overlay marks every `fast/` entry as skipped pending
+that work).
 
 ## What's in `upstream/loki-bench/`
 
@@ -86,9 +89,10 @@ tag recorded in [`upstream/loki-bench/VERSION`](upstream/loki-bench/VERSION):
   `${SELECTOR}` / `${LABEL_NAME}` / `${LABEL_VALUE}` template
   expander.
 - `pkg/logql/bench/remote_test.go` — `TestRemoteStorageEquality`,
-  build-tagged `remote_correctness`. Driven by
-  `scripts/run-loki-compatibility.sh`; replaced by a cerberus-owned
-  driver later (plan PR 5).
+  build-tagged `remote_correctness`. The PR 5 cerberus-owned driver
+  (`cmd/loki-compliance-tester/`) is now the entry point; this file
+  is preserved verbatim as upstream reference and for the eventual
+  bump procedure.
 - `pkg/logql/bench/metadata.go`, `metadata_resolver.go`, `testcase.go`,
   `assertions_test.go`, `convert_test.go` — support files
   `remote_test.go` transitively depends on. PR 2 (#369) intentionally
@@ -124,28 +128,28 @@ Same reasoning as `harness/tempo-compatibility/upstream/` (see PR #367):
 
 ### How the vendor builds
 
-`remote_test.go` imports `github.com/grafana/loki/v3/pkg/logcli/client`
-and `github.com/grafana/loki/v3/pkg/loghttp`, which transitively pull
-in the Loki client + dskit + aws-sdk-go-v2 + azure-sdk + OpenAPI
-chain. These are not deps cerberus's main module wants in its
-`go.mod`. The repo isolates them via two complementary mechanisms:
+The PR 5 cerberus-owned driver (`cmd/loki-compliance-tester/`) imports
+the vendored `bench` package for corpus loading (`QueryRegistry`,
+`LoadMetadata`, `MetadataVariableResolver`, `TestCase`). The
+transitive deps `bench` carries (`logproto`, `logql/syntax`,
+`yaml.v3`) are all already direct entries in the root `go.mod`, so
+the driver builds with a plain `go build` — no `-mod=mod` promotion
+and no go.mod / go.sum mutation per invocation.
 
-1. `go.mod`'s `ignore ./harness/loki-compatibility/upstream` directive
-   keeps `go build ./...`, `go test ./...`, and `go vet ./...` away
-   from the vendored path.
-2. `scripts/run-loki-compatibility.sh` invokes
-   `GOFLAGS=-mod=mod go test -tags=remote_correctness -c` to compile
-   the test binary explicitly. The `-mod=mod` flag is the documented
-   override for ignored paths; it transiently writes the extra
-   transitive deps into the repo's `go.mod` and `go.sum` so the build
-   resolves. A cleanup trap then reverts both files (`git checkout --
-   go.mod go.sum`) so the working tree stays clean on every exit path
-   (success, driver failure, `set -e` abort, SIGINT).
+The `ignore ./harness/loki-compatibility/upstream` directive in
+`go.mod` keeps `go build ./...`, `go test ./...`, and `go vet ./...`
+from walking the vendored path as a build target; the bench package
+is still resolvable when imported by path (`ignore` is wildcard
+exclusion, not import isolation). The `ignore` directive is a Go
+1.25+ feature; cerberus pins Go 1.26 via `go.mod`.
 
-The `ignore` directive is a Go 1.25+ feature; cerberus pins Go 1.26
-via `go.mod`. The cleanup pattern matches the
-`harness/prometheus-compliance/scripts/run-compatibility.sh` precedent
-for managing transient mutations during integration runs.
+Earlier PRs (PR 3, #387) used `GOFLAGS=-mod=mod go test
+-tags=remote_correctness -c` to compile the upstream test driver and
+relied on a `git checkout -- go.mod go.sum` cleanup trap to revert
+the transient direct-dep promotion. PR 5 eliminates both pieces:
+the driver lives in cerberus-owned code, builds against the
+already-direct deps, and the run script no longer touches the
+working tree.
 
 ## Cerberus overlay files
 
@@ -153,11 +157,14 @@ Two files at the harness root capture cerberus-specific configuration
 that lives OUTSIDE the AGPL `upstream/` boundary:
 
 - `cerberus-test-queries.yml` — overlay listing per-query divergences
-  cerberus tracks against the upstream corpus. The PR 3 commit
-  documents the entire `fast/` set as deferred to PR 6 (selector
-  vocabulary mismatch between the seeded fixture and the upstream
-  template defaults). The PR 5 cerberus-owned driver will consume
-  this file; until then it's documentary surface for reviewers.
+  cerberus tracks against the upstream corpus. The PR 5 driver
+  consumes this file: entries under `should_skip:` are suppressed
+  before the wire call (recorded in the report as `skipReason` with
+  no failure flag flipped); `should_fail:` is reserved for the Prom-
+  shape `unexpectedSuccess` semantics (expected hard failures). The
+  PR 3 commit documented the entire `fast/` set as deferred to PR 6
+  (selector vocabulary mismatch between the seeded fixture and the
+  upstream template defaults); the driver suppresses those entries.
 - `dataset_metadata.json` — pinned dataset metadata that maps
   `${SELECTOR}` / `${LABEL_NAME}` / `${LABEL_VALUE}` template vars to
   concrete values. The placeholder shipped by PR 2 (#369) is
@@ -186,18 +193,42 @@ just loki-compatibility-down
 
 The run script's contract:
 
-- Exit 0 → no diffs on any query case.
+- Exit 0 → no diffs on any query case (overlay-skipped cases count
+  as passing).
 - Exit 1 → at least one diff or run-time failure (informational; the
   CI lane in PR 4 will treat this as non-blocking until the corpus
   shape matches the seeded fixture per PR 6).
 - Exit 2+ → harness itself failed (compose, seed, build).
 
-The driver's full stream (`go test -v` output, one
-`PASS`/`FAIL`/`SKIP` line per query case) is written to
-`reports/diff.json`. PR 5's cerberus-owned driver will switch this to
-the same JSON shape that
-`harness/prometheus-compliance/report.json` uses so the two harnesses
-share a single downstream analyser.
+The driver writes a structured JSON report to `reports/diff.json`
+whose envelope matches `harness/prometheus-compliance/report.json`:
+
+```json
+{
+  "totalResults": 14,
+  "includePassing": true,
+  "results": [
+    {
+      "testCase": {
+        "query": "{service=\"checkout\"}",
+        "source": "fast/basic-selectors.yaml",
+        "description": "Basic label selector",
+        "kind": "log", "direction": "backward",
+        "start": "2026-05-15T00:00:00Z", "end": "2026-05-15T00:10:00Z",
+        "instant": false
+      },
+      "diff": "",
+      "unexpectedFailure": "",
+      "unexpectedSuccess": false,
+      "unsupported": false,
+      "skipReason": "Pending PR 6 seed expansion …"
+    }
+  ]
+}
+```
+
+Sharing the envelope with the Prom harness means one analyser (and,
+later, one expected-failures reconciliation script) can consume both.
 
 ## Licensing
 

--- a/harness/loki-compatibility/cmd/loki-compliance-tester/main.go
+++ b/harness/loki-compatibility/cmd/loki-compliance-tester/main.go
@@ -1,0 +1,988 @@
+// Command loki-compliance-tester runs the LogQL compatibility corpus
+// (vendored from grafana/loki:pkg/logql/bench/) against two live Loki
+// HTTP endpoints, diffs the responses with float tolerance, and emits a
+// JSON report whose shape matches harness/prometheus-compliance's
+// promql-compliance-tester (i.e. the `prometheus/compliance` reference
+// driver).
+//
+// This is PR 5 of docs/loki-compliance-plan.md — the cerberus-owned
+// replacement for the `go test -tags=remote_correctness -c` approach
+// wired in PR 3 (#387). The previous approach piped `go test -v` lines
+// into a `.json` file; downstream tooling (informational CI lane, future
+// expected-failures triage) needs the same structured report the Prom
+// harness ships so a single reconciliation script can consume both.
+//
+// Lifecycle:
+//
+//  1. Loads the upstream bench package's QueryRegistry + DatasetMetadata
+//     resolver. Reuses upstream code so template-variable expansion
+//     (`${SELECTOR}` / `${LABEL_NAME}` / `${RANGE}`) tracks Grafana's
+//     reference semantics exactly — cerberus-side divergence here would
+//     defeat the differential test.
+//  2. Loads the optional cerberus-side overlay (cerberus-test-queries.yml)
+//     and indexes its `should_skip` + `should_fail` entries by
+//     `<suite>/<file>.yaml#<description>` keys.
+//  3. For each expanded test case, fans out parallel `/loki/api/v1/query`
+//     or `/query_range` calls against both endpoints, decodes the
+//     responses into a typed value, normalises ordering, and diffs with
+//     a configurable epsilon.
+//  4. Writes the report to `-report` (default: stdout) in the Prom-shape
+//     JSON envelope (`{totalResults, includePassing, results: [...]}`),
+//     with each result carrying `testCase`, `diff`, `unexpectedFailure`,
+//     `unexpectedSuccess`, `unsupported`.
+//
+// The binary imports the vendored upstream/loki-bench/ package; the
+// root go.mod marks that path `ignore` so it's excluded from
+// `go build ./...` walks, but the package itself is reachable via its
+// import path because every transitive dep (`logproto`, `logql/syntax`,
+// `yaml.v3`) is already a direct entry in cerberus's go.mod. A plain
+// `go build` resolves the binary without needing the `-mod=mod`
+// promotion the PR 3 `go test -c` build relied on.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"math"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	bench "github.com/tsouza/cerberus/harness/loki-compatibility/upstream/loki-bench"
+)
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatalf("loki-compliance-tester: %v", err)
+	}
+}
+
+// flags collects all CLI / env knobs in one place.
+type flags struct {
+	addr1       string
+	addr2       string
+	corpusDir   string
+	metadataDir string
+	overlayPath string
+	reportPath  string
+	tolerance   float64
+	rangeType   string
+	seed        int64
+	parallelism int
+	includeSkip bool
+	timeout     time.Duration
+}
+
+func parseFlags() flags {
+	var f flags
+	flag.StringVar(&f.addr1, "addr-1", "", "Address of baseline (reference) Loki instance, e.g. http://localhost:23100")
+	flag.StringVar(&f.addr2, "addr-2", "", "Address of test (cerberus) Loki-API instance, e.g. http://localhost:29092")
+	flag.StringVar(&f.corpusDir, "corpus", "./queries", "Path to the vendored bench/queries/ directory (suite subdirs: fast/, regression/, exhaustive/)")
+	flag.StringVar(&f.metadataDir, "metadata-dir", ".", "Directory containing dataset_metadata.json")
+	flag.StringVar(&f.overlayPath, "overlay", "", "Optional cerberus-test-queries.yml overlay (skip/fail per source key)")
+	flag.StringVar(&f.reportPath, "report", "", "Report output path; empty writes to stdout")
+	flag.Float64Var(&f.tolerance, "tolerance", 1e-5, "Float comparison tolerance (matches upstream remote_test.go default)")
+	flag.StringVar(&f.rangeType, "range-type", "range", "Query range type: 'range' or 'instant'")
+	flag.Int64Var(&f.seed, "seed", 42, "Random seed for query template resolution (matches upstream default)")
+	flag.IntVar(&f.parallelism, "parallelism", 8, "Maximum number of comparison queries to run in parallel")
+	flag.BoolVar(&f.includeSkip, "include-skipped", false, "Include queries the upstream YAML marks `skip: true`")
+	flag.DurationVar(&f.timeout, "timeout", 30*time.Second, "Per-request HTTP timeout for each Loki endpoint")
+	flag.Parse()
+	return f
+}
+
+func run() error {
+	f := parseFlags()
+	if f.addr1 == "" || f.addr2 == "" {
+		return errors.New("both -addr-1 and -addr-2 must be set")
+	}
+	isInstant := f.rangeType == "instant"
+
+	overlay, err := loadOverlay(f.overlayPath)
+	if err != nil {
+		return fmt.Errorf("loading overlay: %w", err)
+	}
+
+	cases, err := loadCases(f, isInstant)
+	if err != nil {
+		return fmt.Errorf("loading cases: %w", err)
+	}
+
+	results := compareAll(cases, f, overlay, isInstant)
+
+	report := Report{
+		TotalResults:   len(results),
+		IncludePassing: true,
+		Results:        results,
+	}
+	out, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshalling report: %w", err)
+	}
+
+	if err := writeReport(f.reportPath, out); err != nil {
+		return fmt.Errorf("writing report: %w", err)
+	}
+
+	// Summary stderr line: mirrors the Prom run script's jq summary so
+	// the run script can `tee | jq` regardless of which tester it ran.
+	pass, diffs, unfail, unsupp := summarise(results)
+	fmt.Fprintf(os.Stderr, "==> summary: total=%d passed=%d diffs=%d unexpected_failures=%d unsupported=%d\n",
+		len(results), pass, diffs, unfail, unsupp)
+
+	if pass != len(results) {
+		// Non-zero exit indicates "at least one diff or runtime failure",
+		// matching the Prom tester's semantics. The informational CI lane
+		// treats this as non-blocking until the corpus stabilises.
+		os.Exit(1)
+	}
+	return nil
+}
+
+// Overlay mirrors the cerberus-test-queries.yml schema documented in
+// harness/loki-compatibility/cerberus-test-queries.yml. The runner
+// consults `ShouldSkip` to decide whether to include a case (when
+// `-include-skipped=false`); the `ShouldFail` slot is plumbed for
+// future use (analogue of prometheus/compliance's `should_fail` —
+// expected hard-failure entries flip `unexpectedSuccess` semantics).
+type Overlay struct {
+	ShouldSkip []OverlayEntry `yaml:"should_skip"`
+	ShouldFail []OverlayEntry `yaml:"should_fail"`
+}
+
+// OverlayEntry is a single overlay row. `Source` is the lookup key in
+// the form `<suite>/<file>.yaml#<description>`; `Reason` documents
+// rationale; the `Since` / `Jira` fields are for drift audits.
+type OverlayEntry struct {
+	Source string `yaml:"source"`
+	Reason string `yaml:"reason"`
+	Since  string `yaml:"since,omitempty"`
+	Jira   string `yaml:"jira,omitempty"`
+}
+
+func loadOverlay(path string) (*Overlay, error) {
+	if path == "" {
+		return &Overlay{}, nil
+	}
+	b, err := os.ReadFile(path) //nolint:gosec // CLI-supplied overlay path; harness tool
+	if err != nil {
+		return nil, err
+	}
+	var o Overlay
+	if err := yaml.Unmarshal(b, &o); err != nil {
+		return nil, err
+	}
+	return &o, nil
+}
+
+// skipKey indexes an overlay entry by its (suite, file, description)
+// triple. The bench package stores `Source` as `<suite>/<file>.yaml:<line>`
+// — we re-derive the description-shaped key (`<suite>/<file>.yaml#<desc>`)
+// at lookup time to match the overlay's documented schema.
+func (o *Overlay) skipKey(suiteFile, description string) (string, bool) {
+	key := suiteFile + "#" + description
+	for _, e := range o.ShouldSkip {
+		if e.Source == key {
+			return e.Reason, true
+		}
+	}
+	return "", false
+}
+
+// loadCases reuses the upstream bench loader so template expansion
+// stays in lock-step with grafana/loki:pkg/logql/bench/. Instant mode
+// mirrors remote_test.go: keep only metric queries, collapse range to
+// a point.
+//
+// Expansion errors are recorded as `loadErr` against the originating
+// QueryDefinition rather than bubbled up — a single corpus-wide failure
+// (e.g. one query template referencing a label the seeded fixture
+// doesn't carry) would otherwise abort the whole run. The caller
+// converts each loadErr into an `UnexpectedFailure` result so the
+// report still emits and the operator can triage per-query.
+func loadCases(f flags, isInstant bool) ([]loadedCase, error) {
+	metadata, err := bench.LoadMetadata(f.metadataDir)
+	if err != nil {
+		return nil, fmt.Errorf("LoadMetadata(%s): %w", f.metadataDir, err)
+	}
+
+	registry := bench.NewQueryRegistry(f.corpusDir)
+	suites := []bench.Suite{bench.SuiteFast, bench.SuiteRegression, bench.SuiteExhaustive}
+	if err := registry.Load(suites...); err != nil {
+		return nil, fmt.Errorf("registry.Load: %w", err)
+	}
+
+	resolver := bench.NewMetadataVariableResolver(metadata, f.seed)
+	defs := registry.GetQueries(f.includeSkip, suites...)
+
+	var cases []loadedCase
+	for _, def := range defs {
+		expanded, err := registry.ExpandQuery(def, resolver, isInstant)
+		if err != nil {
+			cases = append(cases, loadedCase{
+				def:       def,
+				expandErr: fmt.Errorf("expand %q: %w", def.Description, err),
+			})
+			continue
+		}
+		for _, tc := range expanded {
+			cases = append(cases, loadedCase{def: def, tc: tc})
+		}
+	}
+
+	if isInstant {
+		filtered := cases[:0]
+		for _, lc := range cases {
+			if lc.expandErr != nil || lc.tc.Kind() == "metric" {
+				if lc.expandErr == nil {
+					lc.tc.Start = lc.tc.End
+					lc.tc.Step = 0
+				}
+				filtered = append(filtered, lc)
+			}
+		}
+		cases = filtered
+	}
+	return cases, nil
+}
+
+// loadedCase carries either a fully-expanded TestCase or an expansion
+// failure (with the originating QueryDefinition for context). Carrying
+// both via the same slot lets compareAll emit a result row even for
+// queries that never reached the wire.
+type loadedCase struct {
+	def       bench.QueryDefinition
+	tc        bench.TestCase
+	expandErr error
+}
+
+// summarise tallies the four headline counters reported on stderr.
+func summarise(results []Result) (pass, diffs, unfail, unsupp int) {
+	for _, r := range results {
+		switch {
+		case r.UnexpectedFailure != "":
+			unfail++
+			if r.Unsupported {
+				unsupp++
+			}
+		case r.Diff != "":
+			diffs++
+		case r.UnexpectedSuccess:
+			// Counted as a diff for summary purposes (the case was
+			// expected to fail but didn't).
+			diffs++
+		default:
+			pass++
+		}
+	}
+	return pass, diffs, unfail, unsupp
+}
+
+func writeReport(path string, payload []byte) error {
+	if path == "" {
+		_, err := os.Stdout.Write(payload)
+		if err == nil {
+			fmt.Println()
+		}
+		return err
+	}
+	return os.WriteFile(path, payload, 0o600)
+}
+
+// compareAll runs every test case in parallel and collects results.
+// Concurrency is capped at `parallelism` via a buffered work-token
+// channel — same shape as the Prom tester's main.go.
+func compareAll(cases []loadedCase, f flags, overlay *Overlay, isInstant bool) []Result {
+	httpClient := &http.Client{Timeout: f.timeout}
+	results := make([]Result, len(cases))
+
+	workCh := make(chan struct{}, max(1, f.parallelism))
+	var wg sync.WaitGroup
+	var allSuccess atomic.Bool
+	allSuccess.Store(true)
+
+	for i, lc := range cases {
+		i, lc := i, lc
+
+		// Resolve the overlay key using the upstream QueryDefinition.
+		// Both expanded and expansion-failed cases share the same
+		// (Source, Description) pair; resolving up-front means a
+		// skip entry can suppress either kind of failure without
+		// having to know the expansion outcome.
+		suiteFile := stripSourceLine(lc.def.Source)
+		reason, isSkipped := overlay.skipKey(suiteFile, lc.def.Description)
+
+		// Expansion failures: emit a synthetic TestCase from the
+		// upstream QueryDefinition (no time range available) and
+		// surface the error as UnexpectedFailure unless an overlay
+		// entry has explicitly skipped this case.
+		if lc.expandErr != nil {
+			tc := TestCase{
+				Query:       lc.def.Query,
+				Source:      suiteFile,
+				Description: lc.def.Description,
+				Kind:        lc.def.Kind,
+				Direction:   string(lc.def.Directions),
+			}
+			if isSkipped {
+				results[i] = Result{TestCase: tc, SkipReason: reason}
+				continue
+			}
+			results[i] = Result{TestCase: tc, UnexpectedFailure: "expansion: " + lc.expandErr.Error()}
+			allSuccess.Store(false)
+			continue
+		}
+
+		// Apply overlay skip — skipped cases never hit the wire.
+		if isSkipped {
+			results[i] = Result{
+				TestCase: newTestCase(lc.tc, suiteFile, isInstant),
+				// `Diff` empty + `UnexpectedFailure` empty +
+				// `UnexpectedSuccess=false` means "passed"; we use
+				// `SkipReason` to surface the documented rationale.
+				// The shape stays compatible with the Prom envelope
+				// by not flipping any of the failure flags.
+				SkipReason: reason,
+			}
+			continue
+		}
+
+		wg.Add(1)
+		workCh <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-workCh }()
+
+			res := compareOne(httpClient, f, lc.tc, suiteFile, isInstant)
+			results[i] = res
+			if !res.success() {
+				allSuccess.Store(false)
+			}
+		}()
+	}
+
+	wg.Wait()
+	return results
+}
+
+// compareOne performs the per-case differential: fans out concurrent
+// requests to both endpoints, decodes, normalises, diffs.
+func compareOne(c *http.Client, f flags, tc bench.TestCase, suiteFile string, isInstant bool) Result {
+	tcOut := newTestCase(tc, suiteFile, isInstant)
+	result := Result{TestCase: tcOut}
+
+	type fetched struct {
+		value typedResult
+		err   error
+	}
+	out := make([]fetched, 2)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	for idx, addr := range []string{f.addr1, f.addr2} {
+		idx, addr := idx, addr
+		go func() {
+			defer wg.Done()
+			v, err := queryOne(c, addr, tc, isInstant)
+			out[idx] = fetched{value: v, err: err}
+		}()
+	}
+	wg.Wait()
+
+	refErr, testErr := out[0].err, out[1].err
+	switch {
+	case refErr != nil:
+		// Baseline failure isn't a cerberus regression — treat as harness
+		// glitch. We surface it as UnexpectedFailure so the operator
+		// sees it but flag Unsupported=false (it's not a 501).
+		result.UnexpectedFailure = fmt.Sprintf("reference (-addr-1) failed: %v", refErr)
+		return result
+	case testErr != nil:
+		result.UnexpectedFailure = testErr.Error()
+		result.Unsupported = isUnsupportedErr(testErr)
+		return result
+	}
+
+	expected := normaliseTypedResult(out[0].value)
+	actual := normaliseTypedResult(out[1].value)
+	if expected.isEmpty() {
+		// Same convention as upstream `assertResultNotEmpty`: we don't
+		// flip a comparison failure on an empty baseline because the
+		// upstream test framework treats it as a setup error. Report
+		// it explicitly so the overlay author can suppress.
+		result.UnexpectedFailure = "baseline returned empty"
+		return result
+	}
+	if actual.isEmpty() {
+		result.UnexpectedFailure = "test endpoint returned empty"
+		return result
+	}
+	if diff := diffTyped(expected, actual, f.tolerance); diff != "" {
+		result.Diff = diff
+	}
+	return result
+}
+
+// stripSourceLine strips the trailing `:<line>` from a bench source path.
+// Upstream stores `Source` as `fast/basic-selectors.yaml:6`; the overlay
+// keys + the report's `testCase.source` field use the line-less form so
+// they stay stable across upstream re-orderings.
+func stripSourceLine(src string) string {
+	if i := strings.LastIndex(src, ":"); i >= 0 {
+		// Validate the suffix is a number; otherwise leave the string
+		// untouched. Source paths shouldn't carry a colon other than
+		// the line suffix, so this is purely defensive.
+		if _, err := strconv.Atoi(src[i+1:]); err == nil {
+			return src[:i]
+		}
+	}
+	return src
+}
+
+func newTestCase(tc bench.TestCase, suiteFile string, isInstant bool) TestCase {
+	out := TestCase{
+		Query:       tc.Query,
+		Source:      suiteFile,
+		Description: tc.QueryDesc,
+		Kind:        tc.Kind(),
+		Direction:   tc.Direction.String(),
+		Start:       tc.Start.UTC().Format(time.RFC3339Nano),
+		End:         tc.End.UTC().Format(time.RFC3339Nano),
+		Instant:     isInstant,
+		Tags:        tc.Tags,
+	}
+	if tc.Step > 0 {
+		out.Step = tc.Step.String()
+	}
+	return out
+}
+
+// isUnsupportedErr classifies a Loki error as "feature not supported"
+// for the report's Unsupported flag. The Prom analogue keys on HTTP 501;
+// Loki uses a mix of 400-with-"not implemented" + 501 + 400-with-parser
+// errors. We keep the predicate conservative — anything not clearly a
+// shape mismatch is treated as supported.
+func isUnsupportedErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, "status=501") ||
+		strings.Contains(s, "not implemented") ||
+		strings.Contains(s, "unsupported")
+}
+
+// ----- HTTP layer ----------------------------------------------------
+
+// queryOne issues a single instant or range query against `addr` and
+// returns the decoded result. Instant queries hit /loki/api/v1/query
+// only when the TestCase represents one (metric query collapsed to a
+// point); everything else routes to /query_range, matching the
+// upstream test's queryRemote() function.
+func queryOne(c *http.Client, addr string, tc bench.TestCase, isInstant bool) (typedResult, error) {
+	const limit = 1000
+	base := strings.TrimRight(addr, "/")
+
+	if isInstant && tc.Kind() == "metric" && tc.Start.Equal(tc.End) {
+		u := base + "/loki/api/v1/query"
+		params := url.Values{}
+		params.Set("query", tc.Query)
+		params.Set("time", strconv.FormatInt(tc.End.UnixNano(), 10))
+		params.Set("limit", strconv.Itoa(limit))
+		params.Set("direction", tc.Direction.String())
+		return doQuery(c, u, params)
+	}
+
+	u := base + "/loki/api/v1/query_range"
+	params := url.Values{}
+	params.Set("query", tc.Query)
+	params.Set("start", strconv.FormatInt(tc.Start.UnixNano(), 10))
+	params.Set("end", strconv.FormatInt(tc.End.UnixNano(), 10))
+	params.Set("limit", strconv.Itoa(limit))
+	params.Set("direction", tc.Direction.String())
+	if tc.Step > 0 {
+		params.Set("step", strconv.FormatFloat(tc.Step.Seconds(), 'f', -1, 64))
+	}
+	return doQuery(c, u, params)
+}
+
+func doQuery(c *http.Client, u string, params url.Values) (typedResult, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u+"?"+params.Encode(), nil)
+	if err != nil {
+		return typedResult{}, fmt.Errorf("new request: %w", err)
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return typedResult{}, fmt.Errorf("http call: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, 16<<20))
+	if readErr != nil {
+		return typedResult{}, fmt.Errorf("read body: %w", readErr)
+	}
+	if resp.StatusCode != http.StatusOK {
+		// Truncate the error body so a wall-of-text upstream stack
+		// trace doesn't dominate the diff column.
+		snippet := strings.TrimSpace(string(body))
+		if len(snippet) > 400 {
+			snippet = snippet[:400] + "…"
+		}
+		return typedResult{}, fmt.Errorf("status=%d body=%s", resp.StatusCode, snippet)
+	}
+
+	return decodeResponse(body)
+}
+
+// ----- response decoder ---------------------------------------------
+
+// typedResult is a tagged union over the four Loki/PromQL result types.
+// We model it as an opaque struct rather than a sealed interface to
+// keep the decoder allocation-light and the diff loop branch-free.
+type typedResult struct {
+	kind     string // "streams" | "vector" | "matrix" | "scalar" | ""
+	streams  []decodedStream
+	vector   []decodedSample
+	matrix   []decodedSeries
+	scalar   decodedSample
+	hasValue bool
+}
+
+func (t typedResult) isEmpty() bool {
+	switch t.kind {
+	case "streams":
+		return len(t.streams) == 0
+	case "vector":
+		return len(t.vector) == 0
+	case "matrix":
+		// Mirror upstream: a matrix with series-but-no-points is empty.
+		if len(t.matrix) == 0 {
+			return true
+		}
+		for _, s := range t.matrix {
+			if len(s.Floats) > 0 {
+				return false
+			}
+		}
+		return true
+	case "scalar":
+		return !t.hasValue
+	}
+	return true
+}
+
+type decodedStream struct {
+	Labels  map[string]string // canonical label set (sorted at compare time)
+	Entries []logEntry
+}
+
+type logEntry struct {
+	Timestamp int64 // unix nanos
+	Line      string
+}
+
+type decodedSample struct {
+	Metric map[string]string
+	T      int64 // unix ms (matches Prom's promql.Sample.T)
+	F      float64
+}
+
+type decodedSeries struct {
+	Metric map[string]string
+	Floats []decodedPoint
+}
+
+type decodedPoint struct {
+	T int64
+	F float64
+}
+
+// decodeResponse parses Loki's `{status, data: {resultType, result}}`
+// envelope into a typedResult. The `result` decoder is type-driven by
+// `resultType` since each shape has its own JSON layout.
+func decodeResponse(body []byte) (typedResult, error) {
+	var env struct {
+		Status string `json:"status"`
+		Data   struct {
+			ResultType string          `json:"resultType"`
+			Result     json.RawMessage `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil {
+		return typedResult{}, fmt.Errorf("decode envelope: %w", err)
+	}
+	if env.Status != "" && env.Status != "success" {
+		return typedResult{}, fmt.Errorf("loki status=%q", env.Status)
+	}
+
+	switch env.Data.ResultType {
+	case "streams":
+		return decodeStreams(env.Data.Result)
+	case "vector":
+		return decodeVector(env.Data.Result)
+	case "matrix":
+		return decodeMatrix(env.Data.Result)
+	case "scalar":
+		return decodeScalar(env.Data.Result)
+	default:
+		return typedResult{}, fmt.Errorf("unknown resultType %q", env.Data.ResultType)
+	}
+}
+
+func decodeStreams(raw json.RawMessage) (typedResult, error) {
+	var arr []struct {
+		Stream map[string]string `json:"stream"`
+		Values [][2]string       `json:"values"`
+	}
+	if err := json.Unmarshal(raw, &arr); err != nil {
+		return typedResult{}, fmt.Errorf("decode streams: %w", err)
+	}
+	out := typedResult{kind: "streams"}
+	for _, s := range arr {
+		stream := decodedStream{Labels: s.Stream}
+		for _, v := range s.Values {
+			ts, err := strconv.ParseInt(v[0], 10, 64)
+			if err != nil {
+				return typedResult{}, fmt.Errorf("decode stream timestamp %q: %w", v[0], err)
+			}
+			stream.Entries = append(stream.Entries, logEntry{Timestamp: ts, Line: v[1]})
+		}
+		out.streams = append(out.streams, stream)
+	}
+	return out, nil
+}
+
+func decodeVector(raw json.RawMessage) (typedResult, error) {
+	var arr []struct {
+		Metric map[string]string  `json:"metric"`
+		Value  [2]json.RawMessage `json:"value"`
+	}
+	if err := json.Unmarshal(raw, &arr); err != nil {
+		return typedResult{}, fmt.Errorf("decode vector: %w", err)
+	}
+	out := typedResult{kind: "vector"}
+	for _, s := range arr {
+		ts, f, err := decodeSamplePair(s.Value)
+		if err != nil {
+			return typedResult{}, err
+		}
+		out.vector = append(out.vector, decodedSample{Metric: s.Metric, T: ts, F: f})
+	}
+	return out, nil
+}
+
+func decodeMatrix(raw json.RawMessage) (typedResult, error) {
+	var arr []struct {
+		Metric map[string]string    `json:"metric"`
+		Values [][2]json.RawMessage `json:"values"`
+	}
+	if err := json.Unmarshal(raw, &arr); err != nil {
+		return typedResult{}, fmt.Errorf("decode matrix: %w", err)
+	}
+	out := typedResult{kind: "matrix"}
+	for _, s := range arr {
+		series := decodedSeries{Metric: s.Metric}
+		for _, pair := range s.Values {
+			ts, f, err := decodeSamplePair(pair)
+			if err != nil {
+				return typedResult{}, err
+			}
+			series.Floats = append(series.Floats, decodedPoint{T: ts, F: f})
+		}
+		out.matrix = append(out.matrix, series)
+	}
+	return out, nil
+}
+
+func decodeScalar(raw json.RawMessage) (typedResult, error) {
+	var pair [2]json.RawMessage
+	if err := json.Unmarshal(raw, &pair); err != nil {
+		return typedResult{}, fmt.Errorf("decode scalar: %w", err)
+	}
+	ts, f, err := decodeSamplePair(pair)
+	if err != nil {
+		return typedResult{}, err
+	}
+	return typedResult{kind: "scalar", scalar: decodedSample{T: ts, F: f}, hasValue: true}, nil
+}
+
+// decodeSamplePair parses a [<ts>, <value>] pair where `ts` is a Loki
+// timestamp (number or string-of-number) and `value` is a string-encoded
+// float (Prom convention). NaN / +Inf / -Inf round-trip correctly via
+// strconv.ParseFloat.
+func decodeSamplePair(pair [2]json.RawMessage) (int64, float64, error) {
+	var ts int64
+	// Timestamp can come back as either a JSON number or a string;
+	// try string first since that's the Loki convention.
+	var tsStr string
+	if err := json.Unmarshal(pair[0], &tsStr); err == nil {
+		// Loki returns floating-point seconds; convert to unix ms so
+		// the diff comparator can deal in integers.
+		secs, err := strconv.ParseFloat(tsStr, 64)
+		if err != nil {
+			return 0, 0, fmt.Errorf("ts parse %q: %w", tsStr, err)
+		}
+		ts = int64(secs * 1000)
+	} else {
+		var tsNum float64
+		if err := json.Unmarshal(pair[0], &tsNum); err != nil {
+			return 0, 0, fmt.Errorf("ts decode: %w", err)
+		}
+		ts = int64(tsNum * 1000)
+	}
+
+	var fStr string
+	if err := json.Unmarshal(pair[1], &fStr); err != nil {
+		return 0, 0, fmt.Errorf("value decode: %w", err)
+	}
+	f, err := strconv.ParseFloat(fStr, 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("value parse %q: %w", fStr, err)
+	}
+	return ts, f, nil
+}
+
+// ----- normalise + diff ---------------------------------------------
+
+// normaliseTypedResult applies the same ordering the upstream test does
+// (sortVector / sortMatrix / sortStreams). Diff is order-sensitive so
+// canonicalisation has to happen before comparison.
+func normaliseTypedResult(t typedResult) typedResult {
+	switch t.kind {
+	case "vector":
+		sort.SliceStable(t.vector, func(i, j int) bool {
+			if c := labelsCmp(t.vector[i].Metric, t.vector[j].Metric); c != 0 {
+				return c < 0
+			}
+			return t.vector[i].T < t.vector[j].T
+		})
+	case "matrix":
+		sort.SliceStable(t.matrix, func(i, j int) bool {
+			return labelsCmp(t.matrix[i].Metric, t.matrix[j].Metric) < 0
+		})
+	case "streams":
+		sort.SliceStable(t.streams, func(i, j int) bool {
+			return labelsCmp(t.streams[i].Labels, t.streams[j].Labels) < 0
+		})
+		for i := range t.streams {
+			entries := t.streams[i].Entries
+			sort.SliceStable(entries, func(a, b int) bool {
+				if entries[a].Timestamp != entries[b].Timestamp {
+					return entries[a].Timestamp < entries[b].Timestamp
+				}
+				return entries[a].Line < entries[b].Line
+			})
+		}
+	}
+	return t
+}
+
+// labelsCmp gives a stable ordering between two label sets. We sort the
+// keys, then compare key-by-key (k1 vs k2, v1 vs v2). This matches the
+// `labels.Compare` semantics the upstream test uses (canonical sorted
+// pairs).
+func labelsCmp(a, b map[string]string) int {
+	akeys := sortedKeys(a)
+	bkeys := sortedKeys(b)
+	n := len(akeys)
+	if len(bkeys) < n {
+		n = len(bkeys)
+	}
+	for i := 0; i < n; i++ {
+		if c := strings.Compare(akeys[i], bkeys[i]); c != 0 {
+			return c
+		}
+		if c := strings.Compare(a[akeys[i]], b[bkeys[i]]); c != 0 {
+			return c
+		}
+	}
+	return len(akeys) - len(bkeys)
+}
+
+func sortedKeys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// diffTyped runs a value-aware comparison and returns a human-readable
+// diff string (empty means equal). The string is structured enough for
+// triage but stops short of the cmp.Diff verbosity — the goal is the
+// pass/fail signal, with reproducer reference back to the corpus YAML.
+func diffTyped(expected, actual typedResult, tolerance float64) string {
+	if expected.kind != actual.kind {
+		return fmt.Sprintf("resultType differs: expected=%s actual=%s", expected.kind, actual.kind)
+	}
+	switch expected.kind {
+	case "vector":
+		return diffVector(expected.vector, actual.vector, tolerance)
+	case "matrix":
+		return diffMatrix(expected.matrix, actual.matrix, tolerance)
+	case "scalar":
+		return diffScalar(expected.scalar, actual.scalar, tolerance)
+	case "streams":
+		return diffStreams(expected.streams, actual.streams)
+	}
+	return ""
+}
+
+func diffVector(e, a []decodedSample, tol float64) string {
+	if len(e) != len(a) {
+		return fmt.Sprintf("vector length: expected=%d actual=%d", len(e), len(a))
+	}
+	for i := range e {
+		if d := labelsCmp(e[i].Metric, a[i].Metric); d != 0 {
+			return fmt.Sprintf("vector[%d] metric differs: expected=%v actual=%v", i, e[i].Metric, a[i].Metric)
+		}
+		if e[i].T != a[i].T {
+			return fmt.Sprintf("vector[%d] timestamp differs: expected=%d actual=%d", i, e[i].T, a[i].T)
+		}
+		if !floatEqual(e[i].F, a[i].F, tol) {
+			return fmt.Sprintf("vector[%d] value differs: expected=%v actual=%v", i, e[i].F, a[i].F)
+		}
+	}
+	return ""
+}
+
+func diffMatrix(e, a []decodedSeries, tol float64) string {
+	if len(e) != len(a) {
+		return fmt.Sprintf("matrix length: expected=%d actual=%d", len(e), len(a))
+	}
+	for i := range e {
+		if d := labelsCmp(e[i].Metric, a[i].Metric); d != 0 {
+			return fmt.Sprintf("matrix[%d] metric differs: expected=%v actual=%v", i, e[i].Metric, a[i].Metric)
+		}
+		if len(e[i].Floats) != len(a[i].Floats) {
+			return fmt.Sprintf("matrix[%d] series length: expected=%d actual=%d", i, len(e[i].Floats), len(a[i].Floats))
+		}
+		for j := range e[i].Floats {
+			if e[i].Floats[j].T != a[i].Floats[j].T {
+				return fmt.Sprintf("matrix[%d].points[%d] timestamp differs: expected=%d actual=%d", i, j, e[i].Floats[j].T, a[i].Floats[j].T)
+			}
+			if !floatEqual(e[i].Floats[j].F, a[i].Floats[j].F, tol) {
+				return fmt.Sprintf("matrix[%d].points[%d] value differs: expected=%v actual=%v", i, j, e[i].Floats[j].F, a[i].Floats[j].F)
+			}
+		}
+	}
+	return ""
+}
+
+func diffScalar(e, a decodedSample, tol float64) string {
+	if e.T != a.T {
+		return fmt.Sprintf("scalar timestamp differs: expected=%d actual=%d", e.T, a.T)
+	}
+	if !floatEqual(e.F, a.F, tol) {
+		return fmt.Sprintf("scalar value differs: expected=%v actual=%v", e.F, a.F)
+	}
+	return ""
+}
+
+func diffStreams(e, a []decodedStream) string {
+	if len(e) != len(a) {
+		return fmt.Sprintf("streams length: expected=%d actual=%d", len(e), len(a))
+	}
+	for i := range e {
+		if d := labelsCmp(e[i].Labels, a[i].Labels); d != 0 {
+			return fmt.Sprintf("streams[%d] labels differ: expected=%v actual=%v", i, e[i].Labels, a[i].Labels)
+		}
+		if len(e[i].Entries) != len(a[i].Entries) {
+			return fmt.Sprintf("streams[%d] entry count: expected=%d actual=%d", i, len(e[i].Entries), len(a[i].Entries))
+		}
+		for j := range e[i].Entries {
+			if e[i].Entries[j].Timestamp != a[i].Entries[j].Timestamp {
+				return fmt.Sprintf("streams[%d].entries[%d] timestamp differs: expected=%d actual=%d", i, j, e[i].Entries[j].Timestamp, a[i].Entries[j].Timestamp)
+			}
+			if e[i].Entries[j].Line != a[i].Entries[j].Line {
+				return fmt.Sprintf("streams[%d].entries[%d] line differs: expected=%q actual=%q", i, j, e[i].Entries[j].Line, a[i].Entries[j].Line)
+			}
+		}
+	}
+	return ""
+}
+
+// floatEqual mirrors the upstream `require.InDelta` semantics: NaNs
+// compare equal (both backends commonly produce NaN for empty bucket
+// reductions), and within-tolerance values match.
+func floatEqual(a, b, tol float64) bool {
+	if math.IsNaN(a) && math.IsNaN(b) {
+		return true
+	}
+	if math.IsInf(a, 0) || math.IsInf(b, 0) {
+		return a == b
+	}
+	if tol > 0 {
+		return math.Abs(a-b) <= tol
+	}
+	return a == b
+}
+
+// ----- report shape --------------------------------------------------
+
+// Report mirrors the prometheus/compliance JSON shape so cerberus-side
+// tooling (informational CI lane today, the future PR 6 expected-failures
+// reconciliation script) can consume both harness reports with a single
+// schema. See harness/prometheus-compliance/upstream/promql/output/json.go.
+type Report struct {
+	TotalResults   int      `json:"totalResults"`
+	IncludePassing bool     `json:"includePassing"`
+	Results        []Result `json:"results"`
+	// QueryTweaks is reserved for future per-query tolerance / label-drop
+	// adjustments. The Prom harness uses it for the same purpose.
+	QueryTweaks []any `json:"queryTweaks,omitempty"`
+}
+
+// Result is the per-test-case outcome. The four flag fields keep parity
+// with the Prom harness; `SkipReason` is the cerberus-side extension
+// for overlay-driven skips (the Prom corpus stitches these into the
+// upstream YAML directly).
+type Result struct {
+	TestCase          TestCase `json:"testCase"`
+	Diff              string   `json:"diff"`
+	UnexpectedFailure string   `json:"unexpectedFailure"`
+	UnexpectedSuccess bool     `json:"unexpectedSuccess"`
+	Unsupported       bool     `json:"unsupported"`
+	SkipReason        string   `json:"skipReason,omitempty"`
+}
+
+// success replicates `comparer.Result.Success` so the runtime can know
+// when to flag the run as failed without re-deriving the predicate.
+func (r Result) success() bool {
+	return r.Diff == "" && !r.UnexpectedSuccess && r.UnexpectedFailure == ""
+}
+
+// TestCase is the wire surface of a fully-expanded compliance case. We
+// embed the fields the Prom shape carries (query/start/end/resolution)
+// plus the Loki-specific ones (direction/source/kind/instant/tags) the
+// reviewer needs to triage. Field names follow JSON-camelCase to match
+// the Prom report.
+type TestCase struct {
+	Query       string   `json:"query"`
+	Source      string   `json:"source"`
+	Description string   `json:"description,omitempty"`
+	Kind        string   `json:"kind"`
+	Direction   string   `json:"direction"`
+	Start       string   `json:"start"`
+	End         string   `json:"end"`
+	Step        string   `json:"step,omitempty"`
+	Instant     bool     `json:"instant"`
+	Tags        []string `json:"tags,omitempty"`
+}

--- a/harness/loki-compatibility/scripts/run-loki-compatibility.sh
+++ b/harness/loki-compatibility/scripts/run-loki-compatibility.sh
@@ -6,22 +6,28 @@
 #   1. `docker compose up --wait` brings reference Loki + cerberus + CH up.
 #   2. The Go seeder pushes a deterministic fixture to both targets and
 #      asserts /labels is non-empty (the original PR 1 smoke).
-#   3. `go test -tags=remote_correctness -c` builds the diff driver from
-#      the vendored upstream/loki-bench/ corpus (the binary contains the
-#      single TestRemoteStorageEquality test).
+#   3. Builds the cerberus-owned diff driver (cmd/loki-compliance-tester);
+#      the binary imports the vendored upstream/loki-bench/ corpus loader,
+#      so a `-mod=mod` build is required.
 #   4. The driver runs against -addr-1 (reference Loki :23100) and
-#      -addr-2 (cerberus :29092); its JSON-shaped go-test output is
-#      captured to reports/diff.json.
+#      -addr-2 (cerberus :29092); it emits a structured JSON report
+#      matching the prometheus-compliance harness's shape into
+#      reports/diff.json.
 #   5. The compose stack is torn down on every exit path (success,
 #      driver failure, set -e abort, manual SIGINT) via a cleanup trap.
+#
+# PR 5 of docs/loki-compliance-plan.md swapped the upstream `go test -c`
+# driver for the cerberus-owned `cmd/loki-compliance-tester` so the
+# report shape matches the Prom harness; the build / teardown lifecycle
+# is otherwise unchanged.
 #
 # Exit semantics:
 #
 #   - 0  → smoke + driver passed (no diffs reported on any query case).
 #   - 1  → driver reported at least one diff or run-time failure (the
-#          informational CI lane in PR 4 treats this as non-blocking; a
+#          informational CI lane treats this as non-blocking; a
 #          required-check upgrade is planned per docs/loki-compliance-plan.md
-#          PR 5).
+#          PR 6).
 #   - 2+ → harness itself failed (compose up, seed, build, docker missing,
 #          …). Inspect script output; the report file may be empty.
 #
@@ -37,18 +43,15 @@
 #   DRIVER_SKIP         non-empty: skip the diff driver entirely. Useful
 #                       when the seeder is the bisect target.
 #   DRIVER_REPORT       report file path (default: reports/diff.json).
-#                       NOTE: the PR 3 driver emits `go test -v` text;
-#                       the .json suffix is forward-looking — PR 5's
-#                       cerberus-owned driver will switch this to a
-#                       structured JSON report matching the Prom
-#                       harness's report.json shape. Existing tooling
-#                       that consumes `reports/*.json` should pin the
-#                       output format expectation rather than the path.
-#   DRIVER_TIMEOUT      go-test -timeout flag (default: 10m).
-#   DRIVER_TOLERANCE    -tolerance flag passed through to the driver
-#                       (default: 1e-5; matches upstream remote_test.go).
-#   DRIVER_RANGE_TYPE   -remote-range-type flag (default: range).
-#                       Set "instant" to exercise instant-query mode.
+#                       The driver emits a JSON envelope matching the
+#                       Prom harness's report shape; existing tooling
+#                       can consume both via the same schema.
+#   DRIVER_TIMEOUT      Per-request HTTP timeout (default: 30s).
+#   DRIVER_TOLERANCE    -tolerance flag (default: 1e-5; matches upstream).
+#   DRIVER_RANGE_TYPE   -range-type flag (default: range; 'instant' also valid).
+#   DRIVER_PARALLELISM  -parallelism flag (default: 8).
+#   DRIVER_OVERLAY      Path to cerberus-test-queries.yml overlay; default
+#                       resolves the in-tree file beside this script.
 
 set -eu -o pipefail
 
@@ -57,25 +60,26 @@ REPO_ROOT=$(cd "$ROOT_DIR/../.." && pwd)
 cd "$ROOT_DIR"
 
 REPORT=${DRIVER_REPORT:-"$ROOT_DIR/reports/diff.json"}
-TIMEOUT=${DRIVER_TIMEOUT:-10m}
+TIMEOUT=${DRIVER_TIMEOUT:-30s}
 TOLERANCE=${DRIVER_TOLERANCE:-1e-5}
 RANGE_TYPE=${DRIVER_RANGE_TYPE:-range}
+PARALLELISM=${DRIVER_PARALLELISM:-8}
+OVERLAY=${DRIVER_OVERLAY:-"$ROOT_DIR/cerberus-test-queries.yml"}
 
-TEST_BIN=$(mktemp -t cerberus-loki-equality.XXXXXX.test)
+DRIVER_BIN=$(mktemp -t cerberus-loki-tester.XXXXXX)
 
-# Consolidated cleanup: tear down the compose stack, restore the root
-# go.mod / go.sum (the `-mod=mod` build temporarily promotes the
-# vendored Loki-client + transitive deps to direct entries — we revert
-# so the working tree stays clean), and drop the throwaway test binary.
-# Runs on every exit path (success, driver failure, set -e abort, SIGINT)
-# so a non-zero exit can't leak compose state or a dirty go.mod across
-# re-runs.
+# Consolidated cleanup: tear down the compose stack and drop the
+# throwaway driver binary on every exit path (success, driver failure,
+# set -e abort, SIGINT) so a non-zero exit can't leak compose state
+# across re-runs.
+#
+# Unlike the PR 3 `go test -c` approach, the cerberus-owned driver's
+# import surface (bench-package corpus loader + cerberus's existing
+# Loki / yaml deps) resolves through the root go.mod without the
+# `-mod=mod` promotion, so no go.mod / go.sum revert is needed.
 cleanup() {
     rc=$?
-    rm -f "$TEST_BIN"
-    if [ -d "$REPO_ROOT/.git" ]; then
-        (cd "$REPO_ROOT" && git checkout -- go.mod go.sum 2>/dev/null) || true
-    fi
+    rm -f "$DRIVER_BIN"
     if [ -z "${COMPOSE_KEEP:-}" ]; then
         echo "==> tearing down (set COMPOSE_KEEP=1 to leave running)"
         docker compose down -v || true
@@ -97,60 +101,51 @@ if [ -n "${DRIVER_SKIP:-}" ]; then
     exit 0
 fi
 
-# Build the diff driver from the vendored corpus. The root go.mod pins
-# `ignore ./harness/loki-compatibility/upstream` so default toolchain
-# operations skip this path; an explicit build target requires it. We
-# pass -mod=mod so the test-only Loki-client + transitive deps
-# (aws-sdk-go-v2, azure-sdk, openapi, …) can resolve without
-# permanently polluting the root go.mod — the cleanup trap reverts
-# go.mod/go.sum on every exit path.
-echo "==> building diff driver (go test -tags=remote_correctness -c)"
+# Build the cerberus-owned diff driver. The driver imports the
+# vendored bench package for corpus loading + cerberus's existing
+# Loki / yaml deps for the HTTP + decode path. The root go.mod marks
+# `ignore ./harness/loki-compatibility/upstream`, which keeps
+# `go build ./...` from walking the bench tree as a build target;
+# importing the package by path is still permitted because every
+# transitive dep is already a direct entry in go.mod.
+echo "==> building diff driver (cmd/loki-compliance-tester)"
 (cd "$REPO_ROOT" && \
-    GOFLAGS=-mod=mod go test \
-        -tags=remote_correctness \
-        -c \
-        -o "$TEST_BIN" \
-        ./harness/loki-compatibility/upstream/loki-bench/)
+    go build \
+        -o "$DRIVER_BIN" \
+        ./harness/loki-compatibility/cmd/loki-compliance-tester/)
 
-# The driver's NewQueryRegistry("./queries") loader is relative — cwd
-# must contain the corpus subtree. Running from the vendor dir keeps
-# the test binary unaltered (no patches against upstream).
 echo "==> running diff driver (writing report to $REPORT)"
 echo "    -addr-1=http://localhost:23100  (reference Loki)"
 echo "    -addr-2=http://localhost:29092  (cerberus)"
-echo "    -tolerance=$TOLERANCE -remote-range-type=$RANGE_TYPE -timeout=$TIMEOUT"
+echo "    -tolerance=$TOLERANCE -range-type=$RANGE_TYPE -timeout=$TIMEOUT -parallelism=$PARALLELISM"
 
-# Capture the driver's full stdout/stderr (one "--- PASS"/"--- FAIL"
-# line per query subtest plus the standard `go test -v` framing). PR 5
-# will swap this to the JSON shape the Prom harness uses; for now the
-# raw stream is sufficient for the informational lane. The set +e
-# window is just wide enough to capture the driver's exit code so the
-# report write completes before the script propagates the failure. The
-# cleanup trap still runs.
+# The driver writes structured JSON to `-report` and a single-line
+# summary to stderr. We capture only the summary on console (via tee
+# /dev/null to keep the trap-friendly exit-code propagation); the JSON
+# report lives entirely at the report path. The set +e window is just
+# wide enough to capture the exit code before the script propagates
+# any failure.
 set +e
-(cd "$ROOT_DIR/upstream/loki-bench" && \
-    "$TEST_BIN" \
-        -test.v \
-        -test.timeout="$TIMEOUT" \
-        -test.run=TestRemoteStorageEquality \
-        -addr-1=http://localhost:23100 \
-        -addr-2=http://localhost:29092 \
-        -metadata-dir="$ROOT_DIR" \
-        -tolerance="$TOLERANCE" \
-        -remote-range-type="$RANGE_TYPE" 2>&1) | tee "$REPORT"
-DRIVER_RC=${PIPESTATUS[0]}
+"$DRIVER_BIN" \
+    -addr-1=http://localhost:23100 \
+    -addr-2=http://localhost:29092 \
+    -corpus="$ROOT_DIR/upstream/loki-bench/queries" \
+    -metadata-dir="$ROOT_DIR" \
+    -overlay="$OVERLAY" \
+    -report="$REPORT" \
+    -tolerance="$TOLERANCE" \
+    -range-type="$RANGE_TYPE" \
+    -parallelism="$PARALLELISM" \
+    -timeout="$TIMEOUT"
+DRIVER_RC=$?
 set -e
 
 echo "==> report written to $REPORT"
 echo "==> summary:"
-# go-test -v emits human-readable "--- PASS"/"--- FAIL" markers per
-# subtest. The driver registers each query case as a subtest, so a
-# grep against those is the cheapest summary surface; the report
-# captures the full stream for downstream analysis.
-PASS_COUNT=$(grep -c '^    --- PASS' "$REPORT" 2>/dev/null || echo 0)
-FAIL_COUNT=$(grep -c '^    --- FAIL' "$REPORT" 2>/dev/null || echo 0)
-SKIP_COUNT=$(grep -c '^    --- SKIP' "$REPORT" 2>/dev/null || echo 0)
-printf '    passed=%s failed=%s skipped=%s exit_code=%s\n' \
-    "$PASS_COUNT" "$FAIL_COUNT" "$SKIP_COUNT" "$DRIVER_RC"
+if command -v jq >/dev/null 2>&1; then
+    jq '{total: .totalResults, passed: ([.results[]? | select((.unexpectedFailure // "") == "" and (.diff // "") == "" and (.unexpectedSuccess // false) == false)] | length), diffs: ([.results[]? | select((.diff // "") != "")] | length), unexpected_failures: ([.results[]? | select((.unexpectedFailure // "") != "")] | length), unsupported: ([.results[]? | select((.unsupported // false) == true)] | length), skipped: ([.results[]? | select((.skipReason // "") != "")] | length)}' "$REPORT" 2>/dev/null || echo "    (jq failed to parse $REPORT)"
+else
+    echo "    (install jq for per-bucket summary)"
+fi
 
 exit "$DRIVER_RC"


### PR DESCRIPTION
**PR 5** of the rollout in [`docs/loki-compliance-plan.md`](docs/loki-compliance-plan.md):

> PR 5 (later) — cerberus-owned driver replacing the Go test entry. Port `TestRemoteStorageEquality`'s diff loop into `cmd/loki-compliance-tester/` so it emits the same JSON shape as the Prom tester. Add `just compatibility-all`.

Lands on top of #387 (now merged as 8b809c8). PR 3's `go test -tags=remote_correctness -c` script is replaced by a `go build` of the new cerberus-owned driver.

## Summary

Cerberus-owned diff driver replacing the upstream `TestRemoteStorageEquality` entry point. The PR 3 approach piped `go test -v` lines into `reports/diff.json` — usable but a different shape than the Prom harness's `report.json`. The new driver emits the same envelope (`{totalResults, includePassing, results: [{testCase, diff, unexpectedFailure, unexpectedSuccess, unsupported}]}`) so a single downstream analyser can consume both harnesses.

### Driver design

- **CLI**: `-addr-1` / `-addr-2` (Loki endpoints), `-corpus` (vendored `queries/` dir), `-metadata-dir` (`dataset_metadata.json` path), `-overlay` (`cerberus-test-queries.yml`), `-report` (output path), `-tolerance` (default `1e-5`, matches upstream `remote_test.go`), `-range-type` (range/instant), `-seed`, `-parallelism`, `-timeout`.
- **Corpus loader**: reuses the vendored `bench` package's `QueryRegistry` + `LoadMetadata` + `MetadataVariableResolver` + `TestCase`. Template expansion stays in lock-step with grafana/loki — cerberus-side divergence here would defeat the differential test.
- **HTTP**: direct `net/http` calls against `/loki/api/v1/query` (instant + metric kind) or `/query_range` (everything else). Avoids the heavy `pkg/logcli/client` import surface.
- **Decoder**: typed-union `typedResult` over `streams` / `vector` / `matrix` / `scalar`. Hand-rolled JSON decode + Prom-convention string-encoded floats (NaN / +Inf / -Inf round-trip via `strconv.ParseFloat`).
- **Diff**: sort labels canonically, walk in parallel, compare metrics + timestamps + values (with `math.Abs <= tolerance` and NaN-equal semantics matching upstream's `require.InDelta`). Returns a single-line human-readable diff string per case.
- **Overlay**: `cerberus-test-queries.yml` `should_skip:` entries suppress wire calls and surface in the report as `skipReason` (no failure flag flipped — same posture the Prom harness takes via `test-cerberus.yml` drops). `should_fail:` slot plumbed for the Prom-shape `unexpectedSuccess` semantics.
- **Resilience**: a corpus-wide expansion error (e.g. template `length: 24h` vs placeholder `dataset_metadata.json`'s 10-min window) used to fatal the whole run via `tb.Fatalf`. The new driver records each as a per-case `UnexpectedFailure` so the report stays shape-stable.

### go.mod posture

PR 3 (#387) needed `GOFLAGS=-mod=mod` + a `git checkout -- go.mod go.sum` cleanup trap to compile the upstream test binary. The cerberus-owned driver's imports (`bench` + `yaml.v3` + `logproto`-via-bench) are all reachable through cerberus's existing direct deps, so a plain `go build` works. The run script no longer touches the working tree; `go.mod` is unchanged by this PR.

### Run script

`scripts/run-loki-compatibility.sh` swaps the build step from `go test -tags=remote_correctness -c` to `go build ./harness/loki-compatibility/cmd/loki-compliance-tester/`. Invocation passes the new flags (`-corpus`, `-metadata-dir`, `-overlay`, `-report`, …). Summary is generated via `jq` against the structured report (or skipped with a hint if jq isn't installed).

### Justfile

Added `compatibility-all` recipe — runs PromQL + LogQL + TraceQL harnesses sequentially. Per-head recipes unchanged.

### Sample report fragment

Dry-run against unreachable endpoints + the `cerberus-test-queries.yml` overlay:

```json
{
  "totalResults": 14,
  "includePassing": true,
  "results": [
    {
      "testCase": {
        "query": "${SELECTOR}",
        "source": "fast/basic-selectors.yaml",
        "description": "Basic label selector",
        "kind": "log",
        "direction": "backward",
        "start": "",
        "end": "",
        "instant": false
      },
      "diff": "",
      "unexpectedFailure": "",
      "unexpectedSuccess": false,
      "unsupported": false,
      "skipReason": "Pending PR 6 seed expansion — ${SELECTOR} expands to the {service_name=…,namespace=…,cluster=…,container=…} shape but the current seeder only writes {service=…} streams; baseline Loki returns empty."
    }
  ]
}
```

The skip reasons in the overlay (PR 3) flow verbatim into the report's `skipReason` slot, so reviewers see the documented rationale per-case in the same place they'd see a diff.

## Constraints honoured

- chsql Builder discipline — driver code, no new SQL surfaces touched.
- No `t.Skip` outside `harness/*/upstream/**` (the driver is `package main`, no tests).
- No MD060 disable; tables in the harness README are hand-aligned.
- AGPL content stays under `harness/loki-compatibility/upstream/loki-bench/`; the driver lives outside that boundary.

## Test plan

- [ ] `just loki-compatibility` brings up the stack, builds the cerberus-owned driver, runs against both endpoints, writes `harness/loki-compatibility/reports/diff.json` in the Prom-shape envelope.
- [ ] Driver exit code = 1 when at least one case has a diff or unexpected failure; = 0 when every case passes (or is overlay-skipped).
- [ ] After the run, `git status` shows no diff in `go.mod` / `go.sum`.
- [ ] CI: `check` + `lint` + `forbid-skip` green.