### PR TITLE
ci(compatibility): add pull_request trigger for required PR check

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -1,11 +1,13 @@
 name: compatibility
 
 on:
-  # Until M6 the compatibility harness is an informational baseline: it
-  # legitimately fails because most PromQL surface is still landing.
-  # Running it on every PR surfaced confusing red checks; until we
-  # graduate it to a real gate (M6), it runs only on main pushes,
-  # nightly, and manual dispatch.
+  pull_request:
+    branches: [main]
+    paths:
+      - 'internal/promql/**'
+      - 'internal/api/prom/**'
+      - 'harness/prometheus-compliance/**'
+      - '.github/workflows/compatibility.yml'
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
Add a `pull_request:` trigger to the compatibility workflow so that PRs touching PromQL paths must pass the compat suite before merging.

This is the prerequisite for promoting `compatibility` to a required branch-protection check. Currently the workflow only runs on push-to-main, nightly, and manual dispatch — PRs can merge without compat ever running.

**Paths filtered** (same scope as the push trigger, plus `internal/api/prom/`):
- `internal/promql/**`
- `internal/api/prom/**`
- `harness/prometheus-compliance/**`
- `.github/workflows/compatibility.yml`

The `concurrency` group already handles PR cancellation (`cancel-in-progress` for `pull_request` events). The "Fail job if compatibility step failed" step already re-raises harness failures after summary/artifact upload.

Follow-up: add `compatibility` to the required checks list in branch protection (separate change).