### PR TITLE
refactor(telemetry): rename cerberus.X.Y → cerberus_X_Y so dashboards match the stored MetricName

### DIFF
--- a/cmd/cerberus/otel_metrics_test.go
+++ b/cmd/cerberus/otel_metrics_test.go
@@ -48,12 +48,12 @@ func TestTelemetryInstall_ManualReader(t *testing.T) {
 	}
 
 	want := map[string]bool{
-		"cerberus.queries.total":                   false,
-		"cerberus.queries.duration.seconds":        false,
-		"cerberus.pipeline.stage.duration.seconds": false,
-		"cerberus.optimizer.rules_applied":         false,
-		"cerberus.clickhouse.rows_read":            false,
-		"cerberus.clickhouse.bytes_read":           false,
+		"cerberus_queries_total":                   false,
+		"cerberus_queries_duration_seconds":        false,
+		"cerberus_pipeline_stage_duration_seconds": false,
+		"cerberus_optimizer_rules_applied":         false,
+		"cerberus_clickhouse_rows_read":            false,
+		"cerberus_clickhouse_bytes_read":           false,
 	}
 	for _, sm := range rm.ScopeMetrics {
 		if !strings.HasSuffix(sm.Scope.Name, "internal/telemetry") {

--- a/internal/telemetry/contract_test.go
+++ b/internal/telemetry/contract_test.go
@@ -37,12 +37,12 @@ func TestMetricNames_PublicContract(t *testing.T) {
 	}
 
 	want := map[string]bool{
-		"cerberus.queries.total":                   false,
-		"cerberus.queries.duration.seconds":        false,
-		"cerberus.pipeline.stage.duration.seconds": false,
-		"cerberus.optimizer.rules_applied":         false,
-		"cerberus.clickhouse.rows_read":            false,
-		"cerberus.clickhouse.bytes_read":           false,
+		"cerberus_queries_total":                   false,
+		"cerberus_queries_duration_seconds":        false,
+		"cerberus_pipeline_stage_duration_seconds": false,
+		"cerberus_optimizer_rules_applied":         false,
+		"cerberus_clickhouse_rows_read":            false,
+		"cerberus_clickhouse_bytes_read":           false,
 	}
 	for _, sm := range rm.ScopeMetrics {
 		if !strings.HasSuffix(sm.Scope.Name, "internal/telemetry") {
@@ -82,12 +82,12 @@ func TestMetricUnits_PublicContract(t *testing.T) {
 	}
 
 	wantUnits := map[string]string{
-		"cerberus.queries.total":                   "{query}",
-		"cerberus.queries.duration.seconds":        "s",
-		"cerberus.pipeline.stage.duration.seconds": "s",
-		"cerberus.optimizer.rules_applied":         "{rule}",
-		"cerberus.clickhouse.rows_read":            "{row}",
-		"cerberus.clickhouse.bytes_read":           "By",
+		"cerberus_queries_total":                   "{query}",
+		"cerberus_queries_duration_seconds":        "s",
+		"cerberus_pipeline_stage_duration_seconds": "s",
+		"cerberus_optimizer_rules_applied":         "{rule}",
+		"cerberus_clickhouse_rows_read":            "{row}",
+		"cerberus_clickhouse_bytes_read":           "By",
 	}
 	for _, sm := range rm.ScopeMetrics {
 		if !strings.HasSuffix(sm.Scope.Name, "internal/telemetry") {
@@ -129,7 +129,7 @@ func TestAttributeKeys_PublicContract(t *testing.T) {
 		}
 		for _, m := range sm.Metrics {
 			switch m.Name {
-			case "cerberus.queries.total":
+			case "cerberus_queries_total":
 				sum := m.Data.(metricdata.Sum[int64])
 				if len(sum.DataPoints) == 0 {
 					t.Fatalf("queries.total: empty")
@@ -140,7 +140,7 @@ func TestAttributeKeys_PublicContract(t *testing.T) {
 						t.Errorf("queries.total: missing attr %q", key)
 					}
 				}
-			case "cerberus.pipeline.stage.duration.seconds":
+			case "cerberus_pipeline_stage_duration_seconds":
 				hist := m.Data.(metricdata.Histogram[float64])
 				if len(hist.DataPoints) == 0 {
 					t.Fatalf("stage.duration: empty")
@@ -230,7 +230,7 @@ func TestReset_RebuildsInstrumentsAgainstNewProvider(t *testing.T) {
 			continue
 		}
 		for _, m := range sm.Metrics {
-			if m.Name != "cerberus.queries.total" {
+			if m.Name != "cerberus_queries_total" {
 				continue
 			}
 			sum := m.Data.(metricdata.Sum[int64])
@@ -267,7 +267,7 @@ func TestObserveQuery_RoutePopulatedFromExplicitArgument(t *testing.T) {
 			continue
 		}
 		for _, m := range sm.Metrics {
-			if m.Name != "cerberus.queries.total" {
+			if m.Name != "cerberus_queries_total" {
 				continue
 			}
 			sum := m.Data.(metricdata.Sum[int64])

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -137,31 +137,31 @@ func Reset() {
 // rename that violates the syntax surfaces loudly at first use.
 func mustBuild(meter metric.Meter) *Instruments {
 	queriesTotal, err := meter.Int64Counter(
-		"cerberus.queries.total",
+		"cerberus_queries_total",
 		metric.WithDescription("Total queries handled, by language / route / result."),
 		metric.WithUnit("{query}"),
 	)
 	if err != nil {
-		panic("telemetry: build queries.total: " + err.Error())
+		panic("telemetry: build queries_total: " + err.Error())
 	}
 	queryDuration, err := meter.Float64Histogram(
-		"cerberus.queries.duration.seconds",
+		"cerberus_queries_duration_seconds",
 		metric.WithDescription("End-to-end query wall-clock, seconds."),
 		metric.WithUnit("s"),
 	)
 	if err != nil {
-		panic("telemetry: build queries.duration: " + err.Error())
+		panic("telemetry: build queries_duration: " + err.Error())
 	}
 	stageDuration, err := meter.Float64Histogram(
-		"cerberus.pipeline.stage.duration.seconds",
+		"cerberus_pipeline_stage_duration_seconds",
 		metric.WithDescription("Per-stage pipeline wall-clock, seconds."),
 		metric.WithUnit("s"),
 	)
 	if err != nil {
-		panic("telemetry: build stage.duration: " + err.Error())
+		panic("telemetry: build stage_duration: " + err.Error())
 	}
 	rulesApplied, err := meter.Int64Histogram(
-		"cerberus.optimizer.rules_applied",
+		"cerberus_optimizer_rules_applied",
 		metric.WithDescription("Optimizer rule invocations that changed the plan."),
 		metric.WithUnit("{rule}"),
 	)
@@ -169,7 +169,7 @@ func mustBuild(meter metric.Meter) *Instruments {
 		panic("telemetry: build rules_applied: " + err.Error())
 	}
 	chRows, err := meter.Int64Histogram(
-		"cerberus.clickhouse.rows_read",
+		"cerberus_clickhouse_rows_read",
 		metric.WithDescription("ClickHouse rows read per query (sum of Progress events)."),
 		metric.WithUnit("{row}"),
 	)
@@ -177,7 +177,7 @@ func mustBuild(meter metric.Meter) *Instruments {
 		panic("telemetry: build rows_read: " + err.Error())
 	}
 	chBytes, err := meter.Int64Histogram(
-		"cerberus.clickhouse.bytes_read",
+		"cerberus_clickhouse_bytes_read",
 		metric.WithDescription("ClickHouse bytes read per query (sum of Progress events)."),
 		metric.WithUnit("By"),
 	)
@@ -232,7 +232,8 @@ func (t *StageTimer) Done(ctx context.Context) {
 	if t == nil {
 		return
 	}
-	Get().StageDuration.Record(ctx, time.Since(t.start).Seconds(),
+	Get().StageDuration.Record(
+		ctx, time.Since(t.start).Seconds(),
 		metric.WithAttributes(AttrStage.String(t.stage)),
 	)
 }

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -66,8 +66,8 @@ func metricNames(sm metricdata.ScopeMetrics) []string {
 
 // TestObserveQuery_RecordsCounterAndDuration covers the QueryTimer
 // happy path: a single Done(ResultOK) call must bump
-// cerberus.queries.total by one and record a point on
-// cerberus.queries.duration.seconds with matching attributes.
+// cerberus_queries_total by one and record a point on
+// cerberus_queries_duration_seconds with matching attributes.
 func TestObserveQuery_RecordsCounterAndDuration(t *testing.T) {
 	reader := installManualReader(t)
 
@@ -75,7 +75,7 @@ func TestObserveQuery_RecordsCounterAndDuration(t *testing.T) {
 	tm.Done(t.Context(), telemetry.ResultOK)
 
 	sm := collect(t, reader)
-	total := findMetric(t, sm, "cerberus.queries.total")
+	total := findMetric(t, sm, "cerberus_queries_total")
 	sum, ok := total.Data.(metricdata.Sum[int64])
 	if !ok {
 		t.Fatalf("queries.total: unexpected data type %T", total.Data)
@@ -95,7 +95,7 @@ func TestObserveQuery_RecordsCounterAndDuration(t *testing.T) {
 		t.Errorf("result attr: got %v ok=%v", v.AsString(), ok)
 	}
 
-	dur := findMetric(t, sm, "cerberus.queries.duration.seconds")
+	dur := findMetric(t, sm, "cerberus_queries_duration_seconds")
 	hist, ok := dur.Data.(metricdata.Histogram[float64])
 	if !ok {
 		t.Fatalf("queries.duration: unexpected data type %T", dur.Data)
@@ -121,7 +121,7 @@ func TestObserveStage_RecordsHistogram(t *testing.T) {
 	}
 
 	sm := collect(t, reader)
-	m := findMetric(t, sm, "cerberus.pipeline.stage.duration.seconds")
+	m := findMetric(t, sm, "cerberus_pipeline_stage_duration_seconds")
 	hist, ok := m.Data.(metricdata.Histogram[float64])
 	if !ok {
 		t.Fatalf("stage.duration: unexpected data type %T", m.Data)
@@ -141,7 +141,7 @@ func TestRecordRulesApplied_RecordsHistogram(t *testing.T) {
 	telemetry.RecordRulesApplied(t.Context(), 3)
 
 	sm := collect(t, reader)
-	m := findMetric(t, sm, "cerberus.optimizer.rules_applied")
+	m := findMetric(t, sm, "cerberus_optimizer_rules_applied")
 	hist, ok := m.Data.(metricdata.Histogram[int64])
 	if !ok {
 		t.Fatalf("rules_applied: unexpected data type %T", m.Data)
@@ -159,12 +159,12 @@ func TestRecordClickHouseProgress(t *testing.T) {
 	telemetry.RecordClickHouseProgress(t.Context(), "promql", 1234, 56789)
 
 	sm := collect(t, reader)
-	rows := findMetric(t, sm, "cerberus.clickhouse.rows_read")
+	rows := findMetric(t, sm, "cerberus_clickhouse_rows_read")
 	rh, ok := rows.Data.(metricdata.Histogram[int64])
 	if !ok || len(rh.DataPoints) != 1 || rh.DataPoints[0].Sum != 1234 {
 		t.Fatalf("rows_read: got %+v want sum=1234", rh.DataPoints)
 	}
-	bytes := findMetric(t, sm, "cerberus.clickhouse.bytes_read")
+	bytes := findMetric(t, sm, "cerberus_clickhouse_bytes_read")
 	bh, ok := bytes.Data.(metricdata.Histogram[int64])
 	if !ok || len(bh.DataPoints) != 1 || bh.DataPoints[0].Sum != 56789 {
 		t.Fatalf("bytes_read: got %+v want sum=56789", bh.DataPoints)
@@ -195,7 +195,7 @@ func TestQueryMiddleware_ResultOK(t *testing.T) {
 	_ = resp.Body.Close()
 
 	sm := collect(t, reader)
-	total := findMetric(t, sm, "cerberus.queries.total")
+	total := findMetric(t, sm, "cerberus_queries_total")
 	sum := total.Data.(metricdata.Sum[int64])
 	if len(sum.DataPoints) != 1 {
 		t.Fatalf("queries.total DPs: got %d want 1", len(sum.DataPoints))
@@ -229,7 +229,7 @@ func TestQueryMiddleware_ResultError(t *testing.T) {
 	_ = resp.Body.Close()
 
 	sm := collect(t, reader)
-	total := findMetric(t, sm, "cerberus.queries.total")
+	total := findMetric(t, sm, "cerberus_queries_total")
 	sum := total.Data.(metricdata.Sum[int64])
 	if len(sum.DataPoints) != 1 {
 		t.Fatalf("queries.total DPs: got %d want 1", len(sum.DataPoints))


### PR DESCRIPTION
## Summary

OTel-native dotted metric names (`cerberus.queries.total`) land in ClickHouse's `otel_metrics_sum.MetricName` verbatim — dots and all — but the cerberus-self Grafana dashboard's PromQL queries use the Prometheus-canonical underscored form (`cerberus_queries_total`). Result: every panel in `cerberus-self.json` renders "No data" because the `MetricName LIKE 'cerberus_%'` filter on the underscored query never matches the dotted rows in storage.

Fix at the emit site so the names cerberus writes match the names the dashboard reads.

## Renamed metrics (6)

| Before | After |
|---|---|
| `cerberus.queries.total` | `cerberus_queries_total` |
| `cerberus.queries.duration.seconds` | `cerberus_queries_duration_seconds` |
| `cerberus.pipeline.stage.duration.seconds` | `cerberus_pipeline_stage_duration_seconds` |
| `cerberus.optimizer.rules_applied` | `cerberus_optimizer_rules_applied` |
| `cerberus.clickhouse.rows_read` | `cerberus_clickhouse_rows_read` |
| `cerberus.clickhouse.bytes_read` | `cerberus_clickhouse_bytes_read` |

## Out of scope

- **Attribute keys** (`cerberus.ql`, `cerberus.route`, `cerberus.query`, `cerberus.plan_node_count`, `cerberus.rules_applied`, `cerberus.sql_length`) keep their dotted OTel-native form — they're labels, not metric names, and Grafana label autocomplete handles them.
- **External OTel-imported metric names** like `http.server.request.duration` from `otelhttp` middleware — emitted by upstream instrumentation, not cerberus's own.

## Files touched (4)

- `internal/telemetry/metrics.go` — the six instrument names at construction.
- `internal/telemetry/contract_test.go` — public-contract pin tests re-pinned to underscored form.
- `internal/telemetry/metrics_test.go` — unit tests re-pinned.
- `cmd/cerberus/otel_metrics_test.go` — integration test re-pinned.

The cerberus-self dashboard JSON was already underscored — no dashboard edit needed.

## Test plan

- [x] `grep -rE '"cerberus\.[a-z._]+"' internal/telemetry/ internal/cerbtrace/` returns only attribute-key hits, no metric-name hits.
- [ ] CI `check` + `lint` green.
- [ ] Post-merge smoke: `docker compose up --wait` + 30s warm → `SELECT DISTINCT MetricName FROM otel_metrics_sum WHERE MetricName LIKE 'cerberus_%'` returns the renamed metrics → dashboard panels render data.