### PR TITLE
test(compat/loki): pin upstream skip-true set via baseline sanity rail (#269)

### DIFF
--- a/compatibility/loki/README.md
+++ b/compatibility/loki/README.md
@@ -25,6 +25,7 @@ compatibility/loki/
   docker-compose.yml              clickhouse + reference loki + cerberus
   loki-config.yaml                reference Loki single-binary config
   cerberus-test-queries.yml       overlay: per-query drops + reasons
+  upstream-skip-baseline.txt      pinned set of upstream `skip: true` keys (sanity rail; see "Upstream-skip baseline")
   dataset_metadata.json           pinned dataset metadata for ${SELECTOR}/${LABEL_*}
   reports/                        diff driver output (gitignored)
   cmd/
@@ -117,9 +118,58 @@ that lives OUTSIDE the AGPL `upstream/` boundary:
   `reason:` plus a `jira:` reference; the CI gate at
   `scripts/check-skip-additions.sh` rejects new entries that omit
   either.
+- `upstream-skip-baseline.txt` — pinned set of corpus entries the
+  upstream YAML marks `skip: true`, one
+  `<suite>/<file>.yaml#<description>` key per line. The driver's sanity
+  rail (task #269) loads the full corpus on every run and asserts the
+  upstream-skipped set matches this file; drift in either direction
+  (a new upstream skip, or a previously-skipped query re-enabled
+  upstream) is a hard error, surfacing the regression before it can
+  silently feed back into the compliance score. Regenerate via
+  `loki-compliance-tester -regen-baseline -skip-baseline=...` after
+  auditing the corpus diff a re-snapshot introduces. See
+  [Upstream-skip baseline](#upstream-skip-baseline) for the procedure.
 - `dataset_metadata.json` — pinned dataset metadata that maps
   `${SELECTOR}` / `${LABEL_NAME}` / `${LABEL_VALUE}` template vars to
   concrete values produced by the seeder under `cmd/seed/`.
+
+## Upstream-skip baseline
+
+The vendored corpus contains ~15 queries upstream marks `skip: true`
+(quantile/stddev unwrap aggregations, structured-metadata numeric label
+filters, a JSON parser regression). The cerberus driver calls
+`registry.GetQueries(includeSkip=false, ...)` so these never reach the
+wire, but that filtering is invisible to the compat score — if upstream
+ever flips one of these to `skip: false` (e.g. the v2 engine grows
+quantile support), the query would silently slip into the corpus and
+either pass or fail without the operator noticing the boundary moved.
+
+`upstream-skip-baseline.txt` is the trip-wire. The driver loads the
+full corpus (`includeSkipped=true`), partitions it into runnable +
+upstream-skipped, and diffs the upstream-skipped set against the file.
+Drift either way fails the run:
+
+- Added keys (the corpus marks `skip: true` but the baseline does not)
+  mean the re-snapshot introduced new boundaries cerberus needs to
+  triage.
+- Removed keys (the baseline expects `skip: true` but the corpus no
+  longer carries it) mean upstream re-enabled a previously-skipped
+  query; the operator must decide whether cerberus is ready to diff
+  against it.
+
+Regenerate after a corpus bump (or any deliberate baseline update):
+
+```sh
+go run ./compatibility/loki/cmd/loki-compliance-tester \
+    -corpus=compatibility/loki/upstream/loki-bench/queries \
+    -skip-baseline=compatibility/loki/upstream-skip-baseline.txt \
+    -regen-baseline
+```
+
+The regen path is corpus-only — it does not contact any Loki
+endpoint. Review the resulting diff before committing: an unexpected
+addition usually means a real upstream regression cerberus should
+chase, not a baseline to silently rubber-stamp.
 
 ## Running the harness
 

--- a/compatibility/loki/cmd/loki-compliance-tester/main.go
+++ b/compatibility/loki/cmd/loki-compliance-tester/main.go
@@ -74,19 +74,21 @@ func main() {
 
 // flags collects all CLI / env knobs in one place.
 type flags struct {
-	addr1       string
-	addr2       string
-	corpusDir   string
-	metadataDir string
-	overlayPath string
-	reportPath  string
-	scorePath   string
-	tolerance   float64
-	rangeType   string
-	seed        int64
-	parallelism int
-	includeSkip bool
-	timeout     time.Duration
+	addr1            string
+	addr2            string
+	corpusDir        string
+	metadataDir      string
+	overlayPath      string
+	reportPath       string
+	scorePath        string
+	skipBaselinePath string
+	regenBaseline    bool
+	tolerance        float64
+	rangeType        string
+	seed             int64
+	parallelism      int
+	includeSkip      bool
+	timeout          time.Duration
 }
 
 func parseFlags() flags {
@@ -98,6 +100,8 @@ func parseFlags() flags {
 	flag.StringVar(&f.overlayPath, "overlay", "", "Optional cerberus-test-queries.yml overlay (skip/fail per source key)")
 	flag.StringVar(&f.reportPath, "report", "", "Report output path; empty writes to stdout")
 	flag.StringVar(&f.scorePath, "score", "", "shields.io endpoint-badge score JSON output path; empty means do not write")
+	flag.StringVar(&f.skipBaselinePath, "skip-baseline", "", "Path to the upstream-skip-baseline.txt file; when set, the harness asserts the upstream YAML `skip: true` set matches this file and fails on drift")
+	flag.BoolVar(&f.regenBaseline, "regen-baseline", false, "Regenerate -skip-baseline from the current corpus and exit (writes the file, then returns 0 without contacting any Loki endpoint)")
 	flag.Float64Var(&f.tolerance, "tolerance", 1e-5, "Float comparison tolerance (matches upstream remote_test.go default)")
 	flag.StringVar(&f.rangeType, "range-type", "range", "Query range type: 'range' or 'instant'")
 	flag.Int64Var(&f.seed, "seed", 42, "Random seed for query template resolution (matches upstream default)")
@@ -110,10 +114,49 @@ func parseFlags() flags {
 
 func run() error {
 	f := parseFlags()
+
+	// -regen-baseline is a corpus-only operation: load the registry,
+	// derive the skip set, write the baseline file, and exit. No Loki
+	// endpoints are contacted, so -addr-1 / -addr-2 are not required in
+	// this mode.
+	if f.regenBaseline {
+		if f.skipBaselinePath == "" {
+			return errors.New("-regen-baseline requires -skip-baseline to be set (the destination path)")
+		}
+		_, upstreamSkipped, err := loadAllQueriesAndSplit(f)
+		if err != nil {
+			return fmt.Errorf("loading corpus for baseline regen: %w", err)
+		}
+		if err := writeSkipBaseline(f.skipBaselinePath, upstreamSkipped); err != nil {
+			return fmt.Errorf("writing baseline: %w", err)
+		}
+		fmt.Fprintf(os.Stderr, "==> wrote upstream-skip baseline: path=%s entries=%d\n",
+			f.skipBaselinePath, len(upstreamSkipped))
+		return nil
+	}
+
 	if f.addr1 == "" || f.addr2 == "" {
 		return errors.New("both -addr-1 and -addr-2 must be set")
 	}
 	isInstant := f.rangeType == "instant"
+
+	// Sanity rail (task #269): when -skip-baseline is set, partition
+	// the full corpus into runnable + upstream-skipped, then diff the
+	// skipped set against the pinned baseline. Drift surfaces as a hard
+	// error so an upstream YAML flip can't silently regress the
+	// compliance score by reintroducing a query cerberus is not yet
+	// compatible with.
+	if f.skipBaselinePath != "" {
+		_, upstreamSkipped, err := loadAllQueriesAndSplit(f)
+		if err != nil {
+			return fmt.Errorf("loading corpus for skip-baseline check: %w", err)
+		}
+		if err := checkSkipBaseline(f.skipBaselinePath, upstreamSkipped); err != nil {
+			return err
+		}
+		fmt.Fprintf(os.Stderr, "==> upstream-skip baseline ok: entries=%d path=%s\n",
+			len(upstreamSkipped), f.skipBaselinePath)
+	}
 
 	overlay, err := loadOverlay(f.overlayPath)
 	if err != nil {
@@ -297,6 +340,169 @@ func loadCases(f flags, isInstant bool) ([]loadedCase, error) {
 		cases = filtered
 	}
 	return cases, nil
+}
+
+// loadAllQueriesAndSplit reuses the bench registry to load every
+// suite, then partitions the result into runnable (`Skip == false`)
+// and upstream-skipped (`Skip == true`) slices. The runnable slice is
+// what the normal compareAll path operates on; the skipped slice
+// feeds the sanity rail (baseline diff, baseline regen). Loading once
+// and splitting locally keeps the bench-package call surface small —
+// `GetQueries(true, ...)` returns the full corpus.
+func loadAllQueriesAndSplit(f flags) (runnable, upstreamSkipped []bench.QueryDefinition, err error) {
+	registry := bench.NewQueryRegistry(f.corpusDir)
+	suites := []bench.Suite{bench.SuiteFast, bench.SuiteRegression, bench.SuiteExhaustive}
+	if loadErr := registry.Load(suites...); loadErr != nil {
+		return nil, nil, fmt.Errorf("registry.Load: %w", loadErr)
+	}
+	all := registry.GetQueries(true, suites...)
+	for _, def := range all {
+		if def.Skip {
+			upstreamSkipped = append(upstreamSkipped, def)
+		} else {
+			runnable = append(runnable, def)
+		}
+	}
+	return runnable, upstreamSkipped, nil
+}
+
+// baselineKey derives the stable lookup key for a QueryDefinition. The
+// shape matches the overlay key (`<suite>/<file>.yaml#<description>`)
+// so a reviewer can search either file by the same string.
+func baselineKey(def bench.QueryDefinition) string {
+	return stripSourceLine(def.Source) + "#" + def.Description
+}
+
+// readSkipBaseline parses the baseline file. Lines beginning with `#`
+// and blank lines are ignored so the file can carry rationale comments
+// alongside the entries. Returned slice is sorted ascending.
+func readSkipBaseline(path string) ([]string, error) {
+	b, err := os.ReadFile(path) //nolint:gosec // CLI-supplied baseline path; harness tool
+	if err != nil {
+		return nil, err
+	}
+	var out []string
+	for _, line := range strings.Split(string(b), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		out = append(out, trimmed)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// writeSkipBaseline rewrites the baseline file from the given
+// QueryDefinition slice. The header preserves the rationale block + the
+// regen incantation so the file is self-documenting after a regen
+// flips its content. Entries are sorted lexically.
+func writeSkipBaseline(path string, defs []bench.QueryDefinition) error {
+	keys := make([]string, 0, len(defs))
+	for _, def := range defs {
+		keys = append(keys, baselineKey(def))
+	}
+	sort.Strings(keys)
+
+	var buf strings.Builder
+	buf.WriteString(skipBaselineHeader)
+	for _, k := range keys {
+		buf.WriteString(k)
+		buf.WriteByte('\n')
+	}
+	return os.WriteFile(path, []byte(buf.String()), 0o600)
+}
+
+// skipBaselineHeader is the leading commentary written by
+// writeSkipBaseline. It documents the file's purpose + the regen
+// procedure so a reviewer doesn't need to cross-reference the README to
+// understand what the entries represent.
+const skipBaselineHeader = `# Upstream ` + "`skip: true`" + ` baseline for the vendored grafana/loki bench corpus.
+#
+# Each non-comment line is a ` + "`<suite>/<file>.yaml#<description>`" + ` key
+# identifying a corpus entry whose YAML carries ` + "`skip: true`" + `. The
+# loki-compliance-tester's sanity rail loads the full corpus
+# (includeSkipped=true), splits it into runnable + upstream-skipped, and
+# diffs the upstream-skipped set against this file. Any drift (new
+# skipped entries that aren't here, or expected entries that disappeared)
+# fails the harness — so an upstream YAML flipping ` + "`skip: true`" + ` →
+# ` + "`skip: false`" + ` cannot silently reintroduce a query cerberus is not yet
+# compatible with.
+#
+# Regenerate after a corpus re-snapshot via:
+#
+#     loki-compliance-tester \
+#         -corpus=compatibility/loki/upstream/loki-bench/queries \
+#         -skip-baseline=compatibility/loki/upstream-skip-baseline.txt \
+#         -regen-baseline
+#
+# Sorted lexically; comment lines (` + "`#`" + ` prefix) and blank lines are
+# ignored by the loader so the file can carry rationale alongside the
+# entries.
+`
+
+// checkSkipBaseline compares the upstream-skipped corpus set against
+// the pinned baseline file. Drift is reported as a structured error
+// naming every added / removed key so the operator can land a
+// matching baseline update (via -regen-baseline) — or, more often,
+// confront the corpus drift the upstream re-snapshot introduced.
+func checkSkipBaseline(path string, upstreamSkipped []bench.QueryDefinition) error {
+	want, err := readSkipBaseline(path)
+	if err != nil {
+		return fmt.Errorf("reading skip baseline %q: %w", path, err)
+	}
+	got := make([]string, 0, len(upstreamSkipped))
+	for _, def := range upstreamSkipped {
+		got = append(got, baselineKey(def))
+	}
+	sort.Strings(got)
+
+	wantSet := make(map[string]struct{}, len(want))
+	for _, k := range want {
+		wantSet[k] = struct{}{}
+	}
+	gotSet := make(map[string]struct{}, len(got))
+	for _, k := range got {
+		gotSet[k] = struct{}{}
+	}
+
+	var added, removed []string
+	for _, k := range got {
+		if _, ok := wantSet[k]; !ok {
+			added = append(added, k)
+		}
+	}
+	for _, k := range want {
+		if _, ok := gotSet[k]; !ok {
+			removed = append(removed, k)
+		}
+	}
+	if len(added) == 0 && len(removed) == 0 {
+		return nil
+	}
+
+	var msg strings.Builder
+	msg.WriteString("upstream-skip baseline drift detected (vendored corpus no longer matches ")
+	msg.WriteString(path)
+	msg.WriteString(")\n")
+	if len(added) > 0 {
+		msg.WriteString("  added (corpus now marks `skip: true`, baseline does not):\n")
+		for _, k := range added {
+			msg.WriteString("    + ")
+			msg.WriteString(k)
+			msg.WriteByte('\n')
+		}
+	}
+	if len(removed) > 0 {
+		msg.WriteString("  removed (baseline expects `skip: true`, corpus no longer carries it — a previously-skipped query has been re-enabled upstream):\n")
+		for _, k := range removed {
+			msg.WriteString("    - ")
+			msg.WriteString(k)
+			msg.WriteByte('\n')
+		}
+	}
+	msg.WriteString("  resolve by either (a) regenerating the baseline via -regen-baseline after auditing the diff, or (b) restoring the upstream `skip: true` flag if the change was unintentional.")
+	return errors.New(msg.String())
 }
 
 // loadedCase carries either a fully-expanded TestCase or an expansion

--- a/compatibility/loki/cmd/loki-compliance-tester/main_test.go
+++ b/compatibility/loki/cmd/loki-compliance-tester/main_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	bench "github.com/tsouza/cerberus/compatibility/loki/upstream/loki-bench"
@@ -83,5 +86,172 @@ func TestScoreCounts_Empty(t *testing.T) {
 	passed, total := scoreCounts(nil)
 	if passed != 0 || total != 0 {
 		t.Fatalf("(passed, total) = (%d, %d), want (0, 0)", passed, total)
+	}
+}
+
+// TestBaselineKey pins the wire-format key the baseline file + the
+// overlay both index on. Drift here would silently break the sanity
+// rail's name-to-corpus mapping.
+func TestBaselineKey(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		def  bench.QueryDefinition
+		want string
+	}{
+		{
+			name: "strips-line-suffix",
+			def:  bench.QueryDefinition{Source: "fast/basic-selectors.yaml:12", Description: "Basic label selector"},
+			want: "fast/basic-selectors.yaml#Basic label selector",
+		},
+		{
+			name: "no-line-suffix",
+			def:  bench.QueryDefinition{Source: "regression/metric-queries.yaml", Description: "HTTP status code distribution"},
+			want: "regression/metric-queries.yaml#HTTP status code distribution",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := baselineKey(tc.def); got != tc.want {
+				t.Fatalf("baselineKey() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestReadSkipBaseline_IgnoresCommentsAndBlanks pins the parser
+// contract — comment + blank lines stay out of the resulting set so
+// the file can carry rationale prose.
+func TestReadSkipBaseline_IgnoresCommentsAndBlanks(t *testing.T) {
+	t.Parallel()
+	body := "# leading comment\n" +
+		"# another comment\n" +
+		"\n" +
+		"fast/foo.yaml#alpha\n" +
+		"\n" +
+		"   # indented comment\n" +
+		"regression/bar.yaml#beta\n" +
+		"exhaustive/baz.yaml#gamma\n"
+	dir := t.TempDir()
+	path := filepath.Join(dir, "baseline.txt")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write tmp: %v", err)
+	}
+	got, err := readSkipBaseline(path)
+	if err != nil {
+		t.Fatalf("readSkipBaseline: %v", err)
+	}
+	want := []string{
+		"exhaustive/baz.yaml#gamma",
+		"fast/foo.yaml#alpha",
+		"regression/bar.yaml#beta",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d (got=%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("entry %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestCheckSkipBaseline_MatchPasses confirms an exact set match returns
+// nil — the no-drift path.
+func TestCheckSkipBaseline_MatchPasses(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "baseline.txt")
+	body := "fast/a.yaml#one\nregression/b.yaml#two\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write tmp: %v", err)
+	}
+	defs := []bench.QueryDefinition{
+		{Source: "fast/a.yaml:3", Description: "one"},
+		{Source: "regression/b.yaml:7", Description: "two"},
+	}
+	if err := checkSkipBaseline(path, defs); err != nil {
+		t.Fatalf("checkSkipBaseline returned err: %v", err)
+	}
+}
+
+// TestCheckSkipBaseline_DetectsAddition pins the trip-wire: a new
+// upstream entry not in the baseline fails with the new key named.
+func TestCheckSkipBaseline_DetectsAddition(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "baseline.txt")
+	body := "fast/a.yaml#one\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write tmp: %v", err)
+	}
+	defs := []bench.QueryDefinition{
+		{Source: "fast/a.yaml:3", Description: "one"},
+		{Source: "regression/new.yaml:11", Description: "fresh entry"},
+	}
+	err := checkSkipBaseline(path, defs)
+	if err == nil {
+		t.Fatalf("checkSkipBaseline = nil, want drift error")
+	}
+	if !strings.Contains(err.Error(), "regression/new.yaml#fresh entry") {
+		t.Fatalf("error %q missing added key", err.Error())
+	}
+}
+
+// TestCheckSkipBaseline_DetectsRemoval mirrors the addition case for
+// the other direction — an upstream re-enable surfaces.
+func TestCheckSkipBaseline_DetectsRemoval(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "baseline.txt")
+	body := "fast/a.yaml#one\nregression/gone.yaml#two\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write tmp: %v", err)
+	}
+	defs := []bench.QueryDefinition{
+		{Source: "fast/a.yaml:3", Description: "one"},
+	}
+	err := checkSkipBaseline(path, defs)
+	if err == nil {
+		t.Fatalf("checkSkipBaseline = nil, want drift error")
+	}
+	if !strings.Contains(err.Error(), "regression/gone.yaml#two") {
+		t.Fatalf("error %q missing removed key", err.Error())
+	}
+}
+
+// TestWriteSkipBaseline_RoundTripsThroughRead confirms the writer
+// emits a file the reader parses back to the same sorted set, so
+// -regen-baseline + the diff path are self-consistent.
+func TestWriteSkipBaseline_RoundTripsThroughRead(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "baseline.txt")
+	defs := []bench.QueryDefinition{
+		{Source: "regression/b.yaml:7", Description: "two"},
+		{Source: "fast/a.yaml:3", Description: "one"},
+		{Source: "exhaustive/c.yaml:99", Description: "three"},
+	}
+	if err := writeSkipBaseline(path, defs); err != nil {
+		t.Fatalf("writeSkipBaseline: %v", err)
+	}
+	got, err := readSkipBaseline(path)
+	if err != nil {
+		t.Fatalf("readSkipBaseline: %v", err)
+	}
+	want := []string{
+		"exhaustive/c.yaml#three",
+		"fast/a.yaml#one",
+		"regression/b.yaml#two",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d (got=%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("entry %d = %q, want %q", i, got[i], want[i])
+		}
 	}
 }

--- a/compatibility/loki/scripts/run-loki-compatibility.sh
+++ b/compatibility/loki/scripts/run-loki-compatibility.sh
@@ -53,6 +53,12 @@
 #   DRIVER_PARALLELISM  -parallelism flag (default: 8).
 #   DRIVER_OVERLAY      Path to cerberus-test-queries.yml overlay; default
 #                       resolves the in-tree file beside this script.
+#   DRIVER_SKIP_BASELINE
+#                       Path to the upstream `skip: true` baseline file
+#                       (default: $ROOT_DIR/upstream-skip-baseline.txt).
+#                       When set, the driver asserts the upstream YAML's
+#                       skipped set matches this file; drift is a hard
+#                       error (sanity rail per task #269).
 
 set -eu -o pipefail
 
@@ -67,6 +73,7 @@ TOLERANCE=${DRIVER_TOLERANCE:-1e-5}
 RANGE_TYPE=${DRIVER_RANGE_TYPE:-range}
 PARALLELISM=${DRIVER_PARALLELISM:-8}
 OVERLAY=${DRIVER_OVERLAY:-"$ROOT_DIR/cerberus-test-queries.yml"}
+SKIP_BASELINE=${DRIVER_SKIP_BASELINE:-"$ROOT_DIR/upstream-skip-baseline.txt"}
 
 DRIVER_BIN=$(mktemp -t cerberus-loki-tester.XXXXXX)
 
@@ -134,6 +141,7 @@ set +e
     -corpus="$ROOT_DIR/upstream/loki-bench/queries" \
     -metadata-dir="$ROOT_DIR" \
     -overlay="$OVERLAY" \
+    -skip-baseline="$SKIP_BASELINE" \
     -report="$REPORT" \
     -score="$SCORE" \
     -tolerance="$TOLERANCE" \

--- a/compatibility/loki/upstream-skip-baseline.txt
+++ b/compatibility/loki/upstream-skip-baseline.txt
@@ -1,0 +1,37 @@
+# Upstream `skip: true` baseline for the vendored grafana/loki bench corpus.
+#
+# Each non-comment line is a `<suite>/<file>.yaml#<description>` key
+# identifying a corpus entry whose YAML carries `skip: true`. The
+# loki-compliance-tester's sanity rail loads the full corpus
+# (includeSkipped=true), splits it into runnable + upstream-skipped, and
+# diffs the upstream-skipped set against this file. Any drift (new
+# skipped entries that aren't here, or expected entries that disappeared)
+# fails the harness — so an upstream YAML flipping `skip: true` →
+# `skip: false` cannot silently reintroduce a query cerberus is not yet
+# compatible with.
+#
+# Regenerate after a corpus re-snapshot via:
+#
+#     loki-compliance-tester \
+#         -corpus=compatibility/loki/upstream/loki-bench/queries \
+#         -skip-baseline=compatibility/loki/upstream-skip-baseline.txt \
+#         -regen-baseline
+#
+# Sorted lexically; comment lines (`#` prefix) and blank lines are
+# ignored by the loader so the file can carry rationale alongside the
+# entries.
+exhaustive/unwrap-aggregations.yaml#P99 duration with conversion
+exhaustive/unwrap-aggregations.yaml#P99 latency grouped by level
+exhaustive/unwrap-aggregations.yaml#Quantile over time - p50 (median)
+exhaustive/unwrap-aggregations.yaml#Quantile over time - p90
+exhaustive/unwrap-aggregations.yaml#Quantile over time - p95
+exhaustive/unwrap-aggregations.yaml#Quantile over time - p99
+exhaustive/unwrap-aggregations.yaml#Standard deviation grouped by level
+exhaustive/unwrap-aggregations.yaml#Standard deviation over time
+exhaustive/unwrap-aggregations.yaml#Standard variance grouped by level
+exhaustive/unwrap-aggregations.yaml#Standard variance over time
+fast/structured-metadata.yaml#JSON parsing with structured metadata filter first
+regression/drilldown-patterns.yaml#Drilldown unwrap query with detected_level grouping
+regression/metric-queries.yaml#HTTP status code distribution
+regression/structured-metadata.yaml#Drilldown pattern with case-insensitive error search
+regression/structured-metadata.yaml#JSON parsing with duration filter and structured metadata


### PR DESCRIPTION
## Summary

- Loads the full vendored bench corpus (`includeSkipped=true`), partitions runnable vs upstream-skipped, and diffs the upstream-skipped key set against `compatibility/loki/upstream-skip-baseline.txt`. Drift in either direction fails the harness — so an upstream YAML flipping `skip: true` to `skip: false` cannot silently feed an incompatible query through the compliance score (task #269).
- New `-skip-baseline` flag selects the baseline file; new `-regen-baseline` flag rewrites it from the current corpus and exits without contacting any Loki endpoint, so refreshing the baseline after a corpus re-snapshot is mechanical.
- The harness driver script wires the baseline by default (`DRIVER_SKIP_BASELINE` override available); the README documents the regen procedure.

## Why path B (load-all + pinned baseline)

Picked the load-all-then-diff approach over a count-only assertion: the file is grep-able by reviewer, the deltas surface concrete `<suite>/<file>.yaml#<description>` keys, and the regen flow is one CLI invocation.

## Baseline contents

15 entries — the same set the upstream YAML currently marks `skip: true`:

- `exhaustive/unwrap-aggregations.yaml` — 10 quantile / stddev / stdvar entries (v2 engine surface).
- `fast/structured-metadata.yaml` — JSON parsing + structured-metadata filter timeout.
- `regression/structured-metadata.yaml` — 2 numeric label-filter entries.
- `regression/drilldown-patterns.yaml` — drilldown unwrap pipeline error.
- `regression/metric-queries.yaml` — JSON parser regression on the HTTP status distribution.

## Test plan

- [x] `go test ./compatibility/loki/cmd/loki-compliance-tester/` — 18/18 pass, including 5 new tests for `baselineKey`, `readSkipBaseline`, `checkSkipBaseline` (match / added / removed), and `writeSkipBaseline` round-trip.
- [x] `loki-compliance-tester -regen-baseline -skip-baseline=/tmp/x -corpus=...` regenerates a byte-identical file vs the hand-written baseline (15 entries).
- [x] Tampered baseline drift is rejected with structured per-key error messaging.
- [x] Happy-path baseline check passes before the normal HTTP flow proceeds.
- [ ] CI: `check`, `lint`, `forbid-skip`, `compatibility/loki` green.