### PR TITLE
fix(ci/mutation): enforce gremlins efficacy threshold via awk parse

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -62,7 +62,26 @@ jobs:
       - name: Install gremlins
         run: go install github.com/go-gremlins/gremlins/cmd/gremlins@v0.6.0
       - name: gremlins unleash
+        # gremlins v0.6.0's `--threshold-efficacy` flag is documented as
+        # a quality gate ("makes gremlins exit with an error if values
+        # are not met") but in practice the binary exits 0 regardless
+        # of the threshold. Parse the reported efficacy ourselves and
+        # exit non-zero when the matrix `efficacy` floor isn't met.
+        # When upstream fixes the exit-code behaviour, drop the awk
+        # block and let `--threshold-efficacy` do the gating.
         run: |
+          set -euo pipefail
           gremlins unleash \
             --threshold-efficacy ${{ matrix.efficacy }} \
-            ${{ matrix.scope }}
+            ${{ matrix.scope }} | tee gremlins.log
+          awk -v threshold=${{ matrix.efficacy }} '
+            /Test efficacy:/ {
+              measured = $3
+              gsub(/[^0-9.]/, "", measured)
+              if ((measured + 0) < (threshold + 0)) {
+                printf("::error::gremlins efficacy %s%% < threshold %s%%\n", measured, threshold)
+                exit 1
+              }
+              printf("::notice::gremlins efficacy %s%% >= threshold %s%%\n", measured, threshold)
+            }
+          ' gremlins.log


### PR DESCRIPTION
## Summary

gremlins v0.6.0's `--threshold-efficacy` flag is documented as a quality gate but does **not** enforce exit code — verified locally and against the [phase3-optimizer run on PR #488](https://github.com/tsouza/cerberus/actions/runs/26087694248/job/76704928674): efficacy measured 91.81% against the 95% bar, job concluded "success".

Wrap `gremlins unleash | tee gremlins.log` and post-process with awk: parse `Test efficacy:`, compare to matrix floor, exit non-zero on violation with `::error::` annotation.

## Implication for #488's claim

Without this fix, the 95% bump from #488 (and the prior 85/90% bars) was advisory only. After this lands, the next nightly will surface the true picture: matrix entries where the actual efficacy < 95% will turn red.

Per the audit job output, phase3-optimizer is at 91.81% — that matrix entry will fail until the test suite catches the surviving mutants (or the bar is consciously lowered for that package only). The workflow remains informational on push-to-main + nightly + dispatch, so the red entries surface findings without blocking merges.

## Test plan

- [x] Local repro with gremlins v0.6.0 + small Go module: confirms `--threshold-efficacy 99` exits 0 even at 0% measured efficacy.
- [x] awk wrapper exits 1 on below-threshold, 0 on at/above.
- [ ] Next push to main triggers the workflow; expect phase3-optimizer (and possibly others) to surface as red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)