### PR TITLE
feat(harness/tempo-compatibility): tags + tag values endpoints (v1+v2)

### DIFF
--- a/harness/tempo-compatibility/README.md
+++ b/harness/tempo-compatibility/README.md
@@ -1,15 +1,17 @@
 # Tempo / TraceQL compatibility harness
 
-> Status: **PR 4 (read corpus + smoke diff)** of the rollout described
-> in [`docs/tempo-compliance-plan.md`](../../docs/tempo-compliance-plan.md).
+> Status: **PR 6 (tags + tag-values)** of the rollout described in
+> [`docs/tempo-compliance-plan.md`](../../docs/tempo-compliance-plan.md).
 > This directory holds the vendored snapshot from PR 1 (`upstream/`),
 > the Docker Compose stack standing up reference Tempo + cerberus +
 > ClickHouse, the driver binary with two subcommands — `seed` (push
 > deterministic OTLP batch to both backends, smoke `/api/traces/<id>`)
 > and `diff` (run the TXTAR corpus through both backends, write a
 > markdown diff report) — and a nightly / `workflow_dispatch` GitHub
-> Actions lane (informational, not a required check). Metrics and tag
-> endpoints land in PRs 5-6.
+> Actions lane (informational, not a required check). The smoke corpus
+> now covers `/api/search`, `/api/traces/<id>`, and the four tag /
+> tag-values endpoints (V1 + V2); the metrics endpoints
+> (`/api/metrics/query_range` + `/api/metrics/query`) ship in PR 5.
 >
 > ## Ingest path (PR 3 vs the original plan)
 >
@@ -39,7 +41,7 @@ See [`docs/tempo-compliance-plan.md`](../../docs/tempo-compliance-plan.md)
 for the full landscape analysis, the per-PR breakdown, and the diff
 strategy.
 
-## Layout (current — PR 4)
+## Layout (current — PR 6)
 
 ```text
 harness/tempo-compatibility/
@@ -52,11 +54,13 @@ harness/tempo-compatibility/
     Dockerfile          repo-root context multi-stage build
     main.go             subcommand dispatcher (seed / diff)
     seeder.go           OTLP push to Tempo + CH INSERT for cerberus
-    corpus.go           TXTAR corpus loader (PR 4)
-    differ.go           canonical-key + relative-epsilon diff (PR 4)
-    diff.go             `diff` subcommand: HTTP fetch + assertions + report (PR 4)
+    corpus.go           TXTAR corpus loader (PR 4 + PR 6 tag sections)
+    differ.go           canonical-key + relative-epsilon diff (PR 4) +
+                        tag-name / tag-values set diff (PR 6)
+    diff.go             `diff` subcommand: HTTP fetch + assertions + report
     corpus/
-      smoke.txtar       ~20 cases lifted from shadow corpus (PR 4)
+      smoke.txtar       trace search + per-id (PR 4) + tag / tag-values
+                        endpoints (PR 6)
   reports/              driver report output (gitignored)
   upstream/             PR 1 — vendored snapshot (read-only reference)
     LICENSE             AGPL-3.0, copied verbatim from grafana/tempo
@@ -65,13 +69,13 @@ harness/tempo-compatibility/
     pkg/httpclient/     Tempo HTTP client; reused by the future driver
 ```
 
-## Layout (planned — PRs 5-7)
+## Layout (planned — PRs 5 + 7)
 
 ```text
 harness/tempo-compatibility/
   driver/
     corpus/
-      coverage.txtar    PR 5/6 — full coverage (metrics + tags + values)
+      coverage.txtar    PR 5 — metrics endpoints
   expected-failures.json  PR 5+
 ```
 
@@ -98,6 +102,47 @@ compares the responses. Two complications drive the diff strategy:
 
 Numeric fields (durationMs, startTimeUnixNano) compare under a 1e-9
 relative epsilon — same defaults as `harness/prometheus-compliance/shadow`.
+
+## Corpus categories
+
+The TXTAR corpus is the single source of truth for which Tempo HTTP
+shapes the differ exercises. PR 4 lifted the trace-search categories
+from the shadow harness; PR 6 added the four tag / tag-values
+endpoints.
+
+| Category                | Endpoint kind     | Wire shape                                      | Diff strategy                                          |
+| ----------------------- | ----------------- | ----------------------------------------------- | ------------------------------------------------------ |
+| Attribute matchers      | `search`          | `{traces:[TraceSummary]}`                       | Canonical-key (rootSvc, rootName) set diff             |
+| Intrinsics              | `search`          | same                                            | same                                                   |
+| Structural ops          | `search`          | same                                            | same                                                   |
+| Set ops                 | `search`          | same                                            | same                                                   |
+| Inner aggregates        | `search`          | same                                            | same                                                   |
+| Metrics pipeline        | `search` (PR 5)   | Prom series envelope                            | Semantic invariants + structural diff (lands PR 5)     |
+| Per-id round trip       | `traces`          | `{trace:{...}}`                                 | Trace-ID derivation from seeder template + status-2xx  |
+| Tag names V1            | `tags_v1`         | `{tagNames:[string]}`                           | Set diff over the flat list                            |
+| Tag names V2            | `tags_v2`         | `{scopes:[{name, tags}]}`                       | Set diff over flattened tags + per-scope-name diff     |
+| Tag values V1           | `tag_values_v1`   | `{tagValues:[string]}`                          | Set diff over the flat list                            |
+| Tag values V2           | `tag_values_v2`   | `{tagValues:[{type, value}]}`                   | Set diff over `Value` + `Type`-field diff on overlap   |
+
+The PR 6 corpus pins three classes of subset assertion on the tag
+endpoints:
+
+- **Always-present keys** (`service.name`, `http.method`) — the seeder
+  writes these on every span, so both backends MUST surface them in the
+  tag-names lists.
+- **Always-present values** (`checkout` / `payments` / `search` /
+  `shipping` for `service.name`; `compat-test` for `deployment.env`) —
+  the seeded value cardinality is exact, so a missing value is a real
+  ingest / lowering regression.
+- **Empty-result edge case** (`this.tag.does.not.exist`) — both
+  backends must return an empty `tagValues` list, exercising the
+  graceful-empty branches of each side's lookup code.
+
+Cerberus today ignores the `?scope=` filter on `tags_v2` and returns
+every scope regardless. PR 6's `tags_v2_resource` / `tags_v2_span` /
+`tags_v2_intrinsic` cases will surface that gap as a `scope_mismatch`
+reason in the markdown report — informational on the nightly job, not a
+hard fail.
 
 ## What's in `upstream/`
 

--- a/harness/tempo-compatibility/driver/corpus.go
+++ b/harness/tempo-compatibility/driver/corpus.go
@@ -1,5 +1,6 @@
 // Corpus loader for the Tempo / TraceQL compatibility differ
-// (PR 4 of docs/tempo-compliance-plan.md).
+// (PR 4 of docs/tempo-compliance-plan.md; extended in PR 6 to cover
+// the four tag / tag-values endpoints).
 //
 // The format is a lightweight TXTAR variant — same shape as
 // harness/prometheus-compliance/shadow/corpus.go — so the parser
@@ -7,11 +8,28 @@
 // non-header line as section body. The supported sections:
 //
 //	-- name --                  short identifier, used in the report
-//	-- query --                 the TraceQL expression
-//	-- endpoint --              one of: search | search_recent | traces
+//	-- query --                 the TraceQL expression (search endpoints)
+//	-- endpoint --              one of: search | search_recent | traces |
+//	                            tags_v1 | tags_v2 | tag_values_v1 |
+//	                            tag_values_v2
 //	-- traceid_template --      a template like "{svc}/{idx}" (only for `traces`)
+//	-- tag_name --              attribute key whose values to enumerate
+//	                            (tag_values_v1 / tag_values_v2 only)
+//	-- scope --                 optional `?scope=` filter for tags_v2 (one of
+//	                            resource | span | intrinsic | none); empty
+//	                            omits the parameter so both backends return
+//	                            the unfiltered scope set
 //	-- expected_min_traces --   integer; minimum traces both sides must return
 //	-- expected_max_traces --   integer; maximum traces either side may return
