### PR TITLE
fix(api/{loki,tempo}): route Grafana ms timestamps to UnixMilli, split ns at 1e15 (#194)

### DIFF
--- a/internal/api/format/format_test.go
+++ b/internal/api/format/format_test.go
@@ -158,8 +158,22 @@ func TestParseTimeLoki(t *testing.T) {
 	}{
 		{"empty-defaults", "", def, false},
 		{"unix-seconds", "1700000000", time.Unix(1_700_000_000, 0).UTC(), false},
-		{"unix-nanos", "1700000000000000000", time.Unix(0, 1_700_000_000_000_000_000).UTC(), false},
+		{"unix-fractional", "1700000000.5", time.Unix(1_700_000_000, 500_000_000).UTC(), false},
 		{"rfc3339", "2024-01-02T03:04:05Z", time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC), false},
+		// #194: Grafana 11.x emits ms over the Loki `resources/` proxy
+		// (just like Prom). A 13-digit ms value used to land in the ns
+		// branch and overflow ClickHouse's toDateTime64; the parser
+		// now routes 1e12..1e15 to time.UnixMilli.
+		{"unix-millis-13digit-boundary", "1000000000000", time.UnixMilli(1_000_000_000_000).UTC(), false},
+		{"unix-millis-grafana-shape", "1737000000000", time.UnixMilli(1_737_000_000_000).UTC(), false},
+		{"unix-millis-with-frac", "1700000000123", time.UnixMilli(1_700_000_000_123).UTC(), false},
+		{"unix-millis-1_5e12", "1500000000000", time.UnixMilli(1_500_000_000_000).UTC(), false},
+		{"boundary-1e12-minus-1-stays-seconds", "999999999999", time.Unix(999_999_999_999, 0).UTC(), false},
+		// `logcli` and other ns-native Loki clients keep working: the
+		// >=1e15 branch still routes to time.Unix(0, n).
+		{"unix-nanos-1e15-boundary", "1000000000000000", time.Unix(0, 1_000_000_000_000_000).UTC(), false},
+		{"unix-nanos-logcli-shape", "1700000000000000000", time.Unix(0, 1_700_000_000_000_000_000).UTC(), false},
+		{"unix-nanos-2e18", "2000000000000000000", time.Unix(0, 2_000_000_000_000_000_000).UTC(), false},
 		{"bogus", "not-a-time", time.Time{}, true},
 	}
 	for _, tc := range tests {

--- a/internal/api/format/timing.go
+++ b/internal/api/format/timing.go
@@ -52,23 +52,45 @@ func ParseTimeProm(raw string, def time.Time) (time.Time, error) {
 	return t.UTC(), nil
 }
 
-// ParseTimeLoki parses a Loki-API time parameter. Loki accepts three
-// shapes: Unix-seconds float, Unix-nanoseconds int (heuristic: >1e12),
-// or RFC3339. Empty input falls back to def.
+// ParseTimeLoki parses a Loki-API time parameter. Loki accepts four
+// integer shapes plus float-seconds and RFC3339:
+//
+//   - `< 1e12`      → Unix seconds (10-digit, current epoch).
+//   - `1e12 .. 1e15` → Unix milliseconds (13–15 digits). Grafana 11.x
+//     sends ms over `/api/datasources/uid/<ds>/resources/...` for the
+//     Loki datasource just as it does for Prom — the JS frontend never
+//     converts to seconds on that path. Treating ms as ns was the
+//     failure mode of #194: a 13-digit value like `1737000000000`
+//     decoded as ns yields year ~58353 → `toDateTime64('58353-...', 9)`
+//     overflows → ClickHouse returns 500 → Grafana sees empty results.
+//   - `>= 1e15`     → Unix nanoseconds (16+ digits, the `logcli`
+//     convention). 2026 in ns is ~1.74e18 (19 digits); 2001-09 in ns
+//     is ~1.0e18 — so 1e15 is a safe split well below every realistic
+//     ns timestamp and well above every realistic ms timestamp (year
+//     33658+ in ms).
+//
+// Float and RFC3339 inputs fall through the int branch.
+// Empty input falls back to def.
 func ParseTimeLoki(raw string, def time.Time) (time.Time, error) {
 	if raw == "" {
 		return def, nil
 	}
-	if n, err := strconv.ParseInt(raw, 10, 64); err == nil && n > 1_000_000_000_000 {
-		// Heuristic: > 1e12 means nanoseconds (Loki convention).
-		return time.Unix(0, n).UTC(), nil
+	if n, err := strconv.ParseInt(raw, 10, 64); err == nil {
+		switch {
+		case n >= 1_000_000_000_000_000:
+			// >= 1e15 ⇒ nanoseconds (logcli convention).
+			return time.Unix(0, n).UTC(), nil
+		case n >= 1_000_000_000_000:
+			// 1e12..1e15 ⇒ milliseconds (Grafana resources proxy).
+			return time.UnixMilli(n).UTC(), nil
+		}
 	}
 	if f, err := strconv.ParseFloat(raw, 64); err == nil {
 		return time.Unix(int64(f), int64((f-float64(int64(f)))*1e9)).UTC(), nil
 	}
 	t, err := time.Parse(time.RFC3339Nano, raw)
 	if err != nil {
-		return time.Time{}, errors.New("time parameter must be Unix seconds/nanoseconds or RFC3339")
+		return time.Time{}, errors.New("time parameter must be Unix seconds/milliseconds/nanoseconds or RFC3339")
 	}
 	return t.UTC(), nil
 }

--- a/internal/api/loki/conformance_test.go
+++ b/internal/api/loki/conformance_test.go
@@ -1016,3 +1016,77 @@ func TestConformance_LokiAdmitIndependentFromOthers(t *testing.T) {
 		t.Errorf("nil-limiter handler must admit every request: got %d/%d", admitted, n)
 	}
 }
+
+// TestConformance_LokiGrafanaMsTimestamps_ResourcesProxy is the
+// request-level pin for #194 on the Loki side. Grafana 11.x's Loki
+// datasource sends 13-digit ms `start` / `end` timestamps over
+// `/api/datasources/uid/<ds>/resources/...`; cerberus must decode them
+// as milliseconds. The pre-fix `>1e12 → ns` heuristic interpreted a
+// 13-digit ms value as nanoseconds → year-58353 → ClickHouse
+// `toDateTime64` overflow → HTTP 500 → empty Grafana panels.
+//
+// Drives ms-shaped bounds through both range-query endpoints; HTTP 200
+// is the only acceptable outcome. A 500 here is the canary that the
+// ms / ns split regressed.
+func TestConformance_LokiGrafanaMsTimestamps_ResourcesProxy(t *testing.T) {
+	t.Parallel()
+
+	// 2025-01-26 ≈ 1_737_864_000_000 ms; 1 hour later.
+	const startMs = "1737000000000"
+	const endMs = "1737003600000"
+	const q = `{job="api"}`
+
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"query", "/loki/api/v1/query?query=" + url.QueryEscape(q) + "&time=" + endMs},
+		{
+			"query-range",
+			"/loki/api/v1/query_range?query=" + url.QueryEscape(q) +
+				"&start=" + startMs + "&end=" + endMs + "&step=60s",
+		},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			srv := newServer(&stubQuerier{})
+			t.Cleanup(srv.Close)
+			resp, err := http.Get(srv.URL + c.path)
+			if err != nil {
+				t.Fatalf("GET %s: %v", c.path, err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("status=%d body=%s (ms→ns misroute regression)", resp.StatusCode, body)
+			}
+		})
+	}
+}
+
+// TestConformance_LokiLogcliNanosTimestamps pins the ns branch on the
+// Loki side. The `logcli` client emits 19-digit ns timestamps; the
+// 1e15 split must keep routing them to time.Unix(0, n) (i.e., they
+// stay ns, not get misread as ms → year-2554 → also broken).
+func TestConformance_LokiLogcliNanosTimestamps(t *testing.T) {
+	t.Parallel()
+
+	const startNs = "1700000000000000000"
+	const endNs = "1700000060000000000"
+	const q = `{job="api"}`
+
+	srv := newServer(&stubQuerier{})
+	t.Cleanup(srv.Close)
+	resp, err := http.Get(srv.URL + "/loki/api/v1/query_range?query=" + url.QueryEscape(q) +
+		"&start=" + startNs + "&end=" + endNs + "&step=60s")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s (ns branch regression)", resp.StatusCode, body)
+	}
+}

