### PR TITLE
fix(test/e2e): seed otel_metrics_histogram rows for http_server_request_duration

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -370,6 +370,15 @@ e2e-wait-otel:
             gauge=$(kubectl -n cerberus exec deploy/clickhouse -- clickhouse-client \
                 --user cerberus --password cerberus --database otel \
                 --query "SELECT count() FROM otel_metrics_gauge" 2>/dev/null || echo 0); \
+            histogram=$(kubectl -n cerberus exec deploy/clickhouse -- clickhouse-client \
+                --user cerberus --password cerberus --database otel \
+                --query "SELECT count() FROM otel_metrics_histogram WHERE MetricName = 'http_server_request_duration'" 2>/dev/null || echo 0); \
+            hist_spread=0; \
+            if [ "$histogram" -gt 0 ]; then \
+                hist_spread=$(kubectl -n cerberus exec deploy/clickhouse -- clickhouse-client \
+                    --user cerberus --password cerberus --database otel \
+                    --query "SELECT toUInt64(dateDiff('second', min(TimeUnix), max(TimeUnix))) FROM otel_metrics_histogram WHERE MetricName = 'http_server_request_duration'" 2>/dev/null || echo 0); \
+            fi; \
             spread=0; \
             if [ "$sum" -gt 0 ]; then \
                 spread=$(kubectl -n cerberus exec deploy/clickhouse -- clickhouse-client \
@@ -380,9 +389,9 @@ e2e-wait-otel:
                     --user cerberus --password cerberus --database otel \
                     --query "SELECT toUInt64(dateDiff('second', min(TimeUnix), max(TimeUnix))) FROM otel_metrics_gauge" 2>/dev/null || echo 0); \
             fi; \
-            echo "    logs=$logs traces=$traces metrics_sum=$sum metrics_gauge=$gauge spread=${spread}s"; \
-            if [ "$logs" -gt 0 ] && [ "$traces" -gt 0 ] && { [ "$sum" -gt 0 ] || [ "$gauge" -gt 0 ]; } && [ "$spread" -ge 60 ]; then \
-                echo "==> OTel pipeline is live with ≥60s of metric history"; \
+            echo "    logs=$logs traces=$traces metrics_sum=$sum metrics_gauge=$gauge metrics_histogram=$histogram spread=${spread}s hist_spread=${hist_spread}s"; \
+            if [ "$logs" -gt 0 ] && [ "$traces" -gt 0 ] && { [ "$sum" -gt 0 ] || [ "$gauge" -gt 0 ]; } && [ "$spread" -ge 60 ] && [ "$histogram" -gt 0 ] && [ "$hist_spread" -ge 60 ]; then \
+                echo "==> OTel pipeline is live with ≥60s of metric history (incl. histogram companion)"; \
                 exit 0; \
             fi; \
             sleep 5; \

--- a/test/e2e/seed/cmd/seed/main.go
+++ b/test/e2e/seed/cmd/seed/main.go
@@ -195,6 +195,54 @@ SELECT
     true
 FROM numbers(600)`
 
+	// Classic-histogram companion rows for `http_server_request_duration`.
+	//
+	// Since PR #645 (`HistogramCompanionColumn`,
+	// internal/schema/otel.go:373), the PromQL lowering routes any
+	// `<base>_count` / `<base>_sum` reference to `otel_metrics_histogram`
+	// under the bare `<base>` MetricName, projecting `Count` / `Sum` as
+	// the value. That's the correct production behaviour — the OTel-CH
+	// exporter writes classic-histogram series as one row per anchor
+	// with `Count`, `Sum`, `BucketCounts`, `ExplicitBounds` populated,
+	// not as separate `_count` / `_sum` MetricName rows.
+	//
+	// The `otel_metrics_sum` seed above pre-dates that routing change
+	// and is kept for any test that still reads the sum table directly.
+	// This block adds the histogram rows the e2e Prom tests
+	// (`TestPromQueryRangeRate`, `TestPromQuerySubqueryMaxOverTimeRate`)
+	// now depend on: `rate(http_server_request_duration_count[1m])`
+	// scans `otel_metrics_histogram` for MetricName='http_server_request_duration'
+	// and projects `toFloat64(Count)` as the counter value.
+	//
+	// Shape mirrors `insertSumSQL`: 600 samples at 1 s cadence covering
+	// [seed_now - 300 s, seed_now + 299 s] so any 1m / 5m `rate()` window
+	// retains ≥2 samples regardless of ±4 min CI timing jitter. Count
+	// grows monotonically with sample index (100 + number * 5) so
+	// `rate(Count)` is positive; Sum tracks Count (5x scale) so the
+	// `_sum` companion route is also exercised. BucketCounts = [10, 20,
+	// 30, 40] (sum 100, matches the +100 base of Count) and
+	// ExplicitBounds = [0.1, 0.5, 1.0] (three explicit edges + implicit
+	// +Inf trailing bucket) give `histogram_quantile()` a non-trivial
+	// distribution to interpolate over if a future spec exercises it.
+	insertHistogramSQL = `INSERT INTO otel_metrics_histogram
+  (ResourceAttributes, ServiceName, MetricName, MetricDescription, MetricUnit, Attributes, StartTimeUnix, TimeUnix, Count, Sum, BucketCounts, ExplicitBounds, Flags, AggregationTemporality)
+SELECT
+    map('service.name', 'api'),
+    'api',
+    'http_server_request_duration',
+    'HTTP request duration histogram',
+    's',
+    map('job', 'api', 'http_status', '200'),
+    now64(9) + INTERVAL (number - 300) SECOND,
+    now64(9) + INTERVAL (number - 300) SECOND,
+    toUInt64(100 + number * 5),
+    toFloat64((100 + number * 5) * 5) / 1000,
+    [toUInt64(10), toUInt64(20), toUInt64(30), toUInt64(40)],
+    [toFloat64(0.1), toFloat64(0.5), toFloat64(1.0)],
+    toUInt32(0),
+    toInt32(2)
+FROM numbers(600)`
+
 	insertLogsSQL = `INSERT INTO otel_logs
   (Timestamp, TimestampTime, TraceId, SpanId, SeverityText, SeverityNumber, ServiceName, Body, ResourceAttributes, LogAttributes)
 SELECT
