### PR TITLE
ci(chdb): drop pull_request path filter so probe/roundtrip always fire

### DIFF
--- a/.github/workflows/chdb.yml
+++ b/.github/workflows/chdb.yml
@@ -40,30 +40,11 @@ name: chdb
 on:
   push:
     branches: [main]
+  # PR trigger has no `paths:` filter so `probe` and `roundtrip (<ql>)`
+  # always appear in the PR rollup. Required for promoting them to
+  # required-status-checks — a path-skipped check leaves the rollup
+  # missing entries and would block merges of pure-docs PRs.
   pull_request:
-    # Scope the PR trigger to changes that can plausibly affect
-    # SQL emission, plan IR, parser lowering, fixtures, the chDB
-    # roundtrip plumbing, or the HTTP handlers that exercise the
-    # chDB-tagged handler tests. Broad enough that anything touching
-    # the round-trip surface fires the lane; tight enough that pure
-    # docs / unrelated CI tweaks don't pay the libchdb cost.
-    paths:
-      - 'internal/api/**'
-      - 'internal/chsql/**'
-      - 'internal/promql/**'
-      - 'internal/logql/**'
-      - 'internal/traceql/**'
-      - 'internal/chplan/**'
-      - 'internal/optimizer/**'
-      - 'internal/engine/**'
-      - 'internal/chclient/**'
-      - 'internal/chclienttest/**'
-      - 'test/spec/**'
-      - 'compatibility/prometheus/cmd/seed/**'
-      - 'go.mod'
-      - 'go.sum'
-      - '.github/workflows/chdb.yml'
-      - 'Justfile'
   workflow_dispatch:
   schedule:
     # nightly at 04:00 UTC


### PR DESCRIPTION
## Summary

Prerequisite for adding \`probe\` and \`roundtrip (promql|logql|traceql)\` to required-status-checks. A path-skipped workflow leaves the PR rollup missing the check names, which causes branch protection to block pure-docs PRs forever waiting for checks that never run.

Same pattern PR #600 applied to \`compatibility.yml\`. Trade-off: chdb runs on every PR now (libchdb install + \`probe\` + 3 \`roundtrip\` matrix entries) — modest cost, predictable signal. Closes task #89.

## Follow-up

After this merges, a \`gh api\` call adds these to required-status-checks:

- \`probe\`
- \`roundtrip (promql)\`
- \`roundtrip (logql)\`
- \`roundtrip (traceql)\`

(\`compatibility/{prometheus,loki,tempo}\` were already added after PR #600 landed.)

## Test plan

- [ ] CI green
- [ ] \`probe\` and the three \`roundtrip (*)\` jobs all appear in this PR's own rollup

🤖 Generated with [Claude Code](https://claude.com/claude-code)