### PR TITLE
fix(traceql): preserve TraceId in | count() / | avg() second-stage aggregation

### DIFF
--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -506,15 +506,29 @@ func wrapWithSampleProjection(plan chplan.Node, s schema.Traces, meta engine.Met
 		default:
 			return &chplan.Project{Input: plan, Projections: rQualifiedSampleProjections(s)}
 		}
+	case isSpansetAggregateShape(plan):
+		// `| count()` / `| avg()` / `| sum()` / `| min()` / `| max()`
+		// — second-stage spanset aggregates lowered by
+		// internal/traceql/aggregate.go. The Aggregate groups by
+		// TraceId so the per-trace search envelope is preserved (one
+		// row per matching trace). lowerAggregate piggybacks the
+		// envelope columns onto the AggFuncs list (`any(SpanName) AS
+		// MetricName`, `any(ResourceAttributes) AS ResourceAttrs`,
+		// `min(Timestamp) AS TimeUnix`) so the wrap projection just
+		// reads them out + merges the TraceId into Attributes via
+		// mapConcat (same `__cerberus_traceID` reserved-key pattern as
+		// canonicalSampleProjections).
+		return &chplan.Project{Input: plan, Projections: spansetAggregateSampleProjections()}
 	case isAggregateShape(plan):
-		// Aggregate output is just (group-keys, agg-func-aliases). SpanName
-		// and Duration aren't in scope; synthesise the missing pieces.
-		// The aggregate's alias is "Value" by convention (set by
-		// internal/traceql/aggregate.go); other code shapes that emit a
-		// different alias would need to thread it through. count() has
-		// no GROUP BY so ResourceAttributes isn't in scope either — use
-		// an empty Map(String,String) CAST, same pattern as PromQL's
-		// emptyAttrsMap helper.
+		// MetricsAggregate / MetricsSecondStage output is just
+		// (group-keys, agg-func-aliases). SpanName / Timestamp /
+		// Duration aren't in scope; synthesise the missing pieces.
+		// The aggregate's alias is "Value" by convention. The metrics
+		// paths bypass wrapWithSampleProjection (see
+		// metrics_query_range.go / metrics_query_instant.go), so this
+		// branch only fires when a metrics-pipeline query somehow
+		// lands on /api/search; the empty-MetricName synthesis keeps
+		// the response shape sane.
 		return &chplan.Project{Input: plan, Projections: []chplan.Projection{
 			{Expr: &chplan.LitString{V: ""}, Alias: "MetricName"},
 			{Expr: emptyAttrsMap(), Alias: "Attributes"},
@@ -730,6 +744,79 @@ func isAggregateShape(plan chplan.Node) bool {
 		return false
 	}
 	return false
+}
+
+// isSpansetAggregateShape reports whether the plan's root is the
+// per-trace spanset aggregate shape produced by
+// internal/traceql/aggregate.go: a *chplan.Aggregate whose AggFuncs
+// list carries the envelope-column aliases (MetricName /
+// ResourceAttrs / TimeUnix) alongside Value. The scalar-filter HAVING
+// wrap (`| count() > 0`) puts a Filter on top — recurse through
+// Filter so both `| count()` and `| count() > 0` hit this branch.
+// MetricsAggregate / MetricsSecondStage (metrics-pipeline output)
+// deliberately fall through; the metrics search-envelope shape is
+// distinct (no TraceId group key, no `__cerberus_traceID` thread).
+func isSpansetAggregateShape(plan chplan.Node) bool {
+	switch v := plan.(type) {
+	case *chplan.Aggregate:
+		return aggregateCarriesSpansetEnvelope(v)
+	case *chplan.Filter:
+		return isSpansetAggregateShape(v.Input)
+	}
+	return false
+}
+
+// aggregateCarriesSpansetEnvelope reports whether a *chplan.Aggregate
+// has the envelope-column aliases (MetricName, ResourceAttrs,
+// TimeUnix) in its AggFuncs list — the marker that
+// internal/traceql/aggregate.go's lowerAggregate produced it (vs e.g.
+// a hand-rolled aggregate from a future call-site). The check keys
+// off alias presence rather than a structural type so the wrap
+// projection stays decoupled from the lowering layer.
+func aggregateCarriesSpansetEnvelope(a *chplan.Aggregate) bool {
+	wanted := map[string]bool{
+		"MetricName":    false,
+		"ResourceAttrs": false,
+		"TimeUnix":      false,
+	}
+	for _, af := range a.AggFuncs {
+		if _, ok := wanted[af.Alias]; ok {
+			wanted[af.Alias] = true
+		}
+	}
+	for _, found := range wanted {
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+// spansetAggregateSampleProjections returns the wrap-projection used
+// when the plan root is the per-trace spanset Aggregate shape
+// produced by internal/traceql/aggregate.go. The inner Aggregate
+// already emits the per-trace envelope columns (MetricName,
+// ResourceAttrs, TimeUnix) alongside (TraceId, Value); this outer
+// Project merges the TraceId into Attributes via the
+// `__cerberus_traceID` reserved-key pattern and casts Value to
+// float64 — same wire shape as canonicalSampleProjections but
+// reading from the Aggregate's projected columns rather than the
+// raw spans-table columns.
+func spansetAggregateSampleProjections() []chplan.Projection {
+	traceIDMap := &chplan.FuncCall{Name: "map", Args: []chplan.Expr{
+		&chplan.LitString{V: searchKeyTraceID},
+		&chplan.ColumnRef{Name: "TraceId"},
+	}}
+	mergedAttrs := &chplan.FuncCall{Name: "mapConcat", Args: []chplan.Expr{
+		&chplan.ColumnRef{Name: "ResourceAttrs"},
+		traceIDMap,
+	}}
+	return []chplan.Projection{
+		{Expr: &chplan.ColumnRef{Name: "MetricName"}, Alias: "MetricName"},
+		{Expr: mergedAttrs, Alias: "Attributes"},
+		{Expr: &chplan.ColumnRef{Name: "TimeUnix"}, Alias: "TimeUnix"},
+		{Expr: &chplan.FuncCall{Name: "toFloat64", Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}}, Alias: "Value"},
+	}
 }
 
 // toTraceSummaries pivots samples into the per-trace summary shape

--- a/internal/api/tempo/handler_test.go
+++ b/internal/api/tempo/handler_test.go
@@ -511,6 +511,69 @@ func TestSearch_SQLProjectsParentSpanId(t *testing.T) {
 	}
 }
 
+// TestSearch_SpansetAggregate_PerTrace asserts that
+// `{ ... } | count() > 0` returns one summary per matching trace
+// with real rootServiceName / rootTraceName fields, NOT a single
+// corpus-wide row with empty envelope. Mirrors the
+// count_spans_per_trace tempo-compat case.
+func TestSearch_SpansetAggregate_PerTrace(t *testing.T) {
+	t.Parallel()
+	const (
+		traceA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		traceB = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+		traceC = "cccccccccccccccccccccccccccccccc"
+	)
+	q := &stubQuerier{
+		samples: []chclient.Sample{
+			{
+				MetricName: "POST /api/orders",
+				Labels:     map[string]string{"service.name": "checkout", "__cerberus_traceID": traceA},
+				Timestamp:  time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC),
+				Value:      3,
+			},
+			{
+				MetricName: "GET /healthz",
+				Labels:     map[string]string{"service.name": "frontend", "__cerberus_traceID": traceB},
+				Timestamp:  time.Date(2026, 5, 12, 10, 0, 5, 0, time.UTC),
+				Value:      2,
+			},
+			{
+				MetricName: "db.query",
+				Labels:     map[string]string{"service.name": "db", "__cerberus_traceID": traceC},
+				Timestamp:  time.Date(2026, 5, 12, 10, 0, 10, 0, time.UTC),
+				Value:      1,
+			},
+		},
+	}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/search?q=%7B%20resource.service.name%20%3D~%20%22.%2B%22%20%7D%20%7C%20count%28%29%20%3E%200")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	var sr tempo.SearchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&sr); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(sr.Traces) != 3 {
+		t.Fatalf("expected 3 traces (one per matching TraceID), got %d", len(sr.Traces))
+	}
+	if sr.Traces[0].TraceID != traceA || sr.Traces[0].RootServiceName != "checkout" || sr.Traces[0].RootTraceName != "POST /api/orders" {
+		t.Errorf("trace A summary mismatch: %+v", sr.Traces[0])
+	}
+	if sr.Traces[1].TraceID != traceB || sr.Traces[1].RootServiceName != "frontend" || sr.Traces[1].RootTraceName != "GET /healthz" {
+		t.Errorf("trace B summary mismatch: %+v", sr.Traces[1])
+	}
+	if sr.Traces[2].TraceID != traceC || sr.Traces[2].RootServiceName != "db" || sr.Traces[2].RootTraceName != "db.query" {
+		t.Errorf("trace C summary mismatch: %+v", sr.Traces[2])
+	}
+}
+
 // isHexLower reports whether s is a non-empty lowercase hex string.
 // The OTel CH exporter writes TraceId via hex.EncodeToString, which
 // produces lowercase a-f digits.

