### PR TITLE
fix(test/spec/logql): drop empty /b@00:00:00 row from rate_unwrap_json expected_rows

### DIFF
--- a/test/spec/logql/range_mode_rate_unwrap_json.txtar
+++ b/test/spec/logql/range_mode_rate_unwrap_json.txtar
@@ -24,7 +24,6 @@ INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
   [{"path": "/a", "service_name": "api", "status": "200"}, "2026-01-01T00:00:00Z", 0.03333333333333333],
   [{"path": "/a", "service_name": "api", "status": "200"}, "2026-01-01T00:00:30Z", 0.1],
   [{"path": "/a", "service_name": "api", "status": "200"}, "2026-01-01T00:01:00Z", 0.1],
-  [{"path": "/b", "service_name": "api", "status": "500"}, "2026-01-01T00:00:00Z", 0],
   [{"path": "/b", "service_name": "api", "status": "500"}, "2026-01-01T00:00:30Z", 0.1],
   [{"path": "/b", "service_name": "api", "status": "500"}, "2026-01-01T00:01:00Z", 0.4]
 ]


### PR DESCRIPTION
## Summary

PR #578's new `range_mode_rate_unwrap_json.txtar` fixture was generated before PR #577 (log_rate matrix trim) landed. After #577's `WHERE length(\`window_vals\`) >= 1` filter went into the `log_rate` emission, the zero-fill `{/b, 00:00:00}` row no longer materialises in the chDB roundtrip.

Post-#578 main pushed at 01:07:04, and the chdb workflow (run 26134959942) failed with `TestRoundTripChDB/range_mode_rate_unwrap_json` — `got = 5 rows / want = 6 rows`. Drop the stale row.

## Test plan

- [ ] `check` job goes green (was failing on chdb roundtrip)
- [ ] No change to SQL or chplan sections; only `-- expected_rows --` content trimmed by one row

🤖 Generated with [Claude Code](https://claude.com/claude-code)