### PR TITLE
feat(api/tempo): mount gRPC StreamingQuerier scaffold with Unimplemented stubs

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -97,6 +97,10 @@ components:
   api-loki:  { in: api/loki }
   api-prom:  { in: api/prom }
   api-tempo: { in: api/tempo }
+  # gRPC StreamingQuerier surface mounted alongside the HTTP Tempo
+  # handler. Imports the HTTP handler so the gRPC RPCs can route to the
+  # same engine + chsql + chplan layers (no duplicated lowering).
+  api-tempo-grpc: { in: api/tempo/grpc }
   # Cross-cutting utility packages — see commonComponents below.
   schema:         { in: schema }
   schema-ddl:     { in: schema/ddl }
@@ -200,6 +204,15 @@ deps:
       - promql
   api-tempo:
     mayDependOn:
+      - chplan
+      - chsql
+      - chclient
+      - engine
+      - optimizer
+      - traceql
+  api-tempo-grpc:
+    mayDependOn:
+      - api-tempo
       - chplan
       - chsql
       - chclient

--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -15,8 +15,6 @@ import (
 	"time"
 
 	"go.opentelemetry.io/otel"
-	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
 
 	"github.com/tsouza/cerberus/internal/api/admit"
 	"github.com/tsouza/cerberus/internal/api/health"
@@ -235,34 +233,7 @@ func run() error {
 	tempoGRPCService := tempogrpc.NewService(tempoHandler, tempoLimiter, logger.With("api", "tempo-grpc"))
 	grpcServer := tempogrpc.NewServer(tempoGRPCService)
 
-	// h2c content-type dispatcher: HTTP/2 requests whose Content-Type
-	// is application/grpc (or a parameterised variant like
-	// `application/grpc+proto`) go to the gRPC server; everything else
-	// flows to the existing HTTP rootMux. Wrapping the dispatcher in
-	// h2c.NewHandler upgrades cleartext HTTP/2 (PRI preamble) without
-	// requiring TLS, so cerberus accepts:
-	//
-	//   * HTTP/1.1 clients (Grafana HTTP datasource, curl, healthz)
-	//   * HTTP/2 clients via prior-knowledge (grpc-go default)
-	//   * HTTP/2 upgrades from HTTP/1.1 (h2c-aware proxies)
-	//
-	// on the same socket. Behind a TLS-terminating proxy (ingress-
-	// nginx, Envoy, Cloud Run) the proxy negotiates h2 with the client
-	// and forwards h2c upstream — the standard pattern. See
-	// docs/operations.md#port-binding for the deployment story.
-	dispatcher := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.ProtoMajor == 2 && strings.HasPrefix(r.Header.Get("Content-Type"), "application/grpc") {
-			grpcServer.ServeHTTP(w, r)
-			return
-		}
-		rootMux.ServeHTTP(w, r)
-	})
-
-	srv := &http.Server{
-		Addr:              cfg.HTTPAddr,
-		Handler:           h2c.NewHandler(dispatcher, &http2.Server{}),
-		ReadHeaderTimeout: 5 * time.Second,
-	}
+	srv := buildDualStackServer(cfg.HTTPAddr, rootMux, grpcServer)
 
 	serverErr := make(chan error, 1)
 	go func() {
@@ -297,4 +268,41 @@ func run() error {
 	}
 	logger.Info("cerberus stopped")
 	return nil
+}
+
+// buildDualStackServer wires an http.Server that serves HTTP/1.1 (for
+// existing Prom/Loki/Tempo HTTP handlers + /healthz + /readyz) AND
+// unencrypted HTTP/2 (for the Tempo gRPC StreamingQuerier) on the same
+// listener. A content-type dispatcher routes HTTP/2 + application/grpc
+// requests to the gRPC server; everything else flows to the HTTP mux.
+//
+// Cerberus accepts:
+//
+//   - HTTP/1.1 clients (Grafana HTTP datasource, curl, /healthz)
+//   - HTTP/2 clients via prior-knowledge (grpc-go default)
+//   - HTTP/2 upgrades from HTTP/1.1 (h2c-aware proxies)
+//
+// Go 1.24+ `http.Server.Protocols` supersedes the deprecated
+// `golang.org/x/net/http2/h2c.NewHandler` wrap — same wire behaviour,
+// no extra dep. Behind a TLS-terminating proxy (ingress-nginx, Envoy,
+// Cloud Run) the proxy negotiates h2 with the client and forwards
+// h2c upstream — the standard pattern. See
+// docs/operations.md#port-binding.
+func buildDualStackServer(addr string, rootMux, grpcServer http.Handler) *http.Server {
+	dispatcher := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.ProtoMajor == 2 && strings.HasPrefix(r.Header.Get("Content-Type"), "application/grpc") {
+			grpcServer.ServeHTTP(w, r)
+			return
+		}
+		rootMux.ServeHTTP(w, r)
+	})
+	protocols := new(http.Protocols)
+	protocols.SetHTTP1(true)
+	protocols.SetUnencryptedHTTP2(true)
+	return &http.Server{
+		Addr:              addr,
+		Handler:           dispatcher,
+		Protocols:         protocols,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
 }

