### PR TITLE
fix(api/tempo): resolve root span by ParentSpanId='' in search response shaper

### DIFF
--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -411,6 +411,15 @@ func stripLeadingHexZeros(col string) chplan.Expr {
 // searchKeyTraceID reuses the same `__cerberus_traceID` slot on the
 // /api/search path so toTraceSummaries can group spans by real TraceID
 // rather than synthesising a key from (SpanName + Timestamp).
+//
+// searchKeyParentSpanID reuses the same `__cerberus_parentSpanID` slot
+// on the /api/search path so toTraceSummaries can identify the per-trace
+// root span — the row where ParentSpanId is empty. Without this, the
+// shaper anchors RootServiceName / RootTraceName on whichever span CH
+// happens to return first, which for multi-span traces is typically a
+// child span (Tempo's wire spec says rootTraceName is the name of the
+// span at the top of the trace tree). See toTraceSummaries for the
+// resolution logic and the fallback rules for broken or truncated traces.
 const (
 	traceByIDKeyTraceID       = "__cerberus_traceID"
 	traceByIDKeySpanID        = "__cerberus_spanID"
@@ -424,6 +433,11 @@ const (
 	// as traceByIDKeyTraceID — the two paths never overlap (search keeps
 	// the slot for the trace-id, trace-by-id keeps it for the same).
 	searchKeyTraceID = traceByIDKeyTraceID
+	// searchKeyParentSpanID is the reserved Labels key carrying the
+	// hex-encoded ParentSpanId on /api/search responses. Reuses the
+	// traceByIDKeyParentSpanID slot — same constant value, same
+	// namespace; the two paths never overlap.
+	searchKeyParentSpanID = traceByIDKeyParentSpanID
 )
 
 // wrapWithSampleProjection adds a Project on top of plan that emits
@@ -529,21 +543,30 @@ func wrapWithSampleProjection(plan chplan.Node, s schema.Traces, meta engine.Met
 // (`>>` / `<<`) wrap path, where the inner SELECT exposes R's columns
 // unqualified to the outer scope.
 //
-// The Attributes map merges ResourceAttributes with a single
-// reserved-key entry (`__cerberus_traceID` → leading-zero-stripped hex
-// TraceId) so toTraceSummaries can group spans into per-trace summaries
-// by real TraceID rather than synthesising a key from (SpanName +
-// Timestamp). Same mapConcat pattern as traceByIDProjections; the
-// resource keys (`service.*`, `k8s.*`, …) never collide with the
-// `__cerberus_*` namespace so no precedence surprises.
+// The Attributes map merges ResourceAttributes with two reserved-key
+// entries:
+//   - `__cerberus_traceID` → leading-zero-stripped hex TraceId — so
+//     toTraceSummaries can group spans into per-trace summaries by real
+//     TraceID rather than synthesising a key from (SpanName + Timestamp).
+//   - `__cerberus_parentSpanID` → leading-zero-stripped hex ParentSpanId
+//     — so toTraceSummaries can resolve the root span per trace (Tempo's
+//     wire spec anchors rootServiceName / rootTraceName on the span where
+//     ParentSpanId is empty, not the first span returned by the
+//     underlying engine).
+//
+// Same mapConcat pattern as traceByIDProjections; the resource keys
+// (`service.*`, `k8s.*`, …) never collide with the `__cerberus_*`
+// namespace so no precedence surprises.
 func canonicalSampleProjections(s schema.Traces) []chplan.Projection {
-	traceIDMap := &chplan.FuncCall{Name: "map", Args: []chplan.Expr{
+	reservedMap := &chplan.FuncCall{Name: "map", Args: []chplan.Expr{
 		&chplan.LitString{V: searchKeyTraceID},
 		stripLeadingHexZeros(s.TraceIDColumn),
+		&chplan.LitString{V: searchKeyParentSpanID},
+		stripLeadingHexZeros(s.ParentSpanIDColumn),
 	}}
 	mergedAttrs := &chplan.FuncCall{Name: "mapConcat", Args: []chplan.Expr{
 		&chplan.ColumnRef{Name: s.ResourceAttributesColumn},
-		traceIDMap,
+		reservedMap,
 	}}
 	return []chplan.Projection{
 		{Expr: &chplan.ColumnRef{Name: s.SpanNameColumn}, Alias: "MetricName"},
@@ -573,13 +596,15 @@ func canonicalSampleProjections(s schema.Traces) []chplan.Projection {
 // for parity with the historical descendant/ancestor split, but both
 // arms now emit identical projections.
 func rQualifiedSampleProjections(s schema.Traces) []chplan.Projection {
-	traceIDMap := &chplan.FuncCall{Name: "map", Args: []chplan.Expr{
+	reservedMap := &chplan.FuncCall{Name: "map", Args: []chplan.Expr{
 		&chplan.LitString{V: searchKeyTraceID},
 		stripLeadingHexZeros(s.TraceIDColumn),
+		&chplan.LitString{V: searchKeyParentSpanID},
+		stripLeadingHexZeros(s.ParentSpanIDColumn),
 	}}
 	mergedAttrs := &chplan.FuncCall{Name: "mapConcat", Args: []chplan.Expr{
 		&chplan.ColumnRef{Name: s.ResourceAttributesColumn},
-		traceIDMap,
+		reservedMap,
 	}}
 	return []chplan.Projection{
 		{Expr: &chplan.ColumnRef{Name: s.SpanNameColumn}, Alias: "MetricName"},
@@ -714,17 +739,32 @@ func isAggregateShape(plan chplan.Node) bool {
 // aggregate plumbing lands).
 //
 // chclient.Sample's MetricName carries SpanName here (per the wrap
-// projection above) and Attributes carries ResourceAttributes plus a
-// reserved `__cerberus_traceID` entry (searchKeyTraceID); we use the
-// reserved entry as the grouping key so spans share a row when they
-// share a real trace, and derive RootServiceName from
-// Attributes['service.name']. The reserved entry is stripped from
-// the returned RootServiceName lookup since it's namespaced under
-// `__cerberus_*` and never collides with OTel-spec attribute keys.
+// projection above) and Attributes carries ResourceAttributes plus
+// two reserved entries:
+//   - `__cerberus_traceID` (searchKeyTraceID) — the grouping key so
+//     multi-span traces collapse into one summary row.
+//   - `__cerberus_parentSpanID` (searchKeyParentSpanID) — used to
+//     identify the per-trace root span (Tempo's wire spec anchors
+//     rootServiceName / rootTraceName on the span at the top of the
+//     trace tree, where ParentSpanId is empty/unset, not whichever
+//     span the underlying engine happens to return first).
 //
-// Defensive: samples missing the reserved key (older fixtures, stub
-// queriers in tests) fall back to (SpanName | Timestamp) so partial
-// data still surfaces a row rather than silently dropping.
+// Root-span resolution:
+//   - Prefer the row where ParentSpanId == "" (the actual root). Among
+//     multiple roots (broken trace), the earliest by start time wins —
+//     same fallback Tempo uses internally.
+//   - When no row in the matched set is a root (truncated trace; the
+//     matcher only hit children), fall back to the earliest span's
+//     metadata. This degrades gracefully — the search response still
+//     surfaces *something* identifying the trace.
+//
+// Defensive: samples missing the reserved trace-ID key (older fixtures,
+// stub queriers in tests) fall back to (SpanName | Timestamp) so
+// partial data still surfaces a row rather than silently dropping.
+// Samples missing the parent-span-id key default to a non-root
+// classification (since we can't tell — older fixtures pre-date the
+// reserved slot); the trace's RootService/RootTraceName then anchor
+// on the earliest-span fallback path.
 func toTraceSummaries(samples []chclient.Sample) []TraceSummary {
 	type acc struct {
 		traceID     string
@@ -732,6 +772,17 @@ func toTraceSummaries(samples []chclient.Sample) []TraceSummary {
 		traceName   string
 		startNS     int64
 		durationNS  int64
+		// rootStartNS pins the timestamp of the best root-span candidate
+		// seen so far (smallest start time wins ties). 0 means "no
+		// root span seen yet"; we anchor on the earliest-span fallback
+		// in that case.
+		rootStartNS int64
+		// earliestStartNS pins the earliest-by-timestamp span seen,
+		// regardless of root status. Used as the fallback anchor for
+		// truncated traces where no root is in the matched set.
+		earliestStartNS int64
+		// hasRoot is true once we've seen a span with ParentSpanId == "".
+		hasRoot bool
 	}
 	byTrace := map[string]*acc{}
 	for _, s := range samples {
@@ -745,11 +796,8 @@ func toTraceSummaries(samples []chclient.Sample) []TraceSummary {
 		}
 		a, ok := byTrace[key]
 		if !ok {
-			a = &acc{traceID: traceID, traceName: s.MetricName}
+			a = &acc{traceID: traceID}
 			byTrace[key] = a
-		}
-		if svc, ok := s.Labels["service.name"]; ok {
-			a.serviceName = svc
 		}
 		ns := s.Timestamp.UnixNano()
 		if a.startNS == 0 || ns < a.startNS {
@@ -757,6 +805,33 @@ func toTraceSummaries(samples []chclient.Sample) []TraceSummary {
 		}
 		if int64(s.Value) > a.durationNS {
 			a.durationNS = int64(s.Value)
+		}
+
+		// Resolve root-span metadata. The reserved __cerberus_parentSpanID
+		// slot carries the parent ID; empty means this row is the root.
+		// When the slot is missing (older fixtures / stub queriers),
+		// treat every row as a non-root candidate so the fallback path
+		// runs — `parentID, hasParentSlot := ...` captures the
+		// "did we get the projection" signal independently of the
+		// emptiness check.
+		parentID, hasParentSlot := s.Labels[searchKeyParentSpanID]
+		isRoot := hasParentSlot && parentID == ""
+		svc := s.Labels["service.name"]
+		switch {
+		case isRoot && (!a.hasRoot || ns < a.rootStartNS):
+			// First root, or an earlier root (broken trace with
+			// multiple ParentSpanId="" spans — Tempo picks the
+			// earliest by start time, we mirror that).
+			a.hasRoot = true
+			a.rootStartNS = ns
+			a.serviceName = svc
+			a.traceName = s.MetricName
+		case !a.hasRoot && (a.earliestStartNS == 0 || ns < a.earliestStartNS):
+			// No root seen yet (truncated trace) — anchor on the
+			// earliest-by-timestamp child as a graceful fallback.
+			a.earliestStartNS = ns
+			a.serviceName = svc
+			a.traceName = s.MetricName
 		}
 	}
 	out := make([]TraceSummary, 0, len(byTrace))

--- a/internal/api/tempo/handler_test.go
+++ b/internal/api/tempo/handler_test.go
@@ -498,8 +498,16 @@ func TestSearch_SQLProjectsParentSpanId(t *testing.T) {
 	if !strings.Contains(q.lastSQL, "ParentSpanId") {
 		t.Errorf("emitted SQL must project ParentSpanId; got %s", q.lastSQL)
 	}
-	if !strings.Contains(q.lastSQL, "__cerberus_parentSpanID") {
-		t.Errorf("emitted SQL must include reserved __cerberus_parentSpanID slot; got %s", q.lastSQL)
+	// The reserved key string is parameterised — find it in the args.
+	var sawParentSpanIDKey bool
+	for _, a := range q.lastArgs {
+		if s, ok := a.(string); ok && s == "__cerberus_parentSpanID" {
+			sawParentSpanIDKey = true
+			break
+		}
+	}
+	if !sawParentSpanIDKey {
+		t.Errorf("emitted SQL args must include reserved __cerberus_parentSpanID slot; got args=%v", q.lastArgs)
 	}
 }
 

--- a/internal/api/tempo/handler_test.go
+++ b/internal/api/tempo/handler_test.go
@@ -271,6 +271,238 @@ func TestSearch_GroupsByTraceID(t *testing.T) {
 	}
 }
 
+// TestSearch_RootSpanResolution asserts that when a trace contains
+// multiple spans (one root with ParentSpanId="" and several children
+// pointing at the root), the response shaper anchors RootServiceName
+// and RootTraceName on the root span — not on whichever child the
+// underlying engine happens to return first. This is the Tempo wire
+// spec: rootTraceName is the name of the span at the top of the trace
+// tree.
+//
+// Pins the bug behind ~4 Tempo compat cases (status_eq_error /
+// set_or_two_kinds / set_and_checkout_and_status_error /
+// descendant_op_payments_to_consumer / direct_parent_op_checkout_to_child)
+// — see PR description for the before/after wire shape.
+func TestSearch_RootSpanResolution(t *testing.T) {
+	t.Parallel()
+	const traceID = "cccccccccccccccccccccccccccccccc"
+	const rootSpanID = "0000000000000001"
+	q := &stubQuerier{
+		samples: []chclient.Sample{
+			// A child span (returned first by CH; this is exactly the
+			// scenario that produced rootTraceName="checkout.child.2"
+			// in the Tempo compat diff).
+			{
+				MetricName: "checkout.child.2",
+				Labels: map[string]string{
+					"service.name":            "checkout",
+					"__cerberus_traceID":      traceID,
+					"__cerberus_parentSpanID": rootSpanID,
+				},
+				Timestamp: time.Date(2026, 5, 12, 10, 0, 0, 30_000_000, time.UTC),
+				Value:     40_000_000,
+			},
+			// Another child.
+			{
+				MetricName: "checkout.child.0",
+				Labels: map[string]string{
+					"service.name":            "checkout",
+					"__cerberus_traceID":      traceID,
+					"__cerberus_parentSpanID": rootSpanID,
+				},
+				Timestamp: time.Date(2026, 5, 12, 10, 0, 0, 10_000_000, time.UTC),
+				Value:     20_000_000,
+			},
+			// The actual root span — ParentSpanId is empty. The shaper
+			// must anchor RootServiceName + RootTraceName here.
+			{
+				MetricName: "GET /api/checkout/17",
+				Labels: map[string]string{
+					"service.name":            "checkout",
+					"__cerberus_traceID":      traceID,
+					"__cerberus_parentSpanID": "",
+				},
+				Timestamp: time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC),
+				Value:     150_000_000,
+			},
+		},
+	}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/search?q=%7B%20status%20%3D%20error%20%7D")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	var sr tempo.SearchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&sr); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(sr.Traces) != 1 {
+		t.Fatalf("expected 1 trace, got %d", len(sr.Traces))
+	}
+	got := sr.Traces[0]
+	if got.RootTraceName != "GET /api/checkout/17" {
+		t.Errorf("RootTraceName: got %q, want %q (the span where ParentSpanId='', not a child)",
+			got.RootTraceName, "GET /api/checkout/17")
+	}
+	if got.RootServiceName != "checkout" {
+		t.Errorf("RootServiceName: got %q, want %q",
+			got.RootServiceName, "checkout")
+	}
+}
+
+// TestSearch_RootSpanResolution_MultipleRoots covers the broken-trace
+// fallback: when two spans both have ParentSpanId="" (the trace was
+// chopped during collection so multiple roots are present), Tempo
+// anchors on the earliest by start time. The shaper mirrors that.
+func TestSearch_RootSpanResolution_MultipleRoots(t *testing.T) {
+	t.Parallel()
+	const traceID = "dddddddddddddddddddddddddddddddd"
+	q := &stubQuerier{
+		samples: []chclient.Sample{
+			// Later "root" (broken trace).
+			{
+				MetricName: "later-root",
+				Labels: map[string]string{
+					"service.name":            "svcB",
+					"__cerberus_traceID":      traceID,
+					"__cerberus_parentSpanID": "",
+				},
+				Timestamp: time.Date(2026, 5, 12, 10, 0, 5, 0, time.UTC),
+				Value:     100_000_000,
+			},
+			// Earlier "root" — should win.
+			{
+				MetricName: "earliest-root",
+				Labels: map[string]string{
+					"service.name":            "svcA",
+					"__cerberus_traceID":      traceID,
+					"__cerberus_parentSpanID": "",
+				},
+				Timestamp: time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC),
+				Value:     200_000_000,
+			},
+		},
+	}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/search?q=%7B%7D")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	var sr tempo.SearchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&sr); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(sr.Traces) != 1 {
+		t.Fatalf("expected 1 trace, got %d", len(sr.Traces))
+	}
+	if sr.Traces[0].RootTraceName != "earliest-root" {
+		t.Errorf("RootTraceName: got %q, want %q (earliest of multiple roots)",
+			sr.Traces[0].RootTraceName, "earliest-root")
+	}
+	if sr.Traces[0].RootServiceName != "svcA" {
+		t.Errorf("RootServiceName: got %q, want %q",
+			sr.Traces[0].RootServiceName, "svcA")
+	}
+}
+
+// TestSearch_RootSpanResolution_TruncatedTrace covers the truncated-set
+// fallback: when the matcher only matches child spans (the root is in
+// the trace but not in this search result set), the shaper falls back
+// to the earliest-by-timestamp span's metadata. This degrades
+// gracefully — the response surfaces *something* identifying the
+// trace rather than dropping the row.
+func TestSearch_RootSpanResolution_TruncatedTrace(t *testing.T) {
+	t.Parallel()
+	const traceID = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+	const rootSpanID = "0000000000000099"
+	q := &stubQuerier{
+		samples: []chclient.Sample{
+			{
+				MetricName: "child.late",
+				Labels: map[string]string{
+					"service.name":            "svcLate",
+					"__cerberus_traceID":      traceID,
+					"__cerberus_parentSpanID": rootSpanID,
+				},
+				Timestamp: time.Date(2026, 5, 12, 10, 0, 5, 0, time.UTC),
+				Value:     100_000_000,
+			},
+			{
+				MetricName: "child.early",
+				Labels: map[string]string{
+					"service.name":            "svcEarly",
+					"__cerberus_traceID":      traceID,
+					"__cerberus_parentSpanID": rootSpanID,
+				},
+				Timestamp: time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC),
+				Value:     50_000_000,
+			},
+		},
+	}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/search?q=%7B%7D")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	var sr tempo.SearchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&sr); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(sr.Traces) != 1 {
+		t.Fatalf("expected 1 trace, got %d", len(sr.Traces))
+	}
+	// Earliest child wins when no root is in the result set.
+	if sr.Traces[0].RootTraceName != "child.early" {
+		t.Errorf("RootTraceName: got %q, want %q (earliest child when root absent)",
+			sr.Traces[0].RootTraceName, "child.early")
+	}
+	if sr.Traces[0].RootServiceName != "svcEarly" {
+		t.Errorf("RootServiceName: got %q, want %q",
+			sr.Traces[0].RootServiceName, "svcEarly")
+	}
+}
+
+// TestSearch_SQLProjectsParentSpanId pins the SQL emitted by the search
+// path against an OTel-CH default schema. The ParentSpanId column must
+// appear in the projection so toTraceSummaries can resolve the root
+// span — without this column the shaper has no way to identify which
+// row is the root.
+func TestSearch_SQLProjectsParentSpanId(t *testing.T) {
+	t.Parallel()
+	q := &stubQuerier{}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/search?q=%7B%20resource.service.name%20%3D%20%22frontend%22%20%7D")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	// The wrap-projection's reserved map must include
+	// '__cerberus_parentSpanID' → ParentSpanId so the shaper can
+	// classify each row's root status. Substring search keeps the
+	// pin robust against unrelated SQL whitespace / arg-positional
+	// shifts.
+	if !strings.Contains(q.lastSQL, "ParentSpanId") {
+		t.Errorf("emitted SQL must project ParentSpanId; got %s", q.lastSQL)
+	}
+	if !strings.Contains(q.lastSQL, "__cerberus_parentSpanID") {
+		t.Errorf("emitted SQL must include reserved __cerberus_parentSpanID slot; got %s", q.lastSQL)
+	}
+}
+
 // isHexLower reports whether s is a non-empty lowercase hex string.
 // The OTel CH exporter writes TraceId via hex.EncodeToString, which
 // produces lowercase a-f digits.


### PR DESCRIPTION
## Summary

Cerberus's `/api/search` response shaper was anchoring `rootServiceName` / `rootTraceName` on whichever span CH happened to return first per trace — typically a child span. For a multi-span trace seeded with root `GET /api/checkout/17` plus children `checkout.child.{0..N}`, Tempo correctly returned `rootTraceName="GET /api/checkout/17"` while cerberus returned a child name like `"checkout.child.2"`.

The root cause: `toTraceSummaries` in `internal/api/tempo/handler.go` had no signal for which row in a per-trace fold was actually the root. The wrap-projection threaded `__cerberus_traceID` but not `__cerberus_parentSpanID`, so the shaper just took the last `service.name` / `MetricName` it saw per trace.

## Fix

- Thread `ParentSpanId` into the search wrap-projection under a new reserved key `__cerberus_parentSpanID` — mirrors the existing `__cerberus_traceID` slot. Both `canonicalSampleProjections` and `rQualifiedSampleProjections` gained the column so the structural-join paths benefit too.
- Resolve the root span per trace inside `toTraceSummaries`:
  1. Prefer the row where `ParentSpanId == ""`.
  2. Among multiple roots (broken trace), pick the earliest by start time — same fallback Tempo uses internally.
  3. When no root is in the matched set (truncated trace, the matcher only hit children), fall back to the earliest child's metadata so the response still surfaces something identifying the trace.

Everything stays in the response shaper + projection. No `chplan` IR changes, no new node types.

## Before / after wire shape (status_eq_error case)

Tempo (reference):
```json
{ "traceID": "...",
  "rootServiceName": "checkout",
  "rootTraceName": "GET /api/checkout/17" }
```

Cerberus, **before** this PR:
```json
{ "traceID": "...",
  "rootServiceName": "checkout",
  "rootTraceName": "checkout.child.2" }
```
(The child span name leaked through because CH returned the child row before the root row, and the shaper anchored on the first-seen.)

Cerberus, **after** this PR:
```json
{ "traceID": "...",
  "rootServiceName": "checkout",
  "rootTraceName": "GET /api/checkout/17" }
```
(The wrap-projection now carries `ParentSpanId`; `toTraceSummaries` picks the row where it's empty.)

## Expected compat delta

5 Tempo compat cases should move DIFF → PASS:

- `status_eq_error` (120 diff reasons)
- `set_or_two_kinds` (67)
- `set_and_checkout_and_status_error` (30)
- `descendant_op_payments_to_consumer` (30)
- `direct_parent_op_checkout_to_child` (28)

~275 diff reasons removed in total, ~12% compat score increase.

## Test plan

- [x] `TestSearch_RootSpanResolution` — root + two children, asserts the response anchors on the root.
- [x] `TestSearch_RootSpanResolution_MultipleRoots` — broken-trace fallback (earliest-of-multiple-roots wins).
- [x] `TestSearch_RootSpanResolution_TruncatedTrace` — truncated-set fallback (earliest child wins when root absent).
- [x] `TestSearch_SQLProjectsParentSpanId` — pins the emitted SQL includes `ParentSpanId` + the reserved-key slot.
- [ ] CI `check` + `lint` green.
- [ ] Tempo compat suite shows the 5 cases listed above flip to PASS.