### PR TITLE
refactor(justfile): rename compat recipes to compat-<QL> prefix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ Top-level reading order for any new contributor (human or agent):
 - **Add a property test** — add a row to the generator + oracle under `test/property/{gen,oracle}/` and a case to `test/property/promql_test.go`. The framework wires `rapid.Check` → dataset gen → chDB exec → oracle → comparator; you only swap the data shape + oracle. Build-tagged `chdb`; runs in the `chdb` workflow only.
 - **Bump parser deps** — use the `/cerberus:bump-parser-deps` skill. Runs `go get -u` on the three upstream parsers, runs `go mod tidy`, captures the diff for the PR description.
 - **Run E2E locally** — `just e2e-up && just e2e-seed && just e2e-run && just e2e-down`.
-- **Run the compatibility suite** — `just compatibility`. Diffs cerberus against reference Prometheus on a deterministic OTel fixture.
+- **Run the compatibility suite** — `just compat-promql`. Diffs cerberus against reference Prometheus on a deterministic OTel fixture.
 - **Find which test layer covers a class of bug** — see [`docs/test-strategy.md`](docs/test-strategy.md) for the layer map + per-layer "catches X / misses Y" guidance.
 
 ## Toolchain notes

--- a/Justfile
+++ b/Justfile
@@ -391,15 +391,15 @@ e2e: e2e-up e2e-seed e2e-wait-otel e2e-run e2e-playwright e2e-down
 # Run the PromQL compatibility suite end-to-end. Slow; expect minutes.
 # Sets up the Docker Compose stack (reference Prom + cerberus + CH + seeder),
 # runs the upstream tester, writes compatibility/prometheus/report.json.
-compatibility:
+compat-promql:
     ./compatibility/prometheus/scripts/run-compatibility.sh
 
 # Keep the compatibility stack running after the tester finishes (for debugging).
-compatibility-keep:
+compat-promql-keep:
     COMPOSE_KEEP=1 ./compatibility/prometheus/scripts/run-compatibility.sh
 
 # Tear down the compatibility stack manually.
-compatibility-down:
+compat-promql-down:
     cd compatibility/prometheus && docker compose down -v
 
 # === Compatibility (LogQL — Loki compatibility harness) ===
@@ -409,21 +409,21 @@ compatibility-down:
 # the vendored upstream/loki-bench corpus, runs TestRemoteStorageEquality
 # against both endpoints, writes compatibility/loki/reports/diff.json.
 # See compatibility/loki/README.md + docs/loki-compliance-plan.md.
-loki-compatibility:
+compat-logql:
     ./compatibility/loki/scripts/run-loki-compatibility.sh
 
 # Run the smoke (compose + seed + /labels assertion) without the diff
 # driver. Useful when the seeder is the bisect target.
-loki-compatibility-smoke:
+compat-logql-smoke:
     DRIVER_SKIP=1 ./compatibility/loki/scripts/run-loki-compatibility.sh
 
 # Keep the Loki compatibility stack running after the run finishes
 # (for debugging /loki/api/v1/* + ClickHouse manually).
-loki-compatibility-keep:
+compat-logql-keep:
     COMPOSE_KEEP=1 ./compatibility/loki/scripts/run-loki-compatibility.sh
 
 # Tear down the Loki compatibility stack manually.
-loki-compatibility-down:
+compat-logql-down:
     cd compatibility/loki && docker compose down -v
 # === Tempo / TraceQL compatibility harness ===
 
@@ -433,15 +433,15 @@ loki-compatibility-down:
 # deterministic OTLP batch to Tempo and an equivalent INSERT into CH
 # for cerberus, then smokes /api/traces/<id> on both backends.
 # PR 3 of docs/tempo-compliance-plan.md — diff driver lands in PR 4.
-tempo-compatibility:
+compat-traceql:
     ./compatibility/tempo/scripts/run-tempo-compatibility.sh
 
 # Keep the tempo-compatibility stack running after the driver finishes (for debugging).
-tempo-compatibility-keep:
+compat-traceql-keep:
     COMPOSE_KEEP=1 ./compatibility/tempo/scripts/run-tempo-compatibility.sh
 
 # Tear down the tempo-compatibility stack manually.
-tempo-compatibility-down:
+compat-traceql-down:
     cd compatibility/tempo && docker compose down -v
 
 # === Compatibility — all three heads ===
