### PR TITLE
fix(logql): project Attributes (not ResourceAttributes) post vector-aggregate

### DIFF
--- a/harness/loki-compatibility/cerberus-test-queries.yml
+++ b/harness/loki-compatibility/cerberus-test-queries.yml
@@ -83,18 +83,6 @@
 #     matching selectors have been unskipped.
 
 should_skip:
-  # fast/simple-metrics — count_over_time generates SQL referencing the
-  # ResourceAttributes identifier, which cerberus's chsql layer does not
-  # support as a first-class column expression. Known LogQL limitation.
-  - source: "fast/simple-metrics.yaml#Count over time"
-    reason: "Cerberus returns 502: 'Unknown expression identifier ResourceAttributes' — the count_over_time lowering emits a ResourceAttributes column reference that chsql cannot resolve. Known LogQL limitation; tracked in docs/roadmap.md."
-    since: "2026-05-18"
-    jira:  "docs/roadmap.md RC2 LogQL metric-queries / ResourceAttributes support"
-  - source: "fast/simple-metrics.yaml#Count with line filter"
-    reason: "Same ResourceAttributes 502 as Count over time — count_over_time lowering references ResourceAttributes."
-    since: "2026-05-18"
-    jira:  "docs/roadmap.md RC2 LogQL metric-queries / ResourceAttributes support"
-
   # fast/ — entries still skipped require unimplemented LogQL features (detected_level filters, | json, | logfmt):
   - source: "fast/simple-metrics.yaml#Count with error/warn filter"
     reason: "Requires `| detected_level=~\"error|warn\"` filter; cerberus does not yet support structured-metadata label filters in LogQL pipe expressions."

