### PR TITLE
fix(harness/tempo-compat): scope tag_values_v2 fixtures to TraceQL-parseable form

### DIFF
--- a/compatibility/tempo/driver/corpus/smoke.txtar
+++ b/compatibility/tempo/driver/corpus/smoke.txtar
@@ -487,8 +487,18 @@ shipping
 tag_values_v2_service_name
 -- endpoint --
 tag_values_v2
+# Tempo's V2 tag-values endpoint runs `traceql.ParseIdentifier` over
+# the URL `{name}` segment and rejects bare dotted forms like
+# `service.name` (the dotted parts parse as two attribute references,
+# not as one quoted-attribute name). The accepted forms are TraceQL
+# identifiers: intrinsics (`name`, `kind`, ...), scoped attributes
+# (`resource.x`, `span.x`), or the auto-scope leading-dot form (`.x`).
+# We pick the leading-dot form here so a single fixture exercises both
+# backends symmetrically — Tempo and cerberus both treat it as
+# auto-scope (union both maps), and the seeded `service.name` lives
+# in ResourceAttributes so the union still surfaces it.
 -- tag_name --
-service.name
+.service.name
 -- expected_min_values --
 1
 -- expected_max_values --
@@ -503,8 +513,11 @@ shipping
 tag_values_v2_deployment_env
 -- endpoint --
 tag_values_v2
+# Same scoped-form rationale as tag_values_v2_service_name: bare
+# `deployment.env` is rejected by Tempo's V2 parser, leading-dot form
+# resolves to auto-scope and finds the resource-attributes entry.
 -- tag_name --
-deployment.env
+.deployment.env
 -- expected_min_values --
 1
 -- expected_max_values --
@@ -518,8 +531,11 @@ compat-test
 tag_values_v2_unknown_tag_empty
 -- endpoint --
 tag_values_v2
+# `.nonexistent.tag` is a valid TraceQL identifier (leading-dot
+# auto-scope) that simply isn't present in the seed; both backends
+# return an empty `tagValues` list.
 -- tag_name --
-this.tag.does.not.exist
+.nonexistent.tag
 # Both backends should return an empty `tagValues` list for an unknown
 # attribute key — the result is the empty subset of a never-populated
 # CH map column. Differ surfaces a cardinality match on len=0 with no

--- a/internal/api/tempo/search_tag_values.go
+++ b/internal/api/tempo/search_tag_values.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/grafana/tempo/pkg/traceql"
+
 	"github.com/tsouza/cerberus/internal/chsql"
 	"github.com/tsouza/cerberus/internal/schema"
 )
@@ -72,6 +74,27 @@ func (h *Handler) handleSearchTagValuesV2(w http.ResponseWriter, r *http.Request
 }
 
 // respondTagValues is the shared core of V1 + V2.
