### PR TITLE
chore(harness/loki-compat): remove stale should_skip entries citing shipped features

### DIFF
--- a/compatibility/loki/cerberus-test-queries.yml
+++ b/compatibility/loki/cerberus-test-queries.yml
@@ -17,21 +17,25 @@
 #
 # Suites covered by `<suite>/` (per docs/loki-compliance-plan.md PR 6):
 #
-#   - fast/        — vendored verbatim in PR 2; selector-vocabulary skips
-#                    documented since 2026-05-15 pending a future seed
-#                    expansion.
+#   - fast/        — vendored verbatim in PR 2; one upstream-pinned
+#                    `skip: true` row remains.
 #   - regression/  — vendored in PR 6 (this file). Most entries now run
-#                    against cerberus; the remaining skips cite the
-#                    specific gap they hit (`| json`/`| regexp` parser
-#                    stages, `detected_level` structured-metadata label,
-#                    or upstream-pinned `skip: true` rows). `| logfmt`,
-#                    `| unwrap`, range aggregations on unwrapped values,
+#                    against cerberus; the remaining skips are upstream-
+#                    pinned `skip: true` rows, reference-side
+#                    cardinality rejections (HTTP 400, 500-series
+#                    guard), or seed-gap entries pending seeder
+#                    expansion. `| json`, `| logfmt`, `| regexp`,
+#                    `| pattern`, `| unpack`, `| drop`, `| keep`,
+#                    `| unwrap`, `detected_level` injection / filtering,
+#                    range aggregations on unwrapped values,
 #                    range-aggregation `by`/`without` grouping, and
 #                    numeric/duration/bytes label filters are all wired
-#                    so entries that only needed those have been dropped.
+#                    so entries that only needed those have been
+#                    dropped.
 #   - exhaustive/  — vendored in PR 6 (this file). Same posture as
-#                    regression/: most entries lifted, residual skips cite
-#                    the surviving feature gap.
+#                    regression/: most entries lifted, residual skips
+#                    are upstream-pinned, seed-gap, or reference-side
+#                    cardinality rejections.
 #
 # Maintenance:
 #
@@ -51,35 +55,18 @@
 
 # Why parts of the corpus remain skipped:
 #
-#   The fast/ basic-selector and simple-metrics (count_over_time, count
-#   with line filter) entries were unskipped after the seed expansion added
-#   multi-label streams, structured metadata, and multi-format log lines.
-#   The remaining fast/ entries require LogQL features cerberus has not
-#   yet implemented (detected_level filter, | json parser stage).
-#   The regression/ + exhaustive/ slices were originally enrolled in
-#   bulk; entries that only depended on features that have since landed
-#   were dropped. Surviving skips fall into:
+#   The fast/ basic-selector and simple-metrics entries were unskipped
+#   after the seed expansion added multi-label streams, structured
+#   metadata, and multi-format log lines. The regression/ + exhaustive/
+#   slices were originally enrolled in bulk; entries that only depended
+#   on features that have since landed were dropped. Surviving skips
+#   fall into three buckets:
 #
-#     - `| unpack` / `| pattern` — post-fetch (cerberus supports parse-only)
-#     - `| line_format` / `| label_format` — landed via #128/#130
-#     - `| decolorize` — landed
-#     - `| logfmt` (bare + typed `| logfmt foo="bar"`) — landed via
-#       extractKeyValuePairs lowering.
-#     - `| json` / `| regexp` / `| json field=...` — pending chsql
-#       JSONExtract helpers.
-#     - `| drop` / `| keep` — landed as post-fetch label projection.
-#     - Numeric / duration / bytes label filters — landed via
-#       `toFloat64OrZero` / `parseTimeDelta` / `parseReadableSize` on the
-#       parser-extracted label string.
-#     - `| unwrap` (bare + `duration(...)` / `duration_seconds(...)` /
-#       `bytes(...)`) — landed; per-row Value built from the live
-#       labelsExpr the same way `| logfmt` exposes parsed keys.
-#     - Range aggregations on unwrapped values (sum_over_time,
-#       avg_over_time, min/max/stddev/stdvar_over_time, and
-#       quantile_over_time) — landed; reuse the same chsql range-window
-#       emitters the PromQL head ships.
-#     - `by`/`without` grouping on range aggregations — landed; inner
-#       Project synthesises a `map(...)` / `mapFilter(...)` group key.
+#     - Upstream-pinned `skip: true` rows — the vendored corpus marks
+#       these as unsupported by Loki's own v2 engine (stddev_over_time,
+#       quantile_over_time, numeric label filters on certain shapes,
+#       dataobj-engine schema gap). No reference baseline to diff
+#       against.
 #     - Reference-side cardinality rejections — a handful of `| unwrap`d
 #       range-aggregation entries fan a high-cardinality logfmt stream
 #       past reference Loki's 500-series-per-query guard. The reference
