### PR TITLE
fix(api/tempo): emit spec-compliant 32-/16-char trace IDs / span IDs on /api/search + /api/traces/{id} (#209)

### DIFF
--- a/internal/api/tempo/conformance_test.go
+++ b/internal/api/tempo/conformance_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -98,8 +99,25 @@ func TestConformance_TempoVersionWire(t *testing.T) {
 }
 
 // TestConformance_TempoSearchWire — empty + happy + multi-trace payloads.
+//
+// Also pins the spec-compliant traceID hex shape (issue #209): every
+// hex-shaped traceID on /api/search must be exactly 32 lowercase-hex
+// chars (the canonical hex encoding of OTel's 16-byte TraceId).
+// Cerberus historically stripped leading zeros to mirror reference
+// Tempo's wire-format defect; this property-style assertion catches
+// any regression that re-introduces stripping on the OUTPUT side
+// regardless of which sample shape drives the projection.
 func TestConformance_TempoSearchWire(t *testing.T) {
 	t.Parallel()
+
+	// Spec: TraceId is fixed 16 bytes → 32 lowercase-hex chars on
+	// the wire. Anything shorter is a spec violation.
+	traceIDHex := regexp.MustCompile(`^[0-9a-f]{32}$`)
+	// Hex-shape sentinel — used to skip synthetic-key fallback
+	// rows (e.g. `MetricName|TimestampNs`) that don't carry a real
+	// hex traceID, so we only apply the canonical-shape rule where
+	// the projection actually surfaced a hex value.
+	hexLike := regexp.MustCompile(`^[0-9a-f]+$`)
 
 	ts := time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC)
 	cases := []struct {
@@ -118,6 +136,39 @@ func TestConformance_TempoSearchWire(t *testing.T) {
 				{MetricName: "GET /api/users", Labels: map[string]string{"service.name": "frontend"}, Timestamp: ts, Value: 100_000_000},
 			},
 			path: "/api/search?q=%7B%20resource.service.name%20%3D%20%22frontend%22%20%7D",
+		},
+		{
+			// Issue #209: the projection now surfaces the OTel-CH
+			// column verbatim, so a leading-zero traceID must
+			// arrive as the canonical 32-char form, NOT the legacy
+			// stripped shape. Seeds two traces whose canonical hex
+			// starts with `00…` so any future reintroduction of
+			// zero-stripping surfaces here as a < 32-char wire
+			// value and trips the regex below.
+			name: "leading_zero_trace_ids_padded",
+			samples: []chclient.Sample{
+				{
+					MetricName: "GET /api/users",
+					Labels: map[string]string{
+						"service.name":            "frontend",
+						"__cerberus_traceID":      "00af843259b0a78f5cbe59e11cbaf66b",
+						"__cerberus_parentSpanID": "0000000000000000",
+					},
+					Timestamp: ts,
+					Value:     100_000_000,
+				},
+				{
+					MetricName: "POST /api/orders",
+					Labels: map[string]string{
+						"service.name":            "backend",
+						"__cerberus_traceID":      "00000000000000000000000000000001",
+						"__cerberus_parentSpanID": "0000000000000000",
+					},
+					Timestamp: ts,
+					Value:     200_000_000,
+				},
+			},
+			path: "/api/search?q=%7B%7D",
 		},
 	}
 	for _, c := range cases {
@@ -152,7 +203,99 @@ func TestConformance_TempoSearchWire(t *testing.T) {
 			case len(c.samples) > 0 && len(sr.Traces) == 0:
 				t.Errorf("Traces length: got 0, want non-empty (%d sample(s) seeded)", len(c.samples))
 			}
+			// Property: every hex-shaped traceID on the wire must
+			// match the OTel canonical 32-char lowercase-hex shape
+			// (issue #209). Skip synthetic-key fallback rows whose
+			// IDs aren't hex-only (e.g. `MetricName|Timestamp`).
+			for _, tr := range sr.Traces {
+				if tr.TraceID == "" || !hexLike.MatchString(tr.TraceID) {
+					continue
+				}
+				if !traceIDHex.MatchString(tr.TraceID) {
+					t.Errorf("traceID %q (len=%d) violates OTel canonical "+
+						"32-char hex shape; cerberus must NOT strip leading "+
+						"zeros on output (issue #209)",
+						tr.TraceID, len(tr.TraceID))
+				}
+			}
 		})
