### PR TITLE
feat(logql): surface detected_level as stream-label dimension in log + metric pipelines

### DIFF
--- a/internal/logql/detected_level.go
+++ b/internal/logql/detected_level.go
@@ -130,3 +130,53 @@ func anyEqual(expr chplan.Expr, variants []string) chplan.Expr {
 	}
 	return out
 }
+
+// withDetectedLevel wraps a labels-map expression so the result carries
+// the synthesized `detected_level` key whenever the row's SeverityText
+// is non-empty. The emitted shape is
+//
+//	mapConcat(
+//	    <baseLabels>,
+//	    mapFilter((k, v) -> v != '', map('detected_level', multiIf(...))))
+//
+// `mapFilter` drops the `detected_level` entry when the row's
+// SeverityText is empty (the multiIf default branch returns
+// `lower(”) = ”`), so rows without a severity-bearing column don't
+// gain a spurious empty-string label. The shape mirrors Loki's stream-
+// identity contract: `detected_level` is part of the output stream
+// label set whenever the upstream row carries severity metadata, and
+// absent otherwise.
+//
+// Used by both the log-stream projection (Lang.ProjectSamples for log
+// queries, where the surfaced label splits the streams response into
+// one Stream per detected_level) and the bare range-aggregation
+// projection (lowerRangeAggregation when no by/without grouping, where
+// the augmented identity drives the RangeWindow GROUP BY to emit one
+// series per detected_level).
+func withDetectedLevel(s schema.Logs, baseLabels chplan.Expr) chplan.Expr {
+	levelMap := &chplan.FuncCall{
+		Name: "map",
+		Args: []chplan.Expr{
+			&chplan.LitString{V: detectedLevelLabel},
+			detectedLevelExpr(s),
+		},
+	}
+	filtered := &chplan.FuncCall{
+		Name: "mapFilter",
+		Args: []chplan.Expr{
+			&chplan.Lambda{
+				Params: []string{"k", "v"},
+				Body: &chplan.Binary{
+					Op:    chplan.OpNe,
+					Left:  &chplan.BareIdent{Name: "v"},
+					Right: &chplan.LitString{V: ""},
+				},
+			},
+			levelMap,
+		},
+	}
+	return &chplan.FuncCall{
+		Name: "mapConcat",
+		Args: []chplan.Expr{baseLabels, filtered},
+	}
+}

--- a/internal/logql/lang.go
+++ b/internal/logql/lang.go
@@ -190,11 +190,18 @@ func (l *Lang) ProjectSamples(plan chplan.Node, meta engine.Meta) chplan.Node {
 	// can't ride in Value — instead we put it in MetricName (also a String)
 	// and write a 0.0 placeholder into Value. toStreamsWithTransform reads
 	// back from Sample.MetricName as the line content.
+	//
+	// The Attributes column is wrapped in [withDetectedLevel] so the
+	// emitted row carries `detected_level` as a synthesized label
+	// whenever SeverityText is populated. Loki's stream-label contract
+	// surfaces detected_level as part of stream identity, so cerberus's
+	// /query streams response splits into one Stream per detected_level
+	// (matching upstream Loki's wire shape).
 	return &chplan.Project{
 		Input: plan,
 		Projections: []chplan.Projection{
 			{Expr: &chplan.ColumnRef{Name: s.BodyColumn}, Alias: "MetricName"},
-			{Expr: &chplan.ColumnRef{Name: s.ResourceAttributesColumn}, Alias: "Attributes"},
+			{Expr: withDetectedLevel(s, &chplan.ColumnRef{Name: s.ResourceAttributesColumn}), Alias: "Attributes"},
 			{Expr: &chplan.ColumnRef{Name: s.TimestampColumn}, Alias: "TimeUnix"},
 			// Wrap the placeholder zero in toFloat64 so CH returns the column
 			// as Float64; without the cast a bare `0` literal becomes UInt8

--- a/internal/logql/lang_test.go
+++ b/internal/logql/lang_test.go
@@ -300,3 +300,60 @@ func TestProjectSamples_VectorAggregateOverMatrixForwardsTimeUnix(t *testing.T) 
 			"with synth now64 would drop per-step rows)", tsRef.Name, "TimeUnix")
 	}
 }
+
+// TestProjectSamples_LogQuerySurfacesDetectedLevel pins the log-stream
+// branch's Attributes slot to a `mapConcat(...)` that folds the
+// synthesized `detected_level` label onto the row's ResourceAttributes.
+//
+// Loki's stream-identity contract surfaces `detected_level` as a
+// structural label whenever the upstream row carries a severity-bearing
+// column. Cerberus mirrors that on the wire: the
+// `toStreamsWithTransform` pivot keys on `format.CanonicalKey(labels)`,
+// so adding `detected_level` to the labels map splits the streams
+// response into one Stream per distinct severity — matching upstream's
+// shape on a multi-level seed.
+//
+// The pre-detected_level wire-wrap projected `ResourceAttributes`
+// directly; this test pins the upgrade so a regression that reverts to
+// the bare column ref is caught synchronously rather than via the
+// loki-compat harness's "streams length: expected=4 actual=1" failure.
+func TestProjectSamples_LogQuerySurfacesDetectedLevel(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelLogs()
+	l := &logql.Lang{Schema: s}
+
+	// Log-stream queries lower to a Scan (or Filter(Scan)) — no inner
+	// Project layer. ProjectSamples wraps with the wire-shape projection.
+	plan := &chplan.Scan{Table: s.LogsTable}
+	wrapped := l.ProjectSamples(plan, engine.Meta{IsMetric: false})
+
+	proj, ok := wrapped.(*chplan.Project)
+	if !ok {
+		t.Fatalf("ProjectSamples returned %T, want *chplan.Project", wrapped)
+	}
+	if len(proj.Projections) != 4 {
+		t.Fatalf("got %d projections, want 4 (MetricName, Attributes, TimeUnix, Value)",
+			len(proj.Projections))
+	}
+
+	attrsSlot := proj.Projections[1]
+	if attrsSlot.Alias != "Attributes" {
+		t.Fatalf("attributes slot alias: got %q, want %q", attrsSlot.Alias, "Attributes")
+	}
+	// Must be a mapConcat(...) — the helper that folds detected_level
+	// onto the row's ResourceAttributes. A bare ColumnRef would mean
+	// the log-stream branch dropped the augmentation.
+	fn, ok := attrsSlot.Expr.(*chplan.FuncCall)
+	if !ok {
+		t.Fatalf("attributes slot expr: got %T, want *chplan.FuncCall "+
+			"(log-stream wire-wrap must wrap ResourceAttributes in a "+
+			"mapConcat that adds the synthesized `detected_level` label)",
+			attrsSlot.Expr)
+	}
+	if fn.Name != "mapConcat" {
+		t.Errorf("attributes slot FuncCall.Name: got %q, want %q "+
+			"(log-stream wire-wrap must fold detected_level via mapConcat)",
+			fn.Name, "mapConcat")
+	}
+}

--- a/internal/logql/lower_bench_test.go
+++ b/internal/logql/lower_bench_test.go
@@ -73,9 +73,13 @@ func TestAllocs_Lower(t *testing.T) {
 		maxAvg float64
 	}{
 		// Baselines: 15 / 21 / 25 — ceilings = baseline × ~3.
+		// `metric_form` was lifted from 80 → 100 when detected_level was
+		// added as a synthesised identity dimension on bare range
+		// aggregations (mapConcat + mapFilter + multiIf nodes added to
+		// every count_over_time / rate / ... lowering).
 		{"stream_matcher", `{job="api"}`, 45},
 		{"line_filter_chain", `{job="api"} |= "error" |~ "5[0-9]{2}"`, 70},
-		{"metric_form", `count_over_time({job="api"}[5m])`, 80},
+		{"metric_form", `count_over_time({job="api"}[5m])`, 100},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/logql/range_aggregation.go
+++ b/internal/logql/range_aggregation.go
@@ -69,13 +69,28 @@ func lowerRangeAggregation(e *syntax.RangeAggregationExpr, s schema.Logs, lc low
 		return nil, err
 	}
 
-	identityProj := chplan.Projection{Expr: &chplan.ColumnRef{Name: s.ResourceAttributesColumn}}
+	// Default identity: the raw ResourceAttributes column, augmented with
+	// the synthesized `detected_level` label so each distinct severity
+	// becomes its own series. Loki's stream-identity contract includes
+	// detected_level as a structural dimension whenever the upstream row
+	// carries severity metadata; the RangeWindow's GROUP BY (keyed on
+	// the ResourceAttributesColumn alias) then collapses one row per
+	// (stream, detected_level) tuple — matching upstream Loki's matrix
+	// shape (16 of the 19 loki-compat failures came from cerberus
+	// collapsing 4 levels into 1 series here).
+	identityProj := chplan.Projection{
+		Expr:  withDetectedLevel(s, &chplan.ColumnRef{Name: s.ResourceAttributesColumn}),
+		Alias: s.ResourceAttributesColumn,
+	}
 	if groupBy != nil {
 		// With `by (...)` / `without (...)` the inner Project replaces
 		// the per-stream identity with the group-key map so the
 		// RangeWindow GROUP BY (still keyed on the
 		// ResourceAttributesColumn) collapses per-group rather than
-		// per-stream. The alias matches the column name the outer
+		// per-stream. The user-supplied grouping is authoritative: we
+		// do NOT auto-inject detected_level on top of an explicit
+		// `by (...)` / `without (...)` clause — that would defeat the
+		// caller's intent. The alias matches the column name the outer
 		// RangeWindow expects.
 		identityProj = chplan.Projection{Expr: groupBy, Alias: s.ResourceAttributesColumn}
 	}

--- a/test/property/oracle/logql/evaluator.go
+++ b/test/property/oracle/logql/evaluator.go
@@ -44,19 +44,58 @@ func Evaluate(d property.Dataset, q property.Query) property.Outcome {
 	// sees the same series identity cerberus's handler produces. The
 	// handler's toStreamsWithTransform path groups by the
 	// CanonicalKey of the (post-format) labels — match that here.
+	//
+	// Each row's labels also carry the synthesized `detected_level`
+	// derived from the record's SeverityText — Loki surfaces this as a
+	// stream-identity dimension whenever the source row has severity
+	// metadata, and cerberus's wire-wrap (Lang.ProjectSamples on the
+	// log-stream branch) mirrors that. Strip the detection at the
+	// oracle so the comparator sees the same shape.
 	out := property.Outcome{Rows: make([]property.OutcomeRow, 0, len(records))}
 	for _, r := range records {
+		labels := copyLabels(r.ResourceAttributes)
+		if lvl := normaliseLogLevel(r.SeverityText); lvl != "" {
+			labels["detected_level"] = lvl
+		}
 		// TimestampMs is unix milliseconds, matching the prom-side
 		// convention. Cerberus's stream-wire format uses nanos, but
 		// the property runner normalises to milliseconds (the
 		// generator works in nanos so we divide once here).
 		out.Rows = append(out.Rows, property.OutcomeRow{
-			Labels:      copyLabels(r.ResourceAttributes),
+			Labels:      labels,
 			TimestampMs: r.TimestampNanos / int64(1e6),
 			Line:        r.Body,
 		})
 	}
 	return out
+}
+
+// normaliseLogLevel mirrors cerberus's [internal/logql.normaliseLevelExpr]
+// — maps the case-insensitive forms upstream Loki accepts onto the
+// canonical lowercase level strings. Empty input returns the empty
+// string so the caller can skip the label entirely (matches the
+// `mapFilter((k, v) -> v != ”, ...)` shape on the SQL side).
+func normaliseLogLevel(severity string) string {
+	switch strings.ToLower(severity) {
+	case "":
+		return ""
+	case "trace", "trc":
+		return "trace"
+	case "debug", "dbg":
+		return "debug"
+	case "info", "inf", "information":
+		return "info"
+	case "warn", "wrn", "warning":
+		return "warn"
+	case "error", "err":
+		return "error"
+	case "critical":
+		return "critical"
+	case "fatal":
+		return "fatal"
+	default:
+		return strings.ToLower(severity)
+	}
 }
 
 // applyExpr walks the parsed LogQL expression and returns the records

--- a/test/spec/logql/avg_count_over_time.txtar
+++ b/test/spec/logql/avg_count_over_time.txtar
@@ -4,6 +4,7 @@ avg(count_over_time({job="api"}[5m]))
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),
     Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
@@ -17,18 +18,41 @@ INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
   ["", {}, "2026-01-01T00:00:01Z", 2.5]
 ]
 -- sql --
-SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Value` FROM (SELECT avg(`Value`) AS `Value`, count() AS `_cerb_n` FROM (SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1)) WHERE `_cerb_n` > 0)
+SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Value` FROM (SELECT avg(`Value`) AS `Value`, count() AS `_cerb_n` FROM (SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1)) WHERE `_cerb_n` > 0)
 -- args --
 [0] string = ""
 [1] string = "Map(String,String)"
 [2] int64 = 9
-[3] int64 = 1
-[4] string = "job"
-[5] string = "api"
+[3] string = ""
+[4] string = "detected_level"
+[5] string = "trace"
+[6] string = "trc"
+[7] string = "trace"
+[8] string = "debug"
+[9] string = "dbg"
+[10] string = "debug"
+[11] string = "info"
+[12] string = "inf"
+[13] string = "information"
+[14] string = "info"
+[15] string = "warn"
+[16] string = "wrn"
+[17] string = "warning"
+[18] string = "warn"
+[19] string = "error"
+[20] string = "err"
+[21] string = "error"
+[22] string = "critical"
+[23] string = "critical"
+[24] string = "fatal"
+[25] string = "fatal"
+[26] int64 = 1
+[27] string = "job"
+[28] string = "api"
 -- chplan --
 Project ["" AS MetricName, CAST(map(), "Map(String,String)") AS Attributes, now64(9) AS TimeUnix, Value AS Value]
   Aggregate groupBy=[] funcs=[avg(Value) AS Value]
     RangeWindow func=count_over_time range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-      Project [ResourceAttributes, Timestamp, 1 AS Value]
