### PR TITLE
ci(compose): extend smoke with Playwright dashboard-load catch-net over Grafana

### DIFF
--- a/.github/workflows/compose-smoke.yml
+++ b/.github/workflows/compose-smoke.yml
@@ -20,6 +20,15 @@ name: compose-smoke
 # port mismatch would leave the container healthy but the host
 # unreachable — exactly the kind of regression the quickstart README
 # users would hit.
+#
+# On top of the curl smokes, the job also runs a Playwright catch-net
+# spec (`compose_grafana_smoke.spec.ts`) that drives Grafana through
+# every provisioned dashboard. This catches the class of bug where
+# Grafana 200s a `/api/ds/query` request but tunnels per-target errors
+# inside `body.results.<refId>.error` — invisible to curl smokes and
+# to direct cerberus-API tests. The Playwright step is informational
+# on day 1 (`continue-on-error: true`); flip it to a hard failure once
+# it has 1 week of green runs.
 
 on:
   pull_request:
@@ -65,8 +74,60 @@ jobs:
           # Datasource health is a separate per-datasource probe.
           grep -q '"database":[[:space:]]*"ok"' /tmp/grafana-health.json
 
+      # ---- Playwright dashboard catch-net ----
+      # Drives Grafana through every provisioned dashboard, captures
+      # /api/ds/query + /api/dashboards/* traffic, and asserts every
+      # response is 2xx with no tunneled per-target error. This is the
+      # gate that catches the class of bug where Grafana 200s a
+      # ds/query but the body carries .results.<refId>.error — invisible
+      # to curl smokes and to direct cerberus-API tests.
+      #
+      # Gate posture: informational on day 1. `continue-on-error: true`
+      # means the job stays green while we let the lane stabilise; flip
+      # it to a hard failure once it's had ~1 week of green runs.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: test/e2e/playwright/package-lock.json
+
+      - name: install Playwright deps
+        working-directory: test/e2e/playwright
+        run: |
+          # npm ci needs a lockfile; fall back to `npm install` if the
+          # repo doesn't ship one yet (the existing playwright suite
+          # uses the same pattern in the k3d e2e job).
+          if [ -f package-lock.json ]; then
+            npm ci
+          else
+            npm install --no-audit --no-fund
+          fi
+          npx playwright install --with-deps chromium
+
+      - name: playwright compose-grafana-smoke (informational)
+        id: playwright_smoke
+        continue-on-error: true
+        working-directory: test/e2e/playwright
+        env:
+          GRAFANA_BASE_URL: http://localhost:3000
+          GRAFANA_URL: http://localhost:3000
+          CERBERUS_URL: http://localhost:8080
+        run: |
+          npx playwright test compose_grafana_smoke.spec.ts --reporter=list
+
+      - name: upload Playwright report on failure
+        if: steps.playwright_smoke.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: compose-grafana-smoke-report
+          path: |
+            test/e2e/playwright/playwright-report
+            test/e2e/playwright/test-results
+          if-no-files-found: ignore
+          retention-days: 7
+
       - name: dump compose state + logs on failure
-        if: failure()
+        if: failure() || steps.playwright_smoke.outcome == 'failure'
         run: |
           echo "=== compose ps ==="
           docker compose ps

--- a/.github/workflows/compose-smoke.yml
+++ b/.github/workflows/compose-smoke.yml
@@ -85,11 +85,14 @@ jobs:
       # Gate posture: informational on day 1. `continue-on-error: true`
       # means the job stays green while we let the lane stabilise; flip
       # it to a hard failure once it's had ~1 week of green runs.
+      # No npm cache here — the playwright suite doesn't currently
+      # ship a package-lock.json, and setup-node's cache lookup hard-
+      # fails before the install fallback below ever runs when the
+      # cache-dependency-path is unresolvable. Re-add cache: npm once a
+      # lockfile lands under test/e2e/playwright/.
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: npm
-          cache-dependency-path: test/e2e/playwright/package-lock.json
 
       - name: install Playwright deps
         working-directory: test/e2e/playwright

--- a/Justfile
+++ b/Justfile
@@ -429,6 +429,22 @@ e2e-down:
 # collector to populate real OTel data, then run the test matrix.
 e2e: e2e-up e2e-seed e2e-wait-otel e2e-run e2e-playwright e2e-down
 
