### PR TITLE
fix(chsql/range_window): push Start/End onto inner scan for MetricsAggregate matrix path

### DIFF
--- a/internal/chsql/exemplars.go
+++ b/internal/chsql/exemplars.go
@@ -162,14 +162,9 @@ func (e *emitter) emitMetricsExemplars(
 		anchorFanoutFrag(end, stepNS, numAnchors),
 		"anchor_ts",
 	)
-	// Same Start/End pushdown as emitRangeWindowMetrics — pin the
-	// otel_traces scan to the (Start - range, End] window so CH can
-	// prune partitions by the Timestamp key. Conditional on bounds
-	// being set to keep the unbounded shapes byte-stable.
-	if !rw.Start.IsZero() && !rw.End.IsZero() {
-		lo, hi := innerScanTsBoundsFrags(tsCol, rw.Start, rw.End, rangeNS)
-		innerSb.Where(lo, hi)
-	}
+	// Same Start/End pushdown as emitRangeWindowMetrics — see
+	// maybePushInnerScanTimeBounds.
+	maybePushInnerScanTimeBounds(innerSb, rw, tsCol, rangeNS)
 
 	// The outer SELECT MUST project exactly four columns in the order
 	// (MetricName, Attributes, TimeUnix, Value) — chclient.Cursor binds

--- a/internal/chsql/exemplars.go
+++ b/internal/chsql/exemplars.go
@@ -162,6 +162,14 @@ func (e *emitter) emitMetricsExemplars(
 		anchorFanoutFrag(end, stepNS, numAnchors),
 		"anchor_ts",
 	)
+	// Same Start/End pushdown as emitRangeWindowMetrics — pin the
+	// otel_traces scan to the (Start - range, End] window so CH can
+	// prune partitions by the Timestamp key. Conditional on bounds
+	// being set to keep the unbounded shapes byte-stable.
+	if !rw.Start.IsZero() && !rw.End.IsZero() {
+		lo, hi := innerScanTsBoundsFrags(tsCol, rw.Start, rw.End, rangeNS)
+		innerSb.Where(lo, hi)
+	}
 
 	// The outer SELECT MUST project exactly four columns in the order
 	// (MetricName, Attributes, TimeUnix, Value) — chclient.Cursor binds

--- a/internal/chsql/range_window.go
+++ b/internal/chsql/range_window.go
@@ -797,16 +797,11 @@ func (e *emitter) emitRangeWindowMetrics(r *chplan.RangeWindow, m *chplan.Metric
 		anchorFanoutFrag(end, stepNS, numAnchors),
 		"anchor_ts",
 	)
-	// Push the (Start - range, End] time bound onto the wrapping SELECT
-	// over m.Inner so CH can prune partitions / granules by the
-	// otel_traces Timestamp key. Conditional on Start/End being set —
-	// the PromQL subquery-internal shapes (Range/Step/OuterRange only)
-	// keep their current emitter output byte-stable. See
-	// innerScanTsBoundsFrags for the rationale.
-	if !r.Start.IsZero() && !r.End.IsZero() {
-		lo, hi := innerScanTsBoundsFrags(tsCol, r.Start, r.End, rangeNS)
-		innerSb.Where(lo, hi)
-	}
+	// Push (Start - range, End] onto the wrapping SELECT over m.Inner
+	// for CH partition / granule pruning. Gated so subquery-internal
+	// shapes (no Start/End grid) stay byte-stable. See
+	// maybePushInnerScanTimeBounds.
+	maybePushInnerScanTimeBounds(innerSb, r, tsCol, rangeNS)
 
 	// Outer SELECT: GROUP BY group cols + anchor_ts; apply the
 	// per-bucket reducer.
