### PR TITLE
build(compat): make Dockerfile.local go mod download resilient to proxy.golang.org HTTP/2 flakes

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -8,9 +8,37 @@
 FROM golang:1.26 AS build
 WORKDIR /src
 COPY go.mod go.sum ./
-RUN go mod download
+# `go mod download` occasionally fails with a transient
+# `proxy.golang.org` HTTP/2 `stream error ... INTERNAL_ERROR; received
+# from peer` mid-stream (observed on compatibility/loki run
+# 26306912141 against `grpc-ecosystem/grpc-gateway/v2`). The Go module
+# resolver does not retry past that frame — it surfaces the error and
+# exits non-zero, taking the whole compat job with it. Wrap the fetch
+# in a bounded retry loop so a single bad TCP frame from the public
+# proxy can't take down a compat run, and mount BuildKit caches for
+# `/go/pkg/mod` + `/root/.cache/go-build` so warm runners skip the
+# fetch entirely on subsequent builds. The `,sharing=locked` is
+# required because the three compat harnesses (prom/loki/tempo) build
+# this same Dockerfile in parallel on the same runner via separate
+# `docker compose build` invocations.
+RUN --mount=type=cache,target=/go/pkg/mod,sharing=locked \
+    --mount=type=cache,target=/root/.cache/go-build,sharing=locked \
+    set -eu; \
+    for attempt in 1 2 3 4 5; do \
+        if go mod download; then \
+            break; \
+        fi; \
+        if [ "$attempt" = "5" ]; then \
+            echo "go mod download failed after 5 attempts" >&2; \
+            exit 1; \
+        fi; \
+        echo "go mod download attempt $attempt failed, retrying after backoff" >&2; \
+        sleep $(( attempt * 3 )); \
+    done
 COPY . .
-RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w -X main.Version=e2e" -o /out/cerberus ./cmd/cerberus
+RUN --mount=type=cache,target=/go/pkg/mod,sharing=locked \
+    --mount=type=cache,target=/root/.cache/go-build,sharing=locked \
+    CGO_ENABLED=0 go build -trimpath -ldflags="-s -w -X main.Version=e2e" -o /out/cerberus ./cmd/cerberus
 
 FROM gcr.io/distroless/static-debian12:nonroot
 


### PR DESCRIPTION
## Summary

PR #708's `compatibility/loki` job (run 26306912141, job 77445902857)
failed before the harness ever ran:

```
#15 22.88 go: github.com/grpc-ecosystem/grpc-gateway/v2@v2.29.0: read
"https://proxy.golang.org/.../grpc-gateway/v2/@v/v2.29.0.zip":
stream error: stream ID 2015; INTERNAL_ERROR; received from peer
#15 ERROR: process "/bin/sh -c go mod download" did not complete successfully: exit code: 1
```

Not seed-settle (prior fixes #66 / #123 / #136 covered that). The
cerberus image build inside the compat compose stack tripped on a
transient `proxy.golang.org` HTTP/2 stream error during
`RUN go mod download` in `Dockerfile.local`. The Go module resolver
does not retry past a bad HTTP/2 frame, so it fails the whole compat
job.

All three compatibility harnesses (prom/loki/tempo) build cerberus
from this same Dockerfile via their `docker-compose.yml`. The fix is
structural and applies to every head — loki was just the unlucky one
this run.

## Fix

Two changes to `Dockerfile.local`:

1. **Retry loop** around `go mod download` — 5 attempts with linear
   backoff (3/6/9/12s). Surfaces the failure only if all 5 frames
   trip.
2. **BuildKit cache mounts** for `/go/pkg/mod` and
   `/root/.cache/go-build` (`sharing=locked` because the three compat
   harnesses build this Dockerfile in parallel on the same runner).
   Warm runners skip the proxy entirely on subsequent builds, so the
   first-build surface is the only one a future flake can hit.

Mandate compliance: no timeout bump, no rerun-and-pray. The retry is
inside the build at the network layer (where the flake actually is),
not inside the harness at the seed-settle layer.

## Test plan

- [ ] `compatibility/loki` green
- [ ] `compatibility/prometheus` green (same Dockerfile — confirms no regression)
- [ ] `compatibility/tempo` green (ditto)
- [ ] `compose-smoke` green (also builds Dockerfile.local indirectly)