### PR TITLE
test(promql): fix float precision in subquery_over bottomk/quantile expected_rows

### DIFF
--- a/test/spec/promql/subquery_over_bottomk.txtar
+++ b/test/spec/promql/subquery_over_bottomk.txtar
@@ -16,7 +16,7 @@ INSERT INTO otel_metrics_sum VALUES
     ('http_requests_total', map('job', 'api', 'instance', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 60.0);
 -- expected_rows --
 [
-  [{"instance": "b", "job": "api"}, 0.21388888888888888]
+  [{"instance": "b", "job": "api"}, 0.2138888888888889]
 ]
 -- args --
 [0] string = "http_requests_total"

--- a/test/spec/promql/subquery_over_quantile.txtar
+++ b/test/spec/promql/subquery_over_quantile.txtar
@@ -16,7 +16,7 @@ INSERT INTO otel_metrics_sum VALUES
     ('http_requests_total', map('job', 'api', 'instance', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 60.0);
 -- expected_rows --
 [
-  [{"job": "api"}, 0.3208333333333333]
+  [{"job": "api"}, 0.32083333333333336]
 ]
 -- args --
 [0] string = "job"


### PR DESCRIPTION
## Summary

- PR #447 merged with chDB `roundtrip (promql)` failing on `subquery_over_bottomk` and `subquery_over_quantile` (chdb is not a required check, so the merge wasn't blocked).
- Hand-authored `expected_rows` used a one-ULP-lower float64 representation than the value chDB actually computes:
  - `bottomk`: `0.21388888888888888` → `0.2138888888888889`
  - `quantile`: `0.3208333333333333` → `0.32083333333333336`
- The emitted SQL is mathematically correct; the goldens were imprecisely printed.

## Test plan

- [x] `go test -tags chdb -count=1 -run "TestRoundTripChDB/subquery_over_" ./test/spec/promql/` — all 13 round-trip fixtures pass.
- [ ] CI `chdb` workflow `roundtrip (promql)` job goes green.