### PR TITLE
test(e2e/playwright): extend filter-drill sweep to LogQL + TraceQL panels (phase 3b)

### DIFF
--- a/test/e2e/playwright/helpers.spec.ts
+++ b/test/e2e/playwright/helpers.spec.ts
@@ -29,16 +29,21 @@ import {
   type Panel,
   type PanelTarget,
   addLabelFilter,
+  addLogQLLabelFilter,
+  addTraceQLAttributeFilter,
   assertHistogramComplete,
   assertLabelAbsent,
   assertLabelShape,
   assertNoFabricatedValue,
   assertSubsetByCount,
   expectedByKeys,
+  expectedByKeysForDsType,
   expressionHasMatcherFor,
   extractByKeys,
   extractDataSourceProxyURL,
   extractHistogramName,
+  extractLogQLByKeys,
+  extractTraceQLByKeys,
   extractWithoutKeys,
   isHistogramQuantile,
   iterateDashboards,
@@ -481,6 +486,268 @@ test('iterateDrilldownApps returns three apps including the three built-ins', ()
   // contaminate the module-level constant.
   apps.pop();
   expect(DRILLDOWN_APPS.length).toBe(3);
+});
+
+// --- LogQL filter helpers (Phase 3b) ---------------------------------------
+
+test('addLogQLLabelFilter appends to a bare non-empty stream selector', () => {
+  expect(
+    addLogQLLabelFilter('{service_name="cerberus"}', 'level', 'error'),
+  ).toBe('{service_name="cerberus",level="error"}');
+});
+
+test('addLogQLLabelFilter populates an empty stream selector', () => {
+  expect(addLogQLLabelFilter('{}', 'service_name', 'cerberus')).toBe(
+    '{service_name="cerberus"}',
+  );
+});
+
+test('addLogQLLabelFilter only touches the stream selector, not the pipeline', () => {
+  // The label-filter stage `| SeverityText="ERROR"` is a post-parse
+  // predicate, not a stream matcher. Injection must NOT add a second
+  // `level="error"` after the pipe.
+  expect(
+    addLogQLLabelFilter(
+      '{service_name="cerberus"} | SeverityText="ERROR"',
+      'level',
+      'error',
+    ),
+  ).toBe(
+    '{service_name="cerberus",level="error"} | SeverityText="ERROR"',
+  );
+});
+
+test('addLogQLLabelFilter survives a line_format stage with embedded braces', () => {
+  // `| line_format "{{.foo}}"` carries `{{` / `}}` inside a string
+  // literal. A naive `\{[^{}]*\}` regex would carve `{.foo}` out of
+  // it; the walker skips string literals as a whole.
+  expect(
+    addLogQLLabelFilter(
+      '{service_name="cerberus"} | json | line_format "{{.foo}}"',
+      'level',
+      'error',
+    ),
+  ).toBe(
+    '{service_name="cerberus",level="error"} | json | line_format "{{.foo}}"',
+  );
+});
+
+test('addLogQLLabelFilter walks into a sum-by-rate aggregation', () => {
+  // The drill key (`SeverityText`) is distinct from the matcher
+  // already inside the stream selector (`service_name=~".+"`), so the
+  // helper injects rather than no-oping. This mirrors what the
+  // iterator does after filtering out already-matched keys via
+  // `expressionHasMatcherFor`.
+  expect(
+    addLogQLLabelFilter(
+      'sum by (SeverityText) (rate({service_name=~".+"}[5m]))',
+      'SeverityText',
+      'ERROR',
+    ),
+  ).toBe(
+    'sum by (SeverityText) (rate({service_name=~".+",SeverityText="ERROR"}[5m]))',
+  );
+});
+
+test('addLogQLLabelFilter is idempotent when the key is already matched', () => {
+  // The iterator filters out keys with an existing matcher upstream,
+  // but the helper itself is also a no-op defensively.
+  expect(addLogQLLabelFilter('{level="error"}', 'level', 'error')).toBe(
+    '{level="error"}',
+  );
+  expect(
+    addLogQLLabelFilter('{service_name="cerberus",level=~"e.*"}', 'level', 'x'),
+  ).toBe('{service_name="cerberus",level=~"e.*"}');
+});
+
+test('addLogQLLabelFilter escapes embedded double-quotes and backslashes in the value', () => {
+  expect(addLogQLLabelFilter('{a="b"}', 'k', 'a"b')).toBe(
+    '{a="b",k="a\\"b"}',
+  );
+  expect(addLogQLLabelFilter('{a="b"}', 'k', 'a\\b')).toBe(
+    '{a="b",k="a\\\\b"}',
+  );
+});
+
+test('addLogQLLabelFilter handles binary expressions over two stream selectors', () => {
+  // LogQL binary ops (`or`, `and`) over two metric-shape selectors are
+  // valid; each stream-selector block must get the matcher.
+  expect(
+    addLogQLLabelFilter(
+      'rate({a="1"}[5m]) or rate({b="2"}[5m])',
+      'env',
+      'prod',
+    ),
+  ).toBe('rate({a="1",env="prod"}[5m]) or rate({b="2",env="prod"}[5m])');
+});
+
+test('addLogQLLabelFilter does not touch a label-filter-stage matcher', () => {
+  // `| level="error"` is a pipeline-stage filter, not a stream matcher.
+  // Injecting `level` into the *stream* selector is correct; the
+  // post-pipe expression stays untouched.
+  expect(
+    addLogQLLabelFilter(
+      '{service_name="cerberus"} | level="error"',
+      'env',
+      'prod',
+    ),
+  ).toBe('{service_name="cerberus",env="prod"} | level="error"');
+});
+
+test('extractLogQLByKeys parses LogQL sum-by aggregation', () => {
+  expect(
+    extractLogQLByKeys(
+      'sum by (SeverityText) (rate({service_name=~".+"}[5m]))',
+    ),
+  ).toEqual(['SeverityText']);
+});
+
+test('extractLogQLByKeys returns empty for a non-aggregating log query', () => {
+  expect(
+    extractLogQLByKeys('{service_name="cerberus"} | SeverityText="ERROR"'),
+  ).toEqual([]);
+});
+
+// --- TraceQL filter helpers (Phase 3b) -------------------------------------
+
+test('addTraceQLAttributeFilter appends to a non-empty spanset with `&&`', () => {
+  expect(
+    addTraceQLAttributeFilter(
+      '{ status = error }',
+      'resource.service.name',
+      'cerberus',
+    ),
+  ).toBe('{ status = error && resource.service.name="cerberus" }');
+});
+
+test('addTraceQLAttributeFilter populates an empty spanset', () => {
+  expect(
+    addTraceQLAttributeFilter('{}', 'resource.service.name', 'cerberus'),
+  ).toBe('{ resource.service.name="cerberus" }');
+});
+
+test('addTraceQLAttributeFilter survives a pad-free spanset', () => {
+  // `{status=error}` (no padding) should still get a sensible
+  // `&&`-joined matcher rather than malforming into `{status=error&&…}`.
+  expect(
+    addTraceQLAttributeFilter('{status=error}', 'span.kind', 'server'),
+  ).toBe('{status=error && span.kind="server" }');
+});
+
+test('addTraceQLAttributeFilter handles dotted attribute keys', () => {
+  // TraceQL attributes are dotted paths — the matcher must serialise
+  // verbatim, not get reinterpreted as a regex / member-access shape.
+  expect(
+    addTraceQLAttributeFilter(
+      '{ duration > 100ms }',
+      'resource.service.name',
+      'cerberus',
+    ),
+  ).toBe('{ duration > 100ms && resource.service.name="cerberus" }');
+});
+
+test('addTraceQLAttributeFilter only touches the spanset, not the pipeline', () => {
+  // The pipeline `| rate() by (resource.service.name)` carries the
+  // aggregation key but is NOT a filter — the matcher belongs in the
+  // spanset before the pipe.
+  expect(
+    addTraceQLAttributeFilter(
+      '{ status = error } | rate() by (resource.service.name)',
+      'span.kind',
+      'server',
+    ),
+  ).toBe(
+    '{ status = error && span.kind="server" } | rate() by (resource.service.name)',
+  );
+});
+
+test('addTraceQLAttributeFilter is idempotent when the attribute is already matched', () => {
+  expect(
+    addTraceQLAttributeFilter(
+      '{ resource.service.name = "cerberus" }',
+      'resource.service.name',
+      'cerberus',
+    ),
+  ).toBe('{ resource.service.name = "cerberus" }');
+});
+
+test('addTraceQLAttributeFilter ignores `{` inside string literals', () => {
+  // A trace-attribute value containing `{` would otherwise look like a
+  // nested spanset. The walker treats it as opaque.
+  expect(
+    addTraceQLAttributeFilter(
+      '{ resource.service.name = "weird{value" }',
+      'span.kind',
+      'server',
+    ),
+  ).toBe(
+    '{ resource.service.name = "weird{value" && span.kind="server" }',
+  );
+});
+
+test('addTraceQLAttributeFilter escapes embedded double-quotes and backslashes in the value', () => {
+  expect(
+    addTraceQLAttributeFilter('{}', 'span.label', 'a"b'),
+  ).toBe('{ span.label="a\\"b" }');
+  expect(addTraceQLAttributeFilter('{}', 'span.label', 'a\\b')).toBe(
+    '{ span.label="a\\\\b" }',
+  );
+});
+
+test('extractTraceQLByKeys parses `| rate() by (k)` pipeline', () => {
+  expect(
+    extractTraceQLByKeys(
+      '{ status = error } | rate() by (resource.service.name)',
+    ),
+  ).toEqual(['resource.service.name']);
+});
+
+test('extractTraceQLByKeys parses count_over_time/sum_over_time aggregations', () => {
+  expect(
+    extractTraceQLByKeys(
+      '{ resource.service.name = "x" } | count_over_time() by (span.kind)',
+    ),
+  ).toEqual(['span.kind']);
+  expect(
+    extractTraceQLByKeys(
+      '{ resource.service.name != "" } | sum_over_time(duration) by (resource.service.name, span.name)',
+    ),
+  ).toEqual(['resource.service.name', 'span.name']);
+});
+
+test('extractTraceQLByKeys returns empty for a bare spanset', () => {
+  expect(extractTraceQLByKeys('{ resource.service.name != "" }')).toEqual(
+    [],
+  );
+});
+
+test('expectedByKeysForDsType dispatches per dsType', () => {
+  expect(
+    expectedByKeysForDsType(
+      'sum by (cerberus_ql) (rate(cerberus_queries_total[5m]))',
+      'prometheus',
+    ),
+  ).toEqual(['cerberus_ql']);
+  expect(
+    expectedByKeysForDsType(
+      'histogram_quantile(0.95, sum by (le, k) (rate(foo_bucket[5m])))',
+      'prometheus',
+    ),
+  ).toEqual(['k']); // le subtracted by expectedByKeys
+  expect(
+    expectedByKeysForDsType(
+      'sum by (SeverityText) (rate({service_name=~".+"}[5m]))',
+      'loki',
+    ),
+  ).toEqual(['SeverityText']);
+  expect(
+    expectedByKeysForDsType(
+      '{ status = error } | rate() by (resource.service.name)',
+      'tempo',
+    ),
+  ).toEqual(['resource.service.name']);
+  // Unknown dsType → empty (the iterator skips these targets).
+  expect(expectedByKeysForDsType('rate(foo[5m])', 'opentsdb')).toEqual([]);
 });
 
 // --- Live-Grafana tests -----------------------------------------------------

