### PR TITLE
feat: Grafana 12.2.9 + the drilldown-app query surface (loki drilldown-limits, traceql nestedSetParent/nil, histogram_over_time wire-up)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -178,7 +178,7 @@ services:
       start_period: 5s
 
   grafana:
-    image: grafana/grafana:11.4.0
+    image: grafana/grafana:12.2.9
     networks: [cerberus-dev]
     environment:
       GF_SECURITY_ADMIN_USER: admin
@@ -201,7 +201,6 @@ services:
       GF_AUTH_DISABLE_LOGIN_FORM: "true"
       GF_AUTH_DISABLE_SIGNOUT_MENU: "true"
       GF_USERS_DEFAULT_THEME: dark
-      GF_FEATURE_TOGGLES_ENABLE: traceqlSearch
       # Land directly on the cerberus dashboard instead of an empty
       # home page. Path is the in-container mount location of the JSON,
       # not a Grafana URL or UID.

--- a/internal/api/loki/drilldown_limits.go
+++ b/internal/api/loki/drilldown_limits.go
@@ -1,0 +1,49 @@
+package loki
+
+import "net/http"
+
+// DrilldownLimitsResponse mirrors upstream Loki's
+// `/loki/api/v1/drilldown-limits` body (pkg/loki.DrilldownConfigResponse,
+// added by grafana/loki#19028): a flat top-level JSON object, NOT
+// wrapped in the {status, data} envelope the rest of the v1 surface
+// uses. Grafana's first-party Logs Drilldown app
+// (grafana-lokiexplore-app, preinstalled since Grafana 12.x) fetches
+// this resource on boot to decide which UI surfaces to enable.
+type DrilldownLimitsResponse struct {
+	// Limits carries the subset of upstream Loki's per-tenant limits
+	// the backend chooses to publish (upstream filters through its
+	// `tenant_limits_allow_publish` allowlist). Cerberus publishes
+	// only the fields that describe behaviour it actually implements.
+	Limits map[string]any `json:"limits"`
+	// PatternIngesterEnabled gates the Drilldown app's "Patterns" tab.
+	PatternIngesterEnabled bool `json:"pattern_ingester_enabled"`
+	// Version is the backend build identifier (same value the
+	// /status/buildinfo probe reports).
+	Version string `json:"version"`
+}
+
+// handleDrilldownLimits implements `GET /loki/api/v1/drilldown-limits`.
+// The published fields are cerberus's real contract, not a copy of
+// upstream defaults:
+//
+//   - pattern_ingester_enabled: true — cerberus serves
+//     /loki/api/v1/patterns via the drain template miner.
+//   - limits.volume_enabled: true — cerberus serves
+//     /loki/api/v1/index/volume.
+//   - limits.discover_log_levels: true — cerberus synthesizes the
+//     `detected_level` label family from the OTel SeverityText column.
+//   - limits.max_entries_limit_per_query: the hard per-query line cap
+//     cerberus enforces in parseLogLimit (maxLogQueryLimit).
+//
+// No ClickHouse round-trip — the response is static per build.
+func (h *Handler) handleDrilldownLimits(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, DrilldownLimitsResponse{
+		Limits: map[string]any{
+			"discover_log_levels":         true,
+			"max_entries_limit_per_query": maxLogQueryLimit,
+			"volume_enabled":              true,
+		},
+		PatternIngesterEnabled: true,
+		Version:                h.Version,
+	})
+}

--- a/internal/api/loki/drilldown_limits_test.go
+++ b/internal/api/loki/drilldown_limits_test.go
@@ -1,0 +1,102 @@
+package loki_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/api/loki"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestDrilldownLimits_HappyPath drives /loki/api/v1/drilldown-limits and
+// asserts the upstream wire shape: a flat top-level JSON object (NOT the
+// {status, data} envelope), with pattern_ingester_enabled and the
+// published limits cerberus actually implements. Grafana's Logs
+// Drilldown app (preinstalled in 12.x) probes this on boot; a 404 here
+// surfaced as the compose-smoke failure that motivated the endpoint.
+func TestDrilldownLimits_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	srv := newServer(&stubQuerier{})
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/loki/api/v1/drilldown-limits")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("content-type=%q, want application/json", ct)
+	}
+
+	var out loki.DrilldownLimitsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if !out.PatternIngesterEnabled {
+		t.Errorf("pattern_ingester_enabled=false; cerberus serves /patterns so it must advertise true")
+	}
+	if got, want := out.Limits["volume_enabled"], true; got != want {
+		t.Errorf("limits.volume_enabled=%v, want %v", got, want)
+	}
+	if got, want := out.Limits["discover_log_levels"], true; got != want {
+		t.Errorf("limits.discover_log_levels=%v, want %v", got, want)
+	}
+	// JSON numbers decode as float64; the cap mirrors maxLogQueryLimit.
+	if got, want := out.Limits["max_entries_limit_per_query"], float64(5000); got != want {
+		t.Errorf("limits.max_entries_limit_per_query=%v, want %v", got, want)
+	}
+}
+
+// TestDrilldownLimits_VersionThreading pins that the handler surfaces
+// the same build identifier the /status/buildinfo probe reports, so the
+// Drilldown app's version gating sees a consistent value.
+func TestDrilldownLimits_VersionThreading(t *testing.T) {
+	t.Parallel()
+
+	h := loki.New(&stubQuerier{}, schema.DefaultOTelLogs(), nil)
+	h.Version = "v1.2.3-test"
+	mux := http.NewServeMux()
+	h.Mount(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/loki/api/v1/drilldown-limits")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var out loki.DrilldownLimitsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.Version != "v1.2.3-test" {
+		t.Errorf("version=%q, want %q", out.Version, "v1.2.3-test")
+	}
+}
+
+// TestDrilldownLimits_PostRejected pins upstream parity: Loki registers
+// drilldown-limits as GET-only (pkg/loki/loki.go), so a POST must fall
+// through to the JSON-shaped loki 404/405 surface, not silently succeed.
+func TestDrilldownLimits_PostRejected(t *testing.T) {
+	t.Parallel()
+
+	srv := newServer(&stubQuerier{})
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Post(srv.URL+"/loki/api/v1/drilldown-limits", "application/json", nil)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusOK {
+		t.Fatalf("POST returned 200; upstream registers GET only")
+	}
+}

--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -144,6 +144,11 @@ func (h *Handler) Mount(mux *http.ServeMux) {
 	register("GET /loki/api/v1/format_query", h.handleFormatQuery)
 	register("POST /loki/api/v1/format_query", h.handleFormatQuery)
 	register("GET /loki/api/v1/status/buildinfo", h.handleBuildInfo)
+	// Drilldown-limits config probe — Grafana's first-party Logs
+	// Drilldown app (preinstalled in 12.x) fetches this on boot to
+	// gate the Patterns tab / volume panels / level filtering.
+	// Upstream registers GET only (pkg/loki/loki.go).
+	register("GET /loki/api/v1/drilldown-limits", h.handleDrilldownLimits)
 
 	// JSON-shaped 404 fallback for unmatched /loki/api/v1/* routes. Without
 	// this, http.ServeMux serves Go's plain-text "404 page not found"

--- a/internal/api/tempo/metrics_query_range.go
+++ b/internal/api/tempo/metrics_query_range.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"sort"
 	"strconv"
@@ -207,15 +208,32 @@ func (h *Handler) handleMetricsQueryRange(w http.ResponseWriter, r *http.Request
 		writeError(w, http.StatusBadRequest, "", "", errors.New("'start' and 'end' parameters are required"))
 		return
 	}
-	stepStr := r.URL.Query().Get("step")
-	if stepStr == "" {
-		writeError(w, http.StatusBadRequest, "", "", errors.New("missing 'step' parameter"))
-		return
-	}
-	step, err := parseMetricsStep(stepStr)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, "", "", err)
-		return
+	// `step` is optional, matching reference Tempo: the query-frontend
+	// defaults a zero step via traceql.DefaultQueryRangeStep (~240
+	// points across the window, see modules/frontend/
+	// metrics_query_range_handler.go). Grafana's Traces Drilldown app
+	// (preinstalled since Grafana 12.x) relies on this — its
+	// issue-detector query omits step entirely.
+	var step time.Duration
+	if stepStr := r.URL.Query().Get("step"); stepStr == "" {
+		ns := upstreamTraceql.DefaultQueryRangeStep(
+			uint64(start.UnixNano()), uint64(end.UnixNano()),
+		)
+		// DefaultQueryRangeStep targets ~240 points across the window,
+		// so ns is far below MaxInt64 for any representable time range;
+		// clamp anyway so the uint64 → Duration conversion is provably
+		// overflow-free (gosec G115).
+		if ns > math.MaxInt64 {
+			ns = math.MaxInt64
+		}
+		step = time.Duration(ns)
+	} else {
+		var err error
+		step, err = parseMetricsStep(stepStr)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "", "", err)
+			return
+		}
 	}
 	// Align the eval grid to the step the way Tempo's api.AlignRequest
 	// does: start rounds down to a step multiple, end rounds up (or
