### PR TITLE
fix(api/tempo): emit trace duration in spanset-aggregate TraceSummary.durationMs

### DIFF
--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -438,6 +438,17 @@ const (
 	// traceByIDKeyParentSpanID slot — same constant value, same
 	// namespace; the two paths never overlap.
 	searchKeyParentSpanID = traceByIDKeyParentSpanID
+	// searchKeyTraceDurationNs is the reserved Labels key carrying
+	// the **whole-trace** wall-clock duration in nanoseconds. The
+	// spanset-aggregate wrap-projection populates it as
+	// `TraceEndNs - TraceStartNs` (see
+	// spansetAggregateSampleProjections); toTraceSummaries reads it
+	// and surfaces durationMs = ns / 1e6 so the response matches
+	// Tempo's wire spec, which reports the trace-wide span — not the
+	// matched row's own Duration column. Non-aggregate paths leave
+	// the slot empty and fall back to chclient.Sample.Value (the
+	// per-row Duration), preserving the historical shape.
+	searchKeyTraceDurationNs = "__cerberus_traceDurationNs"
 )
 
 // wrapWithSampleProjection adds a Project on top of plan that emits
@@ -796,12 +807,14 @@ func aggregateCarriesSpansetEnvelope(a *chplan.Aggregate) bool {
 // when the plan root is the per-trace spanset Aggregate shape
 // produced by internal/traceql/aggregate.go. The inner Aggregate
 // already emits the per-trace envelope columns (MetricName,
-// ResourceAttrs, TimeUnix) alongside (TraceId, Value); this outer
-// Project merges the TraceId into Attributes via the
-// `__cerberus_traceID` reserved-key pattern and casts Value to
-// float64 — same wire shape as canonicalSampleProjections but
-// reading from the Aggregate's projected columns rather than the
-// raw spans-table columns.
+// ResourceAttrs, TimeUnix) alongside (TraceId, Value, TraceStartNs,
+// TraceEndNs); this outer Project merges TraceId into Attributes via
+// the `__cerberus_traceID` reserved-key pattern, threads the derived
+// whole-trace duration `(TraceEndNs - TraceStartNs)` via
+// `__cerberus_traceDurationNs`, and casts Value to float64 — same
+// wire shape as canonicalSampleProjections but reading from the
+// Aggregate's projected columns rather than the raw spans-table
+// columns.
 //
 // The `TraceId` column the inner Aggregate exposes is the raw
 // fixed-width OTel-CH value (32 lowercase-hex chars); Tempo's wire
@@ -812,10 +825,28 @@ func aggregateCarriesSpansetEnvelope(a *chplan.Aggregate) bool {
 // Tempo's `af…66b`, generating spurious missing_in_a / missing_in_b
 // reasons across the spanset-aggregate compat cases (e.g.
 // `avg_duration_per_trace_status_ok`).
+//
+// Tempo's /api/search wire spec reports `durationMs` as the
+// **whole-trace** wall-clock span (max-end minus min-start across
+// every span in the trace), not the matched span's per-row Duration.
+// Surfacing the derived `TraceEndNs - TraceStartNs` via the reserved
+// `__cerberus_traceDurationNs` slot lets toTraceSummaries report the
+// trace-wide duration while keeping the non-aggregate path's
+// per-row-Duration semantics intact (the slot is absent there, so
+// the shaper falls back to Sample.Value).
 func spansetAggregateSampleProjections() []chplan.Projection {
+	traceDurationNs := &chplan.Binary{
+		Op:    chplan.OpSub,
+		Left:  &chplan.ColumnRef{Name: "TraceEndNs"},
+		Right: &chplan.ColumnRef{Name: "TraceStartNs"},
+	}
 	traceIDMap := &chplan.FuncCall{Name: "map", Args: []chplan.Expr{
 		&chplan.LitString{V: searchKeyTraceID},
 		stripLeadingHexZeros("TraceId"),
+		&chplan.LitString{V: searchKeyTraceDurationNs},
+		// toString keeps the merged Map(String,String) homogeneous;
+		// the shaper parses the int back out on the Go side.
+		&chplan.FuncCall{Name: "toString", Args: []chplan.Expr{traceDurationNs}},
 	}}
 	mergedAttrs := &chplan.FuncCall{Name: "mapConcat", Args: []chplan.Expr{
 		&chplan.ColumnRef{Name: "ResourceAttrs"},
@@ -832,12 +863,15 @@ func spansetAggregateSampleProjections() []chplan.Projection {
 // toTraceSummaries pivots samples into the per-trace summary shape
 // Tempo's /api/search returns. Each unique TraceID becomes one
 // summary; StartTimeUnixNano is the earliest span timestamp seen and
-// DurationMs is the max span duration (a coarse proxy until per-trace
-// aggregate plumbing lands).
+// DurationMs reports the **whole-trace** wall-clock span (max-end
+// minus min-start across every span in the trace) for the
+// spanset-aggregate path, falling back to the max per-row Sample.Value
+// when the reserved `__cerberus_traceDurationNs` slot is absent (non-
+// aggregate /api/search rows, older fixtures, stub queriers).
 //
 // chclient.Sample's MetricName carries SpanName here (per the wrap
 // projection above) and Attributes carries ResourceAttributes plus
-// two reserved entries:
+// three reserved entries:
 //   - `__cerberus_traceID` (searchKeyTraceID) — the grouping key so
 //     multi-span traces collapse into one summary row.
 //   - `__cerberus_parentSpanID` (searchKeyParentSpanID) — used to
@@ -845,6 +879,11 @@ func spansetAggregateSampleProjections() []chplan.Projection {
 //     rootServiceName / rootTraceName on the span at the top of the
 //     trace tree, where ParentSpanId is empty/unset, not whichever
 //     span the underlying engine happens to return first).
+//   - `__cerberus_traceDurationNs` (searchKeyTraceDurationNs) — the
+//     derived whole-trace duration (`max(span.end) - min(span.start)`)
+//     in nanoseconds, populated by spansetAggregateSampleProjections.
+//     Matches Tempo's /api/search wire spec for durationMs: a
+//     trace-wide span, not the matched row's own Duration.
 //
 // Root-span resolution:
 //   - Prefer the row where ParentSpanId == "" (the actual root). Among
@@ -880,6 +919,12 @@ func toTraceSummaries(samples []chclient.Sample) []TraceSummary {
 		earliestStartNS int64
 		// hasRoot is true once we've seen a span with ParentSpanId == "".
 		hasRoot bool
+		// hasTraceDurationNs is set the first time a row supplies the
+		// `__cerberus_traceDurationNs` reserved-key entry. Once true,
+		// `durationNS` carries the trace-wide span and per-row Sample.
+		// Value contributions are ignored — they would otherwise pull
+		// the value back to the max single-span duration.
+		hasTraceDurationNs bool
 	}
 	byTrace := map[string]*acc{}
 	for _, s := range samples {
@@ -900,7 +945,18 @@ func toTraceSummaries(samples []chclient.Sample) []TraceSummary {
 		if a.startNS == 0 || ns < a.startNS {
 			a.startNS = ns
 		}
-		if int64(s.Value) > a.durationNS {
+		// Whole-trace duration takes precedence when the wrap-projection
+		// surfaced one. The spanset-aggregate path emits a single row
+		// per trace so we just overwrite; the guard against per-row-
+		// Duration fallback ensures a mixed-shape stream (older fixture
+		// rows + aggregate rows on the same trace) doesn't pull the
+		// value down to a single span's max.
+		if v, ok := s.Labels[searchKeyTraceDurationNs]; ok && v != "" {
+			if ns, err := strconv.ParseInt(v, 10, 64); err == nil && ns >= 0 {
+				a.durationNS = ns
+				a.hasTraceDurationNs = true
+			}
+		} else if !a.hasTraceDurationNs && int64(s.Value) > a.durationNS {
 			a.durationNS = int64(s.Value)
 		}
 

--- a/internal/api/tempo/handler_test.go
+++ b/internal/api/tempo/handler_test.go
@@ -574,6 +574,164 @@ func TestSearch_SpansetAggregate_PerTrace(t *testing.T) {
 	}
 }
 
+// TestSearch_SpansetAggregate_DurationMsReflectsWholeTrace pins the
+// Tempo wire spec: /api/search's `durationMs` is the **whole-trace**
+// wall-clock span (`max(span.end) - min(span.start)` across every
+// span in the trace), not the matched span's per-row Duration. The
+// spanset-aggregate wrap-projection threads the derived value via
+// the reserved `__cerberus_traceDurationNs` label slot so
+// toTraceSummaries reports it verbatim — matching Tempo for the
+// count_spans_per_trace + avg_duration_per_trace_status_ok compat
+// cases (each ~100 rows of per-trace samples).
+//
+// Pre-fix shape: durationMs = max(per-row Duration) which on a
+// multi-span trace under-reports vs Tempo's actual root-span span;
+// for `| count()` the per-row Value is the count integer and the
+// shaper effectively reported 0ms.
+func TestSearch_SpansetAggregate_DurationMsReflectsWholeTrace(t *testing.T) {
+	t.Parallel()
+	const traceID = "1131bf7acf51ccb10aef0ec7e31bf71f"
+	// One row per trace (the spanset-aggregate inner SELECT collapses
+	// all spans of a trace into one row), carrying the derived
+	// __cerberus_traceDurationNs = 150_000_000 ns (= 150 ms).
+	q := &stubQuerier{
+		samples: []chclient.Sample{
+			{
+				MetricName: "POST /api/orders",
+				Labels: map[string]string{
+					"service.name":               "checkout",
+					"__cerberus_traceID":         traceID,
+					"__cerberus_traceDurationNs": "150000000",
+				},
+				Timestamp: time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC),
+				// Value carries the aggregate (count=3) — must NOT bleed
+				// into durationMs once the reserved-key slot is present.
+				Value: 3,
+			},
+		},
+	}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/search?q=%7B%7D%20%7C%20count%28%29%20%3E%200")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	var sr tempo.SearchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&sr); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(sr.Traces) != 1 {
+		t.Fatalf("expected 1 trace, got %d", len(sr.Traces))
+	}
+	if got := sr.Traces[0].DurationMs; got != 150 {
+		t.Errorf("DurationMs: got %d, want 150 (trace-wide ns / 1e6, not per-row Sample.Value=3)", got)
+	}
+	if got := sr.Traces[0].TraceID; got != traceID {
+		t.Errorf("TraceID: got %q, want %q", got, traceID)
+	}
+}
+
+// TestSearch_SpansetAggregate_DurationMsMultiSpanReplaysAggregate
+// stress-tests the multi-row shape: when the stub returns multiple
+// rows for the same trace (spanset-aggregate today emits one row
+// per trace but the shaper must be resilient if a future projection
+// duplicates rows), the trace-duration reserved slot overrides the
+// per-row Sample.Value fallback regardless of arrival order.
+func TestSearch_SpansetAggregate_DurationMsMultiSpanReplaysAggregate(t *testing.T) {
+	t.Parallel()
+	const traceID = "118b9e55fa97da56152b463462b61607"
+	q := &stubQuerier{
+		samples: []chclient.Sample{
+			// First row — no reserved slot (older fixture / partial
+			// projection). The shaper picks up Sample.Value (50 ns).
+			{
+				MetricName: "GET /a",
+				Labels: map[string]string{
+					"service.name":       "checkout",
+					"__cerberus_traceID": traceID,
+				},
+				Timestamp: time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC),
+				Value:     50_000_000,
+			},
+			// Second row — carries the derived trace-wide duration.
+			// Must overwrite the Sample.Value-based pick from row 1.
+			{
+				MetricName: "GET /a",
+				Labels: map[string]string{
+					"service.name":               "checkout",
+					"__cerberus_traceID":         traceID,
+					"__cerberus_traceDurationNs": "150000000",
+				},
+				Timestamp: time.Date(2026, 5, 12, 10, 0, 1, 0, time.UTC),
+				Value:     2,
+			},
+		},
+	}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/search?q=%7B%7D")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	var sr tempo.SearchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&sr); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(sr.Traces) != 1 {
+		t.Fatalf("expected 1 trace, got %d", len(sr.Traces))
+	}
+	if got := sr.Traces[0].DurationMs; got != 150 {
+		t.Errorf("DurationMs: got %d, want 150 (reserved-slot wins over Sample.Value fallback)", got)
+	}
+}
+
+// TestSearch_SpansetAggregate_SQLProjectsTraceDurationNs pins the
+// SQL emitted by the spanset-aggregate path: the inner Aggregate
+// must surface `TraceStartNs` + `TraceEndNs` aliases and the outer
+// wrap-projection must merge their difference into Attributes via
+// the `__cerberus_traceDurationNs` reserved key. Without this
+// substring pin a regression in either the aggregate lowering or
+// the wrap projection would silently drop the trace-wide duration.
+func TestSearch_SpansetAggregate_SQLProjectsTraceDurationNs(t *testing.T) {
+	t.Parallel()
+	q := &stubQuerier{}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	// `{ resource.service.name = "frontend" } | count() > 0`
+	resp, err := http.Get(srv.URL + "/api/search?q=%7B%20resource.service.name%20%3D%20%22frontend%22%20%7D%20%7C%20count%28%29%20%3E%200")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	// Inner aggregate must surface the two new aliases.
+	if !strings.Contains(q.lastSQL, "TraceStartNs") {
+		t.Errorf("emitted SQL must project TraceStartNs aggregate; got %s", q.lastSQL)
+	}
+	if !strings.Contains(q.lastSQL, "TraceEndNs") {
+		t.Errorf("emitted SQL must project TraceEndNs aggregate; got %s", q.lastSQL)
+	}
+	// Outer wrap must thread the derived duration through the
+	// reserved-key slot.
+	var sawDurationKey bool
+	for _, a := range q.lastArgs {
+		if s, ok := a.(string); ok && s == "__cerberus_traceDurationNs" {
+			sawDurationKey = true
+			break
+		}
+	}
+	if !sawDurationKey {
+		t.Errorf("emitted SQL args must include reserved __cerberus_traceDurationNs slot; got args=%v", q.lastArgs)
+	}
+}
+
 // isHexLower reports whether s is a non-empty lowercase hex string.
 // The OTel CH exporter writes TraceId via hex.EncodeToString, which
 // produces lowercase a-f digits.

--- a/internal/traceql/aggregate.go
+++ b/internal/traceql/aggregate.go
@@ -40,6 +40,15 @@ const (
 	aggMetricNameAlias    = "MetricName"
 	aggResourceAttrsAlias = "ResourceAttrs"
 	aggTimeUnixAlias      = "TimeUnix"
+	// aggTraceStartNsAlias / aggTraceEndNsAlias name the two per-trace
+	// timestamp aggregates used to derive the per-trace duration. Tempo's
+	// /api/search returns `durationMs` as the **whole-trace** wall-clock
+	// span — `max(span.end) - min(span.start)` across every span in the
+	// trace — not the matched span's own duration. The shaper subtracts
+	// the two aliases in the wrap-projection layer (see
+	// internal/api/tempo/handler.go: spansetAggregateSampleProjections).
+	aggTraceStartNsAlias = "TraceStartNs"
+	aggTraceEndNsAlias   = "TraceEndNs"
 )
 
 // lowerAggregate handles `| count()`, `| sum(...)`, `| avg(...)`,
@@ -101,8 +110,69 @@ func lowerAggregate(prev chplan.Node, agg traceql.Aggregate, s schema.Traces) (c
 		Input:          prev,
 		GroupBy:        []chplan.Expr{&chplan.ColumnRef{Name: s.TraceIDColumn}},
 		GroupByAliases: []string{aggTraceIDAlias},
-		AggFuncs:       []chplan.AggFunc{valueFunc, anyAggFunc(s.SpanNameColumn, aggMetricNameAlias), anyAggFunc(s.ResourceAttributesColumn, aggResourceAttrsAlias), minAggFunc(s.TimestampColumn, aggTimeUnixAlias)},
+		AggFuncs: []chplan.AggFunc{
+			valueFunc,
+			anyAggFunc(s.SpanNameColumn, aggMetricNameAlias),
+			anyAggFunc(s.ResourceAttributesColumn, aggResourceAttrsAlias),
+			minAggFunc(s.TimestampColumn, aggTimeUnixAlias),
+			traceStartNsAggFunc(s.TimestampColumn),
+			traceEndNsAggFunc(s.TimestampColumn, s.DurationColumn),
+		},
 	}, nil
+}
+
+// traceStartNsAggFunc returns `min(toUnixTimestamp64Nano(<Timestamp>))
+// AS TraceStartNs` — the earliest span-start across the trace, in
+// nanoseconds since the Unix epoch. Paired with traceEndNsAggFunc so
+// the wrap-projection can derive the per-trace wall-clock duration
+// (max(end) - min(start)) for Tempo's `durationMs` field.
+//
+// The cast to Int64 ns is what lets the difference fall out as a
+// plain integer — `min(Timestamp)` returns DateTime64 and the typed
+// chplan Binary lacks an interval-aware subtraction, so we project
+// the value as nanoseconds up-front.
+func traceStartNsAggFunc(timestampColumn string) chplan.AggFunc {
+	return chplan.AggFunc{
+		Name: "min",
+		Args: []chplan.Expr{
+			&chplan.FuncCall{
+				Name: "toUnixTimestamp64Nano",
+				Args: []chplan.Expr{&chplan.ColumnRef{Name: timestampColumn}},
+			},
+		},
+		Alias: aggTraceStartNsAlias,
+	}
+}
+
+// traceEndNsAggFunc returns `max(toUnixTimestamp64Nano(<Timestamp>) +
+// toInt64(<Duration>)) AS TraceEndNs` — the latest span-end across
+// the trace, in nanoseconds since the Unix epoch. The OTel-CH
+// `Duration` column is UInt64 nanoseconds; coercing to Int64 keeps
+// the sum Int64 so CH does not promote to a wider unsigned type that
+// `min(...)` would refuse to subtract.
+//
+// Pairing this with traceStartNsAggFunc lets the wrap-projection
+// derive the per-trace wall-clock duration as the simple integer
+// difference `TraceEndNs - TraceStartNs` (see
+// internal/api/tempo/handler.go: spansetAggregateSampleProjections).
+func traceEndNsAggFunc(timestampColumn, durationColumn string) chplan.AggFunc {
+	return chplan.AggFunc{
+		Name: "max",
+		Args: []chplan.Expr{
+			&chplan.Binary{
+				Op: chplan.OpAdd,
+				Left: &chplan.FuncCall{
+					Name: "toUnixTimestamp64Nano",
+					Args: []chplan.Expr{&chplan.ColumnRef{Name: timestampColumn}},
+				},
+				Right: &chplan.FuncCall{
+					Name: "toInt64",
+					Args: []chplan.Expr{&chplan.ColumnRef{Name: durationColumn}},
+				},
+			},
+		},
+		Alias: aggTraceEndNsAlias,
+	}
 }
 
 // anyAggFunc returns an `any(<col>) AS <alias>` AggFunc — the

--- a/test/spec/traceql/avg_duration.txtar
+++ b/test/spec/traceql/avg_duration.txtar
@@ -19,12 +19,12 @@ INSERT INTO otel_traces VALUES
 [2] int64 = 50000000
 -- chplan --
 Filter predicate=(Value > 50000000)
-  Aggregate groupBy=[TraceId AS TraceId] funcs=[avg(Duration) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix]
+  Aggregate groupBy=[TraceId AS TraceId] funcs=[avg(Duration) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix, min(toUnixTimestamp64Nano(Timestamp)) AS TraceStartNs, max((toUnixTimestamp64Nano(Timestamp) + toInt64(Duration))) AS TraceEndNs]
     Filter predicate=(ResourceAttributes["service.name"] = "frontend")
       Scan(otel_traces)
 -- sql --
-SELECT * FROM (SELECT `TraceId` AS `TraceId`, avg(`Duration`) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) GROUP BY `TraceId`) WHERE (`Value` > ?)
+SELECT * FROM (SELECT `TraceId` AS `TraceId`, avg(`Duration`) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix`, min(toUnixTimestamp64Nano(`Timestamp`)) AS `TraceStartNs`, max((toUnixTimestamp64Nano(`Timestamp`) + toInt64(`Duration`))) AS `TraceEndNs` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) GROUP BY `TraceId`) WHERE (`Value` > ?)
 -- expected_rows --
 [
-  ["t1", 80000000, "span", {"service.name": "frontend"}, "2024-01-01T00:00:00Z"]
+  ["t1", 80000000, "span", {"service.name": "frontend"}, "2024-01-01T00:00:00Z", 1704067200000000000, 1704067202100000000]
 ]

--- a/test/spec/traceql/count.txtar
+++ b/test/spec/traceql/count.txtar
@@ -5,12 +5,13 @@ CREATE TABLE otel_traces (
     TraceId String,
     SpanName String,
     Timestamp DateTime64(9),
-    ResourceAttributes Map(String, String)
+    ResourceAttributes Map(String, String),
+    Duration UInt64
 ) ENGINE = Memory;
 INSERT INTO otel_traces VALUES
-    ('t1', 'span', toDateTime64('2024-01-01 00:00:00', 9), map('service.name', 'backend')),
-    ('t2', 'span', toDateTime64('2024-01-01 00:00:01', 9), map('service.name', 'db')),
-    ('t3', 'span', toDateTime64('2024-01-01 00:00:02', 9), map('service.name', 'cache'));
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:00', 9), map('service.name', 'backend'), 10000000),
+    ('t2', 'span', toDateTime64('2024-01-01 00:00:01', 9), map('service.name', 'db'),      20000000),
+    ('t3', 'span', toDateTime64('2024-01-01 00:00:02', 9), map('service.name', 'cache'),   30000000);
 -- args --
 [0] int64 = 1
 [1] string = "service.name"
@@ -18,10 +19,10 @@ INSERT INTO otel_traces VALUES
 [3] int64 = 0
 -- chplan --
 Filter predicate=(Value > 0)
-  Aggregate groupBy=[TraceId AS TraceId] funcs=[count(1) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix]
+  Aggregate groupBy=[TraceId AS TraceId] funcs=[count(1) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix, min(toUnixTimestamp64Nano(Timestamp)) AS TraceStartNs, max((toUnixTimestamp64Nano(Timestamp) + toInt64(Duration))) AS TraceEndNs]
     Filter predicate=(ResourceAttributes["service.name"] = "frontend")
       Scan(otel_traces)
 -- sql --
-SELECT * FROM (SELECT `TraceId` AS `TraceId`, toFloat64(count(?)) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) GROUP BY `TraceId`) WHERE (`Value` > ?)
+SELECT * FROM (SELECT `TraceId` AS `TraceId`, toFloat64(count(?)) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix`, min(toUnixTimestamp64Nano(`Timestamp`)) AS `TraceStartNs`, max((toUnixTimestamp64Nano(`Timestamp`) + toInt64(`Duration`))) AS `TraceEndNs` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) GROUP BY `TraceId`) WHERE (`Value` > ?)
 -- expected_rows --
 []

--- a/test/spec/traceql/count_eq_zero.txtar
+++ b/test/spec/traceql/count_eq_zero.txtar
@@ -5,12 +5,13 @@ CREATE TABLE otel_traces (
     TraceId String,
     SpanName String,
     Timestamp DateTime64(9),
-    ResourceAttributes Map(String, String)
+    ResourceAttributes Map(String, String),
+    Duration UInt64
 ) ENGINE = Memory;
 INSERT INTO otel_traces VALUES
-    ('t1', 'span', toDateTime64('2024-01-01 00:00:00', 9), map('service.name', 'frontend')),
-    ('t2', 'span', toDateTime64('2024-01-01 00:00:01', 9), map('service.name', 'frontend')),
-    ('t3', 'span', toDateTime64('2024-01-01 00:00:02', 9), map('service.name', 'backend'));
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:00', 9), map('service.name', 'frontend'), 10000000),
+    ('t2', 'span', toDateTime64('2024-01-01 00:00:01', 9), map('service.name', 'frontend'), 20000000),
+    ('t3', 'span', toDateTime64('2024-01-01 00:00:02', 9), map('service.name', 'backend'),  30000000);
 -- args --
 [0] int64 = 1
 [1] string = "service.name"
@@ -18,10 +19,10 @@ INSERT INTO otel_traces VALUES
 [3] int64 = 0
 -- chplan --
 Filter predicate=(Value = 0)
-  Aggregate groupBy=[TraceId AS TraceId] funcs=[count(1) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix]
+  Aggregate groupBy=[TraceId AS TraceId] funcs=[count(1) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix, min(toUnixTimestamp64Nano(Timestamp)) AS TraceStartNs, max((toUnixTimestamp64Nano(Timestamp) + toInt64(Duration))) AS TraceEndNs]
     Filter predicate=(ResourceAttributes["service.name"] = "frontend")
       Scan(otel_traces)
 -- sql --
-SELECT * FROM (SELECT `TraceId` AS `TraceId`, toFloat64(count(?)) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) GROUP BY `TraceId`) WHERE (`Value` = ?)
+SELECT * FROM (SELECT `TraceId` AS `TraceId`, toFloat64(count(?)) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix`, min(toUnixTimestamp64Nano(`Timestamp`)) AS `TraceStartNs`, max((toUnixTimestamp64Nano(`Timestamp`) + toInt64(`Duration`))) AS `TraceEndNs` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) GROUP BY `TraceId`) WHERE (`Value` = ?)
 -- expected_rows --
 []

--- a/test/spec/traceql/count_ge_threshold.txtar
+++ b/test/spec/traceql/count_ge_threshold.txtar
@@ -5,13 +5,14 @@ CREATE TABLE otel_traces (
     TraceId String,
     SpanName String,
     Timestamp DateTime64(9),
-    ResourceAttributes Map(String, String)
+    ResourceAttributes Map(String, String),
+    Duration UInt64
 ) ENGINE = Memory;
 INSERT INTO otel_traces VALUES
-    ('t1', 'span', toDateTime64('2024-01-01 00:00:00', 9), map('service.name', 'frontend')),
-    ('t1', 'span', toDateTime64('2024-01-01 00:00:01', 9), map('service.name', 'frontend')),
-    ('t1', 'span', toDateTime64('2024-01-01 00:00:02', 9), map('service.name', 'frontend')),
-    ('t2', 'span', toDateTime64('2024-01-01 00:00:03', 9), map('service.name', 'backend'));
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:00', 9), map('service.name', 'frontend'), 10000000),
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:01', 9), map('service.name', 'frontend'), 20000000),
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:02', 9), map('service.name', 'frontend'), 30000000),
+    ('t2', 'span', toDateTime64('2024-01-01 00:00:03', 9), map('service.name', 'backend'),  40000000);
 -- args --
 [0] int64 = 1
 [1] string = "service.name"
@@ -19,10 +20,10 @@ INSERT INTO otel_traces VALUES
 [3] int64 = 5
 -- chplan --
 Filter predicate=(Value >= 5)
-  Aggregate groupBy=[TraceId AS TraceId] funcs=[count(1) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix]
+  Aggregate groupBy=[TraceId AS TraceId] funcs=[count(1) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix, min(toUnixTimestamp64Nano(Timestamp)) AS TraceStartNs, max((toUnixTimestamp64Nano(Timestamp) + toInt64(Duration))) AS TraceEndNs]
     Filter predicate=(ResourceAttributes["service.name"] = "frontend")
       Scan(otel_traces)
 -- sql --
-SELECT * FROM (SELECT `TraceId` AS `TraceId`, toFloat64(count(?)) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) GROUP BY `TraceId`) WHERE (`Value` >= ?)
+SELECT * FROM (SELECT `TraceId` AS `TraceId`, toFloat64(count(?)) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix`, min(toUnixTimestamp64Nano(`Timestamp`)) AS `TraceStartNs`, max((toUnixTimestamp64Nano(`Timestamp`) + toInt64(`Duration`))) AS `TraceEndNs` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) GROUP BY `TraceId`) WHERE (`Value` >= ?)
 -- expected_rows --
 []

