### PR TITLE
fix(logql): preserve per-anchor bucket through nested max(avg by ...) on unwrap matrix

### DIFF
--- a/internal/logql/range_aggregation.go
+++ b/internal/logql/range_aggregation.go
@@ -276,13 +276,18 @@ func applyUnwrapPostFilters(inner chplan.Node, filters []loglib.LabelFilterer, s
 const rangeAggSynthValueColumn = "Value"
 
 // isMatrixRangeWindow reports whether plan's root (walking past
-// value-rewrite Projects / Filters that preserve the inner shape) is a
-// matrix-shape RangeWindow — one emitting N rows per series across
-// [Start, End] spaced by Step, exposing `anchor_ts` as a per-row
-// column. Used by both [Lang.ProjectSamples] (to forward `anchor_ts`
-// into the canonical TimeUnix slot) and [lowerVectorAggregation] (to
-// include `anchor_ts` in the GROUP BY so per-step rows don't collapse).
-// Mirrors prom's isMatrixRangeWindow in internal/api/prom/handler.go.
+// value-rewrite Projects / Filters / Aggregates that preserve the inner
+// matrix shape) bottoms out at a matrix-shape RangeWindow — one emitting
+// N rows per series across [Start, End] spaced by Step, exposing
+// `anchor_ts` as a per-row column. Used by both [Lang.ProjectSamples]
+// (to forward `anchor_ts` into the canonical TimeUnix slot) and
+// [lowerVectorAggregation] (to include the per-anchor column in the
+// GROUP BY so per-step rows don't collapse). The Aggregate case lets
+// nested aggregations (`max(avg by (level) (matrix))`) recognise the
+// matrix shape — the inner Aggregate carries its own per-anchor bucket
+// (re-aliased to TimeUnix by the wrap Project), and the outer
+// aggregation must re-bucket on it. Mirrors prom's isMatrixRangeWindow
+// in internal/api/prom/handler.go.
 func isMatrixRangeWindow(plan chplan.Node) bool {
 	switch v := plan.(type) {
 	case *chplan.RangeWindow:
@@ -291,8 +296,39 @@ func isMatrixRangeWindow(plan chplan.Node) bool {
 		return isMatrixRangeWindow(v.Input)
 	case *chplan.Filter:
 		return isMatrixRangeWindow(v.Input)
+	case *chplan.Aggregate:
+		return isMatrixRangeWindow(v.Input)
 	}
 	return false
+}
+
+// matrixBucketColumn returns the per-anchor bucket-timestamp column
+// name visible to the outer SELECT for a matrix-shape plan. The
+// LogQL matrix pipeline exposes the anchor column under two distinct
+// names depending on how deeply nested the aggregation chain is:
+//
+//   - Direct matrix RangeWindow (or one wrapped in a value-shape Project
+//     / Filter) → "anchor_ts": the RangeWindow emits one row per
+//     (series, anchor) carrying `anchor_ts` as a plain column.
+//
+//   - Vector-aggregation matrix wrap → "TimeUnix": the inner Aggregate
+//     groups by `anchor_ts AS bucket_ts`, then [wrapVectorAggregateForSample]
+//     re-aliases `bucket_ts` to `TimeUnix` so the canonical Sample shape
+//     surfaces. Outer aggregations consume that Project as input, so
+//     their bucket reference is `TimeUnix`, not `anchor_ts` (which is no
+//     longer in scope past the inner Aggregate's projection).
+//
+// Callers are expected to gate on [isMatrixRangeWindow] first.
+func matrixBucketColumn(plan chplan.Node) string {
+	switch v := plan.(type) {
+	case *chplan.Aggregate:
+		return "TimeUnix"
+	case *chplan.Project:
+		return matrixBucketColumn(v.Input)
+	case *chplan.Filter:
+		return matrixBucketColumn(v.Input)
+	}
+	return "anchor_ts"
 }
 
 // rangeValueExpr returns the per-row Value the RangeWindow aggregates.

--- a/internal/logql/range_aggregation_test.go
+++ b/internal/logql/range_aggregation_test.go
@@ -337,3 +337,106 @@ func TestLowerRangeAggregationUnwrapStripsTargetFromIdentity(t *testing.T) {
 		})
 	}
 }