+	}
+}
+
+// TestConformance_TempoTraceByIDWire_HexShape pins the wire-format
+// invariant on /api/traces/{id}: every per-span TraceID / SpanID
+// surfacing in the JSON response must match the OTel canonical hex
+// shape (32 chars for trace IDs, 16 chars for span IDs, lowercase
+// hex). Issue #209.
+//
+// Seeds a span row whose IDs start with leading zeros (the worst-case
+// shape — reference Tempo's legacy wire layer would strip these) and
+// asserts both fields round-trip as the canonical fixed-width form.
+func TestConformance_TempoTraceByIDWire_HexShape(t *testing.T) {
+	t.Parallel()
+
+	const traceIDHex = "0000000000000000af843259b0a78f5c"
+	const spanIDHex = "00000000000000ab"
+	const parentSpanIDHex = "0000000000000000"
+
+	q := &stubQuerier{
+		samples: []chclient.Sample{{
+			MetricName: "GET /api/users",
+			Labels: map[string]string{
+				"service.name":             "frontend",
+				"__cerberus_traceID":       traceIDHex,
+				"__cerberus_spanID":        spanIDHex,
+				"__cerberus_parentSpanID":  parentSpanIDHex,
+				"__cerberus_spanKind":      "SPAN_KIND_SERVER",
+				"__cerberus_statusCode":    "STATUS_CODE_OK",
+				"__cerberus_spanAttrsJSON": "{}",
+			},
+			Timestamp: time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC),
+			Value:     100_000_000,
+		}},
+	}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/traces/" + traceIDHex)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	var tr tempo.TraceByIDResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tr); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	trace32 := regexp.MustCompile(`^[0-9a-f]{32}$`)
+	span16 := regexp.MustCompile(`^[0-9a-f]{16}$`)
+	sawSpan := false
+	for _, b := range tr.Batches {
+		for _, sp := range b.Spans {
+			sawSpan = true
+			if !trace32.MatchString(sp.TraceID) {
+				t.Errorf("SpanEntry.TraceID = %q (len=%d), want canonical "+
+					"32-char hex (issue #209)", sp.TraceID, len(sp.TraceID))
+			}
+			if !span16.MatchString(sp.SpanID) {
+				t.Errorf("SpanEntry.SpanID = %q (len=%d), want canonical "+
+					"16-char hex (issue #209)", sp.SpanID, len(sp.SpanID))
+			}
+			// ParentSpanId may legitimately be empty on the wire
+			// (root span via the legacy fixture shape); when
+			// present it must match the canonical 16-char form.
+			if sp.ParentSpanID != "" && !span16.MatchString(sp.ParentSpanID) {
+				t.Errorf("SpanEntry.ParentSpanID = %q (len=%d), want canonical "+
+					"16-char hex (issue #209)", sp.ParentSpanID, len(sp.ParentSpanID))
+			}
+		}
+	}
+	if !sawSpan {
+		t.Fatalf("response carried no spans; cannot exercise hex-shape invariant")
 	}
 }
 

--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -475,29 +475,28 @@ func normaliseTraceID(s string) string {
 	return strings.Repeat("0", 32-len(s)) + strings.ToLower(s)
 }
 
-// stripLeadingHexZeros returns a chplan expression that emits the hex
-// value of `col` with leading zeros removed, matching Tempo's wire
-// format for trace IDs and span IDs. The OTel-CH exporter writes both
-// as fixed-width lowercase-hex strings (32 chars for TraceId, 16 chars
-// for SpanId / ParentSpanId); Tempo's /api/search + /api/traces/{id}
-// shapers trim leading zeros so e.g. `0000…ab` becomes `ab`.
+// stripLeadingHexZeros historically emitted `replaceRegexpOne(col,
+// '^0+([0-9a-f])', '\\1')` to mirror reference Tempo's habit of
+// stripping leading zeros from trace IDs and span IDs on the wire.
+// That behaviour violates the OTel / Tempo spec: a TraceId is a
+// fixed-width 16-byte value and its hex representation MUST be 32
+// lowercase-hex chars; a SpanId is 8 bytes / 16 hex chars. Reference
+// Tempo's own zero-stripping was a long-standing wire-format defect
+// that clients had to work around — cerberus shouldn't propagate it
+// (issue #209).
 //