--- a/internal/traceql/aggregate.go
+++ b/internal/traceql/aggregate.go
@@ -13,60 +13,125 @@ import (
 	"github.com/tsouza/cerberus/internal/schema"
 )
 
+// Aggregate output-column aliases for the second-stage spanset
+// aggregates (`| count()`, `| sum(...)`, `| avg(...)`, `| max(...)`,
+// `| min(...)`).
+//
+// TraceQL semantics make the spanset aggregates trace-scoped: `{ ... }
+// | count() > 0` returns one row per matching trace, NOT a single
+// corpus-wide row. The lowering therefore groups by TraceId and
+// piggybacks the per-trace envelope columns (representative SpanName,
+// merged ResourceAttributes, earliest Timestamp) onto the Aggregate's
+// AggFunc list so the wrap projection (internal/api/tempo/handler.go:
+// wrapWithSampleProjection's aggregate-shape branch) can surface a
+// real per-trace summary instead of synthesising empty
+// rootServiceName / rootTraceName fields.
+//
+// `aggResourceAttrsAlias` names an `any(ResourceAttributes)`
+// projection on the inner Aggregate; the wrap-projection then merges
+// it with `map('__cerberus_traceID', TraceId)` via mapConcat in an
+// outer Project layer. This split keeps the Aggregate pure (group
+// keys + aggregate calls only — no derived expressions wrapping both)
+// while still threading the per-trace identity into the search
+// envelope.
+const (
+	aggTraceIDAlias       = "TraceId"
+	aggValueAlias         = "Value"
+	aggMetricNameAlias    = "MetricName"
+	aggResourceAttrsAlias = "ResourceAttrs"
+	aggTimeUnixAlias      = "TimeUnix"
+)
+
 // lowerAggregate handles `| count()`, `| sum(...)`, `| avg(...)`,
 // `| max(...)`, `| min(...)`. count() has no inner expression — we
 // aggregate the constant 1 per row. The other four read the inner
 // FieldExpression via the upstream-fork-exposed Aggregate.InnerExpr()
 // accessor (github.com/tsouza/tempo:cerberus-accessors) — see
 // docs/upstream-forks.md.
+//
+// Per-trace identity is preserved by grouping on TraceId and
+// piggybacking representative envelope columns (SpanName,
+// ResourceAttributes, Timestamp) via `any(...)` / `min(...)`
+// aggregates so the search envelope surfaces real
+// rootServiceName / rootTraceName / startTime values for each
+// returned trace rather than collapsing the whole corpus into one row.
 func lowerAggregate(prev chplan.Node, agg traceql.Aggregate, s schema.Traces) (chplan.Node, error) {
 	chFunc, err := mapAggregateOp(agg.Op())
 	if err != nil {
 		return nil, err
 	}
 
-	const valueAlias = "Value"
-
-	// count() takes no inner expression — aggregate a constant.
+	var valueFunc chplan.AggFunc
 	if agg.Op() == traceql.AggregateCount {
-		return &chplan.Aggregate{
-			Input: prev,
-			AggFuncs: []chplan.AggFunc{{
-				Name:  chFunc,
-				Args:  []chplan.Expr{&chplan.LitInt{V: 1}},
-				Alias: valueAlias,
-			}},
-		}, nil
-	}
+		// count() takes no inner expression — aggregate a constant.
+		valueFunc = chplan.AggFunc{
+			Name:  chFunc,
+			Args:  []chplan.Expr{&chplan.LitInt{V: 1}},
+			Alias: aggValueAlias,
+		}
+	} else {
+		// sum/avg/max/min — read the inner FieldExpression via the fork
+		// accessor and lower it.
+		inner := agg.InnerExpr()
+		if inner == nil {
+			return nil, fmt.Errorf("traceql: aggregate `%s` has nil inner expression", agg.Op())
+		}
+		arg, err := lowerFieldExpr(inner, s)
+		if err != nil {
+			return nil, err
+		}
 
-	// sum/avg/max/min — read the inner FieldExpression via the fork
-	// accessor and lower it.
-	inner := agg.InnerExpr()
-	if inner == nil {
-		return nil, fmt.Errorf("traceql: aggregate `%s` has nil inner expression", agg.Op())
-	}
-	arg, err := lowerFieldExpr(inner, s)
-	if err != nil {
-		return nil, err
-	}
+		// Map(String, String) coercion: when the aggregate input is a
+		// FieldAccess against SpanAttributes / ResourceAttributes the value
+		// is a String. ClickHouse refuses `max(String) > 100` with
+		// NO_COMMON_TYPE; wrap in `toFloat64OrZero(...)` at lowering time so
+		// the aggregate sees a Float64 and the downstream numeric
+		// comparison resolves. Intrinsic ColumnRefs (Duration etc.) lower
+		// to a bare ColumnRef and pass through unchanged.
+		arg = coerceMapNumericAggInput(arg)
 
-	// Map(String, String) coercion: when the aggregate input is a
-	// FieldAccess against SpanAttributes / ResourceAttributes the value
-	// is a String. ClickHouse refuses `max(String) > 100` with
-	// NO_COMMON_TYPE; wrap in `toFloat64OrZero(...)` at lowering time so
-	// the aggregate sees a Float64 and the downstream numeric
-	// comparison resolves. Intrinsic ColumnRefs (Duration etc.) lower
-	// to a bare ColumnRef and pass through unchanged.
-	arg = coerceMapNumericAggInput(arg)
-
-	return &chplan.Aggregate{
-		Input: prev,
-		AggFuncs: []chplan.AggFunc{{
+		valueFunc = chplan.AggFunc{
 			Name:  chFunc,
 			Args:  []chplan.Expr{arg},
-			Alias: valueAlias,
-		}},
+			Alias: aggValueAlias,
+		}
+	}
+
+	return &chplan.Aggregate{
+		Input:          prev,
+		GroupBy:        []chplan.Expr{&chplan.ColumnRef{Name: s.TraceIDColumn}},
+		GroupByAliases: []string{aggTraceIDAlias},
+		AggFuncs:       []chplan.AggFunc{valueFunc, anyAggFunc(s.SpanNameColumn, aggMetricNameAlias), anyAggFunc(s.ResourceAttributesColumn, aggResourceAttrsAlias), minAggFunc(s.TimestampColumn, aggTimeUnixAlias)},
 	}, nil
+}
+
+// anyAggFunc returns an `any(<col>) AS <alias>` AggFunc — the
+// per-trace envelope helper used by lowerAggregate to surface a
+// representative SpanName / ResourceAttributes value alongside the
+// numeric Value. `any` picks an arbitrary row's value within the
+// group; for ResourceAttributes that's fine because every span in a
+// trace shares the same service identity in the OTel-CH layout (the
+// resource map is denormalised per-span). For SpanName a real
+// implementation would surface the root span via `argMin(SpanName,
+// Timestamp)`; we use `any` for the first cut so the canonical-row
+// shape is identical regardless of the inner span-set.
+func anyAggFunc(col, alias string) chplan.AggFunc {
+	return chplan.AggFunc{
+		Name:  "any",
+		Args:  []chplan.Expr{&chplan.ColumnRef{Name: col}},
+		Alias: alias,
+	}
+}
+
+// minAggFunc returns a `min(<col>) AS <alias>` AggFunc — used to
+// derive the per-trace earliest Timestamp for the search envelope's
+// startTimeUnixNano field.
+func minAggFunc(col, alias string) chplan.AggFunc {
+	return chplan.AggFunc{
+		Name:  "min",
+		Args:  []chplan.Expr{&chplan.ColumnRef{Name: col}},
+		Alias: alias,
+	}
 }
 
 // coerceMapNumericAggInput wraps Map-subscript expressions

