### PR TITLE
ci: skip heavy test jobs on docs-only PRs (#223)

### DIFF
--- a/.github/workflows/chdb.yml
+++ b/.github/workflows/chdb.yml
@@ -58,8 +58,50 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # See `.github/workflows/ci.yml` for the rationale + filter convention.
+  # Docs-only PRs short-circuit `probe` and the `roundtrip` matrix.
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.compute.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@v6
+        if: github.event_name == 'pull_request'
+
+      - id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            code:
+              - '**'
+              - '!**/*.md'
+              - '!**/*.markdown'
+              - '!docs/**'
+              - '!LICENSE*'
+              - '!CHANGELOG.md'
+              - '!.markdownlint*'
+              - '!CLAUDE.md'
+              - '!AGENTS.md'
+              - '!README*'
+
+      - id: compute
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            if [ "${{ steps.filter.outputs.code }}" = "false" ]; then
+              echo "docs_only=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+          fi
+
   probe:
     name: probe
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -94,6 +136,8 @@ jobs:
   # in one head doesn't mask regressions in the others.
   roundtrip:
     name: roundtrip (${{ matrix.ql }})
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:

--- a/.github/workflows/chdb.yml
+++ b/.github/workflows/chdb.yml
@@ -73,6 +73,9 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: dorny/paths-filter@v3
         with:
+          # See ci.yml for why `every` is required (the `**` baseline
+          # plus negation patterns would otherwise always be true).
+          predicate-quantifier: 'every'
           filters: |
             code:
               - '**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,12 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: dorny/paths-filter@v3
         with:
+          # `every` makes the negation patterns subtractive: a file is
+          # in `code` iff it matches `**` AND does NOT match any of the
+          # `!`-prefixed doc patterns. Under the default `some`
+          # quantifier, `**` matches everything and the negations never
+          # fire — every PR would be flagged as code-touching.
+          predicate-quantifier: 'every'
           # `code` matches "any changed file that is NOT documentation".
           # The `!`-prefixed patterns subtract docs files from the `**`
           # baseline. If `code == 'false'` after the filter runs, every

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,80 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # `changes` computes whether the PR is docs-only. Docs-only PRs short-
+  # circuit the heavy `check` (test + build) job — `lint` and
+  # `forbid-skip` still run unconditionally because they are the gates
+  # that catch broken markdown / discipline regressions in the docs
+  # themselves. See `.github/workflows/compatibility.yml`,
+  # `compose-smoke.yml`, and `chdb.yml` for the matching short-circuit
+  # in the other PR-gate workflows.
+  #
+  # Only computed on `pull_request`. On `push` events (main + tags) the
+  # output is the empty string, so the boolean check `!= 'true'` in
+  # downstream `if:` clauses falls through and the heavy job runs — that
+  # is the safe-by-default behaviour for force-pushes, tag pushes, and
+  # any other event where the diff isn't a clean two-commit range.
+  #
+  # The filter convention: `code` matches "any changed file that is NOT
+  # documentation". If `code == 'false'` we know every changed file was
+  # a doc file → docs_only. If `code == 'true'` at least one non-doc
+  # file changed → full suite.
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.compute.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@v6
+        if: github.event_name == 'pull_request'
+
+      - id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          # `code` matches "any changed file that is NOT documentation".
+          # The `!`-prefixed patterns subtract docs files from the `**`
+          # baseline. If `code == 'false'` after the filter runs, every
+          # changed file was a doc file → docs_only short-circuit. If
+          # `code == 'true'`, at least one non-doc file changed → full
+          # suite.
+          filters: |
+            code:
+              - '**'
+              - '!**/*.md'
+              - '!**/*.markdown'
+              - '!docs/**'
+              - '!LICENSE*'
+              - '!CHANGELOG.md'
+              - '!.markdownlint*'
+              - '!CLAUDE.md'
+              - '!AGENTS.md'
+              - '!README*'
+
+      - id: compute
+        # On non-PR events, leave docs_only as the empty string so the
+        # downstream `!= 'true'` guard falls through and heavy jobs run.
+        # This is the safe-by-default branch for tag pushes, force-
+        # pushes, and any event where the diff isn't a clean two-commit
+        # range.
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            if [ "${{ steps.filter.outputs.code }}" = "false" ]; then
+              echo "docs_only=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+          fi
+
   # `check` is the test + build job. Linting moved to the `lint` job
   # below so lint failures and test failures are surfaced independently
   # and can run in parallel.
   check:
     name: check
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -97,6 +97,9 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: dorny/paths-filter@v3
         with:
+          # See ci.yml for why `every` is required (the `**` baseline
+          # plus negation patterns would otherwise always be true).
+          predicate-quantifier: 'every'
           filters: |
             code:
               - '**'

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -80,8 +80,52 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # See `.github/workflows/ci.yml` for the rationale + filter convention.
+  # On `pull_request` we compute whether every changed file is a doc
+  # file; if so, the per-head compatibility jobs short-circuit. On every
+  # other event we fall through to the full suite.
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.compute.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@v6
+        if: github.event_name == 'pull_request'
+
+      - id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            code:
+              - '**'
+              - '!**/*.md'
+              - '!**/*.markdown'
+              - '!docs/**'
+              - '!LICENSE*'
+              - '!CHANGELOG.md'
+              - '!.markdownlint*'
+              - '!CLAUDE.md'
+              - '!AGENTS.md'
+              - '!README*'
+
+      - id: compute
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            if [ "${{ steps.filter.outputs.code }}" = "false" ]; then
+              echo "docs_only=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+          fi
+
   prometheus:
     name: compatibility/prometheus
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     # NOTE: job-level `continue-on-error: true` was REMOVED here on
@@ -281,6 +325,8 @@ jobs:
 
   tempo:
     name: compatibility/tempo
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -394,6 +440,8 @@ jobs:
 
   loki:
     name: compatibility/loki
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     # NOTE: job-level `continue-on-error: true` was removed here.

--- a/.github/workflows/compose-smoke.yml
+++ b/.github/workflows/compose-smoke.yml
@@ -60,6 +60,9 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: dorny/paths-filter@v3
         with:
+          # See ci.yml for why `every` is required (the `**` baseline
+          # plus negation patterns would otherwise always be true).
+          predicate-quantifier: 'every'
           filters: |
             code:
               - '**'

--- a/.github/workflows/compose-smoke.yml
+++ b/.github/workflows/compose-smoke.yml
@@ -44,8 +44,51 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # See `.github/workflows/ci.yml` for the rationale + filter convention.
+  # Docs-only PRs short-circuit the smoke job (Docker compose build +
+  # Grafana Playwright catch-net are pointless when no code changed).
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.compute.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@v6
+        if: github.event_name == 'pull_request'
+
+      - id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            code:
+              - '**'
+              - '!**/*.md'
+              - '!**/*.markdown'
+              - '!docs/**'
+              - '!LICENSE*'
+              - '!CHANGELOG.md'
+              - '!.markdownlint*'
+              - '!CLAUDE.md'
+              - '!AGENTS.md'
+              - '!README*'
+
+      - id: compute
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            if [ "${{ steps.filter.outputs.code }}" = "false" ]; then
+              echo "docs_only=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+          fi
+
   smoke:
     name: compose-smoke
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 (Unreleased changes land here.)
 
+<!-- sentinel marker for ci-docs-only verification (#223 / PR #671); revert before close -->
+
 ### Added
 
 - Sort-key-aware filter emission + `PREWHERE` promotion (RC3 R3.4). The chsql emitter now fuses `Filter(Scan)` into a single `SELECT … FROM <table> [PREWHERE …] WHERE …` and partitions conjuncts into a sort-prefix bucket / skip-index bucket / rest, then promotes cheap predicates that touch no wide column into `PREWHERE` when the projection reads any wide column. ~219 existing TXTAR fixtures across `test/spec/{chsql,promql,logql,traceql,optimizer}` were re-emitted; the diff is a pure structural rewrite (one less subquery layer, predicates reordered by sort-key rank, optional `PREWHERE` split) and the rendered SQL is semantically equivalent. 29 of the re-emitted fixtures now carry a `PREWHERE` clause. New unit tests cover the predicate classifier (`prewhere_test.go`); new `test/spec/codegen/prewhere/` fixtures pin the four codegen-only behaviours (wide-column-excluded, partial-promotion, no-wide-no-promotion, sort-prefix-order).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 (Unreleased changes land here.)
 
-<!-- sentinel marker for ci-docs-only verification (#223 / PR #671); revert before close -->
-
 ### Added
 
 - Sort-key-aware filter emission + `PREWHERE` promotion (RC3 R3.4). The chsql emitter now fuses `Filter(Scan)` into a single `SELECT … FROM <table> [PREWHERE …] WHERE …` and partitions conjuncts into a sort-prefix bucket / skip-index bucket / rest, then promotes cheap predicates that touch no wide column into `PREWHERE` when the projection reads any wide column. ~219 existing TXTAR fixtures across `test/spec/{chsql,promql,logql,traceql,optimizer}` were re-emitted; the diff is a pure structural rewrite (one less subquery layer, predicates reordered by sort-key rank, optional `PREWHERE` split) and the rendered SQL is semantically equivalent. 29 of the re-emitted fixtures now carry a `PREWHERE` clause. New unit tests cover the predicate classifier (`prewhere_test.go`); new `test/spec/codegen/prewhere/` fixtures pin the four codegen-only behaviours (wide-column-excluded, partial-promotion, no-wide-no-promotion, sort-prefix-order).


### PR DESCRIPTION
## Summary

Tracks #223 — docs-only PRs should skip every CI test job except lint.

- Adds a `changes` job to `ci.yml`, `chdb.yml`, `compatibility.yml`,
  and `compose-smoke.yml`. On `pull_request` it runs
  `dorny/paths-filter@v3` to compute `docs_only=true` iff every changed
  file matches a doc-only glob (`**/*.md`, `**/*.markdown`, `docs/**`,
  `LICENSE*`, `CHANGELOG.md`, `.markdownlint*`, `CLAUDE.md`,
  `AGENTS.md`, `README*`).
- Heavy jobs (`check`, `probe`, `roundtrip (promql|logql|traceql)`,
  `compatibility/{prometheus,loki,tempo}`, `compose-smoke`) gate
  `if: needs.changes.outputs.docs_only != 'true'`.
- The `lint` job (golangci-lint + go-arch-lint + commitlint + markdownlint)
  and `forbid-skip` job in `ci.yml` are left unconditional. They catch
  broken markdown / discipline regressions in the docs themselves and
  run in under a minute.
- On non-PR events (push to main, tag pushes, force-pushes, scheduled
  runs) the `compute` step short-circuits to `docs_only=false`, so the
  full suite always runs there. This is the safe-by-default branch for
  any event where the diff isn't a clean two-commit range.

## Branch-protection compatibility

GitHub treats `skipped` jobs as `success` when they're referenced by
name in branch protection's required-status-checks list, so the gated
jobs (`check`, `probe`, `roundtrip (*)`, `compatibility/*`,
`compose-smoke`) keep satisfying the gate on docs-only PRs without any
bypass.

## Filter spec

```yaml
code:
  - '**'
  - '!**/*.md'
  - '!**/*.markdown'
  - '!docs/**'
  - '!LICENSE*'
  - '!CHANGELOG.md'
  - '!.markdownlint*'
  - '!CLAUDE.md'
  - '!AGENTS.md'
  - '!README*'
```

`code == 'false'` means every changed file is a doc → `docs_only=true`
→ heavy jobs are skipped. `code == 'true'` means at least one non-doc
file changed → full suite runs.

Dependabot lockfile bumps (`go.sum`, `package-lock.json`) and workflow
YAML edits (`.github/workflows/**`) are NOT docs and thus do NOT
short-circuit — they invariably touch the test surface.

## Test plan

- [ ] PR `test-pr-docs-only`: change only `CHANGELOG.md` → CI runs only
      `lint` and `forbid-skip`; `check`, `probe`, `roundtrip (*)`,
      `compatibility/*`, and `compose-smoke` show up as `skipped`.
- [ ] PR `test-pr-code-and-docs`: change both `CHANGELOG.md` and
      `internal/api/prom/handler.go` → full suite runs.
- [ ] Both sentinel PRs close without merging once the behaviour is
      verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)