--- a/internal/api/tempo/conformance_test.go
+++ b/internal/api/tempo/conformance_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -651,5 +652,66 @@ func TestConformance_TempoAdmitNilPassesThrough(t *testing.T) {
 	wg.Wait()
 	if hits.Load() != 25 {
 		t.Errorf("nil limiter must admit every request: got %d/25", hits.Load())
+	}
+}
+
+// TestConformance_TempoGrafanaMsTimestamps_ResourcesProxy is the
+// request-level pin for #194 on the Tempo side. Grafana 11.x's Tempo
+// datasource sends 13-digit ms `start` / `end` timestamps over
+// `/api/datasources/uid/<ds>/resources/...`; cerberus must decode them
+// as milliseconds (not nanoseconds → year-58353 → ClickHouse
+// `toDateTime64` overflow → HTTP 500 → empty Grafana panels).
+//
+// Drives ms-shaped bounds through every Tempo endpoint that consumes
+// parseTempoStartEnd:
+//   - /api/search
+//   - /api/search/tags
+//   - /api/search/tag/{name}/values
+//   - /api/metrics/query_range
+//   - /api/metrics/query   (instant)
+//
+// Each call must return HTTP 200; a 500 here means the heuristic
+// regressed and a real ms timestamp was misrouted into the ns branch.
+func TestConformance_TempoGrafanaMsTimestamps_ResourcesProxy(t *testing.T) {
+	t.Parallel()
+
+	// 2025-01-26 ≈ 1_737_864_000_000 ms; 1 hour later.
+	const startMs = "1737000000000"
+	const endMs = "1737003600000"
+
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"search", "/api/search?start=" + startMs + "&end=" + endMs},
+		{"search-tags", "/api/search/tags?start=" + startMs + "&end=" + endMs},
+		{"search-tag-values", "/api/search/tag/service.name/values?start=" + startMs + "&end=" + endMs},
+		{
+			"metrics-query-range",
+			"/api/metrics/query_range?q=" + url.QueryEscape("{} | rate()") +
+				"&start=" + startMs + "&end=" + endMs + "&step=60s",
+		},
+		{
+			"metrics-query-instant",
+			"/api/metrics/query?q=" + url.QueryEscape("{} | rate()") +
+				"&start=" + startMs + "&end=" + endMs,
+		},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			srv := newServer(&stubQuerier{}, "v1.0.0-test")
+			t.Cleanup(srv.Close)
+			resp, err := http.Get(srv.URL + c.path)
+			if err != nil {
+				t.Fatalf("GET %s: %v", c.path, err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("status=%d body=%s (ms→ns misroute regression)", resp.StatusCode, body)
+			}
+		})
 	}
 }

