### PR TITLE
refactor(tests): rewrite descriptive 'skipped'/'deferred' verbs to neutral terms

### DIFF
--- a/cmd/cerberus/lifecycle_test.go
+++ b/cmd/cerberus/lifecycle_test.go
@@ -74,8 +74,8 @@ func TestSignalNotifyContext_TerminatesOnSIGINT(t *testing.T) {
 	}
 }
 
-// TestSignalNotifyContext_StopReleasesHandler confirms the deferred
-// stop() unhooks the signal handler so a second test in the same
+// TestSignalNotifyContext_StopReleasesHandler confirms the stop()
+// callback unhooks the signal handler so a second test in the same
 // process doesn't see stray cancellations from the first test's
 // signal.
 func TestSignalNotifyContext_StopReleasesHandler(t *testing.T) {

--- a/internal/api/loki/unpack_pattern_test.go
+++ b/internal/api/loki/unpack_pattern_test.go
@@ -90,10 +90,10 @@ func TestUnpack_SkipsNonStringValues(t *testing.T) {
 	_, gotLabels := tx(line, map[string]string{"job": "api"})
 
 	if _, ok := gotLabels["count"]; ok {
-		t.Errorf("non-string `count` should be skipped; got %q", gotLabels["count"])
+		t.Errorf("non-string `count` should be dropped; got %q", gotLabels["count"])
 	}
 	if _, ok := gotLabels["nested"]; ok {
-		t.Errorf("object-valued `nested` should be skipped")
+		t.Errorf("object-valued `nested` should be dropped")
 	}
 	if gotLabels["pod"] != "web-1" {
 		t.Errorf("string-valued `pod` should be extracted; got %q", gotLabels["pod"])
@@ -101,7 +101,7 @@ func TestUnpack_SkipsNonStringValues(t *testing.T) {
 }
 
 // TestPattern_NamedCaptures — the canonical case: each named segment
-// in the pattern becomes a label. `<_>` segments are skipped.
+// in the pattern becomes a label. `<_>` segments are dropped.
 func TestPattern_NamedCaptures(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/prom/handler_chdb_quantile_range_test.go
+++ b/internal/api/prom/handler_chdb_quantile_range_test.go
@@ -90,7 +90,7 @@ func TestQueryRange_QuantileOverTimeOutOfRange_ChDB(t *testing.T) {
 		// otel_metrics_sum which the test seed doesn't populate; the
 		// gauge-side avg_over_time exercises the same chplan shape).
 		// Pre-fix this also 502'd against real CH (the txtar roundtrip
-		// skipped wrapWithSampleProjection, so this regression was
+		// bypassed wrapWithSampleProjection, so this regression was
 		// hidden in the existing chDB lane).
 		{"abs-over-avg_over_time", "abs(avg_over_time(latency_ms[5m]))"},
 	}

--- a/internal/chsql/prewhere_test.go
+++ b/internal/chsql/prewhere_test.go
@@ -56,7 +56,7 @@ func TestCollectColumnRefs(t *testing.T) {
 			want: []string{"ServiceName"},
 		},
 		{
-			name: "qualified column refs skipped",
+			name: "qualified column refs dropped",
 			expr: &chplan.ColumnRef{Name: "SpanName", Qualifier: "R"},
 			want: nil,
 		},

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -234,7 +234,7 @@ func TestEngine_QueryPlan_IsTraceByID_SkipsOptimizer(t *testing.T) {
 			t.Fatalf("QueryPlan: unexpected err: %v", err)
 		}
 		if strings.Contains(res.SQL, rewrittenTable) {
-			t.Errorf("SQL: contains rewritten table %q; optimizer should have been skipped. SQL=%q",
+			t.Errorf("SQL: contains rewritten table %q; optimizer should have been bypassed. SQL=%q",
 				rewrittenTable, res.SQL)
 		}
 		if !strings.Contains(res.SQL, originalTable) {


### PR DESCRIPTION
Cluster of small prose-only test rewrites for PR #461's broad forbid-skip rule. 5 files, 8/-8 lines. Each test was using 'skipped' / 'deferred' as a descriptive English verb; rewriting to 'dropped' / 'bypassed' / 'closing routine' preserves the meaning without the disciplined-erosion smell.