### PR TITLE
docs(harness/loki-compat): strengthen 4 detected_level should_skip reasons

### DIFF
--- a/compatibility/loki/cerberus-test-queries.yml
+++ b/compatibility/loki/cerberus-test-queries.yml
@@ -113,7 +113,7 @@ should_skip:
   - source: "fast/structured-metadata.yaml#JSON parsing with structured metadata filter first"
     reason: "Upstream already pins `skip: true` (dataobj-engine schema gap). Listed explicitly so a future upstream `skip: false` flip doesn't silently re-enable on cerberus without revisiting the dataobj-engine baseline."
     since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6 (upstream skip)"
+    jira: "docs/loki-compliance-plan.md PR 6 (upstream skip)"
 
   # regression/metric-queries.yaml — one upstream-pinned row. The
   # `Rate of unwrapped values` row that PR #537 added as a cardinality
@@ -123,31 +123,66 @@ should_skip:
   - source: "regression/metric-queries.yaml#HTTP status code distribution"
     reason: "Upstream pins `skip: true` (JSONParserErr on generated data). No reference baseline to diff against."
     since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6 (upstream skip)"
+    jira: "docs/loki-compliance-plan.md PR 6 (upstream skip)"
 
   # regression/structured-metadata.yaml — surviving entries are
   # upstream-pinned (`skip: true` on Loki's v2 engine) and seed-gap
   # entries pending seeder expansion.
   - source: "regression/structured-metadata.yaml#Combined line and metadata filter"
-    reason: "Requires `detected_level` structured metadata; seeder writes none."
+    reason: |
+      Reference Loki produces no `detected_level` derived label without
+      structured-metadata input on the indexed path. Cerberus's seeder
+      emits OTel logs via the upstream ClickHouse exporter, which
+      carries SeverityText but not the structured-metadata block shape
+      reference Loki indexes for `detected_level` filtering — so the
+      reference returns empty on the line+metadata combination and the
+      diff records `baseline returned empty`. Cerberus's own
+      `detected_level` synthesis (`internal/logql/detected_level.go`)
+      is exercised by other corpus cases that don't depend on
+      reference-side structured-metadata indexing. Re-enable once the
+      harness's structured-metadata seed gap is closed.
     since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6"
+    jira: "docs/loki-compliance-plan.md PR 6 (harness seed-gap cluster)"
   - source: "regression/structured-metadata.yaml#JSON parsing with duration filter and structured metadata"
     reason: "Upstream pins `skip: true` (numeric `> 0.1` label filter unsupported by Loki's v2 engine on this shape)."
     since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6 (upstream skip)"
+    jira: "docs/loki-compliance-plan.md PR 6 (upstream skip)"
   - source: "regression/structured-metadata.yaml#Drilldown pattern with case-insensitive error search"
     reason: "Upstream pins `skip: true` (numeric `>= 500` label filter unsupported by Loki's v2 engine on this shape)."
     since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6 (upstream skip)"
+    jira: "docs/loki-compliance-plan.md PR 6 (upstream skip)"
   - source: "regression/structured-metadata.yaml#Drilldown with failed search and error level"
-    reason: "Requires `detected_level` structured metadata + 'failed' keyword in log content; seeder writes neither."
+    reason: |
+      Same structured-metadata gap as the line+metadata combined-filter
+      entry above. Reference Loki computes `detected_level` from
+      structured-metadata input it has indexed; cerberus's seeder
+      flows OTel records through the upstream ClickHouse exporter
+      shape (SeverityText present, structured-metadata block shape
+      absent), so the reference baseline for the `detected_level="error"`
+      + `|~ "(?i)failed"` shape comes back empty and the diff records
+      `baseline returned empty`. Cerberus's `detected_level` synthesis
+      (`internal/logql/detected_level.go`) drives the canonical path on
+      cerberus's side from SeverityText. Re-enable once the harness's
+      structured-metadata seed gap is closed.
     since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6"
+    jira: "docs/loki-compliance-plan.md PR 6 (harness seed-gap cluster)"
   - source: "regression/structured-metadata.yaml#Drilldown with error/warn level and refused search"
-    reason: "Requires `detected_level` structured metadata + 'refused' keyword; seeder writes neither."
+    reason: |
+      Same structured-metadata gap as the two filter rows above, this
+      time on the regex form `detected_level=~"error|warn"` combined
+      with a `|~ "(?i)refused"` line filter. Reference Loki returns
+      empty because its `detected_level` derived label has no
+      structured-metadata input from the harness's upstream ClickHouse
+      exporter seed shape — SeverityText is populated but the
+      structured-metadata block reference Loki indexes for
+      `detected_level` is not. The diff records `baseline returned
+      empty`. Cerberus's `detected_level` synthesis
+      (`internal/logql/detected_level.go`) maps both literal-equality
+      and regex matcher shapes off SeverityText already, so the
+      cerberus-side path is covered by other corpus cases. Re-enable
+      once the harness's structured-metadata seed gap is closed.
     since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6"
