### PR TITLE
refactor(optimizer/tests): rename 'skipped' counter to 'dropped'

### DIFF
--- a/internal/optimizer/property_extended_test.go
+++ b/internal/optimizer/property_extended_test.go
@@ -115,7 +115,7 @@ func TestPropertyConstantFoldSemantic_RowSetEquivalent(t *testing.T) {
 	// Literal comparison pairs that semantic fold reduces to LitBool.
 	// All operands sit underneath a wrapping `<binary> AND <leaf>`,
 	// so the binary must collapse to a Bool — arithmetic ops like
-	// OpAdd are skipped (CH would reject `1+2 AND <bool>` typing).
+	// OpAdd are excluded (CH would reject `1+2 AND <bool>` typing).
 	literalPairs := []struct {
 		op   chplan.BinaryOp
 		l, r int64

--- a/internal/optimizer/property_test.go
+++ b/internal/optimizer/property_test.go
@@ -147,11 +147,11 @@ func TestPropertyOptimizerSemanticEquivalence(t *testing.T) {
 	opt := optimizer.Default()
 
 	tried := 0
-	skipped := 0
+	dropped := 0
 	for tried < n {
 		plan := generatePlan(rng, 0)
 		if plan == nil {
-			skipped++
+			dropped++
 			continue
 		}
 
@@ -160,7 +160,7 @@ func TestPropertyOptimizerSemanticEquivalence(t *testing.T) {
 			// Generator produced something the emitter can't render
 			// (e.g. a degenerate Projection list). Skip — this is
 			// not what the property checks.
-			skipped++
+			dropped++
 			continue
 		}
 
@@ -180,7 +180,7 @@ func TestPropertyOptimizerSemanticEquivalence(t *testing.T) {
 		tried++
 	}
 	if testing.Verbose() {
-		t.Logf("property check: %d plans verified (%d skipped) against seed %d", tried, skipped, seed)
+		t.Logf("property check: %d plans verified (%d dropped) against seed %d", tried, dropped, seed)
 	}
 }
 


### PR DESCRIPTION
Property test counted plans the generator rejected via 'skipped'; rename to 'dropped'. Part of the PR #461 cleanup split.