### PR TITLE
feat(logql): implement detected_level synthesized label

### DIFF
--- a/harness/loki-compatibility/cerberus-test-queries.yml
+++ b/harness/loki-compatibility/cerberus-test-queries.yml
@@ -53,7 +53,11 @@
 #   with line filter) entries were unskipped after the seed expansion added
 #   multi-label streams, structured metadata, and multi-format log lines.
 #   The remaining fast/ entries require LogQL features cerberus has
-#   deferred (detected_level filter, | json, | logfmt parser stages).
+#   deferred (| json, | logfmt parser stages). The synthesized
+#   `detected_level` label landed via internal/logql/detected_level.go
+#   and no longer drives any skips on its own — entries that still
+#   mention it are blocked by an unrelated feature (count_over_time
+#   ResourceAttributes 502, range-aggregation grouping, unwrap, …).
 #   The regression/ + exhaustive/ slices exercise LogQL features cerberus
 #   has explicitly deferred per docs/roadmap.md § RC2:
 #
@@ -95,22 +99,23 @@ should_skip:
     since: "2026-05-18"
     jira:  "docs/roadmap.md RC2 LogQL metric-queries / ResourceAttributes support"
 
-  # fast/ — entries still skipped require unimplemented LogQL features (detected_level filters, | json, | logfmt):
+  # fast/ — entries still skipped require unimplemented LogQL features
+  # (count_over_time / rate ResourceAttributes 502; `| json` / `| logfmt`
+  # parser stages). The `| detected_level=` synthesized filter itself
+  # landed via internal/logql/detected_level.go.
   - source: "fast/simple-metrics.yaml#Count with error/warn filter"
-    reason: "Requires `| detected_level=~\"error|warn\"` filter; cerberus does not yet support structured-metadata label filters in LogQL pipe expressions."
+    reason: "`sum(count_over_time(... | detected_level=~\"error|warn\" [...]))` — `detected_level` filter is supported, but the outer `count_over_time` still trips cerberus's ResourceAttributes 502 (see `Count over time` above)."
     since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6"
+    jira:  "docs/roadmap.md RC2 LogQL metric-queries / ResourceAttributes support"
   - source: "fast/simple-metrics.yaml#Rate with error/warn filter"
-    reason: "Requires `| detected_level=~\"error|warn\"` filter; cerberus does not yet support structured-metadata label filters in LogQL pipe expressions."
+    reason: "`sum(rate(... | detected_level=~\"error|warn\" [...]))` — same ResourceAttributes 502 as `Count over time`."
     since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6"
-  # fast/structured-metadata — requires detected_level filter support and/or parser stages.
-  - source: "fast/structured-metadata.yaml#Structured metadata error level filter"
-    reason: "Requires `| detected_level=\"error\"` structured-metadata filter; cerberus does not yet support structured-metadata label filters in LogQL pipe expressions. Seeder now writes detected_level."
-    since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6"
+    jira:  "docs/roadmap.md RC2 LogQL metric-queries / ResourceAttributes support"
+  # fast/structured-metadata — remaining entries depend on parser stages
+  # (`| json` / `| logfmt`); the pure `| detected_level="..."` filter
+  # landed via internal/logql/detected_level.go.
   - source: "fast/structured-metadata.yaml#Logfmt parsing with structured metadata filter"
-    reason: "Cerberus deferred the `| logfmt` parser stage to RC3 (lower.go LogfmtParserExpr returns 'not yet supported'). Also requires `detected_level` structured metadata."
+    reason: "Cerberus deferred the `| logfmt` parser stage to RC3 (lower.go LogfmtParserExpr returns 'not yet supported')."
     since: "2026-05-15"
     jira:  "docs/roadmap.md RC3 logfmt parser; docs/loki-compliance-plan.md PR 6"
   - source: "fast/structured-metadata.yaml#Logfmt parsing with structured metadata filter first"
@@ -118,7 +123,7 @@ should_skip:
     since: "2026-05-15"
     jira:  "docs/roadmap.md RC3 logfmt parser; docs/loki-compliance-plan.md PR 6"
   - source: "fast/structured-metadata.yaml#JSON parsing with structured metadata filter"
