### PR TITLE
fix(compatibility/tempo): true-up the TraceQL compat signal — 30.30% → 84.85%

### DIFF
--- a/compatibility/tempo/driver/differ.go
+++ b/compatibility/tempo/driver/differ.go
@@ -7,13 +7,15 @@
 // `DiffReason`, never collapsed into a single boolean, so the markdown
 // report can surface actionable detail per case.
 //
-// Cerberus emits the real hex(TraceId) on `/api/search` (see
-// internal/api/tempo/handler.go::toTraceSummaries), so both backends
-// produce identical 32-hex-char TraceIDs for the same seeded span set.
-// The differ keys its trace-summary multisets directly on
-// `TraceSummary.TraceID` — no hashing, no canonicalisation.
-// "Different orderings of equal sets don't false-positive" still holds
-// because the index is a map keyed by TraceID, not a positional list.
+// Cerberus emits the spec-canonical 32-hex-char form of TraceId on
+// `/api/search` (PR #656; see internal/api/tempo/handler.go::
+// toTraceSummaries). Reference Tempo strips leading zeros on the wire
+// (`af84…` — 30 chars — for a trace whose first byte is 0x00), so the
+// differ keys its trace-summary multisets on the canonical left-padded
+// form of the TraceID: equal 16-byte values compare equal regardless
+// of which textual shape a backend chose. "Different orderings of
+// equal sets don't false-positive" still holds because the index is a
+// map keyed by the canonical TraceID, not a positional list.
 //
 // So the differ:
 //
@@ -65,11 +67,28 @@ type TraceSummary struct {
 }
 
 // traceKey is the per-trace identifier used to align the two backends'
-// trace lists. Since PR #439, cerberus and Tempo both emit the real
-// hex(TraceId) on `/api/search`, so the raw TraceID string is the
-// natural key — no canonicalisation needed.
+// trace lists. Cerberus emits the spec-canonical 32-hex-char form
+// (PR #656); reference Tempo strips leading zeros on the wire, so the
+// raw strings differ for any trace whose ID has leading zero bytes
+// even though both designate the same 16 bytes. Key on the canonical
+// left-padded form so equal values align. This is comparison
+// semantics — the textual-shape divergence cerberus chose is pinned
+// separately by the wire-shape tests from PR #656; a genuinely
+// different ID still diffs here.
 func traceKey(t TraceSummary) string {
-	return t.TraceID
+	return canonicalTraceID(t.TraceID)
+}
+
+// canonicalTraceID left-pads a hex TraceID to the canonical 32-char
+// lowercase form. IDs already at (or beyond) 32 chars pass through
+// untouched apart from lowercasing.
+func canonicalTraceID(id string) string {
+	const canonicalLen = 32
+	id = strings.ToLower(id)
+	if len(id) >= canonicalLen {
+		return id
+	}
+	return strings.Repeat("0", canonicalLen-len(id)) + id
 }
 
 // DiffOptions controls numeric-field tolerance. Mirrors the prom

