### PR TITLE
fix(api/prom,loki): normalise OTel-dotted label keys to Prom/Loki grammar on the wire

### DIFF
--- a/internal/api/format/otelname.go
+++ b/internal/api/format/otelname.go
@@ -1,0 +1,247 @@
+package format
+
+import "sort"
+
+// OTelToPromLabel returns s rewritten so it satisfies the Prometheus
+// label-name grammar `[a-zA-Z_][a-zA-Z0-9_]*`.
+//
+// Rationale: cerberus stores OTel telemetry verbatim in ClickHouse —
+// the per-row Attributes map (Prom metrics) and ResourceAttributes map
+// (Loki logs) carry OTel semantic-convention keys like
+// `service.name`, `http.request.method`, `network.protocol.version`.
+// PromQL's grammar forbids `.` in identifiers, so a `sum by (service.name)`
+// panel against cerberus's `/labels` output would silently fail to
+// reference any of these keys. Reference Prometheus solves this on the
+// receive side (the OTLP-to-Prom translator normalises before storing);
+// cerberus translates on the wire-emit side instead so the CH-resident
+// data stays OTel-shaped while the wire envelope stays Prom-shaped.
+//
+// Translation rules (per the OTel-Prometheus interop spec for labels):
+//
+//  1. Every byte outside `[A-Za-z0-9_]` is replaced with `_`. The Prom
+//     label grammar also allows `:` for metric names but NOT for label
+//     names — labels are stricter than metric names.
+//  2. If the result starts with a digit, a single leading `_` is
+//     prepended (`1invalid` → `_1invalid`).
+//  3. Empty input returns empty (callers strip empty results separately).
+//
+// Examples:
+//
+//	service.name           → service_name
+//	http.request.method    → http_request_method
+//	network.protocol.name  → network_protocol_name
+//	with-dash              → with_dash
+//	1invalid               → _1invalid
+//	already_ok             → already_ok
+//	服务名                  → ___ (multibyte runes are byte-replaced)
+//
+// The function operates on bytes (not runes) because Prom's grammar is
+// ASCII-only: any multibyte UTF-8 sequence is by definition outside
+// `[A-Za-z0-9_]` and must be replaced. Byte-level replacement gives one
+// `_` per byte of the multibyte rune, which matches the OTel-Prom
+// interop spec wording.
+func OTelToPromLabel(s string) string {
+	if s == "" {
+		return ""
+	}
+	if isPromLabelName(s) {
+		return s
+	}
+	b := make([]byte, 0, len(s)+1)
+	if s[0] >= '0' && s[0] <= '9' {
+		b = append(b, '_')
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'a' && c <= 'z',
+			c >= 'A' && c <= 'Z',
+			c >= '0' && c <= '9',
+			c == '_':
+			b = append(b, c)
+		default:
+			b = append(b, '_')
+		}
+	}
+	return string(b)
+}
+
+// OTelToPromMetric returns s rewritten so it satisfies the Prometheus
+// metric-name grammar `[a-zA-Z_:][a-zA-Z0-9_:]*` — the same rule as
+// labels except `:` is allowed. Used for `__name__` projection and
+// `/api/v1/metadata` metric keys.
+//
+// Semantics match OTelToPromLabel except that `:` passes through
+// untouched. OTel's own metric-name conventions don't currently use
+// `:` (Prom recording rules do), so this is mostly belt-and-braces for
+// pre-existing colon-shaped names that flow through cerberus.
+func OTelToPromMetric(s string) string {
+	if s == "" {
+		return ""
+	}
+	if isPromMetricName(s) {
+		return s
+	}
+	b := make([]byte, 0, len(s)+1)
+	if s[0] >= '0' && s[0] <= '9' {
+		b = append(b, '_')
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'a' && c <= 'z',
+			c >= 'A' && c <= 'Z',
+			c >= '0' && c <= '9',
+			c == '_', c == ':':
+			b = append(b, c)
+		default:
+			b = append(b, '_')
+		}
+	}
+	return string(b)
+}
+
+// isPromLabelName reports whether s already matches the Prom label-name
+// grammar `[a-zA-Z_][a-zA-Z0-9_]*`. Fast-path so already-normalised
+// keys pass through without allocation. The `__name__` synthetic label
+// matches naturally (double underscores are valid).
+func isPromLabelName(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'a' && c <= 'z':
+		case c >= 'A' && c <= 'Z':
+		case c == '_':
+		case c >= '0' && c <= '9' && i > 0:
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// isPromMetricName reports whether s already matches the Prom metric-name
+// grammar `[a-zA-Z_:][a-zA-Z0-9_:]*` (the same as label except `:` is
+// allowed).
+func isPromMetricName(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'a' && c <= 'z':
+		case c >= 'A' && c <= 'Z':
+		case c == '_', c == ':':
+		case c >= '0' && c <= '9' && i > 0:
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// NormalizeLabelMap rewrites the keys of `in` through OTelToPromLabel
+// and returns a fresh map. Values pass through unchanged (Prom values
+// are arbitrary strings — only identifiers go through the grammar).
+//
+// Collision policy (per the task brief): when two source keys normalise
+// to the same target — e.g. both `service.name` and `service_name` are
+// present — the ALREADY-NORMALISED form wins. The dotted OTel form is
+// the "telemetry alias" and the underscored form is the user's intended
+// Prom-style identifier; surfacing only the underscored form keeps
+// Grafana panels written against `{service_name="x"}` working without
+// double-counting the same series.
+//
+// Implementation: iterate keys in sorted order so the result is
+// deterministic regardless of Go's map iteration ordering. For each
+// source key K we compute its normalised form N. If N != K (K needed
+// rewriting) AND the input already contains N, we drop K — the natural
+// form is the authoritative value. Otherwise the (normalised key →
+// value) entry lands in the output. Among colliding rewrites where
+// neither side is naturally-shaped (`a.b` and `a-b` both → `a_b`), the
+// sorted-iteration order picks the lexically-first source — stable but
+// arbitrary; the brief tolerates last-write-wins for this edge case.
+//
+// A nil / empty input returns nil so downstream consumers retain the
+// `len(m) == 0` shortcut without an allocation.
+func NormalizeLabelMap(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return in
+	}
+	keys := make([]string, 0, len(in))
+	for k := range in {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	out := make(map[string]string, len(in))
+	for _, k := range keys {
+		n := OTelToPromLabel(k)
+		if n == "" {
+			continue
+		}
+		if n != k {
+			// k needed rewriting. If the natural form is already in the
+			// input, drop k entirely (policy C: underscored form wins).
+			if _, ok := in[n]; ok {
+				continue
+			}
+		}
+		// First writer wins for non-natural collisions. n == k means
+		// `out[n]` was previously unset (sorted iteration visits each
+		// natural key exactly once); the `_, exists` guard covers the
+		// `a.b` + `a-b` shape so the later one doesn't clobber the
+		// earlier.
+		if _, exists := out[n]; exists {
+			continue
+		}
+		out[n] = in[k]
+	}
+	return out
+}
+
+// NormalizeLabelNames returns a sorted, de-duplicated slice of label
+// names with each entry passed through OTelToPromLabel. Collisions
+// follow the same policy as NormalizeLabelMap: a naturally-shaped
+// entry wins over a rewrite that would land on it.
+//
+// Used by the /labels endpoints in both prom + loki, which return a
+// flat string slice rather than a label map. nil / empty input returns
+// nil so the JSON envelope's `null`-vs-`[]` distinction is left to the
+// caller.
+func NormalizeLabelNames(in []string) []string {
+	if len(in) == 0 {
+		return in
+	}
+	natural := make(map[string]struct{}, len(in))
+	for _, s := range in {
+		if isPromLabelName(s) {
+			natural[s] = struct{}{}
+		}
+	}
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		n := OTelToPromLabel(s)
+		if n == "" {
+			continue
+		}
+		if n != s {
+			if _, ok := natural[n]; ok {
+				// rewrite would collide with an already-natural form;
+				// drop this one.
+				continue
+			}
+		}
+		if _, ok := seen[n]; ok {
+			continue
+		}
+		seen[n] = struct{}{}
+		out = append(out, n)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/api/format/otelname_test.go
+++ b/internal/api/format/otelname_test.go
@@ -1,0 +1,244 @@
+package format_test
+
+import (
+	"reflect"
+	"regexp"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/api/format"
+)
+
+var (
+	promLabelRE  = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+	promMetricRE = regexp.MustCompile(`^[a-zA-Z_:][a-zA-Z0-9_:]*$`)
+)
+
+func TestOTelToPromLabel(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"already_ok", "already_ok"},
+		{"__name__", "__name__"},
+		{"service.name", "service_name"},
+		{"http.request.method", "http_request_method"},
+		{"network.protocol.version", "network_protocol_version"},
+		{"http.response.status_code", "http_response_status_code"},
+		{"with-dash", "with_dash"},
+		{"with space", "with_space"},
+		{"1invalid", "_1invalid"},
+		{"9", "_9"},
+		// `:` is allowed in metric names but NOT in label names.
+		{"a:b", "a_b"},
+		// multibyte: each byte becomes an underscore.
+		{"服务", "______"},
+		// trailing / leading dots collapse to underscores deterministically.
+		{".lead", "_lead"},
+		{"trail.", "trail_"},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			got := format.OTelToPromLabel(c.in)
+			if got != c.want {
+				t.Fatalf("OTelToPromLabel(%q) = %q, want %q", c.in, got, c.want)
+			}
+			// Every non-empty output must satisfy Prom's label grammar.
+			if got != "" && !promLabelRE.MatchString(got) {
+				t.Fatalf("OTelToPromLabel(%q) = %q does not match Prom label grammar", c.in, got)
+			}
+		})
+	}
+}
+
+func TestOTelToPromMetric(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"http_requests_total", "http_requests_total"},
+		{"my:metric", "my:metric"},
+		{"http.requests.total", "http_requests_total"},
+		{"1up", "_1up"},
+		{"with-dash", "with_dash"},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			got := format.OTelToPromMetric(c.in)
+			if got != c.want {
+				t.Fatalf("OTelToPromMetric(%q) = %q, want %q", c.in, got, c.want)
+			}
+			if got != "" && !promMetricRE.MatchString(got) {
+				t.Fatalf("OTelToPromMetric(%q) = %q does not match Prom metric grammar", c.in, got)
+			}
+		})
+	}
+}
+
+func TestNormalizeLabelMap(t *testing.T) {
+	tests := []struct {
+		name string
+		in   map[string]string
+		want map[string]string
+	}{
+		{"nil", nil, nil},
+		{"empty", map[string]string{}, map[string]string{}},
+		{
+			"passthrough",
+			map[string]string{"job": "api", "instance": "x"},
+			map[string]string{"job": "api", "instance": "x"},
+		},
+		{
+			"rewrite-dot",
+			map[string]string{"service.name": "tempo"},
+			map[string]string{"service_name": "tempo"},
+		},
+		{
+			"collision-underscore-wins",
+			// Both forms present — only the underscored form survives,
+			// carrying its own value (NOT the dotted one).
+			map[string]string{"service.name": "tempo", "service_name": "loki"},
+			map[string]string{"service_name": "loki"},
+		},
+		{
+			"mixed-shape",
+			map[string]string{
+				"service.name":         "tempo",
+				"http.request.method":  "GET",
+				"already_ok":           "1",
+				"http.response.status": "200",
+			},
+			map[string]string{
+				"service_name":         "tempo",
+				"http_request_method":  "GET",
+				"already_ok":           "1",
+				"http_response_status": "200",
+			},
+		},
+		{
+			"leading-digit",
+			map[string]string{"1abc": "v"},
+			map[string]string{"_1abc": "v"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := format.NormalizeLabelMap(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("NormalizeLabelMap(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+			for k := range got {
+				if !promLabelRE.MatchString(k) {
+					t.Fatalf("output key %q does not match Prom label grammar", k)
+				}
+			}
+		})
+	}
+}
+
+func TestNormalizeLabelMapDoesNotMutateInput(t *testing.T) {
+	in := map[string]string{"service.name": "x", "ok": "y"}
+	_ = format.NormalizeLabelMap(in)
+	if _, ok := in["service.name"]; !ok {
+		t.Fatalf("input was mutated: %v", in)
+	}
+}
+
+func TestNormalizeLabelNames(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"nil", nil, nil},
+		{
+			"basic",
+			[]string{"service.name", "http.request.method", "job"},
+			[]string{"http_request_method", "job", "service_name"},
+		},
+		{
+			"collision-natural-wins",
+			[]string{"service.name", "service_name", "job"},
+			[]string{"job", "service_name"},
+		},
+		{
+			"dedup",
+			[]string{"service.name", "service.name"},
+			[]string{"service_name"},
+		},
+		{
+			"empty-skipped",
+			[]string{"", "service.name"},
+			[]string{"service_name"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := format.NormalizeLabelNames(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("NormalizeLabelNames(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+			for _, k := range got {
+				if !promLabelRE.MatchString(k) {
+					t.Fatalf("output entry %q does not match Prom label grammar", k)
+				}
+			}
+		})
+	}
+}
+
+// TestNormalizeLabelNamesNoStrayBytes is a property-shape test pinning
+// the conformance contract: every output of NormalizeLabelNames matches
+// `^[a-zA-Z_][a-zA-Z0-9_]*$`. Catches future regressions where a new
+// edge case sneaks through (e.g. someone allowing `:` in label names).
+func TestNormalizeLabelNamesNoStrayBytes(t *testing.T) {
+	in := []string{
+		"__name__",
+		"cerberus.ql",
+		"cerberus.route",
+		"http.request.method",
+		"http.response.status_code",
+		"http.route",
+		"http_status",
+		"job",
+		"network.protocol.name",
+		"network.protocol.version",
+		"result",
+		"server.address",
+		"server.port",
+		"stage",
+		"url.scheme",
+	}
+	got := format.NormalizeLabelNames(in)
+	for _, k := range got {
+		if !promLabelRE.MatchString(k) {
+			t.Fatalf("output %q has stray bytes", k)
+		}
+	}
+	// Verify the specific keys from the bug repro come out clean.
+	expected := map[string]bool{
+		"__name__":                  true,
+		"cerberus_ql":               true,
+		"cerberus_route":            true,
+		"http_request_method":       true,
+		"http_response_status_code": true,
+		"http_route":                true,
+		"http_status":               true,
+		"job":                       true,
+		"network_protocol_name":     true,
+		"network_protocol_version":  true,
+		"result":                    true,
+		"server_address":            true,
+		"server_port":               true,
+		"stage":                     true,
+		"url_scheme":                true,
+	}
+	for _, k := range got {
+		if !expected[k] {
+			t.Fatalf("unexpected output key %q", k)
+		}
+		delete(expected, k)
+	}
+	if len(expected) > 0 {
+		t.Fatalf("missing expected keys: %v", expected)
+	}
+}

