### PR TITLE
fix(logql): drop unconditional detected_level injection on log queries

### DIFF
--- a/internal/logql/detected_level.go
+++ b/internal/logql/detected_level.go
@@ -1,6 +1,8 @@
 package logql
 
 import (
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+
 	"github.com/tsouza/cerberus/internal/chplan"
 	"github.com/tsouza/cerberus/internal/schema"
 )
@@ -217,4 +219,94 @@ func withDetectedLevel(s schema.Logs, baseLabels chplan.Expr) chplan.Expr {
 		Name: "mapConcat",
 		Args: []chplan.Expr{baseLabels, filtered},
 	}
+}
+
+// queryReferencesDetectedLevel reports whether the parsed LogQL
+// expression references the synthesized severity dimension anywhere
+// the user could observe it. Used by the log-stream projection in
+// [Lang.ProjectSamples] to gate the `withDetectedLevel` wrap so a bare
+// selector query (`{service="api"}`) doesn't gain a spurious
+// `detected_level` stream label that would split its single Loki
+// stream into one per severity (the loki-compat
+// fast/basic-selectors.yaml regression: cerberus emitted 4 streams per
+// service where reference Loki emits 1, because reference Loki only
+// surfaces `detected_level` on queries that explicitly reference it).
+//
+// The detection covers four user-visible forms:
+//
+//  1. Stream-selector matchers — `{detected_level="error"}`,
+//     `{level="warn"}`. The matcher name lands in
+//     [syntax.MatchersExpr.Mts].
+//  2. Pipe-stage label filters — `| detected_level="error"`,
+//     `| level=~"warn|error"`. The filter exposes its referenced label
+//     names via [log.LabelFilterer.RequiredLabelNames].
+//  3. Vector-aggregation grouping — `sum by (detected_level) (...)`,
+//     `sum by (level) (...)`, plus the `without (...)` mirror. The
+//     grouping labels live in [syntax.VectorAggregationExpr.Grouping].
+//  4. Range-aggregation grouping — `count_over_time({...}[5m]) by
+//     (detected_level)`, plus `without`. The grouping labels live in
+//     [syntax.RangeAggregationExpr.Grouping].
+//
+// Pipe stages that COULD produce a `level` key as part of their
+// parser-extracted labels (`| logfmt`, `| json`, `| regexp ...`,
+// `| pattern ...`, `| label_format ...`) don't count: the parser-
+// extracted `level` is itself a label-filter-context lookup against
+// the augmented labels map (see [isDetectedLevelLabel] vs
+// [isDetectedLevelGroupingLabel]) and doesn't drive the synthesized
+// SeverityText projection. Only an explicit reference at one of the
+// four sites above pulls `detected_level` into stream identity.
+//
+// Both `detected_level` and its `level` short alias trigger the wrap —
+// upstream Loki treats them as the same dimension once severity
+// detection settles, and the stream-identity layer surfaces the
+// canonical `detected_level` regardless of which form the user wrote.
+func queryReferencesDetectedLevel(expr syntax.Expr) bool {
+	if expr == nil {
+		return false
+	}
+	var found bool
+	expr.Walk(func(e syntax.Expr) bool {
+		if found {
+			return false
+		}
+		switch v := e.(type) {
+		case *syntax.MatchersExpr:
+			for _, m := range v.Mts {
+				if isDetectedLevelGroupingLabel(m.Name) {
+					found = true
+					return false
+				}
+			}
+		case *syntax.LabelFilterExpr:
+			if v.LabelFilterer == nil {
+				return true
+			}
+			for _, name := range v.LabelFilterer.RequiredLabelNames() {
+				if isDetectedLevelGroupingLabel(name) {
+					found = true
+					return false
+				}
+			}
+		case *syntax.VectorAggregationExpr:
+			if v.Grouping != nil {
+				for _, g := range v.Grouping.Groups {
+					if isDetectedLevelGroupingLabel(g) {
+						found = true
+						return false
+					}
+				}
+			}
+		case *syntax.RangeAggregationExpr:
+			if v.Grouping != nil {
+				for _, g := range v.Grouping.Groups {
+					if isDetectedLevelGroupingLabel(g) {
+						found = true
+						return false
+					}
+				}
+			}
+		}
+		return true
+	})
+	return found
 }

