### PR TITLE
feat(test/spec): add raw_strings opt-out to chDB runner decodeCell

### DIFF
--- a/test/spec/decode_cell_test.go
+++ b/test/spec/decode_cell_test.go
@@ -1,0 +1,67 @@
+//go:build chdb
+
+package spec
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestDecodeCell_RawStringsPreservesBracePrefixedPayloads(t *testing.T) {
+	t.Parallel()
+
+	const jsonObject = `{"foo":"bar"}`
+	const jsonArray = `[1,2,3]`
+
+	cases := []struct {
+		name     string
+		in       any
+		raw      bool
+		want     any
+		wantKind reflect.Kind
+	}{
+		{"object_decoded", jsonObject, false, map[string]any{"foo": "bar"}, reflect.Map},
+		{"object_raw", jsonObject, true, jsonObject, reflect.String},
+		{"array_decoded", jsonArray, false, []any{float64(1), float64(2), float64(3)}, reflect.Slice},
+		{"array_raw", jsonArray, true, jsonArray, reflect.String},
+		{"plain_string_decoded", "hello", false, "hello", reflect.String},
+		{"plain_string_raw", "hello", true, "hello", reflect.String},
+		{"bytes_object_decoded", []byte(jsonObject), false, map[string]any{"foo": "bar"}, reflect.Map},
+		{"bytes_object_raw", []byte(jsonObject), true, jsonObject, reflect.String},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := decodeCell(tc.in, tc.raw)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("decodeCell(%#v, raw=%v): got %#v (%T), want %#v (%T)",
+					tc.in, tc.raw, got, got, tc.want, tc.want)
+			}
+			if reflect.ValueOf(got).Kind() != tc.wantKind {
+				t.Fatalf("decodeCell(%#v, raw=%v): kind %s, want %s",
+					tc.in, tc.raw, reflect.ValueOf(got).Kind(), tc.wantKind)
+			}
+		})
+	}
+}
+
+func TestDecodeCell_NilTimeUnchangedByRawFlag(t *testing.T) {
+	t.Parallel()
+
+	if got := decodeCell(nil, true); got != nil {
+		t.Fatalf("nil + raw: got %#v, want nil", got)
+	}
+	if got := decodeCell(nil, false); got != nil {
+		t.Fatalf("nil + decoded: got %#v, want nil", got)
+	}
+
+	ts := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	const want = "2026-01-02T03:04:05Z"
+	if got := decodeCell(ts, true); got != want {
+		t.Fatalf("time + raw: got %#v, want %q", got, want)
+	}
+	if got := decodeCell(ts, false); got != want {
+		t.Fatalf("time + decoded: got %#v, want %q", got, want)
+	}
+}

--- a/test/spec/roundtrip.go
+++ b/test/spec/roundtrip.go
@@ -26,6 +26,16 @@
 //     Go side (per the chDB driver probe, native Map scan panics in
 //     parquet-go inside chdb-go v1.11.0).
 //
+//   - `raw_strings:` (optional, presence-only) — disables the runner's
+//     heuristic JSON-decoding of String/[]byte cells. Without it, any
+//     cell whose string content starts with `{` or `[` is decoded
+//     into a map/slice value before comparison, and expected_rows
+//     must mirror the decoded shape. With it, the runner returns the
+//     raw string, and expected_rows asserts the literal payload — the
+//     correct mode for fixtures that exercise JSON pass-through (e.g.
+//     `| json`/`| logfmt` on log lines that contain brace-prefixed
+//     content).
+//
 // We chose JSON over TSV for `expected_rows:` because Map columns
 // embed nested structure that TSV cannot represent without an
 // escaping convention, and because reflect.DeepEqual on the decoded
@@ -72,6 +82,15 @@ type RoundTripSections struct {
 	// Args is the bound []any matching the `?` placeholders in SQL,
 	// parsed from the `args:` text format the emitter writes.
 	Args []any
+
+	// RawStrings disables the runner's heuristic JSON-decoding of
+	// String/[]byte cells (decodeString in runner_chdb.go promotes
+	// `{...}`/`[...]`-prefixed strings to map/slice values). Opt in
+	// when a fixture asserts a literal brace-prefixed payload — its
+	// expected_rows would otherwise have to mirror the decoded shape
+	// and lose round-trip fidelity with the actual SQL output. Set
+	// by the presence of the `raw_strings:` section in the fixture.
+	RawStrings bool
 
 	// expectedRowsPresent records whether the fixture authored an
 	// `expected_rows:` section at all (even an empty `[]`), so
@@ -121,6 +140,9 @@ func LoadRoundTrip(c *Case) (*RoundTripSections, error) {
 			return nil, fmt.Errorf("args: %w", err)
 		}
 		out.Args = args
+	}
+	if _, ok := c.Section("raw_strings"); ok {
+		out.RawStrings = true
 	}
 	return out, nil
 }