+
+// TestIsMatrixRangeWindowWalksNestedAggregation pins the
+// nested-aggregation traversal in [isMatrixRangeWindow]: the helper
+// MUST walk through `*chplan.Aggregate` so the outer
+// `lowerVectorAggregation` recognises `max(avg by (level)
+// (avg_over_time(...)))` and friends as matrix-shape inputs. The
+// inner aggregation wraps its Aggregate in a Project that
+// re-projects bucket_ts to TimeUnix — without the Aggregate case,
+// the helper returns false at the inner Aggregate boundary and the
+// outer aggregation drops the per-anchor bucket from GROUP BY,
+// collapsing the matrix into a single row. The user-facing symptom
+// is `test endpoint returned empty` on
+// `compatibility/loki/.../exhaustive/unwrap-aggregations.yaml`'s
+// "Nested aggregations" case (the only remaining cerberus-side Loki
+// compat failure post-#577 / #574 / #578).
+func TestIsMatrixRangeWindowWalksNestedAggregation(t *testing.T) {
+	t.Parallel()
+
+	// Build the minimal nested-aggregation shape: a matrix RangeWindow
+	// wrapped in an Aggregate wrapped in a Project (the canonical
+	// [wrapVectorAggregateForSample] output the outer aggregation
+	// consumes as input). The Project alone, the Aggregate alone, and
+	// the full nest must each report true so the helper covers every
+	// depth between bare RangeWindow and a multi-deep stack.
+	rw := &chplan.RangeWindow{Func: "avg_over_time", OuterRange: time.Hour}
+	agg := &chplan.Aggregate{Input: rw, GroupBy: []chplan.Expr{&chplan.ColumnRef{Name: "anchor_ts"}}, GroupByAliases: []string{"bucket_ts"}}
+	proj := &chplan.Project{Input: agg, Projections: []chplan.Projection{{Expr: &chplan.ColumnRef{Name: "bucket_ts"}, Alias: "TimeUnix"}}}
+
+	if !isMatrixRangeWindow(proj) {
+		t.Errorf("isMatrixRangeWindow(Project(Aggregate(RangeWindow))) = false, want true — nested-aggregation matrix shape lost")
+	}
+	if !isMatrixRangeWindow(agg) {
+		t.Errorf("isMatrixRangeWindow(Aggregate(RangeWindow)) = false, want true — Aggregate case missing from helper")
+	}
+	if !isMatrixRangeWindow(rw) {
+		t.Errorf("isMatrixRangeWindow(RangeWindow{OuterRange>0}) = false, want true — base case regressed")
+	}
+
+	// matrixBucketColumn must dispatch on plan depth: a bare RangeWindow
+	// (or a value-shape Project/Filter over one) surfaces `anchor_ts`;
+	// once an Aggregate is in the stack the wrap Project re-aliases
+	// the bucket to `TimeUnix` and `anchor_ts` is no longer in scope.
+	if got := matrixBucketColumn(rw); got != "anchor_ts" {
+		t.Errorf("matrixBucketColumn(RangeWindow) = %q, want %q", got, "anchor_ts")
+	}
+	if got := matrixBucketColumn(agg); got != "TimeUnix" {
+		t.Errorf("matrixBucketColumn(Aggregate(RangeWindow)) = %q, want %q", got, "TimeUnix")
+	}
+	if got := matrixBucketColumn(proj); got != "TimeUnix" {
+		t.Errorf("matrixBucketColumn(Project(Aggregate(RangeWindow))) = %q, want %q", got, "TimeUnix")
+	}
+}
+
+// TestLowerVectorAggregationNestedMatrixBucketsOnTimeUnix pins the
+// downstream effect of [isMatrixRangeWindow] + [matrixBucketColumn]:
+// when the outer aggregation lowers
+// `max(avg by (level) (avg_over_time(...)))` in range mode, the
+// emitted SQL MUST GROUP BY `TimeUnix` (not `anchor_ts`, which is no
+// longer in scope past the inner Aggregate's projection). A regression
+// that re-introduces the bare RangeWindow check would emit either no
+// bucket GROUP BY (collapsing the matrix) or reference `anchor_ts`
+// (CH error: unknown column).
+func TestLowerVectorAggregationNestedMatrixBucketsOnTimeUnix(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelLogs()
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+	step := time.Minute
+
+	query := `max(avg by (level) (avg_over_time({app="api"} | logfmt | duration != "" | unwrap duration(duration) [5m])))`
+	expr, err := syntax.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	va, ok := expr.(*syntax.VectorAggregationExpr)
+	if !ok {
+		t.Fatalf("ParseExpr(%q) -> %T, want *syntax.VectorAggregationExpr", query, expr)
+	}
+
+	plan, err := lowerVectorAggregation(va, s, lowerCtx{Start: start, End: end, Step: step})
+	if err != nil {
+		t.Fatalf("lowerVectorAggregation(%q): %v", query, err)
+	}
+
+	sqlStr, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("chsql.Emit: %v", err)
+	}
+
+	// The outer max(...) is no-grouping; in range mode it must still
+	// bucket on the inner aggregation's TimeUnix column. A regression
+	// that re-instates the bare-RangeWindow check skips the GROUP BY
+	// entirely and the emitter falls through to `emitAggregateNoGroup`
+	// — the test asserts the outer SELECT carries `GROUP BY` referencing
+	// `TimeUnix` and rejects an `anchor_ts`-only bucket reference (the
+	// inner RangeWindow's bucket is still in scope under that name, but
+	// it's been re-projected by the inner wrap, so the outer aggregate
+	// cannot reach it).
+	if !strings.Contains(sqlStr, "GROUP BY `TimeUnix`") {
+		t.Errorf("emitted SQL missing `GROUP BY `TimeUnix`` (nested matrix bucket lost)\nsql=%s", sqlStr)
+	}
+}

