### PR TITLE
fix(traceql): emit duration aggregations in seconds (divide ns by 1e9)

### DIFF
--- a/internal/api/tempo/metrics_query_range_test.go
+++ b/internal/api/tempo/metrics_query_range_test.go
@@ -372,6 +372,127 @@ func TestMetricsQueryRange_ZeroFillSkippedForAvgOverTime(t *testing.T) {
 	}
 }
 
+// TestMetricsQueryRange_DurationAggInSeconds pins the contract that
+// duration-based *_over_time aggregations emit values in seconds, not
+// raw nanoseconds. The OTel-CH Duration column is Int64 ns; Tempo's
+// reference engine divides by 1e9 before producing the InstantSeries
+// value (see pkg/traceql/engine_metrics.go: sumOverTimeAggregator /
+// averageOverTimeAggregator / quantileOverTimeAggregator all
+// divide-by-1e9). Cerberus matches by wrapping the lowered Duration
+// expression in `<expr> / 1e9` at lowering time
+// (internal/traceql/metrics_pipeline.go: metricsAggregateAttr); this
+// test asserts the wrap survives end-to-end by probing the emitted SQL.
+//
+// Without the wrap the Tempo compat differ flagged
+// `metrics_avg_over_time_instant` with a ~1e9 ratio between cerberus
+// (raw ns) and Tempo (seconds). Pinning the SQL shape here keeps that
+// regression from re-emerging.
+func TestMetricsQueryRange_DurationAggInSeconds(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		query string
+		op    string // expected __name__ label value
+	}{
+		{"avg_over_time", "{} | avg_over_time(duration)", "avg_over_time"},
+		{"sum_over_time", "{} | sum_over_time(duration)", "sum_over_time"},
+		{"min_over_time", "{} | min_over_time(duration)", "min_over_time"},
+		{"max_over_time", "{} | max_over_time(duration)", "max_over_time"},
+		{"quantile_over_time", "{} | quantile_over_time(duration, 0.95)", "quantile_over_time"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mid := time.Date(2026, 5, 12, 10, 1, 0, 0, time.UTC)
+			q := &stubQuerier{samples: []chclient.Sample{{
+				MetricName: "",
+				Labels:     map[string]string{"__name__": tc.op},
+				Timestamp:  mid,
+				// Seed a value mimicking what CH would return after
+				// the `/ 1e9` divisor — a sub-second duration. The
+				// stub does not actually run SQL, so we're asserting
+				// the handler propagates the value verbatim; the
+				// real ns→s rebase happens server-side in the
+				// emitted SQL and is asserted via assertSQLContains
+				// below.
+				Value: 0.5,
+			}}}
+			srv := newServer(q, "v1.0.0-test")
+			t.Cleanup(srv.Close)
+
+			u := metricsQueryRangeURL(srv.URL, tc.query, map[string]string{
+				"start": fixtureStartUnix,
+				"end":   fixtureEndUnix,
+				"step":  "60s",
+			})
+			resp, err := http.Get(u)
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+			}
+
+			// The emitted SQL must contain the `/ ?` division that
+			// rebases the raw-ns Duration column into fractional
+			// seconds before the per-bucket reducer (sum / avg / min
+			// / max / quantile) sees it. Without this guard, a
+			// future refactor that bypasses metricsAggregateAttr's
+			// duration branch would silently regress every Tempo
+			// compat case that consumes the `Duration` intrinsic.
+			assertSQLContains(t, q.lastSQL, "`Duration` / ?")
+
+			// The 1e9 divisor must appear in the args list — locks in
+			// the parameterised form rather than an inline literal
+			// (the chplan IR carries data through `?` placeholders).
+			foundDivisor := false
+			for _, a := range q.lastArgs {
+				if f, ok := a.(float64); ok && f == 1e9 {
+					foundDivisor = true
+					break
+				}
+			}
+			if !foundDivisor {
+				t.Errorf("expected 1e9 divisor in args, got %v", q.lastArgs)
+			}
+
+			// The stubbed sub-second value must surface verbatim in
+			// the response — the handler does not (and must not)
+			// further rescale the Value.
+			var body tempo.MetricsQueryRangeResponse
+			if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if len(body.Series) != 1 {
+				t.Fatalf("expected 1 series, got %d: %+v", len(body.Series), body)
+			}
+			// Find the sample that matches the stubbed Timestamp;
+			// other anchors get zero-fill or NaN-skip per Op
+			// (irrelevant to this test — we care about value
+			// fidelity for the observed bucket).
+			midMs := mid.UnixMilli()
+			var observed *tempo.MetricsSample
+			for i := range body.Series[0].Samples {
+				if body.Series[0].Samples[i].TimestampMs == midMs {
+					observed = &body.Series[0].Samples[i]
+					break
+				}
+			}
+			if observed == nil {
+				t.Fatalf("no sample matches stubbed timestamp %d: %+v", midMs, body.Series[0].Samples)
+			}
+			if observed.Value != 0.5 {
+				t.Errorf("expected sub-second value 0.5 to pass through unchanged, got %v", observed.Value)
+			}
+		})
+	}
+}
+
 // mustParseUnix parses a unix-seconds string and returns a UTC time,
 // failing the test on parse error. Mirrors parseTempoTime's heuristics
 // but tightened to the int64-only path the fixture timestamps use.