--- a/test/spec/traceql/count_lt_threshold.txtar
+++ b/test/spec/traceql/count_lt_threshold.txtar
@@ -5,15 +5,16 @@ CREATE TABLE otel_traces (
     TraceId String,
     SpanName String,
     Timestamp DateTime64(9),
-    ResourceAttributes Map(String, String)
+    ResourceAttributes Map(String, String),
+    Duration UInt64
 ) ENGINE = Memory;
 INSERT INTO otel_traces VALUES
-    ('t1', 'span', toDateTime64('2024-01-01 00:00:00', 9), map('service.name', 'frontend')),
-    ('t1', 'span', toDateTime64('2024-01-01 00:00:01', 9), map('service.name', 'frontend')),
-    ('t1', 'span', toDateTime64('2024-01-01 00:00:02', 9), map('service.name', 'frontend')),
-    ('t2', 'span', toDateTime64('2024-01-01 00:00:03', 9), map('service.name', 'frontend')),
-    ('t2', 'span', toDateTime64('2024-01-01 00:00:04', 9), map('service.name', 'frontend')),
-    ('t3', 'span', toDateTime64('2024-01-01 00:00:05', 9), map('service.name', 'backend'));
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:00', 9), map('service.name', 'frontend'), 10000000),
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:01', 9), map('service.name', 'frontend'), 20000000),
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:02', 9), map('service.name', 'frontend'), 30000000),
+    ('t2', 'span', toDateTime64('2024-01-01 00:00:03', 9), map('service.name', 'frontend'), 10000000),
+    ('t2', 'span', toDateTime64('2024-01-01 00:00:04', 9), map('service.name', 'frontend'), 20000000),
+    ('t3', 'span', toDateTime64('2024-01-01 00:00:05', 9), map('service.name', 'backend'),  10000000);
 -- args --
 [0] int64 = 1
 [1] string = "service.name"
