### PR TITLE
fix(api/tempo): drop empty-labels {} series from /api/metrics responses

### DIFF
--- a/internal/api/tempo/metrics_phi_label_test.go
+++ b/internal/api/tempo/metrics_phi_label_test.go
@@ -22,9 +22,14 @@ func TestMetricsLabelNames_PhiLabelAddedForMultiQuantile(t *testing.T) {
 		want []string
 	}{
 		{
+			// Ungrouped (no by(...) + single quantile) is the
+			// UngroupedAggregator-equivalent shape — Tempo's wire
+			// surface for that case is `{__name__="<op>"}`. We surface
+			// the same `__name__` label key (the value is injected by
+			// wrapMetricsForSample via m.Op.String()).
 			name: "no_groupby_single_quantile",
 			m:    &chplan.MetricsAggregate{Quantiles: []float64{0.95}},
-			want: nil,
+			want: []string{"__name__"},
 		},
 		{
 			name: "no_groupby_multi_quantile",
@@ -292,5 +297,89 @@ func TestWrapMetricsForSample_DisplayNameKeysAttributesMap(t *testing.T) {
 	if colRef.Name != "service.name" {
 		t.Errorf("toString column ref = %q, want %q (the bare SQL alias)",
 			colRef.Name, "service.name")
+	}
+}
+
+// TestWrapMetricsForSample_UngroupedAttachesMetricName pins the
+// UngroupedAggregator parity contract: when a TraceQL metrics-pipeline
+// query carries no `by(...)` clause and isn't a multi-quantile fan-out,
+// the Attributes projection must emit `map('__name__', '<op>')` rather
+// than an empty Map(String,String). That mirrors Tempo's reference
+// engine (pkg/traceql.UngroupedAggregator.Series) which attaches a
+// single `__name__=<op_name>` label per series, and stops cerberus
+// from emitting the divergent empty-labels series the Tempo compat
+// differ flagged as `missing_in_a series key e3b0c44298fc1c14` (the
+// sha256 prefix of the empty string).
+func TestWrapMetricsForSample_UngroupedAttachesMetricName(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		op      chplan.MetricsOp
+		wantVal string
+	}{
+		{name: "rate", op: chplan.MetricsOpRate, wantVal: "rate"},
+		{name: "count_over_time", op: chplan.MetricsOpCountOverTime, wantVal: "count_over_time"},
+		{name: "avg_over_time", op: chplan.MetricsOpAvgOverTime, wantVal: "avg_over_time"},
+		{name: "sum_over_time", op: chplan.MetricsOpSumOverTime, wantVal: "sum_over_time"},
+		{name: "quantile_over_time", op: chplan.MetricsOpQuantileOverTime, wantVal: "quantile_over_time"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rw := &chplan.RangeWindow{}
+			m := &chplan.MetricsAggregate{
+				Op:         tc.op,
+				ValueAlias: "Value",
+			}
+			node := wrapMetricsForSample(rw, m)
+			proj, ok := node.(*chplan.Project)
+			if !ok {
+				t.Fatalf("wrapMetricsForSample: got %T, want *chplan.Project", node)
+			}
+			if len(proj.Projections) < 2 {
+				t.Fatalf("project has %d projections, want >= 2", len(proj.Projections))
+			}
+			call, ok := proj.Projections[1].Expr.(*chplan.FuncCall)
+			if !ok || call.Name != "map" {
+				t.Fatalf("Attributes expr = %T (%v), want *chplan.FuncCall(map)", proj.Projections[1].Expr, proj.Projections[1].Expr)
+			}
+			if len(call.Args) != 2 {
+				t.Fatalf("map args = %d, want 2 ({__name__, <op>}): %+v", len(call.Args), call.Args)
+			}
+			keyLit, ok := call.Args[0].(*chplan.LitString)
+			if !ok || keyLit.V != "__name__" {
+				t.Errorf("map arg[0] = %v, want LitString(__name__)", call.Args[0])
+			}
+			valLit, ok := call.Args[1].(*chplan.LitString)
+			if !ok || valLit.V != tc.wantVal {
+				t.Errorf("map arg[1] = %v, want LitString(%q)", call.Args[1], tc.wantVal)
+			}
+		})
+	}
+}
+
+// TestMetricsLabelNames_UngroupedIncludesMetricName pins the helper-side
+// contract: an ungrouped MetricsAggregate (no GroupBy + no multi-phi)
+// surfaces `["__name__"]` so labelsFromSample orders the synthetic
+// label deterministically before any other key the SQL projection
+// might surface. Tempo's UngroupedAggregator wire shape is the upstream
+// reference (pkg/traceql.UngroupedAggregator.Series).
+func TestMetricsLabelNames_UngroupedIncludesMetricName(t *testing.T) {
+	t.Parallel()
+
+	got := metricsLabelNames(&chplan.MetricsAggregate{Op: chplan.MetricsOpRate})
+	if !equalSlice(got, []string{"__name__"}) {
+		t.Fatalf("metricsLabelNames(ungrouped rate) = %v, want [__name__]", got)
+	}
+	// multi-phi takes precedence (the fan-out adds its own column);
+	// the __name__ injection only fires when there's truly nothing
+	// else on the wire.
+	got = metricsLabelNames(&chplan.MetricsAggregate{
+		Op:        chplan.MetricsOpQuantileOverTime,
+		Quantiles: []float64{0.5, 0.9},
+	})
+	if !equalSlice(got, []string{"__phi__"}) {
+		t.Fatalf("metricsLabelNames(ungrouped multi-quantile) = %v, want [__phi__]", got)
 	}
 }

