### PR TITLE
feat(api/prom): rewrite OTel-style dotted metric names to {__name__=...}

### DIFF
--- a/internal/api/prom/dotted_names.go
+++ b/internal/api/prom/dotted_names.go
@@ -1,0 +1,191 @@
+package prom
+
+import "strings"
+
+// normalizeDottedSelectors rewrites OTel-style dotted metric names in
+// selector position to the explicit `{__name__="..."}` form so the
+// PromQL parser — which only accepts ASCII identifiers matching
+// `[a-zA-Z_:][a-zA-Z0-9_:]*` — can handle them.
+//
+// Example: `rate(http.server.request.duration[5m])` becomes
+// `rate({__name__="http.server.request.duration"}[5m])`.
+//
+// Why this is needed: OpenTelemetry's semantic conventions emit dotted
+// metric names (`http.server.request.duration`, `db.client.duration`,
+// `system.cpu.utilization`, etc.). Reference Prometheus has no support
+// for dotted identifiers in selector position; users either rewrite to
+// `{__name__="..."}` manually or hit a 400 parse error. Grafana's
+// metric picker happily round-trips dotted names through cerberus's
+// `/api/v1/label/__name__/values` endpoint, so without this rewrite a
+// user can SEE the dotted metric in the picker, click it, and watch
+// the query fail to parse.
+//
+// The rewrite walks the query as runes, tracking:
+//   - whether we're inside `"…"` / `'…'` / `` `…` `` strings (skip rewrites
+//     so a string literal `"a.b.c"` isn't molested)
+//   - whether the current rune-position is a valid identifier-start
+//     position (after start-of-string, whitespace, or any of the
+//     selector-context delimiters `({,=~!|+-*/<>` etc.)
+//
+// At an identifier-start position we greedy-consume `[a-zA-Z_]([a-zA-Z0-9_]|\.)*`.
+// If the consumed token contains at least one `.` (the load-bearing
+// distinguisher between OTel-dotted names and PromQL-valid names like
+// `http_server_request_duration`), we emit `{__name__="<token>"}`;
+// otherwise we leave the token unchanged.
+//
+// We do NOT try to second-guess whether the dotted name corresponds to
+// a real metric; the resulting selector either matches rows in CH or
+// it doesn't (just like any other selector). False positives — e.g. a
+// dotted token that was meant as a function name — surface as a clean
+// "metric not found" empty result, not a parse error.
+//
+// Known limitations:
+//   - PromQL function names that contain dots are not currently a thing;
+//     no false positive there.
+//   - PromQL label-matcher operators (`=`, `!=`, `=~`, `!~`) are
+//     skipped during string-state tracking via the surrounding
+//     identifier-position predicate.
+//   - Numeric literals like `1.5` are not identifier-start positions
+//     (digit cannot start an identifier), so they pass through unchanged.
+func normalizeDottedSelectors(q string) string {
+	if !strings.ContainsRune(q, '.') {
+		return q
+	}
+	var out strings.Builder
+	out.Grow(len(q) + 32)
+
+	type stringState int
+	const (
+		outside stringState = iota
+		inDouble
+		inSingle
+		inBacktick
+	)
+
+	state := outside
+	identStart := true // start-of-input is identifier-position
+	i := 0
+	for i < len(q) {
+		ch := q[i]
+		switch state {
+		case inDouble:
+			out.WriteByte(ch)
+			if ch == '\\' && i+1 < len(q) {
+				out.WriteByte(q[i+1])
+				i += 2
+				continue
+			}
+			if ch == '"' {
+				state = outside
+			}
+			i++
+			identStart = false
+			continue
+		case inSingle:
+			out.WriteByte(ch)
+			if ch == '\\' && i+1 < len(q) {
+				out.WriteByte(q[i+1])
+				i += 2
+				continue
+			}
+			if ch == '\'' {
+				state = outside
+			}
+			i++
+			identStart = false
+			continue
+		case inBacktick:
+			out.WriteByte(ch)
+			if ch == '`' {
+				state = outside
+			}
+			i++
+			identStart = false
+			continue
+		}
+
+		// outside any string
+		switch ch {
+		case '"':
+			state = inDouble
+			out.WriteByte(ch)
+			i++
+			identStart = false
+			continue
+		case '\'':
+			state = inSingle
+			out.WriteByte(ch)
+			i++
+			identStart = false
+			continue
+		case '`':
+			state = inBacktick
+			out.WriteByte(ch)
+			i++
+			identStart = false
+			continue
+		}
+
+		if identStart && isIdentStart(ch) {
+			// Greedy-consume an identifier-with-dots token.
+			j := i + 1
+			for j < len(q) && (isIdentCont(q[j]) || q[j] == '.') {
+				j++
+			}
+			tok := q[i:j]
+			// Trailing dot is suspicious (e.g. a stray `.` at end of
+			// token) — strip it from the rewrite candidate and write
+			// the leftover dot back into the stream so downstream
+			// tokens still see it.
+			trailingDot := strings.HasSuffix(tok, ".")
+			if trailingDot {
+				tok = strings.TrimRight(tok, ".")
+			}
+			if strings.Contains(tok, ".") {
+				out.WriteString(`{__name__="`)
+				out.WriteString(tok)
+				out.WriteString(`"}`)
+			} else {
+				out.WriteString(tok)
+			}
+			if trailingDot {
+				// Emit the dot that we stripped so the parser still
+				// sees the surrounding tokens (rare path — defensive).
+				out.WriteByte('.')
+			}
+			i = j
+			identStart = false
+			continue
+		}
+
+		// Default: emit the rune and update identStart state.
+		out.WriteByte(ch)
+		identStart = isIdentBoundary(ch)
+		i++
+	}
+	return out.String()
+}
+
+func isIdentStart(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || b == '_' || b == ':'
+}
+
+func isIdentCont(b byte) bool {
+	return isIdentStart(b) || (b >= '0' && b <= '9')
+}
+
+// isIdentBoundary reports whether the previous-rune state means the
+// next rune (if a letter / underscore) starts a new identifier — i.e.
+// we are AFTER whitespace or a selector-context delimiter. Carefully
+// excludes `.` so `foo.bar` isn't split into two identifier-position
+// tokens (the rewrite needs to see the whole dotted name in one shot).
+func isIdentBoundary(b byte) bool {
+	switch b {
+	case ' ', '\t', '\n', '\r',
+		'(', '{', '[', ',',
+		'+', '-', '*', '/', '%', '^',
+		'=', '<', '>', '!', '|', '&', '@':
+		return true
+	}
+	return false
+}

