### PR TITLE
test(spec/logql): seed 7 sum/avg/range-agg fixtures for chDB round-trip

### DIFF
--- a/test/spec/logql/avg_count_over_time.txtar
+++ b/test/spec/logql/avg_count_over_time.txtar
@@ -1,5 +1,21 @@
 -- query.logql --
 avg(count_over_time({job="api"}[5m]))
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
+    (toDateTime64('2025-12-31 23:58:00', 9), 'a', map('job', 'api', 'pod', 'p1')),
+    (toDateTime64('2025-12-31 23:59:00', 9), 'b', map('job', 'api', 'pod', 'p1')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'c', map('job', 'api', 'pod', 'p1')),
+    (toDateTime64('2025-12-31 23:58:00', 9), 'd', map('job', 'api', 'pod', 'p2')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'e', map('job', 'api', 'pod', 'p2'));
+-- expected_rows --
+[
+  ["", {}, "2026-01-01T00:00:01Z", 2.5]
+]
 -- sql --
 SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Value` FROM (SELECT avg(`Value`) AS `Value`, count() AS `_cerb_n` FROM (SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1)) WHERE `_cerb_n` > 0)
 -- args --

--- a/test/spec/logql/range_agg_by_grouping.txtar
+++ b/test/spec/logql/range_agg_by_grouping.txtar
@@ -1,5 +1,21 @@
 -- query.logql --
 avg_over_time({job="api"} | logfmt | unwrap latency [5m]) by (level)
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
+    (toDateTime64('2025-12-31 23:58:00', 9), 'latency=10 path=/a', map('job', 'api', 'level', 'info')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'latency=20 path=/b', map('job', 'api', 'level', 'info')),
+    (toDateTime64('2025-12-31 23:58:00', 9), 'latency=100 path=/c', map('job', 'api', 'level', 'error')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'latency=200 path=/d', map('job', 'api', 'level', 'error'));
+-- expected_rows --
+[
+  [{"level": "error"}, 150.0],
+  [{"level": "info"}, 15.0]
+]
 -- args --
 [0] string = "level"
 [1] string = "level"

--- a/test/spec/logql/sum_by_job_rate.txtar
+++ b/test/spec/logql/sum_by_job_rate.txtar
@@ -1,5 +1,22 @@
 -- query.logql --
 sum by (job) (rate({app="api"}[5m]))
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
+    (toDateTime64('2025-12-31 23:58:00', 9), 'a', map('app', 'api', 'job', 'billing')),
+    (toDateTime64('2025-12-31 23:59:00', 9), 'b', map('app', 'api', 'job', 'billing')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'c', map('app', 'api', 'job', 'billing')),
+    (toDateTime64('2025-12-31 23:58:00', 9), 'd', map('app', 'api', 'job', 'orders')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'e', map('app', 'api', 'job', 'orders'));
+-- expected_rows --
+[
+  ["", {"job": "billing"}, "2026-01-01T00:00:01Z", 0.01],
+  ["", {"job": "orders"}, "2026-01-01T00:00:01Z", 0.006666666666666667]
+]
 -- sql --
 SELECT ? AS `MetricName`, map(?, `gkey_0`) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`[?] AS `gkey_0`, sum(`Value`) AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`)))) GROUP BY `ResourceAttributes`[?])
 -- args --

--- a/test/spec/logql/sum_count_over_time.txtar
+++ b/test/spec/logql/sum_count_over_time.txtar
@@ -1,5 +1,19 @@
 -- query.logql --
 sum(count_over_time({service_name="web-server"}[5m]))
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
+    (toDateTime64('2025-12-31 23:58:00', 9), 'a', map('service_name', 'web-server')),
+    (toDateTime64('2025-12-31 23:59:00', 9), 'b', map('service_name', 'web-server')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'c', map('service_name', 'web-server'));
+-- expected_rows --
+[
+  ["", {}, "2026-01-01T00:00:01Z", 3.0]
+]
 -- sql --
 SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Value` FROM (SELECT sum(`Value`) AS `Value`, count() AS `_cerb_n` FROM (SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1)) WHERE `_cerb_n` > 0)
 -- args --