@@ -250,8 +268,16 @@ func (h *Handler) handleMetricsQueryRange(w http.ResponseWriter, r *http.Request
 
 	metrics, ok := unwrapMetricsAggregate(plan)
 	if !ok {
+		// `| histogram_over_time(<attr>)` lowers to its own plan node
+		// (chplan.MetricsHistogramOverTime) because the per-bucket value
+		// is a distribution, not a scalar — route it through the
+		// histogram response shape (one series per (group, __bucket)).
+		if hist, hok := unwrapMetricsHistogram(plan); hok {
+			h.serveMetricsQueryRangeHistogram(ctx, w, q, plan, hist, start, end, step)
+			return
+		}
 		writeError(w, http.StatusBadRequest, "", "",
-			fmt.Errorf("query %q is not a TraceQL metrics-pipeline expression — /api/metrics/query_range requires `| rate()`, `| count_over_time()`, `| *_over_time(...)` or `| quantile_over_time(...)`", q))
+			fmt.Errorf("query %q is not a TraceQL metrics-pipeline expression — /api/metrics/query_range requires `| rate()`, `| count_over_time()`, `| *_over_time(...)`, `| quantile_over_time(...)` or `| histogram_over_time(...)`", q))
 		return
 	}
 
@@ -757,8 +783,14 @@ func metricsLabelNames(m *chplan.MetricsAggregate) []string {
 // into one series, samples sorted ascending by timestamp. Series order
 // is deterministic (sorted by canonical label-set key).
 func toMetricsSeries(samples []chclient.Sample, m *chplan.MetricsAggregate) []MetricsSeries {
-	labelNames := metricsLabelNames(m)
+	return toMetricsSeriesWithNames(samples, metricsLabelNames(m))
+}
 
+// toMetricsSeriesWithNames is the label-name-parameterised core of
+// toMetricsSeries, shared with the histogram_over_time path (whose
+// label-name derivation lives on chplan.MetricsHistogramOverTime
+// rather than MetricsAggregate — see histogramLabelNames).
+func toMetricsSeriesWithNames(samples []chclient.Sample, labelNames []string) []MetricsSeries {
 	type bucket struct {
 		labels  []MetricsLabel
 		samples []MetricsSample

--- a/internal/api/tempo/metrics_query_range_histogram.go
+++ b/internal/api/tempo/metrics_query_range_histogram.go
@@ -1,0 +1,149 @@
+package tempo
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/engine"
+)
+
+// This file wires `| histogram_over_time(<attr>)` into
+// `GET /api/metrics/query_range`. The plan + SQL layers landed first
+// (chplan.MetricsHistogramOverTime, chsql.emitRangeWindowHistogram —
+// the matrix fan-out groups by (<user group-by>, __bucket, anchor_ts));
+// this is the HTTP envelope on top.
+//
+// Wire shape: Tempo's reference engine routes histogram_over_time
+// through the same bucketize machinery as quantile_over_time
+// (pkg/traceql/ast_metrics.go: byFuncLabel = internalLabelBucket) but —
+// unlike quantile, which folds buckets into per-phi series — the
+// histogram's FINAL series keep `__bucket` as a real output label: one
+// series per (group-by labels…, __bucket=<edge>) carrying per-anchor
+// counts. Grafana's first-party Traces Drilldown app (preinstalled
+// since Grafana 12.x) drives this shape on its duration-histogram
+// panel.
+//
+// Exemplars: upstream Tempo registers `exemplarNaN` for
+// histogram_over_time ("Histogram final series are counts so exemplars
+// are placeholders"), so cerberus ships the empty `Exemplars: []`
+// envelope — the same shape every series gets before attachment.
+
+// unwrapMetricsHistogram returns the MetricsHistogramOverTime at the
+// plan root (or directly under a single Filter wrapper — mirroring
+// unwrapMetricsAggregate's forward-compat posture).
+func unwrapMetricsHistogram(plan chplan.Node) (*chplan.MetricsHistogramOverTime, bool) {
+	switch v := plan.(type) {
+	case *chplan.MetricsHistogramOverTime:
+		return v, true
+	case *chplan.Filter:
+		if inner, ok := v.Input.(*chplan.MetricsHistogramOverTime); ok {
+			return inner, true
+		}
+	}
+	return nil, false
+}
+
+// histogramLabelNames mirrors metricsLabelNames for the histogram node:
+// the user-facing group-by label names (display-name → alias →
+// "group_<i>" fallback chain) with `__bucket` appended — every
+// histogram series carries the bucket-edge label, grouped or not.
+func histogramLabelNames(m *chplan.MetricsHistogramOverTime) []string {
+	out := make([]string, 0, len(m.GroupBy)+1)
+	for i := range m.GroupBy {
+		if i < len(m.GroupByDisplayNames) && m.GroupByDisplayNames[i] != "" {
+			out = append(out, m.GroupByDisplayNames[i])
+			continue
+		}
+		if i < len(m.GroupByAliases) && m.GroupByAliases[i] != "" {
+			out = append(out, m.GroupByAliases[i])
+			continue
+		}
+		out = append(out, "group_"+strconv.Itoa(i))
+	}
+	out = append(out, tempoQuantileBucketLabel)
+	return out
+}
+
+// wrapHistogramForSample wraps the matrix-shape RangeWindow with the
+// Sample projection the engine's row decoder expects — the histogram
+// analogue of wrapMetricsForSample's quantile branch, except `__bucket`
+// is a real wire label here (no post-fold strips it).
+func wrapHistogramForSample(rw *chplan.RangeWindow, m *chplan.MetricsHistogramOverTime) chplan.Node {
+	attrAliases := metricsOuterGroupAliases(m.GroupBy, m.GroupByAliases)
+	labelNames := histogramLabelNames(m)
+
+	args := make([]chplan.Expr, 0, (len(m.GroupBy)+1)*2)
+	for i := range m.GroupBy {
+		args = append(
+			args,
+			&chplan.LitString{V: labelNames[i]},
+			&chplan.FuncCall{
+				Name: "toString",
+				Args: []chplan.Expr{&chplan.ColumnRef{Name: attrAliases[i]}},
+			},
+		)
+	}
+	args = append(
+		args,
+		&chplan.LitString{V: tempoQuantileBucketLabel},
+		&chplan.FuncCall{
+			Name: "toString",
+			Args: []chplan.Expr{&chplan.ColumnRef{Name: m.BucketAlias}},
+		},
+	)
+
+	return &chplan.Project{
+		Input: rw,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.LitString{V: ""}, Alias: "MetricName"},
+			{Expr: &chplan.FuncCall{Name: "map", Args: args}, Alias: "Attributes"},
+			{Expr: &chplan.ColumnRef{Name: "anchor_ts"}, Alias: "TimeUnix"},
+			{Expr: &chplan.ColumnRef{Name: m.ValueAlias}, Alias: "Value"},
+		},
+	}
+}
+
+// serveMetricsQueryRangeHistogram runs the matrix-shape pipeline for a
+// lowered histogram_over_time plan and writes the Tempo
+// series-of-samples envelope.
+func (h *Handler) serveMetricsQueryRangeHistogram(
+	ctx context.Context,
+	w http.ResponseWriter,
+	q string,
+	plan chplan.Node,
+	hist *chplan.MetricsHistogramOverTime,
+	start, end time.Time,
+	step time.Duration,
+) {
+	rw := &chplan.RangeWindow{
+		Input:           plan,
+		Range:           step,
+		Step:            step,
+		Start:           start,
+		End:             end,
+		TimestampColumn: h.Schema.TimestampColumn,
+	}
+	wrapped := wrapHistogramForSample(rw, hist)
+
+	res, qerr := h.Engine.QueryPlan(ctx, metricsLang{}, wrapped, engine.Meta{
+		IsMetric:      true,
+		ResponseShape: "tempo-metrics-matrix",
+	})
+	if qerr != nil {
+		writeError(w, classifyMetricsQueryRangeErr(qerr), "", "", qerr)
+		return
+	}
+	h.Logger.Debug("cerberus tempo metrics_query_range histogram",
+		"traceql", q, "start", start, "end", end, "step", step,
+		"sql", res.SQL, "args", res.Args)
+
+	series := toMetricsSeriesWithNames(res.Samples, histogramLabelNames(hist))
+
+	writeEngineHeaders(w, res.Headers)
+	writeJSON(w, http.StatusOK, MetricsQueryRangeResponse{
+		Series: series,
+	})
+}

