### PR TITLE
feat(logql): lower | logfmt parser stage (bare + typed forms)

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -92,8 +92,8 @@ Most of PromQL isn't lowered yet at the seed stage. Gating now would make every 
 
 ### LogQL
 
-- **`| json` and `| logfmt` parser stages** — return "not yet supported". Both the bare parsers (`| json`, `| logfmt`) and the expression-select variants (`| json field="..."`, `| logfmt field="..."`) are deferred (`internal/logql/lower.go:184`, `lower.go:186`, `lower.go:188`, `lower.go:189`).
-- **`| pattern`, `| unpack`, `| drop`, and `| keep` are supported** as post-fetch stages (no SQL impact); they extract / project labels in Go after the rows return.
+- **`| json` and `| regexp` parser stages** — return "not yet supported". Both the bare parsers (`| json`, `| regexp`) and the `| json field="..."` expression-select variant are deferred pending chsql `JSONExtract` helpers (`internal/logql/lower.go`).
+- **`| pattern`, `| unpack`, `| drop`, `| keep`, and `| logfmt` are supported**. `| pattern`, `| unpack`, `| drop`, `| keep` extract / project labels in Go after the rows return (no SQL impact). `| logfmt` (bare and `| logfmt field="..."`) lowers to `extractKeyValuePairs(Body, '=', ' ', '"')` and merges the parsed keys into the labels map for downstream string-equality / regex label filters. Numeric / duration / bytes label filters over logfmt-parsed values stay deferred (they need typed lifting beyond the Map(String,String) `| logfmt` exposes).
 - **`| unwrap` range aggregations** — `sum_over_time`, `avg_over_time`, `quantile_over_time`, and other value-based ops return "not yet supported" (`internal/logql/range_aggregation.go:30`, `range_aggregation.go:104`, `range_aggregation.go:122`).
 - **Range-aggregation `by` / `without` grouping** — `rate({...}[5m]) by (label)` and similar grouped metric queries return "not yet supported" (`internal/logql/range_aggregation.go:33`).
 

--- a/harness/loki-compatibility/cerberus-test-queries.yml
+++ b/harness/loki-compatibility/cerberus-test-queries.yml
@@ -22,12 +22,16 @@
 #                    expansion.
 #   - regression/  — vendored in PR 6 (this file). Every entry uses
 #                    features cerberus has deferred to RC2/RC3
-#                    (`| json`, `| logfmt`, `| unwrap`,
+#                    (`| json`, `| unwrap`,
 #                    `sum_over_time` / `avg_over_time` /
 #                    `min_over_time` / `max_over_time` /
 #                    `quantile_over_time` / `stddev_over_time`,
 #                    range-aggregation `by`/`without` grouping,
-#                    numeric label filters). All are listed below.
+#                    numeric label filters). `| logfmt` itself is
+#                    supported via extractKeyValuePairs lowering;
+#                    skipped entries mentioning `| logfmt` cite the
+#                    *other* deferred feature in the same pipeline.
+#                    All are listed below.
 #   - exhaustive/  — vendored in PR 6 (this file). Same posture: every
 #                    entry leans on a deferred feature.
 #
@@ -53,17 +57,19 @@
 #   with line filter) entries were unskipped after the seed expansion added
 #   multi-label streams, structured metadata, and multi-format log lines.
 #   The remaining fast/ entries require LogQL features cerberus has
-#   deferred (detected_level filter, | json, | logfmt parser stages).
+#   deferred (detected_level filter, | json parser stage).
 #   The regression/ + exhaustive/ slices exercise LogQL features cerberus
 #   has explicitly deferred per docs/roadmap.md § RC2:
 #
 #     - `| unpack` / `| pattern` — post-fetch (cerberus supports parse-only)
 #     - `| line_format` / `| label_format` — landed via #128/#130
 #     - `| decolorize` — landed
-#     - `| json` / `| logfmt` / `| regexp` / `| json field=...` /
-#       `| logfmt field=...` — RC3 (chsql JSONExtract helpers)
+#     - `| logfmt` (bare + typed `| logfmt foo="bar"`) — landed via
+#       extractKeyValuePairs lowering; entries mentioning `| logfmt`
+#       below are blocked by *other* deferred features in the same pipeline.
+#     - `| json` / `| regexp` / `| json field=...` — RC3 (chsql JSONExtract helpers)
 #     - `| drop` / `| keep` — landed as post-fetch label projection
-#     - numeric / duration / bytes label filters — RC3 (parser-extracted)
+#     - numeric / duration / bytes label filters — RC3 (parser-extracted typed values)
 #     - `unwrap` based range aggregations
 #       (sum_over_time, avg_over_time, max_over_time, min_over_time,
 #       stddev_over_time, stdvar_over_time, quantile_over_time, first_over_time,
@@ -110,13 +116,13 @@ should_skip:
     since: "2026-05-15"
     jira:  "docs/loki-compliance-plan.md PR 6"
   - source: "fast/structured-metadata.yaml#Logfmt parsing with structured metadata filter"
-    reason: "Cerberus deferred the `| logfmt` parser stage to RC3 (lower.go LogfmtParserExpr returns 'not yet supported'). Also requires `detected_level` structured metadata."
+    reason: "`| logfmt` is now supported (extractKeyValuePairs lowering); this query also filters on `detected_level` structured metadata, which cerberus does not yet support."
     since: "2026-05-15"
-    jira:  "docs/roadmap.md RC3 logfmt parser; docs/loki-compliance-plan.md PR 6"
+    jira:  "docs/loki-compliance-plan.md PR 6 (structured-metadata)"
   - source: "fast/structured-metadata.yaml#Logfmt parsing with structured metadata filter first"
-    reason: "Same as `Logfmt parsing with structured metadata filter` — `| logfmt` parser is deferred to RC3."
+    reason: "`| logfmt` is now supported; the remaining blocker is `detected_level` structured-metadata filtering."
     since: "2026-05-15"
-    jira:  "docs/roadmap.md RC3 logfmt parser; docs/loki-compliance-plan.md PR 6"
+    jira:  "docs/loki-compliance-plan.md PR 6 (structured-metadata)"
   - source: "fast/structured-metadata.yaml#JSON parsing with structured metadata filter"
     reason: "Cerberus deferred the `| json` parser stage to RC3 (lower.go JSONExpressionParserExpr returns 'not yet supported'). Also requires `detected_level` + JSON-shaped log lines (seeder emits logfmt)."
     since: "2026-05-15"
