### PR TITLE
test(spec/promql): seed chDB roundtrip for 14 edge a-i fixtures

### DIFF
--- a/test/spec/promql/edge_abs_over_rate.txtar
+++ b/test/spec/promql/edge_abs_over_rate.txtar
@@ -4,6 +4,20 @@ abs(rate(http_requests_total[5m]))
 [0] string = "http_requests_total"
 -- sql --
 SELECT `Attributes`, abs(`Value`) AS `Value` FROM (SELECT `Attributes`, if(sampled_interval > 0, counter_delta * (sampled_interval + if(counter_delta > 0 AND first_val >= 0, least(duration_to_start, sampled_interval * first_val / counter_delta), duration_to_start) + duration_to_end) / sampled_interval / 300, nan) AS `Value` FROM (SELECT `Attributes`, `window_vals`, `counter_delta`, `first_val`, toFloat64(dateDiff('nanosecond', first_ts, last_ts)) / 1e9 AS `sampled_interval`, if(toFloat64(dateDiff('nanosecond', now64(9) - toIntervalNanosecond(300000000000), first_ts)) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', now64(9) - toIntervalNanosecond(300000000000), first_ts)) / 1e9) AS `duration_to_start`, if(toFloat64(dateDiff('nanosecond', last_ts, now64(9))) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', last_ts, now64(9))) / 1e9) AS `duration_to_end` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta`, tupleElement(window_pairs[1], 1) AS `first_ts`, tupleElement(window_pairs[length(window_pairs)], 1) AS `last_ts`, tupleElement(window_pairs[1], 2) AS `first_val` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` = ?)) GROUP BY `Attributes`)))) WHERE length(`window_vals`) >= 2)
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('http_requests_total', map('job', 'api'), toDateTime64('2025-12-31 23:59:31', 9), 10.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 40.0);
+-- expected_rows --
+[
+  [{"job": "api"}, 0.1367816091954023]
+]
 -- chplan --
 Project [Attributes, abs(Value) AS Value]
   RangeWindow func=rate range=5m0s step=0s ts=TimeUnix value=Value groupBy=[Attributes]

--- a/test/spec/promql/edge_at_start_range.txtar
+++ b/test/spec/promql/edge_at_start_range.txtar
@@ -4,6 +4,20 @@ rate(http_requests_total[5m] @ start())
 [0] string = "http_requests_total"
 -- sql --
 SELECT `Attributes`, if(sampled_interval > 0, counter_delta * (sampled_interval + if(counter_delta > 0 AND first_val >= 0, least(duration_to_start, sampled_interval * first_val / counter_delta), duration_to_start) + duration_to_end) / sampled_interval / 300, nan) AS `Value` FROM (SELECT `Attributes`, `window_vals`, `counter_delta`, `first_val`, toFloat64(dateDiff('nanosecond', first_ts, last_ts)) / 1e9 AS `sampled_interval`, if(toFloat64(dateDiff('nanosecond', toDateTime64('1970-01-01 00:01:40.000000000', 9) - toIntervalNanosecond(300000000000), first_ts)) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', toDateTime64('1970-01-01 00:01:40.000000000', 9) - toIntervalNanosecond(300000000000), first_ts)) / 1e9) AS `duration_to_start`, if(toFloat64(dateDiff('nanosecond', last_ts, toDateTime64('1970-01-01 00:01:40.000000000', 9))) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', last_ts, toDateTime64('1970-01-01 00:01:40.000000000', 9))) / 1e9) AS `duration_to_end` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta`, tupleElement(window_pairs[1], 1) AS `first_ts`, tupleElement(window_pairs[length(window_pairs)], 1) AS `last_ts`, tupleElement(window_pairs[1], 2) AS `first_val` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) > toDateTime64('1970-01-01 00:01:40.000000000', 9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= toDateTime64('1970-01-01 00:01:40.000000000', 9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` = ?)) GROUP BY `Attributes`)))) WHERE length(`window_vals`) >= 2
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('http_requests_total', map('job', 'api'), toDateTime64('1970-01-01 00:01:10', 9), 10.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('1970-01-01 00:01:39', 9), 40.0);
+-- expected_rows --
+[
+  [{"job": "api"}, 0.1367816091954023]
+]
 -- chplan --
 RangeWindow func=rate range=5m0s step=0s ts=TimeUnix value=Value groupBy=[Attributes] start=0001-01-01T00:00:00Z end=1970-01-01T00:01:40Z
   Filter predicate=(MetricName = "http_requests_total")

