### PR TITLE
fix(promql): fan out classic-histogram _bucket selector to per-le Sample rows (#216)

### DIFF
--- a/internal/promql/histogram_bucket.go
+++ b/internal/promql/histogram_bucket.go
@@ -1,0 +1,233 @@
+package promql
+
+import (
+	"strings"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// bucketSuffix is the Prometheus convention for classic-histogram bucket
+// companion series — `<base>_bucket`. The OTel-CH classic histogram row
+// instead stores one row per observation under the BARE base name with
+// parallel `BucketCounts` × `ExplicitBounds` arrays, so a bare selector of
+// `<X>_bucket{le="0.5"}` must fan out the array into one Sample-shape row
+// per bucket boundary with a synthesized `le` label.
+const bucketSuffix = "_bucket"
+
+// isClassicBucketSelector reports whether the metric name is a
+// `<base>_bucket` companion that should be routed through the histogram
+// table with per-bucket fan-out. Returns the bare base name on a hit.
+//
+// Mirrors the precedent established by `_count` / `_sum` companion
+// routing (schema.Metrics.HistogramCompanionColumn) and the existing
+// `_bucket` matcher-strip done by `stripBucketSuffix` on the
+// histogram_quantile path. The bucket case is structurally different
+// from `_count` / `_sum` — those project a single column as `Value`,
+// while `_bucket` fans the array into N rows per source row — so the
+// helper lives next to the fan-out wrapper rather than as another
+// branch in HistogramCompanionColumn.
+func isClassicBucketSelector(metricName string, s schema.Metrics) (bare string, ok bool) {
+	if metricName == "" {
+		return "", false
+	}
+	if s.HistogramTable == "" {
+		return "", false
+	}
+	if !strings.HasSuffix(metricName, bucketSuffix) {
+		return "", false
+	}
+	return metricName[:len(metricName)-len(bucketSuffix)], true
+}
+
+// splitBucketMatchers partitions a matcher list into:
+//
+//   - scanMatchers: matchers that resolve against scan-row columns
+//     (`__name__`, attribute keys present on the histogram row).
+//     `__name__` is rewritten to the bare base name so the scan filter
+//     resolves against the OTel-CH row's MetricName.
+//   - leMatchers: matchers naming the synthetic `le` label, which only
+//     exists post-fanout. These are applied as a Filter on the canonical
+//     Sample shape AFTER the fan-out Project synthesises `Attributes['le']`.
+//
+// Copy-on-write semantics mirror stripBucketSuffix / rewriteMetricName:
+// the input slice + entries are never mutated.
+func splitBucketMatchers(matchers []*labels.Matcher, bareName string) (scanMatchers, leMatchers []*labels.Matcher) {
+	scanMatchers = make([]*labels.Matcher, 0, len(matchers))
+	for _, m := range matchers {
+		if m.Name == "le" {
+			leMatchers = append(leMatchers, m)
+			continue
+		}
+		if m.Name == model.MetricNameLabel && m.Type == labels.MatchEqual && m.Value != bareName {
+			copied, err := labels.NewMatcher(m.Type, m.Name, bareName)
+			if err != nil {
+				// labels.NewMatcher only fails on regex compile for the
+				// match-regex types; MatchEqual cannot fail. Fall back
+				// to the original matcher so the lowering still produces
+				// a valid plan even on the impossible path.
+				scanMatchers = append(scanMatchers, m)
+				continue
+			}
+			scanMatchers = append(scanMatchers, copied)
+			continue
+		}
+		scanMatchers = append(scanMatchers, m)
+	}
+	return scanMatchers, leMatchers
+}
+
+// wrapHistogramBucketFanout wraps a histogram-table Scan in a two-stage
+// Project that fans every histogram row into N+1 Sample-shape rows — one
+// per `(le, cumulative_count)` pair — where:
+//
+//   - `le` carries the explicit bound for buckets 1..N (rendered as a
+//     decimal string), and `"+Inf"` for the trailing overflow bucket.
+//   - The cumulative count is `arraySum(arraySlice(BucketCounts, 1, i))`
+//     — i.e. observations with value ≤ ExplicitBounds[i], matching the
+//     Prom `_bucket{le=X}` cumulative-counter convention. OTel-CH stores
+//     per-bucket counts (non-cumulative); the slice-sum is what makes
+//     the wire shape Prom-compatible.
+//   - The synthesised `le` label is mapInsert'd onto the row's Attributes
+//     map so downstream `sum by(le) (...)` aggregations see a real
+//     grouping key (just like Prom-native classic-histogram series).
+//
+// The MetricName carries the SUFFIXED name (`<base>_bucket`) so the
+// downstream Sample-row contract surfaces the Prom-visible series name —
+// /api/v1/series and /api/v1/query both round-trip the user's spelling.
+//
+// Plan shape produced (outer-most first):
+//
+//	Project [MetricName='<base>_bucket', Attributes+le, TimeUnix, Value]
+//	  Project [MetricName, Attributes, TimeUnix, ExplicitBounds, BucketCounts,
+//	           arrayJoin(arrayEnumerate(BucketCounts)) AS le_idx]
+//	    Scan(otel_metrics_histogram)
+//
+// The inner arrayJoin fans the row; the outer Project rewrites the
+// canonical Sample columns using the fanned `le_idx`. CH's `arrayJoin`
+// in a SELECT position is the lateral fan-out idiom — equivalent to an
+// ARRAY JOIN clause but expressed at the expression level so we can
+// reuse the existing Project node without introducing a new IR node.
+//
+// `le_idx` is a CH-safe bare identifier (lowercase ASCII + underscore +
+// digits only) so the BareIdent trust contract is satisfied. The name
+// is prefixed `le_` to avoid colliding with any plausible user-supplied
+// label (Prom forbids labels starting with `__` for the public range and
+// reserved-internal range; `le_idx` falls outside both).
+func wrapHistogramBucketFanout(scanOrFilter chplan.Node, suffixedName string, s schema.Metrics) chplan.Node {
+	// Inner Project — pass the histogram row's identity columns through
+	// and add the fanned bucket index via arrayJoin. Every output row
+	// carries one (MetricName, Attributes, TimeUnix, ExplicitBounds,
+	// BucketCounts, le_idx) tuple — the same row repeats N+1 times,
+	// once per BucketCounts entry, with le_idx running 1..length(BucketCounts).
+	fanout := &chplan.Project{
+		Input: scanOrFilter,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.ColumnRef{Name: s.MetricNameColumn}, Alias: s.MetricNameColumn},
+			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
+			{Expr: &chplan.ColumnRef{Name: s.TimestampColumn}, Alias: s.TimestampColumn},
+			{Expr: &chplan.ColumnRef{Name: s.ExplicitBoundsColumn}, Alias: s.ExplicitBoundsColumn},
+			{Expr: &chplan.ColumnRef{Name: s.BucketCountsColumn}, Alias: s.BucketCountsColumn},
+			{
+				Expr: &chplan.FuncCall{
+					Name: "arrayJoin",
+					Args: []chplan.Expr{
+						&chplan.FuncCall{
+							Name: "arrayEnumerate",
+							Args: []chplan.Expr{&chplan.ColumnRef{Name: s.BucketCountsColumn}},
+						},
+					},
+				},
+				Alias: bucketIdxAlias,
+			},
+		},
+	}
+
+	// Outer Project — synthesize the canonical Sample shape with the
+	// suffixed metric name + the `le` label baked into Attributes + the
+	// cumulative bucket count as Value.
+	//
+	//   le_str = if(le_idx > length(ExplicitBounds), '+Inf',
+	//               toString(ExplicitBounds[le_idx]))
+	//
+	// BucketCounts has length = length(ExplicitBounds)+1 — the trailing
+	// entry is the +Inf overflow bucket. The branch on `le_idx >
+	// length(ExplicitBounds)` selects the +Inf label for that last row
+	// and reads from ExplicitBounds for every other row.
+	//
+	//   cum    = arraySum(arraySlice(BucketCounts, 1, le_idx))
+	//
+	// CH's arraySlice(arr, 1, N) returns the first N elements; arraySum
+	// gives the cumulative count for observations with value ≤
+	// ExplicitBounds[le_idx]. Wrapped in toFloat64 so the canonical
+	// Sample-row Value column stays Float64 (BucketCounts is UInt64).
+	leIdx := &chplan.BareIdent{Name: bucketIdxAlias}
+	lengthBounds := &chplan.FuncCall{
+		Name: "length",
+		Args: []chplan.Expr{&chplan.ColumnRef{Name: s.ExplicitBoundsColumn}},
+	}
+	boundAtIdx := &chplan.Subscript{
+		Container: &chplan.ColumnRef{Name: s.ExplicitBoundsColumn},
+		Key:       leIdx,
+	}
+	leStr := &chplan.FuncCall{
+		Name: "if",
+		Args: []chplan.Expr{
+			&chplan.Binary{Op: chplan.OpGt, Left: leIdx, Right: lengthBounds},
+			&chplan.LitString{V: "+Inf"},
+			&chplan.FuncCall{
+				Name: "toString",
+				Args: []chplan.Expr{boundAtIdx},
+			},
+		},
+	}
+	mergedAttrs := &chplan.FuncCall{
+		Name: "mapConcat",
+		Args: []chplan.Expr{
+			&chplan.ColumnRef{Name: s.AttributesColumn},
+			&chplan.FuncCall{
+				Name: "map",
+				Args: []chplan.Expr{
+					&chplan.LitString{V: "le"},
+					leStr,
+				},
+			},
+		},
+	}
+	cumCount := &chplan.FuncCall{
+		Name: "toFloat64",
+		Args: []chplan.Expr{
+			&chplan.FuncCall{
+				Name: "arraySum",
+				Args: []chplan.Expr{
+					&chplan.FuncCall{
+						Name: "arraySlice",
+						Args: []chplan.Expr{
+							&chplan.ColumnRef{Name: s.BucketCountsColumn},
+							&chplan.LitInt{V: 1},
+							leIdx,
+						},
+					},
+				},
+			},
+		},
+	}
+	return &chplan.Project{
+		Input: fanout,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.LitString{V: suffixedName}, Alias: s.MetricNameColumn},
+			{Expr: mergedAttrs, Alias: s.AttributesColumn},
+			{Expr: &chplan.ColumnRef{Name: s.TimestampColumn}, Alias: s.TimestampColumn},
+			{Expr: cumCount, Alias: s.ValueColumn},
+		},
+	}
+}
+
+// bucketIdxAlias is the CH-safe bare identifier used to surface the
+// fanned `arrayJoin(arrayEnumerate(BucketCounts))` value into the outer
+// Project's expressions. Lowercase ASCII / underscore / digit shape
+// satisfies the BareIdent trust contract (see chplan.BareIdent doc).
+const bucketIdxAlias = "le_idx"

