### PR TITLE
fix(traceql): use left-open per-anchor window for metrics matrix path to match Tempo

### DIFF
--- a/internal/chsql/histogram_over_time.go
+++ b/internal/chsql/histogram_over_time.go
@@ -141,13 +141,18 @@ func histogramBucketFrag(attr chplan.Expr, isDuration bool) Frag {
 //	  FROM (<Inner>)
 //	  WHERE <Attr> >= 2
 //	)
-//	WHERE ts >= anchor_ts - toIntervalNanosecond(<range_ns>)
+//	WHERE ts >  anchor_ts - toIntervalNanosecond(<range_ns>)
 //	  AND ts <= anchor_ts
 //	GROUP BY [<group cols>,] `__bucket`, anchor_ts
 //
 // The bucket column is computed in the inner SELECT (alongside the
 // arrayJoined anchors) so the outer WHERE / GROUP BY can reference it
 // by alias without recomputing the log2.
+//
+// The per-anchor window is left-open / right-closed
+// (`(anchor_ts - range, anchor_ts]`) — same bucket semantics as the
+// non-histogram metrics emitter (emitRangeWindowMetrics) and Tempo
+// upstream's `IntervalMapperQueryRange`.
 func (e *emitter) emitRangeWindowHistogram(r *chplan.RangeWindow, m *chplan.MetricsHistogramOverTime) error {
 	if r.TimestampColumn == "" {
 		return fmt.Errorf("%w: RangeWindow.TimestampColumn unset (required for MetricsHistogramOverTime input)", ErrUnsupported)
@@ -246,10 +251,11 @@ func (e *emitter) emitRangeWindowHistogram(r *chplan.RangeWindow, m *chplan.Metr
 	}
 	outerSb.Select(aggFuncFrag(countFunc))
 
-	// WHERE: ts ∈ [anchor_ts - range, anchor_ts].
+	// WHERE: ts ∈ (anchor_ts - range, anchor_ts] — left-open /
+	// right-closed, matching Tempo's IntervalMapperQueryRange.
 	outerSb.Where(
 		func(b *Builder) {
-			b.sb.WriteString("ts >= anchor_ts - toIntervalNanosecond(")
+			b.sb.WriteString("ts > anchor_ts - toIntervalNanosecond(")
 			b.sb.WriteString(strconv.FormatInt(rangeNS, 10))
 			b.sb.WriteByte(')')
 		},

--- a/internal/chsql/histogram_over_time_test.go
+++ b/internal/chsql/histogram_over_time_test.go
@@ -157,6 +157,48 @@ func TestEmitRangeWindowHistogramMatrix(t *testing.T) {
 	}
 }
 
+// TestEmitRangeWindowHistogramLeftOpenWindow pins the per-anchor
+// bucket boundary for the histogram matrix path: the WHERE clause uses
+// `ts > anchor_ts - toIntervalNanosecond(...)` (not `ts >=`) so the
+// per-anchor window is left-open / right-closed, matching Tempo's
+// `IntervalMapperQueryRange.interval` semantics. Mirrors
+// TestRangeWindowMetricsLeftOpenWindow for the non-histogram metrics
+// emitter; same off-by-one bug class would otherwise surface as
+// histogram-bucket counts drifting from Tempo by 1 at step boundaries.
+func TestEmitRangeWindowHistogramLeftOpenWindow(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 5, 13, 12, 5, 0, 0, time.UTC)
+	plan := &chplan.RangeWindow{
+		Input: &chplan.MetricsHistogramOverTime{
+			Attr:        &chplan.ColumnRef{Name: "Duration"},
+			IsDuration:  true,
+			BucketAlias: "__bucket",
+			ValueAlias:  "Value",
+			Inner:       &chplan.Scan{Table: "otel_traces"},
+		},
+		Step:            time.Minute,
+		Range:           time.Minute,
+		Start:           start,
+		End:             end,
+		TimestampColumn: "Timestamp",
+	}
+	sql, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if !strings.Contains(sql, "ts > anchor_ts - toIntervalNanosecond(") {
+		t.Errorf("expected strict lower bound `ts > anchor_ts - toIntervalNanosecond(...)`; SQL=%s", sql)
+	}
+	if strings.Contains(sql, "ts >= anchor_ts - toIntervalNanosecond(") {
+		t.Errorf("lower bound must be strict (`>`), not inclusive (`>=`); SQL=%s", sql)
+	}
+	if !strings.Contains(sql, "ts <= anchor_ts") {
+		t.Errorf("expected right-closed upper bound `ts <= anchor_ts`; SQL=%s", sql)
+	}
+}
+
 // TestEmitRangeWindowHistogramRejectsZeroStep guards the matrix path's
 // Step > 0 invariant — without it the arrayJoin range would divide
 // by zero.

--- a/internal/chsql/range_window.go
+++ b/internal/chsql/range_window.go
@@ -665,9 +665,19 @@ func formatFloat(v float64) string {
 //	         arrayJoin(arrayMap(i -> <anchor_base> - toIntervalNanosecond(i * <step_ns>), range(0, <N>))) AS anchor_ts
 //	  FROM (<Inner>)
 //	)
-//	WHERE ts >= anchor_ts - toIntervalNanosecond(<range_ns>)
+//	WHERE ts >  anchor_ts - toIntervalNanosecond(<range_ns>)
 //	  AND ts <= anchor_ts
 //	GROUP BY [<group cols>,] anchor_ts
+//
+// The bucket is left-open / right-closed — `(anchor_ts - range, anchor_ts]`
+// — matching Tempo upstream's `IntervalMapperQueryRange` semantics
+// (`(start, start+step], (start+step, start+2*step], …`; see
+// `pkg/traceql/engine_metrics.go`'s `IntervalMapperQueryRange.interval`).
+// A sample at exactly `anchor_ts` belongs to *this* anchor (right edge
+// included); a sample at exactly `anchor_ts - range` belongs to the
+// *previous* anchor (left edge excluded). The earlier `ts >=` form
+// double-counted samples landing on step boundaries — flipping `>=` to
+// `>` closes the off-by-one against Tempo's per-anchor counts.
 //
 // `<reducer>` depends on m.Op:
 //
@@ -806,7 +816,8 @@ func (e *emitter) emitRangeWindowMetrics(r *chplan.RangeWindow, m *chplan.Metric
 		outerSb.Select(As(reducerFrag, m.ValueAlias))
 	}
 
-	// WHERE: ts ∈ [anchor_ts - range, anchor_ts].
+	// WHERE: ts ∈ (anchor_ts - range, anchor_ts] — left-open /
+	// right-closed, matching Tempo's IntervalMapperQueryRange.
 	outerSb.Where(
 		windowTsLowerBoundFrag(rangeNS),
 		verbatim("ts <= anchor_ts"),
@@ -885,12 +896,22 @@ func anchorFanoutFrag(end Frag, stepNS, numAnchors int64) Frag {
 }
 
 // windowTsLowerBoundFrag returns a Frag rendering
-// `ts >= anchor_ts - toIntervalNanosecond(<rangeNS>)`. The companion
+// `ts >  anchor_ts - toIntervalNanosecond(<rangeNS>)`. The companion
 // upper bound is the literal `ts <= anchor_ts` (no parameters); both
 // are spliced into the outer SELECT's WHERE clause.
+//
+// The lower bound is *strict* (`>`, not `>=`) so the bucket is
+// left-open / right-closed — `(anchor_ts - range, anchor_ts]` —
+// matching Tempo upstream's `IntervalMapperQueryRange.interval`
+// semantics (`(start, start+step], (start+step, start+2*step], …`).
+// A sample sitting exactly on a step boundary belongs to *one* anchor
+// (the one whose right edge is that timestamp), not two; using `>=`
+// here would double-count boundary samples between adjacent anchors
+// when `range == step` and surface as a per-anchor off-by-one against
+// Tempo's reference counts.
 func windowTsLowerBoundFrag(rangeNS int64) Frag {
 	return func(b *Builder) {
-		b.sb.WriteString("ts >= anchor_ts - toIntervalNanosecond(")
+		b.sb.WriteString("ts > anchor_ts - toIntervalNanosecond(")
 		b.sb.WriteString(strconv.FormatInt(rangeNS, 10))
 		b.sb.WriteByte(')')
 	}

--- a/internal/chsql/range_window_metrics_test.go
+++ b/internal/chsql/range_window_metrics_test.go
@@ -68,6 +68,70 @@ func TestRangeWindowMetricsExplicitTimeGrid(t *testing.T) {
 	}
 }
 
+// TestRangeWindowMetricsLeftOpenWindow pins the per-anchor bucket
+// boundary: cerberus emits `ts > anchor_ts - toIntervalNanosecond(...)`
+// (not `ts >=`) for the matrix-path WHERE clause, so the per-anchor
+// window is left-open / right-closed — matching Tempo upstream's
+// `IntervalMapperQueryRange.interval` semantics
+// (`(start, start+step], (start+step, start+2*step], …`).
+//
+// Without the strict `>` a sample landing exactly on a step boundary
+// gets counted in TWO adjacent anchors, surfacing as a per-anchor
+// off-by-one against Tempo's reference counts (`metrics_count_over_time_*`
+// + `metrics_rate_*` cases in the Tempo compat suite — fixed by the
+// commit this test guards).
+func TestRangeWindowMetricsLeftOpenWindow(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		op   chplan.MetricsOp
+		attr chplan.Expr
+		q    []float64
+	}{
+		{name: "rate", op: chplan.MetricsOpRate},
+		{name: "count_over_time", op: chplan.MetricsOpCountOverTime},
+		{name: "sum_over_time", op: chplan.MetricsOpSumOverTime, attr: &chplan.ColumnRef{Name: "Duration"}},
+		{name: "avg_over_time", op: chplan.MetricsOpAvgOverTime, attr: &chplan.ColumnRef{Name: "Duration"}},
+		{name: "quantile_over_time", op: chplan.MetricsOpQuantileOverTime, attr: &chplan.ColumnRef{Name: "Duration"}, q: []float64{0.95}},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			plan := &chplan.RangeWindow{
+				Input: &chplan.MetricsAggregate{
+					Op:         c.op,
+					Attr:       c.attr,
+					Quantiles:  c.q,
+					ValueAlias: "Value",
+					Inner:      &chplan.Scan{Table: "otel_traces"},
+				},
+				Step:            time.Minute,
+				OuterRange:      5 * time.Minute,
+				TimestampColumn: "Timestamp",
+			}
+			sql, _, err := chsql.Emit(context.Background(), plan)
+			if err != nil {
+				t.Fatalf("Emit %s: %v", c.name, err)
+			}
+			// Lower bound must be strict (`>`, not `>=`) so a sample at
+			// exactly anchor_ts - range belongs only to the previous
+			// anchor, not also to this one.
+			if !strings.Contains(sql, "ts > anchor_ts - toIntervalNanosecond(") {
+				t.Errorf("%s: expected strict lower bound `ts > anchor_ts - toIntervalNanosecond(...)`; SQL=%s", c.name, sql)
+			}
+			if strings.Contains(sql, "ts >= anchor_ts - toIntervalNanosecond(") {
+				t.Errorf("%s: lower bound must be strict (`>`), not inclusive (`>=`); SQL=%s", c.name, sql)
+			}
+			// Upper bound stays right-closed (anchor_ts is included).
+			if !strings.Contains(sql, "ts <= anchor_ts") {
+				t.Errorf("%s: expected right-closed upper bound `ts <= anchor_ts`; SQL=%s", c.name, sql)
+			}
+		})
+	}
+}
+
 // TestRangeWindowMetricsRejectsZeroStep guards the matrix path's
 // Step > 0 invariant — without it the inner arrayJoin range would
 // divide by zero.

--- a/test/spec/chsql/metrics_second_stage_topk_matrix.txtar
+++ b/test/spec/chsql/metrics_second_stage_topk_matrix.txtar
@@ -1,7 +1,7 @@
 -- args --
 [0] int64 = 1
 -- sql --
-SELECT * FROM (SELECT `service`, `anchor_ts`, toFloat64(count(?)) / 60 AS `Value` FROM (SELECT `ServiceName` AS `service`, `Timestamp` AS `ts`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) WHERE ts >= anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts GROUP BY `service`, `anchor_ts`) ORDER BY `Value` DESC LIMIT 5 BY `anchor_ts`
+SELECT * FROM (SELECT `service`, `anchor_ts`, toFloat64(count(?)) / 60 AS `Value` FROM (SELECT `ServiceName` AS `service`, `Timestamp` AS `ts`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) WHERE ts > anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts GROUP BY `service`, `anchor_ts`) ORDER BY `Value` DESC LIMIT 5 BY `anchor_ts`
 -- chplan --
 MetricsSecondStage op=topk k=5 partitionBy=[anchor_ts] valueAlias=Value
   RangeWindow func= range=0s step=1m0s outerRange=5m0s ts=Timestamp

--- a/test/spec/chsql/range_window_metrics_count_over_time_by.txtar
+++ b/test/spec/chsql/range_window_metrics_count_over_time_by.txtar
@@ -1,7 +1,7 @@
 -- args --
 [0] int64 = 1
 -- sql --
-SELECT `service`, `anchor_ts`, toFloat64(count(?)) AS `Value` FROM (SELECT `ServiceName` AS `service`, `Timestamp` AS `ts`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 11))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) WHERE ts >= anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts GROUP BY `service`, `anchor_ts`
+SELECT `service`, `anchor_ts`, toFloat64(count(?)) AS `Value` FROM (SELECT `ServiceName` AS `service`, `Timestamp` AS `ts`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 11))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) WHERE ts > anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts GROUP BY `service`, `anchor_ts`
 -- chplan --
 RangeWindow func= range=0s step=1m0s outerRange=10m0s ts=Timestamp
   MetricsAggregate op=count_over_time groupBy=[ServiceName AS service] valueAlias=Value

