### PR TITLE
chore(lefthook): add commitlint pre-push backstop for --no-verify bypasses

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -86,6 +86,17 @@ pre-push:
           echo "lefthook: \"not implemented\" in production code — implement the feature or rewrite to a factual verb (rejected / unsupported / falls back)"
           exit 1
         fi
+    # Backstop for the `commit-msg` hook: that hook validates each
+    # commit at creation time, but `git commit --no-verify` bypasses
+    # it. This range-check mirrors the CI `lint` job's
+    # `wagoid/commitlint-github-action@v6` step (which reads the same
+    # `.commitlintrc.json`) so a push with a non-Conventional subject
+    # — or any other rule violation — fails locally before CI runs.
+    commitlint-range:
+      tags: lint
+      run: |
+        base=$(git merge-base HEAD origin/main 2>/dev/null || echo origin/main)
+        npx --no -- commitlint --from "$base" --to HEAD
     forbid-soft-assert:
       tags: discipline
       run: |


### PR DESCRIPTION
## Summary

The `commit-msg` hook in `lefthook.yml` validates each commit subject at creation time via `commitlint --edit`, but `git commit --no-verify` bypasses it entirely. CI's `lint` job catches the violation eventually (`wagoid/commitlint-github-action@v6` reads the same `.commitlintrc.json`), but only after the round-trip — there was no local backstop between bypassed `commit-msg` and the CI runner.

This PR adds a `commitlint-range` command to `pre-push`. It computes the merge-base against `origin/main` and lints every commit in the range, so any subject that escaped the per-commit gate gets caught before the push hits the network.

The stanza mirrors the existing `commit-msg` invocation (`npx --no -- commitlint`) so both gates use the same locally-resolvable CLI + the same `.commitlintrc.json` config that CI's `wagoid/commitlint-github-action@v6` step honours — a comment in the file pins the alignment so future config changes stay in sync across both halves.

Refs: #204

## Stanza added

```yaml
commitlint-range:
  tags: lint
  run: |
    base=$(git merge-base HEAD origin/main 2>/dev/null || echo origin/main)
    npx --no -- commitlint --from "$base" --to HEAD
```

## Verification transcript

1. Branched off `origin/main`, landed the lefthook edit as commit `a02ed54` (subject passes commit-msg cleanly).
2. Added a deliberately bad empty commit, bypassing `commit-msg`:

   ```sh
   git commit --allow-empty --no-verify \
     -m "this subject has no conventional commit type prefix and should fail"
   ```

3. Ran `lefthook run pre-push`. The new gate fired:

   ```text
   ┃  commitlint-range ❯ 
   ⧗   --- input ---
   this subject has no conventional commit type prefix and should fail
   ✖   subject may not be empty [subject-empty]
   ✖   type may not be empty   [type-empty]
   ✖   found 2 problems, 0 warnings
   exit status 1
   🥊 commitlint-range (0.81 seconds)
   ```

4. `git reset --hard` back to the clean fix commit, re-ran `lefthook run pre-push`:

   ```text
   ┃  commitlint-range ❯ 
   ✔️ commitlint-range (1.33 seconds)
   ```

   All other pre-push commands (`golangci-lint`, `markdownlint`, the four `forbid-*` discipline greps) continue to pass.

## Test plan

- [x] Bad commit pushed with `--no-verify` is rejected by `pre-push` (transcript above).
- [x] Clean branch passes `pre-push` (transcript above).
- [ ] CI `lint` job still runs `wagoid/commitlint-github-action@v6` (unchanged) — confirms the comment's alignment claim stays accurate on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)