### PR TITLE
feat(promql): histogram_quantile native aggregated-input lowering (Phase 2)

### DIFF
--- a/docs/native-histogram-plan.md
+++ b/docs/native-histogram-plan.md
@@ -62,7 +62,7 @@ phase has a citable reference rather than rediscovering the design.
   - `edge_hq_native_p25.txtar` / `edge_hq_native_p999.txtar` (edge phi
     values).
 
-## Phase 2 (deferred) — aggregated-input native path
+## Phase 2 (shipped) — aggregated-input native path
 
 PromQL's canonical histogram idiom is
 `histogram_quantile(phi, sum by(le)(rate(<metric>[5m])))`. Cerberus's
@@ -72,37 +72,89 @@ classic-histogram path lowers this via `lowerHistogramQuantileAgg` /
 to `sumForEach(BucketCounts)` + `any(ExplicitBounds)` over a
 time-bounded Filter.
 
-For native histograms the same idiom needs:
+The native equivalent is harder because OTel exp-histogram rows carry
+variable-length / variable-offset / variable-scale bucket arrays —
+two series in the same aggregation group may differ along every
+axis. Phase 2 implements the full merge in `lowerHistogramQuantileNativeAgg`
+(`internal/promql/histogram_quantile.go`) as a two-layer chplan:
 
-- **`sumForEach` on PositiveBucketCounts.** The Positive\* arrays have
-  variable length (PositiveOffset shifts the bucket index per series),
-  so the lowering must align the offsets before element-wise sum. The
-  emitted SQL needs an `arrayMap` + `arrayResize` shape to pad
-  per-series arrays to a common offset, or
-  `arrayElement(PositiveBucketCounts, idx - PositiveOffset)`
-  expansion at quantile-walk time.
-- **Scale folding.** Two series in the same aggregation group may
-  carry different Scale values. The OTel spec says implementations
-  should re-bucket to the coarser scale before merging; PromQL
-  parity argues for matching Prom's native-histogram add-merge
-  behaviour (downscale to the minimum Scale across the group).
-- **ZeroCount + ZeroThreshold merging.** ZeroCount sums trivially;
-  ZeroThreshold takes the max across the group (the merged zero
-  bucket spans the largest individual zero bucket).
+- **Inner Aggregate**: groups by the user's `by/without` clause (after
+  dropping `le` — exp histograms have no `le` label) and collects per-row
+  bucket data into groupArrays plus min/max/sum aggregates of the
+  scalar fields:
 
-Routing in `lowerHistogramQuantile` dispatches to the Phase 2 stub
-`lowerHistogramQuantileNativeAgg`
-(`internal/promql/histogram_quantile.go`), which currently returns
-`"histogram_quantile over aggregated native (exp) histograms is not
-yet supported"` while citing this doc. Phase 2 fills the stub in
-mirroring `lowerHistogramQuantileAgg`'s shape (Filter + Aggregate +
-inner-Project + HistogramQuantileNative + Sample-row wrapping).
+  - `min(Scale) AS _hq_merged_scale` — the coarsest Scale across the
+    group, used as the merged distribution's target Scale.
+  - `sum(ZeroCount) AS ZeroCount` — trivially sums (the merged zero
+    bucket count is the sum of individual ZeroCounts).
+  - `max(ZeroThreshold) AS ZeroThreshold` — the merged zero bucket
+    spans the largest individual zero bucket.
+  - `groupArray({Scale, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts})`
+    — five aliases (`_hq_scales`, `_hq_pos_offsets`,
+    `_hq_pos_buckets`, `_hq_neg_offsets`, `_hq_neg_buckets`) carrying
+    per-row data through to the wrapping Project.
 
-Pinning regression: `TestLower_HistogramQuantile_OverAggregation_NativeRejected`
-(`internal/promql/histogram_quantile_test.go`) asserts the error
-message mentions native histograms **and** cites this doc. Phase 2
-deletes that test and adds the positive-shape mirror tests alongside
-the classic-agg lowering tests.
+- **Outer Project** (`expHistogramMergeOffsetExpr` +
+  `expHistogramMergeBucketsExpr` in `internal/promql/histogram_quantile.go`)
+  folds the groupArrays into a single merged distribution by:
+
+  - **Scale folding.** Per-row downscale to merged Scale via the
+    canonical "absolute bucket idx >> (origScale - targetScale)"
+    mapping (mirrors `model/histogram/float_histogram.go::targetIdx`
+    in the upstream Prom fork). Uniform-Scale groups (the common
+    case) collapse to identity since `delta = 0`.
+  - **Offset alignment + zero-pad.** Each row's downscaled bucket
+    array contributes to the merged array starting at
+    `PositiveOffset >> delta` (absolute bucket index at merged
+    scale); the merged array spans
+    `[arrayMin(downscaled_start), arrayMax(downscaled_end))` across
+    rows. Rows that don't cover the full range contribute 0 to the
+    uncovered positions (the per-target-bucket sum naturally yields
+    0 when no row contributes a value to that index).
+  - **Element-wise sum.** For each target absolute bucket index `T`
+    in the merged range, the merged bucket count is the sum over
+    rows of `arraySum(arrayMap(j -> if((off_i + j - 1) >> delta_i ==
+    T, arr_i[j], 0), arrayEnumerate(arr_i)))`.
+
+The merge expression is built from the typed chplan `Lambda` /
+`BareIdent` / `Subscript` Expr types introduced for this milestone
+(`internal/chplan/lambda.go`); the chsql emitter renders them as
+`(p1, p2) -> body` / `bare_ident` / `<container>[<key>]`
+respectively, with the lambda body composed of standard chplan
+`FuncCall` / `Binary` / `ColumnRef` / `LitInt` nodes that flow
+through the existing `Builder.Expr` dispatch.
+
+Test coverage (Phase 2):
+
+- Layer 2a (TXTAR + chplan + chDB roundtrip):
+  - `test/spec/promql/histogram_quantile_native_agg.txtar`
+    (`sum by(le)`, two series, uniform Scale).
+  - `test/spec/promql/histogram_quantile_native_agg_p50.txtar`
+    (p50 sanity).
+  - `test/spec/promql/histogram_quantile_native_agg_groupby.txtar`
+    (`sum by(le, service)`, multiple groups).
+  - `test/spec/promql/histogram_quantile_native_agg_mixed_scale.txtar`
+    (two series at different Scales — exercises the consolidation
+    path).
+- Layer 2b (chplan shape):
+  - `TestLower_HistogramQuantile_OverAggregation_Native`
+    (`internal/promql/histogram_quantile_test.go`) — pins the
+    Project / HistogramQuantileNative / Project / Aggregate / Filter
+    / Scan tree shape across `sum by`, `sum without`, bare `rate`,
+    and `increase`.
+  - `TestLower_HistogramQuantile_OverAggregation_Native_LeDropped` —
+    pins the `le`-drop rule on the native side.
+- Layer 6a (end-to-end chDB regression):
+  - `TestQuery_HistogramQuantileNativeAgg_ChDB`
+    (`internal/api/prom/handler_chdb_range_mode_test.go`) — uniform
+    Scale, asserts the interpolated value `~7.294`.
+  - `TestQuery_HistogramQuantileNativeAgg_MixedScale_ChDB` —
+    mixed-Scale merge, asserts the consolidated-then-interpolated
+    value `~3.801` against chDB.
+
+Phase 3 (range-mode) and Phase 4 (negative-side observations) remain
+deferred; the IR contract already carries the columns each phase
+needs.
 
 ## Phase 3 (deferred) — range-mode (per-step anchor grid)
 
@@ -173,13 +225,13 @@ Operators that follow a different convention override the suffix via
 
 ## Test coverage map
 
-| Layer | Path                                                                | Phase 1 | Phase 2 | Phase 3 | Phase 4 |
-| ----- | ------------------------------------------------------------------- | ------- | ------- | ------- | ------- |
-| 2a    | `test/spec/promql/histogram_quantile_native_*.txtar` (chplan + SQL) | yes     | TBD     | TBD     | TBD     |
-| 2b    | `internal/promql/histogram_quantile_native_test.go` (lowering)      | yes     | TBD     | TBD     | n/a     |
-| 3     | `internal/chplan/equal_invariants_test.go` (IR Equal)               | yes     | reuses  | reuses  | reuses  |
-| 5     | `internal/chsql/histogram_quantile_native_test.go` (emitter shape)  | yes     | TBD     | TBD     | TBD     |
-| 6a    | TXTAR `-- seed --` / `-- expected_rows --` chDB roundtrip           | yes     | TBD     | TBD     | TBD     |
+| Layer | Path                                                                              | Phase 1 | Phase 2 | Phase 3 | Phase 4 |
+| ----- | --------------------------------------------------------------------------------- | ------- | ------- | ------- | ------- |
+| 2a    | `test/spec/promql/histogram_quantile_native{,_agg}*.txtar` (chplan + SQL)         | yes     | yes     | TBD     | TBD     |
+| 2b    | `internal/promql/histogram_quantile_{native,}_test.go` (lowering)                 | yes     | yes     | TBD     | n/a     |
+| 3     | `internal/chplan/equal_invariants_test.go` (IR Equal)                             | yes     | reuses  | reuses  | reuses  |
+| 5     | `internal/chsql/histogram_quantile_native_test.go` (emitter shape)                | yes     | reuses  | TBD     | TBD     |
+| 6a    | TXTAR `-- seed --` / `-- expected_rows --` chDB roundtrip + `handler_chdb_*_test` | yes     | yes     | TBD     | TBD     |
 
 Each subsequent phase opens its own PR; the box above tracks which
 layers gain coverage. The Layer 6a roundtrip is the strongest signal

--- a/internal/api/prom/handler_chdb_range_mode_test.go
+++ b/internal/api/prom/handler_chdb_range_mode_test.go
@@ -1082,6 +1082,161 @@ func TestQueryRange_RangeMode_HistogramQuantileClassic_ChDB(t *testing.T) {
 	}
 }
 
