### PR TITLE
fix(chclient): client cancellations no longer count as breaker failures

### DIFF
--- a/internal/chclient/breaker.go
+++ b/internal/chclient/breaker.go
@@ -1,6 +1,7 @@
 package chclient
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"time"
@@ -172,22 +173,51 @@ func (b *breaker) allow() bool {
 }
 
 // record observes the outcome of a CH-touching call and advances
-// the breaker state machine accordingly. err is the post-CH error
-// (nil on success, non-nil otherwise). The caller MUST invoke this
-// exactly once after allow() returns true; not calling it leaves the
-// breaker in a corrupted state (especially under HALF-OPEN where
-// probeInFlight stays true and the breaker stalls forever).
+// the breaker state machine accordingly. ctx is the request context
+// the call ran under; err is the post-CH error (nil on success,
+// non-nil otherwise). The caller MUST invoke this exactly once after
+// allow() returns true; not calling it leaves the breaker in a
+// corrupted state (especially under HALF-OPEN where probeInFlight
+// stays true and the breaker stalls forever).
 //
 // Special case: record skips bookkeeping when err == ErrCircuitOpen
 // because that error means the breaker's allow() already short-
 // circuited; the caller passed it through to record purely to make
 // the call-site shape uniform. Counting it would double-fault the
 // breaker.
