### PR TITLE
fix(api/tempo): metrics endpoints emit tempopb KeyValue AnyValue shape

### DIFF
--- a/harness/tempo-compatibility/driver/differ_metrics.go
+++ b/harness/tempo-compatibility/driver/differ_metrics.go
@@ -14,20 +14,16 @@
 //                        different ways" failure mode the plan calls out.
 //   3. AssertMetricsCase + RunSemanticChecks — driven from diffCase.
 //
-// Both backends' JSON differs slightly in label-value shape:
+// Both backends emit Tempo's tempopb KeyValue + AnyValue label shape
+// on the wire — `{"labels":[{"key":"X","value":{"stringValue":"Y"}}], ...}`
+// — matching `pkg/tempopb/common/v1` rendered via gogo `jsonpb`.
 //
-//   * Cerberus internal/api/tempo/metrics_query_range.go emits
-//     `{"labels":[{"key":"X","value":"Y"}], "samples":[{"timestampMs":..,
-//     "value":..}]}` — a flat string `value`.
-//   * Tempo's tempopb projection (pkg/tempopb/common/v1/common.pb.go's
-//     KeyValue) emits `{"labels":[{"key":"X","value":{"stringValue":"Y"}}], ...}`
-//     — a typed AnyValue.
-//
-// The decoder tolerates either form via a small custom Unmarshaler so
-// the differ compares the extracted string value, not the JSON envelope.
-// This is the "structural diff" mandate from the plan; if cerberus
-// migrates to the proto-shape envelope later, the differ keeps working
-// without a code change.
+// Cerberus's `/api/metrics/query_range` historically emitted a flatter
+// `{"key":"X","value":"Y"}` form; that was fixed to match the tempopb
+// projection (EF #398). The decoder below keeps a fallback path for the
+// flat string shape so old replay fixtures (and any consumer still on
+// the legacy shape) keep round-tripping — the structural diff compares
+// the extracted string value, not the JSON envelope.
 
 package main
 

--- a/internal/api/tempo/metrics_query_range.go
+++ b/internal/api/tempo/metrics_query_range.go
@@ -2,6 +2,7 @@ package tempo
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -34,9 +35,87 @@ type MetricsSeries struct {
 }
 
 // MetricsLabel is one (key, value) pair in MetricsSeries.Labels.
+//
+// On the wire it serialises to Tempo's tempopb shape:
+//
+//	{"key":"<k>","value":{"stringValue":"<v>"}}
+//
+// matching `pkg/tempopb/common/v1` KeyValue + AnyValue rendered via
+// `gogo/protobuf/jsonpb` (which honours the `json=stringValue` proto
+// tag, not the Go-side `json:"string_value"` struct tag). Holding the
+// value as a plain Go string in the in-process struct keeps handler /
+// test code ergonomic; the custom MarshalJSON wraps the value in the
+// AnyValue envelope so Grafana's Tempo datasource parses cerberus's
+// metrics responses identically to a reference Tempo backend.
+//
+// See https://github.com/tsouza/cerberus/pull/398 (EF #398) for the
+// shape-divergence finding that motivated this.
 type MetricsLabel struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
