### PR TITLE
feat(logql): expand 'level' label to SeverityText-derived expression in by/without clauses

### DIFF
--- a/internal/logql/detected_level.go
+++ b/internal/logql/detected_level.go
@@ -10,6 +10,16 @@ import (
 // from the record's structured-metadata `detected_level` label or the
 // record's `severity_text` / OTel `SeverityText` field.
 //
+// `level` is Loki's documented short alias — `pkg/distributor/field_detection.go`
+// treats `level`, `LEVEL`, `Level`, `severity`, `SEVERITY`, `Severity`,
+// `lvl`, `LVL`, and `Lvl` as the source labels detection scans. Once
+// detection settles, downstream consumers see both `detected_level` and
+// `level` referring to the same normalised value. Cerberus mirrors the
+// alias surface here so a user query that uses `by (level)` /
+// `without (level)` resolves against the synthesized SeverityText-derived
+// expression rather than collapsing every record into an empty-value
+// group (since cerberus's ResourceAttributes map has no bare `level` key).
+//
 // Upstream Loki's reference derivation
 // (`github.com/grafana/loki/pkg/distributor/field_detection.go::extractLogLevel`)
 // is layered:
@@ -35,12 +45,40 @@ import (
 // harness exercises rely on SeverityText, and emitting the broader
 // shape would double the CH expression size without changing the
 // observable result.
-const detectedLevelLabel = "detected_level"
+const (
+	detectedLevelLabel = "detected_level"
+	// levelLabelAlias is the short alias Loki accepts as equivalent to
+	// `detected_level` once severity detection settles. The aggregation
+	// grouping path (by/without) routes both forms through the same
+	// SeverityText-derived expression so a query that uses either form
+	// returns the same series set. Label-filter / stream-selector matchers
+	// keep the literal-key semantics so a `| logfmt | level="error"`
+	// pipeline still resolves `level` against the parser-extracted map.
+	levelLabelAlias = "level"
+)
 
 // isDetectedLevelLabel reports whether a matcher name targets the
-// synthesized `detected_level` label.
+// synthesized `detected_level` label by its canonical name. Label-filter
+// and stream-selector matchers use this to route ONLY the
+// `detected_level` form through the SeverityText-derived expression —
+// the `level` short alias keeps the literal-key path so parser-extracted
+// `level` (from `| logfmt`, `| json`, etc.) still resolves through
+// labelsExpr.
 func isDetectedLevelLabel(name string) bool {
 	return name == detectedLevelLabel
+}
+
+// isDetectedLevelGroupingLabel reports whether `name` references the
+// synthesized severity dimension in an aggregation `by(...)` / `without(...)`
+// clause. Both `detected_level` and its `level` short alias resolve here
+// because the downstream identity map (Project + RangeWindow) carries
+// only the canonical `detected_level` key — never a raw `level` —
+// regardless of whether the user wrote one form or the other. Matchers
+// take the stricter [isDetectedLevelLabel] path because parser stages
+// produce a real `level` key in the labels map that should win over
+// the synthesized expression.
+func isDetectedLevelGroupingLabel(name string) bool {
+	return name == detectedLevelLabel || name == levelLabelAlias
 }
 
 // detectedLevelExpr returns the chplan expression that computes the

--- a/internal/logql/detected_level_test.go
+++ b/internal/logql/detected_level_test.go
@@ -88,6 +88,197 @@ func TestDetectedLevel_StreamSelector(t *testing.T) {
 	}
 }
 
+// TestDetectedLevel_GroupingLevelAliasesToDetectedLevel pins the
+// `sum by (level) (...)` fix. With this fix, a vector aggregation
+// `by (level)` resolves the synthesized severity dimension through the
+// augmented `ResourceAttributes[detected_level]` map lookup — the
+// outer SELECT can't see `SeverityText` (the inner RangeWindow only
+// exposes the (ResourceAttributes, Value) tuple), so the synthesized
+// key has to ride in the map. Without the alias, the outer would read
+// `ResourceAttributes[level]`, which the OTel-CH seeder writes to
+// nothing on the loki-compat fixture, and all 4 severity series would
+// collapse to a single empty-value group (the 15 `matrix length:
+// expected=4 actual=1` failures this PR clears).
+func TestDetectedLevel_GroupingLevelAliasesToDetectedLevel(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelLogs()
+	expr, err := syntax.ParseExpr(`sum by (level) (count_over_time({app="api"}[5m]))`)
+	if err != nil {
+		t.Fatalf("ParseExpr: %v", err)
+	}
+	plan, err := lower(expr, s, lowerCtx{})
+	if err != nil {
+		t.Fatalf("lower: %v", err)
+	}
+
+	// Walk to the outer Aggregate's GroupBy. The fix routes both `level`
+	// and `detected_level` aliases to a MapAccess on
+	// ResourceAttributes[detected_level].
+	outerProject, ok := plan.(*chplan.Project)
+	if !ok {
+		t.Fatalf("lower top is %T; want *chplan.Project", plan)
+	}
+	outerAgg, ok := outerProject.Input.(*chplan.Aggregate)
+	if !ok {
+		t.Fatalf("Project.Input is %T; want *chplan.Aggregate", outerProject.Input)
+	}
+	if got, want := len(outerAgg.GroupBy), 1; got != want {
+		t.Fatalf("GroupBy length = %d; want %d", got, want)
+	}
+	ma, ok := outerAgg.GroupBy[0].(*chplan.MapAccess)
+	if !ok {
+		t.Fatalf("GroupBy[0] = %T; want *chplan.MapAccess (synthesized lookup)", outerAgg.GroupBy[0])
+	}
+	col, ok := ma.Map.(*chplan.ColumnRef)
+	if !ok || col.Name != s.ResourceAttributesColumn {
+		t.Fatalf("GroupBy MapAccess.Map = %v; want ColumnRef(%q)", ma.Map, s.ResourceAttributesColumn)
+	}
+	keyLit, ok := ma.Key.(*chplan.LitString)
+	if !ok || keyLit.V != detectedLevelLabel {
+		t.Fatalf("GroupBy MapAccess.Key = %v; want %q (level alias canonicalised to detected_level)", ma.Key, detectedLevelLabel)
+	}
+}
+
+// TestDetectedLevel_RangeAggregationLevelByUsesSeverityText pins the
+// inner range-aggregation `by (level)` form. At the inner Project
+// layer, `SeverityText` is still in scope, so the group-key value
+// embeds the full multiIf normalisation directly — the outer
+// MapAccess-via-`detected_level` approach can't apply because the
+// inner Project IS what populates the augmented map (and at this
+// layer the map hasn't been augmented yet).
+func TestDetectedLevel_RangeAggregationLevelByUsesSeverityText(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelLogs()
+	expr, err := syntax.ParseExpr(`avg_over_time({app="api"} | logfmt | unwrap latency [5m]) by (level)`)
+	if err != nil {
+		t.Fatalf("ParseExpr: %v", err)
+	}
+	plan, err := lower(expr, s, lowerCtx{})
+	if err != nil {
+		t.Fatalf("lower: %v", err)
+	}
+
+	// Walk past the RangeWindow → Project → look at the identity
+	// projection's expression. It should be a `map(...)` whose value
+	// for `level` is the multiIf normalisation (a FuncCall named
+	// multiIf), not a MapAccess on ResourceAttributes.
+	rw, ok := plan.(*chplan.RangeWindow)
+	if !ok {
+		t.Fatalf("lower top is %T; want *chplan.RangeWindow", plan)
+	}
+	proj, ok := rw.Input.(*chplan.Project)
+	if !ok {
+		t.Fatalf("RangeWindow.Input is %T; want *chplan.Project", rw.Input)
+	}
+	if len(proj.Projections) == 0 {
+		t.Fatalf("Project has no projections")
+	}
+	mapCall, ok := proj.Projections[0].Expr.(*chplan.FuncCall)
+	if !ok || mapCall.Name != "map" {
+		t.Fatalf("identity projection = %v; want FuncCall(map, ...)", proj.Projections[0].Expr)
+	}
+	// args = ["level", <levelExpr>] for `by (level)`.
+	if got, want := len(mapCall.Args), 2; got != want {
+		t.Fatalf("map call args = %d; want %d", got, want)
+	}
+	keyLit, ok := mapCall.Args[0].(*chplan.LitString)
+	if !ok || keyLit.V != "level" {
+		t.Fatalf("map call args[0] = %v; want LitString(\"level\")", mapCall.Args[0])
+	}
+	multiIf, ok := mapCall.Args[1].(*chplan.FuncCall)
+	if !ok || multiIf.Name != "multiIf" {
+		t.Fatalf("map call args[1] = %v; want FuncCall(multiIf, ...) (SeverityText-derived expression)", mapCall.Args[1])
+	}
+}
+
+// TestDetectedLevel_GroupingDetectedLevelCanonical pins the canonical
+// form: `by (detected_level)` and `by (level)` produce structurally
+// identical plans. The MapAccess key is always `detected_level` because
+// the inner range aggregation's augmentation populates that canonical
+// key (not the `level` alias).
+func TestDetectedLevel_GroupingDetectedLevelCanonical(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelLogs()
+	for _, alias := range []string{"level", "detected_level"} {
+		t.Run(alias, func(t *testing.T) {
+			t.Parallel()
+			expr, err := syntax.ParseExpr(`sum by (` + alias + `) (count_over_time({app="api"}[5m]))`)
+			if err != nil {
+				t.Fatalf("ParseExpr: %v", err)
+			}
+			plan, err := lower(expr, s, lowerCtx{})
+			if err != nil {
+				t.Fatalf("lower: %v", err)
+			}
+			outerProject := plan.(*chplan.Project)
+			outerAgg := outerProject.Input.(*chplan.Aggregate)
+			ma := outerAgg.GroupBy[0].(*chplan.MapAccess)
+			keyLit := ma.Key.(*chplan.LitString)
+			if keyLit.V != detectedLevelLabel {
+				t.Errorf("by (%s): MapAccess.Key = %q; want canonical %q", alias, keyLit.V, detectedLevelLabel)
+			}
+		})
+	}
+}
+
+// TestDetectedLevel_LabelFilterLevelDoesNotAlias pins that the `level`
+// short alias does NOT apply in label-filter context — pipelines like
+// `{job="api"} | logfmt | level="error"` resolve `level` through the
+// labels map (so parser-extracted keys still win) rather than routing
+// to the SeverityText-derived expression. This is the boundary case
+// the [isDetectedLevelGroupingLabel] / [isDetectedLevelLabel] split
+// guards: matchers take the strict path so parser stages keep
+// working, aggregation grouping takes the broader path so
+// `by (level)` matches upstream Loki.
+func TestDetectedLevel_LabelFilterLevelDoesNotAlias(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelLogs()
+	expr, err := syntax.ParseExpr(`{job="api"} | logfmt | level="error"`)
+	if err != nil {
+		t.Fatalf("ParseExpr: %v", err)
+	}
+	plan, err := lower(expr, s, lowerCtx{})
+	if err != nil {
+		t.Fatalf("lower: %v", err)
+	}
+	// The `level="error"` filter must lower to a MapAccess on the
+	// parser-augmented labels map (which is itself a mapConcat over
+	// ResourceAttributes + extracted keys), not to a multiIf on
+	// SeverityText. Walk the predicate tree and assert the level
+	// matcher's LHS is a MapAccess, not a FuncCall named multiIf.
+	filt, ok := plan.(*chplan.Filter)
+	if !ok {
+		t.Fatalf("lower top is %T; want *chplan.Filter", plan)
+	}
+	var sawMapAccessLevel bool
+	walkExprTree(filt.Predicate, func(e chplan.Expr) {
+		bin, ok := e.(*chplan.Binary)
+		if !ok || bin.Op != chplan.OpEq {
+			return
+		}
+		rhs, ok := bin.Right.(*chplan.LitString)
+		if !ok || rhs.V != "error" {
+			return
+		}
+		ma, ok := bin.Left.(*chplan.MapAccess)
+		if !ok {
+			return
+		}
+		keyLit, ok := ma.Key.(*chplan.LitString)
+		if !ok || keyLit.V != "level" {
+			return
+		}
+		sawMapAccessLevel = true
+	})
+	if !sawMapAccessLevel {
+		t.Errorf("expected MapAccess(<labels>, \"level\") = \"error\" filter; got plan %v", filt.Predicate)
+	}
+}
+
 // TestDetectedLevel_NoColumnRefToDetectedLevelLabel verifies that no
 // stray `ResourceAttributes["detected_level"]` MapAccess survives in
 // the lowered tree — the synthesized normalisation should fully

--- a/internal/logql/range_aggregation.go
+++ b/internal/logql/range_aggregation.go
@@ -341,6 +341,12 @@ func unwrapValueExpr(u *syntax.UnwrapExpr, labelsExpr chplan.Expr) (chplan.Expr,
 //	`by (k1, k2)`      → map('k1', RA['k1'], 'k2', RA['k2'])
 //	`by ()`            → map()       (single all-collapsed group)
 //	`without (k1, k2)` → mapFilter((k,v) -> NOT (k IN ('k1','k2')), RA)
+//
+// The `detected_level` family (`detected_level` + its `level` alias) is
+// resolved to the SeverityText-derived `multiIf(...)` normalisation
+// rather than a literal map lookup the seeder doesn't write — mirrors
+// the vector-aggregation alias surface so the two grouping layers
+// behave consistently.
 func rangeAggregationGroupBy(e *syntax.RangeAggregationExpr, s schema.Logs) (chplan.Expr, error) {
 	if e.Grouping == nil {
 		return nil, nil
@@ -348,7 +354,7 @@ func rangeAggregationGroupBy(e *syntax.RangeAggregationExpr, s schema.Logs) (chp
 	if e.Grouping.Without {
 		return &chplan.MapWithoutKeys{
 			Map:  &chplan.ColumnRef{Name: s.ResourceAttributesColumn},
-			Keys: append([]string(nil), e.Grouping.Groups...),
+			Keys: canonicalLevelKeys(e.Grouping.Groups),
 		}, nil
 	}
 	args := make([]chplan.Expr, 0, len(e.Grouping.Groups)*2)
@@ -356,10 +362,7 @@ func rangeAggregationGroupBy(e *syntax.RangeAggregationExpr, s schema.Logs) (chp
 		args = append(
 			args,
 			&chplan.LitString{V: label},
-			&chplan.MapAccess{
-				Map: &chplan.ColumnRef{Name: s.ResourceAttributesColumn},
-				Key: &chplan.LitString{V: label},
-			},
+			levelAwareRangeGroupKey(label, s),
 		)
 	}
 	return &chplan.FuncCall{Name: "map", Args: args}, nil

--- a/internal/logql/vector_aggregation.go
+++ b/internal/logql/vector_aggregation.go
@@ -71,17 +71,31 @@ func lowerVectorAggregation(e *syntax.VectorAggregationExpr, s schema.Logs, lc l
 // in OTel-CH). The output shape exposes group-key columns as
 // `gkey_0`, `gkey_1`, ... so the wrapping Project can build a
 // Map(String, String) Attributes column from them.
+//
+// The synthesized `detected_level` label (and its `level` alias) is
+// special-cased: instead of accessing the RangeWindow's downstream
+// ResourceAttributes column under a key the seeder doesn't write, the
+// group-key expression resolves to the same SeverityText-derived
+// `multiIf(...)` normalisation upstream Loki's `normalizeLogLevel`
+// produces. Without this, `sum by (level) (...)` collapses every record
+// into one empty-value group (the user-facing reason 15 loki-compat
+// `matrix length: expected=4 actual=1` failures persisted post-PR #545).
 func vectorAggregationGroupBy(e *syntax.VectorAggregationExpr, s schema.Logs) ([]chplan.Expr, []string) {
 	if e.Grouping == nil {
 		return nil, nil
 	}
 	if e.Grouping.Without {
 		// `without (k1, k2)`: group by the full ResourceAttributes map
-		// minus the excluded keys.
+		// minus the excluded keys. Normalise `level` to its
+		// `detected_level` canonical form so the exclusion strips the
+		// synthesized-severity key the inner range-aggregation
+		// projection added (via withDetectedLevel). Mirroring the
+		// `by (...)` alias surface keeps the two grouping shapes
+		// symmetric.
 		return []chplan.Expr{
 				&chplan.MapWithoutKeys{
 					Map:  &chplan.ColumnRef{Name: s.ResourceAttributesColumn},
-					Keys: append([]string(nil), e.Grouping.Groups...),
+					Keys: canonicalLevelKeys(e.Grouping.Groups),
 				},
 			},
 			[]string{"gkey_0"}
@@ -92,13 +106,79 @@ func vectorAggregationGroupBy(e *syntax.VectorAggregationExpr, s schema.Logs) ([
 	out := make([]chplan.Expr, 0, len(e.Grouping.Groups))
 	aliases := make([]string, 0, len(e.Grouping.Groups))
 	for i, label := range e.Grouping.Groups {
-		out = append(out, &chplan.MapAccess{
-			Map: &chplan.ColumnRef{Name: s.ResourceAttributesColumn},
-			Key: &chplan.LitString{V: label},
-		})
+		out = append(out, levelAwareGroupKey(label, s))
 		aliases = append(aliases, fmt.Sprintf("gkey_%d", i))
 	}
 	return out, aliases
+}
+
+// levelAwareGroupKey returns the chplan expression that resolves to the
+// group-by value for `label` in a vector-aggregation context (outer
+// `sum by (...)` / `max without (...)`, etc., wrapping a range
+// aggregation). The `detected_level` family (`detected_level` and its
+// `level` alias) reaches through the augmented `ResourceAttributes` map
+// under the canonical `detected_level` key — the inner range
+// aggregation's [withDetectedLevel] projection is what populates that
+// key from SeverityText (see detected_level.go). Reading the
+// synthesized key from the map (rather than re-deriving from
+// `SeverityText`) keeps the outer aggregation SQL self-contained:
+// SeverityText is only visible inside the inner Scan, and the outer
+// SELECT only sees the (ResourceAttributes, Value) tuple the RangeWindow
+// projected.
+//
+// Other labels fall back to the standard map lookup. The inner
+// range-aggregation `by/without` uses the SeverityText-derived
+// expression directly via [levelAwareRangeGroupKey] because at that
+// layer SeverityText is still in scope.
+func levelAwareGroupKey(label string, s schema.Logs) chplan.Expr {
+	if isDetectedLevelGroupingLabel(label) {
+		return &chplan.MapAccess{
+			Map: &chplan.ColumnRef{Name: s.ResourceAttributesColumn},
+			Key: &chplan.LitString{V: detectedLevelLabel},
+		}
+	}
+	return &chplan.MapAccess{
+		Map: &chplan.ColumnRef{Name: s.ResourceAttributesColumn},
+		Key: &chplan.LitString{V: label},
+	}
+}
+
+// levelAwareRangeGroupKey is the inner-range-aggregation companion of
+// [levelAwareGroupKey]: it resolves the `detected_level` family
+// (`detected_level` and its `level` alias) to the
+// SeverityText-derived `multiIf(...)` expression directly, because the
+// inner Project still has `SeverityText` in scope (the Project rides
+// directly above the per-row Scan/Filter). The outer
+// vector-aggregation reads from the post-RangeWindow scope where
+// SeverityText is no longer visible, so it has to reach through the
+// augmented map's `detected_level` key instead.
+func levelAwareRangeGroupKey(label string, s schema.Logs) chplan.Expr {
+	if isDetectedLevelGroupingLabel(label) {
+		return detectedLevelExpr(s)
+	}
+	return &chplan.MapAccess{
+		Map: &chplan.ColumnRef{Name: s.ResourceAttributesColumn},
+		Key: &chplan.LitString{V: label},
+	}
+}
+
+// canonicalLevelKeys returns the input `groups` with every
+// `detected_level`-family key (`detected_level` itself + its `level`
+// alias) normalised to the canonical `detected_level` form. Used by
+// the `without (...)` lowering so the exclusion strips the synthesized
+// key the inner range-aggregation projection added via
+// withDetectedLevel — both `without (level)` and
+// `without (detected_level)` reach the same downstream map shape.
+func canonicalLevelKeys(groups []string) []string {
+	out := make([]string, len(groups))
+	for i, g := range groups {
+		if isDetectedLevelGroupingLabel(g) {
+			out[i] = detectedLevelLabel
+			continue
+		}
+		out[i] = g
+	}
+	return out
 }
 
 // buildVectorAggFunc produces the AggFunc for the LogQL operator.

--- a/test/spec/logql/edge_sum_by_rate.txtar
+++ b/test/spec/logql/edge_sum_by_rate.txtar
@@ -6,7 +6,7 @@ sum by (job, level) (rate({job="api"}[5m]))
 [2] string = "level"
 [3] int64 = 9
 [4] string = "job"
-[5] string = "level"
+[5] string = "detected_level"
 [6] float64 = 300
 [7] string = ""
 [8] string = "detected_level"
@@ -35,7 +35,7 @@ sum by (job, level) (rate({job="api"}[5m]))
 [31] string = "job"
 [32] string = "api"
 [33] string = "job"
-[34] string = "level"
+[34] string = "detected_level"
 -- sql --
 SELECT ? AS `MetricName`, map(?, `gkey_0`, ?, `gkey_1`) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`[?] AS `gkey_0`, `ResourceAttributes`[?] AS `gkey_1`, sum(`Value`) AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`)))) GROUP BY `ResourceAttributes`[?], `ResourceAttributes`[?])
 -- seed --
@@ -45,13 +45,13 @@ CREATE TABLE otel_logs (
     SeverityText LowCardinality(String) DEFAULT '',
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
-INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
-    (toDateTime64('2025-12-31 23:58:00', 9), 'a', map('job', 'api', 'level', 'info')),
-    (toDateTime64('2025-12-31 23:59:00', 9), 'b', map('job', 'api', 'level', 'info')),
-    (toDateTime64('2026-01-01 00:00:00', 9), 'c', map('job', 'api', 'level', 'info')),
-    (toDateTime64('2025-12-31 23:58:00', 9), 'd', map('job', 'api', 'level', 'error')),
-    (toDateTime64('2025-12-31 23:59:00', 9), 'e', map('job', 'api', 'level', 'error')),
-    (toDateTime64('2026-01-01 00:00:00', 9), 'f', map('job', 'api', 'level', 'error'));
+INSERT INTO otel_logs (Timestamp, Body, SeverityText, ResourceAttributes) VALUES
+    (toDateTime64('2025-12-31 23:58:00', 9), 'a', 'INFO',  map('job', 'api')),
+    (toDateTime64('2025-12-31 23:59:00', 9), 'b', 'INFO',  map('job', 'api')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'c', 'INFO',  map('job', 'api')),
+    (toDateTime64('2025-12-31 23:58:00', 9), 'd', 'ERROR', map('job', 'api')),
+    (toDateTime64('2025-12-31 23:59:00', 9), 'e', 'ERROR', map('job', 'api')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'f', 'ERROR', map('job', 'api'));
 -- expected_rows --
 [
   ["", {"job": "api", "level": "error"}, "2026-01-01T00:00:01Z", 0.01],
@@ -59,7 +59,7 @@ INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
 ]
 -- chplan --
 Project ["" AS MetricName, map("job", gkey_0, "level", gkey_1) AS Attributes, now64(9) AS TimeUnix, Value AS Value]
-  Aggregate groupBy=[ResourceAttributes["job"] AS gkey_0, ResourceAttributes["level"] AS gkey_1] funcs=[sum(Value) AS Value]
+  Aggregate groupBy=[ResourceAttributes["job"] AS gkey_0, ResourceAttributes["detected_level"] AS gkey_1] funcs=[sum(Value) AS Value]
     RangeWindow func=log_rate range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
       Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, 1 AS Value]
         Filter predicate=(ResourceAttributes["job"] = "api")

--- a/test/spec/logql/range_agg_by_grouping.txtar
+++ b/test/spec/logql/range_agg_by_grouping.txtar
@@ -7,11 +7,11 @@ CREATE TABLE otel_logs (
     SeverityText LowCardinality(String) DEFAULT '',
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;
-INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
-    (toDateTime64('2025-12-31 23:58:00', 9), 'latency=10 path=/a', map('job', 'api', 'level', 'info')),
-    (toDateTime64('2026-01-01 00:00:00', 9), 'latency=20 path=/b', map('job', 'api', 'level', 'info')),
-    (toDateTime64('2025-12-31 23:58:00', 9), 'latency=100 path=/c', map('job', 'api', 'level', 'error')),
-    (toDateTime64('2026-01-01 00:00:00', 9), 'latency=200 path=/d', map('job', 'api', 'level', 'error'));
+INSERT INTO otel_logs (Timestamp, Body, SeverityText, ResourceAttributes) VALUES
+    (toDateTime64('2025-12-31 23:58:00', 9), 'latency=10 path=/a',  'INFO',  map('job', 'api')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'latency=20 path=/b',  'INFO',  map('job', 'api')),
+    (toDateTime64('2025-12-31 23:58:00', 9), 'latency=100 path=/c', 'ERROR', map('job', 'api')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'latency=200 path=/d', 'ERROR', map('job', 'api'));
 -- expected_rows --
 [
   [{"level": "error"}, 150.0],
@@ -19,18 +19,38 @@ INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
 ]
 -- args --
 [0] string = "level"
-[1] string = "level"
-[2] string = "_extracted"
-[3] string = "="
-[4] string = " "
-[5] string = "\""
-[6] string = "latency"
-[7] string = "job"
-[8] string = "api"
+[1] string = "trace"
+[2] string = "trc"
+[3] string = "trace"
+[4] string = "debug"
+[5] string = "dbg"
+[6] string = "debug"
+[7] string = "info"
+[8] string = "inf"
+[9] string = "information"
+[10] string = "info"
+[11] string = "warn"
+[12] string = "wrn"
+[13] string = "warning"
+[14] string = "warn"
+[15] string = "error"
+[16] string = "err"
+[17] string = "error"
+[18] string = "critical"
+[19] string = "critical"
+[20] string = "fatal"
+[21] string = "fatal"
+[22] string = "_extracted"
+[23] string = "="
+[24] string = " "
+[25] string = "\""
+[26] string = "latency"
+[27] string = "job"
+[28] string = "api"
 -- chplan --
 RangeWindow func=avg_over_time range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
-  Project [map("level", ResourceAttributes["level"]) AS ResourceAttributes, Timestamp, toFloat64OrZero(mapConcat(ResourceAttributes, mapApply((k, v) -> tuple(if(mapContains(ResourceAttributes, k), concat(k, "_extracted"), k), v), extractKeyValuePairs(Body, "=", " ", "\"")))["latency"]) AS Value]
+  Project [map("level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))) AS ResourceAttributes, Timestamp, toFloat64OrZero(mapConcat(ResourceAttributes, mapApply((k, v) -> tuple(if(mapContains(ResourceAttributes, k), concat(k, "_extracted"), k), v), extractKeyValuePairs(Body, "=", " ", "\"")))["latency"]) AS Value]
     Filter predicate=(ResourceAttributes["job"] = "api")
       Scan(otel_logs)
 -- sql --
-SELECT `ResourceAttributes`, if(length(window_vals) > 0, arrayAvg(window_vals), nan) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT map(?, `ResourceAttributes`[?]) AS `ResourceAttributes`, `Timestamp`, toFloat64OrZero(mapConcat(`ResourceAttributes`, mapApply((k, v) -> tuple(if(mapContains(`ResourceAttributes`, k), concat(k, ?), k), v), extractKeyValuePairs(`Body`, ?, ?, ?)))[?]) AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1
+SELECT `ResourceAttributes`, if(length(window_vals) > 0, arrayAvg(window_vals), nan) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))) AS `ResourceAttributes`, `Timestamp`, toFloat64OrZero(mapConcat(`ResourceAttributes`, mapApply((k, v) -> tuple(if(mapContains(`ResourceAttributes`, k), concat(k, ?), k), v), extractKeyValuePairs(`Body`, ?, ?, ?)))[?]) AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1