--- a/internal/promql/histogram_bucket_test.go
+++ b/internal/promql/histogram_bucket_test.go
@@ -1,0 +1,259 @@
+package promql
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestLower_HistogramBucket_RoutesToHistogramTable pins the classic-
+// histogram `_bucket` companion fan-out at the lowering layer.
+//
+// PR #645 routed `_count` / `_sum` companions to the histogram table.
+// `_bucket` carries different semantics — the data lives in the
+// `BucketCounts` × `ExplicitBounds` arrays on the same row — so the
+// rewrite arrayJoin's over the array to emit one Sample-shape row per
+// bucket boundary, with a synthesized `le=<bound>` label baked into
+// the Attributes map and a cumulative count as the Value.
+//
+// Until this PR a bare `<X>_bucket` selector against the OTel-CH layout
+// returned zero series: the suffixed name had no rows on either the
+// gauge or sum tables, and `/api/v1/query_exemplars`-style routing was
+// scoped to the `_count` / `_sum` shapes. This regression broke every
+// classic-histogram bucket panel that Grafana renders against cerberus.
+//
+// The assertions check the structural pieces of the rewrite — Scan
+// targets the histogram table, MetricName matcher resolves against the
+// bare base name, and the fan-out Project carries the arrayJoin / mapConcat /
+// arraySlice chain that turns one histogram row into N+1 Sample rows.
+func TestLower_HistogramBucket_RoutesToHistogramTable(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{})
+
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{name: "bare", query: `http_server_request_duration_bucket`},
+		{name: "with_le_filter", query: `http_server_request_duration_bucket{le="0.5"}`},
+		{name: "rate_wrapped", query: `rate(http_server_request_duration_bucket[5m])`},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", tc.query, err)
+			}
+			plan, err := Lower(context.Background(), expr, s)
+			if err != nil {
+				t.Fatalf("Lower(%q): %v", tc.query, err)
+			}
+
+			scans := collectScans(plan)
+			if len(scans) != 1 {
+				t.Fatalf("want 1 Scan, got %d", len(scans))
+			}
+			if scans[0].Table != s.HistogramTable {
+				t.Fatalf("Scan.Table = %q; want %q (histogram table)",
+					scans[0].Table, s.HistogramTable)
+			}
+
+			// The bare metric name (suffix stripped) must drive the
+			// scan-side MetricName filter. The suffixed name must NOT
+			// appear in any predicate.
+			if !planReferencesMetricName(plan, "http_server_request_duration") {
+				t.Fatalf("plan does not filter on bare MetricName='http_server_request_duration'")
+			}
+			if planReferencesMetricName(plan, "http_server_request_duration_bucket") {
+				t.Fatalf("plan still references the `_bucket`-suffixed MetricName — rewrite did not strip the suffix")
+			}
+
+			// Emit SQL and assert the fan-out pieces are present.
+			sql, _, err := chsql.Emit(context.Background(), plan)
+			if err != nil {
+				t.Fatalf("Emit: %v", err)
+			}
+			for _, want := range []string{
+				"arrayJoin(arrayEnumerate(`BucketCounts`))",
+				"mapConcat(`Attributes`, map(",
+				"arraySlice(`BucketCounts`",
+				"if((le_idx > length(`ExplicitBounds`))",
+			} {
+				if !strings.Contains(sql, want) {
+					t.Errorf("emitted SQL missing fan-out fragment %q\nSQL: %s", want, sql)
+				}
+			}
+		})
+	}
+}
+
+// TestLower_HistogramBucket_NoHistogramTable verifies the fan-out is a
+// no-op when the schema disables the histogram table. Mirrors the
+// `_count` / `_sum` companion fallback in
+// TestLower_HistogramCompanion_NoHistogramTable.
+func TestLower_HistogramBucket_NoHistogramTable(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+	s.HistogramTable = ""
+	p := parser.NewParser(parser.Options{})
+
+	expr, err := p.ParseExpr(`rate(http_server_request_duration_bucket[5m])`)
+	if err != nil {
+		t.Fatalf("ParseExpr: %v", err)
+	}
+	plan, err := Lower(context.Background(), expr, s)
+	if err != nil {
+		t.Fatalf("Lower: %v", err)
+	}
+	scans := collectScans(plan)
+	if len(scans) != 1 {
+		t.Fatalf("want 1 Scan, got %d", len(scans))
+	}
+	// With no histogram table, the `_bucket`-suffixed name falls
+	// through to the sum-table routing — TableFor treats `_bucket` as
+	// a counter-shape suffix. The Scan must NOT target the (now
+	// empty) histogram table.
+	if scans[0].Table == "" {
+		t.Fatalf("Scan.Table is empty — fallback routing did not pick the sum table")
+	}
+	// Suffixed name stays as-is on the fallback path; there's no
+	// fan-out, and no Project wrapping the Scan with the bucket-fanout
+	// arrayJoin shape.
+	if !planReferencesMetricName(plan, "http_server_request_duration_bucket") {
+		t.Fatalf("fallback plan should still reference the `_bucket`-suffixed MetricName")
+	}
+}
+
+// TestLower_HistogramBucket_EmittedShape_CumulativeAndPlusInf pins the
+// emitted plan's bucket fan-out expressions structurally — the `le`
+// label is built from `if(le_idx > length(ExplicitBounds), '+Inf',
+// toString(ExplicitBounds[le_idx]))` and the cumulative count is
+// `toFloat64(arraySum(arraySlice(BucketCounts, 1, le_idx)))`. The
+// Prom wire-shape contract for `_bucket` series requires both: the
+// trailing `+Inf` bucket, and CUMULATIVE counts (per Prom's
+// classic-histogram convention) — OTel-CH stores per-bucket counts.
+func TestLower_HistogramBucket_EmittedShape_CumulativeAndPlusInf(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{})
+
+	expr, err := p.ParseExpr(`http_server_request_duration_bucket`)
+	if err != nil {
+		t.Fatalf("ParseExpr: %v", err)
+	}
+	plan, err := Lower(context.Background(), expr, s)
+	if err != nil {
+		t.Fatalf("Lower: %v", err)
+	}
+	sql, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	// Pin the precise CH idiom for `+Inf` synthesis on the trailing
+	// bucket — the only mechanism that lets a Prom client read the
+	// histogram's total observation count through `_bucket{le="+Inf"}`.
+	want := "if((le_idx > length(`ExplicitBounds`)), ?, toString(`ExplicitBounds`[le_idx]))"
+	if !strings.Contains(sql, want) {
+		t.Errorf("emitted SQL missing +Inf branch %q\nSQL: %s", want, sql)
+	}
+	// Pin the cumulative-count Value expression. `arraySlice(arr, 1, n)`
+	// returns the first n elements; `arraySum` of that gives the
+	// cumulative count for observations with value ≤ the bucket's upper
+	// edge — matching Prom's `_bucket{le=X}` cumulative-counter shape.
+	if !strings.Contains(sql, "toFloat64(arraySum(arraySlice(`BucketCounts`, ?, le_idx)))") {
+		t.Errorf("emitted SQL missing cumulative-count expression\nSQL: %s", sql)
+	}
+}
+
+// TestLower_HistogramBucket_PlanShape walks the produced plan tree and
+// asserts the structural layering — Scan → Filter → fan-out Project →
+// canonical Sample Project. The chplan IR snapshot for the txtar
+// fixture pins the same shape; this Go test pins it at the unit-test
+// layer so a refactor in lower.go that drops the fan-out shows up
+// immediately.
+func TestLower_HistogramBucket_PlanShape(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{})
+
+	expr, err := p.ParseExpr(`rate(http_server_request_duration_bucket[5m])`)
+	if err != nil {
+		t.Fatalf("ParseExpr: %v", err)
+	}
+	plan, err := Lower(context.Background(), expr, s)
+	if err != nil {
+		t.Fatalf("Lower: %v", err)
+	}
+
+	// Find the canonical (outer) bucket-fanout Project — its
+	// MetricName projection is a LitString with the `_bucket` suffix.
+	var canonical *chplan.Project
+	var walk func(n chplan.Node)
+	walk = func(n chplan.Node) {
+		if n == nil {
+			return
+		}
+		if p, ok := n.(*chplan.Project); ok {
+			for _, proj := range p.Projections {
+				if proj.Alias == s.MetricNameColumn {
+					if lit, ok := proj.Expr.(*chplan.LitString); ok && lit.V == "http_server_request_duration_bucket" {
+						canonical = p
+						return
+					}
+				}
+			}
+		}
+		for _, c := range n.Children() {
+			if canonical != nil {
+				return
+			}
+			walk(c)
+		}
+	}
+	walk(plan)
+	if canonical == nil {
+		t.Fatal("plan has no Project that aliases the `_bucket` suffixed name on MetricName")
+	}
+
+	// The canonical Project's Input must itself be a Project (the
+	// arrayJoin fan-out layer). That inner Project must reference
+	// `arrayJoin(arrayEnumerate(BucketCounts))` aliased as `le_idx`.
+	inner, ok := canonical.Input.(*chplan.Project)
+	if !ok {
+		t.Fatalf("canonical Project Input is %T; want *chplan.Project (the fan-out layer)", canonical.Input)
+	}
+	found := false
+	for _, proj := range inner.Projections {
+		if proj.Alias != bucketIdxAlias {
+			continue
+		}
+		fc, ok := proj.Expr.(*chplan.FuncCall)
+		if !ok || fc.Name != "arrayJoin" {
+			continue
+		}
+		if len(fc.Args) != 1 {
+			continue
+		}
+		inner2, ok := fc.Args[0].(*chplan.FuncCall)
+		if !ok || inner2.Name != "arrayEnumerate" {
+			continue
+		}
+		found = true
+		break
+	}
+	if !found {
+		t.Fatalf("fan-out Project has no arrayJoin(arrayEnumerate(BucketCounts)) AS le_idx projection: %+v", inner.Projections)
+	}
+}

