### PR TITLE
feat(api/loki): implement /detected_labels + JSON 404 fallback for Grafana 11.2+

### DIFF
--- a/internal/api/loki/conformance_test.go
+++ b/internal/api/loki/conformance_test.go
@@ -426,6 +426,50 @@ func TestConformance_LokiDetectedFieldsWire(t *testing.T) {
 	}
 }
 
+// TestConformance_LokiDetectedLabelsWire pins the
+// `{"detectedLabels":[{"label":"...","cardinality":N}, ...]}` envelope
+// Grafana 11.2+ expects from /loki/api/v1/detected_labels. Mirrors the
+// detected_fields wire test above so a future schema tweak surfaces here
+// rather than only in Grafana's UI.
+func TestConformance_LokiDetectedLabelsWire(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{
+		labelSets: []map[string]string{
+			{"job": "api", "instance": "host-1"},
+			{"job": "api", "instance": "host-2"},
+		},
+	}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL +
+		`/loki/api/v1/detected_labels?query=%7Bjob%3D%22api%22%7D&start=1717995600&end=1717999200`)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	var env loki.DetectedLabelsData
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(env.DetectedLabels) != 2 {
+		t.Fatalf("got %d labels, want 2: %+v", len(env.DetectedLabels), env.DetectedLabels)
+	}
+	for _, dl := range env.DetectedLabels {
+		if dl.Label == "" {
+			t.Errorf("empty label name in entry %+v", dl)
+		}
+		if dl.Cardinality == 0 {
+			t.Errorf("zero cardinality for label %q", dl.Label)
+		}
+	}
+}
+
 // TestConformance_LokiPatternsBasic — non-empty-data envelope. With
 // the drain wire-up live (PR #517), feeding canned (Timestamp, Body)
 // rows through the stub Querier produces a real cluster on the

