### PR TITLE
fix(promql/histogram_quantile): strip _bucket suffix from classic-histogram name

### DIFF
--- a/internal/promql/histogram_quantile.go
+++ b/internal/promql/histogram_quantile.go
@@ -2,13 +2,57 @@ package promql
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/tsouza/cerberus/internal/chplan"
 	"github.com/tsouza/cerberus/internal/schema"
 )
+
+// stripBucketSuffix returns a copy of matchers where any
+// `__name__=<X>_bucket` matcher has the `_bucket` suffix removed.
+//
+// The Prometheus classic-histogram convention exposes one time series per
+// bucket under the name `<metric>_bucket` with a `le=<bound>` label
+// distinguishing them. OTel-CH stores the same data as one row per
+// observation with parallel `BucketCounts` × `ExplicitBounds` arrays
+// under the bare metric name (`<metric>`, no suffix), so a query
+// like `rate(http_server_request_duration_seconds_bucket[5m])` must
+// be translated to a filter against `MetricName='http_server_request_duration_seconds'`
+// to find any rows.
+//
+// Strip is applied at every classic-histogram lowering path (bare or
+// aggregated, instant or range). The exponential / native-histogram
+// path uses its own metric-name routing (ExpHistogramSuffix) so it
+// doesn't share this behaviour.
+func stripBucketSuffix(matchers []*labels.Matcher) []*labels.Matcher {
+	out := make([]*labels.Matcher, len(matchers))
+	for i, m := range matchers {
+		if m.Name == model.MetricNameLabel && m.Type == labels.MatchEqual && strings.HasSuffix(m.Value, "_bucket") {
+			// labels.NewMatcher recompiles a regex when applicable; for
+			// MatchEqual that's cheap. Build a fresh matcher rather
+			// than mutating the input — the parser may reuse the
+			// matcher slice across lowering passes.
+			copied, err := labels.NewMatcher(m.Type, m.Name, strings.TrimSuffix(m.Value, "_bucket"))
+			if err != nil {
+				// Defensive: NewMatcher only errors on regex compile;
+				// MatchEqual cannot. Forward the original on the
+				// near-impossible failure path so the lowering still
+				// produces a valid plan.
+				out[i] = m
+				continue
+			}
+			out[i] = copied
+			continue
+		}
+		out[i] = m
+	}
+	return out
+}
 
 // lowerHistogramQuantile handles `histogram_quantile(phi, X)`. X is
 // either:
@@ -126,12 +170,14 @@ func lowerHistogramQuantile(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chp
 		return lowerHistogramQuantileClassicBareRange(vs, phi, s, ctx), nil
 	}
 
-	// Target the classic-histogram table directly — the metric name is
-	// not required to carry a `_bucket` suffix (OTel-CH classic
+	// Target the classic-histogram table directly. OTel-CH classic
 	// histograms are one row per series with parallel BucketCounts +
-	// ExplicitBounds arrays; there is no `le` label).
+	// ExplicitBounds arrays (no `le` label per row), under the bare
+	// metric name. Strip the conventional `_bucket` suffix off the
+	// `__name__` matcher so a Grafana query of
+	// `rate(<X>_bucket[5m])` filters against `MetricName='<X>'`.
 	scan := &chplan.Scan{Table: s.HistogramTable}
