### PR TITLE
fix(api/prom): fan bare classic-histogram base names out to companion variants on labels/series

### DIFF
--- a/internal/api/prom/handler_chdb_label_values_test.go
+++ b/internal/api/prom/handler_chdb_label_values_test.go
@@ -54,12 +54,26 @@ const metaShapedSumDDL = `CREATE TABLE otel_metrics_sum (
 // metaShapedHistogramDDL completes the trio. The metadata-handler SQL
 // reads the same three columns regardless of table kind; the histogram
 // kind only matters when query / range-query SQL targets the table.
+//
+// Includes `Count UInt64` + `Sum Float64` because the bare-histogram
+// matcher fan-out (expandBareHistogramMatcher in metadata.go) routes
+// `match[]=<base>` through the `<base>_count` / `<base>_sum` companion
+// lowering paths, which project `toFloat64(Count)` / `toFloat64(Sum)`
+// against this table (see wrapHistogramCompanionProject in
+// internal/promql/lower.go). Without these columns the chDB run fails
+// with `Unknown expression identifier 'Count'` on the
+// `TestLabelValues_MatchSelector_ChDB` path even when no histogram rows
+// are seeded — the SELECT references the columns regardless. Mirrors
+// the production OTel-CH histogram table from
+// internal/schema/otel.go::DefaultOTelMetrics.
 const metaShapedHistogramDDL = `CREATE TABLE otel_metrics_histogram (
     MetricName String,
     MetricDescription String,
     MetricUnit String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
     BucketCounts Array(UInt64),
     ExplicitBounds Array(Float64)
 ) ENGINE = MergeTree() ORDER BY (MetricName, TimeUnix);`

--- a/internal/api/prom/handler_chdb_label_values_test.go
+++ b/internal/api/prom/handler_chdb_label_values_test.go
@@ -72,7 +72,13 @@ const metaShapedHistogramDDL = `CREATE TABLE otel_metrics_histogram (
 func TestLabelValues_MatchSelector_ChDB(t *testing.T) {
 	seedTime := time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC)
 	ts := seedTime.Format("2006-01-02 15:04:05.000")
-	seed := metaShapedGaugeDDL + fmt.Sprintf(`
+	// All three metric tables are created because fetchLabelValuesMatched
+	// fans a bare classic-histogram base name out across the histogram
+	// table via expandBareHistogramMatcher; the companion variants
+	// (`up_bucket` / `up_count` / `up_sum`) lower to the histogram table
+	// and chDB errors on missing-table reads. The histogram + sum tables
+	// stay empty — only gauge carries rows.
+	seed := metaShapedGaugeDDL + metaShapedSumDDL + metaShapedHistogramDDL + fmt.Sprintf(`
 INSERT INTO otel_metrics_gauge (MetricName, MetricDescription, MetricUnit, Attributes, TimeUnix, Value) VALUES
     ('up', 'scrape ok', '', map('job', 'api', 'instance', 'h1:8080'), toDateTime64('%s', 9), 1.0),
     ('up', 'scrape ok', '', map('job', 'db',  'instance', 'h1:8080'), toDateTime64('%s', 9), 0.0),
@@ -175,7 +181,11 @@ INSERT INTO otel_metrics_gauge (MetricName, MetricDescription, MetricUnit, Attri
 func TestLabelValues_MatchSelector_Multiple_ChDB(t *testing.T) {
 	seedTime := time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC)
 	ts := seedTime.Format("2006-01-02 15:04:05.000")
-	seed := metaShapedGaugeDDL + fmt.Sprintf(`
+	// Histogram + sum tables are created (empty) so the bare-name
+	// classic-histogram companion fan-out
+	// (expandBareHistogramMatcher) finds the histogram table when it
+	// probes `up_bucket` / `up_count` / `up_sum`.
+	seed := metaShapedGaugeDDL + metaShapedSumDDL + metaShapedHistogramDDL + fmt.Sprintf(`
 INSERT INTO otel_metrics_gauge (MetricName, MetricDescription, MetricUnit, Attributes, TimeUnix, Value) VALUES
     ('up',   '', '', map('job', 'api'), toDateTime64('%s', 9), 1.0),
     ('up',   '', '', map('job', 'db'),  toDateTime64('%s', 9), 1.0),
@@ -217,7 +227,10 @@ INSERT INTO otel_metrics_gauge (MetricName, MetricDescription, MetricUnit, Attri
 func TestLabelValues_MatchSelector_Empty_ChDB(t *testing.T) {
 	seedTime := time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC)
 	ts := seedTime.Format("2006-01-02 15:04:05.000")
-	seed := metaShapedGaugeDDL + fmt.Sprintf(`
+	// Histogram + sum tables are created (empty) so the bare-name
+	// fan-out for `does_not_exist` finds the histogram table when it
+	// probes `does_not_exist_bucket` / `_count` / `_sum`.
+	seed := metaShapedGaugeDDL + metaShapedSumDDL + metaShapedHistogramDDL + fmt.Sprintf(`
 INSERT INTO otel_metrics_gauge (MetricName, MetricDescription, MetricUnit, Attributes, TimeUnix, Value) VALUES
     ('up', '', '', map('job', 'api'), toDateTime64('%s', 9), 1.0);`, ts)
 

--- a/internal/api/prom/handler_labels_histogram_test.go
+++ b/internal/api/prom/handler_labels_histogram_test.go
@@ -1,0 +1,250 @@
+package prom_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+// labelKeysStub captures every QueryStrings invocation so a conformance
+// test can assert that the labels / series endpoints fan a bare
+// classic-histogram base name out across the three Prom-wire companion
+// variants (`<base>_bucket` / `<base>_count` / `<base>_sum`). The other
+// stubQuerier in handler_test.go only retains `lastSQL` + `lastArgs`,
+// which loses the per-arm history we need to assert here.
+type labelKeysStub struct {
+	mu sync.Mutex
+	// resultsBySQLContains keys are substring matchers; the first key
+	// found inside the QueryStrings SQL returns the corresponding
+	// values slice. Default (no key matches) returns an empty slice so
+	// the union flows through without picking up phantom labels.
+	resultsBySQLContains map[string][]string
+	sqls                 []string
+	// samples mirror stubQuerier's behaviour for the /series surface;
+	// the executeInstant path runs the matcher through QueryCursor, so
+	// we return one sample per matched series.
+	samplesBySQLContains map[string][]chclient.Sample
+}
+
+func (s *labelKeysStub) recordSQL(sql string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sqls = append(s.sqls, sql)
+}
+
+func (s *labelKeysStub) Query(_ context.Context, sql string, _ ...any) ([]chclient.Sample, error) {
+	s.recordSQL(sql)
+	return s.matchSamples(sql), nil
+}
+
+func (s *labelKeysStub) QueryCursor(_ context.Context, sql string, _ ...any) (chclient.Cursor, error) {
+	s.recordSQL(sql)
+	return newSliceCursor(s.matchSamples(sql)), nil
+}
+
+func (s *labelKeysStub) QueryStrings(_ context.Context, sql string, _ ...any) ([]string, error) {
+	s.recordSQL(sql)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for needle, vals := range s.resultsBySQLContains {
+		if strings.Contains(sql, needle) {
+			return vals, nil
+		}
+	}
+	return nil, nil
+}
+
+func (s *labelKeysStub) QueryLabelSets(_ context.Context, sql string, _ ...any) ([]map[string]string, error) {
+	s.recordSQL(sql)
+	return nil, nil
+}
+
+func (s *labelKeysStub) QueryMetricMeta(_ context.Context, sql, _ string, _ ...any) ([]chclient.MetricMetaRow, error) {
+	s.recordSQL(sql)
+	return nil, nil
+}
+
+func (s *labelKeysStub) QueryExemplars(_ context.Context, sql string, _ ...any) ([]chclient.ExemplarRow, error) {
+	s.recordSQL(sql)
+	return nil, nil
+}
+
+func (s *labelKeysStub) matchSamples(sql string) []chclient.Sample {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for needle, samples := range s.samplesBySQLContains {
+		if strings.Contains(sql, needle) {
+			return samples
+		}
+	}
+	return nil
+}
+
+func (s *labelKeysStub) sqlCount(substr string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := 0
+	for _, sql := range s.sqls {
+		if strings.Contains(sql, substr) {
+			n++
+		}
+	}
+	return n
+}
+
+// TestLabels_HistogramBareName_FansOutCompanions pins the fix for the
+// "Unable to fetch labels" regression Grafana's Metrics Explorer hits
+// against a histogram tile. The Metrics Explorer surfaces the bare
+// base name from cerberus's `__name__` listing and queries
+// `match[]=<base>` for the labels chip — before the fix that matcher
+// lowered to a gauge-table scan (TableFor's default), matched zero
+// rows, and the chip rendered "Unable to fetch labels".
+//
+// Asserts (a) the labels handler emits at least one SQL whose FROM
+// clause references the histogram table (the `_bucket` companion
+// variant), and (b) the response body carries the `le` label that
+// only lives on the bucket-fanned rows.
+func TestLabels_HistogramBareName_FansOutCompanions(t *testing.T) {
+	t.Parallel()
+
+	// The companion fan-out emits four matcher arms (base, _bucket,
+	// _count, _sum). We seed the _bucket arm's projection with `le`
+	// + `cerberus_ql` to mimic the histogram's stored label keys;
+	// the gauge-targeted base arm returns nothing.
+	stub := &labelKeysStub{
+		resultsBySQLContains: map[string][]string{
+			"otel_metrics_histogram": {"le", "cerberus_ql"},
+		},
+	}
+	srv := newServer(stub)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL +
+		"/api/v1/labels?match%5B%5D=cerberus_clickhouse_bytes_read")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+
+	// (a) the handler must have visited the histogram table.
+	if got := stub.sqlCount("otel_metrics_histogram"); got == 0 {
+		t.Fatalf("expected at least one SQL targeting otel_metrics_histogram (companion fan-out); got 0\nall SQLs: %v",
+			stub.sqls)
+	}
+
+	// (b) the response body carries the histogram-specific `le`
+	// label — the chip Grafana renders in the Metrics Explorer.
+	var env struct {
+		Status string   `json:"status"`
+		Data   []string `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(body), &env); err != nil {
+		t.Fatalf("decode: %v body=%s", err, body)
+	}
+	if env.Status != "success" {
+		t.Errorf("status: got %q, want success", env.Status)
+	}
+	gotLe := false
+	for _, name := range env.Data {
+		if name == "le" {
+			gotLe = true
+			break
+		}
+	}
+	if !gotLe {
+		t.Errorf("expected `le` label in response (from bucket companion fan-out); got %v", env.Data)
+	}
+}
+
+// TestLabelValues_HistogramBareName_FansOutCompanions covers the
+// label-VALUES counterpart: a bare-name matcher also has to reach
+// the histogram table so `/api/v1/label/le/values?match[]=<base>`
+// returns the bucket boundaries.
+func TestLabelValues_HistogramBareName_FansOutCompanions(t *testing.T) {
+	t.Parallel()
+
+	stub := &labelKeysStub{
+		resultsBySQLContains: map[string][]string{
+			"otel_metrics_histogram": {"0.5", "1", "+Inf"},
+		},
+	}
+	srv := newServer(stub)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL +
+		"/api/v1/label/le/values?match%5B%5D=cerberus_clickhouse_bytes_read")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+
+	if got := stub.sqlCount("otel_metrics_histogram"); got == 0 {
+		t.Fatalf("expected at least one SQL targeting otel_metrics_histogram (companion fan-out); got 0\nall SQLs: %v",
+			stub.sqls)
+	}
+
+	var env struct {
+		Status string   `json:"status"`
+		Data   []string `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(body), &env); err != nil {
+		t.Fatalf("decode: %v body=%s", err, body)
+	}
+	wantAny := map[string]bool{"0.5": false, "1": false, "+Inf": false}
+	for _, v := range env.Data {
+		if _, ok := wantAny[v]; ok {
+			wantAny[v] = true
+		}
+	}
+	for v, seen := range wantAny {
+		if !seen {
+			t.Errorf("expected `%s` bucket-boundary value in response; got %v", v, env.Data)
+		}
+	}
+}
+
+// TestLabels_BucketCompanionDoesNotDoubleScan pins the other edge of
+// the fan-out: when Grafana sends the `_bucket` companion form
+// directly, the handler MUST NOT also fan out into a second `_bucket`
+// arm (which would be a wasted scan). The helper's suffix check
+// short-circuits the fan-out; this test pins the byte-stable
+// single-arm SQL for the companion path.
+func TestLabels_BucketCompanionDoesNotDoubleScan(t *testing.T) {
+	t.Parallel()
+
+	stub := &labelKeysStub{
+		resultsBySQLContains: map[string][]string{
+			"otel_metrics_histogram": {"le", "cerberus_ql"},
+		},
+	}
+	srv := newServer(stub)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL +
+		"/api/v1/labels?match%5B%5D=cerberus_clickhouse_bytes_read_bucket")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+
+	// One QueryStrings call total (the bucket-suffix matcher path
+	// lowers to a histogram-table scan in a single arm).
+	if got := stub.sqlCount("otel_metrics_histogram"); got != 1 {
+		t.Fatalf("expected exactly 1 SQL targeting otel_metrics_histogram; got %d\nall SQLs: %v",
+			got, stub.sqls)
+	}
+}

--- a/internal/api/prom/histogram_bare_match.go
+++ b/internal/api/prom/histogram_bare_match.go
@@ -1,0 +1,146 @@
+package prom
+
+import (
+	"strings"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	promparser "github.com/prometheus/prometheus/promql/parser"
+)
+
+// histogramCompanionSuffixes are the Prom-wire classic-histogram companion
+// suffixes — the three series names Prom exposes for a single
+// classic-histogram OTel-CH row. `_total` is included because the same
+// `TableFor` heuristic treats it as a sum-table counter; expanding a
+// counter-shaped name into histogram companions would point at an
+// empty table.
+var histogramCompanionSuffixes = []string{"_bucket", "_count", "_sum", "_total"}
+
+// expandBareHistogramMatcher takes a raw match[] string and, when it is
+// a single VectorSelector pinning `__name__` to a bare base name (no
+// classic-histogram companion suffix), returns the original matcher PLUS
+// three companion variants — `<base>_bucket`, `<base>_count`,
+// `<base>_sum` — so the labels / series metadata surfaces can fan-out
+// the lookup across the histogram table's companion rows.
+//
+// The OTel-CH classic histogram exporter writes one row under the bare
+// `<base>` name in the histogram table; PromQL exposes that single row
+// as three companion series (`_bucket` / `_count` / `_sum`). Cerberus's
+// `__name__` listing also emits the bare base name (the row's MetricName
+// column literally has that value), so Grafana's Metrics Explorer picks
+// up the bare name and uses it as a match[] selector when fetching the
+// metric's labels chip. Without the companion fan-out the bare-name
+// matcher lowers to a gauge-table scan (TableFor's default), the
+// histogram row never matches, and the labels chip surfaces "Unable to
+// fetch labels".
+//
+// Returns the original matcher string as the first element so callers
+// that union results from each variant still hit the matcher's original
+// shape (e.g. a real gauge metric whose name doesn't carry any
+// companion suffix). Variants are deduped against the original so the
+// callers don't re-scan the same shape twice when the original already
+// is a companion form (e.g. when Grafana sends `<base>_bucket` itself
+// — that path returns the input list of length 1).
+//
+// The parser is the caller's responsibility for the actual matcher SQL
+// lowering; this helper uses its own parse pass against the raw string
+// since the lowering re-parses inside matcherSQL. Parse failures fall
+// through as the single-element slice — the downstream matcherSQL call
+// will surface the same parse error to the client with full diagnostics.
+func expandBareHistogramMatcher(parser promparser.Parser, matcher, histogramTable string) []string {
+	if histogramTable == "" {
+		return []string{matcher}
+	}
+	base, ok := bareHistogramBaseName(parser, matcher)
+	if !ok {
+		return []string{matcher}
+	}
+	out := make([]string, 0, 1+len(histogramCompanionSuffixes)-1)
+	out = append(out, matcher)
+	seen := map[string]struct{}{matcher: {}}
+	for _, suf := range []string{"_bucket", "_count", "_sum"} {
+		variant := companionMatcherString(matcher, base, base+suf)
+		if variant == "" {
+			continue
+		}
+		if _, dup := seen[variant]; dup {
+			continue
+		}
+		seen[variant] = struct{}{}
+		out = append(out, variant)
+	}
+	return out
+}
+
+// bareHistogramBaseName reports whether the matcher names a bare metric
+// (no classic-histogram companion suffix and no counter `_total` suffix)
+// via a single VectorSelector with a `__name__=<X>` equality matcher.
+// Returns the bare name on a hit.
+//
+// `__name__=~"…"` (regex) selectors are not expanded — the user has
+// explicitly chosen a regex shape and the companion fan-out would
+// double-count any match the regex already covers.
+func bareHistogramBaseName(parser promparser.Parser, matcher string) (string, bool) {
+	expr, err := parser.ParseExpr(matcher)
+	if err != nil {
+		return "", false
+	}
+	vs, vsErr := singleVectorSelector(expr)
+	if vsErr != nil {
+		return "", false
+	}
+	name := equalNameMatcher(vs.LabelMatchers)
+	if name == "" {
+		return "", false
+	}
+	for _, suf := range histogramCompanionSuffixes {
+		if strings.HasSuffix(name, suf) {
+			return "", false
+		}
+	}
+	return name, true
+}
+
+// equalNameMatcher returns the value of the `__name__` equality matcher
+// in ms, or "" if none is present (regex / negated matches don't
+// qualify). Mirrors metricNameFromMatchers in internal/promql/lower.go.
+func equalNameMatcher(ms []*labels.Matcher) string {
+	for _, m := range ms {
+		if m.Name == model.MetricNameLabel && m.Type == labels.MatchEqual {
+			return m.Value
+		}
+	}
+	return ""
+}
+
+// companionMatcherString rewrites a bare-name matcher string into the
+// equivalent matcher targeting a companion series. The rewrite preserves
+// the surrounding shape — `name{label="x"}` becomes `companion{label="x"}`;
+// `{__name__="name", …}` becomes `{__name__="companion", …}`; bare
+// `name` becomes bare `companion`.
+//
+// Returns "" when the rewrite isn't trivially safe (e.g. the matcher
+// has been pre-rewritten by normalizeDottedSelectors into a shape the
+// simple replacement doesn't recognise). The caller treats an empty
+// return as "skip this variant" — the bare-name arm still runs.
+func companionMatcherString(matcher, base, companion string) string {
+	trimmed := strings.TrimSpace(matcher)
+	// `__name__="<base>"` inside a `{…}` matcher group — rewrite the
+	// quoted value in place. This is the shape normalizeDottedSelectors
+	// produces and the shape Grafana's Metrics Explorer sometimes sends
+	// explicitly.
+	needle := `__name__="` + base + `"`
+	if strings.Contains(trimmed, needle) {
+		return strings.Replace(trimmed, needle, `__name__="`+companion+`"`, 1)
+	}
+	// Bare-name selector — `<base>` or `<base>{…}`. Detect by checking
+	// whether the matcher starts with the base name followed by either
+	// end-of-string or a `{` matcher-group opener.
+	if strings.HasPrefix(trimmed, base) {
+		rest := trimmed[len(base):]
+		if rest == "" || rest[0] == '{' {
+			return companion + rest
+		}
+	}
+	return ""
+}

--- a/internal/api/prom/histogram_bare_match_test.go
+++ b/internal/api/prom/histogram_bare_match_test.go
@@ -1,0 +1,146 @@
+package prom
+
+import (
+	"testing"
+
+	promparser "github.com/prometheus/prometheus/promql/parser"
+)
+
+// TestExpandBareHistogramMatcher pins the contract the labels / series
+// metadata handlers rely on for histogram-base lookups: a bare
+// VectorSelector naming a metric whose name has no classic-histogram
+// companion suffix fans out into three Prom-wire companion variants,
+// and any matcher that already carries one of those suffixes (or is
+// not a single VectorSelector) passes through unchanged.
+//
+// Companion: TestConformance_LabelsHistogramBareName in
+// conformance_test.go exercises the full HTTP surface; this unit test
+// pins the rewriter's per-case behaviour without the handler scaffold.
+func TestExpandBareHistogramMatcher(t *testing.T) {
+	t.Parallel()
+
+	parser := promparser.NewParser(promparser.Options{EnableExperimentalFunctions: true})
+	const histogramTable = "otel_metrics_histogram"
+
+	cases := []struct {
+		name    string
+		matcher string
+		want    []string
+	}{
+		// Bare base name in the legacy `name` shape — Grafana's
+		// Metrics Explorer renders this when the user clicks a
+		// histogram tile and asks for its labels chip.
+		{
+			name:    "bare_name_short_form",
+			matcher: "cerberus_clickhouse_bytes_read",
+			want: []string{
+				"cerberus_clickhouse_bytes_read",
+				"cerberus_clickhouse_bytes_read_bucket",
+				"cerberus_clickhouse_bytes_read_count",
+				"cerberus_clickhouse_bytes_read_sum",
+			},
+		},
+		// Bare base name with an attached `{…}` matcher group —
+		// label predicates carry through unchanged into each variant.
+		{
+			name:    "bare_name_with_label_predicate",
+			matcher: `cerberus_clickhouse_bytes_read{cerberus_ql="promql"}`,
+			want: []string{
+				`cerberus_clickhouse_bytes_read{cerberus_ql="promql"}`,
+				`cerberus_clickhouse_bytes_read_bucket{cerberus_ql="promql"}`,
+				`cerberus_clickhouse_bytes_read_count{cerberus_ql="promql"}`,
+				`cerberus_clickhouse_bytes_read_sum{cerberus_ql="promql"}`,
+			},
+		},
+		// Explicit `{__name__="…"}` form — the rewriter recognises
+		// the quoted-name shape Grafana also sometimes emits.
+		{
+			name:    "explicit_name_matcher",
+			matcher: `{__name__="cerberus_clickhouse_bytes_read"}`,
+			want: []string{
+				`{__name__="cerberus_clickhouse_bytes_read"}`,
+				`{__name__="cerberus_clickhouse_bytes_read_bucket"}`,
+				`{__name__="cerberus_clickhouse_bytes_read_count"}`,
+				`{__name__="cerberus_clickhouse_bytes_read_sum"}`,
+			},
+		},
+		// Bucket companion: already a histogram-shaped name, no
+		// fan-out (the helper short-circuits on the suffix check).
+		{
+			name:    "bucket_companion_passthrough",
+			matcher: "cerberus_clickhouse_bytes_read_bucket",
+			want:    []string{"cerberus_clickhouse_bytes_read_bucket"},
+		},
+		// Count / sum companions also short-circuit.
+		{
+			name:    "count_companion_passthrough",
+			matcher: "cerberus_clickhouse_bytes_read_count",
+			want:    []string{"cerberus_clickhouse_bytes_read_count"},
+		},
+		{
+			name:    "sum_companion_passthrough",
+			matcher: "cerberus_clickhouse_bytes_read_sum",
+			want:    []string{"cerberus_clickhouse_bytes_read_sum"},
+		},
+		// `_total` is the counter convention — passing it through
+		// the histogram fan-out would scan an unrelated table.
+		{
+			name:    "total_counter_passthrough",
+			matcher: "cerberus_queries_total",
+			want:    []string{"cerberus_queries_total"},
+		},
+		// Regex matcher — explicit user intent, the helper leaves
+		// the original shape alone.
+		{
+			name:    "regex_name_matcher_passthrough",
+			matcher: `{__name__=~"cerberus_.+"}`,
+			want:    []string{`{__name__=~"cerberus_.+"}`},
+		},
+		// Malformed matcher — parse fails, helper returns the
+		// single-element slice and the downstream matcherSQL
+		// surfaces the parse error to the client.
+		{
+			name:    "parse_error_passthrough",
+			matcher: "((not_a_selector",
+			want:    []string{"((not_a_selector"},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := expandBareHistogramMatcher(parser, tc.matcher, histogramTable)
+			if !stringSlicesEqual(got, tc.want) {
+				t.Fatalf("expandBareHistogramMatcher(%q)\n got:  %v\n want: %v", tc.matcher, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestExpandBareHistogramMatcher_NoHistogramTable pins the
+// empty-histogram-table short-circuit: deployments that don't configure
+// the classic-histogram table must see no fan-out (the lookup would
+// scan an absent table and surface a CH error).
+func TestExpandBareHistogramMatcher_NoHistogramTable(t *testing.T) {
+	t.Parallel()
+
+	parser := promparser.NewParser(promparser.Options{EnableExperimentalFunctions: true})
+	got := expandBareHistogramMatcher(parser, "cerberus_clickhouse_bytes_read", "")
+	want := []string{"cerberus_clickhouse_bytes_read"}
+	if !stringSlicesEqual(got, want) {
+		t.Fatalf("expandBareHistogramMatcher with empty HistogramTable\n got:  %v\n want: %v", got, want)
+	}
+}
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/api/prom/metadata.go
+++ b/internal/api/prom/metadata.go
@@ -281,15 +281,24 @@ func (h *Handler) handleSeries(w http.ResponseWriter, r *http.Request) {
 
 	seen := make(map[string]map[string]string)
 	for _, m := range matchers {
-		sets, err := h.fetchSeries(r.Context(), m)
-		if err != nil {
-			h.respondError(w, err)
-			return
-		}
-		for _, lset := range sets {
-			key := format.CanonicalKey(lset)
-			if _, ok := seen[key]; !ok {
-				seen[key] = lset
+		// Fan a bare classic-histogram base name out into its three
+		// Prom-wire companion variants — `<base>_bucket` /
+		// `<base>_count` / `<base>_sum` — so /api/v1/series returns
+		// the three companion series Grafana's Metrics Explorer
+		// expects. See expandBareHistogramMatcher for the
+		// rationale; non-histogram matchers short-circuit through
+		// the helper's single-element return.
+		for _, variant := range expandBareHistogramMatcher(h.parser, m, h.Schema.HistogramTable) {
+			sets, err := h.fetchSeries(r.Context(), variant)
+			if err != nil {
+				h.respondError(w, err)
+				return
+			}
+			for _, lset := range sets {
+				key := format.CanonicalKey(lset)
+				if _, ok := seen[key]; !ok {
+					seen[key] = lset
+				}
 			}
 		}
 	}
@@ -362,14 +371,26 @@ func (h *Handler) fetchLabelValues(ctx context.Context, name string) ([]string, 
 // is always included if at least one selector matches anything. Names
 // pass through Prom-grammar normalisation before dedupe; see
 // `format.NormalizeLabelNames` for the collision policy.
+//
+// Each input matcher fans out through expandBareHistogramMatcher: a
+// bare classic-histogram base name (no `_bucket` / `_count` / `_sum`
+// / `_total` suffix) also visits its three Prom-companion variants
+// against the histogram table. Without the fan-out, Grafana's Metrics
+// Explorer — which surfaces the bare base name from cerberus's
+// `__name__` listing and queries `match[]=<base>` for the labels chip
+// — would see only `__name__` and render "Unable to fetch labels".
+// Non-histogram inputs short-circuit through the no-op (single-element)
+// return of the expander.
 func (h *Handler) fetchLabelNamesMatched(ctx context.Context, matchers []string) ([]string, error) {
 	collected := []string{model.MetricNameLabel}
 	for _, m := range matchers {
-		keys, err := h.labelKeysForMatcher(ctx, m)
-		if err != nil {
-			return nil, err
+		for _, variant := range expandBareHistogramMatcher(h.parser, m, h.Schema.HistogramTable) {
+			keys, err := h.labelKeysForMatcher(ctx, variant)
+			if err != nil {
+				return nil, err
+			}
+			collected = append(collected, keys...)
 		}
-		collected = append(collected, keys...)
 	}
 	out := format.NormalizeLabelNames(collected)
 	sort.Strings(out)
@@ -380,16 +401,24 @@ func (h *Handler) fetchLabelNamesMatched(ctx context.Context, matchers []string)
 // series matching any of the given match[] selectors. The start/end pair
 // is forwarded to matcherSQL via labelValuesForMatcher so the lowering's
 // LWR anchor reflects the request window when present.
+//
+// As with fetchLabelNamesMatched, each matcher fans out through
+// expandBareHistogramMatcher so the bare-base-name shape (which
+// otherwise lowers to a gauge-table scan and returns empty for any
+// histogram metric) also visits the three classic-histogram companion
+// variants. See expandBareHistogramMatcher for the rationale.
 func (h *Handler) fetchLabelValuesMatched(ctx context.Context, name string, matchers []string, start, end time.Time) ([]string, error) {
 	seen := map[string]bool{}
 	for _, m := range matchers {
-		vals, err := h.labelValuesForMatcher(ctx, name, m, start, end)
-		if err != nil {
-			return nil, err
-		}
-		for _, v := range vals {
-			if v != "" {
-				seen[v] = true
+		for _, variant := range expandBareHistogramMatcher(h.parser, m, h.Schema.HistogramTable) {
+			vals, err := h.labelValuesForMatcher(ctx, name, variant, start, end)
+			if err != nil {
+				return nil, err
+			}
+			for _, v := range vals {
+				if v != "" {
+					seen[v] = true
+				}
 			}
 		}
 	}

--- a/test/e2e/playwright/prom_metrics.spec.ts
+++ b/test/e2e/playwright/prom_metrics.spec.ts
@@ -78,3 +78,51 @@ test('subquery up[1m:30s] (bare vector) returns a vector', async ({ request }) =
   expect(body.status, 'prom response status').toBe('success');
   expect(body.data.result.length, 'at least one series').toBeGreaterThan(0);
 });
+
+/**
+ * Grafana's Metrics Explorer (Explore → Metrics) surfaces the BARE
+ * histogram base name from cerberus's `__name__` listing — e.g.
+ * `http_server_request_duration` — and queries `match[]=<base>` for
+ * the labels chip. Before the fan-out fix the bare-name matcher
+ * lowered to a gauge-table scan, matched zero rows, and the chip
+ * rendered "Unable to fetch labels".
+ *
+ * This test pins the contract end-to-end: a bare histogram name
+ * resolves to the labels of its `_bucket` companion, including the
+ * synthetic `le` key.
+ */
+test('prom /api/v1/labels?match[]=<histogram_base> includes le from bucket companion', async ({ request }) => {
+  const matcher = encodeURIComponent('http_server_request_duration');
+  const resp = await request.get(`${promProxy}/labels?match%5B%5D=${matcher}`);
+  expect(resp.status(), 'prom /labels status').toBe(200);
+
+  const body = await resp.json();
+  expect(body.status, 'prom labels status').toBe('success');
+  expect(Array.isArray(body.data), 'data is an array').toBe(true);
+  // The fan-out reaches the histogram-table `_bucket` companion, so
+  // the synthetic `le` label must surface — that's the chip Grafana
+  // Metrics Explorer renders.
+  expect(body.data, 'le label from bucket companion').toContain('le');
+});
+
+/**
+ * Companion to the labels test: /api/v1/series with a bare-name
+ * matcher returns the three companion series (`_bucket`, `_count`,
+ * `_sum`). Grafana uses this surface for the same labels chip when
+ * the explorer asks for one row per series.
+ */
+test('prom /api/v1/series?match[]=<histogram_base> returns companion series', async ({ request }) => {
+  const matcher = encodeURIComponent('http_server_request_duration');
+  const resp = await request.get(`${promProxy}/series?match%5B%5D=${matcher}`);
+  expect(resp.status(), 'prom /series status').toBe(200);
+
+  const body = await resp.json();
+  expect(body.status, 'prom series status').toBe('success');
+  expect(Array.isArray(body.data), 'data is an array').toBe(true);
+  expect(body.data.length, 'at least one series from companion fan-out').toBeGreaterThan(0);
+  const names = new Set(body.data.map((s: Record<string, string>) => s.__name__));
+  // At least one of the companion names must appear; the bucket
+  // companion is the load-bearing one for the labels chip.
+  const seenBucket = names.has('http_server_request_duration_bucket');
+  expect(seenBucket, `expected http_server_request_duration_bucket in series; got ${[...names].join(',')}`).toBe(true);
+});


### PR DESCRIPTION
## Summary

Grafana's Metrics Explorer (Explore → Metrics) surfaces the bare
classic-histogram base name from cerberus's `__name__` listing
(e.g. `cerberus_clickhouse_bytes_read`) and queries
`match[]=<base>` for the labels chip. Before this fix the
bare-name matcher lowered to a gauge-table scan (`TableFor`'s
default), matched zero rows in the histogram table, and the chip
rendered **"Unable to fetch labels"**.

Reproduction (user-confirmed):

```bash
$ curl -sS 'http://localhost:8080/api/v1/labels?match%5B%5D=cerberus_clickhouse_bytes_read'
{"status":"success","data":["__name__"]}

$ curl -sS 'http://localhost:8080/api/v1/labels?match%5B%5D=cerberus_clickhouse_bytes_read_bucket'
{"status":"success","data":["__name__","cerberus_ql","le"]}
```

`expandBareHistogramMatcher` (`internal/api/prom/histogram_bare_match.go`)
fans a bare-base matcher into three Prom-wire companion variants —
`<base>_bucket` / `<base>_count` / `<base>_sum` — so the existing
companion-routing in `internal/promql/lower.go` reaches the
histogram table. Wired into:

- `fetchLabelNamesMatched` — `/api/v1/labels?match[]=…`
- `fetchLabelValuesMatched` — `/api/v1/label/<name>/values?match[]=…`
- `handleSeries` — `/api/v1/series?match[]=…`

Non-histogram matchers short-circuit through the helper's
single-element return; the bucket / count / sum companion
suffixes and the `_total` counter suffix all bypass the fan-out
so the byte-stable single-arm SQL is preserved for the
already-working paths.

## Test plan

- [x] `internal/api/prom/histogram_bare_match_test.go` — unit pins
      for the rewriter: bare name, label-predicate form,
      explicit `__name__` matcher, each companion / `_total`
      passthrough, regex passthrough, parse-error fallthrough,
      empty-histogram-table short-circuit.
- [x] `internal/api/prom/handler_labels_histogram_test.go` —
      conformance tests (`TestLabels_HistogramBareName_FansOutCompanions`,
      `TestLabelValues_HistogramBareName_FansOutCompanions`,
      `TestLabels_BucketCompanionDoesNotDoubleScan`) drive the full
      HTTP surface with a SQL-history-tracking stub.
- [x] `test/e2e/playwright/prom_metrics.spec.ts` — Playwright
      assertions that a bare histogram name (`http_server_request_duration`)
      surfaces `le` on `/labels` and yields a `_bucket` companion
      series on `/series`, both via Grafana's datasource proxy.
- [x] `go test ./internal/api/prom/` — 238 passing locally.
- [x] CI: `check` + `lint` + `compose-smoke` + `dashboard` —
      observed on the PR.