### PR TITLE
refactor(chsql/test): use strconv.FormatInt instead of hand-rolled int→string

### DIFF
--- a/internal/chsql/gremlins_kill_test.go
+++ b/internal/chsql/gremlins_kill_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -417,7 +418,7 @@ func TestEmitMetricsExemplars_RangeDurationFallback(t *testing.T) {
 			}
 			// The rangeNS literal appears as the toIntervalNanosecond
 			// argument inside the windowTsLowerBound predicate.
-			wantSub := "toIntervalNanosecond(" + intToString(c.wantRangeNS) + ")"
+			wantSub := "toIntervalNanosecond(" + strconv.FormatInt(c.wantRangeNS, 10) + ")"
 			if !strings.Contains(sql, wantSub) {
 				t.Errorf("SQL missing %q.\nSQL: %s", wantSub, sql)
 			}
@@ -1933,28 +1934,4 @@ func TestEmitMetricsExemplars_AttributesMapCapacity185(t *testing.T) {
 	if !strings.Contains(sql, "toString(`span`)") {
 		t.Errorf("expected toString(span), SQL=%s", sql)
 	}
-}
-
-// intToString avoids importing strconv just for this conversion in a
-// single test site.
-func intToString(n int64) string {
-	if n == 0 {
-		return "0"
-	}
-	neg := n < 0
-	if neg {
-		n = -n
-	}
-	var buf [20]byte
-	i := len(buf)
-	for n > 0 {
-		i--
-		buf[i] = byte('0' + n%10)
-		n /= 10
-	}
-	if neg {
-		i--
-		buf[i] = '-'
-	}
-	return string(buf[i:])
 }


### PR DESCRIPTION
## Summary

PR #498 introduced a 24-line `intToString(int64) string` helper "to avoid importing strconv just for this conversion". That inverts the right tradeoff — importing the stdlib is always preferable to reinventing it. Drop the helper, import strconv, use \`strconv.FormatInt(n, 10)\` at the one call site.

## Repo-wide audit

Scanned for the same anti-pattern (custom byte-buffer integer formatters, hand-rolled parsers, etc.). Only this one site matched. The other "hand-rolled" comments in the codebase refer to legitimately reinvented things (test fixtures, plan IR structs, parser recognizers in property tests) where no stdlib equivalent exists.

One related but distinct case worth noting (out of scope for this PR): \`compatibility/prometheus/shadow/cmd/shadow/main.go:283\` declares it "avoids importing prometheus/common/model" and inlines anonymous structs for the Prom \`/api/v1/query\` JSON shape. Since cerberus already depends on prometheus/prometheus (and \`common/model\` is therefore in go.sum already), that comment's premise is weak — a follow-up could refactor to use \`model.Vector\` types. Not addressed here.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./internal/chsql/... -count=1\` passes