### PR TITLE
fix(test/e2e/k3d): size probe budgets for a saturated node + gate on zero cerberus restarts

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -356,6 +356,38 @@ jobs:
         #       must not surface "Unable to fetch labels".
         run: npx playwright test
 
+      # Hard gate: zero cerberus container restarts across the whole
+      # job, asserted even when every spec passed. The nightly at run
+      # 27253909069 went GREEN while attempt 1 of the kiosk sweep hit
+      # "dial tcp …:8080: connect: connection refused" — Playwright's
+      # retries rode out a window where every cerberus pod was being
+      # probe-killed/unready at once, so the lane silently shipped a
+      # restart-looping gateway. A restart is a failure to fix at the
+      # source (probe budgets, resources, or a real crash); never a
+      # thing retries may absorb. On violation the step prints the
+      # previous-container logs + describes + events — the crash
+      # evidence — then fails the job.
+      - name: Assert zero cerberus restarts
+        if: always()
+        run: |
+          total=0
+          for c in $(kubectl -n cerberus get pods -l app=cerberus \
+              -o jsonpath='{range .items[*]}{.status.containerStatuses[0].restartCount}{"\n"}{end}'); do
+            total=$((total + c))
+          done
+          echo "cerberus container restarts (sum across pods): $total"
+          if [ "$total" -gt 0 ]; then
+            echo "::error::cerberus pods restarted $total time(s) during the e2e run — dumping evidence"
+            kubectl -n cerberus get pods -o wide || true
+            kubectl -n cerberus get events --sort-by=.lastTimestamp | tail -60 || true
+            for p in $(kubectl -n cerberus get pods -l app=cerberus -o name); do
+              echo "=== $p (previous container) ==="
+              kubectl -n cerberus logs "$p" --previous --tail 120 || true
+            done
+            kubectl -n cerberus describe pods -l app=cerberus || true
+            exit 1
+          fi
+
       - name: Upload Playwright report on failure
         if: failure()
         uses: actions/upload-artifact@v7

--- a/test/e2e/k3s/cerberus.yaml
+++ b/test/e2e/k3s/cerberus.yaml
@@ -83,7 +83,11 @@ spec:
                 name: cerberus-config
           resources:
             requests:
-              cpu: 100m
+              # 250m so the scheduler weights cerberus fairly against
+              # CH + the collector + the Playwright suite on a 4-vCPU
+              # CI node. No CPU limit — bursting is fine; it's the
+              # probe kills under starvation that hurt (see below).
+              cpu: 250m
               memory: 64Mi
             limits:
               memory: 256Mi
@@ -91,18 +95,40 @@ spec:
           # probe doesn't hammer CH) and reports the auto-create-schema
           # invariant. A failure removes the pod from the Service
           # endpoints without restarting it — backpressure, not crash.
+          #
+          # Probe budgets are sized for a saturated CI node, not a
+          # quiet cluster: /readyz pings a SHARED dependency, so when
+          # the e2e suite drives CH hard every replica's probe slows
+          # at once and a tight budget evicts ALL endpoints together —
+          # Grafana then surfaces "dial tcp …:8080: connect:
+          # connection refused" mid-sweep (nightly 27253909069 went
+          # green only because Playwright retried past that window).
+          # timeout 5s + 5 failures ≈ 15-21s of sustained CH
+          # saturation before eviction; recovery stays fast via the
+          # 3s period.
           readinessProbe:
             httpGet:
               path: /readyz
               port: http
             initialDelaySeconds: 2
             periodSeconds: 3
-            timeoutSeconds: 2
+            timeoutSeconds: 5
+            failureThreshold: 5
           # /healthz is intentionally dependency-free: a failure here
           # means the process is wedged and k8s should restart the pod.
+          #
+          # timeoutSeconds was previously unset — the k8s default is
+          # 1s, a hair-trigger on a contended CI node: a CPU-starved
+          # but healthy process missing three 1s probes got KILLED,
+          # racking up restart counts / CrashLoopBackOff exactly while
+          # the suite was load-bursting (the compose stack never saw
+          # this — Docker doesn't kill on unhealthy). 5s × 6 failures
+          # still restarts a genuinely wedged process within ~60s.
           livenessProbe:
             httpGet:
               path: /healthz
               port: http
             initialDelaySeconds: 10
             periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6


### PR DESCRIPTION
## Summary

Response to the flagged nightly ([run 27253909069](https://github.com/tsouza/cerberus/actions/runs/27253909069/job/80484014175)): it went **green while cerberus was restart-looping** — attempt 1 of the kiosk sweep hit `dial tcp 10.43.46.39:8080: connect: connection refused` (zero ready endpoints behind the Service) and Playwright's retries rode out the window. Same shape as the CrashLoopBackOff pods in runs 27249217602 / 27246825822.

## Root cause

Probe budgets sized for a quiet cluster, not a load-test node:

- **livenessProbe had no `timeoutSeconds`** — k8s defaults to **1s**. On a contended 4-vCPU CI node a CPU-starved but healthy process misses three 1s probes and gets killed, racking up restarts / CrashLoopBackOff precisely while the suite load-bursts. The compose stack never reproduced it because Docker doesn't kill on unhealthy.
- **readinessProbe pings ClickHouse — a shared dependency** — so when the suite saturates CH, every replica's probe slows at once and the 2s timeout × 3 failures evicted **all** endpoints together: the exact zero-endpoint connection-refused signature captured by #701's response diagnostics.
- Memory is exonerated: cerberus peaks at ~**73MiB** under the same kiosk+shape sweep (measured against the compose stack), far under the 256Mi limit.

## Fix

- liveness: `timeoutSeconds: 5`, `failureThreshold: 6` — a genuinely wedged process still restarts within ~60s; starvation no longer kills healthy pods.
- readiness: `timeoutSeconds: 5`, `failureThreshold: 5` (period stays 3s for fast recovery) — ~15-21s of sustained CH saturation before eviction instead of ~6s.
- cpu request 100m → 250m for fair scheduling against CH + collector + the suite.
- **New always-run gate: zero cerberus container restarts across the job.** On violation it dumps previous-container logs + describes + events (the crash evidence) and fails the job — a restart-looping gateway can never ship behind green retries again.

## Test plan

- [ ] PR checks green.
- [ ] `dashboard` job on the merge push passes **including the new zero-restart gate** — that's the live proof the probe budgets were the cause. If the gate trips instead, its dump names the real killer and the next fix is at that source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)