--- a/test/spec/logql/sum_by_level_count_over_time.txtar
+++ b/test/spec/logql/sum_by_level_count_over_time.txtar
@@ -1,0 +1,63 @@
+-- query.logql --
+sum by (level) (count_over_time({app="api"}[5m]))
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, SeverityText, ResourceAttributes) VALUES
+    (toDateTime64('2025-12-31 23:57:00', 9), 'a', 'INFO',  map('app', 'api')),
+    (toDateTime64('2025-12-31 23:58:00', 9), 'b', 'INFO',  map('app', 'api')),
+    (toDateTime64('2025-12-31 23:59:00', 9), 'c', 'WARN',  map('app', 'api')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'd', 'ERROR', map('app', 'api')),
+    (toDateTime64('2026-01-01 00:00:01', 9), 'e', 'DEBUG', map('app', 'api'));
+-- expected_rows --
+[
+  ["", {"level": "debug"}, "2026-01-01T00:00:01Z", 1.0],
+  ["", {"level": "error"}, "2026-01-01T00:00:01Z", 1.0],
+  ["", {"level": "info"},  "2026-01-01T00:00:01Z", 2.0],
+  ["", {"level": "warn"},  "2026-01-01T00:00:01Z", 1.0]
+]
+-- args --
+[0] string = ""
+[1] string = "level"
+[2] int64 = 9
+[3] string = "detected_level"
+[4] string = ""
+[5] string = "detected_level"
+[6] string = "trace"
+[7] string = "trc"
+[8] string = "trace"
+[9] string = "debug"
+[10] string = "dbg"
+[11] string = "debug"
+[12] string = "info"
+[13] string = "inf"
+[14] string = "information"
+[15] string = "info"
+[16] string = "warn"
+[17] string = "wrn"
+[18] string = "warning"
+[19] string = "warn"
+[20] string = "error"
+[21] string = "err"
+[22] string = "error"
+[23] string = "critical"
+[24] string = "critical"
+[25] string = "fatal"
+[26] string = "fatal"
+[27] int64 = 1
+[28] string = "app"
+[29] string = "api"
+[30] string = "detected_level"
+-- chplan --
+Project ["" AS MetricName, map("level", gkey_0) AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+  Aggregate groupBy=[ResourceAttributes["detected_level"] AS gkey_0] funcs=[sum(Value) AS Value]
+    RangeWindow func=count_over_time range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
+      Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, 1 AS Value]
+        Filter predicate=(ResourceAttributes["app"] = "api")
+          Scan(otel_logs)
+-- sql --
+SELECT ? AS `MetricName`, map(?, `gkey_0`) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`[?] AS `gkey_0`, sum(`Value`) AS `Value` FROM (SELECT `ResourceAttributes`, toFloat64(length(window_vals)) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1) GROUP BY `ResourceAttributes`[?])


### PR DESCRIPTION
## Summary

- Fixes the largest remaining loki-compat cluster: `sum by (level) (count_over_time({...}[5m]))` (and friends) collapsing 4 severity series into 1.
- Routes vector-aggregation `by/without` on `level` through the augmented `ResourceAttributes[detected_level]` lookup; routes inner range-aggregation `by/without` through the SeverityText-derived `multiIf(...)` directly (different layers, different in-scope columns).
- Keeps label-filter / stream-selector matchers on the strict-canonical `detected_level` path so `{job="api"} | logfmt | level="error"` still resolves `level` through the parser-augmented labels map (logfmt extraction wins).

## Root cause

PR #545 surfaced `detected_level` as a stream-label dimension on bare range aggregations (no `by/without`) but explicitly skipped the by/without case to "respect user intent". But the failing queries write `sum by (level) (...)` — the user IS explicitly asking to group by the synthesized severity dimension. Cerberus's OTel-CH seeder doesn't write a bare `level` key into `ResourceAttributes` (only `LogAttributes` + `SeverityText`), so `RA["level"]` returned empty and collapsed all 4 series.

## Approach

Split the alias surface:

| Context | Function | `level` routes via |
|---|---|---|
| Outer vector aggregation `by (...)` / `without (...)` | `isDetectedLevelGroupingLabel` | `RA["detected_level"]` (augmented map's canonical key) |
| Inner range aggregation `by (...)` / `without (...)` | `isDetectedLevelGroupingLabel` | `multiIf(SeverityText...)` directly (Project still in scope) |
| Label-filter `\| level="..."` / stream-selector `{level="..."}` | `isDetectedLevelLabel` (unchanged) | parser-augmented `labelsExpr["level"]` |

The boundary keeps logfmt-extracted `level` working while making `by (level)` see the synthesized severity.

## Fixtures

- `edge_sum_by_rate.txtar`: seed moved from `level` in `ResourceAttributes` to `SeverityText` (the post-fix contract).
- `range_agg_by_grouping.txtar`: same migration.
- `sum_by_level_count_over_time.txtar`: new fixture pinning the canonical `sum by (level) (count_over_time({...}[5m]))` shape — 5 rows across 4 severities, expected 4 series, validated end-to-end via chDB roundtrip.

## Test plan

- [x] Unit tests in `internal/logql/detected_level_test.go` pin the new grouping behavior + the matcher-vs-grouping split.
- [x] chDB roundtrip on `sum_by_level_count_over_time.txtar` returns 4 series (info/warn/error/debug) with correct counts.
- [x] All existing `internal/logql/...` and `test/spec/...` tests pass (including with `-tags=chdb`).
- [ ] CI loki-compat harness reports ~65%+ pass rate (up from 30.43%).