### PR TITLE
fix(api/tempo): zero-fill quantile/avg/sum/min/max_over_time matrix grid to align with Tempo

### DIFF
--- a/internal/api/tempo/metrics_query_range.go
+++ b/internal/api/tempo/metrics_query_range.go
@@ -256,22 +256,33 @@ func (h *Handler) handleMetricsQueryRange(w http.ResponseWriter, r *http.Request
 		"sql", res.SQL, "args", res.Args)
 
 	series := toMetricsSeries(res.Samples, metrics)
-	// Zero-fill the matrix step grid for count/rate operators so the
-	// response shape matches Tempo's reference engine_metrics.go: its
-	// StepAggregator pre-allocates one CountOverTimeAggregator per
-	// interval whose default Sample() is 0 (count starts at zero), so
-	// empty buckets surface as 0-valued samples across the full
-	// [Start, End] grid. Cerberus's matrix SQL emits one row per
-	// (group, anchor) bucket only when at least one span falls in
-	// (anchor_ts - range, anchor_ts]; without this post-step empty
-	// buckets disappear, dropping samples count from N to (#observed
-	// buckets) — the smoke corpus's count_over_time_groupby_service
-	// case showed tempo=121 vs cerberus=2 against the same seeded
-	// dataset for that reason. Tempo's OverTimeAggregator (sum / avg /
-	// min / max / quantile) initialises its value to NaN, and the
-	// ToProto loop skips NaN samples — so those operators already
-	// match cerberus's observed-only emission without a zero-fill
-	// pass.
+	// Zero-fill the matrix step grid for count/rate AND quantile
+	// operators so the response shape matches Tempo's reference
+	// engine_metrics.go. Two distinct upstream code paths converge on a
+	// "zero-fill every anchor across [Start, End]" emit shape:
+	//
+	//   - count_over_time / rate: StepAggregator pre-allocates one
+	//     CountOverTimeAggregator per interval whose default Sample()
+	//     is 0, so ToProto walks all intervals and emits 0 for empty
+	//     buckets.
+	//   - quantile_over_time: HistogramAggregator.Results explicitly
+	//     sets `ts.Values[i] = 0.0` for any interval with no buckets
+	//     (`if len(in.hist[i].Buckets) == 0 { ts.Values[i] = 0.0 }`),
+	//     so ToProto again emits a value at every anchor.
+	//
+	// Cerberus's matrix SQL emits one row per (group, anchor) bucket
+	// only when at least one span falls in (anchor_ts - range,
+	// anchor_ts]; without this post-step empty buckets disappear,
+	// dropping samples count from N to (#observed buckets) — the smoke
+	// corpus's count_over_time_groupby_service case showed tempo=121 vs
+	// cerberus=2 (and quantile_over_time_p95 showed tempo=121 vs
+	// cerberus=3) against the same seeded dataset for that reason.
+	//
+	// Tempo's OverTimeAggregator (sum / avg / min / max) initialises
+	// its value to NaN, and the ToProto loop skips NaN samples — those
+	// operators already match cerberus's observed-only emission without
+	// a zero-fill pass, so the fill is intentionally scoped to
+	// count/rate/quantile only.
 	series = zeroFillMatrixGrid(series, metrics, start, end, step)
 
 	exSQL, exArgs, exErr := chsql.EmitMetricsExemplars(ctx, rw, metrics,
@@ -639,16 +650,32 @@ func toMetricsSeries(samples []chclient.Sample, m *chplan.MetricsAggregate) []Me
 }
 
 // zeroFillMatrixGrid extends each series's Samples to the full matrix
-// step grid for `| count_over_time()` and `| rate()` queries, inserting
-// 0-valued samples for anchors that had no observed spans.
+// step grid for `| count_over_time()`, `| rate()`, and
+// `| quantile_over_time(...)` queries, inserting 0-valued samples for
+// anchors that had no observed spans.
 //