--- a/test/spec/promql/edge_at_then_offset_neg.txtar
+++ b/test/spec/promql/edge_at_then_offset_neg.txtar
@@ -10,6 +10,19 @@ up @ 1700000000 offset -3m
 [6] int64 = 120000000000
 -- sql --
 SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= (toDateTime64(?, ?) - toIntervalNanosecond(?))) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('instance', 'a'), toDateTime64('2023-11-14 22:16:00', 9), 1.0);
+-- expected_rows --
+[
+  ["up", {"instance": "a"}, "2023-11-14T22:16:00Z", 1]
+]
 -- chplan --
 Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
   Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]

--- a/test/spec/promql/edge_at_timestamp_range.txtar
+++ b/test/spec/promql/edge_at_timestamp_range.txtar
@@ -4,6 +4,20 @@ rate(http_requests_total[5m] @ 1700000000)
 [0] string = "http_requests_total"
 -- sql --
 SELECT `Attributes`, if(sampled_interval > 0, counter_delta * (sampled_interval + if(counter_delta > 0 AND first_val >= 0, least(duration_to_start, sampled_interval * first_val / counter_delta), duration_to_start) + duration_to_end) / sampled_interval / 300, nan) AS `Value` FROM (SELECT `Attributes`, `window_vals`, `counter_delta`, `first_val`, toFloat64(dateDiff('nanosecond', first_ts, last_ts)) / 1e9 AS `sampled_interval`, if(toFloat64(dateDiff('nanosecond', toDateTime64('2023-11-14 22:13:20.000000000', 9) - toIntervalNanosecond(300000000000), first_ts)) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', toDateTime64('2023-11-14 22:13:20.000000000', 9) - toIntervalNanosecond(300000000000), first_ts)) / 1e9) AS `duration_to_start`, if(toFloat64(dateDiff('nanosecond', last_ts, toDateTime64('2023-11-14 22:13:20.000000000', 9))) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', last_ts, toDateTime64('2023-11-14 22:13:20.000000000', 9))) / 1e9) AS `duration_to_end` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta`, tupleElement(window_pairs[1], 1) AS `first_ts`, tupleElement(window_pairs[length(window_pairs)], 1) AS `last_ts`, tupleElement(window_pairs[1], 2) AS `first_val` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) > toDateTime64('2023-11-14 22:13:20.000000000', 9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= toDateTime64('2023-11-14 22:13:20.000000000', 9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` = ?)) GROUP BY `Attributes`)))) WHERE length(`window_vals`) >= 2
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('http_requests_total', map('job', 'api'), toDateTime64('2023-11-14 22:12:50', 9), 10.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2023-11-14 22:13:19', 9), 40.0);
+-- expected_rows --
+[
+  [{"job": "api"}, 0.1367816091954023]
+]
 -- chplan --
 RangeWindow func=rate range=5m0s step=0s ts=TimeUnix value=Value groupBy=[Attributes] start=0001-01-01T00:00:00Z end=2023-11-14T22:13:20Z
   Filter predicate=(MetricName = "http_requests_total")

--- a/test/spec/promql/edge_avg_over_time.txtar
+++ b/test/spec/promql/edge_avg_over_time.txtar
@@ -4,6 +4,21 @@ avg_over_time(temperature[5m])
 [0] string = "temperature"
 -- sql --
 SELECT `Attributes`, if(length(window_vals) > 0, arrayAvg(window_vals), nan) AS `Value` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY `Attributes`))) WHERE length(`window_vals`) >= 1
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('temperature', map('host', 'a'), toDateTime64('2025-12-31 23:58:00', 9), 1.0),
+    ('temperature', map('host', 'a'), toDateTime64('2025-12-31 23:59:00', 9), 2.0),
+    ('temperature', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 3.0);
+-- expected_rows --
+[
+  [{"host": "a"}, 2]
+]
 -- chplan --
 RangeWindow func=avg_over_time range=5m0s step=0s ts=TimeUnix value=Value groupBy=[Attributes]
   Filter predicate=(MetricName = "temperature")

