### PR TITLE
feat(api/tempo): implement /api/metrics/query (instant)

### DIFF
--- a/harness/tempo-compatibility/driver/corpus/smoke.txtar
+++ b/harness/tempo-compatibility/driver/corpus/smoke.txtar
@@ -1,9 +1,12 @@
 # Tempo / TraceQL compatibility smoke corpus.
 #
 # PR 4 lifted-and-adapted the cases from harness/prometheus-compliance/
-# shadow/traceql_shadow_test.go::traceqlInstantCases(). PR 5 extends the
+# shadow/traceql_shadow_test.go::traceqlInstantCases(). PR 5 extended the
 # corpus with /api/metrics/query_range + /api/metrics/query cases and
-# adds the semantic-consistency layer (see differ.go::SemanticConsistency).
+# added the semantic-consistency layer (see differ.go::SemanticConsistency);
+# the three metrics_instant cases were stubbed via `skip_reason` while
+# the cerberus /api/metrics/query handler was pending and were turned
+# on when the handler landed.
 #
 # The shadow test runs the SAME 20 search categories against a fake
 # in-process span set; this corpus runs the SAME categories against
@@ -37,9 +40,9 @@
 # Cases below cover the 7 shadow categories (attribute matchers per
 # scope (5), intrinsics (4), structural ops (4), set ops (3), inner
 # aggregates (2)) plus 6 metrics-pipeline cases (3 range + 3 instant)
-# and a per-id smoke. Total: 25 cases, of which 4 carry `skip_reason`
-# (the three instant ones — pending cerberus /api/metrics/query —
-# plus the per-id smoke when the seeder fixture is absent).
+# and a per-id smoke. Total: 25 cases — the three metrics_instant
+# cases activated alongside the cerberus /api/metrics/query handler
+# (see internal/api/tempo/metrics_query_instant.go).
 
 # --- Attribute matchers per scope (5) ---
 
@@ -320,16 +323,17 @@ metrics_range
 samples_non_negative
 
 # --- Metrics pipeline: /api/metrics/query (instant — 3) ---
-# Instant variant of the range queries above. Cerberus does not yet
-# implement /api/metrics/query (see internal/api/tempo/handler.go::
-# Mount — only query_range is registered today). These cases are
-# parsed and shipped so the corpus is the single source of truth for
-# the eventual full matrix; the differ skips them via skip_reason
-# until cerberus's /api/metrics/query handler lands.
+# Instant variant of the range queries above. Cerberus implements
+# /api/metrics/query (see internal/api/tempo/metrics_query_instant.go);
+# the handler re-uses the range emitter with step=end-start so a single
+# bucket spans the whole query window, then projects the first sample
+# per series as the InstantSeries.Value — same semantics as upstream
+# tempo's translateQueryRangeToInstant.
 #
-# When the handler lands, a follow-up PR removes the skip_reason and
-# the differ exercises both backends' instant responses against the
-# range-vs-instant cross-check (instant ≡ aggregate over the range).
+# Per-series bounds match the range counterparts above. The differ's
+# CompareMetrics tolerates either wire shape (cerberus's flat string
+# label value + Tempo's tempopb AnyValue projection); for instant
+# responses, the single Value is compared under 1e-9 relative epsilon.
 
 -- name --
 metrics_rate_instant
@@ -337,10 +341,13 @@ metrics_rate_instant
 { } | rate()
 -- endpoint --
 metrics_instant
--- skip_reason --
-cerberus /api/metrics/query handler pending (handler.go registers
-only /api/metrics/query_range today); corpus documents the eventual
-shape so the file remains the single source of truth
+-- expected_min_series --
+1
+-- expected_max_series --
+50
+-- semantic_checks --
+samples_non_negative
+labels_match_query
 
 -- name --
 metrics_count_over_time_instant
@@ -348,8 +355,12 @@ metrics_count_over_time_instant
 { } | count_over_time()
 -- endpoint --
 metrics_instant
--- skip_reason --
-cerberus /api/metrics/query handler pending; see metrics_rate_instant
+-- expected_min_series --
+1
+-- expected_max_series --
+50
+-- semantic_checks --
+samples_non_negative
 
 -- name --
 metrics_avg_over_time_instant
@@ -357,8 +368,12 @@ metrics_avg_over_time_instant
 { } | avg_over_time(duration)
 -- endpoint --
 metrics_instant
