### PR TITLE
fix(api/tempo): reuse Tempo Log2QuantileWithBucket for quantile_over_time matrix

### DIFF
--- a/internal/api/tempo/metrics_phi_label_test.go
+++ b/internal/api/tempo/metrics_phi_label_test.go
@@ -1,7 +1,6 @@
 package tempo
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/tsouza/cerberus/internal/chplan"
@@ -101,13 +100,17 @@ func TestMetricsLabelNames_PhiLabelAddedForMultiQuantile(t *testing.T) {
 	}
 }
 
-// TestWrapMetricsForSample_MultiQuantileAttrsIncludePhi pins the
-// Attributes map's shape: when len(Quantiles) > 1 the projected map
-// must reference both the group columns and the synthetic `__phi__`
-// column produced by the chsql fan-out — surfaced on the wire under
-// the Tempo-canonical `p` key (matching HistogramAggregator's
-// `Label{"p", NewStaticFloat(q)}` per-series label).
-func TestWrapMetricsForSample_MultiQuantileAttrsIncludePhi(t *testing.T) {
+// TestWrapMetricsForSample_QuantileAttrsIncludeBucket pins the
+// Attributes map's shape for the bucket-shape matrix path: every
+// quantile_over_time projection (single or multi-phi, with or without
+// `by(...)`) must reference the group columns plus the synthetic
+// `__bucket` column produced by the chsql matrix-path quantile emitter.
+// The post-processor (`postProcessQuantileBuckets`) consumes the
+// `__bucket` label off each row to drive `Log2QuantileWithBucket`, then
+// strips the label before emitting the per-phi `p="<phi>"` wire shape
+// — so the SQL-side projection key is `__bucket`, not the
+// HistogramAggregator-style `p`.
+func TestWrapMetricsForSample_QuantileAttrsIncludeBucket(t *testing.T) {
 	t.Parallel()
 
 	rw := &chplan.RangeWindow{}
@@ -134,37 +137,44 @@ func TestWrapMetricsForSample_MultiQuantileAttrsIncludePhi(t *testing.T) {
 		t.Fatalf("Attributes expr = %T (%v), want *chplan.FuncCall(map)", attrsExpr, attrsExpr)
 	}
 
-	// Args are (key, value) pairs. The wire key is `p`; the SQL column
-	// alias is the unexported `__phi__` constant — they intentionally
-	// diverge so the wire shape mirrors Tempo while the SQL stream stays
-	// recognisable as the multi-phi fan-out output.
-	foundPKey := false
-	foundPhiCol := false
+	// Args are (key, value) pairs. The SQL-side key is `__bucket`; the
+	// value is `toString(__bucket)` so the row stream can pluck the
+	// bucket-edge float out of `chclient.Sample.Labels` as a string.
+	foundBucketKey := false
+	foundBucketCol := false
 	for i, arg := range call.Args {
-		if lit, ok := arg.(*chplan.LitString); ok && lit.V == "p" {
-			foundPKey = true
+		if lit, ok := arg.(*chplan.LitString); ok && lit.V == "__bucket" {
+			foundBucketKey = true
 			if i+1 < len(call.Args) {
-				if col, ok := call.Args[i+1].(*chplan.ColumnRef); ok && col.Name == "__phi__" {
-					foundPhiCol = true
+				if fc, ok := call.Args[i+1].(*chplan.FuncCall); ok && fc.Name == "toString" {
+					if len(fc.Args) == 1 {
+						if col, ok := fc.Args[0].(*chplan.ColumnRef); ok && col.Name == "__bucket" {
+							foundBucketCol = true
+						}
+					}
 				}
 			}
 		}
+		// The `p` label is synthesised by the post-processor, not by
+		// the wrap-side projection — reject any leak that would
+		// double-tag rows with `p` at the SQL layer.
+		if lit, ok := arg.(*chplan.LitString); ok && lit.V == "p" {
+			t.Errorf("quantile wrap unexpectedly projects the 'p' label at the SQL layer (post-processor owns it):\n  %v", call.Args)
+		}
 	}
-	if !foundPKey {
-		t.Errorf("map args do not include 'p' literal key:\n  %v", call.Args)
+	if !foundBucketKey {
+		t.Errorf("map args do not include '__bucket' literal key:\n  %v", call.Args)
 	}
-	if !foundPhiCol {
-		t.Errorf("map args do not pair 'p' wire key with the __phi__ SQL ColumnRef")
+	if !foundBucketCol {
+		t.Errorf("map args do not pair '__bucket' wire key with toString(`__bucket`)")
 	}
 }
 
-// TestWrapMetricsForSample_SingleQuantilePLabelLiteral pins the
-// single-phi quantile_over_time contract: the Attributes map carries a
-// `('p', '<phi_str>')` pair with the phi as an inline literal, because
-// the chsql emitter doesn't project a per-row phi column in the
-// single-phi path. The wire shape stays consistent with the multi-phi
-// branch — both surface a `p` label per series.
-func TestWrapMetricsForSample_SingleQuantilePLabelLiteral(t *testing.T) {
+// TestWrapMetricsForSample_SingleQuantileAlsoBucketShape mirrors the
+// multi-phi test above but for a single phi — the bucket-shape SQL
+// route is independent of len(Quantiles) since the post-processor fans
+// rows across all phis after the bucket count has been computed.
+func TestWrapMetricsForSample_SingleQuantileAlsoBucketShape(t *testing.T) {
 	t.Parallel()
 
 	rw := &chplan.RangeWindow{}
@@ -180,38 +190,41 @@ func TestWrapMetricsForSample_SingleQuantilePLabelLiteral(t *testing.T) {
 	proj := node.(*chplan.Project)
 	call := proj.Projections[1].Expr.(*chplan.FuncCall)
 
-	foundPLit := false
-	for i, arg := range call.Args {
-		if lit, ok := arg.(*chplan.LitString); ok && lit.V == "p" {
-			if i+1 < len(call.Args) {
-				if v, ok := call.Args[i+1].(*chplan.LitString); ok && v.V == "0.95" {
-					foundPLit = true
-				}
-			}
+	foundBucket := false
+	for _, arg := range call.Args {
+		if lit, ok := arg.(*chplan.LitString); ok && lit.V == "__bucket" {
+			// Skip the literal key itself; the bucketKey + value pair
+			// is checked together in TestWrapMetricsForSample_QuantileAttrsIncludeBucket.
+			foundBucket = true
 		}
-		// Reject any leak of the SQL-side `__phi__` alias into the
-		// single-phi path — the chsql emitter doesn't project that
-		// column here.
-		if lit, ok := arg.(*chplan.LitString); ok && strings.Contains(lit.V, "__phi__") {
-			t.Errorf("single-quantile map args unexpectedly include __phi__ key: %v", call.Args)
+		// Reject any leak of an SQL-projected `p` literal — the
+		// post-processor owns the per-phi label.
+		if lit, ok := arg.(*chplan.LitString); ok && lit.V == "p" {
+			t.Errorf("single-quantile map args unexpectedly include 'p' literal key: %v", call.Args)
 		}
 		if col, ok := arg.(*chplan.ColumnRef); ok && col.Name == "__phi__" {
 			t.Errorf("single-quantile map args unexpectedly reference __phi__ ColumnRef: %v", call.Args)
 		}
 	}
-	if !foundPLit {
-		t.Errorf("single-phi quantile_over_time: expected ('p', '0.95') literal pair, got %v", call.Args)
+	if !foundBucket {
+		t.Errorf("single-phi quantile_over_time: expected '__bucket' literal key in map args, got %v", call.Args)
 	}
 }
 
-// TestWrapMetricsForSample_UngroupedQuantileSurfacesPLabel pins the
-// ungrouped quantile path: no `by(...)` clause and a single phi must
-// emit `{p="<phi>"}` (NOT `{__name__="quantile_over_time"}`) because
-// Tempo routes quantile_over_time through HistogramAggregator rather
-// than UngroupedAggregator. This is the case the tempo-compat differ
-// caught with `missing_in_a` for the metrics_quantile_over_time_p95
-// case before the fix.
-func TestWrapMetricsForSample_UngroupedQuantileSurfacesPLabel(t *testing.T) {
+// TestWrapMetricsForSample_UngroupedQuantileSurfacesBucket pins the
+// ungrouped quantile path's SQL-layer projection: no `by(...)` clause
+// and any number of phis must emit `('__bucket', toString(__bucket))`
+// — the bucket-shape row stream the post-processor expects — NOT
+// `('__name__', 'quantile_over_time')` (UngroupedAggregator path) and
+// NOT `('p', '<phi>')` (the post-processor synthesises the `p` label
+// after collapsing bucket counts via `Log2QuantileWithBucket`).
+//
+// This regression test guards against any future revival of the
+// SQL-side `p`-label projection — Tempo routes quantile through
+// HistogramAggregator, but the bucket-shape route lets cerberus reuse
+// the upstream quantile algorithm verbatim rather than duplicating it
+// in CH SQL.
+func TestWrapMetricsForSample_UngroupedQuantileSurfacesBucket(t *testing.T) {
 	t.Parallel()
 
 	rw := &chplan.RangeWindow{}
@@ -225,25 +238,32 @@ func TestWrapMetricsForSample_UngroupedQuantileSurfacesPLabel(t *testing.T) {
 	proj := node.(*chplan.Project)
 	call := proj.Projections[1].Expr.(*chplan.FuncCall)
 
-	// Expect exactly one (key, value) pair: ('p', '0.95').
+	// Expect exactly one (key, value) pair: ('__bucket',
+	// toString(__bucket)).
 	if len(call.Args) != 2 {
 		t.Fatalf("ungrouped quantile_over_time: expected 2 map args (one pair), got %d: %v",
 			len(call.Args), call.Args)
 	}
 	key, ok := call.Args[0].(*chplan.LitString)
-	if !ok || key.V != "p" {
-		t.Errorf("Attributes map[0] (key) = %v, want LitString{p}", call.Args[0])
+	if !ok || key.V != "__bucket" {
+		t.Errorf("Attributes map[0] (key) = %v, want LitString{__bucket}", call.Args[0])
 	}
-	val, ok := call.Args[1].(*chplan.LitString)
-	if !ok || val.V != "0.95" {
-		t.Errorf("Attributes map[1] (value) = %v, want LitString{0.95}", call.Args[1])
+	val, ok := call.Args[1].(*chplan.FuncCall)
+	if !ok || val.Name != "toString" {
+		t.Errorf("Attributes map[1] (value) = %v, want toString(...) call", call.Args[1])
 	}
 
-	// And the `__name__` synthetic label MUST NOT appear — that's the
-	// UngroupedAggregator path, which quantile_over_time skips.
+	// Neither the `__name__` UngroupedAggregator label nor the `p`
+	// HistogramAggregator label may appear at the SQL projection layer
+	// — both are owned by other code paths.
 	for _, arg := range call.Args {
-		if lit, ok := arg.(*chplan.LitString); ok && lit.V == "__name__" {
-			t.Errorf("ungrouped quantile_over_time leaked __name__ label: %v", call.Args)
+		if lit, ok := arg.(*chplan.LitString); ok {
+			if lit.V == "__name__" {
+				t.Errorf("ungrouped quantile_over_time leaked __name__ label: %v", call.Args)
+			}
+			if lit.V == "p" {
+				t.Errorf("ungrouped quantile_over_time leaked SQL-side 'p' label (post-processor owns it): %v", call.Args)
+			}
 		}
 	}
 }

--- a/internal/api/tempo/metrics_query_instant.go
+++ b/internal/api/tempo/metrics_query_instant.go
@@ -131,9 +131,18 @@ func (h *Handler) handleMetricsQueryInstant(w http.ResponseWriter, r *http.Reque
 		"traceql", q, "start", start, "end", end, "step", step,
 		"sql", res.SQL, "args", res.Args)
 
+	// quantile_over_time: same bucket-shape → quantile collapse as in
+	// the range handler — Tempo's reference engine routes the instant
+	// shape through the same HistogramAggregator, so the post-processor
+	// runs before the instant projection.
+	samples := res.Samples
+	if metrics.Op == chplan.MetricsOpQuantileOverTime {
+		samples = postProcessQuantileBuckets(samples, metrics)
+	}
+
 	writeEngineHeaders(w, res.Headers)
 	writeJSON(w, http.StatusOK, MetricsQueryInstantResponse{
-		Series: toMetricsInstantSeries(res.Samples, metrics),
+		Series: toMetricsInstantSeries(samples, metrics),
 	})
 }
 

--- a/internal/api/tempo/metrics_query_range.go
+++ b/internal/api/tempo/metrics_query_range.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	upstreamTraceql "github.com/grafana/tempo/pkg/traceql"
+
 	"github.com/tsouza/cerberus/internal/api/format"
 	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/chplan"
@@ -255,7 +257,19 @@ func (h *Handler) handleMetricsQueryRange(w http.ResponseWriter, r *http.Request
 		"traceql", q, "start", start, "end", end, "step", step,
 		"sql", res.SQL, "args", res.Args)
 
-	series := toMetricsSeries(res.Samples, metrics)
+	// quantile_over_time: the matrix SQL emits `(group, anchor, bucket,
+	// count)` tuples; collapse them into the per-(group, phi, anchor)
+	// scalar wire shape via Tempo's `Log2QuantileWithBucket`. The
+	// remainder of the pipeline (toMetricsSeries / zeroFillMatrixGrid)
+	// sees pre-collapsed `chclient.Sample` values where each entry
+	// already carries the synthetic `p=<phi>` label and `Value` is the
+	// per-anchor quantile.
+	samples := res.Samples
+	if metrics.Op == chplan.MetricsOpQuantileOverTime {
+		samples = postProcessQuantileBuckets(samples, metrics)
+	}
+
+	series := toMetricsSeries(samples, metrics)
 	// Zero-fill the matrix step grid for count/rate AND quantile
 	// operators so the response shape matches Tempo's reference
 	// engine_metrics.go. Two distinct upstream code paths converge on a
@@ -362,16 +376,6 @@ func unwrapMetricsAggregate(plan chplan.Node) (*chplan.MetricsAggregate, bool) {
 	return nil, false
 }
 
-// tempoMultiQuantilePhiLabel is the synthetic alias the chsql
-// multi-quantile fan-out projects when MetricsAggregate.Quantiles
-// holds more than one phi. Lockstep with chsql's
-// `metricsMultiQuantilePhiLabel` (range_window.go) — both must agree
-// on the column alias so the handler can read it out of the row
-// stream. The wire-side label key is `tempoQuantileLabel` ("p"),
-// mirroring Tempo's HistogramAggregator (engine_metrics.go) which
-// appends `Label{"p", NewStaticFloat(q)}` to each per-quantile series.
-const tempoMultiQuantilePhiLabel = "__phi__"
-
 // tempoMetricNameLabel mirrors the Prometheus-style `__name__` label
 // Tempo's UngroupedAggregator (engine_metrics.go) attaches to the
 // single series an ungrouped metrics-pipeline query returns. The
@@ -389,14 +393,27 @@ const tempoMultiQuantilePhiLabel = "__phi__"
 // metricsLabelNames branch on Op to honour that.
 const tempoMetricNameLabel = "__name__"
 
+// tempoQuantileBucketLabel mirrors the `__bucket` synthetic label
+// Tempo's HistogramAggregator uses internally on the metrics-engine
+// hot path (pkg/traceql/engine_metrics.go, `internalLabelBucket`).
+// The chsql matrix-path quantile emitter projects each row's
+// power-of-two bucket edge under this label so the post-processor in
+// the Tempo handler can recover the bucket alongside the count and
+// drive `pkg/traceql.Log2QuantileWithBucket` per phi. The
+// post-processor strips this label before emitting the final wire
+// shape — Tempo's reference engine never surfaces `__bucket` to the
+// client; it's purely an internal-routing key.
+const tempoQuantileBucketLabel = "__bucket"
+
 // tempoQuantileLabel mirrors the `p` label Tempo's HistogramAggregator
 // (engine_metrics.go) appends to every series produced by
 // `quantile_over_time(...)`. The label value is the phi formatted via
 // `strconv.FormatFloat('f', -1, 64)` (e.g. 0.95 → "0.95") — matching
 // what the differ in compatibility/tempo extracts from Tempo's
 // `doubleValue` AnyValue via `fmt.Sprint(*anyV.DoubleValue)` and what
-// chsql's `metricsMultiQuantileFanoutFrag` projects via `formatFloat`
-// for the multi-phi fan-out column. Per-phi series are emitted whether
+// the post-processor (`postProcessQuantileBuckets`) writes onto each
+// per-phi series after collapsing the bucket-shape row stream. Per-phi
+// series are emitted whether
 // or not the query carries a `by(...)` clause: ungrouped queries get
 // `{p="<phi>"}` rather than `{__name__="quantile_over_time"}` because
 // Tempo's UngroupedAggregator is not on the quantile path.
@@ -430,28 +447,31 @@ const tempoQuantileLabel = "p"
 // `quantile_over_time` follows the HistogramAggregator path in Tempo
 // (engine_metrics.go: NewHistogramAggregator + Results) rather than
 // UngroupedAggregator, so every output series carries a `p="<phi>"`
-// label and never `__name__="quantile_over_time"`. The single-phi
-// branch injects the phi string as an inline literal because the chsql
-// emitter doesn't project a per-row phi column in that case; the
-// multi-phi branch surfaces the synthetic `__phi__` column produced by
-// the chsql fan-out under the wire-canonical `p` key so each
-// (group × phi) pair becomes its own response series.
+// label and never `__name__="quantile_over_time"`. The matrix SQL
+// emits one row per (group, anchor, bucket) tuple — the chsql side
+// projects each row's power-of-two bucket edge under the synthetic
+// `__bucket` label; the handler's `postProcessQuantileBuckets` then
+// collapses those rows via `traceql.Log2QuantileWithBucket(phi,
+// buckets)` per phi (independent of len(m.Quantiles)) and synthesises
+// the wire `p="<phi>"` label on each emitted series.
 func wrapMetricsForSample(rw *chplan.RangeWindow, m *chplan.MetricsAggregate) chplan.Node {
 	attrAliases := metricsOuterGroupAliases(m.GroupBy, m.GroupByAliases)
 	labelNames := metricsLabelNames(m)
-	multiPhi := len(m.Quantiles) > 1
 	isQuantile := m.Op == chplan.MetricsOpQuantileOverTime
 
 	var attrs chplan.Expr
 	switch {
 	case isQuantile:
-		// quantile_over_time is special: Tempo's HistogramAggregator
-		// appends `Label{"p", NewStaticFloat(q)}` to every per-phi
-		// series, regardless of whether the query has a `by(...)`
-		// clause. The chsql emitter projects a `__phi__` String column
-		// for the multi-phi fan-out, but the single-phi path returns
-		// just the value column — so the handler injects the phi as an
-		// inline literal in that branch.
+		// quantile_over_time emits `(group, anchor, bucket, count)` rows
+		// out of the chsql matrix path — see
+		// `emitRangeWindowMetricsQuantileBuckets`. The post-processor
+		// (`postProcessQuantileBuckets`) folds the per-bucket counts into
+		// Tempo's `Log2QuantileWithBucket` per phi to produce the
+		// per-(group, phi, anchor) wire value. Until that fold happens,
+		// the row stream needs the bucket-edge `__bucket` column
+		// surfaced as a label so the post-processor can pluck it out of
+		// `chclient.Sample.Labels`; the post-processor strips the
+		// `__bucket` label before emitting the final series.
 		args := make([]chplan.Expr, 0, (len(m.GroupBy)+1)*2)
 		for i := range m.GroupBy {
 			args = append(
@@ -463,19 +483,14 @@ func wrapMetricsForSample(rw *chplan.RangeWindow, m *chplan.MetricsAggregate) ch
 				},
 			)
 		}
-		args = append(args, &chplan.LitString{V: tempoQuantileLabel})
-		if multiPhi {
-			args = append(args, &chplan.ColumnRef{Name: tempoMultiQuantilePhiLabel})
-		} else if len(m.Quantiles) == 1 {
-			args = append(args, &chplan.LitString{V: formatPhi(m.Quantiles[0])})
-		} else {
-			// MetricsAggregate.Quantiles is empty — the chsql emitter
-			// would reject this earlier with ErrUnsupported, but
-			// defensively project an empty string so the response shape
-			// stays self-consistent rather than crashing on
-			// args[len-1].
-			args = append(args, &chplan.LitString{V: ""})
-		}
+		args = append(
+			args,
+			&chplan.LitString{V: tempoQuantileBucketLabel},
+			&chplan.FuncCall{
+				Name: "toString",
+				Args: []chplan.Expr{&chplan.ColumnRef{Name: tempoQuantileBucketLabel}},
+			},
+		)
 		attrs = &chplan.FuncCall{Name: "map", Args: args}
 	case len(m.GroupBy) == 0:
 		// Ungrouped non-quantile: emit Tempo's UngroupedAggregator-style
@@ -519,14 +534,140 @@ func wrapMetricsForSample(rw *chplan.RangeWindow, m *chplan.MetricsAggregate) ch
 
 // formatPhi renders a phi value (0 <= phi <= 1) into the wire-format
 // string Tempo's HistogramAggregator surfaces on the `p` label. Mirrors
-// `strconv.FormatFloat(v, 'f', -1, 64)` — what chsql's
-// metricsMultiQuantileFanoutFrag uses for the inline-literal phi
-// strings in the multi-phi fan-out, and what `fmt.Sprint(float64)`
-// returns when the differ stringifies Tempo's `doubleValue` AnyValue.
-// Stable for the phi values cerberus accepts (0 → "0", 0.5 → "0.5",
-// 0.95 → "0.95", 1 → "1").
+// `strconv.FormatFloat(v, 'f', -1, 64)` — what
+// `postProcessQuantileBuckets` writes onto each per-phi series and what
+// `fmt.Sprint(float64)` returns when the differ stringifies Tempo's
+// `doubleValue` AnyValue. Stable for the phi values cerberus accepts
+// (0 → "0", 0.5 → "0.5", 0.95 → "0.95", 1 → "1").
 func formatPhi(v float64) string {
 	return strconv.FormatFloat(v, 'f', -1, 64)
+}
+
+// postProcessQuantileBuckets folds the chsql matrix-path quantile row
+// stream — one row per (group, anchor, bucket) tuple carrying a count
+// and the synthetic `__bucket` label — into the per-(group, phi,
+// anchor) wire shape Tempo's HistogramAggregator emits.
+//
+// For each (group_labels_minus_bucket, anchor) pair, the per-bucket
+// counts feed `pkg/traceql.Log2QuantileWithBucket(phi, buckets)` from
+// the cerberus-accessors Tempo fork — the same power-of-two
+// bucket-interpolation routine `HistogramAggregator.Results` runs
+// upstream. The post-processor then emits one `chclient.Sample` per
+// (group_labels_minus_bucket, phi, anchor) with a synthetic
+// `p="<phi>"` label.
+//
+// Why a post-processor rather than rendering the algorithm as CH SQL:
+// the upstream algorithm is non-trivial (boundary handling for
+// p100, exponential interpolation between bucket maxima, plus an
+// edge-case sample-count rounding rule) and is being tweaked over
+// time in Tempo upstream. Reusing the upstream function via the
+// cerberus-accessors fork keeps the two backends bit-for-bit aligned
+// even as Tempo refines the algorithm.
+//
+// Returns a fresh `[]chclient.Sample`; the input slice is read-only.
+func postProcessQuantileBuckets(samples []chclient.Sample, m *chplan.MetricsAggregate) []chclient.Sample {
+	if len(samples) == 0 || len(m.Quantiles) == 0 {
+		return samples
+	}
+
+	// Group key: (canonical-label-set-minus-bucket, anchor-ts-unix-nanos)
+	// → ordered list of (bucket-edge, count). The canonical key uses the
+	// same separator format format.CanonicalKey produces so series keying
+	// stays consistent with toMetricsSeries downstream.
+	type bucketEntry struct {
+		max   float64
+		count int
+	}
+	type groupKey struct {
+		labelsKey string
+		anchorNS  int64
+	}
+	type groupState struct {
+		labels  map[string]string
+		anchor  time.Time
+		buckets []bucketEntry
+	}
+	groups := map[groupKey]*groupState{}
+	keyOrder := []groupKey{}
+
+	for _, s := range samples {
+		bucketStr, ok := s.Labels[tempoQuantileBucketLabel]
+		if !ok {
+			// Defensive: a row without the synthetic bucket label is
+			// either an upstream chsql-emit bug or a leaked input from
+			// a different code path. Skip the row rather than
+			// double-counting under a zero bucket; the differ surfaces
+			// the missing samples as a count gap, which is the
+			// debuggable signal.
+			continue
+		}
+		bucket, err := strconv.ParseFloat(bucketStr, 64)
+		if err != nil {
+			continue
+		}
+		// Strip the bucket label from the group-identifying set so two
+		// rows that share (group, anchor) but differ in bucket coalesce
+		// into the same group.
+		groupLabels := make(map[string]string, len(s.Labels))
+		for k, v := range s.Labels {
+			if k == tempoQuantileBucketLabel {
+				continue
+			}
+			groupLabels[k] = v
+		}
+		gk := groupKey{
+			labelsKey: format.CanonicalKey(groupLabels),
+			anchorNS:  s.Timestamp.UnixNano(),
+		}
+		g, ok := groups[gk]
+		if !ok {
+			g = &groupState{labels: groupLabels, anchor: s.Timestamp}
+			groups[gk] = g
+			keyOrder = append(keyOrder, gk)
+		}
+		g.buckets = append(g.buckets, bucketEntry{max: bucket, count: int(s.Value)})
+	}
+
+	// Deterministic emission order: sort keyOrder by (labelsKey,
+	// anchorNS) so the post-processed stream is stable run-to-run.
+	sort.Slice(keyOrder, func(i, j int) bool {
+		if keyOrder[i].labelsKey != keyOrder[j].labelsKey {
+			return keyOrder[i].labelsKey < keyOrder[j].labelsKey
+		}
+		return keyOrder[i].anchorNS < keyOrder[j].anchorNS
+	})
+
+	out := make([]chclient.Sample, 0, len(keyOrder)*len(m.Quantiles))
+	for _, gk := range keyOrder {
+		g := groups[gk]
+		// Tempo's Log2QuantileWithBucket walks buckets in ascending
+		// `Max` order — the upstream HistogramAggregator records into a
+		// `Histogram.Buckets` slice in insertion order and the per-
+		// quantile loop assumes ascending Max. Sort here so a row
+		// stream that surfaces buckets in arbitrary CH-internal order
+		// still feeds the algorithm correctly.
+		sort.Slice(g.buckets, func(i, j int) bool {
+			return g.buckets[i].max < g.buckets[j].max
+		})
+		buckets := make([]upstreamTraceql.HistogramBucket, len(g.buckets))
+		for i, b := range g.buckets {
+			buckets[i] = upstreamTraceql.HistogramBucket{Max: b.max, Count: b.count}
+		}
+		for _, phi := range m.Quantiles {
+			value, _ := upstreamTraceql.Log2QuantileWithBucket(phi, buckets)
+			labels := make(map[string]string, len(g.labels)+1)
+			for k, v := range g.labels {
+				labels[k] = v
+			}
+			labels[tempoQuantileLabel] = formatPhi(phi)
+			out = append(out, chclient.Sample{
+				Labels:    labels,
+				Timestamp: g.anchor,
+				Value:     value,
+			})
+		}
+	}
+	return out
 }
 
 // metricsOuterGroupAliases mirrors the unexported chsql.outerGroupAliases:

--- a/internal/api/tempo/metrics_query_range_test.go
+++ b/internal/api/tempo/metrics_query_range_test.go
@@ -411,23 +411,24 @@ func TestMetricsQueryRange_ZeroFillSkippedForOverTimeAggs(t *testing.T) {
 // gap once the label shape stopped masking it).
 //
 // Setup: 3-minute window @ 60s step → 4 anchors (10:00 / 10:01 / 10:02
-// / 10:03). The CH stub returns exactly one row (10:01) carrying the
-// `p="0.95"` HistogramAggregator label cerberus surfaces for the
-// single-phi branch; the handler must surface a 4-sample stream with
+// / 10:03). The CH stub returns exactly one bucket-shape row at the
+// middle anchor (10:01) — the post-processor synthesises the `p="0.95"`
+// label and runs `Log2QuantileWithBucket(0.95, [...])` to produce the
+// per-anchor value; the handler then surfaces a 4-sample stream with
 // the missing three anchors at value 0.
 func TestMetricsQueryRange_ZeroFillQuantileOverTime(t *testing.T) {
 	t.Parallel()
 
 	mid := time.Date(2026, 5, 12, 10, 1, 0, 0, time.UTC)
+	// Single bucket at 0.5s holding 5 samples — Log2QuantileWithBucket
+	// for p=0.95 over a single 0.5s bucket returns the bucket's Max
+	// (0.5) because the per-quantile sample-count walk consumes the
+	// whole bucket and reports `b.Max`.
 	q := &stubQuerier{samples: []chclient.Sample{{
 		MetricName: "",
-		// Matrix-shape SQL projects `map('p', '0.95')` for the
-		// single-phi quantile branch — wrapMetricsForSample injects
-		// the inline-literal phi as the wire label, mirroring Tempo's
-		// HistogramAggregator emit shape.
-		Labels:    map[string]string{"p": "0.95"},
-		Timestamp: mid,
-		Value:     0.5,
+		Labels:     map[string]string{"__bucket": "0.5"},
+		Timestamp:  mid,
+		Value:      5,
 	}}}
 	srv := newServer(q, "v1.0.0-test")
 	t.Cleanup(srv.Close)
@@ -510,14 +511,26 @@ func TestMetricsQueryRange_DurationAggInSeconds(t *testing.T) {
 		// labels mimics the row Labels the matrix SQL projects for this
 		// op. Non-quantile ungrouped ops surface `__name__=<op>` (Tempo
 		// UngroupedAggregator parity); quantile_over_time surfaces
-		// `p=<phi>` (Tempo HistogramAggregator parity).
+		// `__bucket=<float>` (the bucket-shape row stream the
+		// post-processor consumes — Tempo HistogramAggregator wire
+		// shape is synthesised by `postProcessQuantileBuckets`).
 		labels map[string]string
+		// stubValue picks the Value the stub returns. Per-bucket counts
+		// for quantile_over_time are integer-typed (CH `count(1)`); the
+		// other ops carry the metric value directly. Tracked separately
+		// so the quantile post-processor sees a count rather than a
+		// pre-quantile float.
+		stubValue float64
 	}{
-		{"avg_over_time", "{} | avg_over_time(duration)", map[string]string{"__name__": "avg_over_time"}},
-		{"sum_over_time", "{} | sum_over_time(duration)", map[string]string{"__name__": "sum_over_time"}},
-		{"min_over_time", "{} | min_over_time(duration)", map[string]string{"__name__": "min_over_time"}},
-		{"max_over_time", "{} | max_over_time(duration)", map[string]string{"__name__": "max_over_time"}},
-		{"quantile_over_time", "{} | quantile_over_time(duration, 0.95)", map[string]string{"p": "0.95"}},
+		{"avg_over_time", "{} | avg_over_time(duration)", map[string]string{"__name__": "avg_over_time"}, 0.5},
+		{"sum_over_time", "{} | sum_over_time(duration)", map[string]string{"__name__": "sum_over_time"}, 0.5},
+		{"min_over_time", "{} | min_over_time(duration)", map[string]string{"__name__": "min_over_time"}, 0.5},
+		{"max_over_time", "{} | max_over_time(duration)", map[string]string{"__name__": "max_over_time"}, 0.5},
+		// Bucket at 0.5s → Log2QuantileWithBucket(0.95, [{0.5, 5}])
+		// returns 0.5 (the bucket Max, since the per-quantile walk
+		// consumes the whole single bucket and reports b.Max). That's
+		// what surfaces in the Value column of the response sample.
+		{"quantile_over_time", "{} | quantile_over_time(duration, 0.95)", map[string]string{"__bucket": "0.5"}, 5},
 	}
 
 	for _, tc := range cases {
@@ -537,7 +550,7 @@ func TestMetricsQueryRange_DurationAggInSeconds(t *testing.T) {
 				// real ns→s rebase happens server-side in the
 				// emitted SQL and is asserted via assertSQLContains
 				// below.
-				Value: 0.5,
+				Value: tc.stubValue,
 			}}}
 			srv := newServer(q, "v1.0.0-test")
 			t.Cleanup(srv.Close)
@@ -1220,45 +1233,55 @@ func TestMetricsQueryRange_ResourceLabelWireShape(t *testing.T) {
 // (engine_metrics.go::HistogramAggregator.Results), which appends
 // `Label{"p", NewStaticFloat(q)}` to every series — so the
 // tempo-compat differ canonicalises each series under that key. Before
-// this fix cerberus emitted the UngroupedAggregator-style
-// `{__name__="quantile_over_time"}` shape (PR #554) which diverged
-// from Tempo and tripped the differ on `missing_in_a` for
-// metrics_quantile_over_time_p95.
+// the bucket-shape rewrite cerberus delegated quantile computation to
+// CH's `quantile()` aggregate, whose linear interpolation diverged
+// from Tempo's power-of-two histogram. Now the matrix SQL returns
+// `(group, anchor, bucket, count)` tuples and the handler post-processor
+// (`postProcessQuantileBuckets`) calls `Log2QuantileWithBucket` per phi.
 //
 // Covers both ungrouped (`{p="0.95"}`) and grouped
-// (`{resource.service.name="...", p="0.95"}`) wire shapes; the
-// single-phi label value is injected as an inline literal because the
-// chsql single-phi path doesn't project a per-row phi column.
+// (`{resource.service.name="...", p="0.95"}`) wire shapes; the post-
+// processor synthesises the `p` label from `MetricsAggregate.Quantiles`,
+// strips the synthetic `__bucket` label from each row, and emits one
+// series per (group, phi).
 func TestMetricsQueryRange_QuantileOverTimeWireShape(t *testing.T) {
 	t.Parallel()
 
 	ts := time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC)
 
 	cases := []struct {
-		name      string
-		query     string
-		labels    map[string]string
-		wantPairs []tempo.MetricsLabel // ordered, matches metricsLabelNames output
+		name           string
+		query          string
+		stubSamples    []chclient.Sample
+		wantPairs      []tempo.MetricsLabel
+		wantSampleSize int
 	}{
 		{
-			name:   "ungrouped_single_phi",
-			query:  "{} | quantile_over_time(duration, 0.95)",
-			labels: map[string]string{"p": "0.95"},
+			name:  "ungrouped_single_phi",
+			query: "{} | quantile_over_time(duration, 0.95)",
+			stubSamples: []chclient.Sample{
+				{Labels: map[string]string{"__bucket": "0.125"}, Timestamp: ts, Value: 5},
+			},
 			wantPairs: []tempo.MetricsLabel{
 				{Key: "p", Value: "0.95"},
 			},
+			wantSampleSize: 1,
 		},
 		{
 			name:  "grouped_single_phi",
 			query: "{} | quantile_over_time(duration, 0.95) by (resource.service.name)",
-			labels: map[string]string{
-				"resource.service.name": "frontend",
-				"p":                     "0.95",
+			stubSamples: []chclient.Sample{
+				{
+					Labels:    map[string]string{"resource.service.name": "frontend", "__bucket": "0.125"},
+					Timestamp: ts,
+					Value:     5,
+				},
 			},
 			wantPairs: []tempo.MetricsLabel{
 				{Key: "resource.service.name", Value: "frontend"},
 				{Key: "p", Value: "0.95"},
 			},
+			wantSampleSize: 1,
 		},
 	}
 
@@ -1267,12 +1290,7 @@ func TestMetricsQueryRange_QuantileOverTimeWireShape(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			q := &stubQuerier{samples: []chclient.Sample{{
-				MetricName: "",
-				Labels:     tc.labels,
-				Timestamp:  ts,
-				Value:      0.5,
-			}}}
+			q := &stubQuerier{samples: tc.stubSamples}
 			srv := newServer(q, "v1.0.0-test")
 			t.Cleanup(srv.Close)
 
@@ -1315,25 +1333,28 @@ func TestMetricsQueryRange_QuantileOverTimeWireShape(t *testing.T) {
 				if l.Key == "__name__" {
 					t.Errorf("quantile_over_time leaked __name__ label: %+v", gotLabels)
 				}
+				if l.Key == "__bucket" {
+					t.Errorf("quantile_over_time leaked __bucket label to wire: %+v", gotLabels)
+				}
 			}
 
-			// Single-phi quantile MUST NOT use the multi-phi
-			// `qs_array`/`__phi__` SQL fan-out (that would synthesise a
-			// `__phi__` column that downstream wraps into the wire `p`
-			// label per-row instead of via the inline literal).
-			if strings.Contains(q.lastSQL, "qs_array") {
-				t.Errorf("single-phi quantile SQL unexpectedly fans out via qs_array: %s", q.lastSQL)
+			// SQL must take the bucket-shape route — no CH-side
+			// `quantile()` / `quantiles()` call (those would compute
+			// the wrong quantile per Tempo's HistogramAggregator).
+			for _, banned := range []string{"quantile(?)", "quantiles(?", "qs_array"} {
+				if strings.Contains(q.lastSQL, banned) {
+					t.Errorf("matrix quantile SQL must not contain %q: %s", banned, q.lastSQL)
+				}
 			}
 		})
 	}
 }
 
 // TestMetricsQueryRange_MultiQuantileOverTimeWireShape pins the
-// multi-phi quantile_over_time wire shape: the chsql fan-out projects
-// one row per (group, anchor, phi) tuple with the synthetic `__phi__`
-// SQL column carrying the phi string, surfaced on the wire under the
-// Tempo-canonical `p` key. Each phi value becomes its own
-// MetricsSeries.
+// multi-phi quantile_over_time wire shape: the post-processor
+// (`postProcessQuantileBuckets`) fans the bucket-shape row stream out
+// into one series per phi, each carrying a `p="<phi>"` label whose
+// value is `strconv.FormatFloat(phi, 'f', -1, 64)`.
 //
 // Mirrors Tempo's HistogramAggregator emitting one TimeSeries per phi
 // per group (engine_metrics.go::HistogramAggregator.Results) labelled
@@ -1343,13 +1364,14 @@ func TestMetricsQueryRange_MultiQuantileOverTimeWireShape(t *testing.T) {
 
 	ts := time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC)
 
-	// One row per phi — matches what the chsql multi-phi fan-out
-	// (arrayJoin of (phi, value) tuples) projects after the wrap maps
-	// `__phi__` to the wire key `p`.
+	// One bucket-shape row — three distinct power-of-two buckets fed
+	// into the post-processor. The post-processor calls
+	// Log2QuantileWithBucket(phi, buckets) per phi, so three phis →
+	// three per-phi output series sharing the same (empty) group key.
 	q := &stubQuerier{samples: []chclient.Sample{
-		{Labels: map[string]string{"p": "0.5"}, Timestamp: ts, Value: 0.1},
-		{Labels: map[string]string{"p": "0.9"}, Timestamp: ts, Value: 0.2},
-		{Labels: map[string]string{"p": "0.99"}, Timestamp: ts, Value: 0.3},
+		{Labels: map[string]string{"__bucket": "0.125"}, Timestamp: ts, Value: 5},
+		{Labels: map[string]string{"__bucket": "0.25"}, Timestamp: ts, Value: 3},
+		{Labels: map[string]string{"__bucket": "0.5"}, Timestamp: ts, Value: 2},
 	}}
 	srv := newServer(q, "v1.0.0-test")
 	t.Cleanup(srv.Close)
@@ -1399,7 +1421,7 @@ func TestMetricsQueryRange_MultiQuantileOverTimeWireShape(t *testing.T) {
 	}
 
 	// Wire-shape is the contract — three per-phi series with `p=<phi>`
-	// label set asserted above. The SQL implementation can fan out via
-	// `qs_array`/`__phi__`, via inline literal projection, or via
-	// row-per-phi unrolling without changing the JSON envelope.
+	// label set asserted above. The internal routing (bucket-shape SQL
+	// + Tempo's Log2QuantileWithBucket post-processor) is exercised
+	// through the wire shape rather than pinned to SQL substrings.
 }

--- a/internal/chplan/metrics_aggregate.go
+++ b/internal/chplan/metrics_aggregate.go
@@ -133,8 +133,20 @@ type MetricsAggregate struct {
 	GroupByAliases      []string
 	GroupByDisplayNames []string
 	Quantiles           []float64
-	ValueAlias          string
-	Inner               Node
+	// IsDuration tags MetricsOpQuantileOverTime over a duration-typed
+	// operand. Tempo's HistogramAggregator bucketises duration values in
+	// nanoseconds (`Log2Bucketize(d)`) and divides the resulting bucket
+	// edge by 1e9 so the bucket label reads in fractional seconds; for
+	// non-duration numeric operands the bucket edge is the raw
+	// `Log2Bucketize(uint64(v))`. The chsql matrix emitter mirrors that
+	// dual contract by emitting `pow(2, ceil(log2(toFloat64(metric_arg) *
+	// 1000000000))) / 1000000000` when IsDuration=true and the bare
+	// `pow(2, ceil(log2(toFloat64(metric_arg))))` otherwise. The
+	// post-processor in internal/api/tempo/metrics_query_range.go feeds
+	// those bucket edges into `traceql.Log2QuantileWithBucket` per phi.
+	IsDuration bool
+	ValueAlias string
+	Inner      Node
 }
 
 func (*MetricsAggregate) planNode() {}
@@ -146,7 +158,7 @@ func (m *MetricsAggregate) Equal(other Node) bool {
 	if !ok {
 		return false
 	}
-	if m.Op != o.Op || m.ValueAlias != o.ValueAlias {
+	if m.Op != o.Op || m.ValueAlias != o.ValueAlias || m.IsDuration != o.IsDuration {
 		return false
 	}
 	if (m.Attr == nil) != (o.Attr == nil) {

--- a/internal/chsql/range_window.go
+++ b/internal/chsql/range_window.go
@@ -700,6 +700,17 @@ func (e *emitter) emitRangeWindowMetrics(r *chplan.RangeWindow, m *chplan.Metric
 	if r.Step <= 0 {
 		return fmt.Errorf("%w: RangeWindow wrapping MetricsAggregate requires Step > 0", ErrUnsupported)
 	}
+	// quantile_over_time takes the bucket-shape route: emit one row per
+	// (group, anchor, bucket) with `count(1)` and let the Tempo handler
+	// (internal/api/tempo/metrics_query_range.go) post-process via
+	// pkg/traceql.Log2QuantileWithBucket so the wire matches Tempo's
+	// HistogramAggregator. Native CH `quantile` / `quantiles` aggregates
+	// would diverge from Tempo's power-of-two bucket-interpolation
+	// algorithm; routing through the bucket shape keeps the upstream
+	// algorithm authoritative.
+	if m.Op == chplan.MetricsOpQuantileOverTime {
+		return e.emitRangeWindowMetricsQuantileBuckets(r, m)
+	}
 	chName, params, args, err := metricsAggregateCH(m)
 	if err != nil {
 		return err
@@ -757,8 +768,6 @@ func (e *emitter) emitRangeWindowMetrics(r *chplan.RangeWindow, m *chplan.Metric
 		return err
 	}
 
-	multi := m.Op == chplan.MetricsOpQuantileOverTime && len(m.Quantiles) > 1
-
 	// Inner SELECT: fan each Inner row across N anchors, projecting
 	// group-by cols, the timestamp as `ts`, [the metric operand as
 	// metric_arg,] and the anchor_ts. Group-by columns are aliased
@@ -794,27 +803,8 @@ func (e *emitter) emitRangeWindowMetrics(r *chplan.RangeWindow, m *chplan.Metric
 		outerSb.Select(func(b *Builder) { b.Ident(a) })
 	}
 	outerSb.Select(Col("anchor_ts"))
-	if multi {
-		// Multi-phi: the reducer is `quantiles(p1, p2, ...)(metric_arg)`,
-		// returning Array(Float64). Project under `qs_array` without
-		// the toFloat64 wrap (it would clobber the array shape); the
-		// outer wrapping SELECT below fans the array out per-phi.
-		// Rewrite the args to reference the inner-SELECT alias
-		// `metric_arg` (mirrors metricsReducerFrag's translation).
-		argFrags := make([]func(b *Builder), 0, len(args))
-		for range args {
-			argFrags = append(argFrags, func(b *Builder) { b.Ident("metric_arg") })
-		}
-		paramFrags := make([]func(b *Builder), 0, len(params))
-		for _, p := range params {
-			expr := p
-			paramFrags = append(paramFrags, func(b *Builder) { _ = b.Expr(expr) })
-		}
-		outerSb.Select(rawAs(func(b *Builder) { b.ParamAgg(chName, paramFrags, argFrags) }, "qs_array"))
-	} else {
-		reducerFrag := metricsReducerFrag(m.Op, chName, params, args, rangeSeconds)
-		outerSb.Select(As(reducerFrag, m.ValueAlias))
-	}
+	reducerFrag := metricsReducerFrag(m.Op, chName, params, args, rangeSeconds)
+	outerSb.Select(As(reducerFrag, m.ValueAlias))
 
 	// WHERE: ts ∈ (anchor_ts - range, anchor_ts] — left-open /
 	// right-closed, matching Tempo's IntervalMapperQueryRange.
@@ -832,47 +822,182 @@ func (e *emitter) emitRangeWindowMetrics(r *chplan.RangeWindow, m *chplan.Metric
 	groupFrags = append(groupFrags, Col("anchor_ts"))
 	outerSb.GroupBy(groupFrags...)
 
-	if !multi {
-		e.emitSelect(outerSb)
-		return nil
-	}
-
-	e.emitSelect(emitMultiQuantileMatrixWrap(outerSb.Frag(), groupAliases, m.Quantiles, m.ValueAlias))
+	e.emitSelect(outerSb)
 	return nil
 }
 
-// emitMultiQuantileMatrixWrap builds the two extra SELECTs that fan a
-// per-(group, anchor) `quantiles(...)` Array(Float64) result out into
-// one row per phi tagged with the synthetic `__phi__` label.
+// emitRangeWindowMetricsQuantileBuckets renders quantile_over_time in
+// the matrix path as a `(group, anchor, bucket, count)` row stream. The
+// Tempo handler (internal/api/tempo/metrics_query_range.go) groups those
+// rows by (group, anchor) and calls upstream
+// `pkg/traceql.Log2QuantileWithBucket(phi, buckets)` per phi to compute
+// the per-anchor quantile value — mirroring Tempo's HistogramAggregator
+// (engine_metrics.go) so the wire reading aligns with the reference
+// engine's power-of-two bucket interpolation.
 //
-//   - Layer 1 (fanout): SELECTs the group aliases + anchor_ts +
-//     arrayJoin'd (phi, value) tuple under the `phi_val` alias.
-//   - Layer 2 (final): splits `phi_val` into the synthetic `__phi__`
-//     label + the Float64 value column. The two-tuple is split via
-//     tupleElement here (rather than fused into the arrayJoin lambda)
-//     so the SELECT-list stays readable and the inner arrayJoin
-//     produces just one row per (group, anchor, phi) tuple as intended.
+// SQL skeleton:
 //
-// Mirrors the bare-emit multi-phi wrap in emitMetricsAggregate but
-// retains the matrix-shape `anchor_ts` carry-through.
-func emitMultiQuantileMatrixWrap(inner Frag, groupAliases []string, quantiles []float64, valueAlias string) *QueryBuilder {
-	fanout := NewQuery().From(inner)
-	for _, alias := range groupAliases {
-		a := alias
-		fanout.Select(func(b *Builder) { b.Ident(a) })
+//	SELECT [<group cols>,] anchor_ts,
+//	       pow(2, ceil(log2(toFloat64(metric_arg) [* 1e9]))) [/ 1e9] AS `__bucket`,
+//	       toFloat64(count(1)) AS Value
+//	FROM (
+//	  SELECT [<group cols>,] <TimestampColumn> AS ts, <Attr> AS metric_arg,
+//	         arrayJoin(arrayMap(i -> <anchor_base> - toIntervalNanosecond(i * <step_ns>), range(0, <N>))) AS anchor_ts
+//	  FROM (<Inner>)
+//	)
+//	WHERE ts >  anchor_ts - toIntervalNanosecond(<range_ns>)
+//	  AND ts <= anchor_ts
+//	  AND <metric_arg-in-nanos>  >= 2     -- Tempo's bucketize* drops <2
+//	GROUP BY [<group cols>,] anchor_ts, `__bucket`
+//
+// The `<metric_arg-in-nanos> >= 2` filter mirrors Tempo's
+// bucketizeDuration / bucketizeAttribute "if d < 2 return nil" guard. For
+// duration operands `metric_arg` is already `Duration / 1e9` (the
+// cerberus-side seconds rebase), so the filter expands to
+// `metric_arg * 1e9 >= 2` — i.e. raw `Duration >= 2` nanoseconds. For
+// non-duration numeric operands the cerberus lowering passes the value
+// unchanged, so the filter is `metric_arg >= 2`.
+//
+// The bucket alias is the wire-format-stable `__bucket` literal — same
+// alias `MetricsHistogramOverTime` uses (`histogramBucketAlias` /
+// `internalLabelBucket` in Tempo) so downstream readers can pick the
+// bucket out of the row stream by a stable name.
+func (e *emitter) emitRangeWindowMetricsQuantileBuckets(r *chplan.RangeWindow, m *chplan.MetricsAggregate) error {
+	if m.Attr == nil {
+		return fmt.Errorf("%w: quantile_over_time matrix path requires MetricsAggregate.Attr", ErrUnsupported)
 	}
-	fanout.Select(Col("anchor_ts"))
-	fanout.Select(rawAs(metricsMultiQuantileFanoutFrag(quantiles, "qs_array"), "phi_val"))
+	if len(m.Quantiles) == 0 {
+		return fmt.Errorf("%w: quantile_over_time matrix path requires at least one phi", ErrUnsupported)
+	}
+	if m.Inner == nil {
+		return fmt.Errorf("%w: quantile_over_time matrix path requires MetricsAggregate.Inner", ErrUnsupported)
+	}
 
-	final := NewQuery().From(fanout.Frag())
+	// Pre-flight expressions so chplan errors surface synchronously.
+	if err := (&Builder{}).Expr(m.Attr); err != nil {
+		return err
+	}
+	for _, g := range m.GroupBy {
+		if err := (&Builder{}).Expr(g); err != nil {
+			return err
+		}
+	}
+
+	end := endExprFrag(r)
+	stepNS := r.Step.Nanoseconds()
+	rangeDur := r.Range
+	if rangeDur == 0 {
+		rangeDur = r.Step
+	}
+	rangeNS := rangeDur.Nanoseconds()
+
+	var numAnchors int64
+	switch {
+	case r.OuterRange > 0:
+		numAnchors = r.OuterRange.Nanoseconds()/stepNS + 1
+	case !r.Start.IsZero() && !r.End.IsZero():
+		span := r.End.Sub(r.Start).Nanoseconds()
+		if span < 0 {
+			return fmt.Errorf("%w: RangeWindow.Start > End", ErrUnsupported)
+		}
+		numAnchors = span/stepNS + 1
+	default:
+		numAnchors = 1
+	}
+
+	inner, err := e.subqueryFrag(m.Inner)
+	if err != nil {
+		return err
+	}
+
+	groupAliases := outerGroupAliases(m.GroupBy, m.GroupByAliases)
+	innerSb := NewQuery().From(inner)
+	for i, g := range m.GroupBy {
+		expr := g
+		alias := groupAliases[i]
+		innerSb.SelectAs(func(b *Builder) { _ = b.Expr(expr) }, alias)
+	}
+	tsCol := r.TimestampColumn
+	innerSb.SelectAs(func(b *Builder) { b.Ident(tsCol) }, "ts")
+	attr := m.Attr
+	innerSb.SelectAs(func(b *Builder) { _ = b.Expr(attr) }, "metric_arg")
+	innerSb.SelectAs(anchorFanoutFrag(end, stepNS, numAnchors), "anchor_ts")
+
+	outerSb := NewQuery().From(innerSb.Frag())
 	for _, alias := range groupAliases {
 		a := alias
-		final.Select(func(b *Builder) { b.Ident(a) })
+		outerSb.Select(func(b *Builder) { b.Ident(a) })
 	}
-	final.Select(Col("anchor_ts"))
-	final.Select(As(Call("tupleElement", BareIdent("phi_val"), InlineLit(int64(1))), metricsMultiQuantilePhiLabel))
-	final.Select(As(Call("tupleElement", BareIdent("phi_val"), InlineLit(int64(2))), valueAlias))
-	return final
+	outerSb.Select(Col("anchor_ts"))
+	outerSb.SelectAs(quantileBucketFrag(m.IsDuration), metricsQuantileBucketAlias)
+	outerSb.Select(As(verbatim("toFloat64(count(1))"), m.ValueAlias))
+
+	// WHERE: ts ∈ (anchor_ts - range, anchor_ts] AND raw-value >= 2.
+	outerSb.Where(
+		windowTsLowerBoundFrag(rangeNS),
+		verbatim("ts <= anchor_ts"),
+		quantileMetricArgMinFrag(m.IsDuration),
+	)
+
+	// GROUP BY group aliases + anchor_ts + bucket.
+	groupFrags := make([]Frag, 0, len(groupAliases)+2)
+	for _, alias := range groupAliases {
+		a := alias
+		groupFrags = append(groupFrags, func(b *Builder) { b.Ident(a) })
+	}
+	groupFrags = append(groupFrags, Col("anchor_ts"), Col(metricsQuantileBucketAlias))
+	outerSb.GroupBy(groupFrags...)
+
+	e.emitSelect(outerSb)
+	return nil
+}
+
+// metricsQuantileBucketAlias is the SELECT-list alias the matrix-path
+// quantile_over_time emitter assigns to its per-row bucket column.
+// Mirrors Tempo's internal `__bucket` label name (engine_metrics.go,
+// `internalLabelBucket`) so the Tempo handler's
+// `postProcessQuantileBuckets` can pick the bucket value out of the
+// row stream by a stable name. The Tempo handler holds its own
+// matching constant (`tempoQuantileBucketLabel` in
+// internal/api/tempo/metrics_query_range.go); both must agree on the
+// literal "__bucket".
+const metricsQuantileBucketAlias = "__bucket"
+
+// quantileBucketFrag renders the per-row bucket key. Mirrors Tempo's
+// `Log2Bucketize(v) [/ time.Second]` (pkg/traceql/engine_metrics.go).
+//
+//   - duration operands: cerberus's lowering already projects
+//     `metric_arg = Duration / 1e9`. To recover the raw nanosecond value
+//     for the `Log2Bucketize(d) = 2^ceil(log2(d))` formula, multiply by
+//     1e9 inside the log2; divide the resulting power-of-two back by 1e9
+//     to keep the bucket label in fractional seconds, matching
+//     bucketizeDuration's wire shape.
+//   - non-duration operands: `metric_arg` carries the raw numeric value;
+//     emit `pow(2, ceil(log2(toFloat64(metric_arg))))` verbatim.
+//
+// The 1e9 divisor renders as the literal `1000000000` so the emitted
+// SQL has no bound argument for the unit-conversion constant (it's
+// query-shape, not user data) — same idiom used by
+// `histogramBucketFrag` in internal/chsql/histogram_over_time.go.
+func quantileBucketFrag(isDuration bool) Frag {
+	if isDuration {
+		return verbatim("pow(2, ceil(log2(toFloat64(metric_arg) * 1000000000))) / 1000000000")
+	}
+	return verbatim("pow(2, ceil(log2(toFloat64(metric_arg))))")
+}
+
+// quantileMetricArgMinFrag renders the `metric_arg >= 2` filter that
+// mirrors Tempo's bucketize* "if d < 2 return nil" guard
+// (pkg/traceql/ast_metrics.go, bucketizeDuration / bucketizeAttribute).
+// For duration operands the cerberus lowering pre-divides by 1e9, so
+// the filter expands to `metric_arg * 1e9 >= 2` (i.e. raw `Duration >=
+// 2` nanoseconds). For non-duration numeric operands the filter is the
+// bare `metric_arg >= 2`.
+func quantileMetricArgMinFrag(isDuration bool) Frag {
+	if isDuration {
+		return verbatim("metric_arg * 1000000000 >= 2")
+	}
+	return verbatim("metric_arg >= 2")
 }
 
 // anchorFanoutFrag returns a Frag rendering

--- a/internal/chsql/range_window_metrics_test.go
+++ b/internal/chsql/range_window_metrics_test.go
@@ -258,12 +258,16 @@ func TestMetricsAggregateMultiQuantileBare(t *testing.T) {
 	}
 }
 
-// TestRangeWindowMetricsMultiQuantile exercises the matrix-path
-// fan-out for multi-phi `quantile_over_time`. The middle SELECT
-// computes the per-(group, anchor) `quantiles(...)` array; two
-// wrapping SELECTs fan the array out into one row per
-// (group, anchor, phi) tuple tagged with `__phi__`.
-func TestRangeWindowMetricsMultiQuantile(t *testing.T) {
+// TestRangeWindowMetricsQuantileBuckets exercises the matrix-path
+// emit for `quantile_over_time(...)`: the SQL projects one row per
+// (group, anchor, bucket) with `pow(2, ceil(log2(toFloat64(metric_arg))))`
+// as the synthetic `__bucket` column and `toFloat64(count(1))` as the
+// per-bucket count. The Tempo handler post-processes those rows via
+// `pkg/traceql.Log2QuantileWithBucket` to produce the per-(group,
+// anchor, phi) wire value — so the SQL no longer carries the phi
+// constants and no longer calls CH's `quantile` / `quantiles` aggregate
+// (whose interpolation diverges from Tempo's HistogramAggregator).
+func TestRangeWindowMetricsQuantileBuckets(t *testing.T) {
 	t.Parallel()
 
 	plan := &chplan.RangeWindow{
@@ -283,22 +287,68 @@ func TestRangeWindowMetricsMultiQuantile(t *testing.T) {
 		t.Fatalf("Emit: %v", err)
 	}
 	wantSubstrings := []string{
-		"quantiles(?, ?, ?)(`metric_arg`) AS qs_array",
-		"['0.5', '0.9', '0.99']",
-		"AS phi_val",
-		"tupleElement(phi_val, 1) AS `__phi__`",
-		"tupleElement(phi_val, 2) AS `Value`",
-		"`anchor_ts`",
+		"pow(2, ceil(log2(toFloat64(metric_arg))))",
+		"AS `__bucket`",
+		"toFloat64(count(1)) AS `Value`",
+		"metric_arg >= 2",
+		"GROUP BY `anchor_ts`, `__bucket`",
 	}
 	for _, s := range wantSubstrings {
 		if !strings.Contains(sql, s) {
 			t.Errorf("expected SQL to contain %q; got %s", s, sql)
 		}
 	}
-	// 3 phi args; the matrix path's eval-grid timestamps are inline
-	// literals so no other args bind.
-	if len(args) != 3 {
-		t.Fatalf("len(args) = %d, want 3 (one per phi): %v", len(args), args)
+	// No CH-side quantile call — the phi values are consumed by the
+	// post-processor in internal/api/tempo/metrics_query_range.go.
+	for _, banned := range []string{"quantile(?)", "quantiles(?", "qs_array", "phi_val", "__phi__"} {
+		if strings.Contains(sql, banned) {
+			t.Errorf("matrix quantile SQL must not contain %q (post-processor handles phi): got %s", banned, sql)
+		}
+	}
+	// The phi values do not bind to the SQL anymore — the matrix
+	// quantile emitter drives only the bucket projection.
+	if len(args) != 0 {
+		t.Fatalf("len(args) = %d, want 0 (post-processor consumes phi): %v", len(args), args)
+	}
+}
+
+// TestRangeWindowMetricsQuantileBucketsDuration pins the duration-aware
+// branch of `quantileBucketFrag`: when MetricsAggregate.IsDuration is
+// true the bucket key carries the `* 1e9` / `/ 1e9` rebase so the
+// upstream `Log2Bucketize(d) / time.Second` formula reads bucket edges
+// in fractional seconds. The min-value filter expands to
+// `metric_arg * 1e9 >= 2` so the original-nanosecond `>= 2` guard from
+// `bucketizeDuration` survives the seconds rebase.
+func TestRangeWindowMetricsQuantileBucketsDuration(t *testing.T) {
+	t.Parallel()
+
+	plan := &chplan.RangeWindow{
+		Input: &chplan.MetricsAggregate{
+			Op:         chplan.MetricsOpQuantileOverTime,
+			Attr:       &chplan.ColumnRef{Name: "Duration"},
+			Quantiles:  []float64{0.95},
+			IsDuration: true,
+			ValueAlias: "Value",
+			Inner:      &chplan.Scan{Table: "otel_traces"},
+		},
+		Step:            time.Minute,
+		OuterRange:      5 * time.Minute,
+		TimestampColumn: "Timestamp",
+	}
+	sql, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	wantSubstrings := []string{
+		"pow(2, ceil(log2(toFloat64(metric_arg) * 1000000000))) / 1000000000",
+		"AS `__bucket`",
+		"toFloat64(count(1)) AS `Value`",
+		"metric_arg * 1000000000 >= 2",
+	}
+	for _, s := range wantSubstrings {
+		if !strings.Contains(sql, s) {
+			t.Errorf("expected SQL to contain %q; got %s", s, sql)
+		}
 	}
 }
 

--- a/internal/traceql/metrics_pipeline.go
+++ b/internal/traceql/metrics_pipeline.go
@@ -110,6 +110,17 @@ func lowerMetricsAggregate(prev chplan.Node, agg *traceql.MetricsAggregate, s sc
 		copy(quantiles, qs)
 	}
 
+	// IsDuration drives the bucketise divisor in the chsql matrix-path
+	// quantile emitter (and the post-processor in
+	// internal/api/tempo/metrics_query_range.go) so the bucket edges fed
+	// into Tempo's Log2QuantileWithBucket match what
+	// pkg/traceql.bucketizeDuration produces upstream — Log2Bucketize(d)
+	// in nanos, divided by 1e9 so the bucket reads in seconds. Only
+	// quantile_over_time consults IsDuration today; the rest of the
+	// matrix path emits the same SQL whether or not the operand was
+	// originally a duration intrinsic.
+	isDuration := op == traceql.MetricsAggregateQuantileOverTime && agg.Attribute().Intrinsic == traceql.IntrinsicDuration
+
 	return &chplan.MetricsAggregate{
 		Op:                  cop,
 		Attr:                attr,
@@ -117,6 +128,7 @@ func lowerMetricsAggregate(prev chplan.Node, agg *traceql.MetricsAggregate, s sc
 		GroupByAliases:      groupAliases,
 		GroupByDisplayNames: groupDisplay,
 		Quantiles:           quantiles,
+		IsDuration:          isDuration,
 		ValueAlias:          metricsValueAlias,
 		Inner:               prev,
 	}, nil

--- a/test/spec/chplan_print.go
+++ b/test/spec/chplan_print.go
@@ -225,6 +225,9 @@ func printNode(b *strings.Builder, n chplan.Node, depth int) {
 			}
 			fmt.Fprintf(b, " quantiles=[%s]", strings.Join(qs, ", "))
 		}
+		if v.IsDuration {
+			b.WriteString(" duration=true")
+		}
 		if v.ValueAlias != "" {
 			fmt.Fprintf(b, " valueAlias=%s", v.ValueAlias)
 		}

--- a/test/spec/chsql/range_window_metrics_quantile_over_time_attr.txtar
+++ b/test/spec/chsql/range_window_metrics_quantile_over_time_attr.txtar
@@ -1,7 +1,7 @@
 -- args --
-[0] float64 = 0.95
+(none)
 -- sql --
-SELECT `anchor_ts`, toFloat64(quantile(?)(`metric_arg`)) AS `Value` FROM (SELECT `Timestamp` AS `ts`, `Duration` AS `metric_arg`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) WHERE ts > anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts GROUP BY `anchor_ts`
+SELECT `anchor_ts`, pow(2, ceil(log2(toFloat64(metric_arg)))) AS `__bucket`, toFloat64(count(1)) AS `Value` FROM (SELECT `Timestamp` AS `ts`, `Duration` AS `metric_arg`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) WHERE ts > anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts AND metric_arg >= 2 GROUP BY `anchor_ts`, `__bucket`
 -- chplan --
 RangeWindow func= range=0s step=1m0s outerRange=5m0s ts=Timestamp
   MetricsAggregate op=quantile_over_time attr=Duration quantiles=[0.95] valueAlias=Value

--- a/test/spec/chsql/range_window_metrics_quantile_over_time_multi_attr.txtar
+++ b/test/spec/chsql/range_window_metrics_quantile_over_time_multi_attr.txtar
@@ -1,9 +1,7 @@
 -- args --
-[0] float64 = 0.5
-[1] float64 = 0.9
-[2] float64 = 0.99
+(none)
 -- sql --
-SELECT `anchor_ts`, tupleElement(phi_val, 1) AS `__phi__`, tupleElement(phi_val, 2) AS `Value` FROM (SELECT `anchor_ts`, arrayJoin(arrayMap((phi, q) -> (phi, toFloat64(q)), ['0.5', '0.9', '0.99'], qs_array)) AS phi_val FROM (SELECT `anchor_ts`, quantiles(?, ?, ?)(`metric_arg`) AS qs_array FROM (SELECT `Timestamp` AS `ts`, `Duration` AS `metric_arg`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) WHERE ts > anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts GROUP BY `anchor_ts`))
+SELECT `anchor_ts`, pow(2, ceil(log2(toFloat64(metric_arg)))) AS `__bucket`, toFloat64(count(1)) AS `Value` FROM (SELECT `Timestamp` AS `ts`, `Duration` AS `metric_arg`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) WHERE ts > anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts AND metric_arg >= 2 GROUP BY `anchor_ts`, `__bucket`
 -- chplan --
 RangeWindow func= range=0s step=1m0s outerRange=5m0s ts=Timestamp
   MetricsAggregate op=quantile_over_time attr=Duration quantiles=[0.5, 0.9, 0.99] valueAlias=Value

--- a/test/spec/chsql/range_window_metrics_quantile_over_time_multi_by_attr.txtar
+++ b/test/spec/chsql/range_window_metrics_quantile_over_time_multi_by_attr.txtar
@@ -1,9 +1,7 @@
 -- args --
-[0] float64 = 0.5
-[1] float64 = 0.9
-[2] float64 = 0.99
+(none)
 -- sql --
-SELECT `service`, `anchor_ts`, tupleElement(phi_val, 1) AS `__phi__`, tupleElement(phi_val, 2) AS `Value` FROM (SELECT `service`, `anchor_ts`, arrayJoin(arrayMap((phi, q) -> (phi, toFloat64(q)), ['0.5', '0.9', '0.99'], qs_array)) AS phi_val FROM (SELECT `service`, `anchor_ts`, quantiles(?, ?, ?)(`metric_arg`) AS qs_array FROM (SELECT `ServiceName` AS `service`, `Timestamp` AS `ts`, `Duration` AS `metric_arg`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) WHERE ts > anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts GROUP BY `service`, `anchor_ts`))
+SELECT `service`, `anchor_ts`, pow(2, ceil(log2(toFloat64(metric_arg)))) AS `__bucket`, toFloat64(count(1)) AS `Value` FROM (SELECT `ServiceName` AS `service`, `Timestamp` AS `ts`, `Duration` AS `metric_arg`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) WHERE ts > anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts AND metric_arg >= 2 GROUP BY `service`, `anchor_ts`, `__bucket`
 -- chplan --
 RangeWindow func= range=0s step=1m0s outerRange=5m0s ts=Timestamp
   MetricsAggregate op=quantile_over_time attr=Duration groupBy=[ServiceName AS service] quantiles=[0.5, 0.9, 0.99] valueAlias=Value

--- a/test/spec/traceql/metrics_multi_quantile.txtar
+++ b/test/spec/traceql/metrics_multi_quantile.txtar
@@ -25,6 +25,6 @@ INSERT INTO otel_traces VALUES
   ["0.99", 0.1]
 ]
 -- chplan --
-MetricsAggregate op=quantile_over_time attr=(Duration / 1e+09) quantiles=[0.5, 0.9, 0.99] valueAlias=Value
+MetricsAggregate op=quantile_over_time attr=(Duration / 1e+09) quantiles=[0.5, 0.9, 0.99] duration=true valueAlias=Value
   Filter predicate=true
     Scan(otel_traces)

--- a/test/spec/traceql/metrics_quantile_over_time.txtar
+++ b/test/spec/traceql/metrics_quantile_over_time.txtar
@@ -21,6 +21,6 @@ INSERT INTO otel_traces VALUES
   [0.1]
 ]
 -- chplan --
-MetricsAggregate op=quantile_over_time attr=(Duration / 1e+09) quantiles=[0.95] valueAlias=Value
+MetricsAggregate op=quantile_over_time attr=(Duration / 1e+09) quantiles=[0.95] duration=true valueAlias=Value
   Filter predicate=true
     Scan(otel_traces)


### PR DESCRIPTION
## Summary

The matrix-path `quantile_over_time` emit previously used CH's native `quantile(p)(metric_arg)` aggregate, whose linear interpolation diverged from Tempo's HistogramAggregator power-of-two bucket-interpolation. The tempo-compat differ flagged `metrics_quantile_over_time_p95` with sample-value drift even after the wire-shape and zero-fill fixes (#562 / #567).

Reroute the matrix path through a bucket-shape SQL stream:

```sql
SELECT [<group>,] anchor_ts,
       pow(2, ceil(log2(toFloat64(metric_arg) [* 1e9]))) [/ 1e9] AS `__bucket`,
       toFloat64(count(1)) AS Value
FROM (...)
WHERE ... AND metric_arg [* 1e9] >= 2
GROUP BY [<group>,] anchor_ts, `__bucket`
```

`pow(2, ceil(log2(...)))` mirrors Tempo's `Log2Bucketize(v)` formula (2^ceil(log2(v)) for v >= 2). The `* 1e9` / `/ 1e9` rebase for `IsDuration` recovers the raw-nanosecond bucket that upstream `bucketizeDuration` produces, then re-divides so the bucket edge reads in fractional seconds. A new `IsDuration` flag rides on `chplan.MetricsAggregate`; the traceql lowering sets it whenever the operand is the `duration` intrinsic.

The Tempo handler's `postProcessQuantileBuckets` then folds the row stream into per-(group, phi, anchor) samples by calling the upstream-exported `pkg/traceql.Log2QuantileWithBucket` (already exported in the cerberus-accessors fork at v0.0.3) per phi. This keeps cerberus's quantile algorithm bit-for-bit aligned with Tempo's reference engine — any future tweak to the upstream interpolation rules lands automatically.

## Why this approach over an SQL-side port

- Reusing the upstream function via the fork keeps cerberus and Tempo in lockstep — algorithm changes ride the fork update.
- The power-of-two interpolation + `p100` boundary handling + sample-count rounding is non-trivial to translate to CH SQL; a port would diverge over time.
- The bare emit path (used only by unit tests) is unchanged — CH's `quantile()` keeps the existing TXTAR golden values stable.

## Files touched

- `internal/chsql/range_window.go` — new `emitRangeWindowMetricsQuantileBuckets` + helper Frags (`quantileBucketFrag`, `quantileMetricArgMinFrag`); matrix dispatch routes `MetricsOpQuantileOverTime` into the new path.
- `internal/chplan/metrics_aggregate.go` — add `IsDuration` field + thread through `Equal`.
- `internal/traceql/metrics_pipeline.go` — set `IsDuration` in lowering when operand is `IntrinsicDuration`.
- `internal/api/tempo/metrics_query_range.go` — add `tempoQuantileBucketLabel` constant + `postProcessQuantileBuckets`; reshape `wrapMetricsForSample` quantile branch to surface `__bucket` instead of `p`; call post-processor before `toMetricsSeries`.
- `internal/api/tempo/metrics_query_instant.go` — same post-processor hook in the instant handler.
- `test/spec/chsql/range_window_metrics_quantile_over_time_*.txtar` — update goldens to the bucket-shape SQL.
- `test/spec/traceql/metrics_*quantile*.txtar` — add `duration=true` to the chplan IR snapshot.
- `internal/api/tempo/metrics_phi_label_test.go` — update wrap tests to assert `__bucket` projection (post-processor owns the `p` label).
- `internal/api/tempo/metrics_query_range_test.go` — update zero-fill / wire-shape / duration tests to seed bucket-shape rows.
- `internal/chsql/range_window_metrics_test.go` — replace multi-phi matrix shape test with bucket-shape test + duration variant.

## Test plan

- [x] Rewritten unit tests asserting the new bucket-shape SQL emit
- [x] Updated TXTAR goldens for matrix-path quantile emit
- [x] Post-processor test coverage via the updated handler tests
- [ ] Tempo compat: `metrics_quantile_over_time_p95` should now match Tempo's HistogramAggregator output bit-for-bit (CI confirms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)