--- a/internal/api/format/otelname_test.go
+++ b/internal/api/format/otelname_test.go
@@ -166,7 +166,7 @@ func TestNormalizeLabelNames(t *testing.T) {
 			[]string{"service_name"},
 		},
 		{
-			"empty-skipped",
+			"empty-dropped",
 			[]string{"", "service.name"},
 			[]string{"service_name"},
 		},

--- a/internal/api/loki/conformance_test.go
+++ b/internal/api/loki/conformance_test.go
@@ -1090,3 +1090,85 @@ func TestConformance_LokiLogcliNanosTimestamps(t *testing.T) {
 		t.Fatalf("status=%d body=%s (ns branch regression)", resp.StatusCode, body)
 	}
 }
+
+// TestConformance_LokiLabelsGrammar pins the wire-emit OTel→Loki label
+// normalisation: every key returned by /loki/api/v1/labels matches the
+// Prom/Loki label-name grammar `[a-zA-Z_][a-zA-Z0-9_]*`. Loki stores
+// OTel-original dotted keys in `ResourceAttributes` for stream-selector
+// matching; the wire envelope rewrites them so Grafana panels keying
+// off `service_name` / `k8s_pod_name` don't have to second-guess
+// whether the underlying column is dotted or underscored.
+//
+// Collision policy: when both `service.name` and `service_name` exist,
+// the natural underscored form wins (the dotted form is the OTel
+// telemetry alias).
+func TestConformance_LokiLabelsGrammar(t *testing.T) {
+	t.Parallel()
+
+	rows := []string{
+		"deployment.environment",
+		"service.instance.id",
+		"service.name",
+		"service.version",
+		"service_name", // sibling — wins on collision
+		"k8s.pod.name",
+		"k8s_pod_name", // sibling — wins on collision
+		"detected_level",
+	}
+	srv := newServer(&stubQuerier{stringRows: rows})
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/loki/api/v1/labels?start=1717995600&end=1717999200")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	var env struct {
+		Status string   `json:"status"`
+		Data   []string `json:"data"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil {
+		t.Fatalf("decode: %v body=%s", err, body)
+	}
+
+	for _, k := range env.Data {
+		for i := 0; i < len(k); i++ {
+			c := k[i]
+			switch {
+			case c >= 'a' && c <= 'z':
+			case c >= 'A' && c <= 'Z':
+			case c == '_':
+			case c >= '0' && c <= '9' && i > 0:
+			default:
+				t.Errorf("key %q has stray byte at offset %d (0x%02x); full data=%v",
+					k, i, c, env.Data)
+			}
+		}
+	}
+
+	seen := map[string]struct{}{}
+	for _, k := range env.Data {
+		seen[k] = struct{}{}
+	}
+	for _, dotted := range []string{
+		"deployment.environment", "service.instance.id",
+		"service.name", "service.version", "k8s.pod.name",
+	} {
+		if _, ok := seen[dotted]; ok {
+			t.Errorf("dotted key %q must be normalised away; got data=%v", dotted, env.Data)
+		}
+	}
+	for _, want := range []string{
+		"deployment_environment", "service_instance_id",
+		"service_name", "service_version", "k8s_pod_name",
+		"detected_level",
+	} {
+		if _, ok := seen[want]; !ok {
+			t.Errorf("expected normalised key %q in result; got %v", want, env.Data)
+		}
+	}
+}

--- a/internal/api/loki/detected_labels.go
+++ b/internal/api/loki/detected_labels.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/prometheus/prometheus/model/labels"
 
+	"github.com/tsouza/cerberus/internal/api/format"
 	"github.com/tsouza/cerberus/internal/chsql"
 	"github.com/tsouza/cerberus/internal/logql"
 	"github.com/tsouza/cerberus/internal/schema"
@@ -128,9 +129,11 @@ func buildDetectedLabelsSQL(s schema.Logs, matchers []*labels.Matcher, start, en
 func summariseDetectedLabels(rows []map[string]string) []DetectedLabel {
 	values := map[string]map[string]struct{}{}
 	for _, m := range rows {
-		// Mirror /series: drop the OTel-dotted siblings so the result
-		// envelope matches the normalised Loki form Grafana expects.
-		m = dropOTelDottedLabels(m)
+		// Mirror /series: normalise OTel-dotted keys to the Prom/Loki
+		// grammar so the result envelope matches the wire form Grafana
+		// expects (and so collision policy collapses dotted+underscored
+		// siblings to a single bucket).
+		m = format.NormalizeLabelMap(m)
 		for k, v := range m {
 			if v == "" {
 				continue

--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -493,7 +493,7 @@ func toVector(samples []chclient.Sample, ts time.Time) []VectorSample {
 	stamp := float64(ts.UnixMilli()) / 1e3
 	for _, l := range bySeries {
 		out = append(out, VectorSample{
-			Metric: dropOTelDottedLabels(l.labels),
+			Metric: format.NormalizeLabelMap(l.labels),
 			Value:  [2]any{stamp, strconv.FormatFloat(l.value, 'f', -1, 64)},
 		})
 	}
@@ -547,7 +547,7 @@ func toMatrixStepGrid(samples []chclient.Sample, start, end time.Time, _ time.Du
 
 	out := make([]MatrixSample, 0, len(bySeries))
 	for _, st := range bySeries {
-		ms := MatrixSample{Metric: dropOTelDottedLabels(st.labels)}
+		ms := MatrixSample{Metric: format.NormalizeLabelMap(st.labels)}
 		for _, r := range st.rows {
 			if r.Timestamp.Before(start) || r.Timestamp.After(end) {
 				continue
@@ -604,52 +604,13 @@ func toStreamsWithTransform(samples []chclient.Sample, tx lineTransform) []Strea
 	out := make([]Stream, 0, len(bySeries))
 	for _, a := range bySeries {
 		sort.Slice(a.values, func(i, j int) bool { return a.values[i][0] < a.values[j][0] })
-		out = append(out, Stream{Stream: dropOTelDottedLabels(a.labels), Values: a.values})
-	}
-	return out
-}
-
-// dropOTelDottedLabels returns a copy of in with the OTel-form dotted
-// label keys removed. Loki only surfaces the normalised underscore
-// form (`service_name`, `k8s_pod_name`, …) in Stream response
-// envelopes — even though the underlying ingest pipeline retains the
-// dotted form on `ResourceAttributes` for stream-selector matching.
-// Cerberus reads ResourceAttributes verbatim, so without this filter
-// the wire-format envelope is a superset of Loki's: differential
-// harnesses see `actual=map[... service.name:tempo service_name:tempo]`
-// against Loki's `map[... service_name:tempo]` and reject the row.
-//
-// The filter drops any key K satisfying BOTH:
-//
-//  1. K contains a `.` (OTel-form heuristic), AND
-//  2. The map already contains the `.` → `_` replacement (the
-//     normalised sibling). The companion sibling is the canonical
-//     value the receiver promtail-shim writes for stream-selector
-//     compatibility (PR #525) — when both forms are present, the
-//     dotted form is the redundant one.
-//
-// Returns a fresh map so callers can treat the input as immutable
-// (the wider response shape contracts assume per-sample label
-// allocations don't alias across rows). Drops nothing on empty /
-// nil input — same shape goes through.
-//
-// Only the OUTPUT label envelope is filtered: the WHERE-clause
-// label-matching path runs against the raw ResourceAttributes map at
-// the SQL layer, so dotted-form selectors (`{service.name="x"}`)
-// keep matching. The filter sits strictly in the response-shaper.
-func dropOTelDottedLabels(in map[string]string) map[string]string {
-	if len(in) == 0 {
-		return in
-	}
-	out := make(map[string]string, len(in))
-	for k, v := range in {
-		if strings.ContainsRune(k, '.') {
-			sibling := strings.ReplaceAll(k, ".", "_")
-			if _, ok := in[sibling]; ok {
-				continue
-			}
-		}
-		out[k] = v
+		// NormalizeLabelMap rewrites every OTel-dotted key to Loki's
+		// (and Prom's) `[a-zA-Z_][a-zA-Z0-9_]*` grammar; the
+		// already-underscored sibling wins on collisions. The
+		// WHERE-clause matching path stays bound to raw ResourceAttributes
+		// at the SQL layer so dotted-form selectors (`{service.name="x"}`)
+		// keep matching.
+		out = append(out, Stream{Stream: format.NormalizeLabelMap(a.labels), Values: a.values})
 	}
 	return out
 }

--- a/internal/api/loki/handler_test.go
+++ b/internal/api/loki/handler_test.go
@@ -371,18 +371,18 @@ func containsArg(args []any, want string) bool {
 	return false
 }
 
-// TestQuery_Streams_DropsOTelDottedLabels — when the CH row carries
-// both the OTel-form `service.name` AND the Loki-form `service_name`
-// (the canonical wire-format key), the Stream envelope cerberus
-// returns must only surface the normalised underscore form. Without
-// the filter the response is a superset of what reference Loki emits,
-// and the loki-compat differential harness rejects the row with
-// `streams[0] labels differ: ... actual=map[... service.name:tempo
-// service_name:tempo]`. The seeder in PR #525 intentionally writes
-// both forms into ResourceAttributes so dotted-form stream-selectors
-// continue to match at the WHERE layer; only the OUTPUT envelope
-// needs to drop the redundant sibling.
-func TestQuery_Streams_DropsOTelDottedLabels(t *testing.T) {
+// TestQuery_Streams_NormalisesOTelDottedLabels — every dotted OTel
+// key on the OUTPUT envelope is rewritten to the Prom/Loki-grammar
+// underscored form. When both `service.name` and `service_name` are
+// present (the seeder in PR #525 writes both into ResourceAttributes
+// so dotted-form stream-selectors keep matching at the WHERE layer),
+// the underscored form wins on collision per the NormalizeLabelMap
+// policy. A solo dotted key with no underscored sibling — e.g.
+// `orphan.key` — is normalised to `orphan_key` rather than left as
+// `orphan.key`; the older behaviour of preserving solo dotted keys
+// was the proximate cause of every `sum by (orphan_key)` panel
+// silently returning empty because PromQL grammar forbids `.`.
+func TestQuery_Streams_NormalisesOTelDottedLabels(t *testing.T) {
 	t.Parallel()
 
 	ts := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
@@ -396,10 +396,8 @@ func TestQuery_Streams_DropsOTelDottedLabels(t *testing.T) {
 					"k8s.pod.name":   "pod-0",
 					"k8s_pod_name":   "pod-0",
 					"detected_level": "info",
-					// Dotted key with NO underscore sibling — must pass through
-					// (the only signal that a sibling exists in the map is the
-					// underscore form, so without it we can't tell whether the
-					// dot is OTel-form or a legitimately dotted name).
+					// Dotted key with NO underscore sibling — now normalised
+					// to `orphan_key` so it's actually selectable from PromQL.
 					"orphan.key": "value",
 				},
 				Timestamp: ts,
@@ -435,13 +433,13 @@ func TestQuery_Streams_DropsOTelDottedLabels(t *testing.T) {
 	}
 	got := streams[0].Stream
 	if _, ok := got["service.name"]; ok {
-		t.Errorf("expected service.name to be DROPPED from output (sibling service_name present); got %v", got)
+		t.Errorf("expected service.name to be NORMALISED out (sibling service_name wins); got %v", got)
 	}
 	if got["service_name"] != "tempo" {
 		t.Errorf("expected service_name=tempo to be PRESERVED; got %v", got)
 	}
 	if _, ok := got["k8s.pod.name"]; ok {
-		t.Errorf("expected k8s.pod.name to be DROPPED (sibling k8s_pod_name present); got %v", got)
+		t.Errorf("expected k8s.pod.name to be NORMALISED out (sibling k8s_pod_name wins); got %v", got)
 	}
 	if got["k8s_pod_name"] != "pod-0" {
 		t.Errorf("expected k8s_pod_name=pod-0 to be PRESERVED; got %v", got)
@@ -449,8 +447,25 @@ func TestQuery_Streams_DropsOTelDottedLabels(t *testing.T) {
 	if got["detected_level"] != "info" {
 		t.Errorf("expected detected_level=info to be PRESERVED (non-dotted key); got %v", got)
 	}
-	if got["orphan.key"] != "value" {
-		t.Errorf("expected orphan.key=value to be PRESERVED (no underscore sibling); got %v", got)
+	if _, ok := got["orphan.key"]; ok {
+		t.Errorf("expected orphan.key to be NORMALISED to orphan_key; got %v", got)
+	}
+	if got["orphan_key"] != "value" {
+		t.Errorf("expected orphan_key=value (normalised from orphan.key); got %v", got)
+	}
+	// Every output key must satisfy Prom/Loki label grammar.
+	for k := range got {
+		for i := 0; i < len(k); i++ {
+			c := k[i]
+			switch {
+			case c >= 'a' && c <= 'z':
+			case c >= 'A' && c <= 'Z':
+			case c == '_':
+			case c >= '0' && c <= '9' && i > 0:
+			default:
+				t.Errorf("output key %q has invalid char at offset %d", k, i)
+			}
+		}
 	}
 }
 

--- a/internal/api/loki/index_volume.go
+++ b/internal/api/loki/index_volume.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/prometheus/prometheus/model/labels"
 
+	"github.com/tsouza/cerberus/internal/api/format"
 	"github.com/tsouza/cerberus/internal/chsql"
 	"github.com/tsouza/cerberus/internal/logql"
 	"github.com/tsouza/cerberus/internal/schema"
@@ -79,7 +80,7 @@ func (h *Handler) handleIndexVolume(w http.ResponseWriter, r *http.Request) {
 	result := make([]VectorSample, 0, len(rows))
 	for _, row := range rows {
 		result = append(result, VectorSample{
-			Metric: dropOTelDottedLabels(row.Labels),
+			Metric: format.NormalizeLabelMap(row.Labels),
 			Value:  [2]any{stamp, strconv.FormatUint(row.Bytes, 10)},
 		})
 	}

--- a/internal/api/loki/labels.go
+++ b/internal/api/loki/labels.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/prometheus/prometheus/model/labels"
 
+	"github.com/tsouza/cerberus/internal/api/format"
 	"github.com/tsouza/cerberus/internal/chsql"
 	"github.com/tsouza/cerberus/internal/logql"
 	"github.com/tsouza/cerberus/internal/schema"
@@ -54,9 +55,12 @@ func (h *Handler) handleLabels(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Defensive: drop empties + ensure stable ordering for Grafana's
-	// dropdowns. Loki itself returns the list sorted.
-	out := dedupeAndSort(vals)
+	// Pass through Prom/Loki-grammar normalisation so OTel-dotted keys
+	// (`service.name`, `k8s.pod.name`) surface as their underscored
+	// form on the wire — Grafana's label autocomplete cannot parse `.`
+	// in a label identifier position. dedupeAndSort still runs as a
+	// belt-and-braces order/empty guard.
+	out := dedupeAndSort(format.NormalizeLabelNames(vals))
 
 	writeJSON(w, http.StatusOK, Response{
 		Status: "success",

--- a/internal/api/loki/labels_test.go
+++ b/internal/api/loki/labels_test.go
@@ -37,7 +37,9 @@ func TestLabels_HappyPath(t *testing.T) {
 	if out.Status != "success" {
 		t.Fatalf("status=%q", out.Status)
 	}
-	want := []string{"instance", "job", "service.name"}
+	// `service.name` is rewritten to `service_name` by the wire-emit
+	// normalisation (PromQL/Loki grammar forbids `.` in identifiers).
+	want := []string{"instance", "job", "service_name"}
 	if len(out.Data) != len(want) {
 		t.Fatalf("data=%v want=%v", out.Data, want)
 	}

--- a/internal/api/loki/series.go
+++ b/internal/api/loki/series.go
@@ -141,17 +141,16 @@ func orJoinedFrag(fragments []chsql.Frag) chsql.Frag {
 // guarantees uniqueness at the row level but the Map iteration order on
 // the Go side is non-deterministic, so we re-sort here.
 //
-// Each row is also passed through dropOTelDottedLabels so the wire
-// envelope matches Loki's normalised-form output rather than carrying
-// both OTel- and Loki-form siblings (see the helper doc for the
-// rationale). Filtering before dedupe is important: two rows that
-// differ only by a redundant `.`-form key would otherwise dedupe to
-// two entries when Loki sees one.
+// Each row is passed through `format.NormalizeLabelMap` so OTel-dotted
+// keys (`service.name`, `k8s.pod.name`) surface as their underscored
+// Loki/Prom-grammar form. Normalising before dedupe is important: two
+// rows that differ only by a dotted-vs-underscored alias collapse to
+// one entry, matching Loki's wire envelope.
 func dedupeLabelSets(in []map[string]string) []map[string]string {
 	seen := make(map[string]struct{}, len(in))
 	out := make([]map[string]string, 0, len(in))
 	for _, m := range in {
-		m = dropOTelDottedLabels(m)
+		m = format.NormalizeLabelMap(m)
 		if len(m) == 0 {
 			continue
 		}

--- a/internal/api/prom/conformance_test.go
+++ b/internal/api/prom/conformance_test.go
@@ -1432,3 +1432,155 @@ func TestConformance_DottedMetricNames(t *testing.T) {
 		})
 	}
 }
+
+// TestConformance_LabelsGrammar pins the wire-emit OTel→Prom label
+// normalisation: every key returned by /api/v1/labels MUST match the
+// Prometheus label-name grammar `[a-zA-Z_][a-zA-Z0-9_]*`. The raw
+// `Attributes` map in ClickHouse carries OTel-original dotted keys
+// (`service.name`, `http.request.method`, `cerberus.ql`, ...);
+// without normalisation, every Grafana panel doing `sum by (cerberus_ql)`
+// silently broke because PromQL grammar forbids `.` in identifiers.
+// This test feeds the handler a mix of dotted and underscored keys and
+// asserts the wire envelope projects only the Prom-grammar form.
+//
+// Collision policy (per the task brief): when both `service.name` and
+// `service_name` exist with different contents, the underscored form
+// wins — the dotted form is the OTel telemetry alias and the
+// underscored form is the user's intended Prom-style identifier.
+func TestConformance_LabelsGrammar(t *testing.T) {
+	t.Parallel()
+
+	// Mix every shape the bug repro saw plus a natural-form collision
+	// pair.
+	rows := []string{
+		"cerberus.ql",
+		"cerberus.route",
+		"http.request.method",
+		"http.response.status_code",
+		"http.route",
+		"http_status",
+		"job",
+		"network.protocol.name",
+		"network.protocol.version",
+		"result",
+		"server.address",
+		"server.port",
+		"stage",
+		"url.scheme",
+		// Collision: both forms present. Natural wins.
+		"service.name",
+		"service_name",
+	}
+	srv := newServer(&stubQuerier{strings: rows})
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/labels")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	var env struct {
+		Status string   `json:"status"`
+		Data   []string `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(body), &env); err != nil {
+		t.Fatalf("decode: %v body=%s", err, body)
+	}
+	if env.Status != "success" {
+		t.Fatalf("status=%q", env.Status)
+	}
+
+	// Pin 1: every emitted key matches Prom label grammar — zero
+	// characters outside `[a-zA-Z0-9_]`.
+	for _, k := range env.Data {
+		for i := 0; i < len(k); i++ {
+			c := k[i]
+			switch {
+			case c >= 'a' && c <= 'z':
+			case c >= 'A' && c <= 'Z':
+			case c == '_':
+			case c >= '0' && c <= '9' && i > 0:
+			default:
+				t.Errorf("key %q has stray byte at offset %d (0x%02x); full data=%v",
+					k, i, c, env.Data)
+			}
+		}
+	}
+
+	// Pin 2: collision policy — `service.name` was rewritten away,
+	// only `service_name` survives.
+	seen := map[string]struct{}{}
+	for _, k := range env.Data {
+		seen[k] = struct{}{}
+	}
+	if _, ok := seen["service.name"]; ok {
+		t.Errorf("expected `service.name` to be normalised away; got %v", env.Data)
+	}
+	if _, ok := seen["service_name"]; !ok {
+		t.Errorf("expected `service_name` to survive normalisation; got %v", env.Data)
+	}
+
+	// Pin 3: spot-check that the headline keys from the bug repro
+	// surface in their underscored form.
+	for _, want := range []string{
+		"cerberus_ql", "http_request_method",
+		"http_response_status_code", "url_scheme",
+	} {
+		if _, ok := seen[want]; !ok {
+			t.Errorf("expected normalised key %q in result; got %v", want, env.Data)
+		}
+	}
+}
+
+// TestConformance_LabelValuesGrammar pins the /api/v1/label/__name__/values
+// path: metric-name values must satisfy Prom's metric-name grammar
+// `[a-zA-Z_:][a-zA-Z0-9_:]*`. OTel may store dotted metric names
+// (`http.server.duration`) that PromQL's selector position can't
+// reference directly without `normalizeDottedSelectors` wrapping —
+// surfacing the normalised form on the wire keeps Grafana's metric
+// picker honest.
+func TestConformance_LabelValuesGrammar(t *testing.T) {
+	t.Parallel()
+
+	rows := []string{
+		"http.server.duration",
+		"http.server.request.duration",
+		"already_ok",
+		"with:colon", // colons are valid for metric names
+	}
+	srv := newServer(&stubQuerier{strings: rows})
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/label/__name__/values")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	var env struct {
+		Status string   `json:"status"`
+		Data   []string `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(body), &env); err != nil {
+		t.Fatalf("decode: %v body=%s", err, body)
+	}
+	for _, v := range env.Data {
+		for i := 0; i < len(v); i++ {
+			c := v[i]
+			switch {
+			case c >= 'a' && c <= 'z':
+			case c >= 'A' && c <= 'Z':
+			case c == '_', c == ':':
+			case c >= '0' && c <= '9' && i > 0:
+			default:
+				t.Errorf("metric value %q has stray byte at offset %d (0x%02x); full data=%v",
+					v, i, c, env.Data)
+			}
+		}
+	}
+}

--- a/internal/api/prom/exemplars.go
+++ b/internal/api/prom/exemplars.go
@@ -317,10 +317,14 @@ func groupExemplars(rows []chclient.ExemplarRow, metricName string) []ExemplarSe
 		seriesLabels := format.WithMetricName(r.Attributes, name)
 		if r.ServiceName != "" {
 			// The dedicated LowCardinality column is the OTel exporter's
-			// reserved place for service.name; surface it under the same
-			// canonical wire label PromQL clients expect.
+			// reserved place for service.name. Stamp it under the OTel
+			// key first, then let NormalizeLabelMap collapse it to the
+			// Prom-grammar `service_name` form — that way an Attributes
+			// entry under the same key (or its underscored sibling) is
+			// honoured by the collision-policy in one place.
 			seriesLabels["service.name"] = r.ServiceName
 		}
+		seriesLabels = format.NormalizeLabelMap(seriesLabels)
 		key := format.CanonicalKey(seriesLabels)
 		b, ok := bySeries[key]
 		if !ok {
@@ -363,8 +367,12 @@ func projectExemplar(r chclient.ExemplarRow) Exemplar {
 	if r.SpanID != "" {
 		out["span_id"] = r.SpanID
 	}
+	// Per-exemplar label keys obey the same Prom grammar — Grafana's
+	// exemplar overlay parses them as label identifiers when rendering
+	// the trace-link tooltip. Dotted OTel keys (`http.target`,
+	// `code.namespace`) surface as `http_target` / `code_namespace`.
 	return Exemplar{
-		Labels:    out,
+		Labels:    format.NormalizeLabelMap(out),
 		Value:     r.Value,
 		Timestamp: timestampSeconds(r.Timestamp),
 	}

--- a/internal/api/prom/exemplars_chdb_test.go
+++ b/internal/api/prom/exemplars_chdb_test.go
@@ -227,14 +227,21 @@ INSERT INTO otel_metrics_sum (
 		}
 	}
 
-	// Per-series assertions: each series MUST carry __name__ + service.name
-	// + job, and exactly three exemplars (the seeded fan-out).
+	// Per-series assertions: each series MUST carry __name__ + service_name
+	// + job, and exactly three exemplars (the seeded fan-out). The
+	// dotted OTel `service.name` collapses to the Prom-grammar
+	// `service_name` form via format.NormalizeLabelMap at the emit site
+	// in groupExemplars — the wire shape Grafana's overlay expects.
 	for job, series := range byJob {
 		if got := series.SeriesLabels["__name__"]; got != "http_requests_total" {
 			t.Errorf("job=%s: __name__=%q want http_requests_total", job, got)
 		}
-		if got := series.SeriesLabels["service.name"]; got != "checkout" {
-			t.Errorf("job=%s: service.name=%q want checkout", job, got)
+		if got := series.SeriesLabels["service_name"]; got != "checkout" {
+			t.Errorf("job=%s: service_name=%q want checkout", job, got)
+		}
+		if _, leaked := series.SeriesLabels["service.name"]; leaked {
+			t.Errorf("job=%s: dotted service.name leaked through normalisation: %+v",
+				job, series.SeriesLabels)
 		}
 		if got := series.SeriesLabels["job"]; got != job {
 			t.Errorf("job=%s: SeriesLabels[job]=%q (inconsistent index)", job, got)

--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -674,7 +674,7 @@ func toVector(samples []chclient.Sample, ts time.Time) []VectorSample {
 
 	bySeries := map[string]latest{}
 	for _, s := range samples {
-		labels := format.WithMetricName(s.Labels, s.MetricName)
+		labels := format.NormalizeLabelMap(format.WithMetricName(s.Labels, s.MetricName))
 		key := format.CanonicalKey(labels)
 		cur, ok := bySeries[key]
 		if !ok || s.Timestamp.After(cur.ts) {
@@ -734,7 +734,7 @@ func matrixFromCursor(
 	bySeries := map[string]*seriesState{}
 	for cursor.Next() {
 		s := cursor.Sample()
-		labels := format.WithMetricName(s.Labels, s.MetricName)
+		labels := format.NormalizeLabelMap(format.WithMetricName(s.Labels, s.MetricName))
 		key := format.CanonicalKey(labels)
 		st, ok := bySeries[key]
 		if !ok {

--- a/internal/api/prom/metadata.go
+++ b/internal/api/prom/metadata.go
@@ -159,10 +159,14 @@ func (h *Handler) handleMetadata(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Group by metric name; each metric gets a slice of entries.
+	// Group by metric name; each metric gets a slice of entries. Names
+	// pass through Prom's metric-name grammar (`OTelToPromMetric`) so
+	// OTel-dotted metric names (`http.server.duration`) surface as the
+	// underscored form expected by `/api/v1/label/__name__/values`.
 	grouped := make(map[string][]MetricMetaEntry, len(rows))
 	for _, row := range rows {
-		grouped[row.Name] = append(grouped[row.Name], MetricMetaEntry{
+		name := format.OTelToPromMetric(row.Name)
+		grouped[name] = append(grouped[name], MetricMetaEntry{
 			Type: row.Type,
 			Help: row.Description,
 			Unit: row.Unit,
@@ -307,7 +311,11 @@ func (h *Handler) handleSeries(w http.ResponseWriter, r *http.Request) {
 }
 
 // fetchLabelNames unions the Attributes-map keys across the metric tables
-// and prepends `__name__`. The returned slice is sorted.
+// and prepends `__name__`. The returned slice is sorted + normalised to
+// Prom's `[a-zA-Z_][a-zA-Z0-9_]*` label-name grammar — OTel telemetry
+// stores dotted keys (`service.name`, `http.request.method`) that PromQL
+// grammar forbids in identifier position; without the rewrite, panels
+// doing `sum by (service_name)` silently produce empty matrices.
 func (h *Handler) fetchLabelNames(ctx context.Context) ([]string, error) {
 	sql := h.unionLabelNamesSQL()
 	names, err := timeCH(ctx, func() ([]string, error) {
@@ -316,7 +324,7 @@ func (h *Handler) fetchLabelNames(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusBadGateway}
 	}
-	out := append([]string{model.MetricNameLabel}, names...)
+	out := format.NormalizeLabelNames(append([]string{model.MetricNameLabel}, names...))
 	sort.Strings(out)
 	return out, nil
 }
@@ -330,6 +338,11 @@ func (h *Handler) fetchLabelValues(ctx context.Context, name string) ([]string, 
 		if err != nil {
 			return nil, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusBadGateway}
 		}
+		// Metric-name values pass through Prom's metric-name grammar
+		// (`[a-zA-Z_:][a-zA-Z0-9_:]*`); OTel may store dotted forms
+		// (`http.server.duration`) that the PromQL selector position
+		// can't reference directly.
+		values = normalizeMetricValues(values)
 		sort.Strings(values)
 		return values, nil
 	}
@@ -346,22 +359,19 @@ func (h *Handler) fetchLabelValues(ctx context.Context, name string) ([]string, 
 
 // fetchLabelNamesMatched returns the distinct label names of series
 // matching any of the given match[] selectors. The synthetic `__name__`
-// is always included if at least one selector matches anything.
+// is always included if at least one selector matches anything. Names
+// pass through Prom-grammar normalisation before dedupe; see
+// `format.NormalizeLabelNames` for the collision policy.
 func (h *Handler) fetchLabelNamesMatched(ctx context.Context, matchers []string) ([]string, error) {
-	seen := map[string]bool{model.MetricNameLabel: true}
+	collected := []string{model.MetricNameLabel}
 	for _, m := range matchers {
 		keys, err := h.labelKeysForMatcher(ctx, m)
 		if err != nil {
 			return nil, err
 		}
-		for _, k := range keys {
-			seen[k] = true
-		}
+		collected = append(collected, keys...)
 	}
-	out := make([]string, 0, len(seen))
-	for k := range seen {
-		out = append(out, k)
-	}
+	out := format.NormalizeLabelNames(collected)
 	sort.Strings(out)
 	return out, nil
 }
@@ -489,7 +499,7 @@ func (h *Handler) fetchSeries(ctx context.Context, matcher string) ([]map[string
 
 	seen := make(map[string]map[string]string)
 	for _, s := range samples {
-		labels := format.WithMetricName(s.Labels, s.MetricName)
+		labels := format.NormalizeLabelMap(format.WithMetricName(s.Labels, s.MetricName))
 		key := format.CanonicalKey(labels)
 		if _, ok := seen[key]; !ok {
 			seen[key] = labels
@@ -621,6 +631,41 @@ func mapAtNotEmptyFrag(col, key string) chsql.Frag {
 // (and chsql.PreRenderedSQL).
 func matcherSubqueryFrag(sql string, args []any) chsql.Frag {
 	return chsql.Subquery(chsql.PreRenderedSQL{SQL: sql, Args: args})
+}
+
+// normalizeMetricValues runs each candidate through OTelToPromMetric
+// (Prom's metric-name grammar) and de-dupes the result. Collision
+// policy: a naturally-shaped entry wins over a rewrite that would
+// land on the same target. Used on `/api/v1/label/__name__/values`.
+func normalizeMetricValues(in []string) []string {
+	if len(in) == 0 {
+		return in
+	}
+	natural := make(map[string]struct{}, len(in))
+	for _, s := range in {
+		if s != "" && s == format.OTelToPromMetric(s) {
+			natural[s] = struct{}{}
+		}
+	}
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		n := format.OTelToPromMetric(s)
+		if n == "" {
+			continue
+		}
+		if n != s {
+			if _, ok := natural[n]; ok {
+				continue
+			}
+		}
+		if _, ok := seen[n]; ok {
+			continue
+		}
+		seen[n] = struct{}{}
+		out = append(out, n)
+	}
+	return out
 }
 
 // validLabelName mirrors the Prometheus label-name grammar: [a-zA-Z_][a-zA-Z0-9_]*.


### PR DESCRIPTION
## Summary

Cerberus stored OTel-original `Attributes` / `ResourceAttributes`
verbatim and emitted them verbatim on every Prom + Loki metadata /
data response. PromQL + LogQL grammar forbids `.` in identifiers, so
every Grafana panel doing `sum by (cerberus_ql)` silently returned
empty because `cerberus_ql` doesn't exist — the on-wire label was
`cerberus.ql`, which can't be referenced from PromQL.

Repro before the fix:

```text
$ curl -s http://localhost:8080/api/v1/labels | jq .data
[ "__name__", "cerberus.ql", "cerberus.route",
  "http.request.method", "http.response.status_code", "http.route",
  "http_status", "job", "network.protocol.name",
  "network.protocol.version", "result", "server.address",
  "server.port", "stage", "url.scheme" ]
```

Loki returned the same shape on `/loki/api/v1/labels`, with both
`service.name` and `service_name` coexisting (the latter is the
canonical wire-form key the seeder writes alongside).

## Fix

New package surface: `internal/api/format/otelname.go` adds
`OTelToPromLabel`, `OTelToPromMetric`, `NormalizeLabelMap`,
`NormalizeLabelNames`. Applied at every wire-emit site:

### Prom (`internal/api/prom/`)

- `handler.go::toVector`, `matrixFromCursor` — per-sample labels
- `metadata.go::fetchSeries` — series label sets
- `metadata.go::fetchLabelNames`, `fetchLabelNamesMatched` — `/labels`
- `metadata.go::fetchLabelValues` (`__name__` branch) — metric-name
  values on `/label/__name__/values`
- `metadata.go::handleMetadata` — metric-name keys on `/metadata`
- `exemplars.go::groupExemplars`, `projectExemplar` — exemplar
  series labels + per-exemplar attribute keys

### Loki (`internal/api/loki/`)

- `handler.go::toStreamsWithTransform` — `Stream` envelope
- `handler.go::toMatrixStepGrid` — matrix-shape `Metric` envelope
- `series.go::dedupeLabelSets` — `/series`
- `labels.go::handleLabels` — `/labels`
- `detected_labels.go::summariseDetectedLabels` — `/detected_labels`
- `index_volume.go` — `/index/volume`

Replaces the old Loki-only `dropOTelDottedLabels`, which only dropped
dotted keys when an underscored sibling existed — leaving solo dotted
keys like `orphan.key` unaddressable from PromQL/LogQL.

## Collision policy

When BOTH `service.name` and `service_name` exist with different
contents (the bug repro saw this on Loki), the **natural underscored
form wins**. The dotted form is the OTel telemetry alias; the
underscored form is the user's intended Prom-style identifier. Picking
the natural form keeps Grafana panels written against
`{service_name="x"}` working without double-counting the same series.

The brief listed three options (A/B/C) and recommended (C) — this PR
implements (C).

## Storage layer is untouched

Only the wire envelope normalises. The `Attributes` /
`ResourceAttributes` map in CH still carries the OTel-original dotted
keys, so dotted-form stream selectors (`{service.name="x"}`) keep
matching at the WHERE layer via the existing `MapAccess` lookup —
verified by `TestQuery_Streams_OTelFilterDoesNotAffectSelector` (kept
intact).

## Caveat: matcher-side reverse lookup is NOT included

The brief notes:

> the schema-aware label-matcher path in
> `internal/promql/lower.go::buildPredicate` already maps
> `cerberus_ql` (the underscored query) to `Attributes['cerberus.ql']`
> (the dotted CH-key) — verify this still works after the EMIT-side
> normalisation lands.

It does NOT already map — `matcherToExpr` uses `m.Name` verbatim
against `Attributes[<m.Name>]`. Adding the reverse mapping touches
the lowering hot path and ~50+ TXTAR fixtures; out of scope here.
Filed as a follow-up: this PR fixes the WIRE-side visibility (the
brief's reported "every Grafana panel is silently broken" symptom on
`/labels`), and the immediately-typed-back-in PromQL identifier
remains a known gap until the matcher rewrite lands.

## Tests

- **Unit** (`internal/api/format/otelname_test.go`): table-driven
  cases for `OTelToPromLabel` / `OTelToPromMetric` / `NormalizeLabelMap`
  / `NormalizeLabelNames` pinning the grammar + collision policy.
- **Conformance** (`internal/api/{prom,loki}/conformance_test.go`):
  `TestConformance_LabelsGrammar` and `TestConformance_LabelValuesGrammar`
  in prom; `TestConformance_LokiLabelsGrammar` in loki. Each pins zero
  stray-byte outputs from `/labels` + spot-checks the bug repro's
  exact key list (`cerberus.ql`, `http.request.method`, ...).
- **Handler** (`internal/api/loki/handler_test.go`): renamed
  `TestQuery_Streams_DropsOTelDottedLabels` →
  `TestQuery_Streams_NormalisesOTelDottedLabels` to reflect the new
  semantics; the orphan-key case now asserts `orphan_key` rather than
  `orphan.key`.

`go test ./... = 3823 passed`.

## Test plan

- [x] `go test ./internal/api/format/... ./internal/api/prom/... ./internal/api/loki/...`
- [x] `go build ./...`
- [x] `go vet ./internal/api/...`
- [ ] CI lanes: check, lint, forbid-skip, compatibility/prometheus,
      compatibility/loki, probe, roundtrip (promql/logql), compose-smoke
- [ ] manual repro: hit `/api/v1/labels` against the compose stack
      and assert no key contains `.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)