@@ -88,100 +75,73 @@
 #       those rows are excluded from the compat denominator as
 #       upstream-side rejections rather than counted as cerberus parity
 #       gaps. Each entry below documents the exact query shape.
+#     - Seed-gap entries — labels or log-line keywords the seeder
+#       doesn't yet emit; pending a seeder expansion.
+#
+#   The following LogQL features are wired in cerberus and no longer
+#   gate any skip:
+#
+#     - `| unpack` / `| pattern` — post-fetch (cerberus supports parse-only)
+#     - `| line_format` / `| label_format`
+#     - `| decolorize`
+#     - `| logfmt` (bare + typed `| logfmt foo="bar"`)
+#     - `| json` (bare + typed `| json field="path"`)
+#     - `| regexp`
+#     - `| drop` / `| keep` (post-fetch label projection)
+#     - `detected_level` injection + `| detected_level=...` filtering
+#     - Numeric / duration / bytes label filters
+#     - `| unwrap` (bare + `duration(...)` / `duration_seconds(...)` /
+#       `bytes(...)`)
+#     - Range aggregations on unwrapped values (sum_over_time,
+#       avg_over_time, min/max_over_time, etc.)
+#     - `by`/`without` grouping on range aggregations
 #
 # Resolution path (per docs/loki-compliance-plan.md PR 6):
 #
 #   - PR 6 vendored the regression/ + exhaustive/ subdirs verbatim and
 #     enrolled every entry. As each LogQL feature lands, the matching
-#     overlay rows are dropped (or rewritten with a tighter rationale if
-#     a residual gap remains, e.g. structured-metadata `detected_level`).
+#     overlay rows are dropped and CI verifies the diff is clean.
 #   - The seed expansion now writes multi-label streams with
-#     JSON/logfmt/unstructured lines, structured metadata (detected_level),
-#     and error keywords (failed/refused). Entries that only needed
-#     matching selectors have been unskipped.
+#     JSON/logfmt/unstructured lines, structured metadata
+#     (detected_level), and error keywords (failed/refused). Entries
+#     that only needed matching selectors have been unskipped.
 
 should_skip:
-  # fast/ — entries still skipped require unimplemented LogQL features (detected_level filters, | json, | logfmt):
-  - source: "fast/simple-metrics.yaml#Count with error/warn filter"
-    reason: "Requires `| detected_level=~\"error|warn\"` filter; cerberus does not yet support structured-metadata label filters in LogQL pipe expressions."
-    since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6"
-  - source: "fast/simple-metrics.yaml#Rate with error/warn filter"
-    reason: "Requires `| detected_level=~\"error|warn\"` filter; cerberus does not yet support structured-metadata label filters in LogQL pipe expressions."
-    since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6"
-  # fast/structured-metadata — requires detected_level filter support and/or parser stages.
-  - source: "fast/structured-metadata.yaml#Structured metadata error level filter"
-    reason: "Requires `| detected_level=\"error\"` structured-metadata filter; cerberus does not yet support structured-metadata label filters in LogQL pipe expressions. Seeder now writes detected_level."
-    since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6"
-  - source: "fast/structured-metadata.yaml#Logfmt parsing with structured metadata filter"
-    reason: "`| logfmt` is now supported (extractKeyValuePairs lowering); this query also filters on `detected_level` structured metadata, which cerberus does not yet support."
-    since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6 (structured-metadata)"
-  - source: "fast/structured-metadata.yaml#Logfmt parsing with structured metadata filter first"
-    reason: "`| logfmt` is now supported; the remaining blocker is `detected_level` structured-metadata filtering."
-    since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6 (structured-metadata)"
-  - source: "fast/structured-metadata.yaml#JSON parsing with structured metadata filter"
-    reason: "Cerberus does not yet wire the `| json` parser stage (lower.go JSONExpressionParserExpr returns 'not yet supported'). Also requires `detected_level` + JSON-shaped log lines (seeder emits logfmt)."
-    since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6 (`| json` parser)"
+  # fast/structured-metadata — entry kept here is upstream-pinned
+  # (`skip: true` in the vendored corpus) so that a future upstream
+  # flip doesn't silently re-enable parity diffing on cerberus before
+  # the dataobj-engine baseline is revisited.
   - source: "fast/structured-metadata.yaml#JSON parsing with structured metadata filter first"
