### PR TITLE
test(traceql): seed chDB roundtrip for 10 edge_a-i fixtures

### DIFF
--- a/test/spec/traceql/edge_attr_default_ge.txtar
+++ b/test/spec/traceql/edge_attr_default_ge.txtar
@@ -5,6 +5,20 @@
 [1] int64 = 100
 -- sql --
 SELECT * FROM `otel_traces` WHERE (toFloat64(`SpanAttributes`[?]) >= ?)
+-- seed --
+CREATE TABLE otel_traces (
+    Duration UInt64,
+    SpanAttributes Map(String, String) MATERIALIZED if(Duration = 50000000, map('timeout', '50'), if(Duration = 100000000, map('timeout', '100'), map('timeout', '250')))
+) ENGINE = MergeTree ORDER BY Duration;
+INSERT INTO otel_traces (Duration) VALUES
+    (50000000),
+    (100000000),
+    (250000000);
+-- expected_rows --
+[
+  [100000000],
+  [250000000]
+]
 -- chplan --
 Filter predicate=(toFloat64(SpanAttributes["timeout"]) >= 100)
   Scan(otel_traces)

--- a/test/spec/traceql/edge_attr_default_regex.txtar
+++ b/test/spec/traceql/edge_attr_default_regex.txtar
@@ -5,6 +5,20 @@
 [1] string = "/api/.*"
 -- sql --
 SELECT * FROM `otel_traces` WHERE match(`SpanAttributes`[?], ?)
+-- seed --
+CREATE TABLE otel_traces (
+    Duration UInt64,
+    SpanAttributes Map(String, String) MATERIALIZED if(Duration = 10000000, map('path', '/api/users'), if(Duration = 20000000, map('path', '/api/orders'), map('path', '/healthz')))
+) ENGINE = MergeTree ORDER BY Duration;
+INSERT INTO otel_traces (Duration) VALUES
+    (10000000),
+    (20000000),
+    (30000000);
+-- expected_rows --
+[
+  [10000000],
+  [20000000]
+]
 -- chplan --
 Filter predicate=(SpanAttributes["path"] =~ "/api/.*")
   Scan(otel_traces)

--- a/test/spec/traceql/edge_attr_resource_le.txtar
+++ b/test/spec/traceql/edge_attr_resource_le.txtar
@@ -5,6 +5,20 @@
 [1] int64 = 5
 -- sql --
 SELECT * FROM `otel_traces` WHERE (toFloat64(`ResourceAttributes`[?]) <= ?)
+-- seed --
+CREATE TABLE otel_traces (
+    Duration UInt64,
+    ResourceAttributes Map(String, String) MATERIALIZED if(Duration = 10000000, map('replicas', '3'), if(Duration = 20000000, map('replicas', '5'), map('replicas', '10')))
+) ENGINE = MergeTree ORDER BY Duration;
+INSERT INTO otel_traces (Duration) VALUES
+    (10000000),
+    (20000000),
+    (30000000);
+-- expected_rows --
+[
+  [10000000],
+  [20000000]
+]
 -- chplan --
 Filter predicate=(toFloat64(ResourceAttributes["replicas"]) <= 5)
   Scan(otel_traces)

--- a/test/spec/traceql/edge_attr_resource_not_regex.txtar
+++ b/test/spec/traceql/edge_attr_resource_not_regex.txtar
@@ -5,6 +5,20 @@
 [1] string = "test.*"
 -- sql --
 SELECT * FROM `otel_traces` WHERE NOT match(`ResourceAttributes`[?], ?)
+-- seed --
+CREATE TABLE otel_traces (
+    Duration UInt64,
+    ResourceAttributes Map(String, String) MATERIALIZED if(Duration = 10000000, map('service.name', 'test-runner'), if(Duration = 20000000, map('service.name', 'frontend'), map('service.name', 'backend')))
+) ENGINE = MergeTree ORDER BY Duration;
+INSERT INTO otel_traces (Duration) VALUES
+    (10000000),
+    (20000000),
+    (30000000);
+-- expected_rows --
+[
+  [20000000],
+  [30000000]
+]
 -- chplan --
 Filter predicate=(ResourceAttributes["service.name"] !~ "test.*")
   Scan(otel_traces)

--- a/test/spec/traceql/edge_attr_span_gt.txtar
+++ b/test/spec/traceql/edge_attr_span_gt.txtar
@@ -5,6 +5,20 @@
 [1] int64 = 1024
 -- sql --
 SELECT * FROM `otel_traces` WHERE (toFloat64(`SpanAttributes`[?]) > ?)
