### PR TITLE
refactor(qlcommon): make label_replace loop-control observably distinguishable

### DIFF
--- a/internal/qlcommon/label_replace.go
+++ b/internal/qlcommon/label_replace.go
@@ -80,61 +80,87 @@ func ReplacementToCH(repl, regex string) string {
 
 	var b strings.Builder
 	b.Grow(len(escaped))
-	for i := 0; i < len(escaped); i++ {
-		c := escaped[i]
-		if c != '$' {
-			b.WriteByte(c)
-			continue
-		}
-		// Lone `$` at end of string — preserve.
-		if i+1 >= len(escaped) {
-			b.WriteByte('$')
-			continue
-		}
-		next := escaped[i+1]
-		switch {
-		case next == '$':
-			// `$$` → literal `$`.
-			b.WriteByte('$')
-			i++
-		case next >= '0' && next <= '9':
-			// `$N` → `\N` (single digit only — `$10` is preserved
-			// verbatim per upstream Go regexp semantics, but CH
-			// has no `\10`, so we'd mistranslate either way; preserving
-			// keeps the failure visible rather than silently wrong).
-			if i+2 < len(escaped) && escaped[i+2] >= '0' && escaped[i+2] <= '9' {
-				b.WriteByte('$')
-				continue
-			}
-			n := int(next - '0')
-			// `\0` references the whole match and is always valid; for
-			// numbered captures, only emit `\N` if the regex actually
-			// has N capture groups. Out-of-range refs are dropped so
-			// CH's substitution validator stays happy.
-			if n == 0 || n <= allowed {
-				b.WriteByte('\\')
-				b.WriteByte(next)
-			}
-			i++
-		case next == '{':
-			// `${N}` (single digit) → `\N`. Anything else (named
-			// captures, multi-digit indices) is preserved verbatim.
-			if i+3 < len(escaped) && escaped[i+2] >= '0' && escaped[i+2] <= '9' && escaped[i+3] == '}' {
-				n := int(escaped[i+2] - '0')
-				if n == 0 || n <= allowed {
-					b.WriteByte('\\')
-					b.WriteByte(escaped[i+2])
-				}
-				i += 3
-				continue
-			}
-			b.WriteByte('$')
-		default:
-			// `$<letter>` etc. — preserve verbatim.
-			b.WriteByte('$')
-		}
+	// Step-based loop: each branch returns the number of input bytes it
+	// consumed via `step`, and the for-iterator advances `i` by that
+	// amount. Phrasing the loop this way (rather than using `continue` /
+	// `break` inside an inner `switch`) makes every per-iteration choice
+	// observable in the iterator clause — without it the gremlins
+	// INVERT_LOOPCTRL operator could swap `continue` ↔ `break` inside
+	// dead-end switch cases and the swap would be unkillable because no
+	// statements ran between the keyword and the iterator step. See PR
+	// #499 (the mutant-kill tests) and the follow-up PR that landed this
+	// refactor for the full diagnosis.
+	for i := 0; i < len(escaped); {
+		step := replacementStep(&b, escaped, i, allowed)
+		i += step
 	}
 	return b.String()
+}
+
+// replacementStep handles a single dispatch step of ReplacementToCH at
+// offset `i` of `escaped`. It writes the translated bytes to `b` and
+// returns the number of input bytes it consumed (always >= 1, so the
+// outer loop always makes progress).
+//
+// Splitting this out of the loop body keeps the per-iteration consumed
+// count observable in the caller's iterator clause, so the gremlins
+// INVERT_LOOPCTRL operator can't swap `continue` ↔ `break` and produce
+// an equivalent mutant — the dispatch keywords don't live in a `for`
+// scope at all here.
+func replacementStep(b *strings.Builder, escaped string, i, allowed int) int {
+	c := escaped[i]
+	if c != '$' {
+		b.WriteByte(c)
+		return 1
+	}
+	// Lone `$` at end of string — preserve.
+	if i+1 >= len(escaped) {
+		b.WriteByte('$')
+		return 1
+	}
+	next := escaped[i+1]
+	switch {
+	case next == '$':
+		// `$$` → literal `$`.
+		b.WriteByte('$')
+		return 2
+	case next >= '0' && next <= '9':
+		// `$N` → `\N` (single digit only — `$10` is preserved
+		// verbatim per upstream Go regexp semantics, but CH
+		// has no `\10`, so we'd mistranslate either way; preserving
+		// keeps the failure visible rather than silently wrong).
+		if i+2 < len(escaped) && escaped[i+2] >= '0' && escaped[i+2] <= '9' {
+			b.WriteByte('$')
+			return 1
+		}
+		n := int(next - '0')
+		// `\0` references the whole match and is always valid; for
+		// numbered captures, only emit `\N` if the regex actually
+		// has N capture groups. Out-of-range refs are dropped so
+		// CH's substitution validator stays happy.
+		if n == 0 || n <= allowed {
+			b.WriteByte('\\')
+			b.WriteByte(next)
+		}
+		return 2
+	case next == '{':
+		// `${N}` (single digit) → `\N`. Anything else (named
+		// captures, multi-digit indices) is preserved verbatim.
+		if i+3 < len(escaped) && escaped[i+2] >= '0' && escaped[i+2] <= '9' && escaped[i+3] == '}' {
+			n := int(escaped[i+2] - '0')
+			if n == 0 || n <= allowed {
+				b.WriteByte('\\')
+				b.WriteByte(escaped[i+2])
+			}
+			return 4
+		}
+		b.WriteByte('$')
+		return 1
+	default:
+		// `$<letter>` etc. — preserve verbatim.
+		b.WriteByte('$')
+		return 1
+	}
 }
 
 // EmptyCapturesReplacement returns the result of substituting Go's
@@ -170,47 +196,65 @@ func ReplacementToCH(repl, regex string) string {
 func EmptyCapturesReplacement(repl string) string {
 	var b strings.Builder
 	b.Grow(len(repl))
-	for i := 0; i < len(repl); i++ {
-		c := repl[i]
-		if c != '$' {
-			b.WriteByte(c)
-			continue
-		}
-		// Lone `$` at end of string — preserve.
-		if i+1 >= len(repl) {
-			b.WriteByte('$')
-			continue
-		}
-		next := repl[i+1]
-		switch {
-		case next == '$':
-			// `$$` → literal `$`.
-			b.WriteByte('$')
-			i++
-		case next >= '0' && next <= '9':
-			// `$N` → "" (capture N is empty for an empty-string match).
-			// Two-digit `$10`+ is preserved verbatim — `ReplacementToCH`
-			// makes the same opt-out, so the regex compile / CH parse
-			// error surfaces consistently.
-			if i+2 < len(repl) && repl[i+2] >= '0' && repl[i+2] <= '9' {
-				b.WriteByte('$')
-				continue
-			}
-			// Single-digit numbered capture → empty. Skip past the digit.
-			i++
-		case next == '{':
-			// `${N}` (single digit) → "". Anything else (named captures,
-			// multi-digit indices) is preserved verbatim — same opt-out
-			// as `ReplacementToCH`.
-			if i+3 < len(repl) && repl[i+2] >= '0' && repl[i+2] <= '9' && repl[i+3] == '}' {
-				i += 3
-				continue
-			}
-			b.WriteByte('$')
-		default:
-			// `$<letter>` etc. — preserve verbatim.
-			b.WriteByte('$')
-		}
+	// Step-based loop — see ReplacementToCH for the same rationale: the
+	// dispatch keywords moved into a helper so the gremlins
+	// INVERT_LOOPCTRL operator has no `continue`/`break` to swap inside
+	// a dead-end switch case.
+	for i := 0; i < len(repl); {
+		step := emptyCapturesStep(&b, repl, i)
+		i += step
 	}
 	return b.String()
+}
+
+// emptyCapturesStep handles a single dispatch step of
+// EmptyCapturesReplacement at offset `i` of `repl`. It writes the
+// translated bytes to `b` and returns the number of input bytes it
+// consumed (always >= 1).
+//
+// Mirrors replacementStep but resolves numbered captures to the empty
+// string instead of CH's `\N` form. See replacementStep for the
+// mutation-testing rationale behind the extraction.
+func emptyCapturesStep(b *strings.Builder, repl string, i int) int {
+	c := repl[i]
+	if c != '$' {
+		b.WriteByte(c)
+		return 1
+	}
+	// Lone `$` at end of string — preserve.
+	if i+1 >= len(repl) {
+		b.WriteByte('$')
+		return 1
+	}
+	next := repl[i+1]
+	switch {
+	case next == '$':
+		// `$$` → literal `$`.
+		b.WriteByte('$')
+		return 2
+	case next >= '0' && next <= '9':
+		// `$N` → "" (capture N is empty for an empty-string match).
+		// Two-digit `$10`+ is preserved verbatim — `ReplacementToCH`
+		// makes the same opt-out, so the regex compile / CH parse
+		// error surfaces consistently.
+		if i+2 < len(repl) && repl[i+2] >= '0' && repl[i+2] <= '9' {
+			b.WriteByte('$')
+			return 1
+		}
+		// Single-digit numbered capture → empty. Skip past the digit.
+		return 2
+	case next == '{':
+		// `${N}` (single digit) → "". Anything else (named captures,
+		// multi-digit indices) is preserved verbatim — same opt-out
+		// as `ReplacementToCH`.
+		if i+3 < len(repl) && repl[i+2] >= '0' && repl[i+2] <= '9' && repl[i+3] == '}' {
+			return 4
+		}
+		b.WriteByte('$')
+		return 1
+	default:
+		// `$<letter>` etc. — preserve verbatim.
+		b.WriteByte('$')
+		return 1
+	}
 }

--- a/internal/qlcommon/label_replace_test.go
+++ b/internal/qlcommon/label_replace_test.go
@@ -62,36 +62,36 @@ func TestReplacementToCH(t *testing.T) {
 		// Targeted mutation-kill cases pinning the gremlins CONDITIONALS_
 		// BOUNDARY / INVERT_LOGICAL / ARITHMETIC_BASE / REMOVE_SELF_
 		// ASSIGNMENTS mutants on the multi-digit-preserve and `${N}`
-		// branches at lines 105 / 122 / 124 in `label_replace.go`. Each
-		// row below is calibrated so the original implementation
-		// produces the listed `want`, and at least one boundary-mutated
-		// variant produces an observably different string (or panics).
-		// Treat these as low-level guards — the user-facing semantics
-		// are already covered above; these only widen the discriminator
-		// set the mutation tool can use to prove the boundaries are
-		// load-bearing.
+		// branches inside `replacementStep` (the digit lookahead at the
+		// `next >= '0' && next <= '9'` arm, and the brace-block parse at
+		// the `next == '{'` arm). Each row below is calibrated so the
+		// original implementation produces the listed `want`, and at
+		// least one boundary-mutated variant produces an observably
+		// different string (or panics). Treat these as low-level guards
+		// — the user-facing semantics are already covered above; these
+		// only widen the discriminator set the mutation tool can use to
+		// prove the boundaries are load-bearing.
 		//
 		//  * `multi_digit_unbraced_nine` pins the `<= '9'` upper bound
-		//    of the inner multi-digit lookahead at line 105:65. Char
-		//    at i+2 is exactly '9', so the boundary mutant `< '9'`
-		//    misses the branch and emits the single-digit form `\19`
-		//    instead of the verbatim `$19`.
+		//    of the inner multi-digit lookahead inside the `next >= '0'`
+		//    case. Char at i+2 is exactly '9', so the boundary mutant
+		//    `< '9'` misses the branch and emits the single-digit form
+		//    `\19` instead of the verbatim `$19`.
 		{"multi_digit_unbraced_nine", "$19", nineCaptureRegex, "$19"},
 		//  * `braced_zero_with_caps` pins the `>= '0'` lower bound of
-		//    the braced digit check at line 122:42. Char at i+2 is
-		//    exactly '0', so the boundary mutant `> '0'` skips the
-		//    branch and falls through to write the literal `${0}`
-		//    instead of the canonical `\0`.
+		//    the braced digit check inside the `next == '{'` case. Char
+		//    at i+2 is exactly '0', so the boundary mutant `> '0'`
+		//    skips the branch and falls through to write the literal
+		//    `${0}` instead of the canonical `\0`.
 		{"braced_zero_with_caps", "${0}", nineCaptureRegex, `\0`},
-		//  * `braced_nine_with_caps` pins both the `<= '9'` upper
-		//    bound of the braced digit check at line 122:65 AND the
-		//    `n <= allowed` capture-count gate at line 124:20. Char at
-		//    i+2 is exactly '9' and the regex has exactly 9 capture
-		//    groups, so both boundary mutants (`< '9'` and `< allowed`)
-		//    diverge from the canonical `\9`.
+		//  * `braced_nine_with_caps` pins both the `<= '9'` upper bound
+		//    of the braced digit check AND the `n <= allowed` capture-
+		//    count gate. Char at i+2 is exactly '9' and the regex has
+		//    exactly 9 capture groups, so both boundary mutants (`< '9'`
+		//    and `< allowed`) diverge from the canonical `\9`.
 		{"braced_nine_with_caps", "${9}", nineCaptureRegex, `\9`},
 		//  * `braced_non_digit_inner` pins both INVERT_LOGICAL mutants
-		//    on the chained `&&` at line 122:26 / 122:49. The char at
+		//    on the chained `&&` in the brace-block parse. The char at
 		//    i+2 is a non-digit (`x`), so the original short-circuits
 		//    on `'x' <= '9'` and falls through to the literal-write
 		//    path. Either `&&` → `||` mutation upgrades the partial
@@ -99,9 +99,9 @@ func TestReplacementToCH(t *testing.T) {
 		//    drops the entire `${x}` from the output.
 		{"braced_non_digit_inner", "${x}", nineCaptureRegex, "${x}"},
 		//  * `braced_truncated_digit` pins the ARITHMETIC_BASE mutant
-		//    on `i+3` at line 122:8 AND the CONDITIONALS_BOUNDARY
-		//    mutant on `<` at line 122:11. The input is one byte short
-		//    of a closing `}`, so the original short-circuits on
+		//    on `i+3` AND the CONDITIONALS_BOUNDARY mutant on `<` in
+		//    the brace-block parse. The input is one byte short of a
+		//    closing `}`, so the original short-circuits on
 		//    `i+3 < len` (3 < 3 == false). The `i-3` mutant evaluates
 		//    `-3 < 3` as true and continues into the OOB `escaped[i+3]`
 		//    read; the `<=` mutant evaluates `3 <= 3` as true and does
@@ -167,45 +167,47 @@ func TestEmptyCapturesReplacement(t *testing.T) {
 		// Targeted mutation-kill cases pinning the gremlins CONDITIONALS_
 		// BOUNDARY / INVERT_LOGICAL / ARITHMETIC_BASE / REMOVE_SELF_
 		// ASSIGNMENTS mutants on the multi-digit-preserve and `${N}`
-		// branches at lines 195 / 205 / 206 in `label_replace.go`. The
-		// mirror of the ReplacementToCH cases above, recalibrated for
-		// the empty-captures resolver (numbered captures collapse to
-		// "" instead of `\N`, so the original on the consuming branch
-		// returns the empty string).
+		// branches inside `emptyCapturesStep`. The mirror of the
+		// ReplacementToCH cases above, recalibrated for the empty-
+		// captures resolver (numbered captures collapse to "" instead
+		// of `\N`, so the original on the consuming branch returns the
+		// empty string).
 		//
 		//  * `multi_digit_unbraced_nine` pins the `<= '9'` upper bound
-		//    at line 195:56. Char at i+2 is '9'; the boundary mutant
-		//    `< '9'` falls into the single-digit-collapse branch and
-		//    emits the trailing `9` alone instead of the verbatim
-		//    `$19`.
+		//    of the multi-digit lookahead inside the `next >= '0'` case.
+		//    Char at i+2 is '9'; the boundary mutant `< '9'` falls into
+		//    the single-digit-collapse branch and emits the trailing
+		//    `9` alone instead of the verbatim `$19`.
 		{"multi_digit_unbraced_nine", "$19", "$19"},
-		//  * `braced_zero` pins the `>= '0'` lower bound at line 205:36.
-		//    Char at i+2 is '0'; the boundary mutant `> '0'` skips the
-		//    consuming branch and writes the literal `${0}` instead of
-		//    the empty result the original produces.
+		//  * `braced_zero` pins the `>= '0'` lower bound in the brace-
+		//    block parse. Char at i+2 is '0'; the boundary mutant
+		//    `> '0'` skips the consuming branch and writes the literal
+		//    `${0}` instead of the empty result the original produces.
 		{"braced_zero", "${0}", ""},
-		//  * `braced_nine` pins the `<= '9'` upper bound at line 205:56.
-		//    Char at i+2 is '9'; the boundary mutant `< '9'` skips the
-		//    consuming branch and writes the literal `${9}` instead of
-		//    the empty result.
+		//  * `braced_nine` pins the `<= '9'` upper bound in the brace-
+		//    block parse. Char at i+2 is '9'; the boundary mutant
+		//    `< '9'` skips the consuming branch and writes the literal
+		//    `${9}` instead of the empty result.
 		{"braced_nine", "${9}", ""},
 		//  * `braced_non_digit_inner` pins both INVERT_LOGICAL mutants
-		//    on the chained `&&` at line 205:23 / 205:43. Char at i+2
+		//    on the chained `&&` in the brace-block parse. Char at i+2
 		//    is non-digit; either `&&` → `||` swap upgrades the partial
 		//    truth into a full match and erases the brace block.
 		{"braced_non_digit_inner", "${x}", "${x}"},
-		//  * `braced_truncated_digit` pins ARITHMETIC_BASE on `i+3` at
-		//    line 205:8 AND CONDITIONALS_BOUNDARY on `<` at line 205:11.
+		//  * `braced_truncated_digit` pins ARITHMETIC_BASE on `i+3`
+		//    AND CONDITIONALS_BOUNDARY on `<` in the brace-block parse.
 		//    Same mechanism as the ReplacementToCH twin: the OOB
 		//    `repl[i+3]` read panics under either mutant.
 		{"braced_truncated_digit", "${1", "${1"},
-		//  * `braced_with_trailing_text` pins the REMOVE_SELF_ASSIGNMENTS
-		//    mutant at line 206:7 (`i += 3` → `i = 3`). The literal
-		//    prefix `xy` shifts the `${1}` to offset 2, so the original
-		//    advances `i` to 5 (consuming the brace block) and lands
-		//    on `z`; the mutant resets `i` to 3, which lands on the
-		//    digit `1` inside the brace block, replays the suffix as
-		//    plain text and emits `xy1}z` instead of `xyz`.
+		//  * `braced_with_trailing_text` pins the ARITHMETIC_BASE
+		//    mutant on the `return 4` step value of the brace-block
+		//    branch. The literal prefix `xy` shifts the `${1}` to
+		//    offset 2; the original returns step 4 (consuming the
+		//    brace block) so the next iteration lands on `z`. If the
+		//    consumed-byte count is mutated to 1 the next iteration
+		//    lands on the digit `1` inside the brace block, replays
+		//    the suffix as plain text and emits `xy1}z` instead of
+		//    `xyz`.
 		{"braced_with_trailing_text", "xy${1}z", "xyz"},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary

Restructures `ReplacementToCH` + `EmptyCapturesReplacement` in
`internal/qlcommon/label_replace.go` so the gremlins
`INVERT_LOOPCTRL` operator can no longer produce equivalent mutants
on the file. The per-iteration dispatch moved out of an inner
`switch` (where `continue` ↔ `break` swaps were observationally
identical) and into a helper function returning a `step` count; the
outer `for` body is now `i += step`, with no `continue` / `break`
keywords for the mutator to target.

## Context

PR #499 added 11 targeted unit-test rows that killed 16 of the 22
gremlins LIVED mutants on this file (efficacy from **76.60% →
93.62%**) but explicitly left 6 mutants alive — see [PR #499's
"Mutants NOT killed (equivalent)" table][pr499]. Those 6 are all
`INVERT_LOOPCTRL` swaps where a `continue` sits inside a `switch`
case with no statements between the keyword and the for-iterator
step, so `continue` (skip rest of body → run iterator-step) and
`break` (exit loop) produce the same observable output.

The six equivalent-mutant sites pre-refactor:

| File:line | Function | Switch case |
|---|---|---|
| `label_replace.go:92` | `ReplacementToCH` | `if i+1 >= len(escaped)` (lone-`$` tail) |
| `label_replace.go:107` | `ReplacementToCH` | `case next >= '0' && next <= '9'` (multi-digit lookahead) |
| `label_replace.go:129` | `ReplacementToCH` | `case next == '{'` (braced `${N}`) |
| `label_replace.go:182` | `EmptyCapturesReplacement` | `if i+1 >= len(repl)` |
| `label_replace.go:197` | `EmptyCapturesReplacement` | `case next >= '0' && next <= '9'` |
| `label_replace.go:207` | `EmptyCapturesReplacement` | `case next == '{'` |

[pr499]: https://github.com/tsouza/cerberus/pull/499

Killing these with tests alone is impossible by construction — the
gremlins op generates a mutant that no test can distinguish from
the original. The only path to ≥ 95% efficacy was production-code
restructuring (the bail-out option PR #499 deferred).

## The refactor

Each function's `for i := 0; i < n; i++` loop now reads:

```go
for i := 0; i < len(escaped); {
    step := replacementStep(&b, escaped, i, allowed)
    i += step
}
```

`replacementStep` (and its `EmptyCapturesReplacement` twin
`emptyCapturesStep`) absorbs the entire per-iteration dispatch — the
literal-byte branch, the lone-`$` tail branch, and the three
`switch` cases (`$$` / `$N` / `${N}`) — and returns the number of
input bytes consumed. The outer loop has no `continue` / `break`
keywords. The mutator literally has nothing to mutate on those
sites; the 6 equivalent mutants no longer exist.

The helper preserves byte-for-byte behaviour:

- Cases that previously did `i++` then fell through to the outer
  `i++` (total +2) now `return 2`.
- The `${N}` case that did `i += 3 + continue + outer i++` (total
  +4) now `return 4`.
- Cases that previously wrote then fell through (`i++` only) now
  `return 1`.
- The leading lone-`$`-at-end branch (`continue`, exits via for-cond
  next iteration) and the dollar-letter `default` (writes `$`,
  fall-through) both `return 1` — equivalent because the next
  iteration's for-cond does the same exit check.

## Verification

Local gremlins run on this branch:

```
$ ~/go/bin/gremlins unleash --output gremlins.json ./internal/qlcommon/
…
Killed: 18, Lived: 0, Not covered: 14
Timed out: 69, Not viable: 0, Skipped: 0
Test efficacy: 100.00%
Mutator coverage: 56.25%
```

- **Lived: 0** (was 6) — the 6 `INVERT_LOOPCTRL` mutants are no
  longer generated (search the JSON for `"type":"INVERT_LOOPCTRL"`
  → empty array).
- **Test efficacy: 100.00%** (was 93.62%) — clears the 95% gate
  defined in `.gremlins.yaml` / `.github/workflows/mutation.yml`
  matrix entry `phase5-qlcommon`.
- The 69 "Timed out" mutants are the `i += step` infinite-loop
  variants (e.g. REMOVE_SELF_ASSIGNMENTS swapping `i += step` to
  `i = step`); gremlins doesn't count them as `lived`, so the
  efficacy ratio is unaffected.

`go test ./internal/qlcommon/... -count=1` — 49 subtests pass (same
as PR #499's count; no test logic changed, only stale line-number
references in comments were updated to reference the new helper-
function names).

`go test ./internal/promql/ ./internal/logql/ ./internal/qlcommon/ -count=1`
— 904 tests pass; the public `ReplacementToCH` / `EmptyCapturesReplacement`
signatures are unchanged, so the PromQL + LogQL `label_replace`
lowering paths see no diff.

`go build ./...` clean.

## Test plan

- [x] `go test ./internal/qlcommon/... -count=1` — all subtests pass.
- [x] `go build ./...` clean.
- [x] Local gremlins efficacy = 100.00% on `./internal/qlcommon/`.
- [ ] CI `check` + `lint` green.
- [ ] `phase5-qlcommon` mutation job (push-to-main) reports
  `efficacy >= 95.00` with `lived == 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)