### PR TITLE
feat(traceql): wire second-stage lowering + multi-quantile

### DIFF
--- a/internal/traceql/lower.go
+++ b/internal/traceql/lower.go
@@ -80,19 +80,152 @@ func lowerRoot(expr *traceql.RootExpr, s schema.Traces) (chplan.Node, error) {
 		}
 	}
 	if expr.MetricsSecondStage != nil {
-		// chplan.MetricsSecondStage + chsql.emitMetricsSecondStage now
-		// carry the IR + SQL for `| topk(N)` / `| bottomk(N)` / `| > N`
-		// (see internal/chplan/metrics_second_stage.go +
-		// internal/chsql/metrics_second_stage.go). Wiring the lowering
-		// here is blocked on tsouza/tempo:cerberus-accessors exposing
-		// accessors on the upstream-unexported TopKBottomK.{op,limit}
-		// and MetricsFilter.{op,value} fields (mirrors the
-		// MetricsAggregate accessors added for #143). The fork bump
-		// lands as a follow-up; until then the IR + emitter foundation
-		// is callable directly from chplan-shape tests.
-		return nil, fmt.Errorf("traceql: metrics second-stage operators (`| topk`, `| bottomk`, `| > N`) are not yet supported (chplan + chsql IR landed; lowering wiring blocked on tsouza/tempo SecondStageElement accessors)")
+		plan, err = lowerMetricsSecondStage(plan, expr.MetricsSecondStage)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return plan, nil
+}
+
+// lowerMetricsSecondStage wraps the metrics-aggregate subtree with a
+// chplan.MetricsSecondStage carrying the `| topk(N)` / `| bottomk(N)`
+// / `| > N` / `| < N` / `| >= N` / `| <= N` / `| == N` / `| != N`
+// transform. Chained second-stage (`| topk(5) | > 10`) is supported
+// via traceql.ChainedSecondStage: each element wraps the previous
+// result in document order, so the rightmost element ends up as the
+// outermost chplan node (which matches the chsql emitter's
+// inside-out subquery wrap).
+//
+// The IR + chsql emit foundation landed in PR #437. This lowering
+// became wireable once tsouza/tempo v0.0.3-cerberus-accessors
+// exposed Op() / Limit() / Value() / Elements() / Separators()
+// accessors on the upstream-unexported SecondStageElement variants
+// (mirrors the MetricsAggregate accessor pattern from #143).
+func lowerMetricsSecondStage(inner chplan.Node, ss traceql.SecondStageElement) (chplan.Node, error) {
+	switch v := ss.(type) {
+	case *traceql.TopKBottomK:
+		return lowerTopKBottomK(inner, v)
+	case *traceql.MetricsFilter:
+		return lowerMetricsFilter(inner, v)
+	case traceql.ChainedSecondStage:
+		return lowerChainedSecondStage(inner, v)
+	case *traceql.ChainedSecondStage:
+		return lowerChainedSecondStage(inner, *v)
+	}
+	return nil, fmt.Errorf("traceql: metrics second-stage element %T is not yet supported", ss)
+}
+
+// lowerTopKBottomK turns `| topk(N)` / `| bottomk(N)` into a
+// chplan.MetricsSecondStage wrap with discriminator SecondStageTopK
+// or SecondStageBottomK. K is the upstream limit; the emitter
+// renders `ORDER BY Value <DESC|ASC> LIMIT K` and treats PartitionBy
+// (empty here — TraceQL instant-metrics path; matrix path supplied
+// by the /api/metrics/query_range handler via a wrapping
+// RangeWindow) as the per-anchor key.
+func lowerTopKBottomK(inner chplan.Node, t *traceql.TopKBottomK) (chplan.Node, error) {
+	op, err := mapSecondStageOp(t.Op())
+	if err != nil {
+		return nil, err
+	}
+	limit := t.Limit()
+	if limit <= 0 {
+		return nil, fmt.Errorf("traceql: %s(%d): limit must be > 0", t.Op(), limit)
+	}
+	return &chplan.MetricsSecondStage{
+		Input:      inner,
+		Op:         op,
+		K:          int64(limit),
+		ValueAlias: metricsValueAlias,
+	}, nil
+}
+
+// lowerMetricsFilter turns `| > N` / `| < N` / `| >= N` / `| <= N`
+// / `| == N` / `| != N` into a chplan.MetricsSecondStage with
+// discriminator SecondStageThreshold. The chsql emitter renders the
+// wrap as `WHERE Value <Op> <Value>` on the inner aggregate's row
+// shape.
+func lowerMetricsFilter(inner chplan.Node, f *traceql.MetricsFilter) (chplan.Node, error) {
+	op, err := mapBinaryOp(f.Op())
+	if err != nil {
+		return nil, fmt.Errorf("traceql: metrics filter operator %s: %w", f.Op(), err)
+	}
+	if !isThresholdBinaryOp(op) {
+		return nil, fmt.Errorf("traceql: metrics filter operator %s is not a supported threshold comparison", f.Op())
+	}
+	return &chplan.MetricsSecondStage{
+		Input:          inner,
+		Op:             chplan.SecondStageThreshold,
+		ThresholdOp:    op,
+		ThresholdValue: f.Value(),
+		ValueAlias:     metricsValueAlias,
+	}, nil
+}
+
+// lowerChainedSecondStage walks ChainedSecondStage.Elements() in
+// source order, wrapping the previous result in each successive
+// second-stage node. The first element wraps the upstream metrics
+// aggregate (`inner`); each subsequent element wraps the previous
+// chplan.MetricsSecondStage. The rightmost element in the TraceQL
+// source ends up as the outermost chplan node, matching the
+// inside-out subquery wrap the chsql emitter renders (see
+// test/spec/chsql/metrics_second_stage_chained_topk_threshold.txtar).
+//
+// Separators() carries the pipeline punctuation upstream uses for
+// String() round-trip fidelity. The lowering does not care about
+// the punctuation per se (it's a chained pipe stream — the wrapping
+// order is what matters), but the accessor existence keeps the
+// upstream contract explicit for future regression cases.
+func lowerChainedSecondStage(inner chplan.Node, c traceql.ChainedSecondStage) (chplan.Node, error) {
+	elements := c.Elements()
+	if len(elements) == 0 {
+		return nil, fmt.Errorf("traceql: chained second-stage has no elements")
+	}
+	// Validate Separators() length matches Elements() so a future
+	// upstream change (e.g. dropping a separator slot) trips this
+	// check rather than silently dropping a wrap.
+	if seps := c.Separators(); len(seps) != len(elements) {
+		return nil, fmt.Errorf("traceql: chained second-stage element/separator length mismatch (%d vs %d)", len(elements), len(seps))
+	}
+	current := inner
+	for _, el := range elements {
+		next, err := lowerMetricsSecondStage(current, el)
+		if err != nil {
+			return nil, err
+		}
+		current = next
+	}
+	return current, nil
+}
+
+// mapSecondStageOp translates Tempo's SecondStageOp (OpTopK /
+// OpBottomK) to the chplan discriminator. Reserved-for-future
+// SecondStageOp values surface as a clean unsupported error rather
+// than collapse to SecondStageInvalid (which the emitter would
+// reject anyway).
+func mapSecondStageOp(op traceql.SecondStageOp) (chplan.SecondStageOp, error) {
+	switch op {
+	case traceql.OpTopK:
+		return chplan.SecondStageTopK, nil
+	case traceql.OpBottomK:
+		return chplan.SecondStageBottomK, nil
+	}
+	return chplan.SecondStageInvalid, fmt.Errorf("traceql: second-stage op %s is not supported", op)
+}
+
+// isThresholdBinaryOp reports whether op is one of the six
+// comparison operators Tempo's `MetricsFilter.validate()` accepts
+// (>, >=, <, <=, =, !=). Mirrors chsql.isThresholdOp; duplicated
+// here because the chsql helper is unexported and importing
+// chsql from a lowering package would create the wrong dep
+// direction (chsql consumes chplan; chsql consuming lowering would
+// invert the layering).
+func isThresholdBinaryOp(op chplan.BinaryOp) bool {
+	switch op {
+	case chplan.OpGt, chplan.OpGe, chplan.OpLt, chplan.OpLe, chplan.OpEq, chplan.OpNe:
+		return true
+	}
+	return false
 }
 
 // lowerFollowingElement layers a pipeline element onto the previous

