### PR TITLE
feat(api/tempo): thread __phi__ label through multi-quantile metrics handler

### DIFF
--- a/internal/api/tempo/metrics_phi_label_test.go
+++ b/internal/api/tempo/metrics_phi_label_test.go
@@ -1,0 +1,159 @@
+package tempo
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// TestMetricsLabelNames_PhiLabelAddedForMultiQuantile pins the contract
+// that the response label list includes the synthetic `__phi__` label
+// when MetricsAggregate.Quantiles carries more than one phi value. The
+// chsql multi-quantile fan-out projects an extra column with that
+// alias; the handler must surface it as a wire-format label so each
+// (group × phi) becomes its own response series.
+func TestMetricsLabelNames_PhiLabelAddedForMultiQuantile(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		m    *chplan.MetricsAggregate
+		want []string
+	}{
+		{
+			name: "no_groupby_single_quantile",
+			m:    &chplan.MetricsAggregate{Quantiles: []float64{0.95}},
+			want: nil,
+		},
+		{
+			name: "no_groupby_multi_quantile",
+			m:    &chplan.MetricsAggregate{Quantiles: []float64{0.5, 0.9, 0.99}},
+			want: []string{"__phi__"},
+		},
+		{
+			name: "groupby_single_quantile",
+			m: &chplan.MetricsAggregate{
+				GroupBy:        []chplan.Expr{&chplan.ColumnRef{Name: "x"}},
+				GroupByAliases: []string{"service"},
+				Quantiles:      []float64{0.95},
+			},
+			want: []string{"service"},
+		},
+		{
+			name: "groupby_multi_quantile",
+			m: &chplan.MetricsAggregate{
+				GroupBy:        []chplan.Expr{&chplan.ColumnRef{Name: "x"}},
+				GroupByAliases: []string{"service"},
+				Quantiles:      []float64{0.5, 0.99},
+			},
+			want: []string{"service", "__phi__"},
+		},
+		{
+			name: "non_quantile_op_with_quantiles_unset",
+			m: &chplan.MetricsAggregate{
+				GroupBy:        []chplan.Expr{&chplan.ColumnRef{Name: "x"}},
+				GroupByAliases: []string{"region"},
+			},
+			want: []string{"region"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := metricsLabelNames(tc.m)
+			if !equalSlice(got, tc.want) {
+				t.Fatalf("metricsLabelNames = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestWrapMetricsForSample_MultiQuantileAttrsIncludePhi pins the
+// Attributes map's shape: when len(Quantiles) > 1 the projected map
+// must reference both the group columns and the synthetic `__phi__`
+// column produced by the chsql fan-out.
+func TestWrapMetricsForSample_MultiQuantileAttrsIncludePhi(t *testing.T) {
+	t.Parallel()
+
+	rw := &chplan.RangeWindow{}
+	m := &chplan.MetricsAggregate{
+		GroupBy:        []chplan.Expr{&chplan.ColumnRef{Name: "x"}},
+		GroupByAliases: []string{"service"},
+		Quantiles:      []float64{0.5, 0.9},
+		ValueAlias:     "Value",
+	}
+
+	node := wrapMetricsForSample(rw, m)
+	proj, ok := node.(*chplan.Project)
+	if !ok {
+		t.Fatalf("wrapMetricsForSample: got %T, want *chplan.Project", node)
+	}
+	// The Attributes projection is at index 1 (after MetricName).
+	if len(proj.Projections) < 2 {
+		t.Fatalf("project has %d projections, want >= 2", len(proj.Projections))
+	}
+	attrsExpr := proj.Projections[1].Expr
+	call, ok := attrsExpr.(*chplan.FuncCall)
+	if !ok || call.Name != "map" {
+		t.Fatalf("Attributes expr = %T (%v), want *chplan.FuncCall(map)", attrsExpr, attrsExpr)
+	}
+
+	// Args are (key, value) pairs. Look for the __phi__ key + matching value.
+	foundPhiKey := false
+	foundPhiCol := false
+	for i, arg := range call.Args {
+		if lit, ok := arg.(*chplan.LitString); ok && lit.V == "__phi__" {
+			foundPhiKey = true
+			if i+1 < len(call.Args) {
+				if col, ok := call.Args[i+1].(*chplan.ColumnRef); ok && col.Name == "__phi__" {
+					foundPhiCol = true
+				}
+			}
+		}
+	}
+	if !foundPhiKey {
+		t.Errorf("map args do not include '__phi__' literal key:\n  %v", call.Args)
+	}
+	if !foundPhiCol {
+		t.Errorf("map args do not pair '__phi__' key with __phi__ ColumnRef")
+	}
+}
+
+// TestWrapMetricsForSample_SingleQuantileNoPhiKey pins the inverse:
+// single-quantile or non-quantile aggregates must NOT inject __phi__
+// into the Attributes map (the chsql emitter doesn't project the
+// column in that path).
+func TestWrapMetricsForSample_SingleQuantileNoPhiKey(t *testing.T) {
+	t.Parallel()
+
+	rw := &chplan.RangeWindow{}
+	m := &chplan.MetricsAggregate{
+		GroupBy:        []chplan.Expr{&chplan.ColumnRef{Name: "x"}},
+		GroupByAliases: []string{"service"},
+		Quantiles:      []float64{0.95},
+		ValueAlias:     "Value",
+	}
+
+	node := wrapMetricsForSample(rw, m)
+	proj := node.(*chplan.Project)
+	attrsExpr := proj.Projections[1].Expr.(*chplan.FuncCall)
+
+	for _, arg := range attrsExpr.Args {
+		if lit, ok := arg.(*chplan.LitString); ok && strings.Contains(lit.V, "__phi__") {
+			t.Errorf("single-quantile map args unexpectedly include __phi__ key: %v", attrsExpr.Args)
+		}
+	}
+}
+
+func equalSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/api/tempo/metrics_query_instant.go
+++ b/internal/api/tempo/metrics_query_instant.go
@@ -159,7 +159,7 @@ func metricsInstantQueryParam(r *http.Request) string {
 // sample; the sort is defensive against a future RangeWindow that
 // returns multiple anchors.
 func toMetricsInstantSeries(samples []chclient.Sample, m *chplan.MetricsAggregate) []MetricsInstantSeries {
-	labelNames := metricsLabelNames(m.GroupByAliases, len(m.GroupBy))
+	labelNames := metricsLabelNames(m)
 
 	type bucket struct {
 		labels   []MetricsLabel

--- a/internal/api/tempo/metrics_query_range.go
+++ b/internal/api/tempo/metrics_query_range.go
@@ -334,21 +334,35 @@ func unwrapMetricsAggregate(plan chplan.Node) (*chplan.MetricsAggregate, bool) {
 	return nil, false
 }
 
+// tempoMultiQuantilePhiLabel is the synthetic label name the chsql
+// multi-quantile fan-out projects when MetricsAggregate.Quantiles
+// holds more than one phi. Lockstep with chsql's
+// `metricsMultiQuantilePhiLabel` (range_window.go) — both must agree
+// on the column alias so the handler can read it out of the row
+// stream and surface it as a wire-format label.
+const tempoMultiQuantilePhiLabel = "__phi__"
+
 // wrapMetricsForSample maps the matrix-shape RangeWindow's outer SELECT
 // (g0/<alias>..., anchor_ts, Value) into chclient.Sample's positional
 // shape (MetricName, Attributes, TimeUnix, Value). Attributes becomes
 // `map('<label>', toString(<alias>), ...)` (or an empty Map(String,String)
 // when there's no GroupBy); MetricName is empty (TraceQL has no
 // __name__); anchor_ts arrives as DateTime64(9) → time.Time on the wire.
+//
+// When MetricsAggregate.Quantiles carries multiple phi values, the chsql
+// emitter projects an extra `__phi__` String column per row; this wrap
+// includes it as a synthetic Attributes entry so each (group × phi)
+// pair becomes its own response series.
 func wrapMetricsForSample(rw *chplan.RangeWindow, m *chplan.MetricsAggregate) chplan.Node {
 	attrAliases := metricsOuterGroupAliases(m.GroupBy, m.GroupByAliases)
-	labelNames := metricsLabelNames(m.GroupByAliases, len(m.GroupBy))
+	labelNames := metricsLabelNames(m)
+	multiPhi := len(m.Quantiles) > 1
 
 	var attrs chplan.Expr
-	if len(m.GroupBy) == 0 {
+	if len(m.GroupBy) == 0 && !multiPhi {
 		attrs = emptyAttrsMap()
 	} else {
-		args := make([]chplan.Expr, 0, len(m.GroupBy)*2)
+		args := make([]chplan.Expr, 0, (len(m.GroupBy)+1)*2)
 		for i := range m.GroupBy {
 			args = append(
 				args,
@@ -357,6 +371,12 @@ func wrapMetricsForSample(rw *chplan.RangeWindow, m *chplan.MetricsAggregate) ch
 					Name: "toString",
 					Args: []chplan.Expr{&chplan.ColumnRef{Name: attrAliases[i]}},
 				},
+			)
+		}
+		if multiPhi {
+			args = append(args,
+				&chplan.LitString{V: tempoMultiQuantilePhiLabel},
+				&chplan.ColumnRef{Name: tempoMultiQuantilePhiLabel},
 			)
 		}
 		attrs = &chplan.FuncCall{Name: "map", Args: args}
@@ -395,15 +415,22 @@ func metricsOuterGroupAliases(groupBy []chplan.Expr, aliases []string) []string 
 
 // metricsLabelNames returns the user-facing label names the response's
 // {key,value} pairs surface — the lowering's GroupByAliases with a
-// fallback ("group_0", ...) for any empty alias slot.
-func metricsLabelNames(aliases []string, n int) []string {
-	out := make([]string, 0, n)
+// fallback ("group_0", ...) for any empty alias slot, plus the
+// synthetic `__phi__` label when MetricsAggregate.Quantiles carries
+// more than one phi value (the chsql multi-quantile fan-out adds the
+// extra column to the matrix shape).
+func metricsLabelNames(m *chplan.MetricsAggregate) []string {
+	n := len(m.GroupBy)
+	out := make([]string, 0, n+1)
 	for i := 0; i < n; i++ {
-		if i < len(aliases) && aliases[i] != "" {
-			out = append(out, aliases[i])
+		if i < len(m.GroupByAliases) && m.GroupByAliases[i] != "" {
+			out = append(out, m.GroupByAliases[i])
 			continue
 		}
 		out = append(out, "group_"+strconv.Itoa(i))
+	}
+	if len(m.Quantiles) > 1 {
+		out = append(out, tempoMultiQuantilePhiLabel)
 	}
 	return out
 }
@@ -413,7 +440,7 @@ func metricsLabelNames(aliases []string, n int) []string {
 // into one series, samples sorted ascending by timestamp. Series order
 // is deterministic (sorted by canonical label-set key).
 func toMetricsSeries(samples []chclient.Sample, m *chplan.MetricsAggregate) []MetricsSeries {
-	labelNames := metricsLabelNames(m.GroupByAliases, len(m.GroupBy))
+	labelNames := metricsLabelNames(m)
 
 	type bucket struct {
 		labels  []MetricsLabel
@@ -485,7 +512,7 @@ func labelsFromSample(attrs map[string]string, labelNames []string) []MetricsLab
 }
 
 func attachExemplars(series []MetricsSeries, exSamples []chclient.Sample, m *chplan.MetricsAggregate) {
-	labelNames := metricsLabelNames(m.GroupByAliases, len(m.GroupBy))
+	labelNames := metricsLabelNames(m)
 	byKey := make(map[string]*MetricsSeries, len(series))
 	for i := range series {
 		key := format.CanonicalKey(labelsToMap(series[i].Labels))


### PR DESCRIPTION
## Summary

- `metricsLabelNames` signature: now takes `*chplan.MetricsAggregate` and appends `__phi__` when `len(Quantiles) > 1`.
- `wrapMetricsForSample` injects a `'__phi__', __phi__` entry into the projected `map(...)` Attributes so each (group × phi) row in the chsql fan-out pivots into its own response series.
- New unit tests pin both behaviours; rebases on top of #460's chsql emit.

## Motivation

PR #460 added the multi-quantile fan-out in `internal/chsql/range_window.go` — for `quantile_over_time({...}, 0.5, 0.9, 0.99)`, the emitted SQL projects an extra `__phi__` String column and fans the matrix shape out to one row per phi value. The Tempo handler, however, was still building the Attributes map from `m.GroupBy` only, so all phi rows collapsed onto the same series key in `toMetricsSeries`. This PR closes that gap.

## Test plan

- [x] `go test ./internal/api/tempo/... ./internal/traceql/... ./internal/chsql/...` — 880 tests green
- [x] `go build ./...`
- [ ] tempo/compatibility passes (informational — verifies end-to-end against the upstream Tempo wire shape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)