--- a/test/spec/promql/edge_bool_eq.txtar
+++ b/test/spec/promql/edge_bool_eq.txtar
@@ -11,6 +11,21 @@ up == bool 1
 [7] int64 = 300000000000
 -- sql --
 SELECT ? AS `MetricName`, `Attributes`, `TimeUnix`, toFloat64((`Value` = ?)) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('up', map('instance', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 0.0);
+-- expected_rows --
+[
+  ["", {"instance": "a"}, "2026-01-01T00:00:00Z", 1],
+  ["", {"instance": "b"}, "2026-01-01T00:00:00Z", 0]
+]
 -- chplan --
 Project ["" AS MetricName, Attributes, TimeUnix, toFloat64((Value = 1)) AS Value]
   Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]

--- a/test/spec/promql/edge_bool_ge.txtar
+++ b/test/spec/promql/edge_bool_ge.txtar
@@ -11,6 +11,21 @@ up >= bool 1
 [7] int64 = 300000000000
 -- sql --
 SELECT ? AS `MetricName`, `Attributes`, `TimeUnix`, toFloat64((`Value` >= ?)) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 2.0),
+    ('up', map('instance', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 0.5);
+-- expected_rows --
+[
+  ["", {"instance": "a"}, "2026-01-01T00:00:00Z", 1],
+  ["", {"instance": "b"}, "2026-01-01T00:00:00Z", 0]
+]
 -- chplan --
 Project ["" AS MetricName, Attributes, TimeUnix, toFloat64((Value >= 1)) AS Value]
   Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]

--- a/test/spec/promql/edge_bool_le.txtar
+++ b/test/spec/promql/edge_bool_le.txtar
@@ -11,6 +11,21 @@ up <= bool 1
 [7] int64 = 300000000000
 -- sql --
 SELECT ? AS `MetricName`, `Attributes`, `TimeUnix`, toFloat64((`Value` <= ?)) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 0.5),
+    ('up', map('instance', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 2.0);
+-- expected_rows --
+[
+  ["", {"instance": "a"}, "2026-01-01T00:00:00Z", 1],
+  ["", {"instance": "b"}, "2026-01-01T00:00:00Z", 0]
+]
 -- chplan --
 Project ["" AS MetricName, Attributes, TimeUnix, toFloat64((Value <= 1)) AS Value]
   Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]

--- a/test/spec/promql/edge_bool_ne.txtar
+++ b/test/spec/promql/edge_bool_ne.txtar
@@ -11,6 +11,21 @@ up != bool 0
 [7] int64 = 300000000000
 -- sql --
 SELECT ? AS `MetricName`, `Attributes`, `TimeUnix`, toFloat64((`Value` != ?)) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('up', map('instance', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 0.0);
+-- expected_rows --
+[
+  ["", {"instance": "a"}, "2026-01-01T00:00:00Z", 1],
+  ["", {"instance": "b"}, "2026-01-01T00:00:00Z", 0]
+]
 -- chplan --
 Project ["" AS MetricName, Attributes, TimeUnix, toFloat64((Value != 0)) AS Value]
   Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]