+      Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, 1 AS Value]
         Filter predicate=(ResourceAttributes["job"] = "api")
           Scan(otel_logs)

--- a/test/spec/logql/binop_literal_vector.txtar
+++ b/test/spec/logql/binop_literal_vector.txtar
@@ -4,6 +4,7 @@ vector(5) * on() count_over_time({service_name="api"}[5m])
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),
     Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
@@ -24,9 +25,32 @@ INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
 [6] string = "many-to-many matching not allowed: matching labels must be unique on one side"
 [7] string = ""
 [8] int64 = 9
-[9] int64 = 1
-[10] string = "service_name"
-[11] string = "api"
+[9] string = ""
+[10] string = "detected_level"
+[11] string = "trace"
+[12] string = "trc"
+[13] string = "trace"
+[14] string = "debug"
+[15] string = "dbg"
+[16] string = "debug"
+[17] string = "info"
+[18] string = "inf"
+[19] string = "information"
+[20] string = "info"
+[21] string = "warn"
+[22] string = "wrn"
+[23] string = "warning"
+[24] string = "warn"
+[25] string = "error"
+[26] string = "err"
+[27] string = "error"
+[28] string = "critical"
+[29] string = "critical"
+[30] string = "fatal"
+[31] string = "fatal"
+[32] int64 = 1
+[33] string = "service_name"
+[34] string = "api"
 -- chplan --
 VectorJoin op=* match=on() card=one-to-one
   Project ["" AS MetricName, ResourceAttributes AS Attributes, now64(9) AS TimeUnix, Value AS Value]
@@ -34,8 +58,8 @@ VectorJoin op=* match=on() card=one-to-one
       OneRow
   Project ["" AS MetricName, ResourceAttributes AS Attributes, now64(9) AS TimeUnix, Value AS Value]
     RangeWindow func=count_over_time range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-      Project [ResourceAttributes, Timestamp, 1 AS Value]
+      Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, 1 AS Value]
         Filter predicate=(ResourceAttributes["service_name"] = "api")
           Scan(otel_logs)
 -- sql --
-SELECT ? AS `MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` * R.`Value`) AS `Value` FROM (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT ? AS `MetricName`, `ResourceAttributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT CAST(map(), ?) AS `ResourceAttributes`, ? AS `Value` FROM (SELECT 1))) GROUP BY tuple())) AS L INNER JOIN (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT ? AS `MetricName`, `ResourceAttributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1)) GROUP BY tuple())) AS R ON 1 = 1
+SELECT ? AS `MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` * R.`Value`) AS `Value` FROM (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT ? AS `MetricName`, `ResourceAttributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT CAST(map(), ?) AS `ResourceAttributes`, ? AS `Value` FROM (SELECT 1))) GROUP BY tuple())) AS L INNER JOIN (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT ? AS `MetricName`, `ResourceAttributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1)) GROUP BY tuple())) AS R ON 1 = 1

--- a/test/spec/logql/binop_scalar_vector.txtar
+++ b/test/spec/logql/binop_scalar_vector.txtar
@@ -2,13 +2,37 @@
 2 * count_over_time({service_name="api"}[5m])
 -- args --
 [0] float64 = 2
-[1] int64 = 1
-[2] string = "service_name"
-[3] string = "api"
+[1] string = ""
+[2] string = "detected_level"
+[3] string = "trace"
+[4] string = "trc"
+[5] string = "trace"
+[6] string = "debug"
+[7] string = "dbg"
+[8] string = "debug"
+[9] string = "info"
+[10] string = "inf"
+[11] string = "information"
+[12] string = "info"
+[13] string = "warn"
+[14] string = "wrn"
+[15] string = "warning"
+[16] string = "warn"
+[17] string = "error"
+[18] string = "err"
+[19] string = "error"
+[20] string = "critical"
+[21] string = "critical"
+[22] string = "fatal"
+[23] string = "fatal"
+[24] int64 = 1
+[25] string = "service_name"
+[26] string = "api"
 -- seed --
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),
     Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
@@ -22,8 +46,8 @@ INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
 -- chplan --
 Project [ResourceAttributes, (2 * Value) AS Value]
   RangeWindow func=count_over_time range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-    Project [ResourceAttributes, Timestamp, 1 AS Value]
+    Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, 1 AS Value]
       Filter predicate=(ResourceAttributes["service_name"] = "api")
         Scan(otel_logs)
 -- sql --
-SELECT `ResourceAttributes`, (? * `Value`) AS `Value` FROM (SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1)
+SELECT `ResourceAttributes`, (? * `Value`) AS `Value` FROM (SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1)

--- a/test/spec/logql/binop_vector_vector_bool.txtar
+++ b/test/spec/logql/binop_vector_vector_bool.txtar
@@ -3,13 +3,37 @@ rate({service_name="api"}[5m]) > bool 0
 -- args --
 [0] float64 = 0
 [1] float64 = 300
-[2] int64 = 1
-[3] string = "service_name"
-[4] string = "api"
+[2] string = ""
+[3] string = "detected_level"
+[4] string = "trace"
+[5] string = "trc"
+[6] string = "trace"
+[7] string = "debug"
+[8] string = "dbg"
+[9] string = "debug"
+[10] string = "info"
+[11] string = "inf"
+[12] string = "information"
+[13] string = "info"
+[14] string = "warn"
+[15] string = "wrn"
+[16] string = "warning"
+[17] string = "warn"
+[18] string = "error"
+[19] string = "err"
+[20] string = "error"
+[21] string = "critical"
+[22] string = "critical"
+[23] string = "fatal"
+[24] string = "fatal"
+[25] int64 = 1
+[26] string = "service_name"
+[27] string = "api"
 -- seed --
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),
     Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
@@ -23,8 +47,8 @@ INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
 -- chplan --
 Project [ResourceAttributes, toFloat64((Value > 0)) AS Value]
   RangeWindow func=log_rate range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-    Project [ResourceAttributes, Timestamp, 1 AS Value]
+    Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, 1 AS Value]
       Filter predicate=(ResourceAttributes["service_name"] = "api")
         Scan(otel_logs)
 -- sql --
-SELECT `ResourceAttributes`, toFloat64((`Value` > ?)) AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))))
+SELECT `ResourceAttributes`, toFloat64((`Value` > ?)) AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))))

--- a/test/spec/logql/binop_vv_add_on.txtar
+++ b/test/spec/logql/binop_vv_add_on.txtar
@@ -4,6 +4,7 @@ rate({service_name="api"}[5m]) + on(service_name) rate({service_name="api"}[5m])
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),
     Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
@@ -20,31 +21,77 @@ INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
 [2] string = ""
 [3] int64 = 9
 [4] float64 = 300
-[5] int64 = 1
-[6] string = "service_name"
-[7] string = "api"
-[8] string = "service_name"
-[9] string = "many-to-many matching not allowed: matching labels must be unique on one side"
-[10] string = ""
-[11] int64 = 9
-[12] float64 = 300
-[13] int64 = 1
-[14] string = "service_name"
-[15] string = "api"
-[16] string = "service_name"
-[17] string = "service_name"
-[18] string = "service_name"
+[5] string = ""
+[6] string = "detected_level"
+[7] string = "trace"
+[8] string = "trc"
+[9] string = "trace"
+[10] string = "debug"
+[11] string = "dbg"
+[12] string = "debug"
+[13] string = "info"
+[14] string = "inf"
+[15] string = "information"
+[16] string = "info"
+[17] string = "warn"
+[18] string = "wrn"
+[19] string = "warning"
+[20] string = "warn"
+[21] string = "error"
+[22] string = "err"
+[23] string = "error"
+[24] string = "critical"
+[25] string = "critical"
+[26] string = "fatal"
+[27] string = "fatal"
+[28] int64 = 1
+[29] string = "service_name"
+[30] string = "api"
+[31] string = "service_name"
+[32] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[33] string = ""
+[34] int64 = 9
+[35] float64 = 300
+[36] string = ""
+[37] string = "detected_level"
+[38] string = "trace"
+[39] string = "trc"
+[40] string = "trace"
+[41] string = "debug"
+[42] string = "dbg"
+[43] string = "debug"
+[44] string = "info"
+[45] string = "inf"
+[46] string = "information"
+[47] string = "info"
+[48] string = "warn"
+[49] string = "wrn"
+[50] string = "warning"
+[51] string = "warn"
+[52] string = "error"
+[53] string = "err"
+[54] string = "error"
+[55] string = "critical"
+[56] string = "critical"
+[57] string = "fatal"
+[58] string = "fatal"
+[59] int64 = 1
+[60] string = "service_name"
+[61] string = "api"
+[62] string = "service_name"
+[63] string = "service_name"
+[64] string = "service_name"
 -- chplan --
 VectorJoin op=+ match=on(service_name) card=one-to-one
   Project ["" AS MetricName, ResourceAttributes AS Attributes, now64(9) AS TimeUnix, Value AS Value]
     RangeWindow func=log_rate range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-      Project [ResourceAttributes, Timestamp, 1 AS Value]
+      Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, 1 AS Value]
         Filter predicate=(ResourceAttributes["service_name"] = "api")
           Scan(otel_logs)
   Project ["" AS MetricName, ResourceAttributes AS Attributes, now64(9) AS TimeUnix, Value AS Value]
     RangeWindow func=log_rate range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-      Project [ResourceAttributes, Timestamp, 1 AS Value]
+      Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, 1 AS Value]
         Filter predicate=(ResourceAttributes["service_name"] = "api")
           Scan(otel_logs)
 -- sql --
-SELECT ? AS `MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` + R.`Value`) AS `Value` FROM (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT ? AS `MetricName`, `ResourceAttributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))))) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`))) AS L INNER JOIN (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT ? AS `MetricName`, `ResourceAttributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))))) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`))) AS R ON L.`Attributes`[?] = R.`Attributes`[?]
+SELECT ? AS `MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` + R.`Value`) AS `Value` FROM (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT ? AS `MetricName`, `ResourceAttributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))))) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`))) AS L INNER JOIN (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT ? AS `MetricName`, `ResourceAttributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))))) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`))) AS R ON L.`Attributes`[?] = R.`Attributes`[?]

--- a/test/spec/logql/binop_vv_compare_filter.txtar
+++ b/test/spec/logql/binop_vv_compare_filter.txtar
@@ -4,6 +4,7 @@ rate({service_name="api"}[5m]) > rate({service_name="api"}[5m])
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),
     Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
@@ -17,26 +18,72 @@ INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
 [1] string = ""
 [2] int64 = 9
 [3] float64 = 300
-[4] int64 = 1
-[5] string = "service_name"
-[6] string = "api"
-[7] string = ""
-[8] int64 = 9
-[9] float64 = 300
-[10] int64 = 1
-[11] string = "service_name"
-[12] string = "api"
+[4] string = ""
+[5] string = "detected_level"
+[6] string = "trace"
+[7] string = "trc"
+[8] string = "trace"
+[9] string = "debug"
+[10] string = "dbg"
+[11] string = "debug"
+[12] string = "info"
+[13] string = "inf"
+[14] string = "information"
+[15] string = "info"
+[16] string = "warn"
+[17] string = "wrn"
+[18] string = "warning"
+[19] string = "warn"
+[20] string = "error"
+[21] string = "err"
+[22] string = "error"
+[23] string = "critical"
+[24] string = "critical"
+[25] string = "fatal"
+[26] string = "fatal"
+[27] int64 = 1
+[28] string = "service_name"
+[29] string = "api"
+[30] string = ""
+[31] int64 = 9
+[32] float64 = 300
+[33] string = ""
+[34] string = "detected_level"
+[35] string = "trace"
+[36] string = "trc"
+[37] string = "trace"
+[38] string = "debug"
+[39] string = "dbg"
+[40] string = "debug"
+[41] string = "info"
+[42] string = "inf"
+[43] string = "information"
+[44] string = "info"
+[45] string = "warn"
+[46] string = "wrn"
+[47] string = "warning"
+[48] string = "warn"
+[49] string = "error"
+[50] string = "err"
+[51] string = "error"
+[52] string = "critical"
+[53] string = "critical"
+[54] string = "fatal"
+[55] string = "fatal"
+[56] int64 = 1
+[57] string = "service_name"
+[58] string = "api"
 -- chplan --
 VectorJoin op=> match=default card=one-to-one
   Project ["" AS MetricName, ResourceAttributes AS Attributes, now64(9) AS TimeUnix, Value AS Value]
     RangeWindow func=log_rate range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-      Project [ResourceAttributes, Timestamp, 1 AS Value]
+      Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, 1 AS Value]
         Filter predicate=(ResourceAttributes["service_name"] = "api")
           Scan(otel_logs)
   Project ["" AS MetricName, ResourceAttributes AS Attributes, now64(9) AS TimeUnix, Value AS Value]
     RangeWindow func=log_rate range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-      Project [ResourceAttributes, Timestamp, 1 AS Value]
+      Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, 1 AS Value]
         Filter predicate=(ResourceAttributes["service_name"] = "api")
           Scan(otel_logs)
 -- sql --
-SELECT ? AS `MetricName`, L.`Attributes`, L.`TimeUnix`, L.`Value` AS `Value` FROM (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT `MetricName` AS `_join_MetricName`, `Attributes` AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value` FROM (SELECT ? AS `MetricName`, `ResourceAttributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))))) GROUP BY `MetricName`, `Attributes`)) AS L INNER JOIN (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT `MetricName` AS `_join_MetricName`, `Attributes` AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value` FROM (SELECT ? AS `MetricName`, `ResourceAttributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))))) GROUP BY `MetricName`, `Attributes`)) AS R ON L.`Attributes` = R.`Attributes` WHERE (L.`Value` > R.`Value`)
+SELECT ? AS `MetricName`, L.`Attributes`, L.`TimeUnix`, L.`Value` AS `Value` FROM (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT `MetricName` AS `_join_MetricName`, `Attributes` AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value` FROM (SELECT ? AS `MetricName`, `ResourceAttributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))))) GROUP BY `MetricName`, `Attributes`)) AS L INNER JOIN (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT `MetricName` AS `_join_MetricName`, `Attributes` AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value` FROM (SELECT ? AS `MetricName`, `ResourceAttributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))))) GROUP BY `MetricName`, `Attributes`)) AS R ON L.`Attributes` = R.`Attributes` WHERE (L.`Value` > R.`Value`)