--- a/internal/traceql/aggregate_test.go
+++ b/internal/traceql/aggregate_test.go
@@ -1,0 +1,139 @@
+package traceql_test
+
+import (
+	"context"
+	"testing"
+
+	tempo "github.com/grafana/tempo/pkg/traceql"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/traceql"
+)
+
+// TestLowerSpansetAggregate_PerTraceShape asserts that
+// `| count()` / `| avg()` / `| sum()` / `| min()` / `| max()`
+// — the second-stage spanset aggregates — lower to a
+// chplan.Aggregate with TraceId in GroupBy and the per-trace
+// envelope columns (MetricName / ResourceAttrs / TimeUnix) in
+// AggFuncs. Pins the wire contract behind the per-trace
+// count_spans_per_trace + avg_duration_per_trace_status_ok
+// Tempo-compat cases.
+//
+// Without per-trace grouping, `{ ... } | count() > 0` collapses
+// every matching span into a single row with empty
+// rootServiceName / rootTraceName fields — Grafana's trace list
+// then shows one mystery row instead of one entry per matching
+// trace.
+func TestLowerSpansetAggregate_PerTraceShape(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelTraces()
+
+	cases := []struct {
+		name           string
+		query          string
+		wantValueAgg   string // CH aggregate-function name for the Value slot
+		wantOuterShape string // "Aggregate" (bare) or "Filter" (scalar-filter HAVING wrap)
+	}{
+		{
+			name:           "count_threshold",
+			query:          `{ resource.service.name = "frontend" } | count() > 0`,
+			wantValueAgg:   "count",
+			wantOuterShape: "Filter",
+		},
+		{
+			name:           "avg_threshold",
+			query:          `{ status = ok } | avg(duration) > 0`,
+			wantValueAgg:   "avg",
+			wantOuterShape: "Filter",
+		},
+		{
+			name:           "sum_threshold",
+			query:          `{ resource.service.name = "x" } | sum(duration) > 100ms`,
+			wantValueAgg:   "sum",
+			wantOuterShape: "Filter",
+		},
+		{
+			name:           "min_threshold",
+			query:          `{ resource.service.name = "x" } | min(duration) > 10ms`,
+			wantValueAgg:   "min",
+			wantOuterShape: "Filter",
+		},
+		{
+			name:           "max_threshold",
+			query:          `{ resource.service.name = "x" } | max(duration) > 500ms`,
+			wantValueAgg:   "max",
+			wantOuterShape: "Filter",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			expr, err := tempo.Parse(tc.query)
+			if err != nil {
+				t.Fatalf("Parse(%q): %v", tc.query, err)
+			}
+			plan, err := traceql.Lower(context.Background(), expr, s)
+			if err != nil {
+				t.Fatalf("Lower(%q): %v", tc.query, err)
+			}
+
+			// Walk to the Aggregate node (skipping the scalar-filter
+			// HAVING wrap when present).
+			var agg *chplan.Aggregate
+			switch v := plan.(type) {
+			case *chplan.Filter:
+				if tc.wantOuterShape != "Filter" {
+					t.Errorf("outer shape = Filter, want %s", tc.wantOuterShape)
+				}
+				a, ok := v.Input.(*chplan.Aggregate)
+				if !ok {
+					t.Fatalf("Filter.Input = %T, want *chplan.Aggregate", v.Input)
+				}
+				agg = a
+			case *chplan.Aggregate:
+				if tc.wantOuterShape != "Aggregate" {
+					t.Errorf("outer shape = Aggregate, want %s", tc.wantOuterShape)
+				}
+				agg = v
+			default:
+				t.Fatalf("outer = %T, want Filter/Aggregate", plan)
+			}
+
+			// GroupBy must include exactly TraceId.
+			if len(agg.GroupBy) != 1 {
+				t.Fatalf("len(GroupBy) = %d, want 1 (TraceId)", len(agg.GroupBy))
+			}
+			gbCol, ok := agg.GroupBy[0].(*chplan.ColumnRef)
+			if !ok || gbCol.Name != s.TraceIDColumn {
+				t.Errorf("GroupBy[0] = %v, want ColumnRef(%s)", agg.GroupBy[0], s.TraceIDColumn)
+			}
+			if len(agg.GroupByAliases) != 1 || agg.GroupByAliases[0] != "TraceId" {
+				t.Errorf("GroupByAliases = %v, want [TraceId]", agg.GroupByAliases)
+			}
+
+			// AggFuncs must include Value (with the expected CH agg
+			// name) plus the three envelope columns.
+			aliases := map[string]string{}
+			for _, af := range agg.AggFuncs {
+				aliases[af.Alias] = af.Name
+			}
+			if got := aliases["Value"]; got != tc.wantValueAgg {
+				t.Errorf("Value agg = %q, want %q", got, tc.wantValueAgg)
+			}
+			if got := aliases["MetricName"]; got != "any" {
+				t.Errorf("MetricName agg = %q, want any", got)
+			}
+			if got := aliases["ResourceAttrs"]; got != "any" {
+				t.Errorf("ResourceAttrs agg = %q, want any", got)
+			}
+			if got := aliases["TimeUnix"]; got != "min" {
+				t.Errorf("TimeUnix agg = %q, want min", got)
+			}
+		})
+	}
+}

