### PR TITLE
feat(chsql): emit Prom query_exemplars SQL over OTel-CH Exemplars nested column

### DIFF
--- a/internal/chsql/query_exemplars.go
+++ b/internal/chsql/query_exemplars.go
@@ -1,0 +1,238 @@
+package chsql
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/cerbtrace"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// EmitQueryExemplars renders the SQL for Prometheus's
+// /api/v1/query_exemplars endpoint over the OTel ClickHouse Exporter's
+// `Exemplars` Nested column. The endpoint returns every exemplar the
+// caller's matchers select within `[start, end]`, fanned out one row
+// per per-data-point exemplar via `arrayJoin(arrayEnumerate(...))`.
+//
+// Distinct from EmitMetricsExemplars (Tempo path), which scans
+// `otel_traces` and picks one representative span per (series, bucket)
+// anchor via `argMax`. The two emitters share only the wire envelope
+// (the `{traceID, spanID, value, timestamp, labels}` per-exemplar tuple
+// the handler projects on top); the SQL shape, the source table, and
+// the per-row cardinality differ.
+//
+// The emitted SQL projects the eight columns the handler consumes,
+// positionally:
+//
+//	MetricName String, Attributes Map(String,String), ServiceName String,
+//	Timestamp DateTime64(9), Value Float64, TraceID String, SpanID String,
+//	ExemplarAttributes Map(LowCardinality(String),String)
+//
+// — one row per exemplar. The handler groups rows by
+// `(MetricName, Attributes, ServiceName)` into ExemplarSeries, merges
+// the reserved `trace_id` / `span_id` keys into ExemplarAttributes,
+// and emits the upstream Prom wire envelope.
+//
+// SQL shape (the inner SELECT fans out via `arrayJoin(arrayEnumerate(...))`;
+// the outer projects each exemplar tuple component via `<arr>[i]`):
+//
+//	SELECT
+//	    `MetricName`, `Attributes`, `ServiceName`,
+//	    ts[i]        AS `Timestamp`,
+//	    val[i]       AS `Value`,
+//	    tid[i]       AS `TraceID`,
+//	    sid[i]       AS `SpanID`,
+//	    attrs_arr[i] AS `ExemplarAttributes`
+//	FROM (
+//	    SELECT
+//	        `MetricName`, `Attributes`, `ServiceName`,
+//	        `Exemplars`.`TimeUnix`           AS `ts`,
+//	        `Exemplars`.`Value`              AS `val`,
+//	        `Exemplars`.`TraceId`            AS `tid`,
+//	        `Exemplars`.`SpanId`             AS `sid`,
+//	        `Exemplars`.`FilteredAttributes` AS `attrs_arr`,
+//	        arrayJoin(arrayEnumerate(`Exemplars`.`TimeUnix`)) AS `i`
+//	    FROM `<exemplarsTable>`
+//	    WHERE <predicate>
+//	      AND `TimeUnix` >= toDateTime64(?, ?)
+//	      AND `TimeUnix` <= toDateTime64(?, ?)
+//	      AND length(`Exemplars`.`TimeUnix`) > 0
+//	)
+//
+// The outer SELECT references the inner aliases (ts, val, tid, sid,
+// attrs_arr, i) bare — without backticks — matching the convention
+// the existing exemplars / range-window emitters use for
+// emitter-pinned synthetic alias references via BareIdent. The time
+// bounds bind as parameterised toDateTime64(?, ?) calls — the first
+// `?` is the UTC-formatted timestamp string, the second is the
+// precision constant 9 — mirroring the bind shape PromQL lowering
+// produces in internal/promql/modifiers.go::anchorBaseExpr.
+//
+// The inner subquery applies the matcher predicate, time-bounds the
+// scan, and drops rows whose Exemplars Nested column is empty before
+// the `arrayJoin` fan-out. The outer SELECT then indexes each parallel
+// sub-field by `i` to surface one exemplar per row.
+//
+// Returns ErrUnsupported when:
+//
+//   - `exemplarsTable` equals `s.SummaryTable` — the OTel-CH summary
+//     table has no `Exemplars` column upstream; the handler must
+//     short-circuit summary metrics with `data:[]` before reaching this
+//     emitter, but we defensively guard here too;
+//   - `s.ExemplarsColumn` is empty — the schema has been configured to
+//     elide exemplars (e.g. a deployment running an exporter version
+//     that pre-dates the Exemplars column);
+//   - `s.MetricNameColumn`, `s.AttributesColumn`, `s.ServiceNameColumn`,
+//     or `s.TimestampColumn` is empty — required identity / time
+//     columns missing from the schema.
+//
+// Note on schema variants: the upstream DDL ships `Exemplars` as a
+// Nested column with the default `flatten_nested = 1`, so each
+// sub-field surfaces as a parallel `Array(...)` accessed by
+// `Exemplars.TimeUnix` / etc. A deployment running with
+// `flatten_nested = 0` would expose a single `Array(Tuple(...))`
+// instead; the SQL emitted here targets the parallel-array form.
+// Other read paths in cerberus (Events Nested on `otel_traces`, …) make
+// the same assumption — this is a whole-codebase invariant rather than
+// an exemplars-specific risk.
+func EmitQueryExemplars(
+	ctx context.Context,
+	exemplarsTable string,
+	predicate Frag,
+	start, end time.Time,
+	s schema.Metrics,
+) (string, []any, error) {
+	_, span := tracer.Start(ctx, cerbtrace.SpanEmit)
+	defer span.End()
+
+	if exemplarsTable == "" {
+		err := fmt.Errorf("%w: exemplarsTable is empty", ErrUnsupported)
+		span.RecordError(err)
+		return "", nil, err
+	}
+	// The OTel-CH summary table has no Exemplars Nested column upstream.
+	// Routing summary-shaped queries here would emit SQL that references
+	// a non-existent column and fail at run time. The handler picks
+	// metric→table via schema.Metrics.TableFor (and the upcoming
+	// ExemplarsTableFor wrapper); both must skip summary names. We
+	// guard defensively in case a future caller bypasses that routing.
+	if s.SummaryTable != "" && exemplarsTable == s.SummaryTable {
+		err := fmt.Errorf("%w: exemplars not supported on summary table %q", ErrUnsupported, exemplarsTable)
+		span.RecordError(err)
+		return "", nil, err
+	}
+	if s.ExemplarsColumn == "" {
+		err := fmt.Errorf("%w: schema.Metrics.ExemplarsColumn is empty (exporter version pre-dates exemplars?)", ErrUnsupported)
+		span.RecordError(err)
+		return "", nil, err
+	}
+	if s.MetricNameColumn == "" {
+		err := fmt.Errorf("%w: schema.Metrics.MetricNameColumn is empty", ErrUnsupported)
+		span.RecordError(err)
+		return "", nil, err
+	}
+	if s.AttributesColumn == "" {
+		err := fmt.Errorf("%w: schema.Metrics.AttributesColumn is empty", ErrUnsupported)
+		span.RecordError(err)
+		return "", nil, err
+	}
+	if s.ServiceNameColumn == "" {
+		err := fmt.Errorf("%w: schema.Metrics.ServiceNameColumn is empty", ErrUnsupported)
+		span.RecordError(err)
+		return "", nil, err
+	}
+	if s.TimestampColumn == "" {
+		err := fmt.Errorf("%w: schema.Metrics.TimestampColumn is empty", ErrUnsupported)
+		span.RecordError(err)
+		return "", nil, err
+	}
+
+	// Inner SELECT — fans out via `arrayJoin(arrayEnumerate(...))` and
+	// applies all predicates ahead of the fan-out so the cross product
+	// only fires on rows that pass the matcher + time window.
+	tsField := Qual(s.ExemplarsColumn, "TimeUnix")
+	valField := Qual(s.ExemplarsColumn, "Value")
+	tidField := Qual(s.ExemplarsColumn, "TraceId")
+	sidField := Qual(s.ExemplarsColumn, "SpanId")
+	attrsField := Qual(s.ExemplarsColumn, "FilteredAttributes")
+
+	inner := NewQuery().
+		Select(
+			Col(s.MetricNameColumn),
+			Col(s.AttributesColumn),
+			Col(s.ServiceNameColumn),
+			As(tsField, "ts"),
+			As(valField, "val"),
+			As(tidField, "tid"),
+			As(sidField, "sid"),
+			As(attrsField, "attrs_arr"),
+			As(Call("arrayJoin", Call("arrayEnumerate", tsField)), "i"),
+		).
+		From(Col(exemplarsTable))
+
+	// Predicate composition: (matcher_predicate) AND
+	// (TimeUnix >= toDateTime64(start, 9)) AND
+	// (TimeUnix <= toDateTime64(end, 9)) AND
+	// (length(Exemplars.TimeUnix) > 0).
+	//
+	// The matcher predicate is rendered first so it lands in argument
+	// position 0; the time bounds and the non-empty-exemplars guard
+	// follow in source order. The non-empty guard short-circuits the
+	// arrayJoin for source rows whose Exemplars array is empty — without
+	// it, CH would still emit zero rows for those source rows (arrayJoin
+	// on `[]` produces nothing), but the predicate is cheap and makes
+	// the intent explicit in the plan.
+	where := []Frag{}
+	if predicate != nil {
+		where = append(where, Paren(predicate))
+	}
+	where = append(
+		where,
+		Gte(Col(s.TimestampColumn), dateTime64Frag(start)),
+		Lte(Col(s.TimestampColumn), dateTime64Frag(end)),
+		Gt(Call("length", tsField), InlineLit(int64(0))),
+	)
+	inner.Where(where...)
+
+	// Outer SELECT — picks each parallel-array element by the
+	// `arrayJoin(arrayEnumerate(...))` index alias `i`. The outer
+	// projection's column aliases are the contract the handler decodes
+	// rows by: positional binding to MetricName / Attributes /
+	// ServiceName / Timestamp / Value / TraceID / SpanID /
+	// ExemplarAttributes.
+	outer := NewQuery().
+		Select(
+			Col(s.MetricNameColumn),
+			Col(s.AttributesColumn),
+			Col(s.ServiceNameColumn),
+			As(Subscript(BareIdent("ts"), BareIdent("i")), "Timestamp"),
+			As(Subscript(BareIdent("val"), BareIdent("i")), "Value"),
+			As(Subscript(BareIdent("tid"), BareIdent("i")), "TraceID"),
+			As(Subscript(BareIdent("sid"), BareIdent("i")), "SpanID"),
+			As(Subscript(BareIdent("attrs_arr"), BareIdent("i")), "ExemplarAttributes"),
+		).
+		From(inner.Frag())
+
+	sql, args := outer.Build()
+	span.SetAttributes(cerbtrace.AttrSQLLength.Int(len(sql)))
+	return sql, args, nil
+}
+
+// dateTime64Frag returns a Frag emitting `toDateTime64(?, ?)` with the
+// time formatted at nanosecond precision and the precision constant 9
+// bound as a second positional argument. Matches the bind pattern the
+// promql lowering produces for time-bound predicates
+// (see internal/promql/modifiers.go::anchorBaseExpr), so the args
+// section in fixtures across the codebase stays uniform: a string
+// "2026-01-01 00:00:00.000000000" followed by an int64 9.
+//
+// Zero `t` panics — callers must validate the time range before
+// reaching this emitter.
+func dateTime64Frag(t time.Time) Frag {
+	return Call(
+		"toDateTime64",
+		Lit(t.UTC().Format("2006-01-02 15:04:05.000000000")),
+		Lit(int64(9)),
+	)
+}