--- a/internal/api/tempo/time.go
+++ b/internal/api/tempo/time.go
@@ -32,18 +32,36 @@ func parseTempoStartEnd(r *http.Request) (time.Time, time.Time, error) {
 	return start, end, nil
 }
 
-// parseTempoTime decodes a single Unix-seconds-as-int (or
-// nanoseconds-as-int when > 1e12) timestamp string. An empty input
-// returns the zero time without an error — callers treat that as
-// "predicate omitted". RFC3339 is also accepted for parity with Loki.
+// parseTempoTime decodes a single timestamp string. Tempo accepts
+// integers in three magnitudes plus float-seconds and RFC3339:
+//
+//   - `< 1e12`       → Unix seconds (10-digit, the typical Tempo wire).
+//   - `1e12 .. 1e15` → Unix milliseconds (13–15 digits). Grafana 11.x
+//     sends ms over `/api/datasources/uid/<ds>/resources/...` for the
+//     Tempo datasource just as it does for Prom and Loki — the JS
+//     frontend never converts to seconds on that path. Treating ms as
+//     ns was the failure mode of #194: a 13-digit value like
+//     `1737000000000` decoded as ns yields year ~58353 →
+//     `toDateTime64('58353-...', 9)` overflows in ClickHouse → 500.
+//   - `>= 1e15`     → Unix nanoseconds (16+ digits). Tempo's own
+//     `tempo-vulture` and some Grafana plugins emit raw ns. 2026 in ns
+//     is ~1.74e18; 2001-09 in ns is ~1.0e18 — so 1e15 is a safe split.
+//
+// An empty input returns the zero time without an error — callers
+// treat that as "predicate omitted". RFC3339 is also accepted for
+// parity with Loki / Prom.
 func parseTempoTime(raw string) (time.Time, error) {
 	if raw == "" {
 		return time.Time{}, nil
 	}
 	if n, err := strconv.ParseInt(raw, 10, 64); err == nil {
-		if n > 1_000_000_000_000 {
-			// Heuristic: > 1e12 means nanoseconds.
+		switch {
+		case n >= 1_000_000_000_000_000:
+			// >= 1e15 ⇒ nanoseconds.
 			return time.Unix(0, n).UTC(), nil
+		case n >= 1_000_000_000_000:
+			// 1e12..1e15 ⇒ milliseconds (Grafana resources proxy).
+			return time.UnixMilli(n).UTC(), nil
 		}
 		return time.Unix(n, 0).UTC(), nil
 	}
@@ -52,7 +70,7 @@ func parseTempoTime(raw string) (time.Time, error) {
 	}
 	t, err := time.Parse(time.RFC3339Nano, raw)
 	if err != nil {
-		return time.Time{}, errors.New("time parameter must be Unix seconds/nanoseconds or RFC3339")
+		return time.Time{}, errors.New("time parameter must be Unix seconds/milliseconds/nanoseconds or RFC3339")
 	}
 	return t.UTC(), nil
 }

--- a/internal/api/tempo/time_test.go
+++ b/internal/api/tempo/time_test.go
@@ -1,0 +1,123 @@
+package tempo
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestParseTempoTime covers the three integer magnitudes plus float
+// seconds, RFC3339, and the empty / bogus paths. The 1e12..1e15 ms
+// branch is the #194 fix: Grafana 11.x's Tempo datasource sends ms
+// timestamps over `/api/datasources/uid/<ds>/resources/...`, and the
+// old `>1e12 → ns` heuristic decoded them as ns → year ~58353 → CH
+// `toDateTime64` overflow → 500 response → empty Grafana panels.
+func TestParseTempoTime(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  string
+		want time.Time
+		err  bool
+	}{
+		{"empty-zero", "", time.Time{}, false},
+		{"unix-seconds", "1700000000", time.Unix(1_700_000_000, 0).UTC(), false},
+		{"unix-fractional", "1700000000.5", time.Unix(1_700_000_000, 500_000_000).UTC(), false},
+		{"rfc3339", "2024-01-02T03:04:05Z", time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC), false},
+
+		// #194: 1e12..1e15 → ms (Grafana resources proxy).
+		{"unix-millis-13digit-boundary", "1000000000000", time.UnixMilli(1_000_000_000_000).UTC(), false},
+		{"unix-millis-grafana-shape", "1737000000000", time.UnixMilli(1_737_000_000_000).UTC(), false},
+		{"unix-millis-with-frac", "1700000000123", time.UnixMilli(1_700_000_000_123).UTC(), false},
+		{"unix-millis-1_5e12", "1500000000000", time.UnixMilli(1_500_000_000_000).UTC(), false},
+
+		// Below 1e12 stays in the seconds branch (year ~33658 in
+		// seconds would be absurd; clients never send that).
+		{"boundary-1e12-minus-1-stays-seconds", "999999999999", time.Unix(999_999_999_999, 0).UTC(), false},
+
+		// >=1e15 → ns (tempo-vulture / ns-native plugin shape).
+		{"unix-nanos-1e15-boundary", "1000000000000000", time.Unix(0, 1_000_000_000_000_000).UTC(), false},
+		{"unix-nanos-vulture-shape", "1700000000000000000", time.Unix(0, 1_700_000_000_000_000_000).UTC(), false},
+		{"unix-nanos-2e18", "2000000000000000000", time.Unix(0, 2_000_000_000_000_000_000).UTC(), false},
+
+		{"bogus", "not-a-time", time.Time{}, true},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseTempoTime(tc.raw)
+			if tc.err {
+				if err == nil {
+					t.Fatalf("expected error, got %v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !got.Equal(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParseTempoStartEnd_GrafanaMs is the request-level companion to
+// TestParseTempoTime: an HTTP request with 13-digit ms `start` / `end`
+// (the Grafana 11.x resources-proxy wire shape) must decode to the
+// expected UTC times — not the year-58353 garbage the old `>1e12 → ns`
+// heuristic produced.
+func TestParseTempoStartEnd_GrafanaMs(t *testing.T) {
+	t.Parallel()
+
+	// Pick a recent-ish point: 2025-01-26 ≈ 1_737_864_000_000 ms.
+	const startMs = 1_737_000_000_000
+	const endMs = 1_737_864_000_000
+
+	r := httptest.NewRequest(http.MethodGet,
+		"/api/search?start=1737000000000&end=1737864000000", nil)
+
+	start, end, err := parseTempoStartEnd(r)
+	if err != nil {
+		t.Fatalf("parseTempoStartEnd: %v", err)
+	}
+	wantStart := time.UnixMilli(startMs).UTC()
+	wantEnd := time.UnixMilli(endMs).UTC()
+	if !start.Equal(wantStart) {
+		t.Fatalf("start: got %v, want %v", start, wantStart)
+	}
+	if !end.Equal(wantEnd) {
+		t.Fatalf("end: got %v, want %v", end, wantEnd)
+	}
+	// And the cardinal: the decoded year must be 2025, not 58353
+	// (which is what 1.737e12 interpreted as ns gives).
+	if y := start.Year(); y != 2025 {
+		t.Fatalf("start year: got %d, want 2025 — ms→ns misroute regression", y)
+	}
+}
+
+// TestParseTempoStartEnd_LogcliNanos pins the ns branch. The 19-digit
+// shape must still decode to its original ns instant (this is the
+// `tempo-vulture` / ns-native plugin wire).
+func TestParseTempoStartEnd_LogcliNanos(t *testing.T) {
+	t.Parallel()
+	const startNs = 1_700_000_000_000_000_000
+	const endNs = 1_700_000_060_000_000_000
+
+	r := httptest.NewRequest(http.MethodGet,
+		"/api/search?start=1700000000000000000&end=1700000060000000000", nil)
+
+	start, end, err := parseTempoStartEnd(r)
+	if err != nil {
+		t.Fatalf("parseTempoStartEnd: %v", err)
+	}
+	if got := start.UnixNano(); got != startNs {
+		t.Fatalf("start ns: got %d, want %d", got, startNs)
+	}
+	if got := end.UnixNano(); got != endNs {
+		t.Fatalf("end ns: got %d, want %d", got, endNs)
+	}
+}


### PR DESCRIPTION
## Summary

- `internal/api/format/timing.go::ParseTimeLoki` and `internal/api/tempo/time.go::parseTempoTime` used to send every integer `> 1e12` to nanoseconds. Grafana 11.x sends ms timestamps over `/api/datasources/uid/<ds>/resources/...` for ALL three datasources — a 13-digit ms value like `1737000000000` decoded as ns → year ~58353 → ClickHouse `toDateTime64('58353-...', 9)` overflowed → handler returned 500 → Grafana panels went blank.
- Parallel to PR #630 (Prom), but Loki has a legitimate ns ingestion convention (logcli sends ns), so the upper bound matters. New 3-way split:
  - `< 1e12` → Unix seconds
  - `1e12 .. 1e15` → Unix milliseconds (Grafana resources proxy shape)
  - `>= 1e15` → Unix nanoseconds (logcli / tempo-vulture shape)
- Math: 2026 in ms is ~1.74e12 (13 digits); 2026 in ns is ~1.74e18 (19 digits); 2001-09 in ns is ~1.0e18 — so `1e15` sits safely between every realistic ms value and every realistic ns value.

## Files

- `internal/api/format/timing.go` — `ParseTimeLoki` switch on magnitude.
- `internal/api/tempo/time.go` — `parseTempoTime` switch (keeps the seconds fallback).
- `internal/api/format/format_test.go` — extended `TestParseTimeLoki` with ms boundary (1e12, 1.5e12, 1.737e12), ns boundary (1e15, 1.7e18, 2e18), and stays-seconds case (1e12-1).
- `internal/api/tempo/time_test.go` (new) — table-driven `parseTempoTime` + request-level pins for `parseTempoStartEnd` (Grafana ms shape and logcli ns shape).
- `internal/api/loki/conformance_test.go` — `TestConformance_LokiGrafanaMsTimestamps_ResourcesProxy` drives ms `start`/`end` through `/loki/api/v1/query` + `/loki/api/v1/query_range`; companion `TestConformance_LokiLogcliNanosTimestamps` pins the ns branch.
- `internal/api/tempo/conformance_test.go` — `TestConformance_TempoGrafanaMsTimestamps_ResourcesProxy` drives ms `start`/`end` through `/api/search`, `/api/search/tags`, `/api/search/tag/{name}/values`, `/api/metrics/query_range`, `/api/metrics/query`.

A 500 from any conformance case is the ms→ns misroute regression canary.

## Test plan

- [ ] CI `check` (unit tests, race) — covers Layer-1 boundary cases.
- [ ] CI `check` covers Layer-3 conformance tests (handler routes + parseTempoStartEnd through stubQuerier).
- [ ] CI `compatibility/loki` + `compatibility/tempo` — differential vs reference Loki / Tempo unchanged.
- [ ] `compose-smoke` — Grafana 11.x proxy actually exercises the resources-proxy path; HTTP 200 on Loki + Tempo panels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)