### PR TITLE
feat(api): wire prom + loki /status/buildinfo + loki /format_query

### DIFF
--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -196,10 +196,12 @@ func run() error {
 	promHandler := prom.New(client, cfg.Schema, logger.With("api", "prom"))
 	promHandler.Engine = &engine.Engine{Optimizer: promHandler.Optimizer, Client: client}
 	promHandler.Limiter = promLimiter
+	promHandler.Version = Version
 	promHandler.Mount(traceMux)
 
 	lokiHandler := loki.New(client, cfg.Logs, logger.With("api", "loki"))
 	lokiHandler.Limiter = lokiLimiter
+	lokiHandler.Version = Version
 	lokiHandler.Mount(traceMux)
 
 	tempoHandler := tempo.New(client, cfg.Traces, Version, logger.With("api", "tempo"))

--- a/internal/api/loki/conformance_test.go
+++ b/internal/api/loki/conformance_test.go
@@ -1172,3 +1172,145 @@ func TestConformance_LokiLabelsGrammar(t *testing.T) {
 		}
 	}
 }
+
+// TestConformance_LokiFormatQueryWire pins the wire shape of
+// `/loki/api/v1/format_query`. The endpoint mirrors Prom's
+// /api/v1/format_query — `{status:"success", data:<formatted>}` — but
+// runs the upstream LogQL syntax parser instead. Asserts the success
+// envelope across a representative set of LogQL shapes (stream
+// selector, log pipeline, range aggregation), plus the error path
+// when the `query` parameter is missing.
+func TestConformance_LokiFormatQueryWire(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"selector", `/loki/api/v1/format_query?query=` + url.QueryEscape(`{job="api"}`)},
+		{"pipeline", `/loki/api/v1/format_query?query=` + url.QueryEscape(`{job="api"} |= "boom"`)},
+		{"range_agg", `/loki/api/v1/format_query?query=` + url.QueryEscape(`rate({job="api"}[5m])`)},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			srv := newServer(&stubQuerier{})
+			t.Cleanup(srv.Close)
+
+			resp, err := http.Get(srv.URL + c.path)
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			body := readBody(t, resp)
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+			}
+			if ct := resp.Header.Get("Content-Type"); !strings.Contains(ct, "application/json") {
+				t.Errorf("Content-Type: got %q, want application/json", ct)
+			}
+			var env struct {
+				Status string `json:"status"`
+				Data   string `json:"data"`
+			}
+			if err := json.Unmarshal([]byte(body), &env); err != nil {
+				t.Fatalf("decode: %v body=%s", err, body)
+			}
+			if env.Status != "success" {
+				t.Errorf("status: got %q, want success", env.Status)
+			}
+			if env.Data == "" {
+				t.Errorf("data: empty pretty-printed string in body=%s", body)
+			}
+		})
+	}
+
+	// Missing-query parameter mirrors Prom's /api/v1/format_query:
+	// 400 with `{status:"error", errorType:"bad_data"}`.
+	t.Run("missing_query", func(t *testing.T) {
+		t.Parallel()
+		srv := newServer(&stubQuerier{})
+		t.Cleanup(srv.Close)
+
+		resp, err := http.Get(srv.URL + "/loki/api/v1/format_query")
+		if err != nil {
+			t.Fatalf("GET: %v", err)
+		}
+		body := readBody(t, resp)
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("status: got %d, want 400; body=%s", resp.StatusCode, body)
+		}
+		var env struct {
+			Status    string `json:"status"`
+			ErrorType string `json:"errorType"`
+		}
+		if err := json.Unmarshal([]byte(body), &env); err != nil {
+			t.Fatalf("decode: %v body=%s", err, body)
+		}
+		if env.Status != "error" {
+			t.Errorf("status: got %q, want error", env.Status)
+		}
+		if env.ErrorType != loki.ErrBadData {
+			t.Errorf("errorType: got %q, want %q", env.ErrorType, loki.ErrBadData)
+		}
+	})
+}
+
+// TestConformance_LokiBuildInfoWire pins the wire shape of
+// `/loki/api/v1/status/buildinfo`. Per the Loki HTTP API documentation
+// (docs/sources/reference/loki-http-api.md), this endpoint returns a
+// FLAT top-level JSON object — `{version, revision, branch, buildUser,
+// buildDate, goVersion}` — NOT wrapped in the `{status, data}` envelope
+// the rest of the /loki/api/v1/* surface uses. Grafana's Loki
+// datasource per-page probe relies on the flat shape. Asserts:
+//
+//   - HTTP 200;
+//   - Content-Type carries "application/json";
+//   - the top-level body has NO `status` field (catching accidental
+//     envelope wrapping);
+//   - `goVersion` is non-empty (runtime.Version() is always populated).
+func TestConformance_LokiBuildInfoWire(t *testing.T) {
+	t.Parallel()
+
+	srv := newServer(&stubQuerier{})
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/loki/api/v1/status/buildinfo")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Errorf("Content-Type: got %q, want application/json", ct)
+	}
+
+	// Decode into the typed BuildInfo to pin the field names. The flat
+	// (un-enveloped) shape means the top-level object IS the BuildInfo
+	// — a {status, data} wrap would leave every field zero here.
+	var info loki.BuildInfo
+	if err := json.Unmarshal([]byte(body), &info); err != nil {
+		t.Fatalf("decode: %v body=%s", err, body)
+	}
+	if info.GoVersion == "" {
+		t.Errorf("goVersion should be populated by runtime.Version(); got empty; body=%s", body)
+	}
+
+	// Catch accidental envelope wrapping: the upstream Loki contract
+	// for /status/buildinfo is flat. A `status` field at the top level
+	// signals someone wrapped the body in the {status, data} envelope
+	// the rest of the API uses; Grafana would then fail to find the
+	// version fields it expects.
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(body), &raw); err != nil {
+		t.Fatalf("decode raw: %v body=%s", err, body)
+	}
+	if _, ok := raw["status"]; ok {
+		t.Errorf("buildinfo body must NOT carry a top-level `status` envelope; got body=%s", body)
+	}
+	if _, ok := raw["data"]; ok {
+		t.Errorf("buildinfo body must NOT carry a top-level `data` envelope; got body=%s", body)
+	}
+}

