### PR TITLE
fix(harness/tempo-compat): widen WAL ingestion slack so old-anchor spans aren't clamped

### DIFF
--- a/compatibility/tempo/driver/diff.go
+++ b/compatibility/tempo/driver/diff.go
@@ -186,8 +186,8 @@ func diffCase(ctx context.Context, client *http.Client, tc CorpusCase, opts case
 		return res
 	}
 
-	tempoBody, tempoStatus, terr := fetchJSON(ctx, client, tempoURL, "tempo")
-	cerbBody, cerbStatus, cerr := fetchJSON(ctx, client, cerbURL, "cerberus")
+	tempoBody, tempoStatus, terr := fetchJSON(ctx, client, tempoURL)
+	cerbBody, cerbStatus, cerr := fetchJSON(ctx, client, cerbURL)
 	res.TempoStatus = tempoStatus
 	res.CerberusStatus = cerbStatus
 	if terr != nil {
@@ -400,19 +400,22 @@ func deriveTraceIDFromTemplate(tmpl string) (string, error) {
 
 // fetchJSON GETs a URL with the Accept: application/json header and
 // returns the body + status. Errors include the response body (up to
-// 2KB) so a CH error message lands in the report. When backend is
-// "tempo", the Recent-Data-Target: live-store header is set so Tempo
-// searches the live store (recently-ingested traces) in addition to
-// completed blocks.
-func fetchJSON(ctx context.Context, client *http.Client, urlStr, backend string) ([]byte, int, error) {
+// 2KB) so a CH error message lands in the report.
+//
+// Earlier revisions also set Recent-Data-Target: live-store on tempo
+// requests, intending to expand the search domain to recently-ingested
+// traces still in the live store. That header is parsed by Tempo
+// (pkg/api/http.go::ParseRecentDataTargetHeader) but no module branches
+// on its value in the version this harness pins, so it was a no-op
+// either way. Dropped to avoid implying a behaviour we don't actually
+// get; the differ's start/end window is what makes backend block search
+// surface the seeded data.
+func fetchJSON(ctx context.Context, client *http.Client, urlStr string) ([]byte, int, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlStr, nil)
 	if err != nil {
 		return nil, 0, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if backend == "tempo" {
-		req.Header.Set("Recent-Data-Target", "live-store")
-	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, 0, err

--- a/compatibility/tempo/driver/seeder.go
+++ b/compatibility/tempo/driver/seeder.go
@@ -50,6 +50,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -218,8 +219,15 @@ func runSeed(args []string) error {
 		return fmt.Errorf("smoke: %w", err)
 	}
 
-	logger.Info("smoke /api/search?q={} on tempo (live-store)", "deadline", *searchWait)
-	if err := smokeSearchLiveStore(ctx, logger, *tempoHTTP, *searchWait); err != nil {
+	// Smoke search uses the same time window the differ later builds
+	// (anchor ± 1h, see compatibility/tempo/driver/diff.go::runDiff).
+	// Without start/end the request short-circuits inside Tempo's
+	// search_sharder.go to ingester-only, which is empty after the
+	// live-store has flushed traces to backend blocks.
+	searchStart := startAt.Add(-1 * time.Hour)
+	searchEnd := startAt.Add(1 * time.Hour)
+	logger.Info("smoke /api/search on tempo", "deadline", *searchWait, "start", searchStart, "end", searchEnd)
+	if err := smokeSearchLiveStore(ctx, logger, *tempoHTTP, searchStart, searchEnd, *searchWait); err != nil {
 		logger.Warn("smoke search failed (non-fatal; differ will retry)", "err", err)
 	}
 
@@ -733,18 +741,32 @@ func decodeCerberusSpanCount(r io.Reader) (int, error) {
 	return total, nil
 }
 
-// smokeSearchLiveStore polls Tempo's /api/search?q={} with the
-// Recent-Data-Target: live-store header until the response contains at
-// least one trace. This catches the failure mode where Tempo's search
-// only scans completed blocks (which may not have been flushed yet) and
-// returns 0 results while cerberus returns many.
-func smokeSearchLiveStore(ctx context.Context, logger *slog.Logger, tempoHTTP string, deadline time.Duration) error {
+// smokeSearchLiveStore polls Tempo's /api/search until the response
+// contains at least one trace. This catches the failure mode where the
+// live-store hasn't flushed traces to backend blocks yet AND the
+// blocklist_poll hasn't picked up freshly-flushed blocks.
+//
+// The query passes start/end covering the fixture's span timestamps so
+// the backend block search path is exercised (modules/frontend/
+// search_sharder.go:140 short-circuits when start or end is unset and
+// queries the ingester only — useless on a flushed live-store).
+//
+// The Recent-Data-Target: live-store header is intentionally unset:
+// Tempo v3 parses it via pkg/api/http.go::ParseRecentDataTargetHeader
+// but no module in this build branches on the result, so it's a no-op
+// either way and setting it just propagated a misleading "live data
+// queried" promise to log readers.
+func smokeSearchLiveStore(ctx context.Context, logger *slog.Logger, tempoHTTP string, start, end time.Time, deadline time.Duration) error {
 	ctx, cancel := context.WithTimeout(ctx, deadline)
 	defer cancel()
 
-	url := strings.TrimRight(tempoHTTP, "/") + "/api/search?q=%7B%7D"
+	q := url.Values{}
+	q.Set("q", "{}")
+	q.Set("start", fmt.Sprintf("%d", start.Unix()))
+	q.Set("end", fmt.Sprintf("%d", end.Unix()))
+	target := strings.TrimRight(tempoHTTP, "/") + "/api/search?" + q.Encode()
 	for {
-		n, err := fetchSearchResultCount(ctx, url)
+		n, err := fetchSearchResultCount(ctx, target)
 		if err == nil && n > 0 {
 			logger.Info("tempo search returned traces", "count", n)
 			return nil
@@ -755,7 +777,7 @@ func smokeSearchLiveStore(ctx context.Context, logger *slog.Logger, tempoHTTP st
 			}
 			return fmt.Errorf("tempo search returned 0 traces after %s", deadline)
 		}
-		logger.Debug("retrying tempo search", "url", url, "err", err, "traces", n)
+		logger.Debug("retrying tempo search", "url", target, "err", err, "traces", n)
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -764,16 +786,14 @@ func smokeSearchLiveStore(ctx context.Context, logger *slog.Logger, tempoHTTP st
 	}
 }
 
-// fetchSearchResultCount issues one GET against /api/search with the
-// Recent-Data-Target: live-store header and returns the number of
-// traces in the response.
+// fetchSearchResultCount issues one GET against /api/search and returns
+// the number of traces in the response.
 func fetchSearchResultCount(ctx context.Context, url string) (int, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return 0, err
 	}
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Recent-Data-Target", "live-store")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return 0, err

--- a/compatibility/tempo/tempo-config.yaml
+++ b/compatibility/tempo/tempo-config.yaml
@@ -75,7 +75,27 @@ storage:
 #   1. live_store settings (below) cut and flush blocks aggressively
 #   2. blocklist_poll: 2s (above) ensures queriers discover flushed blocks
 #      quickly (default is 5m, which means 10m staleness window).
+#
+# wal.ingestion_time_range_slack widens the window Tempo accepts for span
+# timestamps relative to ingest wall-clock. Default is 2 minutes:
+# tempodb/wal/wal.go: c.IngestionSlack = 2 * time.Minute. When span
+# Start/End fall outside [now-slack, now+slack], modules/livestore/
+# instance.go:445-454 clamps the span's recorded start/end up to "now",
+# and the block's StartTime/EndTime BlockMeta uses the clamped values.
+# That clamping causes /api/search?start=<X>&end=<Y> to find zero blocks
+# whenever X/Y is more than 2 minutes outside the ingest wall-clock, even
+# though /api/traces/<id> still returns the trace (traceID lookup is not
+# time-range filtered). The differ uses anchor=2026-05-11T00:00:00Z (a
+# fixed point shared by prom/loki/tempo seeders for cross-harness
+# reproducibility) which drifts further from "now" each day. Picking
+# 8760h (= 1 year) gives the harness ~12 months of stable behavior
+# against the same anchor before requiring another bump — long enough
+# that the day-to-day clock drift doesn't surface as a TraceQL parity
+# regression, short enough that genuinely-stale fixtures still warn via
+# WarnOutsideIngestionSlack (tempodb/encoding/common/slackTimeRange.go).
 live_store:
+  wal:
+    ingestion_time_range_slack: 8760h
   max_trace_live: 2s
   max_trace_idle: 1s
   flush_check_period: 1s


### PR DESCRIPTION
## Summary

Closes the 27 DIFFs in `compatibility/tempo` (run 26089867828) where cerberus returned N traces but reference Tempo returned 0. The root cause was Tempo's WAL silently clamping span timestamps at ingest, not a TraceQL semantic gap.

## Root cause

Read the pinned tempo fork (`grafana/tempo:main-2f74ea8` ↔ `tsouza/tempo v0.0.2-cerberus-accessors`) to verify:

1. The seeder anchor is fixed at `2026-05-11T00:00:00Z`, shared with the prom/loki seeders for cross-harness reproducibility. Today (2026-05-19) it's 8 days in the past.
2. Tempo's WAL caps span Start/End to `[now-slack, now+slack]` where `slack = wal.ingestion_time_range_slack` (default 2 minutes — see `tempodb/wal/wal.go RegisterFlags` + `modules/livestore/instance.go` L445-454). 8-day-old spans get their Start clamped up to "now".
3. The block's `BlockMeta.StartTime/EndTime` reflects the clamped values. `/api/traces/<id>` still resolves (TraceID lookup is not time-range filtered) — that's why the seeder's smoke trace-by-ID worked while the smoke search returned 0.
4. The differ requests `/api/search?start=<anchor-1h>&end=<anchor+1h>` (8 days ago). `blockMetasForSearch` (`modules/frontend/frontend.go` L372) filters blocks by `block.StartTime <= searchEnd AND block.EndTime >= searchStart`. Blocks tagged "now" don't overlap "8 days ago" → 0 blocks → 0 traces. Cerberus reads ClickHouse directly with the real timestamps and returns the seeded data.

## Fix

- **`tempo-config.yaml`**: set `live_store.wal.ingestion_time_range_slack: 8760h` (1 year). Block metadata now reflects real span Start/End, so the differ's time-windowed search returns the seeded fixture. Inline comment documents the anchor-drift vs slack tradeoff.
- **`seeder.go::smokeSearchLiveStore`**: pass `start/end` derived from the same anchor the differ uses. Without start/end, Tempo's search sharder (`search_sharder.go` L141) short-circuits to ingester-only, which is empty after live-store flush (`max_block_duration: 2s`). The smoke was timing out at 90s on every CI run for this reason.
- **`diff.go::fetchJSON`**: drop the `Recent-Data-Target: live-store` header. The fork pins a Tempo version where `pkg/api/http.go::ParseRecentDataTargetHeader` exists but no module branches on its value, so setting it was a no-op that misled log readers.

## Clusters resolved

All 27 DIFF clusters in the run-26089867828 report close because Tempo's `/api/search` now returns the same fixture cerberus reads from CH:

- `direct_child_op_client_under_checkout` (15 missing_in_a)
- `direct_parent_op_checkout_to_child` (15 missing_in_a)
- `duration_gt_100ms` (100 missing_in_a)
- `duration_lt_300ms` (100 missing_in_a)
- `kind_eq_server`, `status_eq_error`, `resource_service_name_*`, `span_http_method_eq_get`, `set_or_*`, `tags_v*`, `tag_values_*`, `metrics_*`, `avg_duration_per_trace_status_ok`, `count_spans_per_trace`
- plus `descendant_op_payments_to_consumer` / `ancestor_op_consumer_under_payments` — their HARD ERROR was already fixed by #497; the tempo=0 cardinality side collapses once Tempo block search starts returning data.

## Test plan

- [x] `go build ./compatibility/tempo/driver/` clean
- [x] `go test ./compatibility/tempo/driver/ -count=1 -short` passes
- [ ] `compatibility/tempo` CI job (FAIL_ON_DIFF=1) returns rc=0 on this PR — confirms the harness flake closes and the 27 DIFFs go away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)