--- a/test/spec/logql/binop_vv_div_ignoring.txtar
+++ b/test/spec/logql/binop_vv_div_ignoring.txtar
@@ -4,6 +4,7 @@ rate({service_name="api"}[5m]) / ignoring(level) rate({service_name="api", level
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),
     Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
@@ -20,33 +21,79 @@ INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
 [2] string = ""
 [3] int64 = 9
 [4] float64 = 300
-[5] int64 = 1
-[6] string = "service_name"
-[7] string = "api"
-[8] string = "level"
-[9] string = "many-to-many matching not allowed: matching labels must be unique on one side"
-[10] string = ""
-[11] int64 = 9
-[12] float64 = 300
-[13] int64 = 1
-[14] string = "service_name"
-[15] string = "api"
-[16] string = "level"
-[17] string = "info"
-[18] string = "level"
-[19] string = "level"
-[20] string = "level"
+[5] string = ""
+[6] string = "detected_level"
+[7] string = "trace"
+[8] string = "trc"
+[9] string = "trace"
+[10] string = "debug"
+[11] string = "dbg"
+[12] string = "debug"
+[13] string = "info"
+[14] string = "inf"
+[15] string = "information"
+[16] string = "info"
+[17] string = "warn"
+[18] string = "wrn"
+[19] string = "warning"
+[20] string = "warn"
+[21] string = "error"
+[22] string = "err"
+[23] string = "error"
+[24] string = "critical"
+[25] string = "critical"
+[26] string = "fatal"
+[27] string = "fatal"
+[28] int64 = 1
+[29] string = "service_name"
+[30] string = "api"
+[31] string = "level"
+[32] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[33] string = ""
+[34] int64 = 9
+[35] float64 = 300
+[36] string = ""
+[37] string = "detected_level"
+[38] string = "trace"
+[39] string = "trc"
+[40] string = "trace"
+[41] string = "debug"
+[42] string = "dbg"
+[43] string = "debug"
+[44] string = "info"
+[45] string = "inf"
+[46] string = "information"
+[47] string = "info"
+[48] string = "warn"
+[49] string = "wrn"
+[50] string = "warning"
+[51] string = "warn"
+[52] string = "error"
+[53] string = "err"
+[54] string = "error"
+[55] string = "critical"
+[56] string = "critical"
+[57] string = "fatal"
+[58] string = "fatal"
+[59] int64 = 1
+[60] string = "service_name"
+[61] string = "api"
+[62] string = "level"
+[63] string = "info"
+[64] string = "level"
+[65] string = "level"
+[66] string = "level"
 -- chplan --
 VectorJoin op=/ match=ignoring(level) card=one-to-one
   Project ["" AS MetricName, ResourceAttributes AS Attributes, now64(9) AS TimeUnix, Value AS Value]
     RangeWindow func=log_rate range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-      Project [ResourceAttributes, Timestamp, 1 AS Value]
+      Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, 1 AS Value]
         Filter predicate=(ResourceAttributes["service_name"] = "api")
           Scan(otel_logs)
   Project ["" AS MetricName, ResourceAttributes AS Attributes, now64(9) AS TimeUnix, Value AS Value]
     RangeWindow func=log_rate range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-      Project [ResourceAttributes, Timestamp, 1 AS Value]
+      Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, 1 AS Value]
         Filter predicate=((ResourceAttributes["service_name"] = "api") AND (ResourceAttributes["level"] = "info"))
           Scan(otel_logs)
 -- sql --
-SELECT ? AS `MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` / R.`Value`) AS `Value` FROM (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT ? AS `MetricName`, `ResourceAttributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))))) GROUP BY mapFilter((k, v) -> NOT (k IN (?)), `Attributes`))) AS L INNER JOIN (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT ? AS `MetricName`, `ResourceAttributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))))) GROUP BY mapFilter((k, v) -> NOT (k IN (?)), `Attributes`))) AS R ON mapFilter((k, v) -> NOT (k IN (?)), L.`Attributes`) = mapFilter((k, v) -> NOT (k IN (?)), R.`Attributes`)
+SELECT ? AS `MetricName`, L.`Attributes`, L.`TimeUnix`, (L.`Value` / R.`Value`) AS `Value` FROM (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT ? AS `MetricName`, `ResourceAttributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))))) GROUP BY mapFilter((k, v) -> NOT (k IN (?)), `Attributes`))) AS L INNER JOIN (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT ? AS `MetricName`, `ResourceAttributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))))) GROUP BY mapFilter((k, v) -> NOT (k IN (?)), `Attributes`))) AS R ON mapFilter((k, v) -> NOT (k IN (?)), L.`Attributes`) = mapFilter((k, v) -> NOT (k IN (?)), R.`Attributes`)

--- a/test/spec/logql/binop_vv_eq_bool.txtar
+++ b/test/spec/logql/binop_vv_eq_bool.txtar
@@ -4,6 +4,7 @@ rate({service_name="api"}[5m]) == bool rate({service_name="api"}[5m])
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),
     Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
@@ -19,26 +20,72 @@ INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
 [1] string = ""
 [2] int64 = 9
 [3] float64 = 300
-[4] int64 = 1
-[5] string = "service_name"
-[6] string = "api"
-[7] string = ""
-[8] int64 = 9
-[9] float64 = 300
-[10] int64 = 1
-[11] string = "service_name"
-[12] string = "api"
+[4] string = ""
+[5] string = "detected_level"
+[6] string = "trace"
+[7] string = "trc"
+[8] string = "trace"
+[9] string = "debug"
+[10] string = "dbg"
+[11] string = "debug"
+[12] string = "info"
+[13] string = "inf"
+[14] string = "information"
+[15] string = "info"
+[16] string = "warn"
+[17] string = "wrn"
+[18] string = "warning"
+[19] string = "warn"
+[20] string = "error"
+[21] string = "err"
+[22] string = "error"
+[23] string = "critical"
+[24] string = "critical"
+[25] string = "fatal"
+[26] string = "fatal"
+[27] int64 = 1
+[28] string = "service_name"
+[29] string = "api"
+[30] string = ""
+[31] int64 = 9
+[32] float64 = 300
+[33] string = ""
+[34] string = "detected_level"
+[35] string = "trace"
+[36] string = "trc"
+[37] string = "trace"
+[38] string = "debug"
+[39] string = "dbg"
+[40] string = "debug"
+[41] string = "info"
+[42] string = "inf"
+[43] string = "information"
+[44] string = "info"
+[45] string = "warn"
+[46] string = "wrn"
+[47] string = "warning"
+[48] string = "warn"
+[49] string = "error"
+[50] string = "err"
+[51] string = "error"
+[52] string = "critical"
+[53] string = "critical"
+[54] string = "fatal"
+[55] string = "fatal"
+[56] int64 = 1
+[57] string = "service_name"
+[58] string = "api"
 -- chplan --
 VectorJoin op== match=default card=one-to-one bool
   Project ["" AS MetricName, ResourceAttributes AS Attributes, now64(9) AS TimeUnix, Value AS Value]
     RangeWindow func=log_rate range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-      Project [ResourceAttributes, Timestamp, 1 AS Value]
+      Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, 1 AS Value]
         Filter predicate=(ResourceAttributes["service_name"] = "api")
           Scan(otel_logs)
   Project ["" AS MetricName, ResourceAttributes AS Attributes, now64(9) AS TimeUnix, Value AS Value]
     RangeWindow func=log_rate range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-      Project [ResourceAttributes, Timestamp, 1 AS Value]
+      Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, 1 AS Value]
         Filter predicate=(ResourceAttributes["service_name"] = "api")
           Scan(otel_logs)
 -- sql --
-SELECT ? AS `MetricName`, L.`Attributes`, L.`TimeUnix`, toFloat64((L.`Value` = R.`Value`)) AS `Value` FROM (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT `MetricName` AS `_join_MetricName`, `Attributes` AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value` FROM (SELECT ? AS `MetricName`, `ResourceAttributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))))) GROUP BY `MetricName`, `Attributes`)) AS L INNER JOIN (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT `MetricName` AS `_join_MetricName`, `Attributes` AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value` FROM (SELECT ? AS `MetricName`, `ResourceAttributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))))) GROUP BY `MetricName`, `Attributes`)) AS R ON L.`Attributes` = R.`Attributes`
+SELECT ? AS `MetricName`, L.`Attributes`, L.`TimeUnix`, toFloat64((L.`Value` = R.`Value`)) AS `Value` FROM (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT `MetricName` AS `_join_MetricName`, `Attributes` AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value` FROM (SELECT ? AS `MetricName`, `ResourceAttributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))))) GROUP BY `MetricName`, `Attributes`)) AS L INNER JOIN (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT `MetricName` AS `_join_MetricName`, `Attributes` AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value` FROM (SELECT ? AS `MetricName`, `ResourceAttributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))))) GROUP BY `MetricName`, `Attributes`)) AS R ON L.`Attributes` = R.`Attributes`

--- a/test/spec/logql/binop_vv_group_left.txtar
+++ b/test/spec/logql/binop_vv_group_left.txtar
@@ -4,6 +4,7 @@ count_over_time({service_name="api"}[5m]) / on(service_name) group_left(env) cou
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),
     Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
@@ -22,31 +23,77 @@ INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
 [1] string = "env"
 [2] string = ""
 [3] int64 = 9
-[4] int64 = 1
-[5] string = "service_name"
-[6] string = "api"
-[7] string = "many-to-many matching not allowed: matching labels must be unique on one side"
-[8] string = ""
-[9] int64 = 9
-[10] int64 = 1
-[11] string = "service_name"
-[12] string = "api"
-[13] string = "level"
-[14] string = "meta"
-[15] string = "service_name"
-[16] string = "service_name"
-[17] string = "service_name"
+[4] string = ""
+[5] string = "detected_level"
+[6] string = "trace"
+[7] string = "trc"
+[8] string = "trace"
+[9] string = "debug"
+[10] string = "dbg"
+[11] string = "debug"
+[12] string = "info"
+[13] string = "inf"
+[14] string = "information"
+[15] string = "info"
+[16] string = "warn"
+[17] string = "wrn"
+[18] string = "warning"
+[19] string = "warn"
+[20] string = "error"
+[21] string = "err"
+[22] string = "error"
+[23] string = "critical"
+[24] string = "critical"
+[25] string = "fatal"
+[26] string = "fatal"
+[27] int64 = 1
+[28] string = "service_name"
+[29] string = "api"
+[30] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[31] string = ""
+[32] int64 = 9
+[33] string = ""
+[34] string = "detected_level"
+[35] string = "trace"
+[36] string = "trc"
+[37] string = "trace"
+[38] string = "debug"
+[39] string = "dbg"
+[40] string = "debug"
+[41] string = "info"
+[42] string = "inf"
+[43] string = "information"
+[44] string = "info"
+[45] string = "warn"
+[46] string = "wrn"
+[47] string = "warning"
+[48] string = "warn"
+[49] string = "error"
+[50] string = "err"
+[51] string = "error"
+[52] string = "critical"
+[53] string = "critical"
+[54] string = "fatal"
+[55] string = "fatal"
+[56] int64 = 1
+[57] string = "service_name"
+[58] string = "api"
+[59] string = "level"
+[60] string = "meta"
+[61] string = "service_name"
+[62] string = "service_name"
+[63] string = "service_name"
 -- chplan --
 VectorJoin op=/ match=on(service_name) card=many-to-one include=[env]
   Project ["" AS MetricName, ResourceAttributes AS Attributes, now64(9) AS TimeUnix, Value AS Value]
     RangeWindow func=count_over_time range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-      Project [ResourceAttributes, Timestamp, 1 AS Value]
+      Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, 1 AS Value]
         Filter predicate=(ResourceAttributes["service_name"] = "api")
           Scan(otel_logs)
   Project ["" AS MetricName, ResourceAttributes AS Attributes, now64(9) AS TimeUnix, Value AS Value]
     RangeWindow func=count_over_time range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-      Project [ResourceAttributes, Timestamp, 1 AS Value]
+      Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, 1 AS Value]
         Filter predicate=((ResourceAttributes["service_name"] = "api") AND (ResourceAttributes["level"] = "meta"))
           Scan(otel_logs)
 -- sql --
-SELECT ? AS `MetricName`, mapConcat(L.`Attributes`, mapFilter((k, v) -> k IN (?), R.`Attributes`)) AS `Attributes`, L.`TimeUnix`, (L.`Value` / R.`Value`) AS `Value` FROM (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT `MetricName` AS `_join_MetricName`, `Attributes` AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value` FROM (SELECT ? AS `MetricName`, `ResourceAttributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1)) GROUP BY `MetricName`, `Attributes`)) AS L INNER JOIN (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT ? AS `MetricName`, `ResourceAttributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1)) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`))) AS R ON L.`Attributes`[?] = R.`Attributes`[?]
+SELECT ? AS `MetricName`, mapConcat(L.`Attributes`, mapFilter((k, v) -> k IN (?), R.`Attributes`)) AS `Attributes`, L.`TimeUnix`, (L.`Value` / R.`Value`) AS `Value` FROM (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT `MetricName` AS `_join_MetricName`, `Attributes` AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value` FROM (SELECT ? AS `MetricName`, `ResourceAttributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1)) GROUP BY `MetricName`, `Attributes`)) AS L INNER JOIN (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT ? AS `MetricName`, `ResourceAttributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1)) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`))) AS R ON L.`Attributes`[?] = R.`Attributes`[?]