--- a/internal/traceql/metrics_pipeline.go
+++ b/internal/traceql/metrics_pipeline.go
@@ -196,6 +196,19 @@ func mapMetricsAggregateOp(op traceql.MetricsAggregateOp) (chplan.MetricsOp, err
 // The "no attribute supplied" sentinel is the zero-value `Attribute{}`
 // (same convention Tempo's runtime uses at
 // ast_metrics.go: `a.attr != (Attribute{})`).
+//
+// Unit conversion for `duration`: the OTel-CH `Duration` column is
+// Int64 nanoseconds. Tempo's reference engine emits metric values in
+// fractional seconds — its sumOverTimeAggregator / averageOverTimeAggregator
+// / quantileOverTimeAggregator all read `Span.DurationNanos()` and
+// divide by 1e9 before producing the per-bucket sample. To match Tempo's
+// wire shape (so the differ's `metrics_avg_over_time_instant` and
+// kin compare against a Tempo-side value in seconds, not raw ns), we
+// wrap the lowered duration expression in `<expr> / 1e9` at lowering
+// time when the operand is the `duration` intrinsic. The wrap applies
+// to sum / avg / min / max / quantile aggregations — all the
+// duration-aware *_over_time forms; rate / count_over_time fall out of
+// the switch above before this code runs.
 func metricsAggregateAttr(op traceql.MetricsAggregateOp, attr traceql.Attribute, s schema.Traces) (chplan.Expr, error) {
 	switch op {
 	case traceql.MetricsAggregateRate, traceql.MetricsAggregateCountOverTime:
@@ -208,7 +221,39 @@ func metricsAggregateAttr(op traceql.MetricsAggregateOp, attr traceql.Attribute,
 	// aggregate.go. `*_over_time(span.foo)` resolves to a FieldAccess
 	// against SpanAttributes (typed String); wrap so the downstream CH
 	// aggregate (`max`/`min`/`sum`/`avg`/`quantiles`) sees a Float64.
-	return coerceMapNumericAggInput(lowerAttribute(attr, s)), nil
+	expr := coerceMapNumericAggInput(lowerAttribute(attr, s))
+	if attr.Intrinsic == traceql.IntrinsicDuration {
+		expr = durationNsToSeconds(expr)
+	}
+	return expr, nil
+}
+
+// nanosecondsPerSecond is the divisor used to rebase Int64-ns duration
+// values into fractional seconds for duration-based metrics
+// aggregations. Mirrors Tempo's `nanosToSec` constant
+// (pkg/traceql/engine_metrics.go: 1e9 in the
+// average/sum/quantileOverTime aggregators) so cerberus emits values in
+// the same unit Tempo's wire shape uses.
+const nanosecondsPerSecond = 1e9
+
+// durationNsToSeconds wraps the lowered duration expression in
+// `<expr> / 1e9`. Kept as a tiny helper so the unit-conversion site is
+// easy to spot — the only callers are metricsAggregateAttr (the
+// MetricsAggregate operand) and any future second-stage shapers that
+// need the same rebase.
+//
+// Why a typed chplan.Binary rather than a CH-side `toFloat64(...) /
+// 1e9` FuncCall: the chsql emitter renders Binary{OpDiv} as the bare
+// SQL `/` operator and ClickHouse already promotes the
+// `Int64 / Float64` arithmetic to Float64 — no explicit cast required.
+// The result feeds straight into `sum` / `avg` / `min` / `max` /
+// `quantile`, which all accept Float64.
+func durationNsToSeconds(e chplan.Expr) chplan.Expr {
+	return &chplan.Binary{
+		Op:    chplan.OpDiv,
+		Left:  e,
+		Right: &chplan.LitFloat{V: nanosecondsPerSecond},
+	}
 }
 
 // histogramBucketAlias is the SELECT-list alias for the bucket column

--- a/internal/traceql/metrics_pipeline_test.go
+++ b/internal/traceql/metrics_pipeline_test.go
@@ -168,6 +168,111 @@ func TestLowerMetricsPipeline(t *testing.T) {
 	}
 }
 
+// TestLowerMetricsPipeline_DurationSeconds pins the duration-to-seconds
+// unit conversion for the *_over_time aggregations.
+//
+// The OTel-CH Duration column is Int64 nanoseconds; Tempo's reference
+// engine emits metric values in fractional seconds (its
+// sumOverTimeAggregator / averageOverTimeAggregator /
+// quantileOverTimeAggregator all divide by 1e9 in
+// pkg/traceql/engine_metrics.go). Cerberus matches that wire shape by
+// wrapping the lowered Duration expression in `<expr> / 1e9` at
+// lowering time. The wrap applies to every duration-aware *_over_time
+// aggregation (sum / avg / min / max / quantile) — count_over_time and
+// rate take no operand and fall through the early return in
+// metricsAggregateAttr, so this test does not exercise them.
+//
+// Without the wrap, the Tempo compat differ flagged
+// `metrics_avg_over_time_instant` with a ~1e9 ratio between cerberus
+// (raw ns) and Tempo (seconds); pinning the shape here keeps that bug
+// from regressing.
+func TestLowerMetricsPipeline_DurationSeconds(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelTraces()
+
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{"sum_over_time_duration", `{} | sum_over_time(duration)`},
+		{"avg_over_time_duration", `{} | avg_over_time(duration)`},
+		{"min_over_time_duration", `{} | min_over_time(duration)`},
+		{"max_over_time_duration", `{} | max_over_time(duration)`},
+		{"quantile_over_time_duration", `{} | quantile_over_time(duration, 0.95)`},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			expr, err := tempo.Parse(tc.query)
+			if err != nil {
+				t.Fatalf("Parse(%q): %v", tc.query, err)
+			}
+			plan, err := traceql.Lower(context.Background(), expr, s)
+			if err != nil {
+				t.Fatalf("Lower(%q): %v", tc.query, err)
+			}
+			ma, ok := plan.(*chplan.MetricsAggregate)
+			if !ok {
+				t.Fatalf("expected *chplan.MetricsAggregate, got %T", plan)
+			}
+			// Operand must be a (Duration / 1e9) Binary node so the CH
+			// aggregate (sum / avg / min / max / quantile) reduces over
+			// seconds rather than raw nanoseconds.
+			bin, ok := ma.Attr.(*chplan.Binary)
+			if !ok {
+				t.Fatalf("expected MetricsAggregate.Attr to be *chplan.Binary, got %T", ma.Attr)
+			}
+			if bin.Op != chplan.OpDiv {
+				t.Errorf("Binary.Op = %v, want %v", bin.Op, chplan.OpDiv)
+			}
+			col, ok := bin.Left.(*chplan.ColumnRef)
+			if !ok {
+				t.Fatalf("expected Binary.Left to be *chplan.ColumnRef, got %T", bin.Left)
+			}
+			if col.Name != s.DurationColumn {
+				t.Errorf("Binary.Left.Name = %q, want %q", col.Name, s.DurationColumn)
+			}
+			div, ok := bin.Right.(*chplan.LitFloat)
+			if !ok {
+				t.Fatalf("expected Binary.Right to be *chplan.LitFloat, got %T", bin.Right)
+			}
+			if div.V != 1e9 {
+				t.Errorf("Binary.Right.V = %v, want 1e9", div.V)
+			}
+		})
+	}
+}
+
+// TestLowerMetricsPipeline_NonDurationAttrUnwrapped guards the
+// negative case: only the `duration` intrinsic gets the ns→s rebase.
+// Span-attribute operands (`span.<attr>`) and resource-attribute
+// operands carry user-defined units and must NOT be divided by 1e9.
+func TestLowerMetricsPipeline_NonDurationAttrUnwrapped(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelTraces()
+
+	expr, err := tempo.Parse(`{} | sum_over_time(span.bytes)`)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	plan, err := traceql.Lower(context.Background(), expr, s)
+	if err != nil {
+		t.Fatalf("Lower: %v", err)
+	}
+	ma, ok := plan.(*chplan.MetricsAggregate)
+	if !ok {
+		t.Fatalf("expected *chplan.MetricsAggregate, got %T", plan)
+	}
+	if _, isBin := ma.Attr.(*chplan.Binary); isBin {
+		t.Errorf("non-duration operand must not be wrapped in /1e9 Binary; got %T", ma.Attr)
+	}
+}
+
 // Every metrics-pipeline form now lowers:
 //
 //   - `histogram_over_time(...)` → chplan.MetricsHistogramOverTime

