### PR TITLE
refactor(chclient/tests): rewrite mock ScanStruct stub messages

### DIFF
--- a/internal/chclient/chaos_test.go
+++ b/internal/chclient/chaos_test.go
@@ -91,7 +91,9 @@ func (r *chaosRows) Scan(dest ...any) error {
 	return nil
 }
 
-func (r *chaosRows) ScanStruct(any) error             { return errors.New("test mock: ScanStruct unused by chaos tests") }
+func (r *chaosRows) ScanStruct(any) error {
+	return errors.New("test mock: ScanStruct unused by chaos tests")
+}
 func (r *chaosRows) ColumnTypes() []driver.ColumnType { return nil }
 func (r *chaosRows) Totals(...any) error              { return nil }
 func (r *chaosRows) Columns() []string                { return nil }

--- a/internal/chclient/chaos_test.go
+++ b/internal/chclient/chaos_test.go
@@ -91,7 +91,7 @@ func (r *chaosRows) Scan(dest ...any) error {
 	return nil
 }
 
-func (r *chaosRows) ScanStruct(any) error             { return errors.New("not implemented") }
+func (r *chaosRows) ScanStruct(any) error             { return errors.New("test mock: ScanStruct unused by chaos tests") }
 func (r *chaosRows) ColumnTypes() []driver.ColumnType { return nil }
 func (r *chaosRows) Totals(...any) error              { return nil }
 func (r *chaosRows) Columns() []string                { return nil }

--- a/internal/chclient/cursor_chaos_test.go
+++ b/internal/chclient/cursor_chaos_test.go
@@ -198,7 +198,9 @@ func (r *genRows) Scan(dest ...any) error {
 	return nil
 }
 
-func (r *genRows) ScanStruct(any) error             { return errors.New("test mock: ScanStruct unused by cursor-chaos tests") }
+func (r *genRows) ScanStruct(any) error {
+	return errors.New("test mock: ScanStruct unused by cursor-chaos tests")
+}
 func (r *genRows) ColumnTypes() []driver.ColumnType { return nil }
 func (r *genRows) Totals(...any) error              { return nil }
 func (r *genRows) Columns() []string                { return nil }

--- a/internal/chclient/cursor_chaos_test.go
+++ b/internal/chclient/cursor_chaos_test.go
@@ -198,7 +198,7 @@ func (r *genRows) Scan(dest ...any) error {
 	return nil
 }
 
-func (r *genRows) ScanStruct(any) error             { return errors.New("not implemented") }
+func (r *genRows) ScanStruct(any) error             { return errors.New("test mock: ScanStruct unused by cursor-chaos tests") }
 func (r *genRows) ColumnTypes() []driver.ColumnType { return nil }
 func (r *genRows) Totals(...any) error              { return nil }
 func (r *genRows) Columns() []string                { return nil }

--- a/internal/chclient/cursor_test.go
+++ b/internal/chclient/cursor_test.go
@@ -52,7 +52,9 @@ func (r *fakeRows) Scan(dest ...any) error {
 	return nil
 }
 
-func (r *fakeRows) ScanStruct(any) error             { return errors.New("test mock: ScanStruct unused by cursor tests") }
+func (r *fakeRows) ScanStruct(any) error {
+	return errors.New("test mock: ScanStruct unused by cursor tests")
+}
 func (r *fakeRows) ColumnTypes() []driver.ColumnType { return nil }
 func (r *fakeRows) Totals(...any) error              { return nil }
 func (r *fakeRows) Columns() []string                { return nil }

--- a/internal/chclient/cursor_test.go
+++ b/internal/chclient/cursor_test.go
@@ -52,7 +52,7 @@ func (r *fakeRows) Scan(dest ...any) error {
 	return nil
 }
 
-func (r *fakeRows) ScanStruct(any) error             { return errors.New("not implemented") }
+func (r *fakeRows) ScanStruct(any) error             { return errors.New("test mock: ScanStruct unused by cursor tests") }
 func (r *fakeRows) ColumnTypes() []driver.ColumnType { return nil }
 func (r *fakeRows) Totals(...any) error              { return nil }
 func (r *fakeRows) Columns() []string                { return nil }


### PR DESCRIPTION
Three driver.Rows mocks returned errors.New('not implemented') for ScanStruct — tests don't exercise that method but need to satisfy the interface. Rewriting to 'test mock: ScanStruct unused by X tests'. Part of PR #461 cleanup split.