--- a/test/spec/logql/binop_vv_group_left_with_agg_legs.txtar
+++ b/test/spec/logql/binop_vv_group_left_with_agg_legs.txtar
@@ -4,6 +4,7 @@ sum by (svc) (count_over_time({app="x"}[5m])) / on(svc) group_left(env) sum by (
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),
     Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
@@ -26,39 +27,85 @@ INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
 [5] string = "svc"
 [6] int64 = 9
 [7] string = "svc"
-[8] int64 = 1
-[9] string = "app"
-[10] string = "x"
-[11] string = "svc"
-[12] string = "many-to-many matching not allowed: matching labels must be unique on one side"
-[13] string = ""
-[14] int64 = 9
-[15] string = ""
-[16] string = "svc"
-[17] int64 = 9
-[18] string = "svc"
-[19] int64 = 1
-[20] string = "app"
-[21] string = "y"
-[22] string = "svc"
-[23] string = "svc"
-[24] string = "svc"
-[25] string = "svc"
+[8] string = ""
+[9] string = "detected_level"
+[10] string = "trace"
+[11] string = "trc"
+[12] string = "trace"
+[13] string = "debug"
+[14] string = "dbg"
+[15] string = "debug"
+[16] string = "info"
+[17] string = "inf"
+[18] string = "information"
+[19] string = "info"
+[20] string = "warn"
+[21] string = "wrn"
+[22] string = "warning"
+[23] string = "warn"
+[24] string = "error"
+[25] string = "err"
+[26] string = "error"
+[27] string = "critical"
+[28] string = "critical"
+[29] string = "fatal"
+[30] string = "fatal"
+[31] int64 = 1
+[32] string = "app"
+[33] string = "x"
+[34] string = "svc"
+[35] string = "many-to-many matching not allowed: matching labels must be unique on one side"
+[36] string = ""
+[37] int64 = 9
+[38] string = ""
+[39] string = "svc"
+[40] int64 = 9
+[41] string = "svc"
+[42] string = ""
+[43] string = "detected_level"
+[44] string = "trace"
+[45] string = "trc"
+[46] string = "trace"
+[47] string = "debug"
+[48] string = "dbg"
+[49] string = "debug"
+[50] string = "info"
+[51] string = "inf"
+[52] string = "information"
+[53] string = "info"
+[54] string = "warn"
+[55] string = "wrn"
+[56] string = "warning"
+[57] string = "warn"
+[58] string = "error"
+[59] string = "err"
+[60] string = "error"
+[61] string = "critical"
+[62] string = "critical"
+[63] string = "fatal"
+[64] string = "fatal"
+[65] int64 = 1
+[66] string = "app"
+[67] string = "y"
+[68] string = "svc"
+[69] string = "svc"
+[70] string = "svc"
+[71] string = "svc"
 -- chplan --
 VectorJoin op=/ match=on(svc) card=many-to-one include=[env]
   Project ["" AS MetricName, Attributes AS Attributes, now64(9) AS TimeUnix, Value AS Value]
     Project ["" AS MetricName, map("svc", gkey_0) AS Attributes, now64(9) AS TimeUnix, Value AS Value]
       Aggregate groupBy=[ResourceAttributes["svc"] AS gkey_0] funcs=[sum(Value) AS Value]
         RangeWindow func=count_over_time range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-          Project [ResourceAttributes, Timestamp, 1 AS Value]
+          Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, 1 AS Value]
             Filter predicate=(ResourceAttributes["app"] = "x")
               Scan(otel_logs)
   Project ["" AS MetricName, Attributes AS Attributes, now64(9) AS TimeUnix, Value AS Value]
     Project ["" AS MetricName, map("svc", gkey_0) AS Attributes, now64(9) AS TimeUnix, Value AS Value]
       Aggregate groupBy=[ResourceAttributes["svc"] AS gkey_0] funcs=[sum(Value) AS Value]
         RangeWindow func=count_over_time range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-          Project [ResourceAttributes, Timestamp, 1 AS Value]
+          Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, 1 AS Value]
             Filter predicate=(ResourceAttributes["app"] = "y")
               Scan(otel_logs)
 -- sql --
-SELECT ? AS `MetricName`, mapConcat(L.`Attributes`, mapFilter((k, v) -> k IN (?), R.`Attributes`)) AS `Attributes`, L.`TimeUnix`, (L.`Value` / R.`Value`) AS `Value` FROM (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT `MetricName` AS `_join_MetricName`, `Attributes` AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value` FROM (SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT ? AS `MetricName`, map(?, `gkey_0`) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`[?] AS `gkey_0`, sum(`Value`) AS `Value` FROM (SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1) GROUP BY `ResourceAttributes`[?]))) GROUP BY `MetricName`, `Attributes`)) AS L INNER JOIN (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT ? AS `MetricName`, map(?, `gkey_0`) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`[?] AS `gkey_0`, sum(`Value`) AS `Value` FROM (SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1) GROUP BY `ResourceAttributes`[?]))) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`))) AS R ON L.`Attributes`[?] = R.`Attributes`[?]
+SELECT ? AS `MetricName`, mapConcat(L.`Attributes`, mapFilter((k, v) -> k IN (?), R.`Attributes`)) AS `Attributes`, L.`TimeUnix`, (L.`Value` / R.`Value`) AS `Value` FROM (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT `MetricName` AS `_join_MetricName`, `Attributes` AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value` FROM (SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT ? AS `MetricName`, map(?, `gkey_0`) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`[?] AS `gkey_0`, sum(`Value`) AS `Value` FROM (SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1) GROUP BY `ResourceAttributes`[?]))) GROUP BY `MetricName`, `Attributes`)) AS L INNER JOIN (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT argMax(`MetricName`, `TimeUnix`) AS `_join_MetricName`, argMax(`Attributes`, `TimeUnix`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value`, throwIf(uniqExact(`Attributes`) > 1, ?) AS _cerberus_match_check FROM (SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT ? AS `MetricName`, map(?, `gkey_0`) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`[?] AS `gkey_0`, sum(`Value`) AS `Value` FROM (SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1) GROUP BY `ResourceAttributes`[?]))) GROUP BY mapFilter((k, v) -> k IN (?), `Attributes`))) AS R ON L.`Attributes`[?] = R.`Attributes`[?]

--- a/test/spec/logql/bytes_over_time.txtar
+++ b/test/spec/logql/bytes_over_time.txtar
@@ -1,14 +1,38 @@
 -- query.logql --
 bytes_over_time({job="api"}[5m])
 -- sql --
-SELECT `ResourceAttributes`, arraySum(window_vals) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, toFloat64(length(`Body`)) AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1
+SELECT `ResourceAttributes`, arraySum(window_vals) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, toFloat64(length(`Body`)) AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1
 -- args --
-[0] string = "job"
-[1] string = "api"
+[0] string = ""
+[1] string = "detected_level"
+[2] string = "trace"
+[3] string = "trc"
+[4] string = "trace"
+[5] string = "debug"
+[6] string = "dbg"
+[7] string = "debug"
+[8] string = "info"
+[9] string = "inf"
+[10] string = "information"
+[11] string = "info"
+[12] string = "warn"
+[13] string = "wrn"
+[14] string = "warning"
+[15] string = "warn"
+[16] string = "error"
+[17] string = "err"
+[18] string = "error"
+[19] string = "critical"
+[20] string = "critical"
+[21] string = "fatal"
+[22] string = "fatal"
+[23] string = "job"
+[24] string = "api"
 -- seed --
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),
     Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
@@ -21,6 +45,6 @@ INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
 ]
 -- chplan --
 RangeWindow func=sum_over_time range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-  Project [ResourceAttributes, Timestamp, toFloat64(length(Body)) AS Value]
+  Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, toFloat64(length(Body)) AS Value]
     Filter predicate=(ResourceAttributes["job"] = "api")
       Scan(otel_logs)

--- a/test/spec/logql/bytes_over_time_query.txtar
+++ b/test/spec/logql/bytes_over_time_query.txtar
@@ -1,14 +1,38 @@
 -- query.logql --
 bytes_over_time({job="api"}[1h])
 -- sql --
-SELECT `ResourceAttributes`, arraySum(window_vals) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(3600000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, toFloat64(length(`Body`)) AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1
+SELECT `ResourceAttributes`, arraySum(window_vals) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(3600000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, toFloat64(length(`Body`)) AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1
 -- args --
-[0] string = "job"
-[1] string = "api"
+[0] string = ""
+[1] string = "detected_level"
+[2] string = "trace"
+[3] string = "trc"
+[4] string = "trace"
+[5] string = "debug"
+[6] string = "dbg"
+[7] string = "debug"
+[8] string = "info"
+[9] string = "inf"
+[10] string = "information"
+[11] string = "info"
+[12] string = "warn"
+[13] string = "wrn"
+[14] string = "warning"
+[15] string = "warn"
+[16] string = "error"
+[17] string = "err"
+[18] string = "error"
+[19] string = "critical"
+[20] string = "critical"
+[21] string = "fatal"
+[22] string = "fatal"
+[23] string = "job"
+[24] string = "api"
 -- seed --
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),
     Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
@@ -20,6 +44,6 @@ INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
 ]
 -- chplan --
 RangeWindow func=sum_over_time range=1h0m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-  Project [ResourceAttributes, Timestamp, toFloat64(length(Body)) AS Value]
+  Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, toFloat64(length(Body)) AS Value]
     Filter predicate=(ResourceAttributes["job"] = "api")
       Scan(otel_logs)

--- a/test/spec/logql/bytes_rate.txtar
+++ b/test/spec/logql/bytes_rate.txtar
@@ -1,15 +1,39 @@
 -- query.logql --
 bytes_rate({job="api"}[1m])
 -- sql --
-SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(60000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, toFloat64(length(`Body`)) AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`)))
+SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(60000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, toFloat64(length(`Body`)) AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`)))
 -- args --
 [0] float64 = 60
-[1] string = "job"
-[2] string = "api"
+[1] string = ""
+[2] string = "detected_level"
+[3] string = "trace"
+[4] string = "trc"
+[5] string = "trace"
+[6] string = "debug"
+[7] string = "dbg"
+[8] string = "debug"
+[9] string = "info"
+[10] string = "inf"
+[11] string = "information"
+[12] string = "info"
+[13] string = "warn"
+[14] string = "wrn"
+[15] string = "warning"
+[16] string = "warn"
+[17] string = "error"
+[18] string = "err"
+[19] string = "error"
+[20] string = "critical"
+[21] string = "critical"
+[22] string = "fatal"
+[23] string = "fatal"
+[24] string = "job"
+[25] string = "api"
 -- seed --
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),
     Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
@@ -22,6 +46,6 @@ INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
 ]
 -- chplan --
 RangeWindow func=log_rate range=1m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-  Project [ResourceAttributes, Timestamp, toFloat64(length(Body)) AS Value]
+  Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, toFloat64(length(Body)) AS Value]
     Filter predicate=(ResourceAttributes["job"] = "api")
       Scan(otel_logs)

--- a/test/spec/logql/bytes_rate_query.txtar
+++ b/test/spec/logql/bytes_rate_query.txtar
@@ -1,15 +1,39 @@
 -- query.logql --
 bytes_rate({job="api"}[5m])
 -- sql --
-SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, toFloat64(length(`Body`)) AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`)))
+SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, toFloat64(length(`Body`)) AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`)))
 -- args --
 [0] float64 = 300
-[1] string = "job"
-[2] string = "api"
+[1] string = ""
+[2] string = "detected_level"
+[3] string = "trace"
+[4] string = "trc"
+[5] string = "trace"
+[6] string = "debug"
+[7] string = "dbg"
+[8] string = "debug"
+[9] string = "info"
+[10] string = "inf"
+[11] string = "information"
+[12] string = "info"
+[13] string = "warn"
+[14] string = "wrn"
+[15] string = "warning"
+[16] string = "warn"
+[17] string = "error"
+[18] string = "err"
+[19] string = "error"
+[20] string = "critical"
+[21] string = "critical"
+[22] string = "fatal"
+[23] string = "fatal"
+[24] string = "job"
+[25] string = "api"
 -- seed --
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),
     Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
@@ -25,6 +49,6 @@ INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
 ]
 -- chplan --
 RangeWindow func=log_rate range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-  Project [ResourceAttributes, Timestamp, toFloat64(length(Body)) AS Value]
+  Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, toFloat64(length(Body)) AS Value]
     Filter predicate=(ResourceAttributes["job"] = "api")
       Scan(otel_logs)

--- a/test/spec/logql/count_over_time.txtar
+++ b/test/spec/logql/count_over_time.txtar
@@ -1,15 +1,39 @@
 -- query.logql --
 count_over_time({job="api"}[5m])
 -- sql --
-SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1
+SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1
 -- args --
-[0] int64 = 1
-[1] string = "job"
-[2] string = "api"
+[0] string = ""
+[1] string = "detected_level"
+[2] string = "trace"
+[3] string = "trc"
+[4] string = "trace"
+[5] string = "debug"
+[6] string = "dbg"
+[7] string = "debug"
+[8] string = "info"
+[9] string = "inf"
+[10] string = "information"
+[11] string = "info"
+[12] string = "warn"
+[13] string = "wrn"
+[14] string = "warning"
+[15] string = "warn"
+[16] string = "error"
+[17] string = "err"
+[18] string = "error"
+[19] string = "critical"
+[20] string = "critical"
+[21] string = "fatal"
+[22] string = "fatal"
+[23] int64 = 1
+[24] string = "job"
+[25] string = "api"
 -- seed --
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),
     Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
@@ -22,6 +46,6 @@ INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
 ]
 -- chplan --
 RangeWindow func=count_over_time range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-  Project [ResourceAttributes, Timestamp, 1 AS Value]
+  Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, 1 AS Value]
     Filter predicate=(ResourceAttributes["job"] = "api")
       Scan(otel_logs)