@@ -454,7 +454,7 @@ tempo-compatibility-down:
 # Slow — expect tens of minutes. Use the per-head recipes for iteration.
 # Exit semantics: fails fast on the first non-zero recipe; the report
 # files for each head land under compatibility/*/reports/ regardless.
-compatibility-all: compatibility loki-compatibility tempo-compatibility
+compat-all: compat-promql compat-logql compat-traceql
 
 # === Shadow-mode differential testing (RC3 R3.9) ===
 

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Quick reference:
 | **Property**     | Oracle-based property tests with `rapid` shrinking and chDB execution             | `go test -tags chdb ./test/property/...`            |
 | **Integration**  | `chclient` against a real ClickHouse via testcontainers                           | `go test -tags=integration ./internal/chclient/...` |
 | **E2E**          | k3d cluster with CH + Grafana + cerberus; Grafana Playwright smoke                | `just e2e`                                          |
-| **Compat**       | Differential parity vs reference Prom / Loki / Tempo                              | `just compat-all` (per-head recipes below)              |
+| **Compat**       | Differential parity vs reference Prom / Loki / Tempo                              | `just compat-all` (per-head recipes below)          |
 | **Mutation**     | Gremlins matrix — see `docs/test-strategy.md` § "Gremlins phased rollout" for bar | `just mutate` (slow, nightly in CI)                 |
 
 ## Quick start

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Quick reference:
 | **Property**     | Oracle-based property tests with `rapid` shrinking and chDB execution             | `go test -tags chdb ./test/property/...`            |
 | **Integration**  | `chclient` against a real ClickHouse via testcontainers                           | `go test -tags=integration ./internal/chclient/...` |
 | **E2E**          | k3d cluster with CH + Grafana + cerberus; Grafana Playwright smoke                | `just e2e`                                          |
-| **Compat**       | Differential parity vs reference Prom / Loki / Tempo                              | `just compat-all` (per-head recipes below)   |
+| **Compat**       | Differential parity vs reference Prom / Loki / Tempo                              | `just compat-all` (per-head recipes below)              |
 | **Mutation**     | Gremlins matrix — see `docs/test-strategy.md` § "Gremlins phased rollout" for bar | `just mutate` (slow, nightly in CI)                 |
 
 ## Quick start

--- a/README.md
+++ b/README.md
@@ -243,10 +243,10 @@ Each harness ships as a Docker Compose stack — reference engine,
 cerberus, ClickHouse, and a one-shot seeder. Local execution:
 
 ```sh
-just compatibility            # PromQL — prometheus/compliance
-just loki-compatibility       # LogQL — grafana/loki pkg/logql/bench
-just tempo-compatibility      # TraceQL — tempo-vulture-patterned driver
-just compatibility-all        # run all three
+just compat-promql      # PromQL  — prometheus/compliance
+just compat-logql       # LogQL   — grafana/loki pkg/logql/bench
+just compat-traceql     # TraceQL — tempo-vulture-patterned driver
+just compat-all         # run all three
 ```
 
 The unified workflow at
@@ -296,7 +296,7 @@ Quick reference:
 | **Property**     | Oracle-based property tests with `rapid` shrinking and chDB execution             | `go test -tags chdb ./test/property/...`            |
 | **Integration**  | `chclient` against a real ClickHouse via testcontainers                           | `go test -tags=integration ./internal/chclient/...` |
 | **E2E**          | k3d cluster with CH + Grafana + cerberus; Grafana Playwright smoke                | `just e2e`                                          |
-| **Compat**       | Differential parity vs reference Prom / Loki / Tempo                              | `just compatibility-all` (per-head recipes below)   |
+| **Compat**       | Differential parity vs reference Prom / Loki / Tempo                              | `just compat-all` (per-head recipes below)   |
 | **Mutation**     | Gremlins matrix — see `docs/test-strategy.md` § "Gremlins phased rollout" for bar | `just mutate` (slow, nightly in CI)                 |
 
 ## Quick start