--- a/test/spec/chsql/range_window_metrics_quantile_over_time_attr.txtar
+++ b/test/spec/chsql/range_window_metrics_quantile_over_time_attr.txtar
@@ -1,7 +1,7 @@
 -- args --
 [0] float64 = 0.95
 -- sql --
-SELECT `anchor_ts`, toFloat64(quantile(?)(`metric_arg`)) AS `Value` FROM (SELECT `Timestamp` AS `ts`, `Duration` AS `metric_arg`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) WHERE ts >= anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts GROUP BY `anchor_ts`
+SELECT `anchor_ts`, toFloat64(quantile(?)(`metric_arg`)) AS `Value` FROM (SELECT `Timestamp` AS `ts`, `Duration` AS `metric_arg`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) WHERE ts > anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts GROUP BY `anchor_ts`
 -- chplan --
 RangeWindow func= range=0s step=1m0s outerRange=5m0s ts=Timestamp
   MetricsAggregate op=quantile_over_time attr=Duration quantiles=[0.95] valueAlias=Value

--- a/test/spec/chsql/range_window_metrics_quantile_over_time_multi_attr.txtar
+++ b/test/spec/chsql/range_window_metrics_quantile_over_time_multi_attr.txtar
@@ -3,7 +3,7 @@
 [1] float64 = 0.9
 [2] float64 = 0.99
 -- sql --