--- a/test/spec/logql/count_over_time_detected_level.txtar
+++ b/test/spec/logql/count_over_time_detected_level.txtar
@@ -1,0 +1,55 @@
+-- query.logql --
+count_over_time({job="api"}[5m])
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, SeverityText, ResourceAttributes) VALUES
+    (toDateTime64('2025-12-31 23:58:00', 9), 'a', 'INFO',  map('job', 'api')),
+    (toDateTime64('2025-12-31 23:59:00', 9), 'b', 'WARN',  map('job', 'api')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'c', 'ERROR', map('job', 'api')),
+    (toDateTime64('2026-01-01 00:00:01', 9), 'd', 'DEBUG', map('job', 'api'));
+-- expected_rows --
+[
+  [{"detected_level": "debug", "job": "api"}, 1.0],
+  [{"detected_level": "error", "job": "api"}, 1.0],
+  [{"detected_level": "info",  "job": "api"}, 1.0],
+  [{"detected_level": "warn",  "job": "api"}, 1.0]
+]
+-- args --
+[0] string = ""
+[1] string = "detected_level"
+[2] string = "trace"
+[3] string = "trc"
+[4] string = "trace"
+[5] string = "debug"
+[6] string = "dbg"
+[7] string = "debug"
+[8] string = "info"
+[9] string = "inf"
+[10] string = "information"
+[11] string = "info"
+[12] string = "warn"
+[13] string = "wrn"
+[14] string = "warning"
+[15] string = "warn"
+[16] string = "error"
+[17] string = "err"
+[18] string = "error"
+[19] string = "critical"
+[20] string = "critical"
+[21] string = "fatal"
+[22] string = "fatal"
+[23] int64 = 1
+[24] string = "job"
+[25] string = "api"
+-- chplan --
+RangeWindow func=count_over_time range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
+  Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, 1 AS Value]
+    Filter predicate=(ResourceAttributes["job"] = "api")
+      Scan(otel_logs)
+-- sql --
+SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1

--- a/test/spec/logql/edge_bytes_over_time_filter.txtar
+++ b/test/spec/logql/edge_bytes_over_time_filter.txtar
@@ -1,15 +1,39 @@
 -- query.logql --
 bytes_over_time({job="api"} |= "request"[5m])
 -- args --
-[0] string = "job"
-[1] string = "api"
-[2] string = "request"
+[0] string = ""
+[1] string = "detected_level"
+[2] string = "trace"
+[3] string = "trc"
+[4] string = "trace"
+[5] string = "debug"
+[6] string = "dbg"
+[7] string = "debug"
+[8] string = "info"
+[9] string = "inf"
+[10] string = "information"
+[11] string = "info"
+[12] string = "warn"
+[13] string = "wrn"
+[14] string = "warning"
+[15] string = "warn"
+[16] string = "error"
+[17] string = "err"
+[18] string = "error"
+[19] string = "critical"
+[20] string = "critical"
+[21] string = "fatal"
+[22] string = "fatal"
+[23] string = "job"
+[24] string = "api"
+[25] string = "request"
 -- sql --
-SELECT `ResourceAttributes`, arraySum(window_vals) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, toFloat64(length(`Body`)) AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (position(`Body`, ?) > 0))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1
+SELECT `ResourceAttributes`, arraySum(window_vals) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, toFloat64(length(`Body`)) AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (position(`Body`, ?) > 0))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1
 -- seed --
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),
     Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
@@ -23,6 +47,6 @@ INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
 ]
 -- chplan --
 RangeWindow func=sum_over_time range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-  Project [ResourceAttributes, Timestamp, toFloat64(length(Body)) AS Value]
+  Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, toFloat64(length(Body)) AS Value]
     Filter predicate=((ResourceAttributes["job"] = "api") AND lineContent(Body, "request", substr))
       Scan(otel_logs)

--- a/test/spec/logql/edge_bytes_rate_with_chain.txtar
+++ b/test/spec/logql/edge_bytes_rate_with_chain.txtar
@@ -2,15 +2,39 @@
 bytes_rate({job="api"} |~ "req|resp"[5m])
 -- args --
 [0] float64 = 300
-[1] string = "job"
-[2] string = "api"
-[3] string = "req|resp"
+[1] string = ""
+[2] string = "detected_level"
+[3] string = "trace"
+[4] string = "trc"
+[5] string = "trace"
+[6] string = "debug"
+[7] string = "dbg"
+[8] string = "debug"
+[9] string = "info"
+[10] string = "inf"
+[11] string = "information"
+[12] string = "info"
+[13] string = "warn"
+[14] string = "wrn"
+[15] string = "warning"
+[16] string = "warn"
+[17] string = "error"
+[18] string = "err"
+[19] string = "error"
+[20] string = "critical"
+[21] string = "critical"
+[22] string = "fatal"
+[23] string = "fatal"
+[24] string = "job"
+[25] string = "api"
+[26] string = "req|resp"
 -- sql --
-SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, toFloat64(length(`Body`)) AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND match(`Body`, ?))) GROUP BY `ResourceAttributes`)))
+SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, toFloat64(length(`Body`)) AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND match(`Body`, ?))) GROUP BY `ResourceAttributes`)))
 -- seed --
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),
     Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
@@ -24,6 +48,6 @@ INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
 ]
 -- chplan --
 RangeWindow func=log_rate range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-  Project [ResourceAttributes, Timestamp, toFloat64(length(Body)) AS Value]
+  Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, toFloat64(length(Body)) AS Value]
     Filter predicate=((ResourceAttributes["job"] = "api") AND lineContent(Body, "req|resp", regex))
       Scan(otel_logs)

--- a/test/spec/logql/edge_count_over_time_filter.txtar
+++ b/test/spec/logql/edge_count_over_time_filter.txtar
@@ -1,17 +1,41 @@
 -- query.logql --
 count_over_time({job="api"} |= "error" != "test"[5m])
 -- args --
-[0] int64 = 1
-[1] string = "job"
-[2] string = "api"
-[3] string = "error"
-[4] string = "test"
+[0] string = ""
+[1] string = "detected_level"
+[2] string = "trace"
+[3] string = "trc"
+[4] string = "trace"
+[5] string = "debug"
+[6] string = "dbg"
+[7] string = "debug"
+[8] string = "info"
+[9] string = "inf"
+[10] string = "information"
+[11] string = "info"
+[12] string = "warn"
+[13] string = "wrn"
+[14] string = "warning"
+[15] string = "warn"
+[16] string = "error"
+[17] string = "err"
+[18] string = "error"
+[19] string = "critical"
+[20] string = "critical"
+[21] string = "fatal"
+[22] string = "fatal"
+[23] int64 = 1
+[24] string = "job"
+[25] string = "api"
+[26] string = "error"
+[27] string = "test"
 -- sql --
-SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (position(`Body`, ?) > 0) AND (position(`Body`, ?) = 0))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1
+SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (position(`Body`, ?) > 0) AND (position(`Body`, ?) = 0))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1
 -- seed --
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),
     Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
@@ -26,6 +50,6 @@ INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
 ]
 -- chplan --
 RangeWindow func=count_over_time range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-  Project [ResourceAttributes, Timestamp, 1 AS Value]
+  Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, 1 AS Value]
     Filter predicate=((ResourceAttributes["job"] = "api") AND (lineContent(Body, "error", substr) AND lineContent(Body, "test", substr,not)))
       Scan(otel_logs)

--- a/test/spec/logql/edge_sum_by_rate.txtar
+++ b/test/spec/logql/edge_sum_by_rate.txtar
@@ -8,17 +8,41 @@ sum by (job, level) (rate({job="api"}[5m]))
 [4] string = "job"
 [5] string = "level"
 [6] float64 = 300
-[7] int64 = 1
-[8] string = "job"
-[9] string = "api"
-[10] string = "job"
-[11] string = "level"
+[7] string = ""
+[8] string = "detected_level"
+[9] string = "trace"
+[10] string = "trc"
+[11] string = "trace"
+[12] string = "debug"
+[13] string = "dbg"
+[14] string = "debug"
+[15] string = "info"
+[16] string = "inf"
+[17] string = "information"
+[18] string = "info"
+[19] string = "warn"
+[20] string = "wrn"
+[21] string = "warning"
+[22] string = "warn"
+[23] string = "error"
+[24] string = "err"
+[25] string = "error"
+[26] string = "critical"
+[27] string = "critical"
+[28] string = "fatal"
+[29] string = "fatal"
+[30] int64 = 1
+[31] string = "job"
+[32] string = "api"
+[33] string = "job"
+[34] string = "level"
 -- sql --
-SELECT ? AS `MetricName`, map(?, `gkey_0`, ?, `gkey_1`) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`[?] AS `gkey_0`, `ResourceAttributes`[?] AS `gkey_1`, sum(`Value`) AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`)))) GROUP BY `ResourceAttributes`[?], `ResourceAttributes`[?])
+SELECT ? AS `MetricName`, map(?, `gkey_0`, ?, `gkey_1`) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`[?] AS `gkey_0`, `ResourceAttributes`[?] AS `gkey_1`, sum(`Value`) AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`)))) GROUP BY `ResourceAttributes`[?], `ResourceAttributes`[?])
 -- seed --
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),
     Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
@@ -37,6 +61,6 @@ INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
 Project ["" AS MetricName, map("job", gkey_0, "level", gkey_1) AS Attributes, now64(9) AS TimeUnix, Value AS Value]
   Aggregate groupBy=[ResourceAttributes["job"] AS gkey_0, ResourceAttributes["level"] AS gkey_1] funcs=[sum(Value) AS Value]
     RangeWindow func=log_rate range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-      Project [ResourceAttributes, Timestamp, 1 AS Value]
+      Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, 1 AS Value]
         Filter predicate=(ResourceAttributes["job"] = "api")
           Scan(otel_logs)

--- a/test/spec/logql/edge_sum_without_rate.txtar
+++ b/test/spec/logql/edge_sum_without_rate.txtar
@@ -6,17 +6,41 @@ sum without (instance, pod) (rate({job="api"}[5m]))
 [2] string = "instance"
 [3] string = "pod"
 [4] float64 = 300
-[5] int64 = 1
-[6] string = "job"
-[7] string = "api"
-[8] string = "instance"
-[9] string = "pod"
+[5] string = ""
+[6] string = "detected_level"
+[7] string = "trace"
+[8] string = "trc"
+[9] string = "trace"
+[10] string = "debug"
+[11] string = "dbg"
+[12] string = "debug"
+[13] string = "info"
+[14] string = "inf"
+[15] string = "information"
+[16] string = "info"
+[17] string = "warn"
+[18] string = "wrn"
+[19] string = "warning"
+[20] string = "warn"
+[21] string = "error"
+[22] string = "err"
+[23] string = "error"
+[24] string = "critical"
+[25] string = "critical"
+[26] string = "fatal"
+[27] string = "fatal"
+[28] int64 = 1
+[29] string = "job"
+[30] string = "api"
+[31] string = "instance"
+[32] string = "pod"
 -- sql --
-SELECT ? AS `MetricName`, `gkey_0` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT mapFilter((k, v) -> NOT (k IN (?, ?)), `ResourceAttributes`) AS `gkey_0`, sum(`Value`) AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`)))) GROUP BY mapFilter((k, v) -> NOT (k IN (?, ?)), `ResourceAttributes`))
+SELECT ? AS `MetricName`, `gkey_0` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT mapFilter((k, v) -> NOT (k IN (?, ?)), `ResourceAttributes`) AS `gkey_0`, sum(`Value`) AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`)))) GROUP BY mapFilter((k, v) -> NOT (k IN (?, ?)), `ResourceAttributes`))
 -- seed --
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),
     Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
@@ -33,6 +57,6 @@ INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
 Project ["" AS MetricName, gkey_0 AS Attributes, now64(9) AS TimeUnix, Value AS Value]
   Aggregate groupBy=[mapWithout(ResourceAttributes, [instance, pod]) AS gkey_0] funcs=[sum(Value) AS Value]
     RangeWindow func=log_rate range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-      Project [ResourceAttributes, Timestamp, 1 AS Value]
+      Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, 1 AS Value]
         Filter predicate=(ResourceAttributes["job"] = "api")
           Scan(otel_logs)

--- a/test/spec/logql/label_replace_basic.txtar
+++ b/test/spec/logql/label_replace_basic.txtar
@@ -9,13 +9,37 @@ label_replace(count_over_time({service_name="api"}[5m]), "newlabel", "$1", "serv
 [5] string = "service_name"
 [6] string = "^(.+)$"
 [7] string = "\\1"
-[8] int64 = 1
-[9] string = "service_name"
-[10] string = "api"
+[8] string = ""
+[9] string = "detected_level"
+[10] string = "trace"
+[11] string = "trc"
+[12] string = "trace"
+[13] string = "debug"
+[14] string = "dbg"
+[15] string = "debug"
+[16] string = "info"
+[17] string = "inf"
+[18] string = "information"
+[19] string = "info"
+[20] string = "warn"
+[21] string = "wrn"
+[22] string = "warning"
+[23] string = "warn"
+[24] string = "error"
+[25] string = "err"
+[26] string = "error"
+[27] string = "critical"
+[28] string = "critical"
+[29] string = "fatal"
+[30] string = "fatal"
+[31] int64 = 1
+[32] string = "service_name"
+[33] string = "api"
 -- seed --
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),
     Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
@@ -29,8 +53,8 @@ INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
 -- chplan --
 Project [labelReplace(ResourceAttributes, dst="newlabel", replacement="\\1", src="service_name", regex="(.+)", emptyReplacement="") AS ResourceAttributes, Value]
   RangeWindow func=count_over_time range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-    Project [ResourceAttributes, Timestamp, 1 AS Value]
+    Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, 1 AS Value]
       Filter predicate=(ResourceAttributes["service_name"] = "api")
         Scan(otel_logs)
 -- sql --
-SELECT mapFilter((k, v) -> v != '', if(match(`ResourceAttributes`[?], ?), mapUpdate(`ResourceAttributes`, map(?, if(empty(`ResourceAttributes`[?]), ?, replaceRegexpOne(`ResourceAttributes`[?], ?, ?)))), `ResourceAttributes`)) AS `ResourceAttributes`, `Value` FROM (SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1)
+SELECT mapFilter((k, v) -> v != '', if(match(`ResourceAttributes`[?], ?), mapUpdate(`ResourceAttributes`, map(?, if(empty(`ResourceAttributes`[?]), ?, replaceRegexpOne(`ResourceAttributes`[?], ?, ?)))), `ResourceAttributes`)) AS `ResourceAttributes`, `Value` FROM (SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1)

