### PR TITLE
fix(api/tempo): accept stripped "0" as empty ParentSpanId in root-span resolution

### DIFF
--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -414,12 +414,15 @@ func stripLeadingHexZeros(col string) chplan.Expr {
 //
 // searchKeyParentSpanID reuses the same `__cerberus_parentSpanID` slot
 // on the /api/search path so toTraceSummaries can identify the per-trace
-// root span — the row where ParentSpanId is empty. Without this, the
-// shaper anchors RootServiceName / RootTraceName on whichever span CH
-// happens to return first, which for multi-span traces is typically a
-// child span (Tempo's wire spec says rootTraceName is the name of the
-// span at the top of the trace tree). See toTraceSummaries for the
-// resolution logic and the fallback rules for broken or truncated traces.
+// root span — the row where ParentSpanId is empty (legacy / stub
+// queriers) or `"0"` (the post-strip form of `0000000000000000`, the
+// on-disk shape for a true root span; stripLeadingHexZeros always
+// retains ≥ 1 hex digit). Without this, the shaper anchors
+// RootServiceName / RootTraceName on whichever span CH happens to
+// return first, which for multi-span traces is typically a child span
+// (Tempo's wire spec says rootTraceName is the name of the span at the
+// top of the trace tree). See toTraceSummaries for the resolution
+// logic and the fallback rules for broken or truncated traces.
 const (
 	traceByIDKeyTraceID       = "__cerberus_traceID"
 	traceByIDKeySpanID        = "__cerberus_spanID"
@@ -905,14 +908,24 @@ func toTraceSummaries(samples []chclient.Sample) []TraceSummary {
 		}
 
 		// Resolve root-span metadata. The reserved __cerberus_parentSpanID
-		// slot carries the parent ID; empty means this row is the root.
+		// slot carries the parent ID; empty (or a single "0") means this
+		// row is the root. The OTel-CH exporter writes ParentSpanId as a
+		// 16-char lowercase-hex string and the canonical/r-qualified
+		// projections route it through stripLeadingHexZeros — the regex
+		// `^0+([0-9a-f])` always retains ≥ 1 hex digit, so an all-zero
+		// ParentSpanId (`0000000000000000`, the on-disk form for a true
+		// root span) collapses to `"0"` rather than `""`. We accept both
+		// the legacy pre-strip empty form (older fixtures / stub
+		// queriers) and the post-strip `"0"` form so the same shaper
+		// works on either projection variant.
+		//
 		// When the slot is missing (older fixtures / stub queriers),
 		// treat every row as a non-root candidate so the fallback path
 		// runs — `parentID, hasParentSlot := ...` captures the
 		// "did we get the projection" signal independently of the
 		// emptiness check.
 		parentID, hasParentSlot := s.Labels[searchKeyParentSpanID]
-		isRoot := hasParentSlot && parentID == ""
+		isRoot := hasParentSlot && (parentID == "" || parentID == "0")
 		svc := s.Labels["service.name"]
 		switch {
 		case isRoot && (!a.hasRoot || ns < a.rootStartNS):

--- a/internal/api/tempo/handler_test.go
+++ b/internal/api/tempo/handler_test.go
@@ -471,6 +471,79 @@ func TestSearch_RootSpanResolution_TruncatedTrace(t *testing.T) {
 	}
 }
 
+// TestSearch_RootSpanResolution_StrippedZero pins the post-strip root
+// classification: the OTel-CH exporter stores ParentSpanId as a 16-char
+// lowercase-hex string, and the search projection routes it through
+// stripLeadingHexZeros — the regex `^0+([0-9a-f])` always retains ≥ 1
+// hex digit, so an all-zero ParentSpanId (the on-disk form for a true
+// root span) renders as `"0"` rather than `""`. The shaper must treat
+// `"0"` as a root marker; without this, structural-join queries (`>>`,
+// `<<`, `>`, `<`) report a child span's name as rootTraceName because
+// the search projection's per-trace root row is mis-classified.
+//
+// Pins the failure-mode behind descendant_op_payments_to_consumer /
+// direct_parent_op_checkout_to_child / set_and_checkout_and_status_error
+// / status_eq_error in the Tempo compat report — see PR description.
+func TestSearch_RootSpanResolution_StrippedZero(t *testing.T) {
+	t.Parallel()
+	const traceID = "ffffffffffffffffffffffffffffffff"
+	const rootSpanID = "1"
+	q := &stubQuerier{
+		samples: []chclient.Sample{
+			// Child span — parent points at the root, which after
+			// stripLeadingHexZeros renders as "1".
+			{
+				MetricName: "payments.child.3",
+				Labels: map[string]string{
+					"service.name":            "payments",
+					"__cerberus_traceID":      traceID,
+					"__cerberus_parentSpanID": rootSpanID,
+				},
+				Timestamp: time.Date(2026, 5, 12, 10, 0, 0, 25_000_000, time.UTC),
+				Value:     30_000_000,
+			},
+			// The actual root span — on-disk ParentSpanId is
+			// "0000000000000000", which stripLeadingHexZeros collapses
+			// to "0" (single hex digit, never empty). The shaper must
+			// accept this as a root marker.
+			{
+				MetricName: "GET /api/payments/1",
+				Labels: map[string]string{
+					"service.name":            "payments",
+					"__cerberus_traceID":      traceID,
+					"__cerberus_parentSpanID": "0",
+				},
+				Timestamp: time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC),
+				Value:     120_000_000,
+			},
+		},
+	}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/search?q=%7B%20status%20%3D%20error%20%7D")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	var sr tempo.SearchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&sr); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(sr.Traces) != 1 {
+		t.Fatalf("expected 1 trace, got %d", len(sr.Traces))
+	}
+	got := sr.Traces[0]
+	if got.RootTraceName != "GET /api/payments/1" {
+		t.Errorf("RootTraceName: got %q, want %q (stripped-zero parent must classify as root)",
+			got.RootTraceName, "GET /api/payments/1")
+	}
+	if got.RootServiceName != "payments" {
+		t.Errorf("RootServiceName: got %q, want %q",
+			got.RootServiceName, "payments")
+	}
+}
+
 // TestSearch_SQLProjectsParentSpanId pins the SQL emitted by the search
 // path against an OTel-CH default schema. The ParentSpanId column must
 // appear in the projection so toTraceSummaries can resolve the root