--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -9,17 +9,21 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"sync/atomic"
 	"syscall"
 	"time"
 
 	"go.opentelemetry.io/otel"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
 
 	"github.com/tsouza/cerberus/internal/api/admit"
 	"github.com/tsouza/cerberus/internal/api/health"
 	"github.com/tsouza/cerberus/internal/api/loki"
 	"github.com/tsouza/cerberus/internal/api/prom"
 	"github.com/tsouza/cerberus/internal/api/tempo"
+	tempogrpc "github.com/tsouza/cerberus/internal/api/tempo/grpc"
 	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/config"
 	"github.com/tsouza/cerberus/internal/engine"
@@ -220,9 +224,43 @@ func run() error {
 	healthHandler.Mount(rootMux)
 	rootMux.Handle("/", tracedAPI)
 
+	// Tempo gRPC StreamingQuerier — PR 1 (scaffold) of the Tempo gRPC
+	// rollout. The service shares the Tempo HTTP handler's Engine +
+	// schema + admit limiter so the eventual streaming RPC bodies (PRs
+	// 2-4) and the existing HTTP handlers run the same parse + lower +
+	// emit pipeline against the same backend. Today every RPC returns
+	// codes.Unimplemented via the embedded
+	// UnimplementedStreamingQuerierServer; PRs 2-4 fill in real bodies
+	// one RPC group at a time.
+	tempoGRPCService := tempogrpc.NewService(tempoHandler, tempoLimiter, logger.With("api", "tempo-grpc"))
+	grpcServer := tempogrpc.NewServer(tempoGRPCService)
+
+	// h2c content-type dispatcher: HTTP/2 requests whose Content-Type
+	// is application/grpc (or a parameterised variant like
+	// `application/grpc+proto`) go to the gRPC server; everything else
+	// flows to the existing HTTP rootMux. Wrapping the dispatcher in
+	// h2c.NewHandler upgrades cleartext HTTP/2 (PRI preamble) without
+	// requiring TLS, so cerberus accepts:
+	//
+	//   * HTTP/1.1 clients (Grafana HTTP datasource, curl, healthz)
+	//   * HTTP/2 clients via prior-knowledge (grpc-go default)
+	//   * HTTP/2 upgrades from HTTP/1.1 (h2c-aware proxies)
+	//
+	// on the same socket. Behind a TLS-terminating proxy (ingress-
+	// nginx, Envoy, Cloud Run) the proxy negotiates h2 with the client
+	// and forwards h2c upstream — the standard pattern. See
+	// docs/operations.md#port-binding for the deployment story.
+	dispatcher := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.ProtoMajor == 2 && strings.HasPrefix(r.Header.Get("Content-Type"), "application/grpc") {
+			grpcServer.ServeHTTP(w, r)
+			return
+		}
+		rootMux.ServeHTTP(w, r)
+	})
+
 	srv := &http.Server{
 		Addr:              cfg.HTTPAddr,
-		Handler:           rootMux,
+		Handler:           h2c.NewHandler(dispatcher, &http2.Server{}),
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 
@@ -246,6 +284,12 @@ func run() error {
 	if err := srv.Shutdown(shutdownCtx); err != nil {
 		return fmt.Errorf("graceful shutdown: %w", err)
 	}
+	// Drain any in-flight gRPC streams before tearing telemetry down.
+	// GracefulStop blocks until every active RPC returns or its
+	// stream is closed by the HTTP/2 transport (which srv.Shutdown
+	// has already done). With no in-flight streams it returns
+	// immediately, so this is a no-op on the happy path.
+	grpcServer.GracefulStop()
 	// Flush any pending OTLP batches before the process exits. Noop
 	// when telemetry was disabled (Endpoint == "").
 	if err := providers.Shutdown(shutdownCtx); err != nil {

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -88,6 +88,35 @@ up` exposes `8080:8080`, `test/e2e/k3s/cerberus.yaml` declares a
 listens on `:8080`. No env-var translation is needed between deployment
 targets.
 
+### HTTP/2 (h2c) + gRPC on the same port
+
+The same `:8080` socket accepts three protocol shapes:
+
+- **HTTP/1.1** — the Prometheus, Loki, and Tempo HTTP datasources, plus
+  `/healthz` and `/readyz` probes, plus Loki's WebSocket tail
+  (`/loki/api/v1/tail`).
+- **HTTP/2 cleartext (h2c)** — `application/grpc` content-type traffic
+  flows into the embedded gRPC server. Cerberus serves the Tempo
+  `StreamingQuerier` gRPC surface that Grafana's Tempo datasource opens
+  when the user enables the "Streaming" toggle in datasource settings.
+- **HTTP/2 prior-knowledge** — Go gRPC clients (Grafana's backend
+  client included) connect directly without an upgrade dance.
+
+The dispatch happens at the handler layer: an `h2c.NewHandler` wraps a
+content-type-aware dispatcher that routes `application/grpc` requests
+into the `*grpc.Server` and everything else into the existing HTTP
+mux. This keeps deployment topology unchanged — one container port,
+one `Service` port, one ingress rule.
+
+Behind a TLS-terminating proxy (ingress-nginx, Envoy, Cloud Run): the
+proxy negotiates HTTP/2 with the client and forwards h2c upstream to
+cerberus. This is the standard pattern for in-cluster gRPC services
+and needs no cerberus-side configuration.
+
+For direct internet exposure you would need a `tls.Config` on the
+listener (`CERBERUS_TLS_CERT`/`_KEY`) — not currently implemented;
+deploy behind a TLS-terminating proxy or sidecar.
+
 ## Scaling
 
 Cerberus scales horizontally by adding replicas. Because the process is

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.43.0
 	go.opentelemetry.io/proto/otlp v1.10.0
 	go.uber.org/goleak v1.3.0
-	golang.org/x/net v0.54.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/tools v0.45.0
 	google.golang.org/grpc v1.81.1
@@ -298,6 +297,7 @@ require (
 	golang.org/x/crypto v0.51.0 // indirect
 	golang.org/x/exp v0.0.0-20260312153236-7ab1446f8b90 // indirect
 	golang.org/x/mod v0.36.0 // indirect
+	golang.org/x/net v0.54.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sys v0.44.0 // indirect
 	golang.org/x/term v0.43.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go/modules/clickhouse v0.42.0
 	go.opentelemetry.io/contrib/bridges/otelslog v0.18.0
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.68.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.19.0
@@ -23,14 +24,15 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0
 	go.opentelemetry.io/otel/log v0.19.0
+	go.opentelemetry.io/otel/log/logtest v0.19.0
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/log v0.19.0
-	go.opentelemetry.io/otel/sdk/log/logtest v0.19.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
 	go.opentelemetry.io/proto/otlp v1.10.0
 	go.uber.org/goleak v1.3.0
+	golang.org/x/net v0.54.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/tools v0.45.0
 	google.golang.org/grpc v1.81.1
@@ -275,7 +277,6 @@ require (
 	go.opentelemetry.io/collector/processor v1.57.0 // indirect
 	go.opentelemetry.io/contrib/bridges/prometheus v0.68.0 // indirect
 	go.opentelemetry.io/contrib/exporters/autoexport v0.68.0 // indirect
-	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.68.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.68.0 // indirect
 	go.opentelemetry.io/contrib/propagators/jaeger v1.43.0 // indirect
 	go.opentelemetry.io/contrib/samplers/jaegerremote v0.36.0 // indirect
@@ -287,7 +288,6 @@ require (
 	go.opentelemetry.io/otel/exporters/stdout/stdoutlog v0.19.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.43.0 // indirect
-	go.opentelemetry.io/otel/log/logtest v0.19.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.28.0 // indirect
@@ -298,7 +298,6 @@ require (
 	golang.org/x/crypto v0.51.0 // indirect
 	golang.org/x/exp v0.0.0-20260312153236-7ab1446f8b90 // indirect
 	golang.org/x/mod v0.36.0 // indirect
-	golang.org/x/net v0.54.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sys v0.44.0 // indirect
 	golang.org/x/term v0.43.0 // indirect

--- a/internal/api/admit/admit.go
+++ b/internal/api/admit/admit.go
@@ -1,15 +1,17 @@
 // Package admit provides per-handler concurrency caps for cerberus's
-// HTTP listener. Each cerberus replica accepts unlimited inbound
-// requests by default; under sustained load that fans out into
+// HTTP and gRPC listeners. Each cerberus replica accepts unlimited
+// inbound requests by default; under sustained load that fans out into
 // hundreds of slow ClickHouse queries running in parallel, which
 // exhausts CH's thread pool and drags every concurrent request's
 // latency down with the saturated ones.
 //
 // A Limiter caps the number of in-flight handler invocations for a
 // given API head (Prom / Loki / Tempo). When a new request arrives at
-// the cap, the limiter rejects it immediately with HTTP 503 and a
-// `Retry-After: 1` header so well-behaved clients back off and retry
-// — fail-fast on the slow few rather than degrading service for
+// the cap, the limiter rejects it immediately — HTTP 503 with a
+// `Retry-After: 1` header for HTTP callers (Middleware), gRPC
+// `codes.ResourceExhausted` for streaming RPC callers
+// (StreamInterceptor) — so well-behaved clients back off and retry,
+// failing fast on the slow few rather than degrading service for
 // everyone.
 //
 // The limiter is opt-out (`CERBERUS_ADMIT_DISABLED=true`) for local /
@@ -27,6 +29,9 @@ import (
 	"go.opentelemetry.io/otel/metric"
 
 	"golang.org/x/sync/semaphore"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // meterName is the instrumentation-scope identifier stamped on the
@@ -163,4 +168,33 @@ func (l *Limiter) Head() string {
 		return ""
 	}
 	return l.head
+}
+
+// StreamInterceptor returns a grpc.StreamServerInterceptor that
+// enforces the same admission cap as Middleware does for HTTP. On a
+// saturated limiter the interceptor short-circuits with
+// `codes.ResourceExhausted`; the gRPC equivalent of the HTTP 503 +
+// `Retry-After: 1` pair the Middleware writes. The status code is the
+// canonical signal for "back off and retry" in gRPC clients (Grafana's
+// Go gRPC client honours it via the standard retry policy).
+//
+// A nil *Limiter returns a pass-through interceptor — symmetrical with
+// Middleware so the `CERBERUS_ADMIT_DISABLED=true` path stays
+// allocation-free. The interceptor uses the stream's context for the
+// rejection counter attribution so the per-RPC trace context flows
+// into the recorded metric.
+func (l *Limiter) StreamInterceptor() grpc.StreamServerInterceptor {
+	if l == nil {
+		return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+			return handler(srv, ss)
+		}
+	}
+	return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		release, ok := l.Acquire(ss.Context())
+		if !ok {
+			return status.Errorf(codes.ResourceExhausted, "admission control: server saturated")
+		}
+		defer release()
+		return handler(srv, ss)
+	}
 }

--- a/internal/api/admit/admit_test.go
+++ b/internal/api/admit/admit_test.go
@@ -1,6 +1,7 @@
 package admit_test
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -10,6 +11,9 @@ import (
 
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/tsouza/cerberus/internal/api/admit"
 )
@@ -282,5 +286,116 @@ func TestRejectedCounter(t *testing.T) {
 	}
 	if sum != 2 {
 		t.Fatalf("rejected_total: want 2, got %d", sum)
+	}
+}
+
+// fakeServerStream is the minimal grpc.ServerStream stub the
+// StreamInterceptor tests need to drive the interceptor through its
+// Acquire/Release/Reject paths without standing up a real gRPC
+// transport. Only Context() is consulted by the interceptor.
+type fakeServerStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (f *fakeServerStream) Context() context.Context { return f.ctx }
+
+func TestStreamInterceptorBelowCap(t *testing.T) {
+	t.Parallel()
+	l := admit.New("tempo", 2)
+	var hits atomic.Int32
+	interceptor := l.StreamInterceptor()
+	handler := func(srv any, ss grpc.ServerStream) error {
+		hits.Add(1)
+		return nil
+	}
+	for range 5 {
+		stream := &fakeServerStream{ctx: t.Context()}
+		if err := interceptor(nil, stream, &grpc.StreamServerInfo{}, handler); err != nil {
+			t.Fatalf("interceptor: %v", err)
+		}
+	}
+	if hits.Load() != 5 {
+		t.Fatalf("want 5 handler hits, got %d", hits.Load())
+	}
+}
+
+func TestStreamInterceptorRejectsAtCap(t *testing.T) {
+	t.Parallel()
+	l := admit.New("tempo", 1)
+	// Hold the slot so the next request through the interceptor hits
+	// the cap.
+	rel, ok := l.Acquire(t.Context())
+	if !ok {
+		t.Fatalf("setup acquire: want ok")
+	}
+	defer rel()
+
+	interceptor := l.StreamInterceptor()
+	handler := func(srv any, ss grpc.ServerStream) error {
+		t.Fatalf("handler must not run when limiter is full")
+		return nil
+	}
+	stream := &fakeServerStream{ctx: t.Context()}
+	err := interceptor(nil, stream, &grpc.StreamServerInfo{}, handler)
+	if err == nil {
+		t.Fatalf("want ResourceExhausted, got nil")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("want grpc status, got %v", err)
+	}
+	if st.Code() != codes.ResourceExhausted {
+		t.Fatalf("code: want ResourceExhausted, got %s", st.Code())
+	}
+}
+
+func TestStreamInterceptorNilLimiterPassesThrough(t *testing.T) {
+	t.Parallel()
+	var l *admit.Limiter
+	var hits atomic.Int32
+	interceptor := l.StreamInterceptor()
+	handler := func(srv any, ss grpc.ServerStream) error {
+		hits.Add(1)
+		return nil
+	}
+	for range 10 {
+		stream := &fakeServerStream{ctx: t.Context()}
+		if err := interceptor(nil, stream, &grpc.StreamServerInfo{}, handler); err != nil {
+			t.Fatalf("interceptor: %v", err)
+		}
+	}
+	if hits.Load() != 10 {
+		t.Fatalf("want 10 hits, got %d", hits.Load())
+	}
+}
+
+func TestStreamInterceptorReleasesOnHandlerError(t *testing.T) {
+	t.Parallel()
+	// A handler error must still release the slot so subsequent
+	// requests can acquire. Mirrors the HTTP Middleware's defer-release
+	// guarantee.
+	l := admit.New("tempo", 1)
+	interceptor := l.StreamInterceptor()
+	wantErr := status.Error(codes.Internal, "boom")
+	handler := func(srv any, ss grpc.ServerStream) error {
+		return wantErr
+	}
+	stream := &fakeServerStream{ctx: t.Context()}
+	if err := interceptor(nil, stream, &grpc.StreamServerInfo{}, handler); err != wantErr {
+		t.Fatalf("want handler error pass-through, got %v", err)
+	}
+	// Slot must have been released — second call still succeeds.
+	hit := false
+	handler2 := func(srv any, ss grpc.ServerStream) error {
+		hit = true
+		return nil
+	}
+	stream2 := &fakeServerStream{ctx: t.Context()}
+	if err := interceptor(nil, stream2, &grpc.StreamServerInfo{}, handler2); err != nil {
+		t.Fatalf("second call: want ok, got %v", err)
+	}
+	if !hit {
+		t.Fatalf("handler2 did not run — slot was not released after error")
 	}
 }

--- a/internal/api/tempo/grpc/server.go
+++ b/internal/api/tempo/grpc/server.go
@@ -1,0 +1,38 @@
+package grpc
+
+import (
+	"github.com/grafana/tempo/pkg/tempopb"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"google.golang.org/grpc"
+)
+
+// NewServer builds the gRPC server that hosts cerberus's Tempo
+// StreamingQuerier service. The returned *grpc.Server is ready to be
+// passed to an h2c-wrapped HTTP listener (see cmd/cerberus/main.go) so
+// gRPC and HTTP share one TCP port.
+//
+// The server is preconfigured with two cross-cutting hooks:
+//
+//   - otelgrpc.NewServerHandler() as the stats handler — every RPC
+//     becomes an OTel server span on the same TracerProvider the HTTP
+//     handlers use, and gets the standard set of gRPC metrics
+//     (`rpc.server.duration`, `rpc.server.request.size`, etc.).
+//   - service.Limiter.StreamInterceptor() as the stream interceptor —
+//     per-RPC admission control sharing the same per-head semaphore
+//     the HTTP handlers use, so a saturated Tempo head rejects gRPC
+//     and HTTP traffic symmetrically (gRPC sees codes.ResourceExhausted;
+//     HTTP sees 503 + Retry-After).
+//
+// A nil service is a programmer error and panics; the gRPC server
+// requires a registered implementation to dispatch RPCs to.
+func NewServer(service *Service) *grpc.Server {
+	if service == nil {
+		panic("tempo/grpc: NewServer requires a non-nil Service")
+	}
+	srv := grpc.NewServer(
+		grpc.StatsHandler(otelgrpc.NewServerHandler()),
+		grpc.ChainStreamInterceptor(service.Limiter.StreamInterceptor()),
+	)
+	tempopb.RegisterStreamingQuerierServer(srv, service)
+	return srv
+}

--- a/internal/api/tempo/grpc/service.go
+++ b/internal/api/tempo/grpc/service.go
@@ -1,0 +1,87 @@
+// Package grpc implements cerberus's Tempo StreamingQuerier gRPC
+// service — the streaming sibling of the existing
+// internal/api/tempo HTTP handler. Grafana's Tempo datasource opens a
+// long-lived gRPC stream against cerberus when the user enables the
+// "Streaming" toggle, then accumulates frames as incremental progress;
+// the same TraceQL/metrics queries the HTTP handler answers eagerly
+// stream incrementally over this surface.
+//
+// Wire-format generated stubs live in github.com/grafana/tempo/pkg/
+// tempopb (routed through the tsouza/tempo:cerberus-accessors fork —
+// see go.mod). This package only depends on the generated server
+// interface + the cerberus query pipeline (Engine, schema, admit
+// limiter); no protoc plumbing is needed in tree.
+//
+// This file ships the SCAFFOLD slice of the Tempo gRPC rollout (PR 1
+// of a 4-PR sequence; see .claude/plans/tempo-grpc-streaming-design.md
+// §6). All seven RPCs are advertised but every method returns
+// codes.Unimplemented via the embedded UnimplementedStreamingQuerierServer.
+// PR 2 fills in Search, PR 3 fills in the tag-list RPCs, PR 4 fills in
+// the metrics RPCs. The scaffold is shippable on its own — Grafana's
+// streaming-on toggle falls back to HTTP cleanly when the gRPC client
+// receives Unimplemented, so the rollout can land incrementally without
+// breaking the datasource.
+package grpc
+
+import (
+	"log/slog"
+
+	"github.com/grafana/tempo/pkg/tempopb"
+
+	"github.com/tsouza/cerberus/internal/api/admit"
+	"github.com/tsouza/cerberus/internal/api/tempo"
+)
+
+// Service is the cerberus implementation of tempopb.StreamingQuerierServer.
+// It embeds tempopb.UnimplementedStreamingQuerierServer so every RPC
+// returns codes.Unimplemented by default — PRs 2/3/4 override
+// individual methods to forward to the cerberus query pipeline.
+//
+// Service holds references to the HTTP-side Handler (for the shared
+// Engine + schema + lang) and the per-head admit Limiter, but adds no
+// caching or per-request state of its own. Goroutine-safe by
+// construction: every field is read-only after construction.
+type Service struct {
+	tempopb.UnimplementedStreamingQuerierServer
+
+	// Handler is the existing Tempo HTTP handler; its Engine,
+	// Schema, and lang fields are the source of truth for the
+	// query pipeline. Real RPC implementations (added in PR 2-4)
+	// reuse the same parse + lower + emit + execute path the HTTP
+	// handlers use, then marshal results into tempopb response
+	// messages instead of cerberus's JSON envelope.
+	Handler *tempo.Handler
+
+	// Limiter is the per-head admission-control limiter — the same
+	// one wired into Handler.Limiter for the HTTP surface. The
+	// gRPC server wires it via StreamInterceptor at construction
+	// time; this field is kept as a back-reference so per-RPC code
+	// paths added in later PRs (custom Acquire/weighted slots)
+	// have access to it without re-plumbing.
+	Limiter *admit.Limiter
+
+	// Logger fans out to stderr + the OTLP slog bridge; carries
+	// the `api=tempo-grpc` attribute so dashboards can split gRPC
+	// log volume from HTTP.
+	Logger *slog.Logger
+}
+
+// NewService constructs a Service wired to the given Tempo HTTP
+// Handler. The Service shares the Handler's Engine + schema so the
+// HTTP and gRPC surfaces produce identical query results for the same
+// TraceQL input — gRPC is purely a wire-format alternative, not a
+// behavioural fork.
+//
+// limiter and logger may be nil — a nil limiter falls through to
+// pass-through (admission control disabled), and a nil logger is
+// replaced with slog.Default() so the Service is always safe to call.
+func NewService(handler *tempo.Handler, limiter *admit.Limiter, logger *slog.Logger) *Service {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Service{
+		Handler: handler,
+		Limiter: limiter,
+		Logger:  logger,
+	}
+}

--- a/internal/api/tempo/grpc/service_unimplemented_test.go
+++ b/internal/api/tempo/grpc/service_unimplemented_test.go
@@ -1,0 +1,204 @@
+package grpc_test
+
+import (
+	"context"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/grafana/tempo/pkg/tempopb"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	tempogrpc "github.com/tsouza/cerberus/internal/api/tempo/grpc"
+)
+
+// TestUnimplemented_AllRPCsReturnUnimplemented is the proof-of-life
+// for the PR 1 scaffold slice: every one of the seven StreamingQuerier
+// RPCs must dial, the gRPC handshake must complete, and the server
+// must answer codes.Unimplemented. PRs 2-4 swap the
+// UnimplementedStreamingQuerierServer embedded methods out one by one;
+// when they do, the matching subtest below moves out of this file and
+// into the per-RPC suite.
+//
+// The test uses bufconn (the standard in-memory gRPC transport) so it
+// doesn't need a real network listener and stays hermetic — no port
+// binding, no h2c upgrade dance, no goroutine leaks across parallel
+// test packages.
+func TestUnimplemented_AllRPCsReturnUnimplemented(t *testing.T) {
+	t.Parallel()
+
+	lis := bufconn.Listen(1 << 20)
+	srv := tempogrpc.NewServer(tempogrpc.NewService(nil, nil, nil))
+	go func() {
+		if err := srv.Serve(lis); err != nil {
+			// Serve returns ErrServerStopped on GracefulStop; that's
+			// the normal shutdown path and doesn't need to fail the
+			// test.
+			t.Logf("grpc Serve returned: %v", err)
+		}
+	}()
+	t.Cleanup(srv.GracefulStop)
+
+	dialer := func(ctx context.Context, _ string) (net.Conn, error) {
+		return lis.DialContext(ctx)
+	}
+	conn, err := grpc.NewClient(
+		"passthrough://bufnet",
+		grpc.WithContextDialer(dialer),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("grpc dial bufnet: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	client := tempopb.NewStreamingQuerierClient(conn)
+
+	// drainErr consumes a stream until EOF and returns the first non-EOF
+	// error. The Unimplemented status arrives on the first Recv from a
+	// server-streaming RPC even though the RPC opens "successfully" at
+	// the transport layer.
+	drainErr := func(t *testing.T, stream interface{ RecvMsg(m any) error }) error {
+		t.Helper()
+		for {
+			var msg any
+			if err := stream.RecvMsg(&msg); err != nil {
+				if err == io.EOF {
+					return nil
+				}
+				return err
+			}
+		}
+	}
+
+	assertUnimplemented := func(t *testing.T, name string, err error) {
+		t.Helper()
+		if err == nil {
+			t.Fatalf("%s: want Unimplemented, got nil", name)
+		}
+		st, ok := status.FromError(err)
+		if !ok {
+			t.Fatalf("%s: want grpc status, got %v", name, err)
+		}
+		if st.Code() != codes.Unimplemented {
+			t.Fatalf("%s: want code Unimplemented, got %s", name, st.Code())
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	t.Run("Search", func(t *testing.T) {
+		stream, err := client.Search(ctx, &tempopb.SearchRequest{Query: "{}"})
+		if err != nil {
+			t.Fatalf("open stream: %v", err)
+		}
+		assertUnimplemented(t, "Search", drainErr(t, stream))
+	})
+
+	t.Run("SearchTags", func(t *testing.T) {
+		stream, err := client.SearchTags(ctx, &tempopb.SearchTagsRequest{})
+		if err != nil {
+			t.Fatalf("open stream: %v", err)
+		}
+		assertUnimplemented(t, "SearchTags", drainErr(t, stream))
+	})
+
+	t.Run("SearchTagsV2", func(t *testing.T) {
+		stream, err := client.SearchTagsV2(ctx, &tempopb.SearchTagsRequest{})
+		if err != nil {
+			t.Fatalf("open stream: %v", err)
+		}
+		assertUnimplemented(t, "SearchTagsV2", drainErr(t, stream))
+	})
+
+	t.Run("SearchTagValues", func(t *testing.T) {
+		stream, err := client.SearchTagValues(ctx, &tempopb.SearchTagValuesRequest{TagName: "service.name"})
+		if err != nil {
+			t.Fatalf("open stream: %v", err)
+		}
+		assertUnimplemented(t, "SearchTagValues", drainErr(t, stream))
+	})
+
+	t.Run("SearchTagValuesV2", func(t *testing.T) {
+		stream, err := client.SearchTagValuesV2(ctx, &tempopb.SearchTagValuesRequest{TagName: "service.name"})
+		if err != nil {
+			t.Fatalf("open stream: %v", err)
+		}
+		assertUnimplemented(t, "SearchTagValuesV2", drainErr(t, stream))
+	})
+
+	t.Run("MetricsQueryRange", func(t *testing.T) {
+		stream, err := client.MetricsQueryRange(ctx, &tempopb.QueryRangeRequest{Query: "{} | rate()"})
+		if err != nil {
+			t.Fatalf("open stream: %v", err)
+		}
+		assertUnimplemented(t, "MetricsQueryRange", drainErr(t, stream))
+	})
+
+	t.Run("MetricsQueryInstant", func(t *testing.T) {
+		stream, err := client.MetricsQueryInstant(ctx, &tempopb.QueryInstantRequest{Query: "{} | rate()"})
+		if err != nil {
+			t.Fatalf("open stream: %v", err)
+		}
+		assertUnimplemented(t, "MetricsQueryInstant", drainErr(t, stream))
+	})
+}
+
+// TestServer_AdmitDisabledPath confirms NewServer with a Service whose
+// Limiter is nil still constructs and serves — the gRPC equivalent of
+// the CERBERUS_ADMIT_DISABLED=true path. Stream interceptor goes
+// through admit.StreamInterceptor's nil-receiver pass-through branch.
+func TestServer_AdmitDisabledPath(t *testing.T) {
+	t.Parallel()
+
+	lis := bufconn.Listen(1 << 20)
+	srv := tempogrpc.NewServer(tempogrpc.NewService(nil, nil, nil))
+	go func() {
+		if err := srv.Serve(lis); err != nil {
+			t.Logf("grpc Serve returned: %v", err)
+		}
+	}()
+	t.Cleanup(srv.GracefulStop)
+
+	dialer := func(ctx context.Context, _ string) (net.Conn, error) {
+		return lis.DialContext(ctx)
+	}
+	conn, err := grpc.NewClient(
+		"passthrough://bufnet",
+		grpc.WithContextDialer(dialer),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("grpc dial bufnet: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	// One sanity check is enough — the Unimplemented matrix is
+	// covered above; this test exists only to pin that the nil-Limiter
+	// construction path works end-to-end.
+	client := tempopb.NewStreamingQuerierClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	stream, err := client.Search(ctx, &tempopb.SearchRequest{Query: "{}"})
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
+	var msg any
+	err = stream.RecvMsg(&msg)
+	if err == nil {
+		t.Fatalf("want Unimplemented error, got nil")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("want grpc status, got %v", err)
+	}
+	if st.Code() != codes.Unimplemented {
+		t.Fatalf("code: want Unimplemented, got %s", st.Code())
+	}
+}


### PR DESCRIPTION
## Summary

PR 1 of the Tempo gRPC StreamingQuerier rollout (full design at `.claude/plans/tempo-grpc-streaming-design.md` — §1, §2, §6, §7).

This is the **scaffold** slice: the gRPC surface is advertised on the existing `:8080` socket via h2c, but every RPC returns `codes.Unimplemented` via the embedded `tempopb.UnimplementedStreamingQuerierServer`. PRs 2/3/4 fill in real handlers one RPC group at a time:

- **PR 2** — `Search` impl + frame batching + 1 Playwright spec.
- **PR 3** — `SearchTags` + `SearchTagsV2` + `SearchTagValues` + `SearchTagValuesV2` (single-frame).
- **PR 4** — `MetricsQueryRange` (streaming chunks + final-frame exemplars) + `MetricsQueryInstant`.

## What this PR ships

- **h2c on the same socket.** `cmd/cerberus/main.go` wraps `rootMux` in `h2c.NewHandler` + a content-type dispatcher (`application/grpc` → `*grpc.Server`, else → `rootMux`). One port, one Service, one ingress rule — matches Grafana's Tempo datasource which expects HTTP and gRPC on the same host:port. cmux + separate listener rejected in §1 of the design report.
- **`internal/api/tempo/grpc/` package.** `service.go` embeds `tempopb.UnimplementedStreamingQuerierServer` so all 7 RPCs return `codes.Unimplemented` by default; `server.go` builds the `*grpc.Server` with `otelgrpc.NewServerHandler()` stats handler + chained admit `StreamInterceptor`. Conformance test dials the bufconn transport and asserts each RPC returns Unimplemented.
- **`admit.Limiter.StreamInterceptor()` sibling** of the existing HTTP `Middleware`. Saturated limiter returns `codes.ResourceExhausted` (gRPC analogue of the HTTP 503 + `Retry-After: 1`). Nil limiter falls through (admit-disabled symmetry). Four tests: below-cap, at-cap rejection, nil pass-through, and slot-release-on-handler-error.
- **`docs/operations.md` — Port binding** section adds an HTTP/2 (h2c) + gRPC subsection covering the three protocol shapes the socket now accepts and the TLS-terminating-proxy deployment story.
- **`go.mod`** — `golang.org/x/net` and `otelgrpc` graduate from indirect to direct.

## Behavioural guarantee

Grafana's "streaming" toggle ON falls back to HTTP cleanly when gRPC returns Unimplemented, so this PR is shippable on its own without any datasource breakage. The h2c wrap is transparent for HTTP/1.1 callers (Loki tail WebSocket, Prom chunked-streaming, `/healthz` / `/readyz` all unaffected — see §7 of the design report).

## Out of scope

- Real RPC bodies — PRs 2-4.
- Compat-harness `--mode=grpc` self-equivalence — PR 5.
- `cerberus.queries.*` counter middleware gRPC sibling — PR 6.

## Test plan

- [x] `go build ./...` clean.
- [x] `go vet ./...` clean.
- [x] `go test -race -count=1 ./internal/api/tempo/grpc/ ./internal/api/admit/` — 34 tests pass (new + existing).
- [x] `go test -race -count=1 ./internal/api/... ./cmd/...` — 733 tests pass (broader regression).
- [x] `gofumpt -w` applied to every changed `.go` file.
- [x] `./cerberus --version` runs cleanly post-build.
- [ ] CI `check` + `lint` jobs green.