### PR TITLE
fix(traceql): wrap Map-subscript aggregate inputs in toFloat64OrZero

### DIFF
--- a/internal/traceql/aggregate.go
+++ b/internal/traceql/aggregate.go
@@ -50,6 +50,15 @@ func lowerAggregate(prev chplan.Node, agg traceql.Aggregate, s schema.Traces) (c
 		return nil, err
 	}
 
+	// Map(String, String) coercion: when the aggregate input is a
+	// FieldAccess against SpanAttributes / ResourceAttributes the value
+	// is a String. ClickHouse refuses `max(String) > 100` with
+	// NO_COMMON_TYPE; wrap in `toFloat64OrZero(...)` at lowering time so
+	// the aggregate sees a Float64 and the downstream numeric
+	// comparison resolves. Intrinsic ColumnRefs (Duration etc.) lower
+	// to a bare ColumnRef and pass through unchanged.
+	arg = coerceMapNumericAggInput(arg)
+
 	return &chplan.Aggregate{
 		Input: prev,
 		AggFuncs: []chplan.AggFunc{{
@@ -58,6 +67,32 @@ func lowerAggregate(prev chplan.Node, agg traceql.Aggregate, s schema.Traces) (c
 			Alias: valueAlias,
 		}},
 	}, nil
+}
+
+// coerceMapNumericAggInput wraps Map-subscript expressions
+// (`SpanAttributes['foo']`, `ResourceAttributes['foo']`) with
+// `toFloat64OrZero(...)` so they can flow into a numeric CH aggregate
+// (`max`/`min`/`sum`/`avg`/`quantiles`). The OTel-CH attribute carriers
+// are typed `Map(String, String)`, so a bare subscript returns String —
+// CH then refuses to compare the aggregate against a numeric literal
+// with NO_COMMON_TYPE.
+//
+// The `OrZero` variant silently coerces strings that don't parse as
+// numbers (matches Loki's silent-fallback for typed label filters via
+// PR #479).
+//
+// Pass-through for everything else: intrinsic ColumnRefs (Duration,
+// already Int64) need no cast; pre-wrapped FuncCalls (e.g. an
+// arithmetic Binary that was already coerced) keep their existing
+// shape.
+func coerceMapNumericAggInput(expr chplan.Expr) chplan.Expr {
+	if _, ok := expr.(*chplan.FieldAccess); ok {
+		return &chplan.FuncCall{
+			Name: "toFloat64OrZero",
+			Args: []chplan.Expr{expr},
+		}
+	}
+	return expr
 }
 
 // mapAggregateOp turns a TraceQL AggregateOp into the CH agg function

--- a/internal/traceql/metrics_pipeline.go
+++ b/internal/traceql/metrics_pipeline.go
@@ -204,7 +204,11 @@ func metricsAggregateAttr(op traceql.MetricsAggregateOp, attr traceql.Attribute,
 	if attr == (traceql.Attribute{}) {
 		return nil, fmt.Errorf("traceql: %s requires an attribute operand", op)
 	}
-	return lowerAttribute(attr, s), nil
+	// Map(String, String) coercion: see coerceMapNumericAggInput in
+	// aggregate.go. `*_over_time(span.foo)` resolves to a FieldAccess
+	// against SpanAttributes (typed String); wrap so the downstream CH
+	// aggregate (`max`/`min`/`sum`/`avg`/`quantiles`) sees a Float64.
+	return coerceMapNumericAggInput(lowerAttribute(attr, s)), nil
 }
 
 // histogramBucketAlias is the SELECT-list alias for the bucket column

--- a/internal/traceql/numeric_coercion_test.go
+++ b/internal/traceql/numeric_coercion_test.go
@@ -87,6 +87,54 @@ func TestNumericAttrCoercion(t *testing.T) {
 			wantSubstr: "`Duration` > ?",
 			notSubstr:  "toFloat64(`Duration`",
 		},
