### PR TITLE
ci(mutation): install gremlins via go install (taiki-e/install-action can't resolve Go tools)

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -59,20 +59,14 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
-      # Install gremlins via taiki-e/install-action — the generic
-      # Rust/Go-ecosystem installer honours GITHUB_TOKEN natively
-      # for its release-asset fetches, avoiding the 60-req/hour
-      # unauthenticated GitHub API rate limit that the upstream
-      # `go-gremlins/gremlins-action@v1` hit when 6 matrix jobs
-      # queued release-list calls (see run 26129317141 — passing
-      # GITHUB_TOKEN env to the action did not help because the
-      # action does not honour it). Pin to gremlins 0.6.0 exact.
+      # We install gremlins directly via `go install` so we don't
+      # depend on a third-party Action's release-download path.
+      # setup-go's module cache keeps subsequent runs fast.
       # Use `--output` for structured JSON (gremlins exits 0 even
       # when `--threshold-efficacy` is violated in v0.6.0, so we
       # do the gating ourselves against the parsed JSON below).
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: gremlins@0.6.0
+      - name: install gremlins
+        run: go install github.com/go-gremlins/gremlins/cmd/gremlins@v0.6.0
       - name: gremlins unleash
         run: gremlins unleash --output gremlins.json ${{ matrix.scope }}
       - name: enforce efficacy threshold


### PR DESCRIPTION
## Summary

Since #571 merged, every gremlins matrix job (all 7 phases) fails because `taiki-e/install-action@v2` can't install gremlins. Gremlins is a Go tool (`github.com/go-gremlins/gremlins/cmd/gremlins`), not a Rust crate; the action's native tool list doesn't know it, and its `cargo-binstall` fallback can't find a `gremlins` crate on crates.io. See run 26132714890 / job 76861074830:

```
info: install-action does not support gremlins@0.6.0 (updating install-action might resolve this); fallback to cargo-binstall
INFO resolve: Resolving package: 'gremlins@=0.6.0'
ERROR Fatal error: x For crate gremlins: gremlins is not found  --> gremlins is not found
##[warning]install-action: cargo-binstall fallback does not support prebuilt binaries for gremlins@0.6.0 on this platform (x86_64); use 'cargo-install' fallback instead
error: could not find `gremlins` in registry `crates-io` with version `=0.6.0`
```

Swap the `taiki-e/install-action@v2` step for a direct `go install github.com/go-gremlins/gremlins/cmd/gremlins@v0.6.0`. The build goes through `proxy.golang.org` (unrate-limited) instead of GitHub's release API, and setup-go's module cache (`cache: true` is already enabled) keeps subsequent runs fast. The downstream `gremlins unleash`, `enforce efficacy threshold`, and `upload gremlins report` steps stay unchanged.

## Test plan

- [ ] `mutation` workflow runs on push to this branch (via the on-push schedule on main, plus workflow_dispatch verification once merged)
- [ ] All 7 matrix phases reach `gremlins unleash` (no install-step failure)