### PR TITLE
chore(lint): drop .claude/worktrees/ from golangci-lint discovery

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -128,6 +128,15 @@ linters:
     lll:
       line-length: 280
   exclusions:
+    # Drop sibling agent worktrees from discovery. Lefthook pre-push runs
+    # `golangci-lint run ./...` from the active worktree root; without this
+    # exclusion any file under `.claude/worktrees/<other-agent>/...` (a
+    # parallel worktree's tree) gets reachable via explicit path / IDE
+    # integration and surfaces lint findings unrelated to the committer's
+    # change. The pattern is anchored on the literal segment so it matches
+    # both `.claude/worktrees/agent-…/…` and any nested re-entry.
+    paths:
+      - \.claude/worktrees
     rules:
       - path: _test\.go
         linters:


### PR DESCRIPTION
## Summary

- Lefthook pre-push runs `golangci-lint run ./...` from the active worktree root. When parallel agent worktrees exist under `.claude/worktrees/agent-*/`, files inside those siblings get discovered by golangci-lint (via explicit-path / IDE integration) and surface lint findings unrelated to the committer's actual diff.
- Adds `\.claude/worktrees` to `linters.exclusions.paths` (golangci-lint v2 schema) so those sibling trees are dropped from the analyzer's input.

The exact stanza added under `linters.exclusions`:

```yaml
paths:
  - \.claude/worktrees
```

## Test plan

- [x] Reproduced pre-fix: dropped `.claude/worktrees/test-broken/foo.go` with two `ineffassign` violations, ran `golangci-lint run ./.claude/worktrees/test-broken/...` → reports 2 issues.
- [x] Applied fix, re-ran same command → `0 issues.`
- [x] `golangci-lint config verify` accepts the v2 schema with `linters.exclusions.paths` populated.
- [x] `golangci-lint run ./...` from the worktree root still emits `0 issues.` (no regression on real code paths).
- [x] `golangci-lint run ./... 2>&1 | grep -c "\.claude/worktrees"` → `0` post-fix.

Config-only change; no production code touched, no new tests required (test layer per task is the local repro above).