+		{
+			// Aggregate-input coercion: `max(span.foo)` against a
+			// Map(String, String) attribute reads as String; without the
+			// wrap CH rejects `max(String) > 100` with NO_COMMON_TYPE.
+			// coerceMapNumericAggInput wraps the FieldAccess with
+			// toFloat64OrZero so the aggregate sees a Float64.
+			name:       "max_span_attr_wraps_aggregate_input",
+			query:      `{} | max(span.latency_ms) > 100`,
+			wantSubstr: "max(toFloat64OrZero(`SpanAttributes`[?]))",
+		},
+		{
+			name:       "min_span_attr_wraps_aggregate_input",
+			query:      `{} | min(span.attempts) < 3`,
+			wantSubstr: "min(toFloat64OrZero(`SpanAttributes`[?]))",
+		},
+		{
+			name:       "sum_span_attr_wraps_aggregate_input",
+			query:      `{} | sum(span.size) > 1000`,
+			wantSubstr: "sum(toFloat64OrZero(`SpanAttributes`[?]))",
+		},
+		{
+			name:       "avg_resource_attr_wraps_aggregate_input",
+			query:      `{} | avg(resource.replicas) > 1`,
+			wantSubstr: "avg(toFloat64OrZero(`ResourceAttributes`[?]))",
+		},
+		{
+			// Intrinsic duration aggregates lower to a bare ColumnRef so
+			// the coercion guard leaves them untouched. The existing
+			// avg_duration / metrics_max_over_time fixtures pin this
+			// shape; the unit case anchors the negative half of the
+			// aggregate-input rule.
+			name:      "avg_duration_intrinsic_not_wrapped",
+			query:     `{} | avg(duration) > 100ms`,
+			notSubstr: "toFloat64OrZero(`Duration`",
+		},
+		{
+			// metrics-pipeline aggregates take the same coercion path
+			// via metricsAggregateAttr — `max_over_time(span.foo)` over
+			// a Map(String, String) carrier needs the same wrap.
+			name:       "max_over_time_span_attr_wraps_aggregate_input",
+			query:      `{} | max_over_time(span.latency_ms)`,
+			wantSubstr: "max(toFloat64OrZero(`SpanAttributes`[?]))",
+		},
+		{
+			name:       "quantile_over_time_span_attr_wraps_aggregate_input",
+			query:      `{} | quantile_over_time(span.latency_ms, 0.95)`,
+			wantSubstr: "quantile(?)(toFloat64OrZero(`SpanAttributes`[?]))",
+		},
 	}
 
 	for _, tc := range cases {

--- a/test/spec/traceql/edge_inner_max_attr.txtar
+++ b/test/spec/traceql/edge_inner_max_attr.txtar
@@ -6,9 +6,22 @@
 [2] string = "x"
 [3] int64 = 100
 -- sql --
-SELECT * FROM (SELECT max(`SpanAttributes`[?]) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?))) WHERE (`Value` > ?)
+SELECT * FROM (SELECT max(toFloat64OrZero(`SpanAttributes`[?])) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?))) WHERE (`Value` > ?)
+-- seed --
+CREATE TABLE otel_traces (
+    ResourceAttributes Map(String, String),
+    SpanAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    (map('service.name', 'x'), map('latency_ms', '50')),
+    (map('service.name', 'x'), map('latency_ms', '150')),
+    (map('service.name', 'x'), map('latency_ms', '200'));
+-- expected_rows --
+[
+  [200.0]
+]
 -- chplan --
 Filter predicate=(Value > 100)
-  Aggregate groupBy=[] funcs=[max(SpanAttributes["latency_ms"]) AS Value]
+  Aggregate groupBy=[] funcs=[max(toFloat64OrZero(SpanAttributes["latency_ms"])) AS Value]
     Filter predicate=(ResourceAttributes["service.name"] = "x")
       Scan(otel_traces)

--- a/test/spec/traceql/edge_inner_min_attr.txtar
+++ b/test/spec/traceql/edge_inner_min_attr.txtar
@@ -6,22 +6,22 @@
 [2] string = "x"
 [3] int64 = 3
 -- sql --
-SELECT * FROM (SELECT min(`SpanAttributes`[?]) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?))) WHERE (`Value` < ?)
+SELECT * FROM (SELECT min(toFloat64OrZero(`SpanAttributes`[?])) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?))) WHERE (`Value` < ?)
 -- seed --
 CREATE TABLE otel_traces (
     ResourceAttributes Map(String, String),
-    SpanAttributes Map(String, UInt64)
+    SpanAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_traces VALUES
-    (map('service.name', 'x'), map('attempts', 1)),
-    (map('service.name', 'x'), map('attempts', 5)),
-    (map('service.name', 'x'), map('attempts', 9));
+    (map('service.name', 'x'), map('attempts', '1')),
+    (map('service.name', 'x'), map('attempts', '5')),
+    (map('service.name', 'x'), map('attempts', '9'));
 -- expected_rows --
 [
-  [1]
+  [1.0]
 ]
 -- chplan --
 Filter predicate=(Value < 3)
-  Aggregate groupBy=[] funcs=[min(SpanAttributes["attempts"]) AS Value]
+  Aggregate groupBy=[] funcs=[min(toFloat64OrZero(SpanAttributes["attempts"])) AS Value]
     Filter predicate=(ResourceAttributes["service.name"] = "x")
       Scan(otel_traces)

--- a/test/spec/traceql/edge_inner_sum_attr.txtar
+++ b/test/spec/traceql/edge_inner_sum_attr.txtar
@@ -6,22 +6,22 @@
 [2] string = "x"
 [3] int64 = 1000
 -- sql --
-SELECT * FROM (SELECT sum(`SpanAttributes`[?]) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?))) WHERE (`Value` > ?)
+SELECT * FROM (SELECT sum(toFloat64OrZero(`SpanAttributes`[?])) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?))) WHERE (`Value` > ?)
 -- seed --
 CREATE TABLE otel_traces (
     ResourceAttributes Map(String, String),
-    SpanAttributes Map(String, UInt64)
+    SpanAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_traces VALUES
-    (map('service.name', 'x'), map('size', 400)),
-    (map('service.name', 'x'), map('size', 500)),
-    (map('service.name', 'x'), map('size', 600));
+    (map('service.name', 'x'), map('size', '400')),
+    (map('service.name', 'x'), map('size', '500')),
+    (map('service.name', 'x'), map('size', '600'));
 -- expected_rows --
 [
-  [1500]
+  [1500.0]
 ]
 -- chplan --
 Filter predicate=(Value > 1000)
-  Aggregate groupBy=[] funcs=[sum(SpanAttributes["size"]) AS Value]
+  Aggregate groupBy=[] funcs=[sum(toFloat64OrZero(SpanAttributes["size"])) AS Value]
     Filter predicate=(ResourceAttributes["service.name"] = "x")
       Scan(otel_traces)

--- a/test/spec/traceql/sum_span_attr.txtar
+++ b/test/spec/traceql/sum_span_attr.txtar
@@ -1,7 +1,7 @@
 -- query.traceql --
 { span.http.status_code >= 400 } | sum(span.http.status_code) > 0
 -- sql --
-SELECT * FROM (SELECT sum(`SpanAttributes`[?]) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE (toFloat64(`SpanAttributes`[?]) >= ?))) WHERE (`Value` > ?)
+SELECT * FROM (SELECT sum(toFloat64OrZero(`SpanAttributes`[?])) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE (toFloat64(`SpanAttributes`[?]) >= ?))) WHERE (`Value` > ?)
 -- args --
 [0] string = "http.status_code"
 [1] string = "http.status_code"
