### PR TITLE
test(logql): regenerate expected_rows for parser_json_bare / parser_json_typed

### DIFF
--- a/test/spec/logql/parser_json_bare.txtar
+++ b/test/spec/logql/parser_json_bare.txtar
@@ -20,8 +20,8 @@ INSERT INTO otel_logs (Body) VALUES
     ('{"ts":"2025-01-01","level":"error","msg":"retry"}');
 -- expected_rows --
 [
-  ["{\"ts\":\"2025-01-01\",\"level\":\"error\",\"msg\":\"oops\"}"],
-  ["{\"ts\":\"2025-01-01\",\"level\":\"error\",\"msg\":\"retry\"}"]
+  [{"level": "error", "msg": "oops", "ts": "2025-01-01"}],
+  [{"level": "error", "msg": "retry", "ts": "2025-01-01"}]
 ]
 -- chplan --
 Filter predicate=((ResourceAttributes["job"] = "api") AND (mapConcat(ResourceAttributes, CAST(JSONExtractKeysAndValues(Body, "String"), "Map(String,String)"))["level"] = "error"))

--- a/test/spec/logql/parser_json_typed.txtar
+++ b/test/spec/logql/parser_json_typed.txtar
@@ -20,8 +20,8 @@ INSERT INTO otel_logs (Body) VALUES
     ('{"ts":"2025-01-01","severity":"error","msg":"retry"}');
 -- expected_rows --
 [
-  ["{\"ts\":\"2025-01-01\",\"severity\":\"error\",\"msg\":\"oops\"}"],
-  ["{\"ts\":\"2025-01-01\",\"severity\":\"error\",\"msg\":\"retry\"}"]
+  [{"msg": "oops", "severity": "error", "ts": "2025-01-01"}],
+  [{"msg": "retry", "severity": "error", "ts": "2025-01-01"}]
 ]
 -- chplan --
 Filter predicate=((ResourceAttributes["job"] = "api") AND (mapConcat(ResourceAttributes, map("level", JSONExtractString(Body, "severity")))["level"] = "error"))


### PR DESCRIPTION
## Summary

PR #449's hand-authored `expected_rows:` blocks for `test/spec/logql/parser_json_bare.txtar` and `parser_json_typed.txtar` had JSON-string literals (`"{\"ts\":...}"`) where the chDB test runner returns parsed `map[string]any` objects. SQL / args / chplan / seed are unchanged — only the goldens are regenerated.

## Why

Currently failing `TestRoundTripChDB/parser_json_*` on main, blocking downstream PRs (#456, #457). Diff is 4 lines (2 per fixture).

## Root cause (corrected)

This is **not** the same float-precision class as PR #451. Instead, `test/spec/runner_chdb.go::decodeString` (lines 702-711) auto-JSON-decodes any string cell starting with `{` or `[` — a design choice for Map columns wrapped via `toJSONString(...)`. The fixtures' Body column holds raw JSON strings, so the runner returns them as parsed objects, not literal strings.

## Test plan

- [ ] `roundtrip (logql)` for `parser_json_bare` + `parser_json_typed` passes.

## Follow-up

The bug is arguably in the test infra: a fixture author writing `Body` literally has no way to know the runner will auto-parse `{`-prefixed strings. A follow-up could add an opt-out flag or make `decodeString` strictly typed against the SELECT projection. Out of scope here.