@@ -21,13 +22,13 @@ INSERT INTO otel_traces VALUES
 [3] int64 = 10
 -- chplan --
 Filter predicate=(Value < 10)
-  Aggregate groupBy=[TraceId AS TraceId] funcs=[count(1) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix]
+  Aggregate groupBy=[TraceId AS TraceId] funcs=[count(1) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix, min(toUnixTimestamp64Nano(Timestamp)) AS TraceStartNs, max((toUnixTimestamp64Nano(Timestamp) + toInt64(Duration))) AS TraceEndNs]
     Filter predicate=(ResourceAttributes["service.name"] = "frontend")
       Scan(otel_traces)
 -- sql --
-SELECT * FROM (SELECT `TraceId` AS `TraceId`, toFloat64(count(?)) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) GROUP BY `TraceId`) WHERE (`Value` < ?)
+SELECT * FROM (SELECT `TraceId` AS `TraceId`, toFloat64(count(?)) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix`, min(toUnixTimestamp64Nano(`Timestamp`)) AS `TraceStartNs`, max((toUnixTimestamp64Nano(`Timestamp`) + toInt64(`Duration`))) AS `TraceEndNs` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) GROUP BY `TraceId`) WHERE (`Value` < ?)
 -- expected_rows --
 [
-  ["t1", 3, "span", {"service.name": "frontend"}, "2024-01-01T00:00:00Z"],
-  ["t2", 2, "span", {"service.name": "frontend"}, "2024-01-01T00:00:03Z"]
+  ["t1", 3, "span", {"service.name": "frontend"}, "2024-01-01T00:00:00Z", 1704067200000000000, 1704067202030000000],
+  ["t2", 2, "span", {"service.name": "frontend"}, "2024-01-01T00:00:03Z", 1704067203000000000, 1704067204020000000]
 ]

--- a/test/spec/traceql/count_per_trace.txtar
+++ b/test/spec/traceql/count_per_trace.txtar
@@ -5,15 +5,16 @@ CREATE TABLE otel_traces (
     TraceId String,
     SpanName String,
     Timestamp DateTime64(9),
-    ResourceAttributes Map(String, String)
+    ResourceAttributes Map(String, String),
+    Duration UInt64
 ) ENGINE = Memory;
 INSERT INTO otel_traces VALUES
-    ('t1', 'GET /a', toDateTime64('2024-01-01 00:00:00', 9), map('service.name', 'frontend')),
-    ('t1', 'GET /a', toDateTime64('2024-01-01 00:00:01', 9), map('service.name', 'frontend')),
-    ('t1', 'db.query', toDateTime64('2024-01-01 00:00:02', 9), map('service.name', 'backend')),
-    ('t2', 'GET /b', toDateTime64('2024-01-01 00:00:03', 9), map('service.name', 'checkout')),
-    ('t2', 'cache.get', toDateTime64('2024-01-01 00:00:04', 9), map('service.name', 'cache')),
-    ('t3', 'POST /c', toDateTime64('2024-01-01 00:00:05', 9), map('service.name', 'orders'));
+    ('t1', 'GET /a',    toDateTime64('2024-01-01 00:00:00', 9), map('service.name', 'frontend'), 10000000),
+    ('t1', 'GET /a',    toDateTime64('2024-01-01 00:00:01', 9), map('service.name', 'frontend'), 20000000),
+    ('t1', 'db.query',  toDateTime64('2024-01-01 00:00:02', 9), map('service.name', 'backend'),  30000000),
+    ('t2', 'GET /b',    toDateTime64('2024-01-01 00:00:03', 9), map('service.name', 'checkout'), 10000000),
+    ('t2', 'cache.get', toDateTime64('2024-01-01 00:00:04', 9), map('service.name', 'cache'),    20000000),
+    ('t3', 'POST /c',   toDateTime64('2024-01-01 00:00:05', 9), map('service.name', 'orders'),   10000000);
 -- args --
 [0] int64 = 1
 [1] string = "service.name"
@@ -21,14 +22,14 @@ INSERT INTO otel_traces VALUES
 [3] int64 = 0
 -- chplan --
 Filter predicate=(Value > 0)
-  Aggregate groupBy=[TraceId AS TraceId] funcs=[count(1) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix]
+  Aggregate groupBy=[TraceId AS TraceId] funcs=[count(1) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix, min(toUnixTimestamp64Nano(Timestamp)) AS TraceStartNs, max((toUnixTimestamp64Nano(Timestamp) + toInt64(Duration))) AS TraceEndNs]
     Filter predicate=(ResourceAttributes["service.name"] =~ ".+")
       Scan(otel_traces)
 -- sql --
-SELECT * FROM (SELECT `TraceId` AS `TraceId`, toFloat64(count(?)) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix` FROM (SELECT * FROM `otel_traces` WHERE match(`ResourceAttributes`[?], ?)) GROUP BY `TraceId`) WHERE (`Value` > ?)
+SELECT * FROM (SELECT `TraceId` AS `TraceId`, toFloat64(count(?)) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix`, min(toUnixTimestamp64Nano(`Timestamp`)) AS `TraceStartNs`, max((toUnixTimestamp64Nano(`Timestamp`) + toInt64(`Duration`))) AS `TraceEndNs` FROM (SELECT * FROM `otel_traces` WHERE match(`ResourceAttributes`[?], ?)) GROUP BY `TraceId`) WHERE (`Value` > ?)
 -- expected_rows --
 [
-  ["t1", 3, "GET /a", {"service.name": "frontend"}, "2024-01-01T00:00:00Z"],
-  ["t2", 2, "GET /b", {"service.name": "checkout"}, "2024-01-01T00:00:03Z"],
-  ["t3", 1, "POST /c", {"service.name": "orders"}, "2024-01-01T00:00:05Z"]
+  ["t1", 3, "GET /a", {"service.name": "frontend"}, "2024-01-01T00:00:00Z", 1704067200000000000, 1704067202030000000],
+  ["t2", 2, "GET /b", {"service.name": "checkout"}, "2024-01-01T00:00:03Z", 1704067203000000000, 1704067204020000000],
+  ["t3", 1, "POST /c", {"service.name": "orders"}, "2024-01-01T00:00:05Z", 1704067205000000000, 1704067205010000000]
 ]

--- a/test/spec/traceql/edge_catchall_compound_count.txtar
+++ b/test/spec/traceql/edge_catchall_compound_count.txtar
@@ -14,7 +14,7 @@ INSERT INTO otel_traces (Duration) VALUES
     (12), (13), (14);
 -- expected_rows --
 [
-  ["t1", 12, "span", {"service.name": "x"}, "2024-01-01T00:00:00Z"]
+  ["t1", 12, "span", {"service.name": "x"}, "2024-01-01T00:00:00Z", 1704067200000000000, 1704067211000000000]
 ]
 -- args --
 [0] int64 = 1
@@ -25,8 +25,8 @@ INSERT INTO otel_traces (Duration) VALUES
 [5] int64 = 10
 -- chplan --
 Filter predicate=(Value > 10)
-  Aggregate groupBy=[TraceId AS TraceId] funcs=[count(1) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix]
+  Aggregate groupBy=[TraceId AS TraceId] funcs=[count(1) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix, min(toUnixTimestamp64Nano(Timestamp)) AS TraceStartNs, max((toUnixTimestamp64Nano(Timestamp) + toInt64(Duration))) AS TraceEndNs]
     Filter predicate=((ResourceAttributes["service.name"] = "x") AND (toFloat64(SpanAttributes["http.status_code"]) > 200))
       Scan(otel_traces)
 -- sql --
-SELECT * FROM (SELECT `TraceId` AS `TraceId`, toFloat64(count(?)) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?) AND (toFloat64(`SpanAttributes`[?]) > ?)) GROUP BY `TraceId`) WHERE (`Value` > ?)
+SELECT * FROM (SELECT `TraceId` AS `TraceId`, toFloat64(count(?)) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix`, min(toUnixTimestamp64Nano(`Timestamp`)) AS `TraceStartNs`, max((toUnixTimestamp64Nano(`Timestamp`) + toInt64(`Duration`))) AS `TraceEndNs` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?) AND (toFloat64(`SpanAttributes`[?]) > ?)) GROUP BY `TraceId`) WHERE (`Value` > ?)