--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -68,6 +69,14 @@ type Handler struct {
 	// Limiter caps in-flight Loki API requests. nil disables the
 	// admission middleware. Wired from CERBERUS_ADMIT_LOKI.
 	Limiter *admit.Limiter
+
+	// Version is the cerberus build identifier surfaced via
+	// `/loki/api/v1/status/buildinfo`. Wired from cmd/cerberus's
+	// build-time `Version` var so Grafana's Loki datasource per-page
+	// probe sees a real value; left empty in tests (the buildinfo
+	// handler still returns 200 with empty-string fields, matching
+	// upstream Loki's behaviour when build metadata is unset).
+	Version string
 }
 
 // New constructs a Handler with the seed optimizer wired in.
@@ -127,6 +136,14 @@ func (h *Handler) Mount(mux *http.ServeMux) {
 	register("POST /loki/api/v1/patterns", h.handlePatterns)
 	// /tail is WebSocket-upgrade only; no POST counterpart in upstream Loki.
 	register("GET /loki/api/v1/tail", h.handleTail)
+	// Format-query + build-info probes. Grafana's Loki datasource hits
+	// /status/buildinfo on every page load to gate feature flags
+	// (LogQL editor capabilities, label-browser presence) and uses
+	// /format_query when the query-editor's "Format query" button is
+	// pressed. Neither endpoint touches ClickHouse.
+	register("GET /loki/api/v1/format_query", h.handleFormatQuery)
+	register("POST /loki/api/v1/format_query", h.handleFormatQuery)
+	register("GET /loki/api/v1/status/buildinfo", h.handleBuildInfo)
 
 	// JSON-shaped 404 fallback for unmatched /loki/api/v1/* routes. Without
 	// this, http.ServeMux serves Go's plain-text "404 page not found"
@@ -153,6 +170,43 @@ type errLokiPathNotFound struct{ path string }
 
 func (e errLokiPathNotFound) Error() string {
 	return "unknown loki endpoint: " + e.path
+}
+
+// handleFormatQuery implements `/loki/api/v1/format_query`. Takes a
+// `query` parameter, parses it with the upstream LogQL syntax parser,
+// and returns the pretty-printed string. Grafana's logs query editor
+// uses this to format on save / on the explicit "Format query" button.
+// Wrapped in the standard {status, data} envelope so the Loki
+// datasource decodes it identically to /labels and /series.
+func (h *Handler) handleFormatQuery(w http.ResponseWriter, r *http.Request) {
+	q := r.FormValue("query")
+	if q == "" {
+		writeError(w, http.StatusBadRequest, ErrBadData, errors.New("missing query parameter"))
+		return
+	}
+	expr, err := syntax.ParseExpr(q)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, ErrBadData, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, Response{
+		Status: "success",
+		Data:   expr.String(),
+	})
+}
+
+// handleBuildInfo implements `/loki/api/v1/status/buildinfo`. Returns
+// the upstream Loki BuildInfo shape (version / revision / branch /
+// buildUser / buildDate / goVersion) as a flat top-level JSON object —
+// the Loki API documents this endpoint's body as the BuildInfo struct
+// directly, NOT wrapped in the {status, data} envelope the rest of
+// the v1 surface uses. Grafana parses this body to decide which LogQL
+// features to enable in the query editor.
+func (h *Handler) handleBuildInfo(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, BuildInfo{
+		Version:   h.Version,
+		GoVersion: runtime.Version(),
+	})
 }
 
 func (h *Handler) handleQuery(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/loki/types.go
+++ b/internal/api/loki/types.go
@@ -44,6 +44,22 @@ type VectorSample struct {
 	Value  [2]any            `json:"value"`
 }
 
+// BuildInfo is the body of `/loki/api/v1/status/buildinfo`. Mirrors
+// the upstream Loki `BuildInfo` shape (pkg/ui/cluster.go). Unlike the
+// `{status, data}` envelope the rest of the Loki API uses, the
+// buildinfo response is a flat top-level JSON object — see
+// docs/sources/reference/loki-http-api.md "Show build information"
+// — so Grafana's Loki datasource per-page probe can decode it without
+// peeling an extra layer.
+type BuildInfo struct {
+	Version   string `json:"version"`
+	Revision  string `json:"revision"`
+	Branch    string `json:"branch"`
+	BuildUser string `json:"buildUser"`
+	BuildDate string `json:"buildDate"`
+	GoVersion string `json:"goVersion"`
+}
+
 // errorType constants mirror Loki's documented error vocabulary, which
 // is itself aligned with Prometheus's.
 const (

--- a/internal/api/prom/conformance_test.go
+++ b/internal/api/prom/conformance_test.go
@@ -1745,3 +1745,50 @@ func TestConformance_LabelValuesMatchedEmitsDottedFallback(t *testing.T) {
 			stub.lastArgs, stub.lastSQL)
 	}
 }
