### PR TITLE
ci(mutation): move mutation.yml off per-PR to push-to-main + nightly + dispatch (#239)

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,29 +1,18 @@
 name: mutation
 
-# Per-PR trigger is path-filtered to the 7 mutation-phased packages so
-# only QL / optimizer / chplan / chsql / qlcommon-touching PRs pay the
-# full matrix cost. Documentation / harness-only PRs skip the lane.
-# Informational on push-to-main + nightly + dispatch + PRs; promotion
-# to required PR gate happens after every phase stays green for a week
-# at 95%.
+# Mutation testing runs on push-to-main + nightly + manual dispatch
+# only. Per-PR runs were removed (#239): mutation jobs are
+# informational (test-quality regressions, not prod-blocking bugs),
+# the matrix cost is high, and noisy reds got debounced anyway.
+# Promotion to a required PR gate stays gated on every phase holding
+# its bar across an extended nightly window — at which point the
+# `pull_request:` trigger can be reintroduced.
 
 on:
-  pull_request:
-    branches: [main]
-    paths:
-      - 'internal/chplan/**'
-      - 'internal/chsql/**'
-      - 'internal/optimizer/**'
-      - 'internal/promql/**'
-      - 'internal/logql/**'
-      - 'internal/traceql/**'
-      - 'internal/qlcommon/**'
-      - '.gremlins.yaml'
-      - '.github/workflows/mutation.yml'
   push:
     branches: [main]
   schedule:
-    - cron: '0 4 * * *'
+    - cron: '17 3 * * *'   # nightly at 3:17 UTC; off-minute to avoid scheduler peaks
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Per task #239: move `mutation.yml` from per-PR to merge-to-main + nightly + manual-dispatch.

Per PR #664 rounds 1-10 experience, per-PR mutation testing has structural runner-budget issues. Mutation jobs are informational (test-quality regressions, not prod-blocking bugs), the matrix cost is high, and noisy reds got debounced anyway.

## Change

`.github/workflows/mutation.yml`:

- Drop `pull_request:` trigger entirely (with its path filter list).
- Keep `push.branches: [main]`.
- Shift nightly cron from `0 4 * * *` to `17 3 * * *` (off-minute, scheduler-peak avoidance).
- Keep `workflow_dispatch`.
- Rewrite the leading comment to reflect the new trigger set + the gate to reintroduce per-PR (every phase holding its bar across an extended nightly window).

The matrix workers + `.gremlins.yaml` excluded-files + sub-phase wiring from PR #664 rounds 7/8/9/10 is **not** in this PR. That work is still in flight in #664; this PR only touches the trigger block. After #664 merges, no further mutation.yml conflict is expected — the trigger section is structurally separate from the matrix.

## CLAUDE.md

No edit required. The mutation section under `## Tooling fork — gremlins` describes the fork rationale, not the trigger frequency. The line at the top of the hard-rules block lists `compatibility.yml` as `pull_request + push-to-main + nightly + manual dispatch` (still accurate for compat) and doesn't claim anything about mutation triggers.

## New trigger block (exact)

```yaml
on:
  push:
    branches: [main]
  schedule:
    - cron: '17 3 * * *'   # nightly at 3:17 UTC; off-minute to avoid scheduler peaks
  workflow_dispatch:
```

## Test plan

- [ ] Merge this PR; observe that `mutation` does not appear as a check on subsequent PRs.
- [ ] A push to `main` (e.g. this merge itself) fires the `mutation` workflow.
- [ ] Nightly run lands at 3:17 UTC.
- [ ] `workflow_dispatch` from the Actions tab still works.