--- a/internal/traceql/metrics_pipeline.go
+++ b/internal/traceql/metrics_pipeline.go
@@ -98,10 +98,18 @@ func lowerMetricsAggregate(prev chplan.Node, agg *traceql.MetricsAggregate, s sc
 		if len(qs) == 0 {
 			return nil, fmt.Errorf("traceql: quantile_over_time requires at least one quantile")
 		}
-		if len(qs) > 1 {
-			return nil, fmt.Errorf("traceql: multi-quantile quantile_over_time is not yet supported (got %d quantiles)", len(qs))
-		}
-		quantiles = []float64{qs[0]}
+		// Multi-quantile is accepted at the lowering layer (v0.0.3
+		// fork accessors expose the full slice via Quantiles()); the
+		// emitted plan carries all phi values on
+		// chplan.MetricsAggregate.Quantiles so a future chsql emit
+		// path can render one output series per phi with a synth
+		// `__phi__` label. The current chsql emitter still caps at
+		// one quantile per MetricsAggregate (see
+		// internal/chsql/range_window.go::metricsAggregateCH); the
+		// lowering succeeds either way so callers can introspect
+		// the IR.
+		quantiles = make([]float64, len(qs))
+		copy(quantiles, qs)
 	}
 
 	return &chplan.MetricsAggregate{

--- a/internal/traceql/metrics_pipeline_test.go
+++ b/internal/traceql/metrics_pipeline_test.go
@@ -2,7 +2,6 @@ package traceql_test
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	tempo "github.com/grafana/tempo/pkg/traceql"
@@ -166,57 +165,88 @@ func TestLowerMetricsPipeline(t *testing.T) {
 	}
 }
 
