### PR TITLE
fix(api/tempo): apply leading-zero strip to spanset-aggregate TraceID projection

### DIFF
--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -802,10 +802,20 @@ func aggregateCarriesSpansetEnvelope(a *chplan.Aggregate) bool {
 // float64 — same wire shape as canonicalSampleProjections but
 // reading from the Aggregate's projected columns rather than the
 // raw spans-table columns.
+//
+// The `TraceId` column the inner Aggregate exposes is the raw
+// fixed-width OTel-CH value (32 lowercase-hex chars); Tempo's wire
+// format strips leading zeros, so we route it through
+// stripLeadingHexZeros — same treatment canonicalSampleProjections
+// applies to the scan-level TraceId column. Without the strip, the
+// shadow-mode differ pairs cerberus rows by `00af…66b` against
+// Tempo's `af…66b`, generating spurious missing_in_a / missing_in_b
+// reasons across the spanset-aggregate compat cases (e.g.
+// `avg_duration_per_trace_status_ok`).
 func spansetAggregateSampleProjections() []chplan.Projection {
 	traceIDMap := &chplan.FuncCall{Name: "map", Args: []chplan.Expr{
 		&chplan.LitString{V: searchKeyTraceID},
-		&chplan.ColumnRef{Name: "TraceId"},
+		stripLeadingHexZeros("TraceId"),
 	}}
 	mergedAttrs := &chplan.FuncCall{Name: "mapConcat", Args: []chplan.Expr{
 		&chplan.ColumnRef{Name: "ResourceAttrs"},

--- a/internal/api/tempo/traceid_hex_test.go
+++ b/internal/api/tempo/traceid_hex_test.go
@@ -138,6 +138,37 @@ func TestCanonicalSampleProjections_StripsTraceIDLeadingZeros(t *testing.T) {
 	}
 }
 
+// TestSpansetAggregateSampleProjections_StripsTraceIDLeadingZeros pins
+// the wrap-projection used for `{ ... } | count() > 0`,
+// `| avg(duration) > 0`, and the other per-trace spanset aggregates
+// (see internal/traceql/aggregate.go). The inner Aggregate's
+// `GroupBy: [TraceId]` exposes the raw 32-char zero-padded hex from
+// the OTel-CH column; the outer wrap projection must route it
+// through stripLeadingHexZeros so the `__cerberus_traceID` reserved
+// label arrives at the shadow-mode differ in Tempo's
+// leading-zero-stripped form. Without this strip the differ pairs
+// cerberus rows (e.g. `00af843259b0a78f5cbe59e11cbaf66b`) against
+// Tempo (`af843259b0a78f5cbe59e11cbaf66b`) by mismatched keys,
+// generating spurious missing_in_a / missing_in_b reasons across the
+// spanset-aggregate compat cases.
+func TestSpansetAggregateSampleProjections_StripsTraceIDLeadingZeros(t *testing.T) {
+	t.Parallel()
+
+	projs := spansetAggregateSampleProjections()
+
+	plan := &chplan.Project{
+		Input:       &chplan.Scan{Table: "inner_aggregate"},
+		Projections: projs,
+	}
+	sql, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if !strings.Contains(sql, "replaceRegexpOne(`TraceId`,") {
+		t.Errorf("spanset-aggregate projection must wrap TraceId in replaceRegexpOne; got:\n%s", sql)
+	}
+}
+
 // TestTraceByIDProjections_StripsAllIDColumns covers the
 // /api/traces/{id} response path. TraceId, SpanId, and ParentSpanId
 // all need the leading-zero strip to match Tempo's response shape.


### PR DESCRIPTION
## Summary

- PR #536 added `spansetAggregateSampleProjections` for the per-trace
  spanset-aggregate wrap (`{ ... } | count() > 0`, `| avg(duration) > 0`,
  etc.) but read the inner Aggregate's GROUP BY column `TraceId` raw —
  the OTel-CH 32-char zero-padded hex shape (e.g. `00af843259b0a78f5cbe59e11cbaf66b`).
- Tempo's wire format strips leading zeros from trace IDs (`af843259b0a78f5cbe59e11cbaf66b`).
  The shadow-mode differ paired cerberus rows against Tempo by mismatched
  keys, generating spurious `missing_in_a` / `missing_in_b` reasons
  across ~5 spanset-aggregate compat cases (e.g.
  `avg_duration_per_trace_status_ok`).
- Route the `TraceId` reserved-map entry through `stripLeadingHexZeros`
  — same treatment PR #532 applied to `canonicalSampleProjections`,
  `traceByIDProjections`, and `rQualifiedSampleProjections`. The helper
  emits `replaceRegexpOne(TraceId, '^0+([0-9a-f])', '\1')` which retains
  at least one hex digit so an all-zero TraceID renders as `0`, not the
  empty string.

Expected Tempo compat lift: 54.55% → ~63%.

## Test plan

- [x] Add `TestSpansetAggregateSampleProjections_StripsTraceIDLeadingZeros`
  to `internal/api/tempo/traceid_hex_test.go` pinning the
  `replaceRegexpOne(TraceId, ...)` shape in emitted SQL.
- [x] Existing `TestSearch_SpansetAggregate_PerTrace` exercises the
  handler end-to-end via stub querier (unaffected — it bypasses the SQL
  emitter).
- [ ] CI `check` + `lint` green.
- [ ] Tempo compat nightly run picks up the ~5 newly-passing cases.