-    reason: "Cerberus deferred the `| json` parser stage to RC3 (lower.go JSONExpressionParserExpr returns 'not yet supported'). Also requires `detected_level` + JSON-shaped log lines (seeder emits logfmt)."
+    reason: "Cerberus deferred the `| json` parser stage to RC3 (lower.go JSONExpressionParserExpr returns 'not yet supported'); seeder emits logfmt-shaped lines so a JSON-aware extractor would not match anyway."
     since: "2026-05-15"
     jira:  "docs/roadmap.md RC3 json parser; docs/loki-compliance-plan.md PR 6"
   - source: "fast/structured-metadata.yaml#JSON parsing with structured metadata filter first"
@@ -204,32 +209,22 @@ should_skip:
     since: "2026-05-15"
     jira:  "docs/roadmap.md RC3 json parser; docs/loki-compliance-plan.md PR 6"
 
-  # regression/structured-metadata.yaml — `detected_level` + parsers +
-  # numeric label filters.
-  - source: "regression/structured-metadata.yaml#Combined line and metadata filter"
-    reason: "Requires `detected_level` structured metadata; seeder writes none."
-    since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6"
+  # regression/structured-metadata.yaml — remaining entries depend on
+  # `| json` / `| logfmt` parsers or numeric label filters; pure
+  # `detected_level=` / `detected_level=~` filters landed via
+  # internal/logql/detected_level.go.
   - source: "regression/structured-metadata.yaml#JSON parsing with duration filter and structured metadata"
     reason: "Upstream pins `skip: true` (numeric `> 0.1` label filter unsupported by v2 engine). Cerberus also has `| json` parser deferred to RC3 and numeric label filters deferred to RC3 (lower.go NumericLabelFilter returns 'not yet supported')."
     since: "2026-05-15"
     jira:  "docs/roadmap.md RC3 json parser + numeric label filters; docs/loki-compliance-plan.md PR 6"
   - source: "regression/structured-metadata.yaml#Logfmt parsing with level filter"
-    reason: "`| logfmt | level=\"error\" | detected_level=\"error\"` — `| logfmt` parser deferred + requires `detected_level` structured metadata."
+    reason: "`| logfmt | level=\"error\" | detected_level=\"error\"` — `| logfmt` parser deferred to RC3."
     since: "2026-05-15"
     jira:  "docs/roadmap.md RC3 logfmt parser; docs/loki-compliance-plan.md PR 6"
   - source: "regression/structured-metadata.yaml#Drilldown pattern with case-insensitive error search"
     reason: "Upstream pins `skip: true` (numeric `>= 500` label filter). Cerberus also has `| json` / `| logfmt` + numeric label filter deferred (`| drop` is now supported)."
     since: "2026-05-15"
     jira:  "docs/roadmap.md RC3 parsers + numeric label filters; docs/loki-compliance-plan.md PR 6"
-  - source: "regression/structured-metadata.yaml#Drilldown with failed search and error level"
-    reason: "Requires `detected_level` structured metadata + 'failed' keyword in log content; seeder writes neither."
-    since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6"
-  - source: "regression/structured-metadata.yaml#Drilldown with error/warn level and refused search"
-    reason: "Requires `detected_level` structured metadata + 'refused' keyword; seeder writes neither."
-    since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6"
 
   # exhaustive/aggregations.yaml — `| logfmt` + unwrap + by/without
   # grouping on range aggregations.
@@ -262,9 +257,9 @@ should_skip:
     since: "2026-05-15"
     jira:  "docs/roadmap.md RC2 M3.4 grouping; docs/loki-compliance-plan.md PR 6"
   - source: "exhaustive/aggregations.yaml#Count aggregated by detected_level"
-    reason: "Requires `detected_level` structured metadata; seeder writes none."
+    reason: "`sum by (detected_level) (count_over_time(...))` — `detected_level` is supported as a filter via internal/logql/detected_level.go, but using the synthesized label as a vector-aggregation group key requires projecting the multiIf normalisation through count_over_time's grouping path. Range-aggregation grouping is also deferred to RC2 M3.4."
     since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6"
