### PR TITLE
feat(compatibility): emit score JSON + downgrade per-case diffs from hard fail to report

### DIFF
--- a/compatibility/internal/score/score.go
+++ b/compatibility/internal/score/score.go
@@ -1,0 +1,172 @@
+// Package score builds the per-head compatibility "score JSON" that the
+// three compatibility harnesses (compatibility/{prometheus,loki,tempo})
+// emit alongside their human-readable reports.
+//
+// The score JSON is a shields.io endpoint-badge payload
+// (https://shields.io/badges/endpoint-badge): label / message / color
+// plus a few cerberus-specific bookkeeping fields the badge service
+// ignores but downstream tooling (dashboard, trend graphs) can consume.
+//
+// Centralising the shape + the color thresholds in one place keeps the
+// three drivers honest: a head can't accidentally drift the color cutoff
+// or rename a field and break the badge URL. Drivers call
+// score.Compute(passed, total) to derive the struct, then either
+// score.Write(path, s) for the convenience io path or marshal it
+// themselves if they already own an *os.File.
+//
+// Per task #68 (the broader "compat is informational" workstream): the
+// three drivers report-only — they accumulate per-case results, write
+// this score JSON, and exit 0 even when parity has drifted. Only HARD
+// errors (driver-wide panic, compile failure, harness can't reach the
+// upstream backend) escalate to a non-zero rc. The score percent gives
+// the at-a-glance signal that PR-level CI no longer provides.
+package score
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Score is the shields.io endpoint-badge envelope plus the cerberus
+// bookkeeping fields. The JSON tag set matches the shields contract
+// for the label/message/color fields; the extra fields are tolerated
+// by shields (it ignores unknown keys) and surface in downstream tools.
+type Score struct {
+	// SchemaVersion is the shields.io endpoint-badge schema version.
+	// Pinned at 1 — bump in lock-step with shields if/when they ship
+	// a v2 contract.
+	SchemaVersion int `json:"schemaVersion"`
+
+	// Label is the badge's left-hand text (e.g. "tempo compat").
+	Label string `json:"label"`
+
+	// Message is the badge's right-hand text — by convention the
+	// percent value with one decimal of precision and a "%" suffix.
+	Message string `json:"message"`
+
+	// Color is the shields.io badge color — one of brightgreen / green
+	// / yellowgreen / yellow / orange / red, chosen via threshold bands.
+	Color string `json:"color"`
+
+	// Passed counts cases that fully agreed with the reference backend.
+	Passed int `json:"passed"`
+
+	// Total counts cases attempted (passed + per-case parity failures).
+	// Driver-wide hard errors (panic, compose-up failure) are NOT here
+	// because the driver wouldn't have written the score JSON in that
+	// path; per-case failures (HTTP 5xx, value mismatch, schema diff,
+	// expected-failure marker) all contribute to total.
+	Total int `json:"total"`
+
+	// Percent is the passed/total ratio expressed as a percentage,
+	// rounded to two decimal places. Set to 0 when total == 0
+	// (defensive: an empty corpus would otherwise divide by zero, and
+	// "100% of nothing" is a misleading signal).
+	Percent float64 `json:"percent"`
+}
+
+// Compute derives a Score from the (passed, total) pair, picking the
+// color band per the project-wide thresholds. The thresholds match the
+// "shields.io traffic-light" convention plus an explicit 100% case
+// (brightgreen) so a fully-passing run is visually distinct from a "just
+// barely" pass.
+//
+//   - 100%        -> brightgreen  (deliberately separate from >=95;
+//     brightgreen reads as "perfect")
+//   - [95, 100)%  -> green        (operationally green; small known gaps)
+//   - [80, 95)%   -> yellowgreen  (mostly green; nontrivial gaps)
+//   - [60, 80)%   -> yellow       (mixed; substantial parity work)
+//   - [40, 60)%   -> orange       (early-mover signal)
+//   - [0, 40)%    -> red          (parity is essentially aspirational)
+//
+// The empty-corpus case (total == 0) defaults to red so an
+// accidentally-blank run reads as "do not ship" rather than "perfect".
+func Compute(label string, passed, total int) Score {
+	var pct float64
+	if total > 0 {
+		pct = float64(passed) / float64(total) * 100
+	}
+	pct = roundTwo(pct)
+
+	color := colorFor(pct, total)
+	return Score{
+		SchemaVersion: 1,
+		Label:         label,
+		Message:       formatMessage(pct),
+		Color:         color,
+		Passed:        passed,
+		Total:         total,
+		Percent:       pct,
+	}
+}
+
+// colorFor returns the shields color band for a percent value.
+// Threshold bands are inclusive on the lower edge and exclusive on the
+// upper edge except for the 100% case, which is exact-match for
+// brightgreen so a one-case drop reads as "green" rather than
+// "brightgreen". Empty corpora are forced to red.
+func colorFor(pct float64, total int) string {
+	if total == 0 {
+		return "red"
+	}
+	switch {
+	case pct >= 100:
+		return "brightgreen"
+	case pct >= 95:
+		return "green"
+	case pct >= 80:
+		return "yellowgreen"
+	case pct >= 60:
+		return "yellow"
+	case pct >= 40:
+		return "orange"
+	default:
+		return "red"
+	}
+}
+
+// formatMessage renders the percent value for the shields message slot.
+// Two decimal precision keeps the badge readable while still showing
+// movement when the corpus grows or shrinks by a single case.
+func formatMessage(pct float64) string {
+	// %g would drop trailing zeros (95.00 -> 95); we want a stable
+	// width so the badge SVG layout doesn't jiggle from run to run.
+	return fmt.Sprintf("%.2f%%", pct)
+}
+
+// roundTwo rounds a float to two decimal places. The percent field on
+// the JSON output is documented as "two decimals"; using a dedicated
+// helper means the message + the numeric fields agree on the rounding.
+func roundTwo(f float64) float64 {
+	// Multiply, round half-away-from-zero, divide. Avoids the
+	// math.Round / fmt printing drift that a naive %0.2f -> ParseFloat
+	// roundtrip can introduce on exact .005 boundaries.
+	if f >= 0 {
+		return float64(int64(f*100+0.5)) / 100
+	}
+	return float64(int64(f*100-0.5)) / 100
+}
+
+// Write marshals the Score to path as indented JSON, creating the
+// parent directory as needed. The two-space indent matches what the
+// tempo and loki JSON reports already emit, so a casual tail of the
+// reports/ directory stays visually consistent.
+func Write(path string, s Score) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return fmt.Errorf("mkdir score dir: %w", err)
+	}
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal score: %w", err)
+	}
+	// Append a trailing newline so the file is POSIX-text-clean
+	// (matters for `cat` / editor diffs / git's "no newline at end
+	// of file" warning).
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("write score: %w", err)
+	}
+	return nil
+}

