### PR TITLE
fix(optimizer): walk TopK.KExpr in rewriteChildren

### DIFF
--- a/internal/optimizer/rule.go
+++ b/internal/optimizer/rule.go
@@ -307,11 +307,21 @@ func rewriteChildren(n chplan.Node, fn func(chplan.Node) (chplan.Node, bool)) (c
 		return &cp, true
 	case *chplan.TopK:
 		newInput, ch := fn(v.Input)
-		if !ch {
+		var newKExpr chplan.Node
+		kCh := false
+		if v.KExpr != nil {
+			newKExpr, kCh = fn(v.KExpr)
+		}
+		if !ch && !kCh {
 			return v, false
 		}
 		cp := *v
-		cp.Input = newInput
+		if ch {
+			cp.Input = newInput
+		}
+		if kCh {
+			cp.KExpr = newKExpr
+		}
 		return &cp, true
 	}
 	return n, false


### PR DESCRIPTION
## Summary

PR #445 added the computed-K topk variant — `TopK.KExpr` is a `chplan.Node` subtree whose evaluation yields the LIMIT cardinality. The optimizer's `rewriteChildren` switch in `internal/optimizer/rule.go` only walked `TopK.Input`, so optimizer rules couldn't reach the K subtree. Extends the TopK case to also rewrite `KExpr` — matches `chplan.TopK.Children()` which already returns both `Input` and `KExpr`.

## Why

No current rule targets the K subtree, but the asymmetry between `Children()` and `rewriteChildren()` is the kind of bug that bites later when someone adds a TopK pushdown / constant-folding rule.

## Test plan

- [ ] `check` + `lint` pass.

## Scope

12-line diff in a single file.