-SELECT `anchor_ts`, tupleElement(phi_val, 1) AS `__phi__`, tupleElement(phi_val, 2) AS `Value` FROM (SELECT `anchor_ts`, arrayJoin(arrayMap((phi, q) -> (phi, toFloat64(q)), ['0.5', '0.9', '0.99'], qs_array)) AS phi_val FROM (SELECT `anchor_ts`, quantiles(?, ?, ?)(`metric_arg`) AS qs_array FROM (SELECT `Timestamp` AS `ts`, `Duration` AS `metric_arg`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) WHERE ts >= anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts GROUP BY `anchor_ts`))
+SELECT `anchor_ts`, tupleElement(phi_val, 1) AS `__phi__`, tupleElement(phi_val, 2) AS `Value` FROM (SELECT `anchor_ts`, arrayJoin(arrayMap((phi, q) -> (phi, toFloat64(q)), ['0.5', '0.9', '0.99'], qs_array)) AS phi_val FROM (SELECT `anchor_ts`, quantiles(?, ?, ?)(`metric_arg`) AS qs_array FROM (SELECT `Timestamp` AS `ts`, `Duration` AS `metric_arg`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) WHERE ts > anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts GROUP BY `anchor_ts`))
 -- chplan --
 RangeWindow func= range=0s step=1m0s outerRange=5m0s ts=Timestamp
   MetricsAggregate op=quantile_over_time attr=Duration quantiles=[0.5, 0.9, 0.99] valueAlias=Value

