### PR TITLE
fix(test/property): update TraceQL oracle | count() to per-trace semantics

### DIFF
--- a/test/property/oracle/traceql/doc.go
+++ b/test/property/oracle/traceql/doc.go
@@ -15,21 +15,19 @@
 //
 // TraceQL evaluates over spans. A spanset is the per-trace bucket of
 // spans matching the upstream filter; pipeline operators reduce or
-// transform the spanset.
+// transform the spanset on a per-trace basis.
 //
 //  1. Spanset filter (`{ <attr> = <value> }`): each span is
 //     evaluated against the predicate; surviving spans form the
-//     spanset. Per-trace grouping is implicit in Tempo's engine but
-//     irrelevant for the count() aggregation today — the evaluator
-//     keeps a flat span list because count() across all matching
-//     spans equals count() per-trace summed across traces (each of
-//     the generator's spans lives in its own trace).
-//  2. count() aggregate: returns the number of spans in the spanset.
-//     With a scalar filter (`| count() > N`), the trace is included
-//     in the result only when the predicate holds. Cerberus's wire
-//     surface returns the count value as a single sample (one row
-//     in the search response) when the predicate is satisfied,
-//     zero rows when it isn't — the evaluator mirrors that shape.
+//     per-trace spanset.
+//  2. count() aggregate: returns the number of matching spans IN A
+//     TRACE. With a scalar filter (`| count() > N`), every trace
+//     whose per-trace count satisfies the predicate is included in
+//     the result; traces whose count fails the predicate are
+//     dropped. Cerberus's wire surface emits one chclient.Sample
+//     per surviving trace (the Aggregate groups by TraceId — see
+//     internal/api/tempo/handler.go's isSpansetAggregateShape) so
+//     the evaluator mirrors that per-trace shape.
 //
 // # Wire-shape comparison
 //
@@ -39,10 +37,12 @@
 //
 //   - Selector-only query: one outcome row per matching span, all
 //     stamped with the same empty label set so the framework's
-//     comparator counts rows-per-group.
-//   - count() query that passes: ONE outcome row (count emitted as a
-//     single trace summary in cerberus's response).
-//   - count() query that fails: ZERO outcome rows.
+//     comparator counts rows-per-group. The generator stamps each
+//     span on its own TraceID so per-trace and per-span counts
+//     coincide.
+//   - count() query: one outcome row per matching trace whose
+//     per-trace count satisfies `count() OP N` (zero rows when no
+//     trace's count satisfies the predicate).
 //
 // The framework's CompareOutcomes diff is multiset-aware over the
 // empty-label group, so the row count is what we compare. Tempo's

