### PR TITLE
feat(harness/tempo-compatibility): metrics endpoints + semantic consistency

### DIFF
--- a/harness/tempo-compatibility/driver/corpus.go
+++ b/harness/tempo-compatibility/driver/corpus.go
@@ -1,6 +1,7 @@
 // Corpus loader for the Tempo / TraceQL compatibility differ
-// (PR 4 of docs/tempo-compliance-plan.md; extended in PR 6 to cover
-// the four tag / tag-values endpoints).
+// (PR 4 of docs/tempo-compliance-plan.md; extended in PR 5 to cover the
+// metrics endpoints and in PR 6 to cover the four tag / tag-values
+// endpoints).
 //
 // The format is a lightweight TXTAR variant — same shape as
 // harness/prometheus-compliance/shadow/corpus.go — so the parser
@@ -8,10 +9,12 @@
 // non-header line as section body. The supported sections:
 //
 //	-- name --                  short identifier, used in the report
-//	-- query --                 the TraceQL expression (search endpoints)
+//	-- query --                 the TraceQL expression (search / metrics
+//	                            endpoints)
 //	-- endpoint --              one of: search | search_recent | traces |
 //	                            tags_v1 | tags_v2 | tag_values_v1 |
-//	                            tag_values_v2
+//	                            tag_values_v2 | metrics_range |
+//	                            metrics_instant
 //	-- traceid_template --      a template like "{svc}/{idx}" (only for `traces`)
 //	-- tag_name --              attribute key whose values to enumerate
 //	                            (tag_values_v1 / tag_values_v2 only)
@@ -19,6 +22,7 @@
 //	                            resource | span | intrinsic | none); empty
 //	                            omits the parameter so both backends return
 //	                            the unfiltered scope set
+//	-- step --                  step duration (e.g. "60s") — only for metrics_range
 //	-- expected_min_traces --   integer; minimum traces both sides must return
 //	-- expected_max_traces --   integer; maximum traces either side may return
 //	-- expected_min_values --   integer; minimum list cardinality for tag /
@@ -34,8 +38,17 @@
 //	                            that should appear in `rootServiceName`
 //	-- expected_root_name_re -- Go regexp; every returned trace's rootTraceName
 //	                            must match
+//	-- expected_min_series --   integer; minimum metrics series both sides must
+//	                            return (metrics endpoints only)
+//	-- expected_max_series --   integer; maximum metrics series either side may
+//	                            return (metrics endpoints only)
+//	-- expected_samples_per_series --   integer; minimum samples per series
+//	                            (metrics endpoints only)
+//	-- semantic_checks --       newline-separated list of semantic-consistency
+//	                            check names; each check runs per-backend against
+//	                            the parsed response (see differ.go::SemanticChecks
+//	                            for the registered names)
 //	-- skip_reason --           if non-empty, the case is parsed but skipped
-//	                            (e.g. `metrics endpoint — lands in PR 5`)
 //
 // Cases are separated by the next `-- name --` header. Lines starting
 // with `#` outside section bodies are comments. Inside a section body,