--- a/compatibility/tempo/driver/differ_test.go
+++ b/compatibility/tempo/driver/differ_test.go
@@ -149,11 +149,11 @@ func TestCompare_InvalidJSONFails(t *testing.T) {
 
 func TestTraceKey_UsesRawTraceID(t *testing.T) {
 	t.Parallel()
-	// Since PR #439, cerberus and Tempo both emit the real hex(TraceId),
-	// so the differ keys directly on TraceID. The root names are not
-	// part of the key — only the TraceID is — guaranteeing two traces
-	// with the same TraceID align even if their root names differ
-	// (which would then surface as a field_mismatch under the match).
+	// The differ keys on the canonical form of TraceID. The root names
+	// are not part of the key — only the TraceID is — guaranteeing two
+	// traces with the same TraceID align even if their root names
+	// differ (which would then surface as a field_mismatch under the
+	// match).
 	t1 := TraceSummary{TraceID: "00000000000000000000000000000001", RootServiceName: "checkout", RootTraceName: "GET /api/checkout/0"}
 	t2 := TraceSummary{TraceID: "00000000000000000000000000000001", RootServiceName: "payments", RootTraceName: "POST /api/payments/0"}
 	if traceKey(t1) != traceKey(t2) {
@@ -162,6 +162,56 @@ func TestTraceKey_UsesRawTraceID(t *testing.T) {
 	t3 := TraceSummary{TraceID: "00000000000000000000000000000002", RootServiceName: "checkout", RootTraceName: "GET /api/checkout/0"}
 	if traceKey(t1) == traceKey(t3) {
 		t.Fatal("expected different traceKey for different TraceID")
+	}
+}
+
+// TestTraceKey_CanonicalisesStrippedLeadingZeros pins the
+// zero-padding alignment that flattened 17 of 33 compat cases to DIFF:
+// cerberus emits the spec-canonical 32-hex-char TraceID (PR #656)
+// while reference Tempo strips leading zeros on the wire, so the same
+// 16-byte value arrived as `00af…` (32 chars) on one side and `af…`
+// (30 chars) on the other and the raw-string key filed it as
+// missing_in_a + missing_in_b. Equal values must align; genuinely
+// different IDs must still diff.
+func TestTraceKey_CanonicalisesStrippedLeadingZeros(t *testing.T) {
+	t.Parallel()
+	padded := TraceSummary{TraceID: "00af843259b0a78f5cbe59e11cbaf66b"}
+	stripped := TraceSummary{TraceID: "af843259b0a78f5cbe59e11cbaf66b"}
+	if traceKey(padded) != traceKey(stripped) {
+		t.Fatalf("expected stripped and padded forms of the same TraceID to key identically: %q vs %q",
+			traceKey(padded), traceKey(stripped))
+	}
+	other := TraceSummary{TraceID: "01af843259b0a78f5cbe59e11cbaf66b"}
+	if traceKey(padded) == traceKey(other) {
+		t.Fatal("expected different TraceIDs to key differently")
+	}
+	upper := TraceSummary{TraceID: "00AF843259B0A78F5CBE59E11CBAF66B"}
+	if traceKey(padded) != traceKey(upper) {
+		t.Fatal("expected case-insensitive TraceID keying")
+	}
+}
+
+// TestCompare_StrippedVsPaddedTraceIDsAlign pins the end-to-end
+// Compare behaviour for the zero-padding divergence: a search response
+// pair where tempo stripped the leading zero and cerberus emitted the
+// canonical form must compare Equal.
+func TestCompare_StrippedVsPaddedTraceIDsAlign(t *testing.T) {
+	t.Parallel()
+	tempoBody := []byte(`{"traces":[
+        {"traceID":"af843259b0a78f5cbe59e11cbaf66b","rootServiceName":"checkout","rootTraceName":"GET /api/checkout/22","durationMs":150,"startTimeUnixNano":"1000"}
+    ]}`)
+	cerbBody := []byte(`{"traces":[
+        {"traceID":"00af843259b0a78f5cbe59e11cbaf66b","rootServiceName":"checkout","rootTraceName":"GET /api/checkout/22","durationMs":150,"startTimeUnixNano":"1000"}
+    ]}`)
+	d, err := Compare(tempoBody, cerbBody, "tempo", "cerberus", DefaultDiffOptions())
+	if err != nil {
+		t.Fatalf("Compare: %v", err)
+	}
+	if !d.Equal {
+		t.Fatalf("expected stripped/padded TraceID forms to align, got %+v", d)
+	}
+	if d.MatchedCount != 1 {
+		t.Fatalf("MatchedCount = %d, want 1", d.MatchedCount)
 	}
 }
 

--- a/compatibility/tempo/driver/proto_fetch.go
+++ b/compatibility/tempo/driver/proto_fetch.go
@@ -40,12 +40,14 @@ package main
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"sort"
+	"strings"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/grafana/tempo/pkg/tempopb"
@@ -200,7 +202,7 @@ func projectJSONShape(body []byte) (traceShape, error) {
 		for _, sp := range spans {
 			total++
 			if sp.SpanID != "" {
-				ids[sp.SpanID] = struct{}{}
+				ids[canonicalJSONSpanID(sp.SpanID)] = struct{}{}
 			}
 		}
 	}
@@ -219,6 +221,27 @@ func projectJSONShape(body []byte) (traceShape, error) {
 		}
 	}
 	return traceShape{SpanCount: total, SpanIDs: sortedKeys(ids)}, nil
+}
+
+// canonicalJSONSpanID normalises a span ID lifted from a JSON trace
+// body to the 16-char lowercase-hex form projectProtoShape produces
+// (hex.EncodeToString over the 8 raw bytes). Reference Tempo's JSON
+// encoder follows the proto3 JSON mapping and emits bytes fields as
+// standard base64 ("C9WjFN3vISs="); cerberus emits the hex form
+// directly. Both designate the same 8 bytes, so the cross-encoding
+// parity check must compare the decoded value, not the textual shape.
+// Hex is tried first: a 16-char hex string is also valid base64 but
+// decodes to 12 bytes, so the 8-byte length check disambiguates.
+// Anything that decodes to neither form passes through untouched and
+// diffs loudly.
+func canonicalJSONSpanID(s string) string {
+	if b, err := hex.DecodeString(s); err == nil && len(b) == 8 {
+		return strings.ToLower(s)
+	}
+	if b, err := base64.StdEncoding.DecodeString(s); err == nil && len(b) == 8 {
+		return hex.EncodeToString(b)
+	}
+	return s
 }
 
 // spanIDRecord tolerates both `spanId` (Tempo / cerberus camelCase) and

--- a/compatibility/tempo/driver/proto_fetch_test.go
+++ b/compatibility/tempo/driver/proto_fetch_test.go
@@ -372,3 +372,57 @@ func TestDiffTracesEndpoint_CardinalityMismatchReported(t *testing.T) {
 		t.Errorf("missing cardinality reason; reasons=%+v", res.Diff.Reasons)
 	}
 }