@@ -9,18 +9,18 @@ SELECT * FROM (SELECT sum(`SpanAttributes`[?]) AS `Value` FROM (SELECT * FROM `o
 [3] int64 = 0
 -- seed --
 CREATE TABLE otel_traces (
-    SpanAttributes Map(String, UInt64)
+    SpanAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_traces VALUES
-    (map('http.status_code', 500)),
-    (map('http.status_code', 404)),
-    (map('http.status_code', 200));
+    (map('http.status_code', '500')),
+    (map('http.status_code', '404')),
+    (map('http.status_code', '200'));
 -- expected_rows --
 [
-  [904]
+  [904.0]
 ]
 -- chplan --
 Filter predicate=(Value > 0)
-  Aggregate groupBy=[] funcs=[sum(SpanAttributes["http.status_code"]) AS Value]
+  Aggregate groupBy=[] funcs=[sum(toFloat64OrZero(SpanAttributes["http.status_code"])) AS Value]
     Filter predicate=(toFloat64(SpanAttributes["http.status_code"]) >= 400)
       Scan(otel_traces)


### PR DESCRIPTION
## Summary

ClickHouse refuses `max(SpanAttributes['foo']) > 100` with
`NO_COMMON_TYPE: no supertype for types String, UInt8` because the
OTel-CH attribute carriers are typed `Map(String, String)` — a bare
subscript returns String, and the outer numeric comparison can't
resolve a supertype.

Mirror PR #479's `toFloat64OrZero` wrap from logql's unwrap path:
when the lowered aggregate input is a `FieldAccess` against
`SpanAttributes` / `ResourceAttributes`, wrap with
`toFloat64OrZero(...)` at lowering time so the aggregate sees a
Float64 and the downstream numeric comparison resolves.

Applies to:
- `| max/min/sum/avg(span.foo)` — `internal/traceql/aggregate.go::lowerAggregate`.
- `| max_over_time(span.foo)` / `min_over_time` / `sum_over_time` /
  `avg_over_time` / `quantile_over_time(span.foo, q)` —
  `internal/traceql/metrics_pipeline.go::metricsAggregateAttr`.

Intrinsic ColumnRefs (`Duration`, `SpanName`, etc.) lower to a bare
`ColumnRef`, so the `FieldAccess`-only guard leaves them untouched.
The wrap is also a no-op against pre-wrapped `FuncCall` nodes (e.g.
an arithmetic Binary that was already coerced by the existing
`coerceNumericFieldAccess` rule for filter predicates).

## Test plan

- [x] New unit anchors in `internal/traceql/numeric_coercion_test.go`
      pin the rendered SQL substrings for `max` / `min` / `sum` / `avg`
      on Map attrs, the negative `avg(duration)` intrinsic case, and
      the metrics-pipeline `max_over_time` / `quantile_over_time`
      shapes.
- [x] `edge_inner_max_attr.txtar` now carries a `-- seed --` +
      `-- expected_rows --` section with `Map(String, String)` seed
      values ('50', '150', '200') that actually exercise the
      `toFloat64OrZero` parse path. The 3 sibling fixtures
      (`edge_inner_{min,sum}_attr.txtar`, `sum_span_attr.txtar`) drop
      their earlier `Map(String, UInt64)` workaround in favour of
      `Map(String, String)` since the fix removes the need.
- [x] `go test ./... -count=1`: **3160 passed**.
- [x] `go test -tags chdb ./test/spec/traceql/... -run TestRoundTripChDB`:
      **133 passed** (every TraceQL chDB-seeded fixture incl. the
      primary repro `edge_inner_max_attr.txtar`).

Fixes #58 (chsql Map-aggregate `toFloat64` coercion).