+// expHistogramDDL is the OTel-CH exp-histogram-shaped table the
+// chDB-backed Phase-2 native-aggregated regression tests seed before
+// exercising `histogram_quantile(phi, sum by(le)(rate(<exp_hist>[r])))`.
+// Mirrors `histogramDDL`'s minimal-but-MergeTree shape so the chsql
+// emitter's PREWHERE promotion path runs end-to-end against ClickHouse
+// semantics (Memory engine rejects PREWHERE).
+const expHistogramDDL = `CREATE TABLE otel_metrics_exp_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Scale Int32,
+    ZeroCount UInt64,
+    ZeroThreshold Float64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree() ORDER BY (MetricName, TimeUnix);`
+
+// TestQuery_HistogramQuantileNativeAgg_ChDB pins
+// `histogram_quantile(phi, sum by(le)(rate(<sel>_exp_hist[r])))` over
+// `/api/v1/query` against the OTel-CH exp-histogram table. Phase 2 of
+// docs/native-histogram-plan.md replaced the stub-rejection error with
+// a real lowering: an aggregate that collects per-row exp-histogram
+// fields into groupArrays + a wrapping Project that does the
+// scale-fold + offset-align + zero-pad + element-wise sum, before
+// HistogramQuantileNative walks the merged distribution.
+//
+// Seed: two series sharing Scale=0 with parallel positive bucket
+// arrays [1,2,3] and [3,4,3], both at PositiveOffset=0 → merged
+// distribution [4, 6, 6] (total 16). For phi=0.95 the cum array
+// (prefixed with ZeroCount=0) is [0, 4, 10, 16]; the target value
+// 0.95 * 16 = 15.2 lands in the third positive bucket, log-linear
+// interpolation yields 2^(0 + 2 + (15.2-10)/(16-10)) ≈ 7.2938.
+//
+// Range-mode (`/api/v1/query_range`) for the native path collapses to
+// instant-mode behaviour until Phase 3 wires the per-step anchor
+// grid; the instant endpoint is the meaningful Phase 2 contract.
+func TestQuery_HistogramQuantileNativeAgg_ChDB(t *testing.T) {
+	evalTS := time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+	seedTS := evalTS.Add(-time.Second).Format("2006-01-02 15:04:05.000000000")
+	seed := expHistogramDDL + fmt.Sprintf(`
+INSERT INTO otel_metrics_exp_histogram VALUES
+    ('http_server_duration_exp_hist', map('service', 'api'), toDateTime64('%s', 9), 0, 0, 0.0, 0, [1, 2, 3], 0, []),
+    ('http_server_duration_exp_hist', map('service', 'web'), toDateTime64('%s', 9), 0, 0, 0.0, 0, [3, 4, 3], 0, []);`,
+		seedTS, seedTS)
+	srv, _ := newChDBServer(t, seed)
+
+	q := "histogram_quantile(0.95, sum by(le)(rate(http_server_duration_exp_hist[5m])))"
+	reqURL := fmt.Sprintf("%s/api/v1/query?query=%s&time=%d",
+		srv.URL, url.QueryEscape(q), evalTS.Unix())
+	resp, err := http.Get(reqURL)
+	if err != nil {
+		t.Fatalf("GET %s: %v", reqURL, err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	var parsed queryResponse
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v\nbody=%s", err, body)
+	}
+	if parsed.Status != "success" {
+		t.Fatalf("status: got %q (errorType=%q error=%q), want success",
+			parsed.Status, parsed.ErrorType, parsed.Error)
+	}
+	if parsed.Data.ResultType != "vector" {
+		t.Fatalf("resultType: got %q, want vector", parsed.Data.ResultType)
+	}
+	rawResult, _ := json.Marshal(parsed.Data.Result)
+	var vec []prom.VectorSample
+	if err := json.Unmarshal(rawResult, &vec); err != nil {
+		t.Fatalf("decode vector: %v (raw=%s)", err, rawResult)
+	}
+	// `sum by(le)(...)` collapses to a single group after dropping `le`
+	// (cerberus's exp histograms have no per-bucket `le` label — the
+	// bucket distribution lives in PositiveBucketCounts arrays).
+	if len(vec) != 1 {
+		t.Fatalf("expected exactly 1 series (sum by(le) collapses to a single group), got %d: %+v",
+			len(vec), vec)
+	}
+	gotValue, _ := strconv.ParseFloat(fmt.Sprintf("%v", vec[0].Value[1]), 64)
+	// 2^(0 + 2 + (15.2-10)/(16-10)) = 2^(2.866…) ≈ 7.29378.
+	const wantValue = 7.293779908465734
+	const epsilon = 1e-9
+	if got, want := gotValue, wantValue; got < want-epsilon || got > want+epsilon {
+		t.Errorf("histogram_quantile value: got %v, want %v (±%v)", got, want, epsilon)
+	}
+}
+
+// TestQuery_HistogramQuantileNativeAgg_MixedScale_ChDB pins the
+// scale-fold half of Phase 2: two series with different Scales merge
+// by downscaling the finer one to the coarser one before offset
+// alignment + element-wise sum. The merge mirrors Prometheus's
+// FloatHistogram.Add semantics (model/histogram/float_histogram.go:
+// reduceResolution + addBuckets).
+//
+// Seed: "fine" Scale=1, off=0, buckets=[1,2,3,4] (4 buckets at S=1).
+//       "coarse" Scale=0, off=0, buckets=[5,10] (2 buckets at S=0).
+// Downscale "fine" to S=0 via `targetIdx`: abs idx 0,1,2,3 at S=1 →
+//   abs idx 0,0,1,1 at S=0 → consolidated buckets [1+2, 3+4] = [3,7].
+// Merged at S=0: [3+5, 7+10] = [8, 17] at off=0; total = 25.
+// For phi=0.95: target = 23.75; cum = [0, 8, 25]; idx where cum >=
+// 23.75 is 3 → second positive bucket. value = 2^(0 + 1 + (23.75-8)/(25-8))
+// = 2^(1.9265) ≈ 3.80124.
+func TestQuery_HistogramQuantileNativeAgg_MixedScale_ChDB(t *testing.T) {
+	evalTS := time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+	seedTS := evalTS.Add(-time.Second).Format("2006-01-02 15:04:05.000000000")
+	seed := expHistogramDDL + fmt.Sprintf(`
+INSERT INTO otel_metrics_exp_histogram VALUES
+    ('http_server_duration_exp_hist', map('series', 'fine'),   toDateTime64('%s', 9), 1, 0, 0.0, 0, [1, 2, 3, 4], 0, []),
+    ('http_server_duration_exp_hist', map('series', 'coarse'), toDateTime64('%s', 9), 0, 0, 0.0, 0, [5, 10],       0, []);`,
+		seedTS, seedTS)
+	srv, _ := newChDBServer(t, seed)
+
+	q := "histogram_quantile(0.95, sum by(le)(rate(http_server_duration_exp_hist[5m])))"
+	reqURL := fmt.Sprintf("%s/api/v1/query?query=%s&time=%d",
+		srv.URL, url.QueryEscape(q), evalTS.Unix())
+	resp, err := http.Get(reqURL)
+	if err != nil {
+		t.Fatalf("GET %s: %v", reqURL, err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	var parsed queryResponse
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v\nbody=%s", err, body)
+	}
+	if parsed.Status != "success" {
+		t.Fatalf("status: got %q (errorType=%q error=%q), want success",
+			parsed.Status, parsed.ErrorType, parsed.Error)
+	}
+	if parsed.Data.ResultType != "vector" {
+		t.Fatalf("resultType: got %q, want vector", parsed.Data.ResultType)
+	}
+	rawResult, _ := json.Marshal(parsed.Data.Result)
+	var vec []prom.VectorSample
+	if err := json.Unmarshal(rawResult, &vec); err != nil {
+		t.Fatalf("decode vector: %v (raw=%s)", err, rawResult)
+	}
+	if len(vec) != 1 {
+		t.Fatalf("expected exactly 1 series, got %d: %+v", len(vec), vec)
+	}
+	gotValue, _ := strconv.ParseFloat(fmt.Sprintf("%v", vec[0].Value[1]), 64)
+	// 2^(0 + 1 + (23.75-8)/(25-8)) = 2^1.9265… ≈ 3.80124.
+	const wantValue = 3.801241244429467
+	const epsilon = 1e-9
+	if got, want := gotValue, wantValue; got < want-epsilon || got > want+epsilon {
+		t.Errorf("histogram_quantile value: got %v, want %v (±%v)", got, want, epsilon)
+	}
+}
+
 // TestQueryRange_RangeMode_VVOnCompare_ChDB pins the bare V-V
 // `on(...)` comparison binop family (==, !=, <, >, <=, >=) under
 // `/api/v1/query_range` — the no-`bool`-modifier sibling of

--- a/internal/chplan/lambda.go
+++ b/internal/chplan/lambda.go
@@ -1,0 +1,89 @@
+package chplan
+
+// Lambda is a ClickHouse-style lambda expression — `(p1, p2, ...) -> <body>`
+// — used inside higher-order array functions (`arrayMap`, `arrayFilter`,
+// `arrayFold`, …). Params is the parameter-name list; Body is the
+// expression evaluated for each input tuple.
+//
+// Lambdas are rendered as bare lambdas (no `function` keyword); the
+// emitter writes single-parameter shapes as `p -> body` (no parens)
+// and multi-parameter shapes as `(p1, p2) -> body` (with parens) to
+// match CH's conventional rendering for the two cases.
+//
+// Parameter names follow the BareIdent trust contract — must be a
+// CH-safe bare identifier `[a-zA-Z_][a-zA-Z0-9_]*`; the caller is
+// responsible for ensuring it. Use BareIdent inside the body to
+// reference parameter names without going through Ident's backtick
+// quoting (which would render `s` as “ `s` “ and bind to a
+// non-existent column).
+type Lambda struct {
+	Params []string
+	Body   Expr
+}
+
+func (*Lambda) exprNode() {}
+
+func (l *Lambda) Equal(other Expr) bool {
+	o, ok := other.(*Lambda)
+	if !ok || len(l.Params) != len(o.Params) {
+		return false
+	}
+	for i := range l.Params {
+		if l.Params[i] != o.Params[i] {
+			return false
+		}
+	}
+	if l.Body == nil || o.Body == nil {
+		return l.Body == o.Body
+	}
+	return l.Body.Equal(o.Body)
+}
+
+// BareIdent is an unquoted identifier reference — emitted verbatim by
+// the chsql expression renderer. Used inside Lambda bodies to refer to
+// the lambda's parameter names without going through ColumnRef's
+// backtick quoting (which would treat the param as a column lookup).
+//
+// The trust contract matches chsql.BareIdent: Name MUST be a CH-safe
+// bare identifier `[a-zA-Z_][a-zA-Z0-9_]*`. The caller is responsible
+// for ensuring it.
+type BareIdent struct {
+	Name string
+}
+
+func (*BareIdent) exprNode() {}
+
+func (b *BareIdent) Equal(other Expr) bool {
+	o, ok := other.(*BareIdent)
+	return ok && b.Name == o.Name
+}
+
+// Subscript is the array / map element-access shape — `<container>[<key>]`.
+// Both Container and Key are arbitrary expressions; the emitter renders
+// `<container>[<key>]` with no spaces. Used by the exp-histogram merge
+// to read individual elements out of a groupArray-of-arrays (e.g.
+// `_hq_pos_buckets[i]` for the i-th per-row bucket array).
+type Subscript struct {
+	Container Expr
+	Key       Expr
+}
+
+func (*Subscript) exprNode() {}
+
+func (s *Subscript) Equal(other Expr) bool {
+	o, ok := other.(*Subscript)
+	if !ok {
+		return false
+	}
+	if s.Container == nil || o.Container == nil {
+		if s.Container != o.Container {
+			return false
+		}
+	} else if !s.Container.Equal(o.Container) {
+		return false
+	}
+	if s.Key == nil || o.Key == nil {
+		return s.Key == o.Key
+	}
+	return s.Key.Equal(o.Key)
+}

--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -301,9 +301,64 @@ func (b *Builder) Expr(x chplan.Expr) error {
 		return b.exprFieldAccess(v)
 	case *chplan.NestedArrayExists:
 		return b.exprNestedArrayExists(v)
+	case *chplan.Lambda:
+		return b.exprLambda(v)
+	case *chplan.BareIdent:
+		b.sb.WriteString(v.Name)
+		return nil
+	case *chplan.Subscript:
+		return b.exprSubscript(v)
 	default:
 		return fmt.Errorf("%w: expr %T", ErrUnsupported, x)
 	}
+}
+
+// exprLambda renders chplan.Lambda. Single-parameter shapes render as
+// `p -> body` (no parens); multi-parameter shapes render as
+// `(p1, p2, …) -> body` (with parens) to match CH's conventional
+// lambda forms across the array-function family.
+func (b *Builder) exprLambda(l *chplan.Lambda) error {
+	if len(l.Params) == 0 {
+		return fmt.Errorf("%w: chplan.Lambda requires at least one parameter", ErrUnsupported)
+	}
+	if len(l.Params) == 1 {
+		b.sb.WriteString(l.Params[0])
+	} else {
+		b.sb.WriteByte('(')
+		for i, p := range l.Params {
+			if i > 0 {
+				b.sb.WriteString(", ")
+			}
+			b.sb.WriteString(p)
+		}
+		b.sb.WriteByte(')')
+	}
+	b.sb.WriteString(" -> ")
+	if l.Body == nil {
+		return fmt.Errorf("%w: chplan.Lambda has nil Body", ErrUnsupported)
+	}
+	return b.Expr(l.Body)
+}
+
+// exprSubscript renders `<container>[<key>]`. No surrounding whitespace.
+// Used by the exp-histogram aggregate-merge path to index into
+// groupArray-collected per-row arrays.
+func (b *Builder) exprSubscript(s *chplan.Subscript) error {
+	if s.Container == nil {
+		return fmt.Errorf("%w: chplan.Subscript has nil Container", ErrUnsupported)
+	}
+	if err := b.Expr(s.Container); err != nil {
+		return err
+	}
+	b.sb.WriteByte('[')
+	if s.Key == nil {
+		return fmt.Errorf("%w: chplan.Subscript has nil Key", ErrUnsupported)
+	}
+	if err := b.Expr(s.Key); err != nil {
+		return err
+	}
+	b.sb.WriteByte(']')
+	return nil
 }
 
 // exprNestedArrayExists renders

--- a/internal/promql/histogram_quantile.go
+++ b/internal/promql/histogram_quantile.go
@@ -529,25 +529,451 @@ func lowerHistogramQuantileNative(vs *parser.VectorSelector, phi float64, s sche
 	}, nil
 }
 