-// The CH expression `replaceRegexpOne(col, '^0+([0-9a-f])', '\\1')`
-// strips a run of leading zeros but always retains at least one hex
-// digit — so an all-zero TraceId renders as a single `0` rather than
-// collapsing to the empty string, and an already-empty value (root
-// span's ParentSpanId is "" on the wire) round-trips unchanged because
-// the regex doesn't match. Lowercase-only character class matches the
-// OTel-CH `hex.EncodeToString` output verbatim.
+// The function is retained as a passthrough so every existing call
+// site keeps compiling without churn. The OTel-CH exporter writes
+// TraceId / SpanId / ParentSpanId as canonical fixed-width lowercase-
+// hex strings (`hex.EncodeToString`), so returning the bare column
+// ref yields the spec-compliant 32-/16-char form verbatim on the wire.
+//
+// Input parsing on the `/api/traces/{id}` path still accepts both the
+// padded and the leading-zero-stripped form (see normaliseTraceID) so
+// clients that round-trip via legacy reference-Tempo wire payloads
+// continue to resolve.
 func stripLeadingHexZeros(col string) chplan.Expr {
-	return &chplan.FuncCall{
-		Name: "replaceRegexpOne",
-		Args: []chplan.Expr{
-			&chplan.ColumnRef{Name: col},
-			&chplan.LitString{V: "^0+([0-9a-f])"},
-			&chplan.LitString{V: "\\1"},
-		},
-	}
+	return &chplan.ColumnRef{Name: col}
 }
 
 // Reserved keys used by wrapWithSampleProjection to smuggle trace-detail
@@ -1086,16 +1085,16 @@ func toTraceSummaries(samples []chclient.Sample) ([]TraceSummary, []string) {
 		}
 
 		// Resolve root-span metadata. The reserved __cerberus_parentSpanID
-		// slot carries the parent ID; empty (or a single "0") means this
-		// row is the root. The OTel-CH exporter writes ParentSpanId as a
-		// 16-char lowercase-hex string and the canonical/r-qualified
-		// projections route it through stripLeadingHexZeros — the regex
-		// `^0+([0-9a-f])` always retains ≥ 1 hex digit, so an all-zero
-		// ParentSpanId (`0000000000000000`, the on-disk form for a true
-		// root span) collapses to `"0"` rather than `""`. We accept both
-		// the legacy pre-strip empty form (older fixtures / stub
-		// queriers) and the post-strip `"0"` form so the same shaper
-		// works on either projection variant.
+		// slot carries the parent ID; an empty value (`""`), a single
+		// `"0"`, or the full 16-zero hex string (`"0000000000000000"`)
+		// all mean this row is the root span. The OTel-CH exporter
+		// writes ParentSpanId as a 16-char lowercase-hex string; the
+		// canonical/r-qualified projections now surface that column
+		// verbatim (post-#209 fix: no more leading-zero stripping on
+		// the OUTPUT side), so a true root span arrives as the full
+		// 16-char zero hex. The `""` / `"0"` forms are accepted for
+		// back-compat with legacy fixtures, stub queriers, and the
+		// pre-fix stripped projection variant respectively.
 		//
 		// When the slot is missing (older fixtures / stub queriers),
 		// treat every row as a non-root candidate so the fallback path
