### PR TITLE
test(traceql): seed chDB roundtrip for 7 flip_event/link fixtures

### DIFF
--- a/test/spec/traceql/flip_event_eq_fallthrough.txtar
+++ b/test/spec/traceql/flip_event_eq_fallthrough.txtar
@@ -5,6 +5,16 @@ SELECT * FROM `otel_traces` WHERE arrayExists(x -> x[?] = ?, `Events`.`Attribute
 -- args --
 [0] string = "name"
 [1] string = "exception"
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    `Events.Attributes` Array(Map(String, String)) MATERIALIZED if(_idx = 0, [map('name', 'exception')], [map('name', 'other')])
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1);
+-- expected_rows --
+[
+  [0]
+]
 -- chplan --
 Filter predicate=nestedArrayExists(Events.Attributes["name"] = "exception")
   Scan(otel_traces)

--- a/test/spec/traceql/flip_event_ge.txtar
+++ b/test/spec/traceql/flip_event_ge.txtar
@@ -5,6 +5,16 @@ SELECT * FROM `otel_traces` WHERE arrayExists(x -> x[?] <= ?, `Events`.`Attribut
 -- args --
 [0] string = "code"
 [1] int64 = 500
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    `Events.Attributes` Array(Map(String, Int64)) MATERIALIZED if(_idx = 0, [map('code', toInt64(200))], [map('code', toInt64(900))])
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1);
+-- expected_rows --
+[
+  [0]
+]
 -- chplan --
 Filter predicate=nestedArrayExists(Events.Attributes["code"] <= 500)
   Scan(otel_traces)

--- a/test/spec/traceql/flip_event_lt_duration.txtar
+++ b/test/spec/traceql/flip_event_lt_duration.txtar
@@ -5,6 +5,16 @@ SELECT * FROM `otel_traces` WHERE arrayExists(x -> x[?] > ?, `Events`.`Attribute
 -- args --
 [0] string = "duration"
 [1] int64 = 100000000
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    `Events.Attributes` Array(Map(String, Int64)) MATERIALIZED if(_idx = 0, [map('duration', toInt64(200000000))], [map('duration', toInt64(50000000))])
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1);
+-- expected_rows --
+[
+  [0]
+]
 -- chplan --
 Filter predicate=nestedArrayExists(Events.Attributes["duration"] > 100000000)
   Scan(otel_traces)

--- a/test/spec/traceql/flip_link_ge.txtar
+++ b/test/spec/traceql/flip_link_ge.txtar
@@ -5,6 +5,16 @@ SELECT * FROM `otel_traces` WHERE arrayExists(x -> x[?] <= ?, `Links`.`Attribute
 -- args --
 [0] string = "severity"
 [1] string = "warn"
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    `Links.Attributes` Array(Map(String, String)) MATERIALIZED if(_idx = 0, [map('severity', 'info')], [map('severity', 'xyz')])
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1);
+-- expected_rows --
+[
+  [0]
+]
 -- chplan --
 Filter predicate=nestedArrayExists(Links.Attributes["severity"] <= "warn")
   Scan(otel_traces)

--- a/test/spec/traceql/flip_link_le.txtar
+++ b/test/spec/traceql/flip_link_le.txtar
@@ -5,6 +5,16 @@ SELECT * FROM `otel_traces` WHERE arrayExists(x -> x[?] >= ?, `Links`.`Attribute
 -- args --
 [0] string = "severity"
 [1] string = "info"
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    `Links.Attributes` Array(Map(String, String)) MATERIALIZED if(_idx = 0, [map('severity', 'warn')], [map('severity', 'debug')])
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1);
+-- expected_rows --
+[
+  [0]
+]
 -- chplan --
 Filter predicate=nestedArrayExists(Links.Attributes["severity"] >= "info")
   Scan(otel_traces)

--- a/test/spec/traceql/flip_link_ne_fallthrough.txtar
+++ b/test/spec/traceql/flip_link_ne_fallthrough.txtar
@@ -5,6 +5,16 @@ SELECT * FROM `otel_traces` WHERE arrayExists(x -> x[?] != ?, `Links`.`Attribute
 -- args --
 [0] string = "environment"
 [1] string = "prod"
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    `Links.Attributes` Array(Map(String, String)) MATERIALIZED if(_idx = 0, [map('environment', 'staging')], [map('environment', 'prod')])
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1);
+-- expected_rows --
+[
+  [0]
+]
 -- chplan --
 Filter predicate=nestedArrayExists(Links.Attributes["environment"] != "prod")
   Scan(otel_traces)

--- a/test/spec/traceql/flip_link_numeric.txtar
+++ b/test/spec/traceql/flip_link_numeric.txtar
@@ -5,6 +5,16 @@ SELECT * FROM `otel_traces` WHERE arrayExists(x -> x[?] > ?, `Links`.`Attributes
 -- args --
 [0] string = "http_status"
 [1] int64 = 500
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    `Links.Attributes` Array(Map(String, Int64)) MATERIALIZED if(_idx = 0, [map('http_status', toInt64(900))], [map('http_status', toInt64(200))])
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1);
+-- expected_rows --
+[
+  [0]
+]
 -- chplan --
 Filter predicate=nestedArrayExists(Links.Attributes["http_status"] > 500)
   Scan(otel_traces)


### PR DESCRIPTION
## Summary

Adds `-- seed --` + `-- expected_rows --` blocks to 7 TraceQL flip fixtures so they exercise the post-flip canonical SQL against an in-process chDB session (Layer 2b round-trip pass).

Fixtures:
- `flip_event_eq_fallthrough` (eq, symmetric — no rewrite)
- `flip_event_ge` (numeric event-attribute)
- `flip_event_lt_duration` (duration event-attribute)
- `flip_link_ge` (string link-attribute)
- `flip_link_le` (string link-attribute)
- `flip_link_ne_fallthrough` (ne, symmetric — no rewrite)
- `flip_link_numeric` (numeric link-attribute)

Numeric event/link comparisons seed `Array(Map(String, Int64))` so the int64-bound argument from the emitted SQL has a matching CH supertype (the OTel-CH default is `Map(String, String)`, but the lowering pass for `event.*` / `link.*` doesn't insert a `toFloat64` cast around the map subscript today — the test seed mirrors what the post-flip SQL actually expects to scan).

## Test plan

- [x] `go test -tags chdb ./test/spec/traceql/... -run TestRoundTripChDB -v` — all 7 fixtures pass.
- [x] Full `TestRoundTripChDB` suite (132/132 passing).
- [x] `go test ./internal/traceql/...` — chplan + lower goldens unchanged (303/303 passing).
- [x] `go build ./...` — clean.