### PR TITLE
test(spec/logql): seed 5 unwrap_* fixtures for chDB Layer 6 roundtrip

### DIFF
--- a/internal/logql/range_aggregation.go
+++ b/internal/logql/range_aggregation.go
@@ -262,9 +262,19 @@ func unwrapValueExpr(u *syntax.UnwrapExpr, labelsExpr chplan.Expr) (chplan.Expr,
 			Args: []chplan.Expr{access},
 		}, nil
 	case syntax.OpConvBytes:
+		// `parseReadableSize` returns UInt64 (CH 24.x+); wrap in
+		// `toFloat64` so the downstream windowed-array math (especially
+		// the counter_delta arrayMap that does `if(c < p, c, c - p)`)
+		// can resolve a common type — chDB refuses to mix UInt64
+		// branches with their signed-subtraction siblings. Aligns with
+		// the comment above and matches the `length(Body)` path in
+		// `rangeValueExpr` which is also toFloat64-wrapped.
 		return &chplan.FuncCall{
-			Name: "parseReadableSize",
-			Args: []chplan.Expr{access},
+			Name: "toFloat64",
+			Args: []chplan.Expr{&chplan.FuncCall{
+				Name: "parseReadableSize",
+				Args: []chplan.Expr{access},
+			}},
 		}, nil
 	}
 	return nil, fmt.Errorf("logql: unsupported unwrap conversion %q", u.Operation)

--- a/test/spec/logql/unwrap_avg_over_time.txtar
+++ b/test/spec/logql/unwrap_avg_over_time.txtar
@@ -14,3 +14,17 @@ RangeWindow func=avg_over_time range=5m0s step=0s ts=Timestamp value=Value group
       Scan(otel_logs)
 -- sql --
 SELECT `ResourceAttributes`, if(length(window_vals) > 0, arrayAvg(window_vals), nan) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, toFloat64OrZero(mapConcat(`ResourceAttributes`, extractKeyValuePairs(`Body`, ?, ?, ?))[?]) AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
+    (toDateTime64('2025-12-31 23:58:00', 9), 'latency=1.5 msg=ok', map('job', 'api')),
+    (toDateTime64('2025-12-31 23:59:00', 9), 'latency=2.5 msg=ok', map('job', 'api')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'latency=3.5 msg=ok', map('job', 'api'));
+-- expected_rows --
+[
+  [{"job": "api"}, 2.5]
+]

--- a/test/spec/logql/unwrap_bytes.txtar
+++ b/test/spec/logql/unwrap_bytes.txtar
@@ -9,8 +9,22 @@ sum_over_time({job="api"} | logfmt | unwrap bytes(size) [5m])
 [5] string = "api"
 -- chplan --
 RangeWindow func=sum_over_time range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-  Project [ResourceAttributes, Timestamp, parseReadableSize(mapConcat(ResourceAttributes, extractKeyValuePairs(Body, "=", " ", "\""))["size"]) AS Value]
+  Project [ResourceAttributes, Timestamp, toFloat64(parseReadableSize(mapConcat(ResourceAttributes, extractKeyValuePairs(Body, "=", " ", "\""))["size"])) AS Value]
     Filter predicate=(ResourceAttributes["job"] = "api")
       Scan(otel_logs)
 -- sql --
-SELECT `ResourceAttributes`, arraySum(window_vals) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, parseReadableSize(mapConcat(`ResourceAttributes`, extractKeyValuePairs(`Body`, ?, ?, ?))[?]) AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1
+SELECT `ResourceAttributes`, arraySum(window_vals) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, toFloat64(parseReadableSize(mapConcat(`ResourceAttributes`, extractKeyValuePairs(`Body`, ?, ?, ?))[?])) AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
+    (toDateTime64('2025-12-31 23:58:00', 9), 'size=1KB msg=ok', map('job', 'api')),
+    (toDateTime64('2025-12-31 23:59:00', 9), 'size=2KB msg=ok', map('job', 'api')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'size=3KB msg=ok', map('job', 'api'));
+-- expected_rows --
+[
+  [{"job": "api"}, 6000.0]
+]

--- a/test/spec/logql/unwrap_duration_seconds.txtar
+++ b/test/spec/logql/unwrap_duration_seconds.txtar
@@ -14,3 +14,17 @@ RangeWindow func=sum_over_time range=5m0s step=0s ts=Timestamp value=Value group
       Scan(otel_logs)
 -- sql --
 SELECT `ResourceAttributes`, arraySum(window_vals) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, parseTimeDelta(mapConcat(`ResourceAttributes`, extractKeyValuePairs(`Body`, ?, ?, ?))[?]) AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