--- a/test/spec/traceql/by_mixed_scopes.txtar
+++ b/test/spec/traceql/by_mixed_scopes.txtar
@@ -1,13 +1,14 @@
 -- query.traceql --
 {} | max_over_time(duration) by (resource.service.name, span.http.method)
 -- sql --
-SELECT `ResourceAttributes`[?] AS `service.name`, `SpanAttributes`[?] AS `http.method`, max(`Duration`) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE ?) GROUP BY `ResourceAttributes`[?], `SpanAttributes`[?]
+SELECT `ResourceAttributes`[?] AS `service.name`, `SpanAttributes`[?] AS `http.method`, max((`Duration` / ?)) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE ?) GROUP BY `ResourceAttributes`[?], `SpanAttributes`[?]
 -- args --
 [0] string = "service.name"
 [1] string = "http.method"
-[2] bool = true
-[3] string = "service.name"
-[4] string = "http.method"
+[2] float64 = 1e+09
+[3] bool = true
+[4] string = "service.name"
+[5] string = "http.method"
 -- seed --
 CREATE TABLE otel_traces (
     ResourceAttributes Map(String, String),
@@ -20,9 +21,9 @@ INSERT INTO otel_traces VALUES
     (map('service.name', 'frontend'), map('http.method', 'GET'),  75000000);
 -- expected_rows --
 [
-  ["frontend", "GET", 100000000]
+  ["frontend", "GET", 0.1]
 ]
 -- chplan --
-MetricsAggregate op=max_over_time attr=Duration groupBy=[ResourceAttributes["service.name"] AS service.name|resource.service.name, SpanAttributes["http.method"] AS http.method|span.http.method] valueAlias=Value
+MetricsAggregate op=max_over_time attr=(Duration / 1e+09) groupBy=[ResourceAttributes["service.name"] AS service.name|resource.service.name, SpanAttributes["http.method"] AS http.method|span.http.method] valueAlias=Value
   Filter predicate=true
     Scan(otel_traces)

--- a/test/spec/traceql/metrics_max_over_time.txtar
+++ b/test/spec/traceql/metrics_max_over_time.txtar
@@ -1,9 +1,10 @@
 -- query.traceql --
 {} | max_over_time(duration)
 -- sql --
-SELECT max(`Duration`) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE ?)
+SELECT max((`Duration` / ?)) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE ?)
 -- args --
