### PR TITLE
test(spec/logql): seed 5 edge bytes/count/sum fixtures for chDB round-trip

### DIFF
--- a/test/spec/logql/edge_bytes_over_time_filter.txtar
+++ b/test/spec/logql/edge_bytes_over_time_filter.txtar
@@ -6,6 +6,21 @@ bytes_over_time({job="api"} |= "request"[5m])
 [2] string = "request"
 -- sql --
 SELECT `ResourceAttributes`, arraySum(window_vals) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, toFloat64(length(`Body`)) AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (position(`Body`, ?) > 0))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
+    (toDateTime64('2025-12-31 23:58:00', 9), 'request-1', map('job', 'api')),
+    (toDateTime64('2025-12-31 23:59:00', 9), 'request-2', map('job', 'api')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'request-3', map('job', 'api')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'noise log', map('job', 'api'));
+-- expected_rows --
+[
+  [{"job": "api"}, 27.0]
+]
 -- chplan --
 RangeWindow func=sum_over_time range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
   Project [ResourceAttributes, Timestamp, toFloat64(length(Body)) AS Value]

--- a/test/spec/logql/edge_bytes_rate_with_chain.txtar
+++ b/test/spec/logql/edge_bytes_rate_with_chain.txtar
@@ -7,6 +7,21 @@ bytes_rate({job="api"} |~ "req|resp"[5m])
 [3] string = "req|resp"
 -- sql --
 SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, toFloat64(length(`Body`)) AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND match(`Body`, ?))) GROUP BY `ResourceAttributes`)))
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
+    (toDateTime64('2025-12-31 23:58:00', 9), 'req-line01', map('job', 'api')),
+    (toDateTime64('2025-12-31 23:59:00', 9), 'resp-line2', map('job', 'api')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'req-data99', map('job', 'api')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'unrelated9', map('job', 'api'));
+-- expected_rows --
+[
+  [{"job": "api"}, 0.1]
+]
 -- chplan --
 RangeWindow func=log_rate range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
   Project [ResourceAttributes, Timestamp, toFloat64(length(Body)) AS Value]

--- a/test/spec/logql/edge_count_over_time_filter.txtar
+++ b/test/spec/logql/edge_count_over_time_filter.txtar
@@ -8,6 +8,22 @@ count_over_time({job="api"} |= "error" != "test"[5m])
 [4] string = "test"
 -- sql --
 SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (position(`Body`, ?) > 0) AND (position(`Body`, ?) = 0))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
+    (toDateTime64('2025-12-31 23:58:00', 9), 'error in handler', map('job', 'api')),
+    (toDateTime64('2025-12-31 23:59:00', 9), 'error in production', map('job', 'api')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'error fatal stop', map('job', 'api')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'error in test suite', map('job', 'api')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'all clear status', map('job', 'api'));
+-- expected_rows --
+[
+  [{"job": "api"}, 3.0]
+]
 -- chplan --
 RangeWindow func=count_over_time range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
   Project [ResourceAttributes, Timestamp, 1 AS Value]

--- a/test/spec/logql/edge_sum_by_rate.txtar
+++ b/test/spec/logql/edge_sum_by_rate.txtar
@@ -15,6 +15,24 @@ sum by (job, level) (rate({job="api"}[5m]))
 [11] string = "level"
 -- sql --
 SELECT ? AS `MetricName`, map(?, `gkey_0`, ?, `gkey_1`) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`[?] AS `gkey_0`, `ResourceAttributes`[?] AS `gkey_1`, sum(`Value`) AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`)))) GROUP BY `ResourceAttributes`[?], `ResourceAttributes`[?])
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
+    (toDateTime64('2025-12-31 23:58:00', 9), 'a', map('job', 'api', 'level', 'info')),
+    (toDateTime64('2025-12-31 23:59:00', 9), 'b', map('job', 'api', 'level', 'info')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'c', map('job', 'api', 'level', 'info')),
+    (toDateTime64('2025-12-31 23:58:00', 9), 'd', map('job', 'api', 'level', 'error')),
+    (toDateTime64('2025-12-31 23:59:00', 9), 'e', map('job', 'api', 'level', 'error')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'f', map('job', 'api', 'level', 'error'));
+-- expected_rows --
+[
+  ["", {"job": "api", "level": "error"}, "2026-01-01T00:00:01Z", 0.01],
+  ["", {"job": "api", "level": "info"}, "2026-01-01T00:00:01Z", 0.01]
+]
 -- chplan --
 Project ["" AS MetricName, map("job", gkey_0, "level", gkey_1) AS Attributes, now64(9) AS TimeUnix, Value AS Value]
   Aggregate groupBy=[ResourceAttributes["job"] AS gkey_0, ResourceAttributes["level"] AS gkey_1] funcs=[sum(Value) AS Value]

