### PR TITLE
test(logql): kill 3 gremlins mutants to clear 95% efficacy

### DIFF
--- a/internal/logql/binary_test.go
+++ b/internal/logql/binary_test.go
@@ -2,9 +2,12 @@ package logql
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
+
+	"github.com/tsouza/cerberus/internal/schema"
 )
 
 // TestIncludeLabelsFromBinop pins the surface of [includeLabelsFromBinop]:
@@ -79,5 +82,58 @@ func TestIncludeLabelsFromBinopNil(t *testing.T) {
 	}
 	if len(got) != 0 {
 		t.Fatalf("includeLabelsFromBinop(nil) = %v, want empty slice", got)
+	}
+}
+
+// TestLowerBinaryRejectsNilLeg pins the defensive guard at the top of
+// [lowerBinary]: when *either* the LHS (SampleExpr) or the RHS leg of a
+// BinOpExpr is nil — a shape the upstream parser shouldn't normally
+// hand us — the helper returns a clear error instead of dereferencing
+// the nil leg and panicking.
+//
+// The guard reads `if b.SampleExpr == nil || b.RHS == nil`; a single-leg
+// nil must trip it. Parse a real binop first so the rest of the struct
+// (Op, Opts) stays parser-valid, then drop one leg to nil and confirm
+// the helper rejects it.
+func TestLowerBinaryRejectsNilLeg(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		mut  func(*syntax.BinOpExpr)
+	}{
+		{
+			name: "nil RHS",
+			mut:  func(b *syntax.BinOpExpr) { b.RHS = nil },
+		},
+		{
+			name: "nil LHS (SampleExpr)",
+			mut:  func(b *syntax.BinOpExpr) { b.SampleExpr = nil },
+		},
+	}
+
+	s := schema.DefaultOTelLogs()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			expr, err := syntax.ParseExpr(`rate({app="api"}[1m]) + rate({app="db"}[1m])`)
+			if err != nil {
+				t.Fatalf("ParseExpr: %v", err)
+			}
+			binop, ok := expr.(*syntax.BinOpExpr)
+			if !ok {
+				t.Fatalf("expected *syntax.BinOpExpr, got %T", expr)
+			}
+			tc.mut(binop)
+
+			_, err = lowerBinary(binop, s, lowerCtx{})
+			if err == nil {
+				t.Fatalf("lowerBinary with %s: want error, got nil", tc.name)
+			}
+			if !strings.Contains(err.Error(), "nil leg") {
+				t.Fatalf("lowerBinary with %s: error %q does not mention 'nil leg'", tc.name, err.Error())
+			}
+		})
 	}
 }

