### PR TITLE
fix(e2e/up): pre-pull + k3d-import 4 external images to avoid containerd race

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -250,6 +250,20 @@ chdb-install:
 K3D_CLUSTER := "cerberus-e2e"
 CERBERUS_IMAGE := "cerberus:e2e"
 
+# External images referenced by test/e2e/k3s/*.yaml. Kept in sync with the
+# manifests by convention; a stale entry surfaces as a `Pending` /
+# `ImagePullBackOff` pod once that image is no longer pre-loaded. When you
+# bump a version in a manifest, bump it here too — both sides MUST agree.
+#
+# Why pre-pull: a fresh k3d cluster's containerd hits the registry directly
+# (DockerHub + GHCR). DockerHub's anonymous-pull rate limit is shared across
+# GHA-runner IP pools and intermittently fires at ~1/20 e2e runs, leaving
+# ClickHouse stuck in `ImagePullBackOff` past the 180 s deployment wait. By
+# pulling on the host docker daemon (which has its own auth + cache) and
+# importing into k3d via the API, we never go through containerd's pull
+# path. See run 26136032208 for the symptom.
+E2E_EXTERNAL_IMAGES := "clickhouse/clickhouse-server:24.8-alpine ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.116.0 grafana/grafana:11.4.0 otel/opentelemetry-collector-contrib:0.116.1"
+
 # Boot the k3d cluster, build cerberus image, import it, apply manifests, wait for pods.
 # Host ports map via the k3d loadbalancer to NodePorts on the k3s nodes:
 #   host:8080 -> LB -> NodePort 30080 (cerberus svc)
@@ -264,8 +278,13 @@ e2e-up: e2e-down
         --wait
     @echo "==> building cerberus image"
     docker build -t {{CERBERUS_IMAGE}} -f Dockerfile.local .
-    @echo "==> importing image into k3d"
-    k3d image import {{CERBERUS_IMAGE}} -c {{K3D_CLUSTER}}
+    @echo "==> pre-pulling external images on host docker"
+    @for img in {{E2E_EXTERNAL_IMAGES}}; do \
+        echo "    docker pull $img"; \
+        docker pull "$img" >/dev/null || { echo "ERROR: docker pull $img failed" >&2; exit 1; }; \
+    done
+    @echo "==> importing images into k3d ({{K3D_CLUSTER}})"
+    k3d image import {{CERBERUS_IMAGE}} {{E2E_EXTERNAL_IMAGES}} -c {{K3D_CLUSTER}}
     @echo "==> applying manifests"
     kubectl apply -k test/e2e/k3s/
     @echo "==> waiting for pods (up to 3 min)"


### PR DESCRIPTION
## Summary

Run 26136032208 (2026-05-20 01:40) failed with the ClickHouse pod stuck in \`ImagePullBackOff\` past the 180 s deployment wait. Root cause: k3d's containerd hits DockerHub directly to pull \`clickhouse/clickhouse-server:24.8-alpine\`; the GHA runner's shared-IP pool intermittently trips DockerHub's anonymous-pull rate limit, after which the backoff exponentially extends and the deployment never becomes Available within the timeout.

## Fix

Pre-pull the 4 external images on the host's docker daemon (which has its own auth/cache) before creating the k3d cluster, then bulk-import them via \`k3d image import\`. The pods now load images directly from the cluster's containerd snapshot, never traversing the public registry.

Images pre-imported (in sync with \`test/e2e/k3s/*.yaml\`):

- \`clickhouse/clickhouse-server:24.8-alpine\`
- \`ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.116.0\`
- \`grafana/grafana:11.4.0\`
- \`otel/opentelemetry-collector-contrib:0.116.1\`

Cerberus image (\`cerberus:e2e\`) was already pre-imported; this PR extends the same pattern to the 4 third-party images.

## Frequency

~1/20 historically (uncommon but real). Pre-import makes the path deterministic — k3d's containerd cannot hit a rate-limit window that doesn't exist. Stale-version awareness: the \`E2E_EXTERNAL_IMAGES\` Justfile variable must be kept in sync with the manifests; a stale entry surfaces as a Pending pod once the image is no longer pre-loaded (loud failure, easy to diagnose).

## Test plan

- [ ] \`check\` + \`lint\` green
- [ ] \`just e2e-up\` locally (if possible) — pre-pulls take ~30 s on first run, ~1 s cached
- [ ] Next push-to-main \`e2e :: dashboard\` job; pods come Available without traversing DockerHub
- [ ] No regression on the existing happy path

🤖 Generated with [Claude Code](https://claude.com/claude-code)