--- a/test/spec/runner_chdb.go
+++ b/test/spec/runner_chdb.go
@@ -71,6 +71,7 @@ func tolerantRowsErr(err error) error {
 var mapColumnNames = []string{
 	"Attributes",
 	"ResourceAttributes",
+	"ResourceAttrs",
 	"ScopeAttributes",
 	"SpanAttributes",
 }

--- a/test/spec/traceql/avg_duration.txtar
+++ b/test/spec/traceql/avg_duration.txtar
@@ -1,27 +1,30 @@
 -- query.traceql --
 { resource.service.name = "frontend" } | avg(duration) > 50ms
--- sql --
-SELECT * FROM (SELECT avg(`Duration`) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?))) WHERE (`Value` > ?)
--- args --
-[0] string = "service.name"
-[1] string = "frontend"
-[2] int64 = 50000000
 -- seed --
 CREATE TABLE otel_traces (
+    TraceId String,
+    SpanName String,
+    Timestamp DateTime64(9),
     ResourceAttributes Map(String, String),
     Duration UInt64
 ) ENGINE = Memory;
 INSERT INTO otel_traces VALUES
-    (map('service.name', 'frontend'), 60000000),
-    (map('service.name', 'frontend'), 80000000),
-    (map('service.name', 'frontend'), 100000000),
-    (map('service.name', 'backend'),  10000000);
--- expected_rows --
-[
-  [80000000.0]
-]
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:00', 9), map('service.name', 'frontend'), 60000000),
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:01', 9), map('service.name', 'frontend'), 80000000),
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:02', 9), map('service.name', 'frontend'), 100000000),
+    ('t2', 'span', toDateTime64('2024-01-01 00:00:03', 9), map('service.name', 'backend'),  10000000);
+-- args --
+[0] string = "service.name"
+[1] string = "frontend"
+[2] int64 = 50000000
 -- chplan --
 Filter predicate=(Value > 50000000)
-  Aggregate groupBy=[] funcs=[avg(Duration) AS Value]
+  Aggregate groupBy=[TraceId AS TraceId] funcs=[avg(Duration) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix]
     Filter predicate=(ResourceAttributes["service.name"] = "frontend")
       Scan(otel_traces)
+-- sql --
+SELECT * FROM (SELECT `TraceId` AS `TraceId`, avg(`Duration`) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) GROUP BY `TraceId`) WHERE (`Value` > ?)
+-- expected_rows --
+[
+  ["t1", 80000000, "span", {"service.name": "frontend"}, "2024-01-01T00:00:00Z"]
+]

--- a/test/spec/traceql/count.txtar
+++ b/test/spec/traceql/count.txtar
@@ -1,24 +1,27 @@
 -- query.traceql --
 { resource.service.name = "frontend" } | count() > 0
--- sql --
-SELECT * FROM (SELECT toFloat64(count(?)) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?))) WHERE (`Value` > ?)
+-- seed --
+CREATE TABLE otel_traces (
+    TraceId String,
+    SpanName String,
+    Timestamp DateTime64(9),
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:00', 9), map('service.name', 'backend')),
+    ('t2', 'span', toDateTime64('2024-01-01 00:00:01', 9), map('service.name', 'db')),
+    ('t3', 'span', toDateTime64('2024-01-01 00:00:02', 9), map('service.name', 'cache'));
 -- args --
 [0] int64 = 1
 [1] string = "service.name"
 [2] string = "frontend"
 [3] int64 = 0
--- seed --
-CREATE TABLE otel_traces (
-    ResourceAttributes Map(String, String)
-) ENGINE = Memory;
-INSERT INTO otel_traces VALUES
-    (map('service.name', 'backend')),
-    (map('service.name', 'db')),
-    (map('service.name', 'cache'));
--- expected_rows --
-[]
 -- chplan --
 Filter predicate=(Value > 0)
-  Aggregate groupBy=[] funcs=[count(1) AS Value]
+  Aggregate groupBy=[TraceId AS TraceId] funcs=[count(1) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix]
     Filter predicate=(ResourceAttributes["service.name"] = "frontend")
       Scan(otel_traces)
+-- sql --
+SELECT * FROM (SELECT `TraceId` AS `TraceId`, toFloat64(count(?)) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) GROUP BY `TraceId`) WHERE (`Value` > ?)
+-- expected_rows --
+[]

--- a/test/spec/traceql/count_eq_zero.txtar
+++ b/test/spec/traceql/count_eq_zero.txtar
@@ -1,24 +1,27 @@
 -- query.traceql --
 { resource.service.name = "frontend" } | count() = 0
--- sql --
-SELECT * FROM (SELECT toFloat64(count(?)) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?))) WHERE (`Value` = ?)
+-- seed --
+CREATE TABLE otel_traces (
+    TraceId String,
+    SpanName String,
+    Timestamp DateTime64(9),
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:00', 9), map('service.name', 'frontend')),
+    ('t2', 'span', toDateTime64('2024-01-01 00:00:01', 9), map('service.name', 'frontend')),
+    ('t3', 'span', toDateTime64('2024-01-01 00:00:02', 9), map('service.name', 'backend'));
 -- args --
 [0] int64 = 1
 [1] string = "service.name"
 [2] string = "frontend"
 [3] int64 = 0
--- seed --
-CREATE TABLE otel_traces (
-    ResourceAttributes Map(String, String)
-) ENGINE = Memory;
-INSERT INTO otel_traces VALUES
-    (map('service.name', 'frontend')),
-    (map('service.name', 'frontend')),
-    (map('service.name', 'backend'));
--- expected_rows --
-[]
 -- chplan --
 Filter predicate=(Value = 0)
-  Aggregate groupBy=[] funcs=[count(1) AS Value]
+  Aggregate groupBy=[TraceId AS TraceId] funcs=[count(1) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix]
     Filter predicate=(ResourceAttributes["service.name"] = "frontend")
       Scan(otel_traces)
+-- sql --
+SELECT * FROM (SELECT `TraceId` AS `TraceId`, toFloat64(count(?)) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) GROUP BY `TraceId`) WHERE (`Value` = ?)
+-- expected_rows --
+[]

--- a/test/spec/traceql/count_ge_threshold.txtar
+++ b/test/spec/traceql/count_ge_threshold.txtar
@@ -1,25 +1,28 @@
 -- query.traceql --
 { resource.service.name = "frontend" } | count() >= 5
--- sql --
-SELECT * FROM (SELECT toFloat64(count(?)) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?))) WHERE (`Value` >= ?)
+-- seed --
+CREATE TABLE otel_traces (
+    TraceId String,
+    SpanName String,
+    Timestamp DateTime64(9),
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:00', 9), map('service.name', 'frontend')),
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:01', 9), map('service.name', 'frontend')),
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:02', 9), map('service.name', 'frontend')),
+    ('t2', 'span', toDateTime64('2024-01-01 00:00:03', 9), map('service.name', 'backend'));
 -- args --
 [0] int64 = 1
 [1] string = "service.name"
 [2] string = "frontend"
 [3] int64 = 5
--- seed --
-CREATE TABLE otel_traces (
-    ResourceAttributes Map(String, String)
-) ENGINE = Memory;
-INSERT INTO otel_traces VALUES
-    (map('service.name', 'frontend')),
-    (map('service.name', 'frontend')),
-    (map('service.name', 'frontend')),
-    (map('service.name', 'backend'));
--- expected_rows --
-[]
 -- chplan --
 Filter predicate=(Value >= 5)
-  Aggregate groupBy=[] funcs=[count(1) AS Value]
+  Aggregate groupBy=[TraceId AS TraceId] funcs=[count(1) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix]
     Filter predicate=(ResourceAttributes["service.name"] = "frontend")
       Scan(otel_traces)
+-- sql --
+SELECT * FROM (SELECT `TraceId` AS `TraceId`, toFloat64(count(?)) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) GROUP BY `TraceId`) WHERE (`Value` >= ?)
+-- expected_rows --
+[]

