### PR TITLE
feat(api/tempo): wire exemplars into metrics handlers

### DIFF
--- a/internal/api/tempo/metrics_query_range.go
+++ b/internal/api/tempo/metrics_query_range.go
@@ -14,6 +14,7 @@ import (
 	"github.com/tsouza/cerberus/internal/api/format"
 	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
 	"github.com/tsouza/cerberus/internal/engine"
 	"github.com/tsouza/cerberus/internal/telemetry"
 	traceql_lower "github.com/tsouza/cerberus/internal/traceql"
@@ -42,10 +43,11 @@ type MetricsSeries struct {
 
 // Exemplar is one trace-anchored sample point in MetricsSeries.Exemplars.
 type Exemplar struct {
-	Value     float64 `json:"value"`
-	Timestamp int64   `json:"timestamp_ms"`
-	TraceID   string  `json:"traceID"`
-	SpanID    string  `json:"spanID,omitempty"`
+	Labels    []MetricsLabel `json:"labels"`
+	Value     float64        `json:"value"`
+	Timestamp int64          `json:"timestamp_ms"`
+	TraceID   string         `json:"traceID"`
+	SpanID    string         `json:"spanID,omitempty"`
 }
 
 // MetricsLabel is one (key, value) pair in MetricsSeries.Labels.
@@ -249,9 +251,20 @@ func (h *Handler) handleMetricsQueryRange(w http.ResponseWriter, r *http.Request
 		"traceql", q, "start", start, "end", end, "step", step,
 		"sql", res.SQL, "args", res.Args)
 
+	series := toMetricsSeries(res.Samples, metrics)
+
+	exSQL, exArgs, exErr := chsql.EmitMetricsExemplars(ctx, rw, metrics,
+		h.Schema.TraceIDColumn, h.Schema.SpanIDColumn, 1)
+	if exErr == nil {
+		exSamples, qErr := h.Client.Query(ctx, exSQL, exArgs...)
+		if qErr == nil {
+			attachExemplars(series, exSamples, metrics)
+		}
+	}
+
 	writeEngineHeaders(w, res.Headers)
 	writeJSON(w, http.StatusOK, MetricsQueryRangeResponse{
-		Series: toMetricsSeries(res.Samples, metrics),
+		Series: series,
 	})
 }
 
@@ -456,4 +469,61 @@ func labelsFromSample(attrs map[string]string, labelNames []string) []MetricsLab
 		out = append(out, MetricsLabel{Key: k, Value: attrs[k]})
 	}
 	return out
+}
+
+func attachExemplars(series []MetricsSeries, exSamples []chclient.Sample, m *chplan.MetricsAggregate) {
+	labelNames := metricsLabelNames(m.GroupByAliases, len(m.GroupBy))
+	byKey := make(map[string]*MetricsSeries, len(series))
+	for i := range series {
+		key := format.CanonicalKey(labelsToMap(series[i].Labels))
+		byKey[key] = &series[i]
+	}
+
+	for _, s := range exSamples {
+		traceID := s.Labels["trace:id"]
+		spanID := s.Labels["span:id"]
+		if traceID == "" {
+			continue
+		}
+		groupLabels := make(map[string]string, len(s.Labels))
+		for _, name := range labelNames {
+			if v, ok := s.Labels[name]; ok {
+				groupLabels[name] = v
+			}
+		}
+		key := format.CanonicalKey(groupLabels)
+		ps, ok := byKey[key]
+		if !ok {
+			continue
+		}
+		exLabels := make([]MetricsLabel, 0, 2)
+		exLabels = append(exLabels, MetricsLabel{Key: "trace:id", Value: traceID})
+		if spanID != "" {
+			exLabels = append(exLabels, MetricsLabel{Key: "span:id", Value: spanID})
+		}
+		ps.Exemplars = append(ps.Exemplars, Exemplar{
+			Labels:    exLabels,
+			Value:     s.Value,
+			Timestamp: s.Timestamp.UnixMilli(),
+			TraceID:   traceID,
+			SpanID:    spanID,
+		})
+	}
+
+	for i := range series {
+		if len(series[i].Exemplars) == 0 {
+			series[i].Exemplars = []Exemplar{}
+		}
+		sort.Slice(series[i].Exemplars, func(j, k int) bool {
+			return series[i].Exemplars[j].Timestamp < series[i].Exemplars[k].Timestamp
+		})
+	}
+}
+
+func labelsToMap(labels []MetricsLabel) map[string]string {
+	m := make(map[string]string, len(labels))
+	for _, l := range labels {
+		m[l.Key] = l.Value
+	}
+	return m
 }

