### PR TITLE
refactor(harness/tempo-compat): drop SkipReason mechanism from corpus parser

### DIFF
--- a/harness/tempo-compatibility/driver/corpus.go
+++ b/harness/tempo-compatibility/driver/corpus.go
@@ -48,7 +48,12 @@
 //	                            check names; each check runs per-backend against
 //	                            the parsed response (see differ.go::SemanticChecks
 //	                            for the registered names)
-//	-- skip_reason --           if non-empty, the case is parsed but skipped
+//
+// There is intentionally no opt-out marker on a per-case basis: a case
+// that can't run is removed from the corpus, not flagged. Keeping the
+// corpus a strict declaration of "this must diff cleanly" eliminates the
+// "stub it for later" failure mode where a future contributor forgets to
+// turn the case back on once the missing functionality lands.
 //
 // Cases are separated by the next `-- name --` header. Lines starting
 // with `#` outside section bodies are comments. Inside a section body,
@@ -79,7 +84,7 @@ import (
 // CorpusCase is one entry parsed out of the TXTAR file.
 //
 // Every field except Name + Query + Endpoint is optional; the differ
-// applies whichever assertions are populated and skips the rest. That
+// applies whichever assertions are populated and ignores the rest. That
 // keeps the corpus author free to add narrow per-case assertions without
 // having to populate the whole schema.
 type CorpusCase struct {
@@ -130,12 +135,6 @@ type CorpusCase struct {
 	// "60s", "1m", or plain seconds). An empty Step on a metrics_range
 	// case is a validation error.
 	Step string
-
-	// SkipReason, when non-empty, makes the case parse but skip during
-	// diffing. Used to declare future-shaped cases in the smoke corpus so
-	// the file stays the single source of truth for the eventual full
-	// corpus while keeping CI green.
-	SkipReason string
 
 	// ExpectedMinTraces / ExpectedMaxTraces bound the cardinality both
 	// backends must agree with. Zero (the default) disables the bound.
@@ -213,7 +212,6 @@ const (
 	secTagName          = "tag_name"
 	secScope            = "scope"
 	secStep             = "step"
-	secSkipReason       = "skip_reason"
 	secMinTraces        = "expected_min_traces"
 	secMaxTraces        = "expected_max_traces"
 	secMinValues        = "expected_min_values"
@@ -266,8 +264,6 @@ func applySection(cur *CorpusCase, section, body string) error {
 		cur.Scope = body
 	case secStep:
 		cur.Step = body
-	case secSkipReason:
-		cur.SkipReason = body
 	case secMinTraces:
 		return applyIntSection(body, "expected_min_traces", &cur.ExpectedMinTraces)
 	case secMaxTraces:
@@ -359,7 +355,7 @@ func validateCase(cur CorpusCase, ord int) (CorpusCase, error) {
 	if cur.Scope != "" && cur.Endpoint != "tags_v2" {
 		return cur, fmt.Errorf("case %q: -- scope -- is only valid for endpoint=tags_v2 (got %s)", cur.Name, cur.Endpoint)
 	}
-	if cur.Endpoint == "metrics_range" && cur.Step == "" && cur.SkipReason == "" {
+	if cur.Endpoint == "metrics_range" && cur.Step == "" {
 		return cur, fmt.Errorf("case %q: endpoint=metrics_range requires -- step -- (e.g. \"60s\")", cur.Name)
 	}
 	return cur, nil
@@ -381,7 +377,7 @@ func isTagEndpoint(ep string) bool {
 func isKnownSection(name string) bool {
 	switch name {
 	case secQuery, secEndpoint, secTraceIDTemplate, secTagName, secScope,
-		secStep, secSkipReason,
+		secStep,
 		secMinTraces, secMaxTraces, secMinValues, secMaxValues,
 		secValues, secScopes, secServices, secRootNameRE,
 		secMinSeries, secMaxSeries, secSamplesPerSeries, secSemanticChecks:

--- a/harness/tempo-compatibility/driver/corpus/smoke.txtar
+++ b/harness/tempo-compatibility/driver/corpus/smoke.txtar
@@ -3,10 +3,9 @@
 # PR 4 lifted-and-adapted the cases from harness/prometheus-compliance/
 # shadow/traceql_shadow_test.go::traceqlInstantCases(). PR 5 extended the
 # corpus with /api/metrics/query_range + /api/metrics/query cases and
-# added the semantic-consistency layer (see differ.go::SemanticConsistency);
-# the three metrics_instant cases were stubbed via `skip_reason` while
-# the cerberus /api/metrics/query handler was pending and were turned
-# on when the handler landed.
+# added the semantic-consistency layer (see differ.go::SemanticConsistency).
+# The three metrics_instant cases activated alongside the cerberus
+# /api/metrics/query handler (see internal/api/tempo/metrics_query_instant.go).
 #
 # The shadow test runs the SAME 20 search categories against a fake
 # in-process span set; this corpus runs the SAME categories against

--- a/harness/tempo-compatibility/driver/corpus_test.go
+++ b/harness/tempo-compatibility/driver/corpus_test.go
@@ -29,8 +29,6 @@ status_error
 search
 -- expected_min_traces --
 0
--- skip_reason --
-metrics endpoint
 `
 	got, err := parseCorpus(strings.NewReader(in), "test")
 	if err != nil {
@@ -51,8 +49,8 @@ metrics endpoint
 	if len(got[0].ExpectedServices) != 1 || got[0].ExpectedServices[0] != "checkout" {
 		t.Fatalf("case[0] services = %v", got[0].ExpectedServices)
 	}
-	if got[1].SkipReason != "metrics endpoint" {
-		t.Fatalf("case[1] skip = %q", got[1].SkipReason)
+	if got[1].Name != "status_error" {
+		t.Fatalf("case[1] name = %q", got[1].Name)
 	}
 }
 
@@ -155,6 +153,24 @@ y
 	}
 }
 
+// TestParseCorpus_SkipReasonNoLongerRecognized pins the removal of the
+// per-case opt-out mechanism. The parser must reject `-- skip_reason --`
+// as an unknown section so a corpus author can't reintroduce the
+// "stub it for later" workflow that the harness intentionally lacks.
+func TestParseCorpus_SkipReasonNoLongerRecognized(t *testing.T) {
+	t.Parallel()
+	in := `-- name --
+x
+-- query --
+{ }
+-- skip_reason --
+nope
+`
+	if _, err := parseCorpus(strings.NewReader(in), "test"); err == nil {
+		t.Fatal("expected error: skip_reason is no longer a recognized section")
+	}
+}
+
 func TestParseCorpus_EmptyFails(t *testing.T) {
 	t.Parallel()
 	if _, err := parseCorpus(strings.NewReader("# only comments\n"), "test"); err == nil {
@@ -198,12 +214,9 @@ func TestSmokeCorpus_LoadsAndMeetsFloor(t *testing.T) {
 	if len(cases) < 20 {
 		t.Fatalf("smoke corpus shrunk: got %d, want >= 20", len(cases))
 	}
-	// Every active case has a non-empty query unless the endpoint is one
+	// Every case has a non-empty query unless the endpoint is one
 	// of the "no TraceQL" kinds (search_recent + the four tag endpoints).
 	for _, c := range cases {
-		if c.SkipReason != "" {
-			continue
-		}
 		if c.Query == "" && c.Endpoint != "search_recent" && !isTagEndpoint(c.Endpoint) {
 			t.Fatalf("case %q: empty query but endpoint=%q", c.Name, c.Endpoint)
 		}
@@ -217,7 +230,7 @@ func TestSmokeCorpus_TagEndpointCoverage(t *testing.T) {
 		t.Fatalf("LoadCorpus: %v", err)
 	}
 	// PR 6 commits the four tag endpoints. Every endpoint kind must
-	// have at least one active case in the smoke corpus so the differ
+	// have at least one case in the smoke corpus so the differ
 	// exercises the full response-shape matrix on every nightly run.
 	required := map[string]bool{
 		"tags_v1":       false,
@@ -226,16 +239,13 @@ func TestSmokeCorpus_TagEndpointCoverage(t *testing.T) {
 		"tag_values_v2": false,
 	}
 	for _, c := range cases {
-		if c.SkipReason != "" {
-			continue
-		}
 		if _, ok := required[c.Endpoint]; ok {
 			required[c.Endpoint] = true
 		}
 	}
 	for ep, seen := range required {
 		if !seen {
-			t.Errorf("smoke corpus lacks an active case for endpoint=%q", ep)
+			t.Errorf("smoke corpus lacks a case for endpoint=%q", ep)
 		}
 	}
 }
@@ -387,28 +397,6 @@ metrics_range
 `
 	if _, err := parseCorpus(strings.NewReader(in), "test"); err == nil {
 		t.Fatal("expected error: metrics_range without step")
-	}
-}
-
-func TestParseCorpus_MetricsRangeSkipReasonBypassesStep(t *testing.T) {
-	t.Parallel()
-	// skip_reason'd metrics_range cases don't need step (the case won't
-	// run; the step omission is just a corpus-author convenience).
-	in := `-- name --
-skipped
--- query --
-{ } | rate()
--- endpoint --
-metrics_range
--- skip_reason --
-not implemented
-`
-	got, err := parseCorpus(strings.NewReader(in), "test")
-	if err != nil {
-		t.Fatalf("parseCorpus: %v", err)
-	}
-	if got[0].SkipReason != "not implemented" {
-		t.Fatalf("SkipReason = %q", got[0].SkipReason)
 	}
 }
 

--- a/harness/tempo-compatibility/driver/diff.go
+++ b/harness/tempo-compatibility/driver/diff.go
@@ -101,11 +101,6 @@ func runDiff(args []string) error {
 
 	for _, tc := range cases {
 		tc := tc
-		if tc.SkipReason != "" {
-			logger.Info("skipping case", "name", tc.Name, "reason", tc.SkipReason)
-			results = append(results, CaseResult{Case: tc, Skipped: true})
-			continue
-		}
 		logger.Info("diffing case", "name", tc.Name, "endpoint", tc.Endpoint)
 		results = append(results, diffCase(ctx, client, tc, opts))
 	}
@@ -121,9 +116,6 @@ func runDiff(args []string) error {
 	if *failOnDiff {
 		var unexpected int
 		for _, r := range results {
-			if r.Skipped {
-				continue
-			}
 			if r.HardError != "" || !r.Diff.Equal || len(r.Assertions) > 0 {
 				if _, ok := efSet[r.Case.Name]; ok {
 					logger.Info("expected failure", "name", r.Case.Name)
@@ -144,10 +136,6 @@ func runDiff(args []string) error {
 // partial info when a step failed.
 type CaseResult struct {
 	Case CorpusCase
-
-	// Skipped means the case carried a SkipReason; the report lists
-	// these in a separate section.
-	Skipped bool
 
 	// HardError is set when the case failed before the diff could run
 	// (URL build, HTTP error, non-2xx status). Mutually exclusive with
@@ -484,12 +472,10 @@ func writeReport(path string, results []CaseResult) error {
 }
 
 func renderReport(w io.Writer, results []CaseResult) error {
-	var total, passed, diffed, asserted, skipped, hardErr int
+	var total, passed, diffed, asserted, hardErr int
 	for _, r := range results {
 		total++
 		switch {
-		case r.Skipped:
-			skipped++
 		case r.HardError != "":
 			hardErr++
 		case !r.Diff.Equal:
@@ -520,9 +506,6 @@ func renderReport(w io.Writer, results []CaseResult) error {
 		return err
 	}
 	if _, err := fmt.Fprintf(w, "- Passed: %d\n", passed); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintf(w, "- Skipped: %d\n", skipped); err != nil {
 		return err
 	}
 	if _, err := fmt.Fprintf(w, "- Diff: %d\n", diffed); err != nil {
@@ -569,10 +552,6 @@ func renderCase(w io.Writer, r CaseResult) error {
 		return err
 	}
 	switch {
-	case r.Skipped:
-		if _, err := fmt.Fprintf(w, "- status: SKIPPED (%s)\n", r.Case.SkipReason); err != nil {
-			return err
-		}
 	case r.HardError != "":
 		if _, err := fmt.Fprintf(w, "- status: ERROR — %s\n", r.HardError); err != nil {
 			return err
@@ -590,7 +569,7 @@ func renderCase(w io.Writer, r CaseResult) error {
 			return err
 		}
 	}
-	if !r.Skipped && r.HardError == "" {
+	if r.HardError == "" {
 		if _, err := fmt.Fprintf(w, "- tempo HTTP: %d  cerberus HTTP: %d\n", r.TempoStatus, r.CerberusStatus); err != nil {
 			return err
 		}

--- a/harness/tempo-compatibility/driver/differ_test.go
+++ b/harness/tempo-compatibility/driver/differ_test.go
@@ -527,10 +527,6 @@ func TestRenderReport_Roundtrip(t *testing.T) {
 			Assertions: []DiffReason{{Kind: "assertion", Detail: "got 4, want >= 5"}},
 		},
 		{
-			Case:    CorpusCase{Name: "skip_case", Endpoint: "search", Query: "{ z = 3 }", SkipReason: "pr5"},
-			Skipped: true,
-		},
-		{
 			Case:      CorpusCase{Name: "err_case", Endpoint: "search", Query: "{ q = 4 }"},
 			HardError: "tempo fetch: connection refused",
 		},
@@ -543,18 +539,15 @@ func TestRenderReport_Roundtrip(t *testing.T) {
 	for _, want := range []string{
 		"# Tempo / TraceQL compatibility — diff report",
 		"## Summary",
-		"- Cases: 4",
+		"- Cases: 3",
 		"- Passed: 1",
-		"- Skipped: 1",
 		"- Diff: 1",
 		"- Hard errors: 1",
 		"### `pass_case`",
 		"### `diff_case`",
-		"### `skip_case`",
 		"### `err_case`",
 		"status: PASS",
 		"status: DIFF (1 reasons)",
-		"status: SKIPPED (pr5)",
 		"status: ERROR — tempo fetch: connection refused",
 	} {
 		if !strings.Contains(report, want) {


### PR DESCRIPTION
Per maintainer's non-negotiable rule: nothing in cerberus is skipped. The corpus parser's `SkipReason` field let test cases say "I'm not implemented" instead of being deleted or implemented. Removing the field + the `-- skip_reason --` block parsing. 3 files changed, 35 / -52. Part of the cleanup split for PR #461's broad forbid-skip gate.