### PR TITLE
test(api/loki): assert result key present + empty in query_range conformance

### DIFF
--- a/internal/api/loki/conformance_test.go
+++ b/internal/api/loki/conformance_test.go
@@ -141,7 +141,8 @@ func TestConformance_LokiQueryRangeWire(t *testing.T) {
 			}
 			var env struct {
 				Data struct {
-					ResultType string `json:"resultType"`
+					ResultType string            `json:"resultType"`
+					Result     []json.RawMessage `json:"result"`
 				} `json:"data"`
 			}
 			if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
@@ -149,6 +150,16 @@ func TestConformance_LokiQueryRangeWire(t *testing.T) {
 			}
 			if env.Data.ResultType != c.wantType {
 				t.Errorf("resultType: got %q, want %q", env.Data.ResultType, c.wantType)
+			}
+			// `result` must serialise as the empty JSON array []
+			// (not null) when stubQuerier returns no samples — the
+			// wire contract guarantees the key is always present so
+			// upstream Loki clients can iterate without nil-checking.
+			if env.Data.Result == nil {
+				t.Errorf("result: got null, want empty JSON array []")
+			}
+			if len(env.Data.Result) != 0 {
+				t.Errorf("result: got %d items, want 0 (stubQuerier returns no samples)", len(env.Data.Result))
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

\`TestConformance_LokiQueryRangeWire\` previously decoded only \`data.resultType\`, so a regression where the handler omitted the \`result\` key entirely (or serialised it as JSON \`null\` instead of an empty array \`[]\`) would still pass. This is the HIGH-severity Loki conformance finding from the 2026-05-20 test audit.

Extend the envelope struct to include \`Result []json.RawMessage\` and assert:
1. The key is present (decoder leaves it nil if JSON value is null OR the key is absent).
2. The array is empty (stubQuerier returns no samples).

## Reference

\`docs/test-audit-2026-05-20.md\` §6.2 — Loki conformance audit, single HIGH concern.

## Test plan

- [ ] \`check\` job (\`go test -race ./internal/api/loki/...\`) — both subtests (\`streams_range\`, \`metric_range\`) pass against the current handler implementation
- [ ] No other conformance tests regress

🤖 Generated with [Claude Code](https://claude.com/claude-code)