### PR TITLE
feat(api/loki): train drain on peek window for /loki/api/v1/patterns

### DIFF
--- a/internal/api/loki/chaos_test.go
+++ b/internal/api/loki/chaos_test.go
@@ -25,6 +25,7 @@ import (
 type chaosQuerier struct {
 	samples      []chclient.Sample
 	stringRows   []string
+	tsLines      []chclient.TimestampedLine
 	labelSets    []map[string]string
 	statsRow     chclient.IndexStatsRow
 	volumeRows   []chclient.IndexVolumeRow
@@ -54,6 +55,14 @@ func (c *chaosQuerier) QueryStrings(_ context.Context, _ string, _ ...any) ([]st
 		return nil, c.err
 	}
 	return c.stringRows, nil
+}
+
+func (c *chaosQuerier) QueryTimestampedLines(_ context.Context, _ string, _ ...any) ([]chclient.TimestampedLine, error) {
+	c.calls.Add(1)
+	if c.err != nil {
+		return nil, c.err
+	}
+	return c.tsLines, nil
 }
 
 func (c *chaosQuerier) QueryIndexStats(_ context.Context, _ string, _ ...any) (chclient.IndexStatsRow, error) {

--- a/internal/api/loki/conformance_test.go
+++ b/internal/api/loki/conformance_test.go
@@ -524,6 +524,11 @@ func TestConformance_LokiErrorEnvelope(t *testing.T) {
 			path:     "/loki/api/v1/index/volume?query=%7Bjob%3D%22api%22%7D&start=1&end=60",
 			wantCode: http.StatusBadGateway, wantKind: loki.ErrInternal,
 		},
+		{
+			name: "502_patterns_ch_failure", stub: &stubQuerier{tsLinesErr: errors.New("ch failure")},
+			path:     "/loki/api/v1/patterns?query=%7Bjob%3D%22api%22%7D&start=1&end=60",
+			wantCode: http.StatusBadGateway, wantKind: loki.ErrInternal,
+		},
 	}
 	for _, c := range cases {
 		c := c

--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -32,6 +32,7 @@ import (
 type Querier interface {
 	Query(ctx context.Context, sql string, args ...any) ([]chclient.Sample, error)
 	QueryStrings(ctx context.Context, sql string, args ...any) ([]string, error)
+	QueryTimestampedLines(ctx context.Context, sql string, args ...any) ([]chclient.TimestampedLine, error)
 	QueryIndexStats(ctx context.Context, sql string, args ...any) (chclient.IndexStatsRow, error)
 	QueryIndexVolume(ctx context.Context, sql string, args ...any) ([]chclient.IndexVolumeRow, error)
 	QueryLabelSets(ctx context.Context, sql string, args ...any) ([]map[string]string, error)
@@ -41,8 +42,7 @@ type Querier interface {
 // it via Handler.Mount(mux). The current vertical slice covers
 // /loki/api/v1/query, /loki/api/v1/query_range, /loki/api/v1/index/stats
 // + /index/volume, plus the metadata endpoints /labels,
-// /label/<name>/values, /series, /detected_fields, /patterns (the last
-// stubbed pending its own pattern-discovery workstream).
+// /label/<name>/values, /series, /detected_fields, /patterns.
 type Handler struct {
 	Client    Querier
 	Schema    schema.Logs
@@ -91,7 +91,8 @@ func New(client Querier, s schema.Logs, logger *slog.Logger) *Handler {
 // the metadata endpoints (/labels, /label/{name}/values, /series,
 // /detected_fields, /patterns) cover what Grafana's logs UI queries to
 // populate label autocomplete, the streams chooser, and the patterns
-// panel.
+// panel. /patterns trains a drain template miner over the peek window
+// (see docs/loki-patterns-impl-plan.md § 3 PR B).
 func (h *Handler) Mount(mux *http.ServeMux) {
 	// Route every endpoint through the cerberus.queries.* counter +
 	// duration middleware. WebSocket /tail is included — a

--- a/internal/api/loki/handler_test.go
+++ b/internal/api/loki/handler_test.go
@@ -47,6 +47,11 @@ type stubQuerier struct {
 	// /series canned label-set rows.
 	labelSets    []map[string]string
 	labelSetsErr error
+
+	// /patterns canned (Timestamp, Body) tuples; drain consumes them
+	// as the peek-window training set.
+	tsLines    []chclient.TimestampedLine
+	tsLinesErr error
 }
 
 func (s *stubQuerier) Query(_ context.Context, sql string, args ...any) ([]chclient.Sample, error) {
@@ -90,6 +95,18 @@ func (s *stubQuerier) QueryStrings(_ context.Context, sql string, args ...any) (
 	s.lastSQL = sql
 	s.lastArgs = args
 	rows, err := s.stringRows, s.stringsErr
+	s.mu.Unlock()
+	if err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+func (s *stubQuerier) QueryTimestampedLines(_ context.Context, sql string, args ...any) ([]chclient.TimestampedLine, error) {
+	s.mu.Lock()
+	s.lastSQL = sql
+	s.lastArgs = args
+	rows, err := s.tsLines, s.tsLinesErr
 	s.mu.Unlock()
 	if err != nil {
 		return nil, err

--- a/internal/api/loki/patterns.go
+++ b/internal/api/loki/patterns.go
@@ -3,51 +3,219 @@ package loki
 import (
 	"errors"
 	"net/http"
+	"sort"
+	"time"
+
+	"github.com/grafana/loki/v3/pkg/logproto"
+	drainpkg "github.com/grafana/loki/v3/pkg/pattern/drain"
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/logql"
+	"github.com/tsouza/cerberus/internal/schema"
 )
+
+// defaultPatternsLineLimit caps the number of log rows the drain
+// template miner peeks at when no `line_limit` query parameter is
+// supplied. Mirrors detected_fields' default — drain's
+// `MaxAllowedLineLength` already bounds per-line cost; this caps the
+// number of lines.
+const defaultPatternsLineLimit = 1000
 
 // Pattern is one detected log-line template plus its time-bucketed
 // sample counts. The upstream Loki contract (verified against
 // `pkg/util/marshal/marshal.go:WriteQueryPatternsResponseJSON`) emits
 // each sample as a `[unix_seconds, count]` 2-tuple — the timestamp is
 // `sample.Timestamp.Unix()`, which strips the millisecond component.
+//
+// Level mirrors upstream's per-cluster `detected_level` discriminant.
+// PR B emits `""` for every cluster (one drain instance for all
+// severities, no per-level bucketing). PR C+ wires the multi-instance
+// path that splits clusters by SeverityText — see
+// `docs/loki-patterns-impl-plan.md` § 5.
 type Pattern struct {
 	Pattern string     `json:"pattern"`
+	Level   string     `json:"level"`
 	Samples [][2]int64 `json:"samples"`
 }
+
+// nilLimits satisfies drain.Limits with no per-tenant JSON tokenisation
+// hints. Cerberus is single-tenant for now; the upstream pattern
+// ingester uses this hook to tokenise specific JSON fields differently,
+// but the format passed to drain.New ignores it for FormatUnknown (the
+// generic punctuation tokeniser).
+type nilLimits struct{}
+
+func (nilLimits) PatternIngesterTokenizableJSONFields(string) []string { return nil }
 
 // handlePatterns implements GET /loki/api/v1/patterns.
 //
 // Upstream Loki 3.x exposes a pattern-discovery subsystem (drain3-style
-// log template extraction) on this endpoint. Cerberus does not run a
-// pattern-discovery algorithm itself today — the algorithm is its own
-// beast and Grafana's pattern panel renders an empty result gracefully.
-// The endpoint exists so Grafana's panel doesn't 404; it validates the
-// caller's parameters (so a broken `query` still returns 400) and then
-// emits `{status:"success", data:[]}`. A drain3-equivalent pattern
-// miner could run over the same peek-window used by /detected_fields if
-// there's demand (see `docs/loki-patterns-impl-plan.md` PR B).
+// log template extraction) on this endpoint. Cerberus mirrors that flow
+// with a per-request drain instance trained over a peek window (default
+// 1000 most-recent lines from the matched stream selector). The
+// resulting clusters are projected onto the upstream
+// `WriteQueryPatternsResponseJSON` wire shape:
 //
-// Note the wire shape: `data` is a top-level array of pattern series,
-// NOT a `{patterns: [...]}` wrapper. This matches upstream Loki's
-// `WriteQueryPatternsResponseJSON` exactly so Grafana's pattern panel
-// decodes cerberus responses without any client-side compatibility shim.
+//	{"status":"success","data":[
+//	   {"pattern":"GET /api/<_> 200","level":"","samples":[[ts,n], ...]},
+//	   ...
+//	]}
+//
+// Cerberus is stateless — every request rebuilds the drain from scratch
+// (the CLAUDE.md "No caching" rule reinforces this; drain state is a
+// per-request artefact). Determinism reduces to "feed lines in the same
+// order every time"; the SQL emits `ORDER BY Timestamp DESC LIMIT N` so
+// chDB returns rows in deterministic order.
+//
+// Level inference lands in a follow-up PR (see
+// `docs/loki-patterns-impl-plan.md` § 5). PR B trains a single drain
+// instance for all severities and emits `level:""` for every cluster;
+// Grafana's pattern panel renders both with-level and without-level
+// payloads.
 func (h *Handler) handlePatterns(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query().Get("query")
 	if q == "" {
 		writeError(w, http.StatusBadRequest, ErrBadData, errors.New("missing query parameter"))
 		return
 	}
-	if _, _, err := parseStartEnd(r); err != nil {
+	start, end, err := parseStartEnd(r)
+	if err != nil {
 		writeError(w, http.StatusBadRequest, ErrBadData, err)
 		return
 	}
-	if _, err := selectorMatchers(q); err != nil {
+	matchers, err := selectorMatchers(q)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, ErrBadData, err)
+		return
+	}
+	lineLimit, err := parsePositiveInt(r.URL.Query().Get("line_limit"), defaultPatternsLineLimit)
+	if err != nil {
 		writeError(w, http.StatusBadRequest, ErrBadData, err)
 		return
 	}
 
+	sqlStr, args, err := buildPatternsSQL(h.Schema, matchers, start, end, lineLimit)
+	if err != nil {
+		h.respondError(w, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusInternalServerError})
+		return
+	}
+	h.Logger.Debug("cerberus loki patterns", "logql", q, "sql", sqlStr, "args", args)
+
+	lines, err := h.Client.QueryTimestampedLines(r.Context(), sqlStr, args...)
+	if err != nil {
+		h.Logger.Error("cerberus loki patterns CH query failed", "err", err, "sql", sqlStr)
+		h.respondError(w, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusBadGateway})
+		return
+	}
+
+	patterns := minePatterns(lines)
+
 	writeJSON(w, http.StatusOK, Response{
 		Status: "success",
-		Data:   []Pattern{},
+		Data:   patterns,
 	})
+}
+
+// buildPatternsSQL renders:
+//
+//	SELECT `Timestamp`, `Body`
+//	FROM `otel_logs`
+//	WHERE <matchers> AND <time bounds>
+//	ORDER BY `Timestamp` DESC
+//	LIMIT <lineLimit>
+//
+// Mirrors buildDetectedFieldsSQL but projects two columns — drain needs
+// both the body and a real timestamp to bucket per-cluster samples.
+func buildPatternsSQL(s schema.Logs, matchers []*labels.Matcher, start, end time.Time, lineLimit int) (string, []any, error) {
+	sb := chsql.NewQuery().
+		Select(
+			chsql.Col(s.TimestampColumn),
+			chsql.Col(s.BodyColumn),
+		).
+		From(chsql.Col(s.LogsTable))
+
+	pred := logql.SelectorPredicate(matchers, s)
+	if pred != nil {
+		whereFrag, err := exprFrag(pred)
+		if err != nil {
+			return "", nil, err
+		}
+		sb.Where(whereFrag)
+	}
+	if !start.IsZero() {
+		sb.Where(timeBoundFrag(s.TimestampColumn, ">=", start))
+	}
+	if !end.IsZero() {
+		sb.Where(timeBoundFrag(s.TimestampColumn, "<=", end))
+	}
+	sb.OrderBy(chsql.Col(s.TimestampColumn), true).
+		Limit(int64(lineLimit))
+
+	sqlStr, args := sb.Build()
+	return sqlStr, args, nil
+}
+
+// minePatterns trains a single drain instance over the peek window and
+// projects the resulting clusters onto the upstream `[]Pattern` wire
+// shape. Returns an empty (non-nil) slice when no lines hit any cluster
+// — the JSON envelope encodes that as `data:[]`, matching upstream Loki.
+//
+// drain.New(FormatUnknown) uses the punctuation tokeniser, which is the
+// most generic of the three (JSON / logfmt / unknown) and works on
+// arbitrary log lines. Cerberus does not run DetectLogFormat on the
+// first line because that gates the tokeniser for all subsequent lines
+// — a single non-JSON / non-logfmt row in a mostly-JSON stream would
+// then break tokenisation for the rest. The punctuation tokeniser is
+// equally happy with all three shapes.
+func minePatterns(lines []chclient.TimestampedLine) []Pattern {
+	d := drainpkg.New("", drainpkg.DefaultConfig(), nilLimits{}, drainpkg.FormatUnknown, nil)
+	for _, line := range lines {
+		d.Train(line.Body, line.Timestamp.UnixNano())
+	}
+
+	clusters := d.Clusters()
+	out := make([]Pattern, 0, len(clusters))
+	for _, c := range clusters {
+		if c == nil {
+			continue
+		}
+		s := c.String()
+		if s == "" {
+			continue
+		}
+		out = append(out, Pattern{
+			Pattern: s,
+			Level:   "", // per-level bucketing lands in a follow-up PR — see plan § 5.
+			Samples: projectSamples(c.Samples()),
+		})
+	}
+	// Stable response order — drain's Clusters() return order follows
+	// LRU cache traversal, which is not deterministic across runs.
+	// Sorting by pattern string lets Grafana / tests pin on the wire
+	// shape without flake.
+	sort.Slice(out, func(i, j int) bool { return out[i].Pattern < out[j].Pattern })
+	return out
+}
+
+// projectSamples converts drain's per-cluster []*logproto.PatternSample
+// (Timestamp model.Time = millisecond, Value int64 = count) onto the
+// upstream wire shape `[][unix_seconds, count]`. Samples are sorted by
+// timestamp ascending so the response is stable across runs.
+//
+// model.Time is milliseconds-since-epoch typed as int64; its .Unix()
+// returns seconds. Upstream's WriteQueryPatternsResponseJSON calls
+// `sample.Timestamp.Unix()`, which strips the millisecond component —
+// cerberus matches that exactly.
+func projectSamples(samples []*logproto.PatternSample) [][2]int64 {
+	out := make([][2]int64, 0, len(samples))
+	for _, s := range samples {
+		if s == nil {
+			continue
+		}
+		out = append(out, [2]int64{s.Timestamp.Unix(), s.Value})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i][0] < out[j][0] })
+	return out
 }

--- a/internal/api/loki/patterns_test.go
+++ b/internal/api/loki/patterns_test.go
@@ -3,9 +3,12 @@ package loki_test
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/tsouza/cerberus/internal/api/loki"
+	"github.com/tsouza/cerberus/internal/chclient"
 )
 
 type patternsResponse struct {
@@ -13,12 +16,13 @@ type patternsResponse struct {
 	Data   []loki.Pattern `json:"data"`
 }
 
-// TestPatterns_StubResult — until the pattern-discovery subsystem
-// lands, /patterns returns success with an empty pattern list. Grafana
-// renders this gracefully (the panel just shows "no data"). The wire
-// shape pins `data` as a top-level JSON array (not a `{patterns:[...]}`
-// wrapper) — matches upstream Loki's `WriteQueryPatternsResponseJSON`.
-func TestPatterns_StubResult(t *testing.T) {
+// TestPatterns_EmptyPeekWindow — when the peek SQL returns zero rows the
+// drain miner emits no clusters and the handler returns the empty-data
+// envelope. Grafana renders this gracefully (the panel just shows "no
+// data"). The wire shape pins `data` as a top-level JSON array (not a
+// `{patterns:[...]}` wrapper) — matches upstream Loki's
+// `WriteQueryPatternsResponseJSON`.
+func TestPatterns_EmptyPeekWindow(t *testing.T) {
 	t.Parallel()
 
 	srv := newServer(&stubQuerier{})
@@ -46,6 +50,143 @@ func TestPatterns_StubResult(t *testing.T) {
 	}
 }
 
+// TestPatterns_DrainExtractsCommonTemplate — feeds the handler a peek
+// window of three structurally-equivalent HTTP request lines and asserts
+// drain collapses them into a single cluster. Drain's template format
+// substitutes `<_>` for variable tokens; the assertion is structural
+// (substring + placeholder count) rather than against an exact frozen
+// string so upstream tokeniser tweaks don't churn the test.
+func TestPatterns_DrainExtractsCommonTemplate(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
+	q := &stubQuerier{
+		tsLines: []chclient.TimestampedLine{
+			{Timestamp: base, Body: "GET /api/users/1 status=200 latency=5ms"},
+			{Timestamp: base.Add(1 * time.Second), Body: "GET /api/users/2 status=200 latency=7ms"},
+			{Timestamp: base.Add(2 * time.Second), Body: "GET /api/users/42 status=200 latency=4ms"},
+			{Timestamp: base.Add(3 * time.Second), Body: "GET /api/users/1337 status=200 latency=11ms"},
+		},
+	}
+
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL +
+		`/loki/api/v1/patterns?query=%7Bjob%3D%22api%22%7D&start=1778760000&end=1778760100`)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+
+	var out patternsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.Status != "success" {
+		t.Fatalf("status=%q", out.Status)
+	}
+	if len(out.Data) == 0 {
+		t.Fatalf("expected at least 1 pattern; got %+v", out.Data)
+	}
+	// Find the cluster carrying the GET/status-200 template — drain may
+	// emit additional micro-clusters depending on tokenisation, so we
+	// only assert that ONE of them carries the expected structure.
+	var hit *loki.Pattern
+	for i := range out.Data {
+		p := out.Data[i]
+		if strings.Contains(p.Pattern, "GET") && strings.Contains(p.Pattern, "200") {
+			hit = &p
+			break
+		}
+	}
+	if hit == nil {
+		t.Fatalf("no cluster contained both GET and 200; data=%+v", out.Data)
+	}
+	if !strings.Contains(hit.Pattern, "<_>") {
+		t.Errorf("expected variable placeholder <_> in pattern; got %q", hit.Pattern)
+	}
+	if len(hit.Samples) == 0 {
+		t.Errorf("expected at least one sample tuple; got pattern=%q samples=%+v", hit.Pattern, hit.Samples)
+	}
+	// Per upstream WriteQueryPatternsResponseJSON: each sample is
+	// [unix_seconds, count]. Sum of counts across all samples for this
+	// cluster must equal the number of trained lines (4).
+	var total int64
+	for _, s := range hit.Samples {
+		total += s[1]
+	}
+	if total != 4 {
+		t.Errorf("expected sample count sum of 4 (one per trained line); got %d", total)
+	}
+	// Sample timestamps are unix SECONDS (not ms / ns). 2026-05-14T12:00:00 UTC = 1778760000.
+	const baseUnix = 1778760000
+	for _, s := range hit.Samples {
+		if s[0] < baseUnix-86400 || s[0] > baseUnix+86400 {
+			t.Errorf("sample ts=%d out of expected window [%d ± 1d]; likely a unit mis-shift", s[0], baseUnix)
+		}
+	}
+	// Level is empty in PR B — per-cluster bucketing lands in a
+	// follow-up (see patterns.go doc + plan § 5).
+	if hit.Level != "" {
+		t.Errorf("expected empty Level in PR B; got %q", hit.Level)
+	}
+}
+
+// TestPatterns_PushesLineLimitToSQL pins the contract that the
+// `line_limit` query parameter reaches the peek SQL. The default (1000)
+// is also asserted — its presence in the SQL guards against a future
+// refactor accidentally dropping the LIMIT clause.
+func TestPatterns_PushesLineLimitToSQL(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		url       string
+		wantLimit string
+	}{
+		{
+			name:      "default line_limit",
+			url:       `/loki/api/v1/patterns?query=%7Bjob%3D%22api%22%7D&start=1717995600&end=1717999200`,
+			wantLimit: "LIMIT 1000",
+		},
+		{
+			name:      "explicit line_limit",
+			url:       `/loki/api/v1/patterns?query=%7Bjob%3D%22api%22%7D&start=1717995600&end=1717999200&line_limit=250`,
+			wantLimit: "LIMIT 250",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			q := &stubQuerier{}
+			srv := newServer(q)
+			t.Cleanup(srv.Close)
+			resp, err := http.Get(srv.URL + tc.url)
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status=%d", resp.StatusCode)
+			}
+			gotSQL := q.LastSQL()
+			if !strings.Contains(gotSQL, tc.wantLimit) {
+				t.Errorf("expected SQL to contain %q; got: %s", tc.wantLimit, gotSQL)
+			}
+			// Peek SQL must project both Timestamp and Body — drain
+			// needs the (ts, line) pair to bucket per-cluster samples.
+			if !strings.Contains(gotSQL, "`Timestamp`") || !strings.Contains(gotSQL, "`Body`") {
+				t.Errorf("expected SQL to project both Timestamp and Body; got: %s", gotSQL)
+			}
+		})
+	}
+}
+
 // TestPatterns_BadInput — missing/broken parameters still return 400
 // so a misconfigured client gets a useful error rather than a silent
 // "no data".
@@ -59,8 +200,11 @@ func TestPatterns_BadInput(t *testing.T) {
 		{"missing query", `/loki/api/v1/patterns?start=1&end=2`},
 		{"bad query", `/loki/api/v1/patterns?query=%7Bnot+a+selector`},
 		{"bad start", `/loki/api/v1/patterns?query=%7Bjob%3D%22api%22%7D&start=banana&end=2`},
+		{"bad line_limit", `/loki/api/v1/patterns?query=%7Bjob%3D%22api%22%7D&start=1&end=2&line_limit=banana`},
+		{"non-positive line_limit", `/loki/api/v1/patterns?query=%7Bjob%3D%22api%22%7D&start=1&end=2&line_limit=0`},
 	}
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			srv := newServer(&stubQuerier{})

--- a/internal/api/loki/tail_test.go
+++ b/internal/api/loki/tail_test.go
@@ -44,6 +44,11 @@ type tailStubQuerier struct {
 	// /index/volume canned response.
 	volumeRows []chclient.IndexVolumeRow
 	volumeErr  error
+
+	// /patterns canned (Timestamp, Body) tuples (unused by /tail; held
+	// to satisfy the Querier interface).
+	tsLines    []chclient.TimestampedLine
+	tsLinesErr error
 }
 
 func (s *tailStubQuerier) Query(_ context.Context, sql string, args ...any) ([]chclient.Sample, error) {
@@ -80,6 +85,12 @@ func (s *tailStubQuerier) QueryStrings(_ context.Context, _ string, _ ...any) ([
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.stringRows, s.stringsErr
+}
+
+func (s *tailStubQuerier) QueryTimestampedLines(_ context.Context, _ string, _ ...any) ([]chclient.TimestampedLine, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.tsLines, s.tsLinesErr
 }
 
 func (s *tailStubQuerier) QueryLabelSets(_ context.Context, _ string, _ ...any) ([]map[string]string, error) {

--- a/internal/chclient/client.go
+++ b/internal/chclient/client.go
@@ -258,6 +258,54 @@ func (c *Client) QueryStrings(ctx context.Context, sql string, args ...any) ([]s
 	return out, nil
 }
 
+// TimestampedLine is one (Timestamp, Body) tuple from the peek-window
+// SQL backing /loki/api/v1/patterns. The timestamp is the row's
+// DateTime64 value verbatim; the body is the raw log line. The drain
+// template miner consumes the pair via [drain.Drain.Train], which takes
+// the timestamp as unix nanoseconds.
+type TimestampedLine struct {
+	Timestamp time.Time
+	Body      string
+}
+
+// QueryTimestampedLines runs sql and decodes a (DateTime64, String)
+// two-column result set into a flat slice. Used by /loki/api/v1/patterns
+// to feed the drain template miner — drain needs both the line body and
+// a timestamp to bucket per-cluster samples.
+//
+// Guarded by the circuit breaker (see [Client] doc).
+func (c *Client) QueryTimestampedLines(ctx context.Context, sql string, args ...any) ([]TimestampedLine, error) {
+	if !c.br.allow() {
+		return nil, fmt.Errorf("chclient: query: %w", ErrCircuitOpen)
+	}
+	ctx, span := startExecuteSpan(ctx, sql)
+	defer span.End()
+	defer flushProgress(ctx)
+	rows, err := c.conn.Query(ctx, sql, args...)
+	c.br.record(err)
+	if err != nil {
+		span.RecordError(err)
+		return nil, fmt.Errorf("chclient: query: %w", err)
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+
+	var out []TimestampedLine
+	for rows.Next() {
+		var ts time.Time
+		var body string
+		if err := rows.Scan(&ts, &body); err != nil {
+			return nil, fmt.Errorf("chclient: scan: %w", err)
+		}
+		out = append(out, TimestampedLine{Timestamp: ts, Body: body})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("chclient: rows.Err: %w", err)
+	}
+	return out, nil
+}
+
 // MetricMetaRow is one row from the metadata-discovery query — a metric
 // name plus its OTel description and unit text and the cerberus-derived
 // Prom-style type (gauge / counter / histogram).

--- a/internal/chclienttest/client.go
+++ b/internal/chclienttest/client.go
@@ -185,6 +185,36 @@ func (c *Client) QueryStrings(ctx context.Context, query string, args ...any) ([
 	return out, nil
 }
 
+// QueryTimestampedLines runs sql and decodes a (DateTime64, String)
+// two-column result set into chclient.TimestampedLine tuples. Used by
+// /loki/api/v1/patterns to feed the drain template miner.
+func (c *Client) QueryTimestampedLines(ctx context.Context, query string, args ...any) ([]chclient.TimestampedLine, error) {
+	if c.err != nil {
+		return nil, c.err
+	}
+	rows, err := c.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("chclienttest: query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []chclient.TimestampedLine
+	for rows.Next() {
+		var (
+			ts   time.Time
+			body string
+		)
+		if err := rows.Scan(&ts, &body); err != nil {
+			return nil, fmt.Errorf("chclienttest: scan: %w", err)
+		}
+		out = append(out, chclient.TimestampedLine{Timestamp: ts, Body: body})
+	}
+	if err := tolerantRowsErr(rows.Err()); err != nil {
+		return nil, fmt.Errorf("chclienttest: rows.Err: %w", err)
+	}
+	return out, nil
+}
+
 // QueryLabelSets runs sql expecting a single Map(String,String) column
 // per row. The column is rewritten to toJSONString(…) and decoded back
 // on the Go side.

--- a/test/regression/goleak_test.go
+++ b/test/regression/goleak_test.go
@@ -207,6 +207,10 @@ func (s *lokiStub) QueryStrings(_ context.Context, _ string, _ ...any) ([]string
 	return nil, nil
 }
 
+func (s *lokiStub) QueryTimestampedLines(_ context.Context, _ string, _ ...any) ([]chclient.TimestampedLine, error) {
+	return nil, nil
+}
+
 func (s *lokiStub) QueryIndexStats(_ context.Context, _ string, _ ...any) (chclient.IndexStatsRow, error) {
 	return chclient.IndexStatsRow{}, nil
 }


### PR DESCRIPTION
## Summary

- Wires `grafana/loki/v3/pkg/pattern/drain` into the `/loki/api/v1/patterns` handler so the endpoint emits real log-line templates instead of the empty array PR #514 left as the placeholder shape. Per docs/loki-patterns-impl-plan.md § 3 PR B.
- Handler mirrors `handleDetectedFields`: build a peek-window SQL (default 1000 most-recent matching rows), feed each (Timestamp, Body) tuple to a per-request `drain.Drain` instance, then project the resulting clusters onto the upstream `WriteQueryPatternsResponseJSON` wire shape with `samples` carrying `[unix_seconds, count]` 2-tuples.
- New `chclient.QueryTimestampedLines` method projects two columns (`DateTime64` + `String`) into a `TimestampedLine` slice — mirrors `QueryStrings` for the metadata endpoints.

## Drain config choices

- `drain.New("", DefaultConfig(), nilLimits{}, FormatUnknown, nil)`.
- `FormatUnknown` (not `DetectLogFormat`) — picking JSON / logfmt off the first line gates the tokenizer for every subsequent line, which mis-tokenises mixed streams. The generic punctuation tokenizer handles all three shapes uniformly.
- `nilLimits.PatternIngesterTokenizableJSONFields` returns nil — only consulted under `FormatJSON`, irrelevant here.
- `*Metrics` is nil — every drain callsite is nil-guarded. A later PR can wire a non-nil `*drainpkg.Metrics` into cerberus's `telemetry` package once the endpoint demonstrates value in production.
- `DefaultConfig()` ceilings: `MaxClusters=300`, `LogClusterDepth=30`, `SimTh=0.3`, `MaxAllowedLineLength=3000` — single drain instance ⇒ ~300 cluster nodes per request, peek capped at 1000 lines.

## Handler shape

```
SELECT `Timestamp`, `Body`
FROM `otel_logs`
WHERE <matchers> AND <time bounds>
ORDER BY `Timestamp` DESC
LIMIT <line_limit>      -- default 1000, override via &line_limit=
```

Stateless per-request — no cross-request drain cache (matches the CLAUDE.md "No caching" rule). Sample timestamps converted via `sample.Timestamp.Unix()` (seconds), matching upstream `WriteQueryPatternsResponseJSON`. Clusters sorted by pattern string for deterministic response order.

## Out of scope

- Per-level bucketing (one drain instance per `SeverityText`). PR B emits `level:""` for every cluster; Grafana's pattern panel renders both shapes. Tracked as PR C+ in docs/loki-patterns-impl-plan.md § 5.
- chDB-tagged roundtrip test. PR C lands the build-tagged seed harness.

## Test plan

- [x] Unit: `TestPatterns_EmptyPeekWindow` — empty peek window ⇒ `data:[]` (non-nil empty slice).
- [x] Unit: `TestPatterns_DrainExtractsCommonTemplate` — 4 structurally-equivalent HTTP request lines collapse into a single cluster carrying the `<_>` placeholder; sum of sample counts equals the trained line count; sample timestamps are unix seconds.
- [x] Unit: `TestPatterns_PushesLineLimitToSQL` — default `LIMIT 1000` + explicit `&line_limit=250` both reach the emitted SQL; peek SQL projects both Timestamp and Body.
- [x] Unit: `TestPatterns_BadInput` — missing query / bad selector / bad start / bad line_limit / non-positive line_limit all return 400.
- [x] Conformance: `502_patterns_ch_failure` added to the error-envelope table — CH failure surfaces as 502 with the Loki error envelope.
- [x] Conformance: `TestConformance_LokiPatternsWire` continues to pass — empty peek window yields the non-nil empty `data:[]` shape.