-// lowerHistogramQuantileNativeAgg is the Phase 2 placeholder for the
-// aggregated-input native (exp) histogram path:
-// `histogram_quantile(phi, sum [by/without] (rate(<sel>_exp_hist[r])))`.
+// Aliases used by lowerHistogramQuantileNativeAgg to thread per-row
+// exp-histogram fields through the Aggregate → Project stack. The
+// `_hq_` prefix avoids collision with user-supplied labels (Prom's
+// `__name__` is reserved; cerberus's gkey aliases use `gkey_<n>`;
+// nothing else writes `_hq_*` columns).
+const (
+	hqAggMergedScaleAlias     = "_hq_merged_scale"
+	hqAggScalesArrayAlias     = "_hq_scales"
+	hqAggPosOffsetsArrayAlias = "_hq_pos_offsets"
+	hqAggPosBucketsArrayAlias = "_hq_pos_buckets"
+	hqAggNegOffsetsArrayAlias = "_hq_neg_offsets"
+	hqAggNegBucketsArrayAlias = "_hq_neg_buckets"
+)
+
+// lowerHistogramQuantileNativeAgg builds the chplan tree for
+// `histogram_quantile(phi, sum [by/without] (rate(<sel>_exp_hist[range])))`
+// against the OTel-CH exponential (native) histogram table.
 //
-// The classic-histogram sibling (lowerHistogramQuantileAgg) rewrites
-// the inner chain to sumForEach(BucketCounts) + any(ExplicitBounds)
-// over a time-bounded Filter. The native equivalent needs to align
-// per-series PositiveOffset values before element-wise summing
-// PositiveBucketCounts, downscale series whose Scale differs from the
-// group minimum, sum ZeroCount, and max-merge ZeroThreshold. None of
-// those operations have a single CH primitive, so the lowering needs
-// careful design — see docs/native-histogram-plan.md § Phase 2.
+// The shape of the produced tree mirrors lowerHistogramQuantileAgg's
+// classic-histogram counterpart, but the inner Project does the
+// per-row exp-histogram merge (scale-fold + offset-align + zero-pad)
+// before HistogramQuantileNative walks the merged distribution:
 //