--- a/compatibility/internal/score/score_test.go
+++ b/compatibility/internal/score/score_test.go
@@ -1,0 +1,175 @@
+package score
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCompute_FullyPassing(t *testing.T) {
+	t.Parallel()
+	s := Compute("tempo compat", 10, 10)
+	if s.Color != "brightgreen" {
+		t.Fatalf("100%% should be brightgreen, got %q", s.Color)
+	}
+	if s.Percent != 100.00 {
+		t.Fatalf("100%% should be 100.00, got %v", s.Percent)
+	}
+	if s.Message != "100.00%" {
+		t.Fatalf("message = %q, want %q", s.Message, "100.00%")
+	}
+	if s.SchemaVersion != 1 {
+		t.Fatalf("schemaVersion = %d, want 1", s.SchemaVersion)
+	}
+	if s.Label != "tempo compat" {
+		t.Fatalf("label = %q", s.Label)
+	}
+	if s.Passed != 10 || s.Total != 10 {
+		t.Fatalf("passed/total = %d/%d", s.Passed, s.Total)
+	}
+}
+
+func TestCompute_ColorBands(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name        string
+		passed, tot int
+		wantColor   string
+		wantPercent float64
+	}{
+		{"100%", 10, 10, "brightgreen", 100.00},
+		{"99%", 99, 100, "green", 99.00},
+		{"95%", 95, 100, "green", 95.00},
+		{"94.99%", 9499, 10000, "yellowgreen", 94.99},
+		{"80%", 80, 100, "yellowgreen", 80.00},
+		{"79.99%", 7999, 10000, "yellow", 79.99},
+		{"60%", 60, 100, "yellow", 60.00},
+		{"59.99%", 5999, 10000, "orange", 59.99},
+		{"40%", 40, 100, "orange", 40.00},
+		{"39.99%", 3999, 10000, "red", 39.99},
+		{"0%", 0, 10, "red", 0.00},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s := Compute("x", tc.passed, tc.tot)
+			if s.Color != tc.wantColor {
+				t.Fatalf("color = %q, want %q (passed=%d total=%d)", s.Color, tc.wantColor, tc.passed, tc.tot)
+			}
+			if s.Percent != tc.wantPercent {
+				t.Fatalf("percent = %v, want %v", s.Percent, tc.wantPercent)
+			}
+		})
+	}
+}
+
+func TestCompute_EmptyCorpusForcesRed(t *testing.T) {
+	t.Parallel()
+	// Total == 0 must not divide-by-zero AND must not flash brightgreen
+	// (which "100% of nothing" would compute to under naïve math).
+	s := Compute("x", 0, 0)
+	if s.Color != "red" {
+		t.Fatalf("empty corpus should be red, got %q", s.Color)
+	}
+	if s.Percent != 0 {
+		t.Fatalf("empty corpus percent should be 0, got %v", s.Percent)
+	}
+	if s.Total != 0 {
+		t.Fatalf("total = %d, want 0", s.Total)
+	}
+}
+
+func TestCompute_RoundsToTwoDecimals(t *testing.T) {
+	t.Parallel()
+	// 2/3 = 66.6666...; we want 66.67 (round half-up).
+	s := Compute("x", 2, 3)
+	if s.Percent != 66.67 {
+		t.Fatalf("percent = %v, want 66.67", s.Percent)
+	}
+	if s.Message != "66.67%" {
+		t.Fatalf("message = %q, want 66.67%%", s.Message)
+	}
+}
+
+func TestWrite_RoundTripsThroughJSON(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "compat-score.json")
+
+	in := Compute("loki compat", 17, 20)
+	if err := Write(path, in); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+
+	// Trailing newline check — required for clean diffs.
+	if len(data) == 0 || data[len(data)-1] != '\n' {
+		t.Fatalf("score JSON should end with newline; got tail %q", string(data[max(0, len(data)-4):]))
+	}
+
+	var out Score
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out != in {
+		t.Fatalf("round trip mismatch:\n  in  = %+v\n  out = %+v", in, out)
+	}
+
+	// Verify the shields.io contract keys are present at the top level.
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("re-unmarshal: %v", err)
+	}
+	for _, k := range []string{"schemaVersion", "label", "message", "color"} {
+		if _, ok := raw[k]; !ok {
+			t.Fatalf("missing shields key %q in JSON output", k)
+		}
+	}
+}
+
+func TestWrite_OverwritesExisting(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "compat-score.json")
+
+	if err := Write(path, Compute("x", 1, 10)); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	if err := Write(path, Compute("x", 10, 10)); err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var out Score
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Passed != 10 || out.Total != 10 || out.Color != "brightgreen" {
+		t.Fatalf("second write didn't overwrite; got %+v", out)
+	}
+}
+
+func TestColorFor_BoundaryExactness(t *testing.T) {
+	t.Parallel()
+	// Exact threshold percents land on the lower-band side
+	// (inclusive lower, exclusive upper).
+	if got := colorFor(95.0, 100); got != "green" {
+		t.Fatalf("95.0 -> %q, want green", got)
+	}
+	if got := colorFor(94.999999, 100); got != "yellowgreen" {
+		// Strictly less than 95 by float; we accept that a "drift" near
+		// the band edge would round visually to 95 in the badge message
+		// but still classify yellowgreen on the underlying value.
+		t.Fatalf("94.999999 -> %q, want yellowgreen", got)
+	}
+	if got := colorFor(100.0, 100); got != "brightgreen" {
+		t.Fatalf("100.0 -> %q, want brightgreen", got)
+	}
+}

--- a/compatibility/loki/cmd/loki-compliance-tester/main.go
+++ b/compatibility/loki/cmd/loki-compliance-tester/main.go
@@ -3,7 +3,8 @@
 // HTTP endpoints, diffs the responses with float tolerance, and emits a
 // JSON report whose shape matches compatibility/prometheus's
 // promql-compliance-tester (i.e. the `prometheus/compliance` reference
-// driver).
+// driver). It also emits a shields.io endpoint-badge score JSON when
+// `-score` is set.
 //
 // This is PR 5 of docs/loki-compliance-plan.md — the cerberus-owned
 // replacement for the `go test -tags=remote_correctness -c` approach
@@ -11,6 +12,14 @@
 // into a `.json` file; downstream tooling (informational CI lane, future
 // expected-failures triage) needs the same structured report the Prom
 // harness ships so a single reconciliation script can consume both.
+//
+// Per task #68, the driver is report-only: it always exits 0 on the
+// parity-drift path. Diffs, unexpected failures, and unexpected
+// successes are recorded in the JSON report AND included in the
+// compat-score JSON's denominator, but they do not change the exit
+// code. Only driver-wide hard errors (corpus load, file write) escalate
+// to a non-zero rc. The pre-#68 `os.Exit(1)` on `pass != len(results)`
+// was deleted at the same time.
 //
 // Lifecycle:
 //
@@ -29,7 +38,8 @@
 //  4. Writes the report to `-report` (default: stdout) in the Prom-shape
 //     JSON envelope (`{totalResults, includePassing, results: [...]}`),
 //     with each result carrying `testCase`, `diff`, `unexpectedFailure`,
-//     `unexpectedSuccess`, `unsupported`.
+//     `unexpectedSuccess`, `unsupported`. When `-score` is set, also
+//     writes a shields.io endpoint-badge JSON to that path.
 //
 // The binary imports the vendored upstream/loki-bench/ package; the
 // root go.mod marks that path `ignore` so it's excluded from
@@ -56,11 +66,11 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/tsouza/cerberus/compatibility/internal/score"
 	bench "github.com/tsouza/cerberus/compatibility/loki/upstream/loki-bench"
 )
 