-    reason: "Upstream already pins `skip: true` (dataobj-engine schema gap). Listed explicitly so a future upstream `skip: false` flip doesn't silently re-enable on cerberus before the `| json` parser lands."
+    reason: "Upstream already pins `skip: true` (dataobj-engine schema gap). Listed explicitly so a future upstream `skip: false` flip doesn't silently re-enable on cerberus without revisiting the dataobj-engine baseline."
     since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6 (`| json` parser)"
+    jira:  "docs/loki-compliance-plan.md PR 6 (upstream skip)"
 
-  # regression/drilldown-patterns.yaml — `| json` parser stage remains
-  # the only blocker now that `| unwrap` + range-aggregation grouping land.
-  - source: "regression/drilldown-patterns.yaml#Basic drilldown with json and logfmt parsing"
-    reason: "Uses `| json | logfmt | drop` — `| logfmt` and `| drop` are supported, but `| json` is not yet wired (internal/logql/lower.go)."
-    since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6 (`| json` parser)"
-  - source: "regression/drilldown-patterns.yaml#Drilldown with error level filter"
-    reason: "Same as Basic drilldown — `| json` parser is the remaining blocker."
-    since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6 (`| json` parser)"
-  - source: "regression/drilldown-patterns.yaml#Drilldown with error or warn level filter"
-    reason: "Same as Basic drilldown — `| json` parser is the remaining blocker."
-    since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6 (`| json` parser)"
-  - source: "regression/drilldown-patterns.yaml#Drilldown count with complex filters"
-    reason: "Uses `| detected_level=... or detected_level=... |~ ... | json | logfmt | drop | level=~...` — `| logfmt` / `| drop` are supported, but `| json` and the complex label-filter or-chain over structured metadata remain unsupported."
-    since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6 (`| json` parser)"
-
-  # regression/metric-queries.yaml — most unwrap entries now run; the
-  # remaining entries are the upstream-pinned `HTTP status code
-  # distribution` row plus an entry where reference Loki itself
-  # rejects the query with HTTP 400 (cardinality guard at 500 series).
+  # regression/metric-queries.yaml — one upstream-pinned row plus a
+  # reference-side cardinality rejection (HTTP 400, 500-series guard).
   - source: "regression/metric-queries.yaml#HTTP status code distribution"
-    reason: "Upstream pins `skip: true` (JSONParserErr on generated data). `| json` parser is also unwired on cerberus."
+    reason: "Upstream pins `skip: true` (JSONParserErr on generated data). No reference baseline to diff against."
     since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6 (`| json` parser)"
+    jira:  "docs/loki-compliance-plan.md PR 6 (upstream skip)"
   - source: "regression/metric-queries.yaml#Rate of unwrapped values"
     reason: "Reference Loki rejects this query with HTTP 400 `maximum number of series (500) reached for a single query`. The unwrapped rate on the seeded fixture exceeds the upstream cardinality guard, so the case has no reference baseline to diff against — excluded from the compat denominator as an upstream-side rejection, not a cerberus parity gap."
     since: "2026-05-19"
     jira:  "compatibility/loki/cerberus-test-queries.yml (reference cardinality rejection)"
 
