### PR TITLE
fix(harness/loki-compat): skip "Drilldown count" case missing duration keyword in seed metadata

### DIFF
--- a/compatibility/loki/cerberus-test-queries.yml
+++ b/compatibility/loki/cerberus-test-queries.yml
@@ -149,6 +149,17 @@ should_skip:
     since: "2026-05-15"
     jira:  "docs/loki-compliance-plan.md PR 6"
 
+  # regression/drilldown-patterns.yaml — seed-gap entry. The case requires
+  # the `duration` content keyword but the checked-in dataset_metadata.json
+  # only exposes {debug, error, failed, level, refused} in `by_keyword`
+  # (the seeder emits `duration_ms` / `duration=...ms` substrings but the
+  # metadata snapshot is conservative). Resolver rejects with
+  # `no streams with keyword: duration` before the query hits the wire.
+  - source: "regression/drilldown-patterns.yaml#Drilldown count with complex filters"
+    reason: "Requires `duration` content keyword; dataset_metadata.json's `by_keyword` only exposes {debug, error, failed, level, refused}. ${SELECTOR} expansion rejects before the case can run."
+    since: "2026-05-20"
+    jira:  "docs/loki-compliance-plan.md PR 6 (seed-metadata gap)"
+
   # exhaustive/aggregations.yaml — most entries lifted now that `| unwrap`,
   # value range aggs, and range-agg grouping land. Remaining skips are
   # seed-gap entries (labels the seeder doesn't emit yet).


### PR DESCRIPTION
## Summary

The `regression/drilldown-patterns.yaml#Drilldown count with complex filters` case carries `requires.keywords: [duration]`, but the checked-in `compatibility/loki/dataset_metadata.json` only exposes `{debug, error, failed, level, refused}` in its `by_keyword` map. The `MetadataVariableResolver.resolveLabelSelector` therefore rejects the case during template expansion with `no streams with keyword: duration`, surfacing in run [26134959921](https://github.com/tsouza/cerberus/actions/runs/26134959921) as an `unexpected_failure`:

```
expansion: expand "Drilldown count with complex filters": failed to resolve query: failed to resolve ${SELECTOR}: no streams with keyword: duration
```

This is a seed-metadata gap, not a cerberus-side bug — the seeder writes `duration_ms` / `duration=...ms` substrings to every JSON / logfmt line, but the metadata snapshot was generated with a conservative keyword set.

## Fix

Add a `should_skip` overlay entry in `compatibility/loki/cerberus-test-queries.yml` mirroring the existing seed-gap rows under `regression/structured-metadata.yaml`. The case is suppressed before it hits the wire, with a documented reason citing the metadata gap. Once `dataset_metadata.json` regenerates with the broader keyword set that the upstream `getContentKeywords` table exposes, this entry can be dropped.

## Test plan

- [x] YAML structure matches the existing overlay rows (`source` / `reason` / `since` / `jira` keys, `<suite>/<file>.yaml#<description>` source format).
- [x] `cerberus-test-queries.yml` parses against the `Overlay` struct in `compatibility/loki/cmd/loki-compliance-tester/main.go`.
- [ ] Compatibility CI run drops the `Drilldown count with complex filters` row from `unexpected_failures` and surfaces it as a documented skip.