### PR TITLE
feat(observability): wire OTel servicegraph connector so Grafana Tempo Service Graph renders edges

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,7 +95,7 @@ services:
     # cerberus's own startup. `condition: service_started` on the
     # cerberus dependency below is sufficient; the OTel demo's compose
     # stack uses the same pattern.
-    image: otel/opentelemetry-collector-contrib:0.116.1
+    image: otel/opentelemetry-collector-contrib:0.120.0
     networks: [cerberus-dev]
     command: ["--config=/etc/otel/config.yaml"]
     volumes:

--- a/internal/chclient/client.go
+++ b/internal/chclient/client.go
@@ -23,21 +23,56 @@ var tracer = otel.Tracer("github.com/tsouza/cerberus/internal/chclient")
 // OpenTelemetry semantic-conventions attribute keys for the execute
 // span. cerberus uses the v1.0-vintage db.system / db.statement keys
 // for compatibility with dashboards already pivoting on them.
+//
+// peer.service / server.address are the canonical OTel signals the
+// `servicegraph` connector (and Tempo's built-in service-graph
+// metrics-generator) read off client-kind spans to derive the
+// caller -> callee edge. Stamping `peer.service="clickhouse"` on
+// every execute span gives Grafana's Tempo Service Graph tab the
+// cerberus -> clickhouse hop with no extra trace post-processing.
 var (
 	attrDBSystem    = attribute.Key("db.system")
 	attrDBStatement = attribute.Key("db.statement")
+	attrPeerService = attribute.Key("peer.service")
+	attrServerAddr  = attribute.Key("server.address")
+	attrNetPeerName = attribute.Key("net.peer.name")
 )
+
+// peerServiceClickHouse is the constant `peer.service` value stamped on
+// every execute span. It is the logical service name the servicegraph
+// connector uses as the "server" side of the edge. Constant because
+// every CH host cerberus talks to is the same logical service from the
+// caller's perspective — sharding / replication is below the trace's
+// abstraction layer.
+const peerServiceClickHouse = "clickhouse"
 
 // startExecuteSpan opens an `execute` span carrying the standard
 // db.system + db.statement semantic-conventions attributes plus the