@@ -126,35 +132,34 @@ should_skip:
     since: "2026-05-15"
     jira:  "docs/roadmap.md RC3 json parser; docs/loki-compliance-plan.md PR 6"
 
-  # regression/drilldown-patterns.yaml — `| json` / `| logfmt` parser
-  # stages + `unwrap` + `by` on range-aggregation. `| drop` itself
-  # landed in #?; these entries still need the parser stages.
+  # regression/drilldown-patterns.yaml — `| json` parser stage
+  # + `unwrap` + `by` on range-aggregation. (`| logfmt`, `| drop` are supported.)
   - source: "regression/drilldown-patterns.yaml#Basic drilldown with json and logfmt parsing"
-    reason: "Uses `| json | logfmt | drop` — `| drop` is now supported as a post-fetch label projection, but the `| json` and `| logfmt` parser stages remain deferred to RC3 (internal/logql/lower.go)."
+    reason: "Uses `| json | logfmt | drop` — `| logfmt` and `| drop` are supported, but `| json` is still deferred to RC3 (internal/logql/lower.go)."
     since: "2026-05-15"
-    jira:  "docs/roadmap.md RC3 parsers; docs/loki-compliance-plan.md PR 6"
+    jira:  "docs/roadmap.md RC3 `| json` parser; docs/loki-compliance-plan.md PR 6"
   - source: "regression/drilldown-patterns.yaml#Drilldown with error level filter"
-    reason: "Same as Basic drilldown — `| drop` landed but `| json | logfmt` parsers remain deferred to RC3."
+    reason: "Same as Basic drilldown — `| json` parser is deferred (`| logfmt` and `| drop` are now supported)."
     since: "2026-05-15"
-    jira:  "docs/roadmap.md RC3 parsers; docs/loki-compliance-plan.md PR 6"
+    jira:  "docs/roadmap.md RC3 `| json` parser; docs/loki-compliance-plan.md PR 6"
   - source: "regression/drilldown-patterns.yaml#Drilldown with error or warn level filter"
-    reason: "Same as Basic drilldown — `| json | logfmt` parsers deferred to RC3 plus boolean `or` over label filter."
+    reason: "Same as Basic drilldown — `| json` parser deferred (`| logfmt` and `| drop` are now supported)."
     since: "2026-05-15"
-    jira:  "docs/roadmap.md RC3 parsers; docs/loki-compliance-plan.md PR 6"
+    jira:  "docs/roadmap.md RC3 `| json` parser; docs/loki-compliance-plan.md PR 6"
   - source: "regression/drilldown-patterns.yaml#Drilldown unwrap query with detected_level grouping"
     reason: "Uses `avg_over_time(... | unwrap duration_seconds(duration))` + `sum by (detected_level)` — `| unwrap` range ops (avg_over_time) and range-aggregation grouping are both deferred to RC2/RC3 (internal/logql/range_aggregation.go)."
     since: "2026-05-15"
     jira:  "docs/roadmap.md RC2 M3.4 grouping + RC2/RC3 unwrap; docs/loki-compliance-plan.md PR 6"
   - source: "regression/drilldown-patterns.yaml#Drilldown count with complex filters"
-    reason: "Uses `| detected_level=... or detected_level=... |~ ... | json | logfmt | drop | level=~...` — `| drop` landed but the `| json` and `| logfmt` parsers plus the complex label-filter or-chain over structured metadata remain deferred."
+    reason: "Uses `| detected_level=... or detected_level=... |~ ... | json | logfmt | drop | level=~...` — `| logfmt` and `| drop` are supported, but `| json` and the complex label-filter or-chain over structured metadata remain deferred."
     since: "2026-05-15"
-    jira:  "docs/roadmap.md RC3 parsers; docs/loki-compliance-plan.md PR 6"
+    jira:  "docs/roadmap.md RC3 `| json` parser; docs/loki-compliance-plan.md PR 6"
 
   # regression/metric-queries.yaml — every entry is unwrap-based.
   - source: "regression/metric-queries.yaml#Sum over time with duration conversion"
-    reason: "`sum_over_time(... | unwrap duration(duration))` — `sum_over_time` (RangeWindow non-counter) on unwrapped values and the `| logfmt` parser are both deferred to RC2/RC3 (internal/logql/range_aggregation.go only supports rate/count_over_time/bytes_rate/bytes_over_time today)."
+    reason: "`sum_over_time(... | unwrap duration(duration))` — `sum_over_time` (RangeWindow non-counter) on unwrapped values and `| unwrap` itself are deferred to RC2/RC3 (internal/logql/range_aggregation.go only supports rate/count_over_time/bytes_rate/bytes_over_time today). `| logfmt` is now supported but cannot unblock this on its own."
     since: "2026-05-15"
-    jira:  "docs/roadmap.md RC3 logfmt parser + RC2/RC3 unwrap range ops; docs/loki-compliance-plan.md PR 6"
+    jira:  "docs/roadmap.md RC2/RC3 unwrap range ops; docs/loki-compliance-plan.md PR 6"
   - source: "regression/metric-queries.yaml#Average over time with duration conversion"
     reason: "`avg_over_time(... | unwrap)` — `avg_over_time` not supported on unwrapped values."
     since: "2026-05-15"
@@ -164,7 +169,7 @@ should_skip:
     since: "2026-05-15"
     jira:  "docs/roadmap.md RC2/RC3 unwrap; docs/loki-compliance-plan.md PR 6"
   - source: "regression/metric-queries.yaml#Duration seconds conversion with avg"
-    reason: "`sum by (level) (avg_over_time(... | unwrap duration_seconds(duration)))` — `avg_over_time` on unwrap + range-aggregation `by` grouping + `| logfmt` parser, all deferred."
+    reason: "`sum by (level) (avg_over_time(... | unwrap duration_seconds(duration)))` — `avg_over_time` on unwrap + range-aggregation `by` grouping are still deferred; `| logfmt` is now supported."
     since: "2026-05-15"
     jira:  "docs/roadmap.md RC2/RC3 unwrap + grouping; docs/loki-compliance-plan.md PR 6"
   - source: "regression/metric-queries.yaml#Duration seconds with sum over time"
