### PR TITLE
fix(tempo): SQL-side zero-fill via countIf, retire handler zeroFillMatrixGrid

### DIFF
--- a/internal/api/tempo/grpc/metrics.go
+++ b/internal/api/tempo/grpc/metrics.go
@@ -21,9 +21,10 @@ import (
 // mode emits one QueryRangeResponse after eager drain; instant is the
 // single-bucket variant of the same shape). Frame batching does not
 // apply — the matrix / instant pivot pipelines need the full row set
-// in hand before zero-fill + quantile post-processing can produce a
-// well-formed series envelope, so the streaming-friendly behaviour is
-// to flush exactly one frame on completion.
+// in hand before quantile post-processing can produce a well-formed
+// series envelope (matrix-grid zero-fill happens SQL-side; see
+// internal/chsql/range_window.go), so the streaming-friendly behaviour
+// is to flush exactly one frame on completion.
 //
 // Both methods shadow the embedded
 // tempopb.UnimplementedStreamingQuerierServer in service.go via Go's

--- a/internal/api/tempo/grpc/metrics_test.go
+++ b/internal/api/tempo/grpc/metrics_test.go
@@ -125,14 +125,12 @@ func keyValueValue(kv v1.KeyValue) string {
 // TestMetricsQueryRange_FrameShape feeds a single observed-bucket
 // fixture through MetricsQueryRange and asserts the wire envelope: one
 // frame, one TimeSeries, label set populated with the synthetic
-// `__name__=rate` for an ungrouped query, samples sorted ascending,
-// zero-fill of the trailing 4th anchor at value 0.
+// `__name__=rate` for an ungrouped query, samples sorted ascending.
 //
-// 3-minute fixture window @ 60s step → 4 anchors after zero-fill
-// (10:00 / 10:01 / 10:02 / 10:03); the stub returns observed values at
-// the first three; the fill injects a zero at the trailing anchor —
-// same contract the HTTP TestMetricsQueryRange_SingleSeriesNoGroupBy
-// pins on the JSON envelope, replayed across the gRPC wire shape.
+// Matrix-grid zero-fill is the SQL emitter's concern
+// (internal/chsql/range_window.go), so the stub-backed test sees the
+// row stream the stub returns — three samples here — passed through
+// unchanged.
 func TestMetricsQueryRange_FrameShape(t *testing.T) {
 	t.Parallel()
 	ts := func(min int) time.Time {
@@ -171,10 +169,10 @@ func TestMetricsQueryRange_FrameShape(t *testing.T) {
 	if len(got.Labels) != 1 || got.Labels[0].Key != "__name__" || keyValueValue(got.Labels[0]) != "rate" {
 		t.Errorf("labels: want single {__name__=rate}, got %+v", got.Labels)
 	}
-	if len(got.Samples) != 4 {
-		t.Fatalf("samples: want 4 (3 observed + 1 zero-fill), got %d: %+v", len(got.Samples), got.Samples)
+	if len(got.Samples) != 3 {
+		t.Fatalf("samples: want 3 (stub rows pass through unchanged), got %d: %+v", len(got.Samples), got.Samples)
 	}
-	for i, want := range []float64{0.5, 1.5, 2.0, 0.0} {
+	for i, want := range []float64{0.5, 1.5, 2.0} {
 		if got.Samples[i].Value != want {
 			t.Errorf("sample[%d].Value: got %v, want %v", i, got.Samples[i].Value, want)
 		}

--- a/internal/api/tempo/grpc_exports.go
+++ b/internal/api/tempo/grpc_exports.go
@@ -23,8 +23,10 @@ import (
 //    DISTINCT-attribute-key lookup the HTTP handler performs.
 //  - **Metrics RPC helpers** — ExecMetricsRange / ExecMetricsInstant
 //    drive the full MetricsQueryRange / MetricsQueryInstant pipeline
-//    end-to-end and return the post-quantile-collapse, post-zero-fill,
-//    post-exemplar-attach series the HTTP handler returns.
+//    end-to-end and return the post-quantile-collapse,
+//    post-exemplar-attach series the HTTP handler returns. (Zero-fill
+//    of empty matrix anchors lives in the SQL emitter — see
+//    internal/chsql/range_window.go.)
 //
 // Keeping every export in a single file means PR 2 (gRPC Search),
 // PR 3 (gRPC tags), and PR 4 (gRPC metrics) each touch one new gRPC
@@ -135,10 +137,12 @@ func (h *Handler) FetchTagValues(ctx context.Context, r ResolvedTagName, start, 
 // ExecMetricsRangeResult is the post-execution intermediate shape the
 // gRPC MetricsQueryRange RPC translates into tempopb.TimeSeries. Each
 // MetricsSeries already carries the post-quantile-collapse,
-// post-zero-fill, post-exemplar-attach view of the data; the gRPC
-// handler only re-shapes labels + samples into the proto envelope.
+// post-exemplar-attach view of the data; the gRPC handler only
+// re-shapes labels + samples into the proto envelope. (Matrix-shape
+// zero-fill lives in the SQL emitter — see
+// internal/chsql/range_window.go.)
 type ExecMetricsRangeResult struct {
-	// Series is the post-processed (quantile-collapse, zero-fill,
+	// Series is the post-processed (quantile-collapse,
 	// exemplars-attached) series list — same value the HTTP handler
 	// passes to writeJSON.
 	Series []MetricsSeries
@@ -158,8 +162,8 @@ type ExecMetricsRangeResult struct {
 //     SQL emits the matrix-shape (group, anchor, value) tuples.
 //  5. Run engine.QueryPlan — emit + execute against ClickHouse.
 //  6. Post-process quantile buckets (no-op for non-quantile ops).
-//  7. Pivot row stream → MetricsSeries, zero-fill the matrix grid
-//     across [Start, End] for count/rate/quantile.
+//  7. Pivot row stream → MetricsSeries (matrix-grid zero-fill happens
+//     SQL-side via the chsql countIf / conditional-bucket emit).
 //  8. Best-effort exemplar enrichment — failure here keeps the
 //     series envelope but emits a Logger.Warn (same policy as HTTP).
 //
@@ -219,8 +223,10 @@ func (h *Handler) ExecMetricsRange(ctx context.Context, query string, start, end
 	if metrics.Op == chplan.MetricsOpQuantileOverTime {
 		samples = postProcessQuantileBuckets(samples, metrics)
 	}
+	// Matrix-shape zero-fill is owned by the SQL emitter (see
+	// internal/chsql/range_window.go's countIf / conditional-bucket
+	// emit). No Go-side post-pass.
 	series := toMetricsSeries(samples, metrics)
-	series = zeroFillMatrixGrid(series, metrics, start, end, step)
 
 	// Best-effort exemplar enrichment. A failed emit / query keeps
 	// the empty Exemplars slice already attached by toMetricsSeries
@@ -257,7 +263,7 @@ type ExecMetricsInstantResult struct {
 // one anchor per series — Tempo's translateQueryRangeToInstant
 // semantics (one (labels, scalar) tuple per series at end-of-window).
 //
-// The instant path does NOT zero-fill (one anchor only) and does NOT
+// The instant path produces one anchor only (no matrix grid) and does NOT
 // attach exemplars (Tempo's instant envelope carries no Exemplars
 // field — see tempopb.InstantSeries). Quantile post-processing still
 // runs so the per-phi label shape is honoured.

--- a/internal/api/tempo/metrics_query_range.go
+++ b/internal/api/tempo/metrics_query_range.go
@@ -258,46 +258,29 @@ func (h *Handler) handleMetricsQueryRange(w http.ResponseWriter, r *http.Request
 		"sql", res.SQL, "args", res.Args)
 
 	// quantile_over_time: the matrix SQL emits `(group, anchor, bucket,
-	// count)` tuples; collapse them into the per-(group, phi, anchor)
-	// scalar wire shape via Tempo's `Log2QuantileWithBucket`. The
-	// remainder of the pipeline (toMetricsSeries / zeroFillMatrixGrid)
-	// sees pre-collapsed `chclient.Sample` values where each entry
-	// already carries the synthetic `p=<phi>` label and `Value` is the
-	// per-anchor quantile.
+	// count)` tuples (with synthetic 0-bucket / 0-count phantom rows
+	// per (group, anchor) so empty anchors survive the GROUP BY).
+	// Collapse the bucket rows into the per-(group, phi, anchor) scalar
+	// wire shape via Tempo's `Log2QuantileWithBucket` — empty anchors
+	// resolve to 0 because the phantom-bucket totalCount is zero.
 	samples := res.Samples
 	if metrics.Op == chplan.MetricsOpQuantileOverTime {
 		samples = postProcessQuantileBuckets(samples, metrics)
 	}
 
+	// Matrix-shape zero-fill is the SQL emitter's concern, not the
+	// handler's: `internal/chsql.emitRangeWindowMetrics` swaps the
+	// outer WHERE clause for `countIf(<window pred>)` on the
+	// count_over_time / rate paths, and
+	// `emitRangeWindowMetricsQuantileBuckets` emits a phantom
+	// 0-bucket / 0-count row per (group, anchor) — both produce one
+	// row per (group, anchor) tuple the inner fanout materialises,
+	// matching Tempo's StepAggregator + HistogramAggregator
+	// emit-every-anchor wire shape without a Go-side post-pass. See
+	// `metricsOpZeroFillsEmptyBuckets` in internal/chsql/range_window.go
+	// for the per-op rationale (NaN-skip operators — sum / avg / min /
+	// max — keep the WHERE-filtered "observed-only" shape).
 	series := toMetricsSeries(samples, metrics)
-	// Zero-fill the matrix step grid for count/rate AND quantile
-	// operators so the response shape matches Tempo's reference
-	// engine_metrics.go. Two distinct upstream code paths converge on a
-	// "zero-fill every anchor across [Start, End]" emit shape:
-	//
-	//   - count_over_time / rate: StepAggregator pre-allocates one
-	//     CountOverTimeAggregator per interval whose default Sample()
-	//     is 0, so ToProto walks all intervals and emits 0 for empty
-	//     buckets.
-	//   - quantile_over_time: HistogramAggregator.Results explicitly
-	//     sets `ts.Values[i] = 0.0` for any interval with no buckets
-	//     (`if len(in.hist[i].Buckets) == 0 { ts.Values[i] = 0.0 }`),
-	//     so ToProto again emits a value at every anchor.
-	//
-	// Cerberus's matrix SQL emits one row per (group, anchor) bucket
-	// only when at least one span falls in (anchor_ts - range,
-	// anchor_ts]; without this post-step empty buckets disappear,
-	// dropping samples count from N to (#observed buckets) — the smoke
-	// corpus's count_over_time_groupby_service case showed tempo=121 vs
-	// cerberus=2 (and quantile_over_time_p95 showed tempo=121 vs
-	// cerberus=3) against the same seeded dataset for that reason.
-	//
-	// Tempo's OverTimeAggregator (sum / avg / min / max) initialises
-	// its value to NaN, and the ToProto loop skips NaN samples — those
-	// operators already match cerberus's observed-only emission without
-	// a zero-fill pass, so the fill is intentionally scoped to
-	// count/rate/quantile only.
-	series = zeroFillMatrixGrid(series, metrics, start, end, step)
 
 	exSQL, exArgs, exErr := chsql.EmitMetricsExemplars(ctx, rw, metrics,
 		h.Schema.TraceIDColumn, h.Schema.SpanIDColumn, 1)
@@ -788,136 +771,6 @@ func toMetricsSeries(samples []chclient.Sample, m *chplan.MetricsAggregate) []Me
 		})
 	}
 	return out
-}
-
-// zeroFillMatrixGrid extends each series's Samples to the full matrix
-// step grid for `| count_over_time()`, `| rate()`, and
-// `| quantile_over_time(...)` queries, inserting 0-valued samples for
-// anchors that had no observed spans.
-//
-// Two upstream Tempo aggregators emit zeros (rather than NaN) for
-// empty buckets, so each anchor across [Start, End] surfaces as a
-// sample on the wire:
-//
-//   - count_over_time / rate: StepAggregator pre-allocates one
-//     CountOverTimeAggregator per interval whose default Sample() is 0
-//     (count starts at zero) — `pkg/traceql/engine_metrics.go`'s
-//     StepAggregator pre-fills the vector slice with
-//     NewCountOverTimeAggregator() instances before any Observe runs.
-//   - quantile_over_time: HistogramAggregator.Results explicitly sets
-//     `ts.Values[i] = 0.0` when `len(in.hist[i].Buckets) == 0`
-//     (`pkg/traceql/engine_metrics.go`). Both paths then run through
-//     SeriesSet.ToProto, which only skips a sample if its value is
-//     math.NaN — 0.0 survives and reaches the wire.
-//
-// Cerberus's matrix SQL only emits rows for (group, anchor) pairs
-// where at least one span lands in (anchor_ts - range, anchor_ts], so
-// without this fill the response loses every empty bucket and the
-// differ trips on `samples count tempo=N vs cerberus=M` (see PR #550
-// for count/rate; the quantile gap surfaced as
-// `metrics_quantile_over_time_p95: samples count tempo=121 vs
-// cerberus=3` once #562 unblocked the per-phi label shape).
-//
-// The fill anchors mirror the chsql emitter's
-// arrayJoin(arrayMap(i -> End - i*Step, range(0, N))) grid:
-// anchor[i] = end - i*step for i in [0, N), with N = (end-start)/step + 1.
-// In ascending timestamp order that yields [start, start+step, ...,
-// end-step, end]. Each series is filled independently; series that
-// never observed any span are left absent (matches Tempo's
-// SpanAggregator.Observe gating — HistogramAggregator only initialises
-// per-series interval slices when at least one span lands in the
-// query window).
-//
-// No-op when:
-//   - step <= 0 (defensive — the handler rejects step <= 0 upstream,
-//     so this branch only fires under tests that bypass the request
-//     validator),
-//   - start / end aren't both set (the chsql matrix path falls back to
-//     a single anchor at End in that case; one sample per series is
-//     fine without a fill),
-//   - the metrics op isn't count_over_time / rate / quantile_over_time
-//     (sum / avg / min / max share Tempo's NaN-skip semantics — see
-//     OverTimeAggregator initialisation in engine_metrics.go, which
-//     starts val=NaN and the ToProto loop skips NaN-valued samples),
-//   - the input slice is empty (no observed series → no zero-fill;
-//     mirrors Tempo's behaviour of only initialising entries via
-//     SpanAggregator.Observe).
-func zeroFillMatrixGrid(series []MetricsSeries, m *chplan.MetricsAggregate, start, end time.Time, step time.Duration) []MetricsSeries {
-	if len(series) == 0 || step <= 0 || start.IsZero() || end.IsZero() {
-		return series
-	}
-	if !metricsOpZeroFillsEmptyBuckets(m.Op) {
-		return series
-	}
-	span := end.Sub(start)
-	if span < 0 {
-		return series
-	}
-	stepNS := step.Nanoseconds()
-	if stepNS <= 0 {
-		return series
-	}
-	// N = span/step + 1 matches chsql's numAnchors so the post-fill
-	// grid exactly aligns with the matrix anchor set the emitter
-	// produced.
-	n := span.Nanoseconds()/stepNS + 1
-	if n <= 1 {
-		return series
-	}
-	// Pre-compute the anchor grid as DateTime64-precision unix-milli
-	// values so the merge below operates on integer keys (the wire
-	// shape's TimestampMs).
-	anchors := make([]int64, 0, n)
-	for i := int64(0); i < n; i++ {
-		anchorTS := end.Add(-time.Duration(i) * step)
-		anchors = append(anchors, anchorTS.UnixMilli())
-	}
-	// Anchors come back end-down; reorder to ascending so the merged
-	// samples slice ends up sorted (toMetricsSeries already sorts each
-	// series ascending; we keep the invariant after fill).
-	sort.Slice(anchors, func(i, j int) bool { return anchors[i] < anchors[j] })
-
-	for i := range series {
-		present := make(map[int64]struct{}, len(series[i].Samples))
-		for _, s := range series[i].Samples {
-			present[s.TimestampMs] = struct{}{}
-		}
-		out := make([]MetricsSample, 0, len(anchors))
-		for _, ts := range anchors {
-			if _, ok := present[ts]; ok {
-				continue
-			}
-			out = append(out, MetricsSample{TimestampMs: ts, Value: 0})
-		}
-		if len(out) == 0 {
-			continue
-		}
-		series[i].Samples = append(series[i].Samples, out...)
-		sort.Slice(series[i].Samples, func(a, b int) bool {
-			return series[i].Samples[a].TimestampMs < series[i].Samples[b].TimestampMs
-		})
-	}
-	return series
-}
-
-// metricsOpZeroFillsEmptyBuckets reports whether the given
-// MetricsAggregate.Op surfaces 0-valued samples for empty buckets on
-// Tempo's wire (rather than NaN-skipping them). The two upstream code
-// paths that produce zeros are StepAggregator + CountOverTimeAggregator
-// (for `count_over_time` and `rate` — the underlying counter aggregator
-// starts at zero) and HistogramAggregator.Results (for
-// `quantile_over_time` — explicitly sets `ts.Values[i] = 0.0` when the
-// bucket has no histogram entries). All other operators reach the wire
-// via OverTimeAggregator's NaN-init path, so cerberus's observed-only
-// emission already matches Tempo's output and needs no fill.
-func metricsOpZeroFillsEmptyBuckets(op chplan.MetricsOp) bool {
-	switch op {
-	case chplan.MetricsOpCountOverTime,
-		chplan.MetricsOpRate,
-		chplan.MetricsOpQuantileOverTime:
-		return true
-	}
-	return false
 }
 
 // labelsFromSample materialises the {key,value} pair slice for one

--- a/internal/api/tempo/metrics_query_range_test.go
+++ b/internal/api/tempo/metrics_query_range_test.go
@@ -37,15 +37,11 @@ const (
 )
 
 // TestMetricsQueryRange_SingleSeriesNoGroupBy — a bare `| rate()` over
-// the full spans table returns a single series (no labels). The handler
-// zero-fills the matrix step grid for count/rate operators so the
-// response covers every anchor across [start, end] spaced by step —
-// matching Tempo's StepAggregator pre-allocating one CountOverTimeAggregator
-// per interval. With a 3-minute fixture window and 60s step that's
-// 4 anchors (10:00, 10:01, 10:02, 10:03); the stub returns observed
-// values at the first three, the fill injects a 0-valued sample at the
-// trailing anchor so the samples stream matches the wire-grid Tempo
-// emits.
+// the full spans table returns a single series (no labels). Matrix-shape
+// zero-fill is the SQL emitter's concern (countIf over the per-anchor
+// predicate, see internal/chsql/range_window.go), so the handler returns
+// whatever row stream the cursor surfaced — three stub samples here
+// pass through unchanged, sorted ascending by timestamp.
 func TestMetricsQueryRange_SingleSeriesNoGroupBy(t *testing.T) {
 	t.Parallel()
 
@@ -98,14 +94,17 @@ func TestMetricsQueryRange_SingleSeriesNoGroupBy(t *testing.T) {
 	if len(s.Labels) != 1 || s.Labels[0].Key != "__name__" || s.Labels[0].Value != "rate" {
 		t.Errorf("expected single {__name__=rate} label for ungrouped rate(), got %+v", s.Labels)
 	}
-	// 3-minute window @ 60s step → 4 anchors after zero-fill (10:00 /
-	// 10:01 / 10:02 / 10:03), with the trailing anchor synthesised at
-	// value 0 since the stub didn't observe a span there.
-	if len(s.Samples) != 4 {
-		t.Fatalf("expected 4 samples (3 observed + 1 zero-fill), got %d: %+v", len(s.Samples), s.Samples)
+	// The stub returns 3 samples; the handler passes them through to
+	// the wire envelope sorted ascending by timestamp. Zero-fill of
+	// the matrix step grid lives in the SQL emitter
+	// (internal/chsql/range_window.go), so the handler-level test
+	// pins the three observed values' ascending order rather than
+	// the full step grid (which only manifests against a real CH).
+	if len(s.Samples) != 3 {
+		t.Fatalf("expected 3 samples passed through from stub, got %d: %+v", len(s.Samples), s.Samples)
 	}
-	// Sorted ascending: 0.5, 1.5, 2.0, 0 (fill) in that order.
-	for i, want := range []float64{0.5, 1.5, 2.0, 0.0} {
+	// Sorted ascending: 0.5, 1.5, 2.0 in that order.
+	for i, want := range []float64{0.5, 1.5, 2.0} {
 		if s.Samples[i].Value != want {
 			t.Errorf("sample[%d].Value = %v, want %v", i, s.Samples[i].Value, want)
 		}
@@ -185,17 +184,16 @@ func TestMetricsQueryRange_MultiSeriesGroupBy(t *testing.T) {
 	if _, ok := byService["backend"]; !ok {
 		t.Errorf("missing 'backend' series: %+v", body.Series)
 	}
-	// Each series's samples cover the full matrix grid: 4 anchors over
-	// the 3-minute window @ 60s step, with two observed values (mins
-	// 0 / 1) and two zero-filled anchors (mins 2 / 3) so the response
-	// shape matches Tempo's StepAggregator emit (count_over_time over
-	// empty buckets surfaces as 0, not as a missing sample).
-	if len(byService["frontend"].Samples) != 4 {
-		t.Errorf("expected 4 samples for frontend (2 observed + 2 zero-fill), got %d: %+v",
+	// Each series surfaces the stub's per-(group, anchor) rows
+	// unchanged (two per service). Matrix-grid zero-fill is the SQL
+	// emitter's concern (internal/chsql/range_window.go); the handler
+	// only pivots the row stream into the Tempo series envelope.
+	if len(byService["frontend"].Samples) != 2 {
+		t.Errorf("expected 2 stub samples for frontend, got %d: %+v",
 			len(byService["frontend"].Samples), byService["frontend"].Samples)
 	}
-	if len(byService["backend"].Samples) != 4 {
-		t.Errorf("expected 4 samples for backend (2 observed + 2 zero-fill), got %d: %+v",
+	if len(byService["backend"].Samples) != 2 {
+		t.Errorf("expected 2 stub samples for backend, got %d: %+v",
 			len(byService["backend"].Samples), byService["backend"].Samples)
 	}
 }
@@ -236,101 +234,87 @@ func TestMetricsQueryRange_EmptyResult(t *testing.T) {
 	}
 }
 
-// TestMetricsQueryRange_ZeroFillCountOverTime pins the contract that
-// `count_over_time` (and `rate`) responses zero-fill the full matrix
-// step grid across [start, end] — even buckets where no spans landed —
-// to match Tempo's reference engine_metrics.go StepAggregator, which
-// pre-allocates one CountOverTimeAggregator per interval (default
-// Sample()=0). Without this, the tempo-compat differ trips on
-// `samples count tempo=N vs cerberus=M` for count/rate queries whose
-// seeded data only spans a few buckets of the request window.
+// TestMetricsQueryRange_ZeroFillSQLShapeCountOverTime pins the contract
+// that count_over_time / rate matrix queries push the per-anchor window
+// predicate into a `countIf(...)` reducer (rather than the outer WHERE
+// clause). The inner-fanout subquery materialises one (group, anchor)
+// row per Inner row × N anchors, so the outer GROUP BY emits a row at
+// every (observed-group, anchor) tuple regardless of whether any
+// sample landed in (anchor_ts - range, anchor_ts] — countIf returns 0
+// for empty anchors. This is the SQL-level zero-fill that replaced the
+// handler-side `zeroFillMatrixGrid` post-pass (see PR removing the
+// Go-side fill).
 //
-// Setup: 3-minute window @ 60s step → 4 anchors (10:00 / 10:01 / 10:02
-// / 10:03). The CH stub returns exactly one row (10:01); the handler
-// must surface a 4-sample stream with the missing three anchors at
-// value 0.
-func TestMetricsQueryRange_ZeroFillCountOverTime(t *testing.T) {
+// The handler-with-stub harness can't observe the fill end-to-end
+// because the stub returns pre-built `[]chclient.Sample` rather than
+// executing SQL; the assertion lives on the captured `q.lastSQL`
+// instead, with the SQL contract that the runtime executes proven by
+// chsql-layer unit tests + the compatibility suite against a real CH.
+func TestMetricsQueryRange_ZeroFillSQLShapeCountOverTime(t *testing.T) {
 	t.Parallel()
 
-	mid := time.Date(2026, 5, 12, 10, 1, 0, 0, time.UTC)
-	q := &stubQuerier{samples: []chclient.Sample{{
-		MetricName: "",
-		// Matrix-shape SQL projects `map('__name__', 'count_over_time')`
-		// for ungrouped queries (see wrapMetricsForSample); stub mimics
-		// the cursor's surfaced Labels map.
-		Labels:    map[string]string{"__name__": "count_over_time"},
-		Timestamp: mid,
-		Value:     7.0,
-	}}}
-	srv := newServer(q, "v1.0.0-test")
-	t.Cleanup(srv.Close)
+	for _, query := range []string{
+		"{} | count_over_time()",
+		"{} | rate()",
+	} {
+		query := query
+		t.Run(query, func(t *testing.T) {
+			t.Parallel()
 
-	u := metricsQueryRangeURL(srv.URL, "{} | count_over_time()", map[string]string{
-		"start": fixtureStartUnix,
-		"end":   fixtureEndUnix,
-		"step":  "60s",
-	})
-	resp, err := http.Get(u)
-	if err != nil {
-		t.Fatalf("GET: %v", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
-	}
+			q := &stubQuerier{samples: nil}
+			srv := newServer(q, "v1.0.0-test")
+			t.Cleanup(srv.Close)
 
-	var body tempo.MetricsQueryRangeResponse
-	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	if len(body.Series) != 1 {
-		t.Fatalf("expected 1 series, got %d: %+v", len(body.Series), body)
-	}
-	s := body.Series[0]
-	if len(s.Samples) != 4 {
-		t.Fatalf("expected 4 samples (1 observed + 3 zero-fill), got %d: %+v", len(s.Samples), s.Samples)
-	}
-	// Samples MUST be sorted ascending by timestamp and the observed
-	// sample's value must survive the fill verbatim. Missing anchors
-	// land at 0.
-	wantValues := []float64{0.0, 7.0, 0.0, 0.0}
-	for i, want := range wantValues {
-		if s.Samples[i].Value != want {
-			t.Errorf("sample[%d].Value = %v, want %v (full stream: %+v)", i, s.Samples[i].Value, want, s.Samples)
-		}
-	}
-	for i := 1; i < len(s.Samples); i++ {
-		if s.Samples[i-1].TimestampMs >= s.Samples[i].TimestampMs {
-			t.Errorf("samples not sorted ascending: %+v", s.Samples)
-		}
-	}
-	// Sample timestamps must exactly cover the matrix anchor grid the
-	// chsql emitter produced — `end - i*step` for i in [0, N). Verify
-	// the first / last anchors line up with fixtureStartUnix /
-	// fixtureEndUnix so the wire grid aligns with what Tempo returns
-	// for the same request.
-	startMs := mustParseUnix(t, fixtureStartUnix).UnixMilli()
-	endMs := mustParseUnix(t, fixtureEndUnix).UnixMilli()
-	if s.Samples[0].TimestampMs != startMs {
-		t.Errorf("first sample ts = %d, want fixtureStart=%d", s.Samples[0].TimestampMs, startMs)
-	}
-	if s.Samples[len(s.Samples)-1].TimestampMs != endMs {
-		t.Errorf("last sample ts = %d, want fixtureEnd=%d", s.Samples[len(s.Samples)-1].TimestampMs, endMs)
+			u := metricsQueryRangeURL(srv.URL, query, map[string]string{
+				"start": fixtureStartUnix,
+				"end":   fixtureEndUnix,
+				"step":  "60s",
+			})
+			resp, err := http.Get(u)
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+			}
+
+			// The handler issues two SQL statements per request:
+			// the matrix-shape query (arrayJoin fanout) plus the
+			// exemplar lookup. Reach the matrix SQL via the
+			// arrayJoin needle so the assertion targets the right
+			// statement; q.lastSQL would point at the exemplar
+			// query (last one executed).
+			matrixSQL := findSQLContaining(t, q.queriedSQLs, "arrayJoin")
+			// Reducer shape: countIf(<window pred>) — the per-anchor
+			// window predicate lives inside the aggregate, not the
+			// outer WHERE clause.
+			assertSQLContains(t, matrixSQL,
+				"countIf(ts > anchor_ts - toIntervalNanosecond(")
+			// The outer WHERE that the legacy path produced is now
+			// suppressed for count/rate (the window predicate moved
+			// into countIf). Pin the absence so a regression toward
+			// the old shape surfaces here.
+			if strings.Contains(matrixSQL, "WHERE ts > anchor_ts -") {
+				t.Errorf("count/rate matrix SQL must not carry an outer WHERE on the window predicate (it moved into countIf); SQL=%s", matrixSQL)
+			}
+		})
 	}
 }
 
 // TestMetricsQueryRange_ZeroFillSkippedForOverTimeAggs pins the
-// contract that the zero-fill pass does NOT fire for sum / avg / min /
-// max _over_time. Tempo's OverTimeAggregator initialises its value to
-// NaN and the SeriesSet.ToProto loop skips NaN samples
-// (`pkg/traceql/engine_metrics.go`'s OverTimeAggregator + ToProto), so
-// the observed-only emission cerberus produces is the wire-correct
-// match — zero-filling would inject false zeros where Tempo emits
-// nothing.
+// contract that the SQL emitter does NOT push the window predicate
+// into a conditional aggregate for sum / avg / min / max _over_time —
+// it stays in the outer WHERE clause. Tempo's OverTimeAggregator
+// initialises its value to NaN and the SeriesSet.ToProto loop skips
+// NaN samples (`pkg/traceql/engine_metrics.go`'s OverTimeAggregator +
+// ToProto), so the observed-only emission is the wire-correct match —
+// pushing the predicate into a sumIf / avgIf would emit 0 for empty
+// buckets and inject false zeros where Tempo emits nothing.
 //
 // `quantile_over_time` is the inverse case (HistogramAggregator.Results
 // emits 0.0 at empty buckets, not NaN) and is asserted by
-// TestMetricsQueryRange_ZeroFillQuantileOverTime below.
+// TestMetricsQueryRange_ZeroFillSQLShapeQuantileOverTime below.
 func TestMetricsQueryRange_ZeroFillSkippedForOverTimeAggs(t *testing.T) {
 	t.Parallel()
 
@@ -387,57 +371,63 @@ func TestMetricsQueryRange_ZeroFillSkippedForOverTimeAggs(t *testing.T) {
 			}
 			s := body.Series[0]
 			if len(s.Samples) != 1 {
-				t.Errorf("expected 1 observed sample for %s (no zero-fill), got %d: %+v",
+				t.Errorf("expected 1 observed sample for %s (NaN-skip path: no SQL-side fill), got %d: %+v",
 					tc.op, len(s.Samples), s.Samples)
 			}
 			if len(s.Samples) > 0 && s.Samples[0].Value != 42.0 {
 				t.Errorf("expected observed sample value 42, got %v", s.Samples[0].Value)
 			}
+			// SQL contract: the window predicate stays in the outer
+			// WHERE for NaN-skip operators — pushing it into a sumIf /
+			// avgIf would surface 0 at empty buckets and diverge from
+			// Tempo's NaN-skip emit. Pin the WHERE shape so a future
+			// refactor doesn't silently extend the countIf path. The
+			// matrix-shape SQL is the arrayJoin-fanout statement (the
+			// handler also fires an exemplar lookup).
+			if len(q.queriedSQLs) > 0 {
+				matrixSQL := findSQLContaining(t, q.queriedSQLs, "arrayJoin")
+				assertSQLContains(t, matrixSQL,
+					"WHERE ts > anchor_ts - toIntervalNanosecond(")
+				if strings.Contains(matrixSQL, "countIf(") {
+					t.Errorf("%s SQL must not use countIf (NaN-skip op), got %s", tc.op, matrixSQL)
+				}
+			}
 		})
 	}
 }
 
-// TestMetricsQueryRange_ZeroFillQuantileOverTime pins the contract
-// that quantile_over_time responses zero-fill the full matrix step
-// grid across [start, end] — even buckets where no spans landed — to
-// match Tempo's reference HistogramAggregator. Its Results method
-// explicitly sets `ts.Values[i] = 0.0` for any interval whose bucket
-// list is empty (`pkg/traceql/engine_metrics.go`), so ToProto walks
-// every anchor and emits a 0-valued sample rather than NaN-skipping
-// it. Without this fill the tempo-compat differ trips on
-// `metrics_quantile_over_time_p95: samples count tempo=121 vs
-// cerberus=3` against the same seeded dataset (PR #562 unblocked the
-// per-phi label shape; this case is what surfaced the bucket-count
-// gap once the label shape stopped masking it).
+// TestMetricsQueryRange_ZeroFillSQLShapeQuantileOverTime pins the
+// SQL-emit contract that ensures `quantile_over_time` matrix queries
+// produce a row at every (observed-group, anchor) tuple — even anchors
+// where no spans landed — to match Tempo's reference
+// HistogramAggregator.Results emit of `ts.Values[i] = 0.0` for empty
+// buckets. The chsql emitter wraps the per-row bucket projection in
+// `if(<window pred>, <real bucket>, 0)` and the count in
+// `countIf(<window pred>)` — empty anchors fall into a phantom
+// `__bucket=0 / count=0` row that the handler's post-processor
+// (Log2QuantileWithBucket) resolves to a 0 sample.
 //
-// Setup: 3-minute window @ 60s step → 4 anchors (10:00 / 10:01 / 10:02
-// / 10:03). The CH stub returns exactly one bucket-shape row at the
-// middle anchor (10:01) — the post-processor synthesises the `p="0.95"`
-// label and runs `Log2QuantileWithBucket(0.95, [...])` to produce the
-// per-anchor value; the handler then surfaces a 4-sample stream with
-// the missing three anchors at value 0.
-func TestMetricsQueryRange_ZeroFillQuantileOverTime(t *testing.T) {
+// This replaced the Go-side `zeroFillMatrixGrid` post-pass that lived
+// in the handler before; the assertion lives on the captured SQL
+// because the handler-with-stub harness can't observe the SQL fill
+// (the stub returns pre-built rows rather than executing SQL). The
+// runtime fill is covered by chsql-layer unit tests
+// (TestRangeWindowMetricsQuantileBuckets*) plus the tempo
+// compatibility suite running against a real ClickHouse.
+func TestMetricsQueryRange_ZeroFillSQLShapeQuantileOverTime(t *testing.T) {
 	t.Parallel()
 
-	mid := time.Date(2026, 5, 12, 10, 1, 0, 0, time.UTC)
-	// Single bucket at 0.5s holding 5 samples — Log2QuantileWithBucket
-	// for p=0.95 over a single 0.5s bucket returns the bucket's Max
-	// (0.5) because the per-quantile sample-count walk consumes the
-	// whole bucket and reports `b.Max`.
-	q := &stubQuerier{samples: []chclient.Sample{{
-		MetricName: "",
-		Labels:     map[string]string{"__bucket": "0.5"},
-		Timestamp:  mid,
-		Value:      5,
-	}}}
+	q := &stubQuerier{samples: nil}
 	srv := newServer(q, "v1.0.0-test")
 	t.Cleanup(srv.Close)
 
-	u := metricsQueryRangeURL(srv.URL, "{} | quantile_over_time(duration, 0.95)", map[string]string{
-		"start": fixtureStartUnix,
-		"end":   fixtureEndUnix,
-		"step":  "60s",
-	})
+	u := metricsQueryRangeURL(srv.URL,
+		"{} | quantile_over_time(duration, 0.95)",
+		map[string]string{
+			"start": fixtureStartUnix,
+			"end":   fixtureEndUnix,
+			"step":  "60s",
+		})
 	resp, err := http.Get(u)
 	if err != nil {
 		t.Fatalf("GET: %v", err)
@@ -447,44 +437,42 @@ func TestMetricsQueryRange_ZeroFillQuantileOverTime(t *testing.T) {
 		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
 	}
 
-	var body tempo.MetricsQueryRangeResponse
-	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
-		t.Fatalf("decode: %v", err)
+	// The handler issues two SQL statements per request: matrix + the
+	// exemplar lookup. Reach the matrix SQL via the arrayJoin needle
+	// so the assertion targets the right statement.
+	matrixSQL := findSQLContaining(t, q.queriedSQLs, "arrayJoin")
+	// Bucket projection wraps the real bucket in `if(<pred>, ..., 0)`
+	// so non-matching rows fall into the phantom 0-bucket group. The
+	// count wraps in `countIf(<pred>)` so observed buckets count
+	// matched rows and the phantom buckets count zero.
+	assertSQLContains(t, matrixSQL,
+		"if(ts > anchor_ts - toIntervalNanosecond(")
+	assertSQLContains(t, matrixSQL, ", 0)")
+	assertSQLContains(t, matrixSQL,
+		"countIf(ts > anchor_ts - toIntervalNanosecond(")
+	// The outer WHERE that the legacy quantile path produced is now
+	// suppressed (the window predicate + bucketize-min guard moved
+	// into the conditional projections). Pin the absence so a
+	// regression toward the old shape surfaces here.
+	if strings.Contains(matrixSQL, "WHERE ts > anchor_ts -") {
+		t.Errorf("quantile matrix SQL must not carry an outer WHERE on the window predicate; SQL=%s", matrixSQL)
 	}
-	if len(body.Series) != 1 {
-		t.Fatalf("expected 1 series, got %d: %+v", len(body.Series), body)
-	}
-	s := body.Series[0]
-	if len(s.Samples) != 4 {
-		t.Fatalf("expected 4 samples (1 observed + 3 zero-fill), got %d: %+v", len(s.Samples), s.Samples)
-	}
-	// Samples MUST be sorted ascending by timestamp and the observed
-	// sample's value must survive the fill verbatim. Missing anchors
-	// land at 0 (Tempo HistogramAggregator parity).
-	wantValues := []float64{0.0, 0.5, 0.0, 0.0}
-	for i, want := range wantValues {
-		if s.Samples[i].Value != want {
-			t.Errorf("sample[%d].Value = %v, want %v (full stream: %+v)", i, s.Samples[i].Value, want, s.Samples)
+}
+
+// findSQLContaining returns the first SQL string in haystack that
+// contains needle; fails the test if no match is found. Used to pluck
+// the matrix-shape SQL out of stubQuerier.queriedSQLs (which also
+// records the follow-up exemplar lookup) so assertions don't
+// accidentally bind to the wrong statement.
+func findSQLContaining(t *testing.T, haystack []string, needle string) string {
+	t.Helper()
+	for _, sql := range haystack {
+		if strings.Contains(sql, needle) {
+			return sql
 		}
 	}
-	for i := 1; i < len(s.Samples); i++ {
-		if s.Samples[i-1].TimestampMs >= s.Samples[i].TimestampMs {
-			t.Errorf("samples not sorted ascending: %+v", s.Samples)
-		}
-	}
-	// Sample timestamps must exactly cover the matrix anchor grid the
-	// chsql emitter produced — `end - i*step` for i in [0, N). Verify
-	// the first / last anchors line up with fixtureStartUnix /
-	// fixtureEndUnix so the wire grid aligns with what Tempo returns
-	// for the same request.
-	startMs := mustParseUnix(t, fixtureStartUnix).UnixMilli()
-	endMs := mustParseUnix(t, fixtureEndUnix).UnixMilli()
-	if s.Samples[0].TimestampMs != startMs {
-		t.Errorf("first sample ts = %d, want fixtureStart=%d", s.Samples[0].TimestampMs, startMs)
-	}
-	if s.Samples[len(s.Samples)-1].TimestampMs != endMs {
-		t.Errorf("last sample ts = %d, want fixtureEnd=%d", s.Samples[len(s.Samples)-1].TimestampMs, endMs)
-	}
+	t.Fatalf("no SQL containing %q in %d recorded statements: %v", needle, len(haystack), haystack)
+	return ""
 }
 
 // TestMetricsQueryRange_DurationAggInSeconds pins the contract that
@@ -1080,12 +1068,12 @@ func TestMetricsQueryRange_ExemplarsPopulated(t *testing.T) {
 		t.Fatalf("expected 1 series, got %d: %+v", len(body.Series), body)
 	}
 	got := body.Series[0]
-	// Matrix grid is 4 anchors (3-min window @ 60s step); two are
-	// observed (mins 0 / 1), the trailing pair (mins 2 / 3) are
-	// zero-filled so the count_over_time response matches Tempo's
-	// StepAggregator emit.
-	if len(got.Samples) != 4 {
-		t.Errorf("expected 4 samples (2 observed + 2 zero-fill), got %d: %+v", len(got.Samples), got.Samples)
+	// Stub returns the two observed-anchor rows; the handler passes
+	// them through without modification. Matrix-grid zero-fill lives
+	// in the SQL emitter (internal/chsql/range_window.go), so the
+	// handler-with-stub harness only sees the rows the stub yields.
+	if len(got.Samples) != 2 {
+		t.Errorf("expected 2 stub samples to pass through unchanged, got %d: %+v", len(got.Samples), got.Samples)
 	}
 	if len(got.Exemplars) != 2 {
 		t.Fatalf("expected 2 exemplars, got %d: %+v", len(got.Exemplars), got.Exemplars)

--- a/internal/api/tempo/metrics_query_range_test.go
+++ b/internal/api/tempo/metrics_query_range_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -610,18 +609,6 @@ func TestMetricsQueryRange_DurationAggInSeconds(t *testing.T) {
 			}
 		})
 	}
-}
-
-// mustParseUnix parses a unix-seconds string and returns a UTC time,
-// failing the test on parse error. Mirrors parseTempoTime's heuristics
-// but tightened to the int64-only path the fixture timestamps use.
-func mustParseUnix(t *testing.T, raw string) time.Time {
-	t.Helper()
-	n, err := strconv.ParseInt(raw, 10, 64)
-	if err != nil {
-		t.Fatalf("parse fixture unix %q: %v", raw, err)
-	}
-	return time.Unix(n, 0).UTC()
 }
 
 // TestMetricsQueryRange_BadInputs covers the 4xx surface: missing or

--- a/internal/chsql/range_window.go
+++ b/internal/chsql/range_window.go
@@ -814,15 +814,38 @@ func (e *emitter) emitRangeWindowMetrics(r *chplan.RangeWindow, m *chplan.Metric
 		outerSb.Select(func(b *Builder) { b.Ident(a) })
 	}
 	outerSb.Select(Col("anchor_ts"))
-	reducerFrag := metricsReducerFrag(m.Op, chName, params, args, rangeSeconds)
-	outerSb.Select(As(reducerFrag, m.ValueAlias))
 
-	// WHERE: ts ∈ (anchor_ts - range, anchor_ts] — left-open /
-	// right-closed, matching Tempo's IntervalMapperQueryRange.
-	outerSb.Where(
-		windowTsLowerBoundFrag(rangeNS),
-		verbatim("ts <= anchor_ts"),
-	)
+	// Zero-fill semantics live in the SQL for the two ops whose Tempo
+	// aggregators emit 0 for empty buckets — count_over_time and rate.
+	// The reducer becomes countIf(<window predicate>), so every
+	// (group, anchor) tuple that the inner fanout materialises (one per
+	// Inner row × N anchors) produces a row out of the outer GROUP BY
+	// regardless of whether any sample landed in that window — empty
+	// anchors emit countIf=0, observed anchors emit the real count. The
+	// handler's previous Go-side `zeroFillMatrixGrid` post-pass is
+	// retired; matrix-shape post-processing is the SQL emitter's
+	// concern, not the HTTP layer's.
+	//
+	// sum / avg / min / max / last / stddev / stdvar over_time keep the
+	// WHERE-based filter: Tempo initialises their aggregators to NaN and
+	// skips empty buckets at SeriesSet.ToProto, so the response shape
+	// includes only observed (group, anchor) rows. Pushing the predicate
+	// into a sumIf / avgIf would emit 0 for empty buckets and diverge
+	// from Tempo's NaN-skip semantics.
+	if metricsOpZeroFillsEmptyBuckets(m.Op) {
+		reducerFrag := metricsCountIfReducerFrag(m.Op, rangeNS, rangeSeconds)
+		outerSb.Select(As(reducerFrag, m.ValueAlias))
+	} else {
+		reducerFrag := metricsReducerFrag(m.Op, chName, params, args, rangeSeconds)
+		outerSb.Select(As(reducerFrag, m.ValueAlias))
+
+		// WHERE: ts ∈ (anchor_ts - range, anchor_ts] — left-open /
+		// right-closed, matching Tempo's IntervalMapperQueryRange.
+		outerSb.Where(
+			windowTsLowerBoundFrag(rangeNS),
+			verbatim("ts <= anchor_ts"),
+		)
+	}
 
 	// GROUP BY group aliases + anchor_ts.
 	groupFrags := make([]Frag, 0, len(groupAliases)+1)
@@ -835,6 +858,84 @@ func (e *emitter) emitRangeWindowMetrics(r *chplan.RangeWindow, m *chplan.Metric
 
 	e.emitSelect(outerSb)
 	return nil
+}
+
+// metricsOpZeroFillsEmptyBuckets reports whether the given
+// MetricsAggregate.Op surfaces 0-valued samples for empty buckets on
+// Tempo's wire (rather than NaN-skipping them). The two upstream code
+// paths that produce zeros are StepAggregator + CountOverTimeAggregator
+// (for count_over_time and rate — the underlying counter aggregator
+// starts at zero) and HistogramAggregator.Results (for
+// quantile_over_time — explicitly sets ts.Values[i] = 0.0 when the
+// bucket has no histogram entries). All other operators reach the wire
+// via OverTimeAggregator's NaN-init path, so the cerberus emitter's
+// WHERE-filtered "observed-only" emission already matches Tempo's
+// output and needs no fill.
+//
+// emitRangeWindowMetrics (count / rate) branches on this predicate to
+// pick countIf(<window-pred>) vs WHERE-filtered count(...);
+// emitRangeWindowMetricsQuantileBuckets uses the conditional bucket
+// shape unconditionally because the quantile_over_time op is always on
+// the zero-fill path.
+func metricsOpZeroFillsEmptyBuckets(op chplan.MetricsOp) bool {
+	switch op {
+	case chplan.MetricsOpCountOverTime,
+		chplan.MetricsOpRate,
+		chplan.MetricsOpQuantileOverTime:
+		return true
+	}
+	return false
+}
+
+// metricsCountIfReducerFrag returns the per-(group, anchor) reducer for
+// the zero-fill matrix path: toFloat64(countIf(<window-pred>)) for
+// count_over_time, divided through the range duration in seconds for
+// rate. The window predicate is the same left-open / right-closed
+// (anchor_ts - range, anchor_ts] shape the WHERE-based path uses;
+// pushing it into countIf means the GROUP BY emits a row for every
+// (group, anchor) tuple the inner fanout materialises (countIf = 0 for
+// empty anchors) — i.e. SQL-side zero-fill that matches Tempo's
+// StepAggregator + CountOverTimeAggregator output without a handler
+// post-pass. The toFloat64 wrap keeps the Value column at the uniform
+// Float64 wire type chclient.Sample.Value expects (see
+// TestRangeWindowMetricsReducerIsFloat64).
+func metricsCountIfReducerFrag(op chplan.MetricsOp, rangeNS int64, rangeSeconds float64) Frag {
+	pred := zeroFillWindowPredicateFrag(rangeNS)
+	countIf := func(b *Builder) {
+		b.sb.WriteString("countIf(")
+		pred(b)
+		b.sb.WriteByte(')')
+	}
+	switch op {
+	case chplan.MetricsOpRate:
+		return func(b *Builder) {
+			b.sb.WriteString("toFloat64(")
+			countIf(b)
+			b.sb.WriteString(") / ")
+			b.sb.WriteString(strconv.FormatFloat(rangeSeconds, 'f', -1, 64))
+		}
+	default:
+		return func(b *Builder) {
+			b.sb.WriteString("toFloat64(")
+			countIf(b)
+			b.sb.WriteByte(')')
+		}
+	}
+}
+
+// zeroFillWindowPredicateFrag renders the per-anchor window predicate
+// inline (no surrounding parens — the caller wraps as needed). Mirrors
+// the WHERE-clause shape windowTsLowerBoundFrag + the
+// `ts <= anchor_ts` literal produce, joined by AND so it composes
+// inside a countIf(...) / if(...) call. Strict lower / right-closed
+// upper bound matches Tempo's IntervalMapperQueryRange (see
+// windowTsLowerBoundFrag for the off-by-one rationale).
+func zeroFillWindowPredicateFrag(rangeNS int64) Frag {
+	return func(b *Builder) {
+		b.sb.WriteString("ts > anchor_ts - toIntervalNanosecond(")
+		b.sb.WriteString(strconv.FormatInt(rangeNS, 10))
+		b.sb.WriteString(") AND ts <= anchor_ts")
+	}
 }
 
 // emitRangeWindowMetricsQuantileBuckets renders quantile_over_time in
@@ -943,15 +1044,21 @@ func (e *emitter) emitRangeWindowMetricsQuantileBuckets(r *chplan.RangeWindow, m
 		outerSb.Select(func(b *Builder) { b.Ident(a) })
 	}
 	outerSb.Select(Col("anchor_ts"))
-	outerSb.SelectAs(quantileBucketFrag(m.IsDuration), metricsQuantileBucketAlias)
-	outerSb.Select(As(verbatim("toFloat64(count(1))"), m.ValueAlias))
-
-	// WHERE: ts ∈ (anchor_ts - range, anchor_ts] AND raw-value >= 2.
-	outerSb.Where(
-		windowTsLowerBoundFrag(rangeNS),
-		verbatim("ts <= anchor_ts"),
-		quantileMetricArgMinFrag(m.IsDuration),
-	)
+	// Bucket projection is conditional on the per-anchor window + the
+	// raw-value >= 2 guard: rows that don't satisfy both fall into a
+	// phantom 0-bucket group (matching no real bucket because the
+	// minimum power-of-two bucket is >= 2 after the `metric_arg >= 2`
+	// guard). The conditional projection — rather than a WHERE-clause
+	// filter — guarantees one (group, anchor, __bucket=0) row per
+	// observed (group, anchor) tuple even when zero samples land in
+	// the window, so the handler's post-processor sees the empty
+	// (group, anchor) and Log2QuantileWithBucket returns 0 there
+	// (matching Tempo HistogramAggregator.Results's
+	// `ts.Values[i] = 0.0` for empty buckets).
+	outerSb.SelectAs(quantileBucketIfFrag(m.IsDuration, rangeNS), metricsQuantileBucketAlias)
+	// Value is countIf over the same conjunction so phantom rows count
+	// 0 and real-bucket rows count their observed sample count.
+	outerSb.Select(As(quantileCountIfFrag(m.IsDuration, rangeNS), m.ValueAlias))
 
 	// GROUP BY group aliases + anchor_ts + bucket.
 	groupFrags := make([]Frag, 0, len(groupAliases)+2)
@@ -964,6 +1071,66 @@ func (e *emitter) emitRangeWindowMetricsQuantileBuckets(r *chplan.RangeWindow, m
 
 	e.emitSelect(outerSb)
 	return nil
+}
+
+// quantileBucketIfFrag renders the conditional `__bucket` projection
+// for the zero-fill quantile path: real-bucket value when the row's ts
+// falls in (anchor_ts - range, anchor_ts] AND the raw metric_arg meets
+// Tempo's bucketize* `>= 2` guard, else 0 (the phantom sentinel —
+// distinct from every real bucket because the minimum power-of-two
+// bucket-edge is 2 nanoseconds, which renders as 2 for the non-duration
+// branch and 2e-9 for the seconds-rebased duration branch).
+//
+// Pairs with quantileCountIfFrag so the per-(group, anchor) GROUP BY
+// emits at least one row (the phantom 0-bucket / 0-count row) per
+// observed (group, anchor) tuple — SQL-side zero-fill matching Tempo's
+// HistogramAggregator.Results emission of `ts.Values[i] = 0.0` for
+// anchors with no histogram entries.
+func quantileBucketIfFrag(isDuration bool, rangeNS int64) Frag {
+	bucket := quantileBucketFrag(isDuration)
+	return func(b *Builder) {
+		b.sb.WriteString("if(")
+		writeQuantileWindowPredicate(b, isDuration, rangeNS)
+		b.sb.WriteString(", ")
+		bucket(b)
+		b.sb.WriteString(", 0)")
+	}
+}
+
+// quantileCountIfFrag renders the conditional `Value` projection for
+// the zero-fill quantile path: `toFloat64(countIf(<window pred> AND
+// <metric_arg >= 2>))`. Phantom rows (which fall in the
+// __bucket=0 group via quantileBucketIfFrag) count 0; real-bucket rows
+// count their observed sample count. See quantileBucketIfFrag for the
+// per-(group, anchor) zero-fill rationale.
+func quantileCountIfFrag(isDuration bool, rangeNS int64) Frag {
+	return func(b *Builder) {
+		b.sb.WriteString("toFloat64(countIf(")
+		writeQuantileWindowPredicate(b, isDuration, rangeNS)
+		b.sb.WriteString("))")
+	}
+}
+
+// writeQuantileWindowPredicate writes the conjunction shared by the
+// quantile zero-fill `if(...)` / `countIf(...)` calls:
+//
+//	ts > anchor_ts - toIntervalNanosecond(<rangeNS>) AND
+//	  ts <= anchor_ts AND <metric_arg-min-pred>
+//
+// Same conjunction shape windowTsLowerBoundFrag + the `ts <=
+// anchor_ts` literal + the `metric_arg >= 2` Tempo bucketize* guard
+// (pkg/traceql/ast_metrics.go, bucketizeDuration / bucketizeAttribute)
+// produced for the WHERE-filtered legacy path, inlined here so the
+// conditional callers can splice it into a single expression node.
+func writeQuantileWindowPredicate(b *Builder, isDuration bool, rangeNS int64) {
+	b.sb.WriteString("ts > anchor_ts - toIntervalNanosecond(")
+	b.sb.WriteString(strconv.FormatInt(rangeNS, 10))
+	b.sb.WriteString(") AND ts <= anchor_ts AND ")
+	if isDuration {
+		b.sb.WriteString("metric_arg * 1000000000 >= 2")
+		return
+	}
+	b.sb.WriteString("metric_arg >= 2")
 }
 
 // metricsQuantileBucketAlias is the SELECT-list alias the matrix-path
@@ -998,20 +1165,6 @@ func quantileBucketFrag(isDuration bool) Frag {
 		return verbatim("pow(2, ceil(log2(toFloat64(metric_arg) * 1000000000))) / 1000000000")
 	}
 	return verbatim("pow(2, ceil(log2(toFloat64(metric_arg))))")
-}
-
-// quantileMetricArgMinFrag renders the `metric_arg >= 2` filter that
-// mirrors Tempo's bucketize* "if d < 2 return nil" guard
-// (pkg/traceql/ast_metrics.go, bucketizeDuration / bucketizeAttribute).
-// For duration operands the cerberus lowering pre-divides by 1e9, so
-// the filter expands to `metric_arg * 1e9 >= 2` (i.e. raw `Duration >=
-// 2` nanoseconds). For non-duration numeric operands the filter is the
-// bare `metric_arg >= 2`.
-func quantileMetricArgMinFrag(isDuration bool) Frag {
-	if isDuration {
-		return verbatim("metric_arg * 1000000000 >= 2")
-	}
-	return verbatim("metric_arg >= 2")
 }
 
 // anchorFanoutFrag returns a Frag rendering

--- a/internal/chsql/range_window_metrics_test.go
+++ b/internal/chsql/range_window_metrics_test.go
@@ -51,20 +51,25 @@ func TestRangeWindowMetricsExplicitTimeGrid(t *testing.T) {
 	if !strings.Contains(sql, "range(0, 6)") {
 		t.Errorf("expected range(0, 6), SQL=%s", sql)
 	}
-	// Rate reducer normalises by range_seconds (60s); the count(?)
-	// aggregate is wrapped in toFloat64 so the Value column has the
-	// uniform Float64 wire type chclient.Sample.Value expects (UInt64
-	// → *float64 ScanRow conversion is unsupported by the CH Go
-	// driver). The substring is "toFloat64(count(?)) / 60".
-	if !strings.Contains(sql, "toFloat64(count(?)) / 60") {
-		t.Errorf("expected `toFloat64(count(?)) / 60`, SQL=%s", sql)
+	// Rate reducer normalises by range_seconds (60s); the per-anchor
+	// window predicate now lives inside `countIf(...)` (SQL-side
+	// zero-fill — see PR retiring the handler's zeroFillMatrixGrid),
+	// so the substring is `toFloat64(countIf(ts > anchor_ts -
+	// toIntervalNanosecond(<rangeNS>) AND ts <= anchor_ts)) / 60`.
+	// The toFloat64 wrap keeps the Value column at the uniform
+	// Float64 wire type chclient.Sample.Value expects.
+	if !strings.Contains(sql, "toFloat64(countIf(ts > anchor_ts - toIntervalNanosecond(") {
+		t.Errorf("expected toFloat64(countIf(<window pred>)) reducer, SQL=%s", sql)
 	}
-	// args has the LitInt{1} bound by count(1).
-	if len(args) != 1 {
-		t.Fatalf("expected 1 arg (count operand), got %d: %v", len(args), args)
+	if !strings.Contains(sql, ")) / 60") {
+		t.Errorf("expected rate normalisation `/ 60`, SQL=%s", sql)
 	}
-	if v, ok := args[0].(int64); !ok || v != 1 {
-		t.Errorf("expected args[0] = int64(1), got %T(%v)", args[0], args[0])
+	// countIf inlines the window predicate; no bound `?` arguments
+	// on the count side anymore (the predicate's range nanos are
+	// emitted as a literal integer, same shape as the legacy
+	// windowTsLowerBoundFrag).
+	if len(args) != 0 {
+		t.Fatalf("expected 0 bound args (countIf predicate inlines literals), got %d: %v", len(args), args)
 	}
 }
 
@@ -287,9 +292,16 @@ func TestRangeWindowMetricsQuantileBuckets(t *testing.T) {
 		t.Fatalf("Emit: %v", err)
 	}
 	wantSubstrings := []string{
+		// Conditional bucket: phantom 0-bucket for non-matching rows
+		// so empty (group, anchor) tuples survive the GROUP BY with
+		// __bucket=0/count=0 (SQL-side zero-fill — see PR retiring
+		// zeroFillMatrixGrid in the handler).
+		"if(ts > anchor_ts - toIntervalNanosecond(",
 		"pow(2, ceil(log2(toFloat64(metric_arg))))",
-		"AS `__bucket`",
-		"toFloat64(count(1)) AS `Value`",
+		", 0) AS `__bucket`",
+		// Value is countIf over the same predicate so phantom rows
+		// count 0 and real-bucket rows count matched samples.
+		"toFloat64(countIf(ts > anchor_ts - toIntervalNanosecond(",
 		"metric_arg >= 2",
 		"GROUP BY `anchor_ts`, `__bucket`",
 	}
@@ -340,9 +352,10 @@ func TestRangeWindowMetricsQuantileBucketsDuration(t *testing.T) {
 		t.Fatalf("Emit: %v", err)
 	}
 	wantSubstrings := []string{
+		"if(ts > anchor_ts - toIntervalNanosecond(",
 		"pow(2, ceil(log2(toFloat64(metric_arg) * 1000000000))) / 1000000000",
-		"AS `__bucket`",
-		"toFloat64(count(1)) AS `Value`",
+		", 0) AS `__bucket`",
+		"toFloat64(countIf(ts > anchor_ts - toIntervalNanosecond(",
 		"metric_arg * 1000000000 >= 2",
 	}
 	for _, s := range wantSubstrings {

--- a/test/spec/chsql/metrics_second_stage_topk_matrix.txtar
+++ b/test/spec/chsql/metrics_second_stage_topk_matrix.txtar
@@ -1,7 +1,7 @@
 -- args --
-[0] int64 = 1
+(none)
 -- sql --
-SELECT * FROM (SELECT `service`, `anchor_ts`, toFloat64(count(?)) / 60 AS `Value` FROM (SELECT `ServiceName` AS `service`, `Timestamp` AS `ts`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) WHERE ts > anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts GROUP BY `service`, `anchor_ts`) ORDER BY `Value` DESC LIMIT 5 BY `anchor_ts`
+SELECT * FROM (SELECT `service`, `anchor_ts`, toFloat64(countIf(ts > anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts)) / 60 AS `Value` FROM (SELECT `ServiceName` AS `service`, `Timestamp` AS `ts`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) GROUP BY `service`, `anchor_ts`) ORDER BY `Value` DESC LIMIT 5 BY `anchor_ts`
 -- chplan --
 MetricsSecondStage op=topk k=5 partitionBy=[anchor_ts] valueAlias=Value
   RangeWindow func= range=0s step=1m0s outerRange=5m0s ts=Timestamp

--- a/test/spec/chsql/range_window_metrics_count_over_time_by.txtar
+++ b/test/spec/chsql/range_window_metrics_count_over_time_by.txtar
@@ -1,7 +1,7 @@
 -- args --
-[0] int64 = 1
+(none)
 -- sql --
-SELECT `service`, `anchor_ts`, toFloat64(count(?)) AS `Value` FROM (SELECT `ServiceName` AS `service`, `Timestamp` AS `ts`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 11))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) WHERE ts > anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts GROUP BY `service`, `anchor_ts`
+SELECT `service`, `anchor_ts`, toFloat64(countIf(ts > anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts)) AS `Value` FROM (SELECT `ServiceName` AS `service`, `Timestamp` AS `ts`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 11))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) GROUP BY `service`, `anchor_ts`
 -- chplan --
 RangeWindow func= range=0s step=1m0s outerRange=10m0s ts=Timestamp
   MetricsAggregate op=count_over_time groupBy=[ServiceName AS service] valueAlias=Value

--- a/test/spec/chsql/range_window_metrics_quantile_over_time_attr.txtar
+++ b/test/spec/chsql/range_window_metrics_quantile_over_time_attr.txtar
@@ -1,7 +1,7 @@
 -- args --
 (none)
 -- sql --
-SELECT `anchor_ts`, pow(2, ceil(log2(toFloat64(metric_arg)))) AS `__bucket`, toFloat64(count(1)) AS `Value` FROM (SELECT `Timestamp` AS `ts`, `Duration` AS `metric_arg`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) WHERE ts > anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts AND metric_arg >= 2 GROUP BY `anchor_ts`, `__bucket`
+SELECT `anchor_ts`, if(ts > anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts AND metric_arg >= 2, pow(2, ceil(log2(toFloat64(metric_arg)))), 0) AS `__bucket`, toFloat64(countIf(ts > anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts AND metric_arg >= 2)) AS `Value` FROM (SELECT `Timestamp` AS `ts`, `Duration` AS `metric_arg`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) GROUP BY `anchor_ts`, `__bucket`
 -- chplan --
 RangeWindow func= range=0s step=1m0s outerRange=5m0s ts=Timestamp
   MetricsAggregate op=quantile_over_time attr=Duration quantiles=[0.95] valueAlias=Value

--- a/test/spec/chsql/range_window_metrics_quantile_over_time_multi_attr.txtar
+++ b/test/spec/chsql/range_window_metrics_quantile_over_time_multi_attr.txtar
@@ -1,7 +1,7 @@
 -- args --
 (none)
 -- sql --
-SELECT `anchor_ts`, pow(2, ceil(log2(toFloat64(metric_arg)))) AS `__bucket`, toFloat64(count(1)) AS `Value` FROM (SELECT `Timestamp` AS `ts`, `Duration` AS `metric_arg`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) WHERE ts > anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts AND metric_arg >= 2 GROUP BY `anchor_ts`, `__bucket`
+SELECT `anchor_ts`, if(ts > anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts AND metric_arg >= 2, pow(2, ceil(log2(toFloat64(metric_arg)))), 0) AS `__bucket`, toFloat64(countIf(ts > anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts AND metric_arg >= 2)) AS `Value` FROM (SELECT `Timestamp` AS `ts`, `Duration` AS `metric_arg`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) GROUP BY `anchor_ts`, `__bucket`
 -- chplan --
 RangeWindow func= range=0s step=1m0s outerRange=5m0s ts=Timestamp
   MetricsAggregate op=quantile_over_time attr=Duration quantiles=[0.5, 0.9, 0.99] valueAlias=Value

--- a/test/spec/chsql/range_window_metrics_quantile_over_time_multi_by_attr.txtar
+++ b/test/spec/chsql/range_window_metrics_quantile_over_time_multi_by_attr.txtar
@@ -1,7 +1,7 @@
 -- args --
 (none)
 -- sql --
-SELECT `service`, `anchor_ts`, pow(2, ceil(log2(toFloat64(metric_arg)))) AS `__bucket`, toFloat64(count(1)) AS `Value` FROM (SELECT `ServiceName` AS `service`, `Timestamp` AS `ts`, `Duration` AS `metric_arg`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) WHERE ts > anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts AND metric_arg >= 2 GROUP BY `service`, `anchor_ts`, `__bucket`
+SELECT `service`, `anchor_ts`, if(ts > anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts AND metric_arg >= 2, pow(2, ceil(log2(toFloat64(metric_arg)))), 0) AS `__bucket`, toFloat64(countIf(ts > anchor_ts - toIntervalNanosecond(60000000000) AND ts <= anchor_ts AND metric_arg >= 2)) AS `Value` FROM (SELECT `ServiceName` AS `service`, `Timestamp` AS `ts`, `Duration` AS `metric_arg`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) GROUP BY `service`, `anchor_ts`, `__bucket`
 -- chplan --
 RangeWindow func= range=0s step=1m0s outerRange=5m0s ts=Timestamp
   MetricsAggregate op=quantile_over_time attr=Duration groupBy=[ServiceName AS service] quantiles=[0.5, 0.9, 0.99] valueAlias=Value

--- a/test/spec/chsql/range_window_metrics_rate.txtar
+++ b/test/spec/chsql/range_window_metrics_rate.txtar
@@ -1,7 +1,7 @@
 -- args --
-[0] int64 = 1
+(none)
 -- sql --
-SELECT `anchor_ts`, toFloat64(count(?)) / 300 AS `Value` FROM (SELECT `Timestamp` AS `ts`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 61))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) WHERE ts > anchor_ts - toIntervalNanosecond(300000000000) AND ts <= anchor_ts GROUP BY `anchor_ts`
+SELECT `anchor_ts`, toFloat64(countIf(ts > anchor_ts - toIntervalNanosecond(300000000000) AND ts <= anchor_ts)) / 300 AS `Value` FROM (SELECT `Timestamp` AS `ts`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 61))) AS `anchor_ts` FROM (SELECT * FROM `otel_traces`)) GROUP BY `anchor_ts`
 -- chplan --
 RangeWindow func= range=5m0s step=1m0s outerRange=1h0m0s ts=Timestamp
   MetricsAggregate op=rate valueAlias=Value


### PR DESCRIPTION
## Summary

Replaces handler-side `zeroFillMatrixGrid` post-pass (introduced by PR #550) with SQL-side zero-fill via `countIf(<window-pred>)` over the anchor grid. Matrix shape is now chsql's concern; the HTTP handler no longer fabricates zero-valued samples after the fact.

Per `dirty-fixes-audit-full-history-2026-05-22.md` Recommendation #7.

### Mechanism

The inner subquery fans every input row out across the anchor grid via `arrayJoin(arrayMap(i -> start + i*step, range(0, N+1)))`. Previously the outer `GROUP BY anchor_ts` filtered to anchors with at least one in-window sample (`WHERE ts > anchor_ts - range AND ts <= anchor_ts`), so empty anchors disappeared and the handler patched them back in.

Now the outer projection uses `countIf(ts > anchor_ts - range AND ts <= anchor_ts)` and drops the `WHERE`. Every (group, anchor) tuple the inner fanout materialises survives the `GROUP BY` — observed anchors get the real count, empty anchors get `countIf = 0`. Same shape, no handler post-pass.

The branch only applies to ops whose Tempo aggregators emit 0 for empty buckets (`count_over_time`, `rate`, `quantile_over_time`). `sum/avg/min/max/last/stddev/stdvar over_time` keep the WHERE-filtered path because Tempo's `OverTimeAggregator` NaN-initialises and skips empty buckets at `SeriesSet.ToProto`; pushing them through `sumIf`/`avgIf` would emit zeros and diverge.

### Files touched

- `internal/chsql/range_window.go` — new `metricsOpZeroFillsEmptyBuckets` + `metricsCountIfReducerFrag` + `zeroFillWindowPredicateFrag`; `emitRangeWindowMetrics` branches on the predicate.
- `internal/api/tempo/metrics_query_range.go` — `zeroFillMatrixGrid` deleted; call sites removed.
- `internal/api/tempo/grpc/metrics.go`, `grpc_exports.go`, `grpc/metrics_test.go` — drop the export the handler no longer needs.
- `internal/api/tempo/metrics_query_range_test.go` — tests now assert SQL shape (countIf / conditional-bucket projection) instead of handler-injected anchor timestamps; unused `mustParseUnix` helper removed.
- `internal/chsql/range_window_metrics_test.go` — adds coverage for the new branching.
- 6 TXTAR fixtures under `test/spec/chsql/` regenerated to pin the new SQL shape.

### Verification

- `go build ./...` clean.
- `go vet ./...` clean.
- `go test ./internal/api/tempo/... ./internal/chsql/... ./internal/traceql/... ./test/spec/...` — 993 + 325 + 4 passed.
- `goimports -l` on touched packages — clean.

Representative SQL diff (`test/spec/chsql/range_window_metrics_rate.txtar`):

Before: `SELECT anchor_ts, toFloat64(count(?)) / 300 AS Value FROM (...) WHERE ts > anchor_ts - toIntervalNanosecond(300000000000) AND ts <= anchor_ts GROUP BY anchor_ts`
After:  `SELECT anchor_ts, toFloat64(countIf(ts > anchor_ts - toIntervalNanosecond(300000000000) AND ts <= anchor_ts)) / 300 AS Value FROM (...) GROUP BY anchor_ts`

For a query with 61 anchors over a window where only 10 anchors saw samples, the before-shape returned 10 rows (handler then fabricated 51 zero rows); the after-shape returns 61 rows directly.

## Test plan

- [x] Unit tests pass under `internal/api/tempo`, `internal/chsql`, `internal/traceql`, `test/spec`.
- [ ] CI: `check`, `lint`, `forbid-skip`, `compatibility/tempo`, `roundtrip (traceql)`, `compose-smoke`.