### PR TITLE
test(spec/promql): seed 11 histogram/regex/negative/scientific fixtures for chDB

### DIFF
--- a/test/spec/promql/chained_filter.txtar
+++ b/test/spec/promql/chained_filter.txtar
@@ -1,5 +1,22 @@
 -- query.promql --
 up{job="api",env!="prod"}
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api', 'env', 'prod'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('up', map('job', 'api', 'env', 'dev'), toDateTime64('2026-01-01 00:00:00', 9), 2.0),
+    ('up', map('job', 'api', 'env', 'staging'), toDateTime64('2026-01-01 00:00:00', 9), 3.0),
+    ('up', map('job', 'web', 'env', 'dev'), toDateTime64('2026-01-01 00:00:00', 9), 4.0);
+-- expected_rows --
+[
+  ["up", {"env": "dev", "job": "api"}, "2026-01-01T00:00:00Z", 2.0],
+  ["up", {"env": "staging", "job": "api"}, "2026-01-01T00:00:00Z", 3.0]
+]
 -- sql --
 SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) AND (`Attributes`[?] = ?) AND (`Attributes`[?] != ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)
 -- args --

--- a/test/spec/promql/histogram_quantile_classic_range_step.txtar
+++ b/test/spec/promql/histogram_quantile_classic_range_step.txtar
@@ -1,7 +1,39 @@
+# Range step 30s, eval window 00:00:00..00:05:00 = 11 anchors. Seed places a
+# single histogram observation at 00:00:00. The lookback predicate
+# `TimeUnix > anchor - 5m` is STRICT, so the 00:00 sample matches anchors
+# 00:00 through 04:30 (10 anchors) but NOT 05:00 (since 00:00 > 00:00 fails).
+# Sum-by-le aggregation collapses Attributes to empty map.
+# Buckets [1,2,3] with bounds [0.1,0.5,1.0]: cumsum = [1,3,6], total = 6.
+# 0.95 * 6 = 5.7. arrayFirstIndex(c->c>=5.7, [1,3,6]) = 3 = length(cumsum),
+# so the helper returns the last bound = 1.0 (Prom +Inf-bucket equivalent).
+
 -- query.promql --
 histogram_quantile(0.95, sum by(le)(rate(http_server_request_duration[5m])))
 -- range_step --
 30s
+-- seed --
+CREATE TABLE otel_metrics_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    BucketCounts Array(UInt64),
+    ExplicitBounds Array(Float64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_histogram VALUES
+    ('http_server_request_duration', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), [1, 2, 3], [0.1, 0.5, 1.0]);
+-- expected_rows --
+[
+  ["", {}, "2026-01-01T00:00:00Z", 1.0],
+  ["", {}, "2026-01-01T00:00:30Z", 1.0],
+  ["", {}, "2026-01-01T00:01:00Z", 1.0],
+  ["", {}, "2026-01-01T00:01:30Z", 1.0],
+  ["", {}, "2026-01-01T00:02:00Z", 1.0],
+  ["", {}, "2026-01-01T00:02:30Z", 1.0],
+  ["", {}, "2026-01-01T00:03:00Z", 1.0],
+  ["", {}, "2026-01-01T00:03:30Z", 1.0],
+  ["", {}, "2026-01-01T00:04:00Z", 1.0],
+  ["", {}, "2026-01-01T00:04:30Z", 1.0]
+]
 -- args --
 [0] string = ""
 [1] string = "Map(String,String)"

--- a/test/spec/promql/histogram_quantile_classic_range_step_bare.txtar
+++ b/test/spec/promql/histogram_quantile_classic_range_step_bare.txtar
@@ -1,7 +1,37 @@
+# Bare histogram quantile (no sum-by-le wrapper). Attributes flow through
+# unchanged so each (Attributes, anchor_ts) becomes its own row.
+# Two services seeded; matcher filters to service="api" only.
+# Buckets [1,2,3] / bounds [0.1,0.5,1.0]: cumsum=[1,3,6], 0.95*6=5.7,
+# arrayFirstIndex hits length -> returns 1.0.
+
 -- query.promql --
 histogram_quantile(0.95, http_server_request_duration{service="api"})
 -- range_step --
 30s