+    jira:  "docs/roadmap.md RC2 M3.4 grouping; docs/loki-compliance-plan.md PR 6"
   - source: "exhaustive/aggregations.yaml#Count aggregated by cluster and namespace"
     reason: "`cluster`/`namespace` labels not in seed; range-aggregation `by` grouping deferred."
     since: "2026-05-15"

--- a/internal/logql/detected_level.go
+++ b/internal/logql/detected_level.go
@@ -1,0 +1,133 @@
+package logql
+
+import (
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// detectedLevelLabel is the synthesized label name Loki 3.x exposes for
+// the "detected" log level — a normalised, lower-case severity drawn
+// from the record's structured-metadata `detected_level` label or the
+// record's `severity_text` / OTel `SeverityText` field.
+//
+// Upstream Loki's reference derivation
+// (`github.com/grafana/loki/pkg/distributor/field_detection.go::extractLogLevel`)
+// is layered:
+//
+//  1. If the record's StructuredMetadata already carries `detected_level`,
+//     pass it through (after a lowercase normalise).
+//  2. Else if a stream/structured-metadata label matching one of the
+//     configured "level fields" (`level`, `severity`, `severity_text`, …)
+//     exists, normalise that.
+//  3. Else inspect the log line itself — try JSON/logfmt parsing first,
+//     then fall back to a keyword scan (ERROR / WARN / INFO / DEBUG /
+//     TRACE / FATAL / CRITICAL with word-boundary awareness).
+//
+// The cerberus first-pass implementation emits a CH expression that
+// covers step (1) — read through the OTel `SeverityText` column,
+// normalised to Loki's canonical lowercase set. Production OTel-CH
+// ingestion always populates SeverityText (and cerberus's loki-compat
+// seeder mirrors that), so this single path catches the common case.
+//
+// The content-scan path (step 3 — JSON / logfmt / keyword scan against
+// the log Body) needs Loki's `pkg/pattern` drain machinery on the CH
+// side; we ship it as a follow-up. The structured-metadata flavour of
+// step (1) — `LogAttributes['detected_level']` written by an upstream
+// processor — is left out of the first pass for the same reason: it
+// would double the emitted CH expression size for a path the
+// harness seed doesn't exercise yet.
+const detectedLevelLabel = "detected_level"
+
+// isDetectedLevelLabel reports whether a matcher name targets the
+// synthesized `detected_level` label.
+func isDetectedLevelLabel(name string) bool {
+	return name == detectedLevelLabel
+}
+
+// detectedLevelExpr returns the chplan expression that computes the
+// synthesized `detected_level` value for the current row. The first-pass
+// shape normalises `SeverityText` to Loki's canonical lowercase level
+// set via a `multiIf(...)` chain:
+//
+//	multiIf(
+//	  lower(SeverityText) IN ('trace', 'trc'),                 'trace',
+//	  lower(SeverityText) IN ('debug', 'dbg'),                 'debug',
+//	  lower(SeverityText) IN ('info', 'inf', 'information'),   'info',
+//	  lower(SeverityText) IN ('warn', 'wrn', 'warning'),       'warn',
+//	  lower(SeverityText) IN ('error', 'err'),                 'error',
+//	  lower(SeverityText) =  'critical',                        'critical',
+//	  lower(SeverityText) =  'fatal',                           'fatal',
+//	  lower(SeverityText))
+//
+// Inputs that don't match any group fall through to the lowercased
+// original — matching upstream `normalizeLogLevel`'s default branch.
+// Empty SeverityText emits the empty string (lower(”) = ”).
+//
+// chplan's typed `Expr` surface has no IN frag; the IN clauses above
+// are encoded as left-folded OR-chains of equality comparisons. The
+// emitted SQL is byte-identical to a hand-written `multiIf(... OR ...,
+// ..., ... OR ...)` expression.
+func detectedLevelExpr(s schema.Logs) chplan.Expr {
+	return normaliseLevelExpr(&chplan.ColumnRef{Name: s.SeverityColumn})
+}
+
+// normaliseLevelExpr returns a CH `multiIf(...)` chain that maps the
+// case-insensitive forms upstream Loki accepts (`err`/`error`,
+// `warn`/`wrn`/`warning`, `inf`/`info`/`information`, `dbg`/`debug`,
+// `trc`/`trace`, `critical`, `fatal`) onto Loki's canonical lowercase
+// level strings. Inputs that don't match any group fall through to
+// the lowercased original value — matching upstream `normalizeLogLevel`'s
+// default branch.
+func normaliseLevelExpr(value chplan.Expr) chplan.Expr {
+	lowerValue := &chplan.FuncCall{
+		Name: "lower",
+		Args: []chplan.Expr{value},
+	}
+
+	// Each (variants, canonical) pair builds an OR-chain comparison.
+	// Order matches upstream Loki's `normalizeLogLevel` switch:
+	// trace / debug / info / warn / error / critical / fatal.
+	type group struct {
+		variants  []string
+		canonical string
+	}
+	groups := []group{
+		{[]string{"trace", "trc"}, "trace"},
+		{[]string{"debug", "dbg"}, "debug"},
+		{[]string{"info", "inf", "information"}, "info"},
+		{[]string{"warn", "wrn", "warning"}, "warn"},
+		{[]string{"error", "err"}, "error"},
+		{[]string{"critical"}, "critical"},
+		{[]string{"fatal"}, "fatal"},
+	}
+
+	args := make([]chplan.Expr, 0, len(groups)*2+1)
+	for _, g := range groups {
+		args = append(args, anyEqual(lowerValue, g.variants), &chplan.LitString{V: g.canonical})
+	}
+	// Default branch — pass through the lowercased original. Matches
+	// upstream Loki's `default: return level` behaviour.
+	args = append(args, lowerValue)
+
+	return &chplan.FuncCall{Name: "multiIf", Args: args}
+}
+
+// anyEqual returns a left-folded OR-chain of `expr = variant`
+// comparisons. Single-variant groups short-circuit to a plain
+// `expr = variant`.
+func anyEqual(expr chplan.Expr, variants []string) chplan.Expr {
+	var out chplan.Expr
+	for _, v := range variants {
+		eq := &chplan.Binary{
+			Op:    chplan.OpEq,
+			Left:  expr,
+			Right: &chplan.LitString{V: v},
+		}
+		if out == nil {
+			out = eq
+			continue
+		}
+		out = &chplan.Binary{Op: chplan.OpOr, Left: out, Right: eq}
+	}
+	return out
+}

--- a/internal/logql/detected_level_test.go
+++ b/internal/logql/detected_level_test.go
@@ -1,0 +1,206 @@
+package logql
+
+import (
+	"testing"
+
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestDetectedLevel_RoutesAllMatcherOps exercises the four LogQL label
+// matcher kinds (`=`, `!=`, `=~`, `!~`) against the synthesized
+// `detected_level` label. Every kind must lower to a `chplan.Binary`
+// whose left-hand side is the multiIf normalisation of SeverityText
+// (the SQL-level CASE expression Loki's reference engine emits via
+// `pkg/distributor/field_detection.go::normalizeLogLevel`), not the
+// plain `ResourceAttributes["detected_level"]` lookup that every other
+// label name lowers to. The op carries through unchanged.
+func TestDetectedLevel_RoutesAllMatcherOps(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelLogs()
+
+	cases := []struct {
+		name   string
+		query  string
+		wantOp chplan.BinaryOp
+	}{
+		{"eq", `{job="api"} | detected_level="error"`, chplan.OpEq},
+		{"neq", `{job="api"} | detected_level!="info"`, chplan.OpNe},
+		{"regex", `{job="api"} | detected_level=~"warn|error"`, chplan.OpMatch},
+		{"notregex", `{job="api"} | detected_level!~"fatal"`, chplan.OpNotMatch},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := syntax.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", tc.query, err)
+			}
+
+			filterBin := mustFindDetectedLevelBinary(t, expr, s)
+			if filterBin.Op != tc.wantOp {
+				t.Errorf("matcher %q produced op %q; want %q", tc.name, filterBin.Op, tc.wantOp)
+			}
+			// The LHS must be a `chplan.FuncCall` with name `multiIf` —
+			// the marker that the synthesized normalisation kicked in.
+			// A regression that forgot to route `detected_level` would
+			// emit a `chplan.MapAccess` on ResourceAttributes here.
+			fn, ok := filterBin.Left.(*chplan.FuncCall)
+			if !ok {
+				t.Fatalf("matcher %q: LHS = %T; want *chplan.FuncCall (multiIf)", tc.name, filterBin.Left)
+			}
+			if fn.Name != "multiIf" {
+				t.Errorf("matcher %q: LHS func = %q; want %q", tc.name, fn.Name, "multiIf")
+			}
+			// The matcher value must ride on the RHS as a LitString.
+			lit, ok := filterBin.Right.(*chplan.LitString)
+			if !ok {
+				t.Fatalf("matcher %q: RHS = %T; want *chplan.LitString", tc.name, filterBin.Right)
+			}
+			_ = lit // matcher's value isn't structurally asserted; the parser already exercised it.
+		})
+	}
+}
+
+// TestDetectedLevel_StreamSelector covers the rarer case where
+// `detected_level` is named in the stream selector itself
+// (`{detected_level="error"}`) rather than as a pipe label filter.
+// The synthesized expression must still take over the LHS.
+func TestDetectedLevel_StreamSelector(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelLogs()
+	expr, err := syntax.ParseExpr(`{detected_level="error"}`)
+	if err != nil {
+		t.Fatalf("ParseExpr: %v", err)
+	}
+
+	filterBin := mustFindDetectedLevelBinary(t, expr, s)
+	if filterBin.Op != chplan.OpEq {
+		t.Errorf("stream-selector op = %q; want %q", filterBin.Op, chplan.OpEq)
+	}
+	if _, ok := filterBin.Left.(*chplan.FuncCall); !ok {
+		t.Errorf("stream-selector LHS = %T; want *chplan.FuncCall (multiIf)", filterBin.Left)
+	}
+}
+
+// TestDetectedLevel_NoColumnRefToDetectedLevelLabel verifies that no
+// stray `ResourceAttributes["detected_level"]` MapAccess survives in
+// the lowered tree — the synthesized normalisation should fully
+// shadow the plain map lookup. A failure here would mean the
+// dispatch missed a code path.
+func TestDetectedLevel_NoColumnRefToDetectedLevelLabel(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelLogs()
+	expr, err := syntax.ParseExpr(`{job="api"} | detected_level="error"`)
+	if err != nil {
+		t.Fatalf("ParseExpr: %v", err)
+	}
+	plan, err := lower(expr, s, lowerCtx{})
+	if err != nil {
+		t.Fatalf("lower: %v", err)
+	}
+
+	var found bool
+	walkChplanExpr(plan, func(e chplan.Expr) {
+		ma, ok := e.(*chplan.MapAccess)
+		if !ok {
+			return
+		}
+		lit, ok := ma.Key.(*chplan.LitString)
+		if !ok {
+			return
+		}
+		if lit.V == detectedLevelLabel {
+			found = true
+		}
+	})
+	if found {
+		t.Errorf("plan still contains ResourceAttributes[\"detected_level\"] map lookup; want fully synthesized expression")
+	}
+}
+
+// mustFindDetectedLevelBinary locates the `chplan.Binary` whose RHS is
+// the matcher value LitString for a `detected_level` filter, by
+// walking the filter predicate's AND tree. The helper is the lowest-
+// noise way to assert against a synthesized LHS without re-emitting
+// SQL.
+func mustFindDetectedLevelBinary(t *testing.T, expr syntax.Expr, s schema.Logs) *chplan.Binary {
+	t.Helper()
+	plan, err := lower(expr, s, lowerCtx{})
+	if err != nil {
+		t.Fatalf("lower: %v", err)
+	}
+
+	var bins []*chplan.Binary
+	walkChplanExpr(plan, func(e chplan.Expr) {
+		if b, ok := e.(*chplan.Binary); ok {
+			if isMatchOp(b.Op) {
+				bins = append(bins, b)
+			}
+		}
+	})
+
+	for _, b := range bins {
+		fn, ok := b.Left.(*chplan.FuncCall)
+		if !ok || fn.Name != "multiIf" {
+			continue
+		}
+		if _, ok := b.Right.(*chplan.LitString); ok {
+			return b
+		}
+	}
+	t.Fatalf("no detected_level Binary found in plan; bins=%d", len(bins))
+	return nil
+}
+
+// walkChplanExpr is a minimal sibling of the cross-package
+// chplan.WalkExpr used by collectColumnRefs. Visits every Expr node
+// inside a chplan.Node (recurses through Binary / FuncCall / MapAccess
+// arms; other Expr kinds carry leaves).
+func walkChplanExpr(n chplan.Node, fn func(chplan.Expr)) {
+	switch v := n.(type) {
+	case *chplan.Filter:
+		walkExprTree(v.Predicate, fn)
+		walkChplanExpr(v.Input, fn)
+	case *chplan.Project:
+		for _, p := range v.Projections {
+			walkExprTree(p.Expr, fn)
+		}
+		walkChplanExpr(v.Input, fn)
+	case *chplan.Scan:
+		// nothing
+	}
+}
+
+func walkExprTree(e chplan.Expr, fn func(chplan.Expr)) {
+	if e == nil {
+		return
+	}
+	fn(e)
+	switch v := e.(type) {
+	case *chplan.Binary:
+		walkExprTree(v.Left, fn)
+		walkExprTree(v.Right, fn)
+	case *chplan.FuncCall:
+		for _, a := range v.Args {
+			walkExprTree(a, fn)
+		}
+	case *chplan.MapAccess:
+		walkExprTree(v.Map, fn)
+		walkExprTree(v.Key, fn)
+	}
+}
+
+func isMatchOp(op chplan.BinaryOp) bool {
+	switch op {
+	case chplan.OpEq, chplan.OpNe, chplan.OpMatch, chplan.OpNotMatch:
+		return true
+	}
+	return false
+}