### PR DESCRIPTION
## Summary

- The OTel-CH exporter writes `ParentSpanId` as a 16-char lowercase-hex string and the `/api/search` projection routes it through `stripLeadingHexZeros` — the regex `^0+([0-9a-f])` always retains ≥ 1 hex digit, so an all-zero `ParentSpanId` (`0000000000000000`, the on-disk form for a true root span) collapses to `"0"` rather than `""`.
- The `toTraceSummaries` shaper's `parentID == ""` check (added in #531) fails for true root spans after #543 landed the leading-zero strip, so structural-join cases (descendant `<-`, direct-parent `<`, `set_and_checkout_and_status_error`, `status_eq_error`) anchor `rootServiceName` / `rootTraceName` on a child span instead of the root.
- Fix: extend the root-detection check to `parentID == "" || parentID == "0"` so both the legacy pre-strip empty form (older fixtures / stub queriers) and the post-strip `"0"` form classify as root.

## Root cause

PR #531 introduced the `__cerberus_parentSpanID` reserved key + `parentID == ""` root check.
PR #543 (#strip-leading-zeros) extended `stripLeadingHexZeros` to the search projection's `ParentSpanId` slot — but the regex retains ≥ 1 hex digit by design (so an empty wire value never collides with an all-zero one). That moved the on-disk `0000000000000000` to `"0"` rather than `""`, and the shaper's emptiness check stopped matching real root spans.

The structural-join paths (`descendant_op_payments_to_consumer`, `direct_parent_op_checkout_to_child`, etc.) all route through either `canonicalSampleProjections` or `rQualifiedSampleProjections`, which is why they share the same failure mode.

## Test plan

- [x] `TestSearch_RootSpanResolution_StrippedZero` pins the post-strip `"0"` classification with the same shape as the Tempo compat diff (`"GET /api/payments/1"` root vs `"payments.child.3"` child).
- [x] Existing `TestSearch_RootSpanResolution` + `_MultipleRoots` + `_TruncatedTrace` cover the legacy `""` form (backward compat).
- [x] Existing `TestSearch_SQLProjectsParentSpanId` pins the SQL projection (unchanged here).

Expected Tempo compat delta: **+12%** (kills ~4 cases × 28–120 reasons each in the `rootTraceName` diff column from the latest compat report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)