### PR TITLE
fix(compat/loki): make post-seed /labels probe window anchor-relative

### DIFF
--- a/compatibility/loki/cmd/seed/main.go
+++ b/compatibility/loki/cmd/seed/main.go
@@ -682,11 +682,7 @@ func verifyBothNonEmpty(ctx context.Context, conn driver.Conn, lokiURL, cerbURL 
 	if err != nil {
 		return fmt.Errorf("parse anchor: %w", err)
 	}
-	start := anchorTS.Add(-24 * time.Hour)
-	end := time.Now().Add(24 * time.Hour)
-	if end.Before(anchorTS.Add(time.Hour)) {
-		end = anchorTS.Add(time.Hour)
-	}
+	start, end := verifyLabelsWindow(anchorTS)
 
 	// Wait for the reference Loki ingester to drain its flush queue and
 	// for the TSDB shipper to publish at least one fresh index table.
@@ -1054,6 +1050,24 @@ func matchesPrefix(key, prefix string) bool {
 		return false
 	}
 	return strings.Contains(key[len(name)+1:end], selector)
+}
+
+// verifyLabelsWindow returns the /labels query window for the
+// post-seed verification probe. The fixture is deterministic — every
+// pushed line lives in [anchor, anchor+24h] — so the probe brackets
+// that span with a day of slack on each side and never references the
+// wall clock.
+//
+// The previous implementation used `end = time.Now() + 24h`, which
+// made the window's span grow as real time drifted away from the
+// fixed anchor. Once the span crossed Loki's default
+// `max_query_length` (30d1h — `limits_config` in loki-config.yaml
+// doesn't override it), the reference Loki rejected the probe with
+// status 400 and the nightly went red (2026-06-08, with zero commits
+// on main since 2026-05-23). Any probe window in this harness must be
+// anchor-relative, not wall-clock-relative.
+func verifyLabelsWindow(anchorTS time.Time) (start, end time.Time) {
+	return anchorTS.Add(-24 * time.Hour), anchorTS.Add(48 * time.Hour)
 }
 
 func waitLabelsNonEmpty(ctx context.Context, label, baseURL string, start, end time.Time, logger *slog.Logger) error {

--- a/compatibility/loki/cmd/seed/main_test.go
+++ b/compatibility/loki/cmd/seed/main_test.go
@@ -284,6 +284,37 @@ func TestExtractSnapshot(t *testing.T) {
 	}
 }
 
+// TestVerifyLabelsWindowIsAnchorRelative pins the wall-clock
+// independence of the post-seed /labels probe window. The 2026-06-08
+// nightly went red with zero commits on main because the window's end
+// was `time.Now() + 24h`: the span grew with every passing day until
+// it crossed Loki's default `max_query_length` (30d1h) and the
+// reference Loki started rejecting the probe with status 400. The
+// window must bracket the fixture span [anchor, anchor+24h] and must
+// stay a fixed width regardless of when the harness runs.
+func TestVerifyLabelsWindowIsAnchorRelative(t *testing.T) {
+	t.Parallel()
+
+	anchorTS, err := time.Parse(time.RFC3339, anchor)
+	if err != nil {
+		t.Fatalf("parse anchor: %v", err)
+	}
+	start, end := verifyLabelsWindow(anchorTS)
+
+	if !start.Before(anchorTS) {
+		t.Errorf("window start %v must precede the anchor %v", start, anchorTS)
+	}
+	if fixtureEnd := anchorTS.Add(24 * time.Hour); !end.After(fixtureEnd) {
+		t.Errorf("window end %v must cover the fixture end %v", end, fixtureEnd)
+	}
+	// Loki's default max_query_length is 30d1h (721h). The probe window
+	// must sit far inside it no matter how old the anchor gets.
+	const maxQueryLength = 721 * time.Hour
+	if span := end.Sub(start); span >= maxQueryLength {
+		t.Errorf("window span %v exceeds Loki's default max_query_length %v", span, maxQueryLength)
+	}
+}
+
 // contains is a tiny helper kept local so the test file has no
 // dependency on strings.Contains' import.
 func contains(haystack, needle string) bool {


### PR DESCRIPTION
## Summary

The `compatibility/loki` nightly went red on 2026-06-08 — with **zero commits on main since 2026-05-23** — failing at the seed step with:

```
verify: loki /labels: status 400
```

Root cause: the post-seed verify probe computed its `/labels` window as `[anchor−24h, time.Now()+24h]`. The fixture anchor is fixed (`2026-05-11T00:00:00Z`), so the window's span grew with every passing day. Loki's default `max_query_length` is **30d1h** (the harness `loki-config.yaml` doesn't override it); on the June 7 nightly the span was ~29d6h (green), on June 8 it crossed to ~30d6h and the reference Loki started rejecting the probe with 400. Same time-bomb class as the tempo seed-anchor drift fixed in #725.

## Fix

- Replace the wall-clock end with an anchor-relative window `[anchor−24h, anchor+48h]` — a fixed 72h width that brackets the deterministic fixture span `[anchor, anchor+24h]` with a day of slack on each side. The harness's probe windows are now fully wall-clock independent (audited: this was the only `time.Now()` used for a query range in the loki harness; prometheus uses deadline timers only, tempo rolls its anchor since #725).
- Extract the computation into `verifyLabelsWindow` and pin it with a unit test asserting fixture coverage + fixed width far inside `max_query_length`, so the bomb class can't silently recur.

## Test plan

- [ ] `compatibility/loki` green on this PR (the lane runs the seeder end-to-end against grafana/loki:3.7.0)
- [ ] `check` green (new `TestVerifyLabelsWindowIsAnchorRelative` unit test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)