--- skip_reason --
-cerberus /api/metrics/query handler pending; see metrics_rate_instant
+-- expected_min_series --
+1
+-- expected_max_series --
+50
+-- semantic_checks --
+samples_non_negative
 
 # --- Per-id smoke (1) ---
 # Doesn't map back to a shadow case (the shadow tests evaluate against

--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -108,7 +108,10 @@ func New(client Querier, s schema.Traces, version string, logger *slog.Logger) *
 // metrics pipeline (`| rate()`, `| count_over_time()`, `| *_over_time(...)`)
 // against the spans table and returns the matrix in Tempo's
 // series-of-samples envelope (the shape Grafana's service-graph and
-// metrics dashboards consume).
+// metrics dashboards consume); /api/metrics/query is the instant
+// variant of the same pipeline — single-bucket evaluation over
+// [start, end] returning one (labels, value) per series, matching
+// Tempo's translateQueryRangeToInstant wire shape.
 func (h *Handler) Mount(mux *http.ServeMux) {
 	// Every Tempo endpoint flows through the cerberus.queries.* counter
 	// + duration middleware. /api/echo and /api/status/version
@@ -130,6 +133,7 @@ func (h *Handler) Mount(mux *http.ServeMux) {
 	register("GET /api/v2/search/tag/{name}/values", h.handleSearchTagValuesV2)
 	register("GET /api/traces/{id}", h.handleTraceByID)
 	register("GET /api/metrics/query_range", h.handleMetricsQueryRange)
+	register("GET /api/metrics/query", h.handleMetricsQueryInstant)
 }
 
 func (h *Handler) handleEcho(w http.ResponseWriter, _ *http.Request) {

--- a/internal/api/tempo/metrics_query_instant.go
+++ b/internal/api/tempo/metrics_query_instant.go
@@ -1,0 +1,198 @@
+package tempo
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/api/format"
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/engine"
+	"github.com/tsouza/cerberus/internal/telemetry"
+	traceql_lower "github.com/tsouza/cerberus/internal/traceql"
+)
+
+// MetricsQueryInstantResponse is the body of `GET /api/metrics/query`.
+// Mirrors Tempo's `tempopb.QueryInstantResponse` JSON wire shape — one
+// InstantSeries per (group-by labels) tuple, each carrying a single
+// `value` rather than a `samples` array. Grafana's Tempo datasource
+// uses this for the "now"-style metric widgets that need a scalar per
+// series rather than a matrix.
+//
+// Tempo's reference implementation collapses a range response to an
+// instant one via translateQueryRangeToInstant (modules/frontend/
+// metrics_query_handler.go): step = end - start (one bucket), then
+// each series's first Samples entry becomes the InstantSeries.Value.
+// Cerberus follows the same shape so the differ's CompareMetrics
+// (harness/tempo-compatibility/driver/differ_metrics.go) can canonicalise
+// both backends' responses without a shape-specific branch.
+type MetricsQueryInstantResponse struct {
+	Series []MetricsInstantSeries `json:"series"`
+}
+
+// MetricsInstantSeries is one entry of MetricsQueryInstantResponse.Series.
+// Mirrors `tempopb.InstantSeries` — the `samples` field is replaced by
+// a single `value` scalar.
+type MetricsInstantSeries struct {
+	Labels []MetricsLabel `json:"labels"`
+	Value  float64        `json:"value"`
+}
+
+// handleMetricsQueryInstant implements `GET /api/metrics/query`.
+//
+// Tempo's reference semantics: parse the TraceQL metrics-pipeline query
+// as if it were a range query, but evaluate it over a single bucket
+// spanning [start, end] (step = end - start). Each resulting series is
+// projected to a single (labels, value) tuple — the first sample of
+// the range envelope becomes the instant value. See translateQueryRangeToInstant
+// in upstream tempo modules/frontend/metrics_query_handler.go.
+//
+// Contract: `q` (or `query`) = TraceQL metrics-pipeline expression;
+// `start` / `end` = unix seconds or nanoseconds (parseTempoStartEnd
+// also accepts RFC3339). `step` is unused at the wire level — the
+// handler synthesises it from end-start so the chplan.RangeWindow
+// emits exactly one anchor.
+//
+// Closes the EF noted on #398: PR 5 corpus stubbed three
+// metrics_instant cases with `skip_reason: cerberus /api/metrics/query
+// handler pending`; this handler removes that skip.
+func (h *Handler) handleMetricsQueryInstant(w http.ResponseWriter, r *http.Request) {
+	q := metricsInstantQueryParam(r)
+	if q == "" {
+		writeError(w, http.StatusBadRequest, "", "", errors.New("missing 'q' parameter"))
+		return
+	}
+	start, end, err := parseTempoStartEnd(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "", "", err)
+		return
+	}
+	if start.IsZero() || end.IsZero() {
+		writeError(w, http.StatusBadRequest, "", "", errors.New("'start' and 'end' parameters are required"))
+		return
+	}
+	// Single-bucket evaluation: step = end - start so the inner
+	// chplan.RangeWindow emits exactly one anchor whose sample is the
+	// instant value Tempo's translateQueryRangeToInstant would pick.
+	step := end.Sub(start)
+	if step <= 0 {
+		writeError(w, http.StatusBadRequest, "", "", errors.New("'end' must be after 'start'"))
+		return
+	}
+
+	ctx := r.Context()
+	// Parse + lower inline (same pattern as handleMetricsQueryRange) so
+	// we can wrap the lowered plan with the matrix-shape RangeWindow
+	// before engine.QueryPlan runs.
+	parseT := telemetry.ObserveStage(telemetry.StageParse)
+	expr, perr := parseExpr(ctx, q)
+	parseT.Done(ctx)
+	if perr != nil {
+		writeError(w, http.StatusBadRequest, "", "", perr)
+		return
+	}
+	lowerT := telemetry.ObserveStage(telemetry.StageLower)
+	plan, lerr := traceql_lower.Lower(ctx, expr, h.Schema)
+	lowerT.Done(ctx)
+	if lerr != nil {
+		writeError(w, http.StatusUnprocessableEntity, "", "", lerr)
+		return
+	}
+
+	metrics, ok := unwrapMetricsAggregate(plan)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "", "",
+			fmt.Errorf("query %q is not a TraceQL metrics-pipeline expression — /api/metrics/query requires `| rate()`, `| count_over_time()`, `| *_over_time(...)` or `| quantile_over_time(...)`", q))
+		return
+	}
+
+	rw := &chplan.RangeWindow{
+		Input:           plan,
+		Range:           step,
+		Step:            step,
+		Start:           start,
+		End:             end,
+		TimestampColumn: h.Schema.TimestampColumn,
+	}
+	wrapped := wrapMetricsForSample(rw, metrics)
+
+	res, qerr := h.Engine.QueryPlan(ctx, metricsLang{}, wrapped, engine.Meta{
+		IsMetric:      true,
+		ResponseShape: "tempo-metrics-instant",
+	})
+	if qerr != nil {
+		writeError(w, classifyMetricsQueryRangeErr(qerr), "", "", qerr)
+		return
+	}
+	h.Logger.Debug("cerberus tempo metrics_query_instant",
+		"traceql", q, "start", start, "end", end, "step", step,
+		"sql", res.SQL, "args", res.Args)
+
+	writeEngineHeaders(w, res.Headers)
+	writeJSON(w, http.StatusOK, MetricsQueryInstantResponse{
+		Series: toMetricsInstantSeries(res.Samples, metrics),
+	})
+}
+
+// metricsInstantQueryParam mirrors Tempo's ParseQueryInstantRequest:
+// accept both `q` and `query` (the latter is the original
+// prom-compat alias Grafana still emits on some panels). When both
+// are present the last-set parameter wins — same precedence as
+// upstream's two sequential extractQueryParam calls.
+func metricsInstantQueryParam(r *http.Request) string {
+	vals := r.URL.Query()
+	if s := vals.Get("query"); s != "" {
+		return s
+	}
+	return vals.Get("q")
+}
+
+// toMetricsInstantSeries pivots the flat sample stream into Tempo's
+// instant-series envelope. For each unique label set, the first sample
+// (sorted ascending by timestamp for determinism) becomes the instant
+// value — same rule Tempo's translateQueryRangeToInstant applies
+// upstream. With step=end-start the chplan.RangeWindow emits exactly
+// one anchor per series, so the "first sample" is also the only
+// sample; the sort is defensive against a future RangeWindow that
+// returns multiple anchors.
+func toMetricsInstantSeries(samples []chclient.Sample, m *chplan.MetricsAggregate) []MetricsInstantSeries {
+	labelNames := metricsLabelNames(m.GroupByAliases, len(m.GroupBy))
+
+	type bucket struct {
+		labels   []MetricsLabel
+		firstTS  time.Time
+		firstVal float64
+		filled   bool
+	}
+	byKey := map[string]*bucket{}
+
+	for _, s := range samples {
+		key := format.CanonicalKey(s.Labels)
+		b, ok := byKey[key]
+		if !ok {
+			b = &bucket{labels: labelsFromSample(s.Labels, labelNames)}
+			byKey[key] = b
+		}
+		if !b.filled || s.Timestamp.Before(b.firstTS) {
+			b.firstTS = s.Timestamp
+			b.firstVal = s.Value
+			b.filled = true
+		}
+	}
+
+	keys := make([]string, 0, len(byKey))
+	for k := range byKey {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	out := make([]MetricsInstantSeries, 0, len(byKey))
+	for _, k := range keys {
+		b := byKey[k]
+		out = append(out, MetricsInstantSeries{Labels: b.labels, Value: b.firstVal})
+	}
+	return out
+}

--- a/internal/api/tempo/metrics_query_instant_test.go
+++ b/internal/api/tempo/metrics_query_instant_test.go
@@ -1,0 +1,395 @@
+package tempo_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/api/tempo"
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+// metricsQueryInstantURL builds the test URL for /api/metrics/query.
+// Same q-escaping rationale as metricsQueryRangeURL — TraceQL queries
+// always contain `{` / `}` / quotes / pipes.
+func metricsQueryInstantURL(base, q string, params map[string]string) string {
+	vals := url.Values{}
+	vals.Set("q", q)
+	for k, v := range params {
+		vals.Set(k, v)
+	}
+	return base + "/api/metrics/query?" + vals.Encode()
+}
+
+// TestMetricsQueryInstant_SingleSeriesNoGroupBy — bare `| rate()` over
+// the full spans table returns a single series with one (labels, value)
+// tuple. Validates the response envelope is `{series: [{labels: [],
+// value: N}]}` — no `samples` array.
+func TestMetricsQueryInstant_SingleSeriesNoGroupBy(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{samples: []chclient.Sample{
+		// With step=end-start the inner RangeWindow emits exactly one
+		// anchor per series; the handler propagates that single sample
+		// as the InstantSeries value.
+		{MetricName: "", Labels: map[string]string{}, Timestamp: time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC), Value: 42.0},
+	}}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	u := metricsQueryInstantURL(srv.URL, "{} | rate()", map[string]string{
+		"start": fixtureStartUnix,
+		"end":   fixtureEndUnix,
+	})
+
+	resp, err := http.Get(u)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+
+	var body tempo.MetricsQueryInstantResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Series) != 1 {
+		t.Fatalf("expected 1 series, got %d: %+v", len(body.Series), body)
+	}
+	s := body.Series[0]
+	if len(s.Labels) != 0 {
+		t.Errorf("expected zero labels for ungrouped query, got %+v", s.Labels)
+	}
+	if s.Value != 42.0 {
+		t.Errorf("expected value 42, got %v", s.Value)
+	}
+
+	// JSON body must NOT contain a `samples` key — instant shape is a
+	// scalar `value`, not a samples array. Probing the raw response
+	// guards against a future struct-tag drift that would silently
+	// double-emit both shapes.
+	rawResp, err := http.Get(u)
+	if err != nil {
+		t.Fatalf("GET (raw): %v", err)
+	}
+	rawBody := readBody(t, rawResp)
+	if strings.Contains(rawBody, `"samples"`) {
+		t.Errorf("instant response must not include 'samples' key: %s", rawBody)
+	}
+	if !strings.Contains(rawBody, `"value"`) {
+		t.Errorf("instant response must include 'value' key: %s", rawBody)
+	}
+
+	// Should hit the matrix-shape SQL emitter, same emitter as
+	// /api/metrics/query_range. Probe for the hallmark substrings to
+	// confirm we're routing through emitRangeWindowMetrics rather than
+	// a Sprintf fallback.
+	assertSQLContains(t, q.lastSQL, "arrayJoin")
+	assertSQLContains(t, q.lastSQL, "anchor_ts")
+}
+
+// TestMetricsQueryInstant_MultiSeriesGroupBy — `| count_over_time() by
+// (resource.service.name)` returns one InstantSeries per unique service,
+// each carrying a single Value. Order across series is deterministic
+// (sorted by canonical label-set key).
+func TestMetricsQueryInstant_MultiSeriesGroupBy(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC)
+	q := &stubQuerier{samples: []chclient.Sample{
+		{Labels: map[string]string{"resource.service.name": "frontend"}, Timestamp: ts, Value: 12},
+		{Labels: map[string]string{"resource.service.name": "backend"}, Timestamp: ts, Value: 3},
+	}}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	u := metricsQueryInstantURL(srv.URL,
+		"{} | count_over_time() by (resource.service.name)",
+		map[string]string{
+			"start": fixtureStartUnix,
+			"end":   fixtureEndUnix,
+		})
+	resp, err := http.Get(u)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+
+	var body tempo.MetricsQueryInstantResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Series) != 2 {
+		t.Fatalf("expected 2 series, got %d: %+v", len(body.Series), body)
+	}
+	byService := map[string]tempo.MetricsInstantSeries{}
+	for _, s := range body.Series {
+		if len(s.Labels) != 1 || s.Labels[0].Key != "resource.service.name" {
+			t.Errorf("unexpected labels: %+v", s.Labels)
+			continue
+		}
+		byService[s.Labels[0].Value] = s
+	}
+	if byService["frontend"].Value != 12 {
+		t.Errorf("expected frontend=12, got %v", byService["frontend"].Value)
+	}
+	if byService["backend"].Value != 3 {
+		t.Errorf("expected backend=3, got %v", byService["backend"].Value)
+	}
+}
+
+// TestMetricsQueryInstant_FirstSamplePerSeries — when the inner range
+// envelope emits multiple anchors per series (a defensive case for
+// future RangeWindow shapes), the handler picks the *first* sample
+// (sorted ascending by timestamp), matching Tempo's
+// translateQueryRangeToInstant rule upstream.
+func TestMetricsQueryInstant_FirstSamplePerSeries(t *testing.T) {
+	t.Parallel()
+
+	ts := func(min int) time.Time {
+		return time.Date(2026, 5, 12, 10, min, 0, 0, time.UTC)
+	}
+	q := &stubQuerier{samples: []chclient.Sample{
+		// Intentionally out of order: handler must pick the earliest TS.
+		{Labels: map[string]string{}, Timestamp: ts(2), Value: 99},
+		{Labels: map[string]string{}, Timestamp: ts(0), Value: 7},
+		{Labels: map[string]string{}, Timestamp: ts(1), Value: 50},
+	}}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	u := metricsQueryInstantURL(srv.URL, "{} | rate()", map[string]string{
+		"start": fixtureStartUnix,
+		"end":   fixtureEndUnix,
+	})
+	resp, err := http.Get(u)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	var body tempo.MetricsQueryInstantResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Series) != 1 {
+		t.Fatalf("expected 1 series, got %d", len(body.Series))
+	}
+	if body.Series[0].Value != 7 {
+		t.Errorf("expected first-sample value 7 (ts=10:00), got %v", body.Series[0].Value)
+	}
+}
+
+// TestMetricsQueryInstant_EmptyResult — when CH returns zero rows, the
+// envelope is `{series: []}` (not `null`). Matches the range handler's
+// behaviour so Grafana renders "no data" rather than a JSON-shape error.
+func TestMetricsQueryInstant_EmptyResult(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{samples: nil}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	u := metricsQueryInstantURL(srv.URL, "{} | rate()", map[string]string{
+		"start": fixtureStartUnix,
+		"end":   fixtureEndUnix,
+	})
+	resp, err := http.Get(u)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	var body tempo.MetricsQueryInstantResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Series == nil {
+		t.Fatalf("expected non-nil empty Series slice, got nil (JSON null)")
+	}
+	if len(body.Series) != 0 {
+		t.Fatalf("expected 0 series, got %d", len(body.Series))
+	}
+}
+
+// TestMetricsQueryInstant_QueryParamAliases — Tempo's
+// ParseQueryInstantRequest accepts both `q` and `query` for the TraceQL
+// expression (`query` is the prom-compat alias Grafana still emits on
+// some panels). Both forms must reach the handler.
+func TestMetricsQueryInstant_QueryParamAliases(t *testing.T) {
+	t.Parallel()
+
+	for _, key := range []string{"q", "query"} {
+		key := key
+		t.Run("param="+key, func(t *testing.T) {
+			t.Parallel()
+			q := &stubQuerier{samples: []chclient.Sample{{
+				Labels:    map[string]string{},
+				Timestamp: time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC),
+				Value:     1.0,
+			}}}
+			srv := newServer(q, "v1.0.0-test")
+			t.Cleanup(srv.Close)
+
+			vals := url.Values{}
+			vals.Set(key, "{} | rate()")
+			vals.Set("start", fixtureStartUnix)
+			vals.Set("end", fixtureEndUnix)
+			u := srv.URL + "/api/metrics/query?" + vals.Encode()
+			resp, err := http.Get(u)
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+			}
+		})
+	}
+}
+
+// TestMetricsQueryInstant_BadInputs covers the 4xx surface: missing or
+// malformed `q` / `start` / `end`, and a non-metric TraceQL query.
+func TestMetricsQueryInstant_BadInputs(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		params  map[string]string
+		wantSub string
+	}{
+		{
+			name:    "missing_q",
+			params:  map[string]string{"start": fixtureStartUnix, "end": fixtureEndUnix},
+			wantSub: "missing 'q'",
+		},
+		{
+			name:    "missing_start",
+			params:  map[string]string{"q": "{} | rate()", "end": fixtureEndUnix},
+			wantSub: "required",
+		},
+		{
+			name:    "missing_end",
+			params:  map[string]string{"q": "{} | rate()", "start": fixtureStartUnix},
+			wantSub: "required",
+		},
+		{
+			name: "malformed_time",
+			params: map[string]string{
+				"q":     "{} | rate()",
+				"start": "not-a-time",
+				"end":   fixtureEndUnix,
+			},
+			wantSub: "time",
+		},
+		{
+			name: "end_before_start",
+			params: map[string]string{
+				"q":     "{} | rate()",
+				"start": fixtureEndUnix,
+				"end":   fixtureStartUnix,
+			},
+			wantSub: "before",
+		},
+		{
+			name: "parse_error",
+			params: map[string]string{
+				"q":     "this is not traceql {{{",
+				"start": fixtureStartUnix,
+				"end":   fixtureEndUnix,
+			},
+			wantSub: "",
+		},
+		{
+			name: "non_metric_query",
+			params: map[string]string{
+				// Bare spanset with no metrics pipeline — lowers to a
+				// Filter(Scan), not a MetricsAggregate.
+				"q":     `{ resource.service.name = "frontend" }`,
+				"start": fixtureStartUnix,
+				"end":   fixtureEndUnix,
+			},
+			wantSub: "metrics-pipeline",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			q := &stubQuerier{}
+			srv := newServer(q, "v1.0.0-test")
+			t.Cleanup(srv.Close)
+
+			vals := url.Values{}
+			for k, v := range tc.params {
+				vals.Set(k, v)
+			}
+			u := srv.URL + "/api/metrics/query?" + vals.Encode()
+
+			resp, err := http.Get(u)
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode < 400 || resp.StatusCode >= 500 {
+				t.Fatalf("expected 4xx, got status=%d body=%s",
+					resp.StatusCode, readBody(t, resp))
+			}
+			var er tempo.ErrorResponse
+			body := readBody(t, resp)
+			if err := json.Unmarshal([]byte(body), &er); err != nil {
+				t.Fatalf("decode: %v body=%s", err, body)
+			}
+			if !er.Error {
+				t.Errorf("expected error=true, got %+v", er)
+			}
+			if tc.wantSub != "" && !strings.Contains(er.Message, tc.wantSub) {
+				t.Errorf("error message missing %q: got %q", tc.wantSub, er.Message)
+			}
+		})
+	}
+}
+
+// TestMetricsQueryInstant_CHFailure — a CH-side error surfaces as 502
+// plus the Tempo error envelope, matching the range handler.
+func TestMetricsQueryInstant_CHFailure(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{err: errors.New("clickhouse: connection refused")}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	u := metricsQueryInstantURL(srv.URL, "{} | rate()", map[string]string{
+		"start": fixtureStartUnix,
+		"end":   fixtureEndUnix,
+	})
+	resp, err := http.Get(u)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status=%d, want 502 body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	var er tempo.ErrorResponse
+	if err := json.NewDecoder(resp.Body).Decode(&er); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !er.Error || !strings.Contains(er.Message, "connection refused") {
+		t.Errorf("expected error envelope with upstream message; got %+v", er)
+	}
+}

