### PR TITLE
cleanup(harness/tempo-compat): drop TraceID canonicalisation workaround

### DIFF
--- a/harness/tempo-compatibility/README.md
+++ b/harness/tempo-compatibility/README.md
@@ -55,7 +55,7 @@ harness/tempo-compatibility/
     main.go             subcommand dispatcher (seed / diff)
     seeder.go           OTLP push to Tempo + CH INSERT for cerberus
     corpus.go           TXTAR corpus loader (PR 4 + PR 6 tag sections)
-    differ.go           canonical-key + relative-epsilon diff (PR 4) +
+    differ.go           TraceID-keyed + relative-epsilon diff (PR 4) +
                         tag-name / tag-values set diff (PR 6)
     diff.go             `diff` subcommand: HTTP fetch + assertions + report
     corpus/
@@ -85,14 +85,14 @@ The differ runs each corpus case against both Tempo and cerberus via
 `/api/search` (and `/api/traces/<id>` for per-id smoke cases), then
 compares the responses. Two complications drive the diff strategy:
 
-1. **Cerberus's `TraceSummary.TraceID` is synthetic today.** See
-   `internal/api/tempo/handler.go::toTraceSummaries` — the stub key is
-   `MetricName + "|" + Timestamp`, not the real OTLP trace ID hex
-   Tempo returns. A literal byte-equal would false-positive on every
-   case. The differ canonicalises each summary via
-   `H(rootServiceName || rootTraceName)` and compares the canonical-key
-   multisets, exactly the plan's "hash trace IDs deterministically
-   (different orderings of equal sets don't false-positive)" prescription.
+1. **TraceIDs match byte-for-byte across backends.** As of PR #439
+   `internal/api/tempo/handler.go::toTraceSummaries` emits the real
+   hex(TraceId) from ClickHouse, so cerberus and Tempo return identical
+   32-hex-char IDs for the same seeded span set. The differ keys its
+   trace-summary multisets directly on `TraceSummary.TraceID` — no
+   hashing, no canonicalisation. "Different orderings of equal sets
+   don't false-positive" still holds because the index is a TraceID
+   map, not a positional list.
 2. **Per-case expectations are orthogonal to differential equality.** A
    case like `{ resource.service.name = "checkout" }` can carry an
    `expected_min_traces: 1` assertion ("each backend, on its own, must
@@ -112,7 +112,7 @@ endpoints.
 
 | Category                | Endpoint kind     | Wire shape                                      | Diff strategy                                          |
 | ----------------------- | ----------------- | ----------------------------------------------- | ------------------------------------------------------ |
-| Attribute matchers      | `search`          | `{traces:[TraceSummary]}`                       | Canonical-key (rootSvc, rootName) set diff             |
+| Attribute matchers      | `search`          | `{traces:[TraceSummary]}`                       | TraceID set diff (real hex IDs match byte-for-byte)    |
 | Intrinsics              | `search`          | same                                            | same                                                   |
 | Structural ops          | `search`          | same                                            | same                                                   |
 | Set ops                 | `search`          | same                                            | same                                                   |

--- a/harness/tempo-compatibility/driver/differ.go
+++ b/harness/tempo-compatibility/driver/differ.go
@@ -8,26 +8,20 @@
 // `DiffReason`, never collapsed into a single boolean, so the markdown
 // report can surface actionable detail per case.
 //
-// Why not byte-equal? Cerberus's `TraceSummary.TraceID` is synthetic
-// today (see internal/api/tempo/handler.go::toTraceSummaries — the
-// stub key is `MetricName + "|" + Timestamp`, not the real 16-byte
-// OTLP trace ID hex). Tempo's TraceID is the real hex. A literal
-// byte-equal would false-positive on every case until cerberus
-// projects the real TraceId column through to the search summary —
-// outside PR 4's scope. The plan calls this out explicitly:
-// "hash trace IDs deterministically (different orderings of equal
-// sets don't false-positive)".
+// As of PR #439, cerberus emits the real hex(TraceId) on
+// `/api/search` (see internal/api/tempo/handler.go::toTraceSummaries),
+// so both backends produce identical 32-hex-char TraceIDs for the
+// same seeded span set. The differ keys its trace-summary multisets
+// directly on `TraceSummary.TraceID` — no hashing, no canonicalisation.
+// "Different orderings of equal sets don't false-positive" still holds
+// because the index is a map keyed by TraceID, not a positional list.
 //
 // So the differ:
 //
-//   1. Canonicalises each TraceSummary by deriving a stable key
-//      `H(rootServiceName || rootTraceName)`. Both backends produce
-//      the same hash for the same trace because they read the same
-//      seeded fixture.
-//   2. Sorts the trace list by the canonical key on each side.
-//   3. Diffs the canonical-key multisets (matches "different
-//      orderings of equal sets don't false-positive").
-//   4. For matched entries, diffs the per-summary fields under a
+//   1. Indexes each TraceSummary by its real hex(TraceId).
+//   2. Diffs the TraceID multisets directly (the index is a map, so
+//      order on either side is irrelevant).
+//   3. For matched entries, diffs the per-summary fields under a
 //      relative-epsilon tolerance for `DurationMs` (clock vs
 //      duration-column drift across backends is real).
 //
@@ -37,8 +31,6 @@
 package main
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -75,16 +67,12 @@ type TraceSummary struct {
 	DurationMs        int    `json:"durationMs,omitempty"`
 }
 
-// CanonicalKey is the per-trace hash used to align the two backends'
-// trace lists. Format: hex(SHA-256(rootServiceName + "\x00" +
-// rootTraceName)) truncated to 16 hex chars (8 bytes of entropy is
-// plenty: 100 traces would collide with p ≈ 100²/(2·2⁶⁴) ≈ 2.7e-16).
-//
-// Truncation keeps the key short in the markdown report. The full
-// 64-hex hash is fine too — only readability suffers.
-func CanonicalKey(t TraceSummary) string {
-	h := sha256.Sum256([]byte(t.RootServiceName + "\x00" + t.RootTraceName))
-	return hex.EncodeToString(h[:8])
+// traceKey is the per-trace identifier used to align the two backends'
+// trace lists. Since PR #439, cerberus and Tempo both emit the real
+// hex(TraceId) on `/api/search`, so the raw TraceID string is the
+// natural key — no canonicalisation needed.
+func traceKey(t TraceSummary) string {
+	return t.TraceID
 }
 
 // DiffOptions controls numeric-field tolerance. Mirrors the prom
@@ -117,8 +105,8 @@ type DiffReason struct {
 type Diff struct {
 	// Equal is true iff the two sides match within tolerances.
 	Equal bool
-	// MatchedCount is the number of canonical-key intersections that
-	// survived field-level diffing.
+	// MatchedCount is the number of TraceID intersections that survived
+	// field-level diffing.
 	MatchedCount int
 	// Reasons enumerates every mismatch in deterministic order.
 	Reasons []DiffReason
@@ -222,15 +210,14 @@ func decodeSearch(body []byte) (SearchResponse, error) {
 	return out, nil
 }
 
-// indexByKey deduplicates by CanonicalKey, keeping the first occurrence
-// — a single backend should never return two traces with the same
-// (rootServiceName, rootTraceName) for the corpus shapes we ship in
-// PR 4 (the seeder gives every trace a unique name); if it does, the
-// per-field diff will catch any inconsistency in the second copy.
+// indexByKey deduplicates by traceKey (the real hex(TraceId)), keeping
+// the first occurrence — a single backend should never return two
+// traces with the same TraceID; if it does, the per-field diff will
+// catch any inconsistency in the second copy.
 func indexByKey(ts []TraceSummary) map[string]TraceSummary {
 	out := make(map[string]TraceSummary, len(ts))
 	for _, t := range ts {
-		k := CanonicalKey(t)
+		k := traceKey(t)
 		if _, dup := out[k]; dup {
 			continue
 		}
@@ -239,17 +226,15 @@ func indexByKey(ts []TraceSummary) map[string]TraceSummary {
 	return out
 }
 
-// compareSummary diffs two same-canonical-key TraceSummaries. The
-// `aLabel` / `bLabel` strings end up in the reasons so a downstream
-// reader knows which side reported which value.
+// compareSummary diffs two same-TraceID TraceSummaries. The `aLabel` /
+// `bLabel` strings end up in the reasons so a downstream reader knows
+// which side reported which value.
 func compareSummary(key string, a, b TraceSummary, aLabel, bLabel string, opts DiffOptions) []DiffReason {
 	var reasons []DiffReason
 
 	if a.RootServiceName != b.RootServiceName {
-		// CanonicalKey hashes (rootServiceName, rootTraceName), so a
-		// mismatch here only happens on hash collision — but we still
-		// report it because a future canonical-key change would surface
-		// here first.
+		// Same TraceID, different rootServiceName — a real backend
+		// regression in how span -> trace rollup picks the root.
 		reasons = append(reasons, DiffReason{
 			Kind:   "field_mismatch",
 			Detail: fmt.Sprintf("key %s: rootServiceName %s=%q vs %s=%q", key, aLabel, a.RootServiceName, bLabel, b.RootServiceName),

--- a/harness/tempo-compatibility/driver/differ_test.go
+++ b/harness/tempo-compatibility/driver/differ_test.go
@@ -24,23 +24,40 @@ func TestCompare_Identical(t *testing.T) {
 	}
 }
 
-func TestCompare_IgnoresTraceIDDifference(t *testing.T) {
+func TestCompare_TraceIDMismatchSurfaces(t *testing.T) {
 	t.Parallel()
-	// Tempo returns a real trace ID; cerberus today returns a synthetic
-	// key. The differ canonicalises on (rootServiceName, rootTraceName)
-	// so the two should still match.
+	// As of PR #439 cerberus emits the real hex(TraceId), so the differ
+	// keys directly on TraceID. Two traces with the same root names but
+	// different TraceIDs are no longer canonicalised together — they
+	// surface as missing_in_a / missing_in_b. This guards the contract
+	// that the differ relies on byte-equal TraceIDs across backends.
 	a := []byte(`{"traces":[
-        {"traceID":"aaaaaaaaaaaaaaaa","rootServiceName":"checkout","rootTraceName":"GET /api/checkout/0","durationMs":150,"startTimeUnixNano":"1000"}
+        {"traceID":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","rootServiceName":"checkout","rootTraceName":"GET /api/checkout/0","durationMs":150,"startTimeUnixNano":"1000"}
     ]}`)
 	b := []byte(`{"traces":[
-        {"traceID":"synthetic|key","rootServiceName":"checkout","rootTraceName":"GET /api/checkout/0","durationMs":150,"startTimeUnixNano":"1000"}
+        {"traceID":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","rootServiceName":"checkout","rootTraceName":"GET /api/checkout/0","durationMs":150,"startTimeUnixNano":"1000"}
     ]}`)
 	d, err := Compare(a, b, "tempo", "cerberus", DefaultDiffOptions())
 	if err != nil {
 		t.Fatalf("Compare: %v", err)
 	}
-	if !d.Equal {
-		t.Fatalf("expected canonical-key match, got reasons=%v", d.Reasons)
+	if d.Equal {
+		t.Fatalf("expected Equal=false on differing TraceIDs, got %+v", d)
+	}
+	foundMissingInA, foundMissingInB := false, false
+	for _, r := range d.Reasons {
+		if r.Kind == "missing_in_a" && strings.Contains(r.Detail, "bbbbbbbb") {
+			foundMissingInA = true
+		}
+		if r.Kind == "missing_in_b" && strings.Contains(r.Detail, "aaaaaaaa") {
+			foundMissingInB = true
+		}
+	}
+	if !foundMissingInA {
+		t.Fatalf("expected missing_in_a reason for tempo-only TraceID, got %+v", d.Reasons)
+	}
+	if !foundMissingInB {
+		t.Fatalf("expected missing_in_b reason for cerberus-only TraceID, got %+v", d.Reasons)
 	}
 }
 
@@ -130,16 +147,21 @@ func TestCompare_InvalidJSONFails(t *testing.T) {
 	}
 }
 
-func TestCanonicalKey_DeterministicAcrossInvocations(t *testing.T) {
+func TestTraceKey_UsesRawTraceID(t *testing.T) {
 	t.Parallel()
-	t1 := TraceSummary{RootServiceName: "checkout", RootTraceName: "GET /api/checkout/0"}
-	t2 := TraceSummary{RootServiceName: "checkout", RootTraceName: "GET /api/checkout/0"}
-	if CanonicalKey(t1) != CanonicalKey(t2) {
-		t.Fatal("expected identical canonical key for identical inputs")
+	// Since PR #439, cerberus and Tempo both emit the real hex(TraceId),
+	// so the differ keys directly on TraceID. The root names are not
+	// part of the key — only the TraceID is — guaranteeing two traces
+	// with the same TraceID align even if their root names differ
+	// (which would then surface as a field_mismatch under the match).
+	t1 := TraceSummary{TraceID: "00000000000000000000000000000001", RootServiceName: "checkout", RootTraceName: "GET /api/checkout/0"}
+	t2 := TraceSummary{TraceID: "00000000000000000000000000000001", RootServiceName: "payments", RootTraceName: "POST /api/payments/0"}
+	if traceKey(t1) != traceKey(t2) {
+		t.Fatal("expected identical traceKey for identical TraceID")
 	}
-	t3 := TraceSummary{RootServiceName: "checkout", RootTraceName: "GET /api/checkout/1"}
-	if CanonicalKey(t1) == CanonicalKey(t3) {
-		t.Fatal("expected different canonical keys for different root names")
+	t3 := TraceSummary{TraceID: "00000000000000000000000000000002", RootServiceName: "checkout", RootTraceName: "GET /api/checkout/0"}
+	if traceKey(t1) == traceKey(t3) {
+		t.Fatal("expected different traceKey for different TraceID")
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-up to PR #439, which made `/api/search` responses emit real hex(TraceId). The Tempo compatibility differ previously canonicalised trace summaries via `SHA-256(rootServiceName || rootTraceName)` because the old synthetic IDs couldn't be compared byte-for-byte across backends. With real TraceIDs that match, the workaround is dead weight.

- Replaces `CanonicalKey(TraceSummary)` (SHA-256 of `rootServiceName || rootTraceName`) with `traceKey(TraceSummary)` returning the raw `TraceID`.
- Drops unused `crypto/sha256` + `encoding/hex` imports.
- Refreshes top-of-file / inline doc comments to describe direct TraceID indexing.
- `differ_test.go`: replaces the obsolete `TestCompare_IgnoresTraceIDDifference` with `TestCompare_TraceIDMismatchSurfaces` (differing TraceIDs should NOT match), and `TestCanonicalKey_DeterministicAcrossInvocations` with `TestTraceKey_UsesRawTraceID`.
- README updates at lines 58, 88-95, and the table at line 115 to reflect the direct-TraceID strategy.

## Why

Audit-trail debt removal — the canonicalisation existed only to mask a placeholder. With the placeholder gone, the workaround was actively misleading (made the differ a less-strict comparison than it needs to be).

## Test plan

- [ ] \`check\` + \`lint\` pass.
- [ ] \`tempo/compatibility\` nightly run shows real TraceIDs comparing directly with no false positives.

## Scope

78 insertions / 71 deletions across 3 files.

## Follow-up note

\`harness/tempo-compatibility/driver/corpus/smoke.txtar\` line 31 still mentions the H(...) canonicalisation. Out of scope per agent's allowlist; trivial follow-up to scrub.