--- a/internal/api/tempo/metrics_query_range_histogram_test.go
+++ b/internal/api/tempo/metrics_query_range_histogram_test.go
@@ -1,0 +1,143 @@
+package tempo_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/api/tempo"
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+// TestMetricsQueryRangeHistogram_Ungrouped pins the
+// `| histogram_over_time(duration)` HTTP wire shape: one series per
+// `__bucket` edge, per-anchor counts, empty exemplar envelope (upstream
+// Tempo registers exemplarNaN for histograms — placeholders only).
+// Grafana's Traces Drilldown app (preinstalled since Grafana 12.x)
+// drives this exact query on its duration-histogram panel; before the
+// wiring landed the handler 400'd it as "not a metrics-pipeline
+// expression".
+func TestMetricsQueryRangeHistogram_Ungrouped(t *testing.T) {
+	t.Parallel()
+
+	ts := func(min int) time.Time {
+		return time.Date(2026, 5, 12, 10, min, 0, 0, time.UTC)
+	}
+	// The matrix SQL projects map('__bucket', toString(<bucket edge>))
+	// for the ungrouped histogram. Two buckets, two anchors each.
+	q := &stubQuerier{samples: []chclient.Sample{
+		{Labels: map[string]string{"__bucket": "0.25"}, Timestamp: ts(1), Value: 3},
+		{Labels: map[string]string{"__bucket": "0.25"}, Timestamp: ts(0), Value: 1},
+		{Labels: map[string]string{"__bucket": "0.5"}, Timestamp: ts(0), Value: 2},
+	}}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	u := metricsQueryRangeURL(srv.URL, "{} | histogram_over_time(duration)", map[string]string{
+		"start": fixtureStartUnix,
+		"end":   fixtureEndUnix,
+		"step":  "60s",
+	})
+	resp, err := http.Get(u)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+
+	var body tempo.MetricsQueryRangeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Series) != 2 {
+		t.Fatalf("expected 2 series (one per __bucket), got %d: %+v", len(body.Series), body)
+	}
+	for _, s := range body.Series {
+		if len(s.Labels) != 1 || s.Labels[0].Key != "__bucket" {
+			t.Errorf("expected single __bucket label per histogram series, got %+v", s.Labels)
+		}
+		if s.Exemplars == nil || len(s.Exemplars) != 0 {
+			t.Errorf("expected empty exemplar envelope, got %+v", s.Exemplars)
+		}
+	}
+	// Series are keyed canonically; the 0.25 bucket carries both anchors
+	// sorted ascending.
+	var b025 *tempo.MetricsSeries
+	for i := range body.Series {
+		if body.Series[i].Labels[0].Value == "0.25" {
+			b025 = &body.Series[i]
+		}
+	}
+	if b025 == nil {
+		t.Fatalf("no series for __bucket=0.25: %+v", body.Series)
+	}
+	if len(b025.Samples) != 2 || b025.Samples[0].Value != 1 || b025.Samples[1].Value != 3 {
+		t.Errorf("bucket 0.25 samples wrong (want ascending [1 3]): %+v", b025.Samples)
+	}
+
+	// The histogram matrix emitter must have produced the arrayJoin
+	// fan-out with the __bucket grouping column.
+	assertSQLContains(t, q.lastSQL, "arrayJoin")
+	assertSQLContains(t, q.lastSQL, "anchor_ts")
+	assertSQLContains(t, q.lastSQL, "__bucket")
+}
+
+// TestMetricsQueryRangeHistogram_GroupBy pins the grouped shape: the
+// series label list is (group display name…, __bucket) and the group
+// label uses the Tempo-canonical scope-prefixed wire name.
+func TestMetricsQueryRangeHistogram_GroupBy(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 5, 12, 10, 1, 0, 0, time.UTC)
+	q := &stubQuerier{samples: []chclient.Sample{
+		{
+			Labels:    map[string]string{"resource.service.name": "checkout", "__bucket": "0.25"},
+			Timestamp: ts,
+			Value:     4,
+		},
+		{
+			Labels:    map[string]string{"resource.service.name": "cart", "__bucket": "0.25"},
+			Timestamp: ts,
+			Value:     7,
+		},
+	}}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	u := metricsQueryRangeURL(srv.URL,
+		"{} | histogram_over_time(duration) by (resource.service.name)",
+		map[string]string{
+			"start": fixtureStartUnix,
+			"end":   fixtureEndUnix,
+			"step":  "60s",
+		})
+	resp, err := http.Get(u)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+
+	var body tempo.MetricsQueryRangeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Series) != 2 {
+		t.Fatalf("expected 2 series, got %d: %+v", len(body.Series), body)
+	}
+	for _, s := range body.Series {
+		if len(s.Labels) != 2 {
+			t.Fatalf("expected (group, __bucket) label pair, got %+v", s.Labels)
+		}
+		// Label order follows histogramLabelNames: group-by first
+		// (Tempo-canonical scope-prefixed name), then __bucket.
+		if s.Labels[0].Key != "resource.service.name" || s.Labels[1].Key != "__bucket" {
+			t.Errorf("label order/name mismatch: %+v", s.Labels)
+		}
+	}
+}

--- a/internal/api/tempo/metrics_query_range_test.go
+++ b/internal/api/tempo/metrics_query_range_test.go
@@ -611,10 +611,60 @@ func TestMetricsQueryRange_DurationAggInSeconds(t *testing.T) {
 	}
 }
 
+// TestMetricsQueryRange_DefaultStep pins the reference-Tempo contract
+// that `step` is optional: the query-frontend defaults a zero step via
+// traceql.DefaultQueryRangeStep (modules/frontend/
+// metrics_query_range_handler.go). Grafana's Traces Drilldown app
+// (first-party preinstalled since Grafana 12.x) omits step on its
+// issue-detector query — before this contract landed, cerberus 400'd
+// with "missing 'step' parameter" and the app surfaced a query-error
+// banner on every boot.
+func TestMetricsQueryRange_DefaultStep(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{samples: []chclient.Sample{
+		{
+			MetricName: "",
+			Labels:     map[string]string{"__name__": "rate"},
+			Timestamp:  time.Date(2026, 5, 12, 10, 1, 0, 0, time.UTC),
+			Value:      1.0,
+		},
+	}}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	// No `step` parameter at all — the handler must default it, not 400.
+	u := metricsQueryRangeURL(srv.URL, "{} | rate()", map[string]string{
+		"start": fixtureStartUnix,
+		"end":   fixtureEndUnix,
+	})
+	resp, err := http.Get(u)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s — a missing step must default per reference Tempo, not error", resp.StatusCode, readBody(t, resp))
+	}
+
+	var body tempo.MetricsQueryRangeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Series) != 1 {
+		t.Fatalf("expected 1 series, got %d: %+v", len(body.Series), body)
+	}
+	// The defaulted step must have reached the matrix-shape SQL emitter
+	// — same hallmark probes as the explicit-step happy path.
+	assertSQLContains(t, q.lastSQL, "arrayJoin")
+	assertSQLContains(t, q.lastSQL, "anchor_ts")
+}
+
 // TestMetricsQueryRange_BadInputs covers the 4xx surface: missing or