--- a/test/spec/chsql/range_window_metrics_quantile_over_time_multi_by_attr.txtar
+++ b/test/spec/chsql/range_window_metrics_quantile_over_time_multi_by_attr.txtar
@@ -3,7 +3,7 @@
 [1] float64 = 0.9
 [2] float64 = 0.99
 -- sql --
-SELECT `service`, `anchor_ts`, tupleElement(phi_val, 1) AS `__phi__`, tupleElement(phi_val, 2) AS `Value` FROM (SELECT `service`, `anchor_ts`, arrayJoin(arrayMap((phi, q) -> (phi, toFloat64(q)), ['0.5', '0.9', '0.99'], qs_array)) AS phi_val FROM (SELECT `service`, `anchor_ts`, quantiles(?, ?, ?)(`metric_arg`) AS qs_array FROM (SELECT `ServiceName` AS `service`, `Timestamp` AS `ts`, `Duration` AS `metric_arg`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) WHERE ts >= anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts GROUP BY `service`, `anchor_ts`))
+SELECT `service`, `anchor_ts`, tupleElement(phi_val, 1) AS `__phi__`, tupleElement(phi_val, 2) AS `Value` FROM (SELECT `service`, `anchor_ts`, arrayJoin(arrayMap((phi, q) -> (phi, toFloat64(q)), ['0.5', '0.9', '0.99'], qs_array)) AS phi_val FROM (SELECT `service`, `anchor_ts`, quantiles(?, ?, ?)(`metric_arg`) AS qs_array FROM (SELECT `ServiceName` AS `service`, `Timestamp` AS `ts`, `Duration` AS `metric_arg`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) WHERE ts > anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts GROUP BY `service`, `anchor_ts`))
 -- chplan --
 RangeWindow func= range=0s step=1m0s outerRange=5m0s ts=Timestamp
   MetricsAggregate op=quantile_over_time attr=Duration groupBy=[ServiceName AS service] quantiles=[0.5, 0.9, 0.99] valueAlias=Value

