### PR TITLE
fix(e2e): update tempo_ux assertion for AnyValue label envelope

### DIFF
--- a/test/e2e/playwright/tempo_ux.spec.ts
+++ b/test/e2e/playwright/tempo_ux.spec.ts
@@ -278,7 +278,7 @@ test.describe('Tempo UX — Search flows', () => {
     // a TraceQL metrics pipeline (`| rate()`, `| count_over_time()`,
     // `| *_over_time(...)` etc.) for inter-service rate + duration.
     // Cerberus answers with Tempo's native series-of-samples envelope:
-    //   {series: [{labels: [{key, value}], samples: [{timestampMs, value}]}]}
+    //   {series: [{labels: [{key, value: {stringValue}}], samples: [{timestampMs, value}]}]}
     // The Playwright suite seeds three traces (see L10 seed); a
     // `| count_over_time() by (resource.service.name)` should return at
     // least one series whose label set names the seeded service.
@@ -305,7 +305,8 @@ test.describe('Tempo UX — Search flows', () => {
       expect(Array.isArray(s.samples), 'series.samples is array').toBe(true);
       for (const lbl of s.labels) {
         expect(typeof lbl.key, 'label.key is string').toBe('string');
-        expect(typeof lbl.value, 'label.value is string').toBe('string');
+        expect(typeof lbl.value, 'label.value is object (AnyValue envelope)').toBe('object');
+        expect(typeof lbl.value.stringValue, 'label.value.stringValue is string').toBe('string');
       }
       for (const smp of s.samples) {
         expect(typeof smp.timestampMs, 'sample.timestampMs is number').toBe('number');


### PR DESCRIPTION
PR #411 changed MetricsLabel to serialize value as a tempopb AnyValue envelope ({"stringValue": "frontend"}) instead of a flat string. This is the correct format for Grafana's Tempo datasource, but the Playwright assertion still expected a primitive string.

Fix: update tempo_ux.spec.ts to assert label.value is an object with a .stringValue string property.

The ci/e2e workflow runs on push-to-main + nightly + manual dispatch only, so this won't block PRs.