### PR TITLE
feat(api/tempo): add Exemplars[] envelope to MetricsSeries (empty)

### DIFF
--- a/internal/api/tempo/metrics_query_range.go
+++ b/internal/api/tempo/metrics_query_range.go
@@ -29,9 +29,23 @@ type MetricsQueryRangeResponse struct {
 }
 
 // MetricsSeries is one entry of MetricsQueryRangeResponse.Series.
+//
+// Exemplars is always emitted as a JSON array (never omitted), even
+// when empty, so Grafana's Tempo datasource sees a stable envelope
+// shape; cerberus does not yet populate exemplars (placeholder for a
+// follow-up that wires trace-anchored samples through). See EF #398.
 type MetricsSeries struct {
-	Labels  []MetricsLabel  `json:"labels"`
-	Samples []MetricsSample `json:"samples"`
+	Labels    []MetricsLabel  `json:"labels"`
+	Samples   []MetricsSample `json:"samples"`
+	Exemplars []Exemplar      `json:"exemplars"`
+}
+
+// Exemplar is one trace-anchored sample point in MetricsSeries.Exemplars.
+type Exemplar struct {
+	Value     float64 `json:"value"`
+	Timestamp int64   `json:"timestamp_ms"`
+	TraceID   string  `json:"traceID"`
+	SpanID    string  `json:"spanID,omitempty"`
 }
 
 // MetricsLabel is one (key, value) pair in MetricsSeries.Labels.
@@ -406,7 +420,11 @@ func toMetricsSeries(samples []chclient.Sample, m *chplan.MetricsAggregate) []Me
 		sort.Slice(b.samples, func(i, j int) bool {
 			return b.samples[i].TimestampMs < b.samples[j].TimestampMs
 		})
-		out = append(out, MetricsSeries{Labels: b.labels, Samples: b.samples})
+		out = append(out, MetricsSeries{
+			Labels:    b.labels,
+			Samples:   b.samples,
+			Exemplars: []Exemplar{},
+		})
 	}
 	return out
 }

--- a/internal/api/tempo/metrics_query_range_test.go
+++ b/internal/api/tempo/metrics_query_range_test.go
@@ -481,3 +481,38 @@ func TestMetricsQueryRange_StepDurationForms(t *testing.T) {
 		})
 	}
 }
+
+// TestMetricsQueryRange_ExemplarsEnvelope pins the wire-shape contract
+// that every MetricsSeries emits `"exemplars": []` even before cerberus
+// populates them. Grafana's Tempo datasource expects the field, so
+// omitting it (or rendering it as null) destabilises the envelope. See
+// EF #398 for the broader Tempo metrics shape parity work.
+func TestMetricsQueryRange_ExemplarsEnvelope(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{samples: []chclient.Sample{{
+		Labels:    map[string]string{},
+		Timestamp: time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC),
+		Value:     1.0,
+	}}}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	u := metricsQueryRangeURL(srv.URL, "{} | rate()", map[string]string{
+		"start": fixtureStartUnix,
+		"end":   fixtureEndUnix,
+		"step":  "60s",
+	})
+	resp, err := http.Get(u)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	raw := readBody(t, resp)
+	if !strings.Contains(raw, `"exemplars":[]`) {
+		t.Fatalf("response missing empty exemplars array\nbody=%s", raw)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `Exemplars []Exemplar` field to `MetricsSeries` so every entry in `/api/metrics/query_range`'s response carries the field on the wire.
- Always emit as a JSON array (never omit / null) — `toMetricsSeries` initialises the slice to a non-nil empty slice, and the JSON tag is `"exemplars"` (no `omitempty`).
- Cerberus does not yet populate exemplars; this PR is the envelope-shape contract only. No SQL / plan / data path change.
- Defines `Exemplar { Value, Timestamp, TraceID, SpanID }` matching the tempopb-style wire shape Grafana's datasource expects.

Refs #398.

## Test plan

- [x] `TestMetricsQueryRange_ExemplarsEnvelope` asserts the wire body contains `"exemplars":[]` for an ungrouped `| rate()` query.
- [ ] CI: `check` + `lint` green.