--- a/test/spec/logql/edge_sum_without_rate.txtar
+++ b/test/spec/logql/edge_sum_without_rate.txtar
@@ -13,6 +13,22 @@ sum without (instance, pod) (rate({job="api"}[5m]))
 [9] string = "pod"
 -- sql --
 SELECT ? AS `MetricName`, `gkey_0` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT mapFilter((k, v) -> NOT (k IN (?, ?)), `ResourceAttributes`) AS `gkey_0`, sum(`Value`) AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`)))) GROUP BY mapFilter((k, v) -> NOT (k IN (?, ?)), `ResourceAttributes`))
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
+    (toDateTime64('2025-12-31 23:58:00', 9), 'a', map('job', 'api', 'pod', 'p1', 'instance', 'i1', 'dc', 'us-east')),
+    (toDateTime64('2025-12-31 23:59:00', 9), 'b', map('job', 'api', 'pod', 'p1', 'instance', 'i1', 'dc', 'us-east')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'c', map('job', 'api', 'pod', 'p1', 'instance', 'i1', 'dc', 'us-east')),
+    (toDateTime64('2025-12-31 23:58:00', 9), 'd', map('job', 'api', 'pod', 'p2', 'instance', 'i2', 'dc', 'us-east')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'e', map('job', 'api', 'pod', 'p2', 'instance', 'i2', 'dc', 'us-east'));
+-- expected_rows --
+[
+  ["", {"dc": "us-east", "job": "api"}, "2026-01-01T00:00:01Z", 0.016666666666666666]
+]
 -- chplan --
 Project ["" AS MetricName, gkey_0 AS Attributes, now64(9) AS TimeUnix, Value AS Value]
   Aggregate groupBy=[mapWithout(ResourceAttributes, [instance, pod]) AS gkey_0] funcs=[sum(Value) AS Value]


### PR DESCRIPTION
## Summary

Adds `-- seed --` + `-- expected_rows --` blocks to 5 LogQL edge fixtures so the `TestRoundTripChDB` Layer 6 round-trip pass actually exercises them:

- `edge_bytes_over_time_filter.txtar` — `bytes_over_time({job="api"} |= "request"[5m])`. Seeds three matching log lines of 9 bytes each plus one noise row that fails the substring filter; expected total = 27.
- `edge_bytes_rate_with_chain.txtar` — `bytes_rate({job="api"} |~ "req|resp"[5m])`. Three matching lines of 10 bytes each, /300s → rate = 0.1.
- `edge_count_over_time_filter.txtar` — `count_over_time({job="api"} |= "error" != "test"[5m])`. Five seed rows; three pass the include + exclude filters → count = 3.
- `edge_sum_by_rate.txtar` — `sum by (job, level) (rate({job="api"}[5m]))`. Two distinct series (info, error), three events each, expected = `[0.01, 0.01]` per (job, level).
- `edge_sum_without_rate.txtar` — `sum without (instance, pod) (rate({job="api"}[5m]))`. Two pod/instance series fold into one (job, dc) group; rates 0.01 + 0.00666... = 0.01666...

Follows the table-shape conventions established by PR #472 (sum_*, range_agg) and PR #473 (filter_*). All timestamps anchor to `2026-01-01 00:00:00`, matching the `nowAnchorLiteral` the chDB runner substitutes for `now64(...)`.

## Test plan

- [x] `go test -tags chdb ./test/spec/logql/... -run TestRoundTripChDB -v` — all 5 fixtures PASS, 98 fixture cases total.
- [x] `go test ./internal/logql/... -run TestLower` — 119 PASS (no golden regression).
- [x] `go build ./...` — clean.