### PR TITLE
ci(e2e): wait for ≥60s of metric history before running Playwright specs

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -343,15 +343,19 @@ e2e-seed:
     @echo "==> seed done"
 
 # Wait until the OTel collector has populated real data in every signal
-# table (logs / traces / one of the metrics tables). Bootstraps the
-# pipeline before tests rely on it — telemetrygen + kubeletstats take
-# ~30-60s to flush a first batch through the gateway.
+# table (logs / traces / one of the metrics tables) AND the metric table
+# carries ≥60 s of history. Bootstraps the pipeline before tests rely on
+# it — telemetrygen + kubeletstats take ~30-60s to flush a first batch
+# through the gateway, and 1m-windowed queries (rate(x[1m]), up[1m:30s])
+# need a 60s span of TimeUnix values before they return a vector.
 #
 # Polls every 5s for up to 3 min; fails the recipe if any signal stays
-# empty. Uses `kubectl exec` against the ClickHouse pod so it does not
-# need a host-side port-forward.
+# empty or the metric stream never reaches 60 s of spread. Uses
+# `kubectl exec` against the ClickHouse pod so it does not need a
+# host-side port-forward. Spread is asserted on whichever metric table
+# (sum or gauge) carries non-zero rows first.
 e2e-wait-otel:
-    @echo "==> waiting for real OTel data in ClickHouse"
+    @echo "==> waiting for real OTel data + ≥60s metric history in ClickHouse"
     @deadline=$(($(date +%s) + 180)); \
         while [ $(date +%s) -lt $deadline ]; do \
             logs=$(kubectl -n cerberus exec deploy/clickhouse -- clickhouse-client \
@@ -366,14 +370,24 @@ e2e-wait-otel:
             gauge=$(kubectl -n cerberus exec deploy/clickhouse -- clickhouse-client \
                 --user cerberus --password cerberus --database otel \
                 --query "SELECT count() FROM otel_metrics_gauge" 2>/dev/null || echo 0); \
-            echo "    logs=$logs traces=$traces metrics_sum=$sum metrics_gauge=$gauge"; \
-            if [ "$logs" -gt 0 ] && [ "$traces" -gt 0 ] && { [ "$sum" -gt 0 ] || [ "$gauge" -gt 0 ]; }; then \
-                echo "==> OTel pipeline is live"; \
+            spread=0; \
+            if [ "$sum" -gt 0 ]; then \
+                spread=$(kubectl -n cerberus exec deploy/clickhouse -- clickhouse-client \
+                    --user cerberus --password cerberus --database otel \
+                    --query "SELECT toUInt64(dateDiff('second', min(TimeUnix), max(TimeUnix))) FROM otel_metrics_sum" 2>/dev/null || echo 0); \
+            elif [ "$gauge" -gt 0 ]; then \
+                spread=$(kubectl -n cerberus exec deploy/clickhouse -- clickhouse-client \
+                    --user cerberus --password cerberus --database otel \
+                    --query "SELECT toUInt64(dateDiff('second', min(TimeUnix), max(TimeUnix))) FROM otel_metrics_gauge" 2>/dev/null || echo 0); \
+            fi; \
+            echo "    logs=$logs traces=$traces metrics_sum=$sum metrics_gauge=$gauge spread=${spread}s"; \
+            if [ "$logs" -gt 0 ] && [ "$traces" -gt 0 ] && { [ "$sum" -gt 0 ] || [ "$gauge" -gt 0 ]; } && [ "$spread" -ge 60 ]; then \
+                echo "==> OTel pipeline is live with ≥60s of metric history"; \
                 exit 0; \
             fi; \
             sleep 5; \
         done; \
-        echo "==> timeout waiting for OTel data"; \
+        echo "==> timeout waiting for OTel data / metric history span"; \
         exit 1
 
 # Run Go E2E HTTP tests against the deployed stack.


### PR DESCRIPTION
## Summary

- The `e2e-wait-otel` gate in `Justfile` only checked `count() > 0` per OTel table, so it returned as soon as the first metric row landed. The dashboard specs that issue 1m-windowed PromQL queries (`rate(x[1m])`, `up[1m:30s]`) therefore raced the wait gate and produced an empty-vector response.
- The gate now also asserts `dateDiff('second', min(TimeUnix), max(TimeUnix)) >= 60` on whichever metric table (`otel_metrics_sum` preferred, `otel_metrics_gauge` fallback) has non-zero rows. The existing 180s deadline comfortably covers the typical 75-90s warm-up on a fresh k3d cluster, so the gate stays time-bounded.

## Repro evidence

Today (2026-05-20) the dashboard job inside `.github/workflows/e2e.yml` had a 3/10 fail rate driven by two specs:

- `test/e2e/playwright/prom_metrics.spec.ts:70` — `subquery up[1m:30s] (bare vector) returns a vector` (needs ≥60s of metric history)
- `test/e2e/playwright/prom_ux.spec.ts:178` — `dashboard panel: simulated multi-target panel`, target B = `rate(http_server_request_duration_count[1m])`

Failing post-#610 runs:

- Action run 26160038641 — both specs fail
- Action run 26158016082 — only prom_ux multi-target B fails
- Action run 26154883130 — both specs fail

## Why structural over per-spec retry

Adding a retry loop to the failing specs would hide the race; the wait-gate extension makes any e2e spec that needs ≥60s of history see a deterministic environment, not just the two failing today.

## Test plan

- [ ] `just e2e-up && just e2e-seed && just e2e-wait-otel && just e2e-run` succeeds on a clean cluster.
- [ ] Playwright `dashboard` job on this PR's `e2e` workflow run passes both `prom_metrics.spec.ts:70` and `prom_ux.spec.ts:178` reliably.
- [ ] `e2e-wait-otel` still completes well within the 180s deadline on a fresh k3d.

🤖 Generated with [Claude Code](https://claude.com/claude-code)