### PR TITLE
test(e2e/playwright): land phase-6 drilldown-apps sweep — 4-app + isAppInstalled (#229)

### DIFF
--- a/test/e2e/playwright/helpers.spec.ts
+++ b/test/e2e/playwright/helpers.spec.ts
@@ -49,6 +49,7 @@ import {
   iterateDashboards,
   iteratePanels,
   iterateDrilldownApps,
+  isAppInstalled,
   DRILLDOWN_APPS,
 } from './helpers/index.js';
 
@@ -471,21 +472,31 @@ test('assertSubsetByCount throws when filtered exceeds baseline', () => {
   );
 });
 
-test('iterateDrilldownApps returns three apps including the three built-ins', () => {
+test('iterateDrilldownApps returns four apps including the four built-ins', () => {
   const apps = iterateDrilldownApps();
-  expect(apps.length).toBe(3);
+  expect(apps.length).toBe(4);
   const ids = apps.map((a) => a.id).sort();
   expect(ids).toEqual(
     [
       'grafana-exploretraces-app',
       'grafana-lokiexplore-app',
       'grafana-metricsdrilldown-app',
+      'grafana-pyroscope-app',
     ].sort(),
   );
   // Returned array must be a fresh copy — mutating it must not
   // contaminate the module-level constant.
   apps.pop();
-  expect(DRILLDOWN_APPS.length).toBe(3);
+  expect(DRILLDOWN_APPS.length).toBe(4);
+});
+
+test('DRILLDOWN_APPS entries each carry id + root + label', () => {
+  for (const app of DRILLDOWN_APPS) {
+    expect(app.id).toMatch(/^grafana-[a-z]+-app$/);
+    expect(app.root.startsWith('/a/')).toBe(true);
+    expect(app.root).toContain(app.id);
+    expect(app.label.length).toBeGreaterThan(0);
+  }
 });
 
 // --- LogQL filter helpers (Phase 3b) ---------------------------------------
@@ -780,4 +791,46 @@ test('iterateDashboards round-trips against a live Grafana', async ({
       expect(p.type).not.toBe('row');
     }
   }
+});
+
+test('isAppInstalled distinguishes installed apps from a known-bogus id', async ({
+  request,
+}) => {
+  const baseURL = process.env.GRAFANA_BASE_URL ?? 'http://localhost:3000';
+  const probe = await request.get(`${baseURL}/api/health`).catch(() => null);
+  if (!probe || probe.status() < 200 || probe.status() > 299) {
+    test.info().annotations.push({
+      type: 'live-grafana',
+      description: `Grafana at ${baseURL} not reachable; isAppInstalled smoke skipped`,
+    });
+    return;
+  }
+
+  // A clearly-bogus plugin id must resolve to false (404 → not
+  // installed). This is the load-bearing contract — the phase-6 spec
+  // relies on isAppInstalled returning false on the missing
+  // grafana-pyroscope-app rather than throwing.
+  const bogus = await isAppInstalled(
+    request,
+    baseURL,
+    'grafana-this-app-does-not-exist-anywhere',
+  );
+  expect(bogus).toBe(false);
+
+  // At least one of the preinstalled drilldown apps in Grafana 11.4.0
+  // must resolve to true. We probe all of them but only require ≥1 to
+  // be present so a stripped-down stack (no apps at all) still surfaces
+  // the contract: the helper returned a boolean, not a throw.
+  const installed = await Promise.all(
+    DRILLDOWN_APPS.map((app) => isAppInstalled(request, baseURL, app.id)),
+  );
+  for (const v of installed) {
+    expect(typeof v).toBe('boolean');
+  }
+  test.info().annotations.push({
+    type: 'drilldown-apps-installed',
+    description: DRILLDOWN_APPS.map(
+      (app, i) => `${app.id}=${installed[i] ? 'installed' : 'absent'}`,
+    ).join(', '),
+  });
 });

--- a/test/e2e/playwright/helpers/README.md
+++ b/test/e2e/playwright/helpers/README.md
@@ -13,7 +13,7 @@ land in subsequent PRs.
 | `query-shape.ts` | Regex-based target classification + rewriting: `extractByKeys`, `extractWithoutKeys`, `expectedByKeys`, `isHistogramQuantile`, `extractHistogramName`, `addLabelFilter`, `expressionHasMatcherFor`.   |
 | `assertions.ts`  | Per-shape assertions over the Grafana `/api/ds/query` envelope (`assertLabelShape` / `assertLabelAbsent` / histogram pair / `assertSubsetByCount`) + the zero-404 gate (`assertNon200ResponseClass`). |
 | `sweep.ts`       | `generateSelfTraffic` — pre-step that fires self-traffic against cerberus so the cerberus-self dashboards have data to render.                                                                        |
-| `drilldown.ts`   | Drilldown-app catalogue + `drillTwoLevels` gesture driver for the three built-in apps.                                                                                                                |
+| `drilldown.ts`   | Drilldown-app catalogue (4 built-in apps) + `drillTwoLevels` gesture driver + `isAppInstalled` (`/api/plugins/<id>/settings` probe so the iteration handles apps that aren't provisioned).            |
 | `dom.ts`         | Browser-side helpers: console-error capture, `role="alert"` banner read, kiosk repaint-flicker tolerance.                                                                                             |
 | `probes.ts`      | `fetchAndAssert200` (the zero-404 gate on direct HTTP probes) + `extractDataSourceProxyURL` (panel → datasource proxy path).                                                                          |
 
@@ -32,7 +32,7 @@ concrete iteration:
 | 3     | `iterate-filter-drill.spec.ts`       | `dashboard`, `query-shape` (`addLabelFilter`, `expressionHasMatcherFor`, `expectedByKeys`), `assertions` (`assertSubsetByCount`), `sweep`, `probes` |
 | 4     | `compose_panel_kiosk.spec.ts`        | `dashboard`, `dom`, `assertions`                                                                                                                    |
 | 5     | `iterate-time-ranges.spec.ts`        | `dashboard`, `query-shape`, `assertions`, `sweep`, `probes` — nightly-only (e2e.yml `dashboard` job), NOT compose-smoke (Q2)                        |
-| 6     | `compose_drilldown_apps.spec.ts`     | `drilldown`, `dom`, `assertions`                                                                                                                    |
+| 6     | `iterate-drilldown-apps.spec.ts`     | `drilldown` (4-app catalogue + `isAppInstalled`), `dom`, `probes`                                                                                   |
 
 The existing `compose_grafana_smoke.spec.ts` is untouched in this PR;
 phase 1 will retire its bespoke `driveCerberusQLPartition` /
@@ -50,6 +50,12 @@ Grafana 11.x dashboard JSON shape:
 - Panel headers expose `data-testid="data-testid Panel header <title>"`.
 - Drilldown-app affordances expose stable `data-testid` prefixes
   (`data-testid metric-select`, `data-testid detected-label`, …).
+- Grafana 11.4.0 ships `grafana-metricsdrilldown-app`,
+  `grafana-lokiexplore-app`, and `grafana-exploretraces-app`
+  preinstalled+enabled out of the box. `grafana-pyroscope-app` is
+  NOT preinstalled on the cerberus compose stack — the phase-6 spec
+  uses `isAppInstalled` to detect availability and annotates a
+  cleanly missing app instead of failing.
 
 **Bumping Grafana requires updating the phase specs in the same PR**
 (resolved decision Q4, `~/.claude/plans/e2e-enhance.md` §9). The

--- a/test/e2e/playwright/helpers/drilldown.ts
+++ b/test/e2e/playwright/helpers/drilldown.ts
@@ -1,16 +1,25 @@
 /**
  * Drilldown-app iteration helpers.
  *
- * Grafana ships three built-in drilldown apps:
+ * Grafana ships four built-in drilldown apps (Grafana 11.4.0):
  *   - grafana-metricsdrilldown-app   (Explore Metrics)
  *   - grafana-lokiexplore-app        (Explore Logs)
  *   - grafana-exploretraces-app      (Explore Traces)
+ *   - grafana-pyroscope-app          (Explore Profiles / Pyroscope)
  *
  * Each app boots its own React tree and fires its own wave of
- * `/api/datasources/uid/.../resources/...` calls. The current
- * compose-smoke spec only touches Explore Logs (and only at boot).
- * Phase 6 will drive a two-level click through all three to catch
- * N15-class regressions (drilldown empty after a facet click).
+ * `/api/datasources/uid/.../resources/...` calls. The compose-smoke
+ * spec only touches Explore Logs (and only at boot). The nightly
+ * `iterate-drilldown-apps.spec.ts` drives a two-level click through
+ * each installed app to catch N15-class regressions (drilldown empty
+ * after a facet click).
+ *
+ * The pyroscope app is NOT preinstalled on the cerberus compose stack
+ * (no `GF_INSTALL_PLUGINS` line in `docker-compose.yml`); on a vanilla
+ * Grafana 11.4.0 the first three apps ship out-of-the-box. The spec
+ * uses `isAppInstalled` below to detect per-app availability so a
+ * missing pyroscope (or any other app on a stripped-down stack)
+ * annotates cleanly instead of failing.
  *
  * The drilldown-app surface churns hard on every Grafana upgrade —
  * pin the Grafana version (currently `grafana/grafana:11.4.0`, see
@@ -18,7 +27,7 @@
  * when bumping.
  */
 
-import type { Page } from '@playwright/test';
+import type { APIRequestContext, Page, Response } from '@playwright/test';
 
 export type DrilldownApp = {
   /** Grafana plugin id. */
@@ -45,6 +54,11 @@ export const DRILLDOWN_APPS: ReadonlyArray<DrilldownApp> = [
     root: '/a/grafana-exploretraces-app/explore',
     label: 'Explore Traces',
   },
+  {
+    id: 'grafana-pyroscope-app',
+    root: '/a/grafana-pyroscope-app/single',
+    label: 'Explore Profiles',
+  },
 ];
 
 /**
@@ -58,6 +72,57 @@ export function iterateDrilldownApps(): DrilldownApp[] {
 }
 
 /**
+ * Probe whether a Grafana drilldown app is installed by reading
+ * `/api/plugins/<id>/settings`. Grafana returns 200 + a JSON
+ * `{ enabled: true, ... }` body for an installed+enabled app, 404
+ * for an app that's not installed, and 200 + `{ enabled: false }` for
+ * an app that's installed but disabled.
+ *
+ * The compose stack does not preinstall `grafana-pyroscope-app`
+ * (no `GF_INSTALL_PLUGINS` in `docker-compose.yml`); calls for that
+ * app return 404 there. On a vanilla Grafana 11.4.0 the other three
+ * drilldown apps ship preinstalled+enabled.
+ *
+ * Returns `true` only when the plugin endpoint returns 2xx AND the
+ * `enabled` field is truthy. Network errors (e.g. Grafana down) are
+ * surfaced as a thrown error — the caller is expected to have already
+ * confirmed Grafana reachability before iterating apps.
+ */
+export async function isAppInstalled(
+  request: APIRequestContext,
+  baseURL: string,
+  appId: string,
+): Promise<boolean> {
+  const resp = await request.get(`${baseURL}/api/plugins/${appId}/settings`);
+  const status = resp.status();
+  // 404 → not installed. Other non-2xx (e.g. 401 on an authed Grafana
+  // misconfigured for anonymous) are reported as not-installed so the
+  // spec annotates and moves on; auth misconfig is out of scope for the
+  // drilldown sweep.
+  if (status === 404) return false;
+  if (status < 200 || status > 299) return false;
+  let parsed: { enabled?: boolean };
+  try {
+    parsed = (await resp.json()) as typeof parsed;
+  } catch {
+    return false;
+  }
+  return parsed.enabled === true;
+}
+
+/**
+ * Outcome shape returned by `drillTwoLevels`. The spec uses this to
+ * annotate per-app "got to level N" without inferring depth from a
+ * void return.
+ */
+export type DrillTwoLevelsResult = {
+  /** Number of drill clicks the helper successfully executed (0, 1, or 2). */
+  levelsClicked: number;
+  /** True if the app root navigation rendered no clickable affordance. */
+  rootHadNoAffordance: boolean;
+};
+
+/**
  * Drive two levels of click-drill inside a drilldown app.
  *
  * Step 1: navigate to `app.root` (relative to the page's baseURL).
@@ -66,6 +131,7 @@ export function iterateDrilldownApps(): DrilldownApp[] {
  *           - Explore Metrics  → a metric tile in the trail grid.
  *           - Explore Logs     → a label-value chip in the labels list.
  *           - Explore Traces   → a service-name row in the table.
+ *           - Explore Profiles → a profile-type / service row.
  *         The helper uses a single tolerant selector union so an
  *         affordance schema drift on Grafana upgrade fails loudly
  *         in *this* helper (not silently in a phase spec).
@@ -76,11 +142,14 @@ export function iterateDrilldownApps(): DrilldownApp[] {
  * existing compose-smoke timing budget). Assertions over the
  * captured network traffic + DOM are the spec's job, not this
  * helper's — `drillTwoLevels` only drives the gestures.
+ *
+ * Returns a `DrillTwoLevelsResult` so the spec can annotate
+ * "completed N drill click(s)" without inferring depth from the page.
  */
 export async function drillTwoLevels(
   app: DrilldownApp,
   page: Page,
-): Promise<void> {
+): Promise<DrillTwoLevelsResult> {
   // Step 1 — land on the app root.
   await page.goto(app.root, { waitUntil: 'domcontentloaded', timeout: 90_000 });
   await page
@@ -104,6 +173,9 @@ export async function drillTwoLevels(
         // Explore Traces — service-name row / facet button.
         '[data-testid^="data-testid service-"]',
         '[data-testid^="data-testid facet-"]',
+        // Explore Profiles — profile-type / flamegraph entry.
+        '[data-testid^="data-testid profile-"]',
+        '[data-testid^="data-testid flamegraph"]',
         // Generic Grafana table-row affordance (last-resort).
         '[role="rowgroup"] [role="row"] a[href]',
       ].join(', '),
@@ -115,7 +187,7 @@ export async function drillTwoLevels(
     // failure (covered by the wire / DOM sweeps), not a precondition
     // bug in this helper. Bail out cleanly so the spec sees the
     // empty-state and reports it with full context.
-    return;
+    return { levelsClicked: 0, rootHadNoAffordance: true };
   }
 
   await firstAffordance.click({ timeout: 10_000 });
@@ -135,17 +207,28 @@ export async function drillTwoLevels(
         '[data-testid^="data-testid label-value"]',
         '[data-testid^="data-testid service-"]',
         '[data-testid^="data-testid facet-"]',
+        '[data-testid^="data-testid profile-"]',
+        '[data-testid^="data-testid flamegraph"]',
         '[role="rowgroup"] [role="row"] a[href]',
       ].join(', '),
     )
     .first();
 
   if ((await secondAffordance.count()) === 0) {
-    return;
+    return { levelsClicked: 1, rootHadNoAffordance: false };
   }
 
   await secondAffordance.click({ timeout: 10_000 });
   await page
     .waitForLoadState('networkidle', { timeout: 45_000 })
     .catch(() => {});
+
+  return { levelsClicked: 2, rootHadNoAffordance: false };
 }
+
+/**
+ * `Response` is re-exported for spec convenience so the
+ * iterate-drilldown-apps spec doesn't need a second `@playwright/test`
+ * import just for the response capture type.
+ */
+export type { Response };

--- a/test/e2e/playwright/iterate-drilldown-apps.spec.ts
+++ b/test/e2e/playwright/iterate-drilldown-apps.spec.ts
@@ -1,0 +1,377 @@
+/**
+ * Phase-6 drilldown-apps sweep.
+ *
+ * Iterates every Grafana built-in drilldown app (the 4-app catalogue in
+ * `helpers/drilldown.ts`), drives a two-level click-drill through each
+ * installed app, and asserts the per-app sweep is clean:
+ *
+ *   1. Every captured Grafana / cerberus HTTP response is 2xx (no 4xx
+ *      and no 5xx). Drilldown apps fire `/api/datasources/proxy/uid/…`,
+ *      `/api/datasources/uid/…/resources/…`, and `/api/ds/query` —
+ *      every one is in scope per Q5 of the e2e enhancement plan (no
+ *      tolerated-status allow-list).
+ *   2. No `role="alert"` banner with error-class text is on the page
+ *      at any level (root, after first drill, after second drill).
+ *      Drilldown apps surface query errors as red banners (e.g.
+ *      Explore-Traces' "Query error: illegal wireType" — N4-shaped).
+ *   3. No browser console `error`-level message was emitted across
+ *      the whole app sweep. Plugin failures (chunk-load errors,
+ *      datasource-resource 502s, fetch aborts) all surface as
+ *      console errors; the spec carries no allow-list per Q5.
+ *
+ * Per-app handling for "App not installed":
+ *
+ *   The cerberus compose stack does NOT preinstall
+ *   `grafana-pyroscope-app` (no `GF_INSTALL_PLUGINS` line in
+ *   `docker-compose.yml`). The vanilla Grafana 11.4.0 image ships the
+ *   other three drilldown apps preinstalled+enabled. For each app the
+ *   spec calls `isAppInstalled` (= `/api/plugins/<id>/settings`); if
+ *   the app is absent the spec annotates `app-not-installed` and
+ *   continues to the next one without failing. This matches the brief:
+ *   the spec must surface "Pyroscope not installed" as data, not as a
+ *   sweep failure.
+ *
+ * Gate posture: NIGHTLY ONLY. Wired into the `dashboard` job in
+ * `.github/workflows/e2e.yml`, which runs on push-to-main + nightly +
+ * manual dispatch (NOT pull_request). Drilldown-app UIs are the
+ * highest UI-churn surface in Grafana — keeping this PR-blocking would
+ * push every Grafana bump into a same-day spec rewrite. The nightly
+ * posture buys a 24h buffer before a regression blocks a PR.
+ *
+ * Grafana version pinning: selectors and per-app root URLs are tied to
+ * `grafana/grafana:11.4.0` (the tag pinned in `docker-compose.yml`).
+ * When the compose stack bumps Grafana, this spec MUST be updated in
+ * the same PR — see helpers/README.md "Pinned Grafana version" for
+ * the upgrade checklist. Q4 of `~/.claude/plans/e2e-enhance.md` §9
+ * pinned this maintenance contract.
+ *
+ * What this catches (the latent class the plan file flagged):
+ *
+ *   - N15: drill chain breaks on the second-level click — affordance
+ *     present, click registered, but the result view is empty + emits
+ *     a console error or a `role="alert"` banner.
+ *   - N15 bis: app-chunk load failure (a 4xx/5xx on a `/public/build/…`
+ *     URL during boot, or a datasource-resources 502 mid-drill).
+ *
+ * Env:
+ *   GRAFANA_URL       default http://localhost:3000
+ *   GRAFANA_BASE_URL  honoured as a fallback for parity with
+ *                     compose_grafana_smoke.spec.ts
+ */
+
+import {
+  type Page,
+  type Response,
+  type TestInfo,
+  expect,
+  test,
+} from '@playwright/test';
+
+import {
+  type DrilldownApp,
+  captureConsoleErrors,
+  captureRoleAlertBanners,
+  drillTwoLevels,
+  isAppInstalled,
+  iterateDrilldownApps,
+} from './helpers/index.js';
+
+// `role="alert"` substrings that count as an error-state banner. The
+// same list as the kiosk spec — Grafana surfaces all panel / plugin
+// error states through one of these tokens.
+const ALERT_ERROR_PATTERNS: RegExp[] = [
+  /error/i,
+  /failed/i,
+  /illegal wiretype/i,
+  /plugin\.downstream/i,
+  /unable to/i,
+];
+
+// "App is not installed" placeholder banner that some Grafana
+// drilldown apps surface when their plugin isn't loaded. This is the
+// expected visible state for an absent app; we don't want to
+// `isAppInstalled` it through, but if it shows up after install probe
+// passed we still want to skip the error sweep on it. Conservative:
+// match only the exact phrasing Grafana 11.4.0 renders.
+const APP_NOT_INSTALLED_BANNER_PATTERNS: RegExp[] = [
+  /app plugin not installed/i,
+  /plugin not found/i,
+];
+
+// Upstream-Grafana console-error families that fire on drilldown-app
+// boot regardless of datasource health. Kept narrow on purpose — the
+// kiosk spec carries a single Grafana-internal telemetry pattern, and
+// the drilldown sweep inherits the same policy (Q5 zero-allow-list,
+// scoped to cerberus-emitted errors only).
+const DRILLDOWN_UPSTREAM_GRAFANA_CONSOLE_NOISE: RegExp[] = [
+  /\[Metrics\] Failed to stopMeasure loadDashboardScene.*The mark 'loadDashboardScene_started' does not exist/i,
+];
+
+// Captured response shape: stripped down so the failure detail isn't
+// dragged down by a 1MB ds/query body.
+type CapturedResponseSummary = {
+  url: string;
+  method: string;
+  status: number;
+  bodyPreview: string;
+};
+
+type DrilldownFailure = {
+  app: string;
+  rule: string;
+  detail: string;
+};
+
+test('drilldown-apps: each installed drilldown app drills two levels without 4xx/5xx + no role=alert error + no console errors', async ({
+  page,
+  request,
+}, testInfo) => {
+  // Per-app: 1 navigation + 2 click-drills + 3× networkidle settles.
+  // Budget 4 apps × ~90s + a generous headroom for the heaviest app
+  // (Explore-Traces tends to be slowest on a cold ClickHouse) = 8 min.
+  testInfo.setTimeout(8 * 60_000);
+
+  const baseURL =
+    process.env.GRAFANA_URL ??
+    process.env.GRAFANA_BASE_URL ??
+    'http://localhost:3000';
+
+  const apps = iterateDrilldownApps();
+  expect(apps.length, 'all four built-in drilldown apps in catalogue').toBe(4);
+
+  const failures: DrilldownFailure[] = [];
+  const perAppOutcomes: Array<{ app: string; outcome: string }> = [];
+
+  for (const app of apps) {
+    // 1. Install-probe. If the app isn't installed, annotate and skip.
+    //    This is the only "skip" allowed by the brief: pyroscope is
+    //    expected to be absent on the compose stack, and the spec must
+    //    survive that cleanly.
+    const installed = await isAppInstalled(request, baseURL, app.id);
+    if (!installed) {
+      testInfo.annotations.push({
+        type: 'drilldown-app-not-installed',
+        description: `${app.id} (${app.label}): /api/plugins/${app.id}/settings absent or disabled — drill omitted`,
+      });
+      perAppOutcomes.push({
+        app: app.id,
+        outcome: 'app-not-installed',
+      });
+      continue;
+    }
+
+    // 2. Drive the app + capture wire / DOM signal.
+    const appFailures = await sweepDrilldownApp(page, baseURL, app, testInfo);
+    failures.push(...appFailures);
+
+    perAppOutcomes.push({
+      app: app.id,
+      outcome:
+        appFailures.length === 0
+          ? 'drilled-clean'
+          : `drilled-with-${appFailures.length}-failure(s)`,
+    });
+  }
+
+  testInfo.annotations.push({
+    type: 'drilldown-apps-summary',
+    description: perAppOutcomes
+      .map((o) => `${o.app}: ${o.outcome}`)
+      .join('; '),
+  });
+
+  // Sanity: at least one of the four built-ins must have been
+  // installed. If every app reports "not installed" the compose stack
+  // is broken (or this spec is running against a non-Grafana endpoint)
+  // — surface that loudly rather than passing on an empty sweep.
+  const installedCount = perAppOutcomes.filter(
+    (o) => o.outcome !== 'app-not-installed',
+  ).length;
+  expect(
+    installedCount,
+    'at least one drilldown app installed on the Grafana stack',
+  ).toBeGreaterThan(0);
+
+  if (failures.length > 0) {
+    const detail = failures
+      .map((f) => `[${f.app} :: ${f.rule}] ${f.detail}`)
+      .join('\n\n');
+    throw new Error(
+      `drilldown-apps rule violated for ${failures.length} surface(s):\n\n${detail}`,
+    );
+  }
+});
+
+/**
+ * Drive a single drilldown app:
+ *   - capture console errors + every interesting Grafana/cerberus
+ *     response across the whole gesture sequence,
+ *   - call `drillTwoLevels` to navigate + drill twice,
+ *   - after each settled level, snapshot `role="alert"` banners,
+ *   - tear down listeners,
+ *   - apply: zero non-2xx, no error-class banner text, no console
+ *     error (modulo upstream-Grafana noise).
+ *
+ * Returns a list of failures — empty if the app sweep is clean.
+ */
+async function sweepDrilldownApp(
+  page: Page,
+  baseURL: string,
+  app: DrilldownApp,
+  testInfo: TestInfo,
+): Promise<DrilldownFailure[]> {
+  const failures: DrilldownFailure[] = [];
+
+  const { messages: consoleErrors, stop: stopConsole } =
+    await captureConsoleErrors(page);
+
+  const captured: CapturedResponseSummary[] = [];
+  // Capture every response the drilldown app fires against Grafana's
+  // proxy/resources/ds-query surfaces. This is the same surface set
+  // the existing `compose_grafana_smoke.spec.ts` watches; the drilldown
+  // sweep enforces the same zero-non-2xx rule across all three.
+  const captureBodies: Promise<void>[] = [];
+  const onResponse = (resp: Response) => {
+    const url = resp.url();
+    if (
+      url.includes('/api/ds/query') ||
+      url.includes('/api/dashboards/') ||
+      url.includes('/api/datasources/proxy/uid/') ||
+      (url.includes('/api/datasources/uid/') && url.includes('/resources/')) ||
+      // Drilldown apps also fetch their own plugin chunks via
+      // /public/plugins/<id>/...; a 4xx/5xx there breaks the app boot.
+      url.includes(`/public/plugins/${app.id}/`) ||
+      // Some apps lazy-load chunks under /public/build/...; capture
+      // failure responses there too.
+      (url.includes('/public/build/') && url.endsWith('.js'))
+    ) {
+      // Read body lazily — kept short to keep memory bounded.
+      const status = resp.status();
+      const method = resp.request().method();
+      const summaryPromise = (async () => {
+        let bodyPreview = '';
+        // Only read the body when it's a failure so we don't spam
+        // memory with 1MB success bodies.
+        if (status < 200 || status > 299) {
+          try {
+            const text = await resp.text();
+            bodyPreview = truncate(text, 600);
+          } catch {
+            bodyPreview = '<unreadable>';
+          }
+        }
+        captured.push({
+          url: stripBase(resp.url(), baseURL),
+          method,
+          status,
+          bodyPreview,
+        });
+      })();
+      captureBodies.push(summaryPromise);
+    }
+  };
+  page.on('response', onResponse);
+
+  let levelsClicked = 0;
+  let rootHadNoAffordance = false;
+
+  try {
+    const result = await drillTwoLevels(app, page);
+    levelsClicked = result.levelsClicked;
+    rootHadNoAffordance = result.rootHadNoAffordance;
+
+    // After each settle (root + each click) we snapshot role=alert
+    // banners. We don't have per-step hooks inside drillTwoLevels — the
+    // helper is deliberately gesture-only — so we do one final snapshot
+    // here, which reflects the deepest state reached. If a banner fires
+    // mid-drill the helper's networkidle wait gives Grafana time to
+    // render it before we sample.
+    const alertBanners = await captureRoleAlertBanners(page);
+    for (const banner of alertBanners) {
+      if (
+        APP_NOT_INSTALLED_BANNER_PATTERNS.some((re) => re.test(banner))
+      ) {
+        // isAppInstalled probe said yes but Grafana rendered the
+        // "not installed" banner anyway — surface that as a soft
+        // annotation (it's an installation drift, not a drill regression).
+        testInfo.annotations.push({
+          type: 'drilldown-app-banner-not-installed',
+          description: `${app.id}: rendered "${truncate(
+            banner,
+            200,
+          )}" despite isAppInstalled=true`,
+        });
+        continue;
+      }
+      if (ALERT_ERROR_PATTERNS.some((re) => re.test(banner))) {
+        failures.push({
+          app: app.id,
+          rule: 'role-alert-error-banner',
+          detail: `role=alert banner with error text: ${truncate(banner, 400)}`,
+        });
+      }
+    }
+  } catch (err) {
+    failures.push({
+      app: app.id,
+      rule: 'drilldown-navigation-threw',
+      detail: `drillTwoLevels threw: ${(err as Error).message}; root: ${app.root}`,
+    });
+  } finally {
+    page.off('response', onResponse);
+    stopConsole();
+  }
+
+  // Drain the in-flight body-read promises so we don't miss late
+  // failures (e.g. a 500 still streaming when the navigation settled).
+  await Promise.all(captureBodies);
+
+  // 1. Wire-status sweep over every captured response. Q5: zero
+  //    toleration for 4xx/5xx.
+  for (const resp of captured) {
+    if (resp.status < 200 || resp.status > 299) {
+      failures.push({
+        app: app.id,
+        rule: 'http-non-2xx',
+        detail: `${resp.method} ${resp.url} → ${resp.status}\n  body: ${resp.bodyPreview}`,
+      });
+    }
+  }
+
+  // 2. Console-error sweep. Filter the narrow upstream-Grafana
+  //    telemetry pattern; everything else is a real failure.
+  const cerberusConsoleErrors = consoleErrors.filter(
+    (m) => !DRILLDOWN_UPSTREAM_GRAFANA_CONSOLE_NOISE.some((re) => re.test(m)),
+  );
+  if (cerberusConsoleErrors.length > 0) {
+    failures.push({
+      app: app.id,
+      rule: 'console-error',
+      detail: `${cerberusConsoleErrors.length} console error(s):\n${cerberusConsoleErrors
+        .map((m) => `  - ${truncate(m, 400)}`)
+        .join('\n')}`,
+    });
+  }
+
+  // 3. Annotate per-app drill depth so the test report shows whether
+  //    a "clean" sweep actually exercised both drill clicks. An app
+  //    that drilled 0 levels with no other failure surfaces as a
+  //    "drilled-clean" outcome above, but the annotation here makes
+  //    that visible to the reviewer.
+  testInfo.annotations.push({
+    type: 'drilldown-app-depth',
+    description: `${app.id}: levelsClicked=${levelsClicked}, rootHadNoAffordance=${rootHadNoAffordance}, capturedResponses=${captured.length}`,
+  });
+
+  return failures;
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return `${s.slice(0, max)}…<truncated, ${s.length - max} more char(s)>`;
+}
+
+function stripBase(url: string, baseURL: string): string {
+  if (url.startsWith(baseURL)) return url.slice(baseURL.length);
+  return url;
+}


### PR DESCRIPTION
## Summary

Phase-6 of the e2e-enhance plan (`~/.claude/plans/e2e-enhance.md` §4.2 + §7). Nightly-only, NOT PR-blocking.

- `test/e2e/playwright/iterate-drilldown-apps.spec.ts` drives a two-level click-drill through each Grafana 11.4.0 built-in drilldown app (Explore Metrics / Logs / Traces / Profiles), asserts:
  - every captured `/api/ds/query`, `/api/datasources/proxy/uid/…`, `/api/datasources/uid/…/resources/…`, `/public/plugins/<id>/…` response is 2xx (Q5 zero-toleration; no allow-list),
  - no `role="alert"` banner with error-class text at any level,
  - no browser-console `error` (modulo the narrow upstream-Grafana `loadDashboardScene` telemetry pattern the kiosk spec already filters).
- Closes the N15 latent regression class (drilldown empty after a facet click) from the e2e enhancement plan.

## Helpers extended (phase-0 follow-up)

- `DRILLDOWN_APPS` grows from 3 → 4 entries (added `grafana-pyroscope-app`, root `/a/grafana-pyroscope-app/single`).
- `drillTwoLevels` returns `DrillTwoLevelsResult` (`levelsClicked` + `rootHadNoAffordance`) so the spec can annotate per-app drill depth without inferring from page state.
- New `isAppInstalled(request, baseURL, appId): Promise<boolean>` probes `/api/plugins/<id>/settings` — returns false on 404 or `enabled: false`. The cerberus compose stack does NOT preinstall `grafana-pyroscope-app` (no `GF_INSTALL_PLUGINS` in `docker-compose.yml`); the spec annotates `drilldown-app-not-installed` and continues without failing.
- Unit tests added to `helpers.spec.ts`:
  - `iterateDrilldownApps returns four apps including the four built-ins`,
  - `DRILLDOWN_APPS entries each carry id + root + label`,
  - live-Grafana smoke `isAppInstalled distinguishes installed apps from a known-bogus id`.

## Grafana version pinning

Selectors and per-app root URLs are tied to `grafana/grafana:11.4.0` (docker-compose.yml). Per Q4 of the e2e enhancement plan, a Grafana upgrade MUST update this spec in the same PR (helpers/README.md "Pinned Grafana version" checklist updated to list the 4-app catalogue + pyroscope-not-installed contract).

## CI wiring

Spec is picked up by the existing `dashboard` job's auto-discovery glob (`.github/workflows/e2e.yml :: npx playwright test`); no workflow change required. The `dashboard` job runs on push-to-main + nightly + manual dispatch only — informational, not a PR gate.

## Test plan

- [ ] CI: required checks (`check`, `lint`, `forbid-skip`, `compatibility/*`, `probe`, `roundtrip (*)`, `compose-smoke`) all green.
- [ ] `dashboard` job (informational) exercises the new spec on push-to-main and on the next nightly run.
- [ ] Local `just e2e-up && cd test/e2e/playwright && npx playwright test iterate-drilldown-apps.spec.ts` exercises 3 installed apps + annotates `grafana-pyroscope-app` as not-installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)