### PR TITLE
perf(format): memoise PromLabelToOTelCandidates powerset (~17x per-call speedup)

### DIFF
--- a/internal/api/format/export_test.go
+++ b/internal/api/format/export_test.go
@@ -1,0 +1,15 @@
+package format
+
+// ComputePromLabelCandidatesForTest exposes the cold-path powerset walk
+// so benchmarks can measure the "no cache" baseline directly without
+// touching the [PromLabelToOTelCandidates] memo. Test-only export —
+// production callers always go through the cached entry point.
+func ComputePromLabelCandidatesForTest(s string) []string {
+	if s == "" {
+		return []string{""}
+	}
+	if len(s) >= 2 && s[0] == '_' && s[1] == '_' {
+		return []string{s}
+	}
+	return computePromLabelCandidates(s)
+}

--- a/internal/api/format/format_bench_test.go
+++ b/internal/api/format/format_bench_test.go
@@ -41,6 +41,65 @@ func BenchmarkCanonicalKey_Large(b *testing.B) {
 	}
 }
 
+// BenchmarkPromLabelToOTelCandidates_Cached measures the steady-state
+// cost of resolving a Prom label to its OTel candidate set after the
+// powerset cache has warmed. Representative of every `sum by (X)` /
+// `{foo_bar=~...}` matcher path, where the same label name (`service_name`,
+// `cerberus_ql`, `http_request_method`) recurs across every query. The
+// hot path is a single `sync.Map.Load` returning a pre-computed slice;
+// regressions here mean someone moved work back onto the per-call path.
+func BenchmarkPromLabelToOTelCandidates_Cached(b *testing.B) {
+	// 3 internal underscores → 8-candidate powerset. Pre-warm the cache.
+	const name = "http_request_method"
+	_ = format.PromLabelToOTelCandidates(name)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = format.PromLabelToOTelCandidates(name)
+	}
+}
+
+// BenchmarkPromLabelToOTelCandidates_Uncached measures the powerset
+// fan-out cost when the cache is bypassed — equivalent to the per-call
+// cost the codebase paid before PR #696. Forms the "before" leg of the
+// before/after delta against [BenchmarkPromLabelToOTelCandidates_Cached].
+// Same 3-underscore input shape so the comparison is apples-to-apples.
+func BenchmarkPromLabelToOTelCandidates_Uncached(b *testing.B) {
+	const name = "http_request_method"
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = format.ComputePromLabelCandidatesForTest(name)
+	}
+}
+
+// BenchmarkPromLabelToOTelCandidates_SumByQuery models the realistic
+// `sum by (X)` hot path: a single query lowers ~5–10 matchers, each
+// with a label name like `cerberus_ql` / `http_request_method` /
+// `service_name`. With the cache, every call after the first becomes a
+// `sync.Map.Load`; without it, every call pays the full powerset walk.
+func BenchmarkPromLabelToOTelCandidates_SumByQuery(b *testing.B) {
+	names := []string{
+		"service_name",
+		"cerberus_ql",
+		"http_request_method",
+		"http_response_status_code",
+		"network_protocol_version",
+		"server_address",
+	}
+	// Warm the cache once.
+	for _, n := range names {
+		_ = format.PromLabelToOTelCandidates(n)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, n := range names {
+			_ = format.PromLabelToOTelCandidates(n)
+		}
+	}
+}
+
 // TestAllocs_CanonicalKey pins the alloc count of CanonicalKey at the
 // per-row hot-path scale. The function builds a sorted []string of
 // keys + a []byte buffer for the output — two allocs of expected

--- a/internal/api/format/otelname.go
+++ b/internal/api/format/otelname.go
@@ -3,7 +3,37 @@ package format
 import (
 	"sort"
 	"strings"
+	"sync"
 )