@@ -1106,7 +1105,7 @@ func toTraceSummaries(samples []chclient.Sample) ([]TraceSummary, []string) {
 		if hasParentSlot {
 			a.sawParentSlot = true
 		}
-		isRoot := hasParentSlot && (parentID == "" || parentID == "0")
+		isRoot := hasParentSlot && (parentID == "" || parentID == "0" || parentID == "0000000000000000")
 		svc := s.Labels["service.name"]
 		switch {
 		case isRoot && (!a.hasRoot || ns < a.rootStartNS):

--- a/internal/api/tempo/handler_test.go
+++ b/internal/api/tempo/handler_test.go
@@ -487,15 +487,19 @@ func TestSearch_RootSpanResolution_TruncatedTrace(t *testing.T) {
 	}
 }
 
-// TestSearch_RootSpanResolution_StrippedZero pins the post-strip root
-// classification: the OTel-CH exporter stores ParentSpanId as a 16-char
-// lowercase-hex string, and the search projection routes it through
-// stripLeadingHexZeros — the regex `^0+([0-9a-f])` always retains ≥ 1
-// hex digit, so an all-zero ParentSpanId (the on-disk form for a true
-// root span) renders as `"0"` rather than `""`. The shaper must treat
-// `"0"` as a root marker; without this, structural-join queries (`>>`,
-// `<<`, `>`, `<`) report a child span's name as rootTraceName because
-// the search projection's per-trace root row is mis-classified.
+// TestSearch_RootSpanResolution_StrippedZero pins root classification
+// for the legacy stripped form of an all-zero ParentSpanId: a single
+// `"0"`. The pre-#209 search projection routed ParentSpanId through
+// `replaceRegexpOne(col, '^0+([0-9a-f])', '\\1')` which collapsed
+// `"0000000000000000"` to `"0"`. The shaper still accepts the `"0"`
+// form for back-compat with the historical projection variant.
+// Without it, structural-join queries (`>>`, `<<`, `>`, `<`) would
+// report a child span's name as rootTraceName because the search
+// projection's per-trace root row would be mis-classified.
+//
+// See TestSearch_RootSpanResolution_FullHexZero for the post-#209
+// canonical form (the full 16-char zero hex the OTel-CH exporter
+// writes and the current passthrough projection surfaces verbatim).
 //
 // Pins the failure-mode behind descendant_op_payments_to_consumer /
 // direct_parent_op_checkout_to_child / set_and_checkout_and_status_error
@@ -557,6 +561,85 @@ func TestSearch_RootSpanResolution_StrippedZero(t *testing.T) {
 	if got.RootServiceName != "payments" {
 		t.Errorf("RootServiceName: got %q, want %q",
 			got.RootServiceName, "payments")
+	}
+}
+
+// TestSearch_RootSpanResolution_FullHexZero pins root classification
+// for the canonical post-#209 wire shape: the OTel-CH exporter writes
+// an all-zero ParentSpanId as the full 16-char zero hex string
+// (`"0000000000000000"`) and the search projection now surfaces that
+// column verbatim (no more `replaceRegexpOne`-driven stripping). The
+// shaper must classify a row whose `__cerberus_parentSpanID` slot
+// holds the 16-char zero hex as a root span; without it the same
+// structural-join regressions covered by the stripped-zero sibling
+// test would resurface on traces that include a true OTel root span.
+//
+// Also pins the spec-side invariant: the TraceID emitted on the wire
+// is the canonical 32-char lowercase-hex form (issue #209), NOT the
+// leading-zero-stripped variant the legacy reference-Tempo wire
+// format used.
+func TestSearch_RootSpanResolution_FullHexZero(t *testing.T) {
+	t.Parallel()
+	const traceID = "00af843259b0a78f5cbe59e11cbaf66b"
+	const rootSpanID = "0000000000000001"
+	const rootParentID = "0000000000000000"
+	q := &stubQuerier{
+		samples: []chclient.Sample{
+			// Child span — parent points at the root span (full 16-char hex).
+			{
+				MetricName: "payments.child.3",
+				Labels: map[string]string{
+					"service.name":            "payments",
+					"__cerberus_traceID":      traceID,
+					"__cerberus_parentSpanID": rootSpanID,
+				},
+				Timestamp: time.Date(2026, 5, 12, 10, 0, 0, 25_000_000, time.UTC),
+				Value:     30_000_000,
+			},
+			// The actual root span — on-disk ParentSpanId is the full
+			// 16-char zero hex. The shaper must accept this as a root
+			// marker.
+			{
+				MetricName: "GET /api/payments/1",
+				Labels: map[string]string{
+					"service.name":            "payments",
+					"__cerberus_traceID":      traceID,
+					"__cerberus_parentSpanID": rootParentID,
+				},
+				Timestamp: time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC),
+				Value:     120_000_000,
+			},
+		},
+	}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/search?q=%7B%20status%20%3D%20error%20%7D")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	var sr tempo.SearchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&sr); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(sr.Traces) != 1 {
+		t.Fatalf("expected 1 trace, got %d", len(sr.Traces))
+	}
+	got := sr.Traces[0]
+	if got.RootTraceName != "GET /api/payments/1" {
+		t.Errorf("RootTraceName: got %q, want %q (full-16-char-zero parent must classify as root)",
+			got.RootTraceName, "GET /api/payments/1")
+	}
+	if got.RootServiceName != "payments" {
+		t.Errorf("RootServiceName: got %q, want %q", got.RootServiceName, "payments")
+	}
+	// Spec assertion (issue #209): the traceID surfaces verbatim as
+	// the canonical 32-char lowercase-hex form, NOT in the legacy
+	// leading-zero-stripped shape (which would be 30 chars here).
+	if got.TraceID != traceID {
+		t.Errorf("TraceID on wire: got %q (len=%d), want %q (len=32, spec-canonical OTel hex)",
+			got.TraceID, len(got.TraceID), traceID)
 	}
 }
 

