### PR TITLE
fix(e2e/k3s): mirror servicegraph connector + image bump from compose to k3d collector

### DIFF
--- a/test/e2e/k3s/otel-collector.yaml
+++ b/test/e2e/k3s/otel-collector.yaml
@@ -113,6 +113,53 @@ data:
           - key: k8s.cluster.name
             value: cerberus-e2e
             action: upsert
+      # Strip exemplars from the service-graph metrics before they reach
+      # the clickhouseexporter. The servicegraph connector emits
+      # exemplars whose pcommon.Value pointers the v0.116.0 contrib
+      # clickhouseexporter dereferences without a nil check in its
+      # sum_metrics insert path
+      # (`exporter/clickhouseexporter/internal/sum_metrics.go:129`),
+      # crashing the whole collector on the first metrics_flush_interval
+      # tick. The fix is upstream-bound; until the bump lands here we
+      # drop exemplars on the servicegraph branch — exemplars are a
+      # nice-to-have for service-graph metrics (the connector emits
+      # representative TraceIDs), but the edge series themselves still
+      # flow through.
+      transform/servicegraph_drop_exemplars:
+        error_mode: ignore
+        metric_statements:
+          - context: datapoint
+            statements:
+              # Clear exemplars on every datapoint flowing through this
+              # branch. The connector populates them with representative
+              # trace IDs whose nested pcommon.Value pointers the
+              # v0.116.0 contrib clickhouseexporter dereferences blindly.
+              # Empty slice = no exemplar attribute loop runs at all.
+              - set(exemplars, []) where true
+
+    connectors:
+      # The servicegraph connector reads spans off the `traces` pipeline,
+      # derives caller -> callee edges from SpanKind=Client + peer.service
+      # (stamped by internal/chclient/client.go on every CH round-trip),
+      # and emits Prometheus-shape metrics
+      # (traces_service_graph_request_total / _duration_seconds /
+      # _failed_total) into a `metrics/servicegraph` pipeline that ships
+      # them back through the clickhouseexporter. Grafana's Tempo
+      # datasource Service Graph tab then renders edges by querying
+      # cerberus's own Prom head for those metrics — closing the
+      # observability dogfood loop on the k3d cluster the same way the
+      # compose stack does (see test/e2e/otel-collector/compose-config.yaml).
+      #
+      # Buckets are the OTel-Collector default for HTTP/RPC traffic; ttl
+      # is intentionally short (the store is purely a cross-span join
+      # cache for matching client / server pairs, and CH-call spans don't
+      # have a server-side sibling — every edge resolves on the client
+      # span alone via peer.service).
+      servicegraph:
+        latency_histogram_buckets: [100ms, 250ms, 1s, 5s, 10s]
+        store:
+          ttl: 2s
+        metrics_flush_interval: 15s
 
     exporters:
       clickhouse:
@@ -152,6 +199,24 @@ data:
         traces:
           receivers: [otlp]
           processors: [memory_limiter, resource, batch]
+          # `servicegraph` is wired as an additional exporter on the
+          # traces pipeline because, in connector wiring, a connector
+          # plays the role of an exporter on the source pipeline-type
+          # and a receiver on the destination pipeline-type. Spans
+          # still flow to clickhouseexporter as before — the connector
+          # is a tap, not a swap.
+          exporters: [clickhouse, servicegraph]
+        # metrics/servicegraph receives the connector's derived
+        # `traces_service_graph_*` series and ships them through the
+        # same clickhouseexporter the normal metrics pipeline uses.
+        # Cerberus's Prom head then queries them back out of CH so
+        # Grafana's Tempo Service Graph tab can render edges.
+        metrics/servicegraph:
+          receivers: [servicegraph]
+          processors:
+            - memory_limiter
+            - transform/servicegraph_drop_exemplars
+            - batch
           exporters: [clickhouse]
 ---
 # Agent collector config (per-node DaemonSet):
