### PR TITLE
fix(e2e/seed): extend sum-metric seed to 5 min span so rate([1m]) finds samples

### DIFF
--- a/test/e2e/playwright/prom_ux.spec.ts
+++ b/test/e2e/playwright/prom_ux.spec.ts
@@ -12,9 +12,11 @@ import { test, expect } from '@playwright/test';
  *
  * Seed shape (test/e2e/seed/cmd/seed/main.go):
  *   • otel_metrics_gauge: 2× `up` series, Attributes.job ∈ {api, db}
- *   • otel_metrics_sum:   60× `http_server_request_duration_count`,
+ *   • otel_metrics_sum:   300× `http_server_request_duration_count`,
  *                         Attributes.job = api, Attributes.http_status = 200,
- *                         spaced 1s apart over the last minute.
+ *                         spaced 1s apart over the last 5 minutes so any
+ *                         1m/5m `rate()` window run within the Playwright
+ *                         execution timeframe finds ≥2 samples.
  */
 
 const promProxy = '/api/datasources/proxy/uid/cerberus-prometheus/api/v1';

--- a/test/e2e/seed/cmd/seed/main.go
+++ b/test/e2e/seed/cmd/seed/main.go
@@ -142,6 +142,13 @@ SELECT
     0.0
 FROM numbers(20)`
 
+	// 300 samples at 1 s cadence covers a 5-minute sliding window. A
+	// previous shape inserted only 60 samples (1 min span); by the time
+	// Playwright reached `prom_ux.spec.ts:178` — typically ~60-120 s
+	// after the e2e-wait-otel gate cleared — a 1-minute `rate()` window
+	// at request_time had slid past every seeded sample and returned
+	// 0 series. Matching the gauge seed's 5-minute span gives every
+	// 1m/5m/range query in the suite enough overlap to find ≥2 samples.
 	insertSumSQL = `INSERT INTO otel_metrics_sum
   (ResourceAttributes, MetricName, MetricDescription, MetricUnit, Attributes, StartTimeUnix, TimeUnix, Value, Flags, AggregationTemporality, IsMonotonic)
 SELECT
@@ -156,7 +163,7 @@ SELECT
     toUInt32(0),
     toInt32(2),
     true
-FROM numbers(60)`
+FROM numbers(300)`
 
 	insertLogsSQL = `INSERT INTO otel_logs
   (Timestamp, TimestampTime, TraceId, SpanId, SeverityText, SeverityNumber, ServiceName, Body, ResourceAttributes, LogAttributes)
@@ -188,9 +195,11 @@ VALUES
   (now64(9) - INTERVAL 29 SECOND, 'a0000000000000000000000000000003', '0000000000000007', '0000000000000006', 'cache.refresh',    'Client', 'db',       map('service.name', 'db'),       map('db.system',   'redis'),                                40000000, 'Ok')`
 )
 
-// insertMetrics inserts the two `up` gauge series + 60 counter samples for
-// rate() — preserved verbatim from the previous test/e2e/seed/otel_metrics.sql.
-// PR8's Playwright smoke queries these.
+// insertMetrics inserts the two `up` gauge series + 300 counter samples for
+// rate(). The gauge spans 5 minutes (20 samples × 15 s) and the counter spans
+// 5 minutes (300 samples × 1 s) so a 1m/5m `rate()` window in any Playwright
+// spec — which can fire ~60-120 s after the e2e-wait-otel gate clears — keeps
+// ≥2 samples in the lookback window.
 func insertMetrics(ctx context.Context, conn driver.Conn) error {
 	if err := conn.Exec(ctx, insertGaugeSQL); err != nil {
 		return fmt.Errorf("gauge: %w", err)


### PR DESCRIPTION
## Summary

Fixes the residual `e2e/dashboard` Playwright flake at `prom_ux.spec.ts:178` (target B — `rate(http_server_request_duration_count[1m])` returns 0 series).

## Root cause

The seed program (`test/e2e/seed/cmd/seed/main.go`) inserts the sum metric `http_server_request_duration_count` with 60 samples spaced 1 s apart over `[seed_now - 60 s, seed_now]`. By the time the Playwright spec runs (~60–120 s after seed, after `e2e-wait-otel` clears + Go E2E suite + Playwright install/boot), a 1-minute `rate()` window evaluated at `request_time` has slid **past every seeded sample** — so the window finds zero samples and `rate()` returns no series.

This was not the otelcol HTTP-receiver hypothesis from the task ticket: the metric never came from otelcol's internal middleware. It comes from the seed INSERT, and the gauge sibling already mitigates the same issue (20 samples × 15 s = 5 min span). The sum seed just hadn't been brought to parity.

## Fix

Extend `insertSumSQL` from `FROM numbers(60)` to `FROM numbers(300)` — same 1 s cadence, but a 5-minute span. Any 1m/5m `rate()` window run within the Playwright execution timeframe now keeps ≥ 2 samples in the lookback. Doc comments updated to keep the rowcount accurate.

`prom_metrics.spec.ts` (`rate([5m])`) was unaffected by the bug only because the 5-minute lookback was wide enough to absorb the drift; this fix removes the latent flake there too.

## Test plan

- [x] Local diff is two files — seed program + spec docstring; no Go logic change.
- [ ] Post-merge `e2e` workflow on `main` passes `prom_ux.spec.ts:178` (target B) without the 0-series error.
- [ ] Other tests in `prom_ux` / `prom_metrics` / `prom_explore_flow` specs continue passing.