### PR TITLE
fix(harness/tempo-compatibility): add Recent-Data-Target header, fix tempo v3 config

### DIFF
--- a/harness/tempo-compatibility/driver/diff.go
+++ b/harness/tempo-compatibility/driver/diff.go
@@ -198,8 +198,8 @@ func diffCase(ctx context.Context, client *http.Client, tc CorpusCase, opts case
 		return res
 	}
 
-	tempoBody, tempoStatus, terr := fetchJSON(ctx, client, tempoURL)
-	cerbBody, cerbStatus, cerr := fetchJSON(ctx, client, cerbURL)
+	tempoBody, tempoStatus, terr := fetchJSON(ctx, client, tempoURL, "tempo")
+	cerbBody, cerbStatus, cerr := fetchJSON(ctx, client, cerbURL, "cerberus")
 	res.TempoStatus = tempoStatus
 	res.CerberusStatus = cerbStatus
 	if terr != nil {
@@ -412,13 +412,19 @@ func deriveTraceIDFromTemplate(tmpl string) (string, error) {
 
 // fetchJSON GETs a URL with the Accept: application/json header and
 // returns the body + status. Errors include the response body (up to
-// 2KB) so a CH error message lands in the report.
-func fetchJSON(ctx context.Context, client *http.Client, urlStr string) ([]byte, int, error) {
+// 2KB) so a CH error message lands in the report. When backend is
+// "tempo", the Recent-Data-Target: live-store header is set so Tempo
+// searches the live store (recently-ingested traces) in addition to
+// completed blocks.
+func fetchJSON(ctx context.Context, client *http.Client, urlStr, backend string) ([]byte, int, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlStr, nil)
 	if err != nil {
 		return nil, 0, err
 	}
 	req.Header.Set("Accept", "application/json")
+	if backend == "tempo" {
+		req.Header.Set("Recent-Data-Target", "live-store")
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, 0, err

--- a/harness/tempo-compatibility/driver/seeder.go
+++ b/harness/tempo-compatibility/driver/seeder.go
@@ -157,7 +157,8 @@ func runSeed(args []string) error {
 	for _, t := range traces {
 		totalSpans += len(t.spans)
 	}
-	logger.Info("generated fixture",
+	logger.Info(
+		"generated fixture",
 		"services", len(services),
 		"traces", len(traces),
 		"total_spans", totalSpans,
@@ -207,7 +208,8 @@ func runSeed(args []string) error {
 
 	// --- Smoke ---------------------------------------------------------
 	firstID := hex.EncodeToString(traces[0].traceID[:])
-	logger.Info("smoke /api/traces/<id> on both backends",
+	logger.Info(
+		"smoke /api/traces/<id> on both backends",
 		"trace_id", firstID,
 		"deadline", *smokeWait,
 	)
@@ -215,7 +217,13 @@ func runSeed(args []string) error {
 		return fmt.Errorf("smoke: %w", err)
 	}
 
-	logger.Info("seed done",
+	logger.Info("smoke /api/search?q={} on tempo (live-store)", "deadline", *smokeWait)
+	if err := smokeSearchLiveStore(ctx, logger, *tempoHTTP, *smokeWait); err != nil {
+		return fmt.Errorf("smoke search: %w", err)
+	}
+
+	logger.Info(
+		"seed done",
 		"traces", len(traces),
 		"total_spans", totalSpans,
 	)
@@ -377,7 +385,8 @@ func pushOTLP(ctx context.Context, addr string, traces []*fixtureTrace, logger *
 	// healthcheck already gates compose `up --wait` for us, and the
 	// first Export() call surfaces unreachable-server errors precisely
 	// (vs grpc.WithBlock's opaque "context deadline exceeded").
-	conn, err := grpc.NewClient(addr,
+	conn, err := grpc.NewClient(
+		addr,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
 	if err != nil {
@@ -586,7 +595,8 @@ func smokeTraceByID(ctx context.Context, logger *slog.Logger, tempoHTTP, cerberu
 		return fmt.Errorf("cerberus trace-by-id: %w", err)
 	}
 
-	logger.Info("smoke result",
+	logger.Info(
+		"smoke result",
 		"trace_id", traceID,
 		"tempo_spans", tempoCount,
 		"cerberus_spans", cerberusCount,
@@ -600,7 +610,8 @@ func smokeTraceByID(ctx context.Context, logger *slog.Logger, tempoHTTP, cerberu
 	if tempoCount != cerberusCount {
 		// Not fatal at PR-3's contract ("non-zero on both"), but log
 		// loudly. The real per-span equivalence diff lands in PR 4.
-		logger.Warn("span count mismatch between backends — PR 4 will surface this as a corpus diff",
+		logger.Warn(
+			"span count mismatch between backends — PR 4 will surface this as a corpus diff",
 			"tempo_spans", tempoCount,
 			"cerberus_spans", cerberusCount,
 		)
@@ -719,6 +730,65 @@ func decodeCerberusSpanCount(r io.Reader) (int, error) {
 		total += len(b.Spans)
 	}
 	return total, nil
+}
+
+// smokeSearchLiveStore polls Tempo's /api/search?q={} with the
+// Recent-Data-Target: live-store header until the response contains at
+// least one trace. This catches the failure mode where Tempo's search
+// only scans completed blocks (which may not have been flushed yet) and
+// returns 0 results while cerberus returns many.
+func smokeSearchLiveStore(ctx context.Context, logger *slog.Logger, tempoHTTP string, deadline time.Duration) error {
+	ctx, cancel := context.WithTimeout(ctx, deadline)
+	defer cancel()
+
+	url := strings.TrimRight(tempoHTTP, "/") + "/api/search?q=%7B%7D"
+	for {
+		n, err := fetchSearchResultCount(ctx, url)
+		if err == nil && n > 0 {
+			logger.Info("tempo search returned traces", "count", n)
+			return nil
+		}
+		if ctx.Err() != nil {
+			if err != nil {
+				return fmt.Errorf("tempo search: %w", errors.Join(ctx.Err(), err))
+			}
+			return fmt.Errorf("tempo search returned 0 traces after %s", deadline)
+		}
+		logger.Debug("retrying tempo search", "url", url, "err", err, "traces", n)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(1 * time.Second):
+		}
+	}
+}
+
+// fetchSearchResultCount issues one GET against /api/search with the
+// Recent-Data-Target: live-store header and returns the number of
+// traces in the response.
+func fetchSearchResultCount(ctx context.Context, url string) (int, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Recent-Data-Target", "live-store")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
+	if resp.StatusCode/100 != 2 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return 0, fmt.Errorf("status %d: %s", resp.StatusCode, string(body))
+	}
+	var raw struct {
+		Traces []json.RawMessage `json:"traces"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return 0, fmt.Errorf("decode search response: %w", err)
+	}
+	return len(raw.Traces), nil
 }
 
 // envOr returns the env value or `fallback` if the env var is unset

--- a/harness/tempo-compatibility/tempo-config.yaml
+++ b/harness/tempo-compatibility/tempo-config.yaml
@@ -53,15 +53,18 @@ storage:
       path: /var/tempo/wal
     local:
       path: /var/tempo/blocks
+    block:
+      max_block_duration: 2s
 
-# Tighten the live-store flush cadence so the PR-3 smoke read sees
+# Tighten the ingester flush cadence so the PR-3 smoke read sees
 # spans within seconds of the OTLP push, instead of waiting for the
-# default ingester block duration.
-live_store:
-  max_trace_live: 2s
-  max_trace_idle: 1s
+# default block duration. Tempo v3 uses ingester.trace_live_period /
+# trace_idle_period / flush_check_period (not the legacy live_store
+# section).
+ingester:
+  trace_idle_period: 1s
+  trace_live_period: 2s
   flush_check_period: 1s
-  max_block_duration: 2s
 
 usage_report:
   reporting_enabled: false


### PR DESCRIPTION
Two root causes for the 28 diffs + 4 hard errors:

1. **Missing Recent-Data-Target header**: The differ's fetchJSON() only set Accept: application/json when querying Tempo's /api/search. Tempo v3 only searches completed blocks by default — without the live-store header, it finds 0 traces because they haven't been flushed yet. Added backend param to fetchJSON; when backend=="tempo", sets Recent-Data-Target: live-store.

2. **Broken tempo-config.yaml**: The live_store section used wrong field names (max_trace_live, max_trace_idle) that Tempo v3 silently ignores. Replaced with the correct ingester section (trace_idle_period, trace_live_period, flush_check_period) and moved max_block_duration: 2s to storage.trace.block per grafana/tempo#6647.

3. **Added smoke search check**: New smokeSearchLiveStore() in seeder.go polls /api/search?q={} with the live-store header to verify Tempo search actually returns traces before the differ runs.