--- a/internal/api/prom/dotted_names.go
+++ b/internal/api/prom/dotted_names.go
@@ -21,7 +21,7 @@ import "strings"
 // the query fail to parse.
 //
 // The rewrite walks the query as runes, tracking:
-//   - whether we're inside `"…"` / `'…'` / `` `…` `` strings (skip rewrites
+//   - whether we're inside `"…"` / `'…'` / “ `…` “ strings (skip rewrites
 //     so a string literal `"a.b.c"` isn't molested)
 //   - whether the current rune-position is a valid identifier-start
 //     position (after start-of-string, whitespace, or any of the

--- a/internal/api/prom/dotted_names.go
+++ b/internal/api/prom/dotted_names.go
@@ -2,6 +2,18 @@ package prom
 
 import "strings"
 
+// stringState tracks which (if any) string literal the dotted-selector
+// rewriter is currently inside. Package-scoped so the small helpers
+// below can share it with normalizeDottedSelectors.
+type stringState int
+
+const (
+	outside stringState = iota
+	inDouble
+	inSingle
+	inBacktick
+)
+
 // normalizeDottedSelectors rewrites OTel-style dotted metric names in
 // selector position to the explicit `{__name__="..."}` form so the
 // PromQL parser — which only accepts ASCII identifiers matching