--- a/test/property/oracle/traceql/evaluator.go
+++ b/test/property/oracle/traceql/evaluator.go
@@ -17,19 +17,26 @@ import (
 // Returns property.Outcome carrying:
 //
 //   - one row per matching span (labels: empty map) when the query is a
-//     bare selector;
-//   - exactly one row (labels: empty map) when the query carries a
-//     `| count() OP N` filter and the predicate is satisfied;
-//   - zero rows when the predicate is not satisfied;
+//     bare selector — Tempo's /api/search emits one TraceSummary per
+//     matching trace, and the generator stamps each span on its own
+//     TraceID so the per-trace and per-span counts coincide;
+//   - one row per matching trace whose per-trace count satisfies the
+//     `| count() OP N` predicate (labels: empty map). TraceQL's
+//     pipeline aggregates are trace-scoped per the spec —
+//     `{ ... } | count() > 0` returns one row per matching trace, not
+//     a single corpus-wide aggregate;
+//   - zero rows when no trace's per-trace count satisfies the
+//     predicate;
 //   - an Err otherwise (parse failure / unsupported shape).
 //
-// The single-row count shape mirrors Tempo's /api/search wire shape:
-// cerberus's handler emits one chclient.Sample row when count() passes
-// the scalar filter, zero rows when it doesn't — see
-// internal/api/tempo/handler.go's classifySearchErr path. The
-// framework's comparator counts rows-per-empty-label-key, so this
-// alignment lets the same CompareOutcomes diff catch drift on both
-// shapes.
+// The per-trace row shape mirrors Tempo's /api/search wire shape after
+// cerberus PR #536: the inner Aggregate groups by TraceId and emits
+// one chclient.Sample per matching trace (see
+// internal/api/tempo/handler.go's isSpansetAggregateShape +
+// spansetAggregateSampleProjections branch). The framework's
+// comparator counts rows-per-empty-label-key, so emitting one
+// empty-label row per matching trace lines up with the cerberus side's
+// `inspectedTraces == len(res.Samples)`.
 func Evaluate(d property.Dataset, q property.Query) property.Outcome {
 	parsed, err := parseQuery(q.String)
 	if err != nil {
@@ -38,20 +45,25 @@ func Evaluate(d property.Dataset, q property.Query) property.Outcome {
 
 	spans := filterSpans(d, parsed.selector)
 	if parsed.hasCount {
-		count := int64(len(spans))
-		if !compareCount(count, parsed.countOp, parsed.countN) {
-			return property.Outcome{Rows: nil}
+		// Trace-scoped count: group surviving spans by TraceID, then
+		// emit one outcome row per trace whose per-trace count
+		// satisfies `count() OP N`. Mirrors the per-trace aggregate
+		// cerberus emits (one chclient.Sample per matching TraceId)
+		// — see PR #536. The generator stamps each span on its own
+		// TraceID, so per-trace counts are usually 1; the predicate
+		// arithmetic still has to hold for the trace to surface.
+		perTrace := groupByTraceID(spans)
+		rows := make([]property.OutcomeRow, 0, len(perTrace))
+		for _, count := range perTrace {
+			if compareCount(count, parsed.countOp, parsed.countN) {
+				rows = append(rows, property.OutcomeRow{
+					Labels:      map[string]string{},
+					TimestampMs: 0,
+					Value:       0,
+				})
+			}
 		}
-		// Predicate holds → one outcome row. Cerberus's wire response
-		// surfaces this as a single chclient.Sample (the Aggregate
-		// path projects MetricName="", Value=count) which the
-		// handler reports as `inspectedTraces == 1`. We mirror that:
-		// one row, empty labels, no per-row payload — the
-		// comparator's per-group row-count check is the equivalence
-		// we're asserting.
-		return property.Outcome{Rows: []property.OutcomeRow{
-			{Labels: map[string]string{}, TimestampMs: 0, Value: 0},
-		}}
+		return property.Outcome{Rows: rows}
 	}
 
 	// Selector-only: one row per matching span. Labels stay empty so
@@ -73,10 +85,24 @@ func Evaluate(d property.Dataset, q property.Query) property.Outcome {
 	return property.Outcome{Rows: rows}
 }
 
+// groupByTraceID buckets surviving spans by TraceID and returns each
+// bucket's per-trace count. The generator stamps each span on its own
+// TraceID via deterministicTraceID(i, …) so most buckets are size 1,
+// but the helper is shape-agnostic — a future generator widening
+// (multi-span traces) flows through unchanged.
+func groupByTraceID(spans []spanView) map[string]int64 {
+	out := map[string]int64{}
+	for _, s := range spans {
+		out[s.traceID]++
+	}
+	return out
+}
+
 // spanView is the oracle's per-span snapshot: just the fields the
 // evaluator needs to apply the selector and aggregate. Built once per
 // Evaluate call from the dataset's MetricsModel series.
 type spanView struct {
+	traceID       string
 	service       string
 	name          string
 	startTimeMs   int64
@@ -85,7 +111,9 @@ type spanView struct {
 
 // filterSpans pivots the dataset's MetricsModel into the spanView
 // shape and applies the selector predicate. Only one selector kind is
-// supported today: `resource.service.name = "<value>"`.
+// supported today: `resource.service.name = "<value>"`. The TraceID
+// is threaded through so trace-scoped aggregates (`| count()`) can
+// bucket by trace identity rather than flattening across the corpus.
 func filterSpans(d property.Dataset, sel selector) []spanView {
 	if d.Metrics == nil {
 		return nil
@@ -105,6 +133,7 @@ func filterSpans(d property.Dataset, sel selector) []spanView {
 			durFloat = s.Points[0].Value
 		}
 		out = append(out, spanView{
+			traceID:       s.Labels["__traceID__"],
 			service:       svc,
 			name:          s.MetricName,
 			startTimeMs:   startMs,


### PR DESCRIPTION
## Summary

After PR #536, cerberus's `/api/search` emits one `chclient.Sample` per matching TraceID for `{ ... } | count() OP N` queries (the lowering groups the inner `Aggregate` by `TraceId` and threads the per-trace envelope columns through the wrap projection). The property-test oracle was still modelling the old corpus-wide shape — one row when the count predicate held, zero otherwise — so any random dataset with more than one matching trace tripped:

```
property drift
--- query ---  { resource.service.name = "api" } | count() > 0
--- diff ---   series {}: sample count want=1 got=3
```

## Root cause

`oracle/traceql/evaluator.go`'s `| count()` branch flattened all surviving spans into a single corpus-wide aggregate and emitted one outcome row when the predicate held. PR #536 made cerberus correctly trace-scoped (one chclient.Sample per matching TraceId), so the oracle's want=1 no longer matched cerberus's got=N for N>1.

## Fix

- `spanView` now carries `traceID` (read from the dataset's `__traceID__` reserved label set by `gen/traceql.go`).
- `Evaluate` groups surviving spans by TraceID and emits one empty-label outcome row per trace whose per-trace count satisfies `count() OP N`.
- Selector-only path is unchanged (one row per matching span — the generator stamps each span on its own TraceID, so per-span and per-trace counts coincide for that shape).
- Doc updates in `doc.go` reflect the per-trace TraceQL spec.

## Repro

Failing seed from the bug report:

```sh
go test -tags chdb ./test/property/ -run TestTraceQL_Property \
    -rapid.seed=16628164300418616674
```

Now passes; full 100-iteration sweep is green locally.

## Test plan

- [x] Failing rapid seed (`16628164300418616674`) now passes.
- [x] Full `go test -tags chdb ./test/property/ -run TestTraceQL_Property -count=1` sweep green locally.
- [ ] CI `check` + `lint` green.
- [ ] CI nightly `property` workflow (deeper sweep at `-rapid.checks=500`) green on next run.