+
+// promLabelCandidateCache memoises [PromLabelToOTelCandidates] keyed by
+// the verbatim input label. The same Prom-grammar names recur across
+// every PromQL / LogQL matcher in every query the gateway serves
+// (`service_name`, `cerberus_ql`, `http_request_method`, ...), and the
+// powerset walk is the same pure function of the input every time. A
+// per-input memo collapses the 64-candidate fan-out cost (allocate a
+// 64-entry slice, walk `2^k` masks, copy + sort) to one `sync.Map`
+// lookup on every call after the first.
+//
+// `sync.Map` is the right shape for this workload: writes happen once
+// per distinct label (effectively at startup as queries warm the
+// cache), reads happen every matcher in every query. The read path is
+// lock-free in the common case where the entry is already populated.
+// The cache holds `[]string` values directly — they are read-only by
+// contract (callers may not mutate the returned slice; the existing
+// callers iterate without modifying).
+//
+// Unknown labels (first encounter) still pay the powerset cost once,
+// then become O(1) afterwards. There is no eviction — the label
+// universe is bounded by what Grafana panels reference, which is in
+// the low hundreds even for large deployments.
+//
+// The gate function [PromLabelNeedsDottedFallback] runs first in every
+// caller (it short-circuits names that have no rewritable underscore),
+// so the cache only ever populates entries for labels that actually
+// need the powerset walk. Names like `job` / `__name__` never reach
+// the cache.
+var promLabelCandidateCache sync.Map // map[string][]string
 
 // PromLabelToOTelCandidates returns the list of OTel-attribute-key
 // candidates a Prom matcher name `s` could resolve to inside CH-stored
@@ -56,6 +86,27 @@ func PromLabelToOTelCandidates(s string) []string {
 	if strings.HasPrefix(s, "__") {
 		return []string{s}
 	}
+	// Fast path: lock-free cache hit. Same input label appears across
+	// every matcher in every query the gateway serves; computing the
+	// powerset once per distinct input is the only call we ever want
+	// to make to the slow path below.
+	if cached, ok := promLabelCandidateCache.Load(s); ok {
+		return cached.([]string)
+	}
+	out := computePromLabelCandidates(s)
+	// LoadOrStore lets concurrent first-encounters race without
+	// holding a lock; the loser's slice is discarded by GC. The
+	// candidates slice is read-only by contract — callers iterate.
+	actual, _ := promLabelCandidateCache.LoadOrStore(s, out)
+	return actual.([]string)
+}
+
+// computePromLabelCandidates is the cold path that produces the
+// powerset of dotted re-expansions for `s`. Factored out of
+// [PromLabelToOTelCandidates] so the fast path stays a single
+// `sync.Map.Load`. Callers must take the cache miss path; the cache
+// itself is managed by [PromLabelToOTelCandidates].
+func computePromLabelCandidates(s string) []string {
 	// Strip a single leading underscore from the "rewritable" set:
 	// Prom's leading-underscore is a grammar marker (`_1invalid` from
 	// `1invalid`) and never originated as a dotted segment.

--- a/internal/api/format/otelname_test.go
+++ b/internal/api/format/otelname_test.go
@@ -269,6 +269,30 @@ func TestPromLabelToOTelCandidatesCap(t *testing.T) {
 	}
 }
 
+// TestPromLabelToOTelCandidatesCached pins the memoisation contract:
+// repeated calls with the same input return the same slice (identity,
+// not just deep-equal) so callers can rely on the cache amortising the
+// powerset walk. Unknown-on-first-call labels still resolve correctly
+// through the cold path — the cache is a fast-path overlay, never a
+// gate. The "identity" check uses a tiny indirection trick: take the
+// slice header of each call and compare the underlying data pointer.
+func TestPromLabelToOTelCandidatesCached(t *testing.T) {
+	// A label the cache has likely never seen — uniqueness rules out
+	// test-order coupling with the powerset / fallback tests above.
+	const novel = "cerberus_cache_probe_label"
+	a := format.PromLabelToOTelCandidates(novel)
+	b := format.PromLabelToOTelCandidates(novel)
+	if !reflect.DeepEqual(a, b) {
+		t.Fatalf("repeated calls returned different content: %v vs %v", a, b)
+	}
+	// Identity check: cached slices must share the same backing array.
+	// `&a[0] == &b[0]` is the canonical "is this the same slice header
+	// payload" probe.
+	if len(a) > 0 && len(b) > 0 && &a[0] != &b[0] {
+		t.Fatalf("cache returned a freshly-allocated slice on repeat: pointers differ")
+	}
+}
+
 // TestPromLabelNeedsDottedFallback pins the gate function that
 // lowering paths use to short-circuit single-key emission when no
 // rewrite is possible. The "fast path" stays a plain MapAccess for


