### PR TITLE
fix(api/tempo): TraceQL-metrics step-grid alignment + instant single anchor — TraceQL compat 100%

### DIFF
--- a/internal/api/tempo/export_test.go
+++ b/internal/api/tempo/export_test.go
@@ -1,0 +1,10 @@
+package tempo
+
+import "time"
+
+// AlignMetricsWindowForTest re-exports alignMetricsWindow for the
+// external tempo_test package — the grid-snap formula is pure and
+// worth pinning directly, without driving a full handler round-trip.
+var AlignMetricsWindowForTest = func(start, end time.Time, step time.Duration) (time.Time, time.Time) {
+	return alignMetricsWindow(start, end, step)
+}

--- a/internal/api/tempo/metrics_query_instant.go
+++ b/internal/api/tempo/metrics_query_instant.go
@@ -105,11 +105,24 @@ func (h *Handler) handleMetricsQueryInstant(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	// Start = End on purpose: the matrix emitter generates
+	// (End-Start)/Step + 1 anchors at `End - i*Step`, so Start==End
+	// yields the single anchor at `end` whose right-closed window
+	// (end - Range, end] IS the instant bucket [start, end] Tempo's
+	// IntervalMapperInstant evaluates. Passing Start=start here would
+	// fan out a second anchor at `start` covering (start-step, start]
+	// — entirely before the requested window — which evaluates to 0
+	// and, being the earliest sample, used to win the
+	// first-sample-by-timestamp pick in toMetricsInstantSeries: every
+	// instant compat case returned 0 instead of the real value. The
+	// inner-scan time-bound pushdown still prunes on
+	// (Start - Range, End] = (start, end], so partition pruning is
+	// unaffected.
 	rw := &chplan.RangeWindow{
 		Input:           plan,
 		Range:           step,
 		Step:            step,
-		Start:           start,
+		Start:           end,
 		End:             end,
 		TimestampColumn: h.Schema.TimestampColumn,
 	}

--- a/internal/api/tempo/metrics_query_instant_test.go
+++ b/internal/api/tempo/metrics_query_instant_test.go
@@ -404,3 +404,39 @@ func TestMetricsQueryInstant_CHFailure(t *testing.T) {
 		t.Errorf("expected error envelope with upstream message; got %+v", er)
 	}
 }
+
+// TestMetricsQueryInstant_SingleAnchorFanout pins the instant bucket
+// shape at the SQL layer: the matrix emitter generates
+// (End-Start)/Step + 1 anchors, so the handler passes Start = End to
+// fan out exactly one anchor at `end` whose right-closed window
+// (end - step, end] IS the instant bucket. The previous Start = start
+// produced range(0, 2) — a second anchor at `start` covering
+// (start - step, start], entirely before the requested window, whose
+// zero-fill value 0 was the earliest sample and therefore won the
+// first-sample-by-timestamp pick: every instant compat case returned
+// 0 instead of the real value (tempo=0.0554 vs cerberus=0 on the
+// metrics_rate_instant corpus case).
+func TestMetricsQueryInstant_SingleAnchorFanout(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{samples: []chclient.Sample{}}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	u := metricsQueryInstantURL(srv.URL, "{} | rate()", map[string]string{
+		"start": fixtureStartUnix,
+		"end":   fixtureEndUnix,
+	})
+	resp, err := http.Get(u)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	assertSQLContains(t, q.lastSQL, "range(0, 1)")
+	if strings.Contains(q.lastSQL, "range(0, 2)") {
+		t.Errorf("instant fanout produced a second anchor: %s", q.lastSQL)
+	}
+}

--- a/internal/api/tempo/metrics_query_range.go
+++ b/internal/api/tempo/metrics_query_range.go
@@ -166,6 +166,20 @@ func (metricsLang) ProjectSamples(plan chplan.Node, _ engine.Meta) chplan.Node {
 	return plan
 }
 
+// alignMetricsWindow snaps a metrics-range window to the step grid the
+// way Tempo's api.AlignRequest does: start rounds down to the nearest
+// step multiple, end rounds up (unchanged when already a multiple).
+// Range queries only — Tempo's IsInstant path skips alignment, and so
+// does cerberus's handleMetricsQueryInstant.
+func alignMetricsWindow(start, end time.Time, step time.Duration) (time.Time, time.Time) {
+	alignedStart := start.Truncate(step)
+	alignedEnd := end.Truncate(step)
+	if alignedEnd.Before(end) {
+		alignedEnd = alignedEnd.Add(step)
+	}
+	return alignedStart, alignedEnd
+}
+
 // handleMetricsQueryRange implements `GET /api/metrics/query_range`.
 //
 // Pipeline: parse the TraceQL metrics-pipeline query, lower it to a
@@ -203,6 +217,18 @@ func (h *Handler) handleMetricsQueryRange(w http.ResponseWriter, r *http.Request
 		writeError(w, http.StatusBadRequest, "", "", err)
 		return
 	}
+	// Align the eval grid to the step the way Tempo's api.AlignRequest
+	// does: start rounds down to a step multiple, end rounds up (or
+	// stays put when already aligned). Tempo additionally subtracts one
+	// step from the aligned start to force an initial bucket, then
+	// stamps each right-closed interval with its right edge
+	// (start + (k+1)*step) — netting out to a sample grid of step
+	// multiples spanning [floor(start), ceil(end)], which is exactly
+	// the anchor set the [Start, End] range below fans out. Without
+	// this, the anchors sat at start + k*step — offset from Tempo's
+	// grid by (start mod step) — and every range-shape compat case
+	// diff'd on sample timestamps.
+	start, end = alignMetricsWindow(start, end, step)
 
 	ctx := r.Context()
 	// Parse + lower inline so we can wrap the lowered plan with the