--- a/test/spec/traceql/edge_catchall_pipeline_avg.txtar
+++ b/test/spec/traceql/edge_catchall_pipeline_avg.txtar
@@ -16,7 +16,7 @@ INSERT INTO otel_traces (Duration, StatusCode) VALUES
     (50000000, 'Ok');
 -- expected_rows --
 [
-  ["t1", 800000000, "span", {"service.name": "x"}, "2024-01-01T00:00:00Z"]
+  ["t1", 800000000, "span", {"service.name": "x"}, "2024-01-01T00:00:00Z", 1704067200000000000, 1704067201000000000]
 ]
 -- args --
 [0] string = "Error"
@@ -25,8 +25,8 @@ INSERT INTO otel_traces (Duration, StatusCode) VALUES
 [3] int64 = 500000000
 -- chplan --
 Filter predicate=(Value > 500000000)
-  Aggregate groupBy=[TraceId AS TraceId] funcs=[avg(Duration) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix]
+  Aggregate groupBy=[TraceId AS TraceId] funcs=[avg(Duration) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix, min(toUnixTimestamp64Nano(Timestamp)) AS TraceStartNs, max((toUnixTimestamp64Nano(Timestamp) + toInt64(Duration))) AS TraceEndNs]
     Filter predicate=((ResourceAttributes["service.name"] = "x") AND (StatusCode = "Error"))
       Scan(otel_traces)
 -- sql --
