### PR TITLE
fix(docker-compose): swap ClickHouse to Ubuntu image + SQL healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,15 @@ volumes:
 
 services:
   clickhouse:
-    image: clickhouse/clickhouse-server:24.8-alpine
+    # Use the Ubuntu-base image, NOT -alpine. Per PR #245's finding on
+    # the startup-bench job and PR #297's fix for the compatibility
+    # harnesses, `clickhouse/clickhouse-server:24.8-alpine` stalls in the
+    # entrypoint script for 5+ min (create-user → restart sequence never
+    # completes, port 8123 never binds). The Ubuntu-base variant boots in
+    # ~10-20s on the same hosts. A future maintainer: do NOT innocently
+    # switch back to -alpine without re-validating against the musl /
+    # scheduling regression that bit #245.
+    image: clickhouse/clickhouse-server:24.8
     networks: [cerberus-dev]
     environment:
       CLICKHOUSE_DB: otel
@@ -54,10 +62,18 @@ services:
       - "8123:8123"
       - "9000:9000"
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:8123/ping"]
-      interval: 2s
-      timeout: 2s
-      retries: 30
+      # `clickhouse-client --query 'SELECT 1'` is more reliable than
+      # `wget /ping`: the HTTP listener (:8123) binds slightly before
+      # the SQL engine is ready to answer queries. Talking SQL over the
+      # local unix socket as the default user proves end-to-end
+      # readiness (mirrors compatibility/{prometheus,loki,tempo} after
+      # PR #297). start_period + retries cover the entrypoint's
+      # create-user → restart sequence on first boot.
+      test: ["CMD-SHELL", "clickhouse-client --query 'SELECT 1' 2>/dev/null || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 36
+      start_period: 30s
 
   cerberus:
     image: cerberus:dev


### PR DESCRIPTION
## What was broken

`docker compose up --wait` against the repo-root `docker-compose.yml` (the one-command quickstart from #209) hangs on `cerberus-clickhouse-1 Waiting` until `--wait` gives up, then bails with `container cerberus-clickhouse-1 is unhealthy`. CH never reaches "Application: Ready" so port 8123 never binds and the `wget /ping` healthcheck loops forever.

Reproduction (fresh host, before this PR):

```
$ docker compose up --wait clickhouse
 Container cerberus-clickhouse-1 Started
 Container cerberus-clickhouse-1 Waiting
container cerberus-clickhouse-1 is unhealthy
```

`docker inspect` on the unhealthy container shows 33 consecutive `wget: can't connect to remote host: Connection refused` healthcheck failures. `docker logs` shows the entrypoint stuck mid-init (after `create new user 'cerberus'` and `create database 'otel'`, never `<Information> Application: Ready for connections.`).

## What the fix is

This is the **third** instance of a known regression. PR #245 documented it on the CI startup-bench job ("alpine variant stalls in its entrypoint for 5+ min"). PR #297 fixed the compatibility/ harnesses (PromQL/LogQL/TraceQL). The repo-root quickstart compose — added later, by #209 — was missed by both. Compatibility harnesses' inline notes are explicit: *"Use the Ubuntu-base image, NOT -alpine ... do not innocently switch back."*

Two-line fix, mirrors compatibility/{prometheus,loki,tempo}:

1. `clickhouse/clickhouse-server:24.8-alpine` → `clickhouse/clickhouse-server:24.8` (Ubuntu base; boots in ~10-20s on the same hosts where alpine never starts).
2. `wget /ping` → `clickhouse-client --query 'SELECT 1'` (proves the SQL engine is ready, not just the HTTP listener; `start_period: 30s` + 36 × 5s retries cover the create-user → restart sequence on first boot).

Comment block on the service captures the rationale so future maintainers don't innocently re-add `-alpine` here either.

Verified locally with a port-shifted override (host had a stray k3d cluster on the default ports):

```
$ docker compose up --wait clickhouse
 Container cerberus-clickhouse-1 Started
 Container cerberus-clickhouse-1 Waiting
 Container cerberus-clickhouse-1 Healthy

$ docker exec cerberus-clickhouse-1 clickhouse-client \
    --user cerberus --password cerberus --database otel \
    --query "SELECT 1, currentDatabase(), currentUser()"
1	otel	cerberus
```

End-to-end the full `up --wait` chain (CH → seed) also resolves green; seed completes against CH on first try.

## Why CI didn't catch this

The only docker-compose stack with a PR gate is `compatibility/` (already fixed by #297). The `e2e/dashboard` job uses k3d (in-cluster, where alpine has more headroom and hasn't regressed) — it never exercises `docker compose up --wait` against the repo-root `docker-compose.yml`. So the quickstart compose has zero PR gate today.

## Follow-up (deferred — out of scope for this PR)

Wire a minimal `compose-smoke` CI job that runs:

```
docker compose up --wait clickhouse seed
docker compose down -v
```

against the repo-root stack on each PR. Skipping cerberus + grafana keeps the job fast (no Go build in the compose path) while still gating the CH healthcheck path — which is where this whole class of regression lives. ~10 min of YAML; happy to follow up if the maintainer wants it as a separate PR.

## Test plan

- [x] Reproduced the hang on the alpine image (`Connection refused` for 60s+, container `unhealthy`).
- [x] Verified CH boots `Healthy` in ~10s after the fix.
- [x] Verified seed dependency chain (`condition: service_healthy`) unblocks once CH is healthy.
- [ ] PR `check` + `lint` go green (this PR touches only YAML).