### PR TITLE
ci: promote test gates — compat required, mutation/perf on PRs (path-match)

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -32,17 +32,12 @@ name: compatibility
 #     orphan branch in-place via `git checkout --orphan compat-scores`.
 
 on:
+  # PR trigger has no `paths:` filter so the three head checks always
+  # appear in the rollup. This is intentional for the
+  # required-status-checks promotion: path-skipped checks would leave
+  # the rollup missing entries and block merges.
   pull_request:
     branches: [main]
-    paths:
-      - 'internal/promql/**'
-      - 'internal/logql/**'
-      - 'internal/traceql/**'
-      - 'internal/api/prom/**'
-      - 'internal/api/loki/**'
-      - 'internal/api/tempo/**'
-      - 'compatibility/**'
-      - '.github/workflows/compatibility.yml'
   push:
     branches: [main]
     paths:

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,6 +1,25 @@
 name: mutation
 
+# Per-PR trigger is path-filtered to the 7 mutation-phased packages so
+# only QL / optimizer / chplan / chsql / qlcommon-touching PRs pay the
+# full matrix cost. Documentation / harness-only PRs skip the lane.
+# Informational on push-to-main + nightly + dispatch + PRs; promotion
+# to required PR gate happens after every phase stays green for a week
+# at 95%.
+
 on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'internal/chplan/**'
+      - 'internal/chsql/**'
+      - 'internal/optimizer/**'
+      - 'internal/promql/**'
+      - 'internal/logql/**'
+      - 'internal/traceql/**'
+      - 'internal/qlcommon/**'
+      - '.gremlins.yaml'
+      - '.github/workflows/mutation.yml'
   push:
     branches: [main]
   schedule:

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -15,6 +15,20 @@ name: perf-benchmark
 # GOMAXPROCS=1 to avoid the multi-core sampling cost.
 
 on:
+  pull_request:
+    branches: [main]
+    paths:
+      # Hot paths whose changes can plausibly move benchmarks.
+      - 'internal/promql/**'
+      - 'internal/logql/**'
+      - 'internal/traceql/**'
+      - 'internal/chplan/**'
+      - 'internal/chsql/**'
+      - 'internal/optimizer/**'
+      - 'internal/chclient/**'
+      - 'internal/api/format/**'
+      - 'internal/api/prom/**'
+      - '.github/workflows/perf-benchmark.yml'
   schedule:
     # Sunday 04:00 UTC.
     - cron: '0 4 * * 0'

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -39,11 +39,11 @@ inside each layer.
 | `forbid-skip`                 | `.github/workflows/ci.yml` (job `forbid-skip`) | PRs + push                        | Required           | `t.Skip*` + discipline-erosion wording + soft-assertion + skip-additions                                          |
 | `probe`                       | `.github/workflows/chdb.yml` (job `probe`)     | PRs + push                        | Required           | chDB driver sanity (`TestChDBProbe`)                                                                              |
 | `roundtrip (<ql>)`            | `.github/workflows/chdb.yml` matrix            | PRs + push                        | Required           | TXTAR chDB roundtrip for promql / logql / traceql (Layer 6a-c)                                                    |
-| `compatibility/<head>`        | `.github/workflows/compatibility.yml` matrix   | PRs (path-match) + push + nightly | Required (on path) | Differential vs reference Prom / Loki / Tempo                                                                     |
+| `compatibility/<head>`        | `.github/workflows/compatibility.yml` matrix   | PRs + push + nightly              | Required           | Differential vs reference Prom / Loki / Tempo                                                                     |
 | `dashboard` (E2E)             | `.github/workflows/e2e.yml` (job `dashboard`)  | push-to-main + nightly + manual   | Informational      | k3d + cerberus + Grafana + Playwright (Layer 9)                                                                   |
-| `mutation` (per phase)        | `.github/workflows/mutation.yml` matrix        | push-to-main + nightly + manual   | Informational      | gremlins on each of `chplan` / `chsql` / `optimizer` / `promql` / `logql` / `traceql` / `qlcommon` @ 95% efficacy |
+| `mutation` (per phase)        | `.github/workflows/mutation.yml` matrix        | PRs (path-match) + push + nightly | Informational      | gremlins on each of `chplan` / `chsql` / `optimizer` / `promql` / `logql` / `traceql` / `qlcommon` @ 95% efficacy |
 | `property`                    | `.github/workflows/property.yml`               | push-to-main + nightly + manual   | Informational      | rapid-driven property tests (Layer 4 + 6 cross-check)                                                             |
-| `perf-benchmark`              | `.github/workflows/perf-benchmark.yml`         | manual                            | Informational      | benchstat-based perf regression                                                                                   |
+| `perf-benchmark`              | `.github/workflows/perf-benchmark.yml`         | PRs (path-match) + weekly + manual| Informational      | benchstat-based perf regression                                                                                   |
 
 ## Per-layer guidance
 


### PR DESCRIPTION
## Summary

Three trigger changes from the test-suite honesty audit's promote-up list (the three lanes that earn their keep but were not yet wired to the PR signal):

- \`compatibility.yml\`: drop the pull_request \`paths:\` filter so the three head checks (\`compatibility/{prometheus,loki,tempo}\`) always appear in the PR rollup. Required for promoting them to required-status-checks — a path-skipped check leaves the rollup missing entries and would block merges. All three heads are at 100% so the gate ratchets cleanly.
- \`mutation.yml\`: add a path-filtered \`pull_request:\` trigger covering the 7 mutation-phased packages (chplan / chsql / optimizer / promql / logql / traceql / qlcommon). Informational on PR; promotion to required PR gate happens after every phase stays green for a stable streak (per the workflow's own comment).
- \`perf-benchmark.yml\`: add a path-filtered \`pull_request:\` trigger on the hot packages. Catches alloc and wall-clock regressions when reviewers can still do something about them, instead of weekly-only. Informational.
- \`docs/test-strategy.md\`: update the CI gates table to match.

## Follow-up

After this merges, a separate **branch-protection** update via \`gh api\` adds these to required-status-checks (closes the dangling \"Required on path\" ambiguity for compat):

- \`probe\` (chDB driver sanity) — closes task #89
- \`roundtrip (promql)\`, \`roundtrip (logql)\`, \`roundtrip (traceql)\` — chDB TXTAR roundtrip
- \`compatibility/prometheus\`, \`compatibility/loki\`, \`compatibility/tempo\` — differential parity

## Test plan

- [ ] \`check\` + \`lint\` + \`forbid-skip\` green
- [ ] \`probe\` + \`roundtrip (*)\` green
- [ ] \`compatibility/*\` actually shows up in the rollup (the docs-cleanup PR #597 was the test case — it didn't touch QL paths and compat checks WERE missing; this PR fixes that)
- [ ] \`mutation phase*\` and \`perf-benchmark\` show up because this PR touches workflow files

🤖 Generated with [Claude Code](https://claude.com/claude-code)