### PR TITLE
feat(chplan,chsql): MetricsSecondStage IR + emit for TopK/BottomK/Threshold

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -99,7 +99,7 @@ Most of PromQL isn't lowered yet at the seed stage. Gating now would make every 
 
 ### TraceQL
 
-- **Spanset pipeline expressions** — some `PipelineElement` types return "not yet supported" when cerberus encounters them as a pipeline tail (`internal/traceql/lower.go:114`, `lower.go:186`). Second-stage metrics operators (`| topk`, `| bottomk`, `| > N`) are also unsupported (`internal/traceql/lower.go:83`).
+- **Spanset pipeline expressions** — some `PipelineElement` types return "not yet supported" when cerberus encounters them as a pipeline tail (`internal/traceql/lower.go:114`, `lower.go:186`). Second-stage metrics operators (`| topk`, `| bottomk`, `| > N`) have a landed chplan + chsql IR (`internal/chplan/metrics_second_stage.go`, `internal/chsql/metrics_second_stage.go`) but the TraceQL lowering layer still returns "not yet supported" (`internal/traceql/lower.go:83`) pending tsouza/tempo accessors on the upstream-unexported `TopKBottomK` / `MetricsFilter` fields.
 - **Multi-quantile `quantile_over_time`** — `quantile_over_time(0.5,0.95, ...)` with more than one quantile returns "not yet supported" (`internal/traceql/metrics_pipeline.go:108`).
 - **`?scope=` filter on `/api/v2/search/tags`** — not honoured; the handler returns all scopes (resource, span, intrinsic) regardless of the requested scope (`internal/api/tempo/search_tags.go:109`).
 - **Exemplars on metrics-pipeline queries** — the `Exemplars` field is always an empty array. The wire shape is correct but the handler does not yet populate exemplar data (`internal/api/tempo/metrics_query_range.go:36`).

