### PR TITLE
fix(promql): wrap group() literal in toFloat64 so any(1) survives Sample scan

### DIFF
--- a/internal/promql/aggregate_test.go
+++ b/internal/promql/aggregate_test.go
@@ -7,9 +7,65 @@ import (
 
 	"github.com/prometheus/prometheus/promql/parser"
 
+	"github.com/tsouza/cerberus/internal/chsql"
 	"github.com/tsouza/cerberus/internal/promql"
 	"github.com/tsouza/cerberus/internal/schema"
 )
+
+// TestLower_Group_WrapsLitInOToFloat64 pins the fix for the
+// `group(...)` 502: CH narrows the bound `int64(1)` literal to UInt8,
+// `any(UInt8)` returns UInt8, and clickhouse-go/v2's typed Scan into
+// `chclient.Sample.Value` (`*float64`) errors with
+// `converting UInt8 to *float64 is unsupported`. The lowering wraps
+// the literal in `toFloat64(...)` so the column projects as Float64
+// on the wire regardless of CH's narrowing inference. Mirrors the
+// analogous `count(...)` wrap pinned by
+// test/spec/promql/count_agg_returns_float.txtar.
+//
+// `intReturningAggregates` (chsql/emit_node.go) can't carry this fix
+// because `any(...)` is also used over Float64 (`any(Value)`) and
+// Array(Float64) (`any(ExplicitBounds)` in histogram_quantile) — an
+// unconditional outer toFloat64 wrap would break the latter. The fix
+// lives at the literal, not the aggregate-name dispatch.
+//
+// The chDB round-trip layer (test/spec/promql/group_basic.txtar /
+// group_by_job.txtar) exercises the end-to-end Scan path; this unit
+// pin keeps the SQL byte-shape stable so an accidental regression in
+// `lower.go` surfaces here rather than only at the chDB layer.
+func TestLower_Group_WrapsLitInOToFloat64(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{})
+
+	for _, q := range []string{`group(up)`, `group by (job) (up)`} {
+		q := q
+		t.Run(q, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(q)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", q, err)
+			}
+			plan, err := promql.Lower(context.Background(), expr, s)
+			if err != nil {
+				t.Fatalf("Lower(%q): %v", q, err)
+			}
+			sql, _, err := chsql.Emit(context.Background(), plan)
+			if err != nil {
+				t.Fatalf("Emit: %v", err)
+			}
+			// `any(toFloat64(?))` is the canonical wrapped shape;
+			// the bare `any(?)` (no inner toFloat64) is what
+			// produces the UInt8 → *float64 502.
+			if !strings.Contains(sql, "any(toFloat64(?))") {
+				t.Errorf("group lowering missing any(toFloat64(?)) wrap.\nSQL: %s", sql)
+			}
+			if strings.Contains(sql, "any(?) AS `Value`") {
+				t.Errorf("group lowering still emits unwrapped any(?) — UInt8 narrowing path.\nSQL: %s", sql)
+			}
+		})
+	}
+}
 
 // TestLower_Aggregate_Errors covers the aggregate paths whose error
 // messages are observable contract (param / no-param mismatch, computed

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -1476,13 +1476,35 @@ func buildAggFunc(a *parser.AggregateExpr, s schema.Metrics) (chplan.AggFunc, er
 
 	case parser.GROUP:
 		// PromQL `group(...)` returns 1 for every label combination; emit
-		// `any(1)` which yields a constant 1 per CH group.
+		// `any(toFloat64(1))` which yields a constant 1.0 per CH group.
+		//
+		// The `1` literal is wrapped in `toFloat64(...)` because the
+		// clickhouse-go/v2 driver renders Go `int64(1)` as the SQL
+		// literal `1` and CH narrows that to `UInt8`. `any(UInt8)`
+		// returns UInt8, and the downstream cursor scans Value as
+		// `*float64`. The driver refuses to convert UInt8 → *float64
+		// at Scan time (`converting UInt8 to *float64 is unsupported`)
+		// and the prom handler surfaces it as a 502. Wrapping in
+		// `toFloat64(?)` forces CH to project Float64 on the wire
+		// regardless of the bound literal's inferred type. Mirrors the
+		// same wrap in [lowerAbsent] and [syntheticScalarVector]'s
+		// callers. Cannot piggy-back on
+		// `chsql/emit_node.go::intReturningAggregates` because `any`
+		// over a Float64 / Array(Float64) column (e.g.
+		// `any(ExplicitBounds)` in histogram_quantile) must NOT be
+		// wrapped, so the fix has to be at the literal — not the
+		// aggregate-name dispatch.
 		if a.Param != nil {
 			return chplan.AggFunc{}, fmt.Errorf("promql: group() does not take a parameter")
 		}
 		return chplan.AggFunc{
-			Name:  "any",
-			Args:  []chplan.Expr{&chplan.LitInt{V: 1}},
+			Name: "any",
+			Args: []chplan.Expr{
+				&chplan.FuncCall{
+					Name: "toFloat64",
+					Args: []chplan.Expr{&chplan.LitInt{V: 1}},
+				},
+			},
 			Alias: s.ValueColumn,
 		}, nil
 

--- a/test/spec/promql/group_basic.txtar
+++ b/test/spec/promql/group_basic.txtar
@@ -1,0 +1,51 @@
+# PromQL `group(<vector>)` collapses every input series to a single
+# constant 1.0 sample with no labels. The lowering emits
+# `any(toFloat64(1))` (NOT `any(1)`) — the `toFloat64(...)` wrap
+# matters because `any(1)` would let CH narrow the bound `int64(1)`
+# literal to UInt8, and clickhouse-go/v2 refuses to convert UInt8 →
+# *float64 at Scan time (`converting UInt8 to *float64 is
+# unsupported`), surfacing as a 502 in the prom handler.
+#
+# `count_agg_returns_float.txtar` is the analogous pin for plain
+# `count(...)`; this fixture is the `group(...)` mirror. The chDB
+# round-trip layer is the load-bearing test — it exercises the same
+# code path the prom-handler 502 came from (typed Scan into
+# chclient.Sample.Value).
+
+-- query.promql --
+group(up)
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api', 'instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('up', map('job', 'api', 'instance', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('up', map('job', 'web', 'instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 1.0);
+-- expected_rows --
+[
+  ["", {}, "2026-01-01T00:00:01Z", 1.0]
+]
+-- args --
+[0] string = ""
+[1] string = "Map(String,String)"
+[2] int64 = 9
+[3] int64 = 1
+[4] string = "up"
+[5] string = "2026-01-01 00:00:01.000000000"
+[6] int64 = 9
+[7] string = "2026-01-01 00:00:01.000000000"
+[8] int64 = 9
+[9] int64 = 300000000000
+-- chplan --
+Project ["" AS MetricName, CAST(map(), "Map(String,String)") AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+  Aggregate groupBy=[] funcs=[any(toFloat64(1)) AS Value]
+    Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+      Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+        Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+          Scan(otel_metrics_gauge)
+-- sql --
+SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Value` FROM (SELECT any(toFloat64(?)) AS `Value`, count() AS `_cerb_n` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`))) WHERE `_cerb_n` > 0)

--- a/test/spec/promql/group_by_job.txtar
+++ b/test/spec/promql/group_by_job.txtar
@@ -1,7 +1,7 @@
 -- query.promql --
 group by (job) (up)
 -- sql --
-SELECT ? AS `MetricName`, mapFilter((k, v) -> v != '', map(?, `gkey_0`)) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes`[?] AS `gkey_0`, any(?) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY `Attributes`[?])
+SELECT ? AS `MetricName`, mapFilter((k, v) -> v != '', map(?, `gkey_0`)) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes`[?] AS `gkey_0`, any(toFloat64(?)) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_gauge` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY `Attributes`[?])
 -- args --
 [0] string = ""
 [1] string = "job"
@@ -33,7 +33,7 @@ INSERT INTO otel_metrics_gauge VALUES
 ]
 -- chplan --
 Project ["" AS MetricName, mapWithoutEmpty(map("job", gkey_0)) AS Attributes, now64(9) AS TimeUnix, Value AS Value]
-  Aggregate groupBy=[Attributes["job"] AS gkey_0] funcs=[any(1) AS Value]
+  Aggregate groupBy=[Attributes["job"] AS gkey_0] funcs=[any(toFloat64(1)) AS Value]
     Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
       Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
         Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))


### PR DESCRIPTION
## Summary

`group(<vector>)` lowered to `any(LitInt{V:1})`, which CH narrowed to `any(UInt8)`. The downstream cursor scans `chclient.Sample.Value` as `*float64`, and clickhouse-go/v2 refuses `UInt8 -> *float64` at Scan time (`converting UInt8 to *float64 is unsupported`) - prom handler surfaces it as a 502. Same root cause as #634 (synthetic-scalar binop) and the `count(...)` 502 pinned by `count_agg_returns_float.txtar`.

The fix wraps the literal at the lowering site (`any(toFloat64(1))`) rather than via `chsql/emit_node.go::intReturningAggregates`, because `any(...)` is also emitted over Float64 (`any(Value)`) and Array(Float64) (`any(ExplicitBounds)` in histogram_quantile) - an unconditional outer toFloat64 dispatch would break those callsites. The fix has to live at the literal, not the aggregate-name table. Mirrors the wrap in `internal/promql/absent.go::lowerAbsent`.

## Test plan

- [x] `TestLower_Group_WrapsLitInOToFloat64` (unit) asserts emitted SQL carries `any(toFloat64(?))` and rejects bare `any(?) AS \`Value\``.
- [x] `test/spec/promql/group_basic.txtar` (new) - `group(up)` lowering + chDB round-trip; collapsed to 1.0.
- [x] `test/spec/promql/group_by_job.txtar` rebaselined to wrapped shape; chDB round-trip still green.
- [x] Full `go test -tags chdb ./test/spec/promql/...` passes (252 fixtures).
- [x] Full `go test ./internal/promql/... ./internal/api/prom/... ./test/spec/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)