--- a/internal/logql/lower_internal_test.go
+++ b/internal/logql/lower_internal_test.go
@@ -1,0 +1,117 @@
+package logql
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestHasTimeWindowAsymmetric pins the asymmetric guards in
+// [lowerCtx.hasTimeWindow]: a non-degenerate window requires BOTH bounds
+// to be non-zero. The helper reads `!Start.IsZero() && !End.IsZero()`;
+// flipping the connective to `||` would treat a half-zero pair as a
+// valid window and emit a spurious BETWEEN predicate. Test each of the
+// four corners explicitly.
+func TestHasTimeWindowAsymmetric(t *testing.T) {
+	t.Parallel()
+
+	someTS := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name  string
+		start time.Time
+		end   time.Time
+		want  bool
+	}{
+		{name: "both zero -> no window", start: time.Time{}, end: time.Time{}, want: false},
+		{name: "only start set -> no window", start: someTS, end: time.Time{}, want: false},
+		{name: "only end set -> no window", start: time.Time{}, end: someTS, want: false},
+		{name: "both set -> window", start: someTS, end: someTS.Add(time.Hour), want: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			lc := lowerCtx{Start: tc.start, End: tc.end}
+			if got := lc.hasTimeWindow(); got != tc.want {
+				t.Fatalf("hasTimeWindow() = %v, want %v (start=%v end=%v)", got, tc.want, tc.start, tc.end)
+			}
+		})
+	}
+}
+
+// TestRegexpMergeLabelsSkipsUnnamedSubexps pins the
+// `i == 0 || n == ""` skip in [regexpMergeLabels]: index 0 is the
+// whole-match group and any positional (unnamed) subexp at i > 0 has no
+// name in `re.SubexpNames()`. Both shapes must be dropped before the
+// duplicate-detection map (`seen`) ingests them — otherwise multiple
+// unnamed subexps in the same pattern would all hash under the same
+// empty-string key, tripping the duplicate-capture guard and erroring
+// out on patterns LogQL accepts. Flipping the connective to `&&` keeps
+// the i==0 skip but lets every positional subexp leak through.
+//
+// The returned expression is a `mapConcat(prev, map(<key>, <val>, ...))`
+// FuncCall — the inner `map(...)` must carry exactly `2*len(named)` args.
+// We pin both directions: (a) the inner map has 2 args (one named
+// capture, key+value), (b) every other arg of that map is a non-empty
+// string literal (so unnamed subexps with `n == ""` did not leak in
+// as keys).
+func TestRegexpMergeLabelsSkipsUnnamedSubexps(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelLogs()
+
+	// Pattern with two unnamed positional groups plus one named group.
+	// SubexpNames() returns ["", "", "", "name"]. The original guard
+	// processes only index 3; the mutant `&&` form would walk all four,
+	// build three namedGroup entries (two with empty names), and trip
+	// the "duplicate named capture" error on the second empty name.
+	pattern := `(\d+)-(\d+) (?P<name>\w+)`
+
+	expr, err := regexpMergeLabels(nil, s, pattern)
+	if err != nil {
+		t.Fatalf("regexpMergeLabels(%q) returned error: %v — unnamed subexps leaked into the duplicate-check map", pattern, err)
+	}
+	if expr == nil {
+		t.Fatalf("regexpMergeLabels(%q) returned nil expression", pattern)
+	}
+
+	outer, ok := expr.(*chplan.FuncCall)
+	if !ok {
+		t.Fatalf("regexpMergeLabels(%q) returned %T, want *chplan.FuncCall (mapConcat)", pattern, expr)
+	}
+	if outer.Name != "mapConcat" {
+		t.Fatalf("regexpMergeLabels(%q) outer FuncCall.Name = %q, want %q", pattern, outer.Name, "mapConcat")
+	}
+	if len(outer.Args) != 2 {
+		t.Fatalf("regexpMergeLabels(%q) mapConcat has %d args, want 2", pattern, len(outer.Args))
+	}
+
+	inner, ok := outer.Args[1].(*chplan.FuncCall)
+	if !ok {
+		t.Fatalf("regexpMergeLabels(%q) inner Args[1] is %T, want *chplan.FuncCall (map)", pattern, outer.Args[1])
+	}
+	if inner.Name != "map" {
+		t.Fatalf("regexpMergeLabels(%q) inner FuncCall.Name = %q, want %q", pattern, inner.Name, "map")
+	}
+
+	// One named capture -> exactly 2 (key, value) args. With the `&&`
+	// mutant, this would be 6 (three captures: two unnamed + the named
+	// "name") — assuming the duplicate-check didn't error first.
+	if len(inner.Args) != 2 {
+		t.Fatalf("regexpMergeLabels(%q) inner map has %d args, want 2 — unnamed subexps leaked through the skip", pattern, len(inner.Args))
+	}
+
+	// First arg is the key literal. Confirm it's the named capture and
+	// not the empty positional-subexp name.
+	key, ok := inner.Args[0].(*chplan.LitString)
+	if !ok {
+		t.Fatalf("regexpMergeLabels(%q) inner map key is %T, want *chplan.LitString", pattern, inner.Args[0])
+	}
+	if key.V != "name" {
+		t.Fatalf("regexpMergeLabels(%q) inner map key = %q, want %q", pattern, key.V, "name")
+	}
+}


### PR DESCRIPTION
## Summary

Adds three targeted unit tests in `internal/logql/` that pin behaviour the phase4-logql mutation job had marked LIVED. Drops LIVED mutants from 15 to 12, lifting `test_efficacy` from 94.49% to ≥95.18%.

Math: `efficacy = killed / (killed + lived)`. Pre-PR: `257 / (257 + 15) = 94.49%`. With 3 kills: `260 / (260 + 12) = 95.59%`. The 95% gate now passes; the remaining 12 stay for follow-ups.

## Mutants killed

- **`binary.go:42:25 INVERT_LOGICAL`** (`||` → `&&`) — `TestLowerBinaryRejectsNilLeg` mutates a parser-produced `*syntax.BinOpExpr` so exactly one leg is nil and asserts `lowerBinary` returns the "nil leg" error. The `&&` mutant would skip the guard and dereference the nil leg.
- **`lower.go:46:27 INVERT_LOGICAL`** (`&&` → `||`) — `TestHasTimeWindowAsymmetric` enumerates the four zero/non-zero corners of `(Start, End)`. Flipping the connective to `||` would treat a half-zero pair as a valid window and emit a spurious `BETWEEN` predicate.
- **`lower.go:609:13 INVERT_LOGICAL`** (`||` → `&&`) — `TestRegexpMergeLabelsSkipsUnnamedSubexps` lowers a pattern with two unnamed positional subexps plus one named capture. The `&&` mutant would walk the unnamed subexps into the duplicate-detection map and trip the "duplicate named capture" error on the second empty-name hit.

No production-code changes; tests-only.

## Mutants NOT killed (deferred)

The remaining 12 LIVED mutants are either:
- `ARITHMETIC_BASE` on `make([]T, 0, N*2)` / `N*2+1` slice-capacity hints — output is identical regardless of mutation (equivalent mutants).
- `CONDITIONALS_BOUNDARY` on `len(slice) > 0` guards where the inner branch (`append([]T(nil), slice...)`) yields the same nil slice on len=0 as the skip path.
- One `INVERT_LOGICAL` at `binary.go:115:22` where the mutated newValue is discarded by an unmutated early-return Filter at line 121 — observable output unchanged.

These need either a structural rewrite or different mutant operators; out of scope for the 95% threshold.

## Test plan

- [x] `go test ./internal/logql/... -count=1` — 258 tests pass.
- [x] `go build ./...` — clean.
- [ ] phase4-logql mutation job confirms LIVED ≤ 13 (validated post-merge via the nightly mutation workflow).