### PR TITLE
feat(telemetry): instrument cerberus_query_inflight + relabel cerberus_admit_rejected_total

### DIFF
--- a/internal/api/admit/admit.go
+++ b/internal/api/admit/admit.go
@@ -40,11 +40,43 @@ import (
 // drilling into rejection events.
 const meterName = "github.com/tsouza/cerberus/internal/api/admit"
 
-// attrHead labels the rejection counter with the API head whose
-// limiter rejected the request — "prom" / "loki" / "tempo". The
-// values match the head identifiers used elsewhere in cerberus so
-// dashboards can join admit rejections against query totals.
-const attrHead = attribute.Key("cerberus.admit.head")
+// attrQL labels the rejection counter with the query language the
+// limiter is fronting — "promql" / "logql" / "traceql". Mirrors the
+// cerberus.ql attribute set by internal/telemetry on the
+// per-query counters, so the cerberus-self dashboard's
+// `sum by (cerberus_ql, reason) (rate(cerberus_admit_rejected_total[5m]))`
+// panel resolves consistently across both metric sources.
+const attrQL = attribute.Key("cerberus.ql")
+
+// attrReason labels the rejection counter with the rejection cause.
+// The limiter currently has exactly one rejection path: the weighted
+// semaphore was at its cap when Acquire ran. Future paths (e.g.,
+// queue-timeout, route-disabled) should add to this vocabulary
+// rather than overload an existing value.
+const attrReason = attribute.Key("reason")
+
+// ReasonCapExceeded is emitted on the reason attribute when Acquire
+// is called while the limiter's semaphore is saturated. It's the only
+// rejection path the limiter has today.
+const ReasonCapExceeded = "cap_exceeded"
+
+// headToQL maps the API-head identifier ("prom" / "loki" / "tempo")
+// used to construct a Limiter onto the query-language string
+// ("promql" / "logql" / "traceql") cerberus uses everywhere else in
+// its telemetry. Unknown heads fall through to the raw value so a
+// future head ("otlp"?) still produces a usable metric label.
+func headToQL(head string) string {
+	switch head {
+	case "prom":
+		return "promql"
+	case "loki":
+		return "logql"
+	case "tempo":
+		return "traceql"
+	default:
+		return head
+	}
+}
 
 // Limiter caps concurrent in-flight requests for one API head. The
 // zero value is unusable; build via New. A nil *Limiter is a sentinel
@@ -60,6 +92,7 @@ const attrHead = attribute.Key("cerberus.admit.head")
 // every callsite today uses weight 1.
 type Limiter struct {
 	head     string
+	ql       string
 	sem      *semaphore.Weighted
 	rejected metric.Int64Counter
 }
@@ -89,8 +122,12 @@ func newWithProvider(head string, cap int, mp metric.MeterProvider) *Limiter {
 	}
 	meter := mp.Meter(meterName)
 	rejected, err := meter.Int64Counter(
-		"cerberus.admit.rejected_total",
-		metric.WithDescription("Requests rejected by the per-handler concurrency cap."),
+		"cerberus_admit_rejected_total",
+		metric.WithDescription(
+			"Requests rejected by the per-handler concurrency cap. "+
+				"Labels: cerberus.ql (promql / logql / traceql), "+
+				"reason (cap_exceeded).",
+		),
 		metric.WithUnit("{request}"),
 	)
 	if err != nil {
@@ -101,6 +138,7 @@ func newWithProvider(head string, cap int, mp metric.MeterProvider) *Limiter {
 	}
 	return &Limiter{
 		head:     head,
+		ql:       headToQL(head),
 		sem:      semaphore.NewWeighted(int64(cap)),
 		rejected: rejected,
 	}
@@ -117,7 +155,10 @@ func (l *Limiter) Acquire(ctx context.Context) (release func(), ok bool) {
 		return func() {}, true
 	}
 	if !l.sem.TryAcquire(1) {
-		l.rejected.Add(ctx, 1, metric.WithAttributes(attrHead.String(l.head)))
+		l.rejected.Add(ctx, 1, metric.WithAttributes(
+			attrQL.String(l.ql),
+			attrReason.String(ReasonCapExceeded),
+		))
 		return func() {}, false
 	}
 	released := false

--- a/internal/api/admit/admit_test.go
+++ b/internal/api/admit/admit_test.go
@@ -266,9 +266,10 @@ func TestRejectedCounter(t *testing.T) {
 	}
 	var found bool
 	var sum int64
+	var sawQL, sawReason bool
 	for _, sm := range rm.ScopeMetrics {
 		for _, m := range sm.Metrics {
-			if m.Name != "cerberus.admit.rejected_total" {
+			if m.Name != "cerberus_admit_rejected_total" {
 				continue
 			}
 			found = true
@@ -278,14 +279,26 @@ func TestRejectedCounter(t *testing.T) {
 			}
 			for _, dp := range sumData.DataPoints {
 				sum += dp.Value
+				if v, ok := dp.Attributes.Value("cerberus.ql"); ok && v.AsString() == "promql" {
+					sawQL = true
+				}
+				if v, ok := dp.Attributes.Value("reason"); ok && v.AsString() == admit.ReasonCapExceeded {
+					sawReason = true
+				}
 			}
 		}
 	}
 	if !found {
-		t.Fatalf("cerberus.admit.rejected_total not exported")
+		t.Fatalf("cerberus_admit_rejected_total not exported")
 	}
 	if sum != 2 {
 		t.Fatalf("rejected_total: want 2, got %d", sum)
+	}
+	if !sawQL {
+		t.Errorf("rejected_total: missing cerberus.ql=promql attribute")
+	}
+	if !sawReason {
+		t.Errorf("rejected_total: missing reason=%q attribute", admit.ReasonCapExceeded)
 	}
 }
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -207,6 +207,12 @@ func (e *Engine) QueryPlan(ctx context.Context, lang Lang, plan chplan.Node, met
 		return Result{}, fmt.Errorf("engine: nil plan")
 	}
 
+	// Inflight bookkeeping. Deferred decrement balances the counter
+	// across panics, early returns, and context cancellations. Sibling
+	// instrumentation lives on QueryPlanCursor so the streaming path
+	// gets the same gauge bump.
+	defer telemetry.ObserveQueryInflight(ctx, lang.Name())()
+
 	// Wrap-projection. The adapter owns the per-language switch
 	// (canonical vs. derived vs. structural-join shape); the engine
 	// applies it unconditionally.
@@ -311,6 +317,13 @@ func (e *Engine) QueryPlanCursor(ctx context.Context, lang Lang, plan chplan.Nod
 	if !ok {
 		return CursorResult{}, fmt.Errorf("engine: client does not implement CursorQuerier")
 	}
+
+	// Inflight bookkeeping — symmetrical with QueryPlan so the gauge
+	// covers both the eager and streaming pipelines. Cursor consumers
+	// hold the gauge for the duration of the engine call only (until
+	// QueryPlanCursor returns); the cursor's subsequent drain isn't
+	// "in engine" anymore and shouldn't double-count.
+	defer telemetry.ObserveQueryInflight(ctx, lang.Name())()
 
 	plan = lang.ProjectSamples(plan, meta)
 	if !meta.IsTraceByID {

--- a/internal/telemetry/contract_test.go
+++ b/internal/telemetry/contract_test.go
@@ -30,6 +30,7 @@ func TestMetricNames_PublicContract(t *testing.T) {
 	telemetry.ObserveStage(telemetry.StageExecute).Done(t.Context())
 	telemetry.RecordRulesApplied(t.Context(), 1)
 	telemetry.RecordClickHouseProgress(t.Context(), "promql", 100, 2000)
+	telemetry.ObserveQueryInflight(t.Context(), "promql")()
 
 	var rm metricdata.ResourceMetrics
 	if err := reader.Collect(t.Context(), &rm); err != nil {
@@ -43,6 +44,7 @@ func TestMetricNames_PublicContract(t *testing.T) {
 		"cerberus_optimizer_rules_applied":         false,
 		"cerberus_clickhouse_rows_read":            false,
 		"cerberus_clickhouse_bytes_read":           false,
+		"cerberus_query_inflight":                  false,
 	}
 	for _, sm := range rm.ScopeMetrics {
 		if !strings.HasSuffix(sm.Scope.Name, "internal/telemetry") {

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -98,6 +98,14 @@ type Instruments struct {
 	// reported reading per query (sum across Progress events).
 	// Attribute: cerberus.ql.
 	ClickHouseBytesRead metric.Int64Histogram
+
+	// QueryInflight is the count of currently-executing engine
+	// queries — incremented at engine entry, decremented (via defer)
+	// at engine return so panics + early-returns + cancellations
+	// still balance. Attribute: cerberus.ql. The cerberus-self
+	// dashboard panel queries `sum by (cerberus_ql)
+	// (cerberus_query_inflight)`.
+	QueryInflight metric.Int64UpDownCounter
 }
 
 var (
@@ -184,6 +192,14 @@ func mustBuild(meter metric.Meter) *Instruments {
 	if err != nil {
 		panic("telemetry: build bytes_read: " + err.Error())
 	}
+	queryInflight, err := meter.Int64UpDownCounter(
+		"cerberus_query_inflight",
+		metric.WithDescription("Currently-executing engine queries, by language."),
+		metric.WithUnit("{query}"),
+	)
+	if err != nil {
+		panic("telemetry: build query_inflight: " + err.Error())
+	}
 	return &Instruments{
 		QueriesTotal:        queriesTotal,
 		QueryDuration:       queryDuration,
@@ -191,6 +207,7 @@ func mustBuild(meter metric.Meter) *Instruments {
 		RulesApplied:        rulesApplied,
 		ClickHouseRowsRead:  chRows,
 		ClickHouseBytesRead: chBytes,
+		QueryInflight:       queryInflight,
 	}
 }
 
@@ -279,6 +296,25 @@ func (t *QueryTimer) Done(ctx context.Context, result string) {
 // it doesn't need a stopwatch wrapper.
 func RecordRulesApplied(ctx context.Context, n int) {
 	Get().RulesApplied.Record(ctx, int64(n))
+}
+
+// ObserveQueryInflight increments the QueryInflight gauge for ql and
+// returns a closure that decrements it. The idiomatic call pattern is:
+//
+//	defer telemetry.ObserveQueryInflight(ctx, "promql")()
+//
+// The deferred decrement covers panics, early returns, and context
+// cancellations so the gauge stays balanced across every engine code
+// path. ql is one of "promql" / "logql" / "traceql"; the value lands on
+// the cerberus.ql attribute so the dashboard's `sum by (cerberus_ql)`
+// pivot resolves.
+func ObserveQueryInflight(ctx context.Context, ql string) func() {
+	attrs := metric.WithAttributes(AttrQL.String(ql))
+	inst := Get()
+	inst.QueryInflight.Add(ctx, 1, attrs)
+	return func() {
+		inst.QueryInflight.Add(ctx, -1, attrs)
+	}
 }
 
 // RecordClickHouseProgress records the (rows, bytes) summary the

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -248,3 +248,91 @@ func TestInstall_NilFallsBackToNoop(t *testing.T) {
 	// Should be a no-op, not a panic.
 	telemetry.ObserveStage(telemetry.StageEmit).Done(context.Background())
 }
+
+// inflightValue reads the (signed) cumulative value the manual reader
+// reports for cerberus_query_inflight for the given ql label. Returns
+// 0 when the metric / label combination hasn't been recorded yet.
+func inflightValue(t *testing.T, reader *metric.ManualReader, ql string) int64 {
+	t.Helper()
+	sm := collect(t, reader)
+	for _, m := range sm.Metrics {
+		if m.Name != "cerberus_query_inflight" {
+			continue
+		}
+		sum, ok := m.Data.(metricdata.Sum[int64])
+		if !ok {
+			t.Fatalf("query_inflight: unexpected data type %T", m.Data)
+		}
+		for _, dp := range sum.DataPoints {
+			if v, _ := dp.Attributes.Value("cerberus.ql"); v.AsString() == ql {
+				return dp.Value
+			}
+		}
+	}
+	return 0
+}
+
+// TestObserveQueryInflight_IncrementDecrement covers the inc/dec
+// round-trip: a single ObserveQueryInflight call must leave the gauge
+// at 1; invoking the returned closure must restore it to 0. This is
+// the synthetic-engine-call surrogate — exercises the defer pattern
+// without standing up a chclient stub.
+func TestObserveQueryInflight_IncrementDecrement(t *testing.T) {
+	reader := installManualReader(t)
+
+	dec := telemetry.ObserveQueryInflight(t.Context(), "promql")
+	if got := inflightValue(t, reader, "promql"); got != 1 {
+		t.Fatalf("after increment: got %d want 1", got)
+	}
+	dec()
+	if got := inflightValue(t, reader, "promql"); got != 0 {
+		t.Fatalf("after decrement: got %d want 0", got)
+	}
+}
+
+// TestObserveQueryInflight_BalancedAcrossPanic anchors the defer
+// contract: even when the caller panics between increment and the
+// deferred decrement, the gauge must return to zero. This is the
+// property the engine relies on — Engine.QueryPlan defers the
+// decrement so panics in optimize / emit / execute don't strand a
+// stuck +1 on the gauge.
+func TestObserveQueryInflight_BalancedAcrossPanic(t *testing.T) {
+	reader := installManualReader(t)
+
+	func() {
+		defer func() {
+			// Swallow the panic; we only care that the deferred
+			// decrement still fired.
+			_ = recover()
+		}()
+		defer telemetry.ObserveQueryInflight(t.Context(), "logql")()
+		panic("synthetic engine failure")
+	}()
+
+	if got := inflightValue(t, reader, "logql"); got != 0 {
+		t.Fatalf("post-panic inflight: got %d want 0 (defer must decrement)", got)
+	}
+}
+
+// TestObserveQueryInflight_PerLanguageLabels confirms the cerberus.ql
+// attribute lands on the gauge so the dashboard's
+// `sum by (cerberus_ql) (cerberus_query_inflight)` pivot resolves
+// the three head identifiers independently.
+func TestObserveQueryInflight_PerLanguageLabels(t *testing.T) {
+	reader := installManualReader(t)
+
+	decProm := telemetry.ObserveQueryInflight(t.Context(), "promql")
+	decLoki := telemetry.ObserveQueryInflight(t.Context(), "logql")
+	decTempo := telemetry.ObserveQueryInflight(t.Context(), "traceql")
+	t.Cleanup(func() {
+		decProm()
+		decLoki()
+		decTempo()
+	})
+
+	for _, ql := range []string{"promql", "logql", "traceql"} {
+		if got := inflightValue(t, reader, ql); got != 1 {
+			t.Errorf("inflight[%s]: got %d want 1", ql, got)
+		}
+	}
+}

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -292,7 +292,7 @@ func TestObserveQueryInflight_IncrementDecrement(t *testing.T) {
 
 // TestObserveQueryInflight_BalancedAcrossPanic anchors the defer
 // contract: even when the caller panics between increment and the
-// deferred decrement, the gauge must return to zero. This is the
+// decrement defer, the gauge must return to zero. This is the
 // property the engine relies on — Engine.QueryPlan defers the
 // decrement so panics in optimize / emit / execute don't strand a
 // stuck +1 on the gauge.
@@ -301,8 +301,8 @@ func TestObserveQueryInflight_BalancedAcrossPanic(t *testing.T) {
 
 	func() {
 		defer func() {
-			// Swallow the panic; we only care that the deferred
-			// decrement still fired.
+			// Swallow the panic; we only care that the decrement
+			// defer still fired.
 			_ = recover()
 		}()
 		defer telemetry.ObserveQueryInflight(t.Context(), "logql")()


### PR DESCRIPTION
## Summary

Two telemetry gaps the `cerberus-self.json` dashboard references but
cerberus didn't actually instrument:

- **`cerberus_query_inflight`** — new `Int64UpDownCounter`,
  attribute `cerberus.ql`. Incremented at `Engine.QueryPlan` /
  `QueryPlanCursor` entry with a deferred decrement so panics, early
  returns, and cancellations balance the gauge. `Engine.Query` and
  `Engine.QueryCursor` flow through those two methods so the two
  instrumentation sites cover every engine entrypoint exactly once.
- **`cerberus_admit_rejected_total`** — already existed under
  `cerberus.admit.rejected_total` labelled by `cerberus.admit.head`;
  the dashboard panel pivots on `(cerberus_ql, reason)`. Renamed
  source to underscored form, translated the limiter's head
  identifier (`prom` / `loki` / `tempo`) to the ql vocabulary
  (`promql` / `logql` / `traceql`) at construction, and stamped a
  `reason=cap_exceeded` value at the single rejection path the
  semaphore exposes today. Future rejection paths (queue-timeout,
  route-disabled) extend the `reason` vocabulary rather than
  overload an existing value.

## Audit (referenced-but-not-emitted)

Running the dashboard-vs-code diff surfaced five names dashboards
reference but no code emits:

| Metric | Status |
| --- | --- |
| `cerberus_query_inflight` | **fixed in this PR** |
| `cerberus_admit_rejected_total` | **fixed in this PR** (renamed + relabelled) |
| `cerberus_ch_rows_read_total` | dashboard typo (code emits `cerberus_clickhouse_rows_read`); not addressed here |
| `cerberus_ch_bytes_read_total` | dashboard typo (code emits `cerberus_clickhouse_bytes_read`); not addressed here |
| `cerberus_pipeline_stage_duration_seconds_bucket` | Prom-side histogram explosion — needs OTel-collector `metricstransform` wiring, separate concern |
| `cerberus_queries_duration_seconds_bucket` | same as above |

The two `_bucket` panels are intentionally not addressed in this PR
— they need collector-side histogram translation, not new
instruments. The two `cerberus_ch_*` references look like dashboard
typos against the existing `cerberus_clickhouse_*` instruments and
should be fixed dashboard-side.

## Test plan

- [ ] `internal/telemetry/contract_test.go` `TestMetricNames_PublicContract` now requires `cerberus_query_inflight`.
- [ ] `internal/telemetry/metrics_test.go` new tests cover:
  - `TestObserveQueryInflight_IncrementDecrement` — inc + dec round-trip.
  - `TestObserveQueryInflight_BalancedAcrossPanic` — defer fires across panic.
  - `TestObserveQueryInflight_PerLanguageLabels` — three QL labels resolve independently.
- [ ] `internal/api/admit/admit_test.go` `TestRejectedCounter` updated to match the new metric name and asserts both new attributes (`cerberus.ql=promql`, `reason=cap_exceeded`).
- [ ] CI: `check`, `lint`, `forbid-skip`, `compatibility/*`, `probe`, `roundtrip (*)`, `compose-smoke`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)