### PR TITLE
chore(mutation): consume tsouza/gremlins fork to fix SIGTERM-LIVED bug

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -84,10 +84,17 @@ jobs:
       # Use `--output` for structured JSON (gremlins exits 0 even
       # when `--threshold-efficacy` is violated in v0.6.0, so we
       # do the gating ourselves against the parsed JSON below).
+      #
+      # We consume gremlins via the tsouza/gremlins fork pinned to
+      # v0.6.0-cerberus-sigterm so that in-flight mutants killed by
+      # the runner's SIGTERM at job timeout are recorded as NOT_RUN
+      # (via --on-shutdown-status=not-run) rather than LIVED, which
+      # used to falsely deflate test_efficacy. Upstream PR:
+      # https://github.com/go-gremlins/gremlins/pull/283
       - name: install gremlins
-        run: go install github.com/go-gremlins/gremlins/cmd/gremlins@v0.6.0
+        run: go install github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-sigterm
       - name: gremlins unleash
-        run: gremlins unleash --output gremlins.json ${{ matrix.scope }}
+        run: gremlins unleash --output gremlins.json --on-shutdown-status=not-run ${{ matrix.scope }}
       - name: enforce efficacy threshold
         run: |
           set -euo pipefail

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,15 @@ Two of the four forks carry actual patches:
 
 The other two (`tsouza/prometheus:cerberus-parser`, `tsouza/loki:cerberus-parser`) are unpatched — they exist solely as the Dependabot boundary.
 
+## Tooling fork — gremlins (mutation testing)
+
+`mutation.yml` consumes the **`tsouza/gremlins:cerberus-sigterm-fix`** fork (installed via `go install github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-sigterm`) instead of upstream `go-gremlins/gremlins@v0.6.0`. The fork carries a single fix on top of `v0.6.0`:
+
+- Upstream's signal handler closes the channel that `os/signal` still writes to, so a second signal (typical CI runner sequence: SIGTERM → SIGKILL) panics with `send on closed channel` from `signal.process`. Worse, mutants whose `go test` subprocess is still running at cancellation time fall through `runTests` to the default `return mutator.Lived` branch (the per-test ctx is rooted in `context.Background()`, so only `DeadlineExceeded` is checked). The result on cerberus PR #664 / push-to-main run 26213450154: four untested mutants recorded as LIVED, deflating `test_efficacy`.
+- The fork fixes both: the signal handler no longer self-closes, and the executor now threads the engine's run ctx into the per-test ctx so cancelled-in-flight mutants are reported with the status from the new `--on-shutdown-status` flag. Cerberus passes `--on-shutdown-status=not-run` so cancelled-in-flight mutants land in `NOT_COVERED`, outside the `KILLED / (KILLED + LIVED)` efficacy formula entirely. Upstream PR: <https://github.com/go-gremlins/gremlins/pull/283>.
+
+Unlike the four parser forks, this one is not on the Dependabot-watch flow — it's a build-time tool, not a Go module dep, and the `cerberus-sigterm-fix` branch will be retired once the upstream PR lands and a release tag is cut.
+
 ## Transitive-dep gotcha (the one that bit us)
 
 `go.mod` has this entry:


### PR DESCRIPTION
## Summary

- Switch `mutation.yml` from `go-gremlins/gremlins@v0.6.0` to the `tsouza/gremlins` fork pinned to `v0.6.0-cerberus-sigterm`, which fixes the SIGTERM signal-handler panic + the LIVED-on-cancellation bug behind the four mystery survivors on run [26213450154](https://github.com/tsouza/cerberus/actions/runs/26213450154).
- Pass the fork's new `--on-shutdown-status=not-run` flag so cancelled-in-flight mutants are recorded as `NOT_COVERED` instead of `LIVED`. `test_efficacy = KILLED / (KILLED + LIVED)` is no longer skewed by runner-cancellation noise.
- Upstream PR: https://github.com/go-gremlins/gremlins/pull/283. Once the upstream maintainer merges + cuts a release we can drop the fork and pin back to the upstream module path.

## Root cause

Upstream `cmd/gremlins/main.go` does this:

```go
done := make(chan os.Signal, 1)
signal.Notify(done, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
go func() {
    <-done
    cancel()
    close(done)  // bug: signal.process may still send here
}()
```

The runner sequence is `SIGTERM` → grace window → `SIGKILL`, but the same panic also reproduces if a developer hits Ctrl-C twice. On top of that, `mutantExecutor.runTests` rooted the per-test ctx in `context.Background()` rather than the engine's run ctx, so when the parent ctx is cancelled the test subprocess kept running until it finished (or was killed by the runner's SIGKILL), and the executor fell through to the default `return mutator.Lived` branch.

## Why `not-run`

`test_efficacy = KILLED / (KILLED + LIVED)`. Mapping cancelled-in-flight mutants to `NOT_COVERED` keeps them out of both buckets — they're not survivors and they're not catches, they're _unobserved_. `--on-shutdown-status=timed-out` (also available) would land them in `TIMED_OUT`, also outside the efficacy formula. The legacy `--on-shutdown-status=lived` is supported for users who depend on the old behaviour but is explicitly discouraged.

## Survivor definition unchanged

The cerberus mutation gate (`enforce efficacy threshold` step) reads `.test_efficacy` from `gremlins.json` and compares to the per-phase floor. That formula was, and still is, `KILLED / (KILLED + LIVED)`. The fork's only effect is that some mutants which would have been recorded as `LIVED` (incorrectly — they were never actually tested) now arrive as `NOT_COVERED` instead. No change to what counts as a real survivor; just less noise.

## Test plan

- [ ] `mutation` matrix runs on this PR (path-filtered trigger should fire on `mutation.yml` itself) — efficacy on every phase should match nightly baseline (≥ 95% per phase).
- [ ] No `panic: send on closed channel` in any phase log.
- [ ] Re-run cerberus push-to-main mutation job for commit `8c1b246` (if possible) with the fork installed and verify the four previously-LIVED mutants now show up as `NOT_COVERED` rather than `LIVED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)