### PR TITLE
ci(forbid-skip): reject soft-assertion + silent-recover patterns

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,3 +134,26 @@ jobs:
             echo "::error::discipline-erosion wording (\"not implemented\" / \"skipped\" / \"deferred\") found in test files or TXTAR fixtures — implement the feature, rewrite to a neutral verb (dropped / excluded / rejected / bypassed), or remove the comment"
             exit 1
           fi
+      # Reject soft-assertion patterns that look like real verification
+      # but pass tautologically. Surfaced by the 2026-05-20 test audit
+      # (docs/test-audit-2026-05-20.md §9 PR-β) as a discipline pin
+      # against future fake-pass regressions.
+      #
+      # Patterns rejected:
+      #   - assert.Contains(x, "")           — empty string matches anything
+      #   - assert.ElementsMatch(x, []...{}) — empty slice trivially matches
+      #   - defer recover()                  — silently swallows panics
+      #   - defer func() { _ = recover() }   — explicit silent recover
+      #
+      # Today's codebase produces zero hits (audited 2026-05-20). New
+      # additions must use the matching deep-assertion form: assert
+      # actual content, assert specific panic, or remove the recover.
+      - name: Reject soft-assertion / silent-recover patterns
+        run: |
+          if git ls-files -z -- \
+              '*_test.go' \
+              ':!:compatibility/*/upstream/**' \
+              | xargs -0 grep -nEH 'assert\.Contains\([^,]+,\s*""\s*\)|assert\.ElementsMatch\([^,]+,\s*\[\][^)]*\{\s*\}\s*\)|defer recover\(\)|defer func\(\)\s*\{\s*_ = recover\(\)' --; then
+            echo "::error::soft-assertion or silent-recover pattern found — replace assert.Contains(x, \"\") with the actual substring, replace assert.ElementsMatch(x, []T{}) with len(x) == 0, replace defer recover() with assert.Panics(t, func(){...}, \"reason\")"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Extends the GA \`forbid-skip\` test-discipline gate with a third step that rejects soft-assertion and silent-recover patterns that look like real verification but pass tautologically:

- \`assert.Contains(x, \"\")\` — empty string matches anything
- \`assert.ElementsMatch(x, []T{})\` — empty slice trivially matches
- \`defer recover()\` — silently swallows panics
- \`defer func() { _ = recover() }\` — explicit silent recover

The codebase produces **zero hits** today (verified locally against \`*_test.go\` files excluding \`compatibility/*/upstream/**\`), so this is a forward-looking discipline pin against future fake-pass regressions — not a retroactive cleanup.

## Reference

\`docs/test-audit-2026-05-20.md\` §9 PR-β — discipline mechanical fix to land alongside the audit baseline doc.

## Test plan

- [ ] \`forbid-skip\` job's new step passes on PR (no existing matches)
- [ ] \`forbid-skip\` job's existing two steps continue to pass
- [ ] A follow-up PR adding e.g. \`defer recover()\` to a test file should fail this gate (documents the contract)

🤖 Generated with [Claude Code](https://claude.com/claude-code)