--- a/test/e2e/playwright/helpers/query-shape.ts
+++ b/test/e2e/playwright/helpers/query-shape.ts
@@ -519,3 +519,339 @@ function escapeMatcherValue(v: string): string {
 function escapeRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
+
+// LogQL aggregation `by(...)` keys — the LogQL aggregation syntax
+// mirrors PromQL's (`sum by(k) (rate({...}[5m]))`), so `extractByKeys`
+// already covers it. The standalone helper here exists for symmetry
+// with the TraceQL extractor and so the iterator-spec doesn't have to
+// know that LogQL re-uses the PromQL regex.
+//
+// Examples:
+//   extractLogQLByKeys('sum by (SeverityText) (rate({service_name=~".+"}[5m]))')
+//     → ['SeverityText']
+//   extractLogQLByKeys('{service_name="cerberus"} | SeverityText="ERROR"')
+//     → []                                  // not an aggregation
+export function extractLogQLByKeys(expr: string): string[] {
+  return extractByKeys(expr);
+}
+
+// TraceQL aggregation `by(...)` clauses sit on the pipeline metric
+// functions (`| rate() by (k)`, `| count_over_time() by (k)`), NOT
+// behind a PromQL-style aggregator prefix. The PromQL `BY_REGEX`
+// therefore misses them; this extractor walks every `\| <fn>() by(...)`
+// occurrence and unions the labels.
+//
+// The dotted attribute keys TraceQL uses (`resource.service.name`,
+// `span.http.method`) survive verbatim — the inner regex is
+// `[^)]*` which permits dots.
+//
+// Examples:
+//   extractTraceQLByKeys('{ status = error } | rate() by (resource.service.name)')
+//     → ['resource.service.name']
+//   extractTraceQLByKeys('{ resource.service.name = "x" } | count_over_time() by (span.kind)')
+//     → ['span.kind']
+//   extractTraceQLByKeys('{ resource.service.name != "" }')
+//     → []                                  // bare spanset, no aggregation
+const TRACEQL_BY_REGEX =
+  /\|\s*(?:rate|count_over_time|sum_over_time|avg_over_time|max_over_time|min_over_time|quantile_over_time|histogram_over_time|count|sum|avg|max|min)\s*\([^)]*\)\s*by\s*\(\s*([^)]*)\s*\)/g;
+export function extractTraceQLByKeys(expr: string): string[] {
+  return extractKeysWithRegex(expr, TRACEQL_BY_REGEX);
+}
+
+/**
+ * Per-dsType by-key extractor — the iterator-spec calls this to pick
+ * the set of labels worth drilling on for a panel target.
+ *
+ *   - `prometheus` → `expectedByKeys` (with `histogram_quantile` → `le`
+ *     consumed-label subtraction).
+ *   - `loki`       → `extractLogQLByKeys` (LogQL aggregation mirrors
+ *     PromQL syntactically; the PromQL regex covers it).
+ *   - `tempo`      → `extractTraceQLByKeys` (TraceQL `| <fn>() by(k)`
+ *     pipeline syntax).
+ *
+ * Returns `[]` for any other / unknown dsType — the iterator skips
+ * panels with no extractable by-keys, so the default-empty behaviour
+ * is safe-by-omission rather than a silent surprise.
+ */
+export function expectedByKeysForDsType(
+  expr: string,
+  dsType: string,
+): string[] {
+  if (dsType === 'prometheus') return expectedByKeys(expr);
+  if (dsType === 'loki') return extractLogQLByKeys(expr);
+  if (dsType === 'tempo') return extractTraceQLByKeys(expr);
+  return [];
+}
+
+/**
+ * Re-write a LogQL `expr` to add a `<key>="<value>"` matcher to every
+ * stream-selector `{...}` block. The LogQL grammar splits an
+ * expression into:
+ *
+ *   - The stream selector — a brace block of `key=value` matchers.
+ *     This is the part the filter-drill spec needs to constrain.
+ *   - An optional pipeline — `| <stage> | <stage> …` where each stage
+ *     is a parser (`json`, `logfmt`), a label filter
+ *     (`| SeverityText="ERROR"`), or a line-format expression.
+ *
+ * We inject into the stream selector ONLY: the pipeline part is left
+ * untouched even when stages carry `key="value"`-shaped label filters
+ * (those are post-parsing predicates, not stream matchers).
+ *
+ * Two injection paths, mirroring `addLabelFilter`:
+ *
+ *   - Stream selector already has matchers: append `,<key>="<value>"`
+ *     just before the closing `}`. An empty selector (`{}`) becomes
+ *     `{<key>="<value>"}`.
+ *   - Stream selector already constrains `<key>` via any matcher: the
+ *     rewrite is a no-op for that block (idempotent — drilling on a
+ *     label that's already pinned would either tautologise or
+ *     contradict).
+ *
+ * Aggregating queries such as `sum by (X) (rate({…}[5m]))` are
+ * handled implicitly: the brace block inside is the stream selector,
+ * and the walker injects into it just like in the bare case.
+ *
+ * The walker skips string literals (`"…"`, `` `…` ``) so a
+ * `| line_format "{{.foo}}"` stage doesn't get parsed as a brace
+ * block.
+ *
+ * Examples:
+ *   addLogQLLabelFilter('{service_name="cerberus"}', 'level', 'error')
+ *     → '{service_name="cerberus",level="error"}'
+ *   addLogQLLabelFilter(
+ *     '{service_name="cerberus"} | json | line_format "{{.foo}}"',
+ *     'level', 'error',
+ *   )
+ *     → '{service_name="cerberus",level="error"} | json | line_format "{{.foo}}"'
+ *   addLogQLLabelFilter(
+ *     'sum by (SeverityText) (rate({service_name=~".+"} [5m]))',
+ *     'service_name', 'cerberus',
+ *   )
+ *     → 'sum by (SeverityText) (rate({service_name=~".+",service_name="cerberus"} [5m]))'
+ *     (note: the iterator filters out a key that already has a matcher,
+ *      so in practice this idempotent-by-spec path is unreached; see
+ *      the idempotent-key variant below for the no-op case)
+ *   addLogQLLabelFilter('{}', 'service_name', 'cerberus')
+ *     → '{service_name="cerberus"}'
+ *   addLogQLLabelFilter('{level="error"}', 'level', 'error')
+ *     → '{level="error"}'                                // idempotent
+ */
+export function addLogQLLabelFilter(
+  expr: string,
+  key: string,
+  value: string,
+): string {
+  const matcher = `${key}="${escapeMatcherValue(value)}"`;
+  return rewriteTopLevelBraceBlocks(expr, (inner) =>
+    injectIntoCommaSeparatedBlock(inner, key, matcher),
+  );
+}
+
+/**
+ * Re-write a TraceQL `expr` to add an attribute filter
+ * `<key>="<value>"` to every spanset `{ … }` block. TraceQL spansets
+ * differ from PromQL/LogQL selectors in two ways:
+ *
+ *   - Conjunction is `&&` (whitespace-padded), not `,`.
+ *   - Attribute keys are dotted paths (`resource.service.name`,
+ *     `span.http.method`), not bare identifiers.
+ *
+ * Injection paths:
+ *
+ *   - Spanset already has conditions: append ` && <key>="<value>"`
+ *     just before the closing `}`. The surrounding whitespace is
+ *     preserved: a TraceQL idiom is `{ a = b }` (single-space pads
+ *     on both sides of the brace contents), so we emit the same.
+ *   - Empty spanset (`{}` or `{ }`): becomes `{ <key>="<value>" }`.
+ *   - Spanset already constrains `<key>` via any matcher: no-op
+ *     (idempotent — the iterator filters these out upstream, this is
+ *     defence-in-depth).
+ *
+ * Aggregating queries such as `{ status = error } | rate() by (k)`
+ * are handled implicitly: only the leading spanset is touched; the
+ * pipeline is left as-is.
+ *
+ * The walker skips string literals (`"…"`) so an attribute value
+ * containing `{` or `}` doesn't get mistaken for a brace block.
+ *
+ * Examples:
+ *   addTraceQLAttributeFilter('{ status = error }', 'resource.service.name', 'cerberus')
+ *     → '{ status = error && resource.service.name="cerberus" }'
+ *   addTraceQLAttributeFilter('{}', 'resource.service.name', 'cerberus')
+ *     → '{ resource.service.name="cerberus" }'
+ *   addTraceQLAttributeFilter(
+ *     '{ status = error } | rate() by (resource.service.name)',
+ *     'span.kind', 'server',
+ *   )
+ *     → '{ status = error && span.kind="server" } | rate() by (resource.service.name)'
+ *   addTraceQLAttributeFilter(
+ *     '{ resource.service.name = "cerberus" }', 'resource.service.name', 'cerberus',
+ *   )
+ *     → '{ resource.service.name = "cerberus" }'                  // idempotent
+ */
+export function addTraceQLAttributeFilter(
+  expr: string,
+  key: string,
+  value: string,
+): string {
+  const matcher = `${key}="${escapeMatcherValue(value)}"`;
+  return rewriteTopLevelBraceBlocks(expr, (inner) =>
+    injectIntoSpansetBlock(inner, key, matcher),
+  );
+}
+
+// Walk `expr`, identify every top-level `{…}` brace block (i.e. a
+// brace pair not nested inside another brace block and not inside a
+// string literal), and call `rewriteInner(inner)` to produce the
+// replacement contents. Returns the rewritten expression.
+//
+// LogQL stream selectors and TraceQL spansets share this top-level
+// brace shape; only the *contents* differ (comma- vs `&&`-separated).
+function rewriteTopLevelBraceBlocks(
+  expr: string,
+  rewriteInner: (inner: string) => string,
+): string {
+  let out = '';
+  let i = 0;
+  while (i < expr.length) {
+    const c = expr[i] ?? '';
+    if (c === '"' || c === "'" || c === '`') {
+      // String literal — copy verbatim, respecting backslash escapes
+      // for the double-/single-quote forms (`backtick` strings are raw
+      // in PromQL/LogQL, no escape processing).
+      const quote = c;
+      out += c;
+      i++;
+      while (i < expr.length) {
+        const ch = expr[i] ?? '';
+        out += ch;
+        if (ch === '\\' && quote !== '`') {
+          i++;
+          if (i < expr.length) {
+            out += expr[i];
+            i++;
+          }
+          continue;
+        }
+        if (ch === quote) {
+          i++;
+          break;
+        }
+        i++;
+      }
+      continue;
+    }
+    if (c === '{') {
+      // Find the matching closing `}` at this depth, skipping nested
+      // string literals. LogQL/TraceQL brace blocks don't nest, so a
+      // flat counter suffices.
+      let depth = 1;
+      let j = i + 1;
+      let innerEnd = -1;
+      while (j < expr.length) {
+        const ch = expr[j] ?? '';
+        if (ch === '"' || ch === "'" || ch === '`') {
+          const q = ch;
+          j++;
+          while (j < expr.length) {
+            const sc = expr[j] ?? '';
+            if (sc === '\\' && q !== '`') {
+              j++;
+              if (j < expr.length) j++;
+              continue;
+            }
+            if (sc === q) {
+              j++;
+              break;
+            }
+            j++;
+          }
+          continue;
+        }
+        if (ch === '{') {
+          depth++;
+          j++;
+          continue;
+        }
+        if (ch === '}') {
+          depth--;
+          if (depth === 0) {
+            innerEnd = j;
+            break;
+          }
+          j++;
+          continue;
+        }
+        j++;
+      }
+      if (innerEnd === -1) {
+        // Unbalanced — copy the `{` and continue. The expression is
+        // malformed; the caller will see whatever the parser does
+        // with it.
+        out += c;
+        i++;
+        continue;
+      }
+      const inner = expr.slice(i + 1, innerEnd);
+      out += `{${rewriteInner(inner)}}`;
+      i = innerEnd + 1;
+      continue;
+    }
+    out += c;
+    i++;
+  }
+  return out;
+}
+
+// Inject `matcher` into the comma-separated contents of a
+// LogQL/PromQL brace block. Idempotent on `key`: if any existing
+// matcher in the block already constrains `key`, returns `inner`
+// unchanged.
+function injectIntoCommaSeparatedBlock(
+  inner: string,
+  key: string,
+  matcher: string,
+): string {
+  if (innerHasMatcherForKey(inner, key)) return inner;
+  const trimmed = inner.trim();
+  if (trimmed === '') return matcher;
+  // Preserve trailing whitespace that some LogQL examples carry
+  // between matchers and the closing brace (e.g. `{a="b"} `). The
+  // typical compact form has no trailing space.
+  return `${inner},${matcher}`;
+}
+
+// Inject `matcher` into the `&&`-separated contents of a TraceQL
+// spanset. Idempotent on `key`: if any existing matcher in the
+// spanset already constrains `key`, returns `inner` unchanged.
+function injectIntoSpansetBlock(
+  inner: string,
+  key: string,
+  matcher: string,
+): string {
+  if (innerHasMatcherForKey(inner, key)) return inner;
+  const trimmed = inner.trim();
+  if (trimmed === '') return ` ${matcher} `;
+  // Preserve the leading/trailing pad style that TraceQL examples
+  // commonly use (`{ status = error }`). When the original block was
+  // pad-free (`{status=error}`), we still emit a single space on
+  // either side of the `&&` for readability; the TraceQL parser
+  // accepts both forms.
+  const leading = /^\s*/.exec(inner)?.[0] ?? '';
+  const trailing = /\s*$/.exec(inner)?.[0] ?? '';
+  return `${leading}${trimmed} && ${matcher}${trailing === '' ? ' ' : trailing}`;
+}
+
+// True iff `inner` (the body of a brace block) already constrains
+// `key` via any matcher operator. Shared by both injection paths.
+//
+// The boundary class admits: start-of-block, whitespace, `,`, `{`,
+// and `&` (the second `&` of `&&` is whitespace-padded in idiomatic
+// TraceQL, but a packed form `a=b&&c=d` is also valid).
+function innerHasMatcherForKey(inner: string, key: string): boolean {
+  const re = new RegExp(
+    `(?:^|[\\s,{&])${escapeRegex(key)}\\s*(=~|!~|!=|>=|<=|=|>|<)`,
+  );
+  return re.test(inner);
+}