--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -589,6 +589,10 @@ func isAggregateShape(plan chplan.Node) bool {
 		// TraceQL metrics-pipeline output: same SELECT-list shape as
 		// chplan.Aggregate (group-keys + Value alias).
 		return true
+	case *chplan.MetricsSecondStage:
+		// TraceQL second-stage transforms (topk / bottomk / threshold)
+		// preserve the inner aggregate's SELECT-list shape — recurse.
+		return isAggregateShape(v.Input)
 	case *chplan.Filter:
 		return isAggregateShape(v.Input)
 	case *chplan.Project:

--- a/internal/chplan/metrics_second_stage.go
+++ b/internal/chplan/metrics_second_stage.go
@@ -1,0 +1,133 @@
+package chplan
+
+// SecondStageOp is the TraceQL post-aggregate (a.k.a. "second-stage")
+// operator that produced a MetricsSecondStage node. Carries the source
+// operator symbolically so the emitter can pick the matching SQL wrap
+// (LIMIT BY for topk/bottomk, WHERE Value <op> N for threshold).
+//
+// The enum mirrors Tempo's `pkg/traceql.SecondStageOp` (OpTopK /
+// OpBottomK) plus an OpThreshold value covering the `| > N` / `| < N`
+// / `| >= N` / `| <= N` / `| == N` / `| != N` family that Tempo
+// represents as a `MetricsFilter`. Keeping the trio under one IR node
+// lets a single emitter handle the SQL wrap; the discriminator decides
+// which variant-specific fields are read.
+type SecondStageOp int
+
+const (
+	// SecondStageInvalid is the zero value; surfaces as an emitter error.
+	SecondStageInvalid SecondStageOp = iota
+	// SecondStageTopK corresponds to TraceQL `| topk(N)` — keep the N
+	// series with the highest value at each anchor (matrix) or globally
+	// (instant). Tempo's `processTopK` is a per-anchor top-K selection,
+	// which lowers cleanly to ClickHouse's `LIMIT N BY <anchor_col>`.
+	SecondStageTopK
+	// SecondStageBottomK corresponds to TraceQL `| bottomk(N)` — the
+	// per-anchor low-K dual of SecondStageTopK.
+	SecondStageBottomK
+	// SecondStageThreshold corresponds to TraceQL `| > N` / `| < N` /
+	// `| >= N` / `| <= N` / `| == N` / `| != N` — filter out data
+	// points whose Value does not satisfy the comparison.
+	SecondStageThreshold
+)
+
+// String returns the TraceQL-source name of the operator (`topk`,
+// `bottomk`, `threshold`). Used by chplan_print + error messages.
+func (o SecondStageOp) String() string {
+	switch o {
+	case SecondStageTopK:
+		return "topk"
+	case SecondStageBottomK:
+		return "bottomk"
+	case SecondStageThreshold:
+		return "threshold"
+	}
+	return "invalid"
+}
+
+// MetricsSecondStage applies a post-aggregate transform — topk(N) /
+// bottomk(N) / threshold(value <op> N) — to the row-shape output of a
+// metrics aggregation. Sits above a `MetricsAggregate` (instant path)
+// or a `RangeWindow` wrapping a MetricsAggregate (matrix path); the
+// emitter wraps the inner SQL with the variant-specific clause:
+//
+//   - SecondStageTopK / SecondStageBottomK: `ORDER BY <ValueAlias>
+//     <DESC|ASC> LIMIT K [BY <PartitionBy>...]`. The PartitionBy slot
+//     is the anchor column for matrix queries (`anchor_ts`); empty for
+//     instant queries. ClickHouse's `LIMIT N BY <col>` keeps N rows
+//     per distinct partition value — for matrix that means N series
+//     per anchor, matching Tempo's `processTopK` per-anchor selection
+//     (see engine_metrics.go: processTopK loops timestamps and picks
+//     the top-K series at each).
+//   - SecondStageThreshold: `WHERE <ValueAlias> <ThresholdOp>
+//     <ThresholdValue>`. Filters individual data points whose Value
+//     does not satisfy the comparison; same SQL shape works for both
+//     instant and matrix inputs because the predicate is per-row.
+//
+// Chained second-stage transforms (`| topk(5) | > 10`) nest as separate
+// MetricsSecondStage nodes — the outermost is the rightmost in the
+// TraceQL source. Tempo's `ChainedSecondStage` walks elements in order,
+// so the bottom-up nesting of MetricsSecondStage matches.
+//
+// Fields:
+//
+//   - Input: the lowered subtree this transform applies to —
+//     `*MetricsAggregate` for instant, `*RangeWindow` (wrapping a
+//     `*MetricsAggregate`) for matrix, or another `*MetricsSecondStage`
+//     in the chained case.
+//   - Op: the source TraceQL operator (TopK / BottomK / Threshold).
+//   - K: the limit value for TopK / BottomK. Ignored for Threshold.
+//   - ThresholdOp: the comparison operator for Threshold (chplan.OpGt /
+//     OpGe / OpLt / OpLe / OpEq / OpNe). Ignored for TopK / BottomK.
+//   - ThresholdValue: the literal RHS for Threshold. Ignored for TopK /
+//     BottomK.
+//   - PartitionBy: the column names that partition the LIMIT N BY
+//     clause for TopK / BottomK. For matrix queries this is the anchor
+//     column (typically `["anchor_ts"]`) so the limit fires per
+//     timestamp bucket — matching Tempo's per-anchor top-K semantics.
+//     Empty for instant queries (the limit applies globally to the
+//     single row-per-series shape).
+//   - ValueAlias: the column name carrying the per-anchor value (the
+//     `ValueAlias` slot of the inner MetricsAggregate; "Value" in every
+//     current code path but kept configurable so the IR doesn't pin a
+//     magic string).
+type MetricsSecondStage struct {
+	Input          Node
+	Op             SecondStageOp
+	K              int64
+	ThresholdOp    BinaryOp
+	ThresholdValue float64
+	PartitionBy    []string
+	ValueAlias     string
+}
+
+func (*MetricsSecondStage) planNode() {}
+
+func (m *MetricsSecondStage) Children() []Node { return []Node{m.Input} }
+
+func (m *MetricsSecondStage) Equal(other Node) bool {
+	o, ok := other.(*MetricsSecondStage)
+	if !ok {
+		return false
+	}
+	if m.Op != o.Op || m.K != o.K || m.ValueAlias != o.ValueAlias {
+		return false
+	}
+	if m.ThresholdOp != o.ThresholdOp || m.ThresholdValue != o.ThresholdValue {
+		return false
+	}
+	if len(m.PartitionBy) != len(o.PartitionBy) {
+		return false
+	}
+	for i := range m.PartitionBy {
+		if m.PartitionBy[i] != o.PartitionBy[i] {
+			return false
+		}
+	}
+	if (m.Input == nil) != (o.Input == nil) {
+		return false
+	}
+	if m.Input == nil {
+		return true
+	}
+	return m.Input.Equal(o.Input)
+}

--- a/internal/chplan/metrics_second_stage_test.go
+++ b/internal/chplan/metrics_second_stage_test.go
@@ -1,0 +1,182 @@
+package chplan_test
+
+import (
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// TestMetricsSecondStageEqual exercises structural equality across the
+// node's fields — Op, K, ThresholdOp, ThresholdValue, PartitionBy,
+// ValueAlias, Input.
+func TestMetricsSecondStageEqual(t *testing.T) {
+	t.Parallel()
+
+	base := &chplan.MetricsSecondStage{
+		Input: &chplan.MetricsAggregate{
+			Op:         chplan.MetricsOpRate,
+			ValueAlias: "Value",
+			Inner:      &chplan.Scan{Table: "otel_traces"},
+		},
+		Op:          chplan.SecondStageTopK,
+		K:           5,
+		PartitionBy: []string{"anchor_ts"},
+		ValueAlias:  "Value",
+	}
+	same := &chplan.MetricsSecondStage{
+		Input: &chplan.MetricsAggregate{
+			Op:         chplan.MetricsOpRate,
+			ValueAlias: "Value",
+			Inner:      &chplan.Scan{Table: "otel_traces"},
+		},
+		Op:          chplan.SecondStageTopK,
+		K:           5,
+		PartitionBy: []string{"anchor_ts"},
+		ValueAlias:  "Value",
+	}
+	if !base.Equal(same) {
+		t.Fatalf("identical MetricsSecondStage trees should be Equal")
+	}
+
+	// Different Op.
+	diffOp := *same
+	diffOp.Op = chplan.SecondStageBottomK
+	if base.Equal(&diffOp) {
+		t.Errorf("different Op should not be Equal")
+	}
+
+	// Different K.
+	diffK := *same
+	diffK.K = 10
+	if base.Equal(&diffK) {
+		t.Errorf("different K should not be Equal")
+	}
+
+	// Different ValueAlias.
+	diffAlias := *same
+	diffAlias.ValueAlias = "other"
+	if base.Equal(&diffAlias) {
+		t.Errorf("different ValueAlias should not be Equal")
+	}
+
+	// Different PartitionBy length.
+	diffPartLen := *same
+	diffPartLen.PartitionBy = []string{"anchor_ts", "service"}
+	if base.Equal(&diffPartLen) {
+		t.Errorf("different PartitionBy length should not be Equal")
+	}
+
+	// Different PartitionBy content.
+	diffPartContent := *same
+	diffPartContent.PartitionBy = []string{"step"}
+	if base.Equal(&diffPartContent) {
+		t.Errorf("different PartitionBy content should not be Equal")
+	}
+
+	// Different Input.
+	diffInput := *same
+	diffInput.Input = &chplan.MetricsAggregate{
+		Op:         chplan.MetricsOpCountOverTime,
+		ValueAlias: "Value",
+		Inner:      &chplan.Scan{Table: "otel_traces"},
+	}
+	if base.Equal(&diffInput) {
+		t.Errorf("different Input should not be Equal")
+	}
+
+	// Threshold variant — different op + value.
+	threshold := &chplan.MetricsSecondStage{
+		Input: &chplan.MetricsAggregate{
+			Op:         chplan.MetricsOpRate,
+			ValueAlias: "Value",
+			Inner:      &chplan.Scan{Table: "otel_traces"},
+		},
+		Op:             chplan.SecondStageThreshold,
+		ThresholdOp:    chplan.OpGt,
+		ThresholdValue: 10,
+		ValueAlias:     "Value",
+	}
+	thresholdSame := *threshold
+	if !threshold.Equal(&thresholdSame) {
+		t.Errorf("identical Threshold trees should be Equal")
+	}
+	thresholdDiffOp := *threshold
+	thresholdDiffOp.ThresholdOp = chplan.OpLt
+	if threshold.Equal(&thresholdDiffOp) {
+		t.Errorf("different ThresholdOp should not be Equal")
+	}
+	thresholdDiffVal := *threshold
+	thresholdDiffVal.ThresholdValue = 20
+	if threshold.Equal(&thresholdDiffVal) {
+		t.Errorf("different ThresholdValue should not be Equal")
+	}
+
+	// Different node type.
+	scan := &chplan.Scan{Table: "otel_traces"}
+	if base.Equal(scan) {
+		t.Errorf("MetricsSecondStage.Equal of *Scan should be false")
+	}
+}
+
+// TestMetricsSecondStageChildren confirms Walk descends through Input.
+func TestMetricsSecondStageChildren(t *testing.T) {
+	t.Parallel()
+
+	inner := &chplan.MetricsAggregate{
+		Op:         chplan.MetricsOpRate,
+		ValueAlias: "Value",
+		Inner:      &chplan.Scan{Table: "otel_traces"},
+	}
+	ms := &chplan.MetricsSecondStage{
+		Input:      inner,
+		Op:         chplan.SecondStageTopK,
+		K:          5,
+		ValueAlias: "Value",
+	}
+	kids := ms.Children()
+	if len(kids) != 1 {
+		t.Fatalf("expected 1 child, got %d", len(kids))
+	}
+	if kids[0] != inner {
+		t.Errorf("Children[0] should be the Input MetricsAggregate, got %T", kids[0])
+	}
+
+	var visited []string
+	chplan.Walk(ms, func(n chplan.Node) bool {
+		switch n.(type) {
+		case *chplan.MetricsSecondStage:
+			visited = append(visited, "MetricsSecondStage")
+		case *chplan.MetricsAggregate:
+			visited = append(visited, "MetricsAggregate")
+		case *chplan.Scan:
+			visited = append(visited, "Scan")
+		}
+		return true
+	})
+	want := []string{"MetricsSecondStage", "MetricsAggregate", "Scan"}
+	if len(visited) != len(want) {
+		t.Fatalf("Walk visited %v, want %v", visited, want)
+	}
+	for i := range want {
+		if visited[i] != want[i] {
+			t.Errorf("Walk[%d] = %s, want %s", i, visited[i], want[i])
+		}
+	}
+}
+
+// TestSecondStageOpString round-trips the enum to its TraceQL-source name.
+func TestSecondStageOpString(t *testing.T) {
+	t.Parallel()
+
+	cases := map[chplan.SecondStageOp]string{
+		chplan.SecondStageInvalid:   "invalid",
+		chplan.SecondStageTopK:      "topk",
+		chplan.SecondStageBottomK:   "bottomk",
+		chplan.SecondStageThreshold: "threshold",
+	}
+	for op, want := range cases {
+		if got := op.String(); got != want {
+			t.Errorf("SecondStageOp(%d).String() = %q, want %q", op, got, want)
+		}
+	}
+}

--- a/internal/chplan/walk_invariants_test.go
+++ b/internal/chplan/walk_invariants_test.go
@@ -174,6 +174,20 @@ func TestMetricsHistogramOverTime_Walk_VisitsInner(t *testing.T) {
 	assertSentinels(t, visitScans(root), []string{"mhot_inner"})
 }
 
+func TestMetricsSecondStage_Walk_VisitsInput(t *testing.T) {
+	t.Parallel()
+	root := &chplan.MetricsSecondStage{
+		Input: &chplan.MetricsAggregate{
+			Op:    chplan.MetricsOpRate,
+			Inner: &chplan.Scan{Table: "mss_input"},
+		},
+		Op:         chplan.SecondStageTopK,
+		K:          5,
+		ValueAlias: "Value",
+	}
+	assertSentinels(t, visitScans(root), []string{"mss_input"})
+}
+
 func TestSetOperation_Walk_VisitsBothSides(t *testing.T) {
 	t.Parallel()
 	root := &chplan.SetOperation{
@@ -415,6 +429,21 @@ func TestChildren_MetricsHistogramOverTimeReturnsExactlyInner(t *testing.T) {
 	kids := m.Children()
 	if len(kids) != 1 || kids[0] != inner {
 		t.Errorf("MetricsHistogramOverTime.Children() should return [Inner], got %v", kids)
+	}
+}
+
+func TestChildren_MetricsSecondStageReturnsExactlyInput(t *testing.T) {
+	t.Parallel()
+	input := &chplan.Scan{Table: "t"}
+	m := &chplan.MetricsSecondStage{
+		Input:      input,
+		Op:         chplan.SecondStageTopK,
+		K:          3,
+		ValueAlias: "Value",
+	}
+	kids := m.Children()
+	if len(kids) != 1 || kids[0] != input {
+		t.Errorf("MetricsSecondStage.Children() should return [Input], got %v", kids)
 	}
 }
 

--- a/internal/chsql/emit.go
+++ b/internal/chsql/emit.go
@@ -76,6 +76,8 @@ func (e *emitter) emitNode(n chplan.Node) error {
 		return e.emitAggregate(v)
 	case *chplan.MetricsAggregate:
 		return e.emitMetricsAggregate(v)
+	case *chplan.MetricsSecondStage:
+		return e.emitMetricsSecondStage(v)
 	case *chplan.MetricsHistogramOverTime:
 		return e.emitMetricsHistogramOverTime(v)
 	case *chplan.RangeWindow:

--- a/internal/chsql/emit_negatives_test.go
+++ b/internal/chsql/emit_negatives_test.go
@@ -109,6 +109,93 @@ func TestEmit_RangeWindowUnknownFunc(t *testing.T) {
 	}
 }
 
+// TestEmit_MetricsSecondStage_Errors — MetricsSecondStage rejects
+// invalid shapes loud rather than silently producing degenerate SQL:
+//
+//   - Nil Input → ErrUnsupported (Input is required; no parent to
+//     project from).
+//   - Empty ValueAlias → ErrUnsupported (no column to sort or filter).
+//   - Topk with K=0 → ErrUnsupported (LIMIT 0 disables the second-stage
+//     intent; TraceQL's parser already rejects this, so it's a lowering
+//     bug if it reaches the emitter).
+//   - Threshold with an unsupported op (e.g. OpAnd) → ErrUnsupported.
+//   - Unknown SecondStageOp (zero value SecondStageInvalid) →
+//     ErrUnsupported.
+func TestEmit_MetricsSecondStage_Errors(t *testing.T) {
+	t.Parallel()
+
+	baseInput := func() chplan.Node {
+		return &chplan.MetricsAggregate{
+			Op:         chplan.MetricsOpRate,
+			ValueAlias: "Value",
+			Inner:      &chplan.Scan{Table: "otel_traces"},
+		}
+	}
+
+	cases := []struct {
+		name string
+		ms   *chplan.MetricsSecondStage
+	}{
+		{
+			"nil Input",
+			&chplan.MetricsSecondStage{
+				Input:      nil,
+				Op:         chplan.SecondStageTopK,
+				K:          5,
+				ValueAlias: "Value",
+			},
+		},
+		{
+			"empty ValueAlias",
+			&chplan.MetricsSecondStage{
+				Input:      baseInput(),
+				Op:         chplan.SecondStageTopK,
+				K:          5,
+				ValueAlias: "",
+			},
+		},
+		{
+			"topk with K=0",
+			&chplan.MetricsSecondStage{
+				Input:      baseInput(),
+				Op:         chplan.SecondStageTopK,
+				K:          0,
+				ValueAlias: "Value",
+			},
+		},
+		{
+			"threshold with non-comparison op",
+			&chplan.MetricsSecondStage{
+				Input:          baseInput(),
+				Op:             chplan.SecondStageThreshold,
+				ThresholdOp:    chplan.OpAnd,
+				ThresholdValue: 10,
+				ValueAlias:     "Value",
+			},
+		},
+		{
+			"SecondStageInvalid op",
+			&chplan.MetricsSecondStage{
+				Input:      baseInput(),
+				Op:         chplan.SecondStageInvalid,
+				ValueAlias: "Value",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, _, err := chsql.Emit(context.Background(), tc.ms)
+			if err == nil {
+				t.Fatalf("Emit(%s) returned nil error", tc.name)
+			}
+			if !errors.Is(err, chsql.ErrUnsupported) {
+				t.Errorf("expected wrapped ErrUnsupported; got %v", err)
+			}
+		})
+	}
+}
+
 // TestEmit_StructuralJoinMissingColumns — StructuralJoin needs
 // TraceIDColumn / SpanIDColumn / ParentSpanIDColumn set; emit must
 // reject early.

--- a/internal/chsql/emit_test.go
+++ b/internal/chsql/emit_test.go
@@ -462,6 +462,96 @@ var plans = map[string]chplan.Node{
 		Inner:      &chplan.Scan{Table: "otel_traces"},
 	},
 
+	// MetricsSecondStage wraps a MetricsAggregate (instant) — TraceQL's
+	// `| topk(5)` / `| bottomk(3)` / `| > 10` shape applied to the
+	// row-per-series output of a metrics aggregator. The inner aggregate
+	// uses a bare `count(1) AS Value` (no group-by) so the fixture pins
+	// just the second-stage wrap; group-by variants get coverage from
+	// the chplan TXTAR fixtures + the future traceql lowerings.
+	"metrics_second_stage_topk_instant": &chplan.MetricsSecondStage{
+		Input: &chplan.MetricsAggregate{
+			Op:         chplan.MetricsOpRate,
+			ValueAlias: "Value",
+			Inner:      &chplan.Scan{Table: "otel_traces"},
+		},
+		Op:         chplan.SecondStageTopK,
+		K:          5,
+		ValueAlias: "Value",
+	},
+	"metrics_second_stage_bottomk_instant": &chplan.MetricsSecondStage{
+		Input: &chplan.MetricsAggregate{
+			Op:         chplan.MetricsOpRate,
+			ValueAlias: "Value",
+			Inner:      &chplan.Scan{Table: "otel_traces"},
+		},
+		Op:         chplan.SecondStageBottomK,
+		K:          3,
+		ValueAlias: "Value",
+	},
+	"metrics_second_stage_threshold_gt": &chplan.MetricsSecondStage{
+		Input: &chplan.MetricsAggregate{
+			Op:         chplan.MetricsOpRate,
+			ValueAlias: "Value",
+			Inner:      &chplan.Scan{Table: "otel_traces"},
+		},
+		Op:             chplan.SecondStageThreshold,
+		ThresholdOp:    chplan.OpGt,
+		ThresholdValue: 10,
+		ValueAlias:     "Value",
+	},
+	"metrics_second_stage_threshold_lt": &chplan.MetricsSecondStage{
+		Input: &chplan.MetricsAggregate{
+			Op:         chplan.MetricsOpSumOverTime,
+			Attr:       &chplan.ColumnRef{Name: "Duration"},
+			ValueAlias: "Value",
+			Inner:      &chplan.Scan{Table: "otel_traces"},
+		},
+		Op:             chplan.SecondStageThreshold,
+		ThresholdOp:    chplan.OpLt,
+		ThresholdValue: 0.5,
+		ValueAlias:     "Value",
+	},
+	// MetricsSecondStage wrapping a RangeWindow over MetricsAggregate —
+	// the matrix shape. PartitionBy=["anchor_ts"] so `LIMIT K BY
+	// anchor_ts` keeps K series per timestamp bucket (matches Tempo's
+	// per-anchor processTopK semantics).
+	"metrics_second_stage_topk_matrix": &chplan.MetricsSecondStage{
+		Input: &chplan.RangeWindow{
+			Input: &chplan.MetricsAggregate{
+				Op:             chplan.MetricsOpRate,
+				GroupBy:        []chplan.Expr{&chplan.ColumnRef{Name: "ServiceName"}},
+				GroupByAliases: []string{"service"},
+				ValueAlias:     "Value",
+				Inner:          &chplan.Scan{Table: "otel_traces"},
+			},
+			Step:            time.Minute,
+			OuterRange:      5 * time.Minute,
+			TimestampColumn: "Timestamp",
+		},
+		Op:          chplan.SecondStageTopK,
+		K:           5,
+		PartitionBy: []string{"anchor_ts"},
+		ValueAlias:  "Value",
+	},
+	// Chained second-stage: `| topk(5) | > 10` nests as an outer
+	// Threshold wrapping an inner TopK.
+	"metrics_second_stage_chained_topk_threshold": &chplan.MetricsSecondStage{
+		Input: &chplan.MetricsSecondStage{
+			Input: &chplan.MetricsAggregate{
+				Op:         chplan.MetricsOpRate,
+				ValueAlias: "Value",
+				Inner:      &chplan.Scan{Table: "otel_traces"},
+			},
+			Op:         chplan.SecondStageTopK,
+			K:          5,
+			ValueAlias: "Value",
+		},
+		Op:             chplan.SecondStageThreshold,
+		ThresholdOp:    chplan.OpGt,
+		ThresholdValue: 10,
+		ValueAlias:     "Value",
+	},
+
 	// RangeWindow wrapping MetricsAggregate — the matrix shape used
 	// by TraceQL's /api/metrics/query_range handler. Each per-span row
 	// is fanned across the N evaluation anchors via arrayJoin(range())

--- a/internal/chsql/metrics_second_stage.go
+++ b/internal/chsql/metrics_second_stage.go
@@ -1,0 +1,122 @@
+package chsql
+
+import (
+	"fmt"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// emitMetricsSecondStage renders a chplan.MetricsSecondStage as a
+// subquery-wrapping SELECT over the lowered metrics aggregate's row
+// shape. The wrap depends on m.Op:
+//
+//   - SecondStageTopK / SecondStageBottomK: `ORDER BY <ValueAlias>
+//     <DESC|ASC> LIMIT K [BY <PartitionBy...>]`. ClickHouse's
+//     `LIMIT N BY <col>` keeps N rows per distinct partition value —
+//     for matrix queries the partition is `anchor_ts` so the limit
+//     fires per-timestamp bucket (matching Tempo's `processTopK`
+//     per-anchor selection). For instant queries PartitionBy is empty
+//     and the limit applies globally (top-K series in the
+//     row-per-series shape).
+//   - SecondStageThreshold: `WHERE <ValueAlias> <ThresholdOp>
+//     <ThresholdValue>`. Same SQL for instant + matrix since the
+//     predicate is per-row.
+//
+// The Input subquery's column shape is preserved verbatim (outer
+// `SELECT *`) so downstream consumers (chDB roundtrip, handler
+// projection) see the same columns the inner MetricsAggregate emits.
+func (e *emitter) emitMetricsSecondStage(m *chplan.MetricsSecondStage) error {
+	if m.Input == nil {
+		return fmt.Errorf("%w: MetricsSecondStage.Input is nil", ErrUnsupported)
+	}
+	if m.ValueAlias == "" {
+		return fmt.Errorf("%w: MetricsSecondStage.ValueAlias unset", ErrUnsupported)
+	}
+
+	switch m.Op {
+	case chplan.SecondStageTopK, chplan.SecondStageBottomK:
+		return e.emitMetricsSecondStageTopK(m)
+	case chplan.SecondStageThreshold:
+		return e.emitMetricsSecondStageThreshold(m)
+	}
+	return fmt.Errorf("%w: MetricsSecondStage op %s", ErrUnsupported, m.Op)
+}
+
+// emitMetricsSecondStageTopK renders the topk/bottomk wrap:
+//
+//	SELECT * FROM (<inner>) ORDER BY <ValueAlias> <DESC|ASC>
+//	  LIMIT <K> [BY <PartitionBy_1>, <PartitionBy_2>, ...]
+//
+// K <= 0 is rejected — TraceQL's parser validates `limit > 0` so the
+// only path to a non-positive K is a programmer error in the lowering
+// layer; surfacing it loud avoids an unbounded LIMIT that silently
+// disables the second-stage filter.
+func (e *emitter) emitMetricsSecondStageTopK(m *chplan.MetricsSecondStage) error {
+	if m.K <= 0 {
+		return fmt.Errorf("%w: MetricsSecondStage %s with non-positive K=%d", ErrUnsupported, m.Op, m.K)
+	}
+
+	sub, err := e.subqueryFrag(m.Input)
+	if err != nil {
+		return err
+	}
+
+	desc := m.Op == chplan.SecondStageTopK
+	alias := m.ValueAlias
+	sb := NewQuery().From(sub).
+		OrderBy(func(b *Builder) { b.Ident(alias) }, desc).
+		Limit(m.K)
+	if len(m.PartitionBy) > 0 {
+		parts := make([]Frag, 0, len(m.PartitionBy))
+		for _, p := range m.PartitionBy {
+			col := p
+			parts = append(parts, func(b *Builder) { b.Ident(col) })
+		}
+		sb.LimitBy(parts...)
+	}
+	e.emitSelect(sb)
+	return nil
+}
+
+// emitMetricsSecondStageThreshold renders the threshold wrap:
+//
+//	SELECT * FROM (<inner>) WHERE <ValueAlias> <Op> <Value>
+//
+// The threshold predicate flows through Builder.Expr as a
+// chplan.Binary{ValueAlias <Op> LitFloat(<Value>)} so the SQL shape
+// matches the rest of the emitter's comparison rendering (parenthesis
+// rules, parameter binding) without duplicating the operator table.
+func (e *emitter) emitMetricsSecondStageThreshold(m *chplan.MetricsSecondStage) error {
+	if !isThresholdOp(m.ThresholdOp) {
+		return fmt.Errorf("%w: MetricsSecondStage threshold op %s not supported", ErrUnsupported, m.ThresholdOp)
+	}
+
+	sub, err := e.subqueryFrag(m.Input)
+	if err != nil {
+		return err
+	}
+
+	pred := &chplan.Binary{
+		Op:    m.ThresholdOp,
+		Left:  &chplan.ColumnRef{Name: m.ValueAlias},
+		Right: &chplan.LitFloat{V: m.ThresholdValue},
+	}
+	if err := (&Builder{}).Expr(pred); err != nil {
+		return err
+	}
+	sb := NewQuery().From(sub).Where(func(b *Builder) { _ = b.Expr(pred) })
+	e.emitSelect(sb)
+	return nil
+}
+
+// isThresholdOp reports whether op is one of the six comparison
+// operators TraceQL's `MetricsFilter.validate()` accepts (>, >=, <,
+// <=, =, !=). All other chplan.BinaryOp values surface as a clean
+// emitter error from emitMetricsSecondStageThreshold.
+func isThresholdOp(op chplan.BinaryOp) bool {
+	switch op {
+	case chplan.OpGt, chplan.OpGe, chplan.OpLt, chplan.OpLe, chplan.OpEq, chplan.OpNe:
+		return true
+	}
+	return false
+}

--- a/internal/traceql/lower.go
+++ b/internal/traceql/lower.go
@@ -80,7 +80,17 @@ func lowerRoot(expr *traceql.RootExpr, s schema.Traces) (chplan.Node, error) {
 		}
 	}
 	if expr.MetricsSecondStage != nil {
-		return nil, fmt.Errorf("traceql: metrics second-stage operators (`| topk`, `| bottomk`, `| > N`) are not yet supported")
+		// chplan.MetricsSecondStage + chsql.emitMetricsSecondStage now
+		// carry the IR + SQL for `| topk(N)` / `| bottomk(N)` / `| > N`
+		// (see internal/chplan/metrics_second_stage.go +
+		// internal/chsql/metrics_second_stage.go). Wiring the lowering
+		// here is blocked on tsouza/tempo:cerberus-accessors exposing
+		// accessors on the upstream-unexported TopKBottomK.{op,limit}
+		// and MetricsFilter.{op,value} fields (mirrors the
+		// MetricsAggregate accessors added for #143). The fork bump
+		// lands as a follow-up; until then the IR + emitter foundation
+		// is callable directly from chplan-shape tests.
+		return nil, fmt.Errorf("traceql: metrics second-stage operators (`| topk`, `| bottomk`, `| > N`) are not yet supported (chplan + chsql IR landed; lowering wiring blocked on tsouza/tempo SecondStageElement accessors)")
 	}
 	return plan, nil
 }

--- a/internal/traceql/metrics_pipeline_test.go
+++ b/internal/traceql/metrics_pipeline_test.go
@@ -191,6 +191,29 @@ func TestLowerMetricsPipelineUnsupported(t *testing.T) {
 			query:      `{} | quantile_over_time(duration, 0.5, 0.9, 0.99)`,
 			wantSubstr: "multi-quantile",
 		},
+		{
+			// Second-stage topk/bottomk/threshold land in two phases:
+			// the chplan+chsql foundation is in place (see
+			// chplan/metrics_second_stage.go,
+			// chsql/metrics_second_stage.go) but the traceql lowering
+			// is blocked on tsouza/tempo accessors for the
+			// unexported TopKBottomK / MetricsFilter fields. Until
+			// that fork bump lands, the lowering returns a clean
+			// "not yet supported" with a pointer to the foundation.
+			name:       "second_stage_topk_deferred",
+			query:      `{} | rate() | topk(5)`,
+			wantSubstr: "second-stage",
+		},
+		{
+			name:       "second_stage_bottomk_deferred",
+			query:      `{} | rate() | bottomk(3)`,
+			wantSubstr: "second-stage",
+		},
+		{
+			name:       "second_stage_threshold_deferred",
+			query:      `{} | rate() | > 10`,
+			wantSubstr: "second-stage",
+		},
 	}
 
 	for _, tc := range cases {

--- a/test/spec/chplan_print.go
+++ b/test/spec/chplan_print.go
@@ -215,6 +215,25 @@ func printNode(b *strings.Builder, n chplan.Node, depth int) {
 		if v.Inner != nil {
 			printNode(b, v.Inner, depth+1)
 		}
+	case *chplan.MetricsSecondStage:
+		fmt.Fprintf(b, "%sMetricsSecondStage op=%s", indent, v.Op)
+		switch v.Op {
+		case chplan.SecondStageTopK, chplan.SecondStageBottomK:
+			fmt.Fprintf(b, " k=%d", v.K)
+		case chplan.SecondStageThreshold:
+			fmt.Fprintf(b, " threshold=(%s %s)", v.ThresholdOp,
+				strconv.FormatFloat(v.ThresholdValue, 'g', -1, 64))
+		}
+		if len(v.PartitionBy) > 0 {
+			fmt.Fprintf(b, " partitionBy=[%s]", strings.Join(v.PartitionBy, ", "))
+		}
+		if v.ValueAlias != "" {
+			fmt.Fprintf(b, " valueAlias=%s", v.ValueAlias)
+		}
+		b.WriteString("\n")
+		if v.Input != nil {
+			printNode(b, v.Input, depth+1)
+		}
 	case *chplan.MetricsHistogramOverTime:
 		gb := make([]string, len(v.GroupBy))
 		for i, e := range v.GroupBy {

--- a/test/spec/chsql/metrics_second_stage_bottomk_instant.txtar
+++ b/test/spec/chsql/metrics_second_stage_bottomk_instant.txtar
@@ -1,0 +1,8 @@
+-- args --
+[0] int64 = 1
+-- sql --
+SELECT * FROM (SELECT toFloat64(count(?)) AS `Value` FROM (SELECT * FROM `otel_traces`)) ORDER BY `Value` LIMIT 3
+-- chplan --
+MetricsSecondStage op=bottomk k=3 valueAlias=Value
+  MetricsAggregate op=rate valueAlias=Value
+    Scan(otel_traces)

--- a/test/spec/chsql/metrics_second_stage_chained_topk_threshold.txtar
+++ b/test/spec/chsql/metrics_second_stage_chained_topk_threshold.txtar
@@ -1,0 +1,10 @@
+-- args --
+[0] int64 = 1
+[1] float64 = 10
+-- sql --
+SELECT * FROM (SELECT * FROM (SELECT toFloat64(count(?)) AS `Value` FROM (SELECT * FROM `otel_traces`)) ORDER BY `Value` DESC LIMIT 5) WHERE (`Value` > ?)
+-- chplan --
+MetricsSecondStage op=threshold threshold=(> 10) valueAlias=Value
+  MetricsSecondStage op=topk k=5 valueAlias=Value
+    MetricsAggregate op=rate valueAlias=Value
+      Scan(otel_traces)

--- a/test/spec/chsql/metrics_second_stage_threshold_gt.txtar
+++ b/test/spec/chsql/metrics_second_stage_threshold_gt.txtar
@@ -1,0 +1,9 @@
+-- args --
+[0] int64 = 1
+[1] float64 = 10
+-- sql --
+SELECT * FROM (SELECT toFloat64(count(?)) AS `Value` FROM (SELECT * FROM `otel_traces`)) WHERE (`Value` > ?)
+-- chplan --
+MetricsSecondStage op=threshold threshold=(> 10) valueAlias=Value
+  MetricsAggregate op=rate valueAlias=Value
+    Scan(otel_traces)

--- a/test/spec/chsql/metrics_second_stage_threshold_lt.txtar
+++ b/test/spec/chsql/metrics_second_stage_threshold_lt.txtar
@@ -1,0 +1,8 @@
+-- args --
+[0] float64 = 0.5
+-- sql --
+SELECT * FROM (SELECT sum(`Duration`) AS `Value` FROM (SELECT * FROM `otel_traces`)) WHERE (`Value` < ?)
+-- chplan --
+MetricsSecondStage op=threshold threshold=(< 0.5) valueAlias=Value
+  MetricsAggregate op=sum_over_time attr=Duration valueAlias=Value
+    Scan(otel_traces)

--- a/test/spec/chsql/metrics_second_stage_topk_instant.txtar
+++ b/test/spec/chsql/metrics_second_stage_topk_instant.txtar
@@ -1,0 +1,8 @@
+-- args --
+[0] int64 = 1
+-- sql --
+SELECT * FROM (SELECT toFloat64(count(?)) AS `Value` FROM (SELECT * FROM `otel_traces`)) ORDER BY `Value` DESC LIMIT 5
+-- chplan --
+MetricsSecondStage op=topk k=5 valueAlias=Value
+  MetricsAggregate op=rate valueAlias=Value
+    Scan(otel_traces)

--- a/test/spec/chsql/metrics_second_stage_topk_matrix.txtar
+++ b/test/spec/chsql/metrics_second_stage_topk_matrix.txtar
@@ -1,0 +1,9 @@
+-- args --
+[0] int64 = 1
+-- sql --
+SELECT * FROM (SELECT `service`, `anchor_ts`, toFloat64(count(?)) / 60 AS `Value` FROM (SELECT `ServiceName` AS `service`, `Timestamp` AS `ts`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) WHERE ts >= anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts GROUP BY `service`, `anchor_ts`) ORDER BY `Value` DESC LIMIT 5 BY `anchor_ts`
+-- chplan --
+MetricsSecondStage op=topk k=5 partitionBy=[anchor_ts] valueAlias=Value
+  RangeWindow func= range=0s step=1m0s outerRange=5m0s ts=Timestamp
+    MetricsAggregate op=rate groupBy=[ServiceName AS service] valueAlias=Value
+      Scan(otel_traces)


### PR DESCRIPTION
## Summary — Phase A foundation only

Lands the chplan + chsql foundation for TraceQL second-stage metrics operators (`| topk`, `| bottomk`, `| > N`). The TraceQL lowering wiring is **deferred to a Phase B follow-up** that requires new accessors on the `tsouza/tempo` fork (see "Deferred" below).

- **`internal/chplan/metrics_second_stage.go`** — new `MetricsSecondStage` IR node with `SecondStageOp` enum (TopK / BottomK / Threshold), variant fields (`K`, `ThresholdOp`, `ThresholdValue`), `PartitionBy` for matrix anchor partitioning, plus `Equal` / `Children` / `planNode` invariants.
- **`internal/chsql/metrics_second_stage.go`** — `emitMetricsSecondStage` dispatcher:
  - TopK / BottomK: `ORDER BY <ValueAlias> [DESC] LIMIT K [BY <PartitionBy>]`
  - Threshold: `WHERE <ValueAlias> <op> <value>` (via Binary expression)
- **`internal/chsql/emit.go`** — dispatch case wired in.
- **6 chsql TXTAR golden fixtures** in `test/spec/chsql/metrics_second_stage_*` covering instant / matrix / threshold / chained shapes.
- **`test/spec/chplan_print.go`** — pretty-print support for the new node.
- **Tests**: `internal/chplan/metrics_second_stage_test.go` (Equal, Walk, Children, String enum); `walk_invariants_test.go` additions; `emit_negatives_test.go` for nil / missing / invalid op cases; `traceql/metrics_pipeline_test.go` deferred-error cases.
- **`internal/api/tempo/handler.go::isAggregateShape`** recurses through `MetricsSecondStage`.
- **`docs/compatibility.md` line 102** — updated to reflect partial progress.

## Why

Pre-GA Maximal-GA. `internal/traceql/lower.go:83` rejects second-stage metrics operators today. This PR lands the IR + emit so the next PR (Phase B) only needs to add the upstream-type-to-IR lowering once the fork accessors land.

## Deferred — Phase B (requires fork bump)

`internal/traceql/lower.go:83` still returns "not yet supported" because Tempo upstream exports `TopKBottomK` / `MetricsFilter` / `ChainedSecondStage` **types** but **not their fields** (`op`, `limit`, `value`). The repo's forbidigo lint rule bans `unsafe.Pointer` / `reflect.FieldByName` shims in `internal/traceql/`. Phase B requires:

1. `tsouza/tempo:cerberus-accessors` — add `Op()` / `Limit()` / `Value()` / `Elements()` accessor methods.
2. Cut a new tag (e.g. `v0.0.3-cerberus-accessors`) — this also unblocks PR #430 (the in-flight branch is stuck on a `v0.0.2` checksum mismatch from a force-pushed tag).
3. Bump `go.mod` here, wire `lower.go:83` to use the accessors, and add `test/spec/traceql/metrics_topk.txtar` + `metrics_bottomk.txtar` + `metrics_threshold.txtar`.

## Test plan

- [ ] \`check\` (chplan + chsql + traceql unit tests) passes.
- [ ] \`lint\` passes.
- [ ] The 6 new chsql TXTAR fixtures are pinned by hand — if they drift on CI, regenerate via `GOLDEN_UPDATE=1 just test-spec`.

## Notes

- The matrix `LIMIT K BY anchor_ts` SQL shape matches Tempo's `processTopK` per-anchor top-K semantics (per-timestamp ranking, not whole-series ranking).