--- a/internal/api/loki/detected_labels.go
+++ b/internal/api/loki/detected_labels.go
@@ -1,0 +1,156 @@
+package loki
+
+import (
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/logql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// DetectedLabel is one entry in the /loki/api/v1/detected_labels response.
+// Mirrors the upstream Loki shape Grafana 11.2+ expects when populating
+// the datasource label-explorer pane.
+type DetectedLabel struct {
+	Label       string `json:"label"`
+	Cardinality uint64 `json:"cardinality"`
+}
+
+// DetectedLabelsData is the body of a /loki/api/v1/detected_labels
+// response — a single `detectedLabels` array.
+type DetectedLabelsData struct {
+	DetectedLabels []DetectedLabel `json:"detectedLabels"`
+}
+
+// handleDetectedLabels implements GET /loki/api/v1/detected_labels.
+//
+// Grafana 11.2+ probes this endpoint when opening the Loki datasource UI
+// to populate label autocomplete and surface per-label cardinality. The
+// upstream Loki contract is documented at
+// https://grafana.com/docs/loki/latest/reference/loki-http-api/#detected-labels.
+//
+// Query parameters:
+//   - query (optional): LogQL stream selector to constrain the rows. An
+//     empty selector means "all streams in the time window".
+//   - start / end (optional): time range, defaults to last hour / now.
+//
+// The handler walks the distinct ResourceAttributes label sets matched in
+// the window (the same shape /series fetches) and counts the cardinality
+// of each key client-side. This reuses QueryLabelSets so no new Querier
+// method is needed.
+func (h *Handler) handleDetectedLabels(w http.ResponseWriter, r *http.Request) {
+	start, end, err := parseStartEnd(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, ErrBadData, err)
+		return
+	}
+
+	var matchers []*labels.Matcher
+	if q := r.URL.Query().Get("query"); q != "" {
+		matchers, err = selectorMatchers(q)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, ErrBadData, err)
+			return
+		}
+	}
+
+	sqlStr, args, err := buildDetectedLabelsSQL(h.Schema, matchers, start, end)
+	if err != nil {
+		h.respondError(w, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusInternalServerError})
+		return
+	}
+	h.Logger.Debug("cerberus loki detected_labels", "sql", sqlStr, "args", args)
+
+	rows, err := h.Client.QueryLabelSets(r.Context(), sqlStr, args...)
+	if err != nil {
+		h.Logger.Error("cerberus loki detected_labels CH query failed", "err", err, "sql", sqlStr)
+		h.respondError(w, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusBadGateway})
+		return
+	}
+
+	out := summariseDetectedLabels(rows)
+
+	writeJSON(w, http.StatusOK, DetectedLabelsData{DetectedLabels: out})
+}
+
+// buildDetectedLabelsSQL renders:
+//
+//	SELECT `ResourceAttributes` AS labels
+//	FROM `otel_logs`
+//	WHERE <matchers> AND `Timestamp` >= ? AND `Timestamp` <= ?
+//	GROUP BY labels
+//
+// The shape mirrors /series — one row per distinct stream label set in
+// the window. Per-key cardinality is then derived in Go (see
+// summariseDetectedLabels): a label key's cardinality is the number of
+// distinct values it carries across the matched stream set.
+//
+// All identifiers + time bounds flow through QueryBuilder slots; the
+// selector predicate composes typed Frags via logql.SelectorPredicate.
+func buildDetectedLabelsSQL(s schema.Logs, matchers []*labels.Matcher, start, end time.Time) (string, []any, error) {
+	sb := chsql.NewQuery().
+		Select(chsql.As(chsql.Col(s.ResourceAttributesColumn), "labels")).
+		From(chsql.Col(s.LogsTable))
+
+	pred := logql.SelectorPredicate(matchers, s)
+	if pred != nil {
+		whereFrag, err := exprFrag(pred)
+		if err != nil {
+			return "", nil, err
+		}
+		sb.Where(whereFrag)
+	}
+	if !start.IsZero() {
+		sb.Where(timeBoundFrag(s.TimestampColumn, ">=", start))
+	}
+	if !end.IsZero() {
+		sb.Where(timeBoundFrag(s.TimestampColumn, "<=", end))
+	}
+	sb.GroupBy(chsql.Col("labels"))
+
+	sqlStr, args := sb.Build()
+	return sqlStr, args, nil
+}
+
+// summariseDetectedLabels walks the distinct stream label sets returned
+// by buildDetectedLabelsSQL and aggregates per-key cardinality: for each
+// label key, the cardinality is the count of distinct values observed
+// across the row set. Empty values are dropped — Loki's own implementation
+// treats unset attributes as absent rather than as a distinct value.
+//
+// Results are sorted by label name for deterministic wire output;
+// Grafana's autocomplete consumes the response sorted regardless, so
+// keying the test assertions on order is safe.
+func summariseDetectedLabels(rows []map[string]string) []DetectedLabel {
+	values := map[string]map[string]struct{}{}
+	for _, m := range rows {
+		// Mirror /series: drop the OTel-dotted siblings so the result
+		// envelope matches the normalised Loki form Grafana expects.
+		m = dropOTelDottedLabels(m)
+		for k, v := range m {
+			if v == "" {
+				continue
+			}
+			set, ok := values[k]
+			if !ok {
+				set = map[string]struct{}{}
+				values[k] = set
+			}
+			set[v] = struct{}{}
+		}
+	}
+
+	out := make([]DetectedLabel, 0, len(values))
+	for k, set := range values {
+		out = append(out, DetectedLabel{
+			Label:       k,
+			Cardinality: uint64(len(set)),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Label < out[j].Label })
+	return out
+}

--- a/internal/api/loki/detected_labels_test.go
+++ b/internal/api/loki/detected_labels_test.go
@@ -1,0 +1,204 @@
+package loki_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/api/loki"
+)
+
+// TestDetectedLabels_HappyPath drives /detected_labels with a stub label-
+// set result and asserts the Grafana-shaped envelope:
+//
+//	{"detectedLabels": [{"label": "...", "cardinality": N}, ...]}
+//
+// — sorted by label, empty values dropped, distinct values counted.
+func TestDetectedLabels_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{
+		labelSets: []map[string]string{
+			{"job": "api", "instance": "host-1", "env": "prod"},
+			{"job": "api", "instance": "host-2", "env": "prod"},
+			{"job": "worker", "instance": "host-3", "env": "prod"},
+		},
+	}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL +
+		`/loki/api/v1/detected_labels?query=%7Bjob%3D%22api%22%7D&start=1717995600&end=1717999200`)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+
+	var out loki.DetectedLabelsData
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// Expected per-key cardinalities given the canned rows:
+	//   env=prod (1), instance=host-1/host-2/host-3 (3), job=api/worker (2)
+	want := map[string]uint64{"env": 1, "instance": 3, "job": 2}
+	if len(out.DetectedLabels) != len(want) {
+		t.Fatalf("got %d labels, want %d: %+v", len(out.DetectedLabels), len(want), out.DetectedLabels)
+	}
+	// Sorted by label name.
+	for i := 1; i < len(out.DetectedLabels); i++ {
+		if out.DetectedLabels[i-1].Label > out.DetectedLabels[i].Label {
+			t.Errorf("not sorted: %+v", out.DetectedLabels)
+		}
+	}
+	for _, dl := range out.DetectedLabels {
+		gotCard, ok := want[dl.Label]
+		if !ok {
+			t.Errorf("unexpected label %q", dl.Label)
+			continue
+		}
+		if dl.Cardinality != gotCard {
+			t.Errorf("label %q cardinality=%d want=%d", dl.Label, dl.Cardinality, gotCard)
+		}
+	}
+
+	// SQL sanity: ResourceAttributes column + GROUP BY + time bounds.
+	last := q.LastSQL()
+	if !strings.Contains(last, "`ResourceAttributes` AS `labels`") {
+		t.Errorf("missing labels projection in SQL: %q", last)
+	}
+	if !strings.Contains(last, "GROUP BY `labels`") {
+		t.Errorf("missing GROUP BY in SQL: %q", last)
+	}
+	if !strings.Contains(last, "toDateTime64(") {
+		t.Errorf("missing time bounds in SQL: %q", last)
+	}
+}
+
+// TestDetectedLabels_NoQuery — empty selector means "all streams in the
+// window"; the handler must not 400.
+func TestDetectedLabels_NoQuery(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{labelSets: []map[string]string{{"job": "api"}}}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + `/loki/api/v1/detected_labels?start=1717995600&end=1717999200`)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+
+	var out loki.DetectedLabelsData
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(out.DetectedLabels) != 1 || out.DetectedLabels[0].Label != "job" {
+		t.Fatalf("unexpected payload: %+v", out.DetectedLabels)
+	}
+	if out.DetectedLabels[0].Cardinality != 1 {
+		t.Fatalf("cardinality=%d want=1", out.DetectedLabels[0].Cardinality)
+	}
+}
+
+// TestDetectedLabels_Empty — no rows returned → empty list, not nil. JSON
+// encoders distinguish `[]` (the wire format Grafana expects) from `null`.
+func TestDetectedLabels_Empty(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{labelSets: nil}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + `/loki/api/v1/detected_labels`)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+
+	var raw json.RawMessage
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !strings.Contains(string(raw), `"detectedLabels":[]`) {
+		t.Fatalf("expected empty detectedLabels array, got %s", string(raw))
+	}
+}
+
+// TestDetectedLabels_BadInput — broken query / bad time → 400 with the
+// Loki JSON error envelope.
+func TestDetectedLabels_BadInput(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		url  string
+	}{
+		{"bad query", `/loki/api/v1/detected_labels?query=%7Bnot+a+selector&start=1&end=2`},
+		{"bad start", `/loki/api/v1/detected_labels?query=%7Bjob%3D%22api%22%7D&start=banana&end=2`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv := newServer(&stubQuerier{})
+			t.Cleanup(srv.Close)
+			resp, err := http.Get(srv.URL + tc.url)
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d", resp.StatusCode)
+			}
+		})
+	}
+}
+
+// TestLokiUnknownEndpoint_JSON404 — unmatched /loki/api/* paths should
+// return the JSON error envelope rather than Go's default text body.
+// This is the second half of the Grafana-11.2 fix in this PR: the
+// datasource probes feature endpoints, and on a miss the response body
+// must still parse as JSON.
+func TestLokiUnknownEndpoint_JSON404(t *testing.T) {
+	t.Parallel()
+
+	srv := newServer(&stubQuerier{})
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + `/loki/api/v1/this_route_does_not_exist`)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status=%d want=404", resp.StatusCode)
+	}
+	ct := resp.Header.Get("Content-Type")
+	if !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("Content-Type=%q want application/json*", ct)
+	}
+	var env struct {
+		Status    string `json:"status"`
+		ErrorType string `json:"errorType"`
+		Error     string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatalf("decode 404 body: %v", err)
+	}
+	if env.Status != "error" {
+		t.Errorf("status=%q want error", env.Status)
+	}
+	if env.Error == "" {
+		t.Errorf("empty error field")
+	}
+}

