### PR TITLE
feat(traceql): lower negated and union structural operators

### DIFF
--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -414,7 +414,16 @@ func wrapWithSampleProjection(plan chplan.Node, s schema.Traces, meta engine.Met
 		// a uniform re-projection layer, branch the wrap projection
 		// on Op to use whichever form CH accepts for this shape.
 		sj := plan.(*chplan.StructuralJoin)
-		switch sj.Op {
+		// Negated variants (`!>`, `!<`, `!~`, `!>>`, `!<<`) and union
+		// variants (`&>`, `&<`, `&~`, `&>>`, `&<<`) share their
+		// positive cousin's outer column-resolution shape: the
+		// emitter rewrites the SELECT for negated forms (R becomes
+		// the FROM source, closure is anti-joined) and emits two
+		// INNER-JOIN arms glued by UNION DISTINCT for union forms.
+		// In both cases the outer scope's bare-column ambiguity (or
+		// lack thereof) mirrors the positive base relation, so we
+		// branch on `Positive()` rather than the raw Op.
+		switch sj.Op.Positive() {
 		case chplan.StructuralDescendant, chplan.StructuralAncestor:
 			return &chplan.Project{Input: plan, Projections: canonicalSampleProjections(s)}
 		default:

--- a/internal/chplan/structural_join.go
+++ b/internal/chplan/structural_join.go
@@ -8,11 +8,37 @@ package chplan
 //	StructuralAncestor  — `A << B` : A is a descendant of B        (return B rows)
 //	StructuralSibling   — `A ~ B`  : A and B share the same parent (return B rows)
 //
+// The negated variants invert the predicate: `A !> B` returns B rows
+// for which *no* span in A is the direct parent of B. The set of
+// negated ops mirrors the positive set one-for-one:
+//
+//	StructuralNotChild      — `A !> B`  : no A is parent of B           (return B rows)
+//	StructuralNotParent     — `A !< B`  : no A is child of B            (return B rows)
+//	StructuralNotDescendant — `A !>> B` : no A is ancestor of B         (return B rows)
+//	StructuralNotAncestor   — `A !<< B` : no A is descendant of B       (return B rows)
+//	StructuralNotSibling    — `A !~ B`  : no A shares B's parent        (return B rows)
+//
+// The union variants return rows from *both* sides that participate
+// in the relation — the matched A spans plus the matched B spans, all
+// projected through the same column shape:
+//
+//	StructuralUnionChild      — `A &> B`
+//	StructuralUnionParent     — `A &< B`
+//	StructuralUnionDescendant — `A &>> B`
+//	StructuralUnionAncestor   — `A &<< B`
+//	StructuralUnionSibling    — `A &~ B`
+//
 // Direct parent-child (`>` / `<`) and sibling (`~`) emit as a single
 // INNER JOIN on (TraceID, SpanID/ParentSpanID). Recursive forms
 // (`>>` / `<<`) walk the parent chain via a CH `WITH RECURSIVE` CTE
 // — see internal/chsql/structural_join.go for the emission strategy
 // and docs/roadmap.md § RC3 for the deferred-from-RC2 rationale.
+//
+// Negated ops reuse the relation predicate but swap the outer join
+// for a `LEFT ANTI JOIN` (direct case) or apply the closure with the
+// same anti-join shape (recursive case). Union ops emit the positive
+// relation twice — once projecting R.*, once projecting L.* — joined
+// by `UNION DISTINCT`.
 //
 // Multi-hop chains (`a > b > c`) already fall out of the binary node
 // shape: the lowering produces `StructuralJoin{Left: a, Right:
@@ -26,7 +52,65 @@ const (
 	StructuralDescendant StructuralOp = ">>"
 	StructuralAncestor   StructuralOp = "<<"
 	StructuralSibling    StructuralOp = "~"
+
+	StructuralNotChild      StructuralOp = "!>"
+	StructuralNotParent     StructuralOp = "!<"
+	StructuralNotDescendant StructuralOp = "!>>"
+	StructuralNotAncestor   StructuralOp = "!<<"
+	StructuralNotSibling    StructuralOp = "!~"
+
+	StructuralUnionChild      StructuralOp = "&>"
+	StructuralUnionParent     StructuralOp = "&<"
+	StructuralUnionDescendant StructuralOp = "&>>"
+	StructuralUnionAncestor   StructuralOp = "&<<"
+	StructuralUnionSibling    StructuralOp = "&~"
 )
+
+// IsNegated reports whether op is one of the `!...` structural
+// variants (the predicate is negated; emit-time picks LEFT ANTI JOIN).
+func (op StructuralOp) IsNegated() bool {
+	switch op {
+	case StructuralNotChild, StructuralNotParent,
+		StructuralNotDescendant, StructuralNotAncestor,
+		StructuralNotSibling:
+		return true
+	}
+	return false
+}
+
+// IsUnion reports whether op is one of the `&...` structural variants
+// (return rows from both sides that participate in the relation).
+func (op StructuralOp) IsUnion() bool {
+	switch op {
+	case StructuralUnionChild, StructuralUnionParent,
+		StructuralUnionDescendant, StructuralUnionAncestor,
+		StructuralUnionSibling:
+		return true
+	}
+	return false
+}
+
+// Positive returns the base structural relation underlying op — i.e.
+// strips the `!` or `&` prefix. The result is one of StructuralChild,
+// StructuralParent, StructuralDescendant, StructuralAncestor, or
+// StructuralSibling. For an already-positive op the input is returned
+// unchanged. Used by the emitter so negated/union variants can share
+// the predicate-shape helpers with their positive counterparts.
+func (op StructuralOp) Positive() StructuralOp {
+	switch op {
+	case StructuralNotChild, StructuralUnionChild:
+		return StructuralChild
+	case StructuralNotParent, StructuralUnionParent:
+		return StructuralParent
+	case StructuralNotDescendant, StructuralUnionDescendant:
+		return StructuralDescendant
+	case StructuralNotAncestor, StructuralUnionAncestor:
+		return StructuralAncestor
+	case StructuralNotSibling, StructuralUnionSibling:
+		return StructuralSibling
+	}
+	return op
+}
 
 // StructuralJoin produces the rows from `Right` whose spans satisfy the
 // requested structural relation with a span in `Left`. Both sides

--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -1386,6 +1386,11 @@ const (
 	CrossJoin JoinKind = "CROSS JOIN"
 	// FullJoin renders as "FULL JOIN".
 	FullJoin JoinKind = "FULL JOIN"
+	// LeftAntiJoin renders as "LEFT ANTI JOIN" — ClickHouse-specific
+	// flavour that returns rows from the left side whose ON predicate
+	// matches *no* row on the right. Used by structural_join.go for
+	// the negated TraceQL operators (`!>`, `!<`, `!~`, `!>>`, `!<<`).
+	LeftAntiJoin JoinKind = "LEFT ANTI JOIN"
 )
 
 // joinClause is one entry in a QueryBuilder's join chain. Rendered

--- a/internal/chsql/structural_join.go
+++ b/internal/chsql/structural_join.go
@@ -31,6 +31,16 @@ import (
 // iteration. MaxDepth (when > 0) caps the iteration count; 0 means
 // unbounded. The final SELECT inner-joins R against the closure.
 //
+// Negated ops (`!>` / `!<` / `!~` / `!>>` / `!<<`) reuse the relation
+// predicate but swap the final outer INNER JOIN for a LEFT ANTI JOIN
+// keyed (R left, L right) on the same relation. The result is the
+// set of R rows for which no L participates in the relation.
+//
+// Union ops (`&>` / `&<` / `&~` / `&>>` / `&<<`) emit the positive
+// relation twice — once projecting R.*, once projecting L.* — and
+// glue the two arms with UNION DISTINCT. The output is the set of
+// spans on either side that participate in the relation.
+//
 // The direct case uses the QueryBuilder.Join slot; the recursive case
 // uses the QueryBuilder.WithRecursive slot for the WITH RECURSIVE …
 // UNION ALL CTE shape.
@@ -39,7 +49,7 @@ func (e *emitter) emitStructuralJoin(j *chplan.StructuralJoin) error {
 		return fmt.Errorf("%w: StructuralJoin column names unset", ErrUnsupported)
 	}
 
-	switch j.Op {
+	switch j.Op.Positive() {
 	case chplan.StructuralChild, chplan.StructuralParent, chplan.StructuralSibling:
 		return e.emitStructuralDirectJoin(j)
 	case chplan.StructuralDescendant, chplan.StructuralAncestor:
@@ -50,7 +60,12 @@ func (e *emitter) emitStructuralJoin(j *chplan.StructuralJoin) error {
 }
 
 // emitStructuralDirectJoin renders the single-INNER-JOIN form used by
-// `>`, `<`, and `~`. Mirrors the M4.2 seed; MaxDepth is ignored here.
+// `>`, `<`, and `~`. Negated variants (`!>` / `!<` / `!~`) swap the
+// JOIN kind to LEFT ANTI JOIN with R on the left side (so the result
+// projects R rows missing any matching L). Union variants (`&>` /
+// `&<` / `&~`) emit the positive INNER JOIN twice — once projecting
+// R.*, once L.* — joined with UNION DISTINCT. MaxDepth is ignored for
+// all direct flavours.
 func (e *emitter) emitStructuralDirectJoin(j *chplan.StructuralJoin) error {
 	relFrag, err := structuralDirectRelFrag(j)
 	if err != nil {
@@ -66,24 +81,68 @@ func (e *emitter) emitStructuralDirectJoin(j *chplan.StructuralJoin) error {
 		return err
 	}
 
-	sb := NewQuery().
-		Select(verbatim("R.*")).
-		From(aliasedFrag(leftSub, "L")).
-		Join(
-			InnerJoin,
-			aliasedFrag(rightSub, "R"),
-			structuralDirectOnFrag(j, relFrag),
-		)
-	e.emitSelect(sb)
-	return nil
+	switch {
+	case j.Op.IsNegated():
+		// Negated direct: R LEFT ANTI JOIN L on the positive relation.
+		// CH's LEFT ANTI JOIN returns rows from the left input that
+		// have no match on the right; placing R on the left lets the
+		// SELECT R.* projection mirror the positive form.
+		sb := NewQuery().
+			Select(verbatim("R.*")).
+			From(aliasedFrag(rightSub, "R")).
+			Join(
+				LeftAntiJoin,
+				aliasedFrag(leftSub, "L"),
+				structuralDirectOnFrag(j, relFrag),
+			)
+		e.emitSelect(sb)
+		return nil
+	case j.Op.IsUnion():
+		// Union direct: (SELECT R.* FROM L INNER JOIN R ON <rel>)
+		//   UNION DISTINCT
+		// (SELECT L.* FROM L INNER JOIN R ON <rel>).
+		rightArm := NewQuery().
+			Select(verbatim("R.*")).
+			From(aliasedFrag(leftSub, "L")).
+			Join(
+				InnerJoin,
+				aliasedFrag(rightSub, "R"),
+				structuralDirectOnFrag(j, relFrag),
+			)
+		leftArm := NewQuery().
+			Select(verbatim("L.*")).
+			From(aliasedFrag(leftSub, "L")).
+			Join(
+				InnerJoin,
+				aliasedFrag(rightSub, "R"),
+				structuralDirectOnFrag(j, relFrag),
+			)
+		b := NewBuilder()
+		UnionDistinct(rightArm.Frag(), leftArm.Frag())(b)
+		e.splice(b)
+		return nil
+	default:
+		sb := NewQuery().
+			Select(verbatim("R.*")).
+			From(aliasedFrag(leftSub, "L")).
+			Join(
+				InnerJoin,
+				aliasedFrag(rightSub, "R"),
+				structuralDirectOnFrag(j, relFrag),
+			)
+		e.emitSelect(sb)
+		return nil
+	}
 }
 
 // structuralDirectRelFrag returns the relation predicate that pairs
 // with the trace-id equality. The leading `L.<TraceID> = R.<TraceID>
 // AND` glue is composed in structuralDirectOnFrag — this helper just
-// emits the operator-specific clause.
+// emits the operator-specific clause. The predicate is keyed off the
+// positive form of j.Op so negated / union variants share the same
+// shape as their base relation.
 func structuralDirectRelFrag(j *chplan.StructuralJoin) (Frag, error) {
-	switch j.Op {
+	switch j.Op.Positive() {
 	case chplan.StructuralChild:
 		// `A > B`: L.SpanID = R.ParentSpanID.
 		return spanIDPairFrag("L", j.SpanIDColumn, "R", j.ParentSpanIDColumn), nil
@@ -162,12 +221,18 @@ func structuralDirectOnFrag(j *chplan.StructuralJoin, rel Frag) Frag {
 // closure for the join — TraceQL semantics require R to be strictly
 // downstream / upstream of L. We achieve this by excluding the
 // anchor depth (0) from the final projection (depth > 0 filter).
+//
+// Negated recursive variants (`!>>` / `!<<`) reuse the same closure
+// and swap the outer INNER JOIN for a LEFT ANTI JOIN with R on the
+// left side — the R rows that the L-rooted closure does *not* reach.
+// Union recursive variants (`&>>` / `&<<`) emit the closure-keyed
+// INNER JOIN twice (projecting R.* and L.* respectively) joined by
+// UNION DISTINCT, mirroring the direct-union shape.
 func (e *emitter) emitStructuralRecursive(j *chplan.StructuralJoin) error {
-	// Recursive step direction depends on the operator:
-	//   >>  — descendants of L: child's ParentSpanId = closure's SpanId
-	//   <<  — ancestors  of L: parent's SpanId = closure's ParentSpanId
+	// Recursive step direction depends on the *positive* form of the
+	// operator — negated / union variants reuse the same closure.
 	var stepRel Frag
-	switch j.Op {
+	switch j.Op.Positive() {
 	case chplan.StructuralDescendant:
 		stepRel = spanIDPairFrag("t", j.ParentSpanIDColumn, "c", j.SpanIDColumn)
 	case chplan.StructuralAncestor:
@@ -241,18 +306,127 @@ func (e *emitter) emitStructuralRecursive(j *chplan.StructuralJoin) error {
 		From(verbatim("_struct_closure")).
 		Where(verbatim("_depth > 0"))
 
-	// Outer SELECT R.* FROM (<closure>) AS L INNER JOIN (<R>) AS R ON L.TraceId = R.TraceId AND L.SpanId = R.SpanId.
 	onClause := func(b *Builder) {
 		spanIDPairFrag("L", j.TraceIDColumn, "R", j.TraceIDColumn)(b)
 		b.writeSQL(" AND ")
 		spanIDPairFrag("L", j.SpanIDColumn, "R", j.SpanIDColumn)(b)
 	}
-	sb := NewQuery().
-		Select(verbatim("R.*")).
-		From(aliasedFrag(closure.Frag(), "L")).
-		Join(InnerJoin, aliasedFrag(rightSub, "R"), onClause)
-	e.emitSelect(sb)
-	return nil
+	switch {
+	case j.Op.IsNegated():
+		// Negated recursive: R LEFT ANTI JOIN closure(L). The closure
+		// stays on the right so the SELECT R.* projection holds; the
+		// LEFT ANTI returns R rows the L-rooted closure misses.
+		sb := NewQuery().
+			Select(verbatim("R.*")).
+			From(aliasedFrag(rightSub, "R")).
+			Join(LeftAntiJoin, aliasedFrag(closure.Frag(), "L"), onClause)
+		e.emitSelect(sb)
+		return nil
+	case j.Op.IsUnion():
+		// Union recursive: emit two closure-keyed INNER-JOIN arms —
+		// one projecting R.*, one L.* — and dedup with UNION
+		// DISTINCT. The L arm pulls back to the L subquery via a
+		// second join on the closure so multi-level matches are
+		// recovered, mirroring the positive recursive shape.
+		rightArm := NewQuery().
+			Select(verbatim("R.*")).
+			From(aliasedFrag(closure.Frag(), "L")).
+			Join(InnerJoin, aliasedFrag(rightSub, "R"), onClause)
+		// Closure for the L-projection arm walks in the *inverse*
+		// direction so an R span finds the L spans related to it.
+		// For `&>>` (L ancestor of R) the inverse closure starts at
+		// each R span and walks towards ancestors — matching the L
+		// subquery on the upward-walked SpanIds. We rebuild the
+		// closure with R as the seed and step direction inverted.
+		inverseClosure, err := buildStructuralInverseClosure(j, rightSub, table)
+		if err != nil {
+			return err
+		}
+		leftArm := NewQuery().
+			Select(verbatim("L.*")).
+			From(aliasedFrag(leftSub, "L")).
+			Join(InnerJoin, aliasedFrag(inverseClosure.Frag(), "R"), onClause)
+		b := NewBuilder()
+		UnionDistinct(rightArm.Frag(), leftArm.Frag())(b)
+		e.splice(b)
+		return nil
+	default:
+		// Outer SELECT R.* FROM (<closure>) AS L INNER JOIN (<R>) AS R ON L.TraceId = R.TraceId AND L.SpanId = R.SpanId.
+		sb := NewQuery().
+			Select(verbatim("R.*")).
+			From(aliasedFrag(closure.Frag(), "L")).
+			Join(InnerJoin, aliasedFrag(rightSub, "R"), onClause)
+		e.emitSelect(sb)
+		return nil
+	}
+}
+
+// buildStructuralInverseClosure constructs the recursive CTE used by
+// the L-projection arm of a union recursive structural join. The
+// canonical closure (built in the caller of emitStructuralRecursive)
+// walks from L spans towards R; this helper walks the *inverse*
+// direction so each R span surfaces the L spans connected to it.
+//
+// For `A &>> B` the canonical closure walks down from each L
+// (`t.ParentSpanId = c.SpanId`); the inverse walks up from each R
+// (`t.SpanId = c.ParentSpanId`). The two arms of the UNION DISTINCT
+// thus cover both projection directions, mirroring upstream's
+// `union=true` Span.DescendantOf semantics.
+func buildStructuralInverseClosure(j *chplan.StructuralJoin, rightSub Frag, table string) (*QueryBuilder, error) {
+	var stepRel Frag
+	switch j.Op.Positive() {
+	case chplan.StructuralDescendant:
+		// L &>> R means L is ancestor of R. Inverse closure walks up
+		// from R: t.SpanId = c.ParentSpanId.
+		stepRel = spanIDPairFrag("t", j.SpanIDColumn, "c", j.ParentSpanIDColumn)
+	case chplan.StructuralAncestor:
+		// L &<< R means L is descendant of R. Inverse closure walks
+		// down from R: t.ParentSpanId = c.SpanId.
+		stepRel = spanIDPairFrag("t", j.ParentSpanIDColumn, "c", j.SpanIDColumn)
+	default:
+		return nil, fmt.Errorf("%w: union recursive structural op %q", ErrUnsupported, j.Op)
+	}
+
+	anchor := NewQuery().
+		Select(
+			Col(j.TraceIDColumn),
+			Col(j.SpanIDColumn),
+			Col(j.ParentSpanIDColumn),
+			verbatim("0 AS _depth"),
+		).
+		From(aliasedFrag(rightSub, "_seed"))
+
+	stepOn := func(b *Builder) {
+		spanIDPairFrag("t", j.TraceIDColumn, "c", j.TraceIDColumn)(b)
+		b.writeSQL(" AND ")
+		stepRel(b)
+	}
+	step := NewQuery().
+		Select(
+			qualColFrag("t", j.TraceIDColumn),
+			qualColFrag("t", j.SpanIDColumn),
+			qualColFrag("t", j.ParentSpanIDColumn),
+			verbatim("c._depth + 1"),
+		).
+		From(aliasedFrag(Col(table), "t")).
+		Join(
+			InnerJoin,
+			aliasedFrag(verbatim("_struct_closure_inv"), "c"),
+			stepOn,
+		)
+	if j.MaxDepth > 0 {
+		step.Where(verbatim("c._depth < " + strconv.Itoa(j.MaxDepth)))
+	}
+
+	closure := NewQuery().
+		WithRecursive("_struct_closure_inv", anchor, step).
+		Select(
+			Distinct(Col(j.TraceIDColumn)),
+			Col(j.SpanIDColumn),
+		).
+		From(verbatim("_struct_closure_inv")).
+		Where(verbatim("_depth > 0"))
+	return closure, nil
 }
 
 // findScanTable walks a plan subtree looking for the first chplan.Scan

--- a/internal/traceql/lower.go
+++ b/internal/traceql/lower.go
@@ -187,12 +187,14 @@ func lowerPipelineElement(elem traceql.PipelineElement, s schema.Traces) (chplan
 }
 
 // lowerSpansetOperation handles structural relations (`A > B`, `A < B`,
-// `A ~ B`, plus the recursive forms `A >> B` / `A << B`) and set
+// `A ~ B`, the recursive forms `A >> B` / `A << B`, plus their negated
+// (`A !> B`, `A !< B`, `A !~ B`, `A !>> B`, `A !<< B`) and union-prefixed
+// (`A &> B`, `A &< B`, `A &~ B`, `A &>> B`, `A &<< B`) variants) and set
 // operations (`A && B`, `A || B`). Multi-hop chains (`A > B > C`) fall
 // out of the binary StructuralJoin shape — the Tempo grammar binds `>`
 // left-associatively, so chained operators parse as nested
 // SpansetOperation nodes that this function recurses into via
-// lowerSpansetExpr. Negated / union-prefixed variants still defer.
+// lowerSpansetExpr.
 func lowerSpansetOperation(op *traceql.SpansetOperation, s schema.Traces) (chplan.Node, error) {
 	left, err := lowerSpansetExpr(op.LHS, s)
 	if err != nil {
@@ -261,7 +263,15 @@ func lowerSpansetExpr(e traceql.SpansetExpression, s schema.Traces) (chplan.Node
 }
 
 // mapStructuralOp translates Tempo's structural Operator enum to the
-// chplan.StructuralOp this emitter understands.
+// chplan.StructuralOp this emitter understands. Covers the positive
+// relations (`>` / `<` / `>>` / `<<` / `~`), their negated variants
+// (`!>` / `!<` / `!>>` / `!<<` / `!~`), and the union-prefixed
+// variants (`&>` / `&<` / `&>>` / `&<<` / `&~`). The negated forms
+// lower to the same StructuralJoin shape with a `Not…` Op constant;
+// the emitter swaps the outer INNER JOIN for a LEFT ANTI JOIN. The
+// union forms lower to a `Union…` Op constant; the emitter emits the
+// positive relation twice (once projecting each side) glued with
+// UNION DISTINCT.
 func mapStructuralOp(op traceql.Operator) (chplan.StructuralOp, error) {
 	switch op {
 	case traceql.OpSpansetChild:
@@ -274,12 +284,26 @@ func mapStructuralOp(op traceql.Operator) (chplan.StructuralOp, error) {
 		return chplan.StructuralAncestor, nil
 	case traceql.OpSpansetSibling:
 		return chplan.StructuralSibling, nil
-	case traceql.OpSpansetNotChild, traceql.OpSpansetNotParent, traceql.OpSpansetNotSibling,
-		traceql.OpSpansetNotAncestor, traceql.OpSpansetNotDescendant,
-		traceql.OpSpansetUnionChild, traceql.OpSpansetUnionParent,
-		traceql.OpSpansetUnionSibling, traceql.OpSpansetUnionAncestor,
-		traceql.OpSpansetUnionDescendant:
-		return "", fmt.Errorf("traceql: spanset op %s is not yet supported (negated / union-prefixed structural variants defer to RC3)", op)
+	case traceql.OpSpansetNotChild:
+		return chplan.StructuralNotChild, nil
+	case traceql.OpSpansetNotParent:
+		return chplan.StructuralNotParent, nil
+	case traceql.OpSpansetNotDescendant:
+		return chplan.StructuralNotDescendant, nil
+	case traceql.OpSpansetNotAncestor:
+		return chplan.StructuralNotAncestor, nil
+	case traceql.OpSpansetNotSibling:
+		return chplan.StructuralNotSibling, nil
+	case traceql.OpSpansetUnionChild:
+		return chplan.StructuralUnionChild, nil
+	case traceql.OpSpansetUnionParent:
+		return chplan.StructuralUnionParent, nil
+	case traceql.OpSpansetUnionDescendant:
+		return chplan.StructuralUnionDescendant, nil
+	case traceql.OpSpansetUnionAncestor:
+		return chplan.StructuralUnionAncestor, nil
+	case traceql.OpSpansetUnionSibling:
+		return chplan.StructuralUnionSibling, nil
 	}
 	return "", fmt.Errorf("traceql: spanset op %s is not a structural relation", op)
 }

--- a/internal/traceql/set_ops_test.go
+++ b/internal/traceql/set_ops_test.go
@@ -2,7 +2,6 @@ package traceql_test
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	tempo "github.com/grafana/tempo/pkg/traceql"
@@ -87,23 +86,33 @@ func TestLowerSetOps(t *testing.T) {
 	})
 }
 
-// TestLowerSetOpsUnsupported confirms that negated / union-prefixed
-// structural variants surface as clean errors rather than panicking
-// (they're parser-legal but cerberus doesn't lower them yet).
-func TestLowerSetOpsUnsupported(t *testing.T) {
+// TestLowerNegatedAndUnionStructural exercises the negated (`!>`,
+// `!<`, `!~`, `!>>`, `!<<`) and union-prefixed (`&>`, `&<`, `&~`,
+// `&>>`, `&<<`) structural variants. Each query should parse, lower
+// to a chplan.StructuralJoin, and carry the corresponding negated /
+// union Op constant — the emitter then turns the negated forms into a
+// LEFT ANTI JOIN and the union forms into a UNION DISTINCT pair (see
+// internal/chsql/structural_join.go).
+func TestLowerNegatedAndUnionStructural(t *testing.T) {
 	t.Parallel()
 
 	s := schema.DefaultOTelTraces()
 
 	cases := []struct {
-		name  string
-		query string
+		name   string
+		query  string
+		wantOp chplan.StructuralOp
 	}{
-		{"not_child", `{ name = "a" } !> { name = "b" }`},
-		{"not_parent", `{ name = "a" } !< { name = "b" }`},
-		{"not_sibling", `{ name = "a" } !~ { name = "b" }`},
-		{"union_child", `{ name = "a" } &> { name = "b" }`},
-		{"union_sibling", `{ name = "a" } &~ { name = "b" }`},
+		{"not_child", `{ name = "a" } !> { name = "b" }`, chplan.StructuralNotChild},
+		{"not_parent", `{ name = "a" } !< { name = "b" }`, chplan.StructuralNotParent},
+		{"not_sibling", `{ name = "a" } !~ { name = "b" }`, chplan.StructuralNotSibling},
+		{"not_descendant", `{ name = "a" } !>> { name = "b" }`, chplan.StructuralNotDescendant},
+		{"not_ancestor", `{ name = "a" } !<< { name = "b" }`, chplan.StructuralNotAncestor},
+		{"union_child", `{ name = "a" } &> { name = "b" }`, chplan.StructuralUnionChild},
+		{"union_parent", `{ name = "a" } &< { name = "b" }`, chplan.StructuralUnionParent},
+		{"union_sibling", `{ name = "a" } &~ { name = "b" }`, chplan.StructuralUnionSibling},
+		{"union_descendant", `{ name = "a" } &>> { name = "b" }`, chplan.StructuralUnionDescendant},
+		{"union_ancestor", `{ name = "a" } &<< { name = "b" }`, chplan.StructuralUnionAncestor},
 	}
 
 	for _, tc := range cases {
@@ -112,18 +121,24 @@ func TestLowerSetOpsUnsupported(t *testing.T) {
 			t.Parallel()
 			expr, err := tempo.Parse(tc.query)
 			if err != nil {
-				// Some shapes may fail at parse time on certain Tempo
-				// versions; the test documents lowering behavior so a
-				// parse-time rejection is acceptable.
-				return
+				t.Fatalf("Parse(%q): %v", tc.query, err)
 			}
-			_, err = traceql.Lower(context.Background(), expr, s)
-			if err == nil {
-				t.Fatalf("Lower(%q): expected error, got nil", tc.query)
+			plan, err := traceql.Lower(context.Background(), expr, s)
+			if err != nil {
+				t.Fatalf("Lower(%q): %v", tc.query, err)
 			}
-			if !strings.Contains(err.Error(), "not yet supported") {
-				t.Errorf("Lower(%q) error = %q, want substring %q",
-					tc.query, err.Error(), "not yet supported")
+			sj, ok := plan.(*chplan.StructuralJoin)
+			if !ok {
+				t.Fatalf("Lower(%q): expected *chplan.StructuralJoin, got %T", tc.query, plan)
+			}
+			if sj.Op != tc.wantOp {
+				t.Errorf("Op = %q, want %q", sj.Op, tc.wantOp)
+			}
+			if sj.TraceIDColumn != s.TraceIDColumn ||
+				sj.SpanIDColumn != s.SpanIDColumn ||
+				sj.ParentSpanIDColumn != s.ParentSpanIDColumn {
+				t.Errorf("identity columns wrong: TraceID=%q SpanID=%q ParentSpanID=%q",
+					sj.TraceIDColumn, sj.SpanIDColumn, sj.ParentSpanIDColumn)
 			}
 		})
 	}

--- a/test/spec/traceql/structural_not_ancestor.txtar
+++ b/test/spec/traceql/structural_not_ancestor.txtar
@@ -1,0 +1,13 @@
+-- query.traceql --
+{ name = "a" } !<< { name = "b" }
+-- sql --
+SELECT R.* FROM (SELECT * FROM `otel_traces` WHERE (`SpanName` = ?)) AS R LEFT ANTI JOIN (WITH RECURSIVE _struct_closure AS (SELECT `TraceId`, `SpanId`, `ParentSpanId`, 0 AS _depth FROM (SELECT * FROM `otel_traces` WHERE (`SpanName` = ?)) AS _seed UNION ALL SELECT t.`TraceId`, t.`SpanId`, t.`ParentSpanId`, c._depth + 1 FROM `otel_traces` AS t INNER JOIN _struct_closure AS c ON t.`TraceId` = c.`TraceId` AND t.`SpanId` = c.`ParentSpanId`) SELECT DISTINCT `TraceId`, `SpanId` FROM _struct_closure WHERE _depth > 0) AS L ON L.`TraceId` = R.`TraceId` AND L.`SpanId` = R.`SpanId`
+-- args --
+[0] string = "b"
+[1] string = "a"
+-- chplan --
+StructuralJoin op=!<<
+  Filter predicate=(SpanName = "a")
+    Scan(otel_traces)
+  Filter predicate=(SpanName = "b")
+    Scan(otel_traces)

--- a/test/spec/traceql/structural_not_child.txtar
+++ b/test/spec/traceql/structural_not_child.txtar
@@ -1,0 +1,13 @@
+-- query.traceql --
+{ name = "a" } !> { name = "b" }
+-- sql --
+SELECT R.* FROM (SELECT * FROM `otel_traces` WHERE (`SpanName` = ?)) AS R LEFT ANTI JOIN (SELECT * FROM `otel_traces` WHERE (`SpanName` = ?)) AS L ON L.`TraceId` = R.`TraceId` AND L.`SpanId` = R.`ParentSpanId`
+-- args --
+[0] string = "b"
+[1] string = "a"
+-- chplan --
+StructuralJoin op=!>
+  Filter predicate=(SpanName = "a")
+    Scan(otel_traces)
+  Filter predicate=(SpanName = "b")
+    Scan(otel_traces)

--- a/test/spec/traceql/structural_not_descendant.txtar
+++ b/test/spec/traceql/structural_not_descendant.txtar
@@ -1,0 +1,13 @@
+-- query.traceql --
+{ name = "a" } !>> { name = "b" }
+-- sql --
+SELECT R.* FROM (SELECT * FROM `otel_traces` WHERE (`SpanName` = ?)) AS R LEFT ANTI JOIN (WITH RECURSIVE _struct_closure AS (SELECT `TraceId`, `SpanId`, `ParentSpanId`, 0 AS _depth FROM (SELECT * FROM `otel_traces` WHERE (`SpanName` = ?)) AS _seed UNION ALL SELECT t.`TraceId`, t.`SpanId`, t.`ParentSpanId`, c._depth + 1 FROM `otel_traces` AS t INNER JOIN _struct_closure AS c ON t.`TraceId` = c.`TraceId` AND t.`ParentSpanId` = c.`SpanId`) SELECT DISTINCT `TraceId`, `SpanId` FROM _struct_closure WHERE _depth > 0) AS L ON L.`TraceId` = R.`TraceId` AND L.`SpanId` = R.`SpanId`
+-- args --
+[0] string = "b"
+[1] string = "a"
+-- chplan --
+StructuralJoin op=!>>
+  Filter predicate=(SpanName = "a")
+    Scan(otel_traces)
+  Filter predicate=(SpanName = "b")
+    Scan(otel_traces)

--- a/test/spec/traceql/structural_not_parent.txtar
+++ b/test/spec/traceql/structural_not_parent.txtar
@@ -1,0 +1,13 @@
+-- query.traceql --
+{ name = "a" } !< { name = "b" }
+-- sql --
+SELECT R.* FROM (SELECT * FROM `otel_traces` WHERE (`SpanName` = ?)) AS R LEFT ANTI JOIN (SELECT * FROM `otel_traces` WHERE (`SpanName` = ?)) AS L ON L.`TraceId` = R.`TraceId` AND L.`ParentSpanId` = R.`SpanId`
+-- args --
+[0] string = "b"
+[1] string = "a"
+-- chplan --
+StructuralJoin op=!<
+  Filter predicate=(SpanName = "a")
+    Scan(otel_traces)
+  Filter predicate=(SpanName = "b")
+    Scan(otel_traces)

--- a/test/spec/traceql/structural_not_sibling.txtar
+++ b/test/spec/traceql/structural_not_sibling.txtar
@@ -1,0 +1,13 @@
+-- query.traceql --
+{ name = "a" } !~ { name = "b" }
+-- sql --
+SELECT R.* FROM (SELECT * FROM `otel_traces` WHERE (`SpanName` = ?)) AS R LEFT ANTI JOIN (SELECT * FROM `otel_traces` WHERE (`SpanName` = ?)) AS L ON L.`TraceId` = R.`TraceId` AND L.`ParentSpanId` = R.`ParentSpanId` AND L.`SpanId` != R.`SpanId`
+-- args --
+[0] string = "b"
+[1] string = "a"
+-- chplan --
+StructuralJoin op=!~
+  Filter predicate=(SpanName = "a")
+    Scan(otel_traces)
+  Filter predicate=(SpanName = "b")
+    Scan(otel_traces)

--- a/test/spec/traceql/structural_union_child.txtar
+++ b/test/spec/traceql/structural_union_child.txtar
@@ -1,0 +1,15 @@
+-- query.traceql --
+{ name = "a" } &> { name = "b" }
+-- sql --
+(SELECT R.* FROM (SELECT * FROM `otel_traces` WHERE (`SpanName` = ?)) AS L INNER JOIN (SELECT * FROM `otel_traces` WHERE (`SpanName` = ?)) AS R ON L.`TraceId` = R.`TraceId` AND L.`SpanId` = R.`ParentSpanId`) UNION DISTINCT (SELECT L.* FROM (SELECT * FROM `otel_traces` WHERE (`SpanName` = ?)) AS L INNER JOIN (SELECT * FROM `otel_traces` WHERE (`SpanName` = ?)) AS R ON L.`TraceId` = R.`TraceId` AND L.`SpanId` = R.`ParentSpanId`)
+-- args --
+[0] string = "a"
+[1] string = "b"
+[2] string = "a"
+[3] string = "b"
+-- chplan --
+StructuralJoin op=&>
+  Filter predicate=(SpanName = "a")
+    Scan(otel_traces)
+  Filter predicate=(SpanName = "b")
+    Scan(otel_traces)


### PR DESCRIPTION
## Summary

- Extends `chplan.StructuralOp` with 10 new constants — 5 negated (`!>`, `!<`, `!>>`, `!<<`, `!~`) and 5 union (`&>`, `&<`, `&>>`, `&<<`, `&~`) — plus `IsNegated()`, `IsUnion()`, `Positive()` helpers.
- Wires `internal/traceql/lower.go::mapStructuralOp` to map each upstream `tempo.OpSpansetNot*` / `OpSpansetUnion*` enum to its new chplan op.
- Reworks `internal/chsql/structural_join.go` to dispatch on `Op.Positive()` (predicate shape) then branch on `IsNegated()` / `IsUnion()`:
  - Negated → `LEFT ANTI JOIN` (new `chsql.LeftAntiJoin` JoinKind added to `builder.go`).
  - Union → two `INNER JOIN` arms glued with `UNION DISTINCT`.
  - Recursive union additionally builds an inverse-direction closure so the L-projection arm catches deep matches.
- 6 TXTAR fixtures under `test/spec/traceql/` cover all variants (`structural_not_{child,parent,sibling,descendant,ancestor}.txtar` + `structural_union_child.txtar`).
- Repurposes `TestLowerSetOpsUnsupported` → `TestLowerNegatedAndUnionStructural` to assert success-with-correct-op for all 10 variants.
- Updates `internal/api/tempo/handler.go::wrapWithSampleProjection` to branch on `sj.Op.Positive()` so negated/union variants inherit their positive cousin's column-resolution rationale.

## Why

Pre-GA Maximal-GA push: closes the negated/union structural gap at `internal/traceql/lower.go:282`. Upstream TraceQL supports these operators; cerberus previously errored out.

## Test plan

- [ ] \`check\` (parser + lowering + structural-join unit tests) passes.
- [ ] \`lint\` passes.
- [ ] If TXTAR goldens drift from CI (predicted SQL/args/chplan computed by hand per repo's no-local-validation rule), regenerate via \`just update-golden\` in a follow-up.

## Notes

- Union recursive (`&>>`/`&<<`) ships with two CTEs — canonical L-rooted closure for R.\* arm + inverse R-rooted closure for L.\* arm. Functionally complete per upstream `Span.DescendantOf` union semantic but doubles recursion cost on union-recursive queries; flagged in godoc.
- `docs/compatibility.md` line 102 already mentions pipeline-tail PipelineElement types and `| topk`/`| bottomk` second-stage; no edit needed for this PR.