+//
+// The {name} segment of the URL accepts the TraceQL identifier grammar
+// plus, for backward compatibility with Grafana clients that splice
+// dotted attribute keys directly into the path, a bare opaque-key
+// fallback:
+//
+//   - intrinsics: `name`, `kind`, `status`, `statusMessage`, `duration`,
+//     `parent` — query the dedicated CH column.
+//   - scoped attribute: `resource.x` → ResourceAttributes only,
+//     `span.x` → SpanAttributes only.
+//   - auto-scope leading-dot attribute: `.x`, `.x.y` → both maps.
+//   - bare dotted attribute (e.g. `service.name`) — Tempo's V2 parser
+//     rejects it, but our V1 endpoint historically accepts it and the
+//     V2 endpoint stays permissive too; we treat it as auto-scope
+//     against the bare key. The compatibility harness picks scoped
+//     forms for fixtures specifically so both backends parse them
+//     identically; this fallback exists for direct cerberus callers.
+//
+// resolveTagName runs the parse once; callers downstream switch on
+// whether it landed on an intrinsic column or a map lookup, and which
+// scope the map lookup targets.
 func (h *Handler) respondTagValues(w http.ResponseWriter, r *http.Request, v2 bool) {
 	name := r.PathValue("name")
 	if name == "" {
@@ -84,20 +107,26 @@ func (h *Handler) respondTagValues(w http.ResponseWriter, r *http.Request, v2 bo
 		return
 	}
 
-	col, isIntrinsic := intrinsicColumn(name, h.Schema)
+	resolved, _ := resolveTagName(name, h.Schema)
 	var (
 		sqlStr   string
 		args     []any
 		valueTyp string
 	)
-	if isIntrinsic {
-		sqlStr, args = buildIntrinsicValuesSQL(h.Schema, col, start, end)
-		valueTyp = intrinsicType(name)
+	if resolved.IsIntrinsic {
+		sqlStr, args = buildIntrinsicValuesSQL(h.Schema, resolved.IntrinsicCol, start, end)
+		valueTyp = intrinsicType(resolved.IntrinsicName)
 	} else {
-		sqlStr, args = buildAttributeValuesSQL(h.Schema, name, start, end)
+		sqlStr, args = buildAttributeValuesSQL(h.Schema, resolved.Key, resolved.MapScope, start, end)
 		valueTyp = "string"
 	}
-	h.Logger.Debug("cerberus tempo /search/tag/values", "tag", name, "intrinsic", isIntrinsic, "sql", sqlStr, "args", args)
+	h.Logger.Debug("cerberus tempo /search/tag/values",
+		"tag", name,
+		"intrinsic", resolved.IsIntrinsic,
+		"map_scope", resolved.MapScope,
+		"key", resolved.Key,
+		"sql", sqlStr,
+		"args", args)
 
 	values, err := h.Client.QueryStrings(r.Context(), sqlStr, args...)
 	if err != nil {
@@ -143,9 +172,12 @@ func buildIntrinsicValuesSQL(s schema.Traces, col string, start, end time.Time) 
 }
 
 // buildAttributeValuesSQL builds the SELECT for a dynamic-attribute
-// values lookup. The tag key may live in SpanAttributes or
-// ResourceAttributes; the CH idiom unions both maps via arrayJoin on a
-// two-element array, then filters empties:
+// values lookup. The tag key may live in SpanAttributes (`span.x`),
+// ResourceAttributes (`resource.x`), or either of the two when the
+// caller used the auto-scope leading-dot form (`.x`).
+//
+// For the both-maps form the CH idiom unions both maps via arrayJoin
+// on a two-element array, then filters empties:
 //
 //	SELECT DISTINCT v AS value FROM (
 //	    SELECT arrayJoin([`SpanAttributes`[?], `ResourceAttributes`[?]]) AS v
@@ -158,11 +190,35 @@ func buildIntrinsicValuesSQL(s schema.Traces, col string, start, end time.Time) 
 // The mapContains pre-filter prunes most rows before the arrayJoin
 // fan-out, and the outer v != ” drops the empty-string slot for rows
 // where the key only exists in one of the two maps.
-func buildAttributeValuesSQL(s schema.Traces, name string, start, end time.Time) (string, []any) {
+//
+// For the single-scope forms we collapse the arrayJoin/union and emit
+// a direct DISTINCT projection against the matching column:
+//
+//	SELECT DISTINCT v AS value FROM (
+//	    SELECT `<col>`[?] AS v FROM `otel_traces`
+//	    WHERE mapContains(`<col>`, ?) [AND time bounds]
+//	)
+//	WHERE v != ''
+func buildAttributeValuesSQL(s schema.Traces, name string, scope attrMapScope, start, end time.Time) (string, []any) {
+	var (
+		selFrag   chsql.Frag
+		whereFrag chsql.Frag
+	)
+	switch scope {
+	case attrMapScopeResource:
+		selFrag = chsql.As(mapAtFrag(s.ResourceAttributesColumn, name), "v")
+		whereFrag = mapContainsFrag(s.ResourceAttributesColumn, name)
+	case attrMapScopeSpan:
+		selFrag = chsql.As(mapAtFrag(s.AttributesColumn, name), "v")
+		whereFrag = mapContainsFrag(s.AttributesColumn, name)
+	default: // attrMapScopeAny
+		selFrag = attrValueArrayJoinFrag(s.AttributesColumn, s.ResourceAttributesColumn, name)
+		whereFrag = mapContainsAnyFrag(s.AttributesColumn, s.ResourceAttributesColumn, name)
+	}
 	inner := chsql.NewQuery().
-		Select(attrValueArrayJoinFrag(s.AttributesColumn, s.ResourceAttributesColumn, name)).
+		Select(selFrag).
 		From(chsql.Col(s.SpansTable)).
-		Where(mapContainsAnyFrag(s.AttributesColumn, s.ResourceAttributesColumn, name))
+		Where(whereFrag)
 	if !start.IsZero() {
 		inner.Where(tempoTimeGteFrag(s.TimestampColumn, start))
 	}
@@ -175,6 +231,106 @@ func buildAttributeValuesSQL(s schema.Traces, name string, start, end time.Time)
 		From(inner.Frag()).
 		Where(nonEmptyFrag("v"))
 	return outer.Build()
+}
+
+// attrMapScope expresses which attribute map(s) a tag-values lookup
+// should consult. Driven by parsing the URL tag-name as a TraceQL
+// identifier — see resolveTagName.
+type attrMapScope int
+
+const (
+	// attrMapScopeAny unions both SpanAttributes and ResourceAttributes
+	// (Tempo's auto-scope form: bare `service.name`, leading-dot
+	// `.service.name`).
+	attrMapScopeAny attrMapScope = iota
+	// attrMapScopeResource consults only ResourceAttributes
+	// (Tempo's `resource.x` scoped form).
+	attrMapScopeResource
+	// attrMapScopeSpan consults only SpanAttributes
+	// (Tempo's `span.x` scoped form).
+	attrMapScopeSpan
+)
+
+func (s attrMapScope) String() string {
+	switch s {
+	case attrMapScopeResource:
+		return "resource"
+	case attrMapScopeSpan:
+		return "span"
+	default:
+		return "any"
+	}
+}
+
+// resolvedTagName carries the outcome of running the URL path segment
+// through traceql.ParseIdentifier. Either it resolves to an intrinsic
+// column (IsIntrinsic + IntrinsicCol / IntrinsicName) or to a dynamic
+// attribute lookup against the right CH map column (Key + MapScope).
+type resolvedTagName struct {
+	IsIntrinsic   bool
+	IntrinsicCol  string
+	IntrinsicName string
+	Key           string
+	MapScope      attrMapScope
+}
+
+// resolveTagName parses the URL `name` segment as a TraceQL attribute
+// identifier and maps it onto the cerberus tag-values pipeline.
+//
+// Accepted forms (all per Tempo's grammar):
+//   - intrinsics: `name`, `kind`, `status`, `statusMessage`, `duration`,
+//     `parent` — route to the matching dedicated CH column.
+//   - scoped attribute: `resource.x`, `span.x` — route to that map only.
+//   - auto-scope attribute: `.x`, `.x.y` — both maps.
+//   - bare dotted attribute (V1 only): `service.name` — parser
+//     rejects it; we treat it as auto-scope with the bare key. This
+//     preserves V1 backward compatibility with Grafana clients that
+//     splice attribute keys directly into the path without a scope
+//     prefix.
+//
+// Returns the resolved layout plus the parser error, if any. Callers
+// that want to enforce TraceQL strictness (V2) should reject when
+// parseErr != nil.
+func resolveTagName(name string, s schema.Traces) (resolvedTagName, error) {
+	// Cheap intrinsic short-circuit: if `name` is a bare intrinsic
+	// keyword we recognise we don't need to invoke the parser at all.
+	if col, ok := intrinsicColumn(name, s); ok {
+		return resolvedTagName{IsIntrinsic: true, IntrinsicCol: col, IntrinsicName: name}, nil
+	}
+
+	attr, err := traceql.ParseIdentifier(name)
+	if err != nil {
+		// Backward-compat V1 fallback: parser rejects a bare dotted
+		// key like `service.name`, but the V1 endpoint historically
+		// accepts it. Treat as auto-scope against the bare key.
+		return resolvedTagName{Key: name, MapScope: attrMapScopeAny}, err
+	}
+	// Intrinsic resolved via the parser (covers scoped intrinsics like
+	// `span:name`, `trace:duration` once the schema grows them; today
+	// the intrinsicColumn lookup is keyed by the bare name).
+	if attr.Intrinsic != traceql.IntrinsicNone {
+		if col, ok := intrinsicColumn(attr.Intrinsic.String(), s); ok {
+			return resolvedTagName{
+				IsIntrinsic:   true,
+				IntrinsicCol:  col,
+				IntrinsicName: attr.Intrinsic.String(),
+			}, nil
+		}
+		// Parser recognised an intrinsic we don't model yet — fall
+		// through to the attribute path with the bare name so the
+		// response is empty rather than 5xx.
+		return resolvedTagName{Key: attr.Name, MapScope: attrMapScopeAny}, nil
+	}
+	var ms attrMapScope
+	switch attr.Scope {
+	case traceql.AttributeScopeResource:
+		ms = attrMapScopeResource
+	case traceql.AttributeScopeSpan:
+		ms = attrMapScopeSpan
+	default:
+		ms = attrMapScopeAny
+	}
+	return resolvedTagName{Key: attr.Name, MapScope: ms}, nil
 }
 
 // distinctToStringFrag emits "DISTINCT toString(`<col>`)". `toString`

--- a/internal/api/tempo/search_tag_values_test.go
+++ b/internal/api/tempo/search_tag_values_test.go
@@ -214,3 +214,187 @@ func TestSearchTagValuesV2_IntrinsicType(t *testing.T) {
 		t.Errorf("expected type=duration, got %+v", body.TagValues)
 	}
 }
+
+// TestSearchTagValuesV2_LeadingDotAutoScope — the scoped leading-dot
+// form `.service.name` is the canonical TraceQL identifier shape that
+// Tempo's V2 URL parser accepts. Cerberus must resolve it to the bare
+// attribute key (`service.name`) and query both attribute maps (Tempo's
+// auto-scope semantics). Compatibility-harness fixture uses this form.
+func TestSearchTagValuesV2_LeadingDotAutoScope(t *testing.T) {
+	t.Parallel()
+	q := &stubQuerier{strings: []string{"frontend", "backend"}}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v2/search/tag/.service.name/values")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	var body tempo.SearchTagValuesResponseV2
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.TagValues) != 2 {
+		t.Errorf("expected 2 values, got %v", body.TagValues)
+	}
+	// Auto-scope must touch both maps via arrayJoin, identical to the
+	// bare-name V1 dynamic-attribute path.
+	for _, want := range []string{
+		"`SpanAttributes`[",
+		"`ResourceAttributes`[",
+		"arrayJoin(",
+	} {
+		if !strings.Contains(q.lastSQL, want) {
+			t.Errorf("SQL missing %q for `.service.name`\n  got: %s", want, q.lastSQL)
+		}
+	}
+	// The bound key is the bare attribute name, NOT the leading-dot
+	// form — the parser strips the scope sigil. Mirrors Tempo's
+	// behaviour: `traceql.ParseIdentifier(".service.name")` yields
+	// Attribute{Scope: None, Name: "service.name"}.
+	hits := 0
+	for _, a := range q.lastArgs {
+		if s, ok := a.(string); ok && s == "service.name" {
+			hits++
+		}
+	}
+	if hits < 4 {
+		t.Errorf("expected key %q bound >=4 times, got %d in %v",
+			"service.name", hits, q.lastArgs)
+	}
+}
+
+// TestSearchTagValuesV2_ResourceScope — `resource.service.name` is the
+// explicit-scope TraceQL form. Cerberus must narrow the lookup to the
+// ResourceAttributes column only (no SpanAttributes leg in the SQL).
+func TestSearchTagValuesV2_ResourceScope(t *testing.T) {
+	t.Parallel()
+	q := &stubQuerier{strings: []string{"frontend"}}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v2/search/tag/resource.service.name/values")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	if !strings.Contains(q.lastSQL, "`ResourceAttributes`[") {
+		t.Errorf("expected ResourceAttributes lookup, got: %s", q.lastSQL)
+	}
+	if strings.Contains(q.lastSQL, "`SpanAttributes`[") {
+		t.Errorf("resource scope should NOT touch SpanAttributes, got: %s", q.lastSQL)
+	}
+	if strings.Contains(q.lastSQL, "arrayJoin(") {
+		t.Errorf("single-scope path should NOT emit arrayJoin union, got: %s", q.lastSQL)
+	}
+	// Bound key is the bare attribute name after stripping the scope.
+	hits := 0
+	for _, a := range q.lastArgs {
+		if s, ok := a.(string); ok && s == "service.name" {
+			hits++
+		}
+	}
+	if hits < 2 {
+		t.Errorf("expected key %q bound >=2 times, got %d in %v",
+			"service.name", hits, q.lastArgs)
+	}
+}
+
+// TestSearchTagValuesV2_SpanScope — `span.http.method` narrows to the
+// SpanAttributes column only.
+func TestSearchTagValuesV2_SpanScope(t *testing.T) {
+	t.Parallel()
+	q := &stubQuerier{strings: []string{"GET", "POST"}}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v2/search/tag/span.http.method/values")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	if !strings.Contains(q.lastSQL, "`SpanAttributes`[") {
+		t.Errorf("expected SpanAttributes lookup, got: %s", q.lastSQL)
+	}
+	if strings.Contains(q.lastSQL, "`ResourceAttributes`[") {
+		t.Errorf("span scope should NOT touch ResourceAttributes, got: %s", q.lastSQL)
+	}
+	// Bound key is the bare attribute name after stripping the scope.
+	hits := 0
+	for _, a := range q.lastArgs {
+		if s, ok := a.(string); ok && s == "http.method" {
+			hits++
+		}
+	}
+	if hits < 2 {
+		t.Errorf("expected key %q bound >=2 times, got %d in %v",
+			"http.method", hits, q.lastArgs)
+	}
+}
+
+// TestSearchTagValues_ScopedFormParityWithBare — the scoped
+// `.service.name` form (Tempo-acceptable) and the bare `service.name`
+// form (V1 backward-compat) MUST produce equivalent SQL: identical
+// arrayJoin shape over both maps with the same bare key bound as the
+// positional arg. This is the cross-form parity contract the
+// compatibility-harness fixture relies on — Tempo only accepts the
+// scoped form on V2, but cerberus's two paths must converge on the
+// same data.
+func TestSearchTagValues_ScopedFormParityWithBare(t *testing.T) {
+	t.Parallel()
+	for _, urlPath := range []string{
+		"/api/search/tag/service.name/values",
+		"/api/search/tag/.service.name/values",
+		"/api/v2/search/tag/service.name/values",
+		"/api/v2/search/tag/.service.name/values",
+	} {
+		urlPath := urlPath
+		t.Run(urlPath, func(t *testing.T) {
+			t.Parallel()
+			q := &stubQuerier{strings: []string{"frontend", "backend"}}
+			srv := newServer(q, "v1.0.0-test")
+			t.Cleanup(srv.Close)
+
+			resp, err := http.Get(srv.URL + urlPath)
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status=%d for %s", resp.StatusCode, urlPath)
+			}
+			// All four URLs land on the auto-scope arrayJoin path.
+			for _, want := range []string{
+				"`SpanAttributes`[",
+				"`ResourceAttributes`[",
+				"arrayJoin(",
+			} {
+				if !strings.Contains(q.lastSQL, want) {
+					t.Errorf("%s: SQL missing %q\n  got: %s", urlPath, want, q.lastSQL)
+				}
+			}
+			// Bound key is the bare `service.name`, regardless of which
+			// URL form the caller used.
+			hits := 0
+			for _, a := range q.lastArgs {
+				if s, ok := a.(string); ok && s == "service.name" {
+					hits++
+				}
+			}
+			if hits < 4 {
+				t.Errorf("%s: expected key bound >=4 times, got %d in %v",
+					urlPath, hits, q.lastArgs)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The three `tag_values_v2` corpus cases sent bare dotted keys (`service.name`, `deployment.env`, `this.tag.does.not.exist`), which Tempo's V2 endpoint rejects with HTTP 400 — its parser runs `traceql.ParseIdentifier` and bare dotted forms parse as two attribute references, not as one quoted-attribute name. PR #563 deleted the cases to silence the ERRORs; #564 reverted because deleting tests isn't the fix. This PR is the proper fix:

- **Fixture**: switch the three `-- tag_name --` segments to the leading-dot auto-scope form: `.service.name`, `.deployment.env`, `.nonexistent.tag`. Tempo's V2 parser accepts these; both backends will resolve them to the bare attribute key with both-maps semantics.
- **Cerberus handler**: add a `resolveTagName` step that runs the same `traceql.ParseIdentifier`:
  - Intrinsics (`name`, `kind`, `duration`, ...) → dedicated CH column.
  - `resource.x` → `ResourceAttributes` only.
  - `span.x` → `SpanAttributes` only.
  - Auto-scope leading-dot `.x` or `.x.y` → both maps (matches Tempo's `Scope=None` auto-scope).
  - Bare dotted (parser-reject) → fallback to the legacy dual-map lookup — preserves V1 backward compat for Grafana clients that splice attribute keys directly without scope prefix.
- **Tests**: add four parity cases to `internal/api/tempo/search_tag_values_test.go`:
  - `TestSearchTagValuesV2_LeadingDotAutoScope` — `.service.name` resolves and queries both maps.
  - `TestSearchTagValuesV2_ResourceScope` — `resource.service.name` queries only `ResourceAttributes`.
  - `TestSearchTagValuesV2_SpanScope` — `span.http.method` queries only `SpanAttributes`.
  - `TestSearchTagValues_ScopedFormParityWithBare` — table-driven proof that all four URL shapes (`service.name` / `.service.name` × V1/V2) converge on identical SQL with the same bound key.

## Why this is the right fix

Removing test cases hides the gap. The seeded fixture uses dotted attribute keys; Tempo's V2 grammar accepts them but only under the TraceQL scope sigil. The compat harness exists to surface exactly this kind of fixture-grammar mismatch. The leading-dot form is the smallest fix that makes both backends parse the same input and the differ compare apples-to-apples on the seeded data.

## Test plan

- [ ] CI `check` job re-runs `TestSearchTagValues_*` and the new `TestSearchTagValuesV2_{LeadingDot,Resource,Span}Scope` + `TestSearchTagValues_ScopedFormParityWithBare` and they pass.
- [ ] CI `lint` job stays green; no `t.Skip*` / "skipped" / "deferred" / "post-GA" markers introduced.
- [ ] Next nightly compat run flips the three `tag_values_v2` rows from ERROR → PASS (or DIFF — both backends now return 200 with the same scoped form parsed identically).
- [ ] Corpus floor + `TestSmokeCorpus_TagEndpointCoverage` are unchanged (still 33 cases, `tag_values_v2` coverage required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)