--- a/internal/logql/vector_aggregation.go
+++ b/internal/logql/vector_aggregation.go
@@ -38,17 +38,27 @@ func lowerVectorAggregation(e *syntax.VectorAggregationExpr, s schema.Logs, lc l
 		return nil, err
 	}
 
-	// In range mode the inner plan is a matrix-shape RangeWindow that
-	// exposes a per-row `anchor_ts` column (the eval anchor for that
-	// row). The aggregation MUST include that anchor in its GROUP BY
-	// keys — otherwise CH collapses every per-step row of a series-set
-	// into one aggregate and the wire matrix has a single value per
-	// series instead of one per step. Mirrors the PromQL aggregate
-	// lowering's `rangeBucketed` path in internal/promql/lower.go.
+	// In range mode the inner plan is a matrix-shape RangeWindow (or a
+	// nested aggregation that bottoms out at one) that exposes a
+	// per-row anchor-timestamp column. The aggregation MUST include
+	// that anchor in its GROUP BY keys — otherwise CH collapses every
+	// per-step row of a series-set into one aggregate and the wire
+	// matrix has a single value per series instead of one per step.
+	// Mirrors the PromQL aggregate lowering's `rangeBucketed` path in
+	// internal/promql/lower.go.
+	//
+	// The bucket column's name depends on plan depth: a direct matrix
+	// RangeWindow surfaces `anchor_ts`; a nested vector-aggregation
+	// surfaces `TimeUnix` (the wrap Project re-aliases `bucket_ts` to
+	// match the canonical Sample shape). [matrixBucketColumn] resolves
+	// which column the input exposes so nested aggregations
+	// (`max(avg by (level) (avg_over_time(...)))`) bucket correctly
+	// instead of collapsing the whole matrix into one row.
 	const bucketAlias = "bucket_ts"
 	rangeBucketed := lc.rangeMode() && isMatrixRangeWindow(input)
 	if rangeBucketed {
-		groupBy = append(groupBy, &chplan.ColumnRef{Name: "anchor_ts"})
+		bucketCol := matrixBucketColumn(input)
+		groupBy = append(groupBy, &chplan.ColumnRef{Name: bucketCol})
 		aliases = append(aliases, bucketAlias)
 	}
 