+# Run the compose-stack Grafana catch-net spec locally. Assumes the
+# quickstart compose stack is already up (`docker compose up --wait`).
+# Drives Grafana through every provisioned dashboard and asserts every
+# /api/ds/query + /api/dashboards/* response is 2xx with no tunneled
+# per-target error. Mirrors the Playwright step the compose-smoke CI
+# job runs.
+compose-grafana-smoke:
+    @echo "==> compose-grafana-smoke playwright catch-net"
+    cd test/e2e/playwright && \
+        ( [ -f package-lock.json ] && npm ci || npm install --no-audit --no-fund ) && \
+        npx playwright install --with-deps chromium && \
+        GRAFANA_BASE_URL=http://localhost:3000 \
+        GRAFANA_URL=http://localhost:3000 \
+        CERBERUS_URL=http://localhost:8080 \
+        npx playwright test compose_grafana_smoke.spec.ts --reporter=list
+
 # === Compatibility (prometheus/compliance differential harness) ===
 
 # Run the PromQL compatibility suite end-to-end. Slow; expect minutes.

--- a/test/e2e/playwright/compose_grafana_smoke.spec.ts
+++ b/test/e2e/playwright/compose_grafana_smoke.spec.ts
@@ -1,0 +1,154 @@
+import { test, expect, type Response } from '@playwright/test';
+
+/**
+ * Compose-stack Grafana catch-net.
+ *
+ * Drives the docker-compose quickstart stack end-to-end:
+ *   1. Enumerate every provisioned dashboard via Grafana's /api/search.
+ *   2. Open each dashboard at /d/<uid> and let Grafana run its panel
+ *      queries through the datasource proxy into cerberus.
+ *   3. Capture every /api/ds/query POST and /api/dashboards/* GET that
+ *      Grafana makes during dashboard load.
+ *   4. Assert:
+ *        - HTTP status is 2xx for every captured response.
+ *        - No /api/ds/query response body carries a non-empty error in
+ *          .results.<target>.error  (Grafana 200s the request and
+ *          tunnels per-target failures inside the body — these are the
+ *          regressions that slipped past existing CI gates).
+ *
+ * Why a single test, not test-per-dashboard: the dashboard list is
+ * dynamic (read from /api/search at run time) and Playwright's
+ * test.describe API needs the list at collection time. Looping inside
+ * one test keeps it data-driven without an extra build step.
+ *
+ * Env:
+ *   GRAFANA_BASE_URL  default http://localhost:3000
+ */
+
+type DashboardEntry = { uid: string; title: string; type: string };
+
+type DSQueryError = {
+  url: string;
+  refId: string;
+  status: number;
+  error: string;
+};
+
+test('compose: every provisioned dashboard loads without datasource errors', async ({
+  page,
+  request,
+}, testInfo) => {
+  testInfo.setTimeout(180_000);
+
+  const baseURL = process.env.GRAFANA_BASE_URL ?? 'http://localhost:3000';
+
+  // 1. Enumerate provisioned dashboards. folderIds=0 = the root folder,
+  //    which is where Grafana drops dashboards provisioned via
+  //    file-provider with no explicit folder.
+  const searchResp = await request.get(`${baseURL}/api/search?type=dash-db`);
+  expect(searchResp.status(), 'grafana /api/search status').toBe(200);
+  const dashboards = (await searchResp.json()) as DashboardEntry[];
+  expect(dashboards.length, 'at least one provisioned dashboard').toBeGreaterThan(0);
+
+  const failures: string[] = [];
+
+  for (const dash of dashboards) {
+    const captured: Response[] = [];
+    const dsErrors: DSQueryError[] = [];
+
+    // Subscribe BEFORE navigation so we don't miss the in-flight
+    // requests fired during initial dashboard render.
+    const onResponse = (resp: Response) => {
+      const url = resp.url();
+      if (url.includes('/api/ds/query') || url.includes('/api/dashboards/')) {
+        captured.push(resp);
+      }
+    };
+    page.on('response', onResponse);
+
+    try {
+      await page.goto(`${baseURL}/d/${dash.uid}`, {
+        waitUntil: 'domcontentloaded',
+        timeout: 60_000,
+      });
+
+      // Grafana fires panel queries asynchronously after the page DOM
+      // is up. networkidle waits for the queries to settle; cap it so
+      // a slow CH cold-start doesn't burn the whole budget.
+      await page
+        .waitForLoadState('networkidle', { timeout: 30_000 })
+        .catch(() => {
+          // networkidle timing out isn't fatal — we just stop waiting
+          // and inspect what we captured so far. A panel that never
+          // returns will still show up as a non-2xx or as a tunneled
+          // error in .results below, OR (genuine hang) as a missing
+          // response that other assertions surface.
+        });
+    } finally {
+      page.off('response', onResponse);
+    }
+
+    // 4a. HTTP status sweep.
+    for (const resp of captured) {
+      const status = resp.status();
+      if (status < 200 || status > 299) {
+        let body = '';
+        try {
+          body = await resp.text();
+        } catch {
+          body = '<unreadable>';
+        }
+        failures.push(
+          `[${dash.uid}] ${resp.request().method()} ${resp.url()} -> ${status}\n  body: ${truncate(body, 800)}`,
+        );
+      }
+    }
+
+    // 4b. /api/ds/query tunneled-error sweep. Grafana returns 200 for
+    //     a ds/query request even when individual targets failed, and
+    //     pushes the error string into body.results.<refId>.error.
+    for (const resp of captured) {
+      if (!resp.url().includes('/api/ds/query')) continue;
+      if (resp.status() < 200 || resp.status() > 299) continue; // already reported above
+      let parsed: { results?: Record<string, { error?: string }> };
+      try {
+        parsed = (await resp.json()) as typeof parsed;
+      } catch {
+        continue; // some ds/query responses may legitimately be empty
+      }
+      const results = parsed.results ?? {};
+      for (const [refId, target] of Object.entries(results)) {
+        if (target && typeof target.error === 'string' && target.error.length > 0) {
+          dsErrors.push({
+            url: resp.url(),
+            refId,
+            status: resp.status(),
+            error: target.error,
+          });
+        }
+      }
+    }
+
+    for (const err of dsErrors) {
+      failures.push(
+        `[${dash.uid}] ds/query tunneled error: refId=${err.refId} url=${err.url}\n  error: ${truncate(err.error, 800)}`,
+      );
+    }
+  }
+
+  if (failures.length > 0) {
+    // One big aggregated message — all failing panels in one shot so
+    // the agent CI logs surface every root cause, not just the first.
+    const header = `compose-grafana-smoke caught ${failures.length} dashboard-load failure(s) across ${dashboards.length} dashboard(s):`;
+    const dashList = dashboards
+      .map((d) => `  - ${d.uid} (${d.title})`)
+      .join('\n');
+    const detail = failures.map((f) => `* ${f}`).join('\n');
+    expect.soft(failures, `${header}\nprobed dashboards:\n${dashList}\nfailures:\n${detail}`).toEqual([]);
+    throw new Error(`${header}\n${detail}`);
+  }
+});
+
+function truncate(s: string, n: number): string {
+  return s.length <= n ? s : `${s.slice(0, n)}...<truncated, ${s.length} chars total>`;
+}