+	Key   string
+	Value string
+}
+
+// metricsLabelWire mirrors the on-wire tempopb KeyValue + AnyValue
+// shape (string variant only — TraceQL group-by keys are always
+// stringified via toString(...) on the SQL side, so other AnyValue
+// variants don't apply here).
+type metricsLabelWire struct {
+	Key   string                `json:"key"`
+	Value metricsLabelValueWire `json:"value"`
+}
+
+type metricsLabelValueWire struct {
+	StringValue string `json:"stringValue"`
+}
+
+// MarshalJSON emits the tempopb KeyValue + AnyValue wire shape.
+func (l MetricsLabel) MarshalJSON() ([]byte, error) {
+	return json.Marshal(metricsLabelWire{
+		Key:   l.Key,
+		Value: metricsLabelValueWire{StringValue: l.Value},
+	})
+}
+
+// UnmarshalJSON parses the tempopb KeyValue + AnyValue wire shape.
+// Also tolerates the legacy flat `{"key":"k","value":"v"}` shape that
+// cerberus used to emit (pre-EF #398), so handler tests + any consumer
+// that bound to the old shape keep round-tripping.
+func (l *MetricsLabel) UnmarshalJSON(data []byte) error {
+	// Probe the raw `value` field first — its JSON shape decides which
+	// path to take. A flat-string value can't be decoded into the typed
+	// metricsLabelWire (struct vs. string), so we'd lose the value in a
+	// single-pass decode.
+	var probe struct {
+		Key   string          `json:"key"`
+		Value json.RawMessage `json:"value"`
+	}
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return fmt.Errorf("metrics label: decode: %w", err)
+	}
+	l.Key = probe.Key
+	if len(probe.Value) == 0 || string(probe.Value) == "null" {
+		l.Value = ""
+		return nil
+	}
+	// Tempopb shape — object with stringValue child.
+	if probe.Value[0] == '{' {
+		var v metricsLabelValueWire
+		if err := json.Unmarshal(probe.Value, &v); err != nil {
+			return fmt.Errorf("metrics label %q value: %w", probe.Key, err)
+		}
+		l.Value = v.StringValue
+		return nil
+	}
+	// Legacy flat-string shape.
+	if probe.Value[0] == '"' {
+		var s string
+		if err := json.Unmarshal(probe.Value, &s); err != nil {
+			return fmt.Errorf("metrics label %q value: %w", probe.Key, err)
+		}
+		l.Value = s
+		return nil
+	}
+	return fmt.Errorf("metrics label %q value: unrecognised shape: %s", probe.Key, string(probe.Value))
 }
 
 // MetricsSample is one point in MetricsSeries.Samples — timestamp in

--- a/internal/api/tempo/metrics_query_range_test.go
+++ b/internal/api/tempo/metrics_query_range_test.go
@@ -369,6 +369,84 @@ func TestMetricsQueryRange_CHFailure(t *testing.T) {
 	}
 }
 
+// TestMetricsQueryRange_LabelWireShape pins the tempopb KeyValue +
+// AnyValue wire shape for `{"labels":[...]}`. Grafana's Tempo datasource
+// (and any other consumer parsing through `gogo/protobuf/jsonpb` against
+// `pkg/tempopb/common/v1.KeyValue`) requires the typed AnyValue envelope
+// `{"key":"k","value":{"stringValue":"v"}}` — the flat string form
+// cerberus used to emit (`{"key":"k","value":"v"}`) silently round-trips
+// to an empty AnyValue on the consumer side. EF #398 caught this in the
+// tempo-compatibility harness; this test pins the fixed wire shape so a
+// future refactor can't quietly regress it.
+func TestMetricsQueryRange_LabelWireShape(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{samples: []chclient.Sample{{
+		Labels:    map[string]string{"resource.service.name": "frontend"},
+		Timestamp: time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC),
+		Value:     1.0,
+	}}}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	u := metricsQueryRangeURL(srv.URL,
+		"{} | count_over_time() by (resource.service.name)",
+		map[string]string{
+			"start": fixtureStartUnix,
+			"end":   fixtureEndUnix,
+			"step":  "60s",
+		})
+	resp, err := http.Get(u)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	// Read raw body so we assert wire shape without going through the
+	// MarshalJSON we just defined (i.e. the assertion is on the bytes
+	// Grafana actually receives).
+	raw := readBody(t, resp)
+	wantSub := `"value":{"stringValue":"frontend"}`
+	if !strings.Contains(raw, wantSub) {
+		t.Fatalf("response missing tempopb AnyValue shape %q\nbody=%s", wantSub, raw)
+	}
+	// And the legacy flat shape MUST NOT appear.
+	badSub := `"value":"frontend"`
+	if strings.Contains(raw, badSub) {
+		t.Errorf("response still emits legacy flat label shape %q\nbody=%s", badSub, raw)
+	}
+
+	// Decode through MetricsQueryRangeResponse and verify the in-process
+	// struct still surfaces `frontend` so handler callers stay ergonomic.
+	var body tempo.MetricsQueryRangeResponse
+	if err := json.Unmarshal([]byte(raw), &body); err != nil {
+		t.Fatalf("decode tempopb shape: %v", err)
+	}
+	if len(body.Series) != 1 || len(body.Series[0].Labels) != 1 {
+		t.Fatalf("unexpected shape: %+v", body)
+	}
+	if body.Series[0].Labels[0].Key != "resource.service.name" ||
+		body.Series[0].Labels[0].Value != "frontend" {
+		t.Errorf("decoded label = %+v, want {resource.service.name, frontend}",
+			body.Series[0].Labels[0])
+	}
+
+	// Round-trip: also tolerate the legacy flat shape so an old consumer
+	// pushing data into the type (or an older replay fixture) doesn't
+	// break the decoder side of the contract.
+	legacyJSON := []byte(`{"series":[{"labels":[{"key":"k","value":"v"}],"samples":[]}]}`)
+	var legacy tempo.MetricsQueryRangeResponse
+	if err := json.Unmarshal(legacyJSON, &legacy); err != nil {
+		t.Fatalf("decode legacy flat shape: %v", err)
+	}
+	if len(legacy.Series) != 1 || len(legacy.Series[0].Labels) != 1 ||
+		legacy.Series[0].Labels[0].Key != "k" || legacy.Series[0].Labels[0].Value != "v" {
+		t.Errorf("legacy flat decode = %+v, want {k, v}", legacy.Series[0].Labels)
+	}
+}
+
 // TestMetricsQueryRange_StepDurationForms — accepts integer seconds,
 // float seconds, and Go duration strings interchangeably. Matches the
 // PromQL handler's tolerance so Grafana's Tempo datasource (which can


