### PR TITLE
test(compat/tempo): proto-aware trace-by-id differ to catch wire-format drift

### DIFF
--- a/compatibility/tempo/driver/diff.go
+++ b/compatibility/tempo/driver/diff.go
@@ -229,6 +229,16 @@ func diffCase(ctx context.Context, client *http.Client, tc CorpusCase, opts case
 		return res
 	}
 
+	// The trace-by-id endpoint uses a proto-aware sibling differ (see
+	// diffTracesEndpoint + proto_fetch.go) — that path fetches BOTH
+	// JSON and proto on each side so the differ catches the wire-format
+	// divergence #199/#650 fixed (cerberus silently returning JSON when
+	// a client asked for proto). Every other endpoint stays on JSON.
+	if tc.Endpoint == "traces" {
+		diffTracesEndpoint(ctx, client, tempoURL, cerbURL, &res)
+		return res
+	}
+
 	tempoBody, tempoStatus, terr := fetchJSON(ctx, client, tempoURL)
 	cerbBody, cerbStatus, cerr := fetchJSON(ctx, client, cerbURL)
 	res.TempoStatus = tempoStatus
@@ -444,6 +454,11 @@ func deriveTraceIDFromTemplate(tmpl string) (string, error) {
 // fetchJSON GETs a URL with the Accept: application/json header and
 // returns the body + status. Errors include the response body (up to
 // 2KB) so a CH error message lands in the report.
+//
+// Used for every endpoint except trace-by-id. The trace-by-id path
+// uses fetchProto in lock-step (see proto_fetch.go::fetchProto +
+// diffTracesEndpoint) so the differ also exercises the wire format
+// Grafana actually asks for on /api/traces/<id>.
 //
 // Earlier revisions also set Recent-Data-Target: live-store on tempo
 // requests, intending to expand the search domain to recently-ingested

--- a/compatibility/tempo/driver/proto_fetch.go
+++ b/compatibility/tempo/driver/proto_fetch.go
@@ -1,0 +1,401 @@
+// Proto-aware fetcher for the trace-by-id endpoint.
+//
+// Background (task #202): the homegrown fetchJSON in diff.go hard-codes
+// `Accept: application/json` on every request. Reference Tempo and
+// cerberus both return JSON when asked for JSON, so the differ reports
+// "identical" even when one side has no protobuf support at all — the
+// exact failure mode that crashed Grafana in #199/#650 (cerberus
+// silently returned JSON to a client that asked for proto, Grafana
+// failed to decode the body, the trace view went blank).
+//
+// The vendored upstream pkg/httpclient already picks
+// `application/protobuf` for QueryTraceEndpoint / QueryTraceV2Endpoint
+// (see compatibility/tempo/upstream/pkg/httpclient/client.go), but the
+// upstream subtree is `go.mod ignore`d on purpose — it's reference
+// material, not consumable. We therefore implement a small sibling
+// fetcher here that mirrors upstream's content-type negotiation:
+//
+//   - set Accept: application/protobuf
+//   - read the body up to the same 16 MB limit as fetchJSON
+//   - decode via proto.Unmarshal into *tempopb.Trace
+//
+// The trace-by-id differ then fetches BOTH JSON and proto from each
+// side and asserts:
+//
+//   - JSON decodes on both sides (existing assertion, now explicit)
+//   - proto decodes on both sides (new — catches "cerberus returns JSON
+//     when proto was asked for" and the symmetric "cerberus returns
+//     proto when JSON was asked for")
+//   - the JSON-decoded structural projection (span count + sorted
+//     span-ID set) matches the proto-decoded structural projection on
+//     each side (catches "proto and JSON disagree on what the trace
+//     actually is" — the failure where one encoding is well-formed but
+//     describes a different trace shape than the other).
+//
+// All failures are surfaced as DIFF reasons on CaseResult.Diff, not
+// HardErrors — same posture as the rest of the differ: per-case parity
+// drift is reported, never fatal.
+
+package main
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/grafana/tempo/pkg/tempopb"
+)
+
+// fetchProto GETs a URL with the Accept: application/protobuf header
+// and decodes the body as *tempopb.Trace. Returns the raw bytes (for
+// round-trip / size accounting) + the decoded message + status code.
+//
+// Mirrors fetchJSON's error envelope so callers can lift the snippet
+// into a DiffReason without re-shaping. Status-code semantics match
+// fetchJSON: a non-2xx is surfaced as an error, the body snippet is
+// included for diagnosability.
+func fetchProto(ctx context.Context, client *http.Client, urlStr string) ([]byte, *tempopb.Trace, int, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlStr, nil)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	req.Header.Set("Accept", "application/protobuf")
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 16<<20))
+	if err != nil {
+		return nil, nil, resp.StatusCode, fmt.Errorf("read body: %w", err)
+	}
+	if resp.StatusCode/100 != 2 {
+		snippet := body
+		if len(snippet) > 2048 {
+			snippet = snippet[:2048]
+		}
+		return body, nil, resp.StatusCode, fmt.Errorf("status %d: %s", resp.StatusCode, string(snippet))
+	}
+	trace := &tempopb.Trace{}
+	if err := proto.Unmarshal(body, trace); err != nil {
+		// Surface the body snippet so a reviewer can see whether the
+		// server returned JSON, an error envelope, or just garbage.
+		snippet := body
+		if len(snippet) > 256 {
+			snippet = snippet[:256]
+		}
+		return body, nil, resp.StatusCode, fmt.Errorf("proto.Unmarshal tempopb.Trace: %w (body prefix: %q)", err, string(snippet))
+	}
+	return body, trace, resp.StatusCode, nil
+}
+
+// traceShape is the deterministic projection of a trace used for the
+// JSON-vs-proto structural-parity check. We project both encodings down
+// to (span count, sorted span-ID hex set) — two trace bodies describe
+// the same trace if and only if their shapes match. Field-by-field
+// parity is intentionally out of scope here; the project to span-ID
+// set is what catches "encoding A produced 3 spans, encoding B produced
+// 2" and "encoding A produced span aaaa, encoding B produced span bbbb".
+type traceShape struct {
+	SpanCount int      // total span count across all batches / scope-spans
+	SpanIDs   []string // sorted, lowercase hex; deduped
+}
+
+// equal returns true when both shapes describe the same trace.
+func (s traceShape) equal(o traceShape) bool {
+	if s.SpanCount != o.SpanCount {
+		return false
+	}
+	if len(s.SpanIDs) != len(o.SpanIDs) {
+		return false
+	}
+	for i := range s.SpanIDs {
+		if s.SpanIDs[i] != o.SpanIDs[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// summarise renders the shape as a short string for DiffReason details.
+func (s traceShape) summarise() string {
+	preview := s.SpanIDs
+	if len(preview) > 4 {
+		preview = preview[:4]
+	}
+	return fmt.Sprintf("spans=%d ids=%v", s.SpanCount, preview)
+}
+
+// projectProtoShape walks a decoded *tempopb.Trace and returns the
+// deterministic span-ID set + count. Both ResourceSpans -> ScopeSpans ->
+// Spans nesting levels are flattened.
+func projectProtoShape(t *tempopb.Trace) traceShape {
+	if t == nil {
+		return traceShape{}
+	}
+	ids := make(map[string]struct{})
+	total := 0
+	for _, rs := range t.ResourceSpans {
+		if rs == nil {
+			continue
+		}
+		for _, ss := range rs.ScopeSpans {
+			if ss == nil {
+				continue
+			}
+			for _, sp := range ss.Spans {
+				if sp == nil {
+					continue
+				}
+				total++
+				ids[hex.EncodeToString(sp.SpanId)] = struct{}{}
+			}
+		}
+	}
+	return traceShape{SpanCount: total, SpanIDs: sortedKeys(ids)}
+}
+
+// projectJSONShape decodes a trace-by-id JSON body and returns the same
+// deterministic shape. We tolerate two JSON dialects because cerberus
+// and Tempo differ in nesting:
+//
+//   - Tempo's protojson shape: {batches:[{scopeSpans:[{spans:[{spanId}]}]}]}
+//     (older Tempo builds also emit instrumentationLibrarySpans; we sum
+//     across both nesting variants).
+//   - Cerberus's flattened shape: {batches:[{spans:[{spanId}]}]}.
+//
+// Either way, every "spans" array's elements contribute one span; the
+// `spanId` field is the hex ID Tempo's protojson emits. Cerberus's
+// SpanEntry.spanId field name matches — see internal/api/tempo/types.go.
+func projectJSONShape(body []byte) (traceShape, error) {
+	var raw struct {
+		Batches []struct {
+			Spans      []spanIDRecord `json:"spans"`
+			ScopeSpans []struct {
+				Spans []spanIDRecord `json:"spans"`
+			} `json:"scopeSpans"`
+			InstrumentationLibrarySpans []struct {
+				Spans []spanIDRecord `json:"spans"`
+			} `json:"instrumentationLibrarySpans"`
+		} `json:"batches"`
+		// Tempo v2 protojson sometimes top-keys "resourceSpans" instead
+		// of "batches" depending on the protojson version. Accept both.
+		ResourceSpans []struct {
+			ScopeSpans []struct {
+				Spans []spanIDRecord `json:"spans"`
+			} `json:"scopeSpans"`
+		} `json:"resourceSpans"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return traceShape{}, fmt.Errorf("decode trace json: %w", err)
+	}
+	ids := make(map[string]struct{})
+	total := 0
+	collect := func(spans []spanIDRecord) {
+		for _, sp := range spans {
+			total++
+			if sp.SpanID != "" {
+				ids[sp.SpanID] = struct{}{}
+			}
+		}
+	}
+	for _, b := range raw.Batches {
+		collect(b.Spans)
+		for _, ss := range b.ScopeSpans {
+			collect(ss.Spans)
+		}
+		for _, ils := range b.InstrumentationLibrarySpans {
+			collect(ils.Spans)
+		}
+	}
+	for _, rs := range raw.ResourceSpans {
+		for _, ss := range rs.ScopeSpans {
+			collect(ss.Spans)
+		}
+	}
+	return traceShape{SpanCount: total, SpanIDs: sortedKeys(ids)}, nil
+}
+
+// spanIDRecord tolerates both `spanId` (Tempo / cerberus camelCase) and
+// `span_id` (some upstream JSON variants). Both backends in the harness
+// emit camelCase today; the snake_case fallback is cheap insurance.
+type spanIDRecord struct {
+	SpanID      string `json:"spanId"`
+	SpanIDSnake string `json:"span_id"`
+}
+
+// UnmarshalJSON merges the two field names so callers can read SpanID
+// without caring which spelling came in.
+func (s *spanIDRecord) UnmarshalJSON(b []byte) error {
+	var raw struct {
+		SpanID      string `json:"spanId"`
+		SpanIDSnake string `json:"span_id"`
+	}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if raw.SpanID != "" {
+		s.SpanID = raw.SpanID
+	} else {
+		s.SpanID = raw.SpanIDSnake
+	}
+	return nil
+}
+
+func sortedKeys(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// diffTracesEndpoint runs the proto-aware differ for the trace-by-id
+// case. Called from diffCase when tc.Endpoint == "traces". Mutates res
+// in place; returns nothing — every failure mode is recorded as a
+// DiffReason on res.Diff (never a HardError) so per-case proto drift is
+// reported but doesn't crash the run.
+//
+// The function fetches JSON + proto from each side and surfaces:
+//
+//   - "proto_decode": proto.Unmarshal failed on a side (catches "this
+//     side doesn't actually serve proto, just falls back to JSON"; the
+//     concrete failure mode in #199/#650).
+//   - "json_decode": JSON decode failed on a side (defensive — should
+//     never fire on a 2xx, but if it does we want a clear signal).
+//   - "encoding_mismatch": both decoders succeeded on a side, but the
+//     JSON-decoded shape and the proto-decoded shape describe different
+//     traces (different span counts, different span-ID sets).
+//   - "cardinality" + "missing_in_a"/"missing_in_b": the existing cross-
+//     backend diff — applied to the proto-decoded shapes (since that's
+//     the canonical Tempo wire format).
+//
+// res.Diff.MatchedCount counts spans matched across backends on the
+// proto-decoded shapes — visible in the markdown report alongside the
+// other endpoint kinds.
+func diffTracesEndpoint(ctx context.Context, client *http.Client, tempoURL, cerbURL string, res *CaseResult) {
+	res.Diff = Diff{Equal: true}
+
+	// Fetch JSON from both sides (existing wire format). Status is
+	// recorded on the CaseResult so the markdown report's per-case
+	// "tempo HTTP / cerberus HTTP" line still renders.
+	tempoJSON, tempoStatus, tjErr := fetchJSON(ctx, client, tempoURL)
+	cerbJSON, cerbStatus, cjErr := fetchJSON(ctx, client, cerbURL)
+	res.TempoStatus = tempoStatus
+	res.CerberusStatus = cerbStatus
+	// Fetch proto from both sides (the wire format Grafana actually
+	// asks for on /api/traces/<id>).
+	_, tempoProto, _, tpErr := fetchProto(ctx, client, tempoURL)
+	_, cerbProto, _, cpErr := fetchProto(ctx, client, cerbURL)
+
+	// (a)+(b): record per-side decode failures. These are the high-
+	// signal reasons — a proto decode failure on the cerberus side IS
+	// the #199/#650 bug class.
+	if tjErr != nil {
+		appendReason(&res.Diff, "json_decode", fmt.Sprintf("tempo JSON fetch failed: %v", tjErr))
+	}
+	if cjErr != nil {
+		appendReason(&res.Diff, "json_decode", fmt.Sprintf("cerberus JSON fetch failed: %v", cjErr))
+	}
+	if tpErr != nil {
+		appendReason(&res.Diff, "proto_decode", fmt.Sprintf("tempo proto fetch/decode failed: %v", tpErr))
+	}
+	if cpErr != nil {
+		appendReason(&res.Diff, "proto_decode", fmt.Sprintf("cerberus proto fetch/decode failed: %v", cpErr))
+	}
+
+	// (c)+(d): per-side cross-encoding parity. We only run the parity
+	// check when BOTH encodings decoded on that side; otherwise the
+	// decode-failure reason above already covers the signal.
+	if tjErr == nil && tpErr == nil {
+		ts, err := projectJSONShape(tempoJSON)
+		if err != nil {
+			appendReason(&res.Diff, "json_decode", fmt.Sprintf("tempo JSON shape: %v", err))
+		} else {
+			ps := projectProtoShape(tempoProto)
+			if !ts.equal(ps) {
+				appendReason(&res.Diff, "encoding_mismatch", fmt.Sprintf("tempo: json=(%s) vs proto=(%s)", ts.summarise(), ps.summarise()))
+			}
+		}
+	}
+	if cjErr == nil && cpErr == nil {
+		cs, err := projectJSONShape(cerbJSON)
+		if err != nil {
+			appendReason(&res.Diff, "json_decode", fmt.Sprintf("cerberus JSON shape: %v", err))
+		} else {
+			ps := projectProtoShape(cerbProto)
+			if !cs.equal(ps) {
+				appendReason(&res.Diff, "encoding_mismatch", fmt.Sprintf("cerberus: json=(%s) vs proto=(%s)", cs.summarise(), ps.summarise()))
+			}
+		}
+	}
+
+	// Cross-backend trace-shape parity, using the proto-decoded shape
+	// when available (the canonical wire format), falling back to the
+	// JSON-decoded shape if proto failed. We want SOME comparison even
+	// when one side's proto path is broken — that case will surface as
+	// a proto_decode reason above PLUS the JSON-shape diff below.
+	tempoShape, tempoOK := preferredShape(tempoProto, tempoJSON, tpErr == nil)
+	cerbShape, cerbOK := preferredShape(cerbProto, cerbJSON, cpErr == nil)
+	if tempoOK && cerbOK {
+		if tempoShape.SpanCount != cerbShape.SpanCount {
+			appendReason(&res.Diff, "cardinality", fmt.Sprintf("tempo=%d spans, cerberus=%d spans", tempoShape.SpanCount, cerbShape.SpanCount))
+		}
+		tempoSet := stringSet(tempoShape.SpanIDs)
+		cerbSet := stringSet(cerbShape.SpanIDs)
+		matched := 0
+		var missingInTempo, missingInCerb []string
+		for _, id := range cerbShape.SpanIDs {
+			if tempoSet[id] {
+				matched++
+			} else {
+				missingInTempo = append(missingInTempo, id)
+			}
+		}
+		for _, id := range tempoShape.SpanIDs {
+			if !cerbSet[id] {
+				missingInCerb = append(missingInCerb, id)
+			}
+		}
+		sort.Strings(missingInTempo)
+		sort.Strings(missingInCerb)
+		for _, id := range missingInTempo {
+			appendReason(&res.Diff, "missing_in_a", fmt.Sprintf("span %s present in cerberus but missing in tempo", id))
+		}
+		for _, id := range missingInCerb {
+			appendReason(&res.Diff, "missing_in_b", fmt.Sprintf("span %s present in tempo but missing in cerberus", id))
+		}
+		res.Diff.MatchedCount = matched
+	}
+}
+
+// preferredShape returns the proto-decoded shape when the proto fetch
+// succeeded, else falls back to the JSON-decoded shape. The bool reports
+// whether we got a usable shape at all (false means both encodings
+// failed, in which case the cross-backend compare is skipped).
+func preferredShape(protoMsg *tempopb.Trace, jsonBody []byte, protoOK bool) (traceShape, bool) {
+	if protoOK && protoMsg != nil {
+		return projectProtoShape(protoMsg), true
+	}
+	if len(jsonBody) > 0 {
+		shape, err := projectJSONShape(jsonBody)
+		if err == nil {
+			return shape, true
+		}
+	}
+	return traceShape{}, false
+}
+
+// appendReason updates Diff.Equal + appends one reason. Keeps the
+// Equal-flip discipline local so each call site doesn't risk forgetting
+// to flip Equal.
+func appendReason(d *Diff, kind, detail string) {
+	d.Equal = false
+	d.Reasons = append(d.Reasons, DiffReason{Kind: kind, Detail: detail})
+}

--- a/compatibility/tempo/driver/proto_fetch_test.go
+++ b/compatibility/tempo/driver/proto_fetch_test.go
@@ -1,0 +1,374 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/grafana/tempo/pkg/tempopb"
+	v11 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
+)
+
+// makeSpan returns a Span with the given 16-byte trace ID and 8-byte
+// span ID padded from the input strings. Keeps the test fixtures
+// readable while still producing a real-shape Span.
+func makeSpan(traceHex, spanHex string) *v11.Span {
+	tid := make([]byte, 16)
+	copy(tid, traceHex)
+	sid := make([]byte, 8)
+	copy(sid, spanHex)
+	return &v11.Span{TraceId: tid, SpanId: sid, Name: "op-" + spanHex}
+}
+
+// twoSpanTrace builds a tempopb.Trace with two spans across one
+// ResourceSpans / one ScopeSpans. Used as the canonical "fixture" the
+// JSON + proto encodings both describe in the happy-path test.
+func twoSpanTrace() *tempopb.Trace {
+	return &tempopb.Trace{
+		ResourceSpans: []*v11.ResourceSpans{{
+			ScopeSpans: []*v11.ScopeSpans{{
+				Spans: []*v11.Span{makeSpan("trace1", "spanA"), makeSpan("trace1", "spanB")},
+			}},
+		}},
+	}
+}
+
+func TestFetchProto_DecodesValidTrace(t *testing.T) {
+	t.Parallel()
+	want := twoSpanTrace()
+	body, err := proto.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Accept"); got != "application/protobuf" {
+			t.Errorf("Accept header = %q, want application/protobuf", got)
+		}
+		w.Header().Set("Content-Type", "application/protobuf")
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	raw, trace, status, err := fetchProto(context.Background(), client, srv.URL)
+	if err != nil {
+		t.Fatalf("fetchProto: %v", err)
+	}
+	if status != http.StatusOK {
+		t.Errorf("status = %d, want 200", status)
+	}
+	if len(raw) != len(body) {
+		t.Errorf("raw bytes len = %d, want %d", len(raw), len(body))
+	}
+	got := projectProtoShape(trace)
+	wantShape := projectProtoShape(want)
+	if !got.equal(wantShape) {
+		t.Fatalf("shape mismatch: got=%v want=%v", got, wantShape)
+	}
+}
+
+func TestFetchProto_DetectsJSONInsteadOfProto(t *testing.T) {
+	// This is the #199/#650 failure mode: client asks for proto, server
+	// returns JSON. proto.Unmarshal must fail (not return an empty
+	// message), and the error must carry enough body context to be
+	// diagnosable.
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"batches":[{"spans":[{"spanId":"aaaa"}]}]}`))
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	_, trace, status, err := fetchProto(context.Background(), client, srv.URL)
+	if err == nil {
+		t.Fatalf("fetchProto: want decode error, got nil (trace=%v)", trace)
+	}
+	if !strings.Contains(err.Error(), "proto.Unmarshal") {
+		t.Errorf("error %q does not mention proto.Unmarshal", err.Error())
+	}
+	if !strings.Contains(err.Error(), "batches") {
+		t.Errorf("error %q does not include body snippet", err.Error())
+	}
+	if status != http.StatusOK {
+		t.Errorf("status = %d, want 200", status)
+	}
+}
+
+func TestFetchProto_PropagatesNon2xx(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`trace not found`))
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	_, trace, status, err := fetchProto(context.Background(), client, srv.URL)
+	if err == nil {
+		t.Fatalf("want error on non-2xx, got nil (trace=%v)", trace)
+	}
+	if status != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", status)
+	}
+	if !strings.Contains(err.Error(), "404") || !strings.Contains(err.Error(), "trace not found") {
+		t.Errorf("error %q missing status / body context", err.Error())
+	}
+}
+
+func TestProjectProtoShape_FlattensResourceScopeSpans(t *testing.T) {
+	t.Parallel()
+	trace := &tempopb.Trace{
+		ResourceSpans: []*v11.ResourceSpans{
+			{ScopeSpans: []*v11.ScopeSpans{
+				{Spans: []*v11.Span{makeSpan("t", "s1"), makeSpan("t", "s2")}},
+				{Spans: []*v11.Span{makeSpan("t", "s3")}},
+			}},
+			{ScopeSpans: []*v11.ScopeSpans{
+				{Spans: []*v11.Span{makeSpan("t", "s4")}},
+			}},
+		},
+	}
+	shape := projectProtoShape(trace)
+	if shape.SpanCount != 4 {
+		t.Errorf("SpanCount = %d, want 4", shape.SpanCount)
+	}
+	// Span IDs are 8-byte arrays hex-encoded — sortedKeys gives a
+	// deterministic order. Validate the count + first id contains
+	// "s1" hex prefix.
+	if len(shape.SpanIDs) != 4 {
+		t.Errorf("SpanIDs len = %d, want 4", len(shape.SpanIDs))
+	}
+}
+
+func TestProjectJSONShape_TempoNested(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"batches":[{"scopeSpans":[{"spans":[{"spanId":"aa"},{"spanId":"bb"}]}]}]}`)
+	shape, err := projectJSONShape(body)
+	if err != nil {
+		t.Fatalf("projectJSONShape: %v", err)
+	}
+	if shape.SpanCount != 2 {
+		t.Errorf("SpanCount = %d, want 2", shape.SpanCount)
+	}
+	if len(shape.SpanIDs) != 2 || shape.SpanIDs[0] != "aa" || shape.SpanIDs[1] != "bb" {
+		t.Errorf("SpanIDs = %v, want [aa bb]", shape.SpanIDs)
+	}
+}
+
+func TestProjectJSONShape_CerberusFlat(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"batches":[{"spans":[{"spanId":"aa"},{"spanId":"bb"},{"spanId":"cc"}]}]}`)
+	shape, err := projectJSONShape(body)
+	if err != nil {
+		t.Fatalf("projectJSONShape: %v", err)
+	}
+	if shape.SpanCount != 3 {
+		t.Errorf("SpanCount = %d, want 3", shape.SpanCount)
+	}
+	if len(shape.SpanIDs) != 3 {
+		t.Errorf("SpanIDs len = %d, want 3", len(shape.SpanIDs))
+	}
+}
+
+func TestTraceShape_EqualsDetectsDivergence(t *testing.T) {
+	t.Parallel()
+	a := traceShape{SpanCount: 2, SpanIDs: []string{"aa", "bb"}}
+	b := traceShape{SpanCount: 2, SpanIDs: []string{"aa", "bb"}}
+	if !a.equal(b) {
+		t.Errorf("a.equal(b) = false, want true")
+	}
+	// Different count
+	c := traceShape{SpanCount: 1, SpanIDs: []string{"aa"}}
+	if a.equal(c) {
+		t.Errorf("a.equal(c) = true, want false on differing count")
+	}
+	// Same count, different IDs
+	d := traceShape{SpanCount: 2, SpanIDs: []string{"aa", "cc"}}
+	if a.equal(d) {
+		t.Errorf("a.equal(d) = true, want false on differing IDs")
+	}
+}
+
+func TestDiffTracesEndpoint_CerberusProtoMissingIsReported(t *testing.T) {
+	// Integration-shape test: mock two backends. Reference Tempo serves
+	// the same trace in BOTH JSON and proto (content-negotiated by
+	// Accept). Cerberus serves only JSON — when asked for proto it
+	// returns JSON instead. The differ must report a proto_decode
+	// reason on the cerberus side AND an encoding_mismatch reason
+	// (cerberus json shape vs cerberus proto shape, where the proto
+	// shape is the empty fallback after decode failure).
+	t.Parallel()
+
+	want := twoSpanTrace()
+	protoBytes, err := proto.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	// Tempo-shape JSON: {batches:[{scopeSpans:[{spans:[{spanId}, ...]}]}]}.
+	// We use the same hex span IDs both encodings would project to so
+	// the cross-encoding parity holds on the tempo side.
+	wantShape := projectProtoShape(want)
+	if len(wantShape.SpanIDs) != 2 {
+		t.Fatalf("fixture: want 2 span IDs, got %d", len(wantShape.SpanIDs))
+	}
+	tempoJSON := []byte(`{"batches":[{"scopeSpans":[{"spans":[` +
+		`{"spanId":"` + wantShape.SpanIDs[0] + `"},` +
+		`{"spanId":"` + wantShape.SpanIDs[1] + `"}` +
+		`]}]}]}`)
+
+	tempoSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Accept") == "application/protobuf" {
+			w.Header().Set("Content-Type", "application/protobuf")
+			_, _ = w.Write(protoBytes)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(tempoJSON)
+	}))
+	defer tempoSrv.Close()
+
+	// Cerberus: returns JSON regardless of Accept (the #199/#650 bug).
+	cerbSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(tempoJSON)
+	}))
+	defer cerbSrv.Close()
+
+	res := CaseResult{Case: CorpusCase{Endpoint: "traces"}}
+	client := &http.Client{Timeout: 2 * time.Second}
+	diffTracesEndpoint(context.Background(), client, tempoSrv.URL, cerbSrv.URL, &res)
+
+	if res.Diff.Equal {
+		t.Fatalf("Diff.Equal = true, want false (cerberus proto path is broken)")
+	}
+	// At least one proto_decode reason on the cerberus side.
+	foundProtoDecode := false
+	for _, r := range res.Diff.Reasons {
+		if r.Kind == "proto_decode" && strings.Contains(r.Detail, "cerberus") {
+			foundProtoDecode = true
+			break
+		}
+	}
+	if !foundProtoDecode {
+		t.Errorf("missing proto_decode/cerberus reason; reasons=%+v", res.Diff.Reasons)
+	}
+}
+
+func TestDiffTracesEndpoint_BothBackendsHealthy(t *testing.T) {
+	// Happy path: both backends serve identical JSON + proto. Diff
+	// should be Equal=true with MatchedCount = span count.
+	t.Parallel()
+
+	want := twoSpanTrace()
+	protoBytes, err := proto.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	wantShape := projectProtoShape(want)
+	if len(wantShape.SpanIDs) != 2 {
+		t.Fatalf("fixture: want 2 span IDs, got %d", len(wantShape.SpanIDs))
+	}
+	traceJSON := []byte(`{"batches":[{"scopeSpans":[{"spans":[` +
+		`{"spanId":"` + wantShape.SpanIDs[0] + `"},` +
+		`{"spanId":"` + wantShape.SpanIDs[1] + `"}` +
+		`]}]}]}`)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Accept") == "application/protobuf" {
+			w.Header().Set("Content-Type", "application/protobuf")
+			_, _ = w.Write(protoBytes)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(traceJSON)
+	})
+	tempoSrv := httptest.NewServer(handler)
+	defer tempoSrv.Close()
+	cerbSrv := httptest.NewServer(handler)
+	defer cerbSrv.Close()
+
+	res := CaseResult{Case: CorpusCase{Endpoint: "traces"}}
+	client := &http.Client{Timeout: 2 * time.Second}
+	diffTracesEndpoint(context.Background(), client, tempoSrv.URL, cerbSrv.URL, &res)
+
+	if !res.Diff.Equal {
+		t.Fatalf("Diff.Equal = false, want true; reasons=%+v", res.Diff.Reasons)
+	}
+	if res.Diff.MatchedCount != 2 {
+		t.Errorf("MatchedCount = %d, want 2", res.Diff.MatchedCount)
+	}
+}
+
+func TestDiffTracesEndpoint_CardinalityMismatchReported(t *testing.T) {
+	// Both backends serve proto + JSON cleanly, but each side describes
+	// a different number of spans. The cross-backend cardinality
+	// reason must fire.
+	t.Parallel()
+
+	tempoTrace := twoSpanTrace()
+	tempoProto, err := proto.Marshal(tempoTrace)
+	if err != nil {
+		t.Fatalf("marshal tempo: %v", err)
+	}
+	tempoShape := projectProtoShape(tempoTrace)
+	tempoJSON := []byte(`{"batches":[{"scopeSpans":[{"spans":[` +
+		`{"spanId":"` + tempoShape.SpanIDs[0] + `"},` +
+		`{"spanId":"` + tempoShape.SpanIDs[1] + `"}` +
+		`]}]}]}`)
+
+	// Cerberus: one span only.
+	cerbTrace := &tempopb.Trace{
+		ResourceSpans: []*v11.ResourceSpans{{
+			ScopeSpans: []*v11.ScopeSpans{{
+				Spans: []*v11.Span{makeSpan("trace1", "spanA")},
+			}},
+		}},
+	}
+	cerbProto, err := proto.Marshal(cerbTrace)
+	if err != nil {
+		t.Fatalf("marshal cerb: %v", err)
+	}
+	cerbShape := projectProtoShape(cerbTrace)
+	cerbJSON := []byte(`{"batches":[{"scopeSpans":[{"spans":[` +
+		`{"spanId":"` + cerbShape.SpanIDs[0] + `"}` +
+		`]}]}]}`)
+
+	tempoSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Accept") == "application/protobuf" {
+			_, _ = w.Write(tempoProto)
+			return
+		}
+		_, _ = w.Write(tempoJSON)
+	}))
+	defer tempoSrv.Close()
+	cerbSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Accept") == "application/protobuf" {
+			_, _ = w.Write(cerbProto)
+			return
+		}
+		_, _ = w.Write(cerbJSON)
+	}))
+	defer cerbSrv.Close()
+
+	res := CaseResult{Case: CorpusCase{Endpoint: "traces"}}
+	client := &http.Client{Timeout: 2 * time.Second}
+	diffTracesEndpoint(context.Background(), client, tempoSrv.URL, cerbSrv.URL, &res)
+
+	if res.Diff.Equal {
+		t.Fatalf("Diff.Equal = true, want false on span-count mismatch")
+	}
+	foundCardinality := false
+	for _, r := range res.Diff.Reasons {
+		if r.Kind == "cardinality" {
+			foundCardinality = true
+			break
+		}
+	}
+	if !foundCardinality {
+		t.Errorf("missing cardinality reason; reasons=%+v", res.Diff.Reasons)
+	}
+}


