### PR TITLE
chore(ci/mutation): switch to gremlins-action + JSON-output threshold gate

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -59,29 +59,34 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
-      - name: Install gremlins
-        run: go install github.com/go-gremlins/gremlins/cmd/gremlins@v0.6.0
+      # Official action wraps `gremlins unleash` with the binary
+      # pre-installed and forwards `args` verbatim. Use `--output`
+      # for structured JSON (gremlins exits 0 even when
+      # `--threshold-efficacy` is violated in v0.6.0, so we do the
+      # gating ourselves against the parsed JSON). When upstream
+      # fixes the exit-code behaviour, the jq + threshold check can
+      # be dropped and the action's `args` shortened to
+      # `--threshold-efficacy ${{ matrix.efficacy }} ${{ matrix.scope }}`.
       - name: gremlins unleash
-        # gremlins v0.6.0's `--threshold-efficacy` flag is documented as
-        # a quality gate ("makes gremlins exit with an error if values
-        # are not met") but in practice the binary exits 0 regardless
-        # of the threshold. Parse the reported efficacy ourselves and
-        # exit non-zero when the matrix `efficacy` floor isn't met.
-        # When upstream fixes the exit-code behaviour, drop the awk
-        # block and let `--threshold-efficacy` do the gating.
+        uses: go-gremlins/gremlins-action@v1
+        with:
+          version: v0.6.0
+          args: --output gremlins.json ${{ matrix.scope }}
+      - name: enforce efficacy threshold
         run: |
           set -euo pipefail
-          gremlins unleash \
-            --threshold-efficacy ${{ matrix.efficacy }} \
-            ${{ matrix.scope }} | tee gremlins.log
-          awk -v threshold=${{ matrix.efficacy }} '
-            /Test efficacy:/ {
-              measured = $3
-              gsub(/[^0-9.]/, "", measured)
-              if ((measured + 0) < (threshold + 0)) {
-                printf("::error::gremlins efficacy %s%% < threshold %s%%\n", measured, threshold)
-                exit 1
-              }
-              printf("::notice::gremlins efficacy %s%% >= threshold %s%%\n", measured, threshold)
-            }
-          ' gremlins.log
+          measured=$(jq -r '.test_efficacy' gremlins.json)
+          threshold=${{ matrix.efficacy }}
+          if awk -v m="$measured" -v t="$threshold" 'BEGIN { exit (m < t) ? 1 : 0 }'; then
+            echo "::notice::gremlins efficacy ${measured}% >= threshold ${threshold}%"
+          else
+            echo "::error::gremlins efficacy ${measured}% < threshold ${threshold}%"
+            exit 1
+          fi
+      - name: upload gremlins report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gremlins-${{ matrix.phase }}
+          path: gremlins.json
+          retention-days: 14


### PR DESCRIPTION
## Summary

Replace the stdout-awk wrapper from #490 with:

1. **Official action** — `go-gremlins/gremlins-action@v1` (per [gremlins.dev/usage/ci/github-action](https://gremlins.dev/latest/usage/ci/github-action/)) instead of `go install`. Drops a step, picks up upstream improvements automatically.
2. **Structured JSON** — `gremlins unleash --output gremlins.json` emits a documented schema (`test_efficacy`, `mutations_coverage`, `mutants_*`, `mutator_statistics`). Parse the field with `jq -r '.test_efficacy'` instead of grepping the human-readable line.
3. **Per-phase artifact** — upload `gremlins.json` (14d retention) so the dashboard / trend per phase is browsable.

The action itself is a thin Node wrapper around `gremlins unleash` and does **not** add threshold enforcement (verified by reading [action.yaml](https://github.com/go-gremlins/gremlins-action/blob/v1/action.yaml) — it just forwards `args` verbatim). So we still need the explicit jq + threshold compare; but now it reads a stable schema field instead of a log line.

## When upstream fixes the exit-code behaviour

Drop the `enforce efficacy threshold` step and shorten the action `args` to:

```yaml
with:
  args: --threshold-efficacy ${{ matrix.efficacy }} ${{ matrix.scope }}
```

## Test plan

- [x] Local repro: `gremlins unleash --output gremlins.json` writes `{"test_efficacy": ..., "mutations_coverage": ..., ...}`.
- [x] jq + awk threshold compare exits 0 at/above bar, 1 below.
- [ ] Next push to main exercises the new shape — phase3-optimizer (91.81% measured) will surface as red, others should pass at 95%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)