--- a/internal/api/tempo/metrics_query_range_test.go
+++ b/internal/api/tempo/metrics_query_range_test.go
@@ -1400,3 +1400,62 @@ func TestMetricsQueryRange_MultiQuantileOverTimeWireShape(t *testing.T) {
 	// + Tempo's Log2QuantileWithBucket post-processor) is exercised
 	// through the wire shape rather than pinned to SQL substrings.
 }
+
+// TestAlignMetricsWindow pins the Tempo api.AlignRequest-mirroring
+// grid snap: start rounds down to a step multiple, end rounds up,
+// already-aligned bounds pass through. Without it the anchor grid sat
+// at start + k*step — offset from Tempo's epoch-aligned grid by
+// (start mod step) — and every range-shape compat case diff'd on
+// sample timestamps (e.g. tempo ts=…300000 vs cerberus ts=…346000).
+func TestAlignMetricsWindow(t *testing.T) {
+	t.Parallel()
+
+	step := time.Minute
+	start := time.Date(2026, 5, 12, 10, 0, 46, 0, time.UTC)
+	end := time.Date(2026, 5, 12, 12, 0, 46, 0, time.UTC)
+	s, e := tempo.AlignMetricsWindowForTest(start, end, step)
+	if want := time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC); !s.Equal(want) {
+		t.Errorf("aligned start = %v, want %v", s, want)
+	}
+	if want := time.Date(2026, 5, 12, 12, 1, 0, 0, time.UTC); !e.Equal(want) {
+		t.Errorf("aligned end = %v, want %v", e, want)
+	}
+
+	// Already-aligned bounds must pass through untouched.
+	s2, e2 := tempo.AlignMetricsWindowForTest(
+		time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC),
+		time.Date(2026, 5, 12, 11, 0, 0, 0, time.UTC),
+		step,
+	)
+	if !s2.Equal(time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC)) || !e2.Equal(time.Date(2026, 5, 12, 11, 0, 0, 0, time.UTC)) {
+		t.Errorf("aligned bounds drifted on already-aligned input: %v / %v", s2, e2)
+	}
+}
+
+// TestMetricsQueryRange_AlignsAnchorGridToStep pins the handler-level
+// effect of the alignment: an unaligned start/end pair must produce
+// the anchor count of the ALIGNED window. start=…:00:46 / end=+3m /
+// step=60s aligns to […:00:00, …:04:00] — span 240s → 5 anchors. The
+// unaligned window would fan out only 4.
+func TestMetricsQueryRange_AlignsAnchorGridToStep(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{samples: []chclient.Sample{}}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	u := metricsQueryRangeURL(srv.URL, "{} | rate()", map[string]string{
+		"start": "1778580046", // 2026-05-12T10:00:46Z — deliberately off-grid
+		"end":   "1778580226", // +3m
+		"step":  "60s",
+	})
+	resp, err := http.Get(u)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	assertSQLContains(t, q.lastSQL, "range(0, 5)")
+}


### PR DESCRIPTION
## Summary

The 5 TraceQL-metrics compat cases left after #736 were real cerberus engine divergences. Two fixes take the TraceQL score from **84.85% (28/33) to 100% (33/33)** — all three heads now sit at full parity (PromQL 536/536, LogQL 78/78, TraceQL 33/33).

### 1. Range queries: align the eval grid to step multiples

Tempo's `api.AlignRequest` snaps start down / end up to step multiples, forces one extra initial bucket, and stamps each right-closed interval with its right edge — a sample grid of step multiples spanning `[floor(start), ceil(end)]`. Cerberus fanned anchors from the raw `end`, offsetting every sample by `start mod step` (tempo `…300000` vs cerberus `…346000`) and mis-counting by the alignment slack (122 vs 121). `alignMetricsWindow` snaps the window in the handler; the end-relative anchor fanout then lands exactly on Tempo's grid. Fixes `metrics_rate_no_groupby`, `metrics_quantile_over_time_p95`, `metrics_count_over_time_groupby_service`.

### 2. Instant queries: one anchor, not two

The instant handler synthesised `step = end − start` but passed `Start = start`, and the matrix emitter generates `(End−Start)/Step + 1` anchors — so instant queries fanned out a spurious second anchor at `start` covering `(start−step, start]`, entirely before the requested window. Its zero-fill 0 was the earliest sample and won the first-sample pick: **every instant case returned 0** (`metrics_rate_instant`: tempo=0.0554166… = 399 spans/7200s, cerberus=0). `Start = End` materialises exactly the one anchor whose right-closed window is the instant bucket. Fixes `metrics_rate_instant`, `metrics_count_over_time_instant`.

## Verification

- Full local harness (`./compatibility/tempo/scripts/run-tempo-compatibility.sh`): **33/33, 100%, brightgreen** (was 28/33).
- New pins: `TestAlignMetricsWindow`, `TestMetricsQueryRange_AlignsAnchorGridToStep` (off-grid start must fan out the aligned anchor count), `TestMetricsQueryInstant_SingleAnchorFanout` (`range(0, 1)` and explicitly not `range(0, 2)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)