### PR TITLE
fix(api/prom): accept millisecond start/end/time params

### DIFF
--- a/internal/api/format/format_test.go
+++ b/internal/api/format/format_test.go
@@ -120,6 +120,13 @@ func TestParseTimeProm(t *testing.T) {
 		{"unix-seconds", "1700000000", time.Unix(1_700_000_000, 0).UTC(), false},
 		{"unix-fractional", "1700000000.5", time.Unix(1_700_000_000, 500_000_000).UTC(), false},
 		{"rfc3339", "2024-01-02T03:04:05Z", time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC), false},
+		// Grafana's Prom datasource sends ms over `resources/` proxy.
+		// Routing >= 1e12 to the ms branch protects every Prom handler
+		// from the toDateTime64('58353-12-31', 9) overflow.
+		{"unix-millis-13digit", "1700000000000", time.Unix(1_700_000_000, 0).UTC(), false},
+		{"unix-millis-with-frac", "1700000000123", time.Unix(1_700_000_000, 123_000_000).UTC(), false},
+		{"boundary-1e12-minus-1", "999999999999", time.Unix(999_999_999_999, 0).UTC(), false}, // stays seconds
+		{"boundary-1e12-exact", "1000000000000", time.UnixMilli(1_000_000_000_000).UTC(), false},
 		{"bogus", "not-a-time", time.Time{}, true},
 	}
 	for _, tc := range tests {

--- a/internal/api/format/timing.go
+++ b/internal/api/format/timing.go
@@ -21,22 +21,33 @@ func ParseDuration(raw string) (time.Duration, error) {
 }
 
 // ParseTimeProm parses a Prometheus-API time parameter — Unix-seconds
-// float or RFC3339 timestamp. Empty input falls back to def.
+// float, Unix-milliseconds int, or RFC3339 timestamp. Empty input falls
+// back to def.
 //
-// Loki accepts an additional integer-nanoseconds form, so it uses
-// ParseTimeLoki instead. Keeping the two heads explicit avoids
-// surprising one API with the other's input shape (a 13-digit Prom
-// epoch-millis timestamp must not be reinterpreted as nanoseconds).
+// Grafana's Prometheus datasource plugin sends millisecond timestamps
+// when it routes through `/api/datasources/uid/<ds>/resources/...`
+// (the JS frontend never converts to seconds on that path). Treating
+// a 13-digit ms value as seconds yields a year ~58353 timestamp and
+// overflows ClickHouse's `toDateTime64`, so the heuristic below routes
+// values >= 1e12 to the ms branch. Plain seconds (~1.78e9 today) and
+// fractional seconds stay on the float branch.
+//
+// Loki accepts integer-nanoseconds as well — handled by ParseTimeLoki.
 func ParseTimeProm(raw string, def time.Time) (time.Time, error) {
 	if raw == "" {
 		return def, nil
+	}
+	if n, err := strconv.ParseInt(raw, 10, 64); err == nil && n >= 1_000_000_000_000 {
+		// >= 1e12 ⇒ milliseconds. A seconds value this large would be
+		// year ~33658, which no real client sends deliberately.
+		return time.UnixMilli(n).UTC(), nil
 	}
 	if f, err := strconv.ParseFloat(raw, 64); err == nil {
 		return time.Unix(int64(f), int64((f-float64(int64(f)))*1e9)).UTC(), nil
 	}
 	t, err := time.Parse(time.RFC3339Nano, raw)
 	if err != nil {
-		return time.Time{}, errors.New("time parameter must be Unix seconds or RFC3339")
+		return time.Time{}, errors.New("time parameter must be Unix seconds/milliseconds or RFC3339")
 	}
 	return t.UTC(), nil
 }

--- a/internal/api/prom/conformance_test.go
+++ b/internal/api/prom/conformance_test.go
@@ -677,6 +677,11 @@ func TestConformance_QueryExemplarsWire(t *testing.T) {
 		{"query": {"up"}, "start": {"1717995600"}, "end": {"1717999200"}},
 		{"query": {`up{job="api"}`}, "start": {"1717995600"}, "end": {"1717999200"}},
 		{"query": {`up{instance=~".*"}`}, "start": {"1717995600"}, "end": {"1717999200"}},
+		// Grafana 11.x sends ms over the `resources/` proxy path for
+		// the exemplars endpoint. Anything routed as seconds would
+		// overflow toDateTime64 — pin the contract so the regression
+		// surfaces here, not as a 502 in Grafana's UI.
+		{"query": {"up"}, "start": {"1717995600000"}, "end": {"1717999200000"}},
 	}
 	for i, qs := range cases {
 		qs := qs
@@ -884,6 +889,11 @@ func TestConformance_PromRangeTimeMatrix(t *testing.T) {
 		{"rfc3339", "2024-01-01T00:00:00Z", "2024-01-01T01:00:00Z", "60s", http.StatusOK},
 		{"rfc3339_with_nanos", "2024-01-01T00:00:00.123Z", "2024-01-01T01:00:00.456Z", "30s", http.StatusOK},
 		{"go_duration_step", "1717995600", "1717999200", "5m", http.StatusOK},
+		// Grafana's Prom datasource ships start/end as 13-digit ms when
+		// it routes through `resources/` proxy. Anything < year 33658
+		// expressed as seconds (i.e. >= 1e12) is parsed as ms — anything
+		// else stays on the seconds path.
+		{"unix_millis_int", "1717995600000", "1717999200000", "60", http.StatusOK},
 		// invalid forms
 		{"empty_start", "", "1717999200", "60", http.StatusBadRequest},
 		{"garbage_start", "tomorrow", "1717999200", "60", http.StatusBadRequest},
@@ -938,6 +948,11 @@ func TestConformance_PromQueryTimeMatrix(t *testing.T) {
 		{"empty_uses_now", "", http.StatusOK},
 		{"garbage", "tomorrow", http.StatusBadRequest},
 		{"negative_is_still_unix", "-100", http.StatusOK}, // unix seconds accepts negatives
+		// Grafana sends ms over `resources/`; the >=1e12 heuristic
+		// routes it to UnixMilli so toDateTime64('58353-...') no longer
+		// overflows. Both 13-digit and 14-digit ms forms must pass.
+		{"unix_millis_13digit", "1717995600000", http.StatusOK},
+		{"unix_millis_with_subms_frac", "1717995600123", http.StatusOK},
 	}
 	for _, c := range cases {
 		c := c


### PR DESCRIPTION
## Summary

- Grafana's Prom datasource sends 13-digit ms timestamps over the `/resources/` proxy path. cerberus treated them as seconds → `toDateTime64('58353-12-31', 9)` overflow → 502 on every `/api/v1/query*`. Surfaced by corner-sweep Playwright run on the compose stack (2026-05-20).
- Route values >= 1e12 through `time.UnixMilli`. Seconds, fractional seconds, RFC3339 unchanged.
- Tests added at every layer:
  - **Unit** — `TestParseTimeProm` gains ms + 1e12-boundary cases (`internal/api/format/format_test.go`)
  - **Conformance** — ms cases on `/query`, `/query_range`, `/query_exemplars` (`internal/api/prom/conformance_test.go`)

Closes #183.

## Test plan

- [ ] CI: `check` + `lint` green
- [ ] Manual: `curl 'http://localhost:8080/api/v1/query?query=up&time=1779307108251'` returns 200
- [ ] Manual: Grafana Prom Explore + datasource health no longer 502 in compose stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)