### PR TITLE
fix(test/e2e/k3d): scope dashboard sweep to the stack's own provisioning + install drilldown apps

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -325,6 +325,15 @@ jobs:
         env:
           GRAFANA_URL: http://localhost:3000
           CERBERUS_URL: http://localhost:8080
+          # iterate-all-dashboards reads dashboard JSON from disk;
+          # point it at the k3d stack's provisioning dir (the spec
+          # default is the compose stack's). The compose-only
+          # dashboards (clickhouse / host / otelcol) are fed by
+          # receivers the k3d collector intentionally doesn't run, so
+          # probing them here reports empty panels for data this stack
+          # never ships; the compose set is covered per-PR by the
+          # required compose-smoke job.
+          DASHBOARDS_DIR: ${{ github.workspace }}/test/e2e/grafana/dashboards
         # `npx playwright test` with no spec filter auto-discovers
         # every `*.spec.ts` under test/e2e/playwright/. That includes
         # the phase-5 `iterate-time-ranges.spec.ts` matrix sweep,
@@ -338,11 +347,9 @@ jobs:
         #
         # Auto-discovered specs of note (each is hard-fail in this
         # informational dashboard job; the job itself is not a PR gate):
-        #   - iterate-all-dashboards.spec.ts: reads
-        #       test/e2e/grafana/compose/dashboards/*.json at spec-build
-        #       time and probes every panel against the real cerberus
-        #       stack. Auto-adapts as the rich-observability rollout
-        #       lands new dashboards (clickhouse, otelcol, host).
+        #   - iterate-all-dashboards.spec.ts: reads the DASHBOARDS_DIR
+        #       JSON at spec-build time and probes every panel against
+        #       the real cerberus stack.
         #   - iterate-metrics-explorer.spec.ts: enumerates every
         #       metric cerberus publishes and probes /api/v1/series for
         #       each. Pins the user's #8 sweep finding: the labels chip

--- a/test/e2e/k3s/grafana.yaml
+++ b/test/e2e/k3s/grafana.yaml
@@ -128,6 +128,16 @@ spec:
               value: dark
             - name: GF_FEATURE_TOGGLES_ENABLE
               value: traceqlSearch
+            # The drilldown-apps sweep (iterate-drilldown-apps.spec.ts)
+            # hard-fails on any catalogue app whose
+            # /api/plugins/<id>/settings reports not-installed (the
+            # install-probe early-skip was removed with the rest of the
+            # test escape hatches). grafana-lokiexplore-app ships built
+            # in to grafana/grafana:11.4.0; the metrics and traces
+            # drilldown apps don't until later releases, so install
+            # them from the catalog at startup.
+            - name: GF_INSTALL_PLUGINS
+              value: grafana-metricsdrilldown-app,grafana-exploretraces-app
           volumeMounts:
             - name: datasources
               mountPath: /etc/grafana/provisioning/datasources

--- a/test/e2e/playwright/iterate-all-dashboards.spec.ts
+++ b/test/e2e/playwright/iterate-all-dashboards.spec.ts
@@ -70,16 +70,20 @@ const SEED_TRAFFIC_SECONDS = 30;
 const QUERY_WINDOW_SECONDS = 5 * 60;
 const QUERY_STEP_SECONDS = 15;
 
-// Path to the provisioning directory the compose stack mounts into
-// Grafana. The spec lives at test/e2e/playwright/iterate-all-dashboards.spec.ts
-// so the dashboards dir is one level up + /grafana/compose/dashboards.
-const DASHBOARDS_DIR = resolve(
-  __dirname,
-  '..',
-  'grafana',
-  'compose',
-  'dashboards',
-);
+// Path to the provisioning directory the stack under test mounts into
+// Grafana. Defaults to the compose stack's directory (the spec lives
+// at test/e2e/playwright/iterate-all-dashboards.spec.ts, so that's one
+// level up + /grafana/compose/dashboards); the k3d dashboard job
+// overrides via DASHBOARDS_DIR because the k3d stack provisions a
+// different (smaller) dashboard set — its collector intentionally
+// doesn't run the compose-only sqlquery/hostmetrics/self-scrape
+// receivers, so probing the compose-only dashboards against it
+// reports empty panels for data the stack never ships. Each stack's
+// sweep must cover exactly the dashboards that stack provisions; the
+// compose set stays covered per-PR by the required compose-smoke job.
+const DASHBOARDS_DIR =
+  process.env.DASHBOARDS_DIR ??
+  resolve(__dirname, '..', 'grafana', 'compose', 'dashboards');
 
 /**
  * Local types — kept inline since this spec uses the on-disk JSON


### PR DESCRIPTION
## Summary

The `dashboard` (k3d) job stayed red after #739 fixed the seed step — two k3d-vs-compose parity gaps surfaced by the landing of #712 (escape-hatch removal) and #701 (rich-observability dashboards):

1. **Dashboard sweep probed dashboards the stack doesn't ship.** `iterate-all-dashboards` hard-resolved the *compose* provisioning dir, so the k3d run probed the compose-only dashboards (clickhouse / host / otelcol — fed by the sqlquery / hostmetrics / self-scrape receivers only the compose collector runs) against a stack that never carries that data: `max(clickhouse_metric{name="Query"})` probed empty. The dir is now `DASHBOARDS_DIR`-overridable (compose default unchanged) and the k3d job points it at `test/e2e/grafana/dashboards`. Each stack's sweep covers exactly what that stack provisions — the compose set remains covered per-PR by the required `compose-smoke` job, so no coverage is lost.

2. **Drilldown catalogue apps not installed in k3d Grafana.** #712 removed the install-probe early-skip — a not-installed catalogue app is now a hard fail, with the spec's own remediation: "Provision the plugin … or remove it from the catalogue." `grafana/grafana:11.4.0` ships only `grafana-lokiexplore-app` built in; install `grafana-metricsdrilldown-app` + `grafana-exploretraces-app` via `GF_INSTALL_PLUGINS` in the k3d deployment.

## Test plan

- [ ] PR checks green (the changed spec also runs in the required `compose-smoke` job with its default dir — behaviour there is unchanged).
- [ ] `dashboard` job green on the merge push — the two failing specs were the only red in run 27245720333.

🤖 Generated with [Claude Code](https://claude.com/claude-code)