### PR TITLE
chore(testing): add just recipes for property + chclient-integration lanes

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -74,6 +74,18 @@ spec-chdb:
 test-chdb:
     go test -tags chdb -count=1 ./internal/chclienttest/... ./internal/api/...
 
+# Run the chDB-tagged property tests (rapid + from-scratch oracle).
+# Requires libchdb.so (see `just chdb-install`). Local default is rapid's
+# 100 iterations; the nightly `property` CI workflow overrides to 500.
+property:
+    go test -tags chdb -count=1 ./test/property/...
+
+# Run the chclient testcontainers integration tests against a real
+# ClickHouse container. Requires Docker. Gated behind the `integration`
+# build tag so regular `just test` doesn't pull in Docker.
+chclient-integration:
+    go test -race -tags=integration ./internal/chclient/...
+
 # Run the FuzzParse target for one parser head for a bounded duration.
 # Usage: `just fuzz QL=promql DURATION=60s` (defaults).
 fuzz QL="promql" DURATION="60s":

--- a/README.md
+++ b/README.md
@@ -280,8 +280,8 @@ Quick reference:
 | ---------------- | --------------------------------------------------------------------------------- | --------------------------------------------------- |
 | **Unit**         | Per-package logic, `Equal` contracts, optimizer rule kernels, Frag goldens        | `just test`                                         |
 | **Spec (TXTAR)** | `<QL> → expected SQL` + chplan IR snapshots + optional chDB roundtrip             | `just test`; `just spec-chdb` for roundtrip lane    |
-| **Property**     | Oracle-based property tests with `rapid` shrinking and chDB execution             | `go test -tags chdb ./test/property/...`            |
-| **Integration**  | `chclient` against a real ClickHouse via testcontainers                           | `go test -tags=integration ./internal/chclient/...` |
+| **Property**     | Oracle-based property tests with `rapid` shrinking and chDB execution             | `just property`                                     |
+| **Integration**  | `chclient` against a real ClickHouse via testcontainers                           | `just chclient-integration`                         |
 | **E2E**          | k3d cluster with CH + Grafana + cerberus; Grafana Playwright smoke                | `just e2e`                                          |
 | **Compat**       | Differential parity vs reference Prom / Loki / Tempo                              | `just compat-all` (per-head recipes below)          |
 | **Mutation**     | Gremlins matrix — see `docs/test-strategy.md` § "Gremlins phased rollout" for bar | `just mutate` (slow, nightly in CI)                 |


### PR DESCRIPTION
## Summary

README.md's \"Testing layers\" table documented raw \`go test -tags chdb ./test/property/...\` and \`go test -tags=integration ./internal/chclient/...\` invocations. That breaks the CLAUDE.md **\"Justfile is the canonical task runner\"** rule — every test lane should have a \`just\` recipe that owns the flag surface so contributors don't need to remember which build tag goes with which path.

- **Justfile**: add \`just property\` (chDB-tagged rapid property tests under \`test/property/\`) + \`just chclient-integration\` (testcontainers ClickHouse integration tests under \`internal/chclient/\`). Both mirror the shape of the existing \`spec-chdb\` / \`test-chdb\` / \`schema-ddl-test\` recipes.
- **README.md**: point the Property + Integration rows at the new recipes instead of the raw \`go test\` invocations.

## Test plan

- [ ] \`just --summary\` lists \`property\` and \`chclient-integration\`
- [ ] CI \`check\` + \`lint\` green
- [ ] \`forbid-skip\` green
- [ ] markdownlint clean on README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)