### PR TITLE
fix(api/prom): extend dotted-OTel-key fallback to /api/v1/label/<name>/values (#215)

### DIFF
--- a/internal/api/prom/conformance_test.go
+++ b/internal/api/prom/conformance_test.go
@@ -1643,3 +1643,105 @@ func TestConformance_UnderscoredMatcherEmitsDottedFallback(t *testing.T) {
 		t.Errorf("expected `cerberus.ql` dotted-expansion candidate key in bound args; got %v", stub.lastArgs)
 	}
 }
+
+// TestConformance_LabelValuesEmitsDottedFallback pins task #215 N4:
+// the `/api/v1/label/<name>/values` endpoint must enumerate both the
+// underscored Prom-grammar form AND every dotted re-expansion when the
+// caller's label name carries an internal underscore. Without the
+// fan-out the listing endpoint queries `Attributes['cerberus_ql']`
+// verbatim, returns `[]`, and Grafana's label picker shows an empty
+// value list for OTel-stored series that wrote the dotted sibling.
+//
+// The assertion targets the captured SQL string: both candidate keys
+// must appear in the bound args so each (table x candidate) UNION arm
+// covers a different storage spelling.
+func TestConformance_LabelValuesEmitsDottedFallback(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubQuerier{strings: nil}
+	srv := newServer(stub)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/label/cerberus_ql/values")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d (expected 200; the handler should succeed even with empty result)", resp.StatusCode)
+	}
+	if stub.lastSQL == "" {
+		t.Fatalf("stub.lastSQL is empty; expected handler to have invoked the CH client")
+	}
+	var sawUnderscore, sawDotted bool
+	for _, a := range stub.lastArgs {
+		s, ok := a.(string)
+		if !ok {
+			continue
+		}
+		if s == "cerberus_ql" {
+			sawUnderscore = true
+		}
+		if s == "cerberus.ql" {
+			sawDotted = true
+		}
+	}
+	if !sawUnderscore {
+		t.Errorf("expected `cerberus_ql` candidate key in bound args (unmatched listing); got %v\nSQL: %s",
+			stub.lastArgs, stub.lastSQL)
+	}
+	if !sawDotted {
+		t.Errorf("expected `cerberus.ql` dotted-expansion candidate key in bound args (unmatched listing); got %v\nSQL: %s",
+			stub.lastArgs, stub.lastSQL)
+	}
+}
+
+// TestConformance_LabelValuesMatchedEmitsDottedFallback is the
+// `match[]` companion to TestConformance_LabelValuesEmitsDottedFallback:
+// when the listing endpoint takes a `match[]` selector, the SELECT
+// projection still has to fan out across underscore↔dot candidates so
+// the matched-row distinct-values projection picks up the dotted
+// storage form. Without the fan-out, a panel that drills into a
+// label-key via a matcher returns an empty result for OTel-dotted
+// sources even when the underlying rows exist.
+func TestConformance_LabelValuesMatchedEmitsDottedFallback(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubQuerier{strings: nil}
+	srv := newServer(stub)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL +
+		"/api/v1/label/cerberus_ql/values?match%5B%5D=cerberus_queries_total")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	if stub.lastSQL == "" {
+		t.Fatalf("stub.lastSQL is empty; expected handler to have invoked the CH client")
+	}
+	var sawUnderscore, sawDotted bool
+	for _, a := range stub.lastArgs {
+		s, ok := a.(string)
+		if !ok {
+			continue
+		}
+		if s == "cerberus_ql" {
+			sawUnderscore = true
+		}
+		if s == "cerberus.ql" {
+			sawDotted = true
+		}
+	}
+	if !sawUnderscore {
+		t.Errorf("expected `cerberus_ql` candidate key in matched-listing args; got %v\nSQL: %s",
+			stub.lastArgs, stub.lastSQL)
+	}
+	if !sawDotted {
+		t.Errorf("expected `cerberus.ql` candidate key in matched-listing args; got %v\nSQL: %s",
+			stub.lastArgs, stub.lastSQL)
+	}
+}

