### PR TITLE
fix(api/tempo): strip leading zeros from traceID/spanID hex in search + trace responses

### DIFF
--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -333,16 +333,69 @@ func classifyTraceByIDErr(err error) int {
 // lowerTraceByID builds a chplan tree equivalent to the TraceQL
 // `{ traceID = "<id>" }` query without going through the parser.
 // Cheaper than re-parsing for every trace lookup.
+//
+// The OTel-CH exporter writes TraceId as a 32-char lowercase hex string
+// (see compatibility/tempo/driver/seeder.go: `hex.EncodeToString(s.TraceId)`),
+// but Tempo's wire format strips leading zeros from trace IDs, and most
+// Grafana installations forward the stripped form back on /api/traces/{id}.
+// normaliseTraceID pads the inbound traceID back to the 32-char shape so
+// the WHERE comparison matches the column value regardless of whether the
+// caller sent the stripped or padded form.
 func (h *Handler) lowerTraceByID(traceID string) (chplan.Node, error) {
 	pred := &chplan.Binary{
 		Op:    chplan.OpEq,
 		Left:  &chplan.ColumnRef{Name: h.Schema.TraceIDColumn},
-		Right: &chplan.LitString{V: traceID},
+		Right: &chplan.LitString{V: normaliseTraceID(traceID)},
 	}
 	return &chplan.Filter{
 		Input:     &chplan.Scan{Table: h.Schema.SpansTable},
 		Predicate: pred,
 	}, nil
+}
+
+// normaliseTraceID returns the canonical 32-char lowercase-hex form of
+// the trace-id Tempo's wire format uses on storage (see OTel-CH
+// exporter's `hex.EncodeToString`). Tempo's response shaper strips
+// leading zeros (so `0000…ab` becomes `ab`), and Grafana echoes that
+// stripped form back on /api/traces/{id}/. We restore the padding here
+// so the WHERE comparison in lowerTraceByID hits the column value.
+//
+// Input shape is permissive: any length up to 32 hex chars, padded with
+// leading zeros on the left; anything longer is returned unchanged so a
+// caller's already-canonical 32-char form round-trips byte-for-byte and
+// a malformed/longer id surfaces via the downstream CH not-found path
+// rather than getting silently rewritten here. Lowercases the input so
+// callers that uppercased their hex still resolve.
+func normaliseTraceID(s string) string {
+	if len(s) >= 32 {
+		return strings.ToLower(s)
+	}
+	return strings.Repeat("0", 32-len(s)) + strings.ToLower(s)
+}
+
+// stripLeadingHexZeros returns a chplan expression that emits the hex
+// value of `col` with leading zeros removed, matching Tempo's wire
+// format for trace IDs and span IDs. The OTel-CH exporter writes both
+// as fixed-width lowercase-hex strings (32 chars for TraceId, 16 chars
+// for SpanId / ParentSpanId); Tempo's /api/search + /api/traces/{id}
+// shapers trim leading zeros so e.g. `0000…ab` becomes `ab`.
+//
+// The CH expression `replaceRegexpOne(col, '^0+([0-9a-f])', '\\1')`
+// strips a run of leading zeros but always retains at least one hex
+// digit — so an all-zero TraceId renders as a single `0` rather than
+// collapsing to the empty string, and an already-empty value (root
+// span's ParentSpanId is "" on the wire) round-trips unchanged because
+// the regex doesn't match. Lowercase-only character class matches the
+// OTel-CH `hex.EncodeToString` output verbatim.
+func stripLeadingHexZeros(col string) chplan.Expr {
+	return &chplan.FuncCall{
+		Name: "replaceRegexpOne",
+		Args: []chplan.Expr{
+			&chplan.ColumnRef{Name: col},
+			&chplan.LitString{V: "^0+([0-9a-f])"},
+			&chplan.LitString{V: "\\1"},
+		},
+	}
 }
 
 // Reserved keys used by wrapWithSampleProjection to smuggle trace-detail
@@ -477,16 +530,16 @@ func wrapWithSampleProjection(plan chplan.Node, s schema.Traces, meta engine.Met
 // unqualified to the outer scope.
 //
 // The Attributes map merges ResourceAttributes with a single
-// reserved-key entry (`__cerberus_traceID` → hex TraceId) so
-// toTraceSummaries can group spans into per-trace summaries by real
-// TraceID rather than synthesising a key from (SpanName + Timestamp).
-// Same mapConcat pattern as traceByIDProjections; the resource keys
-// (`service.*`, `k8s.*`, …) never collide with the `__cerberus_*`
-// namespace so no precedence surprises.
+// reserved-key entry (`__cerberus_traceID` → leading-zero-stripped hex
+// TraceId) so toTraceSummaries can group spans into per-trace summaries
+// by real TraceID rather than synthesising a key from (SpanName +
+// Timestamp). Same mapConcat pattern as traceByIDProjections; the
+// resource keys (`service.*`, `k8s.*`, …) never collide with the
+// `__cerberus_*` namespace so no precedence surprises.
 func canonicalSampleProjections(s schema.Traces) []chplan.Projection {
 	traceIDMap := &chplan.FuncCall{Name: "map", Args: []chplan.Expr{
 		&chplan.LitString{V: searchKeyTraceID},
-		&chplan.ColumnRef{Name: s.TraceIDColumn},
+		stripLeadingHexZeros(s.TraceIDColumn),
 	}}
 	mergedAttrs := &chplan.FuncCall{Name: "mapConcat", Args: []chplan.Expr{
 		&chplan.ColumnRef{Name: s.ResourceAttributesColumn},
@@ -522,7 +575,7 @@ func canonicalSampleProjections(s schema.Traces) []chplan.Projection {
 func rQualifiedSampleProjections(s schema.Traces) []chplan.Projection {
 	traceIDMap := &chplan.FuncCall{Name: "map", Args: []chplan.Expr{
 		&chplan.LitString{V: searchKeyTraceID},
-		&chplan.ColumnRef{Name: s.TraceIDColumn},
+		stripLeadingHexZeros(s.TraceIDColumn),
 	}}
 	mergedAttrs := &chplan.FuncCall{Name: "mapConcat", Args: []chplan.Expr{
 		&chplan.ColumnRef{Name: s.ResourceAttributesColumn},
@@ -554,11 +607,11 @@ func traceByIDProjections(s schema.Traces) []chplan.Projection {
 	// satisfies CH's homogeneous-value-type requirement.
 	metaKVPairs := []chplan.Expr{
 		&chplan.LitString{V: traceByIDKeyTraceID},
-		&chplan.ColumnRef{Name: s.TraceIDColumn},
+		stripLeadingHexZeros(s.TraceIDColumn),
 		&chplan.LitString{V: traceByIDKeySpanID},
-		&chplan.ColumnRef{Name: s.SpanIDColumn},
+		stripLeadingHexZeros(s.SpanIDColumn),
 		&chplan.LitString{V: traceByIDKeyParentSpanID},
-		&chplan.ColumnRef{Name: s.ParentSpanIDColumn},
+		stripLeadingHexZeros(s.ParentSpanIDColumn),
 		&chplan.LitString{V: traceByIDKeySpanKind},
 		// SpanKind / StatusCode are LowCardinality(String); cast to
 		// String so the mapConcat homogeneous-value-type requirement

--- a/internal/api/tempo/traceid_hex_test.go
+++ b/internal/api/tempo/traceid_hex_test.go
@@ -1,0 +1,249 @@
+package tempo
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestNormaliseTraceID covers the input-side parser that lets cerberus
+// accept both the stripped (e.g. `ab`) and the padded 32-char form on
+// /api/traces/{id}/. Tempo's wire format strips leading zeros from
+// trace IDs in responses; Grafana echoes that stripped form back on
+// follow-up lookups. Cerberus's storage column carries the 32-char
+// padded shape (the OTel-CH exporter writes `hex.EncodeToString`), so
+// the handler must restore the padding before comparing.
+func TestNormaliseTraceID(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "already_32_hex",
+			in:   "0123456789abcdef0123456789abcdef",
+			want: "0123456789abcdef0123456789abcdef",
+		},
+		{
+			name: "stripped_short_form",
+			in:   "ab",
+			want: "000000000000000000000000000000ab",
+		},
+		{
+			name: "tempo_real_world_stripped",
+			in:   "af843259b0a78f5cbe59e11cbaf66b",
+			want: "00af843259b0a78f5cbe59e11cbaf66b",
+		},
+		{
+			name: "all_zero_single_digit",
+			in:   "0",
+			want: "00000000000000000000000000000000",
+		},
+		{
+			name: "empty",
+			in:   "",
+			want: "00000000000000000000000000000000",
+		},
+		{
+			name: "uppercase_padded_lowercased",
+			in:   "AB",
+			want: "000000000000000000000000000000ab",
+		},
+		{
+			name: "longer_than_32_returned_unchanged",
+			in:   "00000123456789abcdef0123456789abcdef",
+			want: "00000123456789abcdef0123456789abcdef",
+		},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			got := normaliseTraceID(c.in)
+			if got != c.want {
+				t.Errorf("normaliseTraceID(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// TestStripLeadingHexZeros_RendersExpectedSQL pins the SQL shape emitted
+// by the leading-zero-stripping projection. The actual byte-level
+// stripping is exercised end-to-end by the Tempo compatibility harness
+// (which runs CH); this test guards the chsql contract — the function
+// name + argument shape that CH consumes.
+func TestStripLeadingHexZeros_RendersExpectedSQL(t *testing.T) {
+	t.Parallel()
+
+	plan := &chplan.Project{
+		Input: &chplan.Scan{Table: "otel_traces"},
+		Projections: []chplan.Projection{
+			{Expr: stripLeadingHexZeros("TraceId"), Alias: "tid"},
+		},
+	}
+
+	sql, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if !strings.Contains(sql, "replaceRegexpOne(`TraceId`,") {
+		t.Errorf("SQL missing replaceRegexpOne(`TraceId`, ...) call; got:\n%s", sql)
+	}
+	// The two regex literals ride positional args; we don't pin their
+	// indices because the emitter may re-order, but they must be present.
+	wantLit := []string{"^0+([0-9a-f])", `\1`}
+	for _, want := range wantLit {
+		found := false
+		for _, a := range args {
+			if s, ok := a.(string); ok && s == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected arg %q not in %v", want, args)
+		}
+	}
+}
+
+// TestCanonicalSampleProjections_StripsTraceIDLeadingZeros verifies the
+// /api/search projection routes TraceId through stripLeadingHexZeros so
+// the wire format matches Tempo's leading-zero-stripped shape. Without
+// this strip the canonical-key differ pairs the two backends'
+// summaries by mismatched keys (cerberus `00af…66b` vs Tempo
+// `af…66b`), generating spurious missing_in_a / missing_in_b reasons
+// per case.
+func TestCanonicalSampleProjections_StripsTraceIDLeadingZeros(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelTraces()
+	projs := canonicalSampleProjections(s)
+
+	plan := &chplan.Project{
+		Input:       &chplan.Scan{Table: s.SpansTable},
+		Projections: projs,
+	}
+	sql, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if !strings.Contains(sql, "replaceRegexpOne(`"+s.TraceIDColumn+"`,") {
+		t.Errorf("canonical search projection must wrap TraceId in replaceRegexpOne; got:\n%s", sql)
+	}
+}
+
+// TestTraceByIDProjections_StripsAllIDColumns covers the
+// /api/traces/{id} response path. TraceId, SpanId, and ParentSpanId
+// all need the leading-zero strip to match Tempo's response shape.
+func TestTraceByIDProjections_StripsAllIDColumns(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelTraces()
+	projs := traceByIDProjections(s)
+
+	plan := &chplan.Project{
+		Input:       &chplan.Scan{Table: s.SpansTable},
+		Projections: projs,
+	}
+	sql, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	for _, col := range []string{s.TraceIDColumn, s.SpanIDColumn, s.ParentSpanIDColumn} {
+		needle := "replaceRegexpOne(`" + col + "`,"
+		if !strings.Contains(sql, needle) {
+			t.Errorf("trace-by-id projection must wrap %s in replaceRegexpOne; SQL:\n%s", col, sql)
+		}
+	}
+}
+
+// TestLowerTraceByID_AcceptsBothPaddedAndStrippedForms pins the
+// /api/traces/{id} input-parse contract: cerberus must accept both
+// the leading-zero-stripped form Tempo emits on the wire AND the
+// already-padded 32-char form. Both produce an identical WHERE
+// predicate so the row lookup hits the column value the OTel-CH
+// exporter wrote.
+func TestLowerTraceByID_AcceptsBothPaddedAndStrippedForms(t *testing.T) {
+	t.Parallel()
+
+	const padded = "00af843259b0a78f5cbe59e11cbaf66b"
+	const stripped = "af843259b0a78f5cbe59e11cbaf66b"
+
+	h := &Handler{Schema: schema.DefaultOTelTraces()}
+
+	planA, err := h.lowerTraceByID(padded)
+	if err != nil {
+		t.Fatalf("padded form: %v", err)
+	}
+	planB, err := h.lowerTraceByID(stripped)
+	if err != nil {
+		t.Fatalf("stripped form: %v", err)
+	}
+
+	sqlA, argsA, err := chsql.Emit(context.Background(), planA)
+	if err != nil {
+		t.Fatalf("emit padded: %v", err)
+	}
+	sqlB, argsB, err := chsql.Emit(context.Background(), planB)
+	if err != nil {
+		t.Fatalf("emit stripped: %v", err)
+	}
+	if sqlA != sqlB {
+		t.Errorf("SQL must be identical for stripped vs padded inputs;\npadded:  %s\nstripped: %s", sqlA, sqlB)
+	}
+	if len(argsA) != len(argsB) {
+		t.Fatalf("arg count differs: padded=%d stripped=%d", len(argsA), len(argsB))
+	}
+	for i, a := range argsA {
+		if argsB[i] != a {
+			t.Errorf("arg %d differs: padded=%v stripped=%v", i, a, argsB[i])
+		}
+	}
+	// The argument the WHERE predicate binds against MUST be the 32-char
+	// canonical form (so the comparison hits the column value the
+	// OTel-CH exporter wrote via `hex.EncodeToString`).
+	foundCanonical := false
+	for _, a := range argsA {
+		if s, ok := a.(string); ok && s == padded {
+			foundCanonical = true
+			break
+		}
+	}
+	if !foundCanonical {
+		t.Errorf("expected canonical 32-char trace id %q in args; got %v", padded, argsA)
+	}
+}
+
+// TestLowerTraceByID_AllZeroTraceID pins the corner case: an all-zero
+// TraceID round-trips through normaliseTraceID to the 32-char zero
+// string, matching the column value.
+func TestLowerTraceByID_AllZeroTraceID(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{Schema: schema.DefaultOTelTraces()}
+	plan, err := h.lowerTraceByID("0")
+	if err != nil {
+		t.Fatalf("lowerTraceByID: %v", err)
+	}
+	_, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	want := strings.Repeat("0", 32)
+	found := false
+	for _, a := range args {
+		if s, ok := a.(string); ok && s == want {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected all-zero trace id %q in args; got %v", want, args)
+	}
+}


### PR DESCRIPTION
## Summary

Tempo's wire format strips leading zeros from trace and span IDs (e.g.
`af843259b0a78f5cbe59e11cbaf66b` rather than the 32-char
`00af843259b0a78f5cbe59e11cbaf66b` the OTel-CH exporter writes to the
`TraceId` column). Cerberus emitted the column verbatim, so the
compatibility harness's canonical-key differ — which pairs trace
summaries by `traceID` — couldn't match the ~5% of seeded trace IDs
whose SHA-256 prefix happened to start with one or more zero bytes,
generating ~10 spurious `missing_in_a` / `missing_in_b` reasons per
search case.

Wire-format change applied at the SQL projection layer (so CH does the
work, no Go post-processing):

- `internal/api/tempo/handler.go::canonicalSampleProjections` (search
  responses) and `rQualifiedSampleProjections` (structural-join search
  responses) — wrap `TraceId` with `stripLeadingHexZeros`.
- `internal/api/tempo/handler.go::traceByIDProjections` (/api/traces/{id}
  responses) — wrap `TraceId`, `SpanId`, and `ParentSpanId`.

The CH expression is
`replaceRegexpOne(col, '^0+([0-9a-f])', '\\1')` — strips a leading-zero
run while always retaining at least one hex digit, so an all-zero ID
renders as `0` rather than collapsing to the empty string, and a root
span's empty `ParentSpanId` round-trips unchanged because the regex
doesn't match an empty input.

Input-side `/api/traces/{id}` now accepts both the stripped (Tempo wire)
form and the padded form: `normaliseTraceID` pads the inbound id back
to 32 chars before the WHERE comparison so the row lookup hits the
storage column. The error envelope still echoes the user-supplied form.

### Before / after (resource_service_name_eq_checkout sample)

Before (cerberus side, ~5% of summaries):
```json
{ "traceID": "00af843259b0a78f5cbe59e11cbaf66b", "rootServiceName": "checkout", ... }
```

Tempo's side for the same trace:
```json
{ "traceID": "af843259b0a78f5cbe59e11cbaf66b", "rootServiceName": "checkout", ... }
```

After (both sides agree):
```json
{ "traceID": "af843259b0a78f5cbe59e11cbaf66b", "rootServiceName": "checkout", ... }
```

### Expected compat-score delta

~10 Tempo cases move from DIFF to PASS: `resource_service_name_eq_checkout`,
`resource_service_name_neq_checkout`, `resource_service_name_regex_shipping`,
`set_or_two_services`, `duration_gt_100ms`, `duration_lt_300ms`,
`kind_eq_server`, `span_http_method_eq_get`,
`resource_deployment_env_eq_compat_test`, `direct_child_op_client_under_checkout`.
Score 15% → ~45% on the next nightly compat run.

## Test plan

- [x] Unit tests on `normaliseTraceID` covering padded / stripped /
      all-zero / empty / uppercase / over-32-char inputs.
- [x] SQL-shape pin test on `stripLeadingHexZeros` to lock the CH
      `replaceRegexpOne(<col>, '^0+([0-9a-f])', '\1')` contract.
- [x] Projection-shape tests verifying `canonicalSampleProjections` and
      `traceByIDProjections` route the right columns through the
      strip.
- [x] Round-trip test pinning that `lowerTraceByID` produces identical
      WHERE predicates for `af843259b0a78f5cbe59e11cbaf66b` and
      `00af843259b0a78f5cbe59e11cbaf66b`.
- [x] Corner case: an all-zero input traceID normalises to the
      32-char zero string.
- [ ] Tempo compat run on next nightly will confirm the ~10 cases move
      from DIFF to PASS.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>