### PR TITLE
fix(ci/compat): strip extras from compat-scores badge JSON

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -227,11 +227,15 @@ jobs:
           fi
           git config user.name "cerberus-compat-bot"
           git config user.email "cerberus-compat-bot@users.noreply.github.com"
-          # Stash the score file before we switch branches so it survives
-          # the checkout (it lives under a path that the orphan tree may
-          # not contain).
+          # Stash a shields-compatible subset of the score file before we
+          # switch branches: the rich score file (passed / total / percent)
+          # is great for the artifact + step-summary, but shields.io's
+          # endpoint-badge schema is strict and rejects unknown keys with
+          # an "invalid properties: passed, total, percent" SVG title.
+          # Strip to the four schema-spec keys here so the orphan-branch
+          # JSON renders cleanly.
           tmp=$(mktemp)
-          cp "$SRC" "$tmp"
+          jq '{schemaVersion, label, message, color}' "$SRC" > "$tmp"
 
           MAX_ATTEMPTS=5
           attempt=1
@@ -349,8 +353,11 @@ jobs:
           fi
           git config user.name "cerberus-compat-bot"
           git config user.email "cerberus-compat-bot@users.noreply.github.com"
+          # Strip cerberus-only bookkeeping (passed / total / percent)
+          # before publishing: shields.io rejects unknown keys on the
+          # endpoint-badge schema with an "invalid properties" SVG title.
           tmp=$(mktemp)
-          cp "$SRC" "$tmp"
+          jq '{schemaVersion, label, message, color}' "$SRC" > "$tmp"
 
           MAX_ATTEMPTS=5
           attempt=1
@@ -475,8 +482,11 @@ jobs:
           fi
           git config user.name "cerberus-compat-bot"
           git config user.email "cerberus-compat-bot@users.noreply.github.com"
+          # Strip cerberus-only bookkeeping (passed / total / percent)
+          # before publishing: shields.io rejects unknown keys on the
+          # endpoint-badge schema with an "invalid properties" SVG title.
           tmp=$(mktemp)
-          cp "$SRC" "$tmp"
+          jq '{schemaVersion, label, message, color}' "$SRC" > "$tmp"
 
           MAX_ATTEMPTS=5
           attempt=1

--- a/compatibility/internal/score/score.go
+++ b/compatibility/internal/score/score.go
@@ -30,9 +30,20 @@ import (
 )
 
 // Score is the shields.io endpoint-badge envelope plus the cerberus
-// bookkeeping fields. The JSON tag set matches the shields contract
-// for the label/message/color fields; the extra fields are tolerated
-// by shields (it ignores unknown keys) and surface in downstream tools.
+// bookkeeping fields. The schemaVersion / label / message / color tags
+// match the shields contract; passed / total / percent are
+// cerberus-side bookkeeping consumed by the workflow's step-summary
+// step + the artifact upload.
+//
+// Shields.io's endpoint-badge schema is STRICT — it rejects unknown
+// properties and renders the SVG with "invalid properties: passed,
+// total, percent" instead of the badge text if the JSON carries
+// extras. The workflow strips the rich shape to the four
+// shields-spec keys at publish time (see the "Publish score to
+// compat-scores branch" step in .github/workflows/compatibility.yml,
+// the `jq '{schemaVersion, label, message, color}' "$SRC" > "$tmp"`
+// line). Do NOT push this struct directly to the compat-scores
+// orphan branch — go through the workflow's strip path.
 type Score struct {
 	// SchemaVersion is the shields.io endpoint-badge schema version.
 	// Pinned at 1 — bump in lock-step with shields if/when they ship


### PR DESCRIPTION
## Summary

The three custom shields.io endpoint badges in the README (PromQL / LogQL / TraceQL compat) render as a bright-red error badge — `custom badge: invalid properties: passed, total, percent` — instead of the per-head label + percent. The badges have been broken since they were introduced; this PR is the actual fix.

## Root cause

Shields.io's endpoint-badge schema is **strict**: unknown JSON properties cause the SVG renderer to bail with an "invalid properties" title instead of the configured label/message. Our `compat-score.json` carries seven keys:

| Key             | Owner    | Used by                                              |
| --------------- | -------- | ---------------------------------------------------- |
| `schemaVersion` | Shields  | Shields contract                                     |
| `label`         | Shields  | Shields contract (badge left-hand text)              |
| `message`       | Shields  | Shields contract (badge right-hand text)             |
| `color`         | Shields  | Shields contract (badge color band)                  |
| `passed`        | Cerberus | Workflow step-summary (`jq -r .passed`) + artifact   |
| `total`         | Cerberus | Workflow step-summary (`jq -r .total`) + artifact    |
| `percent`       | Cerberus | Workflow step-summary (`jq -r .percent`) + artifact  |

The score package's doc-comment claimed *"the extra fields are tolerated by shields (it ignores unknown keys)"* — that was the broken premise. Shields actively rejects them.

Repro against `compat-scores/badges/prometheus.json` (currently 100% green when rendered correctly):

```sh
$ curl -sL "https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftsouza%2Fcerberus%2Fcompat-scores%2Fbadges%2Fprometheus.json" \
    | grep -oE '<title[^>]*>[^<]+</title>'
<title>custom badge: invalid properties: passed, total, percent</title>
```

## Fix

Strip the rich shape to the four shields-spec keys **at publish time**, in the workflow step that pushes to the `compat-scores` orphan branch. The artifact upload + step-summary continue to read the rich shape from `compat-score.json` untouched — only the bytes that land on the orphan branch (and therefore reach shields) are filtered.

Three publish blocks (prom / loki / tempo), each gets the same one-line `jq` replacement:

```diff
-          tmp=$(mktemp)
-          cp "$SRC" "$tmp"
+          tmp=$(mktemp)
+          jq '{schemaVersion, label, message, color}' "$SRC" > "$tmp"
```

Also rewrite the `Score` struct doc-comment in `compatibility/internal/score/score.go` to spell out the strict shields schema and point at the workflow's strip path, so a future contributor doesn't re-introduce the "shields ignores extras" assumption.

## Verification

`jq` filter against the real orphan-branch JSON (today's `prometheus.json`) produces a clean shields-compatible payload:

```sh
$ curl -sL "https://raw.githubusercontent.com/tsouza/cerberus/compat-scores/badges/prometheus.json" \
    | jq '{schemaVersion, label, message, color}'
{
  "schemaVersion": 1,
  "label": "PromQL compat",
  "message": "100.00%",
  "color": "brightgreen"
}
```

After this PR merges, the next push-to-main will run the compatibility workflow, which will overwrite each `badges/<head>.json` with the four-key payload — and the README badges should immediately resolve to their per-head label + percent + color (within shields-cache `max-age=300`).

## Test plan

- [ ] `check` + `lint` CI green.
- [ ] After merge to main, the `compatibility` workflow runs and the three commits land on `compat-scores` with the four-key payload (verify with `git show origin/compat-scores:badges/prometheus.json` + `git show origin/compat-scores:badges/loki.json` + `git show origin/compat-scores:badges/tempo.json`).
- [ ] Hit each `img.shields.io/endpoint?url=...` URL after the workflow finishes — `<title>` should now read `PromQL compat: 100.00%` / `LogQL compat: 0.00%` / `TraceQL compat: 12.12%` (or whatever the current scores are), not "invalid properties".
- [ ] PR description test plan boxes flipped after manual verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)