### PR TITLE
fix(api/tempo): include trace duration in #555's root-lookup follow-up query

### DIFF
--- a/internal/api/tempo/handler_test.go
+++ b/internal/api/tempo/handler_test.go
@@ -713,6 +713,101 @@ func TestSearch_StructuralJoin_RootSurfaced(t *testing.T) {
 	}
 }
 
+// TestSearch_StructuralJoin_DurationMsRecovered pins the duration
+// arm of the root-lookup follow-up: the initial /api/search result
+// set carries only matched child spans whose per-row Sample.Value
+// captures the *child's* duration (here 20-60ms), but Tempo's wire
+// spec reports `durationMs` as the **trace-wide** wall-clock span
+// (here 150ms). The follow-up CH query's Aggregate computes
+// (max(Timestamp + Duration) - min(Timestamp)) across every span of
+// each affected trace and surfaces the result via the canonical
+// Sample.Value slot; applyRootMetadata reads it back as
+// rootMetadata.TraceDurationNs and rewrites summary.DurationMs.
+//
+// Mirrors the 4 Tempo-compat cases pre-fix reported durationMs=20
+// (per-child) instead of 150 (trace-wide):
+// descendant_op_payments_to_consumer, direct_parent_op_checkout_to_child,
+// set_and_checkout_and_status_error, status_eq_error.
+func TestSearch_StructuralJoin_DurationMsRecovered(t *testing.T) {
+	t.Parallel()
+	const (
+		traceID    = "17"
+		rootSpanID = "1"
+	)
+	q := &stubQuerier{
+		// First (search) query returns two child rows for traceID —
+		// neither is a root span, and each per-row Sample.Value
+		// reports the child's own Duration (20ms / 40ms). Without
+		// the follow-up duration patch, toTraceSummaries reports
+		// DurationMs = max(40ms, 20ms) = 40ms — but Tempo says 150ms.
+		samples: []chclient.Sample{
+			{
+				MetricName: "checkout.child.2",
+				Labels: map[string]string{
+					"service.name":            "checkout",
+					"__cerberus_traceID":      traceID,
+					"__cerberus_parentSpanID": rootSpanID,
+				},
+				Timestamp: time.Date(2026, 5, 12, 10, 0, 0, 30_000_000, time.UTC),
+				Value:     40_000_000,
+			},
+			{
+				MetricName: "checkout.child.0",
+				Labels: map[string]string{
+					"service.name":            "checkout",
+					"__cerberus_traceID":      traceID,
+					"__cerberus_parentSpanID": rootSpanID,
+				},
+				Timestamp: time.Date(2026, 5, 12, 10, 0, 0, 10_000_000, time.UTC),
+				Value:     20_000_000,
+			},
+		},
+		// Second (root-lookup) query returns the trace-wide
+		// envelope: Value carries 150_000_000 ns (= 150 ms), the
+		// derived (TraceEndNs - TraceStartNs).
+		samplesBySQL: map[string][]chclient.Sample{
+			"RootSpanName": {
+				{
+					MetricName: "POST /api/checkout/17",
+					Labels: map[string]string{
+						"service.name":       "checkout",
+						"__cerberus_traceID": traceID,
+					},
+					Timestamp: time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC),
+					Value:     150_000_000,
+				},
+			},
+		},
+	}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/search?q=%7B%20status%20%3D%20error%20%7D")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	var sr tempo.SearchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&sr); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(sr.Traces) != 1 {
+		t.Fatalf("expected 1 trace, got %d (%+v)", len(sr.Traces), sr.Traces)
+	}
+	if got := sr.Traces[0].DurationMs; got != 150 {
+		t.Errorf("DurationMs: got %d, want 150 (trace-wide ns / 1e6, recovered via root-lookup follow-up; child-only result set under-reported pre-fix)", got)
+	}
+	// Confirm the root metadata also flowed through, so we know the
+	// duration patch shares the same lookup row.
+	if sr.Traces[0].RootTraceName != "POST /api/checkout/17" {
+		t.Errorf("RootTraceName: got %q, want %q",
+			sr.Traces[0].RootTraceName, "POST /api/checkout/17")
+	}
+}
+
 // TestSearch_SQLProjectsParentSpanId pins the SQL emitted by the search
 // path against an OTel-CH default schema. The ParentSpanId column must
 // appear in the projection so toTraceSummaries can resolve the root