--- a/test/spec/traceql/count_lt_threshold.txtar
+++ b/test/spec/traceql/count_lt_threshold.txtar
@@ -1,34 +1,33 @@
 -- query.traceql --
 { resource.service.name = "frontend" } | count() < 10
--- sql --
-SELECT * FROM (SELECT toFloat64(count(?)) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?))) WHERE (`Value` < ?)
+-- seed --
+CREATE TABLE otel_traces (
+    TraceId String,
+    SpanName String,
+    Timestamp DateTime64(9),
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:00', 9), map('service.name', 'frontend')),
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:01', 9), map('service.name', 'frontend')),
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:02', 9), map('service.name', 'frontend')),
+    ('t2', 'span', toDateTime64('2024-01-01 00:00:03', 9), map('service.name', 'frontend')),
+    ('t2', 'span', toDateTime64('2024-01-01 00:00:04', 9), map('service.name', 'frontend')),
+    ('t3', 'span', toDateTime64('2024-01-01 00:00:05', 9), map('service.name', 'backend'));
 -- args --
 [0] int64 = 1
 [1] string = "service.name"
 [2] string = "frontend"
 [3] int64 = 10
--- seed --
-CREATE TABLE otel_traces (
-    ResourceAttributes Map(String, String)
-) ENGINE = Memory;
-INSERT INTO otel_traces VALUES
-    (map('service.name', 'frontend')),
-    (map('service.name', 'frontend')),
-    (map('service.name', 'frontend')),
-    (map('service.name', 'frontend')),
-    (map('service.name', 'frontend')),
-    (map('service.name', 'frontend')),
-    (map('service.name', 'frontend')),
-    (map('service.name', 'frontend')),
-    (map('service.name', 'frontend')),
-    (map('service.name', 'frontend')),
-    (map('service.name', 'frontend')),
-    (map('service.name', 'frontend')),
-    (map('service.name', 'backend'));
--- expected_rows --
-[]
 -- chplan --
 Filter predicate=(Value < 10)
-  Aggregate groupBy=[] funcs=[count(1) AS Value]
+  Aggregate groupBy=[TraceId AS TraceId] funcs=[count(1) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix]
     Filter predicate=(ResourceAttributes["service.name"] = "frontend")
       Scan(otel_traces)
+-- sql --
+SELECT * FROM (SELECT `TraceId` AS `TraceId`, toFloat64(count(?)) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) GROUP BY `TraceId`) WHERE (`Value` < ?)
+-- expected_rows --
+[
+  ["t1", 3, "span", {"service.name": "frontend"}, "2024-01-01T00:00:00Z"],
+  ["t2", 2, "span", {"service.name": "frontend"}, "2024-01-01T00:00:03Z"]
+]