--- a/internal/api/tempo/metrics_query_instant_test.go
+++ b/internal/api/tempo/metrics_query_instant_test.go
@@ -27,16 +27,22 @@ func metricsQueryInstantURL(base, q string, params map[string]string) string {
 
 // TestMetricsQueryInstant_SingleSeriesNoGroupBy — bare `| rate()` over
 // the full spans table returns a single series with one (labels, value)
-// tuple. Validates the response envelope is `{series: [{labels: [],
-// value: N}]}` — no `samples` array.
+// tuple. Validates the response envelope is
+// `{series: [{labels: [{__name__: rate}], value: N}]}` — no `samples`
+// array. Cerberus mirrors Tempo's UngroupedAggregator wire shape
+// (`{__name__="<op>"}`) rather than emitting an empty label set; see
+// wrapMetricsForSample for the cross-reference.
 func TestMetricsQueryInstant_SingleSeriesNoGroupBy(t *testing.T) {
 	t.Parallel()
 
 	q := &stubQuerier{samples: []chclient.Sample{
 		// With step=end-start the inner RangeWindow emits exactly one
 		// anchor per series; the handler propagates that single sample
-		// as the InstantSeries value.
-		{MetricName: "", Labels: map[string]string{}, Timestamp: time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC), Value: 42.0},
+		// as the InstantSeries value. The matrix SQL emits the
+		// `map('__name__', 'rate')` Attributes projection for the
+		// ungrouped case (see wrapMetricsForSample), so the stub
+		// mimics what the CH cursor would surface as Labels.
+		{MetricName: "", Labels: map[string]string{"__name__": "rate"}, Timestamp: time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC), Value: 42.0},
 	}}
 	srv := newServer(q, "v1.0.0-test")
 	t.Cleanup(srv.Close)
@@ -63,8 +69,13 @@ func TestMetricsQueryInstant_SingleSeriesNoGroupBy(t *testing.T) {
 		t.Fatalf("expected 1 series, got %d: %+v", len(body.Series), body)
 	}
 	s := body.Series[0]
