### PR TITLE
test(e2e/playwright): land phase-3 filter-drill sweep pinning N3/N15

### DIFF
--- a/.github/workflows/compose-smoke.yml
+++ b/.github/workflows/compose-smoke.yml
@@ -179,6 +179,14 @@ jobs:
           # no-fabricated-value rule for histogram_quantile over
           # bucket-less metrics. Closes N5 / N6.
           #
+          # Phase-3 filter-drill spec (iterate-filter-drill.spec.ts)
+          # rides the same dashboard enumeration: for every panel
+          # with a by(...) clause it re-fires the query with a
+          # `{<key>="<value>"}` matcher synthesised from a baseline-
+          # observed value and asserts the filtered series count is
+          # in (0, baseline] — the Q3-resolved subset rule. Pins
+          # N3/N15 (matcher-path drill regressions).
+          #
           # Phase-4 single-panel-kiosk spec
           # (iterate-panel-kiosk.spec.ts) iterates every provisioned
           # dashboard + every panel, opens the panel in single-panel
@@ -191,6 +199,7 @@ jobs:
             compose_grafana_smoke.spec.ts \
             iterate-panel-shape.spec.ts \
             iterate-histogram-completeness.spec.ts \
+            iterate-filter-drill.spec.ts \
             iterate-panel-kiosk.spec.ts \
             --reporter=list
 