-// malformed `q` / `start` / `end` / `step`, and a non-metric TraceQL
-// query (one that lowers to a Scan/Filter rather than a
-// MetricsAggregate).
+// malformed `q` / `start` / `end`, an explicitly non-positive `step`
+// (absence defaults instead — see TestMetricsQueryRange_DefaultStep),
+// and a non-metric TraceQL query (one that lowers to a Scan/Filter
+// rather than a MetricsAggregate).
 func TestMetricsQueryRange_BadInputs(t *testing.T) {
 	t.Parallel()
 
@@ -627,11 +677,6 @@ func TestMetricsQueryRange_BadInputs(t *testing.T) {
 			name:    "missing_q",
 			params:  map[string]string{"start": fixtureStartUnix, "end": fixtureEndUnix, "step": "30s"},
 			wantSub: "missing 'q'",
-		},
-		{
-			name:    "missing_step",
-			params:  map[string]string{"q": "{} | rate()", "start": fixtureStartUnix, "end": fixtureEndUnix},
-			wantSub: "missing 'step'",
 		},
 		{
 			name:    "missing_start",

--- a/internal/traceql/lower.go
+++ b/internal/traceql/lower.go
@@ -503,6 +503,10 @@ func lowerFieldExpr(e traceql.FieldExpression, s schema.Traces) (chplan.Expr, er
 	switch v := e.(type) {
 	case *traceql.BinaryOperation:
 		return lowerBinaryOperation(v, s)
+	case *traceql.UnaryOperation:
+		return lowerUnaryOperation(*v, s)
+	case traceql.UnaryOperation:
+		return lowerUnaryOperation(v, s)
 	case *traceql.Attribute:
 		return lowerAttributeExpr(*v, s)
 	case traceql.Attribute:
@@ -513,6 +517,66 @@ func lowerFieldExpr(e traceql.FieldExpression, s schema.Traces) (chplan.Expr, er
 		return lowerStatic(v)
 	}
 	return nil, fmt.Errorf("traceql: field expression %T is unsupported", e)
+}
+
+// lowerUnaryOperation handles the unary FieldExpression forms.
+//
+// `<attr> != nil` and `nil != <attr>` parse to UnaryOperation{OpExists}
+// and `<attr> = nil` / `nil = <attr>` to UnaryOperation{OpNotExists}
+// (the grammar rewrites the nil comparison — see upstream expr.y).
+// Grafana's first-party Traces Drilldown app (preinstalled since
+// Grafana 12.x) issues `resource.service.name != nil` on every
+// breakdown view, so the existence test is a load-bearing shape.
+//
+// Existence lowers to ClickHouse `mapContains(<carrier>, '<key>')`
+// against the Map(String, String) attribute carrier for the
+// attribute's scope (SpanAttributes / ResourceAttributes — the same
+// scope mapping lowerAttribute uses). Intrinsics are rejected: OTel-CH
+// materialises every intrinsic as a non-nullable column, so an
+// existence probe on one is almost certainly a query bug — surfacing
+// the gap beats inventing always-true SQL.
+func lowerUnaryOperation(u traceql.UnaryOperation, s schema.Traces) (chplan.Expr, error) {
+	switch u.Op {
+	case traceql.OpExists, traceql.OpNotExists:
+		attr, ok := fieldExprAttribute(u.Expression)
+		if !ok {
+			return nil, fmt.Errorf("traceql: %s operand %T is unsupported — nil comparisons require an attribute reference", u.Op, u.Expression)
+		}
+		if attr.Intrinsic != traceql.IntrinsicNone {
+			return nil, fmt.Errorf("traceql: nil comparison on intrinsic %s is unsupported — OTel-CH intrinsic columns are always present", attr.Intrinsic)
+		}
+		if attr.Scope == traceql.AttributeScopeLink || attr.Scope == traceql.AttributeScopeEvent {
+			return nil, fmt.Errorf("traceql: nil comparison on %s.%s is unsupported", attr.Scope, attr.Name)
+		}
+		carrier := s.AttributesColumn
+		if attr.Scope == traceql.AttributeScopeResource {
+			carrier = s.ResourceAttributesColumn
+		}
+		contains := &chplan.FuncCall{Name: "mapContains", Args: []chplan.Expr{
+			&chplan.ColumnRef{Name: carrier},
+			&chplan.LitString{V: attr.Name},
+		}}
+		if u.Op == traceql.OpNotExists {
+			return &chplan.FuncCall{Name: "not", Args: []chplan.Expr{contains}}, nil
+		}
+		return contains, nil
+	}
+	return nil, fmt.Errorf("traceql: unary operator %s is unsupported", u.Op)
+}
+
+// fieldExprAttribute unwraps a FieldExpression into its Attribute when
+// it is a bare attribute reference (pointer or value form).
+func fieldExprAttribute(e traceql.FieldExpression) (traceql.Attribute, bool) {
+	switch v := e.(type) {
+	case *traceql.Attribute:
+		if v == nil {
+			return traceql.Attribute{}, false
+		}
+		return *v, true
+	case traceql.Attribute:
+		return v, true
+	}
+	return traceql.Attribute{}, false
 }
 
 // lowerAttributeExpr wraps lowerAttribute with a guard: link- /
@@ -526,6 +590,14 @@ func lowerAttributeExpr(a traceql.Attribute, s schema.Traces) (chplan.Expr, erro
 	if a.Scope == traceql.AttributeScopeLink || a.Scope == traceql.AttributeScopeEvent {
 		return nil, fmt.Errorf("traceql: %s.%s used outside a comparison; only equality / inequality / regex filters on link.* and event.* are supported", a.Scope, a.Name)
 	}
+	// Nested-set intrinsics never resolve to a column: comparisons are
+	// intercepted by lowerNestedSetBinary; any other use would silently
+	// dereference SpanAttributes['nestedSet…'] (which the OTel-CH
+	// exporter never writes) — error instead.
+	switch a.Intrinsic {
+	case traceql.IntrinsicNestedSetParent, traceql.IntrinsicNestedSetLeft, traceql.IntrinsicNestedSetRight:
+		return nil, fmt.Errorf("traceql: intrinsic %s is only supported in root-ness comparisons (e.g. nestedSetParent < 0)", a.Intrinsic)
+	}
 	return lowerAttribute(a, s), nil
 }
 
@@ -533,6 +605,14 @@ func lowerBinaryOperation(b *traceql.BinaryOperation, s schema.Traces) (chplan.E
 	op, err := mapBinaryOp(b.Op)
 	if err != nil {
 		return nil, err
+	}
+	// Nested-set intrinsics (nestedSetParent / nestedSetLeft /
+	// nestedSetRight) have no OTel-CH backing column; intercept them
+	// before generic lowering would mis-resolve the name to a
+	// SpanAttributes map lookup. The root-span idiom
+	// (`nestedSetParent < 0`) lowers exactly; anything else errors.
+	if expr, handled, err := lowerNestedSetBinary(b, op, s); handled {
+		return expr, err
 	}
 	// TraceQL link / event spanset filters live on the OTel-CH `Links` /
 	// `Events` Nested columns. Their predicate shape is
@@ -658,6 +738,163 @@ func isNumericExpr(expr chplan.Expr) bool {
 		return true
 	}
 	return false
+}
+
+// lowerNestedSetBinary intercepts comparisons against the nested-set
+// intrinsics (`nestedSetParent` / `nestedSetLeft` / `nestedSetRight`).
+//
+// Tempo materialises a nested-set tree model per trace at ingest time:
+// every span gets left/right interval bounds plus the parent's left
+// bound, with root spans carrying nestedSetParent == -1 and every
+// non-root span a positive position (>= 1). The OTel-CH schema has no
+// equivalent columns, so cerberus cannot reproduce position values —
+// but it CAN answer every comparison whose truth depends only on
+// root-ness, because root-ness maps exactly to `ParentSpanId = ”`.
+//
+// That covers the documented root-span idiom `nestedSetParent < 0`
+// (what Grafana's Traces Drilldown app stamps on every query as its
+// primary-signal filter) and any other (op, literal) pair whose result
+// is constant across the positive non-root domain. Comparisons that
+// would need real positions (e.g. `nestedSetParent = 5`) error out —
+// surfacing the gap beats returning rows from wrong SQL.
+//
+// Returns handled=false when neither side references a nested-set
+// intrinsic (the caller continues with generic lowering).
+func lowerNestedSetBinary(b *traceql.BinaryOperation, op chplan.BinaryOp, s schema.Traces) (chplan.Expr, bool, error) {
+	attr, lit, flipped := traceql.Attribute{}, traceql.Static{}, false
+	if a, ok := nestedSetIntrinsicAttr(b.LHS); ok {
+		st, ok := fieldExprStatic(b.RHS)
+		if !ok {
+			return nil, true, fmt.Errorf("traceql: %s comparisons support only integer literals", a.Intrinsic)
+		}
+		attr, lit = a, st
+	} else if a, ok := nestedSetIntrinsicAttr(b.RHS); ok {
+		st, ok := fieldExprStatic(b.LHS)
+		if !ok {
+			return nil, true, fmt.Errorf("traceql: %s comparisons support only integer literals", a.Intrinsic)
+		}
+		attr, lit, flipped = a, st, true
+	} else {
+		return nil, false, nil
+	}
+
+	if attr.Intrinsic != traceql.IntrinsicNestedSetParent {
+		return nil, true, fmt.Errorf("traceql: intrinsic %s is unsupported — the OTel ClickHouse schema does not materialise nested-set positions", attr.Intrinsic)
+	}
+	if lit.Type != traceql.TypeInt {
+		return nil, true, fmt.Errorf("traceql: nestedSetParent comparisons support only integer literals, got %s", lit.Type)
+	}
+	v64, _ := lit.Int()
+	v := int64(v64)
+	if flipped {
+		op = flipComparisonOp(op)
+	}
+
+	root, err := evalIntCmp(-1, op, v)
+	if err != nil {
+		return nil, true, err
+	}
+	nonRoot, constant := nonRootCmpConstant(op, v)
+	if !constant {
+		return nil, true, fmt.Errorf("traceql: nestedSetParent %s %d depends on nested-set positions the OTel ClickHouse schema does not materialise — only root-ness tests (e.g. nestedSetParent < 0) are supported", op, v)
+	}
+
+	parentCol := &chplan.ColumnRef{Name: s.ParentSpanIDColumn}
+	empty := &chplan.LitString{V: ""}
+	switch {
+	case root && !nonRoot:
+		return &chplan.Binary{Op: chplan.OpEq, Left: parentCol, Right: empty}, true, nil
+	case !root && nonRoot:
+		return &chplan.Binary{Op: chplan.OpNe, Left: parentCol, Right: empty}, true, nil
+	default:
+		// Same truth value for root and non-root spans — the predicate
+		// is constant over the whole table.
+		return &chplan.LitBool{V: root}, true, nil
+	}
+}
+
+// nestedSetIntrinsicAttr returns the attribute when e references one of
+// the nested-set intrinsics.
+func nestedSetIntrinsicAttr(e traceql.FieldExpression) (traceql.Attribute, bool) {
+	a, ok := fieldExprAttribute(e)
+	if !ok {
+		return traceql.Attribute{}, false
+	}
+	switch a.Intrinsic {
+	case traceql.IntrinsicNestedSetParent, traceql.IntrinsicNestedSetLeft, traceql.IntrinsicNestedSetRight:
+		return a, true
+	}
+	return traceql.Attribute{}, false
+}
+
+// fieldExprStatic unwraps a FieldExpression into its Static literal
+// (pointer or value form).
+func fieldExprStatic(e traceql.FieldExpression) (traceql.Static, bool) {
+	switch v := e.(type) {
+	case *traceql.Static:
+		if v == nil {
+			return traceql.Static{}, false
+		}
+		return *v, true
+	case traceql.Static:
+		return v, true
+	}
+	return traceql.Static{}, false
+}
+
+// evalIntCmp evaluates `a op v` for two int64s. Errors on non-comparison
+// ops (arithmetic / regex / logical never reach the nested-set path
+// with a valid TraceQL parse, but fail loudly rather than guess).
+func evalIntCmp(a int64, op chplan.BinaryOp, v int64) (bool, error) {
+	switch op {
+	case chplan.OpEq:
+		return a == v, nil
+	case chplan.OpNe:
+		return a != v, nil
+	case chplan.OpLt:
+		return a < v, nil
+	case chplan.OpLe:
+		return a <= v, nil
+	case chplan.OpGt:
+		return a > v, nil
+	case chplan.OpGe:
+		return a >= v, nil
+	}
+	return false, fmt.Errorf("traceql: operator %s is unsupported on nestedSetParent", op)
+}
+
+// nonRootCmpConstant reports whether `p op v` has the same truth value
+// for every possible non-root nested-set parent position p (p >= 1),
+// and what that value is. When the result varies with p the comparison
+// needs real nested-set positions and cannot be lowered.
+func nonRootCmpConstant(op chplan.BinaryOp, v int64) (value, constant bool) {
+	switch op {
+	case chplan.OpEq:
+		if v < 1 {
+			return false, true
+		}
+	case chplan.OpNe:
+		if v < 1 {
+			return true, true
+		}
+	case chplan.OpLt:
+		if v <= 1 {
+			return false, true
+		}
+	case chplan.OpLe:
+		if v < 1 {
+			return false, true
+		}
+	case chplan.OpGt:
+		if v < 1 {
+			return true, true
+		}
+	case chplan.OpGe:
+		if v <= 1 {
+			return true, true
+		}
+	}
+	return false, false
 }
 
 // lowerNestedAttrBinary recognises the

--- a/internal/traceql/nested_set_nil_test.go
+++ b/internal/traceql/nested_set_nil_test.go
@@ -1,0 +1,140 @@
+package traceql_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tempo "github.com/grafana/tempo/pkg/traceql"
+
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/traceql"
+)
+
+// The happy paths for the nested-set root idiom and nil comparisons are
+// pinned by TXTAR fixtures (nested_set_parent_root / _nonroot,
+// attr_not_nil / attr_eq_nil). This file pins the REJECTION surface:
+// every comparison that would need real nested-set positions (which the
+// OTel-CH schema does not materialise) must fail at lower time with a
+// descriptive error rather than mis-lower to a SpanAttributes map
+// lookup (the pre-fix behaviour, which produced a ClickHouse
+// `Cannot parse Float64 from String` execution error on every Traces
+// Drilldown query — Grafana 12.x stamps `nestedSetParent<0` on each).
+func TestLower_NestedSetUnsupportedShapes(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelTraces()
+	cases := []struct {
+		name    string
+		query   string
+		wantSub string
+	}{
+		{
+			name:    "position_equality_needs_real_positions",
+			query:   `{ nestedSetParent = 5 }`,
+			wantSub: "nested-set positions",
+		},
+		{
+			name:    "position_range_needs_real_positions",
+			query:   `{ nestedSetParent > 2 }`,
+			wantSub: "nested-set positions",
+		},
+		{
+			name:    "nested_set_left_unsupported",
+			query:   `{ nestedSetLeft > 0 }`,
+			wantSub: "unsupported",
+		},
+		{
+			name:    "nested_set_right_unsupported",
+			query:   `{ nestedSetRight > 0 }`,
+			wantSub: "unsupported",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := tempo.Parse(tc.query)
+			if err != nil {
+				t.Fatalf("Parse(%q): %v", tc.query, err)
+			}
+			_, err = traceql.Lower(context.Background(), expr, s)
+			if err == nil {
+				t.Fatalf("Lower(%q) succeeded; want error containing %q", tc.query, tc.wantSub)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("Lower(%q) error %q does not contain %q", tc.query, err, tc.wantSub)
+			}
+		})
+	}
+}
+
+// TestLower_RootIdiomLiteralVariants pins that every literal spelling
+// of the root-span test lowers (Tempo evaluates root-ness as
+// nestedSetParent == -1; spans of an unbuilt tree carry 0, which never
+// matches a root test — cerberus's domain model is {-1} ∪ {>= 1}).
+func TestLower_RootIdiomLiteralVariants(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelTraces()
+	for _, query := range []string{
+		`{ nestedSetParent < 0 }`,
+		`{ nestedSetParent <= -1 }`,
+		`{ nestedSetParent = -1 }`,
+		`{ nestedSetParent >= 0 }`,
+		`{ nestedSetParent != -1 }`,
+		// Literal-on-the-left spelling flips the comparison.
+		`{ 0 > nestedSetParent }`,
+	} {
+		t.Run(query, func(t *testing.T) {
+			t.Parallel()
+			expr, err := tempo.Parse(query)
+			if err != nil {
+				t.Fatalf("Parse(%q): %v", query, err)
+			}
+			if _, err := traceql.Lower(context.Background(), expr, s); err != nil {
+				t.Errorf("Lower(%q): %v — root-ness idiom must lower", query, err)
+			}
+		})
+	}
+}
+
+// TestLower_NilComparisonRejections pins the unsupported nil-comparison
+// operands: intrinsics (always materialised in OTel-CH) and link/event
+// scopes (Nested columns need the arrayExists shape, not mapContains).
+func TestLower_NilComparisonRejections(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelTraces()
+	cases := []struct {
+		name    string
+		query   string
+		wantSub string
+	}{
+		{
+			name:    "intrinsic_always_present",
+			query:   `{ name != nil }`,
+			wantSub: "intrinsic",
+		},
+		{
+			name:    "event_scope_unsupported",
+			query:   `{ event.message != nil }`,
+			wantSub: "unsupported",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := tempo.Parse(tc.query)
+			if err != nil {
+				t.Fatalf("Parse(%q): %v", tc.query, err)
+			}
+			_, err = traceql.Lower(context.Background(), expr, s)
+			if err == nil {
+				t.Fatalf("Lower(%q) succeeded; want error containing %q", tc.query, tc.wantSub)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("Lower(%q) error %q does not contain %q", tc.query, err, tc.wantSub)
+			}
+		})
+	}
+}