--- a/test/spec/promql/edge_ceil_over_sum_by.txtar
+++ b/test/spec/promql/edge_ceil_over_sum_by.txtar
@@ -15,6 +15,22 @@ ceil(sum by (job) (up))
 [11] string = "job"
 -- sql --
 SELECT ? AS `MetricName`, `Attributes`, `TimeUnix`, ceil(`Value`) AS `Value` FROM (SELECT ? AS `MetricName`, mapFilter((k, v) -> v != '', map(?, `gkey_0`)) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes`[?] AS `gkey_0`, sum(`Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY `Attributes`[?]))
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api', 'instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 1.5),
+    ('up', map('job', 'api', 'instance', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 2.3),
+    ('up', map('job', 'web', 'instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 0.4);
+-- expected_rows --
+[
+  ["", {"job": "api"}, "2026-01-01T00:00:01Z", 4],
+  ["", {"job": "web"}, "2026-01-01T00:00:01Z", 1]
+]
 -- chplan --
 Project ["" AS MetricName, Attributes, TimeUnix, ceil(Value) AS Value]
   Project ["" AS MetricName, mapWithoutEmpty(map("job", gkey_0)) AS Attributes, now64(9) AS TimeUnix, Value AS Value]

--- a/test/spec/promql/edge_clamp_neg_to_pos.txtar
+++ b/test/spec/promql/edge_clamp_neg_to_pos.txtar
@@ -12,6 +12,23 @@ clamp(temperature, -100, 100)
 [8] int64 = 300000000000
 -- sql --
 SELECT ? AS `MetricName`, `Attributes`, `TimeUnix`, greatest(?, least(?, `Value`)) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('temperature', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), -150.0),
+    ('temperature', map('host', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 0.0),
+    ('temperature', map('host', 'c'), toDateTime64('2026-01-01 00:00:00', 9), 200.0);
+-- expected_rows --
+[
+  ["", {"host": "a"}, "2026-01-01T00:00:00Z", -100],
+  ["", {"host": "b"}, "2026-01-01T00:00:00Z", 0],
+  ["", {"host": "c"}, "2026-01-01T00:00:00Z", 100]
+]
 -- chplan --
 Project ["" AS MetricName, Attributes, TimeUnix, greatest(-100, least(100, Value)) AS Value]
   Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]

--- a/test/spec/promql/edge_count_over_time.txtar
+++ b/test/spec/promql/edge_count_over_time.txtar
@@ -4,6 +4,21 @@ count_over_time(up[5m])
 [0] string = "up"
 -- sql --
 SELECT `Attributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_gauge` WHERE (`MetricName` = ?)) GROUP BY `Attributes`))) WHERE length(`window_vals`) >= 1
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('instance', 'a'), toDateTime64('2025-12-31 23:58:00', 9), 1.0),
+    ('up', map('instance', 'a'), toDateTime64('2025-12-31 23:59:00', 9), 1.0),
+    ('up', map('instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 1.0);
+-- expected_rows --
+[
+  [{"instance": "a"}, 3]
+]
 -- chplan --
 RangeWindow func=count_over_time range=5m0s step=0s ts=TimeUnix value=Value groupBy=[Attributes]
   Filter predicate=(MetricName = "up")

--- a/test/spec/promql/edge_increase_at_start.txtar
+++ b/test/spec/promql/edge_increase_at_start.txtar
@@ -4,6 +4,20 @@ increase(http_requests_total[5m] @ start())
 [0] string = "http_requests_total"
 -- sql --
 SELECT `Attributes`, if(sampled_interval > 0, counter_delta * (sampled_interval + if(counter_delta > 0 AND first_val >= 0, least(duration_to_start, sampled_interval * first_val / counter_delta), duration_to_start) + duration_to_end) / sampled_interval, nan) AS `Value` FROM (SELECT `Attributes`, `window_vals`, `counter_delta`, `first_val`, toFloat64(dateDiff('nanosecond', first_ts, last_ts)) / 1e9 AS `sampled_interval`, if(toFloat64(dateDiff('nanosecond', toDateTime64('1970-01-01 00:01:40.000000000', 9) - toIntervalNanosecond(300000000000), first_ts)) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', toDateTime64('1970-01-01 00:01:40.000000000', 9) - toIntervalNanosecond(300000000000), first_ts)) / 1e9) AS `duration_to_start`, if(toFloat64(dateDiff('nanosecond', last_ts, toDateTime64('1970-01-01 00:01:40.000000000', 9))) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', last_ts, toDateTime64('1970-01-01 00:01:40.000000000', 9))) / 1e9) AS `duration_to_end` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta`, tupleElement(window_pairs[1], 1) AS `first_ts`, tupleElement(window_pairs[length(window_pairs)], 1) AS `last_ts`, tupleElement(window_pairs[1], 2) AS `first_val` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) > toDateTime64('1970-01-01 00:01:40.000000000', 9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= toDateTime64('1970-01-01 00:01:40.000000000', 9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` = ?)) GROUP BY `Attributes`)))) WHERE length(`window_vals`) >= 2
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('http_requests_total', map('job', 'api'), toDateTime64('1970-01-01 00:01:10', 9), 10.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('1970-01-01 00:01:39', 9), 40.0);
+-- expected_rows --
+[
+  [{"job": "api"}, 41.03448275862069]
+]
 -- chplan --
 RangeWindow func=increase range=5m0s step=0s ts=TimeUnix value=Value groupBy=[Attributes] start=0001-01-01T00:00:00Z end=1970-01-01T00:01:40Z
   Filter predicate=(MetricName = "http_requests_total")

