### PR TITLE
test(e2e/playwright): retire isKnownTolerated404 — both entries now 200 after #632 (Q5)

### DIFF
--- a/test/e2e/playwright/compose_grafana_smoke.spec.ts
+++ b/test/e2e/playwright/compose_grafana_smoke.spec.ts
@@ -187,18 +187,21 @@ test('compose: home, drilldown app, and every provisioned dashboard load without
     }
 
     // 3a. HTTP status sweep over every captured response.
+    //
+    // Zero 404 toleration (Q5, /home/thiago/.claude/plans/e2e-enhance.md
+    // §9.5): every non-2xx captured during the sweep is a failure. The
+    // prior `isKnownTolerated404` allow-list was retired in PR
+    // test/e2e-phase-7-retire-404-allow-list (task #230) — its last
+    // remaining entries (`/api/v1/rules` + `/api/v1/alerts`) became 200
+    // when PR #632 merged. The fix for any new 404 is to implement the
+    // endpoint or to remove that surface from the iteration, not to
+    // extend an allow-list. The new iterate-* specs already enforce the
+    // same policy via helpers/assertions.ts::assertNon200ResponseClass.
     for (const resp of captured) {
       const status = resp.status();
       if (status < 200 || status > 299) {
         const method = resp.request().method();
         const path = stripBase(resp.url(), baseURL);
-        if (isKnownTolerated404(status, path)) {
-          // Documented surface that cerberus does not yet implement and
-          // whose 404 has no UI / dashboard consequence. The list is
-          // narrow on purpose — see isKnownTolerated404 for the
-          // per-path rationale.
-          continue;
-        }
         let body = '';
         try {
           body = await resp.text();
@@ -942,29 +945,27 @@ function stripBase(url: string, base: string): string {
   return url.startsWith(base) ? url.slice(base.length) : url;
 }
 
-/**
- * Surfaces whose 404 has no user-visible consequence and that we
- * therefore tolerate while the corresponding implementation PR lands.
+/*
+ * `isKnownTolerated404` retired in task #230 (PR
+ * test/e2e-phase-7-retire-404-allow-list).
  *
- * Keep this list intentionally narrow — each entry is a known gap
- * tracked by an open PR. When the PR merges, drop the entry so the
- * catch-net snaps back to "every captured request is 2xx".
+ * The function previously allow-listed two Grafana-polled Prom paths
+ * (`/api/v1/rules`, `/api/v1/alerts`) while their backing stubs were
+ * still in flight. Both endpoints now return 200 (empty envelopes)
+ * after PR #632 merged on 2026-05-20:
  *
- * Current entries:
+ *   $ curl -s http://localhost:8080/api/v1/rules
+ *   {"status":"success","data":{"groups":[]}}
+ *   $ curl -s http://localhost:8080/api/v1/alerts
+ *   {"status":"success","data":{"alerts":[]}}
  *
- *   * `/api/datasources/uid/cerberus-prometheus/resources/api/v1/rules`
- *   * `/api/datasources/uid/cerberus-prometheus/resources/api/v1/alerts`
- *     Grafana's Prom datasource polls /api/v1/rules + /api/v1/alerts on
- *     every Explore / page load to gate the "Alert Rules" / "Alerts"
- *     UI affordances. cerberus is a query gateway with no rule engine,
- *     so PR #632 ships an empty-envelope stub. Until #632 merges,
- *     tolerate the 404 — the affordance simply renders empty, no panel
- *     or dashboard surface degrades.
+ * Per resolved decision Q5 in /home/thiago/.claude/plans/e2e-enhance.md
+ * §9.5 — "NO toleration. Every 404 surfaced during the sweep is a bug,
+ * not a tolerated state" — the helper and its allow-list are removed
+ * outright. New non-2xx responses fail the sweep at step 3a; the fix
+ * is to implement the endpoint or to drop the surface from the
+ * iteration, not to re-introduce an allow-list. The phase-1..4
+ * iterate-* specs enforce the same policy via
+ * helpers/assertions.ts::assertNon200ResponseClass, which by design
+ * carries no allow-list parameter.
  */
-function isKnownTolerated404(status: number, path: string): boolean {
-  if (status !== 404) return false;
-  return (
-    path.includes('/api/datasources/uid/cerberus-prometheus/resources/api/v1/rules') ||
-    path.includes('/api/datasources/uid/cerberus-prometheus/resources/api/v1/alerts')
-  );
-}

--- a/test/e2e/playwright/helpers/README.md
+++ b/test/e2e/playwright/helpers/README.md
@@ -71,11 +71,13 @@ When bumping:
 ### Q5 — zero 404 toleration
 
 `assertNon200ResponseClass` does NOT carry a tolerated-status allow
-list. The existing `isKnownTolerated404` in
-`compose_grafana_smoke.spec.ts` is retired (will be removed when
-phase 1 lands). Every non-2xx during a sweep is a failure; the fix
-is either to implement the endpoint or to remove that surface from
-the iteration, not to extend the allow-list.
+list. The legacy `isKnownTolerated404` in
+`compose_grafana_smoke.spec.ts` was retired in task #230 (PR
+`test/e2e-phase-7-retire-404-allow-list`) once its last two entries
+(`/api/v1/rules` + `/api/v1/alerts`) began returning 200 after PR #632
+merged. Every non-2xx during a sweep is a failure; the fix is either
+to implement the endpoint or to remove that surface from the
+iteration, not to extend the allow-list.
 
 ### Q3 — filter-drill subset rule is ≤ baseline count
 

--- a/test/e2e/playwright/helpers/assertions.ts
+++ b/test/e2e/playwright/helpers/assertions.ts
@@ -10,9 +10,11 @@
  *
  * Zero 404 toleration: `assertNon200ResponseClass` does NOT carry an
  * allow-list. Every non-2xx captured during a sweep is a failure. The
- * existing `isKnownTolerated404` in compose_grafana_smoke.spec.ts is
- * being retired and MUST NOT be ported here (resolved decision Q5,
- * /home/thiago/.claude/plans/e2e-enhance.md §9).
+ * legacy `isKnownTolerated404` allow-list in
+ * compose_grafana_smoke.spec.ts was retired in task #230 (PR
+ * test/e2e-phase-7-retire-404-allow-list) once its last two entries
+ * began returning 200. Do NOT reintroduce an allow-list here
+ * (resolved decision Q5, /home/thiago/.claude/plans/e2e-enhance.md §9.5).
  */
 
 import type { Request } from '@playwright/test';
@@ -234,11 +236,11 @@ export function assertSubsetByCount(
  * Assert the response class of a captured Playwright request is 2xx.
  *
  * This is the zero-404-toleration gate (Q5 in the design doc). The
- * existing `isKnownTolerated404` allow-list in
- * compose_grafana_smoke.spec.ts MUST NOT be ported here. Every
- * non-2xx is a failure; the fix is either to implement the endpoint
- * or to remove the surface from the iteration, not to extend an
- * allow-list.
+ * legacy `isKnownTolerated404` allow-list in
+ * compose_grafana_smoke.spec.ts was retired in task #230 and MUST
+ * NOT be ported here. Every non-2xx is a failure; the fix is either
+ * to implement the endpoint or to remove the surface from the
+ * iteration, not to extend an allow-list.
  *
  * The function only needs the Playwright Request handle to extract
  * `method()` + `url()` for the failure message; the status comes


### PR DESCRIPTION
## Summary

Phase 7 of the e2e-enhance plan (task #230) — retires the `isKnownTolerated404` allow-list in `test/e2e/playwright/compose_grafana_smoke.spec.ts`, enforcing the zero-404-toleration policy (resolved decision Q5, `/home/thiago/.claude/plans/e2e-enhance.md` §9.5).

The allow-list previously had two entries — both Grafana-polled Prom paths whose backing stubs landed in PR #632 (merged 2026-05-20):

- `/api/datasources/uid/cerberus-prometheus/resources/api/v1/rules`
- `/api/datasources/uid/cerberus-prometheus/resources/api/v1/alerts`

Live probe against the running compose stack confirms both return `200` with the documented empty envelopes:

```text
$ curl -s http://localhost:8080/api/v1/rules
{"status":"success","data":{"groups":[]}}
$ curl -s http://localhost:8080/api/v1/alerts
{"status":"success","data":{"alerts":[]}}
```

## Per-entry retirement decision

| Path | Status today | Decision |
| ---- | ------------ | -------- |
| `/api/v1/rules` | `200 {"status":"success","data":{"groups":[]}}` | **Removed** — stub from #632 returns the documented empty envelope. |
| `/api/v1/alerts` | `200 {"status":"success","data":{"alerts":[]}}` | **Removed** — stub from #632 returns the documented empty envelope. |

**Final state of the allow-list: empty.** The `isKnownTolerated404` function itself is removed; the catch-net at step 3a snaps back to "every captured request is 2xx."

## What this PR does

- Drops the `isKnownTolerated404` helper outright from `compose_grafana_smoke.spec.ts` (function definition + call site).
- Replaces the function definition with a `/* ... */` comment block at the original location preserving the Q5 rationale and the audit trail (last entries, retiring PR, plan reference) for archaeological lookup.
- Inlines a shorter pointer comment at the step 3a sweep site so anyone reading the loop sees why the toleration branch is gone.
- Updates `helpers/assertions.ts` and `helpers/README.md` to describe the allow-list as RETIRED (past tense) rather than "being retired" / "will be removed when phase 1 lands."

The new phase-1..4 `iterate-*` specs (`iterate-panel-shape`, `iterate-histogram-completeness`, `iterate-filter-drill`, `iterate-panel-kiosk`) already enforce zero toleration via `helpers/assertions.ts::assertNon200ResponseClass`, which by design carries no allow-list parameter — so the catch-net is consistent across both the legacy compose smoke and the new iteration sweep.

Closes task #230.

## Test plan

- [ ] `compose-smoke` CI gate passes (the spec touched is its primary fixture).
- [ ] `lint` / `forbid-skip` CI gates pass.
- [ ] Local check (already verified by author): the live compose stack returns `200` for both `/api/v1/rules` and `/api/v1/alerts`, so any sweep against the current stack reports zero failures from the retired allow-list paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)