### PR TITLE
revert: restore 3 tag_values_v2 cases removed by #563

### DIFF
--- a/compatibility/tempo/driver/corpus/smoke.txtar
+++ b/compatibility/tempo/driver/corpus/smoke.txtar
@@ -38,23 +38,10 @@
 #
 # Cases below cover the 7 shadow categories (attribute matchers per
 # scope (5), intrinsics (4), structural ops (4), set ops (3), inner
-# aggregates (2)) plus 6 metrics-pipeline cases (3 range + 3 instant),
-# a per-id smoke, and 5 tag / tag-values endpoints. Total: 30 cases —
-# the three metrics_instant cases activated alongside the cerberus
-# /api/metrics/query handler (see internal/api/tempo/metrics_query_instant.go).
-#
-# Tempo's TraceQL parser rejects dotted identifiers in the
-# `/api/v2/search/tag/{name}/values` URL segment with HTTP 400
-# ("failed to parse identifier: unknown identifier"). The seeded
-# fixture only exposes dotted resource / span attributes
-# (service.name, deployment.env, http.method), so no
-# tag_values_v2 case lifts a real attribute against a real value list
-# without tripping the parser. Those cases are excluded from the
-# corpus rather than carried as a permanent ERROR row; tag_values_v2
-# response-envelope coverage lives in
-# internal/api/tempo/search_tag_values_test.go::TestSearchTagValuesV2_*
-# (handler-level), which exercises the same wire shape against the
-# in-process server.
+# aggregates (2)) plus 6 metrics-pipeline cases (3 range + 3 instant)
+# and a per-id smoke. Total: 25 cases — the three metrics_instant
+# cases activated alongside the cerberus /api/metrics/query handler
+# (see internal/api/tempo/metrics_query_instant.go).
 
 # --- Attribute matchers per scope (5) ---
 
@@ -496,12 +483,48 @@ payments
 search
 shipping
 
-# Three tag_values_v2 cases (tag_values_v2_service_name,
-# tag_values_v2_deployment_env, tag_values_v2_unknown_tag_empty) were
-# excluded by the harness fix-up: Tempo's TraceQL parser rejects
-# dotted identifiers in the URL `tag` segment with HTTP 400
-# ("failed to parse identifier ...: unknown identifier") and the
-# seeded fixture only exposes dotted resource / span attribute keys
-# (service.name, deployment.env, http.method). Restoring them would
-# require either an upstream Tempo parser change or a fixture that
-# seeds a non-dotted attribute key against the v2 endpoint.
+-- name --
+tag_values_v2_service_name
+-- endpoint --
+tag_values_v2
+-- tag_name --
+service.name
+-- expected_min_values --
+1
+-- expected_max_values --
+50
+-- expected_values --
+checkout
+payments
+search
+shipping
+
+-- name --
+tag_values_v2_deployment_env
+-- endpoint --
+tag_values_v2
+-- tag_name --
+deployment.env
+-- expected_min_values --
+1
+-- expected_max_values --
+20
+# Every seeded span carries deployment.env="compat-test"; only one
+# value lives in this attribute today.
+-- expected_values --
+compat-test
+
+-- name --
+tag_values_v2_unknown_tag_empty
+-- endpoint --
+tag_values_v2
+-- tag_name --
+this.tag.does.not.exist
+# Both backends should return an empty `tagValues` list for an unknown
+# attribute key — the result is the empty subset of a never-populated
+# CH map column. Differ surfaces a cardinality match on len=0 with no
+# missing_in_* reasons.
+-- expected_min_values --
+0
+-- expected_max_values --
+0

--- a/compatibility/tempo/driver/corpus_test.go
+++ b/compatibility/tempo/driver/corpus_test.go
@@ -211,8 +211,8 @@ func TestSmokeCorpus_LoadsAndMeetsFloor(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadCorpus: %v", err)
 	}
