### PR TITLE
test(spec/promql): seed chDB roundtrip for 16 time/at/binop/date-fn fixtures

### DIFF
--- a/test/spec/promql/at_modifier_range_mode_collapse.txtar
+++ b/test/spec/promql/at_modifier_range_mode_collapse.txtar
@@ -2,6 +2,29 @@
 up @ 1767225600
 -- range_step --
 30s
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 1.0);
+-- expected_rows --
+[
+  ["up", {"instance": "a"}, "2026-01-01T00:00:00Z", 1],
+  ["up", {"instance": "a"}, "2026-01-01T00:00:30Z", 1],
+  ["up", {"instance": "a"}, "2026-01-01T00:01:00Z", 1],
+  ["up", {"instance": "a"}, "2026-01-01T00:01:30Z", 1],
+  ["up", {"instance": "a"}, "2026-01-01T00:02:00Z", 1],
+  ["up", {"instance": "a"}, "2026-01-01T00:02:30Z", 1],
+  ["up", {"instance": "a"}, "2026-01-01T00:03:00Z", 1],
+  ["up", {"instance": "a"}, "2026-01-01T00:03:30Z", 1],
+  ["up", {"instance": "a"}, "2026-01-01T00:04:00Z", 1],
+  ["up", {"instance": "a"}, "2026-01-01T00:04:30Z", 1],
+  ["up", {"instance": "a"}, "2026-01-01T00:05:00Z", 1]
+]
 -- args --
 [0] string = "up"
 [1] string = "2026-01-01 00:00:00.000000000"

--- a/test/spec/promql/at_start_basic.txtar
+++ b/test/spec/promql/at_start_basic.txtar
@@ -1,5 +1,18 @@
 -- query.promql --
 up @ start()
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('instance', 'a'), toDateTime64('1970-01-01 00:01:40', 9), 1.0);
+-- expected_rows --
+[
+  ["up", {"instance": "a"}, "1970-01-01T00:01:40Z", 1]
+]
 -- args --
 [0] string = "up"
 [1] string = "1970-01-01 00:01:40.000000000"

--- a/test/spec/promql/binop_time_arith_range.txtar
+++ b/test/spec/promql/binop_time_arith_range.txtar
@@ -12,6 +12,28 @@
 time() + http_requests_total
 -- range_step --
 30s
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 5000.0);
+-- expected_rows --
+[
+  ["", {"job": "api"}, "2026-01-01T00:00:00Z", 1767230600],
+  ["", {"job": "api"}, "2026-01-01T00:00:30Z", 1767230630],
+  ["", {"job": "api"}, "2026-01-01T00:01:00Z", 1767230660],
+  ["", {"job": "api"}, "2026-01-01T00:01:30Z", 1767230690],
+  ["", {"job": "api"}, "2026-01-01T00:02:00Z", 1767230720],
+  ["", {"job": "api"}, "2026-01-01T00:02:30Z", 1767230750],
+  ["", {"job": "api"}, "2026-01-01T00:03:00Z", 1767230780],
+  ["", {"job": "api"}, "2026-01-01T00:03:30Z", 1767230810],
+  ["", {"job": "api"}, "2026-01-01T00:04:00Z", 1767230840],
+  ["", {"job": "api"}, "2026-01-01T00:04:30Z", 1767230870]
+]
 -- args --
 [0] string = ""
 [1] int64 = 1000000000

--- a/test/spec/promql/binop_time_lt_metric.txtar
+++ b/test/spec/promql/binop_time_lt_metric.txtar
@@ -13,6 +13,20 @@
 # test instead).
 -- query.promql --
 time() < http_requests_total
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 9999999999.0),
+    ('http_requests_total', map('job', 'db'), toDateTime64('2026-01-01 00:00:00', 9), 5.0);
+-- expected_rows --
+[
+  ["http_requests_total", {"job": "api"}, "2026-01-01T00:00:00Z", 9999999999]
+]
 -- args --
 [0] string = "http_requests_total"
 [1] string = "2026-01-01 00:00:01.000000000"

--- a/test/spec/promql/comparison_arithmetic.txtar
+++ b/test/spec/promql/comparison_arithmetic.txtar
@@ -1,5 +1,19 @@
 -- query.promql --
 (up * 2) > 1
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('up', map('instance', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 0.25);
+-- expected_rows --
+[
+  ["", {"instance": "a"}, "2026-01-01T00:00:00Z", 2]
+]
 -- sql --
 SELECT * FROM (SELECT ? AS `MetricName`, `Attributes`, `TimeUnix`, (`Value` * ?) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))) WHERE (`Value` > ?)
 -- args --

--- a/test/spec/promql/day_of_month_default.txtar
+++ b/test/spec/promql/day_of_month_default.txtar
@@ -7,6 +7,17 @@
 
 -- query.promql --
 day_of_month()
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- expected_rows --
+[
+  ["", {}, "2026-01-01T00:00:01Z", 1]
+]
 -- args --
 [0] string = ""
 [1] string = "Map(String,String)"

