### PR TITLE
fix(chclienttest): add QueryExemplars stub to satisfy prom.Querier under -tags chdb

### DIFF
--- a/internal/chclienttest/client.go
+++ b/internal/chclienttest/client.go
@@ -215,6 +215,60 @@ func (c *Client) QueryTimestampedLines(ctx context.Context, query string, args .
 	return out, nil
 }
 
+// QueryExemplars runs sql expecting the 8-column shape EmitQueryExemplars
+// projects (MetricName, Attributes, ServiceName, Timestamp, Value,
+// TraceID, SpanID, ExemplarAttributes). Used by /api/v1/query_exemplars.
+// Map(String,String) columns are wrapped server-side in toJSONString(...)
+// by rewriteMapProjections and decoded back on the Go side per the chDB
+// driver Map-panic probe.
+func (c *Client) QueryExemplars(ctx context.Context, query string, args ...any) ([]chclient.ExemplarRow, error) {
+	if c.err != nil {
+		return nil, c.err
+	}
+	rewritten := rewriteMapProjections(query)
+	rows, err := c.db.QueryContext(ctx, rewritten, args...)
+	if err != nil {
+		return nil, fmt.Errorf("chclienttest: query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []chclient.ExemplarRow
+	for rows.Next() {
+		var (
+			r           chclient.ExemplarRow
+			attrsJSON   string
+			exAttrsJSON string
+		)
+		if err := rows.Scan(
+			&r.MetricName,
+			&attrsJSON,
+			&r.ServiceName,
+			&r.Timestamp,
+			&r.Value,
+			&r.TraceID,
+			&r.SpanID,
+			&exAttrsJSON,
+		); err != nil {
+			return nil, fmt.Errorf("chclienttest: scan: %w", err)
+		}
+		attrs, err := decodeMapJSON(attrsJSON)
+		if err != nil {
+			return nil, err
+		}
+		exAttrs, err := decodeMapJSON(exAttrsJSON)
+		if err != nil {
+			return nil, err
+		}
+		r.Attributes = attrs
+		r.ExemplarAttributes = exAttrs
+		out = append(out, r)
+	}
+	if err := tolerantRowsErr(rows.Err()); err != nil {
+		return nil, fmt.Errorf("chclienttest: rows.Err: %w", err)
+	}
+	return out, nil
+}
+
 // QueryLabelSets runs sql expecting a single Map(String,String) column
 // per row. The column is rewritten to toJSONString(…) and decoded back
 // on the Go side.


### PR DESCRIPTION
## Summary

PR #520 added \`QueryExemplars\` to the \`prom.Querier\` interface (the handler wire-up). The \`internal/chclienttest.Client\` test-double needs the matching method or the chdb-tagged build fails on the interface-assertion at \`internal/chclienttest/interfaces_test.go:17\` plus \`internal/api/prom/handler_chdb_test.go\`. The probe job on #520 caught this but isn't a required check, so #520 merged.

Add the stub: same shape as the existing \`QueryStrings\` / \`QueryTimestampedLines\` / \`QueryLabelSets\` methods, scanning the 8-column \`EmitQueryExemplars\` projection (MetricName, Attributes, ServiceName, Timestamp, Value, TraceID, SpanID, ExemplarAttributes). Uses \`rewriteMapProjections\` to wrap the Map columns server-side in \`toJSONString(…)\` and \`decodeMapJSON\` on the Go side — matches the chDB driver Map-panic probe.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go build -tags chdb ./...\` clean (this is the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)