### PR TITLE
feat(logql): extract group_left/right include-labels helper

### DIFF
--- a/internal/logql/binary.go
+++ b/internal/logql/binary.go
@@ -224,6 +224,30 @@ func vectorMatchingFromOpts(vm *syntax.VectorMatching) (chplan.VectorCard, chpla
 	return card, match, include, nil
 }
 
+// includeLabelsFromBinop returns the labels listed in `group_left(...)` /
+// `group_right(...)` of the binop's VectorMatching. Returns an empty
+// (non-nil) slice when the binop has no Opts, no VectorMatching, or
+// when the matching declares no Include labels.
+//
+// Sources `b.Opts.VectorMatching.Include`. The returned slice is a fresh
+// copy — callers may retain or mutate it without aliasing the parser AST.
+//
+// Pre-thread for #393: aggregation lowering will read this to project
+// the join-side include labels onto the aggregation output. The helper
+// itself does not yet feed any caller — that wiring lands in a follow-up.
+func includeLabelsFromBinop(b *syntax.BinOpExpr) []string {
+	if b == nil || b.Opts == nil || b.Opts.VectorMatching == nil {
+		return []string{}
+	}
+	src := b.Opts.VectorMatching.Include
+	if len(src) == 0 {
+		return []string{}
+	}
+	out := make([]string, len(src))
+	copy(out, src)
+	return out
+}
+
 // logqlBinaryOp maps a LogQL parser op string to the chplan op enum.
 // Arithmetic and comparison ops are handled here; logical ops
 // (`and` / `or` / `unless`) defer to a later milestone.

--- a/internal/logql/binary_test.go
+++ b/internal/logql/binary_test.go
@@ -1,0 +1,83 @@
+package logql
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+)
+
+// TestIncludeLabelsFromBinop pins the surface of [includeLabelsFromBinop]:
+// the helper returns the labels declared inside `group_left(...)` /
+// `group_right(...)` of a binop's VectorMatching, and returns an empty
+// (non-nil) slice when no Include list is present.
+//
+// Pre-threading work for #393 (LogQL include-labels through aggregation
+// lowering).
+func TestIncludeLabelsFromBinop(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		query string
+		want  []string
+	}{
+		{
+			name:  "bare op has no include labels",
+			query: `sum(rate({app="api"}[1m])) + sum(rate({app="db"}[1m]))`,
+			want:  []string{},
+		},
+		{
+			name:  "group_left single label",
+			query: `sum by (svc) (rate({app="api"}[1m])) * on (svc) group_left(env) sum by (svc, env) (rate({app="meta"}[1m]))`,
+			want:  []string{"env"},
+		},
+		{
+			name:  "group_left multiple labels",
+			query: `sum by (svc) (rate({app="api"}[1m])) * on (svc) group_left(env, region) sum by (svc, env, region) (rate({app="meta"}[1m]))`,
+			want:  []string{"env", "region"},
+		},
+		{
+			name:  "group_right with ignoring",
+			query: `sum by (svc, level) (rate({app="meta"}[1m])) * ignoring(level) group_right(svc) sum by (svc) (rate({app="api"}[1m]))`,
+			want:  []string{"svc"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			expr, err := syntax.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", tc.query, err)
+			}
+			binop, ok := expr.(*syntax.BinOpExpr)
+			if !ok {
+				t.Fatalf("ParseExpr(%q): expected *syntax.BinOpExpr, got %T", tc.query, expr)
+			}
+
+			got := includeLabelsFromBinop(binop)
+			if got == nil {
+				t.Fatalf("includeLabelsFromBinop returned nil slice; want non-nil")
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("includeLabelsFromBinop = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIncludeLabelsFromBinopNil guards the defensive nil-input path so
+// future call sites can pass a possibly-nil binop without panicking.
+func TestIncludeLabelsFromBinopNil(t *testing.T) {
+	t.Parallel()
+
+	got := includeLabelsFromBinop(nil)
+	if got == nil {
+		t.Fatalf("includeLabelsFromBinop(nil) returned nil; want empty slice")
+	}
+	if len(got) != 0 {
+		t.Fatalf("includeLabelsFromBinop(nil) = %v, want empty slice", got)
+	}
+}


### PR DESCRIPTION
## Summary

Pre-threading for #393. Adds an unexported helper `includeLabelsFromBinop(b *syntax.BinOpExpr) []string` in `internal/logql/binary.go` that returns the labels declared inside `group_left(...)` / `group_right(...)` of a binop's `VectorMatching`. Returns an empty (non-nil) slice when no `Opts` / `VectorMatching` / `Include` list is present, and when `b` itself is nil.

Sources `b.Opts.VectorMatching.Include` (the same field the existing `vectorMatchingFromOpts` already consumes) and returns a fresh copy so callers can retain or mutate it without aliasing the parser AST.

Tiny scope on purpose: no call sites yet. The wiring into LogQL vector-aggregation lowering — projecting the join-side include labels onto the aggregation output — lands in the follow-up PR that closes #393.

## Test plan

- [x] `TestIncludeLabelsFromBinop` table-driven cases (bare op, `group_left(env)`, `group_left(env, region)`, `ignoring(level) group_right(svc)`)
- [x] `TestIncludeLabelsFromBinopNil` guards the defensive nil-input path
- [ ] CI `check` + `lint`

Refs #393.