### PR TITLE
test(spec/traceql): seed 8 structural !/&& fixtures for chDB roundtrip

### DIFF
--- a/test/spec/traceql/structural_child_of_union.txtar
+++ b/test/spec/traceql/structural_child_of_union.txtar
@@ -9,6 +9,25 @@ SELECT R.* FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)
 [3] string = "b"
 [4] string = "service.name"
 [5] string = "c"
+-- seed --
+CREATE TABLE otel_traces (
+    TraceId String,
+    SpanId String,
+    ParentSpanId String,
+    _svc String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('service.name', _svc)
+) ENGINE = Memory;
+INSERT INTO otel_traces (TraceId, SpanId, ParentSpanId, _svc) VALUES
+    ('t1', 's1', '',   'a'),
+    ('t1', 's2', 's1', 'b'),
+    ('t1', 's3', 's1', 'c'),
+    ('t2', 's4', '',   'a'),
+    ('t2', 's5', 's4', 'd');
+-- expected_rows --
+[
+  ["t1", "s2", "s1", "b"],
+  ["t1", "s3", "s1", "c"]
+]
 -- chplan --
 StructuralJoin op=>
   Filter predicate=(ResourceAttributes["service.name"] = "a")

--- a/test/spec/traceql/structural_descendant_of_intersect.txtar
+++ b/test/spec/traceql/structural_descendant_of_intersect.txtar
@@ -9,6 +9,20 @@ SELECT R.* FROM (WITH RECURSIVE _struct_closure AS (SELECT `TraceId`, `SpanId`, 
 [3] string = "b"
 [4] string = "service.name"
 [5] string = "c"
+-- seed --
+CREATE TABLE otel_traces (
+    TraceId String,
+    SpanId String,
+    ParentSpanId String,
+    _svc String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('service.name', _svc)
+) ENGINE = Memory;
+INSERT INTO otel_traces (TraceId, SpanId, ParentSpanId, _svc) VALUES
+    ('t1', 's1', '',   'a'),
+    ('t1', 's2', 's1', 'b'),
+    ('t1', 's3', 's2', 'c');
+-- expected_rows --
+[]
 -- chplan --
 StructuralJoin op=>>
   SetOperation op=&&

--- a/test/spec/traceql/structural_not_ancestor.txtar
+++ b/test/spec/traceql/structural_not_ancestor.txtar
@@ -5,6 +5,24 @@ SELECT R.* FROM (SELECT * FROM `otel_traces` WHERE (`SpanName` = ?)) AS R LEFT A
 -- args --
 [0] string = "b"
 [1] string = "a"
+-- seed --
+CREATE TABLE otel_traces (
+    TraceId String,
+    SpanId String,
+    ParentSpanId String,
+    SpanName String
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    ('t1', 's1', '',   'b'),
+    ('t1', 's2', 's1', 'a'),
+    ('t2', 's3', '',   'a'),
+    ('t2', 's4', 's3', 'b'),
+    ('t3', 's5', '',   'b');
+-- expected_rows --
+[
+  ["t2", "s4", "s3", "b"],
+  ["t3", "s5", "", "b"]
+]
 -- chplan --
 StructuralJoin op=!<<
   Filter predicate=(SpanName = "a")

--- a/test/spec/traceql/structural_not_child.txtar
+++ b/test/spec/traceql/structural_not_child.txtar
@@ -5,6 +5,24 @@ SELECT R.* FROM (SELECT * FROM `otel_traces` WHERE (`SpanName` = ?)) AS R LEFT A
 -- args --
 [0] string = "b"
 [1] string = "a"
+-- seed --
+CREATE TABLE otel_traces (
+    TraceId String,
+    SpanId String,
+    ParentSpanId String,
+    SpanName String
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    ('t1', 's1', '',   'a'),
+    ('t1', 's2', 's1', 'b'),
+    ('t2', 's3', '',   'c'),
+    ('t2', 's4', 's3', 'b'),
+    ('t3', 's5', '',   'b');
+-- expected_rows --
+[
+  ["t2", "s4", "s3", "b"],
+  ["t3", "s5", "", "b"]
+]
 -- chplan --
 StructuralJoin op=!>
   Filter predicate=(SpanName = "a")

--- a/test/spec/traceql/structural_not_descendant.txtar
+++ b/test/spec/traceql/structural_not_descendant.txtar
@@ -5,6 +5,25 @@ SELECT R.* FROM (SELECT * FROM `otel_traces` WHERE (`SpanName` = ?)) AS R LEFT A
 -- args --
 [0] string = "b"
 [1] string = "a"
+-- seed --
+CREATE TABLE otel_traces (
+    TraceId String,
+    SpanId String,
+    ParentSpanId String,
+    SpanName String
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    ('t1', 's1', '',   'a'),
+    ('t1', 's2', 's1', 'b'),
+    ('t1', 's3', 's2', 'b'),
+    ('t2', 's4', '',   'c'),
+    ('t2', 's5', 's4', 'b'),
+    ('t3', 's6', '',   'b');
+-- expected_rows --
+[
+  ["t2", "s5", "s4", "b"],
+  ["t3", "s6", "", "b"]
+]
 -- chplan --
 StructuralJoin op=!>>
   Filter predicate=(SpanName = "a")

--- a/test/spec/traceql/structural_not_parent.txtar
+++ b/test/spec/traceql/structural_not_parent.txtar
@@ -5,6 +5,24 @@ SELECT R.* FROM (SELECT * FROM `otel_traces` WHERE (`SpanName` = ?)) AS R LEFT A
 -- args --
 [0] string = "b"
 [1] string = "a"
+-- seed --
+CREATE TABLE otel_traces (
+    TraceId String,
+    SpanId String,
+    ParentSpanId String,
+    SpanName String
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    ('t1', 's1', '',   'b'),
+    ('t1', 's2', 's1', 'a'),
+    ('t2', 's3', '',   'b'),
+    ('t2', 's4', 's3', 'c'),
+    ('t3', 's5', '',   'b');
+-- expected_rows --
+[
+  ["t2", "s3", "", "b"],
+  ["t3", "s5", "", "b"]
+]
 -- chplan --
 StructuralJoin op=!<
   Filter predicate=(SpanName = "a")

--- a/test/spec/traceql/structural_not_sibling.txtar
+++ b/test/spec/traceql/structural_not_sibling.txtar
@@ -5,6 +5,26 @@ SELECT R.* FROM (SELECT * FROM `otel_traces` WHERE (`SpanName` = ?)) AS R LEFT A
 -- args --
 [0] string = "b"
 [1] string = "a"
+-- seed --
+CREATE TABLE otel_traces (
+    TraceId String,
+    SpanId String,
+    ParentSpanId String,
+    SpanName String
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    ('t1', 's1', '',   'p'),
+    ('t1', 's2', 's1', 'a'),
+    ('t1', 's3', 's1', 'b'),
+    ('t2', 's4', '',   'p'),
+    ('t2', 's5', 's4', 'c'),
+    ('t2', 's6', 's4', 'b'),
+    ('t3', 's7', '',   'b');
+-- expected_rows --
+[
+  ["t2", "s6", "s4", "b"],
+  ["t3", "s7", "", "b"]
+]
 -- chplan --
 StructuralJoin op=!~
   Filter predicate=(SpanName = "a")

--- a/test/spec/traceql/structural_union_child.txtar
+++ b/test/spec/traceql/structural_union_child.txtar
@@ -7,6 +7,26 @@
 [1] string = "b"
 [2] string = "a"
 [3] string = "b"
+-- seed --
+CREATE TABLE otel_traces (
+    TraceId String,
+    SpanId String,
+    ParentSpanId String,
+    SpanName String
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    ('t1', 's1', '',   'a'),
+    ('t1', 's2', 's1', 'b'),
+    ('t2', 's3', '',   'c'),
+    ('t2', 's4', 's3', 'd'),
+    ('t3', 's5', '',   'a'),
+    ('t3', 's6', 's5', 'c'),
+    ('t4', 's7', '',   'b');
+-- expected_rows --
+[
+  ["t1", "s1", "", "a"],
+  ["t1", "s2", "s1", "b"]
+]
 -- chplan --
 StructuralJoin op=&>
   Filter predicate=(SpanName = "a")


### PR DESCRIPTION
## Summary

Adds `-- seed --` + `-- expected_rows --` blocks to 8 TraceQL structural fixtures, opting them into the chDB round-trip layer alongside the 8 fixtures landed in #482 and the edge_a-i set in #483.

Covered:
- `structural_child_of_union` (`A > (B || C)`)
- `structural_descendant_of_intersect` (`(A && B) >> C`)
- `structural_not_ancestor` (`A !<< B`)
- `structural_not_child` (`A !> B`)
- `structural_not_descendant` (`A !>> B`)
- `structural_not_parent` (`A !< B`)
- `structural_not_sibling` (`A !~ B`)
- `structural_union_child` (`A &> B`)

Seeds follow the convention #482 established: ordinary `TraceId` / `SpanId` / `ParentSpanId` columns plus `_svc` + `ResourceAttributes MATERIALIZED map('service.name', _svc)` for the `service.name` cases, or `SpanName` for the `name=` cases. `MATERIALIZED` keeps Map columns out of `*` expansion so the runner's wildcard-aware `extractProjectionCount` (added in #482) sees the right ordinary-column count.

Each seed is designed so the predicate result is non-trivial — anti-joins assert exclusion against rows that DO match the inverse, the union shape returns both arms, and the intersect-of-`service.name` arm is deliberately empty (no span can have `service.name='a'` AND `service.name='b'`) to assert the empty-set propagation.

## Test plan

- [x] `go test -tags chdb ./test/spec/traceql/... -run TestRoundTripChDB/structural_` — all 8 pass.
- [x] `go test -tags chdb ./test/spec/... -run TestRoundTripChDB` — no regression across the wider chDB corpus.
- [x] `go test ./internal/traceql/... -run TestLower` — text-equality goldens still pass (seed blocks are inert without the build tag).
- [x] `go build ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)