### PR TITLE
fix(test/e2e/k3d): scope drilldown catalogue to apps Grafana 11.4 can run

### DIFF
--- a/test/e2e/k3s/grafana.yaml
+++ b/test/e2e/k3s/grafana.yaml
@@ -128,16 +128,15 @@ spec:
               value: dark
             - name: GF_FEATURE_TOGGLES_ENABLE
               value: traceqlSearch
-            # The drilldown-apps sweep (iterate-drilldown-apps.spec.ts)
-            # hard-fails on any catalogue app whose
-            # /api/plugins/<id>/settings reports not-installed (the
-            # install-probe early-skip was removed with the rest of the
-            # test escape hatches). grafana-lokiexplore-app ships built
-            # in to grafana/grafana:11.4.0; the metrics and traces
-            # drilldown apps don't until later releases, so install
-            # them from the catalog at startup.
-            - name: GF_INSTALL_PLUGINS
-              value: grafana-metricsdrilldown-app,grafana-exploretraces-app
+            # Deliberately NO GF_INSTALL_PLUGINS for the drilldown
+            # apps: grafana-metricsdrilldown-app and
+            # grafana-exploretraces-app require Grafana >= 11.6 and
+            # installing them on this 11.4.0 image bricks the frontend
+            # (run 27246825822 hung the whole Playwright suite on its
+            # first navigation, both attempts). The drilldown catalogue
+            # (test/e2e/playwright/helpers/drilldown.ts) is scoped to
+            # the apps this image ships; both come back as first-party
+            # preinstalled apps when the Grafana pin bumps to 12.x.
           volumeMounts:
             - name: datasources
               mountPath: /etc/grafana/provisioning/datasources

--- a/test/e2e/playwright/helpers/drilldown.ts
+++ b/test/e2e/playwright/helpers/drilldown.ts
@@ -38,21 +38,23 @@ export type DrilldownApp = {
   label: string;
 };
 
+// The catalogue lists exactly the drilldown apps the pinned Grafana
+// image can run — the same rule that dropped grafana-pyroscope-app
+// (cerberus doesn't ship profiling). grafana/grafana:11.4.0 ships
+// grafana-lokiexplore-app built in; grafana-metricsdrilldown-app and
+// grafana-exploretraces-app require Grafana >= 11.6 (exploretraces
+// grafanaDependency: ">=11.6.11 <12 || >=12.0.10 …") and cannot run
+// on this image — installing them anyway via GF_INSTALL_PLUGINS
+// bricked the 11.4 frontend and hung the entire k3d Playwright suite
+// on its first navigation (run 27246825822, both attempts: 21 silent
+// minutes after "Running 165 tests"). Restore both entries when the
+// Grafana pin bumps to a release that preinstalls them (12.x) — they
+// are first-party there and need no GF_INSTALL_PLUGINS.
 export const DRILLDOWN_APPS: ReadonlyArray<DrilldownApp> = [
-  {
-    id: 'grafana-metricsdrilldown-app',
-    root: '/a/grafana-metricsdrilldown-app/trail',
-    label: 'Explore Metrics',
-  },
   {
     id: 'grafana-lokiexplore-app',
     root: '/a/grafana-lokiexplore-app/explore?var-ds=cerberus-loki',
     label: 'Explore Logs',
-  },
-  {
-    id: 'grafana-exploretraces-app',
-    root: '/a/grafana-exploretraces-app/explore',
-    label: 'Explore Traces',
   },
 ];
 


### PR DESCRIPTION
## Summary

#740's `GF_INSTALL_PLUGINS` approach backfired: `grafana-metricsdrilldown-app` and `grafana-exploretraces-app` require **Grafana ≥ 11.6** (exploretraces `grafanaDependency: ">=11.6.11 <12 || >=12.0.10 …"`), and force-installing them on the pinned `grafana/grafana:11.4.0` bricks the frontend. Run 27246825822 hung the entire k3d Playwright suite on its first navigation — both attempts sat 21 silent minutes after "Running 165 tests" until the job's 25-minute budget killed them (`compose_grafana_smoke` sets an 8-minute per-test budget × 3 attempts).

## Fix

- Revert the `GF_INSTALL_PLUGINS` env (with an in-manifest comment pinning why it must not return on 11.4).
- Scope the drilldown catalogue to what the pinned image actually ships: `grafana-lokiexplore-app` (built in since 11.3). This is the catalogue's own rule — the same one that dropped `grafana-pyroscope-app` (cerberus doesn't ship profiling). The two newer apps were never actually exercised on this stack: the pre-#712 install-probe always skipped them, so no real coverage is lost.
- Both apps return as **first-party preinstalled** catalogue entries when the Grafana pin bumps to 12.x — tracked follow-up, which also needs a selector re-validation across the suite (Grafana 12 UI changes).

## Test plan

- [ ] PR checks green.
- [ ] `dashboard` job green on the merge push — with the catalogue scoped and no plugin install, the stack is byte-identical to the last green configuration plus #739/#740's orthogonal fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)