+
+// TestConformance_BuildInfoWire pins the wire shape of
+// `/api/v1/status/buildinfo`. Grafana's Prom datasource hits this on
+// every page load to gate PromQL editor feature flags; the body must
+// be `{status:"success", data:{version, revision, branch, buildUser,
+// buildDate, goVersion}}` — the upstream PrometheusVersion shape
+// wrapped in the standard envelope. Asserts:
+//
+//   - HTTP 200;
+//   - Content-Type carries "application/json";
+//   - top-level `status` == "success";
+//   - `data.version` echoes whatever Handler.Version is set to (the
+//     stub server leaves it empty, so we assert it's a string field —
+//     not missing — by decoding into the typed BuildInfo);
+//   - `data.goVersion` is non-empty (runtime.Version() always returns
+//     a populated `go1.x.y` string).
+func TestConformance_BuildInfoWire(t *testing.T) {
+	t.Parallel()
+
+	srv := newServer(&stubQuerier{})
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/status/buildinfo")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Errorf("Content-Type: got %q, want application/json", ct)
+	}
+	var env struct {
+		Status string         `json:"status"`
+		Data   prom.BuildInfo `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(body), &env); err != nil {
+		t.Fatalf("decode: %v body=%s", err, body)
+	}
+	if env.Status != "success" {
+		t.Errorf("status: got %q, want success", env.Status)
+	}
+	if env.Data.GoVersion == "" {
+		t.Errorf("data.goVersion should be populated by runtime.Version(); got empty; body=%s", body)
+	}
+}

--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"runtime"
 	"strconv"
 	"time"
 
@@ -60,6 +61,14 @@ type Handler struct {
 	// this from CERBERUS_ADMIT_PROM; tests leave it nil for
 	// unconstrained behaviour.
 	Limiter *admit.Limiter
+
+	// Version is the cerberus build identifier surfaced via
+	// `/api/v1/status/buildinfo`. Wired from cmd/cerberus's build-time
+	// `Version` var so Grafana's Prom datasource per-page probe sees a
+	// real value; left empty in tests (the buildinfo handler still
+	// returns 200 with empty-string fields, matching upstream Prom's
+	// behaviour when build metadata is unset).
+	Version string
 
 	// parser is the single PromQL parser instance the handler uses for
 	// every parse path. The scalar-fold short-circuit (parseExpr,
@@ -134,6 +143,26 @@ func (h *Handler) Mount(mux *http.ServeMux) {
 	// upstream Prometheus would, so Grafana's per-page probe is quiet.
 	register("GET /api/v1/rules", h.handleRules)
 	register("GET /api/v1/alerts", h.handleAlerts)
+	// Build-info probe. Grafana's Prom datasource hits this on every
+	// page load to gate feature flags (PromQL editor capabilities,
+	// remote-write receiver presence). The body is the upstream
+	// PrometheusVersion shape wrapped in the {status, data} envelope.
+	register("GET /api/v1/status/buildinfo", h.handleBuildInfo)
+}
+
+// handleBuildInfo implements `/api/v1/status/buildinfo`. Returns the
+// upstream PrometheusVersion shape (version / revision / branch /
+// buildUser / buildDate / goVersion) wrapped in the standard
+// {status, data} envelope. Grafana parses this body to decide which
+// PromQL features to enable in the query editor.
+func (h *Handler) handleBuildInfo(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, Response{
+		Status: "success",
+		Data: BuildInfo{
+			Version:   h.Version,
+			GoVersion: runtime.Version(),
+		},
+	})
 }
 
 // handleFormatQuery implements `/api/v1/format_query`. Takes a `query`

--- a/internal/api/prom/types.go
+++ b/internal/api/prom/types.go
@@ -42,6 +42,20 @@ type MatrixSample struct {
 // numeric values as strings to preserve precision; we match that exactly.
 type Sample [2]any
 
+// BuildInfo is the body of `/api/v1/status/buildinfo`. Mirrors the
+// upstream Prometheus `PrometheusVersion` shape (web/api/v1/api.go) so
+// Grafana's Prom datasource per-page probe parses cerberus's reply
+// without datasource-specific quirks. Wrapped in the standard
+// {status, data} envelope by handleBuildInfo.
+type BuildInfo struct {
+	Version   string `json:"version"`
+	Revision  string `json:"revision"`
+	Branch    string `json:"branch"`
+	BuildUser string `json:"buildUser"`
+	BuildDate string `json:"buildDate"`
+	GoVersion string `json:"goVersion"`
+}
+
 // errorType constants mirror Prometheus's documented error vocabulary.
 const (
 	ErrBadData   = "bad_data"


### PR DESCRIPTION
## Summary

Implements the three endpoints Grafana's per-page probes hit and cerberus was 404'ing on — prerequisite for retiring the compose-grafana-smoke "tolerated 404" allow-list (Q5 of the e2e-enhance plan, zero-toleration goal).

- `GET /api/v1/status/buildinfo` on the Prom head — upstream `PrometheusVersion` shape (`version` / `revision` / `branch` / `buildUser` / `buildDate` / `goVersion`) wrapped in the standard `{status, data}` envelope.
- `GET /loki/api/v1/status/buildinfo` on the Loki head — flat top-level JSON (NO `{status, data}` envelope), per `docs/sources/reference/loki-http-api.md` "Show build information".
- `GET/POST /loki/api/v1/format_query` on the Loki head — `syntax.ParseExpr(query).String()` wrapped in the standard `{status, data}` envelope. 400 + `bad_data` on missing query mirrors Prom's behaviour.

Version threads in via new `Handler.Version` fields on both heads (settable after `New()` like `Limiter` — keeps the `New(...)` signature untouched, callers in `cmd/cerberus/main.go` now set `.Version = Version` alongside `.Limiter`).

Note: the task brief listed `/api/v1/format_query` as missing on the Prom head, but it was already implemented (handler at `internal/api/prom/handler.go:139`, conformance test at `internal/api/prom/conformance_test.go:474`). Substituted `/api/v1/status/buildinfo` on the Prom head — the other endpoint Grafana's Prom datasource per-page probe hits and that cerberus was also 404'ing on — to keep the PR consistent with the task's "zero toleration" goal.

## Conformance assertions pinned

For each endpoint:

- 200 status code
- `Content-Type` carries `application/json`
- Response decodes cleanly into the typed wire-format struct
- `goVersion` is non-empty (`runtime.Version()` is always populated)

Plus shape-specific pins:

- Prom `/status/buildinfo` — `status:"success"` + `data:{version, revision, branch, buildUser, buildDate, goVersion}`.
- Loki `/status/buildinfo` — flat shape, **no** top-level `status` or `data` key (catches accidental envelope wrapping).
- Loki `/format_query` — `status:"success"` + non-empty `data` string across stream-selector / log-pipeline / range-aggregation LogQL inputs; missing-query path returns 400 + `status:"error"` + `errorType:"bad_data"`.

## File:line registrations

- `internal/api/prom/handler.go:142` — `register("GET /api/v1/status/buildinfo", h.handleBuildInfo)`
- `internal/api/loki/handler.go:135` — `register("GET /loki/api/v1/format_query", h.handleFormatQuery)` (+ POST at :136, `register("GET /loki/api/v1/status/buildinfo", h.handleBuildInfo)` at :137)

## Test plan

- [ ] CI: `check` runs the three new conformance tests (`TestConformance_BuildInfoWire`, `TestConformance_LokiFormatQueryWire`, `TestConformance_LokiBuildInfoWire`).
- [ ] Manual: hit `/api/v1/status/buildinfo`, `/loki/api/v1/status/buildinfo`, `/loki/api/v1/format_query?query={job="api"}` against a running cerberus and confirm 200 + documented wire shape.
- [ ] Follow-up: once this merges, drop the `isKnownTolerated404` allow-list in `test/e2e/playwright/compose_grafana_smoke.spec.ts` (the rules/alerts entries land via PR #632; this PR removes the buildinfo / format-query rationale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)