### PR TITLE
test(spec/promql): seed chDB roundtrip for 14 aggregator/scalar fixtures

### DIFF
--- a/test/spec/promql/bottomk_range_bare.txtar
+++ b/test/spec/promql/bottomk_range_bare.txtar
@@ -2,6 +2,72 @@
 bottomk(5, demo_memory_usage_bytes)
 -- range_step --
 30s
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('demo_memory_usage_bytes', map('instance', 'host-1'), toDateTime64('2026-01-01 00:00:00', 9), 100.0),
+    ('demo_memory_usage_bytes', map('instance', 'host-2'), toDateTime64('2026-01-01 00:00:00', 9), 200.0),
+    ('demo_memory_usage_bytes', map('instance', 'host-3'), toDateTime64('2026-01-01 00:00:00', 9), 300.0),
+    ('demo_memory_usage_bytes', map('instance', 'host-4'), toDateTime64('2026-01-01 00:00:00', 9), 400.0),
+    ('demo_memory_usage_bytes', map('instance', 'host-5'), toDateTime64('2026-01-01 00:00:00', 9), 500.0);
+-- expected_rows --
+[
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:00:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:00:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:01:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:01:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:02:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:02:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:03:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:03:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:04:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:04:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:00:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:00:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:01:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:01:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:02:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:02:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:03:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:03:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:04:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:04:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:00:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:00:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:01:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:01:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:02:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:02:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:03:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:03:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:04:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:04:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:00:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:00:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:01:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:01:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:02:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:02:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:03:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:03:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:04:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:04:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:00:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:00:30Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:01:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:01:30Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:02:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:02:30Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:03:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:03:30Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:04:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:04:30Z", 500]
+]
 -- args --
 [0] string = "demo_memory_usage_bytes"
 [1] int64 = 300000000000

--- a/test/spec/promql/bottomk_range_by_instance.txtar
+++ b/test/spec/promql/bottomk_range_by_instance.txtar
@@ -2,6 +2,72 @@
 bottomk by(instance) (5, demo_memory_usage_bytes)
 -- range_step --
 30s
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('demo_memory_usage_bytes', map('instance', 'host-1'), toDateTime64('2026-01-01 00:00:00', 9), 100.0),
+    ('demo_memory_usage_bytes', map('instance', 'host-2'), toDateTime64('2026-01-01 00:00:00', 9), 200.0),
+    ('demo_memory_usage_bytes', map('instance', 'host-3'), toDateTime64('2026-01-01 00:00:00', 9), 300.0),
+    ('demo_memory_usage_bytes', map('instance', 'host-4'), toDateTime64('2026-01-01 00:00:00', 9), 400.0),
+    ('demo_memory_usage_bytes', map('instance', 'host-5'), toDateTime64('2026-01-01 00:00:00', 9), 500.0);
+-- expected_rows --
+[
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:00:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:00:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:01:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:01:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:02:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:02:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:03:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:03:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:04:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:04:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:00:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:00:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:01:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:01:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:02:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:02:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:03:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:03:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:04:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:04:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:00:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:00:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:01:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:01:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:02:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:02:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:03:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:03:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:04:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:04:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:00:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:00:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:01:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:01:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:02:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:02:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:03:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:03:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:04:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:04:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:00:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:00:30Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:01:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:01:30Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:02:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:02:30Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:03:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:03:30Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:04:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:04:30Z", 500]
+]
 -- args --
 [0] string = "demo_memory_usage_bytes"
 [1] int64 = 300000000000

