### PR TITLE
fix(promql): add subquery-over-rate range-fn regression test

### DIFF
--- a/test/spec/promql/subquery_over_rate_range.txtar
+++ b/test/spec/promql/subquery_over_rate_range.txtar
@@ -1,0 +1,54 @@
+-- query.promql --
+avg_over_time(rate(http_requests_total[1m])[2m:10s])
+-- range_step --
+30s
+-- args --
+[0] string = "http_requests_total"
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('http_requests_total', map('job', 'demo'), toDateTime64('2025-12-31 23:56:00', 9), 0.0),
+    ('http_requests_total', map('job', 'demo'), toDateTime64('2025-12-31 23:56:30', 9), 30.0),
+    ('http_requests_total', map('job', 'demo'), toDateTime64('2025-12-31 23:57:00', 9), 60.0),
+    ('http_requests_total', map('job', 'demo'), toDateTime64('2025-12-31 23:57:30', 9), 90.0),
+    ('http_requests_total', map('job', 'demo'), toDateTime64('2025-12-31 23:58:00', 9), 120.0),
+    ('http_requests_total', map('job', 'demo'), toDateTime64('2025-12-31 23:58:30', 9), 150.0),
+    ('http_requests_total', map('job', 'demo'), toDateTime64('2025-12-31 23:59:00', 9), 180.0),
+    ('http_requests_total', map('job', 'demo'), toDateTime64('2025-12-31 23:59:30', 9), 210.0),
+    ('http_requests_total', map('job', 'demo'), toDateTime64('2026-01-01 00:00:00', 9), 240.0),
+    ('http_requests_total', map('job', 'demo'), toDateTime64('2026-01-01 00:00:30', 9), 270.0),
+    ('http_requests_total', map('job', 'demo'), toDateTime64('2026-01-01 00:01:00', 9), 300.0),
+    ('http_requests_total', map('job', 'demo'), toDateTime64('2026-01-01 00:01:30', 9), 330.0),
+    ('http_requests_total', map('job', 'demo'), toDateTime64('2026-01-01 00:02:00', 9), 360.0),
+    ('http_requests_total', map('job', 'demo'), toDateTime64('2026-01-01 00:02:30', 9), 390.0),
+    ('http_requests_total', map('job', 'demo'), toDateTime64('2026-01-01 00:03:00', 9), 420.0),
+    ('http_requests_total', map('job', 'demo'), toDateTime64('2026-01-01 00:03:30', 9), 450.0),
+    ('http_requests_total', map('job', 'demo'), toDateTime64('2026-01-01 00:04:00', 9), 480.0),
+    ('http_requests_total', map('job', 'demo'), toDateTime64('2026-01-01 00:04:30', 9), 510.0),
+    ('http_requests_total', map('job', 'demo'), toDateTime64('2026-01-01 00:05:00', 9), 540.0);
+-- expected_rows --
+[
+  [{"job": "demo"}, "2026-01-01T00:00:00Z", 1],
+  [{"job": "demo"}, "2026-01-01T00:00:30Z", 1],
+  [{"job": "demo"}, "2026-01-01T00:01:00Z", 1],
+  [{"job": "demo"}, "2026-01-01T00:01:30Z", 1],
+  [{"job": "demo"}, "2026-01-01T00:02:00Z", 1],
+  [{"job": "demo"}, "2026-01-01T00:02:30Z", 1],
+  [{"job": "demo"}, "2026-01-01T00:03:00Z", 1],
+  [{"job": "demo"}, "2026-01-01T00:03:30Z", 1],
+  [{"job": "demo"}, "2026-01-01T00:04:00Z", 1],
+  [{"job": "demo"}, "2026-01-01T00:04:30Z", 1],
+  [{"job": "demo"}, "2026-01-01T00:05:00Z", 1]
+]
+-- chplan --
+RangeWindow func=avg_over_time range=2m0s step=30s outerRange=5m0s ts=anchor_ts value=Value groupBy=[Attributes] start=2026-01-01T00:00:00Z end=2026-01-01T00:05:00Z
+  RangeWindow func=rate range=1m0s step=10s outerRange=7m0s ts=TimeUnix value=Value groupBy=[Attributes] start=2025-12-31T23:58:00Z end=2026-01-01T00:05:00Z
+    Filter predicate=(MetricName = "http_requests_total")
+      Scan(otel_metrics_sum)
+-- sql --
+SELECT `Attributes`, `anchor_ts`, if(length(window_vals) > 0, arrayAvg(window_vals), nan) AS `Value` FROM (SELECT `Attributes`, `anchor_ts`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, `anchor_ts`, arrayFilter(p -> tupleElement(p, 1) > anchor_ts - toIntervalNanosecond(120000000000) AND tupleElement(p, 1) <= anchor_ts, series_array) AS `window_pairs` FROM (SELECT `Attributes`, `series_array`, arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(i * 30000000000), range(0, 11))) AS `anchor_ts` FROM (SELECT `Attributes`, arraySort(groupArray((`anchor_ts`, `Value`))) AS `series_array` FROM (SELECT `Attributes`, `anchor_ts`, if(sampled_interval > 0, counter_delta * (sampled_interval + if(counter_delta > 0 AND first_val >= 0, least(duration_to_start, sampled_interval * first_val / counter_delta), duration_to_start) + duration_to_end) / sampled_interval / 60, nan) AS `Value` FROM (SELECT `Attributes`, `anchor_ts`, `window_vals`, `counter_delta`, `first_val`, toFloat64(dateDiff('nanosecond', first_ts, last_ts)) / 1e9 AS `sampled_interval`, if(toFloat64(dateDiff('nanosecond', anchor_ts - toIntervalNanosecond(60000000000), first_ts)) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', anchor_ts - toIntervalNanosecond(60000000000), first_ts)) / 1e9) AS `duration_to_start`, if(toFloat64(dateDiff('nanosecond', last_ts, anchor_ts)) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', last_ts, anchor_ts)) / 1e9) AS `duration_to_end` FROM (SELECT `Attributes`, `anchor_ts`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta`, tupleElement(window_pairs[1], 1) AS `first_ts`, tupleElement(window_pairs[length(window_pairs)], 1) AS `last_ts`, tupleElement(window_pairs[1], 2) AS `first_val` FROM (SELECT `Attributes`, `anchor_ts`, arrayFilter(p -> tupleElement(p, 1) > anchor_ts - toIntervalNanosecond(60000000000) AND tupleElement(p, 1) <= anchor_ts, series_array) AS `window_pairs` FROM (SELECT `Attributes`, `series_array`, arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(i * 10000000000), range(0, 43))) AS `anchor_ts` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` = ?)) GROUP BY `Attributes`))))) WHERE length(`window_vals`) >= 2) GROUP BY `Attributes`)))) WHERE length(`window_vals`) >= 1


### PR DESCRIPTION
## What

Adds a TXTAR spec test at `test/spec/promql/subquery_over_rate_range.txtar` that exercises the `avg_over_time(rate(http_requests_total[1m])[2m:10s])` shape in range mode — the "Bucket 3" pattern from the compat-residual audit (#400) where subquery-over-counter-range-fn previously returned an empty matrix.

## Why

PR #402 widened the inner-subquery anchor grid in `lowerOuterRangeFnOverSubquery` (lines 313–317 of `internal/promql/subquery.go`), which fixed the empty-matrix bug. This test adds a dedicated regression guard with:

- A denser seed (19 samples at 30s intervals across a 9-minute counter) that would have produced an empty matrix without the widening fix
- `expected_rows` with 11 populated anchor points (the full `[00:00:00, 00:05:00]` step grid), confirming the widening works end-to-end via chDB round-trip
- Both the spec lowering test (`TestLower`) and the chDB round-trip test (`TestRoundTripChDB`) pass

## Audit cross-ref

- `docs/compat-residual-audit-25898791664.md` Bucket 3: subquery-over-counter-range-fn
- The fix is already in place; this PR adds the regression guard only