### PR TITLE
fix(startup): serve unready instead of exit(1) when ClickHouse is down at boot + cap CI HPA

### DIFF
--- a/cmd/cerberus/auto_create_integration_test.go
+++ b/cmd/cerberus/auto_create_integration_test.go
@@ -28,7 +28,8 @@ func TestAutoCreateSchema_StartupWiring(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	container, err := tcclickhouse.Run(ctx,
+	container, err := tcclickhouse.Run(
+		ctx,
 		"clickhouse/clickhouse-server:24.8-alpine",
 		tcclickhouse.WithUsername("cerberus"),
 		tcclickhouse.WithPassword("cerberus"),
@@ -50,7 +51,7 @@ func TestAutoCreateSchema_StartupWiring(t *testing.T) {
 		t.Fatalf("port: %v", err)
 	}
 
-	client, err := chclient.New(ctx, chclient.Config{
+	client, err := chclient.New(chclient.Config{
 		Addr:        fmt.Sprintf("%s:%s", host, port.Port()),
 		Database:    "otel",
 		Username:    "cerberus",

--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -95,33 +95,23 @@ func run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	client, err := chclient.New(ctx, cfg.ClickHouse)
+	// Construction is lazy — chclient.New never dials, it only
+	// validates options. An error here is misconfiguration that can
+	// never succeed (fail-fast is correct); connectivity problems
+	// surface on the best-effort Ping below and on /readyz.
+	client, err := chclient.New(cfg.ClickHouse)
 	if err != nil {
-		return fmt.Errorf("connect to clickhouse: %w", err)
+		return fmt.Errorf("configure clickhouse client: %w", err)
 	}
 	defer func() {
 		_ = client.Close()
 	}()
 
-	// schemaReady tracks whether the auto-create-schema startup hook
-	// has finished at least once. When auto-create is off the readiness
-	// probe should not gate on it, so we seed it true.
-	var schemaReady atomic.Bool
-	if cfg.AutoCreateSchema {
-		logger.Info(
-			"auto-creating OTel ClickHouse schema",
-			"database", cfg.ClickHouse.Database,
-			"signals", "metrics,logs,traces",
-		)
-		applyCfg := ddl.Config{Database: cfg.ClickHouse.Database}
-		if err := ddl.ApplyWithConfig(ctx, client.Conn(), applyCfg, ddl.All); err != nil {
-			return fmt.Errorf("auto-create schema: %w", err)
-		}
-		logger.Info("OTel ClickHouse schema ready")
-		schemaReady.Store(true)
-	} else {
-		schemaReady.Store(true)
-	}
+	warnIfClickHouseUnreachable(ctx, logger, client, cfg.ClickHouse)
+
+	// schemaReady reports whether the auto-create-schema startup hook
+	// has finished at least once; /readyz consults it on every probe.
+	schemaReady := setupSchema(ctx, logger, client, cfg.ClickHouse.Database, cfg.AutoCreateSchema)
 
 	// Install the W3C+Baggage propagator and build OTel providers from
 	// the OTLP env config. When CERBERUS_OTLP_ENDPOINT is empty the
@@ -218,7 +208,7 @@ func run() error {
 	// into a single ClickHouse ping per window.
 	healthHandler := health.New(health.Options{
 		Pinger:      client,
-		SchemaReady: schemaReady.Load,
+		SchemaReady: schemaReady,
 	})
 
 	rootMux := http.NewServeMux()
@@ -271,6 +261,113 @@ func run() error {
 	}
 	logger.Info("cerberus stopped")
 	return nil
+}
+
+// warnIfClickHouseUnreachable performs the best-effort startup
+// connectivity validation, demoted to a WARN. A replica that boots
+// while ClickHouse is saturated or still starting (HPA scale-up during
+// a load burst — CI run 27272406583 crash-looped on exactly this) must
+// come up "started but unready": the HTTP listener binds regardless and
+// /readyz keeps the pod out of the Service endpoints until the CH ping
+// succeeds. That is what Kubernetes readiness gating is for — exiting
+// here would just convert a transient dependency outage into a
+// CrashLoopBackOff.
+func warnIfClickHouseUnreachable(ctx context.Context, logger *slog.Logger, client *chclient.Client, cfg chclient.Config) {
+	timeout := cfg.DialTimeout
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+	pingCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	if err := client.Ping(pingCtx); err != nil {
+		logger.Warn(
+			"clickhouse not reachable at startup; serving unready until it appears (/readyz gates traffic)",
+			"addr", cfg.Addr,
+			"err", err,
+		)
+	}
+}
+
+// setupSchema runs the auto-create-schema startup hook (when enabled)
+// and returns the SchemaReadyFunc the /readyz handler consults. When
+// auto-create is off, readiness must not gate on it, so the returned
+// func reports true immediately. When the first apply fails — the same
+// incident class as the startup ping above: the DDL templates are
+// static and covered by integration tests, so a failure here is
+// overwhelmingly "ClickHouse isn't up yet" — the apply retries in the
+// background and /readyz reports schema "pending" instead of the
+// process exiting.
+func setupSchema(
+	ctx context.Context,
+	logger *slog.Logger,
+	client *chclient.Client,
+	database string,
+	autoCreate bool,
+) health.SchemaReadyFunc {
+	ready := new(atomic.Bool)
+	if !autoCreate {
+		ready.Store(true)
+		return ready.Load
+	}
+	logger.Info(
+		"auto-creating OTel ClickHouse schema",
+		"database", database,
+		"signals", "metrics,logs,traces",
+	)
+	applyCfg := ddl.Config{Database: database}
+	apply := func(ctx context.Context) error {
+		return ddl.ApplyWithConfig(ctx, client.Conn(), applyCfg, ddl.All)
+	}
+	if err := apply(ctx); err != nil {
+		logger.Warn(
+			"auto-create schema failed at startup; retrying in background (/readyz reports schema pending)",
+			"err", err,
+		)
+		go retrySchemaApply(ctx, logger, ready, schemaRetryInterval, apply)
+		return ready.Load
+	}
+	logger.Info("OTel ClickHouse schema ready")
+	ready.Store(true)
+	return ready.Load
+}
+
+// schemaRetryInterval is the cadence of background auto-create-schema
+// retries after a failed startup attempt. 5s sits between the /readyz
+// probe period (3s) and the readiness TTL cache (2s): a recovering
+// ClickHouse is picked up within roughly two probe periods without
+// hammering a server that is still coming up.
+const schemaRetryInterval = 5 * time.Second
+
+// retrySchemaApply re-runs the auto-create-schema hook until it
+// succeeds once or ctx is cancelled (SIGTERM / process shutdown). On
+// success it flips ready, which the /readyz handler consults — until
+// then the pod reports schema "pending" and stays out of the Service
+// endpoints. Failures stay WARNs: a booting replica must not exit(1)
+// because ClickHouse isn't accepting connections yet (CI run
+// 27272406583 crash-looped a scale-up replica on exactly that).
+func retrySchemaApply(
+	ctx context.Context,
+	logger *slog.Logger,
+	ready *atomic.Bool,
+	interval time.Duration,
+	apply func(context.Context) error,
+) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+		if err := apply(ctx); err != nil {
+			logger.Warn("auto-create schema retry failed", "err", err)
+			continue
+		}
+		logger.Info("OTel ClickHouse schema ready")
+		ready.Store(true)
+		return
+	}
 }
 
 // buildDualStackServer wires an http.Server that serves HTTP/1.1 (for

--- a/cmd/cerberus/startup_test.go
+++ b/cmd/cerberus/startup_test.go
@@ -1,0 +1,227 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/api/health"
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+// Startup-resilience tests for the "ClickHouse down at boot" incident
+// class (CI run 27272406583, job 80544908938): an HPA scale-up replica
+// that booted while ClickHouse was saturated exited(1) on
+// `dial tcp …:9000: connect: connection refused` and crash-looped.
+// The contract pinned here is the k8s-idiomatic one:
+//
+//   - process construction succeeds with CH unreachable (chclient.New
+//     is lazy — no startup dial is fatal),
+//   - the HTTP listener serves /healthz 200 regardless,
+//   - /readyz reports 503 until ClickHouse appears, then flips to 200,
+//   - the auto-create-schema hook retries in the background instead of
+//     exiting, flipping schemaReady on its first success.
+//
+// run() itself is not directly callable (see lifecycle_test.go for the
+// rationale); these tests exercise the exact building blocks run()
+// composes, using the same wiring shapes.
+
+// unreachableAddr returns a 127.0.0.1 address that is guaranteed to
+// refuse connections: it binds an ephemeral port, then closes the
+// listener so the kernel RSTs any subsequent dial.
+func unreachableAddr(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	if err := ln.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	return addr
+}
+
+// TestStartup_CHDownAtBoot_ClientConstructionSucceeds pins the lazy
+// chclient.New contract main.go depends on: with nothing listening on
+// the CH address, construction must succeed (no exit(1) path) while
+// Ping — the readiness signal — fails.
+func TestStartup_CHDownAtBoot_ClientConstructionSucceeds(t *testing.T) {
+	client, err := chclient.New(chclient.Config{
+		Addr:        unreachableAddr(t),
+		Database:    "otel",
+		DialTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("chclient.New with unreachable CH must not fail-fast; got %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := client.Ping(ctx); err == nil {
+		t.Fatal("Ping against an unreachable ClickHouse must error (it is the readiness signal)")
+	}
+}
+
+// TestStartup_CHDownAtBoot_HealthzUpReadyzUnready wires the same
+// root-mux shape run() builds — health handler mounted next to the API
+// mux — against a client whose CH is down, and pins the probe split:
+// liveness (/healthz) 200, readiness (/readyz) 503. This is "started
+// but unready": k8s keeps the pod alive and out of the Service
+// endpoints instead of restart-looping it.
+func TestStartup_CHDownAtBoot_HealthzUpReadyzUnready(t *testing.T) {
+	client, err := chclient.New(chclient.Config{
+		Addr:        unreachableAddr(t),
+		Database:    "otel",
+		DialTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("chclient.New: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	var schemaReady atomic.Bool
+	schemaReady.Store(true) // auto-create off — only the CH ping gates
+
+	healthHandler := health.New(health.Options{
+		Pinger:      client,
+		SchemaReady: schemaReady.Load,
+		CacheTTL:    -1, // no coalescing in tests
+	})
+	rootMux := http.NewServeMux()
+	healthHandler.Mount(rootMux)
+
+	srv := httptest.NewServer(rootMux)
+	t.Cleanup(srv.Close)
+
+	gotHealthz := getStatus(t, srv.URL+"/healthz")
+	if gotHealthz != http.StatusOK {
+		t.Errorf("/healthz with CH down = %d; want 200 (liveness must not depend on CH)", gotHealthz)
+	}
+	gotReadyz := getStatus(t, srv.URL+"/readyz")
+	if gotReadyz != http.StatusServiceUnavailable {
+		t.Errorf("/readyz with CH down = %d; want 503", gotReadyz)
+	}
+}
+
+// flipPinger fails until healthy is set — the minimal stand-in for
+// "ClickHouse appears after the replica booted".
+type flipPinger struct {
+	healthy atomic.Bool
+}
+
+func (f *flipPinger) Ping(context.Context) error {
+	if f.healthy.Load() {
+		return nil
+	}
+	return errors.New("dial tcp 10.0.0.1:9000: connect: connection refused")
+}
+
+// TestStartup_ReadyzFlipsReadyOnceCHAppears pins the recovery half of
+// the contract: a replica that booted unready must flip /readyz to 200
+// as soon as the CH ping succeeds — no restart required.
+func TestStartup_ReadyzFlipsReadyOnceCHAppears(t *testing.T) {
+	pinger := &flipPinger{}
+	healthHandler := health.New(health.Options{
+		Pinger:   pinger,
+		CacheTTL: -1, // each probe re-pings, so the flip is observed immediately
+	})
+	rootMux := http.NewServeMux()
+	healthHandler.Mount(rootMux)
+
+	srv := httptest.NewServer(rootMux)
+	t.Cleanup(srv.Close)
+
+	if got := getStatus(t, srv.URL+"/readyz"); got != http.StatusServiceUnavailable {
+		t.Fatalf("/readyz before CH appears = %d; want 503", got)
+	}
+
+	pinger.healthy.Store(true)
+
+	if got := getStatus(t, srv.URL+"/readyz"); got != http.StatusOK {
+		t.Errorf("/readyz after CH appears = %d; want 200", got)
+	}
+}
+
+// TestRetrySchemaApply_FlipsReadyAfterTransientFailures pins the
+// background auto-create-schema retry loop: apply failures (CH still
+// booting) are retried on the interval, and the first success flips
+// the ready flag /readyz consults — without ever returning an error
+// that would tear the process down.
+func TestRetrySchemaApply_FlipsReadyAfterTransientFailures(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var ready atomic.Bool
+	var attempts atomic.Int32
+	apply := func(context.Context) error {
+		if attempts.Add(1) < 3 {
+			return errors.New("dial tcp 10.0.0.1:9000: connect: connection refused")
+		}
+		return nil
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		retrySchemaApply(ctx, slog.New(slog.DiscardHandler), &ready, time.Millisecond, apply)
+	}()
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		t.Fatal("retrySchemaApply did not return after a successful apply")
+	}
+	if !ready.Load() {
+		t.Error("ready = false after successful apply; want true")
+	}
+	if got := attempts.Load(); got != 3 {
+		t.Errorf("attempts = %d; want 3 (two transient failures, then success)", got)
+	}
+}
+
+// TestRetrySchemaApply_StopsOnContextCancel pins shutdown behavior: a
+// SIGTERM (ctx cancel) must end the retry loop promptly without
+// flipping ready.
+func TestRetrySchemaApply_StopsOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var ready atomic.Bool
+	apply := func(context.Context) error {
+		return errors.New("dial tcp 10.0.0.1:9000: connect: connection refused")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		retrySchemaApply(ctx, slog.New(slog.DiscardHandler), &ready, time.Millisecond, apply)
+	}()
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("retrySchemaApply did not stop after context cancel")
+	}
+	if ready.Load() {
+		t.Error("ready = true after cancellation; want false (apply never succeeded)")
+	}
+}
+
+// getStatus GETs url and returns the status code.
+func getStatus(t *testing.T, url string) int {
+	t.Helper()
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	return resp.StatusCode
+}

--- a/docs/health.md
+++ b/docs/health.md
@@ -132,7 +132,28 @@ on the very next merge.
 When `CERBERUS_AUTO_CREATE_SCHEMA=true`, the startup hook that applies
 the OTel ClickHouse DDL runs synchronously **before** the listener
 binds, so both probes wait for the schema to be ready; in that mode the
-< 2 s budget no longer applies (DDL apply time dominates).
+< 2 s budget no longer applies (DDL apply time dominates). If that
+first apply fails (typically: ClickHouse not up yet), cerberus does
+**not** exit — the listener binds anyway and the apply is retried in
+the background every 5 s; `/readyz` reports `"schema":"pending"` until
+the first success.
+
+## ClickHouse down at boot
+
+An unreachable ClickHouse never prevents startup. The connection pool
+is constructed lazily (no dial), the startup connectivity ping is
+demoted to a WARN log, and the process serves immediately:
+
+- `/healthz` → `200` (the process is alive),
+- `/readyz` → `503` (the CH ping fails),
+
+flipping `/readyz` to `200` as soon as ClickHouse answers — no restart
+needed. This is the readiness-gating contract Kubernetes expects: a
+replica scaled up while ClickHouse is saturated (CI run 27272406583
+crash-looped on exactly this) waits out the outage out of the Service
+endpoints instead of converting it into a CrashLoopBackOff. Fail-fast
+remains for misconfiguration that can never succeed (bad env values,
+invalid connection options).
 
 ## Implementation pointers
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -165,6 +165,17 @@ every request becomes a server span. Optionally, when
 `CERBERUS_AUTO_CREATE_SCHEMA=true`, the OTel-CH DDL is applied before
 serving begins so the readiness probe doesn't gate on missing tables.
 
+An **unreachable ClickHouse at boot is not fatal**: construction of the
+connection pool is lazy (no dial), the startup connectivity ping is a
+best-effort WARN, and a failed first DDL apply falls back to a
+background retry loop. The replica comes up "started but unready" —
+`/healthz` 200, `/readyz` 503 — and flips ready as soon as ClickHouse
+answers, which is exactly the contract Kubernetes readiness gating
+expects (a scale-up replica booting into a saturated CH must not
+crash-loop; see [`health.md`](health.md)). Fail-fast is reserved for
+misconfiguration that can never succeed — a bad env value or invalid
+connection options abort startup with a clear error.
+
 ### Shutdown
 
 On `SIGINT` or `SIGTERM`, cerberus:

--- a/internal/chclient/client.go
+++ b/internal/chclient/client.go
@@ -115,9 +115,23 @@ type Client struct {
 	maxSamples int64
 }
 
-// New opens a connection pool to ClickHouse and pings it once to confirm
-// reachability. The returned Client is safe for concurrent use.
-func New(ctx context.Context, cfg Config) (*Client, error) {
+// New opens a connection pool to ClickHouse. Construction is lazy:
+// clickhouse.Open only validates options and never dials, so New
+// succeeds even when ClickHouse is unreachable — the first Ping/Query
+// performs the actual dial. That is deliberate: a cerberus replica that
+// boots while ClickHouse is saturated or still starting (e.g. an HPA
+// scale-up during a load burst — CI run 27272406583) must come up
+// "started but unready" and let /readyz gate traffic, not exit(1) and
+// crash-loop on `dial tcp …:9000: connect: connection refused`.
+//
+// Fail-fast is preserved for misconfiguration that can never succeed:
+// clickhouse.Open's option validation errors are returned as-is.
+// Connectivity validation belongs to the caller (cmd/cerberus does a
+// best-effort startup Ping demoted to a WARN log) and to the readiness
+// probe (internal/api/health pings via this Client).
+//
+// The returned Client is safe for concurrent use.
+func New(cfg Config) (*Client, error) {
 	dial := cfg.DialTimeout
 	if dial == 0 {
 		dial = 5 * time.Second
@@ -133,11 +147,6 @@ func New(ctx context.Context, cfg Config) (*Client, error) {
 	})
 	if err != nil {
 		return nil, fmt.Errorf("chclient: open: %w", err)
-	}
-	pingCtx, cancel := context.WithTimeout(ctx, dial)
-	defer cancel()
-	if err := conn.Ping(pingCtx); err != nil {
-		return nil, fmt.Errorf("chclient: ping %s: %w", cfg.Addr, err)
 	}
 	return &Client{conn: conn, addr: cfg.Addr, maxSamples: cfg.MaxQuerySamples}, nil
 }
@@ -157,9 +166,9 @@ func (c *Client) Conn() driver.Conn {
 // to drive the cursor / Exec / Query paths against a fault-injecting fake
 // driver.Conn without standing up a real ClickHouse server.
 //
-// Production callers MUST use New, which goes through clickhouse.Open and
-// performs the connectivity Ping. This constructor bypasses both — it is
-// unexported and intentionally narrow.
+// Production callers MUST use New, which goes through clickhouse.Open's
+// option validation. This constructor bypasses it — it is unexported and
+// intentionally narrow.
 //
 //nolint:revive // test-only seam; production code must use New.
 func newWithConn(conn driver.Conn) *Client {

--- a/internal/chclient/client_integration_test.go
+++ b/internal/chclient/client_integration_test.go
@@ -22,7 +22,8 @@ func TestQuery_E2E(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	container, err := tcclickhouse.Run(ctx,
+	container, err := tcclickhouse.Run(
+		ctx,
 		"clickhouse/clickhouse-server:24.8-alpine",
 		tcclickhouse.WithUsername("cerberus"),
 		tcclickhouse.WithPassword("cerberus"),
@@ -44,7 +45,7 @@ func TestQuery_E2E(t *testing.T) {
 		t.Fatalf("port: %v", err)
 	}
 
-	client, err := chclient.New(ctx, chclient.Config{
+	client, err := chclient.New(chclient.Config{
 		Addr:     host + ":" + port.Port(),
 		Database: "otel",
 		Username: "cerberus",
@@ -75,7 +76,8 @@ func TestQuery_E2E(t *testing.T) {
 		t.Fatalf("insert: %v", err)
 	}
 
-	samples, err := client.Query(ctx,
+	samples, err := client.Query(
+		ctx,
 		"SELECT MetricName, Attributes, TimeUnix, Value FROM otel_metrics_gauge WHERE MetricName = ? ORDER BY Value DESC",
 		"up",
 	)

--- a/test/e2e/k3s/README.md
+++ b/test/e2e/k3s/README.md
@@ -98,7 +98,11 @@ autoscaler up alongside everything else.
 
 Defaults:
 
-- `minReplicas: 2`, `maxReplicas: 10`.
+- `minReplicas: 2`, `maxReplicas: 4`. The ceiling is a **CI** bound:
+  the 16GB/4vCPU GitHub runner cannot back 10 × 1Gi of cerberus burst
+  next to ClickHouse + collector + Grafana + Playwright (run
+  27272406583 saturated CH that way). Production ceilings belong in
+  production overlays.
 - Scales on **CPU utilisation** at 70% of the pod's CPU request. The
   standard `metrics-server` is the only dependency (already present
   in k3d/k3s). No prometheus-adapter, no prometheus-operator.
@@ -117,14 +121,15 @@ kubectl -n cerberus describe hpa cerberus
 ```
 
 The output should show `TARGETS  70%/<current>%` and
-`MINPODS  2`, `MAXPODS  10`. If `TARGETS` is `<unknown>/70%`,
+`MINPODS  2`, `MAXPODS  4`. If `TARGETS` is `<unknown>/70%`,
 metrics-server has not reported yet — give it 60 seconds after the
 pods become Ready.
 
 ### Tuning
 
-- **Bigger ceiling** — raise `maxReplicas` once the upstream
-  ClickHouse cluster can absorb the parallel query load.
+- **Bigger ceiling** — raise `maxReplicas` in a production overlay
+  once the upstream ClickHouse cluster can absorb the parallel query
+  load; this manifest's value is sized for the CI runner.
 - **Quieter scale-down** — increase `scaleDown.stabilizationWindowSeconds`
   for workloads with predictable diurnal dips.
 - **Load-aware scaling** — see the commented block at the bottom of

--- a/test/e2e/k3s/cerberus-hpa.yaml
+++ b/test/e2e/k3s/cerberus-hpa.yaml
@@ -20,10 +20,19 @@
 # Replica bounds:
 #   - minReplicas: 2 — survives a single-pod failure (rolling restarts,
 #     node drains, OOM kills) without dropping below one healthy pod.
-#   - maxReplicas: 10 — conservative ceiling. Operators with larger
-#     ClickHouse clusters can lift this; the gateway itself is cheap
-#     (~64Mi memory request) but the upstream CH cluster must absorb
-#     the parallel query load.
+#   - maxReplicas: 4 — the CI ceiling, not a product recommendation
+#     (production ceilings belong in production overlays). This manifest
+#     runs on a 16GB/4vCPU GitHub runner where the k3d node advertises
+#     the FULL host memory, so the scheduler happily places pods the
+#     host cannot back: each cerberus pod requests only 128Mi but is
+#     limited at 1Gi, so the old maxReplicas: 10 allowed up to 10Gi of
+#     cerberus burst next to ClickHouse + the collector + Grafana +
+#     Playwright — host-level overcommit with nothing else preventing
+#     it. Run 27272406583 hit exactly that: the load burst scaled
+#     cerberus out until ClickHouse was saturated/starved and the
+#     freshest replica crash-looped against it. 4 × 1Gi keeps the
+#     worst-case cerberus footprint within what the runner can actually
+#     serve alongside the rest of the stack.
 #
 # Scale behaviour:
 #   - Scale-up is fast: at most 3 pods per 60s window, with a 30s
@@ -43,7 +52,8 @@ spec:
     kind: Deployment
     name: cerberus
   minReplicas: 2
-  maxReplicas: 10
+  # CI ceiling — see the "Replica bounds" note above (run 27272406583).
+  maxReplicas: 4
   metrics:
     - type: Resource
       resource:


### PR DESCRIPTION
## Summary

The last zero-restart-gate tripper. Post-#746 dashboard runs (27272406583, 27272745146) show the OOM class closed (zero `OOMKilled`, restarts down 9 → 2) — the residual is cerberus's startup validation ping fail-fasting when a scale-up replica boots against a saturated/unready ClickHouse:

```
cerberus exited with error: connect to clickhouse: chclient: ping clickhouse:9000: dial tcp …:9000: connect: connection refused
```

Exit(1) at boot turns a transient dependency wobble into a CrashLoopBackOff exactly when the HPA is adding capacity.

## Changes

- **Startup**: the boot-time CH ping no longer kills the process — the HTTP listener comes up, the failure logs as WARN, and `/readyz` (which already pings CH) gates traffic: a booting replica is *started-but-unready*, which is precisely what k8s readiness semantics are for. Misconfiguration that can never succeed (bad address syntax) still fails fast. `cmd/cerberus/startup_test.go` pins the contract: CH down at boot → process up, `/healthz` 200, `/readyz` not-ready; CH appears → `/readyz` flips ready.
- **CI HPA cap**: `maxReplicas` 10 → 4 in the k3d manifest — 10 × 1Gi over-commits the 16GB/4vCPU runner (the k3d node advertises full host memory; nothing else prevents host-level overcommit). Production ceilings belong in production overlays. Evidence: run 27272406583 hit 6 replicas during the saturation spiral.
- docs/health.md + docs/operations.md updated for the new startup posture.

## Test plan

- [ ] `check` green (startup contract tests)
- [ ] dashboard job on the merge push passes **the zero-restart gate** — with OOM (#746) and startup fail-fast (this PR) both closed, restarts should finally be 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)