### PR TITLE
test(ci): sentinel — code+docs PR should run full CI (#223)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 (Unreleased changes land here.)
 
+<!-- sentinel marker for code+docs CI verification (#223 / PR #671); revert before close -->
+
 ### Added
 
 - Sort-key-aware filter emission + `PREWHERE` promotion (RC3 R3.4). The chsql emitter now fuses `Filter(Scan)` into a single `SELECT … FROM <table> [PREWHERE …] WHERE …` and partitions conjuncts into a sort-prefix bucket / skip-index bucket / rest, then promotes cheap predicates that touch no wide column into `PREWHERE` when the projection reads any wide column. ~219 existing TXTAR fixtures across `test/spec/{chsql,promql,logql,traceql,optimizer}` were re-emitted; the diff is a pure structural rewrite (one less subquery layer, predicates reordered by sort-key rank, optional `PREWHERE` split) and the rendered SQL is semantically equivalent. 29 of the re-emitted fixtures now carry a `PREWHERE` clause. New unit tests cover the predicate classifier (`prewhere_test.go`); new `test/spec/codegen/prewhere/` fixtures pin the four codegen-only behaviours (wide-column-excluded, partial-promotion, no-wide-no-promotion, sort-prefix-order).

--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -27,7 +27,8 @@ import (
 )
 
 // tracer emits the `parse` pipeline-stage span before the PromQL parser
-// runs. The subsequent lower / optimize / emit / execute stages carry
+// runs. Sentinel marker for #223 / PR #671 — revert before close.
+// The subsequent lower / optimize / emit / execute stages carry
 // their own tracers from their owning packages.
 var tracer = otel.Tracer("github.com/tsouza/cerberus/internal/api/prom")
 


### PR DESCRIPTION
## Summary

Sentinel-only PR for #671 / #223. Targets the `ci/docs-only-skip-tests`
branch so the docs-only filter is active on this PR's CI rollup.

Changes: a one-line sentinel comment in `CHANGELOG.md` (doc) AND a
one-line comment in `internal/api/prom/handler.go` (code).

## Expected behaviour

Because `internal/api/prom/handler.go` matches the `code` filter, the
`changes` job should compute `docs_only=false` and every gated job
should run, exactly like a normal code PR.

- `lint`, `forbid-skip`: run + green.
- `check`, `probe`, `roundtrip (promql|logql|traceql)`,
  `compatibility/{prometheus,loki,tempo}`, `compose-smoke`: all run.

Close without merging once the rollup confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)