### PR TITLE
chore(discipline): scrub "not implemented" from internal/**.go

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,22 @@ jobs:
             echo "::error::discipline-erosion wording (\"not implemented\" / \"skipped\" / \"deferred\") found in test files or TXTAR fixtures — implement the feature, rewrite to a neutral verb (dropped / excluded / rejected / bypassed), or remove the comment"
             exit 1
           fi
+      # Production code (non-test) must not advertise "not implemented".
+      # The bare words "skipped" / "deferred" are *not* gated here
+      # because Go has legitimate uses of both — `defer` statements
+      # described in docstrings, runtime "X is skipped" behaviour
+      # prose — that would all false-positive. "not implemented" has
+      # no legitimate prod meaning: either implement the feature or
+      # rewrite to a factual verb (rejected / unsupported / falls back).
+      - name: Reject "not implemented" in production code
+        run: |
+          if git ls-files -z -- \
+              'internal/**/*.go' \
+              ':!:internal/**/*_test.go' \
+              | xargs -0 grep -niEH 'not implemented' --; then
+            echo "::error::\"not implemented\" found in production code — implement the feature or rewrite to a factual verb (rejected / unsupported / falls back)"
+            exit 1
+          fi
       # Reject soft-assertion patterns that look like real verification
       # but pass tautologically — a discipline pin against fake-pass
       # regressions.

--- a/internal/api/tempo/types.go
+++ b/internal/api/tempo/types.go
@@ -7,7 +7,7 @@ package tempo
 // SearchResponse is the body of `GET /api/search`. Tempo's `traces`
 // array contains one trace summary per match; `metrics` carries
 // aggregate counts (cerberus reports an empty metrics block — the
