### PR TITLE
fix(api/tempo): zero-fill matrix step grid for count_over_time and rate

### DIFF
--- a/internal/api/tempo/metrics_query_range.go
+++ b/internal/api/tempo/metrics_query_range.go
@@ -256,6 +256,23 @@ func (h *Handler) handleMetricsQueryRange(w http.ResponseWriter, r *http.Request
 		"sql", res.SQL, "args", res.Args)
 
 	series := toMetricsSeries(res.Samples, metrics)
+	// Zero-fill the matrix step grid for count/rate operators so the
+	// response shape matches Tempo's reference engine_metrics.go: its
+	// StepAggregator pre-allocates one CountOverTimeAggregator per
+	// interval whose default Sample() is 0 (count starts at zero), so
+	// empty buckets surface as 0-valued samples across the full
+	// [Start, End] grid. Cerberus's matrix SQL emits one row per
+	// (group, anchor) bucket only when at least one span falls in
+	// (anchor_ts - range, anchor_ts]; without this post-step empty
+	// buckets disappear, dropping samples count from N to (#observed
+	// buckets) — the smoke corpus's count_over_time_groupby_service
+	// case showed tempo=121 vs cerberus=2 against the same seeded
+	// dataset for that reason. Tempo's OverTimeAggregator (sum / avg /
+	// min / max / quantile) initialises its value to NaN, and the
+	// ToProto loop skips NaN samples — so those operators already
+	// match cerberus's observed-only emission without a zero-fill
+	// pass.
+	series = zeroFillMatrixGrid(series, metrics, start, end, step)
 
 	exSQL, exArgs, exErr := chsql.EmitMetricsExemplars(ctx, rw, metrics,
 		h.Schema.TraceIDColumn, h.Schema.SpanIDColumn, 1)
@@ -384,7 +401,8 @@ func wrapMetricsForSample(rw *chplan.RangeWindow, m *chplan.MetricsAggregate) ch
 			)
 		}
 		if multiPhi {
-			args = append(args,
+			args = append(
+				args,
 				&chplan.LitString{V: tempoMultiQuantilePhiLabel},
 				&chplan.ColumnRef{Name: tempoMultiQuantilePhiLabel},
 			)
@@ -506,6 +524,97 @@ func toMetricsSeries(samples []chclient.Sample, m *chplan.MetricsAggregate) []Me
 		})
 	}
 	return out