-// Pinned by TestLower_HistogramQuantile_OverAggregation_NativeRejected
-// (internal/promql/histogram_quantile_test.go); Phase 2 deletes the
-// rejection test and adds the positive-shape mirror tests alongside
-// the classic-agg lowering tests.
-func lowerHistogramQuantileNativeAgg(_ histogramAggShape, _ float64, _ schema.Metrics, _ lowerCtx) (chplan.Node, error) {
-	return nil, fmt.Errorf("promql: histogram_quantile over aggregated native (exp) histograms is not yet supported (see docs/native-histogram-plan.md § Phase 2)")
+//	Project [Sample-row contract]
+//	  HistogramQuantileNative phi=phi, groupBy=[Attributes]
+//	    Project [Attributes (rebuilt from gkeys), Scale, ZeroCount, ZeroThreshold,
+//	             PositiveOffset, PositiveBucketCounts,
+//	             NegativeOffset, NegativeBucketCounts]
+//	      Aggregate groupBy=[<user labels>] funcs=[
+//	          min(Scale)                       AS _hq_merged_scale,
+//	          sum(ZeroCount)                   AS ZeroCount,
+//	          max(ZeroThreshold)               AS ZeroThreshold,
+//	          groupArray(Scale)                AS _hq_scales,
+//	          groupArray(PositiveOffset)       AS _hq_pos_offsets,
+//	          groupArray(PositiveBucketCounts) AS _hq_pos_buckets,
+//	          groupArray(NegativeOffset)       AS _hq_neg_offsets,
+//	          groupArray(NegativeBucketCounts) AS _hq_neg_buckets,
+//	      ]
+//	        Filter <metric matchers> AND TimeUnix in (anchor-Range, anchor]
+//	          Scan(otel_metrics_exp_histogram)
+//
+// The merge algorithm in the inner Project (see
+// expHistogramMergeOffsetExpr + expHistogramMergeBucketsExpr) mirrors
+// Prometheus's FloatHistogram.Add semantics:
+//
+//   - Scale folding: per-row downscale to min(Scale) via the canonical
+//     "absolute bucket idx >> (origScale - targetScale)" mapping
+//     (model/histogram/float_histogram.go § targetIdx). Uniform-Scale
+//     groups (the common case) collapse to identity since delta = 0.
+//
+//   - Offset alignment: each row's downscaled bucket array contributes
+//     to the merged array starting at "PositiveOffset >> delta"
+//     (absolute bucket index at merged scale). The merged array spans
+//     [arrayMin(downscaled_offset), arrayMax(downscaled_offset+downscaled_length))
+//     across rows, zero-padding rows that don't cover the full range.
+//
+//   - ZeroCount sums trivially; ZeroThreshold takes the max across
+//     rows (the merged zero bucket spans the largest individual zero
+//     bucket).
+//
+// The `le` label is silently dropped from any user-supplied `by(...)`
+// grouping on the native path too (cerberus's exp histograms never
+// carry an `le` label — the bucket distribution lives in the
+// PositiveBucketCounts array with PositiveOffset shifting the
+// starting absolute index per series). Mirrors classic-agg's behaviour.
+func lowerHistogramQuantileNativeAgg(shape histogramAggShape, phi float64, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	vs := shape.selector
+
+	// Build the Scan + Filter. Same shape as the classic-agg path: the
+	// metric-name + label matchers go through buildPredicate; the
+	// rate's [range] adds the time-bound window.
+	scan := &chplan.Scan{Table: s.ExpHistogramTable}
+	pred := buildPredicate(vs.LabelMatchers, s)
+
+	anchor, err := anchorFromSelector(vs, ctx)
+	if err != nil {
+		return nil, err
+	}
+	if anchor.End.IsZero() && !ctx.end.IsZero() {
+		anchor.End = ctx.end.UTC()
+	}
+	pred = andExpr(pred, timeBoundExpr(s.TimestampColumn, anchor))
+	if shape.windowRange > 0 {
+		pred = andExpr(pred, stalenessLowerBoundExpr(s.TimestampColumn, anchor, shape.windowRange))
+	}
+
+	var input chplan.Node = scan
+	if pred != nil {
+		input = &chplan.Filter{Input: scan, Predicate: pred}
+	}
+
+	// Aggregate: collect per-row exp-histogram fields into groupArrays so
+	// the wrapping Project can fold them into a single merged distribution.
+	// The simple aggregates (min Scale, sum ZeroCount, max ZeroThreshold)
+	// land on the same aggregate so the wrapping Project can refer to
+	// them by alias.
+	groupBy, groupByAliases, attrsRebuild := histogramAggGroupBy(shape.agg, s)
+	aggFuncs := []chplan.AggFunc{
+		{Name: "min", Args: []chplan.Expr{&chplan.ColumnRef{Name: s.ScaleColumn}}, Alias: hqAggMergedScaleAlias},
+		{Name: "sum", Args: []chplan.Expr{&chplan.ColumnRef{Name: s.ZeroCountColumn}}, Alias: s.ZeroCountColumn},
+		{Name: "max", Args: []chplan.Expr{&chplan.ColumnRef{Name: s.ZeroThresholdColumn}}, Alias: s.ZeroThresholdColumn},
+		{Name: "groupArray", Args: []chplan.Expr{&chplan.ColumnRef{Name: s.ScaleColumn}}, Alias: hqAggScalesArrayAlias},
+		{Name: "groupArray", Args: []chplan.Expr{&chplan.ColumnRef{Name: s.PositiveOffsetColumn}}, Alias: hqAggPosOffsetsArrayAlias},
+		{Name: "groupArray", Args: []chplan.Expr{&chplan.ColumnRef{Name: s.PositiveBucketCountsColumn}}, Alias: hqAggPosBucketsArrayAlias},
+		{Name: "groupArray", Args: []chplan.Expr{&chplan.ColumnRef{Name: s.NegativeOffsetColumn}}, Alias: hqAggNegOffsetsArrayAlias},
+		{Name: "groupArray", Args: []chplan.Expr{&chplan.ColumnRef{Name: s.NegativeBucketCountsColumn}}, Alias: hqAggNegBucketsArrayAlias},
+	}
+	agg := &chplan.Aggregate{
+		Input:              input,
+		GroupBy:            groupBy,
+		GroupByAliases:     groupByAliases,
+		AggFuncs:           aggFuncs,
+		DropEmptyOnNoGroup: true,
+	}
+
+	// Inner Project re-shapes the aggregate output into the exp-histogram
+	// row contract HistogramQuantileNative expects: Attributes (rebuilt
+	// from gkeys) + the merged Scale / ZeroCount / ZeroThreshold +
+	// the folded {Positive,Negative}{Offset,BucketCounts}.
+	rebuilt := &chplan.Project{
+		Input: agg,
+		Projections: []chplan.Projection{
+			{Expr: attrsRebuild, Alias: s.AttributesColumn},
+			{Expr: &chplan.ColumnRef{Name: hqAggMergedScaleAlias}, Alias: s.ScaleColumn},
+			{Expr: &chplan.ColumnRef{Name: s.ZeroCountColumn}, Alias: s.ZeroCountColumn},
+			{Expr: &chplan.ColumnRef{Name: s.ZeroThresholdColumn}, Alias: s.ZeroThresholdColumn},
+			{Expr: expHistogramMergeOffsetExpr(hqAggPosOffsetsArrayAlias, hqAggScalesArrayAlias, hqAggMergedScaleAlias), Alias: s.PositiveOffsetColumn},
+			{Expr: expHistogramMergeBucketsExpr(hqAggPosOffsetsArrayAlias, hqAggPosBucketsArrayAlias, hqAggScalesArrayAlias, hqAggMergedScaleAlias), Alias: s.PositiveBucketCountsColumn},
+			{Expr: expHistogramMergeOffsetExpr(hqAggNegOffsetsArrayAlias, hqAggScalesArrayAlias, hqAggMergedScaleAlias), Alias: s.NegativeOffsetColumn},
+			{Expr: expHistogramMergeBucketsExpr(hqAggNegOffsetsArrayAlias, hqAggNegBucketsArrayAlias, hqAggScalesArrayAlias, hqAggMergedScaleAlias), Alias: s.NegativeBucketCountsColumn},
+		},
+	}
+
+	hq := &chplan.HistogramQuantileNative{
+		Input:                      rebuilt,
+		Phi:                        phi,
+		ScaleColumn:                s.ScaleColumn,
+		ZeroCountColumn:            s.ZeroCountColumn,
+		ZeroThresholdColumn:        s.ZeroThresholdColumn,
+		PositiveOffsetColumn:       s.PositiveOffsetColumn,
+		PositiveBucketCountsColumn: s.PositiveBucketCountsColumn,
+		NegativeOffsetColumn:       s.NegativeOffsetColumn,
+		NegativeBucketCountsColumn: s.NegativeBucketCountsColumn,
+		GroupBy: []chplan.Expr{
+			&chplan.ColumnRef{Name: s.AttributesColumn},
+		},
+		GroupByAliases:   []string{s.AttributesColumn},
+		MetricNameColumn: s.MetricNameColumn,
+		AttributesColumn: s.AttributesColumn,
+		TimestampColumn:  s.TimestampColumn,
+	}
+
+	// Final Sample-row wrapping, same as the bare-selector / classic-agg paths.
+	return &chplan.Project{
+		Input: hq,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.LitString{V: ""}, Alias: s.MetricNameColumn},
+			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
+			{Expr: &chplan.FuncCall{Name: "now64", Args: []chplan.Expr{&chplan.LitInt{V: 9}}}, Alias: s.TimestampColumn},
+			{Expr: &chplan.ColumnRef{Name: s.ValueColumn}, Alias: s.ValueColumn},
+		},
+	}, nil
+}
+
+// expHistogramMergeOffsetExpr renders the merged PositiveOffset (or
+// NegativeOffset) for a group of native-histogram rows: the minimum of
+// per-row downscaled-to-merged-scale offsets.
+//
+// Emitted CH expression:
+//
+//	arrayMin(arrayMap((s, off) -> bitShiftRight(off, s - <mergedScale>),
+//	                   <scalesArr>, <offArr>))
+//
+// CH's bitShiftRight on signed Int32 performs arithmetic right shift,
+// matching Prometheus's "(idx >> delta)" semantics for negative bucket
+// indices (sub-1 latencies). When all rows share Scale the delta is 0
+// for every row, so the shift is identity and the merged offset
+// reduces to arrayMin(offArr) — identical to classic-histogram
+// min-offset semantics.
+func expHistogramMergeOffsetExpr(offArrAlias, scalesArrAlias, mergedScaleAlias string) chplan.Expr {
+	return &chplan.FuncCall{
+		Name: "arrayMin",
+		Args: []chplan.Expr{
+			&chplan.FuncCall{
+				Name: "arrayMap",
+				Args: []chplan.Expr{
+					&chplan.Lambda{
+						Params: []string{"s", "off"},
+						Body: &chplan.FuncCall{
+							Name: "bitShiftRight",
+							Args: []chplan.Expr{
+								&chplan.BareIdent{Name: "off"},
+								&chplan.Binary{
+									Op:    chplan.OpSub,
+									Left:  &chplan.BareIdent{Name: "s"},
+									Right: &chplan.ColumnRef{Name: mergedScaleAlias},
+								},
+							},
+						},
+					},
+					&chplan.ColumnRef{Name: scalesArrAlias},
+					&chplan.ColumnRef{Name: offArrAlias},
+				},
+			},
+		},
+	}
+}
+
+// expHistogramMergeBucketsExpr renders the merged PositiveBucketCounts
+// (or NegativeBucketCounts) for a group of native-histogram rows: a
+// scale-folded, offset-aligned, zero-padded, element-wise sum.
+//
+// Algorithm: for each target absolute bucket index `T` in
+// [merged_offset, merged_offset + merged_length), the merged value is
+//
+//	Σ_{row i} arraySum(arrayMap(j ->
+//	    if((off_i + j - 1) >> delta_i == T, arr_i[j], 0),
+//	    arrayEnumerate(arr_i)))
+//
+// where delta_i = scales_arr[i] - merged_scale (per-row downscale
+// distance), j is 1-based (array position inside row i's bucket
+// array), and (off_i + j - 1) is the absolute bucket index of position
+// j at row i's original scale.
+//
+// merged_length is computed as
+//
+//	max((off_i + length(arr_i) - 1) >> delta_i) -
+//	    min(off_i >> delta_i) + 1
+//
+// across rows. Rows with empty bucket arrays contribute zero to every
+// target position (no `j` in arrayEnumerate of empty array).
+func expHistogramMergeBucketsExpr(offArrAlias, bucArrAlias, scalesArrAlias, mergedScaleAlias string) chplan.Expr {
+	const paramT = "t"
+
+	mergedScale := &chplan.ColumnRef{Name: mergedScaleAlias}
+	scalesArr := &chplan.ColumnRef{Name: scalesArrAlias}
+	offArr := &chplan.ColumnRef{Name: offArrAlias}
+	bucArr := &chplan.ColumnRef{Name: bucArrAlias}
+
+	mergedStart, mergedLength := expHistogramMergeBucketsBoundsExpr(scalesArr, offArr, bucArr, mergedScale)
+	rowsSum := expHistogramMergeBucketsRowsSumExpr(scalesArr, offArr, bucArr, mergedScale, mergedStart, paramT)
+
+	// Outer: arrayMap(t -> rowsSum, range(toUInt64(mergedLength))).
+	// `t` is 0-based; the inner expression reconstructs the absolute
+	// target index as mergedStart + t. CH's `range(N)` produces
+	// [0, N) over UInt64; toUInt64 keeps the cast explicit so the SQL
+	// parses cleanly even when mergedLength is computed from signed
+	// values.
+	return &chplan.FuncCall{
+		Name: "arrayMap",
+		Args: []chplan.Expr{
+			&chplan.Lambda{
+				Params: []string{paramT},
+				Body:   rowsSum,
+			},
+			&chplan.FuncCall{
+				Name: "range",
+				Args: []chplan.Expr{
+					&chplan.FuncCall{Name: "toUInt64", Args: []chplan.Expr{mergedLength}},
+				},
+			},
+		},
+	}
+}
+
+// expHistogramMergeBucketsBoundsExpr builds (mergedStart, mergedLength)
+// for the bucket-merge expression. Returned mergedStart is the
+// arrayMin of per-row downscaled offsets; mergedLength is
+// greatest(0, mergedEnd - mergedStart + 1), clamped so an all-empty
+// group produces a zero-length output array.
+func expHistogramMergeBucketsBoundsExpr(scalesArr, offArr, bucArr, mergedScale chplan.Expr) (mergedStart, mergedLength chplan.Expr) {
+	const (
+		paramScalesInner = "sm"
+		paramOffInner    = "om"
+		paramArrInner    = "am"
+	)
+
+	// per-row downscaled start: arrayMap((sm, om) -> bitShiftRight(om, sm - merged_scale), scalesArr, offArr)
+	downscaledStarts := &chplan.FuncCall{
+		Name: "arrayMap",
+		Args: []chplan.Expr{
+			&chplan.Lambda{
+				Params: []string{paramScalesInner, paramOffInner},
+				Body: &chplan.FuncCall{
+					Name: "bitShiftRight",
+					Args: []chplan.Expr{
+						&chplan.BareIdent{Name: paramOffInner},
+						&chplan.Binary{
+							Op:    chplan.OpSub,
+							Left:  &chplan.BareIdent{Name: paramScalesInner},
+							Right: mergedScale,
+						},
+					},
+				},
+			},
+			scalesArr,
+			offArr,
+		},
+	}
+
+	// per-row downscaled end: arrayMap((sm, om, am) -> bitShiftRight(om + length(am) - 1, sm - merged_scale), scalesArr, offArr, bucArr).
+	// Rows with empty arrays produce (om + 0 - 1) = om - 1 — slightly below their start, which is fine since they contribute nothing.
+	downscaledEnds := &chplan.FuncCall{
+		Name: "arrayMap",
+		Args: []chplan.Expr{
+			&chplan.Lambda{
+				Params: []string{paramScalesInner, paramOffInner, paramArrInner},
+				Body: &chplan.FuncCall{
+					Name: "bitShiftRight",
+					Args: []chplan.Expr{
+						&chplan.Binary{
+							Op:   chplan.OpAdd,
+							Left: &chplan.BareIdent{Name: paramOffInner},
+							Right: &chplan.Binary{
+								Op:    chplan.OpSub,
+								Left:  &chplan.FuncCall{Name: "length", Args: []chplan.Expr{&chplan.BareIdent{Name: paramArrInner}}},
+								Right: &chplan.LitInt{V: 1},
+							},
+						},
+						&chplan.Binary{
+							Op:    chplan.OpSub,
+							Left:  &chplan.BareIdent{Name: paramScalesInner},
+							Right: mergedScale,
+						},
+					},
+				},
+			},
+			scalesArr,
+			offArr,
+			bucArr,
+		},
+	}
+
+	mergedStart = &chplan.FuncCall{Name: "arrayMin", Args: []chplan.Expr{downscaledStarts}}
+	mergedEnd := &chplan.FuncCall{Name: "arrayMax", Args: []chplan.Expr{downscaledEnds}}
+	// merged_length = mergedEnd - mergedStart + 1.
+	// Guard the "no rows contribute" case by clamping to 0 via greatest(0, …).
+	mergedLength = &chplan.FuncCall{
+		Name: "greatest",
+		Args: []chplan.Expr{
+			&chplan.LitInt{V: 0},
+			&chplan.Binary{
+				Op: chplan.OpAdd,
+				Left: &chplan.Binary{
+					Op:    chplan.OpSub,
+					Left:  mergedEnd,
+					Right: mergedStart,
+				},
+				Right: &chplan.LitInt{V: 1},
+			},
+		},
+	}
+	return mergedStart, mergedLength
+}
+
+// expHistogramMergeBucketsRowsSumExpr builds the per-target-bucket
+// row-sum used inside the outer arrayMap. For target offset `t`
+// (0-based; absolute index = mergedStart + t), it sums every row's
+// contribution at that bucket: arraySum over rows of the inner
+// arraySum-of-arrayMap that picks bucket[j] when (off + j - 1) >>
+// (s - merged_scale) == mergedStart + t, else 0.
+func expHistogramMergeBucketsRowsSumExpr(scalesArr, offArr, bucArr, mergedScale, mergedStart chplan.Expr, paramT string) chplan.Expr {
+	const (
+		paramScale = "s"
+		paramOff   = "off"
+		paramArr   = "arr"
+		paramJ     = "j"
+	)
+
+	// Inner-most: for one (s, off, arr) tuple and target absolute index T,
+	// arraySum(arrayMap(j -> if(bitShiftRight(off + j - 1, s - merged_scale) = T, arr[j], 0), arrayEnumerate(arr))).
+	innerContrib := &chplan.FuncCall{
+		Name: "arraySum",
+		Args: []chplan.Expr{
+			&chplan.FuncCall{
+				Name: "arrayMap",
+				Args: []chplan.Expr{
+					&chplan.Lambda{
+						Params: []string{paramJ},
+						Body: &chplan.FuncCall{
+							Name: "if",
+							Args: []chplan.Expr{
+								&chplan.Binary{
+									Op: chplan.OpEq,
+									Left: &chplan.FuncCall{
+										Name: "bitShiftRight",
+										Args: []chplan.Expr{
+											&chplan.Binary{
+												Op:   chplan.OpAdd,
+												Left: &chplan.BareIdent{Name: paramOff},
+												Right: &chplan.Binary{
+													Op:    chplan.OpSub,
+													Left:  &chplan.BareIdent{Name: paramJ},
+													Right: &chplan.LitInt{V: 1},
+												},
+											},
+											&chplan.Binary{
+												Op:    chplan.OpSub,
+												Left:  &chplan.BareIdent{Name: paramScale},
+												Right: mergedScale,
+											},
+										},
+									},
+									// target absolute index = mergedStart + t (t is 0-based).
+									Right: &chplan.Binary{
+										Op:    chplan.OpAdd,
+										Left:  mergedStart,
+										Right: &chplan.BareIdent{Name: paramT},
+									},
+								},
+								&chplan.Subscript{
+									Container: &chplan.BareIdent{Name: paramArr},
+									Key:       &chplan.BareIdent{Name: paramJ},
+								},
+								&chplan.LitInt{V: 0},
+							},
+						},
+					},
+					&chplan.FuncCall{
+						Name: "arrayEnumerate",
+						Args: []chplan.Expr{&chplan.BareIdent{Name: paramArr}},
+					},
+				},
+			},
+		},
+	}
+
+	// Sum over rows. arraySum(arrayMap((s, off, arr) -> innerContrib, scalesArr, offArr, bucArr)).
+	return &chplan.FuncCall{
+		Name: "arraySum",
+		Args: []chplan.Expr{
+			&chplan.FuncCall{
+				Name: "arrayMap",
+				Args: []chplan.Expr{
+					&chplan.Lambda{
+						Params: []string{paramScale, paramOff, paramArr},
+						Body:   innerContrib,
+					},
+					scalesArr,
+					offArr,
+					bucArr,
+				},
+			},
+		},
+	}
 }
 
 // unwrapVectorSelector peels ParenExpr / StepInvariantExpr wrappers off