### PR DESCRIPTION
## Summary

The PromQL / LogQL matcher-lowering hot path called `format.PromLabelToOTelCandidates(name)` once per matcher per query. Each call recomputed the same powerset over the same input — up to 64 candidates (2^6 internal underscores) — for the same handful of names that recur across every panel: `service_name`, `cerberus_ql`, `http_request_method`, `http_response_status_code`, `network_protocol_version`, etc. Five cascade PRs (#207 / #214 / #215 / #246 / #247) wired the same expansion through repeatedly without ever caching the result.

This PR adds a `sync.Map`-backed memo keyed on the verbatim input label. First-encounter calls still pay the powerset walk; every subsequent call returns the cached slice via a lock-free `sync.Map.Load`. The candidate-slice contract is read-only by spec (existing callers iterate), so sharing the slice between goroutines is safe.

## Benchmark delta

Measured on Intel i7-10510U @ 1.80GHz with `go test -bench='BenchmarkPromLabelToOTelCandidates' -benchmem`:

```
before (no cache):  274.7 ns/op, 136 B/op, 4 allocs/op
after  (warm hit):   16.4 ns/op,   0 B/op, 0 allocs/op   ~17x speedup
sum-by-6-labels:    103.7 ns/op,   0 B/op, 0 allocs/op   (6 lookups in a realistic `sum by (X)` shape)
```

Three benchmarks land in `format_bench_test.go` for future regression detection:

- `BenchmarkPromLabelToOTelCandidates_Cached` — steady-state warm-cache cost.
- `BenchmarkPromLabelToOTelCandidates_Uncached` — cold-path baseline via a test-only `ComputePromLabelCandidatesForTest` export so the "before" leg is reproducible in-tree.
- `BenchmarkPromLabelToOTelCandidates_SumByQuery` — realistic 6-label `sum by (X)` matcher set.

## Fallback path

Unknown labels (first encounter) still resolve correctly. The cache is a fast-path overlay, never a gate — `computePromLabelCandidates` (the same powerset walker that lived inside `PromLabelToOTelCandidates` before) is unchanged and runs on every cache miss. The 6-internal-underscore cap fallback (verbatim + all-dots) survives because it lives inside `computePromLabelCandidates`. The existing test suite (`TestPromLabelToOTelCandidates`, `TestPromLabelToOTelCandidatesCap`, `TestPromLabelNeedsDottedFallback`) plus a new `TestPromLabelToOTelCandidatesCached` (identity-check that repeated calls return the same backing slice) all pass.

## LOC delta

- `internal/api/format/otelname.go` +51 (cache var + comment + entry-point split into fast/cold path).
- `internal/api/format/otelname_test.go` +24 (cache identity test).
- `internal/api/format/format_bench_test.go` +59 (three benchmarks).
- `internal/api/format/export_test.go` +15 (test-only cold-path export for the "before" benchmark leg).

No production callers changed — the optimisation is transparent.

## Test plan

- [x] `go test ./internal/api/format/ ./internal/promql/ ./internal/logql/ ./internal/api/prom/ ./internal/api/loki/` — 1783 tests pass.
- [x] Benchmark numbers reproducible via `go test -bench='BenchmarkPromLabelToOTelCandidates' -benchmem -run=^$ ./internal/api/format/`.
- [ ] CI required checks: `check`, `lint`, `forbid-skip`, `compatibility/{prometheus,loki,tempo}`, `probe`, `roundtrip (promql,logql,traceql)`, `compose-smoke`.