### PR TITLE
fix(harness/loki-compat): seed stream labels into ResourceAttributes

### DIFF
--- a/compatibility/loki/cmd/seed/main.go
+++ b/compatibility/loki/cmd/seed/main.go
@@ -474,20 +474,37 @@ func insertCHLogs(ctx context.Context, conn driver.Conn, streams []stream) error
 	}
 
 	for _, s := range streams {
+		// resourceAttrs carries the stream-identity labels — the same nine
+		// keys the seeder hands to Loki via pushLoki's stream label set.
+		// Cerberus's LogQL stream selector resolves `{label=value}`
+		// matchers against this map (see
+		// internal/logql/lower.go::matcherToExpr → `ResourceAttributes[<key>]`).
+		// Mirrors the OTel-CH exporter's resource → ResourceAttributes
+		// mapping; Loki's own data model treats stream labels as
+		// resource-level too, so this keeps the two backends comparable.
+		// `service.name` is duplicated alongside the bare `service_name`
+		// key because the OTel-CH schema also surfaces it via the
+		// dedicated `ServiceName` column for /labels parity.
+		resourceAttrs := map[string]string{
+			"cluster":      s.config.Cluster,
+			"namespace":    s.config.Namespace,
+			"service":      s.config.Name,
+			"service_name": s.config.ServiceName,
+			"service.name": s.config.ServiceName,
+			"pod":          s.config.Pod,
+			"container":    s.config.Container,
+			"env":          "production",
+			"region":       "us-east-1",
+			"datacenter":   "dc1",
+		}
 		for _, e := range s.entries {
 			level := e.level
+			// LogAttributes carries per-record attributes — the severity
+			// markers Loki materialises as structured metadata. Stream
+			// labels live in resourceAttrs above, not here.
 			logAttrs := map[string]string{
 				"level":          strings.ToLower(level),
 				"detected_level": strings.ToLower(level),
-				"cluster":        s.config.Cluster,
-				"namespace":      s.config.Namespace,
-				"service":        s.config.Name,
-				"service_name":   s.config.ServiceName,
-				"pod":            s.config.Pod,
-				"container":      s.config.Container,
-				"env":            "production",
-				"region":         "us-east-1",
-				"datacenter":     "dc1",
 			}
 			if err := batch.Append(
 				e.ts,
@@ -499,7 +516,7 @@ func insertCHLogs(ctx context.Context, conn driver.Conn, streams []stream) error
 				s.config.ServiceName,
 				e.line,
 				"",
-				map[string]string{"service.name": s.config.ServiceName},
+				resourceAttrs,
 				"",
 				"cerberus-loki-compat-seeder",
 				"1",


### PR DESCRIPTION
## Summary

The Loki compatibility harness was scoring 0/55 (100% diff). 45 cases failed with `unexpectedFailure: "test endpoint returned empty"` and the rest were swallowed by the baseline-empty / Loki cardinality guards.

Root cause: `compatibility/loki/cmd/seed/main.go`'s `insertCHLogs` wrote the 9 stream-identity labels (`cluster`, `namespace`, `service`, `service_name`, `pod`, `container`, `env`, `region`, `datacenter`) into `LogAttributes` and only `service.name` into `ResourceAttributes`. Cerberus's LogQL stream selector resolves `{label=value}` matchers against `ResourceAttributes` only (see `internal/logql/lower.go::matcherToExpr` line 906-910), so every selector matched zero rows. The seeder log already hinted at this:

```
target=loki     labels="[cluster container datacenter env namespace pod region service service_name]"
target=cerberus labels=[service.name]
```

Loki itself stores the same nine labels as resource-level via `pushLoki`'s stream label set; aligning the CH side keeps the two backends comparable.

LogAttributes keeps `level` / `detected_level` (per-record severity markers; `detected_level` is short-circuited to a SeverityText normalisation in cerberus regardless). The dedicated `ServiceName` column plus a duplicated `service.name` key in `ResourceAttributes` preserve `/labels` parity for callers that consult the OTel column.

Latest 0/55 run: <https://github.com/tsouza/cerberus/actions/runs/26098988786>

## Test plan

- [ ] `compatibility/loki` job on this PR shows a non-zero passing count (and a far smaller "test endpoint returned empty" tally) in the per-job report artifact.
- [ ] Seed log surfaces `target=cerberus labels=[cluster container datacenter env namespace pod region service service.name service_name]` (parity with `target=loki`).