### PR TITLE
fix(promql): widen inner-subquery anchor grid in range-mode counter rate

### DIFF
--- a/internal/promql/subquery.go
+++ b/internal/promql/subquery.go
@@ -292,6 +292,29 @@ func lowerOuterRangeFnOverSubquery(
 		rw.End = ctx.end.UTC()
 		rw.Step = ctx.step
 		rw.OuterRange = ctx.end.Sub(ctx.start)
+		// Widen the inner subquery's anchor grid so it covers the union
+		// of the outer evaluation window plus one full subquery range.
+		// Without this, the inner stays anchored at `now64(9) - sub.Range`
+		// (`lowerSubqueryOverCall`'s `End` defaults to zero because
+		// `subqueryAnchor` only honours `@start()` / `@end()`). For every
+		// outer anchor `t` in `[ctx.start, ctx.end]` the outer's
+		// per-anchor filter `(t - sub.Range, t]` reads the inner's
+		// `anchor_ts` column — so the inner anchor grid must extend
+		// across `[ctx.start - sub.Range, ctx.end]` or the filter falls
+		// outside the emitted inner anchors and the matrix collapses to
+		// an empty matrix. Compat-lane manifestation:
+		// `avg_over_time(rate(demo_cpu_usage_seconds_total[1m])[2m:10s])`
+		// returned [] vs Prom's populated matrix (`#400` Bucket 3).
+		// The Identity-true sibling (`max_over_time((<binary>)[5m:10s])`)
+		// also benefits from the same widening — the inner's anchor
+		// grid is the same shape, the bug just manifests less obviously
+		// because the binary inner doesn't carry the `>= 2 samples`
+		// guard that the counter-extrapolation path adds.
+		if innerRW, ok := inner.(*chplan.RangeWindow); ok {
+			innerRW.Start = ctx.start.Add(-sub.Range).UTC()
+			innerRW.End = ctx.end.UTC()
+			innerRW.OuterRange = ctx.end.Sub(ctx.start) + sub.Range
+		}
 	}
 	return rw, nil
 }

--- a/test/spec/promql/subquery_avg_over_time_rate.txtar
+++ b/test/spec/promql/subquery_avg_over_time_rate.txtar
@@ -1,0 +1,32 @@
+-- query.promql --
+avg_over_time(rate(http_requests_total[1m])[2m:10s])
+-- range_step --
+30s
+-- args --
+[0] string = "http_requests_total"
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('http_requests_total', map('job', 'api'), toDateTime64('2025-12-31 23:58:00', 9), 0.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2025-12-31 23:58:30', 9), 5.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2025-12-31 23:59:00', 9), 10.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2025-12-31 23:59:30', 9), 15.0);
+-- expected_rows --
+[
+  [{"job": "api"}, "2026-01-01T00:00:00Z", 0.14814814814814814],
+  [{"job": "api"}, "2026-01-01T00:00:30Z", 0.15625],
+  [{"job": "api"}, "2026-01-01T00:01:00Z", 0.16666666666666666],
+  [{"job": "api"}, "2026-01-01T00:01:30Z", 0.16666666666666666]
+]
+-- chplan --
+RangeWindow func=avg_over_time range=2m0s step=30s outerRange=5m0s ts=anchor_ts value=Value groupBy=[Attributes] start=2026-01-01T00:00:00Z end=2026-01-01T00:05:00Z
+  RangeWindow func=rate range=1m0s step=10s outerRange=7m0s ts=TimeUnix value=Value groupBy=[Attributes] start=2025-12-31T23:58:00Z end=2026-01-01T00:05:00Z
+    Filter predicate=(MetricName = "http_requests_total")
+      Scan(otel_metrics_sum)
+-- sql --
+SELECT `Attributes`, `anchor_ts`, if(length(window_vals) > 0, arrayAvg(window_vals), nan) AS `Value` FROM (SELECT `Attributes`, `anchor_ts`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, `anchor_ts`, arrayFilter(p -> tupleElement(p, 1) > anchor_ts - toIntervalNanosecond(120000000000) AND tupleElement(p, 1) <= anchor_ts, series_array) AS `window_pairs` FROM (SELECT `Attributes`, `series_array`, arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(i * 30000000000), range(0, 11))) AS `anchor_ts` FROM (SELECT `Attributes`, arraySort(groupArray((`anchor_ts`, `Value`))) AS `series_array` FROM (SELECT `Attributes`, `anchor_ts`, if(sampled_interval > 0, counter_delta * (sampled_interval + if(counter_delta > 0 AND first_val >= 0, least(duration_to_start, sampled_interval * first_val / counter_delta), duration_to_start) + duration_to_end) / sampled_interval / 60, nan) AS `Value` FROM (SELECT `Attributes`, `anchor_ts`, `window_vals`, `counter_delta`, `first_val`, toFloat64(dateDiff('nanosecond', first_ts, last_ts)) / 1e9 AS `sampled_interval`, if(toFloat64(dateDiff('nanosecond', anchor_ts - toIntervalNanosecond(60000000000), first_ts)) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', anchor_ts - toIntervalNanosecond(60000000000), first_ts)) / 1e9) AS `duration_to_start`, if(toFloat64(dateDiff('nanosecond', last_ts, anchor_ts)) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', last_ts, anchor_ts)) / 1e9) AS `duration_to_end` FROM (SELECT `Attributes`, `anchor_ts`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta`, tupleElement(window_pairs[1], 1) AS `first_ts`, tupleElement(window_pairs[length(window_pairs)], 1) AS `last_ts`, tupleElement(window_pairs[1], 2) AS `first_val` FROM (SELECT `Attributes`, `anchor_ts`, arrayFilter(p -> tupleElement(p, 1) > anchor_ts - toIntervalNanosecond(60000000000) AND tupleElement(p, 1) <= anchor_ts, series_array) AS `window_pairs` FROM (SELECT `Attributes`, `series_array`, arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(i * 10000000000), range(0, 43))) AS `anchor_ts` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` = ?)) GROUP BY `Attributes`))))) WHERE length(`window_vals`) >= 2) GROUP BY `Attributes`)))) WHERE length(`window_vals`) >= 1