--- a/test/spec/logql/pipeline_drop_on_aggregation.txtar
+++ b/test/spec/logql/pipeline_drop_on_aggregation.txtar
@@ -1,15 +1,39 @@
 -- query.logql --
 count_over_time({job="api"} | drop env [5m])
 -- sql --
-SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1
+SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1
 -- args --
-[0] int64 = 1
-[1] string = "job"
-[2] string = "api"
+[0] string = ""
+[1] string = "detected_level"
+[2] string = "trace"
+[3] string = "trc"
+[4] string = "trace"
+[5] string = "debug"
+[6] string = "dbg"
+[7] string = "debug"
+[8] string = "info"
+[9] string = "inf"
+[10] string = "information"
+[11] string = "info"
+[12] string = "warn"
+[13] string = "wrn"
+[14] string = "warning"
+[15] string = "warn"
+[16] string = "error"
+[17] string = "err"
+[18] string = "error"
+[19] string = "critical"
+[20] string = "critical"
+[21] string = "fatal"
+[22] string = "fatal"
+[23] int64 = 1
+[24] string = "job"
+[25] string = "api"
 -- seed --
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),
     Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
@@ -22,6 +46,6 @@ INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
 ]
 -- chplan --
 RangeWindow func=count_over_time range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-  Project [ResourceAttributes, Timestamp, 1 AS Value]
+  Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, 1 AS Value]
     Filter predicate=(ResourceAttributes["job"] = "api")
       Scan(otel_logs)

--- a/test/spec/logql/range_agg_by_grouping.txtar
+++ b/test/spec/logql/range_agg_by_grouping.txtar
@@ -4,6 +4,7 @@ avg_over_time({job="api"} | logfmt | unwrap latency [5m]) by (level)
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),
     Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES

--- a/test/spec/logql/range_mode_count_over_time.txtar
+++ b/test/spec/logql/range_mode_count_over_time.txtar
@@ -10,6 +10,7 @@ count_over_time({service_name="web-server"}[5m])
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),
     Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
@@ -25,17 +26,40 @@ INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
   [{"service_name": "web-server"}, "2026-01-01T00:01:00Z", 5.0]
 ]
 -- args --
-[0] int64 = 1
-[1] string = "2026-01-01 00:00:00.000000000"
-[2] int64 = 9
-[3] string = "2026-01-01 00:01:00.000000000"
-[4] int64 = 9
-[5] string = "service_name"
-[6] string = "web-server"
+[0] string = ""
+[1] string = "detected_level"
+[2] string = "trace"
+[3] string = "trc"
+[4] string = "trace"
+[5] string = "debug"
+[6] string = "dbg"
+[7] string = "debug"
+[8] string = "info"
+[9] string = "inf"
+[10] string = "information"
+[11] string = "info"
+[12] string = "warn"
+[13] string = "wrn"
+[14] string = "warning"
+[15] string = "warn"
+[16] string = "error"
+[17] string = "err"
+[18] string = "error"
+[19] string = "critical"
+[20] string = "critical"
+[21] string = "fatal"
+[22] string = "fatal"
+[23] int64 = 1
+[24] string = "2026-01-01 00:00:00.000000000"
+[25] int64 = 9
+[26] string = "2026-01-01 00:01:00.000000000"
+[27] int64 = 9
+[28] string = "service_name"
+[29] string = "web-server"
 -- chplan --
 RangeWindow func=count_over_time range=5m0s step=30s outerRange=1m0s ts=Timestamp value=Value groupBy=[ResourceAttributes] start=2026-01-01T00:00:00Z end=2026-01-01T00:01:00Z
-  Project [ResourceAttributes, Timestamp, 1 AS Value]
+  Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, 1 AS Value]
     Filter predicate=((ResourceAttributes["service_name"] = "web-server") AND ((Timestamp >= toDateTime64("2026-01-01 00:00:00.000000000", 9)) AND (Timestamp <= toDateTime64("2026-01-01 00:01:00.000000000", 9))))
       Scan(otel_logs)
 -- sql --
-SELECT `ResourceAttributes`, `anchor_ts`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, `anchor_ts`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, `anchor_ts`, arrayFilter(p -> tupleElement(p, 1) > anchor_ts - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= anchor_ts, series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, `series_array`, arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:01:00.000000000', 9) - toIntervalNanosecond(i * 30000000000), range(0, 3))) AS `anchor_ts` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`Timestamp` >= toDateTime64(?, ?)) AND (`Timestamp` <= toDateTime64(?, ?)) AND (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`)))) WHERE length(`window_vals`) >= 1
+SELECT `ResourceAttributes`, `anchor_ts`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, `anchor_ts`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, `anchor_ts`, arrayFilter(p -> tupleElement(p, 1) > anchor_ts - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= anchor_ts, series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, `series_array`, arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:01:00.000000000', 9) - toIntervalNanosecond(i * 30000000000), range(0, 3))) AS `anchor_ts` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`Timestamp` >= toDateTime64(?, ?)) AND (`Timestamp` <= toDateTime64(?, ?)) AND (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`)))) WHERE length(`window_vals`) >= 1

--- a/test/spec/logql/range_mode_sum_count_over_time.txtar
+++ b/test/spec/logql/range_mode_sum_count_over_time.txtar
@@ -10,6 +10,7 @@ sum(count_over_time({service_name="web-server"}[5m]))
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),
     Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
@@ -27,19 +28,42 @@ INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
 -- args --
 [0] string = ""
 [1] string = "Map(String,String)"
-[2] int64 = 1
-[3] string = "2026-01-01 00:00:00.000000000"
-[4] int64 = 9
-[5] string = "2026-01-01 00:01:00.000000000"
-[6] int64 = 9
-[7] string = "service_name"
-[8] string = "web-server"
+[2] string = ""
+[3] string = "detected_level"
+[4] string = "trace"
+[5] string = "trc"
+[6] string = "trace"
+[7] string = "debug"
+[8] string = "dbg"
+[9] string = "debug"
+[10] string = "info"
+[11] string = "inf"
+[12] string = "information"
+[13] string = "info"
+[14] string = "warn"
+[15] string = "wrn"
+[16] string = "warning"
+[17] string = "warn"
+[18] string = "error"
+[19] string = "err"
+[20] string = "error"
+[21] string = "critical"
+[22] string = "critical"
+[23] string = "fatal"
+[24] string = "fatal"
+[25] int64 = 1
+[26] string = "2026-01-01 00:00:00.000000000"
+[27] int64 = 9
+[28] string = "2026-01-01 00:01:00.000000000"
+[29] int64 = 9
+[30] string = "service_name"
+[31] string = "web-server"
 -- chplan --
 Project ["" AS MetricName, CAST(map(), "Map(String,String)") AS Attributes, bucket_ts AS TimeUnix, Value AS Value]
   Aggregate groupBy=[anchor_ts AS bucket_ts] funcs=[sum(Value) AS Value]
     RangeWindow func=count_over_time range=5m0s step=30s outerRange=1m0s ts=Timestamp value=Value groupBy=[ResourceAttributes] start=2026-01-01T00:00:00Z end=2026-01-01T00:01:00Z
-      Project [ResourceAttributes, Timestamp, 1 AS Value]
+      Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, 1 AS Value]
         Filter predicate=((ResourceAttributes["service_name"] = "web-server") AND ((Timestamp >= toDateTime64("2026-01-01 00:00:00.000000000", 9)) AND (Timestamp <= toDateTime64("2026-01-01 00:01:00.000000000", 9))))
           Scan(otel_logs)
 -- sql --
-SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, `bucket_ts` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `anchor_ts` AS `bucket_ts`, sum(`Value`) AS `Value` FROM (SELECT `ResourceAttributes`, `anchor_ts`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, `anchor_ts`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, `anchor_ts`, arrayFilter(p -> tupleElement(p, 1) > anchor_ts - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= anchor_ts, series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, `series_array`, arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:01:00.000000000', 9) - toIntervalNanosecond(i * 30000000000), range(0, 3))) AS `anchor_ts` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`Timestamp` >= toDateTime64(?, ?)) AND (`Timestamp` <= toDateTime64(?, ?)) AND (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`)))) WHERE length(`window_vals`) >= 1) GROUP BY `anchor_ts`)
+SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, `bucket_ts` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `anchor_ts` AS `bucket_ts`, sum(`Value`) AS `Value` FROM (SELECT `ResourceAttributes`, `anchor_ts`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, `anchor_ts`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, `anchor_ts`, arrayFilter(p -> tupleElement(p, 1) > anchor_ts - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= anchor_ts, series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, `series_array`, arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:01:00.000000000', 9) - toIntervalNanosecond(i * 30000000000), range(0, 3))) AS `anchor_ts` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`Timestamp` >= toDateTime64(?, ?)) AND (`Timestamp` <= toDateTime64(?, ?)) AND (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`)))) WHERE length(`window_vals`) >= 1) GROUP BY `anchor_ts`)

--- a/test/spec/logql/rate.txtar
+++ b/test/spec/logql/rate.txtar
@@ -1,16 +1,40 @@
 -- query.logql --
 rate({job="api"}[1m])
 -- sql --
-SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(60000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`)))
+SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(60000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`)))
 -- args --
 [0] float64 = 60
-[1] int64 = 1
-[2] string = "job"
-[3] string = "api"
+[1] string = ""
+[2] string = "detected_level"
+[3] string = "trace"
+[4] string = "trc"
+[5] string = "trace"
+[6] string = "debug"
+[7] string = "dbg"
+[8] string = "debug"
+[9] string = "info"
+[10] string = "inf"
+[11] string = "information"
+[12] string = "info"
+[13] string = "warn"
+[14] string = "wrn"
+[15] string = "warning"
+[16] string = "warn"
+[17] string = "error"
+[18] string = "err"
+[19] string = "error"
+[20] string = "critical"
+[21] string = "critical"
+[22] string = "fatal"
+[23] string = "fatal"
+[24] int64 = 1
+[25] string = "job"
+[26] string = "api"
 -- seed --
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),
     Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
@@ -35,6 +59,6 @@ INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
 ]
 -- chplan --
 RangeWindow func=log_rate range=1m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-  Project [ResourceAttributes, Timestamp, 1 AS Value]
+  Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, 1 AS Value]
     Filter predicate=(ResourceAttributes["job"] = "api")
       Scan(otel_logs)

--- a/test/spec/logql/rate_with_filter.txtar
+++ b/test/spec/logql/rate_with_filter.txtar
@@ -1,17 +1,41 @@
 -- query.logql --
 rate({job="api"} |= "error" [5m])
 -- sql --
-SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (position(`Body`, ?) > 0))) GROUP BY `ResourceAttributes`)))
+SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (position(`Body`, ?) > 0))) GROUP BY `ResourceAttributes`)))
 -- args --
 [0] float64 = 300
-[1] int64 = 1
-[2] string = "job"
-[3] string = "api"
-[4] string = "error"
+[1] string = ""
+[2] string = "detected_level"
+[3] string = "trace"
+[4] string = "trc"
+[5] string = "trace"
+[6] string = "debug"
+[7] string = "dbg"
+[8] string = "debug"
+[9] string = "info"
+[10] string = "inf"
+[11] string = "information"
+[12] string = "info"
+[13] string = "warn"
+[14] string = "wrn"
+[15] string = "warning"
+[16] string = "warn"
+[17] string = "error"
+[18] string = "err"
+[19] string = "error"
+[20] string = "critical"
+[21] string = "critical"
+[22] string = "fatal"
+[23] string = "fatal"
+[24] int64 = 1
+[25] string = "job"
+[26] string = "api"
+[27] string = "error"
 -- seed --
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),
     Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
@@ -25,6 +49,6 @@ INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
 ]
 -- chplan --
 RangeWindow func=log_rate range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-  Project [ResourceAttributes, Timestamp, 1 AS Value]
+  Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, 1 AS Value]
     Filter predicate=((ResourceAttributes["job"] = "api") AND lineContent(Body, "error", substr))
       Scan(otel_logs)

--- a/test/spec/logql/sum_by_job_rate.txtar
+++ b/test/spec/logql/sum_by_job_rate.txtar
@@ -4,6 +4,7 @@ sum by (job) (rate({app="api"}[5m]))
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),
     Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
@@ -18,21 +19,44 @@ INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
   ["", {"job": "orders"}, "2026-01-01T00:00:01Z", 0.006666666666666667]
 ]
 -- sql --
-SELECT ? AS `MetricName`, map(?, `gkey_0`) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`[?] AS `gkey_0`, sum(`Value`) AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`)))) GROUP BY `ResourceAttributes`[?])
+SELECT ? AS `MetricName`, map(?, `gkey_0`) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`[?] AS `gkey_0`, sum(`Value`) AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`)))) GROUP BY `ResourceAttributes`[?])
 -- args --
 [0] string = ""
 [1] string = "job"
 [2] int64 = 9
 [3] string = "job"
 [4] float64 = 300
-[5] int64 = 1
-[6] string = "app"
-[7] string = "api"
-[8] string = "job"
+[5] string = ""
+[6] string = "detected_level"
+[7] string = "trace"
+[8] string = "trc"
+[9] string = "trace"
+[10] string = "debug"
+[11] string = "dbg"
+[12] string = "debug"
+[13] string = "info"
+[14] string = "inf"
+[15] string = "information"
+[16] string = "info"
+[17] string = "warn"
+[18] string = "wrn"
+[19] string = "warning"
+[20] string = "warn"
+[21] string = "error"
+[22] string = "err"
+[23] string = "error"
+[24] string = "critical"
+[25] string = "critical"
+[26] string = "fatal"
+[27] string = "fatal"
+[28] int64 = 1
+[29] string = "app"
+[30] string = "api"
+[31] string = "job"
 -- chplan --
 Project ["" AS MetricName, map("job", gkey_0) AS Attributes, now64(9) AS TimeUnix, Value AS Value]
   Aggregate groupBy=[ResourceAttributes["job"] AS gkey_0] funcs=[sum(Value) AS Value]
     RangeWindow func=log_rate range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-      Project [ResourceAttributes, Timestamp, 1 AS Value]
