### PR TITLE
ci(mutation): switch to taiki-e/install-action for gremlins to fix rate-limit failures

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -59,25 +59,22 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
-      # Official action wraps `gremlins unleash` with the binary
-      # pre-installed and forwards `args` verbatim. Use `--output`
-      # for structured JSON (gremlins exits 0 even when
-      # `--threshold-efficacy` is violated in v0.6.0, so we do the
-      # gating ourselves against the parsed JSON). When upstream
-      # fixes the exit-code behaviour, the jq + threshold check can
-      # be dropped and the action's `args` shortened to
-      # `--threshold-efficacy ${{ matrix.efficacy }} ${{ matrix.scope }}`.
-      - name: gremlins unleash
-        uses: go-gremlins/gremlins-action@v1
-        env:
-          # Auth the action's release-asset download so it doesn't
-          # hit GitHub's 60-req/hour unauthenticated rate limit
-          # (which causes the install step to fail mid-burst, see
-          # run 26120689458).
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Install gremlins via taiki-e/install-action — the generic
+      # Rust/Go-ecosystem installer honours GITHUB_TOKEN natively
+      # for its release-asset fetches, avoiding the 60-req/hour
+      # unauthenticated GitHub API rate limit that the upstream
+      # `go-gremlins/gremlins-action@v1` hit when 6 matrix jobs
+      # queued release-list calls (see run 26129317141 — passing
+      # GITHUB_TOKEN env to the action did not help because the
+      # action does not honour it). Pin to gremlins 0.6.0 exact.
+      # Use `--output` for structured JSON (gremlins exits 0 even
+      # when `--threshold-efficacy` is violated in v0.6.0, so we
+      # do the gating ourselves against the parsed JSON below).
+      - uses: taiki-e/install-action@v2
         with:
-          version: v0.6.0
-          args: --output gremlins.json ${{ matrix.scope }}
+          tool: gremlins@0.6.0
+      - name: gremlins unleash
+        run: gremlins unleash --output gremlins.json ${{ matrix.scope }}
       - name: enforce efficacy threshold
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

- Replace `go-gremlins/gremlins-action@v1` in `.github/workflows/mutation.yml` with `taiki-e/install-action@v2` (installing `gremlins@0.6.0`) plus a plain `run:` step that invokes `gremlins unleash` directly.
- The previous attempt (PR #553) passing `GITHUB_TOKEN` env to the upstream action did not help — `go-gremlins/gremlins-action@v1` does not actually honour the token. Run [26129317141](https://github.com/tsouza/cerberus/actions/runs/26129317141)'s `phase3-optimizer` matrix entry still hit GitHub's 60-req/hour unauthenticated API rate limit when 6 matrix jobs raced release-list calls.
- `taiki-e/install-action@v2` is a JS action that reads `process.env.GITHUB_TOKEN` natively, is widely used + well-maintained, and is the recommended generic Rust/Go-ecosystem installer per the global CI_STEPS guideline.

## Test plan

- [ ] Workflow-only change. The `mutation` workflow runs on push-to-main + nightly + dispatch — once merged, the next push-to-main exercises the new installer across all 7 matrix entries (`phase1` … `phase5-qlcommon`).
- [ ] Verify the downstream `enforce efficacy threshold` step still finds `gremlins.json` with a `.test_efficacy` field (the `--output gremlins.json` flag is unchanged).
- [ ] Spot-check that `gremlins@0.6.0` resolves via `taiki-e/install-action`'s manifest (it lists gremlins as a supported tool with v0.6.0 in the release manifest).