--- a/test/spec/promql/edge_join_ignoring_extra.txtar
+++ b/test/spec/promql/edge_join_ignoring_extra.txtar
@@ -21,6 +21,20 @@ up * ignoring(pod) group_left(env) machine_role
 [17] string = "pod"
 -- sql --
 SELECT ? AS `MetricName`, mapConcat(L.`Attributes`, mapFilter((k, v) -> k IN (?), R.`Attributes`)) AS `Attributes`, L.`TimeUnix`, (L.`Value` * R.`Value`) AS `Value` FROM (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT `MetricName` AS `_join_MetricName`, `Attributes` AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY `MetricName`, `Attributes`)) AS L INNER JOIN (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY mapFilter((k, v) -> NOT (k IN (?)), `Attributes`))) AS R ON mapFilter((k, v) -> NOT (k IN (?)), L.`Attributes`) = mapFilter((k, v) -> NOT (k IN (?)), R.`Attributes`)
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api', 'env', 'prod', 'pod', 'p1'), toDateTime64('2026-01-01 00:00:00', 9), 4.0),
+    ('machine_role', map('job', 'api', 'env', 'prod'), toDateTime64('2026-01-01 00:00:00', 9), 2.0);
+-- expected_rows --
+[
+  ["", {"env": "prod", "job": "api", "pod": "p1"}, "2026-01-01T00:00:00Z", 8]
+]
 -- chplan --
 VectorJoin op=* match=ignoring(pod) card=many-to-one include=[env]
   Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]


### PR DESCRIPTION
## Summary

Seeds all 14 alphabetic-first-half `edge_*` PromQL fixtures so the chDB
roundtrip lane asserts the SQL emit produces the expected value per
series. Anchors timestamps to `2026-01-01` (the `nowAnchorLiteral` the
runner splices in for `now64`), `1970-01-01 00:01:40` (the `@ start()`
anchor), or `2023-11-14 22:13:20` (the `@ 1700000000` anchor) per
fixture.

## Per-fixture results

| Fixture | Shape | Result |
|---|---|---|
| `edge_abs_over_rate` | `abs(rate(...[5m]))` over counter | `0.1367816091954023` |
| `edge_at_start_range` | `rate(...[5m] @ start())` | `0.1367816091954023` |
| `edge_at_then_offset_neg` | `up @ 1700000000 offset -3m` | `1` for instance=a |
| `edge_at_timestamp_range` | `rate(...[5m] @ 1700000000)` | `0.1367816091954023` |
| `edge_avg_over_time` | mean of 1, 2, 3 | `2` |
| `edge_bool_eq` | `up == bool 1` | series straddling threshold |
| `edge_bool_ge` | `up >= bool 1` | series straddling threshold |
| `edge_bool_le` | `up <= bool 1` | series straddling threshold |
| `edge_bool_ne` | `up != bool 0` | series straddling threshold |
| `edge_ceil_over_sum_by` | `ceil(sum by(job)(up))` | `ceil(3.8)=4`, `ceil(0.4)=1` |
| `edge_clamp_neg_to_pos` | `clamp(t, -100, 100)` | `-100, 0, 100` |
| `edge_count_over_time` | three 5m samples | `3` |
| `edge_increase_at_start` | `increase(...[5m] @ start())` | `41.03448275862069` |
| `edge_join_ignoring_extra` | `up * ignoring(pod) group_left(env) machine_role` | `4*2 = 8` |

The rate and increase fixtures share Prometheus's extrapolation formula
(`counter_delta * (sampled_interval + duration_to_start + duration_to_end) / sampled_interval`),
where `duration_to_start` is clamped to `sampled_interval * first_val / counter_delta`
when the counter is positive. The 2-sample seed at `(t-29s, 10) → (t, 40)` produces
the same `0.1367816091954023` (rate 5m) / `41.03448275862069` (increase) cross-fixture.

## Test plan

- [x] `go test -tags chdb ./test/spec/promql/... -run TestRoundTripChDB` passes for all 14 fixtures
- [x] full `./test/spec/promql/...` chDB lane passes (no other-fixture regressions)
- [x] `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)