### PR TITLE
fix(api/tempo): /api/v2/search/tags honors ?scope= filter

### DIFF
--- a/internal/api/tempo/search_tags.go
+++ b/internal/api/tempo/search_tags.go
@@ -52,6 +52,26 @@ type TagScope struct {
 	Tags []string `json:"tags"`
 }
 
+// scope query-param values accepted by /api/v2/search/tags. Mirrors
+// upstream Tempo's `pkg/api.ParseSearchTagsRequest` semantics:
+//
+//   - "resource"  → only the resource scope bucket
+//   - "span"      → only the span scope bucket
+//   - "intrinsic" → only the intrinsic bucket
+//   - "none" or "" → every scope (default; matches AttributeScopeNone)
+//
+// Anything else is a 400. We accept "all" as a friendly alias for the
+// default — upstream Tempo doesn't define it, but the parameter is
+// otherwise free-form to clients and "all" is the obvious user
+// intuition for "give me everything", so we let it through.
+const (
+	tagScopeResource  = "resource"
+	tagScopeSpan      = "span"
+	tagScopeIntrinsic = "intrinsic"
+	tagScopeNone      = "none"
+	tagScopeAll       = "all"
+)
+
 // handleSearchTags implements `GET /api/search/tags`. Returns the union
 // of every dynamic attribute key (span + resource maps) plus the static
 // intrinsic-span list, sorted ascending. Honours optional `start`/`end`