--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -121,10 +121,38 @@ func (h *Handler) Mount(mux *http.ServeMux) {
 	register("POST /loki/api/v1/series", h.handleSeries)
 	register("GET /loki/api/v1/detected_fields", h.handleDetectedFields)
 	register("POST /loki/api/v1/detected_fields", h.handleDetectedFields)
+	register("GET /loki/api/v1/detected_labels", h.handleDetectedLabels)
+	register("POST /loki/api/v1/detected_labels", h.handleDetectedLabels)
 	register("GET /loki/api/v1/patterns", h.handlePatterns)
 	register("POST /loki/api/v1/patterns", h.handlePatterns)
 	// /tail is WebSocket-upgrade only; no POST counterpart in upstream Loki.
 	register("GET /loki/api/v1/tail", h.handleTail)
+
+	// JSON-shaped 404 fallback for unmatched /loki/api/v1/* routes. Without
+	// this, http.ServeMux serves Go's plain-text "404 page not found"
+	// body, which trips Grafana 11.2+ — the Loki datasource probes feature
+	// endpoints (e.g. /detected_labels on older cerberus) and expects a
+	// JSON envelope even on misses. Registering the catch-all on the
+	// prefix keeps unrelated routes (/, /healthz, /metrics, the Prom and
+	// Tempo paths) untouched.
+	mux.HandleFunc("/loki/api/", h.handleLokiNotFound)
+}
+
+// handleLokiNotFound serves a JSON-shaped 404 for unmatched /loki/* paths.
+// Mirrors the wire envelope writeError emits on real 400/500s so Grafana
+// parses the body uniformly regardless of which route missed.
+func (h *Handler) handleLokiNotFound(w http.ResponseWriter, r *http.Request) {
+	writeError(w, http.StatusNotFound, ErrBadData, errLokiPathNotFound{path: r.URL.Path})
+}
+
+// errLokiPathNotFound is a tiny typed error so the 404 body carries the
+// request path back to the operator (Grafana surfaces the `error` field
+// in datasource health checks). Implementing error keeps writeError's
+// signature untouched.
+type errLokiPathNotFound struct{ path string }
+
+func (e errLokiPathNotFound) Error() string {
+	return "unknown loki endpoint: " + e.path
 }
 
 func (h *Handler) handleQuery(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

- Adds `/loki/api/v1/detected_labels` — Grafana 11.2+ probes this when populating the Loki datasource UI. The HAR capture in `~/workspace/localhost.har` shows the datasource health check failing because cerberus returned a Go-default plain-text 404 for the endpoint.
- Adds a JSON 404 fallback for unmatched `/loki/api/*` routes so the datasource probe always sees the standard `{"status":"error","errorType":"bad_data","error":...}` envelope.
- `/detected_fields` was already implemented in #515; this PR closes the remaining gap.

## SQL strategy

`/detected_labels` reuses the `/series` shape:
```
SELECT `ResourceAttributes` AS labels FROM `otel_logs`
WHERE <selector> AND Timestamp BETWEEN ? AND ?
GROUP BY labels
```
…and derives per-key cardinality client-side from the distinct label sets. This avoids a new `Querier` method and matches Loki's documented `{"detectedLabels":[{"label","cardinality"}]}` shape Grafana expects. All SQL flows through the typed `chsql.QueryBuilder` API — no raw strings.

## What's stubbed vs fully implemented

- `/detected_labels` — fully implemented (handler + SQL + 4 unit tests + 1 conformance test).
- `/detected_fields` — already implemented upstream.
- JSON 404 fallback — fully implemented (wires `mux.HandleFunc("/loki/api/", ...)` returning the Loki error envelope).

## Test plan

- [ ] `TestDetectedLabels_HappyPath` / `_NoQuery` / `_Empty` / `_BadInput` pass.
- [ ] `TestConformance_LokiDetectedLabelsWire` pins the wire envelope.
- [ ] `TestLokiUnknownEndpoint_JSON404` asserts the 404 envelope shape.
- [ ] CI `check` + `lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)