### PR TITLE
test(e2e): align drilldown catalogue pin + capture cerberus crash evidence in the k3d dump

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -369,8 +369,24 @@ jobs:
         run: |
           echo "=== pods ==="
           kubectl -n cerberus get pods -o wide || true
+          echo "=== events (last 50) ==="
+          kubectl -n cerberus get events --sort-by=.lastTimestamp | tail -50 || true
           echo "=== cerberus logs ==="
           kubectl -n cerberus logs deploy/cerberus --tail 200 || true
+          # Per-pod current + previous-container logs for EVERY
+          # cerberus pod: `logs deploy/...` picks one pod, which on a
+          # crash-looping deployment is usually a healthy survivor —
+          # run 27249217602 had two cerberus pods in CrashLoopBackOff
+          # (exit 1) and the dump captured nothing about why. The
+          # --previous tail is the crash evidence.
+          for p in $(kubectl -n cerberus get pods -l app=cerberus -o name); do
+            echo "=== $p (current) ==="
+            kubectl -n cerberus logs "$p" --tail 50 || true
+            echo "=== $p (previous container, if restarted) ==="
+            kubectl -n cerberus logs "$p" --previous --tail 100 || true
+          done
+          echo "=== cerberus pod describes ==="
+          kubectl -n cerberus describe pods -l app=cerberus || true
           echo "=== clickhouse logs ==="
           kubectl -n cerberus logs deploy/clickhouse --tail 200 || true
           echo "=== grafana logs ==="

--- a/test/e2e/playwright/helpers.spec.ts
+++ b/test/e2e/playwright/helpers.spec.ts
@@ -472,22 +472,21 @@ test('assertSubsetByCount throws when filtered exceeds baseline', () => {
   );
 });
 
-test('iterateDrilldownApps returns four apps including the four built-ins', () => {
+test('iterateDrilldownApps returns the apps the pinned Grafana ships', () => {
+  // The catalogue is scoped to what grafana/grafana:11.4.0 can run:
+  // grafana-pyroscope-app left with the escape-hatch cleanup (cerberus
+  // doesn't ship profiling) and grafana-metricsdrilldown-app /
+  // grafana-exploretraces-app require Grafana >= 11.6 (see
+  // helpers/drilldown.ts). This pin moves in lock-step with the
+  // catalogue — when the Grafana pin bumps to 12.x the two newer apps
+  // return as first-party preinstalled entries.
   const apps = iterateDrilldownApps();
-  expect(apps.length).toBe(4);
-  const ids = apps.map((a) => a.id).sort();
-  expect(ids).toEqual(
-    [
-      'grafana-exploretraces-app',
-      'grafana-lokiexplore-app',
-      'grafana-metricsdrilldown-app',
-      'grafana-pyroscope-app',
-    ].sort(),
-  );
+  expect(apps.length).toBe(1);
+  expect(apps.map((a) => a.id)).toEqual(['grafana-lokiexplore-app']);
   // Returned array must be a fresh copy — mutating it must not
   // contaminate the module-level constant.
   apps.pop();
-  expect(DRILLDOWN_APPS.length).toBe(4);
+  expect(DRILLDOWN_APPS.length).toBe(1);
 });
 
 test('DRILLDOWN_APPS entries each carry id + root + label', () => {


### PR DESCRIPTION
## Summary

Two fixes for the k3d `dashboard` lane, from run 27249217602's post-#741 failures:

1. **Stale catalogue pin.** `helpers.spec.ts` still asserted the original four-app drilldown catalogue (including `grafana-pyroscope-app`, dropped by #712, and the two ≥11.6-only apps scoped out by #741). The k3d lane is the only place this spec runs, so the stale pin has been failing there since #712 — masked behind the lane's louder failures. The pin now moves in lock-step with the catalogue and documents the Grafana-pin coupling.

2. **Blind crash dump.** The same run had two cerberus pods in CrashLoopBackOff (exit 1, 5 restarts) producing five empty-body Grafana-proxy 502s in the panel-shape sweep — and the failure dump captured nothing about why: `kubectl logs deploy/…` picks one pod, usually a healthy survivor. The dump now captures per-pod current + `--previous` logs for every cerberus pod, the pod describes, and the last 50 namespace events.

The crash loop itself (suspected: HPA scale-out under the suite's warmup burst on a 2-core runner, fresh pods failing against a saturated stack) is NOT fixed here — a rerun of the same commit is in flight to gauge determinism, and the improved dump makes the next occurrence name the actual exit cause.

## Test plan

- [ ] PR checks green.
- [ ] `dashboard` job on the merge push: helpers.spec passes; if the crash loop recurs, the dump now contains the previous-container logs to root-cause it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)