+-- seed --
+CREATE TABLE otel_metrics_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    BucketCounts Array(UInt64),
+    ExplicitBounds Array(Float64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_histogram VALUES
+    ('http_server_request_duration', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), [1, 2, 3], [0.1, 0.5, 1.0]),
+    ('http_server_request_duration', map('service', 'web'), toDateTime64('2026-01-01 00:00:00', 9), [4, 4, 2], [0.1, 0.5, 1.0]);
+-- expected_rows --
+[
+  ["", {"service": "api"}, "2026-01-01T00:00:00Z", 1.0],
+  ["", {"service": "api"}, "2026-01-01T00:00:30Z", 1.0],
+  ["", {"service": "api"}, "2026-01-01T00:01:00Z", 1.0],
+  ["", {"service": "api"}, "2026-01-01T00:01:30Z", 1.0],
+  ["", {"service": "api"}, "2026-01-01T00:02:00Z", 1.0],
+  ["", {"service": "api"}, "2026-01-01T00:02:30Z", 1.0],
+  ["", {"service": "api"}, "2026-01-01T00:03:00Z", 1.0],
+  ["", {"service": "api"}, "2026-01-01T00:03:30Z", 1.0],
+  ["", {"service": "api"}, "2026-01-01T00:04:00Z", 1.0],
+  ["", {"service": "api"}, "2026-01-01T00:04:30Z", 1.0]
+]
 -- args --
 [0] string = ""
 [1] string = "http_server_request_duration"

--- a/test/spec/promql/multiple_matchers.txtar
+++ b/test/spec/promql/multiple_matchers.txtar
@@ -1,5 +1,20 @@
 -- query.promql --
 up{job="api",env="prod"}
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api', 'env', 'prod'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('up', map('job', 'api', 'env', 'dev'), toDateTime64('2026-01-01 00:00:00', 9), 2.0),
+    ('up', map('job', 'web', 'env', 'prod'), toDateTime64('2026-01-01 00:00:00', 9), 3.0);
+-- expected_rows --
+[
+  ["up", {"env": "prod", "job": "api"}, "2026-01-01T00:00:00Z", 1.0]
+]
 -- sql --
 SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) AND (`Attributes`[?] = ?) AND (`Attributes`[?] = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)
 -- args --

--- a/test/spec/promql/negative_at.txtar
+++ b/test/spec/promql/negative_at.txtar
@@ -1,5 +1,25 @@
+# `@ 100` pins the evaluation to t=100s past the epoch (1970-01-01 00:01:40).
+# Lookback is 5m; the seed places one sample inside the window
+# (1970-01-01 00:00:30) and one outside (2026-01-01) that the @-anchor must
+# drop. The output TimeUnix is the matched sample's TimeUnix (via the LWR
+# argMax projection), not the test harness's wall-clock anchor.
+
 -- query.promql --
 up @ 100
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('instance', 'a'), toDateTime64('1970-01-01 00:00:30', 9), 1.0),
+    ('up', map('instance', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 2.0);
+-- expected_rows --
+[
+  ["up", {"instance": "a"}, "1970-01-01T00:00:30Z", 1.0]
+]
 -- sql --
 SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)
 -- args --

--- a/test/spec/promql/negative_offset.txtar
+++ b/test/spec/promql/negative_offset.txtar
@@ -1,5 +1,30 @@
+# `offset -7m` shifts the lookback FORWARD by 7m. With eval anchor
+# 2026-01-01 00:00:01 and a 5m lookback default, the effective window
+# becomes (00:02:01, 00:07:01]. Seed places samples around this band:
+# - 00:00:00 (before, outside)
+# - 00:04:00 (inside, kept)
+# - 00:06:30 (inside, kept; latest for instance 'b')
+# - 00:10:00 (after, outside)
+
 -- query.promql --
 up offset -7m
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('up', map('instance', 'a'), toDateTime64('2026-01-01 00:04:00', 9), 2.0),
+    ('up', map('instance', 'b'), toDateTime64('2026-01-01 00:06:30', 9), 3.0),
+    ('up', map('instance', 'c'), toDateTime64('2026-01-01 00:10:00', 9), 4.0);
+-- expected_rows --
+[
+  ["up", {"instance": "a"}, "2026-01-01T00:04:00Z", 2.0],
+  ["up", {"instance": "b"}, "2026-01-01T00:06:30Z", 3.0]
+]
 -- sql --
 SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= (toDateTime64(?, ?) - toIntervalNanosecond(?))) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)
 -- args --