--- a/internal/api/tempo/root_lookup.go
+++ b/internal/api/tempo/root_lookup.go
@@ -16,37 +16,59 @@ import (
 // that TraceId — a true truncation where the trace's root is not in
 // otel_traces, vs. a structural-join / status-filter where the root
 // is present but absent from the original result set.
+//
+// TraceDurationNs carries the whole-trace wall-clock span
+// (`max(span.end) - min(span.start)` across every span of the trace,
+// in nanoseconds). Tempo's /api/search reports `durationMs` as the
+// trace-wide wall-clock span, not the matched row's per-span
+// Duration; the search result set typically contains only matched
+// child spans (structural-join queries, `{ status = error }` against
+// child-only fixtures), so the per-row Sample.Value fallback in
+// toTraceSummaries under-reports vs. Tempo. The same follow-up CH
+// query that recovers RootSpanName + RootServiceName also computes
+// the trace-wide duration so applyRootMetadata can patch DurationMs
+// alongside the root identity.
 type rootMetadata struct {
-	ServiceName string
-	SpanName    string
+	ServiceName     string
+	SpanName        string
+	TraceDurationNs int64
 }
 
 // resolveTraceRoots issues a follow-up CH query that fetches each
-// missing trace's root-span identity (SpanName + service.name). The
-// /api/search wrap projection projects only the spans matched by the
-// user's TraceQL predicate, so structural-join queries (`>`, `<`,
-// `>>`, `<<`, set ops) and filter queries that exclude the root span
-// (`{ status = error }` on a fixture where only children carry that
-// status) deliver result sets without a root row. The shaper anchors
-// on the earliest matched span as a fallback, but Tempo's wire spec
-// pins rootTraceName / rootServiceName to the **actual** root span at
-// the top of the trace tree. This helper recovers that.
+// missing trace's root-span identity (SpanName + service.name) and the
+// whole-trace duration. The /api/search wrap projection projects only
+// the spans matched by the user's TraceQL predicate, so structural-
+// join queries (`>`, `<`, `>>`, `<<`, set ops) and filter queries that
+// exclude the root span (`{ status = error }` on a fixture where only
+// children carry that status) deliver result sets without a root row
+// and with per-span (not trace-wide) durations. The shaper anchors on
+// the earliest matched span as a fallback, but Tempo's wire spec pins
+// rootTraceName / rootServiceName to the **actual** root span at the
+// top of the trace tree and `durationMs` to the trace-wide wall-clock
+// span. This helper recovers both.
 //
 // Implementation: a chplan tree built by hand (no parser, no
 // optimizer pass needed) lowering to:
 //
 //	SELECT
-//	  argMin(SpanName, Timestamp) AS RootSpanName,
-//	  map(
-//	    '__cerberus_traceID', stripLeadingHexZeros(TraceId),
-//	    'service.name',       argMin(ResourceAttributes['service.name'], Timestamp),
-//	  ) AS Attributes,
-//	  now64(9) AS TimeUnix,
-//	  0 AS Value
+//	  argMinIf(SpanName, Timestamp, ParentSpanId = '' OR ParentSpanId = '0000000000000000') AS RootSpanName,
+//	  argMinIf(ResourceAttributes['service.name'], Timestamp, ParentSpanId = '' OR ParentSpanId = '0000000000000000') AS RootSvc,
+//	  min(toUnixTimestamp64Nano(Timestamp)) AS TraceStartNs,
+//	  max(toUnixTimestamp64Nano(Timestamp) + toInt64(Duration)) AS TraceEndNs
 //	FROM otel_traces
-//	WHERE (ParentSpanId = '' OR ParentSpanId = '0000000000000000')
-//	  AND TraceId IN ('<padded-id-1>', '<padded-id-2>', ...)
+//	WHERE TraceId IN ('<padded-id-1>', '<padded-id-2>', ...)
 //	GROUP BY TraceId
+//
+// then an outer Project rewrites the Aggregate's columns into the
+// canonical chclient.Sample envelope (MetricName / Attributes /
+// TimeUnix / Value). Value carries `TraceEndNs - TraceStartNs` as
+// float64 so applyRootMetadata can patch summary.DurationMs alongside
+// the root identity.
+//
+// The WHERE clause is intentionally TraceId-only (no ParentSpanId
+// restriction) so the trace start/end aggregates see every span,
+// not just the root row. argMinIf isolates the root-span identity
+// inside the same group so the query stays a single round trip.
 //
 // Result is keyed by the stripped-zero TraceID (the form the original
 // /api/search shaper used). Returns an empty map when traceIDs is
@@ -76,9 +98,21 @@ func (h *Handler) resolveTraceRoots(ctx context.Context, traceIDs []string) (map
 		if tid == "" {
 			continue
 		}
+		// Sample.Value carries the trace-wide duration in nanoseconds
+		// (TraceEndNs - TraceStartNs), cast to float64 by the outer
+		// Project so the chclient cursor decodes positionally. The
+		// difference is non-negative by construction (max ≥ min); a
+		// negative read indicates a corrupt fixture and is treated as
+		// "no duration recovered" so the shaper's per-row fallback
+		// stays in place.
+		var durationNs int64
+		if s.Value > 0 {
+			durationNs = int64(s.Value)
+		}
 		out[tid] = rootMetadata{
-			ServiceName: s.Labels["service.name"],
-			SpanName:    s.MetricName,
+			ServiceName:     s.Labels["service.name"],
+			SpanName:        s.MetricName,
+			TraceDurationNs: durationNs,
 		}
 	}
 	return out, nil
@@ -93,67 +127,129 @@ func (h *Handler) resolveTraceRoots(ctx context.Context, traceIDs []string) (map
 // existing chclient.Sample decoding picks it up without a new path.
 // The Attributes map carries the stripped-zero TraceID (the search-
 // path identity key) plus the root span's service.name; MetricName
-// carries the root SpanName. The `TimeUnix` and `Value` columns are
-// constant placeholders — the follow-up lookup contributes metadata,
-// not per-trace timing, which the original shaper already has.
+// carries the root SpanName. The `TimeUnix` column is a constant
+// placeholder (`now64(9)`) — the follow-up lookup contributes per-
+// trace metadata, not per-row timing. The `Value` column carries the
+// trace-wide wall-clock duration in nanoseconds (max-end minus min-
+// start across every span of the trace) cast to float64 so the
+// chclient cursor decodes positionally; the shaper's
+// applyRootMetadata reads it back and surfaces durationMs =
+// TraceDurationNs / 1e6 alongside the recovered root identity.
+//
+// The filter is TraceId-only (no ParentSpanId restriction) so the
+// trace start / end aggregates see every span of each affected
+// trace, not just the root row. The root-span identifying
+// aggregates use argMinIf with the (ParentSpanId IN (”,
+// '0000000000000000')) condition so they pick the earliest root
+// span within the same GROUP BY group — keeping the lookup a single
+// round trip while distinguishing root vs. non-root rows.
 func buildRootLookupPlan(s schema.Traces, traceIDs []string) chplan.Node {
-	// Filter predicate: ParentSpanId IN ('', '0000000000000000') AND
-	// TraceId IN (<padded-id-1>, <padded-id-2>, ...). Without an `IN`
-	// chplan expression, both arms render as flat OR-chains of Eq
-	// predicates — CH planner collapses these to constant-set lookups
-	// at execute time.
-	parentIsRoot := orEqLiterals(s.ParentSpanIDColumn, []string{"", "0000000000000000"})
+	// Filter predicate: TraceId IN (<padded-id-1>, <padded-id-2>, ...).
+	// Without an `IN` chplan expression this renders as a flat OR-chain
+	// of Eq predicates — CH planner collapses to a constant-set lookup
+	// at execute time. Restricting to TraceId only lets the trace
+	// start / end aggregates see every span of the trace; argMinIf
+	// (below) carries the ParentSpanId restriction on the root-span
+	// identifying aggregates so the same group computes both.
 	traceMatch := orEqLiterals(s.TraceIDColumn, padTraceIDs(traceIDs))
-	pred := &chplan.Binary{
-		Op:    chplan.OpAnd,
-		Left:  parentIsRoot,
-		Right: traceMatch,
-	}
 
-	// argMin(SpanName, Timestamp) AS RootSpanName.
+	// rootCond expresses ParentSpanId IN ('', '0000000000000000') — the
+	// on-disk root marker (pre-strip empty form + canonical 16-char
+	// zero form). Reused inside both argMinIf aggregates so they pick
+	// the root span among each TraceId group.
+	rootCond := orEqLiterals(s.ParentSpanIDColumn, []string{"", "0000000000000000"})
+
+	// argMinIf(SpanName, Timestamp, rootCond) AS RootSpanName.
 	aggSpanName := chplan.AggFunc{
-		Name:  "argMin",
-		Args:  []chplan.Expr{&chplan.ColumnRef{Name: s.SpanNameColumn}, &chplan.ColumnRef{Name: s.TimestampColumn}},
+		Name: "argMinIf",
+		Args: []chplan.Expr{
+			&chplan.ColumnRef{Name: s.SpanNameColumn},
+			&chplan.ColumnRef{Name: s.TimestampColumn},
+			rootCond,
+		},
 		Alias: "RootSpanName",
 	}
-	// argMin(ResourceAttributes['service.name'], Timestamp) AS RootSvc.
+	// argMinIf(ResourceAttributes['service.name'], Timestamp, rootCond) AS RootSvc.
 	aggSvc := chplan.AggFunc{
-		Name: "argMin",
+		Name: "argMinIf",
 		Args: []chplan.Expr{
 			&chplan.MapAccess{
 				Map: &chplan.ColumnRef{Name: s.ResourceAttributesColumn},
 				Key: &chplan.LitString{V: "service.name"},
 			},
 			&chplan.ColumnRef{Name: s.TimestampColumn},
+			rootCond,
 		},
 		Alias: "RootSvc",
 	}
+	// min(toUnixTimestamp64Nano(Timestamp)) AS TraceStartNs — the
+	// earliest span-start across the trace, in nanoseconds since the
+	// Unix epoch. Casting up-front lets the difference fall out as a
+	// plain integer (DateTime64 lacks a typed interval subtraction
+	// in the chplan IR).
+	aggTraceStart := chplan.AggFunc{
+		Name: "min",
+		Args: []chplan.Expr{
+			&chplan.FuncCall{
+				Name: "toUnixTimestamp64Nano",
+				Args: []chplan.Expr{&chplan.ColumnRef{Name: s.TimestampColumn}},
+			},
+		},
+		Alias: "TraceStartNs",
+	}
+	// max(toUnixTimestamp64Nano(Timestamp) + toInt64(Duration)) AS TraceEndNs —
+	// the latest span-end across the trace. Coercing Duration to Int64
+	// keeps the sum Int64 so subtracting TraceStartNs (Int64) yields
+	// a signed integer CH doesn't refuse to subtract.
+	aggTraceEnd := chplan.AggFunc{
+		Name: "max",
+		Args: []chplan.Expr{
+			&chplan.Binary{
+				Op: chplan.OpAdd,
+				Left: &chplan.FuncCall{
+					Name: "toUnixTimestamp64Nano",
+					Args: []chplan.Expr{&chplan.ColumnRef{Name: s.TimestampColumn}},
+				},
+				Right: &chplan.FuncCall{
+					Name: "toInt64",
+					Args: []chplan.Expr{&chplan.ColumnRef{Name: s.DurationColumn}},
+				},
+			},
+		},
+		Alias: "TraceEndNs",
+	}
 	agg := &chplan.Aggregate{
-		Input:          &chplan.Filter{Input: &chplan.Scan{Table: s.SpansTable}, Predicate: pred},
+		Input:          &chplan.Filter{Input: &chplan.Scan{Table: s.SpansTable}, Predicate: traceMatch},
 		GroupBy:        []chplan.Expr{&chplan.ColumnRef{Name: s.TraceIDColumn}},
 		GroupByAliases: []string{"TraceId"},
-		AggFuncs:       []chplan.AggFunc{aggSpanName, aggSvc},
+		AggFuncs:       []chplan.AggFunc{aggSpanName, aggSvc, aggTraceStart, aggTraceEnd},
 	}
 
 	// Outer Project rewrites to canonical Sample shape so chclient
 	// decodes positionally: MetricName (RootSpanName), Attributes
 	// (map carrying TraceID + service.name), TimeUnix (now64), Value
-	// (0). Reading the columns produced by the Aggregate by bare name
-	// works because Aggregate emits `<expr> AS <alias>` + `<func> AS
-	// <alias>` in the SELECT list.
+	// (TraceEndNs - TraceStartNs as float64). Reading the columns
+	// produced by the Aggregate by bare name works because Aggregate
+	// emits `<expr> AS <alias>` + `<func> AS <alias>` in the SELECT
+	// list.
 	attrsMap := &chplan.FuncCall{Name: "map", Args: []chplan.Expr{
 		&chplan.LitString{V: searchKeyTraceID},
 		stripLeadingHexZeros("TraceId"),
 		&chplan.LitString{V: "service.name"},
 		&chplan.ColumnRef{Name: "RootSvc"},
 	}}
+	traceDurationNs := &chplan.Binary{
+		Op:    chplan.OpSub,
+		Left:  &chplan.ColumnRef{Name: "TraceEndNs"},
+		Right: &chplan.ColumnRef{Name: "TraceStartNs"},
+	}
 	return &chplan.Project{
 		Input: agg,
 		Projections: []chplan.Projection{
 			{Expr: &chplan.ColumnRef{Name: "RootSpanName"}, Alias: "MetricName"},
 			{Expr: attrsMap, Alias: "Attributes"},
 			{Expr: &chplan.FuncCall{Name: "now64", Args: []chplan.Expr{&chplan.LitInt{V: 9}}}, Alias: "TimeUnix"},
-			{Expr: &chplan.FuncCall{Name: "toFloat64", Args: []chplan.Expr{&chplan.LitInt{V: 0}}}, Alias: "Value"},
+			{Expr: &chplan.FuncCall{Name: "toFloat64", Args: []chplan.Expr{traceDurationNs}}, Alias: "Value"},
 		},
 	}
 }
@@ -202,10 +298,21 @@ func padTraceIDs(ids []string) []string {
 }
 
 // applyRootMetadata patches each summary whose TraceID appears in
-// roots with the looked-up RootServiceName / RootTraceName. Skips
-// summaries with no matching root entry (the trace's root is not in
-// otel_traces — true truncation; the earliest-span fallback that
-// toTraceSummaries already populated stays in place).
+// roots with the looked-up RootServiceName / RootTraceName /
+// DurationMs. Skips summaries with no matching root entry (the
+// trace's root is not in otel_traces — true truncation; the
+// earliest-span fallback that toTraceSummaries already populated
+// stays in place).
+//
+// The duration patch is the source of truth for traces whose result
+// set lacked a root row: toTraceSummaries' fallback path picks the
+// max per-row Sample.Value, which for structural-join / status-
+// filter queries (where the result set only carries matched child
+// spans) under-reports vs. Tempo's trace-wide wall-clock span. The
+// follow-up CH query computes (max(Timestamp + Duration) -
+// min(Timestamp)) across every span of each affected trace and
+// surfaces the result via rootMetadata.TraceDurationNs; we patch it
+// in here when positive so summary.DurationMs matches Tempo.
 //
 // Modifies the summaries slice in place; the slice header itself
 // (length, capacity, ordering) is unchanged.
@@ -228,6 +335,13 @@ func applyRootMetadata(summaries []TraceSummary, roots map[string]rootMetadata) 
 		}
 		if root.ServiceName != "" {
 			summaries[i].RootServiceName = root.ServiceName
+		}
+		// Patch DurationMs only when the lookup recovered a positive
+		// trace-wide span (negative would indicate a corrupt fixture;
+		// zero means a single-instant trace and is indistinguishable
+		// from "no duration computed" so the per-row fallback stays).
+		if root.TraceDurationNs > 0 {
+			summaries[i].DurationMs = int(root.TraceDurationNs / 1_000_000)
 		}
 	}
 }

