### PR TITLE
fix(api/tempo): resolve trace root via follow-up CH query on missing-root result sets

### DIFF
--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -169,9 +169,26 @@ func (h *Handler) handleSearch(w http.ResponseWriter, r *http.Request) {
 	}
 	h.Logger.Debug("cerberus tempo search", "traceql", q, "sql", res.SQL, "args", res.Args)
 
+	summaries, missingRoots := toTraceSummaries(res.Samples)
+	if len(missingRoots) > 0 {
+		// The result set lacked a root row for some traces — typical
+		// for structural-join queries (the join projects only matched
+		// children) and filter predicates that never match the root
+		// (`{ status = error }`, `{ kind = consumer }`). Issue a
+		// follow-up lookup against otel_traces filtered to root spans
+		// of the affected TraceIDs and patch RootServiceName /
+		// RootTraceName before responding.
+		roots, lookupErr := h.resolveTraceRoots(ctx, missingRoots)
+		if lookupErr != nil {
+			h.Logger.Warn("cerberus tempo root-span lookup failed",
+				"err", lookupErr, "missing", len(missingRoots))
+		} else {
+			applyRootMetadata(summaries, roots)
+		}
+	}
 	writeEngineHeaders(w, res.Headers)
 	writeJSON(w, http.StatusOK, SearchResponse{
-		Traces:  toTraceSummaries(res.Samples),
+		Traces:  summaries,
 		Metrics: SearchMetrics{InspectedTraces: len(res.Samples)},
 	})
 }
@@ -257,9 +274,19 @@ func (h *Handler) handleSearchRecent(w http.ResponseWriter, r *http.Request) {
 	}
 	h.Logger.Debug("cerberus tempo search/recent", "limit", limit, "sql", res.SQL, "args", res.Args)
 
+	summaries, missingRoots := toTraceSummaries(res.Samples)
+	if len(missingRoots) > 0 {
+		roots, lookupErr := h.resolveTraceRoots(ctx, missingRoots)
+		if lookupErr != nil {
+			h.Logger.Warn("cerberus tempo root-span lookup failed",
+				"err", lookupErr, "missing", len(missingRoots))
+		} else {
+			applyRootMetadata(summaries, roots)
+		}
+	}
 	writeEngineHeaders(w, res.Headers)
 	writeJSON(w, http.StatusOK, SearchResponse{
-		Traces:  toTraceSummaries(res.Samples),
+		Traces:  summaries,
 		Metrics: SearchMetrics{InspectedTraces: len(res.Samples)},
 	})
 }
