### PR TITLE
fix(harness/tempo-compat): accept string-encoded timestampMs in metrics decoder

### DIFF
--- a/compatibility/tempo/driver/differ_metrics.go
+++ b/compatibility/tempo/driver/differ_metrics.go
@@ -34,8 +34,40 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strconv"
 	"strings"
 )
+
+// FlexInt64 is an int64 that decodes from either a JSON number or a
+// JSON string-encoded integer. Tempo's /api/metrics response encodes
+// `timestampMs` as a JSON string in recent tags (the protobuf-to-JSON
+// projection emits int64 fields as strings to dodge JS-number precision
+// loss), while cerberus emits the same field as a plain number. The
+// differ needs to decode both shapes.
+//
+// The underlying type is int64 so existing callers that read the field
+// (`%d` formatting, `<` comparisons, arithmetic) keep working without
+// any conversion.
+type FlexInt64 int64
+
+// UnmarshalJSON accepts either a JSON number or a JSON string holding
+// a base-10 integer. Any other shape (object, bool, null) returns an
+// error so a malformed body still fails loudly.
+func (f *FlexInt64) UnmarshalJSON(b []byte) error {
+	// Strip outer quotes if present so we can parse the inner integer
+	// uniformly. JSON strings are guaranteed to start with `"` and end
+	// with `"`; everything else is forwarded to strconv as-is.
+	s := string(b)
+	if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
+		s = s[1 : len(s)-1]
+	}
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return fmt.Errorf("FlexInt64: cannot parse %q as int64: %w", string(b), err)
+	}
+	*f = FlexInt64(n)
+	return nil
+}
 
 // MetricsResponse is the differ-side struct mirroring Tempo's
 // /api/metrics/query_range envelope (and the /api/metrics/query
@@ -127,10 +159,12 @@ func (l *MetricsLabel) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// MetricsSample is a single (timestampMs, value) point.
+// MetricsSample is a single (timestampMs, value) point. TimestampMs
+// uses FlexInt64 so the differ accepts both wire shapes Tempo and
+// cerberus emit (number vs string-encoded int64); see FlexInt64.
 type MetricsSample struct {
-	TimestampMs int64   `json:"timestampMs"`
-	Value       float64 `json:"value"`
+	TimestampMs FlexInt64 `json:"timestampMs"`
+	Value       float64   `json:"value"`
 }
 
 // MetricsExemplar is one exemplar attached to a series. The Labels are
@@ -139,7 +173,7 @@ type MetricsSample struct {
 type MetricsExemplar struct {
 	Labels      []MetricsLabel `json:"labels,omitempty"`
 	Value       float64        `json:"value"`
-	TimestampMs int64          `json:"timestampMs"`
+	TimestampMs FlexInt64      `json:"timestampMs"`
 }
 
 // metricsCanonicalKey produces the differ-internal series identifier

--- a/compatibility/tempo/driver/differ_metrics_test.go
+++ b/compatibility/tempo/driver/differ_metrics_test.go
@@ -46,6 +46,94 @@ func TestMetricsLabel_UnmarshalEmptyAnyValue(t *testing.T) {
 	}
 }
 
