### PR TITLE
fix(test/property): declare top-level OTel-CH log columns so LogQL matcher coalesce parses

### DIFF
--- a/test/property/gen/logql.go
+++ b/test/property/gen/logql.go
@@ -144,9 +144,17 @@ func drawBody(t *rapid.T, id string) string {
 // side rationale: the optimizer's PREWHERE promotion fires
 // unconditionally and chDB's Memory engine refuses PREWHERE.
 //
-// Only the columns LogQL touches today are projected — the OTel-CH
-// schema is much wider, but generating empty placeholder columns
-// would just slow chDB down without exercising any production path.
+// The DDL must declare every top-level OTel-CH scalar column the
+// LogQL lowering routes through `topLevelLogColumnFor` — even though
+// the property generator only populates `ResourceAttributes`,
+// `SeverityText`, `Body`, and `Timestamp`. The matcher lowering
+// emits `coalesce(nullIf(ServiceName, ”),
+// ResourceAttributes['service_name'])` (and the matching shape for
+// each other top-level label), so chDB rejects the query with
+// `Unknown expression identifier ServiceName` if the column is
+// missing. The empty-string / zero-value defaults keep the `nullIf`
+// branch falsy, so the coalesce still falls through to the
+// ResourceAttributes map the generator populated.
 func renderLogsDDL(records []property.LogRecord) string {
 	var b strings.Builder
 	b.WriteString(`CREATE OR REPLACE TABLE `)
@@ -154,8 +162,16 @@ func renderLogsDDL(records []property.LogRecord) string {
 	b.WriteString(` (
     Timestamp DateTime64(9),
     SeverityText LowCardinality(String),
+    SeverityNumber UInt8 DEFAULT 0,
     Body String,
-    ResourceAttributes Map(LowCardinality(String), String)
+    ResourceAttributes Map(LowCardinality(String), String),
+    ServiceName LowCardinality(String) DEFAULT '',
+    ScopeName String DEFAULT '',
+    ScopeVersion String DEFAULT '',
+    EventName LowCardinality(String) DEFAULT '',
+    TraceId String DEFAULT '',
+    SpanId String DEFAULT '',
+    TraceFlags UInt8 DEFAULT 0
 ) ENGINE = MergeTree ORDER BY Timestamp;
 `)
 	if len(records) == 0 {


### PR DESCRIPTION
## Summary

`TestLogQL_Property` was failing on `main` (CI run 26276793473, job 77342905937) because the new LogQL matcher lowering (PR #690) routes every top-level OTel-CH label through `coalesce(nullIf(<col>, ''), ResourceAttributes[<key>])`, but the property test's synthetic `otel_logs` DDL only declared `Timestamp / SeverityText / Body / ResourceAttributes`. chDB rejected the query with:

```
Code: 47. DB::Exception: Unknown expression identifier `ServiceName` in scope
SELECT Body, ResourceAttributes, ServiceName, SeverityText, Timestamp FROM otel_logs
WHERE (coalesce(nullIf(ServiceName, ''), ...) = 'checkout') ...
```

This patch extends the property generator's DDL (in `test/property/gen/logql.go::renderLogsDDL`) to declare every top-level OTel-CH scalar column listed in `internal/logql/top_level_columns.go::topLevelLogColumnFor`:

- `SeverityNumber UInt8`
- `ServiceName LowCardinality(String)`
- `ScopeName String`
- `ScopeVersion String`
- `EventName LowCardinality(String)`
- `TraceId String`
- `SpanId String`
- `TraceFlags UInt8`

(`SeverityText` was already declared.) Each new column gets an empty-string / zero default — the LogQL coalesce's `nullIf(col, '')` branch stays falsy, so resolution falls through to the `ResourceAttributes` map the generator already populates. The `INSERT` column list is unchanged.

This is the right side to fix: the production schema has these columns, so the property test should match production — not the other way around (making lowering schema-aware would be wrong).

## Test plan

- [ ] `chdb` workflow's `TestLogQL_Property` goes green
- [ ] No other property tests regress