@@ -83,6 +103,12 @@ func (h *Handler) handleSearchTagsV2(w http.ResponseWriter, r *http.Request) {
 // respondTags is the shared core of V1 + V2: it runs two independent
 // CH lookups (one per attribute map) so the V2 response can keep the
 // resource-vs-span split, then unions them for the V1 envelope.
+//
+// The optional `?scope=` query parameter filters which buckets are
+// fetched and returned. Honouring it on V2 was missing before — the
+// handler emitted every scope regardless of what the client asked for,
+// which made Grafana's per-scope autocomplete iterate over irrelevant
+// keys.
 func (h *Handler) respondTags(w http.ResponseWriter, r *http.Request, v2 bool) {
 	start, end, err := parseTempoStartEnd(r)
 	if err != nil {
@@ -90,36 +116,77 @@ func (h *Handler) respondTags(w http.ResponseWriter, r *http.Request, v2 bool) {
 		return
 	}
 
-	resourceTags, err := h.fetchTagKeys(r.Context(), h.Schema.ResourceAttributesColumn, start, end)
+	scope, err := parseTagScope(r.URL.Query().Get("scope"))
 	if err != nil {
-		h.Logger.Error("cerberus tempo /search/tags resource CH query failed", "err", err)
-		writeError(w, http.StatusBadGateway, "", "", err)
-		return
-	}
-	spanTags, err := h.fetchTagKeys(r.Context(), h.Schema.AttributesColumn, start, end)
-	if err != nil {
-		h.Logger.Error("cerberus tempo /search/tags span CH query failed", "err", err)
-		writeError(w, http.StatusBadGateway, "", "", err)
+		writeError(w, http.StatusBadRequest, "", "", err)
 		return
 	}
 
+	var resourceTags, spanTags []string
+	if scope == tagScopeNone || scope == tagScopeResource {
+		resourceTags, err = h.fetchTagKeys(r.Context(), h.Schema.ResourceAttributesColumn, start, end)
+		if err != nil {
+			h.Logger.Error("cerberus tempo /search/tags resource CH query failed", "err", err)
+			writeError(w, http.StatusBadGateway, "", "", err)
+			return
+		}
+	}
+	if scope == tagScopeNone || scope == tagScopeSpan {
+		spanTags, err = h.fetchTagKeys(r.Context(), h.Schema.AttributesColumn, start, end)
+		if err != nil {
+			h.Logger.Error("cerberus tempo /search/tags span CH query failed", "err", err)
+			writeError(w, http.StatusBadGateway, "", "", err)
+			return
+		}
+	}
+
 	if v2 {
-		writeJSON(w, http.StatusOK, SearchTagsResponseV2{
-			Scopes: []TagScope{
-				{Name: "resource", Tags: sortedUnique(resourceTags)},
-				{Name: "span", Tags: sortedUnique(spanTags)},
-				{Name: "intrinsic", Tags: append([]string(nil), intrinsicTags...)},
-			},
-		})
+		scopes := make([]TagScope, 0, 3)
+		if scope == tagScopeNone || scope == tagScopeResource {
+			scopes = append(scopes, TagScope{Name: tagScopeResource, Tags: sortedUnique(resourceTags)})
+		}
+		if scope == tagScopeNone || scope == tagScopeSpan {
+			scopes = append(scopes, TagScope{Name: tagScopeSpan, Tags: sortedUnique(spanTags)})
+		}
+		if scope == tagScopeNone || scope == tagScopeIntrinsic {
+			scopes = append(scopes, TagScope{Name: tagScopeIntrinsic, Tags: append([]string(nil), intrinsicTags...)})
+		}
+		writeJSON(w, http.StatusOK, SearchTagsResponseV2{Scopes: scopes})
 		return
 	}
 
 	all := make([]string, 0, len(resourceTags)+len(spanTags)+len(intrinsicTags))
 	all = append(all, resourceTags...)
 	all = append(all, spanTags...)
-	all = append(all, intrinsicTags...)
+	if scope == tagScopeNone || scope == tagScopeIntrinsic {
+		all = append(all, intrinsicTags...)
+	}
 	writeJSON(w, http.StatusOK, SearchTagsResponse{TagNames: sortedUnique(all)})
 }
+
+// parseTagScope normalises the `?scope=` query parameter against the
+// upstream Tempo allowlist. Returns the canonical scope keyword the
+// rest of the handler branches on, or an error suitable for a 400. The
+// empty string and the literal "none" both collapse to "none" (= every
+// scope, matching upstream's AttributeScopeNone). "all" is accepted as
+// a synonym for "none" because it's the obvious user intuition; every
+// other value is rejected with the same shape upstream Tempo uses.
+func parseTagScope(raw string) (string, error) {
+	switch raw {
+	case "", tagScopeNone, tagScopeAll:
+		return tagScopeNone, nil
+	case tagScopeResource, tagScopeSpan, tagScopeIntrinsic:
+		return raw, nil
+	default:
+		return "", &tagScopeError{raw: raw}
+	}
+}
+
+// tagScopeError carries the rejected scope value into writeError so the
+// 400 body matches upstream Tempo's `invalid scope: <v>` phrasing.
+type tagScopeError struct{ raw string }
+
+func (e *tagScopeError) Error() string { return "invalid scope: " + e.raw }
 
 // fetchTagKeys runs the mapKeys-distinct lookup for a single attribute
 // map column. Splitting into two queries (rather than one with

--- a/internal/api/tempo/search_tags_test.go
+++ b/internal/api/tempo/search_tags_test.go
@@ -220,6 +220,180 @@ func TestSearchTagsV2_ScopePartition(t *testing.T) {
 	}
 }
 
+// TestSearchTagsV2_ScopeFilter — the `?scope=` query parameter on
+// /api/v2/search/tags must restrict the response to the requested
+// bucket. Mirrors upstream Tempo's pkg/api.ParseSearchTagsRequest
+// semantics (resource / span / intrinsic / none-or-empty / "all" alias).
+// Before this fix the handler silently emitted every scope, so
+// Grafana's per-scope autocomplete iterated over irrelevant keys.
+func TestSearchTagsV2_ScopeFilter(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name       string
+		query      string
+		wantScopes []string
+		// wantTag is one tag the response *must* contain; absent means
+		// "no positive-content assertion, just the scope partition
+		// matters".
+		wantTag string
+	}{
+		{name: "resource_only", query: "?scope=resource", wantScopes: []string{"resource"}, wantTag: "service.name"},
+		{name: "span_only", query: "?scope=span", wantScopes: []string{"span"}, wantTag: "http.method"},
+		{name: "intrinsic_only", query: "?scope=intrinsic", wantScopes: []string{"intrinsic"}, wantTag: "name"},
+		{name: "none_default", query: "", wantScopes: []string{"resource", "span", "intrinsic"}},
+		{name: "none_explicit", query: "?scope=none", wantScopes: []string{"resource", "span", "intrinsic"}},
+		{name: "all_alias", query: "?scope=all", wantScopes: []string{"resource", "span", "intrinsic"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			q := &stubQuerier{stringsBySQL: map[string][]string{
+				"`ResourceAttributes`": {"service.name"},
+				"`SpanAttributes`":     {"http.method"},
+			}}
+			srv := newServer(q, "v1.0.0-test")
+			t.Cleanup(srv.Close)
+
+			resp, err := http.Get(srv.URL + "/api/v2/search/tags" + tc.query)
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+			}
+			var body tempo.SearchTagsResponseV2
+			if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+
+			gotNames := make([]string, 0, len(body.Scopes))
+			gotByName := map[string][]string{}
+			for _, s := range body.Scopes {
+				gotNames = append(gotNames, s.Name)
+				gotByName[s.Name] = s.Tags
+			}
+			if len(gotNames) != len(tc.wantScopes) {
+				t.Fatalf("scope buckets=%v want=%v", gotNames, tc.wantScopes)
+			}
+			for _, want := range tc.wantScopes {
+				if _, ok := gotByName[want]; !ok {
+					t.Errorf("missing scope %q in %v", want, gotNames)
+				}
+			}
+			if tc.wantTag != "" {
+				// The single requested scope must carry the canary tag.
+				bucket := tc.wantScopes[0]
+				if !contains(gotByName[bucket], tc.wantTag) {
+					t.Errorf("scope %q missing %q: %+v", bucket, tc.wantTag, gotByName[bucket])
+				}
+			}
+		})
+	}
+}
+
+// TestSearchTagsV2_InvalidScope — anything outside the upstream
+// allowlist must surface as a 400 with the Tempo error envelope, so
+// clients see the same shape they would hitting reference Tempo.
+func TestSearchTagsV2_InvalidScope(t *testing.T) {
+	t.Parallel()
+	q := &stubQuerier{}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v2/search/tags?scope=bogus")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status=%d want 400 body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	var er tempo.ErrorResponse
+	if err := json.NewDecoder(resp.Body).Decode(&er); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !er.Error {
+		t.Errorf("expected error=true, got %+v", er)
+	}
+	if !strings.Contains(er.Message, "invalid scope") {
+		t.Errorf("expected error message to mention %q, got %q", "invalid scope", er.Message)
+	}
+}
+
+// TestSearchTagsV2_ScopeSkipsCH — when the caller asks for `scope=intrinsic`
+// the handler must NOT issue the resource / span CH lookups. Pins the
+// no-extra-roundtrips behaviour so future refactors can't quietly
+// regress to always-fetch-all.
+func TestSearchTagsV2_ScopeSkipsCH(t *testing.T) {
+	t.Parallel()
+	q := &stubQuerier{stringsBySQL: map[string][]string{
+		"`ResourceAttributes`": {"resource.should.not.appear"},
+		"`SpanAttributes`":     {"span.should.not.appear"},
+	}}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v2/search/tags?scope=intrinsic")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	if q.lastSQL != "" {
+		t.Errorf("intrinsic-only request must not hit CH, got SQL=%q", q.lastSQL)
+	}
+}
+
+// TestSearchTags_V1ScopeFilter — V1 mirrors V2's parsing: invalid
+// scopes still 400, and `scope=intrinsic` collapses the envelope to
+// just the static intrinsic list (no CH fetches).
+func TestSearchTags_V1ScopeFilter(t *testing.T) {
+	t.Parallel()
+	t.Run("intrinsic_only", func(t *testing.T) {
+		t.Parallel()
+		q := &stubQuerier{stringsBySQL: map[string][]string{
+			"`ResourceAttributes`": {"resource.should.not.appear"},
+			"`SpanAttributes`":     {"span.should.not.appear"},
+		}}
+		srv := newServer(q, "v1.0.0-test")
+		t.Cleanup(srv.Close)
+
+		resp, err := http.Get(srv.URL + "/api/search/tags?scope=intrinsic")
+		if err != nil {
+			t.Fatalf("GET: %v", err)
+		}
+		defer resp.Body.Close()
+		var body tempo.SearchTagsResponse
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if contains(body.TagNames, "resource.should.not.appear") {
+			t.Errorf("intrinsic-only V1 envelope leaked resource tag: %v", body.TagNames)
+		}
+		if !contains(body.TagNames, "name") {
+			t.Errorf("intrinsic-only V1 envelope missing intrinsic %q: %v", "name", body.TagNames)
+		}
+	})
+	t.Run("invalid", func(t *testing.T) {
+		t.Parallel()
+		q := &stubQuerier{}
+		srv := newServer(q, "v1.0.0-test")
+		t.Cleanup(srv.Close)
+
+		resp, err := http.Get(srv.URL + "/api/search/tags?scope=bogus")
+		if err != nil {
+			t.Fatalf("GET: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("status=%d want 400", resp.StatusCode)
+		}
+	})
+}
+
 // contains is a small helper so test failures point at the missing
 // string rather than dumping the whole slice diff.
 func contains(haystack []string, needle string) bool {


### PR DESCRIPTION
## Summary

- `/api/v2/search/tags` (and V1) ignored the `?scope=` query parameter — handler always emitted resource + span + intrinsic, so Grafana's per-scope autocomplete iterated over irrelevant keys. Found by EG #397.
- Parse the parameter against upstream Tempo's allowlist (resource / span / intrinsic / none-or-empty; `all` accepted as a friendly alias for the default) and skip both the CH lookup and the response bucket for scopes the caller didn't ask for.
- Invalid values now surface as a 400 with upstream's `invalid scope: <v>` error envelope.

## Scope value semantics

| value | behavior |
| --- | --- |
| `resource` | only the resource bucket; resource-attrs CH lookup only |
| `span` | only the span bucket; span-attrs CH lookup only |
| `intrinsic` | only the static intrinsic list; **no CH lookups** |
| `none` / `` (default) | all three buckets (matches upstream `AttributeScopeNone`) |
| `all` | cerberus-friendly alias for `none` |
| anything else | 400 `invalid scope: <v>` |

## Test plan

- [x] `TestSearchTagsV2_ScopeFilter` — table-driven, asserts each scope value returns exactly the buckets it asked for plus a canary tag per scope.
- [x] `TestSearchTagsV2_InvalidScope` — bogus scope returns 400 with Tempo error envelope shape + `invalid scope` phrasing.
- [x] `TestSearchTagsV2_ScopeSkipsCH` — `?scope=intrinsic` never calls `QueryStrings` (no extra CH roundtrips).
- [x] `TestSearchTags_V1ScopeFilter` — V1 envelope also honours scope (intrinsic-only collapses to static list; invalid still 400).
- [x] Existing `TestSearchTagsV2_ScopePartition` + conformance `v2` subtest still pass on the default (empty) scope path.