-SELECT * FROM (SELECT `TraceId` AS `TraceId`, avg(`Duration`) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix` FROM (SELECT * FROM `otel_traces` PREWHERE (`StatusCode` = ?) WHERE (`ResourceAttributes`[?] = ?)) GROUP BY `TraceId`) WHERE (`Value` > ?)
+SELECT * FROM (SELECT `TraceId` AS `TraceId`, avg(`Duration`) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix`, min(toUnixTimestamp64Nano(`Timestamp`)) AS `TraceStartNs`, max((toUnixTimestamp64Nano(`Timestamp`) + toInt64(`Duration`))) AS `TraceEndNs` FROM (SELECT * FROM `otel_traces` PREWHERE (`StatusCode` = ?) WHERE (`ResourceAttributes`[?] = ?)) GROUP BY `TraceId`) WHERE (`Value` > ?)

--- a/test/spec/traceql/edge_inner_max_attr.txtar
+++ b/test/spec/traceql/edge_inner_max_attr.txtar
@@ -6,12 +6,13 @@ CREATE TABLE otel_traces (
     SpanName String,
     Timestamp DateTime64(9),
     ResourceAttributes Map(String, String),
-    SpanAttributes Map(String, String)
+    SpanAttributes Map(String, String),
+    Duration UInt64
 ) ENGINE = Memory;
 INSERT INTO otel_traces VALUES