--- a/test/spec/roundtrip_test.go
+++ b/test/spec/roundtrip_test.go
@@ -1,0 +1,73 @@
+package spec
+
+import (
+	"testing"
+
+	"golang.org/x/tools/txtar"
+)
+
+func TestLoadRoundTrip_RawStringsSectionSetsFlag(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{
+			name: "absent_section_keeps_false",
+			body: `-- seed --
+CREATE TABLE t (a String) ENGINE = Memory;
+INSERT INTO t VALUES ('hi');
+-- sql --
+SELECT a FROM t
+-- expected_rows --
+[["hi"]]
+`,
+			want: false,
+		},
+		{
+			name: "present_section_sets_true",
+			body: `-- seed --
+CREATE TABLE t (a String) ENGINE = Memory;
+INSERT INTO t VALUES ('hi');
+-- sql --
+SELECT a FROM t
+-- expected_rows --
+[["hi"]]
+-- raw_strings --
+`,
+			want: true,
+		},
+		{
+			name: "present_section_with_body_still_true",
+			body: `-- seed --
+CREATE TABLE t (a String) ENGINE = Memory;
+INSERT INTO t VALUES ('hi');
+-- sql --
+SELECT a FROM t
+-- expected_rows --
+[["hi"]]
+-- raw_strings --
+preserve literal { and [ payloads
+`,
+			want: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Case{
+				Name:    "inline",
+				archive: txtar.Parse([]byte(tc.body)),
+			}
+			rt, err := LoadRoundTrip(c)
+			if err != nil {
+				t.Fatalf("LoadRoundTrip: %v", err)
+			}
+			if rt.RawStrings != tc.want {
+				t.Fatalf("RawStrings = %v, want %v", rt.RawStrings, tc.want)
+			}
+		})
+	}
+}

--- a/test/spec/runner_chdb.go
+++ b/test/spec/runner_chdb.go
@@ -539,7 +539,7 @@ func RunRoundTrip(t *testing.T, c *Case) {
 		}
 		row := make([]any, colCount)
 		for i, v := range cells {
-			row[i] = decodeCell(v)
+			row[i] = decodeCell(v, rt.RawStrings)
 		}
 		got = append(got, row)
 	}
@@ -680,15 +680,26 @@ func sortRows(rows [][]any) {
 // driver returns a string; we try JSON-decode and fall back to the
 // raw string. time.Time values are normalized to RFC3339Nano so
 // fixture authors can write them as quoted strings.
-func decodeCell(v any) any {
+//
+// When rawStrings is true the JSON-decode pass on String/[]byte cells
+// is skipped — the runner returns the raw string. Fixtures opt in
+// via the `raw_strings:` section when they need to assert literal
+// brace-prefixed payloads against the SQL output.
+func decodeCell(v any, rawStrings bool) any {
 	switch x := v.(type) {
 	case nil:
 		return nil
 	case time.Time:
 		return x.UTC().Format(time.RFC3339Nano)
 	case []byte:
+		if rawStrings {
+			return string(x)
+		}
 		return decodeBytes(x)
 	case string:
+		if rawStrings {
+			return x
+		}
 		return decodeString(x)
 	default:
 		return v


### PR DESCRIPTION
## Summary

- Add a presence-only `raw_strings:` TXTAR section that disables the chDB roundtrip runner's heuristic JSON-decoding of String/[]byte cells.
- decodeCell now takes a `rawStrings bool` flag and returns the raw string for `{...}`/`[...]`-prefixed cells when set.
- Unit tests for both decodeCell (chdb-tagged) and LoadRoundTrip (non-tagged) section parsing.

## Motivation

The runner's existing heuristic — try-JSON-decode any `{`/`[`-prefixed string, fall back to raw — exists to round-trip Map(String,String) columns (wrapped server-side in `toJSONString`). It mis-classifies fixtures that assert literal brace-prefixed payloads from `| json` / `| logfmt` log lines: the SQL output is a real string, but the comparator coerces it into a map. PR #459 had to regenerate the parser_json_* goldens to mirror the decoded shape — losing direct fidelity with what the SQL actually produces.

The opt-out is presence-only (no body needed) so the fixture intent stays obvious at a glance.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./test/spec/... -run TestLoadRoundTrip` passes
- [ ] `chdb` workflow runs the new decodeCell unit test (CI)
- [ ] Existing chDB roundtrip fixtures remain green (no default-behaviour change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)