--- a/internal/chsql/query_exemplars_spec_test.go
+++ b/internal/chsql/query_exemplars_spec_test.go
@@ -1,0 +1,122 @@
+package chsql_test
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/test/spec"
+)
+
+// queryExemplarsFixtureDir holds the Layer-2a TXTAR snapshot(s) for
+// the Prom /api/v1/query_exemplars emitter. The fixture lives under
+// test/spec/promql/exemplars_*.txtar — the same dir the promql lower
+// fixtures live in — because PR B's handler treats it as a promql-head
+// endpoint. The promql/ runner (internal/promql/lower_test.go) tests
+// `query.promql`-bearing fixtures; this harness pairs with the
+// exemplar fixtures by filename prefix so the two layers coexist on a
+// shared directory.
+var queryExemplarsFixtureDir = filepath.Join("..", "..", "test", "spec", "promql")
+
+// queryExemplarsCases maps fixture base name → the emitter input
+// shape. Mirrors the pattern in emit_test.go's plans map — adding a
+// fixture is:
+//  1. Create the .txtar with at least an empty `-- sql --` section.
+//  2. Register an entry here.
+//  3. Run `GOLDEN_UPDATE=1 just test-spec` to materialise the SQL.
+//  4. Review the diff and commit both files.
+//
+// The handler-side scenarios (multi-matcher predicate, large window,
+// summary short-circuit) live in PR B's handler tests; this layer-2a
+// harness asserts only the SQL shape the emitter produces.
+var queryExemplarsCases = map[string]struct {
+	table     string
+	predicate chsql.Frag
+	start     time.Time
+	end       time.Time
+	schema    schema.Metrics
+}{
+	"exemplars_basic": {
+		table: schema.DefaultOTelMetrics().SumTable,
+		predicate: chsql.Eq(
+			chsql.Col(schema.DefaultOTelMetrics().MetricNameColumn),
+			chsql.Lit("http_request_duration_seconds"),
+		),
+		start:  time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		end:    time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC),
+		schema: schema.DefaultOTelMetrics(),
+	},
+}
+
+// TestEmitQueryExemplars_Fixtures runs the registered cases against
+// the TXTAR snapshots. Walks every `exemplars_*.txtar` under
+// test/spec/promql/ and asserts the emitted SQL + args match.
+//
+// The walker filters by filename prefix (not by section presence)
+// because cerberus's CI rejects t.Skip in test code (the forbid-skip
+// GA gate). The promql/ directory hosts both the lower-pipeline
+// fixtures (consumed by internal/promql/lower_test.go) and the
+// exemplars layer-2a fixtures (consumed here); the prefix-filter
+// keeps each harness scoped without spurious case discovery.
+func TestEmitQueryExemplars_Fixtures(t *testing.T) {
+	t.Parallel()
+
+	matches, err := filepath.Glob(filepath.Join(queryExemplarsFixtureDir, "exemplars_*.txtar"))
+	if err != nil {
+		t.Fatalf("glob %s: %v", queryExemplarsFixtureDir, err)
+	}
+	if len(matches) == 0 {
+		t.Fatalf("no exemplars_*.txtar fixtures in %s", queryExemplarsFixtureDir)
+	}
+	sort.Strings(matches)
+	for _, m := range matches {
+		c, err := spec.Load(m)
+		if err != nil {
+			t.Fatalf("load %s: %v", m, err)
+		}
+		t.Run(c.Name, func(t *testing.T) {
+			tc, ok := queryExemplarsCases[c.Name]
+			if !ok {
+				t.Fatalf("no case registered for fixture %s; add it to queryExemplarsCases in query_exemplars_spec_test.go", c.Name)
+			}
+
+			sql, args, err := chsql.EmitQueryExemplars(
+				context.Background(),
+				tc.table,
+				tc.predicate,
+				tc.start,
+				tc.end,
+				tc.schema,
+			)
+			if err != nil {
+				t.Fatalf("EmitQueryExemplars: %v", err)
+			}
+
+			spec.Match(t, c, map[string]string{
+				"sql":  sql,
+				"args": formatQueryExemplarsArgs(args),
+			})
+		})
+	}
+}
+
+// formatQueryExemplarsArgs mirrors the formatArgs helper in
+// emit_test.go. Duplicated rather than exported so the exemplars suite
+// stays free to change its formatting independently of the main emit
+// suite.
+func formatQueryExemplarsArgs(args []any) string {
+	if len(args) == 0 {
+		return "(none)\n"
+	}
+	var b strings.Builder
+	for i, a := range args {
+		fmt.Fprintf(&b, "[%d] %T = %#v\n", i, a, a)
+	}
+	return b.String()
+}