-    ('t1', 'span', toDateTime64('2024-01-01 00:00:00', 9), map('service.name', 'x'), map('latency_ms', '50')),
-    ('t1', 'span', toDateTime64('2024-01-01 00:00:01', 9), map('service.name', 'x'), map('latency_ms', '150')),
-    ('t1', 'span', toDateTime64('2024-01-01 00:00:02', 9), map('service.name', 'x'), map('latency_ms', '200'));
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:00', 9), map('service.name', 'x'), map('latency_ms', '50'),  50000000),
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:01', 9), map('service.name', 'x'), map('latency_ms', '150'), 150000000),
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:02', 9), map('service.name', 'x'), map('latency_ms', '200'), 200000000);
 -- args --
 [0] string = "latency_ms"
 [1] string = "service.name"
@@ -19,12 +20,12 @@ INSERT INTO otel_traces VALUES
 [3] int64 = 100
 -- chplan --
 Filter predicate=(Value > 100)
-  Aggregate groupBy=[TraceId AS TraceId] funcs=[max(toFloat64OrZero(SpanAttributes["latency_ms"])) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix]
+  Aggregate groupBy=[TraceId AS TraceId] funcs=[max(toFloat64OrZero(SpanAttributes["latency_ms"])) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix, min(toUnixTimestamp64Nano(Timestamp)) AS TraceStartNs, max((toUnixTimestamp64Nano(Timestamp) + toInt64(Duration))) AS TraceEndNs]
     Filter predicate=(ResourceAttributes["service.name"] = "x")
       Scan(otel_traces)
 -- sql --
-SELECT * FROM (SELECT `TraceId` AS `TraceId`, max(toFloat64OrZero(`SpanAttributes`[?])) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) GROUP BY `TraceId`) WHERE (`Value` > ?)
+SELECT * FROM (SELECT `TraceId` AS `TraceId`, max(toFloat64OrZero(`SpanAttributes`[?])) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix`, min(toUnixTimestamp64Nano(`Timestamp`)) AS `TraceStartNs`, max((toUnixTimestamp64Nano(`Timestamp`) + toInt64(`Duration`))) AS `TraceEndNs` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) GROUP BY `TraceId`) WHERE (`Value` > ?)
 -- expected_rows --
 [
-  ["t1", 200, "span", {"service.name": "x"}, "2024-01-01T00:00:00Z"]
+  ["t1", 200, "span", {"service.name": "x"}, "2024-01-01T00:00:00Z", 1704067200000000000, 1704067202200000000]
 ]

--- a/test/spec/traceql/edge_inner_min_attr.txtar
+++ b/test/spec/traceql/edge_inner_min_attr.txtar
@@ -6,12 +6,13 @@ CREATE TABLE otel_traces (
     SpanName String,
     Timestamp DateTime64(9),
     ResourceAttributes Map(String, String),
-    SpanAttributes Map(String, String)
+    SpanAttributes Map(String, String),
+    Duration UInt64
 ) ENGINE = Memory;
 INSERT INTO otel_traces VALUES
-    ('t1', 'span', toDateTime64('2024-01-01 00:00:00', 9), map('service.name', 'x'), map('attempts', '1')),
-    ('t1', 'span', toDateTime64('2024-01-01 00:00:01', 9), map('service.name', 'x'), map('attempts', '5')),
-    ('t1', 'span', toDateTime64('2024-01-01 00:00:02', 9), map('service.name', 'x'), map('attempts', '9'));
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:00', 9), map('service.name', 'x'), map('attempts', '1'), 10000000),
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:01', 9), map('service.name', 'x'), map('attempts', '5'), 20000000),
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:02', 9), map('service.name', 'x'), map('attempts', '9'), 30000000);
 -- args --
 [0] string = "attempts"
 [1] string = "service.name"
@@ -19,12 +20,12 @@ INSERT INTO otel_traces VALUES
 [3] int64 = 3
 -- chplan --
 Filter predicate=(Value < 3)
-  Aggregate groupBy=[TraceId AS TraceId] funcs=[min(toFloat64OrZero(SpanAttributes["attempts"])) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix]
+  Aggregate groupBy=[TraceId AS TraceId] funcs=[min(toFloat64OrZero(SpanAttributes["attempts"])) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix, min(toUnixTimestamp64Nano(Timestamp)) AS TraceStartNs, max((toUnixTimestamp64Nano(Timestamp) + toInt64(Duration))) AS TraceEndNs]
     Filter predicate=(ResourceAttributes["service.name"] = "x")
       Scan(otel_traces)
 -- sql --
-SELECT * FROM (SELECT `TraceId` AS `TraceId`, min(toFloat64OrZero(`SpanAttributes`[?])) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) GROUP BY `TraceId`) WHERE (`Value` < ?)
+SELECT * FROM (SELECT `TraceId` AS `TraceId`, min(toFloat64OrZero(`SpanAttributes`[?])) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix`, min(toUnixTimestamp64Nano(`Timestamp`)) AS `TraceStartNs`, max((toUnixTimestamp64Nano(`Timestamp`) + toInt64(`Duration`))) AS `TraceEndNs` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) GROUP BY `TraceId`) WHERE (`Value` < ?)
 -- expected_rows --
 [
-  ["t1", 1, "span", {"service.name": "x"}, "2024-01-01T00:00:00Z"]
+  ["t1", 1, "span", {"service.name": "x"}, "2024-01-01T00:00:00Z", 1704067200000000000, 1704067202030000000]
 ]