-	pred := buildPredicate(vs.LabelMatchers, s)
+	pred := buildPredicate(stripBucketSuffix(vs.LabelMatchers), s)
 	if hasModifier(vs) {
 		anchor, err := anchorFromSelector(vs, ctx)
 		if err != nil {
@@ -301,9 +347,10 @@ func lowerHistogramQuantileAgg(shape histogramAggShape, phi float64, s schema.Me
 
 	// Build the Scan + Filter. The metric-name matcher and any
 	// user-supplied label matchers go straight through buildPredicate;
-	// the rate's [range] adds the time-bound window.
+	// the rate's [range] adds the time-bound window. `_bucket` suffix
+	// strip mirrors the bare-selector path — see stripBucketSuffix.
 	scan := &chplan.Scan{Table: s.HistogramTable}
-	pred := buildPredicate(vs.LabelMatchers, s)
+	pred := buildPredicate(stripBucketSuffix(vs.LabelMatchers), s)
 
 	anchor, err := anchorFromSelector(vs, ctx)
 	if err != nil {

--- a/internal/promql/histogram_quantile_range.go
+++ b/internal/promql/histogram_quantile_range.go
@@ -77,7 +77,12 @@ func lowerHistogramQuantileClassicBareRange(
 	ctx lowerCtx,
 ) chplan.Node {
 	scan := &chplan.Scan{Table: s.HistogramTable}
-	pred := buildPredicate(vs.LabelMatchers, s)
+	// `_bucket` suffix strip — see stripBucketSuffix in
+	// histogram_quantile.go. Grafana classic-histogram dashboards
+	// fire `rate(<X>_bucket[r])`; the OTel-CH histogram row carries
+	// the bare `<X>` MetricName, so the strip is what makes the
+	// filter find rows.
+	pred := buildPredicate(stripBucketSuffix(vs.LabelMatchers), s)
 
 	groupBy := []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}}
 	groupByAliases := []string{s.AttributesColumn}
@@ -121,7 +126,9 @@ func lowerHistogramQuantileClassicAggRange(
 ) chplan.Node {
 	vs := shape.selector
 	scan := &chplan.Scan{Table: s.HistogramTable}
-	pred := buildPredicate(vs.LabelMatchers, s)
+	// `_bucket` suffix strip — see stripBucketSuffix in
+	// histogram_quantile.go.
+	pred := buildPredicate(stripBucketSuffix(vs.LabelMatchers), s)
 
 	groupBy, groupByAliases, attrsRebuild := histogramAggGroupBy(shape.agg, s)
 	bucketAggs := []chplan.AggFunc{

--- a/internal/promql/histogram_quantile_strip_test.go
+++ b/internal/promql/histogram_quantile_strip_test.go
@@ -1,0 +1,146 @@
+package promql
+
+import (
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+// TestStripBucketSuffix pins the Grafana classic-histogram name
+// translation: when a query references `<X>_bucket`, the classic
+// lowering must read from the OTel-CH histogram row keyed by `<X>`
+// (no suffix). The pre-fix behaviour silently routed the
+// `MetricName='<X>_bucket'` predicate to the histogram table where it
+// matched zero rows — every dashboard p95 panel rendered "No data".
+//
+// Coverage:
+//   - `__name__="<X>_bucket"` MatchEqual → rewritten to `<X>`.
+//   - `__name__="<X>"` (no suffix) → unchanged.
+//   - `__name__=~"<X>_bucket"` MatchRegexp → unchanged (regex matchers
+//     are user-authored; we do not edit them — stripping a regex
+//     anchor would change the semantics).
+//   - non-`__name__` matchers → unchanged.
+//   - empty input → empty output (no panic on nil).
+//   - boundary: `__name__="_bucket"` → stripped to `""` (acceptable —
+//     no real histogram is named `_bucket`, so the resulting empty
+//     `__name__` filter is harmless and matches no rows).
+func TestStripBucketSuffix(t *testing.T) {
+	t.Parallel()
+
+	mk := func(typ labels.MatchType, name, value string) *labels.Matcher {
+		m, err := labels.NewMatcher(typ, name, value)
+		if err != nil {
+			t.Fatalf("NewMatcher(%v, %q, %q): %v", typ, name, value, err)
+		}
+		return m
+	}
+
+	type expect struct {
+		name, value string
+		matchType   labels.MatchType
+	}
+	cases := []struct {
+		name string
+		in   []*labels.Matcher
+		want []expect
+	}{
+		{
+			name: "name_bucket_stripped",
+			in: []*labels.Matcher{
+				mk(labels.MatchEqual, model.MetricNameLabel, "http_request_duration_bucket"),
+			},
+			want: []expect{
+				{name: model.MetricNameLabel, value: "http_request_duration", matchType: labels.MatchEqual},
+			},
+		},
+		{
+			name: "name_without_bucket_unchanged",
+			in: []*labels.Matcher{
+				mk(labels.MatchEqual, model.MetricNameLabel, "http_request_duration"),
+			},
+			want: []expect{
+				{name: model.MetricNameLabel, value: "http_request_duration", matchType: labels.MatchEqual},
+			},
+		},
+		{
+			name: "name_regex_unchanged",
+			in: []*labels.Matcher{
+				mk(labels.MatchRegexp, model.MetricNameLabel, ".*_bucket"),
+			},
+			want: []expect{
+				{name: model.MetricNameLabel, value: ".*_bucket", matchType: labels.MatchRegexp},
+			},
+		},
+		{
+			name: "other_labels_unchanged",
+			in: []*labels.Matcher{
+				mk(labels.MatchEqual, model.MetricNameLabel, "http_request_duration_bucket"),
+				mk(labels.MatchEqual, "job", "api_bucket"),
+				mk(labels.MatchRegexp, "instance", "host-.*"),
+			},
+			want: []expect{
+				{name: model.MetricNameLabel, value: "http_request_duration", matchType: labels.MatchEqual},
+				{name: "job", value: "api_bucket", matchType: labels.MatchEqual},
+				{name: "instance", value: "host-.*", matchType: labels.MatchRegexp},
+			},
+		},
+		{
+			name: "empty_input",
+			in:   nil,
+			want: nil,
+		},
+		{
+			name: "boundary_bare_underscore_bucket",
+			in: []*labels.Matcher{
+				mk(labels.MatchEqual, model.MetricNameLabel, "_bucket"),
+			},
+			want: []expect{
+				{name: model.MetricNameLabel, value: "", matchType: labels.MatchEqual},
+			},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := stripBucketSuffix(tc.in)
+			if len(got) != len(tc.want) {
+				t.Fatalf("len: got %d, want %d", len(got), len(tc.want))
+			}
+			for i, g := range got {
+				w := tc.want[i]
+				if g.Name != w.name || g.Value != w.value || g.Type != w.matchType {
+					t.Errorf("matcher[%d]: got (%v, %q, %q), want (%v, %q, %q)",
+						i, g.Type, g.Name, g.Value, w.matchType, w.name, w.value)
+				}
+			}
+		})
+	}
+}
+
+// TestStripBucketSuffix_DoesNotMutateInput pins the copy-on-write
+// invariant: the input slice + matcher pointers must not be mutated
+// by the strip. PromQL's parser may reuse matcher slices across
+// lowering passes; an in-place rewrite would leak the bare name back
+// into subsequent passes that expected the `_bucket`-suffixed form.
+func TestStripBucketSuffix_DoesNotMutateInput(t *testing.T) {
+	t.Parallel()
+
+	origin, err := labels.NewMatcher(labels.MatchEqual, model.MetricNameLabel, "http_request_duration_bucket")
+	if err != nil {
+		t.Fatalf("NewMatcher: %v", err)
+	}
+	in := []*labels.Matcher{origin}
+
+	out := stripBucketSuffix(in)
+	if out[0] == origin {
+		t.Fatalf("stripBucketSuffix reused the input pointer; must allocate a fresh matcher")
+	}
+	if origin.Value != "http_request_duration_bucket" {
+		t.Errorf("input matcher Value mutated: %q", origin.Value)
+	}
+	if out[0].Value != "http_request_duration" {
+		t.Errorf("output matcher Value: got %q, want %q", out[0].Value, "http_request_duration")
+	}
+}

--- a/internal/promql/histogram_quantile_strip_test.go
+++ b/internal/promql/histogram_quantile_strip_test.go
@@ -144,3 +144,213 @@ func TestStripBucketSuffix_DoesNotMutateInput(t *testing.T) {
 		t.Errorf("output matcher Value: got %q, want %q", out[0].Value, "http_request_duration")
 	}
 }
+
+// TestStripBucketSuffix_PassesThroughNonMatching pins the pointer-
+// passthrough contract for matchers that don't satisfy ALL three
+// strip conditions (Name==__name__ AND Type==MatchEqual AND
+// HasSuffix(_bucket)). Non-matching matchers must be reused
+// pointer-identically — they are NEVER re-allocated.
+//
+// This kills the invert-logical mutant on the second `&&`
+// (`A && B && C` → `A && (B || C)`) on inputs where A=T, B=T, C=F:
+// the mutated branch would enter the strip path, call
+// labels.NewMatcher, and store a *fresh* pointer in `out[i]` even
+// though TrimSuffix would be a no-op on the value. The pointer-
+// identity check distinguishes the two paths even when the matcher
+// fields look semantically identical.
+//
+// Mirror coverage for the other two conditions:
+//
+//   - `Name != __name__` (a regular label like `job`) — even if
+//     Type==MatchEqual and value has `_bucket` suffix, must pass through.
+//   - `Type != MatchEqual` (a regex matcher) — even if Name==__name__
+//     and the value text ends in `_bucket`, must pass through.
+func TestStripBucketSuffix_PassesThroughNonMatching(t *testing.T) {
+	t.Parallel()
+
+	mk := func(typ labels.MatchType, name, value string) *labels.Matcher {
+		m, err := labels.NewMatcher(typ, name, value)
+		if err != nil {
+			t.Fatalf("NewMatcher(%v, %q, %q): %v", typ, name, value, err)
+		}
+		return m
+	}
+
+	cases := []struct {
+		name string
+		in   *labels.Matcher
+	}{
+		{
+			// A=T, B=T, C=F: name is __name__, type is MatchEqual, but
+			// the value has no `_bucket` suffix. Kills the
+			// `A && (B || C)` invert-logical mutant on the second `&&`.
+			name: "name_metricname_eq_no_bucket_suffix",
+			in:   mk(labels.MatchEqual, model.MetricNameLabel, "http_request_duration"),
+		},
+		{
+			// A=F, B=T, C=T: name is a regular label, type is MatchEqual,
+			// value ends in `_bucket`. Pins the Name==__name__ guard.
+			name: "name_not_metricname_value_has_bucket",
+			in:   mk(labels.MatchEqual, "job", "api_bucket"),
+		},
+		{
+			// A=T, B=F, C=T: name is __name__, type is regex, value
+			// looks like `*_bucket`. Pins the Type==MatchEqual guard.
+			name: "name_metricname_regex_value_has_bucket",
+			in:   mk(labels.MatchRegexp, model.MetricNameLabel, ".*_bucket"),
+		},
+		{
+			// A=T, B=F, C=F: regex matcher without suffix in pattern.
+			// Pins the combined Type==MatchEqual + HasSuffix guard.
+			name: "name_metricname_regex_no_bucket",
+			in:   mk(labels.MatchRegexp, model.MetricNameLabel, ".*"),
+		},
+		{
+			// A=F, B=F, C=T: regular label with regex matcher whose
+			// pattern happens to end in `_bucket`. Belt-and-braces:
+			// only matchers that satisfy ALL three conditions trigger
+			// the strip.
+			name: "name_not_metricname_regex_value_has_bucket",
+			in:   mk(labels.MatchRegexp, "job", ".*_bucket"),
+		},
+		{
+			// A=F, B=T, C=F: regular label, MatchEqual, value without
+			// `_bucket` suffix. The "all three false" baseline.
+			name: "name_not_metricname_eq_no_bucket",
+			in:   mk(labels.MatchEqual, "job", "api"),
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			out := stripBucketSuffix([]*labels.Matcher{tc.in})
+			if len(out) != 1 {
+				t.Fatalf("len(out) = %d, want 1", len(out))
+			}
+			if out[0] != tc.in {
+				t.Errorf("non-matching matcher was re-allocated: got %p, want %p (%v %q=%q)",
+					out[0], tc.in, tc.in.Type, tc.in.Name, tc.in.Value)
+			}
+		})
+	}
+}
+
+// TestStripBucketSuffix_PreservesPositionAndLength pins the slice
+// shape: the output is a fresh slice of EXACTLY len(input), with
+// each position carrying either the rewritten matcher (when all
+// three strip conditions hold) or the original pointer (otherwise).
+//
+// Coverage targets:
+//
+//   - `make([]*labels.Matcher, len(matchers))` with conditionals-
+//     boundary or arithmetic mutations: a wrong allocation length
+//     panics on out-of-bounds write or leaves nil tail entries.
+//   - empty-input case asserts the function does NOT panic and
+//     returns a non-nil zero-length slice (callers downstream may
+//     range over `out` and expect a defined, even if empty, value).
+//   - position preservation kills mutants that swap `i` with a
+//     constant (e.g., always overwriting `out[0]`).
+func TestStripBucketSuffix_PreservesPositionAndLength(t *testing.T) {
+	t.Parallel()
+
+	mk := func(typ labels.MatchType, name, value string) *labels.Matcher {
+		m, err := labels.NewMatcher(typ, name, value)
+		if err != nil {
+			t.Fatalf("NewMatcher(%v, %q, %q): %v", typ, name, value, err)
+		}
+		return m
+	}
+
+	// Three matchers in a deliberately scrambled order so that a
+	// mutant which (a) always writes out[0], or (b) reverses the
+	// loop direction, surfaces as either a duplicated or
+	// out-of-order output.
+	m0 := mk(labels.MatchEqual, "job", "api")                                  // pass-through
+	m1 := mk(labels.MatchEqual, model.MetricNameLabel, "http_duration_bucket") // strip
+	m2 := mk(labels.MatchRegexp, "instance", "host-.*")                        // pass-through
+	in := []*labels.Matcher{m0, m1, m2}
+
+	out := stripBucketSuffix(in)
+	if len(out) != len(in) {
+		t.Fatalf("len(out) = %d, want %d", len(out), len(in))
+	}
+	if out[0] != m0 {
+		t.Errorf("out[0] = %p, want pass-through of m0 %p", out[0], m0)
+	}
+	if out[1] == m1 {
+		t.Errorf("out[1] is the original m1 pointer; must be a fresh stripped matcher")
+	}
+	if out[1].Value != "http_duration" {
+		t.Errorf("out[1].Value = %q, want %q", out[1].Value, "http_duration")
+	}
+	if out[2] != m2 {
+		t.Errorf("out[2] = %p, want pass-through of m2 %p", out[2], m2)
+	}
+
+	// Empty-input path: must return a non-nil zero-length slice.
+	// A `len(matchers)-1` mutation would panic here (negative cap);
+	// returning nil would still pass `len()==0` but break callers
+	// that do `append(...stripBucketSuffix(...)...)` patterns.
+	empty := stripBucketSuffix(nil)
+	if len(empty) != 0 {
+		t.Errorf("stripBucketSuffix(nil) length = %d, want 0", len(empty))
+	}
+
+	// Single-element input strictly matters for the `len()` allocation
+	// bound: a `len-1` arithmetic mutant would panic on the first
+	// `out[0] = ...` write. Explicitly run a 1-element case so the
+	// boundary mutant has a deterministic crash site.
+	one := stripBucketSuffix([]*labels.Matcher{m0})
+	if len(one) != 1 {
+		t.Errorf("stripBucketSuffix(1-element) length = %d, want 1", len(one))
+	}
+	if one[0] != m0 {
+		t.Errorf("stripBucketSuffix(1-element)[0] = %p, want %p", one[0], m0)
+	}
+}
+
+// TestStripBucketSuffix_TrimSuffixSemantics pins that the strip
+// removes EXACTLY the trailing `_bucket` and nothing more. Kills
+// any mutant that turns `strings.TrimSuffix(m.Value, "_bucket")`
+// into a different transformation (e.g., chopping a different
+// fixed number of characters, removing all occurrences, trimming
+// from the left).
+//
+// `_bucket_bucket` → `_bucket` (only the trailing suffix removed).
+// `bucket_bucket`  → `bucket` (the leading `bucket` token survives).
+// `__bucket`       → `_` (a single underscore remains).
+func TestStripBucketSuffix_TrimSuffixSemantics(t *testing.T) {
+	t.Parallel()
+
+	mk := func(value string) *labels.Matcher {
+		m, err := labels.NewMatcher(labels.MatchEqual, model.MetricNameLabel, value)
+		if err != nil {
+			t.Fatalf("NewMatcher(%q): %v", value, err)
+		}
+		return m
+	}
+
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"_bucket_bucket", "_bucket_bucket"[:len("_bucket_bucket")-len("_bucket")]}, // -> "_bucket"
+		{"bucket_bucket", "bucket"},
+		{"__bucket", "_"},
+		{"http_request_duration_bucket", "http_request_duration"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.in, func(t *testing.T) {
+			t.Parallel()
+			out := stripBucketSuffix([]*labels.Matcher{mk(tc.in)})
+			if len(out) != 1 {
+				t.Fatalf("len(out) = %d, want 1", len(out))
+			}
+			if out[0].Value != tc.want {
+				t.Errorf("stripBucketSuffix(%q).Value = %q, want %q", tc.in, out[0].Value, tc.want)
+			}
+		})
+	}
+}

--- a/internal/promql/histogram_quantile_test.go
+++ b/internal/promql/histogram_quantile_test.go
@@ -672,10 +672,18 @@ func TestLower_HistogramQuantile_BucketSuffixStrip(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Lower: %v", err)
 			}
-			sql, _, err := chsql.Emit(context.Background(), plan)
+			sql, args, err := chsql.Emit(context.Background(), plan)
 			if err != nil {
 				t.Fatalf("Emit: %v", err)
 			}
+			// The chsql emitter renders string literals (including the
+			// MetricName predicate value) as `?` placeholders carried in
+			// the `args` slice — they don't appear inlined in the SQL.
+			// Check both: (a) the SQL text never carries the suffixed
+			// name (no path inlines `_bucket`), (b) the args carry the
+			// BARE name and never the suffixed name, and (c) the SQL
+			// targets the classic-histogram table (so the strip didn't
+			// misroute the lowering to a non-histogram table).
 			if strings.Contains(sql, suffixed) {
 				t.Errorf("emitted SQL contains the unstripped suffixed name %q — "+
 					"the histogram table is keyed by the BARE metric name; "+
@@ -683,11 +691,35 @@ func TestLower_HistogramQuantile_BucketSuffixStrip(t *testing.T) {
 					"every dashboard p95 panel reads 'No data'.\nfull SQL:\n%s",
 					suffixed, sql)
 			}
-			if !strings.Contains(sql, bare) {
-				t.Errorf("emitted SQL does not contain the bare metric name %q — "+
+			if !strings.Contains(sql, "`"+s.HistogramTable+"`") {
+				t.Errorf("emitted SQL does not target the classic-histogram table %q — "+
 					"the strip dropped too much or the histogram path is "+
 					"misrouting to a non-histogram table.\nfull SQL:\n%s",
-					bare, sql)
+					s.HistogramTable, sql)
+			}
+			var sawBare, sawSuffixed bool
+			for _, a := range args {
+				str, ok := a.(string)
+				if !ok {
+					continue
+				}
+				if str == bare {
+					sawBare = true
+				}
+				if str == suffixed {
+					sawSuffixed = true
+				}
+			}
+			if sawSuffixed {
+				t.Errorf("emitted SQL params carry the unstripped suffixed name %q — "+
+					"the histogram table is keyed by the BARE metric name; "+
+					"a `_bucket`-suffixed predicate matches zero rows.\nargs: %v",
+					suffixed, args)
+			}
+			if !sawBare {
+				t.Errorf("emitted SQL params do not carry the bare metric name %q — "+
+					"the strip dropped too much.\nargs: %v",
+					bare, args)
 			}
 		})
 	}

