### PR TITLE
test(spec/logql): seed + expected_rows for 6 edge label/format fixtures

### DIFF
--- a/test/spec/logql/edge_decolorize_after_filter.txtar
+++ b/test/spec/logql/edge_decolorize_after_filter.txtar
@@ -6,6 +6,21 @@
 [2] string = "error"
 -- sql --
 SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (position(`Body`, ?) > 0)
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES
+    ('\x1b[31merror\x1b[0m red ansi'),
+    ('\x1b[1;33mwarn\x1b[0m yellow'),
+    ('\x1b[32mok\x1b[0m green'),
+    ('plain error no color');
+-- expected_rows --
+[
+  ["\u001b[31merror\u001b[0m red ansi"],
+  ["plain error no color"]
+]
 -- chplan --
 Filter predicate=((ResourceAttributes["job"] = "api") AND lineContent(Body, "error", substr))
   Scan(otel_logs)

--- a/test/spec/logql/edge_label_filter_and_then_line_filter.txtar
+++ b/test/spec/logql/edge_label_filter_and_then_line_filter.txtar
@@ -8,6 +8,25 @@
 [4] string = "timeout"
 -- sql --
 SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (`ResourceAttributes`[?] = ?) AND (position(`Body`, ?) > 0)
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map(
+        'job', 'api',
+        'level', if(Body LIKE 'i%', 'info', 'error')
+    )
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES
+    ('e1-timeout reading upstream'),
+    ('e2-timeout opening db'),
+    ('e3-no-match-here'),
+    ('i1-timeout but info level'),
+    ('i2-info quiet');
+-- expected_rows --
+[
+  ["e1-timeout reading upstream"],
+  ["e2-timeout opening db"]
+]
 -- chplan --
 Filter predicate=(((ResourceAttributes["job"] = "api") AND (ResourceAttributes["level"] = "error")) AND lineContent(Body, "timeout", substr))
   Scan(otel_logs)

--- a/test/spec/logql/edge_label_filter_or_chain.txtar
+++ b/test/spec/logql/edge_label_filter_or_chain.txtar
@@ -11,6 +11,30 @@
 [7] string = "fatal"
 -- sql --
 SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (((`ResourceAttributes`[?] = ?) OR (`ResourceAttributes`[?] = ?)) OR (`ResourceAttributes`[?] = ?))
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map(
+        'job', 'api',
+        'level',
+            if(Body = 'r1-err', 'error',
+            if(Body = 'r2-warn', 'warn',
+            if(Body = 'r3-fatal', 'fatal',
+            if(Body = 'r4-info', 'info', 'debug'))))
+    )
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES
+    ('r1-err'),
+    ('r2-warn'),
+    ('r3-fatal'),
+    ('r4-info'),
+    ('r5-debug');
+-- expected_rows --
+[
+  ["r1-err"],
+  ["r2-warn"],
+  ["r3-fatal"]
+]
 -- chplan --
 Filter predicate=((ResourceAttributes["job"] = "api") AND (((ResourceAttributes["level"] = "error") OR (ResourceAttributes["level"] = "warn")) OR (ResourceAttributes["level"] = "fatal")))
   Scan(otel_logs)

--- a/test/spec/logql/edge_label_format_rename_and_template.txtar
+++ b/test/spec/logql/edge_label_format_rename_and_template.txtar
@@ -5,6 +5,21 @@
 [1] string = "api"
 -- sql --
 SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?)
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map(
+        'job', 'api',
+        'severity', if(Body = 'lf1', 'high', if(Body = 'lf2', 'low', 'medium'))
+    )
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES ('lf1'), ('lf2'), ('lf3');
+-- expected_rows --
+[
+  ["lf1"],
+  ["lf2"],
+  ["lf3"]
+]
 -- chplan --
 Filter predicate=(ResourceAttributes["job"] = "api")
   Scan(otel_logs)

--- a/test/spec/logql/edge_label_format_template.txtar
+++ b/test/spec/logql/edge_label_format_template.txtar
@@ -5,6 +5,20 @@
 [1] string = "api"
 -- sql --
 SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?)
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map(
+        'job', 'api',
+        'severity', if(Body = 'tpl1', 'critical', 'normal')
+    )
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES ('tpl1'), ('tpl2');
+-- expected_rows --
+[
+  ["tpl1"],
+  ["tpl2"]
+]
 -- chplan --
 Filter predicate=(ResourceAttributes["job"] = "api")
   Scan(otel_logs)

--- a/test/spec/logql/edge_line_format_missing_label.txtar
+++ b/test/spec/logql/edge_line_format_missing_label.txtar
@@ -5,6 +5,17 @@
 [1] string = "api"
 -- sql --
 SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?)
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES ('lfmt1 original'), ('lfmt2 original');
+-- expected_rows --
+[
+  ["lfmt1 original"],
+  ["lfmt2 original"]
+]
 -- chplan --
 Filter predicate=(ResourceAttributes["job"] = "api")
   Scan(otel_logs)


### PR DESCRIPTION
## Summary

Adds chDB round-trip coverage (`seed:` + `expected_rows:`) to six previously-unseeded edge fixtures under `test/spec/logql/`:

- `edge_label_filter_and_then_line_filter` — label filter (`level="error"`) followed by line filter (`|= "timeout"`); seed mixes matching rows, level-mismatch rows, and one row that matches the line filter but the wrong level so the AND'd predicate has something real to prune.
- `edge_label_filter_or_chain` — three-way `level="error" or level="warn" or level="fatal"`; seed covers each branch plus two non-matching levels (`info`, `debug`).
- `edge_label_format_rename_and_template` — `label_format svc=job, lvl="{{.severity}}"`; seed includes the `severity` label so the formatter's source labels exist (label_format is a Go-side post-process; the SQL just streams rows, the runner asserts SQL output).
- `edge_label_format_template` — single-target `label_format severity_level="{{.severity}}-level"`; same shape with a single-rename template.
- `edge_decolorize_after_filter` — line filter `|= "error"` then `| decolorize`; seed bodies embed ANSI color sequences via CH's `\x1b[...m` literal so the row stream that decolorize would strip is non-trivial. Expected rows JSON-encode the surviving ESC bytes as `` (decolorize is post-process; the runner asserts the SQL output containing the color codes).
- `edge_line_format_missing_label` — `line_format "[{{.nonexistent}}] {{__line__}}"`; asserts the SQL row stream is unchanged (Loki's silent-fallback for missing template labels is a Go-side post-process that the SQL knows nothing about).

## Test plan

- [x] `go test -tags chdb ./test/spec/logql/... -run TestRoundTripChDB/edge_(label_filter_and_then_line_filter|label_filter_or_chain|label_format_rename_and_template|label_format_template|decolorize_after_filter|line_format_missing_label) -v` passes locally.
- [x] `go test ./internal/logql/...` text-equality goldens still pass (no SQL / chplan section drift).
- [x] `go build ./...` clean.