### PR TITLE
fix(api/loki): align patterns response shape to upstream contract

### DIFF
--- a/internal/api/loki/conformance_test.go
+++ b/internal/api/loki/conformance_test.go
@@ -417,7 +417,8 @@ func TestConformance_LokiDetectedFieldsWire(t *testing.T) {
 
 // TestConformance_LokiPatternsWire — empty-data envelope. Cerberus
 // doesn't run pattern discovery yet; the test pins the wire-stable
-// `data:{patterns:[]}` shape.
+// `data:[]` shape (top-level array, matching upstream Loki's
+// `WriteQueryPatternsResponseJSON`).
 func TestConformance_LokiPatternsWire(t *testing.T) {
 	t.Parallel()
 
@@ -441,14 +442,14 @@ func TestConformance_LokiPatternsWire(t *testing.T) {
 				t.Fatalf("status=%d body=%s", resp.StatusCode, body)
 			}
 			var env struct {
-				Status string            `json:"status"`
-				Data   loki.PatternsData `json:"data"`
+				Status string         `json:"status"`
+				Data   []loki.Pattern `json:"data"`
 			}
 			if err := json.Unmarshal(body, &env); err != nil {
 				t.Fatalf("decode: %v", err)
 			}
-			if env.Data.Patterns == nil {
-				t.Errorf("expected non-nil Patterns slice (JSON []); got nil — body=%s", body)
+			if env.Data == nil {
+				t.Errorf("expected non-nil Data slice (JSON []); got nil — body=%s", body)
 			}
 		})
 	}

--- a/internal/api/loki/patterns.go
+++ b/internal/api/loki/patterns.go
@@ -5,19 +5,11 @@ import (
 	"net/http"
 )
 
-// PatternsData is the body of a /loki/api/v1/patterns response. Each
-// pattern is a {pattern, samples} object where samples is a slice of
-// (unix_ms, count) tuples — matching Loki's documented schema.
-//
-// Cerberus's first cut returns an empty pattern list (see handler
-// docstring for the deferral rationale). The type is concrete so we can
-// fill it in without changing the wire shape later.
-type PatternsData struct {
-	Patterns []Pattern `json:"patterns"`
-}
-
 // Pattern is one detected log-line template plus its time-bucketed
-// sample counts.
+// sample counts. The upstream Loki contract (verified against
+// `pkg/util/marshal/marshal.go:WriteQueryPatternsResponseJSON`) emits
+// each sample as a `[unix_seconds, count]` 2-tuple — the timestamp is
+// `sample.Timestamp.Unix()`, which strips the millisecond component.
 type Pattern struct {
 	Pattern string     `json:"pattern"`
 	Samples [][2]int64 `json:"samples"`
@@ -31,9 +23,14 @@ type Pattern struct {
 // beast and Grafana's pattern panel renders an empty result gracefully.
 // The endpoint exists so Grafana's panel doesn't 404; it validates the
 // caller's parameters (so a broken `query` still returns 400) and then
-// emits {status:"success", data:{patterns:[]}}. A drain3-equivalent
-// pattern miner could run over the same peek-window used by
-// /detected_fields if there's demand.
+// emits `{status:"success", data:[]}`. A drain3-equivalent pattern
+// miner could run over the same peek-window used by /detected_fields if
+// there's demand (see `docs/loki-patterns-impl-plan.md` PR B).
+//
+// Note the wire shape: `data` is a top-level array of pattern series,
+// NOT a `{patterns: [...]}` wrapper. This matches upstream Loki's
+// `WriteQueryPatternsResponseJSON` exactly so Grafana's pattern panel
+// decodes cerberus responses without any client-side compatibility shim.
 func (h *Handler) handlePatterns(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query().Get("query")
 	if q == "" {
@@ -51,6 +48,6 @@ func (h *Handler) handlePatterns(w http.ResponseWriter, r *http.Request) {
 
 	writeJSON(w, http.StatusOK, Response{
 		Status: "success",
-		Data:   PatternsData{Patterns: []Pattern{}},
+		Data:   []Pattern{},
 	})
 }

--- a/internal/api/loki/patterns_test.go
+++ b/internal/api/loki/patterns_test.go
@@ -9,13 +9,15 @@ import (
 )
 
 type patternsResponse struct {
-	Status string            `json:"status"`
-	Data   loki.PatternsData `json:"data"`
+	Status string         `json:"status"`
+	Data   []loki.Pattern `json:"data"`
 }
 
 // TestPatterns_StubResult — until the pattern-discovery subsystem
 // lands, /patterns returns success with an empty pattern list. Grafana
-// renders this gracefully (the panel just shows "no data").
+// renders this gracefully (the panel just shows "no data"). The wire
+// shape pins `data` as a top-level JSON array (not a `{patterns:[...]}`
+// wrapper) — matches upstream Loki's `WriteQueryPatternsResponseJSON`.
 func TestPatterns_StubResult(t *testing.T) {
 	t.Parallel()
 
@@ -39,8 +41,8 @@ func TestPatterns_StubResult(t *testing.T) {
 	if out.Status != "success" {
 		t.Fatalf("status=%q", out.Status)
 	}
-	if out.Data.Patterns == nil || len(out.Data.Patterns) != 0 {
-		t.Fatalf("patterns=%+v want []", out.Data.Patterns)
+	if out.Data == nil || len(out.Data) != 0 {
+		t.Fatalf("data=%+v want []", out.Data)
 	}
 }
 


### PR DESCRIPTION
## Summary

PR A of the `/loki/api/v1/patterns` implementation plan (`docs/loki-patterns-impl-plan.md`). Pure wire-format fix — no drain wire-up yet (that's PR B).

The current stub returned `{"data":{"patterns":[]}}`, but upstream Loki emits `data` as a **top-level array** of `{pattern, samples}` objects. Verified against `pkg/util/marshal/marshal.go:WriteQueryPatternsResponseJSON` in the `tsouza/loki` fork — see lines 192-233:

```go
s.WriteObjectField("data")
s.WriteArrayStart()
// ... per series:
s.WriteObjectField("samples")
s.WriteArrayStart()
for j, sample := range series.Samples {
    s.WriteArrayStart()
    s.WriteInt64(sample.Timestamp.Unix())  // <-- unix SECONDS, not ms
    s.WriteMore()
    s.WriteInt64(sample.Value)
    s.WriteArrayEnd()
    // ...
```

Changes:

- Drop the `PatternsData{Patterns: []Pattern}` wrapper struct; return `[]Pattern` directly.
- Fix the `[2]int64` comment — sample tuple is `[unix_seconds, count]`, not `[unix_ms, count]`. Upstream calls `sample.Timestamp.Unix()` which strips the ms component.
- Handler still returns the empty-array contract Grafana renders gracefully.
- Update `patterns_test.go` + `conformance_test.go` to assert the new top-level array shape.

No new functionality — drain integration lands in PR B per the docs plan.

## Test plan

- [x] `go build ./internal/api/loki/...` clean.
- [x] `go test ./internal/api/loki/... -count=1` passes (197 tests, including the updated `TestPatterns_StubResult` + `TestConformance_LokiPatternsWire`).
- [x] `gofumpt -w` on the three touched files.

Refs: `docs/loki-patterns-impl-plan.md` §3 PR A (merged via #513).

🤖 Generated with [Claude Code](https://claude.com/claude-code)