--- a/test/spec/promql/not_regex_label.txtar
+++ b/test/spec/promql/not_regex_label.txtar
@@ -1,5 +1,22 @@
 -- query.promql --
 up{job!~"backend.*"}
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'backend-api'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('up', map('job', 'backend-worker'), toDateTime64('2026-01-01 00:00:00', 9), 2.0),
+    ('up', map('job', 'frontend'), toDateTime64('2026-01-01 00:00:00', 9), 3.0),
+    ('up', map('job', 'database'), toDateTime64('2026-01-01 00:00:00', 9), 4.0);
+-- expected_rows --
+[
+  ["up", {"job": "database"}, "2026-01-01T00:00:00Z", 4.0],
+  ["up", {"job": "frontend"}, "2026-01-01T00:00:00Z", 3.0]
+]
 -- sql --
 SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) AND NOT match(`Attributes`[?], ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)
 -- args --

--- a/test/spec/promql/offset_negative.txtar
+++ b/test/spec/promql/offset_negative.txtar
@@ -17,6 +17,25 @@
 demo_memory_usage_bytes offset -5m
 -- range_step --
 1m
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('demo_memory_usage_bytes', map('instance', 'a'), toDateTime64('2026-01-01 00:03:00', 9), 100.0),
+    ('demo_memory_usage_bytes', map('instance', 'a'), toDateTime64('2026-01-01 00:06:00', 9), 200.0);
+-- expected_rows --
+[
+  ["demo_memory_usage_bytes", {"instance": "a"}, "2026-01-01T00:00:00Z", 100.0],
+  ["demo_memory_usage_bytes", {"instance": "a"}, "2026-01-01T00:01:00Z", 200.0],
+  ["demo_memory_usage_bytes", {"instance": "a"}, "2026-01-01T00:02:00Z", 200.0],
+  ["demo_memory_usage_bytes", {"instance": "a"}, "2026-01-01T00:03:00Z", 200.0],
+  ["demo_memory_usage_bytes", {"instance": "a"}, "2026-01-01T00:04:00Z", 200.0],
+  ["demo_memory_usage_bytes", {"instance": "a"}, "2026-01-01T00:05:00Z", 200.0]
+]
 -- args --
 [0] string = "demo_memory_usage_bytes"
 [1] int64 = -300000000000

--- a/test/spec/promql/regex_alternation.txtar
+++ b/test/spec/promql/regex_alternation.txtar
@@ -1,5 +1,25 @@
+# ClickHouse `match()` is unanchored (re2). `api|web` matches the labels
+# 'api' and 'web' AND any substring containing them. Seed values are
+# chosen so the expected matches read unambiguously.
+
 -- query.promql --
 up{job=~"api|web"}
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('up', map('job', 'web'), toDateTime64('2026-01-01 00:00:00', 9), 2.0),
+    ('up', map('job', 'database'), toDateTime64('2026-01-01 00:00:00', 9), 3.0);
+-- expected_rows --
+[
+  ["up", {"job": "api"}, "2026-01-01T00:00:00Z", 1.0],
+  ["up", {"job": "web"}, "2026-01-01T00:00:00Z", 2.0]
+]
 -- sql --
 SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) AND match(`Attributes`[?], ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)
 -- args --