@@ -78,6 +88,7 @@ type flags struct {
 	metadataDir string
 	overlayPath string
 	reportPath  string
+	scorePath   string
 	tolerance   float64
 	rangeType   string
 	seed        int64
@@ -94,6 +105,7 @@ func parseFlags() flags {
 	flag.StringVar(&f.metadataDir, "metadata-dir", ".", "Directory containing dataset_metadata.json")
 	flag.StringVar(&f.overlayPath, "overlay", "", "Optional cerberus-test-queries.yml overlay (skip/fail per source key)")
 	flag.StringVar(&f.reportPath, "report", "", "Report output path; empty writes to stdout")
+	flag.StringVar(&f.scorePath, "score", "", "shields.io endpoint-badge score JSON output path; empty means do not write")
 	flag.Float64Var(&f.tolerance, "tolerance", 1e-5, "Float comparison tolerance (matches upstream remote_test.go default)")
 	flag.StringVar(&f.rangeType, "range-type", "range", "Query range type: 'range' or 'instant'")
 	flag.Int64Var(&f.seed, "seed", 42, "Random seed for query template resolution (matches upstream default)")
@@ -143,13 +155,49 @@ func run() error {
 	fmt.Fprintf(os.Stderr, "==> summary: total=%d passed=%d diffs=%d unexpected_failures=%d unsupported=%d\n",
 		len(results), pass, diffs, unfail, unsupp)
 
-	if pass != len(results) {
-		// Non-zero exit indicates "at least one diff or runtime failure",
-		// matching the Prom tester's semantics. The informational CI lane
-		// treats this as non-blocking until the corpus stabilises.
-		os.Exit(1)
+	// Per task #68, the driver is report-only: parity drift is captured
+	// in the JSON report + compat-score.json, but never in the exit
+	// code. Hard errors (corpus load failure, file write failure) still
+	// return a non-zero rc — those are infrastructure failures, not
+	// parity drift. A previous revision called os.Exit(1) when any case
+	// diff'd; that semantic moved out of the driver and is now derived
+	// from compat-score.json by downstream tooling.
+	if f.scorePath != "" {
+		// The score's denominator includes every case the driver
+		// attempted that wasn't an overlay-driven skip. Diffs,
+		// unexpected failures (including baseline failures + unsupported
+		// markers), and unexpected successes all contribute to total
+		// but not to passed. Overlay-skipped cases are excluded entirely:
+		// they're documented as out-of-scope rather than as parity
+		// gaps, so counting them would penalise the score for
+		// intentional exclusions.
+		passed, total := scoreCounts(results)
+		s := score.Compute("loki compat", passed, total)
+		if err := score.Write(f.scorePath, s); err != nil {
+			return fmt.Errorf("writing score: %w", err)
+		}
+		fmt.Fprintf(os.Stderr, "==> score: passed=%d total=%d percent=%.2f color=%s -> %s\n",
+			passed, total, s.Percent, s.Color, f.scorePath)
 	}
 	return nil
+}
+
+// scoreCounts derives (passed, total) for the compat-score JSON.
+// Overlay-driven skips (cases the cerberus-test-queries.yml flagged as
+// out-of-scope) are excluded from both counts so they don't penalise
+// the score; everything else (passes, diffs, unexpected failures /
+// successes) contributes to the denominator.
+func scoreCounts(results []Result) (passed, total int) {
+	for _, r := range results {
+		if r.SkipReason != "" {
+			continue
+		}
+		total++
+		if r.success() {
+			passed++
+		}
+	}
+	return passed, total
 }
 
 // Overlay mirrors the cerberus-test-queries.yml schema documented in
@@ -305,14 +353,19 @@ func writeReport(path string, payload []byte) error {
 // compareAll runs every test case in parallel and collects results.
 // Concurrency is capped at `parallelism` via a buffered work-token
 // channel — same shape as the Prom tester's main.go.
+//
+// Note: this used to maintain an `allSuccess` flag for the
+// "exit non-zero on any diff" semantic the driver shipped before task
+// #68. Under report-only, the driver always returns 0 from run() on
+// the parity-drift path; the score JSON + the per-result fields carry
+// the signal. The pre-#68 `allSuccess atomic.Bool` was removed at the
+// same time the exit-on-diff branch was deleted.
 func compareAll(cases []loadedCase, f flags, overlay *Overlay, isInstant bool) []Result {
 	httpClient := &http.Client{Timeout: f.timeout}
 	results := make([]Result, len(cases))
 
 	workCh := make(chan struct{}, max(1, f.parallelism))
 	var wg sync.WaitGroup
-	var allSuccess atomic.Bool
-	allSuccess.Store(true)
 
 	for i, lc := range cases {
 		i, lc := i, lc
@@ -342,7 +395,6 @@ func compareAll(cases []loadedCase, f flags, overlay *Overlay, isInstant bool) [
 				continue
 			}
 			results[i] = Result{TestCase: tc, UnexpectedFailure: "expansion: " + lc.expandErr.Error()}
-			allSuccess.Store(false)
 			continue
 		}
 
@@ -366,11 +418,7 @@ func compareAll(cases []loadedCase, f flags, overlay *Overlay, isInstant bool) [
 			defer wg.Done()
 			defer func() { <-workCh }()
 
-			res := compareOne(httpClient, f, lc.tc, suiteFile, isInstant)
-			results[i] = res
-			if !res.success() {
-				allSuccess.Store(false)
-			}
+			results[i] = compareOne(httpClient, f, lc.tc, suiteFile, isInstant)
 		}()
 	}
 

--- a/compatibility/loki/cmd/loki-compliance-tester/main_test.go
+++ b/compatibility/loki/cmd/loki-compliance-tester/main_test.go
@@ -1,0 +1,52 @@
+package main
+
+import "testing"
+
+func TestScoreCounts_ExcludesOverlaySkips(t *testing.T) {
+	t.Parallel()
+	results := []Result{
+		{},                                   // pass
+		{},                                   // pass
+		{Diff: "x"},                          // diff
+		{UnexpectedFailure: "y"},             // unexpected failure
+		{UnexpectedSuccess: true},            // unexpected success
+		{SkipReason: "documented exclusion"}, // excluded — outside total
+		{SkipReason: "harness limit"},        // excluded — outside total
+	}
+	passed, total := scoreCounts(results)
+	if total != 5 {
+		t.Fatalf("total = %d, want 5 (excluded cases not counted)", total)
+	}
+	if passed != 2 {
+		t.Fatalf("passed = %d, want 2", passed)
+	}
+}
+
+func TestScoreCounts_AllPassing(t *testing.T) {
+	t.Parallel()
+	results := []Result{{}, {}, {}}
+	passed, total := scoreCounts(results)
+	if passed != 3 || total != 3 {
+		t.Fatalf("(passed, total) = (%d, %d), want (3, 3)", passed, total)
+	}
+}
+
+func TestScoreCounts_AllSkipped(t *testing.T) {
+	t.Parallel()
+	results := []Result{
+		{SkipReason: "a"},
+		{SkipReason: "b"},
+	}
+	passed, total := scoreCounts(results)
+	if passed != 0 || total != 0 {
+		t.Fatalf("(passed, total) = (%d, %d), want (0, 0) when every case is excluded", passed, total)
+	}
+}
+
+func TestScoreCounts_Empty(t *testing.T) {
+	t.Parallel()
+	passed, total := scoreCounts(nil)
+	if passed != 0 || total != 0 {
+		t.Fatalf("(passed, total) = (%d, %d), want (0, 0)", passed, total)
+	}
+}

--- a/compatibility/loki/scripts/run-loki-compatibility.sh
+++ b/compatibility/loki/scripts/run-loki-compatibility.sh
@@ -21,15 +21,15 @@
 # report shape matches the Prom harness; the build / teardown lifecycle
 # is otherwise unchanged.
 #
-# Exit semantics:
+# Exit semantics (post task #68 / "compat is informational"):
 #
-#   - 0  → smoke + driver passed (no diffs reported on any query case).
-#   - 1  → driver reported at least one diff or run-time failure (the
-#          informational CI lane treats this as non-blocking; a
-#          required-check upgrade is planned per docs/loki-compliance-plan.md
-#          PR 6).
-#   - 2+ → harness itself failed (compose up, seed, build, docker missing,
-#          …). Inspect script output; the report file may be empty.
+#   - 0  → smoke + driver completed. Parity drift (diffs, unexpected
+#          failures) is captured in the JSON report + the shields.io
+#          endpoint-badge compat-score.json, NOT in the exit code.
+#   - 1+ → harness itself failed (compose up, seed, build, docker
+#          missing, file write, …) OR the driver hit a hard error
+#          before it could write the report. Inspect script output;
+#          the report file may be empty or partial.
 #
 # Usage:
 #   ./compatibility/loki/scripts/run-loki-compatibility.sh   full lifecycle
@@ -46,6 +46,9 @@
 #                       The driver emits a JSON envelope matching the
 #                       Prom harness's report shape; existing tooling
 #                       can consume both via the same schema.
+#   DRIVER_SCORE        compat-score.json file path (default:
+#                       reports/compat-score.json). shields.io endpoint-
+#                       badge contract; see compatibility/internal/score.
 #   DRIVER_TIMEOUT      Per-request HTTP timeout (default: 30s).
 #   DRIVER_TOLERANCE    -tolerance flag (default: 1e-5; matches upstream).
 #   DRIVER_RANGE_TYPE   -range-type flag (default: range; 'instant' also valid).
@@ -60,6 +63,7 @@ REPO_ROOT=$(cd "$ROOT_DIR/../.." && pwd)
 cd "$ROOT_DIR"
 
 REPORT=${DRIVER_REPORT:-"$ROOT_DIR/reports/diff.json"}
+SCORE=${DRIVER_SCORE:-"$ROOT_DIR/reports/compat-score.json"}
 TIMEOUT=${DRIVER_TIMEOUT:-30s}
 TOLERANCE=${DRIVER_TOLERANCE:-1e-5}
 RANGE_TYPE=${DRIVER_RANGE_TYPE:-range}
@@ -133,6 +137,7 @@ set +e
     -metadata-dir="$ROOT_DIR" \
     -overlay="$OVERLAY" \
     -report="$REPORT" \
+    -score="$SCORE" \
     -tolerance="$TOLERANCE" \
     -range-type="$RANGE_TYPE" \
     -parallelism="$PARALLELISM" \
@@ -141,6 +146,7 @@ DRIVER_RC=$?
 set -e
 
 echo "==> report written to $REPORT"
+echo "==> score written to $SCORE"
 echo "==> summary:"
 if command -v jq >/dev/null 2>&1; then
     jq '{total: .totalResults, passed: ([.results[]? | select((.unexpectedFailure // "") == "" and (.diff // "") == "" and (.unexpectedSuccess // false) == false)] | length), diffs: ([.results[]? | select((.diff // "") != "")] | length), unexpected_failures: ([.results[]? | select((.unexpectedFailure // "") != "")] | length), unsupported: ([.results[]? | select((.unsupported // false) == true)] | length), skipped: ([.results[]? | select((.skipReason // "") != "")] | length)}' "$REPORT" 2>/dev/null || echo "    (jq failed to parse $REPORT)"

--- a/compatibility/prometheus/cmd/scorer/main.go
+++ b/compatibility/prometheus/cmd/scorer/main.go
@@ -1,0 +1,142 @@
+// Command prometheus-compat-scorer reads a promql-compliance-tester
+// JSON report and emits a shields.io endpoint-badge "compat-score
+// JSON" alongside it.
+//
+// The upstream `promql-compliance-tester` (built from the vendored
+// `compatibility/prometheus/upstream` submodule of
+// prometheus/compliance) writes its own report JSON, but it does not
+// emit the shields.io endpoint-badge envelope cerberus's downstream
+// dashboard + badge need. Forking the upstream tester to add that
+// emit would mean carrying a patch on top of the submodule, which
+// the upstream-forks playbook tries to avoid for unpatched
+// dependencies. Instead, the shell harness invokes the upstream
+// tester to produce report.json AND this in-tree post-processor to
+// derive compat-score.json from it.
+//
+// Per task #68 ("compat is informational"), the wrapping shell
+// script swallows the tester's non-zero exit on parity diffs and
+// always exits 0 in the parity-drift path. Only hard infrastructure
+// failures (build failure, compose-up failure, scorer can't parse
+// report.json) escalate. This binary is one step in that pipeline:
+// it reads the tester's output and writes the shields envelope; the
+// shell script then ignores any per-case diff exit from the tester.
+//
+// Score semantics (mirrors compatibility/loki/cmd/loki-compliance-
+// tester's scoreCounts):
+//
+//   - total counts every result row in the report.
+//   - passed counts rows where both `diff` and `unexpectedFailure`
+//     are empty AND `unexpectedSuccess` is false. These are the
+//     "fully agreed with the reference" cases.
+//   - per-case diffs, unexpected failures (including unsupported
+//     queries), and unexpected successes contribute to total but
+//     not to passed.
+//   - the upstream tester does not surface "skipped" cases in
+//     report.json (skip entries are pre-filtered at config-load
+//     time), so there's no skip-exclusion branch like in the loki
+//     scorer.
+//
+// Exit codes:
+//
+//   - 0: report.json parsed and score JSON written.
+//   - 1: cannot read or parse report.json, or cannot write score JSON.
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/tsouza/cerberus/compatibility/internal/score"
+)
+
+// reportEnvelope is the subset of promql-compliance-tester's JSON
+// output we need. The upstream shape (see
+// `compatibility/prometheus/upstream/promql/output/json.go`) carries
+// more fields — `totalResults`, `includePassing`, optional query
+// tweaks — but our scoring only depends on the per-result flag
+// quartet. Decoding the minimal subset keeps this binary
+// independent of upstream schema additions.
+type reportEnvelope struct {
+	Results []reportResult `json:"results"`
+}
+
+// reportResult mirrors the four flag fields the upstream tester
+// emits per query. Empty strings + false booleans mean "passed";
+// any non-zero value means the case diverged.
+type reportResult struct {
+	// Diff is non-empty when the structural diff between the two
+	// backends reported a mismatch.
+	Diff string `json:"diff"`
+
+	// UnexpectedFailure is non-empty when the test backend returned
+	// an error that the suite did not expect.
+	UnexpectedFailure string `json:"unexpectedFailure"`
+
+	// UnexpectedSuccess is true when the case was tagged should_fail
+	// but actually succeeded.
+	UnexpectedSuccess bool `json:"unexpectedSuccess"`
+}
+
+// passed reports whether this case contributes to the "passed"
+// numerator. Mirrors loki's `Result.success()` and tempo's
+// "no HardError && Diff.Equal && no Assertions" predicate.
+func (r reportResult) passed() bool {
+	return r.Diff == "" && r.UnexpectedFailure == "" && !r.UnexpectedSuccess
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatalf("prometheus-compat-scorer: %v", err)
+	}
+}
+
+func run() error {
+	var (
+		reportPath = flag.String("report", "", "promql-compliance-tester report JSON (required)")
+		scorePath  = flag.String("score", "", "shields.io endpoint-badge score JSON output (required)")
+		label      = flag.String("label", "prometheus compat", "badge label text")
+	)
+	flag.Parse()
+
+	if *reportPath == "" || *scorePath == "" {
+		return errors.New("both -report and -score are required")
+	}
+
+	data, err := os.ReadFile(*reportPath) //nolint:gosec // CLI-supplied trusted path
+	if err != nil {
+		return fmt.Errorf("read report %s: %w", *reportPath, err)
+	}
+
+	var env reportEnvelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		return fmt.Errorf("parse report %s: %w", *reportPath, err)
+	}
+
+	passed, total := tally(env.Results)
+	s := score.Compute(*label, passed, total)
+	if err := score.Write(*scorePath, s); err != nil {
+		return fmt.Errorf("write score: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr,
+		"==> score: passed=%d total=%d percent=%.2f color=%s -> %s\n",
+		passed, total, s.Percent, s.Color, *scorePath)
+	return nil
+}
+
+// tally derives (passed, total) from the report's per-result rows.
+// Every row counts toward total; rows that pass on all four flag
+// dimensions contribute to passed.
+func tally(results []reportResult) (passed, total int) {
+	for _, r := range results {
+		total++
+		if r.passed() {
+			passed++
+		}
+	}
+	return passed, total
+}

--- a/compatibility/prometheus/cmd/scorer/main_test.go
+++ b/compatibility/prometheus/cmd/scorer/main_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestReportResult_Passed(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		r    reportResult
+		want bool
+	}{
+		{"all clean", reportResult{}, true},
+		{"diff non-empty", reportResult{Diff: "vector length differs"}, false},
+		{"unexpected failure", reportResult{UnexpectedFailure: "status=500"}, false},
+		{"unexpected success", reportResult{UnexpectedSuccess: true}, false},
+		{"diff + unexpected failure", reportResult{Diff: "x", UnexpectedFailure: "y"}, false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.r.passed(); got != tc.want {
+				t.Fatalf("passed() = %v, want %v (r=%+v)", got, tc.want, tc.r)
+			}
+		})
+	}
+}
+
+func TestTally(t *testing.T) {
+	t.Parallel()
+	results := []reportResult{
+		{},                                   // pass
+		{},                                   // pass
+		{Diff: "x"},                          // fail
+		{UnexpectedFailure: "y"},             // fail
+		{UnexpectedSuccess: true},            // fail
+		{Diff: "x", UnexpectedSuccess: true}, // fail (single fail counts once)
+	}
+	passed, total := tally(results)
+	if total != 6 {
+		t.Fatalf("total = %d, want 6", total)
+	}
+	if passed != 2 {
+		t.Fatalf("passed = %d, want 2", passed)
+	}
+}
+
+func TestTally_EmptyReport(t *testing.T) {
+	t.Parallel()
+	passed, total := tally(nil)
+	if passed != 0 || total != 0 {
+		t.Fatalf("expected (0, 0), got (%d, %d)", passed, total)
+	}
+}