### PR DESCRIPTION
## Summary

The trace-by-id slot in the tempo compat differ hard-coded `Accept: application/json`, so reference Tempo and cerberus both returned JSON and the differ never noticed when one side's protobuf path was broken — the exact failure mode #199/#650 fixed (cerberus silently returned JSON to a client that asked for proto, and Grafana's trace view rendered blank).

This PR adds a sibling `fetchProto` next to `fetchJSON` and rewires the trace-by-id case to fetch BOTH encodings on each side.

- Picked the canonical (B) sibling-fetcher design from #202: stronger coverage than (A) "use the vendored httpclient" because (B) also catches "cerberus serves proto but its JSON path is broken" and "proto + JSON disagree on what the trace actually is".
- The vendored `compatibility/tempo/upstream/pkg/httpclient` stays on `go.mod ignore` — un-ignoring it would pull in a separate dep cone and is out of scope for this fix.
- Seeder's two `Accept: application/json` callers stay on JSON. The cerberus-side check that matters most is the differ; the seeder polls for span counts and that contract is JSON-stable on both backends today.

## What the new path reports

For `tc.Endpoint == "traces"`, `diffTracesEndpoint` (in `proto_fetch.go`) fetches JSON + proto from each side and surfaces failures as DiffReasons on `res.Diff` (never HardErrors — same posture as the rest of the differ):