### PR DESCRIPTION
## Summary

Cerberus's `/api/metrics/query_range` was rendering label entries as flat `{"key":"k","value":"v"}` strings. Tempo's reference servers go through `gogo/protobuf/jsonpb` against `pkg/tempopb/common/v1` `KeyValue` + `AnyValue`, which emits `{"key":"k","value":{"stringValue":"v"}}` — the proto `json=stringValue` tag (not the Go-side `string_value` struct tag). Grafana's Tempo datasource is built against the latter; the flat shape silently round-tripped to an empty AnyValue on the consumer side — the wire-shape divergence the tempo-compatibility harness flagged via EF #398.

## Change

- `internal/api/tempo/metrics_query_range.go`: `MetricsLabel` keeps its in-process Go API (`Key string` / `Value string`) — handler / test ergonomics stay the same. Custom `MarshalJSON` wraps the value in the tempopb AnyValue envelope. `UnmarshalJSON` probes the JSON value shape and accepts both forms (new typed object + legacy flat string) so any old replay fixture still round-trips.
- `internal/api/tempo/metrics_query_range_test.go`: new `TestMetricsQueryRange_LabelWireShape` asserts on the raw response bytes (`"value":{"stringValue":"frontend"}` present, legacy `"value":"frontend"` absent), and round-trips both the new and legacy shapes through the decoder so handler callers stay ergonomic.
- `harness/tempo-compatibility/driver/differ_metrics.go`: the differ already tolerated both shapes (kept on purpose for replay-fixture stability); the file-level comment is updated to reflect that cerberus now emits the tempopb projection natively — EF #398 is fixed.

## Before / after

Same TraceQL query: `{} | count_over_time() by (resource.service.name)` with one `frontend` row.

Before (cerberus):

```json
{"series":[{"labels":[{"key":"resource.service.name","value":"frontend"}],"samples":[{"timestampMs":1778580000000,"value":1}]}]}
```

After (cerberus, matches Tempo's jsonpb wire):

```json
{"series":[{"labels":[{"key":"resource.service.name","value":{"stringValue":"frontend"}}],"samples":[{"timestampMs":1778580000000,"value":1}]}]}
```

## Cross-refs

- EF source: #398 (tempo-compatibility harness; metrics endpoints + semantic consistency).
- Tempo type: [`pkg/tempopb/common/v1/common.pb.go` `KeyValue` / `AnyValue`](https://github.com/grafana/tempo/blob/main/pkg/tempopb/common/v1/common.pb.go).

## Test plan

- [x] New `TestMetricsQueryRange_LabelWireShape` pins the tempopb wire shape from the cerberus side + tolerates the legacy flat shape via the decoder.
- [x] Existing handler tests (`TestMetricsQueryRange_SingleSeriesNoGroupBy`, `..._MultiSeriesGroupBy`, etc.) continue to decode through the typed struct API.
- [ ] Nightly `tempo-compatibility` workflow: the metrics-range diff cases stop relying on the differ's shape-tolerance branch (informational; no gate change).