--- a/test/spec/traceql/edge_inner_sum_attr.txtar
+++ b/test/spec/traceql/edge_inner_sum_attr.txtar
@@ -6,12 +6,13 @@ CREATE TABLE otel_traces (
     SpanName String,
     Timestamp DateTime64(9),
     ResourceAttributes Map(String, String),
-    SpanAttributes Map(String, String)
+    SpanAttributes Map(String, String),
+    Duration UInt64
 ) ENGINE = Memory;
 INSERT INTO otel_traces VALUES
-    ('t1', 'span', toDateTime64('2024-01-01 00:00:00', 9), map('service.name', 'x'), map('size', '400')),
-    ('t1', 'span', toDateTime64('2024-01-01 00:00:01', 9), map('service.name', 'x'), map('size', '500')),
-    ('t1', 'span', toDateTime64('2024-01-01 00:00:02', 9), map('service.name', 'x'), map('size', '600'));
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:00', 9), map('service.name', 'x'), map('size', '400'), 10000000),
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:01', 9), map('service.name', 'x'), map('size', '500'), 20000000),
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:02', 9), map('service.name', 'x'), map('size', '600'), 30000000);
 -- args --
 [0] string = "size"
 [1] string = "service.name"
@@ -19,12 +20,12 @@ INSERT INTO otel_traces VALUES
 [3] int64 = 1000
 -- chplan --
 Filter predicate=(Value > 1000)
-  Aggregate groupBy=[TraceId AS TraceId] funcs=[sum(toFloat64OrZero(SpanAttributes["size"])) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix]
+  Aggregate groupBy=[TraceId AS TraceId] funcs=[sum(toFloat64OrZero(SpanAttributes["size"])) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix, min(toUnixTimestamp64Nano(Timestamp)) AS TraceStartNs, max((toUnixTimestamp64Nano(Timestamp) + toInt64(Duration))) AS TraceEndNs]
     Filter predicate=(ResourceAttributes["service.name"] = "x")
       Scan(otel_traces)
 -- sql --
-SELECT * FROM (SELECT `TraceId` AS `TraceId`, sum(toFloat64OrZero(`SpanAttributes`[?])) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) GROUP BY `TraceId`) WHERE (`Value` > ?)
+SELECT * FROM (SELECT `TraceId` AS `TraceId`, sum(toFloat64OrZero(`SpanAttributes`[?])) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix`, min(toUnixTimestamp64Nano(`Timestamp`)) AS `TraceStartNs`, max((toUnixTimestamp64Nano(`Timestamp`) + toInt64(`Duration`))) AS `TraceEndNs` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) GROUP BY `TraceId`) WHERE (`Value` > ?)
 -- expected_rows --
 [
-  ["t1", 1500, "span", {"service.name": "x"}, "2024-01-01T00:00:00Z"]
+  ["t1", 1500, "span", {"service.name": "x"}, "2024-01-01T00:00:00Z", 1704067200000000000, 1704067202030000000]
 ]

--- a/test/spec/traceql/max_duration.txtar
+++ b/test/spec/traceql/max_duration.txtar
@@ -19,12 +19,12 @@ INSERT INTO otel_traces VALUES
 [2] int64 = 500000000
 -- chplan --
 Filter predicate=(Value > 500000000)
-  Aggregate groupBy=[TraceId AS TraceId] funcs=[max(Duration) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix]
+  Aggregate groupBy=[TraceId AS TraceId] funcs=[max(Duration) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix, min(toUnixTimestamp64Nano(Timestamp)) AS TraceStartNs, max((toUnixTimestamp64Nano(Timestamp) + toInt64(Duration))) AS TraceEndNs]
     Filter predicate=(ResourceAttributes["service.name"] = "frontend")
       Scan(otel_traces)
 -- sql --
-SELECT * FROM (SELECT `TraceId` AS `TraceId`, max(`Duration`) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) GROUP BY `TraceId`) WHERE (`Value` > ?)
+SELECT * FROM (SELECT `TraceId` AS `TraceId`, max(`Duration`) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix`, min(toUnixTimestamp64Nano(`Timestamp`)) AS `TraceStartNs`, max((toUnixTimestamp64Nano(`Timestamp`) + toInt64(`Duration`))) AS `TraceEndNs` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) GROUP BY `TraceId`) WHERE (`Value` > ?)
 -- expected_rows --
 [
-  ["t1", 600000000, "span", {"service.name": "frontend"}, "2024-01-01T00:00:00Z"]
+  ["t1", 600000000, "span", {"service.name": "frontend"}, "2024-01-01T00:00:00Z", 1704067200000000000, 1704067202400000000]
 ]

--- a/test/spec/traceql/min_duration.txtar
+++ b/test/spec/traceql/min_duration.txtar
@@ -19,12 +19,12 @@ INSERT INTO otel_traces VALUES
 [2] int64 = 10000000
 -- chplan --
 Filter predicate=(Value > 10000000)
-  Aggregate groupBy=[TraceId AS TraceId] funcs=[min(Duration) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix]
+  Aggregate groupBy=[TraceId AS TraceId] funcs=[min(Duration) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix, min(toUnixTimestamp64Nano(Timestamp)) AS TraceStartNs, max((toUnixTimestamp64Nano(Timestamp) + toInt64(Duration))) AS TraceEndNs]
     Filter predicate=(ResourceAttributes["service.name"] = "frontend")
       Scan(otel_traces)
 -- sql --
-SELECT * FROM (SELECT `TraceId` AS `TraceId`, min(`Duration`) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) GROUP BY `TraceId`) WHERE (`Value` > ?)
+SELECT * FROM (SELECT `TraceId` AS `TraceId`, min(`Duration`) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix`, min(toUnixTimestamp64Nano(`Timestamp`)) AS `TraceStartNs`, max((toUnixTimestamp64Nano(`Timestamp`) + toInt64(`Duration`))) AS `TraceEndNs` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) GROUP BY `TraceId`) WHERE (`Value` > ?)
 -- expected_rows --
 [
-  ["t1", 30000000, "span", {"service.name": "frontend"}, "2024-01-01T00:00:00Z"]
+  ["t1", 30000000, "span", {"service.name": "frontend"}, "2024-01-01T00:00:00Z", 1704067200000000000, 1704067202080000000]
 ]

--- a/test/spec/traceql/sum_duration.txtar
+++ b/test/spec/traceql/sum_duration.txtar
@@ -19,12 +19,12 @@ INSERT INTO otel_traces VALUES
 [2] int64 = 100000000
 -- chplan --
 Filter predicate=(Value > 100000000)
-  Aggregate groupBy=[TraceId AS TraceId] funcs=[sum(Duration) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix]
+  Aggregate groupBy=[TraceId AS TraceId] funcs=[sum(Duration) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix, min(toUnixTimestamp64Nano(Timestamp)) AS TraceStartNs, max((toUnixTimestamp64Nano(Timestamp) + toInt64(Duration))) AS TraceEndNs]
     Filter predicate=(ResourceAttributes["service.name"] = "frontend")
       Scan(otel_traces)
 -- sql --
-SELECT * FROM (SELECT `TraceId` AS `TraceId`, sum(`Duration`) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) GROUP BY `TraceId`) WHERE (`Value` > ?)
+SELECT * FROM (SELECT `TraceId` AS `TraceId`, sum(`Duration`) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix`, min(toUnixTimestamp64Nano(`Timestamp`)) AS `TraceStartNs`, max((toUnixTimestamp64Nano(`Timestamp`) + toInt64(`Duration`))) AS `TraceEndNs` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) GROUP BY `TraceId`) WHERE (`Value` > ?)
 -- expected_rows --
 [
-  ["t1", 250000000, "span", {"service.name": "frontend"}, "2024-01-01T00:00:00Z"]
+  ["t1", 250000000, "span", {"service.name": "frontend"}, "2024-01-01T00:00:00Z", 1704067200000000000, 1704067202120000000]
 ]