-[0] bool = true
+[0] float64 = 1e+09
+[1] bool = true
 -- seed --
 CREATE TABLE otel_traces (
     Duration UInt64
@@ -14,9 +15,9 @@ INSERT INTO otel_traces VALUES
     (100000000);
 -- expected_rows --
 [
-  [200000000]
+  [0.2]
 ]
 -- chplan --
-MetricsAggregate op=max_over_time attr=Duration valueAlias=Value
+MetricsAggregate op=max_over_time attr=(Duration / 1e+09) valueAlias=Value
   Filter predicate=true
     Scan(otel_traces)

--- a/test/spec/traceql/metrics_min_over_time.txtar
+++ b/test/spec/traceql/metrics_min_over_time.txtar
@@ -1,9 +1,10 @@
 -- query.traceql --
 {} | min_over_time(duration)
 -- sql --
-SELECT min(`Duration`) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE ?)
+SELECT min((`Duration` / ?)) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE ?)
 -- args --
-[0] bool = true
+[0] float64 = 1e+09
+[1] bool = true
 -- seed --
 CREATE TABLE otel_traces (
     Duration UInt64
@@ -14,9 +15,9 @@ INSERT INTO otel_traces VALUES
     (100000000);
 -- expected_rows --
 [
-  [50000000]
+  [0.05]
 ]
 -- chplan --
-MetricsAggregate op=min_over_time attr=Duration valueAlias=Value
+MetricsAggregate op=min_over_time attr=(Duration / 1e+09) valueAlias=Value
   Filter predicate=true
     Scan(otel_traces)

--- a/test/spec/traceql/metrics_multi_quantile.txtar
+++ b/test/spec/traceql/metrics_multi_quantile.txtar
@@ -1,12 +1,13 @@
 -- query.traceql --
 {} | quantile_over_time(duration, 0.5, 0.9, 0.99)
 -- sql --
-SELECT tupleElement(phi_val, 1) AS `__phi__`, tupleElement(phi_val, 2) AS `Value` FROM (SELECT arrayJoin(arrayMap((phi, q) -> (phi, toFloat64(q)), ['0.5', '0.9', '0.99'], qs_array)) AS phi_val FROM (SELECT quantiles(?, ?, ?)(`Duration`) AS qs_array FROM (SELECT * FROM `otel_traces` WHERE ?)))
+SELECT tupleElement(phi_val, 1) AS `__phi__`, tupleElement(phi_val, 2) AS `Value` FROM (SELECT arrayJoin(arrayMap((phi, q) -> (phi, toFloat64(q)), ['0.5', '0.9', '0.99'], qs_array)) AS phi_val FROM (SELECT quantiles(?, ?, ?)((`Duration` / ?)) AS qs_array FROM (SELECT * FROM `otel_traces` WHERE ?)))
 -- args --
 [0] float64 = 0.5
 [1] float64 = 0.9
 [2] float64 = 0.99
-[3] bool = true
+[3] float64 = 1e+09
+[4] bool = true
 -- seed --
 CREATE TABLE otel_traces (
     Duration UInt64
@@ -19,11 +20,11 @@ INSERT INTO otel_traces VALUES
     (100000000);
 -- expected_rows --
 [
-  ["0.5", 100000000.0],
-  ["0.9", 100000000.0],
-  ["0.99", 100000000.0]
+  ["0.5", 0.1],
+  ["0.9", 0.1],
+  ["0.99", 0.1]
 ]
 -- chplan --
-MetricsAggregate op=quantile_over_time attr=Duration quantiles=[0.5, 0.9, 0.99] valueAlias=Value
+MetricsAggregate op=quantile_over_time attr=(Duration / 1e+09) quantiles=[0.5, 0.9, 0.99] valueAlias=Value
   Filter predicate=true
     Scan(otel_traces)

--- a/test/spec/traceql/metrics_quantile_over_time.txtar
+++ b/test/spec/traceql/metrics_quantile_over_time.txtar
@@ -1,10 +1,11 @@
 -- query.traceql --
 {} | quantile_over_time(duration, 0.95)
 -- sql --
-SELECT quantile(?)(`Duration`) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE ?)
+SELECT quantile(?)((`Duration` / ?)) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE ?)
 -- args --
 [0] float64 = 0.95
