### PR TITLE
test(spec/logql): seed + expected_rows for 5 edge pattern/unpack fixtures

### DIFF
--- a/test/spec/logql/edge_multistage_filter_unpack_format.txtar
+++ b/test/spec/logql/edge_multistage_filter_unpack_format.txtar
@@ -6,6 +6,20 @@
 [2] string = "packed"
 -- sql --
 SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (position(`Body`, ?) > 0)
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES
+    ('p1 packed pod=p1 level=info msg=first'),
+    ('p2 packed pod=p2 level=error msg=second'),
+    ('p3 unrelated line with no marker');
+-- expected_rows --
+[
+  ["p1 packed pod=p1 level=info msg=first"],
+  ["p2 packed pod=p2 level=error msg=second"]
+]
 -- chplan --
 Filter predicate=((ResourceAttributes["job"] = "api") AND lineContent(Body, "packed", substr))
   Scan(otel_logs)

--- a/test/spec/logql/edge_multistage_pattern_filter_format.txtar
+++ b/test/spec/logql/edge_multistage_pattern_filter_format.txtar
@@ -7,6 +7,24 @@
 [3] string = "error"
 -- sql --
 SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (`ResourceAttributes`[?] = ?)
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map(
+        'job', 'api',
+        'level', if(Body LIKE 'm1%', 'error', if(Body LIKE 'm2%', 'error', if(Body LIKE 'm3%', 'warn', 'info')))
+    )
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES
+    ('m1 ts error db timeout'),
+    ('m2 ts error upstream gone'),
+    ('m3 ts warn slow query'),
+    ('m4 ts info background sync');
+-- expected_rows --
+[
+  ["m1 ts error db timeout"],
+  ["m2 ts error upstream gone"]
+]
 -- chplan --
 Filter predicate=((ResourceAttributes["job"] = "api") AND (ResourceAttributes["level"] = "error"))
   Scan(otel_logs)

--- a/test/spec/logql/edge_pattern_msg_then_filter.txtar
+++ b/test/spec/logql/edge_pattern_msg_then_filter.txtar
@@ -7,6 +7,23 @@
 [3] string = "^$"
 -- sql --
 SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND NOT match(`ResourceAttributes`[?], ?)
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map(
+        'job', 'api',
+        'msg', if(Body = 'r3-blank', '', if(Body LIKE 'r1%', 'hello', 'quick'))
+    )
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES
+    ('r1 hello world'),
+    ('r2 quick test'),
+    ('r3-blank');
+-- expected_rows --
+[
+  ["r1 hello world"],
+  ["r2 quick test"]
+]
 -- chplan --
 Filter predicate=((ResourceAttributes["job"] = "api") AND (ResourceAttributes["msg"] !~ "^$"))
   Scan(otel_logs)

--- a/test/spec/logql/edge_pattern_multi_capture.txtar
+++ b/test/spec/logql/edge_pattern_multi_capture.txtar
@@ -7,6 +7,24 @@
 [3] string = "error"
 -- sql --
 SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (`ResourceAttributes`[?] = ?)
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map(
+        'job', 'api',
+        'level', if(Body LIKE 'e%', 'error', if(Body LIKE 'w%', 'warn', 'info'))
+    )
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES
+    ('e1 2026-01-01 error db timeout'),
+    ('e2 2026-01-01 error upstream gone'),
+    ('w1 2026-01-01 warn slow'),
+    ('i1 2026-01-01 info ok');
+-- expected_rows --
+[
+  ["e1 2026-01-01 error db timeout"],
+  ["e2 2026-01-01 error upstream gone"]
+]
 -- chplan --
 Filter predicate=((ResourceAttributes["job"] = "api") AND (ResourceAttributes["level"] = "error"))
   Scan(otel_logs)

--- a/test/spec/logql/edge_unpack_then_label_filter.txtar
+++ b/test/spec/logql/edge_unpack_then_label_filter.txtar
@@ -7,6 +7,27 @@
 [3] string = "warn|error"
 -- sql --
 SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND match(`ResourceAttributes`[?], ?)
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map(
+        'job', 'api',
+        'level',
+            if(Body = 'u1', 'warn',
+            if(Body = 'u2', 'error',
+            if(Body = 'u3', 'info', 'debug')))
+    )
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES
+    ('u1'),
+    ('u2'),
+    ('u3'),
+    ('u4');
+-- expected_rows --
+[
+  ["u1"],
+  ["u2"]
+]
 -- chplan --
 Filter predicate=((ResourceAttributes["job"] = "api") AND (ResourceAttributes["level"] =~ "warn|error"))
   Scan(otel_logs)


### PR DESCRIPTION
## Summary

Adds chDB round-trip coverage (`seed:` + `expected_rows:`) to five previously-unseeded edge fixtures under `test/spec/logql/` whose pipelines exercise the pattern / unpack post-process stages:

- `edge_pattern_msg_then_filter` — `| pattern "<_> <msg> <_>" | msg !~ "^$"`. The lowered SQL filters on `ResourceAttributes["msg"]` so the seed materializes `msg` per-row (one row left blank). Expected rows keep the two non-blank bodies.
- `edge_pattern_multi_capture` — `| pattern "<ts> <level> <msg>" | level="error"`. Seed materializes `level` from Body prefix (`e*` → error, `w*` → warn, `i*` → info); expected rows keep the two error bodies.
- `edge_multistage_filter_unpack_format` — `|= "packed" | unpack | line_format`. Bodies marked with the literal `packed` substring so `position(Body, "packed") > 0` has prunable rows; the no-marker line is excluded. (Bodies avoid `{`/`[` prefixes so the runner's JSON heuristic doesn't promote them to maps.)
- `edge_multistage_pattern_filter_format` — `| pattern | level="error" | line_format`. Same shape as `edge_pattern_multi_capture`; seed materializes level on body-prefix, expected rows keep the two error rows.
- `edge_unpack_then_label_filter` — `| unpack | level=~"warn|error"`. Seed materializes level on a per-marker if-chain; expected rows keep the warn / error rows.

Pattern / unpack stages are Go-side post-process — the SQL just streams rows, so `expected_rows:` asserts the SQL output (raw Body), not the post-processed Loki streams envelope. Convention mirrors PR #474's edge_decolorize / edge_label_filter / edge_label_format / edge_line_format fixtures.

## Test plan

- [x] `go test -tags chdb ./test/spec/logql/... -run "TestRoundTripChDB/(edge_pattern_msg_then_filter|edge_pattern_multi_capture|edge_multistage_filter_unpack_format|edge_multistage_pattern_filter_format|edge_unpack_then_label_filter)" -v` passes locally.
- [x] `go test -tags chdb ./test/spec/logql/...` full suite passes (no other fixture regressed).
- [x] `go test ./internal/logql/...` text-equality goldens still pass (no SQL / chplan section drift).
- [x] `go build ./...` clean.