@@ -176,7 +181,7 @@ should_skip:
     since: "2026-05-15"
     jira:  "docs/roadmap.md RC2/RC3 unwrap range ops; docs/loki-compliance-plan.md PR 6"
   - source: "regression/metric-queries.yaml#Bytes conversion with sum"
-    reason: "`sum_over_time(... | logfmt | unwrap bytes)` — sum_over_time + unwrap deferred."
+    reason: "`sum_over_time(... | logfmt | unwrap bytes)` — `| logfmt` is now supported, but `sum_over_time` on unwrap remains deferred."
     since: "2026-05-15"
     jira:  "docs/roadmap.md RC2/RC3 unwrap; docs/loki-compliance-plan.md PR 6"
   - source: "regression/metric-queries.yaml#Bytes grouped by level"
@@ -184,9 +189,9 @@ should_skip:
     since: "2026-05-15"
     jira:  "docs/roadmap.md RC2 M3.4 grouping + unwrap; docs/loki-compliance-plan.md PR 6"
   - source: "regression/metric-queries.yaml#Logfmt size unwrap"
-    reason: "`sum_over_time(... | logfmt | unwrap size)` — sum_over_time + unwrap + logfmt parser deferred."
+    reason: "`sum_over_time(... | logfmt | unwrap size)` — `| logfmt` is now supported, but `sum_over_time` on unwrap remains deferred."
     since: "2026-05-15"
-    jira:  "docs/roadmap.md RC2/RC3 unwrap + RC3 logfmt parser; docs/loki-compliance-plan.md PR 6"
+    jira:  "docs/roadmap.md RC2/RC3 unwrap range ops; docs/loki-compliance-plan.md PR 6"
   - source: "regression/metric-queries.yaml#Min over time with unwrap"
     reason: "`min(min_over_time(... | unwrap))` — min_over_time + unwrap deferred."
     since: "2026-05-15"
@@ -196,9 +201,9 @@ should_skip:
     since: "2026-05-15"
     jira:  "docs/roadmap.md RC2/RC3 unwrap range ops; docs/loki-compliance-plan.md PR 6"
   - source: "regression/metric-queries.yaml#Logfmt status unwrap"
-    reason: "`avg_over_time(... | logfmt | unwrap status)` — avg_over_time + unwrap + logfmt parser deferred."
+    reason: "`avg_over_time(... | logfmt | unwrap status)` — `| logfmt` is now supported, but `avg_over_time` on unwrap remains deferred."
     since: "2026-05-15"
-    jira:  "docs/roadmap.md RC2/RC3 unwrap + RC3 logfmt parser; docs/loki-compliance-plan.md PR 6"
+    jira:  "docs/roadmap.md RC2/RC3 unwrap range ops; docs/loki-compliance-plan.md PR 6"
   - source: "regression/metric-queries.yaml#HTTP status code distribution"
     reason: "Upstream already pins `skip: true` (JSONParserErr on generated data); listed for explicitness — `| json` parser is also a cerberus deferred feature for RC3."
     since: "2026-05-15"
@@ -215,13 +220,13 @@ should_skip:
     since: "2026-05-15"
     jira:  "docs/roadmap.md RC3 json parser + numeric label filters; docs/loki-compliance-plan.md PR 6"
   - source: "regression/structured-metadata.yaml#Logfmt parsing with level filter"
-    reason: "`| logfmt | level=\"error\" | detected_level=\"error\"` — `| logfmt` parser deferred + requires `detected_level` structured metadata."
+    reason: "`| logfmt | level=\"error\" | detected_level=\"error\"` — `| logfmt` is now supported, but `detected_level` structured-metadata filtering remains deferred."
     since: "2026-05-15"
-    jira:  "docs/roadmap.md RC3 logfmt parser; docs/loki-compliance-plan.md PR 6"
+    jira:  "docs/loki-compliance-plan.md PR 6 (structured-metadata)"
   - source: "regression/structured-metadata.yaml#Drilldown pattern with case-insensitive error search"
-    reason: "Upstream pins `skip: true` (numeric `>= 500` label filter). Cerberus also has `| json` / `| logfmt` + numeric label filter deferred (`| drop` is now supported)."
+    reason: "Upstream pins `skip: true` (numeric `>= 500` label filter). Cerberus also has `| json` + numeric label filters deferred (`| logfmt` and `| drop` are now supported)."
     since: "2026-05-15"
-    jira:  "docs/roadmap.md RC3 parsers + numeric label filters; docs/loki-compliance-plan.md PR 6"
+    jira:  "docs/roadmap.md RC3 `| json` parser + numeric label filters; docs/loki-compliance-plan.md PR 6"
   - source: "regression/structured-metadata.yaml#Drilldown with failed search and error level"
     reason: "Requires `detected_level` structured metadata + 'failed' keyword in log content; seeder writes neither."
     since: "2026-05-15"
@@ -231,16 +236,17 @@ should_skip:
     since: "2026-05-15"
     jira:  "docs/loki-compliance-plan.md PR 6"
 
-  # exhaustive/aggregations.yaml — `| logfmt` + unwrap + by/without
-  # grouping on range aggregations.
+  # exhaustive/aggregations.yaml — unwrap + by/without grouping on
+  # range aggregations. (`| logfmt` is supported now; the remaining
+  # blocker on these entries is the unwrap/grouping pair.)
   - source: "exhaustive/aggregations.yaml#Average over time with unwrap - no grouping"
-    reason: "`avg_over_time(... | logfmt | unwrap duration(duration))` — avg_over_time on unwrap + logfmt parser deferred."
+    reason: "`avg_over_time(... | logfmt | unwrap duration(duration))` — `| logfmt` is now supported, but `avg_over_time` on unwrap is still deferred."
     since: "2026-05-15"
-    jira:  "docs/roadmap.md RC2/RC3 unwrap + RC3 logfmt parser; docs/loki-compliance-plan.md PR 6"
+    jira:  "docs/roadmap.md RC2/RC3 unwrap range ops; docs/loki-compliance-plan.md PR 6"
   - source: "exhaustive/aggregations.yaml#Average over time with line filter and unwrap"
-    reason: "Same as `Average over time with unwrap - no grouping`."
+    reason: "Same as `Average over time with unwrap - no grouping` — `avg_over_time` on unwrap deferred."
     since: "2026-05-15"