@@ -939,12 +934,8 @@ func (e *emitter) emitRangeWindowMetricsQuantileBuckets(r *chplan.RangeWindow, m
 	innerSb.SelectAs(func(b *Builder) { _ = b.Expr(attr) }, "metric_arg")
 	innerSb.SelectAs(anchorFanoutFrag(end, stepNS, numAnchors), "anchor_ts")
 	// Same Start/End pushdown as emitRangeWindowMetrics — see
-	// innerScanTsBoundsFrags. Conditional so the unbounded
-	// subquery-internal shapes stay byte-stable.
-	if !r.Start.IsZero() && !r.End.IsZero() {
-		lo, hi := innerScanTsBoundsFrags(tsCol, r.Start, r.End, rangeNS)
-		innerSb.Where(lo, hi)
-	}
+	// maybePushInnerScanTimeBounds.
+	maybePushInnerScanTimeBounds(innerSb, r, tsCol, rangeNS)
 
 	outerSb := NewQuery().From(innerSb.Frag())
 	for _, alias := range groupAliases {
@@ -1065,28 +1056,42 @@ func windowTsLowerBoundFrag(rangeNS int64) Frag {
 	}
 }
 
+// maybePushInnerScanTimeBounds pushes the (Start - range, End] time
+// bound onto `innerSb` (the wrapping SELECT over the MetricsAggregate
+// Inner subquery) so ClickHouse can prune partitions / granules by the
+// otel_traces Timestamp key — without the bounds the fan-out
+// `arrayJoin(range(0, N))` shape would force a full-table scan
+// (~31× row blowup per anchor) which routinely outlasts Grafana's
+// request timeout on the TraceQL /api/metrics/query_range path.
+//
+// The pushdown is gated on BOTH Start and End being set — the PromQL
+// subquery-internal RangeWindow shapes (Range / Step / OuterRange only,
+// no explicit grid) rely on the bounds being absent to stay byte-stable
+// against pinned snapshots. The `&&` gate is load-bearing: with either
+// bound zero the WHERE clause is suppressed entirely. Shared by
+// emitRangeWindowMetrics, emitRangeWindowMetricsQuantileBuckets, and
+// emitMetricsExemplars so the three matrix-shape emitters keep a single
+// pushdown contract.
+func maybePushInnerScanTimeBounds(innerSb *QueryBuilder, rw *chplan.RangeWindow, tsCol string, rangeNS int64) {
+	if rw.Start.IsZero() || rw.End.IsZero() {
+		return
+	}
+	lo, hi := innerScanTsBoundsFrags(tsCol, rw.Start, rw.End, rangeNS)
+	innerSb.Where(lo, hi)
+}
+
 // innerScanTsBoundsFrags returns the two Frags that pin the input scan
 // to the (Start - range, End] window:
 //
 //	<tsCol> >  <Start> - toIntervalNanosecond(<rangeNS>)
 //	<tsCol> <= <End>
 //
-// The bounds are pushed onto the wrapping SELECT over the MetricsAggregate
-// Inner subquery so ClickHouse can use the table's Timestamp partition /
-// order key for granule pruning — without the bounds the fan-out
-// `arrayJoin(range(0, N))` shape would force a full-table scan of
-// otel_traces (~31× row blowup per anchor) which routinely outlasts
-// Grafana's request timeout on the TraceQL /api/metrics/query_range path.
-//
 // Strict lower / inclusive upper matches the per-anchor `(anchor_ts -
 // range, anchor_ts]` window the outer SELECT later applies: any row that
 // could land in any anchor on the [Start, End] grid satisfies
-// `tsCol > Start - range AND tsCol <= End`.
-//
-// Callers MUST gate this on `!start.IsZero() && !end.IsZero()` — the
-// existing PromQL subquery-internal RangeWindow shapes (only Range / Step
-// / OuterRange set) rely on the bounds being absent to stay byte-stable
-// against pinned snapshots.
+// `tsCol > Start - range AND tsCol <= End`. See
+// maybePushInnerScanTimeBounds for the gating contract callers go
+// through.
 func innerScanTsBoundsFrags(tsCol string, start, end time.Time, rangeNS int64) (Frag, Frag) {
 	startFrag := timeOrNowFrag(start)
 	endFrag := timeOrNowFrag(end)

--- a/internal/chsql/range_window.go
+++ b/internal/chsql/range_window.go
@@ -797,6 +797,16 @@ func (e *emitter) emitRangeWindowMetrics(r *chplan.RangeWindow, m *chplan.Metric
 		anchorFanoutFrag(end, stepNS, numAnchors),
 		"anchor_ts",
 	)
+	// Push the (Start - range, End] time bound onto the wrapping SELECT
+	// over m.Inner so CH can prune partitions / granules by the
+	// otel_traces Timestamp key. Conditional on Start/End being set —
+	// the PromQL subquery-internal shapes (Range/Step/OuterRange only)
+	// keep their current emitter output byte-stable. See
+	// innerScanTsBoundsFrags for the rationale.
+	if !r.Start.IsZero() && !r.End.IsZero() {
+		lo, hi := innerScanTsBoundsFrags(tsCol, r.Start, r.End, rangeNS)
+		innerSb.Where(lo, hi)
+	}
 
 	// Outer SELECT: GROUP BY group cols + anchor_ts; apply the
 	// per-bucket reducer.
@@ -928,6 +938,13 @@ func (e *emitter) emitRangeWindowMetricsQuantileBuckets(r *chplan.RangeWindow, m
 	attr := m.Attr
 	innerSb.SelectAs(func(b *Builder) { _ = b.Expr(attr) }, "metric_arg")
 	innerSb.SelectAs(anchorFanoutFrag(end, stepNS, numAnchors), "anchor_ts")
+	// Same Start/End pushdown as emitRangeWindowMetrics — see
+	// innerScanTsBoundsFrags. Conditional so the unbounded
+	// subquery-internal shapes stay byte-stable.
+	if !r.Start.IsZero() && !r.End.IsZero() {
+		lo, hi := innerScanTsBoundsFrags(tsCol, r.Start, r.End, rangeNS)
+		innerSb.Where(lo, hi)
+	}
 
 	outerSb := NewQuery().From(innerSb.Frag())
 	for _, alias := range groupAliases {
@@ -1046,6 +1063,39 @@ func windowTsLowerBoundFrag(rangeNS int64) Frag {
 		b.sb.WriteString(strconv.FormatInt(rangeNS, 10))
 		b.sb.WriteByte(')')
 	}
+}
+
+// innerScanTsBoundsFrags returns the two Frags that pin the input scan
+// to the (Start - range, End] window:
+//
+//	<tsCol> >  <Start> - toIntervalNanosecond(<rangeNS>)
+//	<tsCol> <= <End>
+//
+// The bounds are pushed onto the wrapping SELECT over the MetricsAggregate
+// Inner subquery so ClickHouse can use the table's Timestamp partition /
+// order key for granule pruning — without the bounds the fan-out
+// `arrayJoin(range(0, N))` shape would force a full-table scan of
+// otel_traces (~31× row blowup per anchor) which routinely outlasts
+// Grafana's request timeout on the TraceQL /api/metrics/query_range path.
+//
+// Strict lower / inclusive upper matches the per-anchor `(anchor_ts -
+// range, anchor_ts]` window the outer SELECT later applies: any row that
+// could land in any anchor on the [Start, End] grid satisfies
+// `tsCol > Start - range AND tsCol <= End`.
+//
+// Callers MUST gate this on `!start.IsZero() && !end.IsZero()` — the
+// existing PromQL subquery-internal RangeWindow shapes (only Range / Step
+// / OuterRange set) rely on the bounds being absent to stay byte-stable
+// against pinned snapshots.
+func innerScanTsBoundsFrags(tsCol string, start, end time.Time, rangeNS int64) (Frag, Frag) {
+	startFrag := timeOrNowFrag(start)
+	endFrag := timeOrNowFrag(end)
+	lower := Gt(
+		Col(tsCol),
+		Sub(startFrag, Call("toIntervalNanosecond", InlineLit(rangeNS))),
+	)
+	upper := Lte(Col(tsCol), endFrag)
+	return lower, upper
 }
 
 // groupArrayPairFrag returns a Frag rendering

--- a/internal/chsql/range_window_pushdown_test.go
+++ b/internal/chsql/range_window_pushdown_test.go
@@ -1,0 +1,296 @@
+package chsql_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+)
+
+// The matrix-shape MetricsAggregate emitters
+// (emitRangeWindowMetrics, emitRangeWindowMetricsQuantileBuckets,
+// emitMetricsExemplars) pin the inner otel_traces scan to the
+// (Start - range, End] window via maybePushInnerScanTimeBounds so
+// ClickHouse can prune partitions / granules by the Timestamp key.
+// The pushdown is gated on BOTH Start AND End being set — the PromQL
+// subquery-internal RangeWindow shapes (only Range / Step / OuterRange,
+// no explicit grid) rely on the bounds being absent to keep the
+// emitter output byte-stable against pinned snapshots.
+//
+// The tests below pin both halves of the gate:
+//
+//   - Start AND End set → WHERE clause MUST carry the `<tsCol> >
+//     toDateTime64(...)` / `<tsCol> <= toDateTime64(...)` pair.
+//   - Either Start or End zero → WHERE clause MUST NOT carry that pair
+//     (so OuterRange-only PromQL shapes stay byte-stable).
+//
+// These coverage shapes kill the INVERT_LOGICAL mutant on the
+// `Start.IsZero() || End.IsZero()` short-circuit (flip the `||` to
+// `&&` and Start=zero+End=set emits the WHERE clause that the original
+// suppressed).
+
+// pushdownLowerSubstr is the load-bearing substring the matrix-shape
+// emitters render for the lower half of the inner-scan time pushdown.
+// It is structurally distinct from the outer per-anchor WHERE
+// (`ts > anchor_ts - ...`) because the inner pushdown references the
+// scan's actual timestamp column (`Timestamp`) rather than the inner
+// `ts` alias — so a substring hit uniquely identifies the pushdown.
+const (
+	pushdownLowerSubstr = "`Timestamp` > toDateTime64("
+	pushdownUpperSubstr = "`Timestamp` <= toDateTime64("
+)
+
+func TestRangeWindowMetricsInnerScanPushdown_BothSet(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 5, 13, 12, 5, 0, 0, time.UTC)
+
+	plan := &chplan.RangeWindow{
+		Input: &chplan.MetricsAggregate{
+			Op:         chplan.MetricsOpRate,
+			ValueAlias: "Value",
+			Inner:      &chplan.Scan{Table: "otel_traces"},
+		},
+		Step:            time.Minute,
+		Range:           time.Minute,
+		Start:           start,
+		End:             end,
+		TimestampColumn: "Timestamp",
+	}
+
+	sql, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if !strings.Contains(sql, pushdownLowerSubstr) {
+		t.Errorf("expected inner-scan lower-bound pushdown %q in SQL=%s", pushdownLowerSubstr, sql)
+	}
+	if !strings.Contains(sql, pushdownUpperSubstr) {
+		t.Errorf("expected inner-scan upper-bound pushdown %q in SQL=%s", pushdownUpperSubstr, sql)
+	}
+}
+
+// TestRangeWindowMetricsInnerScanPushdown_OnlyOneSet pins the gate's
+// short-circuit: with only one of Start/End set the inner-scan WHERE
+// pushdown MUST be suppressed (so the PromQL subquery-internal shapes
+// — OuterRange-only — stay byte-stable). Kills the INVERT_LOGICAL
+// mutant on `Start.IsZero() || End.IsZero()` (flip to `&&` and the
+// pushdown leaks into the SQL with a `now64(9)` half-bound).
+func TestRangeWindowMetricsInnerScanPushdown_OnlyOneSet(t *testing.T) {
+	t.Parallel()
+
+	nonZero := time.Date(2026, 5, 13, 12, 5, 0, 0, time.UTC)
+
+	cases := []struct {
+		name  string
+		start time.Time
+		end   time.Time
+	}{
+		{name: "start_only", start: nonZero, end: time.Time{}},
+		{name: "end_only", start: time.Time{}, end: nonZero},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			plan := &chplan.RangeWindow{
+				Input: &chplan.MetricsAggregate{
+					Op:         chplan.MetricsOpRate,
+					ValueAlias: "Value",
+					Inner:      &chplan.Scan{Table: "otel_traces"},
+				},
+				Step:            time.Minute,
+				Range:           time.Minute,
+				Start:           c.start,
+				End:             c.end,
+				OuterRange:      5 * time.Minute,
+				TimestampColumn: "Timestamp",
+			}
+			sql, _, err := chsql.Emit(context.Background(), plan)
+			if err != nil {
+				t.Fatalf("Emit: %v", err)
+			}
+			if strings.Contains(sql, pushdownLowerSubstr) {
+				t.Errorf("inner-scan lower-bound pushdown leaked with only %s set; SQL=%s", c.name, sql)
+			}
+			if strings.Contains(sql, pushdownUpperSubstr) {
+				t.Errorf("inner-scan upper-bound pushdown leaked with only %s set; SQL=%s", c.name, sql)
+			}
+		})
+	}
+}
+
+// TestRangeWindowMetricsQuantileBucketsInnerScanPushdown_BothSet pins
+// the matrix-quantile path's pushdown: with Start AND End set the
+// inner SELECT carries the (Start - range, End] WHERE.
+func TestRangeWindowMetricsQuantileBucketsInnerScanPushdown_BothSet(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 5, 13, 12, 5, 0, 0, time.UTC)
+
+	plan := &chplan.RangeWindow{
+		Input: &chplan.MetricsAggregate{
+			Op:         chplan.MetricsOpQuantileOverTime,
+			Attr:       &chplan.ColumnRef{Name: "Duration"},
+			Quantiles:  []float64{0.95},
+			ValueAlias: "Value",
+			Inner:      &chplan.Scan{Table: "otel_traces"},
+		},
+		Step:            time.Minute,
+		Range:           time.Minute,
+		Start:           start,
+		End:             end,
+		TimestampColumn: "Timestamp",
+	}
+
+	sql, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if !strings.Contains(sql, pushdownLowerSubstr) {
+		t.Errorf("expected lower-bound pushdown %q in SQL=%s", pushdownLowerSubstr, sql)
+	}
+	if !strings.Contains(sql, pushdownUpperSubstr) {
+		t.Errorf("expected upper-bound pushdown %q in SQL=%s", pushdownUpperSubstr, sql)
+	}
+}
+
+// TestRangeWindowMetricsQuantileBucketsInnerScanPushdown_OnlyOneSet
+// mirrors the rate path's gate-short-circuit test for the
+// quantile-bucket emitter.
+func TestRangeWindowMetricsQuantileBucketsInnerScanPushdown_OnlyOneSet(t *testing.T) {
+	t.Parallel()
+
+	nonZero := time.Date(2026, 5, 13, 12, 5, 0, 0, time.UTC)
+
+	cases := []struct {
+		name  string
+		start time.Time
+		end   time.Time
+	}{
+		{name: "start_only", start: nonZero, end: time.Time{}},
+		{name: "end_only", start: time.Time{}, end: nonZero},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			plan := &chplan.RangeWindow{
+				Input: &chplan.MetricsAggregate{
+					Op:         chplan.MetricsOpQuantileOverTime,
+					Attr:       &chplan.ColumnRef{Name: "Duration"},
+					Quantiles:  []float64{0.95},
+					ValueAlias: "Value",
+					Inner:      &chplan.Scan{Table: "otel_traces"},
+				},
+				Step:            time.Minute,
+				Range:           time.Minute,
+				Start:           c.start,
+				End:             c.end,
+				OuterRange:      5 * time.Minute,
+				TimestampColumn: "Timestamp",
+			}
+			sql, _, err := chsql.Emit(context.Background(), plan)
+			if err != nil {
+				t.Fatalf("Emit: %v", err)
+			}
+			if strings.Contains(sql, pushdownLowerSubstr) {
+				t.Errorf("lower-bound pushdown leaked with only %s set; SQL=%s", c.name, sql)
+			}
+			if strings.Contains(sql, pushdownUpperSubstr) {
+				t.Errorf("upper-bound pushdown leaked with only %s set; SQL=%s", c.name, sql)
+			}
+		})
+	}
+}
+
+// TestEmitMetricsExemplarsInnerScanPushdown_BothSet pins the same
+// (Start - range, End] pushdown contract for the exemplar emitter.
+func TestEmitMetricsExemplarsInnerScanPushdown_BothSet(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 5, 13, 12, 5, 0, 0, time.UTC)
+
+	m := &chplan.MetricsAggregate{
+		Op:         chplan.MetricsOpRate,
+		ValueAlias: "Value",
+		Inner:      &chplan.Scan{Table: "otel_traces"},
+	}
+	rw := &chplan.RangeWindow{
+		Input:           m,
+		Step:            time.Minute,
+		Range:           time.Minute,
+		Start:           start,
+		End:             end,
+		TimestampColumn: "Timestamp",
+	}
+
+	sql, _, err := chsql.EmitMetricsExemplars(context.Background(), rw, m, "TraceId", "SpanId", 1)
+	if err != nil {
+		t.Fatalf("EmitMetricsExemplars: %v", err)
+	}
+	if !strings.Contains(sql, pushdownLowerSubstr) {
+		t.Errorf("expected exemplar lower-bound pushdown %q in SQL=%s", pushdownLowerSubstr, sql)
+	}
+	if !strings.Contains(sql, pushdownUpperSubstr) {
+		t.Errorf("expected exemplar upper-bound pushdown %q in SQL=%s", pushdownUpperSubstr, sql)
+	}
+}
+
+// TestEmitMetricsExemplarsInnerScanPushdown_OnlyOneSet mirrors the
+// matrix-path gate test for the exemplar emitter. With only one of
+// Start/End set the WHERE pushdown MUST be suppressed — kills the
+// INVERT_LOGICAL mutant on the gate.
+//
+// Note: EmitMetricsExemplars rejects a missing Range upfront via
+// `rw.Range == 0 → defaults to Step`, so the gate is reached even when
+// one bound is zero (numAnchors falls through to 1 in that branch).
+func TestEmitMetricsExemplarsInnerScanPushdown_OnlyOneSet(t *testing.T) {
+	t.Parallel()
+
+	nonZero := time.Date(2026, 5, 13, 12, 5, 0, 0, time.UTC)
+
+	cases := []struct {
+		name  string
+		start time.Time
+		end   time.Time
+	}{
+		{name: "start_only", start: nonZero, end: time.Time{}},
+		{name: "end_only", start: time.Time{}, end: nonZero},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			m := &chplan.MetricsAggregate{
+				Op:         chplan.MetricsOpRate,
+				ValueAlias: "Value",
+				Inner:      &chplan.Scan{Table: "otel_traces"},
+			}
+			rw := &chplan.RangeWindow{
+				Input:           m,
+				Step:            time.Minute,
+				Range:           time.Minute,
+				Start:           c.start,
+				End:             c.end,
+				TimestampColumn: "Timestamp",
+			}
+			sql, _, err := chsql.EmitMetricsExemplars(context.Background(), rw, m, "TraceId", "SpanId", 1)
+			if err != nil {
+				t.Fatalf("EmitMetricsExemplars: %v", err)
+			}
+			if strings.Contains(sql, pushdownLowerSubstr) {
+				t.Errorf("exemplar lower-bound pushdown leaked with only %s set; SQL=%s", c.name, sql)
+			}
+			if strings.Contains(sql, pushdownUpperSubstr) {
+				t.Errorf("exemplar upper-bound pushdown leaked with only %s set; SQL=%s", c.name, sql)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- TraceQL `/api/metrics/query_range` lowers to `RangeWindow over MetricsAggregate over Scan(otel_traces)`. The chsql emitter was wrapping the inner SELECT without a Timestamp WHERE, so the `arrayJoin(range(0, N))` fan-out forced a full-table scan that outlasted Grafana's request timeout (panel stuck loading forever — task #178).
- Push `(Start - range, End]` onto the inner SELECT in `emitRangeWindowMetrics`, `emitRangeWindowMetricsQuantileBuckets`, and `emitMetricsExemplars`. Strict lower / inclusive upper matches the per-anchor `(anchor_ts - range, anchor_ts]` window the outer SELECT later applies.
- Gated on `!Start.IsZero() && !End.IsZero()` so PromQL subquery-internal shapes (only Range/Step/OuterRange set) keep their current emitter output byte-stable against pinned snapshots.

Closes #180.

## Test plan

- [ ] CI: `check` + `roundtrip (traceql)` + `compose-smoke` green
- [ ] Manual: `{status=error} | rate() by (resource.service.name)` panel renders within Grafana timeout on the compose stack
- [ ] No existing TXTAR snapshot churn (bounds gated, unbounded shapes unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)