### PR TITLE
chore: strip future-tense / planning-language comments in internal/

### DIFF
--- a/internal/api/loki/patterns.go
+++ b/internal/api/loki/patterns.go
@@ -39,10 +39,10 @@ type Pattern struct {
 }
 
 // nilLimits satisfies drain.Limits with no per-tenant JSON tokenisation
-// hints. Cerberus is single-tenant for now; the upstream pattern
-// ingester uses this hook to tokenise specific JSON fields differently,
-// but the format passed to drain.New ignores it for FormatUnknown (the
-// generic punctuation tokeniser).
+// hints. Cerberus is single-tenant; the upstream pattern ingester uses
+// this hook to tokenise specific JSON fields differently, but the
+// format passed to drain.New ignores it for FormatUnknown (the generic
+// punctuation tokeniser).
 type nilLimits struct{}
 
 func (nilLimits) PatternIngesterTokenizableJSONFields(string) []string { return nil }
@@ -183,7 +183,7 @@ func minePatterns(lines []chclient.TimestampedLine) []Pattern {
 		}
 		out = append(out, Pattern{
 			Pattern: s,
-			Level:   "", // per-level bucketing lands in a follow-up PR — see plan § 5.
+			Level:   "",
 			Samples: projectSamples(c.Samples()),
 		})
 	}

