### PR TITLE
chore(forbid-skip): widen patterns 4+5 to cover testify 3-arg shape (#277)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,7 +248,7 @@ jobs:
           if git ls-files -z -- \
               '*_test.go' \
               ':!:compatibility/*/upstream/**' \
-              | xargs -0 grep -nEH 'assert\.Contains\([^,]+,\s*""\s*\)|assert\.ElementsMatch\([^,]+,\s*\[\][^)]*\{\s*\}\s*\)' --; then
+              | xargs -0 grep -nEH 'assert\.Contains\(([^,]+,\s*){0,1}[^,]+,\s*""\s*\)|assert\.ElementsMatch\(([^,]+,\s*){0,1}[^,]+,\s*\[\][^)]*\{\s*\}\s*\)' --; then
             fail=1
           fi
           # Multi-line silent-recover scan. Catches both the bare

--- a/docs/forbid-skip.md
+++ b/docs/forbid-skip.md
@@ -57,8 +57,8 @@ shape.
 | 1   | Reject `t.Skip[fN]?` calls                                                                                  | `*_test.go`                                                     | #309          |
 | 2   | Reject bare "not implemented" / "skipped" / "deferred" wording                                              | `*_test.go` + `*.txtar`                                         | #461          |
 | 3   | Reject "not implemented" wording in production code                                                         | `internal/**/*.go` (non-test)                                   | #197          |
-| 4   | Reject `assert.Contains(x, "")` soft assertion                                                              | `*_test.go`                                                     | #587          |
-| 5   | Reject `assert.ElementsMatch(x, []T{})` soft assertion                                                      | `*_test.go`                                                     | #587          |
+| 4   | Reject `assert.Contains(x, "")` soft assertion (2-arg + testify 3-arg)                                      | `*_test.go`                                                     | #587 / #277   |
+| 5   | Reject `assert.ElementsMatch(x, []T{})` soft assertion (2-arg + testify 3-arg)                              | `*_test.go`                                                     | #587 / #277   |
 | 6   | Reject silent panic recovery (`defer recover()` and the multi-line `defer func(){ _ = recover() }()` block) | `*_test.go`                                                     | #587 / #648   |
 | 7   | Reject net-new `should_skip:` overlay entries lacking a tracking ref                                        | overlay YAML in `OVERLAY_FILES`                                 | #596          |
 
@@ -119,9 +119,9 @@ correct rewrite of "skipped" rather than something to forbid.
 - Matches: `return errors.New("not implemented")`
 - Does NOT match: `return errUnsupported // rejects unsupported foo`
 
-## Pattern 4 — `assert.Contains(x, "")` soft assertion (PR #587)
+## Pattern 4 — `assert.Contains(x, "")` soft assertion (PR #587, widened #277)
 
-Regex: `assert\.Contains\([^,]+,\s*""\s*\)`
+Regex: `assert\.Contains\(([^,]+,\s*){0,1}[^,]+,\s*""\s*\)`
 
 PR #587 added this. The trigger was a sweep that uncovered
 `assert.Contains(body, "")` calls — they pass any input, look like
@@ -129,30 +129,35 @@ real assertions in reviews, but verify nothing.
 
 The regex uses `[^,]+` to clamp the haystack-argument match inside a
 single function call (so it doesn't reach into adjacent calls), and
-`\s*""\s*` to allow optional whitespace around the empty needle.
+`\s*""\s*` to allow optional whitespace around the empty needle. The
+leading `([^,]+,\s*){0,1}` is an optional prefix that consumes a
+testify-style first argument (`t *testing.T`) when present, so the
+single regex catches BOTH the 2-arg gocheck-style call
+(`assert.Contains(haystack, "")`) and the 3-arg testify call
+(`assert.Contains(t, haystack, "")`). The original PR #587 regex was
+2-arg-only; PR #277 widened it to both shapes after the limitation
+was flagged on PR #719.
 
-**Known scope limitation:** the `[^,]+,` clause requires exactly one
-comma between haystack and needle, so the regex catches the 2-arg
-gocheck-style call but not the testify 3-arg call
-(`assert.Contains(t, haystack, "")`). Widening to the testify form is
-a deliberate future change — listed as a follow-up rather than rolled
-into this normalisation pass so the behaviour of the gate stays
-byte-identical to its previous shape.
-
-- Matches: `assert.Contains(body, "")`
+- Matches (2-arg gocheck): `assert.Contains(body, "")`
+- Matches (3-arg testify): `assert.Contains(t, body, "")`
 - Does NOT match: `assert.Contains(body, "error: foo")`
+- Does NOT match: `assert.Contains(t, body, "error: foo")`
 
-## Pattern 5 — `assert.ElementsMatch(x, []T{})` soft assertion (PR #587)
+## Pattern 5 — `assert.ElementsMatch(x, []T{})` soft assertion (PR #587, widened #277)
 
-Regex: `assert\.ElementsMatch\([^,]+,\s*\[\][^)]*\{\s*\}\s*\)`
+Regex: `assert\.ElementsMatch\(([^,]+,\s*){0,1}[^,]+,\s*\[\][^)]*\{\s*\}\s*\)`
 
 Sibling of pattern 4. Same regex shape (`[^,]+,` clamp + empty-needle
-match) targeting `ElementsMatch` against an empty slice literal. Same
-known scope limitation as pattern 4 — catches 2-arg gocheck-style
-calls but not the testify 3-arg form.
+match) targeting `ElementsMatch` against an empty slice literal. The
+optional `([^,]+,\s*){0,1}` prefix matches the testify-style
+`t *testing.T` first arg when present, so the regex catches BOTH the
+2-arg gocheck-style and the 3-arg testify forms — widened by PR #277
+on top of PR #587's original 2-arg-only shape.
 
-- Matches: `assert.ElementsMatch(got, []string{})`
+- Matches (2-arg gocheck): `assert.ElementsMatch(got, []string{})`
+- Matches (3-arg testify): `assert.ElementsMatch(t, got, []string{})`
 - Does NOT match: `assert.ElementsMatch(got, []string{"a", "b"})`
+- Does NOT match: `assert.ElementsMatch(t, got, []string{"a", "b"})`
 
 ## Pattern 6 — silent panic recovery (PR #587 / #648)
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -111,7 +111,7 @@ pre-push:
         if git ls-files -z -- \
             '*_test.go' \
             ':!:compatibility/*/upstream/**' \
-            | xargs -0 grep -nEH 'assert\.Contains\([^,]+,\s*""\s*\)|assert\.ElementsMatch\([^,]+,\s*\[\][^)]*\{\s*\}\s*\)' --; then
+            | xargs -0 grep -nEH 'assert\.Contains\(([^,]+,\s*){0,1}[^,]+,\s*""\s*\)|assert\.ElementsMatch\(([^,]+,\s*){0,1}[^,]+,\s*\[\][^)]*\{\s*\}\s*\)' --; then
           fail=1
         fi
         # Multi-line silent-recover scan — mirrors the CI `forbid-skip`

--- a/scripts/test-forbid-skip.sh
+++ b/scripts/test-forbid-skip.sh
@@ -120,28 +120,36 @@ expect_match    "case3 not-implemented prod"  "$RE3" "$tmpdir/case3_match.txt"
 expect_no_match "case3 factual verb"          "$RE3" "$tmpdir/case3_nomatch.txt"
 
 # --------------------------------------------------------------------
-# case 4 — assert.Contains(x, "")  (PR #587)
+# case 4 — assert.Contains(x, "")  (PR #587, widened #277)
 # --------------------------------------------------------------------
-# NB: the regex's `[^,]+,` clause requires exactly one comma between
-# haystack and needle, so it matches the 2-arg gocheck-style call
-# (`assert.Contains(haystack, "")`) but not the testify 3-arg
-# `assert.Contains(t, haystack, "")` form. See docs/forbid-skip.md
-# § "Known scope limitation".
-RE4='assert\.Contains\([^,]+,\s*""\s*\)'
-printf 'assert.Contains(body, "")\n'           >"$tmpdir/case4_match.txt"
-printf 'assert.Contains(body, "error: foo")\n' >"$tmpdir/case4_nomatch.txt"
-expect_match    "case4 empty-needle Contains"   "$RE4" "$tmpdir/case4_match.txt"
-expect_no_match "case4 real-needle Contains"    "$RE4" "$tmpdir/case4_nomatch.txt"
+# The optional `([^,]+,\s*){0,1}` prefix matches the testify
+# `t *testing.T` first arg when present, so the regex catches BOTH
+# the 2-arg gocheck-style call (`assert.Contains(haystack, "")`) and
+# the 3-arg testify call (`assert.Contains(t, haystack, "")`).
+RE4='assert\.Contains\(([^,]+,\s*){0,1}[^,]+,\s*""\s*\)'
+printf 'assert.Contains(body, "")\n'              >"$tmpdir/case4_match.txt"
+printf 'assert.Contains(t, body, "")\n'           >"$tmpdir/case4_match_testify.txt"
+printf 'assert.Contains(body, "error: foo")\n'    >"$tmpdir/case4_nomatch.txt"
+printf 'assert.Contains(t, body, "error: foo")\n' >"$tmpdir/case4_nomatch_testify.txt"
+expect_match    "case4 empty-needle Contains (2-arg)"   "$RE4" "$tmpdir/case4_match.txt"
+expect_match    "case4 empty-needle Contains (3-arg)"   "$RE4" "$tmpdir/case4_match_testify.txt"
+expect_no_match "case4 real-needle Contains (2-arg)"    "$RE4" "$tmpdir/case4_nomatch.txt"
+expect_no_match "case4 real-needle Contains (3-arg)"    "$RE4" "$tmpdir/case4_nomatch_testify.txt"
 
 # --------------------------------------------------------------------
-# case 5 — assert.ElementsMatch(x, []T{})  (PR #587)
+# case 5 — assert.ElementsMatch(x, []T{})  (PR #587, widened #277)
 # --------------------------------------------------------------------
-# Same 2-arg gocheck-style scope limitation as case4.
-RE5='assert\.ElementsMatch\([^,]+,\s*\[\][^)]*\{\s*\}\s*\)'
-printf 'assert.ElementsMatch(got, []string{})\n'        >"$tmpdir/case5_match.txt"
-printf 'assert.ElementsMatch(got, []string{"a", "b"})\n' >"$tmpdir/case5_nomatch.txt"
-expect_match    "case5 empty-slice ElementsMatch" "$RE5" "$tmpdir/case5_match.txt"
-expect_no_match "case5 populated ElementsMatch"   "$RE5" "$tmpdir/case5_nomatch.txt"
+# Same optional-`t`-prefix widening as case4 — covers both 2-arg
+# gocheck-style and 3-arg testify shapes.
+RE5='assert\.ElementsMatch\(([^,]+,\s*){0,1}[^,]+,\s*\[\][^)]*\{\s*\}\s*\)'
+printf 'assert.ElementsMatch(got, []string{})\n'           >"$tmpdir/case5_match.txt"
+printf 'assert.ElementsMatch(t, got, []string{})\n'        >"$tmpdir/case5_match_testify.txt"
+printf 'assert.ElementsMatch(got, []string{"a", "b"})\n'   >"$tmpdir/case5_nomatch.txt"
+printf 'assert.ElementsMatch(t, got, []string{"a", "b"})\n' >"$tmpdir/case5_nomatch_testify.txt"
+expect_match    "case5 empty-slice ElementsMatch (2-arg)" "$RE5" "$tmpdir/case5_match.txt"
+expect_match    "case5 empty-slice ElementsMatch (3-arg)" "$RE5" "$tmpdir/case5_match_testify.txt"
+expect_no_match "case5 populated ElementsMatch (2-arg)"   "$RE5" "$tmpdir/case5_nomatch.txt"
+expect_no_match "case5 populated ElementsMatch (3-arg)"   "$RE5" "$tmpdir/case5_nomatch_testify.txt"
 
 # --------------------------------------------------------------------
 # case 6 — silent panic recovery, both shapes  (PR #587 / #648)


### PR DESCRIPTION
## Summary

- Widen `forbid-skip` patterns 4 (`assert.Contains(x, "")`) and 5 (`assert.ElementsMatch(x, []T{})`) so they also catch the testify 3-arg shape (`assert.Contains(t, x, "")` / `assert.ElementsMatch(t, x, []T{})`). PR #587 only matched the 2-arg gocheck-style call; PR #719 documented the gap and deferred the fix.
- Approach: prepend `([^,]+,\s*){0,1}` to each regex — an optional first-argument prefix that consumes a leading `t *testing.T` when present. The original 2-arg form still matches; the 3-arg testify form now matches too; real-needle calls in either shape still don't.
- Mirrored across both `.github/workflows/ci.yml` and `lefthook.yml` (byte-identical regex per the row-1-to-6 rule).
- Updated `docs/forbid-skip.md` (regex + intent + scope + origin + match/counter-examples for both shapes) and `scripts/test-forbid-skip.sh` (new positive + counter-example assertions for the 3-arg shape: 18/18 OK).

## Verification

- `scripts/test-forbid-skip.sh` → 18/18 OK locally (4 cases added covering both 2-arg and 3-arg shapes per side).
- Repo scan with the widened regex returns zero hits (no real offenders); current codebase remains compliant.
- Throwaway probe (`assert.Contains(t, "haystack", "")` / `assert.ElementsMatch(t, []string{"a"}, []string{})`) confirmed both new shapes fire, then was reverted.

## Test plan

- [ ] CI `forbid-skip` job green.
- [ ] `forbid-skip` self-test step inside CI prints `18/18 OK`.
- [ ] Lefthook pre-push mirror runs the same regex shape locally for contributors.

Origin: task #277 (follow-up to #719's flagged limitation).