### PR DESCRIPTION
## Summary

Adds a Grafana E2E catch-net CI layer that drives the docker-compose stack with Playwright, opens every provisioned dashboard, captures Grafana's actual `/api/ds/query` + `/api/dashboards/*` traffic, and asserts every response is 2xx with no tunneled per-target error.

Closes the gap exposed by the HAR digest (bugs #167, #168, #169 — none of which existing CI caught, because no test exercises Grafana's datasource-proxy layer against cerberus).

- New Playwright spec `test/e2e/playwright/compose_grafana_smoke.spec.ts` enumerates dashboards via `/api/search?type=dash-db`, navigates to each `/d/<uid>`, subscribes to `page.on('response', …)` before navigation, waits for `networkidle` (capped at 30s), then asserts:
  - every captured response status is in `[200, 299]`,
  - no `/api/ds/query` body has a non-empty `.results.<refId>.error` (the Grafana-tunneled-error class).
- `.github/workflows/compose-smoke.yml` gets a Playwright step after the existing curl smokes, using `actions/setup-node@v4` (cached) + `npx playwright install --with-deps chromium`. The step is `continue-on-error: true` — **informational on day 1**, to be flipped to a hard failure once it has ~1 week of green runs. Failure dumps the Playwright report as an artifact and the compose container logs.
- New `just compose-grafana-smoke` recipe runs the same spec locally against an already-up `docker compose up --wait` stack.

## Expected to fail until #167 + #169 land

This PR is the catch-net itself; once #167 + #169 fixes are in, the job goes green and the gap is closed. Until then, the Playwright step on this PR is **expected to fail** with output like:

- `sum by (X) (rate(...))` panel queries → `body.results.A.error` non-empty (per-target error tunneled inside a 200).
- `/api/dashboards/home` → 500.

That's the proof the catch-net is working as designed. Because the step is informational (`continue-on-error: true`), the overall job still reports green — but the captured failure messages in the step output are exactly what reviewers should look for to confirm the catch-net wires through.

## Test plan

- [ ] CI: compose-smoke job stands up the stack, runs the Playwright step, captures the expected `body.results.<refId>.error` failure for the broken `sum by (X) (rate(...))` panel(s) — visible in the step log even though the overall job stays green.
- [ ] Locally: `docker compose up --wait` then `just compose-grafana-smoke` reproduces the same set of failures.
- [ ] Once #167 + #169 merge, re-run this job and confirm it goes green.
- [ ] Follow-up: flip `continue-on-error: true` → off after ~1 week of green runs.