### PR TITLE
test(spec/promql): seed chDB roundtrip for 14 edge j-z fixtures

### DIFF
--- a/test/spec/promql/edge_join_ignoring_group_right.txtar
+++ b/test/spec/promql/edge_join_ignoring_group_right.txtar
@@ -31,3 +31,19 @@ VectorJoin op=* match=ignoring(instance) card=one-to-many include=[env]
     Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
       Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
         Scan(otel_metrics_gauge)
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('machine_role', map('job', 'api', 'env', 'prod'), toDateTime64('2026-01-01 00:00:00', 9), 3.0),
+    ('up', map('job', 'api', 'env', 'prod', 'instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 4.0),
+    ('up', map('job', 'api', 'env', 'prod', 'instance', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 5.0);
+-- expected_rows --
+[
+  ["", {"env": "prod", "instance": "a", "job": "api"}, "2026-01-01T00:00:00Z", 12],
+  ["", {"env": "prod", "instance": "b", "job": "api"}, "2026-01-01T00:00:00Z", 15]
+]

--- a/test/spec/promql/edge_join_on_extra_labels.txtar
+++ b/test/spec/promql/edge_join_on_extra_labels.txtar
@@ -33,3 +33,17 @@ VectorJoin op=* match=on(job) card=many-to-one include=[env, region, svc]
     Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
       Filter predicate=(((MetricName = "machine_role") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
         Scan(otel_metrics_gauge)
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api', 'instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 4.0),
+    ('machine_role', map('job', 'api', 'env', 'prod', 'region', 'us-east', 'svc', 'orders'), toDateTime64('2026-01-01 00:00:00', 9), 2.0);
+-- expected_rows --
+[
+  ["", {"env": "prod", "instance": "a", "job": "api", "region": "us-east", "svc": "orders"}, "2026-01-01T00:00:00Z", 8]
+]

--- a/test/spec/promql/edge_join_on_three_keys.txtar
+++ b/test/spec/promql/edge_join_on_three_keys.txtar
@@ -40,3 +40,17 @@ VectorJoin op=* match=on(job,env,svc) card=one-to-one
     Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
       Filter predicate=(((MetricName = "machine_role") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
         Scan(otel_metrics_gauge)
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api', 'env', 'prod', 'svc', 'orders'), toDateTime64('2026-01-01 00:00:00', 9), 3.0),
+    ('machine_role', map('job', 'api', 'env', 'prod', 'svc', 'orders'), toDateTime64('2026-01-01 00:00:00', 9), 7.0);
+-- expected_rows --
+[
+  ["", {"env": "prod", "job": "api", "svc": "orders"}, "2026-01-01T00:00:00Z", 21]
+]

--- a/test/spec/promql/edge_last_over_time.txtar
+++ b/test/spec/promql/edge_last_over_time.txtar
@@ -12,3 +12,18 @@ Project ["up" AS MetricName, Attributes AS Attributes, (now64(9) - toIntervalNan
   RangeWindow func=last_over_time range=5m0s step=0s ts=TimeUnix value=Value groupBy=[Attributes]
     Filter predicate=(MetricName = "up")
       Scan(otel_metrics_gauge)
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('instance', 'a'), toDateTime64('2025-12-31 23:58:00', 9), 1.0),
+    ('up', map('instance', 'a'), toDateTime64('2025-12-31 23:59:00', 9), 2.0),
+    ('up', map('instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 3.0);
+-- expected_rows --
+[
+  ["up", {"instance": "a"}, "2025-12-31T23:59:56Z", 3]
+]

--- a/test/spec/promql/edge_log10_over_rate.txtar
+++ b/test/spec/promql/edge_log10_over_rate.txtar
@@ -9,3 +9,17 @@ Project [Attributes, log10(Value) AS Value]
   RangeWindow func=rate range=5m0s step=0s ts=TimeUnix value=Value groupBy=[Attributes]
     Filter predicate=(MetricName = "http_requests_total")
       Scan(otel_metrics_sum)
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('http_requests_total', map('job', 'api'), toDateTime64('2025-12-31 23:59:31', 9), 10.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 40.0);
+-- expected_rows --
+[
+  [{"job": "api"}, -0.8639722912260878]
+]

--- a/test/spec/promql/edge_max_over_time_subquery_step_default.txtar
+++ b/test/spec/promql/edge_max_over_time_subquery_step_default.txtar
@@ -9,3 +9,17 @@ RangeWindow func=max_over_time range=1h0m0s step=0s ts=anchor_ts value=Value gro
   RangeWindow func=rate range=5m0s step=1m0s outerRange=1h0m0s ts=TimeUnix value=Value groupBy=[Attributes]
     Filter predicate=(MetricName = "http_requests_total")
       Scan(otel_metrics_sum)
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('http_requests_total', map('job', 'api'), toDateTime64('2025-12-31 23:59:31', 9), 10.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 40.0);
+-- expected_rows --
+[
+  [{"job": "api"}, 0.1367816091954023]
+]

--- a/test/spec/promql/edge_min_over_time.txtar
+++ b/test/spec/promql/edge_min_over_time.txtar
@@ -8,3 +8,18 @@ SELECT `Attributes`, if(length(window_vals) > 0, arrayMin(window_vals), nan) AS 
 RangeWindow func=min_over_time range=10m0s step=0s ts=TimeUnix value=Value groupBy=[Attributes]
   Filter predicate=(MetricName = "temperature")
     Scan(otel_metrics_gauge)
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('temperature', map('host', 'a'), toDateTime64('2025-12-31 23:55:00', 9), 5.0),
+    ('temperature', map('host', 'a'), toDateTime64('2025-12-31 23:58:00', 9), 3.0),
+    ('temperature', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 7.0);
+-- expected_rows --
+[
+  [{"host": "a"}, 3]
+]

--- a/test/spec/promql/edge_neg_scalar_minus_vector.txtar
+++ b/test/spec/promql/edge_neg_scalar_minus_vector.txtar
@@ -17,3 +17,16 @@ Project ["" AS MetricName, Attributes, TimeUnix, (-5 - Value) AS Value]
     Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
       Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
         Scan(otel_metrics_gauge)
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 3.0);
+-- expected_rows --
+[
+  ["", {"instance": "a"}, "2026-01-01T00:00:00Z", -8]
+]

--- a/test/spec/promql/edge_offset_zero.txtar
+++ b/test/spec/promql/edge_offset_zero.txtar
@@ -14,3 +14,16 @@ Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix,
   Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
     Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
       Scan(otel_metrics_gauge)
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 1.0);
+-- expected_rows --
+[
+  ["up", {"instance": "a"}, "2026-01-01T00:00:00Z", 1]
+]

--- a/test/spec/promql/edge_paren_chain_arith.txtar
+++ b/test/spec/promql/edge_paren_chain_arith.txtar
@@ -23,3 +23,16 @@ Project ["" AS MetricName, Attributes, TimeUnix, (Value / 3) AS Value]
         Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
           Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
             Scan(otel_metrics_gauge)
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 4.0);
+-- expected_rows --
+[
+  ["", {"instance": "a"}, "2026-01-01T00:00:00Z", 3]
+]

--- a/test/spec/promql/edge_rate_negative_offset.txtar
+++ b/test/spec/promql/edge_rate_negative_offset.txtar
@@ -8,3 +8,17 @@ SELECT `Attributes`, if(sampled_interval > 0, counter_delta * (sampled_interval 
 RangeWindow func=rate range=5m0s step=0s offset=-3m0s ts=TimeUnix value=Value groupBy=[Attributes]
   Filter predicate=(MetricName = "http_requests_total")
     Scan(otel_metrics_sum)
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:02:31', 9), 10.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:03:00', 9), 40.0);
+-- expected_rows --
+[
+  [{"job": "api"}, 0.1367816091954023]
+]

--- a/test/spec/promql/edge_round_step_half.txtar
+++ b/test/spec/promql/edge_round_step_half.txtar
@@ -18,3 +18,16 @@ Project ["" AS MetricName, Attributes, TimeUnix, (round((Value / 0.5)) * 0.5) AS
     Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
       Filter predicate=(((MetricName = "temperature") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
         Scan(otel_metrics_gauge)
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('temperature', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 3.7);
+-- expected_rows --
+[
+  ["", {"host": "a"}, "2026-01-01T00:00:00Z", 3.5]
+]

--- a/test/spec/promql/edge_sqrt_over_aggregate.txtar
+++ b/test/spec/promql/edge_sqrt_over_aggregate.txtar
@@ -21,3 +21,17 @@ Project ["" AS MetricName, Attributes, TimeUnix, sqrt(Value) AS Value]
         Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
           Filter predicate=(((MetricName = "latency_seconds") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
             Scan(otel_metrics_gauge)
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('latency_seconds', map('endpoint', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 9.0),
+    ('latency_seconds', map('endpoint', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 16.0);
+-- expected_rows --
+[
+  ["", {}, "2026-01-01T00:00:01Z", 3.5355339059327378]
+]

--- a/test/spec/promql/edge_subquery_nested.txtar
+++ b/test/spec/promql/edge_subquery_nested.txtar
@@ -9,3 +9,16 @@ RangeWindow func=max_over_time range=1h0m0s step=0s ts=anchor_ts value=Value gro
   RangeWindow func=avg_over_time range=5m0s step=5m0s outerRange=1h0m0s ts=TimeUnix value=Value groupBy=[Attributes]
     Filter predicate=(MetricName = "up")
       Scan(otel_metrics_gauge)
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 42.0);
+-- expected_rows --
+[
+  [{"instance": "a"}, 42]
+]


### PR DESCRIPTION
## Summary

Seeds all 14 alphabetic-second-half `edge_*` PromQL fixtures so the chDB
roundtrip lane asserts the SQL emit produces the expected value per
series. Anchors timestamps to `2026-01-01` (the `nowAnchorLiteral` the
runner splices in for `now64`).

Continues the seeding workstream after PR #508 (edge a-i) and #509
(histogram/regex/negative/scientific): all 14 fixtures here cover
binary-op label matching, range functions, arithmetic over rates/aggregates,
subqueries with explicit/default steps, and offset semantics with explicit
zero and negative values.

## Per-fixture cells

- `edge_join_ignoring_group_right` — `machine_role * ignoring(instance) group_right(env) up` with matching `{job=api, env=prod}` on both sides, R-driven many-side fan-out by `instance` → `3 * (4, 5) = (12, 15)`.
- `edge_join_on_extra_labels` — `up * on(job) group_left(env, region, svc) machine_role` → L keeps `instance`, gets `env`/`region`/`svc` from R, value `4 * 2 = 8`.
- `edge_join_on_three_keys` — `up * on(job, env, svc) machine_role` one-to-one matching on all three → `3 * 7 = 21`.
- `edge_last_over_time` — 3 monotonic samples; `last_over_time` returns last value 3 at synthesized TimeUnix (`now - 5ns offset = 2025-12-31 23:59:56`).
- `edge_log10_over_rate` — same `0.1367816...` rate seed pattern as #508's `abs_over_rate` → `log10(0.1367816) ≈ -0.864`.
- `edge_max_over_time_subquery_step_default` — rate seed positioned at the late anchors → max across the [1h:] subquery anchors picks the same `0.1367816091954023`.
- `edge_min_over_time` — three samples (5, 3, 7) over the 10m window → min 3.
- `edge_neg_scalar_minus_vector` — `up=3` → `-5 - 3 = -8`.
- `edge_offset_zero` — `up offset 0s` identity, returns 1.
- `edge_paren_chain_arith` — `((4*2)+1)/3 = 3`.
- `edge_rate_negative_offset` — forward-shifted window (`now+3m`) with samples at `00:02:31 / 00:03:00`; same 30-delta-over-29s shape → `0.1367816091954023`.
- `edge_round_step_half` — `round(3.7, 0.5) = round(3.7/0.5)*0.5 = 7*0.5 = 3.5`.
- `edge_sqrt_over_aggregate` — `avg(9, 16) = 12.5` → `sqrt(12.5) ≈ 3.5355339059327378`.
- `edge_subquery_nested` — `max_over_time(avg_over_time(up[5m])[1h:5m])` with one sample at value 42 → max across anchors = 42.

## Test plan

- [x] `go test -tags chdb ./test/spec/promql/... -run TestRoundTripChDB -v` passes (249 tests).
- [x] `go build ./...` clean.
- [x] `go test ./internal/promql/...` clean (597 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)