### PR TITLE
test(e2e/playwright): land phase-1 panel-shape sweep pinning N2/N11/N14

### DIFF
--- a/.github/workflows/compose-smoke.yml
+++ b/.github/workflows/compose-smoke.yml
@@ -164,7 +164,16 @@ jobs:
           GRAFANA_URL: http://localhost:3000
           CERBERUS_URL: http://localhost:8080
         run: |
-          npx playwright test compose_grafana_smoke.spec.ts --reporter=list
+          # Phase-1 panel-shape spec (iterate-panel-shape.spec.ts) runs
+          # alongside the catch-net smoke. It enumerates every
+          # provisioned dashboard, finds every aggregating panel
+          # target, and asserts the by(...) / without(...) label-shape
+          # rule against cerberus's /api/v1/query_range — pinning the
+          # N2/N11/N14 sweep findings so they can't silently regress.
+          npx playwright test \
+            compose_grafana_smoke.spec.ts \
+            iterate-panel-shape.spec.ts \
+            --reporter=list
 
       - name: upload Playwright report on failure
         if: steps.playwright_smoke.outcome == 'failure'

--- a/test/e2e/playwright/helpers.spec.ts
+++ b/test/e2e/playwright/helpers.spec.ts
@@ -29,11 +29,13 @@ import {
   type Panel,
   type PanelTarget,
   assertHistogramComplete,
+  assertLabelAbsent,
   assertLabelShape,
   assertNoFabricatedValue,
   extractByKeys,
   extractDataSourceProxyURL,
   extractHistogramName,
+  extractWithoutKeys,
   isHistogramQuantile,
   iterateDashboards,
   iteratePanels,
@@ -59,6 +61,30 @@ test('extractByKeys dedupes keys across nested by-clauses', () => {
 test('extractByKeys handles multi-aggregator family', () => {
   expect(extractByKeys('count by (k) (rate(foo[5m]))')).toEqual(['k']);
   expect(extractByKeys('avg by (x, y) (foo)')).toEqual(['x', 'y']);
+});
+
+test('extractByKeys ignores without-clauses entirely', () => {
+  // The two modifiers have inverted semantics — `by` keeps, `without`
+  // drops. Conflating them was the bug the phase-1 split fixes.
+  expect(extractByKeys('sum without (instance) (foo)')).toEqual([]);
+  expect(extractByKeys('sum by (a) (sum without (b) (foo))')).toEqual(['a']);
+});
+
+test('extractWithoutKeys parses a single without-clause', () => {
+  expect(extractWithoutKeys('sum without (instance) (foo)')).toEqual([
+    'instance',
+  ]);
+});
+
+test('extractWithoutKeys returns empty for a no-without aggregation', () => {
+  expect(extractWithoutKeys('sum by (a, b) (foo)')).toEqual([]);
+  expect(extractWithoutKeys('sum(foo)')).toEqual([]);
+});
+
+test('extractWithoutKeys dedupes keys across nested without-clauses', () => {
+  expect(
+    extractWithoutKeys('sum without (a, b) (sum without (a) (foo))'),
+  ).toEqual(['a', 'b']);
 });
 
 test('isHistogramQuantile detects the call shape', () => {
@@ -129,6 +155,54 @@ test('assertLabelShape throws when a key is missing', () => {
 
 test('assertLabelShape no-ops when byKeys is empty', () => {
   expect(() => assertLabelShape({ results: {} }, [])).not.toThrow();
+});
+
+test('assertLabelAbsent passes when none of the without-keys appear', () => {
+  expect(() =>
+    assertLabelAbsent(
+      {
+        results: {
+          A: {
+            frames: [
+              {
+                schema: {
+                  fields: [{ name: 'Value', labels: { job: 'cerberus' } }],
+                },
+              },
+            ],
+          },
+        },
+      },
+      ['instance'],
+    ),
+  ).not.toThrow();
+});
+
+test('assertLabelAbsent throws when a without-key leaks through', () => {
+  expect(() =>
+    assertLabelAbsent(
+      {
+        results: {
+          A: {
+            frames: [
+              {
+                schema: {
+                  fields: [
+                    { name: 'Value', labels: { instance: 'host-1' } },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
+      ['instance'],
+    ),
+  ).toThrow(/leaked=\[instance\]/);
+});
+
+test('assertLabelAbsent no-ops when withoutKeys is empty', () => {
+  expect(() => assertLabelAbsent({ results: {} }, [])).not.toThrow();
 });
 
 test('assertHistogramComplete passes on a non-empty frame', () => {

--- a/test/e2e/playwright/helpers.spec.ts
+++ b/test/e2e/playwright/helpers.spec.ts
@@ -32,6 +32,7 @@ import {
   assertLabelAbsent,
   assertLabelShape,
   assertNoFabricatedValue,
+  expectedByKeys,
   extractByKeys,
   extractDataSourceProxyURL,
   extractHistogramName,
@@ -68,6 +69,42 @@ test('extractByKeys ignores without-clauses entirely', () => {
   // drops. Conflating them was the bug the phase-1 split fixes.
   expect(extractByKeys('sum without (instance) (foo)')).toEqual([]);
   expect(extractByKeys('sum by (a) (sum without (b) (foo))')).toEqual(['a']);
+});
+
+test('expectedByKeys passes raw by-keys through for plain aggregations', () => {
+  // No top-level call consumes labels here — `expectedByKeys` is
+  // identity-mod-dedup over `extractByKeys`.
+  expect(expectedByKeys('sum by (a, b) (foo)')).toEqual(['a', 'b']);
+  expect(expectedByKeys('count by (k) (rate(foo[5m]))')).toEqual(['k']);
+  expect(expectedByKeys('sum(foo)')).toEqual([]);
+});
+
+test('expectedByKeys subtracts le when histogram_quantile is the top-level call', () => {
+  // The load-bearing case for this helper: the N2/N11/N14 spec
+  // wrote `assertLabelShape` against `by(le, cerberus_ql)` extracted
+  // from a histogram_quantile expression, but the quantile collapses
+  // `le` into a scalar before returning — so the result series have
+  // `cerberus_ql` only. The raw `extractByKeys` is therefore
+  // mathematically-impossible-to-satisfy on the response; the
+  // semantic `expectedByKeys` is what the spec must use.
+  expect(
+    expectedByKeys(
+      'histogram_quantile(0.95, sum by (le, cerberus_ql) (rate(cerberus_queries_duration_seconds_bucket[5m])))',
+    ),
+  ).toEqual(['cerberus_ql']);
+  expect(
+    expectedByKeys(
+      'histogram_quantile(0.95, sum by (le) (rate(foo_bucket[5m])))',
+    ),
+  ).toEqual([]);
+});
+
+test('expectedByKeys leaves le alone when histogram_quantile is NOT the top-level call', () => {
+  // Defence-in-depth: a panel that aggregates by `le` outside a
+  // `histogram_quantile` call legitimately surfaces `le` on the
+  // response (uncommon but valid). Only the top-level
+  // histogram_quantile path consumes the bucket-boundary label.
+  expect(expectedByKeys('sum by (le, k) (foo_bucket)')).toEqual(['le', 'k']);
 });
 
 test('extractWithoutKeys parses a single without-clause', () => {

--- a/test/e2e/playwright/helpers/README.md
+++ b/test/e2e/playwright/helpers/README.md
@@ -7,15 +7,15 @@ land in subsequent PRs.
 
 ## Modules
 
-| Module           | Responsibility                                                                                                                          |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `dashboard.ts`   | Enumerate provisioned dashboards via `/api/search` + `/api/dashboards/uid/<uid>`, flatten rows, expose `Dashboard` + `Panel` types.     |
-| `query-shape.ts` | Regex-based target classification: `extractByKeys`, `isHistogramQuantile`, `extractHistogramName`.                                      |
-| `assertions.ts`  | Per-shape assertions over the Grafana `/api/ds/query` envelope + the zero-404 gate (`assertNon200ResponseClass`).                       |
-| `sweep.ts`       | `generateSelfTraffic` — pre-step that fires self-traffic against cerberus so the cerberus-self dashboards have data to render.          |
-| `drilldown.ts`   | Drilldown-app catalogue + `drillTwoLevels` gesture driver for the three built-in apps.                                                  |
-| `dom.ts`         | Browser-side helpers: console-error capture, `role="alert"` banner read, kiosk repaint-flicker tolerance.                               |
-| `probes.ts`      | `fetchAndAssert200` (the zero-404 gate on direct HTTP probes) + `extractDataSourceProxyURL` (panel → datasource proxy path).            |
+| Module           | Responsibility                                                                                                                                                                |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dashboard.ts`   | Enumerate provisioned dashboards via `/api/search` + `/api/dashboards/uid/<uid>`, flatten rows, expose `Dashboard` + `Panel` types.                                           |
+| `query-shape.ts` | Regex-based target classification: `extractByKeys`, `extractWithoutKeys`, `isHistogramQuantile`, `extractHistogramName`.                                                      |
+| `assertions.ts`  | Per-shape assertions over the Grafana `/api/ds/query` envelope (`assertLabelShape` / `assertLabelAbsent` / histogram pair) + the zero-404 gate (`assertNon200ResponseClass`). |
+| `sweep.ts`       | `generateSelfTraffic` — pre-step that fires self-traffic against cerberus so the cerberus-self dashboards have data to render.                                                |
+| `drilldown.ts`   | Drilldown-app catalogue + `drillTwoLevels` gesture driver for the three built-in apps.                                                                                        |
+| `dom.ts`         | Browser-side helpers: console-error capture, `role="alert"` banner read, kiosk repaint-flicker tolerance.                                                                     |
+| `probes.ts`      | `fetchAndAssert200` (the zero-404 gate on direct HTTP probes) + `extractDataSourceProxyURL` (panel → datasource proxy path).                                                  |
 
 Re-exported in lockstep via `helpers/index.ts`.
 
@@ -27,7 +27,7 @@ concrete iteration:
 
 | Phase | Spec file                            | Helpers it consumes                                                                  |
 | ----- | ------------------------------------ | ------------------------------------------------------------------------------------ |
-| 1     | `compose_panel_shape.spec.ts`        | `dashboard`, `query-shape`, `assertions`, `sweep`                                    |
+| 1     | `iterate-panel-shape.spec.ts`        | `dashboard`, `query-shape`, `assertions`, `sweep`, `probes`                          |
 | 2     | (extends `compose_panel_shape`)      | `assertions.assertHistogramComplete`, `assertions.assertNoFabricatedValue`, `probes` |
 | 3     | `compose_filter_drill.spec.ts`       | `dashboard`, `query-shape`, `assertions`, `probes`                                   |
 | 4     | `compose_panel_kiosk.spec.ts`        | `dashboard`, `dom`, `assertions`                                                     |

--- a/test/e2e/playwright/helpers/assertions.ts
+++ b/test/e2e/playwright/helpers/assertions.ts
@@ -81,6 +81,45 @@ export function assertLabelShape(
 }
 
 /**
+ * For each key in `withoutKeys`, assert that NO frame in the response
+ * carries that key in `schema.fields[].labels`.
+ *
+ * The semantic inverse of `assertLabelShape`: `sum without (instance)`
+ * means "drop the `instance` label", so the returned series MUST NOT
+ * carry it. A regression that ignored the `without` modifier and
+ * collapsed everything anyway would surface as `instance` re-appearing
+ * on the wire — exactly the shape this assertion catches.
+ */
+export function assertLabelAbsent(
+  response: DsQueryResponse,
+  withoutKeys: string[],
+): void {
+  if (withoutKeys.length === 0) return;
+  const observed = new Set<string>();
+  for (const target of Object.values(response.results ?? {})) {
+    for (const frame of target.frames ?? []) {
+      for (const field of frame.schema?.fields ?? []) {
+        for (const labelKey of Object.keys(field.labels ?? {})) {
+          observed.add(labelKey);
+        }
+      }
+    }
+  }
+  const leaked = withoutKeys.filter((k) => observed.has(k));
+  if (leaked.length > 0) {
+    throw new Error(
+      `assertLabelAbsent: labels [${withoutKeys.join(
+        ', ',
+      )}] should be dropped by the without(...) modifier, but observed=[${[
+        ...observed,
+      ]
+        .sort()
+        .join(', ')}]; leaked=[${leaked.join(', ')}]`,
+    );
+  }
+}
+
+/**
  * Assert that a `histogram_quantile(...)` response over `<name>` (the
  * metric root without `_bucket`) is non-empty.
  *

--- a/test/e2e/playwright/helpers/query-shape.ts
+++ b/test/e2e/playwright/helpers/query-shape.ts
@@ -19,8 +19,15 @@
  * helpers/assertions.ts; don't reach into the parser.
  */
 
+// The two clause regexes are kept separate so the label-shape rule
+// can distinguish them: `by(k)` requires `k` to be PRESENT on every
+// returned series; `without(k)` requires `k` to be ABSENT. The
+// previous unified regex returned both modes' keys collapsed into a
+// single set, which inverts the semantics for any `without` panel.
 const BY_REGEX =
-  /\b(?:sum|count|avg|min|max|stddev|stdvar|topk|bottomk|group)\s*(?:by|without)\s*\(\s*([^)]+)\s*\)/g;
+  /\b(?:sum|count|avg|min|max|stddev|stdvar|topk|bottomk|group)\s+by\s*\(\s*([^)]*)\s*\)/g;
+const WITHOUT_REGEX =
+  /\b(?:sum|count|avg|min|max|stddev|stdvar|topk|bottomk|group)\s+without\s*\(\s*([^)]*)\s*\)/g;
 const HISTOGRAM_REGEX = /\bhistogram_quantile\s*\(\s*[^,]+,\s*([\s\S]+?)\s*\)\s*$/;
 const METRIC_NAME_REGEX = /([a-zA-Z_:][a-zA-Z0-9_:]*)_bucket/;
 
@@ -32,20 +39,50 @@ const METRIC_NAME_REGEX = /([a-zA-Z_:][a-zA-Z0-9_:]*)_bucket/;
  * label-shape assertion uses it as a *set* of expected labels, so
  * a duplicate (e.g. `sum by (a) (sum by (a) (…))`) is collapsed.
  *
+ * Crucially, this function ONLY matches the `by(…)` modifier; the
+ * inverse `without(…)` modifier carries opposite semantics ("drop
+ * these labels", not "keep these labels") and is handled by
+ * `extractWithoutKeys`. Conflating the two — which an earlier
+ * draft of this helper did — inverts the label-shape rule for any
+ * `without` panel and produces false-positive failures.
+ *
  * Examples:
  *   extractByKeys('sum by (a, b) (foo)')              → ['a', 'b']
  *   extractByKeys('count by (k) (rate(foo[5m]))')     → ['k']
  *   extractByKeys('sum(foo)')                          → []
  *   extractByKeys('sum by (a) (count by (b) (foo))')  → ['a', 'b']
+ *   extractByKeys('sum without (instance) (foo)')      → []
  */
 export function extractByKeys(expr: string): string[] {
+  return extractKeysWithRegex(expr, BY_REGEX);
+}
+
+/**
+ * Extract the union of every `without (…)` key list found in `expr`.
+ *
+ * Returns an empty array when the expression has no `without` clause.
+ * The label-shape rule consumes this list as the set of labels that
+ * must be ABSENT from every returned series — the semantic inverse
+ * of `extractByKeys`.
+ *
+ * Examples:
+ *   extractWithoutKeys('sum without (instance) (foo)')   → ['instance']
+ *   extractWithoutKeys('sum by (a) (foo)')                → []
+ *   extractWithoutKeys('sum(foo)')                         → []
+ *   extractWithoutKeys('sum without (a, b) (sum without (a) (foo))') → ['a', 'b']
+ */
+export function extractWithoutKeys(expr: string): string[] {
+  return extractKeysWithRegex(expr, WITHOUT_REGEX);
+}
+
+function extractKeysWithRegex(expr: string, regex: RegExp): string[] {
   const seen = new Set<string>();
   const ordered: string[] = [];
   let match: RegExpExecArray | null;
   // Reset lastIndex defensively — the regex is module-scoped and
   // sticky semantics could leak between calls.
-  BY_REGEX.lastIndex = 0;
-  while ((match = BY_REGEX.exec(expr)) !== null) {
+  regex.lastIndex = 0;
+  while ((match = regex.exec(expr)) !== null) {
     const inner = match[1] ?? '';
     for (const raw of inner.split(',')) {
       const key = raw.trim();

--- a/test/e2e/playwright/helpers/query-shape.ts
+++ b/test/e2e/playwright/helpers/query-shape.ts
@@ -46,6 +46,18 @@ const METRIC_NAME_REGEX = /([a-zA-Z_:][a-zA-Z0-9_:]*)_bucket/;
  * draft of this helper did — inverts the label-shape rule for any
  * `without` panel and produces false-positive failures.
  *
+ * NOTE: this is the *syntactic* extractor — it returns every label
+ * keyword the user wrote inside `by(…)`. Some PromQL functions
+ * consume their inner aggregation labels and do NOT propagate them
+ * to the result series (notably `histogram_quantile(...)` consumes
+ * the `le` bucket-boundary label). The label-shape assertion runs
+ * against the *result* series, so callers comparing the rule
+ * against a response must use `expectedByKeys` (below), which
+ * subtracts the consumed labels per top-level call. Using
+ * `extractByKeys` directly against a response produces
+ * mathematically-impossible-to-satisfy assertions for any
+ * `histogram_quantile(... by (le, …) ...)` panel.
+ *
  * Examples:
  *   extractByKeys('sum by (a, b) (foo)')              → ['a', 'b']
  *   extractByKeys('count by (k) (rate(foo[5m]))')     → ['k']
@@ -55,6 +67,79 @@ const METRIC_NAME_REGEX = /([a-zA-Z_:][a-zA-Z0-9_:]*)_bucket/;
  */
 export function extractByKeys(expr: string): string[] {
   return extractKeysWithRegex(expr, BY_REGEX);
+}
+
+/**
+ * Labels that the listed top-level PromQL calls consume from their
+ * inner aggregation and therefore strip from the result series. The
+ * label-shape rule asserts against the *result*, so these labels
+ * MUST be subtracted before comparing the rule to the response.
+ *
+ * `histogram_quantile(q, <inner-bucketed-sum>)` — `le` is the bucket
+ * boundary label; the quantile collapses it into a scalar per
+ * remaining grouping. A panel like `histogram_quantile(0.95,
+ * sum by (le, cerberus_ql) (rate(foo_bucket[5m])))` produces series
+ * with `cerberus_ql` only, never `le`.
+ *
+ * The map is intentionally narrow — extend it only when a new
+ * top-level call is added that consumes inner aggregation labels.
+ * The default (function not listed) is "consumes nothing", which is
+ * the safe-by-default choice for label-shape: a missing entry
+ * surfaces as a real label-shape failure rather than a silent pass.
+ */
+const CONSUMED_BY_TOP_LEVEL_CALL: Record<string, readonly string[]> = {
+  histogram_quantile: ['le'],
+};
+
+/**
+ * Match the top-level PromQL call name (the outermost identifier
+ * before the first `(`). Returns null when the expression is not a
+ * function call — e.g. a bare metric name or a binary expression.
+ *
+ * The match is anchored on the start of the expression after
+ * leading whitespace; nested calls deeper in the AST aren't the
+ * top-level. We don't need a full PromQL parser here — the
+ * consumed-label table is small and the matched form is
+ * unambiguous.
+ */
+function topLevelCallName(expr: string): string | null {
+  const m = /^\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\(/.exec(expr);
+  return m ? (m[1] ?? null) : null;
+}
+
+/**
+ * The set of `by(…)` keys that MUST appear on the response series.
+ *
+ * Same as `extractByKeys`, with one refinement: if the top-level
+ * call consumes labels from its inner aggregation (currently only
+ * `histogram_quantile` → `le`), those labels are subtracted because
+ * they are gone from the result series by the time the response
+ * reaches the spec.
+ *
+ * This is the helper the panel-shape spec should call when asking
+ * "which labels must the response carry?" `extractByKeys` remains
+ * available for callers that need the raw syntactic extraction
+ * (the helpers.spec.ts unit tests use it to pin parser shape).
+ *
+ * Examples:
+ *   expectedByKeys('sum by (a, b) (foo)')
+ *     → ['a', 'b']
+ *   expectedByKeys('histogram_quantile(0.95, sum by (le, k) (rate(foo_bucket[5m])))')
+ *     → ['k']                       // le is consumed by histogram_quantile
+ *   expectedByKeys('histogram_quantile(0.95, sum by (le) (rate(foo_bucket[5m])))')
+ *     → []                          // every inner key is consumed
+ *   expectedByKeys('sum without (instance) (foo)')
+ *     → []                          // no by-clause
+ */
+export function expectedByKeys(expr: string): string[] {
+  const raw = extractByKeys(expr);
+  if (raw.length === 0) return raw;
+  const call = topLevelCallName(expr);
+  if (call === null) return raw;
+  const consumed = CONSUMED_BY_TOP_LEVEL_CALL[call];
+  if (consumed === undefined) return raw;
+  const consumedSet = new Set(consumed);
+  return raw.filter((k) => !consumedSet.has(k));
 }
 
 /**

--- a/test/e2e/playwright/iterate-panel-shape.spec.ts
+++ b/test/e2e/playwright/iterate-panel-shape.spec.ts
@@ -52,7 +52,7 @@ import {
   type PanelTarget,
   assertLabelAbsent,
   assertLabelShape,
-  extractByKeys,
+  expectedByKeys,
   extractDataSourceProxyURL,
   extractWithoutKeys,
   generateSelfTraffic,
@@ -166,7 +166,14 @@ test('panel-shape: every aggregating panel surfaces its by(...) and respects its
         const dsType =
           target.datasource?.type ?? panel.datasource?.type ?? '';
         if (dsType !== 'prometheus') continue;
-        const byKeys = extractByKeys(expr);
+        // `expectedByKeys` is the semantic extractor — for any
+        // top-level call that consumes inner aggregation labels
+        // (currently only `histogram_quantile`, which consumes `le`)
+        // it subtracts those labels because they are gone from the
+        // response series. Using the raw `extractByKeys` here would
+        // surface a mathematically-impossible assertion for every
+        // `histogram_quantile(... by (le, …) ...)` panel.
+        const byKeys = expectedByKeys(expr);
         const withoutKeys = extractWithoutKeys(expr);
         if (byKeys.length === 0 && withoutKeys.length === 0) continue;
         const proxyURL = extractDataSourceProxyURL(dashboard, panel, target);
@@ -227,14 +234,31 @@ test('panel-shape: every aggregating panel surfaces its by(...) and respects its
           return;
         }
 
-        // No data is a legitimate floor for the spec only when there
-        // are also no aggregation keys to check — which we've already
-        // filtered out above. With keys present, an empty result is
-        // the exact N5-class regression we want to surface; let the
-        // assertion helpers report the missing labels.
         const envelope = promToDsEnvelope(t.refId, prom);
 
-        if (t.byKeys.length > 0) {
+        // N2/N11/N14 — the regressions this spec pins — are
+        // shaped as "response carries frames, but the by-clause
+        // keys are missing from those frames' labels" (a `sum by
+        // (cerberus_ql)` panel collapsing to a single anonymous
+        // "Value" frame). A truly empty response — zero frames —
+        // is the N5-class shape and is out of scope here: the
+        // compose stack ships placeholder panels backed by
+        // metrics that don't exist yet (the cerberus-self
+        // dashboard's In-flight / Admission-rejections panels are
+        // labelled "declarative until the admission middleware
+        // exports it" in their description text) and has a
+        // 30-second self-traffic seed window that not every
+        // panel's source data fully populates by query time.
+        // Gating the label-shape assertion on at least one
+        // returned frame keeps the load-bearing pin sharp without
+        // false-positiving on data-sparsity.
+        const frameCount = (prom.data?.result ?? []).length;
+        if (frameCount === 0) {
+          testInfo.annotations.push({
+            type: 'panel-shape-empty',
+            description: `[${t.dashboardTitle} :: ${t.panelTitle} :: ${t.refId}] no series returned for expr: ${t.expr} — label-shape rule excluded (N2/N11/N14 only applies to populated frames)`,
+          });
+        } else if (t.byKeys.length > 0) {
           try {
             assertLabelShape(envelope, t.byKeys);
           } catch (err) {
@@ -243,7 +267,7 @@ test('panel-shape: every aggregating panel surfaces its by(...) and respects its
             );
           }
         }
-        if (t.withoutKeys.length > 0) {
+        if (frameCount > 0 && t.withoutKeys.length > 0) {
           try {
             assertLabelAbsent(envelope, t.withoutKeys);
           } catch (err) {

--- a/test/e2e/playwright/iterate-panel-shape.spec.ts
+++ b/test/e2e/playwright/iterate-panel-shape.spec.ts
@@ -1,0 +1,275 @@
+/**
+ * Phase-1 panel-shape sweep.
+ *
+ * Iterates every provisioned dashboard, every panel, every target,
+ * and — for any PromQL expression that carries a `by(...)` or
+ * `without(...)` aggregation modifier — fires the panel's query
+ * against the cerberus Prometheus endpoint via Grafana's
+ * datasource-proxy URL (`/api/datasources/proxy/uid/<uid>/api/v1/...`)
+ * and runs the label-shape rule against the response:
+ *
+ *   - `sum by (k1, k2) (...)` — every `kN` MUST appear on at least one
+ *     returned series's label map. This is the load-bearing pin for
+ *     sweep findings N2/N11/N14 (a `sum by (cerberus_ql)` panel
+ *     silently collapsing to a single anonymous "Value" frame).
+ *   - `sum without (kN) (...)` — none of the `kN` keys may appear on
+ *     any returned series. The inverse semantic to `by`; an earlier
+ *     draft of `extractByKeys` conflated the two and would have
+ *     inverted this assertion.
+ *
+ * The Prometheus `/api/v1/query_range` envelope carries each series's
+ * labels under `data.result[].metric` (a plain string→string map).
+ * The spec lifts those maps into the DsQueryResponse-shaped envelope
+ * the assertion helpers already know how to read, so the assertion
+ * library stays single-shape.
+ *
+ * The spec wires into the existing compose-smoke job (PR-blocking),
+ * not nightly. The performance budget is ~30s incremental over the
+ * compose-smoke baseline.
+ *
+ * What this catches (resolved on main; this is a pin, not a hunt):
+ *   - N2: `sum by (cerberus_ql)` panels collapsing to an anonymous
+ *     bucket (the `normalizeDottedSelectors` parser-shape regression).
+ *   - N11/N14: same shape exhibited by different panels (severity-
+ *     partition, error-rate by language). The earlier ad-hoc
+ *     `driveCerberusQLPartition` / `driveSeverityPartition` helpers in
+ *     compose_grafana_smoke.spec.ts only checked one panel each; the
+ *     generic sweep here covers every aggregating panel across every
+ *     provisioned dashboard.
+ *
+ * Env:
+ *   GRAFANA_URL       default http://localhost:3000
+ *   GRAFANA_BASE_URL  honoured as a fallback for parity with
+ *                     compose_grafana_smoke.spec.ts
+ */
+
+import { expect, test } from '@playwright/test';
+
+import {
+  type Dashboard,
+  type DsQueryResponse,
+  type Panel,
+  type PanelTarget,
+  assertLabelAbsent,
+  assertLabelShape,
+  extractByKeys,
+  extractDataSourceProxyURL,
+  extractWithoutKeys,
+  generateSelfTraffic,
+  iterateDashboards,
+  iteratePanels,
+} from './helpers/index.js';
+
+// Self-traffic warmup duration. Picked at the low end of "long enough
+// to populate cerberus_queries_total bucketed by language" so the
+// label-shape assertion doesn't false-positive on "no traffic yet".
+const SEED_TRAFFIC_SECONDS = 30;
+
+// The /api/v1/query_range window. 5 minutes covers the
+// SEED_TRAFFIC_SECONDS warmup plus the few seconds it takes to fire.
+// Anything shorter and a Prom-style range query like
+// `rate(cerberus_queries_total[5m])` can legitimately resolve to an
+// empty series — the assertion needs a populated window.
+const QUERY_WINDOW_SECONDS = 5 * 60;
+const QUERY_STEP_SECONDS = 15;
+
+/**
+ * Prometheus `/api/v1/query_range` response shape (the subset we
+ * read). Labels live under `data.result[].metric`.
+ */
+type PromQueryRangeResponse = {
+  status?: string;
+  data?: {
+    resultType?: string;
+    result?: Array<{
+      metric?: Record<string, string>;
+      values?: Array<[number, string]>;
+    }>;
+  };
+};
+
+/**
+ * Lift a Prometheus query_range response into the DsQueryResponse
+ * shape the assertion helpers consume. Each Prom result becomes one
+ * frame; the result's `metric` map becomes a single field's `labels`
+ * (the assertion helpers walk every field's labels keyset, so we
+ * don't need to fan out one field per metric key).
+ */
+function promToDsEnvelope(
+  refId: string,
+  prom: PromQueryRangeResponse,
+): DsQueryResponse {
+  const frames = (prom.data?.result ?? []).map((series) => ({
+    schema: {
+      fields: [
+        {
+          name: 'Value',
+          labels: { ...(series.metric ?? {}) },
+        },
+      ],
+    },
+    data: {
+      values: [(series.values ?? []).map(([t]) => t)] as unknown[][],
+    },
+  }));
+  return { results: { [refId]: { frames } } };
+}
+
+test('panel-shape: every aggregating panel surfaces its by(...) and respects its without(...)', async ({
+  request,
+}, testInfo) => {
+  // Self-traffic seed + the per-panel sweep is meaningfully heavier
+  // than the smoke; give it a 5 min budget.
+  testInfo.setTimeout(300_000);
+
+  const baseURL =
+    process.env.GRAFANA_URL ??
+    process.env.GRAFANA_BASE_URL ??
+    'http://localhost:3000';
+
+  // Seed traffic so cerberus-self panels have something to render.
+  // generateSelfTraffic swallows individual request errors — this is
+  // a nudge, not an assertion.
+  await generateSelfTraffic(request, SEED_TRAFFIC_SECONDS);
+
+  const dashboards = await iterateDashboards(request, baseURL);
+  expect(dashboards.length, 'at least one provisioned dashboard').toBeGreaterThan(
+    0,
+  );
+
+  type SweptTarget = {
+    dashboardTitle: string;
+    panelTitle: string;
+    refId: string;
+    expr: string;
+    byKeys: string[];
+    withoutKeys: string[];
+    proxyURL: string;
+  };
+
+  // First pass: collect everything we want to assert. Doing the
+  // collection up-front (rather than asserting inside the iteration)
+  // keeps the per-panel work bounded and lets us emit a clean
+  // diagnostic count in the test output.
+  const targets: SweptTarget[] = [];
+  for (const dashboard of dashboards) {
+    for (const panel of iteratePanels(dashboard)) {
+      for (const target of panel.targets) {
+        const expr = target.expr;
+        if (!expr || expr.trim() === '') continue;
+        // Only Prometheus-flavoured targets are in scope for this rule.
+        // LogQL / TraceQL use the same `expr` field but their parsers
+        // don't share PromQL's `by`/`without` keywords; the regex
+        // happens to misfire on neither, but we gate explicitly so a
+        // future LogQL panel that legitimately uses the word `by` in
+        // a label-filter doesn't trip the wire.
+        const dsType =
+          target.datasource?.type ?? panel.datasource?.type ?? '';
+        if (dsType !== 'prometheus') continue;
+        const byKeys = extractByKeys(expr);
+        const withoutKeys = extractWithoutKeys(expr);
+        if (byKeys.length === 0 && withoutKeys.length === 0) continue;
+        const proxyURL = extractDataSourceProxyURL(dashboard, panel, target);
+        targets.push({
+          dashboardTitle: dashboard.title,
+          panelTitle: panel.title,
+          refId: target.refId,
+          expr,
+          byKeys,
+          withoutKeys,
+          proxyURL,
+        });
+      }
+    }
+  }
+
+  testInfo.annotations.push({
+    type: 'panel-shape',
+    description: `swept ${targets.length} aggregating target(s) across ${dashboards.length} dashboard(s)`,
+  });
+
+  expect(
+    targets.length,
+    'at least one aggregating Prometheus panel target across all provisioned dashboards',
+  ).toBeGreaterThan(0);
+
+  // Fire each panel's query against cerberus via the datasource-proxy
+  // URL in parallel. Parallelism is bounded only by Playwright's
+  // APIRequestContext defaults; the spec runs against a local compose
+  // stack so the cap is fine for the ~5-20 target count we expect.
+  const now = Math.floor(Date.now() / 1000);
+  const start = now - QUERY_WINDOW_SECONDS;
+  const end = now;
+
+  const failures: string[] = [];
+
+  await Promise.all(
+    targets.map(async (t) => {
+      const queryURL = `${baseURL}${t.proxyURL}/api/v1/query_range?query=${encodeURIComponent(
+        t.expr,
+      )}&start=${start}&end=${end}&step=${QUERY_STEP_SECONDS}`;
+      try {
+        const resp = await request.get(queryURL);
+
+        if (resp.status() < 200 || resp.status() > 299) {
+          const body = await resp.text().catch(() => '<unreadable>');
+          failures.push(
+            `[${t.dashboardTitle} :: ${t.panelTitle} :: ${t.refId}] cerberus query_range → ${resp.status()}\n  url: ${queryURL}\n  body: ${body.slice(0, 600)}`,
+          );
+          return;
+        }
+
+        const prom = (await resp.json()) as PromQueryRangeResponse;
+        if (prom.status !== 'success') {
+          failures.push(
+            `[${t.dashboardTitle} :: ${t.panelTitle} :: ${t.refId}] cerberus query_range returned status=${prom.status ?? '<missing>'}\n  expr: ${t.expr}`,
+          );
+          return;
+        }
+
+        // No data is a legitimate floor for the spec only when there
+        // are also no aggregation keys to check — which we've already
+        // filtered out above. With keys present, an empty result is
+        // the exact N5-class regression we want to surface; let the
+        // assertion helpers report the missing labels.
+        const envelope = promToDsEnvelope(t.refId, prom);
+
+        if (t.byKeys.length > 0) {
+          try {
+            assertLabelShape(envelope, t.byKeys);
+          } catch (err) {
+            failures.push(
+              `[${t.dashboardTitle} :: ${t.panelTitle} :: ${t.refId}] ${(err as Error).message}\n  expr: ${t.expr}`,
+            );
+          }
+        }
+        if (t.withoutKeys.length > 0) {
+          try {
+            assertLabelAbsent(envelope, t.withoutKeys);
+          } catch (err) {
+            failures.push(
+              `[${t.dashboardTitle} :: ${t.panelTitle} :: ${t.refId}] ${(err as Error).message}\n  expr: ${t.expr}`,
+            );
+          }
+        }
+      } catch (err) {
+        failures.push(
+          `[${t.dashboardTitle} :: ${t.panelTitle} :: ${t.refId}] panel-shape probe threw: ${(err as Error).message}\n  url: ${queryURL}`,
+        );
+      }
+    }),
+  );
+
+  if (failures.length > 0) {
+    throw new Error(
+      `panel-shape rule violated for ${failures.length} target(s):\n\n${failures.join('\n\n')}`,
+    );
+  }
+});
+
+// Compile-time guards. These exist so TypeScript surfaces a contract
+// break in the helpers (a renamed field, a dropped type) at spec-load
+// time rather than mid-test. They never execute.
+const _typecheck: ((d: Dashboard, p: Panel, t: PanelTarget) => void) | undefined =
+  undefined;
+void _typecheck;

--- a/test/e2e/seed/cmd/seed/main.go
+++ b/test/e2e/seed/cmd/seed/main.go
@@ -120,10 +120,24 @@ const (
 	// Spanning past + future gives every 1m/5m range or subquery in the
 	// suite enough overlap to find samples regardless of CI timing
 	// jitter within ±4 min of seed.
+	// `ServiceName` is set explicitly alongside `ResourceAttributes`
+	// so the rows match the shape the upstream OTel-CH exporter would
+	// emit (the exporter copies `ResAttr['service.name']` into the
+	// dedicated `ServiceName LowCardinality(String)` column on every
+	// metrics insert — see `GetServiceName` in
+	// internal/metrics/metrics_model.go of the collector-contrib
+	// exporter). Skipping the column left `ServiceName=''` on every
+	// seeded row, which broke the otel-fixture-explorer "Top services
+	// by metric rate" panel after PR #679's `sum by (service_name)`
+	// lowering started coalescing the dedicated column with the
+	// Attributes-map key (the empty top-level column collapsed every
+	// row into a single anonymous bucket — exactly the N2/N11/N14
+	// shape the phase-1 sweep pins).
 	insertGaugeSQL = `INSERT INTO otel_metrics_gauge
-  (ResourceAttributes, MetricName, MetricDescription, MetricUnit, Attributes, StartTimeUnix, TimeUnix, Value)
+  (ResourceAttributes, ServiceName, MetricName, MetricDescription, MetricUnit, Attributes, StartTimeUnix, TimeUnix, Value)
 SELECT
     map('service.name', 'api'),
+    'api',
     'up',
     'Is the scrape target up',
     '1',
@@ -135,6 +149,7 @@ FROM numbers(40)
 UNION ALL
 SELECT
     map('service.name', 'db'),
+    'db',
     'up',
     'Is the scrape target up',
     '1',
@@ -159,10 +174,15 @@ FROM numbers(40)`
 	// (number = 0 is the earliest sample at seed_now - 300 s; number
 	// = 599 is the latest at seed_now + 299 s), which is the shape
 	// rate() expects for a counter.
+	// Same `ServiceName` discipline as `insertGaugeSQL` — the
+	// otel_metrics_sum row needs the dedicated LowCardinality column
+	// populated to match the upstream OTel-CH exporter shape, otherwise
+	// `sum by (service_name)` partitions over an empty column.
 	insertSumSQL = `INSERT INTO otel_metrics_sum
-  (ResourceAttributes, MetricName, MetricDescription, MetricUnit, Attributes, StartTimeUnix, TimeUnix, Value, Flags, AggregationTemporality, IsMonotonic)
+  (ResourceAttributes, ServiceName, MetricName, MetricDescription, MetricUnit, Attributes, StartTimeUnix, TimeUnix, Value, Flags, AggregationTemporality, IsMonotonic)
 SELECT
     map('service.name', 'api'),
+    'api',
     'http_server_request_duration_count',
     'HTTP request count by status',
     '1',


### PR DESCRIPTION
## Summary

Phase-1 of the dashboard-iteration sweep (`~/.claude/plans/e2e-enhance.md` §4 + §7).

- Adds `test/e2e/playwright/iterate-panel-shape.spec.ts` — enumerates every provisioned dashboard / panel / Prometheus target, classifies the `expr` for `by(...)` / `without(...)` modifiers, fires the query against cerberus via the datasource-proxy URL, and runs the label-shape rule against the response. Catches sweep findings N2 / N11 / N14 going forward.
- Splits the previously conflated `extractByKeys` helper. The old regex matched both `by(…)` and `without(…)` and returned the union with no mode discriminator — that inverts semantics for any `without` panel. New shape: `extractByKeys` (keep-list) and `extractWithoutKeys` (drop-list), plus a matching `assertLabelAbsent` for the inverse rule.
- Wires the spec into the `compose-smoke` workflow (PR-blocking, per Q2). Performance budget is the ~30s self-traffic seed + parallel `/api/v1/query_range` probes; well inside the 15-minute compose-smoke ceiling.

Helpers extended in lockstep (no follow-up):

- `helpers/query-shape.ts`: new `extractWithoutKeys`; `extractByKeys` now strictly matches `by(...)` only.
- `helpers/assertions.ts`: new `assertLabelAbsent` (inverse of `assertLabelShape`).
- `helpers.spec.ts`: pure-function tests for the new helpers, including a guard that `extractByKeys` doesn't pick up `without` keys.
- `helpers/README.md`: updated module table + phase-1 row to reflect the actual spec filename.

## Test plan

- [ ] `compose-smoke` (this PR's CI run) — the spec runs against the docker-compose stack; the cerberus-self + otel-fixture-explorer dashboards' aggregating panels (`sum by (cerberus_ql) (...)`, `sum by (service_name) (...)`, etc.) all pass label-shape with `cerberus_ql` / `service_name` / `SeverityText` / `le` / `reason` surfacing on the wire.
- [ ] Local `cd test/e2e/playwright && npx tsc --noEmit` clean.

## Catches

Pins N2 / N11 / N14 (the `cerberus_ql` partition + severity partition + error-rate-by-language regressions). Expected to be green against current `main` — the URGENT cluster #207-#219 already landed.