### PR TITLE
fix(chclient): label-map interning + Prometheus-parity per-query sample budget

### DIFF
--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -3,6 +3,7 @@ package loki
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"runtime"
@@ -367,6 +368,23 @@ func classifyEngineErr(err error) error {
 			Err:               err,
 			Status:            http.StatusServiceUnavailable,
 			RetryAfterSeconds: 5,
+		}
+	}
+	// Sample-budget exceedance: the per-query CERBERUS_QUERY_MAX_SAMPLES
+	// cap aborted the result-set drain inside chclient. Surface it the
+	// way upstream Loki reports query-limit violations — HTTP 400 with a
+	// "maximum ... reached for a single query" message — NOT a 5xx: the
+	// query is over-broad, ClickHouse is healthy (the breaker never sees
+	// drain errors, see chclient.QueryCursor).
+	var tooMany *chclient.TooManySamplesError
+	if errors.As(err, &tooMany) {
+		return &apiError{
+			Kind: ErrBadData,
+			Err: fmt.Errorf(
+				"maximum number of samples (%d) reached for a single query; consider reducing the query range or resolution",
+				tooMany.Limit,
+			),
+			Status: http.StatusBadRequest,
 		}
 	}
 	var apiErr *apiError

--- a/internal/api/loki/handler_sample_budget_test.go
+++ b/internal/api/loki/handler_sample_budget_test.go
@@ -1,0 +1,62 @@
+package loki_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+// TestQueryRange_SampleBudget400 — when the per-query sample budget
+// (CERBERUS_QUERY_MAX_SAMPLES) aborts the result-set drain, the Loki
+// head must answer with an upstream-Loki-style limit rejection: HTTP
+// 400 bad_data with a "maximum ... reached for a single query"
+// message carrying the configured limit — never a 5xx (ClickHouse is
+// healthy; the query is over-broad).
+func TestQueryRange_SampleBudget400(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{err: &chclient.TooManySamplesError{Limit: 7}}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	end := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
+	reqURL := fmt.Sprintf(
+		"%s/loki/api/v1/query_range?query=%s&start=%d&end=%d",
+		srv.URL,
+		url.QueryEscape(`{job="api"}`),
+		end.Add(-time.Hour).UnixNano(),
+		end.UnixNano(),
+	)
+	resp, err := http.Get(reqURL)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400", resp.StatusCode)
+	}
+	var body struct {
+		Status    string `json:"status"`
+		ErrorType string `json:"errorType"`
+		Error     string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body.Status != "error" {
+		t.Fatalf("status field: got %q, want \"error\"", body.Status)
+	}
+	if body.ErrorType != "bad_data" {
+		t.Fatalf("errorType: got %q, want \"bad_data\"", body.ErrorType)
+	}
+	want := "maximum number of samples (7) reached for a single query; consider reducing the query range or resolution"
+	if body.Error != want {
+		t.Fatalf("error message: got %q, want %q", body.Error, want)
+	}
+}

--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -331,7 +331,7 @@ func (h *Handler) handleQueryRange(w http.ResponseWriter, r *http.Request) {
 
 	result, err := matrixFromCursor(cursor, start, end, step)
 	if err != nil {
-		h.respondError(w, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusBadGateway})
+		h.respondError(w, classifyDrainError(err))
 		return
 	}
 	writeEngineHeaders(w, hdr)
@@ -477,6 +477,41 @@ func writeEngineHeaders(w http.ResponseWriter, hdr map[string]string) {
 	}
 }
 
+// promMaxSamplesMessage is upstream Prometheus's exact wire message for
+// a query that crosses --query.max-samples: the promql engine raises
+// ErrTooManySamples(env) with env = "query execution" (see
+// promql/engine.go in the pinned tsouza/prometheus fork), and the v1
+// API maps it to HTTP 422 errorType=execution. Cerberus mirrors the
+// message verbatim so clients that already parse Prom's budget
+// rejection see identical behaviour.
+const promMaxSamplesMessage = "query processing would load too many samples into memory in query execution"
+
+// tooManySamplesAPIError is the Prometheus-parity rejection for a
+// sample-budget exceedance: HTTP 422, errorType "execution",
+// upstream's exact wire message. Shared by classifyEngineError (eager
+// drain inside engine.Query) and classifyDrainError (handler-side
+// cursor drain).
+func tooManySamplesAPIError() *apiError {
+	return &apiError{
+		Kind:   ErrExecution,
+		Err:    errors.New(promMaxSamplesMessage),
+		Status: http.StatusUnprocessableEntity,
+	}
+}
+
+// classifyDrainError maps errors surfaced while draining a query_range
+// cursor (matrixFromCursor → cursor.Err()). The sample-budget sentinel
+// becomes the Prometheus-parity 422; everything else keeps the
+// transport-failure 502 shape. Budget errors occur AFTER the cursor
+// open succeeded, so they are never recorded against the chclient
+// circuit breaker — this mapping is purely a wire-shape concern.
+func classifyDrainError(err error) error {
+	if errors.Is(err, chclient.ErrTooManySamples) {
+		return tooManySamplesAPIError()
+	}
+	return &apiError{Kind: ErrInternal, Err: err, Status: http.StatusBadGateway}
+}
+
 // classifyEngineError maps engine.Query / engine.QueryCursor errors to
 // the per-stage apiError shape the Prom handler exposes via
 // respondError. The engine wraps each stage's error with an
@@ -500,6 +535,13 @@ func classifyEngineError(err error) error {
 			Status:            http.StatusServiceUnavailable,
 			RetryAfterSeconds: 5,
 		}