+// TestMetricsSample_TimestampMs_NumberWire pins the cerberus-side wire
+// shape: `timestampMs` is a JSON number. Both endpoints' decoders must
+// keep handling it after the FlexInt64 swap.
+func TestMetricsSample_TimestampMs_NumberWire(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"series":[{"labels":[{"key":"k","value":"v"}],"samples":[{"timestampMs":1747000000,"value":1.5}]}]}`)
+	m, err := decodeMetrics(body)
+	if err != nil {
+		t.Fatalf("decodeMetrics number-shape timestamp: %v", err)
+	}
+	if got := m.Series[0].Samples[0].TimestampMs; got != 1747000000 {
+		t.Fatalf("TimestampMs = %d, want 1747000000", got)
+	}
+}
+
+// TestMetricsSample_TimestampMs_StringWire pins the recent Tempo wire
+// shape: `timestampMs` is a JSON string holding a base-10 int64. The
+// upstream protobuf-to-JSON projection emits int64 fields as strings
+// to dodge JS-number precision loss. Before FlexInt64 this body failed
+// to decode with `json: cannot unmarshal string into Go struct field
+// MetricsSample.series.samples.timestampMs of type int64`, which then
+// surfaced in the compatibility report as ERROR for the three metrics
+// cases (count_over_time, quantile_over_time, rate_no_groupby).
+func TestMetricsSample_TimestampMs_StringWire(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"series":[{"labels":[{"key":"k","value":"v"}],"samples":[{"timestampMs":"1747000000","value":1.5}]}]}`)
+	m, err := decodeMetrics(body)
+	if err != nil {
+		t.Fatalf("decodeMetrics string-shape timestamp: %v", err)
+	}
+	if got := m.Series[0].Samples[0].TimestampMs; got != 1747000000 {
+		t.Fatalf("TimestampMs = %d, want 1747000000", got)
+	}
+}
+
+// TestMetricsExemplar_TimestampMs_StringWire covers the exemplar path
+// because exemplars use the same JSON projection as samples — Tempo
+// string-encodes both.
+func TestMetricsExemplar_TimestampMs_StringWire(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"series":[{
+		"labels":[{"key":"k","value":"v"}],
+		"samples":[{"timestampMs":"1000","value":1}],
+		"exemplars":[{"timestampMs":"1500","value":1.2,"labels":[{"key":"k","value":"v"}]}]
+	}]}`)
+	m, err := decodeMetrics(body)
+	if err != nil {
+		t.Fatalf("decodeMetrics exemplar string-shape timestamp: %v", err)
+	}
+	if got := m.Series[0].Exemplars[0].TimestampMs; got != 1500 {
+		t.Fatalf("Exemplar TimestampMs = %d, want 1500", got)
+	}
+}
+
+// TestMetricsSample_TimestampMs_Malformed pins the loud-fail behaviour
+// on a malformed body so a bad wire shape still produces a decode
+// error (rather than silently zero-filling the timestamp).
+func TestMetricsSample_TimestampMs_Malformed(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"series":[{"labels":[],"samples":[{"timestampMs":"not-a-number","value":1}]}]}`)
+	if _, err := decodeMetrics(body); err == nil {
+		t.Fatal("expected decode error for non-integer string timestamp, got nil")
+	}
+}
+
+// TestCompareMetrics_MixedTimestampWire is the cross-shape parity case
+// that motivated the fix: tempo-side string-encoded `timestampMs`,
+// cerberus-side number-encoded `timestampMs`. Same numeric value, same
+// label set, same float value — the differ must report Equal=true.
+func TestCompareMetrics_MixedTimestampWire(t *testing.T) {
+	t.Parallel()
+	tempoSide := []byte(`{"series":[
+		{"labels":[{"key":"k","value":"v"}],
+		 "samples":[{"timestampMs":"1747000000","value":1.5}]}
+	]}`)
+	cerberusSide := []byte(`{"series":[
+		{"labels":[{"key":"k","value":"v"}],
+		 "samples":[{"timestampMs":1747000000,"value":1.5}]}
+	]}`)
+	d, err := CompareMetrics(tempoSide, cerberusSide, "tempo", "cerberus", DefaultDiffOptions())
+	if err != nil {
+		t.Fatalf("CompareMetrics: %v", err)
+	}
+	if !d.Equal {
+		t.Fatalf("expected Equal across mixed timestampMs wire shapes, got reasons=%v", d.Reasons)
+	}
+}
+
 func TestCompareMetrics_Identical(t *testing.T) {
 	t.Parallel()
 	body := []byte(`{"series":[


### PR DESCRIPTION
## Summary

Tempo's `/api/metrics` response encodes `timestampMs` as a JSON **string** in recent tags (the protobuf-to-JSON projection emits int64 fields as strings to dodge JS-number precision loss), while cerberus emits the same field as a plain JSON number. The differ's `MetricsSample` / `MetricsExemplar` structs in `compatibility/tempo/driver/differ_metrics.go` declared `TimestampMs int64`, so Tempo bodies failed to decode with:

```
json: cannot unmarshal string into Go struct field MetricsSample.series.samples.timestampMs of type int64
```

That decode error surfaced in the compatibility report as **ERROR** for three metrics cases:

- `metrics_count_over_time_groupby_service`
- `metrics_quantile_over_time_p95`
- `metrics_rate_no_groupby`

This is a **harness-side** bug — cerberus's own response shape is fine; the differ just needs to accept both wire forms of the same numeric value.

## What changed

- Introduce a `FlexInt64` named type (`type FlexInt64 int64`) with a custom `UnmarshalJSON` that accepts either a JSON number or a JSON string holding a base-10 int64. Other shapes (object, bool, null, non-integer strings) return an error so a malformed body still fails loudly.
- Swap `MetricsSample.TimestampMs` and `MetricsExemplar.TimestampMs` from `int64` to `FlexInt64`.
- Underlying type stays `int64`, so every call-site (sort comparator, `%d` formatting, equality, arithmetic) keeps working without explicit conversion.

## Tests

Five unit tests in `differ_metrics_test.go` pin every path:

1. `TestMetricsSample_TimestampMs_NumberWire` — cerberus-style JSON number.
2. `TestMetricsSample_TimestampMs_StringWire` — Tempo-style JSON string.
3. `TestMetricsExemplar_TimestampMs_StringWire` — exemplars use the same projection.
4. `TestMetricsSample_TimestampMs_Malformed` — non-integer string is rejected loudly.
5. `TestCompareMetrics_MixedTimestampWire` — cross-shape `CompareMetrics` returns Equal=true.

## Expected compat score delta

The three ERROR cases listed above can now decode and be diffed. Whether they ultimately PASS or DIFF depends on cerberus output once decoding works — but at minimum they stop being ERROR, which unblocks the differential signal for those queries.

## Test plan

- [ ] CI `check` job: existing `differ_metrics_test.go` tests still pass; new tests pass.
- [ ] CI `lint` job: `gofumpt -w` already applied to both touched files; `goimports` clean.
- [ ] Next compat-tempo run picks up the decode fix; three previously ERROR cases move to PASS or DIFF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)