### PR TITLE
test(spec/promql): seed chDB roundtrip for up family + vector_promotes fixtures

### DIFF
--- a/test/spec/promql/up.txtar
+++ b/test/spec/promql/up.txtar
@@ -1,5 +1,20 @@
 -- query.promql --
 up
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('up', map('instance', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 0.0);
+-- expected_rows --
+[
+  ["up", {"instance": "a"}, "2026-01-01T00:00:00Z", 1],
+  ["up", {"instance": "b"}, "2026-01-01T00:00:00Z", 0]
+]
 -- args --
 [0] string = "up"
 [1] string = "2026-01-01 00:00:01.000000000"

--- a/test/spec/promql/up_at_offset_combined.txtar
+++ b/test/spec/promql/up_at_offset_combined.txtar
@@ -1,5 +1,18 @@
 -- query.promql --
 up @ 1640995200 offset 5m
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('instance', 'a'), toDateTime64('2021-12-31 23:55:00', 9), 1.0);
+-- expected_rows --
+[
+  ["up", {"instance": "a"}, "2021-12-31T23:55:00Z", 1]
+]
 -- sql --
 SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= (toDateTime64(?, ?) - toIntervalNanosecond(?))) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)
 -- args --

--- a/test/spec/promql/up_at_timestamp.txtar
+++ b/test/spec/promql/up_at_timestamp.txtar
@@ -1,5 +1,18 @@
 -- query.promql --
 up @ 1640995200
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('instance', 'a'), toDateTime64('2022-01-01 00:00:00', 9), 1.0);
+-- expected_rows --
+[
+  ["up", {"instance": "a"}, "2022-01-01T00:00:00Z", 1]
+]
 -- sql --
 SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)
 -- args --

--- a/test/spec/promql/up_gt_threshold.txtar
+++ b/test/spec/promql/up_gt_threshold.txtar
@@ -1,5 +1,22 @@
 -- query.promql --
 up > 0.5
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 0.0),
+    ('up', map('instance', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 0.5),
+    ('up', map('instance', 'c'), toDateTime64('2026-01-01 00:00:00', 9), 0.75),
+    ('up', map('instance', 'd'), toDateTime64('2026-01-01 00:00:00', 9), 1.0);
+-- expected_rows --
+[
+  ["up", {"instance": "c"}, "2026-01-01T00:00:00Z", 0.75],
+  ["up", {"instance": "d"}, "2026-01-01T00:00:00Z", 1]
+]
 -- sql --
 SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) WHERE (`Value` > ?)
 -- args --

--- a/test/spec/promql/up_ne_zero.txtar
+++ b/test/spec/promql/up_ne_zero.txtar
@@ -1,5 +1,21 @@
 -- query.promql --
 up != 0
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 0.0),
+    ('up', map('instance', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('up', map('instance', 'c'), toDateTime64('2026-01-01 00:00:00', 9), 2.5);
+-- expected_rows --
+[
+  ["up", {"instance": "b"}, "2026-01-01T00:00:00Z", 1],
+  ["up", {"instance": "c"}, "2026-01-01T00:00:00Z", 2.5]
+]
 -- sql --
 SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) WHERE (`Value` != ?)
 -- args --

--- a/test/spec/promql/up_offset_5m.txtar
+++ b/test/spec/promql/up_offset_5m.txtar
@@ -1,5 +1,18 @@
 -- query.promql --
 up offset 5m
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('instance', 'a'), toDateTime64('2025-12-31 23:55:00', 9), 1.0);
+-- expected_rows --
+[
+  ["up", {"instance": "a"}, "2025-12-31T23:55:00Z", 1]
+]
 -- sql --
 SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= (toDateTime64(?, ?) - toIntervalNanosecond(?))) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)
 -- args --