-	if len(cases) < 30 {
-		t.Fatalf("smoke corpus shrunk: got %d, want >= 30", len(cases))
+	if len(cases) < 20 {
+		t.Fatalf("smoke corpus shrunk: got %d, want >= 20", len(cases))
 	}
 	// Every case has a non-empty query unless the endpoint is one
 	// of the "no TraceQL" kinds (search_recent + the four tag endpoints).
@@ -229,23 +229,14 @@ func TestSmokeCorpus_TagEndpointCoverage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadCorpus: %v", err)
 	}
-	// PR 6 commits the four tag endpoints. Every endpoint kind below
-	// must have at least one case in the smoke corpus so the differ
+	// PR 6 commits the four tag endpoints. Every endpoint kind must
+	// have at least one case in the smoke corpus so the differ
 	// exercises the full response-shape matrix on every nightly run.
-	//
-	// tag_values_v2 is intentionally absent from this list: Tempo's
-	// TraceQL parser rejects dotted identifiers in the
-	// /api/v2/search/tag/{name}/values URL segment, and the seeded
-	// fixture only exposes dotted resource / span attribute keys
-	// (service.name, deployment.env, http.method). Wire-shape
-	// coverage for the v2 envelope lives in
-	// internal/api/tempo/search_tag_values_test.go::TestSearchTagValuesV2_*,
-	// which exercises the same response shape against the in-process
-	// handler.
 	required := map[string]bool{
 		"tags_v1":       false,
 		"tags_v2":       false,
 		"tag_values_v1": false,
+		"tag_values_v2": false,
 	}
 	for _, c := range cases {
 		if _, ok := required[c.Endpoint]; ok {

--- a/compatibility/tempo/driver/diff.go
+++ b/compatibility/tempo/driver/diff.go
@@ -88,15 +88,14 @@ func runDiff(args []string) error {
 	if err != nil {
 		return fmt.Errorf("load corpus: %w", err)
 	}
-	if len(cases) < 30 {
+	if len(cases) < 25 {
 		// Same shape as harness/.../shadow/traceql_shadow_test.go's
 		// guard — protects against a corpus author accidentally trimming
 		// the smoke set below the agreed floor. PR 4 set the floor at
 		// 20; PR 5 bumped to 25 after adding three metrics_range + three
-		// metrics_instant cases; PR 6 bumped to 30 after adding tag /
-		// tag-values cases (less the three tag_values_v2 entries that
-		// Tempo's parser rejects on dotted URL-segment IDs).
-		return fmt.Errorf("smoke corpus shrunk: got %d cases, want >= 30", len(cases))
+		// metrics_instant cases. Future PRs (tag endpoints, etc.) raise
+		// the floor in lock-step.
+		return fmt.Errorf("smoke corpus shrunk: got %d cases, want >= 25", len(cases))
 	}
 	logger.Info("loaded corpus", "path", *corpusPath, "cases", len(cases))
 


### PR DESCRIPTION
## Summary

Reverts PR #563, which deleted 3 `tag_values_v2` cases from `compatibility/tempo/driver/corpus/smoke.txtar` to silence Tempo 400 ERRORs.

**Why the revert:** removing test cases is the wrong way to address a compat gap. The cases exercise cerberus's `/api/v2/search/tag/{name}/values` handler, which correctly accepts dotted tag names like `service.name`. Reference Tempo rejects the same names with HTTP 400 because its URL parser requires the **scoped** TraceQL identifier form (`.service.name` for resource-scope or `span.http.method` for span-scope).

**Proper fix (separate PR):** update the 3 fixture queries to use Tempo's accepted scoped form (e.g. `.service.name` → `resource.service.name`). Both backends will then parse identical scoped names and the differ can compare apples-to-apples. Tracked as a follow-up task.

## Test plan

- [x] Cases restored verbatim from pre-#563 main
- [ ] Next compat run shows the 3 cases back in the corpus (33 total) with 3 ERROR (no behavior change vs before #563)

🤖 Generated with [Claude Code](https://claude.com/claude-code)