+}
+
+// zeroFillMatrixGrid extends each series's Samples to the full matrix
+// step grid for `| count_over_time()` and `| rate()` queries, inserting
+// 0-valued samples for anchors that had no observed spans.
+//
+// Tempo's reference metrics engine pre-allocates one
+// CountOverTimeAggregator per interval (engine_metrics.go::StepAggregator)
+// whose default Sample() is 0; its ToProto path emits the full grid for
+// count/rate. Cerberus's matrix SQL only emits rows for (group, anchor)
+// pairs where at least one span lands in (anchor_ts - range, anchor_ts],
+// so without this fill the response loses every empty bucket and the
+// differ trips on `samples count tempo=N vs cerberus=M`.
+//
+// The fill anchors mirror the chsql emitter's
+// arrayJoin(arrayMap(i -> End - i*Step, range(0, N))) grid:
+// anchor[i] = end - i*step for i in [0, N), with N = (end-start)/step + 1.
+// In ascending timestamp order that yields [start, start+step, ...,
+// end-step, end]. Each series is filled independently; series that
+// never observed any span are left absent (matches Tempo's
+// SpanAggregator.Observe gating).
+//
+// No-op when:
+//   - step <= 0 (defensive — the handler rejects step <= 0 upstream,
+//     so this branch only fires under tests that bypass the request
+//     validator),
+//   - start / end aren't both set (the chsql matrix path falls back to
+//     a single anchor at End in that case; one sample per series is
+//     fine without a fill),
+//   - the metrics op isn't count_over_time / rate (sum / avg / min /
+//     max / quantile share Tempo's NaN-skip semantics — see
+//     OverTimeAggregator initialisation in engine_metrics.go),
+//   - the input slice is empty (no observed series → no zero-fill;
+//     mirrors Tempo's behaviour of only initialising entries via
+//     SpanAggregator.Observe).
+func zeroFillMatrixGrid(series []MetricsSeries, m *chplan.MetricsAggregate, start, end time.Time, step time.Duration) []MetricsSeries {
+	if len(series) == 0 || step <= 0 || start.IsZero() || end.IsZero() {
+		return series
+	}
+	if m.Op != chplan.MetricsOpCountOverTime && m.Op != chplan.MetricsOpRate {
+		return series
+	}
+	span := end.Sub(start)
+	if span < 0 {
+		return series
+	}
+	stepNS := step.Nanoseconds()
+	if stepNS <= 0 {
+		return series
+	}
+	// N = span/step + 1 matches chsql's numAnchors so the post-fill
+	// grid exactly aligns with the matrix anchor set the emitter
+	// produced.
+	n := span.Nanoseconds()/stepNS + 1
+	if n <= 1 {
+		return series
+	}
+	// Pre-compute the anchor grid as DateTime64-precision unix-milli
+	// values so the merge below operates on integer keys (the wire
+	// shape's TimestampMs).
+	anchors := make([]int64, 0, n)
+	for i := int64(0); i < n; i++ {
+		anchorTS := end.Add(-time.Duration(i) * step)
+		anchors = append(anchors, anchorTS.UnixMilli())
+	}
+	// Anchors come back end-down; reorder to ascending so the merged
+	// samples slice ends up sorted (toMetricsSeries already sorts each
+	// series ascending; we keep the invariant after fill).
+	sort.Slice(anchors, func(i, j int) bool { return anchors[i] < anchors[j] })
+
+	for i := range series {
+		present := make(map[int64]struct{}, len(series[i].Samples))
+		for _, s := range series[i].Samples {
+			present[s.TimestampMs] = struct{}{}
+		}
+		out := make([]MetricsSample, 0, len(anchors))
+		for _, ts := range anchors {
+			if _, ok := present[ts]; ok {
+				continue
+			}
+			out = append(out, MetricsSample{TimestampMs: ts, Value: 0})
+		}
+		if len(out) == 0 {
+			continue
+		}
+		series[i].Samples = append(series[i].Samples, out...)
+		sort.Slice(series[i].Samples, func(a, b int) bool {
+			return series[i].Samples[a].TimestampMs < series[i].Samples[b].TimestampMs
+		})
+	}
+	return series
 }
 
 // labelsFromSample materialises the {key,value} pair slice for one

--- a/internal/api/tempo/metrics_query_range_test.go
+++ b/internal/api/tempo/metrics_query_range_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -36,8 +37,15 @@ const (
 )
 
 // TestMetricsQueryRange_SingleSeriesNoGroupBy — a bare `| rate()` over