+//	-- expected_min_values --   integer; minimum list cardinality for tag /
+//	                            tag-values endpoints
+//	-- expected_max_values --   integer; maximum list cardinality for tag /
+//	                            tag-values endpoints
+//	-- expected_values --       newline-separated subset that must appear in
+//	                            the response list (tag-names or tag-values)
+//	-- expected_scopes --       newline-separated subset of scope names
+//	                            (resource / span / intrinsic) that must
+//	                            appear in tags_v2 responses
 //	-- expected_services --     newline-separated list of `service.name` values
 //	                            that should appear in `rootServiceName`
 //	-- expected_root_name_re -- Go regexp; every returned trace's rootTraceName
@@ -63,9 +81,13 @@ type CorpusCase struct {
 
 	// Endpoint selects the HTTP path the differ hits:
 	//
-	//   * search         GET /api/search?q=<TraceQL>
-	//   * search_recent  GET /api/search/recent (TraceQL ignored)
-	//   * traces         GET /api/traces/<id>   (TraceIDTemplate populated)
+	//   * search          GET /api/search?q=<TraceQL>
+	//   * search_recent   GET /api/search/recent (TraceQL ignored)
+	//   * traces          GET /api/traces/<id>   (TraceIDTemplate populated)
+	//   * tags_v1         GET /api/search/tags
+	//   * tags_v2         GET /api/v2/search/tags[?scope=<Scope>]
+	//   * tag_values_v1   GET /api/search/tag/{TagName}/values
+	//   * tag_values_v2   GET /api/v2/search/tag/{TagName}/values
 	//
 	// The seeder pushes data with deterministic trace IDs derived from
 	// (service, traceIdx); see TraceIDTemplate below for the format.
@@ -78,6 +100,16 @@ type CorpusCase struct {
 	// from the binary trace ID keeps the corpus file human-editable.
 	TraceIDTemplate string
 
+	// TagName is the {name} path component for the tag_values_v1 /
+	// tag_values_v2 endpoints. Required for those two endpoints, unused
+	// elsewhere.
+	TagName string
+
+	// Scope is the optional `?scope=` query parameter for tags_v2. One of
+	// "resource" / "span" / "intrinsic" / "none". Empty leaves the
+	// parameter off the URL (Tempo defaults to returning every scope).
+	Scope string
+
 	// SkipReason, when non-empty, makes the case parse but skip during
 	// diffing. Used to declare PR-5-shaped cases (metrics endpoints)
 	// in the smoke corpus so the file stays the single source of truth
@@ -88,6 +120,20 @@ type CorpusCase struct {
 	// backends must agree with. Zero (the default) disables the bound.
 	ExpectedMinTraces int
 	ExpectedMaxTraces int
+
+	// ExpectedMinValues / ExpectedMaxValues bound the list-cardinality
+	// of the tag / tag-values endpoints. Zero disables.
+	ExpectedMinValues int
+	ExpectedMaxValues int
+
+	// ExpectedValues is a subset-must-be-present assertion for the
+	// tag-names list (tags_v1 / tags_v2 flattened) or the tag-values list
+	// (tag_values_v1 / tag_values_v2). Empty disables.
+	ExpectedValues []string
+
+	// ExpectedScopes is a subset-must-be-present assertion for the
+	// tags_v2 response (the `Scopes[*].Name` strings). Empty disables.
+	ExpectedScopes []string
 
 	// ExpectedServices is a set membership assertion: every value listed
 	// here must appear in at least one returned trace's rootServiceName.
@@ -120,9 +166,15 @@ const (
 	secQuery           = "query"
 	secEndpoint        = "endpoint"
 	secTraceIDTemplate = "traceid_template"
+	secTagName         = "tag_name"
+	secScope           = "scope"
 	secSkipReason      = "skip_reason"
 	secMinTraces       = "expected_min_traces"
 	secMaxTraces       = "expected_max_traces"
+	secMinValues       = "expected_min_values"
+	secMaxValues       = "expected_max_values"
+	secValues          = "expected_values"
+	secScopes          = "expected_scopes"
 	secServices        = "expected_services"
 	secRootNameRE      = "expected_root_name_re"
 )
@@ -159,21 +211,26 @@ func applySection(cur *CorpusCase, section, body string) error {
 		cur.Endpoint = body
 	case secTraceIDTemplate:
 		cur.TraceIDTemplate = body
+	case secTagName:
+		cur.TagName = body
+	case secScope:
+		cur.Scope = body
 	case secSkipReason:
 		cur.SkipReason = body
 	case secMinTraces:
 		return applyIntSection(body, "expected_min_traces", &cur.ExpectedMinTraces)
 	case secMaxTraces:
 		return applyIntSection(body, "expected_max_traces", &cur.ExpectedMaxTraces)
+	case secMinValues:
+		return applyIntSection(body, "expected_min_values", &cur.ExpectedMinValues)
+	case secMaxValues:
+		return applyIntSection(body, "expected_max_values", &cur.ExpectedMaxValues)
+	case secValues:
+		appendNonEmptyLines(body, &cur.ExpectedValues)
+	case secScopes:
+		appendNonEmptyLines(body, &cur.ExpectedScopes)
 	case secServices:
-		if body == "" {
-			return nil
-		}
-		for _, line := range strings.Split(body, "\n") {
-			if s := strings.TrimSpace(line); s != "" {
-				cur.ExpectedServices = append(cur.ExpectedServices, s)
-			}
-		}
+		appendNonEmptyLines(body, &cur.ExpectedServices)
 	case secRootNameRE:
 		if body == "" {
 			return nil
@@ -185,6 +242,21 @@ func applySection(cur *CorpusCase, section, body string) error {
 		cur.ExpectedRootNameRE = re
 	}
 	return nil
+}
+
+// appendNonEmptyLines splits `body` on newlines and appends every
+// trimmed non-empty line to `*dst`. Pulled out so the multi-line
+// subset assertions (expected_services / expected_values /
+// expected_scopes) share one parse path instead of three near-duplicates.
+func appendNonEmptyLines(body string, dst *[]string) {
+	if body == "" {
+		return
+	}
+	for _, line := range strings.Split(body, "\n") {
+		if s := strings.TrimSpace(line); s != "" {
+			*dst = append(*dst, s)
+		}
+	}
 }
 
 func applyIntSection(body, name string, dst *int) error {
@@ -205,21 +277,38 @@ func validateCase(cur CorpusCase, ord int) (CorpusCase, error) {
 	if cur.Name == "" {
 		return cur, fmt.Errorf("case missing -- name -- (case #%d)", ord)
 	}
-	if cur.Query == "" && cur.Endpoint != "search_recent" {
-		return cur, fmt.Errorf("case %q missing -- query -- (search_recent is the only endpoint that may omit it)", cur.Name)
-	}
 	if cur.Endpoint == "" {
 		cur.Endpoint = "search"
 	}
+	if !isTagEndpoint(cur.Endpoint) && cur.Query == "" && cur.Endpoint != "search_recent" {
+		return cur, fmt.Errorf("case %q missing -- query -- (search_recent and the four tag endpoints are the only kinds that may omit it)", cur.Name)
+	}
 	switch cur.Endpoint {
-	case "search", "search_recent", "traces":
+	case "search", "search_recent", "traces",
+		"tags_v1", "tags_v2", "tag_values_v1", "tag_values_v2":
 	default:
-		return cur, fmt.Errorf("case %q: unknown endpoint %q (want search | search_recent | traces)", cur.Name, cur.Endpoint)
+		return cur, fmt.Errorf("case %q: unknown endpoint %q (want search | search_recent | traces | tags_v1 | tags_v2 | tag_values_v1 | tag_values_v2)", cur.Name, cur.Endpoint)
 	}
 	if cur.Endpoint == "traces" && cur.TraceIDTemplate == "" {
 		return cur, fmt.Errorf("case %q: endpoint=traces requires -- traceid_template --", cur.Name)
 	}
+	if (cur.Endpoint == "tag_values_v1" || cur.Endpoint == "tag_values_v2") && cur.TagName == "" {
+		return cur, fmt.Errorf("case %q: endpoint=%s requires -- tag_name --", cur.Name, cur.Endpoint)
+	}
+	if cur.Scope != "" && cur.Endpoint != "tags_v2" {
+		return cur, fmt.Errorf("case %q: -- scope -- is only valid for endpoint=tags_v2 (got %s)", cur.Name, cur.Endpoint)
+	}
 	return cur, nil
+}
+
+// isTagEndpoint reports whether the given endpoint is one of the four
+// tag / tag-values endpoints, which all have no TraceQL query slot.
+func isTagEndpoint(ep string) bool {
+	switch ep {
+	case "tags_v1", "tags_v2", "tag_values_v1", "tag_values_v2":
+		return true
+	}
+	return false
 }
 
 // isKnownSection reports whether the given header name is a recognized
@@ -227,8 +316,10 @@ func validateCase(cur CorpusCase, ord int) (CorpusCase, error) {
 // boundary).
 func isKnownSection(name string) bool {
 	switch name {
-	case secQuery, secEndpoint, secTraceIDTemplate, secSkipReason,
-		secMinTraces, secMaxTraces, secServices, secRootNameRE:
+	case secQuery, secEndpoint, secTraceIDTemplate, secTagName, secScope,
+		secSkipReason,
+		secMinTraces, secMaxTraces, secMinValues, secMaxValues,
+		secValues, secScopes, secServices, secRootNameRE:
 		return true
 	}
 	return false

--- a/harness/tempo-compatibility/driver/corpus/smoke.txtar
+++ b/harness/tempo-compatibility/driver/corpus/smoke.txtar
@@ -290,3 +290,141 @@ trace_by_id_first_checkout
 traces
 -- traceid_template --
 checkout/0
+
+# --- Tags + tag-values endpoints (PR 6) ---
+# Conformance for the four tag endpoints. Cardinality bounds are wide
+# because the precise per-backend tag-key inventory drifts with both
+# backends' OTLP→storage mapping (cerberus surfaces ResourceAttributes /
+# SpanAttributes map keys + a static intrinsic list; real Tempo surfaces
+# whatever its block-storage indexer recorded). The structural diff
+# tells us which keys disagree; the subset assertions pin the keys that
+# MUST appear because the seeder writes them on every span.
+
+-- name --
+tags_v1_all
+-- endpoint --
+tags_v1
+-- expected_min_values --
+1
+-- expected_max_values --
+500
+-- expected_values --
+service.name
+http.method
+
+-- name --
+tags_v2_resource
+-- endpoint --
+tags_v2
+-- scope --
+resource
+# Cerberus today ignores ?scope= and always returns the full scope set,
+# so the differ will surface a scope-axis diff between cerberus and
+# Tempo here. The subset assertion still passes on both sides because
+# `service.name` lives in the resource scope on Tempo and cerberus
+# both surfaces it (from ResourceAttributes / static map).
+-- expected_min_values --
+1
+-- expected_max_values --
+500
+-- expected_values --
+service.name
+-- expected_scopes --
+resource
+
+-- name --
+tags_v2_span
+-- endpoint --
+tags_v2
+-- scope --
+span
+-- expected_min_values --
+1
+-- expected_max_values --
+500
+-- expected_values --
+http.method
+-- expected_scopes --
+span
+
+-- name --
+tags_v2_intrinsic
+-- endpoint --
+tags_v2
+-- scope --
+intrinsic
+-- expected_min_values --
+1
+-- expected_max_values --
+500
+# Intrinsics are static in both backends; the seeder doesn't influence
+# their presence — they always surface alongside dynamic attributes.
+-- expected_values --
+name
+kind
+-- expected_scopes --
+intrinsic
+
+-- name --
+tag_values_v1_service_name
+-- endpoint --
+tag_values_v1
+-- tag_name --
+service.name
+-- expected_min_values --
+1
+-- expected_max_values --
+50
+# Seeder writes 4 service.name values; every one MUST surface on both
+# sides because resource.service.name is the canonical dispatcher.
+-- expected_values --
+checkout
+payments
+search
+shipping
+
+-- name --
+tag_values_v2_service_name
+-- endpoint --
+tag_values_v2
+-- tag_name --
+service.name
+-- expected_min_values --
+1
+-- expected_max_values --
+50
+-- expected_values --
+checkout
+payments
+search
+shipping
+
+-- name --
+tag_values_v2_deployment_env
+-- endpoint --
+tag_values_v2
+-- tag_name --
+deployment.env
+-- expected_min_values --
+1
+-- expected_max_values --
+20
+# Every seeded span carries deployment.env="compat-test"; only one
+# value lives in this attribute today.
+-- expected_values --
+compat-test
+
+-- name --
+tag_values_v2_unknown_tag_empty
+-- endpoint --
+tag_values_v2
+-- tag_name --
+this.tag.does.not.exist
+# Both backends should return an empty `tagValues` list for an unknown
+# attribute key — the result is the empty subset of a never-populated
+# CH map column. Differ surfaces a cardinality match on len=0 with no
+# missing_in_* reasons.
+-- expected_min_values --
+0
+-- expected_max_values --
+0

--- a/harness/tempo-compatibility/driver/corpus_test.go
+++ b/harness/tempo-compatibility/driver/corpus_test.go
@@ -198,13 +198,129 @@ func TestSmokeCorpus_LoadsAndMeetsFloor(t *testing.T) {
 	if len(cases) < 20 {
 		t.Fatalf("smoke corpus shrunk: got %d, want >= 20", len(cases))
 	}
-	// Every active case has a non-empty query.
+	// Every active case has a non-empty query unless the endpoint is one
+	// of the "no TraceQL" kinds (search_recent + the four tag endpoints).
 	for _, c := range cases {
 		if c.SkipReason != "" {
 			continue
 		}
-		if c.Query == "" && c.Endpoint != "search_recent" {
+		if c.Query == "" && c.Endpoint != "search_recent" && !isTagEndpoint(c.Endpoint) {
 			t.Fatalf("case %q: empty query but endpoint=%q", c.Name, c.Endpoint)
 		}
+	}
+}
+
+func TestSmokeCorpus_TagEndpointCoverage(t *testing.T) {
+	t.Parallel()
+	cases, err := LoadCorpus(filepath.Join("corpus", "smoke.txtar"))
+	if err != nil {
+		t.Fatalf("LoadCorpus: %v", err)
+	}
+	// PR 6 commits the four tag endpoints. Every endpoint kind must
+	// have at least one active case in the smoke corpus so the differ
+	// exercises the full response-shape matrix on every nightly run.
+	required := map[string]bool{
+		"tags_v1":       false,
+		"tags_v2":       false,
+		"tag_values_v1": false,
+		"tag_values_v2": false,
+	}
+	for _, c := range cases {
+		if c.SkipReason != "" {
+			continue
+		}
+		if _, ok := required[c.Endpoint]; ok {
+			required[c.Endpoint] = true
+		}
+	}
+	for ep, seen := range required {
+		if !seen {
+			t.Errorf("smoke corpus lacks an active case for endpoint=%q", ep)
+		}
+	}
+}
+
+func TestParseCorpus_TagValuesRequiresTagName(t *testing.T) {
+	t.Parallel()
+	for _, ep := range []string{"tag_values_v1", "tag_values_v2"} {
+		in := `-- name --
+x
+-- endpoint --
+` + ep + `
+`
+		if _, err := parseCorpus(strings.NewReader(in), "test"); err == nil {
+			t.Fatalf("endpoint=%s without tag_name should fail", ep)
+		}
+	}
+}
+
+func TestParseCorpus_TagValuesWithTagNameOK(t *testing.T) {
+	t.Parallel()
+	in := `-- name --
+tv
+-- endpoint --
+tag_values_v1
+-- tag_name --
+service.name
+-- expected_values --
+checkout
+payments
+`
+	got, err := parseCorpus(strings.NewReader(in), "test")
+	if err != nil {
+		t.Fatalf("parseCorpus: %v", err)
+	}
+	if got[0].TagName != "service.name" {
+		t.Fatalf("tag_name = %q", got[0].TagName)
+	}
+	if len(got[0].ExpectedValues) != 2 ||
+		got[0].ExpectedValues[0] != "checkout" || got[0].ExpectedValues[1] != "payments" {
+		t.Fatalf("expected_values = %v", got[0].ExpectedValues)
+	}
+}
+
+func TestParseCorpus_TagsV2WithScopeOK(t *testing.T) {
+	t.Parallel()
+	in := `-- name --
+tg
+-- endpoint --
+tags_v2
+-- scope --
+resource
+-- expected_scopes --
+resource
+-- expected_min_values --
+1
+-- expected_max_values --
+500
+`
+	got, err := parseCorpus(strings.NewReader(in), "test")
+	if err != nil {
+		t.Fatalf("parseCorpus: %v", err)
+	}
+	if got[0].Scope != "resource" {
+		t.Fatalf("scope = %q", got[0].Scope)
+	}
+	if len(got[0].ExpectedScopes) != 1 || got[0].ExpectedScopes[0] != "resource" {
+		t.Fatalf("expected_scopes = %v", got[0].ExpectedScopes)
+	}
+	if got[0].ExpectedMinValues != 1 || got[0].ExpectedMaxValues != 500 {
+		t.Fatalf("min/max values = %d..%d", got[0].ExpectedMinValues, got[0].ExpectedMaxValues)
+	}
+}
+
+func TestParseCorpus_ScopeOnlyValidForTagsV2(t *testing.T) {
+	t.Parallel()
+	in := `-- name --
+bad
+-- query --
+{ x = 1 }
+-- endpoint --
+search
+-- scope --
+resource
+`
+	if _, err := parseCorpus(strings.NewReader(in), "test"); err == nil {
+		t.Fatal("scope on a non-tags_v2 case should fail")
 	}
 }

--- a/harness/tempo-compatibility/driver/diff.go
+++ b/harness/tempo-compatibility/driver/diff.go
@@ -217,13 +217,40 @@ func diffCase(ctx context.Context, client *http.Client, tc CorpusCase, opts case
 
 	// Differential diff. The case sets some upper bound on what we
 	// can expect to agree on; the structural diff is independent.
-	d, err := Compare(tempoBody, cerbBody, "tempo", "cerberus", DefaultDiffOptions())
+	// Dispatch by endpoint kind: trace endpoints use the SearchResponse
+	// canonical-key diff; the four tag endpoints diff the string-list
+	// envelope; tag-values v2 additionally checks the Type field per
+	// matched value. Keeping the dispatch here (vs threading a closure
+	// through every helper) keeps the runtime branches local to where
+	// the response shapes diverge.
+	d, err := compareForEndpoint(tc, tempoBody, cerbBody)
 	if err != nil {
 		res.HardError = fmt.Sprintf("diff: %v", err)
 		return res
 	}
 	res.Diff = d
 	return res
+}
+
+// compareForEndpoint runs the right structural-diff function for the
+// case's endpoint kind. The four tag endpoints share `CompareTagNames`
+// (envelope is a flat string set on V1 + a flatten-the-scopes view on
+// V2) and `CompareTagValues` (envelope is a flat list on V1, typed
+// objects on V2 — the differ unifies on the `Value` field and reports
+// `Type` mismatches as field_mismatch reasons).
+func compareForEndpoint(tc CorpusCase, tempoBody, cerbBody []byte) (Diff, error) {
+	switch tc.Endpoint {
+	case "tags_v1":
+		return CompareTagNames(tempoBody, cerbBody, "tempo", "cerberus", false)
+	case "tags_v2":
+		return CompareTagNames(tempoBody, cerbBody, "tempo", "cerberus", true)
+	case "tag_values_v1":
+		return CompareTagValues(tempoBody, cerbBody, "tempo", "cerberus", false)
+	case "tag_values_v2":
+		return CompareTagValues(tempoBody, cerbBody, "tempo", "cerberus", true)
+	default:
+		return Compare(tempoBody, cerbBody, "tempo", "cerberus", DefaultDiffOptions())
+	}
 }
 
 // buildURL composes the per-endpoint URL for a corpus case. The
@@ -250,6 +277,25 @@ func buildURL(base string, tc CorpusCase, backend string, startTS, endTS time.Ti
 			return "", err
 		}
 		u.Path += "/api/traces/" + id
+	case "tags_v1":
+		u.Path += "/api/search/tags"
+		q.Set("start", fmt.Sprintf("%d", startTS.Unix()))
+		q.Set("end", fmt.Sprintf("%d", endTS.Unix()))
+	case "tags_v2":
+		u.Path += "/api/v2/search/tags"
+		q.Set("start", fmt.Sprintf("%d", startTS.Unix()))
+		q.Set("end", fmt.Sprintf("%d", endTS.Unix()))
+		if tc.Scope != "" {
+			q.Set("scope", tc.Scope)
+		}
+	case "tag_values_v1":
+		u.Path += "/api/search/tag/" + tc.TagName + "/values"
+		q.Set("start", fmt.Sprintf("%d", startTS.Unix()))
+		q.Set("end", fmt.Sprintf("%d", endTS.Unix()))
+	case "tag_values_v2":
+		u.Path += "/api/v2/search/tag/" + tc.TagName + "/values"
+		q.Set("start", fmt.Sprintf("%d", startTS.Unix()))
+		q.Set("end", fmt.Sprintf("%d", endTS.Unix()))
 	default:
 		return "", fmt.Errorf("unsupported endpoint %q", tc.Endpoint)
 	}

--- a/harness/tempo-compatibility/driver/diff_test.go
+++ b/harness/tempo-compatibility/driver/diff_test.go
@@ -126,3 +126,86 @@ func TestDeriveTraceIDFromTemplate_BadFormatFails(t *testing.T) {
 		t.Fatal("expected error on non-numeric idx")
 	}
 }
+
+func TestBuildURL_TagsV1(t *testing.T) {
+	t.Parallel()
+	tc := CorpusCase{Name: "x", Endpoint: "tags_v1"}
+	u, err := buildURL("http://tempo:3200", tc, "tempo", time.Unix(1000, 0), time.Unix(2000, 0), 200)
+	if err != nil {
+		t.Fatalf("buildURL: %v", err)
+	}
+	if !strings.HasPrefix(u, "http://tempo:3200/api/search/tags?") {
+		t.Fatalf("unexpected url: %s", u)
+	}
+	if !strings.Contains(u, "start=1000") || !strings.Contains(u, "end=2000") {
+		t.Fatalf("missing start/end: %s", u)
+	}
+}
+
+func TestBuildURL_TagsV2WithScope(t *testing.T) {
+	t.Parallel()
+	tc := CorpusCase{Name: "x", Endpoint: "tags_v2", Scope: "resource"}
+	u, err := buildURL("http://tempo:3200", tc, "tempo", time.Unix(1000, 0), time.Unix(2000, 0), 200)
+	if err != nil {
+		t.Fatalf("buildURL: %v", err)
+	}
+	if !strings.HasPrefix(u, "http://tempo:3200/api/v2/search/tags?") {
+		t.Fatalf("unexpected url: %s", u)
+	}
+	if !strings.Contains(u, "scope=resource") {
+		t.Fatalf("scope query missing: %s", u)
+	}
+}
+
+func TestBuildURL_TagsV2WithoutScopeOmitsParam(t *testing.T) {
+	t.Parallel()
+	tc := CorpusCase{Name: "x", Endpoint: "tags_v2"}
+	u, err := buildURL("http://tempo:3200", tc, "tempo", time.Unix(0, 0), time.Unix(0, 0), 20)
+	if err != nil {
+		t.Fatalf("buildURL: %v", err)
+	}
+	if strings.Contains(u, "scope=") {
+		t.Fatalf("scope= should be omitted when Scope is empty: %s", u)
+	}
+}
+
+func TestBuildURL_TagValuesV1(t *testing.T) {
+	t.Parallel()
+	tc := CorpusCase{Name: "x", Endpoint: "tag_values_v1", TagName: "service.name"}
+	u, err := buildURL("http://tempo:3200", tc, "tempo", time.Unix(1000, 0), time.Unix(2000, 0), 200)
+	if err != nil {
+		t.Fatalf("buildURL: %v", err)
+	}
+	if !strings.HasPrefix(u, "http://tempo:3200/api/search/tag/service.name/values?") {
+		t.Fatalf("unexpected url: %s", u)
+	}
+}
+
+func TestBuildURL_TagValuesV2(t *testing.T) {
+	t.Parallel()
+	tc := CorpusCase{Name: "x", Endpoint: "tag_values_v2", TagName: "deployment.env"}
+	u, err := buildURL("http://tempo:3200", tc, "tempo", time.Unix(1000, 0), time.Unix(2000, 0), 200)
+	if err != nil {
+		t.Fatalf("buildURL: %v", err)
+	}
+	if !strings.HasPrefix(u, "http://tempo:3200/api/v2/search/tag/deployment.env/values?") {
+		t.Fatalf("unexpected url: %s", u)
+	}
+}
+
+func TestCompareForEndpoint_DispatchesTagShape(t *testing.T) {
+	t.Parallel()
+	// Both bodies are V1 tag-names envelopes; the trace-search Compare
+	// would error on the shape, so a clean Diff confirms the dispatch
+	// routed to CompareTagNames.
+	a := []byte(`{"tagNames":["service.name","http.method"]}`)
+	b := []byte(`{"tagNames":["service.name","http.method"]}`)
+	tc := CorpusCase{Name: "tags_match", Endpoint: "tags_v1"}
+	d, err := compareForEndpoint(tc, a, b)
+	if err != nil {
+		t.Fatalf("compareForEndpoint: %v", err)
+	}
+	if !d.Equal {
+		t.Fatalf("expected equal on identical tag names, got %+v", d)
+	}
+}

--- a/harness/tempo-compatibility/driver/differ.go
+++ b/harness/tempo-compatibility/driver/differ.go
@@ -321,6 +321,20 @@ func valuesClose(a, b float64, opts DiffOptions) bool {
 // Returns reasons for every expectation that failed. An empty slice
 // means all expectations passed.
 func AssertCase(tc CorpusCase, body []byte, backendLabel string) ([]DiffReason, error) {
+	switch tc.Endpoint {
+	case "tags_v1", "tags_v2":
+		return assertTagsCase(tc, body, backendLabel)
+	case "tag_values_v1", "tag_values_v2":
+		return assertTagValuesCase(tc, body, backendLabel)
+	default:
+		return assertTraceSearchCase(tc, body, backendLabel)
+	}
+}
+
+// assertTraceSearchCase is the original AssertCase body — applies the
+// trace-search assertions (min/max traces, expected services, root-name
+// regexp) to a SearchResponse body.
+func assertTraceSearchCase(tc CorpusCase, body []byte, backendLabel string) ([]DiffReason, error) {
 	var reasons []DiffReason
 	a, err := decodeSearch(body)
 	if err != nil {
@@ -364,6 +378,401 @@ func AssertCase(tc CorpusCase, body []byte, backendLabel string) ([]DiffReason, 
 		}
 	}
 	return reasons, nil
+}
+
+// assertTagsCase applies the tag-endpoint assertions: min/max list
+// cardinality, expected-values subset (every value in tc.ExpectedValues
+// must appear in the response), and (for tags_v2) expected-scopes
+// subset.
+func assertTagsCase(tc CorpusCase, body []byte, backendLabel string) ([]DiffReason, error) {
+	v2 := tc.Endpoint == "tags_v2"
+	tagNames, scopeNames, err := decodeTagNames(body, v2)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", backendLabel, err)
+	}
+	var reasons []DiffReason
+	if tc.ExpectedMinValues > 0 && len(tagNames) < tc.ExpectedMinValues {
+		reasons = append(reasons, DiffReason{
+			Kind:   "assertion",
+			Detail: fmt.Sprintf("%s: got %d tag names, want >= %d", backendLabel, len(tagNames), tc.ExpectedMinValues),
+		})
+	}
+	if tc.ExpectedMaxValues > 0 && len(tagNames) > tc.ExpectedMaxValues {
+		reasons = append(reasons, DiffReason{
+			Kind:   "assertion",
+			Detail: fmt.Sprintf("%s: got %d tag names, want <= %d", backendLabel, len(tagNames), tc.ExpectedMaxValues),
+		})
+	}
+	if len(tc.ExpectedValues) > 0 {
+		seen := stringSet(tagNames)
+		for _, want := range tc.ExpectedValues {
+			if !seen[want] {
+				reasons = append(reasons, DiffReason{
+					Kind:   "assertion",
+					Detail: fmt.Sprintf("%s: expected tag name %q in response", backendLabel, want),
+				})
+			}
+		}
+	}
+	if len(tc.ExpectedScopes) > 0 {
+		if !v2 {
+			reasons = append(reasons, DiffReason{
+				Kind:   "assertion",
+				Detail: fmt.Sprintf("%s: expected_scopes only meaningful for tags_v2", backendLabel),
+			})
+		} else {
+			seen := stringSet(scopeNames)
+			for _, want := range tc.ExpectedScopes {
+				if !seen[want] {
+					reasons = append(reasons, DiffReason{
+						Kind:   "assertion",
+						Detail: fmt.Sprintf("%s: expected scope %q in response (got %v)", backendLabel, want, scopeNames),
+					})
+				}
+			}
+		}
+	}
+	return reasons, nil
+}
+
+// assertTagValuesCase applies the tag-values assertions: min/max list
+// cardinality + expected-values subset.
+func assertTagValuesCase(tc CorpusCase, body []byte, backendLabel string) ([]DiffReason, error) {
+	v2 := tc.Endpoint == "tag_values_v2"
+	values, _, err := decodeTagValues(body, v2)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", backendLabel, err)
+	}
+	var reasons []DiffReason
+	if tc.ExpectedMinValues > 0 && len(values) < tc.ExpectedMinValues {
+		reasons = append(reasons, DiffReason{
+			Kind:   "assertion",
+			Detail: fmt.Sprintf("%s: got %d tag values, want >= %d", backendLabel, len(values), tc.ExpectedMinValues),
+		})
+	}
+	if tc.ExpectedMaxValues > 0 && len(values) > tc.ExpectedMaxValues {
+		reasons = append(reasons, DiffReason{
+			Kind:   "assertion",
+			Detail: fmt.Sprintf("%s: got %d tag values, want <= %d", backendLabel, len(values), tc.ExpectedMaxValues),
+		})
+	}
+	if len(tc.ExpectedValues) > 0 {
+		seen := stringSet(values)
+		for _, want := range tc.ExpectedValues {
+			if !seen[want] {
+				reasons = append(reasons, DiffReason{
+					Kind:   "assertion",
+					Detail: fmt.Sprintf("%s: expected tag value %q in response (tag_name=%q)", backendLabel, want, tc.TagName),
+				})
+			}
+		}
+	}
+	return reasons, nil
+}
+
+// stringSet is a tiny helper: returns a presence map keyed on the slice
+// entries. Inlined in two places (CompareTagNames + assertion paths) so
+// extracting it keeps both sites identical.
+func stringSet(in []string) map[string]bool {
+	out := make(map[string]bool, len(in))
+	for _, s := range in {
+		out[s] = true
+	}
+	return out
+}
+
+// TagNamesResponseV1 mirrors `/api/search/tags`.
+type TagNamesResponseV1 struct {
+	TagNames []string `json:"tagNames"`
+}
+
+// TagNamesResponseV2 mirrors `/api/v2/search/tags`. Each scope carries
+// a name (resource / span / intrinsic) and the keys belonging to it.
+type TagNamesResponseV2 struct {
+	Scopes []TagNamesScope `json:"scopes"`
+}
+
+// TagNamesScope is one V2 scope entry.
+type TagNamesScope struct {
+	Name string   `json:"name"`
+	Tags []string `json:"tags"`
+}
+
+// TagValuesResponseV1 mirrors `/api/search/tag/{name}/values`.
+type TagValuesResponseV1 struct {
+	TagValues []string `json:"tagValues"`
+}
+
+// TagValuesResponseV2 mirrors `/api/v2/search/tag/{name}/values`. Each
+// entry is a typed object so the autocomplete UI can render the type
+// suffix on dynamic attributes.
+type TagValuesResponseV2 struct {
+	TagValues []TagValueV2 `json:"tagValues"`
+}
+
+// TagValueV2 is one typed value entry.
+type TagValueV2 struct {
+	Type  string `json:"type"`
+	Value string `json:"value"`
+}
+
+// decodeTagNames parses a tags response and returns the flattened set of
+// tag names plus (for v2) the list of scope names that appeared. The
+// flatten-then-set approach lets CompareTagNames lean on the same path
+// for V1 and V2; the V2 scope partition is reported separately via the
+// scopeNames return so the differ can surface scope-set mismatches.
+func decodeTagNames(body []byte, v2 bool) (tagNames, scopeNames []string, err error) {
+	if v2 {
+		var out TagNamesResponseV2
+		if err := json.Unmarshal(body, &out); err != nil {
+			return nil, nil, fmt.Errorf("decode /api/v2/search/tags response: %w", err)
+		}
+		seen := map[string]struct{}{}
+		for _, sc := range out.Scopes {
+			scopeNames = append(scopeNames, sc.Name)
+			for _, t := range sc.Tags {
+				if _, dup := seen[t]; dup {
+					continue
+				}
+				seen[t] = struct{}{}
+				tagNames = append(tagNames, t)
+			}
+		}
+		sort.Strings(tagNames)
+		sort.Strings(scopeNames)
+		return tagNames, scopeNames, nil
+	}
+	var out TagNamesResponseV1
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, nil, fmt.Errorf("decode /api/search/tags response: %w", err)
+	}
+	tagNames = append(tagNames, out.TagNames...)
+	sort.Strings(tagNames)
+	return tagNames, nil, nil
+}
+
+// decodeTagValues parses a tag-values response and returns the flat
+// list of values plus (for v2) the per-value Type strings keyed by
+// value. The byValueType map lets CompareTagValues report mismatched
+// type annotations on the intersection without false-positing when one
+// side omits the V2 envelope.
+func decodeTagValues(body []byte, v2 bool) (values []string, byValueType map[string]string, err error) {
+	if v2 {
+		var out TagValuesResponseV2
+		if err := json.Unmarshal(body, &out); err != nil {
+			return nil, nil, fmt.Errorf("decode /api/v2/search/tag/{name}/values response: %w", err)
+		}
+		byValueType = make(map[string]string, len(out.TagValues))
+		for _, tv := range out.TagValues {
+			values = append(values, tv.Value)
+			byValueType[tv.Value] = tv.Type
+		}
+		sort.Strings(values)
+		return values, byValueType, nil
+	}
+	var out TagValuesResponseV1
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, nil, fmt.Errorf("decode /api/search/tag/{name}/values response: %w", err)
+	}
+	values = append(values, out.TagValues...)
+	sort.Strings(values)
+	return values, nil, nil
+}
+
+// CompareTagNames diffs two tags-endpoint response bodies. The diff is
+// a set-difference on the flattened tag-name set: a key present on one
+// side and missing on the other is reported as missing_in_a /
+// missing_in_b. For tags_v2 the per-scope set is also diffed so a
+// missing or extra scope name surfaces as a `scope_mismatch` reason.
+func CompareTagNames(aBody, bBody []byte, aLabel, bLabel string, v2 bool) (Diff, error) {
+	aNames, aScopes, err := decodeTagNames(aBody, v2)
+	if err != nil {
+		return Diff{}, fmt.Errorf("%s: %w", aLabel, err)
+	}
+	bNames, bScopes, err := decodeTagNames(bBody, v2)
+	if err != nil {
+		return Diff{}, fmt.Errorf("%s: %w", bLabel, err)
+	}
+
+	out := Diff{Equal: true}
+
+	if len(aNames) != len(bNames) {
+		out.Equal = false
+		out.Reasons = append(out.Reasons, DiffReason{
+			Kind:   "cardinality",
+			Detail: fmt.Sprintf("%s=%d tag names, %s=%d tag names", aLabel, len(aNames), bLabel, len(bNames)),
+		})
+	}
+
+	addSetDiff(&out, aNames, bNames, aLabel, bLabel)
+	out.MatchedCount = countIntersection(aNames, bNames)
+
+	if v2 {
+		// Scope-set differences ride on top of the tag-name diff because
+		// they describe a different axis (cerberus today returns the same
+		// scope set regardless of ?scope=, real Tempo filters). Reporting
+		// the scope axis explicitly keeps the markdown report actionable.
+		addScopeDiff(&out, aScopes, bScopes, aLabel, bLabel)
+	}
+
+	return out, nil
+}
+
+// CompareTagValues diffs two tag-values-endpoint response bodies. The
+// diff is a set-difference on the value list. For tag_values_v2 the
+// per-value `Type` field is also compared on the intersection — a
+// disagreement there is reported as `field_mismatch`.
+func CompareTagValues(aBody, bBody []byte, aLabel, bLabel string, v2 bool) (Diff, error) {
+	aValues, aTypes, err := decodeTagValues(aBody, v2)
+	if err != nil {
+		return Diff{}, fmt.Errorf("%s: %w", aLabel, err)
+	}
+	bValues, bTypes, err := decodeTagValues(bBody, v2)
+	if err != nil {
+		return Diff{}, fmt.Errorf("%s: %w", bLabel, err)
+	}
+
+	out := Diff{Equal: true}
+
+	if len(aValues) != len(bValues) {
+		out.Equal = false
+		out.Reasons = append(out.Reasons, DiffReason{
+			Kind:   "cardinality",
+			Detail: fmt.Sprintf("%s=%d tag values, %s=%d tag values", aLabel, len(aValues), bLabel, len(bValues)),
+		})
+	}
+
+	addSetDiff(&out, aValues, bValues, aLabel, bLabel)
+	out.MatchedCount = countIntersection(aValues, bValues)
+
+	if v2 && len(aTypes) > 0 && len(bTypes) > 0 {
+		// Walk the intersection in deterministic order so the report is
+		// reproducible; only report a type mismatch when both sides
+		// populated the field (mirrors the trace differ's "skip blanks"
+		// rule).
+		intersection := intersect(aValues, bValues)
+		for _, v := range intersection {
+			at := aTypes[v]
+			bt := bTypes[v]
+			if at != "" && bt != "" && at != bt {
+				out.Equal = false
+				out.Reasons = append(out.Reasons, DiffReason{
+					Kind:   "field_mismatch",
+					Detail: fmt.Sprintf("value %q: type %s=%q vs %s=%q", v, aLabel, at, bLabel, bt),
+				})
+			}
+		}
+	}
+
+	return out, nil
+}
+
+// addSetDiff appends missing_in_a / missing_in_b reasons for the
+// symmetric difference of a + b. Order is deterministic so the report
+// is reproducible across runs.
+func addSetDiff(out *Diff, a, b []string, aLabel, bLabel string) {
+	aSet := stringSet(a)
+	bSet := stringSet(b)
+	var missingInA, missingInB []string
+	for s := range bSet {
+		if !aSet[s] {
+			missingInA = append(missingInA, s)
+		}
+	}
+	for s := range aSet {
+		if !bSet[s] {
+			missingInB = append(missingInB, s)
+		}
+	}
+	sort.Strings(missingInA)
+	sort.Strings(missingInB)
+	for _, s := range missingInA {
+		out.Equal = false
+		out.Reasons = append(out.Reasons, DiffReason{
+			Kind:   "missing_in_a",
+			Detail: fmt.Sprintf("%q present in %s but missing in %s", s, bLabel, aLabel),
+		})
+	}
+	for _, s := range missingInB {
+		out.Equal = false
+		out.Reasons = append(out.Reasons, DiffReason{
+			Kind:   "missing_in_b",
+			Detail: fmt.Sprintf("%q present in %s but missing in %s", s, aLabel, bLabel),
+		})
+	}
+}
+
+// addScopeDiff is the V2-tags-specific scope-set diff. Reasons get a
+// `scope_mismatch` kind so the report distinguishes them from the
+// tag-name set diff.
+func addScopeDiff(out *Diff, a, b []string, aLabel, bLabel string) {
+	aSet := stringSet(a)
+	bSet := stringSet(b)
+	var missingInA, missingInB []string
+	for s := range bSet {
+		if !aSet[s] {
+			missingInA = append(missingInA, s)
+		}
+	}
+	for s := range aSet {
+		if !bSet[s] {
+			missingInB = append(missingInB, s)
+		}
+	}
+	sort.Strings(missingInA)
+	sort.Strings(missingInB)
+	for _, s := range missingInA {
+		out.Equal = false
+		out.Reasons = append(out.Reasons, DiffReason{
+			Kind:   "scope_mismatch",
+			Detail: fmt.Sprintf("scope %q present in %s but missing in %s", s, bLabel, aLabel),
+		})
+	}
+	for _, s := range missingInB {
+		out.Equal = false
+		out.Reasons = append(out.Reasons, DiffReason{
+			Kind:   "scope_mismatch",
+			Detail: fmt.Sprintf("scope %q present in %s but missing in %s", s, aLabel, bLabel),
+		})
+	}
+}
+
+// countIntersection counts the size of the set intersection of a + b.
+// O(|a| + |b|); duplicates inside one side count once.
+func countIntersection(a, b []string) int {
+	aSet := stringSet(a)
+	n := 0
+	seen := map[string]bool{}
+	for _, s := range b {
+		if seen[s] {
+			continue
+		}
+		seen[s] = true
+		if aSet[s] {
+			n++
+		}
+	}
+	return n
+}
+
+// intersect returns the lexicographically sorted intersection of two
+// string slices. Used by CompareTagValues to walk matched values in a
+// reproducible order.
+func intersect(a, b []string) []string {
+	aSet := stringSet(a)
+	out := make([]string, 0, len(b))
+	seen := map[string]bool{}
+	for _, s := range b {
+		if seen[s] {
+			continue
+		}
+		seen[s] = true
+		if aSet[s] {
+			out = append(out, s)
+		}
+	}
+	sort.Strings(out)
+	return out
 }
 
 // canonicalizeJSON re-marshals a JSON blob with sorted object keys so

--- a/harness/tempo-compatibility/driver/differ_test.go
+++ b/harness/tempo-compatibility/driver/differ_test.go
@@ -227,6 +227,269 @@ func TestCanonicalizeJSON_StableKeyOrder(t *testing.T) {
 	}
 }
 
+func TestCompareTagNames_V1Identical(t *testing.T) {
+	t.Parallel()
+	a := []byte(`{"tagNames":["a","b","c"]}`)
+	b := []byte(`{"tagNames":["c","b","a"]}`) // different order
+	d, err := CompareTagNames(a, b, "tempo", "cerberus", false)
+	if err != nil {
+		t.Fatalf("CompareTagNames: %v", err)
+	}
+	if !d.Equal {
+		t.Fatalf("expected Equal on identical sets, got %+v", d)
+	}
+	if d.MatchedCount != 3 {
+		t.Fatalf("MatchedCount = %d, want 3", d.MatchedCount)
+	}
+}
+
+func TestCompareTagNames_V1MissingInB(t *testing.T) {
+	t.Parallel()
+	a := []byte(`{"tagNames":["a","b","c"]}`)
+	b := []byte(`{"tagNames":["a","b"]}`)
+	d, err := CompareTagNames(a, b, "tempo", "cerberus", false)
+	if err != nil {
+		t.Fatalf("CompareTagNames: %v", err)
+	}
+	if d.Equal {
+		t.Fatal("expected Equal=false on differing sets")
+	}
+	foundMissing := false
+	foundCard := false
+	for _, r := range d.Reasons {
+		if r.Kind == "missing_in_b" && strings.Contains(r.Detail, `"c"`) {
+			foundMissing = true
+		}
+		if r.Kind == "cardinality" {
+			foundCard = true
+		}
+	}
+	if !foundMissing {
+		t.Errorf("expected missing_in_b reason for 'c', got %+v", d.Reasons)
+	}
+	if !foundCard {
+		t.Errorf("expected cardinality reason, got %+v", d.Reasons)
+	}
+}
+
+func TestCompareTagNames_V2FlattensScopes(t *testing.T) {
+	t.Parallel()
+	a := []byte(`{"scopes":[
+        {"name":"resource","tags":["service.name"]},
+        {"name":"span","tags":["http.method"]},
+        {"name":"intrinsic","tags":["name","kind"]}
+    ]}`)
+	b := []byte(`{"scopes":[
+        {"name":"resource","tags":["service.name"]},
+        {"name":"span","tags":["http.method"]},
+        {"name":"intrinsic","tags":["name","kind"]}
+    ]}`)
+	d, err := CompareTagNames(a, b, "tempo", "cerberus", true)
+	if err != nil {
+		t.Fatalf("CompareTagNames: %v", err)
+	}
+	if !d.Equal {
+		t.Fatalf("expected Equal, got %+v", d)
+	}
+}
+
+func TestCompareTagNames_V2ScopeMismatchSurfaces(t *testing.T) {
+	t.Parallel()
+	// Same tag-names, different scope partition — only happens when the
+	// `?scope=` filter is honoured on one side but not the other. The
+	// differ reports a scope_mismatch reason in addition to the (zero)
+	// tag-name set diff.
+	a := []byte(`{"scopes":[
+        {"name":"resource","tags":["service.name"]}
+    ]}`)
+	b := []byte(`{"scopes":[
+        {"name":"resource","tags":["service.name"]},
+        {"name":"span","tags":[]},
+        {"name":"intrinsic","tags":[]}
+    ]}`)
+	d, err := CompareTagNames(a, b, "tempo", "cerberus", true)
+	if err != nil {
+		t.Fatalf("CompareTagNames: %v", err)
+	}
+	if d.Equal {
+		t.Fatal("expected Equal=false on differing scope partition")
+	}
+	foundScope := false
+	for _, r := range d.Reasons {
+		if r.Kind == "scope_mismatch" {
+			foundScope = true
+		}
+	}
+	if !foundScope {
+		t.Fatalf("expected scope_mismatch reason, got %+v", d.Reasons)
+	}
+}
+
+func TestCompareTagValues_V1SetDiff(t *testing.T) {
+	t.Parallel()
+	a := []byte(`{"tagValues":["checkout","payments","search","shipping"]}`)
+	b := []byte(`{"tagValues":["checkout","payments"]}`)
+	d, err := CompareTagValues(a, b, "tempo", "cerberus", false)
+	if err != nil {
+		t.Fatalf("CompareTagValues: %v", err)
+	}
+	if d.Equal {
+		t.Fatal("expected Equal=false on differing sets")
+	}
+	count := 0
+	for _, r := range d.Reasons {
+		if r.Kind == "missing_in_b" {
+			count++
+		}
+	}
+	if count != 2 {
+		t.Fatalf("expected 2 missing_in_b reasons, got %d (%+v)", count, d.Reasons)
+	}
+}
+
+func TestCompareTagValues_V2TypeMismatchFlagged(t *testing.T) {
+	t.Parallel()
+	a := []byte(`{"tagValues":[{"type":"string","value":"checkout"}]}`)
+	b := []byte(`{"tagValues":[{"type":"int","value":"checkout"}]}`)
+	d, err := CompareTagValues(a, b, "tempo", "cerberus", true)
+	if err != nil {
+		t.Fatalf("CompareTagValues: %v", err)
+	}
+	if d.Equal {
+		t.Fatal("expected Equal=false on type mismatch")
+	}
+	found := false
+	for _, r := range d.Reasons {
+		if r.Kind == "field_mismatch" && strings.Contains(r.Detail, "type") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected type field_mismatch, got %+v", d.Reasons)
+	}
+}
+
+func TestCompareTagValues_V2EmptyBothSides(t *testing.T) {
+	t.Parallel()
+	a := []byte(`{"tagValues":[]}`)
+	b := []byte(`{"tagValues":[]}`)
+	d, err := CompareTagValues(a, b, "tempo", "cerberus", true)
+	if err != nil {
+		t.Fatalf("CompareTagValues: %v", err)
+	}
+	if !d.Equal {
+		t.Fatalf("expected Equal on empty both sides, got %+v", d)
+	}
+}
+
+func TestAssertCase_TagsV2ExpectedValuesAndScopes(t *testing.T) {
+	t.Parallel()
+	tc := CorpusCase{
+		Name:           "x",
+		Endpoint:       "tags_v2",
+		ExpectedValues: []string{"service.name"},
+		ExpectedScopes: []string{"resource"},
+	}
+	body := []byte(`{"scopes":[
+        {"name":"resource","tags":["service.name"]}
+    ]}`)
+	reasons, err := AssertCase(tc, body, "tempo")
+	if err != nil {
+		t.Fatalf("AssertCase: %v", err)
+	}
+	if len(reasons) != 0 {
+		t.Fatalf("expected no reasons, got %+v", reasons)
+	}
+}
+
+func TestAssertCase_TagsV2MissingExpectedScope(t *testing.T) {
+	t.Parallel()
+	tc := CorpusCase{
+		Name:           "x",
+		Endpoint:       "tags_v2",
+		ExpectedScopes: []string{"resource"},
+	}
+	body := []byte(`{"scopes":[
+        {"name":"span","tags":[]}
+    ]}`)
+	reasons, err := AssertCase(tc, body, "cerberus")
+	if err != nil {
+		t.Fatalf("AssertCase: %v", err)
+	}
+	found := false
+	for _, r := range reasons {
+		if strings.Contains(r.Detail, `expected scope "resource"`) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected scope-missing reason, got %+v", reasons)
+	}
+}
+
+func TestAssertCase_TagValuesMinValues(t *testing.T) {
+	t.Parallel()
+	tc := CorpusCase{
+		Name:              "x",
+		Endpoint:          "tag_values_v1",
+		TagName:           "service.name",
+		ExpectedMinValues: 3,
+	}
+	body := []byte(`{"tagValues":["checkout","payments"]}`)
+	reasons, err := AssertCase(tc, body, "tempo")
+	if err != nil {
+		t.Fatalf("AssertCase: %v", err)
+	}
+	if len(reasons) == 0 || !strings.Contains(reasons[0].Detail, "want >= 3") {
+		t.Fatalf("expected min-values reason, got %+v", reasons)
+	}
+}
+
+func TestAssertCase_TagValuesMaxValues(t *testing.T) {
+	t.Parallel()
+	tc := CorpusCase{
+		Name:              "x",
+		Endpoint:          "tag_values_v2",
+		TagName:           "service.name",
+		ExpectedMaxValues: 1,
+	}
+	body := []byte(`{"tagValues":[
+        {"type":"string","value":"checkout"},
+        {"type":"string","value":"payments"}
+    ]}`)
+	reasons, err := AssertCase(tc, body, "tempo")
+	if err != nil {
+		t.Fatalf("AssertCase: %v", err)
+	}
+	if len(reasons) == 0 || !strings.Contains(reasons[0].Detail, "want <= 1") {
+		t.Fatalf("expected max-values reason, got %+v", reasons)
+	}
+}
+
+func TestAssertCase_TagValuesExpectedValuesMissing(t *testing.T) {
+	t.Parallel()
+	tc := CorpusCase{
+		Name:           "x",
+		Endpoint:       "tag_values_v1",
+		TagName:        "service.name",
+		ExpectedValues: []string{"checkout", "shipping"},
+	}
+	body := []byte(`{"tagValues":["checkout","payments"]}`)
+	reasons, err := AssertCase(tc, body, "tempo")
+	if err != nil {
+		t.Fatalf("AssertCase: %v", err)
+	}
+	found := false
+	for _, r := range reasons {
+		if strings.Contains(r.Detail, `"shipping"`) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected reason flagging shipping, got %+v", reasons)
+	}
+}
+
 func TestRenderReport_Roundtrip(t *testing.T) {
 	t.Parallel()
 	results := []CaseResult{


### PR DESCRIPTION
## Summary

PR 6 of [docs/tempo-compliance-plan.md](../blob/main/docs/tempo-compliance-plan.md#per-pr-breakdown) — extends the tempo compatibility TXTAR corpus + differ to cover the four tag / tag-values endpoints (V1 + V2 wire shapes). Stacked on #395 (corpus infra), which is merged.

- **Corpus**: four new endpoint kinds (`tags_v1`, `tags_v2`, `tag_values_v1`, `tag_values_v2`) and the supporting sections (`-- tag_name --`, `-- scope --`, `-- expected_min_values --`, `-- expected_max_values --`, `-- expected_values --`, `-- expected_scopes --`).
- **Differ**: `CompareTagNames` (V1 flat set + V2 scope-flattened set, with a separate `scope_mismatch` axis) and `CompareTagValues` (V1 flat list + V2 typed envelope, with `field_mismatch` on intersection type drift).
- **Smoke corpus**: 8 new cases — `tags_v1_all`, `tags_v2_resource`/`_span`/`_intrinsic`, `tag_values_v1_service_name`, `tag_values_v2_service_name`/`_deployment_env`, and an empty-result edge case `tag_values_v2_unknown_tag_empty`.
- **README**: new `Corpus categories` table mapping each endpoint kind to its wire shape + diff strategy.

### Endpoint coverage delta

| Endpoint                                  | Before PR 6 | After PR 6 |
| ----------------------------------------- | ----------- | ---------- |
| `GET /api/search/tags`                    | -           | tags_v1 (1 case) |
| `GET /api/v2/search/tags?scope=...`       | -           | tags_v2 (3 cases: resource / span / intrinsic) |
| `GET /api/search/tag/{n}/values`          | -           | tag_values_v1 (1 case) |
| `GET /api/v2/search/tag/{n}/values`       | -           | tag_values_v2 (3 cases incl. empty-result edge) |

### Expected informational diff

Cerberus's `/api/v2/search/tags` handler currently ignores the `?scope=` filter and always returns all three scopes (see `internal/api/tempo/search_tags.go::handleSearchTagsV2`). PR 6's `tags_v2_resource` / `_span` / `_intrinsic` cases will surface that gap as a `scope_mismatch` reason in the nightly markdown report. The workflow stays informational (`continue-on-error: true`) until PR 7 promotes it to a required check.

## Test plan

- [ ] CI `check` job builds the driver + runs the new unit tests under `harness/tempo-compatibility/driver/`.
- [ ] CI `lint` job is green.
- [ ] `tempo-compatibility` nightly run picks up the new cases (informational; reports `scope_mismatch` on the `?scope=` axis as expected — see Expected informational diff above).