--- a/test/spec/promql/bottomk_range_without_empty.txtar
+++ b/test/spec/promql/bottomk_range_without_empty.txtar
@@ -2,6 +2,72 @@
 bottomk without() (5, demo_memory_usage_bytes)
 -- range_step --
 30s
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('demo_memory_usage_bytes', map('instance', 'host-1'), toDateTime64('2026-01-01 00:00:00', 9), 100.0),
+    ('demo_memory_usage_bytes', map('instance', 'host-2'), toDateTime64('2026-01-01 00:00:00', 9), 200.0),
+    ('demo_memory_usage_bytes', map('instance', 'host-3'), toDateTime64('2026-01-01 00:00:00', 9), 300.0),
+    ('demo_memory_usage_bytes', map('instance', 'host-4'), toDateTime64('2026-01-01 00:00:00', 9), 400.0),
+    ('demo_memory_usage_bytes', map('instance', 'host-5'), toDateTime64('2026-01-01 00:00:00', 9), 500.0);
+-- expected_rows --
+[
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:00:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:00:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:01:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:01:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:02:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:02:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:03:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:03:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:04:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:04:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:00:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:00:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:01:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:01:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:02:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:02:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:03:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:03:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:04:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:04:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:00:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:00:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:01:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:01:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:02:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:02:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:03:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:03:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:04:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:04:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:00:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:00:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:01:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:01:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:02:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:02:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:03:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:03:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:04:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:04:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:00:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:00:30Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:01:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:01:30Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:02:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:02:30Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:03:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:03:30Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:04:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:04:30Z", 500]
+]
 -- args --
 [0] string = "demo_memory_usage_bytes"
 [1] int64 = 300000000000

--- a/test/spec/promql/bottomk_range_without_instance.txtar
+++ b/test/spec/promql/bottomk_range_without_instance.txtar
@@ -2,6 +2,72 @@
 bottomk without(instance) (5, demo_memory_usage_bytes)
 -- range_step --
 30s
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('demo_memory_usage_bytes', map('instance', 'host-1', 'job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 100.0),
+    ('demo_memory_usage_bytes', map('instance', 'host-2', 'job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 200.0),
+    ('demo_memory_usage_bytes', map('instance', 'host-3', 'job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 300.0),
+    ('demo_memory_usage_bytes', map('instance', 'host-4', 'job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 400.0),
+    ('demo_memory_usage_bytes', map('instance', 'host-5', 'job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 500.0);
+-- expected_rows --
+[
+  ["demo_memory_usage_bytes", {"instance": "host-1", "job": "api"}, "2026-01-01T00:00:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1", "job": "api"}, "2026-01-01T00:00:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1", "job": "api"}, "2026-01-01T00:01:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1", "job": "api"}, "2026-01-01T00:01:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1", "job": "api"}, "2026-01-01T00:02:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1", "job": "api"}, "2026-01-01T00:02:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1", "job": "api"}, "2026-01-01T00:03:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1", "job": "api"}, "2026-01-01T00:03:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1", "job": "api"}, "2026-01-01T00:04:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1", "job": "api"}, "2026-01-01T00:04:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-2", "job": "api"}, "2026-01-01T00:00:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2", "job": "api"}, "2026-01-01T00:00:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2", "job": "api"}, "2026-01-01T00:01:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2", "job": "api"}, "2026-01-01T00:01:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2", "job": "api"}, "2026-01-01T00:02:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2", "job": "api"}, "2026-01-01T00:02:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2", "job": "api"}, "2026-01-01T00:03:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2", "job": "api"}, "2026-01-01T00:03:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2", "job": "api"}, "2026-01-01T00:04:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2", "job": "api"}, "2026-01-01T00:04:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-3", "job": "api"}, "2026-01-01T00:00:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3", "job": "api"}, "2026-01-01T00:00:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3", "job": "api"}, "2026-01-01T00:01:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3", "job": "api"}, "2026-01-01T00:01:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3", "job": "api"}, "2026-01-01T00:02:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3", "job": "api"}, "2026-01-01T00:02:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3", "job": "api"}, "2026-01-01T00:03:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3", "job": "api"}, "2026-01-01T00:03:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3", "job": "api"}, "2026-01-01T00:04:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3", "job": "api"}, "2026-01-01T00:04:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-4", "job": "api"}, "2026-01-01T00:00:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4", "job": "api"}, "2026-01-01T00:00:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4", "job": "api"}, "2026-01-01T00:01:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4", "job": "api"}, "2026-01-01T00:01:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4", "job": "api"}, "2026-01-01T00:02:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4", "job": "api"}, "2026-01-01T00:02:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4", "job": "api"}, "2026-01-01T00:03:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4", "job": "api"}, "2026-01-01T00:03:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4", "job": "api"}, "2026-01-01T00:04:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4", "job": "api"}, "2026-01-01T00:04:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-5", "job": "api"}, "2026-01-01T00:00:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5", "job": "api"}, "2026-01-01T00:00:30Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5", "job": "api"}, "2026-01-01T00:01:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5", "job": "api"}, "2026-01-01T00:01:30Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5", "job": "api"}, "2026-01-01T00:02:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5", "job": "api"}, "2026-01-01T00:02:30Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5", "job": "api"}, "2026-01-01T00:03:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5", "job": "api"}, "2026-01-01T00:03:30Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5", "job": "api"}, "2026-01-01T00:04:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5", "job": "api"}, "2026-01-01T00:04:30Z", 500]
+]
 -- args --
 [0] string = "demo_memory_usage_bytes"
 [1] int64 = 300000000000