--- a/test/spec/logql/sum_count_over_time_line_filter.txtar
+++ b/test/spec/logql/sum_count_over_time_line_filter.txtar
@@ -1,5 +1,19 @@
 -- query.logql --
 sum(count_over_time({service_name="web-server"} |= "level" [5m]))
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
+    (toDateTime64('2025-12-31 23:58:00', 9), 'level=info ready', map('service_name', 'web-server')),
+    (toDateTime64('2025-12-31 23:59:00', 9), 'startup banner', map('service_name', 'web-server')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'level=error oops', map('service_name', 'web-server'));
+-- expected_rows --
+[
+  ["", {}, "2026-01-01T00:00:01Z", 2.0]
+]
 -- sql --
 SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Value` FROM (SELECT sum(`Value`) AS `Value`, count() AS `_cerb_n` FROM (SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (position(`Body`, ?) > 0))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1)) WHERE `_cerb_n` > 0)
 -- args --

--- a/test/spec/logql/sum_rate.txtar
+++ b/test/spec/logql/sum_rate.txtar
@@ -1,5 +1,22 @@
 -- query.logql --
 sum(rate({job="api"}[1m]))
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
+    (toDateTime64('2025-12-31 23:59:10', 9), 'a', map('job', 'api')),
+    (toDateTime64('2025-12-31 23:59:20', 9), 'b', map('job', 'api')),
+    (toDateTime64('2025-12-31 23:59:30', 9), 'c', map('job', 'api')),
+    (toDateTime64('2025-12-31 23:59:40', 9), 'd', map('job', 'api')),
+    (toDateTime64('2025-12-31 23:59:50', 9), 'e', map('job', 'api')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'f', map('job', 'api'));
+-- expected_rows --
+[
+  ["", {}, "2026-01-01T00:00:01Z", 0.1]
+]
 -- sql --
 SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Value` FROM (SELECT sum(`Value`) AS `Value`, count() AS `_cerb_n` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(60000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))))) WHERE `_cerb_n` > 0)
 -- args --

--- a/test/spec/logql/sum_without_pod.txtar
+++ b/test/spec/logql/sum_without_pod.txtar
@@ -1,5 +1,21 @@
 -- query.logql --
 sum without (pod) (rate({job="api"}[5m]))
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
+    (toDateTime64('2025-12-31 23:58:00', 9), 'a', map('job', 'api', 'pod', 'p1', 'dc', 'us-east')),
+    (toDateTime64('2025-12-31 23:59:00', 9), 'b', map('job', 'api', 'pod', 'p1', 'dc', 'us-east')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'c', map('job', 'api', 'pod', 'p1', 'dc', 'us-east')),
+    (toDateTime64('2025-12-31 23:58:00', 9), 'd', map('job', 'api', 'pod', 'p2', 'dc', 'us-east')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'e', map('job', 'api', 'pod', 'p2', 'dc', 'us-east'));
+-- expected_rows --
+[
+  ["", {"dc": "us-east", "job": "api"}, "2026-01-01T00:00:01Z", 0.016666666666666666]
+]
 -- sql --
 SELECT ? AS `MetricName`, `gkey_0` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT mapFilter((k, v) -> NOT (k IN (?)), `ResourceAttributes`) AS `gkey_0`, sum(`Value`) AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`)))) GROUP BY mapFilter((k, v) -> NOT (k IN (?)), `ResourceAttributes`))
 -- args --


### PR DESCRIPTION
## Summary

- Adds `-- seed --` + `-- expected_rows --` blocks to 7 LogQL fixtures so the chDB round-trip layer actually asserts on emitted rows for the `sum`/`avg` + `rate`/`count_over_time` family
- Anchors each seed to the runner's deterministic `now64` literal (`2026-01-01T00:00:01Z`) so windowing is reproducible across CI runs
- Fixtures covered:
  - `sum_by_job_rate.txtar` — multi-job rate, group-by emits two series
  - `sum_count_over_time.txtar` — single series count
  - `sum_count_over_time_line_filter.txtar` — `|= "level"` body filter
  - `sum_rate.txtar` — 1m window, 6 events
  - `sum_without_pod.txtar` — drop pod, two pods merged
  - `range_agg_by_grouping.txtar` — `avg_over_time | logfmt | unwrap | by`
  - `avg_count_over_time.txtar` — avg of two count series

## Test plan

- [x] `go test -tags chdb ./test/spec/logql/... -run TestRoundTripChDB` — 98 passed
- [x] `go test ./internal/logql/...` — 119 passed (text-equality goldens unchanged)
- [x] `go build ./...`