--- a/test/spec/promql/regex_anchored.txtar
+++ b/test/spec/promql/regex_anchored.txtar
@@ -1,5 +1,25 @@
+# Regex carries explicit ^/$ anchors. Seed includes the bare match plus
+# variants that would only pass an unanchored regex (api-v2, apiserver),
+# all of which must be filtered out by the `^api$` pattern.
+
 -- query.promql --
 up{job=~"^api$"}
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('up', map('job', 'api-v2'), toDateTime64('2026-01-01 00:00:00', 9), 2.0),
+    ('up', map('job', 'apiserver'), toDateTime64('2026-01-01 00:00:00', 9), 3.0),
+    ('up', map('job', 'web'), toDateTime64('2026-01-01 00:00:00', 9), 4.0);
+-- expected_rows --
+[
+  ["up", {"job": "api"}, "2026-01-01T00:00:00Z", 1.0]
+]
 -- sql --
 SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) AND match(`Attributes`[?], ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)
 -- args --

--- a/test/spec/promql/scientific_threshold.txtar
+++ b/test/spec/promql/scientific_threshold.txtar
@@ -1,5 +1,27 @@
+# Threshold filter Value > 1e3 (= 1000). Seed values straddle the boundary:
+# 500 (below, dropped), 999.9 (just below, dropped), 1000 (equal, dropped),
+# 1500 (above, kept), 12345.6 (above, kept).
+
 -- query.promql --
 up > 1e3
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 500.0),
+    ('up', map('instance', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 999.9),
+    ('up', map('instance', 'c'), toDateTime64('2026-01-01 00:00:00', 9), 1000.0),
+    ('up', map('instance', 'd'), toDateTime64('2026-01-01 00:00:00', 9), 1500.0),
+    ('up', map('instance', 'e'), toDateTime64('2026-01-01 00:00:00', 9), 12345.6);
+-- expected_rows --
+[
+  ["up", {"instance": "d"}, "2026-01-01T00:00:00Z", 1500.0],
+  ["up", {"instance": "e"}, "2026-01-01T00:00:00Z", 12345.6]
+]
 -- sql --
 SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) WHERE (`Value` > ?)
 -- args --


### PR DESCRIPTION
## Summary

Adds `-- seed --` + `-- expected_rows --` blocks to 11 PromQL TXTAR fixtures so each now exercises the chDB-backed round-trip lane in addition to the existing text-equality golden:

- `histogram_quantile_classic_range_step.txtar` + `_bare.txtar` (range-mode classic histogram_quantile)
- `multiple_matchers.txtar`, `chained_filter.txtar` (label-matcher combinations)
- `not_regex_label.txtar`, `regex_alternation.txtar`, `regex_anchored.txtar` (re2 matcher flavors)
- `negative_at.txtar`, `negative_offset.txtar`, `offset_negative.txtar` (`@` + signed offset)
- `scientific_threshold.txtar` (`up > 1e3`)

Each seed anchors to `2026-01-01 00:00:00` (matching the test harness's `now64` substitution at `2026-01-01 00:00:01`) and pins the actual ClickHouse query semantics that the cerberus emitter produces:

- PREWHERE-promoted `MetricName` + `Attributes[<label>]` filters
- ClickHouse `match()` is unanchored (re2) — `^api$` anchors via the regex itself, `api|web` matches both branches but also substrings; `regex_alternation` seed lists this explicitly so future readers don't get tripped up
- Negative offset / range-step window is a forward-shifted lookback `(anchor_ts, anchor_ts + 5m]`
- `@ 100` pins the eval anchor to Unix t=100s (1970-01-01 00:01:40)
- Classic histogram_quantile interpolation: cumsum `[1,3,6]`, `0.95*6=5.7`, arrayFirstIndex hits length → returns the last explicit bound (1.0)

## Test plan

- [x] `go test -tags chdb -count=1 ./test/spec/promql/... -run TestRoundTripChDB` — 249 passed
- [x] Full `go test -tags chdb ./test/spec/...` — 496 passed across 4 packages
- [x] `go test ./internal/promql/...` — 597 passed (text-equality goldens untouched)
- [x] `go build ./...` clean