@@ -238,6 +286,9 @@ func insertMetrics(ctx context.Context, conn driver.Conn) error {
 	if err := conn.Exec(ctx, insertSumSQL); err != nil {
 		return fmt.Errorf("sum: %w", err)
 	}
+	if err := conn.Exec(ctx, insertHistogramSQL); err != nil {
+		return fmt.Errorf("histogram: %w", err)
+	}
 	return nil
 }
 
@@ -273,6 +324,7 @@ func verifyRowcounts(ctx context.Context, conn driver.Conn) error {
 	}{
 		{"metrics_gauge", "SELECT count() FROM otel_metrics_gauge"},
 		{"metrics_sum", "SELECT count() FROM otel_metrics_sum"},
+		{"metrics_histogram", "SELECT count() FROM otel_metrics_histogram"},
 		{"logs", "SELECT count() FROM otel_logs"},
 		{"traces", "SELECT count() FROM otel_traces"},
 	}


### PR DESCRIPTION
## Summary

PR #645 (`3fb14ab`, merged 2026-05-21) routed every PromQL `<base>_count` / `<base>_sum` reference to `otel_metrics_histogram` under the bare `<base>` MetricName (see `HistogramCompanionColumn` in `internal/schema/otel.go:373` + `internal/promql/lower.go:166`). That is the correct production behaviour — the OTel-CH exporter writes classic-histogram series as one row per anchor with `Count` / `Sum` / `BucketCounts` / `ExplicitBounds` populated, not as separate `_count` / `_sum` MetricName rows.

But the e2e seed (`test/e2e/seed/cmd/seed/main.go`) pre-dates that routing change and still only inserts `http_server_request_duration_count` into `otel_metrics_sum`. After #645 merged, the dashboard / Prom e2e tests started failing:

- `TestPromQueryRangeRate` (`test/e2e/e2e_prom_test.go:41`) — `rate(http_server_request_duration_count[1m])` now scans the histogram table for the bare name → 0 rows → `expected at least one series; got 0`.
- `TestPromQuerySubqueryMaxOverTimeRate` (`test/e2e/e2e_prom_test.go:94`) — `max_over_time(rate(http_server_request_duration_count[5m])[5m:1m])` hits the same path.

This PR seeds the histogram companion rows the new routing expects, mirroring the existing sum-table shape (600 samples at 1 s cadence, ±300 s span around seed_now, monotone `Count` so `rate()` returns a positive value). The existing `otel_metrics_sum` seed stays in place — anything else still reading that table directly is unaffected.

Justfile `e2e-wait-otel` is extended to also assert the histogram table has rows for `http_server_request_duration` spanning ≥60 s (matches the existing sum/gauge spread check) so the wait doesn't return prematurely before the histogram block lands.

### Sample histogram row shape

```sql
INSERT INTO otel_metrics_histogram
  (ResourceAttributes, ServiceName, MetricName, MetricDescription, MetricUnit, Attributes, StartTimeUnix, TimeUnix, Count, Sum, BucketCounts, ExplicitBounds, Flags, AggregationTemporality)
SELECT
    map('service.name', 'api'), 'api', 'http_server_request_duration',
    'HTTP request duration histogram', 's',
    map('job', 'api', 'http_status', '200'),
    now64(9) + INTERVAL (number - 300) SECOND,
    now64(9) + INTERVAL (number - 300) SECOND,
    toUInt64(100 + number * 5),
    toFloat64((100 + number * 5) * 5) / 1000,
    [toUInt64(10), toUInt64(20), toUInt64(30), toUInt64(40)],
    [toFloat64(0.1), toFloat64(0.5), toFloat64(1.0)],
    toUInt32(0), toInt32(2)
FROM numbers(600)
```

## Test plan

- [ ] CI `dashboard` job (in `.github/workflows/e2e.yml`) goes green on this PR
- [ ] `TestPromQueryRangeRate` returns ≥1 series
- [ ] `TestPromQuerySubqueryMaxOverTimeRate` returns ≥1 series
- [ ] `TestMetricsSeedHasHistogramTable` regression still passes (still asserts `ddl.All` is applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)