--- a/internal/chsql/exemplars.go
+++ b/internal/chsql/exemplars.go
@@ -1,0 +1,192 @@
+package chsql
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/tsouza/cerberus/internal/cerbtrace"
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+func EmitMetricsExemplars(
+	ctx context.Context,
+	rw *chplan.RangeWindow,
+	m *chplan.MetricsAggregate,
+	traceIDCol, spanIDCol string,
+	maxPerSeries int64,
+) (string, []any, error) {
+	_, span := tracer.Start(ctx, cerbtrace.SpanEmit)
+	defer span.End()
+
+	if rw == nil {
+		err := fmt.Errorf("%w: RangeWindow is nil", ErrUnsupported)
+		span.RecordError(err)
+		return "", nil, err
+	}
+	if m == nil {
+		err := fmt.Errorf("%w: MetricsAggregate is nil", ErrUnsupported)
+		span.RecordError(err)
+		return "", nil, err
+	}
+	if rw.TimestampColumn == "" {
+		err := fmt.Errorf("%w: RangeWindow.TimestampColumn unset (required for exemplar emission)", ErrUnsupported)
+		span.RecordError(err)
+		return "", nil, err
+	}
+	if rw.Step <= 0 {
+		err := fmt.Errorf("%w: RangeWindow wrapping exemplars requires Step > 0", ErrUnsupported)
+		span.RecordError(err)
+		return "", nil, err
+	}
+	if m.Inner == nil {
+		err := fmt.Errorf("%w: MetricsAggregate.Inner is nil", ErrUnsupported)
+		span.RecordError(err)
+		return "", nil, err
+	}
+	if traceIDCol == "" {
+		err := fmt.Errorf("%w: traceIDCol is empty", ErrUnsupported)
+		span.RecordError(err)
+		return "", nil, err
+	}
+	if spanIDCol == "" {
+		err := fmt.Errorf("%w: spanIDCol is empty", ErrUnsupported)
+		span.RecordError(err)
+		return "", nil, err
+	}
+
+	e := &emitter{}
+	if err := e.emitMetricsExemplars(rw, m, traceIDCol, spanIDCol, maxPerSeries); err != nil {
+		span.RecordError(err)
+		return "", nil, err
+	}
+	sql := e.b.String()
+	span.SetAttributes(cerbtrace.AttrSQLLength.Int(len(sql)))
+	return sql, e.args, nil
+}
+
+func (e *emitter) emitMetricsExemplars(
+	rw *chplan.RangeWindow,
+	m *chplan.MetricsAggregate,
+	traceIDCol, spanIDCol string,
+	maxPerSeries int64,
+) error {
+	for _, g := range m.GroupBy {
+		if err := (&Builder{}).Expr(g); err != nil {
+			return err
+		}
+	}
+
+	end := endExprFrag(rw)
+	stepNS := rw.Step.Nanoseconds()
+	rangeDur := rw.Range
+	if rangeDur == 0 {
+		rangeDur = rw.Step
+	}
+	rangeNS := rangeDur.Nanoseconds()
+
+	var numAnchors int64
+	switch {
+	case rw.OuterRange > 0:
+		numAnchors = rw.OuterRange.Nanoseconds()/stepNS + 1
+	case !rw.Start.IsZero() && !rw.End.IsZero():
+		span := rw.End.Sub(rw.Start).Nanoseconds()
+		if span < 0 {
+			return fmt.Errorf("%w: RangeWindow.Start > End", ErrUnsupported)
+		}
+		numAnchors = span/stepNS + 1
+	default:
+		numAnchors = 1
+	}
+
+	inner, err := e.subqueryFrag(m.Inner)
+	if err != nil {
+		return err
+	}
+
+	groupAliases := outerGroupAliases(m.GroupBy, m.GroupByAliases)
+
+	innerSb := NewQuery().From(inner)
+	for i, g := range m.GroupBy {
+		expr := g
+		alias := groupAliases[i]
+		innerSb.SelectAs(func(b *Builder) { _ = b.Expr(expr) }, alias)
+	}
+	tsCol := rw.TimestampColumn
+	innerSb.SelectAs(func(b *Builder) { b.Ident(tsCol) }, "ts")
+	if m.Op != chplan.MetricsOpRate && m.Op != chplan.MetricsOpCountOverTime && m.Attr != nil {
+		attr := m.Attr
+		innerSb.SelectAs(func(b *Builder) { _ = b.Expr(attr) }, "metric_arg")
+	}
+	innerSb.SelectAs(func(b *Builder) { b.Ident(traceIDCol) }, "exemplar_trace_id")
+	innerSb.SelectAs(func(b *Builder) { b.Ident(spanIDCol) }, "exemplar_span_id")
+	innerSb.SelectAs(
+		anchorFanoutFrag(end, stepNS, numAnchors),
+		"anchor_ts",
+	)
+
+	outerSb := NewQuery().From(innerSb.Frag())
+
+	outerSb.Select(As(Lit(""), "MetricName"))
+
+	for _, alias := range groupAliases {
+		a := alias
+		outerSb.Select(func(b *Builder) { b.Ident(a) })
+	}
+
+	attrMapFrags := make([]Frag, 0, len(groupAliases)*2+4)
+	for _, alias := range groupAliases {
+		a := alias
+		attrMapFrags = append(attrMapFrags,
+			Lit(a),
+			Call("toString", Col(a)),
+		)
+	}
+	attrMapFrags = append(attrMapFrags,
+		Lit("trace:id"),
+		Call("argMax", Col("exemplar_trace_id"), Col("ts")),
+		Lit("span:id"),
+		Call("argMax", Col("exemplar_span_id"), Col("ts")),
+	)
+	outerSb.Select(As(
+		Call("map", attrMapFrags...),
+		"Attributes",
+	))
+	outerSb.SelectAs(Col("anchor_ts"), "TimeUnix")
+
+	var valueFrag Frag
+	if m.Op == chplan.MetricsOpRate || m.Op == chplan.MetricsOpCountOverTime {
+		valueFrag = Call("toFloat64", Call("argMax", InlineLit(int64(1)), Col("ts")))
+	} else if m.Attr != nil {
+		valueFrag = Call("toFloat64", Call("argMax", Col("metric_arg"), Col("ts")))
+	} else {
+		valueFrag = Call("toFloat64", Call("argMax", InlineLit(int64(1)), Col("ts")))
+	}
+	outerSb.Select(As(valueFrag, "Value"))
+
+	outerSb.Where(
+		windowTsLowerBoundFrag(rangeNS),
+		verbatim("ts <= anchor_ts"),
+	)
+
+	groupFrags := make([]Frag, 0, len(groupAliases)+1)
+	for _, alias := range groupAliases {
+		a := alias
+		groupFrags = append(groupFrags, func(b *Builder) { b.Ident(a) })
+	}
+	groupFrags = append(groupFrags, Col("anchor_ts"))
+	outerSb.GroupBy(groupFrags...)
+
+	if maxPerSeries > 0 {
+		limitByFrags := make([]Frag, 0, len(groupAliases))
+		for _, alias := range groupAliases {
+			a := alias
+			limitByFrags = append(limitByFrags, func(b *Builder) { b.Ident(a) })
+		}
+		limitByFrags = append(limitByFrags, Col("anchor_ts"))
+		outerSb.Limit(maxPerSeries)
+		outerSb.LimitBy(limitByFrags...)
+	}
+
+	e.emitSelect(outerSb)
+	return nil
+}

