### PR TITLE
fix(logql): surface parser-stage extracted labels as stream dimensions in output

### DIFF
--- a/internal/logql/lang.go
+++ b/internal/logql/lang.go
@@ -212,8 +212,27 @@ func (l *Lang) ProjectSamples(plan chplan.Node, meta engine.Meta) chplan.Node {
 	// restores stream-identity parity for bare selectors, line
 	// filters, label filters on unrelated keys, and parser-stage
 	// queries (`| logfmt`, `| json`, `| regexp ...`).
+	//
+	// When the parsed pipeline carries a SQL-side parser stage
+	// (`| logfmt`, `| json`, `| regexp ...`, typed-variants), the
+	// projection swaps the bare `ResourceAttributes` column for the
+	// pipeline's final labels-map expression (see [PipelineLabelsExpr])
+	// so each row carries the union of stream-selector labels and
+	// parser-extracted keys. [toStreamsWithTransform] groups by the
+	// projected label set, so unique (resource-label, extracted-key)
+	// tuples land in distinct Streams — matching reference Loki's
+	// stream-identity contract. Without this swap the projection only
+	// surfaces ResourceAttributes and a query like
+	// `{cluster="c"} | logfmt` collapses hundreds of upstream-Loki
+	// streams into a single one, regressing the loki-compat diff.
+	expr, _ := meta.Extra["expr"].(syntax.Expr)
 	attrsExpr := chplan.Expr(&chplan.ColumnRef{Name: s.ResourceAttributesColumn})
-	if expr, _ := meta.Extra["expr"].(syntax.Expr); queryShouldSurfaceDetectedLevel(expr) {
+	if HasParserStage(expr) {
+		if parsed, err := PipelineLabelsExpr(expr, s); err == nil && parsed != nil {
+			attrsExpr = parsed
+		}
+	}
+	if queryShouldSurfaceDetectedLevel(expr) {
 		attrsExpr = withDetectedLevel(s, attrsExpr)
 	}
 	return &chplan.Project{

--- a/internal/logql/lang_test.go
+++ b/internal/logql/lang_test.go
@@ -557,6 +557,152 @@ func TestProjectSamples_LineFilterQuerySurfacesDetectedLevel(t *testing.T) {
 	}
 }
 
+// TestProjectSamples_ParserStageSurfacesExtractedLabels pins the
+// parser-stage label surface — queries with `| logfmt`, `| json`,
+// `| regexp ...`, or their typed-variants MUST project the merged
+// (resource-label, extracted-key) map as `Attributes`, not just the
+// raw ResourceAttributes column.
+//
+// Root cause this guards against: cerberus previously projected
+// `mapConcat(ResourceAttributes, detected_level_map)` for every log
+// query — losing the parser-extracted keys that the labels-merge
+// (`| logfmt` → `mapConcat(ResourceAttributes, extractKeyValuePairs)`)
+// only used for WHERE-side label filters. Downstream
+// `toStreamsWithTransform` groups by the projected label set, so
+// without the merged labels it collapsed reference Loki's hundreds
+// of streams (one per unique extracted-key tuple) into single-digit
+// counts in the loki-compat differential.
+//
+// The assertion drills into the nested mapConcat: the OUTER wrap is
+// the `withDetectedLevel` mapConcat; its first argument MUST be the
+// parser-merge mapConcat whose own first argument is the raw
+// ResourceAttributes column. A flat `mapConcat(ResourceAttributes,
+// detected_level_map)` would mean the parser-stage labels never
+// landed on the row's Attributes — the regression this test pins.
+func TestProjectSamples_ParserStageSurfacesExtractedLabels(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelLogs()
+	l := &logql.Lang{Schema: s}
+
+	for _, q := range []string{
+		// Bare logfmt: extracts all `key=value` pairs.
+		`{cluster="c1"} | logfmt`,
+		// Bare JSON: extracts all top-level keys.
+		`{cluster="c1"} | json`,
+		// Typed logfmt: extracts named fields only.
+		`{cluster="c1"} | logfmt level="lvl", app="application"`,
+		// Typed JSON: extracts named JSON paths only.
+		`{cluster="c1"} | json level="lvl", code="status.code"`,
+		// Regexp parser with named captures.
+		`{cluster="c1"} | regexp "(?P<method>\\w+) (?P<path>\\S+)"`,
+	} {
+		t.Run(q, func(t *testing.T) {
+			t.Parallel()
+			expr, err := syntax.ParseExpr(q)
+			if err != nil {
+				t.Fatalf("ParseExpr: %v", err)
+			}
+			plan := &chplan.Scan{Table: s.LogsTable}
+			wrapped := l.ProjectSamples(plan, engine.Meta{
+				IsMetric: false,
+				Extra:    map[string]any{"expr": expr},
+			})
+			proj := wrapped.(*chplan.Project)
+			attrsSlot := proj.Projections[1]
+
+			// Outer wrap is withDetectedLevel's mapConcat. Drill into
+			// arg[0] to find the parser-merge mapConcat. A leaf
+			// ColumnRef there would be the regression: parser-stage
+			// labels never landed on the row's projected Attributes.
+			outer, ok := attrsSlot.Expr.(*chplan.FuncCall)
+			if !ok {
+				t.Fatalf("attributes slot expr: got %T, want *chplan.FuncCall", attrsSlot.Expr)
+			}
+			if outer.Name != "mapConcat" {
+				t.Fatalf("outer FuncCall.Name: got %q, want %q", outer.Name, "mapConcat")
+			}
+			if len(outer.Args) != 2 {
+				t.Fatalf("outer mapConcat args: got %d, want 2", len(outer.Args))
+			}
+			inner, ok := outer.Args[0].(*chplan.FuncCall)
+			if !ok {
+				t.Fatalf("outer arg[0]: got %T, want *chplan.FuncCall (parser-stage "+
+					"merge mapConcat); a bare ColumnRef here means parser-extracted "+
+					"keys are not landing on the row's Attributes — the precise "+
+					"regression that collapsed reference Loki's hundreds of streams "+
+					"per `| logfmt` / `| json` query into a handful on the "+
+					"loki-compat differential", outer.Args[0])
+			}
+			if inner.Name != "mapConcat" {
+				t.Errorf("inner parser-merge FuncCall.Name: got %q, want %q", inner.Name, "mapConcat")
+			}
+		})
+	}
+}
+
+// TestProjectSamples_NoParserStage_KeepsBareResourceAttributes pins the
+// negative path: when the query has no SQL-side parser stage, the
+// projection MUST keep the bare ResourceAttributes column under the
+// outer withDetectedLevel wrap. Regression coverage for the parser-stage
+// branch over-firing on plain selectors / line filters / `| unpack` /
+// `| pattern` (the latter two are Go-side post-fetch stages that the
+// SQL projection should not try to surface).
+func TestProjectSamples_NoParserStage_KeepsBareResourceAttributes(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelLogs()
+	l := &logql.Lang{Schema: s}
+
+	for _, q := range []string{
+		`{cluster="c1"}`,
+		`{cluster="c1"} |= "error"`,
+		`{cluster="c1"} | namespace="ns-0"`,
+		`{cluster="c1"} | unpack`,
+		`{cluster="c1"} | pattern "<method> <path>"`,
+	} {
+		t.Run(q, func(t *testing.T) {
+			t.Parallel()
+			expr, err := syntax.ParseExpr(q)
+			if err != nil {
+				t.Fatalf("ParseExpr: %v", err)
+			}
+			plan := &chplan.Scan{Table: s.LogsTable}
+			wrapped := l.ProjectSamples(plan, engine.Meta{
+				IsMetric: false,
+				Extra:    map[string]any{"expr": expr},
+			})
+			proj := wrapped.(*chplan.Project)
+			attrsSlot := proj.Projections[1]
+			outer, ok := attrsSlot.Expr.(*chplan.FuncCall)
+			if !ok {
+				t.Fatalf("attributes slot expr: got %T, want *chplan.FuncCall "+
+					"(detected_level wrap)", attrsSlot.Expr)
+			}
+			if outer.Name != "mapConcat" {
+				t.Fatalf("outer FuncCall.Name: got %q, want %q", outer.Name, "mapConcat")
+			}
+			// arg[0] must be the bare ResourceAttributes ColumnRef — NOT
+			// another mapConcat. A nested mapConcat would mean the
+			// parser-stage surface is firing on queries that don't have
+			// a SQL-side parser stage.
+			ref, ok := outer.Args[0].(*chplan.ColumnRef)
+			if !ok {
+				t.Fatalf("outer arg[0]: got %T, want *chplan.ColumnRef "+
+					"(the bare ResourceAttributes column when no SQL-side parser "+
+					"stage is present); nesting another mapConcat here would mean "+
+					"the parser-stage surface is over-firing on plain selectors "+
+					"/ line filters / post-fetch parsers (`| unpack`, `| pattern`)",
+					outer.Args[0])
+			}
+			if ref.Name != s.ResourceAttributesColumn {
+				t.Errorf("outer arg[0] ColumnRef.Name: got %q, want %q",
+					ref.Name, s.ResourceAttributesColumn)
+			}
+		})
+	}
+}
+
 // TestProjectSamples_LogQueryWithDetectedLevelFilterTriggersWrap is a
 // focused coverage point for the label-filter reference path — the
 // `| detected_level="error"` form must trigger the wrap even though

--- a/internal/logql/lower.go
+++ b/internal/logql/lower.go
@@ -243,6 +243,116 @@ func lowerPipelineWithLabels(e *syntax.PipelineExpr, s schema.Logs, lc lowerCtx)
 	return &chplan.Filter{Input: inner, Predicate: pred}, labelsExpr, nil
 }
 
+// PipelineLabelsExpr re-walks the parsed LogQL expression and returns the
+// final labels-map expression a log-stream query would project as its
+// per-row Attributes column. The returned shape mirrors the live
+// labelsExpr that [lowerPipelineWithLabels] threads through pipeline
+// stages — the schema's ResourceAttributes column when no parser stage
+// fired, or a `mapConcat(...)` wrapper folding parser-extracted keys
+// onto the prior labels map (see [logfmtMergeLabels] / [jsonBareMergeLabels]
+// / [regexpMergeLabels] / [logfmtExpressionMergeLabels] /
+// [jsonExpressionMergeLabels]).
+//
+// Returns nil when expr is nil, when expr is a non-log shape (metric
+// queries hit a different ProjectSamples branch), or when the pipeline
+// has no parser stage (the caller can fall back to ResourceAttributes
+// directly).
+//
+// Used by [Lang.ProjectSamples]'s log-stream branch to surface
+// parser-extracted keys (`| logfmt`, `| json`, `| regexp ...`) as
+// per-row Attributes so [toStreamsWithTransform] groups one Stream per
+// unique (resource-label, extracted-key) tuple — matching reference
+// Loki's stream-identity contract (PR #570). Without this hook the
+// projection would only carry the raw ResourceAttributes column and a
+// query like `{cluster="c"} | logfmt` would collapse hundreds of
+// reference-Loki streams into a handful, regressing the loki-compat
+// differential.
+//
+// The implementation re-walks rather than re-using the lowering's
+// labelsExpr because Parse → ProjectSamples threads through engine.Meta,
+// not through the Lower call stack, and storing a chplan.Expr in
+// Meta.Extra would tie the engine type to chplan. The walk is cheap
+// (linear in stage count) and the lowering itself is the source-of-truth
+// for the per-stage merge shape — the helpers below dispatch to the
+// same constructors.
+func PipelineLabelsExpr(expr syntax.Expr, s schema.Logs) (chplan.Expr, error) {
+	pipe, ok := expr.(*syntax.PipelineExpr)
+	if !ok {
+		return nil, nil
+	}
+	labelsExpr := chplan.Expr(&chplan.ColumnRef{Name: s.ResourceAttributesColumn})
+	for _, stage := range pipe.MultiStages {
+		merged, err := pipelineStageLabels(stage, s, labelsExpr)
+		if err != nil {
+			return nil, err
+		}
+		if merged != nil {
+			labelsExpr = merged
+		}
+	}
+	return labelsExpr, nil
+}
+
+// pipelineStageLabels returns the post-stage labels-map expression for a
+// single pipeline stage, or nil if the stage doesn't alter the visible
+// label set. Mirrors the `newLabels` branch of [lowerStage] but isolates
+// the labels-only walk from the predicate-side concerns so callers that
+// only need the final labels expression don't pay for predicate
+// construction.
+func pipelineStageLabels(stage syntax.StageExpr, s schema.Logs, labelsExpr chplan.Expr) (chplan.Expr, error) {
+	switch st := stage.(type) {
+	case *syntax.LineParserExpr:
+		switch st.Op {
+		case syntax.OpParserTypeUnpack, syntax.OpParserTypePattern:
+			return nil, nil
+		case syntax.OpParserTypeJSON:
+			return jsonBareMergeLabels(labelsExpr, s), nil
+		case syntax.OpParserTypeRegexp:
+			return regexpMergeLabels(labelsExpr, s, st.Param)
+		}
+		return nil, nil
+	case *syntax.LogfmtParserExpr:
+		return logfmtMergeLabels(labelsExpr, s), nil
+	case *syntax.JSONExpressionParserExpr:
+		return jsonExpressionMergeLabels(labelsExpr, s, st.Expressions)
+	case *syntax.LogfmtExpressionParserExpr:
+		return logfmtExpressionMergeLabels(labelsExpr, s, st.Expressions)
+	}
+	return nil, nil
+}
+
+// HasParserStage reports whether the parsed LogQL expression contains a
+// parser stage (`| logfmt`, `| json`, `| regexp ...`, typed-variants)
+// that the SQL lowering folds into the labels map. Used by
+// [Lang.ProjectSamples] to gate the parser-extracted labels surface —
+// when true, the projection uses [PipelineLabelsExpr]'s output for the
+// Attributes column so per-row labels include extracted keys.
+//
+// `| unpack` and `| pattern` return false: those parsers extract their
+// labels in Go after the rows return (see post_process.go), not in SQL,
+// so the SQL projection has nothing to surface for them — the
+// post-process step mutates the labels map per-row instead.
+func HasParserStage(expr syntax.Expr) bool {
+	pipe, ok := expr.(*syntax.PipelineExpr)
+	if !ok {
+		return false
+	}
+	for _, stage := range pipe.MultiStages {
+		switch st := stage.(type) {
+		case *syntax.LineParserExpr:
+			switch st.Op {
+			case syntax.OpParserTypeJSON, syntax.OpParserTypeRegexp:
+				return true
+			}
+		case *syntax.LogfmtParserExpr,
+			*syntax.JSONExpressionParserExpr,
+			*syntax.LogfmtExpressionParserExpr:
+			return true
+		}
+	}
+	return false
+}
+
 // lowerStage handles one pipeline stage. Returns up to two values:
 //
 //   - pred: a predicate expression to AND into the pipeline filter


### PR DESCRIPTION
## Summary

- `Lang.ProjectSamples` log-stream branch now reads the parser-stage labels-map (`mapConcat(ResourceAttributes, <extracted>)`) into the row's projected `Attributes` column when the parsed pipeline carries `| logfmt`, `| json`, `| regexp ...`, or their typed variants. Without this hook, downstream `toStreamsWithTransform` groups by the bare `ResourceAttributes` and collapses reference Loki's hundreds of streams per `{cluster=\"c\"} | logfmt` query into a handful — the precise regression the loki-compat differential showed as `expected=352 actual=1`, `expected=724 actual=2`, etc.
- New exported helpers `logql.PipelineLabelsExpr` + `logql.HasParserStage` walk the parsed AST and dispatch to the same `*MergeLabels` constructors the lowering uses (`logfmtMergeLabels`, `jsonBareMergeLabels`, `regexpMergeLabels`, `logfmtExpressionMergeLabels`, `jsonExpressionMergeLabels`), so the labels-map shape stays single-source-of-truth.
- Two new layer-1 tests pin the behavior: `TestProjectSamples_ParserStageSurfacesExtractedLabels` (5 parser-stage shapes drill into the nested `mapConcat` to confirm parser-extracted keys land on `Attributes`) and `TestProjectSamples_NoParserStage_KeepsBareResourceAttributes` (5 non-parser shapes confirm the negative path keeps the bare `ResourceAttributes` ColumnRef so the parser-stage surface doesn't over-fire on plain selectors, line filters, `| unpack`, `| pattern`).

## Root cause

Parser stages already produce a `mapConcat(...)` labels expression that subsequent label filters resolve against (see `internal/logql/lower.go::logfmtMergeLabels` and the four sibling constructors). But the labels expression lived only inside the lowering's local `labelsExpr` thread — it never reached the wire-shape projection in `Lang.ProjectSamples`, which always projected the bare `ResourceAttributes` column wrapped with `withDetectedLevel`. So the SQL emitted `SELECT ..., <ResourceAttributes>, ...` and the per-row `Attributes` map only carried stream-selector labels. `toStreamsWithTransform` then groups one Stream per unique label tuple — without parser-extracted keys, every parser-stage query returned 1-4 streams instead of the hundreds reference Loki returns.

## Implementation

- `internal/logql/lower.go` — exports `PipelineLabelsExpr(expr, schema)` and `HasParserStage(expr)`. The former walks the parsed pipeline stages and dispatches each parser stage through `pipelineStageLabels` (a label-only sibling of `lowerStage` that skips predicate construction). `| unpack` / `| pattern` return nil from both — they're Go-side post-fetch parsers, no SQL surface.
- `internal/logql/lang.go::ProjectSamples` — when `HasParserStage(expr)` is true, swaps the bare `ResourceAttributes` ColumnRef for `PipelineLabelsExpr(expr, schema)`'s output before threading through `withDetectedLevel`. Final shape: `mapConcat(mapConcat(ResourceAttributes, parsed), mapFilter(...))` — valid CH SQL, the inner `mapConcat` matches the labels-merge the lowering already emits in WHERE-side label filters.
- `internal/logql/lang_test.go` — two new test functions covering the positive (5 parser-stage shapes) and negative (5 non-parser shapes) paths. The positive drills into the nested `mapConcat` to confirm `outer.Args[0]` is itself a `mapConcat` (the parser-merge) — a leaf `ColumnRef` there would be the regression. The negative confirms `outer.Args[0]` stays a bare `ColumnRef` to `ResourceAttributes` so the parser-stage surface doesn't over-fire on `| unpack` / `| pattern` / plain selectors.

## Expected compat delta

Loki-compat from 47.46% to 65%+, per the PR brief. The exact landing point depends on how many additional `| logfmt` / `| json` cases now match reference Loki's stream identity — the cases the PR fixes are precisely the high-cardinality parser-stage queries (`{cluster=\"cluster-1\"} | logfmt`, `{cluster=\"cluster-1\"} | json`, and their typed-variant siblings).

## Test plan

- [x] `go build ./internal/logql/...` — clean
- [x] `go vet ./internal/logql/...` — clean
- [x] `go test ./internal/logql/...` — 328 tests pass (35 ProjectSamples tests including the 2 new ones)
- [x] `go test ./internal/api/loki/...` — 208 tests pass (no regression in handler tests)
- [ ] Loki-compat lane on push-to-main confirms the differential improves from 47.46% to ≥65%

🤖 Generated with [Claude Code](https://claude.com/claude-code)