--- a/internal/promql/histogram_quantile_test.go
+++ b/internal/promql/histogram_quantile_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
 	"github.com/tsouza/cerberus/internal/promql"
 	"github.com/tsouza/cerberus/internal/schema"
 )
@@ -589,6 +590,104 @@ func TestLower_HistogramQuantile_Errors(t *testing.T) {
 				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
 			} else if !strings.Contains(err.Error(), tc.wantErr) {
 				t.Fatalf("error %q does not contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestLower_HistogramQuantile_BucketSuffixStrip pins the Grafana
+// classic-histogram dashboard pattern:
+//
+//	histogram_quantile(0.95, sum by (le) (rate(<X>_bucket[5m])))
+//
+// OTel-CH stores the same data as one row per observation under the
+// bare metric name `<X>` (no `_bucket` suffix; the BucketCounts +
+// ExplicitBounds arrays carry the distribution). Pre-fix, cerberus
+// passed the `__name__='<X>_bucket'` matcher through verbatim, the
+// emitted WHERE filtered the histogram table for a non-existent
+// MetricName, and every dashboard p95 panel rendered "No data".
+//
+// The fix (stripBucketSuffix in histogram_quantile.go) trims `_bucket`
+// off the `__name__` matcher before the predicate emits. Pin both:
+//
+//  1. The emitted SQL filters on the BARE name (no `_bucket`).
+//  2. The SQL does NOT carry the unstripped `_bucket`-suffixed form.
+//
+// Coverage at every classic-histogram entry point:
+//   - bare selector (instant): `histogram_quantile(phi, <X>_bucket)`
+//   - aggregated (instant):    `histogram_quantile(phi, sum by(le) (rate(<X>_bucket[r])))`
+//   - bare selector (range):   same as bare-instant under range mode
+//   - aggregated (range):      same as agg-instant under range mode
+func TestLower_HistogramQuantile_BucketSuffixStrip(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+
+	// Same metric across all cases — `cerberus_queries_duration_seconds`
+	// mirrors the actual self-telemetry histogram the dashboard targets.
+	const bare = "cerberus_queries_duration_seconds"
+	const suffixed = bare + "_bucket"
+
+	cases := []struct {
+		name    string
+		query   string
+		ctxStep time.Duration // 0 == instant, > 0 == range mode
+	}{
+		{
+			name:  "bare_instant",
+			query: `histogram_quantile(0.95, ` + suffixed + `)`,
+		},
+		{
+			name:  "agg_instant",
+			query: `histogram_quantile(0.95, sum by (le) (rate(` + suffixed + `[5m])))`,
+		},
+		{
+			name:    "bare_range",
+			query:   `histogram_quantile(0.95, ` + suffixed + `)`,
+			ctxStep: 30 * time.Second,
+		},
+		{
+			name:    "agg_range",
+			query:   `histogram_quantile(0.95, sum by (le) (rate(` + suffixed + `[5m])))`,
+			ctxStep: 30 * time.Second,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr: %v", err)
+			}
+			var plan chplan.Node
+			if tc.ctxStep > 0 {
+				start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+				end := start.Add(time.Hour)
+				plan, err = promql.LowerAtRange(context.Background(), expr, s, start, end, tc.ctxStep)
+			} else {
+				plan, err = promql.Lower(context.Background(), expr, s)
+			}
+			if err != nil {
+				t.Fatalf("Lower: %v", err)
+			}
+			sql, _, err := chsql.Emit(context.Background(), plan)
+			if err != nil {
+				t.Fatalf("Emit: %v", err)
+			}
+			if strings.Contains(sql, suffixed) {
+				t.Errorf("emitted SQL contains the unstripped suffixed name %q — "+
+					"the histogram table is keyed by the BARE metric name; "+
+					"a `_bucket`-suffixed predicate matches zero rows and "+
+					"every dashboard p95 panel reads 'No data'.\nfull SQL:\n%s",
+					suffixed, sql)
+			}
+			if !strings.Contains(sql, bare) {
+				t.Errorf("emitted SQL does not contain the bare metric name %q — "+
+					"the strip dropped too much or the histogram path is "+
+					"misrouting to a non-histogram table.\nfull SQL:\n%s",
+					bare, sql)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Grafana classic-histogram dashboards fire \`histogram_quantile(0.95, sum by(le) (rate(<X>_bucket[5m])))\`. cerberus stored the same data under the bare \`<X>\` MetricName, so the \`_bucket\`-suffixed predicate matched zero rows and every p95 panel rendered "No data".
- Add \`stripBucketSuffix\` and call it at the four classic-histogram lowering paths (bare + agg, instant + range). Native paths untouched.
- Tests at unit + lowering layers pin the strip in both directions (bare stays present, suffixed form does not appear in SQL).

Closes #182.

🤖 Generated with [Claude Code](https://claude.com/claude-code)