### PR TITLE
chore(api): log deferred Close errors instead of discarding

### DIFF
--- a/internal/api/loki/tail.go
+++ b/internal/api/loki/tail.go
@@ -136,12 +136,19 @@ func (h *Handler) handleTail(w http.ResponseWriter, r *http.Request) {
 		h.Logger.Warn("cerberus loki tail upgrade failed", "err", err)
 		return
 	}
-	defer func() { _ = conn.Close() }()
+	defer func() {
+		if err := conn.Close(); err != nil {
+			h.Logger.Warn("cerberus loki tail: websocket close failed", "err", err)
+		}
+	}()
 
 	tx, err := postProcessExtract(expr)
 	if err != nil {
 		// postProcessExtract failure on a log-stream query is unexpected
 		// (the pipeline parsed fine above); send an error frame and exit.
+		// The write error (if any) is intentionally discarded: the
+		// connection is about to be closed by the deferred Close above,
+		// so logging a separate write failure adds noise without signal.
 		_ = conn.WriteJSON(Response{
 			Status:    "error",
 			ErrorType: ErrBadData,
@@ -257,6 +264,10 @@ func (h *Handler) runTailLoop(ctx context.Context, conn *websocket.Conn, cfg tai
 // writes the JSON frame with a bounded write deadline. Caller is
 // responsible for tearing the connection down on error.
 func writeTailChunk(conn *websocket.Conn, streams []Stream) error {
+	// SetWriteDeadline only fails if the underlying connection has
+	// already been torn down — in which case the WriteJSON below will
+	// surface the real failure to the caller. Discarding this error is
+	// intentional, not silenced.
 	_ = conn.SetWriteDeadline(time.Now().Add(tailWriteTimeout))
 	return conn.WriteJSON(tailResponse{
 		Streams:        streams,

--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -267,7 +267,9 @@ func (h *Handler) handleQueryRange(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer func() {
-		_ = cursor.Close()
+		if err := cursor.Close(); err != nil {
+			h.Logger.Warn("cerberus prom: cursor close failed", "err", err)
+		}
 	}()
 
 	result, err := matrixFromCursor(cursor, start, end, step)


### PR DESCRIPTION
## Summary

Address two LOW-severity audit-pass punch-list items where deferred `Close()` errors were silently discarded.

- `internal/api/prom/handler.go:269-273` — log `cursor.Close()` failures at `Warn`. Close-after-drain is extremely rare in practice, but a silent loss could mask connection-pool starvation, so it's worth the line.
- `internal/api/loki/tail.go:139-143` — log `conn.Close()` failures at `Warn`. WebSocket close errors happen on peer reset / network drop and are useful observability signal.
- `internal/api/loki/tail.go:145-156` — the `conn.WriteJSON` in the early-exit error-frame path stays best-effort: the deferred Close above is about to tear the connection down anyway, so a separate write-failure log adds noise without signal. Added a comment so the discard is visibly intentional rather than overlooked.
- `internal/api/loki/tail.go:266-278` — the `_ = conn.SetWriteDeadline(...)` in `writeTailChunk` stays best-effort: it only fails if the connection has already been torn down, in which case the subsequent `WriteJSON` surfaces the real failure to the caller. Added a comment to the same effect.

These were the only two `_ = *.Close()` discards in production code under `internal/api/` (a sweep turned up only test-file siblings, which are fine as-is).

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/api/prom/... ./internal/api/loki/... -count=1` — 358 tests pass
- [x] `gofumpt -w` on touched files
- [ ] CI `check` + `lint` green

Generated with [Claude Code](https://claude.com/claude-code)