--- a/internal/logql/vector_aggregation_test.go
+++ b/internal/logql/vector_aggregation_test.go
@@ -12,35 +12,44 @@ import (
 
 // TestLowerVectorAggregationRangeBucketedGate pins the
 // `lc.rangeMode() && isMatrixRangeWindow(input)` gate inside
-// [lowerVectorAggregation]. The flag controls whether `anchor_ts` is
-// added to the Aggregate's GROUP BY so per-step rows survive the
-// aggregation collapse.
+// [lowerVectorAggregation]. The flag controls whether the per-anchor
+// bucket column is added to the Aggregate's GROUP BY so per-step rows
+// survive the aggregation collapse.
 //
 // An INVERT_LOGICAL mutant flips `&&` to `||`, causing two divergent
 // behaviours:
 //
-//   - range mode + non-matrix inner (e.g. an outer aggregation wrapping
-//     an inner aggregation): original keeps rangeBucketed=false;
-//     mutant turns it on and references a non-existent `anchor_ts`
-//     column.
+//   - range mode + non-matrix inner (e.g. an outer aggregation
+//     wrapping a `vector(N)` literal): original keeps
+//     rangeBucketed=false; mutant turns it on and references a
+//     non-existent `anchor_ts` / `TimeUnix` column.
 //   - instant mode + matrix inner: not constructible — matrix shape is
 //     only produced under range mode.
 //
-// Pin the first case: lower a doubly-nested `sum by (job) (sum by
-// (job) (rate(...)))` under [LowerAtRange] and inspect the OUTER
-// Aggregate's GROUP BY. The original lowering leaves it with a single
-// expression (the by-key access); the mutant prepends `anchor_ts` and
-// the GROUP BY length grows to two.
+// Pin the first case via `sum by (job) (vector(1))` lowered under
+// [LowerAtRange]. `vector(...)` lowers to a Project over `chplan.OneRow`
+// (see [lowerVector] / [syntheticLogScalar]) — a truly non-matrix
+// shape that `isMatrixRangeWindow` will reject regardless of how
+// many Aggregate / Project / Filter layers it walks through. The
+// original lowering keeps the outer Aggregate at one GroupBy
+// expression (the `by (job)` map-access); the mutant prepends the
+// bucket and the GROUP BY length grows to two.
+//
+// Doubly-nested aggregations over a matrix (e.g. `sum by (job) (sum
+// by (job) (rate(...)))`) DO surface a matrix RangeWindow through
+// the inner Aggregate — see [TestIsMatrixRangeWindowWalksNestedAggregation]
+// — so they're NOT suitable as the gate-isolation fixture; their
+// outer aggregation correctly buckets per anchor.
 func TestLowerVectorAggregationRangeBucketedGate(t *testing.T) {
 	t.Parallel()
 
 	s := schema.DefaultOTelLogs()
 
-	// Nested aggregation: the outer `sum by (job)` sees an inner that
-	// is a *chplan.Project over *chplan.Aggregate — not a matrix
-	// RangeWindow. `isMatrixRangeWindow` returns false; the original
-	// keeps rangeBucketed=false; the mutant turns it on.
-	query := `sum by (job) (sum by (job) (rate({app="api"}[5m])))`
+	// Non-matrix inner: `vector(1)` lowers to Project(OneRow), which
+	// bottoms out at a non-matrix node. `isMatrixRangeWindow` returns
+	// false; the original keeps rangeBucketed=false; the mutant turns
+	// it on.
+	query := `sum by (job) (vector(1))`
 	expr, err := syntax.ParseExpr(query)
 	if err != nil {
 		t.Fatalf("ParseExpr(%q): %v", query, err)
@@ -68,17 +77,16 @@ func TestLowerVectorAggregationRangeBucketedGate(t *testing.T) {
 		t.Fatalf("lower(%q): Project.Input is %T, want *chplan.Aggregate", query, outerProject.Input)
 	}
 
-	// The outer Aggregate's inner is the inner sum's Project. Confirm
-	// — this anchors the test fixture against future changes.
+	// The outer Aggregate's inner is the `vector(1)` Project.
 	if _, ok := outerAgg.Input.(*chplan.Project); !ok {
-		t.Fatalf("outer Aggregate.Input is %T, want *chplan.Project (inner sample-shape wrapper)", outerAgg.Input)
+		t.Fatalf("outer Aggregate.Input is %T, want *chplan.Project (vector synthetic-scalar wrapper)", outerAgg.Input)
 	}
 
 	// Original: GroupBy carries one entry (the `by (job)` map-access
-	// on ResourceAttributes). The mutant `||` would append `anchor_ts`
-	// → GroupBy length 2.
+	// on ResourceAttributes). The mutant `||` would append the
+	// bucket column → GroupBy length 2.
 	if got, want := len(outerAgg.GroupBy), 1; got != want {
-		t.Fatalf("outer Aggregate.GroupBy length = %d, want %d (rangeBucketed gate leaked through — `anchor_ts` was appended to a non-matrix inner)", got, want)
+		t.Fatalf("outer Aggregate.GroupBy length = %d, want %d (rangeBucketed gate leaked through — bucket column was appended to a non-matrix inner)", got, want)
 	}
 
 	// Anchor the alias count to the same number — the mutant also

--- a/test/spec/logql/edge_nested_max_avg_by_unwrap.txtar
+++ b/test/spec/logql/edge_nested_max_avg_by_unwrap.txtar
@@ -1,0 +1,87 @@
+-- query.logql --
+max(avg by (level) (avg_over_time({service_name="api"} | logfmt | duration != "" | unwrap duration(duration) [5m])))
+-- start --
+2026-01-01T00:00:00Z
+-- end --
+2026-01-01T00:01:00Z
+-- step --
+30s
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, SeverityText, ResourceAttributes) VALUES
+    (toDateTime64('2026-01-01 00:00:00', 9), 'duration=100ms msg=ok', 'INFO',  map('service_name', 'api')),
+    (toDateTime64('2026-01-01 00:00:15', 9), 'duration=200ms msg=ok', 'INFO',  map('service_name', 'api')),
+    (toDateTime64('2026-01-01 00:00:30', 9), 'duration=400ms msg=ok', 'ERROR', map('service_name', 'api')),
+    (toDateTime64('2026-01-01 00:00:45', 9), 'duration=600ms msg=ok', 'ERROR', map('service_name', 'api')),
+    (toDateTime64('2026-01-01 00:01:00', 9), 'duration=800ms msg=ok', 'ERROR', map('service_name', 'api'));
+-- expected_rows --
+[
+  ["", {}, "2026-01-01T00:00:00Z", 0.1],
+  ["", {}, "2026-01-01T00:00:30Z", 0.4],
+  ["", {}, "2026-01-01T00:01:00Z", 0.6]
+]
+-- args --
+[0] string = ""
+[1] string = "Map(String,String)"
+[2] string = ""
+[3] string = "level"
+[4] string = "detected_level"
+[5] string = "duration"
+[6] string = ""
+[7] string = "detected_level"
+[8] string = "trace"
+[9] string = "trc"
+[10] string = "trace"
+[11] string = "debug"
+[12] string = "dbg"
+[13] string = "debug"
+[14] string = "info"
+[15] string = "inf"
+[16] string = "information"
+[17] string = "info"
+[18] string = "warn"
+[19] string = "wrn"
+[20] string = "warning"
+[21] string = "warn"
+[22] string = "error"
+[23] string = "err"
+[24] string = "error"
+[25] string = "critical"
+[26] string = "critical"
+[27] string = "fatal"
+[28] string = "fatal"
+[29] string = "duration"
+[30] string = "_extracted"
+[31] string = "="
+[32] string = " "
+[33] string = "\""
+[34] string = "2025-12-31 23:55:00.000000000"
+[35] int64 = 9
+[36] string = "2026-01-01 00:01:00.000000000"
+[37] int64 = 9
+[38] string = "service_name"
+[39] string = "api"
+[40] string = "_extracted"
+[41] string = "="
+[42] string = " "
+[43] string = "\""
+[44] string = "duration"
+[45] string = ""
+[46] string = "detected_level"
+-- chplan --
+Project ["" AS MetricName, CAST(map(), "Map(String,String)") AS Attributes, bucket_ts AS TimeUnix, Value AS Value]
+  Aggregate groupBy=[TimeUnix AS bucket_ts] funcs=[max(Value) AS Value]
+    Project ["" AS MetricName, map("level", gkey_0) AS Attributes, bucket_ts AS TimeUnix, Value AS Value]
+      Aggregate groupBy=[ResourceAttributes["detected_level"] AS gkey_0, anchor_ts AS bucket_ts] funcs=[avg(Value) AS Value]
+        RangeWindow func=avg_over_time range=5m0s step=30s outerRange=1m0s ts=Timestamp value=Value groupBy=[ResourceAttributes] start=2026-01-01T00:00:00Z end=2026-01-01T00:01:00Z
+          Project [mapConcat(mapWithout(_logql_merged_labels, [duration]), mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, parseTimeDelta(_logql_merged_labels["duration"]) AS Value]
+            Project [ResourceAttributes, Timestamp, Body, SeverityText, mapConcat(ResourceAttributes, mapApply((k, v) -> tuple(if(mapContains(ResourceAttributes, k), concat(k, "_extracted"), k), v), extractKeyValuePairs(Body, "=", " ", "\""))) AS _logql_merged_labels]
+              Filter predicate=(((ResourceAttributes["service_name"] = "api") AND ((Timestamp >= toDateTime64("2025-12-31 23:55:00.000000000", 9)) AND (Timestamp <= toDateTime64("2026-01-01 00:01:00.000000000", 9)))) AND (mapConcat(ResourceAttributes, mapApply((k, v) -> tuple(if(mapContains(ResourceAttributes, k), concat(k, "_extracted"), k), v), extractKeyValuePairs(Body, "=", " ", "\"")))["duration"] != ""))
+                Scan(otel_logs)
+-- sql --
+SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, `bucket_ts` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `TimeUnix` AS `bucket_ts`, max(`Value`) AS `Value` FROM (SELECT ? AS `MetricName`, map(?, `gkey_0`) AS `Attributes`, `bucket_ts` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`[?] AS `gkey_0`, `anchor_ts` AS `bucket_ts`, avg(`Value`) AS `Value` FROM (SELECT `ResourceAttributes`, `anchor_ts`, if(length(window_vals) > 0, arrayAvg(window_vals), nan) AS `Value` FROM (SELECT `ResourceAttributes`, `anchor_ts`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, `anchor_ts`, arrayFilter(p -> tupleElement(p, 1) > anchor_ts - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= anchor_ts, series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, `series_array`, arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:01:00.000000000', 9) - toIntervalNanosecond(i * 30000000000), range(0, 3))) AS `anchor_ts` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(mapFilter((k, v) -> NOT (k IN (?)), `_logql_merged_labels`), mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, parseTimeDelta(`_logql_merged_labels`[?]) AS `Value` FROM (SELECT `ResourceAttributes`, `Timestamp`, `Body`, `SeverityText`, mapConcat(`ResourceAttributes`, mapApply((k, v) -> tuple(if(mapContains(`ResourceAttributes`, k), concat(k, ?), k), v), extractKeyValuePairs(`Body`, ?, ?, ?))) AS `_logql_merged_labels` FROM (SELECT * FROM `otel_logs` WHERE (`Timestamp` >= toDateTime64(?, ?)) AND (`Timestamp` <= toDateTime64(?, ?)) AND (`ResourceAttributes`[?] = ?) AND (mapConcat(`ResourceAttributes`, mapApply((k, v) -> tuple(if(mapContains(`ResourceAttributes`, k), concat(k, ?), k), v), extractKeyValuePairs(`Body`, ?, ?, ?)))[?] != ?)))) GROUP BY `ResourceAttributes`)))) WHERE length(`window_vals`) >= 1) GROUP BY `ResourceAttributes`[?], `anchor_ts`)) GROUP BY `TimeUnix`)


### PR DESCRIPTION
## Summary

The outer aggregation of `max(avg by (level) (avg_over_time(...)))` in range mode collapsed every per-step row into a single bucket because `isMatrixRangeWindow` stopped walking at the inner Aggregate boundary. With the matrix shape lost, the outer aggregation skipped the per-anchor GROUP BY and the wire matrix shrank to one row anchored at `now64(9)` — well outside the request window, surfacing as `test endpoint returned empty` on the only remaining cerberus-side loki-compat failure (the "Nested aggregations" case in `compatibility/loki/upstream/loki-bench/queries/exhaustive/unwrap-aggregations.yaml`; the failure observed in compat run [26134959921](https://github.com/tsouza/cerberus/actions/runs/26134959921)).

## Root cause

`isMatrixRangeWindow` walked through `*chplan.Project` and `*chplan.Filter` but stopped at `*chplan.Aggregate`. Nested aggregations (`max(...)` over `avg by (level) (...)`) feed the outer aggregation a `Project(Aggregate(RangeWindow))` shape, so the helper returned `false`, the outer aggregation skipped the per-anchor GROUP BY, and the emitter fell into the `count() > 0` no-group guard — one wire row, anchored at `now64(9)`, outside the query window.

A second, related issue: the outer aggregation referenced the bucket column under its inner alias (`anchor_ts`). The wrap Project on the inner aggregation re-aliases the bucket to `TimeUnix` (the canonical Sample-shape column), so even with `isMatrixRangeWindow` corrected, the outer GROUP BY would have referenced a column no longer in scope past the inner Aggregate's projection.

## Fix

- Walk `*chplan.Aggregate` in `isMatrixRangeWindow` so nested aggregations recognise the matrix shape.
- Add `matrixBucketColumn(plan)` that dispatches the outer GROUP BY reference: a direct matrix RangeWindow surfaces `anchor_ts`; once an Aggregate is in the stack, the wrap Project has re-aliased the bucket to `TimeUnix`.
- The outer aggregation in `lowerVectorAggregation` now GROUP BYs whichever column the input exposes, restoring the per-anchor matrix for any double-aggregation shape over a matrix RangeWindow.

The fix mirrors PromQL's `rangeBucketed := ctx.step > 0` lowering (`internal/promql/lower.go::lowerAggregation`), which has always bucketed unconditionally in range mode — LogQL's narrower `isMatrixRangeWindow` gate predated the nested-aggregation pin.

## Test plan

- [x] `TestIsMatrixRangeWindowWalksNestedAggregation` (new) — unit cover for the helper traversal (RangeWindow, Aggregate(RW), Project(Aggregate(RW))) and the bucket-column dispatch.
- [x] `TestLowerVectorAggregationNestedMatrixBucketsOnTimeUnix` (new) — end-to-end lowering test asserting `GROUP BY \`TimeUnix\`` in the emitted SQL for the failing query shape.
- [x] `test/spec/logql/edge_nested_max_avg_by_unwrap.txtar` (new) — TXTAR fixture pinning the chplan IR + emitted SQL + chDB expected_rows on the canonical failing case (3 anchors × matrix shape, INFO/ERROR severities → `max(0.4, 0.15) = 0.4`, etc.).
- [x] `TestLowerVectorAggregationRangeBucketedGate` (updated) — the prior `sum by (job) (sum by (job) (rate(...)))` shape now correctly buckets per anchor under the fix and no longer isolates the gate from a `&&` → `||` mutation. Replaced with `sum by (job) (vector(1))`, which lowers to `Project(OneRow)` — a genuinely non-matrix shape that `isMatrixRangeWindow` rejects regardless of how many Aggregate / Project / Filter layers it walks through.
- [x] Existing `TestLowerVectorAggregationRangeBucketedHonoursMatrixInner` continues to pass — the positive-direction gate guard.
- [ ] Next `compatibility-loki` run picks up the fix on the "Nested aggregations" case.