### PR TITLE
feat(api/tempo/grpc): implement MetricsQueryRange + MetricsQueryInstant RPCs

### DIFF
--- a/internal/api/tempo/grpc/metrics.go
+++ b/internal/api/tempo/grpc/metrics.go
@@ -1,0 +1,252 @@
+package grpc
+
+import (
+	"context"
+	"errors"
+	"math"
+	"time"
+
+	"github.com/grafana/tempo/pkg/tempopb"
+	v1 "github.com/grafana/tempo/pkg/tempopb/common/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/tsouza/cerberus/internal/api/tempo"
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+// This file implements the two metrics StreamingQuerier RPCs:
+// MetricsQueryRange + MetricsQueryInstant. Both are SINGLE-FRAME
+// streams per .claude/plans/tempo-grpc-streaming-design.md §6 (range
+// mode emits one QueryRangeResponse after eager drain; instant is the
+// single-bucket variant of the same shape). Frame batching does not
+// apply — the matrix / instant pivot pipelines need the full row set
+// in hand before zero-fill + quantile post-processing can produce a
+// well-formed series envelope, so the streaming-friendly behaviour is
+// to flush exactly one frame on completion.
+//
+// Both methods shadow the embedded
+// tempopb.UnimplementedStreamingQuerierServer in service.go via Go's
+// promoted-method-shadowing — implementing them here replaces the
+// codes.Unimplemented default for these two RPCs only. Admission
+// control is handled by Limiter.StreamInterceptor at the gRPC server
+// level (server.go); the per-RPC code below does NOT re-acquire a
+// slot.
+//
+// Error mapping (matches the design-doc §3 table):
+//   - tempo.ErrParseStage / tempo.ErrLowerStage → codes.InvalidArgument
+//     (user-facing query errors — bad TraceQL, non-metrics-pipeline
+//     expression, missing start/end/step).
+//   - chclient.ErrCircuitOpen → codes.Unavailable.
+//   - any other engine / CH error → codes.Internal.
+//
+// Cancellation: stream.Context() flows through Handler.ExecMetrics*
+// → engine.QueryPlan → chclient.Client.Query, so a client disconnect
+// surfaces as ctx.Err() on the in-flight CH driver call and the gRPC
+// transport closes the stream with codes.Canceled.
+
+// MetricsQueryRange implements StreamingQuerier_MetricsQueryRangeServer.
+// Mirrors the HTTP /api/metrics/query_range endpoint: evaluate the
+// TraceQL metrics-pipeline expression over [Start, End] with the given
+// Step, then return one tempopb.QueryRangeResponse carrying the full
+// matrix (one TimeSeries per group-by tuple, samples sorted ascending,
+// exemplars best-effort). Start / End / Step on the wire are uint64
+// nanoseconds (per upstream Tempo's `pkg/tempopb` proto definition);
+// Step = 0 is rejected as InvalidArgument.
+func (s *Service) MetricsQueryRange(req *tempopb.QueryRangeRequest, stream tempopb.StreamingQuerier_MetricsQueryRangeServer) error {
+	if s.Handler == nil {
+		return status.Error(codes.Internal, "tempo gRPC: handler not wired")
+	}
+	if req == nil {
+		return status.Error(codes.InvalidArgument, "tempo gRPC: nil QueryRangeRequest")
+	}
+	if req.Query == "" {
+		return status.Error(codes.InvalidArgument, "tempo gRPC: missing 'query' field")
+	}
+	if req.Start == 0 || req.End == 0 {
+		return status.Error(codes.InvalidArgument, "tempo gRPC: 'start' and 'end' are required")
+	}
+	if req.Step == 0 {
+		return status.Error(codes.InvalidArgument, "tempo gRPC: 'step' must be > 0")
+	}
+	if req.End < req.Start {
+		return status.Error(codes.InvalidArgument, "tempo gRPC: 'end' must not be before 'start'")
+	}
+	if req.Start > math.MaxInt64 || req.End > math.MaxInt64 || req.Step > math.MaxInt64 {
+		return status.Error(codes.InvalidArgument, "tempo gRPC: 'start' / 'end' / 'step' must fit in int64 nanoseconds")
+	}
+
+	ctx := stream.Context()
+	start := nanosToTime(req.Start)
+	end := nanosToTime(req.End)
+	step := time.Duration(req.Step) //nolint:gosec // bounded above by req.Step <= math.MaxInt64
+
+	out, err := metricsExecRange(ctx, s.Handler, req.Query, start, end, step)
+	if err != nil {
+		return mapMetricsError(err)
+	}
+	return mapStreamSendError(stream.Send(out))
+}
+
+// MetricsQueryInstant implements StreamingQuerier_MetricsQueryInstantServer.
+// Single-bucket evaluation over [Start, End] returning one InstantSeries
+// per group-by tuple (each carrying a scalar Value rather than a
+// Samples slice). Mirrors HTTP /api/metrics/query — Tempo's
+// translateQueryRangeToInstant collapses a range response by setting
+// step = end - start; cerberus follows the same rule on the gRPC side.
+func (s *Service) MetricsQueryInstant(req *tempopb.QueryInstantRequest, stream tempopb.StreamingQuerier_MetricsQueryInstantServer) error {
+	if s.Handler == nil {
+		return status.Error(codes.Internal, "tempo gRPC: handler not wired")
+	}
+	if req == nil {
+		return status.Error(codes.InvalidArgument, "tempo gRPC: nil QueryInstantRequest")
+	}
+	if req.Query == "" {
+		return status.Error(codes.InvalidArgument, "tempo gRPC: missing 'query' field")
+	}
+	if req.Start == 0 || req.End == 0 {
+		return status.Error(codes.InvalidArgument, "tempo gRPC: 'start' and 'end' are required")
+	}
+	if req.End <= req.Start {
+		return status.Error(codes.InvalidArgument, "tempo gRPC: 'end' must be after 'start'")
+	}
+	if req.Start > math.MaxInt64 || req.End > math.MaxInt64 {
+		return status.Error(codes.InvalidArgument, "tempo gRPC: 'start' / 'end' must fit in int64 nanoseconds")
+	}
+
+	ctx := stream.Context()
+	start := nanosToTime(req.Start)
+	end := nanosToTime(req.End)
+
+	out, err := metricsExecInstant(ctx, s.Handler, req.Query, start, end)
+	if err != nil {
+		return mapMetricsError(err)
+	}
+	return mapStreamSendError(stream.Send(out))
+}
+
+// metricsExecRange runs the cerberus metrics-pipeline path for a range
+// query and pivots the post-processed MetricsSeries list into the
+// tempopb.QueryRangeResponse wire shape. Mirrors PR 2's searchFlusher
+// in spirit (separate helper to keep test-side helpers focused) but
+// is a single-frame pivot rather than a streaming flusher — range
+// mode emits one frame after eager drain (design §6).
+func metricsExecRange(ctx context.Context, h *tempo.Handler, query string, start, end time.Time, step time.Duration) (*tempopb.QueryRangeResponse, error) {
+	res, err := h.ExecMetricsRange(ctx, query, start, end, step)
+	if err != nil {
+		return nil, err
+	}
+	out := &tempopb.QueryRangeResponse{
+		Series: make([]*tempopb.TimeSeries, 0, len(res.Series)),
+	}
+	for _, ms := range res.Series {
+		ts := &tempopb.TimeSeries{
+			Labels:    metricsLabelsToKeyValues(ms.Labels),
+			Samples:   make([]tempopb.Sample, 0, len(ms.Samples)),
+			Exemplars: make([]tempopb.Exemplar, 0, len(ms.Exemplars)),
+		}
+		for _, s := range ms.Samples {
+			ts.Samples = append(ts.Samples, tempopb.Sample{
+				TimestampMs: s.TimestampMs,
+				Value:       s.Value,
+			})
+		}
+		for _, ex := range ms.Exemplars {
+			ts.Exemplars = append(ts.Exemplars, tempopb.Exemplar{
+				Labels:      metricsLabelsToKeyValues(ex.Labels),
+				Value:       ex.Value,
+				TimestampMs: ex.Timestamp,
+			})
+		}
+		out.Series = append(out.Series, ts)
+	}
+	return out, nil
+}
+
+// metricsExecInstant runs the cerberus metrics-pipeline path for an
+// instant query and pivots the post-processed MetricsInstantSeries
+// list into the tempopb.QueryInstantResponse wire shape. Each series
+// carries a scalar Value rather than a Samples slice.
+func metricsExecInstant(ctx context.Context, h *tempo.Handler, query string, start, end time.Time) (*tempopb.QueryInstantResponse, error) {
+	res, err := h.ExecMetricsInstant(ctx, query, start, end)
+	if err != nil {
+		return nil, err
+	}
+	out := &tempopb.QueryInstantResponse{
+		Series: make([]*tempopb.InstantSeries, 0, len(res.Series)),
+	}
+	for _, ms := range res.Series {
+		out.Series = append(out.Series, &tempopb.InstantSeries{
+			Labels: metricsLabelsToKeyValues(ms.Labels),
+			Value:  ms.Value,
+		})
+	}
+	return out, nil
+}
+
+// metricsLabelsToKeyValues pivots cerberus's MetricsLabel slice into
+// the tempopb v1.KeyValue + AnyValue wire shape (string variant only —
+// TraceQL group-by keys + intrinsic labels are always stringified on
+// the SQL side, so other AnyValue variants don't apply). Mirrors the
+// HTTP JSON path's MetricsLabel.MarshalJSON envelope (metricsLabelWire)
+// so the streaming + HTTP responses canonicalise identically.
+func metricsLabelsToKeyValues(in []tempo.MetricsLabel) []v1.KeyValue {
+	out := make([]v1.KeyValue, 0, len(in))
+	for _, l := range in {
+		out = append(out, v1.KeyValue{
+			Key: l.Key,
+			Value: &v1.AnyValue{
+				Value: &v1.AnyValue_StringValue{StringValue: l.Value},
+			},
+		})
+	}
+	return out
+}
+
+// mapMetricsError converts an Engine / pipeline error into the gRPC
+// status the metrics RPCs return. Mirrors classifyMetricsQueryRangeErr's
+// HTTP-status mapping while adopting the gRPC error vocabulary:
+//
+//   - parse + lower (tempo.ErrParseStage / ErrLowerStage) →
+//     codes.InvalidArgument (user-facing query errors).
+//   - chclient circuit-open (errors.Is against chclient.ErrCircuitOpen) →
+//     codes.Unavailable (downstream saturation, retry-after).
+//   - everything else (emit / execute / unexpected) → codes.Internal.
+func mapMetricsError(err error) error {
+	if err == nil {
+		return nil
+	}
+	switch {
+	case errors.Is(err, chclient.ErrCircuitOpen):
+		return status.Errorf(codes.Unavailable, "%v", err)
+	case errors.Is(err, tempo.ErrParseStage), errors.Is(err, tempo.ErrLowerStage):
+		return status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	return status.Errorf(codes.Internal, "%v", err)
+}
+
+// nanosToTime converts a tempopb-wire-format nanosecond timestamp
+// (uint64; per upstream Tempo's QueryRangeRequest / QueryInstantRequest
+// proto definition) into the time.Time the engine pipeline consumes.
+// The MetricsQueryRange / MetricsQueryInstant entry points pre-check
+// that the input fits in int64 (the gosec bound) before calling this
+// helper, so the int64 cast is safe by construction; the //nolint:gosec
+// directive keeps the linter from re-flagging the proven-safe cast.
+func nanosToTime(n uint64) time.Time {
+	return time.Unix(0, int64(n)).UTC() //nolint:gosec // caller pre-checks n <= math.MaxInt64
+}
+
+// mapStreamSendError preserves an existing gRPC status when the send
+// failed mid-flight (the gRPC runtime usually returns status-wrapped
+// errors here) and wraps a non-status error as codes.Internal so the
+// caller never gets a bare transport error. Mirrors PR 2's
+// mapStreamError for the search path.
+func mapStreamSendError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if _, ok := status.FromError(err); ok {
+		return err
+	}
+	return status.Errorf(codes.Internal, "stream send: %v", err)
+}

--- a/internal/api/tempo/grpc/metrics_test.go
+++ b/internal/api/tempo/grpc/metrics_test.go
@@ -1,0 +1,482 @@
+package grpc_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/grafana/tempo/pkg/tempopb"
+	v1 "github.com/grafana/tempo/pkg/tempopb/common/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/tsouza/cerberus/internal/api/tempo"
+	tempogrpc "github.com/tsouza/cerberus/internal/api/tempo/grpc"
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// metricsFixtureStartNs / metricsFixtureEndNs mirror the canonical
+// fixtureStart / fixtureEnd anchors from the HTTP metrics tests
+// (2026-05-12T10:00:00Z + 3 minutes) but in the nanosecond units the
+// gRPC tempopb.QueryRangeRequest / QueryInstantRequest wire fields
+// expect.
+const (
+	metricsFixtureStartNs uint64 = 1778580000 * 1_000_000_000
+	metricsFixtureEndNs   uint64 = 1778580180 * 1_000_000_000
+	metricsFixtureStepNs  uint64 = 60 * 1_000_000_000
+)
+
+// metricsFakeQuerier is a tempo.Querier stub the metrics gRPC tests
+// drive. It returns a fixed []chclient.Sample (`samples`) from Query,
+// plus an optional `err` that maps to the engine's "execute" stage —
+// the gRPC handler then maps to codes.Internal or codes.Unavailable
+// depending on the error value. QueryStrings is unused by the metrics
+// RPCs; QueryCursor is unused too (the metrics path doesn't use the
+// streaming cursor — it's an eager-drain pivot).
+type metricsFakeQuerier struct {
+	mu       sync.Mutex
+	samples  []chclient.Sample
+	err      error
+	delay    time.Duration
+	lastSQLs []string
+}
+
+func (m *metricsFakeQuerier) Query(ctx context.Context, sql string, _ ...any) ([]chclient.Sample, error) {
+	m.mu.Lock()
+	m.lastSQLs = append(m.lastSQLs, sql)
+	delay := m.delay
+	err := m.err
+	rows := append([]chclient.Sample(nil), m.samples...)
+	m.mu.Unlock()
+
+	if delay > 0 {
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+func (m *metricsFakeQuerier) QueryStrings(_ context.Context, _ string, _ ...any) ([]string, error) {
+	return nil, errors.New("metricsFakeQuerier.QueryStrings unused in metrics RPC tests")
+}
+
+// newMetricsTestServer wires up the bufconn-based gRPC plumbing the
+// metrics RPCs need: a fake querier → cerberus tempo.Handler → gRPC
+// Service → grpc.Server on bufconn → client. Returns the dialled
+// client + a cleanup func.
+func newMetricsTestServer(t *testing.T, q tempo.Querier) (tempopb.StreamingQuerierClient, func()) {
+	t.Helper()
+	handler := tempo.New(q, schema.DefaultOTelTraces(), "test-grpc", nil)
+	service := tempogrpc.NewService(handler, nil, nil)
+	srv := tempogrpc.NewServer(service)
+	lis := bufconn.Listen(1 << 20)
+	go func() {
+		if err := srv.Serve(lis); err != nil {
+			t.Logf("grpc Serve returned: %v", err)
+		}
+	}()
+
+	conn, err := grpc.NewClient(
+		"passthrough://bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("grpc dial bufnet: %v", err)
+	}
+	return tempopb.NewStreamingQuerierClient(conn), func() {
+		_ = conn.Close()
+		srv.GracefulStop()
+	}
+}
+
+// keyValueValue pulls the AnyValue.StringValue from a v1.KeyValue,
+// folding the AnyValue oneof switch into a single test-side accessor.
+// The metrics RPCs only emit string-variant AnyValues (TraceQL group-by
+// + intrinsic labels stringify on the SQL side), so we don't need a
+// full type switch.
+func keyValueValue(kv v1.KeyValue) string {
+	if kv.Value == nil {
+		return ""
+	}
+	if s, ok := kv.Value.Value.(*v1.AnyValue_StringValue); ok {
+		return s.StringValue
+	}
+	return ""
+}
+
+// TestMetricsQueryRange_FrameShape feeds a single observed-bucket
+// fixture through MetricsQueryRange and asserts the wire envelope: one
+// frame, one TimeSeries, label set populated with the synthetic
+// `__name__=rate` for an ungrouped query, samples sorted ascending,
+// zero-fill of the trailing 4th anchor at value 0.
+//
+// 3-minute fixture window @ 60s step → 4 anchors after zero-fill
+// (10:00 / 10:01 / 10:02 / 10:03); the stub returns observed values at
+// the first three; the fill injects a zero at the trailing anchor —
+// same contract the HTTP TestMetricsQueryRange_SingleSeriesNoGroupBy
+// pins on the JSON envelope, replayed across the gRPC wire shape.
+func TestMetricsQueryRange_FrameShape(t *testing.T) {
+	t.Parallel()
+	ts := func(min int) time.Time {
+		return time.Date(2026, 5, 12, 10, min, 0, 0, time.UTC)
+	}
+	q := &metricsFakeQuerier{samples: []chclient.Sample{
+		{Labels: map[string]string{"__name__": "rate"}, Timestamp: ts(2), Value: 2.0},
+		{Labels: map[string]string{"__name__": "rate"}, Timestamp: ts(0), Value: 0.5},
+		{Labels: map[string]string{"__name__": "rate"}, Timestamp: ts(1), Value: 1.5},
+	}}
+	client, cleanup := newMetricsTestServer(t, q)
+	t.Cleanup(cleanup)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	stream, err := client.MetricsQueryRange(ctx, &tempopb.QueryRangeRequest{
+		Query: "{} | rate()",
+		Start: metricsFixtureStartNs,
+		End:   metricsFixtureEndNs,
+		Step:  metricsFixtureStepNs,
+	})
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
+
+	frames := drainRangeFrames(t, stream)
+	// Range mode emits exactly one frame after eager drain
+	// (design-doc §6 — frame batching does not apply).
+	if got, want := len(frames), 1; got != want {
+		t.Fatalf("frame count: got %d, want %d (range mode is single-frame)", got, want)
+	}
+	if got, want := len(frames[0].Series), 1; got != want {
+		t.Fatalf("series count: got %d, want %d", got, want)
+	}
+	got := frames[0].Series[0]
+	if len(got.Labels) != 1 || got.Labels[0].Key != "__name__" || keyValueValue(got.Labels[0]) != "rate" {
+		t.Errorf("labels: want single {__name__=rate}, got %+v", got.Labels)
+	}
+	if len(got.Samples) != 4 {
+		t.Fatalf("samples: want 4 (3 observed + 1 zero-fill), got %d: %+v", len(got.Samples), got.Samples)
+	}
+	for i, want := range []float64{0.5, 1.5, 2.0, 0.0} {
+		if got.Samples[i].Value != want {
+			t.Errorf("sample[%d].Value: got %v, want %v", i, got.Samples[i].Value, want)
+		}
+	}
+	for i := 1; i < len(got.Samples); i++ {
+		if got.Samples[i-1].TimestampMs >= got.Samples[i].TimestampMs {
+			t.Errorf("samples not sorted ascending by timestamp: %+v", got.Samples)
+		}
+	}
+}
+
+// TestMetricsQueryInstant_FrameShape asserts the instant wire shape
+// diverges from range as documented: InstantSeries has a scalar Value
+// (no Samples slice). With step = end - start the matrix RangeWindow
+// emits exactly one anchor per series; the instant projection picks
+// that single sample's value as the series scalar.
+func TestMetricsQueryInstant_FrameShape(t *testing.T) {
+	t.Parallel()
+	ts := func(min int) time.Time {
+		return time.Date(2026, 5, 12, 10, min, 0, 0, time.UTC)
+	}
+	q := &metricsFakeQuerier{samples: []chclient.Sample{
+		{Labels: map[string]string{"resource.service.name": "frontend"}, Timestamp: ts(0), Value: 12},
+		{Labels: map[string]string{"resource.service.name": "backend"}, Timestamp: ts(0), Value: 3},
+	}}
+	client, cleanup := newMetricsTestServer(t, q)
+	t.Cleanup(cleanup)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	stream, err := client.MetricsQueryInstant(ctx, &tempopb.QueryInstantRequest{
+		Query: "{} | count_over_time() by (resource.service.name)",
+		Start: metricsFixtureStartNs,
+		End:   metricsFixtureEndNs,
+	})
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
+
+	frames := drainInstantFrames(t, stream)
+	if got, want := len(frames), 1; got != want {
+		t.Fatalf("frame count: got %d, want %d (instant is single-frame)", got, want)
+	}
+	if got, want := len(frames[0].Series), 2; got != want {
+		t.Fatalf("series count: got %d, want %d", got, want)
+	}
+	// Series are sorted by canonical label key (deterministic
+	// emission); backend < frontend lexicographically.
+	values := map[string]float64{}
+	for _, s := range frames[0].Series {
+		if len(s.Labels) != 1 || s.Labels[0].Key != "resource.service.name" {
+			t.Errorf("series labels: want single resource.service.name, got %+v", s.Labels)
+			continue
+		}
+		values[keyValueValue(s.Labels[0])] = s.Value
+	}
+	if got, want := values["frontend"], 12.0; got != want {
+		t.Errorf("frontend value: got %v, want %v", got, want)
+	}
+	if got, want := values["backend"], 3.0; got != want {
+		t.Errorf("backend value: got %v, want %v", got, want)
+	}
+}
+
+// TestMetricsQueryRange_ParseError confirms the gRPC error-mapping
+// table from the design doc §3: a TraceQL parser failure surfaces as
+// codes.InvalidArgument (user-facing query error), not codes.Internal.
+// The HTTP equivalent returns 400 (see classifyMetricsQueryRangeErr) —
+// both surfaces converge on "user typed a broken metrics query."
+func TestMetricsQueryRange_ParseError(t *testing.T) {
+	t.Parallel()
+	q := &metricsFakeQuerier{}
+	client, cleanup := newMetricsTestServer(t, q)
+	t.Cleanup(cleanup)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	stream, err := client.MetricsQueryRange(ctx, &tempopb.QueryRangeRequest{
+		Query: "{ unclosed",
+		Start: metricsFixtureStartNs,
+		End:   metricsFixtureEndNs,
+		Step:  metricsFixtureStepNs,
+	})
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
+	_, recvErr := stream.Recv()
+	if recvErr == nil {
+		t.Fatalf("want error, got nil")
+	}
+	st, ok := status.FromError(recvErr)
+	if !ok {
+		t.Fatalf("want grpc status, got %v", recvErr)
+	}
+	if st.Code() != codes.InvalidArgument {
+		t.Errorf("code: got %s, want InvalidArgument (err=%v)", st.Code(), recvErr)
+	}
+}
+
+// TestMetricsQueryInstant_Cancellation wires a slow CH stub, cancels
+// the client context mid-flight, and asserts the stream terminates
+// with a cancellation status. This is the proof that gRPC stream
+// context cancellation flows through Handler.ExecMetricsInstant →
+// engine.QueryPlan → Client.Query (the slow ctx-aware path).
+//
+// We can't observe a synthetic-cursor counter the way PR 2's search
+// path does (the metrics RPCs use Query, not QueryCursor); instead
+// we assert on the propagated status — either codes.Canceled (the
+// gRPC transport observed the client disconnect first) or
+// codes.Internal wrapping ctx.Err() (the server-side Query returned
+// before the transport observed cancel). Both are valid outcomes —
+// the test pins "either".
+func TestMetricsQueryInstant_Cancellation(t *testing.T) {
+	t.Parallel()
+	q := &metricsFakeQuerier{
+		samples: []chclient.Sample{
+			{Labels: map[string]string{"__name__": "count_over_time"}, Timestamp: time.Now(), Value: 1},
+		},
+		// Long enough that the cancel arrives before Query returns
+		// in steady state on any reasonable test host.
+		delay: 500 * time.Millisecond,
+	}
+	client, cleanup := newMetricsTestServer(t, q)
+	t.Cleanup(cleanup)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stream, err := client.MetricsQueryInstant(ctx, &tempopb.QueryInstantRequest{
+		Query: "{} | count_over_time()",
+		Start: metricsFixtureStartNs,
+		End:   metricsFixtureEndNs,
+	})
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
+	// Cancel mid-flight.
+	time.AfterFunc(50*time.Millisecond, cancel)
+
+	_, recvErr := stream.Recv()
+	if recvErr == nil {
+		t.Fatalf("want cancellation error, got nil response")
+	}
+	st, ok := status.FromError(recvErr)
+	if !ok {
+		t.Fatalf("want grpc status, got %v", recvErr)
+	}
+	// Either codes.Canceled (transport saw cancel first) or
+	// codes.Internal wrapping context.Canceled (engine surfaced
+	// ctx.Err() as an execute-stage error first). Both prove the
+	// cancellation flowed through.
+	if st.Code() != codes.Canceled && st.Code() != codes.Internal {
+		t.Errorf("code: got %s, want Canceled or Internal", st.Code())
+	}
+	if st.Code() == codes.Internal && !strings.Contains(st.Message(), "context canceled") {
+		t.Errorf("Internal status message: want to mention 'context canceled', got %q", st.Message())
+	}
+}
+
+// TestMetricsQueryRange_CircuitOpen confirms chclient.ErrCircuitOpen
+// surfaces as codes.Unavailable rather than the default codes.Internal.
+// This is the gRPC equivalent of the HTTP 503 + Retry-After path —
+// the design-doc §3 calls out Unavailable as the wire-canonical "ask
+// the client to retry later" response.
+func TestMetricsQueryRange_CircuitOpen(t *testing.T) {
+	t.Parallel()
+	q := &metricsFakeQuerier{err: chclient.ErrCircuitOpen}
+	client, cleanup := newMetricsTestServer(t, q)
+	t.Cleanup(cleanup)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	stream, err := client.MetricsQueryRange(ctx, &tempopb.QueryRangeRequest{
+		Query: "{} | rate()",
+		Start: metricsFixtureStartNs,
+		End:   metricsFixtureEndNs,
+		Step:  metricsFixtureStepNs,
+	})
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
+	_, recvErr := stream.Recv()
+	if recvErr == nil {
+		t.Fatalf("want error, got nil")
+	}
+	st, ok := status.FromError(recvErr)
+	if !ok {
+		t.Fatalf("want grpc status, got %v", recvErr)
+	}
+	if st.Code() != codes.Unavailable {
+		t.Errorf("code: got %s, want Unavailable (err=%v)", st.Code(), recvErr)
+	}
+}
+
+// TestMetricsQueryRange_NonMetricsQuery asserts the parse-then-lower
+// path's "not a metrics-pipeline expression" rejection: a bare TraceQL
+// query (no `| rate()` / `| *_over_time()` tail) returns InvalidArgument
+// rather than the default Internal. The HTTP handler returns 400 on
+// the same shape (see handleMetricsQueryRange's "not a TraceQL
+// metrics-pipeline expression" error).
+func TestMetricsQueryRange_NonMetricsQuery(t *testing.T) {
+	t.Parallel()
+	q := &metricsFakeQuerier{}
+	client, cleanup := newMetricsTestServer(t, q)
+	t.Cleanup(cleanup)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	stream, err := client.MetricsQueryRange(ctx, &tempopb.QueryRangeRequest{
+		Query: "{ name=\"foo\" }",
+		Start: metricsFixtureStartNs,
+		End:   metricsFixtureEndNs,
+		Step:  metricsFixtureStepNs,
+	})
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
+	_, recvErr := stream.Recv()
+	if recvErr == nil {
+		t.Fatalf("want error, got nil")
+	}
+	st, ok := status.FromError(recvErr)
+	if !ok {
+		t.Fatalf("want grpc status, got %v", recvErr)
+	}
+	if st.Code() != codes.InvalidArgument {
+		t.Errorf("code: got %s, want InvalidArgument (err=%v)", st.Code(), recvErr)
+	}
+}
+
+// TestMetricsQueryRange_BadInputs pins the request-validation surface:
+// missing query / start / end / step / inverted-bounds all map to
+// codes.InvalidArgument rather than letting the engine see a malformed
+// request.
+func TestMetricsQueryRange_BadInputs(t *testing.T) {
+	t.Parallel()
+	q := &metricsFakeQuerier{}
+	client, cleanup := newMetricsTestServer(t, q)
+	t.Cleanup(cleanup)
+
+	cases := []struct {
+		name string
+		req  *tempopb.QueryRangeRequest
+	}{
+		{"missing query", &tempopb.QueryRangeRequest{Start: metricsFixtureStartNs, End: metricsFixtureEndNs, Step: metricsFixtureStepNs}},
+		{"zero start", &tempopb.QueryRangeRequest{Query: "{} | rate()", End: metricsFixtureEndNs, Step: metricsFixtureStepNs}},
+		{"zero end", &tempopb.QueryRangeRequest{Query: "{} | rate()", Start: metricsFixtureStartNs, Step: metricsFixtureStepNs}},
+		{"zero step", &tempopb.QueryRangeRequest{Query: "{} | rate()", Start: metricsFixtureStartNs, End: metricsFixtureEndNs}},
+		{"end before start", &tempopb.QueryRangeRequest{Query: "{} | rate()", Start: metricsFixtureEndNs, End: metricsFixtureStartNs, Step: metricsFixtureStepNs}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			stream, err := client.MetricsQueryRange(ctx, tc.req)
+			if err != nil {
+				t.Fatalf("open stream: %v", err)
+			}
+			_, recvErr := stream.Recv()
+			if recvErr == nil {
+				t.Fatalf("want error, got nil")
+			}
+			st, ok := status.FromError(recvErr)
+			if !ok {
+				t.Fatalf("want grpc status, got %v", recvErr)
+			}
+			if st.Code() != codes.InvalidArgument {
+				t.Errorf("code: got %s, want InvalidArgument (err=%v)", st.Code(), recvErr)
+			}
+		})
+	}
+}
+
+// drainRangeFrames pulls every QueryRangeResponse frame off the
+// streaming RPC until EOF. Mirrors PR 2's drainSearch helper but for
+// the metrics-range envelope.
+func drainRangeFrames(t *testing.T, stream tempopb.StreamingQuerier_MetricsQueryRangeClient) []*tempopb.QueryRangeResponse {
+	t.Helper()
+	var frames []*tempopb.QueryRangeResponse
+	for {
+		f, err := stream.Recv()
+		if err == io.EOF {
+			return frames
+		}
+		if err != nil {
+			t.Fatalf("recv: %v", err)
+		}
+		frames = append(frames, f)
+	}
+}
+
+// drainInstantFrames is the instant-side sibling of drainRangeFrames.
+// Returns the collected QueryInstantResponse frames in arrival order.
+func drainInstantFrames(t *testing.T, stream tempopb.StreamingQuerier_MetricsQueryInstantClient) []*tempopb.QueryInstantResponse {
+	t.Helper()
+	var frames []*tempopb.QueryInstantResponse
+	for {
+		f, err := stream.Recv()
+		if err == io.EOF {
+			return frames
+		}
+		if err != nil {
+			t.Fatalf("recv: %v", err)
+		}
+		frames = append(frames, f)
+	}
+}

--- a/internal/api/tempo/grpc/service_unimplemented_test.go
+++ b/internal/api/tempo/grpc/service_unimplemented_test.go
@@ -93,10 +93,12 @@ func TestUnimplemented_AllRPCsReturnUnimplemented(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	t.Cleanup(cancel)
 
-	// Search has been ported (PR 2 — see search.go + search_test.go).
-	// The matrix below covers the six RPCs that remain
-	// Unimplemented today; the dropped Search subtest is now
-	// exercised end-to-end against the streaming pipeline.
+	// Search has been ported (search.go + search_test.go) and the two
+	// metrics RPCs have been ported (metrics.go + metrics_test.go).
+	// The matrix below covers the four tag-list RPCs that remain
+	// Unimplemented today; the dropped subtests are exercised
+	// end-to-end against the streaming pipeline in their per-RPC
+	// suites.
 
 	t.Run("SearchTags", func(t *testing.T) {
 		stream, err := client.SearchTags(ctx, &tempopb.SearchTagsRequest{})
@@ -128,22 +130,6 @@ func TestUnimplemented_AllRPCsReturnUnimplemented(t *testing.T) {
 			t.Fatalf("open stream: %v", err)
 		}
 		assertUnimplemented(t, "SearchTagValuesV2", drainErr(t, stream))
-	})
-
-	t.Run("MetricsQueryRange", func(t *testing.T) {
-		stream, err := client.MetricsQueryRange(ctx, &tempopb.QueryRangeRequest{Query: "{} | rate()"})
-		if err != nil {
-			t.Fatalf("open stream: %v", err)
-		}
-		assertUnimplemented(t, "MetricsQueryRange", drainErr(t, stream))
-	})
-
-	t.Run("MetricsQueryInstant", func(t *testing.T) {
-		stream, err := client.MetricsQueryInstant(ctx, &tempopb.QueryInstantRequest{Query: "{} | rate()"})
-		if err != nil {
-			t.Fatalf("open stream: %v", err)
-		}
-		assertUnimplemented(t, "MetricsQueryInstant", drainErr(t, stream))
 	})
 }
 

--- a/internal/api/tempo/grpc_exports.go
+++ b/internal/api/tempo/grpc_exports.go
@@ -1,0 +1,214 @@
+package tempo
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/engine"
+	"github.com/tsouza/cerberus/internal/telemetry"
+	traceql_lower "github.com/tsouza/cerberus/internal/traceql"
+)
+
+// This file exports a narrow set of the Tempo HTTP-handler internals
+// the sibling `internal/api/tempo/grpc` package needs to answer the
+// StreamingQuerier metrics RPCs (MetricsQueryRange + MetricsQueryInstant)
+// without duplicating the parse + lower + wrap + execute + post-process
+// pipeline encoded in handleMetricsQueryRange / handleMetricsQueryInstant.
+// The exports keep the HTTP surface as the source of truth for behaviour
+// — the gRPC surface only diverges on the wire envelope (tempopb
+// TimeSeries / InstantSeries vs the JSON MetricsSeries / MetricsInstantSeries
+// shapes the HTTP handler returns). See .claude/plans/tempo-grpc-streaming-design.md
+// §3 + §6 for the single-frame strategy this enables.
+
+// ExecMetricsRangeResult is the post-execution intermediate shape the
+// gRPC MetricsQueryRange RPC translates into tempopb.TimeSeries. Each
+// MetricsSeries already carries the post-quantile-collapse,
+// post-zero-fill, post-exemplar-attach view of the data; the gRPC
+// handler only re-shapes labels + samples into the proto envelope.
+type ExecMetricsRangeResult struct {
+	// Series is the post-processed (quantile-collapse, zero-fill,
+	// exemplars-attached) series list — same value the HTTP handler
+	// passes to writeJSON.
+	Series []MetricsSeries
+}
+
+// ExecMetricsRange runs the full metrics-pipeline evaluation that
+// /api/metrics/query_range performs and returns the post-processed
+// series list. Pipeline (mirrors handleMetricsQueryRange):
+//
+//  1. Parse the TraceQL metrics-pipeline expression — errors wrap
+//     ErrParseStage so the gRPC layer maps to codes.InvalidArgument.
+//  2. Lower to chplan — errors wrap ErrLowerStage (also
+//     codes.InvalidArgument).
+//  3. Unwrap the MetricsAggregate; reject non-metrics queries so the
+//     gRPC layer surfaces InvalidArgument rather than a malformed plan.
+//  4. Wrap with chplan.RangeWindow + sample projection so the inner
+//     SQL emits the matrix-shape (group, anchor, value) tuples.
+//  5. Run engine.QueryPlan — emit + execute against ClickHouse.
+//  6. Post-process quantile buckets (no-op for non-quantile ops).
+//  7. Pivot row stream → MetricsSeries, zero-fill the matrix grid
+//     across [Start, End] for count/rate/quantile.
+//  8. Best-effort exemplar enrichment — failure here keeps the
+//     series envelope but emits a Logger.Warn (same policy as HTTP).
+//
+// Returns the engine error verbatim so the gRPC caller can errors.Is
+// against ErrParseStage / ErrLowerStage / chclient.ErrCircuitOpen.
+func (h *Handler) ExecMetricsRange(ctx context.Context, query string, start, end time.Time, step time.Duration) (ExecMetricsRangeResult, error) {
+	if query == "" {
+		return ExecMetricsRangeResult{}, fmt.Errorf("%w: missing query", errParseStage)
+	}
+	if start.IsZero() || end.IsZero() {
+		return ExecMetricsRangeResult{}, fmt.Errorf("%w: 'start' and 'end' are required", errParseStage)
+	}
+	if step <= 0 {
+		return ExecMetricsRangeResult{}, fmt.Errorf("%w: 'step' must be > 0", errParseStage)
+	}
+
+	parseT := telemetry.ObserveStage(telemetry.StageParse)
+	expr, perr := parseExpr(ctx, query)
+	parseT.Done(ctx)
+	if perr != nil {
+		return ExecMetricsRangeResult{}, fmt.Errorf("%w: %w", errParseStage, perr)
+	}
+	lowerT := telemetry.ObserveStage(telemetry.StageLower)
+	plan, lerr := traceql_lower.Lower(ctx, expr, h.Schema)
+	lowerT.Done(ctx)
+	if lerr != nil {
+		return ExecMetricsRangeResult{}, fmt.Errorf("%w: %w", errLowerStage, lerr)
+	}
+
+	metrics, ok := unwrapMetricsAggregate(plan)
+	if !ok {
+		return ExecMetricsRangeResult{}, fmt.Errorf("%w: query %q is not a TraceQL metrics-pipeline expression — MetricsQueryRange requires `| rate()`, `| count_over_time()`, `| *_over_time(...)` or `| quantile_over_time(...)`", errLowerStage, query)
+	}
+
+	rw := &chplan.RangeWindow{
+		Input:           plan,
+		Range:           step,
+		Step:            step,
+		Start:           start,
+		End:             end,
+		TimestampColumn: h.Schema.TimestampColumn,
+	}
+	wrapped := wrapMetricsForSample(rw, metrics)
+
+	res, qerr := h.Engine.QueryPlan(ctx, metricsLang{}, wrapped, engine.Meta{
+		IsMetric:      true,
+		ResponseShape: "tempo-metrics-matrix",
+	})
+	if qerr != nil {
+		return ExecMetricsRangeResult{}, qerr
+	}
+	h.Logger.Debug("cerberus tempo grpc metrics_query_range",
+		"traceql", query, "start", start, "end", end, "step", step,
+		"sql", res.SQL, "args", res.Args)
+
+	samples := res.Samples
+	if metrics.Op == chplan.MetricsOpQuantileOverTime {
+		samples = postProcessQuantileBuckets(samples, metrics)
+	}
+	series := toMetricsSeries(samples, metrics)
+	series = zeroFillMatrixGrid(series, metrics, start, end, step)
+
+	// Best-effort exemplar enrichment. A failed emit / query keeps
+	// the empty Exemplars slice already attached by toMetricsSeries
+	// — the wire envelope stays well-formed.
+	exSQL, exArgs, exErr := chsql.EmitMetricsExemplars(ctx, rw, metrics,
+		h.Schema.TraceIDColumn, h.Schema.SpanIDColumn, 1)
+	if exErr != nil {
+		h.Logger.Warn("cerberus tempo grpc metrics_query_range exemplars emit failed",
+			"err", exErr)
+	} else {
+		exSamples, qErr := h.Client.Query(ctx, exSQL, exArgs...)
+		if qErr != nil {
+			h.Logger.Warn("cerberus tempo grpc metrics_query_range exemplars query failed",
+				"err", qErr)
+		} else {
+			attachExemplars(series, exSamples, metrics)
+		}
+	}
+
+	return ExecMetricsRangeResult{Series: series}, nil
+}
+
+// ExecMetricsInstantResult is the post-execution intermediate the
+// gRPC MetricsQueryInstant RPC translates into tempopb.InstantSeries.
+// Mirrors ExecMetricsRangeResult but carries the single-bucket
+// projection — one (labels, scalar value) tuple per series.
+type ExecMetricsInstantResult struct {
+	Series []MetricsInstantSeries
+}
+
+// ExecMetricsInstant runs the full instant evaluation that
+// /api/metrics/query performs. Same pipeline shape as ExecMetricsRange
+// but with step = end - start so the chplan.RangeWindow emits exactly
+// one anchor per series — Tempo's translateQueryRangeToInstant
+// semantics (one (labels, scalar) tuple per series at end-of-window).
+//
+// The instant path does NOT zero-fill (one anchor only) and does NOT
+// attach exemplars (Tempo's instant envelope carries no Exemplars
+// field — see tempopb.InstantSeries). Quantile post-processing still
+// runs so the per-phi label shape is honoured.
+func (h *Handler) ExecMetricsInstant(ctx context.Context, query string, start, end time.Time) (ExecMetricsInstantResult, error) {
+	if query == "" {
+		return ExecMetricsInstantResult{}, fmt.Errorf("%w: missing query", errParseStage)
+	}
+	if start.IsZero() || end.IsZero() {
+		return ExecMetricsInstantResult{}, fmt.Errorf("%w: 'start' and 'end' are required", errParseStage)
+	}
+	step := end.Sub(start)
+	if step <= 0 {
+		return ExecMetricsInstantResult{}, fmt.Errorf("%w: 'end' must be after 'start'", errParseStage)
+	}
+
+	parseT := telemetry.ObserveStage(telemetry.StageParse)
+	expr, perr := parseExpr(ctx, query)
+	parseT.Done(ctx)
+	if perr != nil {
+		return ExecMetricsInstantResult{}, fmt.Errorf("%w: %w", errParseStage, perr)
+	}
+	lowerT := telemetry.ObserveStage(telemetry.StageLower)
+	plan, lerr := traceql_lower.Lower(ctx, expr, h.Schema)
+	lowerT.Done(ctx)
+	if lerr != nil {
+		return ExecMetricsInstantResult{}, fmt.Errorf("%w: %w", errLowerStage, lerr)
+	}
+
+	metrics, ok := unwrapMetricsAggregate(plan)
+	if !ok {
+		return ExecMetricsInstantResult{}, fmt.Errorf("%w: query %q is not a TraceQL metrics-pipeline expression — MetricsQueryInstant requires `| rate()`, `| count_over_time()`, `| *_over_time(...)` or `| quantile_over_time(...)`", errLowerStage, query)
+	}
+
+	rw := &chplan.RangeWindow{
+		Input:           plan,
+		Range:           step,
+		Step:            step,
+		Start:           start,
+		End:             end,
+		TimestampColumn: h.Schema.TimestampColumn,
+	}
+	wrapped := wrapMetricsForSample(rw, metrics)
+
+	res, qerr := h.Engine.QueryPlan(ctx, metricsLang{}, wrapped, engine.Meta{
+		IsMetric:      true,
+		ResponseShape: "tempo-metrics-instant",
+	})
+	if qerr != nil {
+		return ExecMetricsInstantResult{}, qerr
+	}
+	h.Logger.Debug("cerberus tempo grpc metrics_query_instant",
+		"traceql", query, "start", start, "end", end, "step", step,
+		"sql", res.SQL, "args", res.Args)
+
+	samples := res.Samples
+	if metrics.Op == chplan.MetricsOpQuantileOverTime {
+		samples = postProcessQuantileBuckets(samples, metrics)
+	}
+
+	return ExecMetricsInstantResult{
+		Series: toMetricsInstantSeries(samples, metrics),
+	}, nil
+}

--- a/internal/api/tempo/lang.go
+++ b/internal/api/tempo/lang.go
@@ -20,11 +20,11 @@ import (
 // preserves the per-stage HTTP-status mapping the inlined handler
 // used to return.
 //
-// ErrParseStage / ErrLowerStage are the exported aliases; the gRPC
-// Search RPC chains them via errors.Is to map user-facing query errors
-// onto codes.InvalidArgument (parser + lower) while keeping
-// emit/execute on codes.Internal — sibling of classifySearchErr's
-// HTTP-status mapping.
+// ErrParseStage / ErrLowerStage are the exported aliases the sibling
+// gRPC handler (internal/api/tempo/grpc) chains via errors.Is to map
+// user-facing query errors onto codes.InvalidArgument (parser + lower)
+// while keeping emit/execute on codes.Internal — sibling of
+// classifySearchErr's HTTP-status mapping.
 var (
 	errParseStage = errors.New("traceql parse stage")
 	errLowerStage = errors.New("traceql lower stage")


### PR DESCRIPTION
## Summary

PR 4 of the Tempo gRPC StreamingQuerier rollout, per
[`.claude/plans/tempo-grpc-streaming-design.md`](.claude/plans/tempo-grpc-streaming-design.md)
§3 + §6 (single-frame strategy for the metrics-pipeline RPCs).

Implements the final two methods of `tempopb.StreamingQuerierServer`
in a NEW file `internal/api/tempo/grpc/metrics.go`. Both methods
shadow the embedded `tempopb.UnimplementedStreamingQuerierServer` in
`service.go` via Go's promoted-method-shadowing — zero conflict with
PR 2 (Search, #612) or PR 3 (tag RPCs, #611) which land in sibling
files.

| RPC | Response shape |
|---|---|
| `MetricsQueryRange` | `QueryRangeResponse{Series []*TimeSeries}` (matrix, exemplars-attached) |
| `MetricsQueryInstant` | `QueryInstantResponse{Series []*InstantSeries}` (scalar Value per series) |

Both RPCs are **single-frame** streams: the matrix / instant pivot
pipelines need the full row set in hand before zero-fill + quantile
post-processing can produce a well-formed series envelope, so the
streaming-friendly behaviour is to flush exactly one frame after the
engine drains. Frame batching does not apply.

### Engine reuse

`internal/api/tempo/grpc_exports.go` (NEW) exposes two narrow helpers
`Handler.ExecMetricsRange` + `Handler.ExecMetricsInstant` that
encapsulate the parse + lower + wrap + execute + post-process pipeline
today inlined in `handleMetricsQueryRange` / `handleMetricsQueryInstant`.

The HTTP surface stays the source of truth for behaviour (zero-fill,
quantile post-processing, exemplars best-effort enrichment); the gRPC
handler only diverges on the wire envelope (`tempopb.TimeSeries` /
`InstantSeries` vs the JSON `MetricsSeries` / `MetricsInstantSeries`
shapes the HTTP path returns). `metricsLabelsToKeyValues` pivots
cerberus's `MetricsLabel` slice into the tempopb `v1.KeyValue` +
`AnyValue` envelope (string variant only — TraceQL group-by keys
stringify on the SQL side).

`service.go` / `server.go` / `search.go` / `tags.go` untouched (per
the parallel-PR coordination contract in the design doc + task brief).

### Admission + error mapping

- Admission control is handled by `Limiter.StreamInterceptor` at the
  gRPC server level (`server.go` from PR 1); the per-RPC code does
  NOT re-acquire.
- Error policy (matches `classifyMetricsQueryRangeErr`'s HTTP-status
  table, adapted to gRPC codes):
  - `tempo.ErrParseStage` / `tempo.ErrLowerStage` →
    `codes.InvalidArgument`
  - `chclient.ErrCircuitOpen` → `codes.Unavailable`
  - any other engine / CH error → `codes.Internal`
  - missing query / start / end / step / inverted bounds →
    `codes.InvalidArgument` (pre-validated before engine entry)
- Cancellation: `stream.Context()` flows through
  `Handler.ExecMetrics*` → `engine.QueryPlan` → `Client.Query`, so a
  client disconnect surfaces as `ctx.Err()` on the in-flight CH driver
  call.

### Sentinel re-exports

`lang.go` gets the same `ErrParseStage` / `ErrLowerStage` re-export
PR 2 (#612) also lands — declaring once here so the gRPC metrics
RPCs can `errors.Is` against user-facing TraceQL errors without
depending on the unexported sentinels. If PR 2 merges first the
declarations are identical (rebase is a no-op); if this one merges
first PR 2's rebase becomes the no-op.

### `service_unimplemented_test.go`

The `MetricsQueryRange` + `MetricsQueryInstant` subtests moved into
the new per-RPC suite (they expected `codes.Unimplemented`, which
would now be a false negative). The comment at the top of that file
already foreshadowed this move.

### Test plan

New file `internal/api/tempo/grpc/metrics_test.go` (bufconn-based, hermetic):

- [x] `TestMetricsQueryRange_FrameShape` — single frame, label set populated, zero-fill at trailing anchor, samples sorted ascending
- [x] `TestMetricsQueryInstant_FrameShape` — single frame, scalar `Value` (not `Samples` slice), per-group-by series projection
- [x] `TestMetricsQueryRange_ParseError` — TraceQL parser failure → `codes.InvalidArgument`
- [x] `TestMetricsQueryRange_NonMetricsQuery` — non-metrics-pipeline TraceQL → `codes.InvalidArgument`
- [x] `TestMetricsQueryRange_CircuitOpen` — `chclient.ErrCircuitOpen` → `codes.Unavailable`
- [x] `TestMetricsQueryRange_BadInputs` (5 subtests: missing query, zero start, zero end, zero step, inverted bounds) → `codes.InvalidArgument` across the matrix
- [x] `TestMetricsQueryInstant_Cancellation` — slow CH stub + client cancel mid-flight; assert the stream terminates with `codes.Canceled` or `codes.Internal` wrapping `context.Canceled`

### Out of scope

- Compat harness gRPC mode.
- gRPC stream telemetry middleware sibling.