@@ -893,9 +920,14 @@ func spansetAggregateSampleProjections() []chplan.Projection {
 //     multiple roots (broken trace), the earliest by start time wins —
 //     same fallback Tempo uses internally.
 //   - When no row in the matched set is a root (truncated trace; the
-//     matcher only hit children), fall back to the earliest span's
-//     metadata. This degrades gracefully — the search response still
-//     surfaces *something* identifying the trace.
+//     matcher only hit children, the common case for structural-join
+//     queries and `{ status = error }` against fixtures where only
+//     child spans satisfy the predicate), the second return value
+//     surfaces the missing-root TraceIDs so the caller can issue a
+//     follow-up root-lookup query (see resolveTraceRoots) and patch
+//     RootServiceName / RootTraceName before responding. Until that
+//     follow-up resolves, the summary anchors on the earliest-span
+//     fallback so a response is always emitted.
 //
 // Defensive: samples missing the reserved trace-ID key (older fixtures,
 // stub queriers in tests) fall back to (SpanName | Timestamp) so
@@ -904,7 +936,15 @@ func spansetAggregateSampleProjections() []chplan.Projection {
 // classification (since we can't tell — older fixtures pre-date the
 // reserved slot); the trace's RootService/RootTraceName then anchor
 // on the earliest-span fallback path.
-func toTraceSummaries(samples []chclient.Sample) []TraceSummary {
+//
+// Returns (summaries, missingRootTraceIDs). `missingRootTraceIDs`
+// contains the stripped-zero-form TraceID of every trace whose result
+// set lacked a true root span — the structural-join SQL only returns
+// the join's right-side rows (no root row by construction), and many
+// filter queries (`{ status = error }`, `{ kind = consumer }`) only
+// match child spans. resolveTraceRoots fetches the real root from
+// otel_traces and patches the affected summaries.
+func toTraceSummaries(samples []chclient.Sample) ([]TraceSummary, []string) {
 	type acc struct {
 		traceID     string
 		serviceName string
@@ -922,6 +962,13 @@ func toTraceSummaries(samples []chclient.Sample) []TraceSummary {
 		earliestStartNS int64
 		// hasRoot is true once we've seen a span with ParentSpanId == "".
 		hasRoot bool
+		// sawParentSlot is true once any of the trace's rows supplied
+		// the reserved `__cerberus_parentSpanID` slot. When false the
+		// shaper can't distinguish root from child (e.g. legacy fixtures
+		// + stub queriers that never populate the slot), so the
+		// missing-root follow-up lookup is suppressed and the
+		// earliest-span fallback handles the trace alone.
+		sawParentSlot bool
 		// hasTraceDurationNs is set the first time a row supplies the
 		// `__cerberus_traceDurationNs` reserved-key entry. Once true,
 		// `durationNS` carries the trace-wide span and per-row Sample.
@@ -981,6 +1028,9 @@ func toTraceSummaries(samples []chclient.Sample) []TraceSummary {
 		// "did we get the projection" signal independently of the
 		// emptiness check.
 		parentID, hasParentSlot := s.Labels[searchKeyParentSpanID]
+		if hasParentSlot {
+			a.sawParentSlot = true
+		}
 		isRoot := hasParentSlot && (parentID == "" || parentID == "0")
 		svc := s.Labels["service.name"]
 		switch {
@@ -1001,6 +1051,7 @@ func toTraceSummaries(samples []chclient.Sample) []TraceSummary {
 		}
 	}
 	out := make([]TraceSummary, 0, len(byTrace))
+	var missing []string
 	for k, a := range byTrace {
 		// Emit the real TraceID when the projection supplied one;
 		// otherwise surface the synthetic key (back-compat for stub
@@ -1016,9 +1067,20 @@ func toTraceSummaries(samples []chclient.Sample) []TraceSummary {
 			StartTimeUnixNano: strconv.FormatInt(a.startNS, 10),
 			DurationMs:        int(a.durationNS / 1_000_000),
 		})
+		// Only flag traces where we actually have a real TraceID, the
+		// projection populated the __cerberus_parentSpanID slot for at
+		// least one row (so we can trust "no root present"), and no
+		// row in the result set was a root span. The synthetic-key
+		// fallback path (no real TraceID) can't be looked up; the
+		// no-parent-slot path is the legacy fixture / stub-querier
+		// shape and stays on the earliest-span anchor.
+		if a.traceID != "" && a.sawParentSlot && !a.hasRoot {
+			missing = append(missing, a.traceID)
+		}
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].TraceID < out[j].TraceID })
-	return out
+	sort.Strings(missing)
+	return out, missing
 }
 
 // groupBatches converts a flat span list into Tempo's `batches` shape

--- a/internal/api/tempo/handler_test.go
+++ b/internal/api/tempo/handler_test.go
@@ -412,11 +412,20 @@ func TestSearch_RootSpanResolution_MultipleRoots(t *testing.T) {
 }
 
 // TestSearch_RootSpanResolution_TruncatedTrace covers the truncated-set
-// fallback: when the matcher only matches child spans (the root is in
-// the trace but not in this search result set), the shaper falls back
-// to the earliest-by-timestamp span's metadata. This degrades
-// gracefully — the response surfaces *something* identifying the
-// trace rather than dropping the row.
+// fallback: when the matcher only matches child spans AND the
+// follow-up root-lookup against otel_traces returns no row for that
+// trace (the trace's root was never collected — true truncation), the
+// shaper falls back to the earliest-by-timestamp span's metadata so
+// the response surfaces *something* identifying the trace rather than
+// dropping the row.
+//
+// The structural-join / status-filter / set-op compat cases hit the
+// non-truncated path: their result set lacks a root row but
+// otel_traces does carry one, so resolveTraceRoots recovers it (see
+// TestSearch_StructuralJoin_RootSurfaced). This test is the
+// degradation envelope: when the follow-up also misses, we keep the
+// earliest-child anchor rather than silently dropping the RootTraceName
+// field.
 func TestSearch_RootSpanResolution_TruncatedTrace(t *testing.T) {
 	t.Parallel()
 	const traceID = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
@@ -444,6 +453,12 @@ func TestSearch_RootSpanResolution_TruncatedTrace(t *testing.T) {
 				Value:     50_000_000,
 			},
 		},
+		// The follow-up root-lookup query carries the
+		// `RootSpanName` alias in its outer Project. Stub it with an
+		// empty row set so the truncated-trace fallback fires.
+		samplesBySQL: map[string][]chclient.Sample{
+			"RootSpanName": {},
+		},
 	}
 	srv := newServer(q, "v1.0.0-test")
 	t.Cleanup(srv.Close)
@@ -460,7 +475,8 @@ func TestSearch_RootSpanResolution_TruncatedTrace(t *testing.T) {
 	if len(sr.Traces) != 1 {
 		t.Fatalf("expected 1 trace, got %d", len(sr.Traces))
 	}
-	// Earliest child wins when no root is in the result set.
+	// Earliest child wins when no root is in either the result set
+	// OR the follow-up root lookup.
 	if sr.Traces[0].RootTraceName != "child.early" {
 		t.Errorf("RootTraceName: got %q, want %q (earliest child when root absent)",
 			sr.Traces[0].RootTraceName, "child.early")
@@ -541,6 +557,159 @@ func TestSearch_RootSpanResolution_StrippedZero(t *testing.T) {
 	if got.RootServiceName != "payments" {
 		t.Errorf("RootServiceName: got %q, want %q",
 			got.RootServiceName, "payments")
+	}
+}
+
+// TestSearch_StructuralJoin_RootSurfaced pins the fix for the four
+// remaining tempo-compat regressions (status_eq_error,
+// descendant_op_payments_to_consumer, direct_parent_op_checkout_to_child,
+// set_and_checkout_and_status_error). Each query's result set carries
+// only **child** spans — the structural join projects R-side rows,
+// `{ status = error }` matches only the children that report error
+// status, set ops like `&&` only return rows satisfying every leg —
+// so no row in the original result is a root span (every
+// __cerberus_parentSpanID is a non-empty / non-zero hex value pointing
+// at the actual root).
+//
+// The handler must detect the missing-root case, issue a follow-up
+// query against otel_traces filtered to
+// `ParentSpanId IN (”, '0000000000000000') AND TraceId IN (...)`, and
+// patch RootServiceName / RootTraceName on the affected summaries
+// before responding. This test stubs both stages: the first query
+// returns child rows; the second returns the recovered root for one
+// of the two traces and nothing for the other (modelling a true
+// truncation), letting us assert both code paths.
+func TestSearch_StructuralJoin_RootSurfaced(t *testing.T) {
+	t.Parallel()
+	const (
+		traceWithRoot = "17" // the stripped form (rootSpanID for child rows is the same)
+		traceNoRoot   = "abc"
+		rootSpanID    = "1"
+	)
+	q := &stubQuerier{
+		// First (search) query returns two child rows on traceWithRoot
+		// and one child row on traceNoRoot — neither trace's result
+		// set contains its true root span (per structural-join /
+		// status-filter semantics).
+		samples: []chclient.Sample{
+			{
+				MetricName: "checkout.child.2",
+				Labels: map[string]string{
+					"service.name":            "checkout",
+					"__cerberus_traceID":      traceWithRoot,
+					"__cerberus_parentSpanID": rootSpanID,
+				},
+				Timestamp: time.Date(2026, 5, 12, 10, 0, 0, 30_000_000, time.UTC),
+				Value:     40_000_000,
+			},
+			{
+				MetricName: "checkout.child.0",
+				Labels: map[string]string{
+					"service.name":            "checkout",
+					"__cerberus_traceID":      traceWithRoot,
+					"__cerberus_parentSpanID": rootSpanID,
+				},
+				Timestamp: time.Date(2026, 5, 12, 10, 0, 0, 10_000_000, time.UTC),
+				Value:     20_000_000,
+			},
+			{
+				MetricName: "payments.child.4",
+				Labels: map[string]string{
+					"service.name":            "payments",
+					"__cerberus_traceID":      traceNoRoot,
+					"__cerberus_parentSpanID": rootSpanID,
+				},
+				Timestamp: time.Date(2026, 5, 12, 10, 0, 0, 50_000_000, time.UTC),
+				Value:     60_000_000,
+			},
+		},
+		// Second (root-lookup) query returns the recovered root for
+		// traceWithRoot only — traceNoRoot is truncated. The follow-up
+		// emits the canonical Sample envelope so chclient decodes it
+		// positionally; the Attributes carry the stripped TraceID and
+		// the recovered service.name.
+		samplesBySQL: map[string][]chclient.Sample{
+			"RootSpanName": {
+				{
+					MetricName: "GET /api/checkout/17",
+					Labels: map[string]string{
+						"service.name":       "checkout",
+						"__cerberus_traceID": traceWithRoot,
+					},
+					Timestamp: time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC),
+					Value:     0,
+				},
+			},
+		},
+	}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/search?q=%7B%20status%20%3D%20error%20%7D")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	var sr tempo.SearchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&sr); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(sr.Traces) != 2 {
+		t.Fatalf("expected 2 traces, got %d (%+v)", len(sr.Traces), sr.Traces)
+	}
+	// Locate traces by ID — the slice is sorted by TraceID.
+	var withRoot, noRoot tempo.TraceSummary
+	for _, tr := range sr.Traces {
+		switch tr.TraceID {
+		case traceWithRoot:
+			withRoot = tr
+		case traceNoRoot:
+			noRoot = tr
+		}
+	}
+	if withRoot.RootTraceName != "GET /api/checkout/17" {
+		t.Errorf("withRoot.RootTraceName: got %q, want %q (recovered from follow-up lookup, not the child)",
+			withRoot.RootTraceName, "GET /api/checkout/17")
+	}
+	if withRoot.RootServiceName != "checkout" {
+		t.Errorf("withRoot.RootServiceName: got %q, want %q",
+			withRoot.RootServiceName, "checkout")
+	}
+	// Truncated trace: follow-up returned nothing; the earliest-span
+	// fallback ("payments.child.4") stays in place so the summary
+	// still identifies the trace.
+	if noRoot.RootTraceName != "payments.child.4" {
+		t.Errorf("noRoot.RootTraceName: got %q, want %q (earliest-span fallback when follow-up returns no root)",
+			noRoot.RootTraceName, "payments.child.4")
+	}
+
+	// At least two SQL queries should have been issued (search + lookup).
+	if len(q.queriedSQLs) < 2 {
+		t.Errorf("expected ≥2 CH queries (search + root lookup), got %d: %v",
+			len(q.queriedSQLs), q.queriedSQLs)
+	}
+	// The lookup SQL must filter on (TraceId, ParentSpanId).
+	var lookupSQL string
+	for _, sql := range q.queriedSQLs {
+		if strings.Contains(sql, "RootSpanName") {
+			lookupSQL = sql
+			break
+		}
+	}
+	if lookupSQL == "" {
+		t.Fatalf("no follow-up root-lookup query was issued; queries=%v", q.queriedSQLs)
+	}
+	if !strings.Contains(lookupSQL, "argMin") {
+		t.Errorf("lookup SQL must use argMin to pick the per-trace root span; got %s", lookupSQL)
+	}
+	if !strings.Contains(lookupSQL, "ParentSpanId") {
+		t.Errorf("lookup SQL must filter on ParentSpanId; got %s", lookupSQL)
+	}
+	if !strings.Contains(lookupSQL, "TraceId") {
+		t.Errorf("lookup SQL must filter on TraceId; got %s", lookupSQL)
 	}
 }
 

--- a/internal/api/tempo/root_lookup.go
+++ b/internal/api/tempo/root_lookup.go
@@ -1,0 +1,233 @@
+package tempo
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// rootMetadata carries the root-span identification a follow-up CH
+// lookup recovers for a single trace. Empty fields mean the lookup
+// found no row matching (TraceId, ParentSpanId IN (empty or zero hex)) for
+// that TraceId — a true truncation where the trace's root is not in
+// otel_traces, vs. a structural-join / status-filter where the root
+// is present but absent from the original result set.
+type rootMetadata struct {
+	ServiceName string
+	SpanName    string
+}
+
+// resolveTraceRoots issues a follow-up CH query that fetches each
+// missing trace's root-span identity (SpanName + service.name). The
+// /api/search wrap projection projects only the spans matched by the
+// user's TraceQL predicate, so structural-join queries (`>`, `<`,
+// `>>`, `<<`, set ops) and filter queries that exclude the root span
+// (`{ status = error }` on a fixture where only children carry that
+// status) deliver result sets without a root row. The shaper anchors
+// on the earliest matched span as a fallback, but Tempo's wire spec
+// pins rootTraceName / rootServiceName to the **actual** root span at
+// the top of the trace tree. This helper recovers that.
+//
+// Implementation: a chplan tree built by hand (no parser, no
+// optimizer pass needed) lowering to:
+//
+//	SELECT
+//	  argMin(SpanName, Timestamp) AS RootSpanName,
+//	  map(
+//	    '__cerberus_traceID', stripLeadingHexZeros(TraceId),
+//	    'service.name',       argMin(ResourceAttributes['service.name'], Timestamp),
+//	  ) AS Attributes,
+//	  now64(9) AS TimeUnix,
+//	  0 AS Value
+//	FROM otel_traces
+//	WHERE (ParentSpanId = '' OR ParentSpanId = '0000000000000000')
+//	  AND TraceId IN ('<padded-id-1>', '<padded-id-2>', ...)
+//	GROUP BY TraceId
+//
+// Result is keyed by the stripped-zero TraceID (the form the original
+// /api/search shaper used). Returns an empty map when traceIDs is
+// empty; never returns nil on success.
+func (h *Handler) resolveTraceRoots(ctx context.Context, traceIDs []string) (map[string]rootMetadata, error) {
+	if len(traceIDs) == 0 {
+		return map[string]rootMetadata{}, nil
+	}
+
+	plan := buildRootLookupPlan(h.Schema, traceIDs)
+	sql, args, err := chsql.Emit(ctx, plan)
+	if err != nil {
+		return nil, fmt.Errorf("root lookup: emit: %w", err)
+	}
+
+	samples, err := h.Client.Query(ctx, sql, args...)
+	if err != nil {
+		return nil, fmt.Errorf("root lookup: execute: %w", err)
+	}
+
+	out := make(map[string]rootMetadata, len(samples))
+	for _, s := range samples {
+		// The aggregate's Attributes map carries the stripped TraceID
+		// under searchKeyTraceID (`__cerberus_traceID`) and the root
+		// span's service.name under the canonical `service.name` key.
+		tid := s.Labels[searchKeyTraceID]
+		if tid == "" {
+			continue
+		}
+		out[tid] = rootMetadata{
+			ServiceName: s.Labels["service.name"],
+			SpanName:    s.MetricName,
+		}
+	}
+	return out, nil
+}
+
+// buildRootLookupPlan returns the chplan tree resolveTraceRoots emits.
+// Extracted so the SQL shape can be tested in isolation without going
+// through the chclient stub.
+//
+// The shape is intentionally rendered through the canonical wrap-
+// projection format (MetricName, Attributes, TimeUnix, Value) so the
+// existing chclient.Sample decoding picks it up without a new path.
+// The Attributes map carries the stripped-zero TraceID (the search-
+// path identity key) plus the root span's service.name; MetricName
+// carries the root SpanName. The `TimeUnix` and `Value` columns are
+// constant placeholders — the follow-up lookup contributes metadata,
+// not per-trace timing, which the original shaper already has.
+func buildRootLookupPlan(s schema.Traces, traceIDs []string) chplan.Node {
+	// Filter predicate: ParentSpanId IN ('', '0000000000000000') AND
+	// TraceId IN (<padded-id-1>, <padded-id-2>, ...). Without an `IN`
+	// chplan expression, both arms render as flat OR-chains of Eq
+	// predicates — CH planner collapses these to constant-set lookups
+	// at execute time.
+	parentIsRoot := orEqLiterals(s.ParentSpanIDColumn, []string{"", "0000000000000000"})
+	traceMatch := orEqLiterals(s.TraceIDColumn, padTraceIDs(traceIDs))
+	pred := &chplan.Binary{
+		Op:    chplan.OpAnd,
+		Left:  parentIsRoot,
+		Right: traceMatch,
+	}
+
+	// argMin(SpanName, Timestamp) AS RootSpanName.
+	aggSpanName := chplan.AggFunc{
+		Name:  "argMin",
+		Args:  []chplan.Expr{&chplan.ColumnRef{Name: s.SpanNameColumn}, &chplan.ColumnRef{Name: s.TimestampColumn}},
+		Alias: "RootSpanName",
+	}
+	// argMin(ResourceAttributes['service.name'], Timestamp) AS RootSvc.
+	aggSvc := chplan.AggFunc{
+		Name: "argMin",
+		Args: []chplan.Expr{
+			&chplan.MapAccess{
+				Map: &chplan.ColumnRef{Name: s.ResourceAttributesColumn},
+				Key: &chplan.LitString{V: "service.name"},
+			},
+			&chplan.ColumnRef{Name: s.TimestampColumn},
+		},
+		Alias: "RootSvc",
+	}
+	agg := &chplan.Aggregate{
+		Input:          &chplan.Filter{Input: &chplan.Scan{Table: s.SpansTable}, Predicate: pred},
+		GroupBy:        []chplan.Expr{&chplan.ColumnRef{Name: s.TraceIDColumn}},
+		GroupByAliases: []string{"TraceId"},
+		AggFuncs:       []chplan.AggFunc{aggSpanName, aggSvc},
+	}
+
+	// Outer Project rewrites to canonical Sample shape so chclient
+	// decodes positionally: MetricName (RootSpanName), Attributes
+	// (map carrying TraceID + service.name), TimeUnix (now64), Value
+	// (0). Reading the columns produced by the Aggregate by bare name
+	// works because Aggregate emits `<expr> AS <alias>` + `<func> AS
+	// <alias>` in the SELECT list.
+	attrsMap := &chplan.FuncCall{Name: "map", Args: []chplan.Expr{
+		&chplan.LitString{V: searchKeyTraceID},
+		stripLeadingHexZeros("TraceId"),
+		&chplan.LitString{V: "service.name"},
+		&chplan.ColumnRef{Name: "RootSvc"},
+	}}
+	return &chplan.Project{
+		Input: agg,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.ColumnRef{Name: "RootSpanName"}, Alias: "MetricName"},
+			{Expr: attrsMap, Alias: "Attributes"},
+			{Expr: &chplan.FuncCall{Name: "now64", Args: []chplan.Expr{&chplan.LitInt{V: 9}}}, Alias: "TimeUnix"},
+			{Expr: &chplan.FuncCall{Name: "toFloat64", Args: []chplan.Expr{&chplan.LitInt{V: 0}}}, Alias: "Value"},
+		},
+	}
+}
+
+// orEqLiterals returns `<col> = <v1> OR <col> = <v2> OR ...` as a
+// nested chplan.Binary OR-chain. Returns a single Eq when len(vals) ==
+// 1, and a guaranteed-false (`<col> = <col> AND 1=0`-equivalent) when
+// vals is empty — but the caller (resolveTraceRoots) guards against
+// the empty case so the branch is unreachable in production.
+func orEqLiterals(col string, vals []string) chplan.Expr {
+	if len(vals) == 0 {
+		// Guaranteed-false: 1 = 0. CH evaluates this at planning time
+		// and short-circuits the filter; we should never hit this
+		// branch but it keeps the helper total over its input.
+		return &chplan.Binary{
+			Op:    chplan.OpEq,
+			Left:  &chplan.LitInt{V: 1},
+			Right: &chplan.LitInt{V: 0},
+		}
+	}
+	eq := func(v string) chplan.Expr {
+		return &chplan.Binary{
+			Op:    chplan.OpEq,
+			Left:  &chplan.ColumnRef{Name: col},
+			Right: &chplan.LitString{V: v},
+		}
+	}
+	out := eq(vals[0])
+	for i := 1; i < len(vals); i++ {
+		out = &chplan.Binary{Op: chplan.OpOr, Left: out, Right: eq(vals[i])}
+	}
+	return out
+}
+
+// padTraceIDs left-pads each stripped-zero TraceID back to the
+// canonical 32-char lowercase-hex on-disk form so the equality
+// predicate matches otel_traces.TraceId. Mirrors normaliseTraceID
+// but in bulk; sorted-stable so the generated SQL is deterministic
+// across calls (helps the chsql golden tests this helper unblocks).
+func padTraceIDs(ids []string) []string {
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, normaliseTraceID(id))
+	}
+	return out
+}
+
+// applyRootMetadata patches each summary whose TraceID appears in
+// roots with the looked-up RootServiceName / RootTraceName. Skips
+// summaries with no matching root entry (the trace's root is not in
+// otel_traces — true truncation; the earliest-span fallback that
+// toTraceSummaries already populated stays in place).
+//
+// Modifies the summaries slice in place; the slice header itself
+// (length, capacity, ordering) is unchanged.
+func applyRootMetadata(summaries []TraceSummary, roots map[string]rootMetadata) {
+	if len(roots) == 0 {
+		return
+	}
+	for i := range summaries {
+		root, ok := roots[summaries[i].TraceID]
+		if !ok {
+			continue
+		}
+		// Empty root SpanName means the lookup returned a row but the
+		// column was empty — treat as "no useful root data" and keep
+		// the earliest-span fallback. SpanName=="" rows can happen if
+		// a future producer emits a span with no name; the wire spec
+		// permits but discourages it.
+		if strings.TrimSpace(root.SpanName) != "" {
+			summaries[i].RootTraceName = root.SpanName
+		}
+		if root.ServiceName != "" {
+			summaries[i].RootServiceName = root.ServiceName
+		}
+	}
+}