-// Tempo's reference metrics engine pre-allocates one
-// CountOverTimeAggregator per interval (engine_metrics.go::StepAggregator)
-// whose default Sample() is 0; its ToProto path emits the full grid for
-// count/rate. Cerberus's matrix SQL only emits rows for (group, anchor)
-// pairs where at least one span lands in (anchor_ts - range, anchor_ts],
-// so without this fill the response loses every empty bucket and the
-// differ trips on `samples count tempo=N vs cerberus=M`.
+// Two upstream Tempo aggregators emit zeros (rather than NaN) for
+// empty buckets, so each anchor across [Start, End] surfaces as a
+// sample on the wire:
+//
+//   - count_over_time / rate: StepAggregator pre-allocates one
+//     CountOverTimeAggregator per interval whose default Sample() is 0
+//     (count starts at zero) — `pkg/traceql/engine_metrics.go`'s
+//     StepAggregator pre-fills the vector slice with
+//     NewCountOverTimeAggregator() instances before any Observe runs.
+//   - quantile_over_time: HistogramAggregator.Results explicitly sets
+//     `ts.Values[i] = 0.0` when `len(in.hist[i].Buckets) == 0`
+//     (`pkg/traceql/engine_metrics.go`). Both paths then run through
+//     SeriesSet.ToProto, which only skips a sample if its value is
+//     math.NaN — 0.0 survives and reaches the wire.
+//
+// Cerberus's matrix SQL only emits rows for (group, anchor) pairs
+// where at least one span lands in (anchor_ts - range, anchor_ts], so
+// without this fill the response loses every empty bucket and the
+// differ trips on `samples count tempo=N vs cerberus=M` (see PR #550
+// for count/rate; the quantile gap surfaced as
+// `metrics_quantile_over_time_p95: samples count tempo=121 vs
+// cerberus=3` once #562 unblocked the per-phi label shape).
 //
 // The fill anchors mirror the chsql emitter's
 // arrayJoin(arrayMap(i -> End - i*Step, range(0, N))) grid:
@@ -656,7 +683,9 @@ func toMetricsSeries(samples []chclient.Sample, m *chplan.MetricsAggregate) []Me
 // In ascending timestamp order that yields [start, start+step, ...,
 // end-step, end]. Each series is filled independently; series that
 // never observed any span are left absent (matches Tempo's
-// SpanAggregator.Observe gating).
+// SpanAggregator.Observe gating — HistogramAggregator only initialises
+// per-series interval slices when at least one span lands in the
+// query window).
 //
 // No-op when:
 //   - step <= 0 (defensive — the handler rejects step <= 0 upstream,
@@ -665,9 +694,10 @@ func toMetricsSeries(samples []chclient.Sample, m *chplan.MetricsAggregate) []Me
 //   - start / end aren't both set (the chsql matrix path falls back to
 //     a single anchor at End in that case; one sample per series is
 //     fine without a fill),
-//   - the metrics op isn't count_over_time / rate (sum / avg / min /
-//     max / quantile share Tempo's NaN-skip semantics — see
-//     OverTimeAggregator initialisation in engine_metrics.go),
+//   - the metrics op isn't count_over_time / rate / quantile_over_time
+//     (sum / avg / min / max share Tempo's NaN-skip semantics — see
+//     OverTimeAggregator initialisation in engine_metrics.go, which
+//     starts val=NaN and the ToProto loop skips NaN-valued samples),
 //   - the input slice is empty (no observed series → no zero-fill;
 //     mirrors Tempo's behaviour of only initialising entries via
 //     SpanAggregator.Observe).
@@ -675,7 +705,7 @@ func zeroFillMatrixGrid(series []MetricsSeries, m *chplan.MetricsAggregate, star
 	if len(series) == 0 || step <= 0 || start.IsZero() || end.IsZero() {
 		return series
 	}
-	if m.Op != chplan.MetricsOpCountOverTime && m.Op != chplan.MetricsOpRate {
+	if !metricsOpZeroFillsEmptyBuckets(m.Op) {
 		return series
 	}
 	span := end.Sub(start)
@@ -727,6 +757,26 @@ func zeroFillMatrixGrid(series []MetricsSeries, m *chplan.MetricsAggregate, star
 		})
 	}
 	return series
