### PR TITLE
feat(traceql): implement avg_over_time metrics pipeline lowering

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -341,7 +341,7 @@ replace github.com/grafana/loki/v3 => github.com/tsouza/loki/v3 v3.0.0-cerberus-
 // tempo: narrow accessors on top of pkg/traceql to retire the unsafe.Pointer
 // + reflect.FieldByName shims in internal/traceql/. See docs/fork-tempo-
 // plan.md for the migration plan and accessor inventory.
-replace github.com/grafana/tempo => github.com/tsouza/tempo v0.0.1-cerberus-accessors
+replace github.com/grafana/tempo => github.com/tsouza/tempo v0.0.2-cerberus-accessors
 
 // otelc: hoists the ClickHouse exporter's sqltemplates out of `internal/`
 // so cerberus can import them as the schema source-of-truth. collector-

--- a/go.mod
+++ b/go.mod
@@ -341,7 +341,7 @@ replace github.com/grafana/loki/v3 => github.com/tsouza/loki/v3 v3.0.0-cerberus-
 // tempo: narrow accessors on top of pkg/traceql to retire the unsafe.Pointer
 // + reflect.FieldByName shims in internal/traceql/. See docs/fork-tempo-
 // plan.md for the migration plan and accessor inventory.
-replace github.com/grafana/tempo => github.com/tsouza/tempo v0.0.2-cerberus-accessors
+replace github.com/grafana/tempo => github.com/tsouza/tempo v0.0.3-cerberus-accessors
 
 // otelc: hoists the ClickHouse exporter's sqltemplates out of `internal/`
 // so cerberus can import them as the schema source-of-truth. collector-

--- a/go.sum
+++ b/go.sum
@@ -710,8 +710,8 @@ github.com/tsouza/opentelemetry-collector-contrib/pkg/translator/jaeger v0.0.1-c
 github.com/tsouza/opentelemetry-collector-contrib/pkg/translator/jaeger v0.0.1-cerberus-ddl/go.mod h1:oH8MAPQVje+h6zawzcX9O5heDyXm3hhvTUl0SqTE6cs=
 github.com/tsouza/prometheus v0.0.1-cerberus-parser h1:RjX9HKGVHPxLbtGKSbzWJ3bGFsmOEORWG2DX2Spg6oY=
 github.com/tsouza/prometheus v0.0.1-cerberus-parser/go.mod h1:orN7+39ySpDpDwh+EbN7UYpMHYNXrl0rabkpVMfMN4g=
-github.com/tsouza/tempo v0.0.1-cerberus-accessors h1:Iovv/sEnVBPYblpboa9pJIQrkFvICjbZszgVV0YT7i4=
-github.com/tsouza/tempo v0.0.1-cerberus-accessors/go.mod h1:tV3Pl9la00Ti1stc4RMsIa41zkx1i3mtxKKy13vXwt4=
+github.com/tsouza/tempo v0.0.2-cerberus-accessors h1:jbKl366btg5rIzeo4Dt6iQzjneouSMKaJBzMHlEc9iM=
+github.com/tsouza/tempo v0.0.2-cerberus-accessors/go.mod h1:tV3Pl9la00Ti1stc4RMsIa41zkx1i3mtxKKy13vXwt4=
 github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31/go.mod h1:onvgF043R+lC5RZ8IT9rBXDaEDnpnw/Cl+HFiw+v/7Q=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/twmb/franz-go v1.21.0 h1:J3uB/poWgHD6VIilER2uCPFAZHDRXVFT+11pBgRKod4=

--- a/go.sum
+++ b/go.sum
@@ -710,8 +710,8 @@ github.com/tsouza/opentelemetry-collector-contrib/pkg/translator/jaeger v0.0.1-c
 github.com/tsouza/opentelemetry-collector-contrib/pkg/translator/jaeger v0.0.1-cerberus-ddl/go.mod h1:oH8MAPQVje+h6zawzcX9O5heDyXm3hhvTUl0SqTE6cs=
 github.com/tsouza/prometheus v0.0.1-cerberus-parser h1:RjX9HKGVHPxLbtGKSbzWJ3bGFsmOEORWG2DX2Spg6oY=
 github.com/tsouza/prometheus v0.0.1-cerberus-parser/go.mod h1:orN7+39ySpDpDwh+EbN7UYpMHYNXrl0rabkpVMfMN4g=