--- a/internal/api/tempo/root_lookup_test.go
+++ b/internal/api/tempo/root_lookup_test.go
@@ -69,6 +69,35 @@ func TestBuildRootLookupPlan_SQLShape(t *testing.T) {
 		}
 	}
 
+	// Trace-duration aggregates: the inner Aggregate must surface
+	// TraceStartNs (min of toUnixTimestamp64Nano(Timestamp)) and
+	// TraceEndNs (max of toUnixTimestamp64Nano(Timestamp) +
+	// toInt64(Duration)) so the outer Project can derive
+	// `TraceEndNs - TraceStartNs` as the trace-wide wall-clock span
+	// in nanoseconds, threaded through the canonical Value slot for
+	// the shaper's applyRootMetadata to pick up.
+	for _, alias := range []string{"TraceStartNs", "TraceEndNs"} {
+		if !strings.Contains(sql, alias) {
+			t.Errorf("SQL must project trace-duration aggregate %q; got %s", alias, sql)
+		}
+	}
+	if !strings.Contains(sql, "toUnixTimestamp64Nano") {
+		t.Errorf("SQL must cast Timestamp to nanoseconds via toUnixTimestamp64Nano; got %s", sql)
+	}
+	if !strings.Contains(sql, "toInt64") {
+		t.Errorf("SQL must cast Duration to Int64 so the sum stays signed; got %s", sql)
+	}
+	// The root-span identifying aggregates must use argMinIf so the
+	// (ParentSpanId IN ('', '0000000000000000')) condition carries
+	// inside the same GROUP BY group as the unconditional trace
+	// start / end aggregates. The previous shape filtered with WHERE
+	// ParentSpanId IN (...) AND ..., which would have scoped the
+	// trace-duration aggregates to root spans only and under-
+	// reported by definition.
+	if !strings.Contains(sql, "argMinIf") {
+		t.Errorf("SQL must use argMinIf so root-span identity scopes ParentSpanId without restricting the trace-duration aggregates; got %s", sql)
+	}
+
 	// Args must include each TraceID padded to 32-char lowercase hex
 	// so the equality match hits the otel_traces.TraceId column.
 	// padTraceIDs pads to 32 chars: "17" → 30 zeros + "17", "abc" → 29
