### PR TITLE
fix(logql): surface top-level OTel columns to outer by-clause (#218)

### DIFF
--- a/internal/logql/detected_level.go
+++ b/internal/logql/detected_level.go
@@ -194,13 +194,54 @@ func anyEqual(expr chplan.Expr, variants []string) chplan.Expr {
 // the augmented identity drives the RangeWindow GROUP BY to emit one
 // series per detected_level).
 func withDetectedLevel(s schema.Logs, baseLabels chplan.Expr) chplan.Expr {
-	levelMap := &chplan.FuncCall{
-		Name: "map",
-		Args: []chplan.Expr{
-			&chplan.LitString{V: detectedLevelLabel},
-			detectedLevelExpr(s),
-		},
+	return withDetectedLevelAndColumns(s, baseLabels, nil)
+}
+
+// withDetectedLevelAndColumns is the column-aware companion of
+// [withDetectedLevel]: it augments the identity map with the
+// synthesised `detected_level` key AND with one synthesised key per
+// top-level OTel-CH scalar column (SeverityText, ServiceName, ...)
+// named in `outerByLabels`. The outer-by-labels list comes from
+// [lowerCtx.OuterByLabels] — i.e. the by-clause of the enclosing
+// vector aggregation, threaded down so the inner identity exposes
+// exactly the top-level columns the outer aggregate needs.
+//
+// The map shape becomes
+//
+//	mapConcat(
+//	    <baseLabels>,
+//	    mapFilter((k, v) -> v != '',
+//	        map('detected_level', multiIf(...),
+//	            '<col1>',         toString(<col1>),
+//	            '<col2>',         toString(<col2>),
+//	            ...)))
+//
+// `toString` coerces non-String top-level columns (SeverityNumber,
+// TraceFlags) into the Map(String, String) value slot. String-typed
+// columns are already string-shaped so the coercion is a no-op the
+// emitter elides. `mapFilter` drops empty entries the same way it
+// does for `detected_level`, so a row with an empty severity column
+// doesn't gain a spurious `{SeverityText:""}` key.
+//
+// When `outerByLabels` is empty the function behaves identically to
+// the original [withDetectedLevel] — bare `rate({}[5m])` and other
+// no-outer-grouping queries keep their lean identity map.
+func withDetectedLevelAndColumns(s schema.Logs, baseLabels chplan.Expr, outerByLabels []string) chplan.Expr {
+	args := []chplan.Expr{
+		&chplan.LitString{V: detectedLevelLabel},
+		detectedLevelExpr(s),
 	}
+	for _, col := range topLevelColumnsReferencedBy(outerByLabels, s) {
+		args = append(
+			args,
+			&chplan.LitString{V: col},
+			&chplan.FuncCall{
+				Name: "toString",
+				Args: []chplan.Expr{topLevelColumnRef(col)},
+			},
+		)
+	}
+	synthMap := &chplan.FuncCall{Name: "map", Args: args}
 	filtered := &chplan.FuncCall{
 		Name: "mapFilter",
 		Args: []chplan.Expr{
@@ -212,7 +253,7 @@ func withDetectedLevel(s schema.Logs, baseLabels chplan.Expr) chplan.Expr {
 					Right: &chplan.LitString{V: ""},
 				},
 			},
-			levelMap,
+			synthMap,
 		},
 	}
 	return &chplan.FuncCall{

--- a/internal/logql/lower.go
+++ b/internal/logql/lower.go
@@ -50,6 +50,33 @@ type lowerCtx struct {
 	Start time.Time
 	End   time.Time
 	Step  time.Duration
+
+	// OuterByLabels carries the by-clause labels of an enclosing
+	// vector aggregation (`sum by (SeverityText, ServiceName) (rate(...))`)
+	// down into the inner range aggregation's identity Project. When
+	// one of these labels names a top-level OTel-CH scalar column
+	// (SeverityText, ServiceName, SeverityNumber, ...) that lives
+	// outside ResourceAttributes, the inner range Project surfaces it
+	// into the augmented identity map so the outer Aggregate's
+	// `ResourceAttributes[<label>]` lookup resolves to the column's
+	// per-row value rather than the empty string. Without this plumb,
+	// `sum by (SeverityText) (rate({}[5m]))` collapsed every row into
+	// one series `{SeverityText:""}` because `SeverityText` is a
+	// top-level otel_logs column, not a key inside the
+	// ResourceAttributes Map. See [withDetectedLevel] for the wrap
+	// that consumes this list and [topLevelLogColumnFor] for the
+	// label→column resolution.
+	OuterByLabels []string
+}
+
+// withOuterByLabels returns a copy of c with OuterByLabels set to
+// labels. Used by [lowerVectorAggregation] before recursing into the
+// inner range aggregation so the inner identity can surface any
+// top-level OTel-CH columns the outer by-clause references.
+func (c lowerCtx) withOuterByLabels(labels []string) lowerCtx {
+	out := c
+	out.OuterByLabels = labels
+	return out
 }
 
 // hasTimeWindow reports whether the context carries a non-degenerate

--- a/internal/logql/range_aggregation.go
+++ b/internal/logql/range_aggregation.go
@@ -139,7 +139,7 @@ func lowerRangeAggregation(e *syntax.RangeAggregationExpr, s schema.Logs, lc low
 		identityBase = &chplan.MapWithoutKeys{Map: labelsExpr, Keys: []string{e.Left.Unwrap.Identifier}}
 	}
 	identityProj := chplan.Projection{
-		Expr:  withDetectedLevel(s, identityBase),
+		Expr:  withDetectedLevelAndColumns(s, identityBase, lc.OuterByLabels),
 		Alias: s.ResourceAttributesColumn,
 	}
 	if groupBy != nil {

--- a/internal/logql/top_level_columns.go
+++ b/internal/logql/top_level_columns.go
@@ -1,0 +1,99 @@
+package logql
+
+import (
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// topLevelLogColumnFor reports whether `label` names a top-level OTel-CH
+// scalar column on the logs table (rather than a key inside the
+// ResourceAttributes / LogAttributes maps). When it does, the second
+// return is the underlying column name (`SeverityText`, `ServiceName`,
+// ...) that the lowering should reference directly via `ColumnRef`.
+//
+// Why this exists: cerberus's default OTel-CH schema dedicates several
+// fields (severity, service name, scope, trace correlation, event name)
+// to their own top-level columns alongside the generic
+// ResourceAttributes Map. Users (and Grafana panels) reach for those
+// fields by their canonical column names (`sum by (SeverityText) (...)`,
+// `sum by (ServiceName) (...)`) — the LogQL grammar accepts any label
+// identifier, so the parser doesn't distinguish "a stream attribute"
+// from "a top-level column". Before this helper, `levelAwareGroupKey`
+// resolved every label as `ResourceAttributes[<label>]`, which silently
+// returned the empty string for top-level columns and collapsed every
+// matching query into a single `{<label>:""}` series — the bug task #218
+// reported (every Log volume / Log rate by-clause dashboard panel
+// broken).
+//
+// The recognised set mirrors the schema.Logs fields that name a
+// scalar (non-Map) column. Map-typed columns (LogAttributes,
+// ResourceAttributes, ScopeAttributes) are deliberately excluded
+// because users group by keys inside those maps, not by the map as a
+// whole. The set is closed against the schema: a custom-schema user
+// who renames `SeverityColumn` to `level_text` automatically gets
+// `level_text` as the recognised top-level label here too, because
+// the resolution reads from the schema fields rather than a static
+// allow-list of names.
+//
+// Both the inner range-aggregation identity wrap ([withDetectedLevel]
+// and friends) and the inner range-aggregation's own `by/without`
+// resolution ([levelAwareRangeGroupKey]) consult this helper so the
+// two grouping layers agree on which labels surface from top-level
+// columns vs which fall back to the ResourceAttributes map.
+func topLevelLogColumnFor(label string, s schema.Logs) (string, bool) {
+	if label == "" {
+		return "", false
+	}
+	// Each case matches `label` against a schema field only when the
+	// field itself is non-empty — a custom schema that blanks a column
+	// out (e.g. no dedicated EventName column) must not collapse
+	// every empty-string label lookup into a spurious match.
+	candidates := []string{
+		s.SeverityColumn,
+		s.SeverityNumberColumn,
+		s.ServiceNameColumn,
+		s.ScopeNameColumn,
+		s.ScopeVersionColumn,
+		s.EventNameColumn,
+		s.TraceIDColumn,
+		s.SpanIDColumn,
+		s.TraceFlagsColumn,
+	}
+	for _, col := range candidates {
+		if col != "" && col == label {
+			return col, true
+		}
+	}
+	return "", false
+}
+
+// topLevelColumnsReferencedBy returns the subset of `labels` that name
+// top-level OTel-CH scalar columns on the schema. Order is preserved
+// and duplicates are dropped so the downstream identity wrap emits a
+// deterministic map shape. Used by [withDetectedLevel] to inflate the
+// augmented identity map with exactly the top-level columns an outer
+// `by(...)` clause references — see [lowerCtx.OuterByLabels].
+func topLevelColumnsReferencedBy(labels []string, s schema.Logs) []string {
+	if len(labels) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(labels))
+	out := make([]string, 0, len(labels))
+	for _, lbl := range labels {
+		col, ok := topLevelLogColumnFor(lbl, s)
+		if !ok || seen[col] {
+			continue
+		}
+		seen[col] = true
+		out = append(out, col)
+	}
+	return out
+}
+
+// topLevelColumnRef returns a chplan ColumnRef pointing at the
+// top-level OTel-CH column named `col`. Used by both the inner range
+// aggregation's `by/without` resolution and the augmented-identity
+// wrap so the two paths emit identical column references.
+func topLevelColumnRef(col string) chplan.Expr {
+	return &chplan.ColumnRef{Name: col}
+}

--- a/internal/logql/top_level_columns_test.go
+++ b/internal/logql/top_level_columns_test.go
@@ -1,0 +1,121 @@
+package logql
+
+import (
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestTopLevelLogColumnFor_DefaultOTel pins the recognised set for the
+// default OTel-CH logs schema. The bug task #218 reported (every Log
+// volume / Log rate `by(SeverityText)` panel collapsing to one series)
+// stems from a missing entry here: any top-level OTel-CH scalar column
+// the schema names must surface so the inner identity wrap and outer
+// MapAccess agree on which labels resolve from the column vs from
+// ResourceAttributes.
+func TestTopLevelLogColumnFor_DefaultOTel(t *testing.T) {
+	s := schema.DefaultOTelLogs()
+	cases := []struct {
+		label string
+		want  string
+		match bool
+	}{
+		// Recognised: every scalar (non-Map) top-level column on the
+		// default OTel-CH schema. Each entry doubles as a guard
+		// against a schema-field rename silently dropping a column
+		// out of the recognised set.
+		{"SeverityText", "SeverityText", true},
+		{"SeverityNumber", "SeverityNumber", true},
+		{"ServiceName", "ServiceName", true},
+		{"ScopeName", "ScopeName", true},
+		{"ScopeVersion", "ScopeVersion", true},
+		{"EventName", "EventName", true},
+		{"TraceId", "TraceId", true},
+		{"SpanId", "SpanId", true},
+		{"TraceFlags", "TraceFlags", true},
+
+		// Not recognised: Map-typed columns (users group by keys
+		// inside those maps, never by the map as a whole) and the
+		// Body / Timestamp / table-name slots (never legitimate
+		// group-by targets).
+		{"ResourceAttributes", "", false},
+		{"LogAttributes", "", false},
+		{"ScopeAttributes", "", false},
+		{"Body", "", false},
+		{"Timestamp", "", false},
+
+		// Stream attribute keys (live inside ResourceAttributes) fall
+		// through to the attribute-map lookup.
+		{"job", "", false},
+		{"namespace", "", false},
+
+		// Empty label name short-circuits to a no-match so a
+		// custom-schema user who blanks out a column doesn't snag an
+		// empty-label query.
+		{"", "", false},
+	}
+	for _, c := range cases {
+		got, ok := topLevelLogColumnFor(c.label, s)
+		if ok != c.match || got != c.want {
+			t.Errorf("topLevelLogColumnFor(%q) = (%q, %v); want (%q, %v)",
+				c.label, got, ok, c.want, c.match)
+		}
+	}
+}
+
+// TestTopLevelLogColumnFor_CustomSchema verifies the helper reads from
+// the schema fields rather than a static name allow-list — a custom
+// schema that renames SeverityColumn (e.g. an ingestion pipeline that
+// writes severity to a `level_text` column instead) automatically gets
+// the new name recognised here, with the old default name no longer
+// matching.
+func TestTopLevelLogColumnFor_CustomSchema(t *testing.T) {
+	s := schema.DefaultOTelLogs()
+	s.SeverityColumn = "level_text"
+
+	if got, ok := topLevelLogColumnFor("level_text", s); !ok || got != "level_text" {
+		t.Errorf("topLevelLogColumnFor(level_text) on custom schema = (%q, %v); want (level_text, true)", got, ok)
+	}
+	if got, ok := topLevelLogColumnFor("SeverityText", s); ok {
+		t.Errorf("topLevelLogColumnFor(SeverityText) on custom schema = (%q, %v); want (\"\", false) — schema field renamed away from default", got, ok)
+	}
+}
+
+// TestTopLevelLogColumnFor_BlankedFieldNoMatch pins the "empty schema
+// field doesn't snag an empty-label query" invariant — a custom schema
+// that blanks out EventNameColumn must not collapse `by("")` lookups
+// into a spurious EventName match.
+func TestTopLevelLogColumnFor_BlankedFieldNoMatch(t *testing.T) {
+	s := schema.DefaultOTelLogs()
+	s.EventNameColumn = ""
+
+	if got, ok := topLevelLogColumnFor("", s); ok {
+		t.Errorf("topLevelLogColumnFor(\"\") with blanked EventName = (%q, %v); want (\"\", false)", got, ok)
+	}
+}
+
+// TestTopLevelColumnsReferencedBy pins the order-preserving,
+// dedup-on-column-name behaviour the inner identity wrap depends on
+// for a deterministic map-literal shape.
+func TestTopLevelColumnsReferencedBy(t *testing.T) {
+	s := schema.DefaultOTelLogs()
+
+	got := topLevelColumnsReferencedBy([]string{"SeverityText", "job", "ServiceName", "SeverityText", "namespace"}, s)
+	want := []string{"SeverityText", "ServiceName"}
+
+	if len(got) != len(want) {
+		t.Fatalf("topLevelColumnsReferencedBy len = %d (%v); want %d (%v)", len(got), got, len(want), want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("topLevelColumnsReferencedBy[%d] = %q; want %q", i, got[i], want[i])
+		}
+	}
+
+	if got := topLevelColumnsReferencedBy(nil, s); got != nil {
+		t.Errorf("topLevelColumnsReferencedBy(nil) = %v; want nil", got)
+	}
+	if got := topLevelColumnsReferencedBy([]string{"job", "namespace"}, s); len(got) != 0 {
+		t.Errorf("topLevelColumnsReferencedBy(no-top-level) = %v; want empty", got)
+	}
+}

--- a/internal/logql/vector_aggregation.go
+++ b/internal/logql/vector_aggregation.go
@@ -27,7 +27,19 @@ func lowerVectorAggregation(e *syntax.VectorAggregationExpr, s schema.Logs, lc l
 	if !ok {
 		return nil, fmt.Errorf("logql: vector-aggregation inner is not an Expr (%T)", e.Left)
 	}
-	input, err := lower(innerExpr, s, lc)
+	// Thread the outer by-clause labels down so the inner range
+	// aggregation's identity wrap surfaces any top-level OTel-CH
+	// scalar columns this aggregate groups by (SeverityText,
+	// ServiceName, ...). The `without` clause is intentionally NOT
+	// plumbed — exclusion semantics don't reference specific columns
+	// to surface, they only strip keys from the existing identity.
+	// See [lowerCtx.OuterByLabels] and [withDetectedLevelAndColumns]
+	// for the consumer side.
+	innerLc := lc
+	if e.Grouping != nil && !e.Grouping.Without && len(e.Grouping.Groups) > 0 {
+		innerLc = lc.withOuterByLabels(e.Grouping.Groups)
+	}
+	input, err := lower(innerExpr, s, innerLc)
 	if err != nil {
 		return nil, err
 	}
@@ -151,6 +163,23 @@ func levelAwareGroupKey(label string, s schema.Logs) chplan.Expr {
 			Key: &chplan.LitString{V: detectedLevelLabel},
 		}
 	}
+	if col, ok := topLevelLogColumnFor(label, s); ok {
+		// Top-level OTel-CH columns (SeverityText, ServiceName, ...)
+		// surface in the post-RangeWindow scope only as keys inside
+		// the augmented identity map (see [withDetectedLevel] — the
+		// inner range Project inflates the map with these columns when
+		// the outer by-clause references them via OuterByLabels). The
+		// outer aggregate reads them back via MapAccess on the column
+		// name, matching the key the wrap wrote. Without this branch
+		// `attributeLookupColumn` would look up the column name in
+		// ResourceAttributes (where it isn't present) and the
+		// aggregate would collapse every row into one
+		// `{<col>:""}` series — the bug task #218 fixed.
+		return &chplan.MapAccess{
+			Map: &chplan.ColumnRef{Name: s.ResourceAttributesColumn},
+			Key: &chplan.LitString{V: col},
+		}
+	}
 	return attributeLookupColumn(s.ResourceAttributesColumn, label)
 }
 
@@ -166,6 +195,17 @@ func levelAwareGroupKey(label string, s schema.Logs) chplan.Expr {
 func levelAwareRangeGroupKey(label string, s schema.Logs) chplan.Expr {
 	if isDetectedLevelGroupingLabel(label) {
 		return detectedLevelExpr(s)
+	}
+	if col, ok := topLevelLogColumnFor(label, s); ok {
+		// At the inner range-aggregation layer the top-level OTel
+		// column (SeverityText, ServiceName, ...) is still in scope —
+		// the inner Project reads directly from the Scan — so the
+		// group-key resolves to a plain ColumnRef rather than a map
+		// lookup. The outer aggregation's
+		// [levelAwareGroupKey] hops through the augmented
+		// ResourceAttributes map instead, since the post-RangeWindow
+		// scope only exposes the identity map.
+		return topLevelColumnRef(col)
 	}
 	return attributeLookupColumn(s.ResourceAttributesColumn, label)
 }

--- a/internal/logql/vector_aggregation_test.go
+++ b/internal/logql/vector_aggregation_test.go
@@ -146,3 +146,127 @@ func TestLowerVectorAggregationRangeBucketedHonoursMatrixInner(t *testing.T) {
 		t.Fatalf("last GroupBy ColumnRef.Name = %q, want %q", last.Name, "anchor_ts")
 	}
 }
+
+// TestLowerVectorAggregationByTopLevelColumn pins the fix for task #218:
+// `sum by (SeverityText) (rate({}[5m]))` (and the same pattern for any
+// top-level OTel-CH scalar column the schema names) must produce one
+// output series per distinct column value rather than collapsing every
+// row into a single `{SeverityText:""}` series.
+//
+// Pre-fix flow: `levelAwareGroupKey("SeverityText", s)` returned
+// `attributeLookupColumn(ResourceAttributes, "SeverityText")` — a Map
+// access against a key that is never present (SeverityText is a
+// top-level otel_logs column, not a key inside ResourceAttributes), so
+// the outer Aggregate's GROUP BY column was always the empty string.
+//
+// Post-fix flow: the inner range Project's `withDetectedLevelAndColumns`
+// wrap inflates the augmented identity map with a synthesised
+// `SeverityText` key carrying `toString(SeverityText)`, AND the outer
+// Aggregate's GROUP BY reads `ResourceAttributes['SeverityText']` from
+// that map. The two layers agree on the key, so distinct severities
+// produce distinct rows.
+//
+// This test walks the lowered plan and asserts the augmented-identity
+// map carries the `SeverityText` synthesised key. The TXTAR fixture
+// `test/spec/logql/agg_by_severity.txtar` exercises the end-to-end
+// chDB round-trip (4 distinct severity rows survive the Aggregate).
+func TestLowerVectorAggregationByTopLevelColumn(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelLogs()
+	const query = `sum by (SeverityText) (rate({job="api"}[5m]))`
+	expr, err := syntax.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+
+	plan, err := lower(expr, s, lowerCtx{})
+	if err != nil {
+		t.Fatalf("lower(%q): %v", query, err)
+	}
+
+	// Walk down to the inner range Project to find the augmented map.
+	// Plan shape: Project -> Aggregate -> RangeWindow -> Project (identity wrap).
+	outerProj, ok := plan.(*chplan.Project)
+	if !ok {
+		t.Fatalf("plan = %T, want *chplan.Project", plan)
+	}
+	agg, ok := outerProj.Input.(*chplan.Aggregate)
+	if !ok {
+		t.Fatalf("outer.Input = %T, want *chplan.Aggregate", outerProj.Input)
+	}
+	rw, ok := agg.Input.(*chplan.RangeWindow)
+	if !ok {
+		t.Fatalf("Aggregate.Input = %T, want *chplan.RangeWindow", agg.Input)
+	}
+	innerProj, ok := rw.Input.(*chplan.Project)
+	if !ok {
+		t.Fatalf("RangeWindow.Input = %T, want *chplan.Project", rw.Input)
+	}
+
+	// The first projection is the identity wrap (aliased to
+	// ResourceAttributes). It must be a mapConcat whose synthesised
+	// inner map literal carries a `SeverityText` key.
+	if len(innerProj.Projections) == 0 {
+		t.Fatalf("inner Project has no projections")
+	}
+	wrap, ok := innerProj.Projections[0].Expr.(*chplan.FuncCall)
+	if !ok || wrap.Name != "mapConcat" {
+		t.Fatalf("inner identity projection is %T (name %q), want *chplan.FuncCall(mapConcat)", innerProj.Projections[0].Expr, funcName(innerProj.Projections[0].Expr))
+	}
+	if len(wrap.Args) < 2 {
+		t.Fatalf("mapConcat has %d args, want >= 2", len(wrap.Args))
+	}
+	mapFilter, ok := wrap.Args[1].(*chplan.FuncCall)
+	if !ok || mapFilter.Name != "mapFilter" {
+		t.Fatalf("mapConcat.Args[1] = %T (%q), want *chplan.FuncCall(mapFilter)", wrap.Args[1], funcName(wrap.Args[1]))
+	}
+	if len(mapFilter.Args) < 2 {
+		t.Fatalf("mapFilter has %d args, want >= 2", len(mapFilter.Args))
+	}
+	synthMap, ok := mapFilter.Args[1].(*chplan.FuncCall)
+	if !ok || synthMap.Name != "map" {
+		t.Fatalf("mapFilter.Args[1] = %T (%q), want *chplan.FuncCall(map)", mapFilter.Args[1], funcName(mapFilter.Args[1]))
+	}
+
+	// Scan the synthesised map's args for a `SeverityText` key. The
+	// map literal alternates key/value, so we walk even indices.
+	var foundSeverityText bool
+	for i := 0; i+1 < len(synthMap.Args); i += 2 {
+		key, ok := synthMap.Args[i].(*chplan.LitString)
+		if !ok {
+			continue
+		}
+		if key.V == s.SeverityColumn {
+			foundSeverityText = true
+			break
+		}
+	}
+	if !foundSeverityText {
+		t.Fatalf("synthesised identity map missing %q key — outer by-clause cannot resolve to the column value (task #218 regression)", s.SeverityColumn)
+	}
+
+	// Outer Aggregate's GROUP BY reads from ResourceAttributes via
+	// the synthesised key.
+	if len(agg.GroupBy) != 1 {
+		t.Fatalf("outer Aggregate.GroupBy length = %d, want 1", len(agg.GroupBy))
+	}
+	gkey, ok := agg.GroupBy[0].(*chplan.MapAccess)
+	if !ok {
+		t.Fatalf("outer Aggregate.GroupBy[0] = %T, want *chplan.MapAccess", agg.GroupBy[0])
+	}
+	key, ok := gkey.Key.(*chplan.LitString)
+	if !ok || key.V != s.SeverityColumn {
+		t.Fatalf("outer Aggregate.GroupBy[0].Key = %v, want LitString(%q)", gkey.Key, s.SeverityColumn)
+	}
+}
+
+// funcName extracts the Name field from a FuncCall expression for
+// diagnostic messages. Returns the empty string when expr isn't a
+// FuncCall.
+func funcName(expr chplan.Expr) string {
+	if fc, ok := expr.(*chplan.FuncCall); ok {
+		return fc.Name
+	}
+	return ""
+}

--- a/test/e2e/playwright/compose_grafana_smoke.spec.ts
+++ b/test/e2e/playwright/compose_grafana_smoke.spec.ts
@@ -344,6 +344,22 @@ test('compose: home, drilldown app, and every provisioned dashboard load without
   const partitionFailures = await driveCerberusQLPartition(page, baseURL);
   failures.push(...partitionFailures);
 
+  // 7. LogQL by-severity partition sweep.
+  //
+  //    The otel-fixture-explorer dashboard's "Log volume by severity"
+  //    panel fires `sum by (SeverityText) (rate({service_name=~".+"}
+  //    [5m]))`. SeverityText is a top-level otel_logs column, not a
+  //    key inside ResourceAttributes — pre-fix, the lowering looked it
+  //    up as `ResourceAttributes['SeverityText']` and the panel
+  //    collapsed every row into a single anonymous series. Task #218
+  //    plumbed the outer by-clause down so the inner range identity
+  //    surfaces SeverityText into the augmented map. The sweep asserts
+  //    the panel's response renders ≥ 2 distinct severity legend
+  //    entries (compose seeds INFO / WARN / ERROR rows, so a healthy
+  //    stack yields 3).
+  const severityFailures = await driveSeverityPartition(page, baseURL);
+  failures.push(...severityFailures);
+
   if (failures.length > 0) {
     const header = `compose-grafana-smoke caught ${failures.length} failure(s) across ${surfaces.length} surface(s):`;
     const surfaceList = surfaces
@@ -666,6 +682,126 @@ async function driveCerberusQLPartition(
     failures.push(
       `[partition:${panelTitle}] expected ≥ 2 grouped series (cerberus_ql=promql/logql/traceql) but saw ${maxSeries}\n  ` +
         `regression of task #214 — dotted-OTel-key lookup fell back to a single anonymous bucket`,
+    );
+  }
+
+  return failures;
+}
+
+/**
+ * Drive the otel-fixture-explorer → "Log volume by severity" panel and
+ * assert the LogQL `sum by (SeverityText) (rate(...))` lowering returns
+ * at least 2 distinct severity series.
+ *
+ * Pre-fix bug shape (task #218): the LogQL lowering resolved every
+ * outer by-clause label as `ResourceAttributes[<label>]`. SeverityText
+ * is a top-level otel_logs column (not a key inside ResourceAttributes),
+ * so the lookup returned the empty string for every row and the panel
+ * collapsed every severity into a single `{SeverityText:""}` series.
+ * The fix plumbs the outer by-clause down through lowerCtx so the
+ * inner range identity wrap surfaces SeverityText into the augmented
+ * map, and the outer Aggregate reads it back via MapAccess.
+ *
+ * The assertion targets the /api/ds/query response the panel fires:
+ * the JSON envelope's `data.result` array must carry at least 2
+ * entries. The compose seeder writes INFO / WARN / ERROR rows
+ * (test/e2e/seed/cmd/seed/main.go) so a healthy stack yields 3; we
+ * assert ≥ 2 to tolerate a stack where one severity momentarily has
+ * no samples.
+ *
+ * If the panel isn't provisioned in the current stack (compose
+ * variant without the otel-fixture-explorer dashboard) the function
+ * returns cleanly — the dashboard sweep above already covers the
+ * "panel exists" case.
+ */
+async function driveSeverityPartition(
+  page: Page,
+  baseURL: string,
+): Promise<string[]> {
+  const failures: string[] = [];
+
+  // Capture ds/query responses BEFORE navigation so the panel's
+  // initial fetch is in our buffer when the load settles.
+  const captured: { url: string; body: string; status: number }[] = [];
+  const onResponse = async (resp: Response) => {
+    const url = resp.url();
+    if (!url.includes('/api/ds/query')) return;
+    let body = '';
+    try {
+      body = await resp.text();
+    } catch {
+      body = '';
+    }
+    captured.push({ url, body, status: resp.status() });
+  };
+  page.on('response', onResponse);
+
+  try {
+    await page.goto(`${baseURL}/d/otel-fixture-explorer`, {
+      waitUntil: 'domcontentloaded',
+      timeout: 90_000,
+    });
+    await page
+      .waitForLoadState('networkidle', { timeout: 45_000 })
+      .catch(() => {});
+  } finally {
+    page.off('response', onResponse);
+  }
+
+  const panelTitle = 'Log volume by severity';
+  const panelLocator = page.locator(
+    `[data-testid="data-testid Panel header ${panelTitle}"]`,
+  );
+  if ((await panelLocator.count()) === 0) {
+    return failures;
+  }
+
+  // Find a ds/query response whose body references `SeverityText`
+  // (the panel's group-by key). Grafana 11.x stringifies the parsed
+  // LogQL into the response envelope alongside the result, so
+  // `body.includes('SeverityText')` narrows to the panel's request
+  // without parsing the JSON.
+  const panelResponses = captured.filter((c) => c.body.includes('SeverityText'));
+  if (panelResponses.length === 0) {
+    failures.push(
+      `[partition:${panelTitle}] no /api/ds/query response referenced SeverityText — Grafana may have served the panel from cache; rerun with cleared session if seen`,
+    );
+    return failures;
+  }
+
+  let maxSeries = 0;
+  for (const resp of panelResponses) {
+    if (resp.status < 200 || resp.status > 299) {
+      failures.push(
+        `[partition:${panelTitle}] /api/ds/query → ${resp.status}\n  url: ${resp.url}\n  body: ${truncate(resp.body, 600)}`,
+      );
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(resp.body) as {
+        results?: Record<string, { frames?: Array<{ schema?: { fields?: unknown[] } }> }>;
+      };
+      const results = parsed.results ?? {};
+      for (const refID of Object.keys(results)) {
+        const frames = results[refID]?.frames ?? [];
+        if (frames.length > maxSeries) {
+          maxSeries = frames.length;
+        }
+      }
+    } catch (err) {
+      failures.push(
+        `[partition:${panelTitle}] response body is not valid JSON: ${truncate(
+          (err as Error).message,
+          200,
+        )}\n  body: ${truncate(resp.body, 600)}`,
+      );
+    }
+  }
+
+  if (maxSeries < 2) {
+    failures.push(
+      `[partition:${panelTitle}] expected ≥ 2 grouped severity series (INFO/WARN/ERROR seed) but saw ${maxSeries}\n  ` +
+        `regression of task #218 — top-level OTel column lookup collapsed to a single empty-string bucket`,
     );
   }
 

--- a/test/spec/logql/agg_by_severity.txtar
+++ b/test/spec/logql/agg_by_severity.txtar
@@ -1,0 +1,72 @@
+-- query.logql --
+sum by (SeverityText) (rate({job="api"}[5m]))
+-- args --
+[0] string = ""
+[1] string = "SeverityText"
+[2] int64 = 9
+[3] string = "SeverityText"
+[4] float64 = 300
+[5] string = ""
+[6] string = "detected_level"
+[7] string = "trace"
+[8] string = "trc"
+[9] string = "trace"
+[10] string = "debug"
+[11] string = "dbg"
+[12] string = "debug"
+[13] string = "info"
+[14] string = "inf"
+[15] string = "information"
+[16] string = "info"
+[17] string = "warn"
+[18] string = "wrn"
+[19] string = "warning"
+[20] string = "warn"
+[21] string = "error"
+[22] string = "err"
+[23] string = "error"
+[24] string = "critical"
+[25] string = "critical"
+[26] string = "fatal"
+[27] string = "fatal"
+[28] string = "SeverityText"
+[29] int64 = 1
+[30] string = "job"
+[31] string = "api"
+[32] string = "SeverityText"
+-- sql --
+SELECT ? AS `MetricName`, map(?, `gkey_0`) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`[?] AS `gkey_0`, sum(`Value`) AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`)), ?, toString(`SeverityText`)))) AS `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1) GROUP BY `ResourceAttributes`[?])
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, SeverityText, ResourceAttributes) VALUES
+    (toDateTime64('2025-12-31 23:58:00', 9), 'a', 'INFO',  map('job', 'api')),
+    (toDateTime64('2025-12-31 23:59:00', 9), 'b', 'INFO',  map('job', 'api')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'c', 'INFO',  map('job', 'api')),
+    (toDateTime64('2025-12-31 23:58:00', 9), 'd', 'WARN',  map('job', 'api')),
+    (toDateTime64('2025-12-31 23:59:00', 9), 'e', 'WARN',  map('job', 'api')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'f', 'WARN',  map('job', 'api')),
+    (toDateTime64('2025-12-31 23:58:00', 9), 'g', 'ERROR', map('job', 'api')),
+    (toDateTime64('2025-12-31 23:59:00', 9), 'h', 'ERROR', map('job', 'api')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'i', 'ERROR', map('job', 'api')),
+    (toDateTime64('2025-12-31 23:58:00', 9), 'j', 'DEBUG', map('job', 'api')),
+    (toDateTime64('2025-12-31 23:59:00', 9), 'k', 'DEBUG', map('job', 'api')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'l', 'DEBUG', map('job', 'api'));
+-- expected_rows --
+[
+  ["", {"SeverityText": "DEBUG"}, "2026-01-01T00:00:01Z", 0.01],
+  ["", {"SeverityText": "ERROR"}, "2026-01-01T00:00:01Z", 0.01],
+  ["", {"SeverityText": "INFO"}, "2026-01-01T00:00:01Z", 0.01],
+  ["", {"SeverityText": "WARN"}, "2026-01-01T00:00:01Z", 0.01]
+]
+-- chplan --
+Project ["" AS MetricName, map("SeverityText", gkey_0) AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+  Aggregate groupBy=[ResourceAttributes["SeverityText"] AS gkey_0] funcs=[sum(Value) AS Value]
+    RangeWindow func=log_rate range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
+      Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText)), "SeverityText", toString(SeverityText)))) AS ResourceAttributes, Timestamp, 1 AS Value]
+        Filter predicate=(ResourceAttributes["job"] = "api")
+          Scan(otel_logs)


### PR DESCRIPTION
## Summary

`sum by (SeverityText) (rate({...}[5m]))` and every Log volume / Log rate dashboard panel using a top-level OTel-CH column in the by-clause collapsed every row into one `{SeverityText:""}` series. `levelAwareGroupKey` resolved the outer label as `ResourceAttributes['SeverityText']` — but SeverityText is a top-level `otel_logs` column, not a key inside the `ResourceAttributes` Map.

## Fix

- New `internal/logql/top_level_columns.go` resolves a label against the schema's named scalar columns (SeverityText, SeverityNumber, ServiceName, ScopeName/Version, EventName, TraceId, SpanId, TraceFlags) without hardcoding a name allow-list — a custom schema that renames `SeverityColumn` automatically gets the new name recognised.
- New `lowerCtx.OuterByLabels` plumbs the outer aggregation's by-clause labels down into the inner range aggregation's identity Project.
- `withDetectedLevelAndColumns` inflates the augmented identity map with one synthesised key per referenced top-level column (`map('detected_level', ..., 'SeverityText', toString(SeverityText), ...)`), gated by the existing `mapFilter(v != '')` so empty-column rows don't gain spurious keys.
- `levelAwareGroupKey` (outer) and `levelAwareRangeGroupKey` (inner) recognise top-level columns: the outer reads via `MapAccess(ResourceAttributes, <col>)`; the inner uses a plain `ColumnRef` since the column is still in scope above the Scan.
- `without` clauses are unchanged — exclusion semantics don't reference specific columns, so `OuterByLabels` stays empty and bare-rate identity stays lean.

## Test plan

- [x] `internal/logql/top_level_columns_test.go` — pins the helper's recognised set, custom-schema rename, and blank-field-no-match invariants.
- [x] `internal/logql/vector_aggregation_test.go::TestLowerVectorAggregationByTopLevelColumn` — pins the chplan shape: inner identity map carries `SeverityText`, outer Aggregate reads it via `MapAccess`.
- [x] `test/spec/logql/agg_by_severity.txtar` — chDB round-trip: INFO/WARN/ERROR/DEBUG seed → 4 distinct severity series survive (pre-fix: 1 collapsed `{SeverityText:""}` row).
- [x] `test/e2e/playwright/compose_grafana_smoke.spec.ts::driveSeverityPartition` — asserts the otel-fixture-explorer "Log volume by severity" panel renders >=2 distinct severity series end-to-end through Grafana.
- [x] Existing 4587 unit + spec + chdb tests pass — no regressions on bare `rate({}[5m])`, `by(level)`, `without(...)`, unwrap, parser-stage, or nested-aggregation flows.

## Notes

The fix only surfaces columns referenced by an *outer by-clause* — bare `rate({}[5m])` keeps its existing lean identity (detected_level only), so series cardinality at the wire doesn't change for queries that don't ask for it.

Inner-aggregation by-clauses (`sum(sum by (job) (rate(...)))`) that explicitly drop a top-level column behave per reference Loki — the column is gone after the inner aggregate, and the outer by-clause sees an empty key. No new semantic divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)