### PR TITLE
fix(logql): emit matrix RangeWindow for /query_range metric queries

### DIFF
--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -194,7 +194,7 @@ func (h *Handler) handleQueryRange(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	res, err := h.Engine.Query(r.Context(), h.langForRequest(start, end), q)
+	res, err := h.Engine.Query(r.Context(), h.langForRangeRequest(start, end, step), q)
 	if err != nil {
 		h.respondError(w, classifyEngineErr(err))
 		return
@@ -224,6 +224,20 @@ func (h *Handler) handleQueryRange(w http.ResponseWriter, r *http.Request) {
 // requested window.
 func (h *Handler) langForRequest(start, end time.Time) *logql.Lang {
 	return &logql.Lang{Schema: h.Schema, Start: start, End: end}
+}
+
+// langForRangeRequest builds a per-request *logql.Lang carrying the
+// request's [start, end, step] for metric queries. The engine threads
+// Step alongside Start / End so range-aggregation lowerings switch to
+// the matrix RangeWindow shape (one row per anchor across [start, end]
+// spaced by step). Without this, metric queries whose seeded data
+// lies outside the last 5 minutes of wall-clock return an empty matrix
+// because the windowed-array filter anchors at `now64(9)`. Log queries
+// also use this entry point — Step is harmless on the non-metric path
+// since lowerCtx.rangeMode() only fires inside the range-aggregation
+// lowering.
+func (h *Handler) langForRangeRequest(start, end time.Time, step time.Duration) *logql.Lang {
+	return &logql.Lang{Schema: h.Schema, Start: start, End: end, Step: step}
 }
 
 // writeEngineHeaders stamps the X-Cerberus-* response headers populated

--- a/internal/logql/lang.go
+++ b/internal/logql/lang.go
@@ -38,10 +38,20 @@ import (
 // + lower contract without an HTTP window). The handler constructs a
 // fresh *Lang per request; the long-lived bits (Schema) come from the
 // Handler so per-request allocation is cheap.
+//
+// Step carries the request's `step` for /loki/api/v1/query_range metric
+// queries. When > 0, the range-aggregation lowering switches to the
+// matrix RangeWindow shape (one row per anchor across [Start, End]
+// spaced by Step) so the emitter fans across the step grid instead of
+// anchoring at `now64(9)`. Without this, a metric query whose seeded
+// data lies outside the last 5 minutes of wall-clock returns an empty
+// matrix (the compat-harness 0/55 regression that surfaced when the
+// seed window drifted away from wall-clock).
 type Lang struct {
 	Schema schema.Logs
 	Start  time.Time
 	End    time.Time
+	Step   time.Duration
 }
 
 // errorTypes mirrors the Loki errorType vocabulary the handler emits.
@@ -75,7 +85,7 @@ func (l *Lang) Parse(ctx context.Context, query string) (chplan.Node, engine.Met
 	}
 
 	lowerT := telemetry.ObserveStage(telemetry.StageLower)
-	plan, err := LowerAt(ctx, expr, l.Schema, l.Start, l.End)
+	plan, err := LowerAtRange(ctx, expr, l.Schema, l.Start, l.End, l.Step)
 	lowerT.Done(ctx)
 	if err != nil {
 		return nil, engine.Meta{}, &httperr.Error{
@@ -137,19 +147,40 @@ func (l *Lang) ProjectSamples(plan chplan.Node, meta engine.Meta) chplan.Node {
 		if isVectorAggregateSampleShape(plan) {
 			attrsCol = "Attributes"
 		}
+		// TimeUnix source:
+		//   - Matrix-shape RangeWindow (OuterRange > 0): the inner SELECT
+		//     exposes the per-row anchor under the literal column
+		//     `anchor_ts`. Forward it so toMatrixStepGrid sees one row per
+		//     anchor across the request's step grid. Without this, the
+		//     outer synthesised `now64(9) - 5s` collapses every per-step
+		//     row into a single point — the matrix pivot then sees one
+		//     sample per series instead of one per step.
+		//   - Vector aggregate over matrix RangeWindow: the inner
+		//     `wrapVectorAggregateForSample` already projected TimeUnix
+		//     from the per-anchor bucket alias. Forward the existing
+		//     `TimeUnix` column rather than overwrite it.
+		//   - Instant shape: synthesise `now64(9) - 5s` as before so the
+		//     matrix pivot doesn't drop the only row when CH-now beats
+		//     the client-end timestamp.
+		var tsExpr chplan.Expr
+		switch {
+		case isVectorAggregateSampleShape(plan):
+			tsExpr = &chplan.ColumnRef{Name: "TimeUnix"}
+		case isMatrixRangeWindow(plan):
+			tsExpr = &chplan.ColumnRef{Name: "anchor_ts"}
+		default:
+			tsExpr = &chplan.Binary{
+				Op:    chplan.OpSub,
+				Left:  &chplan.FuncCall{Name: "now64", Args: []chplan.Expr{&chplan.LitInt{V: 9}}},
+				Right: &chplan.FuncCall{Name: "toIntervalNanosecond", Args: []chplan.Expr{&chplan.LitInt{V: 5_000_000_000}}},
+			}
+		}
 		return &chplan.Project{
 			Input: plan,
 			Projections: []chplan.Projection{
 				{Expr: &chplan.LitString{V: ""}, Alias: "MetricName"},
 				{Expr: &chplan.ColumnRef{Name: attrsCol}, Alias: "Attributes"},
-				// now64(9) - 5s buffer; see prom handler's synthesizedAnchor
-				// docstring. Avoids toMatrixStepGrid dropping the only row
-				// when CH-now > client-end.
-				{Expr: &chplan.Binary{
-					Op:    chplan.OpSub,
-					Left:  &chplan.FuncCall{Name: "now64", Args: []chplan.Expr{&chplan.LitInt{V: 9}}},
-					Right: &chplan.FuncCall{Name: "toIntervalNanosecond", Args: []chplan.Expr{&chplan.LitInt{V: 5_000_000_000}}},
-				}, Alias: "TimeUnix"},
+				{Expr: tsExpr, Alias: "TimeUnix"},
 				{Expr: &chplan.ColumnRef{Name: rangeAggSynthValueColumn}, Alias: "Value"},
 			},
 		}

--- a/internal/logql/lang_test.go
+++ b/internal/logql/lang_test.go
@@ -170,3 +170,133 @@ func TestProjectSamples_VectorAggregateRefsAttributes(t *testing.T) {
 			"consumed it)", attrsRef.Name, "Attributes")
 	}
 }
+
+// TestProjectSamples_MatrixRangeWindowRefsAnchorTs pins the metric-branch
+// wire-wrap against the loki-compatibility 0/55 regression where every
+// LogQL metric query (`count_over_time` / `rate` / `*_over_time`) over a
+// /loki/api/v1/query_range request returned an empty matrix.
+//
+// Root cause: LogQL's range-aggregation lowering left RangeWindow.Start /
+// End / Step / OuterRange zero, so the chsql emitter took the instant
+// path and anchored the windowed-array filter at `now64(9)`. Any query
+// whose seeded data lay outside the last 5 minutes of wall-clock (the
+// compat harness seeds day-old data) had every sample filtered out by
+// `arrayFilter(p -> tupleElement(p,1) > now64(9) - <range>, ...)`.
+//
+// The fix wires `lc.Step` + `lc.Start` / `lc.End` into the RangeWindow
+// so the matrix path fires (one row per anchor across [Start, End]
+// spaced by Step). The matrix RangeWindow exposes the per-row anchor
+// under the literal column `anchor_ts`; ProjectSamples must forward it
+// into the canonical TimeUnix slot — otherwise the outer synth
+// `now64(9) - 5s` collapses every per-step row into one point and the
+// matrix pivot drops everything but one sample per series.
+//
+// Mirrors the PromQL side's matrix-shape handling in
+// `wrapWithSampleProjection` (internal/api/prom/handler.go).
+func TestProjectSamples_MatrixRangeWindowRefsAnchorTs(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelLogs()
+	l := &logql.Lang{Schema: s}
+
+	// Synthetic matrix-shape RangeWindow: OuterRange + Step set the same
+	// way logql.LowerAtRange does when handed a non-zero step. The
+	// emitter's matrix path projects `anchor_ts` per row; ProjectSamples
+	// must rename it to TimeUnix on the outer SELECT.
+	plan := &chplan.RangeWindow{
+		Input:           &chplan.Scan{Table: s.LogsTable},
+		Func:            "count_over_time",
+		Range:           5 * time.Minute,
+		Step:            time.Minute,
+		OuterRange:      time.Hour,
+		Start:           time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		End:             time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC),
+		TimestampColumn: s.TimestampColumn,
+		ValueColumn:     "Value",
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: s.ResourceAttributesColumn}},
+	}
+
+	wrapped := l.ProjectSamples(plan, engine.Meta{IsMetric: true})
+
+	proj, ok := wrapped.(*chplan.Project)
+	if !ok {
+		t.Fatalf("ProjectSamples returned %T, want *chplan.Project", wrapped)
+	}
+	tsSlot := proj.Projections[2]
+	if tsSlot.Alias != "TimeUnix" {
+		t.Errorf("ts slot alias: got %q, want %q", tsSlot.Alias, "TimeUnix")
+	}
+	tsRef, ok := tsSlot.Expr.(*chplan.ColumnRef)
+	if !ok {
+		t.Fatalf("ts slot expr: got %T, want *chplan.ColumnRef (matrix path "+
+			"must forward the inner `anchor_ts` column; a synth now64-based "+
+			"expression would collapse every per-step row into one point)",
+			tsSlot.Expr)
+	}
+	if tsRef.Name != "anchor_ts" {
+		t.Errorf("ts slot ColumnRef.Name: got %q, want %q (matrix-shape "+
+			"RangeWindow exposes the per-row anchor under the literal column "+
+			"`anchor_ts`; synthing `now64(9) - 5s` here would drop every "+
+			"per-step row outside the matrix pivot's 5-minute lookback)",
+			tsRef.Name, "anchor_ts")
+	}
+}
+
+// TestProjectSamples_VectorAggregateOverMatrixForwardsTimeUnix pins the
+// "vector aggregation over a matrix-shape RangeWindow" path against the
+// sibling regression: `sum(count_over_time({...}[5m]))` over query_range.
+//
+// Inner shape: `wrapVectorAggregateForSample` re-aliases the Aggregate's
+// per-anchor bucket column to `TimeUnix` so the canonical Sample contract
+// carries one row per step. ProjectSamples must forward that existing
+// `TimeUnix` column rather than overwrite it with `now64(9) - 5s`; the
+// overwrite would collapse every per-step row into one point and the
+// matrix pivot would emit one sample per series instead of one per step.
+func TestProjectSamples_VectorAggregateOverMatrixForwardsTimeUnix(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelLogs()
+	l := &logql.Lang{Schema: s}
+
+	// Synthetic vector-aggregate output (matches `wrapVectorAggregateForSample`
+	// in range mode where bucket_ts → TimeUnix). The presence of an
+	// "Attributes" alias is the canonical-shape marker; the TimeUnix slot
+	// is a `bucket_ts` ColumnRef (re-aliased to TimeUnix by the inner
+	// Project) carrying the per-anchor timestamp.
+	plan := &chplan.Project{
+		Input: &chplan.Scan{Table: s.LogsTable},
+		Projections: []chplan.Projection{
+			{Expr: &chplan.LitString{V: ""}, Alias: "MetricName"},
+			{Expr: &chplan.FuncCall{
+				Name: "CAST",
+				Args: []chplan.Expr{
+					&chplan.FuncCall{Name: "map", Args: nil},
+					&chplan.LitString{V: "Map(String,String)"},
+				},
+			}, Alias: "Attributes"},
+			{Expr: &chplan.ColumnRef{Name: "bucket_ts"}, Alias: "TimeUnix"},
+			{Expr: &chplan.ColumnRef{Name: "Value"}, Alias: "Value"},
+		},
+	}
+
+	wrapped := l.ProjectSamples(plan, engine.Meta{IsMetric: true})
+
+	proj, ok := wrapped.(*chplan.Project)
+	if !ok {
+		t.Fatalf("ProjectSamples returned %T, want *chplan.Project", wrapped)
+	}
+	tsSlot := proj.Projections[2]
+	tsRef, ok := tsSlot.Expr.(*chplan.ColumnRef)
+	if !ok {
+		t.Fatalf("ts slot expr: got %T, want *chplan.ColumnRef "+
+			"(vector-aggregate path must forward the inner `TimeUnix` column; "+
+			"a synth now64-based expression would collapse every per-step "+
+			"row into one point)", tsSlot.Expr)
+	}
+	if tsRef.Name != "TimeUnix" {
+		t.Errorf("ts slot ColumnRef.Name: got %q, want %q (vector-aggregate "+
+			"already projected the per-anchor bucket alias as the canonical "+
+			"`TimeUnix` slot via wrapVectorAggregateForSample — overwriting "+
+			"with synth now64 would drop per-step rows)", tsRef.Name, "TimeUnix")
+	}
+}

--- a/internal/logql/lower.go
+++ b/internal/logql/lower.go
@@ -35,15 +35,36 @@ var tracer = otel.Tracer("github.com/tsouza/cerberus/internal/logql")
 // is filtered down to the requested wire-format window at the SQL layer
 // (the previous behaviour returned every matching log row regardless of
 // the requested window — a Loki wire-format contract violation).
+//
+// Step carries the request's `step` for /loki/api/v1/query_range metric
+// queries. When > 0 (and the [Start, End] window is non-zero), the
+// range-aggregation lowering sets RangeWindow.{Start,End,Step,OuterRange}
+// so the emitter fans across the request's step grid via the matrix
+// path (one row per anchor in [Start, End], spaced by Step) instead of
+// the instant-eval shape that anchors at `now64(9)`. Without this, a
+// metric query whose seeded data lies outside the last 5 minutes of
+// wall-clock returns an empty matrix because the windowed-array filter
+// `arrayFilter(p -> tupleElement(p,1) > now64(9) - <range>, ...)` drops
+// every sample. Mirrors the PromQL LowerAtRange / lowerCtx.step shape
+// in internal/promql/lower.go.
 type lowerCtx struct {
 	Start time.Time
 	End   time.Time
+	Step  time.Duration
 }
 
 // hasTimeWindow reports whether the context carries a non-degenerate
 // [Start, End] pair to inject as a BETWEEN predicate.
 func (c lowerCtx) hasTimeWindow() bool {
 	return !c.Start.IsZero() && !c.End.IsZero()
+}
+
+// rangeMode reports whether the context carries a request step grid
+// (a non-zero Step on top of a non-zero [Start, End] pair). The
+// range-aggregation lowering switches to the matrix RangeWindow shape
+// only when this is true.
+func (c lowerCtx) rangeMode() bool {
+	return c.Step > 0 && c.hasTimeWindow()
 }
 
 // Lower turns a parsed LogQL expression into a chplan tree. No time
@@ -60,6 +81,15 @@ func Lower(ctx context.Context, expr syntax.Expr, s schema.Logs) (chplan.Node, e
 // passes start == end == ts (or [time-step, time] per Loki convention).
 func LowerAt(ctx context.Context, expr syntax.Expr, s schema.Logs, start, end time.Time) (chplan.Node, error) {
 	return lowerWithCtx(ctx, expr, s, lowerCtx{Start: start, End: end})
+}
+
+// LowerAtRange is the range-mode variant of [LowerAt]: it threads a
+// step duration alongside [start, end] so range-aggregation lowerings
+// can emit the matrix RangeWindow shape (one row per anchor across
+// [start, end] spaced by step). Mirrors PromQL's LowerAtRange. Step ≤ 0
+// falls back to the instant shape (same as LowerAt).
+func LowerAtRange(ctx context.Context, expr syntax.Expr, s schema.Logs, start, end time.Time, step time.Duration) (chplan.Node, error) {
+	return lowerWithCtx(ctx, expr, s, lowerCtx{Start: start, End: end, Step: step})
 }
 
 func lowerWithCtx(ctx context.Context, expr syntax.Expr, s schema.Logs, lc lowerCtx) (chplan.Node, error) {
@@ -369,7 +399,8 @@ func logfmtExpressionMergeLabels(prev chplan.Expr, s schema.Logs, exprs []loglib
 		if key == "" {
 			key = ext.Identifier
 		}
-		args = append(args,
+		args = append(
+			args,
 			renameIdentifierOnCollision(s, ext.Identifier),
 			&chplan.MapAccess{
 				Map: kvBase,
@@ -543,7 +574,8 @@ func jsonExpressionMergeLabels(prev chplan.Expr, s schema.Logs, exprs []loglib.L
 		if err != nil {
 			return nil, err
 		}
-		args = append(args,
+		args = append(
+			args,
 			&chplan.LitString{V: ext.Identifier},
 			extract,
 		)
@@ -629,7 +661,8 @@ func regexpMergeLabels(prev chplan.Expr, s schema.Logs, pattern string) (chplan.
 	}
 	mapArgs := make([]chplan.Expr, 0, len(named)*2)
 	for _, g := range named {
-		mapArgs = append(mapArgs,
+		mapArgs = append(
+			mapArgs,
 			&chplan.LitString{V: g.name},
 			// extractAllGroupsHorizontal(...)[<group>][1] — group i,
 			// first match. CH 1-indexes both dimensions. Allocate a

--- a/internal/logql/lower_test.go
+++ b/internal/logql/lower_test.go
@@ -23,12 +23,15 @@ var fixtureDir = filepath.Join("..", "..", "test", "spec", "logql")
 // the LogQL in `query.logql`, lowers it, emits SQL, and compares the
 // result to the recorded `sql` + `args` sections.
 //
-// Fixtures may optionally declare `start:` and `end:` sections (both
-// RFC3339Nano timestamps) — when present the lowering uses
-// [logql.LowerAt] so the emitted SQL carries a Timestamp BETWEEN
-// predicate matching what the Loki handler threads through at request
-// time. Fixtures without those sections lower via [logql.Lower] (no
-// time window) so the existing fixture corpus remains stable.
+// Fixtures may optionally declare `start:` / `end:` / `step:` sections.
+// `start:` + `end:` (both RFC3339Nano) thread a [start, end] window
+// through [logql.LowerAt], so the emitted SQL carries a Timestamp
+// BETWEEN predicate above every Scan(LogsTable). Adding a `step:`
+// duration (e.g. `1m`) lifts the lowering to [logql.LowerAtRange] so
+// range-aggregation lowerings switch to the matrix RangeWindow shape
+// (one row per anchor across [start, end] spaced by step). Fixtures
+// without any of these sections lower via [logql.Lower] (no time
+// window) so the existing fixture corpus remains stable.
 func TestLower(t *testing.T) {
 	t.Parallel()
 
@@ -46,15 +49,18 @@ func TestLower(t *testing.T) {
 			t.Fatalf("ParseExpr(%q): %v", query, err)
 		}
 
-		start, end, err := readWindowSections(c)
+		start, end, step, err := readWindowSections(c)
 		if err != nil {
 			t.Fatalf("window sections: %v", err)
 		}
 
 		var plan chplan.Node
-		if start.IsZero() && end.IsZero() {
+		switch {
+		case start.IsZero() && end.IsZero():
 			plan, err = logql.Lower(context.Background(), expr, s)
-		} else {
+		case step > 0:
+			plan, err = logql.LowerAtRange(context.Background(), expr, s, start, end, step)
+		default:
 			plan, err = logql.LowerAt(context.Background(), expr, s, start, end)
 		}
 		if err != nil {
@@ -73,17 +79,21 @@ func TestLower(t *testing.T) {
 	})
 }
 
-// readWindowSections pulls optional `start:` / `end:` RFC3339Nano
-// sections from c. Missing or empty sections return zero times so the
-// caller falls back to the no-window Lower path.
-func readWindowSections(c *spec.Case) (time.Time, time.Time, error) {
-	var start, end time.Time
+// readWindowSections pulls optional `start:` / `end:` (RFC3339Nano) and
+// `step:` (Go duration) sections from c. Missing or empty sections
+// return zero values so the caller falls back to the no-window Lower
+// path (or the no-step LowerAt path when only start/end are set).
+func readWindowSections(c *spec.Case) (time.Time, time.Time, time.Duration, error) {
+	var (
+		start, end time.Time
+		step       time.Duration
+	)
 	if v, ok := c.Section("start"); ok {
 		v = strings.TrimSpace(v)
 		if v != "" {
 			t, err := time.Parse(time.RFC3339Nano, v)
 			if err != nil {
-				return time.Time{}, time.Time{}, fmt.Errorf("start: %w", err)
+				return time.Time{}, time.Time{}, 0, fmt.Errorf("start: %w", err)
 			}
 			start = t
 		}
@@ -93,12 +103,22 @@ func readWindowSections(c *spec.Case) (time.Time, time.Time, error) {
 		if v != "" {
 			t, err := time.Parse(time.RFC3339Nano, v)
 			if err != nil {
-				return time.Time{}, time.Time{}, fmt.Errorf("end: %w", err)
+				return time.Time{}, time.Time{}, 0, fmt.Errorf("end: %w", err)
 			}
 			end = t
 		}
 	}
-	return start, end, nil
+	if v, ok := c.Section("step"); ok {
+		v = strings.TrimSpace(v)
+		if v != "" {
+			d, err := time.ParseDuration(v)
+			if err != nil {
+				return time.Time{}, time.Time{}, 0, fmt.Errorf("step: %w", err)
+			}
+			step = d
+		}
+	}
+	return start, end, step, nil
 }
 
 func formatArgs(args []any) string {

--- a/internal/logql/range_aggregation.go
+++ b/internal/logql/range_aggregation.go
@@ -103,6 +103,23 @@ func lowerRangeAggregation(e *syntax.RangeAggregationExpr, s schema.Logs, lc low
 		ValueColumn:     rangeAggSynthValueColumn,
 		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: s.ResourceAttributesColumn}},
 	}
+	// Range mode: fan the range function across the request's step grid
+	// so each anchor in [Start, End] (spaced by Step) emits one row per
+	// series with the per-anchor function value. Without this, the
+	// emitter anchors at `now64(9)` — a query whose [start, end] window
+	// lies outside the last 5 minutes of wall-clock (e.g. compatibility
+	// harnesses seeding day-old data) yields an empty matrix because the
+	// windowed-array filter
+	// `arrayFilter(p -> tupleElement(p,1) > now64(9) - <range>, ...)`
+	// drops every sample. Mirrors the PromQL side in lowerMatrixCall
+	// (internal/promql/lower.go::lowerMatrixCall) which sets the same
+	// fields when ctx.step > 0.
+	if lc.rangeMode() {
+		rw.Start = lc.Start.UTC()
+		rw.End = lc.End.UTC()
+		rw.Step = lc.Step
+		rw.OuterRange = lc.End.Sub(lc.Start)
+	}
 	if e.Operation == syntax.OpRangeTypeQuantile {
 		if e.Params == nil {
 			return nil, fmt.Errorf("logql: quantile_over_time requires a phi parameter")
@@ -165,6 +182,26 @@ func applyUnwrapPostFilters(inner chplan.Node, filters []loglib.LabelFilterer, s
 // one place keeps the two layers from drifting like they did between
 // #310 and the e2e-failures it surfaced.
 const rangeAggSynthValueColumn = "Value"
+
+// isMatrixRangeWindow reports whether plan's root (walking past
+// value-rewrite Projects / Filters that preserve the inner shape) is a
+// matrix-shape RangeWindow — one emitting N rows per series across
+// [Start, End] spaced by Step, exposing `anchor_ts` as a per-row
+// column. Used by both [Lang.ProjectSamples] (to forward `anchor_ts`
+// into the canonical TimeUnix slot) and [lowerVectorAggregation] (to
+// include `anchor_ts` in the GROUP BY so per-step rows don't collapse).
+// Mirrors prom's isMatrixRangeWindow in internal/api/prom/handler.go.
+func isMatrixRangeWindow(plan chplan.Node) bool {
+	switch v := plan.(type) {
+	case *chplan.RangeWindow:
+		return v.OuterRange > 0
+	case *chplan.Project:
+		return isMatrixRangeWindow(v.Input)
+	case *chplan.Filter:
+		return isMatrixRangeWindow(v.Input)
+	}
+	return false
+}
 
 // rangeValueExpr returns the per-row Value the RangeWindow aggregates.
 //
@@ -301,7 +338,8 @@ func rangeAggregationGroupBy(e *syntax.RangeAggregationExpr, s schema.Logs) (chp
 	}
 	args := make([]chplan.Expr, 0, len(e.Grouping.Groups)*2)
 	for _, label := range e.Grouping.Groups {
-		args = append(args,
+		args = append(
+			args,
 			&chplan.LitString{V: label},
 			&chplan.MapAccess{
 				Map: &chplan.ColumnRef{Name: s.ResourceAttributesColumn},

--- a/internal/logql/vector_aggregation.go
+++ b/internal/logql/vector_aggregation.go
@@ -38,6 +38,20 @@ func lowerVectorAggregation(e *syntax.VectorAggregationExpr, s schema.Logs, lc l
 		return nil, err
 	}
 
+	// In range mode the inner plan is a matrix-shape RangeWindow that
+	// exposes a per-row `anchor_ts` column (the eval anchor for that
+	// row). The aggregation MUST include that anchor in its GROUP BY
+	// keys — otherwise CH collapses every per-step row of a series-set
+	// into one aggregate and the wire matrix has a single value per
+	// series instead of one per step. Mirrors the PromQL aggregate
+	// lowering's `rangeBucketed` path in internal/promql/lower.go.
+	const bucketAlias = "bucket_ts"
+	rangeBucketed := lc.rangeMode() && isMatrixRangeWindow(input)
+	if rangeBucketed {
+		groupBy = append(groupBy, &chplan.ColumnRef{Name: "anchor_ts"})
+		aliases = append(aliases, bucketAlias)
+	}
+
 	agg := &chplan.Aggregate{
 		Input:              input,
 		GroupBy:            groupBy,
@@ -45,7 +59,11 @@ func lowerVectorAggregation(e *syntax.VectorAggregationExpr, s schema.Logs, lc l
 		AggFuncs:           []chplan.AggFunc{aggFunc},
 		DropEmptyOnNoGroup: true,
 	}
-	return wrapVectorAggregateForSample(agg, e, s, aliases), nil
+	userAliases := aliases
+	if rangeBucketed {
+		userAliases = aliases[:len(aliases)-1]
+	}
+	return wrapVectorAggregateForSample(agg, e, s, userAliases, rangeBucketed, bucketAlias), nil
 }
 
 // vectorAggregationGroupBy mirrors PromQL aggregateGroupBy, but Loki's
@@ -125,9 +143,15 @@ func buildVectorAggFunc(e *syntax.VectorAggregationExpr, _ schema.Logs) (chplan.
 //	Attributes  = map('lbl0', gkey_0, ...)    for `by (...)`
 //	            | gkey_0                        for `without (...)` (mapFilter output)
 //	            | empty Map(String,String)      for unaggregated
-//	TimeUnix    = now64(9)
+//	TimeUnix    = now64(9)                      (instant mode)
+//	            | <bucketAlias>                  (range mode: per-anchor anchor_ts)
 //	Value       = <agg alias>
-func wrapVectorAggregateForSample(agg *chplan.Aggregate, e *syntax.VectorAggregationExpr, s schema.Logs, aliases []string) chplan.Node {
+//
+// In range mode (rangeBucketed=true) the inner Aggregate carries the
+// per-anchor timestamp under bucketAlias; the outer Project re-aliases
+// it to TimeUnix so the canonical Sample shape exposes one row per step
+// instead of collapsing to one row per series at `now64(9)`.
+func wrapVectorAggregateForSample(agg *chplan.Aggregate, e *syntax.VectorAggregationExpr, s schema.Logs, aliases []string, rangeBucketed bool, bucketAlias string) chplan.Node {
 	var attrs chplan.Expr
 	switch {
 	case len(aliases) == 0:
@@ -152,12 +176,17 @@ func wrapVectorAggregateForSample(agg *chplan.Aggregate, e *syntax.VectorAggrega
 		valueCol      = "Value"
 	)
 
+	tsExpr := chplan.Expr(&chplan.FuncCall{Name: "now64", Args: []chplan.Expr{&chplan.LitInt{V: 9}}})
+	if rangeBucketed {
+		tsExpr = &chplan.ColumnRef{Name: bucketAlias}
+	}
+
 	return &chplan.Project{
 		Input: agg,
 		Projections: []chplan.Projection{
 			{Expr: &chplan.LitString{V: ""}, Alias: metricNameCol},
 			{Expr: attrs, Alias: attrsCol},
-			{Expr: &chplan.FuncCall{Name: "now64", Args: []chplan.Expr{&chplan.LitInt{V: 9}}}, Alias: tsCol},
+			{Expr: tsExpr, Alias: tsCol},
 			{Expr: &chplan.ColumnRef{Name: "Value"}, Alias: valueCol},
 		},
 	}

--- a/test/spec/logql/range_mode_count_over_time.txtar
+++ b/test/spec/logql/range_mode_count_over_time.txtar
@@ -1,0 +1,41 @@
+-- query.logql --
+count_over_time({service_name="web-server"}[5m])
+-- start --
+2026-01-01T00:00:00Z
+-- end --
+2026-01-01T00:01:00Z
+-- step --
+30s
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
+    (toDateTime64('2026-01-01 00:00:00', 9), 'a', map('service_name', 'web-server')),
+    (toDateTime64('2026-01-01 00:00:15', 9), 'b', map('service_name', 'web-server')),
+    (toDateTime64('2026-01-01 00:00:30', 9), 'c', map('service_name', 'web-server')),
+    (toDateTime64('2026-01-01 00:00:45', 9), 'd', map('service_name', 'web-server')),
+    (toDateTime64('2026-01-01 00:01:00', 9), 'e', map('service_name', 'web-server'));
+-- expected_rows --
+[
+  [{"service_name": "web-server"}, "2026-01-01T00:00:00Z", 1.0],
+  [{"service_name": "web-server"}, "2026-01-01T00:00:30Z", 3.0],
+  [{"service_name": "web-server"}, "2026-01-01T00:01:00Z", 5.0]
+]
+-- args --
+[0] int64 = 1
+[1] string = "2026-01-01 00:00:00.000000000"
+[2] int64 = 9
+[3] string = "2026-01-01 00:01:00.000000000"
+[4] int64 = 9
+[5] string = "service_name"
+[6] string = "web-server"
+-- chplan --
+RangeWindow func=count_over_time range=5m0s step=30s outerRange=1m0s ts=Timestamp value=Value groupBy=[ResourceAttributes] start=2026-01-01T00:00:00Z end=2026-01-01T00:01:00Z
+  Project [ResourceAttributes, Timestamp, 1 AS Value]
+    Filter predicate=((ResourceAttributes["service_name"] = "web-server") AND ((Timestamp >= toDateTime64("2026-01-01 00:00:00.000000000", 9)) AND (Timestamp <= toDateTime64("2026-01-01 00:01:00.000000000", 9))))
+      Scan(otel_logs)
+-- sql --
+SELECT `ResourceAttributes`, `anchor_ts`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, `anchor_ts`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, `anchor_ts`, arrayFilter(p -> tupleElement(p, 1) > anchor_ts - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= anchor_ts, series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, `series_array`, arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:01:00.000000000', 9) - toIntervalNanosecond(i * 30000000000), range(0, 3))) AS `anchor_ts` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`Timestamp` >= toDateTime64(?, ?)) AND (`Timestamp` <= toDateTime64(?, ?)) AND (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`)))) WHERE length(`window_vals`) >= 1

--- a/test/spec/logql/range_mode_sum_count_over_time.txtar
+++ b/test/spec/logql/range_mode_sum_count_over_time.txtar
@@ -1,0 +1,45 @@
+-- query.logql --
+sum(count_over_time({service_name="web-server"}[5m]))
+-- start --
+2026-01-01T00:00:00Z
+-- end --
+2026-01-01T00:01:00Z
+-- step --
+30s
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
+    (toDateTime64('2026-01-01 00:00:00', 9), 'a', map('service_name', 'web-server')),
+    (toDateTime64('2026-01-01 00:00:15', 9), 'b', map('service_name', 'web-server')),
+    (toDateTime64('2026-01-01 00:00:30', 9), 'c', map('service_name', 'web-server')),
+    (toDateTime64('2026-01-01 00:00:45', 9), 'd', map('service_name', 'web-server')),
+    (toDateTime64('2026-01-01 00:01:00', 9), 'e', map('service_name', 'web-server'));
+-- expected_rows --
+[
+  ["", {}, "2026-01-01T00:00:00Z", 1.0],
+  ["", {}, "2026-01-01T00:00:30Z", 3.0],
+  ["", {}, "2026-01-01T00:01:00Z", 5.0]
+]
+-- args --
+[0] string = ""
+[1] string = "Map(String,String)"
+[2] int64 = 1
+[3] string = "2026-01-01 00:00:00.000000000"
+[4] int64 = 9
+[5] string = "2026-01-01 00:01:00.000000000"
+[6] int64 = 9
+[7] string = "service_name"
+[8] string = "web-server"
+-- chplan --
+Project ["" AS MetricName, CAST(map(), "Map(String,String)") AS Attributes, bucket_ts AS TimeUnix, Value AS Value]
+  Aggregate groupBy=[anchor_ts AS bucket_ts] funcs=[sum(Value) AS Value]
+    RangeWindow func=count_over_time range=5m0s step=30s outerRange=1m0s ts=Timestamp value=Value groupBy=[ResourceAttributes] start=2026-01-01T00:00:00Z end=2026-01-01T00:01:00Z
+      Project [ResourceAttributes, Timestamp, 1 AS Value]
+        Filter predicate=((ResourceAttributes["service_name"] = "web-server") AND ((Timestamp >= toDateTime64("2026-01-01 00:00:00.000000000", 9)) AND (Timestamp <= toDateTime64("2026-01-01 00:01:00.000000000", 9))))
+          Scan(otel_logs)
+-- sql --
+SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, `bucket_ts` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `anchor_ts` AS `bucket_ts`, sum(`Value`) AS `Value` FROM (SELECT `ResourceAttributes`, `anchor_ts`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, `anchor_ts`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, `anchor_ts`, arrayFilter(p -> tupleElement(p, 1) > anchor_ts - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= anchor_ts, series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, `series_array`, arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:01:00.000000000', 9) - toIntervalNanosecond(i * 30000000000), range(0, 3))) AS `anchor_ts` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`Timestamp` >= toDateTime64(?, ?)) AND (`Timestamp` <= toDateTime64(?, ?)) AND (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`)))) WHERE length(`window_vals`) >= 1) GROUP BY `anchor_ts`)


### PR DESCRIPTION
## Summary

- LogQL's range-aggregation lowering left `RangeWindow.{Start,End,Step,OuterRange}` zero, so the chsql emitter took the instant path and anchored the windowed-array filter at `now64(9)`. Every `count_over_time` / `rate` / `*_over_time` query whose seeded data lay outside the last 5 minutes of wall-clock had every sample filtered out by `arrayFilter(p -> tupleElement(p,1) > now64(9) - <range>, ...)` — the loki-compatibility 0/55 regression.
- Thread the request's `step` from `/loki/api/v1/query_range` down through a new `LowerAtRange` entry point + `lowerCtx.Step` field. Lift the range-aggregation lowering to the matrix shape (one row per anchor across `[Start, End]` spaced by Step), thread `anchor_ts` through the vector-aggregate `GROUP BY`, and forward it into the canonical TimeUnix slot in `Lang.ProjectSamples`. Mirror of the PromQL side's `LowerAtRange` / `ctx.step` pattern.

## Root cause

The seeded compat data is at `2026-05-11/12`; the harness runs queries with `start=2026-05-11T00:00:00 end=2026-05-12T00:00:00 step=1m`. Before this fix the emitted SQL anchored the windowed-array filter at `now64(9)` (current wall-clock, ~2026-05-19 in CI). Every sample fell outside `(now64() - 5m, now64()]` and the matrix came back empty.

PromQL solved the same problem in `lowerMatrixCall` via `ctx.step > 0 && !ctx.start.IsZero() && !ctx.end.IsZero()` → `rw.Start = ctx.start, rw.End = ctx.end, rw.Step = ctx.step, rw.OuterRange = ctx.end.Sub(ctx.start)`. This PR ports that switch to LogQL.

## Before / after (one-case repro)

Query (from `compatibility/loki/...`):

```
sum(count_over_time({service=\"mimir\", ...}[5m]))
start=2026-05-11T00:00:00Z end=2026-05-12T00:00:00Z step=1m
```

- **Before:** empty matrix from cerberus, full matrix from reference Loki → \"test endpoint returned empty\" diff.
- **After:** matrix with 1441 anchors (one per minute) carrying the per-step count, matching the reference.

## Files touched

- `internal/logql/lower.go` — add `Step` to `lowerCtx`; add `rangeMode()` helper; add `LowerAtRange` entry point.
- `internal/logql/range_aggregation.go` — wire `Start/End/Step/OuterRange` onto the emitted RangeWindow when `lc.rangeMode()`; add shared `isMatrixRangeWindow` helper.
- `internal/logql/vector_aggregation.go` — append `anchor_ts` to GROUP BY in range mode; re-alias `bucket_ts → TimeUnix` in the outer wrap so per-step rows survive the Aggregate collapse.
- `internal/logql/lang.go` — add `Step` field to `Lang`; route lowering through `LowerAtRange`; teach `ProjectSamples` to forward `anchor_ts` / `TimeUnix` per inner shape.
- `internal/api/loki/handler.go` — add `langForRangeRequest(start, end, step)`; wire it for `/loki/api/v1/query_range`.
- `internal/logql/lang_test.go` — pin TimeUnix slot resolution for both bare matrix RangeWindow (forward `anchor_ts`) and vector-aggregate over matrix (forward `TimeUnix`).
- `internal/logql/lower_test.go` — accept a `step:` TXTAR section so fixtures can opt into `LowerAtRange`.
- `test/spec/logql/range_mode_count_over_time.txtar` — chDB roundtrip pinning the bare matrix RangeWindow shape and expected per-step values (1.0 / 3.0 / 5.0 at 00:00 / 00:30 / 01:00 from a 5-point dataset over [00:00, 01:00] @ 30s step).
- `test/spec/logql/range_mode_sum_count_over_time.txtar` — chDB roundtrip pinning the vector-aggregate-over-matrix shape and the same per-step values flow through `sum(...)`.

## Expected compat score delta

`loki-compatibility` 0/55 → ~40/55 (every metric-pipeline case currently failing with \"test endpoint returned empty\"). Lifts the LogQL compat score from 0% to ~70% — the headline RC7 deliverable per the earlier compat-verification report.

## Test plan

- [x] `go test ./internal/logql/... ./internal/api/loki/...` — 467 pass
- [x] `go test -tags chdb ./test/spec/...` — 499 pass (includes the two new fixtures)
- [x] `go test ./internal/chsql/... ./internal/chplan/... ./internal/engine/...` — 802 pass (no shape regressions on the emitter side)
- [ ] CI `check` + `lint` jobs
- [ ] Loki-compatibility informational run after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)