--- a/test/spec/promql/count_no_group.txtar
+++ b/test/spec/promql/count_no_group.txtar
@@ -1,5 +1,21 @@
 -- query.promql --
 count(up)
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('instance', 'host-1'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('up', map('instance', 'host-2'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('up', map('instance', 'host-3'), toDateTime64('2026-01-01 00:00:00', 9), 0.0),
+    ('up', map('instance', 'host-4'), toDateTime64('2026-01-01 00:00:00', 9), 1.0);
+-- expected_rows --
+[
+  ["", {}, "2026-01-01T00:00:01Z", 4]
+]
 -- args --
 [0] string = ""
 [1] string = "Map(String,String)"

--- a/test/spec/promql/scalar_binop_fold.txtar
+++ b/test/spec/promql/scalar_binop_fold.txtar
@@ -1,5 +1,16 @@
 -- query.promql --
 1 + 2
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- expected_rows --
+[
+  ["", {}, "2026-01-01T00:00:01Z", 3]
+]
 -- args --
 [0] string = ""
 [1] string = "Map(String,String)"

--- a/test/spec/promql/scalar_binop_fold_bool.txtar
+++ b/test/spec/promql/scalar_binop_fold_bool.txtar
@@ -1,5 +1,16 @@
 -- query.promql --
 1 == bool 2
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- expected_rows --
+[
+  ["", {}, "2026-01-01T00:00:01Z", 0]
+]
 -- args --
 [0] string = ""
 [1] string = "Map(String,String)"

--- a/test/spec/promql/scalar_binop_fold_precedence.txtar
+++ b/test/spec/promql/scalar_binop_fold_precedence.txtar
@@ -1,5 +1,16 @@
 -- query.promql --
 1 + 2 * 3
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- expected_rows --
+[
+  ["", {}, "2026-01-01T00:00:01Z", 7]
+]
 -- args --
 [0] string = ""
 [1] string = "Map(String,String)"

--- a/test/spec/promql/scalar_lt_vector.txtar
+++ b/test/spec/promql/scalar_lt_vector.txtar
@@ -1,5 +1,22 @@
 -- query.promql --
 100 < temperature
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('temperature', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 50.0),
+    ('temperature', map('host', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 99.5),
+    ('temperature', map('host', 'c'), toDateTime64('2026-01-01 00:00:00', 9), 150.0),
+    ('temperature', map('host', 'd'), toDateTime64('2026-01-01 00:00:00', 9), 200.0);
+-- expected_rows --
+[
+  ["temperature", {"host": "c"}, "2026-01-01T00:00:00Z", 150],
+  ["temperature", {"host": "d"}, "2026-01-01T00:00:00Z", 200]
+]
 -- sql --
 SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) WHERE (? < `Value`)
 -- args --

--- a/test/spec/promql/stdvar_no_group.txtar
+++ b/test/spec/promql/stdvar_no_group.txtar
@@ -1,5 +1,21 @@
 -- query.promql --
 stdvar(latency_seconds)
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('latency_seconds', map('endpoint', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('latency_seconds', map('endpoint', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 2.0),
+    ('latency_seconds', map('endpoint', 'c'), toDateTime64('2026-01-01 00:00:00', 9), 3.0),
+    ('latency_seconds', map('endpoint', 'd'), toDateTime64('2026-01-01 00:00:00', 9), 4.0);
+-- expected_rows --
+[
+  ["", {}, "2026-01-01T00:00:01Z", 1.25]
+]
 -- sql --
 SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Value` FROM (SELECT varPop(`Value`) AS `Value`, count() AS `_cerb_n` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))) WHERE `_cerb_n` > 0)
 -- args --

--- a/test/spec/promql/topk_range_bare.txtar
+++ b/test/spec/promql/topk_range_bare.txtar
@@ -2,6 +2,72 @@
 topk(5, demo_memory_usage_bytes)
 -- range_step --
 30s
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('demo_memory_usage_bytes', map('instance', 'host-1'), toDateTime64('2026-01-01 00:00:00', 9), 100.0),
+    ('demo_memory_usage_bytes', map('instance', 'host-2'), toDateTime64('2026-01-01 00:00:00', 9), 200.0),
+    ('demo_memory_usage_bytes', map('instance', 'host-3'), toDateTime64('2026-01-01 00:00:00', 9), 300.0),
+    ('demo_memory_usage_bytes', map('instance', 'host-4'), toDateTime64('2026-01-01 00:00:00', 9), 400.0),
+    ('demo_memory_usage_bytes', map('instance', 'host-5'), toDateTime64('2026-01-01 00:00:00', 9), 500.0);
+-- expected_rows --
+[
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:00:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:00:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:01:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:01:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:02:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:02:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:03:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:03:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:04:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:04:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:00:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:00:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:01:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:01:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:02:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:02:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:03:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:03:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:04:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:04:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:00:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:00:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:01:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:01:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:02:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:02:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:03:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:03:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:04:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:04:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:00:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:00:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:01:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:01:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:02:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:02:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:03:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:03:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:04:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:04:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:00:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:00:30Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:01:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:01:30Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:02:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:02:30Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:03:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:03:30Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:04:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:04:30Z", 500]
+]
 -- args --
 [0] string = "demo_memory_usage_bytes"
 [1] int64 = 300000000000

--- a/test/spec/promql/topk_range_by_instance.txtar
+++ b/test/spec/promql/topk_range_by_instance.txtar
@@ -2,6 +2,72 @@
 topk by(instance) (5, demo_memory_usage_bytes)
 -- range_step --
 30s
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('demo_memory_usage_bytes', map('instance', 'host-1'), toDateTime64('2026-01-01 00:00:00', 9), 100.0),
+    ('demo_memory_usage_bytes', map('instance', 'host-2'), toDateTime64('2026-01-01 00:00:00', 9), 200.0),
+    ('demo_memory_usage_bytes', map('instance', 'host-3'), toDateTime64('2026-01-01 00:00:00', 9), 300.0),
+    ('demo_memory_usage_bytes', map('instance', 'host-4'), toDateTime64('2026-01-01 00:00:00', 9), 400.0),
+    ('demo_memory_usage_bytes', map('instance', 'host-5'), toDateTime64('2026-01-01 00:00:00', 9), 500.0);
+-- expected_rows --
+[
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:00:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:00:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:01:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:01:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:02:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:02:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:03:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:03:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:04:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:04:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:00:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:00:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:01:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:01:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:02:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:02:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:03:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:03:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:04:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:04:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:00:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:00:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:01:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:01:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:02:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:02:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:03:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:03:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:04:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:04:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:00:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:00:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:01:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:01:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:02:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:02:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:03:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:03:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:04:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:04:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:00:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:00:30Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:01:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:01:30Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:02:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:02:30Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:03:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:03:30Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:04:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:04:30Z", 500]
+]
 -- args --
 [0] string = "demo_memory_usage_bytes"
 [1] int64 = 300000000000

--- a/test/spec/promql/topk_range_without_empty.txtar
+++ b/test/spec/promql/topk_range_without_empty.txtar
@@ -2,6 +2,72 @@
 topk without() (5, demo_memory_usage_bytes)
 -- range_step --
 30s
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('demo_memory_usage_bytes', map('instance', 'host-1'), toDateTime64('2026-01-01 00:00:00', 9), 100.0),
+    ('demo_memory_usage_bytes', map('instance', 'host-2'), toDateTime64('2026-01-01 00:00:00', 9), 200.0),
+    ('demo_memory_usage_bytes', map('instance', 'host-3'), toDateTime64('2026-01-01 00:00:00', 9), 300.0),
+    ('demo_memory_usage_bytes', map('instance', 'host-4'), toDateTime64('2026-01-01 00:00:00', 9), 400.0),
+    ('demo_memory_usage_bytes', map('instance', 'host-5'), toDateTime64('2026-01-01 00:00:00', 9), 500.0);
+-- expected_rows --
+[
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:00:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:00:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:01:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:01:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:02:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:02:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:03:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:03:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:04:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1"}, "2026-01-01T00:04:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:00:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:00:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:01:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:01:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:02:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:02:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:03:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:03:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:04:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2"}, "2026-01-01T00:04:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:00:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:00:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:01:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:01:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:02:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:02:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:03:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:03:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:04:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3"}, "2026-01-01T00:04:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:00:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:00:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:01:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:01:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:02:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:02:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:03:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:03:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:04:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4"}, "2026-01-01T00:04:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:00:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:00:30Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:01:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:01:30Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:02:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:02:30Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:03:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:03:30Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:04:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5"}, "2026-01-01T00:04:30Z", 500]
+]
 -- args --
 [0] string = "demo_memory_usage_bytes"
 [1] int64 = 300000000000

--- a/test/spec/promql/topk_range_without_instance.txtar
+++ b/test/spec/promql/topk_range_without_instance.txtar
@@ -2,6 +2,72 @@
 topk without(instance) (5, demo_memory_usage_bytes)
 -- range_step --
 30s
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('demo_memory_usage_bytes', map('instance', 'host-1', 'job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 100.0),
+    ('demo_memory_usage_bytes', map('instance', 'host-2', 'job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 200.0),
+    ('demo_memory_usage_bytes', map('instance', 'host-3', 'job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 300.0),
+    ('demo_memory_usage_bytes', map('instance', 'host-4', 'job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 400.0),
+    ('demo_memory_usage_bytes', map('instance', 'host-5', 'job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 500.0);
+-- expected_rows --
+[
+  ["demo_memory_usage_bytes", {"instance": "host-1", "job": "api"}, "2026-01-01T00:00:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1", "job": "api"}, "2026-01-01T00:00:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1", "job": "api"}, "2026-01-01T00:01:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1", "job": "api"}, "2026-01-01T00:01:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1", "job": "api"}, "2026-01-01T00:02:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1", "job": "api"}, "2026-01-01T00:02:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1", "job": "api"}, "2026-01-01T00:03:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1", "job": "api"}, "2026-01-01T00:03:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1", "job": "api"}, "2026-01-01T00:04:00Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-1", "job": "api"}, "2026-01-01T00:04:30Z", 100],
+  ["demo_memory_usage_bytes", {"instance": "host-2", "job": "api"}, "2026-01-01T00:00:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2", "job": "api"}, "2026-01-01T00:00:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2", "job": "api"}, "2026-01-01T00:01:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2", "job": "api"}, "2026-01-01T00:01:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2", "job": "api"}, "2026-01-01T00:02:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2", "job": "api"}, "2026-01-01T00:02:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2", "job": "api"}, "2026-01-01T00:03:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2", "job": "api"}, "2026-01-01T00:03:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2", "job": "api"}, "2026-01-01T00:04:00Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-2", "job": "api"}, "2026-01-01T00:04:30Z", 200],
+  ["demo_memory_usage_bytes", {"instance": "host-3", "job": "api"}, "2026-01-01T00:00:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3", "job": "api"}, "2026-01-01T00:00:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3", "job": "api"}, "2026-01-01T00:01:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3", "job": "api"}, "2026-01-01T00:01:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3", "job": "api"}, "2026-01-01T00:02:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3", "job": "api"}, "2026-01-01T00:02:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3", "job": "api"}, "2026-01-01T00:03:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3", "job": "api"}, "2026-01-01T00:03:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3", "job": "api"}, "2026-01-01T00:04:00Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-3", "job": "api"}, "2026-01-01T00:04:30Z", 300],
+  ["demo_memory_usage_bytes", {"instance": "host-4", "job": "api"}, "2026-01-01T00:00:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4", "job": "api"}, "2026-01-01T00:00:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4", "job": "api"}, "2026-01-01T00:01:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4", "job": "api"}, "2026-01-01T00:01:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4", "job": "api"}, "2026-01-01T00:02:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4", "job": "api"}, "2026-01-01T00:02:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4", "job": "api"}, "2026-01-01T00:03:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4", "job": "api"}, "2026-01-01T00:03:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4", "job": "api"}, "2026-01-01T00:04:00Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-4", "job": "api"}, "2026-01-01T00:04:30Z", 400],
+  ["demo_memory_usage_bytes", {"instance": "host-5", "job": "api"}, "2026-01-01T00:00:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5", "job": "api"}, "2026-01-01T00:00:30Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5", "job": "api"}, "2026-01-01T00:01:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5", "job": "api"}, "2026-01-01T00:01:30Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5", "job": "api"}, "2026-01-01T00:02:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5", "job": "api"}, "2026-01-01T00:02:30Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5", "job": "api"}, "2026-01-01T00:03:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5", "job": "api"}, "2026-01-01T00:03:30Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5", "job": "api"}, "2026-01-01T00:04:00Z", 500],
+  ["demo_memory_usage_bytes", {"instance": "host-5", "job": "api"}, "2026-01-01T00:04:30Z", 500]
+]
 -- args --
 [0] string = "demo_memory_usage_bytes"
 [1] int64 = 300000000000

--- a/test/spec/runner_chdb.go
+++ b/test/spec/runner_chdb.go
@@ -86,6 +86,80 @@ func isMapColumn(name string) bool {
 	return false
 }
 
+// expandStarProjection rewrites a top-level `SELECT * FROM (SELECT
+// <projs> FROM ...) ...` into `SELECT <alias-list> FROM (SELECT
+// <projs> FROM ...) ...` so the subsequent [rewriteMapProjections]
+// pass can wrap Map-typed columns in `toJSONString(...)`. cerberus's
+// emitter sometimes hoists a star projection over a fully-aliased
+// inner SELECT (e.g. the `Filter ... Project ...` lowering shape of
+// `<scalar> < metric`); without expansion, the outer `*` carries the
+// inner Map column through unwrapped and chdb-go's parquet driver
+// panics with `could not cast to type: MAP`.
+//
+// The transform is conservative: it fires only when the outer
+// projection is exactly `*` and the inner subquery starts with
+// `SELECT ` (case-insensitive). Anything else passes through. The
+// inner subquery's projections are re-rendered as their aliases
+// (preferring explicit `AS <alias>` over the implicit form), which
+// lets the outer SELECT name the columns and the Map-wrap pass do
+// its work without touching the inner shape.
+func expandStarProjection(query string) string {
+	head, tail := splitOuterSelect(query)
+	if head == "" || strings.TrimSpace(head) != "*" {
+		return query
+	}
+	// `tail` starts with " FROM "; the next non-space token should be
+	// `(` opening an inner subquery whose projection list we can
+	// borrow. Bail out otherwise.
+	rest := strings.TrimSpace(strings.TrimPrefix(tail, " FROM "))
+	if !strings.HasPrefix(rest, "(") {
+		return query
+	}
+	// Find the matching `)` for the subquery.
+	depth := 0
+	end := -1
+	for i := 0; i < len(rest); i++ {
+		switch rest[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				end = i
+			}
+		}
+		if end >= 0 {
+			break
+		}
+	}
+	if end < 0 {
+		return query
+	}
+	inner := strings.TrimSpace(rest[1:end])
+	innerHead, _ := splitOuterSelect(inner)
+	if innerHead == "" {
+		return query
+	}
+	innerProjs := splitProjections(innerHead)
+	aliases := make([]string, 0, len(innerProjs))
+	for _, p := range innerProjs {
+		expr, alias := splitAlias(p)
+		if alias == "" {
+			alias = mapColAlias(strings.TrimSpace(expr))
+		}
+		// Bail when the inner projection is itself a star, a
+		// function call, or anything else that doesn't reduce to a
+		// stable column name. Returning the original query keeps
+		// the existing Map-panic failure mode for shapes the
+		// rewriter cannot canonically enumerate.
+		if alias == "" || alias == "*" || strings.ContainsAny(alias, "()`") {
+			return query
+		}
+		aliases = append(aliases, "`"+alias+"`")
+	}
+	return "SELECT " + strings.Join(aliases, ", ") + tail
+}
+
 // rewriteMapProjections wraps any top-level SELECT projection whose
 // alias is a known Map column in toJSONString(...). The transform
 // fires on the OUTER SELECT only — subqueries keep their Map columns
@@ -536,6 +610,7 @@ func RunRoundTrip(t *testing.T, c *Case) {
 	// the args side is global, and ordering them this way keeps the
 	// argIdx accounting in substituteNow64 simple.
 	query, queryArgs := substituteNow64(rt.SQL, rt.Args)
+	query = expandStarProjection(query)
 	query = rewriteMapProjections(query)
 	colCount := extractProjectionCount(query)
 


### PR DESCRIPTION
## Summary

- Adds `-- seed --` + `-- expected_rows --` blocks for 14 PromQL fixtures so the chDB-tagged round-trip runner now exercises them end-to-end:
  - 4 `topk_range_*` + 4 `bottomk_range_*` fixtures — 5 distinct series at `2026-01-01 00:00:00`, 5 m lookback × 30 s step grid yields the expected 50-row matrix per fixture (10 anchors × 5 series).
  - 3 `scalar_binop_fold*` fixtures — constant-fold path (`SELECT 1` literal source); seed creates the `otel_metrics_gauge` table without rows so the opt-in works.
  - `scalar_lt_vector`, `count_no_group`, `stdvar_no_group` — multi-series gauges sized so the aggregate / threshold is unambiguous.
- Extends `test/spec/runner_chdb.go` with `expandStarProjection`. cerberus's emitter occasionally hoists `SELECT * FROM (SELECT a AS A, b AS B, ...)` (e.g. the `Filter ... Project ...` lowering shape of `<scalar> < metric`). Without expansion, the outer `*` carries the inner Map column through unwrapped and chdb-go's parquet driver panics with `could not cast to type: MAP`. The new pass rewrites the outer projection to the inner SELECT's alias list, conservatively bailing on nested `*`, function-call, or otherwise-non-stable aliases so existing fixtures (notably `traceql/metrics_chained`'s `SELECT * FROM (SELECT * FROM ...)`) keep their current shape.

## Test plan

- [x] `CGO_ENABLED=1 LD_LIBRARY_PATH=/usr/local/lib go test -tags chdb ./test/spec/...` — 496 pass, 0 fail locally.
- [x] `go build ./...` clean.
- [x] Each new fixture re-verified without `GOLDEN_UPDATE=1` to confirm the expected rows match a fresh chDB execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)