### PR TITLE
fix(api/tempo): alias /api/v2/traces/{id} so Grafana 11.x trace drill-down stops 404-ing

### DIFF
--- a/internal/api/tempo/conformance_test.go
+++ b/internal/api/tempo/conformance_test.go
@@ -312,6 +312,18 @@ func TestConformance_TempoSearchTagValuesWire(t *testing.T) {
 // with error envelope when not. The error envelope is Tempo's distinct
 // shape: {traceID, spanID, error, message}.
 //
+// Drives BOTH the v1 (`/api/traces/<id>`) and the v2
+// (`/api/v2/traces/<id>`) URLs and asserts byte-identical bodies for the
+// same input. Grafana 11.x's Tempo datasource defaults to
+// `tempoApiVersion >= v2` for newly-provisioned datasources, so the v2
+// URL is what the modern UI actually hits when drilling into a trace.
+// Upstream Tempo's QueryTrace + QueryTraceV2 (see
+// compatibility/tempo/upstream/pkg/httpclient/client.go) differ only in
+// path — the response body is the same trace shape — so cerberus must
+// alias the route to keep both datasource versions working. Before the
+// alias landed, the v2 URL 404'd unconditionally and every modern
+// Grafana trace drill-down broke (cerberus task #208).
+//
 // Also pins the Content-Type negotiation under Accept: the bare /
 // `application/json` paths keep the documented JSON envelope; the
 // `application/protobuf` / `application/x-protobuf` / `application/grpc`
@@ -321,48 +333,88 @@ func TestConformance_TempoSearchTagValuesWire(t *testing.T) {
 func TestConformance_TempoTraceByIDWire(t *testing.T) {
 	t.Parallel()
 
+	// Both URLs must resolve to the same handler and produce
+	// byte-identical bodies. The v2 entries are the new gate added by
+	// PR fix/tempo-v2-traces-alias; the v1 entries remain the
+	// historical contract.
+	pathVariants := []struct {
+		name string
+		path string
+	}{
+		{name: "v1", path: "/api/traces/abc123"},
+		{name: "v2", path: "/api/v2/traces/abc123"},
+	}
+
 	t.Run("found", func(t *testing.T) {
 		t.Parallel()
-		q := &stubQuerier{samples: []chclient.Sample{{
-			MetricName: "x", Labels: map[string]string{"service.name": "frontend"},
-			Timestamp: time.Now(), Value: 1,
-		}}}
-		srv := newServer(q, "v1.0.0-test")
-		t.Cleanup(srv.Close)
-		resp, err := http.Get(srv.URL + "/api/traces/abc123")
-		if err != nil {
-			t.Fatalf("GET: %v", err)
+		// Capture each variant's body to a shared map (test runs are
+		// sequential within this sub-test so the map write is safe).
+		// A fixed Timestamp keeps the response deterministic for the
+		// byte-level cross-check below.
+		fixedTime := time.Unix(1700000000, 0).UTC()
+		sample := chclient.Sample{
+			MetricName: "x",
+			Labels:     map[string]string{"service.name": "frontend"},
+			Timestamp:  fixedTime,
+			Value:      1,
 		}
-		defer resp.Body.Close()
-		if resp.StatusCode != http.StatusOK {
-			t.Fatalf("status=%d", resp.StatusCode)
+		bodies := map[string][]byte{}
+		for _, pv := range pathVariants {
+			q := &stubQuerier{samples: []chclient.Sample{sample}}
+			srv := newServer(q, "v1.0.0-test")
+			t.Cleanup(srv.Close)
+			resp, err := http.Get(srv.URL + pv.path)
+			if err != nil {
+				t.Fatalf("%s: GET: %v", pv.name, err)
+			}
+			raw, readErr := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if readErr != nil {
+				t.Fatalf("%s: read body: %v", pv.name, readErr)
+			}
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("%s: status=%d body=%q", pv.name, resp.StatusCode, raw)
+			}
+			var r tempo.TraceByIDResponse
+			if err := json.Unmarshal(raw, &r); err != nil {
+				t.Fatalf("%s: decode: %v", pv.name, err)
+			}
+			if r.Batches == nil {
+				t.Errorf("%s: Batches nil; expected non-nil", pv.name)
+			}
+			bodies[pv.name] = raw
 		}
-		var r tempo.TraceByIDResponse
-		if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
-			t.Fatalf("decode: %v", err)
-		}
-		if r.Batches == nil {
-			t.Errorf("Batches nil; expected non-nil")
+		// v1 vs v2 must be byte-identical — same handler, same input.
+		// If v2 ever diverges (different status, different shape, an
+		// added/removed field), this fails loudly.
+		if v1, v2 := bodies["v1"], bodies["v2"]; string(v1) != string(v2) {
+			t.Errorf("v1 vs v2 body diverged:\n v1=%s\n v2=%s", v1, v2)
 		}
 	})
 	t.Run("not_found", func(t *testing.T) {
 		t.Parallel()
-		srv := newServer(&stubQuerier{samples: nil}, "v1.0.0-test")
-		t.Cleanup(srv.Close)
-		resp, err := http.Get(srv.URL + "/api/traces/abc123")
-		if err != nil {
-			t.Fatalf("GET: %v", err)
-		}
-		defer resp.Body.Close()
-		if resp.StatusCode != http.StatusNotFound {
-			t.Fatalf("status=%d, want 404", resp.StatusCode)
-		}
-		var er tempo.ErrorResponse
-		if err := json.NewDecoder(resp.Body).Decode(&er); err != nil {
-			t.Fatalf("decode: %v", err)
-		}
-		if er.TraceID != "abc123" || !er.Error {
-			t.Errorf("envelope: got %+v, want traceID=abc123, error=true", er)
+		for _, pv := range pathVariants {
+			pv := pv
+			t.Run(pv.name, func(t *testing.T) {
+				t.Parallel()
+				srv := newServer(&stubQuerier{samples: nil}, "v1.0.0-test")
+				t.Cleanup(srv.Close)
+				resp, err := http.Get(srv.URL + pv.path)
+				if err != nil {
+					t.Fatalf("GET: %v", err)
+				}
+				defer resp.Body.Close()
+				if resp.StatusCode != http.StatusNotFound {
+					t.Fatalf("status=%d, want 404", resp.StatusCode)
+				}
+				var er tempo.ErrorResponse
+				if err := json.NewDecoder(resp.Body).Decode(&er); err != nil {
+					t.Fatalf("decode: %v", err)
+				}
+				if er.TraceID != "abc123" || !er.Error {
+					t.Errorf("envelope: got %+v, want traceID=abc123, error=true", er)
+				}
+			})
 		}
 	})
 
@@ -398,22 +450,27 @@ func TestConformance_TempoTraceByIDWire(t *testing.T) {
 			// proto entry wins.
 			{"application/protobuf, application/json;q=0.9", "application/protobuf"},
 		}
-		for _, tc := range cases {
-			req, err := http.NewRequest("GET", srv.URL+"/api/traces/abc123", nil)
-			if err != nil {
-				t.Fatalf("NewRequest: %v", err)
-			}
-			if tc.accept != "" {
-				req.Header.Set("Accept", tc.accept)
-			}
-			resp, err := http.DefaultClient.Do(req)
-			if err != nil {
-				t.Fatalf("Accept=%q: GET: %v", tc.accept, err)
-			}
-			resp.Body.Close()
-			if !strings.Contains(resp.Header.Get("Content-Type"), tc.wantCT) {
-				t.Errorf("Accept=%q: Content-Type=%q, want substring %q",
-					tc.accept, resp.Header.Get("Content-Type"), tc.wantCT)
+		// The same negotiation must hold for both the v1 and v2 URLs —
+		// Grafana 11.x's plugin hits v2 by default and expects the same
+		// Content-Type switching behavior the v1 path has shipped with.
+		for _, pv := range pathVariants {
+			for _, tc := range cases {
+				req, err := http.NewRequest("GET", srv.URL+pv.path, nil)
+				if err != nil {
+					t.Fatalf("NewRequest: %v", err)
+				}
+				if tc.accept != "" {
+					req.Header.Set("Accept", tc.accept)
+				}
+				resp, err := http.DefaultClient.Do(req)
+				if err != nil {
+					t.Fatalf("%s Accept=%q: GET: %v", pv.name, tc.accept, err)
+				}
+				resp.Body.Close()
+				if !strings.Contains(resp.Header.Get("Content-Type"), tc.wantCT) {
+					t.Errorf("%s Accept=%q: Content-Type=%q, want substring %q",
+						pv.name, tc.accept, resp.Header.Get("Content-Type"), tc.wantCT)
+				}
 			}
 		}
 	})
@@ -472,6 +529,19 @@ func TestConformance_TempoErrorEnvelope(t *testing.T) {
 			name: "404_trace_not_found",
 			stub: &stubQuerier{samples: nil},
 			path: "/api/traces/abc123", wantCode: http.StatusNotFound,
+		},
+		// v2 URL mirrors the v1 route — Grafana 11.x's Tempo plugin
+		// defaults to `tempoApiVersion >= v2`, so error envelopes must
+		// hold on both paths.
+		{
+			name: "502_trace_by_id_v2_ch_failure",
+			stub: &stubQuerier{err: errors.New("ch failure")},
+			path: "/api/v2/traces/abc123", wantCode: http.StatusBadGateway,
+		},
+		{
+			name: "404_trace_not_found_v2",
+			stub: &stubQuerier{samples: nil},
+			path: "/api/v2/traces/abc123", wantCode: http.StatusNotFound,
 		},
 	}
 	for _, c := range cases {

--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -185,6 +185,19 @@ func (h *Handler) Mount(mux *http.ServeMux) {
 	register("GET /api/v2/search/tags", h.handleSearchTagsV2)
 	register("GET /api/v2/search/tag/{name}/values", h.handleSearchTagValuesV2)
 	register("GET /api/traces/{id}", h.handleTraceByID)
+	// /api/v2/traces/{id} is the modern Grafana Tempo datasource path —
+	// the default in Grafana 11.x whenever the datasource's
+	// `tempoApiVersion` setting is >= v2 (which is the out-of-the-box
+	// default for new datasources). Upstream Tempo's
+	// `compatibility/tempo/upstream/pkg/httpclient/client.go` exposes
+	// `QueryTraceEndpoint = "/api/traces"` (v1) and
+	// `QueryTraceV2Endpoint = "/api/v2/traces"` (v2) — the URL is the
+	// only thing the v2 bump changes, the response body is the same
+	// trace shape (Trace proto / TraceByIDResponse JSON). Aliasing the
+	// route to the same handler keeps cerberus drop-in for both
+	// datasource versions and stops Grafana 404-ing every trace
+	// drill-down.
+	register("GET /api/v2/traces/{id}", h.handleTraceByID)
 	register("GET /api/metrics/query_range", h.handleMetricsQueryRange)
 	register("GET /api/metrics/query", h.handleMetricsQueryInstant)
 }

--- a/test/e2e/playwright/compose_grafana_smoke.spec.ts
+++ b/test/e2e/playwright/compose_grafana_smoke.spec.ts
@@ -402,11 +402,30 @@ async function driveTraceClick(page: Page, baseURL: string): Promise<string[]> {
   }
 
   // 3. Subscribe to responses BEFORE the click so we catch the
-  //    /api/ds/query the drill-through fires.
+  //    /api/ds/query the drill-through fires AND any direct
+  //    trace-by-id call Grafana proxies through.
+  //
+  //    Grafana 11.x's Tempo datasource defaults to `tempoApiVersion >=
+  //    v2`, which means trace drill-downs route through
+  //    `/api/v2/traces/<id>` (via the datasource proxy / resources
+  //    endpoint), not the legacy `/api/traces/<id>`. We capture every
+  //    trace-by-id URL the page fires so the assertion below can pin
+  //    "the request landed on v2" — without that gate, a regression
+  //    that drops the v2 alias from cerberus's Mount() would silently
+  //    404 the trace view (task #208).
   const captured: Response[] = [];
+  const traceByIDRequests: { url: string; status: number }[] = [];
   const onResponse = (resp: Response) => {
-    if (resp.url().includes('/api/ds/query')) {
+    const url = resp.url();
+    if (url.includes('/api/ds/query')) {
       captured.push(resp);
+    }
+    // Match every outbound trace-by-id Grafana issues against the
+    // cerberus-tempo datasource — whichever proxy path the plugin
+    // uses internally (proxy/uid/<uid>/api/... vs
+    // datasources/uid/<uid>/resources/api/...).
+    if (url.includes('/cerberus-tempo/') && /\/(v2\/)?traces\/[0-9a-f]+/i.test(url)) {
+      traceByIDRequests.push({ url, status: resp.status() });
     }
   };
   page.on('response', onResponse);
@@ -421,6 +440,39 @@ async function driveTraceClick(page: Page, baseURL: string): Promise<string[]> {
       .catch(() => {});
   } finally {
     page.off('response', onResponse);
+  }
+
+  // 3b. Trace-by-id URL gate. If Grafana fired any trace-by-id
+  //     request during the drill-through, at least one must hit the
+  //     v2 URL (the Grafana 11.x default for newly-provisioned Tempo
+  //     datasources, which is what compose's
+  //     test/e2e/grafana/compose/datasources/cerberus.yaml ships).
+  //     Every captured v2 hit must also resolve 2xx — that's the
+  //     load-bearing gate for task #208: cerberus aliased
+  //     `/api/v2/traces/{id}` to the same handler so the modern UI
+  //     stops 404-ing every drill-down.
+  //
+  //     When `traceByIDRequests` is empty the Tempo plugin didn't
+  //     hit cerberus directly during this click (Grafana sometimes
+  //     resolves the trace view client-side from the panel's existing
+  //     query result), and the tunneled-error / DOM-alert sweeps
+  //     below still cover the rendering side.
+  if (traceByIDRequests.length > 0) {
+    const v2Hits = traceByIDRequests.filter((r) => r.url.includes('/v2/traces/'));
+    if (v2Hits.length === 0) {
+      failures.push(
+        `[trace-click] no /api/v2/traces hit observed — Grafana 11.x defaults to tempoApiVersion>=v2, so every trace drill-down must route through v2; captured:\n${traceByIDRequests
+          .map((r) => `  ${r.status} ${r.url}`)
+          .join('\n')}`,
+      );
+    }
+    for (const hit of v2Hits) {
+      if (hit.status < 200 || hit.status > 299) {
+        failures.push(
+          `[trace-click] /api/v2/traces hit ${hit.url} → ${hit.status}, want 2xx (task #208: cerberus must alias the v2 URL to handleTraceByID)`,
+        );
+      }
+    }
   }
 
   // 4a. /api/ds/query status sweep over what the click fired.

--- a/test/e2e/playwright/tempo_traces.spec.ts
+++ b/test/e2e/playwright/tempo_traces.spec.ts
@@ -63,3 +63,27 @@ test('tempo /api/traces/<id> returns batches for a seeded trace', async ({ reque
     expect(Array.isArray(batch.spans), 'batch has spans array').toBe(true);
   }
 });
+
+/**
+ * Grafana 11.x's Tempo datasource defaults to `tempoApiVersion >= v2`,
+ * which switches every trace drill-down from `/api/traces/<id>` to
+ * `/api/v2/traces/<id>`. Before cerberus aliased the v2 path to the
+ * same handler, the modern UI 404'd every click. This test pins both
+ * URLs against the same seeded trace and asserts the bodies are
+ * byte-identical — the v2 bump is URL-only per upstream Tempo
+ * (compatibility/tempo/upstream/pkg/httpclient/client.go ships
+ * QueryTrace + QueryTraceV2 differing only in path).
+ */
+test('tempo /api/v2/traces/<id> is a byte-for-byte alias of v1', async ({ request }) => {
+  const traceID = 'a0000000000000000000000000000001';
+  const [v1Resp, v2Resp] = await Promise.all([
+    request.get(`${tempoProxy}/traces/${traceID}`),
+    request.get(`${tempoProxy}/v2/traces/${traceID}`),
+  ]);
+  expect(v1Resp.status(), 'tempo v1 status').toBe(200);
+  expect(v2Resp.status(), 'tempo v2 status').toBe(200);
+
+  const v1Body = await v1Resp.text();
+  const v2Body = await v2Resp.text();
+  expect(v2Body, 'v2 body identical to v1').toBe(v1Body);
+});


### PR DESCRIPTION
## Summary

Grafana 11.x's Tempo datasource defaults to `tempoApiVersion >= v2`, which routes every trace drill-down through `/api/v2/traces/{id}` instead of `/api/traces/{id}`. cerberus only registered the v1 path, so the modern UI got an unconditional 404 on every trace click (task #208).

Per upstream Tempo (`compatibility/tempo/upstream/pkg/httpclient/client.go`), `QueryTraceEndpoint = "/api/traces"` and `QueryTraceV2Endpoint = "/api/v2/traces"` differ **only in URL** — the response body is the same `Trace` proto / `TraceByIDResponse` JSON shape — so aliasing the v2 route to `handleTraceByID` is the full fix.

Repro before this PR:

```
curl -i http://localhost:8080/api/v2/traces/$(printf "%032x" 1)
HTTP/1.1 404 Not Found
```

After: same response as the v1 URL (404 with documented Tempo error envelope on miss; 200 with batches on hit).

## Test plan

- [x] Conformance: `TestConformance_TempoTraceByIDWire` now drives **both** URLs and asserts **byte-identical bodies** for the same input (found / not_found subtests). Accept-header content-type negotiation is mirrored on v2. The error-envelope table gains 502 + 404 cases for v2.
- [x] Playwright (compose smoke): `driveTraceClick` captures every trace-by-id URL Grafana fires against `cerberus-tempo` and asserts at least one hits `/api/v2/traces/` with a 2xx. A regression that drops the alias would surface as a captured 404 on the v2 URL.
- [x] Playwright (tempo_traces.spec): direct datasource-proxy test pins v1 and v2 as byte-for-byte aliases.
- [x] `go test ./internal/api/tempo/...` passes locally (no Skip / not-implemented / deferred markers).

Closes cerberus task #208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)