-[1] bool = true
+[1] float64 = 1e+09
+[2] bool = true
 -- seed --
 CREATE TABLE otel_traces (
     Duration UInt64
@@ -17,9 +18,9 @@ INSERT INTO otel_traces VALUES
     (100000000);
 -- expected_rows --
 [
-  [100000000.0]
+  [0.1]
 ]
 -- chplan --
-MetricsAggregate op=quantile_over_time attr=Duration quantiles=[0.95] valueAlias=Value
+MetricsAggregate op=quantile_over_time attr=(Duration / 1e+09) quantiles=[0.95] valueAlias=Value
   Filter predicate=true
     Scan(otel_traces)

--- a/test/spec/traceql/metrics_sum_over_time.txtar
+++ b/test/spec/traceql/metrics_sum_over_time.txtar
@@ -1,9 +1,10 @@
 -- query.traceql --
 {} | sum_over_time(duration)
 -- sql --
-SELECT sum(`Duration`) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE ?)
+SELECT sum((`Duration` / ?)) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE ?)
 -- args --
-[0] bool = true
+[0] float64 = 1e+09
+[1] bool = true
 -- seed --
 CREATE TABLE otel_traces (
     Duration UInt64
@@ -14,9 +15,9 @@ INSERT INTO otel_traces VALUES
     (200000000);
 -- expected_rows --
 [
-  [350000000]
+  [0.35]
 ]
 -- chplan --
-MetricsAggregate op=sum_over_time attr=Duration valueAlias=Value
+MetricsAggregate op=sum_over_time attr=(Duration / 1e+09) valueAlias=Value
   Filter predicate=true
     Scan(otel_traces)


### PR DESCRIPTION
## Summary

The Tempo compat differ flagged `metrics_avg_over_time_instant` with a
~1e9 ratio (tempo=0.06917 vs cerberus=6.917e+07) — cerberus emitted
raw nanoseconds while Tempo emits fractional seconds.

The OTel-CH `Duration` column is stored as `Int64` nanoseconds. Tempo's
reference engine divides by `1e9` before producing
`MetricsSample.Value` (pkg/traceql/engine_metrics.go:
`sumOverTimeAggregator` / `averageOverTimeAggregator` /
`quantileOverTimeAggregator`). This PR matches that wire shape by
wrapping the lowered duration expression in `<expr> / 1e9` at lowering
time.

Applies to: `sum_over_time(duration)`, `avg_over_time(duration)`,
`min_over_time(duration)`, `max_over_time(duration)`,
`quantile_over_time(duration, ...)`. Not applied to `rate()` /
`count_over_time()` (which use `count(1)` and have no operand) or to
non-`duration` operands (e.g. `span.bytes` carries user-defined units).

## Implementation

- `internal/traceql/metrics_pipeline.go` — `metricsAggregateAttr` now
  wraps the lowered Duration expression in `chplan.Binary{OpDiv, ...,
  LitFloat{1e9}}` when the operand is the `duration` intrinsic. The
  fix lives in one place because both `lowerMetricsAggregate` (sum /
  min / max / quantile) and `lowerAverageOverTime` (Tempo's dedicated
  `avg_over_time` aggregator) route through it.

## Tests

- Unit test `TestLowerMetricsPipeline_DurationSeconds` pins the IR
  shape: every duration-aware *_over_time op produces a
  `Binary{OpDiv}` over `Duration / 1e9`.
- Negative test `TestLowerMetricsPipeline_NonDurationAttrUnwrapped`
  guards the boundary: non-duration operands (span attributes,
  resource attributes) must NOT be wrapped.
- Handler-level test `TestMetricsQueryRange_DurationAggInSeconds`
  exercises every affected op end-to-end and asserts the emitted SQL
  contains `` `Duration` / ? `` plus a `1e9` divisor in the args list.
- TXTAR fixtures `metrics_{sum,avg,min,max,quantile}_over_time.txtar`,
  `metrics_multi_quantile.txtar`, and `by_mixed_scopes.txtar` updated
  to reflect the new SQL shape; `expected_rows` rebased from ns to
  seconds. Round-trip exercised via the `chdb` build tag.

## Expected compat delta

`metrics_avg_over_time_instant` should now pass against Tempo. The
same fix unblocks the rest of the duration-based aggregation cases in
the corpus (`metrics_quantile_over_time_p95`,
`metrics_count_over_time_groupby_service` once their other blockers
clear) — every place the differ compares cerberus's `Value` against
Tempo's in-seconds wire value.

## Test plan

- [x] `go test ./internal/traceql/`
- [x] `go test ./internal/api/tempo/`
- [x] `go test ./internal/chsql/`
- [x] `go test -tags chdb ./test/spec/traceql/`
- [x] `go test ./internal/...` (3194 tests pass)
- [ ] CI `check` + `lint`
- [ ] Tempo compat suite (nightly / manual dispatch)