-  # regression/structured-metadata.yaml — `detected_level` + `| json`
-  # parsers are the remaining blockers.
+  # regression/structured-metadata.yaml — surviving entries are
+  # upstream-pinned (`skip: true` on Loki's v2 engine) and seed-gap
+  # entries pending seeder expansion.
   - source: "regression/structured-metadata.yaml#Combined line and metadata filter"
     reason: "Requires `detected_level` structured metadata; seeder writes none."
     since: "2026-05-15"
     jira:  "docs/loki-compliance-plan.md PR 6"
   - source: "regression/structured-metadata.yaml#JSON parsing with duration filter and structured metadata"
-    reason: "Upstream pins `skip: true` (numeric `> 0.1` label filter unsupported by v2 engine). Cerberus also requires the `| json` parser to feed the numeric label."
+    reason: "Upstream pins `skip: true` (numeric `> 0.1` label filter unsupported by Loki's v2 engine on this shape)."
     since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6 (`| json` parser)"
-  - source: "regression/structured-metadata.yaml#Logfmt parsing with level filter"
-    reason: "`| logfmt | level=\"error\" | detected_level=\"error\"` — `| logfmt` is supported, but `detected_level` structured-metadata filtering is not yet wired."
-    since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6 (structured-metadata)"
+    jira:  "docs/loki-compliance-plan.md PR 6 (upstream skip)"
   - source: "regression/structured-metadata.yaml#Drilldown pattern with case-insensitive error search"
-    reason: "Upstream pins `skip: true` (numeric `>= 500` label filter). Cerberus also needs the `| json` parser for the upstream pipeline."
+    reason: "Upstream pins `skip: true` (numeric `>= 500` label filter unsupported by Loki's v2 engine on this shape)."
     since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6 (`| json` parser)"
+    jira:  "docs/loki-compliance-plan.md PR 6 (upstream skip)"
   - source: "regression/structured-metadata.yaml#Drilldown with failed search and error level"
     reason: "Requires `detected_level` structured metadata + 'failed' keyword in log content; seeder writes neither."
     since: "2026-05-15"
@@ -219,23 +179,16 @@ should_skip:
     since: "2026-05-15"
     jira:  "docs/loki-compliance-plan.md PR 6 (seed gap)"
 
-  # exhaustive/unwrap-aggregations.yaml — `| json`-based,
-  # upstream-pinned, and reference-side cardinality-rejection entries
-  # remain; everything else now runs. The cardinality-rejection entries
-  # (HTTP 400 `maximum number of series (500) reached`) all share the
-  # same shape: an `| unwrap`d range aggregation against a high-fan-out
-  # logfmt stream selector that drives the reference Loki past its
-  # 500-series-per-query guard. Each case has no reference baseline to
-  # diff against, so it's excluded from the compat denominator as an
-  # upstream-side rejection — not a cerberus parity gap.
-  - source: "exhaustive/unwrap-aggregations.yaml#Rate of unwrapped values - no grouping"
-    reason: "`rate(... | json | unwrap duration_ms)` — `| json` parser is not yet wired."
-    since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6 (`| json` parser)"
-  - source: "exhaustive/unwrap-aggregations.yaml#Sum over time - no grouping"
-    reason: "`sum_over_time(... | json | unwrap duration_ms)` — `| json` parser is the remaining blocker."
-    since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6 (`| json` parser)"
+  # exhaustive/unwrap-aggregations.yaml — surviving entries are
+  # upstream-pinned (`skip: true` on Loki's v2 engine) and
+  # reference-side cardinality-rejection entries. The cardinality
+  # rejections (HTTP 400 `maximum number of series (500) reached`)
+  # all share the same shape: an `| unwrap`d range aggregation
+  # against a high-fan-out logfmt stream selector that drives the
+  # reference Loki past its 500-series-per-query guard. Each case
+  # has no reference baseline to diff against, so it's excluded from
+  # the compat denominator as an upstream-side rejection — not a
+  # cerberus parity gap.
   - source: "exhaustive/unwrap-aggregations.yaml#Standard variance over time"
     reason: "Upstream pins `skip: true` (stddev_over_time / stdvar_over_time unsupported by Loki's v2 engine)."
     since: "2026-05-15"


