### PR TITLE
fix(harness/loki-compat): make seed-settle verifier sticky to absorb chunk-flush index gap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,4 +51,13 @@ test/e2e/playwright/node_modules/
 test/e2e/playwright/test-results/
 test/e2e/playwright/playwright-report/
 .claude/worktrees/
-seed
+# Compiled compatibility-seeder binary (the `seed/` package source dir
+# itself must not be ignored, so we anchor the pattern to the binary
+# location rather than using the bare `seed` filename — `seed` without
+# a leading slash matches every path component named `seed` anywhere
+# in the tree, which silently shadowed test files like
+# compatibility/loki/cmd/seed/main_test.go).
+/seed
+/compatibility/loki/cmd/seed/seed
+/compatibility/prometheus/cmd/seed/seed
+/test/e2e/seed/cmd/seed/seed

--- a/compatibility/loki/cmd/seed/main.go
+++ b/compatibility/loki/cmd/seed/main.go
@@ -711,22 +711,39 @@ func verifyBothNonEmpty(ctx context.Context, conn driver.Conn, lokiURL, cerbURL 
 // the ingester needs a moment to flush in-memory chunks into the TSDB
 // index before a /query_range against the same window returns rows.
 //
-// Settle criteria (BOTH must hold):
+// Settle criteria (BOTH must hold at any point during the wait, not
+// necessarily concurrently in the same tick — see the latch rationale
+// below):
 //
-//   - /labels returns >= the expected count of resource label keys
-//     (cluster, namespace, service, service_name, pod, container, env,
-//     region, datacenter — 9 keys from the seed; Loki may also surface
-//     `detected_level` from structured metadata, so we tolerate >=).
-//   - /series with `match[]={service_name!=""}` returns >= the expected
-//     stream count (len(streams), which equals len(serviceConfigs) = 13).
-//     Every seeded stream carries `service_name`, so the not-empty
-//     matcher selects all of them. A non-zero `/series` body is the
-//     strongest pre-query signal that chunks have been indexed: Loki
-//     resolves /series against the same TSDB index a log query consults.
-//     (We avoid the more obvious `=~".+"` form because Loki's TSDB
-//     index treats `service_name` as a discovery-managed label and
-//     returns a partial set under that regex shape — see the seriesURL
-//     comment below.)
+//   - /labels has at some point returned >= the expected count of
+//     resource label keys (cluster, namespace, service, service_name,
+//     pod, container, env, region, datacenter — 9 keys from the seed;
+//     Loki may also surface `detected_level` from structured metadata,
+//     so we tolerate >=).
+//   - /series with `match[]={service_name!=""}` has at some point
+//     returned >= the expected stream count (len(streams), which
+//     equals len(serviceConfigs) = 13). Every seeded stream carries
+//     `service_name`, so the not-empty matcher selects all of them. A
+//     non-zero `/series` body is the strongest pre-query signal that
+//     chunks have been indexed: Loki resolves /series against the same
+//     TSDB index a log query consults. (We avoid the more obvious
+//     `=~".+"` form because Loki's TSDB index treats `service_name` as
+//     a discovery-managed label and returns a partial set under that
+//     regex shape — see the seriesURL comment below.)
+//
+// Latch rationale: Loki's ingester serves /labels + /series from
+// in-memory chunks first, then transparently flips to the BoltDB-backed
+// TSDB index after the periodic chunk flush. During the cutover window
+// (typically a few seconds) /labels can transiently return zero — the
+// in-memory chunks are gone, the BoltDB shipper hasn't yet persisted
+// the freshly-flushed index files. Run 26132714829 hit exactly this
+// shape: both endpoints returned the full cardinality at T=5–25s, then
+// /labels dropped to 0 at T=30s and never recovered before the 90s
+// timeout — even though the harness had clear evidence the index was
+// already fully populated. The latches turn the gate into "have we
+// ever seen the full set" rather than "is the full set visible right
+// now"; once a side latches it stays latched, so a transient regression
+// during the flush window can't unstick a previously-observed signal.
 //
 // Poll: 1s interval, 90s deadline, progress log every 5s — see the
 // `settle*` constants inside. Mirrors the cadence in waitTempoReady /
@@ -779,6 +796,11 @@ func waitLokiIndexSettle(ctx context.Context, baseURL string, streams []stream, 
 	var lastLabels []string
 	var lastSeriesCount int
 	var lastErr error
+	// High-water-mark latches: once each side has been observed at or
+	// above its threshold, the gate considers that side satisfied even
+	// if a subsequent poll regresses (see the latch rationale in the
+	// function-level doc comment).
+	var labelsLatched, seriesLatched bool
 
 	for {
 		labels, err := fetchLokiLabels(ctx, labelsURL)
@@ -796,12 +818,17 @@ func waitLokiIndexSettle(ctx context.Context, baseURL string, streams []stream, 
 
 		labelKeysOK := err == nil && hasAllLabels(labels, expectedLabels)
 		seriesOK := serr == nil && seriesCount >= expectedStreams
-		if labelKeysOK && seriesOK {
-			sort.Strings(labels)
+		labelsLatched = labelsLatched || labelKeysOK
+		seriesLatched = seriesLatched || seriesOK
+		if labelsLatched && seriesLatched {
+			sort.Strings(lastLabels)
 			logger.Info(
 				"loki index settled",
-				"labels", labels,
-				"series", seriesCount,
+				"labels_now", lastLabels,
+				"labels_now_count", len(lastLabels),
+				"labels_needed", len(expectedLabels),
+				"series_now", lastSeriesCount,
+				"series_needed", expectedStreams,
 				"elapsed", time.Since(begin).Round(time.Millisecond),
 			)
 			return nil
@@ -812,8 +839,10 @@ func waitLokiIndexSettle(ctx context.Context, baseURL string, streams []stream, 
 				"still waiting for loki index settle",
 				"labels_seen", len(lastLabels),
 				"labels_needed", len(expectedLabels),
+				"labels_latched", labelsLatched,
 				"series_seen", lastSeriesCount,
 				"series_needed", expectedStreams,
+				"series_latched", seriesLatched,
 				"remaining", time.Until(deadline).Round(time.Second),
 			)
 			lastProgress = time.Now()
@@ -821,11 +850,11 @@ func waitLokiIndexSettle(ctx context.Context, baseURL string, streams []stream, 
 
 		if time.Now().After(deadline) {
 			if lastErr != nil {
-				return fmt.Errorf("loki index settle: last error: %w (labels=%d/%d series=%d/%d after %s)",
-					lastErr, len(lastLabels), len(expectedLabels), lastSeriesCount, expectedStreams, settleTimeout)
+				return fmt.Errorf("loki index settle: last error: %w (labels_latched=%t series_latched=%t labels_now=%d/%d series_now=%d/%d after %s)",
+					lastErr, labelsLatched, seriesLatched, len(lastLabels), len(expectedLabels), lastSeriesCount, expectedStreams, settleTimeout)
 			}
-			return fmt.Errorf("loki index settle: timed out (labels=%d/%d series=%d/%d after %s)",
-				len(lastLabels), len(expectedLabels), lastSeriesCount, expectedStreams, settleTimeout)
+			return fmt.Errorf("loki index settle: timed out (labels_latched=%t series_latched=%t labels_now=%d/%d series_now=%d/%d after %s)",
+				labelsLatched, seriesLatched, len(lastLabels), len(expectedLabels), lastSeriesCount, expectedStreams, settleTimeout)
 		}
 		select {
 		case <-ctx.Done():

--- a/compatibility/loki/cmd/seed/main_test.go
+++ b/compatibility/loki/cmd/seed/main_test.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestWaitLokiIndexSettle_StickyAbsorbsTransientRegression simulates the
+// chunk-flush → BoltDB-persist window where /labels and /series each
+// briefly return the full cardinality (ingester in-memory chunks), then
+// drop to empty (chunks flushed, BoltDB shipper hasn't yet persisted
+// the freshly-flushed index files). Run 26132714829 hit exactly this
+// shape on the real harness.
+//
+// The two endpoints latch at *different ticks* — /labels is full on
+// tick 1 then empty thereafter; /series is empty on tick 1 then full on
+// tick 2 then empty thereafter. The two threshold-crossings never
+// overlap in a single tick. The pre-sticky gate (which required both
+// "now" readings to satisfy the threshold concurrently) would time
+// out; the sticky gate latches each side independently and returns
+// nil on tick 2 after both latches have flipped.
+func TestWaitLokiIndexSettle_StickyAbsorbsTransientRegression(t *testing.T) {
+	t.Parallel()
+
+	// streams here mirrors a slimmed-down version of the seed: 2 streams
+	// each carrying the same single label key. expectedLabelKeys returns
+	// ["k"]; len(streams) == 2.
+	streams := []stream{
+		{labels: map[string]string{"k": "a"}},
+		{labels: map[string]string{"k": "b"}},
+	}
+
+	var labelPolls, seriesPolls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/loki/api/v1/labels"):
+			n := labelPolls.Add(1)
+			// Full only on the first poll; empty on every poll after.
+			var data []string
+			if n == 1 {
+				data = []string{"k"}
+			} else {
+				data = []string{}
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status": "success",
+				"data":   data,
+			})
+		case strings.HasPrefix(r.URL.Path, "/loki/api/v1/series"):
+			n := seriesPolls.Add(1)
+			// Empty on the first poll, full only on the second, empty
+			// on every poll after — the threshold-crossings for the
+			// two endpoints never overlap in a single tick, so the
+			// pre-sticky gate would time out here.
+			var data []map[string]string
+			switch {
+			case n == 2:
+				data = []map[string]string{
+					{"k": "a"},
+					{"k": "b"},
+				}
+			default:
+				data = []map[string]string{}
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status": "success",
+				"data":   data,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	// Use a context with a reasonable bound so a hung test fails fast.
+	// The function's internal 90s deadline is the real upper bound; we
+	// only need a few ticks to exercise the latch behaviour.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	start := time.Unix(0, 0)
+	end := start.Add(1 * time.Hour)
+
+	if err := waitLokiIndexSettle(ctx, srv.URL, streams, start, end, logger); err != nil {
+		t.Fatalf("waitLokiIndexSettle returned error despite latched success: %v", err)
+	}
+}
+
+// TestWaitLokiIndexSettle_NeverLatchedTimesOut confirms the timeout
+// path still fires when neither side ever crosses the threshold — the
+// stickiness must not turn the gate into a no-op for the truly-broken
+// case where Loki never indexes the seed.
+func TestWaitLokiIndexSettle_NeverLatchedTimesOut(t *testing.T) {
+	t.Parallel()
+
+	streams := []stream{
+		{labels: map[string]string{"k": "a"}},
+		{labels: map[string]string{"k": "b"}},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/loki/api/v1/labels"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status": "success",
+				"data":   []string{},
+			})
+		case strings.HasPrefix(r.URL.Path, "/loki/api/v1/series"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status": "success",
+				"data":   []map[string]string{},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	// Use a short context to cut the test off well before the 90s
+	// internal deadline — we only need to confirm "no latch → no
+	// success", not exercise the full timeout path.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	t.Cleanup(cancel)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	start := time.Unix(0, 0)
+	end := start.Add(1 * time.Hour)
+
+	err := waitLokiIndexSettle(ctx, srv.URL, streams, start, end, logger)
+	if err == nil {
+		t.Fatalf("waitLokiIndexSettle returned nil when neither side latched")
+	}
+}

--- a/compatibility/loki/cmd/seed/main_test.go
+++ b/compatibility/loki/cmd/seed/main_test.go
@@ -62,8 +62,8 @@ func TestWaitLokiIndexSettle_StickyAbsorbsTransientRegression(t *testing.T) {
 			// two endpoints never overlap in a single tick, so the
 			// pre-sticky gate would time out here.
 			var data []map[string]string
-			switch {
-			case n == 2:
+			switch n {
+			case 2:
 				data = []map[string]string{
 					{"k": "a"},
 					{"k": "b"},


### PR DESCRIPTION
## Summary

The Loki compat seeder's `waitLokiIndexSettle` polls `/loki/api/v1/labels` and `/loki/api/v1/series` until both report the full cardinality of the seeded fixture (9 label keys + 13 streams). Run [26132714829](https://github.com/tsouza/cerberus/actions/runs/26132714829) failed because Loki's index transiently regressed in the chunk-flush -> BoltDB-persist window: labels were visible at T=5-25s (in-memory ingester chunks), then dropped to 0 at T=30s (chunks flushed, BoltDB shipper hadn't yet persisted the freshly-flushed index files), and never recovered before the 90s timeout - even though both thresholds had clearly been observed earlier.

Bumping the timeout (#561 already took it 30s -> 90s) doesn't help when the verifier insists on *current* consistency. This PR changes the success criterion from "both **current** readings meet threshold" to "both readings have **ever** met threshold during the wait".

## Changes

- `compatibility/loki/cmd/seed/main.go` - add `labelsLatched` / `seriesLatched` high-water-mark booleans alongside the existing per-tick `labelKeysOK` / `seriesOK` computation. Once a side observes its threshold, the latch stays set; the gate fires when both latches are set, regardless of whether the current tick's reading regressed. The settled-log line and the timeout error message now surface the latch state independently from the current readings.
- `compatibility/loki/cmd/seed/main_test.go` (new) - two `httptest`-based unit tests:
  - **StickyAbsorbsTransientRegression** - simulates a Loki where `/labels` is full only on tick 1 and `/series` is full only on tick 2; the threshold-crossings never overlap in a single tick, so the pre-sticky gate would have timed out. Confirms the latch absorbs the gap.
  - **NeverLatchedTimesOut** - simulates a Loki that never returns any data; confirms the stickiness doesn't turn the gate into a no-op when the index is genuinely broken.
- `.gitignore` - the bare `seed` pattern matched every path component named `seed` anywhere in the tree (gitignore patterns without a leading slash are path-component matches), which silently swallowed the new `compatibility/loki/cmd/seed/main_test.go`. Replace with anchored paths to the three actual compiled-binary locations plus a `/seed` for the repo-root build artifact.

## Test plan

- [x] `go test ./compatibility/loki/cmd/seed/ -run TestWaitLokiIndexSettle -v` - both new cases pass locally
- [x] `go build ./compatibility/loki/cmd/seed/` - sanity build clean
- [x] `gofumpt -w` applied to both touched .go files
- [ ] `check` + `lint` CI gates green