--- a/test/spec/traceql/count_per_trace.txtar
+++ b/test/spec/traceql/count_per_trace.txtar
@@ -1,0 +1,34 @@
+-- query.traceql --
+{ resource.service.name =~ ".+" } | count() > 0
+-- seed --
+CREATE TABLE otel_traces (
+    TraceId String,
+    SpanName String,
+    Timestamp DateTime64(9),
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    ('t1', 'GET /a', toDateTime64('2024-01-01 00:00:00', 9), map('service.name', 'frontend')),
+    ('t1', 'GET /a', toDateTime64('2024-01-01 00:00:01', 9), map('service.name', 'frontend')),
+    ('t1', 'db.query', toDateTime64('2024-01-01 00:00:02', 9), map('service.name', 'backend')),
+    ('t2', 'GET /b', toDateTime64('2024-01-01 00:00:03', 9), map('service.name', 'checkout')),
+    ('t2', 'cache.get', toDateTime64('2024-01-01 00:00:04', 9), map('service.name', 'cache')),
+    ('t3', 'POST /c', toDateTime64('2024-01-01 00:00:05', 9), map('service.name', 'orders'));
+-- args --
+[0] int64 = 1
+[1] string = "service.name"
+[2] string = ".+"
+[3] int64 = 0
+-- chplan --
+Filter predicate=(Value > 0)
+  Aggregate groupBy=[TraceId AS TraceId] funcs=[count(1) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix]
+    Filter predicate=(ResourceAttributes["service.name"] =~ ".+")
+      Scan(otel_traces)
+-- sql --
+SELECT * FROM (SELECT `TraceId` AS `TraceId`, toFloat64(count(?)) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix` FROM (SELECT * FROM `otel_traces` WHERE match(`ResourceAttributes`[?], ?)) GROUP BY `TraceId`) WHERE (`Value` > ?)
+-- expected_rows --
+[
+  ["t1", 3, "GET /a", {"service.name": "frontend"}, "2024-01-01T00:00:00Z"],
+  ["t2", 2, "GET /b", {"service.name": "checkout"}, "2024-01-01T00:00:03Z"],
+  ["t3", 1, "POST /c", {"service.name": "orders"}, "2024-01-01T00:00:05Z"]
+]

--- a/test/spec/traceql/edge_catchall_compound_count.txtar
+++ b/test/spec/traceql/edge_catchall_compound_count.txtar
@@ -1,5 +1,21 @@
 -- query.traceql --
 { resource.service.name = "x" && span.http.status_code > 200 } | count() > 10
+-- seed --
+CREATE TABLE otel_traces (
+    TraceId String DEFAULT 't1',
+    SpanName String DEFAULT 'span',
+    Timestamp DateTime64(9) DEFAULT toDateTime64('2024-01-01 00:00:00', 9) + toIntervalSecond(toInt64(Duration)),
+    Duration UInt64,
+    ResourceAttributes Map(String, String) DEFAULT if(Duration < 12, map('service.name', 'x'), map('service.name', 'y')),
+    SpanAttributes Map(String, String) DEFAULT if(Duration < 12, map('http.status_code', '500'), map('http.status_code', '100'))
+) ENGINE = MergeTree ORDER BY Duration;
+INSERT INTO otel_traces (Duration) VALUES
+    (0), (1), (2), (3), (4), (5), (6), (7), (8), (9), (10), (11),
+    (12), (13), (14);
+-- expected_rows --
+[
+  ["t1", 12, "span", {"service.name": "x"}, "2024-01-01T00:00:00Z"]
+]
 -- args --
 [0] int64 = 1
 [1] string = "service.name"
@@ -7,23 +23,10 @@
 [3] string = "http.status_code"
 [4] int64 = 200
 [5] int64 = 10
--- sql --
-SELECT * FROM (SELECT toFloat64(count(?)) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?) AND (toFloat64(`SpanAttributes`[?]) > ?))) WHERE (`Value` > ?)
--- seed --
-CREATE TABLE otel_traces (
-    Duration UInt64,
-    ResourceAttributes Map(String, String) MATERIALIZED if(Duration < 12, map('service.name', 'x'), map('service.name', 'y')),
-    SpanAttributes Map(String, String) MATERIALIZED if(Duration < 12, map('http.status_code', '500'), map('http.status_code', '100'))
-) ENGINE = MergeTree ORDER BY Duration;
-INSERT INTO otel_traces (Duration) VALUES
-    (0), (1), (2), (3), (4), (5), (6), (7), (8), (9), (10), (11),
-    (12), (13), (14);
--- expected_rows --
-[
-  [12.0]
-]
 -- chplan --
 Filter predicate=(Value > 10)
-  Aggregate groupBy=[] funcs=[count(1) AS Value]
+  Aggregate groupBy=[TraceId AS TraceId] funcs=[count(1) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix]
     Filter predicate=((ResourceAttributes["service.name"] = "x") AND (toFloat64(SpanAttributes["http.status_code"]) > 200))
       Scan(otel_traces)
+-- sql --
+SELECT * FROM (SELECT `TraceId` AS `TraceId`, toFloat64(count(?)) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?) AND (toFloat64(`SpanAttributes`[?]) > ?)) GROUP BY `TraceId`) WHERE (`Value` > ?)

--- a/test/spec/traceql/edge_catchall_pipeline_avg.txtar
+++ b/test/spec/traceql/edge_catchall_pipeline_avg.txtar
@@ -1,17 +1,13 @@
 -- query.traceql --
 { resource.service.name = "x" && status = error } | avg(duration) > 500ms
--- args --
-[0] string = "Error"
-[1] string = "service.name"
-[2] string = "x"
-[3] int64 = 500000000
--- sql --
-SELECT * FROM (SELECT avg(`Duration`) AS `Value` FROM (SELECT * FROM `otel_traces` PREWHERE (`StatusCode` = ?) WHERE (`ResourceAttributes`[?] = ?))) WHERE (`Value` > ?)
 -- seed --
 CREATE TABLE otel_traces (
+    TraceId String DEFAULT 't1',
+    SpanName String DEFAULT 'span',
+    Timestamp DateTime64(9) DEFAULT toDateTime64('2024-01-01 00:00:00', 9),
     Duration UInt64,
     StatusCode String,
-    ResourceAttributes Map(String, String) MATERIALIZED map('service.name', 'x')
+    ResourceAttributes Map(String, String) DEFAULT map('service.name', 'x')
 ) ENGINE = MergeTree ORDER BY Duration;
 INSERT INTO otel_traces (Duration, StatusCode) VALUES
     (600000000, 'Error'),
@@ -20,10 +16,17 @@ INSERT INTO otel_traces (Duration, StatusCode) VALUES
     (50000000, 'Ok');
 -- expected_rows --
 [
-  [800000000.0]
+  ["t1", 800000000, "span", {"service.name": "x"}, "2024-01-01T00:00:00Z"]
 ]
+-- args --
+[0] string = "Error"
+[1] string = "service.name"
+[2] string = "x"
+[3] int64 = 500000000
 -- chplan --
 Filter predicate=(Value > 500000000)
-  Aggregate groupBy=[] funcs=[avg(Duration) AS Value]
+  Aggregate groupBy=[TraceId AS TraceId] funcs=[avg(Duration) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix]
     Filter predicate=((ResourceAttributes["service.name"] = "x") AND (StatusCode = "Error"))
       Scan(otel_traces)
+-- sql --
+SELECT * FROM (SELECT `TraceId` AS `TraceId`, avg(`Duration`) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix` FROM (SELECT * FROM `otel_traces` PREWHERE (`StatusCode` = ?) WHERE (`ResourceAttributes`[?] = ?)) GROUP BY `TraceId`) WHERE (`Value` > ?)

--- a/test/spec/traceql/edge_inner_max_attr.txtar
+++ b/test/spec/traceql/edge_inner_max_attr.txtar
@@ -1,27 +1,30 @@
 -- query.traceql --
 { resource.service.name = "x" } | max(span.latency_ms) > 100
+-- seed --
+CREATE TABLE otel_traces (
+    TraceId String,
+    SpanName String,
+    Timestamp DateTime64(9),
+    ResourceAttributes Map(String, String),
+    SpanAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:00', 9), map('service.name', 'x'), map('latency_ms', '50')),
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:01', 9), map('service.name', 'x'), map('latency_ms', '150')),
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:02', 9), map('service.name', 'x'), map('latency_ms', '200'));
 -- args --
 [0] string = "latency_ms"
 [1] string = "service.name"
 [2] string = "x"
 [3] int64 = 100
--- sql --
-SELECT * FROM (SELECT max(toFloat64OrZero(`SpanAttributes`[?])) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?))) WHERE (`Value` > ?)
--- seed --
-CREATE TABLE otel_traces (
-    ResourceAttributes Map(String, String),
-    SpanAttributes Map(String, String)
-) ENGINE = Memory;
-INSERT INTO otel_traces VALUES
-    (map('service.name', 'x'), map('latency_ms', '50')),
-    (map('service.name', 'x'), map('latency_ms', '150')),
-    (map('service.name', 'x'), map('latency_ms', '200'));
--- expected_rows --
-[
-  [200.0]
-]
 -- chplan --
 Filter predicate=(Value > 100)
-  Aggregate groupBy=[] funcs=[max(toFloat64OrZero(SpanAttributes["latency_ms"])) AS Value]
+  Aggregate groupBy=[TraceId AS TraceId] funcs=[max(toFloat64OrZero(SpanAttributes["latency_ms"])) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix]
     Filter predicate=(ResourceAttributes["service.name"] = "x")
       Scan(otel_traces)
+-- sql --
+SELECT * FROM (SELECT `TraceId` AS `TraceId`, max(toFloat64OrZero(`SpanAttributes`[?])) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) GROUP BY `TraceId`) WHERE (`Value` > ?)
+-- expected_rows --
+[
+  ["t1", 200, "span", {"service.name": "x"}, "2024-01-01T00:00:00Z"]
+]

--- a/test/spec/traceql/edge_inner_min_attr.txtar
+++ b/test/spec/traceql/edge_inner_min_attr.txtar
@@ -1,27 +1,30 @@
 -- query.traceql --
 { resource.service.name = "x" } | min(span.attempts) < 3
+-- seed --
+CREATE TABLE otel_traces (
+    TraceId String,
+    SpanName String,
+    Timestamp DateTime64(9),
+    ResourceAttributes Map(String, String),
+    SpanAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:00', 9), map('service.name', 'x'), map('attempts', '1')),
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:01', 9), map('service.name', 'x'), map('attempts', '5')),
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:02', 9), map('service.name', 'x'), map('attempts', '9'));
 -- args --
 [0] string = "attempts"
 [1] string = "service.name"
 [2] string = "x"
 [3] int64 = 3
--- sql --
-SELECT * FROM (SELECT min(toFloat64OrZero(`SpanAttributes`[?])) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?))) WHERE (`Value` < ?)
--- seed --
-CREATE TABLE otel_traces (
-    ResourceAttributes Map(String, String),
-    SpanAttributes Map(String, String)
-) ENGINE = Memory;
-INSERT INTO otel_traces VALUES
-    (map('service.name', 'x'), map('attempts', '1')),
-    (map('service.name', 'x'), map('attempts', '5')),
-    (map('service.name', 'x'), map('attempts', '9'));
--- expected_rows --
-[
-  [1.0]
-]
 -- chplan --
 Filter predicate=(Value < 3)
-  Aggregate groupBy=[] funcs=[min(toFloat64OrZero(SpanAttributes["attempts"])) AS Value]
+  Aggregate groupBy=[TraceId AS TraceId] funcs=[min(toFloat64OrZero(SpanAttributes["attempts"])) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix]
     Filter predicate=(ResourceAttributes["service.name"] = "x")
       Scan(otel_traces)