-// TestLowerMetricsPipelineUnsupported documents the cases that
-// surface as clean errors rather than panicking.
+// All previously deferred metrics-pipeline forms now lower:
 //
-// `histogram_over_time(...)` is no longer here — it lowers to a
-// chplan.MetricsHistogramOverTime node; see TestLowerHistogramOverTime
-// in histogram_over_time_test.go.
+//   - `histogram_over_time(...)` → chplan.MetricsHistogramOverTime
+//     (TestLowerHistogramOverTime in histogram_over_time_test.go).
+//   - `avg_over_time(...)` → chplan.MetricsAggregate{Op:
+//     MetricsOpAvgOverTime} via lowerAverageOverTime, which unwraps
+//     the Tempo fork's exported AverageOverTimeAggregator type
+//     (#430).
+//   - `| topk(N)` / `| bottomk(N)` / `| > N` / chained second-stage
+//     → chplan.MetricsSecondStage via lowerMetricsSecondStage; see
+//     TestLowerMetricsSecondStage below.
+//   - `quantile_over_time(attr, q1, q2, ...)` → multi-element
+//     chplan.MetricsAggregate.Quantiles; see
+//     TestLowerMetricsMultiQuantile below.
 //
-// `| > 0` (MetricsSecondStage) is deferred until the second-stage
-// filter / topk lowering lands.
+// TestLowerMetricsPipelineUnsupported has therefore been retired.
+// A future deferred form (e.g. an unsupported PipelineElement kind)
+// should land its own focused test rather than reviving a generic
+// "everything that errors" pool.
+
+// TestLowerMetricsSecondStage asserts that the `| topk(N)` /
+// `| bottomk(N)` / `| > N` / `| < N` / `| >= N` / `| <= N` /
+// `| == N` / `| != N` and chained second-stage forms lower
+// successfully into a chplan.MetricsSecondStage wrapping the
+// upstream MetricsAggregate.
 //
