### PR TITLE
fix(promql): route service_name matcher + by-clause to ServiceName column (#232)

### DIFF
--- a/internal/api/prom/conformance_test.go
+++ b/internal/api/prom/conformance_test.go
@@ -1585,6 +1585,95 @@ func TestConformance_LabelValuesGrammar(t *testing.T) {
 	}
 }
 
+// TestConformance_ServiceNameMatcherRoutesToTopLevelColumn pins task
+// #232: `{service_name="cerberus"}` (and the dotted-canonical sibling)
+// must hit the dedicated OTel-CH `ServiceName LowCardinality(String)`
+// column via `coalesce(nullIf(ServiceName, ”),
+// Attributes['service.name']-fallback)` — not just the Attributes-map
+// lookup. Without this routing every OTel-collector-routed row
+// (which carries the value ONLY in the top-level column with no
+// Attributes entry) silently returns the empty string and the
+// selector returns zero series. Mirrors LogQL's task #217 fix
+// (PR #669) and the exemplars handler's ServiceName precedence.
+//
+// The assertion targets the captured SQL: `coalesce(nullIf(`ServiceName`
+// + the literal `”` empty-sentinel must appear so the matcher's lhs
+// reads from the dedicated column first.
+func TestConformance_ServiceNameMatcherRoutesToTopLevelColumn(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{"underscored", `cerberus_queries_total{service_name="cerberus"}`},
+		{"dotted", `cerberus_queries_total{"service.name"="cerberus"}`},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			stub := &stubQuerier{samples: nil}
+			srv := newServer(stub)
+			t.Cleanup(srv.Close)
+
+			q := url.QueryEscape(tc.query)
+			resp, err := http.Get(srv.URL + "/api/v1/query?query=" + q + "&time=1717999200")
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status=%d (expected 200)", resp.StatusCode)
+			}
+			if stub.lastSQL == "" {
+				t.Fatalf("stub.lastSQL is empty; expected handler to have invoked the CH client")
+			}
+			if !strings.Contains(stub.lastSQL, "coalesce(nullIf(`ServiceName`") {
+				t.Errorf("SQL is missing the `coalesce(nullIf(ServiceName, ''), ...)` routing for the service.name matcher\nSQL: %s", stub.lastSQL)
+			}
+		})
+	}
+}
+
+// TestConformance_ServiceNameByClauseAugmentsAttributes pins the
+// outer-aggregation by-clause shape for task #232: `sum by
+// (service_name) (rate(...))` must inflate the per-row Attributes
+// with a synthesised `service_name` key sourced from the top-level
+// `ServiceName` column. Without this, every row collapses into a
+// single `{service_name:""}` bucket because `Attributes['service_name']`
+// returns the empty string for OTel-collector-routed rows.
+//
+// The assertion targets the captured SQL: `mapConcat(`Attributes`,
+// mapFilter(...))` + `toString(`ServiceName`)` must appear in the
+// inner subquery so the augmenting Project lands above the Scan.
+func TestConformance_ServiceNameByClauseAugmentsAttributes(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubQuerier{samples: nil}
+	srv := newServer(stub)
+	t.Cleanup(srv.Close)
+
+	q := url.QueryEscape(`sum by (service_name) (rate(cerberus_queries_total[5m]))`)
+	resp, err := http.Get(srv.URL + "/api/v1/query?query=" + q + "&time=1717999200")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d (expected 200)", resp.StatusCode)
+	}
+	if stub.lastSQL == "" {
+		t.Fatalf("stub.lastSQL is empty; expected handler to have invoked the CH client")
+	}
+	if !strings.Contains(stub.lastSQL, "mapConcat(`Attributes`") {
+		t.Errorf("SQL is missing the `mapConcat(Attributes, ...)` augmentation for the service_name by-clause\nSQL: %s", stub.lastSQL)
+	}
+	if !strings.Contains(stub.lastSQL, "toString(`ServiceName`)") {
+		t.Errorf("SQL is missing the `toString(ServiceName)` synthesised key for the service_name by-clause\nSQL: %s", stub.lastSQL)
+	}
+}
+
 // TestConformance_UnderscoredMatcherEmitsDottedFallback pins the
 // matcher-side resolution for underscored Prom-grammar names that
 // could resolve to a dotted OTel-canonical key in storage. Without

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -215,6 +215,19 @@ func lowerVectorSelector(v *parser.VectorSelector, s schema.Metrics, ctx lowerCt
 		return nil, err
 	}
 
+	// When an enclosing vector aggregation's by-clause references a
+	// label that routes to a dedicated top-level OTel-CH column
+	// (currently only `service.name` / `service_name` → ServiceName),
+	// inflate Attributes with one synthesised key per such column so
+	// the downstream LWR / RangeWindow groups partition over the
+	// effective series identity. Without this, rows with distinct
+	// ServiceName collapse into a single Attributes bucket — the
+	// `sum by (service_name) (rate({__name__=~".+"}[5m]))` task-#232
+	// bug. The Project lands between the Scan/Filter and the per-mode
+	// wraps so PREWHERE-eligible matchers stay on the raw Scan
+	// (the optimizer's promotion path is untouched).
+	selectorInput = augmentSelectorAttributes(selectorInput, ctx, s)
+
 	if ctx.inRangeVector {
 		// Inside a range vector / subquery the surrounding node owns
 		// the per-window aggregation. We still apply the modifier's
@@ -287,6 +300,47 @@ func wrapHistogramCompanionProject(scan *chplan.Scan, sourceColumn string, s sch
 				},
 				Alias: s.ValueColumn,
 			},