@@ -190,5 +219,62 @@ func TestApplyRootMetadata_EmptyRootsNoop(t *testing.T) {
 	applyRootMetadata(summaries, nil)
 	if summaries[0].RootServiceName != "fallback" || summaries[0].RootTraceName != "fallback" {
 		t.Errorf("empty roots must leave summaries untouched; got %+v", summaries[0])
+	}
+}
+
+// TestApplyRootMetadata_PatchesDurationMs covers the duration-patch
+// arm: the follow-up lookup query surfaces the whole-trace wall-
+// clock span via rootMetadata.TraceDurationNs, and the merge step
+// must convert it to milliseconds and overwrite the per-row
+// Sample.Value fallback toTraceSummaries computed from matched
+// child spans. Mirrors the structural-join / status-filter compat
+// cases that pre-fix reported durationMs from a single child span
+// instead of the trace-wide span Tempo emits.
+func TestApplyRootMetadata_PatchesDurationMs(t *testing.T) {
+	t.Parallel()
+	summaries := []TraceSummary{
+		// trace a: per-row fallback computed 20ms; the follow-up
+		// lookup recovers the trace-wide 150ms span.
+		{TraceID: "a", DurationMs: 20},
+		// trace b: lookup recovered no positive duration (e.g. a
+		// single-instant trace, or a fixture with no spans seeded
+		// post-search-window) — the per-row fallback (80ms) stays.
+		{TraceID: "b", DurationMs: 80},
+		// trace c: lookup absent (true truncation) — DurationMs
+		// untouched.
+		{TraceID: "c", DurationMs: 60},
+	}
+	roots := map[string]rootMetadata{
+		"a": {ServiceName: "checkout", SpanName: "POST /api/checkout", TraceDurationNs: 150_000_000},
+		"b": {ServiceName: "frontend", SpanName: "GET /healthz"},
+	}
+	applyRootMetadata(summaries, roots)
+
+	if got := summaries[0].DurationMs; got != 150 {
+		t.Errorf("trace a DurationMs: got %d, want 150 (lookup-recovered trace-wide span)", got)
+	}
+	if got := summaries[1].DurationMs; got != 80 {
+		t.Errorf("trace b DurationMs: got %d, want 80 (lookup carried no duration; per-row fallback preserved)", got)
+	}
+	if got := summaries[2].DurationMs; got != 60 {
+		t.Errorf("trace c DurationMs: got %d, want 60 (lookup absent; per-row fallback preserved)", got)
+	}
+}
+
+// TestApplyRootMetadata_NegativeDurationIgnored guards against the
+// (defensively-handled) corrupt-fixture path where TraceEndNs <
+// TraceStartNs leaks through resolveTraceRoots. The patch must not
+// rewrite DurationMs to a negative integer.
+func TestApplyRootMetadata_NegativeDurationIgnored(t *testing.T) {
+	t.Parallel()
+	summaries := []TraceSummary{
+		{TraceID: "a", DurationMs: 42},
+	}
+	roots := map[string]rootMetadata{
+		"a": {ServiceName: "svc", SpanName: "name", TraceDurationNs: -1},
+	}
+	applyRootMetadata(summaries, roots)
+	if summaries[0].DurationMs != 42 {
+		t.Errorf("negative TraceDurationNs must be ignored; got DurationMs=%d", summaries[0].DurationMs)
 	}
 }


