### PR TITLE
test(spec/traceql): seed 8 structural/bool fixtures for chDB roundtrip

### DIFF
--- a/test/spec/runner_chdb.go
+++ b/test/spec/runner_chdb.go
@@ -238,12 +238,39 @@ func unquoteBackticks(s string) string {
 // re-splitting the outer SELECT's projection list on depth-0 commas.
 // Used to size the scan-target slice without calling
 // rows.ColumnTypes() (which panics on Map columns per the chDB probe).
+//
+// Returns 0 when the outer projection list contains a `*` wildcard
+// (bare `*`, `R.*`, etc.) — the caller falls back to `rows.Columns()`
+// to size the destination slice once the query has executed. Wildcard
+// projections appear in structural-join lowerings (`SELECT R.* FROM
+// ...`) where the fixture seed schema determines the actual column
+// count.
 func extractProjectionCount(query string) int {
 	head, _ := splitOuterSelect(query)
 	if head == "" {
 		return 0
 	}
-	return len(splitProjections(head))
+	projs := splitProjections(head)
+	for _, p := range projs {
+		if isWildcardProjection(p) {
+			return 0
+		}
+	}
+	return len(projs)
+}
+
+// isWildcardProjection reports whether p is a `*` or `<qualifier>.*`
+// projection. The qualifier may be a bare identifier or a backtick-
+// quoted alias.
+func isWildcardProjection(p string) bool {
+	p = strings.TrimSpace(p)
+	if p == "*" {
+		return true
+	}
+	if i := strings.LastIndex(p, "."); i >= 0 {
+		return strings.TrimSpace(p[i+1:]) == "*"
+	}
+	return false
 }
 
 // substituteNow64 rewrites every `now64(...)` reference in the emitted
@@ -511,9 +538,6 @@ func RunRoundTrip(t *testing.T, c *Case) {
 	query, queryArgs := substituteNow64(rt.SQL, rt.Args)
 	query = rewriteMapProjections(query)
 	colCount := extractProjectionCount(query)
-	if colCount == 0 {
-		t.Fatalf("fixture %s: cannot determine SELECT projection count from sql", c.Name)
-	}
 
 	rows, err := db.Query(query, queryArgs...)
 	if err != nil {
@@ -521,6 +545,22 @@ func RunRoundTrip(t *testing.T, c *Case) {
 			query, queryArgs, err)
 	}
 	defer func() { _ = rows.Close() }()
+
+	if colCount == 0 {
+		// Wildcard outer projection (`SELECT R.* FROM ...`): the
+		// fixture seed determines the actual column count. `rows.
+		// Columns()` returns names without instantiating the
+		// driver's column-type table, so it sidesteps the Map
+		// `rows.ColumnTypes()` panic.
+		cols, cerr := rows.Columns()
+		if cerr != nil {
+			t.Fatalf("rows.Columns: %v", cerr)
+		}
+		colCount = len(cols)
+		if colCount == 0 {
+			t.Fatalf("fixture %s: cannot determine SELECT projection count from sql", c.Name)
+		}
+	}
 
 	got := make([][]any, 0, len(rt.ExpectedRows))
 	for rows.Next() {

--- a/test/spec/traceql/bool_attr.txtar
+++ b/test/spec/traceql/bool_attr.txtar
@@ -5,6 +5,22 @@ SELECT * FROM `otel_traces` WHERE (`SpanAttributes`[?] = ?)
 -- args --
 [0] string = "cache.hit"
 [1] bool = true
+-- seed --
+CREATE TABLE otel_traces (
+    TraceId String,
+    SpanId String,
+    _hit Bool,
+    SpanAttributes Map(String, Bool) MATERIALIZED map('cache.hit', _hit)
+) ENGINE = Memory;
+INSERT INTO otel_traces (TraceId, SpanId, _hit) VALUES
+    ('a0000000000000000000000000000001', '0000000000000001', true),
+    ('a0000000000000000000000000000001', '0000000000000002', false),
+    ('a0000000000000000000000000000002', '0000000000000010', true);
+-- expected_rows --
+[
+  ["a0000000000000000000000000000001", "0000000000000001", true],
+  ["a0000000000000000000000000000002", "0000000000000010", true]
+]
 -- chplan --
 Filter predicate=(SpanAttributes["cache.hit"] = true)
   Scan(otel_traces)

--- a/test/spec/traceql/child_of.txtar
+++ b/test/spec/traceql/child_of.txtar
@@ -7,6 +7,23 @@ SELECT R.* FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)
 [1] string = "api"
 [2] string = "service.name"
 [3] string = "frontend"
+-- seed --
+CREATE TABLE otel_traces (
+    TraceId String,
+    SpanId String,
+    ParentSpanId String,
+    _svc String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('service.name', _svc)
+) ENGINE = Memory;
+INSERT INTO otel_traces (TraceId, SpanId, ParentSpanId, _svc) VALUES
+    ('a0000000000000000000000000000001', '0000000000000001', '',                 'frontend'),
+    ('a0000000000000000000000000000001', '0000000000000002', '0000000000000001', 'api'),
+    ('a0000000000000000000000000000001', '0000000000000003', '0000000000000002', 'db'),
+    ('a0000000000000000000000000000002', '0000000000000010', '',                 'api');
+-- expected_rows --
+[
+  ["a0000000000000000000000000000001", "0000000000000001", "", "frontend"]
+]
 -- chplan --
 StructuralJoin op=<
   Filter predicate=(ResourceAttributes["service.name"] = "api")

--- a/test/spec/traceql/parent_of.txtar
+++ b/test/spec/traceql/parent_of.txtar
@@ -7,6 +7,23 @@ SELECT R.* FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)
 [1] string = "frontend"
 [2] string = "service.name"
 [3] string = "api"
+-- seed --
+CREATE TABLE otel_traces (
+    TraceId String,
+    SpanId String,
+    ParentSpanId String,
+    _svc String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('service.name', _svc)
+) ENGINE = Memory;
+INSERT INTO otel_traces (TraceId, SpanId, ParentSpanId, _svc) VALUES
+    ('a0000000000000000000000000000001', '0000000000000001', '',                 'frontend'),
+    ('a0000000000000000000000000000001', '0000000000000002', '0000000000000001', 'api'),
+    ('a0000000000000000000000000000001', '0000000000000003', '0000000000000002', 'db'),
+    ('a0000000000000000000000000000002', '0000000000000010', '',                 'api');
+-- expected_rows --
+[
+  ["a0000000000000000000000000000001", "0000000000000002", "0000000000000001", "api"]
+]
 -- chplan --
 StructuralJoin op=>
   Filter predicate=(ResourceAttributes["service.name"] = "frontend")

--- a/test/spec/traceql/recursive_ancestor.txtar
+++ b/test/spec/traceql/recursive_ancestor.txtar
@@ -7,6 +7,25 @@ SELECT R.* FROM (WITH RECURSIVE _struct_closure AS (SELECT `TraceId`, `SpanId`, 
 [1] string = "leaf"
 [2] string = "service.name"
 [3] string = "root"
+-- seed --
+CREATE TABLE otel_traces (
+    TraceId String,
+    SpanId String,
+    ParentSpanId String,
+    _svc String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('service.name', _svc)
+) ENGINE = Memory;
+INSERT INTO otel_traces (TraceId, SpanId, ParentSpanId, _svc) VALUES
+    ('a0000000000000000000000000000001', '0000000000000001', '',                 'root'),
+    ('a0000000000000000000000000000001', '0000000000000002', '0000000000000001', 'mid'),
+    ('a0000000000000000000000000000001', '0000000000000003', '0000000000000002', 'leaf'),
+    ('a0000000000000000000000000000001', '0000000000000004', '0000000000000003', 'leafer'),
+    ('a0000000000000000000000000000002', '0000000000000010', '',                 'leaf'),
+    ('a0000000000000000000000000000002', '0000000000000011', '',                 'root');
+-- expected_rows --
+[
+  ["a0000000000000000000000000000001", "0000000000000001", "", "root"]
+]
 -- chplan --
 StructuralJoin op=<<
   Filter predicate=(ResourceAttributes["service.name"] = "leaf")

--- a/test/spec/traceql/recursive_descendant.txtar
+++ b/test/spec/traceql/recursive_descendant.txtar
@@ -7,6 +7,25 @@ SELECT R.* FROM (WITH RECURSIVE _struct_closure AS (SELECT `TraceId`, `SpanId`, 
 [1] string = "root"
 [2] string = "service.name"
 [3] string = "leaf"
+-- seed --
+CREATE TABLE otel_traces (
+    TraceId String,
+    SpanId String,
+    ParentSpanId String,
+    _svc String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('service.name', _svc)
+) ENGINE = Memory;
+INSERT INTO otel_traces (TraceId, SpanId, ParentSpanId, _svc) VALUES
+    ('a0000000000000000000000000000001', '0000000000000001', '',                 'root'),
+    ('a0000000000000000000000000000001', '0000000000000002', '0000000000000001', 'mid'),
+    ('a0000000000000000000000000000001', '0000000000000003', '0000000000000002', 'leaf'),
+    ('a0000000000000000000000000000001', '0000000000000004', '0000000000000003', 'leafer'),
+    ('a0000000000000000000000000000002', '0000000000000010', '',                 'leaf'),
+    ('a0000000000000000000000000000002', '0000000000000011', '',                 'root');
+-- expected_rows --
+[
+  ["a0000000000000000000000000000001", "0000000000000003", "0000000000000002", "leaf"]
+]
 -- chplan --
 StructuralJoin op=>>
   Filter predicate=(ResourceAttributes["service.name"] = "root")

--- a/test/spec/traceql/set_intersect_simple.txtar
+++ b/test/spec/traceql/set_intersect_simple.txtar
@@ -6,6 +6,24 @@ SELECT L.* FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)
 [0] string = "service.name"
 [1] string = "a"
 [2] int64 = 1000000000
+-- seed --
+CREATE TABLE otel_traces (
+    TraceId String,
+    SpanId String,
+    Duration UInt64,
+    _svc String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('service.name', _svc)
+) ENGINE = Memory;
+INSERT INTO otel_traces (TraceId, SpanId, Duration, _svc) VALUES
+    ('a0000000000000000000000000000001', '0000000000000001', 500000000,  'a'),
+    ('a0000000000000000000000000000001', '0000000000000002', 2000000000, 'a'),
+    ('a0000000000000000000000000000001', '0000000000000003', 3000000000, 'b'),
+    ('a0000000000000000000000000000002', '0000000000000010', 5000000000, 'a');
+-- expected_rows --
+[
+  ["a0000000000000000000000000000001", "0000000000000002", 2000000000, "a"],
+  ["a0000000000000000000000000000002", "0000000000000010", 5000000000, "a"]
+]
 -- chplan --
 SetOperation op=&&
   Filter predicate=(ResourceAttributes["service.name"] = "a")

--- a/test/spec/traceql/set_union_simple.txtar
+++ b/test/spec/traceql/set_union_simple.txtar
@@ -7,6 +7,24 @@
 [1] string = "a"
 [2] string = "service.name"
 [3] string = "b"
+-- seed --
+CREATE TABLE otel_traces (
+    TraceId String,
+    SpanId String,
+    _svc String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('service.name', _svc)
+) ENGINE = Memory;
+INSERT INTO otel_traces (TraceId, SpanId, _svc) VALUES
+    ('a0000000000000000000000000000001', '0000000000000001', 'a'),
+    ('a0000000000000000000000000000001', '0000000000000002', 'b'),
+    ('a0000000000000000000000000000001', '0000000000000003', 'c'),
+    ('a0000000000000000000000000000002', '0000000000000010', 'a');
+-- expected_rows --
+[
+  ["a0000000000000000000000000000001", "0000000000000001", "a"],
+  ["a0000000000000000000000000000001", "0000000000000002", "b"],
+  ["a0000000000000000000000000000002", "0000000000000010", "a"]
+]
 -- chplan --
 SetOperation op=||
   Filter predicate=(ResourceAttributes["service.name"] = "a")

--- a/test/spec/traceql/sibling_simple.txtar
+++ b/test/spec/traceql/sibling_simple.txtar
@@ -5,6 +5,24 @@ SELECT R.* FROM (SELECT * FROM `otel_traces` WHERE (`SpanName` = ?)) AS L INNER 
 -- args --
 [0] string = "parent"
 [1] string = "sibling"
+-- seed --
+CREATE TABLE otel_traces (
+    TraceId String,
+    SpanId String,
+    ParentSpanId String,
+    SpanName String
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    ('a0000000000000000000000000000001', '0000000000000010', '',                 'root'),
+    ('a0000000000000000000000000000001', '0000000000000011', '0000000000000010', 'parent'),
+    ('a0000000000000000000000000000001', '0000000000000012', '0000000000000010', 'sibling'),
+    ('a0000000000000000000000000000001', '0000000000000013', '0000000000000011', 'child'),
+    ('a0000000000000000000000000000002', '0000000000000020', '',                 'parent'),
+    ('a0000000000000000000000000000002', '0000000000000021', '0000000000000020', 'sibling');
+-- expected_rows --
+[
+  ["a0000000000000000000000000000001", "0000000000000012", "0000000000000010", "sibling"]
+]
 -- chplan --
 StructuralJoin op=~
   Filter predicate=(SpanName = "parent")


### PR DESCRIPTION
## Summary

- Adds `-- seed --` + `-- expected_rows --` blocks to 8 TraceQL fixtures so they execute against the chDB-backed round-trip layer (Layer 6) in addition to the text-equality golden (Layer 1):
  - `parent_of`, `child_of`, `sibling_simple` (single-hop structural joins)
  - `set_intersect_simple`, `set_union_simple` (set ops)
  - `recursive_ancestor`, `recursive_descendant` (WITH RECURSIVE closures)
  - `bool_attr` (`{ span.cache.hit = true }`)
- Bumps the chDB round-trip runner (`test/spec/runner_chdb.go`) so wildcard outer projections (`SELECT R.* FROM ...`) fall back to `rows.Columns()` when sizing the scan-target slice. `rows.Columns()` only returns names — it doesn't touch the parquet column-type table the existing comment cites as the reason for the manual count — so it's a safe fallback.

## Skipped

`multi_hop_chain` and `recursive_mixed` (2 of the 10 fixtures the task targeted) are intentionally **not** seeded in this PR. Their emitted SQL has the shape:

```sql
SELECT R.* FROM
  (SELECT R.* FROM ... AS L INNER JOIN ... AS R ON ...) AS L
  INNER JOIN ... AS R ON L.TraceId = R.TraceId AND ...
```

chDB 25.8 (and matching ClickHouse 25.8 analyzer behaviour) rejects this with:

> `Identifier 'L.TraceId' cannot be resolved from subquery with name L. […]. Maybe you meant: ['R.TraceId']`

i.e. the inner `R.*` keeps its `R.` qualifier when the wrapping subquery is re-aliased to outer `L`, so the outer `L.TraceId` reference can't be resolved. This is an emitter-shape issue to revisit separately (`multi_hop_chain` and `recursive_mixed` are still covered by the Layer 1 text golden — only Layer 6 is held back).

## Schema trick

Structural-join fixtures use a `MATERIALIZED` `ResourceAttributes` column derived from a plain `_svc String` column. This keeps the WHERE filters (`ResourceAttributes['service.name'] = ?`) functional while ensuring `SELECT * FROM otel_traces` (and therefore `SELECT R.*` on the outer join) returns only the four scalar columns — the chDB parquet driver still panics on native `Map(String, String)` scans, and the outer `R.*` projection doesn't go through the runner's `toJSONString(...)` rewrite (the rewrite only fires on named aliases).

`bool_attr` uses `Map(String, Bool)` for the same reason — the lowered SQL compares the Map value to a `bool` placeholder, and a `Map(String, String)` carrier would `NO_COMMON_TYPE` against the chdb-bound `bool`. The fixture isn't trying to mirror the production OTel-CH schema; it's a controlled seed for the assertion layer.

## Test plan

- [x] `go test -tags chdb -count=1 ./test/spec/traceql/... -run TestRoundTripChDB` — 132 passed
- [x] `go test -tags chdb -count=1 ./test/spec/...` — 493 passed
- [x] `go test -count=1 ./test/spec/...` (default tag, runner refactor compiles + passes) — 4 passed
- [x] `go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)