### PR TITLE
fix(logql): project Attributes (not ResourceAttributes) in projectValueOverLogInner

### DIFF
--- a/internal/logql/binary.go
+++ b/internal/logql/binary.go
@@ -316,16 +316,23 @@ func projectValueOverLogInner(inner chplan.Node, s schema.Logs, newValue chplan.
 		}
 	}
 	// Vector-aggregation output (post-wrapVectorAggregateForSample) and
-	// the synthetic literal/vector(...) output both expose the
-	// canonical (MetricName, Attributes, TimeUnix, Value) shape via
-	// the LogQL Sample contract. lowerLiteral / lowerVector keep only
-	// (ResourceAttributes, Value), so we forward whichever subset is
-	// in scope by emitting an aliased projection that the emitter
-	// resolves at SQL-build time.
+	// the synthetic literal/vector(...) output expose different
+	// stream-identity columns: a vector aggregation has already been
+	// projected to the canonical (MetricName, Attributes, TimeUnix,
+	// Value) shape — at that point `ResourceAttributes` is gone (the
+	// Aggregate's GROUP BY consumed it) and identity rides under
+	// `Attributes`. lowerLiteral / lowerVector / label_replace keep
+	// only (ResourceAttributes, Value). Pick the right column based on
+	// inner shape — mirrors the same switch sampleShapeOverLogInner
+	// uses (see also Lang.ProjectSamples).
+	attrsCol := s.ResourceAttributesColumn
+	if isVectorAggregateSampleShape(inner) {
+		attrsCol = "Attributes"
+	}
 	return &chplan.Project{
 		Input: inner,
 		Projections: []chplan.Projection{
-			{Expr: &chplan.ColumnRef{Name: s.ResourceAttributesColumn}},
+			{Expr: &chplan.ColumnRef{Name: attrsCol}},
 			{Expr: newValue, Alias: rangeAggSynthValueColumn},
 		},
 	}


### PR DESCRIPTION
## Summary

Mirrors PR #433's fix in `Lang.ProjectSamples`: when the inner plan has already been projected to the canonical Sample contract via `wrapVectorAggregateForSample`, the `ResourceAttributes` column is gone (consumed by the Aggregate's GROUP BY) and stream identity rides under the `Attributes` alias. `projectValueOverLogInner` in `internal/logql/binary.go:308` had the same blind `ResourceAttributesColumn` reference that the in-tree `sampleShapeOverLogInner` helper already learned to dispatch on via `isVectorAggregateSampleShape`.

## Why

Before this fix, queries like `<scalar> * sum(count_over_time(...))` would surface as 502 `Unknown identifier ResourceAttributes` from ClickHouse. The harness corpus doesn't exercise this shape today, so the bug was latent — flagged at PR #433 review.

## Test plan

- [ ] `check` + `lint` pass.

## Scope

Single function, 14-line diff in `internal/logql/binary.go`. No new tests — the existing `binary_test.go` table covers the scalar × sum(count_over_time(...)) shape once the lowering doesn't error.