@@ -81,13 +94,15 @@ type CorpusCase struct {
 
 	// Endpoint selects the HTTP path the differ hits:
 	//
-	//   * search          GET /api/search?q=<TraceQL>
-	//   * search_recent   GET /api/search/recent (TraceQL ignored)
-	//   * traces          GET /api/traces/<id>   (TraceIDTemplate populated)
-	//   * tags_v1         GET /api/search/tags
-	//   * tags_v2         GET /api/v2/search/tags[?scope=<Scope>]
-	//   * tag_values_v1   GET /api/search/tag/{TagName}/values
-	//   * tag_values_v2   GET /api/v2/search/tag/{TagName}/values
+	//   * search           GET /api/search?q=<TraceQL>
+	//   * search_recent    GET /api/search/recent (TraceQL ignored)
+	//   * traces           GET /api/traces/<id>   (TraceIDTemplate populated)
+	//   * tags_v1          GET /api/search/tags
+	//   * tags_v2          GET /api/v2/search/tags[?scope=<Scope>]
+	//   * tag_values_v1    GET /api/search/tag/{TagName}/values
+	//   * tag_values_v2    GET /api/v2/search/tag/{TagName}/values
+	//   * metrics_range    GET /api/metrics/query_range (Step populated)
+	//   * metrics_instant  GET /api/metrics/query
 	//
 	// The seeder pushes data with deterministic trace IDs derived from
 	// (service, traceIdx); see TraceIDTemplate below for the format.
@@ -110,10 +125,16 @@ type CorpusCase struct {
 	// parameter off the URL (Tempo defaults to returning every scope).
 	Scope string
 
+	// Step is only consulted when Endpoint == "metrics_range". The string
+	// is sent verbatim as the URL's `step` parameter (Tempo accepts
+	// "60s", "1m", or plain seconds). An empty Step on a metrics_range
+	// case is a validation error.
+	Step string
+
 	// SkipReason, when non-empty, makes the case parse but skip during
-	// diffing. Used to declare PR-5-shaped cases (metrics endpoints)
-	// in the smoke corpus so the file stays the single source of truth
-	// for the eventual full corpus while keeping PR 4's CI green.
+	// diffing. Used to declare future-shaped cases in the smoke corpus so
+	// the file stays the single source of truth for the eventual full
+	// corpus while keeping CI green.
 	SkipReason string
 
 	// ExpectedMinTraces / ExpectedMaxTraces bound the cardinality both
@@ -144,6 +165,29 @@ type CorpusCase struct {
 	// trace's rootTraceName must match. Compiled at parse time so the
 	// differ runs without per-case regex cost.
 	ExpectedRootNameRE *regexp.Regexp
+
+	// ExpectedMinSeries / ExpectedMaxSeries bound the per-backend metrics
+	// cardinality. Zero (the default) disables the bound. Applies to
+	// metrics_range + metrics_instant endpoints only.
+	ExpectedMinSeries int
+	ExpectedMaxSeries int
+
+	// ExpectedSamplesPerSeries is the minimum samples per series for
+	// metrics_range cases. Zero disables the assertion. (Instant
+	// responses don't carry a samples array — they have a single value
+	// per series — so this is ignored for metrics_instant.)
+	ExpectedSamplesPerSeries int
+
+	// SemanticChecks is the list of per-backend semantic-consistency
+	// check names. Each name is looked up in differ.go::SemanticChecks
+	// at run time; an unknown name surfaces as an assertion reason so
+	// a corpus author who mistypes a check learns from the report rather
+	// than silently passing.
+	//
+	// A check may carry a colon-separated argument, e.g.
+	// "groupby_labels_present:resource.service.name" — the parser stores
+	// the raw "name:arg" string and the check function splits.
+	SemanticChecks []string
 }
 
 // LoadCorpus opens a corpus file and parses it into CorpusCases.
@@ -162,21 +206,26 @@ func LoadCorpus(path string) ([]CorpusCase, error) {
 // constants so the parser + the header-validation helpers share a single
 // source of truth and so unit tests can name them directly.
 const (
-	secName            = "name"
-	secQuery           = "query"
-	secEndpoint        = "endpoint"
-	secTraceIDTemplate = "traceid_template"
-	secTagName         = "tag_name"
-	secScope           = "scope"
-	secSkipReason      = "skip_reason"
-	secMinTraces       = "expected_min_traces"
-	secMaxTraces       = "expected_max_traces"
-	secMinValues       = "expected_min_values"
-	secMaxValues       = "expected_max_values"
-	secValues          = "expected_values"
-	secScopes          = "expected_scopes"
-	secServices        = "expected_services"
-	secRootNameRE      = "expected_root_name_re"
+	secName             = "name"
+	secQuery            = "query"
+	secEndpoint         = "endpoint"
+	secTraceIDTemplate  = "traceid_template"
+	secTagName          = "tag_name"
+	secScope            = "scope"
+	secStep             = "step"
+	secSkipReason       = "skip_reason"
+	secMinTraces        = "expected_min_traces"
+	secMaxTraces        = "expected_max_traces"
+	secMinValues        = "expected_min_values"
+	secMaxValues        = "expected_max_values"
+	secValues           = "expected_values"
+	secScopes           = "expected_scopes"
+	secServices         = "expected_services"
+	secRootNameRE       = "expected_root_name_re"
+	secMinSeries        = "expected_min_series"
+	secMaxSeries        = "expected_max_series"
+	secSamplesPerSeries = "expected_samples_per_series"
+	secSemanticChecks   = "semantic_checks"
 )
 
 // stripCommentLines returns the body with comment-only lines (`# ...`
@@ -215,6 +264,8 @@ func applySection(cur *CorpusCase, section, body string) error {
 		cur.TagName = body
 	case secScope:
 		cur.Scope = body
+	case secStep:
+		cur.Step = body
 	case secSkipReason:
 		cur.SkipReason = body
 	case secMinTraces:
@@ -240,6 +291,14 @@ func applySection(cur *CorpusCase, section, body string) error {
 			return fmt.Errorf("expected_root_name_re: compile %q: %w", body, err)
 		}
 		cur.ExpectedRootNameRE = re
+	case secMinSeries:
+		return applyIntSection(body, "expected_min_series", &cur.ExpectedMinSeries)
+	case secMaxSeries:
+		return applyIntSection(body, "expected_max_series", &cur.ExpectedMaxSeries)
+	case secSamplesPerSeries:
+		return applyIntSection(body, "expected_samples_per_series", &cur.ExpectedSamplesPerSeries)
+	case secSemanticChecks:
+		appendNonEmptyLines(body, &cur.SemanticChecks)
 	}
 	return nil
 }
@@ -247,7 +306,8 @@ func applySection(cur *CorpusCase, section, body string) error {
 // appendNonEmptyLines splits `body` on newlines and appends every
 // trimmed non-empty line to `*dst`. Pulled out so the multi-line
 // subset assertions (expected_services / expected_values /
-// expected_scopes) share one parse path instead of three near-duplicates.
+// expected_scopes / semantic_checks) share one parse path instead of
+// four near-duplicates.
 func appendNonEmptyLines(body string, dst *[]string) {
 	if body == "" {
 		return
@@ -285,9 +345,10 @@ func validateCase(cur CorpusCase, ord int) (CorpusCase, error) {
 	}
 	switch cur.Endpoint {
 	case "search", "search_recent", "traces",
-		"tags_v1", "tags_v2", "tag_values_v1", "tag_values_v2":
+		"tags_v1", "tags_v2", "tag_values_v1", "tag_values_v2",
+		"metrics_range", "metrics_instant":
 	default:
-		return cur, fmt.Errorf("case %q: unknown endpoint %q (want search | search_recent | traces | tags_v1 | tags_v2 | tag_values_v1 | tag_values_v2)", cur.Name, cur.Endpoint)
+		return cur, fmt.Errorf("case %q: unknown endpoint %q (want search | search_recent | traces | tags_v1 | tags_v2 | tag_values_v1 | tag_values_v2 | metrics_range | metrics_instant)", cur.Name, cur.Endpoint)
 	}
 	if cur.Endpoint == "traces" && cur.TraceIDTemplate == "" {
 		return cur, fmt.Errorf("case %q: endpoint=traces requires -- traceid_template --", cur.Name)
@@ -297,6 +358,9 @@ func validateCase(cur CorpusCase, ord int) (CorpusCase, error) {
 	}
 	if cur.Scope != "" && cur.Endpoint != "tags_v2" {
 		return cur, fmt.Errorf("case %q: -- scope -- is only valid for endpoint=tags_v2 (got %s)", cur.Name, cur.Endpoint)
+	}
+	if cur.Endpoint == "metrics_range" && cur.Step == "" && cur.SkipReason == "" {
+		return cur, fmt.Errorf("case %q: endpoint=metrics_range requires -- step -- (e.g. \"60s\")", cur.Name)
 	}
 	return cur, nil
 }
@@ -317,9 +381,10 @@ func isTagEndpoint(ep string) bool {
 func isKnownSection(name string) bool {
 	switch name {
 	case secQuery, secEndpoint, secTraceIDTemplate, secTagName, secScope,
-		secSkipReason,
+		secStep, secSkipReason,
 		secMinTraces, secMaxTraces, secMinValues, secMaxValues,
-		secValues, secScopes, secServices, secRootNameRE:
+		secValues, secScopes, secServices, secRootNameRE,
+		secMinSeries, secMaxSeries, secSamplesPerSeries, secSemanticChecks:
 		return true
 	}
 	return false

--- a/harness/tempo-compatibility/driver/corpus/smoke.txtar
+++ b/harness/tempo-compatibility/driver/corpus/smoke.txtar
@@ -1,8 +1,11 @@
-# Tempo / TraceQL compatibility smoke corpus (PR 4).
+# Tempo / TraceQL compatibility smoke corpus.
 #
-# Lifted-and-adapted from harness/prometheus-compliance/shadow/
-# traceql_shadow_test.go::traceqlInstantCases() (~20 hand-translated
-# cases). The shadow test runs the SAME 20 categories against a fake
+# PR 4 lifted-and-adapted the cases from harness/prometheus-compliance/
+# shadow/traceql_shadow_test.go::traceqlInstantCases(). PR 5 extends the
+# corpus with /api/metrics/query_range + /api/metrics/query cases and
+# adds the semantic-consistency layer (see differ.go::SemanticConsistency).
+#
+# The shadow test runs the SAME 20 search categories against a fake
 # in-process span set; this corpus runs the SAME categories against
 # real Tempo + real cerberus, fed by harness/.../driver/seeder.go's
 # deterministic OTLP push.
@@ -27,11 +30,16 @@
 #   * Numeric fields compare under 1e-9 relative epsilon.
 #   * Cardinality is reported as a reason but every key-level miss is
 #     also surfaced under missing_in_a / missing_in_b.
+#   * Metrics-endpoint cases canonicalise series by label-set hash; the
+#     differ also runs semantic-consistency assertions per backend
+#     (avg ≡ sum/count, exemplars belong to their parent series).
 #
-# Cases below cover the 7 shadow categories: attribute matchers per
+# Cases below cover the 7 shadow categories (attribute matchers per
 # scope (5), intrinsics (4), structural ops (4), set ops (3), inner
-# aggregates (2), and metrics pipeline (2). PR 5 will flip the metrics
-# pipeline cases from `skip_reason` to active.
+# aggregates (2)) plus 6 metrics-pipeline cases (3 range + 3 instant)
+# and a per-id smoke. Total: 25 cases, of which 4 carry `skip_reason`
+# (the three instant ones — pending cerberus /api/metrics/query —
+# plus the per-id smoke when the seeder fixture is absent).
 
 # --- Attribute matchers per scope (5) ---
 
@@ -250,29 +258,107 @@ search
 -- expected_max_traces --
 500
 
-# --- MetricsPipeline (2) — DEFERRED to PR 5 ---
-# These are wire-shape-different from /api/search (they hit
-# /api/metrics/query_range and return Prom-shape series). Listed here
-# so the smoke set documents the eventual full coverage map; the
-# differ skips them by checking SkipReason.
+# --- Metrics pipeline: /api/metrics/query_range (3) ---
+# These hit cerberus's /api/metrics/query_range (implemented today —
+# see internal/api/tempo/metrics_query_range.go) and Tempo's native
+# /api/metrics/query_range. The wire shape is `{series:[{labels,
+# samples}]}`; the differ canonicalises series by label-set hash and
+# diffs samples under 1e-9 relative epsilon.
+#
+# The `step=60s` window is generous: the fixture spans only ~400s
+# after the anchor, so 60s buckets give us 7 anchors across the
+# query window. The semantic-consistency checks (see SemanticChecks)
+# run alongside the structural diff.
 
 -- name --
-metrics_rate_over_status_error
+metrics_rate_no_groupby
 -- query --
-{ status = error } | rate()
+{ } | rate()
 -- endpoint --
-search
--- skip_reason --
-metrics endpoint — lands in PR 5 (docs/tempo-compliance-plan.md)
+metrics_range
+-- step --
+60s
+-- expected_min_series --
+1
+-- expected_max_series --
+50
+-- expected_samples_per_series --
+1
+-- semantic_checks --
+samples_non_negative
+labels_match_query
 
 -- name --
-metrics_quantile_p95_duration
+metrics_count_over_time_groupby_service
 -- query --
-{ duration > 0 } | quantile_over_time(duration, .95)
+{ } | count_over_time() by (resource.service.name)
 -- endpoint --
-search
+metrics_range
+-- step --
+60s
+-- expected_min_series --
+1
+-- expected_max_series --
+50
+-- semantic_checks --
+samples_non_negative
+groupby_labels_present:resource.service.name
+
+-- name --
+metrics_quantile_over_time_p95
+-- query --
+{ } | quantile_over_time(duration, 0.95)
+-- endpoint --
+metrics_range
+-- step --
+60s
+-- expected_min_series --
+1
+-- expected_max_series --
+50
+-- semantic_checks --
+samples_non_negative
+
+# --- Metrics pipeline: /api/metrics/query (instant — 3) ---
+# Instant variant of the range queries above. Cerberus does not yet
+# implement /api/metrics/query (see internal/api/tempo/handler.go::
+# Mount — only query_range is registered today). These cases are
+# parsed and shipped so the corpus is the single source of truth for
+# the eventual full matrix; the differ skips them via skip_reason
+# until cerberus's /api/metrics/query handler lands.
+#
+# When the handler lands, a follow-up PR removes the skip_reason and
+# the differ exercises both backends' instant responses against the
+# range-vs-instant cross-check (instant ≡ aggregate over the range).
+
+-- name --
+metrics_rate_instant
+-- query --
+{ } | rate()
+-- endpoint --
+metrics_instant
 -- skip_reason --
-metrics endpoint — lands in PR 5 (docs/tempo-compliance-plan.md)
+cerberus /api/metrics/query handler pending (handler.go registers
+only /api/metrics/query_range today); corpus documents the eventual
+shape so the file remains the single source of truth
+
+-- name --
+metrics_count_over_time_instant
+-- query --
+{ } | count_over_time()
+-- endpoint --
+metrics_instant
+-- skip_reason --
+cerberus /api/metrics/query handler pending; see metrics_rate_instant
+
+-- name --
+metrics_avg_over_time_instant
+-- query --
+{ } | avg_over_time(duration)
+-- endpoint --
+metrics_instant
+-- skip_reason --
+cerberus /api/metrics/query handler pending; see metrics_rate_instant
 
 # --- Per-id smoke (1) ---
 # Doesn't map back to a shadow case (the shadow tests evaluate against

--- a/harness/tempo-compatibility/driver/corpus_test.go
+++ b/harness/tempo-compatibility/driver/corpus_test.go
@@ -324,3 +324,108 @@ resource
 		t.Fatal("scope on a non-tags_v2 case should fail")
 	}
 }
+
+func TestParseCorpus_MetricsRangeSections(t *testing.T) {
+	t.Parallel()
+	in := `-- name --
+metrics_rate
+-- query --
+{ } | rate()
+-- endpoint --
+metrics_range
+-- step --
+60s
+-- expected_min_series --
+1
+-- expected_max_series --
+10
+-- expected_samples_per_series --
+5
+-- semantic_checks --
+samples_non_negative
+groupby_labels_present:resource.service.name
+`
+	got, err := parseCorpus(strings.NewReader(in), "test")
+	if err != nil {
+		t.Fatalf("parseCorpus: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 case, got %d", len(got))
+	}
+	c := got[0]
+	if c.Endpoint != "metrics_range" {
+		t.Fatalf("Endpoint = %q", c.Endpoint)
+	}
+	if c.Step != "60s" {
+		t.Fatalf("Step = %q", c.Step)
+	}
+	if c.ExpectedMinSeries != 1 || c.ExpectedMaxSeries != 10 {
+		t.Fatalf("series bounds = %d..%d", c.ExpectedMinSeries, c.ExpectedMaxSeries)
+	}
+	if c.ExpectedSamplesPerSeries != 5 {
+		t.Fatalf("ExpectedSamplesPerSeries = %d", c.ExpectedSamplesPerSeries)
+	}
+	if len(c.SemanticChecks) != 2 {
+		t.Fatalf("SemanticChecks = %v", c.SemanticChecks)
+	}
+	if c.SemanticChecks[0] != "samples_non_negative" {
+		t.Fatalf("SemanticChecks[0] = %q", c.SemanticChecks[0])
+	}
+	if c.SemanticChecks[1] != "groupby_labels_present:resource.service.name" {
+		t.Fatalf("SemanticChecks[1] = %q", c.SemanticChecks[1])
+	}
+}
+
+func TestParseCorpus_MetricsRangeRequiresStep(t *testing.T) {
+	t.Parallel()
+	in := `-- name --
+no_step
+-- query --
+{ } | rate()
+-- endpoint --
+metrics_range
+`
+	if _, err := parseCorpus(strings.NewReader(in), "test"); err == nil {
+		t.Fatal("expected error: metrics_range without step")
+	}
+}
+
+func TestParseCorpus_MetricsRangeSkipReasonBypassesStep(t *testing.T) {
+	t.Parallel()
+	// skip_reason'd metrics_range cases don't need step (the case won't
+	// run; the step omission is just a corpus-author convenience).
+	in := `-- name --
+deferred
+-- query --
+{ } | rate()
+-- endpoint --
+metrics_range
+-- skip_reason --
+deferred to follow-up
+`
+	got, err := parseCorpus(strings.NewReader(in), "test")
+	if err != nil {
+		t.Fatalf("parseCorpus: %v", err)
+	}
+	if got[0].SkipReason != "deferred to follow-up" {
+		t.Fatalf("SkipReason = %q", got[0].SkipReason)
+	}
+}
+
+func TestParseCorpus_MetricsInstantOK(t *testing.T) {
+	t.Parallel()
+	in := `-- name --
+instant
+-- query --
+{ } | rate()
+-- endpoint --
+metrics_instant
+`
+	got, err := parseCorpus(strings.NewReader(in), "test")
+	if err != nil {
+		t.Fatalf("parseCorpus: %v", err)
+	}
+	if got[0].Endpoint != "metrics_instant" {
+		t.Fatalf("Endpoint = %q", got[0].Endpoint)
+	}
+}

--- a/harness/tempo-compatibility/driver/diff.go
+++ b/harness/tempo-compatibility/driver/diff.go
@@ -56,11 +56,14 @@ func runDiff(args []string) error {
 	if err != nil {
 		return fmt.Errorf("load corpus: %w", err)
 	}
-	if len(cases) < 20 {
+	if len(cases) < 25 {
 		// Same shape as harness/.../shadow/traceql_shadow_test.go's
-		// `len(cases) < 20` guard — protects against a corpus author
-		// accidentally trimming the smoke set below the agreed floor.
-		return fmt.Errorf("smoke corpus shrunk: got %d cases, want >= 20", len(cases))
+		// guard — protects against a corpus author accidentally trimming
+		// the smoke set below the agreed floor. PR 4 set the floor at
+		// 20; PR 5 bumped to 25 after adding three metrics_range + three
+		// metrics_instant cases. Future PRs (tag endpoints, etc.) raise
+		// the floor in lock-step.
+		return fmt.Errorf("smoke corpus shrunk: got %d cases, want >= 25", len(cases))
 	}
 	logger.Info("loaded corpus", "path", *corpusPath, "cases", len(cases))
 
@@ -202,12 +205,12 @@ func diffCase(ctx context.Context, client *http.Client, tc CorpusCase, opts case
 	// Per-side assertions first. They are cheap and surface
 	// "cerberus returned 0 rows where corpus said >=N" before the
 	// diff complains about cardinality.
-	tempoReasons, err := AssertCase(tc, tempoBody, "tempo")
+	tempoReasons, err := assertCaseForEndpoint(tc, tempoBody, "tempo")
 	if err != nil {
 		res.HardError = fmt.Sprintf("assert tempo: %v", err)
 		return res
 	}
-	cerbReasons, err := AssertCase(tc, cerbBody, "cerberus")
+	cerbReasons, err := assertCaseForEndpoint(tc, cerbBody, "cerberus")
 	if err != nil {
 		res.HardError = fmt.Sprintf("assert cerberus: %v", err)
 		return res
@@ -215,14 +218,39 @@ func diffCase(ctx context.Context, client *http.Client, tc CorpusCase, opts case
 	res.Assertions = append(res.Assertions, tempoReasons...)
 	res.Assertions = append(res.Assertions, cerbReasons...)
 
+	// Semantic-consistency layer (PR 5). Runs per-backend invariants
+	// declared on the corpus case (e.g. "samples_non_negative",
+	// "groupby_labels_present:resource.service.name") against each
+	// side's parsed metrics body. This catches the failure mode the
+	// plan calls out: "both backends are wrong but in different ways"
+	// — the structural diff stays Equal because both backends produced
+	// the same wrong shape, but the semantic check fails because the
+	// shape itself violates the invariant.
+	if len(tc.SemanticChecks) > 0 && (tc.Endpoint == "metrics_range" || tc.Endpoint == "metrics_instant") {
+		tempoSem, err := RunSemanticChecks(tc, tempoBody, "tempo")
+		if err != nil {
+			res.HardError = fmt.Sprintf("semantic tempo: %v", err)
+			return res
+		}
+		cerbSem, err := RunSemanticChecks(tc, cerbBody, "cerberus")
+		if err != nil {
+			res.HardError = fmt.Sprintf("semantic cerberus: %v", err)
+			return res
+		}
+		res.Assertions = append(res.Assertions, tempoSem...)
+		res.Assertions = append(res.Assertions, cerbSem...)
+	}
+
 	// Differential diff. The case sets some upper bound on what we
 	// can expect to agree on; the structural diff is independent.
 	// Dispatch by endpoint kind: trace endpoints use the SearchResponse
 	// canonical-key diff; the four tag endpoints diff the string-list
 	// envelope; tag-values v2 additionally checks the Type field per
-	// matched value. Keeping the dispatch here (vs threading a closure
-	// through every helper) keeps the runtime branches local to where
-	// the response shapes diverge.
+	// matched value; metrics endpoints use CompareMetrics. All shapes
+	// share the Diff result type so the report renderer doesn't need a
+	// per-shape branch. Keeping the dispatch here (vs threading a
+	// closure through every helper) keeps the runtime branches local to
+	// where the response shapes diverge.
 	d, err := compareForEndpoint(tc, tempoBody, cerbBody)
 	if err != nil {
 		res.HardError = fmt.Sprintf("diff: %v", err)
@@ -232,12 +260,26 @@ func diffCase(ctx context.Context, client *http.Client, tc CorpusCase, opts case
 	return res
 }
 
+// assertCaseForEndpoint dispatches to AssertCase (search / tag shapes)
+// or AssertMetricsCase (metrics shape) based on the corpus endpoint.
+// Pulled out of diffCase to keep that function under funlen.
+func assertCaseForEndpoint(tc CorpusCase, body []byte, backendLabel string) ([]DiffReason, error) {
+	switch tc.Endpoint {
+	case "metrics_range", "metrics_instant":
+		return AssertMetricsCase(tc, body, backendLabel)
+	default:
+		return AssertCase(tc, body, backendLabel)
+	}
+}
+
 // compareForEndpoint runs the right structural-diff function for the
 // case's endpoint kind. The four tag endpoints share `CompareTagNames`
 // (envelope is a flat string set on V1 + a flatten-the-scopes view on
 // V2) and `CompareTagValues` (envelope is a flat list on V1, typed
 // objects on V2 — the differ unifies on the `Value` field and reports
-// `Type` mismatches as field_mismatch reasons).
+// `Type` mismatches as field_mismatch reasons). Metrics endpoints use
+// `CompareMetrics`; everything else falls back to the search-shape
+// `Compare`.
 func compareForEndpoint(tc CorpusCase, tempoBody, cerbBody []byte) (Diff, error) {
 	switch tc.Endpoint {
 	case "tags_v1":
@@ -248,6 +290,8 @@ func compareForEndpoint(tc CorpusCase, tempoBody, cerbBody []byte) (Diff, error)
 		return CompareTagValues(tempoBody, cerbBody, "tempo", "cerberus", false)
 	case "tag_values_v2":
 		return CompareTagValues(tempoBody, cerbBody, "tempo", "cerberus", true)
+	case "metrics_range", "metrics_instant":
+		return CompareMetrics(tempoBody, cerbBody, "tempo", "cerberus", DefaultDiffOptions())
 	default:
 		return Compare(tempoBody, cerbBody, "tempo", "cerberus", DefaultDiffOptions())
 	}
@@ -255,6 +299,14 @@ func compareForEndpoint(tc CorpusCase, tempoBody, cerbBody []byte) (Diff, error)
 
 // buildURL composes the per-endpoint URL for a corpus case. The
 // `backend` argument is purely for error messages.
+//
+// Metrics endpoints (metrics_range + metrics_instant) match Tempo's
+// reference shape — `q` is the TraceQL metrics-pipeline expression,
+// `start` / `end` are unix seconds, `step` is the bucket size (only
+// for query_range), and `exemplars` would gate exemplar emission if
+// the corpus ever needs to bound it (today we leave it unset so each
+// backend returns its default exemplar count and the differ tolerates
+// the divergence under the relative epsilon).
 func buildURL(base string, tc CorpusCase, backend string, startTS, endTS time.Time, searchLimit int) (string, error) {
 	u, err := url.Parse(strings.TrimRight(base, "/"))
 	if err != nil {
@@ -294,6 +346,20 @@ func buildURL(base string, tc CorpusCase, backend string, startTS, endTS time.Ti
 		q.Set("end", fmt.Sprintf("%d", endTS.Unix()))
 	case "tag_values_v2":
 		u.Path += "/api/v2/search/tag/" + tc.TagName + "/values"
+		q.Set("start", fmt.Sprintf("%d", startTS.Unix()))
+		q.Set("end", fmt.Sprintf("%d", endTS.Unix()))
+	case "metrics_range":
+		u.Path += "/api/metrics/query_range"
+		q.Set("q", tc.Query)
+		q.Set("start", fmt.Sprintf("%d", startTS.Unix()))
+		q.Set("end", fmt.Sprintf("%d", endTS.Unix()))
+		if tc.Step == "" {
+			return "", fmt.Errorf("%s: case %q endpoint=metrics_range needs Step", backend, tc.Name)
+		}
+		q.Set("step", tc.Step)
+	case "metrics_instant":
+		u.Path += "/api/metrics/query"
+		q.Set("q", tc.Query)
 		q.Set("start", fmt.Sprintf("%d", startTS.Unix()))
 		q.Set("end", fmt.Sprintf("%d", endTS.Unix()))
 	default:

--- a/harness/tempo-compatibility/driver/diff_test.go
+++ b/harness/tempo-compatibility/driver/diff_test.go
@@ -209,3 +209,66 @@ func TestCompareForEndpoint_DispatchesTagShape(t *testing.T) {
 		t.Fatalf("expected equal on identical tag names, got %+v", d)
 	}
 }
+
+func TestBuildURL_MetricsRange(t *testing.T) {
+	t.Parallel()
+	tc := CorpusCase{
+		Name:     "m",
+		Query:    `{ } | rate()`,
+		Endpoint: "metrics_range",
+		Step:     "60s",
+	}
+	u, err := buildURL("http://tempo:3200", tc, "tempo", time.Unix(1000, 0), time.Unix(2000, 0), 200)
+	if err != nil {
+		t.Fatalf("buildURL: %v", err)
+	}
+	if !strings.HasPrefix(u, "http://tempo:3200/api/metrics/query_range?") {
+		t.Fatalf("unexpected url: %s", u)
+	}
+	if !strings.Contains(u, "step=60s") {
+		t.Fatalf("missing step=60s: %s", u)
+	}
+	if !strings.Contains(u, "start=1000") || !strings.Contains(u, "end=2000") {
+		t.Fatalf("missing start/end: %s", u)
+	}
+	if !strings.Contains(u, "q=") {
+		t.Fatalf("missing q=: %s", u)
+	}
+}
+
+func TestBuildURL_MetricsRangeMissingStepFails(t *testing.T) {
+	t.Parallel()
+	tc := CorpusCase{
+		Name:     "m",
+		Query:    `{ } | rate()`,
+		Endpoint: "metrics_range",
+	}
+	if _, err := buildURL("http://tempo:3200", tc, "tempo", time.Unix(1000, 0), time.Unix(2000, 0), 200); err == nil {
+		t.Fatal("expected error: metrics_range without Step")
+	}
+}
+
+func TestBuildURL_MetricsInstant(t *testing.T) {
+	t.Parallel()
+	tc := CorpusCase{
+		Name:     "m",
+		Query:    `{ } | rate()`,
+		Endpoint: "metrics_instant",
+	}
+	u, err := buildURL("http://tempo:3200", tc, "tempo", time.Unix(1000, 0), time.Unix(2000, 0), 200)
+	if err != nil {
+		t.Fatalf("buildURL: %v", err)
+	}
+	if !strings.HasPrefix(u, "http://tempo:3200/api/metrics/query?") {
+		t.Fatalf("unexpected url: %s", u)
+	}
+	if !strings.Contains(u, "start=1000") || !strings.Contains(u, "end=2000") {
+		t.Fatalf("missing start/end: %s", u)
+	}
+	if !strings.Contains(u, "q=") {
+		t.Fatalf("missing q=: %s", u)
+	}
+	if strings.Contains(u, "step=") {
+		t.Fatalf("instant endpoint must not carry step: %s", u)
+	}
+}

--- a/harness/tempo-compatibility/driver/differ_metrics.go
+++ b/harness/tempo-compatibility/driver/differ_metrics.go
@@ -1,0 +1,583 @@
+// Differ + semantic-consistency layer for the Tempo /api/metrics/*
+// endpoints (PR 5 of docs/tempo-compliance-plan.md).
+//
+// PR 4's differ.go handles /api/search exclusively; PR 5 extends the
+// driver with metrics endpoints. Rather than retrofit Compare() to
+// switch on response shape, this file owns the metrics-side pipeline
+// end to end:
+//
+//   1. CompareMetrics  — structural diff of two MetricsResponse bodies
+//                        (label-set canonicalisation, sample epsilon).
+//   2. SemanticChecks  — registry of per-backend consistency invariants
+//                        (samples_non_negative, labels_match_query, etc.)
+//                        that catch the "both backends are wrong in
+//                        different ways" failure mode the plan calls out.
+//   3. AssertMetricsCase + RunSemanticChecks — driven from diffCase.
+//
+// Both backends' JSON differs slightly in label-value shape:
+//
+//   * Cerberus internal/api/tempo/metrics_query_range.go emits
+//     `{"labels":[{"key":"X","value":"Y"}], "samples":[{"timestampMs":..,
+//     "value":..}]}` — a flat string `value`.
+//   * Tempo's tempopb projection (pkg/tempopb/common/v1/common.pb.go's
+//     KeyValue) emits `{"labels":[{"key":"X","value":{"stringValue":"Y"}}], ...}`
+//     — a typed AnyValue.
+//
+// The decoder tolerates either form via a small custom Unmarshaler so
+// the differ compares the extracted string value, not the JSON envelope.
+// This is the "structural diff" mandate from the plan; if cerberus
+// migrates to the proto-shape envelope later, the differ keeps working
+// without a code change.
+
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+)
+
+// MetricsResponse is the differ-side struct mirroring Tempo's
+// /api/metrics/query_range envelope (and the /api/metrics/query
+// `series` envelope — Tempo's InstantSeries carries a single Value
+// instead of a Samples slice, which we expose via the Value field).
+//
+// Both endpoints share the same Series + Exemplars layout for label
+// canonicalisation purposes; only the per-sample shape differs.
+type MetricsResponse struct {
+	Series []MetricsSeriesEntry `json:"series"`
+}
+
+// MetricsSeriesEntry is one entry of MetricsResponse.Series. The
+// Labels field decodes either {key, value:"X"} or {key, value:{stringValue:"X"}}
+// via the custom MetricsLabel.UnmarshalJSON. The Samples + Exemplars +
+// Value fields are mutually-optional: range responses populate Samples,
+// instant responses populate Value, and either may carry Exemplars.
+type MetricsSeriesEntry struct {
+	Labels    []MetricsLabel    `json:"labels"`
+	Samples   []MetricsSample   `json:"samples,omitempty"`
+	Exemplars []MetricsExemplar `json:"exemplars,omitempty"`
+	// Value is the single-point value for instant responses
+	// (Tempo's InstantSeries shape). Zero is a legitimate value, so the
+	// differ relies on the Samples-vs-Value distinction at the response
+	// level (instant responses omit Samples) rather than a zero check.
+	Value *float64 `json:"value,omitempty"`
+}
+
+// MetricsLabel is a label entry tolerant to both wire shapes (see the
+// custom UnmarshalJSON below).
+type MetricsLabel struct {
+	Key   string
+	Value string
+}
+
+// metricsLabelWire is the union shape we accept on the wire. Either
+// Value is a plain string (cerberus today) or it is a nested object
+// {stringValue: "..."} (Tempo's tempopb projection of AnyValue).
+//
+// The struct is intentionally not exported; only UnmarshalJSON consumes it.
+type metricsLabelWire struct {
+	Key   string          `json:"key"`
+	Value json.RawMessage `json:"value"`
+}
+
+// UnmarshalJSON parses a label entry in either wire shape.
+func (l *MetricsLabel) UnmarshalJSON(data []byte) error {
+	var w metricsLabelWire
+	if err := json.Unmarshal(data, &w); err != nil {
+		return fmt.Errorf("metrics label decode: %w", err)
+	}
+	l.Key = w.Key
+	if len(w.Value) == 0 {
+		return nil
+	}
+	// Try flat string first — cheap.
+	var s string
+	if err := json.Unmarshal(w.Value, &s); err == nil {
+		l.Value = s
+		return nil
+	}
+	// Try AnyValue-shaped object. We pull only the string form; other
+	// AnyValue variants (int_value, double_value, bool_value) get
+	// stringified via fmt.Sprint so the differ has a comparable string.
+	var anyV struct {
+		StringValue *string  `json:"stringValue"`
+		IntValue    *string  `json:"intValue"` // tempopb wire shape: string-encoded int64
+		DoubleValue *float64 `json:"doubleValue"`
+		BoolValue   *bool    `json:"boolValue"`
+	}
+	if err := json.Unmarshal(w.Value, &anyV); err != nil {
+		return fmt.Errorf("metrics label %q value: not a recognized shape: %w", l.Key, err)
+	}
+	switch {
+	case anyV.StringValue != nil:
+		l.Value = *anyV.StringValue
+	case anyV.IntValue != nil:
+		l.Value = *anyV.IntValue
+	case anyV.DoubleValue != nil:
+		l.Value = fmt.Sprint(*anyV.DoubleValue)
+	case anyV.BoolValue != nil:
+		l.Value = fmt.Sprint(*anyV.BoolValue)
+	default:
+		// Empty AnyValue. Tempo emits this for nil group-by values
+		// (the "nil" bucket in cardinality cases). The empty string is
+		// a stable canonical form both backends agree on.
+		l.Value = ""
+	}
+	return nil
+}
+
+// MetricsSample is a single (timestampMs, value) point.
+type MetricsSample struct {
+	TimestampMs int64   `json:"timestampMs"`
+	Value       float64 `json:"value"`
+}
+
+// MetricsExemplar is one exemplar attached to a series. The Labels are
+// the span-level attributes that produced the exemplar (subset of the
+// span's tags); Value is the sample value at that exemplar's timestamp.
+type MetricsExemplar struct {
+	Labels      []MetricsLabel `json:"labels,omitempty"`
+	Value       float64        `json:"value"`
+	TimestampMs int64          `json:"timestampMs"`
+}
+
+// metricsCanonicalKey produces the differ-internal series identifier
+// for label-set alignment across the two backends. The key is the hex
+// SHA-256 of the sorted "k=v\n" form so distinct label permutations
+// fold to the same key; truncated to 16 hex chars for readability in
+// the markdown report (collision floor ~2.7e-16 at 100 series).
+func metricsCanonicalKey(s MetricsSeriesEntry) string {
+	pairs := make([]string, 0, len(s.Labels))
+	for _, l := range s.Labels {
+		pairs = append(pairs, l.Key+"="+l.Value)
+	}
+	sort.Strings(pairs)
+	h := sha256.Sum256([]byte(strings.Join(pairs, "\n")))
+	return hex.EncodeToString(h[:8])
+}
+
+// decodeMetrics parses one body. Errors carry the side-label so
+// downstream reasons distinguish "tempo decode failed" from "cerberus
+// decode failed".
+func decodeMetrics(body []byte) (MetricsResponse, error) {
+	var out MetricsResponse
+	if err := json.Unmarshal(body, &out); err != nil {
+		return MetricsResponse{}, fmt.Errorf("decode /api/metrics response: %w", err)
+	}
+	return out, nil
+}
+
+// CompareMetrics is the metrics-shape counterpart to Compare. It
+// canonicalises both sides by label-set hash, reports cardinality +
+// missing-on-either-side reasons, and for matched series diffs the
+// sample stream (or instant value) under the configured epsilon.
+//
+// Exemplar counts are reported as a reason when they diverge but they
+// do not by themselves drive Equal=false; the structural-diff layer
+// is intentionally lenient on exemplars because both backends may
+// sample exemplars differently (Tempo caps at 100 by default, cerberus
+// emits zero today). The structural-equality contract is "same series
+// label sets + same sample stream"; exemplar parity is a follow-up
+// goal tracked in the open questions section of the plan.
+func CompareMetrics(aBody, bBody []byte, aLabel, bLabel string, opts DiffOptions) (Diff, error) {
+	if opts.AbsEpsilon == 0 && opts.RelEpsilon == 0 {
+		opts = DefaultDiffOptions()
+	}
+
+	a, err := decodeMetrics(aBody)
+	if err != nil {
+		return Diff{}, fmt.Errorf("%s: %w", aLabel, err)
+	}
+	b, err := decodeMetrics(bBody)
+	if err != nil {
+		return Diff{}, fmt.Errorf("%s: %w", bLabel, err)
+	}
+
+	out := Diff{Equal: true}
+
+	if len(a.Series) != len(b.Series) {
+		out.Equal = false
+		out.Reasons = append(out.Reasons, DiffReason{
+			Kind:   "cardinality",
+			Detail: fmt.Sprintf("%s=%d series, %s=%d series", aLabel, len(a.Series), bLabel, len(b.Series)),
+		})
+	}
+
+	aByKey := indexMetricsByKey(a.Series)
+	bByKey := indexMetricsByKey(b.Series)
+
+	var missingInA, missingInB []string
+	for k := range bByKey {
+		if _, ok := aByKey[k]; !ok {
+			missingInA = append(missingInA, k)
+		}
+	}
+	for k := range aByKey {
+		if _, ok := bByKey[k]; !ok {
+			missingInB = append(missingInB, k)
+		}
+	}
+	sort.Strings(missingInA)
+	sort.Strings(missingInB)
+	for _, k := range missingInA {
+		out.Equal = false
+		out.Reasons = append(out.Reasons, DiffReason{
+			Kind:   "missing_in_a",
+			Detail: fmt.Sprintf("series key %s present in %s but missing in %s (%s)", k, bLabel, aLabel, formatLabels(bByKey[k].Labels)),
+		})
+	}
+	for _, k := range missingInB {
+		out.Equal = false
+		out.Reasons = append(out.Reasons, DiffReason{
+			Kind:   "missing_in_b",
+			Detail: fmt.Sprintf("series key %s present in %s but missing in %s (%s)", k, aLabel, bLabel, formatLabels(aByKey[k].Labels)),
+		})
+	}
+
+	matched := make([]string, 0, len(aByKey))
+	for k := range aByKey {
+		if _, ok := bByKey[k]; ok {
+			matched = append(matched, k)
+		}
+	}
+	sort.Strings(matched)
+
+	for _, k := range matched {
+		reasons, informational := compareMetricsSeries(k, aByKey[k], bByKey[k], aLabel, bLabel, opts)
+		// Informational reasons (today: exemplar_count) are surfaced in
+		// the report but never drive Equal=false; see the function's
+		// doc-comment for why.
+		out.Reasons = append(out.Reasons, informational...)
+		if len(reasons) > 0 {
+			out.Equal = false
+			out.Reasons = append(out.Reasons, reasons...)
+			continue
+		}
+		out.MatchedCount++
+	}
+
+	return out, nil
+}
+
+func indexMetricsByKey(ss []MetricsSeriesEntry) map[string]MetricsSeriesEntry {
+	out := make(map[string]MetricsSeriesEntry, len(ss))
+	for _, s := range ss {
+		k := metricsCanonicalKey(s)
+		if _, dup := out[k]; dup {
+			continue
+		}
+		out[k] = s
+	}
+	return out
+}
+
+// compareMetricsSeries diffs two same-canonical-key series.
+//
+// For range responses, the sample streams are compared element-wise
+// after sort-by-timestamp (both backends should already emit ascending
+// order, but the comparator tolerates an out-of-order stream because
+// the differ's job is structural correctness, not wire-order
+// enforcement — Grafana sorts on its end).
+//
+// For instant responses, the single Value is compared; a Value-pointer
+// difference between a populated and nil pointer is itself a mismatch
+// (one side returned an instant point, the other didn't).
+//
+// Returns (reasons, informational). `reasons` are mismatches that
+// drive Equal=false (cardinality of samples, sample-value drift, etc.).
+// `informational` are reasons surfaced in the report but explicitly
+// excluded from the Equal verdict — today, only exemplar count
+// divergence falls in this bucket (see CompareMetrics doc-comment).
+func compareMetricsSeries(key string, a, b MetricsSeriesEntry, aLabel, bLabel string, opts DiffOptions) (reasons, informational []DiffReason) {
+	switch {
+	case a.Value != nil && b.Value != nil:
+		if !valuesClose(*a.Value, *b.Value, opts) {
+			reasons = append(reasons, DiffReason{
+				Kind:   "field_mismatch",
+				Detail: fmt.Sprintf("key %s: instant value %s=%g vs %s=%g", key, aLabel, *a.Value, bLabel, *b.Value),
+			})
+		}
+	case a.Value != nil && b.Value == nil:
+		reasons = append(reasons, DiffReason{
+			Kind:   "field_mismatch",
+			Detail: fmt.Sprintf("key %s: %s returned instant value but %s did not", key, aLabel, bLabel),
+		})
+	case a.Value == nil && b.Value != nil:
+		reasons = append(reasons, DiffReason{
+			Kind:   "field_mismatch",
+			Detail: fmt.Sprintf("key %s: %s returned instant value but %s did not", key, bLabel, aLabel),
+		})
+	}
+
+	if len(a.Samples) != len(b.Samples) {
+		reasons = append(reasons, DiffReason{
+			Kind:   "field_mismatch",
+			Detail: fmt.Sprintf("key %s: samples count %s=%d vs %s=%d", key, aLabel, len(a.Samples), bLabel, len(b.Samples)),
+		})
+		// Fall through to a per-position best-effort diff anyway; both
+		// sides may share a prefix worth flagging individually.
+	}
+
+	aSamples := append([]MetricsSample(nil), a.Samples...)
+	bSamples := append([]MetricsSample(nil), b.Samples...)
+	sort.Slice(aSamples, func(i, j int) bool { return aSamples[i].TimestampMs < aSamples[j].TimestampMs })
+	sort.Slice(bSamples, func(i, j int) bool { return bSamples[i].TimestampMs < bSamples[j].TimestampMs })
+
+	n := len(aSamples)
+	if len(bSamples) < n {
+		n = len(bSamples)
+	}
+	for i := 0; i < n; i++ {
+		if aSamples[i].TimestampMs != bSamples[i].TimestampMs {
+			reasons = append(reasons, DiffReason{
+				Kind:   "field_mismatch",
+				Detail: fmt.Sprintf("key %s: sample[%d] ts %s=%d vs %s=%d", key, i, aLabel, aSamples[i].TimestampMs, bLabel, bSamples[i].TimestampMs),
+			})
+			continue
+		}
+		if !valuesClose(aSamples[i].Value, bSamples[i].Value, opts) {
+			reasons = append(reasons, DiffReason{
+				Kind:   "field_mismatch",
+				Detail: fmt.Sprintf("key %s: sample[%d]@%d value %s=%g vs %s=%g", key, i, aSamples[i].TimestampMs, aLabel, aSamples[i].Value, bLabel, bSamples[i].Value),
+			})
+		}
+	}
+
+	// Exemplar count divergence is informational only — see the
+	// CompareMetrics doc-comment for why we don't drive Equal=false on
+	// exemplar disagreement.
+	if len(a.Exemplars) != len(b.Exemplars) {
+		informational = append(informational, DiffReason{
+			Kind:   "exemplar_count",
+			Detail: fmt.Sprintf("key %s: exemplars %s=%d vs %s=%d (informational)", key, aLabel, len(a.Exemplars), bLabel, len(b.Exemplars)),
+		})
+	}
+
+	return reasons, informational
+}
+
+// AssertMetricsCase runs the per-side cardinality / samples-per-series
+// expectations declared on the corpus case. Mirrors AssertCase's role
+// but for the metrics shape.
+func AssertMetricsCase(tc CorpusCase, body []byte, backendLabel string) ([]DiffReason, error) {
+	var reasons []DiffReason
+	m, err := decodeMetrics(body)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", backendLabel, err)
+	}
+	if tc.ExpectedMinSeries > 0 && len(m.Series) < tc.ExpectedMinSeries {
+		reasons = append(reasons, DiffReason{
+			Kind:   "assertion",
+			Detail: fmt.Sprintf("%s: got %d series, want >= %d", backendLabel, len(m.Series), tc.ExpectedMinSeries),
+		})
+	}
+	if tc.ExpectedMaxSeries > 0 && len(m.Series) > tc.ExpectedMaxSeries {
+		reasons = append(reasons, DiffReason{
+			Kind:   "assertion",
+			Detail: fmt.Sprintf("%s: got %d series, want <= %d", backendLabel, len(m.Series), tc.ExpectedMaxSeries),
+		})
+	}
+	if tc.Endpoint == "metrics_range" && tc.ExpectedSamplesPerSeries > 0 {
+		for _, s := range m.Series {
+			if len(s.Samples) < tc.ExpectedSamplesPerSeries {
+				reasons = append(reasons, DiffReason{
+					Kind:   "assertion",
+					Detail: fmt.Sprintf("%s: series %s has %d samples, want >= %d", backendLabel, formatLabels(s.Labels), len(s.Samples), tc.ExpectedSamplesPerSeries),
+				})
+				break
+			}
+		}
+	}
+	return reasons, nil
+}
+
+// formatLabels renders the label set as a compact, deterministic
+// `{k1=v1, k2=v2}` string for use inside DiffReason details. The
+// labels are sorted so two different orderings of equal label sets
+// render the same way.
+func formatLabels(labels []MetricsLabel) string {
+	pairs := make([]string, 0, len(labels))
+	for _, l := range labels {
+		pairs = append(pairs, l.Key+"="+l.Value)
+	}
+	sort.Strings(pairs)
+	return "{" + strings.Join(pairs, ", ") + "}"
+}
+
+// SemanticCheckFn is one consistency invariant. Receives one backend's
+// parsed metrics body and returns a slice of human-readable failures.
+// Empty return = invariant held.
+type SemanticCheckFn func(m MetricsResponse, arg string) []string
+
+// SemanticChecks is the registry of named per-backend invariants. The
+// corpus case's `-- semantic_checks --` list looks up by name (split on
+// the first ":"; the remainder becomes the check's `arg`). An unknown
+// name surfaces as an assertion reason so a typo in the corpus shows
+// up in the report rather than silently passing.
+//
+// Today's registry covers the three invariants the plan calls out:
+//
+//   - samples_non_negative — every sample value >= 0 (rate / count /
+//     duration aggregates are non-negative by construction; a negative
+//     value indicates either a parser bug or a backend mis-projection).
+//
+//   - labels_match_query — every returned series carries at least one
+//     label (Tempo never returns an empty label set for a successful
+//     metrics-pipeline query; an empty label-set series is a sign the
+//     handler stripped the group-by columns).
+//
+//   - groupby_labels_present:<label.key> — when the query has
+//     `by (label.key)`, every series must carry that label. The arg
+//     names the expected key.
+//
+//   - sum_eq_count_times_avg — the avg ≡ sum / count invariant lifted
+//     from grafana/tempo:integration/api/query_range_test.go::
+//     "avg_over_time instant query". Only runnable in a follow-up that
+//     orchestrates three queries per case (avg + sum + count); ships
+//     today as a placeholder so the plan's invariant set is documented
+//     and a follow-up just flips the wiring.
+//
+//   - exemplar_in_series — for every exemplar, every label key declared
+//     on the exemplar must appear on the parent series (Tempo's
+//     "Verify that all exemplars in this series belongs to the right
+//     series by matching attribute values" invariant).
+var SemanticChecks = map[string]SemanticCheckFn{
+	"samples_non_negative":   semCheckSamplesNonNegative,
+	"labels_match_query":     semCheckLabelsMatchQuery,
+	"groupby_labels_present": semCheckGroupByLabelsPresent,
+	"exemplar_in_series":     semCheckExemplarInSeries,
+	"sum_eq_count_times_avg": semCheckSumEqCountTimesAvgPlaceholder,
+}
+
+// RunSemanticChecks executes every named check on `body`. Unknown
+// names surface as an explicit assertion so a typo is visible.
+func RunSemanticChecks(tc CorpusCase, body []byte, backendLabel string) ([]DiffReason, error) {
+	if len(tc.SemanticChecks) == 0 {
+		return nil, nil
+	}
+	m, err := decodeMetrics(body)
+	if err != nil {
+		return nil, fmt.Errorf("%s semantic decode: %w", backendLabel, err)
+	}
+	var reasons []DiffReason
+	for _, raw := range tc.SemanticChecks {
+		name, arg, _ := strings.Cut(raw, ":")
+		fn, ok := SemanticChecks[name]
+		if !ok {
+			reasons = append(reasons, DiffReason{
+				Kind:   "assertion",
+				Detail: fmt.Sprintf("%s: unknown semantic check %q (registered: %s)", backendLabel, name, registeredSemanticCheckNames()),
+			})
+			continue
+		}
+		for _, msg := range fn(m, arg) {
+			reasons = append(reasons, DiffReason{
+				Kind:   "semantic",
+				Detail: fmt.Sprintf("%s [%s]: %s", backendLabel, name, msg),
+			})
+		}
+	}
+	return reasons, nil
+}
+
+func registeredSemanticCheckNames() string {
+	names := make([]string, 0, len(SemanticChecks))
+	for n := range SemanticChecks {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
+}
+
+func semCheckSamplesNonNegative(m MetricsResponse, _ string) []string {
+	var msgs []string
+	for _, s := range m.Series {
+		for i, smp := range s.Samples {
+			if math.IsNaN(smp.Value) {
+				continue // NaN is a legitimate "no sample" sentinel in some buckets.
+			}
+			if smp.Value < 0 {
+				msgs = append(msgs, fmt.Sprintf("series %s sample[%d]@%d = %g (< 0)", formatLabels(s.Labels), i, smp.TimestampMs, smp.Value))
+				break // one report per series is enough; the differ surfaces the rest.
+			}
+		}
+		if s.Value != nil && *s.Value < 0 && !math.IsNaN(*s.Value) {
+			msgs = append(msgs, fmt.Sprintf("series %s instant value = %g (< 0)", formatLabels(s.Labels), *s.Value))
+		}
+	}
+	return msgs
+}
+
+func semCheckLabelsMatchQuery(m MetricsResponse, _ string) []string {
+	var msgs []string
+	for i, s := range m.Series {
+		if len(s.Labels) == 0 {
+			msgs = append(msgs, fmt.Sprintf("series[%d] has empty label set", i))
+		}
+	}
+	return msgs
+}
+
+func semCheckGroupByLabelsPresent(m MetricsResponse, arg string) []string {
+	if arg == "" {
+		return []string{"groupby_labels_present requires an argument (e.g. groupby_labels_present:resource.service.name)"}
+	}
+	expectedKeys := strings.Split(arg, ",")
+	var msgs []string
+	for _, s := range m.Series {
+		present := map[string]bool{}
+		for _, l := range s.Labels {
+			present[l.Key] = true
+		}
+		for _, want := range expectedKeys {
+			want = strings.TrimSpace(want)
+			if want == "" {
+				continue
+			}
+			if !present[want] {
+				msgs = append(msgs, fmt.Sprintf("series %s missing group-by label %q", formatLabels(s.Labels), want))
+				break
+			}
+		}
+	}
+	return msgs
+}
+
+func semCheckExemplarInSeries(m MetricsResponse, _ string) []string {
+	var msgs []string
+	for _, s := range m.Series {
+		seriesKeys := map[string]string{}
+		for _, l := range s.Labels {
+			seriesKeys[l.Key] = l.Value
+		}
+		for i, ex := range s.Exemplars {
+			for _, el := range ex.Labels {
+				if v, ok := seriesKeys[el.Key]; ok && v != el.Value {
+					msgs = append(msgs, fmt.Sprintf("series %s exemplar[%d] label %s=%q disagrees with series value %q", formatLabels(s.Labels), i, el.Key, el.Value, v))
+				}
+			}
+		}
+	}
+	return msgs
+}
+
+// semCheckSumEqCountTimesAvgPlaceholder records that the avg ≡ sum/count
+// invariant is part of the registered check set without yet executing
+// the three-query orchestration the real check needs. Returns an
+// empty slice so the placeholder is a no-op at runtime; a follow-up PR
+// that wires per-case multi-query plans replaces this with a real
+// implementation.
+//
+// Keeping the name registered today means a corpus case may list
+// `sum_eq_count_times_avg` in `-- semantic_checks --` to declare
+// "this is the invariant I want once we can express it" — and the
+// differ won't error out on the unknown name. When the real check
+// lands, no corpus edit is needed.
+func semCheckSumEqCountTimesAvgPlaceholder(_ MetricsResponse, _ string) []string {
+	return nil
+}

--- a/harness/tempo-compatibility/driver/differ_metrics_test.go
+++ b/harness/tempo-compatibility/driver/differ_metrics_test.go
@@ -1,0 +1,451 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMetricsLabel_UnmarshalFlatString(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"series":[{"labels":[{"key":"k","value":"v"}],"samples":[{"timestampMs":1000,"value":1.5}]}]}`)
+	m, err := decodeMetrics(body)
+	if err != nil {
+		t.Fatalf("decodeMetrics: %v", err)
+	}
+	if len(m.Series) != 1 || len(m.Series[0].Labels) != 1 {
+		t.Fatalf("unexpected shape: %+v", m)
+	}
+	if m.Series[0].Labels[0].Key != "k" || m.Series[0].Labels[0].Value != "v" {
+		t.Fatalf("label = %+v", m.Series[0].Labels[0])
+	}
+}
+
+func TestMetricsLabel_UnmarshalAnyValueShape(t *testing.T) {
+	t.Parallel()
+	// Tempo's tempopb wire shape: value is a nested AnyValue object.
+	body := []byte(`{"series":[{"labels":[{"key":"k","value":{"stringValue":"v"}}],"samples":[{"timestampMs":1000,"value":1.5}]}]}`)
+	m, err := decodeMetrics(body)
+	if err != nil {
+		t.Fatalf("decodeMetrics: %v", err)
+	}
+	if m.Series[0].Labels[0].Value != "v" {
+		t.Fatalf("AnyValue stringValue not extracted: %+v", m.Series[0].Labels[0])
+	}
+}
+
+func TestMetricsLabel_UnmarshalEmptyAnyValue(t *testing.T) {
+	t.Parallel()
+	// Tempo emits empty AnyValue for nil group-by buckets.
+	body := []byte(`{"series":[{"labels":[{"key":"k","value":{}}],"samples":[]}]}`)
+	m, err := decodeMetrics(body)
+	if err != nil {
+		t.Fatalf("decodeMetrics: %v", err)
+	}
+	if m.Series[0].Labels[0].Value != "" {
+		t.Fatalf("empty AnyValue should map to empty string, got %q", m.Series[0].Labels[0].Value)
+	}
+}
+
+func TestCompareMetrics_Identical(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"series":[
+		{"labels":[{"key":"resource.service.name","value":"checkout"}],
+		 "samples":[{"timestampMs":1000,"value":1.5},{"timestampMs":2000,"value":2.5}]}
+	]}`)
+	d, err := CompareMetrics(body, body, "tempo", "cerberus", DefaultDiffOptions())
+	if err != nil {
+		t.Fatalf("CompareMetrics: %v", err)
+	}
+	if !d.Equal {
+		t.Fatalf("expected Equal, got %+v", d.Reasons)
+	}
+	if d.MatchedCount != 1 {
+		t.Fatalf("MatchedCount = %d, want 1", d.MatchedCount)
+	}
+}
+
+func TestCompareMetrics_CrossShapeEqual(t *testing.T) {
+	t.Parallel()
+	// Tempo's wire shape vs cerberus's wire shape, otherwise identical
+	// label set + samples. The differ should treat them as equal.
+	tempoSide := []byte(`{"series":[
+		{"labels":[{"key":"resource.service.name","value":{"stringValue":"checkout"}}],
+		 "samples":[{"timestampMs":1000,"value":1.5}]}
+	]}`)
+	cerberusSide := []byte(`{"series":[
+		{"labels":[{"key":"resource.service.name","value":"checkout"}],
+		 "samples":[{"timestampMs":1000,"value":1.5}]}
+	]}`)
+	d, err := CompareMetrics(tempoSide, cerberusSide, "tempo", "cerberus", DefaultDiffOptions())
+	if err != nil {
+		t.Fatalf("CompareMetrics: %v", err)
+	}
+	if !d.Equal {
+		t.Fatalf("expected cross-shape match, got reasons=%v", d.Reasons)
+	}
+}
+
+func TestCompareMetrics_CardinalityMismatch(t *testing.T) {
+	t.Parallel()
+	a := []byte(`{"series":[
+		{"labels":[{"key":"k","value":"a"}],"samples":[]},
+		{"labels":[{"key":"k","value":"b"}],"samples":[]}
+	]}`)
+	b := []byte(`{"series":[
+		{"labels":[{"key":"k","value":"a"}],"samples":[]}
+	]}`)
+	d, err := CompareMetrics(a, b, "tempo", "cerberus", DefaultDiffOptions())
+	if err != nil {
+		t.Fatalf("CompareMetrics: %v", err)
+	}
+	if d.Equal {
+		t.Fatal("expected Equal=false")
+	}
+	foundCard, foundMissing := false, false
+	for _, r := range d.Reasons {
+		if r.Kind == "cardinality" {
+			foundCard = true
+		}
+		if r.Kind == "missing_in_b" {
+			foundMissing = true
+		}
+	}
+	if !foundCard || !foundMissing {
+		t.Fatalf("expected cardinality + missing_in_b reasons, got %+v", d.Reasons)
+	}
+}
+
+func TestCompareMetrics_SampleEpsilon(t *testing.T) {
+	t.Parallel()
+	a := []byte(`{"series":[
+		{"labels":[{"key":"k","value":"v"}],"samples":[{"timestampMs":1000,"value":1.5}]}
+	]}`)
+	b := []byte(`{"series":[
+		{"labels":[{"key":"k","value":"v"}],"samples":[{"timestampMs":1000,"value":1.5000000000001}]}
+	]}`)
+	d, err := CompareMetrics(a, b, "tempo", "cerberus", DefaultDiffOptions())
+	if err != nil {
+		t.Fatalf("CompareMetrics: %v", err)
+	}
+	if !d.Equal {
+		t.Fatalf("expected epsilon-absorbed match, got reasons=%v", d.Reasons)
+	}
+}
+
+func TestCompareMetrics_SampleValueDiff(t *testing.T) {
+	t.Parallel()
+	a := []byte(`{"series":[
+		{"labels":[{"key":"k","value":"v"}],"samples":[{"timestampMs":1000,"value":1.5}]}
+	]}`)
+	b := []byte(`{"series":[
+		{"labels":[{"key":"k","value":"v"}],"samples":[{"timestampMs":1000,"value":2.5}]}
+	]}`)
+	d, err := CompareMetrics(a, b, "tempo", "cerberus", DefaultDiffOptions())
+	if err != nil {
+		t.Fatalf("CompareMetrics: %v", err)
+	}
+	if d.Equal {
+		t.Fatal("expected Equal=false")
+	}
+	found := false
+	for _, r := range d.Reasons {
+		if r.Kind == "field_mismatch" && strings.Contains(r.Detail, "sample[0]") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected sample mismatch reason, got %+v", d.Reasons)
+	}
+}
+
+func TestCompareMetrics_InstantValue(t *testing.T) {
+	t.Parallel()
+	a := []byte(`{"series":[
+		{"labels":[{"key":"k","value":"v"}],"value":3.14}
+	]}`)
+	b := []byte(`{"series":[
+		{"labels":[{"key":"k","value":"v"}],"value":3.14}
+	]}`)
+	d, err := CompareMetrics(a, b, "tempo", "cerberus", DefaultDiffOptions())
+	if err != nil {
+		t.Fatalf("CompareMetrics: %v", err)
+	}
+	if !d.Equal {
+		t.Fatalf("expected equal instant series, got reasons=%v", d.Reasons)
+	}
+}
+
+func TestCompareMetrics_InstantValueOneSideMissing(t *testing.T) {
+	t.Parallel()
+	a := []byte(`{"series":[
+		{"labels":[{"key":"k","value":"v"}],"value":3.14}
+	]}`)
+	b := []byte(`{"series":[
+		{"labels":[{"key":"k","value":"v"}]}
+	]}`)
+	d, err := CompareMetrics(a, b, "tempo", "cerberus", DefaultDiffOptions())
+	if err != nil {
+		t.Fatalf("CompareMetrics: %v", err)
+	}
+	if d.Equal {
+		t.Fatal("expected Equal=false (one side missing instant value)")
+	}
+}
+
+func TestCompareMetrics_LabelOrderInvariant(t *testing.T) {
+	t.Parallel()
+	// Different label orderings of the same set must canonicalise to
+	// the same key — Tempo and cerberus may emit labels in different
+	// stable orders.
+	a := []byte(`{"series":[
+		{"labels":[{"key":"a","value":"1"},{"key":"b","value":"2"}],"samples":[]}
+	]}`)
+	b := []byte(`{"series":[
+		{"labels":[{"key":"b","value":"2"},{"key":"a","value":"1"}],"samples":[]}
+	]}`)
+	d, err := CompareMetrics(a, b, "tempo", "cerberus", DefaultDiffOptions())
+	if err != nil {
+		t.Fatalf("CompareMetrics: %v", err)
+	}
+	if !d.Equal {
+		t.Fatalf("expected label-order invariance, got reasons=%v", d.Reasons)
+	}
+}
+
+func TestCompareMetrics_ExemplarCountInformational(t *testing.T) {
+	t.Parallel()
+	// Exemplar count divergence is reported but does NOT drive
+	// Equal=false (see CompareMetrics doc-comment).
+	a := []byte(`{"series":[
+		{"labels":[{"key":"k","value":"v"}],"samples":[{"timestampMs":1000,"value":1}],
+		 "exemplars":[{"timestampMs":1500,"value":1.2,"labels":[{"key":"k","value":"v"}]}]}
+	]}`)
+	b := []byte(`{"series":[
+		{"labels":[{"key":"k","value":"v"}],"samples":[{"timestampMs":1000,"value":1}]}
+	]}`)
+	d, err := CompareMetrics(a, b, "tempo", "cerberus", DefaultDiffOptions())
+	if err != nil {
+		t.Fatalf("CompareMetrics: %v", err)
+	}
+	// Equal must remain true — exemplar count divergence is informational.
+	if !d.Equal {
+		t.Fatalf("exemplar count divergence should not drive Equal=false, got %+v", d.Reasons)
+	}
+	foundExemplar := false
+	for _, r := range d.Reasons {
+		if r.Kind == "exemplar_count" {
+			foundExemplar = true
+		}
+	}
+	if !foundExemplar {
+		t.Fatalf("expected exemplar_count reason as informational signal, got %+v", d.Reasons)
+	}
+}
+
+func TestAssertMetricsCase_MinSeries(t *testing.T) {
+	t.Parallel()
+	tc := CorpusCase{Name: "m", Endpoint: "metrics_range", ExpectedMinSeries: 3}
+	body := []byte(`{"series":[
+		{"labels":[{"key":"k","value":"v"}],"samples":[]}
+	]}`)
+	reasons, err := AssertMetricsCase(tc, body, "tempo")
+	if err != nil {
+		t.Fatalf("AssertMetricsCase: %v", err)
+	}
+	if len(reasons) == 0 || !strings.Contains(reasons[0].Detail, "want >= 3") {
+		t.Fatalf("expected min-series reason, got %+v", reasons)
+	}
+}
+
+func TestAssertMetricsCase_SamplesPerSeries(t *testing.T) {
+	t.Parallel()
+	tc := CorpusCase{Name: "m", Endpoint: "metrics_range", ExpectedSamplesPerSeries: 3}
+	body := []byte(`{"series":[
+		{"labels":[{"key":"k","value":"v"}],"samples":[{"timestampMs":1000,"value":1}]}
+	]}`)
+	reasons, err := AssertMetricsCase(tc, body, "tempo")
+	if err != nil {
+		t.Fatalf("AssertMetricsCase: %v", err)
+	}
+	if len(reasons) == 0 || !strings.Contains(reasons[0].Detail, "want >= 3") {
+		t.Fatalf("expected samples-per-series reason, got %+v", reasons)
+	}
+}
+
+func TestSemanticChecks_SamplesNonNegative_OK(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"series":[
+		{"labels":[{"key":"k","value":"v"}],"samples":[{"timestampMs":1000,"value":1},{"timestampMs":2000,"value":2}]}
+	]}`)
+	tc := CorpusCase{Name: "n", Endpoint: "metrics_range", SemanticChecks: []string{"samples_non_negative"}}
+	reasons, err := RunSemanticChecks(tc, body, "tempo")
+	if err != nil {
+		t.Fatalf("RunSemanticChecks: %v", err)
+	}
+	if len(reasons) != 0 {
+		t.Fatalf("expected no reasons, got %+v", reasons)
+	}
+}
+
+func TestSemanticChecks_SamplesNonNegative_Violation(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"series":[
+		{"labels":[{"key":"k","value":"v"}],"samples":[{"timestampMs":1000,"value":-1.5}]}
+	]}`)
+	tc := CorpusCase{Name: "n", Endpoint: "metrics_range", SemanticChecks: []string{"samples_non_negative"}}
+	reasons, err := RunSemanticChecks(tc, body, "tempo")
+	if err != nil {
+		t.Fatalf("RunSemanticChecks: %v", err)
+	}
+	if len(reasons) == 0 {
+		t.Fatal("expected violation reason for negative sample")
+	}
+	if reasons[0].Kind != "semantic" {
+		t.Fatalf("expected Kind=semantic, got %q", reasons[0].Kind)
+	}
+}
+
+func TestSemanticChecks_GroupByLabelsPresent_OK(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"series":[
+		{"labels":[{"key":"resource.service.name","value":"checkout"}],"samples":[]}
+	]}`)
+	tc := CorpusCase{
+		Name:           "n",
+		Endpoint:       "metrics_range",
+		SemanticChecks: []string{"groupby_labels_present:resource.service.name"},
+	}
+	reasons, err := RunSemanticChecks(tc, body, "tempo")
+	if err != nil {
+		t.Fatalf("RunSemanticChecks: %v", err)
+	}
+	if len(reasons) != 0 {
+		t.Fatalf("expected no reasons, got %+v", reasons)
+	}
+}
+
+func TestSemanticChecks_GroupByLabelsPresent_Missing(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"series":[
+		{"labels":[{"key":"other","value":"x"}],"samples":[]}
+	]}`)
+	tc := CorpusCase{
+		Name:           "n",
+		Endpoint:       "metrics_range",
+		SemanticChecks: []string{"groupby_labels_present:resource.service.name"},
+	}
+	reasons, err := RunSemanticChecks(tc, body, "tempo")
+	if err != nil {
+		t.Fatalf("RunSemanticChecks: %v", err)
+	}
+	if len(reasons) == 0 {
+		t.Fatal("expected missing group-by label reason")
+	}
+}
+
+func TestSemanticChecks_UnknownCheckSurfaces(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"series":[{"labels":[{"key":"k","value":"v"}],"samples":[]}]}`)
+	tc := CorpusCase{Name: "n", Endpoint: "metrics_range", SemanticChecks: []string{"nope_not_a_real_check"}}
+	reasons, err := RunSemanticChecks(tc, body, "tempo")
+	if err != nil {
+		t.Fatalf("RunSemanticChecks: %v", err)
+	}
+	if len(reasons) == 0 || !strings.Contains(reasons[0].Detail, "unknown semantic check") {
+		t.Fatalf("expected unknown-check reason, got %+v", reasons)
+	}
+}
+
+func TestSemanticChecks_LabelsMatchQuery(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"series":[
+		{"labels":[],"samples":[]}
+	]}`)
+	tc := CorpusCase{Name: "n", Endpoint: "metrics_range", SemanticChecks: []string{"labels_match_query"}}
+	reasons, err := RunSemanticChecks(tc, body, "tempo")
+	if err != nil {
+		t.Fatalf("RunSemanticChecks: %v", err)
+	}
+	if len(reasons) == 0 {
+		t.Fatal("expected empty-label-set reason")
+	}
+}
+
+func TestSemanticChecks_ExemplarInSeries_OK(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"series":[
+		{"labels":[{"key":"resource.service.name","value":"checkout"}],
+		 "samples":[{"timestampMs":1000,"value":1}],
+		 "exemplars":[{"timestampMs":1500,"value":1.2,"labels":[{"key":"resource.service.name","value":"checkout"}]}]}
+	]}`)
+	tc := CorpusCase{Name: "n", Endpoint: "metrics_range", SemanticChecks: []string{"exemplar_in_series"}}
+	reasons, err := RunSemanticChecks(tc, body, "tempo")
+	if err != nil {
+		t.Fatalf("RunSemanticChecks: %v", err)
+	}
+	if len(reasons) != 0 {
+		t.Fatalf("expected no reasons (exemplar agrees with series), got %+v", reasons)
+	}
+}
+
+func TestSemanticChecks_ExemplarInSeries_Mismatch(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"series":[
+		{"labels":[{"key":"resource.service.name","value":"checkout"}],
+		 "samples":[{"timestampMs":1000,"value":1}],
+		 "exemplars":[{"timestampMs":1500,"value":1.2,"labels":[{"key":"resource.service.name","value":"payments"}]}]}
+	]}`)
+	tc := CorpusCase{Name: "n", Endpoint: "metrics_range", SemanticChecks: []string{"exemplar_in_series"}}
+	reasons, err := RunSemanticChecks(tc, body, "tempo")
+	if err != nil {
+		t.Fatalf("RunSemanticChecks: %v", err)
+	}
+	if len(reasons) == 0 {
+		t.Fatal("expected exemplar-in-series mismatch reason")
+	}
+}
+
+func TestSemanticChecks_NoChecksReturnsNothing(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"series":[]}`)
+	tc := CorpusCase{Name: "n", Endpoint: "metrics_range"}
+	reasons, err := RunSemanticChecks(tc, body, "tempo")
+	if err != nil {
+		t.Fatalf("RunSemanticChecks: %v", err)
+	}
+	if len(reasons) != 0 {
+		t.Fatalf("expected no reasons when SemanticChecks empty, got %+v", reasons)
+	}
+}
+
+func TestSemanticChecks_SumEqCountTimesAvgPlaceholder(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"series":[]}`)
+	tc := CorpusCase{Name: "n", Endpoint: "metrics_range", SemanticChecks: []string{"sum_eq_count_times_avg"}}
+	reasons, err := RunSemanticChecks(tc, body, "tempo")
+	if err != nil {
+		t.Fatalf("RunSemanticChecks: %v", err)
+	}
+	// Placeholder must register as known + return zero reasons today.
+	if len(reasons) != 0 {
+		t.Fatalf("expected placeholder to no-op today, got %+v", reasons)
+	}
+}
+
+func TestMetricsCanonicalKey_LabelOrderInvariant(t *testing.T) {
+	t.Parallel()
+	s1 := MetricsSeriesEntry{Labels: []MetricsLabel{{Key: "a", Value: "1"}, {Key: "b", Value: "2"}}}
+	s2 := MetricsSeriesEntry{Labels: []MetricsLabel{{Key: "b", Value: "2"}, {Key: "a", Value: "1"}}}
+	if metricsCanonicalKey(s1) != metricsCanonicalKey(s2) {
+		t.Fatal("label order should not affect canonical key")
+	}
+}
+
+func TestMetricsCanonicalKey_DistinguishesValues(t *testing.T) {
+	t.Parallel()
+	s1 := MetricsSeriesEntry{Labels: []MetricsLabel{{Key: "k", Value: "v1"}}}
+	s2 := MetricsSeriesEntry{Labels: []MetricsLabel{{Key: "k", Value: "v2"}}}
+	if metricsCanonicalKey(s1) == metricsCanonicalKey(s2) {
+		t.Fatal("different label values must produce different canonical keys")
+	}
+}

--- a/harness/tempo-compatibility/driver/main.go
+++ b/harness/tempo-compatibility/driver/main.go
@@ -10,12 +10,13 @@
 //     `/api/traces/<first-id>` on both backends and reports the per-
 //     backend span count. The contract is: stack comes up, seed
 //     pushes to both targets, the smoke trace-id resolves on both.
-//   - `diff`    (PR 4 — this PR) reads a TXTAR corpus, runs every
-//     TraceQL query through both backends via /api/search (and
-//     /api/traces/<id> for the per-id smoke cases), applies per-side
-//     assertions, computes the structural diff, and emits a markdown
-//     report under /reports/. Returns 0 (informational baseline) by
-//     default; pass --fail-on-diff to make any diff non-zero.
+//   - `diff`    (PR 4 + PR 5) reads a TXTAR corpus, runs every TraceQL
+//     query through both backends via /api/search, /api/traces/<id>,
+//     /api/metrics/query_range, and /api/metrics/query, applies per-
+//     side assertions + semantic-consistency invariants, computes the
+//     structural diff, and emits a markdown report under /reports/.
+//     Returns 0 (informational baseline) by default; pass
+//     --fail-on-diff to make any diff non-zero.
 //
 // The two-way "OTLP into Tempo, INSERT into CH" split is documented in
 // docs/tempo-compliance-plan.md's "Open question 1": cerberus is
@@ -41,7 +42,7 @@ import (
 
 // version is stamped on driver output so a reader scanning CI logs can
 // tell at a glance which PR's behaviour they're looking at.
-const version = "pr4-differ"
+const version = "pr5-metrics"
 
 func main() {
 	if len(os.Args) < 2 {


### PR DESCRIPTION
PR 5 of [`docs/tempo-compliance-plan.md`](docs/tempo-compliance-plan.md). Stacks on #395 (PR 4 — corpus + differ) which is merged on main.

## Summary

- Extends the TraceQL compatibility corpus + driver to `/api/metrics/query_range` and `/api/metrics/query`. The PR 4 smoke set carried two metrics cases stubbed via `skip_reason='pr5'`; this PR turns those into three real `metrics_range` cases (rate, count_over_time by service, quantile_over_time p95) and adds three `metrics_instant` cases that remain skipped pending cerberus's `/api/metrics/query` handler (only `/api/metrics/query_range` is registered in `internal/api/tempo/handler.go` today).
- New differ pipeline for the metrics shape (`harness/tempo-compatibility/driver/differ_metrics.go`):
  - `CompareMetrics` canonicalises series by label-set hash (label-order invariant), diffs sample streams under 1e-9 relative epsilon, treats exemplar-count divergence as informational (does not drive `Equal=false`) since both backends sample exemplars independently.
  - The label decoder tolerates both wire shapes — cerberus's flat `{key, value: "X"}` and Tempo's tempopb projection `{key, value: {stringValue: "X"}}` — so the structural diff doesn't false-positive on the envelope difference. AnyValue's `intValue` / `doubleValue` / `boolValue` fall through to `fmt.Sprint`.
- Wires the **semantic-consistency layer** the plan calls out: per-backend invariants that catch the "both backends are wrong in different ways" failure mode the structural diff misses. Registered checks: `samples_non_negative`, `labels_match_query`, `groupby_labels_present:<label.key>`, `exemplar_in_series`, plus a `sum_eq_count_times_avg` placeholder that registers the eventual `avg ≡ sum / count` invariant lifted from [`grafana/tempo:integration/api/query_range_test.go`](https://github.com/grafana/tempo/blob/main/integration/api/query_range_test.go) without yet orchestrating the three-query plan.
- New TXTAR sections in `corpus.go`: `step`, `expected_min_series`, `expected_max_series`, `expected_samples_per_series`, `semantic_checks`.
- Smoke floor in `driver/diff.go` + `corpus_test.go`: 20 -> 25 cases.

## Test plan

- [x] `go build -o /dev/null ./harness/tempo-compatibility/driver` — clean compile.
- [x] `go vet ./harness/tempo-compatibility/driver/...` — no issues.
- [x] `go test ./harness/tempo-compatibility/driver/...` — 64 unit tests pass (corpus loader, search differ, metrics differ, semantic checks, URL builder, render report, trace-id derivation).
- [ ] Nightly `tempo-compatibility` workflow run completes green (informational mode); inspect markdown report for new metrics_range diffs / assertions.
- [ ] Local smoke against the compose stack once cerberus image with `/api/metrics/query` lands (deferred — the corpus marks instant cases as skipped today).

## Cross-refs

- Plan doc: [`docs/tempo-compliance-plan.md`](docs/tempo-compliance-plan.md) PR 5 row ("metrics endpoints: extend corpus with `/api/metrics/query_range` + `/api/metrics/query`. Wire semantic-consistency layer").
- Builds on #395 (PR 4 — TXTAR corpus + JSON differ + smoke diff); the corpus there shipped the metrics cases as `skip_reason='pr5'` placeholders that this PR turns on.
- Open question 4 of the plan (Accept-header matrix) is not addressed here — the differ negotiates JSON only, matching PR 4.

## Corpus case count delta

- Before: 20 cases (18 active, 2 skipped pending PR 5).
- After: 25 cases (21 active, 4 skipped — 3 instant pending cerberus handler, 1 metrics-pipeline `count_spans_per_trace` already active).