### PR TITLE
fix(harness/loki-compat): honor empty-result corpus tag so impossible-filter case stops flagging baseline-empty

### DIFF
--- a/compatibility/loki/cmd/loki-compliance-tester/main.go
+++ b/compatibility/loki/cmd/loki-compliance-tester/main.go
@@ -62,6 +62,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -466,6 +467,29 @@ func compareOne(c *http.Client, f flags, tc bench.TestCase, suiteFile string, is
 
 	expected := normaliseTypedResult(out[0].value)
 	actual := normaliseTypedResult(out[1].value)
+	// Cases tagged `empty-result` in the upstream YAML are designed to
+	// return no rows (e.g. `${SELECTOR} |= "this will not hit any line"`
+	// in fast/basic-selectors.yaml — the filter literal can never match
+	// a seeded log line by construction). For those cases a baseline-
+	// empty response is the expected outcome, so we treat
+	// baseline-empty + actual-empty as a parity pass and flip the
+	// diff direction: actual-non-empty means cerberus returned rows
+	// reference Loki did not, which is a real shape mismatch.
+	if isExpectedEmptyCase(tc) {
+		switch {
+		case expected.isEmpty() && actual.isEmpty():
+			return result
+		case expected.isEmpty() && !actual.isEmpty():
+			result.Diff = "baseline empty (expected) but test endpoint returned rows"
+			return result
+		case !expected.isEmpty() && actual.isEmpty():
+			result.UnexpectedFailure = "test endpoint returned empty"
+			return result
+		}
+		// Fall through to the diff path when both sides have rows —
+		// the case may carry the tag for the cache exercise reason
+		// even though the seeded data happens to flow through.
+	}
 	if expected.isEmpty() {
 		// Same convention as upstream `assertResultNotEmpty`: we don't
 		// flip a comparison failure on an empty baseline because the
@@ -482,6 +506,18 @@ func compareOne(c *http.Client, f flags, tc bench.TestCase, suiteFile string, is
 		result.Diff = diff
 	}
 	return result
+}
+
+// isExpectedEmptyCase returns true when the upstream YAML tags this
+// case as intentionally empty. The fast/basic-selectors.yaml entry
+// `Log query with impossible filter ...` is the canonical example —
+// the corpus author plugs in a filter literal that cannot match any
+// seeded line. Without this signal the harness would flag every such
+// case as `baseline returned empty` and force a should_skip overlay,
+// turning an honest differential ("both endpoints agree on empty")
+// into a silenced row.
+func isExpectedEmptyCase(tc bench.TestCase) bool {
+	return slices.Contains(tc.Tags, "empty-result")
 }
 
 // stripSourceLine strips the trailing `:<line>` from a bench source path.

--- a/compatibility/loki/cmd/loki-compliance-tester/main_test.go
+++ b/compatibility/loki/cmd/loki-compliance-tester/main_test.go
@@ -1,6 +1,41 @@
 package main
 
-import "testing"
+import (
+	"testing"
+
+	bench "github.com/tsouza/cerberus/compatibility/loki/upstream/loki-bench"
+)
+
+// TestIsExpectedEmptyCase pins the corpus-tag contract that powers
+// `compareOne`'s empty-result branch. A drift in the upstream YAML tag
+// vocabulary (e.g. renaming the tag) would silently flip the failing
+// `fast/basic-selectors.yaml#Log query with impossible filter` case
+// back into a `baseline returned empty` row, so we anchor the predicate
+// against the tag literal here.
+func TestIsExpectedEmptyCase(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		tags []string
+		want bool
+	}{
+		{"tagged-empty-result", []string{"line-filter", "empty-result", "cache-test"}, true},
+		{"tag-set-without-empty", []string{"line-filter", "regex"}, false},
+		{"nil-tags", nil, false},
+		{"empty-tags", []string{}, false},
+		{"only-empty-result", []string{"empty-result"}, true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := isExpectedEmptyCase(bench.TestCase{Tags: tc.tags})
+			if got != tc.want {
+				t.Fatalf("isExpectedEmptyCase(tags=%v) = %v, want %v", tc.tags, got, tc.want)
+			}
+		})
+	}
+}
 
 func TestScoreCounts_ExcludesOverlaySkips(t *testing.T) {
 	t.Parallel()

--- a/test/regression/seed_test.go
+++ b/test/regression/seed_test.go
@@ -131,6 +131,41 @@ func TestMetricsSeedHasHistogramTable(t *testing.T) {
 	}
 }
 