### PR DESCRIPTION
## Summary

Extends PR #555's follow-up CH query so the same single round trip
that recovers `rootServiceName` + `rootTraceName` for missing-root
result sets also recovers the whole-trace wall-clock duration. The
shaper's existing per-row Sample.Value fallback under-reports
`durationMs` on structural-join / `{ status = error }` queries
(child-only result sets) — Tempo's wire spec reports the trace-wide
span (`max(span.end) - min(span.start)`), not the matched span's
own Duration.

## Root cause

PR #555 detected the "no root in result set" case and recovered
root identity via a follow-up CH lookup, but `toTraceSummaries`'s
`DurationMs = max(Sample.Value)` fallback still ran on the child-
only first-query rows. For the 4 affected Tempo compat cases
(`descendant_op_payments_to_consumer`,
`direct_parent_op_checkout_to_child`,
`set_and_checkout_and_status_error`,
`status_eq_error`) the child spans clock at 20/60/80 ms while the
trace-wide span is 150 ms.

## What changed

`internal/api/tempo/root_lookup.go`:

- `buildRootLookupPlan` now emits two extra aggregates (`TraceStartNs` =
  `min(toUnixTimestamp64Nano(Timestamp))`, `TraceEndNs` = `max(toUnixTimestamp64Nano(Timestamp) + toInt64(Duration))`)
  alongside the root-identity ones.
