### PR TITLE
feat(api/tempo): emit Tempo-canonical scope-prefixed group-by labels

### DIFF
--- a/internal/api/tempo/metrics_phi_label_test.go
+++ b/internal/api/tempo/metrics_phi_label_test.go
@@ -157,3 +157,140 @@ func equalSlice(a, b []string) bool {
 	}
 	return true
 }
+
+// TestMetricsLabelNames_TempoCanonicalDisplay pins the
+// metricsLabelNames contract on the chplan-IR side: when the
+// MetricsAggregate carries GroupByDisplayNames, those names win over
+// the SQL aliases — the handler surfaces the scope-prefixed wire form
+// to Grafana, not the bare alias used inside the SQL emit.
+//
+// Mirrors upstream Tempo's response shape; see the long comment on
+// metricsLabelNames for the upstream cross-references. The test is
+// purely on the helper rather than the full handler so a regression
+// surfaces at the right altitude (a wrong label-name selection inside
+// the helper, not a wrong JSON marshal).
+func TestMetricsLabelNames_TempoCanonicalDisplay(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		aliases []string
+		display []string
+		want    []string
+	}{
+		{
+			name:    "resource scope: display wins, prefix appears",
+			aliases: []string{"service.name"},
+			display: []string{"resource.service.name"},
+			want:    []string{"resource.service.name"},
+		},
+		{
+			name:    "span scope: same shape, different prefix",
+			aliases: []string{"http.method"},
+			display: []string{"span.http.method"},
+			want:    []string{"span.http.method"},
+		},
+		{
+			name:    "intrinsic: display == alias (no scope prefix)",
+			aliases: []string{"kind"},
+			display: []string{"kind"},
+			want:    []string{"kind"},
+		},
+		{
+			name:    "mixed: order preserved across resource/intrinsic/span",
+			aliases: []string{"service.name", "kind", "http.method"},
+			display: []string{"resource.service.name", "kind", "span.http.method"},
+			want:    []string{"resource.service.name", "kind", "span.http.method"},
+		},
+		{
+			name:    "legacy / non-TraceQL: empty display, fallback to aliases",
+			aliases: []string{"service.name"},
+			display: nil,
+			want:    []string{"service.name"},
+		},
+		{
+			name:    "partial display: per-slot fallback to alias for blank slots",
+			aliases: []string{"service.name", "http.method"},
+			display: []string{"resource.service.name", ""},
+			want:    []string{"resource.service.name", "http.method"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			groupBy := make([]chplan.Expr, len(tc.aliases))
+			for i := range groupBy {
+				groupBy[i] = &chplan.ColumnRef{Name: tc.aliases[i]}
+			}
+			got := metricsLabelNames(&chplan.MetricsAggregate{
+				GroupBy:             groupBy,
+				GroupByAliases:      tc.aliases,
+				GroupByDisplayNames: tc.display,
+			})
+			if !equalSlice(got, tc.want) {
+				t.Fatalf("metricsLabelNames = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestWrapMetricsForSample_DisplayNameKeysAttributesMap pins the
+// Attributes-map projection contract on the matrix-shape wrap: the
+// LHS (KEY) of each `map(<key>, toString(<col>))` pair uses the
+// Tempo-canonical display name when one is set, while the RHS (VALUE)
+// keeps referencing the SQL-side alias. The two slices decouple
+// deliberately — the chsql emitter aliases the SELECT column as the
+// bare path for compact column names, and the wire layer prefixes the
+// scope for upstream Tempo parity.
+func TestWrapMetricsForSample_DisplayNameKeysAttributesMap(t *testing.T) {
+	t.Parallel()
+
+	rw := &chplan.RangeWindow{}
+	m := &chplan.MetricsAggregate{
+		GroupBy:             []chplan.Expr{&chplan.ColumnRef{Name: "x"}},
+		GroupByAliases:      []string{"service.name"},
+		GroupByDisplayNames: []string{"resource.service.name"},
+		ValueAlias:          "Value",
+	}
+
+	node := wrapMetricsForSample(rw, m)
+	proj, ok := node.(*chplan.Project)
+	if !ok {
+		t.Fatalf("wrapMetricsForSample: got %T, want *chplan.Project", node)
+	}
+	if len(proj.Projections) < 2 {
+		t.Fatalf("project has %d projections, want >= 2", len(proj.Projections))
+	}
+	call, ok := proj.Projections[1].Expr.(*chplan.FuncCall)
+	if !ok || call.Name != "map" {
+		t.Fatalf("Attributes expr = %T (%v), want *chplan.FuncCall(map)", proj.Projections[1].Expr, proj.Projections[1].Expr)
+	}
+	if len(call.Args) < 2 {
+		t.Fatalf("map call has %d args, want >= 2", len(call.Args))
+	}
+	keyLit, ok := call.Args[0].(*chplan.LitString)
+	if !ok {
+		t.Fatalf("map arg[0] = %T, want *chplan.LitString (the KEY)", call.Args[0])
+	}
+	if keyLit.V != "resource.service.name" {
+		t.Errorf("Attributes map key = %q, want %q (Tempo-canonical wire form)",
+			keyLit.V, "resource.service.name")
+	}
+	// And the VALUE side wraps toString around the SQL-side alias, not
+	// the display name.
+	valueCall, ok := call.Args[1].(*chplan.FuncCall)
+	if !ok || valueCall.Name != "toString" {
+		t.Fatalf("map arg[1] = %T (%v), want toString(<alias>)", call.Args[1], call.Args[1])
+	}
+	if len(valueCall.Args) != 1 {
+		t.Fatalf("toString call has %d args, want 1", len(valueCall.Args))
+	}
+	colRef, ok := valueCall.Args[0].(*chplan.ColumnRef)
+	if !ok {
+		t.Fatalf("toString arg = %T, want *chplan.ColumnRef (the SQL alias)", valueCall.Args[0])
+	}
+	if colRef.Name != "service.name" {
+		t.Errorf("toString column ref = %q, want %q (the bare SQL alias)",
+			colRef.Name, "service.name")
+	}
+}

--- a/internal/api/tempo/metrics_query_range.go
+++ b/internal/api/tempo/metrics_query_range.go
@@ -349,6 +349,16 @@ const tempoMultiQuantilePhiLabel = "__phi__"
 // when there's no GroupBy); MetricName is empty (TraceQL has no
 // __name__); anchor_ts arrives as DateTime64(9) → time.Time on the wire.
 //
+// The Attributes map's keys are the Tempo-canonical wire names from
+// metricsLabelNames (scope-prefixed `resource.service.name`,
+// `span.http.method`, etc., mirroring upstream Tempo's response shape).
+// The values still reference the SQL-side bare aliases via attrAliases
+// — the SELECT-list column for `by (resource.service.name)` is aliased
+// as `service.name`, while the row's Attributes map key is
+// `resource.service.name`. Decoupling the two slices lets the chsql
+// emitter keep emitting compact column aliases without disturbing the
+// wire shape Grafana's Tempo datasource consumes.
+//
 // When MetricsAggregate.Quantiles carries multiple phi values, the chsql
 // emitter projects an extra `__phi__` String column per row; this wrap
 // includes it as a synthetic Attributes entry so each (group × phi)
@@ -414,15 +424,31 @@ func metricsOuterGroupAliases(groupBy []chplan.Expr, aliases []string) []string 
 }
 
 // metricsLabelNames returns the user-facing label names the response's
-// {key,value} pairs surface — the lowering's GroupByAliases with a
-// fallback ("group_0", ...) for any empty alias slot, plus the
+// {key,value} pairs surface — the lowering's GroupByDisplayNames (the
+// Tempo-canonical scope-prefixed wire form such as
+// `resource.service.name`, `span.http.method`, or a bare intrinsic name
+// like `kind`), with a fallback to GroupByAliases (bare attribute
+// path) when the lowering didn't populate the display slice, and a
+// further fallback ("group_0", ...) for any empty slot. Plus the
 // synthetic `__phi__` label when MetricsAggregate.Quantiles carries
 // more than one phi value (the chsql multi-quantile fan-out adds the
 // extra column to the matrix shape).
+//
+// Aligning with the upstream Tempo response shape: the reference
+// /api/metrics/query_range emits `resource.service.name` for a
+// `by (resource.service.name)` clause — see grafana/tempo
+// `pkg/traceql.Attribute.String` and the metrics-engine `labelsFor`
+// loop, plus the integration test in `integration/api/query_range_test.go`
+// that asserts `label.Key == "resource.res_attr"` for a
+// `by (resource.res_attr)` query.
 func metricsLabelNames(m *chplan.MetricsAggregate) []string {
 	n := len(m.GroupBy)
 	out := make([]string, 0, n+1)
 	for i := 0; i < n; i++ {
+		if i < len(m.GroupByDisplayNames) && m.GroupByDisplayNames[i] != "" {
+			out = append(out, m.GroupByDisplayNames[i])
+			continue
+		}
 		if i < len(m.GroupByAliases) && m.GroupByAliases[i] != "" {
 			out = append(out, m.GroupByAliases[i])
 			continue

--- a/internal/api/tempo/metrics_query_range_test.go
+++ b/internal/api/tempo/metrics_query_range_test.go
@@ -540,14 +540,16 @@ func TestMetricsQueryRange_ExemplarsEnvelope(t *testing.T) {
 // Attributes` column. attachExemplars keys each exemplar against its
 // matching series via the by(...) label canonical key.
 //
-// Note: the stubbed Labels map keys use the lowering alias
-// (`service.name`) rather than the source TraceQL attribute name
-// (`resource.service.name`). The chsql emitter projects the inner
-// SELECT with `ResourceAttributes['service.name'] AS service.name`
-// (alias drops the scope prefix), and the matrix/exemplar wrap
-// projections key the outer `Attributes` map by that alias. So real
-// CH returns Sample.Labels keyed by `service.name`; the stub must
-// mirror that for attachExemplars's by-label match to succeed.
+// Note: the stubbed Labels map keys use the Tempo-canonical wire form
+// (`resource.service.name`) rather than the SQL-side alias
+// (`service.name`). The chsql emitter projects the inner SELECT with
+// `ResourceAttributes['service.name'] AS service.name` (the SQL alias
+// drops the scope prefix to keep column names compact), but the outer
+// matrix and exemplar projections key the `Attributes` map by the
+// scope-prefixed display name so the wire shape matches upstream
+// Tempo's metrics-query response. attachExemplars matches each
+// exemplar to its parent series via canonical label-set hash, so both
+// the matrix branch and exemplars branch must agree on the key form.
 func TestMetricsQueryRange_ExemplarsPopulated(t *testing.T) {
 	t.Parallel()
 
@@ -557,15 +559,17 @@ func TestMetricsQueryRange_ExemplarsPopulated(t *testing.T) {
 	q := &stubQuerier{
 		samples: []chclient.Sample{
 			// Matrix branch — one series, two anchors. Labels are keyed
-			// by the lowering alias (`service.name`), matching what the
-			// chsql emitter projects via the outer `Attributes` map.
+			// by the Tempo-canonical scope-prefixed wire name
+			// (`resource.service.name`), matching what
+			// wrapMetricsForSample projects via the outer `Attributes`
+			// map.
 			{
-				Labels:    map[string]string{"service.name": "frontend"},
+				Labels:    map[string]string{"resource.service.name": "frontend"},
 				Timestamp: ts(0),
 				Value:     12,
 			},
 			{
-				Labels:    map[string]string{"service.name": "frontend"},
+				Labels:    map[string]string{"resource.service.name": "frontend"},
 				Timestamp: ts(1),
 				Value:     18,
 			},
@@ -574,23 +578,24 @@ func TestMetricsQueryRange_ExemplarsPopulated(t *testing.T) {
 			// Exemplars branch — one trace-anchored sample per anchor,
 			// carrying the trace:id + span:id pair attachExemplars
 			// surfaces under Exemplar.TraceID / SpanID. The by(...)
-			// alias key (`service.name`) lets attachExemplars match the
-			// exemplar back to its parent series.
+			// display key (`resource.service.name`) lets
+			// attachExemplars match the exemplar back to its parent
+			// series by canonical label-set hash.
 			"exemplar_trace_id": {
 				{
 					Labels: map[string]string{
-						"service.name": "frontend",
-						"trace:id":     "0123456789abcdef0123456789abcdef",
-						"span:id":      "0011223344556677",
+						"resource.service.name": "frontend",
+						"trace:id":              "0123456789abcdef0123456789abcdef",
+						"span:id":               "0011223344556677",
 					},
 					Timestamp: ts(0),
 					Value:     1,
 				},
 				{
 					Labels: map[string]string{
-						"service.name": "frontend",
-						"trace:id":     "fedcba9876543210fedcba9876543210",
-						"span:id":      "aabbccddeeff0011",
+						"resource.service.name": "frontend",
+						"trace:id":              "fedcba9876543210fedcba9876543210",
+						"span:id":               "aabbccddeeff0011",
 					},
 					Timestamp: ts(1),
 					Value:     1,
@@ -691,3 +696,95 @@ func TestMetricsQueryRange_ExemplarsPopulated(t *testing.T) {
 		}
 	}
 }
+
+// TestMetricsQueryRange_ResourceLabelWireShape conforms cerberus's
+// metrics-query response to upstream Tempo's wire shape for
+// resource-scoped group-by labels.
+//
+// Upstream Tempo emits the full scope-prefixed form
+// `resource.service.name` on the response Labels list for a
+// `by (resource.service.name)` clause (see grafana/tempo
+// `pkg/traceql.Attribute.String` and `engine_metrics.go::labelsFor`;
+// the upstream integration test `integration/api/query_range_test.go`
+// pins `label.Key == "resource.res_attr"` for the equivalent query).
+//
+// Cerberus's SQL emitter aliases the inner SELECT column as the bare
+// path (`AS service.name`) to keep CH column names short, but the
+// matrix-shape outer wrap projects the `Attributes` map with the
+// Tempo-canonical scope-prefixed key — so the chclient.Sample.Labels
+// the handler decodes carries `resource.service.name`, and the JSON
+// envelope mirrors that. This test feeds a stub Sample whose Labels
+// map uses the wire-canonical key (matching what the matrix SQL would
+// produce post-wrap) and asserts the JSON `labels[].key` reads
+// `resource.service.name`.
+func TestMetricsQueryRange_ResourceLabelWireShape(t *testing.T) {
+	t.Parallel()
+
+	ts := func(min int) time.Time {
+		return time.Date(2026, 5, 12, 10, min, 0, 0, time.UTC)
+	}
+	q := &stubQuerier{samples: []chclient.Sample{
+		// The matrix outer SELECT emits `map('resource.service.name', toString(service.name), ...)`
+		// — see wrapMetricsForSample. The decoded Sample.Labels map is
+		// therefore keyed by the scope-prefixed wire form, not the bare
+		// SQL alias. The stub mirrors that contract.
+		{Labels: map[string]string{"resource.service.name": "frontend"}, Timestamp: ts(0), Value: 12},
+		{Labels: map[string]string{"resource.service.name": "frontend"}, Timestamp: ts(1), Value: 18},
+		{Labels: map[string]string{"resource.service.name": "backend"}, Timestamp: ts(0), Value: 3},
+	}}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	u := metricsQueryRangeURL(srv.URL,
+		"{} | count_over_time() by (resource.service.name)",
+		map[string]string{
+			"start": fixtureStartUnix,
+			"end":   fixtureEndUnix,
+			"step":  "60s",
+		})
+	resp, err := http.Get(u)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+
+	raw := readBody(t, resp)
+	// The Tempo-canonical wire key MUST appear verbatim (the assertion
+	// is on the bytes Grafana / a tempopb consumer actually reads).
+	wantSub := `"key":"resource.service.name"`
+	if !strings.Contains(raw, wantSub) {
+		t.Fatalf("response missing wire-canonical resource-scope key %q\nbody=%s", wantSub, raw)
+	}
+	// And the bare-alias form (the SQL-side alias) MUST NOT appear as a
+	// response key — that would mean the wrap leaked the alias to the
+	// wire instead of the scope-prefixed display name.
+	badSub := `"key":"service.name"`
+	if strings.Contains(raw, badSub) {
+		t.Errorf("response surfaces bare SQL alias %q where the Tempo-canonical form is required\nbody=%s",
+			badSub, raw)
+	}
+
+	// Decode the response through the typed struct and verify every
+	// series's first (and only) label carries the prefixed key.
+	var body tempo.MetricsQueryRangeResponse
+	if err := json.NewDecoder(strings.NewReader(raw)).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Series) != 2 {
+		t.Fatalf("expected 2 series, got %d: %+v", len(body.Series), body)
+	}
+	for i, s := range body.Series {
+		if len(s.Labels) != 1 {
+			t.Errorf("series[%d]: expected 1 label, got %+v", i, s.Labels)
+			continue
+		}
+		if s.Labels[0].Key != "resource.service.name" {
+			t.Errorf("series[%d].Labels[0].Key = %q, want %q",
+				i, s.Labels[0].Key, "resource.service.name")
+		}
+	}
+}
+

--- a/internal/api/tempo/metrics_query_range_test.go
+++ b/internal/api/tempo/metrics_query_range_test.go
@@ -787,4 +787,3 @@ func TestMetricsQueryRange_ResourceLabelWireShape(t *testing.T) {
 		}
 	}
 }
-

--- a/internal/chplan/equal_invariants_test.go
+++ b/internal/chplan/equal_invariants_test.go
@@ -1178,6 +1178,35 @@ func TestMetricsHistogramOverTime_Equal_Negative_InnerNilPresence(t *testing.T) 
 	}
 }
 
+func TestMetricsHistogramOverTime_Equal_Negative_GroupByDisplayNames(t *testing.T) {
+	t.Parallel()
+	// Same SQL alias on both sides, but only one side carries the
+	// Tempo-canonical display name. Equal must split them apart so the
+	// IR comparator (used by optimizer-rule rewrite tests + Walk
+	// invariants) catches a regression that drops the display-name
+	// slot.
+	a := &chplan.MetricsHistogramOverTime{
+		GroupBy:        []chplan.Expr{&chplan.ColumnRef{Name: "X"}},
+		GroupByAliases: []string{"service.name"},
+		Inner:          &chplan.Scan{Table: "t"},
+	}
+	b := &chplan.MetricsHistogramOverTime{
+		GroupBy:             []chplan.Expr{&chplan.ColumnRef{Name: "X"}},
+		GroupByAliases:      []string{"service.name"},
+		GroupByDisplayNames: []string{"resource.service.name"},
+		Inner:               &chplan.Scan{Table: "t"},
+	}
+	if a.Equal(b) || b.Equal(a) {
+		t.Errorf("display-name presence should differentiate Equal in both directions")
+	}
+	// Same alias, different display prefixes.
+	c := *b
+	c.GroupByDisplayNames = []string{"span.service.name"}
+	if b.Equal(&c) {
+		t.Errorf("different GroupByDisplayNames should not be Equal")
+	}
+}
+
 // -----------------------------------------------------------------------
 // Expr Equal tests — coverage parallel to node_negatives_test.go,
 // focused on positive cases the existing file does not exercise.

--- a/internal/chplan/metrics_aggregate.go
+++ b/internal/chplan/metrics_aggregate.go
@@ -101,7 +101,7 @@ func (o MetricsOp) String() string {
 //     for SELECT-list aliasing (mirrors chplan.Aggregate).
 //   - GroupByAliases: SQL SELECT-list alias for each GroupBy entry.
 //     Bare-named (e.g. `service.name`) so the chsql emitter renders
-//     `AS \`service.name\`` regardless of TraceQL scope.
+//     `AS \`service.name\“ regardless of TraceQL scope.
 //   - GroupByDisplayNames: optional parallel slice carrying the
 //     TraceQL-canonical wire label name for each GroupBy entry — the
 //     scope-prefixed form (`resource.service.name`, `span.http.method`,

--- a/internal/chplan/metrics_aggregate.go
+++ b/internal/chplan/metrics_aggregate.go
@@ -99,6 +99,20 @@ func (o MetricsOp) String() string {
 //     Nil for rate and count_over_time (no operand at the source).
 //   - GroupBy: the `by(...)` label expressions; parallel to GroupByAliases
 //     for SELECT-list aliasing (mirrors chplan.Aggregate).
+//   - GroupByAliases: SQL SELECT-list alias for each GroupBy entry.
+//     Bare-named (e.g. `service.name`) so the chsql emitter renders
+//     `AS \`service.name\`` regardless of TraceQL scope.
+//   - GroupByDisplayNames: optional parallel slice carrying the
+//     TraceQL-canonical wire label name for each GroupBy entry — the
+//     scope-prefixed form (`resource.service.name`, `span.http.method`,
+//     intrinsic name like `kind`) that the Tempo metrics-query response
+//     surfaces. When empty (PromQL/LogQL paths never populate it) the
+//     Tempo handler falls back to GroupByAliases, preserving the
+//     historical wire shape for non-TraceQL callers. Tempo emits the
+//     full scope-prefixed key (see upstream
+//     `pkg/traceql.Attribute.String` + the metrics-engine label-build
+//     loop) so cerberus mirrors that shape on the response without
+//     altering the SQL-side alias used for column projection.
 //   - Quantiles: the quantile values for MetricsOpQuantileOverTime;
 //     today the lowering accepts a single quantile, so len(Quantiles)
 //     is always 1 for that op. Empty for all other ops.
@@ -113,13 +127,14 @@ func (o MetricsOp) String() string {
 // TimestampColumn slot; the per-span Timestamp column is the matrix
 // shape's bucket key.
 type MetricsAggregate struct {
-	Op             MetricsOp
-	Attr           Expr
-	GroupBy        []Expr
-	GroupByAliases []string
-	Quantiles      []float64
-	ValueAlias     string
-	Inner          Node
+	Op                  MetricsOp
+	Attr                Expr
+	GroupBy             []Expr
+	GroupByAliases      []string
+	GroupByDisplayNames []string
+	Quantiles           []float64
+	ValueAlias          string
+	Inner               Node
 }
 
 func (*MetricsAggregate) planNode() {}
@@ -153,6 +168,14 @@ func (m *MetricsAggregate) Equal(other Node) bool {
 	}
 	for i := range m.GroupByAliases {
 		if m.GroupByAliases[i] != o.GroupByAliases[i] {
+			return false
+		}
+	}
+	if len(m.GroupByDisplayNames) != len(o.GroupByDisplayNames) {
+		return false
+	}
+	for i := range m.GroupByDisplayNames {
+		if m.GroupByDisplayNames[i] != o.GroupByDisplayNames[i] {
 			return false
 		}
 	}

--- a/internal/chplan/metrics_aggregate_test.go
+++ b/internal/chplan/metrics_aggregate_test.go
@@ -91,6 +91,24 @@ func TestMetricsAggregateEqual(t *testing.T) {
 		t.Errorf("different GroupByAliases should not be Equal")
 	}
 
+	// GroupByDisplayNames diff — populated on one side, empty on the
+	// other (the legacy / non-TraceQL path leaves it empty).
+	withDisplay := *same
+	withDisplay.GroupByDisplayNames = []string{"resource.service.name"}
+	if base.Equal(&withDisplay) {
+		t.Errorf("display-name presence should differentiate Equal")
+	}
+	if withDisplay.Equal(base) {
+		t.Errorf("display-name presence should differentiate Equal (other side)")
+	}
+
+	// GroupByDisplayNames diff — different prefixes (resource vs. span).
+	otherDisplay := withDisplay
+	otherDisplay.GroupByDisplayNames = []string{"span.service.name"}
+	if withDisplay.Equal(&otherDisplay) {
+		t.Errorf("different GroupByDisplayNames should not be Equal")
+	}
+
 	// GroupBy len diff.
 	moreGroup := *same
 	moreGroup.GroupBy = append([]chplan.Expr{}, same.GroupBy...)

--- a/internal/chplan/metrics_histogram_over_time.go
+++ b/internal/chplan/metrics_histogram_over_time.go
@@ -37,6 +37,17 @@ package chplan
 //     duration cases — duration attrs encode as nanos already).
 //   - GroupBy: the user-supplied `by(...)` label expressions; parallel
 //     to GroupByAliases for SELECT-list aliasing.
+//   - GroupByAliases: SQL SELECT-list alias for each GroupBy entry.
+//     Bare-named for resource / span attributes (`service.name`,
+//     `http.method`) so the chsql emitter renders `AS \`<bare>\`` with no
+//     scope prefix in the column name.
+//   - GroupByDisplayNames: optional parallel slice carrying the
+//     TraceQL-canonical wire label name for each GroupBy entry — the
+//     scope-prefixed form (`resource.service.name`, `span.http.method`)
+//     that the Tempo metrics-query response surfaces. When empty the
+//     Tempo handler falls back to GroupByAliases. Mirrors the same field
+//     on MetricsAggregate; see that type for the cross-reference to
+//     Tempo's upstream wire shape.
 //   - BucketAlias: the SELECT-list alias for the synthesised bucket
 //     column. The TraceQL runtime uses the internal label name
 //     "__bucket"; cerberus mirrors that so downstream `/api/metrics/query_range`
@@ -46,13 +57,14 @@ package chplan
 //   - Inner: the underlying spanset relation — typically a Filter
 //     / Scan tree from the `{...}` selector.
 type MetricsHistogramOverTime struct {
-	Attr           Expr
-	IsDuration     bool
-	GroupBy        []Expr
-	GroupByAliases []string
-	BucketAlias    string
-	ValueAlias     string
-	Inner          Node
+	Attr                Expr
+	IsDuration          bool
+	GroupBy             []Expr
+	GroupByAliases      []string
+	GroupByDisplayNames []string
+	BucketAlias         string
+	ValueAlias          string
+	Inner               Node
 }
 
 func (*MetricsHistogramOverTime) planNode() {}
@@ -88,6 +100,14 @@ func (m *MetricsHistogramOverTime) Equal(other Node) bool {
 	}
 	for i := range m.GroupByAliases {
 		if m.GroupByAliases[i] != o.GroupByAliases[i] {
+			return false
+		}
+	}
+	if len(m.GroupByDisplayNames) != len(o.GroupByDisplayNames) {
+		return false
+	}
+	for i := range m.GroupByDisplayNames {
+		if m.GroupByDisplayNames[i] != o.GroupByDisplayNames[i] {
 			return false
 		}
 	}

--- a/internal/chplan/metrics_histogram_over_time.go
+++ b/internal/chplan/metrics_histogram_over_time.go
@@ -39,7 +39,7 @@ package chplan
 //     to GroupByAliases for SELECT-list aliasing.
 //   - GroupByAliases: SQL SELECT-list alias for each GroupBy entry.
 //     Bare-named for resource / span attributes (`service.name`,
-//     `http.method`) so the chsql emitter renders `AS \`<bare>\`` with no
+//     `http.method`) so the chsql emitter renders `AS \`<bare>\“ with no
 //     scope prefix in the column name.
 //   - GroupByDisplayNames: optional parallel slice carrying the
 //     TraceQL-canonical wire label name for each GroupBy entry — the

--- a/internal/chsql/exemplars.go
+++ b/internal/chsql/exemplars.go
@@ -126,6 +126,22 @@ func (e *emitter) emitMetricsExemplars(
 	}
 
 	groupAliases := outerGroupAliases(m.GroupBy, m.GroupByAliases)
+	// Attributes-map keys: prefer the lowering's display names (the
+	// Tempo-canonical scope-prefixed form, e.g. `resource.service.name`)
+	// so the exemplar response uses the same wire labels as the matrix
+	// shape. Falls back to the SQL alias when the lowering didn't
+	// populate display names (PromQL paths leave them empty; no
+	// behaviour change for those). The KEYS of the resulting Attributes
+	// map are the wire labels; the VALUES still reference the SQL-side
+	// alias via Col(alias).
+	groupDisplayNames := make([]string, len(groupAliases))
+	for i, alias := range groupAliases {
+		if i < len(m.GroupByDisplayNames) && m.GroupByDisplayNames[i] != "" {
+			groupDisplayNames[i] = m.GroupByDisplayNames[i]
+			continue
+		}
+		groupDisplayNames[i] = alias
+	}
 
 	innerSb := NewQuery().From(inner)
 	for i, g := range m.GroupBy {
@@ -158,12 +174,20 @@ func (e *emitter) emitMetricsExemplars(
 	// Attributes carries the group-by labels plus the trace:id / span:id
 	// keys attachExemplars reads. Group aliases reference the inner
 	// SELECT (grouped + scalar), so toString(<alias>) is a valid SELECT
-	// item under the outer GROUP BY (alias, anchor_ts).
+	// item under the outer GROUP BY (alias, anchor_ts). The KEY side of
+	// the map uses the Tempo-canonical display name (e.g.
+	// `resource.service.name`) so the exemplar wire shape matches the
+	// matrix-shape labels produced by
+	// internal/api/tempo/metrics_query_range.go::wrapMetricsForSample;
+	// attachExemplars matches each exemplar to its parent series by
+	// canonical label-set hash, so the two label-key projections must
+	// agree.
 	attrMapFrags := make([]Frag, 0, len(groupAliases)*2+4)
-	for _, alias := range groupAliases {
+	for i, alias := range groupAliases {
 		a := alias
+		display := groupDisplayNames[i]
 		attrMapFrags = append(attrMapFrags,
-			Lit(a),
+			Lit(display),
 			Call("toString", Col(a)),
 		)
 	}

--- a/internal/traceql/histogram_over_time_test.go
+++ b/internal/traceql/histogram_over_time_test.go
@@ -83,6 +83,10 @@ func TestLowerHistogramOverTime(t *testing.T) {
 				t.Errorf("GroupBy / GroupByAliases length mismatch: %d vs %d",
 					len(h.GroupBy), len(h.GroupByAliases))
 			}
+			if len(h.GroupBy) > 0 && len(h.GroupBy) != len(h.GroupByDisplayNames) {
+				t.Errorf("GroupBy / GroupByDisplayNames length mismatch: %d vs %d",
+					len(h.GroupBy), len(h.GroupByDisplayNames))
+			}
 			if h.Inner == nil {
 				t.Errorf("Inner is nil; want the spanset tree")
 			}

--- a/internal/traceql/metrics_pipeline.go
+++ b/internal/traceql/metrics_pipeline.go
@@ -261,7 +261,7 @@ func lowerMetricsHistogramOverTime(prev chplan.Node, agg *traceql.MetricsAggrega
 //
 //   - aliases: the SQL SELECT-list alias. For a scoped attribute this is
 //     the bare `attr.Name` (e.g. `service.name` for `resource.service.name`)
-//     so the emitter renders `AS \`service.name\`` — keeping the column
+//     so the emitter renders `AS \`service.name\“ — keeping the column
 //     name short and identifying the carrier-side payload only. Locking
 //     in the bare form preserves the existing TXTAR SQL fixtures.
 //   - display: the Tempo-canonical wire label name (`attr.String()`).

--- a/internal/traceql/metrics_pipeline.go
+++ b/internal/traceql/metrics_pipeline.go
@@ -88,7 +88,7 @@ func lowerMetricsAggregate(prev chplan.Node, agg *traceql.MetricsAggregate, s sc
 		return nil, err
 	}
 
-	groupBy, groupAliases, err := lowerMetricsGroupBy(agg.GroupBy(), s)
+	groupBy, groupAliases, groupDisplay, err := lowerMetricsGroupBy(agg.GroupBy(), s)
 	if err != nil {
 		return nil, err
 	}
@@ -111,13 +111,14 @@ func lowerMetricsAggregate(prev chplan.Node, agg *traceql.MetricsAggregate, s sc
 	}
 
 	return &chplan.MetricsAggregate{
-		Op:             cop,
-		Attr:           attr,
-		GroupBy:        groupBy,
-		GroupByAliases: groupAliases,
-		Quantiles:      quantiles,
-		ValueAlias:     metricsValueAlias,
-		Inner:          prev,
+		Op:                  cop,
+		Attr:                attr,
+		GroupBy:             groupBy,
+		GroupByAliases:      groupAliases,
+		GroupByDisplayNames: groupDisplay,
+		Quantiles:           quantiles,
+		ValueAlias:          metricsValueAlias,
+		Inner:               prev,
 	}, nil
 }
 
@@ -140,18 +141,19 @@ func lowerAverageOverTime(prev chplan.Node, agg *traceql.AverageOverTimeAggregat
 		return nil, err
 	}
 
-	groupBy, groupAliases, err := lowerMetricsGroupBy(agg.GroupBy(), s)
+	groupBy, groupAliases, groupDisplay, err := lowerMetricsGroupBy(agg.GroupBy(), s)
 	if err != nil {
 		return nil, err
 	}
 
 	return &chplan.MetricsAggregate{
-		Op:             chplan.MetricsOpAvgOverTime,
-		Attr:           attr,
-		GroupBy:        groupBy,
-		GroupByAliases: groupAliases,
-		ValueAlias:     metricsValueAlias,
-		Inner:          prev,
+		Op:                  chplan.MetricsOpAvgOverTime,
+		Attr:                attr,
+		GroupBy:             groupBy,
+		GroupByAliases:      groupAliases,
+		GroupByDisplayNames: groupDisplay,
+		ValueAlias:          metricsValueAlias,
+		Inner:               prev,
 	}, nil
 }
 
@@ -229,46 +231,74 @@ func lowerMetricsHistogramOverTime(prev chplan.Node, agg *traceql.MetricsAggrega
 	}
 	attrExpr := lowerAttribute(attr, s)
 
-	groupBy, groupAliases, err := lowerMetricsGroupBy(agg.GroupBy(), s)
+	groupBy, groupAliases, groupDisplay, err := lowerMetricsGroupBy(agg.GroupBy(), s)
 	if err != nil {
 		return nil, err
 	}
 
 	return &chplan.MetricsHistogramOverTime{
-		Attr:           attrExpr,
-		IsDuration:     attr.Intrinsic == traceql.IntrinsicDuration,
-		GroupBy:        groupBy,
-		GroupByAliases: groupAliases,
-		BucketAlias:    histogramBucketAlias,
-		ValueAlias:     metricsValueAlias,
-		Inner:          prev,
+		Attr:                attrExpr,
+		IsDuration:          attr.Intrinsic == traceql.IntrinsicDuration,
+		GroupBy:             groupBy,
+		GroupByAliases:      groupAliases,
+		GroupByDisplayNames: groupDisplay,
+		BucketAlias:         histogramBucketAlias,
+		ValueAlias:          metricsValueAlias,
+		Inner:               prev,
 	}, nil
 }
 
 // lowerMetricsGroupBy turns a TraceQL `by (<attr>, <attr>, ...)` list
-// into the chplan grouping expressions + parallel alias slice.
+// into the chplan grouping expressions + parallel alias slice + parallel
+// display-name slice.
 //
 // Each `by` attribute lowers via the same accessor lowerAttribute uses
 // for spanset matchers, so resource.* / span.* / intrinsics all resolve
 // to the right carrier (column ref for intrinsics, FieldAccess for map
-// keys). The alias is the attribute's TraceQL name — that lets the
-// /api/metrics/query_range handler decode the SELECT row back into a
-// labelled series without re-parsing the source.
+// keys).
 //
-// Returns (nil, nil, nil) when the `by(...)` list is empty — that
+// Two parallel name slices come back:
+//
+//   - aliases: the SQL SELECT-list alias. For a scoped attribute this is
+//     the bare `attr.Name` (e.g. `service.name` for `resource.service.name`)
+//     so the emitter renders `AS \`service.name\`` — keeping the column
+//     name short and identifying the carrier-side payload only. Locking
+//     in the bare form preserves the existing TXTAR SQL fixtures.
+//   - display: the Tempo-canonical wire label name (`attr.String()`).
+//     For a resource-scoped attribute this is `resource.service.name`;
+//     for a span-scoped attribute, `span.http.method`; for an intrinsic
+//     such as `kind`, just `kind`. The Tempo metrics-query handler
+//     uses this name when projecting the response's `Labels` map so the
+//     wire shape matches upstream Tempo's `pkg/traceql.Labels.String`
+//     output (which calls `Attribute.String()` per the engine_metrics
+//     `labelsFor` loop). The SQL emitter ignores this slice; only the
+//     /api/metrics handler reads it.
+//
+// Returns (nil, nil, nil, nil) when the `by(...)` list is empty — that
 // matches chplan.Aggregate's convention for "no grouping".
-func lowerMetricsGroupBy(attrs []traceql.Attribute, s schema.Traces) ([]chplan.Expr, []string, error) {
+func lowerMetricsGroupBy(attrs []traceql.Attribute, s schema.Traces) ([]chplan.Expr, []string, []string, error) {
 	if len(attrs) == 0 {
-		return nil, nil, nil
+		return nil, nil, nil, nil
 	}
 	exprs := make([]chplan.Expr, 0, len(attrs))
 	aliases := make([]string, 0, len(attrs))
+	display := make([]string, 0, len(attrs))
 	for _, a := range attrs {
 		if a == (traceql.Attribute{}) {
-			return nil, nil, fmt.Errorf("traceql: empty by(...) group key")
+			return nil, nil, nil, fmt.Errorf("traceql: empty by(...) group key")
 		}
 		exprs = append(exprs, lowerAttribute(a, s))
+		// SQL alias is the bare attribute path (`a.Name` is set by
+		// traceql.NewAttribute / NewScopedAttribute / NewIntrinsic to
+		// either the carrier-map key, e.g. `service.name`, or the
+		// intrinsic's source-text name, e.g. `kind`). Locking in the
+		// bare form keeps every TXTAR SQL fixture stable across this
+		// change. The Tempo-canonical wire name (the scope-prefixed
+		// `Attribute.String()` form) ships on GroupByDisplayNames so
+		// the /api/metrics handler can surface it without the chsql
+		// emitter caring.
 		aliases = append(aliases, a.Name)
+		display = append(display, a.String())
 	}
-	return exprs, aliases, nil
+	return exprs, aliases, display, nil
 }

--- a/internal/traceql/metrics_pipeline_test.go
+++ b/internal/traceql/metrics_pipeline_test.go
@@ -134,6 +134,9 @@ func TestLowerMetricsPipeline(t *testing.T) {
 			if len(ma.GroupBy) != len(ma.GroupByAliases) {
 				t.Errorf("GroupBy/GroupByAliases length mismatch: %d vs %d", len(ma.GroupBy), len(ma.GroupByAliases))
 			}
+			if len(ma.GroupBy) > 0 && len(ma.GroupBy) != len(ma.GroupByDisplayNames) {
+				t.Errorf("GroupBy/GroupByDisplayNames length mismatch: %d vs %d", len(ma.GroupBy), len(ma.GroupByDisplayNames))
+			}
 
 			// Walk the inner subtree: Scan, optionally wrapped by Filter.
 			inner := ma.Inner

--- a/test/spec/chplan_print.go
+++ b/test/spec/chplan_print.go
@@ -201,11 +201,15 @@ func printNode(b *strings.Builder, n chplan.Node, depth int) {
 	case *chplan.MetricsAggregate:
 		gb := make([]string, len(v.GroupBy))
 		for i, e := range v.GroupBy {
-			if i < len(v.GroupByAliases) && v.GroupByAliases[i] != "" {
-				gb[i] = fmt.Sprintf("%s AS %s", printExpr(e), v.GroupByAliases[i])
-			} else {
-				gb[i] = printExpr(e)
+			alias := ""
+			if i < len(v.GroupByAliases) {
+				alias = v.GroupByAliases[i]
 			}
+			display := ""
+			if i < len(v.GroupByDisplayNames) {
+				display = v.GroupByDisplayNames[i]
+			}
+			gb[i] = formatGroupByEntry(printExpr(e), alias, display)
 		}
 		fmt.Fprintf(b, "%sMetricsAggregate op=%s", indent, v.Op)
 		if v.Attr != nil {
@@ -250,11 +254,15 @@ func printNode(b *strings.Builder, n chplan.Node, depth int) {
 	case *chplan.MetricsHistogramOverTime:
 		gb := make([]string, len(v.GroupBy))
 		for i, e := range v.GroupBy {
-			if i < len(v.GroupByAliases) && v.GroupByAliases[i] != "" {
-				gb[i] = fmt.Sprintf("%s AS %s", printExpr(e), v.GroupByAliases[i])
-			} else {
-				gb[i] = printExpr(e)
+			alias := ""
+			if i < len(v.GroupByAliases) {
+				alias = v.GroupByAliases[i]
 			}
+			display := ""
+			if i < len(v.GroupByDisplayNames) {
+				display = v.GroupByDisplayNames[i]
+			}
+			gb[i] = formatGroupByEntry(printExpr(e), alias, display)
 		}
 		fmt.Fprintf(b, "%sMetricsHistogramOverTime", indent)
 		if v.Attr != nil {
@@ -450,4 +458,26 @@ func printVectorCard(c chplan.VectorCard) string {
 		return "one-to-many"
 	}
 	return "unknown"
+}
+
+// formatGroupByEntry renders one MetricsAggregate / MetricsHistogramOverTime
+// group-by entry for the IR snapshot. When the lowering populated a
+// display name (the Tempo-canonical wire form, e.g.
+// `resource.service.name`) that differs from the SQL alias (the bare
+// `service.name`) the snapshot surfaces both via the `AS alias|display`
+// suffix so a reader can tell which name the SQL emitter uses (alias)
+// vs. which name the Tempo handler surfaces on the wire (display).
+// When they agree (e.g. unscoped attributes, intrinsics like `kind`)
+// only the alias prints, keeping legacy fixtures byte-stable.
+func formatGroupByEntry(expr, alias, display string) string {
+	switch {
+	case alias == "" && display == "":
+		return expr
+	case alias == "" || alias == display:
+		return fmt.Sprintf("%s AS %s", expr, display)
+	case display == "":
+		return fmt.Sprintf("%s AS %s", expr, alias)
+	default:
+		return fmt.Sprintf("%s AS %s|%s", expr, alias, display)
+	}
 }

--- a/test/spec/traceql/by_intrinsic_and_attr.txtar
+++ b/test/spec/traceql/by_intrinsic_and_attr.txtar
@@ -22,6 +22,6 @@ INSERT INTO otel_traces VALUES
   ["Client", "frontend", 4]
 ]
 -- chplan --
-MetricsAggregate op=count_over_time groupBy=[SpanKind AS kind, ResourceAttributes["service.name"] AS service.name] valueAlias=Value
+MetricsAggregate op=count_over_time groupBy=[SpanKind AS kind, ResourceAttributes["service.name"] AS service.name|resource.service.name] valueAlias=Value
   Filter predicate=true
     Scan(otel_traces)

--- a/test/spec/traceql/by_mixed_scopes.txtar
+++ b/test/spec/traceql/by_mixed_scopes.txtar
@@ -23,6 +23,6 @@ INSERT INTO otel_traces VALUES
   ["frontend", "GET", 100000000]
 ]
 -- chplan --
-MetricsAggregate op=max_over_time attr=Duration groupBy=[ResourceAttributes["service.name"] AS service.name, SpanAttributes["http.method"] AS http.method] valueAlias=Value
+MetricsAggregate op=max_over_time attr=Duration groupBy=[ResourceAttributes["service.name"] AS service.name|resource.service.name, SpanAttributes["http.method"] AS http.method|span.http.method] valueAlias=Value
   Filter predicate=true
     Scan(otel_traces)

--- a/test/spec/traceql/by_multi_attribute.txtar
+++ b/test/spec/traceql/by_multi_attribute.txtar
@@ -23,6 +23,6 @@ INSERT INTO otel_traces VALUES
   ["frontend", "200", 3]
 ]
 -- chplan --
-MetricsAggregate op=count_over_time groupBy=[ResourceAttributes["service.name"] AS service.name, SpanAttributes["http.status_code"] AS http.status_code] valueAlias=Value
+MetricsAggregate op=count_over_time groupBy=[ResourceAttributes["service.name"] AS service.name|resource.service.name, SpanAttributes["http.status_code"] AS http.status_code|span.http.status_code] valueAlias=Value
   Filter predicate=true
     Scan(otel_traces)

--- a/test/spec/traceql/by_three_attributes.txtar
+++ b/test/spec/traceql/by_three_attributes.txtar
@@ -27,6 +27,6 @@ INSERT INTO otel_traces VALUES
   ["frontend", "Client", "GET", 5]
 ]
 -- chplan --
-MetricsAggregate op=rate groupBy=[ResourceAttributes["service.name"] AS service.name, SpanAttributes["kind"] AS kind, SpanAttributes["http.method"] AS http.method] valueAlias=Value
+MetricsAggregate op=rate groupBy=[ResourceAttributes["service.name"] AS service.name|resource.service.name, SpanAttributes["kind"] AS kind|span.kind, SpanAttributes["http.method"] AS http.method|span.http.method] valueAlias=Value
   Filter predicate=true
     Scan(otel_traces)

--- a/test/spec/traceql/metrics_count_over_time_by_multi_service.txtar
+++ b/test/spec/traceql/metrics_count_over_time_by_multi_service.txtar
@@ -23,6 +23,6 @@ INSERT INTO otel_traces VALUES
   ["frontend", 3]
 ]
 -- chplan --
-MetricsAggregate op=count_over_time groupBy=[ResourceAttributes["service.name"] AS service.name] valueAlias=Value
+MetricsAggregate op=count_over_time groupBy=[ResourceAttributes["service.name"] AS service.name|resource.service.name] valueAlias=Value
   Filter predicate=true
     Scan(otel_traces)

--- a/test/spec/traceql/metrics_groupby_resource_wire_label.txtar
+++ b/test/spec/traceql/metrics_groupby_resource_wire_label.txtar
@@ -9,15 +9,12 @@ SELECT `ResourceAttributes`[?] AS `service.name`, toFloat64(count(?)) AS `Value`
 [3] string = "service.name"
 -- seed --
 CREATE TABLE otel_traces (
-    Timestamp DateTime64(9),
-    TraceId String,
-    SpanId String,
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_traces VALUES
-    (toDateTime64('2026-05-12 10:00:00', 9), '0123456789abcdef0123456789abcdef', '0011223344556677', map('service.name', 'frontend')),
-    (toDateTime64('2026-05-12 10:00:01', 9), 'fedcba9876543210fedcba9876543210', 'aabbccddeeff0011', map('service.name', 'frontend')),
-    (toDateTime64('2026-05-12 10:00:02', 9), '11111111111111111111111111111111', '1111111111111111', map('service.name', 'backend'));
+    (map('service.name', 'frontend')),
+    (map('service.name', 'frontend')),
+    (map('service.name', 'backend'));
 -- expected_rows --
 [
   ["backend", 1],

--- a/test/spec/traceql/metrics_histogram_over_time_by.txtar
+++ b/test/spec/traceql/metrics_histogram_over_time_by.txtar
@@ -21,6 +21,6 @@ INSERT INTO otel_traces VALUES
   ["frontend", 1.0e-08, 3]
 ]
 -- chplan --
-MetricsHistogramOverTime attr=Duration duration=true groupBy=[ResourceAttributes["service.name"] AS service.name] bucketAlias=__bucket valueAlias=Value
+MetricsHistogramOverTime attr=Duration duration=true groupBy=[ResourceAttributes["service.name"] AS service.name|resource.service.name] bucketAlias=__bucket valueAlias=Value
   Filter predicate=true
     Scan(otel_traces)

--- a/test/spec/traceql/metrics_rate_by.txtar
+++ b/test/spec/traceql/metrics_rate_by.txtar
@@ -20,6 +20,6 @@ INSERT INTO otel_traces VALUES
   ["frontend", 3]
 ]
 -- chplan --
-MetricsAggregate op=rate groupBy=[ResourceAttributes["service.name"] AS service.name] valueAlias=Value
+MetricsAggregate op=rate groupBy=[ResourceAttributes["service.name"] AS service.name|resource.service.name] valueAlias=Value
   Filter predicate=true
     Scan(otel_traces)


### PR DESCRIPTION
## Summary

- Add `GroupByDisplayNames` to `chplan.MetricsAggregate` and
  `chplan.MetricsHistogramOverTime` so the TraceQL lowering can carry
  the Tempo-canonical wire form (`Attribute.String()`) alongside the
  compact SQL alias (`Attribute.Name`).
- Make the Tempo /api/metrics handlers (`wrapMetricsForSample`,
  `metricsLabelNames`) prefer display names, and mirror the same
  alignment in `chsql.EmitMetricsExemplars` so the matrix + exemplar
  branches agree on label keys for `attachExemplars`'s canonical-key
  match.
- Update existing TXTAR IR snapshots with the new `alias|display`
  suffix and add a dedicated fixture
  (`test/spec/traceql/metrics_groupby_resource_wire_label.txtar`)
  documenting the wire-shape contract.
- Add a `TestMetricsQueryRange_ResourceLabelWireShape` conformance
  test asserting the JSON `labels[].key` reads
  `resource.service.name` for a `by (resource.service.name)` clause.

## Why

Upstream Tempo emits the scope-prefixed form `resource.service.name`
on the response label list for a `by (resource.service.name)` clause
— verified against grafana/tempo's
`pkg/traceql.Attribute.String` and the integration test
`integration/api/query_range_test.go` which pins
`label.Key == \"resource.res_attr\"` for `by (resource.res_attr)`.

Cerberus's lowering aliased SELECT columns by the bare attribute path
(`AS service.name`), and that alias also flowed through to the
chclient `Sample.Labels` key — so a TraceQL metrics query served
`service.name` on the response while Tempo served
`resource.service.name`. Grafana's Tempo datasource (and the
`compatibility/tempo` differ's canonical-key hashing) treats this as
a missing-in-cerberus diff.

## What changed

- `internal/chplan/metrics_aggregate.go` +
  `internal/chplan/metrics_histogram_over_time.go`: new
  `GroupByDisplayNames` field on both metrics nodes; structural
  `Equal` covers it.
- `internal/traceql/metrics_pipeline.go::lowerMetricsGroupBy`:
  populates aliases (`a.Name`) + display names (`a.String()`) in
  parallel.
- `internal/api/tempo/metrics_query_range.go::metricsLabelNames` +
  `wrapMetricsForSample`: prefer display names, fall back to aliases.
- `internal/chsql/exemplars.go`: project the `Attributes` map keys
  using display names too so `attachExemplars` matches each exemplar
  to its parent series.
- Test fixtures: TXTAR `chplan` snapshots embed the
  `alias|display` form when they differ; new fixture documents the
  wire-shape contract; new conformance test + helper tests pin the
  contract.

## Test plan

- [ ] `check` CI job — Go build + unit tests across all packages.
- [ ] `lint` CI job — golangci-lint v2 + markdownlint.
- [ ] `chdb` workflow (run nightly + on demand) — exercises the new
      fixture via real chDB execution.
- [ ] `compatibility/tempo` differ workflow (informational baseline
      on push-to-main) — once cerberus emits the prefixed key, the
      pre-existing `metrics_count_over_time_groupby_service` corpus
      case's `groupby_labels_present:resource.service.name` semantic
      check is satisfied by both backends.