--- a/internal/logql/lang.go
+++ b/internal/logql/lang.go
@@ -117,11 +117,31 @@ func (l *Lang) ProjectSamples(plan chplan.Node, meta engine.Meta) chplan.Node {
 		// SELECT site since #310 collapsed the rename Project layer); mirror
 		// it here so the wire-wrap doesn't ColumnRef the pre-#310 lowercase
 		// alias.
+		//
+		// Inner stream-identity column resolution: a bare range-aggregation
+		// (`rate({...}[5m])` / `count_over_time({...}[5m])` / …) leaves the
+		// raw `ResourceAttributes` column in scope, since the RangeWindow's
+		// outer SELECT projects it under its own name. A vector aggregation
+		// (`sum(rate(...))` / `sum by (svc) (count_over_time(...))` / …)
+		// runs through [wrapVectorAggregateForSample], which has already
+		// projected the row into the canonical (MetricName, Attributes,
+		// TimeUnix, Value) Sample contract — at that point `ResourceAttributes`
+		// is gone (the Aggregate's GROUP BY consumed it) and the stream
+		// identity rides under the `Attributes` alias instead. Reading
+		// `ResourceAttributes` in that scope surfaces as 502 'Unknown
+		// expression identifier ResourceAttributes' from ClickHouse. Pick
+		// the right column name based on the inner shape — mirrors the
+		// same `isVectorAggregateSampleShape` switch the binop lowering
+		// applies in [sampleShapeOverLogInner].
+		attrsCol := s.ResourceAttributesColumn
+		if isVectorAggregateSampleShape(plan) {
+			attrsCol = "Attributes"
+		}
 		return &chplan.Project{
 			Input: plan,
 			Projections: []chplan.Projection{
 				{Expr: &chplan.LitString{V: ""}, Alias: "MetricName"},
-				{Expr: &chplan.ColumnRef{Name: s.ResourceAttributesColumn}, Alias: "Attributes"},
+				{Expr: &chplan.ColumnRef{Name: attrsCol}, Alias: "Attributes"},
 				// now64(9) - 5s buffer; see prom handler's synthesizedAnchor
 				// docstring. Avoids toMatrixStepGrid dropping the only row
 				// when CH-now > client-end.

--- a/internal/logql/lang_test.go
+++ b/internal/logql/lang_test.go
@@ -106,3 +106,67 @@ func TestProjectSamples_MetricBranchRefsValueColumn(t *testing.T) {
 			attrsRef.Name, s.ResourceAttributesColumn)
 	}
 }
+
+// TestProjectSamples_VectorAggregateRefsAttributes pins the metric-branch
+// wire-wrap against the regression `sum(count_over_time({...}[5m]))`
+// surfaced via the loki-compatibility harness as 502 'Unknown expression
+// identifier ResourceAttributes' from ClickHouse.
+//
+// Root cause: a vector aggregation runs through `wrapVectorAggregateForSample`,
+// which has already projected the row into the canonical (MetricName,
+// Attributes, TimeUnix, Value) Sample contract before reaching the engine
+// wire-wrap. At that point the raw `ResourceAttributes` column is gone (the
+// Aggregate's GROUP BY consumed it) — the stream identity rides under the
+// `Attributes` alias. The previous `Lang.ProjectSamples` blindly ColumnRef'd
+// `s.ResourceAttributesColumn` regardless of inner shape, so the outer SELECT
+// referenced a column that ClickHouse couldn't resolve.
+//
+// The fix mirrors the same `isVectorAggregateSampleShape` switch the binop
+// lowering applies in `sampleShapeOverLogInner` (see internal/logql/binary.go).
+// Construct a synthetic Project carrying the canonical-shape aliases and
+// assert the wrap picks `Attributes` instead of `ResourceAttributes`.
+func TestProjectSamples_VectorAggregateRefsAttributes(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelLogs()
+	l := &logql.Lang{Schema: s}
+
+	// Synthetic plan shaped like `wrapVectorAggregateForSample`'s output:
+	// a *chplan.Project whose Alias list includes "Attributes" — the
+	// canonical-shape marker `isVectorAggregateSampleShape` keys on.
+	plan := &chplan.Project{
+		Input: &chplan.Scan{Table: s.LogsTable},
+		Projections: []chplan.Projection{
+			{Expr: &chplan.LitString{V: ""}, Alias: "MetricName"},
+			{Expr: &chplan.FuncCall{
+				Name: "CAST",
+				Args: []chplan.Expr{
+					&chplan.FuncCall{Name: "map", Args: nil},
+					&chplan.LitString{V: "Map(String,String)"},
+				},
+			}, Alias: "Attributes"},
+			{Expr: &chplan.FuncCall{Name: "now64", Args: []chplan.Expr{&chplan.LitInt{V: 9}}}, Alias: "TimeUnix"},
+			{Expr: &chplan.ColumnRef{Name: "Value"}, Alias: "Value"},
+		},
+	}
+
+	wrapped := l.ProjectSamples(plan, engine.Meta{IsMetric: true})
+
+	proj, ok := wrapped.(*chplan.Project)
+	if !ok {
+		t.Fatalf("ProjectSamples returned %T, want *chplan.Project", wrapped)
+	}
+	attrsSlot := proj.Projections[1]
+	attrsRef, ok := attrsSlot.Expr.(*chplan.ColumnRef)
+	if !ok {
+		t.Fatalf("attributes slot expr: got %T, want *chplan.ColumnRef", attrsSlot.Expr)
+	}
+	if attrsRef.Name != "Attributes" {
+		t.Errorf("attributes slot ColumnRef.Name: got %q, want %q "+
+			"(vector-aggregation already projected stream identity as the "+
+			"`Attributes` alias via wrapVectorAggregateForSample — referencing "+
+			"the raw `ResourceAttributes` column at the outer SELECT site "+
+			"surfaces as 502 from ClickHouse since the Aggregate's GROUP BY "+
+			"consumed it)", attrsRef.Name, "Attributes")
+	}
+}

--- a/test/spec/logql/sum_count_over_time.txtar
+++ b/test/spec/logql/sum_count_over_time.txtar
@@ -1,0 +1,18 @@
+-- query.logql --
+sum(count_over_time({service_name="web-server"}[5m]))
+-- sql --
+SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Value` FROM (SELECT sum(`Value`) AS `Value`, count() AS `_cerb_n` FROM (SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1)) WHERE `_cerb_n` > 0)
+-- args --
+[0] string = ""
+[1] string = "Map(String,String)"
+[2] int64 = 9
+[3] int64 = 1
+[4] string = "service_name"
+[5] string = "web-server"
+-- chplan --
+Project ["" AS MetricName, CAST(map(), "Map(String,String)") AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+  Aggregate groupBy=[] funcs=[sum(Value) AS Value]
+    RangeWindow func=count_over_time range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
+      Project [ResourceAttributes, Timestamp, 1 AS Value]
+        Filter predicate=(ResourceAttributes["service_name"] = "web-server")
+          Scan(otel_logs)

--- a/test/spec/logql/sum_count_over_time_line_filter.txtar
+++ b/test/spec/logql/sum_count_over_time_line_filter.txtar
@@ -1,0 +1,19 @@
+-- query.logql --
+sum(count_over_time({service_name="web-server"} |= "level" [5m]))
+-- sql --
+SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Value` FROM (SELECT sum(`Value`) AS `Value`, count() AS `_cerb_n` FROM (SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (position(`Body`, ?) > 0))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1)) WHERE `_cerb_n` > 0)
+-- args --
+[0] string = ""
+[1] string = "Map(String,String)"
+[2] int64 = 9
+[3] int64 = 1
+[4] string = "service_name"
+[5] string = "web-server"
+[6] string = "level"
+-- chplan --
+Project ["" AS MetricName, CAST(map(), "Map(String,String)") AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+  Aggregate groupBy=[] funcs=[sum(Value) AS Value]
+    RangeWindow func=count_over_time range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
+      Project [ResourceAttributes, Timestamp, 1 AS Value]
+        Filter predicate=((ResourceAttributes["service_name"] = "web-server") AND lineContent(Body, "level", substr))
+          Scan(otel_logs)


### PR DESCRIPTION
## Summary

- Root cause: `Lang.ProjectSamples` (`internal/logql/lang.go`) blindly referenced `s.ResourceAttributesColumn` for all metric queries. For vector-aggregated queries (e.g. `sum(count_over_time({...}[5m]))`), the inner plan has already passed through `wrapVectorAggregateForSample`, which projects rows into the canonical (MetricName, Attributes, TimeUnix, Value) shape — `ResourceAttributes` is no longer in scope at that point (consumed by the Aggregate GROUP BY) and stream identity rides under `Attributes`. Reading `ResourceAttributes` surfaced as a 502 `Unknown identifier` from ClickHouse.
- Fix: reuse the existing `isVectorAggregateSampleShape` helper (already in use by `sampleShapeOverLogInner` for binop lowering) to detect the canonical-shape plan and read through `Attributes` instead. Bare-RangeWindow path keeps using `ResourceAttributesColumn` (RangeWindow's outer SELECT still projects it).
- Adds `TestProjectSamples_VectorAggregateRefsAttributes` to lock the new behavior; pre-existing `TestProjectSamples_MetricBranchRefsValueColumn` still guards the bare-RangeWindow path.
- Adds 2 TXTAR fixtures under `test/spec/logql/` mirroring the failing harness queries.

## Why

Pre-GA Maximal-GA push: closes 2 of 99 LogQL compatibility skips. Both queries (`sum(count_over_time({...}[range]))` and the line-filter variant) were skipped in commit `5ffdef8` pending this fix.

## Skip entries removed (from `harness/loki-compatibility/cerberus-test-queries.yml`)

- \`fast/simple-metrics.yaml#Count over time\` — \`sum(count_over_time(\${SELECTOR}[\${RANGE}]))\`
- \`fast/simple-metrics.yaml#Count with line filter\` — \`sum(count_over_time(\${SELECTOR} |= \"level\" [\${RANGE}]))\`

## Test plan

- [ ] \`check\` + \`lint\` pass.
- [ ] \`loki/compatibility\` shows the 2 previously-skipped queries pass.

## Follow-up (out of scope)

\`projectValueOverLogInner\` (\`internal/logql/binary.go:308\`) has the same bare \`ResourceAttributesColumn\` ref over a post-\`wrapVectorAggregateForSample\` inner. That'd surface as the same 502 for \`<scalar> * sum(count_over_time(...))\`-style queries. Not exercised by current harness corpus — flagging for future fix when the shape lands in coverage.