--- a/test/e2e/playwright/iterate-filter-drill.spec.ts
+++ b/test/e2e/playwright/iterate-filter-drill.spec.ts
@@ -1,13 +1,20 @@
 /**
- * Phase-3 filter drill-down sweep.
+ * Phase-3 / Phase-3b filter drill-down sweep.
  *
- * For every provisioned dashboard / panel / PromQL target with a
- * grouping `by(...)` clause, fire the baseline query against cerberus
- * via the Grafana datasource-proxy URL, pick one (label, value) pair
- * observed in the response, re-fire the same query with a
- * `{<label>="<value>"}` matcher tacked onto every selector, and assert
- * the filtered result is non-empty AND has at most `baseline` series
- * (the Q3-resolved subset rule from `~/.claude/plans/e2e-enhance.md`).
+ * For every provisioned dashboard / panel target with an aggregation
+ * `by(...)` clause, fire the baseline query against cerberus via the
+ * Grafana datasource-proxy URL, pick one (label, value) pair observed
+ * in the response, re-fire the same query with a `<key>="<value>"`
+ * matcher injected into every selector / spanset, and assert the
+ * filtered result is non-empty AND has at most `baseline` series (the
+ * Q3-resolved subset rule from `~/.claude/plans/e2e-enhance.md`).
+ *
+ * The spec dispatches per-target dsType so all three heads exercise
+ * the same drill-down semantic against their own matcher grammar:
+ *
+ *   - `prometheus` → `addLabelFilter` (Phase 3).
+ *   - `loki`       → `addLogQLLabelFilter` (Phase 3b).
+ *   - `tempo`      → `addTraceQLAttributeFilter` (Phase 3b).
  *
  * What this catches (resolved on main; this is a regression pin):
  *
@@ -17,6 +24,9 @@
  *     drops series the unfiltered path returned.
  *   - N15: drill-down chain breaks — the second-level drill returns
  *     empty (`filteredSeriesCount === 0`) on a real, observed value.
+ *   - N7/N8/N16: `service_name=cerberus` invisible on a LogQL panel.
+ *     Phase 3 PromQL-only drill missed this because LogQL panels were
+ *     unconditionally skipped; Phase 3b's LogQL path covers it.
  *
  * Subset semantics (Q3, plan §9): **count-based, not element-wise**.
  * Element-wise strict-subset is order-dependent and flakes under
@@ -24,11 +34,8 @@
  * gate. `assertSubsetByCount(filtered, baseline)` enforces both
  * `filtered > 0` and `filtered ≤ baseline`.
  *
- * Scope caveats (from the task brief):
+ * Scope caveats:
  *
- *   - PromQL only. LogQL / TraceQL filter-drill is filed as a sibling
- *     task; the `addLabelFilter` helper is PromQL-specific. Loki /
- *     Tempo targets are skipped in this phase via the `dsType` check.
  *   - Targets whose expression already constrains the drill label
  *     via a hardcoded matcher (e.g.
  *     `cerberus_queries_total{cerberus_ql="promql"}`) are skipped —
@@ -40,6 +47,11 @@
  *     top-level quantile), not the inner `le`. Drilling on `le`
  *     would produce a single-bucket scan whose subset comparison is
  *     meaningless.
+ *   - The Prom query_range envelope is used for all three heads via
+ *     the Grafana datasource-proxy URL; cerberus's Loki / Tempo HTTP
+ *     handlers route `instant`/`range` requests through the same
+ *     wire-format the proxy sends, so the per-head response parsing
+ *     stays uniform.
  *
  * Env:
  *   GRAFANA_URL       default http://localhost:3000
@@ -51,8 +63,10 @@ import { expect, test } from '@playwright/test';
 
 import {
   addLabelFilter,
+  addLogQLLabelFilter,
+  addTraceQLAttributeFilter,
   assertSubsetByCount,
-  expectedByKeys,
+  expectedByKeysForDsType,
   expressionHasMatcherFor,
   extractDataSourceProxyURL,
   generateSelfTraffic,
@@ -70,26 +84,11 @@ const SEED_TRAFFIC_SECONDS = 30;
 const QUERY_WINDOW_SECONDS = 5 * 60;
 const QUERY_STEP_SECONDS = 15;
 
-/**
- * Subset of the Prometheus /api/v1/query_range envelope we read.
- * The drill-down spec only needs the per-series `metric` map and a
- * top-level `status` field; sample values are irrelevant here.
- */
-type PromQueryRangeResponse = {
-  status?: string;
-  data?: {
-    resultType?: string;
-    result?: Array<{
-      metric?: Record<string, string>;
-      values?: Array<[number, string]>;
-    }>;
-  };
-};
-
 type DrillCandidate = {
   dashboardTitle: string;
   panelTitle: string;
   refId: string;
+  dsType: 'prometheus' | 'loki' | 'tempo';
   expr: string;
   byKeys: string[];
   proxyURL: string;
@@ -97,11 +96,26 @@ type DrillCandidate = {
 
 type DrillPair = {
   surface: string;
+  dsType: 'prometheus' | 'loki' | 'tempo';
   baselineExpr: string;
   filteredExpr: string;
   key: string;
   value: string;
 };
+
+// Per-head matcher injection. Each rewriter operates on the head's
+// native selector grammar — see `helpers/query-shape.ts` for the
+// per-grammar behaviour and idempotence guarantees.
+function injectMatcher(
+  dsType: 'prometheus' | 'loki' | 'tempo',
+  expr: string,
+  key: string,
+  value: string,
+): string {
+  if (dsType === 'prometheus') return addLabelFilter(expr, key, value);
+  if (dsType === 'loki') return addLogQLLabelFilter(expr, key, value);
+  return addTraceQLAttributeFilter(expr, key, value);
+}
 
 test('filter-drill: every aggregating panel produces a non-empty subset when filtered on a real observed label value', async ({
   request,
@@ -134,28 +148,41 @@ test('filter-drill: every aggregating panel produces a non-empty subset when fil
   for (const dashboard of dashboards) {
     for (const panel of iteratePanels(dashboard)) {
       for (const target of panel.targets) {
-        const expr = target.expr;
-        if (!expr || expr.trim() === '') continue;
-
-        const dsType =
+        const rawDsType =
           target.datasource?.type ?? panel.datasource?.type ?? '';
         const surface = `${dashboard.title} :: ${panel.title} :: ${target.refId}`;
 
-        // LogQL / TraceQL — out of scope per the brief. Filed for a
-        // sibling task; the `addLabelFilter` helper is PromQL-only.
-        if (dsType !== 'prometheus') {
+        // Per-head expression slot: PromQL + LogQL targets carry the
+        // expression in `target.expr`; TraceQL carries it in
+        // `target.query`. Other heads fall through to the "unknown"
+        // skip below.
+        let expr: string | undefined;
+        let dsType: 'prometheus' | 'loki' | 'tempo';
+        if (rawDsType === 'prometheus') {
+          expr = target.expr;
+          dsType = 'prometheus';
+        } else if (rawDsType === 'loki') {
+          expr = target.expr;
+          dsType = 'loki';
+        } else if (rawDsType === 'tempo') {
+          // Some Tempo panel targets (Search-mode panels) carry the
+          // search filter on `target.expr` instead of `target.query`.
+          // Prefer whichever slot is populated.
+          expr = target.query ?? target.expr;
+          dsType = 'tempo';
+        } else {
           skipped.push({
             surface,
-            reason: `non-prometheus datasource (type=${dsType || '<unset>'})`,
+            reason: `unsupported datasource type=${rawDsType || '<unset>'}`,
           });
           continue;
         }
+        if (!expr || expr.trim() === '') continue;
 
-        // `expectedByKeys` subtracts labels the top-level call
-        // consumes (currently only `le` for `histogram_quantile`);
-        // drilling on `le` would scan a single histogram bucket
-        // which is not what the drill semantic targets.
-        const byKeys = expectedByKeys(expr);
+        // `expectedByKeysForDsType` dispatches on dsType — see the
+        // helper for the per-grammar extraction rules (PromQL's
+        // `histogram_quantile`-consumes-`le` subtraction lives there).
+        const byKeys = expectedByKeysForDsType(expr, dsType);
         if (byKeys.length === 0) {
           // Not an aggregating panel — no drill candidate.
           continue;
@@ -164,8 +191,11 @@ test('filter-drill: every aggregating panel produces a non-empty subset when fil
         // Skip the target if every byKey already has a hardcoded
         // matcher in the expression — drilling would be a no-op or
         // contradict the existing matcher, neither informative.
+        // `expressionHasMatcherFor` reads brace-block contents and
+        // covers both LogQL stream selectors and TraceQL spansets in
+        // addition to PromQL label selectors.
         const drillableKeys = byKeys.filter(
-          (k) => !expressionHasMatcherFor(expr, k),
+          (k) => !expressionHasMatcherFor(expr!, k),
         );
         if (drillableKeys.length === 0) {
           skipped.push({
@@ -182,6 +212,7 @@ test('filter-drill: every aggregating panel produces a non-empty subset when fil
           dashboardTitle: dashboard.title,
           panelTitle: panel.title,
           refId: target.refId,
+          dsType,
           expr,
           byKeys: drillableKeys,
           proxyURL,
@@ -203,7 +234,7 @@ test('filter-drill: every aggregating panel produces a non-empty subset when fil
 
   expect(
     candidates.length,
-    'at least one drillable Prometheus panel target across all provisioned dashboards',
+    'at least one drillable panel target across all provisioned dashboards',
   ).toBeGreaterThan(0);
 
   // Second pass: fire baselines, extract observed (key, value)
@@ -216,6 +247,12 @@ test('filter-drill: every aggregating panel produces a non-empty subset when fil
 
   const failures: string[] = [];
   const drillPairs: DrillPair[] = [];
+  // Per-dsType pair counter for the test-info annotation.
+  const drillPairsByDsType: Record<'prometheus' | 'loki' | 'tempo', number> = {
+    prometheus: 0,
+    loki: 0,
+    tempo: 0,
+  };
   const seenPair = new Set<string>();
 
   for (const cand of candidates) {
@@ -223,13 +260,14 @@ test('filter-drill: every aggregating panel produces a non-empty subset when fil
     const baselineURL = buildQueryRangeURL(
       baseURL,
       cand.proxyURL,
+      cand.dsType,
       cand.expr,
       start,
       end,
     );
 
     // Fire baseline.
-    let baseline: PromQueryRangeResponse;
+    let baselineSeriesLabels: Array<Record<string, string>>;
     try {
       const resp = await request.get(baselineURL);
       if (resp.status() < 200 || resp.status() > 299) {
@@ -242,7 +280,8 @@ test('filter-drill: every aggregating panel produces a non-empty subset when fil
         );
         continue;
       }
-      baseline = (await resp.json()) as PromQueryRangeResponse;
+      const body = await resp.json();
+      baselineSeriesLabels = parseSeriesLabels(cand.dsType, body);
     } catch (err) {
       failures.push(
         `[${surface}] baseline probe threw: ${(err as Error).message}\n  url: ${baselineURL}`,
@@ -250,15 +289,7 @@ test('filter-drill: every aggregating panel produces a non-empty subset when fil
       continue;
     }
 
-    if (baseline.status !== 'success') {
-      failures.push(
-        `[${surface}] baseline returned status=${baseline.status ?? '<missing>'}\n  expr: ${cand.expr}`,
-      );
-      continue;
-    }
-
-    const baselineSeries = baseline.data?.result ?? [];
-    const baselineCount = baselineSeries.length;
+    const baselineCount = baselineSeriesLabels.length;
     if (baselineCount === 0) {
       // No baseline data — nothing to drill on. The panel-shape spec
       // already annotates empty panels; this isn't a filter-drill
@@ -271,13 +302,13 @@ test('filter-drill: every aggregating panel produces a non-empty subset when fil
     }
 
     // For each drillable byKey, collect the set of observed values
-    // from baseline.data.result[].metric[key]. Pick the first
-    // non-empty value — the first iteration order is deterministic
-    // across runs since the response is sorted by Prometheus.
+    // from baseline labels. Pick the first non-empty value — the
+    // first iteration order is deterministic across runs since the
+    // response is sorted by the upstream backend.
     for (const key of cand.byKeys) {
       const observedValues = new Set<string>();
-      for (const series of baselineSeries) {
-        const v = series.metric?.[key];
+      for (const labels of baselineSeriesLabels) {
+        const v = labels[key];
         if (typeof v === 'string' && v !== '') observedValues.add(v);
       }
       if (observedValues.size === 0) {
@@ -294,22 +325,25 @@ test('filter-drill: every aggregating panel produces a non-empty subset when fil
       // Pick the first observed value deterministically (sorted).
       const value = [...observedValues].sort()[0]!;
 
-      const filteredExpr = addLabelFilter(cand.expr, key, value);
+      const filteredExpr = injectMatcher(cand.dsType, cand.expr, key, value);
       const dedupKey = `${cand.proxyURL}\x00${filteredExpr}`;
       if (seenPair.has(dedupKey)) continue;
       seenPair.add(dedupKey);
 
       drillPairs.push({
         surface: `${surface} | drill ${key}=${value}`,
+        dsType: cand.dsType,
         baselineExpr: cand.expr,
         filteredExpr,
         key,
         value,
       });
+      drillPairsByDsType[cand.dsType]++;
 
       const filteredURL = buildQueryRangeURL(
         baseURL,
         cand.proxyURL,
+        cand.dsType,
         filteredExpr,
         start,
         end,
@@ -327,14 +361,8 @@ test('filter-drill: every aggregating panel produces a non-empty subset when fil
           );
           continue;
         }
-        const filtered = (await resp.json()) as PromQueryRangeResponse;
-        if (filtered.status !== 'success') {
-          failures.push(
-            `[${surface}] filtered query (${key}="${value}") status=${filtered.status ?? '<missing>'}\n  expr: ${filteredExpr}`,
-          );
-          continue;
-        }
-        const filteredCount = (filtered.data?.result ?? []).length;
+        const filtered = await resp.json();
+        const filteredCount = parseSeriesLabels(cand.dsType, filtered).length;
         try {
           assertSubsetByCount(
             filteredCount,
@@ -354,7 +382,7 @@ test('filter-drill: every aggregating panel produces a non-empty subset when fil
 
   testInfo.annotations.push({
     type: 'filter-drill-pairs',
-    description: `exercised ${drillPairs.length} baseline→filtered drill pair(s)`,
+    description: `exercised ${drillPairs.length} baseline→filtered drill pair(s) (prometheus=${drillPairsByDsType.prometheus}, loki=${drillPairsByDsType.loki}, tempo=${drillPairsByDsType.tempo})`,
   });
 
   expect(
@@ -369,14 +397,87 @@ test('filter-drill: every aggregating panel produces a non-empty subset when fil
   }
 });
 
+// Build the per-head range-query URL. Each upstream HTTP API has its
+// own path + parameter names; cerberus mirrors them so the panel
+// targets that Grafana fires go through the same path the spec uses
+// here.
+//
+//   - Prometheus: `<proxy>/api/v1/query_range?query=…&start=…&end=…&step=…`
+//   - Loki:       `<proxy>/loki/api/v1/query_range?query=…&start=…&end=…&step=…`
+//                 (seconds-resolution start/end; cerberus handles the
+//                 ns-resolution form too)
+//   - Tempo:      `<proxy>/api/metrics/query_range?q=…&start=…&end=…&step=…s`
+//                 (TraceQL `q=` rather than `query=`, step duration
+//                 carries the `s` suffix per Tempo's flag-style parser)
 function buildQueryRangeURL(
   baseURL: string,
   proxyURL: string,
+  dsType: 'prometheus' | 'loki' | 'tempo',
   expr: string,
   start: number,
   end: number,
 ): string {
-  return `${baseURL}${proxyURL}/api/v1/query_range?query=${encodeURIComponent(
-    expr,
-  )}&start=${start}&end=${end}&step=${QUERY_STEP_SECONDS}`;
+  const enc = encodeURIComponent(expr);
+  if (dsType === 'prometheus') {
+    return `${baseURL}${proxyURL}/api/v1/query_range?query=${enc}&start=${start}&end=${end}&step=${QUERY_STEP_SECONDS}`;
+  }
+  if (dsType === 'loki') {
+    return `${baseURL}${proxyURL}/loki/api/v1/query_range?query=${enc}&start=${start}&end=${end}&step=${QUERY_STEP_SECONDS}`;
+  }
+  // tempo
+  return `${baseURL}${proxyURL}/api/metrics/query_range?q=${enc}&start=${start}&end=${end}&step=${QUERY_STEP_SECONDS}s`;
+}
+
+// Parse the per-head range-query response body into a uniform
+// "series labels" array. Each entry is the label map for one series;
+// the drill semantic only cares about the labels (to pick a value to
+// filter on) and the count (for subset assertion).
+//
+//   - Prometheus + Loki share the `{status, data: {result: [{metric}]}}`
+//     envelope; both expose labels under `result[].metric`.
+//   - Tempo's `/api/metrics/query_range` returns `{series: [{labels:
+//     [{key, value: {stringValue}}], samples}]}` — labels are an array
+//     of KeyValue/AnyValue entries, not a map.
+//
+// Returns `[]` on any parse mismatch — the caller treats that as
+// "empty baseline" and annotates rather than failing, matching the
+// existing Phase-3 behaviour for the Prom-only path.
+function parseSeriesLabels(
+  dsType: 'prometheus' | 'loki' | 'tempo',
+  body: unknown,
+): Array<Record<string, string>> {
+  if (body === null || typeof body !== 'object') return [];
+  if (dsType === 'prometheus' || dsType === 'loki') {
+    const env = body as {
+      status?: string;
+      data?: { result?: Array<{ metric?: Record<string, string> }> };
+    };
+    if (env.status !== 'success') return [];
+    return (env.data?.result ?? []).map((r) => r.metric ?? {});
+  }
+  // tempo
+  const env = body as {
+    series?: Array<{
+      labels?: Array<{
+        key?: string;
+        value?: string | { stringValue?: string };
+      }>;
+    }>;
+  };
+  return (env.series ?? []).map((s) => {
+    const out: Record<string, string> = {};
+    for (const l of s.labels ?? []) {
+      if (typeof l.key !== 'string' || l.key === '') continue;
+      // Tempo serialises AnyValue; the typical shape carries a
+      // `stringValue` child, but the legacy flat-string form is also
+      // accepted by cerberus's UnmarshalJSON path (see metrics_query_range.go).
+      const v = l.value;
+      if (typeof v === 'string') {
+        out[l.key] = v;
+      } else if (v && typeof v === 'object' && typeof v.stringValue === 'string') {
+        out[l.key] = v.stringValue;
+      }
+    }
+    return out;
+  });
 }


### PR DESCRIPTION
## Summary

Phase-3b of the e2e-enhance plan: extends the filter drill-down sweep to LogQL and TraceQL panels. Phase 3 (#681) shipped `addLabelFilter` for PromQL only — LogQL and TraceQL targets were unconditionally skipped via `filter-drill-skip`, leaving N7/N8/N16 (cerberus-as-service-name invisible on LogQL panels) outside the regression net.

- New helpers in `helpers/query-shape.ts`:
  - `addLogQLLabelFilter(expr, key, value)` — inject `{key="value"}` into LogQL stream selectors; the walker skips string literals (so `line_format "{{.foo}}"` doesn't get carved up) and leaves the pipeline alone.
  - `addTraceQLAttributeFilter(expr, key, value)` — append `&& key="value"` to TraceQL spansets; handles dotted attribute paths (`resource.service.name`), empty spansets (`{}`), and pad-free / padded forms.
  - `extractTraceQLByKeys(expr)` — parse `| <fn>() by(k)` so TraceQL aggregations the PromQL-shaped `BY_REGEX` misses still register as drill candidates.
  - `expectedByKeysForDsType(expr, dsType)` — per-head dispatcher used by the iterator.
- `iterate-filter-drill.spec.ts` now dispatches by `dsType` on both the matcher rewriter and the by-key extractor, and parses each head's range-query response shape (Prom/Loki `{status,data:{result:[{metric}]}}` envelope vs Tempo `MetricsQueryRangeResponse{series:[{labels:[{key,value:{stringValue}}]}]}`). The PromQL-only skip on non-Prometheus targets is gone; the per-head URL builder targets `/api/v1/query_range`, `/loki/api/v1/query_range`, and `/api/metrics/query_range` respectively.

## Drill exercised per dsType (real provisioned dashboards)

From `test/e2e/grafana/compose/dashboards/`:

| dsType     | example baseline                                                                         | drills exercised                                |
| ---------- | ---------------------------------------------------------------------------------------- | ----------------------------------------------- |
| prometheus | `sum by (cerberus_ql) (rate(cerberus_queries_total[5m]))` + 4 more aggregating panels    | 1+ per cerberus-self panel (unchanged from #681) |
| loki       | `sum by (SeverityText) (rate({service_name=~".+"} [5m]))`                                | 1 per drillable by-key                          |
| tempo      | `{ status = error } \| rate() by (resource.service.name)`                                | 1 per drillable by-key                          |

The spec annotates per-dsType drill counts via `filter-drill-pairs`; runs against an empty stack still annotate via `filter-drill-empty-baseline` rather than failing.

## Test plan

- [x] `helpers.spec.ts` — 23 new pure-function tests (12 LogQL + 11 TraceQL incl. dispatcher); local `npx playwright test helpers.spec.ts` → 68 pass / 0 fail (was 45). Strict-mode TS clean (`npx tsc --noEmit`).
- [ ] CI compose-grafana smoke (informational dashboard job) — verifies the dispatched LogQL / TraceQL drills fire against the real compose stack.
- [ ] CI `compose-smoke` required check stays green.

## Open questions / caveats

- TraceQL drill keys come from the pipeline aggregator (`| rate() by (X)`), not from a PromQL-shape `sum by(...)` prefix. The new `extractTraceQLByKeys` covers `rate`, `count_over_time`, `sum_over_time`, `avg_over_time`, `max_over_time`, `min_over_time`, `quantile_over_time`, `histogram_over_time`, and the bare `count|sum|avg|max|min`. If upstream Tempo adds a new metric function, the regex needs the new name.
- LogQL drilling on a non-stream label (e.g. drilling on `SeverityText` for a panel whose stream selector is `{service_name=~".+"}`) injects into the stream selector even though SeverityText is upstream-Loki-side a parser-extracted label. cerberus reads SeverityText as a column on the OTel-CH logs table, so this works; if the schema ever flips to parser-only, drilling on parser labels would need a label-filter-stage rewriter instead.
- TraceQL spansets in pad-free form (`{status=error}`) emit a single space on either side of the injected `&&` for readability. Both forms are accepted by the TraceQL parser, but the diff in matcher style is observable in failure messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)