+	}
+	// Sample-budget exceedance (instant path: engine.Query drains the
+	// cursor inside chclient.Client.Query, so the sentinel arrives
+	// wrapped as `engine: execute: ...`). Prometheus parity: 422
+	// errorType=execution with the upstream wire message.
+	if errors.Is(err, chclient.ErrTooManySamples) {
+		return tooManySamplesAPIError()
 	}
 	var ps *parseStageError
 	if errors.As(err, &ps) {

--- a/internal/api/prom/handler_sample_budget_test.go
+++ b/internal/api/prom/handler_sample_budget_test.go
@@ -1,0 +1,138 @@
+package prom_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+// upstreamMaxSamplesMessage is upstream Prometheus's exact wire message
+// for a query that crosses --query.max-samples (promql.ErrTooManySamples
+// with env "query execution", surfaced by web/api/v1 as HTTP 422
+// errorType=execution). Hardcoded here — not imported from the handler —
+// so a drift in the production constant fails this pin.
+const upstreamMaxSamplesMessage = "query processing would load too many samples into memory in query execution"
+
+// budgetCursor yields its canned samples, then terminates with a
+// *chclient.TooManySamplesError — the exact shape a real rowsCursor
+// produces when a drain crosses CERBERUS_QUERY_MAX_SAMPLES.
+type budgetCursor struct {
+	samples []chclient.Sample
+	idx     int
+	cur     chclient.Sample
+	limit   int64
+	err     error
+}
+
+func (c *budgetCursor) Next() bool {
+	if c.err != nil {
+		return false
+	}
+	if c.idx >= len(c.samples) {
+		c.err = &chclient.TooManySamplesError{Limit: c.limit}
+		return false
+	}
+	c.cur = c.samples[c.idx]
+	c.idx++
+	return true
+}
+
+func (c *budgetCursor) Sample() chclient.Sample { return c.cur }
+func (c *budgetCursor) Err() error              { return c.err }
+func (c *budgetCursor) Close() error            { return nil }
+
+// budgetQuerier reuses stubQuerier for every endpoint except
+// QueryCursor, which returns a cursor that fails the drain with the
+// sample-budget sentinel after surfacing its canned rows.
+type budgetQuerier struct {
+	stubQuerier
+	limit int64
+}
+
+func (q *budgetQuerier) QueryCursor(_ context.Context, sql string, args ...any) (chclient.Cursor, error) {
+	q.lastSQL = sql
+	q.lastArgs = args
+	return &budgetCursor{samples: q.samples, limit: q.limit}, nil
+}
+
+// assertBudget422 decodes a Prom error envelope and pins the
+// Prometheus-parity contract: HTTP 422, errorType "execution",
+// upstream's exact wire message.
+func assertBudget422(t *testing.T, resp *http.Response) {
+	t.Helper()
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Fatalf("status: got %d, want 422", resp.StatusCode)
+	}
+	var body queryResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	_ = resp.Body.Close()
+	if body.Status != "error" {
+		t.Fatalf("status field: got %q, want \"error\"", body.Status)
+	}
+	if body.ErrorType != "execution" {
+		t.Fatalf("errorType: got %q, want \"execution\"", body.ErrorType)
+	}
+	if body.Error != upstreamMaxSamplesMessage {
+		t.Fatalf("error message: got %q, want the exact upstream message %q",
+			body.Error, upstreamMaxSamplesMessage)
+	}
+}
+
+// TestQueryRange_SampleBudget422 — the regression pin for the
+// query-of-death OOM class (k3d run 27269987620): when the cursor
+// drain behind /api/v1/query_range crosses the per-query sample
+// budget, the handler must answer with upstream Prometheus's
+// --query.max-samples rejection — 422, errorType=execution, exact
+// message — instead of buffering an unbounded matrix or dressing the
+// abort as a 5xx transport failure.
+func TestQueryRange_SampleBudget422(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
+	q := &budgetQuerier{
+		stubQuerier: stubQuerier{
+			samples: []chclient.Sample{
+				{MetricName: "up", Labels: map[string]string{"job": "api"}, Timestamp: ts, Value: 1},
+				{MetricName: "up", Labels: map[string]string{"job": "db"}, Timestamp: ts, Value: 1},
+			},
+		},
+		limit: 2,
+	}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	url := fmt.Sprintf(
+		"%s/api/v1/query_range?query=up&start=%d&end=%d&step=15",
+		srv.URL, ts.Add(-time.Hour).Unix(), ts.Unix(),
+	)
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	assertBudget422(t, resp)
+}
+
+// TestQuery_SampleBudget422 — instant-query sibling: the eager path
+// (engine.Query → chclient.Client.Query) drains a cursor internally,
+// so the same sentinel arrives wrapped as `engine: execute: ...` and
+// must map onto the identical 422 contract.
+func TestQuery_SampleBudget422(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{err: &chclient.TooManySamplesError{Limit: 5}}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/query?query=up")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	assertBudget422(t, resp)
+}