+
+// TestCanonicalJSONSpanID pins the cross-encoding span-ID
+// normalisation that flattened the trace-by-id compat case to
+// encoding_mismatch: reference Tempo's JSON encoder follows the
+// proto3 JSON mapping and emits bytes fields as standard base64
+// ("C9WjFN3vISs=") while projectProtoShape produces 16-char
+// lowercase hex — both naming the same 8 bytes. The hex-first order
+// matters: a 16-char hex string is also syntactically valid base64
+// but decodes to 12 bytes, so the 8-byte length check disambiguates.
+func TestCanonicalJSONSpanID(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in, want, why string
+	}{
+		{"0bd5a314ddef212b", "0bd5a314ddef212b", "hex form passes through"},
+		{"0BD5A314DDEF212B", "0bd5a314ddef212b", "hex form is lowercased"},
+		{"C9WjFN3vISs=", "0bd5a314ddef212b", "base64 of the same 8 bytes decodes to hex"},
+		{"cm0aM7aB/T4=", "726d1a33b681fd3e", "base64 with non-hex alphabet chars decodes to hex"},
+		{"not-an-id", "not-an-id", "undecodable input passes through and diffs loudly"},
+	}
+	for _, c := range cases {
+		if got := canonicalJSONSpanID(c.in); got != c.want {
+			t.Errorf("canonicalJSONSpanID(%q) = %q, want %q (%s)", c.in, got, c.want, c.why)
+		}
+	}
+}
+
+// TestProjectJSONShape_DecodesBase64SpanIDs pins that a Tempo-style
+// protojson body (base64 span IDs) projects to the same shape as the
+// proto decoding of the same trace — the parity the per-side
+// encoding_mismatch check asserts.
+func TestProjectJSONShape_DecodesBase64SpanIDs(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"batches":[{"scopeSpans":[{"spans":[
+        {"spanId":"C9WjFN3vISs="},
+        {"spanId":"cm0aM7aB/T4="}
+    ]}]}]}`)
+	shape, err := projectJSONShape(body)
+	if err != nil {
+		t.Fatalf("projectJSONShape: %v", err)
+	}
+	if shape.SpanCount != 2 {
+		t.Fatalf("SpanCount = %d, want 2", shape.SpanCount)
+	}
+	want := []string{"0bd5a314ddef212b", "726d1a33b681fd3e"}
+	if len(shape.SpanIDs) != len(want) {
+		t.Fatalf("SpanIDs = %v, want %v", shape.SpanIDs, want)
+	}
+	for i := range want {
+		if shape.SpanIDs[i] != want[i] {
+			t.Fatalf("SpanIDs[%d] = %q, want %q", i, shape.SpanIDs[i], want[i])
+		}
+	}
+}

--- a/compatibility/tempo/tempo-config.yaml
+++ b/compatibility/tempo/tempo-config.yaml
@@ -104,5 +104,21 @@ live_store:
   max_block_duration: 2s
   complete_block_timeout: 5s
 
+# Route TraceQL-metrics queries (/api/metrics/query_range +
+# /api/metrics/query) to the backend-blocks path instead of the live
+# stores. Tempo v3 splits a metrics query at query_backend_after: the
+# part more recent than the cutoff goes to Querier.queryRangeRecent
+# (live stores), the rest to backend blocks. The aggressive live_store
+# flush cadence above keeps only ~5s of data live
+# (complete_block_timeout), so with the default cutoff every harness
+# metrics query — the differ probes an anchor ± 1h window with
+# anchor = now()-5m — lands on the live store and 500s with
+# "time range must be within last 5s". 1s routes effectively
+# everything to the completed blocks the search endpoints already
+# read (blocklist_poll: 2s above keeps discovery fast).
+query_frontend:
+  metrics:
+    query_backend_after: 1s
+
 usage_report:
   reporting_enabled: false


### PR DESCRIPTION
## Summary

The TraceQL compat score sat at **30.30% (10/33)** while all 23 failures were harness-side false negatives masking the real signal. Three fixes:

1. **Canonical TraceID keying (17 cases).** Cerberus emits the spec-canonical zero-padded 32-hex TraceID on `/api/search` (#656); reference Tempo strips leading zeros. The differ keyed on the raw string, so every trace with leading zero bytes filed as a `missing_in_a` + `missing_in_b` pair. The key is now the left-padded lowercase form — equal 16-byte values align, genuinely different IDs still diff. Comparison semantics, not tolerance (same class as the existing float epsilon).
2. **Protojson base64 span IDs (1 case).** Tempo's JSON trace body encodes bytes per the proto3 JSON mapping (`C9WjFN3vISs=`); the proto projection hex-encodes the same 8 bytes. The cross-encoding parity check compared text, so trace-by-id always reported `encoding_mismatch`. JSON-lifted IDs now normalise to 16-char hex (hex tried first; the 8-byte decode-length check disambiguates the hex/base64 overlap).
3. **TraceQL-metrics routing (6 cases).** The harness live-store keeps only ~5s of data (`complete_block_timeout: 5s`), so with the default `query_backend_after` every metrics case 500'd on the reference side with `time range must be within last 5s`. `query_frontend.metrics.query_backend_after: 1s` routes metrics to the same completed blocks the search endpoints already read.

## Verification

Full local harness run (`./compatibility/tempo/scripts/run-tempo-compatibility.sh`): **28/33 (84.85%)**, up from 10/33. Unit tests pin the keying (`TestTraceKey_CanonicalisesStrippedLeadingZeros`, `TestCompare_StrippedVsPaddedTraceIDsAlign`) and the ID normalisation (`TestCanonicalJSONSpanID`, `TestProjectJSONShape_DecodesBase64SpanIDs`).

## What's left (follow-up, real engine work)

The 5 residual DIFFs are genuine cerberus-side TraceQL-metrics divergences, now visible for the first time:
- range samples are start-relative instead of step-grid-aligned (tempo `…300000` vs cerberus `…346000`, off by `start mod step`) — 3 range cases;
- `/api/metrics/query` instant rate returns 0 where Tempo computes 0.0554 — 2 instant cases.

Follow-up PR will fix the engine; this PR exists so the score reflects reality instead of harness noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)