-// per-search aggregate plumbing is not implemented).
+// aggregate fields are reported as zeros).
 type SearchResponse struct {
 	Traces  []TraceSummary `json:"traces"`
 	Metrics SearchMetrics  `json:"metrics,omitempty"`
@@ -25,8 +25,8 @@ type TraceSummary struct {
 }
 
 // SearchMetrics is Tempo's per-search aggregate block. Cerberus
-// reports zeros — the aggregate plumbing is not implemented; the shape
-// is here so the response stays parseable by Grafana.
+// reports the aggregate fields as zeros; the shape is here so the
+// response stays parseable by Grafana.
 type SearchMetrics struct {
 	InspectedTraces int `json:"inspectedTraces"`
 	InspectedBytes  int `json:"inspectedBytes"`

--- a/internal/logql/binary.go
+++ b/internal/logql/binary.go
@@ -32,7 +32,7 @@ import (
 //   - vector OP vector — VectorJoin over both sides projected to the
 //     Sample-shape, threading `Opts.ReturnBool` into VectorJoin.
 //
-// Logical ops (`and` / `or` / `unless`) are not implemented.
+// Logical ops (`and` / `or` / `unless`) are rejected at lowering.
 func lowerBinary(b *syntax.BinOpExpr, s schema.Logs, lc lowerCtx) (chplan.Node, error) {
 	// BinOpExpr stores parse errors in an unexported `err` field; the
 	// parser surfaces them at ParseExpr time before lowering reaches us.
@@ -144,7 +144,7 @@ func lowerVectorScalar(vec syntax.Expr, s schema.Logs, op chplan.BinaryOp, scala
 // The `bool` modifier threads into VectorJoin.ReturnBool — mirroring
 // PromQL's exact behaviour: comparison ops yield 1.0 / 0.0 per matched
 // pair rather than dropping non-matching rows. Logical ops
-// (`and`/`or`/`unless`) are not implemented.
+// (`and`/`or`/`unless`) are rejected upstream of this call.
 func lowerVectorVector(b *syntax.BinOpExpr, s schema.Logs, op chplan.BinaryOp, returnBool bool, vm *syntax.VectorMatching, lc lowerCtx) (chplan.Node, error) {
 	if returnBool && !isComparison(op) {
 		return nil, fmt.Errorf("logql: 'bool' modifier is only allowed on comparison binary ops")
@@ -245,7 +245,7 @@ func includeLabelsFromBinop(b *syntax.BinOpExpr) []string {
 
 // logqlBinaryOp maps a LogQL parser op string to the chplan op enum.
 // Arithmetic and comparison ops are handled here; logical ops
-// (`and` / `or` / `unless`) are not implemented.
+// (`and` / `or` / `unless`) are rejected as unsupported.
 func logqlBinaryOp(op string) (chplan.BinaryOp, error) {
 	switch op {
 	case syntax.OpTypeAdd:
@@ -273,7 +273,7 @@ func logqlBinaryOp(op string) (chplan.BinaryOp, error) {
 	case syntax.OpTypeGTE:
 		return chplan.OpGe, nil
 	}
-	return "", fmt.Errorf("logql: binary op %s unsupported (logical ops `and`/`or`/`unless` are not implemented)", op)
+	return "", fmt.Errorf("logql: binary op %s unsupported (logical ops `and`/`or`/`unless` are not supported)", op)
 }
 
 // isComparison reports whether op is one of the six comparison ops.

--- a/internal/promql/histogram_quantile_range.go
+++ b/internal/promql/histogram_quantile_range.go
@@ -47,7 +47,7 @@ import (
 //
 // Selectors carrying `@`/offset modifiers fall through to the instant-
 // mode path; range-mode matrix-anchor handling for histogram_quantile
-// under modifiers is not implemented. In practice the modifier-bearing
+// under modifiers falls back to instant mode. In practice the modifier-bearing
 // shapes are rare (Grafana never emits them on query_range), so the
 // instant-mode fallback is byte-stable for the existing fixtures and
 // the range-mode rewrite covers the wire-shape Grafana actually drives.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -76,6 +76,16 @@ pre-push:
           echo "lefthook: discipline-erosion wording — rewrite to a neutral verb (dropped / excluded / rejected / bypassed) or remove"
           exit 1
         fi
+    forbid-not-implemented-prod:
+      tags: discipline
+      run: |
+        if git ls-files -z -- \
+            'internal/**/*.go' \
+            ':!:internal/**/*_test.go' \
+            | xargs -0 grep -niEH 'not implemented' --; then
+          echo "lefthook: \"not implemented\" in production code — implement the feature or rewrite to a factual verb (rejected / unsupported / falls back)"
+          exit 1
+        fi
     forbid-soft-assert:
       tags: discipline
       run: |


### PR DESCRIPTION
## Summary

Task #197. Four documented "not implemented" hits in production code (`internal/**/*.go`, non-test) rewritten to neutral wording, plus CI + lefthook gates extended to prevent regressions.

## Rewrites

| File:line | Verb chosen |
| --- | --- |
| `internal/logql/binary.go:35` (docstring) | "are rejected at lowering" |
| `internal/logql/binary.go:147` (docstring) | "are rejected upstream of this call" |
| `internal/logql/binary.go:248` (docstring) | "are rejected as unsupported" |
| `internal/logql/binary.go:276` (user-visible error string) | "are not supported" (parenthetical only; outer "unsupported" was already the operative word) |
| `internal/api/tempo/types.go:10` (docstring) | "the aggregate fields are reported as zeros" |
| `internal/api/tempo/types.go:28` (docstring) | "reports the aggregate fields as zeros" |
| `internal/promql/histogram_quantile_range.go:50` (docstring) | "falls back to instant mode" |

All purely editorial — no semantic change. The error message in `binary.go:276` retains its full information content (op name + the three rejected logical-op symbols).

## Gate extension

Production-scoped guard added to both CI (`.github/workflows/ci.yml` `forbid-skip` job) and the local `pre-push` hook (`lefthook.yml`):

```sh
git ls-files -z -- 'internal/**/*.go' ':!:internal/**/*_test.go' \
  | xargs -0 grep -niEH 'not implemented'
```

Only `not implemented` is gated on the prod side — the broader `\bskipped\b` / `\bdeferred\b` words are intentionally left out because Go's `defer` keyword and runtime "X is skipped" behaviour prose legitimately appear in production docstrings (e.g., `defer recover`, `Empty statements are skipped at runtime`). `not implemented` has no legitimate prod meaning.

The full sweep over `internal/**/*.go` (non-test) for the broader regex now shows zero `not implemented` hits.

## Test plan

- [ ] CI `forbid-skip` job passes (i.e., the new step finds zero hits on this branch).
- [ ] `check` + `lint` stay green — rewrites are docstring-only outside of one error message whose information content is preserved.