--- a/internal/promql/histogram_quantile_test.go
+++ b/internal/promql/histogram_quantile_test.go
@@ -264,13 +264,137 @@ func TestLower_HistogramQuantile_OverAggregation_LeDropped(t *testing.T) {
 	}
 }
 
-// TestLower_HistogramQuantile_OverAggregation_NativeRejected confirms
-// the aggregated-input path bails out on native (exp) histograms via
-// the Phase 2 stub (lowerHistogramQuantileNativeAgg). The native path's
-// bucket arithmetic differs enough that mirroring the classic-path
-// lowering is a separate milestone — see docs/native-histogram-plan.md
-// § Phase 2 for the deferred design.
-func TestLower_HistogramQuantile_OverAggregation_NativeRejected(t *testing.T) {
+// TestLower_HistogramQuantile_OverAggregation_Native pins the chplan
+// shape for `histogram_quantile(phi, sum by(...) (rate(<sel>_exp_hist[r])))`.
+// Phase 2 (docs/native-histogram-plan.md § Phase 2) replaced the
+// stub-rejection error with a real lowering that mirrors the classic
+// aggregated-input path but threads exp-histogram merge math through
+// the inner Project (scale-fold + offset-align + zero-pad + element-
+// wise sum). The lowering must:
+//
+//   - Produce a Project(HistogramQuantileNative(Project(Aggregate(Filter(Scan))))) tree.
+//   - Drop `le` from any by-clause (same rule as the classic native
+//     path — exp-histogram bucket data lives in PositiveBucketCounts,
+//     not as a per-bucket label).
+//   - Aggregate via min(Scale) + sum(ZeroCount) + max(ZeroThreshold)
+//   - groupArray of every per-row exp-histogram column.
+//   - Filter the Scan to the rate's time window.
+func TestLower_HistogramQuantile_OverAggregation_Native(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+
+	cases := []struct {
+		name    string
+		query   string
+		wantPhi float64
+	}{
+		{
+			name:    "sum by(le) over rate on exp_hist",
+			query:   `histogram_quantile(0.95, sum by(le) (rate(http_server_duration_exp_hist[5m])))`,
+			wantPhi: 0.95,
+		},
+		{
+			name:    "sum by(le, job) over rate on exp_hist",
+			query:   `histogram_quantile(0.99, sum by(le, job) (rate(http_server_duration_exp_hist[5m])))`,
+			wantPhi: 0.99,
+		},
+		{
+			name:    "sum without over rate on exp_hist",
+			query:   `histogram_quantile(0.5, sum without(instance) (rate(http_server_duration_exp_hist[5m])))`,
+			wantPhi: 0.5,
+		},
+		{
+			name:    "bare rate (no sum wrapper) on exp_hist",
+			query:   `histogram_quantile(0.5, rate(http_server_duration_exp_hist[5m]))`,
+			wantPhi: 0.5,
+		},
+		{
+			name:    "increase variant on exp_hist",
+			query:   `histogram_quantile(0.5, sum by(le) (increase(http_server_duration_exp_hist[10m])))`,
+			wantPhi: 0.5,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr: %v", err)
+			}
+			plan, err := promql.Lower(context.Background(), expr, s)
+			if err != nil {
+				t.Fatalf("Lower: %v", err)
+			}
+			pj, ok := plan.(*chplan.Project)
+			if !ok {
+				t.Fatalf("want top-level *chplan.Project, got %T", plan)
+			}
+			hq, ok := pj.Input.(*chplan.HistogramQuantileNative)
+			if !ok {
+				t.Fatalf("want Project.Input = *chplan.HistogramQuantileNative, got %T", pj.Input)
+			}
+			if hq.Phi != tc.wantPhi {
+				t.Errorf("Phi = %v, want %v", hq.Phi, tc.wantPhi)
+			}
+
+			var foundAgg *chplan.Aggregate
+			var foundScan *chplan.Scan
+			chplan.Walk(hq.Input, func(n chplan.Node) bool {
+				switch v := n.(type) {
+				case *chplan.Aggregate:
+					if foundAgg == nil {
+						foundAgg = v
+					}
+				case *chplan.Scan:
+					if foundScan == nil {
+						foundScan = v
+					}
+				}
+				return true
+			})
+			if foundAgg == nil {
+				t.Fatalf("expected an Aggregate node in the tree, found none")
+			}
+			if foundScan == nil {
+				t.Fatalf("expected a Scan node in the tree, found none")
+			}
+			if foundScan.Table != s.ExpHistogramTable {
+				t.Errorf("Scan.Table = %q, want %q", foundScan.Table, s.ExpHistogramTable)
+			}
+
+			// Validate the aggregate function set: min(Scale) +
+			// sum(ZeroCount) + max(ZeroThreshold) + groupArray of every
+			// per-row exp-histogram column.
+			if len(foundAgg.AggFuncs) != 8 {
+				t.Errorf("Aggregate.AggFuncs = %d funcs, want 8", len(foundAgg.AggFuncs))
+			}
+			want := map[string]bool{
+				"min": false, "sum": false, "max": false, "groupArray": false,
+			}
+			for _, af := range foundAgg.AggFuncs {
+				if _, ok := want[af.Name]; ok {
+					want[af.Name] = true
+				}
+			}
+			for name, seen := range want {
+				if !seen {
+					t.Errorf("Aggregate missing expected aggregator %q", name)
+				}
+			}
+		})
+	}
+}
+
+// TestLower_HistogramQuantile_OverAggregation_Native_LeDropped pins the
+// rule that `le` is silently dropped from `sum by(le)` clauses on the
+// native aggregated-input path too. Mirrors
+// TestLower_HistogramQuantile_OverAggregation_LeDropped on the classic
+// side: exp-histogram bucket distribution lives in
+// PositiveBucketCounts (offset by PositiveOffset), not as a per-bucket
+// label, so `sum by(le)` semantically collapses to a single group.
+func TestLower_HistogramQuantile_OverAggregation_Native_LeDropped(t *testing.T) {
 	t.Parallel()
 
 	s := schema.DefaultOTelMetrics()
@@ -280,17 +404,26 @@ func TestLower_HistogramQuantile_OverAggregation_NativeRejected(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseExpr: %v", err)
 	}
-	if _, err := promql.Lower(context.Background(), expr, s); err == nil {
-		t.Fatalf("expected error for aggregated native histogram, got nil")
-	} else {
-		if !strings.Contains(err.Error(), "native") {
-			t.Errorf("error %q should mention native histograms", err.Error())
+	plan, err := promql.Lower(context.Background(), expr, s)
+	if err != nil {
+		t.Fatalf("Lower: %v", err)
+	}
+	pj := plan.(*chplan.Project)
+	hq := pj.Input.(*chplan.HistogramQuantileNative)
+
+	var foundAgg *chplan.Aggregate
+	chplan.Walk(hq.Input, func(n chplan.Node) bool {
+		if v, ok := n.(*chplan.Aggregate); ok {
+			foundAgg = v
 		}
-		// The Phase 2 stub points readers at the deferred design doc so
-		// they can pick up the work without re-deriving the algorithm.
-		if !strings.Contains(err.Error(), "native-histogram-plan.md") {
-			t.Errorf("error %q should cite docs/native-histogram-plan.md", err.Error())
-		}
+		return true
+	})
+	if foundAgg == nil {
+		t.Fatalf("no Aggregate found")
+	}
+	if len(foundAgg.GroupBy) != 0 {
+		t.Errorf("Aggregate.GroupBy = %d expressions, want 0 (le must be dropped, no other labels)",
+			len(foundAgg.GroupBy))
 	}
 }
 

--- a/test/spec/chplan_print.go
+++ b/test/spec/chplan_print.go
@@ -362,6 +362,15 @@ func printExpr(e chplan.Expr) string {
 	case *chplan.NestedArrayExists:
 		return fmt.Sprintf("nestedArrayExists(%s.%s[%q] %s %s)",
 			v.Column, v.SubField, v.Key, v.Op, printExpr(v.Value))
+	case *chplan.Lambda:
+		if len(v.Params) == 1 {
+			return fmt.Sprintf("%s -> %s", v.Params[0], printExpr(v.Body))
+		}
+		return fmt.Sprintf("(%s) -> %s", strings.Join(v.Params, ", "), printExpr(v.Body))
+	case *chplan.BareIdent:
+		return v.Name
+	case *chplan.Subscript:
+		return fmt.Sprintf("%s[%s]", printExpr(v.Container), printExpr(v.Key))
 	default:
 		return fmt.Sprintf("<unknown:%T>", e)
 	}

--- a/test/spec/promql/histogram_quantile_native_agg.txtar
+++ b/test/spec/promql/histogram_quantile_native_agg.txtar
@@ -1,0 +1,51 @@
+-- query.promql --
+histogram_quantile(0.95, sum by(le)(rate(http_server_duration_exp_hist[5m])))
+-- seed --
+CREATE TABLE otel_metrics_exp_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Scale Int32,
+    ZeroCount UInt64,
+    ZeroThreshold Float64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_exp_histogram VALUES
+    ('http_server_duration_exp_hist', map('service', 'api'),  toDateTime64('2026-01-01 00:00:00', 9), 0, 0, 0.0, 0, [1, 2, 3], 0, []),
+    ('http_server_duration_exp_hist', map('service', 'web'),  toDateTime64('2026-01-01 00:00:00', 9), 0, 0, 0.0, 0, [3, 4, 3], 0, []);
+-- expected_rows --
+[
+  ["", {}, "2026-01-01T00:00:01Z", 7.293779908465734]
+]
+-- args --
+[0] string = ""
+[1] int64 = 9
+[2] string = "Map(String,String)"
+[3] int64 = 1
+[4] int64 = 0
+[5] int64 = 0
+[6] int64 = 1
+[7] int64 = 1
+[8] int64 = 1
+[9] int64 = 0
+[10] int64 = 0
+[11] int64 = 1
+[12] int64 = 1
+[13] string = "http_server_duration_exp_hist"
+[14] string = "2026-01-01 00:00:01.000000000"
+[15] int64 = 9
+[16] string = "2026-01-01 00:00:01.000000000"
+[17] int64 = 9
+[18] int64 = 300000000000
+-- chplan --
+Project ["" AS MetricName, Attributes AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+  HistogramQuantileNative phi=0.95 groupBy=[Attributes AS Attributes]
+    Project [CAST(map(), "Map(String,String)") AS Attributes, _hq_merged_scale AS Scale, ZeroCount AS ZeroCount, ZeroThreshold AS ZeroThreshold, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_pos_offsets)) AS PositiveOffset, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - 1)), (s - _hq_merged_scale)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets)) + t)), arr[j], 0), arrayEnumerate(arr))), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)), range(toUInt64(greatest(0, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets))) + 1))))) AS PositiveBucketCounts, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_neg_offsets)) AS NegativeOffset, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - 1)), (s - _hq_merged_scale)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets)) + t)), arr[j], 0), arrayEnumerate(arr))), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)), range(toUInt64(greatest(0, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets))) + 1))))) AS NegativeBucketCounts]
+      Aggregate groupBy=[] funcs=[min(Scale) AS _hq_merged_scale, sum(ZeroCount) AS ZeroCount, max(ZeroThreshold) AS ZeroThreshold, groupArray(Scale) AS _hq_scales, groupArray(PositiveOffset) AS _hq_pos_offsets, groupArray(PositiveBucketCounts) AS _hq_pos_buckets, groupArray(NegativeOffset) AS _hq_neg_offsets, groupArray(NegativeBucketCounts) AS _hq_neg_buckets]
+        Filter predicate=(((MetricName = "http_server_duration_exp_hist") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+          Scan(otel_metrics_exp_histogram)
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes` AS `Attributes`, if(arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[length(arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`)))] = 0, nan, if(0.95 <= 0, 0.0, if(0.95 >= 1, pow(pow(2, pow(2, -`Scale`)), `PositiveOffset` + length(`PositiveBucketCounts`)), if(arrayFirstIndex(c -> c >= (0.95 * arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[length(arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`)))]), arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))) = 1, `ZeroThreshold`, pow(pow(2, pow(2, -`Scale`)), `PositiveOffset` + (arrayFirstIndex(c -> c >= (0.95 * arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[length(arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`)))]), arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))) - 2) + ((0.95 * arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[length(arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`)))]) - arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[arrayFirstIndex(c -> c >= (0.95 * arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[length(arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`)))]), arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))) - 1]) / (arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[arrayFirstIndex(c -> c >= (0.95 * arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[length(arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`)))]), arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`)))] - arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[arrayFirstIndex(c -> c >= (0.95 * arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[length(arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`)))]), arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))) - 1])))))) AS `Value` FROM (SELECT CAST(map(), ?) AS `Attributes`, `_hq_merged_scale` AS `Scale`, `ZeroCount` AS `ZeroCount`, `ZeroThreshold` AS `ZeroThreshold`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`)) AS `PositiveOffset`, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - ?)), (s - `_hq_merged_scale`)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`)) + t)), arr[j], ?), arrayEnumerate(arr))), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)), range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`))) + ?))))) AS `PositiveBucketCounts`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`)) AS `NegativeOffset`, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - ?)), (s - `_hq_merged_scale`)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`)) + t)), arr[j], ?), arrayEnumerate(arr))), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)), range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`))) + ?))))) AS `NegativeBucketCounts` FROM (SELECT `_hq_merged_scale`, `ZeroCount`, `ZeroThreshold`, `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`, `_hq_neg_offsets`, `_hq_neg_buckets` FROM (SELECT min(`Scale`) AS `_hq_merged_scale`, sum(`ZeroCount`) AS `ZeroCount`, max(`ZeroThreshold`) AS `ZeroThreshold`, groupArray(`Scale`) AS `_hq_scales`, groupArray(`PositiveOffset`) AS `_hq_pos_offsets`, groupArray(`PositiveBucketCounts`) AS `_hq_pos_buckets`, groupArray(`NegativeOffset`) AS `_hq_neg_offsets`, groupArray(`NegativeBucketCounts`) AS `_hq_neg_buckets`, count() AS `_cerb_n` FROM (SELECT * FROM `otel_metrics_exp_histogram` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?))))) WHERE `_cerb_n` > 0)))

--- a/test/spec/promql/histogram_quantile_native_agg_groupby.txtar
+++ b/test/spec/promql/histogram_quantile_native_agg_groupby.txtar
@@ -1,0 +1,54 @@
+-- query.promql --
+histogram_quantile(0.95, sum by(le, service)(rate(http_server_duration_exp_hist[5m])))
+-- seed --
+CREATE TABLE otel_metrics_exp_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Scale Int32,
+    ZeroCount UInt64,
+    ZeroThreshold Float64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_exp_histogram VALUES
+    ('http_server_duration_exp_hist', map('service', 'api'),  toDateTime64('2026-01-01 00:00:00', 9), 0, 0, 0.0, 0, [1, 2, 3], 0, []),
+    ('http_server_duration_exp_hist', map('service', 'web'),  toDateTime64('2026-01-01 00:00:00', 9), 0, 0, 0.0, 0, [3, 4, 3], 0, []);
+-- expected_rows --
+[
+  ["", {"service": "api"}, "2026-01-01T00:00:01Z", 7.464263932294459],
+  ["", {"service": "web"}, "2026-01-01T00:00:01Z", 7.127189745122715]
+]
+-- args --
+[0] string = ""
+[1] int64 = 9
+[2] string = "service"
+[3] int64 = 1
+[4] int64 = 0
+[5] int64 = 0
+[6] int64 = 1
+[7] int64 = 1
+[8] int64 = 1
+[9] int64 = 0
+[10] int64 = 0
+[11] int64 = 1
+[12] int64 = 1
+[13] string = "service"
+[14] string = "http_server_duration_exp_hist"
+[15] string = "2026-01-01 00:00:01.000000000"
+[16] int64 = 9
+[17] string = "2026-01-01 00:00:01.000000000"
+[18] int64 = 9
+[19] int64 = 300000000000
+[20] string = "service"
+-- chplan --
+Project ["" AS MetricName, Attributes AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+  HistogramQuantileNative phi=0.95 groupBy=[Attributes AS Attributes]
+    Project [map("service", gkey_0) AS Attributes, _hq_merged_scale AS Scale, ZeroCount AS ZeroCount, ZeroThreshold AS ZeroThreshold, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_pos_offsets)) AS PositiveOffset, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - 1)), (s - _hq_merged_scale)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets)) + t)), arr[j], 0), arrayEnumerate(arr))), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)), range(toUInt64(greatest(0, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets))) + 1))))) AS PositiveBucketCounts, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_neg_offsets)) AS NegativeOffset, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - 1)), (s - _hq_merged_scale)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets)) + t)), arr[j], 0), arrayEnumerate(arr))), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)), range(toUInt64(greatest(0, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets))) + 1))))) AS NegativeBucketCounts]
+      Aggregate groupBy=[Attributes["service"] AS gkey_0] funcs=[min(Scale) AS _hq_merged_scale, sum(ZeroCount) AS ZeroCount, max(ZeroThreshold) AS ZeroThreshold, groupArray(Scale) AS _hq_scales, groupArray(PositiveOffset) AS _hq_pos_offsets, groupArray(PositiveBucketCounts) AS _hq_pos_buckets, groupArray(NegativeOffset) AS _hq_neg_offsets, groupArray(NegativeBucketCounts) AS _hq_neg_buckets]
+        Filter predicate=(((MetricName = "http_server_duration_exp_hist") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+          Scan(otel_metrics_exp_histogram)
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes` AS `Attributes`, if(arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[length(arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`)))] = 0, nan, if(0.95 <= 0, 0.0, if(0.95 >= 1, pow(pow(2, pow(2, -`Scale`)), `PositiveOffset` + length(`PositiveBucketCounts`)), if(arrayFirstIndex(c -> c >= (0.95 * arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[length(arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`)))]), arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))) = 1, `ZeroThreshold`, pow(pow(2, pow(2, -`Scale`)), `PositiveOffset` + (arrayFirstIndex(c -> c >= (0.95 * arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[length(arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`)))]), arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))) - 2) + ((0.95 * arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[length(arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`)))]) - arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[arrayFirstIndex(c -> c >= (0.95 * arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[length(arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`)))]), arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))) - 1]) / (arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[arrayFirstIndex(c -> c >= (0.95 * arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[length(arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`)))]), arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`)))] - arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[arrayFirstIndex(c -> c >= (0.95 * arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[length(arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`)))]), arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))) - 1])))))) AS `Value` FROM (SELECT map(?, `gkey_0`) AS `Attributes`, `_hq_merged_scale` AS `Scale`, `ZeroCount` AS `ZeroCount`, `ZeroThreshold` AS `ZeroThreshold`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`)) AS `PositiveOffset`, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - ?)), (s - `_hq_merged_scale`)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`)) + t)), arr[j], ?), arrayEnumerate(arr))), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)), range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`))) + ?))))) AS `PositiveBucketCounts`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`)) AS `NegativeOffset`, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - ?)), (s - `_hq_merged_scale`)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`)) + t)), arr[j], ?), arrayEnumerate(arr))), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)), range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`))) + ?))))) AS `NegativeBucketCounts` FROM (SELECT `Attributes`[?] AS `gkey_0`, min(`Scale`) AS `_hq_merged_scale`, sum(`ZeroCount`) AS `ZeroCount`, max(`ZeroThreshold`) AS `ZeroThreshold`, groupArray(`Scale`) AS `_hq_scales`, groupArray(`PositiveOffset`) AS `_hq_pos_offsets`, groupArray(`PositiveBucketCounts`) AS `_hq_pos_buckets`, groupArray(`NegativeOffset`) AS `_hq_neg_offsets`, groupArray(`NegativeBucketCounts`) AS `_hq_neg_buckets` FROM (SELECT * FROM `otel_metrics_exp_histogram` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`[?])))

--- a/test/spec/promql/histogram_quantile_native_agg_mixed_scale.txtar
+++ b/test/spec/promql/histogram_quantile_native_agg_mixed_scale.txtar
@@ -1,0 +1,58 @@
+-- query.promql --
+histogram_quantile(0.95, sum by(le)(rate(http_server_duration_exp_hist[5m])))
+-- seed --
+CREATE TABLE otel_metrics_exp_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Scale Int32,
+    ZeroCount UInt64,
+    ZeroThreshold Float64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- Two series with different Scales. The merge downscales the Scale=1
+-- (fine) series to Scale=0 (coarse) before offset-aligning + summing.
+-- At Scale=1, bucket k (1-indexed absolute) maps to bucket k>>1 at
+-- Scale=0 — so the fine series's [1, 2, 3, 4] at off=0
+-- (abs idxs 0..3 at S=1) collapses to [1+2, 3+4] = [3, 7] at off=0
+-- at S=0. Merging with the coarse series's [5, 10] at off=0:
+-- merged = [3+5, 7+10] = [8, 17] at S=0, off=0.
+INSERT INTO otel_metrics_exp_histogram VALUES
+    ('http_server_duration_exp_hist', map('series', 'fine'),   toDateTime64('2026-01-01 00:00:00', 9), 1, 0, 0.0, 0, [1, 2, 3, 4], 0, []),
+    ('http_server_duration_exp_hist', map('series', 'coarse'), toDateTime64('2026-01-01 00:00:00', 9), 0, 0, 0.0, 0, [5, 10],       0, []);
+-- expected_rows --
+[
+  ["", {}, "2026-01-01T00:00:01Z", 3.801241244429467]
+]
+-- args --
+[0] string = ""
+[1] int64 = 9
+[2] string = "Map(String,String)"
+[3] int64 = 1
+[4] int64 = 0
+[5] int64 = 0
+[6] int64 = 1
+[7] int64 = 1
+[8] int64 = 1
+[9] int64 = 0
+[10] int64 = 0
+[11] int64 = 1
+[12] int64 = 1
+[13] string = "http_server_duration_exp_hist"
+[14] string = "2026-01-01 00:00:01.000000000"
+[15] int64 = 9
+[16] string = "2026-01-01 00:00:01.000000000"
+[17] int64 = 9
+[18] int64 = 300000000000
+-- chplan --
+Project ["" AS MetricName, Attributes AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+  HistogramQuantileNative phi=0.95 groupBy=[Attributes AS Attributes]
+    Project [CAST(map(), "Map(String,String)") AS Attributes, _hq_merged_scale AS Scale, ZeroCount AS ZeroCount, ZeroThreshold AS ZeroThreshold, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_pos_offsets)) AS PositiveOffset, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - 1)), (s - _hq_merged_scale)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets)) + t)), arr[j], 0), arrayEnumerate(arr))), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)), range(toUInt64(greatest(0, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets))) + 1))))) AS PositiveBucketCounts, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_neg_offsets)) AS NegativeOffset, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - 1)), (s - _hq_merged_scale)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets)) + t)), arr[j], 0), arrayEnumerate(arr))), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)), range(toUInt64(greatest(0, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets))) + 1))))) AS NegativeBucketCounts]
+      Aggregate groupBy=[] funcs=[min(Scale) AS _hq_merged_scale, sum(ZeroCount) AS ZeroCount, max(ZeroThreshold) AS ZeroThreshold, groupArray(Scale) AS _hq_scales, groupArray(PositiveOffset) AS _hq_pos_offsets, groupArray(PositiveBucketCounts) AS _hq_pos_buckets, groupArray(NegativeOffset) AS _hq_neg_offsets, groupArray(NegativeBucketCounts) AS _hq_neg_buckets]
+        Filter predicate=(((MetricName = "http_server_duration_exp_hist") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+          Scan(otel_metrics_exp_histogram)
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes` AS `Attributes`, if(arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[length(arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`)))] = 0, nan, if(0.95 <= 0, 0.0, if(0.95 >= 1, pow(pow(2, pow(2, -`Scale`)), `PositiveOffset` + length(`PositiveBucketCounts`)), if(arrayFirstIndex(c -> c >= (0.95 * arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[length(arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`)))]), arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))) = 1, `ZeroThreshold`, pow(pow(2, pow(2, -`Scale`)), `PositiveOffset` + (arrayFirstIndex(c -> c >= (0.95 * arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[length(arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`)))]), arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))) - 2) + ((0.95 * arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[length(arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`)))]) - arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[arrayFirstIndex(c -> c >= (0.95 * arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[length(arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`)))]), arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))) - 1]) / (arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[arrayFirstIndex(c -> c >= (0.95 * arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[length(arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`)))]), arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`)))] - arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[arrayFirstIndex(c -> c >= (0.95 * arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[length(arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`)))]), arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))) - 1])))))) AS `Value` FROM (SELECT CAST(map(), ?) AS `Attributes`, `_hq_merged_scale` AS `Scale`, `ZeroCount` AS `ZeroCount`, `ZeroThreshold` AS `ZeroThreshold`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`)) AS `PositiveOffset`, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - ?)), (s - `_hq_merged_scale`)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`)) + t)), arr[j], ?), arrayEnumerate(arr))), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)), range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`))) + ?))))) AS `PositiveBucketCounts`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`)) AS `NegativeOffset`, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - ?)), (s - `_hq_merged_scale`)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`)) + t)), arr[j], ?), arrayEnumerate(arr))), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)), range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`))) + ?))))) AS `NegativeBucketCounts` FROM (SELECT `_hq_merged_scale`, `ZeroCount`, `ZeroThreshold`, `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`, `_hq_neg_offsets`, `_hq_neg_buckets` FROM (SELECT min(`Scale`) AS `_hq_merged_scale`, sum(`ZeroCount`) AS `ZeroCount`, max(`ZeroThreshold`) AS `ZeroThreshold`, groupArray(`Scale`) AS `_hq_scales`, groupArray(`PositiveOffset`) AS `_hq_pos_offsets`, groupArray(`PositiveBucketCounts`) AS `_hq_pos_buckets`, groupArray(`NegativeOffset`) AS `_hq_neg_offsets`, groupArray(`NegativeBucketCounts`) AS `_hq_neg_buckets`, count() AS `_cerb_n` FROM (SELECT * FROM `otel_metrics_exp_histogram` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?))))) WHERE `_cerb_n` > 0)))

