### PR TITLE
fix(test/spec/traceql): seed edge_chain_mixed_5 with full otel_traces schema

### DIFF
--- a/test/spec/traceql/edge_chain_mixed_5.txtar
+++ b/test/spec/traceql/edge_chain_mixed_5.txtar
@@ -16,8 +16,11 @@ CREATE TABLE otel_traces (
     TraceId String,
     SpanId String,
     ParentSpanId String,
+    SpanName String DEFAULT '',
+    Duration UInt64 DEFAULT 0,
+    Timestamp UInt64 DEFAULT 0,
     _svc String,
-    ResourceAttributes Map(String, String) MATERIALIZED map('service.name', _svc)
+    ResourceAttributes Map(String, String) DEFAULT map('service.name', _svc)
 ) ENGINE = Memory;
 INSERT INTO otel_traces (TraceId, SpanId, ParentSpanId, _svc) VALUES
     ('a0000000000000000000000000000001', '0000000000000001', '',                 'a'),
@@ -34,7 +37,7 @@ INSERT INTO otel_traces (TraceId, SpanId, ParentSpanId, _svc) VALUES
     ('a0000000000000000000000000000003', '0000000000000023', '0000000000000022', 'e');
 -- expected_rows --
 [
-  ["a0000000000000000000000000000001", "0000000000000007", "0000000000000006", "e"]
+  ["a0000000000000000000000000000001", "0000000000000007", "0000000000000006", "", 0, 0, {"service.name": "e"}]
 ]
 -- sql --
 SELECT R.`TraceId` AS `TraceId`, R.`SpanId` AS `SpanId`, R.`ParentSpanId` AS `ParentSpanId`, R.`SpanName` AS `SpanName`, R.`Duration` AS `Duration`, R.`Timestamp` AS `Timestamp`, R.`ResourceAttributes` AS `ResourceAttributes` FROM (WITH RECURSIVE _struct_closure AS (SELECT `TraceId`, `SpanId`, `ParentSpanId`, 0 AS _depth FROM (SELECT R.`TraceId` AS `TraceId`, R.`SpanId` AS `SpanId`, R.`ParentSpanId` AS `ParentSpanId`, R.`SpanName` AS `SpanName`, R.`Duration` AS `Duration`, R.`Timestamp` AS `Timestamp`, R.`ResourceAttributes` AS `ResourceAttributes` FROM (SELECT R.`TraceId` AS `TraceId`, R.`SpanId` AS `SpanId`, R.`ParentSpanId` AS `ParentSpanId`, R.`SpanName` AS `SpanName`, R.`Duration` AS `Duration`, R.`Timestamp` AS `Timestamp`, R.`ResourceAttributes` AS `ResourceAttributes` FROM (WITH RECURSIVE _struct_closure AS (SELECT `TraceId`, `SpanId`, `ParentSpanId`, 0 AS _depth FROM (SELECT R.`TraceId` AS `TraceId`, R.`SpanId` AS `SpanId`, R.`ParentSpanId` AS `ParentSpanId`, R.`SpanName` AS `SpanName`, R.`Duration` AS `Duration`, R.`Timestamp` AS `Timestamp`, R.`ResourceAttributes` AS `ResourceAttributes` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) AS L INNER JOIN (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) AS R ON L.`TraceId` = R.`TraceId` AND L.`SpanId` = R.`ParentSpanId`) AS _seed UNION ALL SELECT t.`TraceId`, t.`SpanId`, t.`ParentSpanId`, c._depth + 1 FROM `otel_traces` AS t INNER JOIN _struct_closure AS c ON t.`TraceId` = c.`TraceId` AND t.`ParentSpanId` = c.`SpanId`) SELECT DISTINCT `TraceId`, `SpanId` FROM _struct_closure WHERE _depth > 0) AS L INNER JOIN (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) AS R ON L.`TraceId` = R.`TraceId` AND L.`SpanId` = R.`SpanId`) AS L INNER JOIN (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) AS R ON L.`TraceId` = R.`TraceId` AND L.`SpanId` = R.`ParentSpanId`) AS _seed UNION ALL SELECT t.`TraceId`, t.`SpanId`, t.`ParentSpanId`, c._depth + 1 FROM `otel_traces` AS t INNER JOIN _struct_closure AS c ON t.`TraceId` = c.`TraceId` AND t.`ParentSpanId` = c.`SpanId`) SELECT DISTINCT `TraceId`, `SpanId` FROM _struct_closure WHERE _depth > 0) AS L INNER JOIN (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) AS R ON L.`TraceId` = R.`TraceId` AND L.`SpanId` = R.`SpanId`


### PR DESCRIPTION
## Summary

- `edge_chain_mixed_5.txtar` ships with a minimal otel_traces seed (TraceId / SpanId / ParentSpanId / _svc / ResourceAttributes) inherited from PR #515. PR #528 then switched the structural-join wrap projection from `R.* EXCEPT (...)` to explicit `R.SpanName AS SpanName` etc. — the explicit columns rely on the seed table having SpanName / Duration / Timestamp, which `edge_chain_mixed_5` does not declare.
- chDB's analyzer reports `Identifier 'R.SpanName' cannot be resolved from subquery with name R` against the innermost `(SELECT * FROM otel_traces) AS R` step, which surfaced as the only failing case in the `chdb / roundtrip (traceql)` job after #528 merged.
- Add SpanName / Duration / Timestamp columns to the seed and flip ResourceAttributes from `MATERIALIZED` to `DEFAULT` so the wrap projections resolve. Update `expected_rows` to match the new column count.

## Root cause

The bug isn't in the recursive emitter — `internal/chsql/structural_join.go` already routes both the direct and recursive paths through `structuralProjectionFrags`, so the explicit-column projection introduced in #528 covers the recursive case automatically. The schema in `edge_chain_mixed_5`'s seed simply didn't keep pace with the wrap projection's column list when the rest of the structural-join fixtures were updated.

## Test plan

- [x] `go test -tags chdb ./test/spec/traceql/ -run 'TestRoundTripChDB/edge_chain_mixed_5'` — green
- [x] `go test -tags chdb ./test/spec/traceql/` — 134 fixtures pass
- [x] `go test ./internal/traceql/ -run TestLower` — 206 lowering goldens pass (the SQL block in this fixture is unchanged)
- [x] `go test ./internal/chsql/ -run 'Structural'` — 15 structural-join tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)