--- a/test/spec/promql/day_of_week_default.txtar
+++ b/test/spec/promql/day_of_week_default.txtar
@@ -12,6 +12,17 @@
 
 -- query.promql --
 day_of_week()
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- expected_rows --
+[
+  ["", {}, "2026-01-01T00:00:01Z", 4]
+]
 -- args --
 [0] string = ""
 [1] string = "Map(String,String)"

--- a/test/spec/promql/days_in_month_default.txtar
+++ b/test/spec/promql/days_in_month_default.txtar
@@ -10,6 +10,17 @@
 
 -- query.promql --
 days_in_month()
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- expected_rows --
+[
+  ["", {}, "2026-01-01T00:00:01Z", 31]
+]
 -- args --
 [0] string = ""
 [1] string = "Map(String,String)"

--- a/test/spec/promql/hour_default.txtar
+++ b/test/spec/promql/hour_default.txtar
@@ -9,6 +9,17 @@
 
 -- query.promql --
 hour()
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- expected_rows --
+[
+  ["", {}, "2026-01-01T00:00:01Z", 0]
+]
 -- args --
 [0] string = ""
 [1] string = "Map(String,String)"

--- a/test/spec/promql/minute_default.txtar
+++ b/test/spec/promql/minute_default.txtar
@@ -9,6 +9,17 @@
 
 -- query.promql --
 minute()
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- expected_rows --
+[
+  ["", {}, "2026-01-01T00:00:01Z", 0]
+]
 -- args --
 [0] string = ""
 [1] string = "Map(String,String)"

--- a/test/spec/promql/month_default.txtar
+++ b/test/spec/promql/month_default.txtar
@@ -9,6 +9,17 @@
 
 -- query.promql --
 month()
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- expected_rows --
+[
+  ["", {}, "2026-01-01T00:00:01Z", 1]
+]
 -- args --
 [0] string = ""
 [1] string = "Map(String,String)"

--- a/test/spec/promql/time_eq_bool_time_range.txtar
+++ b/test/spec/promql/time_eq_bool_time_range.txtar
@@ -7,6 +7,17 @@
 # for the fold's rationale.
 -- query.promql --
 time() == bool time()
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- expected_rows --
+[
+  ["", {}, "2026-01-01T00:00:01Z", 1]
+]
 -- args --
 [0] string = ""
 [1] string = "Map(String,String)"

--- a/test/spec/promql/time_minus_time_range.txtar
+++ b/test/spec/promql/time_minus_time_range.txtar
@@ -4,6 +4,17 @@
 # fold's rationale.
 -- query.promql --
 time() - time()
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- expected_rows --
+[
+  ["", {}, "2026-01-01T00:00:01Z", 0]
+]
 -- args --
 [0] string = ""
 [1] string = "Map(String,String)"

--- a/test/spec/promql/time_plus_time_range.txtar
+++ b/test/spec/promql/time_plus_time_range.txtar
@@ -12,6 +12,17 @@
 # under internal/api/prom/handler_chdb_step_loop_test.go.
 -- query.promql --
 time() + time()
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- expected_rows --
+[
+  ["", {}, "2026-01-01T00:00:01Z", 3534451202]
+]
 -- args --
 [0] string = ""
 [1] string = "Map(String,String)"

--- a/test/spec/promql/time_returns_eval_ts.txtar
+++ b/test/spec/promql/time_returns_eval_ts.txtar
@@ -1,5 +1,16 @@
 -- query.promql --
 time()
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- expected_rows --
+[
+  ["", {}, "2026-01-01T00:00:01Z", 1767225601]
+]
 -- args --
 [0] string = ""
 [1] string = "Map(String,String)"

--- a/test/spec/promql/year_default.txtar
+++ b/test/spec/promql/year_default.txtar
@@ -1,5 +1,16 @@
 -- query.promql --
 year()
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- expected_rows --
+[
+  ["", {}, "2026-01-01T00:00:01Z", 2026]
+]
 -- args --
 [0] string = ""
 [1] string = "Map(String,String)"

--- a/test/spec/runner_chdb.go
+++ b/test/spec/runner_chdb.go
@@ -408,15 +408,18 @@ func isWildcardProjection(p string) bool {
 	return false
 }
 