--- a/test/e2e/grafana/compose/datasources/cerberus.yaml
+++ b/test/e2e/grafana/compose/datasources/cerberus.yaml
@@ -39,7 +39,7 @@ datasources:
       serviceMap:
         datasourceUid: cerberus-prometheus
   # ---------------------------------------------------------------------
-  # Grafana 11.x ships three built-in drilldown apps preinstalled:
+  # Grafana 12.x ships three built-in drilldown apps preinstalled:
   #   - grafana-metricsdrilldown-app  (Explore Metrics)
   #   - grafana-lokiexplore-app       (Explore Logs)
   #   - grafana-exploretraces-app     (Explore Traces)

--- a/test/e2e/k3s/grafana.yaml
+++ b/test/e2e/k3s/grafana.yaml
@@ -41,7 +41,7 @@ data:
           # rest of the stack.
           serviceMap:
             datasourceUid: cerberus-prometheus
-      # Aliases for Grafana 11.x built-in drilldown apps. Each app's
+      # Aliases for Grafana's built-in drilldown apps. Each app's
       # factory defaults reference Grafana Cloud's canonical
       # `grafanacloud-{metrics,logs,traces}` UIDs; without those
       # entries the apps log "Datasource grafanacloud-* was not
@@ -111,7 +111,7 @@ spec:
     spec:
       containers:
         - name: grafana
