### PR TITLE
feat(compose): provision cerberus self-obs + OTel fixture-explorer dashboards

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,10 @@
 #                   successful run; doesn't block the long-lived services
 #                   from being ready.
 #   grafana         pre-provisioned with cerberus as three datasources
-#                   (Prometheus / Loki / Tempo). Provisioning files live
+#                   (Prometheus / Loki / Tempo) and two starter dashboards
+#                   under the "Cerberus" folder — `cerberus-self` (self-obs;
+#                   set as home dashboard) and `otel-fixture-explorer`
+#                   (tour of the seed fixture). Provisioning files live
 #                   under `test/e2e/grafana/compose/`.
 #
 # Default host port map:
@@ -192,8 +195,17 @@ services:
       GF_AUTH_DISABLE_SIGNOUT_MENU: "true"
       GF_USERS_DEFAULT_THEME: dark
       GF_FEATURE_TOGGLES_ENABLE: traceqlSearch
+      # Land directly on the cerberus-self dashboard instead of an empty
+      # home page. Path is the in-container mount location of the JSON,
+      # not a Grafana URL or UID.
+      GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /etc/grafana/provisioning/dashboards/cerberus/cerberus-self.json
     volumes:
       - ./test/e2e/grafana/compose/datasources:/etc/grafana/provisioning/datasources:ro
+      # Dashboard provider config tells Grafana to scan the `cerberus`
+      # subdir for JSON dashboards; the dashboards themselves live one
+      # level down so the provider's `path:` matches the mount point.
+      - ./test/e2e/grafana/compose/dashboards-provider.yaml:/etc/grafana/provisioning/dashboards/provider.yaml:ro
+      - ./test/e2e/grafana/compose/dashboards:/etc/grafana/provisioning/dashboards/cerberus:ro
     ports:
       - "3000:3000"
     depends_on:

--- a/test/e2e/grafana/compose/dashboards-provider.yaml
+++ b/test/e2e/grafana/compose/dashboards-provider.yaml
@@ -1,0 +1,29 @@
+# Grafana dashboard-provisioning config for the repo-root docker-compose.yml
+# stack. Tells Grafana to scan /etc/grafana/provisioning/dashboards/cerberus
+# for JSON dashboards and load them under the "Cerberus" folder.
+#
+# Two starter dashboards ship with the compose quickstart:
+#   - cerberus-self.json: cerberus's own observability surface (per-head
+#     request rate, latency quantiles, error rate, in-flight, admission
+#     rejections, recent ERROR logs, slow-query traces). Wired as the
+#     home dashboard via GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH so
+#     opening localhost:3000 lands directly on it.
+#   - otel-fixture-explorer.json: tours the seed fixture (top services by
+#     request rate, log-severity histogram, trace error rate, recent spans).
+#     A useful "what's in this CH database?" first-look for demo users.
+#
+# The k3d e2e stack at test/e2e/k3s/ has its own ConfigMap-based provisioning
+# (grafana-dashboards.yaml) — keep the two in sync when adding new dashboards.
+apiVersion: 1
+providers:
+  - name: cerberus
+    orgId: 1
+    folder: Cerberus
+    type: file
+    disableDeletion: true
+    editable: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: false
+    options:
+      path: /etc/grafana/provisioning/dashboards/cerberus
+      foldersFromFilesStructure: false