--- a/test/spec/promql/histogram_quantile_native_agg_p50.txtar
+++ b/test/spec/promql/histogram_quantile_native_agg_p50.txtar
@@ -1,0 +1,51 @@
+-- query.promql --
+histogram_quantile(0.5, sum by(le)(rate(http_server_duration_exp_hist[5m])))
+-- seed --
+CREATE TABLE otel_metrics_exp_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Scale Int32,
+    ZeroCount UInt64,
+    ZeroThreshold Float64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_exp_histogram VALUES
+    ('http_server_duration_exp_hist', map('service', 'api'),  toDateTime64('2026-01-01 00:00:00', 9), 0, 0, 0.0, 0, [1, 2, 3], 0, []),
+    ('http_server_duration_exp_hist', map('service', 'web'),  toDateTime64('2026-01-01 00:00:00', 9), 0, 0, 0.0, 0, [3, 4, 3], 0, []);
+-- expected_rows --
+[
+  ["", {}, "2026-01-01T00:00:01Z", 3.1748021039363987]
+]
+-- args --
+[0] string = ""
+[1] int64 = 9
+[2] string = "Map(String,String)"
+[3] int64 = 1
+[4] int64 = 0
+[5] int64 = 0
+[6] int64 = 1
+[7] int64 = 1
+[8] int64 = 1
+[9] int64 = 0
+[10] int64 = 0
+[11] int64 = 1
+[12] int64 = 1
+[13] string = "http_server_duration_exp_hist"
+[14] string = "2026-01-01 00:00:01.000000000"
+[15] int64 = 9
+[16] string = "2026-01-01 00:00:01.000000000"
+[17] int64 = 9
+[18] int64 = 300000000000
+-- chplan --
+Project ["" AS MetricName, Attributes AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+  HistogramQuantileNative phi=0.5 groupBy=[Attributes AS Attributes]
+    Project [CAST(map(), "Map(String,String)") AS Attributes, _hq_merged_scale AS Scale, ZeroCount AS ZeroCount, ZeroThreshold AS ZeroThreshold, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_pos_offsets)) AS PositiveOffset, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - 1)), (s - _hq_merged_scale)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets)) + t)), arr[j], 0), arrayEnumerate(arr))), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)), range(toUInt64(greatest(0, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets))) + 1))))) AS PositiveBucketCounts, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_neg_offsets)) AS NegativeOffset, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - 1)), (s - _hq_merged_scale)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets)) + t)), arr[j], 0), arrayEnumerate(arr))), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)), range(toUInt64(greatest(0, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets))) + 1))))) AS NegativeBucketCounts]
+      Aggregate groupBy=[] funcs=[min(Scale) AS _hq_merged_scale, sum(ZeroCount) AS ZeroCount, max(ZeroThreshold) AS ZeroThreshold, groupArray(Scale) AS _hq_scales, groupArray(PositiveOffset) AS _hq_pos_offsets, groupArray(PositiveBucketCounts) AS _hq_pos_buckets, groupArray(NegativeOffset) AS _hq_neg_offsets, groupArray(NegativeBucketCounts) AS _hq_neg_buckets]
+        Filter predicate=(((MetricName = "http_server_duration_exp_hist") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+          Scan(otel_metrics_exp_histogram)
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes` AS `Attributes`, if(arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[length(arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`)))] = 0, nan, if(0.5 <= 0, 0.0, if(0.5 >= 1, pow(pow(2, pow(2, -`Scale`)), `PositiveOffset` + length(`PositiveBucketCounts`)), if(arrayFirstIndex(c -> c >= (0.5 * arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[length(arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`)))]), arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))) = 1, `ZeroThreshold`, pow(pow(2, pow(2, -`Scale`)), `PositiveOffset` + (arrayFirstIndex(c -> c >= (0.5 * arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[length(arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`)))]), arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))) - 2) + ((0.5 * arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[length(arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`)))]) - arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[arrayFirstIndex(c -> c >= (0.5 * arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[length(arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`)))]), arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))) - 1]) / (arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[arrayFirstIndex(c -> c >= (0.5 * arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[length(arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`)))]), arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`)))] - arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[arrayFirstIndex(c -> c >= (0.5 * arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))[length(arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`)))]), arrayCumSum(arrayConcat([`ZeroCount`], `PositiveBucketCounts`))) - 1])))))) AS `Value` FROM (SELECT CAST(map(), ?) AS `Attributes`, `_hq_merged_scale` AS `Scale`, `ZeroCount` AS `ZeroCount`, `ZeroThreshold` AS `ZeroThreshold`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`)) AS `PositiveOffset`, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - ?)), (s - `_hq_merged_scale`)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`)) + t)), arr[j], ?), arrayEnumerate(arr))), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)), range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`))) + ?))))) AS `PositiveBucketCounts`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`)) AS `NegativeOffset`, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - ?)), (s - `_hq_merged_scale`)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`)) + t)), arr[j], ?), arrayEnumerate(arr))), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)), range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`))) + ?))))) AS `NegativeBucketCounts` FROM (SELECT `_hq_merged_scale`, `ZeroCount`, `ZeroThreshold`, `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`, `_hq_neg_offsets`, `_hq_neg_buckets` FROM (SELECT min(`Scale`) AS `_hq_merged_scale`, sum(`ZeroCount`) AS `ZeroCount`, max(`ZeroThreshold`) AS `ZeroThreshold`, groupArray(`Scale`) AS `_hq_scales`, groupArray(`PositiveOffset`) AS `_hq_pos_offsets`, groupArray(`PositiveBucketCounts`) AS `_hq_pos_buckets`, groupArray(`NegativeOffset`) AS `_hq_neg_offsets`, groupArray(`NegativeBucketCounts`) AS `_hq_neg_buckets`, count() AS `_cerb_n` FROM (SELECT * FROM `otel_metrics_exp_histogram` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?))))) WHERE `_cerb_n` > 0)))


### PR DESCRIPTION
## Summary

Implements Phase 2 of `docs/native-histogram-plan.md`: the
`histogram_quantile(phi, sum [by/without] (rate(<sel>_exp_hist[r])))`
idiom over OTel-CH native (exponential) histograms.

Phase 1 ([#171](https://github.com/tsouza/cerberus/pull/171)) shipped
the bare-selector instant-mode quantile. This PR replaces the Phase 2
stub error (`lowerHistogramQuantileNativeAgg` in
`internal/promql/histogram_quantile.go`) with a real lowering that
mirrors the classic-histogram aggregated path but threads the
exp-histogram-specific merge math (scale-fold + offset-align + zero-pad
+ element-wise sum) through an inner Project before
`HistogramQuantileNative` walks the merged distribution.

The merge mirrors Prometheus's `FloatHistogram.Add` semantics
(`model/histogram/float_histogram.go::targetIdx` in the upstream fork):

- **Inner Aggregate** collects per-row Scale / PositiveOffset /
  PositiveBucketCounts / NegativeOffset / NegativeBucketCounts into
  groupArrays alongside `min(Scale)` / `sum(ZeroCount)` /
  `max(ZeroThreshold)`.
- **Outer Project** downscales each per-row bucket array to the merged
  Scale via `bitShiftRight(idx, scale - mergedScale)`, then computes
  each target bucket's value as the sum of per-row contributions over
  `arrayMap(j -> if((off + j - 1) >> delta == T, arr[j], 0), arrayEnumerate(arr))`.

Three new typed chplan `Expr` types (`Lambda` / `BareIdent` /
`Subscript`) were added to express the multi-arg lambdas the merge
needs; the existing `Builder.Expr` dispatch renders them.

The same `le`-drop rule from the classic native path applies here:
exp-histogram bucket data lives in `PositiveBucketCounts` (offset by
`PositiveOffset`), so `sum by(le)` silently collapses to a single
group.

## Test plan

- [x] Layer 2a — four new TXTAR fixtures:
  - `histogram_quantile_native_agg.txtar` (uniform Scale, `sum by(le)`).
  - `histogram_quantile_native_agg_p50.txtar` (p50 sanity).
  - `histogram_quantile_native_agg_groupby.txtar` (`sum by(le, service)`).
  - `histogram_quantile_native_agg_mixed_scale.txtar` (mixed-Scale,
    exercises the consolidation path).
- [x] Layer 2b — `TestLower_HistogramQuantile_OverAggregation_Native` +
  `_LeDropped` in `internal/promql/histogram_quantile_test.go`,
  replacing the prior `_NativeRejected` rejection test.
- [x] Layer 6a — `TestQuery_HistogramQuantileNativeAgg_ChDB` +
  `TestQuery_HistogramQuantileNativeAgg_MixedScale_ChDB` in
  `internal/api/prom/handler_chdb_range_mode_test.go`, pinning the
  end-to-end interpolated value against chDB (`~7.294` uniform-Scale,
  `~3.801` mixed-Scale).
- [x] `go test ./internal/... -count=1` passes 2,623 tests.
- [x] `go test -tags chdb ./internal/... ./test/spec/... -count=1`
  passes 3,161 tests.

Cites: [#171](https://github.com/tsouza/cerberus/pull/171),
[#373](https://github.com/tsouza/cerberus/pull/373).