--- a/internal/logql/lower.go
+++ b/internal/logql/lower.go
@@ -252,14 +252,33 @@ func labelFiltererToExpr(lf loglib.LabelFilterer, s schema.Logs) (chplan.Expr, e
 // ResourceAttributes. Shared between StringLabelFilter and the
 // short-circuit-friendly LineFilterLabelFilter — both embed the same
 // *labels.Matcher.
+//
+// The synthesized `detected_level` label routes to a special-case
+// expression that normalises the OTel `SeverityText` column to Loki's
+// canonical lowercase level set, rather than a plain
+// `ResourceAttributes['detected_level']` lookup — see
+// [detectedLevelExpr] for the derivation table and scope notes.
 func labelMatcherToExpr(m *labels.Matcher, s schema.Logs) chplan.Expr {
+	lhs := matcherLHS(m, s)
 	return &chplan.Binary{
-		Op: matchOp(m.Type),
-		Left: &chplan.MapAccess{
-			Map: &chplan.ColumnRef{Name: s.ResourceAttributesColumn},
-			Key: &chplan.LitString{V: m.Name},
-		},
+		Op:    matchOp(m.Type),
+		Left:  lhs,
 		Right: &chplan.LitString{V: m.Value},
+	}
+}
+
+// matcherLHS returns the chplan expression that represents the
+// matched-against value for a label matcher. Synthesized labels
+// (`detected_level` today; future entries can grow this dispatch)
+// route to their own expression; ordinary labels fall back to a
+// `ResourceAttributes[<name>]` lookup.
+func matcherLHS(m *labels.Matcher, s schema.Logs) chplan.Expr {
+	if isDetectedLevelLabel(m.Name) {
+		return detectedLevelExpr(s)
+	}
+	return &chplan.MapAccess{
+		Map: &chplan.ColumnRef{Name: s.ResourceAttributesColumn},
+		Key: &chplan.LitString{V: m.Name},
 	}
 }
 
@@ -352,13 +371,9 @@ func buildMatchersPredicate(matchers []*labels.Matcher, s schema.Logs) chplan.Ex
 }
 
 func matcherToExpr(m *labels.Matcher, s schema.Logs) chplan.Expr {
-	lhs := &chplan.MapAccess{
-		Map: &chplan.ColumnRef{Name: s.ResourceAttributesColumn},
-		Key: &chplan.LitString{V: m.Name},
-	}
 	return &chplan.Binary{
 		Op:    matchOp(m.Type),
-		Left:  lhs,
+		Left:  matcherLHS(m, s),
 		Right: &chplan.LitString{V: m.Value},
 	}
 }

