### PR TITLE
test(promql): pin sum by (cerberus_ql) rate() against dotted-source rows

### DIFF
--- a/test/spec/promql/sum_by_rate_dotted_source.txtar
+++ b/test/spec/promql/sum_by_rate_dotted_source.txtar
@@ -1,0 +1,104 @@
+# Regression pin for the cerberus-self "Query rate by language" panel
+# (compose_grafana_smoke.spec.ts ≥ 2 partition assertion). The panel
+# fires `sum by (cerberus_ql) (rate(cerberus_queries_total[5m]))` and
+# the underlying OTel-CH rows store the data-point attribute under its
+# OTel-canonical dotted form `cerberus.ql` (the Go SDK + clickhouse-
+# exporter pair preserve dotted keys verbatim).
+#
+# Sister fixture to `sum_by_rate_range_step.txtar` (underscored seed)
+# and `sum_by_underscored_otel_label.txtar` (instant + dotted seed) —
+# this one closes the dot↔underscore × instant↔range matrix:
+#
+#                          underscored seed          dotted seed
+#   instant `sum by`       (covered upstream)        sum_by_underscored_otel_label
+#   range  `sum by (rate)` sum_by_rate_range_step    THIS FIXTURE
+#
+# Pre-task-#214 the inner Aggregate's group-key emitted a bare
+# `Attributes['cerberus_ql']` which missed every CH row whose
+# attribute key is the dotted form. The fix in
+# `internal/promql/lower.go::attributeLookup` emits an
+# `if(mapContains(...), ..., ...)` chain over both candidates so the
+# lookup hits whichever spelling the producer wrote — including under
+# the range-mode rate pipeline. Without this fixture a future emitter
+# refactor could regress the range path silently while the instant
+# path stays green; the e2e Playwright partition check is the only
+# downstream catch and runs nightly + push-to-main, not per-PR.
+
+-- query.promql --
+sum by(cerberus_ql) (rate(cerberus_queries_total[5m]))
+-- range_step --
+30s
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('cerberus_queries_total', map('cerberus.ql', 'promql'), toDateTime64('2026-01-01 00:00:00', 9), 0.0),
+    ('cerberus_queries_total', map('cerberus.ql', 'promql'), toDateTime64('2026-01-01 00:01:00', 9), 12.0),
+    ('cerberus_queries_total', map('cerberus.ql', 'promql'), toDateTime64('2026-01-01 00:02:00', 9), 24.0),
+    ('cerberus_queries_total', map('cerberus.ql', 'promql'), toDateTime64('2026-01-01 00:03:00', 9), 36.0),
+    ('cerberus_queries_total', map('cerberus.ql', 'promql'), toDateTime64('2026-01-01 00:04:00', 9), 48.0),
+    ('cerberus_queries_total', map('cerberus.ql', 'promql'), toDateTime64('2026-01-01 00:05:00', 9), 60.0),
+    ('cerberus_queries_total', map('cerberus.ql', 'logql'), toDateTime64('2026-01-01 00:00:00', 9), 0.0),
+    ('cerberus_queries_total', map('cerberus.ql', 'logql'), toDateTime64('2026-01-01 00:01:00', 9), 6.0),
+    ('cerberus_queries_total', map('cerberus.ql', 'logql'), toDateTime64('2026-01-01 00:02:00', 9), 12.0),
+    ('cerberus_queries_total', map('cerberus.ql', 'logql'), toDateTime64('2026-01-01 00:03:00', 9), 18.0),
+    ('cerberus_queries_total', map('cerberus.ql', 'logql'), toDateTime64('2026-01-01 00:04:00', 9), 24.0),
+    ('cerberus_queries_total', map('cerberus.ql', 'logql'), toDateTime64('2026-01-01 00:05:00', 9), 30.0),
+    ('cerberus_queries_total', map('cerberus.ql', 'traceql'), toDateTime64('2026-01-01 00:00:00', 9), 0.0),
+    ('cerberus_queries_total', map('cerberus.ql', 'traceql'), toDateTime64('2026-01-01 00:01:00', 9), 3.0),
+    ('cerberus_queries_total', map('cerberus.ql', 'traceql'), toDateTime64('2026-01-01 00:02:00', 9), 6.0),
+    ('cerberus_queries_total', map('cerberus.ql', 'traceql'), toDateTime64('2026-01-01 00:03:00', 9), 9.0),
+    ('cerberus_queries_total', map('cerberus.ql', 'traceql'), toDateTime64('2026-01-01 00:04:00', 9), 12.0),
+    ('cerberus_queries_total', map('cerberus.ql', 'traceql'), toDateTime64('2026-01-01 00:05:00', 9), 15.0);
+-- expected_rows --
+[
+  ["", {"cerberus_ql": "logql"}, "2026-01-01T00:01:00Z", 0.02],
+  ["", {"cerberus_ql": "logql"}, "2026-01-01T00:01:30Z", 0.03],
+  ["", {"cerberus_ql": "logql"}, "2026-01-01T00:02:00Z", 0.04],
+  ["", {"cerberus_ql": "logql"}, "2026-01-01T00:02:30Z", 0.05],
+  ["", {"cerberus_ql": "logql"}, "2026-01-01T00:03:00Z", 0.06],
+  ["", {"cerberus_ql": "logql"}, "2026-01-01T00:03:30Z", 0.07],
+  ["", {"cerberus_ql": "logql"}, "2026-01-01T00:04:00Z", 0.08],
+  ["", {"cerberus_ql": "logql"}, "2026-01-01T00:04:30Z", 0.09],
+  ["", {"cerberus_ql": "logql"}, "2026-01-01T00:05:00Z", 0.1],
+  ["", {"cerberus_ql": "promql"}, "2026-01-01T00:01:00Z", 0.04],
+  ["", {"cerberus_ql": "promql"}, "2026-01-01T00:01:30Z", 0.06],
+  ["", {"cerberus_ql": "promql"}, "2026-01-01T00:02:00Z", 0.08],
+  ["", {"cerberus_ql": "promql"}, "2026-01-01T00:02:30Z", 0.1],
+  ["", {"cerberus_ql": "promql"}, "2026-01-01T00:03:00Z", 0.12],
+  ["", {"cerberus_ql": "promql"}, "2026-01-01T00:03:30Z", 0.14],
+  ["", {"cerberus_ql": "promql"}, "2026-01-01T00:04:00Z", 0.16],
+  ["", {"cerberus_ql": "promql"}, "2026-01-01T00:04:30Z", 0.18],
+  ["", {"cerberus_ql": "promql"}, "2026-01-01T00:05:00Z", 0.2],
+  ["", {"cerberus_ql": "traceql"}, "2026-01-01T00:01:00Z", 0.01],
+  ["", {"cerberus_ql": "traceql"}, "2026-01-01T00:01:30Z", 0.015],
+  ["", {"cerberus_ql": "traceql"}, "2026-01-01T00:02:00Z", 0.02],
+  ["", {"cerberus_ql": "traceql"}, "2026-01-01T00:02:30Z", 0.025],
+  ["", {"cerberus_ql": "traceql"}, "2026-01-01T00:03:00Z", 0.03],
+  ["", {"cerberus_ql": "traceql"}, "2026-01-01T00:03:30Z", 0.035],
+  ["", {"cerberus_ql": "traceql"}, "2026-01-01T00:04:00Z", 0.04],
+  ["", {"cerberus_ql": "traceql"}, "2026-01-01T00:04:30Z", 0.045],
+  ["", {"cerberus_ql": "traceql"}, "2026-01-01T00:05:00Z", 0.05]
+]
+-- args --
+[0] string = ""
+[1] string = "cerberus_ql"
+[2] string = "cerberus_ql"
+[3] string = "cerberus_ql"
+[4] string = "cerberus.ql"
+[5] string = "cerberus_queries_total"
+[6] string = "cerberus_ql"
+[7] string = "cerberus_ql"
+[8] string = "cerberus.ql"
+-- chplan --
+Project ["" AS MetricName, mapWithoutEmpty(map("cerberus_ql", gkey_0)) AS Attributes, bucket_ts AS TimeUnix, Value AS Value]
+  Aggregate groupBy=[if(mapContains(Attributes, "cerberus_ql"), Attributes["cerberus_ql"], Attributes["cerberus.ql"]) AS gkey_0, TimeUnix AS bucket_ts] funcs=[sum(Value) AS Value]
+    RangeWindow func=rate range=5m0s step=30s outerRange=5m0s ts=TimeUnix value=Value groupBy=[Attributes] start=2026-01-01T00:00:00Z end=2026-01-01T00:05:00Z
+      Filter predicate=(MetricName = "cerberus_queries_total")
+        Scan(otel_metrics_sum)
+-- sql --
+SELECT ? AS `MetricName`, mapFilter((k, v) -> v != '', map(?, `gkey_0`)) AS `Attributes`, `bucket_ts` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT if(mapContains(`Attributes`, ?), `Attributes`[?], `Attributes`[?]) AS `gkey_0`, `TimeUnix` AS `bucket_ts`, sum(`Value`) AS `Value` FROM (SELECT `Attributes`, `anchor_ts`, anchor_ts AS `TimeUnix`, if(sampled_interval > 0, counter_delta * (sampled_interval + if(counter_delta > 0 AND first_val >= 0, least(duration_to_start, sampled_interval * first_val / counter_delta), duration_to_start) + duration_to_end) / sampled_interval / 300, nan) AS `Value` FROM (SELECT `Attributes`, `anchor_ts`, `window_vals`, `counter_delta`, `first_val`, toFloat64(dateDiff('nanosecond', first_ts, last_ts)) / 1e9 AS `sampled_interval`, if(toFloat64(dateDiff('nanosecond', anchor_ts - toIntervalNanosecond(300000000000), first_ts)) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', anchor_ts - toIntervalNanosecond(300000000000), first_ts)) / 1e9) AS `duration_to_start`, if(toFloat64(dateDiff('nanosecond', last_ts, anchor_ts)) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', last_ts, anchor_ts)) / 1e9) AS `duration_to_end` FROM (SELECT `Attributes`, `anchor_ts`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta`, tupleElement(window_pairs[1], 1) AS `first_ts`, tupleElement(window_pairs[length(window_pairs)], 1) AS `last_ts`, tupleElement(window_pairs[1], 2) AS `first_val` FROM (SELECT `Attributes`, `anchor_ts`, arrayFilter(p -> tupleElement(p, 1) > anchor_ts - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= anchor_ts, series_array) AS `window_pairs` FROM (SELECT `Attributes`, `series_array`, arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(i * 30000000000), range(0, 11))) AS `anchor_ts` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` = ?)) GROUP BY `Attributes`))))) WHERE length(`window_vals`) >= 2) GROUP BY if(mapContains(`Attributes`, ?), `Attributes`[?], `Attributes`[?]), `TimeUnix`)