-// `avg_over_time(...)` is no longer deferred — it lowers to a
-// chplan.MetricsAggregate{Op: MetricsOpAvgOverTime} node via
-// lowerAverageOverTime, which unwraps the Tempo fork's exported
-// AverageOverTimeAggregator type.
-func TestLowerMetricsPipelineUnsupported(t *testing.T) {
+// The wrap order for chained second-stage is bottom-up: each
+// successive element in ChainedSecondStage.Elements() wraps the
+// previous result, so the rightmost source element ends up as
+// the outermost chplan node (matches the chsql inside-out
+// subquery wrap).
+func TestLowerMetricsSecondStage(t *testing.T) {
 	t.Parallel()
 
 	s := schema.DefaultOTelTraces()
 
 	cases := []struct {
-		name       string
-		query      string
-		wantSubstr string
+		name         string
+		query        string
+		wantOuterOp  chplan.SecondStageOp
+		wantK        int64
+		wantThreshOp chplan.BinaryOp
+		wantThreshV  float64
+		wantDepth    int // total chained MetricsSecondStage wraps
 	}{
 		{
-			name:       "quantile_over_time_multi_deferred",
-			query:      `{} | quantile_over_time(duration, 0.5, 0.9, 0.99)`,
-			wantSubstr: "multi-quantile",
+			name:        "topk",
+			query:       `{} | rate() | topk(5)`,
+			wantOuterOp: chplan.SecondStageTopK,
+			wantK:       5,
+			wantDepth:   1,
 		},
 		{
-			// Second-stage topk/bottomk/threshold land in two phases:
-			// the chplan+chsql foundation is in place (see
-			// chplan/metrics_second_stage.go,
-			// chsql/metrics_second_stage.go) but the traceql lowering
-			// is blocked on tsouza/tempo accessors for the
-			// unexported TopKBottomK / MetricsFilter fields. Until
-			// that fork bump lands, the lowering returns a clean
-			// "not yet supported" with a pointer to the foundation.
-			name:       "second_stage_topk_deferred",
-			query:      `{} | rate() | topk(5)`,
-			wantSubstr: "second-stage",
+			name:        "bottomk",
+			query:       `{} | rate() | bottomk(3)`,
+			wantOuterOp: chplan.SecondStageBottomK,
+			wantK:       3,
+			wantDepth:   1,
 		},
 		{
-			name:       "second_stage_bottomk_deferred",
-			query:      `{} | rate() | bottomk(3)`,
-			wantSubstr: "second-stage",
+			name:         "threshold_gt",
+			query:        `{} | rate() > 10`,
+			wantOuterOp:  chplan.SecondStageThreshold,
+			wantThreshOp: chplan.OpGt,
+			wantThreshV:  10,
+			wantDepth:    1,
 		},
 		{
-			name:       "second_stage_threshold_deferred",
-			query:      `{} | rate() | > 10`,
-			wantSubstr: "second-stage",
+			name:         "threshold_le",
+			query:        `{} | rate() <= 1.5`,
+			wantOuterOp:  chplan.SecondStageThreshold,
+			wantThreshOp: chplan.OpLe,
+			wantThreshV:  1.5,
+			wantDepth:    1,
+		},
+		{
+			name:         "chained_topk_threshold",
+			query:        `{} | rate() | topk(5) > 10`,
+			wantOuterOp:  chplan.SecondStageThreshold,
+			wantThreshOp: chplan.OpGt,
+			wantThreshV:  10,
+			wantDepth:    2,
 		},
 	}
 
@@ -227,19 +257,94 @@ func TestLowerMetricsPipelineUnsupported(t *testing.T) {
 
 			expr, err := tempo.Parse(tc.query)
 			if err != nil {
-				// Some forms may fail to parse upstream — the test
-				// is documenting what cerberus surfaces, so a parser
-				// error is acceptable for these deferred forms.
-				return
+				t.Fatalf("Parse(%q): %v", tc.query, err)
 			}
-			_, err = traceql.Lower(context.Background(), expr, s)
-			if err == nil {
-				t.Fatalf("Lower(%q): expected error, got nil", tc.query)
+			plan, err := traceql.Lower(context.Background(), expr, s)
+			if err != nil {
+				t.Fatalf("Lower(%q): %v", tc.query, err)
 			}
-			if !strings.Contains(err.Error(), tc.wantSubstr) {
-				t.Errorf("Lower(%q) error = %q, want substring %q",
-					tc.query, err.Error(), tc.wantSubstr)
+
+			ss, ok := plan.(*chplan.MetricsSecondStage)
+			if !ok {
+				t.Fatalf("expected outermost node to be *chplan.MetricsSecondStage, got %T", plan)
+			}
+			if ss.Op != tc.wantOuterOp {
+				t.Errorf("MetricsSecondStage.Op = %v, want %v", ss.Op, tc.wantOuterOp)
+			}
+			if tc.wantOuterOp == chplan.SecondStageTopK || tc.wantOuterOp == chplan.SecondStageBottomK {
+				if ss.K != tc.wantK {
+					t.Errorf("MetricsSecondStage.K = %d, want %d", ss.K, tc.wantK)
+				}
+			}
+			if tc.wantOuterOp == chplan.SecondStageThreshold {
+				if ss.ThresholdOp != tc.wantThreshOp {
+					t.Errorf("MetricsSecondStage.ThresholdOp = %v, want %v", ss.ThresholdOp, tc.wantThreshOp)
+				}
+				if ss.ThresholdValue != tc.wantThreshV {
+					t.Errorf("MetricsSecondStage.ThresholdValue = %v, want %v", ss.ThresholdValue, tc.wantThreshV)
+				}
+			}
+			if ss.ValueAlias != "Value" {
+				t.Errorf("MetricsSecondStage.ValueAlias = %q, want %q", ss.ValueAlias, "Value")
+			}
+
+			// Walk the nested chain — count how many
+			// MetricsSecondStage wraps stack on top of the
+			// MetricsAggregate.
+			depth := 0
+			cur := chplan.Node(ss)
+			for {
+				inner, ok := cur.(*chplan.MetricsSecondStage)
+				if !ok {
+					break
+				}
+				depth++
+				cur = inner.Input
+			}
+			if depth != tc.wantDepth {
+				t.Errorf("chained MetricsSecondStage depth = %d, want %d", depth, tc.wantDepth)
+			}
+			// Innermost child should be the metrics aggregate.
+			if _, ok := cur.(*chplan.MetricsAggregate); !ok {
+				t.Errorf("expected innermost wrapped node to be *chplan.MetricsAggregate, got %T", cur)
 			}
 		})
+	}
+}
+
+// TestLowerMetricsMultiQuantile asserts that multi-quantile
+// `quantile_over_time(attr, q1, q2, q3)` lowers into a single
+// chplan.MetricsAggregate whose Quantiles slice carries every phi
+// in source order. The chsql emit path for the multi-quantile
+// shape (one output series per phi labelled with `__phi__`) lives
+// outside this lowering test; this case pins the IR contract.
+func TestLowerMetricsMultiQuantile(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelTraces()
+
+	expr, err := tempo.Parse(`{} | quantile_over_time(duration, 0.5, 0.9, 0.99)`)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	plan, err := traceql.Lower(context.Background(), expr, s)
+	if err != nil {
+		t.Fatalf("Lower: %v", err)
+	}
+	ma, ok := plan.(*chplan.MetricsAggregate)
+	if !ok {
+		t.Fatalf("expected *chplan.MetricsAggregate, got %T", plan)
+	}
+	if ma.Op != chplan.MetricsOpQuantileOverTime {
+		t.Errorf("MetricsAggregate.Op = %v, want %v", ma.Op, chplan.MetricsOpQuantileOverTime)
+	}
+	want := []float64{0.5, 0.9, 0.99}
+	if len(ma.Quantiles) != len(want) {
+		t.Fatalf("len(Quantiles) = %d, want %d", len(ma.Quantiles), len(want))
+	}
+	for i := range want {
+		if ma.Quantiles[i] != want[i] {
+			t.Errorf("Quantiles[%d] = %v, want %v", i, ma.Quantiles[i], want[i])
+		}
 	}
 }

--- a/test/spec/traceql/metrics_bottomk.txtar
+++ b/test/spec/traceql/metrics_bottomk.txtar
@@ -1,0 +1,23 @@
+-- query.traceql --
+{} | rate() | bottomk(3)
+-- sql --
+SELECT * FROM (SELECT toFloat64(count(?)) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE ?)) ORDER BY `Value` LIMIT 3
+-- args --
+[0] int64 = 1
+[1] bool = true
+-- seed --
+CREATE TABLE otel_traces (
+    Duration UInt64
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    (10000000),
+    (20000000);
+-- expected_rows --
+[
+  [2]
+]
+-- chplan --
+MetricsSecondStage op=bottomk k=3 valueAlias=Value
+  MetricsAggregate op=rate valueAlias=Value
+    Filter predicate=true
+      Scan(otel_traces)

--- a/test/spec/traceql/metrics_chained.txtar
+++ b/test/spec/traceql/metrics_chained.txtar
@@ -1,0 +1,26 @@
+-- query.traceql --
+{} | rate() | topk(5) > 1
+-- sql --
+SELECT * FROM (SELECT * FROM (SELECT toFloat64(count(?)) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE ?)) ORDER BY `Value` DESC LIMIT 5) WHERE (`Value` > ?)
+-- args --
+[0] int64 = 1
+[1] bool = true
+[2] float64 = 1
+-- seed --
+CREATE TABLE otel_traces (
+    Duration UInt64
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    (10000000),
+    (20000000),
+    (30000000);
+-- expected_rows --
+[
+  [3]
+]
+-- chplan --
+MetricsSecondStage op=threshold threshold=(> 1) valueAlias=Value
+  MetricsSecondStage op=topk k=5 valueAlias=Value
+    MetricsAggregate op=rate valueAlias=Value
+      Filter predicate=true
+        Scan(otel_traces)

--- a/test/spec/traceql/metrics_threshold.txtar
+++ b/test/spec/traceql/metrics_threshold.txtar
@@ -1,0 +1,37 @@
+-- query.traceql --
+{} | rate() > 10
+-- sql --
+SELECT * FROM (SELECT toFloat64(count(?)) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE ?)) WHERE (`Value` > ?)
+-- args --
+[0] int64 = 1
+[1] bool = true
+[2] float64 = 10
+-- seed --
+CREATE TABLE otel_traces (
+    Duration UInt64
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    (10000000),
+    (20000000),
+    (30000000),
+    (40000000),
+    (50000000),
+    (60000000),
+    (70000000),
+    (80000000),
+    (90000000),
+    (100000000),
+    (110000000),
+    (120000000),
+    (130000000),
+    (140000000),
+    (150000000);
+-- expected_rows --
+[
+  [15]
+]
+-- chplan --
+MetricsSecondStage op=threshold threshold=(> 10) valueAlias=Value
+  MetricsAggregate op=rate valueAlias=Value
+    Filter predicate=true
+      Scan(otel_traces)

--- a/test/spec/traceql/metrics_topk.txtar
+++ b/test/spec/traceql/metrics_topk.txtar
@@ -1,0 +1,26 @@
+-- query.traceql --
+{ resource.service.name = "checkout" } | rate() | topk(5)
+-- sql --
+SELECT * FROM (SELECT toFloat64(count(?)) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?))) ORDER BY `Value` DESC LIMIT 5
+-- args --
+[0] int64 = 1
+[1] string = "service.name"
+[2] string = "checkout"
+-- seed --
+CREATE TABLE otel_traces (
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    (map('service.name', 'checkout')),
+    (map('service.name', 'checkout')),
+    (map('service.name', 'checkout')),
+    (map('service.name', 'inventory'));
+-- expected_rows --
+[
+  [3]
+]
+-- chplan --
+MetricsSecondStage op=topk k=5 valueAlias=Value
+  MetricsAggregate op=rate valueAlias=Value
+    Filter predicate=(ResourceAttributes["service.name"] = "checkout")
+      Scan(otel_traces)


### PR DESCRIPTION
## Summary

- Wires `internal/traceql/lower.go` to lower `| topk(N)` / `| bottomk(N)` / `| > N` / chained second-stage onto `chplan.MetricsSecondStage` using the v0.0.3-cerberus-accessors fork accessors (`Op()` / `Limit()` / `Value()` / `Elements()` / `Separators()`).
- Relaxes multi-quantile lowering in `internal/traceql/metrics_pipeline.go` to populate `chplan.MetricsAggregate.Quantiles` with every phi instead of rejecting at parse time.
- Retires `TestLowerMetricsPipelineUnsupported` (all cases lower now); adds `TestLowerMetricsSecondStage` (5 sub-tests: topk / bottomk / 2 thresholds / chained) + `TestLowerMetricsMultiQuantile`.
- Four TXTAR roundtrip fixtures: `metrics_topk` / `metrics_bottomk` / `metrics_threshold` / `metrics_chained` covering chplan IR + SQL + seed + expected_rows.

## Why

Pre-GA Maximal-GA push. PR #437 + #445 shipped the chplan / chsql foundation; this PR completes the TraceQL surface for second-stage operators now that the fork accessors are reachable via v0.0.3-cerberus-accessors.

## Test plan

- [ ] `check` + `lint` pass.
- [ ] `roundtrip (traceql)` exercises the 4 new fixtures.

## Known follow-ups (out of scope)

1. **Multi-quantile emit cap**: `internal/chsql/range_window.go::metricsAggregateCH` still caps at `len(Quantiles) == 1`. The lowering contract is pinned by `TestLowerMetricsMultiQuantile`; the emitter needs to either (a) fan out into N `quantile(phi_i)(arg)` aggregates with a synth `__phi__` label per output series, or (b) emit `quantiles(p1, p2, ...)(arg)` returning an array column. Separate PR.
2. **docs/compatibility.md** still references the now-stale "blocked on tsouza/tempo accessors" / "multi-quantile not yet supported" wording; refresh in a follow-up doc-only PR.