--- a/internal/api/tempo/root_lookup_test.go
+++ b/internal/api/tempo/root_lookup_test.go
@@ -1,0 +1,194 @@
+package tempo
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestBuildRootLookupPlan_SQLShape pins the SQL shape emitted by the
+// follow-up root-lookup the /api/search shaper issues when the
+// original result set lacks a root row. The query must:
+//
+//  1. Group by TraceId and emit argMin(SpanName, Timestamp) AS
+//     RootSpanName so the earliest root span (smallest Timestamp)
+//     wins under broken-trace shapes with multiple roots.
+//  2. Filter on the OTel-CH on-disk root markers (empty / 16-char-zero
+//     ParentSpanId) AND on the affected TraceIDs so only true root
+//     rows are aggregated and the scan is bounded.
+//  3. Project the canonical Sample shape (MetricName, Attributes,
+//     TimeUnix, Value) so chclient.Sample decodes the rows positionally
+//     — the resolveTraceRoots caller reads SpanName off MetricName and
+//     service.name + __cerberus_traceID off the Attributes map.
+func TestBuildRootLookupPlan_SQLShape(t *testing.T) {
+	t.Parallel()
+	plan := buildRootLookupPlan(schema.DefaultOTelTraces(), []string{
+		"17",                               // short stripped form
+		"abc",                              // shorter, will be padded
+		"0123456789abcdef0123456789abcdef", // already 32 chars
+	})
+
+	sql, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	// Must aggregate via argMin(SpanName, Timestamp) so the earliest
+	// root span wins for broken traces.
+	if !strings.Contains(sql, "argMin") {
+		t.Errorf("SQL must use argMin for per-trace root selection; got %s", sql)
+	}
+	// Must alias one aggregate as RootSpanName so the outer Project
+	// can project it as MetricName.
+	if !strings.Contains(sql, "RootSpanName") {
+		t.Errorf("SQL must alias the SpanName argMin as RootSpanName; got %s", sql)
+	}
+	// Must alias the service-name aggregate as RootSvc.
+	if !strings.Contains(sql, "RootSvc") {
+		t.Errorf("SQL must alias the service.name argMin as RootSvc; got %s", sql)
+	}
+	// Must filter on ParentSpanId (the root-identifier column).
+	if !strings.Contains(sql, "ParentSpanId") {
+		t.Errorf("SQL must filter on ParentSpanId; got %s", sql)
+	}
+	// Must filter on TraceId (the per-trace scoping column).
+	if !strings.Contains(sql, "TraceId") {
+		t.Errorf("SQL must filter on TraceId; got %s", sql)
+	}
+	// Must group by TraceId so the aggregate yields one row per trace.
+	if !strings.Contains(sql, "GROUP BY") {
+		t.Errorf("SQL must group by TraceId; got %s", sql)
+	}
+	// Canonical Sample envelope columns.
+	for _, alias := range []string{"MetricName", "Attributes", "TimeUnix", "Value"} {
+		if !strings.Contains(sql, alias) {
+			t.Errorf("SQL must project canonical Sample alias %q; got %s", alias, sql)
+		}
+	}
+
+	// Args must include each TraceID padded to 32-char lowercase hex
+	// so the equality match hits the otel_traces.TraceId column.
+	// padTraceIDs pads to 32 chars: "17" → 30 zeros + "17", "abc" → 29
+	// zeros + "abc", already-32-char input round-trips byte-for-byte.
+	wantPadded := map[string]bool{
+		"00000000000000000000000000000017": false,
+		"00000000000000000000000000000abc": false,
+		"0123456789abcdef0123456789abcdef": false,
+	}
+	for _, a := range args {
+		s, ok := a.(string)
+		if !ok {
+			continue
+		}
+		if _, present := wantPadded[s]; present {
+			wantPadded[s] = true
+		}
+	}
+	for id, found := range wantPadded {
+		if !found {
+			t.Errorf("padded TraceID %q missing from args %v", id, args)
+		}
+	}
+
+	// Reserved key strings must be parameterised — searchKeyTraceID
+	// + "service.name" both appear as args so the map() call binds
+	// positionally.
+	for _, key := range []string{searchKeyTraceID, "service.name"} {
+		var sawKey bool
+		for _, a := range args {
+			if s, ok := a.(string); ok && s == key {
+				sawKey = true
+				break
+			}
+		}
+		if !sawKey {
+			t.Errorf("expected reserved key %q in args; got %v", key, args)
+		}
+	}
+
+	// Empty parent-span-id literal must appear so the OR-chain matches
+	// the OTel-CH on-disk empty form (hex.EncodeToString(nil) → "").
+	var sawEmptyParent bool
+	for _, a := range args {
+		if s, ok := a.(string); ok && s == "" {
+			sawEmptyParent = true
+			break
+		}
+	}
+	if !sawEmptyParent {
+		t.Errorf("expected empty-string ParentSpanId literal in args; got %v", args)
+	}
+	// 16-char zero form must appear so the OR-chain also matches
+	// producers that store the canonical hex-encoded all-zero shape.
+	var sawZeroParent bool
+	for _, a := range args {
+		if s, ok := a.(string); ok && s == "0000000000000000" {
+			sawZeroParent = true
+			break
+		}
+	}
+	if !sawZeroParent {
+		t.Errorf("expected 16-char-zero ParentSpanId literal in args; got %v", args)
+	}
+}
+
+// TestBuildRootLookupPlan_NoTraces verifies the helper renders a
+// valid SQL even with no trace IDs — defensive guarantee against an
+// empty `missing` list bypassing the caller's `len(traceIDs) == 0`
+// short-circuit (callers should not reach this with empty input, but
+// the helper must stay total).
+func TestBuildRootLookupPlan_NoTraces(t *testing.T) {
+	t.Parallel()
+	plan := buildRootLookupPlan(schema.DefaultOTelTraces(), nil)
+	sql, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit on empty traceIDs: %v", err)
+	}
+	if sql == "" {
+		t.Errorf("expected non-empty SQL even for empty traceIDs; got empty string")
+	}
+}
+
+// TestApplyRootMetadata_PatchesSummaries verifies the per-trace patch
+// merges recovered roots into the summary slice without touching
+// summaries whose TraceID is absent from the lookup map.
+func TestApplyRootMetadata_PatchesSummaries(t *testing.T) {
+	t.Parallel()
+	summaries := []TraceSummary{
+		{TraceID: "a", RootServiceName: "fallback-svc-a", RootTraceName: "fallback-name-a"},
+		{TraceID: "b", RootServiceName: "fallback-svc-b", RootTraceName: "fallback-name-b"},
+		{TraceID: "c", RootServiceName: "fallback-svc-c", RootTraceName: "fallback-name-c"},
+	}
+	roots := map[string]rootMetadata{
+		"a": {ServiceName: "real-svc-a", SpanName: "real-name-a"},
+		"c": {ServiceName: "real-svc-c", SpanName: "real-name-c"},
+	}
+	applyRootMetadata(summaries, roots)
+
+	if summaries[0].RootTraceName != "real-name-a" || summaries[0].RootServiceName != "real-svc-a" {
+		t.Errorf("summary a: got %+v, want recovered metadata", summaries[0])
+	}
+	if summaries[1].RootTraceName != "fallback-name-b" || summaries[1].RootServiceName != "fallback-svc-b" {
+		t.Errorf("summary b: got %+v, want untouched fallback metadata", summaries[1])
+	}
+	if summaries[2].RootTraceName != "real-name-c" || summaries[2].RootServiceName != "real-svc-c" {
+		t.Errorf("summary c: got %+v, want recovered metadata", summaries[2])
+	}
+}
+
+// TestApplyRootMetadata_EmptyRootsNoop confirms the helper is a no-op
+// when no roots were recovered (lookup returned nothing for any
+// trace) — the caller's earliest-span fallback survives intact.
+func TestApplyRootMetadata_EmptyRootsNoop(t *testing.T) {
+	t.Parallel()
+	summaries := []TraceSummary{
+		{TraceID: "a", RootServiceName: "fallback", RootTraceName: "fallback"},
+	}
+	applyRootMetadata(summaries, nil)
+	if summaries[0].RootServiceName != "fallback" || summaries[0].RootTraceName != "fallback" {
+		t.Errorf("empty roots must leave summaries untouched; got %+v", summaries[0])
+	}
+}


