### PR TITLE
docs(readme): add shields.io compat-score badges for prom/loki/tempo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Go Reference](https://pkg.go.dev/badge/github.com/tsouza/cerberus.svg)](https://pkg.go.dev/github.com/tsouza/cerberus)
 [![Go Report Card](https://goreportcard.com/badge/github.com/tsouza/cerberus)](https://goreportcard.com/report/github.com/tsouza/cerberus)
+[![Prom compat](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftsouza%2Fcerberus%2Fcompat-scores%2Fbadges%2Fprometheus.json)](https://github.com/tsouza/cerberus/actions/workflows/compatibility.yml)
+[![Loki compat](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftsouza%2Fcerberus%2Fcompat-scores%2Fbadges%2Floki.json)](https://github.com/tsouza/cerberus/actions/workflows/compatibility.yml)
+[![Tempo compat](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftsouza%2Fcerberus%2Fcompat-scores%2Fbadges%2Ftempo.json)](https://github.com/tsouza/cerberus/actions/workflows/compatibility.yml)
 
 ---
 


### PR DESCRIPTION
## Summary

Adds three shields.io endpoint badges to `README.md`, one per upstream head, surfacing the latest compat scores produced by the compatibility harnesses.

- Prom badge reads `badges/prometheus.json`
- Loki badge reads `badges/loki.json`
- Tempo badge reads `badges/tempo.json`

All three URLs target the `compat-scores` orphan branch in this repo (published by the workflow added in #505), and each badge links to the `compatibility.yml` Actions page so a click drills into the run that produced the score.

## Note on first publish

The badges will render as `404` until the `compat-scores` orphan branch is first populated. That happens automatically on the next push-to-main once both #503 (drivers emit the JSON) and #505 (workflow publishes it) have landed. After that, every `compatibility.yml` run on `main` refreshes the values.

## Test plan

- [x] Confirmed badge markdown URL-encodes `:` and `/` (shields.io rejects unencoded `?url=` values).
- [x] `MD013` is disabled in `.markdownlint.yaml`, so long single-line badge URLs are fine.
- [ ] CI `lint` job passes (markdownlint-cli2 in particular).
- [ ] After merge + #505 merge + next main-push, manually verify each badge resolves to a non-404 image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)