--- a/test/spec/logql/filter_detected_level.txtar
+++ b/test/spec/logql/filter_detected_level.txtar
@@ -1,0 +1,53 @@
+-- query.logql --
+{job="api"} | detected_level="error"
+-- sql --
+SELECT * FROM `otel_logs` WHERE (multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`)) = ?) AND (`ResourceAttributes`[?] = ?)
+-- args --
+[0] string = "trace"
+[1] string = "trc"
+[2] string = "trace"
+[3] string = "debug"
+[4] string = "dbg"
+[5] string = "debug"
+[6] string = "info"
+[7] string = "inf"
+[8] string = "information"
+[9] string = "info"
+[10] string = "warn"
+[11] string = "wrn"
+[12] string = "warning"
+[13] string = "warn"
+[14] string = "error"
+[15] string = "err"
+[16] string = "error"
+[17] string = "critical"
+[18] string = "critical"
+[19] string = "fatal"
+[20] string = "fatal"
+[21] string = "error"
+[22] string = "job"
+[23] string = "api"
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    SeverityText LowCardinality(String) MATERIALIZED multiIf(
+        Body = 'line-warn', 'WARN',
+        Body = 'line-info', 'INFO',
+        Body = 'line-debug', 'DEBUG',
+        Body = 'line-fatal', 'FATAL',
+        'ERROR'),
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES
+    ('line-err'),
+    ('line-warn'),
+    ('line-info'),
+    ('line-debug'),
+    ('line-fatal');
+-- expected_rows --
+[
+  ["line-err"]
+]
+-- chplan --
+Filter predicate=((ResourceAttributes["job"] = "api") AND (multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText)) = "error"))
+  Scan(otel_logs)


### PR DESCRIPTION
## Summary

- Lowers LogQL `detected_level` label matchers (all four matcher ops: `=`, `!=`, `=~`, `!~`) to a `multiIf(lower(SeverityText) = ?, ?, ...)` chain that mirrors upstream Loki's `normalizeLogLevel` table.
- Routes both stream-selector and pipe-stage label matchers via a new `matcherLHS` dispatch in `internal/logql/lower.go`.
- Adds `test/spec/logql/filter_detected_level.txtar` (chDB-roundtrip seed + expected_rows) and `internal/logql/detected_level_test.go`.

## Why

Pre-GA Maximal-GA push: closes the `detected_level` portion of the deferred LogQL surface. Unblocks 4 harness skips.

## Skip entries removed

- \`fast/structured-metadata.yaml#Structured metadata error level filter\`
- \`regression/structured-metadata.yaml#Combined line and metadata filter\`
- \`regression/structured-metadata.yaml#Drilldown with failed search and error level\`
- \`regression/structured-metadata.yaml#Drilldown with error/warn level and refused search\`

Three further skip entries (`Count/Rate with error/warn filter`, `Count aggregated by detected_level`) had their `reason:` rewritten — `detected_level` is no longer the blocker; remaining blockers are `count_over_time`'s ResourceAttributes 502 (PR #433 partial fix) and range-aggregation grouping.

## Test plan

- [ ] \`check\` + \`lint\` pass.
- [ ] \`roundtrip (logql)\` exercises the new fixture.

## Scope notes / follow-ups

- **First-pass uses `SeverityText` only.** Skips content-scan path (JSON / logfmt / keyword scan against Body) — that's Loki's `pkg/pattern/drain` territory and is the canonical scope for the patterns endpoint PR. Loki-compat seeder writes `SeverityText` for every row so this covers every harness query that filters on `detected_level`.
- **`Count aggregated by detected_level` stays skipped.** Using the synthesized expression as a vector-aggregation group key is a bigger lift (project the multiIf through the count_over_time grouping path) and is out of scope.
- Synthesized expression normalises the case-insensitive variants upstream accepts (`err`/`error`, `warn`/`wrn`/`warning`, `inf`/`info`/`information`, `dbg`/`debug`, `trc`/`trace`, `critical`, `fatal`) and falls through to `lower(SeverityText)` for inputs that don't match — matching upstream `normalizeLogLevel`'s default branch.