+    (toDateTime64('2025-12-31 23:58:00', 9), 'latency=500ms msg=ok', map('job', 'api')),
+    (toDateTime64('2025-12-31 23:59:00', 9), 'latency=1s msg=ok', map('job', 'api')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'latency=2s msg=ok', map('job', 'api'));
+-- expected_rows --
+[
+  [{"job": "api"}, 3.5]
+]

--- a/test/spec/logql/unwrap_quantile_over_time.txtar
+++ b/test/spec/logql/unwrap_quantile_over_time.txtar
@@ -14,3 +14,17 @@ RangeWindow func=quantile_over_time range=5m0s step=0s ts=Timestamp value=Value 
       Scan(otel_logs)
 -- sql --
 SELECT `ResourceAttributes`, if(length(window_vals) > 0, arrayReduce('quantile(0.95)', window_vals), nan) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, toFloat64OrZero(mapConcat(`ResourceAttributes`, extractKeyValuePairs(`Body`, ?, ?, ?))[?]) AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
+    (toDateTime64('2025-12-31 23:58:00', 9), 'latency=1.5 msg=ok', map('job', 'api')),
+    (toDateTime64('2025-12-31 23:59:00', 9), 'latency=2.5 msg=ok', map('job', 'api')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'latency=3.5 msg=ok', map('job', 'api'));
+-- expected_rows --
+[
+  [{"job": "api"}, 3.3999999999999995]
+]

--- a/test/spec/logql/unwrap_sum_over_time.txtar
+++ b/test/spec/logql/unwrap_sum_over_time.txtar
@@ -14,3 +14,17 @@ RangeWindow func=sum_over_time range=5m0s step=0s ts=Timestamp value=Value group
       Scan(otel_logs)
 -- sql --
 SELECT `ResourceAttributes`, arraySum(window_vals) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, toFloat64OrZero(mapConcat(`ResourceAttributes`, extractKeyValuePairs(`Body`, ?, ?, ?))[?]) AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
+    (toDateTime64('2025-12-31 23:58:00', 9), 'latency=1.5 msg=ok', map('job', 'api')),
+    (toDateTime64('2025-12-31 23:59:00', 9), 'latency=2.5 msg=ok', map('job', 'api')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'latency=3.5 msg=ok', map('job', 'api'));
+-- expected_rows --
+[
+  [{"job": "api"}, 7.5]
+]


### PR DESCRIPTION
## Summary

- Adds `-- seed --` + `-- expected_rows --` to the five LogQL
  `unwrap_*` range-aggregation fixtures: `unwrap_avg_over_time`,
  `unwrap_bytes`, `unwrap_duration_seconds`,
  `unwrap_quantile_over_time`, `unwrap_sum_over_time`. The seeds
  plant `latency=<val>` / `size=<KB>` strings in `Body` so
  `extractKeyValuePairs(Body, "=", " ", "\"")` resolves the unwrap
  identifier; timestamps anchor to the `2026-01-01 00:00:01` instant
  the runner splices in for `now64(9)` so all three rows fall inside
  the 5m window.

- Wraps `parseReadableSize(...)` in `toFloat64` in the LogQL
  unwrap-bytes lowering path (`internal/logql/range_aggregation.go`).
  The CH function returns `UInt64`, and the downstream windowed-array
  `counter_delta` arrayMap (`if(c < p, c, c - p)`) fails to resolve a
  supertype (UInt64 branch vs Int64 subtraction). The doc-comment
  block already documented Float64 as the intent and the sibling
  `length(Body)` byte-counter path is toFloat64-wrapped for the same
  reason — this aligns the unwrap-bytes path with that contract.

## Per-fixture results

5m windows over the seeded rows:

| fixture                             | result               |
| ---                                 | ---                  |
| `unwrap_sum_over_time`              | 7.5                  |
| `unwrap_avg_over_time`              | 2.5                  |
| `unwrap_quantile_over_time` (0.95)  | 3.3999999999999995   |
| `unwrap_bytes` (1KB+2KB+3KB)        | 6000.0               |
| `unwrap_duration_seconds` (500ms+1s+2s) | 3.5              |

## Test plan

- [x] `go test -tags chdb ./test/spec/logql/... -run TestRoundTripChDB` — all 5 unwrap fixtures pass, no regression on the rest of the LogQL corpus.
- [x] `go test ./internal/logql/... -count=1` — TXTAR goldens regenerated via `GOLDEN_UPDATE=1` for the `unwrap_bytes` chplan/sql diff; remaining fixtures' goldens unchanged.
- [x] `go build ./...` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)