--- a/internal/api/tempo/root_lookup.go
+++ b/internal/api/tempo/root_lookup.go
@@ -70,9 +70,10 @@ type rootMetadata struct {
 // not just the root row. argMinIf isolates the root-span identity
 // inside the same group so the query stays a single round trip.
 //
-// Result is keyed by the stripped-zero TraceID (the form the original
-// /api/search shaper used). Returns an empty map when traceIDs is
-// empty; never returns nil on success.
+// Result is keyed by the canonical 32-char lowercase-hex TraceID (the
+// form the /api/search shaper surfaces on the wire post-#209; pre-fix,
+// this was the leading-zero-stripped variant). Returns an empty map
+// when traceIDs is empty; never returns nil on success.
 func (h *Handler) resolveTraceRoots(ctx context.Context, traceIDs []string) (map[string]rootMetadata, error) {
 	if len(traceIDs) == 0 {
 		return map[string]rootMetadata{}, nil
@@ -91,9 +92,10 @@ func (h *Handler) resolveTraceRoots(ctx context.Context, traceIDs []string) (map
 
 	out := make(map[string]rootMetadata, len(samples))
 	for _, s := range samples {
-		// The aggregate's Attributes map carries the stripped TraceID
-		// under searchKeyTraceID (`__cerberus_traceID`) and the root
-		// span's service.name under the canonical `service.name` key.
+		// The aggregate's Attributes map carries the canonical 32-char
+		// TraceID under searchKeyTraceID (`__cerberus_traceID`) and the
+		// root span's service.name under the canonical `service.name`
+		// key.
 		tid := s.Labels[searchKeyTraceID]
 		if tid == "" {
 			continue

--- a/internal/api/tempo/traceid_hex_test.go
+++ b/internal/api/tempo/traceid_hex_test.go
@@ -73,12 +73,13 @@ func TestNormaliseTraceID(t *testing.T) {
 	}
 }
 
-// TestStripLeadingHexZeros_RendersExpectedSQL pins the SQL shape emitted
-// by the leading-zero-stripping projection. The actual byte-level
-// stripping is exercised end-to-end by the Tempo compatibility harness
-// (which runs CH); this test guards the chsql contract — the function
-// name + argument shape that CH consumes.
-func TestStripLeadingHexZeros_RendersExpectedSQL(t *testing.T) {
+// TestStripLeadingHexZeros_EmitsBareColumn pins the EMIT-side contract
+// post-#209: `stripLeadingHexZeros` is a passthrough — the SQL must
+// reference the column directly and must NOT wrap it in
+// `replaceRegexpOne` (the legacy zero-stripping shape that violated
+// the OTel / Tempo wire-format spec). Guards against accidental
+// re-introduction of stripping on the response path.
+func TestStripLeadingHexZeros_EmitsBareColumn(t *testing.T) {
 	t.Parallel()
 
 	plan := &chplan.Project{
@@ -92,34 +93,30 @@ func TestStripLeadingHexZeros_RendersExpectedSQL(t *testing.T) {
 	if err != nil {
 		t.Fatalf("emit: %v", err)
 	}
-	if !strings.Contains(sql, "replaceRegexpOne(`TraceId`,") {
-		t.Errorf("SQL missing replaceRegexpOne(`TraceId`, ...) call; got:\n%s", sql)
+	if strings.Contains(sql, "replaceRegexpOne") {
+		t.Errorf("SQL must not call replaceRegexpOne on trace-id columns "+
+			"(spec violation — issue #209); got:\n%s", sql)
 	}
-	// The two regex literals ride positional args; we don't pin their
-	// indices because the emitter may re-order, but they must be present.
-	wantLit := []string{"^0+([0-9a-f])", `\1`}
-	for _, want := range wantLit {
-		found := false
+	if !strings.Contains(sql, "`TraceId`") {
+		t.Errorf("SQL must reference TraceId column directly; got:\n%s", sql)
+	}
+	// The historical zero-strip regex literals must NOT bind as args.
+	for _, lit := range []string{"^0+([0-9a-f])", `\1`} {
 		for _, a := range args {
-			if s, ok := a.(string); ok && s == want {
-				found = true
-				break
+			if s, ok := a.(string); ok && s == lit {
+				t.Errorf("unexpected zero-strip regex literal %q in bound args %v", lit, args)
 			}
-		}
-		if !found {
-			t.Errorf("expected arg %q not in %v", want, args)
 		}
 	}
 }
 
-// TestCanonicalSampleProjections_StripsTraceIDLeadingZeros verifies the
-// /api/search projection routes TraceId through stripLeadingHexZeros so
-// the wire format matches Tempo's leading-zero-stripped shape. Without
-// this strip the canonical-key differ pairs the two backends'
-// summaries by mismatched keys (cerberus `00af…66b` vs Tempo
-// `af…66b`), generating spurious missing_in_a / missing_in_b reasons
-// per case.
-func TestCanonicalSampleProjections_StripsTraceIDLeadingZeros(t *testing.T) {
+// TestCanonicalSampleProjections_PreservesFullTraceID pins the EMIT
+// side of the /api/search projection: TraceId and ParentSpanId must
+// flow into the canonical Sample envelope WITHOUT being wrapped in
+// `replaceRegexpOne` (issue #209). The OTel-CH exporter already
+// writes the canonical 32-/16-char lowercase-hex form, so the wire
+// response must surface that exact form.
+func TestCanonicalSampleProjections_PreservesFullTraceID(t *testing.T) {
 	t.Parallel()
 
 	s := schema.DefaultOTelTraces()
@@ -133,25 +130,30 @@ func TestCanonicalSampleProjections_StripsTraceIDLeadingZeros(t *testing.T) {
 	if err != nil {
 		t.Fatalf("emit: %v", err)
 	}
-	if !strings.Contains(sql, "replaceRegexpOne(`"+s.TraceIDColumn+"`,") {
-		t.Errorf("canonical search projection must wrap TraceId in replaceRegexpOne; got:\n%s", sql)
+	if strings.Contains(sql, "replaceRegexpOne(`"+s.TraceIDColumn+"`,") {
+		t.Errorf("canonical search projection must NOT wrap %s in "+
+			"replaceRegexpOne (spec violation — issue #209); got:\n%s",
+			s.TraceIDColumn, sql)
+	}
+	if strings.Contains(sql, "replaceRegexpOne(`"+s.ParentSpanIDColumn+"`,") {
+		t.Errorf("canonical search projection must NOT wrap %s in "+
+			"replaceRegexpOne (spec violation — issue #209); got:\n%s",
+			s.ParentSpanIDColumn, sql)
+	}
+	if !strings.Contains(sql, "`"+s.TraceIDColumn+"`") {
+		t.Errorf("canonical search projection must reference %s directly; got:\n%s",
+			s.TraceIDColumn, sql)
 	}
 }
 
-// TestSpansetAggregateSampleProjections_StripsTraceIDLeadingZeros pins
-// the wrap-projection used for `{ ... } | count() > 0`,
-// `| avg(duration) > 0`, and the other per-trace spanset aggregates
-// (see internal/traceql/aggregate.go). The inner Aggregate's
-// `GroupBy: [TraceId]` exposes the raw 32-char zero-padded hex from
-// the OTel-CH column; the outer wrap projection must route it
-// through stripLeadingHexZeros so the `__cerberus_traceID` reserved
-// label arrives at the compat differ in Tempo's leading-zero-stripped
-// form. Without this strip the differ pairs cerberus rows (e.g.
-// `00af843259b0a78f5cbe59e11cbaf66b`) against Tempo
-// (`af843259b0a78f5cbe59e11cbaf66b`) by mismatched keys, generating
-// spurious missing_in_a / missing_in_b reasons across the
-// spanset-aggregate compat cases.
-func TestSpansetAggregateSampleProjections_StripsTraceIDLeadingZeros(t *testing.T) {
+// TestSpansetAggregateSampleProjections_PreservesFullTraceID pins the
+// wrap-projection used for per-trace spanset aggregates (`{ ... } |
+// count() > 0`, `| avg(duration) > 0`, etc; see
+// internal/traceql/aggregate.go). The TraceId column the inner
+// Aggregate exposes must reach the `__cerberus_traceID` reserved-
+// label slot verbatim — no `replaceRegexpOne` wrapping — so the
+// canonical 32-char form survives to the wire (issue #209).
+func TestSpansetAggregateSampleProjections_PreservesFullTraceID(t *testing.T) {
 	t.Parallel()
 
 	projs := spansetAggregateSampleProjections()
@@ -164,15 +166,21 @@ func TestSpansetAggregateSampleProjections_StripsTraceIDLeadingZeros(t *testing.
 	if err != nil {
 		t.Fatalf("emit: %v", err)
 	}
-	if !strings.Contains(sql, "replaceRegexpOne(`TraceId`,") {
-		t.Errorf("spanset-aggregate projection must wrap TraceId in replaceRegexpOne; got:\n%s", sql)
+	if strings.Contains(sql, "replaceRegexpOne(`TraceId`,") {
+		t.Errorf("spanset-aggregate projection must NOT wrap TraceId in "+
+			"replaceRegexpOne (spec violation — issue #209); got:\n%s", sql)
+	}
+	if !strings.Contains(sql, "`TraceId`") {
+		t.Errorf("spanset-aggregate projection must reference TraceId directly; got:\n%s", sql)
 	}
 }
 
-// TestTraceByIDProjections_StripsAllIDColumns covers the
+// TestTraceByIDProjections_PreservesFullIDColumns covers the
 // /api/traces/{id} response path. TraceId, SpanId, and ParentSpanId
-// all need the leading-zero strip to match Tempo's response shape.
-func TestTraceByIDProjections_StripsAllIDColumns(t *testing.T) {
+// must all flow through the projection WITHOUT leading-zero stripping
+// so the wire payload conforms to the OTel / Tempo canonical hex
+// shapes (issue #209).
+func TestTraceByIDProjections_PreservesFullIDColumns(t *testing.T) {
 	t.Parallel()
 
 	s := schema.DefaultOTelTraces()
@@ -187,9 +195,14 @@ func TestTraceByIDProjections_StripsAllIDColumns(t *testing.T) {
 		t.Fatalf("emit: %v", err)
 	}
 	for _, col := range []string{s.TraceIDColumn, s.SpanIDColumn, s.ParentSpanIDColumn} {
-		needle := "replaceRegexpOne(`" + col + "`,"
-		if !strings.Contains(sql, needle) {
-			t.Errorf("trace-by-id projection must wrap %s in replaceRegexpOne; SQL:\n%s", col, sql)
+		bad := "replaceRegexpOne(`" + col + "`,"
+		if strings.Contains(sql, bad) {
+			t.Errorf("trace-by-id projection must NOT wrap %s in "+
+				"replaceRegexpOne (spec violation — issue #209); SQL:\n%s", col, sql)
+		}
+		direct := "`" + col + "`"
+		if !strings.Contains(sql, direct) {
+			t.Errorf("trace-by-id projection must reference %s directly; SQL:\n%s", col, sql)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Closes #209. Cerberus's Tempo `/api/search` (and `/api/traces/{id}`) handlers inherited reference Tempo's wire-format defect of stripping leading zeros from trace IDs and span IDs, emitting e.g. `841a72c308fcebcec8f656c362d0e9d` (31 chars) instead of the canonical `0841a72c308fcebcec8f656c362d0e9d`. The OTel / Tempo spec requires fixed-width IDs: 16-byte TraceId → 32 lowercase-hex chars, 8-byte SpanId → 16 hex chars.

The fix turns `stripLeadingHexZeros(col)` (the CH-side `replaceRegexpOne(col, '^0+([0-9a-f])', '\\1')` shim) into a passthrough that surfaces the OTel-CH column verbatim. Every projection call site (`canonicalSampleProjections`, `rQualifiedSampleProjections`, `traceByIDProjections`, `spansetAggregateSampleProjections`, the root-lookup wrap) picks the change up without further churn. Root-span detection in `toTraceSummaries` extends to accept the canonical 16-char zero hex (`'0000000000000000'`) alongside the legacy `''` / `'0'` forms so structural-join / status-filter result sets don't lose root classification.

The INPUT side stays permissive: cerberus keeps accepting both the canonical 32-char form and the legacy leading-zero-stripped form on `/api/traces/{id}` (PR #93 / #104 contract).

### Emit sites fixed

- `internal/api/tempo/handler.go`
  - `stripLeadingHexZeros` → passthrough (`&chplan.ColumnRef{Name: col}`).
  - `canonicalSampleProjections` (`TraceId`, `ParentSpanId`).
  - `rQualifiedSampleProjections` (`TraceId`, `ParentSpanId`).
  - `traceByIDProjections` (`TraceId`, `SpanId`, `ParentSpanId`).
  - `spansetAggregateSampleProjections` (`TraceId`).
  - `toTraceSummaries` — root marker now accepts `''` / `'0'` / `'0000000000000000'`.
- `internal/api/tempo/root_lookup.go` — `stripLeadingHexZeros("TraceId")` in the canonical Sample envelope picks up the passthrough automatically. The proto-encoder path (PR #650 `handler_trace_proto.go`) uses raw byte arrays via `hexToBytesPadded`, which already restores 16-/8-byte width from any input length, so it stays spec-compliant for free.

## Test plan

- [x] Unit (`internal/api/tempo/traceid_hex_test.go`) — flipped four projection assertions: SQL must reference the bare column and must NOT call `replaceRegexpOne`. Guards against any future reintroduction of the spec-violating strip.
- [x] Unit (`TestSearch_RootSpanResolution_FullHexZero`) — new sibling to the existing `TestSearch_RootSpanResolution_StrippedZero`. Drives a true root span whose ParentSpanId is the full 16-char zero hex (the post-fix wire shape) and asserts the row classifies as root + the trace's wire TraceID is the canonical 32-char form.
- [x] Conformance (`TestConformance_TempoSearchWire`) — property-style assertion that every hex-shaped traceID in `/api/search` responses matches `^[0-9a-f]{32}$`. New `leading_zero_trace_ids_padded` sub-case seeds IDs that start with `00…` so stripping would trip the regex.
- [x] Conformance (`TestConformance_TempoTraceByIDWire_HexShape`) — same property-style guard on `/api/traces/{id}`: TraceID is 32 hex chars, SpanID and (non-empty) ParentSpanID are 16 hex chars. Seeds leading-zero IDs.
- [x] Input contract — `TestNormaliseTraceID` and `TestLowerTraceByID_AcceptsBothPaddedAndStrippedForms` left intact: cerberus keeps accepting the legacy stripped form on the way IN.
- [x] `go test -race ./internal/api/tempo/...` — all 307 tests green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)