--- a/internal/chsql/exemplars_test.go
+++ b/internal/chsql/exemplars_test.go
@@ -1,0 +1,110 @@
+package chsql_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+)
+
+func TestEmitMetricsExemplars_NilRangeWindow(t *testing.T) {
+	t.Parallel()
+	_, _, err := chsql.EmitMetricsExemplars(context.Background(), nil, &chplan.MetricsAggregate{
+		Op:         chplan.MetricsOpRate,
+		ValueAlias: "Value",
+		Inner:      &chplan.Scan{Table: "otel_traces"},
+	}, "TraceId", "SpanId", 1)
+	if err == nil {
+		t.Fatalf("expected error for nil RangeWindow, got nil")
+	}
+	if !errors.Is(err, chsql.ErrUnsupported) {
+		t.Errorf("expected ErrUnsupported, got %v", err)
+	}
+}
+
+func TestEmitMetricsExemplars_MissingColumns(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name        string
+		traceIDCol  string
+		spanIDCol   string
+		wantSub     string
+	}{
+		{name: "empty_trace_id", traceIDCol: "", spanIDCol: "SpanId", wantSub: "traceIDCol"},
+		{name: "empty_span_id", traceIDCol: "TraceId", spanIDCol: "", wantSub: "spanIDCol"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			plan := &chplan.RangeWindow{
+				Input: &chplan.MetricsAggregate{
+					Op:         chplan.MetricsOpRate,
+					ValueAlias: "Value",
+					Inner:      &chplan.Scan{Table: "otel_traces"},
+				},
+				Step:            time.Minute,
+				Range:           time.Minute,
+				Start:           time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC),
+				End:             time.Date(2026, 5, 13, 12, 5, 0, 0, time.UTC),
+				TimestampColumn: "Timestamp",
+			}
+			_, _, err := chsql.EmitMetricsExemplars(context.Background(), plan,
+				plan.Input.(*chplan.MetricsAggregate),
+				tc.traceIDCol, tc.spanIDCol, 1)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("error %q missing substring %q", err.Error(), tc.wantSub)
+			}
+		})
+	}
+}
+
+func TestEmitMetricsExemplars_ShapeSanity(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 5, 13, 12, 5, 0, 0, time.UTC)
+	m := &chplan.MetricsAggregate{
+		Op:             chplan.MetricsOpRate,
+		GroupBy:        []chplan.Expr{&chplan.ColumnRef{Name: "resource.service.name"}},
+		GroupByAliases: []string{"resource.service.name"},
+		ValueAlias:     "Value",
+		Inner:          &chplan.Scan{Table: "otel_traces"},
+	}
+	rw := &chplan.RangeWindow{
+		Input:           m,
+		Step:            time.Minute,
+		Range:           time.Minute,
+		Start:           start,
+		End:             end,
+		TimestampColumn: "Timestamp",
+	}
+
+	sql, args, err := chsql.EmitMetricsExemplars(context.Background(), rw, m, "TraceId", "SpanId", 2)
+	if err != nil {
+		t.Fatalf("EmitMetricsExemplars: %v", err)
+	}
+
+	tokens := []string{
+		"argMax",
+		"exemplar_trace_id",
+		"exemplar_span_id",
+		"map(",
+		"LIMIT 2 BY",
+	}
+	for _, tok := range tokens {
+		if !strings.Contains(sql, tok) {
+			t.Errorf("SQL missing token %q\nSQL=%s", tok, sql)
+		}
+	}
+	if len(args) == 0 {
+		t.Errorf("expected non-empty args, got nil")
+	}
+}