-          image: grafana/grafana:11.4.0
+          image: grafana/grafana:12.2.9
           ports:
             - name: http
               containerPort: 3000
@@ -126,17 +126,20 @@ spec:
               value: Viewer
             - name: GF_USERS_DEFAULT_THEME
               value: dark
-            - name: GF_FEATURE_TOGGLES_ENABLE
-              value: traceqlSearch
             # Deliberately NO GF_INSTALL_PLUGINS for the drilldown
-            # apps: grafana-metricsdrilldown-app and
-            # grafana-exploretraces-app require Grafana >= 11.6 and
-            # installing them on this 11.4.0 image bricks the frontend
-            # (run 27246825822 hung the whole Playwright suite on its
-            # first navigation, both attempts). The drilldown catalogue
-            # (test/e2e/playwright/helpers/drilldown.ts) is scoped to
-            # the apps this image ships; both come back as first-party
-            # preinstalled apps when the Grafana pin bumps to 12.x.
+            # apps: on Grafana 12.x grafana-lokiexplore-app,
+            # grafana-exploretraces-app, and
+            # grafana-metricsdrilldown-app are first-party preinstalled
+            # (hardcoded in Grafana's pkg/setting/setting_plugins.go
+            # preinstall list), so installing them again via
+            # GF_INSTALL_PLUGINS would only race the built-in flow.
+            # Note: the preinstall is an ASYNC boot-time download from
+            # grafana.com that starts after /api/health goes green —
+            # the pod needs egress to grafana.com, and
+            # /api/plugins/<id>/settings can briefly 404 right after
+            # boot (see grafana/grafana#106871). The drilldown
+            # catalogue (test/e2e/playwright/helpers/drilldown.ts)
+            # bounds that race with waitForAppInstalled.
           volumeMounts:
             - name: datasources
               mountPath: /etc/grafana/provisioning/datasources