-    jira:  "docs/roadmap.md RC2/RC3 unwrap + RC3 logfmt parser; docs/loki-compliance-plan.md PR 6"
+    jira:  "docs/roadmap.md RC2/RC3 unwrap range ops; docs/loki-compliance-plan.md PR 6"
   - source: "exhaustive/aggregations.yaml#Min over time with unwrap"
     reason: "`min_over_time(... | unwrap)` — min_over_time + unwrap deferred."
     since: "2026-05-15"
@@ -274,13 +280,13 @@ should_skip:
     since: "2026-05-15"
     jira:  "docs/roadmap.md RC2 M3.4 grouping; docs/loki-compliance-plan.md PR 6"
   - source: "exhaustive/aggregations.yaml#JSON duration by level"
-    reason: "`sum_over_time(... | logfmt | unwrap duration(duration))` + `sum by (level)` — sum_over_time + unwrap + logfmt parser + range-agg grouping all deferred."
+    reason: "`sum_over_time(... | logfmt | unwrap duration(duration))` + `sum by (level)` — `| logfmt` is now supported, but `sum_over_time` on unwrap and range-aggregation grouping are still deferred."
     since: "2026-05-15"
-    jira:  "docs/roadmap.md RC2/RC3 unwrap + RC3 logfmt parser; docs/loki-compliance-plan.md PR 6"
+    jira:  "docs/roadmap.md RC2/RC3 unwrap + RC2 M3.4 grouping; docs/loki-compliance-plan.md PR 6"
   - source: "exhaustive/aggregations.yaml#Loki duration unwrap with logfmt"
-    reason: "Same as `JSON duration by level`."
+    reason: "Same as `JSON duration by level` — `sum_over_time` on unwrap + grouping deferred."
     since: "2026-05-15"
-    jira:  "docs/roadmap.md RC2/RC3 unwrap + RC3 logfmt parser; docs/loki-compliance-plan.md PR 6"
+    jira:  "docs/roadmap.md RC2/RC3 unwrap + RC2 M3.4 grouping; docs/loki-compliance-plan.md PR 6"
   - source: "exhaustive/aggregations.yaml#Max of min duration by level"
     reason: "`max by (level) (min_over_time(... | unwrap))` — min_over_time + unwrap + grouping deferred."
     since: "2026-05-15"
@@ -321,17 +327,17 @@ should_skip:
     since: "2026-05-15"
     jira:  "docs/roadmap.md RC2 M3.4 grouping + unwrap; docs/loki-compliance-plan.md PR 6"
   - source: "exhaustive/unwrap-aggregations.yaml#Rate with duration conversion"
-    reason: "`rate(... | logfmt | unwrap duration_seconds(duration))` — rate on unwrap + logfmt parser deferred."
+    reason: "`rate(... | logfmt | unwrap duration_seconds(duration))` — `| logfmt` is now supported, but `rate` on unwrap remains deferred."
     since: "2026-05-15"
-    jira:  "docs/roadmap.md RC3 logfmt parser + RC2/RC3 unwrap; docs/loki-compliance-plan.md PR 6"
+    jira:  "docs/roadmap.md RC2/RC3 unwrap; docs/loki-compliance-plan.md PR 6"
   - source: "exhaustive/unwrap-aggregations.yaml#Sum over time - no grouping"
     reason: "`sum_over_time(... | json | unwrap duration_ms)` — sum_over_time + unwrap + json parser deferred."
     since: "2026-05-15"
     jira:  "docs/roadmap.md RC2/RC3 unwrap + RC3 json parser; docs/loki-compliance-plan.md PR 6"
   - source: "exhaustive/unwrap-aggregations.yaml#Sum over time with top-level aggregation"
-    reason: "`sum(sum_over_time(... | logfmt | unwrap))` — sum_over_time + unwrap + logfmt parser deferred."
+    reason: "`sum(sum_over_time(... | logfmt | unwrap))` — `| logfmt` is now supported, but `sum_over_time` on unwrap remains deferred."
     since: "2026-05-15"
-    jira:  "docs/roadmap.md RC2/RC3 unwrap + RC3 logfmt parser; docs/loki-compliance-plan.md PR 6"
+    jira:  "docs/roadmap.md RC2/RC3 unwrap; docs/loki-compliance-plan.md PR 6"
   - source: "exhaustive/unwrap-aggregations.yaml#Sum over time grouped by single label"
     reason: "`sum by (level) (sum_over_time(... | unwrap))` — sum_over_time + unwrap + range-agg grouping deferred."
     since: "2026-05-15"
@@ -345,9 +351,9 @@ should_skip:
     since: "2026-05-15"
     jira:  "docs/roadmap.md RC2 M3.4 grouping + unwrap; docs/loki-compliance-plan.md PR 6"
   - source: "exhaustive/unwrap-aggregations.yaml#Sum over time with bytes"
-    reason: "`sum_over_time(... | logfmt | unwrap bytes)` — sum_over_time + unwrap + logfmt parser deferred."
+    reason: "`sum_over_time(... | logfmt | unwrap bytes)` — `| logfmt` is now supported, but `sum_over_time` on unwrap remains deferred."
     since: "2026-05-15"
-    jira:  "docs/roadmap.md RC2/RC3 unwrap + RC3 logfmt parser; docs/loki-compliance-plan.md PR 6"
+    jira:  "docs/roadmap.md RC2/RC3 unwrap; docs/loki-compliance-plan.md PR 6"
   - source: "exhaustive/unwrap-aggregations.yaml#Average over time - no grouping"
     reason: "`avg_over_time(... | unwrap)` — avg_over_time + unwrap deferred."
     since: "2026-05-15"
@@ -449,9 +455,9 @@ should_skip:
     since: "2026-05-15"
     jira:  "docs/roadmap.md RC2/RC3 unwrap range ops; docs/loki-compliance-plan.md PR 6"
   - source: "exhaustive/unwrap-aggregations.yaml#Logfmt size unwrap"
-    reason: "`sum_over_time(... | logfmt | unwrap size)` — sum_over_time + unwrap + logfmt parser deferred."
+    reason: "`sum_over_time(... | logfmt | unwrap size)` — `| logfmt` is now supported, but `sum_over_time` on unwrap remains deferred."
     since: "2026-05-15"