--- a/test/e2e/grafana/compose/dashboards/cerberus-self.json
+++ b/test/e2e/grafana/compose/dashboards/cerberus-self.json
@@ -1,0 +1,590 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Cerberus self-observability. All panels query cerberus's own dogfood loop: cerberus -> OTLP -> Collector -> ClickHouse -> cerberus -> Grafana. Until the OTel collector service lands in the quickstart compose, the metric / log / trace panels here will render 'no data' rather than error out.",
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "cerberus-prometheus"
+      },
+      "description": "Per-second query rate seen by cerberus, broken down by upstream query language (PromQL / LogQL / TraceQL). Backed by the cerberus_queries_total counter.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "cerberus-prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (cerberus_ql) (rate(cerberus_queries_total[5m]))",
+          "legendFormat": "{{cerberus_ql}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Query rate by language",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "cerberus-prometheus"
+      },
+      "description": "P95 query latency per head (PromQL / LogQL / TraceQL), computed from cerberus_queries_duration_seconds_bucket with histogram_quantile.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "cerberus-prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, cerberus_ql) (rate(cerberus_queries_duration_seconds_bucket[5m])))",
+          "legendFormat": "p95 {{cerberus_ql}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "P95 latency by language",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "cerberus-prometheus"
+      },
+      "description": "Fraction of queries that returned an error, per language. Computed from cerberus_queries_total filtered by result=error over the per-language total. Threshold at 1% yellow / 5% red.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "scheme",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.01
+              },
+              {
+                "color": "red",
+                "value": 0.05
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "cerberus-prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (cerberus_ql) (rate(cerberus_queries_total{result=\"error\"}[5m])) / clamp_min(sum by (cerberus_ql) (rate(cerberus_queries_total[5m])), 1e-9)",
+          "legendFormat": "{{cerberus_ql}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Error rate by language",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "cerberus-prometheus"
+      },
+      "description": "Concurrent in-flight queries per head. Backed by the cerberus_query_inflight gauge — declarative until the admission middleware exports it.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 50
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "cerberus-prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (cerberus_ql) (cerberus_query_inflight)",
+          "legendFormat": "{{cerberus_ql}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "In-flight queries",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "cerberus-prometheus"
+      },
+      "description": "Admission-control rejections per second, per head. Backed by cerberus_admit_rejected_total — declarative until the admission middleware exports it.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "cerberus-prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (cerberus_ql, reason) (rate(cerberus_admit_rejected_total[5m]))",
+          "legendFormat": "{{cerberus_ql}} / {{reason}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Admission rejections",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "cerberus-loki"
+      },
+      "description": "Recent ERROR-severity log records emitted by cerberus itself (service_name=cerberus, SeverityText=ERROR). Sourced via the Loki head against the otel_logs table.",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "id": 6,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": true,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "cerberus-loki"
+          },
+          "editorMode": "code",
+          "expr": "{service_name=\"cerberus\"} | SeverityText=\"ERROR\"",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Cerberus ERROR logs",
+      "type": "logs"
+    },
+    {
+      "datasource": {
+        "type": "tempo",
+        "uid": "cerberus-tempo"
+      },
+      "description": "Slow cerberus query traces — spans from service.name=cerberus with duration > 100ms. Sourced via the Tempo head against the otel_traces table.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 34
+      },
+      "id": 7,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "tempo",
+            "uid": "cerberus-tempo"
+          },
+          "limit": 20,
+          "query": "{ resource.service.name = \"cerberus\" && duration > 100ms }",
+          "queryType": "traceql",
+          "refId": "A",
+          "tableType": "traces"
+        }
+      ],
+      "title": "Slow cerberus traces (>100ms)",
+      "type": "table"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["cerberus", "self-observability", "dogfood"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Cerberus - self-observability",
+  "uid": "cerberus-self",
+  "version": 1,
+  "weekStart": ""
+}

--- a/test/e2e/grafana/compose/dashboards/otel-fixture-explorer.json
+++ b/test/e2e/grafana/compose/dashboards/otel-fixture-explorer.json
@@ -1,0 +1,385 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Tour of the OTel fixture seeded into ClickHouse by the compose `seed` service. Pivots all three signals (metrics / logs / traces) through cerberus's three heads against the otel_metrics_sum / otel_logs / otel_traces tables so demo users can see the same data shaped three ways without writing a query.",
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "cerberus-prometheus"
+      },
+      "description": "Top services by request rate. Sums the http.server.request.count metric (from otel_metrics_sum) grouped by service_name. Replace the metric name with whatever your fixture emits if different.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "cerberus-prometheus"
+          },
+          "editorMode": "code",
+          "expr": "topk(10, sum by (service_name) (rate({__name__=~\".+\"}[5m])))",
+          "legendFormat": "{{service_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Top services by metric rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "cerberus-loki"
+      },
+      "description": "Per-second log volume from otel_logs, stacked by SeverityText. A quick read of error / warn / info skew across the fixture.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "logs/s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "cerberus-loki"
+          },
+          "editorMode": "code",
+          "expr": "sum by (SeverityText) (rate({service_name=~\".+\"} [5m]))",
+          "legendFormat": "{{SeverityText}}",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Log volume by severity",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "tempo",
+        "uid": "cerberus-tempo"
+      },
+      "description": "Error-rate per service from otel_traces: spans whose StatusCode = Error divided by total spans, grouped by resource.service.name. Sourced via the Tempo head's TraceQL metrics endpoint.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "scheme",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.01
+              },
+              {
+                "color": "red",
+                "value": 0.05
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "tempo",
+            "uid": "cerberus-tempo"
+          },
+          "query": "{ status = error } | rate() by (resource.service.name)",
+          "queryType": "traceqlMetrics",
+          "refId": "A"
+        }
+      ],
+      "title": "Trace error rate by service",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "tempo",
+        "uid": "cerberus-tempo"
+      },
+      "description": "Most recent 20 spans across the fixture — TraceID, service.name, span name, and duration. A quick `which traces did the seed actually load?` answer.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "id": 4,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "tempo",
+            "uid": "cerberus-tempo"
+          },
+          "limit": 20,
+          "query": "{ resource.service.name != \"\" }",
+          "queryType": "traceql",
+          "refId": "A",
+          "tableType": "traces"
+        }
+      ],
+      "title": "Recent spans",
+      "type": "table"
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "tags": ["cerberus", "otel-fixture", "explorer"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "OTel fixture explorer",
+  "uid": "otel-fixture-explorer",
+  "version": 1,
+  "weekStart": ""
+}