-github.com/tsouza/tempo v0.0.2-cerberus-accessors h1:jbKl366btg5rIzeo4Dt6iQzjneouSMKaJBzMHlEc9iM=
-github.com/tsouza/tempo v0.0.2-cerberus-accessors/go.mod h1:tV3Pl9la00Ti1stc4RMsIa41zkx1i3mtxKKy13vXwt4=
+github.com/tsouza/tempo v0.0.3-cerberus-accessors h1:e7HawgDTaAE25M/8LC3zfDLvmrkqMg3Yow6RA+WVpUE=
+github.com/tsouza/tempo v0.0.3-cerberus-accessors/go.mod h1:tV3Pl9la00Ti1stc4RMsIa41zkx1i3mtxKKy13vXwt4=
 github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31/go.mod h1:onvgF043R+lC5RZ8IT9rBXDaEDnpnw/Cl+HFiw+v/7Q=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/twmb/franz-go v1.21.0 h1:J3uB/poWgHD6VIilER2uCPFAZHDRXVFT+11pBgRKod4=

--- a/internal/traceql/metrics_pipeline.go
+++ b/internal/traceql/metrics_pipeline.go
@@ -40,15 +40,9 @@ func lowerMetricsPipeline(prev chplan.Node, mp traceql.FirstStageElement, s sche
 	if v, ok := mp.(*traceql.MetricsAggregate); ok {
 		return lowerMetricsAggregate(prev, v, s)
 	}
-	// Tempo parses `| avg_over_time(attr)` into an unexported
-	// `*averageOverTimeAggregator` rather than a `*MetricsAggregate`
-	// (see pkg/traceql/engine_metrics_average.go). The fork hasn't
-	// exposed accessors on that type yet; rather than reach for
-	// reflect/unsafe (forbidden post-#148), surface a clean
-	// not-yet-supported error here. A follow-up fork patch can add
-	// `Attribute()` / `GroupBy()` accessors and a small adapter; the
-	// CH aggregate it would lower to (`avg`) is already wired in
-	// mapMetricsAggregateOp below.
+	if v, ok := mp.(*traceql.AverageOverTimeAggregator); ok {
+		return lowerAverageOverTime(prev, v, s)
+	}
 	return nil, fmt.Errorf("traceql: metrics pipeline element %T is not yet supported", mp)
 }
 