- Root-identity aggregates switch from `argMin(...)` over a WHERE-
  filtered scan to `argMinIf(..., ParentSpanId IN ('', '0000000000000000'))`
  over a TraceId-only WHERE — the new shape lets the trace-duration
  aggregates see every span of the affected traces while keeping the
  root-span identification scoped to the on-disk root marker, all in
  the same single round trip.
- Outer Project's `Value` slot now carries `toFloat64(TraceEndNs - TraceStartNs)`
  so chclient decodes the duration positionally.
- `rootMetadata` gains a `TraceDurationNs int64` field; `resolveTraceRoots`
  populates it from `Sample.Value` (positive only — negative reads
  fall through to the per-row fallback as a corrupt-fixture safety belt).
- `applyRootMetadata` patches `summary.DurationMs = int(TraceDurationNs / 1e6)`
  when the lookup recovered a positive trace-wide span.

All chplan composition uses typed `chplan.FuncCall` / `chplan.Binary` /
`chplan.AggFunc` constructors — no raw SQL strings.

## Tests added

- `TestBuildRootLookupPlan_SQLShape` (extended): pins the new
  `TraceStartNs` / `TraceEndNs` aggregates, the `toUnixTimestamp64Nano` +
  `toInt64` casts, and the `argMinIf` swap in the emitted SQL.
- `TestApplyRootMetadata_PatchesDurationMs`: covers the merge step
  for positive vs. absent vs. zero `TraceDurationNs`.
- `TestApplyRootMetadata_NegativeDurationIgnored`: pins the corrupt-
  fixture safety belt.
- `TestSearch_StructuralJoin_DurationMsRecovered` (in
  `handler_test.go`): end-to-end shape — child-only first query
  reports `Sample.Value=40_000_000` per row; the follow-up's
  `Sample.Value=150_000_000` ns flows through `applyRootMetadata`;
  the response surfaces `durationMs=150`.

## Expected compat delta

Tempo compat 66.67% → ~78%+ (4 cases × ~14-60 reasons → all clear).

## Test plan

- [x] `internal/api/tempo` unit tests cover the new SQL shape
- [x] `internal/api/tempo` unit tests cover the merge-path duration patch
- [x] `internal/api/tempo` end-to-end test verifies child-only result set + follow-up lookup yields `durationMs=150`
- [ ] CI `check` + `lint` green
- [ ] Tempo compat (informational) goes 66.67% → ~78%

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>