--- a/compatibility/loki/README.md
+++ b/compatibility/loki/README.md
@@ -214,19 +214,19 @@ that lives OUTSIDE the AGPL `upstream/` boundary:
 
 ```sh
 # Full lifecycle: compose up, seed, build driver, diff, tear down.
-just loki-compatibility
+just compat-logql
 
 # Smoke only (skip the diff driver — useful for bisecting the seeder).
-DRIVER_SKIP=1 just loki-compatibility
+DRIVER_SKIP=1 just compat-logql
 
 # Keep the stack up after the run for manual poking.
-just loki-compatibility-keep
+just compat-logql-keep
 
 # Instant-query mode (default is range).
-DRIVER_RANGE_TYPE=instant just loki-compatibility
+DRIVER_RANGE_TYPE=instant just compat-logql
 
 # Tear the stack down manually.
-just loki-compatibility-down
+just compat-logql-down
 ```
 
 The run script's contract:

--- a/docs/12factor.md
+++ b/docs/12factor.md
@@ -354,7 +354,7 @@ against the same backing ClickHouse:
   ClickHouse connection inputs as cerberus does, so a single set of
   credentials drives both the long-lived server and the one-shot
   task.
-- **Compatibility harness** — `just compatibility` boots cerberus
+- **Compatibility harness** — `just compat-promql` boots cerberus
   alongside upstream Prometheus and diffs the two against a shared
   fixture. Again, a one-shot process; cerberus stays unchanged.
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -7,7 +7,7 @@ Today (M0.6) the harness lands as **informational** — the workflow runs but do
 ## Local run
 
 ```sh
-just compatibility
+just compat-promql
 ```
 
 This:
@@ -21,9 +21,9 @@ This:
 Set `COMPOSE_KEEP=1` to leave the stack running for poking around:
 
 ```sh
-just compatibility-keep
+just compat-promql-keep
 # inspect things; then
-just compatibility-down
+just compat-promql-down
 ```
 
 ## Reading the report
@@ -76,7 +76,7 @@ If the case is cerberus-specific (e.g. OTel-CH schema quirk), add it as a TXTAR 
 
 Most of PromQL isn't lowered yet at the seed stage. Gating now would make every PR red. The harness lands now so:
 
-- Each subsequent M1.x PR can run `just compatibility` locally and report the pass-rate delta in the PR body (per the [CONTRIBUTING](../CONTRIBUTING.md) test-plan template).
+- Each subsequent M1.x PR can run `just compat-promql` locally and report the pass-rate delta in the PR body (per the [CONTRIBUTING](../CONTRIBUTING.md) test-plan template).
 - The CI run produces an artifact (`compatibility-prometheus-report` for 30 days) so we can chart progress.
 - When M1.7 closes, flipping the gate is a one-line `continue-on-error: false` + adding the check to branch protection.
 