+      Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, 1 AS Value]
         Filter predicate=(ResourceAttributes["app"] = "api")
           Scan(otel_logs)

--- a/test/spec/logql/sum_count_over_time.txtar
+++ b/test/spec/logql/sum_count_over_time.txtar
@@ -4,6 +4,7 @@ sum(count_over_time({service_name="web-server"}[5m]))
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),
     Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
@@ -15,18 +16,41 @@ INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
   ["", {}, "2026-01-01T00:00:01Z", 3.0]
 ]
 -- sql --
-SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Value` FROM (SELECT sum(`Value`) AS `Value`, count() AS `_cerb_n` FROM (SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1)) WHERE `_cerb_n` > 0)
+SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Value` FROM (SELECT sum(`Value`) AS `Value`, count() AS `_cerb_n` FROM (SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1)) WHERE `_cerb_n` > 0)
 -- args --
 [0] string = ""
 [1] string = "Map(String,String)"
 [2] int64 = 9
-[3] int64 = 1
-[4] string = "service_name"
-[5] string = "web-server"
+[3] string = ""
+[4] string = "detected_level"
+[5] string = "trace"
+[6] string = "trc"
+[7] string = "trace"
+[8] string = "debug"
+[9] string = "dbg"
+[10] string = "debug"
+[11] string = "info"
+[12] string = "inf"
+[13] string = "information"
+[14] string = "info"
+[15] string = "warn"
+[16] string = "wrn"
+[17] string = "warning"
+[18] string = "warn"
+[19] string = "error"
+[20] string = "err"
+[21] string = "error"
+[22] string = "critical"
+[23] string = "critical"
+[24] string = "fatal"
+[25] string = "fatal"
+[26] int64 = 1
+[27] string = "service_name"
+[28] string = "web-server"
 -- chplan --
 Project ["" AS MetricName, CAST(map(), "Map(String,String)") AS Attributes, now64(9) AS TimeUnix, Value AS Value]
   Aggregate groupBy=[] funcs=[sum(Value) AS Value]
     RangeWindow func=count_over_time range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-      Project [ResourceAttributes, Timestamp, 1 AS Value]
+      Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, 1 AS Value]
         Filter predicate=(ResourceAttributes["service_name"] = "web-server")
           Scan(otel_logs)

--- a/test/spec/logql/sum_count_over_time_line_filter.txtar
+++ b/test/spec/logql/sum_count_over_time_line_filter.txtar
@@ -4,6 +4,7 @@ sum(count_over_time({service_name="web-server"} |= "level" [5m]))
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),
     Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
@@ -15,19 +16,42 @@ INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
   ["", {}, "2026-01-01T00:00:01Z", 2.0]
 ]
 -- sql --
-SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Value` FROM (SELECT sum(`Value`) AS `Value`, count() AS `_cerb_n` FROM (SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (position(`Body`, ?) > 0))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1)) WHERE `_cerb_n` > 0)
+SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Value` FROM (SELECT sum(`Value`) AS `Value`, count() AS `_cerb_n` FROM (SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND (position(`Body`, ?) > 0))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1)) WHERE `_cerb_n` > 0)
 -- args --
 [0] string = ""
 [1] string = "Map(String,String)"
 [2] int64 = 9
-[3] int64 = 1
-[4] string = "service_name"
-[5] string = "web-server"
-[6] string = "level"
+[3] string = ""
+[4] string = "detected_level"
+[5] string = "trace"
+[6] string = "trc"
+[7] string = "trace"
+[8] string = "debug"
+[9] string = "dbg"
+[10] string = "debug"
+[11] string = "info"
+[12] string = "inf"
+[13] string = "information"
+[14] string = "info"
+[15] string = "warn"
+[16] string = "wrn"
+[17] string = "warning"
+[18] string = "warn"
+[19] string = "error"
+[20] string = "err"
+[21] string = "error"
+[22] string = "critical"
+[23] string = "critical"
+[24] string = "fatal"
+[25] string = "fatal"
+[26] int64 = 1
+[27] string = "service_name"
+[28] string = "web-server"
+[29] string = "level"
 -- chplan --
 Project ["" AS MetricName, CAST(map(), "Map(String,String)") AS Attributes, now64(9) AS TimeUnix, Value AS Value]
   Aggregate groupBy=[] funcs=[sum(Value) AS Value]
     RangeWindow func=count_over_time range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-      Project [ResourceAttributes, Timestamp, 1 AS Value]
+      Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, 1 AS Value]
         Filter predicate=((ResourceAttributes["service_name"] = "web-server") AND lineContent(Body, "level", substr))
           Scan(otel_logs)

--- a/test/spec/logql/sum_rate.txtar
+++ b/test/spec/logql/sum_rate.txtar
@@ -4,6 +4,7 @@ sum(rate({job="api"}[1m]))
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),
     Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
@@ -18,19 +19,42 @@ INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
   ["", {}, "2026-01-01T00:00:01Z", 0.1]
 ]
 -- sql --
-SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Value` FROM (SELECT sum(`Value`) AS `Value`, count() AS `_cerb_n` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(60000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))))) WHERE `_cerb_n` > 0)
+SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Value` FROM (SELECT sum(`Value`) AS `Value`, count() AS `_cerb_n` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(60000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))))) WHERE `_cerb_n` > 0)
 -- args --
 [0] string = ""
 [1] string = "Map(String,String)"
 [2] int64 = 9
 [3] float64 = 60
-[4] int64 = 1
-[5] string = "job"
-[6] string = "api"
+[4] string = ""
+[5] string = "detected_level"
+[6] string = "trace"
+[7] string = "trc"
+[8] string = "trace"
+[9] string = "debug"
+[10] string = "dbg"
+[11] string = "debug"
+[12] string = "info"
+[13] string = "inf"
+[14] string = "information"
+[15] string = "info"
+[16] string = "warn"
+[17] string = "wrn"
+[18] string = "warning"
+[19] string = "warn"
+[20] string = "error"
+[21] string = "err"
+[22] string = "error"
+[23] string = "critical"
+[24] string = "critical"
+[25] string = "fatal"
+[26] string = "fatal"
+[27] int64 = 1
+[28] string = "job"
+[29] string = "api"
 -- chplan --
 Project ["" AS MetricName, CAST(map(), "Map(String,String)") AS Attributes, now64(9) AS TimeUnix, Value AS Value]
   Aggregate groupBy=[] funcs=[sum(Value) AS Value]
     RangeWindow func=log_rate range=1m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-      Project [ResourceAttributes, Timestamp, 1 AS Value]
+      Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, 1 AS Value]
         Filter predicate=(ResourceAttributes["job"] = "api")
           Scan(otel_logs)

--- a/test/spec/logql/sum_without_pod.txtar
+++ b/test/spec/logql/sum_without_pod.txtar
@@ -4,6 +4,7 @@ sum without (pod) (rate({job="api"}[5m]))
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),
     Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
@@ -17,20 +18,43 @@ INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
   ["", {"dc": "us-east", "job": "api"}, "2026-01-01T00:00:01Z", 0.016666666666666666]
 ]
 -- sql --
-SELECT ? AS `MetricName`, `gkey_0` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT mapFilter((k, v) -> NOT (k IN (?)), `ResourceAttributes`) AS `gkey_0`, sum(`Value`) AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`)))) GROUP BY mapFilter((k, v) -> NOT (k IN (?)), `ResourceAttributes`))
+SELECT ? AS `MetricName`, `gkey_0` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT mapFilter((k, v) -> NOT (k IN (?)), `ResourceAttributes`) AS `gkey_0`, sum(`Value`) AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`)))) GROUP BY mapFilter((k, v) -> NOT (k IN (?)), `ResourceAttributes`))
 -- args --
 [0] string = ""
 [1] int64 = 9
 [2] string = "pod"
 [3] float64 = 300
-[4] int64 = 1
-[5] string = "job"
-[6] string = "api"
-[7] string = "pod"
+[4] string = ""
+[5] string = "detected_level"
+[6] string = "trace"
+[7] string = "trc"
+[8] string = "trace"
+[9] string = "debug"
+[10] string = "dbg"
+[11] string = "debug"
+[12] string = "info"
+[13] string = "inf"
+[14] string = "information"
+[15] string = "info"
+[16] string = "warn"
+[17] string = "wrn"
+[18] string = "warning"
+[19] string = "warn"
+[20] string = "error"
+[21] string = "err"
+[22] string = "error"
+[23] string = "critical"
+[24] string = "critical"
+[25] string = "fatal"
+[26] string = "fatal"
+[27] int64 = 1
+[28] string = "job"
+[29] string = "api"
+[30] string = "pod"
 -- chplan --
 Project ["" AS MetricName, gkey_0 AS Attributes, now64(9) AS TimeUnix, Value AS Value]
   Aggregate groupBy=[mapWithout(ResourceAttributes, [pod]) AS gkey_0] funcs=[sum(Value) AS Value]
     RangeWindow func=log_rate range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-      Project [ResourceAttributes, Timestamp, 1 AS Value]
+      Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, 1 AS Value]
         Filter predicate=(ResourceAttributes["job"] = "api")
           Scan(otel_logs)

--- a/test/spec/logql/unwrap_avg_over_time.txtar
+++ b/test/spec/logql/unwrap_avg_over_time.txtar
@@ -1,24 +1,48 @@
 -- query.logql --
 avg_over_time({job="api"} | logfmt | unwrap latency [5m])
 -- args --
-[0] string = "_extracted"
-[1] string = "="
-[2] string = " "
-[3] string = "\""
-[4] string = "latency"
-[5] string = "job"
-[6] string = "api"
+[0] string = ""
+[1] string = "detected_level"
+[2] string = "trace"
+[3] string = "trc"
+[4] string = "trace"
+[5] string = "debug"
+[6] string = "dbg"
+[7] string = "debug"
+[8] string = "info"
+[9] string = "inf"
+[10] string = "information"
+[11] string = "info"
+[12] string = "warn"
+[13] string = "wrn"
+[14] string = "warning"
+[15] string = "warn"
+[16] string = "error"
+[17] string = "err"
+[18] string = "error"
+[19] string = "critical"
+[20] string = "critical"
+[21] string = "fatal"
+[22] string = "fatal"
+[23] string = "_extracted"
+[24] string = "="
+[25] string = " "
+[26] string = "\""
+[27] string = "latency"
+[28] string = "job"
+[29] string = "api"
 -- chplan --
 RangeWindow func=avg_over_time range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-  Project [ResourceAttributes, Timestamp, toFloat64OrZero(mapConcat(ResourceAttributes, mapApply((k, v) -> tuple(if(mapContains(ResourceAttributes, k), concat(k, "_extracted"), k), v), extractKeyValuePairs(Body, "=", " ", "\"")))["latency"]) AS Value]
+  Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, toFloat64OrZero(mapConcat(ResourceAttributes, mapApply((k, v) -> tuple(if(mapContains(ResourceAttributes, k), concat(k, "_extracted"), k), v), extractKeyValuePairs(Body, "=", " ", "\"")))["latency"]) AS Value]
     Filter predicate=(ResourceAttributes["job"] = "api")
       Scan(otel_logs)
 -- sql --
-SELECT `ResourceAttributes`, if(length(window_vals) > 0, arrayAvg(window_vals), nan) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, toFloat64OrZero(mapConcat(`ResourceAttributes`, mapApply((k, v) -> tuple(if(mapContains(`ResourceAttributes`, k), concat(k, ?), k), v), extractKeyValuePairs(`Body`, ?, ?, ?)))[?]) AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1
+SELECT `ResourceAttributes`, if(length(window_vals) > 0, arrayAvg(window_vals), nan) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, toFloat64OrZero(mapConcat(`ResourceAttributes`, mapApply((k, v) -> tuple(if(mapContains(`ResourceAttributes`, k), concat(k, ?), k), v), extractKeyValuePairs(`Body`, ?, ?, ?)))[?]) AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1
 -- seed --
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),
     Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES

--- a/test/spec/logql/unwrap_bytes.txtar
+++ b/test/spec/logql/unwrap_bytes.txtar
@@ -1,24 +1,48 @@
 -- query.logql --
 sum_over_time({job="api"} | logfmt | unwrap bytes(size) [5m])
 -- args --
-[0] string = "_extracted"
-[1] string = "="
-[2] string = " "
-[3] string = "\""
-[4] string = "size"
-[5] string = "job"
-[6] string = "api"
+[0] string = ""
+[1] string = "detected_level"
+[2] string = "trace"
+[3] string = "trc"
+[4] string = "trace"
+[5] string = "debug"
+[6] string = "dbg"
+[7] string = "debug"
+[8] string = "info"
+[9] string = "inf"
+[10] string = "information"
+[11] string = "info"
+[12] string = "warn"
+[13] string = "wrn"
+[14] string = "warning"
+[15] string = "warn"
+[16] string = "error"
+[17] string = "err"
+[18] string = "error"
+[19] string = "critical"
+[20] string = "critical"
+[21] string = "fatal"
+[22] string = "fatal"
+[23] string = "_extracted"
+[24] string = "="
+[25] string = " "
+[26] string = "\""
+[27] string = "size"
+[28] string = "job"
+[29] string = "api"
 -- chplan --
 RangeWindow func=sum_over_time range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-  Project [ResourceAttributes, Timestamp, toFloat64(parseReadableSize(mapConcat(ResourceAttributes, mapApply((k, v) -> tuple(if(mapContains(ResourceAttributes, k), concat(k, "_extracted"), k), v), extractKeyValuePairs(Body, "=", " ", "\"")))["size"])) AS Value]