@@ -302,7 +367,13 @@ spec:
       serviceAccountName: otel-collector
       containers:
         - name: collector
-          image: otel/opentelemetry-collector-contrib:0.116.1
+          # 0.120.0 mirrors the compose stack (docker-compose.yml). v0.116.1
+          # ships a clickhouseexporter that nil-derefs on the servicegraph
+          # connector's exemplar payload (sum_metrics.go:129); 0.120.0 is
+          # the smallest bump that boots clean against the same config and
+          # is the floor for the servicegraph + transform/servicegraph_drop_exemplars
+          # branch added above.
+          image: otel/opentelemetry-collector-contrib:0.120.0
           args: ["--config=/etc/otel/config.yaml"]
           ports:
             - name: otlp-grpc
@@ -359,7 +430,9 @@ spec:
       hostNetwork: false
       containers:
         - name: collector
-          image: otel/opentelemetry-collector-contrib:0.116.1
+          # Pinned to the same 0.120.0 tag as the gateway above to keep
+          # the agent / gateway pair on a matching contrib release.
+          image: otel/opentelemetry-collector-contrib:0.120.0
           args: ["--config=/etc/otel/config.yaml"]
           env:
             - name: K8S_NODE_NAME

--- a/test/regression/k3s_tempo_servicemap_test.go
+++ b/test/regression/k3s_tempo_servicemap_test.go
@@ -113,3 +113,144 @@ func TestK3sTempoDatasourcesCarryServiceMapDatasourceUID(t *testing.T) {
 		t.Errorf("test/e2e/k3s/grafana.yaml: found %d tempo datasource(s), expected at least 2 (cerberus-tempo primary + grafanacloud-traces alias) — mirror of test/e2e/grafana/compose/datasources/cerberus.yaml drifted", tempoEntries)
 	}
 }