--- a/test/spec/chsql/range_window_metrics_rate.txtar
+++ b/test/spec/chsql/range_window_metrics_rate.txtar
@@ -1,7 +1,7 @@
 -- args --
 [0] int64 = 1
 -- sql --
-SELECT `anchor_ts`, toFloat64(count(?)) / 300 AS `Value` FROM (SELECT `Timestamp` AS `ts`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 61))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) WHERE ts >= anchor_ts - toIntervalNanosecond(300000000000) AND ts <= anchor_ts GROUP BY `anchor_ts`
+SELECT `anchor_ts`, toFloat64(count(?)) / 300 AS `Value` FROM (SELECT `Timestamp` AS `ts`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 61))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) WHERE ts > anchor_ts - toIntervalNanosecond(300000000000) AND ts <= anchor_ts GROUP BY `anchor_ts`
 -- chplan --
 RangeWindow func= range=5m0s step=1m0s outerRange=1h0m0s ts=Timestamp
   MetricsAggregate op=rate valueAlias=Value

--- a/test/spec/chsql/range_window_metrics_sum_over_time_attr.txtar
+++ b/test/spec/chsql/range_window_metrics_sum_over_time_attr.txtar
@@ -1,7 +1,7 @@
 -- args --
 (none)
 -- sql --
-SELECT `anchor_ts`, toFloat64(sum(`metric_arg`)) AS `Value` FROM (SELECT `Timestamp` AS `ts`, `Duration` AS `metric_arg`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) WHERE ts >= anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts GROUP BY `anchor_ts`
+SELECT `anchor_ts`, toFloat64(sum(`metric_arg`)) AS `Value` FROM (SELECT `Timestamp` AS `ts`, `Duration` AS `metric_arg`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) WHERE ts > anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts GROUP BY `anchor_ts`
 -- chplan --
 RangeWindow func= range=0s step=1m0s outerRange=5m0s ts=Timestamp
   MetricsAggregate op=sum_over_time attr=Duration valueAlias=Value