### PR DESCRIPTION
## Summary

The compose_grafana_smoke "Query rate by language" partition check (the last 2 of 17 failures from PR #693) asserts >= 2 grouped series on `sum by (cerberus_ql) (rate(cerberus_queries_total[5m]))` against a CH stack that stores the OTel-canonical dotted attribute key `cerberus.ql`. The instant-mode equivalent is pinned by `sum_by_underscored_otel_label.txtar` (dotted seed) and `sum_by_rate_range_step.txtar` covers the range path with the underscored sibling — but no Layer 2a spec covered the range-mode + dotted-source combination, which is exactly the shape the cerberus-self panel exercises.

This fixture closes the matrix:

|                              | underscored seed             | dotted seed                          |
|------------------------------|------------------------------|--------------------------------------|
| instant `sum by`             | upstream coverage            | `sum_by_underscored_otel_label.txtar`|
| range  `sum by (rate(...))`  | `sum_by_rate_range_step.txtar` | **`sum_by_rate_dotted_source.txtar`** (this PR) |

The chDB roundtrip verifies the if-chain `attributeLookup` lowering from PR #214 / task #214 partitions three input series (promql/logql/traceql) correctly under the OTel-dotted form, with the wire emitting the underscored Prom-canonical spelling. The SQL pin guarantees the
`if(mapContains(Attributes, 'cerberus_ql'), Attributes['cerberus_ql'], Attributes['cerberus.ql'])` group-by chain stays in place under the range-mode rate pipeline — any future refactor that drops the dotted fallback inside the range path will break the spec test before reaching the nightly e2e smoke.

## Test plan

- [ ] `roundtrip (promql)` lane runs the new TXTAR fixture in chDB and matches `expected_rows` (3 series x 9 anchors = 27 rows)
- [ ] `check` lane parses the SQL section and pins the byte-stable emit
- [ ] `dashboard` job picks up the regression-pinning fixture nightly to keep the spec layer aligned with the e2e Playwright partition assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)