-// the full spans table returns a single series (no labels). Three
-// anchor rows in, three samples out, sorted by timestamp ascending.
+// the full spans table returns a single series (no labels). The handler
+// zero-fills the matrix step grid for count/rate operators so the
+// response covers every anchor across [start, end] spaced by step —
+// matching Tempo's StepAggregator pre-allocating one CountOverTimeAggregator
+// per interval. With a 3-minute fixture window and 60s step that's
+// 4 anchors (10:00, 10:01, 10:02, 10:03); the stub returns observed
+// values at the first three, the fill injects a 0-valued sample at the
+// trailing anchor so the samples stream matches the wire-grid Tempo
+// emits.
 func TestMetricsQueryRange_SingleSeriesNoGroupBy(t *testing.T) {
 	t.Parallel()
 
@@ -79,18 +87,22 @@ func TestMetricsQueryRange_SingleSeriesNoGroupBy(t *testing.T) {
 	if len(s.Labels) != 0 {
 		t.Errorf("expected zero labels for ungrouped query, got %+v", s.Labels)
 	}
-	if len(s.Samples) != 3 {
-		t.Fatalf("expected 3 samples, got %d", len(s.Samples))
+	// 3-minute window @ 60s step → 4 anchors after zero-fill (10:00 /
+	// 10:01 / 10:02 / 10:03), with the trailing anchor synthesised at
+	// value 0 since the stub didn't observe a span there.
+	if len(s.Samples) != 4 {
+		t.Fatalf("expected 4 samples (3 observed + 1 zero-fill), got %d: %+v", len(s.Samples), s.Samples)
 	}
-	// Sorted ascending: 0.5, 1.5, 2.0 in that order.
-	for i, want := range []float64{0.5, 1.5, 2.0} {
+	// Sorted ascending: 0.5, 1.5, 2.0, 0 (fill) in that order.
+	for i, want := range []float64{0.5, 1.5, 2.0, 0.0} {
 		if s.Samples[i].Value != want {
 			t.Errorf("sample[%d].Value = %v, want %v", i, s.Samples[i].Value, want)
 		}
 	}
-	if s.Samples[0].TimestampMs >= s.Samples[1].TimestampMs ||
-		s.Samples[1].TimestampMs >= s.Samples[2].TimestampMs {
-		t.Errorf("samples not sorted ascending by timestamp: %+v", s.Samples)
+	for i := 1; i < len(s.Samples); i++ {
+		if s.Samples[i-1].TimestampMs >= s.Samples[i].TimestampMs {
+			t.Errorf("samples not sorted ascending by timestamp: %+v", s.Samples)
+		}
 	}
 
 	// The handler should have asked the matrix-shape SQL emitter (an
@@ -162,8 +174,18 @@ func TestMetricsQueryRange_MultiSeriesGroupBy(t *testing.T) {
 	if _, ok := byService["backend"]; !ok {
 		t.Errorf("missing 'backend' series: %+v", body.Series)
 	}
-	if len(byService["frontend"].Samples) != 2 {
-		t.Errorf("expected 2 samples for frontend, got %d", len(byService["frontend"].Samples))
+	// Each series's samples cover the full matrix grid: 4 anchors over
+	// the 3-minute window @ 60s step, with two observed values (mins
+	// 0 / 1) and two zero-filled anchors (mins 2 / 3) so the response
+	// shape matches Tempo's StepAggregator emit (count_over_time over
+	// empty buckets surfaces as 0, not as a missing sample).
+	if len(byService["frontend"].Samples) != 4 {
+		t.Errorf("expected 4 samples for frontend (2 observed + 2 zero-fill), got %d: %+v",
+			len(byService["frontend"].Samples), byService["frontend"].Samples)
+	}
+	if len(byService["backend"].Samples) != 4 {
+		t.Errorf("expected 4 samples for backend (2 observed + 2 zero-fill), got %d: %+v",
+			len(byService["backend"].Samples), byService["backend"].Samples)
 	}
 }
 
@@ -201,6 +223,148 @@ func TestMetricsQueryRange_EmptyResult(t *testing.T) {
 	if len(body.Series) != 0 {
 		t.Fatalf("expected 0 series, got %d", len(body.Series))
 	}
+}
+
+// TestMetricsQueryRange_ZeroFillCountOverTime pins the contract that
+// `count_over_time` (and `rate`) responses zero-fill the full matrix
+// step grid across [start, end] — even buckets where no spans landed —
+// to match Tempo's reference engine_metrics.go StepAggregator, which
+// pre-allocates one CountOverTimeAggregator per interval (default
+// Sample()=0). Without this, the tempo-compat differ trips on
+// `samples count tempo=N vs cerberus=M` for count/rate queries whose
+// seeded data only spans a few buckets of the request window.
+//
+// Setup: 3-minute window @ 60s step → 4 anchors (10:00 / 10:01 / 10:02
+// / 10:03). The CH stub returns exactly one row (10:01); the handler
+// must surface a 4-sample stream with the missing three anchors at
+// value 0.
+func TestMetricsQueryRange_ZeroFillCountOverTime(t *testing.T) {
+	t.Parallel()
+
+	mid := time.Date(2026, 5, 12, 10, 1, 0, 0, time.UTC)
+	q := &stubQuerier{samples: []chclient.Sample{{
+		MetricName: "",
+		Labels:     map[string]string{},
+		Timestamp:  mid,
+		Value:      7.0,
+	}}}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	u := metricsQueryRangeURL(srv.URL, "{} | count_over_time()", map[string]string{
+		"start": fixtureStartUnix,
+		"end":   fixtureEndUnix,
+		"step":  "60s",
+	})
+	resp, err := http.Get(u)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+
+	var body tempo.MetricsQueryRangeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Series) != 1 {
+		t.Fatalf("expected 1 series, got %d: %+v", len(body.Series), body)
+	}
+	s := body.Series[0]
+	if len(s.Samples) != 4 {
+		t.Fatalf("expected 4 samples (1 observed + 3 zero-fill), got %d: %+v", len(s.Samples), s.Samples)
+	}
+	// Samples MUST be sorted ascending by timestamp and the observed
+	// sample's value must survive the fill verbatim. Missing anchors
+	// land at 0.
+	wantValues := []float64{0.0, 7.0, 0.0, 0.0}
+	for i, want := range wantValues {
+		if s.Samples[i].Value != want {
+			t.Errorf("sample[%d].Value = %v, want %v (full stream: %+v)", i, s.Samples[i].Value, want, s.Samples)
+		}
+	}
+	for i := 1; i < len(s.Samples); i++ {
+		if s.Samples[i-1].TimestampMs >= s.Samples[i].TimestampMs {
+			t.Errorf("samples not sorted ascending: %+v", s.Samples)
+		}
+	}
+	// Sample timestamps must exactly cover the matrix anchor grid the
+	// chsql emitter produced — `end - i*step` for i in [0, N). Verify
+	// the first / last anchors line up with fixtureStartUnix /
+	// fixtureEndUnix so the wire grid aligns with what Tempo returns
+	// for the same request.
+	startMs := mustParseUnix(t, fixtureStartUnix).UnixMilli()
+	endMs := mustParseUnix(t, fixtureEndUnix).UnixMilli()
+	if s.Samples[0].TimestampMs != startMs {
+		t.Errorf("first sample ts = %d, want fixtureStart=%d", s.Samples[0].TimestampMs, startMs)
+	}
+	if s.Samples[len(s.Samples)-1].TimestampMs != endMs {
+		t.Errorf("last sample ts = %d, want fixtureEnd=%d", s.Samples[len(s.Samples)-1].TimestampMs, endMs)
+	}
+}
+
+// TestMetricsQueryRange_ZeroFillSkippedForAvgOverTime pins the contract
+// that the zero-fill pass only fires for count_over_time / rate. For
+// sum / avg / min / max / quantile_over_time, Tempo's
+// OverTimeAggregator initialises val=NaN and the ToProto loop skips
+// NaN samples, so the observed-only emission cerberus produces today
+// is the wire-correct match — zero-filling would inject false zeros
+// where Tempo emits nothing.
+func TestMetricsQueryRange_ZeroFillSkippedForAvgOverTime(t *testing.T) {
+	t.Parallel()
+
+	mid := time.Date(2026, 5, 12, 10, 1, 0, 0, time.UTC)
+	q := &stubQuerier{samples: []chclient.Sample{{
+		MetricName: "",
+		Labels:     map[string]string{},
+		Timestamp:  mid,
+		Value:      42.0,
+	}}}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	u := metricsQueryRangeURL(srv.URL, "{} | avg_over_time(duration)", map[string]string{
+		"start": fixtureStartUnix,
+		"end":   fixtureEndUnix,
+		"step":  "60s",
+	})
+	resp, err := http.Get(u)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	var body tempo.MetricsQueryRangeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Series) != 1 {
+		t.Fatalf("expected 1 series, got %d", len(body.Series))
+	}
+	s := body.Series[0]
+	if len(s.Samples) != 1 {
+		t.Errorf("expected 1 observed sample for avg_over_time (no zero-fill), got %d: %+v",
+			len(s.Samples), s.Samples)
+	}
+	if s.Samples[0].Value != 42.0 {
+		t.Errorf("expected observed sample value 42, got %v", s.Samples[0].Value)
+	}
+}
+
+// mustParseUnix parses a unix-seconds string and returns a UTC time,
+// failing the test on parse error. Mirrors parseTempoTime's heuristics
+// but tightened to the int64-only path the fixture timestamps use.
+func mustParseUnix(t *testing.T, raw string) time.Time {
+	t.Helper()
+	n, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		t.Fatalf("parse fixture unix %q: %v", raw, err)
+	}
+	return time.Unix(n, 0).UTC()
 }
 
 // TestMetricsQueryRange_BadInputs covers the 4xx surface: missing or
@@ -647,8 +811,12 @@ func TestMetricsQueryRange_ExemplarsPopulated(t *testing.T) {
 		t.Fatalf("expected 1 series, got %d: %+v", len(body.Series), body)
 	}
 	got := body.Series[0]
-	if len(got.Samples) != 2 {
-		t.Errorf("expected 2 samples, got %d", len(got.Samples))
+	// Matrix grid is 4 anchors (3-min window @ 60s step); two are
+	// observed (mins 0 / 1), the trailing pair (mins 2 / 3) are
+	// zero-filled so the count_over_time response matches Tempo's
+	// StepAggregator emit.
+	if len(got.Samples) != 4 {
+		t.Errorf("expected 4 samples (2 observed + 2 zero-fill), got %d: %+v", len(got.Samples), got.Samples)
 	}
 	if len(got.Exemplars) != 2 {
 		t.Fatalf("expected 2 exemplars, got %d: %+v", len(got.Exemplars), got.Exemplars)


### PR DESCRIPTION
## Summary

Tempo's reference `engine_metrics.go::StepAggregator` pre-allocates one
`CountOverTimeAggregator` per interval whose default `Sample()` is 0, so empty
buckets surface as 0-valued samples across the full `[Start, End]` grid in
`/api/metrics/query_range`. Cerberus's matrix SQL only emits rows for
`(group, anchor)` pairs where at least one span lands in
`(anchor_ts - range, anchor_ts]`, so without a post-pass empty buckets disappear
and the smoke corpus's `count_over_time_groupby_service` case trips
`samples count tempo=121 vs cerberus=2 / sample[0] ts tempo=...4000000 vs
cerberus=...7660000` against the same seeded dataset.

The fix adds a handler-side `zeroFillMatrixGrid` pass invoked after
`toMetricsSeries`: it walks each existing series, builds the canonical anchor
grid (`end - i*step` for i in `[0, N)` where `N = (end-start)/step + 1`,
exactly matching the chsql emitter's `anchorFanoutFrag`), and injects 0-valued
samples for anchors with no observed bucket row. The fill only fires for
`MetricsOpCountOverTime` / `MetricsOpRate` — Tempo's `OverTimeAggregator`
(sum / avg / min / max / quantile) initialises `val=NaN` and the `ToProto`
loop skips NaN samples, so cerberus's observed-only emission already matches
for those operators without injecting false zeros.

No raw SQL is added — the fix is post-execution in pure Go. The chsql typed
builder API is untouched.

## Affected smoke corpus cases

- `metrics_count_over_time_groupby_service`: 2 → 121 samples per series;
  first sample ts aligns at Start (matrix grid anchor[0]) instead of the
  first observed bucket.
- `metrics_rate_no_groupby`: same matrix-grid fill semantics.
- `metrics_count_over_time_instant` / `metrics_rate_instant` /
  `metrics_avg_over_time_instant`: instant handler reuses range emit
  (step = end - start so N = 2), the extra start-anchor zero doesn't
  affect `toMetricsInstantSeries` because the instant code already
  isolates the end-bucket sample.
- `metrics_quantile_over_time_p95`: unchanged (NaN-skip path matches
  Tempo's OverTimeAggregator).

Expected tempo-compat delta: ~+18% across the six smoke-corpus cases.

## Test plan

- [x] New `TestMetricsQueryRange_ZeroFillCountOverTime` asserts a single
  observed bucket fans out to 4 samples (3-min window @ 60s step) with the
  observed value preserved at the middle anchor and 0s at the surrounding
  three; first / last sample timestamps line up with the request's start /
  end exactly.
- [x] New `TestMetricsQueryRange_ZeroFillSkippedForAvgOverTime` pins the
  contract that `avg_over_time` stays observed-only.
- [x] Existing `TestMetricsQueryRange_SingleSeriesNoGroupBy`,
  `TestMetricsQueryRange_MultiSeriesGroupBy`, and
  `TestMetricsQueryRange_ExemplarsPopulated` re-assert the new full-grid
  sample counts (3-min window @ 60s = 4 per series).
- [x] All 201 existing tempo handler tests pass.
- [ ] tempo-compat run on this branch shows the six target cases moving
  from FAIL to PASS.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>