--- a/compatibility/prometheus/scripts/run-compatibility.sh
+++ b/compatibility/prometheus/scripts/run-compatibility.sh
@@ -3,8 +3,17 @@
 #
 # Brings up the docker-compose stack (reference Prometheus + cerberus +
 # ClickHouse + seeder), builds the upstream promql-compliance-tester
-# binary, runs it pointed at the two endpoints, and writes the JSON
-# report to compatibility/prometheus/report.json.
+# binary, runs it pointed at the two endpoints, writes the JSON report
+# to compatibility/prometheus/report.json, and emits a shields.io
+# endpoint-badge compat-score JSON next to it.
+#
+# Per task #68 ("compat is informational" workstream), this harness is
+# report-only: per-case parity diffs no longer fail the run. The
+# upstream tester still exits non-zero when any case diff'd (it has
+# no "report-only" flag), but the wrapping script ignores that exit
+# as long as it can read + score the report. Only hard infrastructure
+# failures (compose-up, build, missing report.json, scorer failure)
+# escalate to a non-zero rc.
 #
 # Tests are RUN_ONCE here; reconciliation against expected-failures.json
 # is done by a follow-up Go script (lands in M1.x — for the seed we just
@@ -16,6 +25,10 @@
 #
 # Env:
 #   TESTER_OUTPUT     report file path (default: compatibility/prometheus/report.json)
