### PR TITLE
fix(promql): wrap synthetic vector/literal Value in toFloat64 so V-V binop survives Sample scan

### DIFF
--- a/internal/api/prom/handler_chdb_test.go
+++ b/internal/api/prom/handler_chdb_test.go
@@ -239,6 +239,80 @@ func TestQuery_ScalarFold_ChDB(t *testing.T) {
 	}
 }
 
+// TestQuery_VectorVectorSynthBinop_ChDB exercises the Grafana PromQL
+// CheckHealth probe shape `vector(N)+vector(N)` end-to-end against
+// chDB. Pre-fix this returned a 502 with `converting UInt16 to *float64
+// is unsupported` — the clickhouse-go/v2 driver renders Go's
+// `float64(1.0)` as the SQL literal `1` (no decimal, fmt.Sprint fallback
+// in its bind.go::format), CH narrows that to `UInt8`, the synthetic-
+// fold Value projection's `(? OP ?)` expression promotes to `UInt16`,
+// and the chclient cursor refuses to scan a UInt16 column into
+// `chclient.Sample.Value` (`*float64`). The fix wraps the synthetic
+// LitFloat in `toFloat64(...)` at [syntheticScalarVector], which keeps
+// the Value column Float64 across the V-V binop fold.
+//
+// Mirrors [internal/api/loki/conformance_test.go::
+// TestConformance_LokiQueryConstantArithmetic_HealthProbe] for the
+// PromQL side — but executes against a real chDB session rather than a
+// stub so the UInt8 → UInt16 → *float64 scan path is exercised.
+//
+// Unlike `1+1` (which TryFoldScalar short-circuits to a scalar without
+// touching CH), `vector(N)+vector(N)` is rejected by the fold (LHS /
+// RHS are Calls, not NumberLiterals) and flows through lowering / emit
+// / chDB execution / chclient scan — the exact path where the
+// narrowing surfaces.
+func TestQuery_VectorVectorSynthBinop_ChDB(t *testing.T) {
+	cases := []struct {
+		name      string
+		query     string
+		wantValue string
+	}{
+		{"add", "vector(1)+vector(1)", "2"},
+		{"sub", "vector(3)-vector(1)", "2"},
+		{"mul", "vector(2)*vector(3)", "6"},
+		{"div", "vector(8)/vector(2)", "4"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			srv, _ := newChDBServer(t, gaugeDDL)
+			resp, err := http.Get(srv.URL + "/api/v1/query?query=" + tc.query)
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			body := readBody(t, resp)
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status=%d body=%s — Grafana PromQL CheckHealth "+
+					"probe lands here; a non-200 surfaces as 'Unable to "+
+					"connect with Prometheus' on every Grafana page load",
+					resp.StatusCode, body)
+			}
+			var parsed queryResponse
+			if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+				t.Fatalf("unmarshal: %v\nbody=%s", err, body)
+			}
+			if parsed.Status != "success" {
+				t.Fatalf("status=%q err=%s body=%s", parsed.Status, parsed.Error, body)
+			}
+			if parsed.Data.ResultType != "vector" {
+				t.Fatalf("resultType=%q, want vector; body=%s",
+					parsed.Data.ResultType, body)
+			}
+			rawResult, _ := json.Marshal(parsed.Data.Result)
+			var vec []prom.VectorSample
+			if err := json.Unmarshal(rawResult, &vec); err != nil {
+				t.Fatalf("decode vector: %v", err)
+			}
+			if len(vec) != 1 {
+				t.Fatalf("expected 1 synthetic sample, got %d: %+v", len(vec), vec)
+			}
+			if got := vec[0].Value[1]; got != tc.wantValue {
+				t.Errorf("Value: got %q, want %q (folded V-V scalar)", got, tc.wantValue)
+			}
+		})
+	}
+}
+
 func TestQuery_UpstreamError_ChDB(t *testing.T) {
 	// NewChDBWithError synthesises a Querier that errors every call —
 	// the proxy for an unreachable ClickHouse. The handler should

--- a/internal/api/prom/handler_chdb_test.go
+++ b/internal/api/prom/handler_chdb_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -276,7 +277,12 @@ func TestQuery_VectorVectorSynthBinop_ChDB(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			srv, _ := newChDBServer(t, gaugeDDL)
-			resp, err := http.Get(srv.URL + "/api/v1/query?query=" + tc.query)
+			// url.QueryEscape so the binop's `+` isn't decoded to a
+			// space by net/http — Grafana sends pre-encoded queries,
+			// mirror that here so the parser sees `vector(N)+vector(N)`
+			// rather than `vector(N) vector(N)` (the latter is a parse
+			// error: `unexpected identifier "vector"`).
+			resp, err := http.Get(srv.URL + "/api/v1/query?query=" + url.QueryEscape(tc.query))
 			if err != nil {
 				t.Fatalf("GET: %v", err)
 			}

--- a/internal/promql/synthetic.go
+++ b/internal/promql/synthetic.go
@@ -9,6 +9,27 @@ import (
 	"github.com/tsouza/cerberus/internal/schema"
 )
 
+// synthFloatValue wraps a float literal in `toFloat64(...)` so the
+// emitted Value column is Float64 on the wire regardless of what CH
+// types the bound parameter as. Without the wrap, the clickhouse-go/v2
+// driver renders an integer-valued `float64(1.0)` as the SQL literal
+// `1` (no decimal — its `bind.go::format()` has no `case float64` and
+// falls through to `fmt.Sprint(v)`, which uses Go's `%v` for float64
+// and prints `1` for whole numbers). CH narrows that to `UInt8`, and
+// `UInt8 OP UInt8` promotes to `UInt16`. Once it lands in
+// `chclient.Sample.Value` (declared `float64`), the driver refuses the
+// conversion with `converting UInt16 to *float64 is unsupported. try
+// using *uint16` — surfaced as the Grafana PromQL datasource
+// CheckHealth probe's 502 on `vector(1)+vector(1)`.
+//
+// Mirrors the same wrap [internal/logql/literal.go::synthFloatValue]
+// applies on the LogQL side (PR #634) and the per-callsite wrap
+// [internal/promql/absent.go] uses for the PromQL `absent(...)`
+// Value(1) shape (the original site, predating the others).
+func synthFloatValue(v float64) chplan.Expr {
+	return &chplan.FuncCall{Name: "toFloat64", Args: []chplan.Expr{&chplan.LitFloat{V: v}}}
+}
+
 // syntheticScalarVector builds a Project-over-(OneRow|StepGrid) plan
 // that materialises a synthetic sample with empty labels and the
 // supplied value/timestamp expressions. Used by `time()`,
@@ -37,7 +58,17 @@ import (
 // range) when nil — every callsite except the `time()` lowering wants
 // the eval anchor's wall-clock representation rather than the
 // timestamp-as-value reflection that `time()` uses.
+//
+// Bare `*chplan.LitFloat` valueExpr arguments are wrapped in
+// `toFloat64(...)` before projection — see [synthFloatValue] for the
+// failure mode this guards against. Pre-wrapped expressions (`time()`'s
+// `toFloat64(toUnixTimestamp64Nano(...))`, the date-fn `asFloat64(...)`
+// path, the scalar-binop fold's [foldSyntheticBinary] output) pass
+// through unchanged so the existing byte-stable fixtures don't shift.
 func syntheticScalarVector(valueExpr, timeExpr chplan.Expr, s schema.Metrics, ctx lowerCtx) chplan.Node {
+	if lit, ok := valueExpr.(*chplan.LitFloat); ok {
+		valueExpr = synthFloatValue(lit.V)
+	}
 	if ctx.step > 0 {
 		if timeExpr == nil {
 			timeExpr = &chplan.ColumnRef{Name: "anchor_ts"}

--- a/internal/promql/synthetic_tofloat64_test.go
+++ b/internal/promql/synthetic_tofloat64_test.go
@@ -1,0 +1,166 @@
+package promql_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestSyntheticScalarVector_WrapsLitFloatInToFloat64 pins the wrap of
+// the synthetic-vector Value projection at the `vector(N)`,
+// scalar-only-binop fold, and `time() OP time()` callsites. Without the
+// wrap, `vector(1)+vector(1)` (Grafana's PromQL CheckHealth probe
+// shape) returns 502 with:
+//
+//	engine: execute: chclient: scan: clickhouse [ScanRow]:
+//	(Value) converting UInt16 to *float64 is unsupported. try using *uint16
+//
+// Root cause is in clickhouse-go/v2's parameter binding: its
+// `bind.go::format()` has no `case float64`, so a Go `float64(1.0)`
+// falls through to `fmt.Sprint(v)` and emits the SQL literal `1` (no
+// decimal). CH narrows that to `UInt8`, the synthetic-fold Value
+// projection's `(? + ?)` expression promotes to `UInt16`, and the
+// chclient cursor refuses to scan a UInt16 column into
+// `chclient.Sample.Value` (`*float64`).
+//
+// Mirrors [internal/logql/literal_test.go::TestLowerVectorWrapsValueInToFloat64]
+// for the PromQL side. Pinning the wrap at the lowering site means a
+// future refactor of [syntheticScalarVector] / [foldSyntheticBinary]
+// can't drop it without breaking the Grafana datasource health probe.
+func TestSyntheticScalarVector_WrapsLitFloatInToFloat64(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{})
+	instant := time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+
+	cases := []struct {
+		name  string
+		query string
+	}{
+		// `vector(N)` — lowerVector, synthetic.go:lowerVector callsite
+		// passing &chplan.LitFloat{V:v} to syntheticScalarVector.
+		{"vector_one", `vector(1)`},
+		{"vector_two", `vector(2)`},
+		// `1+1` — lowerBinary scalar-only fold, binary.go:45 callsite
+		// passing &chplan.LitFloat{V:v} to syntheticScalarVector.
+		{"scalar_fold_add", `1+1`},
+		{"scalar_fold_mul", `2*3`},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr: %v", err)
+			}
+			plan, err := promql.LowerAt(context.Background(), expr, s, instant, instant)
+			if err != nil {
+				t.Fatalf("LowerAt: %v", err)
+			}
+			proj, ok := plan.(*chplan.Project)
+			if !ok {
+				t.Fatalf("plan: got %T, want *chplan.Project", plan)
+			}
+			if len(proj.Projections) != 4 {
+				t.Fatalf("Projections: got %d, want 4", len(proj.Projections))
+			}
+			valueProj := proj.Projections[3]
+			if valueProj.Alias != s.ValueColumn {
+				t.Fatalf("Value projection alias: got %q, want %q",
+					valueProj.Alias, s.ValueColumn)
+			}
+			fc, ok := valueProj.Expr.(*chplan.FuncCall)
+			if !ok {
+				t.Fatalf("Value expr: got %T, want *chplan.FuncCall — the "+
+					"toFloat64 wrap is missing and CH will type the column "+
+					"as UInt8, surfacing as `UInt16 to *float64 unsupported` "+
+					"on any V-V binop over synthetic scalars (Grafana PromQL "+
+					"CheckHealth probe `vector(1)+vector(1)`)", valueProj.Expr)
+			}
+			if fc.Name != "toFloat64" {
+				t.Errorf("Value expr func name: got %q, want %q", fc.Name, "toFloat64")
+			}
+			if len(fc.Args) != 1 {
+				t.Fatalf("toFloat64 args: got %d, want 1", len(fc.Args))
+			}
+			if _, ok := fc.Args[0].(*chplan.LitFloat); !ok {
+				t.Fatalf("toFloat64 arg: got %T, want *chplan.LitFloat", fc.Args[0])
+			}
+		})
+	}
+}
+
+// TestSyntheticFold_VectorVector_WrapsValueInToFloat64 pins the
+// `foldSyntheticBinary` Value composition: when both legs of a V-V
+// binop lower to the synthetic-scalar shape (e.g. `vector(1)+vector(1)`)
+// the resulting Value slot must compose `toFloat64(?) OP toFloat64(?)`
+// — not bare `? OP ?`. The per-leg wrap is contributed by
+// [syntheticScalarVector]; this test asserts the composition survives
+// the fold rather than being unwrapped by [foldSyntheticBinary].
+//
+// The emitted SQL is the canonical proxy for "the wrap survives": the
+// presence of `toFloat64(?)` on both sides of the binop expression
+// inside the Value slot.
+func TestSyntheticFold_VectorVector_WrapsValueInToFloat64(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{})
+	instant := time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{"add", `vector(1)+vector(1)`},
+		{"sub", `vector(1)-vector(1)`},
+		{"mul", `vector(2)*vector(3)`},
+		{"div", `vector(8)/vector(2)`},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr: %v", err)
+			}
+			plan, err := promql.LowerAt(context.Background(), expr, s, instant, instant)
+			if err != nil {
+				t.Fatalf("LowerAt: %v", err)
+			}
+			sql, _, err := chsql.Emit(context.Background(), plan)
+			if err != nil {
+				t.Fatalf("Emit: %v", err)
+			}
+			// The fold path must produce a Value column whose
+			// expression composes two toFloat64(?) operands. The proxy
+			// is the substring `toFloat64(?) <op> toFloat64(?)` showing
+			// up inside the rendered SQL — any drop would either elide
+			// one of the wraps (regressing to UInt8 narrowing) or move
+			// the wrap outside the binop (regressing to a different
+			// narrowing shape).
+			//
+			// Use a loose "two wraps near each other" check rather than
+			// an exact op-character match — chsql renders operators with
+			// surrounding spaces (`(toFloat64(?) + toFloat64(?))`) so
+			// the substring is stable across the six arithmetic ops.
+			if c := strings.Count(sql, "toFloat64(?)"); c < 2 {
+				t.Fatalf("expected at least two toFloat64(?) wraps in the "+
+					"synthetic V-V fold Value slot; got %d. SQL:\n%s", c, sql)
+			}
+		})
+	}
+}

