### PR TITLE
fix(harness/loki-compat): add duration to dataset_metadata.json by_keyword map

### DIFF
--- a/compatibility/loki/dataset_metadata.json
+++ b/compatibility/loki/dataset_metadata.json
@@ -37,19 +37,45 @@
     ]
   },
   "by_service_name": {
-    "web-server": ["{cluster=\"cluster-0\", container=\"container-0\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-0\", pod=\"pod-0\", region=\"us-east-1\", service=\"web-server\", service_name=\"web-server\"}"],
-    "database": ["{cluster=\"cluster-0\", container=\"container-0\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-0\", pod=\"pod-1\", region=\"us-east-1\", service=\"database\", service_name=\"database\"}"],
-    "cache": ["{cluster=\"cluster-0\", container=\"container-0\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-1\", pod=\"pod-2\", region=\"us-east-1\", service=\"cache\", service_name=\"cache\"}"],
-    "auth-service": ["{cluster=\"cluster-0\", container=\"container-0\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-1\", pod=\"pod-3\", region=\"us-east-1\", service=\"auth-service\", service_name=\"auth-service\"}"],
-    "kafka": ["{cluster=\"cluster-1\", container=\"container-1\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-2\", pod=\"pod-4\", region=\"us-east-1\", service=\"kafka\", service_name=\"kafka\"}"],
-    "prometheus": ["{cluster=\"cluster-1\", container=\"container-1\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-2\", pod=\"pod-5\", region=\"us-east-1\", service=\"prometheus\", service_name=\"prometheus\"}"],
-    "loki": ["{cluster=\"cluster-1\", container=\"container-1\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-3\", pod=\"pod-6\", region=\"us-east-1\", service=\"loki\", service_name=\"loki\"}"],
-    "mimir": ["{cluster=\"cluster-1\", container=\"container-1\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-3\", pod=\"pod-7\", region=\"us-east-1\", service=\"mimir\", service_name=\"mimir\"}"],
-    "tempo": ["{cluster=\"cluster-1\", container=\"container-1\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-4\", pod=\"pod-8\", region=\"us-east-1\", service=\"tempo\", service_name=\"tempo\"}"],
-    "grafana": ["{cluster=\"cluster-1\", container=\"container-1\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-4\", pod=\"pod-9\", region=\"us-east-1\", service=\"grafana\", service_name=\"grafana\"}"],
-    "nginx": ["{cluster=\"cluster-0\", container=\"container-0\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-0\", pod=\"pod-10\", region=\"us-east-1\", service=\"nginx\", service_name=\"nginx\"}"],
-    "kubernetes": ["{cluster=\"cluster-0\", container=\"container-0\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-1\", pod=\"pod-11\", region=\"us-east-1\", service=\"kubernetes\", service_name=\"kubernetes\"}"],
-    "syslog": ["{cluster=\"cluster-1\", container=\"container-1\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-4\", pod=\"pod-12\", region=\"us-east-1\", service=\"syslog\", service_name=\"syslog\"}"]
+    "web-server": [
+      "{cluster=\"cluster-0\", container=\"container-0\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-0\", pod=\"pod-0\", region=\"us-east-1\", service=\"web-server\", service_name=\"web-server\"}"
+    ],
+    "database": [
+      "{cluster=\"cluster-0\", container=\"container-0\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-0\", pod=\"pod-1\", region=\"us-east-1\", service=\"database\", service_name=\"database\"}"
+    ],
+    "cache": [
+      "{cluster=\"cluster-0\", container=\"container-0\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-1\", pod=\"pod-2\", region=\"us-east-1\", service=\"cache\", service_name=\"cache\"}"
+    ],
+    "auth-service": [
+      "{cluster=\"cluster-0\", container=\"container-0\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-1\", pod=\"pod-3\", region=\"us-east-1\", service=\"auth-service\", service_name=\"auth-service\"}"
+    ],
+    "kafka": [
+      "{cluster=\"cluster-1\", container=\"container-1\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-2\", pod=\"pod-4\", region=\"us-east-1\", service=\"kafka\", service_name=\"kafka\"}"
+    ],
+    "prometheus": [
+      "{cluster=\"cluster-1\", container=\"container-1\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-2\", pod=\"pod-5\", region=\"us-east-1\", service=\"prometheus\", service_name=\"prometheus\"}"
+    ],
+    "loki": [
+      "{cluster=\"cluster-1\", container=\"container-1\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-3\", pod=\"pod-6\", region=\"us-east-1\", service=\"loki\", service_name=\"loki\"}"
+    ],
+    "mimir": [
+      "{cluster=\"cluster-1\", container=\"container-1\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-3\", pod=\"pod-7\", region=\"us-east-1\", service=\"mimir\", service_name=\"mimir\"}"
+    ],
+    "tempo": [
+      "{cluster=\"cluster-1\", container=\"container-1\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-4\", pod=\"pod-8\", region=\"us-east-1\", service=\"tempo\", service_name=\"tempo\"}"
+    ],
+    "grafana": [
+      "{cluster=\"cluster-1\", container=\"container-1\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-4\", pod=\"pod-9\", region=\"us-east-1\", service=\"grafana\", service_name=\"grafana\"}"
+    ],
+    "nginx": [
+      "{cluster=\"cluster-0\", container=\"container-0\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-0\", pod=\"pod-10\", region=\"us-east-1\", service=\"nginx\", service_name=\"nginx\"}"
+    ],
+    "kubernetes": [
+      "{cluster=\"cluster-0\", container=\"container-0\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-1\", pod=\"pod-11\", region=\"us-east-1\", service=\"kubernetes\", service_name=\"kubernetes\"}"
+    ],
+    "syslog": [
+      "{cluster=\"cluster-1\", container=\"container-1\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-4\", pod=\"pod-12\", region=\"us-east-1\", service=\"syslog\", service_name=\"syslog\"}"
+    ]
   },
   "statistics": {
     "generated": "2026-05-15T00:00:00Z",
@@ -345,6 +371,17 @@
       "{cluster=\"cluster-0\", container=\"container-0\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-1\", pod=\"pod-2\", region=\"us-east-1\", service=\"cache\", service_name=\"cache\"}",
       "{cluster=\"cluster-0\", container=\"container-0\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-1\", pod=\"pod-3\", region=\"us-east-1\", service=\"auth-service\", service_name=\"auth-service\"}",
       "{cluster=\"cluster-1\", container=\"container-1\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-2\", pod=\"pod-4\", region=\"us-east-1\", service=\"kafka\", service_name=\"kafka\"}",
+      "{cluster=\"cluster-1\", container=\"container-1\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-2\", pod=\"pod-5\", region=\"us-east-1\", service=\"prometheus\", service_name=\"prometheus\"}",
+      "{cluster=\"cluster-1\", container=\"container-1\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-3\", pod=\"pod-6\", region=\"us-east-1\", service=\"loki\", service_name=\"loki\"}",
+      "{cluster=\"cluster-1\", container=\"container-1\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-3\", pod=\"pod-7\", region=\"us-east-1\", service=\"mimir\", service_name=\"mimir\"}",
+      "{cluster=\"cluster-1\", container=\"container-1\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-4\", pod=\"pod-8\", region=\"us-east-1\", service=\"tempo\", service_name=\"tempo\"}",
+      "{cluster=\"cluster-1\", container=\"container-1\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-4\", pod=\"pod-9\", region=\"us-east-1\", service=\"grafana\", service_name=\"grafana\"}"
+    ],
+    "duration": [
+      "{cluster=\"cluster-0\", container=\"container-0\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-0\", pod=\"pod-0\", region=\"us-east-1\", service=\"web-server\", service_name=\"web-server\"}",
+      "{cluster=\"cluster-0\", container=\"container-0\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-0\", pod=\"pod-1\", region=\"us-east-1\", service=\"database\", service_name=\"database\"}",
+      "{cluster=\"cluster-0\", container=\"container-0\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-1\", pod=\"pod-2\", region=\"us-east-1\", service=\"cache\", service_name=\"cache\"}",
+      "{cluster=\"cluster-0\", container=\"container-0\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-1\", pod=\"pod-3\", region=\"us-east-1\", service=\"auth-service\", service_name=\"auth-service\"}",
       "{cluster=\"cluster-1\", container=\"container-1\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-2\", pod=\"pod-5\", region=\"us-east-1\", service=\"prometheus\", service_name=\"prometheus\"}",
       "{cluster=\"cluster-1\", container=\"container-1\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-3\", pod=\"pod-6\", region=\"us-east-1\", service=\"loki\", service_name=\"loki\"}",
       "{cluster=\"cluster-1\", container=\"container-1\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-3\", pod=\"pod-7\", region=\"us-east-1\", service=\"mimir\", service_name=\"mimir\"}",


### PR DESCRIPTION
## Summary

The `regression/drilldown-patterns.yaml#Drilldown count with complex filters` case carries `requires.keywords: [duration]`, but the checked-in `dataset_metadata.json` snapshot's `by_keyword` map only listed `{debug, error, failed, level, refused}`. The vendored `metadata_resolver.resolveLabelSelector` therefore aborted `${SELECTOR}` expansion with `no streams with keyword: duration` — surfacing as `unexpectedFailure: "expansion: ..."` in the Loki compat report (run 26134959921).

## Root cause

The seeder DOES emit `duration_ms` (JSON path) and `duration=Xms` (logfmt path) on **every** log line of **every** service except kafka — per `getContentKeywords()` in `compatibility/loki/upstream/loki-bench/metadata.go`. The metadata snapshot just predates that emission, or was generated with a narrower keyword set. So the right fix is to update the snapshot to reflect what the seeder actually produces, not to add a `should_skip` overlay (which would hide the test, against repo policy).

## Fix

Extend `by_keyword.duration` with all 9 non-kafka selectors (`web-server`, `database`, `cache`, `auth-service`, `prometheus`, `mimir`, `loki`, `tempo`, `grafana`). The harness can now resolve `${SELECTOR}` to a real selector and the case exercises actual cerberus query behavior.

## Expected delta

`unexpectedFailure: "expansion: ..."` clears for this case → reference Loki + cerberus both run the query → if both return the same data, +1.47pp Loki score (95.59% → 97.06%). If they diff, the next sweep surfaces a real bug to fix.

## Test plan

- [ ] `check` + `lint` green
- [ ] Next nightly compat run no longer reports `expansion: expand "Drilldown count with complex filters"` failure
- [ ] Loki compat score either climbs or surfaces a new (real) diff

Replaces PR #580 (which proposed a `should_skip` overlay — wrong direction per the task spec and repo's anti-skip policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)