+#   TESTER_SCORE      compat-score.json output path (default:
+#                     compatibility/prometheus/compat-score.json).
+#                     Shields.io endpoint-badge contract — see
+#                     compatibility/internal/score for the schema.
 #   TESTER_QUERIES    queries yaml (default: compatibility/prometheus/cerberus-test-queries.yml,
 #                     a curated copy of upstream/promql/promql-test-queries.yml
 #                     with corpus-incompatible should_fail entries removed —
@@ -41,6 +54,12 @@ ROOT_DIR=$(cd "$(dirname "$0")/.." && pwd)
 cd "$ROOT_DIR"
 
 OUTPUT=${TESTER_OUTPUT:-"$ROOT_DIR/report.json"}
+# Score JSON lives next to report.json so today's workflow (which
+# uploads the single report.json file as an artifact) can be widened
+# in task #69 to include the score with a single path-glob change.
+# A dedicated reports/ sub-dir (like compatibility/{loki,tempo}/
+# reports/) would have required the workflow change up-front.
+SCORE=${TESTER_SCORE:-"$ROOT_DIR/compat-score.json"}
 QUERIES=${TESTER_QUERIES:-"$ROOT_DIR/cerberus-test-queries.yml"}
 END_TIME=${TESTER_END_TIME:-"2026-05-11T01:00:00Z"}
 RANGE=${TESTER_RANGE:-3600}
@@ -63,16 +82,17 @@ TESTER_BIN="$ROOT_DIR/upstream/promql/cmd/promql-compliance-tester/promql-compli
 # overlay carries CI-volatile values (END_TIME / RANGE) which are
 # expected to differ per local invocation and per CI dispatch.
 OVERLAY=$(mktemp -t cerberus-compat-overlay.XXXXXX.yml)
+SCORER_BIN=$(mktemp -t cerberus-prom-scorer.XXXXXX)
 
