### PR TITLE
test(logql): seed filter_bytes/duration/numeric for chDB Layer 6 roundtrip

### DIFF
--- a/test/spec/logql/filter_bytes.txtar
+++ b/test/spec/logql/filter_bytes.txtar
@@ -8,6 +8,20 @@
 [4] string = "\""
 [5] string = "size"
 [6] float64 = 10000
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES
+    ('ts=2026-01-01 size=5KB msg="small"'),
+    ('ts=2026-01-01 size=20KB msg="medium"'),
+    ('ts=2026-01-01 size=100KB msg="large"');
+-- expected_rows --
+[
+  ["ts=2026-01-01 size=20KB msg=\"medium\""],
+  ["ts=2026-01-01 size=100KB msg=\"large\""]
+]
 -- chplan --
 Filter predicate=((ResourceAttributes["job"] = "api") AND (parseReadableSize(mapConcat(ResourceAttributes, extractKeyValuePairs(Body, "=", " ", "\""))["size"]) > 10000))
   Scan(otel_logs)

--- a/test/spec/logql/filter_duration.txtar
+++ b/test/spec/logql/filter_duration.txtar
@@ -8,6 +8,20 @@
 [4] string = "\""
 [5] string = "latency"
 [6] float64 = 0.5
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES
+    ('ts=2026-01-01 latency=200ms msg="fast"'),
+    ('ts=2026-01-01 latency=1s msg="slow"'),
+    ('ts=2026-01-01 latency=2s msg="very_slow"');
+-- expected_rows --
+[
+  ["ts=2026-01-01 latency=1s msg=\"slow\""],
+  ["ts=2026-01-01 latency=2s msg=\"very_slow\""]
+]
 -- chplan --
 Filter predicate=((ResourceAttributes["job"] = "api") AND (parseTimeDelta(mapConcat(ResourceAttributes, extractKeyValuePairs(Body, "=", " ", "\""))["latency"]) > 0.5))
   Scan(otel_logs)

--- a/test/spec/logql/filter_numeric.txtar
+++ b/test/spec/logql/filter_numeric.txtar
@@ -8,6 +8,20 @@
 [4] string = "\""
 [5] string = "status"
 [6] float64 = 400
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES
+    ('ts=2026-01-01 status=200 msg="ok"'),
+    ('ts=2026-01-01 status=500 msg="server_error"'),
+    ('ts=2026-01-01 status=503 msg="unavailable"');
+-- expected_rows --
+[
+  ["ts=2026-01-01 status=500 msg=\"server_error\""],
+  ["ts=2026-01-01 status=503 msg=\"unavailable\""]
+]
 -- chplan --
 Filter predicate=((ResourceAttributes["job"] = "api") AND (toFloat64OrZero(mapConcat(ResourceAttributes, extractKeyValuePairs(Body, "=", " ", "\""))["status"]) > 400))
   Scan(otel_logs)


### PR DESCRIPTION
## Summary
- Adds `-- seed --` + `-- expected_rows --` sections to the three logfmt label-filter fixtures so they're covered by the chDB Layer 6 roundtrip pass (`go test -tags chdb ./test/spec/logql/... -run TestRoundTripChDB`) instead of stopping at text-equality.
- Each fixture seeds three log lines whose extracted key (`size` / `latency` / `status`) straddles the predicate boundary, exercising `parseReadableSize` / `parseTimeDelta` / `toFloat64OrZero` end-to-end against chDB.
- Task #44.

## Fixtures touched
- `test/spec/logql/filter_bytes.txtar` — `size > 10KB`; seed has `5KB` (rejected), `20KB` (kept), `100KB` (kept).
- `test/spec/logql/filter_duration.txtar` — `latency > 500ms`; seed has `200ms` (rejected), `1s` (kept), `2s` (kept).
- `test/spec/logql/filter_numeric.txtar` — `status > 400`; seed has `200` (rejected), `500` (kept), `503` (kept).

## Test plan
- [x] `go test -tags chdb ./test/spec/logql/... -run TestRoundTripChDB` passes locally — 98 total subtests, including the three newly-seeded ones.
- [x] `go test ./internal/logql/...` still passes (text-equality goldens unchanged).
- [x] `go build ./...` succeeds.