--- a/internal/promql/histogram_quantile_empty_test.go
+++ b/internal/promql/histogram_quantile_empty_test.go
@@ -1,0 +1,94 @@
+package promql
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestHistogramQuantile_EmptyInput_DropsRow pins task #216's N6
+// regression: when the underlying histogram has zero matching rows,
+// `histogram_quantile(phi, sum by(le)(rate(<X>_bucket[r])))` must
+// return EMPTY across the entire phi range — not a synthesised default
+// quantile (the user-visible "4.75 with metric:{}" wire shape).
+//
+// The aggregated lowering (`lowerHistogramQuantileAgg`) sets
+// `DropEmptyOnNoGroup: true` on the inner Aggregate so CH's default
+// "1-row-of-zeros over empty input" for aggregates without GROUP BY
+// is suppressed. The emit-time guard is `WHERE _cerb_n > 0` over a
+// synthesised `count()` companion column. This test pins the guard's
+// presence in the emitted SQL across a representative phi sweep —
+// `phi ∈ {0.0, 0.1, 0.5, 0.95, 1.0}` covers the edge-case branches
+// inside the quantile-interpolation expression (phi=0 → lowest bound,
+// phi=1 → highest bound, mid-range → linear interp).
+//
+// The test runs at the Go-unit-test layer (no chDB build tag) so the
+// guarantee holds on every CI run, not just the chDB-tagged workflow.
+// The semantic round-trip is pinned separately by
+// test/spec/promql/histogram_quantile_agg_empty.txtar (chdb-only).
+func TestHistogramQuantile_EmptyInput_DropsRow(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{})
+
+	for _, phi := range []float64{0.0, 0.1, 0.5, 0.95, 1.0} {
+		phi := phi
+		t.Run(fmt.Sprintf("phi=%.2f", phi), func(t *testing.T) {
+			t.Parallel()
+			query := fmt.Sprintf(
+				`histogram_quantile(%g, sum by (le) (rate(missing_metric_bucket[5m])))`,
+				phi,
+			)
+			expr, err := p.ParseExpr(query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", query, err)
+			}
+			plan, err := Lower(context.Background(), expr, s)
+			if err != nil {
+				t.Fatalf("Lower(%q): %v", query, err)
+			}
+
+			// Walk to the inner Aggregate and assert DropEmptyOnNoGroup.
+			var agg *chplan.Aggregate
+			var walk func(chplan.Node)
+			walk = func(n chplan.Node) {
+				if n == nil || agg != nil {
+					return
+				}
+				if a, ok := n.(*chplan.Aggregate); ok {
+					agg = a
+					return
+				}
+				for _, c := range n.Children() {
+					walk(c)
+				}
+			}
+			walk(plan)
+			if agg == nil {
+				t.Fatalf("no Aggregate node in plan for %q", query)
+			}
+			if !agg.DropEmptyOnNoGroup {
+				t.Fatalf("Aggregate.DropEmptyOnNoGroup = false for %q; histogram_quantile over empty input would emit a default row", query)
+			}
+
+			// The emitted SQL must guard the no-group aggregate with
+			// `_cerb_n > 0` so CH's "1-row-of-zeros" behaviour can't
+			// produce a synthesised quantile out of empty input.
+			sql, _, err := chsql.Emit(context.Background(), plan)
+			if err != nil {
+				t.Fatalf("Emit(%q): %v", query, err)
+			}
+			if !strings.Contains(sql, "`_cerb_n` > 0") {
+				t.Errorf("emitted SQL for %q lacks the empty-input guard `_cerb_n > 0`\nSQL: %s", query, sql)
+			}
+		})
+	}
+}

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -144,9 +144,26 @@ func lowerVectorSelector(v *parser.VectorSelector, s schema.Metrics, ctx lowerCt
 	// the downstream Sample-row contract holds. Mirrors stripBucketSuffix
 	// (PR #637) for the `_bucket` companion, and the exemplars handler's
 	// routing in internal/api/prom/exemplars.go::exemplarsTableFor.
+	//
+	// `<base>_bucket` takes a parallel-but-distinct path: the OTel-CH
+	// histogram row stores per-bucket counts as the `BucketCounts` array
+	// with `ExplicitBounds` carrying the bucket edges. Prom exposes the
+	// same data as N+1 separate series under `<base>_bucket{le=<bound>}`,
+	// so the bare-selector lowering fans the array into N+1 Sample-shape
+	// rows via arrayJoin. See wrapHistogramBucketFanout for the plan
+	// shape. The bucket suffix is detected via isClassicBucketSelector;
+	// the matcher-strip + `le` matcher split happens in splitBucketMatchers.
 	matchers := v.LabelMatchers
 	var companionValueColumn string
-	if bare, col, ok := s.HistogramCompanionColumn(metricName); ok && s.HistogramTable != "" {
+	var bucketSuffixed string
+	var bucketLeMatchers []*labels.Matcher
+	if bareBucket, ok := isClassicBucketSelector(metricName, s); ok {
+		table = s.HistogramTable
+		bucketSuffixed = metricName
+		var scanMatchers []*labels.Matcher
+		scanMatchers, bucketLeMatchers = splitBucketMatchers(matchers, bareBucket)
+		matchers = scanMatchers
+	} else if bare, col, ok := s.HistogramCompanionColumn(metricName); ok && s.HistogramTable != "" {
 		table = s.HistogramTable
 		matchers = rewriteMetricName(matchers, bare)
 		companionValueColumn = col
@@ -159,8 +176,33 @@ func lowerVectorSelector(v *parser.VectorSelector, s schema.Metrics, ctx lowerCt
 	// For the classic-histogram companion path we project the source
 	// column (Count / Sum) as `Value` so downstream nodes still see the
 	// canonical (MetricName, Attributes, TimeUnix, Value) shape.
+	//
+	// For the `_bucket` companion path the fan-out is more involved —
+	// arrayJoin over BucketCounts × ExplicitBounds produces N+1 rows per
+	// source row with the synthetic `le` label baked into Attributes.
+	// Any user-supplied `le` matcher applies AFTER the fan-out as an
+	// outer Filter on `Attributes['le']` (the column doesn't exist on
+	// the raw scan row).
 	var selectorInput chplan.Node = scan
-	if companionValueColumn != "" {
+	switch {
+	case bucketSuffixed != "":
+		// The scan-side filter (non-le matchers) feeds into the
+		// fan-out Project, then the post-fanout filter applies any
+		// `le=<bound>` matcher the user wrote against the synthesized
+		// `Attributes['le']` key.
+		var fanInput chplan.Node = scan
+		if pred != nil {
+			fanInput = &chplan.Filter{Input: scan, Predicate: pred}
+		}
+		selectorInput = wrapHistogramBucketFanout(fanInput, bucketSuffixed, s)
+		if lePred := buildPredicate(bucketLeMatchers, s); lePred != nil {
+			selectorInput = &chplan.Filter{Input: selectorInput, Predicate: lePred}
+		}
+		// `pred` is already baked into the fan-out's input Filter (or
+		// nil when there were no scan-side matchers), so the LWR /
+		// range-vector wrapper below must NOT re-apply it.
+		pred = nil
+	case companionValueColumn != "":
 		selectorInput = wrapHistogramCompanionProject(scan, companionValueColumn, s)
 	}
 

--- a/test/spec/promql/histogram_bucket_companion.txtar
+++ b/test/spec/promql/histogram_bucket_companion.txtar
@@ -1,0 +1,44 @@
+-- query.promql --
+http_server_request_duration_bucket
+-- seed --
+CREATE TABLE otel_metrics_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    BucketCounts Array(UInt64),
+    ExplicitBounds Array(Float64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_histogram VALUES
+    ('http_server_request_duration', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 21, 10.0, [1, 2, 3, 4, 5, 6], [1.0, 2.0, 3.0, 4.0, 5.0]);
+-- expected_rows --
+[
+  ["http_server_request_duration_bucket", {"le": "+Inf", "service": "api"}, "2026-01-01T00:00:00Z", 21],
+  ["http_server_request_duration_bucket", {"le": "1", "service": "api"}, "2026-01-01T00:00:00Z", 1],
+  ["http_server_request_duration_bucket", {"le": "2", "service": "api"}, "2026-01-01T00:00:00Z", 3],
+  ["http_server_request_duration_bucket", {"le": "3", "service": "api"}, "2026-01-01T00:00:00Z", 6],
+  ["http_server_request_duration_bucket", {"le": "4", "service": "api"}, "2026-01-01T00:00:00Z", 10],
+  ["http_server_request_duration_bucket", {"le": "5", "service": "api"}, "2026-01-01T00:00:00Z", 15]
+]
+-- args --
+[0] string = "http_server_request_duration_bucket"
+[1] string = "le"
+[2] string = "+Inf"
+[3] int64 = 1
+[4] string = "http_server_request_duration"
+[5] string = "2026-01-01 00:00:01.000000000"
+[6] int64 = 9
+[7] string = "2026-01-01 00:00:01.000000000"
+[8] int64 = 9
+[9] int64 = 300000000000
+-- chplan --
+Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+  Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+    Filter predicate=((TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9)) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+      Project ["http_server_request_duration_bucket" AS MetricName, mapConcat(Attributes, map("le", if((le_idx > length(ExplicitBounds)), "+Inf", toString(ExplicitBounds[le_idx])))) AS Attributes, TimeUnix AS TimeUnix, toFloat64(arraySum(arraySlice(BucketCounts, 1, le_idx))) AS Value]
+        Project [MetricName AS MetricName, Attributes AS Attributes, TimeUnix AS TimeUnix, ExplicitBounds AS ExplicitBounds, BucketCounts AS BucketCounts, arrayJoin(arrayEnumerate(BucketCounts)) AS le_idx]
+          Filter predicate=(MetricName = "http_server_request_duration")
+            Scan(otel_metrics_histogram)
+-- sql --
+SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT ? AS `MetricName`, mapConcat(`Attributes`, map(?, if((le_idx > length(`ExplicitBounds`)), ?, toString(`ExplicitBounds`[le_idx])))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(arraySum(arraySlice(`BucketCounts`, ?, le_idx))) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `TimeUnix` AS `TimeUnix`, `ExplicitBounds` AS `ExplicitBounds`, `BucketCounts` AS `BucketCounts`, arrayJoin(arrayEnumerate(`BucketCounts`)) AS `le_idx` FROM (SELECT * FROM `otel_metrics_histogram` WHERE (`MetricName` = ?)))) WHERE ((`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`)

--- a/test/spec/promql/histogram_bucket_le_filter.txtar
+++ b/test/spec/promql/histogram_bucket_le_filter.txtar
@@ -1,0 +1,42 @@
+-- query.promql --
+http_server_request_duration_bucket{le="2"}
+-- seed --
+CREATE TABLE otel_metrics_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    BucketCounts Array(UInt64),
+    ExplicitBounds Array(Float64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_histogram VALUES
+    ('http_server_request_duration', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 21, 10.0, [1, 2, 3, 4, 5, 6], [1.0, 2.0, 3.0, 4.0, 5.0]);
+-- expected_rows --
+[
+  ["http_server_request_duration_bucket", {"le": "2", "service": "api"}, "2026-01-01T00:00:00Z", 3]
+]
+-- args --
+[0] string = "http_server_request_duration_bucket"
+[1] string = "le"
+[2] string = "+Inf"
+[3] int64 = 1
+[4] string = "http_server_request_duration"
+[5] string = "le"
+[6] string = "2"
+[7] string = "2026-01-01 00:00:01.000000000"
+[8] int64 = 9
+[9] string = "2026-01-01 00:00:01.000000000"
+[10] int64 = 9
+[11] int64 = 300000000000
+-- chplan --
+Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+  Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+    Filter predicate=((TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9)) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+      Filter predicate=(Attributes["le"] = "2")
+        Project ["http_server_request_duration_bucket" AS MetricName, mapConcat(Attributes, map("le", if((le_idx > length(ExplicitBounds)), "+Inf", toString(ExplicitBounds[le_idx])))) AS Attributes, TimeUnix AS TimeUnix, toFloat64(arraySum(arraySlice(BucketCounts, 1, le_idx))) AS Value]
+          Project [MetricName AS MetricName, Attributes AS Attributes, TimeUnix AS TimeUnix, ExplicitBounds AS ExplicitBounds, BucketCounts AS BucketCounts, arrayJoin(arrayEnumerate(BucketCounts)) AS le_idx]
+            Filter predicate=(MetricName = "http_server_request_duration")
+              Scan(otel_metrics_histogram)
+-- sql --
+SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT * FROM (SELECT ? AS `MetricName`, mapConcat(`Attributes`, map(?, if((le_idx > length(`ExplicitBounds`)), ?, toString(`ExplicitBounds`[le_idx])))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(arraySum(arraySlice(`BucketCounts`, ?, le_idx))) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `TimeUnix` AS `TimeUnix`, `ExplicitBounds` AS `ExplicitBounds`, `BucketCounts` AS `BucketCounts`, arrayJoin(arrayEnumerate(`BucketCounts`)) AS `le_idx` FROM (SELECT * FROM `otel_metrics_histogram` WHERE (`MetricName` = ?)))) WHERE (`Attributes`[?] = ?)) WHERE ((`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`)

--- a/test/spec/promql/histogram_quantile_agg_empty.txtar
+++ b/test/spec/promql/histogram_quantile_agg_empty.txtar
@@ -1,0 +1,49 @@
+# N6 regression: when the histogram table has zero rows matching the
+# selector, `histogram_quantile(0.95, sum by(le)(rate(<X>_bucket[5m])))`
+# must return EMPTY — not a default `metric:{}, value=4.75` row from
+# walking over an empty histogram array.
+#
+# The agg-path lowering (`lowerHistogramQuantileAgg`) sets the inner
+# Aggregate's `DropEmptyOnNoGroup: true` flag so CH's
+# "1-row-of-zeros over empty input" default for aggregates without
+# GROUP BY collapses to zero rows. The downstream HistogramQuantile
+# then sees an empty input and produces no rows.
+#
+# This fixture pins that contract — a missing-metric query must round-
+# trip to zero rows, not a synthesised default quantile.
+
+-- query.promql --
+histogram_quantile(0.95, sum by (le) (rate(missing_metric_bucket[5m])))
+-- seed --
+CREATE TABLE otel_metrics_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    BucketCounts Array(UInt64),
+    ExplicitBounds Array(Float64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_histogram VALUES
+    ('http_server_request_duration', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 10, 5.0, [3, 4, 3], [0.1, 0.5, 1.0]);
+-- expected_rows --
+[]
+-- args --
+[0] string = ""
+[1] int64 = 9
+[2] string = "Map(String,String)"
+[3] string = "missing_metric"
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] string = "2026-01-01 00:00:01.000000000"
+[7] int64 = 9
+[8] int64 = 300000000000
+-- chplan --
+Project ["" AS MetricName, Attributes AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+  HistogramQuantile phi=0.95 groupBy=[Attributes AS Attributes]
+    Project [CAST(map(), "Map(String,String)") AS Attributes, BucketCounts AS BucketCounts, ExplicitBounds AS ExplicitBounds]
+      Aggregate groupBy=[] funcs=[sumForEach(BucketCounts) AS BucketCounts, any(ExplicitBounds) AS ExplicitBounds]
+        Filter predicate=(((MetricName = "missing_metric") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+          Scan(otel_metrics_histogram)
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes` AS `Attributes`, if(length(`BucketCounts`) = 0, nan, if(arraySum(arrayMap(x -> toFloat64(x), `BucketCounts`)) = 0, nan, if(0.95 <= 0, 0.0, if(0.95 >= 1, `ExplicitBounds`[length(`ExplicitBounds`)], if(arrayFirstIndex(c -> c >= (0.95 * arraySum(arrayMap(x -> toFloat64(x), `BucketCounts`))), arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`))) = length(arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`))), `ExplicitBounds`[length(`ExplicitBounds`)], (if(arrayFirstIndex(c -> c >= (0.95 * arraySum(arrayMap(x -> toFloat64(x), `BucketCounts`))), arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`))) = 1, 0.0, `ExplicitBounds`[arrayFirstIndex(c -> c >= (0.95 * arraySum(arrayMap(x -> toFloat64(x), `BucketCounts`))), arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`))) - 1]) + (`ExplicitBounds`[arrayFirstIndex(c -> c >= (0.95 * arraySum(arrayMap(x -> toFloat64(x), `BucketCounts`))), arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`)))] - if(arrayFirstIndex(c -> c >= (0.95 * arraySum(arrayMap(x -> toFloat64(x), `BucketCounts`))), arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`))) = 1, 0.0, `ExplicitBounds`[arrayFirstIndex(c -> c >= (0.95 * arraySum(arrayMap(x -> toFloat64(x), `BucketCounts`))), arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`))) - 1])) * ((0.95 * arraySum(arrayMap(x -> toFloat64(x), `BucketCounts`))) - if(arrayFirstIndex(c -> c >= (0.95 * arraySum(arrayMap(x -> toFloat64(x), `BucketCounts`))), arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`))) = 1, 0.0, arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`))[arrayFirstIndex(c -> c >= (0.95 * arraySum(arrayMap(x -> toFloat64(x), `BucketCounts`))), arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`))) - 1])) / (arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`))[arrayFirstIndex(c -> c >= (0.95 * arraySum(arrayMap(x -> toFloat64(x), `BucketCounts`))), arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`)))] - if(arrayFirstIndex(c -> c >= (0.95 * arraySum(arrayMap(x -> toFloat64(x), `BucketCounts`))), arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`))) = 1, 0.0, arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`))[arrayFirstIndex(c -> c >= (0.95 * arraySum(arrayMap(x -> toFloat64(x), `BucketCounts`))), arrayCumSum(arrayMap(x -> toFloat64(x), `BucketCounts`))) - 1])))))))) AS `Value` FROM (SELECT CAST(map(), ?) AS `Attributes`, `BucketCounts` AS `BucketCounts`, `ExplicitBounds` AS `ExplicitBounds` FROM (SELECT `BucketCounts`, `ExplicitBounds` FROM (SELECT sumForEach(`BucketCounts`) AS `BucketCounts`, any(`ExplicitBounds`) AS `ExplicitBounds`, count() AS `_cerb_n` FROM (SELECT * FROM `otel_metrics_histogram` PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?))))) WHERE `_cerb_n` > 0)))


### PR DESCRIPTION
## Summary

- **N5 fix**: Bare `<X>_bucket` classic-histogram selectors now fan out the OTel-CH `BucketCounts` × `ExplicitBounds` arrays into N+1 Sample-shape rows with synthesized `le=<bound>` labels (including the trailing `le="+Inf"`). Cumulative counts are computed as `toFloat64(arraySum(arraySlice(BucketCounts, 1, le_idx)))` to match Prom's classic-bucket wire shape (cumulative, not per-bucket).
- **N6 fix**: `histogram_quantile(phi, sum by(le)(rate(<X>_bucket[r])))` against an empty matcher set returns empty (not a synthesized `metric:{} value=4.75`). The existing `DropEmptyOnNoGroup: true` flag on `lowerHistogramQuantileAgg` already renders as a `WHERE _cerb_n > 0` SQL guard; this PR adds the regression coverage to pin it (fixture + phi-sweep Go test).

## Implementation

`lowerVectorSelector` (`internal/promql/lower.go`) gains a new `_bucket` arm parallel to the existing `_count` / `_sum` companion routing landed in PR #645. The fan-out emits a two-layer Project:

```
Project [MetricName='<X>_bucket', mapConcat(Attributes, map('le', le_str)) AS Attributes,
         TimeUnix, toFloat64(arraySum(arraySlice(BucketCounts, 1, le_idx))) AS Value]
  Project [..., arrayJoin(arrayEnumerate(BucketCounts)) AS le_idx]
    Filter(MetricName='<X>')
      Scan(otel_metrics_histogram)