-# Consolidated cleanup: remove the overlay AND tear down the compose
-# stack on every exit path (success, tester failure, set -e abort,
-# manual SIGINT). Without this, a non-zero tester exit propagated by
-# `set -e` would leak the stack across re-runs — local repros, in
-# particular, would inherit dirty CH state and confuse subsequent
-# debugging.
+# Consolidated cleanup: remove the overlay + scorer binary AND tear
+# down the compose stack on every exit path (success, tester failure,
+# set -e abort, manual SIGINT). Without this, a non-zero tester exit
+# propagated by `set -e` would leak the stack across re-runs — local
+# repros, in particular, would inherit dirty CH state and confuse
+# subsequent debugging.
 cleanup() {
     rc=$?
-    rm -f "$OVERLAY"
+    rm -f "$OVERLAY" "$SCORER_BIN"
     if [ -z "${COMPOSE_KEEP:-}" ]; then
         echo "==> tearing down (set COMPOSE_KEEP=1 to leave running)"
         docker compose down -v || true
@@ -88,15 +108,20 @@ query_time_parameters:
 EOF
 
 echo "==> running tester"
-# Note: NO `|| true` here. The tester's exit code is meaningful:
+# The upstream tester's exit code:
 #   - 0 → every test passed (no diffs, no unexpected failures)
 #   - 1 → at least one diff / unexpected failure (allSuccess=false in
 #         the tester's main.go), OR log.Fatalf on a corpus-vs-tester
 #         mismatch (e.g. should_fail entry that no longer fails)
 #   - 2 → flag parse / config load / build error
-# The `set +e` window is just wide enough to capture the exit code so
-# we can emit the report summary before propagating the failure. The
-# cleanup trap tears down the compose stack on every exit path.
+#
+# Per task #68, RC=1 (parity drift) is no longer a harness failure:
+# the report.json captures the drift and the scorer below renders it
+# into compat-score.json. RC=2 (config / flag / build error) is still
+# a hard failure because there's no usable report to score. We
+# distinguish the two by checking whether report.json was produced
+# AND parses as JSON with a non-null results array — if so, RC=1 is
+# parity drift; otherwise it's hard.
 set +e
 "$TESTER_BIN" \
     -config-file "$ROOT_DIR/test-cerberus.yml" \
@@ -110,4 +135,26 @@ echo "==> report written to $OUTPUT"
 echo "==> summary:"
 jq '{total: ([.results[]?] | length), passed: ([.results[]? | select((.unexpectedFailure // "") == "" and (.diff // "") == "")] | length), diffs: ([.results[]? | select((.diff // "") != "")] | length), unexpected_failures: ([.results[]? | select((.unexpectedFailure // "") != "")] | length)}' "$OUTPUT" 2>/dev/null || echo "(install jq for summary)"
 
-exit "$TESTER_RC"
+# Hard-error gate: if the tester didn't even produce a parseable JSON
+# report, the run is infrastructure-broken. Bail with the tester's
+# rc so the workflow turns red.
+if ! jq -e '.results | type == "array"' "$OUTPUT" >/dev/null 2>&1; then
+    echo "==> report not parseable as JSON with .results array; treating as hard failure"
+    exit "$TESTER_RC"
+fi
+
+# Build + run the in-tree scorer. The scorer reads report.json and
+# writes the shields.io endpoint-badge compat-score JSON to $SCORE.
+# Its own exit is propagated — a scorer failure means the harness
+# can't produce the downstream artefact, which IS a hard failure.
+echo "==> building prometheus-compat-scorer"
+(cd "$ROOT_DIR/../.." && go build -o "$SCORER_BIN" ./compatibility/prometheus/cmd/scorer)
+
+mkdir -p "$(dirname "$SCORE")"
+"$SCORER_BIN" -report "$OUTPUT" -score "$SCORE"
+
+echo "==> score written to $SCORE"
+if [ "$TESTER_RC" -ne 0 ]; then
+    echo "==> tester rc=$TESTER_RC was parity drift (report.json present); exiting 0"
+fi
+exit 0

--- a/compatibility/tempo/driver/Dockerfile
+++ b/compatibility/tempo/driver/Dockerfile
@@ -12,13 +12,15 @@
 #   docker compose build tempo-compat-driver
 # Run:
 #   docker compose run --rm tempo-compat-driver seed
-#   docker compose run --rm tempo-compat-driver diff [--fail-on-diff]
+#   docker compose run --rm tempo-compat-driver diff
 #
 # Subcommands (see driver/main.go):
 #   seed   PR 3 — push OTLP to Tempo + INSERT into ClickHouse +
 #                 smoke-poll /api/traces on both backends.
 #   diff   PR 4 — read TXTAR corpus, run TraceQL through both backends
-#                 via /api/search + /api/traces, write markdown report.
+#                 via /api/search + /api/traces, write markdown report
+#                 + shields.io endpoint-badge score JSON. Report-only;
+#                 parity drift does not change the exit code.
 
 FROM golang:1.26 AS build
 WORKDIR /src

--- a/compatibility/tempo/driver/diff.go
+++ b/compatibility/tempo/driver/diff.go
@@ -1,6 +1,6 @@
 // Diff subcommand: drives the TraceQL corpus through both backends,
 // applies per-case assertions, computes the structural diff, and
-// emits a markdown report.
+// emits a markdown report PLUS a shields.io endpoint-badge score JSON.
 //
 // PR 4 of docs/tempo-compliance-plan.md. Smoke is the only corpus
 // shipped today (~20 cases lifted from the in-tree shadow corpus);
@@ -9,6 +9,14 @@
 //
 // Flag surface mirrors the seeder so a script that scripts the seeder
 // can re-target the differ with the same env-or-flag triple.
+//
+// Per task #68, the driver is report-only. Per-case parity failures
+// (mismatches, assertion failures, per-case HTTP errors) are recorded
+// in the markdown report AND included in the compat-score JSON's
+// denominator, but they do not change the exit code. Only driver-wide
+// hard errors (corpus load failure, write failure) bubble up. The
+// score JSON drives the downstream badge; CI uses the artifact, not
+// the exit code, to track drift over time.
 
 package main
 
@@ -29,9 +37,21 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/tsouza/cerberus/compatibility/internal/score"
 )
 
 // runDiff is the subcommand entry point. Wired from main.go.
