### PR TITLE
fix(e2e/k3d): mirror tempo serviceMap.datasourceUid onto k3d grafana ConfigMap

### DIFF
--- a/test/e2e/k3s/grafana.yaml
+++ b/test/e2e/k3s/grafana.yaml
@@ -29,6 +29,18 @@ data:
         access: proxy
         url: http://cerberus:8080
         editable: false
+        jsonData:
+          # serviceMap.datasourceUid tells Grafana's Tempo datasource
+          # which Prom backend to query for the
+          # `traces_service_graph_request_total{client, server}` series
+          # the OTel-Collector servicegraph connector emits. With this
+          # field set, the "Service Graph" tab in Explore renders edges
+          # by issuing PromQL `sum by (client, server)
+          # (rate(traces_service_graph_request_total[$__range]))`
+          # against cerberus's Prom head — same dogfood loop as the
+          # rest of the stack.
+          serviceMap:
+            datasourceUid: cerberus-prometheus
       # Aliases for Grafana 11.x built-in drilldown apps. Each app's
       # factory defaults reference Grafana Cloud's canonical
       # `grafanacloud-{metrics,logs,traces}` UIDs; without those
@@ -57,6 +69,9 @@ data:
         access: proxy
         url: http://cerberus:8080
         editable: false
+        jsonData:
+          serviceMap:
+            datasourceUid: cerberus-prometheus
 ---
 apiVersion: v1
 kind: Service

--- a/test/regression/k3s_tempo_servicemap_test.go
+++ b/test/regression/k3s_tempo_servicemap_test.go
@@ -1,0 +1,115 @@
+package regression
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestK3sTempoDatasourcesCarryServiceMapDatasourceUID guards against the
+// post-#700 regression behind workflow run 26287654251 (e2e dashboard job
+// 77379658293, on push-to-main commit 006f160e). PR #700 wired the
+// "Service Graph" tab in Grafana's Tempo Explore by adding
+// `jsonData.serviceMap.datasourceUid: cerberus-prometheus` to the COMPOSE
+// Tempo datasource (test/e2e/grafana/compose/datasources/cerberus.yaml)
+// — but the k3d ConfigMap mirror at test/e2e/k3s/grafana.yaml was not
+// updated. The Playwright `service_graph.spec.ts:103` smoke pings
+// `/api/datasources/uid/cerberus-tempo` on the k3d-deployed Grafana and
+// expects `body.jsonData.serviceMap.datasourceUid === 'cerberus-prometheus'`;
+// against the un-mirrored ConfigMap it sees `undefined` and the dashboard
+// job fails on every push-to-main run.
+//
+// This test pins the k3d ConfigMap's Tempo datasource entries (both the
+// `cerberus-tempo` primary and the `grafanacloud-traces` alias) to carry
+// the same `serviceMap.datasourceUid: cerberus-prometheus` block as the
+// compose source-of-truth. Catches: any future drop / rename / typo of
+// the field in the k3d manifest — the kind of drift that the compose
+// stack's live smoke can't see because it doesn't load this file.
+//
+// The check parses the ConfigMap's `datasources.yaml` payload rather
+// than grepping the raw YAML, so YAML key reorderings, comment edits or
+// alias-anchor refactors don't false-positive.
+func TestK3sTempoDatasourcesCarryServiceMapDatasourceUID(t *testing.T) {
+	t.Parallel()
+
+	buf, err := os.ReadFile("../e2e/k3s/grafana.yaml")
+	if err != nil {
+		t.Fatalf("read k3s grafana.yaml: %v", err)
+	}
+
+	// The file is a multi-doc YAML (ConfigMap + Service + Deployment).
+	// Walk every doc, find the one whose `metadata.name` is
+	// `grafana-datasources`, then parse its `data["datasources.yaml"]`
+	// inner payload.
+	dec := yaml.NewDecoder(strings.NewReader(string(buf)))
+
+	type k8sObj struct {
+		Kind     string `yaml:"kind"`
+		Metadata struct {
+			Name string `yaml:"name"`
+		} `yaml:"metadata"`
+		Data map[string]string `yaml:"data"`
+	}
+
+	var inner string
+	for {
+		var obj k8sObj
+		if err := dec.Decode(&obj); err != nil {
+			break
+		}
+		if obj.Kind == "ConfigMap" && obj.Metadata.Name == "grafana-datasources" {
+			inner = obj.Data["datasources.yaml"]
+			break
+		}
+	}
+	if inner == "" {
+		t.Fatalf("test/e2e/k3s/grafana.yaml: no `grafana-datasources` ConfigMap with `data[\"datasources.yaml\"]` payload found — the file shape changed; update this regression test alongside the manifest")
+	}
+
+	type datasource struct {
+		Name     string `yaml:"name"`
+		UID      string `yaml:"uid"`
+		Type     string `yaml:"type"`
+		JSONData struct {
+			ServiceMap struct {
+				DatasourceUID string `yaml:"datasourceUid"`
+			} `yaml:"serviceMap"`
+		} `yaml:"jsonData"`
+	}
+	type provisioning struct {
+		APIVersion  int          `yaml:"apiVersion"`
+		Datasources []datasource `yaml:"datasources"`
+	}
+
+	var prov provisioning
+	if err := yaml.Unmarshal([]byte(inner), &prov); err != nil {
+		t.Fatalf("parse datasources.yaml payload: %v", err)
+	}
+
+	// Every `type: tempo` datasource must carry the serviceMap
+	// wiring — the k3d ConfigMap mirrors compose, which sets it on
+	// both the primary `cerberus-tempo` entry and the
+	// `grafanacloud-traces` drilldown alias.
+	const want = "cerberus-prometheus"
+	tempoEntries := 0
+	for _, ds := range prov.Datasources {
+		if ds.Type != "tempo" {
+			continue
+		}
+		tempoEntries++
+		if ds.JSONData.ServiceMap.DatasourceUID != want {
+			t.Errorf(
+				"test/e2e/k3s/grafana.yaml: tempo datasource %q (uid=%q) has jsonData.serviceMap.datasourceUid=%q, want %q — Playwright service_graph.spec.ts:103 fails against the k3d-deployed Grafana without this field",
+				ds.Name, ds.UID, ds.JSONData.ServiceMap.DatasourceUID, want,
+			)
+		}
+	}
+	if tempoEntries == 0 {
+		t.Fatalf("test/e2e/k3s/grafana.yaml: no `type: tempo` datasource entries — the cerberus-tempo + grafanacloud-traces entries were removed; the dashboard smoke expects both")
+	}
+	if tempoEntries < 2 {
+		t.Errorf("test/e2e/k3s/grafana.yaml: found %d tempo datasource(s), expected at least 2 (cerberus-tempo primary + grafanacloud-traces alias) — mirror of test/e2e/grafana/compose/datasources/cerberus.yaml drifted", tempoEntries)
+	}
+}


