### PR TITLE
fix(mutation): pin gremlins fork to -consume tag so go install accepts it

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -86,13 +86,13 @@ jobs:
       # do the gating ourselves against the parsed JSON below).
       #
       # We consume gremlins via the tsouza/gremlins fork pinned to
-      # v0.6.0-cerberus-sigterm so that in-flight mutants killed by
+      # v0.6.0-cerberus-sigterm-consume so that in-flight mutants killed by
       # the runner's SIGTERM at job timeout are recorded as NOT_RUN
       # (via --on-shutdown-status=not-run) rather than LIVED, which
       # used to falsely deflate test_efficacy. Upstream PR:
       # https://github.com/go-gremlins/gremlins/pull/283
       - name: install gremlins
-        run: go install github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-sigterm
+        run: go install github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-sigterm-consume
       - name: gremlins unleash
         run: gremlins unleash --output gremlins.json --on-shutdown-status=not-run ${{ matrix.scope }}
       - name: enforce efficacy threshold

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,12 +91,17 @@ The other two (`tsouza/prometheus:cerberus-parser`, `tsouza/loki:cerberus-parser
 
 ## Tooling fork — gremlins (mutation testing)
 
-`mutation.yml` consumes the **`tsouza/gremlins:cerberus-sigterm-fix`** fork (installed via `go install github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-sigterm`) instead of upstream `go-gremlins/gremlins@v0.6.0`. The fork carries a single fix on top of `v0.6.0`:
+`mutation.yml` consumes the **`tsouza/gremlins`** fork (installed via `go install github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-sigterm-consume`) instead of upstream `go-gremlins/gremlins@v0.6.0`. The fork carries a single fix on top of `v0.6.0`:
 
 - Upstream's signal handler closes the channel that `os/signal` still writes to, so a second signal (typical CI runner sequence: SIGTERM → SIGKILL) panics with `send on closed channel` from `signal.process`. Worse, mutants whose `go test` subprocess is still running at cancellation time fall through `runTests` to the default `return mutator.Lived` branch (the per-test ctx is rooted in `context.Background()`, so only `DeadlineExceeded` is checked). The result on cerberus PR #664 / push-to-main run 26213450154: four untested mutants recorded as LIVED, deflating `test_efficacy`.
 - The fork fixes both: the signal handler no longer self-closes, and the executor now threads the engine's run ctx into the per-test ctx so cancelled-in-flight mutants are reported with the status from the new `--on-shutdown-status` flag. Cerberus passes `--on-shutdown-status=not-run` so cancelled-in-flight mutants land in `NOT_COVERED`, outside the `KILLED / (KILLED + LIVED)` efficacy formula entirely. Upstream PR: <https://github.com/go-gremlins/gremlins/pull/283>.
 
-Unlike the four parser forks, this one is not on the Dependabot-watch flow — it's a build-time tool, not a Go module dep, and the `cerberus-sigterm-fix` branch will be retired once the upstream PR lands and a release tag is cut.
+The fork ships two parallel branches/tags by design:
+
+- **`cerberus-sigterm-fix` @ `v0.6.0-cerberus-sigterm`** — the branch the upstream PR is built from. Keeps the upstream module path `github.com/go-gremlins/gremlins` so the diff stays clean and reviewable.
+- **`cerberus-sigterm-fix-consume` @ `v0.6.0-cerberus-sigterm-consume`** — the branch cerberus's `mutation.yml` installs. Adds a single extra commit that renames the `go.mod` module path to `github.com/tsouza/gremlins` (and rewrites all internal imports), because `go install github.com/tsouza/gremlins/cmd/gremlins@...` rejects the module otherwise with `module declares its path as: github.com/go-gremlins/gremlins`. The fix itself is identical to the upstream-PR branch.
+
+Unlike the four parser forks, this one is not on the Dependabot-watch flow — it's a build-time tool, not a Go module dep, and both branches will be retired once the upstream PR lands and a release tag is cut.
 
 ## Transitive-dep gotcha (the one that bit us)
 


### PR DESCRIPTION
## Summary

- PR #676 (just merged) bumped the install line to `v0.6.0-cerberus-sigterm`, but that tag sits on the upstream-PR branch where `go.mod` declares the module path as `github.com/go-gremlins/gremlins`. `go install github.com/tsouza/gremlins/cmd/gremlins@<tag>` rejects this with `module declares its path as: github.com/go-gremlins/gremlins`, so every matrix entry in `mutation.yml` crashed at the install step on run [26216898619](https://github.com/tsouza/cerberus/actions/runs/26216898619). PR #676 still squash-merged because mutation is informational, not a required gate — but the gate is broken for everyone until this lands.
- The fork now ships two parallel branches/tags: `v0.6.0-cerberus-sigterm` (upstream-PR branch, upstream module path, clean diff) and `v0.6.0-cerberus-sigterm-consume` (cerberus-consumed branch, module path renamed to `github.com/tsouza/gremlins` + every import rewritten, so `go install` accepts it). The signal/executor fix itself is identical between the two branches.
- This PR switches the install line + the `gremlins unleash` invocation comment to the `-consume` tag and updates the CLAUDE.md "Tooling fork — gremlins" section to document the two-branch setup.

## Repro

```
$ go install github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-sigterm
go: downloading github.com/tsouza/gremlins v0.6.0-cerberus-sigterm
go: github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-sigterm: version constraints conflict:
   module declares its path as: github.com/go-gremlins/gremlins
```

```
$ GOBIN=/tmp/gobin go install github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-sigterm-consume
go: downloading github.com/tsouza/gremlins v0.6.0-cerberus-sigterm-consume
go: github.com/tsouza/gremlins@v0.6.0-cerberus-sigterm-consume requires go >= 1.25.0; switching to go1.25.10
$ ls /tmp/gobin/
gremlins
```

## Test plan

- [ ] `mutation` matrix runs on this PR (path-filtered trigger fires on `mutation.yml`) — every phase reaches the `gremlins unleash` step instead of crashing at install.
- [ ] No `module declares its path as` errors in any phase log.
- [ ] No `panic: send on closed channel` in any phase log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)