### PR DESCRIPTION
## Summary

- /api/search wrap projection projects only spans matching the TraceQL predicate. For structural-join queries (`>`, `<`, `>>`, `<<`, set ops) and filter predicates that exclude the root (`{ status = error }`, `{ kind = consumer }`), the result set lacks any row whose `ParentSpanId` is the root marker. The existing `toTraceSummaries` shaper falls back to the earliest matched child for `rootServiceName` / `rootTraceName`, producing e.g. `rootTraceName="checkout.child.2"` instead of `"GET /api/checkout/17"`.
- Modify `toTraceSummaries` to surface the set of TraceIDs whose result set lacked a root row. When non-empty, issue a follow-up CH query against `otel_traces` filtered to `ParentSpanId IN ('', '0000000000000000') AND TraceId IN (<padded ids>)`, `argMin`-aggregating `SpanName` + `ResourceAttributes['service.name']` by `Timestamp`. The handler patches affected summaries in place before responding. Truncated traces (lookup returns no row) keep the earliest-span fallback so a response always surfaces the trace.

## Root cause

Confirmed Hypothesis B from the dispatch: the structural-join SQL strictly returns the join's R-side rows (none of which is the trace's root), and `{ status = error }` against the seeded fixture matches only children (the root span reports `Ok`). The four affected compat cases (`descendant_op_payments_to_consumer` 28, `direct_parent_op_checkout_to_child` 28, `set_and_checkout_and_status_error` 30, `status_eq_error` 120) all produced this exact `child-name-as-root` failure mode.

