### PR TITLE
fix(api/tempo): log exemplars emit / query failures via slog.Warn

### DIFF
--- a/internal/api/tempo/metrics_query_range.go
+++ b/internal/api/tempo/metrics_query_range.go
@@ -259,9 +259,18 @@ func (h *Handler) handleMetricsQueryRange(w http.ResponseWriter, r *http.Request
 
 	exSQL, exArgs, exErr := chsql.EmitMetricsExemplars(ctx, rw, metrics,
 		h.Schema.TraceIDColumn, h.Schema.SpanIDColumn, 1)
-	if exErr == nil {
+	if exErr != nil {
+		// Emit failure: the matrix response still ships with an empty
+		// `Exemplars` array per Tempo's wire shape. Warn so production
+		// can see this rather than silently degrade.
+		h.Logger.Warn("cerberus tempo metrics_query_range exemplars emit failed (matrix returns without exemplars)", "err", exErr)
+	} else {
 		exSamples, qErr := h.Client.Query(ctx, exSQL, exArgs...)
-		if qErr == nil {
+		if qErr != nil {
+			// Execution failure: same wire shape applies. Warn so a
+			// transient CH failure doesn't go unnoticed.
+			h.Logger.Warn("cerberus tempo metrics_query_range exemplars query failed (matrix returns without exemplars)", "err", qErr)
+		} else {
 			attachExemplars(series, exSamples, metrics)
 		}
 	}


### PR DESCRIPTION
## Summary

PR #435 wired the Tempo metrics-endpoint exemplars data path with a best-effort fallback: if the EmitMetricsExemplars call or the chDB query fails, the matrix response still ships with an empty `Exemplars` array per Tempo's wire shape. Before this PR, both error paths were swallowed silently. Now both emit `h.Logger.Warn` with the err so operators can see degraded states rather than guessing.

## Why

Flagged at PR #435 review (task #14). Wire shape unchanged — the matrix response still ships; only the diagnostic visibility changes.

## Test plan

- [ ] `check` + `lint` pass.

## Scope

11-line diff in `internal/api/tempo/metrics_query_range.go`. No new Prometheus counter — slog Warn is the existing diagnostic primitive in this package; adding a dedicated counter would require new wiring in `internal/telemetry/metrics.go::Instruments` plus reader injection, which is bigger than warranted for a soft-fail observability gap.