### PR TITLE
test(chsql): kill 2 surviving mutants to clear 95% efficacy gate

### DIFF
--- a/internal/chsql/gremlins_kill_test.go
+++ b/internal/chsql/gremlins_kill_test.go
@@ -2186,3 +2186,73 @@ func TestPartitionPrewhere_LastWhereRetainsExactConjunct(t *testing.T) {
 		t.Errorf("WHERE has no operand (mutant emitted empty clause).\nSQL=%s", sql)
 	}
 }
+
+// TestEmitWindowedArrayMatrix_LogRateMinWindowZero kills the
+// `minWindowSize > 0` boundary at range_window.go:1947 inside
+// emitWindowedArrayMatrix. The values-only matrix path is reached
+// with minWindowSize = 0 only via `log_rate` (LogQL's `rate({...}[r])`,
+// which emits 0 for empty windows rather than dropping them). All
+// other matrix-path callers pass a positive minWindowSize, so the
+// mutant `>= 0` was indistinguishable from the original on the
+// existing fixtures — exercising the log_rate + OuterRange combo
+// forces the boundary to bite (the mutant would append
+// `WHERE length(window_vals) >= 0`, a no-op filter the LogRate
+// semantics explicitly disallow).
+func TestEmitWindowedArrayMatrix_LogRateMinWindowZero(t *testing.T) {
+	t.Parallel()
+	plan := &chplan.RangeWindow{
+		Input:           &chplan.Scan{Table: "otel_logs"},
+		Func:            "log_rate",
+		Range:           time.Minute,
+		Step:            time.Minute,
+		OuterRange:      5 * time.Minute,
+		TimestampColumn: "Timestamp",
+		ValueColumn:     "Value",
+	}
+	sql, _, err := Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	// LogRate matrix MUST NOT emit a window-length filter — its
+	// semantics are sum/range with a 0 fallback for empty windows.
+	if strings.Contains(sql, "length(`window_vals`) >= 0") {
+		t.Errorf("LogRate matrix unexpectedly emitted >= 0 length filter (boundary mutant).\nSQL=%s", sql)
+	}
+	// Defence in depth: any `length(window_vals) >= N` at all is wrong
+	// for the LogRate path; the original skips the WHERE entirely.
+	if strings.Contains(sql, "length(`window_vals`) >=") {
+		t.Errorf("LogRate matrix must not gate on window length.\nSQL=%s", sql)
+	}
+}
+
+// TestEmitWindowedArrayPairsAnchored_MinWindowZero kills the
+// `minWindowSize > 0` boundary at range_window.go:504 inside
+// emitWindowedArrayPairsAnchored. The instant pairs path is
+// reached by deriv / irate / last_over_time / predict_linear /
+// holt_winters, all of which pass minWindowSize ∈ {1, 2}. Every
+// production call exercises the >0 branch, so the mutant `>= 0`
+// produces identical SQL on the existing fixtures. Calling the
+// unexported emitter helper directly with minWindowSize = 0
+// reaches the boundary: the original skips the WHERE; the mutant
+// emits `WHERE length(window_pairs) >= 0`.
+func TestEmitWindowedArrayPairsAnchored_MinWindowZero(t *testing.T) {
+	t.Parallel()
+	e := &emitter{}
+	r := &chplan.RangeWindow{
+		Input:           &chplan.Scan{Table: "otel_metrics_gauge"},
+		Range:           time.Minute,
+		TimestampColumn: "TimeUnix",
+		ValueColumn:     "Value",
+	}
+	writer := func(_ Frag) Frag { return verbatim("0") }
+	if err := e.emitWindowedArrayPairsAnchored(r, writer, 0); err != nil {
+		t.Fatalf("emitWindowedArrayPairsAnchored: %v", err)
+	}
+	sql := e.b.String()
+	if strings.Contains(sql, "length(`window_pairs`) >= 0") {
+		t.Errorf("minWindowSize=0 must not gate on window length.\nSQL=%s", sql)
+	}
+	if strings.Contains(sql, "length(`window_pairs`) >=") {
+		t.Errorf("minWindowSize=0 must skip the length filter entirely.\nSQL=%s", sql)
+	}
+}


### PR DESCRIPTION
## Summary

Phase-2 mutation efficacy on main dropped to **94.98%** (492 killed / 518 runnable) — 0.02% under the 95% gate (run 26108141906, job 76777622803). Same playbook as #62 / #90.

Of the 26 LIVED mutants, 24 are **structurally equivalent** (sentinel guards / no-op appends mask the flip on every reachable input). The 2 truly reachable boundaries are both on \`minWindowSize > 0\`:

- **range_window.go:1947** (\`emitWindowedArrayMatrix\`) — only \`log_rate\` (LogQL's \`rate({...}[r])\`, which emits 0 for empty windows rather than dropping them) routes here with \`minWindowSize = 0\`. Existing matrix tests cover \`sum_over_time\` (1) and \`deriv\` (2), masking the boundary. Adding a \`log_rate\` + \`OuterRange\` plan forces the original to skip the WHERE while the mutant emits \`WHERE length(\`window_vals\`) >= 0\`.
- **range_window.go:504** (\`emitWindowedArrayPairsAnchored\`) — every production caller passes 2; the boundary is exercised by calling the unexported helper directly with \`minWindowSize = 0\` from the in-package test.

After: 494 / 518 = **95.37%**. Leaves ~0.37% headroom over the gate.

## Test plan

- [x] Verified both new tests pass on unmutated code (\`go test ./internal/chsql/... -count=1\` → 584 tests pass).
- [x] Verified each test fails when the boundary is patched to \`>=\` (manual mutation drill at line 504 and line 1947 — both kill tests turn red, confirming the mutant is no longer LIVED).
- [x] No \`t.Skip*\` / "skipped" / "deferred" / "not implemented" / "post-GA" / "RC*" markers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)