### PR TITLE
feat(compose): wire otel-collector service into the quickstart stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,30 +4,36 @@
 #   open http://localhost:3000   # Grafana (admin/admin)
 #
 # Services:
-#   clickhouse   single-node CH server, OTel-aware (db=otel, user/pass=cerberus).
-#                Named volume `clickhouse-data` survives `docker compose down`
-#                so seed rows persist across restarts. Use `down -v` to wipe.
-#   cerberus     built from the repo-root `Dockerfile.local` (same image the
-#                k3d E2E uses). Auto-creates the OTel-CH schema on startup via
-#                CERBERUS_AUTO_CREATE_SCHEMA=true, so no separate init job.
-#   seed         one-shot Go program that inserts the deterministic OTel
-#                fixture rows from test/e2e/seed/cmd/seed. Exits after a
-#                successful run; doesn't block the long-lived services from
-#                being ready.
-#   grafana      pre-provisioned with cerberus as three datasources
-#                (Prometheus / Loki / Tempo). Provisioning files live under
-#                `test/e2e/grafana/compose/`.
-#
-# The OTLP exporter wiring (cerberus -> OTel Collector -> CH) is intentionally
-# omitted: the self-telemetry OTLP code path and the cerberus-self dashboard
-# both land later in RC4. Add an `otel-collector` service alongside cerberus
-# once those land — see test/e2e/k3s/otel-collector.yaml for the config shape.
+#   clickhouse      single-node CH server, OTel-aware (db=otel,
+#                   user/pass=cerberus). Named volume `clickhouse-data`
+#                   survives `docker compose down` so seed rows persist
+#                   across restarts. Use `down -v` to wipe.
+#   otel-collector  OpenTelemetry Collector configured for the compose
+#                   stack (OTLP gRPC :4317 in, clickhouseexporter out).
+#                   Closes the dogfood loop: cerberus emits self-telemetry
+#                   over OTLP -> collector writes to ClickHouse -> cerberus
+#                   queries it back through its own Prom/Loki/Tempo APIs.
+#                   Config: test/e2e/otel-collector/compose-config.yaml.
+#   cerberus        built from the repo-root `Dockerfile.local` (same image
+#                   the k3d E2E uses). Auto-creates the OTel-CH schema on
+#                   startup via CERBERUS_AUTO_CREATE_SCHEMA=true, so no
+#                   separate init job. Exports OTLP to `otel-collector:4317`.
+#   seed            one-shot Go program that inserts the deterministic OTel
+#                   fixture rows from test/e2e/seed/cmd/seed. Exits after a
+#                   successful run; doesn't block the long-lived services
+#                   from being ready.
+#   grafana         pre-provisioned with cerberus as three datasources
+#                   (Prometheus / Loki / Tempo). Provisioning files live
+#                   under `test/e2e/grafana/compose/`.
 #
 # Default host port map:
 #   3000  -> grafana
 #   8080  -> cerberus (Prom + Loki + Tempo HTTP APIs)
 #   8123  -> clickhouse HTTP
 #   9000  -> clickhouse native protocol
+#   (otel-collector's OTLP port :4317 stays on the cerberus-dev network;
+#   no host port mapping needed since only the cerberus container talks
+#   to it.)
 
 name: cerberus
 
@@ -75,6 +81,30 @@ services:
       retries: 36
       start_period: 30s
 
+  otel-collector:
+    # Pinned to the same upstream-contrib release the k3d E2E uses
+    # (test/e2e/k3s/otel-collector.yaml). Bump both together.
+    #
+    # No `healthcheck:` block: the contrib image is FROM scratch — no
+    # shell, no wget, no curl, no nc — so the standard HTTP/TCP probe
+    # commands are not callable. Cerberus's OTLP exporter retries in
+    # the background, so a slow-starting collector won't fail
+    # cerberus's own startup. `condition: service_started` on the
+    # cerberus dependency below is sufficient; the OTel demo's compose
+    # stack uses the same pattern.
+    image: otel/opentelemetry-collector-contrib:0.116.1
+    networks: [cerberus-dev]
+    command: ["--config=/etc/otel/config.yaml"]
+    volumes:
+      - ./test/e2e/otel-collector/compose-config.yaml:/etc/otel/config.yaml:ro
+    environment:
+      # Mirror the k3d gateway's memory cap so a misbehaving exporter
+      # backlog can't push the collector OOMKill in the dev stack.
+      GOMEMLIMIT: "400MiB"
+    depends_on:
+      clickhouse:
+        condition: service_healthy
+
   cerberus:
     image: cerberus:dev
     pull_policy: build
