### PR TITLE
refactor(test/regression): describe Prom/OTel naming behavior, drop 'not implemented'

### DIFF
--- a/test/regression/seed_test.go
+++ b/test/regression/seed_test.go
@@ -77,8 +77,9 @@ func TestSeedScriptsHaveNoInlineCommentsInValues(t *testing.T) {
 // inserts `service.name` (dotted, OTel convention) instead, every
 // Loki E2E test silently returns empty streams.
 //
-// The Prom/OTel naming bridge is not implemented; the seed must use
-// the underscored form so cerberus's current code finds the row.
+// Cerberus uses matcher names verbatim — there is no automatic
+// Prom/OTel naming translation. The seed must use the underscored
+// form so cerberus's labelMatcherToExpr lookup finds the row.
 func TestLogsSeedUsesUnderscoredServiceName(t *testing.T) {
 	t.Parallel()
 
@@ -102,7 +103,7 @@ func TestLogsSeedUsesUnderscoredServiceName(t *testing.T) {
 	logsBlock := content[logsStart : logsStart+logsEnd]
 	mapDottedRE := regexp.MustCompile(`map\(\s*'service\.name'`)
 	if mapDottedRE.MatchString(logsBlock) {
-		t.Errorf("%s: found `map('service.name', ...)` inside the logs INSERT — LogQL stream selectors won't match this; use `service_name` instead (Prom/OTel naming bridge is not implemented)", seedSource)
+		t.Errorf("%s: found `map('service.name', ...)` inside the logs INSERT — LogQL stream selectors won't match this; use `service_name` instead (cerberus uses matcher names verbatim — no automatic Prom/OTel naming translation)", seedSource)
 	}
 }
 


### PR DESCRIPTION
Seed-test guarded that logs INSERT uses underscored 'service_name'. Reason was 'Prom/OTel naming bridge is not implemented' — actually it's intentional: cerberus uses matcher names verbatim. Rewriting to describe the real behavior. Part of PR #461 cleanup split.