-// substituteNow64 rewrites every `now64(...)` reference in the emitted
-// SQL to the deterministic [nowAnchorLiteral] so instant queries that
-// project the wall-clock as `TimeUnix` (PromQL aggregations, histogram
-// quantiles, subqueries, predict_linear, holt_winters) produce a
-// repeatable cell in `expected_rows:`. Without this, the outer
-// projection would scan as the wall-clock at test execution time and
-// never match a written-in-stone fixture row.
+// substituteNow64 rewrites every `now64(...)` and `now()` reference in
+// the emitted SQL to the deterministic [nowAnchorLiteral] so instant
+// queries that project the wall-clock as `TimeUnix` (PromQL
+// aggregations, histogram quantiles, subqueries, predict_linear,
+// holt_winters) or read the wall-clock as a DateTime through `now()`
+// (PromQL zero-arg date functions like `day_of_month()` / `hour()` /
+// `month()` lower to `toDayOfMonth(now())` etc.) produce a repeatable
+// cell in `expected_rows:`. Without this, the outer projection would
+// scan as the wall-clock at test execution time and never match a
+// written-in-stone fixture row.
 //
-// Two shapes appear in the corpus:
+// Three shapes appear in the corpus:
 //
 //   - `now64(?)` — parameterized; the trailing `?` is bound to an
 //     int64 precision arg in `args:`. We strip the corresponding
@@ -427,6 +430,15 @@ func isWildcardProjection(p string) bool {
 //     predict_linear, and holt_winters lowerings. No args slot to
 //     consume.
 //
+//   - `now()` — emitted by the zero-arg PromQL date-function lowerings
+//     (`day_of_month()` / `day_of_week()` / `days_in_month()` /
+//     `hour()` / `minute()` / `month()` / `year()`). CH's date
+//     accessors accept DateTime64 the same way they accept DateTime,
+//     so substituting the full [nowAnchorLiteral] (which is a
+//     DateTime64(9)) preserves type compatibility with `toYear`,
+//     `toMonth`, `toDayOfMonth`, `toDayOfWeek`, `toLastDayOfMonth`,
+//     `toHour`, `toMinute`. No args slot to consume.
+//
 // The function tracks `?` placeholder offsets while scanning so the
 // args list is mutated in lock-step. This is a test-infra workaround
 // for the inherent non-determinism of wall-clock projections in
@@ -436,7 +448,7 @@ func isWildcardProjection(p string) bool {
 // together.
 func substituteNow64(query string, args []any) (string, []any) {
 	// Fast-path: nothing to do when neither shape is present.
-	if !strings.Contains(query, "now64(") {
+	if !strings.Contains(query, "now64(") && !strings.Contains(query, "now()") {
 		return query, args
 	}
 
@@ -506,6 +518,19 @@ func substituteNow64(query string, args []any) (string, []any) {
 					continue
 				}
 			}
+		}
+
+		// Match `now()` — the zero-arg DateTime form emitted by PromQL
+		// zero-arg date functions. Substitute with the deterministic
+		// DateTime64 anchor literal; CH's `toYear`/`toMonth`/
+		// `toDayOfMonth`/`toDayOfWeek`/`toLastDayOfMonth`/`toHour`/
+		// `toMinute` accept DateTime64 the same as DateTime, so the
+		// type widening is invisible at the call site. No args slot
+		// to consume.
+		if c == 'n' && strings.HasPrefix(query[i:], "now()") {
+			out.WriteString(nowAnchorLiteral)
+			i += len("now()") - 1
+			continue
 		}
 
 		// Generic `?` placeholder: copy the arg through.


### PR DESCRIPTION
## Summary

Lifts 16 PromQL fixtures onto the seed-driven chDB execution path
(Layer 6 in `docs/test-strategy.md`):

- `time_returns_eval_ts` / `time_plus_time_range` / `time_minus_time_range` / `time_eq_bool_time_range` — synthetic-scalar OneRow folds
- `comparison_arithmetic` — Filter-wrapped `(up * 2) > 1`
- `binop_time_lt_metric` — `time() < metric` asymmetric fold (instant)
- `binop_time_arith_range` — `time() + metric` asymmetric fold (range)
- `at_modifier_range_mode_collapse` — `up @ <unix_ts>` cross-join with StepGrid
- `at_start_basic` — `up @ start()` resolves eval-ts to the fixed range start
- `day_of_month_default` / `day_of_week_default` / `days_in_month_default` / `hour_default` / `minute_default` / `month_default` / `year_default` — zero-arg date functions over the OneRow source

Also extends `test/spec/runner_chdb.go`'s `substituteNow64` pass to
recognise bare `now()` (no precision arg) and rewrite it to the
deterministic `nowAnchorLiteral`. CH's date accessors (`toYear` /
`toMonth` / `toDayOfMonth` / `toDayOfWeek` / `toLastDayOfMonth` /
`toHour` / `toMinute`) accept DateTime64 transparently, so the
substitution preserves type compatibility at every call site that the
zero-arg date-fn lowerings emit. Without this, the `*_default`
fixtures would scan as wall-clock-at-test-time and never match a
pinned row.

## Test plan

- [x] `go test -tags chdb ./test/spec/promql/... -run TestRoundTripChDB` — 249 pass
- [x] `go test ./internal/promql/... ` — 597 pass (text-equality unaffected)
- [x] `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)