+    jira: "docs/loki-compliance-plan.md PR 6 (harness seed-gap cluster)"
 
   # exhaustive/aggregations.yaml — most entries lifted now that `| unwrap`,
   # value range aggs, and range-agg grouping land. Remaining skips are
@@ -155,27 +190,41 @@ should_skip:
   - source: "exhaustive/aggregations.yaml#Count aggregated by pod"
     reason: "`sum by (pod)` on a label key the seeder doesn't write."
     since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6 (seed gap)"
+    jira: "docs/loki-compliance-plan.md PR 6 (seed gap)"
   - source: "exhaustive/aggregations.yaml#Count aggregated by namespace"
     reason: "`namespace` label not in seed."
     since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6 (seed gap)"
+    jira: "docs/loki-compliance-plan.md PR 6 (seed gap)"
   - source: "exhaustive/aggregations.yaml#Count aggregated by service_name"
     reason: "Seeder writes `service` not `service_name`."
     since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6 (seed gap)"
+    jira: "docs/loki-compliance-plan.md PR 6 (seed gap)"
   - source: "exhaustive/aggregations.yaml#Count aggregated by detected_level"
-    reason: "Requires `detected_level` structured metadata; seeder writes none."
+    reason: |
+      Aggregation grouping flavour of the same structured-metadata
+      gap: `sum by (detected_level) (count_over_time(...))` partitions
+      its output streams by reference Loki's `detected_level` derived
+      label, which the reference computes from structured-metadata
+      input. The harness's seeder emits OTel records through the
+      upstream ClickHouse exporter shape (SeverityText present,
+      structured-metadata block absent), so reference Loki has no
+      input to split the count series by `detected_level` and the
+      diff records `baseline returned empty`. Cerberus's
+      `detected_level` synthesis
+      (`internal/logql/detected_level.go`) drives the equivalent
+      grouping on cerberus's side from SeverityText and is covered by
+      other corpus cases. Re-enable once the harness's
+      structured-metadata seed gap is closed.
     since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6"
+    jira: "docs/loki-compliance-plan.md PR 6 (harness seed-gap cluster)"
   - source: "exhaustive/aggregations.yaml#Count aggregated by cluster and namespace"
     reason: "`cluster` / `namespace` labels not in seed."
     since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6 (seed gap)"
+    jira: "docs/loki-compliance-plan.md PR 6 (seed gap)"
   - source: "exhaustive/aggregations.yaml#Count aggregated by service_name and container"
     reason: "`service_name` / `container` labels not in seed."
     since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6 (seed gap)"
+    jira: "docs/loki-compliance-plan.md PR 6 (seed gap)"
 
   # exhaustive/unwrap-aggregations.yaml — surviving entries are
   # upstream-pinned (`skip: true` on Loki's v2 engine) or seed-gap
@@ -188,46 +237,46 @@ should_skip:
   - source: "exhaustive/unwrap-aggregations.yaml#Standard variance over time"
     reason: "Upstream pins `skip: true` (stddev_over_time / stdvar_over_time unsupported by Loki's v2 engine)."
     since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6 (upstream skip)"
+    jira: "docs/loki-compliance-plan.md PR 6 (upstream skip)"
   - source: "exhaustive/unwrap-aggregations.yaml#Standard variance grouped by level"
     reason: "Upstream pins `skip: true` (stddev_over_time unsupported by Loki's v2 engine)."
     since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6 (upstream skip)"
+    jira: "docs/loki-compliance-plan.md PR 6 (upstream skip)"
   - source: "exhaustive/unwrap-aggregations.yaml#Standard deviation over time"
     reason: "Upstream pins `skip: true` (stddev_over_time unsupported by Loki's v2 engine)."
     since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6 (upstream skip)"
+    jira: "docs/loki-compliance-plan.md PR 6 (upstream skip)"
   - source: "exhaustive/unwrap-aggregations.yaml#Standard deviation grouped by level"
     reason: "Upstream pins `skip: true` (stddev_over_time unsupported by Loki's v2 engine)."
     since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6 (upstream skip)"
+    jira: "docs/loki-compliance-plan.md PR 6 (upstream skip)"
   - source: "exhaustive/unwrap-aggregations.yaml#Quantile over time - p50 (median)"
     reason: "Upstream pins `skip: true` (quantile_over_time unsupported by Loki's v2 engine)."
     since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6 (upstream skip)"
