### PR TITLE
fix(api/loki): drop extra stream-dimensions from bare log query output to match Loki

### DIFF
--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -139,6 +139,12 @@ func (h *Handler) handleQuery(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, ErrBadData, err)
 		return
 	}
+	limit, err := parseLogLimit(r.URL.Query().Get("limit"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, ErrBadData, err)
+		return
+	}
+	dir := parseLogDirection(r.URL.Query().Get("direction"))
 
 	// Instant /query: collapse the window onto a single point. Per
 	// upstream Loki contract the evaluation lookback is the previous
@@ -154,7 +160,7 @@ func (h *Handler) handleQuery(w http.ResponseWriter, r *http.Request) {
 	expr, _ := res.Meta.Extra["expr"].(syntax.Expr)
 	h.Logger.Debug("cerberus loki query", "logql", q, "sql", res.SQL, "args", res.Args)
 
-	data, err := buildInstantData(expr, res.Samples, ts, h.Schema)
+	data, err := buildInstantData(expr, res.Samples, ts, h.Schema, limit, dir)
 	if err != nil {
 		h.respondError(w, err)
 		return
@@ -193,6 +199,12 @@ func (h *Handler) handleQueryRange(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, ErrBadData, errors.New("'end' must be after 'start'"))
 		return
 	}
+	limit, err := parseLogLimit(r.URL.Query().Get("limit"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, ErrBadData, err)
+		return
+	}
+	dir := parseLogDirection(r.URL.Query().Get("direction"))
 
 	res, err := h.Engine.Query(r.Context(), h.langForRangeRequest(start, end, step), q)
 	if err != nil {
@@ -202,7 +214,7 @@ func (h *Handler) handleQueryRange(w http.ResponseWriter, r *http.Request) {
 	expr, _ := res.Meta.Extra["expr"].(syntax.Expr)
 	h.Logger.Debug("cerberus loki query_range", "logql", q, "sql", res.SQL, "args", res.Args)
 
-	data, err := buildRangeData(expr, res.Samples, start, end, step, h.Schema)
+	data, err := buildRangeData(expr, res.Samples, start, end, step, h.Schema, limit, dir)
 	if err != nil {
 		h.respondError(w, err)
 		return
@@ -293,8 +305,10 @@ func classifyEngineErr(err error) error {
 
 // buildInstantData turns the sample stream into a Loki instant-query
 // data body. Metric queries produce a vector; log queries produce
-// streams.
-func buildInstantData(expr syntax.Expr, samples []chclient.Sample, ts time.Time, _ schema.Logs) (*QueryData, error) {
+// streams. The limit + direction control how many log entries to
+// surface and in what order (Loki applies `limit` to the TOTAL entry
+// count across all streams, not per-stream).
+func buildInstantData(expr syntax.Expr, samples []chclient.Sample, ts time.Time, _ schema.Logs, limit int, dir logDirection) (*QueryData, error) {
 	if logql.IsMetricQuery(expr) {
 		return &QueryData{
 			ResultType: "vector",
@@ -305,6 +319,7 @@ func buildInstantData(expr syntax.Expr, samples []chclient.Sample, ts time.Time,
 	if err != nil {
 		return nil, &apiError{Kind: ErrBadData, Err: err, Status: http.StatusBadRequest}
 	}
+	samples = clampLogSamples(samples, limit, dir)
 	return &QueryData{
 		ResultType: "streams",
 		Result:     toStreamsWithTransform(samples, tx),
@@ -313,8 +328,9 @@ func buildInstantData(expr syntax.Expr, samples []chclient.Sample, ts time.Time,
 
 // buildRangeData turns the sample stream into a Loki range-query data
 // body. Metric queries produce a matrix (per-step latest value per
-// series). Log queries produce streams.
-func buildRangeData(expr syntax.Expr, samples []chclient.Sample, start, end time.Time, step time.Duration, _ schema.Logs) (*QueryData, error) {
+// series). Log queries produce streams; limit + direction follow the
+// same `total entries across all streams` rule as [buildInstantData].
+func buildRangeData(expr syntax.Expr, samples []chclient.Sample, start, end time.Time, step time.Duration, _ schema.Logs, limit int, dir logDirection) (*QueryData, error) {
 	if logql.IsMetricQuery(expr) {
 		return &QueryData{
 			ResultType: "matrix",
@@ -325,10 +341,110 @@ func buildRangeData(expr syntax.Expr, samples []chclient.Sample, start, end time
 	if err != nil {
 		return nil, &apiError{Kind: ErrBadData, Err: err, Status: http.StatusBadRequest}
 	}
+	samples = clampLogSamples(samples, limit, dir)
 	return &QueryData{
 		ResultType: "streams",
 		Result:     toStreamsWithTransform(samples, tx),
 	}, nil
+}
+
+// logDirection is the wire-format direction parameter — "backward"
+// (most-recent-first, the default) or "forward". Used to order log
+// entries when applying the `limit` clamp so the surfaced subset
+// matches reference Loki's truncation rule (latest N for backward,
+// earliest N for forward). Metric queries ignore this field; their
+// matrix / vector emitters carry their own per-anchor ordering.
+type logDirection int
+
+const (
+	// directionBackward returns the most-recent N entries — Loki's
+	// default and the only direction the loki-bench harness exercises
+	// for log queries (forward log queries are unsupported by Loki's
+	// v2 engine, see fast/basic-selectors.yaml).
+	directionBackward logDirection = iota
+	directionForward
+)
+
+// Loki's documented limit defaults. The default + ceiling mirror the
+// upstream `pkg/loghttp/params.go::defaultQueryLimit` /
+// `maxQueryLimit` constants — a request with no `limit` parameter
+// returns up to 100 entries; values above 5000 are clamped to 5000
+// rather than rejected so a misbehaving client doesn't trigger
+// runaway memory growth.
+const (
+	defaultLogQueryLimit = 100
+	maxLogQueryLimit     = 5000
+)
+
+// parseLogLimit reads the URL's `limit` query parameter, clamping at
+// [maxLogQueryLimit] and defaulting to [defaultLogQueryLimit] when
+// absent. Non-positive or non-numeric values fail with a 400-mapped
+// error so a Grafana / loki-bench client that passes garbage sees
+// the same diagnostic shape upstream Loki emits.
+func parseLogLimit(raw string) (int, error) {
+	if raw == "" {
+		return defaultLogQueryLimit, nil
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return 0, errors.New("'limit' must be a positive integer")
+	}
+	if n > maxLogQueryLimit {
+		n = maxLogQueryLimit
+	}
+	return n, nil
+}
+
+// parseLogDirection maps the URL's `direction` query parameter onto
+// the [logDirection] enum. Unknown / empty values fall back to
+// backward (the Loki documented default — the loki-bench harness
+// also sends explicit "backward" for every log case).
+func parseLogDirection(raw string) logDirection {
+	if strings.EqualFold(raw, "forward") {
+		return directionForward
+	}
+	return directionBackward
+}
+
+// clampLogSamples sorts samples by timestamp (direction-aware) and
+// truncates to limit. Loki's wire contract applies `limit` to the
+// TOTAL entry count across all streams — not per-stream — so we sort
+// the flat sample slice first and let [toStreamsWithTransform] group
+// the surviving subset into Streams by labelset. Without this clamp,
+// a query whose underlying SQL returns more rows than limit would
+// over-surface the response: reference Loki would return e.g. 1000
+// streams (one per unique post-parser labelset for the latest 1000
+// entries) where cerberus returned every matching row as its own
+// stream (the loki-compat `regression/drilldown-patterns.yaml#Basic
+// drilldown with json and logfmt parsing` case surfaced as `streams
+// length: expected=1000 actual=1440`).
+//
+// Samples come back from the engine in CH's natural ORDER BY-free
+// order; sorting here is authoritative for the wire-format response
+// since the chsql emitter for log Scans doesn't currently project an
+// ORDER BY clause. Sorting before truncation keeps the chosen subset
+// stable across CH execution-plan changes.
+//
+// limit <= 0 is treated as "no clamp" so test callers that don't
+// care about the cap can pass 0; the production handler always
+// passes a positive value out of [parseLogLimit].
+func clampLogSamples(samples []chclient.Sample, limit int, dir logDirection) []chclient.Sample {
+	if len(samples) == 0 {
+		return samples
+	}
+	if dir == directionBackward {
+		sort.SliceStable(samples, func(i, j int) bool {
+			return samples[i].Timestamp.After(samples[j].Timestamp)
+		})
+	} else {
+		sort.SliceStable(samples, func(i, j int) bool {
+			return samples[i].Timestamp.Before(samples[j].Timestamp)
+		})
+	}
+	if limit > 0 && len(samples) > limit {
+		samples = samples[:limit]
+	}
+	return samples
 }
 
 // toVector groups samples by label set, picks the latest per series.

--- a/internal/api/loki/handler_test.go
+++ b/internal/api/loki/handler_test.go
@@ -494,6 +494,7 @@ func TestQueryRange_BadInput(t *testing.T) {
 		{"missing start", `/loki/api/v1/query_range?query=%7Bjob%3D%22api%22%7D&end=1717999200&step=60`},
 		{"missing end", `/loki/api/v1/query_range?query=%7Bjob%3D%22api%22%7D&start=1717995600&step=60`},
 		{"end before start", `/loki/api/v1/query_range?query=%7Bjob%3D%22api%22%7D&start=1717999200&end=1717995600&step=60`},
+		{"invalid limit", `/loki/api/v1/query_range?query=%7Bjob%3D%22api%22%7D&start=1717995600&end=1717999200&step=60&limit=-5`},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -508,5 +509,243 @@ func TestQueryRange_BadInput(t *testing.T) {
 				t.Fatalf("expected 400, got %d", resp.StatusCode)
 			}
 		})
+	}
+}
+
+// TestQuery_Streams_RespectsLimitParameter pins the wire-format
+// contract that /query honours Loki's `limit` URL parameter on
+// log-stream queries: the response surfaces AT MOST `limit` entries
+// across all returned streams. The bug this guards against was
+// cerberus ignoring `limit` entirely — the
+// `regression/drilldown-patterns.yaml#Basic drilldown with json and
+// logfmt parsing` loki-compat case surfaced this as `streams length:
+// expected=1000 actual=1440`. With per-entry-unique parser-extracted
+// labels (which is what a `| json | logfmt` pipeline produces against
+// the loki-compat seed), every entry collapses into its own Stream,
+// so an unbounded sample stream becomes a stream-count mismatch on
+// the wire.
+//
+// The test uses a parser-stage-free query so the labels are constant
+// across rows — collapsing into a single Stream — and asserts the
+// entry count inside that stream is exactly `limit`. A bare selector
+// with 5 underlying CH rows + `limit=3` should produce one Stream
+// with three entries; without the clamp it would surface all five.
+func TestQuery_Streams_RespectsLimitParameter(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+	q := &stubQuerier{
+		samples: []chclient.Sample{
+			{MetricName: "line-1", Labels: map[string]string{"job": "api"}, Timestamp: base},
+			{MetricName: "line-2", Labels: map[string]string{"job": "api"}, Timestamp: base.Add(1 * time.Second)},
+			{MetricName: "line-3", Labels: map[string]string{"job": "api"}, Timestamp: base.Add(2 * time.Second)},
+			{MetricName: "line-4", Labels: map[string]string{"job": "api"}, Timestamp: base.Add(3 * time.Second)},
+			{MetricName: "line-5", Labels: map[string]string{"job": "api"}, Timestamp: base.Add(4 * time.Second)},
+		},
+	}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + `/loki/api/v1/query?query=%7Bjob%3D%22api%22%7D&limit=3`)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+
+	var parsed queryResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	raw, _ := json.Marshal(parsed.Data.Result)
+	var streams []loki.Stream
+	if err := json.Unmarshal(raw, &streams); err != nil {
+		t.Fatalf("decode streams: %v", err)
+	}
+	if len(streams) != 1 {
+		t.Fatalf("expected 1 stream (constant labelset), got %d", len(streams))
+	}
+	if got, want := len(streams[0].Values), 3; got != want {
+		t.Fatalf("stream values: got %d, want %d (the 3 latest entries surfaced under direction=backward default)", got, want)
+	}
+	// The latest three timestamps should be line-3, line-4, line-5
+	// — direction=backward orders descending so the response carries
+	// them most-recent-first. Verify by extracting the line bodies
+	// (the second tuple slot in each value).
+	got := map[string]bool{}
+	for _, v := range streams[0].Values {
+		got[v[1]] = true
+	}
+	for _, want := range []string{"line-3", "line-4", "line-5"} {
+		if !got[want] {
+			t.Errorf("expected limit=3 backward clamp to surface %q, got values %v", want, streams[0].Values)
+		}
+	}
+	for _, dropped := range []string{"line-1", "line-2"} {
+		if got[dropped] {
+			t.Errorf("expected limit=3 backward clamp to drop %q, got values %v", dropped, streams[0].Values)
+		}
+	}
+}
+
+// TestQuery_Streams_CollapsesPerEntryLabelsToStreamCount mirrors the
+// loki-compat `regression/drilldown-patterns.yaml#Basic drilldown
+// with json and logfmt parsing` case where each entry has unique
+// parser-extracted labels so every entry surfaces as its own stream.
+// Without the limit clamp every entry would be its own stream, blowing
+// past Loki's documented `limit` ceiling; with the clamp the
+// per-entry-unique labelset still produces one stream per surviving
+// entry, but the total entry count (== stream count) honours the
+// caller's `limit`. Acts as a direct regression test for the
+// "1000 vs 1440" diff the loki-compat differential surfaces.
+func TestQuery_Streams_CollapsesPerEntryLabelsToStreamCount(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+	samples := make([]chclient.Sample, 0, 10)
+	for i := 0; i < 10; i++ {
+		samples = append(samples, chclient.Sample{
+			MetricName: "line-" + strconv.Itoa(i),
+			// Per-entry-unique label so every entry surfaces as
+			// its own Stream — mirrors the parser-stage shape
+			// (json + logfmt extract caller-varying keys per row).
+			Labels:    map[string]string{"job": "api", "request_id": strconv.Itoa(i)},
+			Timestamp: base.Add(time.Duration(i) * time.Second),
+		})
+	}
+	q := &stubQuerier{samples: samples}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + `/loki/api/v1/query?query=%7Bjob%3D%22api%22%7D&limit=4`)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+
+	var parsed queryResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	raw, _ := json.Marshal(parsed.Data.Result)
+	var streams []loki.Stream
+	if err := json.Unmarshal(raw, &streams); err != nil {
+		t.Fatalf("decode streams: %v", err)
+	}
+	if got, want := len(streams), 4; got != want {
+		t.Fatalf("streams length: got %d, want %d (limit=4 clamp, one stream per unique parser-extracted labelset)", got, want)
+	}
+}
+
+// TestQueryRange_Streams_DefaultLimitClampsResponse pins the
+// default-limit behaviour: a /query_range request with no `limit`
+// parameter clamps the response to Loki's documented 100-entry
+// default. Without the clamp every CH row would surface — a
+// long-window log query against a multi-thousand-entry seed would
+// return more entries than `limit=100` callers expect, breaking
+// downstream tools that paginate against Loki's contract.
+func TestQueryRange_Streams_DefaultLimitClampsResponse(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+	samples := make([]chclient.Sample, 0, 250)
+	for i := 0; i < 250; i++ {
+		samples = append(samples, chclient.Sample{
+			MetricName: "line-" + strconv.Itoa(i),
+			Labels:     map[string]string{"job": "api"},
+			Timestamp:  base.Add(time.Duration(i) * time.Second),
+		})
+	}
+	q := &stubQuerier{samples: samples}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	start := strconv.FormatInt(base.Unix(), 10)
+	end := strconv.FormatInt(base.Add(300*time.Second).Unix(), 10)
+	resp, err := http.Get(srv.URL + `/loki/api/v1/query_range?query=%7Bjob%3D%22api%22%7D&start=` + start + `&end=` + end + `&step=60`)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+
+	var parsed queryResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	raw, _ := json.Marshal(parsed.Data.Result)
+	var streams []loki.Stream
+	if err := json.Unmarshal(raw, &streams); err != nil {
+		t.Fatalf("decode streams: %v", err)
+	}
+	if len(streams) != 1 {
+		t.Fatalf("expected 1 stream (constant labelset), got %d", len(streams))
+	}
+	if got, want := len(streams[0].Values), 100; got != want {
+		t.Fatalf("default-limit clamp: got %d entries, want %d (Loki documented default)", got, want)
+	}
+}
+
+// TestQuery_Streams_RespectsForwardDirection pins the wire-format
+// contract that `direction=forward` flips the limit clamp to surface
+// the EARLIEST N entries rather than the latest. The loki-bench
+// harness sets every log case to backward (forward is unsupported by
+// Loki's v2 engine) but the handler still has to accept the parameter
+// per Loki's documented API.
+func TestQuery_Streams_RespectsForwardDirection(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+	q := &stubQuerier{
+		samples: []chclient.Sample{
+			{MetricName: "line-1", Labels: map[string]string{"job": "api"}, Timestamp: base},
+			{MetricName: "line-2", Labels: map[string]string{"job": "api"}, Timestamp: base.Add(1 * time.Second)},
+			{MetricName: "line-3", Labels: map[string]string{"job": "api"}, Timestamp: base.Add(2 * time.Second)},
+			{MetricName: "line-4", Labels: map[string]string{"job": "api"}, Timestamp: base.Add(3 * time.Second)},
+			{MetricName: "line-5", Labels: map[string]string{"job": "api"}, Timestamp: base.Add(4 * time.Second)},
+		},
+	}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + `/loki/api/v1/query?query=%7Bjob%3D%22api%22%7D&limit=2&direction=forward`)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+
+	var parsed queryResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	raw, _ := json.Marshal(parsed.Data.Result)
+	var streams []loki.Stream
+	if err := json.Unmarshal(raw, &streams); err != nil {
+		t.Fatalf("decode streams: %v", err)
+	}
+	if len(streams) != 1 {
+		t.Fatalf("expected 1 stream, got %d", len(streams))
+	}
+	if got, want := len(streams[0].Values), 2; got != want {
+		t.Fatalf("stream values: got %d, want %d", got, want)
+	}
+	got := map[string]bool{}
+	for _, v := range streams[0].Values {
+		got[v[1]] = true
+	}
+	for _, want := range []string{"line-1", "line-2"} {
+		if !got[want] {
+			t.Errorf("expected limit=2 forward clamp to surface %q, got values %v", want, streams[0].Values)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- Cerberus's `/loki/api/v1/{query,query_range}` handlers ignored Loki's `limit` and `direction` URL parameters, returning every matching ClickHouse row instead of the documented up-to-N clamp. With per-entry-unique parser-extracted labels (`| json | logfmt` shape) every entry surfaces under its own labelset, so the unbounded sample stream became a stream-count mismatch on the wire — the loki-compat `regression/drilldown-patterns.yaml#Basic drilldown with json and logfmt parsing` case surfaced as `streams length: expected=1000 actual=1440`.
- Adds Loki's documented `limit` (default 100, max 5000) + `direction` (default backward, accepts forward) handling: `parseLogLimit` / `parseLogDirection` / `clampLogSamples` sort the engine's flat sample slice direction-aware and truncate to `limit` BEFORE `toStreamsWithTransform` groups it by labelset, matching Loki's `limit-applies-to-total-entries-not-per-stream` rule.
- Metric queries don't apply this clamp — their matrix / vector emitters keep their own per-anchor ordering, and the harness only asserts shape (not entry count) on those.

## Root cause

The `regression/drilldown-patterns.yaml#Basic drilldown with json and logfmt parsing` case parses each entry with `| json | logfmt`, so every entry's parser-extracted labels (HTTP method, status, request_id, duration, etc.) make each entry surface as its own Stream. The loki-bench harness sends `limit=1000` so reference Loki returns 1000 such streams; cerberus had no limit handling and returned all 1440 seeded entries as 1440 streams.

## Test plan

- [x] `TestQuery_Streams_RespectsLimitParameter` — bare selector + 5 samples + `limit=3` surfaces only the 3 latest entries.
- [x] `TestQuery_Streams_CollapsesPerEntryLabelsToStreamCount` — mirrors the loki-compat drilldown case: 10 per-entry-unique labelsets + `limit=4` produces exactly 4 streams.
- [x] `TestQueryRange_Streams_DefaultLimitClampsResponse` — 250 samples + no `limit` clamps to 100 (Loki documented default).
- [x] `TestQuery_Streams_RespectsForwardDirection` — `direction=forward` flips to earliest-N truncation.
- [x] `TestQueryRange_BadInput` gains an `invalid limit` row.
- [ ] Loki-compat differential picks up the drilldown case + cascading entry-count drifts on `fast/basic-selectors.yaml` (+2% to +5% overall).

## Expected compat delta

Loki compat lane: `regression/drilldown-patterns.yaml#Basic drilldown with json and logfmt parsing` should flip from `streams length: expected=1000 actual=1440` to PASS. `fast/basic-selectors.yaml` entry-count rows (`expected=253 actual=360`, `expected=261 actual=361`, etc.) similarly fall under the documented 1000-entry clamp once cerberus stops over-surfacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)