### PR TITLE
ci(forbid-skip): widen silent-recover gate to catch multi-line variants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,16 +147,42 @@ jobs:
       #   - assert.ElementsMatch(x, []...{}) — empty slice trivially matches
       #   - defer recover()                  — silently swallows panics
       #   - defer func() { _ = recover() }   — explicit silent recover
+      #     (single-line AND multi-line; perl slurp catches both)
       #
       # New additions must use the matching deep-assertion form: assert
       # actual content, assert specific panic, or remove the recover.
       - name: Reject soft-assertion / silent-recover patterns
         run: |
+          fail=0
           if git ls-files -z -- \
               '*_test.go' \
               ':!:compatibility/*/upstream/**' \
-              | xargs -0 grep -nEH 'assert\.Contains\([^,]+,\s*""\s*\)|assert\.ElementsMatch\([^,]+,\s*\[\][^)]*\{\s*\}\s*\)|defer recover\(\)|defer func\(\)\s*\{\s*_ = recover\(\)' --; then
-            echo "::error::soft-assertion or silent-recover pattern found — replace assert.Contains(x, \"\") with the actual substring, replace assert.ElementsMatch(x, []T{}) with len(x) == 0, replace defer recover() with assert.Panics(t, func(){...}, \"reason\")"
+              | xargs -0 grep -nEH 'assert\.Contains\([^,]+,\s*""\s*\)|assert\.ElementsMatch\([^,]+,\s*\[\][^)]*\{\s*\}\s*\)' --; then
+            fail=1
+          fi
+          # Multi-line silent-recover scan. Catches both the bare
+          # `defer recover()` form and the `defer func() { ... _ =
+          # recover() ... }()` block — including variants where comments
+          # or blank lines sit between the brace and the recover. The
+          # `[^{}]*` clamp keeps the match inside a single brace level
+          # so it does not over-reach into surrounding bodies, while
+          # `_\s*=\s*recover` discriminates a silent swallow from the
+          # legitimate `r := recover(); if r == nil { t.Fatal(...) }`
+          # assert-the-panic pattern used elsewhere in the repo.
+          matches=$(git ls-files -z -- '*_test.go' ':!:compatibility/*/upstream/**' \
+            | xargs -0 perl -0777 -ne '
+                while (/defer\s+recover\s*\(\s*\)|defer\s+func\s*\(\s*\)\s*\{[^{}]*_\s*=\s*recover\s*\(\s*\)/g) {
+                  my $pre = substr($_, 0, $-[0]);
+                  my $line = ($pre =~ tr/\n//) + 1;
+                  print "$ARGV:$line: silent-recover pattern\n";
+                }
+              ')
+          if [ -n "$matches" ]; then
+            printf '%s\n' "$matches"
+            fail=1
+          fi
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::soft-assertion or silent-recover pattern found — replace assert.Contains(x, \"\") with the actual substring, replace assert.ElementsMatch(x, []T{}) with len(x) == 0, replace defer recover() / defer func(){_ = recover()}() with assert.Panics(t, func(){...}, \"reason\")"
             exit 1
           fi
       # Reject net-new `should_skip:` entries in compatibility overlays

--- a/internal/api/admit/chaos_test.go
+++ b/internal/api/admit/chaos_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/tsouza/cerberus/internal/api/admit"
 )
 
@@ -200,12 +202,9 @@ func TestAdmit_MiddlewareUnderHandlerPanic_ReleasesSlot(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/x", nil)
 
-	func() {
-		defer func() {
-			_ = recover() // swallow the panic to keep the test running
-		}()
+	assert.Panics(t, func() {
 		h.ServeHTTP(rec, req)
-	}()
+	}, "inner handler must propagate its panic; middleware does not catch")
 
 	// The slot must be free again — subsequent Acquire succeeds.
 	rel, ok := l.Acquire(t.Context())

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
@@ -299,15 +300,10 @@ func TestObserveQueryInflight_IncrementDecrement(t *testing.T) {
 func TestObserveQueryInflight_BalancedAcrossPanic(t *testing.T) {
 	reader := installManualReader(t)
 
-	func() {
-		defer func() {
-			// Swallow the panic; we only care that the decrement
-			// defer still fired.
-			_ = recover()
-		}()
+	assert.Panics(t, func() {
 		defer telemetry.ObserveQueryInflight(t.Context(), "logql")()
 		panic("synthetic engine failure")
-	}()
+	}, "synthetic panic must propagate; the defer-decrement is what we verify after")
 
 	if got := inflightValue(t, reader, "logql"); got != 0 {
 		t.Fatalf("post-panic inflight: got %d want 0 (defer must decrement)", got)

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -79,10 +79,29 @@ pre-push:
     forbid-soft-assert:
       tags: discipline
       run: |
+        fail=0
         if git ls-files -z -- \
             '*_test.go' \
             ':!:compatibility/*/upstream/**' \
-            | xargs -0 grep -nEH 'assert\.Contains\([^,]+,\s*""\s*\)|assert\.ElementsMatch\([^,]+,\s*\[\][^)]*\{\s*\}\s*\)|defer recover\(\)|defer func\(\)\s*\{\s*_ = recover\(\)' --; then
+            | xargs -0 grep -nEH 'assert\.Contains\([^,]+,\s*""\s*\)|assert\.ElementsMatch\([^,]+,\s*\[\][^)]*\{\s*\}\s*\)' --; then
+          fail=1
+        fi
+        # Multi-line silent-recover scan — mirrors the CI `forbid-skip`
+        # gate so the inner loop catches both single-line and
+        # multi-line `defer func() { _ = recover() }()` blocks.
+        matches=$(git ls-files -z -- '*_test.go' ':!:compatibility/*/upstream/**' \
+          | xargs -0 perl -0777 -ne '
+              while (/defer\s+recover\s*\(\s*\)|defer\s+func\s*\(\s*\)\s*\{[^{}]*_\s*=\s*recover\s*\(\s*\)/g) {
+                my $pre = substr($_, 0, $-[0]);
+                my $line = ($pre =~ tr/\n//) + 1;
+                print "$ARGV:$line: silent-recover pattern\n";
+              }
+            ')
+        if [ -n "$matches" ]; then
+          printf '%s\n' "$matches"
+          fail=1
+        fi
+        if [ "$fail" -ne 0 ]; then
           echo "lefthook: soft-assertion or silent-recover pattern — assert specific content / use assert.Panics"
           exit 1
         fi


### PR DESCRIPTION
## Summary

- Widen the `forbid-skip` CI gate's silent-recover regex to catch multi-line `defer func() { _ = recover() }()` blocks (the existing `grep -E` `\s*` does not span newlines).
- Fix the two existing offenders that had slipped through: `internal/api/admit/chaos_test.go` (handler-panic releases-slot) and `internal/telemetry/metrics_test.go` (inflight gauge balanced across panic). Both are rewritten to `assert.Panics(t, func(){...}, "reason")` per the gate's own docstring, preserving the post-panic side-effect assertion.
- Mirror the same widened regex in `lefthook.yml`'s `forbid-soft-assert` pre-push command so the inner-loop gate is consistent with CI.

## Details

The CI step (`forbid-skip` job, "Reject soft-assertion / silent-recover patterns") now splits into two passes:

1. Single-line `grep -E` for `assert.Contains(x, "")` / `assert.ElementsMatch(x, []T{})`.
2. A `perl -0777` whole-file slurp matching `defer recover()` OR `defer func() { ... _ = recover() ... }()` — including comments / blank lines between the brace and the recover. The `[^{}]*` clamp keeps the match inside one brace level so it does not over-reach into surrounding bodies.

Critically the recover regex requires `_\s*=\s*recover` (silent-swallow), which discriminates it from the legitimate `r := recover(); if r == nil { t.Fatal(...) }` assert-the-panic idiom used elsewhere in the repo (`internal/chsql/builder_test.go`, `internal/optimizer/analyzer_test.go`, `internal/chsql/gremlins_kill_test.go`, …). Those keep working.

Local verification: running the widened pipeline across the tree after the two test rewrites returns zero matches — the gate is now consistent with the code.

## Test plan

- [x] Local widened pipeline returns zero matches after the rewrites
- [x] `go test` passes for `TestAdmit_MiddlewareUnderHandlerPanic_ReleasesSlot` + `TestObserveQueryInflight_BalancedAcrossPanic`
- [x] `gofumpt` / `goimports` clean
- [x] `go vet` clean
- [ ] CI `forbid-skip` gate green on this PR (proves the new perl pipeline works on the GH runner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)