PR #531 / #548 added the in-result-set root detection logic but it can only work when a root row is present in the response. This PR layers a separate cross-trace lookup so the canonical Tempo wire spec ("rootTraceName is the span at the top of the trace tree") holds across all four query families.

## Design choice (Option D vs C from the dispatch)

The dispatch prompt preferred Option C (project trace-level metadata via subquery on the same `otel_traces` table from inside the wrap projection). After investigation, Option C requires either a new chplan node (joining the Project's `Input` to a derived table) or a chsql emitter change to weave a `LEFT JOIN root_lookup AS root` into the wrap's outer SELECT. Both are sizable structural changes touching the chsql golden fixtures.

Option D (handler-layer follow-up query) is the smaller change with the same end-state:
  - **Wrap-projection SQL is unchanged** — all 30+ traceql TXTAR fixtures stay byte-stable.
  - **Two CH round-trips** (search + follow-up) only when the result set is rootless; otherwise the existing path runs unchanged.
  - The follow-up plan is built with the typed `chplan` API (no raw SQL strings, complying with CLAUDE.md's hard rule).

## Suppression rules

These keep all pre-existing tests stable without any test code changes:
  - Traces without a real TraceID (legacy synthetic-key fallback) stay on the earliest-span anchor — the lookup needs a real TraceID.
  - Traces whose rows never populated the `__cerberus_parentSpanID` slot (older fixtures, stub queriers) stay on the earliest-span anchor — the shaper cannot tell roots from children without the slot, so the follow-up is suppressed.

## Expected compat delta

The four affected cases each contribute 28-120 reasons in run `26119894887`. Recovering all four should clear ~206 reasons from the next compat run and lift the suite by ~6 percentage points.

## Files touched

- `internal/api/tempo/handler.go` — `toTraceSummaries` returns (summaries, missingRoots); `handleSearch` + `handleSearchRecent` invoke the follow-up + merge step.
- `internal/api/tempo/root_lookup.go` (new) — `resolveTraceRoots`, `buildRootLookupPlan`, `applyRootMetadata`, supporting helpers (`orEqLiterals`, `padTraceIDs`).
- `internal/api/tempo/root_lookup_test.go` (new) — whitebox tests pinning the SQL shape + the in-place merge helper.
- `internal/api/tempo/handler_test.go` — new `TestSearch_StructuralJoin_RootSurfaced` exercising both the recovered-root and truncated-fallback paths via stubQuerier; existing truncated-trace test updated to stub the follow-up as empty.

## Test plan

- [x] `go test ./internal/api/tempo/...` — 206 tests pass.
- [x] `gofumpt -w` — all changed files clean.
- [x] `go vet ./...` — no issues.
- [ ] CI `check` + `lint` green.
- [ ] Next nightly tempo-compat run shows the four cases recovered.