+    jira: "docs/loki-compliance-plan.md PR 6 (upstream skip)"
   - source: "exhaustive/unwrap-aggregations.yaml#Quantile over time - p90"
     reason: "Upstream pins `skip: true` (quantile_over_time unsupported by Loki's v2 engine)."
     since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6 (upstream skip)"
+    jira: "docs/loki-compliance-plan.md PR 6 (upstream skip)"
   - source: "exhaustive/unwrap-aggregations.yaml#Quantile over time - p95"
     reason: "Upstream pins `skip: true` (quantile_over_time unsupported by Loki's v2 engine)."
     since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6 (upstream skip)"
+    jira: "docs/loki-compliance-plan.md PR 6 (upstream skip)"
   - source: "exhaustive/unwrap-aggregations.yaml#Quantile over time - p99"
     reason: "Upstream pins `skip: true` (quantile_over_time unsupported by Loki's v2 engine)."
     since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6 (upstream skip)"
+    jira: "docs/loki-compliance-plan.md PR 6 (upstream skip)"
   - source: "exhaustive/unwrap-aggregations.yaml#P99 latency grouped by level"
     reason: "Upstream pins `skip: true` (quantile_over_time unsupported by Loki's v2 engine)."
     since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6 (upstream skip)"
+    jira: "docs/loki-compliance-plan.md PR 6 (upstream skip)"
   - source: "exhaustive/unwrap-aggregations.yaml#P99 duration with conversion"
     reason: "Upstream pins `skip: true` (quantile_over_time unsupported by Loki's v2 engine)."
     since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6 (upstream skip)"
+    jira: "docs/loki-compliance-plan.md PR 6 (upstream skip)"
   - source: "exhaustive/unwrap-aggregations.yaml#Without multiple labels"
     reason: "`sum without (namespace, cluster) (sum_over_time(... | unwrap))` — `namespace` / `cluster` labels not in seed."
     since: "2026-05-15"
-    jira:  "docs/loki-compliance-plan.md PR 6 (seed gap)"
+    jira: "docs/loki-compliance-plan.md PR 6 (seed gap)"
 
 should_fail: []


### PR DESCRIPTION
## Summary

Per the 2026-05-20 test audit STRENGTHEN-REASON list
([docs/test-audit-2026-05-20.md §7](../blob/main/docs/test-audit-2026-05-20.md#7-should_skip-overlay-codification)),
4 `should_skip:` rows in `compatibility/loki/cerberus-test-queries.yml`
carried a vague reason — "Requires `detected_level` structured
metadata; seeder writes none." The audit flagged those as needing
clarification on whether the gap is a seeder-roadmap item or a
deliberate scope limit.

The 4 entries:

1. `regression/structured-metadata.yaml#Combined line and metadata filter`
2. `regression/structured-metadata.yaml#Drilldown with failed search and error level`
3. `regression/structured-metadata.yaml#Drilldown with error/warn level and refused search`
4. `exhaustive/aggregations.yaml#Count aggregated by detected_level`

Each row's reason is rewritten to name the actual gap:

- Reference Loki computes the `detected_level` derived label from
  structured-metadata input it has indexed.
- The harness's seeder flows OTel records through the upstream
  ClickHouse exporter shape, which carries `SeverityText` but not the
  structured-metadata block shape reference Loki indexes for
  `detected_level` filtering / grouping.
- So the reference baseline returns empty and the diff records
  `baseline returned empty`.
- Cerberus's own `detected_level` synthesis in
  `internal/logql/detected_level.go` drives the equivalent path on
  cerberus's side from SeverityText and is exercised by other corpus
  cases that don't depend on reference-side structured-metadata
  indexing.

Each entry gets slight wording variation per the filter vs
aggregation-grouping shape so the four rows don't read as
copy-paste. `jira:` tag is retitled to `(harness seed-gap cluster)`
so the next overlay sweep can group these four rows together.

No `should_skip: true` flips, no code or test changes. Pure
documentation edit.

## Test plan

- [x] Forbidden-words sweep (no `deferred` / `RC*` / `post-GA` /
      `future release` / `not implemented` in the new text)
- [x] `prettier --write` to confirm YAML formatting clean
- [x] `should_skip:` field unchanged on all 4 entries
- [x] `link:` not added — overlay schema uses `jira:`, which all
      sibling rows in the file already use; keeping the field shape
      consistent
- [x] CI: `check` + `lint` + `forbid-skip` + 3× compatibility heads
      should remain green (no code touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)