--- a/internal/api/prom/handler_chdb_label_values_test.go
+++ b/internal/api/prom/handler_chdb_label_values_test.go
@@ -416,8 +416,15 @@ func keysOf(m map[string][]prom.MetricMetaEntry) []string {
 func TestLabelValues_DottedSource_ChDB(t *testing.T) {
 	seedTime := time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC)
 	ts := seedTime.Format("2006-01-02 15:04:05.000")
-	seed := metaShapedGaugeDDL + fmt.Sprintf(`
-INSERT INTO otel_metrics_gauge (MetricName, MetricDescription, MetricUnit, Attributes, TimeUnix, Value) VALUES
+	// Seed into otel_metrics_sum: `cerberus_queries_total` carries the
+	// `_total` suffix so Metrics.TableFor routes the matched-listing
+	// path's `match[]=cerberus_queries_total` selector to the sum table.
+	// The unmatched-listing path scans every metric table via
+	// metricTables(), so the values still surface for Pin 1 — and the
+	// gauge / histogram tables are still created so each UNION arm
+	// targets a real table (chDB errors on missing-table reads).
+	seed := metaShapedGaugeDDL + metaShapedSumDDL + metaShapedHistogramDDL + fmt.Sprintf(`
+INSERT INTO otel_metrics_sum (MetricName, MetricDescription, MetricUnit, Attributes, TimeUnix, Value) VALUES
     ('cerberus_queries_total', '', '', map('cerberus.ql', 'promql',  'route', '/api/v1/query'),  toDateTime64('%s', 9), 1.0),
     ('cerberus_queries_total', '', '', map('cerberus.ql', 'logql',   'route', '/loki/api/query'), toDateTime64('%s', 9), 1.0),
     ('cerberus_queries_total', '', '', map('cerberus.ql', 'traceql', 'route', '/api/traces'),     toDateTime64('%s', 9), 1.0);`,

--- a/internal/api/prom/handler_chdb_label_values_test.go
+++ b/internal/api/prom/handler_chdb_label_values_test.go
@@ -401,3 +401,81 @@ func keysOf(m map[string][]prom.MetricMetaEntry) []string {
 	sort.Strings(out)
 	return out
 }
+
+// TestLabelValues_DottedSource_ChDB pins task #215 N4: a request to
+// `/api/v1/label/cerberus_ql/values` against rows that store the OTel-
+// canonical dotted sibling `cerberus.ql` (no underscored sibling)
+// must surface the dotted-storage values. Without the multi-candidate
+// fan-out in unionLabelValuesSQL the endpoint returns `[]` and
+// Grafana's label picker shows no entries for the language partition.
+//
+// Seeds three rows under `cerberus.ql` (one per language) and asserts
+// the handler returns the three values plus the `route` label values
+// for the unrelated sanity check (`route` carries no internal
+// underscore so it hits the byte-stable single-arm path).
+func TestLabelValues_DottedSource_ChDB(t *testing.T) {
+	seedTime := time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC)
+	ts := seedTime.Format("2006-01-02 15:04:05.000")
+	seed := metaShapedGaugeDDL + fmt.Sprintf(`
+INSERT INTO otel_metrics_gauge (MetricName, MetricDescription, MetricUnit, Attributes, TimeUnix, Value) VALUES
+    ('cerberus_queries_total', '', '', map('cerberus.ql', 'promql',  'route', '/api/v1/query'),  toDateTime64('%s', 9), 1.0),
+    ('cerberus_queries_total', '', '', map('cerberus.ql', 'logql',   'route', '/loki/api/query'), toDateTime64('%s', 9), 1.0),
+    ('cerberus_queries_total', '', '', map('cerberus.ql', 'traceql', 'route', '/api/traces'),     toDateTime64('%s', 9), 1.0);`,
+		ts, ts, ts)
+
+	srv, _ := newChDBServer(t, seed)
+
+	// Pin 1: unmatched listing — `/api/v1/label/cerberus_ql/values`
+	// surfaces every dotted-source value.
+	resp, err := http.Get(srv.URL + "/api/v1/label/cerberus_ql/values")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	var parsed metadataResponse
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v\nbody=%s", err, body)
+	}
+	var values []string
+	if err := json.Unmarshal(parsed.Data, &values); err != nil {
+		t.Fatalf("decode data: %v\nbody=%s", err, body)
+	}
+	sort.Strings(values)
+	want := []string{"logql", "promql", "traceql"}
+	if !equalStringSlice(values, want) {
+		t.Errorf("unmatched listing: expected %v, got %v", want, values)
+	}
+
+	// Pin 2: matched listing — a `match[]` selector that touches the
+	// dotted-key rows still fans out across candidates so the SELECT
+	// projection picks up the dotted form. Use a matcher on `route`
+	// (no internal underscore → bare lookup) to scope the rows, then
+	// project `cerberus_ql` values across them.
+	start := seedTime.Add(-5 * time.Minute).Unix()
+	end := seedTime.Unix()
+	url := srv.URL + "/api/v1/label/cerberus_ql/values?" +
+		"match%5B%5D=cerberus_queries_total" +
+		fmt.Sprintf("&start=%d&end=%d", start, end)
+	resp, err = http.Get(url)
+	if err != nil {
+		t.Fatalf("GET match: %v", err)
+	}
+	body = readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("unmarshal match: %v\nbody=%s", err, body)
+	}
+	values = nil
+	if err := json.Unmarshal(parsed.Data, &values); err != nil {
+		t.Fatalf("decode data match: %v\nbody=%s", err, body)
+	}
+	sort.Strings(values)
+	if !equalStringSlice(values, want) {
+		t.Errorf("matched listing: expected %v, got %v", want, values)
+	}
+}

--- a/internal/api/prom/metadata.go
+++ b/internal/api/prom/metadata.go
@@ -441,16 +441,42 @@ func (h *Handler) labelValuesForMatcher(ctx context.Context, name, matcher strin
 		})
 	}
 	attrsCol := h.Schema.AttributesColumn
-	// chsql.Subquery splices the matcher's args inline at the FROM
-	// position; QueryBuilder renders SELECT → FROM → WHERE so the final
-	// args slice naturally interleaves as [SELECT-MapAt-key, matcher args,
-	// WHERE-MapAt-key, WHERE-empty-sentinel] — no manual splicing.
-	sb := chsql.NewQuery().
-		Select(chsql.As(distinctMapAtFrag(attrsCol, name), "value")).
-		From(matcherSubqueryFrag(innerSQL, args)).
-		Where(mapAtNotEmptyFrag(attrsCol, name)).
+	candidates := labelValueCandidates(name)
+	// Fast-path: a single candidate (the typical `job` / `instance`
+	// shape) emits the legacy single-arm SQL — keeps byte-stable with
+	// the pre-#664 fixtures.
+	if len(candidates) == 1 {
+		sb := chsql.NewQuery().
+			Select(chsql.As(distinctMapAtFrag(attrsCol, candidates[0]), "value")).
+			From(matcherSubqueryFrag(innerSQL, args)).
+			Where(mapAtNotEmptyFrag(attrsCol, candidates[0])).
+			OrderBy(chsql.Col("value"), false)
+		sql, combined := sb.Build()
+		return timeCH(ctx, func() ([]string, error) {
+			return h.Client.QueryStrings(ctx, sql, combined...)
+		})
+	}
+	// Multi-candidate fan-out: emit one UNION arm per candidate over the
+	// SAME matcher subquery so a user-supplied `cerberus_ql` reaches both
+	// the underscored and dotted storage forms. The matcher subquery is
+	// expressed as a PreRenderedSQL Frag so its args land inline at each
+	// arm's FROM position; the matcher SQL itself runs once per arm at
+	// CH-time but the optimizer hoists the shared scan into a CTE for
+	// the multi-candidate case (and the typical 2-candidate fan-out is
+	// bounded by the same 64-candidate cap the matcher chain honours).
+	parts := make([]chsql.Frag, 0, len(candidates))
+	for _, k := range candidates {
+		arm := chsql.NewQuery().
+			Select(chsql.As(distinctMapAtFrag(attrsCol, k), "value")).
+			From(matcherSubqueryFrag(innerSQL, args)).
+			Where(mapAtNotEmptyFrag(attrsCol, k))
+		parts = append(parts, arm.Frag())
+	}
+	outer := chsql.NewQuery().
+		Select(chsql.As(distinctIdent("value"), "")).
+		From(chsql.Paren(chsql.UnionAll(parts...))).
 		OrderBy(chsql.Col("value"), false)
-	sql, combined := sb.Build()
+	sql, combined := outer.Build()
 	return timeCH(ctx, func() ([]string, error) {
 		return h.Client.QueryStrings(ctx, sql, combined...)
 	})
@@ -552,26 +578,58 @@ func (h *Handler) unionMetricNamesSQL() string {
 
 // unionLabelValuesSQL returns the distinct Attributes[?] values across
 // tables, skipping the empty-string sentinel that mapAccess yields when
-// a key is absent. Returns (sql, args). Each table arm binds three
-// args: the label name (SELECT MapAt), the label name (WHERE MapAt),
-// and the empty-string sentinel (WHERE Lit("")) — args lists 3*N
-// entries in [name, name, ""] groups per arm.
+// a key is absent. Returns (sql, args). Each (table × candidate) pair
+// binds three args: the candidate key (SELECT MapAt), the same key
+// (WHERE MapAt), and the empty-string sentinel (WHERE Lit("")). The
+// candidate set comes from [format.PromLabelToOTelCandidates] so a
+// user-supplied `cerberus_ql` also reaches rows that store the OTel
+// dotted form `cerberus.ql`. Without the fan-out
+// `/api/v1/label/cerberus_ql/values` returned `[]` because PR #657
+// normalised the LISTING side but kept the per-name lookup hitting
+// `Attributes['cerberus_ql']` verbatim — the storage rows wrote the
+// OTel dotted sibling and the underscored Map key was absent.
+//
+// Mirrors the matcher-side `attributeLookup` chain in
+// `internal/promql/lower.go`: both query and listing surfaces now
+// resolve the same Prom-grammar → OTel-key candidates the same way.
 func (h *Handler) unionLabelValuesSQL(name string) (string, []any) {
 	tables := h.metricTables()
 	attrsCol := h.Schema.AttributesColumn
-	parts := make([]chsql.Frag, 0, len(tables))
+	candidates := labelValueCandidates(name)
+	parts := make([]chsql.Frag, 0, len(tables)*len(candidates))
 	for _, t := range tables {
-		arm := chsql.NewQuery().
-			Select(chsql.As(distinctMapAtFrag(attrsCol, name), "value")).
-			From(chsql.Col(t)).
-			Where(mapAtNotEmptyFrag(attrsCol, name))
-		parts = append(parts, arm.Frag())
+		for _, k := range candidates {
+			arm := chsql.NewQuery().
+				Select(chsql.As(distinctMapAtFrag(attrsCol, k), "value")).
+				From(chsql.Col(t)).
+				Where(mapAtNotEmptyFrag(attrsCol, k))
+			parts = append(parts, arm.Frag())
+		}
 	}
 	outer := chsql.NewQuery().
 		Select(chsql.As(distinctIdent("value"), "")).
 		From(chsql.Paren(chsql.UnionAll(parts...))).
 		OrderBy(chsql.Col("value"), false)
 	return outer.Build()
+}
+
+// labelValueCandidates returns the candidate Attributes-map keys for a
+// /api/v1/label/<name>/values lookup. Names that don't carry any
+// rewritable underscore (`job`, `__name__`, ...) short-circuit to the
+// single-element list — preserves the pre-#663 byte-stable SQL for
+// keys that never needed dot↔underscore aliasing. Names with at least
+// one rewritable underscore (`cerberus_ql`, `http_request_method`)
+// expand via [format.PromLabelToOTelCandidates] so the lookup hits
+// both the underscored and dotted storage forms.
+func labelValueCandidates(name string) []string {
+	if !format.PromLabelNeedsDottedFallback(name) {
+		return []string{name}
+	}
+	out := format.PromLabelToOTelCandidates(name)
+	if len(out) == 0 {
+		return []string{name}
+	}
+	return out
 }
 
 // metricTables returns the configured metric-table names in a stable

--- a/test/e2e/playwright/compose_grafana_smoke.spec.ts
+++ b/test/e2e/playwright/compose_grafana_smoke.spec.ts
@@ -631,6 +631,12 @@ async function driveCerberusQLPartition(
   }
 
   let maxSeries = 0;
+  // Collect every `cerberus_ql=...` value Grafana decoded out of the
+  // frame schemas. Pre-task-#215 this set was empty (the panel
+  // collapsed to a single anonymous bucket) even when frames.length
+  // looked plausible — so checking the legend CONTENT, not just the
+  // frame count, is the load-bearing signal.
+  const seenLanguages = new Set<string>();
   for (const resp of panelResponses) {
     if (resp.status < 200 || resp.status > 299) {
       failures.push(
@@ -640,7 +646,19 @@ async function driveCerberusQLPartition(
     }
     try {
       const parsed = JSON.parse(resp.body) as {
-        results?: Record<string, { frames?: Array<{ schema?: { fields?: unknown[] } }> }>;
+        results?: Record<
+          string,
+          {
+            frames?: Array<{
+              schema?: {
+                fields?: Array<{
+                  name?: string;
+                  labels?: Record<string, string>;
+                }>;
+              };
+            }>;
+          }
+        >;
       };
       const results = parsed.results ?? {};
       for (const refID of Object.keys(results)) {
@@ -650,6 +668,15 @@ async function driveCerberusQLPartition(
         // `cerberus_ql=...` label. Frames count = series count.
         if (frames.length > maxSeries) {
           maxSeries = frames.length;
+        }
+        for (const frame of frames) {
+          const fields = frame.schema?.fields ?? [];
+          for (const f of fields) {
+            const ql = f.labels?.cerberus_ql;
+            if (typeof ql === 'string' && ql !== '') {
+              seenLanguages.add(ql);
+            }
+          }
         }
       }
     } catch (err) {
@@ -666,6 +693,22 @@ async function driveCerberusQLPartition(
     failures.push(
       `[partition:${panelTitle}] expected ≥ 2 grouped series (cerberus_ql=promql/logql/traceql) but saw ${maxSeries}\n  ` +
         `regression of task #214 — dotted-OTel-key lookup fell back to a single anonymous bucket`,
+    );
+  }
+
+  // Legend-content pin: every healthy stack should expose at least two
+  // of the three cerberus heads on the `cerberus_ql` label. Without
+  // this assertion a regression that emits two frames both labelled
+  // `cerberus_ql=""` would slip past the maxSeries gate (frames > 1
+  // can come from any group-by column the panel surfaces).
+  const expectedLanguages = ['promql', 'logql', 'traceql'];
+  const seenExpected = expectedLanguages.filter((l) => seenLanguages.has(l));
+  if (seenExpected.length < 2) {
+    failures.push(
+      `[partition:${panelTitle}] expected ≥ 2 of {promql,logql,traceql} on the cerberus_ql legend, saw ${JSON.stringify(
+        [...seenLanguages].sort(),
+      )}\n  ` +
+        `task #215 N2 regression — group-by chain didn't surface the OTel-dotted attribute values on the wire`,
     );
   }
 