--- a/test/spec/promql/up_with_label.txtar
+++ b/test/spec/promql/up_with_label.txtar
@@ -1,5 +1,20 @@
 -- query.promql --
 up{job="api"}
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api', 'instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('up', map('job', 'web', 'instance', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 0.0),
+    ('up', map('job', 'db', 'instance', 'c'), toDateTime64('2026-01-01 00:00:00', 9), 1.0);
+-- expected_rows --
+[
+  ["up", {"instance": "a", "job": "api"}, "2026-01-01T00:00:00Z", 1]
+]
 -- args --
 [0] string = "up"
 [1] string = "job"

--- a/test/spec/promql/up_with_regex.txtar
+++ b/test/spec/promql/up_with_regex.txtar
@@ -1,5 +1,22 @@
 -- query.promql --
 up{job=~"api-.*"}
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api-foo'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('up', map('job', 'api-bar'), toDateTime64('2026-01-01 00:00:00', 9), 0.0),
+    ('up', map('job', 'web'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('up', map('job', 'db'), toDateTime64('2026-01-01 00:00:00', 9), 1.0);
+-- expected_rows --
+[
+  ["up", {"job": "api-bar"}, "2026-01-01T00:00:00Z", 0],
+  ["up", {"job": "api-foo"}, "2026-01-01T00:00:00Z", 1]
+]
 -- args --
 [0] string = "up"
 [1] string = "job"

--- a/test/spec/promql/vector_promotes_scalar.txtar
+++ b/test/spec/promql/vector_promotes_scalar.txtar
@@ -1,5 +1,16 @@
 -- query.promql --
 vector(42)
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- expected_rows --
+[
+  ["", {}, "2026-01-01T00:00:01Z", 42]
+]
 -- args --
 [0] string = ""
 [1] string = "Map(String,String)"

--- a/test/spec/promql/vector_promotes_time.txtar
+++ b/test/spec/promql/vector_promotes_time.txtar
@@ -1,5 +1,16 @@
 -- query.promql --
 vector(time())
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- expected_rows --
+[
+  ["", {}, "2026-01-01T00:00:01Z", 1767225601]
+]
 -- args --
 [0] string = ""
 [1] string = "Map(String,String)"


### PR DESCRIPTION
## Summary
- Adds `-- seed --` + `-- expected_rows --` blocks to all 10 remaining PromQL fixtures in the `up_*` family and the `vector_promotes_*` pair so the chDB-backed round-trip lane asserts the SQL emit produces the expected value per series.
- Anchors instant-mode windows to the runner's `nowAnchorLiteral` (`2026-01-01 00:00:01`) and the `@`-pinned fixtures to `2022-01-01 00:00:00` (= 1640995200), with samples placed inside each computed window.
- `vector_promotes_time` pins the materialized Unix-timestamp value (1767225601) so the wall-clock projection through `now64(...)` collapses to a deterministic row.

### Per-fixture rationale
- `up`: two instances inside the 5m lookback at the anchor minute (1.0 and 0.0), both kept.
- `up_with_label`: three jobs (api, web, db); matcher selects only `api`.
- `up_with_regex`: four jobs straddling `api-.*` (api-foo, api-bar kept; web, db dropped).
- `up_gt_threshold`: four values straddling 0.5 (0, 0.5 dropped; 0.75, 1.0 kept).
- `up_ne_zero`: three values straddling 0 (0 dropped; 1.0, 2.5 kept).
- `up_offset_5m`: window shifted back 5m, sample at `2025-12-31 23:55:00`.
- `up_at_timestamp`: anchor pinned to `2022-01-01 00:00:00`, sample at the anchor.
- `up_at_offset_combined`: anchor `2022-01-01` + 5m offset, sample at `2021-12-31 23:55:00`.
- `vector_promotes_scalar`: `vector(42)` against empty table -> `("", {}, anchor, 42)`.
- `vector_promotes_time`: `vector(time())` -> `("", {}, anchor, 1767225601)`.

## Test plan
- [x] `go test -tags chdb ./test/spec/promql/... -run "TestRoundTripChDB/up|TestRoundTripChDB/vector_promotes"` passes locally (22/22 subtests).
- [x] `go build ./...` clean.
- [x] `go test ./internal/promql/... -run TestLower` still passes (356/356).
- [ ] CI `check` + `lint` green.

Refs #75. Cluster follow-up after #506-#509.