### PR DESCRIPTION
## Summary

- PR #700 added `jsonData.serviceMap.datasourceUid: cerberus-prometheus` to the compose Tempo datasource provisioning (`test/e2e/grafana/compose/datasources/cerberus.yaml`) so the "Service Graph" tab in Explore renders edges from the OTel-Collector servicegraph connector's `traces_service_graph_request_total` series.
- The k3d ConfigMap mirror at `test/e2e/k3s/grafana.yaml` was not updated in the same PR. Playwright `service_graph.spec.ts:103` asserts `jsonData.serviceMap.datasourceUid === 'cerberus-prometheus'` against the k3d-deployed Grafana; it saw `undefined` and the dashboard smoke regressed on every push-to-main run starting with 006f160e (failing job 77379658293 / workflow run 26287654251).
- Apply the same `jsonData.serviceMap.datasourceUid: cerberus-prometheus` block to both tempo entries in the k3d ConfigMap — the primary `cerberus-tempo` datasource and the `grafanacloud-traces` drilldown alias — matching the compose source-of-truth verbatim.
- Pin the mirror with `test/regression/k3s_tempo_servicemap_test.go`: parses the ConfigMap's inner `datasources.yaml`, walks every `type: tempo` entry, and asserts each carries the wiring. Structural YAML decode (not regex), so future re-orderings or comment edits don't false-positive.

## Test plan

- [ ] CI: `check`, `lint`, `forbid-skip`, `compatibility/{prometheus,loki,tempo}`, `probe`, `roundtrip *`, `compose-smoke` all green.
- [ ] CI: new regression test `TestK3sTempoDatasourcesCarryServiceMapDatasourceUID` passes inside the `test/regression` package.
- [ ] After merge: push-to-main `dashboard` job (`.github/workflows/e2e.yml`) goes back to green — Playwright `service_graph.spec.ts:103` observes `jsonData.serviceMap.datasourceUid === 'cerberus-prometheus'` against the k3d Grafana.

Generated with Claude Code.