+  Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, toFloat64(parseReadableSize(mapConcat(ResourceAttributes, mapApply((k, v) -> tuple(if(mapContains(ResourceAttributes, k), concat(k, "_extracted"), k), v), extractKeyValuePairs(Body, "=", " ", "\"")))["size"])) AS Value]
     Filter predicate=(ResourceAttributes["job"] = "api")
       Scan(otel_logs)
 -- sql --
-SELECT `ResourceAttributes`, arraySum(window_vals) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, toFloat64(parseReadableSize(mapConcat(`ResourceAttributes`, mapApply((k, v) -> tuple(if(mapContains(`ResourceAttributes`, k), concat(k, ?), k), v), extractKeyValuePairs(`Body`, ?, ?, ?)))[?])) AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1
+SELECT `ResourceAttributes`, arraySum(window_vals) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, toFloat64(parseReadableSize(mapConcat(`ResourceAttributes`, mapApply((k, v) -> tuple(if(mapContains(`ResourceAttributes`, k), concat(k, ?), k), v), extractKeyValuePairs(`Body`, ?, ?, ?)))[?])) AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1
 -- seed --
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),
     Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES

--- a/test/spec/logql/unwrap_duration_seconds.txtar
+++ b/test/spec/logql/unwrap_duration_seconds.txtar
@@ -1,24 +1,48 @@
 -- query.logql --
 sum_over_time({job="api"} | logfmt | unwrap duration_seconds(latency) [5m])
 -- args --
-[0] string = "_extracted"
-[1] string = "="
-[2] string = " "
-[3] string = "\""
-[4] string = "latency"
-[5] string = "job"
-[6] string = "api"
+[0] string = ""
+[1] string = "detected_level"
+[2] string = "trace"
+[3] string = "trc"
+[4] string = "trace"
+[5] string = "debug"
+[6] string = "dbg"
+[7] string = "debug"
+[8] string = "info"
+[9] string = "inf"
+[10] string = "information"
+[11] string = "info"
+[12] string = "warn"
+[13] string = "wrn"
+[14] string = "warning"
+[15] string = "warn"
+[16] string = "error"
+[17] string = "err"
+[18] string = "error"
+[19] string = "critical"
+[20] string = "critical"
+[21] string = "fatal"
+[22] string = "fatal"
+[23] string = "_extracted"
+[24] string = "="
+[25] string = " "
+[26] string = "\""
+[27] string = "latency"
+[28] string = "job"
+[29] string = "api"
 -- chplan --
 RangeWindow func=sum_over_time range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-  Project [ResourceAttributes, Timestamp, parseTimeDelta(mapConcat(ResourceAttributes, mapApply((k, v) -> tuple(if(mapContains(ResourceAttributes, k), concat(k, "_extracted"), k), v), extractKeyValuePairs(Body, "=", " ", "\"")))["latency"]) AS Value]
+  Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, parseTimeDelta(mapConcat(ResourceAttributes, mapApply((k, v) -> tuple(if(mapContains(ResourceAttributes, k), concat(k, "_extracted"), k), v), extractKeyValuePairs(Body, "=", " ", "\"")))["latency"]) AS Value]
     Filter predicate=(ResourceAttributes["job"] = "api")
       Scan(otel_logs)
 -- sql --
-SELECT `ResourceAttributes`, arraySum(window_vals) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, parseTimeDelta(mapConcat(`ResourceAttributes`, mapApply((k, v) -> tuple(if(mapContains(`ResourceAttributes`, k), concat(k, ?), k), v), extractKeyValuePairs(`Body`, ?, ?, ?)))[?]) AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1
+SELECT `ResourceAttributes`, arraySum(window_vals) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, parseTimeDelta(mapConcat(`ResourceAttributes`, mapApply((k, v) -> tuple(if(mapContains(`ResourceAttributes`, k), concat(k, ?), k), v), extractKeyValuePairs(`Body`, ?, ?, ?)))[?]) AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1
 -- seed --
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),
     Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES

--- a/test/spec/logql/unwrap_quantile_over_time.txtar
+++ b/test/spec/logql/unwrap_quantile_over_time.txtar
@@ -1,24 +1,48 @@
 -- query.logql --
 quantile_over_time(0.95, {job="api"} | logfmt | unwrap latency [5m])
 -- args --
-[0] string = "_extracted"
-[1] string = "="
-[2] string = " "
-[3] string = "\""
-[4] string = "latency"
-[5] string = "job"
-[6] string = "api"
+[0] string = ""
+[1] string = "detected_level"
+[2] string = "trace"
+[3] string = "trc"
+[4] string = "trace"
+[5] string = "debug"
+[6] string = "dbg"
+[7] string = "debug"
+[8] string = "info"
+[9] string = "inf"
+[10] string = "information"
+[11] string = "info"
+[12] string = "warn"
+[13] string = "wrn"
+[14] string = "warning"
+[15] string = "warn"
+[16] string = "error"
+[17] string = "err"
+[18] string = "error"
+[19] string = "critical"
+[20] string = "critical"
+[21] string = "fatal"
+[22] string = "fatal"
+[23] string = "_extracted"
+[24] string = "="
+[25] string = " "
+[26] string = "\""
+[27] string = "latency"
+[28] string = "job"
+[29] string = "api"
 -- chplan --
 RangeWindow func=quantile_over_time range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes] scalars=[0.95]
-  Project [ResourceAttributes, Timestamp, toFloat64OrZero(mapConcat(ResourceAttributes, mapApply((k, v) -> tuple(if(mapContains(ResourceAttributes, k), concat(k, "_extracted"), k), v), extractKeyValuePairs(Body, "=", " ", "\"")))["latency"]) AS Value]
+  Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, toFloat64OrZero(mapConcat(ResourceAttributes, mapApply((k, v) -> tuple(if(mapContains(ResourceAttributes, k), concat(k, "_extracted"), k), v), extractKeyValuePairs(Body, "=", " ", "\"")))["latency"]) AS Value]
     Filter predicate=(ResourceAttributes["job"] = "api")
       Scan(otel_logs)
 -- sql --
-SELECT `ResourceAttributes`, if(length(window_vals) > 0, arrayReduce('quantile(0.95)', window_vals), nan) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, toFloat64OrZero(mapConcat(`ResourceAttributes`, mapApply((k, v) -> tuple(if(mapContains(`ResourceAttributes`, k), concat(k, ?), k), v), extractKeyValuePairs(`Body`, ?, ?, ?)))[?]) AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1
+SELECT `ResourceAttributes`, if(length(window_vals) > 0, arrayReduce('quantile(0.95)', window_vals), nan) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, toFloat64OrZero(mapConcat(`ResourceAttributes`, mapApply((k, v) -> tuple(if(mapContains(`ResourceAttributes`, k), concat(k, ?), k), v), extractKeyValuePairs(`Body`, ?, ?, ?)))[?]) AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1
 -- seed --
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),
     Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES

--- a/test/spec/logql/unwrap_sum_over_time.txtar
+++ b/test/spec/logql/unwrap_sum_over_time.txtar
@@ -1,24 +1,48 @@
 -- query.logql --
 sum_over_time({job="api"} | logfmt | unwrap latency [5m])
 -- args --
-[0] string = "_extracted"
-[1] string = "="
-[2] string = " "
-[3] string = "\""
-[4] string = "latency"
-[5] string = "job"
-[6] string = "api"
+[0] string = ""
+[1] string = "detected_level"
+[2] string = "trace"
+[3] string = "trc"
+[4] string = "trace"
+[5] string = "debug"
+[6] string = "dbg"
+[7] string = "debug"
+[8] string = "info"
+[9] string = "inf"
+[10] string = "information"
+[11] string = "info"
+[12] string = "warn"
+[13] string = "wrn"
+[14] string = "warning"
+[15] string = "warn"
+[16] string = "error"
+[17] string = "err"
+[18] string = "error"
+[19] string = "critical"
+[20] string = "critical"
+[21] string = "fatal"
+[22] string = "fatal"
+[23] string = "_extracted"
+[24] string = "="
+[25] string = " "
+[26] string = "\""
+[27] string = "latency"
+[28] string = "job"
+[29] string = "api"
 -- chplan --
 RangeWindow func=sum_over_time range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-  Project [ResourceAttributes, Timestamp, toFloat64OrZero(mapConcat(ResourceAttributes, mapApply((k, v) -> tuple(if(mapContains(ResourceAttributes, k), concat(k, "_extracted"), k), v), extractKeyValuePairs(Body, "=", " ", "\"")))["latency"]) AS Value]
+  Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, toFloat64OrZero(mapConcat(ResourceAttributes, mapApply((k, v) -> tuple(if(mapContains(ResourceAttributes, k), concat(k, "_extracted"), k), v), extractKeyValuePairs(Body, "=", " ", "\"")))["latency"]) AS Value]
     Filter predicate=(ResourceAttributes["job"] = "api")
       Scan(otel_logs)
 -- sql --
-SELECT `ResourceAttributes`, arraySum(window_vals) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT `ResourceAttributes`, `Timestamp`, toFloat64OrZero(mapConcat(`ResourceAttributes`, mapApply((k, v) -> tuple(if(mapContains(`ResourceAttributes`, k), concat(k, ?), k), v), extractKeyValuePairs(`Body`, ?, ?, ?)))[?]) AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1
+SELECT `ResourceAttributes`, arraySum(window_vals) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, toFloat64OrZero(mapConcat(`ResourceAttributes`, mapApply((k, v) -> tuple(if(mapContains(`ResourceAttributes`, k), concat(k, ?), k), v), extractKeyValuePairs(`Body`, ?, ?, ?)))[?]) AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1
 -- seed --
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),
     Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES


### PR DESCRIPTION
## Summary

Loki's stream-identity contract surfaces `detected_level` as a structural label whenever the upstream row carries severity metadata. Cerberus previously collapsed every level into a single stream/series — surfacing as **16 `matrix length: expected=4 actual=1` + 3 `streams length: expected=4 actual=1`** failures in the loki-compat harness (~28.26% pass rate).

This change folds `detected_level` into the row's label map at two points:

- **Log-stream queries** (`Lang.ProjectSamples` log branch): wrap the `Attributes` column in `mapConcat(RA, mapFilter((k,v) -> v != '', map('detected_level', multiIf(SeverityText...))))` so `toStreamsWithTransform`'s `CanonicalKey`-based grouping splits the streams response into one `Stream` per distinct severity.
- **Bare range aggregations** (`lowerRangeAggregation`, no `by/without`): the inner `Project`'s identity projection emits the same `mapConcat` shape aliased back to `ResourceAttributes`. The `RangeWindow`'s `GROUP BY` then collapses one row per `(stream, detected_level)` tuple — matching upstream Loki's matrix shape.

`by(...)` / `without(...)` clauses are untouched: user-specified grouping is authoritative and `detected_level` is **not** auto-injected over an explicit clause.

The `mapFilter((k, v) -> v != '', ...)` wrap drops the `detected_level` key when `SeverityText` is empty, so rows without severity-bearing columns don't gain a spurious empty-string label.

## Root cause

`lowerRangeAggregation` previously projected the raw `ResourceAttributes` column as the per-stream identity, so the `RangeWindow`'s `GROUP BY ResourceAttributes` produced one row per stream — collapsing all 4 severities into a single series. `Lang.ProjectSamples` mirrored that on the log branch (bare `ColumnRef` to `ResourceAttributesColumn`).

Loki's `field_detection.go::extractLogLevel` derives `detected_level` from the row's `SeverityText` (step 2 in its layered detection) and treats it as part of stream identity. Cerberus's `internal/logql/detected_level.go` already had a `multiIf(...)` normalisation expression (used by the `| detected_level=\"error\"` filter in #13); this PR plumbs that expression into the per-row label map at the two points above.

## Files touched

- `internal/logql/detected_level.go` — new `withDetectedLevel(s, baseLabels)` helper (`mapConcat` + `mapFilter` + the existing `multiIf`).
- `internal/logql/lang.go` — log-stream `Attributes` projection wraps via `withDetectedLevel`.
- `internal/logql/range_aggregation.go` — bare-range identity projection wraps via `withDetectedLevel`; `by/without` clauses unchanged.
- `internal/logql/lang_test.go` — new `TestProjectSamples_LogQuerySurfacesDetectedLevel` pins the wrap shape so a regression that reverts to a bare `ColumnRef` is caught locally rather than via the compat harness.
- `internal/logql/lower_bench_test.go` — `metric_form` alloc ceiling lifted 80 → 100 (the `mapConcat`/`mapFilter`/`multiIf` nodes add ~12 allocs to every bare range aggregation lowering).
- `test/property/oracle/logql/evaluator.go` — parallel `normaliseLogLevel` helper so the property-test oracle's row shape matches cerberus's wire output. (Initial run without this update surfaced a `property drift` failure — the oracle hadn't yet been taught about `detected_level`. After the oracle update the property test passes.)
- `test/spec/logql/*.txtar` — 36 fixtures' seed `CREATE TABLE` extended with `SeverityText LowCardinality(String) DEFAULT ''`; `sql` / `args` / `chplan` regenerated via `GOLDEN_UPDATE=1`. `expected_rows` stays stable because `mapFilter` drops the empty-severity entry.
- `test/spec/logql/count_over_time_detected_level.txtar` — new fixture demonstrating the 4-series-per-level shape end-to-end on a multi-severity seed.

## Expected compatibility delta

- Loki compat: **~28.26% → ~70%+** (16 metric + 3 streams cases unblocked).

## Test plan

- [x] `go test ./internal/logql/... ./internal/api/loki/...` green (264 + 205 passing).
- [x] `go test -tags=chdb ./...` — 4089 tests passing after the oracle update (all chDB-roundtripped TXTAR fixtures execute correctly against an in-process chDB session; property test passes with the synchronised oracle).
- [x] New `count_over_time_detected_level.txtar` fixture's chDB roundtrip produces 4 series on the multi-severity seed.
- [x] New `TestProjectSamples_LogQuerySurfacesDetectedLevel` unit test pins the wrap shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)