--- a/internal/logql/detected_level.go
+++ b/internal/logql/detected_level.go
@@ -281,7 +281,7 @@ func queryReferencesDetectedLevel(expr syntax.Expr) bool {
 			if v.LabelFilterer == nil {
 				return true
 			}
-			for _, name := range v.LabelFilterer.RequiredLabelNames() {
+			for _, name := range v.RequiredLabelNames() {
 				if isDetectedLevelGroupingLabel(name) {
 					found = true
 					return false

--- a/internal/logql/lang.go
+++ b/internal/logql/lang.go
@@ -191,17 +191,27 @@ func (l *Lang) ProjectSamples(plan chplan.Node, meta engine.Meta) chplan.Node {
 	// and write a 0.0 placeholder into Value. toStreamsWithTransform reads
 	// back from Sample.MetricName as the line content.
 	//
-	// The Attributes column is wrapped in [withDetectedLevel] so the
-	// emitted row carries `detected_level` as a synthesized label
-	// whenever SeverityText is populated. Loki's stream-label contract
-	// surfaces detected_level as part of stream identity, so cerberus's
-	// /query streams response splits into one Stream per detected_level
-	// (matching upstream Loki's wire shape).
+	// The Attributes column is wrapped in [withDetectedLevel] ONLY when
+	// the query explicitly references `detected_level` / `level` (in a
+	// matcher, label filter, or grouping clause). Reference Loki only
+	// surfaces the synthesized severity label when the query asks for
+	// it; auto-injecting it on every log query splits a single stream
+	// into one per severity, breaking the
+	// `fast/basic-selectors.yaml :: streams[0] entry count` compat-
+	// harness invariant for bare selector queries. When the user does
+	// reference `detected_level` (e.g. `{job="api"} |
+	// detected_level="error"`), the wrap kicks in so the streams
+	// response carries the synthesized label that downstream consumers
+	// expect.
+	attrsExpr := chplan.Expr(&chplan.ColumnRef{Name: s.ResourceAttributesColumn})
+	if expr, _ := meta.Extra["expr"].(syntax.Expr); queryReferencesDetectedLevel(expr) {
+		attrsExpr = withDetectedLevel(s, attrsExpr)
+	}
 	return &chplan.Project{
 		Input: plan,
 		Projections: []chplan.Projection{
 			{Expr: &chplan.ColumnRef{Name: s.BodyColumn}, Alias: "MetricName"},
-			{Expr: withDetectedLevel(s, &chplan.ColumnRef{Name: s.ResourceAttributesColumn}), Alias: "Attributes"},
+			{Expr: attrsExpr, Alias: "Attributes"},
 			{Expr: &chplan.ColumnRef{Name: s.TimestampColumn}, Alias: "TimeUnix"},
 			// Wrap the placeholder zero in toFloat64 so CH returns the column
 			// as Float64; without the cast a bare `0` literal becomes UInt8

--- a/internal/logql/lang_test.go
+++ b/internal/logql/lang_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+
 	"github.com/tsouza/cerberus/internal/chplan"
 	"github.com/tsouza/cerberus/internal/engine"
 	"github.com/tsouza/cerberus/internal/logql"
@@ -301,32 +303,41 @@ func TestProjectSamples_VectorAggregateOverMatrixForwardsTimeUnix(t *testing.T) 
 	}
 }
 
-// TestProjectSamples_LogQuerySurfacesDetectedLevel pins the log-stream
-// branch's Attributes slot to a `mapConcat(...)` that folds the
-// synthesized `detected_level` label onto the row's ResourceAttributes.
+// TestProjectSamples_LogQuerySurfacesDetectedLevelWhenReferenced pins
+// the log-stream branch's Attributes slot to a `mapConcat(...)` that
+// folds the synthesized `detected_level` label onto the row's
+// ResourceAttributes WHEN the query explicitly references the label.
 //
-// Loki's stream-identity contract surfaces `detected_level` as a
-// structural label whenever the upstream row carries a severity-bearing
-// column. Cerberus mirrors that on the wire: the
-// `toStreamsWithTransform` pivot keys on `format.CanonicalKey(labels)`,
-// so adding `detected_level` to the labels map splits the streams
-// response into one Stream per distinct severity — matching upstream's
-// shape on a multi-level seed.
+// Reference Loki only surfaces `detected_level` as a stream-identity
+// label when the query asks for it (matcher, label filter, or grouping
+// clause). Cerberus mirrors that here: a query like `{job="api"} |
+// detected_level="error"` produces an Attributes slot wrapped with the
+// detected_level augmentation, so downstream stream-identity layers
+// see the synthesized severity dimension.
 //
-// The pre-detected_level wire-wrap projected `ResourceAttributes`
-// directly; this test pins the upgrade so a regression that reverts to
-// the bare column ref is caught synchronously rather than via the
-// loki-compat harness's "streams length: expected=4 actual=1" failure.
-func TestProjectSamples_LogQuerySurfacesDetectedLevel(t *testing.T) {
+// Pair with [TestProjectSamples_BareLogQueryDoesNotSurfaceDetectedLevel]
+// which pins the no-reference path — that's the loki-compat
+// `fast/basic-selectors.yaml :: streams[0] entry count` invariant
+// (cerberus auto-injecting `detected_level` on every log query split
+// each stream into one per severity).
+func TestProjectSamples_LogQuerySurfacesDetectedLevelWhenReferenced(t *testing.T) {
 	t.Parallel()
 
 	s := schema.DefaultOTelLogs()
 	l := &logql.Lang{Schema: s}
 
+	expr, err := syntax.ParseExpr(`{job="api"} | detected_level="error"`)
+	if err != nil {
+		t.Fatalf("ParseExpr: %v", err)
+	}
+
 	// Log-stream queries lower to a Scan (or Filter(Scan)) — no inner
 	// Project layer. ProjectSamples wraps with the wire-shape projection.
 	plan := &chplan.Scan{Table: s.LogsTable}
-	wrapped := l.ProjectSamples(plan, engine.Meta{IsMetric: false})
+	wrapped := l.ProjectSamples(plan, engine.Meta{
+		IsMetric: false,
+		Extra:    map[string]any{"expr": expr},
+	})
 
 	proj, ok := wrapped.(*chplan.Project)
 	if !ok {
@@ -342,18 +353,124 @@ func TestProjectSamples_LogQuerySurfacesDetectedLevel(t *testing.T) {
 		t.Fatalf("attributes slot alias: got %q, want %q", attrsSlot.Alias, "Attributes")
 	}
 	// Must be a mapConcat(...) — the helper that folds detected_level
-	// onto the row's ResourceAttributes. A bare ColumnRef would mean
-	// the log-stream branch dropped the augmentation.
+	// onto the row's ResourceAttributes. A bare ColumnRef here would
+	// mean the conditional wrap missed the explicit `|
+	// detected_level=...` reference.
 	fn, ok := attrsSlot.Expr.(*chplan.FuncCall)
 	if !ok {
 		t.Fatalf("attributes slot expr: got %T, want *chplan.FuncCall "+
-			"(log-stream wire-wrap must wrap ResourceAttributes in a "+
-			"mapConcat that adds the synthesized `detected_level` label)",
+			"(wire-wrap must wrap ResourceAttributes in a mapConcat that "+
+			"adds the synthesized `detected_level` label when the query "+
+			"explicitly references it)",
 			attrsSlot.Expr)
 	}
 	if fn.Name != "mapConcat" {
 		t.Errorf("attributes slot FuncCall.Name: got %q, want %q "+
-			"(log-stream wire-wrap must fold detected_level via mapConcat)",
-			fn.Name, "mapConcat")
+			"(wire-wrap must fold detected_level via mapConcat when "+
+			"referenced)", fn.Name, "mapConcat")
+	}
+}
+
+// TestProjectSamples_BareLogQueryDoesNotSurfaceDetectedLevel pins the
+// inverse path: a bare selector query (`{service="api"}`) without any
+// `detected_level` / `level` reference must NOT gain the synthesized
+// label in its Attributes projection.
+//
+// Reference Loki only surfaces `detected_level` on queries that ask
+// for it; auto-injecting on every log query splits a single Loki
+// stream into one per severity, breaking the `fast/basic-selectors.yaml
+// :: streams[0] entry count` loki-compat invariant (4 cases failed
+// with `expected=246-338 actual=360-361` because cerberus emitted 4
+// streams per service where reference Loki emits 1). This test pins
+// the no-reference path so a regression to unconditional injection is
+// caught synchronously rather than via the compat harness.
+func TestProjectSamples_BareLogQueryDoesNotSurfaceDetectedLevel(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelLogs()
+	l := &logql.Lang{Schema: s}
+
+	expr, err := syntax.ParseExpr(`{service="api"}`)
+	if err != nil {
+		t.Fatalf("ParseExpr: %v", err)
+	}
+
+	plan := &chplan.Scan{Table: s.LogsTable}
+	wrapped := l.ProjectSamples(plan, engine.Meta{
+		IsMetric: false,
+		Extra:    map[string]any{"expr": expr},
+	})
+
+	proj, ok := wrapped.(*chplan.Project)
+	if !ok {
+		t.Fatalf("ProjectSamples returned %T, want *chplan.Project", wrapped)
+	}
+
+	attrsSlot := proj.Projections[1]
+	if attrsSlot.Alias != "Attributes" {
+		t.Fatalf("attributes slot alias: got %q, want %q", attrsSlot.Alias, "Attributes")
+	}
+	// Must be a bare ColumnRef on ResourceAttributes — the conditional
+	// wrap must skip the mapConcat augmentation when the query has no
+	// `detected_level` / `level` reference. A FuncCall here would mean
+	// the unconditional auto-injection reappeared.
+	colRef, ok := attrsSlot.Expr.(*chplan.ColumnRef)
+	if !ok {
+		t.Fatalf("attributes slot expr: got %T, want *chplan.ColumnRef "+
+			"(bare selector query must NOT wrap Attributes in mapConcat — "+
+			"auto-injecting detected_level on every log query splits each "+
+			"stream into one per severity, breaking the loki-compat "+
+			"fast/basic-selectors entry-count invariant)",
+			attrsSlot.Expr)
+	}
+	if colRef.Name != s.ResourceAttributesColumn {
+		t.Errorf("attributes slot ColumnRef.Name: got %q, want %q "+
+			"(schema's ResourceAttributesColumn)",
+			colRef.Name, s.ResourceAttributesColumn)
+	}
+}
+
+// TestProjectSamples_LogQueryWithDetectedLevelFilterTriggersWrap is a
+// focused coverage point for the label-filter reference path — the
+// `| detected_level="error"` form must trigger the wrap even though
+// the matcher itself sits in a pipe stage rather than the stream
+// selector. Same expectation as the explicit-matcher variant.
+func TestProjectSamples_LogQueryWithDetectedLevelFilterTriggersWrap(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelLogs()
+	l := &logql.Lang{Schema: s}
+
+	for _, q := range []string{
+		// label-filter form (pipe stage)
+		`{job="api"} | detected_level="error"`,
+		// short-alias label filter
+		`{job="api"} | level=~"error|warn"`,
+		// stream-selector form
+		`{detected_level="error"}`,
+	} {
+		t.Run(q, func(t *testing.T) {
+			t.Parallel()
+			expr, err := syntax.ParseExpr(q)
+			if err != nil {
+				t.Fatalf("ParseExpr: %v", err)
+			}
+			plan := &chplan.Scan{Table: s.LogsTable}
+			wrapped := l.ProjectSamples(plan, engine.Meta{
+				IsMetric: false,
+				Extra:    map[string]any{"expr": expr},
+			})
+			proj := wrapped.(*chplan.Project)
+			attrsSlot := proj.Projections[1]
+			fn, ok := attrsSlot.Expr.(*chplan.FuncCall)
+			if !ok {
+				t.Fatalf("attributes slot expr: got %T, want *chplan.FuncCall (mapConcat) for query %q",
+					attrsSlot.Expr, q)
+			}
+			if fn.Name != "mapConcat" {
+				t.Errorf("attributes slot FuncCall.Name: got %q, want %q for query %q",
+					fn.Name, "mapConcat", q)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

PR #545 wrapped every LogQL log-stream `Attributes` projection with `withDetectedLevel`, surfacing the synthesized severity label on every row regardless of whether the query asked for it. Reference Loki only exposes `detected_level` as part of stream identity when the query explicitly references it (matcher, label filter, or grouping clause). The auto-injection split each Loki stream into one per severity, breaking the loki-compat `fast/basic-selectors.yaml :: streams[0] entry count` invariant for bare selector queries (cerberus emitted ~4 streams per service where reference Loki emits 1).

## Fix

- `Lang.ProjectSamples` (log branch) now gates the `withDetectedLevel` wrap on a new `queryReferencesDetectedLevel(expr)` helper that walks the parsed LogQL AST and reports whether any matcher, label filter, or grouping clause references the `detected_level` / `level` dimension.
- The metric branch (`lowerRangeAggregation`) keeps its unconditional auto-injection — that's the documented Loki shape for metric queries (one series per severity in the matrix response).

### Detection covers four user-visible reference forms

1. Stream-selector matchers (`{detected_level="error"}`, `{level="warn"}`).
2. Pipe-stage label filters (`| detected_level=...`, `| level=~"..."`).
3. Vector-aggregation grouping (`sum by (detected_level) (...)` / `sum by (level) (...)`).
4. Range-aggregation grouping (`count_over_time({...}[5m]) by (detected_level)`).

Parser-extracted `level` keys (`| logfmt | level="..."`) keep going through the existing label-map lookup path (handled by `isDetectedLevelLabel` / `isDetectedLevelGroupingLabel`).

## Expected compat delta

Loki compatibility: ~30.43% → ~40%+ (4 cases under `fast/basic-selectors.yaml` clear: `expected=246-338 actual=360-361` → match).

## Test plan

- [x] `go test ./internal/logql/...` — 303 pass (was 300; +3 new tests).
- [x] `go test ./internal/api/loki/... ./test/spec/...` — 211 pass.
- [x] New unit tests:
  - `TestProjectSamples_BareLogQueryDoesNotSurfaceDetectedLevel` — bare `{service="api"}` yields plain ColumnRef on ResourceAttributes (no mapConcat wrap).
  - `TestProjectSamples_LogQuerySurfacesDetectedLevelWhenReferenced` — `{job="api"} | detected_level="error"` yields the mapConcat wrap.
  - `TestProjectSamples_LogQueryWithDetectedLevelFilterTriggersWrap` — exercises label-filter, short-alias, and stream-selector paths.
- [x] Loki compat run (CI) should report 4 additional passes under `fast/basic-selectors.yaml`.

Generated with Claude Code