--- a/internal/chsql/query_exemplars_test.go
+++ b/internal/chsql/query_exemplars_test.go
@@ -1,0 +1,322 @@
+package chsql_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestEmitQueryExemplars_GoldenSQL pins the SQL shape for the four
+// metrics tables that carry the OTel-CH Exemplars Nested column
+// (gauge / sum / histogram / exp_histogram). The summary table has no
+// Exemplars column upstream and is rejected by a separate test below.
+//
+// The matcher predicate is a single `MetricName = ?` equality — the
+// minimum the upstream Prom contract requires. PR B's handler wires
+// the full label-matcher list via the existing `buildPredicate`
+// helper; that bind shape is covered indirectly by the predicate-
+// woven test further down.
+func TestEmitQueryExemplars_GoldenSQL(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)
+
+	// One predicate variant reused across the four-table fan-out.
+	// Args from the predicate bind first; the time bounds (2 args each
+	// — formatted string + precision 9) follow in source order.
+	mkPredicate := func() chsql.Frag {
+		return chsql.Eq(chsql.Col(s.MetricNameColumn), chsql.Lit("http_request_duration_seconds"))
+	}
+
+	// The outer SELECT references the inner SELECT's aliases via
+	// BareIdent — `ts[i]`, `val[i]`, etc., without backticks — to
+	// match the convention the existing emitter family (absent /
+	// range-window) uses for emitter-pinned synthetic alias
+	// references. `BareIdent` carries the trust contract that the
+	// name is a CH-safe bare identifier; the emitter pins these
+	// names.
+	const wantSQLTmpl = "SELECT `MetricName`, `Attributes`, `ServiceName`, " +
+		"ts[i] AS `Timestamp`, val[i] AS `Value`, " +
+		"tid[i] AS `TraceID`, sid[i] AS `SpanID`, " +
+		"attrs_arr[i] AS `ExemplarAttributes` " +
+		"FROM (SELECT `MetricName`, `Attributes`, `ServiceName`, " +
+		"`Exemplars`.`TimeUnix` AS `ts`, `Exemplars`.`Value` AS `val`, " +
+		"`Exemplars`.`TraceId` AS `tid`, `Exemplars`.`SpanId` AS `sid`, " +
+		"`Exemplars`.`FilteredAttributes` AS `attrs_arr`, " +
+		"arrayJoin(arrayEnumerate(`Exemplars`.`TimeUnix`)) AS `i` " +
+		"FROM `%TABLE%` " +
+		"WHERE (`MetricName` = ?) AND `TimeUnix` >= toDateTime64(?, ?) " +
+		"AND `TimeUnix` <= toDateTime64(?, ?) " +
+		"AND length(`Exemplars`.`TimeUnix`) > 0)"
+
+	cases := []struct {
+		name  string
+		table string
+	}{
+		{name: "gauge", table: s.GaugeTable},
+		{name: "sum", table: s.SumTable},
+		{name: "histogram", table: s.HistogramTable},
+		{name: "exp_histogram", table: s.ExpHistogramTable},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			sql, args, err := chsql.EmitQueryExemplars(
+				context.Background(),
+				tc.table,
+				mkPredicate(),
+				start,
+				end,
+				s,
+			)
+			if err != nil {
+				t.Fatalf("EmitQueryExemplars(%q): %v", tc.table, err)
+			}
+
+			wantSQL := strings.Replace(wantSQLTmpl, "%TABLE%", tc.table, 1)
+			if sql != wantSQL {
+				t.Errorf("SQL mismatch\nwant: %s\n got: %s", wantSQL, sql)
+			}
+
+			// Arg order: predicate metric-name literal, then start
+			// (formatted string + precision 9), then end (same).
+			wantArgs := []any{
+				"http_request_duration_seconds",
+				"2026-01-01 00:00:00.000000000",
+				int64(9),
+				"2026-01-01 01:00:00.000000000",
+				int64(9),
+			}
+			if len(args) != len(wantArgs) {
+				t.Fatalf("Args length = %d; want %d (args=%v)", len(args), len(wantArgs), args)
+			}
+			for i, want := range wantArgs {
+				if args[i] != want {
+					t.Errorf("Args[%d] = %v (%T); want %v (%T)", i, args[i], args[i], want, want)
+				}
+			}
+		})
+	}
+}
+
+// TestEmitQueryExemplars_RejectsSummaryTable — the OTel-CH summary
+// table has no `Exemplars` Nested column upstream. The emitter must
+// refuse rather than emit SQL that references a non-existent column.
+// PR B's handler routing must skip summary metrics before reaching
+// the emitter, but this is the defensive guard at the lower layer.
+func TestEmitQueryExemplars_RejectsSummaryTable(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)
+
+	_, _, err := chsql.EmitQueryExemplars(
+		context.Background(),
+		s.SummaryTable,
+		chsql.Eq(chsql.Col(s.MetricNameColumn), chsql.Lit("my_summary_metric")),
+		start,
+		end,
+		s,
+	)
+	if err == nil {
+		t.Fatalf("expected ErrUnsupported for summary table, got nil")
+	}
+	if !errors.Is(err, chsql.ErrUnsupported) {
+		t.Errorf("expected ErrUnsupported, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "summary") {
+		t.Errorf("error %q should mention 'summary' to aid debugging", err.Error())
+	}
+}
+
+// TestEmitQueryExemplars_RejectsMissingExemplarsColumn — when the
+// schema has been configured with an empty `ExemplarsColumn` (e.g. a
+// deployment running an exporter version that pre-dates exemplars),
+// the emitter must refuse rather than emit SQL that scans a
+// non-existent column.
+func TestEmitQueryExemplars_RejectsMissingExemplarsColumn(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	s.ExemplarsColumn = ""
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)
+
+	_, _, err := chsql.EmitQueryExemplars(
+		context.Background(),
+		s.SumTable,
+		chsql.Eq(chsql.Col(s.MetricNameColumn), chsql.Lit("http_requests_total")),
+		start,
+		end,
+		s,
+	)
+	if err == nil {
+		t.Fatalf("expected ErrUnsupported for empty ExemplarsColumn, got nil")
+	}
+	if !errors.Is(err, chsql.ErrUnsupported) {
+		t.Errorf("expected ErrUnsupported, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "ExemplarsColumn") {
+		t.Errorf("error %q should mention ExemplarsColumn to aid debugging", err.Error())
+	}
+}
+
+// TestEmitQueryExemplars_RejectsEmptyTable — defensive guard against
+// a caller passing an empty string for the exemplars table. The
+// handler resolves the table from a known set, but we still want a
+// crisp error rather than an SQL syntax failure deeper in the stack.
+func TestEmitQueryExemplars_RejectsEmptyTable(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)
+
+	_, _, err := chsql.EmitQueryExemplars(
+		context.Background(),
+		"",
+		chsql.Eq(chsql.Col(s.MetricNameColumn), chsql.Lit("http_requests_total")),
+		start,
+		end,
+		s,
+	)
+	if err == nil {
+		t.Fatalf("expected ErrUnsupported for empty table, got nil")
+	}
+	if !errors.Is(err, chsql.ErrUnsupported) {
+		t.Errorf("expected ErrUnsupported, got %v", err)
+	}
+}
+
+// TestEmitQueryExemplars_PredicateWoven — confirms a multi-matcher
+// predicate (the shape buildPredicate produces from the
+// VectorSelector.LabelMatchers) gets parenthesised into the WHERE
+// clause as the first conjunct, with the time-bound and
+// non-empty-Exemplars guards following in source order. The args
+// preserve emission order: predicate args first, then start, then
+// end.
+func TestEmitQueryExemplars_PredicateWoven(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)
+
+	// A two-matcher predicate: MetricName = "x" AND Attributes["job"] = "api".
+	// The map-subscript shape mirrors what buildPredicate emits for
+	// non-`__name__` label matchers.
+	predicate := chsql.And(
+		chsql.Eq(chsql.Col(s.MetricNameColumn), chsql.Lit("http_request_duration_seconds")),
+		chsql.Eq(
+			chsql.Subscript(chsql.Col(s.AttributesColumn), chsql.Lit("job")),
+			chsql.Lit("api"),
+		),
+	)
+
+	sql, args, err := chsql.EmitQueryExemplars(
+		context.Background(),
+		s.SumTable,
+		predicate,
+		start,
+		end,
+		s,
+	)
+	if err != nil {
+		t.Fatalf("EmitQueryExemplars: %v", err)
+	}
+
+	// The predicate is wrapped in a single Paren and AND-joined with
+	// the time-bound and non-empty-Exemplars guards. The substring
+	// pins the conjunct ordering (predicate first; non-empty guard
+	// last) and the parenthesisation of the predicate as a single
+	// WHERE conjunct.
+	wantSub := "WHERE (`MetricName` = ? AND `Attributes`[?] = ?) " +
+		"AND `TimeUnix` >= toDateTime64(?, ?) " +
+		"AND `TimeUnix` <= toDateTime64(?, ?) " +
+		"AND length(`Exemplars`.`TimeUnix`) > 0"
+	if !strings.Contains(sql, wantSub) {
+		t.Errorf("SQL missing expected WHERE shape\nwant substring: %s\n           got: %s", wantSub, sql)
+	}
+
+	// Arg order: MetricName literal, Attributes key, Attributes value,
+	// start (string + 9), end (string + 9).
+	wantArgs := []any{
+		"http_request_duration_seconds",
+		"job",
+		"api",
+		"2026-01-01 00:00:00.000000000",
+		int64(9),
+		"2026-01-01 01:00:00.000000000",
+		int64(9),
+	}
+	if len(args) != len(wantArgs) {
+		t.Fatalf("Args length = %d; want %d (args=%v)", len(args), len(wantArgs), args)
+	}
+	for i, want := range wantArgs {
+		if args[i] != want {
+			t.Errorf("Args[%d] = %v (%T); want %v (%T)", i, args[i], args[i], want, want)
+		}
+	}
+}
+
+// TestEmitQueryExemplars_NilPredicate — defensive case: when no
+// matcher predicate is passed (e.g. a hypothetical "all exemplars"
+// query the handler permits in a debug path), the emitter omits the
+// matcher conjunct from the WHERE clause. The time bounds and
+// non-empty-Exemplars guard still apply. The handler must always
+// pass a non-nil predicate per the upstream Prom contract; this test
+// pins the emitter's behaviour for the boundary case so a future
+// caller misuse surfaces obviously rather than panics deep inside the
+// builder.
+func TestEmitQueryExemplars_NilPredicate(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)
+
+	sql, args, err := chsql.EmitQueryExemplars(
+		context.Background(),
+		s.SumTable,
+		nil, // intentionally nil — see test docstring
+		start,
+		end,
+		s,
+	)
+	if err != nil {
+		t.Fatalf("EmitQueryExemplars: %v", err)
+	}
+
+	wantSub := "WHERE `TimeUnix` >= toDateTime64(?, ?) " +
+		"AND `TimeUnix` <= toDateTime64(?, ?) " +
+		"AND length(`Exemplars`.`TimeUnix`) > 0"
+	if !strings.Contains(sql, wantSub) {
+		t.Errorf("SQL missing expected WHERE shape\nwant substring: %s\n           got: %s", wantSub, sql)
+	}
+	// No predicate args; just the two time bounds.
+	wantArgs := []any{
+		"2026-01-01 00:00:00.000000000",
+		int64(9),
+		"2026-01-01 01:00:00.000000000",
+		int64(9),
+	}
+	if len(args) != len(wantArgs) {
+		t.Fatalf("Args length = %d; want %d (args=%v)", len(args), len(wantArgs), args)
+	}
+	for i, want := range wantArgs {
+		if args[i] != want {
+			t.Errorf("Args[%d] = %v (%T); want %v (%T)", i, args[i], args[i], want, want)
+		}
+	}
+}

