### PR TITLE
fix(logql): route all 9 top-level OTel-CH columns through matcher coalesce fallback (#240)

### DIFF
--- a/internal/logql/lower.go
+++ b/internal/logql/lower.go
@@ -1175,9 +1175,11 @@ func matcherToExpr(m *labels.Matcher, s schema.Logs) chplan.Expr {
 	if isDetectedLevelLabel(m.Name) {
 		lhs = detectedLevelExpr(s)
 	} else {
-		lhs = attributeLookupColumn(s.ResourceAttributesColumn, m.Name)
+		mapLookup := attributeLookupColumn(s.ResourceAttributesColumn, m.Name)
 		if col := resourceFallbackColumn(s, m.Name); col != "" {
-			lhs = resourceAttributeFallbackLHS(col, lhs)
+			lhs = resourceAttributeFallbackLHS(col, mapLookup)
+		} else {
+			lhs = mapLookup
 		}
 	}
 	return &chplan.Binary{
@@ -1192,24 +1194,36 @@ func matcherToExpr(m *labels.Matcher, s schema.Logs) chplan.Expr {
 // has no such fallback. The OTel ClickHouse Exporter hoists a fixed set
 // of OTel semantic-convention resource attributes out of the
 // ResourceAttributes map into named columns (most prominently
-// `service.name` → `ServiceName`) — rows ingested through that path
-// carry the value ONLY in the top-level column, leaving
-// `ResourceAttributes['service.name']` empty. A matcher lowering that
-// reads from the map alone misses every such row, which is exactly the
-// failure cerberus's own logs exhibited in task #217: cerberus itself
-// emits via the OTel collector → CH exporter pipeline, so its rows
-// carry `ServiceName='cerberus'` with no map entry, and
-// `{service_name="cerberus"}` returned zero streams.
+// `service.name` → `ServiceName`, but also SeverityText, SeverityNumber,
+// ScopeName, ScopeVersion, EventName, TraceId, SpanId, TraceFlags — every
+// scalar top-level column the OTel-CH default schema dedicates). Rows
+// ingested through that path carry the value ONLY in the top-level
+// column, leaving `ResourceAttributes[<label>]` empty. A matcher
+// lowering that reads from the map alone misses every such row.
 //
-// The mapping table is intentionally narrow — only labels whose
-// fallback column is part of the OTel-CH default schema. New entries
-// require both a schema.Logs field and an upstream OTel-CH exporter
-// promotion to land. Custom-schema users who clear the corresponding
-// schema.Logs field (e.g. `ServiceNameColumn=""`) opt out: the helper
-// returns "" so the lowering stays map-only.
+// Task #240 widened the fallback from `service_name` only (initial #217
+// fix) to the full top-level scalar set: `{SeverityText="DEBUG"}` and
+// the matcher-path twins on the other 8 columns were silently returning
+// zero rows because their values lived in the top-level columns while
+// the matcher consulted the empty ResourceAttributes map. The
+// group-by path (`levelAwareGroupKey`) had already routed all 9 columns
+// via [topLevelLogColumnFor] when #218 was fixed; this helper now
+// delegates to the same table so the two parse paths can't drift again.
+//
+// Custom-schema users who clear the corresponding schema.Logs field
+// (e.g. `ServiceNameColumn=""`) opt out: the helper returns "" so the
+// lowering stays map-only.
 func resourceFallbackColumn(s schema.Logs, labelName string) string {
-	switch labelName {
-	case "service_name":
+	if col, ok := topLevelLogColumnFor(labelName, s); ok {
+		return col
+	}
+	// Prom/Loki convention spells `service.name` as the OTel-CH
+	// `ServiceName` column's stream attribute as `service_name`. The
+	// other 8 top-level columns surface under their literal column
+	// name (no Prom/Loki underscore alias is in idiomatic use), but
+	// `service_name` is the form Grafana panels + the
+	// `matcher_self_service` fixture both emit, so this alias stays.
+	if labelName == "service_name" {
 		return s.ServiceNameColumn
 	}
 	return ""

--- a/internal/logql/lower_internal_test.go
+++ b/internal/logql/lower_internal_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/prometheus/model/labels"
+
 	"github.com/tsouza/cerberus/internal/chplan"
 	"github.com/tsouza/cerberus/internal/schema"
 )
@@ -332,10 +334,13 @@ func TestIsMatrixRangeWindowWalksWrappers(t *testing.T) {
 // top-level-column entries that anchor the OTel-CH resource-attribute
 // fallback. The matcher lowering reads this helper to decide whether
 // to wrap the ResourceAttributes lookup in a coalesce(nullIf(...), ...)
-// against a dedicated column. Adding a new entry requires both a
-// schema.Logs field AND an upstream OTel-CH exporter that promotes the
-// label out of the map — the helper deliberately stays narrow so a
-// regression that silently expands the table is loud in this test.
+// against a dedicated column. Task #240 widened the table from
+// service_name only to the full top-level OTel-CH scalar set the
+// schema declares: the helper now delegates to [topLevelLogColumnFor]
+// so the matcher path and the group-by path consult the same table —
+// pre-#240 the matcher whitelisted `service_name` only while the
+// group-by path already routed all 9 columns, so `{SeverityText="X"}`
+// silently returned zero rows.
 func TestResourceFallbackColumn(t *testing.T) {
 	t.Parallel()
 
@@ -345,7 +350,22 @@ func TestResourceFallbackColumn(t *testing.T) {
 		label string
 		want  string
 	}{
+		// All 9 top-level scalar columns the default OTel-CH schema
+		// names must resolve so the matcher coalesce-wraps against the
+		// dedicated column. Pre-#240 only the first row passed.
 		{name: "service_name resolves to ServiceName", label: "service_name", want: "ServiceName"},
+		{name: "SeverityText resolves to SeverityText", label: "SeverityText", want: "SeverityText"},
+		{name: "SeverityNumber resolves to SeverityNumber", label: "SeverityNumber", want: "SeverityNumber"},
+		{name: "ServiceName resolves to ServiceName", label: "ServiceName", want: "ServiceName"},
+		{name: "ScopeName resolves to ScopeName", label: "ScopeName", want: "ScopeName"},
+		{name: "ScopeVersion resolves to ScopeVersion", label: "ScopeVersion", want: "ScopeVersion"},
+		{name: "EventName resolves to EventName", label: "EventName", want: "EventName"},
+		{name: "TraceId resolves to TraceId", label: "TraceId", want: "TraceId"},
+		{name: "SpanId resolves to SpanId", label: "SpanId", want: "SpanId"},
+		{name: "TraceFlags resolves to TraceFlags", label: "TraceFlags", want: "TraceFlags"},
+
+		// Negative cases: labels with no dedicated top-level column
+		// stay on the map-only lowering path.
 		{name: "job has no top-level column", label: "job", want: ""},
 		{name: "k8s_pod_name has no top-level column", label: "k8s_pod_name", want: ""},
 		{name: "detected_level has no top-level column", label: "detected_level", want: ""},
@@ -375,5 +395,101 @@ func TestResourceFallbackColumn_RespectsSchemaOverride(t *testing.T) {
 	s.ServiceNameColumn = ""
 	if got := resourceFallbackColumn(s, "service_name"); got != "" {
 		t.Errorf("resourceFallbackColumn with cleared ServiceNameColumn = %q, want \"\"", got)
+	}
+}
+
+// TestMatcherToExpr_TopLevelColumnCoalesce_Conformance pins that the
+// matcher path emits a `coalesce(nullIf(<col>, ”),
+// ResourceAttributes[<col>])` shape for EVERY top-level OTel-CH scalar
+// column the default schema names. Task #240 was the matcher-path twin
+// of the bug #218 fixed for the group-by path: `levelAwareGroupKey`
+// already routed all 9 columns through [topLevelLogColumnFor], but
+// `matcherToExpr` only consulted a narrow `service_name`-only switch.
+// `{SeverityText="DEBUG"}` therefore returned 0 rows on rows ingested
+// through the OTel collector → CH exporter pipeline (which carries
+// SeverityText in the dedicated column with an empty
+// ResourceAttributes map).
+//
+// This test is the conformance gate that pins the two parse paths
+// against future drift: a regression that whittles the helper back
+// down to a narrow whitelist (or, conversely, an addition that adds a
+// new top-level column to the schema without extending the matcher
+// path) fails here with the missing column name shown explicitly.
+func TestMatcherToExpr_TopLevelColumnCoalesce_Conformance(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelLogs()
+	// The 9 top-level OTel-CH scalar columns the default schema declares
+	// (mirrors the candidates list in topLevelLogColumnFor). Each label
+	// is the canonical column name itself — Grafana panels + the loki
+	// conformance corpus emit `{ColumnName="val"}` against rows whose
+	// value lives in that top-level column.
+	columns := []string{
+		"SeverityText",
+		"SeverityNumber",
+		"ServiceName",
+		"ScopeName",
+		"ScopeVersion",
+		"EventName",
+		"TraceId",
+		"SpanId",
+		"TraceFlags",
+	}
+	for _, col := range columns {
+		col := col
+		t.Run(col, func(t *testing.T) {
+			t.Parallel()
+			m := labels.MustNewMatcher(labels.MatchEqual, col, "val")
+			expr := matcherToExpr(m, s)
+
+			// Top-level Binary: `<lhs> = "val"`.
+			bin, ok := expr.(*chplan.Binary)
+			if !ok {
+				t.Fatalf("matcherToExpr(%s=val) returned %T; want *chplan.Binary", col, expr)
+			}
+			if bin.Op != chplan.OpEq {
+				t.Errorf("matcherToExpr(%s=val) Op = %v; want OpEq", col, bin.Op)
+			}
+			lit, ok := bin.Right.(*chplan.LitString)
+			if !ok || lit.V != "val" {
+				t.Errorf("matcherToExpr(%s=val) RHS = %v; want LitString{V:\"val\"}", col, bin.Right)
+			}
+
+			// LHS must be `coalesce(nullIf(<col>, ''),
+			// ResourceAttributes[<col>])`. Unwrap layer-by-layer so
+			// a regression that drops the wrap is loud.
+			coalesce, ok := bin.Left.(*chplan.FuncCall)
+			if !ok || coalesce.Name != "coalesce" || len(coalesce.Args) != 2 {
+				t.Fatalf("matcherToExpr(%s=val) LHS = %v; want coalesce(nullIf(...), ...) — top-level column missed the resourceAttributeFallbackLHS wrap (task #240)", col, bin.Left)
+			}
+			null, ok := coalesce.Args[0].(*chplan.FuncCall)
+			if !ok || null.Name != "nullIf" || len(null.Args) != 2 {
+				t.Fatalf("matcherToExpr(%s=val) coalesce arg0 = %v; want nullIf(<col>, '')", col, coalesce.Args[0])
+			}
+			topRef, ok := null.Args[0].(*chplan.ColumnRef)
+			if !ok || topRef.Name != col {
+				t.Errorf("matcherToExpr(%s=val) nullIf arg0 = %v; want ColumnRef{Name:%q}", col, null.Args[0], col)
+			}
+			sentinel, ok := null.Args[1].(*chplan.LitString)
+			if !ok || sentinel.V != "" {
+				t.Errorf("matcherToExpr(%s=val) nullIf arg1 = %v; want LitString{V:\"\"}", col, null.Args[1])
+			}
+			// Fallback arm: `ResourceAttributes[<col>]`. Labels like
+			// SeverityText / TraceId carry no underscore, so
+			// attributeLookupExpr emits a plain MapAccess (no
+			// dotted-fallback `if(mapContains(...), ..., ...)` chain).
+			ma, ok := coalesce.Args[1].(*chplan.MapAccess)
+			if !ok {
+				t.Fatalf("matcherToExpr(%s=val) coalesce arg1 = %v; want ResourceAttributes[%q]", col, coalesce.Args[1], col)
+			}
+			mapRef, ok := ma.Map.(*chplan.ColumnRef)
+			if !ok || mapRef.Name != s.ResourceAttributesColumn {
+				t.Errorf("matcherToExpr(%s=val) MapAccess.Map = %v; want ColumnRef{Name:%q}", col, ma.Map, s.ResourceAttributesColumn)
+			}
+			keyLit, ok := ma.Key.(*chplan.LitString)
+			if !ok || keyLit.V != col {
+				t.Errorf("matcherToExpr(%s=val) MapAccess.Key = %v; want LitString{V:%q}", col, ma.Key, col)
+			}
+		})
 	}
 }

--- a/test/spec/logql/matcher_severity_number.txtar
+++ b/test/spec/logql/matcher_severity_number.txtar
@@ -3,8 +3,8 @@
 -- seed --
 -- Task #240 twin of matcher_severity_text: SeverityNumber is one of the
 -- 9 top-level OTel-CH scalar columns. The OTel collector → CH exporter
--- promotes severity_number into a dedicated UInt8 column; the matcher
--- pre-#240 looked only at ResourceAttributes['SeverityNumber'] (empty
+-- promotes severity_number into a dedicated UInt8 column, but the
+-- matcher pre-#240 looked only at ResourceAttributes['SeverityNumber'] (empty
 -- map for promoted rows) so `{SeverityNumber="9"}` returned 0 rows
 -- even though the row was present. The coalesce fallback fixes it.
 --

--- a/test/spec/logql/matcher_severity_number.txtar
+++ b/test/spec/logql/matcher_severity_number.txtar
@@ -1,0 +1,49 @@
+-- query.logql --
+{SeverityNumber="9"}
+-- seed --
+-- Task #240 twin of matcher_severity_text: SeverityNumber is one of the
+-- 9 top-level OTel-CH scalar columns. The OTel collector → CH exporter
+-- promotes severity_number into a dedicated UInt8 column; the matcher
+-- pre-#240 looked only at ResourceAttributes['SeverityNumber'] (empty
+-- map for promoted rows) so `{SeverityNumber="9"}` returned 0 rows
+-- even though the row was present. The coalesce fallback fixes it.
+--
+-- NB: LogQL matchers are string-typed. The value "9" matches the
+-- CH-rendered string form of the UInt8 (9 → '9') through the coalesce.
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    SeverityNumber String MATERIALIZED multiIf(
+        Body = 'top-level-only', '9',
+        Body = 'both', '9',
+        Body = 'negative-top', '17',
+        ''
+    ),
+    ResourceAttributes Map(String, String) MATERIALIZED multiIf(
+        Body = 'map-only', map('SeverityNumber', '9'),
+        Body = 'both', map('SeverityNumber', '9'),
+        Body = 'negative-map', map('SeverityNumber', '17'),
+        CAST(map() AS Map(String, String))
+    )
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body) VALUES
+    (toDateTime64('2026-05-20 12:00:00.000000000', 9), 'top-level-only'),
+    (toDateTime64('2026-05-20 12:01:00.000000000', 9), 'map-only'),
+    (toDateTime64('2026-05-20 12:02:00.000000000', 9), 'both'),
+    (toDateTime64('2026-05-20 12:03:00.000000000', 9), 'negative-top'),
+    (toDateTime64('2026-05-20 12:04:00.000000000', 9), 'negative-map');
+-- expected_rows --
+[
+  ["2026-05-20T12:00:00Z", "top-level-only"],
+  ["2026-05-20T12:01:00Z", "map-only"],
+  ["2026-05-20T12:02:00Z", "both"]
+]
+-- args --
+[0] string = ""
+[1] string = "SeverityNumber"
+[2] string = "9"
+-- chplan --
+Filter predicate=(coalesce(nullIf(SeverityNumber, ""), ResourceAttributes["SeverityNumber"]) = "9")
+  Scan(otel_logs)
+-- sql --
+SELECT * FROM `otel_logs` WHERE (coalesce(nullIf(`SeverityNumber`, ?), `ResourceAttributes`[?]) = ?)

--- a/test/spec/logql/matcher_severity_text.txtar
+++ b/test/spec/logql/matcher_severity_text.txtar
@@ -1,0 +1,56 @@
+-- query.logql --
+{SeverityText="DEBUG"}
+-- seed --
+-- Task #240: the matcher path lowered `{SeverityText="DEBUG"}` to a
+-- bare `ResourceAttributes["SeverityText"] = "DEBUG"`. Rows ingested
+-- through the OTel collector → CH exporter pipeline carry SeverityText
+-- in the dedicated top-level column with an EMPTY ResourceAttributes
+-- map, so the matcher matched zero rows even though `sum by
+-- (SeverityText) (...)` produced a DEBUG group with data (asymmetric
+-- with the group-by path which #218 routed through topLevelLogColumnFor
+-- for all 9 top-level OTel-CH scalar columns). The fix delegates
+-- `resourceFallbackColumn` to the same helper so the matcher wraps
+-- the lookup in `coalesce(nullIf(SeverityText, ''),
+-- ResourceAttributes['SeverityText'])` and the row is found.
+--
+-- Seed encodes the four storage shapes (top-level only / map only /
+-- both / negative) by Body content so the runner's `SELECT *` returns
+-- only the inserted columns — the same pattern matcher_self_service
+-- uses for ServiceName.
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    SeverityText LowCardinality(String) MATERIALIZED multiIf(
+        Body = 'top-level-only', 'DEBUG',
+        Body = 'both', 'DEBUG',
+        Body = 'negative-top', 'INFO',
+        ''
+    ),
+    ResourceAttributes Map(String, String) MATERIALIZED multiIf(
+        Body = 'map-only', map('SeverityText', 'DEBUG'),
+        Body = 'both', map('SeverityText', 'DEBUG'),
+        Body = 'negative-map', map('SeverityText', 'INFO'),
+        CAST(map() AS Map(String, String))
+    )
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body) VALUES
+    (toDateTime64('2026-05-20 12:00:00.000000000', 9), 'top-level-only'),
+    (toDateTime64('2026-05-20 12:01:00.000000000', 9), 'map-only'),
+    (toDateTime64('2026-05-20 12:02:00.000000000', 9), 'both'),
+    (toDateTime64('2026-05-20 12:03:00.000000000', 9), 'negative-top'),
+    (toDateTime64('2026-05-20 12:04:00.000000000', 9), 'negative-map');
+-- expected_rows --
+[
+  ["2026-05-20T12:00:00Z", "top-level-only"],
+  ["2026-05-20T12:01:00Z", "map-only"],
+  ["2026-05-20T12:02:00Z", "both"]
+]
+-- args --
+[0] string = ""
+[1] string = "SeverityText"
+[2] string = "DEBUG"
+-- chplan --
+Filter predicate=(coalesce(nullIf(SeverityText, ""), ResourceAttributes["SeverityText"]) = "DEBUG")
+  Scan(otel_logs)
+-- sql --
+SELECT * FROM `otel_logs` WHERE (coalesce(nullIf(`SeverityText`, ?), `ResourceAttributes`[?]) = ?)

--- a/test/spec/logql/matcher_trace_id.txtar
+++ b/test/spec/logql/matcher_trace_id.txtar
@@ -1,0 +1,44 @@
+-- query.logql --
+{TraceId="0123456789abcdef0123456789abcdef"}
+-- seed --
+-- Task #240 twin of matcher_severity_text for TraceId, the OTel-CH
+-- top-level column carrying span trace correlation. The fix delegates
+-- resourceFallbackColumn → topLevelLogColumnFor, so the matcher wraps
+-- the lookup in coalesce(nullIf(TraceId, ''), ResourceAttributes['TraceId']).
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    TraceId String MATERIALIZED multiIf(
+        Body = 'top-level-only', '0123456789abcdef0123456789abcdef',
+        Body = 'both', '0123456789abcdef0123456789abcdef',
+        Body = 'negative-top', 'fedcba9876543210fedcba9876543210',
+        ''
+    ),
+    ResourceAttributes Map(String, String) MATERIALIZED multiIf(
+        Body = 'map-only', map('TraceId', '0123456789abcdef0123456789abcdef'),
+        Body = 'both', map('TraceId', '0123456789abcdef0123456789abcdef'),
+        Body = 'negative-map', map('TraceId', 'fedcba9876543210fedcba9876543210'),
+        CAST(map() AS Map(String, String))
+    )
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body) VALUES
+    (toDateTime64('2026-05-20 12:00:00.000000000', 9), 'top-level-only'),
+    (toDateTime64('2026-05-20 12:01:00.000000000', 9), 'map-only'),
+    (toDateTime64('2026-05-20 12:02:00.000000000', 9), 'both'),
+    (toDateTime64('2026-05-20 12:03:00.000000000', 9), 'negative-top'),
+    (toDateTime64('2026-05-20 12:04:00.000000000', 9), 'negative-map');
+-- expected_rows --
+[
+  ["2026-05-20T12:00:00Z", "top-level-only"],
+  ["2026-05-20T12:01:00Z", "map-only"],
+  ["2026-05-20T12:02:00Z", "both"]
+]
+-- args --
+[0] string = ""
+[1] string = "TraceId"
+[2] string = "0123456789abcdef0123456789abcdef"
+-- chplan --
+Filter predicate=(coalesce(nullIf(TraceId, ""), ResourceAttributes["TraceId"]) = "0123456789abcdef0123456789abcdef")
+  Scan(otel_logs)
+-- sql --
+SELECT * FROM `otel_logs` WHERE (coalesce(nullIf(`TraceId`, ?), `ResourceAttributes`[?]) = ?)


### PR DESCRIPTION
## Summary

PR #689 (Phase 3b LogQL/TraceQL drill) surfaced the matcher-path twin of
bug #218: `{SeverityText="DEBUG"}` returned 0 rows even though
`sum by (SeverityText) (...)` produced a DEBUG group with data.

The asymmetry was structural:

- **Group-by path** (`internal/logql/vector_aggregation.go::levelAwareGroupKey`)
  routed ALL 9 top-level OTel-CH scalar columns via `topLevelLogColumnFor`
  after #218 fixed it.
- **Matcher path** (`internal/logql/lower.go::matcherToExpr`) only
  consulted `resourceFallbackColumn`, which whitelisted `service_name`
  only. Every other top-level column (SeverityText, SeverityNumber,
  ScopeName, ScopeVersion, EventName, TraceId, SpanId, TraceFlags) fell
  through to `attributeLookupColumn(ResourceAttributes, ...)` and matched
  zero rows on OTel-collector-ingested data (value lives in the dedicated
  column with an empty `ResourceAttributes` map).

## Fix

Delegate `resourceFallbackColumn` to `topLevelLogColumnFor` so the
matcher path and group-by path consult one table. The Prom/Loki
`service_name` → `ServiceName` underscore alias is kept as an explicit
secondary case (Grafana panels + `matcher_self_service.txtar` emit
`service_name`, while the other 8 columns are queried by their literal
column names — `{SeverityText="DEBUG"}`).

The matcher's `lhs` becomes `coalesce(nullIf(<col>, ''),
ResourceAttributes[<col>])` for every top-level scalar the default
OTel-CH schema declares.

## Columns covered (9)

`SeverityText`, `SeverityNumber`, `ServiceName`, `ScopeName`,
`ScopeVersion`, `EventName`, `TraceId`, `SpanId`, `TraceFlags`.

## Tests

- **TXTAR fixtures** (Layer 2 + Layer 5 with `seed:` + `expected_rows:`):
  - `test/spec/logql/matcher_severity_text.txtar` — `{SeverityText="DEBUG"}`
    against four storage shapes (top-level only, map only, both,
    negative). Asserts the fix returns the three positive rows.
  - `test/spec/logql/matcher_severity_number.txtar` — same shape for
    `{SeverityNumber="9"}`.
  - `test/spec/logql/matcher_trace_id.txtar` — same shape for
    `{TraceId="..."}`.
- **Conformance test** (`internal/logql/lower_internal_test.go`):
  `TestMatcherToExpr_TopLevelColumnCoalesce_Conformance` pins the
  `coalesce(nullIf(<col>, ''), ResourceAttributes[<col>])` IR shape for
  each of the 9 columns. A regression that whittles the table back to a
  narrow whitelist fails here loudly.
- **Table widening** (`TestResourceFallbackColumn`): the legacy
  service_name-only table was widened to assert all 9 columns resolve.

## Existing fixture drift

Zero. No pre-existing matcher fixture stream-selects against a top-level
column other than the `service_name` alias that
`matcher_self_service.txtar` already covers.

## Coordination

Unblocks PR #689 automatically. This PR does not touch #689.

## Test plan

- [x] `go test ./internal/logql/... ./internal/api/loki/... ./internal/promql/...` — 1424 passed
- [x] `go build ./...` — clean
- [x] Pre-commit hooks (gofumpt/goimports/commitlint) — clean
- [ ] CI required checks (`check`, `lint`, `forbid-skip`, `compatibility/loki`, ...)