--- a/test/spec/promql/scalar_binop_fold.txtar
+++ b/test/spec/promql/scalar_binop_fold.txtar
@@ -17,7 +17,7 @@ CREATE TABLE otel_metrics_gauge (
 [2] int64 = 9
 [3] float64 = 3
 -- chplan --
-Project ["" AS MetricName, CAST(map(), "Map(String,String)") AS Attributes, now64(9) AS TimeUnix, 3 AS Value]
+Project ["" AS MetricName, CAST(map(), "Map(String,String)") AS Attributes, now64(9) AS TimeUnix, toFloat64(3) AS Value]
   OneRow
 -- sql --
-SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, ? AS `Value` FROM (SELECT 1)
+SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(?) AS `Value` FROM (SELECT 1)

--- a/test/spec/promql/scalar_binop_fold_bool.txtar
+++ b/test/spec/promql/scalar_binop_fold_bool.txtar
@@ -17,7 +17,7 @@ CREATE TABLE otel_metrics_gauge (
 [2] int64 = 9
 [3] float64 = 0
 -- chplan --
-Project ["" AS MetricName, CAST(map(), "Map(String,String)") AS Attributes, now64(9) AS TimeUnix, 0 AS Value]
+Project ["" AS MetricName, CAST(map(), "Map(String,String)") AS Attributes, now64(9) AS TimeUnix, toFloat64(0) AS Value]
   OneRow
 -- sql --
-SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, ? AS `Value` FROM (SELECT 1)
+SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(?) AS `Value` FROM (SELECT 1)

--- a/test/spec/promql/scalar_binop_fold_precedence.txtar
+++ b/test/spec/promql/scalar_binop_fold_precedence.txtar
@@ -17,7 +17,7 @@ CREATE TABLE otel_metrics_gauge (
 [2] int64 = 9
 [3] float64 = 7
 -- chplan --
-Project ["" AS MetricName, CAST(map(), "Map(String,String)") AS Attributes, now64(9) AS TimeUnix, 7 AS Value]
+Project ["" AS MetricName, CAST(map(), "Map(String,String)") AS Attributes, now64(9) AS TimeUnix, toFloat64(7) AS Value]
   OneRow
 -- sql --
-SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, ? AS `Value` FROM (SELECT 1)
+SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(?) AS `Value` FROM (SELECT 1)

--- a/test/spec/promql/vector_promotes_scalar.txtar
+++ b/test/spec/promql/vector_promotes_scalar.txtar
@@ -17,7 +17,7 @@ CREATE TABLE otel_metrics_gauge (
 [2] int64 = 9
 [3] float64 = 42
 -- chplan --
-Project ["" AS MetricName, CAST(map(), "Map(String,String)") AS Attributes, now64(9) AS TimeUnix, 42 AS Value]
+Project ["" AS MetricName, CAST(map(), "Map(String,String)") AS Attributes, now64(9) AS TimeUnix, toFloat64(42) AS Value]
   OneRow
 -- sql --
-SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, ? AS `Value` FROM (SELECT 1)
+SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(?) AS `Value` FROM (SELECT 1)


### PR DESCRIPTION
## Summary

- PromQL's `vector(N)+vector(N)` synthetic-fold path was binding a bare
  `float64` through clickhouse-go/v2; the driver's `bind.go::format()`
  has no `case float64` and fell through to `fmt.Sprint(v)`, which
  renders integer-valued floats as the SQL literal `1` (no decimal).
  CH narrowed that to `UInt8`, the V-V fold's `(? OP ?)` promoted to
  `UInt16`, and the chclient cursor refused to scan `UInt16` into
  `chclient.Sample.Value` (`*float64`) — surfaced as the Grafana PromQL
  CheckHealth probe's 502.
- Fix mirrors PR #634 (LogQL `synthFloatValue`) on the PromQL side: at
  `syntheticScalarVector`, wrap a bare `*chplan.LitFloat` valueExpr in
  `toFloat64(...)` so the Value column stays Float64 across any
  downstream arithmetic. Pre-wrapped expressions (`time()`'s
  `toFloat64(toUnixTimestamp64Nano(...))`, the date-fn `asFloat64(...)`
  path, the V-V fold output) pass through unchanged so existing
  byte-stable fixtures don't shift.
- This addresses Task #189 (per-callsite wrap on PromQL's synthetic
  paths for parity with LogQL).

## Task #190 deferred

Task #190 (lift the wrap into `chsql.Builder.Expr` for every LitFloat
globally) was investigated and deferred — blast radius is well over
50 fixtures. Every PromQL `NumberLiteral` lowers to a LitFloat (Prom
has no integer literal type), so threshold values in vector-scalar
binops, quantile arguments, clamp / round / deriv constants,
date-function literals, traceql metric pipelines, optimizer
constant-fold output, and the existing absent / synthetic / logql
helpers all bind a LitFloat that would acquire the wrap. A rough
fixture scan (`vector(`, `quantile(?`, `histogram_quantile`, `clamp`,
arithmetic with `?`-bound operands) covers 100+ goldens before
counting per-fixture variants. The narrow per-callsite wrap covers
the actual narrowing surface (whole-number float64 bound through the
driver) without forcing a global golden re-pin.

If a future cleanup wants to take #190, the touch list is: every
fixture under `test/spec/{promql,logql,traceql,chsql}/` whose SQL
section contains a `?` slot from a LitFloat (currently rendered as
`?`, would become `toFloat64(?)`); the `args` section is unchanged
(same float64 binding). The chplan IR snapshots stay byte-identical
(the IR pretty-printer renders LitFloat values inline, not their
emit form). The redundant helpers that could then be removed:
`internal/promql/synthetic.go::synthFloatValue` (this PR),
`internal/logql/literal.go::synthFloatValue`, the `toFloat64`-on-1.0
wrap in `internal/promql/absent.go::lowerAbsent`.

## Test plan

- [x] Unit (`internal/promql/synthetic_tofloat64_test.go`):
  - `TestSyntheticScalarVector_WrapsLitFloatInToFloat64` pins the wrap at
    `vector(N)` / `1+1` scalar-fold callsites.
  - `TestSyntheticFold_VectorVector_WrapsValueInToFloat64` asserts the
    wrap survives the V-V synthetic-fold composition (both legs end up
    `toFloat64(?) OP toFloat64(?)` in the emitted SQL).
- [x] Spec golden (`test/spec/promql/scalar_binop_fold*.txtar`,
  `vector_promotes_scalar.txtar`): re-pin the chplan + SQL goldens.
- [x] Handler-roundtrip (`internal/api/prom/handler_chdb_test.go`):
  `TestQuery_VectorVectorSynthBinop_ChDB` exercises
  `vector(N)+vector(N)` (and -, *, /) end-to-end against a chDB
  session so the UInt8 → UInt16 → *float64 scan path is asserted, not
  just the lowering shape.
- [ ] CI to confirm no other fixture / test drift.

Closes #189.
Defers #190 — see PR description for the writeup.

Generated with [Claude Code](https://claude.com/claude-code)