--- a/test/e2e/playwright/helpers.spec.ts
+++ b/test/e2e/playwright/helpers.spec.ts
@@ -473,20 +473,22 @@ test('assertSubsetByCount throws when filtered exceeds baseline', () => {
 });
 
 test('iterateDrilldownApps returns the apps the pinned Grafana ships', () => {
-  // The catalogue is scoped to what grafana/grafana:11.4.0 can run:
-  // grafana-pyroscope-app left with the escape-hatch cleanup (cerberus
-  // doesn't ship profiling) and grafana-metricsdrilldown-app /
-  // grafana-exploretraces-app require Grafana >= 11.6 (see
-  // helpers/drilldown.ts). This pin moves in lock-step with the
-  // catalogue — when the Grafana pin bumps to 12.x the two newer apps
-  // return as first-party preinstalled entries.
+  // The catalogue is scoped to what grafana/grafana:12.2.9 preinstalls
+  // first-party (hardcoded in Grafana's pkg/setting/setting_plugins.go
+  // preinstall list): the metrics, logs, and traces drilldown apps.
+  // grafana-pyroscope-app stays out — cerberus ships no profiling
+  // backend. This pin moves in lock-step with the catalogue.
   const apps = iterateDrilldownApps();
-  expect(apps.length).toBe(1);
-  expect(apps.map((a) => a.id)).toEqual(['grafana-lokiexplore-app']);
+  expect(apps.length).toBe(3);
+  expect(apps.map((a) => a.id)).toEqual([
+    'grafana-metricsdrilldown-app',
+    'grafana-lokiexplore-app',
+    'grafana-exploretraces-app',
+  ]);
   // Returned array must be a fresh copy — mutating it must not
   // contaminate the module-level constant.
   apps.pop();
-  expect(DRILLDOWN_APPS.length).toBe(1);
+  expect(DRILLDOWN_APPS.length).toBe(3);
 });
 
 test('DRILLDOWN_APPS entries each carry id + root + label', () => {
@@ -816,7 +818,7 @@ test('isAppInstalled distinguishes installed apps from a known-bogus id', async 
   );
   expect(bogus).toBe(false);
 
-  // At least one of the preinstalled drilldown apps in Grafana 11.4.0
+  // At least one of the preinstalled drilldown apps in Grafana 12.2.9
   // must resolve to true. We probe all of them but only require ≥1 to
   // be present so a stripped-down stack (no apps at all) still surfaces
   // the contract: the helper returned a boolean, not a throw.

--- a/test/e2e/playwright/helpers/README.md
+++ b/test/e2e/playwright/helpers/README.md
@@ -13,7 +13,7 @@ land in subsequent PRs.
 | `query-shape.ts` | Regex-based target classification + rewriting: `extractByKeys`, `extractWithoutKeys`, `expectedByKeys`, `isHistogramQuantile`, `extractHistogramName`, `addLabelFilter`, `expressionHasMatcherFor`.   |
 | `assertions.ts`  | Per-shape assertions over the Grafana `/api/ds/query` envelope (`assertLabelShape` / `assertLabelAbsent` / histogram pair / `assertSubsetByCount`) + the zero-404 gate (`assertNon200ResponseClass`). |
 | `sweep.ts`       | `generateSelfTraffic` — pre-step that fires self-traffic against cerberus so the cerberus dashboards have data to render.                                                                             |
-| `drilldown.ts`   | Drilldown-app catalogue (4 built-in apps) + `drillTwoLevels` gesture driver + `isAppInstalled` (`/api/plugins/<id>/settings` probe so the iteration handles apps that aren't provisioned).            |
+| `drilldown.ts`   | Drilldown-app catalogue (3 first-party apps) + `drillTwoLevels` gesture driver + `isAppInstalled` / `waitForAppInstalled` (`/api/plugins/<id>/settings` probe + bounded async-preinstall wait).       |
 | `dom.ts`         | Browser-side helpers: console-error capture, `role="alert"` banner read, kiosk repaint-flicker tolerance.                                                                                             |
 | `probes.ts`      | `fetchAndAssert200` (the zero-404 gate on direct HTTP probes) + `extractDataSourceProxyURL` (panel → datasource proxy path).                                                                          |
 
@@ -32,7 +32,7 @@ concrete iteration:
 | 3     | `iterate-filter-drill.spec.ts`       | `dashboard`, `query-shape` (`addLabelFilter`, `expressionHasMatcherFor`, `expectedByKeys`), `assertions` (`assertSubsetByCount`), `sweep`, `probes` |
 | 4     | `compose_panel_kiosk.spec.ts`        | `dashboard`, `dom`, `assertions`                                                                                                                    |
 | 5     | `iterate-time-ranges.spec.ts`        | `dashboard`, `query-shape`, `assertions`, `sweep`, `probes` — nightly-only (e2e.yml `dashboard` job), NOT compose-smoke (Q2)                        |
-| 6     | `iterate-drilldown-apps.spec.ts`     | `drilldown` (4-app catalogue + `isAppInstalled`), `dom`, `probes`                                                                                   |
+| 6     | `iterate-drilldown-apps.spec.ts`     | `drilldown` (3-app catalogue + `waitForAppInstalled`), `dom`, `probes`                                                                              |
 
 The existing `compose_grafana_smoke.spec.ts` is untouched in this PR;
 phase 1 will retire its bespoke `driveCerberusQLPartition` /
@@ -41,21 +41,23 @@ phase 1 will retire its bespoke `driveCerberusQLPartition` /
 
 ## Pinned Grafana version
 
-The compose stack pins `grafana/grafana:11.4.0` (see
+The compose stack pins `grafana/grafana:12.2.9` (see
 `docker-compose.yml`). The drilldown-app catalogue in `drilldown.ts`
 and the panel-schema flattening in `dashboard.ts` both assume the
-Grafana 11.x dashboard JSON shape:
+Grafana 12.x dashboard JSON shape:
 
 - Rows nest their contents under `panel.panels[]`.
 - Panel headers expose `data-testid="data-testid Panel header <title>"`.
 - Drilldown-app affordances expose stable `data-testid` prefixes
   (`data-testid metric-select`, `data-testid detected-label`, …).
-- Grafana 11.4.0 ships `grafana-metricsdrilldown-app`,
+- Grafana 12.x preinstalls `grafana-metricsdrilldown-app`,
   `grafana-lokiexplore-app`, and `grafana-exploretraces-app`
-  preinstalled+enabled out of the box. `grafana-pyroscope-app` is
-  NOT preinstalled on the cerberus compose stack — the phase-6 spec
-  uses `isAppInstalled` to detect availability and annotates a
-  cleanly missing app instead of failing.
+  first-party (hardcoded in `pkg/setting/setting_plugins.go`). The
+  preinstall is an async boot-time download from grafana.com that
+  completes AFTER `/api/health` goes green (grafana/grafana#106871) —
+  specs synchronize on it via `waitForAppInstalled` (bounded 120s
+  poll) before hard-asserting install status. `grafana-pyroscope-app`
+  is NOT in the catalogue — cerberus ships no profiling backend.
 
 **Bumping Grafana requires updating the phase specs in the same PR**
 (resolved decision Q4, `~/.claude/plans/e2e-enhance.md` §9). The

--- a/test/e2e/playwright/helpers/dashboard.ts
+++ b/test/e2e/playwright/helpers/dashboard.ts
@@ -10,10 +10,11 @@
  * /api/search response only carries the title + uid.
  *
  * Grafana version pinned in `docker-compose.yml` at the time of writing
- * is `grafana/grafana:11.4.0`. The panel schema shape (rows containing
- * nested panels[]) is the 11.x shape; if/when the compose stack bumps
- * Grafana, audit this file for schema drift and update the spec phases
- * in the same PR. See helpers/README.md for the version-bump checklist.
+ * is `grafana/grafana:12.2.9`. The panel schema shape (rows containing
+ * nested panels[]) is unchanged from 11.x through 12.x; if/when the
+ * compose stack bumps Grafana, audit this file for schema drift and
+ * update the spec phases in the same PR. See helpers/README.md for the
+ * version-bump checklist.
  */
 
 import type { APIRequestContext } from '@playwright/test';

--- a/test/e2e/playwright/helpers/drilldown.ts
+++ b/test/e2e/playwright/helpers/drilldown.ts
@@ -1,8 +1,8 @@
 /**
  * Drilldown-app iteration helpers.
  *
- * The cerberus compose stack provisions three Grafana built-in drilldown
- * apps (Grafana 11.4.0):
+ * The cerberus stacks run three Grafana first-party drilldown apps
+ * (preinstalled by Grafana 12.x out of the box):
  *   - grafana-metricsdrilldown-app   (Explore Metrics)
  *   - grafana-lokiexplore-app        (Explore Logs)
  *   - grafana-exploretraces-app      (Explore Traces)
@@ -15,14 +15,15 @@
  * facet click).
  *
  * Every catalog entry MUST be installed in the compose stack — the
- * spec hard-asserts install status. If a future Grafana upgrade drops
- * one of the three apps from the vanilla image, either provision it
- * via `GF_INSTALL_PLUGINS` or remove the entry from the catalog.
+ * spec hard-asserts install status (after a bounded readiness wait,
+ * see `waitForAppInstalled`). If a future Grafana upgrade drops one
+ * of the three apps from the vanilla image, either provision it via
+ * `GF_INSTALL_PLUGINS` or remove the entry from the catalog.
  * `grafana-pyroscope-app` is deliberately not in the catalog because
  * cerberus does not ship profiling.
  *
  * The drilldown-app surface churns hard on every Grafana upgrade —
- * pin the Grafana version (currently `grafana/grafana:11.4.0`, see
+ * pin the Grafana version (currently `grafana/grafana:12.2.9`, see
  * helpers/README.md) and re-audit the click paths in the same PR
  * when bumping.
  */
@@ -39,22 +40,28 @@ export type DrilldownApp = {
 };
 
 // The catalogue lists exactly the drilldown apps the pinned Grafana
-// image can run — the same rule that dropped grafana-pyroscope-app
-// (cerberus doesn't ship profiling). grafana/grafana:11.4.0 ships
-// grafana-lokiexplore-app built in; grafana-metricsdrilldown-app and
-// grafana-exploretraces-app require Grafana >= 11.6 (exploretraces
-// grafanaDependency: ">=11.6.11 <12 || >=12.0.10 …") and cannot run
-// on this image — installing them anyway via GF_INSTALL_PLUGINS
-// bricked the 11.4 frontend and hung the entire k3d Playwright suite
-// on its first navigation (run 27246825822, both attempts: 21 silent
-// minutes after "Running 165 tests"). Restore both entries when the
-// Grafana pin bumps to a release that preinstalls them (12.x) — they
-// are first-party there and need no GF_INSTALL_PLUGINS.
+// image (grafana/grafana:12.2.9) preinstalls first-party — Grafana
+// 12.x hardcodes grafana-lokiexplore-app, grafana-metricsdrilldown-app,
+// and grafana-exploretraces-app in its preinstall list
+// (pkg/setting/setting_plugins.go), so none of them needs
+// GF_INSTALL_PLUGINS. grafana-pyroscope-app stays OUT of the
+// catalogue: cerberus ships no profiling backend, so the app has
+// nothing to drill into.
 export const DRILLDOWN_APPS: ReadonlyArray<DrilldownApp> = [
+  {
+    id: 'grafana-metricsdrilldown-app',
+    root: '/a/grafana-metricsdrilldown-app/trail',
+    label: 'Explore Metrics',
+  },
   {
     id: 'grafana-lokiexplore-app',
     root: '/a/grafana-lokiexplore-app/explore?var-ds=cerberus-loki',
     label: 'Explore Logs',
+  },
+  {
+    id: 'grafana-exploretraces-app',
+    root: '/a/grafana-exploretraces-app/explore',
+    label: 'Explore Traces',
   },
 ];
 
@@ -95,6 +102,38 @@ export async function isAppInstalled(
     return false;
   }
   return parsed.enabled === true;
+}
+
+/**
+ * Bounded readiness wait for the async first-party preinstall flow.
+ *
+ * Grafana 12.x downloads its preinstalled drilldown apps from
+ * grafana.com asynchronously at boot, AFTER `/api/health` already
+ * reports green (grafana/grafana#106871). A spec that probes
+ * `/api/plugins/<id>/settings` right after the stack comes up can
+ * therefore see a transient 404 / `enabled: false` for an app that
+ * will be installed seconds later.
+ *
+ * This helper polls `isAppInstalled` until it reports true or the
+ * deadline expires. It is startup *synchronization* — the same role
+ * `docker compose up --wait` plays for containers — NOT failure
+ * tolerance: callers must still hard-assert the final result, and an
+ * app that never installs within the budget fails exactly as a
+ * never-installed app does.
+ */
+export async function waitForAppInstalled(
+  request: APIRequestContext,
+  baseURL: string,
+  appId: string,
+  timeoutMs = 120_000,
+  pollIntervalMs = 3_000,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (await isAppInstalled(request, baseURL, appId)) return true;
+    if (Date.now() + pollIntervalMs > deadline) return false;
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
 }
 
 /**
@@ -151,9 +190,17 @@ export async function drillTwoLevels(
   const firstAffordance = page
     .locator(
       [
-        // Explore Metrics — metric tile / trail card.
+        // Metrics Drilldown (12.x) — per-metric "Select" action on the
+        // tile grid (testid select-action-<metric_name>, verified live
+        // against grafana/grafana:12.2.9).
+        '[data-testid^="select-action-"]',
+        // Explore Metrics — metric tile / trail card (11.x families,
+        // kept so a selector rename fails loudly here, not silently).
         '[data-testid^="data-testid metric-select"]',
         '[data-testid^="data-testid trail-"]',
+        // Logs Drilldown (12.x) — per-service "Show logs" select button
+        // (verified live against grafana/grafana:12.2.9).
+        '[data-testid="data-testid button-select-service"]',
         // Explore Logs — label chip / detected-label entry.
         '[data-testid^="data-testid detected-label"]',
         '[data-testid^="data-testid label-name"]',
@@ -188,6 +235,11 @@ export async function drillTwoLevels(
   const secondAffordance = page
     .locator(
       [
+        // 12.x families first (see the first-drill union above): a
+        // second select-action drills into a breakdown label; the
+        // include-filter button drills a logs facet.
+        '[data-testid^="select-action-"]',
+        '[data-testid="data-testid button-filter-include"]',
         '[data-testid^="data-testid metric-select"]',
         '[data-testid^="data-testid trail-"]',
         '[data-testid^="data-testid detected-label-value"]',

--- a/test/e2e/playwright/iterate-drilldown-apps.spec.ts
+++ b/test/e2e/playwright/iterate-drilldown-apps.spec.ts
@@ -27,7 +27,7 @@
  * posture buys a 24h buffer before a regression blocks a PR.
  *
  * Grafana version pinning: selectors and per-app root URLs are tied to
- * `grafana/grafana:11.4.0` (the tag pinned in `docker-compose.yml`).
+ * `grafana/grafana:12.2.9` (the tag pinned in `docker-compose.yml`).
  * When the compose stack bumps Grafana, this spec MUST be updated in
  * the same PR — see helpers/README.md "Pinned Grafana version" for
  * the upgrade checklist.
@@ -59,8 +59,8 @@ import {
   captureConsoleErrors,
   captureRoleAlertBanners,
   drillTwoLevels,
-  isAppInstalled,
   iterateDrilldownApps,
+  waitForAppInstalled,
 } from './helpers/index.js';
 
 // Every `role="alert"` banner counts as a failure. No allow-list of
@@ -88,9 +88,13 @@ test('drilldown-apps: each installed drilldown app drills two levels without 4xx
   request,
 }, testInfo) => {
   // Per-app: 1 navigation + 2 click-drills + 3× networkidle settles.
-  // Budget 4 apps × ~90s + a generous headroom for the heaviest app
-  // (Explore-Traces tends to be slowest on a cold ClickHouse) = 8 min.
-  testInfo.setTimeout(8 * 60_000);
+  // Budget 3 apps × ~90s + a generous headroom for the heaviest app
+  // (Explore-Traces tends to be slowest on a cold ClickHouse) plus up
+  // to 120s of async-preinstall readiness wait (the wait is shared in
+  // practice — Grafana downloads all preinstalled apps in one boot
+  // pass, so once the first app reports installed the rest resolve on
+  // their first poll) = 10 min.
+  testInfo.setTimeout(10 * 60_000);
 
   const baseURL =
     process.env.GRAFANA_URL ??
@@ -105,15 +109,19 @@ test('drilldown-apps: each installed drilldown app drills two levels without 4xx
 
   for (const app of apps) {
     // 1. Install-probe — every catalogue entry MUST be installed and
-    //    enabled. A negative probe collects a failure (rather than
-    //    aborting the loop) so the report surfaces every misconfigured
-    //    app in one run.
-    const installed = await isAppInstalled(request, baseURL, app.id);
+    //    enabled. Grafana 12.x preinstalls the drilldown apps via an
+    //    async boot-time download that finishes AFTER /api/health goes
+    //    green, so the probe first synchronizes on the install (bounded
+    //    120s wait — see waitForAppInstalled). After the wait the
+    //    assertion is exactly as hard as before: a negative probe
+    //    collects a failure (rather than aborting the loop) so the
+    //    report surfaces every misconfigured app in one run.
+    const installed = await waitForAppInstalled(request, baseURL, app.id);
     if (!installed) {
       failures.push({
         app: app.id,
         rule: 'app-not-installed-or-disabled',
-        detail: `/api/plugins/${app.id}/settings reports not-installed-or-disabled. Provision the plugin in docker-compose or remove it from the catalogue.`,
+        detail: `/api/plugins/${app.id}/settings reports not-installed-or-disabled (still, after the 120s async-preinstall readiness wait). Provision the plugin in docker-compose or remove it from the catalogue.`,
       });
       perAppOutcomes.push({ app: app.id, outcome: 'not-installed-or-disabled' });
       continue;

--- a/test/spec/traceql/attr_eq_nil.txtar
+++ b/test/spec/traceql/attr_eq_nil.txtar
@@ -1,0 +1,23 @@
+-- query.traceql --
+{ span.http.method = nil }
+-- sql --
+SELECT * FROM `otel_traces` WHERE not(mapContains(`SpanAttributes`, ?))
+-- args --
+[0] string = "http.method"
+-- seed --
+CREATE TABLE otel_traces (
+    SpanId String,
+    SpanAttributes Map(String, String) MATERIALIZED if(SpanId = 'aaaa', map('http.method', 'GET'), map())
+) ENGINE = MergeTree ORDER BY SpanId;
+INSERT INTO otel_traces (SpanId) VALUES
+    ('aaaa'),
+    ('bbbb'),
+    ('cccc');
+-- expected_rows --
+[
+  ["bbbb"],
+  ["cccc"]
+]
+-- chplan --
+Filter predicate=not(mapContains(SpanAttributes, "http.method"))
+  Scan(otel_traces)

--- a/test/spec/traceql/attr_not_nil.txtar
+++ b/test/spec/traceql/attr_not_nil.txtar
@@ -1,0 +1,23 @@
+-- query.traceql --
+{ resource.service.name != nil }
+-- sql --
+SELECT * FROM `otel_traces` WHERE mapContains(`ResourceAttributes`, ?)
+-- args --
+[0] string = "service.name"
+-- seed --
+CREATE TABLE otel_traces (
+    SpanId String,
+    ResourceAttributes Map(String, String) MATERIALIZED if(SpanId != 'bbbb', map('service.name', 'checkout'), map())
+) ENGINE = MergeTree ORDER BY SpanId;
+INSERT INTO otel_traces (SpanId) VALUES
+    ('aaaa'),
+    ('bbbb'),
+    ('cccc');
+-- expected_rows --
+[
+  ["aaaa"],
+  ["cccc"]
+]
+-- chplan --
+Filter predicate=mapContains(ResourceAttributes, "service.name")
+  Scan(otel_traces)

--- a/test/spec/traceql/nested_set_parent_nonroot.txtar
+++ b/test/spec/traceql/nested_set_parent_nonroot.txtar
@@ -1,0 +1,23 @@
+-- query.traceql --
+{ nestedSetParent >= 0 }
+-- sql --
+SELECT * FROM `otel_traces` WHERE (`ParentSpanId` != ?)
+-- args --
+[0] string = ""
+-- seed --
+CREATE TABLE otel_traces (
+    SpanId String,
+    ParentSpanId String
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    ('aaaa', ''),
+    ('bbbb', 'aaaa'),
+    ('cccc', 'bbbb');
+-- expected_rows --
+[
+  ["bbbb", "aaaa"],
+  ["cccc", "bbbb"]
+]
+-- chplan --
+Filter predicate=(ParentSpanId != "")
+  Scan(otel_traces)

--- a/test/spec/traceql/nested_set_parent_root.txtar
+++ b/test/spec/traceql/nested_set_parent_root.txtar
@@ -1,0 +1,24 @@
+-- query.traceql --
+{ nestedSetParent < 0 }
+-- sql --
+SELECT * FROM `otel_traces` WHERE (`ParentSpanId` = ?)
+-- args --
+[0] string = ""
+-- seed --
+CREATE TABLE otel_traces (
+    SpanId String,
+    ParentSpanId String
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    ('aaaa', ''),
+    ('bbbb', 'aaaa'),
+    ('cccc', 'bbbb'),
+    ('dddd', '');
+-- expected_rows --
+[
+  ["aaaa", ""],
+  ["dddd", ""]
+]
+-- chplan --
+Filter predicate=(ParentSpanId = "")
+  Scan(otel_traces)


### PR DESCRIPTION
## Summary

Bumps both stacks **grafana/grafana:11.4.0 → 12.2.9** — the floor where all three drilldown apps (`grafana-lokiexplore-app`, `grafana-exploretraces-app`, `grafana-metricsdrilldown-app`) ship **first-party preinstalled** (`setting_plugins.go` hardcodes them since 12.0) — and restores the 3-app catalogue that 11.4 couldn't run (#741 context). The local verification loop (full 9-spec Playwright suite against the live 12.2.9 compose stack, iterated to green) then exposed **three real cerberus gaps** behind the now-actually-running apps, all fixed at the source:

1. **`GET /loki/api/v1/drilldown-limits`** (upstream grafana/loki#19028): the 12.x Logs Drilldown app fetches it on boot; cerberus 404'd, failing the zero-non-2xx sweep. Implemented with upstream's flat JSON shape, advertising only behaviour cerberus actually implements.
2. **TraceQL `nestedSetParent` root idiom**: was mis-lowered to a `SpanAttributes` map lookup that crashed ClickHouse (`Cannot parse Float64 from String`) on **every** Traces Drilldown query. Root-ness comparisons now lower exactly to `ParentSpanId = ''` / `!= ''`; position-dependent comparisons and `nestedSetLeft/Right` error descriptively at lower time (OTel-CH has no nested-set columns — exact positions are unrepresentable by design). Plus `= nil` / `!= nil` (OpExists/OpNotExists) lowering via `mapContains`. TXTAR fixtures with chDB roundtrips for all four shapes.
3. **`histogram_over_time` wired into `GET /api/metrics/query_range`** (plan+SQL layers already existed; the HTTP envelope didn't) — one series per (group-by, __bucket), matching Tempo's wire shape.

Stack/catalogue mechanics: stale `traceqlSearch` toggle dropped (GA'd, absent from the 12.x registry); `waitForAppInstalled` bounded 120s poll synchronizes on 12.x's **async boot-time preinstall** before the unchanged hard assertions (startup sync, not tolerance — after the wait every catalogue app must be installed or it hard-fails); drill-affordance selectors re-audited against live 12.2.9 (metrics + logs apps now actually drill, were 0-depth); datasource UIDs audited for 12.0's `failWrongDSUID` (all conform).

## Verification

Full 9-spec serial suite green against the live 12.2.9 compose stack (compose_grafana_smoke, panel-shape, histogram-completeness, filter-drill, panel-kiosk, all-dashboards, metrics-explorer, drilldown-apps, helpers), iterated find→fix→re-verify until clean.

## Notes

- exploretraces sweeps clean but reports drill-depth 0 (no matching affordance testids in its breakdown view yet) — selector follow-up noted.
- `histogram_over_time` instant endpoint + gRPC still reject with the existing clear error — follow-up if a consumer needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)