-    jira:  "docs/roadmap.md RC2/RC3 unwrap + RC3 logfmt parser; docs/loki-compliance-plan.md PR 6"
+    jira:  "docs/roadmap.md RC2/RC3 unwrap; docs/loki-compliance-plan.md PR 6"
   - source: "exhaustive/unwrap-aggregations.yaml#Empty by() clause"
     reason: "`max by () (max_over_time(... | unwrap))` — max_over_time + unwrap + range-agg grouping deferred."
     since: "2026-05-15"
@@ -465,13 +471,13 @@ should_skip:
     since: "2026-05-15"
     jira:  "docs/roadmap.md RC2/RC3 unwrap + grouping; docs/loki-compliance-plan.md PR 6"
   - source: "exhaustive/unwrap-aggregations.yaml#Unwrap with line filter"
-    reason: "`sum_over_time(... |= \"level\" | logfmt | unwrap)` — sum_over_time + unwrap + logfmt parser deferred."
+    reason: "`sum_over_time(... |= \"level\" | logfmt | unwrap)` — `| logfmt` is now supported, but `sum_over_time` on unwrap remains deferred."
     since: "2026-05-15"
-    jira:  "docs/roadmap.md RC2/RC3 unwrap + RC3 logfmt parser; docs/loki-compliance-plan.md PR 6"
+    jira:  "docs/roadmap.md RC2/RC3 unwrap; docs/loki-compliance-plan.md PR 6"
   - source: "exhaustive/unwrap-aggregations.yaml#Unwrap with regex line filter"
-    reason: "Same as `Unwrap with line filter`, with a regex line filter."
+    reason: "Same as `Unwrap with line filter` — `sum_over_time` on unwrap deferred."
     since: "2026-05-15"
-    jira:  "docs/roadmap.md RC2/RC3 unwrap + RC3 logfmt parser; docs/loki-compliance-plan.md PR 6"
+    jira:  "docs/roadmap.md RC2/RC3 unwrap; docs/loki-compliance-plan.md PR 6"
   - source: "exhaustive/unwrap-aggregations.yaml#Unwrap with label filter after parsing"
     reason: "`sum by (level) (sum_over_time(... | logfmt | level != \"\" | duration != \"\" | unwrap))` — sum_over_time + unwrap + logfmt parser + range-agg grouping + post-parse string label filter (level != \"\") all combined; the unwrap path is the hard block."
     since: "2026-05-15"

--- a/internal/logql/lower.go
+++ b/internal/logql/lower.go
@@ -111,8 +111,21 @@ func lowerMatchers(e *syntax.MatchersExpr, s schema.Logs, lc lowerCtx) chplan.No
 	return &chplan.Filter{Input: scan, Predicate: pred}
 }
 