+}
+
+// metricsOpZeroFillsEmptyBuckets reports whether the given
+// MetricsAggregate.Op surfaces 0-valued samples for empty buckets on
+// Tempo's wire (rather than NaN-skipping them). The two upstream code
+// paths that produce zeros are StepAggregator + CountOverTimeAggregator
+// (for `count_over_time` and `rate` — the underlying counter aggregator
+// starts at zero) and HistogramAggregator.Results (for
+// `quantile_over_time` — explicitly sets `ts.Values[i] = 0.0` when the
+// bucket has no histogram entries). All other operators reach the wire
+// via OverTimeAggregator's NaN-init path, so cerberus's observed-only
+// emission already matches Tempo's output and needs no fill.
+func metricsOpZeroFillsEmptyBuckets(op chplan.MetricsOp) bool {
+	switch op {
+	case chplan.MetricsOpCountOverTime,
+		chplan.MetricsOpRate,
+		chplan.MetricsOpQuantileOverTime:
+		return true
+	}
+	return false
 }
 
 // labelsFromSample materialises the {key,value} pair slice for one

--- a/internal/api/tempo/metrics_query_range_test.go
+++ b/internal/api/tempo/metrics_query_range_test.go
@@ -319,30 +319,120 @@ func TestMetricsQueryRange_ZeroFillCountOverTime(t *testing.T) {
 	}
 }
 