@@ -116,6 +110,40 @@ func lowerMetricsAggregate(prev chplan.Node, agg *traceql.MetricsAggregate, s sc
 		GroupBy:        groupBy,
 		GroupByAliases: groupAliases,
 		Quantiles:      quantiles,
+		ValueAlias:     metricsValueAlias,
+		Inner:          prev,
+	}, nil
+}
+
+// lowerAverageOverTime lowers Tempo's dedicated
+// *traceql.AverageOverTimeAggregator (the unexported
+// averageOverTimeAggregator surfaced via the exported type alias in the
+// cerberus-accessors fork) into a chplan.MetricsAggregate with
+// Op=MetricsOpAvgOverTime.
+//
+// Tempo parses `| avg_over_time(attr)` into
+// *averageOverTimeAggregator rather than *MetricsAggregate because
+// avg_over_time uses a Kahan-summation weighted-average algorithm that
+// doesn't fit MetricsAggregate's generic init() switch. For cerberus's
+// purposes the lowering is identical — we emit `avg(<attr>)` in CH SQL
+// — so we just unwrap the accessor fields and produce the same
+// chplan.MetricsAggregate node.
+func lowerAverageOverTime(prev chplan.Node, agg *traceql.AverageOverTimeAggregator, s schema.Traces) (chplan.Node, error) {
+	attr, err := metricsAggregateAttr(traceql.MetricsAggregateAvgOverTime, agg.Attribute(), s)
+	if err != nil {
+		return nil, err
+	}
+
+	groupBy, groupAliases, err := lowerMetricsGroupBy(agg.GroupBy(), s)
+	if err != nil {
+		return nil, err
+	}
+
+	return &chplan.MetricsAggregate{
+		Op:             chplan.MetricsOpAvgOverTime,
+		Attr:           attr,
+		GroupBy:        groupBy,
+		GroupByAliases: groupAliases,
 		ValueAlias:     metricsValueAlias,
 		Inner:          prev,
 	}, nil

--- a/internal/traceql/metrics_pipeline_test.go
+++ b/internal/traceql/metrics_pipeline_test.go
@@ -86,6 +86,16 @@ func TestLowerMetricsPipeline(t *testing.T) {
 			wantOp: chplan.MetricsOpCountOverTime, wantAttr: false, wantGroup: 2, hasFilter: true,
 		},
 		{
+			name:   "avg_over_time_attr",
+			query:  `{} | avg_over_time(duration)`,
+			wantOp: chplan.MetricsOpAvgOverTime, wantAttr: true, wantGroup: 0, hasFilter: true,
+		},
+		{
+			name:   "avg_over_time_by_label",
+			query:  `{} | avg_over_time(duration) by (resource.service.name)`,
+			wantOp: chplan.MetricsOpAvgOverTime, wantAttr: true, wantGroup: 1, hasFilter: true,
+		},
+		{
 			name:   "quantile_over_time_single",
 			query:  `{} | quantile_over_time(duration, 0.95)`,
 			wantOp: chplan.MetricsOpQuantileOverTime, wantAttr: true, wantGroup: 0, hasFilter: true,
@@ -159,18 +169,17 @@ func TestLowerMetricsPipeline(t *testing.T) {
 // TestLowerMetricsPipelineUnsupported documents the cases that
 // surface as clean errors rather than panicking.
 //
-// `avg_over_time(...)` is deferred because Tempo parses it into an
-// unexported `*averageOverTimeAggregator` rather than a
-// `*MetricsAggregate` — the cerberus-accessors fork hasn't exposed
-// accessors on that type yet, and the post-#148 rule forbids
-// reflect/unsafe on parser AST.
-//
 // `histogram_over_time(...)` is no longer here — it lowers to a
-// chplan.MetricsHistogramOverTime node as of this PR; see
-// TestLowerHistogramOverTime in histogram_over_time_test.go.
+// chplan.MetricsHistogramOverTime node; see TestLowerHistogramOverTime
+// in histogram_over_time_test.go.
 //
 // `| > 0` (MetricsSecondStage) is deferred until the second-stage
 // filter / topk lowering lands.
+//
+// `avg_over_time(...)` is no longer deferred — it lowers to a
+// chplan.MetricsAggregate{Op: MetricsOpAvgOverTime} node via
+// lowerAverageOverTime, which unwraps the Tempo fork's exported
+// AverageOverTimeAggregator type.
 func TestLowerMetricsPipelineUnsupported(t *testing.T) {
 	t.Parallel()
 
@@ -181,11 +190,6 @@ func TestLowerMetricsPipelineUnsupported(t *testing.T) {
 		query      string
 		wantSubstr string
 	}{
-		{
-			name:       "avg_over_time_deferred",
-			query:      `{} | avg_over_time(duration)`,
-			wantSubstr: "not yet supported",
-		},
 		{
 			name:       "quantile_over_time_multi_deferred",
 			query:      `{} | quantile_over_time(duration, 0.5, 0.9, 0.99)`,


### PR DESCRIPTION
Implements `| avg_over_time(attr)` TraceQL metrics queries by:

1. **Tempo fork (v0.0.2-cerberus-accessors)**: Added `Attribute()` and `GroupBy()` accessors + `AverageOverTimeAggregator` exported type alias on the previously unexported `averageOverTimeAggregator` struct.

2. **cerberus lowering layer** (`internal/traceql/metrics_pipeline.go`): Added `lowerAverageOverTime()` function that type-asserts on `*traceql.AverageOverTimeAggregator` and lowers to `chplan.MetricsAggregate{Op: MetricsOpAvgOverTime}`.

3. **Tests**: Removed `avg_over_time_deferred` from the unsupported/error test and added two positive cases (`avg_over_time_attr` and `avg_over_time_by_label`).

The downstream pipeline (`chsql` emitter → ClickHouse `avg()`) was already wired — the gap was only in the lowering layer.

This also bumps the Tempo fork dependency from v0.0.1 to v0.0.2.

Follows up on the tempo-compat config fix from PR #428 (blocklist_poll, search smoke non-fatal, complete_block_timeout reduction).