### PR TITLE
fix(e2e/seed): emit up gauge over 5-min sliding window to absorb timing race

### DIFF
--- a/test/e2e/seed/cmd/seed/main.go
+++ b/test/e2e/seed/cmd/seed/main.go
@@ -110,11 +110,39 @@ func run(ctx context.Context) error {
 // Static SQL — no string interpolation. Table names are unqualified; the
 // clickhouse-go Auth.Database resolves them server-side.
 const (
+	// `up` is seeded as a 5-minute sliding window of samples (one per
+	// 15 s = 20 samples per series, 2 series = 40 rows) so any
+	// subquery / range query that runs within ~5 minutes of `e2e-seed`
+	// finds at least one sample. A single-timestamp seed
+	// (the previous shape) was timing-sensitive: by the time the
+	// Playwright dashboard tests ran (~3–5 min after seed), the
+	// subquery `up[1m:30s]` looked back 1 min from request_time and
+	// missed the seed timestamp, returning 0 series intermittently.
+	// See docs/test-audit-2026-05-20.md follow-up + e2e run
+	// 26147340075 for the failure mode.
 	insertGaugeSQL = `INSERT INTO otel_metrics_gauge
   (ResourceAttributes, MetricName, MetricDescription, MetricUnit, Attributes, StartTimeUnix, TimeUnix, Value)
-VALUES
-  ({'service.name': 'api'}, 'up', 'Is the scrape target up', '1', {'job': 'api'}, now64(9), now64(9), 1.0),
-  ({'service.name': 'db'},  'up', 'Is the scrape target up', '1', {'job': 'db'},  now64(9), now64(9), 0.0)`
+SELECT
+    map('service.name', 'api'),
+    'up',
+    'Is the scrape target up',
+    '1',
+    map('job', 'api'),
+    now64(9) - INTERVAL number * 15 SECOND,
+    now64(9) - INTERVAL number * 15 SECOND,
+    1.0
+FROM numbers(20)
+UNION ALL
+SELECT
+    map('service.name', 'db'),
+    'up',
+    'Is the scrape target up',
+    '1',
+    map('job', 'db'),
+    now64(9) - INTERVAL number * 15 SECOND,
+    now64(9) - INTERVAL number * 15 SECOND,
+    0.0
+FROM numbers(20)`
 
 	insertSumSQL = `INSERT INTO otel_metrics_sum
   (ResourceAttributes, MetricName, MetricDescription, MetricUnit, Attributes, StartTimeUnix, TimeUnix, Value, Flags, AggregationTemporality, IsMonotonic)


### PR DESCRIPTION
## Investigation result

The "k3d startup race" framing was incomplete. Two distinct failure modes exist on the \`e2e :: dashboard\` job (informational, push-to-main only):

1. **Rare**: ClickHouse \`ImagePullBackOff\` inside k3d (run 26136032208 at 01:40). ~1/20 frequency. Real k3d-internal docker pull race. **Not addressed in this PR.**
2. **Frequent**: 2 Playwright tests asserting \`up\` returns ≥1 series (runs 26147022308 at 07:05 and 26147340075 at 07:12). ~2/20 frequency. **This PR fixes it.**

## Root cause

The seed at \`test/e2e/seed/cmd/seed/main.go\` inserted exactly 2 \`up\` gauge rows at \`now64(9)\` — a single timestamp at seed-time. By the time Playwright tests ran (after \`e2e-wait-otel\` + \`e2e-run\`, typically 3–5 min later), the subquery \`up[1m:30s]\` looked back 60s from request-time and missed the seed timestamp, returning 0 series.

Whether the test passed or failed depended entirely on how fast the pipeline ran:
- Fast run (run 26147608976 at 07:18) → seed-to-test latency < 60s → test passes
- Slow run (run 26147340075 at 07:12) → seed-to-test latency > 60s → test fails

## Fix

Replace the single-timestamp \`VALUES\` form with \`SELECT … FROM numbers(20)\` per series. Spacing rows 15s apart × 20 samples = 5-min sliding window per series. Covers any subquery / range query running within 285s of seed completion, with margin for the longest Playwright assertion (\`up[1m:30s]\`).

## Tests affected

- \`test/e2e/playwright/prom_metrics.spec.ts:70\` — \`up[1m:30s]\` returns ≥1 series
- \`test/e2e/playwright/prom_ux.spec.ts:178\` — dashboard multi-target panel

## Test plan

- [ ] \`check\` + \`lint\` green
- [ ] Next push-to-main triggers \`e2e :: dashboard\` job; the 2 Playwright tests above pass deterministically
- [ ] No other e2e tests regress

## Follow-up (separately tracked)

The ClickHouse image-pull race (mode 1) is rare and not addressed here. Could be mitigated by pre-pulling images via \`k3d image import\` before \`k3d cluster create\` — file as a follow-up task if it recurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)