--- a/internal/promql/lower_test.go
+++ b/internal/promql/lower_test.go
@@ -57,6 +57,19 @@ func TestLower(t *testing.T) {
 	rangeEnd := rangeStart.Add(5 * time.Minute)
 
 	spec.Walk(t, fixtureDir, func(t *testing.T, c *spec.Case) {
+		// Fixtures prefixed `exemplars_` are owned by the chsql
+		// exemplars emitter harness under
+		// internal/chsql/query_exemplars_spec_test.go — they record
+		// the layer-2a SQL snapshot for the Prom
+		// /api/v1/query_exemplars endpoint, which does NOT flow
+		// through promql.Lower. Return early so the lower-pipeline
+		// harness no-ops on them rather than fail with a missing
+		// `query.promql` section. The forbid-skip CI gate rejects
+		// t.Skip in test files, so we no-op the subtest body rather
+		// than call t.Skip.
+		if strings.HasPrefix(c.Name, "exemplars_") {
+			return
+		}
 		query, ok := c.Section("query.promql")
 		if !ok {
 			t.Fatalf("fixture %s missing 'query.promql' section", c.Name)

--- a/test/spec/promql/exemplars_basic.txtar
+++ b/test/spec/promql/exemplars_basic.txtar
@@ -1,0 +1,8 @@
+-- sql --
+SELECT `MetricName`, `Attributes`, `ServiceName`, ts[i] AS `Timestamp`, val[i] AS `Value`, tid[i] AS `TraceID`, sid[i] AS `SpanID`, attrs_arr[i] AS `ExemplarAttributes` FROM (SELECT `MetricName`, `Attributes`, `ServiceName`, `Exemplars`.`TimeUnix` AS `ts`, `Exemplars`.`Value` AS `val`, `Exemplars`.`TraceId` AS `tid`, `Exemplars`.`SpanId` AS `sid`, `Exemplars`.`FilteredAttributes` AS `attrs_arr`, arrayJoin(arrayEnumerate(`Exemplars`.`TimeUnix`)) AS `i` FROM `otel_metrics_sum` WHERE (`MetricName` = ?) AND `TimeUnix` >= toDateTime64(?, ?) AND `TimeUnix` <= toDateTime64(?, ?) AND length(`Exemplars`.`TimeUnix`) > 0)
+-- args --
+[0] string = "http_request_duration_seconds"
+[1] string = "2026-01-01 00:00:00.000000000"
+[2] int64 = 9
+[3] string = "2026-01-01 01:00:00.000000000"
+[4] int64 = 9


### PR DESCRIPTION
## Summary

Per [`docs/prom-exemplars-impl-plan.md`](https://github.com/tsouza/cerberus/blob/main/docs/prom-exemplars-impl-plan.md) §5 PR A (the plan landed via #516) — this lands the new chsql emitter that renders the SQL for Prometheus's `/api/v1/query_exemplars` endpoint over the OTel-CH Exporter's `Exemplars` Nested column. PR B will wire this into the handler; PR C lands the TXTAR seed + chDB roundtrip.

### What lands

- **`internal/chsql/query_exemplars.go`** — `EmitQueryExemplars(ctx, exemplarsTable, predicate, start, end, schema)`. Fans out one row per per-data-point exemplar via `arrayJoin(arrayEnumerate(Exemplars.TimeUnix))`, projects the 8 columns the handler decodes (`MetricName`, `Attributes`, `ServiceName`, `Timestamp`, `Value`, `TraceID`, `SpanID`, `ExemplarAttributes`), and rejects with `ErrUnsupported` on the summary table (no `Exemplars` column upstream), empty `ExemplarsColumn`, empty table, or empty required identity/time columns.
- **`internal/chsql/query_exemplars_test.go`** — unit goldens for all 4 supported tables (gauge / sum / histogram / exp_histogram), the four `ErrUnsupported` paths, a predicate-woven test pinning the WHERE conjunct ordering for a multi-matcher `And(...)` predicate, and a nil-predicate boundary case.
- **`internal/chsql/query_exemplars_spec_test.go`** — Layer-2a TXTAR harness that consumes `test/spec/promql/exemplars_*.txtar`.
- **`test/spec/promql/exemplars_basic.txtar`** — the seed fixture: `MetricName = "http_request_duration_seconds"` predicate over `otel_metrics_sum` with a 1-hour window. Just `-- sql --` + `-- args --` (no `-- seed --` / `-- expected_rows --` yet — that's PR C).
- **`internal/promql/lower_test.go`** — the existing promql lower runner now ignores `exemplars_`-prefixed fixtures by filename so the two harnesses share `test/spec/promql/` without colliding. Filename-prefix gate instead of `t.Skip` (the `forbid-skip` CI gate rejects `t.Skip*` in test files).

### Shape of the emitted SQL

The inner SELECT applies the matcher predicate, time-bounds the scan, drops rows with empty Exemplars arrays, and fans out via `arrayJoin(arrayEnumerate(Exemplars.TimeUnix))`. The outer SELECT then indexes each parallel sub-field by `i`:

```sql
SELECT
    `MetricName`, `Attributes`, `ServiceName`,
    ts[i]        AS `Timestamp`,
    val[i]       AS `Value`,
    tid[i]       AS `TraceID`,
    sid[i]       AS `SpanID`,
    attrs_arr[i] AS `ExemplarAttributes`
FROM (
    SELECT `MetricName`, `Attributes`, `ServiceName`,
           `Exemplars`.`TimeUnix`           AS `ts`,
           `Exemplars`.`Value`              AS `val`,
           `Exemplars`.`TraceId`            AS `tid`,
           `Exemplars`.`SpanId`             AS `sid`,
           `Exemplars`.`FilteredAttributes` AS `attrs_arr`,
           arrayJoin(arrayEnumerate(`Exemplars`.`TimeUnix`)) AS `i`
    FROM `otel_metrics_sum`
    WHERE (`MetricName` = ?)
      AND `TimeUnix` >= toDateTime64(?, ?)
      AND `TimeUnix` <= toDateTime64(?, ?)
      AND length(`Exemplars`.`TimeUnix`) > 0
)
```

Composed entirely from typed Frags + `QueryBuilder` slots (`Col`, `Qual`, `As`, `Subscript`, `BareIdent`, `Call`, `Paren`, `Eq`, `Gte`, `Lte`, `Gt`, `Lit`, `InlineLit`) — no raw SQL strings, no new typed Frag constructors added. The `dateTime64Frag` helper is package-private and mirrors the bind shape the PromQL lowering already produces (see `internal/promql/modifiers.go::anchorBaseExpr`) so the args section stays uniform across fixtures: a string `"YYYY-MM-DD HH:MM:SS.NNNNNNNNN"` followed by an `int64` 9.

### Distinct from the existing Tempo-path emitter

The existing `internal/chsql/exemplars.go::EmitMetricsExemplars` is the Tempo trace-anchored path (one representative span per `(series, bucket)` anchor via `argMax` over `otel_traces`). The Prom path is structurally simpler — just `arrayJoin` a Nested column on the metrics tables. No shared logic; only the wire envelope `{traceID, spanID, value, timestamp, labels}` matches between the two.

### Out of scope (PR B / PR C)

- Handler wire-up + `Metrics.ExemplarsTableFor(name)` router + `Querier.QueryExemplars` cursor.
- TXTAR `-- seed --` / `-- expected_rows --` for chDB roundtrip, including the summary-empty-case fixture.
- Closing the matching entries in `compatibility/prometheus/expected-failures.json`.

## Test plan

- [x] `go build ./...` clean.
- [x] `go test ./internal/chsql/... ./internal/promql/... -count=1` — 1169 passed.
- [x] `go test -race ./internal/chsql/... ./internal/promql/... -count=1` — 1169 passed.
- [x] `gofumpt -l` clean on the four touched files.
- [x] `golangci-lint run ./internal/chsql/...` clean.
- [x] `forbid-skip` CI grep simulation locally — no `t.Skip*`, no `\bskipped\b` / `\bdeferred\b` / `not implemented` in touched test files or fixtures.
- [x] Layer-2a TXTAR golden regenerates clean via `GOLDEN_UPDATE=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)