### PR TITLE
fix(harness/tempo-compatibility): run driver on host with localhost ports to avoid Docker DNS failures

### DIFF
--- a/harness/tempo-compatibility/docker-compose.yml
+++ b/harness/tempo-compatibility/docker-compose.yml
@@ -128,12 +128,18 @@ services:
       retries: 30
 
   tempo-compat-driver:
-    # PR 4: the driver now exposes two real subcommands — `seed` (push
-    # fixture into both backends) and `diff` (run TXTAR corpus, write
-    # markdown report). The run-tempo-compatibility script invokes
-    # them in sequence; the default `command:` keeps `seed` so an ad-hoc
-    # `docker compose run --rm tempo-compat-driver` still does the
-    # right thing during local debugging.
+    # The script (run-tempo-compatibility.sh) runs the seeder and differ
+    # as Go binaries on the host, connecting to Docker-published ports
+    # on localhost. This avoids Docker DNS resolution failures on CI
+    # runners (see the script header for details).
+    #
+    # This service definition is retained for optional in-Docker
+    # debugging: `docker compose run --rm tempo-compat-driver seed`
+    # or `docker compose run --rm tempo-compat-driver diff` still
+    # works inside the compose network. The env vars below set
+    # Docker-internal hostnames that resolve only from within the
+    # compose network; the Go flag defaults use localhost + published
+    # ports for host execution.
     #
     # Build context widened from `./driver` to the repo root so the
     # driver can `import "github.com/tsouza/cerberus/internal/schema/ddl"`