-// TestMetricsQueryRange_ZeroFillSkippedForAvgOverTime pins the contract
-// that the zero-fill pass only fires for count_over_time / rate. For
-// sum / avg / min / max / quantile_over_time, Tempo's
-// OverTimeAggregator initialises val=NaN and the ToProto loop skips
-// NaN samples, so the observed-only emission cerberus produces today
-// is the wire-correct match — zero-filling would inject false zeros
-// where Tempo emits nothing.
-func TestMetricsQueryRange_ZeroFillSkippedForAvgOverTime(t *testing.T) {
+// TestMetricsQueryRange_ZeroFillSkippedForOverTimeAggs pins the
+// contract that the zero-fill pass does NOT fire for sum / avg / min /
+// max _over_time. Tempo's OverTimeAggregator initialises its value to
+// NaN and the SeriesSet.ToProto loop skips NaN samples
+// (`pkg/traceql/engine_metrics.go`'s OverTimeAggregator + ToProto), so
+// the observed-only emission cerberus produces is the wire-correct
+// match — zero-filling would inject false zeros where Tempo emits
+// nothing.
+//
+// `quantile_over_time` is the inverse case (HistogramAggregator.Results
+// emits 0.0 at empty buckets, not NaN) and is asserted by
+// TestMetricsQueryRange_ZeroFillQuantileOverTime below.
+func TestMetricsQueryRange_ZeroFillSkippedForOverTimeAggs(t *testing.T) {
+	t.Parallel()
+
+	mid := time.Date(2026, 5, 12, 10, 1, 0, 0, time.UTC)
+
+	cases := []struct {
+		name  string
+		query string
+		op    string
+	}{
+		{"avg_over_time", "{} | avg_over_time(duration)", "avg_over_time"},
+		{"sum_over_time", "{} | sum_over_time(duration)", "sum_over_time"},
+		{"min_over_time", "{} | min_over_time(duration)", "min_over_time"},
+		{"max_over_time", "{} | max_over_time(duration)", "max_over_time"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			q := &stubQuerier{samples: []chclient.Sample{{
+				MetricName: "",
+				// Matrix-shape SQL projects `map('__name__',
+				// '<op>')` for ungrouped queries (see
+				// wrapMetricsForSample); stub mimics the cursor's
+				// surfaced Labels map.
+				Labels:    map[string]string{"__name__": tc.op},
+				Timestamp: mid,
+				Value:     42.0,
+			}}}
+			srv := newServer(q, "v1.0.0-test")
+			t.Cleanup(srv.Close)
+
+			u := metricsQueryRangeURL(srv.URL, tc.query, map[string]string{
+				"start": fixtureStartUnix,
+				"end":   fixtureEndUnix,
+				"step":  "60s",
+			})
+			resp, err := http.Get(u)
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+			}
+			var body tempo.MetricsQueryRangeResponse
+			if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if len(body.Series) != 1 {
+				t.Fatalf("expected 1 series, got %d", len(body.Series))
+			}
+			s := body.Series[0]
+			if len(s.Samples) != 1 {
+				t.Errorf("expected 1 observed sample for %s (no zero-fill), got %d: %+v",
+					tc.op, len(s.Samples), s.Samples)
+			}
+			if len(s.Samples) > 0 && s.Samples[0].Value != 42.0 {
+				t.Errorf("expected observed sample value 42, got %v", s.Samples[0].Value)
+			}
+		})
+	}
+}
+
+// TestMetricsQueryRange_ZeroFillQuantileOverTime pins the contract
+// that quantile_over_time responses zero-fill the full matrix step
+// grid across [start, end] — even buckets where no spans landed — to
+// match Tempo's reference HistogramAggregator. Its Results method
+// explicitly sets `ts.Values[i] = 0.0` for any interval whose bucket
+// list is empty (`pkg/traceql/engine_metrics.go`), so ToProto walks
+// every anchor and emits a 0-valued sample rather than NaN-skipping
+// it. Without this fill the tempo-compat differ trips on
+// `metrics_quantile_over_time_p95: samples count tempo=121 vs
+// cerberus=3` against the same seeded dataset (PR #562 unblocked the
+// per-phi label shape; this case is what surfaced the bucket-count
+// gap once the label shape stopped masking it).
+//
+// Setup: 3-minute window @ 60s step → 4 anchors (10:00 / 10:01 / 10:02
+// / 10:03). The CH stub returns exactly one row (10:01) carrying the
+// `p="0.95"` HistogramAggregator label cerberus surfaces for the
+// single-phi branch; the handler must surface a 4-sample stream with
+// the missing three anchors at value 0.
+func TestMetricsQueryRange_ZeroFillQuantileOverTime(t *testing.T) {
 	t.Parallel()
 
 	mid := time.Date(2026, 5, 12, 10, 1, 0, 0, time.UTC)
 	q := &stubQuerier{samples: []chclient.Sample{{
 		MetricName: "",
-		// Matrix-shape SQL projects `map('__name__', 'avg_over_time')`
-		// for ungrouped queries (see wrapMetricsForSample); stub mimics
-		// the cursor's surfaced Labels map.
-		Labels:    map[string]string{"__name__": "avg_over_time"},
+		// Matrix-shape SQL projects `map('p', '0.95')` for the
+		// single-phi quantile branch — wrapMetricsForSample injects
+		// the inline-literal phi as the wire label, mirroring Tempo's
+		// HistogramAggregator emit shape.
+		Labels:    map[string]string{"p": "0.95"},
 		Timestamp: mid,
-		Value:     42.0,
+		Value:     0.5,
 	}}}
 	srv := newServer(q, "v1.0.0-test")
 	t.Cleanup(srv.Close)
 
-	u := metricsQueryRangeURL(srv.URL, "{} | avg_over_time(duration)", map[string]string{
+	u := metricsQueryRangeURL(srv.URL, "{} | quantile_over_time(duration, 0.95)", map[string]string{
 		"start": fixtureStartUnix,
 		"end":   fixtureEndUnix,
 		"step":  "60s",
@@ -355,20 +445,44 @@ func TestMetricsQueryRange_ZeroFillSkippedForAvgOverTime(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
 	}
+
 	var body tempo.MetricsQueryRangeResponse
 	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
 	if len(body.Series) != 1 {
-		t.Fatalf("expected 1 series, got %d", len(body.Series))
+		t.Fatalf("expected 1 series, got %d: %+v", len(body.Series), body)
 	}
 	s := body.Series[0]
-	if len(s.Samples) != 1 {
-		t.Errorf("expected 1 observed sample for avg_over_time (no zero-fill), got %d: %+v",
-			len(s.Samples), s.Samples)
+	if len(s.Samples) != 4 {
+		t.Fatalf("expected 4 samples (1 observed + 3 zero-fill), got %d: %+v", len(s.Samples), s.Samples)
 	}
-	if s.Samples[0].Value != 42.0 {
-		t.Errorf("expected observed sample value 42, got %v", s.Samples[0].Value)
+	// Samples MUST be sorted ascending by timestamp and the observed
+	// sample's value must survive the fill verbatim. Missing anchors
+	// land at 0 (Tempo HistogramAggregator parity).
+	wantValues := []float64{0.0, 0.5, 0.0, 0.0}
+	for i, want := range wantValues {
+		if s.Samples[i].Value != want {
+			t.Errorf("sample[%d].Value = %v, want %v (full stream: %+v)", i, s.Samples[i].Value, want, s.Samples)
+		}
+	}
+	for i := 1; i < len(s.Samples); i++ {
+		if s.Samples[i-1].TimestampMs >= s.Samples[i].TimestampMs {
+			t.Errorf("samples not sorted ascending: %+v", s.Samples)
+		}
+	}
+	// Sample timestamps must exactly cover the matrix anchor grid the
+	// chsql emitter produced — `end - i*step` for i in [0, N). Verify
+	// the first / last anchors line up with fixtureStartUnix /
+	// fixtureEndUnix so the wire grid aligns with what Tempo returns
+	// for the same request.
+	startMs := mustParseUnix(t, fixtureStartUnix).UnixMilli()
+	endMs := mustParseUnix(t, fixtureEndUnix).UnixMilli()
+	if s.Samples[0].TimestampMs != startMs {
+		t.Errorf("first sample ts = %d, want fixtureStart=%d", s.Samples[0].TimestampMs, startMs)
+	}
+	if s.Samples[len(s.Samples)-1].TimestampMs != endMs {
+		t.Errorf("last sample ts = %d, want fixtureEnd=%d", s.Samples[len(s.Samples)-1].TimestampMs, endMs)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Extend `zeroFillMatrixGrid` to also fire for `MetricsOpQuantileOverTime`, closing the `metrics_quantile_over_time_p95` compat case that diffed `samples count tempo=121 vs cerberus=3` after #562 unblocked the per-phi label shape.
- Update the test matrix to cover the contract: count/rate/quantile zero-fill the full anchor grid; sum/avg/min/max_over_time keep the NaN-skip parity with Tempo's `OverTimeAggregator`.

## Root cause

Tempo's `HistogramAggregator.Results` (`pkg/traceql/engine_metrics.go`) explicitly seeds empty intervals with `0.0` rather than NaN:

```go
if len(in.hist[i].Buckets) == 0 {
    ts.Values[i] = 0.0
    continue
}
```

`SeriesSet.ToProto` then only skips a sample if its value is `math.NaN`, so 0.0 survives and reaches the wire — one sample per matrix anchor. Cerberus's matrix SQL only emits a row per (group, anchor) pair when at least one span lands in `(anchor_ts - range, anchor_ts]`, so without a post-step fill the response loses every empty bucket and the differ flags the cardinality gap.

The `*_over_time` path is the inverse: `OverTimeAggregator` initialises `val=NaN`, `ToProto` NaN-skips, so cerberus's observed-only emission already matches Tempo — no fill needed.

## Implementation

- New helper `metricsOpZeroFillsEmptyBuckets` centralises the predicate (count/rate/quantile → fill; sum/avg/min/max → skip).
- `zeroFillMatrixGrid` doc-comment + handler comment reorganised to call out the two upstream Tempo code paths (`StepAggregator` and `HistogramAggregator.Results`) that drive the zero-fill contract.
- Tests:
  - Split the old `TestMetricsQueryRange_ZeroFillSkippedForAvgOverTime` into a table-driven `TestMetricsQueryRange_ZeroFillSkippedForOverTimeAggs` covering all four NaN-skip aggs (sum/avg/min/max).
  - Add `TestMetricsQueryRange_ZeroFillQuantileOverTime` asserting the 4-anchor emit (1 observed + 3 zero-fill) for a 3-minute window @ 60s step, mirroring the existing `TestMetricsQueryRange_ZeroFillCountOverTime` shape.

## Expected compat delta

`compatibility/tempo` smoke corpus: `metrics_quantile_over_time_p95` moves from DIFF (`samples count tempo=121 vs cerberus=3` + `sample[0] ts` divergence) to PASS, with the per-anchor 0.0 fill aligning the cerberus output to Tempo's `HistogramAggregator.Results` shape. Other metrics_range cases (rate/count/sum/avg/min/max) keep their current parity status.

## Test plan

- [ ] CI `check` (unit tests) passes on the new + renamed zero-fill tests
- [ ] CI `lint` passes (gofumpt-formatted)
- [ ] Local: `compatibility/tempo` smoke shows `metrics_quantile_over_time_p95: PASS` (informational; runs nightly + manual)