### PR TITLE
ci(mutation): authenticate gremlins-action to avoid GH API rate limit

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -69,6 +69,12 @@ jobs:
       # `--threshold-efficacy ${{ matrix.efficacy }} ${{ matrix.scope }}`.
       - name: gremlins unleash
         uses: go-gremlins/gremlins-action@v1
+        env:
+          # Auth the action's release-asset download so it doesn't
+          # hit GitHub's 60-req/hour unauthenticated rate limit
+          # (which causes the install step to fail mid-burst, see
+          # run 26120689458).
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           version: v0.6.0
           args: --output gremlins.json ${{ matrix.scope }}


### PR DESCRIPTION
## Summary

Run 26120689458's `gremlins phase3-optimizer` failed at install with HTTP 429:

```
API rate limit exceeded for 20.55.86.53. (But here's the good news: Authenticated requests get a higher rate limit...)
```

The 6-job matrix fires in parallel; the install step hits GitHub's release-asset API 6× in a few seconds. Unauthenticated callers get 60 req/hour shared per source IP — easy to saturate when multiple workflow runs queue up.

Fix: pass `GITHUB_TOKEN` via `env` to `go-gremlins/gremlins-action@v1`. Authenticated requests get 5000/hour.

## Test plan

- [ ] Next mutation run on main installs cleanly across all 6 phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)