### PR TITLE
test(logql): harden case-insensitive line-filter regression coverage with multi-case chDB roundtrip

### DIFF
--- a/test/spec/logql/line_filter_not_regex_case_insensitive.txtar
+++ b/test/spec/logql/line_filter_not_regex_case_insensitive.txtar
@@ -1,0 +1,28 @@
+-- query.logql --
+{job="api"} !~ "(?i)debug"
+-- sql --
+SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND NOT match(`Body`, ?)
+-- args --
+[0] string = "job"
+[1] string = "api"
+[2] string = "(?i)debug"
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES
+    ('level=debug msg=lowercase'),
+    ('level=DEBUG msg=uppercase'),
+    ('level=Debug msg=titlecase'),
+    ('level=DeBuG msg=mixedcase'),
+    ('level=info msg=clean'),
+    ('level=error msg=oops');
+-- expected_rows --
+[
+  ["level=error msg=oops"],
+  ["level=info msg=clean"]
+]
+-- chplan --
+Filter predicate=((ResourceAttributes["job"] = "api") AND lineContent(Body, "(?i)debug", regex,not))
+  Scan(otel_logs)

--- a/test/spec/logql/line_filter_regex_case_insensitive_multicase.txtar
+++ b/test/spec/logql/line_filter_regex_case_insensitive_multicase.txtar
@@ -1,0 +1,30 @@
+-- query.logql --
+{job="api"} |~ "(?i)error"
+-- sql --
+SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?) AND match(`Body`, ?)
+-- args --
+[0] string = "job"
+[1] string = "api"
+[2] string = "(?i)error"
+-- seed --
+CREATE TABLE otel_logs (
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api')
+) ENGINE = Memory;
+INSERT INTO otel_logs (Body) VALUES
+    ('level=error msg=lowercase'),
+    ('level=ERROR msg=uppercase'),
+    ('level=Error msg=titlecase'),
+    ('level=ErRoR msg=mixedcase'),
+    ('level=info msg=clean'),
+    ('level=warn msg=alert');
+-- expected_rows --
+[
+  ["level=ERROR msg=uppercase"],
+  ["level=ErRoR msg=mixedcase"],
+  ["level=Error msg=titlecase"],
+  ["level=error msg=lowercase"]
+]
+-- chplan --
+Filter predicate=((ResourceAttributes["job"] = "api") AND lineContent(Body, "(?i)error", regex))
+  Scan(otel_logs)


### PR DESCRIPTION
## Summary

Adds two TXTAR fixtures that lock in correct `(?i)` regex flag handling in the LogQL line-filter lowering path. Both fixtures use the chDB-backed round-trip layer so they fail loudly if a future change strips the `(?i)` prefix, mishandles `match(Body, ?)` parameter binding, or otherwise breaks case-folded matching against ClickHouse `match()` (re2).

- `line_filter_not_regex_case_insensitive.txtar` exercises `{job="api"} !~ "(?i)debug"` against 6 seed rows containing four case variants of `debug` plus two non-debug entries; expected_rows asserts both non-debug entries pass through and all four case variants are excluded.
- `line_filter_regex_case_insensitive_multicase.txtar` exercises `{job="api"} |~ "(?i)error"` against 6 seed rows containing four case variants of `error` plus two non-error entries; expected_rows asserts all four case variants match.

## Investigation context

This PR originated from a report that the LogQL compat harness shows `streams[0] entry count: expected=338 actual=360` on `{...} !~ "(?i)debug"` (and similar deltas on `|= "level"`, `| namespace="namespace-0"`, the basic-selector baseline, etc.). The working hypothesis was that cerberus was stripping the `(?i)` flag during lowering and emitting a case-sensitive `match()` against ClickHouse.

That hypothesis turned out to be wrong:

- `internal/logql/lower.go::lineFilterPart` passes `lf.Match` (the raw pattern string from Loki's parser) directly into `chplan.LineContent.Pattern`, with no rewriting.
- `internal/chsql/builder.go::exprLineContent` emits `match(<Body>, ?)` with the pattern bound as a parameter — no flag manipulation.
- ClickHouse 24.8's `match()` honors `(?i)` natively via re2, verified both inside chDB and in `clickhouse-server:24.8` against the seeded body shape.
- The passing case `{...} |~ "(?i)error"` on the `tempo` stream confirms the case-folded match works end-to-end in the same harness.

The actual cause of the `expected vs actual` deltas appears to be the recent `detected_level` stream-label promotion (#545). Cerberus's `Lang.ProjectSamples` log branch now wraps the row's `Attributes` map with a `detected_level` value, so `toStreamsWithTransform` groups rows by `(resourceAttrs, detected_level)`, splitting the response into one stream per level. The compat harness's `streams[0] entry count` diff is comparing cerberus's per-level stream against Loki's collapsed stream — they are different groupings, not a regex mismatch. That belongs in a separate follow-up.

The hardening tests in this PR are still worth landing: they pin the `(?i)` semantics so any future regression in the lowering or emit path is caught immediately, independent of the stream-splitting issue.

## Test plan

- [x] `go test ./internal/logql/ -run TestLower/line_filter_(not_)?regex.*case_insensitive` — both fixtures pass the text-equality / chplan check.
- [x] `CGO_ENABLED=1 go test -tags chdb ./test/spec/logql/ -run TestRoundTripChDB/line_filter_(not_)?regex.*case_insensitive` — both fixtures pass the chDB round-trip (expected_rows match).
- [ ] CI `check` + `lint` green on the branch.