### PR TITLE
test(promql): kill 4 arith mutants in label_fns slice-cap + src-label printf

### DIFF
--- a/internal/promql/gremlins_kill_test.go
+++ b/internal/promql/gremlins_kill_test.go
@@ -17,6 +17,7 @@ package promql
 
 import (
 	"math"
+	"strings"
 	"testing"
 
 	"github.com/prometheus/prometheus/promql/parser"
@@ -332,5 +333,224 @@ func TestFoldBinaryScalar_DivByZeroNegativeBranches(t *testing.T) {
 	}
 	if !math.IsNaN(gotZero) {
 		t.Fatalf("0/0 = %v; want NaN", gotZero)
+	}
+}
+
+// TestLowerLabelJoin_SrcsSliceCapacityIsTight kills the two adjacent
+// arithmetic mutants at label_fns.go:81:39 inside lowerLabelJoin's
+// slice-capacity hint:
+//
+//	srcs := make([]string, 0, len(c.Args)-3)
+//
+// The `-` is gremlins ARITHMETIC_BASE (`-` → `+`) and the literal `3`
+// is INVERT_NEGATIVES (`-3` → `+3`). Both mutants enlarge the initial
+// capacity by 6 — `append` silently uses the extra headroom, so the
+// resulting LabelJoin holds an identical Srcs slice and every
+// semantic-level assertion (Dst / Separator / Srcs values / SQL output)
+// passes under both branches.
+//
+// The only externally observable difference is the slice's cap:
+// `make([]T, 0, N)` returns cap == N, and the lowering then appends
+// exactly N times (one append per c.Args[3:] entry), so cap stays at N
+// under the original arithmetic. With `+` in place of `-`, cap = N+6
+// while len = N — and `len(c.Args) = 5` (one vector + dst + sep + 2
+// srcs) means original cap = 2, mutant cap = 8.
+//
+// Calling lowerLabelJoin directly (rather than going through Lower /
+// the optimizer) keeps the slice identity intact — no rule in the
+// optimizer touches LabelJoin.Srcs, but going direct removes any
+// possibility of a future fixup pass cloning the slice and masking
+// the cap difference.
+func TestLowerLabelJoin_SrcsSliceCapacityIsTight(t *testing.T) {
+	t.Parallel()
+
+	expr := mustParse(t, `label_join(up, "id", "-", "instance", "job")`)
+	call, ok := expr.(*parser.Call)
+	if !ok {
+		t.Fatalf("expected *parser.Call, got %T", expr)
+	}
+	s := schema.DefaultOTelMetrics()
+
+	plan, err := lowerLabelJoin(call, s, lowerCtx{})
+	if err != nil {
+		t.Fatalf("lowerLabelJoin: %v", err)
+	}
+	proj, ok := plan.(*chplan.Project)
+	if !ok {
+		t.Fatalf("expected *chplan.Project, got %T", plan)
+	}
+	// Inner is a non-RangeWindow LWR shape (Aggregate over Filter over
+	// Scan), so attrs sits at Projections[1] per
+	// projectAttributesOverInner.
+	if len(proj.Projections) != 4 {
+		t.Fatalf("expected 4 projections (non-RangeWindow shape), got %d", len(proj.Projections))
+	}
+	lj, ok := proj.Projections[1].Expr.(*chplan.LabelJoin)
+	if !ok {
+		t.Fatalf("expected projections[1].Expr to be *chplan.LabelJoin, got %T", proj.Projections[1].Expr)
+	}
+
+	const wantSrcs = 2 // "instance", "job"
+	if got := len(lj.Srcs); got != wantSrcs {
+		t.Fatalf("len(Srcs) = %d; want %d", got, wantSrcs)
+	}
+	// Original code: cap == len(c.Args)-3 == 5-3 == 2.
+	// `+` mutant: cap == 5+3 == 8.
+	// `-3` → `+3` mutant: cap == 5+3 == 8 (same observable as above).
+	// Both mutants must yield cap == 8; original yields cap == 2.
+	if got := cap(lj.Srcs); got != wantSrcs {
+		t.Fatalf("cap(Srcs) = %d; want %d (mutants `-` → `+` and `-3` → `+3` at label_fns.go:81:39 would yield cap=%d)",
+			got, wantSrcs, len(call.Args)+3)
+	}
+}
+
+// TestLowerLabelJoin_SrcsSliceCapacityIsTight_FiveSrcs reinforces the
+// cap-assertion above with a larger argument list so the differential
+// between original and mutant cap is unambiguous. With 5 srcs, c.Args
+// has 8 entries (1 vector + dst + sep + 5 srcs):
+//
+//   - Original `-3`: cap = 5, len = 5 (exact fit, no headroom).
+//   - `+` mutant:  cap = 11, len = 5 (6 cells of headroom).
+//   - `-3` → `+3`: cap = 11, len = 5 (same observable).
+//
+// Two independent fixtures (2 srcs, 5 srcs) make accidental coincidence
+// (e.g., a Go runtime growth schedule that lands on the original cap)
+// impossible.
+func TestLowerLabelJoin_SrcsSliceCapacityIsTight_FiveSrcs(t *testing.T) {
+	t.Parallel()
+
+	expr := mustParse(t, `label_join(up, "fqdn", "/", "a", "b", "c", "d", "e")`)
+	call, ok := expr.(*parser.Call)
+	if !ok {
+		t.Fatalf("expected *parser.Call, got %T", expr)
+	}
+	s := schema.DefaultOTelMetrics()
+
+	plan, err := lowerLabelJoin(call, s, lowerCtx{})
+	if err != nil {
+		t.Fatalf("lowerLabelJoin: %v", err)
+	}
+	proj, ok := plan.(*chplan.Project)
+	if !ok {
+		t.Fatalf("expected *chplan.Project, got %T", plan)
+	}
+	lj, ok := proj.Projections[1].Expr.(*chplan.LabelJoin)
+	if !ok {
+		t.Fatalf("expected projections[1].Expr to be *chplan.LabelJoin, got %T", proj.Projections[1].Expr)
+	}
+
+	const wantSrcs = 5
+	if got := len(lj.Srcs); got != wantSrcs {
+		t.Fatalf("len(Srcs) = %d; want %d", got, wantSrcs)
+	}
+	if got := cap(lj.Srcs); got != wantSrcs {
+		t.Fatalf("cap(Srcs) = %d; want %d (mutants at label_fns.go:81:39 would yield cap=%d)",
+			got, wantSrcs, len(call.Args)+3)
+	}
+}
+
+// TestLowerLabelJoin_NonLiteralSrcErrorIndexesParamName kills the two
+// adjacent arithmetic mutants at label_fns.go:83:79 inside the
+// per-src error-formatting:
+//
+//	fmt.Sprintf("src_label_%d", i-2)
+//
+// The `-` is gremlins ARITHMETIC_BASE (`-` → `+`) and the literal `2`
+// is INVERT_NEGATIVES (`-2` → `+2`). Both mutants change the parameter
+// name embedded in the error message — surfaced only on the
+// non-StringLiteral guard path inside stringArg.
+//
+// The loop iterates `i := 3 .. len(c.Args)-1`. The intent of `i-2` is
+// to print the 1-based source-label index (src_label_1, src_label_2,
+// …): at i=3 → "src_label_1", at i=4 → "src_label_2", etc. Mutating
+// `-` to `+` shifts every printed index by +4 (i=3 → "src_label_5",
+// i=4 → "src_label_6", …); mutating `-2` to `+2` does the same. The
+// kill therefore pins the printed index at a chosen position.
+//
+// Strategy: construct a parser.Call by hand with a non-StringLiteral
+// in the second src slot (c.Args[4], i=4). The PromQL parser refuses
+// to accept this shape, so we bypass it and feed lowerLabelJoin
+// directly. The original code prints "src_label_2"; both mutants
+// print "src_label_6".
+func TestLowerLabelJoin_NonLiteralSrcErrorIndexesParamName(t *testing.T) {
+	t.Parallel()
+
+	// Args: [vector, dst, separator, src1, src2_nonliteral]
+	//   index   0      1     2         3     4
+	// The non-literal slot is at c.Args[4] → i=4 in the loop → the
+	// original "src_label_%d" formats as "src_label_2" (4-2=2). Both
+	// mutants format as "src_label_6" (4+2=6).
+	innerSelector := &parser.VectorSelector{
+		Name: "up",
+	}
+	call := &parser.Call{
+		Func: parser.MustGetFunction("label_join"),
+		Args: parser.Expressions{
+			innerSelector,
+			&parser.StringLiteral{Val: "id"},
+			&parser.StringLiteral{Val: "-"},
+			&parser.StringLiteral{Val: "instance"},
+			// Non-string-literal at src position 2 (i=4 in the loop).
+			// A NumberLiteral is convenient — definitely not a
+			// *parser.StringLiteral, so stringArg's type-assert fails.
+			&parser.NumberLiteral{Val: 1.5},
+		},
+	}
+	s := schema.DefaultOTelMetrics()
+
+	_, err := lowerLabelJoin(call, s, lowerCtx{})
+	if err == nil {
+		t.Fatalf("expected non-literal src arg to error; got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "src_label_2") {
+		t.Fatalf("error %q does not mention %q (mutants `-` → `+` and `-2` → `+2` at label_fns.go:83:79 would emit %q)",
+			msg, "src_label_2", "src_label_6")
+	}
+	// Defensive: also ensure the mutant string is NOT present (e.g., if a
+	// future refactor printed both indices, the positive assertion above
+	// would still pass while the mutant survived).
+	if strings.Contains(msg, "src_label_6") {
+		t.Fatalf("error %q contains the mutant param name %q", msg, "src_label_6")
+	}
+}
+
+// TestLowerLabelJoin_NonLiteralSrcErrorIndexesParamName_FirstSlot
+// reinforces the kill above by exercising the i=3 boundary — the very
+// first src position. With the original `i-2` arithmetic this prints
+// "src_label_1"; both mutants print "src_label_5".
+//
+// Two cases at different i values rule out an accidental coincidence
+// where one specific mutant happens to print the original-style index
+// (e.g., if a refactor used `i & 0x3` or similar).
+func TestLowerLabelJoin_NonLiteralSrcErrorIndexesParamName_FirstSlot(t *testing.T) {
+	t.Parallel()
+
+	innerSelector := &parser.VectorSelector{
+		Name: "up",
+	}
+	call := &parser.Call{
+		Func: parser.MustGetFunction("label_join"),
+		Args: parser.Expressions{
+			innerSelector,
+			&parser.StringLiteral{Val: "id"},
+			&parser.StringLiteral{Val: "-"},
+			// Non-string-literal at the first src slot (i=3).
+			&parser.NumberLiteral{Val: 2.5},
+		},
+	}
+	s := schema.DefaultOTelMetrics()
+
+	_, err := lowerLabelJoin(call, s, lowerCtx{})
+	if err == nil {
+		t.Fatalf("expected non-literal src arg to error; got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "src_label_1") {
+		t.Fatalf("error %q does not mention %q (mutants at label_fns.go:83:79 would emit %q)",
+			msg, "src_label_1", "src_label_5")
+	}
+	if strings.Contains(msg, "src_label_5") {
+		t.Fatalf("error %q contains the mutant param name %q", msg, "src_label_5")
 	}
 }


### PR DESCRIPTION
## Summary

Kills the four surviving gremlins mutants reported by run `26143128549`
(artifact `gremlins-phase4-promql`) at:

- `internal/promql/label_fns.go:81:39` — `ARITHMETIC_BASE` + `INVERT_NEGATIVES`
- `internal/promql/label_fns.go:83:79` — `ARITHMETIC_BASE` + `INVERT_NEGATIVES`

Test-audit reference: [`docs/test-audit-2026-05-20.md`](docs/test-audit-2026-05-20.md) § row #3.

## Root cause — actual code at the mutation sites

The 2026-05-20 audit framed this as "float arithmetic in label-fn
helpers", but the actual code is integer arithmetic — same shape as
PR #588 (the LogQL `multiIf` cap-allocator kill):

```go
// internal/promql/label_fns.go, inside lowerLabelJoin:
81:    srcs := make([]string, 0, len(c.Args)-3)
82:    for i := 3; i < len(c.Args); i++ {
83:        src, err := stringArg(c.Args[i], "label_join", fmt.Sprintf("src_label_%d", i-2))
```

- **Line 81** — slice-capacity hint. Both `-` -> `+` (ARITHMETIC_BASE)
  and `-3` -> `+3` (INVERT_NEGATIVES) enlarge the pre-allocated
  capacity; `append` silently uses the extra headroom and produces a
  `LabelJoin` whose `Srcs` slice carries the same values. Every
  semantic-level assertion (`Dst` / `Separator` / `Srcs[i]` / emitted
  SQL) is byte-identical under the mutants.

- **Line 83** — `fmt.Sprintf` param name embedded in the
  non-string-literal guard's error message. Both `-` -> `+` and
  `-2` -> `+2` shift every printed index by +4 (i=3 prints
  `src_label_5` instead of `src_label_1`, etc.).

## Kill strategy

Two test pairs in `internal/promql/gremlins_kill_test.go`:

1. **`TestLowerLabelJoin_SrcsSliceCapacityIsTight` + `_FiveSrcs`** —
   parse `label_join(up, "id", "-", "instance", "job")` (and a 5-srcs
   variant), call `lowerLabelJoin` directly to bypass any optimizer
   path, extract the resulting `*chplan.LabelJoin` from
   `Project.Projections[1].Expr`, and assert `cap(Srcs) == len(Srcs)
   == len(c.Args)-3`. Original arithmetic yields cap=2 (2-src case)
   and cap=5 (5-src case); both mutants yield cap=8 and cap=11
   respectively. Two independent cap values rule out accidental
   coincidence from Go's runtime size-class rounding.

2. **`TestLowerLabelJoin_NonLiteralSrcErrorIndexesParamName` +
   `_FirstSlot`** — construct `parser.Call{...}` by hand with a
   `*parser.NumberLiteral` in a src position (the PromQL parser refuses
   this shape, so direct construction is the only way to reach the
   guard), call `lowerLabelJoin`, and assert the returned error's
   message contains the original `src_label_N` substring AND does NOT
   contain the mutant `src_label_(N+4)` substring. The two cases pin
   both boundary positions (i=3 and i=4).

The cap-assertion pattern mirrors PR #588's
`TestNormaliseLevelExpr_MultiIfArgsCapacityAndShape` — the same shape
of mutant on a structurally identical line of code in `internal/logql/`.

## Test plan

- [ ] CI `check` job runs the four new tests under `go test -race`.
- [ ] Next mutation run reports `label_fns.go:81:39` and `:83:79`
      mutants as `KILLED` instead of `LIVED`.