### PR DESCRIPTION
## Summary

Prunes 13 stale `should_skip` entries from `compatibility/loki/cerberus-test-queries.yml` whose cited gaps have since shipped. The overlay now lets the harness diff those cases live; remaining diffs become real signal we can act on instead of hidden bypass.

- `| json` / `| logfmt` / `| regexp` / `| pattern` / `| unpack` / `| drop` / `| keep` parser + projection stages are wired in `internal/logql/lower.go`.
- `detected_level` injection (always-on for log streams) + `| detected_level=...` filtering are wired (PR #545 / PR #560).
- Range aggregations (`count_over_time` / `sum_over_time` / `rate` / `avg_over_time` / `min/max_over_time` / `quantile_over_time`) with `by` / `without` grouping and numeric / duration / bytes label filters are all live.
- Comments restructured to call out the three remaining buckets: upstream-pinned `skip: true`, reference-side cardinality rejections (HTTP 400, 500-series guard), and seed-gap entries pending a separate seeder expansion.

## Entries removed (13)

- `fast/simple-metrics.yaml#Count with error/warn filter` (`| detected_level=~`)
- `fast/simple-metrics.yaml#Rate with error/warn filter` (`| detected_level=~`)
- `fast/structured-metadata.yaml#Structured metadata error level filter` (`| detected_level=`)
- `fast/structured-metadata.yaml#Logfmt parsing with structured metadata filter` (`| logfmt` + `detected_level`)
- `fast/structured-metadata.yaml#Logfmt parsing with structured metadata filter first` (`| logfmt` + `detected_level`)
- `fast/structured-metadata.yaml#JSON parsing with structured metadata filter` (`| json` + `detected_level`)
- `regression/drilldown-patterns.yaml#Basic drilldown with json and logfmt parsing` (`| json`)
- `regression/drilldown-patterns.yaml#Drilldown with error level filter` (`| json`)
- `regression/drilldown-patterns.yaml#Drilldown with error or warn level filter` (`| json`)
- `regression/drilldown-patterns.yaml#Drilldown count with complex filters` (`| json` + `detected_level`)
- `regression/structured-metadata.yaml#Logfmt parsing with level filter` (`| logfmt` + `detected_level`)
- `exhaustive/unwrap-aggregations.yaml#Rate of unwrapped values - no grouping` (`| json`)
- `exhaustive/unwrap-aggregations.yaml#Sum over time - no grouping` (`| json`)

## Entries kept (32)

Per the audit policy:

- 1 upstream `skip: true` in `fast/`
- 7 upstream `skip: true` / reference cardinality rejections in `regression/` (1 fast-suite + 2 metric-queries + upstream-pinned regression rows)
- 6 seeder-gap entries in `regression/structured-metadata.yaml` (3) + `exhaustive/aggregations.yaml` (5+1) pending seeder expansion
- 10 upstream `skip: true` rows in `exhaustive/unwrap-aggregations.yaml` (`stddev_over_time` / `quantile_over_time`)
- 1 seed-gap (`Without multiple labels`) + 7 reference cardinality rejections in `exhaustive/unwrap-aggregations.yaml`

## Expected denominator delta

The compat harness will now diff 13 additional cases against reference Loki. Outcomes split into:

- PASS: rows we can already round-trip cleanly.
- DIFF: real parity issues, surfaced as actionable follow-ups (no longer hidden).
- ERROR: cases that fail wire-side; the runner records these so they can be triaged.

## Test plan

- [ ] CI `check` + `lint` pass on the new branch.
- [ ] Manual `compatibility/loki` workflow dispatch (informational) — observe the new denominator and any surfaced DIFFs.
- [ ] File follow-up PRs for any real DIFFs that surface from the now-diff-able cases.