+-- seed --
+CREATE TABLE otel_traces (
+    Duration UInt64,
+    SpanAttributes Map(String, String) MATERIALIZED if(Duration = 10000000, map('size', '512'), if(Duration = 20000000, map('size', '2048'), map('size', '4096')))
+) ENGINE = MergeTree ORDER BY Duration;
+INSERT INTO otel_traces (Duration) VALUES
+    (10000000),
+    (20000000),
+    (30000000);
+-- expected_rows --
+[
+  [20000000],
+  [30000000]
+]
 -- chplan --
 Filter predicate=(toFloat64(SpanAttributes["size"]) > 1024)
   Scan(otel_traces)

--- a/test/spec/traceql/edge_attr_span_lt.txtar
+++ b/test/spec/traceql/edge_attr_span_lt.txtar
@@ -5,6 +5,20 @@
 [1] int64 = 500
 -- sql --
 SELECT * FROM `otel_traces` WHERE (toFloat64(`SpanAttributes`[?]) < ?)
+-- seed --
+CREATE TABLE otel_traces (
+    Duration UInt64,
+    SpanAttributes Map(String, String) MATERIALIZED if(Duration = 10000000, map('http.status_code', '200'), if(Duration = 20000000, map('http.status_code', '404'), map('http.status_code', '500')))
+) ENGINE = MergeTree ORDER BY Duration;
+INSERT INTO otel_traces (Duration) VALUES
+    (10000000),
+    (20000000),
+    (30000000);
+-- expected_rows --
+[
+  [10000000],
+  [20000000]
+]
 -- chplan --
 Filter predicate=(toFloat64(SpanAttributes["http.status_code"]) < 500)
   Scan(otel_traces)

--- a/test/spec/traceql/edge_catchall_compound_count.txtar
+++ b/test/spec/traceql/edge_catchall_compound_count.txtar
@@ -9,6 +9,19 @@
 [5] int64 = 10
 -- sql --
 SELECT * FROM (SELECT toFloat64(count(?)) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?) AND (toFloat64(`SpanAttributes`[?]) > ?))) WHERE (`Value` > ?)
+-- seed --
+CREATE TABLE otel_traces (
+    Duration UInt64,
+    ResourceAttributes Map(String, String) MATERIALIZED if(Duration < 12, map('service.name', 'x'), map('service.name', 'y')),
+    SpanAttributes Map(String, String) MATERIALIZED if(Duration < 12, map('http.status_code', '500'), map('http.status_code', '100'))
+) ENGINE = MergeTree ORDER BY Duration;
+INSERT INTO otel_traces (Duration) VALUES
+    (0), (1), (2), (3), (4), (5), (6), (7), (8), (9), (10), (11),
+    (12), (13), (14);
+-- expected_rows --
+[
+  [12.0]
+]
 -- chplan --
 Filter predicate=(Value > 10)
   Aggregate groupBy=[] funcs=[count(1) AS Value]

--- a/test/spec/traceql/edge_catchall_pipeline_avg.txtar
+++ b/test/spec/traceql/edge_catchall_pipeline_avg.txtar
@@ -7,6 +7,21 @@
 [3] int64 = 500000000
 -- sql --
 SELECT * FROM (SELECT avg(`Duration`) AS `Value` FROM (SELECT * FROM `otel_traces` PREWHERE (`StatusCode` = ?) WHERE (`ResourceAttributes`[?] = ?))) WHERE (`Value` > ?)
+-- seed --
+CREATE TABLE otel_traces (
+    Duration UInt64,
+    StatusCode String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('service.name', 'x')
+) ENGINE = MergeTree ORDER BY Duration;
+INSERT INTO otel_traces (Duration, StatusCode) VALUES
+    (600000000, 'Error'),
+    (800000000, 'Error'),
+    (1000000000, 'Error'),
+    (50000000, 'Ok');
+-- expected_rows --
+[
+  [800000000.0]
+]
 -- chplan --
 Filter predicate=(Value > 500000000)
   Aggregate groupBy=[] funcs=[avg(Duration) AS Value]

--- a/test/spec/traceql/edge_event_name_match.txtar
+++ b/test/spec/traceql/edge_event_name_match.txtar
@@ -5,6 +5,17 @@
 [1] string = "exception"
 -- sql --
 SELECT * FROM `otel_traces` WHERE arrayExists(x -> x[?] = ?, `Events`.`Attributes`)
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    `Events.Attributes` Array(Map(String, String)) MATERIALIZED if(_idx = 0, [map('name', 'exception')], if(_idx = 1, [map('name', 'log'), map('name', 'exception')], [map('name', 'heartbeat')]))
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1), (2);
+-- expected_rows --
+[
+  [0],
+  [1]
+]
 -- chplan --
 Filter predicate=nestedArrayExists(Events.Attributes["name"] = "exception")
   Scan(otel_traces)

