### PR TITLE
chore(compose): Grafana auto-login as admin — drop the admin/admin prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Docker Compose, Kubernetes, or a bare-metal supervisor — see
 ```sh
 git clone https://github.com/tsouza/cerberus.git && cd cerberus
 docker compose up --wait
-open http://localhost:3000   # Grafana (admin/admin); cerberus on :8080
+open http://localhost:3000   # Grafana (auto-login as admin); cerberus on :8080
 ```
 
 The stack builds cerberus from the repo, boots a single-node ClickHouse,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,8 +137,16 @@ services:
     environment:
       GF_SECURITY_ADMIN_USER: admin
       GF_SECURITY_ADMIN_PASSWORD: admin
+      # Anonymous-Admin + disabled login form means the user opens
+      # http://localhost:3000 and lands directly on the home dashboard
+      # with full edit rights — no admin/admin prompt to navigate. The
+      # admin user above still exists for API automation; the signout
+      # menu is hidden so the in-browser session can't accidentally
+      # drop to a "logged out" state with no way back in.
       GF_AUTH_ANONYMOUS_ENABLED: "true"
-      GF_AUTH_ANONYMOUS_ORG_ROLE: Viewer
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
+      GF_AUTH_DISABLE_LOGIN_FORM: "true"
+      GF_AUTH_DISABLE_SIGNOUT_MENU: "true"
       GF_USERS_DEFAULT_THEME: dark
       GF_FEATURE_TOGGLES_ENABLE: traceqlSearch
     volumes:


### PR DESCRIPTION
## Summary

The quickstart \`docker compose up --wait && open localhost:3000\` lands on Grafana's login form, then the user types \`admin/admin\`, then \"change your password\", then \"skip\". Three clicks of friction before they see anything cerberus actually does. The compose stack is a local-dev quickstart — there's no security model to preserve.

Set anonymous role to **Admin** and disable both the login form and the signout menu. User opens :3000 and lands directly on the home dashboard with full edit rights.

- \`GF_AUTH_ANONYMOUS_ORG_ROLE: Admin\` (was \`Viewer\`)
- \`GF_AUTH_DISABLE_LOGIN_FORM: \"true\"\` (new)
- \`GF_AUTH_DISABLE_SIGNOUT_MENU: \"true\"\` (new — so the in-browser session can't accidentally drop to a \"logged out\" state with no way back in)

The \`admin/admin\` credentials still exist for any API automation that needs them; only the in-browser UX changes.

README.md updated to drop the \`(admin/admin)\` annotation since the prompt is gone.

## Follow-up (separate PRs in the quickstart UX arc)

- **B** — add \`otel-collector\` service to the compose stack so cerberus dogfoods its own telemetry through the realistic OTLP write path.
- **C** — provision starter dashboards (cerberus self-observability + OTel-fixture explorer).

## Test plan

- [ ] \`compose-smoke\` CI green (proves Grafana still passes \`/api/health\`)
- [ ] Manual: \`docker compose up --wait && open localhost:3000\` lands on home dashboard, no login prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)