### PR TITLE
fix(compose): disable basic auth so Grafana never prompts on quickstart

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -185,12 +185,19 @@ services:
       GF_SECURITY_ADMIN_PASSWORD: admin
       # Anonymous-Admin + disabled login form means the user opens
       # http://localhost:3000 and lands directly on the home dashboard
-      # with full edit rights — no admin/admin prompt to navigate. The
-      # admin user above still exists for API automation; the signout
-      # menu is hidden so the in-browser session can't accidentally
-      # drop to a "logged out" state with no way back in.
+      # with full edit rights — no admin/admin prompt to navigate.
+      # Basic auth is also disabled because Grafana 11+ still emits a
+      # `WWW-Authenticate: Basic` challenge header on some routes when
+      # basic auth is enabled (even with the form disabled) — browsers
+      # then pop their native credentials modal. Killing basic auth
+      # removes that prompt entirely. API automation in this stack
+      # uses Grafana service accounts / API keys, not basic auth, so
+      # nothing else depends on it. The signout menu is hidden so the
+      # in-browser session can't accidentally drop to a "logged out"
+      # state with no way back in.
       GF_AUTH_ANONYMOUS_ENABLED: "true"
       GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
+      GF_AUTH_BASIC_ENABLED: "false"
       GF_AUTH_DISABLE_LOGIN_FORM: "true"
       GF_AUTH_DISABLE_SIGNOUT_MENU: "true"
       GF_USERS_DEFAULT_THEME: dark


### PR DESCRIPTION
## Summary

- Add `GF_AUTH_BASIC_ENABLED=false` to the quickstart Grafana service.
- Even with `auth.disable_login_form=true` + `auth.anonymous.enabled=true`, Grafana 11+ still emits a `WWW-Authenticate: Basic` challenge on certain routes (admin / org / API paths). When the browser sees that header, it pops the native OS-level credentials modal, regardless of what the in-page UI is doing. The result is the user hits `localhost:3000`, gets the anonymous dashboard load — but somewhere mid-load Grafana 401s a sub-request, the modal pops, and the quickstart promise breaks.
- Setting `auth.basic.enabled=false` removes the challenge header from every response, so the browser never offers the modal. The in-page flow (anonymous-Admin → home dashboard) is untouched.

## Test plan

- [x] `docker compose down -v && docker compose up --wait` on a fresh state
- [ ] Open `http://localhost:3000` in a clean browser session — should land on the cerberus-self dashboard with full edit rights, no creds prompt at any point
- [ ] Open `http://localhost:3000/admin/users` directly — should return 403 (anonymous Admin doesn't satisfy Grafana-Admin role), NOT a credentials modal
- [x] `compose-smoke` job: assert `/api/health` returns 200 anonymously (the basic-auth disable doesn't break the healthcheck path)

API automation note: previous flow that used `curl -u admin:admin` against the local stack will now 401 (basic auth disabled). Switch to Grafana service accounts / API keys for that. Nothing inside the repo's compose stack currently uses basic-auth against Grafana, so no in-repo follow-up needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)