### PR TITLE
ci(compose-smoke): bump job timeout 15m → 30m for iterate-* specs

### DIFF
--- a/.github/workflows/compose-smoke.yml
+++ b/.github/workflows/compose-smoke.yml
@@ -93,7 +93,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
Iterate-* specs added by PR #698 push compose-smoke runtime past 15 min on first run (docker build + stack startup + 12 min Playwright suite). Job was hitting GitHub's timeout-minutes ceiling and getting cancelled mid-flight — not a flake.

Bumped to 30m to give comfortable headroom.