### PR TITLE
fix(test/e2e/seed): drop TimestampTime from the logs INSERT — schema skew with collector 0.152

### DIFF
--- a/test/e2e/seed/cmd/seed/main.go
+++ b/test/e2e/seed/cmd/seed/main.go
@@ -320,11 +320,23 @@ FROM numbers(600)`
 	// this INSERT every 30 s, so every Loki `/query` instant request
 	// (5 m staleness lookback, see internal/api/loki/handler.go:235)
 	// finds ≥1 row inside the lookback regardless of suite drift.
+	//
+	// The column list deliberately omits `TimestampTime`: upstream's
+	// clickhouseexporter removed the column from the logs DDL in
+	// v0.150.0, so which schema `otel_logs` carries depends on who
+	// created it first — this seeder's ddl.Apply (legacy fork
+	// templates, column present + materialized from Timestamp) or the
+	// k3d otel-collector's own exporter (0.152.x, column gone).
+	// Cerberus's startup warmup (#712) made the collector reliably win
+	// that race, and an INSERT naming the column hard-fails against
+	// the new schema ("No such column TimestampTime"). Upstream's own
+	// insert path stays compatible with both schemas by never naming
+	// it — the legacy schema materializes it from Timestamp — so this
+	// INSERT does the same.
 	insertLogsSQL = `INSERT INTO otel_logs
-  (Timestamp, TimestampTime, TraceId, SpanId, SeverityText, SeverityNumber, ServiceName, Body, ResourceAttributes, LogAttributes)
+  (Timestamp, TraceId, SpanId, SeverityText, SeverityNumber, ServiceName, Body, ResourceAttributes, LogAttributes)
 SELECT
     now64(9) + INTERVAL ((number - 20) * 15) SECOND AS ts,
-    ts,
     lpad(toString(number % 4), 32, '0'),
     lpad(toString(number % 4), 16, '0'),
     multiIf(number % 5 = 0, 'ERROR', number % 3 = 0, 'WARN', 'INFO'),

--- a/test/regression/seed_test.go
+++ b/test/regression/seed_test.go
@@ -186,3 +186,33 @@ func TestTracesSeedHasFrontendAndApiServices(t *testing.T) {
 		}
 	}
 }
+
+// TestLogsSeedOmitsTimestampTime pins the schema-skew fix from the
+// 2026-06-10 dashboard-job failures: upstream's clickhouseexporter
+// removed the TimestampTime column from the logs DDL in v0.150.0, so
+// which schema `otel_logs` carries depends on who creates it first —
+// the seeder's ddl.Apply (legacy fork templates, column present and
+// materialized from Timestamp) or the k3d otel-collector's own
+// exporter (0.152.x, column gone). Cerberus's startup warmup (#712)
+// made the collector reliably win that race, and the seeder's INSERT
+// naming the column hard-failed with "No such column TimestampTime".
+// The compatible INSERT shape — upstream's own posture across its
+// schema migration — never names the column; the legacy schema
+// materializes it from Timestamp.
+func TestLogsSeedOmitsTimestampTime(t *testing.T) {
+	t.Parallel()
+
+	content := readSeedSource(t)
+	logsStart := strings.Index(content, "insertLogsSQL")
+	if logsStart < 0 {
+		t.Fatalf("%s: insertLogsSQL constant not found", seedSource)
+	}
+	logsEnd := strings.Index(content[logsStart:], "insertTracesSQL")
+	if logsEnd < 0 {
+		logsEnd = len(content) - logsStart
+	}
+	logsBlock := content[logsStart : logsStart+logsEnd]
+	if strings.Contains(logsBlock, "TimestampTime") {
+		t.Errorf("%s: logs INSERT names TimestampTime — the column does not exist in the post-v0.150.0 exporter schema, so the INSERT hard-fails whenever the collector created otel_logs first; omit it (the legacy schema materializes it from Timestamp)", seedSource)
+	}
+}


### PR DESCRIPTION
## Summary

The `dashboard` e2e job went red on every push-to-main tonight, failing at the seed step:

```
seed: insert logs: code: 16, message: No such column TimestampTime in table otel.otel_logs
```

Root cause is a schema race with two creators: upstream's clickhouseexporter **removed `TimestampTime` from the otel_logs DDL in v0.150.0**, so which schema the table carries depends on who creates it first — the seeder's `ddl.Apply` (legacy fork templates: column present, materialized from `Timestamp`) or the k3d otel-collector's own exporter (0.152.x: column gone). The startup warmup #712 added makes cerberus emit self-telemetry logs at boot, so the collector now reliably wins the race; the seeder's INSERT named the column explicitly and hard-failed against the new schema. (Nightlies were green before tonight because the seeder used to win.)

## Fix

Omit `TimestampTime` from the INSERT column list — exactly upstream's own posture across its schema migration ("the INSERT path remains compatible with both old and new schemas"). Against the legacy schema the column materializes from `Timestamp`; against the new schema it doesn't exist. Either way the seed succeeds.

`TestLogsSeedOmitsTimestampTime` (test/regression) pins the column out of the logs-INSERT block so the skew class can't silently recur.

## Follow-up (separate PR)

The deeper alignment — rebasing `tsouza/opentelemetry-collector-contrib:cerberus-ddl` onto the v0.152 sqltemplates so cerberus's own `ddl.Apply` creates the modern schema (new ORDER BY, materialized k8s columns, TTL on `Timestamp`) — goes through the documented fork flow and is tracked separately; it isn't needed for green.

## Test plan

- [ ] `check` green (`TestLogsSeedOmitsTimestampTime` + existing seed-invariant pins)
- [ ] After merge: `dashboard` job green on the merge push (the failing step was the first 30s of that job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)