+		},
+	}
+}
+
+// augmentSelectorAttributes wraps `input` with a Project that rebinds
+// the Attributes column to `mapConcat(Attributes, <synthesised top-
+// level columns>)` when the enclosing aggregation's by-clause
+// (threaded via [lowerCtx.outerByLabels]) references a label that
+// routes to a dedicated top-level OTel-CH column. When the by-clause
+// references no such label — the common case — the function returns
+// `input` unchanged so existing fixture SQL stays byte-identical.
+//
+// The Project's column shape preserves the canonical Sample-row
+// quadruple (MetricName, Attributes, TimeUnix, Value) the downstream
+// LWR / RangeWindow consumes. The dedicated top-level column
+// (ServiceName) is read by `augmentAttributesForOuterBy` from the
+// row's input scope — when `input` is a Scan / Filter the column is
+// directly addressable; when `input` is a `wrapHistogramCompanion-
+// Project` the column flows through unchanged because the histogram
+// companion Project preserves every original Scan column the next
+// SELECT references (CH resolves `ServiceName` against the inner
+// subquery's underlying table).
+//
+// Mirrors the LogQL augmenting wrap in
+// [internal/logql.withDetectedLevelAndColumns] (PR #666 / task #218)
+// at a different layer: LogQL inflates the post-RangeWindow identity
+// map; PromQL inflates the pre-RangeWindow per-row Attributes so the
+// RangeWindow's `GROUP BY Attributes` already partitions over the
+// distinct ServiceName values.
+func augmentSelectorAttributes(input chplan.Node, ctx lowerCtx, s schema.Metrics) chplan.Node {
+	augmented := augmentAttributesForOuterBy(s, ctx.outerByLabels)
+	if augmented == nil {
+		return input
+	}
+	return &chplan.Project{
+		Input: input,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.ColumnRef{Name: s.MetricNameColumn}, Alias: s.MetricNameColumn},
+			{Expr: augmented, Alias: s.AttributesColumn},
+			{Expr: &chplan.ColumnRef{Name: s.TimestampColumn}, Alias: s.TimestampColumn},
+			{Expr: &chplan.ColumnRef{Name: s.ValueColumn}, Alias: s.ValueColumn},
 		},
 	}
 }
@@ -742,12 +796,12 @@ func buildPredicate(matchers []*labels.Matcher, s schema.Metrics) chplan.Expr {
 //
 // The two paths must share the matcher → predicate translation so the
 // exemplars endpoint applies the same Attributes-map lookup, the same
-// regex semantics, and the same MetricName-column routing the rest of
-// PromQL uses. Sharing keeps "what does `label=~regex` mean" defined
-// in exactly one place; future schema-aware matcher rewrites (e.g.
-// pushing `service.name` to [schema.Metrics.ServiceNameColumn] instead
-// of the Attributes map) land in [matcherToExpr] and flow to every
-// caller automatically.
+// regex semantics, and the same MetricName-column / schema-aware
+// top-level-column routing the rest of PromQL uses. Sharing keeps
+// "what does `label=~regex` mean" defined in exactly one place;
+// schema-aware matcher rewrites (e.g. pushing `service.name` to
+// [schema.Metrics.ServiceNameColumn] instead of the Attributes map)
+// live in [matcherToExpr] and flow to every caller automatically.
 //
 // Returns nil for an empty matcher list — callers fold a nil
 // predicate into "no WHERE clause" rather than emitting a `WHERE true`
@@ -756,12 +810,49 @@ func BuildMatcherPredicate(matchers []*labels.Matcher, s schema.Metrics) chplan.
 	return buildPredicate(matchers, s)
 }
 