--- a/internal/chsql/exemplars_test.go
+++ b/internal/chsql/exemplars_test.go
@@ -29,10 +29,10 @@ func TestEmitMetricsExemplars_NilRangeWindow(t *testing.T) {
 func TestEmitMetricsExemplars_MissingColumns(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
-		name        string
-		traceIDCol  string
-		spanIDCol   string
-		wantSub     string
+		name       string
+		traceIDCol string
+		spanIDCol  string
+		wantSub    string
 	}{
 		{name: "empty_trace_id", traceIDCol: "", spanIDCol: "SpanId", wantSub: "traceIDCol"},
 		{name: "empty_span_id", traceIDCol: "TraceId", spanIDCol: "", wantSub: "spanIDCol"},


### PR DESCRIPTION
## Summary

Wires the TraceQL metrics-pipeline exemplar SQL into the Tempo metrics handlers so each `MetricsSeries` in the `query_range` and `query_instant` response carries populated `Exemplars`.

### Changes

- **`internal/chsql/exemplars.go`**: New `EmitMetricsExemplars` function that emits SQL picking one exemplar span per (series, anchor) bucket via `argMax`. The shape mirrors `emitRangeWindowMetrics` — same arrayJoin anchor fanout, same group-by bucketing — but the reducer is `argMax(<col>, ts)` instead of the metric's aggregate function.
- **`internal/chsql/exemplars_test.go`**: Nil-input, missing-columns, and shape-sanity tests.
- **`internal/api/tempo/metrics_query_range.go`**: `Exemplar` struct gains `Labels []MetricsLabel` (tempopb wire format). `handleMetricsQueryRange` makes a second SQL call via `EmitMetricsExemplars` and pivots results into parent series via `attachExemplars`. Exemplar query errors are non-blocking — the primary metric query always succeeds.

### Dependencies

Builds on top of the Exemplars[] envelope from #408 (already merged).

### Refs

- See `harness/tempo-compatibility/driver/differ_metrics.go` — the differ already supports exemplar comparison (`MetricsExemplar`, `semCheckExemplarInSeries`).
- Tempo wire contract caps at 100 exemplars per series.