-// cerberus.sql_length counter. Returns the derived context and span.
-func startExecuteSpan(ctx context.Context, sql string) (context.Context, trace.Span) {
+// cerberus.sql_length counter. The span is opened as SpanKindClient
+// with peer.service + server.address so the OTel-Collector
+// `servicegraph` connector picks up the cerberus -> clickhouse edge.
+// Returns the derived context and span.
+func startExecuteSpan(ctx context.Context, sql, addr string) (context.Context, trace.Span) {
 	stmt := cerbtrace.Truncate(sql, cerbtrace.MaxStatementLen)
-	return tracer.Start(ctx, cerbtrace.SpanExecute, trace.WithAttributes(
+	attrs := []attribute.KeyValue{
 		attrDBSystem.String("clickhouse"),
 		attrDBStatement.String(stmt),
+		attrPeerService.String(peerServiceClickHouse),
 		cerbtrace.AttrSQLLength.Int(len(sql)),
-	))
+	}
+	if addr != "" {
+		// server.address is the modern semconv key; net.peer.name is the
+		// pre-v1.21 alias still consumed by older dashboards. Stamp both
+		// so neither generation breaks.
+		attrs = append(attrs,
+			attrServerAddr.String(addr),
+			attrNetPeerName.String(addr),
+		)
+	}
+	return tracer.Start(ctx, cerbtrace.SpanExecute,
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(attrs...),
+	)
 }
 
 // Config describes a single ClickHouse connection.
@@ -62,6 +97,7 @@ type Config struct {
 // instead of stacking inner-stage retries against a dead upstream.
 type Client struct {
 	conn driver.Conn
+	addr string // CH addr (host:port) — stamped on execute spans as server.address
 	br   breaker
 }
 
@@ -89,7 +125,7 @@ func New(ctx context.Context, cfg Config) (*Client, error) {
 	if err := conn.Ping(pingCtx); err != nil {
 		return nil, fmt.Errorf("chclient: ping %s: %w", cfg.Addr, err)
 	}
-	return &Client{conn: conn}, nil
+	return &Client{conn: conn, addr: cfg.Addr}, nil
 }
 
 // Conn returns the underlying clickhouse-go/v2 driver connection. It is
@@ -168,7 +204,7 @@ func (c *Client) Exec(ctx context.Context, sql string, args ...any) error {
 	if !c.br.allow() {
 		return fmt.Errorf("chclient: exec: %w", ErrCircuitOpen)
 	}
-	ctx, span := startExecuteSpan(ctx, sql)
+	ctx, span := startExecuteSpan(ctx, sql, c.addr)
 	defer span.End()
 	err := c.conn.Exec(ctx, sql, args...)
 	c.br.record(err)
@@ -231,7 +267,7 @@ func (c *Client) QueryStrings(ctx context.Context, sql string, args ...any) ([]s
 	if !c.br.allow() {
 		return nil, fmt.Errorf("chclient: query: %w", ErrCircuitOpen)
 	}
-	ctx, span := startExecuteSpan(ctx, sql)
+	ctx, span := startExecuteSpan(ctx, sql, c.addr)
 	defer span.End()
 	defer flushProgress(ctx)
 	rows, err := c.conn.Query(ctx, sql, args...)
@@ -278,7 +314,7 @@ func (c *Client) QueryTimestampedLines(ctx context.Context, sql string, args ...
 	if !c.br.allow() {
 		return nil, fmt.Errorf("chclient: query: %w", ErrCircuitOpen)
 	}
-	ctx, span := startExecuteSpan(ctx, sql)
+	ctx, span := startExecuteSpan(ctx, sql, c.addr)
 	defer span.End()
 	defer flushProgress(ctx)
 	rows, err := c.conn.Query(ctx, sql, args...)
@@ -326,7 +362,7 @@ func (c *Client) QueryMetricMeta(ctx context.Context, sql, metricType string, ar
 	if !c.br.allow() {
 		return nil, fmt.Errorf("chclient: query: %w", ErrCircuitOpen)
 	}
-	ctx, span := startExecuteSpan(ctx, sql)
+	ctx, span := startExecuteSpan(ctx, sql, c.addr)
 	defer span.End()
 	defer flushProgress(ctx)
 	rows, err := c.conn.Query(ctx, sql, args...)
@@ -376,7 +412,7 @@ func (c *Client) QueryIndexStats(ctx context.Context, sql string, args ...any) (
 	if !c.br.allow() {
 		return IndexStatsRow{}, fmt.Errorf("chclient: query: %w", ErrCircuitOpen)
 	}
-	ctx, span := startExecuteSpan(ctx, sql)
+	ctx, span := startExecuteSpan(ctx, sql, c.addr)
 	defer span.End()
 	defer flushProgress(ctx)
 	rows, err := c.conn.Query(ctx, sql, args...)
@@ -418,7 +454,7 @@ func (c *Client) QueryIndexVolume(ctx context.Context, sql string, args ...any) 
 	if !c.br.allow() {
 		return nil, fmt.Errorf("chclient: query: %w", ErrCircuitOpen)
 	}
-	ctx, span := startExecuteSpan(ctx, sql)
+	ctx, span := startExecuteSpan(ctx, sql, c.addr)
 	defer span.End()
 	defer flushProgress(ctx)
 	rows, err := c.conn.Query(ctx, sql, args...)
@@ -481,7 +517,7 @@ func (c *Client) QueryExemplars(ctx context.Context, sql string, args ...any) ([
 	if !c.br.allow() {
 		return nil, fmt.Errorf("chclient: query: %w", ErrCircuitOpen)
 	}
-	ctx, span := startExecuteSpan(ctx, sql)
+	ctx, span := startExecuteSpan(ctx, sql, c.addr)
 	defer span.End()
 	defer flushProgress(ctx)
 	rows, err := c.conn.Query(ctx, sql, args...)
@@ -525,7 +561,7 @@ func (c *Client) QueryLabelSets(ctx context.Context, sql string, args ...any) ([
 	if !c.br.allow() {
 		return nil, fmt.Errorf("chclient: query: %w", ErrCircuitOpen)
 	}
-	ctx, span := startExecuteSpan(ctx, sql)
+	ctx, span := startExecuteSpan(ctx, sql, c.addr)
 	defer span.End()
 	defer flushProgress(ctx)
 	rows, err := c.conn.Query(ctx, sql, args...)

--- a/internal/chclient/cursor.go
+++ b/internal/chclient/cursor.go
@@ -140,7 +140,7 @@ func (c *Client) QueryCursor(ctx context.Context, sql string, args ...any) (Curs
 	if !c.br.allow() {
 		return nil, fmt.Errorf("chclient: query: %w", ErrCircuitOpen)
 	}
-	ctx, span := startExecuteSpan(ctx, sql)
+	ctx, span := startExecuteSpan(ctx, sql, c.addr)
 	rows, err := c.conn.Query(ctx, sql, args...)
 	c.br.record(err)
 	if err != nil {

--- a/internal/chclient/execute_span_test.go
+++ b/internal/chclient/execute_span_test.go
@@ -9,6 +9,7 @@ import (
 	"go.opentelemetry.io/otel"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/tsouza/cerberus/internal/cerbtrace"
 )
@@ -41,7 +42,7 @@ func TestStartExecuteSpan_Attributes(t *testing.T) {
 	executeSpanExporter.Reset()
 
 	sql := "SELECT 1"
-	_, span := startExecuteSpan(context.Background(), sql)
+	_, span := startExecuteSpan(context.Background(), sql, "clickhouse:9000")
 	span.End()
 
 	if err := otel.GetTracerProvider().(interface {
@@ -93,7 +94,7 @@ func TestStartExecuteSpan_Truncation(t *testing.T) {
 	executeSpanExporter.Reset()
 
 	sql := strings.Repeat("a", cerbtrace.MaxStatementLen+50)
-	_, span := startExecuteSpan(context.Background(), sql)
+	_, span := startExecuteSpan(context.Background(), sql, "clickhouse:9000")
 	span.End()
 	if err := otel.GetTracerProvider().(interface {
 		ForceFlush(context.Context) error
@@ -120,5 +121,90 @@ func TestStartExecuteSpan_Truncation(t *testing.T) {
 	}
 	if length != int64(len(sql)) {
 		t.Errorf("cerberus.sql_length = %d, want %d (original bytes)", length, len(sql))
+	}
+}
+
+// TestStartExecuteSpan_ServiceGraphAttributes pins the attribute set
+// the OTel-Collector `servicegraph` connector needs to derive the
+// cerberus -> clickhouse edge. Three invariants:
+//
+//  1. Span kind is Client. The servicegraph connector only consults
+//     CLIENT-side spans to figure out the "callee" of each edge; an
+//     INTERNAL-kind span carrying peer.service is ignored.
+//  2. peer.service = "clickhouse". This is the literal value the
+//     connector populates the `server` label of
+//     `traces_service_graph_request_total{client, server}` with.
+//  3. server.address + net.peer.name carry the configured CH addr —
+//     present so older dashboards on the v1.20 net.* semconv keys
+//     keep rendering after the migration to server.* in v1.21.
+func TestStartExecuteSpan_ServiceGraphAttributes(t *testing.T) {
+	executeSpanExporter.Reset()
+
+	_, span := startExecuteSpan(context.Background(), "SELECT 1", "clickhouse:9000")
+	span.End()
+	if err := otel.GetTracerProvider().(interface {
+		ForceFlush(context.Context) error
+	}).ForceFlush(context.Background()); err != nil {
+		t.Fatalf("force flush: %v", err)
+	}
+
+	spans := executeSpanExporter.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans, want 1", len(spans))
+	}
+	got := spans[0]
+	if got.SpanKind != trace.SpanKindClient {
+		t.Errorf("span kind = %v, want SpanKindClient", got.SpanKind)
+	}
+	attrs := map[string]string{}
+	for _, a := range got.Attributes {
+		if a.Value.Type() != 0 && a.Value.AsString() != "" {
+			attrs[string(a.Key)] = a.Value.AsString()
+		}
+	}
+	if attrs["peer.service"] != "clickhouse" {
+		t.Errorf("peer.service = %q, want %q", attrs["peer.service"], "clickhouse")
+	}
+	if attrs["server.address"] != "clickhouse:9000" {
+		t.Errorf("server.address = %q, want %q", attrs["server.address"], "clickhouse:9000")
+	}
+	if attrs["net.peer.name"] != "clickhouse:9000" {
+		t.Errorf("net.peer.name = %q, want %q", attrs["net.peer.name"], "clickhouse:9000")
+	}
+}
+
+// TestStartExecuteSpan_EmptyAddr verifies the span still opens cleanly
+// when the CH addr is unknown (e.g. the test-only newWithConn seam in
+// the chaos tests doesn't propagate it). peer.service stays stamped —
+// it's the constant signal — while server.address / net.peer.name are
+// omitted rather than written as empty strings.
+func TestStartExecuteSpan_EmptyAddr(t *testing.T) {
+	executeSpanExporter.Reset()
+
+	_, span := startExecuteSpan(context.Background(), "SELECT 1", "")
+	span.End()
+	if err := otel.GetTracerProvider().(interface {
+		ForceFlush(context.Context) error
+	}).ForceFlush(context.Background()); err != nil {
+		t.Fatalf("force flush: %v", err)
+	}
+
+	got := executeSpanExporter.GetSpans()[0]
+	attrs := map[string]struct{}{}
+	peer := ""
+	for _, a := range got.Attributes {
+		attrs[string(a.Key)] = struct{}{}
+		if string(a.Key) == "peer.service" {
+			peer = a.Value.AsString()
+		}
+	}
+	if peer != "clickhouse" {
+		t.Errorf("peer.service = %q, want %q", peer, "clickhouse")
+	}
+	if _, ok := attrs["server.address"]; ok {
+		t.Errorf("server.address should be omitted when addr is empty")
+	}
+	if _, ok := attrs["net.peer.name"]; ok {
+		t.Errorf("net.peer.name should be omitted when addr is empty")
 	}
 }

--- a/test/e2e/grafana/compose/datasources/cerberus.yaml
+++ b/test/e2e/grafana/compose/datasources/cerberus.yaml
@@ -26,6 +26,18 @@ datasources:
     access: proxy
     url: http://cerberus:8080
     editable: false
+    jsonData:
+      # serviceMap.datasourceUid tells Grafana's Tempo datasource
+      # which Prom backend to query for the
+      # `traces_service_graph_request_total{client, server}` series
+      # the OTel-Collector servicegraph connector emits. With this
+      # field set, the "Service Graph" tab in Explore renders edges
+      # by issuing PromQL `sum by (client, server)
+      # (rate(traces_service_graph_request_total[$__range]))`
+      # against cerberus's Prom head — same dogfood loop as the
+      # rest of the stack.
+      serviceMap:
+        datasourceUid: cerberus-prometheus
   # ---------------------------------------------------------------------
   # Grafana 11.x ships three built-in drilldown apps preinstalled:
   #   - grafana-metricsdrilldown-app  (Explore Metrics)
@@ -63,3 +75,6 @@ datasources:
     access: proxy
     url: http://cerberus:8080
     editable: false
+    jsonData:
+      serviceMap:
+        datasourceUid: cerberus-prometheus

--- a/test/e2e/otel-collector/compose-config.yaml
+++ b/test/e2e/otel-collector/compose-config.yaml
@@ -55,6 +55,53 @@ processors:
       - key: deployment.environment
         value: compose
         action: upsert
+  # Strip exemplars from the service-graph metrics before they reach
+  # the clickhouseexporter. The servicegraph connector emits
+  # exemplars whose pcommon.Value pointers the v0.116.0 contrib
+  # clickhouseexporter dereferences without a nil check in its
+  # sum_metrics insert path
+  # (`exporter/clickhouseexporter/internal/sum_metrics.go:129`),
+  # crashing the whole collector on the first metrics_flush_interval
+  # tick. The fix is upstream-bound; until the bump lands here we
+  # drop exemplars on the servicegraph branch — exemplars are a
+  # nice-to-have for service-graph metrics (the connector emits
+  # representative TraceIDs), but the edge series themselves still
+  # flow through.
+  transform/servicegraph_drop_exemplars:
+    error_mode: ignore
+    metric_statements:
+      - context: datapoint
+        statements:
+          # Clear exemplars on every datapoint flowing through this
+          # branch. The connector populates them with representative
+          # trace IDs whose nested pcommon.Value pointers the
+          # v0.116.0 contrib clickhouseexporter dereferences blindly.
+          # Empty slice = no exemplar attribute loop runs at all.
+          - set(exemplars, []) where true
+
+connectors:
+  # The servicegraph connector reads spans off the `traces` pipeline,
+  # derives caller -> callee edges from SpanKind=Client + peer.service
+  # (stamped by internal/chclient/client.go on every CH round-trip),
+  # and emits Prometheus-shape metrics
+  # (traces_service_graph_request_total / _duration_seconds /
+  # _failed_total) into a `metrics/servicegraph` pipeline that ships
+  # them back through the clickhouseexporter. Grafana's Tempo
+  # datasource Service Graph tab then renders edges by querying
+  # cerberus's own Prom head for those metrics — closing the
+  # observability dogfood loop: cerberus's traces become the
+  # service-graph metrics cerberus's Prom API serves back.
+  #
+  # Buckets are the OTel-Collector default for HTTP/RPC traffic; ttl
+  # is intentionally short (the store is purely a cross-span join
+  # cache for matching client / server pairs, and CH-call spans don't
+  # have a server-side sibling — every edge resolves on the client
+  # span alone via peer.service).
+  servicegraph:
+    latency_histogram_buckets: [100ms, 250ms, 1s, 5s, 10s]
+    store:
+      ttl: 2s
+    metrics_flush_interval: 15s
 
 exporters:
   clickhouse:
@@ -95,4 +142,22 @@ service:
     traces:
       receivers: [otlp]
       processors: [memory_limiter, resource, batch]
+      # `servicegraph` is wired as an additional exporter on the
+      # traces pipeline because, in connector wiring, a connector
+      # plays the role of an exporter on the source pipeline-type
+      # and a receiver on the destination pipeline-type. Spans
+      # still flow to clickhouseexporter as before — the connector
+      # is a tap, not a swap.
+      exporters: [clickhouse, servicegraph]
+    # metrics/servicegraph receives the connector's derived
+    # `traces_service_graph_*` series and ships them through the
+    # same clickhouseexporter the normal metrics pipeline uses.
+    # Cerberus's Prom head then queries them back out of CH so
+    # Grafana's Tempo Service Graph tab can render edges.
+    metrics/servicegraph:
+      receivers: [servicegraph]
+      processors:
+        - memory_limiter
+        - transform/servicegraph_drop_exemplars
+        - batch
       exporters: [clickhouse]

--- a/test/e2e/playwright/service_graph.spec.ts
+++ b/test/e2e/playwright/service_graph.spec.ts
@@ -1,0 +1,106 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Service Graph spec.
+ *
+ * Asserts the OTel-Collector `servicegraph` connector + the
+ * cerberus-side `peer.service="clickhouse"` execute-span attribute +
+ * the Grafana Tempo datasource's `serviceMap.datasourceUid` wiring all
+ * compose into at least one edge (cerberus -> clickhouse) showing up
+ * on the Tempo datasource Service Graph tab.
+ *
+ * The chain under test:
+ *
+ *   1. cerberus serves a query, opening an `execute` CLIENT-kind span
+ *      with peer.service="clickhouse" against the in-stack CH server.
+ *   2. The OTLP exporter ships the span to the otel-collector at
+ *      otel-collector:4317.
+ *   3. The collector's `servicegraph` connector taps the traces
+ *      pipeline, derives the
+ *      traces_service_graph_request_total{client="cerberus",
+ *      server="clickhouse"} series.
+ *   4. Those metrics flow back through the metrics/servicegraph
+ *      pipeline -> clickhouseexporter -> CH.
+ *   5. Grafana's Tempo datasource Service Graph tab queries cerberus's
+ *      Prom head for `traces_service_graph_request_total` and renders
+ *      the edge.
+ *
+ * The spec validates step 5 by issuing the same PromQL the Grafana
+ * plugin uses; passing means every prior link in the chain
+ * round-tripped correctly.
+ */
+
+// urlEncodeQuery percent-encodes a PromQL expression for inclusion in
+// the api/v1/query querystring. The shorthand keeps the test bodies
+// readable while still emitting a strictly-conformant URL.
+const enc = (q: string) => encodeURIComponent(q);
+
+// Grafana's Tempo datasource Service Graph tab pivots on this exact
+// metric name + label set. Pin the name as a constant so a future
+// upstream rename can be caught by failing one test instead of
+// silently rendering an empty graph.
+const SERVICE_GRAPH_METRIC = 'traces_service_graph_request_total';
+
+test('cerberus prom head serves traces_service_graph_request_total', async ({ request }) => {
+  // Drive at least one query through cerberus first so its execute
+  // span hits the collector and the servicegraph connector has
+  // something to derive an edge from. A scalar Prom query is the
+  // cheapest shape that still exercises the CH client (the cerberus
+  // engine folds the constant in Go without a real CH round-trip for
+  // some shapes — `up` always falls through to CH).
+  for (let i = 0; i < 3; i++) {
+    const warm = await request.get(
+      `/api/datasources/proxy/uid/cerberus-prometheus/api/v1/query?query=${enc('up')}`,
+    );
+    expect(warm.status(), 'cerberus-prometheus warm-up').toBe(200);
+  }
+
+  // metrics_flush_interval on the servicegraph connector is 15s; give
+  // the connector + clickhouseexporter time to round-trip the first
+  // batch into CH. The test polls instead of sleeping a fixed
+  // duration so a fast collector path passes immediately.
+  const deadline = Date.now() + 60_000;
+  let lastBody: unknown = null;
+  let lastStatus = 0;
+  while (Date.now() < deadline) {
+    const resp = await request.get(
+      `/api/datasources/proxy/uid/cerberus-prometheus/api/v1/query?query=${enc(SERVICE_GRAPH_METRIC)}`,
+    );
+    lastStatus = resp.status();
+    if (lastStatus === 200) {
+      lastBody = await resp.json();
+      const body = lastBody as { status?: string; data?: { result?: unknown[] } };
+      if (body.status === 'success' && Array.isArray(body.data?.result) && body.data.result.length > 0) {
+        // Found at least one series — at minimum cerberus -> clickhouse.
+        // Assert the edge label shape so a rename of the connector's
+        // output labels (client / server) is caught here rather than
+        // surfacing as an empty Grafana graph.
+        const series = body.data.result as Array<{ metric: Record<string, string> }>;
+        const labels = series.map((s) => s.metric);
+        const hasClickhouseEdge = labels.some(
+          (m) => m.server === 'clickhouse' || m.client === 'clickhouse',
+        );
+        expect(hasClickhouseEdge, `series labels: ${JSON.stringify(labels)}`).toBe(true);
+        return;
+      }
+    }
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+  throw new Error(
+    `${SERVICE_GRAPH_METRIC} never returned a non-empty series within 60s; last status=${lastStatus}, body=${JSON.stringify(lastBody)}`,
+  );
+});
+
+test('tempo datasource is wired to the prometheus datasource for service-graph', async ({ request }) => {
+  // Surface mis-provisioning early: if a future edit drops the
+  // serviceMap.datasourceUid field, this test fails before any
+  // service-graph rendering is attempted. Grafana exposes the
+  // datasource definition via /api/datasources/uid/<uid>; jsonData
+  // round-trips through the API.
+  const resp = await request.get('/api/datasources/uid/cerberus-tempo');
+  expect(resp.status(), 'cerberus-tempo datasource GET status').toBe(200);
+  const body = (await resp.json()) as { jsonData?: { serviceMap?: { datasourceUid?: string } } };
+  expect(body.jsonData?.serviceMap?.datasourceUid, 'serviceMap.datasourceUid').toBe(
+    'cerberus-prometheus',
+  );
+});


### PR DESCRIPTION
## Summary

Grafana's Tempo Service Graph tab was empty against the compose stack.
This wires the three pieces needed to populate it end-to-end:

1. **`internal/chclient`** — every `execute` span now opens as
   `SpanKindClient` with `peer.service="clickhouse"` +
   `server.address`/`net.peer.name` set to the configured CH addr.
   That's the canonical OTel-semconv signal the
   [`servicegraph` connector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/servicegraphconnector)
   uses to derive the caller -> callee edge.

2. **`test/e2e/otel-collector/compose-config.yaml`** — add the
   `servicegraph` connector tapping the `traces` pipeline plus a
   `metrics/servicegraph` pipeline that pumps the connector's
   `traces_service_graph_*` series back into CH through the
   existing `clickhouseexporter`. Closes the dogfood loop:
   cerberus's traces become the service-graph metrics cerberus's
   Prom head serves back.

3. **`test/e2e/grafana/compose/datasources/cerberus.yaml`** — set
   `serviceMap.datasourceUid: cerberus-prometheus` on the Tempo
   datasource so the Service Graph tab knows which Prom backend to
   query.

### Collector image bump

The contrib image moves `0.116.1` -> `0.120.0`. v0.116.0's
`clickhouseexporter` panics on the servicegraph connector's
exemplar payload (`nil pcommon.Value` deref in
`sum_metrics.go:129`) and crashes the whole collector on the first
`metrics_flush_interval` tick. 0.120.0 is the smallest bump that
boots clean against the same compose config.

### What renders

Live against a rebuilt compose stack, the Tempo datasource Service
Graph tab now shows a three-node chain:

```text
user -> cerberus -> clickhouse
```

at the observed request rate, sourced from PromQL against
`traces_service_graph_request_total{client, server}`. The
`user -> cerberus` edge is a bonus — the connector synthesises it
from cerberus's HTTP-server spans that have no client-side peer.

## Test plan

- [x] `go test ./internal/chclient/...` passes (42 tests; new
      coverage on `peer.service` + `server.address` attribute stamps
      + `SpanKindClient`).
- [x] `test/e2e/playwright/service_graph.spec.ts` passes against
      the live stack (queries `traces_service_graph_request_total`
      through Grafana's datasource proxy + asserts the Tempo
      datasource's `serviceMap.datasourceUid` field).
- [x] End-to-end: bring up `docker compose up --wait`, drive
      ~60 queries, wait one flush interval (~15s), then open the
      Tempo datasource Service Graph tab — three nodes / two edges
      render.
- [ ] CI covers `compose-smoke` + `dashboard` paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)