### PR TITLE
ci(forbid-skip): document the canonical regex set + self-test harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,3 +289,12 @@ jobs:
         run: |
           scripts/check-skip-additions.sh --self-test
           scripts/check-skip-additions.sh
+      # Regex self-test for the gate above. Every pattern documented in
+      # docs/forbid-skip.md has a canonical match-example and a
+      # counter-example; this step asserts the regexes still classify
+      # both correctly. When a future PR widens or normalises the
+      # gate, update docs/forbid-skip.md AND scripts/test-forbid-skip.sh
+      # in the same change.
+      - name: Self-test forbid-skip regex set
+        run: |
+          scripts/test-forbid-skip.sh

--- a/docs/forbid-skip.md
+++ b/docs/forbid-skip.md
@@ -1,0 +1,244 @@
+# `forbid-skip` — canonical pattern reference
+
+The `forbid-skip` CI gate (and its `lefthook.yml` pre-push mirror) is the
+machine-enforced arm of cerberus's GA test-discipline rule: **no `t.Skip`,
+no "not implemented", no "skipped" or "deferred" wording, no soft
+assertions, no silent panic recovery, no untracked `should_skip` overlay
+entries.**
+
+The gate grew iteratively — six PRs widened it as new offenders escaped
+prior regex shapes. This document is the canonical, frozen reference for
+the full pattern set so future widenings start from a known baseline
+instead of re-deriving from CI failure tickers.
+
+## Where the patterns live
+
+The patterns run in **two places**, and the two MUST stay in sync:
+
+1. `.github/workflows/ci.yml` job `forbid-skip` — required status check
+   on `main`.
+2. `lefthook.yml` `pre-push` hook — local-mirror of the same gate so a
+   push that would have failed CI fails locally first.
+
+`scripts/test-forbid-skip.sh` is the assertion that the regexes still
+match their canonical positive examples and still reject the matching
+counter-examples below. It runs both as a standalone unit-test (invoke
+the script directly) and as a step inside the `forbid-skip` CI job. The
+lefthook `forbid-skip-self-test` command runs the same script on
+pre-push.
+
+The two locations carry **identical** patterns for rows 1–6 of the
+summary table below. Row 7 (`should_skip:` overlay tracking-ref guard)
+is CI-only because it needs a diff against `origin/main` to identify
+net-new entries — locally that base-ref isn't always meaningful, and
+the CI gate is the authoritative pre-merge backstop.
+
+## Adding a new pattern
+
+When a new offender shape is discovered:
+
+1. Add the new regex to **both** `.github/workflows/ci.yml` and
+   `lefthook.yml` in the same PR.
+2. Add a new row to the summary table below + a detailed subsection
+   covering the regex, its intent, a match-example, and a
+   counter-example.
+3. Add a matching `case_N_*` block to `scripts/test-forbid-skip.sh`
+   covering both directions.
+4. Note the originating PR number.
+
+Never weaken an existing regex without a recorded rationale — every
+widening so far traces back to a real offender that escaped a narrower
+shape.
+
+## Summary
+
+| #   | Intent                                                                                                      | Scope                                                           | Origin        |
+| --- | ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- | ------------- |
+| 1   | Reject `t.Skip[fN]?` calls                                                                                  | `*_test.go`                                                     | #309          |
+| 2   | Reject bare "not implemented" / "skipped" / "deferred" wording                                              | `*_test.go` + `*.txtar`                                         | #461          |
+| 3   | Reject "not implemented" wording in production code                                                         | `internal/**/*.go` (non-test)                                   | #197          |
+| 4   | Reject `assert.Contains(x, "")` soft assertion                                                              | `*_test.go`                                                     | #587          |
+| 5   | Reject `assert.ElementsMatch(x, []T{})` soft assertion                                                      | `*_test.go`                                                     | #587          |
+| 6   | Reject silent panic recovery (`defer recover()` and the multi-line `defer func(){ _ = recover() }()` block) | `*_test.go`                                                     | #587 / #648   |
+| 7   | Reject net-new `should_skip:` overlay entries lacking a tracking ref                                        | overlay YAML in `OVERLAY_FILES`                                 | #596          |
+
+Vendored upstream snapshots under `compatibility/*/upstream/**` are
+excluded from every test-file / fixture grep — they sit outside
+cerberus's authorship boundary.
+
+## Pattern 1 — `t.Skip[fN]?` (PR #309)
+
+Regex: `t\.Skip[fN]?\(`
+
+PR #309 wired this gate. Before #309 the maintainer noticed `t.Skip`
+calls accumulating in test files as a way to mark known-broken tests
+as "we'll fix it later." The bug never got fixed. The skip lingered.
+The discipline rule became "fix the bug or delete the test, no
+skipping" — and the regex is the enforcement.
+
+`[fN]?` covers all three call shapes (`t.Skip`, `t.Skipf`, `t.SkipNow`)
+in one alternation. The literal `(` anchors against accidental matches
+on identifiers.
+
+- Matches: `func TestFoo(t *testing.T) { t.Skip("upstream bug") }`
+- Does NOT match: `func TestFoo(t *testing.T) { tx.Skipper() }` (different
+  receiver / method name)
+
+## Pattern 2 — bare discipline-erosion wording (PR #461)
+
+Regex: `not implemented` \| `\bskipped\b` \| `\bdeferred\b`
+
+PR #309 caught only `t.Skip*` calls — but English wording like "not
+implemented yet" / "deferred to RC3" / "skipped because foo" in
+comments and TXTAR fixtures was just as much a discipline smell.
+PR #458 first added a phrase-pattern regex (`deferred to`, `not yet
+supported`, etc.); PR #461 widened to bare words because the
+phrase-only shape kept missing new offenders.
+
+The bare-word shape does produce some apparent false positives — Go
+has the `defer` keyword, mock packages have `Skipper` types — which
+is why the gate scope is narrow (`*_test.go` + `*.txtar`) and why the
+remedy is "rewrite to a neutral verb (dropped / excluded / rejected /
+bypassed)" rather than "delete the comment."
+
+- Matches: `// not implemented yet`, `var skipped = 0`,
+  `// deferred until RC3`
+- Does NOT match: `// dropped because of foo`, `defer cleanup()` (the
+  Go `defer` keyword, distinct from the word "deferred")
+
+## Pattern 3 — "not implemented" in production code (PR #197)
+
+Regex: `not implemented`
+
+PR #197 scrubbed `not implemented` from `internal/**.go` and added the
+gate so it stays scrubbed. Bare `skipped` / `deferred` are NOT in the
+production gate — `defer` statements described in docstrings would
+false-positive, and runtime prose like "request X is rejected" is the
+correct rewrite of "skipped" rather than something to forbid.
+
+- Matches: `return errors.New("not implemented")`
+- Does NOT match: `return errUnsupported // rejects unsupported foo`
+
+## Pattern 4 — `assert.Contains(x, "")` soft assertion (PR #587)
+
+Regex: `assert\.Contains\([^,]+,\s*""\s*\)`
+
+PR #587 added this. The trigger was a sweep that uncovered
+`assert.Contains(body, "")` calls — they pass any input, look like
+real assertions in reviews, but verify nothing.
+
+The regex uses `[^,]+` to clamp the haystack-argument match inside a
+single function call (so it doesn't reach into adjacent calls), and
+`\s*""\s*` to allow optional whitespace around the empty needle.
+
+**Known scope limitation:** the `[^,]+,` clause requires exactly one
+comma between haystack and needle, so the regex catches the 2-arg
+gocheck-style call but not the testify 3-arg call
+(`assert.Contains(t, haystack, "")`). Widening to the testify form is
+a deliberate future change — listed as a follow-up rather than rolled
+into this normalisation pass so the behaviour of the gate stays
+byte-identical to its previous shape.
+
+- Matches: `assert.Contains(body, "")`
+- Does NOT match: `assert.Contains(body, "error: foo")`
+
+## Pattern 5 — `assert.ElementsMatch(x, []T{})` soft assertion (PR #587)
+
+Regex: `assert\.ElementsMatch\([^,]+,\s*\[\][^)]*\{\s*\}\s*\)`
+
+Sibling of pattern 4. Same regex shape (`[^,]+,` clamp + empty-needle
+match) targeting `ElementsMatch` against an empty slice literal. Same
+known scope limitation as pattern 4 — catches 2-arg gocheck-style
+calls but not the testify 3-arg form.
+
+- Matches: `assert.ElementsMatch(got, []string{})`
+- Does NOT match: `assert.ElementsMatch(got, []string{"a", "b"})`
+
+## Pattern 6 — silent panic recovery (PR #587 / #648)
+
+Regex (perl-slurp form):
+`defer\s+recover\s*\(\s*\)` \| `defer\s+func\s*\(\s*\)\s*\{[^{}]*_\s*=\s*recover\s*\(\s*\)`
+
+PR #587 added the single-line `defer recover()` and the same-line
+`defer func() { _ = recover() }()`. PR #648 widened to the
+multi-line variant via a `perl -0777` slurp because reviewers found
+the original regex missed `defer func() {\n  _ = recover()\n}()`.
+
+The `[^{}]*` clamp keeps the multi-line match inside a single brace
+level so it doesn't over-reach. The `_\s*=\s*recover` discriminator
+distinguishes a silent swallow from the legitimate
+`r := recover(); if r == nil { t.Fatal(...) }` asserted-panic form
+used in real tests.
+
+- Matches (bare): `defer recover()`
+- Matches (multi-line):
+
+  ```go
+  defer func() {
+    _ = recover()
+  }()
+  ```
+
+- Does NOT match (asserted-panic form):
+
+  ```go
+  defer func() {
+    r := recover()
+    if r == nil { t.Fatal("expected panic") }
+  }()
+  ```
+
+## Pattern 7 — `should_skip:` overlay tracking-ref guard (PR #596)
+
+Regex: not a single line of regex; delegated to
+`scripts/check-skip-additions.sh`, which diffs the overlay against
+`origin/main` and requires every net-new `should_skip:` entry to carry
+one of: a non-empty `jira:` value, a `link:` field, or a `#NNN` GitHub
+PR / issue reference inside `reason:`.
+
+PR #596 added this after PRs #429 and #537 added `should_skip:` rows
+to silence failing Loki compat cases without fixing the underlying
+bug. Two of those skip-PRs stayed merged for weeks before someone
+wired the real fix.
+
+The guard script has a `--self-test` mode that the CI step runs first.
+`scripts/test-forbid-skip.sh` delegates to that self-test as its
+case 7 assertion.
+
+- Matches (net-new entry, no tracking ref):
+
+  ```yaml
+  - source: "fast/example.yaml#bad-entry"
+    reason: "no tracking ref"
+    since: "2026-05-20"
+  ```
+
+- Does NOT match (net-new entry with inline ref):
+
+  ```yaml
+  - source: "fast/example.yaml#good-entry"
+    reason: "tracked via #450"
+    since: "2026-05-20"
+  ```
+
+## Redundancy review (2026-05-22)
+
+A read-through of the seven patterns shows no strict redundancies —
+each catches a shape the others would miss:
+
+- Patterns 2 and 3 both look at `not implemented`, but pattern 2 only
+  inspects `*_test.go` + `*.txtar` while pattern 3 only inspects
+  `internal/**/*.go` (excluding the test files). Together they cover
+  the codebase without double-counting.
+- Patterns 4 and 5 both target soft-assertion shapes, but they match
+  different `assert.*` calls (`Contains` vs `ElementsMatch`). A single
+  combined alternation would work but the two-regex shape keeps the
+  error message specific.
+- Pattern 6 has two alternatives in a single regex (bare `defer
+  recover()` vs the multi-line block). They cannot be merged with
+  patterns 4 / 5 because pattern 6 needs the `perl -0777` slurp to
+  span lines.
+
+The gate's total pattern count after this documentation pass: **7**
+(unchanged — this PR documents the existing set rather than altering
+behaviour).

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -97,6 +97,13 @@ pre-push:
       run: |
         base=$(git merge-base HEAD origin/main 2>/dev/null || echo origin/main)
         npx --no -- commitlint --from "$base" --to HEAD
+    # Mirrors the `Self-test forbid-skip regex set` CI step. Runs the
+    # canonical match / no-match assertions documented in
+    # docs/forbid-skip.md against the regex set shared with the CI gate.
+    forbid-skip-self-test:
+      tags: discipline
+      run: |
+        scripts/test-forbid-skip.sh
     forbid-soft-assert:
       tags: discipline
       run: |

--- a/scripts/test-forbid-skip.sh
+++ b/scripts/test-forbid-skip.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+#
+# test-forbid-skip.sh — assertion harness for the `forbid-skip` regex
+# set documented in docs/forbid-skip.md.
+#
+# Each pattern in that doc has a canonical match-example and a
+# canonical no-match counter-example. This script writes both into a
+# scratch directory and runs the exact regex shape used by
+# .github/workflows/ci.yml + lefthook.yml against them, asserting that
+# match-examples MATCH and counter-examples do NOT.
+#
+# Invocation:
+#   scripts/test-forbid-skip.sh           # run all cases, exit 0 on green
+#   scripts/test-forbid-skip.sh --verbose # print every case decision
+#
+# Wired into CI as a step inside the `forbid-skip` job. Also runs from
+# lefthook's pre-push hook via the `forbid-skip-self-test` command.
+#
+# When adding a new pattern: update docs/forbid-skip.md AND add a
+# `case_N_*` block below. The two MUST stay in lockstep.
+
+set -euo pipefail
+
+VERBOSE=0
+if [[ "${1:-}" == "--verbose" ]]; then
+  VERBOSE=1
+fi
+
+passes=0
+failures=0
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+note() {
+  if [[ $VERBOSE -eq 1 ]]; then
+    printf '  %s\n' "$1"
+  fi
+}
+
+# expect_match <label> <regex> <fixture-file>
+expect_match() {
+  local label="$1" regex="$2" file="$3"
+  if grep -nE -- "$regex" "$file" >/dev/null; then
+    note "PASS  match  $label"
+    passes=$((passes + 1))
+  else
+    printf 'FAIL  match  %s — regex %q did not match %s\n' "$label" "$regex" "$file" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+# expect_no_match <label> <regex> <fixture-file>
+expect_no_match() {
+  local label="$1" regex="$2" file="$3"
+  if grep -nE -- "$regex" "$file" >/dev/null; then
+    printf 'FAIL  reject %s — regex %q false-matched %s\n' "$label" "$regex" "$file" >&2
+    failures=$((failures + 1))
+  else
+    note "PASS  reject $label"
+    passes=$((passes + 1))
+  fi
+}
+
+# expect_match_perl / expect_no_match_perl — same idea, but using the
+# perl -0777 slurp shape from the CI step (pattern 6).
+expect_match_perl() {
+  local label="$1" regex="$2" file="$3"
+  if perl -0777 -ne 'exit !/'"$regex"'/' <"$file"; then
+    note "PASS  match  $label (perl)"
+    passes=$((passes + 1))
+  else
+    printf 'FAIL  match  %s (perl) — regex did not match %s\n' "$label" "$file" >&2
+    failures=$((failures + 1))
+  fi
+}
+expect_no_match_perl() {
+  local label="$1" regex="$2" file="$3"
+  if perl -0777 -ne 'exit !/'"$regex"'/' <"$file"; then
+    printf 'FAIL  reject %s (perl) — regex false-matched %s\n' "$label" "$file" >&2
+    failures=$((failures + 1))
+  else
+    note "PASS  reject $label (perl)"
+    passes=$((passes + 1))
+  fi
+}
+
+# --------------------------------------------------------------------
+# case 1 — t.Skip / t.Skipf / t.SkipNow  (PR #309)
+# --------------------------------------------------------------------
+RE1='t\.Skip[fN]?\('
+printf 'func TestFoo(t *testing.T) { t.Skip("upstream bug") }\n' >"$tmpdir/case1_match.txt"
+printf 'func TestFoo(t *testing.T) { tx.Skipper() }\n'           >"$tmpdir/case1_nomatch.txt"
+expect_match    "case1 t.Skip"        "$RE1" "$tmpdir/case1_match.txt"
+expect_no_match "case1 tx.Skipper()"  "$RE1" "$tmpdir/case1_nomatch.txt"
+
+# --------------------------------------------------------------------
+# case 2 — bare discipline-erosion wording  (PR #461)
+# --------------------------------------------------------------------
+RE2='not implemented|\bskipped\b|\bdeferred\b'
+{
+  printf '// not implemented yet\n'
+  printf 'var skipped = 0\n'
+  printf '// deferred until RC3\n'
+} >"$tmpdir/case2_match.txt"
+{
+  printf '// dropped because of foo\n'
+  printf 'defer cleanup()\n'
+  printf 'rejection := errReject\n'
+} >"$tmpdir/case2_nomatch.txt"
+expect_match    "case2 bare wording"            "$RE2" "$tmpdir/case2_match.txt"
+expect_no_match "case2 neutral verbs + defer kw" "$RE2" "$tmpdir/case2_nomatch.txt"
+
+# --------------------------------------------------------------------
+# case 3 — "not implemented" in production code  (PR #197)
+# --------------------------------------------------------------------
+RE3='not implemented'
+printf 'return errors.New("not implemented")\n' >"$tmpdir/case3_match.txt"
+printf 'return errUnsupported // rejects unsupported foo\n' >"$tmpdir/case3_nomatch.txt"
+expect_match    "case3 not-implemented prod"  "$RE3" "$tmpdir/case3_match.txt"
+expect_no_match "case3 factual verb"          "$RE3" "$tmpdir/case3_nomatch.txt"
+
+# --------------------------------------------------------------------
+# case 4 — assert.Contains(x, "")  (PR #587)
+# --------------------------------------------------------------------
+# NB: the regex's `[^,]+,` clause requires exactly one comma between
+# haystack and needle, so it matches the 2-arg gocheck-style call
+# (`assert.Contains(haystack, "")`) but not the testify 3-arg
+# `assert.Contains(t, haystack, "")` form. See docs/forbid-skip.md
+# § "Known scope limitation".
+RE4='assert\.Contains\([^,]+,\s*""\s*\)'
+printf 'assert.Contains(body, "")\n'           >"$tmpdir/case4_match.txt"
+printf 'assert.Contains(body, "error: foo")\n' >"$tmpdir/case4_nomatch.txt"
+expect_match    "case4 empty-needle Contains"   "$RE4" "$tmpdir/case4_match.txt"
+expect_no_match "case4 real-needle Contains"    "$RE4" "$tmpdir/case4_nomatch.txt"
+
+# --------------------------------------------------------------------
+# case 5 — assert.ElementsMatch(x, []T{})  (PR #587)
+# --------------------------------------------------------------------
+# Same 2-arg gocheck-style scope limitation as case4.
+RE5='assert\.ElementsMatch\([^,]+,\s*\[\][^)]*\{\s*\}\s*\)'
+printf 'assert.ElementsMatch(got, []string{})\n'        >"$tmpdir/case5_match.txt"
+printf 'assert.ElementsMatch(got, []string{"a", "b"})\n' >"$tmpdir/case5_nomatch.txt"
+expect_match    "case5 empty-slice ElementsMatch" "$RE5" "$tmpdir/case5_match.txt"
+expect_no_match "case5 populated ElementsMatch"   "$RE5" "$tmpdir/case5_nomatch.txt"
+
+# --------------------------------------------------------------------
+# case 6 — silent panic recovery, both shapes  (PR #587 / #648)
+# --------------------------------------------------------------------
+RE6='defer\s+recover\s*\(\s*\)|defer\s+func\s*\(\s*\)\s*\{[^{}]*_\s*=\s*recover\s*\(\s*\)'
+# 6a — bare `defer recover()`
+printf 'defer recover()\n' >"$tmpdir/case6a_match.txt"
+expect_match_perl "case6a bare-defer-recover" "$RE6" "$tmpdir/case6a_match.txt"
+# 6b — multi-line `defer func() { _ = recover() }()`
+{
+  printf 'defer func() {\n'
+  printf '  _ = recover()\n'
+  printf '}()\n'
+} >"$tmpdir/case6b_match.txt"
+expect_match_perl "case6b multi-line silent recover" "$RE6" "$tmpdir/case6b_match.txt"
+# 6c — asserted-panic form MUST NOT match
+{
+  printf 'defer func() {\n'
+  printf '  r := recover()\n'
+  printf '  if r == nil { t.Fatal("expected panic") }\n'
+  printf '}()\n'
+} >"$tmpdir/case6c_nomatch.txt"
+expect_no_match_perl "case6c asserted-panic form" "$RE6" "$tmpdir/case6c_nomatch.txt"
+
+# --------------------------------------------------------------------
+# case 7 — should_skip overlay tracking-ref guard  (PR #596)
+#
+# Delegated to check-skip-additions.sh --self-test, which runs the
+# same inspect_block routine the CI gate uses against four canned
+# YAML cases (missing ref → reject, jira populated → accept,
+# inline #NNN ref → accept, empty jira → reject).
+# --------------------------------------------------------------------
+repo_root="$(git rev-parse --show-toplevel)"
+if "$repo_root/scripts/check-skip-additions.sh" --self-test >/dev/null; then
+  note "PASS  case7 should_skip tracking-ref guard"
+  passes=$((passes + 1))
+else
+  printf 'FAIL  case7 check-skip-additions.sh --self-test failed\n' >&2
+  failures=$((failures + 1))
+fi
+
+# --------------------------------------------------------------------
+# summary
+# --------------------------------------------------------------------
+total=$((passes + failures))
+if [[ $failures -gt 0 ]]; then
+  printf '\nforbid-skip regex tests: %d/%d FAILED\n' "$failures" "$total" >&2
+  exit 1
+fi
+printf 'forbid-skip regex tests: %d/%d OK\n' "$passes" "$total"


### PR DESCRIPTION
## Summary

Promotes the iteratively-widened `forbid-skip` gate (PRs #309 → #458 → #461 → #587 → #648, plus the `should_skip` overlay guard in #596) to a stable, documented regex set with a regression-style self-test.

Per [`docs/dirty-fixes-audit-full-history-2026-05-22`](https://github.com/tsouza/cerberus/blob/main/CLAUDE.md) Recommendation #11. Each widening shipped without a written record of the full set or canonical positive / negative examples, so successive widenings re-derived the shape from CI failure tickers.

## Changes

- `docs/forbid-skip.md` — new. Summary table of 7 patterns + a per-pattern subsection covering the regex, intent, scope, originating PR, matching example, and counter-example. Explains why the patterns live in both `ci.yml` and `lefthook.yml`, why row 7 is CI-only, and how to add a new pattern.
- `scripts/test-forbid-skip.sh` — new. Asserts every regex still classifies its canonical match-example as a match and its counter-example as a no-match. 14 test cases total (one per pattern row plus three sub-cases for pattern 6 covering both shapes and the asserted-panic counter-example, plus delegation to `scripts/check-skip-additions.sh --self-test` for pattern 7).
- `.github/workflows/ci.yml` — wire `scripts/test-forbid-skip.sh` as a new step inside the existing `forbid-skip` job.
- `lefthook.yml` — wire the same script as a new `forbid-skip-self-test` pre-push command so the regression assertion runs locally too.

No regex behaviour changes — same 7 patterns before and after this PR. The doc calls out one known scope limitation (patterns 4 + 5's `[^,]+,` clause matches the 2-arg gocheck-style call but not the testify 3-arg form) so the next widening has a starting point; that widening is deliberately deferred to a separate PR rather than rolled into this normalisation pass.

## Pattern count

- Before this PR: 7 patterns (1 t.Skip, 2 bare-wording tests, 3 not-implemented prod, 4 + 5 soft-assert, 6 silent-recover, 7 should_skip overlay).
- After this PR: 7 patterns (unchanged). No redundancies — each pattern catches a shape the others would miss; see the "Redundancy review" section in the new doc.

## Test plan

- [x] `scripts/test-forbid-skip.sh --verbose` exits 0 with `14/14 OK` on the worktree.
- [x] `scripts/check-skip-additions.sh --self-test` exits 0 with `4/4 cases passed` (transitively asserted by case 7).
- [x] `markdownlint-cli2 docs/forbid-skip.md` clean.
- [x] None of the new files trip the gate itself (test script lives in `scripts/`, doc lives in `docs/` — both outside the `*_test.go` / `*.txtar` / `internal/**/*.go` globs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)