-	if len(s.Labels) != 0 {
-		t.Errorf("expected zero labels for ungrouped query, got %+v", s.Labels)
+	// Ungrouped instant queries surface a single `__name__=<op>` label
+	// (matching Tempo's UngroupedAggregator wire shape) so the response
+	// is keyed by at least one label rather than the empty label set
+	// that previously diverged from Tempo and caused the differ to
+	// flag `missing_in_a series key e3b0c44298fc1c14`.
+	if len(s.Labels) != 1 || s.Labels[0].Key != "__name__" || s.Labels[0].Value != "rate" {
+		t.Errorf("expected single {__name__=rate} label for ungrouped rate(), got %+v", s.Labels)
 	}
 	if s.Value != 42.0 {
 		t.Errorf("expected value 42, got %v", s.Value)

--- a/internal/api/tempo/metrics_query_range.go
+++ b/internal/api/tempo/metrics_query_range.go
@@ -359,12 +359,31 @@ func unwrapMetricsAggregate(plan chplan.Node) (*chplan.MetricsAggregate, bool) {
 // stream and surface it as a wire-format label.
 const tempoMultiQuantilePhiLabel = "__phi__"
 
+// tempoMetricNameLabel mirrors the Prometheus-style `__name__` label
+// Tempo's UngroupedAggregator (engine_metrics.go) attaches to the
+// single series an ungrouped metrics-pipeline query returns. The
+// reference engine emits `{__name__="rate"}` for `{} | rate()` and
+// `{__name__="avg_over_time"}` for `{} | avg_over_time(duration)`,
+// rather than an empty label set, so Grafana's Tempo datasource (and
+// the differ in compatibility/tempo) can always key series by at least
+// one label. Cerberus mirrors that shape so an ungrouped response
+// canonicalises identically across the two backends.
+const tempoMetricNameLabel = "__name__"
+
 // wrapMetricsForSample maps the matrix-shape RangeWindow's outer SELECT
 // (g0/<alias>..., anchor_ts, Value) into chclient.Sample's positional
 // shape (MetricName, Attributes, TimeUnix, Value). Attributes becomes
-// `map('<label>', toString(<alias>), ...)` (or an empty Map(String,String)
-// when there's no GroupBy); MetricName is empty (TraceQL has no
-// __name__); anchor_ts arrives as DateTime64(9) → time.Time on the wire.
+// `map('<label>', toString(<alias>), ...)`; when the query has no
+// `by(...)` clause the map carries a single
+// `('__name__', '<op-name>')` entry mirroring Tempo's UngroupedAggregator
+// (see `pkg/traceql.UngroupedAggregator.Series`), so an ungrouped
+// response is keyed by at least one label rather than emitting the
+// empty `{}` label set that previously diverged from the reference
+// engine's `{__name__="rate"}` / `{__name__="count_over_time"}` shape.
+// MetricName is empty on the chclient.Sample tuple (TraceQL has no
+// per-row metric name beyond the synthetic `__name__` carried in
+// Attributes); anchor_ts arrives as DateTime64(9) → time.Time on the
+// wire.
 //
 // The Attributes map's keys are the Tempo-canonical wire names from
 // metricsLabelNames (scope-prefixed `resource.service.name`,
@@ -386,9 +405,23 @@ func wrapMetricsForSample(rw *chplan.RangeWindow, m *chplan.MetricsAggregate) ch
 	multiPhi := len(m.Quantiles) > 1
 
 	var attrs chplan.Expr
-	if len(m.GroupBy) == 0 && !multiPhi {
-		attrs = emptyAttrsMap()
-	} else {
+	switch {
+	case len(m.GroupBy) == 0 && !multiPhi:
+		// Ungrouped: emit Tempo's UngroupedAggregator-style
+		// `{__name__="<op>"}` label so the response series is keyed by
+		// `__name__` rather than the empty label set. The constant
+		// op-name comes from chplan.MetricsOp.String() (rate /
+		// count_over_time / avg_over_time / quantile_over_time / ...),
+		// matching the upstream wire form
+		// LabelsFromArgs(labels.MetricName, op.String()).
+		attrs = &chplan.FuncCall{
+			Name: "map",
+			Args: []chplan.Expr{
+				&chplan.LitString{V: tempoMetricNameLabel},
+				&chplan.LitString{V: m.Op.String()},
+			},
+		}
+	default:
 		args := make([]chplan.Expr, 0, (len(m.GroupBy)+1)*2)
 		for i := range m.GroupBy {
 			args = append(
@@ -452,6 +485,12 @@ func metricsOuterGroupAliases(groupBy []chplan.Expr, aliases []string) []string 
 // more than one phi value (the chsql multi-quantile fan-out adds the
 // extra column to the matrix shape).
 //
+// For ungrouped metrics queries (no `by(...)` clause and no multi-phi
+// fan-out) the slice is `["__name__"]` so labelsFromSample preserves
+// the order expected by Tempo's UngroupedAggregator wire shape (a
+// single `__name__=<op>` label per series — see wrapMetricsForSample's
+// doc-comment for the upstream reference).
+//
 // Aligning with the upstream Tempo response shape: the reference
 // /api/metrics/query_range emits `resource.service.name` for a
 // `by (resource.service.name)` clause — see grafana/tempo
@@ -461,6 +500,10 @@ func metricsOuterGroupAliases(groupBy []chplan.Expr, aliases []string) []string 
 // `by (resource.res_attr)` query.
 func metricsLabelNames(m *chplan.MetricsAggregate) []string {
 	n := len(m.GroupBy)
+	multiPhi := len(m.Quantiles) > 1
+	if n == 0 && !multiPhi {
+		return []string{tempoMetricNameLabel}
+	}
 	out := make([]string, 0, n+1)
 	for i := 0; i < n; i++ {
 		if i < len(m.GroupByDisplayNames) && m.GroupByDisplayNames[i] != "" {
@@ -473,7 +516,7 @@ func metricsLabelNames(m *chplan.MetricsAggregate) []string {
 		}
 		out = append(out, "group_"+strconv.Itoa(i))
 	}
-	if len(m.Quantiles) > 1 {
+	if multiPhi {
 		out = append(out, tempoMultiQuantilePhiLabel)
 	}
 	return out

--- a/internal/api/tempo/metrics_query_range_test.go
+++ b/internal/api/tempo/metrics_query_range_test.go
@@ -52,11 +52,17 @@ func TestMetricsQueryRange_SingleSeriesNoGroupBy(t *testing.T) {
 	ts := func(min int) time.Time {
 		return time.Date(2026, 5, 12, 10, min, 0, 0, time.UTC)
 	}
+	// The matrix-shape SQL emits `map('__name__', 'rate')` for the
+	// ungrouped Attributes projection (mirroring Tempo's
+	// UngroupedAggregator wire shape — see
+	// wrapMetricsForSample's doc-comment). The stub mimics that wire
+	// projection so the handler's response-shaper sees the same
+	// Labels map a real CH cursor would surface.
 	q := &stubQuerier{samples: []chclient.Sample{
 		// Intentionally out of order — handler must sort within each series.
-		{MetricName: "", Labels: map[string]string{}, Timestamp: ts(2), Value: 2.0},
-		{MetricName: "", Labels: map[string]string{}, Timestamp: ts(0), Value: 0.5},
-		{MetricName: "", Labels: map[string]string{}, Timestamp: ts(1), Value: 1.5},
+		{MetricName: "", Labels: map[string]string{"__name__": "rate"}, Timestamp: ts(2), Value: 2.0},
+		{MetricName: "", Labels: map[string]string{"__name__": "rate"}, Timestamp: ts(0), Value: 0.5},
+		{MetricName: "", Labels: map[string]string{"__name__": "rate"}, Timestamp: ts(1), Value: 1.5},
 	}}
 	srv := newServer(q, "v1.0.0-test")
 	t.Cleanup(srv.Close)
@@ -84,8 +90,13 @@ func TestMetricsQueryRange_SingleSeriesNoGroupBy(t *testing.T) {
 		t.Fatalf("expected 1 series, got %d: %+v", len(body.Series), body)
 	}
 	s := body.Series[0]
-	if len(s.Labels) != 0 {
-		t.Errorf("expected zero labels for ungrouped query, got %+v", s.Labels)
+	// Ungrouped queries surface a single `__name__=<op>` label per
+	// series (matching Tempo's UngroupedAggregator wire shape) — never
+	// an empty label set. Previously cerberus emitted `{}` here and the
+	// Tempo differ flagged the divergence as
+	// `missing_in_a series key e3b0c44298fc1c14 (sha256("") prefix)`.
+	if len(s.Labels) != 1 || s.Labels[0].Key != "__name__" || s.Labels[0].Value != "rate" {
+		t.Errorf("expected single {__name__=rate} label for ungrouped rate(), got %+v", s.Labels)
 	}
 	// 3-minute window @ 60s step → 4 anchors after zero-fill (10:00 /
 	// 10:01 / 10:02 / 10:03), with the trailing anchor synthesised at
@@ -244,9 +255,12 @@ func TestMetricsQueryRange_ZeroFillCountOverTime(t *testing.T) {
 	mid := time.Date(2026, 5, 12, 10, 1, 0, 0, time.UTC)
 	q := &stubQuerier{samples: []chclient.Sample{{
 		MetricName: "",
-		Labels:     map[string]string{},
-		Timestamp:  mid,
-		Value:      7.0,
+		// Matrix-shape SQL projects `map('__name__', 'count_over_time')`
+		// for ungrouped queries (see wrapMetricsForSample); stub mimics
+		// the cursor's surfaced Labels map.
+		Labels:    map[string]string{"__name__": "count_over_time"},
+		Timestamp: mid,
+		Value:     7.0,
 	}}}
 	srv := newServer(q, "v1.0.0-test")
 	t.Cleanup(srv.Close)
@@ -318,9 +332,12 @@ func TestMetricsQueryRange_ZeroFillSkippedForAvgOverTime(t *testing.T) {
 	mid := time.Date(2026, 5, 12, 10, 1, 0, 0, time.UTC)
 	q := &stubQuerier{samples: []chclient.Sample{{
 		MetricName: "",
-		Labels:     map[string]string{},
-		Timestamp:  mid,
-		Value:      42.0,
+		// Matrix-shape SQL projects `map('__name__', 'avg_over_time')`
+		// for ungrouped queries (see wrapMetricsForSample); stub mimics
+		// the cursor's surfaced Labels map.
+		Labels:    map[string]string{"__name__": "avg_over_time"},
+		Timestamp: mid,
+		Value:     42.0,
 	}}}
 	srv := newServer(q, "v1.0.0-test")
 	t.Cleanup(srv.Close)

--- a/internal/chsql/exemplars.go
+++ b/internal/chsql/exemplars.go
@@ -182,16 +182,33 @@ func (e *emitter) emitMetricsExemplars(
 	// attachExemplars matches each exemplar to its parent series by
 	// canonical label-set hash, so the two label-key projections must
 	// agree.
-	attrMapFrags := make([]Frag, 0, len(groupAliases)*2+4)
+	attrMapFrags := make([]Frag, 0, len(groupAliases)*2+6)
 	for i, alias := range groupAliases {
 		a := alias
 		display := groupDisplayNames[i]
-		attrMapFrags = append(attrMapFrags,
+		attrMapFrags = append(
+			attrMapFrags,
 			Lit(display),
 			Call("toString", Col(a)),
 		)
 	}
-	attrMapFrags = append(attrMapFrags,
+	// Ungrouped queries surface a single `{__name__="<op>"}` series in
+	// the matrix-shape response (mirroring Tempo's UngroupedAggregator;
+	// see internal/api/tempo/metrics_query_range.go::wrapMetricsForSample).
+	// The exemplar response keys series by the same canonical label-set
+	// hash via attachExemplars, so the exemplar Attributes must carry
+	// the same `__name__=<op>` entry — otherwise the exemplar's
+	// canonical key drifts to the empty label set and no series in the
+	// matrix shape matches.
+	if len(groupAliases) == 0 {
+		attrMapFrags = append(
+			attrMapFrags,
+			Lit("__name__"),
+			Lit(m.Op.String()),
+		)
+	}
+	attrMapFrags = append(
+		attrMapFrags,
 		Lit("trace:id"),
 		Call("argMax", Col("exemplar_trace_id"), Col("ts")),
 		Lit("span:id"),


### PR DESCRIPTION
## Summary

Tempo's reference `UngroupedAggregator` (`pkg/traceql.UngroupedAggregator.Series`) attaches a single `{__name__="<op>"}` label per series for queries without a `by(...)` clause — `{} | rate()` emits `{__name__="rate"}`, `{} | avg_over_time(duration)` emits `{__name__="avg_over_time"}`, etc. Cerberus previously emitted an empty label set in the same case, causing the tempo-compat differ to flag five smoke cases with `missing_in_a series key e3b0c44298fc1c14 ({})` — the sha256 prefix of the empty string (since `metricsCanonicalKey` hashed `{}` on the cerberus side, while Tempo's side hashed `{__name__=rate}`).

Affected smoke cases (each previously contributed 2 reasons to the diff):
- `metrics_avg_over_time_instant`
- `metrics_count_over_time_instant`
- `metrics_quantile_over_time_p95`
- `metrics_rate_instant`
- `metrics_rate_no_groupby`

## Root cause

`internal/api/tempo/metrics_query_range.go::wrapMetricsForSample` projected `CAST(map(), 'Map(String,String)')` for ungrouped queries instead of a `map('__name__', '<op-name>')` literal. The exemplar SQL in `internal/chsql/exemplars.go::emitMetricsExemplars` was symmetrically silent on `__name__` so the exemplar's canonical-key hash also drifted to the empty-label-set bucket. Both projections needed the synthetic `__name__=<op>` entry to canonicalise identically to Tempo's `UngroupedAggregator.Series` shape.

## What changed

- `wrapMetricsForSample`: for ungrouped + non-multi-quantile queries, emit `map('__name__', '<op>')` literal. The op-name comes from `chplan.MetricsOp.String()` (`rate` / `count_over_time` / `avg_over_time` / `quantile_over_time` / ...), exactly mirroring Tempo's `LabelsFromArgs(labels.MetricName, op.String())`.
- `metricsLabelNames`: returns `["__name__"]` for the ungrouped case so `labelsFromSample` orders the synthetic label deterministically.
- `emitMetricsExemplars`: append `('__name__', m.Op.String())` to the exemplar Attributes when `len(groupAliases) == 0` so the exemplar's canonical-label-set hash matches the matrix-shape parent series. `attachExemplars` then attaches exemplars to the right series for ungrouped queries.
- Tests updated: stubs for ungrouped fixtures now seed `Labels: {"__name__": "<op>"}` (mirroring what a real CH cursor surfaces post-SQL change); response assertions check for the single `{__name__=<op>}` label rather than an empty label slice. New `TestWrapMetricsForSample_UngroupedAttachesMetricName` + `TestMetricsLabelNames_UngroupedIncludesMetricName` pin the projection contract per op.

Expected compatibility delta: Tempo compat 60.61% → ~75%+ (the five flagged metrics cases canonicalise identically across the two backends after this).

## Test plan

- [x] `TestWrapMetricsForSample_UngroupedAttachesMetricName` exercises every supported op (rate / count_over_time / avg_over_time / sum_over_time / quantile_over_time).
- [x] `TestMetricsLabelNames_UngroupedIncludesMetricName` pins the helper contract: ungrouped → `["__name__"]`, ungrouped multi-quantile → `["__phi__"]` (the multi-phi fan-out wins because it provides a real per-series differentiator).
- [x] Updated `TestMetricsQueryRange_SingleSeriesNoGroupBy` + `TestMetricsQueryInstant_SingleSeriesNoGroupBy` assert the wire-shape `{__name__=rate}` label on the response.
- [ ] Tempo compatibility harness re-run on push-to-main should drop the five `missing_in_a series key e3b0c44298fc1c14` reasons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)