### PR TITLE
fix(compatibility/tempo): roll seed anchor with wall-clock; drop ingestion slack from 1y to 1h

### DIFF
--- a/compatibility/tempo/driver/corpus/smoke.txtar
+++ b/compatibility/tempo/driver/corpus/smoke.txtar
@@ -23,8 +23,9 @@
 #     trace.index=<idx>
 #   * Span attrs (child): child.index, kind
 #   * Status: Ok (default), Error for every 5th child
-#   * Anchor: 2026-05-11T00:00:00Z; each trace shifted by (svcIdx*25 +
-#     traceIdx) seconds — last trace lands ~400s after anchor
+#   * Anchor: rolling — recomputed per run as `now() - 5m` (see
+#     driver/seeder.go::currentAnchor). Each trace shifted by (svcIdx*25 +
+#     traceIdx) seconds — last trace lands ~400s after anchor.
 #
 # Diff strategy reminder (see differ.go top-of-file):
 #   * Trace IDs are canonicalised via H(rootServiceName||rootTraceName)

--- a/compatibility/tempo/driver/diff.go
+++ b/compatibility/tempo/driver/diff.go
@@ -59,7 +59,7 @@ func runDiff(args []string) error {
 		overall     = fs.Duration("timeout", 5*time.Minute, "overall driver timeout")
 		perReq      = fs.Duration("request-timeout", 30*time.Second, "per-HTTP-request timeout")
 		searchLimit = fs.Int("search-limit", 200, "Tempo /api/search ?limit= value")
-		anchorIn    = fs.String("anchor", anchor, "fixture anchor RFC3339; used to compute search start/end window")
+		anchorIn    = fs.String("anchor", "", "fixture anchor RFC3339 override; empty means roll the anchor to (now - anchorOffset), matching the seeder")
 		efPath      = fs.String("expected-failures", envOr("EXPECTED_FAILURES", ""), "path to expected-failures JSON; cases listed there are flagged in the markdown report but still count as parity diffs in the compat-score JSON")
 	)
 	if err := fs.Parse(args); err != nil {
@@ -95,13 +95,27 @@ func runDiff(args []string) error {
 	}
 	logger.Info("loaded corpus", "path", *corpusPath, "cases", len(cases))
 
-	anchorTS, err := time.Parse(time.RFC3339, *anchorIn)
-	if err != nil {
-		return fmt.Errorf("parse anchor %q: %w", *anchorIn, err)
+	// If --anchor is empty, recompute the rolling anchor here. The
+	// differ runs as a separate process from the seeder (see
+	// scripts/run-tempo-compatibility.sh) so each phase picks its own
+	// `now()` — the ±1h search window below absorbs the typically <60s
+	// drift between them. Pass --anchor explicitly only when re-running
+	// the differ standalone against a stack seeded earlier.
+	var anchorTS time.Time
+	if *anchorIn == "" {
+		anchorTS = currentAnchor()
+	} else {
+		parsed, err := time.Parse(time.RFC3339, *anchorIn)
+		if err != nil {
+			return fmt.Errorf("parse anchor %q: %w", *anchorIn, err)
+		}
+		anchorTS = parsed
 	}
 	// Search window: one hour either side of the anchor. The seeder
 	// pushes traces at anchor + (svcIdx*25 + traceIdx) seconds, so the
-	// last span lands at anchor + ~400s; ±1h is generous slack.
+	// last span lands at anchor + ~400s; ±1h is generous slack and also
+	// covers the inter-process drift between the seeder's and differ's
+	// independent currentAnchor() readings.
 	startTS := anchorTS.Add(-1 * time.Hour)
 	endTS := anchorTS.Add(1 * time.Hour)
 

--- a/compatibility/tempo/driver/seeder.go
+++ b/compatibility/tempo/driver/seeder.go
@@ -3,9 +3,11 @@
 // What this file does, end to end:
 //
 //  1. Build a deterministic in-memory fixture of traces (4 services ×
-//     25 traces × 3-5 spans).  All trace IDs / span IDs / timestamps /
-//     attributes are derived from a fixed anchor + indices so re-running
-//     the seeder against fresh backends produces byte-identical content.
+//     25 traces × 3-5 spans). Trace IDs / span IDs / attributes are
+//     index-derived and byte-stable across runs; timestamps roll with
+//     wall-clock (anchor = now() - anchorOffset, see currentAnchor) so
+//     the live store's ingestion-time-range slack doesn't need to grow
+//     unboundedly as the codebase ages.
 //  2. Push the fixture into the reference Tempo via OTLP gRPC :4317.
 //  3. Insert the fixture into ClickHouse `otel_traces` (the read path
 //     cerberus uses to answer Tempo HTTP queries). Cerberus is read-only
@@ -66,10 +68,30 @@ import (
 	"github.com/tsouza/cerberus/internal/schema/ddl"
 )
 
-// anchor pins the fixture's first span timestamp. Mirrors the anchor
-// used by the prom + loki harness seeders so all three datasets land
-// in the same wall-clock window when re-running compatibility locally.
-const anchor = "2026-05-11T00:00:00Z"
+// anchorOffset is how far in the past the seeder anchors the fixture's
+// first span timestamp. The anchor is recomputed on every invocation as
+// `time.Now().UTC().Truncate(time.Second) - anchorOffset` so the live
+// store's `wal.ingestion_time_range_slack` (default 2m, harness-set to
+// 1h for safety) doesn't have to grow unboundedly as the codebase ages.
+// 5m is comfortably inside the harness slack and large enough that the
+// fixture's last span (anchor + ~400s) still lands well before "now".
+//
+// Previously this was a fixed point ("2026-05-11T00:00:00Z") shared with
+// the prom + loki seeders. That meant the live store needed an ever-
+// growing slack (PR #501 set it to 1 year) to keep accepting spans that
+// drifted further from wall-clock with every passing day. The prom +
+// loki seeders insert directly into ClickHouse and aren't affected by
+// Tempo's ingestion clamping, so they can keep the fixed anchor.
+const anchorOffset = 5 * time.Minute
+
+// currentAnchor returns the rolling fixture anchor. Called once per
+// `seed` / `diff` invocation; both phases compute their own and use it
+// independently — the differ's ±1h search window absorbs the small drift
+// (typically <60s) between the seeder's anchor and the differ's anchor
+// when they run back-to-back from the harness script.
+func currentAnchor() time.Time {
+	return time.Now().UTC().Truncate(time.Second).Add(-anchorOffset)
+}
 
 // fixture-shape constants. 4 services × 25 traces × variable spans
 // (3..5 round-robin) ≈ 400 spans — well above the smoke assertion's
@@ -145,10 +167,7 @@ func runSeed(args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), *overall)
 	defer cancel()
 
-	startAt, err := time.Parse(time.RFC3339, anchor)
-	if err != nil {
-		return fmt.Errorf("parse anchor: %w", err)
-	}
+	startAt := currentAnchor()
 
 	traces := buildFixture(startAt)
 	totalSpans := 0
@@ -160,7 +179,7 @@ func runSeed(args []string) error {
 		"services", len(services),
 		"traces", len(traces),
 		"total_spans", totalSpans,
-		"anchor", anchor,
+		"anchor", startAt.Format(time.RFC3339),
 	)
 
 	// --- ClickHouse side ----------------------------------------------

--- a/compatibility/tempo/tempo-config.yaml
+++ b/compatibility/tempo/tempo-config.yaml
@@ -82,19 +82,22 @@ storage:
 # instance.go:445-454 clamps the span's recorded start/end up to "now",
 # and the block's StartTime/EndTime BlockMeta uses the clamped values.
 # That clamping causes /api/search?start=<X>&end=<Y> to find zero blocks
-# whenever X/Y is more than 2 minutes outside the ingest wall-clock, even
+# whenever X/Y is more than ~slack outside the ingest wall-clock, even
 # though /api/traces/<id> still returns the trace (traceID lookup is not
-# time-range filtered). The differ uses anchor=2026-05-11T00:00:00Z (a
-# fixed point shared by prom/loki/tempo seeders for cross-harness
-# reproducibility) which drifts further from "now" each day. Picking
-# 8760h (= 1 year) gives the harness ~12 months of stable behavior
-# against the same anchor before requiring another bump — long enough
-# that the day-to-day clock drift doesn't surface as a TraceQL parity
-# regression, short enough that genuinely-stale fixtures still warn via
+# time-range filtered).
+#
+# The seeder anchors its fixture at `now() - 5m` (see driver/seeder.go::
+# currentAnchor); the differ recomputes its own anchor and uses ±1h
+# window. 1h slack here is roomy enough to absorb the inter-process
+# `now()` drift plus any flush/poll latency, while staying tight enough
+# that a genuinely-stale fixture still surfaces via
 # WarnOutsideIngestionSlack (tempodb/encoding/common/slackTimeRange.go).
+# Previously this was 8760h (1y) as an escape hatch for the fixed
+# 2026-05-11 anchor — that hatch is no longer needed now the anchor
+# rolls with wall-clock.
 live_store:
   wal:
-    ingestion_time_range_slack: 8760h
+    ingestion_time_range_slack: 1h
   max_trace_live: 2s
   max_trace_idle: 1s
   flush_check_period: 1s


### PR DESCRIPTION
## Summary

- Seeder anchor moves from a fixed `2026-05-11T00:00:00Z` (set by PR #501's design) to a rolling `now() - 5m`, recomputed on every `seed` / `diff` invocation.
- `compatibility/tempo/tempo-config.yaml`'s `live_store.wal.ingestion_time_range_slack` drops from `8760h` (1 year) back to `1h` — the escape hatch added by PR #501 is no longer needed.
- The differ's `--anchor` default flips from the const literal to `""` ("roll the anchor here too"); pass an explicit RFC3339 to re-run the differ standalone against a stack seeded earlier.

## Why

Per dirty-fixes audit (recommendation #10): the 1-year slack masked the actual design smell — a fixed past anchor that needs ever-growing slack as time passes. Rolling the anchor with wall-clock makes the slack a meaningful safety margin again instead of a permanent escape hatch.

The prom + loki seeders insert directly into ClickHouse and aren't affected by Tempo's live-store ingestion clamping (`modules/livestore/instance.go:445-454`), so they keep their fixed `2026-05-11` anchor unchanged.

## Test plan

- [x] `go build ./compatibility/tempo/driver/` — green.
- [x] `go test ./compatibility/tempo/driver/` — 104 tests pass.
- [x] `bash compatibility/tempo/scripts/run-tempo-compatibility.sh` end-to-end — seeder pushed to anchor `2026-05-22T22:37:09Z` (rolling), Tempo `/api/search` returned traces, differ wrote score `10/33` (matches the existing main baseline).
- [ ] CI: `compatibility/tempo` job must stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)