### PR DESCRIPTION
## Summary

- `avg_over_time(rate(m[1m])[2m:10s])` (and any `<range-vector-fn>(<counter-fn>(<vec>[range])[<sub-range>:<sub-step>])`) returned `model.Matrix{}` from cerberus when the request's `[start, end]` sat far from wall-clock — the inner rate's anchor grid stayed pinned at `now64(9)`, so the outer's per-anchor filter `(t_outer - sub.Range, t_outer]` missed every inner sample.
- Fix widens the inner RangeWindow's `End` to `ctx.end` and `OuterRange` to `(ctx.end - ctx.start) + sub.Range` so the inner anchor grid spans `[ctx.start - sub.Range, ctx.end]`. Gated on `ctx.step > 0 && !ctx.start.IsZero() && !ctx.end.IsZero()` — instant-mode is untouched and every existing subquery TXTAR golden stays byte-stable.
- Closes the `avg_over_time(rate(demo_cpu_usage_seconds_total[1m])[2m:10s])` diff cited in [`docs/pre-ga-readiness-signoff.md`](docs/pre-ga-readiness-signoff.md) line 117 and [`docs/compat-residual-audit-postE.md` § Bucket 3](docs/compat-residual-audit-postE.md) (#400 Pool-BE dispatch).

## Root cause

`lowerOuterRangeFnOverSubquery` (`internal/promql/subquery.go:259`) wires the **outer** RangeWindow's `Start`/`End`/`Step`/`OuterRange` to the request eval window when in range mode, but `lowerSubquery` builds the **inner** RangeWindow via `lowerSubqueryOverCall`, which sets `End: anchor.End` from `subqueryAnchor(sub, ctx)` — zero unless an explicit `@start()`/`@end()` modifier is present. Zero `End` renders as `now64(9)` in the chsql emitter via `endExprFrag` → the inner anchor grid is `[now64(9) - OuterRange, now64(9)]` regardless of where the request's `[start, end]` sits.

## chplan before / after (range_step=30s, sub=`[2m:10s]`, inner=`rate(m[1m])`)

Before (inner has no Start/End, OuterRange=2m → grid spans `[now-2m, now]`):

```text
RangeWindow func=avg_over_time range=2m0s step=30s outerRange=5m0s ts=anchor_ts value=Value groupBy=[Attributes] start=2026-01-01T00:00:00Z end=2026-01-01T00:05:00Z
  RangeWindow func=rate range=1m0s step=10s outerRange=2m0s ts=TimeUnix value=Value groupBy=[Attributes]
    Filter predicate=(MetricName = "http_requests_total")
      Scan(otel_metrics_sum)
```

After (inner widened to span `[ctx.start - sub.Range, ctx.end]`, OuterRange=7m → grid spans the outer eval window):

```text
RangeWindow func=avg_over_time range=2m0s step=30s outerRange=5m0s ts=anchor_ts value=Value groupBy=[Attributes] start=2026-01-01T00:00:00Z end=2026-01-01T00:05:00Z
  RangeWindow func=rate range=1m0s step=10s outerRange=7m0s ts=TimeUnix value=Value groupBy=[Attributes] start=2025-12-31T23:58:00Z end=2026-01-01T00:05:00Z
    Filter predicate=(MetricName = "http_requests_total")
      Scan(otel_metrics_sum)
```

Emitted SQL diff: inner `arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 10000000000), range(0, 13)))` → `arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(i * 10000000000), range(0, 43)))`.

## Test plan

- [x] Added TXTAR fixture `test/spec/promql/subquery_avg_over_time_rate.txtar` with `range_step: 30s`, deterministic counter-series seed, and a chDB roundtrip that returns 4 populated rows. Without the fix the fixture returned 1 row (collapsed to instant mode); with the fix it emits the expected 4-row matrix.
- [x] Re-ran every subquery-family TXTAR (`TestLower/subquery*` + `TestRoundTripChDB/subquery*` + `edge_max_over_time_subquery_step_default` + `edge_subquery_nested`) — all green, no tracked-file golden drift outside the new fixture (instant-mode paths untouched).
- [ ] Compatibility lane (auto-dispatch on merge to main) — should drop the `avg_over_time(rate(demo_cpu_usage_seconds_total[1m])[2m:10s])` diff to 12 diffs total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)