@@ -54,72 +66,19 @@ func normalizeDottedSelectors(q string) string {
 	var out strings.Builder
 	out.Grow(len(q) + 32)
 
-	type stringState int
-	const (
-		outside stringState = iota
-		inDouble
-		inSingle
-		inBacktick
-	)
-
 	state := outside
 	identStart := true // start-of-input is identifier-position
 	i := 0
 	for i < len(q) {
 		ch := q[i]
-		switch state {
-		case inDouble:
-			out.WriteByte(ch)
-			if ch == '\\' && i+1 < len(q) {
-				out.WriteByte(q[i+1])
-				i += 2
-				continue
-			}
-			if ch == '"' {
-				state = outside
-			}
-			i++
-			identStart = false
-			continue
-		case inSingle:
-			out.WriteByte(ch)
-			if ch == '\\' && i+1 < len(q) {
-				out.WriteByte(q[i+1])
-				i += 2
-				continue
-			}
-			if ch == '\'' {
-				state = outside
-			}
-			i++
-			identStart = false
-			continue
-		case inBacktick:
-			out.WriteByte(ch)
-			if ch == '`' {
-				state = outside
-			}
-			i++
+		if state != outside {
+			i, state = advanceInString(&out, q, i, state)
 			identStart = false
 			continue
 		}
 
-		// outside any string
-		switch ch {
-		case '"':
-			state = inDouble
-			out.WriteByte(ch)
-			i++
-			identStart = false
-			continue
-		case '\'':
-			state = inSingle
-			out.WriteByte(ch)
-			i++
-			identStart = false
-			continue
-		case '`':
-			state = inBacktick
+		if next, ok := openString(ch); ok {
+			state = next
 			out.WriteByte(ch)
 			i++
 			identStart = false
@@ -164,6 +123,41 @@ func normalizeDottedSelectors(q string) string {
 		i++
 	}
 	return out.String()
+}
+
+// openString reports whether `ch` opens a string literal and, if so,
+// the string state we enter. Returned `ok=false` means `ch` is not a
+// string-opening delimiter.
+func openString(ch byte) (stringState, bool) {
+	switch ch {
+	case '"':
+		return inDouble, true
+	case '\'':
+		return inSingle, true
+	case '`':
+		return inBacktick, true
+	}
+	return outside, false
+}
+
+// advanceInString copies one rune (or one escape pair) from `q` at
+// position `i` into `out`, updating the string state when the closing
+// delimiter is seen. Backticked strings do not honour `\` escapes (raw
+// strings); double / single quoted strings do.
+func advanceInString(out *strings.Builder, q string, i int, state stringState) (int, stringState) {
+	ch := q[i]
+	out.WriteByte(ch)
+	if state != inBacktick && ch == '\\' && i+1 < len(q) {
+		out.WriteByte(q[i+1])
+		return i + 2, state
+	}
+	switch {
+	case state == inDouble && ch == '"',
+		state == inSingle && ch == '\'',
+		state == inBacktick && ch == '`':
+		state = outside
+	}
+	return i + 1, state
 }
 
 func isIdentStart(b byte) bool {

--- a/internal/api/prom/dotted_names_test.go
+++ b/internal/api/prom/dotted_names_test.go
@@ -1,0 +1,133 @@
+package prom
+
+import "testing"
+
+// TestNormalizeDottedSelectors covers the OTel-dotted-name rewrite at
+// the unit layer. The handler wires this in front of `parser.ParseExpr`
+// so a Grafana query containing `http.server.request.duration` lowers
+// the way `{__name__="http.server.request.duration"}` would.
+func TestNormalizeDottedSelectors(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// no rewrite — query contains no dotted identifiers
+		{
+			name: "noop_no_dots",
+			in:   `rate(http_requests_total[5m])`,
+			want: `rate(http_requests_total[5m])`,
+		},
+		{
+			name: "noop_numeric_literal_with_dot",
+			in:   `1.5 * rate(x[5m])`,
+			want: `1.5 * rate(x[5m])`,
+		},
+		// bare metric name with dots
+		{
+			name: "bare_dotted_metric",
+			in:   `http.server.request.duration`,
+			want: `{__name__="http.server.request.duration"}`,
+		},
+		// dotted metric inside a function call
+		{
+			name: "inside_rate",
+			in:   `rate(http.server.request.duration[5m])`,
+			want: `rate({__name__="http.server.request.duration"}[5m])`,
+		},
+		// dotted metric inside an aggregation
+		{
+			name: "inside_aggregation",
+			in:   `sum by (le) (rate(http.server.request.duration_bucket[5m]))`,
+			want: `sum by (le) (rate({__name__="http.server.request.duration_bucket"}[5m]))`,
+		},
+		// dotted metric on both sides of a binop
+		{
+			name: "binop_both_sides_dotted",
+			in:   `a.b.c + x.y.z`,
+			want: `{__name__="a.b.c"} + {__name__="x.y.z"}`,
+		},
+		// dotted metric with label matcher — Grafana's metric picker
+		// drops the user into this shape when they pick a metric AND
+		// add a label filter.
+		{
+			name: "dotted_with_label_filter",
+			in:   `http.server.request.duration{job="api"}`,
+			want: `{__name__="http.server.request.duration"}{job="api"}`,
+		},
+		// string content must not be rewritten — a dotted string inside
+		// `"..."` is a label-value, not a metric name.
+		{
+			name: "preserve_string_content",
+			in:   `up{job="my.api.service"}`,
+			want: `up{job="my.api.service"}`,
+		},
+		{
+			name: "preserve_string_content_with_escape",
+			in:   `up{job="my.api.\"escaped\".service"}`,
+			want: `up{job="my.api.\"escaped\".service"}`,
+		},
+		// backtick string — Loki / cerberus harness pattern; the
+		// classifier still has to honor it. The parser is PromQL but
+		// the function should not corrupt backtick strings.
+		{
+			name: "preserve_backtick_string",
+			in:   "up{job=`my.api.service`}",
+			want: "up{job=`my.api.service`}",
+		},
+		// histogram_quantile classic shape with dotted name (a
+		// composition of every code path that the rewrite has to walk
+		// past — function call, agg-by, rate, range-vec selector,
+		// label matcher).
+		{
+			name: "histogram_quantile_classic_dotted",
+			in:   `histogram_quantile(0.95, sum by (le) (rate(http.server.duration_bucket{job="api"}[5m])))`,
+			want: `histogram_quantile(0.95, sum by (le) (rate({__name__="http.server.duration_bucket"}{job="api"}[5m])))`,
+		},
+		// empty input must round-trip
+		{
+			name: "empty",
+			in:   ``,
+			want: ``,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := normalizeDottedSelectors(tc.in)
+			if got != tc.want {
+				t.Errorf("normalizeDottedSelectors(%q):\n got: %q\nwant: %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNormalizeDottedSelectors_Idempotent pins idempotency — running
+// the rewrite twice produces the same result as running it once. The
+// second pass should see only `{__name__="..."}` form (already inside
+// a label-matcher string) and leave it untouched.
+func TestNormalizeDottedSelectors_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	inputs := []string{
+		`rate(http.server.request.duration[5m])`,
+		`sum by (job) (a.b + x.y.z)`,
+		`up{job="my.api"}`,
+		`histogram_quantile(0.95, sum by (le) (rate(http.server.duration_bucket{job="api"}[5m])))`,
+	}
+	for _, in := range inputs {
+		in := in
+		t.Run(in, func(t *testing.T) {
+			t.Parallel()
+			first := normalizeDottedSelectors(in)
+			second := normalizeDottedSelectors(first)
+			if first != second {
+				t.Errorf("not idempotent:\n  in:     %q\n  first:  %q\n  second: %q", in, first, second)
+			}
+		})
+	}
+}

--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -302,11 +302,18 @@ func (h *Handler) tryScalarFold(ctx context.Context, query string) (float64, boo
 // parseExpr wraps the prom parser in a `parse` pipeline-stage span. The
 // QL identifier and the (truncated) query string land on the span as
 // `cerberus.ql` + `cerberus.query`.
+//
+// Before parsing, the query passes through normalizeDottedSelectors,
+// which rewrites OTel-style dotted metric names (e.g.
+// `http.server.request.duration`) to the explicit `{__name__="..."}`
+// form. PromQL's parser only accepts ASCII identifiers in selector
+// position; the rewrite lets users keep typing the OTel name they see
+// in Grafana's metric picker without a 400 parse error.
 func (h *Handler) parseExpr(ctx context.Context, query string) (promparser.Expr, error) {
 	_, span := tracer.Start(ctx, cerbtrace.SpanParse,
 		trace.WithAttributes(cerbtrace.ParseAttrs("promql", query)...))
 	defer span.End()
-	expr, err := h.parser.ParseExpr(query)
+	expr, err := h.parser.ParseExpr(normalizeDottedSelectors(query))
 	if err != nil {
 		span.RecordError(err)
 		return nil, err


### PR DESCRIPTION
Closes #173. See commit body.