### PR DESCRIPTION
## Summary

Provisions two starter Grafana dashboards in the repo-root quickstart compose
stack so `docker compose up --wait && open http://localhost:3000` lands on a
useful demo instead of an empty home page.

- `cerberus-self` is wired as the Grafana home dashboard via
  `GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH`, so the quickstart opens
  directly on cerberus's own observability surface.
- Both dashboards land in the "Cerberus" folder via the file-provider in
  `test/e2e/grafana/compose/dashboards-provider.yaml`.

## Dashboards shipped

### Cerberus - self-observability (`uid: cerberus-self`)

7 panels, all using the existing `cerberus-prometheus` / `cerberus-loki` /
`cerberus-tempo` datasource UIDs:

| # | Panel | Datasource | Query (shape) |
|---|---|---|---|
| 1 | Query rate by language | cerberus-prometheus | `sum by (cerberus_ql) (rate(cerberus_queries_total[5m]))` |
| 2 | P95 latency by language | cerberus-prometheus | `histogram_quantile(0.95, sum by (le, cerberus_ql) (rate(cerberus_queries_duration_seconds_bucket[5m])))` |
| 3 | Error rate by language | cerberus-prometheus | `errors / total` ratio per `cerberus_ql` with 1% / 5% thresholds |
| 4 | In-flight queries | cerberus-prometheus | `sum by (cerberus_ql) (cerberus_query_inflight)` — gauge, declarative until the admission middleware exports it |
| 5 | Admission rejections | cerberus-prometheus | `sum by (cerberus_ql, reason) (rate(cerberus_admit_rejected_total[5m]))` — declarative until the admission middleware exports it |
| 6 | Cerberus ERROR logs | cerberus-loki | `{service_name="cerberus"} \| SeverityText="ERROR"` |
| 7 | Slow cerberus traces (>100ms) | cerberus-tempo | TraceQL: `{ resource.service.name = "cerberus" && duration > 100ms }` |

Metric names are grounded against `internal/telemetry/metrics.go`:
`cerberus.queries.total` -> Prom-exposed as `cerberus_queries_total`,
labels `cerberus_ql` / `cerberus_route` / `result`. The in-flight and
admit-rejected names are declarative against the admission middleware
that lands later — until then those two panels render "no data".

### OTel fixture explorer (`uid: otel-fixture-explorer`)

4 panels:

| # | Panel | Datasource | Query (shape) |
|---|---|---|---|
| 1 | Top services by metric rate | cerberus-prometheus | `topk(10, sum by (service_name) (rate({__name__=~".+"}[5m])))` |
| 2 | Log volume by severity | cerberus-loki | `sum by (SeverityText) (rate({service_name=~".+"} [5m]))` |
| 3 | Trace error rate by service | cerberus-tempo | TraceQL metrics: `{ status = error } \| rate() by (resource.service.name)` |
| 4 | Recent spans | cerberus-tempo | TraceQL table: `{ resource.service.name != "" }` limit 20 |

## Wiring

`docker-compose.yml`:
- Mounts `test/e2e/grafana/compose/dashboards-provider.yaml` ->
  `/etc/grafana/provisioning/dashboards/provider.yaml:ro`
- Mounts `test/e2e/grafana/compose/dashboards` ->
  `/etc/grafana/provisioning/dashboards/cerberus:ro`
- Sets `GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/etc/grafana/provisioning/dashboards/cerberus/cerberus-self.json`

## Note on "no data"

Until the QS UX B work lands the OTel collector service into the quickstart
compose, the cerberus self-obs panels (and trace / log queries against
service.name = cerberus) will render "no data" rather than error. That's
Grafana's documented default behaviour for an empty TSDB and is the
intended interim UX — the dashboard structure is valid and ready to
populate the moment OTLP wiring lands.

## Test plan

- [ ] `compose-smoke` CI gate brings Grafana up healthy with the new mounts.
- [ ] Local: `docker compose up --wait && open http://localhost:3000` lands on the cerberus-self dashboard (not the Grafana welcome page).
- [ ] Cerberus folder appears in the Grafana left nav with both dashboards listed.
- [ ] All panels render (with or without data) without query-parse errors.
- [ ] `docker compose down -v` cleans up cleanly.