- `proto_decode`: `proto.Unmarshal` failed on a side. Catches cerberus serving JSON when proto was asked for (the #199/#650 bug class).
- `json_decode`: defensive — JSON fetch / decode failed.
- `encoding_mismatch`: both decoders succeeded on a side, but their span-ID sets describe different traces.
- `cardinality` / `missing_in_a` / `missing_in_b`: cross-backend trace-shape diff, on the proto-decoded shape (the canonical Tempo wire format).

`res.Diff.MatchedCount` counts spans matched across backends so the markdown report's per-case line stays informative.

## Test plan

- [x] Unit (`compatibility/tempo/driver/proto_fetch_test.go`): 10 new tests
  - `TestFetchProto_DecodesValidTrace` — happy-path proto decode.
  - `TestFetchProto_DetectsJSONInsteadOfProto` — the #199/#650 case; the err carries `proto.Unmarshal` + a body-prefix snippet.
  - `TestFetchProto_PropagatesNon2xx` — 404 + body context in the error.
  - `TestProjectProtoShape_FlattensResourceScopeSpans` — multi-batch / multi-scope span aggregation.
  - `TestProjectJSONShape_TempoNested` / `_CerberusFlat` — both JSON dialects.
  - `TestTraceShape_EqualsDetectsDivergence` — span-count + span-ID set parity.
  - `TestDiffTracesEndpoint_BothBackendsHealthy` — Equal=true on identical fixtures.
  - `TestDiffTracesEndpoint_CerberusProtoMissingIsReported` — fires `proto_decode` on cerberus when only Tempo serves real proto.
  - `TestDiffTracesEndpoint_CardinalityMismatchReported` — cross-backend span-count divergence.
- [x] All 104 existing driver tests still pass (no regressions in the rest of the differ).
- [x] `go vet ./compatibility/tempo/driver/...` clean.
- [ ] CI `compatibility/tempo` lane: the existing corpus entry `trace_by_id_first_checkout` (compatibility/tempo/driver/corpus/smoke.txtar:386) now exercises both encodings — no corpus changes needed.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)