--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -149,7 +149,7 @@ func (h *Handler) handleFormatQuery(w http.ResponseWriter, r *http.Request) {
 // param, parses it, and returns the AST. Upstream Prometheus returns
 // a rich nested-node tree; cerberus returns a minimal shape that
 // signals "parsed OK" via the Type field — enough for Grafana's
-// inline syntax check. Full nested-AST serialization is a follow-up.
+// inline syntax check.
 func (h *Handler) handleParseQuery(w http.ResponseWriter, r *http.Request) {
 	// r.FormValue merges URL query params with POST form-encoded body
 	// (auto-calling ParseForm). Matches the consistent surface used by
@@ -527,7 +527,7 @@ func wrapWithSampleProjection(plan chplan.Node, s schema.Metrics) chplan.Node {
 // isMatrixRangeWindow reports whether the plan root is a matrix-shape
 // RangeWindow — i.e., one that emits N rows per series (one per anchor
 // across [End-OuterRange, End] spaced by Step) and exposes `anchor_ts`
-// as a per-row column. Set by PromQL subquery lowering (P0 4.5+).
+// as a per-row column. Set by PromQL subquery lowering.
 //
 // "Plan root" here is "after walking past any value-rewrite Projects"
 // — `projectValueOverInner` (RangeWindow case) drops a Project on top

--- a/internal/api/prom/metadata.go
+++ b/internal/api/prom/metadata.go
@@ -135,8 +135,8 @@ func (h *Handler) handleLabelValues(w http.ResponseWriter, r *http.Request) {
 
 // MetricMetaEntry is one entry in the per-metric metadata array Prometheus
 // emits from /api/v1/metadata. Cerberus emits exactly one entry per
-// metric for now (multiple entries would be required only if the same
-// metric appears in multiple types — uncommon).
+// metric (multiple entries would be required only if the same metric
+// appears in multiple types — uncommon).
 type MetricMetaEntry struct {
 	Type string `json:"type"`
 	Help string `json:"help"`
@@ -263,9 +263,6 @@ func truncateMetadata(in map[string][]MetricMetaEntry, limit int) map[string][]M
 // is expected to be a single VectorSelector; the union of distinct label
 // sets across all matchers is returned (Prom convention: each entry
 // includes the synthetic `__name__` label).
-//
-// Time-range filtering (start/end) is parsed but not yet pushed into the
-// SQL — lands with M2.7.
 func (h *Handler) handleSeries(w http.ResponseWriter, r *http.Request) {
 	if err := r.ParseForm(); err != nil {
 		writeError(w, http.StatusBadRequest, ErrBadData, err)

--- a/internal/api/tempo/metrics_query_instant.go
+++ b/internal/api/tempo/metrics_query_instant.go
@@ -55,10 +55,6 @@ type MetricsInstantSeries struct {
 // also accepts RFC3339). `step` is unused at the wire level — the
 // handler synthesises it from end-start so the chplan.RangeWindow
 // emits exactly one anchor.
-//
-// Closes the EF noted on #398: PR 5 corpus stubbed three
-// metrics_instant cases with `skip_reason: cerberus /api/metrics/query
-// handler pending`; this handler removes that skip.
 func (h *Handler) handleMetricsQueryInstant(w http.ResponseWriter, r *http.Request) {
 	q := metricsInstantQueryParam(r)
 	if q == "" {

--- a/internal/chclient/breaker.go
+++ b/internal/chclient/breaker.go
@@ -154,12 +154,12 @@ func (b *breaker) allow() bool {
 			return false
 		}
 		// Probe completed but state machine hasn't been driven to
-		// CLOSED yet (record() always sets state); if we land here
-		// we admit a fresh probe. In practice this branch is
+		// CLOSED (record() always sets state); if we land here we
+		// admit a fresh probe. In practice this branch is
 		// unreachable because record() either closes the circuit
-		// or re-opens it before releasing probeInFlight, but the
-		// guard makes the state machine defensive against a future
-		// edit that splits record into two phases.
+		// or re-opens it before releasing probeInFlight; the guard
+		// makes the state machine defensive if record is ever
+		// split into two phases.
 		b.probeInFlight = true
 		return true
 	default:

--- a/internal/chplan/histogram_quantile_native.go
+++ b/internal/chplan/histogram_quantile_native.go
@@ -35,7 +35,7 @@ package chplan
 //     (Scale, ZeroCount, PositiveOffset, PositiveBucketCounts,
 //     NegativeOffset, NegativeBucketCounts). Typically Scan or
 //     Filter over otel_metrics_exp_histogram.
-//   - Phi is a scalar literal in [0, 1]; computed phi defers to RC3.
+//   - Phi is a scalar literal in [0, 1]; computed phi is not modelled.
 //   - GroupBy + GroupByAliases name the per-series projection from
 //     the inner subquery. The emitter projects each `<expr> AS <alias>`
 //     in the outer SELECT so the wrapping Sample projection can pick

--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -1228,9 +1228,8 @@ func Subquery(s Subqueryable) Frag {
 // PreRenderedSQL adapts an already-rendered (sql, args) pair into a
 // Subqueryable so it can flow through Subquery without raw-string
 // composition. Holds an opaque CH SQL string plus its positional args;
-// reserved for legacy chsql.Emit output that pre-dates the
-// QueryBuilder migration. A future port can move chsql.Emit to return
-// a *QueryBuilder directly and retire this type.
+// the adapter exists for legacy chsql.Emit output that pre-dates the
+// QueryBuilder migration.
 //
 // Don't reach for this for newly written code — compose with
 // QueryBuilder + typed Frags instead.
@@ -1458,8 +1457,7 @@ type joinClause struct {
 //	WITH RECURSIVE <name> AS (<anchor> UNION ALL <recursive>)
 //
 // Non-recursive CTEs render the anchor alone (no UNION ALL). Only
-// recursive CTEs are wired up today — the non-recursive case is
-// reserved for a future port if needed.
+// recursive CTEs are wired up; the non-recursive shape is unused.
 type cteClause struct {
 	Name      string
 	Anchor    *QueryBuilder
@@ -1563,8 +1561,8 @@ func (s *QueryBuilder) Join(kind JoinKind, src, on Frag) *QueryBuilder {
 //
 // Multiple WithRecursive calls chain — rendered as a single
 // `WITH RECURSIVE <n1> AS (...), <n2> AS (...)` head per CH syntax.
-// Only structural_join.go uses one CTE per emit today; the multi-CTE
-// shape is reserved for future ports.
+// Only structural_join.go uses one CTE per emit; the multi-CTE shape
+// is unused.
 //
 // Passing a nil anchor or recursive panics at render time.
 func (s *QueryBuilder) WithRecursive(name string, anchor, recursive *QueryBuilder) *QueryBuilder {

--- a/internal/chsql/late_mat.go
+++ b/internal/chsql/late_mat.go
@@ -58,10 +58,9 @@ type lateMatShape struct {
 //
 // The registry is populated from the default OTel-CH schema at package
 // init time. Custom-schema deployments overriding table names via
-// Config currently bypass the rewrite — the registry keys on the
-// default table names. Threading custom schemas into chsql is left to
-// a follow-up; the seed value here is the OTel default + a small
-// indirection layer that future PRs can extend.
+// Config bypass the rewrite — the registry keys on the default table
+// names. The seed value here is the OTel default plus a small
+// indirection layer.
 func lateMatShapeFor(table string) (lateMatShape, bool) {
 	s, ok := lateMatShapes[table]
 	return s, ok

--- a/internal/chsql/range_window.go
+++ b/internal/chsql/range_window.go
@@ -247,7 +247,7 @@ func metricsMultiQuantileFanoutFrag(qs []float64, qsCol string) Frag {
 // arrayJoin fans out one row per anchor across [End-OuterRange, End]
 // spaced by Step (end-inclusive), and the outer SELECT projects the
 // anchor timestamp alongside the per-anchor value. Used by PromQL
-// subqueries (P0 #4).
+// subqueries.
 //
 // When r.Identity is true, Func is ignored and the per-window value is
 // the last sample in the window — used by bare-vector subqueries like
@@ -1191,9 +1191,9 @@ func outerGroupAliases(groupBy []chplan.Expr, aliases []string) []string {
 
 // emitRangeWindowIdentity emits the "last value in window" shape used
 // by bare-vector subqueries (`up[5m:1m]`). Functionally equivalent to
-// last_over_time but lowered from a SubqueryExpr (P0 #4.5) rather than
-// a Call. Drops anchors whose window is empty (1+ samples required to
-// have a "last").
+// last_over_time but lowered from a SubqueryExpr rather than a Call.
+// Drops anchors whose window is empty (1+ samples required to have a
+// "last").
 func (e *emitter) emitRangeWindowIdentity(r *chplan.RangeWindow) error {
 	return e.emitWindowedArray(r, verbatim("if(length(window_vals) > 0, window_vals[length(window_vals)], nan)"), 1)
 }

--- a/internal/chsql/tableshape.go
+++ b/internal/chsql/tableshape.go
@@ -11,9 +11,9 @@ import "github.com/tsouza/cerberus/internal/schema"
 // columns (large strings, Maps, Arrays) that PREWHERE wants to avoid
 // reading until predicates have culled the row set.
 //
-// SkipIndexColumns is reserved for future use (registered Bloom-filter
-// or set indexes). The current default tables expose none — the field
-// is plumbed so an override can populate it without a schema migration.
+// SkipIndexColumns names columns covered by registered Bloom-filter
+// or set indexes. The default tables expose none — the field is
+// plumbed so an override can populate it without a schema migration.
 type TableShape struct {
 	SortColumns      []string
 	WideColumns      []string

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -12,10 +12,6 @@
 // type stays inside the adapter, lowering happens inside Lang.Parse,
 // and the sample-row reshaping that used to live in each handler's
 // wrapWithSampleProjection helper moves behind Lang.ProjectSamples.
-//
-// This scaffolding is intentionally additive — the handlers continue
-// to orchestrate the pipeline directly until per-head port milestones
-// rewrite them against Engine.
 package engine
 
 import (
@@ -68,7 +64,7 @@ func strategyFor(meta Meta) string {
 // requires only the row-returning Query method since adapters lower to
 // a plan that emits chclient.Sample rows. Streaming / strings /
 // label-set callers go straight to their handler's Querier — the
-// engine's surface is intentionally narrow for now.
+// engine's surface is intentionally narrow.
 type Querier interface {
 	Query(ctx context.Context, sql string, args ...any) ([]chclient.Sample, error)
 }

--- a/internal/logql/binary.go
+++ b/internal/logql/binary.go
@@ -32,8 +32,7 @@ import (
 //   - vector OP vector — VectorJoin over both sides projected to the
 //     Sample-shape, threading `Opts.ReturnBool` into VectorJoin.
 //
-// Logical ops (`and` / `or` / `unless`) defer to a later milestone in
-// line with the PromQL surface.
+// Logical ops (`and` / `or` / `unless`) are not implemented.
 func lowerBinary(b *syntax.BinOpExpr, s schema.Logs, lc lowerCtx) (chplan.Node, error) {
 	// BinOpExpr stores parse errors in an unexported `err` field; the
 	// parser surfaces them at ParseExpr time before lowering reaches us.
@@ -145,7 +144,7 @@ func lowerVectorScalar(vec syntax.Expr, s schema.Logs, op chplan.BinaryOp, scala
 // The `bool` modifier threads into VectorJoin.ReturnBool — mirroring
 // PromQL's exact behaviour: comparison ops yield 1.0 / 0.0 per matched
 // pair rather than dropping non-matching rows. Logical ops
-// (`and`/`or`/`unless`) defer to a later milestone.
+// (`and`/`or`/`unless`) are not implemented.
 func lowerVectorVector(b *syntax.BinOpExpr, s schema.Logs, op chplan.BinaryOp, returnBool bool, vm *syntax.VectorMatching, lc lowerCtx) (chplan.Node, error) {
 	if returnBool && !isComparison(op) {
 		return nil, fmt.Errorf("logql: 'bool' modifier is only allowed on comparison binary ops")
@@ -231,10 +230,6 @@ func vectorMatchingFromOpts(vm *syntax.VectorMatching) (chplan.VectorCard, chpla
 //
 // Sources `b.Opts.VectorMatching.Include`. The returned slice is a fresh
 // copy — callers may retain or mutate it without aliasing the parser AST.
-//
-// Pre-thread for #393: aggregation lowering will read this to project
-// the join-side include labels onto the aggregation output. The helper
-// itself does not yet feed any caller — that wiring lands in a follow-up.
 func includeLabelsFromBinop(b *syntax.BinOpExpr) []string {
 	if b == nil || b.Opts == nil || b.Opts.VectorMatching == nil {
 		return []string{}
@@ -250,7 +245,7 @@ func includeLabelsFromBinop(b *syntax.BinOpExpr) []string {
 
 // logqlBinaryOp maps a LogQL parser op string to the chplan op enum.
 // Arithmetic and comparison ops are handled here; logical ops
-// (`and` / `or` / `unless`) defer to a later milestone.
+// (`and` / `or` / `unless`) are not implemented.
 func logqlBinaryOp(op string) (chplan.BinaryOp, error) {
 	switch op {
 	case syntax.OpTypeAdd:

--- a/internal/logql/lower.go
+++ b/internal/logql/lower.go
@@ -1,10 +1,8 @@
 // Package logql lowers Loki LogQL queries into the shared cerberus chplan
-// IR. The seed (M3.1) covers stream selectors with `=`/`!=`/`=~`/`!~`
-// label matchers and the line-filter family (`|=`, `!=`, `|~`, `!~`).
-//
-// Subsequent milestones add label filters (`| label="v"`), parsers
-// (`| json`, `| logfmt`), the metric form (rate, count_over_time, ...),
-// and aggregations.
+// IR. Covers stream selectors with `=`/`!=`/`=~`/`!~` label matchers,
+// the line-filter family (`|=`, `!=`, `|~`, `!~`), label filters
+// (`| label="v"`), parsers (`| json`, `| logfmt`), the metric form
+// (rate, count_over_time, ...), and aggregations.
 package logql
 
 import (
@@ -419,7 +417,7 @@ func lowerStage(stage syntax.StageExpr, s schema.Logs, labelsExpr chplan.Expr) (
 		// Bare `| logfmt` — extracts all `key=value` pairs from the
 		// line. Subsequent label filters resolve against
 		// mapConcat(<prev labels>, extractKeyValuePairs(Body, ...)).
-		// Strict / KeepEmpty flags are intentionally ignored for now:
+		// Strict / KeepEmpty flags are intentionally ignored:
 		// CH's extractKeyValuePairs is lenient (no Strict equivalent)
 		// and always drops bare keys (no KeepEmpty equivalent), which
 		// matches Loki's non-strict default semantics for the common

--- a/internal/optimizer/mv_substitution.go
+++ b/internal/optimizer/mv_substitution.go
@@ -282,17 +282,15 @@ func commutesWith(promFunc string, aggOp schema.RollupAggOp) bool {
 // costModel picks one rollup from a slate of candidates that all
 // pass the safety conditions on MVSubstitution.
 //
-// v1 ships exactly one implementation — firstApplicableCostModel —
-// which returns the first candidate (and so requires callers to list
+// The current implementation is firstApplicableCostModel, which
+// returns the first candidate (and so requires callers to list
 // rollups coarsest-first in the registry; the default schema does).
-// v2 will introduce a real estimator that compares scan-cost / row
-// cardinality across overlapping candidates; the interface exists so
-// that swap is local to this file rather than rippling through the
+// The interface allows swapping in a real scan-cost / cardinality
+// estimator locally to this file rather than rippling through the
 // rule.
 //
-// Not exported. v1 callers don't construct one — they invoke
-// MVSubstitution which wires firstApplicableCostModel itself. v2 will
-// flip the visibility once a second impl exists.
+// Not exported. Callers don't construct one — they invoke
+// MVSubstitution which wires firstApplicableCostModel itself.
 type costModel interface {
 	Pick(candidates []schema.Rollup) schema.Rollup
 }

--- a/internal/optimizer/rule.go
+++ b/internal/optimizer/rule.go
@@ -102,9 +102,9 @@ func NewWithBatches(batches ...Batch) *Driver {
 //     load-bearing here.
 //   - "optimizer.projection" (FixedPoint) — ProjectionPushdown may
 //     iterate as pushdown unused-column elimination cascades through
-//     nested Projects. Today only one pass changes anything, but the
-//     strategy leaves room for follow-up rules to land in this batch
-//     without changing wiring.
+//     nested Projects. Only one pass changes anything in the current
+//     rule set, but the FixedPoint strategy lets additional rules join
+//     the batch without changing wiring.
 //   - "optimizer.mv-substitution" (FixedPoint) — MVSubstitution
 //     rewrites `RangeWindow(Scan(base))` to `RangeWindow(Scan(rollup))`
 //     when the operator has declared a pre-aggregated rollup whose

--- a/internal/promql/absent.go
+++ b/internal/promql/absent.go
@@ -39,11 +39,10 @@ import (
 //
 // Compared to Prom's `funcAbsent`, this lowering checks for the
 // existence of *any* sample matching `v`'s matchers in the configured
-// metric table — it does not (yet) apply the same instant-vector
-// staleness window the bare-selector LWR wrap uses. That tightening is
-// safe to layer on later: for the compatibility-harness fixtures and
-// the OTel-CH gauge tables, "metric has zero rows in the table" is the
-// signal that matters.
+// metric table — it does not apply the same instant-vector staleness
+// window the bare-selector LWR wrap uses. For the compatibility-harness
+// fixtures and the OTel-CH gauge tables, "metric has zero rows in the
+// table" is the signal that matters.
 func lowerAbsent(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
 	if len(c.Args) != 1 {
 		return nil, fmt.Errorf("promql: absent() expects 1 argument, got %d", len(c.Args))

--- a/internal/promql/date_fns.go
+++ b/internal/promql/date_fns.go
@@ -94,10 +94,7 @@ func lowerDateFn(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, e
 // The SQL works against real CH 24.x, but using the dedicated
 // `chplan.OneRow` source is cleaner: it bypasses the qualified-table
 // emit path entirely and reuses the same `SELECT 1` shape that
-// `time()` / `vector(scalar)` already rely on. The `Scan{Database:...}`
-// shape now has no remaining callers in the PromQL head; the
-// emitter's `scanTableFrag` qualified branch can be retired in a
-// follow-up cleanup.
+// `time()` / `vector(scalar)` already rely on.
 //
 // In range mode (ctx.step > 0) the source is swapped for a StepGrid
 // emitting one anchor per step in `[start, end]`; `now()` references

--- a/internal/promql/histogram_quantile.go
+++ b/internal/promql/histogram_quantile.go
@@ -34,9 +34,8 @@ import (
 //   - `any(ExplicitBounds)` — picking one representative bounds array
 //     (every row of the same metric in OTel-CH carries the same bounds).
 //
-// The native (exp-histogram) path still requires a bare VectorSelector
-// for now — the same idiom over native histograms lands in a later
-// milestone.
+// The native (exp-histogram) path requires a bare VectorSelector; the
+// `rate(...)`-wrapped idiom is not modelled on the native side.
 //
 // Routing decision: the metric-name suffix configured on
 // schema.Metrics.ExpHistogramSuffix (default `"_exp_hist"`) selects
@@ -53,8 +52,8 @@ import (
 // The result is wrapped in a Project to match the Sample contract
 // downstream — `MetricName=”` (Prom quantile drops __name__),
 // `Attributes` reconstructed from the per-row Attributes column,
-// `TimeUnix = now64(9)` (instant eval anchor; M2.1 plumbs real eval
-// time), `Value` from the interpolated quantile.
+// `TimeUnix = now64(9)` (instant eval anchor), `Value` from the
+// interpolated quantile.
 func lowerHistogramQuantile(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
 	if len(c.Args) != 2 {
 		return nil, fmt.Errorf("promql: histogram_quantile expects 2 arguments, got %d", len(c.Args))

--- a/internal/promql/histogram_quantile_range.go
+++ b/internal/promql/histogram_quantile_range.go
@@ -46,11 +46,11 @@ import (
 // per-step anchor_ts.
 //
 // Selectors carrying `@`/offset modifiers fall through to the instant-
-// mode path: matrix-anchor handling for histogram_quantile under
-// modifiers is a follow-up. In practice the modifier-bearing shapes are
-// rare (Grafana never emits them on query_range), so the instant-mode
-// fallback is byte-stable for the existing fixtures and the range-mode
-// rewrite covers the wire-shape Grafana actually drives.
+// mode path; range-mode matrix-anchor handling for histogram_quantile
+// under modifiers is not implemented. In practice the modifier-bearing
+// shapes are rare (Grafana never emits them on query_range), so the
+// instant-mode fallback is byte-stable for the existing fixtures and
+// the range-mode rewrite covers the wire-shape Grafana actually drives.
 
 const histogramAnchorCol = "anchor_ts"
 
@@ -602,9 +602,8 @@ func buildHistogramNativeRangeTreeMerge(
 // per-anchor lookback Filter. Returns the filtered subtree plus the
 // joined CrossJoin (the latter exposed so callers that want to wrap
 // the join itself stay flexible). The classic path duplicates this
-// shape inline today; refactoring it to share the same helper is a
-// follow-up — keeping the duplication scoped to one file means we
-// don't churn unrelated callers in this change.
+// shape inline; the duplication is scoped to one file so unrelated
+// callers stay untouched.
 func buildHistogramRangeAnchorJoin(
 	scan *chplan.Scan,
 	pred chplan.Expr,

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -26,15 +26,8 @@ var tracer = otel.Tracer("github.com/tsouza/cerberus/internal/promql")
 // range-vector Call (`rate` / `increase` / `delta` / `*_over_time`),
 // instant-vector Call (`abs`, `sqrt`, `ln`, ...), AggregateExpr with
 // `by (...)`, ParenExpr, BinaryExpr with scalar/vector arithmetic,
-// SubqueryExpr (P0 4.5–4.7: bare-vector, over range-vector calls,
-// outer reducer over subquery).
-//
-// Deferred to RC3 / later milestones: subquery over `without(...)`
-// aggregations and parameterised aggregates (quantile / topk / bottomk
-// / count_values), subquery `@ start()`/`@ end()` outside the limited
-// support already wired, native-histogram `histogram_quantile`
-// (PR H, otel_metrics_exp_histogram), exemplars. Nested subqueries
-// reachable through the parser (e.g.
+// SubqueryExpr (bare-vector, over range-vector calls, outer reducer
+// over subquery). Nested subqueries reachable through the parser (e.g.
 // `max_over_time(rate(m[1m])[5m:30s])[1h:5m]`,
 // `sum_over_time(max_over_time(rate(m[5m])[10m:1m])[1h:5m])`) lower
 // via the Call / ParenExpr / AggregateExpr intermediaries the parser
@@ -668,8 +661,8 @@ func matchOp(t labels.MatchType) chplan.BinaryOp {
 // path: a MatrixSelector means a range-vector function (rate, increase,
 // *_over_time); the clamp family takes a vector + scalar bounds; everything
 // else is treated as an instant-vector math function (abs, sqrt, ln, ...)
-// if recognised. Other functions surface a clear "not yet supported"
-// error pointing at the relevant milestone.
+// if recognised. Unrecognised functions surface a clear "unsupported"
+// error to the caller.
 func lowerCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
 	// `quantile_over_time(phi, v[range])` takes a scalar first; the
 	// range-vector lives at c.Args[1]. Route it before the generic
@@ -809,10 +802,9 @@ func lowerRangeVectorCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chpla
 	// The matcher's `__name__` value must be a single equality matcher
 	// (`metric_name{...}`) for `metricNameFromMatchers` to return a
 	// non-empty string. Regex `__name__=~"foo|bar"` falls through to
-	// the existing empty-MetricName behaviour — the structural fix to
-	// thread per-series names through the windowed aggregation is a
-	// larger change deferred until a query in that shape surfaces in
-	// the compat lane.
+	// the existing empty-MetricName behaviour — threading per-series
+	// names through the windowed aggregation is a larger structural
+	// change not modelled here.
 	if c.Func.Name == "last_over_time" || c.Func.Name == "first_over_time" {
 		return wrapRangeWindowPreserveName(rw, s, metricNameFromMatchers(vs.LabelMatchers)), nil
 	}
@@ -1276,8 +1268,8 @@ func topKPartition(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) []ch
 //
 // Only `scalar(<vector>)` is accepted as the K shape — mixed forms
 // like `topk(2 + scalar(x), v)` would require constant-folding around
-// the scalar subquery, which is a bigger change deferred to a
-// follow-up. The PromQL parser already type-checks the K arg as
+// the scalar subquery, which is a larger structural change not
+// modelled here. The PromQL parser already type-checks the K arg as
 // scalar-valued, so this is a narrow filter on the lowering surface.
 func lowerTopKComputed(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
 	// Peel ParenExpr wrappers so `topk((scalar(x)), v)` still routes

--- a/internal/promql/subquery.go
+++ b/internal/promql/subquery.go
@@ -13,15 +13,14 @@ import (
 // defaultSubqueryStep is the step cerberus substitutes when a subquery
 // omits an explicit `step` (`expr[5m:]`). Prom defines empty-step
 // semantics as "use the engine's eval step"; cerberus doesn't thread
-// that through lowering yet (M2.1 territory) so we hardcode 1m, which
-// matches Prom's default eval step.
+// that through lowering, so we hardcode 1m, which matches Prom's
+// default eval step.
 const defaultSubqueryStep = time.Minute
 
-// lowerSubquery handles `<expr>[<range>:<step>]`. P0 4.5 scope: the
-// inner is a `*parser.VectorSelector` (`up[5m:1m]`). Inner ranges over
-// other call shapes (`rate(m[5m])[1h:5m]`) land in P0 4.6; outer
-// range-vector functions over a subquery (`max_over_time(...)[1h:5m]`)
-// land in P0 4.7.
+// lowerSubquery handles `<expr>[<range>:<step>]`. Supports VectorSelector
+// inners (`up[5m:1m]`), inner Call shapes (`rate(m[5m])[1h:5m]`), and
+// outer range-vector functions over a subquery
+// (`max_over_time(...)[1h:5m]`) via the switch below.
 //
 // The lowered shape is a matrix-mode RangeWindow with Identity=true
 // (the "last value in window" emission). Each anchor across
@@ -714,12 +713,14 @@ func lowerSubqueryOverCountValues(
 	default:
 		mapArgs := make([]chplan.Expr, 0, (len(agg.Grouping)+1)*2)
 		for i, lbl := range agg.Grouping {
-			mapArgs = append(mapArgs,
+			mapArgs = append(
+				mapArgs,
 				&chplan.LitString{V: lbl},
 				&chplan.ColumnRef{Name: aliases[i]},
 			)
 		}
-		mapArgs = append(mapArgs,
+		mapArgs = append(
+			mapArgs,
 			&chplan.LitString{V: label},
 			&chplan.ColumnRef{Name: valueKeyAlias},
 		)
@@ -844,7 +845,8 @@ func buildAttributesFromAggregate(agg *parser.AggregateExpr, gkeyAliases []strin
 	}
 	args := make([]chplan.Expr, 0, len(agg.Grouping)*2)
 	for i, label := range agg.Grouping {
-		args = append(args,
+		args = append(
+			args,
 			&chplan.LitString{V: label},
 			&chplan.ColumnRef{Name: gkeyAliases[i]},
 		)

--- a/internal/qlcommon/label_replace.go
+++ b/internal/qlcommon/label_replace.go
@@ -49,7 +49,7 @@ import (
 //     `${name}`, `$10` etc.) is preserved verbatim so we don't silently
 //     mistranslate a shape we don't fully support.
 //
-// regex is the regex string the replacement will be applied against;
+// regex is the regex string the replacement is applied against;
 // it's used to count capture groups so out-of-range backrefs can be
 // rewritten to the empty string. CH validates `replaceRegexpOne`'s
 // substitution string against the regex's capture-group count at SQL-

--- a/internal/schema/env.go
+++ b/internal/schema/env.go
@@ -41,8 +41,8 @@ func envOverride(key, def string) string {
 // DefaultOTelMetricsFromEnv returns DefaultOTelMetrics() with any
 // CERBERUS_SCHEMA_METRICS_*_TABLE env overrides applied. Unset or
 // whitespace-only values leave the corresponding field at its default.
-// Non-table fields (column names, rollups, suffixes) are not yet
-// overridable — extend the surface here if a deployment demonstrates
+// Non-table fields (column names, rollups, suffixes) are not exposed
+// as overrides — extend the surface here if a deployment demonstrates
 // the need.
 func DefaultOTelMetricsFromEnv() Metrics {
 	m := DefaultOTelMetrics()

--- a/internal/traceql/lower.go
+++ b/internal/traceql/lower.go
@@ -1,8 +1,8 @@
 // Package traceql lowers Tempo TraceQL queries into the shared cerberus
-// chplan IR. The seed (M4.1) covers the SpansetFilter form: attribute
-// matchers like `{ .service.name = "x" }`, `{ duration > 100ms }`,
-// `{ span.http.status_code >= 500 }`. Structural operators (`>>`/`>`),
-// aggregators, time filters, and `| select(...)` land in M4.2-M4.4.
+// chplan IR. Covers the SpansetFilter form (attribute matchers like
+// `{ .service.name = "x" }`, `{ duration > 100ms }`,
+// `{ span.http.status_code >= 500 }`), structural operators
+// (`>>`/`>`), aggregators, time filters, and `| select(...)`.
 package traceql
 
 import (
@@ -61,10 +61,10 @@ func lowerRoot(expr *traceql.RootExpr, s schema.Traces) (chplan.Node, error) {
 		return nil, err
 	}
 
-	// Subsequent pipeline elements layer onto the previous result. M4.3
-	// supports `| count()` / `| sum(...)` / `| avg(...)` / `| max(...)`
-	// / `| min(...)`. Other follow-on stages (scalar filter, group /
-	// coalesce / select) defer to M4.4.
+	// Subsequent pipeline elements layer onto the previous result.
+	// Aggregators (`| count()` / `| sum(...)` / `| avg(...)` /
+	// `| max(...)` / `| min(...)`) and follow-on stages (scalar filter,
+	// group / coalesce / select) are handled by lowerFollowingElement.
 	for _, el := range expr.Pipeline.Elements[1:] {
 		next, err := lowerFollowingElement(plan, el, s)
 		if err != nil {
@@ -314,9 +314,10 @@ func lowerScalarExpr(prev chplan.Node, e traceql.ScalarExpression, s schema.Trac
 	return nil, fmt.Errorf("traceql: scalar expression %T is unsupported", e)
 }
 
-// lowerPipelineElement dispatches a single TraceQL pipeline element to
-// its corresponding lowering routine. Currently SpansetFilter and
-// SpansetOperation; aggregates / select / scalar filters defer.
+// lowerPipelineElement dispatches the first TraceQL pipeline element to
+// its corresponding lowering routine: SpansetFilter or SpansetOperation.
+// Aggregates, select, and scalar filters appear only as following
+// elements and are dispatched by lowerFollowingElement.
 func lowerPipelineElement(elem traceql.PipelineElement, s schema.Traces) (chplan.Node, error) {
 	switch v := elem.(type) {
 	case *traceql.SpansetFilter:


### PR DESCRIPTION
## Summary

Mechanical pass over Go comments in \`internal/**/*.go\` (excluding \`*_test.go\`) to remove aspirational / planning-language framing. The comments either referenced upcoming milestones (\`M1.x\`, \`M2.x\`, \`M3.x\`, \`M4.x\`, \`P0 4.5-4.7\`, \`RC3\`) or pointed at \"future PRs\" / \"follow-up cleanups\" that either never came or have already landed in the tree.

## Categories touched

1. **Stale milestone references rewritten to neutral present tense.**
   - \`internal/promql/lower.go\` — drop \"Deferred to RC3 / later milestones: ...\" block; the listed features are either supported or out-of-scope.
   - \`internal/promql/subquery.go\` — drop \"P0 4.5 scope / land in P0 4.6 / 4.7\" framing (already supported via the switch).
   - \`internal/promql/histogram_quantile.go\` — drop \"M2.1 plumbs real eval time\" reference.
   - \`internal/promql/histogram_quantile_range.go\` — drop \"matrix-anchor handling under modifiers is a follow-up\".
   - \`internal/promql/date_fns.go\` — drop \"can be retired in a follow-up cleanup\".
   - \`internal/promql/absent.go\` — drop \"safe to layer on later\".
   - \`internal/promql/lower.go\` (lowerTopKComputed) — drop \"deferred to a follow-up\".
   - \`internal/traceql/lower.go\` — drop \"M4.1 / M4.2-M4.4\" milestones from package godoc and \`lowerPipelineElement\`.
   - \`internal/logql/lower.go\` — drop \"Subsequent milestones add\" from package godoc.
   - \`internal/logql/binary.go\` — \"defer to a later milestone\" → \"are not implemented\".
   - \`internal/chplan/histogram_quantile_native.go\` — drop \"defers to RC3\".
   - \`internal/api/prom/handler.go\` — drop \"P0 4.5+\" marker; drop \"Full nested-AST serialization is a follow-up\".
   - \`internal/api/prom/metadata.go\` — drop \"lands with M2.7\" + \"for now\" framings.
   - \`internal/api/loki/patterns.go\` — drop \"per-level bucketing lands in a follow-up PR\" + \"for now\".
   - \`internal/api/tempo/metrics_query_instant.go\` — drop stale \"Closes the EF noted on #398\" paragraph referring to a now-removed skip.

2. **\"for now\" / \"reserved for future use\" rewrites.**
   - \`internal/chsql/builder.go\` — \"future port\" / \"future ports\" framing on \`PreRenderedSQL\` + \`WithRecursive\` flattened to current-state description.
   - \`internal/chsql/tableshape.go\` — \"reserved for future use\" → declarative \"names columns covered by registered Bloom-filter or set indexes\".
   - \`internal/optimizer/mv_substitution.go\` — \"v2 will introduce a real estimator\" rewritten without the version-promise framing.
   - \`internal/optimizer/rule.go\` — \"leaves room for follow-up rules to land\" → \"lets additional rules join the batch\".
   - \`internal/engine/engine.go\` — drop the \"until per-head port milestones rewrite\" sentence; \"intentionally narrow for now\" → \"intentionally narrow\".
   - \`internal/schema/env.go\` — \"are not yet overridable\" → \"are not exposed as overrides\".
   - \`internal/logql/lower.go\` (logfmt) — drop \"for now\".
   - \`internal/api/loki/patterns.go\` — drop \"single-tenant for now\".

3. **Dangling \"follow-up\" notes about helpers that fed nothing.**
   - \`internal/logql/binary.go\` (\`includeLabelsFromBinop\`) — drop \"Pre-thread for #393 ... wiring lands in a follow-up\" (the helper still has only test callers; the planning note no longer adds anything).

4. **Defensive \"future edit\" framing trimmed.**
   - \`internal/chclient/breaker.go\` — \"defensive against a future edit that splits record into two phases\" → \"defensive if record is ever split into two phases\".

## Representative diff hunk

\`\`\`go
// internal/promql/subquery.go
-// lowerSubquery handles \`<expr>[<range>:<step>]\`. P0 4.5 scope: the
-// inner is a \`*parser.VectorSelector\` (\`up[5m:1m]\`). Inner ranges over
-// other call shapes (\`rate(m[5m])[1h:5m]\`) land in P0 4.6; outer
-// range-vector functions over a subquery (\`max_over_time(...)[1h:5m]\`)
-// land in P0 4.7.
+// lowerSubquery handles \`<expr>[<range>:<step>]\`. Supports VectorSelector
+// inners (\`up[5m:1m]\`), inner Call shapes (\`rate(m[5m])[1h:5m]\`), and
+// outer range-vector functions over a subquery
+// (\`max_over_time(...)[1h:5m]\`) via the switch below.
\`\`\`

## Out of scope

Error strings that say \"not yet supported\" / \"land in M3.2\" / \"lands with M1.7\" are user-facing wire surface, not Go comments — left for a separate cleanup if a wire-string audit becomes the goal.

## Stats

24 files changed, 100 insertions(+), 134 deletions(-).

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] Comment-only changes; no test or behavior modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)