### PR TITLE
fix(dash/cerberus-self): correct cerberus_ch_* typo to cerberus_clickhouse_*

### DIFF
--- a/test/e2e/grafana/dashboards/cerberus-self.json
+++ b/test/e2e/grafana/dashboards/cerberus-self.json
@@ -323,7 +323,7 @@
         "type": "prometheus",
         "uid": "cerberus-prometheus"
       },
-      "description": "ClickHouse rows and bytes read per cerberus query, summed over the selected range. Backed by the cerberus_ch_rows_read_total / cerberus_ch_bytes_read_total counters shipped by R4.4.",
+      "description": "ClickHouse rows and bytes read per cerberus query, summed over the selected range. Backed by the cerberus_clickhouse_rows_read / cerberus_clickhouse_bytes_read counters shipped by R4.4.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -413,7 +413,7 @@
             "uid": "cerberus-prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(cerberus_ch_rows_read_total{service_name=\"cerberus\"}[5m]))",
+          "expr": "sum(rate(cerberus_clickhouse_rows_read{service_name=\"cerberus\"}[5m]))",
           "legendFormat": "rows/s",
           "range": true,
           "refId": "A"
@@ -424,7 +424,7 @@
             "uid": "cerberus-prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(cerberus_ch_bytes_read_total{service_name=\"cerberus\"}[5m]))",
+          "expr": "sum(rate(cerberus_clickhouse_bytes_read{service_name=\"cerberus\"}[5m]))",
           "legendFormat": "bytes/s",
           "range": true,
           "refId": "B"


### PR DESCRIPTION
## Summary

The k3d e2e cerberus-self dashboard (`test/e2e/grafana/dashboards/cerberus-self.json`) referenced ClickHouse rows/bytes metrics under typo'd names. The "ClickHouse rows / bytes read per second" panel rendered empty against a live cerberus.

The dashboard expected vs what code emits:

| Dashboard expected | Code emits (`internal/telemetry/metrics.go`) |
|---|---|
| `cerberus_ch_bytes_read_total` | `cerberus_clickhouse_bytes_read` |
| `cerberus_ch_rows_read_total`  | `cerberus_clickhouse_rows_read`  |

Two issues per ref:

1. `_ch_` is the dashboard's abbreviated form; code spells it out as `_clickhouse_`. Code is the authoritative source — the dashboard is the consumer.
2. The `_total` suffix on the dashboard refs doesn't match the bare instrument names in code. Cerberus's `_total`-less convention is consistent with the other `cerberus_clickhouse_*` counters.

Fix: rename the three offending strings in the dashboard JSON (1 description, 2 `expr` targets). No panel titles, layout, axes, or threshold changes.

Audit surfaced by agent #177.

## Sites fixed (grep-confirmed before)

```
test/e2e/grafana/dashboards/cerberus-self.json:326  description (cerberus_ch_rows_read_total / cerberus_ch_bytes_read_total)
test/e2e/grafana/dashboards/cerberus-self.json:416  expr: sum(rate(cerberus_ch_rows_read_total{...}[5m]))
test/e2e/grafana/dashboards/cerberus-self.json:427  expr: sum(rate(cerberus_ch_bytes_read_total{...}[5m]))
```

`test/e2e/grafana/compose/dashboards/cerberus-self.json` does not contain these panels — no edit needed.

## Verification

Post-edit grep returns zero hits:

```
$ grep -rE 'cerberus_ch_' test/e2e/grafana/
(no matches)
```

## Test plan

- [x] grep confirms zero remaining `cerberus_ch_*` references in `test/e2e/grafana/`
- [x] Replacement names match emitter (`internal/telemetry/metrics.go` lines 172, 180)
- [ ] On `docker compose up --wait`, the cerberus-self CH bytes/rows panel populates (manual; ~30s lag for sample accumulation)