### PR TITLE
test(qlcommon): kill 16 gremlins mutants in label_replace via boundary cases

### DIFF
--- a/internal/qlcommon/label_replace_test.go
+++ b/internal/qlcommon/label_replace_test.go
@@ -59,6 +59,54 @@ func TestReplacementToCH(t *testing.T) {
 		// will surface the regex error to the client). The replacement
 		// translation is unchanged from the always-allowed shape.
 		{"invalid_regex_passthrough", "$1", "(.*", `\1`},
+		// Targeted mutation-kill cases pinning the gremlins CONDITIONALS_
+		// BOUNDARY / INVERT_LOGICAL / ARITHMETIC_BASE / REMOVE_SELF_
+		// ASSIGNMENTS mutants on the multi-digit-preserve and `${N}`
+		// branches at lines 105 / 122 / 124 in `label_replace.go`. Each
+		// row below is calibrated so the original implementation
+		// produces the listed `want`, and at least one boundary-mutated
+		// variant produces an observably different string (or panics).
+		// Treat these as low-level guards — the user-facing semantics
+		// are already covered above; these only widen the discriminator
+		// set the mutation tool can use to prove the boundaries are
+		// load-bearing.
+		//
+		//  * `multi_digit_unbraced_nine` pins the `<= '9'` upper bound
+		//    of the inner multi-digit lookahead at line 105:65. Char
+		//    at i+2 is exactly '9', so the boundary mutant `< '9'`
+		//    misses the branch and emits the single-digit form `\19`
+		//    instead of the verbatim `$19`.
+		{"multi_digit_unbraced_nine", "$19", nineCaptureRegex, "$19"},
+		//  * `braced_zero_with_caps` pins the `>= '0'` lower bound of
+		//    the braced digit check at line 122:42. Char at i+2 is
+		//    exactly '0', so the boundary mutant `> '0'` skips the
+		//    branch and falls through to write the literal `${0}`
+		//    instead of the canonical `\0`.
+		{"braced_zero_with_caps", "${0}", nineCaptureRegex, `\0`},
+		//  * `braced_nine_with_caps` pins both the `<= '9'` upper
+		//    bound of the braced digit check at line 122:65 AND the
+		//    `n <= allowed` capture-count gate at line 124:20. Char at
+		//    i+2 is exactly '9' and the regex has exactly 9 capture
+		//    groups, so both boundary mutants (`< '9'` and `< allowed`)
+		//    diverge from the canonical `\9`.
+		{"braced_nine_with_caps", "${9}", nineCaptureRegex, `\9`},
+		//  * `braced_non_digit_inner` pins both INVERT_LOGICAL mutants
+		//    on the chained `&&` at line 122:26 / 122:49. The char at
+		//    i+2 is a non-digit (`x`), so the original short-circuits
+		//    on `'x' <= '9'` and falls through to the literal-write
+		//    path. Either `&&` → `||` mutation upgrades the partial
+		//    truth into a full match, enters the consuming branch and
+		//    drops the entire `${x}` from the output.
+		{"braced_non_digit_inner", "${x}", nineCaptureRegex, "${x}"},
+		//  * `braced_truncated_digit` pins the ARITHMETIC_BASE mutant
+		//    on `i+3` at line 122:8 AND the CONDITIONALS_BOUNDARY
+		//    mutant on `<` at line 122:11. The input is one byte short
+		//    of a closing `}`, so the original short-circuits on
+		//    `i+3 < len` (3 < 3 == false). The `i-3` mutant evaluates
+		//    `-3 < 3` as true and continues into the OOB `escaped[i+3]`
+		//    read; the `<=` mutant evaluates `3 <= 3` as true and does
+		//    the same. Both surface as test-failing panics.
+		{"braced_truncated_digit", "${1", nineCaptureRegex, "${1"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -116,6 +164,49 @@ func TestEmptyCapturesReplacement(t *testing.T) {
 		// metacharacters are interpreted in the Go regex replacement
 		// template the QLs feed us.
 		{"existing_backslash_preserved", `\1`, `\1`},
+		// Targeted mutation-kill cases pinning the gremlins CONDITIONALS_
+		// BOUNDARY / INVERT_LOGICAL / ARITHMETIC_BASE / REMOVE_SELF_
+		// ASSIGNMENTS mutants on the multi-digit-preserve and `${N}`
+		// branches at lines 195 / 205 / 206 in `label_replace.go`. The
+		// mirror of the ReplacementToCH cases above, recalibrated for
+		// the empty-captures resolver (numbered captures collapse to
+		// "" instead of `\N`, so the original on the consuming branch
+		// returns the empty string).
+		//
+		//  * `multi_digit_unbraced_nine` pins the `<= '9'` upper bound
+		//    at line 195:56. Char at i+2 is '9'; the boundary mutant
+		//    `< '9'` falls into the single-digit-collapse branch and
+		//    emits the trailing `9` alone instead of the verbatim
+		//    `$19`.
+		{"multi_digit_unbraced_nine", "$19", "$19"},
+		//  * `braced_zero` pins the `>= '0'` lower bound at line 205:36.
+		//    Char at i+2 is '0'; the boundary mutant `> '0'` skips the
+		//    consuming branch and writes the literal `${0}` instead of
+		//    the empty result the original produces.
+		{"braced_zero", "${0}", ""},
+		//  * `braced_nine` pins the `<= '9'` upper bound at line 205:56.
+		//    Char at i+2 is '9'; the boundary mutant `< '9'` skips the
+		//    consuming branch and writes the literal `${9}` instead of
+		//    the empty result.
+		{"braced_nine", "${9}", ""},
+		//  * `braced_non_digit_inner` pins both INVERT_LOGICAL mutants
+		//    on the chained `&&` at line 205:23 / 205:43. Char at i+2
+		//    is non-digit; either `&&` → `||` swap upgrades the partial
+		//    truth into a full match and erases the brace block.
+		{"braced_non_digit_inner", "${x}", "${x}"},
+		//  * `braced_truncated_digit` pins ARITHMETIC_BASE on `i+3` at
+		//    line 205:8 AND CONDITIONALS_BOUNDARY on `<` at line 205:11.
+		//    Same mechanism as the ReplacementToCH twin: the OOB
+		//    `repl[i+3]` read panics under either mutant.
+		{"braced_truncated_digit", "${1", "${1"},
+		//  * `braced_with_trailing_text` pins the REMOVE_SELF_ASSIGNMENTS
+		//    mutant at line 206:7 (`i += 3` → `i = 3`). The literal
+		//    prefix `xy` shifts the `${1}` to offset 2, so the original
+		//    advances `i` to 5 (consuming the brace block) and lands
+		//    on `z`; the mutant resets `i` to 3, which lands on the
+		//    digit `1` inside the brace block, replays the suffix as
+		//    plain text and emits `xy1}z` instead of `xyz`.
+		{"braced_with_trailing_text", "xy${1}z", "xyz"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds 11 targeted unit-test rows across `TestReplacementToCH` +
`TestEmptyCapturesReplacement` that pin behaviour the
`phase5-qlcommon` mutation job had marked LIVED. Drops LIVED mutants
from **22 to 6** in `internal/qlcommon/label_replace.go`, lifting
`test_efficacy` from **76.60%** toward the **95%** gate.

Math: `efficacy = killed / (killed + lived)`. Pre-PR:
`72 / (72 + 22) = 76.60%`. With 16 kills:
`88 / (88 + 6) = 93.62%`. The gate is informational at 93.62% (below
95%); the remaining 6 are equivalent INVERT_LOOPCTRL mutants that
cannot be killed by tests alone — see "Mutants NOT killed (equivalent)"
below.

No production-code changes; tests-only.

## Mutants killed (16 / 22)

`ReplacementToCH` (lines 64-138):

| Mutant | Operator swap | Killing test row |
|---|---|---|
| `label_replace.go:105:65` CONDITIONALS_BOUNDARY | `<= '9'` → `< '9'` | `multi_digit_unbraced_nine` (`$19`) |
| `label_replace.go:122:8` ARITHMETIC_BASE | `i+3` → `i-3` | `braced_truncated_digit` (`${1`) |
| `label_replace.go:122:11` CONDITIONALS_BOUNDARY | `<` → `<=` | `braced_truncated_digit` |
| `label_replace.go:122:26` INVERT_LOGICAL | first `&&` → `\|\|` | `braced_truncated_digit` |
| `label_replace.go:122:42` CONDITIONALS_BOUNDARY | `>= '0'` → `> '0'` | `braced_zero_with_caps` (`${0}`) |
| `label_replace.go:122:49` INVERT_LOGICAL | second `&&` → `\|\|` | `braced_truncated_digit` |
| `label_replace.go:122:65` CONDITIONALS_BOUNDARY | `<= '9'` → `< '9'` | `braced_nine_with_caps` (`${9}`) |
| `label_replace.go:124:20` CONDITIONALS_BOUNDARY | `<= allowed` → `< allowed` | `braced_nine_with_caps` |

`EmptyCapturesReplacement` (lines 170-216):

| Mutant | Operator swap | Killing test row |
|---|---|---|
| `label_replace.go:195:56` CONDITIONALS_BOUNDARY | `<= '9'` → `< '9'` | `multi_digit_unbraced_nine` |
| `label_replace.go:205:8` ARITHMETIC_BASE | `i+3` → `i-3` | `braced_truncated_digit` (`${1`) |
| `label_replace.go:205:11` CONDITIONALS_BOUNDARY | `<` → `<=` | `braced_truncated_digit` |
| `label_replace.go:205:23` INVERT_LOGICAL | first `&&` → `\|\|` | `braced_truncated_digit` |
| `label_replace.go:205:36` CONDITIONALS_BOUNDARY | `>= '0'` → `> '0'` | `braced_zero` (`${0}`) |
| `label_replace.go:205:43` INVERT_LOGICAL | second `&&` → `\|\|` | `braced_truncated_digit` |
| `label_replace.go:205:56` CONDITIONALS_BOUNDARY | `<= '9'` → `< '9'` | `braced_nine` (`${9}`) |
| `label_replace.go:206:7` REMOVE_SELF_ASSIGNMENTS | `i += 3` → `i = 3` | `braced_with_trailing_text` (`xy${1}z`) |

Each kill was verified locally by hand-mutating `label_replace.go`,
re-running `go test ./internal/qlcommon/... -count=1`, and confirming
the specific subtest failed. The mutation was then reverted before
the next one.

## Mutants NOT killed (6 equivalent)

The remaining 6 LIVED mutants are all `INVERT_LOOPCTRL` swaps
(`continue` ↔ `break`) and are **observationally equivalent** to the
original — no test can distinguish them:

| Mutant | Location | Why equivalent |
|---|---|---|
| `label_replace.go:92:4` | `ReplacementToCH`, inside `if i+1 >= len(escaped)` | The branch only fires when `i == len-1`, so the next for-iterator step would exit the loop anyway. `continue` and `break` both terminate the loop. |
| `label_replace.go:107:5` | `ReplacementToCH`, inside `case next >= '0' && next <= '9'` | `continue` is inside a `switch` case; the innermost breakable container for `break` is the `switch`, so the mutation exits the switch instead of the for. Since the for body IS the switch (no statements after), both swap to the same `i++` next-iter step. |
| `label_replace.go:129:5` | `ReplacementToCH`, inside `case next == '{'` | Same shape as L107:5 — the `b.WriteByte('$')` fallback at the end of the case is dead code on the `continue`/`break` branch in both variants. |
| `label_replace.go:182:4` | `EmptyCapturesReplacement`, mirror of L92 | Same reasoning as L92:4. |
| `label_replace.go:197:5` | `EmptyCapturesReplacement`, mirror of L107 | Same reasoning as L107:5. |
| `label_replace.go:207:5` | `EmptyCapturesReplacement`, mirror of L129 | Same reasoning as L129:5. |

Killing these would require restructuring the for-body to put code
between the switch and the for-iterator step (so `break` and
`continue` diverge), which is a production-code change rejected here
to keep the diff tests-only — same pattern as PRs #494 / #495 / #496.

## Math

- Pre-PR: 72 killed / 22 lived / 94 total → **76.60%** efficacy.
- This PR: +16 kills, -16 lived → 88 killed / 6 lived / 94 total →
  **93.62%** efficacy.
- Gate at 95% remains breached by 1.38 pp; 6 equivalent mutants are
  the floor without a production-code restructure.

## Test plan

- [x] `go test ./internal/qlcommon/... -count=1` — 49 subtests pass
  (was 38, +11 new rows).
- [x] `go build ./...` — clean.
- [x] Each new test row hand-verified to kill the targeted mutant
  by transiently mutating `label_replace.go` (then reverting).
- [ ] CI `check` + `lint` + `forbid-skip` green.
- [ ] `phase5-qlcommon` mutation job (push-to-main) reports
  `>= 93.5%` efficacy (informational) with `lived == 6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)