### PR TITLE
fix(logql): treat VectorJoin output as canonical sample shape

### DIFF
--- a/internal/api/loki/conformance_test.go
+++ b/internal/api/loki/conformance_test.go
@@ -106,6 +106,49 @@ func TestConformance_LokiQueryWire(t *testing.T) {
 	}
 }
 
+// TestConformance_LokiQueryConstantArithmetic_HealthProbe pins the Grafana
+// Loki CheckHealth probe shape — `vector(1)+vector(1)` (and friends) —
+// against the regression where the metric-branch wire-wrap blindly
+// ColumnRef'd `ResourceAttributes` over a top-level VectorJoin output.
+// ClickHouse returned `code: 47 Unknown expression identifier
+// 'ResourceAttributes'`, which Grafana surfaced as a red "Unable to
+// connect with Loki" banner on every page load.
+//
+// The fix extends `isVectorAggregateSampleShape` in internal/logql/binary.go
+// to also recognise VectorJoin (its emitter projects under the canonical
+// `Attributes` alias). Pin all four arithmetic ops + a literal-vector mix
+// so a future refactor of the helper can't silently drop the branch.
+func TestConformance_LokiQueryConstantArithmetic_HealthProbe(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{
+		`vector(1)+vector(1)`,
+		`vector(1)-vector(1)`,
+		`vector(2)*vector(3)`,
+		`vector(8)/vector(2)`,
+	}
+	for _, q := range cases {
+		q := q
+		t.Run(q, func(t *testing.T) {
+			t.Parallel()
+			srv := newServer(&stubQuerier{})
+			t.Cleanup(srv.Close)
+			resp, err := http.Get(srv.URL + "/loki/api/v1/query?query=" + url.QueryEscape(q))
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			defer resp.Body.Close()
+			body, _ := io.ReadAll(resp.Body)
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status=%d body=%s — Grafana's Loki CheckHealth "+
+					"probe lands here; a non-200 surfaces as 'Unable to "+
+					"connect with Loki' on every Grafana page load",
+					resp.StatusCode, string(body))
+			}
+		})
+	}
+}
+
 // TestConformance_LokiQueryRangeWire — `/loki/api/v1/query_range` for
 // metric and log queries returns the matching matrix / streams shape.
 func TestConformance_LokiQueryRangeWire(t *testing.T) {

--- a/internal/logql/binary.go
+++ b/internal/logql/binary.go
@@ -374,13 +374,27 @@ func sampleShapeOverLogInner(inner chplan.Node, s schema.Logs) chplan.Node {
 }
 
 // isVectorAggregateSampleShape reports whether inner already carries the
-// canonical Sample contract — i.e. came out of
-// [wrapVectorAggregateForSample]. The signal is a top-level
-// `*chplan.Project` whose alias list includes `Attributes`; that's the
-// only LogQL lowering that produces an `Attributes`-aliased projection
-// (RangeWindow / lowerLiteral / lowerVector / label_replace all alias
-// `ResourceAttributes`).
+// canonical Sample contract (MetricName, Attributes, TimeUnix, Value)
+// — i.e. came out of [wrapVectorAggregateForSample] or
+// [lowerVectorVector]. The signal is one of:
+//
+//   - a top-level `*chplan.Project` whose alias list includes
+//     `Attributes` (RangeWindow / lowerLiteral / lowerVector /
+//     label_replace all alias `ResourceAttributes`, so the
+//     `Attributes` alias is specific to the vector-aggregate
+//     re-shape).
+//   - a top-level `*chplan.VectorJoin` — its emitter projects
+//     `L.Attributes` / `L.TimeUnix` / `L.Value` (with the value-fold
+//     `L.Value <op> R.Value`) so the post-join scope already exposes
+//     `Attributes`, not `ResourceAttributes`. Without this branch a
+//     query like `vector(1) + vector(1)` (Grafana's Loki health probe)
+//     surfaces as ClickHouse `code: 47 Unknown expression identifier
+//     'ResourceAttributes'` when [Lang.ProjectSamples] wraps the join
+//     output.
 func isVectorAggregateSampleShape(n chplan.Node) bool {
+	if _, ok := n.(*chplan.VectorJoin); ok {
+		return true
+	}
 	p, ok := n.(*chplan.Project)
 	if !ok {
 		return false

--- a/internal/logql/lang_test.go
+++ b/internal/logql/lang_test.go
@@ -303,6 +303,80 @@ func TestProjectSamples_VectorAggregateOverMatrixForwardsTimeUnix(t *testing.T) 
 	}
 }
 
+// TestProjectSamples_VectorVectorBinopRefsAttributes pins the metric-branch
+// wire-wrap against the Grafana Loki datasource health-check regression:
+// `vector(1) + vector(1)` (Grafana's CheckHealth probe) lowered to a
+// VectorJoin whose emitter projects `L.Attributes` / `L.TimeUnix` /
+// `L.Value`. The previous Lang.ProjectSamples saw a top-level VectorJoin
+// (not a *chplan.Project), fell through to the default branch, and
+// ColumnRef'd the raw `ResourceAttributes` column at the outer wrap —
+// ClickHouse returned `code: 47 Unknown expression identifier
+// 'ResourceAttributes'` (and Grafana surfaced "Unable to connect with
+// Loki" in red on every page load even though log queries worked).
+//
+// The fix extends `isVectorAggregateSampleShape` to recognise VectorJoin
+// as canonical-Sample-shape since its emitter projects under the
+// `Attributes` alias by construction. Pin that here so any future
+// refactor of the helper can't silently drop the VectorJoin branch.
+func TestProjectSamples_VectorVectorBinopRefsAttributes(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelLogs()
+	l := &logql.Lang{Schema: s}
+
+	// Synthetic VectorJoin output — the exact node shape lowerVectorVector
+	// produces for `vector(1) + vector(1)`. The legs themselves don't
+	// matter for the ProjectSamples wrap; only the top-level type does.
+	leftLeg := &chplan.Project{
+		Input: &chplan.OneRow{},
+		Projections: []chplan.Projection{
+			{Expr: &chplan.LitString{V: ""}, Alias: "MetricName"},
+			{Expr: &chplan.LitString{V: ""}, Alias: "Attributes"},
+			{Expr: &chplan.FuncCall{Name: "now64", Args: []chplan.Expr{&chplan.LitInt{V: 9}}}, Alias: "TimeUnix"},
+			{Expr: &chplan.LitFloat{V: 1}, Alias: "Value"},
+		},
+	}
+	plan := &chplan.VectorJoin{
+		Left:             leftLeg,
+		Right:            leftLeg,
+		Op:               chplan.OpAdd,
+		MetricNameColumn: "MetricName",
+		AttributesColumn: "Attributes",
+		TimestampColumn:  "TimeUnix",
+		ValueColumn:      "Value",
+	}
+
+	wrapped := l.ProjectSamples(plan, engine.Meta{IsMetric: true})
+
+	proj, ok := wrapped.(*chplan.Project)
+	if !ok {
+		t.Fatalf("ProjectSamples returned %T, want *chplan.Project", wrapped)
+	}
+	attrsSlot := proj.Projections[1]
+	attrsRef, ok := attrsSlot.Expr.(*chplan.ColumnRef)
+	if !ok {
+		t.Fatalf("attributes slot expr: got %T, want *chplan.ColumnRef", attrsSlot.Expr)
+	}
+	if attrsRef.Name != "Attributes" {
+		t.Errorf("attributes slot ColumnRef.Name: got %q, want %q "+
+			"(VectorJoin's emitter projects `L.Attributes` / `L.TimeUnix` / "+
+			"`L.Value` so the post-join scope exposes `Attributes`, not "+
+			"`ResourceAttributes` — outer wrap must follow suit)",
+			attrsRef.Name, "Attributes")
+	}
+	tsSlot := proj.Projections[2]
+	tsRef, ok := tsSlot.Expr.(*chplan.ColumnRef)
+	if !ok {
+		t.Fatalf("ts slot expr: got %T, want *chplan.ColumnRef", tsSlot.Expr)
+	}
+	if tsRef.Name != "TimeUnix" {
+		t.Errorf("ts slot ColumnRef.Name: got %q, want %q (VectorJoin "+
+			"output exposes TimeUnix from L.TimeUnix; the default synth "+
+			"`now64(9) - 5s` would land outside the join's per-row "+
+			"timestamp scope)", tsRef.Name, "TimeUnix")
+	}
+}
+
 // TestProjectSamples_LogQuerySurfacesDetectedLevelWhenReferenced pins
 // the log-stream branch's Attributes slot to a `mapConcat(...)` that
 // folds the synthesized `detected_level` label onto the row's


### PR DESCRIPTION
## Summary

- Grafana's Loki CheckHealth probe sends \`vector(1)+vector(1)\` to \`/loki/api/v1/query\`. LogQL lowered it to a top-level \`*chplan.VectorJoin\` but \`isVectorAggregateSampleShape\` only recognised the \`*chplan.Project\` form, so \`Lang.ProjectSamples\` ColumnRef'd \`ResourceAttributes\` at the outer wrap — ClickHouse returned \`code: 47 Unknown expression identifier 'ResourceAttributes'\`. Grafana surfaced "Unable to connect with Loki" on every page load.
- VectorJoin's emitter projects \`L.Attributes\` / \`L.TimeUnix\` / \`L.Value\`, same canonical shape \`wrapVectorAggregateForSample\` produces. Extend the helper to detect it.
- Tests at every layer:
  - **Unit** (\`internal/logql/lang_test.go\`): \`TestProjectSamples_VectorVectorBinopRefsAttributes\` constructs a synthetic VectorJoin and asserts both the Attributes + TimeUnix slot pick canonical column names.
  - **Conformance** (\`internal/api/loki/conformance_test.go\`): \`TestConformance_LokiQueryConstantArithmetic_HealthProbe\` drives all 4 arithmetic ops through the real handler — a non-200 surfaces as the exact UI banner Grafana shows users.

Closes #184.

## Test plan

- [ ] CI: \`check\` + \`lint\` + \`forbid-skip\` + \`roundtrip (logql)\` green
- [ ] Manual: \`curl 'http://localhost:8080/loki/api/v1/query?query=vector(1)%2Bvector(1)&time=...'\` returns 200
- [ ] Manual: Grafana Loki datasource health turns green in compose stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)