### PR TITLE
docs(chsql): track upstream clickhouse-go float64 bind defect at LitFloat emit site

### DIFF
--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -260,6 +260,24 @@ func (b *Builder) Expr(x chplan.Expr) error {
 		b.Arg(v.V)
 		return nil
 	case *chplan.LitFloat:
+		// LitFloat values are passed to b.Arg as `?` placeholders,
+		// and callers that project the bound value back as a
+		// `Float64` column wrap the placeholder in `toFloat64(?)`
+		// at the emission site (see internal/chsql/absent_over_time.go,
+		// internal/chsql/exemplars.go, internal/chsql/vector_join.go,
+		// and the `group(...)` / `count(...)` / `absent_over_time(...)`
+		// PromQL lowerings — #634, #644, #646). The wrap exists
+		// because clickhouse-go/v2's bind.go::format() has no
+		// `case float64:` branch: integer-valued `float64` values
+		// (e.g. `float64(1.0)`) fall through to `fmt.Sprint(v)`,
+		// which renders the bare SQL literal `1` (no decimal).
+		// ClickHouse then narrows the parameter to `UInt8`, and the
+		// chclient cursor's typed `*float64` scan path errors with
+		// `converting UInt8 to *float64 is unsupported`. Tracked
+		// upstream at https://github.com/ClickHouse/clickhouse-go/issues/1862;
+		// drop the toFloat64 wraps once that lands and we bump past
+		// the fixed clickhouse-go version.
+		//
 		// Non-finite float64 values (±Inf / NaN) cannot ride the
 		// positional `?` parameter slot: clickhouse-go and chdb-go
 		// both render them via fmt.Sprint / strconv.AppendFloat,


### PR DESCRIPTION
## Summary

Add a tracking comment at the `case *chplan.LitFloat:` branch in `internal/chsql/builder.go` pointing at the upstream `clickhouse-go/v2` defect that motivates the `toFloat64(?)` wraps scattered across the chsql emitter (and several PromQL lowerings — `group(...)`, `count(...)`, `absent_over_time(...)`, synthetic-scalar binops from #634, #644, #646).

The defect: `clickhouse-go/v2`'s `bind.go::format()` has no `case float64:` branch. Integer-valued `float64` values (`float64(1.0)`, `float64(0)`, etc.) fall through every type switch and end up at `return fmt.Sprint(v), nil`. `fmt.Sprint(float64(1.0))` renders the bare string `"1"`, so the SQL the driver assembles carries an integer literal. ClickHouse narrows that to `UInt8`, the chclient cursor scans the column as `*float64`, and clickhouse-go refuses the conversion at Scan time:

```
converting UInt8 to *float64 is unsupported
```

Surfaces in the prom handler as a 502. The cerberus workaround — wrap every projected float literal in `toFloat64(?)` — costs an extra call across the emitter surface. Tracked upstream at [ClickHouse/clickhouse-go#1862](https://github.com/ClickHouse/clickhouse-go/issues/1862) so future readers know the wraps are not gratuitous and can be removed in one sweep once the fix lands and we bump past it.

No behaviour change: the existing ±Inf / NaN inline-non-finite path (`writeInlineNonFinite`) is untouched, and the bound-value path (`b.Arg(v.V)`) is unchanged.

Closes task #191.

## Test plan

- [ ] `check` / `lint` / `forbid-skip` pass (comment-only change, no test surface affected)
- [ ] `compatibility/{prometheus,loki,tempo}` pass (no SQL byte-shape change)
- [ ] `roundtrip (promql)` / `roundtrip (logql)` / `roundtrip (traceql)` pass
- [ ] `compose-smoke` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
