### PR TITLE
feat(api/prom): stub /api/v1/rules + /api/v1/alerts

### DIFF
--- a/internal/api/prom/conformance_test.go
+++ b/internal/api/prom/conformance_test.go
@@ -409,6 +409,65 @@ func TestConformance_MetadataWire(t *testing.T) {
 	}
 }
 
+// TestConformance_RulesEndpoints pins the empty-envelope shape for
+// `/api/v1/rules` + `/api/v1/alerts`. Grafana's Prom datasource polls
+// both on every page load to gate the "Alert Rules" / "Alerts" UI
+// affordances; a 404 here logs noisy "Failed to load resource" errors
+// in every user's console and degrades the alerting UI.
+//
+// The wire shape matches upstream Prometheus exactly: status:"success",
+// data:{groups:[]} for /rules, data:{alerts:[]} for /alerts.
+func TestConformance_RulesEndpoints(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		path     string
+		dataKey  string
+	}{
+		{"rules_empty", "/api/v1/rules", "groups"},
+		{"alerts_empty", "/api/v1/alerts", "alerts"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv := newServer(&stubQuerier{})
+			t.Cleanup(srv.Close)
+
+			resp, err := http.Get(srv.URL + tc.path)
+			if err != nil {
+				t.Fatalf("GET %s: %v", tc.path, err)
+			}
+			body := readBody(t, resp)
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status=%d body=%s — a 404 here surfaces as "+
+					"a noisy 'Failed to load resource' on every Grafana "+
+					"page load", resp.StatusCode, body)
+			}
+			var env struct {
+				Status string                 `json:"status"`
+				Data   map[string]json.RawMessage `json:"data"`
+			}
+			if err := json.Unmarshal([]byte(body), &env); err != nil {
+				t.Fatalf("decode: %v\nbody=%s", err, body)
+			}
+			if env.Status != "success" {
+				t.Errorf("status: got %q, want success", env.Status)
+			}
+			raw, ok := env.Data[tc.dataKey]
+			if !ok {
+				t.Fatalf("data missing %q key; got keys: %v", tc.dataKey, env.Data)
+			}
+			// Must be an array (empty or otherwise), never null —
+			// upstream clients iterate without nil-checking.
+			if string(raw) != "[]" {
+				t.Errorf("data.%s: got %s, want []", tc.dataKey, string(raw))
+			}
+		})
+	}
+}
+
 // TestConformance_FormatQueryWire — `/api/v1/format_query` returns
 // `data: <string>` (the pretty-printed query). Three payloads cover
 // trivial / function / matcher forms.

--- a/internal/api/prom/conformance_test.go
+++ b/internal/api/prom/conformance_test.go
@@ -421,9 +421,9 @@ func TestConformance_RulesEndpoints(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name     string
-		path     string
-		dataKey  string
+		name    string
+		path    string
+		dataKey string
 	}{
 		{"rules_empty", "/api/v1/rules", "groups"},
 		{"alerts_empty", "/api/v1/alerts", "alerts"},
@@ -446,7 +446,7 @@ func TestConformance_RulesEndpoints(t *testing.T) {
 					"page load", resp.StatusCode, body)
 			}
 			var env struct {
-				Status string                 `json:"status"`
+				Status string                     `json:"status"`
 				Data   map[string]json.RawMessage `json:"data"`
 			}
 			if err := json.Unmarshal([]byte(body), &env); err != nil {

--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -120,6 +120,11 @@ func (h *Handler) Mount(mux *http.ServeMux) {
 	register("POST /api/v1/parse_query", h.handleParseQuery)
 	register("GET /api/v1/query_exemplars", h.handleQueryExemplars)
 	register("POST /api/v1/query_exemplars", h.handleQueryExemplars)
+	// Alerting / recording-rules probe endpoints. cerberus has no rule
+	// engine — return the canonical empty envelope an unconfigured
+	// upstream Prometheus would, so Grafana's per-page probe is quiet.
+	register("GET /api/v1/rules", h.handleRules)
+	register("GET /api/v1/alerts", h.handleAlerts)
 }
 
 // handleFormatQuery implements `/api/v1/format_query`. Takes a `query`

--- a/internal/api/prom/rules.go
+++ b/internal/api/prom/rules.go
@@ -1,0 +1,50 @@
+package prom
+
+import (
+	"net/http"
+)
+
+// handleRules implements `/api/v1/rules` and `/api/v1/alerts` — both are
+// Prometheus alerting/recording-rules endpoints that Grafana polls on every
+// page load to gate the "Alert Rules" UI affordance. cerberus does not
+// evaluate alerting or recording rules (it is a query gateway, not a Prom
+// server), so both return the canonical empty envelope an unconfigured
+// upstream Prometheus would.
+//
+// Wire shape (matches upstream Prometheus exactly):
+//
+//	{
+//	  "status": "success",
+//	  "data": {"groups": []}    // rules
+//	  "data": {"alerts": []}    // alerts
+//	}
+//
+// Returning 404 here (the pre-handler behaviour) caused two visible
+// regressions in the compose stack:
+//
+//   - Every Grafana page load logged a `404 page not found` on
+//     `/api/datasources/uid/cerberus-prometheus/resources/api/v1/rules`,
+//     polluting the browser console and the user's "Failed to load
+//     resource" tally.
+//   - The Grafana alerting UI degraded to a generic error banner because
+//     the probe couldn't distinguish "datasource doesn't support rules"
+//     from "datasource is broken".
+//
+// A 200-with-empty-groups response answers both — Grafana treats it as
+// "no rules configured" and the page is quiet.
+func (h *Handler) handleRules(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, Response{
+		Status: "success",
+		Data:   map[string]any{"groups": []any{}},
+	})
+}
+
+// handleAlerts implements `/api/v1/alerts` — the active-alerts companion
+// to /rules. Same rationale: cerberus has no alerting state, so the
+// canonical empty envelope keeps Grafana's poll quiet.
+func (h *Handler) handleAlerts(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, Response{
+		Status: "success",
+		Data:   map[string]any{"alerts": []any{}},
+	})
+}


### PR DESCRIPTION
## Summary

- Grafana polls \`/api/v1/rules\` + \`/api/v1/alerts\` on every page load. cerberus had no handlers → 404 → noisy console errors + degraded alerting UI.
- Stub both with the canonical empty-envelope shape an unconfigured upstream Prometheus returns.
- Conformance test pins 200 + non-null \`[]\` payload.

Closes #185.

## Test plan

- [ ] CI: \`check\` + \`lint\` green
- [ ] Manual: \`curl 'http://localhost:8080/api/v1/rules'\` returns \`{\"status\":\"success\",\"data\":{\"groups\":[]}}\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)