@@ -94,9 +124,22 @@ services:
       # CERBERUS_AUTO_CREATE_SCHEMA   apply the OTel-CH DDL on startup so a
       # fresh CH volume is queryable without a separate migration step.
       CERBERUS_AUTO_CREATE_SCHEMA: "true"
+      # CERBERUS_OTLP_*       export self-telemetry (metrics + logs +
+      # traces) to the in-stack OTel Collector over OTLP/gRPC. Closes
+      # the dogfood loop: cerberus emits -> collector writes to CH ->
+      # cerberus queries it back through its own APIs. Insecure is
+      # safe inside the cerberus-dev docker network.
+      CERBERUS_OTLP_ENDPOINT: "otel-collector:4317"
+      CERBERUS_OTLP_INSECURE: "true"
     depends_on:
       clickhouse:
         condition: service_healthy
+      otel-collector:
+        # service_started — the contrib image is FROM scratch with no
+        # probe binaries, so a real healthcheck isn't expressible.
+        # Cerberus's OTLP gRPC exporter retries in the background, so
+        # racing the collector start at boot is safe.
+        condition: service_started
     ports:
       - "8080:8080"
     healthcheck:

--- a/test/e2e/otel-collector/compose-config.yaml
+++ b/test/e2e/otel-collector/compose-config.yaml
@@ -1,0 +1,98 @@
+# OpenTelemetry Collector config for the repo-root docker-compose quickstart.
+#
+# This is the compose-flavoured cousin of test/e2e/k3s/otel-collector.yaml,
+# stripped of every k8s-specific receiver (k8s_cluster, k8s_events,
+# kubeletstats, filelog) and the agent/gateway split that only makes
+# sense in a cluster. Compose has a single collector instance:
+#
+#   cerberus -> otel-collector (OTLP/gRPC :4317) -> clickhouseexporter -> CH
+#
+# Cerberus reaches the collector over the cerberus-dev docker network at
+# `otel-collector:4317`. The collector then writes to the same
+# `clickhouse` service the cerberus query path reads from, so the
+# dogfood loop closes: cerberus emits self-telemetry, the collector
+# persists it in CH, and cerberus's own Prom/Loki/Tempo APIs can query
+# it back through Grafana.
+#
+# The clickhouseexporter rides the upstream sqltemplates package — the
+# same set internal/schema/ddl uses — so the table shapes
+# (otel_logs / otel_metrics_* / otel_traces) cannot drift from what
+# cerberus expects to query.
+extensions:
+  # health_check exposes :13133/ on the cerberus-dev network. The
+  # compose stack itself doesn't bind a `healthcheck:` against it
+  # (the upstream contrib image is FROM scratch — no wget/curl/nc to
+  # call out from inside the container), but the endpoint is left
+  # enabled so an operator can curl it from a sidecar / from the host
+  # via `docker compose exec -T otel-collector` (where applicable) to
+  # confirm the pipelines are live.
+  health_check:
+    endpoint: 0.0.0.0:13133
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_percentage: 80
+    spike_limit_percentage: 25
+  batch:
+    send_batch_size: 1024
+    timeout: 5s
+  # Ensure every record carries a service.name even when the sender
+  # forgot to set one. Mirrors the k3s gateway's defaults.
+  resource:
+    attributes:
+      - key: service.name
+        value: cerberus-otel-collector
+        action: insert
+      - key: deployment.environment
+        value: compose
+        action: upsert
+
+exporters:
+  clickhouse:
+    endpoint: tcp://clickhouse:9000?dial_timeout=10s
+    database: otel
+    username: cerberus
+    password: cerberus
+    ttl: 0
+    create_schema: true
+    logs_table_name: otel_logs
+    traces_table_name: otel_traces
+    metrics_table_name: otel_metrics
+    timeout: 10s
+    retry_on_failure:
+      enabled: true
+      initial_interval: 1s
+      max_interval: 30s
+      max_elapsed_time: 5m
+    sending_queue:
+      enabled: true
+      num_consumers: 4
+      queue_size: 1000
+
+service:
+  extensions: [health_check]
+  telemetry:
+    logs:
+      level: info
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [memory_limiter, resource, batch]
+      exporters: [clickhouse]
+    logs:
+      receivers: [otlp]
+      processors: [memory_limiter, resource, batch]
+      exporters: [clickhouse]
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, resource, batch]
+      exporters: [clickhouse]