+-- sql --
+SELECT * FROM (SELECT `TraceId` AS `TraceId`, min(toFloat64OrZero(`SpanAttributes`[?])) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) GROUP BY `TraceId`) WHERE (`Value` < ?)
+-- expected_rows --
+[
+  ["t1", 1, "span", {"service.name": "x"}, "2024-01-01T00:00:00Z"]
+]

--- a/test/spec/traceql/edge_inner_sum_attr.txtar
+++ b/test/spec/traceql/edge_inner_sum_attr.txtar
@@ -1,27 +1,30 @@
 -- query.traceql --
 { resource.service.name = "x" } | sum(span.size) > 1000
+-- seed --
+CREATE TABLE otel_traces (
+    TraceId String,
+    SpanName String,
+    Timestamp DateTime64(9),
+    ResourceAttributes Map(String, String),
+    SpanAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:00', 9), map('service.name', 'x'), map('size', '400')),
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:01', 9), map('service.name', 'x'), map('size', '500')),
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:02', 9), map('service.name', 'x'), map('size', '600'));
 -- args --
 [0] string = "size"
 [1] string = "service.name"
 [2] string = "x"
 [3] int64 = 1000
--- sql --
-SELECT * FROM (SELECT sum(toFloat64OrZero(`SpanAttributes`[?])) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?))) WHERE (`Value` > ?)
--- seed --
-CREATE TABLE otel_traces (
-    ResourceAttributes Map(String, String),
-    SpanAttributes Map(String, String)
-) ENGINE = Memory;
-INSERT INTO otel_traces VALUES
-    (map('service.name', 'x'), map('size', '400')),
-    (map('service.name', 'x'), map('size', '500')),
-    (map('service.name', 'x'), map('size', '600'));
--- expected_rows --
-[
-  [1500.0]
-]
 -- chplan --
 Filter predicate=(Value > 1000)
-  Aggregate groupBy=[] funcs=[sum(toFloat64OrZero(SpanAttributes["size"])) AS Value]
+  Aggregate groupBy=[TraceId AS TraceId] funcs=[sum(toFloat64OrZero(SpanAttributes["size"])) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix]
     Filter predicate=(ResourceAttributes["service.name"] = "x")
       Scan(otel_traces)
+-- sql --
+SELECT * FROM (SELECT `TraceId` AS `TraceId`, sum(toFloat64OrZero(`SpanAttributes`[?])) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) GROUP BY `TraceId`) WHERE (`Value` > ?)
+-- expected_rows --
+[
+  ["t1", 1500, "span", {"service.name": "x"}, "2024-01-01T00:00:00Z"]
+]

--- a/test/spec/traceql/max_duration.txtar
+++ b/test/spec/traceql/max_duration.txtar
@@ -1,27 +1,30 @@
 -- query.traceql --
 { resource.service.name = "frontend" } | max(duration) > 500ms
--- sql --
-SELECT * FROM (SELECT max(`Duration`) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?))) WHERE (`Value` > ?)
--- args --
-[0] string = "service.name"
-[1] string = "frontend"
-[2] int64 = 500000000
 -- seed --
 CREATE TABLE otel_traces (
+    TraceId String,
+    SpanName String,
+    Timestamp DateTime64(9),
     ResourceAttributes Map(String, String),
     Duration UInt64
 ) ENGINE = Memory;
 INSERT INTO otel_traces VALUES
-    (map('service.name', 'frontend'), 200000000),
-    (map('service.name', 'frontend'), 600000000),
-    (map('service.name', 'frontend'), 400000000),
-    (map('service.name', 'backend'),  900000000);
--- expected_rows --
-[
-  [600000000]
-]
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:00', 9), map('service.name', 'frontend'), 200000000),
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:01', 9), map('service.name', 'frontend'), 600000000),
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:02', 9), map('service.name', 'frontend'), 400000000),
+    ('t2', 'span', toDateTime64('2024-01-01 00:00:03', 9), map('service.name', 'backend'),  900000000);
+-- args --
+[0] string = "service.name"
+[1] string = "frontend"
+[2] int64 = 500000000
 -- chplan --
 Filter predicate=(Value > 500000000)
-  Aggregate groupBy=[] funcs=[max(Duration) AS Value]
+  Aggregate groupBy=[TraceId AS TraceId] funcs=[max(Duration) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix]
     Filter predicate=(ResourceAttributes["service.name"] = "frontend")
       Scan(otel_traces)
+-- sql --
+SELECT * FROM (SELECT `TraceId` AS `TraceId`, max(`Duration`) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) GROUP BY `TraceId`) WHERE (`Value` > ?)
+-- expected_rows --
+[
+  ["t1", 600000000, "span", {"service.name": "frontend"}, "2024-01-01T00:00:00Z"]
+]

--- a/test/spec/traceql/min_duration.txtar
+++ b/test/spec/traceql/min_duration.txtar
@@ -1,27 +1,30 @@
 -- query.traceql --
 { resource.service.name = "frontend" } | min(duration) > 10ms
--- sql --
-SELECT * FROM (SELECT min(`Duration`) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?))) WHERE (`Value` > ?)
--- args --
-[0] string = "service.name"
-[1] string = "frontend"
-[2] int64 = 10000000
 -- seed --
 CREATE TABLE otel_traces (
+    TraceId String,
+    SpanName String,
+    Timestamp DateTime64(9),
     ResourceAttributes Map(String, String),
     Duration UInt64
 ) ENGINE = Memory;
 INSERT INTO otel_traces VALUES
-    (map('service.name', 'frontend'), 30000000),
-    (map('service.name', 'frontend'), 50000000),
-    (map('service.name', 'frontend'), 80000000),
-    (map('service.name', 'backend'),   5000000);
--- expected_rows --
-[
-  [30000000]
-]
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:00', 9), map('service.name', 'frontend'), 30000000),
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:01', 9), map('service.name', 'frontend'), 50000000),
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:02', 9), map('service.name', 'frontend'), 80000000),
+    ('t2', 'span', toDateTime64('2024-01-01 00:00:03', 9), map('service.name', 'backend'),   5000000);
+-- args --
+[0] string = "service.name"
+[1] string = "frontend"
+[2] int64 = 10000000
 -- chplan --
 Filter predicate=(Value > 10000000)
-  Aggregate groupBy=[] funcs=[min(Duration) AS Value]
+  Aggregate groupBy=[TraceId AS TraceId] funcs=[min(Duration) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix]
     Filter predicate=(ResourceAttributes["service.name"] = "frontend")
       Scan(otel_traces)
+-- sql --
+SELECT * FROM (SELECT `TraceId` AS `TraceId`, min(`Duration`) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) GROUP BY `TraceId`) WHERE (`Value` > ?)
+-- expected_rows --
+[
+  ["t1", 30000000, "span", {"service.name": "frontend"}, "2024-01-01T00:00:00Z"]
+]

--- a/test/spec/traceql/sum_duration.txtar
+++ b/test/spec/traceql/sum_duration.txtar
@@ -1,27 +1,30 @@
 -- query.traceql --
 { resource.service.name = "frontend" } | sum(duration) > 100ms
--- sql --
-SELECT * FROM (SELECT sum(`Duration`) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?))) WHERE (`Value` > ?)
--- args --
-[0] string = "service.name"
-[1] string = "frontend"
-[2] int64 = 100000000
 -- seed --
 CREATE TABLE otel_traces (
+    TraceId String,
+    SpanName String,
+    Timestamp DateTime64(9),
     ResourceAttributes Map(String, String),
     Duration UInt64
 ) ENGINE = Memory;
 INSERT INTO otel_traces VALUES
