### PR TITLE
feat(api/tempo): use real hex TraceID in /api/search responses

### DIFF
--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -354,6 +354,10 @@ func (h *Handler) lowerTraceByID(traceID string) (chplan.Node, error) {
 // The keys are namespaced under `__cerberus_*` so they cannot collide
 // with real OTel attribute keys (which by spec are reserved namespaces
 // like `service.*`, `http.*`, etc., never `__*`).
+//
+// searchKeyTraceID reuses the same `__cerberus_traceID` slot on the
+// /api/search path so toTraceSummaries can group spans by real TraceID
+// rather than synthesising a key from (SpanName + Timestamp).
 const (
 	traceByIDKeyTraceID       = "__cerberus_traceID"
 	traceByIDKeySpanID        = "__cerberus_spanID"
@@ -361,6 +365,12 @@ const (
 	traceByIDKeySpanKind      = "__cerberus_spanKind"
 	traceByIDKeyStatusCode    = "__cerberus_statusCode"
 	traceByIDKeySpanAttrsJSON = "__cerberus_spanAttrsJSON"
+
+	// searchKeyTraceID is the reserved Labels key that carries the
+	// hex-encoded TraceId on /api/search responses. Same constant value
+	// as traceByIDKeyTraceID — the two paths never overlap (search keeps
+	// the slot for the trace-id, trace-by-id keeps it for the same).
+	searchKeyTraceID = traceByIDKeyTraceID
 )
 
 // wrapWithSampleProjection adds a Project on top of plan that emits
@@ -456,10 +466,26 @@ func wrapWithSampleProjection(plan chplan.Node, s schema.Traces, meta engine.Met
 // columns. Used for /api/search and the recursive structural-join
 // (`>>` / `<<`) wrap path, where the inner SELECT exposes R's columns
 // unqualified to the outer scope.
+//
+// The Attributes map merges ResourceAttributes with a single
+// reserved-key entry (`__cerberus_traceID` → hex TraceId) so
+// toTraceSummaries can group spans into per-trace summaries by real
+// TraceID rather than synthesising a key from (SpanName + Timestamp).
+// Same mapConcat pattern as traceByIDProjections; the resource keys
+// (`service.*`, `k8s.*`, …) never collide with the `__cerberus_*`
+// namespace so no precedence surprises.
 func canonicalSampleProjections(s schema.Traces) []chplan.Projection {
+	traceIDMap := &chplan.FuncCall{Name: "map", Args: []chplan.Expr{
+		&chplan.LitString{V: searchKeyTraceID},
+		&chplan.ColumnRef{Name: s.TraceIDColumn},
+	}}
+	mergedAttrs := &chplan.FuncCall{Name: "mapConcat", Args: []chplan.Expr{
+		&chplan.ColumnRef{Name: s.ResourceAttributesColumn},
+		traceIDMap,
+	}}
 	return []chplan.Projection{
 		{Expr: &chplan.ColumnRef{Name: s.SpanNameColumn}, Alias: "MetricName"},
-		{Expr: &chplan.ColumnRef{Name: s.ResourceAttributesColumn}, Alias: "Attributes"},
+		{Expr: mergedAttrs, Alias: "Attributes"},
 		{Expr: &chplan.ColumnRef{Name: s.TimestampColumn}, Alias: "TimeUnix"},
 		// Duration is Int64 (nanoseconds) in OTel-CH; chclient.Sample.Value
 		// is float64 and clickhouse-go's Scan refuses Int64→float64 without
@@ -477,9 +503,17 @@ func canonicalSampleProjections(s schema.Traces) []chplan.Projection {
 // produces `Unknown expression identifier 'SpanName'` because L and R
 // share names).
 func rQualifiedSampleProjections(s schema.Traces) []chplan.Projection {
+	traceIDMap := &chplan.FuncCall{Name: "map", Args: []chplan.Expr{
+		&chplan.LitString{V: searchKeyTraceID},
+		&chplan.ColumnRef{Qualifier: "R", Name: s.TraceIDColumn},
+	}}
+	mergedAttrs := &chplan.FuncCall{Name: "mapConcat", Args: []chplan.Expr{
+		&chplan.ColumnRef{Qualifier: "R", Name: s.ResourceAttributesColumn},
+		traceIDMap,
+	}}
 	return []chplan.Projection{
 		{Expr: &chplan.ColumnRef{Qualifier: "R", Name: s.SpanNameColumn}, Alias: "MetricName"},
-		{Expr: &chplan.ColumnRef{Qualifier: "R", Name: s.ResourceAttributesColumn}, Alias: "Attributes"},
+		{Expr: mergedAttrs, Alias: "Attributes"},
 		{Expr: &chplan.ColumnRef{Qualifier: "R", Name: s.TimestampColumn}, Alias: "TimeUnix"},
 		{Expr: &chplan.FuncCall{Name: "toFloat64", Args: []chplan.Expr{&chplan.ColumnRef{Qualifier: "R", Name: s.DurationColumn}}}, Alias: "Value"},
 	}
@@ -601,14 +635,25 @@ func isAggregateShape(plan chplan.Node) bool {
 
 // toTraceSummaries pivots samples into the per-trace summary shape
 // Tempo's /api/search returns. Each unique TraceID becomes one
-// summary; duration is the max span duration seen for that trace
-// (a coarse proxy until the per-trace aggregate plumbing lands).
+// summary; StartTimeUnixNano is the earliest span timestamp seen and
+// DurationMs is the max span duration (a coarse proxy until per-trace
+// aggregate plumbing lands).
 //
-// Note: chclient.Sample's MetricName carries SpanName here (per the
-// projection above) and Attributes carries ResourceAttributes; we
-// derive RootServiceName from Attributes['service.name'].
+// chclient.Sample's MetricName carries SpanName here (per the wrap
+// projection above) and Attributes carries ResourceAttributes plus a
+// reserved `__cerberus_traceID` entry (searchKeyTraceID); we use the
+// reserved entry as the grouping key so spans share a row when they
+// share a real trace, and derive RootServiceName from
+// Attributes['service.name']. The reserved entry is stripped from
+// the returned RootServiceName lookup since it's namespaced under
+// `__cerberus_*` and never collides with OTel-spec attribute keys.
+//
+// Defensive: samples missing the reserved key (older fixtures, stub
+// queriers in tests) fall back to (SpanName | Timestamp) so partial
+// data still surfaces a row rather than silently dropping.
 func toTraceSummaries(samples []chclient.Sample) []TraceSummary {
 	type acc struct {
+		traceID     string
 		serviceName string
 		traceName   string
 		startNS     int64
@@ -616,15 +661,17 @@ func toTraceSummaries(samples []chclient.Sample) []TraceSummary {
 	}
 	byTrace := map[string]*acc{}
 	for _, s := range samples {
-		// The TraceID lives in the row's labels under a synthetic key —
-		// for the search projection we don't pull it out (handler hits
-		// `/search/tags` defer); instead each unique sample is one span,
-		// and we use the MetricName + Timestamp to summarise. A future
-		// release can include TraceId in the projection if needed.
-		key := s.MetricName + "|" + s.Timestamp.Format("20060102150405.000000000")
+		traceID, hasID := s.Labels[searchKeyTraceID]
+		// Group key prefers the real TraceID so multi-span traces
+		// collapse into one row; fall back to the legacy synthetic
+		// shape only when the projection didn't supply it.
+		key := traceID
+		if !hasID || key == "" {
+			key = s.MetricName + "|" + s.Timestamp.Format("20060102150405.000000000")
+		}
 		a, ok := byTrace[key]
 		if !ok {
-			a = &acc{traceName: s.MetricName}
+			a = &acc{traceID: traceID, traceName: s.MetricName}
 			byTrace[key] = a
 		}
 		if svc, ok := s.Labels["service.name"]; ok {
@@ -640,8 +687,15 @@ func toTraceSummaries(samples []chclient.Sample) []TraceSummary {
 	}
 	out := make([]TraceSummary, 0, len(byTrace))
 	for k, a := range byTrace {
+		// Emit the real TraceID when the projection supplied one;
+		// otherwise surface the synthetic key (back-compat for stub
+		// queriers + older fixtures that never threaded it through).
+		tid := a.traceID
+		if tid == "" {
+			tid = k
+		}
 		out = append(out, TraceSummary{
-			TraceID:           k, // synthetic until we project TraceId
+			TraceID:           tid,
 			RootServiceName:   a.serviceName,
 			RootTraceName:     a.traceName,
 			StartTimeUnixNano: strconv.FormatInt(a.startNS, 10),

--- a/internal/api/tempo/handler_test.go
+++ b/internal/api/tempo/handler_test.go
@@ -128,13 +128,21 @@ func TestSearch_Empty(t *testing.T) {
 
 func TestSearch_Query(t *testing.T) {
 	t.Parallel()
+	// hex-TraceID smuggled through the wrap projection via the reserved
+	// __cerberus_traceID label key — toTraceSummaries reads it out so
+	// the response surfaces real per-trace identity (32 hex chars)
+	// rather than the legacy SpanName|Timestamp synthetic key.
+	const wantTraceID = "0123456789abcdef0123456789abcdef"
 	q := &stubQuerier{
 		samples: []chclient.Sample{
 			{
 				MetricName: "GET /api/users",
-				Labels:     map[string]string{"service.name": "frontend"},
-				Timestamp:  time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC),
-				Value:      150_000_000, // 150ms in nanoseconds
+				Labels: map[string]string{
+					"service.name":       "frontend",
+					"__cerberus_traceID": wantTraceID,
+				},
+				Timestamp: time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC),
+				Value:     150_000_000, // 150ms in nanoseconds
 			},
 		},
 	}
@@ -156,12 +164,113 @@ func TestSearch_Query(t *testing.T) {
 	if len(sr.Traces) != 1 {
 		t.Fatalf("expected 1 trace, got %d", len(sr.Traces))
 	}
+	if sr.Traces[0].TraceID != wantTraceID {
+		t.Errorf("TraceID: got %q, want %q (32 hex chars from the search projection)",
+			sr.Traces[0].TraceID, wantTraceID)
+	}
+	if len(sr.Traces[0].TraceID) != 32 {
+		t.Errorf("TraceID length: got %d, want 32 (hex-encoded 16-byte trace id)",
+			len(sr.Traces[0].TraceID))
+	}
+	if !isHexLower(sr.Traces[0].TraceID) {
+		t.Errorf("TraceID format: got %q, want lowercase hex", sr.Traces[0].TraceID)
+	}
 	if sr.Traces[0].RootServiceName != "frontend" {
 		t.Errorf("expected frontend service, got %q", sr.Traces[0].RootServiceName)
 	}
 	if sr.Traces[0].DurationMs != 150 {
 		t.Errorf("expected 150ms, got %d", sr.Traces[0].DurationMs)
 	}
+}
+
+// TestSearch_GroupsByTraceID asserts that multiple span rows sharing a
+// real TraceID collapse into a single per-trace summary; this is the
+// core behaviour change behind switching from the synthetic
+// (SpanName | Timestamp) key to the real hex(TraceId).
+func TestSearch_GroupsByTraceID(t *testing.T) {
+	t.Parallel()
+	const traceA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	const traceB = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	q := &stubQuerier{
+		samples: []chclient.Sample{
+			// Two spans on trace A — should collapse into one summary;
+			// DurationMs reflects the max span duration; StartTimeUnixNano
+			// the earliest span timestamp.
+			{
+				MetricName: "POST /api/orders",
+				Labels: map[string]string{
+					"service.name":       "checkout",
+					"__cerberus_traceID": traceA,
+				},
+				Timestamp: time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC),
+				Value:     200_000_000,
+			},
+			{
+				MetricName: "db.query",
+				Labels: map[string]string{
+					"service.name":       "checkout",
+					"__cerberus_traceID": traceA,
+				},
+				Timestamp: time.Date(2026, 5, 12, 10, 0, 1, 0, time.UTC),
+				Value:     50_000_000,
+			},
+			// One span on trace B — separate summary.
+			{
+				MetricName: "GET /healthz",
+				Labels: map[string]string{
+					"service.name":       "frontend",
+					"__cerberus_traceID": traceB,
+				},
+				Timestamp: time.Date(2026, 5, 12, 10, 0, 5, 0, time.UTC),
+				Value:     5_000_000,
+			},
+		},
+	}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/search?q=%7B%7D")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	var sr tempo.SearchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&sr); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(sr.Traces) != 2 {
+		t.Fatalf("expected 2 distinct traces (grouped by real TraceID), got %d", len(sr.Traces))
+	}
+	// Results sort ascending by TraceID.
+	if sr.Traces[0].TraceID != traceA {
+		t.Errorf("[0] TraceID: got %q, want %q", sr.Traces[0].TraceID, traceA)
+	}
+	if sr.Traces[1].TraceID != traceB {
+		t.Errorf("[1] TraceID: got %q, want %q", sr.Traces[1].TraceID, traceB)
+	}
+	// DurationMs is the max of {200, 50}ms = 200ms across trace A's two spans.
+	if sr.Traces[0].DurationMs != 200 {
+		t.Errorf("[0] DurationMs: got %d, want 200 (max across grouped spans)",
+			sr.Traces[0].DurationMs)
+	}
+}
+
+// isHexLower reports whether s is a non-empty lowercase hex string.
+// The OTel CH exporter writes TraceId via hex.EncodeToString, which
+// produces lowercase a-f digits.
+func isHexLower(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, c := range s {
+		switch {
+		case c >= '0' && c <= '9':
+		case c >= 'a' && c <= 'f':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 func TestTraceByID_NotFound(t *testing.T) {

--- a/test/spec/traceql/search_traceid.txtar
+++ b/test/spec/traceql/search_traceid.txtar
@@ -1,0 +1,29 @@
+-- query.traceql --
+{ resource.service.name = "frontend" } | select(span.http.method)
+-- sql --
+SELECT `TraceId`, `SpanId`, `Timestamp`, `SpanAttributes`[?] AS `http.method` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?))
+-- args --
+[0] string = "http.method"
+[1] string = "service.name"
+[2] string = "frontend"
+-- seed --
+CREATE TABLE otel_traces (
+    TraceId String,
+    SpanId String,
+    Timestamp DateTime64(9),
+    SpanAttributes Map(String, String),
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    ('0123456789abcdef0123456789abcdef', '0000000000000001', toDateTime64('2026-01-01 00:00:00', 9), map('http.method', 'GET'), map('service.name', 'frontend')),
+    ('fedcba9876543210fedcba9876543210', '0000000000000002', toDateTime64('2026-01-01 00:00:01', 9), map('http.method', 'POST'), map('service.name', 'frontend')),
+    ('aabbccddeeff00112233445566778899', '0000000000000003', toDateTime64('2026-01-01 00:00:02', 9), map('http.method', 'GET'), map('service.name', 'backend'));
+-- expected_rows --
+[
+  ["0123456789abcdef0123456789abcdef", "0000000000000001", "2026-01-01T00:00:00Z", "GET"],
+  ["fedcba9876543210fedcba9876543210", "0000000000000002", "2026-01-01T00:00:01Z", "POST"]
+]
+-- chplan --
+Project [TraceId, SpanId, Timestamp, SpanAttributes["http.method"] AS http.method]
+  Filter predicate=(ResourceAttributes["service.name"] = "frontend")
+    Scan(otel_traces)


### PR DESCRIPTION
## Summary

- Threads the real hex TraceId through the search wrap-projection via `mapConcat` under the reserved `__cerberus_traceID` Labels key (same pattern as `traceByIDProjections`).
- `toTraceSummaries` now groups by real TraceID and emits it on the response, with back-compat fallback to the synthetic `SpanName|Timestamp` key when the projection didn't supply one.
- Two handler tests (TraceID surfacing + multi-span grouping) plus new TXTAR fixture `test/spec/traceql/search_traceid.txtar`.

## Why

Pre-GA Maximal-GA: closes the last "synthetic value leaking to wire" placeholder identified in the codebase audit. `internal/api/tempo/handler.go:644` previously emitted `SpanName + "|" + Timestamp` as a fake TraceID, breaking trace identity for clients that click through from search to `/api/traces/{id}`.

## Scope

Tight per-file allowlist: `internal/api/tempo/handler.go`, `internal/api/tempo/handler_test.go`, `test/spec/traceql/search_traceid.txtar`. **210 insertions / 18 deletions.**

## Test plan

- [ ] \`check\` (handler unit tests + spec runner) passes.
- [ ] \`lint\` passes.
- [ ] \`tempo/compatibility\` nightly run shows search responses now contain hex TraceIDs.

## Follow-up — Phase 1.1b

`harness/tempo-compatibility/driver/differ.go` still canonicalises via `H(rootServiceName || rootTraceName)`. That workaround is now redundant (real TraceIDs match byte-for-byte across backends) but leaving it in place keeps the differ working invariant to TraceID realness. Separate cleanup PR.

## Implementation notes

- `searchKeyTraceID` is defined as `= traceByIDKeyTraceID` (same constant value, `__cerberus_traceID`) — the search and trace-by-id paths never overlap (different wrap-projection branches), so reusing the slot keeps `splitTraceByIDLabels` working unchanged for both.
- Both `canonicalSampleProjections` and `rQualifiedSampleProjections` were updated symmetrically so structural-join \`>>\`/\`<<\` (canonical, unqualified) and \`>\`/\`<\`/\`~\` (R-qualified) flow real TraceID too.
- The aggregate branch in `wrapWithSampleProjection` was intentionally not touched — it synthesises an empty Attributes map (no ResourceAttributes in scope) and is reached only by metrics-shaped pipelines that don't return per-trace identity.