--- a/docs/loki-compliance-plan.md
+++ b/docs/loki-compliance-plan.md
@@ -90,9 +90,9 @@ Initially: `/loki/api/v1/query` + `/query_range`. PR 4 expands to `/labels`, `/l
 
 1. **PR 1 — scaffold** (compose + reference Loki + cerberus + seed). No corpus yet. `docker compose up --wait` brings reference Loki up at `:23100` and cerberus at `:29092`. Seeder pushes 5-10 minutes of deterministic log streams to both endpoints. Smoke: `/labels` non-empty on both.
 2. **PR 2 — vendor `pkg/logql/bench/`** subtree + minimal corpus. Pull `queries/fast/*.yaml`, `schema.json`, `query_registry.go`, `remote_test.go`. Add `cerberus-test-queries.yml` overlay documenting drops for unsupported LogQL features per `docs/roadmap.md`. Pinned `dataset_metadata.json`.
-3. **PR 3 — `scripts/run-loki-compatibility.sh` + just recipe.** Build the test driver (`go test -tags=remote_correctness -c`), point at the two endpoints, write report. Add `just loki-compatibility`.
+3. **PR 3 — `scripts/run-loki-compatibility.sh` + just recipe.** Build the test driver (`go test -tags=remote_correctness -c`), point at the two endpoints, write report. Add `just compat-logql`.
 4. **PR 4 — informational lane** in `.github/workflows/loki-compatibility.yml`. Trigger: `push: main` + nightly cron + `workflow_dispatch`. Report uploaded as artifact. Initially NOT a required check (matches Prom precedent).
-5. **PR 5 (later) — cerberus-owned driver** replacing the Go test entry. Port `TestRemoteStorageEquality`'s diff loop into `cmd/loki-compliance-tester/` so it emits the same JSON shape as the Prom tester. Add `just compatibility-all`.
+5. **PR 5 (later) — cerberus-owned driver** replacing the Go test entry. Port `TestRemoteStorageEquality`'s diff loop into `cmd/loki-compliance-tester/` so it emits the same JSON shape as the Prom tester. Add `just compat-all`.
 6. **PR 6 — expand corpus.** Add `queries/regression/` + slices of `queries/exhaustive/` as cerberus's LogQL coverage grows. Track in `cerberus-test-queries.yml` header.
 
 ## Open questions

--- a/docs/pre-ga-readiness-signoff.md
+++ b/docs/pre-ga-readiness-signoff.md
@@ -190,7 +190,7 @@ Once those three flip, the readiness score moves to 14 / 14 (100%) and the maint
 
 ## What this audit explicitly did NOT do
 
-- It did not run `just test` / `just lint` / `just compatibility`
+- It did not run `just test` / `just lint` / `just compat-promql`
   locally (per the CLAUDE.md "no local validation" rule).
 - It did not modify any code or workflow files.
 - It did not open a sub-PR for any of the NEEDS-WORK rows — those

--- a/docs/prom-exemplars-impl-plan.md
+++ b/docs/prom-exemplars-impl-plan.md
@@ -478,7 +478,7 @@ PR C does not change production code; it is fixture + asserts.
   `compatibility/prometheus/expected-failures.json` already lists the
   exemplars-related queries; PR C closes those entries (or downgrades them
   to "passes" once the implementation lands). Confirm by re-running
-  `just compatibility` locally and updating the failure list in the same PR.
+  `just compat-promql` locally and updating the failure list in the same PR.
 
 ## 7 — Open questions and risks
 

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -68,7 +68,7 @@ in the relevant section below.
 | chDB handler tests    | `just test-chdb`                                                | `go test -tags chdb ./internal/chclienttest/... ./internal/api/...`                            |
 | Property framework    | `go test -tags chdb ./test/property/...`                        | Oracle property test (`pgregory.net/rapid` shrinking) — requires libchdb                       |
 | E2E (k3d + Grafana)   | `just e2e-up && just e2e-seed && just e2e-run && just e2e-down` | Full Playwright suite under `test/e2e/playwright/` runs via `just e2e-playwright`              |
-| Compatibility harness | `just compatibility`                                            | `prometheus/compliance` Docker Compose harness                                                 |
+| Compatibility harness | `just compat-promql`                                            | `prometheus/compliance` Docker Compose harness                                                 |
 | Mutation (whole-repo) | `just mutate`                                                   | Slow (minutes) — global `.gremlins.yaml` threshold; informational                              |
 | Mutation (chDB lane)  | `just mutate-chdb`                                              | Tighter kill criterion via `-t chdb -i` against `internal/optimizer/` + `internal/chsql/`      |
 | Fuzz one head         | `just fuzz QL=promql DURATION=60s`                              | Bounded fuzz run against `internal/<ql>/FuzzParse`                                             |


### PR DESCRIPTION
## Summary

Standardise the compatibility-harness recipe names so they sort together and read predictably, and reflect the **query language** each harness tests (not the reference engine).

| Old                         | New                       |
| --------------------------- | ------------------------- |
| `just compatibility`        | `just compat-promql`      |
| `just compatibility-keep`   | `just compat-promql-keep` |
| `just compatibility-down`   | `just compat-promql-down` |
| `just loki-compatibility`   | `just compat-logql`       |
| `just loki-compatibility-smoke` | `just compat-logql-smoke` |
| `just loki-compatibility-keep`  | `just compat-logql-keep`  |
| `just loki-compatibility-down`  | `just compat-logql-down`  |
| `just tempo-compatibility`  | `just compat-traceql`     |
| `just tempo-compatibility-keep` | `just compat-traceql-keep` |
| `just tempo-compatibility-down` | `just compat-traceql-down` |
| `just compatibility-all`    | `just compat-all`         |

User-facing doc references in CLAUDE.md, README.md, docs/, and the per-harness READMEs updated in lock-step. Workflow filenames, docker-compose project names, image tags, and shell-script filenames are intentionally **out of scope** — touching those would cascade into CI publish paths and is a larger move.

## Test plan

- [x] `just --list` enumerates all renamed recipes
- [ ] CI: `check` + `lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)