-    (map('service.name', 'frontend'), 50000000),
-    (map('service.name', 'frontend'), 80000000),
-    (map('service.name', 'frontend'), 120000000),
-    (map('service.name', 'backend'),  900000000);
--- expected_rows --
-[
-  [250000000]
-]
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:00', 9), map('service.name', 'frontend'), 50000000),
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:01', 9), map('service.name', 'frontend'), 80000000),
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:02', 9), map('service.name', 'frontend'), 120000000),
+    ('t2', 'span', toDateTime64('2024-01-01 00:00:03', 9), map('service.name', 'backend'),  900000000);
+-- args --
+[0] string = "service.name"
+[1] string = "frontend"
+[2] int64 = 100000000
 -- chplan --
 Filter predicate=(Value > 100000000)
-  Aggregate groupBy=[] funcs=[sum(Duration) AS Value]
+  Aggregate groupBy=[TraceId AS TraceId] funcs=[sum(Duration) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix]
     Filter predicate=(ResourceAttributes["service.name"] = "frontend")
       Scan(otel_traces)
+-- sql --
+SELECT * FROM (SELECT `TraceId` AS `TraceId`, sum(`Duration`) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) GROUP BY `TraceId`) WHERE (`Value` > ?)
+-- expected_rows --
+[
+  ["t1", 250000000, "span", {"service.name": "frontend"}, "2024-01-01T00:00:00Z"]
+]

--- a/test/spec/traceql/sum_span_attr.txtar
+++ b/test/spec/traceql/sum_span_attr.txtar
@@ -1,26 +1,30 @@
 -- query.traceql --
 { span.http.status_code >= 400 } | sum(span.http.status_code) > 0
--- sql --
-SELECT * FROM (SELECT sum(toFloat64OrZero(`SpanAttributes`[?])) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE (toFloat64(`SpanAttributes`[?]) >= ?))) WHERE (`Value` > ?)
+-- seed --
+CREATE TABLE otel_traces (
+    TraceId String,
+    SpanName String,
+    Timestamp DateTime64(9),
+    ResourceAttributes Map(String, String),
+    SpanAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:00', 9), map(), map('http.status_code', '500')),
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:01', 9), map(), map('http.status_code', '404')),
+    ('t2', 'span', toDateTime64('2024-01-01 00:00:02', 9), map(), map('http.status_code', '200'));
 -- args --
 [0] string = "http.status_code"
 [1] string = "http.status_code"
 [2] int64 = 400
 [3] int64 = 0
--- seed --
-CREATE TABLE otel_traces (
-    SpanAttributes Map(String, String)
-) ENGINE = Memory;
-INSERT INTO otel_traces VALUES
-    (map('http.status_code', '500')),
-    (map('http.status_code', '404')),
-    (map('http.status_code', '200'));
--- expected_rows --
-[
-  [904.0]
-]
 -- chplan --
 Filter predicate=(Value > 0)
-  Aggregate groupBy=[] funcs=[sum(toFloat64OrZero(SpanAttributes["http.status_code"])) AS Value]
+  Aggregate groupBy=[TraceId AS TraceId] funcs=[sum(toFloat64OrZero(SpanAttributes["http.status_code"])) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix]
     Filter predicate=(toFloat64(SpanAttributes["http.status_code"]) >= 400)
       Scan(otel_traces)
+-- sql --
+SELECT * FROM (SELECT `TraceId` AS `TraceId`, sum(toFloat64OrZero(`SpanAttributes`[?])) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix` FROM (SELECT * FROM `otel_traces` WHERE (toFloat64(`SpanAttributes`[?]) >= ?)) GROUP BY `TraceId`) WHERE (`Value` > ?)
+-- expected_rows --
+[
+  ["t1", 904, "span", {}, "2024-01-01T00:00:00Z"]
+]


### PR DESCRIPTION
## Summary

- `| count()` / `| sum()` / `| avg()` / `| min()` / `| max()` are trace-scoped per TraceQL spec — `{ ... } | count() > 0` returns one row per matching trace, not a single corpus-wide aggregate. The previous lowering collapsed every span into a single \`count(1) AS Value\` row, so /api/search surfaced one mystery summary with empty rootServiceName / rootTraceName.
- Lower the aggregate as \`Aggregate groupBy=[TraceId] funcs=[<value>, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix]\` so each matching trace gets its own row carrying the per-trace envelope. The wrap projection picks the new shape via \`isSpansetAggregateShape\` (alias-set marker) and threads \`__cerberus_traceID\` into Attributes via mapConcat so \`toTraceSummaries\` still groups by real TraceID.

## Root cause

`internal/traceql/aggregate.go::lowerAggregate` emitted \`chplan.Aggregate{GroupBy: nil, ...}\`. With an empty GroupBy the emitter renders \`SELECT <agg> FROM (...)\` — CH returns one row of aggregate values. The wrap projection's aggregate-shape branch then synthesised MetricName=\"\" / Attributes=empty / TimeUnix=now64() because the original Scan-level columns were no longer in scope, producing a single summary with no per-trace identity.

## Fix

- `internal/traceql/aggregate.go` — adds \`TraceId\` to GroupBy + alias \`TraceId\`; piggybacks envelope columns onto AggFuncs (\`any(SpanName) AS MetricName\`, \`any(ResourceAttributes) AS ResourceAttrs\`, \`min(Timestamp) AS TimeUnix\`).
- `internal/api/tempo/handler.go` — new \`isSpansetAggregateShape\` + \`spansetAggregateSampleProjections\` recognise the new shape and project bare envelope columns (with mapConcat merging \`__cerberus_traceID\` into Attributes). The previous synthesised-empty branch stays for the metrics-pipeline path (MetricsAggregate / MetricsSecondStage) which deliberately falls through.
- `test/spec/runner_chdb.go` — extends the Map-column allowlist so \`ResourceAttrs\` (the inner aggregate's any() alias) routes through \`toJSONString\` on the chDB roundtrip.

## Tests

- New: `internal/traceql/aggregate_test.go::TestLowerSpansetAggregate_PerTraceShape` — asserts every spanset aggregate (count/avg/sum/min/max) lowers with TraceId in GroupBy + the four AggFunc aliases.
- New: `internal/api/tempo/handler_test.go::TestSearch_SpansetAggregate_PerTrace` — pumps three per-trace samples through /api/search and asserts three distinct summaries with the right rootServiceName / rootTraceName.
- New TXTAR: `test/spec/traceql/count_per_trace.txtar` — multi-trace round-trip exercising the \`{ resource.service.name =~ \".+\" } | count() > 0\` shape from the count_spans_per_trace Tempo-compat case (3 traces → 3 rows).
- Regenerated 13 existing aggregate TXTAR fixtures (seeds now include TraceId/SpanName/Timestamp columns; SQL / chplan / expected_rows refreshed via \`GOLDEN_UPDATE=1\`).

## Test plan

- [x] `go test ./...` → 3428 passed
- [x] `go test -tags=chdb ./test/spec/traceql/...` → 132 passed, 1 pre-existing failure (\`edge_chain_mixed_5\`, unrelated to this change)
- [x] `go vet ./...` → clean
- [ ] Tempo compat: \`count_spans_per_trace\` + \`avg_duration_per_trace_status_ok\` move from FAIL → PASS (~204 diff reasons removed) — verify on the nightly compat run

🤖 Generated with [Claude Code](https://claude.com/claude-code)