### PR TITLE
fix(api/tempo): reject malformed trace ids with 400 before the engine lookup (#211)

### DIFF
--- a/internal/api/tempo/chaos_test.go
+++ b/internal/api/tempo/chaos_test.go
@@ -79,7 +79,7 @@ func TestTempoCH_TraceByID_UpstreamError_Returns502(t *testing.T) {
 	srv := newServer(q, "v1.0.0-test")
 	t.Cleanup(srv.Close)
 
-	resp, err := http.Get(srv.URL + "/api/traces/abc123")
+	resp, err := http.Get(srv.URL + "/api/traces/0123456789abcdef")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}

--- a/internal/api/tempo/conformance_test.go
+++ b/internal/api/tempo/conformance_test.go
@@ -484,8 +484,8 @@ func TestConformance_TempoTraceByIDWire(t *testing.T) {
 		name string
 		path string
 	}{
-		{name: "v1", path: "/api/traces/abc123"},
-		{name: "v2", path: "/api/v2/traces/abc123"},
+		{name: "v1", path: "/api/traces/0123456789abcdef"},
+		{name: "v2", path: "/api/v2/traces/0123456789abcdef"},
 	}
 
 	t.Run("found", func(t *testing.T) {
@@ -554,8 +554,8 @@ func TestConformance_TempoTraceByIDWire(t *testing.T) {
 				if err := json.NewDecoder(resp.Body).Decode(&er); err != nil {
 					t.Fatalf("decode: %v", err)
 				}
-				if er.TraceID != "abc123" || !er.Error {
-					t.Errorf("envelope: got %+v, want traceID=abc123, error=true", er)
+				if er.TraceID != "0123456789abcdef" || !er.Error {
+					t.Errorf("envelope: got %+v, want traceID=0123456789abcdef, error=true", er)
 				}
 			})
 		}
@@ -666,12 +666,12 @@ func TestConformance_TempoErrorEnvelope(t *testing.T) {
 		{
 			name: "502_trace_by_id_ch_failure",
 			stub: &stubQuerier{err: errors.New("ch failure")},
-			path: "/api/traces/abc123", wantCode: http.StatusBadGateway,
+			path: "/api/traces/0123456789abcdef", wantCode: http.StatusBadGateway,
 		},
 		{
 			name: "404_trace_not_found",
 			stub: &stubQuerier{samples: nil},
-			path: "/api/traces/abc123", wantCode: http.StatusNotFound,
+			path: "/api/traces/0123456789abcdef", wantCode: http.StatusNotFound,
 		},
 		// v2 URL mirrors the v1 route — Grafana 11.x's Tempo plugin
 		// defaults to `tempoApiVersion >= v2`, so error envelopes must
@@ -679,12 +679,12 @@ func TestConformance_TempoErrorEnvelope(t *testing.T) {
 		{
 			name: "502_trace_by_id_v2_ch_failure",
 			stub: &stubQuerier{err: errors.New("ch failure")},
-			path: "/api/v2/traces/abc123", wantCode: http.StatusBadGateway,
+			path: "/api/v2/traces/0123456789abcdef", wantCode: http.StatusBadGateway,
 		},
 		{
 			name: "404_trace_not_found_v2",
 			stub: &stubQuerier{samples: nil},
-			path: "/api/v2/traces/abc123", wantCode: http.StatusNotFound,
+			path: "/api/v2/traces/0123456789abcdef", wantCode: http.StatusNotFound,
 		},
 	}
 	for _, c := range cases {
@@ -803,8 +803,11 @@ func TestConformance_TempoStartEndMatrix(t *testing.T) {
 // --- Section E: trace-id edge cases -------------------------------------
 
 // TestConformance_TempoTraceIDEdge — special characters in the trace
-// path segment are passed to CH safely (parameterised) — no panic, no
-// SQL injection. We expect 404 (no rows match) but no crash.
+// path segment are rejected up-front by the 16-/32-hex grammar gate
+// with 400 ("invalid trace id"), matching reference Tempo. The gate
+// runs before any CH lookup, so SQL injection / panic / crash paths
+// are unreachable from these inputs — covered by inspection of the
+// handler, this test pins the wire-format response.
 func TestConformance_TempoTraceIDEdge(t *testing.T) {
 	t.Parallel()
 
@@ -824,9 +827,9 @@ func TestConformance_TempoTraceIDEdge(t *testing.T) {
 				t.Fatalf("GET: %v", err)
 			}
 			defer resp.Body.Close()
-			if resp.StatusCode != http.StatusNotFound {
+			if resp.StatusCode != http.StatusBadRequest {
 				body, _ := io.ReadAll(resp.Body)
-				t.Errorf("status: got %d, want 404; body=%s", resp.StatusCode, body)
+				t.Errorf("status: got %d, want 400; body=%s", resp.StatusCode, body)
 			}
 		})
 	}

--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -364,6 +364,19 @@ func (h *Handler) handleTraceByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Reference Tempo's `/api/traces/{id}` rejects malformed IDs with
+	// 400 (`invalid trace id`) before any storage lookup: only 16-char
+	// (span-id-sized, retained for compatibility with older clients) or
+	// 32-char hex strings are valid trace IDs. Without this gate, a
+	// `curl /api/traces/ZZZZ` would surface as 404 ("trace not found")
+	// and Grafana's Tempo plugin would render the wrong UX. Lower-case
+	// up front so mixed-case input matches `^[0-9a-f]{16,32}$`.
+	traceID = strings.ToLower(traceID)
+	if !isValidTraceID(traceID) {
+		writeError(w, http.StatusBadRequest, "", "", fmt.Errorf("invalid trace id"))
+		return
+	}
+
 	// Build the lowered query: { traceID = "<id>" }.
 	plan, err := h.lowerTraceByID(traceID)
 	if err != nil {
@@ -1282,6 +1295,29 @@ func writeTraceProto(w http.ResponseWriter, status int, t *tempopb.Trace) {
 	w.Header().Set("Content-Type", "application/protobuf")
 	w.WriteHeader(status)
 	_, _ = w.Write(b)
+}
+
+// isValidTraceID mirrors reference Tempo's trace-id grammar on the
+// `/api/traces/{id}` (v1 + v2) wire: a lowercase hex string of length
+// 16 or 32. Callers must `strings.ToLower` the input first so
+// upper-case IDs are accepted (Grafana sometimes emits upper-case);
+// the length check here is on the lowered string so it stays
+// allocation-free in the hot path. Anything else — non-hex bytes,
+// off-by-one length, empty — is a 400 ("invalid trace id") before
+// the engine lookup, matching upstream behaviour.
+func isValidTraceID(id string) bool {
+	switch len(id) {
+	case 16, 32:
+	default:
+		return false
+	}
+	for i := 0; i < len(id); i++ {
+		c := id[i]
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
 }
 
 // writeError emits Tempo's distinct error envelope

--- a/internal/api/tempo/handler_error_paths_test.go
+++ b/internal/api/tempo/handler_error_paths_test.go
@@ -77,15 +77,18 @@ func TestSearch_CHFailure(t *testing.T) {
 
 // TestTraceByID_CHFailure — same shape on the trace-by-ID endpoint.
 // The error envelope must include the requested traceID so Grafana
-// can show "could not load trace abc123".
+// can show "could not load trace <id>". Uses a valid 16-hex ID so the
+// up-front 16-/32-hex grammar gate (which returns 400 before any CH
+// lookup) doesn't pre-empt the CH-failure path under test.
 func TestTraceByID_CHFailure(t *testing.T) {
 	t.Parallel()
 
+	const traceID = "0123456789abcdef"
 	q := &stubQuerier{err: errors.New("clickhouse: timeout")}
 	srv := newServer(q, "v1.0.0-test")
 	t.Cleanup(srv.Close)
 
-	resp, err := http.Get(srv.URL + "/api/traces/abc123")
+	resp, err := http.Get(srv.URL + "/api/traces/" + traceID)
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -97,43 +100,93 @@ func TestTraceByID_CHFailure(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&er); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if er.TraceID != "abc123" {
-		t.Errorf("traceID: got %q, want abc123", er.TraceID)
+	if er.TraceID != traceID {
+		t.Errorf("traceID: got %q, want %q", er.TraceID, traceID)
 	}
 }
 
-// TestTraceByID_InvalidHex — non-hex IDs are passed through to CH as
-// strings; with no rows matching, the response is the standard
-// not-found envelope. Verify cerberus doesn't panic on weird input
-// (single quote, dollar sign, etc.).
+// TestTraceByID_GrammarGate pins reference Tempo's trace-id grammar
+// on `/api/traces/{id}` (and the v2 alias from #208): only 16- or
+// 32-char lowercase hex is accepted; anything else is 400 ("invalid
+// trace id") BEFORE the CH lookup, valid IDs that don't match fall
+// through to 404 ("trace not found: <id>"), and mixed-case input is
+// lower-cased for the lookup (Grafana sometimes emits upper-case).
+//
+// Both `/api/traces/{id}` and `/api/v2/traces/{id}` share the handler
+// and thus the same gate; the v2 sub-runs guarantee the alias doesn't
+// silently drift.
 //
 // NOTE: sub-tests deliberately run sequentially (no inner
 // `t.Parallel()`) so they don't race on the shared `stubQuerier`'s
 // `lastSQL` / `lastArgs` fields. The outer `t.Parallel()` still
 // allows this test to run alongside other top-level tests in the
 // package — each of which builds its own stubQuerier instance.
-func TestTraceByID_InvalidHex(t *testing.T) {
+func TestTraceByID_GrammarGate(t *testing.T) {
 	t.Parallel()
 
 	q := &stubQuerier{samples: nil}
 	srv := newServer(q, "v1.0.0-test")
 	t.Cleanup(srv.Close)
 
-	cases := []string{
-		"not-hex-at-all",
-		"123!", // shell-special
-		"zzzz", // hex-shaped but not hex
+	// 40-hex string used by the "too long" case: length is hex-shaped
+	// but neither 16 nor 32, so the gate must reject it.
+	const tooLong40Hex = "0123456789abcdef0123456789abcdef01234567"
+
+	cases := []struct {
+		name       string
+		id         string
+		wantStatus int
+		wantMsg    string // substring assertion on the JSON `message`
+	}{
+		// Reference Tempo: 400 "invalid trace id".
+		{name: "non_hex_ZZZZ", id: "ZZZZ", wantStatus: http.StatusBadRequest, wantMsg: "invalid trace id"},
+		{name: "too_short_abc", id: "abc", wantStatus: http.StatusBadRequest, wantMsg: "invalid trace id"},
+		{name: "too_long_40hex", id: tooLong40Hex, wantStatus: http.StatusBadRequest, wantMsg: "invalid trace id"},
+		// Length-15 (off-by-one against the 16-char form).
+		{name: "off_by_one_15hex", id: "0123456789abcde", wantStatus: http.StatusBadRequest, wantMsg: "invalid trace id"},
+		// Hex-shaped but non-hex bytes (`g`).
+		{name: "non_hex_16chars", id: "g123456789abcdef", wantStatus: http.StatusBadRequest, wantMsg: "invalid trace id"},
+		// Valid grammar, no rows → 404 (existing behaviour).
+		{name: "valid_16hex_not_found", id: "0123456789abcdef", wantStatus: http.StatusNotFound, wantMsg: "trace not found"},
+		{name: "valid_32hex_not_found", id: "0123456789abcdef0123456789abcdef", wantStatus: http.StatusNotFound, wantMsg: "trace not found"},
+		// Upper-case input is accepted (lower-cased before lookup);
+		// no rows → 404 with the lower-cased id in the message.
+		{name: "mixed_case_valid_16", id: "0123456789ABCDEF", wantStatus: http.StatusNotFound, wantMsg: "0123456789abcdef"},
+		{name: "mixed_case_valid_32", id: "0123456789ABCDEF0123456789abcdef", wantStatus: http.StatusNotFound, wantMsg: "0123456789abcdef0123456789abcdef"},
 	}
-	for _, id := range cases {
-		t.Run(id, func(t *testing.T) {
-			// No t.Parallel() inside — see comment above.
-			resp, err := http.Get(srv.URL + "/api/traces/" + id)
-			if err != nil {
-				t.Fatalf("GET: %v", err)
-			}
-			defer resp.Body.Close()
-			if resp.StatusCode != http.StatusNotFound {
-				t.Fatalf("status: got %d, want 404", resp.StatusCode)
+	versions := []struct {
+		name string
+		path string
+	}{
+		{name: "v1", path: "/api/traces/"},
+		{name: "v2", path: "/api/v2/traces/"},
+	}
+	for _, ver := range versions {
+		ver := ver
+		t.Run(ver.name, func(t *testing.T) {
+			// No t.Parallel() — sub-tests share the stubQuerier.
+			for _, c := range cases {
+				c := c
+				t.Run(c.name, func(t *testing.T) {
+					resp, err := http.Get(srv.URL + ver.path + c.id)
+					if err != nil {
+						t.Fatalf("GET: %v", err)
+					}
+					defer resp.Body.Close()
+					if resp.StatusCode != c.wantStatus {
+						t.Fatalf("status: got %d, want %d", resp.StatusCode, c.wantStatus)
+					}
+					var er tempo.ErrorResponse
+					if err := json.NewDecoder(resp.Body).Decode(&er); err != nil {
+						t.Fatalf("decode: %v", err)
+					}
+					if !er.Error {
+						t.Errorf("error: got %v, want true", er.Error)
+					}
+					if c.wantMsg != "" && !strings.Contains(er.Message, c.wantMsg) {
+						t.Errorf("message: got %q, want substring %q", er.Message, c.wantMsg)
+					}
+				})
 			}
 		})
 	}

--- a/internal/api/tempo/handler_test.go
+++ b/internal/api/tempo/handler_test.go
@@ -1176,7 +1176,7 @@ func TestTraceByID_NotFound(t *testing.T) {
 	srv := newServer(q, "v1.0.0-test")
 	t.Cleanup(srv.Close)
 
-	resp, err := http.Get(srv.URL + "/api/traces/abc123")
+	resp, err := http.Get(srv.URL + "/api/traces/0123456789abcdef")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1188,7 +1188,7 @@ func TestTraceByID_NotFound(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&er); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if !er.Error || er.TraceID != "abc123" {
+	if !er.Error || er.TraceID != "0123456789abcdef" {
 		t.Fatalf("unexpected error body: %+v", er)
 	}
 }
@@ -1208,7 +1208,7 @@ func TestTraceByID_Found(t *testing.T) {
 	srv := newServer(q, "v1.0.0-test")
 	t.Cleanup(srv.Close)
 
-	resp, err := http.Get(srv.URL + "/api/traces/abc123")
+	resp, err := http.Get(srv.URL + "/api/traces/0123456789abcdef")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1266,7 +1266,7 @@ func TestResponseHeaders_EngineInstrumentation(t *testing.T) {
 	})
 
 	t.Run("traceByID_short_circuit", func(t *testing.T) {
-		resp, err := http.Get(srv.URL + "/api/traces/abc123")
+		resp, err := http.Get(srv.URL + "/api/traces/0123456789abcdef")
 		if err != nil {
 			t.Fatalf("GET: %v", err)
 		}

--- a/internal/api/tempo/handler_trace_proto_test.go
+++ b/internal/api/tempo/handler_trace_proto_test.go
@@ -305,7 +305,10 @@ func TestHandleTraceByID_AcceptProto_NotFound(t *testing.T) {
 	srv := newServer(q, "v1.0.0-test")
 	t.Cleanup(srv.Close)
 
-	req, err := http.NewRequest("GET", srv.URL+"/api/traces/missing", nil)
+	// Valid 32-hex grammar so the 16-/32-hex gate passes; the
+	// stubQuerier returns no rows, exercising the proto-encoded
+	// not-found branch.
+	req, err := http.NewRequest("GET", srv.URL+"/api/traces/00000000000000000000000000000000", nil)
 	if err != nil {
 		t.Fatalf("NewRequest: %v", err)
 	}


### PR DESCRIPTION
## Summary

- **Bug.** `curl /api/traces/ZZZZ` returned `404 {"error":true,"message":"trace not found: ZZZZ"}` — reference Tempo returns `400 {"error":true,"message":"invalid trace id"}` up-front, before any storage lookup. Cerberus was passing the raw string through to the engine + CH, which then surfaced as a not-found and Grafana's Tempo plugin rendered the wrong UX.
- **Fix.** `internal/api/tempo/handler.go::handleTraceByID` now `strings.ToLower`s the path segment and runs a 16-/32-char hex grammar gate (`isValidTraceID`). Mismatched grammar → `400 "invalid trace id"`. Mixed-case input is accepted (Grafana sometimes emits upper-case). Both `/api/traces/{id}` and `/api/v2/traces/{id}` share the handler so the same gate covers the v2 alias from #208.
- **Test (Layer 4).** New `TestTraceByID_GrammarGate` in `handler_error_paths_test.go` matrix-runs v1 + v2 across: `non_hex_ZZZZ`, `too_short_abc`, `too_long_40hex`, `off_by_one_15hex`, `non_hex_16chars`, `valid_16hex_not_found` (→ 404), `valid_32hex_not_found` (→ 404), `mixed_case_valid_16` / `mixed_case_valid_32` (→ 404 with the lower-cased id in the envelope). Existing tests rolled off the now-invalid `abc123` placeholder onto a real 16-hex value (`0123456789abcdef`); one chaos-style edge test that previously asserted 404 for non-hex paths now correctly asserts 400.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/api/tempo/...` — all 328 tests in 2 packages pass
- [x] lefthook `pre-push`: lint + forbid-skip + markdownlint all green
- [ ] CI: `check`, `lint`, `forbid-skip`, `compatibility/tempo`, `roundtrip (traceql)`, `compose-smoke`

Refs cerberus task #211.

🤖 Generated with [Claude Code](https://claude.com/claude-code)