-// lowerPipeline handles a stream selector followed by line filters
-// (and, in later milestones, label filters and parsers).
+// lowerPipeline handles a stream selector followed by line / label
+// filters and parser stages.
+//
+// labelsExpr threads the "current labels map" through stage iteration:
+// initially it's the schema's ResourceAttributes column; after a
+// `| logfmt` parser stage it becomes
+// `mapConcat(<prev>, extractKeyValuePairs(Body, '=', ' ', '"'))` so
+// downstream label filters resolve against the parsed key set in
+// addition to the stream-selector labels. Loki's documented contract
+// is "parsed labels appended; on conflict the stream label wins and
+// parsed gets `_extracted` suffix"; the CH-side mapConcat lets parsed
+// keys win on conflict instead. That's an acceptable v1 approximation
+// — the common case is parsed keys that don't shadow stream labels
+// (`level`, `msg`, `duration`, …). Strict Loki conflict semantics
+// stay open as a follow-up.
 func lowerPipeline(e *syntax.PipelineExpr, s schema.Logs, lc lowerCtx) (chplan.Node, error) {
 	inner := lowerMatchers(e.Left, s, lc)
 	pred := chplan.Expr(nil)
@@ -120,10 +133,14 @@ func lowerPipeline(e *syntax.PipelineExpr, s schema.Logs, lc lowerCtx) (chplan.N
 		pred = f.Predicate
 		inner = f.Input
 	}
+	labelsExpr := chplan.Expr(&chplan.ColumnRef{Name: s.ResourceAttributesColumn})
 	for _, stage := range e.MultiStages {
-		next, err := lowerStage(stage, s)
+		next, newLabels, err := lowerStage(stage, s, labelsExpr)
 		if err != nil {
 			return nil, err
+		}
+		if newLabels != nil {
+			labelsExpr = newLabels
 		}
 		// Post-fetch stages (`| line_format`, `| decolorize`) return a
 		// nil predicate — they're applied in Go after the rows return,
@@ -143,12 +160,26 @@ func lowerPipeline(e *syntax.PipelineExpr, s schema.Logs, lc lowerCtx) (chplan.N
 	return &chplan.Filter{Input: inner, Predicate: pred}, nil
 }
 
-func lowerStage(stage syntax.StageExpr, s schema.Logs) (chplan.Expr, error) {
+// lowerStage handles one pipeline stage. Returns up to two values:
+//
+//   - pred: a predicate expression to AND into the pipeline filter
+//     (nil for post-fetch / no-op-in-SQL stages).
+//   - newLabels: a replacement labels-map expression to thread into
+//     subsequent label filters (nil for stages that don't change the
+//     visible label set).
+//
+// labelsExpr is the current "labels map" expression — the base
+// `ResourceAttributes` column, or a `mapConcat(...)` wrapped form after
+// a `| logfmt` stage. Label filters MapAccess against it so they see
+// both stream-selector labels and parser-extracted keys.
+func lowerStage(stage syntax.StageExpr, s schema.Logs, labelsExpr chplan.Expr) (chplan.Expr, chplan.Expr, error) {
 	switch st := stage.(type) {
 	case *syntax.LineFilterExpr:
-		return lowerLineFilter(st, s)
+		p, err := lowerLineFilter(st, s)
+		return p, nil, err
 	case *syntax.LabelFilterExpr:
-		return lowerLabelFilter(st, s)
+		p, err := lowerLabelFilter(st, labelsExpr)
+		return p, nil, err
 	case *syntax.LineFmtExpr:
 		// `| line_format "{{.x}}"` is a post-fetch transform —
 		// applied in the API handler over the streams response, not
@@ -156,18 +187,18 @@ func lowerStage(stage syntax.StageExpr, s schema.Logs) (chplan.Expr, error) {
 		// on it but the handler still sees the LineFmtExpr in the
 		// original parsed expression.
 		_ = st
-		return nil, nil
+		return nil, nil, nil
 	case *syntax.DecolorizeExpr:
 		// Same post-fetch shape: strip ANSI codes from each line
 		// after the rows return. No SQL impact.
-		return nil, nil
+		return nil, nil, nil
 	case *syntax.LabelFmtExpr:
 		// `| label_format new=old, lvl="{{.severity}}"` mutates the
 		// row's label set in Go after the rows return — rename or
 		// template-set per Loki's contract. No SQL impact; the
 		// post-process pipeline pulls the LabelFmtExpr from the
 		// parsed expression on the handler side.
-		return nil, nil
+		return nil, nil, nil
 	case *syntax.LineParserExpr:
 		// `| unpack` and `| pattern` are parser stages that extract
 		// labels from the line in Go after the rows return — they have
@@ -175,19 +206,35 @@ func lowerStage(stage syntax.StageExpr, s schema.Logs) (chplan.Expr, error) {
 		// pulls them out of the parsed expression via postProcessExtract
 		// and applies them per row.
 		//
-		// Other parser stages (`| json`, `| logfmt`, `| regexp`) stay
-		// deferred to RC3 alongside `chsql` JSONExtract helpers.
+		// `| json` / `| regexp` parser stages stay deferred (the
+		// dedicated `| logfmt` syntax types are handled below).
 		switch st.Op {
 		case syntax.OpParserTypeUnpack, syntax.OpParserTypePattern:
-			return nil, nil
+			return nil, nil, nil
 		}
-		return nil, fmt.Errorf("logql: parser stage `| %s` is not yet supported (json/logfmt/regexp parsers deferred from M3.2; revisit in RC3 alongside chsql JSONExtract/extractKeyValuePairs helpers)", st.Op)
+		return nil, nil, fmt.Errorf("logql: parser stage `| %s` is not yet supported (json/regexp parsers deferred from M3.2; revisit in RC3 alongside chsql JSONExtract helpers)", st.Op)
 	case *syntax.LogfmtParserExpr:
-		return nil, fmt.Errorf("logql: `| logfmt` parser is not yet supported (deferred from M3.2; revisit in RC3)")
+		// Bare `| logfmt` — extracts all `key=value` pairs from the
+		// line. Subsequent label filters resolve against
+		// mapConcat(<prev labels>, extractKeyValuePairs(Body, ...)).
+		// Strict / KeepEmpty flags are intentionally ignored for now:
+		// CH's extractKeyValuePairs is lenient (no Strict equivalent)
+		// and always drops bare keys (no KeepEmpty equivalent), which
+		// matches Loki's non-strict default semantics for the common
+		// case.
+		_ = st
+		return nil, logfmtMergeLabels(labelsExpr, s), nil
 	case *syntax.JSONExpressionParserExpr:
-		return nil, fmt.Errorf("logql: `| json field=\"...\"` parser is not yet supported (deferred from M3.2; revisit in RC3)")
+		return nil, nil, fmt.Errorf("logql: `| json field=\"...\"` parser is not yet supported (deferred from M3.2; revisit in RC3)")
 	case *syntax.LogfmtExpressionParserExpr:
-		return nil, fmt.Errorf("logql: `| logfmt field=\"...\"` parser is not yet supported (deferred from M3.2; revisit in RC3)")
+		// Typed `| logfmt foo="bar", baz="qux"` — maps caller-chosen
+		// local names to specific logfmt keys. Resulting labels expose
+		// only the named fields (no implicit merge of all pairs).
+		merged, err := logfmtExpressionMergeLabels(labelsExpr, s, st.Expressions)
+		if err != nil {
+			return nil, nil, err
+		}
+		return nil, merged, nil
 	case *syntax.DropLabelsExpr:
 		// `| drop foo, bar` removes named keys from the output label set
 		// in Go after the rows return. The matching `*labels.Matcher`
@@ -197,41 +244,123 @@ func lowerStage(stage syntax.StageExpr, s schema.Logs) (chplan.Expr, error) {
 		// only narrows the label map carried back to the caller. The
 		// API handler pulls the stage out via postProcessExtract.
 		_ = st
-		return nil, nil
+		return nil, nil, nil
 	case *syntax.KeepLabelsExpr:
 		// `| keep foo, bar` is the inverse projection: only the named
 		// labels survive on the output row. Same post-fetch shape as
 		// `| drop` — no SQL impact, applied in Go.
 		_ = st
-		return nil, nil
+		return nil, nil, nil
 	default:
-		return nil, fmt.Errorf("logql: pipeline stage %T is not yet supported", stage)
+		return nil, nil, fmt.Errorf("logql: pipeline stage %T is not yet supported", stage)
+	}
+}
+
+// logfmtMergeLabels wraps the current labelsExpr with a
+// `mapConcat(<prev>, extractKeyValuePairs(Body, '=', ' ', '"'))` so
+// subsequent label filters see the union of stream-selector labels
+// and logfmt-parsed key/value pairs. extractKeyValuePairs is the CH
+// built-in that lifts arbitrary `key=value` text into a
+// `Map(String, String)`; the separator / pair-delimiter / quote
+// arguments mirror Loki's logfmt parser defaults.
+func logfmtMergeLabels(prev chplan.Expr, s schema.Logs) chplan.Expr {
+	return &chplan.FuncCall{
+		Name: "mapConcat",
+		Args: []chplan.Expr{
+			prev,
+			extractKVPairs(s),
+		},
+	}
+}
+
+// logfmtExpressionMergeLabels wraps labelsExpr with a `mapConcat` that
+// stitches in only the named extractions (identifier => extracted
+// value). Each expression is `<identifier>="<key-path>"` — for logfmt
+// the path is a top-level key, so the lowering is
+// `extractKeyValuePairs(Body, ...)[<key-path>]`. The result is a
+// `map(<id1>, <val1>, <id2>, <val2>, …)` that mapConcat appends onto
+// the prior label map.
+func logfmtExpressionMergeLabels(prev chplan.Expr, s schema.Logs, exprs []loglib.LabelExtractionExpr) (chplan.Expr, error) {
+	if len(exprs) == 0 {
+		// Defensive: a parser-emitted empty list is shaped like the
+		// bare `| logfmt` form. Treat it as such so we don't drop the
+		// stage entirely.
+		return logfmtMergeLabels(prev, s), nil
+	}
+	kvBase := extractKVPairs(s)
+	args := make([]chplan.Expr, 0, len(exprs)*2)
+	for _, ext := range exprs {
+		if ext.Identifier == "" {
+			return nil, fmt.Errorf("logql: `| logfmt` expression has empty identifier")
+		}
+		// `Expression` is the source key in the logfmt-parsed map.
+		// When the user writes `| logfmt foo` (no `="..."`), Loki's
+		// parser fills `Expression == Identifier` so both forms
+		// resolve identically.
+		key := ext.Expression
+		if key == "" {
+			key = ext.Identifier
+		}
+		args = append(args,
+			&chplan.LitString{V: ext.Identifier},
+			&chplan.MapAccess{
+				Map: kvBase,
+				Key: &chplan.LitString{V: key},
+			},
+		)
+	}
+	return &chplan.FuncCall{
+		Name: "mapConcat",
+		Args: []chplan.Expr{
+			prev,
+			&chplan.FuncCall{Name: "map", Args: args},
+		},
+	}, nil
+}
+
+// extractKVPairs renders the CH built-in
+// `extractKeyValuePairs(<Body>, '=', ' ', '"')` — the Map(String,String)
+// that the `| logfmt` parser stage exposes to downstream label filters.
+// The three delimiter arguments are Loki's logfmt defaults: `=` between
+// key and value, space between pairs, double-quote as the quoting
+// character.
+func extractKVPairs(s schema.Logs) chplan.Expr {
+	return &chplan.FuncCall{
+		Name: "extractKeyValuePairs",
+		Args: []chplan.Expr{
+			&chplan.ColumnRef{Name: s.BodyColumn},
+			&chplan.LitString{V: "="},
+			&chplan.LitString{V: " "},
+			&chplan.LitString{V: "\""},
+		},
 	}
 }
 
 // lowerLabelFilter handles `| label="val"` / `| label=~"regex"` and the
 // boolean conjunctions Loki packs into BinaryLabelFilter. The named
-// label is resolved against ResourceAttributes (parser-extracted labels
-// defer until parser stages are wired up).
-func lowerLabelFilter(f *syntax.LabelFilterExpr, s schema.Logs) (chplan.Expr, error) {
-	return labelFiltererToExpr(f.LabelFilterer, s)
+// label is resolved against labelsExpr — initially the schema's
+// ResourceAttributes column, but after a `| logfmt` parser stage a
+// `mapConcat(ResourceAttributes, extractKeyValuePairs(Body, ...))`
+// wrapper so parsed keys are also visible.
+func lowerLabelFilter(f *syntax.LabelFilterExpr, labelsExpr chplan.Expr) (chplan.Expr, error) {
+	return labelFiltererToExpr(f.LabelFilterer, labelsExpr)
 }
 
-func labelFiltererToExpr(lf loglib.LabelFilterer, s schema.Logs) (chplan.Expr, error) {
+func labelFiltererToExpr(lf loglib.LabelFilterer, labelsExpr chplan.Expr) (chplan.Expr, error) {
 	switch v := lf.(type) {
 	case *loglib.StringLabelFilter:
-		return labelMatcherToExpr(v.Matcher, s), nil
+		return labelMatcherToExpr(v.Matcher, labelsExpr), nil
 	case *loglib.LineFilterLabelFilter:
 		// Loki may wrap a string label filter in this when a line-filter
 		// short-circuit is also possible. Both embed *labels.Matcher and
 		// behave identically for our query-rewrite purposes.
-		return labelMatcherToExpr(v.Matcher, s), nil
+		return labelMatcherToExpr(v.Matcher, labelsExpr), nil
 	case *loglib.BinaryLabelFilter:
-		left, err := labelFiltererToExpr(v.Left, s)
+		left, err := labelFiltererToExpr(v.Left, labelsExpr)
 		if err != nil {
 			return nil, err
 		}
-		right, err := labelFiltererToExpr(v.Right, s)
+		right, err := labelFiltererToExpr(v.Right, labelsExpr)
 		if err != nil {
 			return nil, err
 		}
@@ -241,22 +370,22 @@ func labelFiltererToExpr(lf loglib.LabelFilterer, s schema.Logs) (chplan.Expr, e
 		}
 		return &chplan.Binary{Op: op, Left: left, Right: right}, nil
 	case *loglib.NumericLabelFilter:
-		return nil, fmt.Errorf("logql: numeric label filters are not yet supported (parser-extracted numbers depend on `| json` / `| logfmt` parser stages; both deferred to RC3)")
+		return nil, fmt.Errorf("logql: numeric label filters are not yet supported (parser-extracted numbers require typed lifting beyond the Map(String,String) `| logfmt` exposes; deferred to a follow-up)")
 	case *loglib.DurationLabelFilter, *loglib.BytesLabelFilter:
-		return nil, fmt.Errorf("logql: %T label filter is not yet supported (parser-extracted typed fields depend on `| json` / `| logfmt` stages; deferred to RC3)", lf)
+		return nil, fmt.Errorf("logql: %T label filter is not yet supported (parser-extracted typed fields require typed lifting beyond the Map(String,String) `| logfmt` exposes; deferred to a follow-up)", lf)
 	}
 	return nil, fmt.Errorf("logql: unsupported label filterer %T", lf)
 }
 
 // labelMatcherToExpr renders a Prometheus-style label Matcher against
-// ResourceAttributes. Shared between StringLabelFilter and the
-// short-circuit-friendly LineFilterLabelFilter — both embed the same
-// *labels.Matcher.
-func labelMatcherToExpr(m *labels.Matcher, s schema.Logs) chplan.Expr {
+// labelsExpr — the live "labels map" for the current point in the
+// pipeline. Shared between StringLabelFilter and the short-circuit-
+// friendly LineFilterLabelFilter (both embed the same *labels.Matcher).
+func labelMatcherToExpr(m *labels.Matcher, labelsExpr chplan.Expr) chplan.Expr {
 	return &chplan.Binary{
 		Op: matchOp(m.Type),
 		Left: &chplan.MapAccess{
-			Map: &chplan.ColumnRef{Name: s.ResourceAttributesColumn},
+			Map: labelsExpr,
 			Key: &chplan.LitString{V: m.Name},
 		},
 		Right: &chplan.LitString{V: m.Value},

--- a/internal/logql/unpack_pattern_test.go
+++ b/internal/logql/unpack_pattern_test.go
@@ -76,15 +76,14 @@ func TestLowerUnpackPattern_NoSQLImpact(t *testing.T) {
 }
 
 // TestLowerUnpackPattern_StillRejectsOtherParsers pins that we didn't
-// accidentally light up `| json` / `| logfmt` / `| regexp` while
-// enabling unpack + pattern — those stay deferred to RC3.
+// accidentally light up `| json` / `| regexp` while enabling unpack +
+// pattern (and `| logfmt`) — those stay deferred to RC3.
 func TestLowerUnpackPattern_StillRejectsOtherParsers(t *testing.T) {
 	t.Parallel()
 
 	s := schema.DefaultOTelLogs()
 	cases := []string{
 		`{job="api"} | json`,
-		`{job="api"} | logfmt`,
 		`{job="api"} | regexp "(?P<status>\\d+)"`,
 	}
 	for _, q := range cases {

--- a/test/spec/logql/parser_logfmt.txtar
+++ b/test/spec/logql/parser_logfmt.txtar
@@ -1,0 +1,29 @@
+-- query.logql --
+{job="api"} | logfmt | level="error"
+-- sql --
+SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (mapConcat(`ResourceAttributes`, extractKeyValuePairs(`Body`, ?, ?, ?))[?] = ?)
+-- args --
+[0] string = "job"
+[1] string = "api"
+[2] string = "="
+[3] string = " "
+[4] string = "\""
+[5] string = "level"
+[6] string = "error"
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES
+    ('ts=2025-01-01 level=error msg="oops"'),
+    ('ts=2025-01-01 level=info msg="skip"'),
+    ('ts=2025-01-01 level=error msg="retry"');
+-- expected_rows --
+[
+  ["ts=2025-01-01 level=error msg=\"oops\""],
+  ["ts=2025-01-01 level=error msg=\"retry\""]
+]
+-- chplan --
+Filter predicate=((ResourceAttributes["job"] = "api") AND (mapConcat(ResourceAttributes, extractKeyValuePairs(Body, "=", " ", "\""))["level"] = "error"))
+  Scan(otel_logs)

--- a/test/spec/logql/parser_logfmt_typed.txtar
+++ b/test/spec/logql/parser_logfmt_typed.txtar
@@ -1,0 +1,31 @@
+-- query.logql --
+{job="api"} | logfmt level="severity" | level="error"
+-- sql --
+SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (mapConcat(`ResourceAttributes`, map(?, extractKeyValuePairs(`Body`, ?, ?, ?)[?]))[?] = ?)
+-- args --
+[0] string = "job"
+[1] string = "api"
+[2] string = "level"
+[3] string = "="
+[4] string = " "
+[5] string = "\""
+[6] string = "severity"
+[7] string = "level"
+[8] string = "error"
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES
+    ('ts=2025-01-01 severity=error msg="oops"'),
+    ('ts=2025-01-01 severity=info msg="skip"'),
+    ('ts=2025-01-01 severity=error msg="retry"');
+-- expected_rows --
+[
+  ["ts=2025-01-01 severity=error msg=\"oops\""],
+  ["ts=2025-01-01 severity=error msg=\"retry\""]
+]
+-- chplan --
+Filter predicate=((ResourceAttributes["job"] = "api") AND (mapConcat(ResourceAttributes, map("level", extractKeyValuePairs(Body, "=", " ", "\"")["severity"]))["level"] = "error"))
+  Scan(otel_logs)


### PR DESCRIPTION
## Summary

- Refactors `lowerPipeline` to thread a `labelsExpr` through stage iteration.
  - Bare \`| logfmt\` wraps it in \`mapConcat(<prev>, extractKeyValuePairs(Body, '=', ' ', '"'))\`.
  - Typed \`| logfmt foo="bar"\` wraps in \`mapConcat(<prev>, map('foo', extractKeyValuePairs(...)['bar']))\`.
- All `LabelFilter` shapes (`StringLabelFilter` / `LineFilterLabelFilter` / `BinaryLabelFilter`) now resolve `MapAccess` against the live `labelsExpr` instead of a hardcoded `ResourceAttributes` ref.
- 2 TXTAR fixtures: `test/spec/logql/parser_logfmt.txtar`, `parser_logfmt_typed.txtar` (chDB seed + expected_rows).
- `docs/compatibility.md` + `harness/loki-compatibility/cerberus-test-queries.yml` skip reasons updated.

## Why

Pre-GA Maximal-GA push: lands one of the three RC3-deferred parser stages. Closes the `| logfmt` blocker on ~12 harness queries (no entries unblocked outright since each remains blocked by additional deferred features — `| json`, unwrap, by/without grouping, etc. — but the rewrites flag them as one-blocker-resolved).

## Test plan

- [ ] \`check\` (logql + chsql tests) passes.
- [ ] \`lint\` passes.
- [ ] \`roundtrip (logql)\` exercises the new fixtures.

## Known limitations / follow-ups

1. **Conflict semantics differ from Loki.** Loki documents: "parsed labels appended; on conflict, stream label wins, parsed gets `_extracted` suffix." `mapConcat(stream, parsed)` order in this PR lets parsed override stream on key conflict — the opposite. Documented inline in `lowerPipeline`'s docstring as an acceptable v1 approximation. Strict semantics need a follow-up (likely a custom CH UDF or arrayMap-based reconciliation).
2. **Streams response label extraction is untouched.** SQL-side filter pushdown works, but the Go-side `postProcessExtract` in `internal/api/loki/post_process.go` does not yet add a `| logfmt` step that populates response stream labels — running \`{job=…} | logfmt\` as a *log* query (not metric) won't surface parsed keys in the wire-format `stream.<key>` labels. Follow-up: add a `logfmtStep` to mirror `unpackStep` / `newPatternStep`.
3. **`Strict` / `KeepEmpty` flags ignored.** Loki's `| logfmt --strict` errors on malformed input; `--keep-empty` retains keys with empty values. CH's `extractKeyValuePairs` has no equivalent flags and is uniformly lenient. Documented in the LogfmtParserExpr case comment.