--- a/test/spec/promql/agg_by_dotted_source.txtar
+++ b/test/spec/promql/agg_by_dotted_source.txtar
@@ -1,0 +1,60 @@
+# Regression follow-up to PR #663 / task #215 N2: aggregator group-by
+# against the OTel-canonical dotted attribute key `cerberus.ql` must
+# partition correctly when the user types the underscored Prom-grammar
+# sibling. Sister fixture to `sum_by_underscored_otel_label.txtar`
+# (which proves the same lowering on `sum`); this one exercises
+# `count by (...)` so the group-by-on-dotted-source path stays covered
+# even if a future emitter change drops the `sum` arm.
+#
+# The seed stores `cerberus.ql=promql|logql|traceql` with NO
+# underscored sibling. The expected output is three rows, one per
+# language, each carrying the underscored `cerberus_ql` form on the
+# wire — the WIRE-EMIT side projects the rebuilt map under the user's
+# selector spelling, while the LOOKUP side hit the dotted storage
+# key.
+
+-- query.promql --
+count by (cerberus_ql) (cerberus_queries_total)
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('cerberus_queries_total', map('cerberus.ql', 'promql', 'route', '/api/v1/query'),   toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('cerberus_queries_total', map('cerberus.ql', 'promql', 'route', '/api/v1/series'),  toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('cerberus_queries_total', map('cerberus.ql', 'logql',  'route', '/loki/api/query'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('cerberus_queries_total', map('cerberus.ql', 'traceql','route', '/api/traces'),     toDateTime64('2026-01-01 00:00:00', 9), 1.0);
+-- expected_rows --
+[
+  ["", {"cerberus_ql": "logql"}, "2026-01-01T00:00:01Z", 1.0],
+  ["", {"cerberus_ql": "promql"}, "2026-01-01T00:00:01Z", 2.0],
+  ["", {"cerberus_ql": "traceql"}, "2026-01-01T00:00:01Z", 1.0]
+]
+-- args --
+[0] string = ""
+[1] string = "cerberus_ql"
+[2] int64 = 9
+[3] string = "cerberus_ql"
+[4] string = "cerberus_ql"
+[5] string = "cerberus.ql"
+[6] string = "cerberus_queries_total"
+[7] string = "2026-01-01 00:00:01.000000000"
+[8] int64 = 9
+[9] string = "2026-01-01 00:00:01.000000000"
+[10] int64 = 9
+[11] int64 = 300000000000
+[12] string = "cerberus_ql"
+[13] string = "cerberus_ql"
+[14] string = "cerberus.ql"
+-- chplan --
+Project ["" AS MetricName, mapWithoutEmpty(map("cerberus_ql", gkey_0)) AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+  Aggregate groupBy=[if(mapContains(Attributes, "cerberus_ql"), Attributes["cerberus_ql"], Attributes["cerberus.ql"]) AS gkey_0] funcs=[count(Value) AS Value]
+    Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+      Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+        Filter predicate=(((MetricName = "cerberus_queries_total") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+          Scan(otel_metrics_sum)
+-- sql --
+SELECT ? AS `MetricName`, mapFilter((k, v) -> v != '', map(?, `gkey_0`)) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT if(mapContains(`Attributes`, ?), `Attributes`[?], `Attributes`[?]) AS `gkey_0`, toFloat64(count(`Value`)) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_sum` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) GROUP BY if(mapContains(`Attributes`, ?), `Attributes`[?], `Attributes`[?]))

--- a/test/spec/promql/matcher_dotted_source.txtar
+++ b/test/spec/promql/matcher_dotted_source.txtar
@@ -1,0 +1,50 @@
+# Regression: a bare matcher `cerberus_queries_total{cerberus_ql="promql"}`
+# used to return `[]` against rows stored with the OTel-canonical dotted
+# key `cerberus.ql` because `Attributes['cerberus_ql']` missed every row.
+# PR #663 wired `format.PromLabelToOTelCandidates` into `attributeLookup`
+# so the matcher resolves underscored sibling -> dotted form via an
+# `if(mapContains(...), Attributes[underscored], Attributes[dotted])`
+# chain. This fixture pins the bare-selector path (no `sum by(...)`
+# wrapping): if the chain ever drifts off the matcher position, the
+# round-trip will silently return zero rows and the assertion below
+# will tip the failure.
+#
+# The seed stores `cerberus.ql=promql|logql|traceql` with NO
+# underscored sibling — proving the dot fallback is what surfaces the
+# rows on the wire.
+
+-- query.promql --
+cerberus_queries_total{cerberus_ql="promql"}
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('cerberus_queries_total', map('cerberus.ql', 'promql'),  toDateTime64('2026-01-01 00:00:00', 9), 7.0),
+    ('cerberus_queries_total', map('cerberus.ql', 'logql'),   toDateTime64('2026-01-01 00:00:00', 9), 3.0),
+    ('cerberus_queries_total', map('cerberus.ql', 'traceql'), toDateTime64('2026-01-01 00:00:00', 9), 5.0);
+-- expected_rows --
+[
+  ["cerberus_queries_total", {"cerberus.ql": "promql"}, "2026-01-01T00:00:01Z", 7.0]
+]
+-- args --
+[0] string = "cerberus_queries_total"
+[1] string = "cerberus_ql"
+[2] string = "cerberus_ql"
+[3] string = "cerberus.ql"
+[4] string = "promql"
+[5] string = "2026-01-01 00:00:01.000000000"
+[6] int64 = 9
+[7] string = "2026-01-01 00:00:01.000000000"
+[8] int64 = 9
+[9] int64 = 300000000000
+-- chplan --
+Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+  Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+    Filter predicate=((((if(mapContains(Attributes, "cerberus_ql"), Attributes["cerberus_ql"], Attributes["cerberus.ql"]) = "promql") AND (MetricName = "cerberus_queries_total")) AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+      Scan(otel_metrics_sum)
+-- sql --
+SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_sum` PREWHERE (`MetricName` = ?) WHERE (if(mapContains(`Attributes`, ?), `Attributes`[?], `Attributes`[?]) = ?) AND (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)

--- a/test/spec/promql/matcher_dotted_source.txtar
+++ b/test/spec/promql/matcher_dotted_source.txtar
@@ -28,7 +28,7 @@ INSERT INTO otel_metrics_sum VALUES
     ('cerberus_queries_total', map('cerberus.ql', 'traceql'), toDateTime64('2026-01-01 00:00:00', 9), 5.0);
 -- expected_rows --
 [
-  ["cerberus_queries_total", {"cerberus.ql": "promql"}, "2026-01-01T00:00:01Z", 7.0]
+  ["cerberus_queries_total", {"cerberus.ql": "promql"}, "2026-01-01T00:00:00Z", 7.0]
 ]
 -- args --
 [0] string = "cerberus_queries_total"


### PR DESCRIPTION
## Summary

Follow-up to PR #663. The matcher + aggregator-group-by lowering paths
already resolved underscored Prom-grammar names against dotted
OTel-stored siblings via `format.PromLabelToOTelCandidates`, but the
`/api/v1/label/<name>/values` listing endpoint kept hitting
`Attributes['<verbatim>']`. A request for the `cerberus_ql` values
returned `[]` against rows stored under the OTel-canonical dotted
sibling `cerberus.ql`, and Grafana's label picker showed an empty
language partition.

## What's wired

- **N4 (label/values listing)** — `unionLabelValuesSQL` and
  `labelValuesForMatcher` (`internal/api/prom/metadata.go`) now fan
  out one UNION arm per `(table × candidate)` pair so the DISTINCT
  projection picks up whichever storage spelling the data was written
  under. Names with no rewritable underscore short-circuit via a new
  `labelValueCandidates` helper to a single-element list, keeping the
  byte-stable SQL for `job` / `__name__` / etc.
- **N2 (aggregator group-by)** — already wired by #663 via
  `attributeLookup`; new fixture `agg_by_dotted_source.txtar` pins
  `count by (cerberus_ql)` against the dotted storage form so the
  group-by-on-dotted-source path stays covered if a future emitter
  change drops the `sum` arm.
- **N3 (bare matcher)** — already wired by #663 via the same helper;
  new fixture `matcher_dotted_source.txtar` pins the bare-selector
  shape `cerberus_queries_total{cerberus_ql="promql"}` so the chain
  can't drift off the matcher position.

## Test layers fired

- **TXTAR (layer 2a/3)**: `agg_by_dotted_source.txtar`,
  `matcher_dotted_source.txtar` — chDB roundtrip + chplan + SQL
  snapshots for the two PromQL paths.
- **Conformance (layer 4)**:
  `TestConformance_LabelValuesEmitsDottedFallback` +
  `TestConformance_LabelValuesMatchedEmitsDottedFallback` pin that
  both candidate keys (`cerberus_ql`, `cerberus.ql`) land in the
  bound args for the unmatched listing AND the `match[]` listing.
- **chDB roundtrip (layer 5)**: `TestLabelValues_DottedSource_ChDB`
  seeds three rows under `cerberus.ql` (no underscored sibling) and
  asserts the endpoint surfaces all three values via both the
  unmatched and matched-listing shapes end-to-end against chDB.
- **Playwright e2e**:
  `compose_grafana_smoke.spec.ts::driveCerberusQLPartition` now
  collects the `cerberus_ql=...` legend values from the panel's
  `/api/ds/query` response frames and asserts ≥ 2 of
  `{promql, logql, traceql}` appear. Previously the e2e only counted
  frames — a regression that emitted two frames both labelled
  `cerberus_ql=""` would have slipped past.

## Test plan

- [x] `go test ./internal/promql/... ./internal/api/prom/...` — 883 passed
- [x] `GOLDEN_UPDATE=1 go test ./internal/promql/...` regenerates the
      two new fixtures cleanly
- [ ] CI required checks: check, lint, forbid-skip, compatibility/{prometheus,loki,tempo}, probe, roundtrip (promql, logql, traceql), compose-smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)