### PR TITLE
test(spec/traceql): seed chDB roundtrip for edge_chain_mixed_5 fixture

### DIFF
--- a/test/spec/traceql/edge_chain_mixed_5.txtar
+++ b/test/spec/traceql/edge_chain_mixed_5.txtar
@@ -11,6 +11,31 @@
 [7] string = "d"
 [8] string = "service.name"
 [9] string = "e"
+-- seed --
+CREATE TABLE otel_traces (
+    TraceId String,
+    SpanId String,
+    ParentSpanId String,
+    _svc String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('service.name', _svc)
+) ENGINE = Memory;
+INSERT INTO otel_traces (TraceId, SpanId, ParentSpanId, _svc) VALUES
+    ('a0000000000000000000000000000001', '0000000000000001', '',                 'a'),
+    ('a0000000000000000000000000000001', '0000000000000002', '0000000000000001', 'b'),
+    ('a0000000000000000000000000000001', '0000000000000003', '0000000000000002', 'x'),
+    ('a0000000000000000000000000000001', '0000000000000004', '0000000000000003', 'c'),
+    ('a0000000000000000000000000000001', '0000000000000005', '0000000000000004', 'd'),
+    ('a0000000000000000000000000000001', '0000000000000006', '0000000000000005', 'x'),
+    ('a0000000000000000000000000000001', '0000000000000007', '0000000000000006', 'e'),
+    ('a0000000000000000000000000000002', '0000000000000010', '',                 'e'),
+    ('a0000000000000000000000000000003', '0000000000000020', '',                 'b'),
+    ('a0000000000000000000000000000003', '0000000000000021', '0000000000000020', 'c'),
+    ('a0000000000000000000000000000003', '0000000000000022', '0000000000000021', 'd'),
+    ('a0000000000000000000000000000003', '0000000000000023', '0000000000000022', 'e');
+-- expected_rows --
+[
+  ["a0000000000000000000000000000001", "0000000000000007", "0000000000000006", "e"]
+]
 -- sql --
 SELECT R.`TraceId` AS `TraceId`, R.`SpanId` AS `SpanId`, R.`ParentSpanId` AS `ParentSpanId`, R.* EXCEPT (`TraceId`, `SpanId`, `ParentSpanId`) FROM (WITH RECURSIVE _struct_closure AS (SELECT `TraceId`, `SpanId`, `ParentSpanId`, 0 AS _depth FROM (SELECT R.`TraceId` AS `TraceId`, R.`SpanId` AS `SpanId`, R.`ParentSpanId` AS `ParentSpanId`, R.* EXCEPT (`TraceId`, `SpanId`, `ParentSpanId`) FROM (SELECT R.`TraceId` AS `TraceId`, R.`SpanId` AS `SpanId`, R.`ParentSpanId` AS `ParentSpanId`, R.* EXCEPT (`TraceId`, `SpanId`, `ParentSpanId`) FROM (WITH RECURSIVE _struct_closure AS (SELECT `TraceId`, `SpanId`, `ParentSpanId`, 0 AS _depth FROM (SELECT R.`TraceId` AS `TraceId`, R.`SpanId` AS `SpanId`, R.`ParentSpanId` AS `ParentSpanId`, R.* EXCEPT (`TraceId`, `SpanId`, `ParentSpanId`) FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) AS L INNER JOIN (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) AS R ON L.`TraceId` = R.`TraceId` AND L.`SpanId` = R.`ParentSpanId`) AS _seed UNION ALL SELECT t.`TraceId`, t.`SpanId`, t.`ParentSpanId`, c._depth + 1 FROM `otel_traces` AS t INNER JOIN _struct_closure AS c ON t.`TraceId` = c.`TraceId` AND t.`ParentSpanId` = c.`SpanId`) SELECT DISTINCT `TraceId`, `SpanId` FROM _struct_closure WHERE _depth > 0) AS L INNER JOIN (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) AS R ON L.`TraceId` = R.`TraceId` AND L.`SpanId` = R.`SpanId`) AS L INNER JOIN (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) AS R ON L.`TraceId` = R.`TraceId` AND L.`SpanId` = R.`ParentSpanId`) AS _seed UNION ALL SELECT t.`TraceId`, t.`SpanId`, t.`ParentSpanId`, c._depth + 1 FROM `otel_traces` AS t INNER JOIN _struct_closure AS c ON t.`TraceId` = c.`TraceId` AND t.`ParentSpanId` = c.`SpanId`) SELECT DISTINCT `TraceId`, `SpanId` FROM _struct_closure WHERE _depth > 0) AS L INNER JOIN (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) AS R ON L.`TraceId` = R.`TraceId` AND L.`SpanId` = R.`SpanId`
 -- chplan --


### PR DESCRIPTION
## Summary

- Completes TraceQL chDB seed coverage by adding `-- seed --` / `-- expected_rows --` blocks to `test/spec/traceql/edge_chain_mixed_5.txtar`, the last unseeded chain fixture.
- The five-hop mixed structural chain `{a} > {b} >> {c} > {d} >> {e}` (alternating direct-child and descendant operators) was the only chain fixture left over after #489 landed seeds for the three-hop ancestor/descendant trio plus the five-hop direct-child variant.
- Seed shape: one positive trace (a→b→x→c→d→x→e chain so each `>>` traverses at least one intermediate hop, exercising the `WITH RECURSIVE _struct_closure` block) + two decoy traces (orphan `e` with no chain; `b→c→d→e` chain missing the `a` ancestor) that exercise the closure's pruning.
- Exactly one row surfaces: span 07 of trace 01 (the `e` span at the end of the positive chain).

After this lands, TraceQL chDB seed coverage is 100% complete.

## Test plan

- [x] `go test -tags chdb ./test/spec/traceql/... -run TestRoundTripChDB/edge_chain_mixed_5 -v` passes
- [x] `go test -tags chdb ./test/spec/traceql/...` — all 133 chDB fixtures pass
- [x] `go test ./internal/traceql/...` — all 199 lower goldens pass (text-equality untouched)
- [x] `go build ./...` clean