--- a/test/spec/traceql/sum_span_attr.txtar
+++ b/test/spec/traceql/sum_span_attr.txtar
@@ -6,12 +6,13 @@ CREATE TABLE otel_traces (
     SpanName String,
     Timestamp DateTime64(9),
     ResourceAttributes Map(String, String),
-    SpanAttributes Map(String, String)
+    SpanAttributes Map(String, String),
+    Duration UInt64
 ) ENGINE = Memory;
 INSERT INTO otel_traces VALUES
-    ('t1', 'span', toDateTime64('2024-01-01 00:00:00', 9), map(), map('http.status_code', '500')),
-    ('t1', 'span', toDateTime64('2024-01-01 00:00:01', 9), map(), map('http.status_code', '404')),
-    ('t2', 'span', toDateTime64('2024-01-01 00:00:02', 9), map(), map('http.status_code', '200'));
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:00', 9), map(), map('http.status_code', '500'), 10000000),
+    ('t1', 'span', toDateTime64('2024-01-01 00:00:01', 9), map(), map('http.status_code', '404'), 20000000),
+    ('t2', 'span', toDateTime64('2024-01-01 00:00:02', 9), map(), map('http.status_code', '200'), 30000000);
 -- args --
 [0] string = "http.status_code"
 [1] string = "http.status_code"
@@ -19,12 +20,12 @@ INSERT INTO otel_traces VALUES
 [3] int64 = 0
 -- chplan --
 Filter predicate=(Value > 0)
-  Aggregate groupBy=[TraceId AS TraceId] funcs=[sum(toFloat64OrZero(SpanAttributes["http.status_code"])) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix]
+  Aggregate groupBy=[TraceId AS TraceId] funcs=[sum(toFloat64OrZero(SpanAttributes["http.status_code"])) AS Value, any(SpanName) AS MetricName, any(ResourceAttributes) AS ResourceAttrs, min(Timestamp) AS TimeUnix, min(toUnixTimestamp64Nano(Timestamp)) AS TraceStartNs, max((toUnixTimestamp64Nano(Timestamp) + toInt64(Duration))) AS TraceEndNs]
     Filter predicate=(toFloat64(SpanAttributes["http.status_code"]) >= 400)
       Scan(otel_traces)
 -- sql --
-SELECT * FROM (SELECT `TraceId` AS `TraceId`, sum(toFloat64OrZero(`SpanAttributes`[?])) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix` FROM (SELECT * FROM `otel_traces` WHERE (toFloat64(`SpanAttributes`[?]) >= ?)) GROUP BY `TraceId`) WHERE (`Value` > ?)
+SELECT * FROM (SELECT `TraceId` AS `TraceId`, sum(toFloat64OrZero(`SpanAttributes`[?])) AS `Value`, any(`SpanName`) AS `MetricName`, any(`ResourceAttributes`) AS `ResourceAttrs`, min(`Timestamp`) AS `TimeUnix`, min(toUnixTimestamp64Nano(`Timestamp`)) AS `TraceStartNs`, max((toUnixTimestamp64Nano(`Timestamp`) + toInt64(`Duration`))) AS `TraceEndNs` FROM (SELECT * FROM `otel_traces` WHERE (toFloat64(`SpanAttributes`[?]) >= ?)) GROUP BY `TraceId`) WHERE (`Value` > ?)
 -- expected_rows --
 [
-  ["t1", 904, "span", {}, "2024-01-01T00:00:00Z"]
+  ["t1", 904, "span", {}, "2024-01-01T00:00:00Z", 1704067200000000000, 1704067201020000000]
 ]


### PR DESCRIPTION
## Summary

- Tempo's `/api/search` wire spec reports `durationMs` as the **whole-trace** wall-clock span (`max(span.end) - min(span.start)` across every span in the trace), not the matched row's per-row `Duration`. The spanset-aggregate path (`| count()`, `| avg(duration)`, …) collapses every trace to one row whose `Sample.Value` carries the aggregate result, so the shaper's previous fallback to `Sample.Value` under-reported `durationMs` (e.g. `count()` → `durationMs=0`; `avg(duration)` → the representative span's duration, not the trace span).
- `lowerAggregate` now adds two extra envelope aliases — `TraceStartNs` (`min(toUnixTimestamp64Nano(Timestamp))`) and `TraceEndNs` (`max(toUnixTimestamp64Nano(Timestamp) + toInt64(Duration))`).
- `spansetAggregateSampleProjections` threads the derived `TraceEndNs - TraceStartNs` through a new reserved Attributes slot (`__cerberus_traceDurationNs`).
- `toTraceSummaries` reads the reserved slot, surfaces `durationMs = ns / 1e6`, and falls back to `Sample.Value` for non-aggregate paths so older fixtures + stub queriers keep working.

## Expected compat impact

The PR description on PR #536 (which seeded the per-trace envelope) flagged the two cases this fixes: `count_spans_per_trace` and `avg_duration_per_trace_status_ok`. Each is ~100 rows in the Tempo compat run; lifting them out of `field_mismatch` should move the suite from the recent ~54.55% baseline by +~6 percentage points.

Sample failures pre-fix (from a recent run):

```
- [field_mismatch] key 1131bf7acf51ccb10aef0ec7e31bf71f: durationMs tempo=150 vs cerberus=72
- [field_mismatch] key 118b9e55fa97da56152b463462b61607: durationMs tempo=150 vs cerberus=67
```

## Test plan

- [x] Unit: `TestSearch_SpansetAggregate_DurationMsReflectsWholeTrace` — single-row aggregate, asserts `durationMs=150` from the reserved slot
- [x] Unit: `TestSearch_SpansetAggregate_DurationMsMultiSpanReplaysAggregate` — reserved slot wins over Sample.Value fallback regardless of arrival order
- [x] Unit: `TestSearch_SpansetAggregate_SQLProjectsTraceDurationNs` — pins the SQL substring + reserved-key arg slot
- [x] 15 spec TXTAR fixtures refreshed via `GOLDEN_UPDATE=1`; chDB round-trip green across the 134 traceql fixtures
- [x] `internal/api/tempo/...` + `internal/traceql/...` test suite passes (516 tests)

## Notes for reviewers

- Schema column refs (`Duration`, `Timestamp`) are hard-coded in the new `traceStartNsAggFunc` / `traceEndNsAggFunc` for the OTel-CH default; if a future custom schema overrides `DurationColumn` / `TimestampColumn` the wrap-projection will need to thread the schema in (parity with how `lowerAggregate` already wires `s.SpanNameColumn` + `s.ResourceAttributesColumn`).
- New reserved Attributes key (`__cerberus_traceDurationNs`) namespaced under the existing `__cerberus_*` prefix so it cannot collide with real OTel attribute keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)