--- a/test/regression/goleak_test.go
+++ b/test/regression/goleak_test.go
@@ -325,6 +325,32 @@ func TestNoGoroutineLeak_TempoTraceByID(t *testing.T) {
 	}
 }
 
+// TestNoGoroutineLeak_TempoMetricsQueryInstant exercises the instant
+// variant of the TraceQL metrics pipeline — the handler shares the
+// matrix-shape RangeWindow plan with /api/metrics/query_range but
+// runs it over a single bucket (step=end-start). A regression here
+// would surface as a goroutine spawned per request by the metrics
+// engine path that the handler then forgets to tear down.
+func TestNoGoroutineLeak_TempoMetricsQueryInstant(t *testing.T) {
+	defer goleak.VerifyNone(t, goleakOpts()...)
+
+	h := tempo.New(&tempoStub{}, schema.DefaultOTelTraces(), "v1.0.0", slog.Default())
+	mux := http.NewServeMux()
+	h.Mount(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	for range 30 {
+		u := fmt.Sprintf("%s/api/metrics/query?q=%%7B%%7D%%20%%7C%%20rate()&start=%d&end=%d",
+			srv.URL, time.Now().Add(-1*time.Hour).Unix(), time.Now().Unix())
+		resp, err := http.Get(u)
+		if err != nil {
+			t.Fatalf("GET: %v", err)
+		}
+		_ = resp.Body.Close()
+	}
+}
+
 // TestNoGoroutineLeak_UnderError — drives requests against a failing CH
 // stub so the error path is the one exercised. Different goroutine
 // graph than the happy path (no streaming cursor open, immediate


### PR DESCRIPTION
## Summary

Implements the TraceQL instant-metrics endpoint (`GET /api/metrics/query`). Tempo's reference semantics: parse the metrics-pipeline query as if it were a range query, evaluate over a single bucket (`step = end - start`), then project each series's first sample as `InstantSeries.Value`. Cerberus follows that recipe by reusing the existing matrix-shape `chplan.RangeWindow` plan from `/api/metrics/query_range` with `step = end - start`, then pivoting `chclient.Sample` rows into the `tempopb.QueryInstantResponse` JSON shape.

- New `internal/api/tempo/metrics_query_instant.go` — handler + response types.
- New route `GET /api/metrics/query` registered in `Handler.Mount`.
- Unit tests in `internal/api/tempo/metrics_query_instant_test.go` covering single-series + multi-series-groupby + first-sample-per-series + empty-result + `q`/`query` aliases + the 4xx surface (missing q / start / end, malformed time, end-before-start, parse error, non-metric query) + 502 on CH failure.
- Goleak detector for the new entrypoint in `test/regression/goleak_test.go` for parity with #253.
- Three `metrics_instant` cases in `harness/tempo-compatibility/driver/corpus/smoke.txtar` (`metrics_rate_instant`, `metrics_count_over_time_instant`, `metrics_avg_over_time_instant`) flipped from `skip_reason: cerberus /api/metrics/query handler pending` to active, with `expected_min_series` / `expected_max_series` + `samples_non_negative` / `labels_match_query` semantic checks matching their range counterparts.

Closes the EF noted on #398: PR 5 of the tempo-compatibility plan shipped the metrics corpus with the instant cases stubbed pending this handler.

## Wire shape

```json
{
  "series": [
    { "labels": [{"key": "resource.service.name", "value": "checkout"}], "value": 12 }
  ]
}
```

`samples` is intentionally omitted — the unit test asserts the raw JSON body contains `"value"` and does not contain `"samples"`.

## Test plan

- [x] `go build ./internal/api/tempo/...` clean.
- [x] `go vet ./internal/api/tempo/... ./test/regression/... ./harness/tempo-compatibility/driver/...` clean.
- [ ] CI `check` + `lint` green.
- [ ] Nightly `tempo-compatibility` workflow exercises the three newly-active `metrics_instant` cases against real Tempo + cerberus.

## Cross-refs

- PR #398 — the PR 5 corpus + differ that stubbed these instant cases.
- `harness/tempo-compatibility/driver/differ_metrics.go` `CompareMetrics` already handles the instant shape (it canonicalises by label-set hash and diffs `Value` when both sides populate it).
- Upstream Tempo: `modules/frontend/metrics_query_handler.go::translateQueryRangeToInstant` is the reference algorithm cerberus mirrors.