--- a/harness/tempo-compatibility/driver/diff.go
+++ b/harness/tempo-compatibility/driver/diff.go
@@ -36,8 +36,8 @@ func runDiff(args []string) error {
 	fs := flag.NewFlagSet("diff", flag.ContinueOnError)
 	var (
 		corpusPath  = fs.String("corpus", envOr("CORPUS_PATH", "/corpus/smoke.txtar"), "path to the TXTAR corpus file")
-		tempoHTTP   = fs.String("tempo-http", envOr("TEMPO_HTTP_URL", "http://tempo:3200"), "Tempo HTTP base URL")
-		cerberusURL = fs.String("cerberus", envOr("CERBERUS_URL", "http://cerberus-tempo:29092"), "cerberus HTTP base URL")
+		tempoHTTP   = fs.String("tempo-http", envOr("TEMPO_HTTP_URL", "http://localhost:23200"), "Tempo HTTP base URL")
+		cerberusURL = fs.String("cerberus", envOr("CERBERUS_URL", "http://localhost:29092"), "cerberus HTTP base URL")
 		reportPath  = fs.String("report", envOr("REPORT_PATH", "/reports/diff.md"), "markdown report output path")
 		overall     = fs.Duration("timeout", 5*time.Minute, "overall driver timeout")
 		perReq      = fs.Duration("request-timeout", 30*time.Second, "per-HTTP-request timeout")

--- a/harness/tempo-compatibility/driver/seeder.go
+++ b/harness/tempo-compatibility/driver/seeder.go
@@ -129,10 +129,10 @@ type fixtureTrace struct {
 func runSeed(args []string) error {
 	fs := flag.NewFlagSet("seed", flag.ContinueOnError)
 	var (
-		tempoOTLP   = fs.String("tempo-otlp", envOr("TEMPO_OTLP_ADDR", "tempo:4317"), "Tempo OTLP gRPC endpoint (host:port)")
-		tempoHTTP   = fs.String("tempo-http", envOr("TEMPO_HTTP_URL", "http://tempo:3200"), "Tempo HTTP base URL (read-back / smoke)")
-		cerberusURL = fs.String("cerberus", envOr("CERBERUS_URL", "http://cerberus-tempo:29092"), "cerberus HTTP base URL (read-back / smoke)")
-		chAddr      = fs.String("ch-addr", envOr("CERBERUS_CH_ADDR", "clickhouse:9000"), "ClickHouse host:port (CH-side write path)")
+		tempoOTLP   = fs.String("tempo-otlp", envOr("TEMPO_OTLP_ADDR", "localhost:24317"), "Tempo OTLP gRPC endpoint (host:port)")
+		tempoHTTP   = fs.String("tempo-http", envOr("TEMPO_HTTP_URL", "http://localhost:23200"), "Tempo HTTP base URL (read-back / smoke)")
+		cerberusURL = fs.String("cerberus", envOr("CERBERUS_URL", "http://localhost:29092"), "cerberus HTTP base URL (read-back / smoke)")
+		chAddr      = fs.String("ch-addr", envOr("CERBERUS_CH_ADDR", "localhost:29100"), "ClickHouse host:port (CH-side write path)")
 		chDatabase  = fs.String("ch-database", envOr("CERBERUS_CH_DATABASE", "otel"), "ClickHouse database")
 		chUser      = fs.String("ch-user", envOr("CERBERUS_CH_USERNAME", "cerberus"), "ClickHouse username")
 		chPassword  = fs.String("ch-password", envOr("CERBERUS_CH_PASSWORD", "cerberus"), "ClickHouse password")

--- a/harness/tempo-compatibility/scripts/run-tempo-compatibility.sh
+++ b/harness/tempo-compatibility/scripts/run-tempo-compatibility.sh
@@ -14,6 +14,13 @@
 #             returns 0 even if the corpus diffs); set FAIL_ON_DIFF=1
 #             to bubble per-case regressions up to a non-zero rc.
 #
+# The seeder and differ run as Go binaries on the CI runner (host),
+# connecting to Docker-published ports on localhost. This avoids Docker
+# DNS resolution failures ("lookup tempo on 127.0.0.11:53: server
+# misbehaving") that occur when the driver runs inside Docker on some
+# CI runner configurations. Matches the pattern used by the sibling
+# Loki harness (harness/loki-compatibility/).
+#
 # Usage:
 #   ./harness/tempo-compatibility/scripts/run-tempo-compatibility.sh   full lifecycle (seed → diff)
 #   COMPOSE_KEEP=1 ./...                                               leave stack up after run
@@ -38,20 +45,23 @@
 set -eu -o pipefail
 
 ROOT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+REPO_ROOT=$(cd "$ROOT_DIR/../.." && pwd)
 cd "$ROOT_DIR"
 
 REPORT_DIR=${REPORT_DIR:-"$ROOT_DIR/reports"}
 mkdir -p "$REPORT_DIR"
 chmod a+w "$REPORT_DIR"
 
-# Consolidated cleanup: tear down the compose stack on every exit path
-# (success, driver failure, set -e abort, SIGINT). Without this, a
-# non-zero driver exit propagated by `set -e` would leak the stack
-# across re-runs — local repros, in particular, would inherit dirty
-# Tempo block storage and confuse subsequent debugging. Same pattern
-# as harness/prometheus-compliance/scripts/run-compatibility.sh.
+DRIVER_BIN=$(mktemp -t cerberus-tempo-compat-driver.XXXXXX)
+
+# Consolidated cleanup: tear down the compose stack and drop the
+# throwaway driver binary on every exit path (success, driver failure,
+# set -e abort, SIGINT) so a non-zero exit can't leak compose state
+# across re-runs. Same pattern as harness/loki-compatibility/scripts/
+# run-loki-compatibility.sh.
 cleanup() {
     rc=$?
+    rm -f "$DRIVER_BIN"
     if [ -z "${COMPOSE_KEEP:-}" ]; then
         echo "==> tearing down (set COMPOSE_KEEP=1 to leave running)"
         docker compose down -v || true
@@ -72,18 +82,26 @@ docker compose up -d --build tempo
 docker compose up -d --build --wait --wait-timeout 300 \
     clickhouse cerberus-tempo
 
-echo "==> running tempo-compat-driver seed"
-# `docker compose run --rm` invokes the seeder and removes the
-# container afterwards. The seeder pushes OTLP into Tempo, INSERTs the
-# same fixture into ClickHouse, and polls /api/traces/<id> on both
-# backends as the in-process smoke check.
+# The seeder and differ run as Go binaries on the host, connecting
+# to Docker-published ports on localhost. Port mapping from
+# docker-compose.yml:
+#   Tempo HTTP:    23200:3200   → localhost:23200
+#   Tempo OTLP:    24317:4317   → localhost:24317
+#   cerberus:      29092:29092  → localhost:29092
+#   ClickHouse:    29100:9000   → localhost:29100
 #
+# The Go flag defaults match these host-accessible endpoints; the
+# docker-compose.yml env vars set Docker-internal hostnames for
+# optional in-Docker debugging (`docker compose run --rm
+# tempo-compat-driver`).
+
+echo "==> running seeder (go run ./harness/tempo-compatibility/driver/ seed)"
 # Note: NO `|| true` here. The driver's exit code is meaningful — masking
 # it would let regressions land green (the same trap that bit the PromQL
 # harness pre-#298). The cleanup trap still tears down the stack on a
 # non-zero exit.
 set +e
-docker compose run --rm tempo-compat-driver seed
+(cd "$REPO_ROOT" && go run ./harness/tempo-compatibility/driver/ seed)
 SEED_RC=$?
 set -e
 
@@ -93,21 +111,34 @@ if [ "$SEED_RC" -ne 0 ]; then
     exit "$SEED_RC"
 fi
 
-# PR 4: after seed, run the differ against the same backends. The
-# differ emits a markdown report under $REPORT_DIR; in informational
-# mode (default) it returns 0 even if the report contains diffs so
-# the workflow stays a baseline. Set FAIL_ON_DIFF=1 to bubble
-# regressions up to a non-zero rc — useful for `just`-style local
-# repro and for the eventual PR 7 promotion to a required check.
+# Build the diff driver. The driver imports internal/schema/ddl and
+# OTLP gRPC client types via cerberus's go.mod, so it compiles from
+# the repo root like the cerberus binary.
+echo "==> building diff driver"
+(cd "$REPO_ROOT" && go build -o "$DRIVER_BIN" ./harness/tempo-compatibility/driver/)
+
+# After seed, run the differ against the same backends. The differ
+# emits a markdown report under $REPORT_DIR; in informational mode
+# (default) it returns 0 even if the report contains diffs so the
+# workflow stays a baseline. Set FAIL_ON_DIFF=1 to bubble regressions
+# up to a non-zero rc — useful for `just`-style local repro and for
+# the eventual PR 7 promotion to a required check.
 DIFF_FLAGS=""
 if [ -n "${FAIL_ON_DIFF:-}" ]; then
     DIFF_FLAGS="--fail-on-diff"
 fi
-DIFF_FLAGS="$DIFF_FLAGS --expected-failures /expected-failures.json"
+DIFF_FLAGS="$DIFF_FLAGS --expected-failures $ROOT_DIR/expected-failures.json"
 
-echo "==> running tempo-compat-driver diff"
+echo "==> running diff driver (writing report to $REPORT_DIR/diff.md)"
+echo "    --tempo-http=http://localhost:23200  (reference Tempo)"
+echo "    --cerberus=http://localhost:29092  (cerberus)"
 set +e
-docker compose run --rm tempo-compat-driver diff $DIFF_FLAGS
+"$DRIVER_BIN" diff \
+    --tempo-http=http://localhost:23200 \
+    --cerberus=http://localhost:29092 \
+    --corpus="$ROOT_DIR/driver/corpus/smoke.txtar" \
+    --report="$REPORT_DIR/diff.md" \
+    $DIFF_FLAGS
 DIFF_RC=$?
 set -e
 


### PR DESCRIPTION
## Problem

The tempo-compatibility harness runs the seeder and differ inside Docker via `docker compose run --rm tempo-compat-driver`, using Docker-internal hostnames (`tempo:3200`, `cerberus-tempo:29092`). On some CI runner configurations, Docker's embedded DNS resolver (127.0.0.11:53) fails to resolve these names:

```
dial tcp: lookup tempo on 127.0.0.11:53: server misbehaving
```

This happens even though the Tempo container is running (docker compose shows it as "Started"). The DNS failure is intermittent and runner-dependent.

## Fix

Match the sibling Loki harness pattern — run the seeder and differ as Go binaries on the host, connecting to Docker-published ports on localhost:

| Service | Docker-internal | Host-accessible |
|---------|----------------|-----------------|
| Tempo HTTP | `tempo:3200` | `localhost:23200` |
| Tempo OTLP | `tempo:4317` | `localhost:24317` |
| cerberus | `cerberus-tempo:29092` | `localhost:29092` |
| ClickHouse | `clickhouse:9000` | `localhost:29100` |

## Changes

- **`driver/seeder.go`**: flag defaults changed from Docker-internal hostnames to `localhost` + published ports
- **`driver/diff.go`**: flag defaults changed from Docker-internal hostnames to `localhost` + published ports
- **`scripts/run-tempo-compatibility.sh`**: replaced `docker compose run --rm tempo-compat-driver` with `go run` (seeder) and a host-built binary (differ), matching the Loki harness lifecycle
- **`docker-compose.yml`**: updated `tempo-compat-driver` comments to document the host-execution model; the service is retained for optional in-Docker debugging (env vars still set Docker-internal hostnames that override the Go defaults)

## Verification

- `go vet ./harness/tempo-compatibility/driver/` passes
- The Loki harness already follows this exact pattern successfully