--- a/test/spec/traceql/edge_group_by_span_attr.txtar
+++ b/test/spec/traceql/edge_group_by_span_attr.txtar
@@ -6,6 +6,21 @@
 [2] string = "http.method"
 -- sql --
 SELECT `SpanAttributes`[?] AS `GroupKey`, any(`TraceId`) AS `TraceId`, any(`SpanId`) AS `SpanId`, min(`Timestamp`) AS `Timestamp` FROM (SELECT * FROM `otel_traces` WHERE ?) GROUP BY `SpanAttributes`[?]
+-- seed --
+CREATE TABLE otel_traces (
+    TraceId String,
+    SpanId String,
+    Timestamp DateTime64(9),
+    SpanAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    ('a0000000000000000000000000000001', '0000000000000001', toDateTime64('2026-01-01 00:00:00', 9), map('http.method', 'GET')),
+    ('a0000000000000000000000000000002', '0000000000000002', toDateTime64('2026-01-01 00:00:00', 9), map('http.method', 'POST'));
+-- expected_rows --
+[
+  ["GET", "a0000000000000000000000000000001", "0000000000000001", "2026-01-01T00:00:00Z"],
+  ["POST", "a0000000000000000000000000000002", "0000000000000002", "2026-01-01T00:00:00Z"]
+]
 -- chplan --
 Aggregate groupBy=[SpanAttributes["http.method"] AS GroupKey] funcs=[any(TraceId) AS TraceId, any(SpanId) AS SpanId, min(Timestamp) AS Timestamp]
   Filter predicate=true


### PR DESCRIPTION
## Summary

Adds `-- seed --` + `-- expected_rows --` blocks to 10 of the 15 alphabetically-first `edge_*` TraceQL fixtures so the chDB roundtrip lane (`./test/spec/traceql/` with the `chdb` build tag) actually executes the emitted SQL against an in-process chDB session and asserts the rows.

Landed:
- `edge_attr_default_ge` — `.timeout >= 100`
- `edge_attr_default_regex` — `.path =~ "/api/.*"`
- `edge_attr_resource_le` — `resource.replicas <= 5`
- `edge_attr_resource_not_regex` — `resource.service.name !~ "test.*"`
- `edge_attr_span_gt` — `span.size > 1024`
- `edge_attr_span_lt` — `span.http.status_code < 500`
- `edge_catchall_compound_count` — `{...} | count() > 10`
- `edge_catchall_pipeline_avg` — `{...} | avg(duration) > 500ms`
- `edge_event_name_match` — `event.name = "exception"` (Events nested seed)
- `edge_group_by_span_attr` — `{} | by(span.http.method)` (multi-group)

## Skipped — chDB analyzer / cerberus emitter limitations

Five fixtures from the original 15 are kept text-only (no seed) because the emitted SQL cannot round-trip through chDB:

- `edge_chain_ancestor_3`, `edge_chain_descendant_3`, `edge_chain_mixed_5` — chDB analyzer rejects nested `WITH RECURSIVE` CTEs whose seed is a prior `SELECT R.* FROM (...) AS L INNER JOIN (...) AS R` subquery: `UNKNOWN_IDENTIFIER: Unknown expression identifier 'TraceId' in scope SELECT TraceId, SpanId, ParentSpanId, 0 AS _depth FROM (SELECT R.* FROM (WITH RECURSIVE _struct_closure AS ...) AS L INNER JOIN ... AS R)`.
- `edge_chain_child_5` — same family without recursion: `UNKNOWN_IDENTIFIER: Identifier 'L.TraceId' cannot be resolved from subquery with name L. Maybe you meant: ['R.TraceId']` in nested `SELECT R.*` chains.
- `edge_inner_max_attr` — `max(SpanAttributes[k])` returns `String` (Map values are `String`); the outer `WHERE Value > 100` (Int) fails with `NO_COMMON_TYPE: There is no supertype for types String, UInt8`. chDB has no implicit String→numeric cast in `WHERE` against an outer-projected `Value` column. Cerberus's emitter would need an explicit `toFloat64` cast on Map-valued aggregate inputs to round-trip cleanly. Pre-existing emitter issue, separate from this PR.

## Test plan
- [x] `go test -tags chdb -count=1 ./test/spec/traceql/... -run TestRoundTripChDB` — 132 passed
- [x] `go build ./...` clean
- [x] Rebased on latest main

🤖 Generated with [Claude Code](https://claude.com/claude-code)