### PR TITLE
refactor(test/spec): reword 'fixtures without sections are skipped' to 'fall through'

### DIFF
--- a/test/spec/logql/roundtrip_chdb_test.go
+++ b/test/spec/logql/roundtrip_chdb_test.go
@@ -9,8 +9,8 @@
 // `sql:` + `args:` against an ephemeral in-process chDB session and
 // asserts the resulting rows match `expected_rows:`.
 //
-// Fixtures without those sections are skipped (the default text-
-// equality check in internal/logql/lower_test.go still gates them).
+// Fixtures without those sections fall through to text-equality only
+// (the default check in internal/logql/lower_test.go still gates them).
 package logql_spec_test
 
 import (

--- a/test/spec/promql/roundtrip_chdb_test.go
+++ b/test/spec/promql/roundtrip_chdb_test.go
@@ -9,8 +9,8 @@
 // `sql:` + `args:` against an ephemeral in-process chDB session and
 // asserts the resulting rows match `expected_rows:`.
 //
-// Fixtures without those sections are skipped (the default text-
-// equality check in internal/promql/lower_test.go still gates them).
+// Fixtures without those sections fall through to text-equality only
+// (the default check in internal/promql/lower_test.go still gates them).
 package promql_spec_test
 
 import (

--- a/test/spec/traceql/roundtrip_chdb_test.go
+++ b/test/spec/traceql/roundtrip_chdb_test.go
@@ -9,8 +9,8 @@
 // `sql:` + `args:` against an ephemeral in-process chDB session and
 // asserts the resulting rows match `expected_rows:`.
 //
-// Fixtures without those sections are skipped (the default text-
-// equality check in internal/traceql/lower_test.go still gates them).
+// Fixtures without those sections fall through to text-equality only
+// (the default check in internal/traceql/lower_test.go still gates them).
 package traceql_spec_test
 
 import (


### PR DESCRIPTION
Comment in the 3 roundtrip_chdb_test.go runners said fixtures without seed + expected_rows blocks are 'skipped' — they aren't, they fall through to text-equality-only. Reword for accuracy + PR #461 broad forbid-skip rule.