+
+// TestK3sOtelCollectorGatewayCarriesServiceGraphConnector guards against the
+// post-#702 regression behind workflow run 26289535170 (e2e dashboard job
+// 77385760886, on push-to-main commit e98e3103). PR #700 added the
+// `servicegraph` connector + `metrics/servicegraph` pipeline to the COMPOSE
+// collector config (test/e2e/otel-collector/compose-config.yaml) and PR #702
+// wired Grafana's Tempo datasource to query the resulting metrics — but the
+// k3d gateway ConfigMap at test/e2e/k3s/otel-collector.yaml was not updated.
+// The Playwright `service_graph.spec.ts:44` test drives a warm-up query
+// through cerberus, then polls cerberus's Prom head for
+// `traces_service_graph_request_total`; without the connector on the k3d
+// collector the metric never lands in ClickHouse and the test times out at
+// 60s.
+//
+// This test pins the k3d gateway's collector config to carry:
+//   - a `connectors.servicegraph` block,
+//   - the `servicegraph` exporter on the `traces` pipeline (alongside
+//     `clickhouse`),
+//   - a `metrics/servicegraph` pipeline receiving from `servicegraph` and
+//     routing through `transform/servicegraph_drop_exemplars` into the
+//     `clickhouse` exporter (the transform processor is required because
+//     the v0.116.0 clickhouseexporter nil-derefs on the connector's
+//     exemplar payload; the same trap re-appears any time the contrib
+//     image is downgraded).
+//
+// Parses the ConfigMap's `config.yaml` payload rather than grepping the
+// raw YAML so reorderings / comment edits don't false-positive.
+func TestK3sOtelCollectorGatewayCarriesServiceGraphConnector(t *testing.T) {
+	t.Parallel()
+
+	buf, err := os.ReadFile("../e2e/k3s/otel-collector.yaml")
+	if err != nil {
+		t.Fatalf("read k3s otel-collector.yaml: %v", err)
+	}
+
+	dec := yaml.NewDecoder(strings.NewReader(string(buf)))
+
+	type k8sObj struct {
+		Kind     string `yaml:"kind"`
+		Metadata struct {
+			Name string `yaml:"name"`
+		} `yaml:"metadata"`
+		Data map[string]string `yaml:"data"`
+	}
+
+	var inner string
+	for {
+		var obj k8sObj
+		if err := dec.Decode(&obj); err != nil {
+			break
+		}
+		if obj.Kind == "ConfigMap" && obj.Metadata.Name == "otel-collector-gateway-config" {
+			inner = obj.Data["config.yaml"]
+			break
+		}
+	}
+	if inner == "" {
+		t.Fatalf("test/e2e/k3s/otel-collector.yaml: no `otel-collector-gateway-config` ConfigMap with `data[\"config.yaml\"]` payload found — the file shape changed; update this regression test alongside the manifest")
+	}
+
+	type pipeline struct {
+		Receivers  []string `yaml:"receivers"`
+		Processors []string `yaml:"processors"`
+		Exporters  []string `yaml:"exporters"`
+	}
+	type service struct {
+		Pipelines map[string]pipeline `yaml:"pipelines"`
+	}
+	type collector struct {
+		Connectors map[string]map[string]any `yaml:"connectors"`
+		Processors map[string]map[string]any `yaml:"processors"`
+		Service    service                   `yaml:"service"`
+	}
+
+	var cfg collector
+	if err := yaml.Unmarshal([]byte(inner), &cfg); err != nil {
+		t.Fatalf("parse otel-collector gateway config payload: %v", err)
+	}
+
+	if _, ok := cfg.Connectors["servicegraph"]; !ok {
+		t.Errorf(
+			"test/e2e/k3s/otel-collector.yaml: gateway ConfigMap is missing `connectors.servicegraph` — Playwright service_graph.spec.ts:44 polls cerberus's Prom head for `traces_service_graph_request_total` and times out at 60s without the connector emitting the metric",
+		)
+	}
+	if _, ok := cfg.Processors["transform/servicegraph_drop_exemplars"]; !ok {
+		t.Errorf(
+			"test/e2e/k3s/otel-collector.yaml: gateway ConfigMap is missing `processors.transform/servicegraph_drop_exemplars` — required to strip the servicegraph connector's exemplar payload before it hits the clickhouseexporter (otherwise the collector crashes on the first metrics_flush_interval tick)",
+		)
+	}
+
+	traces, ok := cfg.Service.Pipelines["traces"]
+	if !ok {
+		t.Fatalf("test/e2e/k3s/otel-collector.yaml: gateway ConfigMap has no `service.pipelines.traces` — the traces pipeline was renamed or removed; the dashboard smoke expects it")
+	}
+	if !contains(traces.Exporters, "servicegraph") {
+		t.Errorf(
+			"test/e2e/k3s/otel-collector.yaml: `service.pipelines.traces.exporters` = %v, missing `servicegraph` — the connector must tap the traces pipeline to derive caller/callee edges from CH-call spans",
+			traces.Exporters,
+		)
+	}
+	if !contains(traces.Exporters, "clickhouse") {
+		t.Errorf(
+			"test/e2e/k3s/otel-collector.yaml: `service.pipelines.traces.exporters` = %v, missing `clickhouse` — the connector must coexist with the regular CH writer; the servicegraph wiring is a tap, not a swap",
+			traces.Exporters,
+		)
+	}
+
+	sg, ok := cfg.Service.Pipelines["metrics/servicegraph"]
+	if !ok {
+		t.Fatalf(
+			"test/e2e/k3s/otel-collector.yaml: gateway ConfigMap is missing the `service.pipelines.metrics/servicegraph` pipeline — without it the connector's `traces_service_graph_*` series never reach ClickHouse and cerberus's Prom head returns an empty result, timing out service_graph.spec.ts:44",
+		)
+	}
+	if !contains(sg.Receivers, "servicegraph") {
+		t.Errorf(
+			"test/e2e/k3s/otel-collector.yaml: `metrics/servicegraph.receivers` = %v, must include `servicegraph` — that's the connector wired as the receiver side of the destination pipeline",
+			sg.Receivers,
+		)
+	}
+	if !contains(sg.Processors, "transform/servicegraph_drop_exemplars") {
+		t.Errorf(
+			"test/e2e/k3s/otel-collector.yaml: `metrics/servicegraph.processors` = %v, must include `transform/servicegraph_drop_exemplars` — exemplar stripping must run on this branch before the payload reaches clickhouseexporter",
+			sg.Processors,
+		)
+	}
+	if !contains(sg.Exporters, "clickhouse") {
+		t.Errorf(
+			"test/e2e/k3s/otel-collector.yaml: `metrics/servicegraph.exporters` = %v, must include `clickhouse` — the derived metrics must round-trip into the same CH `otel_metrics_*` tables cerberus's Prom head queries back",
+			sg.Exporters,
+		)
+	}
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Fixes the post-#702 dashboard e2e regression. PR #700 added the OTel
servicegraph connector + `metrics/servicegraph` pipeline to the
**compose** collector config and bumped the contrib image to `0.120.0`
to dodge the v0.116.0 clickhouseexporter exemplar nil-deref. The k3d
gateway ConfigMap at `test/e2e/k3s/otel-collector.yaml` was not
updated in lock-step, so on push-to-main `e98e3103` the dashboard job
(workflow run [26289535170](https://github.com/tsouza/cerberus/actions/runs/26289535170),
job 77385760886) timed out on `service_graph.spec.ts:44` — cerberus's
Prom head returned an empty result for `traces_service_graph_request_total`
because the metric never left the k3d collector.

## Changes

- `test/e2e/k3s/otel-collector.yaml` — mirrors the compose
  source-of-truth into the gateway ConfigMap:
  - `connectors.servicegraph` block (same `latency_histogram_buckets`,
    2s `store.ttl`, 15s `metrics_flush_interval`).
  - `processors.transform/servicegraph_drop_exemplars` clearing
    exemplars so the clickhouseexporter doesn't nil-deref.
  - `service.pipelines.traces.exporters` becomes
    `[clickhouse, servicegraph]` (connector tapped, not swapped).
  - New `service.pipelines.metrics/servicegraph` routes the connector
    output through the drop-exemplars transform into the
    `clickhouse` exporter.
  - Both gateway + agent collector images bumped from `0.116.1` to
    `0.120.0` (gateway needs the panic fix; agent follows for
    release-pair consistency).
- `test/regression/k3s_tempo_servicemap_test.go` — new test
  `TestK3sOtelCollectorGatewayCarriesServiceGraphConnector` parses
  the gateway ConfigMap's nested `config.yaml` payload and pins the
  presence of the `servicegraph` connector, the
  `transform/servicegraph_drop_exemplars` processor, the traces
  pipeline's `[clickhouse, servicegraph]` exporters, and the
  `metrics/servicegraph` pipeline's receiver / processors / exporter
  shape. Catches any future drop / rename of these pieces before
  it surfaces as a 60s Playwright timeout.

## Verification

- YAML parses clean (round-tripped through `yaml.safe_load_all`) with
  the expected connector + pipeline shape.
- Regression test asserts every load-bearing field; the same shape
  the compose stack proved live in #700.
- CI's `dashboard` job (informational on PRs, gating on push-to-main)
  re-runs `service_graph.spec.ts:44` against the patched k3d cluster.

## Test plan

- [x] `connectors.servicegraph` present in gateway ConfigMap
- [x] `processors.transform/servicegraph_drop_exemplars` present
- [x] `traces` pipeline exports to `[clickhouse, servicegraph]`
- [x] `metrics/servicegraph` pipeline routes through drop-exemplars
  and exports to `clickhouse`
- [x] Collector image bumped to `0.120.0` (matches compose stack)
- [x] Regression test pins all of the above