+// matcherToExpr resolves a single PromQL label matcher into the
+// chplan predicate that lands on the inner Scan's Filter. The three
+// routing branches are:
+//
+//  1. `__name__` — references the dedicated MetricName column.
+//
+//  2. A label that names a top-level OTel-CH column (currently only
+//     `service.name` / `service_name` → `ServiceName`). The lookup
+//     coalesces the dedicated column with the Attributes-map fallback
+//     so producers that wrote either side (OTel-collector → top-level
+//     column; raw inserts → Attributes-map key) both resolve.
+//     `nullIf(<col>, ”)` rewrites the String-default-empty sentinel
+//     back to NULL so `coalesce` selects the map fallback when the
+//     dedicated column is unpopulated. Mirrors the LogQL fix from
+//     PR #669 / task #217 in [internal/logql.matcherToExpr].
+//
+//  3. Anything else — falls through to the Attributes-map lookup
+//     (with the dot/underscore candidate expansion documented on
+//     [attributeLookup]).
 func matcherToExpr(m *labels.Matcher, s schema.Metrics) chplan.Expr {
 	var lhs chplan.Expr
-	if m.Name == model.MetricNameLabel {
+	switch {
+	case m.Name == model.MetricNameLabel:
 		lhs = &chplan.ColumnRef{Name: s.MetricNameColumn}
-	} else {
-		lhs = attributeLookup(s.AttributesColumn, m.Name)
+	default:
+		mapLookup := attributeLookup(s.AttributesColumn, m.Name)
+		if col := schemaTopLevelColumn(s, m.Name); col != "" {
+			lhs = &chplan.FuncCall{
+				Name: "coalesce",
+				Args: []chplan.Expr{
+					&chplan.FuncCall{
+						Name: "nullIf",
+						Args: []chplan.Expr{
+							&chplan.ColumnRef{Name: col},
+							&chplan.LitString{V: ""},
+						},
+					},
+					mapLookup,
+				},
+			}
+		} else {
+			lhs = mapLookup
+		}
 	}
 	return &chplan.Binary{
 		Op:    matchOp(m.Type),
@@ -1088,7 +1179,20 @@ func lowerAggregate(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) (ch
 		return lowerCountValues(a, s, ctx)
 	}
 
-	input, err := lower(a.Expr, s, ctx)
+	// Thread the outer by-clause's labels down so the inner selector
+	// path can inflate Attributes with the top-level OTel-CH columns
+	// (currently `service_name` → `ServiceName`) the outer aggregate
+	// needs to partition over. Only `by(...)` propagates — `without(...)`
+	// exclusion semantics don't reference specific columns, so the
+	// without branch keeps the lean Attributes shape. See
+	// [augmentAttributesForOuterBy] for the resulting Project wrap and
+	// [internal/logql.lowerCtx.OuterByLabels] for the LogQL precedent
+	// (PR #666 / task #218).
+	innerCtx := ctx
+	if !a.Without {
+		innerCtx = ctx.withOuterByLabels(a.Grouping)
+	}
+	input, err := lower(a.Expr, s, innerCtx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -831,10 +831,9 @@ func BuildMatcherPredicate(matchers []*labels.Matcher, s schema.Metrics) chplan.
 //     [attributeLookup]).
 func matcherToExpr(m *labels.Matcher, s schema.Metrics) chplan.Expr {
 	var lhs chplan.Expr
-	switch {
-	case m.Name == model.MetricNameLabel:
+	if m.Name == model.MetricNameLabel {
 		lhs = &chplan.ColumnRef{Name: s.MetricNameColumn}
-	default:
+	} else {
 		mapLookup := attributeLookup(s.AttributesColumn, m.Name)
 		if col := schemaTopLevelColumn(s, m.Name); col != "" {
 			lhs = &chplan.FuncCall{

--- a/internal/promql/modifiers.go
+++ b/internal/promql/modifiers.go
@@ -50,6 +50,30 @@ type lowerCtx struct {
 	// kept for byte-stable SQL on the existing fixtures.
 	step          time.Duration
 	inRangeVector bool
+	// outerByLabels carries the by-clause labels of an enclosing
+	// vector aggregation, threaded down so the inner selector path
+	// can inflate Attributes with the top-level OTel-CH columns
+	// (currently `service_name` → `ServiceName`) the outer aggregate
+	// needs. Empty (the default) means "no outer by-clause referencing
+	// a top-level column" — the augmenting Project is suppressed and
+	// the bare-selector / range-vector plan stays byte-identical with
+	// pre-#232 fixtures.
+	//
+	// Only `by(...)` propagates; `without(...)` exclusion semantics
+	// don't reference specific columns so the slot stays nil for the
+	// without branch (see [lowerAggregate]).
+	outerByLabels []string
+}
+
+// withOuterByLabels returns a copy of c with outerByLabels set to
+// the given list. nil/empty input clears the slot — the inner
+// augmenting Project is suppressed and the lowering produces today's
+// byte-stable plan tree. Mirrors the
+// [internal/logql.lowerCtx.withOuterByLabels] convention from PR #666.
+func (c lowerCtx) withOuterByLabels(labels []string) lowerCtx {
+	out := c
+	out.outerByLabels = labels
+	return out
 }
 
 // instantLookback is the default Prometheus staleness window applied

--- a/internal/promql/schema_lookup.go
+++ b/internal/promql/schema_lookup.go
@@ -1,0 +1,180 @@
+package promql
+
+import (
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// schemaTopLevelColumn returns the dedicated top-level OTel-CH column
+// that mirrors a PromQL label name, or "" when the label has no
+// top-level column and should fall back to the Attributes-map lookup.
+//
+// The OTel-CH default metrics schema hoists `service.name` out of the
+// Attributes map into a dedicated `ServiceName LowCardinality(String)`
+// column. PromQL queries that reach for it under the Prom-grammar
+// underscored form (`{service_name="cerberus"}`,
+// `sum by (service_name) (...)`) — or the OTel-canonical dotted form
+// (`{"service.name"="cerberus"}`) — would otherwise miss every
+// OTel-collector-routed row because the value lives ONLY in the
+// top-level column, leaving `Attributes['service.name']` /
+// `Attributes['service_name']` empty.
+//
+// Both spellings route to the same `s.ServiceNameColumn` so the wire
+// behaviour is symmetric across producers (the Prom-tooling-side may
+// have re-underscored the label before the matcher reached us; the
+// OTel-side may have kept the dotted form). This mirrors the LogQL
+// side's [internal/logql.resourceFallbackColumn] (PR #669 / task #217)
+// and the exemplars handler's `ServiceName != ""` precedence in
+// [internal/api/prom/exemplars.go::groupExemplars].
+//
+// A custom-schema user who clears [schema.Metrics.ServiceNameColumn]
+// opts out — the helper returns "" so the lowering stays Attributes-
+// map-only. The mapping table is intentionally narrow (only
+// service.name today); generalise to other top-level columns
+// (service_namespace, service_instance_id, scope_name, ...) when those
+// bugs surface — don't over-engineer the first cut.
+func schemaTopLevelColumn(s schema.Metrics, labelName string) string {
+	switch labelName {
+	case "service_name", "service.name":
+		return s.ServiceNameColumn
+	}
+	return ""
+}
+
+// promqlTopLevelColumnsReferencedBy returns the set of dedicated CH
+// column names that the labels in `labels` route to via
+// [schemaTopLevelColumn]. Order is preserved against the first
+// occurrence; duplicates are dropped so the augmenting Project that
+// consumes this list emits a deterministic map shape.
+//
+// Used by [augmentAttributesForOuterBy] to inflate the inner LWR /
+// RangeWindow input's Attributes map with exactly the top-level columns
+// the outer aggregation's by-clause references. Mirrors the LogQL
+// [internal/logql.topLevelColumnsReferencedBy] from PR #666 / task #218.
+func promqlTopLevelColumnsReferencedBy(labels []string, s schema.Metrics) []string {
+	if len(labels) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(labels))
+	out := make([]string, 0, len(labels))
+	for _, lbl := range labels {
+		col := schemaTopLevelColumn(s, lbl)
+		if col == "" || seen[col] {
+			continue
+		}
+		seen[col] = true
+		out = append(out, col)
+	}
+	return out
+}
+
+// promqlTopLevelKeysForOuterBy returns the list of Prom-grammar label
+// names that the inner augmenting Project should synthesise into
+// Attributes. The names are normalised to the underscored form
+// (`service_name`) so the outer aggregate's `Attributes[<label>]`
+// lookup — which iterates over [internal/api/format.PromLabelToOTelCandidates] —
+// hits the synthesised key on the underscored candidate. Order
+// mirrors `outerByLabels` (first-seen wins) with duplicates dropped.
+//
+// Each returned tuple is `(promLabel, topLevelColumn)`. Both spellings
+// of `service.name` collapse to `service_name` here so the wire
+// response carries the Prom-canonical form regardless of which
+// spelling the user typed in the by-clause.
+func promqlTopLevelKeysForOuterBy(labels []string, s schema.Metrics) [][2]string {
+	if len(labels) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(labels))
+	out := make([][2]string, 0, len(labels))
+	for _, lbl := range labels {
+		col := schemaTopLevelColumn(s, lbl)
+		if col == "" {
+			continue
+		}
+		key := promCanonicalTopLevelLabel(lbl)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, [2]string{key, col})
+	}
+	return out
+}
+
+// promCanonicalTopLevelLabel returns the Prom-canonical underscored
+// spelling of a label that routes to a top-level OTel-CH column.
+// `service.name` → `service_name`. Used by
+// [promqlTopLevelKeysForOuterBy] to normalise the synthesised
+// Attributes-map key so the outer aggregate's
+// `Attributes['service_name']` lookup hits regardless of which
+// spelling the user wrote.
+func promCanonicalTopLevelLabel(label string) string {
+	switch label {
+	case "service.name", "service_name":
+		return "service_name"
+	}
+	return label
+}
+
+// augmentAttributesForOuterBy returns a chplan expression that wraps
+// the per-row Attributes map with one synthesised key per top-level
+// OTel-CH column referenced by `outerByLabels`. The shape is
+//
+//	mapConcat(
+//	    Attributes,
+//	    mapFilter((k, v) -> v != '',
+//	        map('<promLabel0>', toString(<col0>),
+//	            '<promLabel1>', toString(<col1>),
+//	            ...)))
+//
+// `toString` is a no-op for `String`-typed columns (CH elides it at
+// the wire) but coerces non-String top-level columns into the
+// Map(String, String) value slot. `mapFilter(v != ”)` drops empty-
+// column rows so a row with `ServiceName=”` doesn't gain a spurious
+// `{service_name:”}` key — matching Prom's "absent label" semantics.
+//
+// `mapConcat` is later-key-wins, so an explicit Attributes binding
+// (a producer that wrote both the top-level column AND the underscored
+// map key) is overwritten by the top-level column. That's the
+// intended precedence: the dedicated column is the OTel-CH-canonical
+// storage shape and the map entry is the fallback.
+//
+// Returns nil when `outerByLabels` contains no top-level-routed
+// labels — callers fold a nil augmentation into "no Project wrap"
+// rather than emitting a degenerate identity map.
+func augmentAttributesForOuterBy(s schema.Metrics, outerByLabels []string) chplan.Expr {
+	pairs := promqlTopLevelKeysForOuterBy(outerByLabels, s)
+	if len(pairs) == 0 {
+		return nil
+	}
+	args := make([]chplan.Expr, 0, len(pairs)*2)
+	for _, p := range pairs {
+		args = append(
+			args,
+			&chplan.LitString{V: p[0]},
+			&chplan.FuncCall{
+				Name: "toString",
+				Args: []chplan.Expr{&chplan.ColumnRef{Name: p[1]}},
+			},
+		)
+	}
+	synth := &chplan.FuncCall{Name: "map", Args: args}
+	filtered := &chplan.FuncCall{
+		Name: "mapFilter",
+		Args: []chplan.Expr{
+			&chplan.Lambda{
+				Params: []string{"k", "v"},
+				Body: &chplan.Binary{
+					Op:    chplan.OpNe,
+					Left:  &chplan.BareIdent{Name: "v"},
+					Right: &chplan.LitString{V: ""},
+				},
+			},
+			synth,
+		},
+	}
+	return &chplan.FuncCall{
+		Name: "mapConcat",
+		Args: []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}, filtered},
+	}
+}

--- a/internal/promql/schema_lookup.go
+++ b/internal/promql/schema_lookup.go
@@ -41,33 +41,6 @@ func schemaTopLevelColumn(s schema.Metrics, labelName string) string {
 	return ""
 }
 
-// promqlTopLevelColumnsReferencedBy returns the set of dedicated CH
-// column names that the labels in `labels` route to via
-// [schemaTopLevelColumn]. Order is preserved against the first
-// occurrence; duplicates are dropped so the augmenting Project that
-// consumes this list emits a deterministic map shape.
-//
-// Used by [augmentAttributesForOuterBy] to inflate the inner LWR /
-// RangeWindow input's Attributes map with exactly the top-level columns
-// the outer aggregation's by-clause references. Mirrors the LogQL
-// [internal/logql.topLevelColumnsReferencedBy] from PR #666 / task #218.
-func promqlTopLevelColumnsReferencedBy(labels []string, s schema.Metrics) []string {
-	if len(labels) == 0 {
-		return nil
-	}
-	seen := make(map[string]bool, len(labels))
-	out := make([]string, 0, len(labels))
-	for _, lbl := range labels {
-		col := schemaTopLevelColumn(s, lbl)
-		if col == "" || seen[col] {
-			continue
-		}
-		seen[col] = true
-		out = append(out, col)
-	}
-	return out
-}
-
 // promqlTopLevelKeysForOuterBy returns the list of Prom-grammar label
 // names that the inner augmenting Project should synthesise into
 // Attributes. The names are normalised to the underscored form

--- a/internal/promql/schema_lookup_test.go
+++ b/internal/promql/schema_lookup_test.go
@@ -1,0 +1,203 @@
+package promql
+
+import (
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestSchemaTopLevelColumn_ServiceName pins the matcher-routing
+// invariant for task #232: both Prom-grammar (`service_name`) and
+// OTel-canonical (`service.name`) spellings of the service-name label
+// resolve to [schema.Metrics.ServiceNameColumn]. Other labels keep
+// returning "" so the lowering falls back to the Attributes map.
+func TestSchemaTopLevelColumn_ServiceName(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+
+	cases := []struct {
+		label string
+		want  string
+	}{
+		{"service_name", s.ServiceNameColumn},
+		{"service.name", s.ServiceNameColumn},
+		{"job", ""},
+		{"__name__", ""},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.label, func(t *testing.T) {
+			t.Parallel()
+			if got := schemaTopLevelColumn(s, tc.label); got != tc.want {
+				t.Errorf("schemaTopLevelColumn(%q) = %q, want %q", tc.label, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSchemaTopLevelColumn_ClearedFieldOptsOut pins the custom-schema
+// opt-out: a user who clears [schema.Metrics.ServiceNameColumn] takes
+// the bare-map fallback because [schemaTopLevelColumn] reads the
+// schema field rather than a static allow-list of column names.
+func TestSchemaTopLevelColumn_ClearedFieldOptsOut(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+	s.ServiceNameColumn = ""
+	if got := schemaTopLevelColumn(s, "service_name"); got != "" {
+		t.Errorf("schemaTopLevelColumn with cleared ServiceNameColumn = %q, want \"\"", got)
+	}
+}
+
+// TestMatcherToExpr_ServiceNameRoutesToCoalesce pins the
+// matcher-lowering shape for `service_name` / `service.name` matchers:
+// both spellings emit `coalesce(nullIf(ServiceName, ”),
+// Attributes['service.name']-fallback-chain)` so producers that
+// wrote either side (top-level column or map key) both match. Mirrors
+// the LogQL fix in [internal/logql.matcherToExpr] (PR #669).
+func TestMatcherToExpr_ServiceNameRoutesToCoalesce(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+
+	for _, spelling := range []string{"service_name", "service.name"} {
+		spelling := spelling
+		t.Run(spelling, func(t *testing.T) {
+			t.Parallel()
+			m, err := labels.NewMatcher(labels.MatchEqual, spelling, "cerberus")
+			if err != nil {
+				t.Fatalf("NewMatcher: %v", err)
+			}
+			expr := matcherToExpr(m, s)
+			bin, ok := expr.(*chplan.Binary)
+			if !ok {
+				t.Fatalf("expr type: got %T, want *chplan.Binary", expr)
+			}
+			if bin.Op != chplan.OpEq {
+				t.Errorf("Op: got %v, want OpEq", bin.Op)
+			}
+			coalesce, ok := bin.Left.(*chplan.FuncCall)
+			if !ok || coalesce.Name != "coalesce" {
+				t.Fatalf("lhs: got %#v, want coalesce(...)", bin.Left)
+			}
+			if len(coalesce.Args) != 2 {
+				t.Fatalf("coalesce args: got %d, want 2", len(coalesce.Args))
+			}
+			nullIf, ok := coalesce.Args[0].(*chplan.FuncCall)
+			if !ok || nullIf.Name != "nullIf" {
+				t.Fatalf("coalesce arg0: got %#v, want nullIf(...)", coalesce.Args[0])
+			}
+			col, ok := nullIf.Args[0].(*chplan.ColumnRef)
+			if !ok || col.Name != s.ServiceNameColumn {
+				t.Errorf("nullIf arg0: got %#v, want ColumnRef(%q)", nullIf.Args[0], s.ServiceNameColumn)
+			}
+		})
+	}
+}
+
+// TestMatcherToExpr_OtherLabelStaysAttributesMap pins that labels with
+// no top-level routing keep emitting the bare Attributes-map lookup
+// shape — no spurious coalesce wrap.
+func TestMatcherToExpr_OtherLabelStaysAttributesMap(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+	m, err := labels.NewMatcher(labels.MatchEqual, "job", "api")
+	if err != nil {
+		t.Fatalf("NewMatcher: %v", err)
+	}
+	expr := matcherToExpr(m, s)
+	bin, ok := expr.(*chplan.Binary)
+	if !ok {
+		t.Fatalf("expr type: got %T, want *chplan.Binary", expr)
+	}
+	// `job` is a simple ASCII label with no underscore → bare MapAccess.
+	if _, ok := bin.Left.(*chplan.MapAccess); !ok {
+		t.Errorf("lhs: got %T, want *chplan.MapAccess (no coalesce wrap)", bin.Left)
+	}
+}
+
+// TestPromqlTopLevelKeysForOuterBy pins the normalisation of by-clause
+// labels to the underscored Prom-canonical spelling so the outer
+// aggregate's `Attributes['service_name']` lookup hits the synthesised
+// map key regardless of which spelling the user wrote.
+func TestPromqlTopLevelKeysForOuterBy(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+
+	cases := []struct {
+		name string
+		in   []string
+		want [][2]string
+	}{
+		{"empty", nil, nil},
+		{"underscored", []string{"service_name"}, [][2]string{{"service_name", s.ServiceNameColumn}}},
+		{"dotted", []string{"service.name"}, [][2]string{{"service_name", s.ServiceNameColumn}}},
+		{"both_collapse", []string{"service_name", "service.name"}, [][2]string{{"service_name", s.ServiceNameColumn}}},
+		{"unrelated_dropped", []string{"job", "service_name", "instance"}, [][2]string{{"service_name", s.ServiceNameColumn}}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := promqlTopLevelKeysForOuterBy(tc.in, s)
+			if len(got) != len(tc.want) {
+				t.Fatalf("len: got %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("[%d]: got %v, want %v", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestAugmentSelectorAttributes_NoOuterByIsPassThrough pins that the
+// augmenting Project is suppressed when the outer by-clause references
+// no top-level-routed label — existing fixture SQL stays byte-stable.
+func TestAugmentSelectorAttributes_NoOuterByIsPassThrough(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+	input := &chplan.Scan{Table: s.GaugeTable}
+	ctx := lowerCtx{}
+	if got := augmentSelectorAttributes(input, ctx, s); got != chplan.Node(input) {
+		t.Errorf("no-outer-by: expected pass-through, got %#v", got)
+	}
+	// `by(job)` references no top-level column → still pass-through.
+	ctx = ctx.withOuterByLabels([]string{"job"})
+	if got := augmentSelectorAttributes(input, ctx, s); got != chplan.Node(input) {
+		t.Errorf("by(job): expected pass-through, got %#v", got)
+	}
+}
+
+// TestAugmentSelectorAttributes_ServiceNameWrapsProject pins the
+// augmenting Project shape when the outer by-clause references
+// `service_name`. The Attributes slot becomes
+// `mapConcat(Attributes, mapFilter(v != ”, map('service_name',
+// toString(ServiceName))))` so the downstream LWR / RangeWindow's
+// `GROUP BY Attributes` partitions over distinct ServiceName values.
+func TestAugmentSelectorAttributes_ServiceNameWrapsProject(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+	input := &chplan.Scan{Table: s.GaugeTable}
+	ctx := lowerCtx{}.withOuterByLabels([]string{"service_name"})
+
+	got := augmentSelectorAttributes(input, ctx, s)
+	proj, ok := got.(*chplan.Project)
+	if !ok {
+		t.Fatalf("got %T, want *chplan.Project", got)
+	}
+	if len(proj.Projections) != 4 {
+		t.Fatalf("projections: got %d, want 4", len(proj.Projections))
+	}
+	attrsProj := proj.Projections[1]
+	if attrsProj.Alias != s.AttributesColumn {
+		t.Errorf("alias[1]: got %q, want %q", attrsProj.Alias, s.AttributesColumn)
+	}
+	mapConcat, ok := attrsProj.Expr.(*chplan.FuncCall)
+	if !ok || mapConcat.Name != "mapConcat" {
+		t.Fatalf("attrs expr: got %#v, want mapConcat(...)", attrsProj.Expr)
+	}
+}

--- a/test/spec/promql/agg_by_service_name.txtar
+++ b/test/spec/promql/agg_by_service_name.txtar
@@ -1,0 +1,67 @@
+# Task #232 — `sum by (service_name) (rate({__name__=~".+"}[5m]))`
+# must partition over the dedicated OTel-CH `ServiceName` column
+# the way it partitions over an Attributes-map key. Pre-fix the by-
+# clause resolved `service_name` against `Attributes['service_name']`
+# which silently returned the empty string for every OTel-collector-
+# routed row (those carry the value ONLY in the top-level column,
+# never in the map) — so every series collapsed into a single
+# `{service_name:""}` bucket, exactly the PR #678 compose-smoke
+# failure shape.
+#
+# Fix: when the outer aggregation's by-clause references a label
+# that routes to a top-level OTel-CH column, the inner selector path
+# wraps Attributes with `mapConcat(Attributes, mapFilter(v != '',
+# map('service_name', toString(ServiceName))))`. The RangeWindow's
+# `GROUP BY Attributes` then partitions over the augmented map, and
+# the outer aggregate's `Attributes['service_name']` MapAccess hits
+# the synthesised key.
+
+-- query.promql --
+sum by (service_name) (cerberus_queries_total)
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    ServiceName LowCardinality(String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('cerberus_queries_total', map('route', '/api/v1/query'),  'cerberus', toDateTime64('2026-01-01 00:00:00', 9), 7.0),
+    ('cerberus_queries_total', map('route', '/api/v1/series'), 'cerberus', toDateTime64('2026-01-01 00:00:00', 9), 3.0),
+    ('cerberus_queries_total', map('route', '/loki/api/query'),'api',      toDateTime64('2026-01-01 00:00:00', 9), 99.0),
+    ('cerberus_queries_total', map('route', '/api/traces'),    'db',       toDateTime64('2026-01-01 00:00:00', 9), 42.0);
+-- expected_rows --
+[
+  ["", {"service_name": "api"}, "2026-01-01T00:00:01Z", 99.0],
+  ["", {"service_name": "cerberus"}, "2026-01-01T00:00:01Z", 10.0],
+  ["", {"service_name": "db"}, "2026-01-01T00:00:01Z", 42.0]
+]
+-- args --
+[0] string = ""
+[1] string = "service_name"
+[2] int64 = 9
+[3] string = "service_name"
+[4] string = "service_name"
+[5] string = "service.name"
+[6] string = ""
+[7] string = "service_name"
+[8] string = "cerberus_queries_total"
+[9] string = "2026-01-01 00:00:01.000000000"
+[10] int64 = 9
+[11] string = "2026-01-01 00:00:01.000000000"
+[12] int64 = 9
+[13] int64 = 300000000000
+[14] string = "service_name"
+[15] string = "service_name"
+[16] string = "service.name"
+-- chplan --
+Project ["" AS MetricName, mapWithoutEmpty(map("service_name", gkey_0)) AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+  Aggregate groupBy=[if(mapContains(Attributes, "service_name"), Attributes["service_name"], Attributes["service.name"]) AS gkey_0] funcs=[sum(Value) AS Value]
+    Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+      Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+        Filter predicate=(((MetricName = "cerberus_queries_total") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+          Project [MetricName AS MetricName, mapConcat(Attributes, mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName)))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
+            Scan(otel_metrics_sum)
+-- sql --
+SELECT ? AS `MetricName`, mapFilter((k, v) -> v != '', map(?, `gkey_0`)) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT if(mapContains(`Attributes`, ?), `Attributes`[?], `Attributes`[?]) AS `gkey_0`, sum(`Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, mapConcat(`Attributes`, mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`)))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM `otel_metrics_sum`)) WHERE (((`MetricName` = ?) AND (`TimeUnix` <= toDateTime64(?, ?))) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`)) GROUP BY if(mapContains(`Attributes`, ?), `Attributes`[?], `Attributes`[?]))

--- a/test/spec/promql/matcher_service_name.txtar
+++ b/test/spec/promql/matcher_service_name.txtar
@@ -29,8 +29,8 @@ INSERT INTO otel_metrics_sum VALUES
     ('cerberus_queries_total', map('route', '/api/traces'),    'db',       toDateTime64('2026-01-01 00:00:00', 9), 42.0);
 -- expected_rows --
 [
-  ["cerberus_queries_total", {"route": "/api/v1/query"}, "2026-01-01T00:00:01Z", 7.0],
-  ["cerberus_queries_total", {"route": "/api/v1/series"}, "2026-01-01T00:00:01Z", 3.0]
+  ["cerberus_queries_total", {"route": "/api/v1/query"}, "2026-01-01T00:00:00Z", 7.0],
+  ["cerberus_queries_total", {"route": "/api/v1/series"}, "2026-01-01T00:00:00Z", 3.0]
 ]
 -- args --
 [0] string = "cerberus_queries_total"

--- a/test/spec/promql/matcher_service_name.txtar
+++ b/test/spec/promql/matcher_service_name.txtar
@@ -1,0 +1,53 @@
+# Task #232 — `{service_name="cerberus"}` matcher must hit the dedicated
+# OTel-CH `ServiceName LowCardinality(String)` column, not just the
+# Attributes map. Pre-fix the matcher emitted
+# `Attributes['service_name']` which silently returned the empty
+# string for every OTel-collector-routed row (those carry the value
+# ONLY in the top-level column with no Attributes entry) — so the
+# selector returned zero series for cerberus's own self-metrics.
+#
+# Fix routes the matcher through `coalesce(nullIf(ServiceName, ''),
+# Attributes['service.name']-fallback-chain)` so both producers
+# resolve: OTel-collector rows (top-level column populated) AND raw
+# inserts (Attributes-map key populated). Mirrors the LogQL fix from
+# PR #669 / task #217.
+
+-- query.promql --
+cerberus_queries_total{service_name="cerberus"}
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    ServiceName LowCardinality(String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('cerberus_queries_total', map('route', '/api/v1/query'),  'cerberus', toDateTime64('2026-01-01 00:00:00', 9), 7.0),
+    ('cerberus_queries_total', map('route', '/api/v1/series'), 'cerberus', toDateTime64('2026-01-01 00:00:00', 9), 3.0),
+    ('cerberus_queries_total', map('route', '/loki/api/query'),'api',      toDateTime64('2026-01-01 00:00:00', 9), 99.0),
+    ('cerberus_queries_total', map('route', '/api/traces'),    'db',       toDateTime64('2026-01-01 00:00:00', 9), 42.0);
+-- expected_rows --
+[
+  ["cerberus_queries_total", {"route": "/api/v1/query"}, "2026-01-01T00:00:01Z", 7.0],
+  ["cerberus_queries_total", {"route": "/api/v1/series"}, "2026-01-01T00:00:01Z", 3.0]
+]
+-- args --
+[0] string = "cerberus_queries_total"
+[1] string = ""
+[2] string = "service_name"
+[3] string = "service_name"
+[4] string = "service.name"
+[5] string = "cerberus"
+[6] string = "2026-01-01 00:00:01.000000000"
+[7] int64 = 9
+[8] string = "2026-01-01 00:00:01.000000000"
+[9] int64 = 9
+[10] int64 = 300000000000
+-- chplan --
+Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+  Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+    Filter predicate=((((coalesce(nullIf(ServiceName, ""), if(mapContains(Attributes, "service_name"), Attributes["service_name"], Attributes["service.name"])) = "cerberus") AND (MetricName = "cerberus_queries_total")) AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+      Scan(otel_metrics_sum)
+-- sql --
+SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM `otel_metrics_sum` PREWHERE (`MetricName` = ?) WHERE (coalesce(nullIf(`ServiceName`, ?), if(mapContains(`Attributes`, ?), `Attributes`[?], `Attributes`[?])) = ?) AND (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)


### PR DESCRIPTION
## Summary

URGENT: PR #678's Phase 1 e2e sweep caught a real bug. `sum by (service_name) (rate({__name__=~\".+\"}[5m]))` collapses every row into a single `{service_name:\"\"}` bucket because the OTel-CH default schema stores `service.name` ONLY in the dedicated `ServiceName LowCardinality(String)` top-level column — the PromQL lowering uniformly read `Attributes['service_name']` and missed every OTel-collector-routed row. `{service_name=\"cerberus\"}` matchers returned zero series for the same reason. Mirrors the LogQL fix from task #217 (PR #669) + the by-clause plumbing from task #218 (PR #666).

- New `internal/promql/schema_lookup.go` — `schemaTopLevelColumn` maps `service.name` / `service_name` → `schema.Metrics.ServiceNameColumn`; helpers + `augmentAttributesForOuterBy` synthesise the inner-Project augmentation. Custom schemas that clear `ServiceNameColumn` opt out cleanly. Generalisable to other top-level columns (service_namespace, service_instance_id, ...) when those bugs surface — kept tight to `service.name` for the first cut per the task brief.
- `matcherToExpr` wraps the Attributes-map lookup in `coalesce(nullIf(ServiceName, ''), <map>)` for `service_name` / `service.name`. Producers that wrote either side now resolve symmetrically.
- `lowerCtx.outerByLabels` threads the enclosing aggregation's by-clause down; `lowerAggregate` populates it only for `by(...)` (not `without(...)` per the LogQL precedent).
- `augmentSelectorAttributes` wraps the inner selector with a Project that rebinds Attributes to `mapConcat(Attributes, mapFilter((k, v) -> v != '', map('service_name', toString(ServiceName))))` when the outer by-clause references a top-level-routed label. **Conditional**: the augmentation is suppressed otherwise so existing 705 promql tests + every TXTAR fixture stay byte-stable (verified locally — no goldens drifted).
- Removes the resolved TODO comment on `BuildMatcherPredicate`.

PR #678's `iterate-panel-shape.spec.ts` compose-smoke failure unblocks automatically once this lands.

## Test plan

- [x] `test/spec/promql/matcher_service_name.txtar` — chDB round-trip pins the matcher path: 4 seed rows (2 cerberus, 1 api, 1 db), `{service_name=\"cerberus\"}` returns only the 2 cerberus rows. SQL emits `coalesce(nullIf(\`ServiceName\`, ?), if(mapContains(\`Attributes\`, ?), ...))`.
- [x] `test/spec/promql/agg_by_service_name.txtar` — chDB round-trip pins the by-clause path: same seed, `sum by (service_name) (cerberus_queries_total)` returns 3 grouped series with the `service_name` label populated. SQL emits the inner `mapConcat(\`Attributes\`, mapFilter(...))` augmentation.
- [x] `internal/promql/schema_lookup_test.go` — unit pins for the helper + matcher routing + augmentation gating (pass-through when no top-level label is in the outer by-clause).
- [x] `internal/api/prom/conformance_test.go::TestConformance_ServiceName*` — SQL-shape pins for both the matcher coalesce + the by-clause augmenting Project.
- [x] `go test ./internal/...` — 3782 tests pass, no fixture drift.
- [ ] PR #678's `compose-smoke` (auto-unblocks once this PR merges).

## Catches

- **N2-class bug** (`sum by (service_name) (rate({__name__=~\".+\"}[5m]))` collapsing): the augmenting Project lands above the Scan so the RangeWindow's `GROUP BY Attributes` partitions over the synthesised key.
- **N-class regression: `{service_name=\"cerberus\"}` matcher missing**: the coalesce shape reads the dedicated column first, falls back to the map-key candidates only when ServiceName is empty.
- Both spellings (`service_name`, `service.name`) route consistently — the wire response normalises to the underscored Prom-grammar form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)