-func (b *breaker) record(err error) {
+func (b *breaker) record(ctx context.Context, err error) {
 	// Don't double-count: ErrCircuitOpen means allow() returned
 	// false, so the call never touched CH. Counting it as a failure
 	// would keep the breaker permanently OPEN.
 	if errors.Is(err, ErrCircuitOpen) {
+		return
+	}
+
+	// Client-initiated cancellation is not a ClickHouse health
+	// signal: the caller walked away before the backend answered.
+	// Grafana aborts every in-flight panel query on dashboard
+	// navigation, so counting cancellations as failures lets a
+	// fast-navigating client trip the breaker against a perfectly
+	// healthy CH — the compose kiosk sweep produced exactly that
+	// storm (rapid ?viewPanel navigations cancelled dozens of
+	// in-flight queries within the 10s window, opened the breaker,
+	// and 503'd every panel for the next 5s; see PR #701's
+	// kiosk-console-error capture). The ctx.Err() check catches
+	// driver errors that stringify the cancellation instead of
+	// wrapping context.Canceled. Deadline expiry still counts as a
+	// failure: a backend that can't answer inside the caller's
+	// budget is operationally indistinguishable from a dead one.
+	if err != nil &&
+		(errors.Is(err, context.Canceled) ||
+			(ctx != nil && errors.Is(ctx.Err(), context.Canceled))) {
+		b.mu.Lock()
+		defer b.mu.Unlock()
+		// A cancelled HALF-OPEN probe is no verdict either way —
+		// release the probe slot so the next allow() admits a fresh
+		// probe instead of stalling the state machine forever.
+		if b.state == stateHalfOpen {
+			b.probeInFlight = false
+		}
 		return
 	}
 

--- a/internal/chclient/breaker_cancel_test.go
+++ b/internal/chclient/breaker_cancel_test.go
@@ -1,0 +1,92 @@
+package chclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// TestBreakerRecord_ClientCancellationIsNeutral pins the rule that
+// client-initiated cancellation never advances the breaker state
+// machine: a cancelled query says nothing about ClickHouse health.
+// Grafana aborts every in-flight panel query on dashboard navigation,
+// so counting cancellations as failures let a fast-navigating client
+// trip the breaker against a perfectly healthy CH — the compose kiosk
+// sweep's rapid ?viewPanel navigations cancelled dozens of in-flight
+// queries inside one breakerWindow, opened the breaker, and 503'd
+// every subsequent panel (PR #701's kiosk-console-error capture).
+func TestBreakerRecord_ClientCancellationIsNeutral(t *testing.T) {
+	t.Parallel()
+
+	b := &breaker{}
+
+	// Wrapped context.Canceled errors never trip the breaker, no
+	// matter how many arrive inside the window.
+	for i := 0; i < breakerThreshold*3; i++ {
+		b.record(context.Background(), fmt.Errorf("chclient: query: %w", context.Canceled))
+	}
+	if got := b.currentState(); got != "closed" {
+		t.Fatalf("breaker state after wrapped-Canceled storm = %q, want closed", got)
+	}
+
+	// Driver errors that stringify the cancellation instead of
+	// wrapping context.Canceled are caught via the request context.
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	for i := 0; i < breakerThreshold*3; i++ {
+		b.record(canceledCtx, errors.New("driver: context canceled (not wrapped)"))
+	}
+	if got := b.currentState(); got != "closed" {
+		t.Fatalf("breaker state after unwrapped-cancel storm = %q, want closed", got)
+	}
+
+	// Genuine backend failures still trip it.
+	for i := 0; i < breakerThreshold; i++ {
+		b.record(context.Background(), errors.New("dial tcp 127.0.0.1:9000: connection refused"))
+	}
+	if got := b.currentState(); got != "open" {
+		t.Fatalf("breaker state after genuine failures = %q, want open", got)
+	}
+}
+
+// TestBreakerRecord_CancelledProbeReleasesSlot pins the HALF-OPEN
+// interaction: a cancelled probe is no verdict either way, so the
+// probe slot must be released for the next allow() to admit a fresh
+// probe — swallowing the slot would stall the breaker OPEN forever.
+func TestBreakerRecord_CancelledProbeReleasesSlot(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(1_700_000_000, 0)
+	b := &breaker{now: func() time.Time { return now }}
+
+	// Trip the breaker with genuine failures.
+	for i := 0; i < breakerThreshold; i++ {
+		b.record(context.Background(), errors.New("connection refused"))
+	}
+	if got := b.currentState(); got != "open" {
+		t.Fatalf("setup: breaker = %q, want open", got)
+	}
+
+	// Backoff elapses; allow() admits the HALF-OPEN probe.
+	now = now.Add(breakerOpenInterval + time.Second)
+	if !b.allow() {
+		t.Fatal("expected allow() to admit the half-open probe after backoff")
+	}
+
+	// The probe gets cancelled mid-flight. The slot must come free…
+	b.record(context.Background(), fmt.Errorf("chclient: query: %w", context.Canceled))
+	if got := b.currentState(); got != "half-open" {
+		t.Fatalf("breaker after cancelled probe = %q, want half-open", got)
+	}
+	// …so the next caller is admitted as a fresh probe, and its
+	// success closes the circuit.
+	if !b.allow() {
+		t.Fatal("expected allow() to admit a fresh probe after the cancelled one")
+	}
+	b.record(context.Background(), nil)
+	if got := b.currentState(); got != "closed" {
+		t.Fatalf("breaker after successful probe = %q, want closed", got)
+	}
+}

--- a/internal/chclient/client.go
+++ b/internal/chclient/client.go
@@ -64,12 +64,14 @@ func startExecuteSpan(ctx context.Context, sql, addr string) (context.Context, t
 		// server.address is the modern semconv key; net.peer.name is the
 		// pre-v1.21 alias still consumed by older dashboards. Stamp both
 		// so neither generation breaks.
-		attrs = append(attrs,
+		attrs = append(
+			attrs,
 			attrServerAddr.String(addr),
 			attrNetPeerName.String(addr),
 		)
 	}
-	return tracer.Start(ctx, cerbtrace.SpanExecute,
+	return tracer.Start(
+		ctx, cerbtrace.SpanExecute,
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(attrs...),
 	)
@@ -178,7 +180,7 @@ func (c *Client) Ping(ctx context.Context) error {
 		return fmt.Errorf("chclient: ping: %w", ErrCircuitOpen)
 	}
 	err := c.conn.Ping(ctx)
-	c.br.record(err)
+	c.br.record(ctx, err)
 	if err != nil {
 		return fmt.Errorf("chclient: ping: %w", err)
 	}
@@ -207,7 +209,7 @@ func (c *Client) Exec(ctx context.Context, sql string, args ...any) error {
 	ctx, span := startExecuteSpan(ctx, sql, c.addr)
 	defer span.End()
 	err := c.conn.Exec(ctx, sql, args...)
-	c.br.record(err)
+	c.br.record(ctx, err)
 	if err != nil {
 		span.RecordError(err)
 		return fmt.Errorf("chclient: exec: %w", err)
@@ -271,7 +273,7 @@ func (c *Client) QueryStrings(ctx context.Context, sql string, args ...any) ([]s
 	defer span.End()
 	defer flushProgress(ctx)
 	rows, err := c.conn.Query(ctx, sql, args...)
-	c.br.record(err)
+	c.br.record(ctx, err)
 	if err != nil {
 		span.RecordError(err)
 		return nil, fmt.Errorf("chclient: query: %w", err)
@@ -318,7 +320,7 @@ func (c *Client) QueryTimestampedLines(ctx context.Context, sql string, args ...
 	defer span.End()
 	defer flushProgress(ctx)
 	rows, err := c.conn.Query(ctx, sql, args...)
-	c.br.record(err)
+	c.br.record(ctx, err)
 	if err != nil {
 		span.RecordError(err)
 		return nil, fmt.Errorf("chclient: query: %w", err)
@@ -366,7 +368,7 @@ func (c *Client) QueryMetricMeta(ctx context.Context, sql, metricType string, ar
 	defer span.End()
 	defer flushProgress(ctx)
 	rows, err := c.conn.Query(ctx, sql, args...)
-	c.br.record(err)
+	c.br.record(ctx, err)
 	if err != nil {
 		span.RecordError(err)
 		return nil, fmt.Errorf("chclient: query: %w", err)
@@ -416,7 +418,7 @@ func (c *Client) QueryIndexStats(ctx context.Context, sql string, args ...any) (
 	defer span.End()
 	defer flushProgress(ctx)
 	rows, err := c.conn.Query(ctx, sql, args...)
-	c.br.record(err)
+	c.br.record(ctx, err)
 	if err != nil {
 		span.RecordError(err)
 		return IndexStatsRow{}, fmt.Errorf("chclient: query: %w", err)
@@ -458,7 +460,7 @@ func (c *Client) QueryIndexVolume(ctx context.Context, sql string, args ...any) 
 	defer span.End()
 	defer flushProgress(ctx)
 	rows, err := c.conn.Query(ctx, sql, args...)
-	c.br.record(err)
+	c.br.record(ctx, err)
 	if err != nil {
 		span.RecordError(err)
 		return nil, fmt.Errorf("chclient: query: %w", err)
@@ -521,7 +523,7 @@ func (c *Client) QueryExemplars(ctx context.Context, sql string, args ...any) ([
 	defer span.End()
 	defer flushProgress(ctx)
 	rows, err := c.conn.Query(ctx, sql, args...)
-	c.br.record(err)
+	c.br.record(ctx, err)
 	if err != nil {
 		span.RecordError(err)
 		return nil, fmt.Errorf("chclient: query: %w", err)
@@ -565,7 +567,7 @@ func (c *Client) QueryLabelSets(ctx context.Context, sql string, args ...any) ([
 	defer span.End()
 	defer flushProgress(ctx)
 	rows, err := c.conn.Query(ctx, sql, args...)
-	c.br.record(err)
+	c.br.record(ctx, err)
 	if err != nil {
 		span.RecordError(err)
 		return nil, fmt.Errorf("chclient: query: %w", err)

--- a/internal/chclient/cursor.go
+++ b/internal/chclient/cursor.go
@@ -142,7 +142,7 @@ func (c *Client) QueryCursor(ctx context.Context, sql string, args ...any) (Curs
 	}
 	ctx, span := startExecuteSpan(ctx, sql, c.addr)
 	rows, err := c.conn.Query(ctx, sql, args...)
-	c.br.record(err)
+	c.br.record(ctx, err)
 	if err != nil {
 		span.RecordError(err)
 		span.End()


### PR DESCRIPTION
## Summary

Root-cause fix for PR #701's CI-only compose-smoke failures — and a real production bug: **a client that cancels queries fast enough could trip the circuit breaker against a perfectly healthy ClickHouse**, 503-ing every query for 5s.

The breaker counted every non-nil error as a CH failure, including `context.Canceled` from clients that walked away. Grafana aborts all in-flight panel queries on every dashboard navigation, so the kiosk sweep's rapid `?viewPanel` navigations on the 2-core CI runner cancelled dozens of in-flight queries inside one 10s `breakerWindow` → breaker OPEN → every subsequent panel got `unavailable: engine: execute: chclient: query: chclient: circuit breaker open` (rendered as anonymous 400s until #701 grew non-2xx response capture). Never reproducible locally: on a fast machine the queries complete before navigation can abort them.

## Fix

`record()` now takes the request context and treats client cancellation as **neutral** — neither success nor failure:

- wrapped `context.Canceled` matched via `errors.Is`;
- driver errors that stringify the cancellation instead of wrapping it are caught via `ctx.Err()`;
- a cancelled HALF-OPEN probe releases the probe slot without a verdict, so the next caller is admitted as a fresh probe (swallowing the slot would stall the breaker OPEN forever);
- deadline expiry still counts as failure — a backend that can't answer inside the caller's budget is operationally indistinguishable from a dead one.

## Test plan

- `TestBreakerRecord_ClientCancellationIsNeutral` — wrapped + unwrapped cancellation storms leave the breaker CLOSED; genuine failures still trip it.
- `TestBreakerRecord_CancelledProbeReleasesSlot` — cancelled HALF-OPEN probe frees the slot; the follow-up probe's success closes the circuit.
- Existing Layer-11 breaker chaos tests drive the state machine through the Client surface and are unaffected.
- After merge: PR #701 rebases onto this and its compose-smoke kiosk sweep should go green (the sweep is the original reproducer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)