--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -287,6 +287,13 @@ func classifySearchErr(err error) int {
 	switch {
 	case errors.Is(err, chclient.ErrCircuitOpen):
 		return http.StatusServiceUnavailable
+	// Sample-budget exceedance (CERBERUS_QUERY_MAX_SAMPLES) is an
+	// over-broad query, not a transport failure — surface 422 like the
+	// other "query is valid TraceQL but cannot be evaluated" rejections
+	// instead of a breaker-adjacent 5xx. The error body carries the
+	// chclient budget message including the configured limit.
+	case errors.Is(err, chclient.ErrTooManySamples):
+		return http.StatusUnprocessableEntity
 	case errors.Is(err, errParseStage):
 		return http.StatusBadRequest
 	case errors.Is(err, errLowerStage):
@@ -451,6 +458,11 @@ func classifyTraceByIDErr(err error) int {
 	}
 	if errors.Is(err, chclient.ErrCircuitOpen) {
 		return http.StatusServiceUnavailable
+	}
+	// Sample-budget exceedance → 422, mirroring classifySearchErr; see
+	// the rationale there.
+	if errors.Is(err, chclient.ErrTooManySamples) {
+		return http.StatusUnprocessableEntity
 	}
 	if strings.Contains(err.Error(), "engine: execute:") {
 		return http.StatusBadGateway

--- a/internal/api/tempo/handler_sample_budget_test.go
+++ b/internal/api/tempo/handler_sample_budget_test.go
@@ -1,0 +1,34 @@
+package tempo_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+// TestSearchRecent_SampleBudget422 — when the per-query sample budget
+// (CERBERUS_QUERY_MAX_SAMPLES) aborts the result-set drain, the Tempo
+// head must answer 422 (an over-broad query, peer to the lower-stage
+// rejections) — never a 5xx: ClickHouse is healthy and the chclient
+// breaker never counts drain errors as failures.
+func TestSearchRecent_SampleBudget422(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{err: &chclient.TooManySamplesError{Limit: 3}}
+	srv := newServer(q, "v-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/search/recent")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Fatalf("status: got %d (body %q), want 422", resp.StatusCode, body)
+	}
+	if !strings.Contains(body, "sample budget exceeded") {
+		t.Fatalf("body %q does not carry the budget message", body)
+	}
+}

--- a/internal/api/tempo/metrics_query_range.go
+++ b/internal/api/tempo/metrics_query_range.go
@@ -339,6 +339,11 @@ func classifyMetricsQueryRangeErr(err error) int {
 	if err == nil {
 		return http.StatusInternalServerError
 	}
+	// Sample-budget exceedance → 422, mirroring classifySearchErr in
+	// handler.go; see the rationale there.
+	if errors.Is(err, chclient.ErrTooManySamples) {
+		return http.StatusUnprocessableEntity
+	}
 	if strings.Contains(err.Error(), "engine: execute:") {
 		return http.StatusBadGateway
 	}

--- a/internal/chclient/client.go
+++ b/internal/chclient/client.go
@@ -86,6 +86,14 @@ type Config struct {
 
 	// DialTimeout caps the initial connection dial. Zero falls back to 5s.
 	DialTimeout time.Duration
+
+	// MaxQuerySamples caps the number of Sample rows a single query may
+	// load into memory. When a cursor drain crosses the budget,
+	// iteration aborts and Cursor.Err() returns a *TooManySamplesError
+	// (errors.Is ErrTooManySamples). 0 disables the budget. Mirrors
+	// upstream Prometheus's --query.max-samples knob; cmd/cerberus
+	// wires it from CERBERUS_QUERY_MAX_SAMPLES.
+	MaxQuerySamples int64
 }
 
 // Client is a stateless wrapper over a clickhouse-go/v2 connection pool.
@@ -101,6 +109,10 @@ type Client struct {
 	conn driver.Conn
 	addr string // CH addr (host:port) — stamped on execute spans as server.address
 	br   breaker
+	// maxSamples is Config.MaxQuerySamples, threaded into every cursor
+	// QueryCursor opens (and therefore into Query, which drains a
+	// cursor). 0 = unlimited.
+	maxSamples int64
 }
 
 // New opens a connection pool to ClickHouse and pings it once to confirm
@@ -127,7 +139,7 @@ func New(ctx context.Context, cfg Config) (*Client, error) {
 	if err := conn.Ping(pingCtx); err != nil {
 		return nil, fmt.Errorf("chclient: ping %s: %w", cfg.Addr, err)
 	}
-	return &Client{conn: conn, addr: cfg.Addr}, nil
+	return &Client{conn: conn, addr: cfg.Addr, maxSamples: cfg.MaxQuerySamples}, nil
 }
 
 // Conn returns the underlying clickhouse-go/v2 driver connection. It is
@@ -189,6 +201,14 @@ func (c *Client) Ping(ctx context.Context) error {
 
 // Sample is one row of metrics data returned by Query. It's the shape the
 // /api/v1/query and /api/v1/query_range handlers expect — see api/prom.
+//
+// Labels sharing contract: the cursor interns decoded label maps by
+// canonical key, so every Sample belonging to the same series carries
+// the SAME map instance — that is what keeps a multi-thousand-row
+// matrix drain at one retained map per series instead of one per row.
+// Consumers MUST treat Labels as read-only; copy before mutating
+// (internal/api/format.WithMetricName / NormalizeLabelMap and the
+// loki/tempo label pivots already allocate fresh output maps).
 type Sample struct {
 	MetricName string
 	Labels     map[string]string

--- a/internal/chclient/cursor.go
+++ b/internal/chclient/cursor.go
@@ -2,12 +2,45 @@ package chclient
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sort"
 	"sync"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"go.opentelemetry.io/otel/trace"
 )
+
+// ErrTooManySamples is the sentinel matched (via errors.Is) when a
+// cursor's iteration crosses the per-query sample budget configured by
+// Config.MaxQuerySamples. It mirrors upstream Prometheus's
+// promql.ErrTooManySamples contract: the query is aborted instead of
+// materialising an unbounded result set in process memory.
+//
+// The concrete error a Cursor's Err() returns is *TooManySamplesError,
+// which wraps this sentinel and carries the configured limit.
+//
+// Budget exceedance is an iteration error, not a transport failure: it
+// surfaces via cursor.Err() AFTER QueryCursor's open call already
+// recorded success against the circuit breaker, so it never counts as
+// a CH failure (see the breaker note on QueryCursor).
+var ErrTooManySamples = errors.New("query sample budget exceeded")
+
+// TooManySamplesError is the concrete error returned by Cursor.Err()
+// when iteration crosses the configured per-query sample budget. It
+// wraps [ErrTooManySamples] (errors.Is matches) and carries the limit
+// so API handlers can render head-idiomatic over-limit messages.
+type TooManySamplesError struct {
+	// Limit is the configured per-query sample budget that iteration
+	// crossed.
+	Limit int64
+}
+
+func (e *TooManySamplesError) Error() string {
+	return fmt.Sprintf("chclient: query sample budget exceeded: result set exceeds %d samples", e.Limit)
+}
+
+func (e *TooManySamplesError) Unwrap() error { return ErrTooManySamples }
 
 // Cursor is a forward-only iterator over a Sample result set. Use it to
 // stream rows out of ClickHouse without materialising the full slice in
@@ -36,6 +69,22 @@ type rowsCursor struct {
 	rows driver.Rows
 	cur  Sample
 	err  error
+	// maxSamples is the per-query sample budget (0 = unlimited). When
+	// iteration crosses it, Next returns false and Err yields a
+	// *TooManySamplesError wrapping ErrTooManySamples.
+	maxSamples int64
+	// seen counts rows successfully decoded so far, compared against
+	// maxSamples after each scan.
+	seen int64
+	// interned caches decoded label maps keyed by their canonical
+	// serialised form so all rows of one series share a single map
+	// instance. A long-window matrix query returns thousands of rows
+	// per series, each carrying an identical label set; without
+	// interning every row retains its own map (header + N string
+	// pairs), which is exactly the per-row overhead that OOMKilled the
+	// k3d e2e pods (run 27269987620). Consumers MUST treat
+	// Sample.Labels as read-only — see the contract on [Sample].
+	interned map[string]map[string]string
 	// span is the `execute` pipeline-stage span opened by QueryCursor.
 	// Held by the cursor (rather than closed when QueryCursor returns)
 	// so that row decode + CH wire transit are billed to the execute
@@ -73,9 +122,61 @@ func (c *rowsCursor) Next() bool {
 		c.err = fmt.Errorf("chclient: scan: %w", err)
 		return false
 	}
-	s.Labels = labels
+	c.seen++
+	if c.maxSamples > 0 && c.seen > c.maxSamples {
+		c.err = &TooManySamplesError{Limit: c.maxSamples}
+		return false
+	}
+	s.Labels = c.internLabels(labels)
 	c.cur = s
 	return true
+}
+
+// internLabels returns the canonical shared map instance for the
+// decoded label set: the first occurrence of a label set is cached
+// under its canonical key, and every later row with the same set
+// returns that exact map. The freshly decoded duplicate becomes
+// short-lived garbage; what matters is that the RETAINED set (the
+// samples a handler buffers while pivoting a matrix response) holds
+// one map per series instead of one map per row.
+func (c *rowsCursor) internLabels(labels map[string]string) map[string]string {
+	if labels == nil {
+		return nil
+	}
+	key := canonicalLabelKey(labels)
+	if cached, ok := c.interned[key]; ok {
+		return cached
+	}
+	if c.interned == nil {
+		c.interned = make(map[string]map[string]string)
+	}
+	c.interned[key] = labels
+	return labels
+}
+
+// canonicalLabelKey is a deterministic string form of a label set:
+// keys sorted ASCII-ascending, pairs joined as "k=v\x00" so two
+// distinct label sets cannot alias. Mirrors the canonical-key shape
+// the API layer uses for series grouping (internal/api/format
+// .CanonicalKey) — duplicated locally because chclient must not
+// import api packages.
+func canonicalLabelKey(labels map[string]string) string {
+	if len(labels) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(labels))
+	for k := range labels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b []byte
+	for _, k := range keys {
+		b = append(b, k...)
+		b = append(b, '=')
+		b = append(b, labels[k]...)
+		b = append(b, 0)
+	}
+	return string(b)
 }
 
 // Sample returns the row that the most recent Next() call landed on.
@@ -130,12 +231,20 @@ func (c *rowsCursor) Close() error {
 // for long-window `query_range` requests. Callers MUST Close the cursor
 // to return its connection to the pool.
 //
+// When the Client was configured with a positive MaxQuerySamples, the
+// cursor enforces it as a per-query sample budget: crossing it stops
+// iteration and Err() returns a *TooManySamplesError (errors.Is
+// ErrTooManySamples). Mirrors upstream Prometheus's
+// --query.max-samples abort-the-query contract.
+//
 // Guarded by the circuit breaker (see [Client] doc). The breaker
 // observes the open-call outcome only — once the cursor is returned,
 // iteration errors propagate via cursor.Err() but are NOT re-recorded
 // against the breaker. A single failed query is one failure, not N
 // where N is the number of rows the caller drained before hitting the
-// transport drop.
+// transport drop. The same property keeps sample-budget rejections
+// (ErrTooManySamples) out of the breaker's failure count entirely: a
+// client asking for too much data is not a ClickHouse outage.
 func (c *Client) QueryCursor(ctx context.Context, sql string, args ...any) (Cursor, error) {
 	if !c.br.allow() {
 		return nil, fmt.Errorf("chclient: query: %w", ErrCircuitOpen)
@@ -148,5 +257,10 @@ func (c *Client) QueryCursor(ctx context.Context, sql string, args ...any) (Curs
 		span.End()
 		return nil, fmt.Errorf("chclient: query: %w", err)
 	}
-	return &rowsCursor{rows: rows, span: span, rec: recorderFromContext(ctx)}, nil
+	return &rowsCursor{
+		rows:       rows,
+		span:       span,
+		rec:        recorderFromContext(ctx),
+		maxSamples: c.maxSamples,
+	}, nil
 }

--- a/internal/chclient/cursor_budget_test.go
+++ b/internal/chclient/cursor_budget_test.go
@@ -1,0 +1,276 @@
+package chclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+)
+
+// freshLabelRows is a driver.Rows fake whose Scan decodes a FRESH
+// labels map on every row — mirroring clickhouse-go's Map column
+// decode, which allocates per row. The interning tests need this so
+// any map identity observed downstream is provably produced by the
+// cursor's intern cache, not by the fake handing the same map twice.
+type freshLabelRows struct {
+	rows   []Sample
+	idx    int
+	closed bool
+}
+
+func (r *freshLabelRows) Next() bool {
+	if r.idx >= len(r.rows) {
+		return false
+	}
+	r.idx++
+	return true
+}
+
+func (r *freshLabelRows) Scan(dest ...any) error {
+	if len(dest) != 4 {
+		return errors.New("freshLabelRows.Scan: want 4 destinations")
+	}
+	s := r.rows[r.idx-1]
+	if p, ok := dest[0].(*string); ok {
+		*p = s.MetricName
+	}
+	if p, ok := dest[1].(*map[string]string); ok {
+		// Fresh allocation per row — the per-row overhead the intern
+		// cache exists to deduplicate.
+		m := make(map[string]string, len(s.Labels))
+		for k, v := range s.Labels {
+			m[k] = v
+		}
+		*p = m
+	}
+	if p, ok := dest[2].(*time.Time); ok {
+		*p = s.Timestamp
+	}
+	if p, ok := dest[3].(*float64); ok {
+		*p = s.Value
+	}
+	return nil
+}
+
+func (r *freshLabelRows) ScanStruct(any) error {
+	return errors.New("test mock: ScanStruct unused by cursor budget tests")
+}
+func (r *freshLabelRows) ColumnTypes() []driver.ColumnType { return nil }
+func (r *freshLabelRows) Totals(...any) error              { return nil }
+func (r *freshLabelRows) Columns() []string                { return nil }
+func (r *freshLabelRows) Err() error                       { return nil }
+func (r *freshLabelRows) HasData() bool                    { return len(r.rows) > 0 }
+
+func (r *freshLabelRows) Close() error {
+	r.closed = true
+	return nil
+}
+
+// mapID returns a stable identity token for a map value. Two map
+// values print the same %p pointer iff they are the same map instance;
+// no mutation, no unsafe.
+func mapID(m map[string]string) string { return fmt.Sprintf("%p", m) }
+
+// TestRowsCursor_InternsLabelMapsPerSeries — the memory-shape pin for
+// the k3d OOM class (run 27269987620): all rows of one series must
+// share ONE label-map instance even though the driver decodes a fresh
+// map per row, and distinct series must keep distinct maps.
+func TestRowsCursor_InternsLabelMapsPerSeries(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
+	seriesA := map[string]string{"job": "api", "instance": "a"}
+	seriesB := map[string]string{"job": "api", "instance": "b"}
+	rows := &freshLabelRows{rows: []Sample{
+		{MetricName: "up", Labels: seriesA, Timestamp: ts, Value: 1},
+		{MetricName: "up", Labels: seriesB, Timestamp: ts, Value: 0},
+		{MetricName: "up", Labels: seriesA, Timestamp: ts.Add(time.Minute), Value: 1},
+		{MetricName: "up", Labels: seriesB, Timestamp: ts.Add(time.Minute), Value: 1},
+		{MetricName: "up", Labels: seriesA, Timestamp: ts.Add(2 * time.Minute), Value: 0},
+	}}
+	cursor := &rowsCursor{rows: rows}
+	defer func() { _ = cursor.Close() }()
+
+	var got []Sample
+	for cursor.Next() {
+		got = append(got, cursor.Sample())
+	}
+	if err := cursor.Err(); err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	if len(got) != 5 {
+		t.Fatalf("drained %d rows, want 5", len(got))
+	}
+
+	// Same series → the IDENTICAL map instance on every row.
+	if mapID(got[0].Labels) != mapID(got[2].Labels) || mapID(got[2].Labels) != mapID(got[4].Labels) {
+		t.Errorf("series A rows do not share one map instance: %s / %s / %s",
+			mapID(got[0].Labels), mapID(got[2].Labels), mapID(got[4].Labels))
+	}
+	if mapID(got[1].Labels) != mapID(got[3].Labels) {
+		t.Errorf("series B rows do not share one map instance: %s / %s",
+			mapID(got[1].Labels), mapID(got[3].Labels))
+	}
+	// Distinct series → distinct maps.
+	if mapID(got[0].Labels) == mapID(got[1].Labels) {
+		t.Errorf("series A and B alias the same map instance: %s", mapID(got[0].Labels))
+	}
+	// Content survives interning intact.
+	for i, want := range []map[string]string{seriesA, seriesB, seriesA, seriesB, seriesA} {
+		for k, v := range want {
+			if got[i].Labels[k] != v {
+				t.Errorf("row %d label %q: got %q, want %q", i, k, got[i].Labels[k], v)
+			}
+		}
+		if len(got[i].Labels) != len(want) {
+			t.Errorf("row %d: got %d labels, want %d", i, len(got[i].Labels), len(want))
+		}
+	}
+}
+
+// TestRowsCursor_InternDoesNotAliasDifferentValues — two label sets
+// with the same keys but different values must NOT collapse onto one
+// map (the canonical key includes values).
+func TestRowsCursor_InternDoesNotAliasDifferentValues(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Unix(0, 0)
+	rows := &freshLabelRows{rows: []Sample{
+		{MetricName: "up", Labels: map[string]string{"job": "api"}, Timestamp: ts, Value: 1},
+		{MetricName: "up", Labels: map[string]string{"job": "db"}, Timestamp: ts, Value: 1},
+	}}
+	cursor := &rowsCursor{rows: rows}
+	defer func() { _ = cursor.Close() }()
+
+	var got []Sample
+	for cursor.Next() {
+		got = append(got, cursor.Sample())
+	}
+	if err := cursor.Err(); err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	if mapID(got[0].Labels) == mapID(got[1].Labels) {
+		t.Fatal("distinct label values were interned onto one map instance")
+	}
+	if got[0].Labels["job"] != "api" || got[1].Labels["job"] != "db" {
+		t.Fatalf("label values corrupted: %v / %v", got[0].Labels, got[1].Labels)
+	}
+}
+
+// TestRowsCursor_SampleBudgetAborts — crossing MaxQuerySamples stops
+// iteration and surfaces the ErrTooManySamples sentinel (wrapped in a
+// *TooManySamplesError carrying the limit).
+func TestRowsCursor_SampleBudgetAborts(t *testing.T) {
+	t.Parallel()
+
+	rows := newGenRows(10)
+	cursor := &rowsCursor{rows: rows, maxSamples: 3}
+	defer func() { _ = cursor.Close() }()
+
+	count := 0
+	for cursor.Next() {
+		count++
+	}
+	if count != 3 {
+		t.Fatalf("drained %d rows before abort, want exactly the 3-sample budget", count)
+	}
+	err := cursor.Err()
+	if !errors.Is(err, ErrTooManySamples) {
+		t.Fatalf("Err: got %v, want errors.Is(_, ErrTooManySamples)", err)
+	}
+	var tooMany *TooManySamplesError
+	if !errors.As(err, &tooMany) {
+		t.Fatalf("Err: got %T, want *TooManySamplesError", err)
+	}
+	if tooMany.Limit != 3 {
+		t.Fatalf("Limit: got %d, want 3", tooMany.Limit)
+	}
+	// Iteration stays terminated.
+	if cursor.Next() {
+		t.Fatal("Next must stay false after the budget abort")
+	}
+}
+
+// TestRowsCursor_SampleBudgetExactLimitPasses — a result set exactly
+// at the budget drains fully with no error (the budget rejects "more
+// than", not "equal to").
+func TestRowsCursor_SampleBudgetExactLimitPasses(t *testing.T) {
+	t.Parallel()
+
+	rows := newGenRows(3)
+	cursor := &rowsCursor{rows: rows, maxSamples: 3}
+	defer func() { _ = cursor.Close() }()
+
+	count := 0
+	for cursor.Next() {
+		count++
+	}
+	if count != 3 {
+		t.Fatalf("drained %d rows, want 3", count)
+	}
+	if err := cursor.Err(); err != nil {
+		t.Fatalf("Err: %v, want nil at exactly the budget", err)
+	}
+}
+
+// TestRowsCursor_SampleBudgetZeroDisables — MaxQuerySamples = 0 means
+// unlimited (the documented opt-out).
+func TestRowsCursor_SampleBudgetZeroDisables(t *testing.T) {
+	t.Parallel()
+
+	rows := newGenRows(50)
+	cursor := &rowsCursor{rows: rows, maxSamples: 0}
+	defer func() { _ = cursor.Close() }()
+
+	count := 0
+	for cursor.Next() {
+		count++
+	}
+	if count != 50 {
+		t.Fatalf("drained %d rows, want all 50 with the budget disabled", count)
+	}
+	if err := cursor.Err(); err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+}
+
+// budgetConn is a driver.Conn fake whose Query returns a generator of
+// rowsPerQuery rows. Reuses chaosConn for the interface surface.
+type budgetConn struct {
+	chaosConn
+	rowsPerQuery int
+}
+
+func (c *budgetConn) Query(context.Context, string, ...any) (driver.Rows, error) {
+	return newGenRows(c.rowsPerQuery), nil
+}
+
+// TestClientQuery_SampleBudget_DoesNotTripBreaker — budget exceedance
+// is a drain-time error: the breaker records the (successful) cursor
+// open and never sees the sentinel, so repeated over-budget queries
+// MUST NOT open the circuit. Pins the "a client asking for too much
+// data is not a ClickHouse outage" contract from PR #738's
+// open-call-only breaker recording.
+func TestClientQuery_SampleBudget_DoesNotTripBreaker(t *testing.T) {
+	t.Parallel()
+
+	client := newWithConn(&budgetConn{rowsPerQuery: 10})
+	client.maxSamples = 2
+
+	// Well past breakerThreshold (5) consecutive budget rejections.
+	for i := 0; i < 3*breakerThreshold; i++ {
+		_, err := client.Query(context.Background(), "SELECT budgeted")
+		if !errors.Is(err, ErrTooManySamples) {
+			t.Fatalf("call %d: got %v, want ErrTooManySamples", i, err)
+		}
+		if errors.Is(err, ErrCircuitOpen) {
+			t.Fatalf("call %d: breaker opened on budget rejections", i)
+		}
+	}
+	if !client.br.allow() {
+		t.Fatal("breaker is OPEN after budget-only rejections; budget errors must not count as CH failures")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -139,6 +139,7 @@ type OTLPConfig struct {
 //	CERBERUS_CH_USERNAME           default "default"
 //	CERBERUS_CH_PASSWORD           default ""
 //	CERBERUS_CH_DIAL_TIMEOUT       default "5s"
+//	CERBERUS_QUERY_MAX_SAMPLES     default 50000000 (0 disables the budget)
 //	CERBERUS_AUTO_CREATE_SCHEMA    default "false"
 //	CERBERUS_LOG_FORMAT            default "text"  ("text" | "json")
 //	CERBERUS_LOG_LEVEL             default "info"  ("debug" | "info" | "warn" | "error")
@@ -173,6 +174,13 @@ func FromEnv() (Config, error) {
 	if err != nil {
 		return Config{}, fmt.Errorf("CERBERUS_AUTO_CREATE_SCHEMA: %w", err)
 	}
+	maxSamples, err := envInt64("CERBERUS_QUERY_MAX_SAMPLES", defaultQueryMaxSamples)
+	if err != nil {
+		return Config{}, fmt.Errorf("CERBERUS_QUERY_MAX_SAMPLES: %w", err)
+	}
+	if maxSamples < 0 {
+		return Config{}, fmt.Errorf("CERBERUS_QUERY_MAX_SAMPLES: must be >= 0, got %d", maxSamples)
+	}
 	logCfg, err := envLog()
 	if err != nil {
 		return Config{}, err
@@ -188,11 +196,12 @@ func FromEnv() (Config, error) {
 	return Config{
 		HTTPAddr: envDefault("CERBERUS_HTTP_ADDR", ":8080"),
 		ClickHouse: chclient.Config{
-			Addr:        envDefault("CERBERUS_CH_ADDR", "localhost:9000"),
-			Database:    envDefault("CERBERUS_CH_DATABASE", "otel"),
-			Username:    envDefault("CERBERUS_CH_USERNAME", "default"),
-			Password:    envDefault("CERBERUS_CH_PASSWORD", ""),
-			DialTimeout: dial,
+			Addr:            envDefault("CERBERUS_CH_ADDR", "localhost:9000"),
+			Database:        envDefault("CERBERUS_CH_DATABASE", "otel"),
+			Username:        envDefault("CERBERUS_CH_USERNAME", "default"),
+			Password:        envDefault("CERBERUS_CH_PASSWORD", ""),
+			DialTimeout:     dial,
+			MaxQuerySamples: maxSamples,
 		},
 		Schema:           schema.DefaultOTelMetricsFromEnv(),
 		Logs:             schema.DefaultOTelLogsFromEnv(),
@@ -203,6 +212,18 @@ func FromEnv() (Config, error) {
 		Admit:            admit,
 	}, nil
 }
+
+// defaultQueryMaxSamples is the default per-query sample budget,
+// mirroring upstream Prometheus's --query.max-samples default
+// (50,000,000). A query whose result-set drain crosses the budget is
+// aborted (Prom head: 422 errorType=execution with Prometheus's exact
+// wire message) instead of materialising an unbounded matrix in
+// process memory. Note Prometheus sizes its default around ~16-byte
+// in-memory samples; cerberus rows carry label maps (interned
+// per-series, but still heavier), so memory-constrained deploys
+// should set CERBERUS_QUERY_MAX_SAMPLES well below the default — the
+// k3d e2e stack runs at 5,000,000.
+const defaultQueryMaxSamples int64 = 50_000_000
 
 // Default per-handler concurrency caps. Tempo gets a smaller cap
 // because trace queries (search + tag-value scans + per-trace span
@@ -382,6 +403,21 @@ func envInt(key string, def int) (int, error) {
 		return def, nil
 	}
 	n, err := strconv.Atoi(v)
+	if err != nil {
+		return 0, fmt.Errorf("invalid integer %q: %w", v, err)
+	}
+	return n, nil
+}
+
+// envInt64 parses a 64-bit integer env var. An unset or empty value
+// returns def. Anything that fails strconv.ParseInt is rejected with
+// an error so misconfiguration fails fast at startup.
+func envInt64(key string, def int64) (int64, error) {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return def, nil
+	}
+	n, err := strconv.ParseInt(v, 10, 64)
 	if err != nil {
 		return 0, fmt.Errorf("invalid integer %q: %w", v, err)
 	}

--- a/internal/config/query_max_samples_test.go
+++ b/internal/config/query_max_samples_test.go
@@ -1,0 +1,64 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestFromEnv_QueryMaxSamples_Default confirms the budget defaults to
+// Prometheus's --query.max-samples default (50,000,000) when
+// CERBERUS_QUERY_MAX_SAMPLES is unset.
+func TestFromEnv_QueryMaxSamples_Default(t *testing.T) {
+	t.Setenv("CERBERUS_QUERY_MAX_SAMPLES", "")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if cfg.ClickHouse.MaxQuerySamples != 50_000_000 {
+		t.Errorf("MaxQuerySamples = %d; want 50000000 (Prometheus parity default)",
+			cfg.ClickHouse.MaxQuerySamples)
+	}
+}
+
+// TestFromEnv_QueryMaxSamples_Override confirms the env var threads
+// through to chclient.Config, including the documented 0 = disabled
+// opt-out.
+func TestFromEnv_QueryMaxSamples_Override(t *testing.T) {
+	cases := []struct {
+		val  string
+		want int64
+	}{
+		{"5000000", 5_000_000},
+		{"0", 0},
+		{"1", 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.val, func(t *testing.T) {
+			t.Setenv("CERBERUS_QUERY_MAX_SAMPLES", tc.val)
+			cfg, err := FromEnv()
+			if err != nil {
+				t.Fatalf("FromEnv: %v", err)
+			}
+			if cfg.ClickHouse.MaxQuerySamples != tc.want {
+				t.Errorf("MaxQuerySamples = %d; want %d", cfg.ClickHouse.MaxQuerySamples, tc.want)
+			}
+		})
+	}
+}
+
+// TestFromEnv_QueryMaxSamples_Invalid confirms non-integer and negative
+// values fail fast at startup rather than silently defaulting.
+func TestFromEnv_QueryMaxSamples_Invalid(t *testing.T) {
+	for _, val := range []string{"lots", "1.5", "-1"} {
+		t.Run(val, func(t *testing.T) {
+			t.Setenv("CERBERUS_QUERY_MAX_SAMPLES", val)
+			_, err := FromEnv()
+			if err == nil {
+				t.Fatalf("FromEnv accepted %q; want error", val)
+			}
+			if !strings.Contains(err.Error(), "CERBERUS_QUERY_MAX_SAMPLES") {
+				t.Errorf("error %q does not name the env var", err)
+			}
+		})
+	}
+}

--- a/test/e2e/k3s/cerberus.yaml
+++ b/test/e2e/k3s/cerberus.yaml
@@ -29,6 +29,15 @@ data:
   # (zero-collector binary).
   CERBERUS_OTLP_ENDPOINT: "otel-collector-gateway.cerberus.svc:4317"
   CERBERUS_OTLP_INSECURE: "true"
+  # Per-query sample budget (Prometheus --query.max-samples parity).
+  # 5M samples × the cursor's interned per-row overhead sits
+  # comfortably inside the 1Gi pod limit below; the binary default
+  # (50M) mirrors Prometheus but assumes Prom's ~16-byte in-memory
+  # samples, which cerberus rows (label-map-carrying) are not. A
+  # query that crosses the budget gets the upstream-parity 422
+  # errorType=execution rejection instead of OOMKilling the pod —
+  # the query-of-death loop from run 27269987620.
+  CERBERUS_QUERY_MAX_SAMPLES: "5000000"
 ---
 apiVersion: v1
 kind: Service
@@ -83,12 +92,19 @@ spec:
                 name: cerberus-config
           env:
             # Go's GC doesn't see cgroup limits — GOMEMLIMIT keeps heap
-            # pressure below the 512Mi ceiling so allocation bursts from
+            # pressure below the 1Gi ceiling so allocation bursts from
             # the heavy auto-discovered Playwright specs trigger GC
-            # instead of the OOM killer; evidence run 27263112345
-            # (cerberus pods OOMKilled exit 137 at the old 256Mi limit).
+            # instead of the OOM killer. Evidence: run 27263112345
+            # (OOMKilled exit 137 at 256Mi), then run 27269987620
+            # superseding it — STILL OOMKilled at 512Mi/400MiB within
+            # ~30s of start during the iterate-time-ranges (range,
+            # step) matrix sweep, and again immediately on retry (a
+            # query-of-death loop). The real demand is bounded by the
+            # cursor's label-map interning + the CERBERUS_QUERY_MAX_
+            # SAMPLES budget in the ConfigMap above; 800MiB/1Gi gives
+            # the bounded workload honest headroom.
             - name: GOMEMLIMIT
-              value: 400MiB
+              value: 800MiB
           resources:
             requests:
               # 250m so the scheduler weights cerberus fairly against
@@ -98,13 +114,18 @@ spec:
               cpu: 250m
               memory: 128Mi
             limits:
-              # 512Mi (was 256Mi): the Playwright dashboard sweep's
-              # matrix specs buffer full query_range matrices per
-              # request; run 27263112345 OOMKilled cerberus (exit 137)
-              # at 256Mi while compose-side peak for light specs is
-              # only ~73MiB. Paired with GOMEMLIMIT=400MiB above so the
-              # Go heap backs off well before this ceiling.
-              memory: 512Mi
+              # 1Gi (was 512Mi, was 256Mi): the Playwright dashboard
+              # sweep's matrix specs buffer full query_range matrices
+              # per request. Run 27263112345 OOMKilled cerberus (exit
+              # 137) at 256Mi; run 27269987620 (superseding) OOMKilled
+              # again at 512Mi + GOMEMLIMIT=400MiB during the
+              # iterate-time-ranges sweep. The fix is two-sided: the
+              # chclient cursor now interns per-series label maps and
+              # enforces CERBERUS_QUERY_MAX_SAMPLES (ConfigMap above),
+              # and this limit right-sizes the pod for the bounded
+              # demand. Paired with GOMEMLIMIT=800MiB above so the Go
+              # heap backs off well before this ceiling.
+              memory: 1Gi
           # /readyz pings ClickHouse (with a small TTL cache so this
           # probe doesn't hammer CH) and reports the auto-create-schema
           # invariant. A failure removes the pod from the Service


### PR DESCRIPTION
## Summary

Closes the k3d OOMKill loop at its real source. Even after #744's resolution cap + 512Mi/GOMEMLIMIT right-sizing, pods kept dying (run 27269987620: `OOMKilled` exit 137, containers surviving ~21s under mid-suite traffic, fresh replicas killed again on retry). Two production defects:

1. **Per-row label-map allocation.** The CH cursor decoded a fresh `Labels` map for every row, though all rows of one series share an identical label set — a 432k-sample matrix retained hundreds of MB of duplicate maps while `matrixFromCursor` buffered the response. The cursor now **interns label maps by canonical key**: one map per series, shared across rows. Every `Sample.Labels` consumer across all three heads was audited for mutation (none mutate — the only `delete()` operates on a per-row copy); the read-only sharing contract is documented on the type and pinned by `TestRowsCursor_InternsLabelMapsPerSeries`.
2. **No total-sample budget.** Upstream Prometheus enforces `--query.max-samples` (default 50M) and aborts with 422 `execution` / *"query processing would load too many samples into memory in query execution"*. Cerberus now enforces `CERBERUS_QUERY_MAX_SAMPLES` (same 50M default, 0 disables) centrally in the cursor, so all three heads inherit it: prom returns the **exact upstream 422 contract** (message verified verbatim against the pinned fork), loki a 400 in upstream-Loki limit style, tempo 422 — never a 5xx. Budget rejections are structurally breaker-neutral (drain errors never reach `record()` — pinned by `TestClientQuery_SampleBudget_DoesNotTripBreaker`).

k3d env: limit 1Gi, GOMEMLIMIT 800MiB, `CERBERUS_QUERY_MAX_SAMPLES=5000000` in the ConfigMap with rationale.

## Notes

- `iterate-time-ranges` unchanged by the math: widest tuple = 5,760 points/series; crossing the 5M k3d budget would need ≥869 series per query — far above seed cardinality.
- The budget counts cursor rows (series × anchors); parity with Prometheus is in the abort + wire contract, not the engine-internal counting semantics.
- Interning bounds *retained* memory; the per-row transient from clickhouse-go's Map scan remains GC-managed garbage under GOMEMLIMIT.

## Test plan

- [ ] `check` green (interning identity pin, budget 422/400 contract pins per head, config env tests, breaker-neutrality pin)
- [ ] `dashboard` job on the merge push passes **including the zero-restart gate** — the live proof the OOM class is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)