--- a/test/e2e/playwright/helpers.spec.ts
+++ b/test/e2e/playwright/helpers.spec.ts
@@ -28,11 +28,14 @@ import {
   type Dashboard,
   type Panel,
   type PanelTarget,
+  addLabelFilter,
   assertHistogramComplete,
   assertLabelAbsent,
   assertLabelShape,
   assertNoFabricatedValue,
+  assertSubsetByCount,
   expectedByKeys,
+  expressionHasMatcherFor,
   extractByKeys,
   extractDataSourceProxyURL,
   extractHistogramName,
@@ -334,6 +337,132 @@ test('extractDataSourceProxyURL throws when no uid is resolvable', () => {
   const target: PanelTarget = { refId: 'A' };
   expect(() => extractDataSourceProxyURL(dashboard, panel, target)).toThrow(
     /no datasource uid/,
+  );
+});
+
+test('addLabelFilter injects into a bare metric name', () => {
+  expect(addLabelFilter('rate(foo[5m])', 'cerberus_ql', 'promql')).toBe(
+    'rate(foo{cerberus_ql="promql"}[5m])',
+  );
+});
+
+test('addLabelFilter appends to an existing non-empty selector block', () => {
+  expect(
+    addLabelFilter('rate(foo{job="x"}[5m])', 'cerberus_ql', 'promql'),
+  ).toBe('rate(foo{job="x",cerberus_ql="promql"}[5m])');
+});
+
+test('addLabelFilter populates an empty selector block', () => {
+  expect(addLabelFilter('rate(foo{}[5m])', 'cerberus_ql', 'promql')).toBe(
+    'rate(foo{cerberus_ql="promql"}[5m])',
+  );
+});
+
+test('addLabelFilter handles metric-less selectors like {__name__=~".+"}', () => {
+  expect(
+    addLabelFilter('rate({__name__=~".+"}[5m])', 'service_name', 'cerberus'),
+  ).toBe('rate({__name__=~".+",service_name="cerberus"}[5m])');
+});
+
+test('addLabelFilter walks through aggregation wrappers untouched', () => {
+  expect(
+    addLabelFilter(
+      'sum by (cerberus_ql) (rate(cerberus_queries_total[5m]))',
+      'cerberus_ql',
+      'promql',
+    ),
+  ).toBe(
+    'sum by (cerberus_ql) (rate(cerberus_queries_total{cerberus_ql="promql"}[5m]))',
+  );
+});
+
+test('addLabelFilter handles histogram_quantile + inner by(le, k)', () => {
+  expect(
+    addLabelFilter(
+      'histogram_quantile(0.95, sum by (le, cerberus_ql) (rate(cerberus_queries_duration_seconds_bucket[5m])))',
+      'cerberus_ql',
+      'promql',
+    ),
+  ).toBe(
+    'histogram_quantile(0.95, sum by (le, cerberus_ql) (rate(cerberus_queries_duration_seconds_bucket{cerberus_ql="promql"}[5m])))',
+  );
+});
+
+test('addLabelFilter does not mistake `m` in `[5m]` for an identifier', () => {
+  // Regression guard: a naive identifier regex matches `m` in the
+  // duration suffix `5m`. The walker uses a word-boundary check that
+  // excludes preceding digits.
+  const out = addLabelFilter('rate(foo[5m])', 'k', 'v');
+  expect(out).toBe('rate(foo{k="v"}[5m])');
+  expect(out).not.toContain('m{');
+});
+
+test('addLabelFilter escapes embedded double-quotes and backslashes in the value', () => {
+  expect(addLabelFilter('foo', 'k', 'a"b')).toBe('foo{k="a\\"b"}');
+  expect(addLabelFilter('foo', 'k', 'a\\b')).toBe('foo{k="a\\\\b"}');
+});
+
+test('addLabelFilter does not mutate label values inside existing matchers', () => {
+  // The string literal `"x"` must be copied verbatim — the `x` is not
+  // a fresh metric-name selector.
+  expect(addLabelFilter('foo{job="x"} or bar', 'k', 'v')).toBe(
+    'foo{job="x",k="v"} or bar{k="v"}',
+  );
+});
+
+test('addLabelFilter respects function calls and PromQL keywords', () => {
+  // `rate(`, `sum(`, `histogram_quantile(` are all function calls
+  // (followed by `(`) and never selectors. `or`, `and`, `unless` are
+  // keywords. Only the metric names `foo` / `bar` get the injection.
+  expect(
+    addLabelFilter('rate(foo[5m]) or rate(bar[5m])', 'k', 'v'),
+  ).toBe('rate(foo{k="v"}[5m]) or rate(bar{k="v"}[5m])');
+});
+
+test('expressionHasMatcherFor finds a matcher in any selector block', () => {
+  expect(
+    expressionHasMatcherFor(
+      'rate(foo{cerberus_ql="promql"}[5m])',
+      'cerberus_ql',
+    ),
+  ).toBe(true);
+  expect(
+    expressionHasMatcherFor('rate(foo{job="x"}[5m])', 'cerberus_ql'),
+  ).toBe(false);
+  expect(expressionHasMatcherFor('rate(foo[5m])', 'cerberus_ql')).toBe(false);
+});
+
+test('expressionHasMatcherFor does not confuse by(...) keys for matchers', () => {
+  // `sum by (cerberus_ql)` doesn't constrain the label — it just
+  // groups by it. The drill-down spec must still be willing to
+  // filter on cerberus_ql.
+  expect(
+    expressionHasMatcherFor('sum by (cerberus_ql) (foo)', 'cerberus_ql'),
+  ).toBe(false);
+});
+
+test('expressionHasMatcherFor handles all matcher operators', () => {
+  expect(expressionHasMatcherFor('foo{k="a"}', 'k')).toBe(true);
+  expect(expressionHasMatcherFor('foo{k!="a"}', 'k')).toBe(true);
+  expect(expressionHasMatcherFor('foo{k=~"a"}', 'k')).toBe(true);
+  expect(expressionHasMatcherFor('foo{k!~"a"}', 'k')).toBe(true);
+});
+
+test('assertSubsetByCount passes when filtered is non-empty + ≤ baseline', () => {
+  expect(() => assertSubsetByCount(3, 10, 'panel:foo')).not.toThrow();
+  expect(() => assertSubsetByCount(10, 10, 'panel:foo')).not.toThrow();
+  expect(() => assertSubsetByCount(1, 1, 'panel:foo')).not.toThrow();
+});
+
+test('assertSubsetByCount throws when filtered is zero', () => {
+  expect(() => assertSubsetByCount(0, 10, 'panel:foo')).toThrow(
+    /returned 0 series/,
+  );
+});
+
+test('assertSubsetByCount throws when filtered exceeds baseline', () => {
+  expect(() => assertSubsetByCount(11, 10, 'panel:foo')).toThrow(
+    /filtered=11 > baseline=10/,
   );
 });
 

--- a/test/e2e/playwright/helpers/README.md
+++ b/test/e2e/playwright/helpers/README.md
@@ -7,15 +7,15 @@ land in subsequent PRs.
 
 ## Modules
 
-| Module           | Responsibility                                                                                                                                                                |
-| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dashboard.ts`   | Enumerate provisioned dashboards via `/api/search` + `/api/dashboards/uid/<uid>`, flatten rows, expose `Dashboard` + `Panel` types.                                           |
-| `query-shape.ts` | Regex-based target classification: `extractByKeys`, `extractWithoutKeys`, `isHistogramQuantile`, `extractHistogramName`.                                                      |
-| `assertions.ts`  | Per-shape assertions over the Grafana `/api/ds/query` envelope (`assertLabelShape` / `assertLabelAbsent` / histogram pair) + the zero-404 gate (`assertNon200ResponseClass`). |
-| `sweep.ts`       | `generateSelfTraffic` — pre-step that fires self-traffic against cerberus so the cerberus-self dashboards have data to render.                                                |
-| `drilldown.ts`   | Drilldown-app catalogue + `drillTwoLevels` gesture driver for the three built-in apps.                                                                                        |
-| `dom.ts`         | Browser-side helpers: console-error capture, `role="alert"` banner read, kiosk repaint-flicker tolerance.                                                                     |
-| `probes.ts`      | `fetchAndAssert200` (the zero-404 gate on direct HTTP probes) + `extractDataSourceProxyURL` (panel → datasource proxy path).                                                  |
+| Module           | Responsibility                                                                                                                                                                                        |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dashboard.ts`   | Enumerate provisioned dashboards via `/api/search` + `/api/dashboards/uid/<uid>`, flatten rows, expose `Dashboard` + `Panel` types.                                                                   |
+| `query-shape.ts` | Regex-based target classification + rewriting: `extractByKeys`, `extractWithoutKeys`, `expectedByKeys`, `isHistogramQuantile`, `extractHistogramName`, `addLabelFilter`, `expressionHasMatcherFor`.   |
+| `assertions.ts`  | Per-shape assertions over the Grafana `/api/ds/query` envelope (`assertLabelShape` / `assertLabelAbsent` / histogram pair / `assertSubsetByCount`) + the zero-404 gate (`assertNon200ResponseClass`). |
+| `sweep.ts`       | `generateSelfTraffic` — pre-step that fires self-traffic against cerberus so the cerberus-self dashboards have data to render.                                                                        |
+| `drilldown.ts`   | Drilldown-app catalogue + `drillTwoLevels` gesture driver for the three built-in apps.                                                                                                                |
+| `dom.ts`         | Browser-side helpers: console-error capture, `role="alert"` banner read, kiosk repaint-flicker tolerance.                                                                                             |
+| `probes.ts`      | `fetchAndAssert200` (the zero-404 gate on direct HTTP probes) + `extractDataSourceProxyURL` (panel → datasource proxy path).                                                                          |
 
 Re-exported in lockstep via `helpers/index.ts`.
 
@@ -25,14 +25,14 @@ Phase 0 (this PR) ships helpers only. Each later phase lands one new
 spec under `test/e2e/playwright/` that wires the helpers into a
 concrete iteration:
 
-| Phase | Spec file                            | Helpers it consumes                                                                  |
-| ----- | ------------------------------------ | ------------------------------------------------------------------------------------ |
-| 1     | `iterate-panel-shape.spec.ts`        | `dashboard`, `query-shape`, `assertions`, `sweep`, `probes`                          |
-| 2     | (extends `compose_panel_shape`)      | `assertions.assertHistogramComplete`, `assertions.assertNoFabricatedValue`, `probes` |
-| 3     | `compose_filter_drill.spec.ts`       | `dashboard`, `query-shape`, `assertions`, `probes`                                   |
-| 4     | `compose_panel_kiosk.spec.ts`        | `dashboard`, `dom`, `assertions`                                                     |
-| 5     | `compose_variable_matrix.spec.ts`    | `dashboard`, `sweep`, `assertions`                                                   |
-| 6     | `compose_drilldown_apps.spec.ts`     | `drilldown`, `dom`, `assertions`                                                     |
+| Phase | Spec file                            | Helpers it consumes                                                                                                                                 |
+| ----- | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1     | `iterate-panel-shape.spec.ts`        | `dashboard`, `query-shape`, `assertions`, `sweep`, `probes`                                                                                         |
+| 2     | (extends `compose_panel_shape`)      | `assertions.assertHistogramComplete`, `assertions.assertNoFabricatedValue`, `probes`                                                                |
+| 3     | `iterate-filter-drill.spec.ts`       | `dashboard`, `query-shape` (`addLabelFilter`, `expressionHasMatcherFor`, `expectedByKeys`), `assertions` (`assertSubsetByCount`), `sweep`, `probes` |
+| 4     | `compose_panel_kiosk.spec.ts`        | `dashboard`, `dom`, `assertions`                                                                                                                    |
+| 5     | `compose_variable_matrix.spec.ts`    | `dashboard`, `sweep`, `assertions`                                                                                                                  |
+| 6     | `compose_drilldown_apps.spec.ts`     | `drilldown`, `dom`, `assertions`                                                                                                                    |
 
 The existing `compose_grafana_smoke.spec.ts` is untouched in this PR;
 phase 1 will retire its bespoke `driveCerberusQLPartition` /

--- a/test/e2e/playwright/helpers/assertions.ts
+++ b/test/e2e/playwright/helpers/assertions.ts
@@ -187,6 +187,50 @@ export function assertNoFabricatedValue(
 }
 
 /**
+ * Assert that the filtered series count is a non-empty subset of the
+ * baseline by *count* (not element-wise).
+ *
+ * The filter-drill spec re-fires a panel's baseline expression after
+ * tacking a `{<key>="<value>"}` matcher onto every selector; this
+ * helper is the load-bearing comparator for that drill.
+ *
+ * Two failure modes are caught:
+ *
+ *   1. `filtered === 0`: the drill returned nothing even though the
+ *      `(key, value)` pair came from the baseline response. This is
+ *      the N3-class regression — a real, observed label value goes
+ *      empty under the matcher path.
+ *   2. `filtered > baseline`: the filter somehow *expanded* the
+ *      result set. PromQL's matcher semantics guarantee the filtered
+ *      series are a subset of the unfiltered ones, so any growth is
+ *      the matcher path emitting series the unfiltered query didn't.
+ *      That's a second N3-class shape (lower priority but equally
+ *      load-bearing for the regression pin).
+ *
+ * Q3 of the e2e-enhance plan (`/home/thiago/.claude/plans/e2e-enhance.md`
+ * §9) resolves the comparator semantics: `≤ baseline count`, NOT
+ * element-wise strict subset. Element-wise comparison is order-
+ * dependent and flakes under series re-orderings between the two
+ * queries.
+ */
+export function assertSubsetByCount(
+  filtered: number,
+  baseline: number,
+  context: string,
+): void {
+  if (filtered === 0) {
+    throw new Error(
+      `assertSubsetByCount: filtered query returned 0 series despite drilling on a real baseline value (${context}); ≥ 1 series expected (N3-class regression — matcher path broken)`,
+    );
+  }
+  if (filtered > baseline) {
+    throw new Error(
+      `assertSubsetByCount: filtered=${filtered} > baseline=${baseline} (${context}); filtering must shrink or keep the series set, never grow it (N3-class regression — matcher path emitting series the unfiltered query did not)`,
+    );
+  }
+}
+
+/**
  * Assert the response class of a captured Playwright request is 2xx.
  *
  * This is the zero-404-toleration gate (Q5 in the design doc). The

--- a/test/e2e/playwright/helpers/query-shape.ts
+++ b/test/e2e/playwright/helpers/query-shape.ts
@@ -216,3 +216,306 @@ export function extractHistogramName(expr: string): string | null {
   if (!nameMatch) return null;
   return nameMatch[1] ?? null;
 }
+
+// PromQL identifiers that aren't metric-name selectors — they appear
+// in identifier position but introduce keywords / call-shaped clauses.
+// `by` / `without` / `on` / `ignoring` / `group_left` / `group_right`
+// are all followed by `(`, which the selector-finder already excludes;
+// the entries here cover the bare-keyword cases (`and`, `or`, `unless`,
+// `offset`, `bool`) plus the call-style ones for defence in depth.
+const PROMQL_KEYWORDS = new Set<string>([
+  // Binary operators / modifiers in identifier position.
+  'and',
+  'or',
+  'unless',
+  'offset',
+  'bool',
+  'by',
+  'without',
+  'on',
+  'ignoring',
+  'group_left',
+  'group_right',
+  'start',
+  'end',
+  'atan2',
+  // Aggregation operators. These always take a `(...)` argument
+  // list (optionally with a `by(...)` or `without(...)` clause
+  // *between* the name and the parens). The walker peeks one token
+  // ahead and would otherwise see the `by` / `without` keyword
+  // rather than the `(`, so we have to mark the aggregator names
+  // explicitly. (When the aggregator is followed directly by `(`,
+  // the walker's `next === '('` branch catches it; this set covers
+  // the `sum by (...) (...)` shape.)
+  'sum',
+  'avg',
+  'min',
+  'max',
+  'count',
+  'stddev',
+  'stdvar',
+  'topk',
+  'bottomk',
+  'group',
+  'quantile',
+  'count_values',
+]);
+
+/**
+ * True iff `expr` already constrains label `key` via a matcher of any
+ * kind (`=`, `!=`, `=~`, `!~`) in any of its `{...}` selector blocks.
+ *
+ * Used by the filter-drill spec to skip targets whose expression
+ * already carries a hardcoded matcher for the label we'd otherwise
+ * drill on — drilling there would either be a no-op (the value
+ * matches the hardcoded one) or contradict the existing matcher (the
+ * value differs, producing an empty set that isn't a regression
+ * signal). Either way the drill isn't informative; the spec excludes
+ * the target.
+ *
+ * The match is conservative — we only look at `<key>` appearing in
+ * matcher position (`<key><op>`); a label appearing as a `by(...)`
+ * key or as a function-arg name doesn't count.
+ *
+ * Examples:
+ *   expressionHasMatcherFor('rate(foo{cerberus_ql="promql"}[5m])', 'cerberus_ql')
+ *     → true
+ *   expressionHasMatcherFor('rate(foo[5m])', 'cerberus_ql')         → false
+ *   expressionHasMatcherFor('rate(foo{job="x"}[5m])', 'cerberus_ql') → false
+ *   expressionHasMatcherFor('sum by (cerberus_ql) (foo)', 'cerberus_ql')
+ *     → false                                                       // by() isn't a matcher
+ */
+export function expressionHasMatcherFor(expr: string, key: string): boolean {
+  // Find every `{...}` block and look for `<key>\s*(=|!=|=~|!~)`
+  // inside it. The outer block matcher is non-greedy and balanced-
+  // brace-free, which matches PromQL's selector syntax — selectors
+  // don't nest.
+  const blocks = expr.match(/\{[^{}]*\}/g) ?? [];
+  const matcherRegex = new RegExp(
+    `(?:^|[\\s,{])${escapeRegex(key)}\\s*(=~|!~|!=|=)`,
+  );
+  for (const b of blocks) {
+    if (matcherRegex.test(b)) return true;
+  }
+  return false;
+}
+
+/**
+ * Re-write `expr` to add a `<key>="<value>"` matcher to every vector
+ * selector. This is the load-bearing helper for the phase-3
+ * filter-drill spec: given a panel's baseline expression and a
+ * (label, value) pair observed in the baseline response, produce
+ * the filtered expression to fire as the drill-down probe.
+ *
+ * Two injection paths:
+ *
+ *   - Selector already has a `{...}` block: append `,<key>="<value>"`
+ *     just before the closing `}`. An empty block (`{}`) becomes
+ *     `{<key>="<value>"}`.
+ *   - Bare metric name (no `{...}` block): synthesise
+ *     `<metric>{<key>="<value>"}`.
+ *
+ * Identifiers immediately followed by `(` are PromQL function calls
+ * (`rate(...)`, `histogram_quantile(...)`, `sum(...)`) and are NOT
+ * vector selectors — they're skipped. Bare keywords (`and`, `or`,
+ * `unless`, `offset`, `bool`, plus the call-shape ones for defence
+ * in depth) are likewise skipped.
+ *
+ * The value is quoted with double quotes; embedded `"` and `\` are
+ * escaped per PromQL string-literal grammar. Callers shouldn't pass
+ * a value containing a literal newline — those don't occur in real
+ * label values and the helper doesn't try to model them.
+ *
+ * Examples:
+ *   addLabelFilter('rate(foo[5m])', 'cerberus_ql', 'promql')
+ *     → 'rate(foo{cerberus_ql="promql"}[5m])'
+ *   addLabelFilter('sum by (cerberus_ql) (rate(cerberus_queries_total[5m]))', 'cerberus_ql', 'promql')
+ *     → 'sum by (cerberus_ql) (rate(cerberus_queries_total{cerberus_ql="promql"}[5m]))'
+ *   addLabelFilter('rate(foo{job="x"}[5m])', 'cerberus_ql', 'promql')
+ *     → 'rate(foo{job="x",cerberus_ql="promql"}[5m])'
+ *   addLabelFilter('rate({__name__=~".+"}[5m])', 'service_name', 'cerberus')
+ *     → 'rate({__name__=~".+",service_name="cerberus"}[5m])'
+ *   addLabelFilter('histogram_quantile(0.95, sum by (le, cerberus_ql) (rate(foo_bucket[5m])))', 'cerberus_ql', 'promql')
+ *     → 'histogram_quantile(0.95, sum by (le, cerberus_ql) (rate(foo_bucket{cerberus_ql="promql"}[5m])))'
+ */
+export function addLabelFilter(
+  expr: string,
+  key: string,
+  value: string,
+): string {
+  const matcher = `${key}="${escapeMatcherValue(value)}"`;
+
+  // First pass: inject into every existing `{...}` selector block.
+  // Empty `{}` becomes `{<matcher>}`; non-empty appends `,<matcher>`.
+  // This catches the `{__name__=~".+"}`-style metric-less selectors
+  // that the bare-name pass below wouldn't see.
+  let out = expr.replace(/\{([^{}]*)\}/g, (_full, inner: string) => {
+    const trimmed = inner.trim();
+    if (trimmed === '') return `{${matcher}}`;
+    return `{${inner},${matcher}}`;
+  });
+
+  // Second pass: synthesise `{<matcher>}` after any bare metric name
+  // (identifier NOT followed by `(`, NOT already followed by `{...}`,
+  // and not a reserved word). We walk the string token-by-token so
+  // we can skip `{...}` blocks and string literals as a whole — the
+  // identifiers *inside* those (e.g. label keys, regex literals) are
+  // not selectors and must not be touched.
+  return walkAndInjectBare(out, matcher);
+}
+
+// Walk `expr` left to right; for every bare metric-name selector
+// (identifier in selector position, not followed by `{...}` or `(`),
+// emit `<ident>{matcher}` in place of `<ident>`. Skips strings and
+// `{...}` blocks wholesale — identifiers inside them are not
+// selectors.
+function walkAndInjectBare(expr: string, matcher: string): string {
+  let out = '';
+  let i = 0;
+  while (i < expr.length) {
+    const c = expr[i] ?? '';
+    // String literal — copy until the matching closing quote,
+    // respecting backslash escapes. PromQL accepts ", ', and `
+    // delimiters.
+    if (c === '"' || c === "'" || c === '`') {
+      const quote = c;
+      out += c;
+      i++;
+      while (i < expr.length) {
+        const ch = expr[i] ?? '';
+        out += ch;
+        if (ch === '\\' && quote !== '`') {
+          // Escape sequence: copy next char verbatim.
+          i++;
+          if (i < expr.length) {
+            out += expr[i];
+            i++;
+          }
+          continue;
+        }
+        if (ch === quote) {
+          i++;
+          break;
+        }
+        i++;
+      }
+      continue;
+    }
+    // `{...}` block — copy the whole thing. Selectors don't nest,
+    // so a flat counter suffices.
+    if (c === '{') {
+      let depth = 1;
+      out += c;
+      i++;
+      while (i < expr.length && depth > 0) {
+        const ch = expr[i] ?? '';
+        out += ch;
+        if (ch === '"' || ch === "'" || ch === '`') {
+          // skip string in case label values include `{` / `}`
+          const q = ch;
+          i++;
+          while (i < expr.length) {
+            const sc = expr[i] ?? '';
+            out += sc;
+            if (sc === '\\' && q !== '`') {
+              i++;
+              if (i < expr.length) {
+                out += expr[i];
+                i++;
+              }
+              continue;
+            }
+            if (sc === q) {
+              i++;
+              break;
+            }
+            i++;
+          }
+          continue;
+        }
+        if (ch === '{') depth++;
+        else if (ch === '}') depth--;
+        i++;
+      }
+      continue;
+    }
+    // Identifier — collect, then decide whether to inject.
+    if (/[a-zA-Z_:]/.test(c)) {
+      // Word-boundary: an identifier preceded by `.` is a field
+      // access (TraceQL `resource.service.name`), not a fresh
+      // selector. The PromQL parser doesn't use dots in identifiers
+      // but the spec uses this helper for promql only — defence in
+      // depth.
+      const prev = i > 0 ? (expr[i - 1] ?? '') : '';
+      if (/[A-Za-z0-9_:.]/.test(prev)) {
+        out += c;
+        i++;
+        continue;
+      }
+      let j = i;
+      while (j < expr.length && /[a-zA-Z0-9_:]/.test(expr[j] ?? '')) j++;
+      const ident = expr.slice(i, j);
+      out += ident;
+      i = j;
+      // Skip whitespace to peek at the next significant char.
+      let k = i;
+      while (k < expr.length && /\s/.test(expr[k] ?? '')) k++;
+      const next = k < expr.length ? (expr[k] ?? '') : '';
+      // Grouping-modifier keywords (`by`, `without`, `on`,
+      // `ignoring`, `group_left`, `group_right`) followed by `(` —
+      // the `(...)` block is a label list (or a series of label
+      // names), not a selector. Skip the whole block so the walker
+      // doesn't inject into the label names. This check has to come
+      // BEFORE the generic `next === '('` branch, otherwise `by` is
+      // mistaken for a function call and the inner label-list is
+      // walked as if it were a function argument list.
+      if (
+        next === '(' &&
+        (ident === 'by' ||
+          ident === 'without' ||
+          ident === 'on' ||
+          ident === 'ignoring' ||
+          ident === 'group_left' ||
+          ident === 'group_right')
+      ) {
+        // Copy whitespace + balanced (...) block verbatim.
+        out += expr.slice(i, k + 1); // through the opening `(`
+        i = k + 1;
+        let depth = 1;
+        while (i < expr.length && depth > 0) {
+          const ch = expr[i] ?? '';
+          out += ch;
+          if (ch === '(') depth++;
+          else if (ch === ')') depth--;
+          i++;
+        }
+        continue;
+      }
+      // Function call → not a selector.
+      if (next === '(') continue;
+      // Already has a `{...}` block → first pass handled it.
+      if (next === '{') continue;
+      // Other keywords (bare `and`, `or`, `unless`, `offset`, `bool`,
+      // plus the aggregator names when used with a `by(...)` /
+      // `without(...)` modifier between the aggregator and the
+      // `(args)` block) → not selectors.
+      if (PROMQL_KEYWORDS.has(ident)) continue;
+      // Inject the synthesised selector block.
+      out += `{${matcher}}`;
+      continue;
+    }
+    // Any other character — copy verbatim.
+    out += c;
+    i++;
+  }
+  return out;
+}
+
+function escapeMatcherValue(v: string): string {
+  // PromQL string literal escaping: backslash, double quote.
+  return v.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/test/e2e/playwright/iterate-filter-drill.spec.ts
+++ b/test/e2e/playwright/iterate-filter-drill.spec.ts
@@ -1,0 +1,382 @@
+/**
+ * Phase-3 filter drill-down sweep.
+ *
+ * For every provisioned dashboard / panel / PromQL target with a
+ * grouping `by(...)` clause, fire the baseline query against cerberus
+ * via the Grafana datasource-proxy URL, pick one (label, value) pair
+ * observed in the response, re-fire the same query with a
+ * `{<label>="<value>"}` matcher tacked onto every selector, and assert
+ * the filtered result is non-empty AND has at most `baseline` series
+ * (the Q3-resolved subset rule from `~/.claude/plans/e2e-enhance.md`).
+ *
+ * What this catches (resolved on main; this is a regression pin):
+ *
+ *   - N3: a click on a stream-label value in Explore-Logs returns
+ *     empty even though the unfiltered query exposed that label.
+ *     Same root cause for the Prom-side variant: a matcher path that
+ *     drops series the unfiltered path returned.
+ *   - N15: drill-down chain breaks — the second-level drill returns
+ *     empty (`filteredSeriesCount === 0`) on a real, observed value.
+ *
+ * Subset semantics (Q3, plan §9): **count-based, not element-wise**.
+ * Element-wise strict-subset is order-dependent and flakes under
+ * series re-orderings — the count comparator is the load-bearing
+ * gate. `assertSubsetByCount(filtered, baseline)` enforces both
+ * `filtered > 0` and `filtered ≤ baseline`.
+ *
+ * Scope caveats (from the task brief):
+ *
+ *   - PromQL only. LogQL / TraceQL filter-drill is filed as a sibling
+ *     task; the `addLabelFilter` helper is PromQL-specific. Loki /
+ *     Tempo targets are skipped in this phase via the `dsType` check.
+ *   - Targets whose expression already constrains the drill label
+ *     via a hardcoded matcher (e.g.
+ *     `cerberus_queries_total{cerberus_ql="promql"}`) are skipped —
+ *     drilling there is either a no-op or contradicts the existing
+ *     matcher, neither of which is informative.
+ *   - `histogram_quantile(...)` panels: the drill keys come from the
+ *     *output* labels of the quantile (i.e. `expectedByKeys`, which
+ *     subtracts the `le` bucket-boundary label consumed by the
+ *     top-level quantile), not the inner `le`. Drilling on `le`
+ *     would produce a single-bucket scan whose subset comparison is
+ *     meaningless.
+ *
+ * Env:
+ *   GRAFANA_URL       default http://localhost:3000
+ *   GRAFANA_BASE_URL  honoured as a fallback for parity with
+ *                     compose_grafana_smoke.spec.ts
+ */
+
+import { expect, test } from '@playwright/test';
+
+import {
+  addLabelFilter,
+  assertSubsetByCount,
+  expectedByKeys,
+  expressionHasMatcherFor,
+  extractDataSourceProxyURL,
+  generateSelfTraffic,
+  iterateDashboards,
+  iteratePanels,
+} from './helpers/index.js';
+
+// Self-traffic warmup. Same envelope as the panel-shape spec — the
+// drill is meaningless against an empty baseline, so we seed first.
+const SEED_TRAFFIC_SECONDS = 30;
+
+// /api/v1/query_range window. Mirrors iterate-panel-shape.spec.ts so
+// the per-spec timing assumptions stay aligned (panel-shape's
+// rate(... [5m]) expressions need ≥ 5 min of populated data).
+const QUERY_WINDOW_SECONDS = 5 * 60;
+const QUERY_STEP_SECONDS = 15;
+
+/**
+ * Subset of the Prometheus /api/v1/query_range envelope we read.
+ * The drill-down spec only needs the per-series `metric` map and a
+ * top-level `status` field; sample values are irrelevant here.
+ */
+type PromQueryRangeResponse = {
+  status?: string;
+  data?: {
+    resultType?: string;
+    result?: Array<{
+      metric?: Record<string, string>;
+      values?: Array<[number, string]>;
+    }>;
+  };
+};
+
+type DrillCandidate = {
+  dashboardTitle: string;
+  panelTitle: string;
+  refId: string;
+  expr: string;
+  byKeys: string[];
+  proxyURL: string;
+};
+
+type DrillPair = {
+  surface: string;
+  baselineExpr: string;
+  filteredExpr: string;
+  key: string;
+  value: string;
+};
+
+test('filter-drill: every aggregating panel produces a non-empty subset when filtered on a real observed label value', async ({
+  request,
+}, testInfo) => {
+  // Drill = baseline query + N filtered queries per panel. Give the
+  // spec a 5-min budget; the panel-shape spec uses the same envelope.
+  testInfo.setTimeout(300_000);
+
+  const baseURL =
+    process.env.GRAFANA_URL ??
+    process.env.GRAFANA_BASE_URL ??
+    'http://localhost:3000';
+
+  // Seed self-traffic so the by-language / by-severity panels have
+  // data to drill on. The seed helper swallows individual request
+  // errors — this is a nudge, not an assertion.
+  await generateSelfTraffic(request, SEED_TRAFFIC_SECONDS);
+
+  const dashboards = await iterateDashboards(request, baseURL);
+  expect(
+    dashboards.length,
+    'at least one provisioned dashboard',
+  ).toBeGreaterThan(0);
+
+  // First pass: collect every Prom target with at least one by(...)
+  // key that doesn't already have a hardcoded matcher for that key.
+  const candidates: DrillCandidate[] = [];
+  const skipped: Array<{ surface: string; reason: string }> = [];
+
+  for (const dashboard of dashboards) {
+    for (const panel of iteratePanels(dashboard)) {
+      for (const target of panel.targets) {
+        const expr = target.expr;
+        if (!expr || expr.trim() === '') continue;
+
+        const dsType =
+          target.datasource?.type ?? panel.datasource?.type ?? '';
+        const surface = `${dashboard.title} :: ${panel.title} :: ${target.refId}`;
+
+        // LogQL / TraceQL — out of scope per the brief. Filed for a
+        // sibling task; the `addLabelFilter` helper is PromQL-only.
+        if (dsType !== 'prometheus') {
+          skipped.push({
+            surface,
+            reason: `non-prometheus datasource (type=${dsType || '<unset>'})`,
+          });
+          continue;
+        }
+
+        // `expectedByKeys` subtracts labels the top-level call
+        // consumes (currently only `le` for `histogram_quantile`);
+        // drilling on `le` would scan a single histogram bucket
+        // which is not what the drill semantic targets.
+        const byKeys = expectedByKeys(expr);
+        if (byKeys.length === 0) {
+          // Not an aggregating panel — no drill candidate.
+          continue;
+        }
+
+        // Skip the target if every byKey already has a hardcoded
+        // matcher in the expression — drilling would be a no-op or
+        // contradict the existing matcher, neither informative.
+        const drillableKeys = byKeys.filter(
+          (k) => !expressionHasMatcherFor(expr, k),
+        );
+        if (drillableKeys.length === 0) {
+          skipped.push({
+            surface,
+            reason: `every by-key already has a hardcoded matcher (byKeys=[${byKeys.join(
+              ', ',
+            )}])`,
+          });
+          continue;
+        }
+
+        const proxyURL = extractDataSourceProxyURL(dashboard, panel, target);
+        candidates.push({
+          dashboardTitle: dashboard.title,
+          panelTitle: panel.title,
+          refId: target.refId,
+          expr,
+          byKeys: drillableKeys,
+          proxyURL,
+        });
+      }
+    }
+  }
+
+  testInfo.annotations.push({
+    type: 'filter-drill-candidates',
+    description: `collected ${candidates.length} drill candidate(s) across ${dashboards.length} dashboard(s); skipped ${skipped.length} target(s)`,
+  });
+  for (const s of skipped) {
+    testInfo.annotations.push({
+      type: 'filter-drill-skip',
+      description: `[${s.surface}] ${s.reason}`,
+    });
+  }
+
+  expect(
+    candidates.length,
+    'at least one drillable Prometheus panel target across all provisioned dashboards',
+  ).toBeGreaterThan(0);
+
+  // Second pass: fire baselines, extract observed (key, value)
+  // pairs, then fire one filtered query per pair. We dedupe by
+  // (proxyURL, expr, key, value) so the same drill isn't fired twice
+  // across panels that share an expression.
+  const now = Math.floor(Date.now() / 1000);
+  const start = now - QUERY_WINDOW_SECONDS;
+  const end = now;
+
+  const failures: string[] = [];
+  const drillPairs: DrillPair[] = [];
+  const seenPair = new Set<string>();
+
+  for (const cand of candidates) {
+    const surface = `${cand.dashboardTitle} :: ${cand.panelTitle} :: ${cand.refId}`;
+    const baselineURL = buildQueryRangeURL(
+      baseURL,
+      cand.proxyURL,
+      cand.expr,
+      start,
+      end,
+    );
+
+    // Fire baseline.
+    let baseline: PromQueryRangeResponse;
+    try {
+      const resp = await request.get(baselineURL);
+      if (resp.status() < 200 || resp.status() > 299) {
+        const body = await resp.text().catch(() => '<unreadable>');
+        failures.push(
+          `[${surface}] baseline query → ${resp.status()}\n  url: ${baselineURL}\n  body: ${body.slice(
+            0,
+            600,
+          )}`,
+        );
+        continue;
+      }
+      baseline = (await resp.json()) as PromQueryRangeResponse;
+    } catch (err) {
+      failures.push(
+        `[${surface}] baseline probe threw: ${(err as Error).message}\n  url: ${baselineURL}`,
+      );
+      continue;
+    }
+
+    if (baseline.status !== 'success') {
+      failures.push(
+        `[${surface}] baseline returned status=${baseline.status ?? '<missing>'}\n  expr: ${cand.expr}`,
+      );
+      continue;
+    }
+
+    const baselineSeries = baseline.data?.result ?? [];
+    const baselineCount = baselineSeries.length;
+    if (baselineCount === 0) {
+      // No baseline data — nothing to drill on. The panel-shape spec
+      // already annotates empty panels; this isn't a filter-drill
+      // failure (the drill is only well-defined when there's data).
+      testInfo.annotations.push({
+        type: 'filter-drill-empty-baseline',
+        description: `[${surface}] baseline returned 0 series — drill skipped (no observed values to pick from)`,
+      });
+      continue;
+    }
+
+    // For each drillable byKey, collect the set of observed values
+    // from baseline.data.result[].metric[key]. Pick the first
+    // non-empty value — the first iteration order is deterministic
+    // across runs since the response is sorted by Prometheus.
+    for (const key of cand.byKeys) {
+      const observedValues = new Set<string>();
+      for (const series of baselineSeries) {
+        const v = series.metric?.[key];
+        if (typeof v === 'string' && v !== '') observedValues.add(v);
+      }
+      if (observedValues.size === 0) {
+        // The by-key wasn't actually populated on any frame — the
+        // panel-shape rule (#678) catches this shape under
+        // `assertLabelShape`; we don't double-report here.
+        testInfo.annotations.push({
+          type: 'filter-drill-empty-key',
+          description: `[${surface}] by-key "${key}" had no observed values across ${baselineCount} baseline frame(s) — drill not applicable`,
+        });
+        continue;
+      }
+
+      // Pick the first observed value deterministically (sorted).
+      const value = [...observedValues].sort()[0]!;
+
+      const filteredExpr = addLabelFilter(cand.expr, key, value);
+      const dedupKey = `${cand.proxyURL}\x00${filteredExpr}`;
+      if (seenPair.has(dedupKey)) continue;
+      seenPair.add(dedupKey);
+
+      drillPairs.push({
+        surface: `${surface} | drill ${key}=${value}`,
+        baselineExpr: cand.expr,
+        filteredExpr,
+        key,
+        value,
+      });
+
+      const filteredURL = buildQueryRangeURL(
+        baseURL,
+        cand.proxyURL,
+        filteredExpr,
+        start,
+        end,
+      );
+
+      try {
+        const resp = await request.get(filteredURL);
+        if (resp.status() < 200 || resp.status() > 299) {
+          const body = await resp.text().catch(() => '<unreadable>');
+          failures.push(
+            `[${surface}] filtered query (${key}="${value}") → ${resp.status()}\n  url: ${filteredURL}\n  body: ${body.slice(
+              0,
+              600,
+            )}`,
+          );
+          continue;
+        }
+        const filtered = (await resp.json()) as PromQueryRangeResponse;
+        if (filtered.status !== 'success') {
+          failures.push(
+            `[${surface}] filtered query (${key}="${value}") status=${filtered.status ?? '<missing>'}\n  expr: ${filteredExpr}`,
+          );
+          continue;
+        }
+        const filteredCount = (filtered.data?.result ?? []).length;
+        try {
+          assertSubsetByCount(
+            filteredCount,
+            baselineCount,
+            `${surface} | drill ${key}="${value}" | baselineExpr: ${cand.expr} | filteredExpr: ${filteredExpr}`,
+          );
+        } catch (err) {
+          failures.push(`[${surface}] ${(err as Error).message}`);
+        }
+      } catch (err) {
+        failures.push(
+          `[${surface}] filtered probe threw: ${(err as Error).message}\n  url: ${filteredURL}`,
+        );
+      }
+    }
+  }
+
+  testInfo.annotations.push({
+    type: 'filter-drill-pairs',
+    description: `exercised ${drillPairs.length} baseline→filtered drill pair(s)`,
+  });
+
+  expect(
+    drillPairs.length,
+    'at least one (baseline → filtered) drill pair exercised across all candidates',
+  ).toBeGreaterThan(0);
+
+  if (failures.length > 0) {
+    throw new Error(
+      `filter-drill rule violated for ${failures.length} drill(s):\n\n${failures.join('\n\n')}`,
+    );
+  }
+});
+
+function buildQueryRangeURL(
+  baseURL: string,
+  proxyURL: string,
+  expr: string,
+  start: number,
+  end: number,
+): string {
+  return `${baseURL}${proxyURL}/api/v1/query_range?query=${encodeURIComponent(
+    expr,
+  )}&start=${start}&end=${end}&step=${QUERY_STEP_SECONDS}`;
+}


### PR DESCRIPTION
## Summary

Phase-3 of the dashboard-iteration sweep (`~/.claude/plans/e2e-enhance.md` §4 + §7). Lands `iterate-filter-drill.spec.ts` alongside the existing `iterate-panel-shape.spec.ts` and wires it into `compose-smoke` (PR-blocking).

- For every provisioned dashboard / panel / Prometheus target with a `by(...)` clause, fires the baseline query against cerberus via the Grafana datasource-proxy URL, picks one observed `(label, value)` pair from the response, re-fires the same query with a `{<label>="<value>"}` matcher synthesised onto every selector, and asserts the filtered series count is in `(0, baseline]` (Q3-resolved count-based subset rule).
- Catches sweep findings N3 (`{cerberus_ql="promql"}` returns empty despite the unfiltered query exposing that label) and N15 (drill-down chain breaks). Both already fixed by PR #665 / #663 — this spec is the regression pin.

## Helpers added (with unit tests in `helpers.spec.ts`)

- `query-shape.addLabelFilter(expr, key, value)` — re-writes a PromQL expression to inject the matcher onto every vector selector. Token-walker handles bare metric names, empty / non-empty selector blocks, metric-less selectors (`{__name__=~".+"}`), histogram_quantile wrappers, and the grouping-modifier label lists inside `by(...)` / `without(...)` / `on(...)` / `ignoring(...)`. Duration suffixes (`5m`), string-literal contents, and TraceQL-style dotted accessors are not mistaken for selectors.
- `query-shape.expressionHasMatcherFor(expr, key)` — true iff `expr` already constrains `key` via any matcher operator (`=`, `!=`, `=~`, `!~`). The spec uses it to skip targets whose drill key is already hardcoded (drilling would be a no-op or contradict the existing matcher).
- `assertions.assertSubsetByCount(filtered, baseline, ctx)` — Q3-resolved count-based subset gate. Throws when `filtered === 0` (N3: real, observed value goes empty under the matcher path) and when `filtered > baseline` (matcher path emitting series the unfiltered query didn't).

## Scope caveats

- **PromQL only.** LogQL / TraceQL filter-drill is filed as a sibling task — the `addLabelFilter` token-walker is PromQL-grammar-specific. Loki / Tempo targets are skipped in this phase (the spec emits a `filter-drill-skip` annotation noting the datasource type).
- **Already-hardcoded matchers skipped.** Targets whose every by-key is already pinned by a matcher in the expression are excluded (annotated as `filter-drill-skip`).
- **`histogram_quantile(...)` drills on output labels.** The drill keys come from `expectedByKeys`, which subtracts the `le` bucket-boundary label consumed by the top-level quantile; drilling on `le` would scan a single histogram bucket.

## Test plan

- [ ] `compose-smoke` (this PR's CI run) — the spec runs against the docker-compose stack; the cerberus-self + otel-fixture-explorer aggregating panels (`sum by (cerberus_ql) (...)`, `sum by (cerberus_ql, reason) (...)`, `histogram_quantile(0.95, sum by (le, cerberus_ql) (...))`, `topk(10, sum by (service_name) (...))`, etc.) all pass the `(0, baseline]` rule when drilled on a real observed value.
- [ ] Local `cd test/e2e/playwright && npx tsc --noEmit` clean; `npx playwright test helpers.spec.ts` passes 45/45.

## Catches

Pins N3 / N15 (matcher-path drill regressions — `{cerberus_ql="promql"}` returning empty against an unfiltered query that exposed the label, and the drill-down chain breaking on a real observed value). Expected to be green against current `main` — the URGENT cluster #207-#219 already landed.