### PR TITLE
feat(api/tempo/grpc): implement Search RPC with 20-trace frame batching

### DIFF
--- a/internal/api/tempo/grpc/search.go
+++ b/internal/api/tempo/grpc/search.go
@@ -79,7 +79,7 @@ func (s *Service) Search(req *tempopb.SearchRequest, stream tempopb.StreamingQue
 	if err != nil {
 		return mapEngineError(err)
 	}
-	defer res.Cursor.Close()
+	defer func() { _ = res.Cursor.Close() }()
 
 	// Drain the cursor into a samples slice. The toTraceSummaries
 	// shaper requires the full result set to group spans by TraceID;
@@ -136,6 +136,7 @@ func (s *Service) Search(req *tempopb.SearchRequest, stream tempopb.StreamingQue
 	if err := stream.Send(&tempopb.SearchResponse{
 		Traces: tail,
 		Metrics: &tempopb.SearchMetrics{
+			//nolint:gosec // search result count is bounded by CH row LIMIT; overflow would require > 4B summaries which the engine can't materialise.
 			InspectedTraces: uint32(len(summaries)),
 		},
 	}); err != nil {
@@ -198,7 +199,8 @@ func toTempopbTraceMetadata(t tempo.TraceSummary) *tempopb.TraceSearchMetadata {
 		RootServiceName:   t.RootServiceName,
 		RootTraceName:     t.RootTraceName,
 		StartTimeUnixNano: startNs,
-		DurationMs:        uint32(t.DurationMs),
+		//nolint:gosec // DurationMs is sourced from a TraceSummary populated by dateDiff(ms, …) over CH spans; field tops out at int32 in practice — uint32 cannot overflow.
+		DurationMs: uint32(t.DurationMs),
 	}
 }
 

--- a/internal/api/tempo/grpc/search.go
+++ b/internal/api/tempo/grpc/search.go
@@ -1,0 +1,270 @@
+package grpc
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/grafana/tempo/pkg/tempopb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/tsouza/cerberus/internal/api/tempo"
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+// searchFrameSize caps the number of TraceSearchMetadata entries
+// cerberus packs into one tempopb.SearchResponse before flushing it
+// down the gRPC stream. Sized to amortise the per-Send framing
+// overhead (~30B/Send on HTTP/2) without overshooting the default
+// per-stream HTTP/2 window (64 KiB) — 20 trace summaries at ~1 KB each
+// land at ~20 KB per frame, comfortably under the window. The exact
+// value isn't load-bearing; the design-doc §4 picks 20 as the search-
+// path counterpart to MetricsQueryRange's 50-series-per-frame.
+const searchFrameSize = 20
+
+// Search implements the streaming /search gRPC RPC. It mirrors the
+// HTTP /api/search handler byte-for-byte on the wire-format side
+// (same TraceQL → chplan → CH-row → toTraceSummaries pipeline) and
+// only diverges on the response envelope: instead of one JSON body
+// with all trace summaries, cerberus emits one or more
+// tempopb.SearchResponse frames, each carrying up to searchFrameSize
+// summaries. The final frame stamps SearchMetrics.InspectedTraces with
+// the total trace count so Grafana's Tempo datasource has the same
+// aggregate the HTTP path returns.
+//
+// This method shadows the embedded
+// tempopb.UnimplementedStreamingQuerierServer.Search promoted via
+// Service — Go's method-shadowing rules dispatch here while the other
+// six RPCs continue to return codes.Unimplemented until PRs 3 + 4
+// land. See .claude/plans/tempo-grpc-streaming-design.md §3 (Search row)
+// + §4 (frame mapping) for the cross-RPC strategy.
+//
+// Error mapping (matches the design-doc table):
+//   - TraceQL parser error / lowering error → codes.InvalidArgument
+//     (errors.Is against tempo.ErrParseStage / tempo.ErrLowerStage).
+//   - chclient circuit-open → codes.Unavailable.
+//   - any other engine/CH error → codes.Internal.
+//
+// The admit limiter is enforced upstream by the stream interceptor
+// wired in NewServer (see server.go); a saturated head short-circuits
+// with codes.ResourceExhausted before Search is invoked, mirroring the
+// HTTP 503 + Retry-After: 1 path.
+func (s *Service) Search(req *tempopb.SearchRequest, stream tempopb.StreamingQuerier_SearchServer) error {
+	if s.Handler == nil {
+		return status.Errorf(codes.Internal, "tempo gRPC: handler not wired")
+	}
+	if req == nil {
+		return status.Errorf(codes.InvalidArgument, "tempo gRPC: nil SearchRequest")
+	}
+	if req.Query == "" {
+		// HTTP /api/search returns an empty result set on empty Query
+		// (Grafana sometimes pings without a query as a health-check);
+		// mirror that by emitting one empty frame with zero metrics
+		// rather than InvalidArgument so the streaming health-check
+		// stays equivalent to the HTTP one.
+		return stream.Send(&tempopb.SearchResponse{
+			Traces:  []*tempopb.TraceSearchMetadata{},
+			Metrics: &tempopb.SearchMetrics{InspectedTraces: 0},
+		})
+	}
+
+	ctx := stream.Context()
+
+	// Open the streaming cursor against the lowered TraceQL plan.
+	// cursor.Close is deferred so a client cancellation (ctx.Done()
+	// fires through QueryCursor's progress-context) propagates into
+	// the CH driver — same pattern as Loki's /tail and Prom's
+	// /query_range chunked path.
+	res, err := s.Handler.Engine.QueryCursor(ctx, s.Handler.Lang(), req.Query)
+	if err != nil {
+		return mapEngineError(err)
+	}
+	defer res.Cursor.Close()
+
+	// Drain the cursor into a samples slice. The toTraceSummaries
+	// shaper requires the full result set to group spans by TraceID;
+	// the gRPC frame batching kicks in on the post-shaped summary
+	// list (so frames carry whole-trace summaries, not partial spans).
+	// Cancellation through ctx surfaces as cursor.Next returning false
+	// + cursor.Err returning the wrapped context error.
+	samples := make([]chclient.Sample, 0, 64)
+	for res.Cursor.Next() {
+		samples = append(samples, res.Cursor.Sample())
+		// Honour context cancellation between rows so a client
+		// disconnect mid-drain doesn't block on CH back-pressure.
+		if err := ctx.Err(); err != nil {
+			return status.FromContextError(err).Err()
+		}
+	}
+	if err := res.Cursor.Err(); err != nil {
+		return mapEngineError(err)
+	}
+
+	summaries, missingRoots := tempo.ToTraceSummaries(samples)
+	if len(missingRoots) > 0 {
+		// Same best-effort policy the HTTP handler uses: log + ignore
+		// a follow-up lookup failure (the earliest-span fallback in
+		// summaries stays in place). Errors here are NOT surfaced to
+		// the client — a downgraded summary is preferable to a hard
+		// 5xx when the primary query already succeeded.
+		if err := s.Handler.ResolveMissingRoots(ctx, summaries, missingRoots); err != nil {
+			s.Logger.Warn("tempo gRPC root-span lookup failed",
+				"err", err, "missing", len(missingRoots))
+		}
+	}
+
+	// Frame-batch the summaries into searchFrameSize-sized chunks.
+	// The tail frame carries SearchMetrics so Grafana sees the
+	// aggregate exactly once at end-of-stream — mirroring how the
+	// HTTP /api/search response embeds Metrics alongside the (single)
+	// traces array.
+	flusher := newSearchFlusher(searchFrameSize)
+	for i := range summaries {
+		shard, ready := flusher.Push(toTempopbTraceMetadata(summaries[i]))
+		if !ready {
+			continue
+		}
+		if err := stream.Send(&tempopb.SearchResponse{Traces: shard}); err != nil {
+			return mapStreamError(err)
+		}
+	}
+	tail := flusher.Tail()
+	// Always emit a tail frame, even when summaries is empty or the
+	// final shard would be empty — Grafana parses SearchMetrics from
+	// the tail and an empty trailer keeps the wire envelope round-
+	// tripable through the streaming/HTTP equivalence check.
+	if err := stream.Send(&tempopb.SearchResponse{
+		Traces: tail,
+		Metrics: &tempopb.SearchMetrics{
+			InspectedTraces: uint32(len(summaries)),
+		},
+	}); err != nil {
+		return mapStreamError(err)
+	}
+	return nil
+}
+
+// mapEngineError converts an engine.Query / Engine.QueryCursor error
+// into the gRPC status the Search RPC returns. Mirrors
+// classifySearchErr's HTTP-status mapping in handler.go: parse + lower
+// stages → codes.InvalidArgument (user-facing query errors);
+// chclient circuit-open → codes.Unavailable; anything else → codes.Internal.
+func mapEngineError(err error) error {
+	if err == nil {
+		return nil
+	}
+	switch {
+	case errors.Is(err, chclient.ErrCircuitOpen):
+		return status.Errorf(codes.Unavailable, "%v", err)
+	case errors.Is(err, tempo.ErrParseStage), errors.Is(err, tempo.ErrLowerStage):
+		return status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	return status.Errorf(codes.Internal, "%v", err)
+}
+
+// mapStreamError converts a stream.Send error into the appropriate
+// gRPC status. Send fails most often because the client cancelled
+// (ctx.Err()) or the transport dropped; we keep the underlying status
+// when it's already a gRPC one (the gRPC runtime usually returns
+// status-wrapped errors here) and otherwise surface codes.Internal.
+func mapStreamError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if _, ok := status.FromError(err); ok {
+		return err
+	}
+	return status.Errorf(codes.Internal, "stream send: %v", err)
+}
+
+// toTempopbTraceMetadata pivots cerberus's local tempo.TraceSummary
+// into the wire-format tempopb.TraceSearchMetadata Grafana's Tempo
+// datasource consumes over gRPC. Field-for-field equivalence with the
+// HTTP /api/search JSON envelope (see tempo.TraceSummary) so a search
+// query through the streaming path produces the same trace identity +
+// timestamps + duration the HTTP path returns. The startTimeUnixNano
+// field switches from JSON-string (HTTP) to uint64 (proto); we parse
+// the string back into the integer the proto field expects, falling
+// back to 0 when the conversion fails (defensive — TraceSummary
+// populates the field via strconv.FormatInt of a UnixNano result that
+// always round-trips).
+func toTempopbTraceMetadata(t tempo.TraceSummary) *tempopb.TraceSearchMetadata {
+	var startNs uint64
+	if v, err := strconv.ParseUint(t.StartTimeUnixNano, 10, 64); err == nil {
+		startNs = v
+	}
+	return &tempopb.TraceSearchMetadata{
+		TraceID:           t.TraceID,
+		RootServiceName:   t.RootServiceName,
+		RootTraceName:     t.RootTraceName,
+		StartTimeUnixNano: startNs,
+		DurationMs:        uint32(t.DurationMs),
+	}
+}
+
+// searchFlusher batches TraceSearchMetadata entries into shards of a
+// fixed size + tracks the running total so the tail-frame Metrics
+// block can stamp the inspected-trace aggregate exactly once.
+//
+// Lifecycle:
+//   - Push(m) appends m to the current shard. When the shard reaches
+//     `size`, Push returns (shard, true) and resets the internal
+//     buffer; the caller is expected to flush the returned shard
+//     immediately via stream.Send.
+//   - Tail() returns whatever rows accumulated after the last full
+//     shard (empty when the row count is a clean multiple of size).
+//     Callers always emit the tail with SearchMetrics attached even
+//     when len(Tail())==0, so Grafana parses the aggregate from a
+//     well-defined "last frame" position.
+//
+// The struct is intentionally unexported — only Search.search-shaped
+// code paths in this package consume it. PR 4's MetricsQueryRange
+// sibling has its own series-batching helper with different chunking
+// semantics (per-series chunks, not per-summary).
+type searchFlusher struct {
+	size  int
+	cur   []*tempopb.TraceSearchMetadata
+	total int
+}
+
+// newSearchFlusher returns a flusher that emits a shard every `size`
+// pushes. size MUST be > 0; size <= 0 panics — there's no sensible
+// fallback (a non-batching flusher would defeat the purpose).
+func newSearchFlusher(size int) *searchFlusher {
+	if size <= 0 {
+		panic("tempo/grpc: newSearchFlusher requires size > 0")
+	}
+	return &searchFlusher{
+		size: size,
+		cur:  make([]*tempopb.TraceSearchMetadata, 0, size),
+	}
+}
+
+// Push appends m to the current shard. When the shard fills, returns
+// the now-flushable batch along with `ready=true` and resets the
+// internal buffer for the next shard. When the shard is not yet full,
+// returns (nil, false) — the caller continues feeding.
+func (f *searchFlusher) Push(m *tempopb.TraceSearchMetadata) ([]*tempopb.TraceSearchMetadata, bool) {
+	f.cur = append(f.cur, m)
+	f.total++
+	if len(f.cur) < f.size {
+		return nil, false
+	}
+	shard := f.cur
+	f.cur = make([]*tempopb.TraceSearchMetadata, 0, f.size)
+	return shard, true
+}
+
+// Tail returns whatever rows accumulated after the last full shard.
+// Empty (nil-or-zero-length) when the total push count is a clean
+// multiple of size. Callers stamp SearchMetrics on the tail frame even
+// when Tail returns an empty slice so Grafana receives the aggregate
+// at a well-defined wire position.
+func (f *searchFlusher) Tail() []*tempopb.TraceSearchMetadata {
+	if len(f.cur) == 0 {
+		return nil
+	}
+	out := f.cur
+	f.cur = nil
+	return out
+}

--- a/internal/api/tempo/grpc/search_test.go
+++ b/internal/api/tempo/grpc/search_test.go
@@ -1,0 +1,514 @@
+package grpc_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/grafana/tempo/pkg/tempopb"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/tsouza/cerberus/internal/api/tempo"
+	tempogrpc "github.com/tsouza/cerberus/internal/api/tempo/grpc"
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// stubCursorQuerier is the in-test ClickHouse client cerberus's gRPC
+// Search RPC drives against. It satisfies both engine.Querier
+// (Query) and engine.CursorQuerier (QueryCursor) — the gRPC Search
+// path opens a streaming cursor, then issues an eager Query for the
+// follow-up root-resolution lookup, so the stub has to answer both.
+//
+// rowsByQuery routes the cursor open call by SQL-substring match so
+// the same stub serves both the canonical search-path SQL (the
+// first QueryCursor) and any follow-up Query the resolveTraceRoots
+// path issues (matched via the "argMinIf" needle that appears in the
+// root-lookup SQL).
+type stubCursorQuerier struct {
+	rows []chclient.Sample
+	// rootSamples are returned by the follow-up Query that
+	// resolveTraceRoots fires for traces whose result set lacked a
+	// real root span. Empty / nil here means "no roots to patch",
+	// matching the steady-state happy path.
+	rootSamples []chclient.Sample
+	// closed flips to 1 once the cursor's Close has been invoked.
+	// Tests assert against it to prove that cancellation reached the
+	// streaming cursor.
+	closed atomic.Int32
+}
+
+func (s *stubCursorQuerier) Query(_ context.Context, _ string, _ ...any) ([]chclient.Sample, error) {
+	return s.rootSamples, nil
+}
+
+func (s *stubCursorQuerier) QueryStrings(_ context.Context, _ string, _ ...any) ([]string, error) {
+	return nil, nil
+}
+
+func (s *stubCursorQuerier) QueryCursor(ctx context.Context, _ string, _ ...any) (chclient.Cursor, error) {
+	return &stubCursor{rows: s.rows, ctx: ctx, closed: &s.closed}, nil
+}
+
+// stubCursor walks rowsByQuery one Sample at a time. Honours ctx
+// cancellation so the gRPC Search RPC can prove that a client
+// disconnect mid-stream surfaces as a cursor termination.
+type stubCursor struct {
+	rows   []chclient.Sample
+	i      int
+	cur    chclient.Sample
+	err    error
+	ctx    context.Context
+	closed *atomic.Int32
+}
+
+func (c *stubCursor) Next() bool {
+	// Mid-iteration context cancellation: shortcut Next to surface the
+	// ctx error via Err(). Matches the rowsCursor production shape
+	// where a cancelled driver.Rows reports its cause through Err.
+	if err := c.ctx.Err(); err != nil {
+		c.err = err
+		return false
+	}
+	if c.i >= len(c.rows) {
+		return false
+	}
+	c.cur = c.rows[c.i]
+	c.i++
+	return true
+}
+
+func (c *stubCursor) Sample() chclient.Sample { return c.cur }
+func (c *stubCursor) Err() error              { return c.err }
+func (c *stubCursor) Close() error {
+	c.closed.Store(1)
+	return nil
+}
+
+// makeSearchRow returns one synthetic chclient.Sample shaped like the
+// canonical wrap-projection output: MetricName carries SpanName, the
+// reserved __cerberus_traceID label carries the 32-char hex TraceID,
+// Timestamp carries the span start, Value carries the per-row span
+// duration in ns. Spans are root-anchored (ParentSpanID == "0" — the
+// post-strip form of 0000000000000000) so toTraceSummaries doesn't
+// flag the trace as missing-root.
+func makeSearchRow(traceID, spanName, service string, ts time.Time, durationMs int64) chclient.Sample {
+	return chclient.Sample{
+		MetricName: spanName,
+		Labels: map[string]string{
+			"service.name":               service,
+			"__cerberus_traceID":         traceID,
+			"__cerberus_parentSpanID":    "0",
+			"__cerberus_traceDurationNs": fmt.Sprintf("%d", durationMs*1_000_000),
+		},
+		Timestamp: ts,
+		Value:     float64(durationMs * 1_000_000),
+	}
+}
+
+// padHexTraceID returns a 32-char hex string of the form NNN... so each
+// synthetic trace gets a unique stable TraceID without re-implementing
+// hex encoding semantics in the test.
+func padHexTraceID(i int) string {
+	return fmt.Sprintf("%032x", i+1)
+}
+
+// dialServer wires a Service to a bufconn listener and returns the
+// dialled tempopb.StreamingQuerierClient + a cleanup func. Used by
+// the Search RPC tests to keep the boilerplate per-case overhead low.
+func dialServer(t *testing.T, q *stubCursorQuerier) (tempopb.StreamingQuerierClient, func()) {
+	t.Helper()
+	handler := tempo.New(q, schema.DefaultOTelTraces(), "test", nil)
+	svc := tempogrpc.NewService(handler, nil, nil)
+	srv := tempogrpc.NewServer(svc)
+	lis := bufconn.Listen(1 << 20)
+	go func() {
+		if err := srv.Serve(lis); err != nil {
+			t.Logf("grpc Serve returned: %v", err)
+		}
+	}()
+	dialer := func(ctx context.Context, _ string) (net.Conn, error) {
+		return lis.DialContext(ctx)
+	}
+	conn, err := grpc.NewClient(
+		"passthrough://bufnet",
+		grpc.WithContextDialer(dialer),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("grpc dial bufnet: %v", err)
+	}
+	return tempopb.NewStreamingQuerierClient(conn), func() {
+		_ = conn.Close()
+		srv.GracefulStop()
+	}
+}
+
+// drainSearch consumes the streaming response and returns the
+// collected frames in arrival order. Stops at io.EOF (clean end of
+// stream); any other RecvMsg error is returned as-is so callers can
+// assert on it.
+func drainSearch(t *testing.T, stream tempopb.StreamingQuerier_SearchClient) ([]*tempopb.SearchResponse, error) {
+	t.Helper()
+	var frames []*tempopb.SearchResponse
+	for {
+		f, err := stream.Recv()
+		if err == io.EOF {
+			return frames, nil
+		}
+		if err != nil {
+			return frames, err
+		}
+		frames = append(frames, f)
+	}
+}
+
+// TestSearch_FrameBatching feeds 45 synthetic traces through the gRPC
+// Search RPC and asserts the wire-level frame layout: 2 full shards
+// of 20 traces each + 1 tail shard with the remaining 5, where the
+// tail carries the SearchMetrics with InspectedTraces = 45.
+//
+// 45 = 2*searchFrameSize + 5 is picked so the test exercises both the
+// "shard fills exactly" path (Push returns ready=true) and the "tail
+// rolls over" path (Tail returns the partial buffer). Frame count =
+// ceil(45/20) = 3 — the design-doc §4 contract.
+func TestSearch_FrameBatching(t *testing.T) {
+	t.Parallel()
+
+	const total = 45
+	rows := make([]chclient.Sample, 0, total)
+	ts := time.Date(2026, 5, 19, 0, 0, 0, 0, time.UTC)
+	for i := 0; i < total; i++ {
+		rows = append(rows, makeSearchRow(
+			padHexTraceID(i), "GET /api", "svc",
+			ts.Add(time.Duration(i)*time.Millisecond), 10,
+		))
+	}
+	q := &stubCursorQuerier{rows: rows}
+	client, cleanup := dialServer(t, q)
+	t.Cleanup(cleanup)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	stream, err := client.Search(ctx, &tempopb.SearchRequest{Query: "{}"})
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
+	frames, err := drainSearch(t, stream)
+	if err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+
+	// Expected: 3 frames total — two full 20-trace shards + a 5-trace
+	// tail that also carries SearchMetrics.
+	if got, want := len(frames), 3; got != want {
+		t.Fatalf("frame count: got %d, want %d", got, want)
+	}
+	if got := len(frames[0].Traces); got != 20 {
+		t.Errorf("frame[0] traces: got %d, want 20", got)
+	}
+	if got := len(frames[1].Traces); got != 20 {
+		t.Errorf("frame[1] traces: got %d, want 20", got)
+	}
+	if got := len(frames[2].Traces); got != 5 {
+		t.Errorf("frame[2] (tail) traces: got %d, want 5", got)
+	}
+	// Metrics live on the tail frame exclusively.
+	if frames[0].Metrics != nil {
+		t.Errorf("frame[0] metrics: want nil, got %+v", frames[0].Metrics)
+	}
+	if frames[1].Metrics != nil {
+		t.Errorf("frame[1] metrics: want nil, got %+v", frames[1].Metrics)
+	}
+	if frames[2].Metrics == nil {
+		t.Fatalf("frame[2] (tail) metrics: want non-nil")
+	}
+	if got, want := int(frames[2].Metrics.InspectedTraces), total; got != want {
+		t.Errorf("frame[2] InspectedTraces: got %d, want %d", got, want)
+	}
+	// Sum-check: total traces across all frames matches the input.
+	sum := 0
+	for _, f := range frames {
+		sum += len(f.Traces)
+	}
+	if sum != total {
+		t.Errorf("traces across frames: got %d, want %d", sum, total)
+	}
+
+	// Cursor.Close MUST be called by the Search handler so CH
+	// resources don't leak. Cancel the context first so any
+	// in-flight goroutine drains, then check.
+	cancel()
+	if !waitForClose(&q.closed, time.Second) {
+		t.Errorf("cursor.Close was not invoked")
+	}
+}
+
+// TestSearch_EmptyResultSet asserts the zero-row happy path: a search
+// against a CH cursor that returns 0 rows still produces exactly one
+// frame (the tail with InspectedTraces=0 + empty Traces slice).
+// Grafana's Tempo datasource parses the metrics from the last frame
+// regardless of trace count, so this is the wire-format contract for
+// "no results found".
+func TestSearch_EmptyResultSet(t *testing.T) {
+	t.Parallel()
+	q := &stubCursorQuerier{rows: nil}
+	client, cleanup := dialServer(t, q)
+	t.Cleanup(cleanup)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	stream, err := client.Search(ctx, &tempopb.SearchRequest{Query: "{}"})
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
+	frames, err := drainSearch(t, stream)
+	if err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+	if got, want := len(frames), 1; got != want {
+		t.Fatalf("frame count: got %d, want %d (tail-only)", got, want)
+	}
+	if got := len(frames[0].Traces); got != 0 {
+		t.Errorf("frame[0] traces: got %d, want 0", got)
+	}
+	if frames[0].Metrics == nil {
+		t.Fatalf("frame[0] metrics: want non-nil with InspectedTraces=0")
+	}
+	if got := int(frames[0].Metrics.InspectedTraces); got != 0 {
+		t.Errorf("InspectedTraces: got %d, want 0", got)
+	}
+}
+
+// TestSearch_EmptyQueryHealthCheck asserts the empty-query Grafana
+// health-check path — the gRPC analogue of the HTTP /api/search
+// behaviour where an empty `q` returns a 200 + empty traces. Over
+// gRPC we emit one frame with empty Traces + zero-metrics so the
+// streaming health-check stays semantically identical to the HTTP one.
+func TestSearch_EmptyQueryHealthCheck(t *testing.T) {
+	t.Parallel()
+	q := &stubCursorQuerier{rows: nil}
+	client, cleanup := dialServer(t, q)
+	t.Cleanup(cleanup)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	stream, err := client.Search(ctx, &tempopb.SearchRequest{Query: ""})
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
+	frames, err := drainSearch(t, stream)
+	if err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+	if got, want := len(frames), 1; got != want {
+		t.Fatalf("frame count: got %d, want %d", got, want)
+	}
+	if len(frames[0].Traces) != 0 {
+		t.Errorf("expected empty traces, got %d", len(frames[0].Traces))
+	}
+}
+
+// TestSearch_TraceMetadataPivot pins the conversion from cerberus's
+// tempo.TraceSummary into the wire-format tempopb.TraceSearchMetadata.
+// The mapping is field-for-field (TraceID / RootServiceName /
+// RootTraceName / startTimeUnixNano / durationMs) so a search query
+// over the streaming path produces the same identity + timing the
+// HTTP path returns; this test pins the conversion so a future field
+// reorder is caught at the gRPC boundary, not by the e2e smoke.
+func TestSearch_TraceMetadataPivot(t *testing.T) {
+	t.Parallel()
+	const traceID = "0123456789abcdef0123456789abcdef"
+	ts := time.Date(2026, 5, 19, 12, 0, 0, 123_456_789, time.UTC)
+	rows := []chclient.Sample{
+		makeSearchRow(traceID, "GET /api/users", "frontend", ts, 250),
+	}
+	q := &stubCursorQuerier{rows: rows}
+	client, cleanup := dialServer(t, q)
+	t.Cleanup(cleanup)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	stream, err := client.Search(ctx, &tempopb.SearchRequest{Query: "{}"})
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
+	frames, err := drainSearch(t, stream)
+	if err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+	if len(frames) != 1 || len(frames[0].Traces) != 1 {
+		t.Fatalf("expected 1 frame with 1 trace, got %d frames, frame[0] traces=%d",
+			len(frames), len(frames[0].Traces))
+	}
+	tr := frames[0].Traces[0]
+	if tr.TraceID != traceID {
+		t.Errorf("TraceID: got %q, want %q", tr.TraceID, traceID)
+	}
+	if tr.RootServiceName != "frontend" {
+		t.Errorf("RootServiceName: got %q, want %q", tr.RootServiceName, "frontend")
+	}
+	if tr.RootTraceName != "GET /api/users" {
+		t.Errorf("RootTraceName: got %q, want %q", tr.RootTraceName, "GET /api/users")
+	}
+	if got, want := tr.StartTimeUnixNano, uint64(ts.UnixNano()); got != want {
+		t.Errorf("StartTimeUnixNano: got %d, want %d", got, want)
+	}
+	if tr.DurationMs != 250 {
+		t.Errorf("DurationMs: got %d, want 250", tr.DurationMs)
+	}
+}
+
+// TestSearch_CancellationPropagatesToCursor wires a slow synthetic
+// cursor (1 row every 50ms), cancels the client context mid-stream,
+// and asserts that cursor.Close was invoked. This is the proof that
+// gRPC stream context cancellation flows through to the CH cursor's
+// resource-release path — the property the design-doc §4 calls out
+// as "Cancellation: stream.Context() cancels on client disconnect;
+// pass into Engine.QueryPlanCursor."
+func TestSearch_CancellationPropagatesToCursor(t *testing.T) {
+	t.Parallel()
+	// Enough rows that no realistic in-flight drain ever exhausts the
+	// cursor before the test cancels — we want the cancel to be
+	// observable, not a race with the natural end-of-stream.
+	rows := make([]chclient.Sample, 0, 1000)
+	ts := time.Now()
+	for i := 0; i < 1000; i++ {
+		rows = append(rows, makeSearchRow(padHexTraceID(i), "GET /api", "svc", ts, 1))
+	}
+	q := &slowCursorQuerier{
+		stubCursorQuerier: stubCursorQuerier{rows: rows},
+		rowDelay:          20 * time.Millisecond,
+	}
+	client, cleanup := dialServer(t, &q.stubCursorQuerier)
+	t.Cleanup(cleanup)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stream, err := client.Search(ctx, &tempopb.SearchRequest{Query: "{}"})
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
+
+	// Pump the stream in a goroutine so we can cancel mid-drain and
+	// observe Close from the test thread.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			if _, err := stream.Recv(); err != nil {
+				return
+			}
+		}
+	}()
+
+	// Give the server a moment to start draining, then cancel.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("stream did not terminate after cancel")
+	}
+
+	if !waitForClose(&q.closed, time.Second) {
+		t.Errorf("cursor.Close was not invoked after cancellation")
+	}
+}
+
+// slowCursorQuerier is stubCursorQuerier with a delay between
+// Next() calls so the CancellationPropagatesToCursor test has
+// enough wall-clock to interrupt mid-stream. The embedded
+// stubCursorQuerier carries the rows + closed-counter; the delay
+// is layered on by wrapping QueryCursor's returned cursor.
+type slowCursorQuerier struct {
+	stubCursorQuerier
+	rowDelay time.Duration
+}
+
+func (s *slowCursorQuerier) QueryCursor(ctx context.Context, _ string, _ ...any) (chclient.Cursor, error) {
+	return &slowCursor{
+		stubCursor: stubCursor{rows: s.rows, ctx: ctx, closed: &s.closed},
+		delay:      s.rowDelay,
+	}, nil
+}
+
+type slowCursor struct {
+	stubCursor
+	delay time.Duration
+}
+
+func (c *slowCursor) Next() bool {
+	if c.i > 0 {
+		// Honour ctx cancellation while sleeping so the cancel
+		// propagates promptly (a naked time.Sleep wouldn't return).
+		select {
+		case <-time.After(c.delay):
+		case <-c.ctx.Done():
+			c.err = c.ctx.Err()
+			return false
+		}
+	}
+	return c.stubCursor.Next()
+}
+
+func (c *slowCursor) Sample() chclient.Sample { return c.stubCursor.Sample() }
+func (c *slowCursor) Err() error              { return c.stubCursor.Err() }
+func (c *slowCursor) Close() error            { return c.stubCursor.Close() }
+
+// waitForClose polls the closed counter for up to deadline so the
+// test doesn't race the goroutine that owns the cursor. Returns true
+// once Close has been observed; false when the deadline expires.
+func waitForClose(c *atomic.Int32, deadline time.Duration) bool {
+	end := time.Now().Add(deadline)
+	for time.Now().Before(end) {
+		if c.Load() == 1 {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return c.Load() == 1
+}
+
+// TestSearch_ParseErrorMapsToInvalidArgument confirms the gRPC error-
+// mapping table from the design doc §3: a TraceQL parser failure
+// surfaces as codes.InvalidArgument (user-facing query error), not
+// the default codes.Internal. The HTTP equivalent returns 400 (see
+// classifySearchErr) — both heads converge on "user typed a broken
+// query."
+func TestSearch_ParseErrorMapsToInvalidArgument(t *testing.T) {
+	t.Parallel()
+	q := &stubCursorQuerier{}
+	client, cleanup := dialServer(t, q)
+	t.Cleanup(cleanup)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	// A non-empty but syntactically invalid TraceQL query — the
+	// upstream parser rejects it before lowering, so the engine
+	// surfaces ErrParseStage and the gRPC handler maps to
+	// codes.InvalidArgument.
+	stream, err := client.Search(ctx, &tempopb.SearchRequest{Query: "{ unclosed"})
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
+	_, recvErr := drainSearch(t, stream)
+	if recvErr == nil {
+		t.Fatalf("want error, got nil")
+	}
+	st, ok := status.FromError(recvErr)
+	if !ok {
+		t.Fatalf("want grpc status, got %v", recvErr)
+	}
+	if st.Code() != codes.InvalidArgument {
+		t.Errorf("code: got %s, want InvalidArgument (err=%v)", st.Code(), recvErr)
+	}
+}

--- a/internal/api/tempo/grpc/service_unimplemented_test.go
+++ b/internal/api/tempo/grpc/service_unimplemented_test.go
@@ -18,12 +18,12 @@ import (
 )
 
 // TestUnimplemented_AllRPCsReturnUnimplemented is the proof-of-life
-// for the PR 1 scaffold slice: every one of the seven StreamingQuerier
-// RPCs must dial, the gRPC handshake must complete, and the server
-// must answer codes.Unimplemented. PRs 2-4 swap the
-// UnimplementedStreamingQuerierServer embedded methods out one by one;
-// when they do, the matching subtest below moves out of this file and
-// into the per-RPC suite.
+// for the gRPC scaffold: every StreamingQuerier RPC that has not yet
+// been ported must dial, the gRPC handshake must complete, and the
+// server must answer codes.Unimplemented. PR 2 ported Search out of
+// this matrix and into search_test.go (the subtest below is gone);
+// PRs 3 + 4 continue the same migration for the tag-list and metrics
+// RPCs.
 //
 // The test uses bufconn (the standard in-memory gRPC transport) so it
 // doesn't need a real network listener and stays hermetic — no port
@@ -93,13 +93,10 @@ func TestUnimplemented_AllRPCsReturnUnimplemented(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	t.Cleanup(cancel)
 
-	t.Run("Search", func(t *testing.T) {
-		stream, err := client.Search(ctx, &tempopb.SearchRequest{Query: "{}"})
-		if err != nil {
-			t.Fatalf("open stream: %v", err)
-		}
-		assertUnimplemented(t, "Search", drainErr(t, stream))
-	})
+	// Search has been ported (PR 2 — see search.go + search_test.go).
+	// The matrix below covers the six RPCs that remain
+	// Unimplemented today; the dropped Search subtest is now
+	// exercised end-to-end against the streaming pipeline.
 
 	t.Run("SearchTags", func(t *testing.T) {
 		stream, err := client.SearchTags(ctx, &tempopb.SearchTagsRequest{})
@@ -181,11 +178,15 @@ func TestServer_AdmitDisabledPath(t *testing.T) {
 
 	// One sanity check is enough — the Unimplemented matrix is
 	// covered above; this test exists only to pin that the nil-Limiter
-	// construction path works end-to-end.
+	// construction path works end-to-end. Use SearchTags rather than
+	// Search because PR 2 ported Search to a real handler (a nil
+	// Handler would return codes.Internal here, not the Unimplemented
+	// status this test asserts on); SearchTags remains Unimplemented
+	// until PR 3, which is the right shape for the admit-disabled probe.
 	client := tempopb.NewStreamingQuerierClient(conn)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	t.Cleanup(cancel)
-	stream, err := client.Search(ctx, &tempopb.SearchRequest{Query: "{}"})
+	stream, err := client.SearchTags(ctx, &tempopb.SearchTagsRequest{})
 	if err != nil {
 		t.Fatalf("open stream: %v", err)
 	}

--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -101,6 +101,52 @@ func New(client Querier, s schema.Traces, version string, logger *slog.Logger) *
 	}
 }
 
+// Lang exposes the TraceQL engine.Lang adapter wired into the Handler.
+// Sibling surfaces (the gRPC StreamingQuerier in internal/api/tempo/grpc)
+// reuse this so the parse + lower + wrap-projection pipeline is shared
+// byte-for-byte with the HTTP /api/search path — the only divergence is
+// the response serialisation.
+func (h *Handler) Lang() engine.Lang { return h.lang }
+
+// ToTraceSummaries is the package-level export of the toTraceSummaries
+// shaper used by /api/search. The gRPC Search RPC (see
+// internal/api/tempo/grpc/search.go) calls it to translate the cursor's
+// chclient.Sample stream into the per-trace summary shape that maps
+// onto tempopb.TraceSearchMetadata.
+//
+// Returns (summaries, missingRootTraceIDs); see toTraceSummaries for
+// the per-row grouping + root-resolution semantics. Equivalent to
+// calling toTraceSummaries directly inside the tempo package; the
+// re-export exists purely so external callers don't depend on an
+// unexported helper.
+func ToTraceSummaries(samples []chclient.Sample) ([]TraceSummary, []string) {
+	return toTraceSummaries(samples)
+}
+
+// ResolveMissingRoots issues the follow-up CH lookup that recovers root-
+// span identity + trace-wide duration for traces whose result set
+// lacked a true root row (typical for structural-join queries and
+// `{ status = error }` style predicates that only match child spans),
+// then patches the affected summaries in place. Mirrors the HTTP
+// handler's post-search resolution step so the gRPC Search RPC produces
+// byte-equivalent trace metadata for the same TraceQL input.
+//
+// `missing` may be nil/empty (no-op fast path). Returns a non-nil error
+// only when the follow-up CH query fails — callers typically log + ignore
+// (the earliest-span fallback in summaries stays in place), matching the
+// HTTP handler's "best-effort" semantics.
+func (h *Handler) ResolveMissingRoots(ctx context.Context, summaries []TraceSummary, missing []string) error {
+	if len(missing) == 0 {
+		return nil
+	}
+	roots, err := h.resolveTraceRoots(ctx, missing)
+	if err != nil {
+		return err
+	}
+	applyRootMetadata(summaries, roots)
+	return nil
+}
+
 // Mount registers the Tempo-compatible endpoints under /api/ on mux.
 // /api/echo + /api/status/version satisfy Grafana's datasource health
 // check; /api/search runs a TraceQL query; /api/traces/{id} fetches a

--- a/internal/api/tempo/lang.go
+++ b/internal/api/tempo/lang.go
@@ -19,9 +19,22 @@ import (
 // into a single bucket; carrying the stage in the wrapped error chain
 // preserves the per-stage HTTP-status mapping the inlined handler
 // used to return.
+//
+// ErrParseStage / ErrLowerStage are the exported aliases; the gRPC
+// Search RPC chains them via errors.Is to map user-facing query errors
+// onto codes.InvalidArgument (parser + lower) while keeping
+// emit/execute on codes.Internal — sibling of classifySearchErr's
+// HTTP-status mapping.
 var (
 	errParseStage = errors.New("traceql parse stage")
 	errLowerStage = errors.New("traceql lower stage")
+
+	// ErrParseStage / ErrLowerStage re-export the parse / lower stage
+	// markers so external callers (e.g. the gRPC StreamingQuerier
+	// surface) can errors.Is against them without depending on the
+	// unexported sentinels.
+	ErrParseStage = errParseStage
+	ErrLowerStage = errLowerStage
 )
 
 // traceqlLang adapts the TraceQL head to engine.Lang. Parse runs the


### PR DESCRIPTION
## Summary

PR 2 of the Tempo gRPC StreamingQuerier rollout (PR 1 = #610). Implements
the **Search** RPC: opens `Engine.QueryCursor` against the lowered TraceQL
plan, drains CH rows into trace summaries, then frames the result list
into `tempopb.SearchResponse` shards of 20 trace summaries each. The tail
frame stamps `SearchMetrics.InspectedTraces` so Grafana sees the aggregate
the HTTP `/api/search` path returns.

The other six RPCs (`SearchTags*`, `MetricsQuery*`) stay on the embedded
`UnimplementedStreamingQuerierServer` stubs until PRs 3 + 4 land.

## Authority

- Design + sketch: `.claude/plans/tempo-grpc-streaming-design.md`
  - **§3** (Search row + per-RPC strategy + code sketch).
  - **§4** (CH-cursor → gRPC frame mapping: 20 traces per frame, ~20 KB
    per shard, end-to-end backpressure via `grpc.ServerStream.SendMsg`).
  - **§5** (test strategy: fake cursor + bufconn; cancellation
    propagation property).
  - **§6** (PR slicing: PR 1 scaffold → PR 2 Search → PR 3 tags → PR 4
    metrics → PR 5 compat → PR 6 telemetry polish).

## Implementation

- **New file**: `internal/api/tempo/grpc/search.go`. Method shadows the
  embedded `UnimplementedStreamingQuerierServer.Search` via Go's normal
  method-shadowing rules (the other six RPCs still dispatch to the
  embedded Unimplemented stubs). Cross-PR file-layout convention so PRs
  3 + 4 can land in parallel without touching `service.go` or `server.go`.
- **Frame batching**: unexported `searchFlusher` with `Push(meta) →
  (shard, ready)` + `Tail() → shard` semantics. Sized at 20 to amortise
  per-`Send` framing overhead (~30B) without overshooting the HTTP/2
  per-stream window (64 KiB) — design §4 row.
- **Error mapping** (mirrors `classifySearchErr` HTTP-status table):
  - Parse / lower stage → `codes.InvalidArgument` (`errors.Is` against
    `tempo.ErrParseStage` / `tempo.ErrLowerStage`).
  - `chclient.ErrCircuitOpen` → `codes.Unavailable`.
  - Anything else → `codes.Internal`.
- **Admit limiter**: enforced upstream via the stream interceptor wired
  in PR 1 (`server.go` `ChainStreamInterceptor`), so saturated heads
  reject before Search is invoked with `codes.ResourceExhausted`.
- **Cancellation**: `stream.Context()` propagates into
  `Engine.QueryCursor`; cursor's `Close` runs via `defer`; pinned by a
  dedicated test that observes the close counter under context cancel.
- **Exports added** (minimal, scoped, no PR 3/4 conflicts):
  - `tempo.Handler.Lang()` — accessor over the unexported `traceqlLang`.
  - `tempo.ToTraceSummaries` — re-export of the existing shaper.
  - `tempo.Handler.ResolveMissingRoots` — combined helper that wraps the
    `resolveTraceRoots` + `applyRootMetadata` follow-up step.
  - `tempo.ErrParseStage` / `tempo.ErrLowerStage` — re-export of the
    stage sentinels for cross-package `errors.Is`.

## Tests

`internal/api/tempo/grpc/search_test.go` — bufconn-driven, fake CH
cursor stub:

- `TestSearch_FrameBatching` — 45 synthetic traces → asserts 3 frames
  (2×20 + tail 5); `SearchMetrics.InspectedTraces = 45` on tail only.
- `TestSearch_EmptyResultSet` — 0 rows → exactly 1 tail frame with
  `InspectedTraces = 0`.
- `TestSearch_EmptyQueryHealthCheck` — empty `Query` → 1 frame with
  empty `Traces`, mirroring the HTTP `/api/search?q=` health-check
  semantics.
- `TestSearch_TraceMetadataPivot` — pins the `tempo.TraceSummary` →
  `tempopb.TraceSearchMetadata` field-for-field conversion (TraceID,
  RootServiceName, RootTraceName, `StartTimeUnixNano` (uint64 via
  `strconv.ParseUint` of the JSON-string form), DurationMs).
- `TestSearch_CancellationPropagatesToCursor` — slow synthetic cursor,
  client cancel mid-stream, asserts `cursor.Close` was observed.
- `TestSearch_ParseErrorMapsToInvalidArgument` — broken TraceQL
  (`{ unclosed`) → `codes.InvalidArgument`.

Existing scaffold tests in `service_unimplemented_test.go` updated:

- Dropped the `Search` subtest from the Unimplemented matrix.
- `TestServer_AdmitDisabledPath` now exercises `SearchTags` (still
  Unimplemented), since Search now dispatches to a real handler.

## Test plan

- [ ] CI `check` job passes (all internal unit tests).
- [ ] CI `lint` job passes (gofumpt + goimports clean, funlen under 150
      statements per method).
- [ ] Existing Tempo HTTP tests still pass (no behavioural drift from
      the new exported helpers).
- [ ] Playwright streaming variant deferred per design §5 caveat —
      cerberus's gRPC streaming is on the Grafana backend channel, so
      the existing Playwright HTTP probes already cover the end-user
      search flow. A follow-up TaskCreate will wire the streaming
      datasource jsonData + k3d image once PR 3 + PR 4 land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)