+//
+// Per task #68 ("compat is informational" workstream), the driver is
+// report-only: parity drift no longer fails the run. Only driver-wide
+// HARD errors (corpus load failure, report-write failure, anchor parse
+// error) bubble up to a non-zero exit. Per-case errors (HTTP 5xx from
+// either backend, value mismatch, schema diff, missing trace) are
+// recorded in the markdown report AND counted as diffs in the
+// compat-score JSON, but they do not change the exit code. The score
+// JSON is the downstream signal — the badge color drops, but CI stays
+// green.
 func runDiff(args []string) error {
 	fs := flag.NewFlagSet("diff", flag.ContinueOnError)
 	var (
@@ -39,12 +59,12 @@ func runDiff(args []string) error {
 		tempoHTTP   = fs.String("tempo-http", envOr("TEMPO_HTTP_URL", "http://localhost:23200"), "Tempo HTTP base URL")
 		cerberusURL = fs.String("cerberus", envOr("CERBERUS_URL", "http://localhost:29092"), "cerberus HTTP base URL")
 		reportPath  = fs.String("report", envOr("REPORT_PATH", "/reports/diff.md"), "markdown report output path")
+		scorePath   = fs.String("score", envOr("SCORE_PATH", "/reports/compat-score.json"), "shields.io endpoint-badge score JSON output path")
 		overall     = fs.Duration("timeout", 5*time.Minute, "overall driver timeout")
 		perReq      = fs.Duration("request-timeout", 30*time.Second, "per-HTTP-request timeout")
-		failOnDiff  = fs.Bool("fail-on-diff", false, "exit non-zero if any case reports a diff (otherwise just write report)")
 		searchLimit = fs.Int("search-limit", 200, "Tempo /api/search ?limit= value")
 		anchorIn    = fs.String("anchor", anchor, "fixture anchor RFC3339; used to compute search start/end window")
-		efPath      = fs.String("expected-failures", envOr("EXPECTED_FAILURES", ""), "path to expected-failures JSON; cases listed there are exempt from --fail-on-diff")
+		efPath      = fs.String("expected-failures", envOr("EXPECTED_FAILURES", ""), "path to expected-failures JSON; cases listed there are flagged in the markdown report but still count as parity diffs in the compat-score JSON")
 	)
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -110,25 +130,52 @@ func runDiff(args []string) error {
 	}
 	logger.Info("wrote markdown report", "path", *reportPath)
 
-	// Per the plan: PR 4 is informational only (continue-on-error at
-	// the workflow level). The differ still respects --fail-on-diff so
-	// a local repro can hard-fail on a regression.
-	if *failOnDiff {
-		var unexpected int
-		for _, r := range results {
-			if r.HardError != "" || !r.Diff.Equal || len(r.Assertions) > 0 {
-				if _, ok := efSet[r.Case.Name]; ok {
-					logger.Info("expected failure", "name", r.Case.Name)
-					continue
-				}
-				unexpected++
-			}
-		}
-		if unexpected > 0 {
-			return fmt.Errorf("%d unexpected diffs reported; see %s", unexpected, *reportPath)
+	// Compute the shields.io endpoint-badge score JSON. Per-case parity
+	// failures count toward total — including expected-failures, which
+	// are documented gaps but still real parity divergence. A passing
+	// case is one that matched the reference backend with no diff and
+	// no assertion failures. The expected-failures list is logged for
+	// visibility but no longer governs the exit code.
+	passed, total := computeScore(results)
+	for _, r := range results {
+		if _, ok := efSet[r.Case.Name]; ok {
+			logger.Info("expected failure (counted as diff in score)", "name", r.Case.Name)
 		}
 	}
+	s := score.Compute("tempo compat", passed, total)
+	if err := score.Write(*scorePath, s); err != nil {
+		return fmt.Errorf("write score: %w", err)
+	}
+	logger.Info(
+		"wrote compat score",
+		"path", *scorePath,
+		"passed", passed,
+		"total", total,
+		"percent", s.Percent,
+		"color", s.Color,
+	)
+
 	return nil
+}
+
+// computeScore tallies (passed, total) from the per-case results.
+//
+// Total includes every case the driver attempted — passes, structural
+// diffs, assertion failures, and per-case hard errors (HTTP 5xx, body
+// parse failures). A per-case hard error means cerberus couldn't even
+// produce a comparable response, which is itself a parity gap and
+// belongs in the denominator. The only failure mode that's NOT counted
+// here is driver-wide (corpus load, anchor parse, write failure) —
+// those return an error from runDiff before this is called, and no
+// score JSON is written.
+func computeScore(results []CaseResult) (passed, total int) {
+	for _, r := range results {
+		total++
+		if r.HardError == "" && r.Diff.Equal && len(r.Assertions) == 0 {
+			passed++
+		}
+	}
+	return passed, total
 }
 
 // CaseResult is one corpus case's outcome. Populated incrementally

--- a/compatibility/tempo/driver/diff_test.go
+++ b/compatibility/tempo/driver/diff_test.go
@@ -248,6 +248,35 @@ func TestBuildURL_MetricsRangeMissingStepFails(t *testing.T) {
 	}
 }
 
+func TestComputeScore_AllVariants(t *testing.T) {
+	t.Parallel()
+	// One pass (no HardError, Equal diff, no assertions), three
+	// failure modes — each must count toward total but NOT toward
+	// passed.
+	results := []CaseResult{
+		{Diff: Diff{Equal: true}},                                                           // pass
+		{Diff: Diff{Equal: true}},                                                           // pass
+		{HardError: "tempo fetch: dial tcp: refused", Diff: Diff{}},                         // per-case hard error
+		{Diff: Diff{Equal: false, Reasons: []DiffReason{{Kind: "cardinality"}}}},            // diff
+		{Diff: Diff{Equal: true}, Assertions: []DiffReason{{Kind: "samples_non_negative"}}}, // assertion fail
+	}
+	passed, total := computeScore(results)
+	if total != 5 {
+		t.Fatalf("total = %d, want 5", total)
+	}
+	if passed != 2 {
+		t.Fatalf("passed = %d, want 2", passed)
+	}
+}
+
+func TestComputeScore_EmptyResults(t *testing.T) {
+	t.Parallel()
+	passed, total := computeScore(nil)
+	if passed != 0 || total != 0 {
+		t.Fatalf("(passed, total) = (%d, %d), want (0, 0)", passed, total)
+	}
+}
+
 func TestBuildURL_MetricsInstant(t *testing.T) {
 	t.Parallel()
 	tc := CorpusCase{

--- a/compatibility/tempo/driver/main.go
+++ b/compatibility/tempo/driver/main.go
@@ -14,9 +14,10 @@
 //     query through both backends via /api/search, /api/traces/<id>,
 //     /api/metrics/query_range, and /api/metrics/query, applies per-
 //     side assertions + semantic-consistency invariants, computes the
-//     structural diff, and emits a markdown report under /reports/.
-//     Returns 0 (informational baseline) by default; pass
-//     --fail-on-diff to make any diff non-zero.
+//     structural diff, and emits a markdown report under /reports/
+//     plus a shields.io endpoint-badge score JSON. Report-only: exit
+//     code is 0 on parity drift; only driver-wide hard errors (corpus
+//     load, report write) escalate to a non-zero rc.
 //
 // The two-way "OTLP into Tempo, INSERT into CH" split is documented in
 // docs/tempo-compliance-plan.md's "Open question 1": cerberus is
@@ -84,8 +85,9 @@ subcommands:
           equivalent rows into ClickHouse otel_traces; smoke-poll
           /api/traces/<id> on both backends.
   diff    run the TraceQL corpus through both backends, emit a
-          markdown diff report under /reports/. Default exit code is
-          0 (informational); pass --fail-on-diff to bubble per-case
-          regressions up to a non-zero rc.
+          markdown diff report under /reports/ and a shields.io
+          endpoint-badge score JSON. Report-only: exit code is 0 on
+          parity drift; only driver-wide hard errors (corpus load,
+          report write) escalate to a non-zero rc.
 `, version)
 }

--- a/compatibility/tempo/scripts/run-tempo-compatibility.sh
+++ b/compatibility/tempo/scripts/run-tempo-compatibility.sh
@@ -10,9 +10,11 @@
 #             backends resolve the first trace ID with non-zero spans.
 #   2. diff — read the TXTAR corpus, run every TraceQL query through
 #             both backends, write a markdown diff report to
-#             $REPORT_DIR/diff.md. Default: informational (script
-#             returns 0 even if the corpus diffs); set FAIL_ON_DIFF=1
-#             to bubble per-case regressions up to a non-zero rc.
+#             $REPORT_DIR/diff.md AND a shields.io endpoint-badge score
+#             JSON to $REPORT_DIR/compat-score.json. Report-only: the
+#             differ exits 0 even when parity diffs are present; only
+#             driver-wide hard errors (compose up failure, seed failure,
+#             corpus load failure) escalate to a non-zero rc.
 #
 # The seeder and differ run as Go binaries on the CI runner (host),
 # connecting to Docker-published ports on localhost. This avoids Docker
@@ -24,23 +26,20 @@
 # Usage:
 #   ./compatibility/tempo/scripts/run-tempo-compatibility.sh   full lifecycle (seed → diff)
 #   COMPOSE_KEEP=1 ./...                                               leave stack up after run
-#   FAIL_ON_DIFF=1 ./...                                               exit non-zero on diffs
 #
 # Env:
-#   REPORT_DIR     where the driver writes diff.md (default:
-#                  compatibility/tempo/reports/).
+#   REPORT_DIR     where the driver writes diff.md and compat-score.json
+#                  (default: compatibility/tempo/reports/).
 #   COMPOSE_KEEP   non-empty: leave the compose stack running after the
 #                  differ completes (useful for poking at /api/traces
 #                  and the otel_traces table manually).
-#   FAIL_ON_DIFF   non-empty: forward --fail-on-diff to the differ so
-#                  the script exits non-zero on any case that reported
-#                  a structural diff / assertion / hard error.
 #
 # Exit codes:
-#   0  seed + diff completed (informational mode) OR with FAIL_ON_DIFF
-#      set, every corpus case passed.
-#   non-zero  stack failed to come up OR seeder failed OR (with
-#             FAIL_ON_DIFF set) the differ reported a regression.
+#   0         seed + diff completed; parity drift is captured in
+#             compat-score.json, not in the exit code.
+#   non-zero  stack failed to come up OR seeder failed OR differ hit
+#             a hard error (corpus load, report write, etc.). Parity
+#             drift never reaches this branch.
 
 set -eu -o pipefail
 
@@ -126,19 +125,14 @@ sleep 30
 echo "==> building diff driver"
 (cd "$REPO_ROOT" && go build -o "$DRIVER_BIN" ./compatibility/tempo/driver/)
 
-# After seed, run the differ against the same backends. The differ
-# emits a markdown report under $REPORT_DIR; in informational mode
-# (default) it returns 0 even if the report contains diffs so the
-# workflow stays a baseline. Set FAIL_ON_DIFF=1 to bubble regressions
-# up to a non-zero rc — useful for `just`-style local repro and for
-# the eventual PR 7 promotion to a required check.
-DIFF_FLAGS=""
-if [ -n "${FAIL_ON_DIFF:-}" ]; then
-    DIFF_FLAGS="--fail-on-diff"
-fi
-DIFF_FLAGS="$DIFF_FLAGS --expected-failures $ROOT_DIR/expected-failures.json"
+# After seed, run the differ against the same backends. Report-only:
+# parity drift is captured in compat-score.json (shields.io endpoint
+# badge JSON) and the markdown diff report; the driver returns 0 even
+# when cases diverge. Only driver-wide hard errors (corpus load failure,
+# report write failure) escalate to a non-zero rc.
+DIFF_FLAGS="--expected-failures $ROOT_DIR/expected-failures.json"
 
-echo "==> running diff driver (writing report to $REPORT_DIR/diff.md)"
+echo "==> running diff driver (writing report to $REPORT_DIR/diff.md, score to $REPORT_DIR/compat-score.json)"
 echo "    --tempo-http=http://localhost:23200  (reference Tempo)"
 echo "    --cerberus=http://localhost:29092  (cerberus)"
 set +e
@@ -147,11 +141,13 @@ set +e
     --cerberus=http://localhost:29092 \
     --corpus="$ROOT_DIR/driver/corpus/smoke.txtar" \
     --report="$REPORT_DIR/diff.md" \
+    --score="$REPORT_DIR/compat-score.json" \
     $DIFF_FLAGS
 DIFF_RC=$?
 set -e
 
 echo "==> differ exited with rc=$DIFF_RC"
 echo "==> report at $REPORT_DIR/diff.md"
+echo "==> score at $REPORT_DIR/compat-score.json"
 
 exit "$DIFF_RC"


### PR DESCRIPTION
## Summary

Per task #68, the three compatibility harnesses (prometheus / loki / tempo) now accumulate per-case results, write a [shields.io endpoint-badge](https://shields.io/badges/endpoint-badge) `compat-score.json`, and exit 0 on parity drift. Only **driver-wide hard errors** (corpus load failure, compose-up failure, missing report, scorer failure) escalate to a non-zero rc.

The score JSON drives the downstream badge color (`brightgreen` / `green` / `yellowgreen` / `yellow` / `orange` / `red`) with project-wide thresholds (100% / >=95% / >=80% / >=60% / >=40% / <40%). Empty corpora are forced to `red` so a misconfigured run doesn't masquerade as `brightgreen`.

### What changed

- **`compatibility/internal/score`** — new shared package with `Score` struct, `Compute(label, passed, total)`, `Write(path, s)`, and the color/threshold logic. One source of truth for all three heads, fully unit-tested.
- **`compatibility/tempo/driver`** — adds `--score` flag (default `/reports/compat-score.json`), removes `--fail-on-diff` (parity drift no longer fails the run), expected-failures count as diffs in the score (so the percentage tracks raw parity).
- **`compatibility/loki/cmd/loki-compliance-tester`** — adds `-score` flag, drops the `os.Exit(1)` when any case diff'd, drops the now-unused `allSuccess atomic.Bool`, overlay-skipped cases are excluded from both numerator and denominator (documented exclusions shouldn't penalise the score).
- **`compatibility/prometheus/cmd/scorer`** — new in-tree post-processor that reads the upstream `promql-compliance-tester`'s `report.json` and emits `compat-score.json`. We can't easily modify the upstream submodule, so the wrapper script invokes the tester, then this scorer.
- **Shell scripts** for all three heads updated to invoke the new flag / post-processor and to document the report-only exit semantics.

### Score JSON output paths

| head | path |
|------|------|
| prometheus | `compatibility/prometheus/compat-score.json` |
| loki | `compatibility/loki/reports/compat-score.json` |
| tempo | `compatibility/tempo/reports/compat-score.json` |

Loki and tempo paths are already under the directories the workflow's `upload-artifact` collects. Prometheus's existing artifact upload is a single-file glob on `report.json`; widening that to pick up the score JSON is deferred to task #69 along with the rest of the workflow changes.

### Exit semantics (new contract)

- **0**: harness completed; parity drift (if any) is captured in `report.json` + `compat-score.json`, not in the exit code.
- **non-zero**: hard infrastructure failure — compose-up failure, seeder failure, build failure, missing/malformed report.json, scorer failure. These remain runners-of-CI red signals.

Workflow-level changes (artifact upload paths, removing `FAIL_ON_DIFF: "1"` env, dropping the `Fail job if harness step failed` step) are explicitly deferred to **task #69** per the task description. This PR is driver + scorer + script changes only.

## Test plan

- [x] `go build ./compatibility/...` clean
- [x] `go test ./compatibility/...` — 249 tests pass across 8 packages, including new unit tests for `score.Compute` / `score.Write` (color thresholds, empty-corpus, round-trip, overwrite), `computeScore` / `scoreCounts` (per-head numerator/denominator semantics), and the prometheus scorer's `tally`
- [x] `gofumpt -l compatibility/` — clean on every file this PR touches (one unrelated pre-existing dirty file in `compatibility/prometheus/cmd/seed/main.go`)
- [x] `golangci-lint run ./compatibility/...` — no issues
- [x] Dry-run of `score.Compute` across all color bands — JSON output matches shields.io contract; percent rounding works at .005 boundaries; trailing newline present
- [x] Dry-run of `prometheus-compat-scorer` on a fake `report.json` with mixed pass/diff/UnexpectedFailure/UnexpectedSuccess rows — `(passed=2, total=5, percent=40.00, color=orange)` as expected
- [ ] CI's compatibility workflow runs the three harnesses against live Prometheus / Loki / Tempo and produces the score JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)