### PR DESCRIPTION
## Summary

The TraceQL metrics matrix-path (`emitRangeWindowMetrics`) used `ts >= anchor_ts - range AND ts <= anchor_ts` for the per-anchor WHERE clause — both bounds inclusive. With `range == step` (the standard Tempo metrics shape) a sample landing exactly on a step boundary got counted in TWO adjacent anchors: once as the right edge of anchor N (whose `anchor_ts == sample_ts`) and once as the left edge of anchor N+1 (whose `anchor_ts - range == sample_ts`).

Tempo's reference `pkg/traceql/engine_metrics.go::IntervalMapperQueryRange.interval` documents the per-anchor bucket as `(start, start+step]` — **left-open, right-closed**. The handler-side comment in `internal/api/tempo/metrics_query_range.go` already described the intended window as `(anchor_ts - range, anchor_ts]`; the SQL emitter just hadn't caught up.

This PR flips the lower bound from `>=` to `>` in `windowTsLowerBoundFrag` (used by `emitRangeWindowMetrics` + `emitMetricsExemplars`) and mirrors the change in `emitRangeWindowHistogram`. Closes the off-by-one drift on the Tempo compat suite's `metrics_count_over_time_groupby_service` and `metrics_rate_no_groupby` cases (cerberus=60 vs tempo=59, cerberus=99 vs tempo=98, rate cerberus=4.0167 vs tempo=4.0 — all off by exactly 1 boundary sample per series).

Expected Tempo compat delta: **81.82% → ~87.88%** (2 cases flip PASS).

### Scope

Tempo-only. `MetricsAggregate` and `MetricsHistogramOverTime` are TraceQL-only chplan nodes (verified via `grep -r "MetricsAggregate" internal/{traceql,logql,promql}` — only `internal/traceql/` references them). PromQL / LogQL use the windowed-array `RangeWindowFilter` idiom (`(end-range, end]` — `tupleElement(p, 1) > start AND tupleElement(p, 1) <= end`) which already matches Tempo's boundary semantic and is untouched.

### Files touched

- `internal/chsql/range_window.go` — flip `windowTsLowerBoundFrag` from `ts >=` to `ts >`; update doc comments on `emitRangeWindowMetrics` to spell out the `(anchor - range, anchor]` semantic and the Tempo reference.
- `internal/chsql/histogram_over_time.go` — same flip for `emitRangeWindowHistogram` (inline WHERE writer; shares the same matrix-path shape).
- `internal/chsql/range_window_metrics_test.go` — `TestRangeWindowMetricsLeftOpenWindow` pins the new SQL boundary across rate / count / sum / avg / quantile metric ops with positive (`ts > anchor_ts - toIntervalNanosecond(...)`) and negative (`ts >=` must not appear) assertions.
- `internal/chsql/histogram_over_time_test.go` — `TestEmitRangeWindowHistogramLeftOpenWindow` mirrors the same assertions for the histogram path.
- `test/spec/chsql/range_window_metrics_{rate,count_over_time_by,sum_over_time_attr,quantile_over_time_attr,quantile_over_time_multi_attr,quantile_over_time_multi_by_attr}.txtar` + `metrics_second_stage_topk_matrix.txtar` — SQL goldens updated from `ts >=` to `ts >` to match the new emission (chplan IR unchanged).

`emitMetricsExemplars` shares the `windowTsLowerBoundFrag` helper so the fix propagates automatically.

## Test plan

- [ ] `check` job passes — golden snapshots + the two new unit tests catch regressions.
- [ ] `lint` job passes — no new raw-SQL writes; doc comments and tests updated alongside the behaviour change.
- [ ] On next nightly Tempo compat run, `metrics_count_over_time_groupby_service` and `metrics_rate_no_groupby` flip from FAIL to PASS, lifting compat to ~87.88%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)