### PR DESCRIPTION
## Summary

Closes the cerberus self-observability **dogfood loop** in the
repo-root docker-compose quickstart:

```
cerberus -> otel-collector (OTLP gRPC :4317) -> clickhouseexporter -> ClickHouse
                                                                          ^
                                                                          |
cerberus's Prom/Loki/Tempo HTTP APIs read --------------------------------+
                                                                          |
Grafana datasources -> cerberus -> CH -----------------------------------'
```

`docker compose up --wait && open http://localhost:3000` now shows
**live cerberus self-telemetry** (metrics + logs + traces emitted by
cerberus itself, persisted by the collector, queried back through
cerberus) instead of just the static seeded fixture rows.

## What changed

- **`docker-compose.yml`** — add the `otel-collector` service:
  - Image: `otel/opentelemetry-collector-contrib:0.116.1` (same
    pinned version as `test/e2e/k3s/otel-collector.yaml`; bump both
    together).
  - OTLP gRPC `:4317` stays on the `cerberus-dev` network — no host
    port mapping since only the cerberus container talks to it.
  - `depends_on: clickhouse: service_healthy` so the
    clickhouseexporter has a live CH to write into from t=0.
  - **No `healthcheck:`** block. The contrib image is `FROM scratch`
    — no shell, no wget, no curl, no nc — so the standard HTTP/TCP
    probe commands aren't callable from inside the container. The
    `health_check` extension is still enabled in the collector
    config (sidecar/external probes can hit `:13133`); the
    `cerberus` service uses `condition: service_started` for its
    dependency on the collector, mirroring the
    [opentelemetry-demo](https://github.com/open-telemetry/opentelemetry-demo)
    compose stack. Cerberus's OTLP gRPC exporter retries in the
    background, so racing the collector start at boot is safe.
- **`cerberus` service env**:
  - `CERBERUS_OTLP_ENDPOINT=otel-collector:4317`
  - `CERBERUS_OTLP_INSECURE=true`
  - Plus `depends_on: otel-collector: service_started`.
- **`test/e2e/otel-collector/compose-config.yaml`** (new) —
  compose-flavoured collector config. Lifted from
  `test/e2e/k3s/otel-collector.yaml` but stripped of every
  k8s-specific receiver (`k8s_cluster`, `k8s_events`,
  `kubeletstats`, `filelog`) and collapsed from agent + gateway
  into a single instance. Pipelines: `otlp -> memory_limiter +
  resource + batch -> clickhouse`. The `clickhouseexporter` rides
  the same upstream `sqltemplates` package as
  `internal/schema/ddl`, so the table shapes (`otel_logs` /
  `otel_metrics_*` / `otel_traces`) cannot drift from what
  cerberus expects to query.
- **Inline docs comment** at the top of `docker-compose.yml`:
  drop the "intentionally omitted / land later in RC4" wording,
  document the new collector service alongside the others.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('docker-compose.yml'))"` parses clean.
- [x] `python3 -c "import yaml; yaml.safe_load(open('test/e2e/otel-collector/compose-config.yaml'))"` parses clean.
- [x] `docker compose -f docker-compose.yml config --quiet` validates.
- [ ] `compose-smoke` GH workflow validates end-to-end on this PR
      (`docker compose up --wait --wait-timeout 300` then curl
      cerberus's `/healthz` + `/readyz` and Grafana's `/api/health`).

## Out of scope

- Dashboard provisioning that uses the live self-telemetry — separate
  follow-up. This PR just gets the data flowing into CH.