### PR TITLE
test(logql): seed 4 edge_line_filter fixtures for chDB roundtrip coverage

### DIFF
--- a/test/spec/logql/edge_line_filter_chained_3.txtar
+++ b/test/spec/logql/edge_line_filter_chained_3.txtar
@@ -8,6 +8,23 @@
 [4] string = "timeout"
 -- sql --
 SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (position(`Body`, ?) > 0) AND (position(`Body`, ?) > 0) AND (position(`Body`, ?) > 0)
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES
+    ('error: db query timeout exceeded'),
+    ('error: db query failed'),
+    ('warn: timeout on db pool'),
+    ('error queue overflow timeout'),
+    ('info: request served'),
+    ('error: db pool timeout after retry');
+-- expected_rows --
+[
+  ["error: db query timeout exceeded"],
+  ["error: db pool timeout after retry"]
+]
 -- chplan --
 Filter predicate=((ResourceAttributes["job"] = "api") AND ((lineContent(Body, "error", substr) AND lineContent(Body, "db", substr)) AND lineContent(Body, "timeout", substr)))
   Scan(otel_logs)

--- a/test/spec/logql/edge_line_filter_chained_5_mixed.txtar
+++ b/test/spec/logql/edge_line_filter_chained_5_mixed.txtar
@@ -10,6 +10,25 @@
 [6] string = "prod"
 -- sql --
 SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (position(`Body`, ?) > 0) AND (position(`Body`, ?) = 0) AND match(`Body`, ?) AND NOT match(`Body`, ?) AND (position(`Body`, ?) > 0)
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES
+    ('error 503 in prod'),
+    ('error 502 prod backend'),
+    ('error 200 in prod'),
+    ('error 504 prod debug session'),
+    ('test: error 500 prod'),
+    ('error 500 staging'),
+    ('error 599 prod fallback');
+-- expected_rows --
+[
+  ["error 503 in prod"],
+  ["error 502 prod backend"],
+  ["error 599 prod fallback"]
+]
 -- chplan --
 Filter predicate=((ResourceAttributes["job"] = "api") AND ((((lineContent(Body, "error", substr) AND lineContent(Body, "debug", substr,not)) AND lineContent(Body, "5[0-9]{2}", regex)) AND lineContent(Body, "^test", regex,not)) AND lineContent(Body, "prod", substr)))
   Scan(otel_logs)

--- a/test/spec/logql/edge_line_filter_not_chain_3.txtar
+++ b/test/spec/logql/edge_line_filter_not_chain_3.txtar
@@ -8,6 +8,24 @@
 [4] string = "trace"
 -- sql --
 SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (position(`Body`, ?) = 0) AND (position(`Body`, ?) = 0) AND (position(`Body`, ?) = 0)
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES
+    ('warn: pool exhausted'),
+    ('error: request failed'),
+    ('info: started server'),
+    ('debug: handler entered'),
+    ('trace: span emitted'),
+    ('fatal: panic recovered');
+-- expected_rows --
+[
+  ["warn: pool exhausted"],
+  ["error: request failed"],
+  ["fatal: panic recovered"]
+]
 -- chplan --
 Filter predicate=((ResourceAttributes["job"] = "api") AND ((lineContent(Body, "info", substr,not) AND lineContent(Body, "debug", substr,not)) AND lineContent(Body, "trace", substr,not)))
   Scan(otel_logs)

--- a/test/spec/logql/edge_line_filter_or_alt_chain.txtar
+++ b/test/spec/logql/edge_line_filter_or_alt_chain.txtar
@@ -8,6 +8,25 @@
 [4] string = "panic"
 -- sql --
 SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (((position(`Body`, ?) > 0) OR (position(`Body`, ?) > 0)) OR (position(`Body`, ?) > 0))
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES
+    ('error: connection refused'),
+    ('fatal: out of memory'),
+    ('panic: nil dereference'),
+    ('info: heartbeat ok'),
+    ('warn: retry queued'),
+    ('debug: error masked by panic recovery');
+-- expected_rows --
+[
+  ["error: connection refused"],
+  ["fatal: out of memory"],
+  ["panic: nil dereference"],
+  ["debug: error masked by panic recovery"]
+]
 -- chplan --
 Filter predicate=((ResourceAttributes["job"] = "api") AND ((lineContent(Body, "error", substr) OR lineContent(Body, "fatal", substr)) OR lineContent(Body, "panic", substr)))
   Scan(otel_logs)


### PR DESCRIPTION
## Summary

Add `-- seed --` + `-- expected_rows --` blocks to four chained line-filter edge fixtures so the chDB roundtrip lane asserts row-level semantics, not just SQL text equality:

- `edge_line_filter_chained_3` — AND chain of three substring filters (`|= "error" |= "db" |= "timeout"`)
- `edge_line_filter_chained_5_mixed` — AND chain mixing `|=`, `!=`, `|~`, `!~`, `|=` (substring + regex, positive + negated)
- `edge_line_filter_not_chain_3` — AND chain of three `!=` substring exclusions
- `edge_line_filter_or_alt_chain` — OR-alternation across three substring terms (`|= "error" or "fatal" or "panic"`)

Each fixture follows the seeded shape introduced in PR #473 / #472:
- `Body String` + `ResourceAttributes Map(String,String) MATERIALIZED map('job','api')` so `SELECT *` scans only `Body`, keeping `expected_rows` single-column.
- 6 rows per fixture covering hit / miss / near-miss to exercise each predicate clause independently.

## Test plan

- [x] `go test -tags chdb ./test/spec/logql/... -run TestRoundTripChDB -v` — full LogQL chDB suite (98 fixtures) PASS.
- [x] `go test -tags chdb ./test/spec/logql/... -run "TestRoundTripChDB/edge_line_filter" -v` — 4 modified fixtures + 1 pre-existing edge_line_filter case PASS.
- [x] `go build ./...` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)