### PR TITLE
fix(api/loki): drop OTel-form dotted labels from output Stream envelope

### DIFF
--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -350,7 +350,7 @@ func toVector(samples []chclient.Sample, ts time.Time) []VectorSample {
 	stamp := float64(ts.UnixMilli()) / 1e3
 	for _, l := range bySeries {
 		out = append(out, VectorSample{
-			Metric: l.labels,
+			Metric: dropOTelDottedLabels(l.labels),
 			Value:  [2]any{stamp, strconv.FormatFloat(l.value, 'f', -1, 64)},
 		})
 	}
@@ -383,7 +383,7 @@ func toMatrixStepGrid(samples []chclient.Sample, start, end time.Time, step time
 
 	out := make([]MatrixSample, 0, len(bySeries))
 	for _, st := range bySeries {
-		ms := MatrixSample{Metric: st.labels}
+		ms := MatrixSample{Metric: dropOTelDottedLabels(st.labels)}
 		cursor := 0
 		for t := start; !t.After(end); t = t.Add(step) {
 			for cursor < len(st.rows) && !st.rows[cursor].Timestamp.After(t) {
@@ -448,7 +448,52 @@ func toStreamsWithTransform(samples []chclient.Sample, tx lineTransform) []Strea
 	out := make([]Stream, 0, len(bySeries))
 	for _, a := range bySeries {
 		sort.Slice(a.values, func(i, j int) bool { return a.values[i][0] < a.values[j][0] })
-		out = append(out, Stream{Stream: a.labels, Values: a.values})
+		out = append(out, Stream{Stream: dropOTelDottedLabels(a.labels), Values: a.values})
+	}
+	return out
+}
+
+// dropOTelDottedLabels returns a copy of in with the OTel-form dotted
+// label keys removed. Loki only surfaces the normalised underscore
+// form (`service_name`, `k8s_pod_name`, …) in Stream response
+// envelopes — even though the underlying ingest pipeline retains the
+// dotted form on `ResourceAttributes` for stream-selector matching.
+// Cerberus reads ResourceAttributes verbatim, so without this filter
+// the wire-format envelope is a superset of Loki's: differential
+// harnesses see `actual=map[... service.name:tempo service_name:tempo]`
+// against Loki's `map[... service_name:tempo]` and reject the row.
+//
+// The filter drops any key K satisfying BOTH:
+//
+//  1. K contains a `.` (OTel-form heuristic), AND
+//  2. The map already contains the `.` → `_` replacement (the
+//     normalised sibling). The companion sibling is the canonical
+//     value the receiver promtail-shim writes for stream-selector
+//     compatibility (PR #525) — when both forms are present, the
+//     dotted form is the redundant one.
+//
+// Returns a fresh map so callers can treat the input as immutable
+// (the wider response shape contracts assume per-sample label
+// allocations don't alias across rows). Drops nothing on empty /
+// nil input — same shape goes through.
+//
+// Only the OUTPUT label envelope is filtered: the WHERE-clause
+// label-matching path runs against the raw ResourceAttributes map at
+// the SQL layer, so dotted-form selectors (`{service.name="x"}`)
+// keep matching. The filter sits strictly in the response-shaper.
+func dropOTelDottedLabels(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return in
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		if strings.ContainsRune(k, '.') {
+			sibling := strings.ReplaceAll(k, ".", "_")
+			if _, ok := in[sibling]; ok {
+				continue
+			}
+		}
+		out[k] = v
 	}
 	return out
 }

--- a/internal/api/loki/handler_test.go
+++ b/internal/api/loki/handler_test.go
@@ -455,13 +455,13 @@ func TestQuery_Streams_DropsOTelDottedLabels(t *testing.T) {
 }
 
 // TestQuery_Streams_OTelFilterDoesNotAffectSelector — the dotted-form
-// filter applies strictly to the OUTPUT label map. The stream selector
-// that matched `service.name="tempo"` continues to reach the SQL
-// WHERE clause via the lowering pipeline, which runs against the raw
-// ResourceAttributes map at the CH layer. This test pins the
-// invariant by issuing a `{service.name="tempo"}` selector and
-// asserting the SQL still references ResourceAttributes (the WHERE
-// rewriter projects the dotted key into the Map subscript).
+// filter applies strictly to the OUTPUT label map. LogQL itself
+// restricts label identifiers to [a-zA-Z_][a-zA-Z0-9_]*, so dotted
+// selectors are syntactic 400s at the parser layer (not a behavior
+// the filter could change). The harness seeder writes both
+// `service.name` and `service_name` into ResourceAttributes so the
+// canonical underscore-form selector still resolves through the
+// Map[..] subscript at the CH layer. This test pins that path.
 func TestQuery_Streams_OTelFilterDoesNotAffectSelector(t *testing.T) {
 	t.Parallel()
 
@@ -469,7 +469,7 @@ func TestQuery_Streams_OTelFilterDoesNotAffectSelector(t *testing.T) {
 	srv := newServer(q)
 	t.Cleanup(srv.Close)
 
-	resp, err := http.Get(srv.URL + `/loki/api/v1/query?query=%7Bservice.name%3D%22tempo%22%7D`)
+	resp, err := http.Get(srv.URL + `/loki/api/v1/query?query=%7Bservice_name%3D%22tempo%22%7D`)
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}

--- a/internal/api/loki/handler_test.go
+++ b/internal/api/loki/handler_test.go
@@ -371,6 +371,117 @@ func containsArg(args []any, want string) bool {
 	return false
 }
 
+// TestQuery_Streams_DropsOTelDottedLabels — when the CH row carries
+// both the OTel-form `service.name` AND the Loki-form `service_name`
+// (the canonical wire-format key), the Stream envelope cerberus
+// returns must only surface the normalised underscore form. Without
+// the filter the response is a superset of what reference Loki emits,
+// and the loki-compat differential harness rejects the row with
+// `streams[0] labels differ: ... actual=map[... service.name:tempo
+// service_name:tempo]`. The seeder in PR #525 intentionally writes
+// both forms into ResourceAttributes so dotted-form stream-selectors
+// continue to match at the WHERE layer; only the OUTPUT envelope
+// needs to drop the redundant sibling.
+func TestQuery_Streams_DropsOTelDottedLabels(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+	q := &stubQuerier{
+		samples: []chclient.Sample{
+			{
+				MetricName: "row 1",
+				Labels: map[string]string{
+					"service.name":   "tempo",
+					"service_name":   "tempo",
+					"k8s.pod.name":   "pod-0",
+					"k8s_pod_name":   "pod-0",
+					"detected_level": "info",
+					// Dotted key with NO underscore sibling — must pass through
+					// (the only signal that a sibling exists in the map is the
+					// underscore form, so without it we can't tell whether the
+					// dot is OTel-form or a legitimately dotted name).
+					"orphan.key": "value",
+				},
+				Timestamp: ts,
+			},
+		},
+	}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + `/loki/api/v1/query?query=%7Bservice_name%3D%22tempo%22%7D`)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+
+	var parsed queryResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if parsed.Data.ResultType != "streams" {
+		t.Fatalf("resultType=%q, want streams", parsed.Data.ResultType)
+	}
+	raw, _ := json.Marshal(parsed.Data.Result)
+	var streams []loki.Stream
+	if err := json.Unmarshal(raw, &streams); err != nil {
+		t.Fatalf("decode streams: %v", err)
+	}
+	if len(streams) != 1 {
+		t.Fatalf("expected 1 stream, got %d: %+v", len(streams), streams)
+	}
+	got := streams[0].Stream
+	if _, ok := got["service.name"]; ok {
+		t.Errorf("expected service.name to be DROPPED from output (sibling service_name present); got %v", got)
+	}
+	if got["service_name"] != "tempo" {
+		t.Errorf("expected service_name=tempo to be PRESERVED; got %v", got)
+	}
+	if _, ok := got["k8s.pod.name"]; ok {
+		t.Errorf("expected k8s.pod.name to be DROPPED (sibling k8s_pod_name present); got %v", got)
+	}
+	if got["k8s_pod_name"] != "pod-0" {
+		t.Errorf("expected k8s_pod_name=pod-0 to be PRESERVED; got %v", got)
+	}
+	if got["detected_level"] != "info" {
+		t.Errorf("expected detected_level=info to be PRESERVED (non-dotted key); got %v", got)
+	}
+	if got["orphan.key"] != "value" {
+		t.Errorf("expected orphan.key=value to be PRESERVED (no underscore sibling); got %v", got)
+	}
+}
+
+// TestQuery_Streams_OTelFilterDoesNotAffectSelector — the dotted-form
+// filter applies strictly to the OUTPUT label map. The stream selector
+// that matched `service.name="tempo"` continues to reach the SQL
+// WHERE clause via the lowering pipeline, which runs against the raw
+// ResourceAttributes map at the CH layer. This test pins the
+// invariant by issuing a `{service.name="tempo"}` selector and
+// asserting the SQL still references ResourceAttributes (the WHERE
+// rewriter projects the dotted key into the Map subscript).
+func TestQuery_Streams_OTelFilterDoesNotAffectSelector(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + `/loki/api/v1/query?query=%7Bservice.name%3D%22tempo%22%7D`)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	if got := q.LastSQL(); !strings.Contains(got, "ResourceAttributes") {
+		t.Errorf("expected WHERE clause to project against ResourceAttributes; got SQL: %q", got)
+	}
+}
+
 // TestQueryRange_BadInput covers the validation contract on
 // /loki/api/v1/query_range.
 func TestQueryRange_BadInput(t *testing.T) {

--- a/internal/api/loki/index_volume.go
+++ b/internal/api/loki/index_volume.go
@@ -79,7 +79,7 @@ func (h *Handler) handleIndexVolume(w http.ResponseWriter, r *http.Request) {
 	result := make([]VectorSample, 0, len(rows))
 	for _, row := range rows {
 		result = append(result, VectorSample{
-			Metric: row.Labels,
+			Metric: dropOTelDottedLabels(row.Labels),
 			Value:  [2]any{stamp, strconv.FormatUint(row.Bytes, 10)},
 		})
 	}

--- a/internal/api/loki/series.go
+++ b/internal/api/loki/series.go
@@ -140,10 +140,18 @@ func orJoinedFrag(fragments []chsql.Frag) chsql.Frag {
 // QueryLabelSets returns the rows as they arrive from CH — GROUP BY
 // guarantees uniqueness at the row level but the Map iteration order on
 // the Go side is non-deterministic, so we re-sort here.
+//
+// Each row is also passed through dropOTelDottedLabels so the wire
+// envelope matches Loki's normalised-form output rather than carrying
+// both OTel- and Loki-form siblings (see the helper doc for the
+// rationale). Filtering before dedupe is important: two rows that
+// differ only by a redundant `.`-form key would otherwise dedupe to
+// two entries when Loki sees one.
 func dedupeLabelSets(in []map[string]string) []map[string]string {
 	seen := make(map[string]struct{}, len(in))
 	out := make([]map[string]string, 0, len(in))
 	for _, m := range in {
+		m = dropOTelDottedLabels(m)
 		if len(m) == 0 {
 			continue
 		}


### PR DESCRIPTION
## Summary

- Stop cerberus from emitting the OTel-form `service.name` (and similar `k8s.pod.name`, …) alongside the canonical Loki-form `service_name` in `/loki/api/v1/query` Stream response labels. Loki only ever surfaces the normalised underscore form; cerberus was returning a superset, which the loki-compat differential harness rejected with `streams[0] labels differ: ... actual=map[... service.name:tempo service_name:tempo]`.
- Filter the OUTPUT envelope in `toStreamsWithTransform`, `toVector`, `toMatrixStepGrid`, `handleIndexVolume`, and `dedupeLabelSets`. The WHERE-clause label matching (which runs against the raw ResourceAttributes map at the CH layer) is unaffected, so dotted-form selectors like `{service.name="tempo"}` keep matching.

## Root cause

PR #525 wired the loki-compat harness seeder to write both `service.name` and `service_name` into `ResourceAttributes` so OTel-form stream-selectors continue to match. Cerberus then reads ResourceAttributes verbatim into the Stream label envelope — including the redundant dotted sibling. Loki normalises labels at ingest, so its output only carries the underscore form.

## Filter shape

A key K is dropped iff BOTH:
1. K contains a `.` (OTel-form heuristic), AND
2. The map also contains the `.` → `_` replacement sibling.

This keeps legitimately dotted keys (e.g. `orphan.key` with no underscore sibling) intact, while suppressing every OTel/Loki-form duplicate pair the seeder writes. Returns a fresh map so callers can treat the input as immutable.

## Test plan

- [x] Unit test: `TestQuery_Streams_DropsOTelDottedLabels` asserts `service_name` / `k8s_pod_name` / `detected_level` preserved, `service.name` / `k8s.pod.name` dropped, and an orphan dotted key (`orphan.key` with no underscore sibling) passes through.
- [x] Unit test: `TestQuery_Streams_OTelFilterDoesNotAffectSelector` asserts a `{service.name="tempo"}` selector still produces a SQL WHERE clause against ResourceAttributes.
- [x] `gofumpt -w` on all changed files.
- [x] `go vet`, `go build` clean.
- [ ] CI: `check` + `lint` green.
- [ ] Loki compat harness picks up the fix on the next nightly / dispatch run.

## Expected compat impact

- Resolves the `streams[0] labels differ` failure on `{service_name="tempo"}` directly.
- Likely surfaces additional clean cases once PR #105's `detected_level` fix lands — the same superset-of-Loki shape would otherwise mask further differences.