```

`le_str` resolves to `if(le_idx > length(ExplicitBounds), '+Inf', toString(ExplicitBounds[le_idx]))` so the trailing overflow bucket carries the canonical `+Inf` label.

Matchers are partitioned via `splitBucketMatchers`: scan-side matchers (with `__name__` rewritten to the bare base name) apply to the inner Scan; `le=<bound>` matchers apply as an outer Filter on the fanned-out `Attributes['le']` key.

## Test plan

- [x] `internal/promql/histogram_bucket_test.go` — Scan routing, suffix strip, plan-shape walk, no-histogram-table fallback, emitted SQL fragments
- [x] `internal/promql/histogram_quantile_empty_test.go` — phi-sweep `{0.0, 0.1, 0.5, 0.95, 1.0}` asserts `DropEmptyOnNoGroup` + `_cerb_n > 0` guard
- [x] `test/spec/promql/histogram_bucket_companion.txtar` — chDB round-trip: 6 fanned rows with cumulative counts `[1, 3, 6, 10, 15, 21]` and `+Inf` overflow
- [x] `test/spec/promql/histogram_bucket_le_filter.txtar` — chDB round-trip: `_bucket{le="2"}` filter applied post-fanout
- [x] `test/spec/promql/histogram_quantile_agg_empty.txtar` — chDB round-trip: empty-input → `[]` (N6 regression pin)
- [x] Full `go test ./...` green; full `go test -tags=chdb ./test/spec/promql/` green (259 round-trips)

Closes the N5 + N6 findings in task #216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)