+// TestLokiBenchTagsImpossibleFilterAsEmptyResult guards against an
+// upstream re-vendor of grafana/loki:pkg/logql/bench/queries/ that
+// drops the `empty-result` tag on the
+// `fast/basic-selectors.yaml#Log query with impossible filter ...`
+// entry. The cerberus diff driver
+// (compatibility/loki/cmd/loki-compliance-tester/main.go) keys its
+// "baseline-empty is the expected outcome" branch on that tag — losing
+// it would silently flip the case back into a `baseline returned empty`
+// row in the compat report, masking real parity drift behind a
+// harness-shape false positive. See PR introducing this regression.
+func TestLokiBenchTagsImpossibleFilterAsEmptyResult(t *testing.T) {
+	t.Parallel()
+
+	const corpusPath = "../../compatibility/loki/upstream/loki-bench/queries/fast/basic-selectors.yaml"
+	buf, err := os.ReadFile(corpusPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", corpusPath, err)
+	}
+	content := string(buf)
+
+	// The impossible-filter entry — pinned by both the description and the
+	// `empty-result` tag literal the driver reads at runtime. An upstream
+	// rename of either drops parity for this case, so we require both.
+	const (
+		description = "Log query with impossible filter (guarantees empty results, exercises log result cache)"
+		tagLiteral  = "- empty-result"
+	)
+	if !strings.Contains(content, description) {
+		t.Errorf("%s: expected description %q — corpus may have been re-vendored under a different label", corpusPath, description)
+	}
+	if !strings.Contains(content, tagLiteral) {
+		t.Errorf("%s: expected `%s` tag — the diff driver relies on it to treat baseline-empty as the parity-expected outcome (otherwise the case shows up as `baseline returned empty`)", corpusPath, tagLiteral)
+	}
+}
+
 // TestTracesSeedHasFrontendAndApiServices guards against silent seed
 // drift breaking the existing TraceQL E2E tests, which assert that
 // {resource.service.name="frontend"} returns rows and the trace ID


### PR DESCRIPTION
## Summary

The Loki diff driver's `compareOne` unconditionally flagged any baseline-empty response as `unexpectedFailure: baseline returned empty`. That predicate was wrong for the upstream fast/basic-selectors.yaml entry `Log query with impossible filter (guarantees empty results, exercises log result cache)`, whose query `${SELECTOR} |= "this will not hit any line"` is engineered to return zero rows by construction. The corpus author signals that intent via the `empty-result` tag the driver was ignoring.

Compat run 26134959921 (report artifact `compatibility-loki-report`) flagged this case as `unexpectedFailure: "baseline returned empty"` for the kafka@namespace-2/pod-4 selector — the seeded fixture pushed lines for that stream, so the baseline-empty response was the correct Loki answer (impossible filter on a populated stream returns no rows). The seed-settle wait that landed in #576 cleared the indexing-lag false positives on the other fast/basic-selectors entries, leaving this single intentionally-empty case as the only `baseline returned empty` row in run 26135908299's report (2 unexpected failures total: this one + the unrelated unwrap-aggregations `test endpoint returned empty` case).

The fix is to treat the `empty-result` tag as a signal: both-empty becomes parity pass, actual-non-empty becomes a real diff ("cerberus returned rows reference Loki did not"), and actual-empty/baseline-non-empty still surfaces as `test endpoint returned empty`. The non-tagged path keeps the existing `assertResultNotEmpty` convention so we don't silence genuine seeding gaps elsewhere in the corpus.

## Root cause and fix

- **Root cause:** the upstream YAML tags this case `empty-result`; the diff driver ignored the tag and applied a generic "baseline must be non-empty" rule that turned an honest both-endpoints-agree-on-empty outcome into a `baseline returned empty` unexpected failure. The case has the kafka selector under seed=42 today, but the issue is tag-driven, not selector-driven — any seed that resolves `${SELECTOR}` to a populated stream surfaces the same false positive.
- **Fix:** `compareOne` now branches on the `empty-result` tag before applying the baseline-empty guard. New helper `isExpectedEmptyCase` keys on the tag literal. Unit test in `compatibility/loki/cmd/loki-compliance-tester/main_test.go` and regression-layer pin in `test/regression/seed_test.go` (asserts the upstream corpus still carries the tag literal on this entry) guard against the predicate or the tag drifting.

## Test plan

- [x] `TestIsExpectedEmptyCase` pins the tag-driven predicate.
- [x] `TestLokiBenchTagsImpossibleFilterAsEmptyResult` pins the upstream tag literal so a re-vendor that drops it surfaces immediately.
- [ ] Next nightly compat run validates the impossible-filter case no longer shows in the `baseline returned empty` bucket.