### PR TITLE
test(api/tempo): assert Traces cardinality in search conformance tests

### DIFF
--- a/internal/api/tempo/conformance_test.go
+++ b/internal/api/tempo/conformance_test.go
@@ -125,6 +125,16 @@ func TestConformance_TempoSearchWire(t *testing.T) {
 			if sr.Traces == nil {
 				t.Errorf("Traces is nil; should be empty slice, not nil")
 			}
+			// Cardinality: empty sample input must produce an
+			// empty Traces array; non-empty input must produce at
+			// least one trace. A regression that silently swaps
+			// shapes would slip past the nil-check alone.
+			switch {
+			case len(c.samples) == 0 && len(sr.Traces) != 0:
+				t.Errorf("Traces length: got %d, want 0 with no samples", len(sr.Traces))
+			case len(c.samples) > 0 && len(sr.Traces) == 0:
+				t.Errorf("Traces length: got 0, want non-empty (%d sample(s) seeded)", len(c.samples))
+			}
 		})
 	}
 }
@@ -155,6 +165,12 @@ func TestConformance_TempoSearchRecentWire(t *testing.T) {
 	}
 	if sr.Traces == nil {
 		t.Errorf("Traces is nil; should be slice")
+	}
+	// Cardinality: stubQuerier returned 1 sample, so /api/search/recent
+	// must surface at least one trace. A regression that drops the
+	// projection on this endpoint would still pass the nil-check alone.
+	if len(sr.Traces) == 0 {
+		t.Errorf("Traces length: got 0, want non-empty (1 sample seeded)")
 	}
 }
 


### PR DESCRIPTION
## Summary

\`TestConformance_TempoSearchWire\` and \`TestConformance_TempoSearchRecentWire\` asserted that \`sr.Traces\` is non-nil (so JSON renders as \`[]\` not \`null\`) but did not validate cardinality. A regression that swapped the populated vs empty shapes — e.g., always returning an empty array — would slip past the nil-check alone.

Strengthens both tests:

- **SearchWire**: assert the empty-samples case produces 0 traces and the populated case produces at least 1.
- **SearchRecentWire**: stubQuerier ships 1 sample, so assert at least 1 trace surfaces.

## Reference

\`docs/test-audit-2026-05-20.md\` §6.3 — Tempo conformance audit, 2 MEDIUM-severity gaps.

## Test plan

- [ ] \`check\` job (\`go test -race ./internal/api/tempo/...\`) — all subtests pass against current handler
- [ ] No other Tempo tests regress

🤖 Generated with [Claude Code](https://claude.com/claude-code)