### PR TITLE
fix(compat/loki): honest denominator — revive 8 silently-dropped bench cases + fix the 2 real bugs they exposed

### DIFF
--- a/compatibility/loki/cmd/loki-compliance-tester/main.go
+++ b/compatibility/loki/cmd/loki-compliance-tester/main.go
@@ -258,6 +258,9 @@ func loadCases(f flags, isInstant bool) ([]loadedCase, error) {
 			})
 			continue
 		}
+		if err := checkExpansion(def, len(expanded)); err != nil {
+			return nil, err
+		}
 		for _, tc := range expanded {
 			cases = append(cases, loadedCase{def: def, tc: tc})
 		}
@@ -277,6 +280,26 @@ func loadCases(f flags, isInstant bool) ([]loadedCase, error) {
 		cases = filtered
 	}
 	return cases, nil
+}
+
+// checkExpansion is the zero-expansion rail: a corpus query definition
+// that expands to zero test cases would silently vanish from the score
+// denominator — exactly what happened when the vendored registry
+// defaulted Directions before Kind and eight metric-shaped definitions
+// in exhaustive/aggregations.yaml expanded to nothing, invisible to
+// both the score and the upstream-skip baseline. Every definition the
+// driver loads (runnable by default; upstream-skipped too under
+// -include-skipped) must contribute at least one case, so a regression
+// here is a hard error naming the definition, not a quietly smaller
+// total.
+func checkExpansion(def bench.QueryDefinition, n int) error {
+	if n > 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"query definition %q (%s) expanded to zero test cases (kind=%q directions=%q); refusing to run with a silently shrunken corpus",
+		def.Description, def.Source, def.Kind, def.Directions,
+	)
 }
 
 // loadAllQueriesAndSplit reuses the bench registry to load every

--- a/compatibility/loki/cmd/loki-compliance-tester/main_test.go
+++ b/compatibility/loki/cmd/loki-compliance-tester/main_test.go
@@ -5,6 +5,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/grafana/loki/v3/pkg/logproto"
 
 	bench "github.com/tsouza/cerberus/compatibility/loki/upstream/loki-bench"
 )
@@ -76,6 +79,95 @@ func TestScoreCounts_Empty(t *testing.T) {
 	passed, total := scoreCounts(nil)
 	if passed != 0 || total != 0 {
 		t.Fatalf("(passed, total) = (%d, %d), want (0, 0)", passed, total)
+	}
+}
+
+// TestCheckExpansion pins the zero-expansion rail: a definition that
+// expands to zero cases is a hard error naming the definition, while
+// any positive expansion passes. The rail exists because the vendored
+// registry once defaulted Directions before Kind, expanding eight
+// metric-shaped exhaustive/aggregations.yaml definitions to zero cases
+// — invisible to both the score denominator and the skip baseline.
+func TestCheckExpansion(t *testing.T) {
+	t.Parallel()
+	def := bench.QueryDefinition{
+		Description: "ghost query",
+		Source:      "exhaustive/aggregations.yaml:177",
+		Kind:        "log",
+	}
+	err := checkExpansion(def, 0)
+	if err == nil {
+		t.Fatalf("checkExpansion(n=0) = nil, want hard error")
+	}
+	for _, want := range []string{"ghost query", "exhaustive/aggregations.yaml:177", "zero test cases"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q missing %q", err.Error(), want)
+		}
+	}
+	for _, n := range []int{1, 2} {
+		if err := checkExpansion(def, n); err != nil {
+			t.Fatalf("checkExpansion(n=%d) = %v, want nil", n, err)
+		}
+	}
+}
+
+// TestLoadCases_FullCorpusExpansion loads the real vendored corpus +
+// dataset metadata through the same path the driver uses and pins the
+// honest denominator: every runnable definition expands to at least
+// one case, and the eight kind-less metric-shaped definitions in
+// exhaustive/aggregations.yaml each contribute exactly one forward
+// metric case carrying the YAML's 1m step. Before the registry's
+// kind-before-directions defaulting fix the corpus expanded to 78
+// cases with those eight silently absent; the fixed total is 86.
+func TestLoadCases_FullCorpusExpansion(t *testing.T) {
+	t.Parallel()
+	f := flags{
+		corpusDir:   filepath.Join("..", "..", "upstream", "loki-bench", "queries"),
+		metadataDir: filepath.Join("..", ".."),
+		seed:        42,
+	}
+	cases, err := loadCases(f, false)
+	if err != nil {
+		t.Fatalf("loadCases: %v", err)
+	}
+	if len(cases) != 86 {
+		t.Fatalf("corpus expanded to %d cases, want 86", len(cases))
+	}
+
+	revived := []string{
+		"Loki duration unwrap with logfmt",
+		"Max of min duration by level",
+		"Avg duration by level",
+		"Max avg duration without grouping",
+		"Max avg duration by level without service_name",
+		"Max sum without grouping modifier",
+		"Avg duration without grouping",
+		"Sum duration without outer aggregation",
+	}
+	byDesc := make(map[string][]bench.TestCase)
+	for _, lc := range cases {
+		if lc.expandErr != nil {
+			t.Fatalf("expansion error for %q: %v", lc.def.Description, lc.expandErr)
+		}
+		if strings.HasPrefix(lc.def.Source, "exhaustive/aggregations.yaml") {
+			byDesc[lc.def.Description] = append(byDesc[lc.def.Description], lc.tc)
+		}
+	}
+	for _, desc := range revived {
+		tcs := byDesc[desc]
+		if len(tcs) != 1 {
+			t.Fatalf("definition %q expanded to %d cases, want exactly 1 (metric, forward)", desc, len(tcs))
+		}
+		tc := tcs[0]
+		if got := tc.Kind(); got != "metric" {
+			t.Fatalf("definition %q resolved to kind %q, want metric (query=%s)", desc, got, tc.Query)
+		}
+		if tc.Direction != logproto.FORWARD {
+			t.Fatalf("definition %q direction = %v, want FORWARD", desc, tc.Direction)
+		}
+		if tc.Step != time.Minute {
+			t.Fatalf("definition %q step = %v, want 1m (from the YAML time_range.step)", desc, tc.Step)
+		}
 	}
 }
 

--- a/compatibility/loki/loki-config.yaml
+++ b/compatibility/loki/loki-config.yaml
@@ -69,6 +69,20 @@ limits_config:
   max_streams_per_user: 0
   max_query_parallelism: 32
 
+# Disable the ingester WAL's host-disk-usage throttle. The default
+# (`-ingester.wal-disk-full-threshold=0.90`) rejects every /push with
+# `500: Ingester is shutting down` once the HOST disk crosses 90% —
+# the check reads the container filesystem's usage, which mirrors the
+# host. A hermetic differential stack ingesting a ~19k-line ephemeral
+# fixture must not change behaviour based on how full the developer's
+# (or runner's) disk happens to be; the throttle exists to protect
+# long-lived production WALs, not a compose stack that is torn down
+# minutes after it starts. Setting 0 disables the check (upstream-
+# documented semantics).
+ingester:
+  wal:
+    disk_full_threshold: 0
+
 ruler:
   alertmanager_url: http://localhost:9093
 

--- a/compatibility/loki/upstream/loki-bench/VERSION
+++ b/compatibility/loki/upstream/loki-bench/VERSION
@@ -13,6 +13,21 @@ upstream_repo:     github.com/grafana/loki
 upstream_tag:      v3.7.0
 upstream_commit:   3361de24b692875d77bd7433cd6baa7c68dc0ef9
 
+local_patches:
+  # query_registry.go: loadFile() defaults Kind BEFORE Directions and
+  # infers a missing `kind` from the query shape (inferQueryKind, via
+  # syntax.ParseExpr on a placeholder-substituted query). Upstream
+  # (verified identical on grafana/loki main as of 2026-06-10) defaults
+  # Directions first, gated on `Kind == "log"`, so a definition with
+  # neither `kind` nor `directions` gets Directions="" and ExpandQuery
+  # emits ZERO test cases — eight metric-shaped definitions in
+  # queries/exhaustive/aggregations.yaml silently vanished from the
+  # corpus. Candidate for an upstream contribution; re-apply (or drop,
+  # if upstream fixed it) on the next snapshot bump. The driver's
+  # zero-expansion rail (cmd/loki-compliance-tester checkExpansion)
+  # hard-fails if a bump reintroduces the bug.
+  - query_registry.go
+
 vendored_paths:
   - pkg/logql/bench/queries/fast/*.yaml
   # PR 6 (docs/loki-compliance-plan.md) widened the corpus to include

--- a/compatibility/loki/upstream/loki-bench/query_registry.go
+++ b/compatibility/loki/upstream/loki-bench/query_registry.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
 )
 
 // QueryDirection specifies which direction(s) to run a log query
@@ -203,13 +204,26 @@ func (r *QueryRegistry) loadFile(filePath string, suite Suite, fileName string) 
 		}
 		q.Source = fmt.Sprintf("%s/%s:%d", suite, fileName, lineNum)
 
+		// Default kind BEFORE directions. [cerberus patch, diverges from
+		// the upstream v3.7.0 snapshot — see upstream/loki-bench/VERSION]
+		// Upstream defaults Directions first (gated on `q.Kind == "log"`)
+		// and only then defaults an empty Kind to "log". A definition
+		// that declares neither `kind` nor `directions` therefore ends
+		// up with Kind="log" but Directions="" — and ExpandQuery's
+		// direction switch matches no case, expanding the definition to
+		// ZERO test cases. Eight metric-shaped definitions in
+		// exhaustive/aggregations.yaml hit exactly that and silently
+		// vanished from the corpus. Instead of blindly defaulting to
+		// "log" (the schema.json default), infer the kind from the query
+		// shape, mirroring TestCase.Kind(): metric queries must expand to
+		// a single forward case carrying the step.
+		if q.Kind != "metric" && q.Kind != "log" {
+			q.Kind = inferQueryKind(q.Query)
+		}
+
 		// Default directions to "both" for log queries
 		if q.Directions == "" && q.Kind == "log" {
 			q.Directions = DirectionBoth
-		}
-
-		if q.Kind == "" || (q.Kind != "metric" && q.Kind != "log") {
-			q.Kind = "log"
 		}
 
 		// Validate time range
@@ -234,6 +248,34 @@ func (r *QueryRegistry) loadFile(filePath string, suite Suite, fileName string) 
 	}
 
 	return queryFile.Queries, nil
+}
+
+// queryKindPlaceholders substitutes the corpus's template placeholders
+// with syntactically valid LogQL fragments so a still-templated query
+// can be parsed for kind inference before variable resolution happens.
+// The dummy values never reach the wire — they exist only to make
+// syntax.ParseExpr accept the query shape.
+var queryKindPlaceholders = strings.NewReplacer(
+	"${SELECTOR}", `{placeholder="x"}`,
+	"${RANGE}", "5m",
+	"${LABEL_NAME}", "placeholder",
+	"${LABEL_VALUE}", "x",
+)
+
+// inferQueryKind classifies a query definition as "metric" or "log" by
+// parsing the placeholder-substituted query, mirroring TestCase.Kind()
+// (which runs the same SampleExpr check on the resolved query). Falls
+// back to "log" — the schema.json default — when the query does not
+// parse even after substitution.
+func inferQueryKind(query string) string {
+	expr, err := syntax.ParseExpr(queryKindPlaceholders.Replace(query))
+	if err != nil {
+		return "log"
+	}
+	if _, ok := expr.(syntax.SampleExpr); ok {
+		return "metric"
+	}
+	return "log"
 }
 
 // extractQueryLineNumbers extracts line numbers for each query in the YAML
@@ -362,7 +404,8 @@ func (r *QueryRegistry) ExpandQuery(def QueryDefinition, resolver VariableResolv
 				Tags:      def.Tags,
 			})
 		case DirectionBoth:
-			cases = append(cases,
+			cases = append(
+				cases,
 				TestCase{
 					Query:     resolvedQuery,
 					Start:     start,

--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -569,6 +569,16 @@ func (b *Builder) exprMapAccess(m *chplan.MapAccess) error {
 }
 
 func (b *Builder) exprMapWithoutKeys(m *chplan.MapWithoutKeys) error {
+	// Zero keys is the identity: emit the map directly. The degenerate
+	// `mapFilter((k, v) -> NOT (k IN ()), m)` is invalid ClickHouse —
+	// CH rejects an empty IN list with "Function 'in' is supported only
+	// if second argument is constant or table expression". LogQL
+	// `max without () (...)` / PromQL `sum without() (...)` reach this
+	// shape with an empty exclusion set, which by upstream semantics
+	// groups by the full label set.
+	if len(m.Keys) == 0 {
+		return b.Expr(m.Map)
+	}
 	b.sb.WriteString("mapFilter((k, v) -> NOT (k IN (")
 	for i, k := range m.Keys {
 		if i > 0 {

--- a/internal/chsql/emit_test.go
+++ b/internal/chsql/emit_test.go
@@ -252,6 +252,26 @@ var plans = map[string]chplan.Node{
 		},
 	},
 
+	// MapWithoutKeys with ZERO keys: LogQL `max without () (...)` /
+	// PromQL `sum without() (...)`. Stripping nothing is the identity —
+	// the emitter must render the bare map, never a degenerate
+	// `mapFilter((k, v) -> NOT (k IN ()), ...)` (ClickHouse rejects the
+	// empty IN list with "Function 'in' is supported only if second
+	// argument is constant or table expression" — loki-compat
+	// exhaustive/aggregations.yaml#Max sum without grouping modifier).
+	"aggregate_sum_without_empty": &chplan.Aggregate{
+		Input: &chplan.Scan{Table: "otel_metrics_gauge"},
+		GroupBy: []chplan.Expr{
+			&chplan.MapWithoutKeys{
+				Map:  &chplan.ColumnRef{Name: "Attributes"},
+				Keys: nil,
+			},
+		},
+		AggFuncs: []chplan.AggFunc{
+			{Name: "sum", Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}, Alias: "total"},
+		},
+	},
+
 	// Aggregate with parameterised CH aggregate: quantile(0.95)(value).
 	"aggregate_quantile_param": &chplan.Aggregate{
 		Input: &chplan.Scan{Table: "otel_metrics_gauge"},

--- a/internal/logql/range_aggregation.go
+++ b/internal/logql/range_aggregation.go
@@ -71,11 +71,6 @@ func lowerRangeAggregation(e *syntax.RangeAggregationExpr, s schema.Logs, lc low
 		return nil, err
 	}
 
-	groupBy, err := rangeAggregationGroupBy(e, s)
-	if err != nil {
-		return nil, err
-	}
-
 	// Default identity: the raw ResourceAttributes column, augmented with
 	// the synthesized `detected_level` label so each distinct severity
 	// becomes its own series. Loki's stream-identity contract includes
@@ -138,6 +133,22 @@ func lowerRangeAggregation(e *syntax.RangeAggregationExpr, s schema.Logs, lc low
 		// since RA is a plain column reference.
 		identityBase = &chplan.MapWithoutKeys{Map: labelsExpr, Keys: []string{e.Left.Unwrap.Identifier}}
 	}
+	// The grouping key is computed AGAINST identityBase — the full
+	// series identity (parser-merged labels minus the unwrap target
+	// when applicable) — not against the raw ResourceAttributes column.
+	// `without (service_name)` on `avg_over_time({...} | logfmt |
+	// unwrap duration_seconds(duration) [5m])` must keep every
+	// logfmt-extracted label (level, status, ...) in the series
+	// identity; grouping on RA-minus-keys silently dropped the
+	// extracted labels and the enclosing `max by (level)` collapsed the
+	// matrix to a single empty-level series (loki-compat
+	// exhaustive/aggregations.yaml#Max avg duration by level without
+	// service_name).
+	groupBy, err := rangeAggregationGroupBy(e, s, identityBase)
+	if err != nil {
+		return nil, err
+	}
+
 	identityProj := chplan.Projection{
 		Expr:  withDetectedLevelAndColumns(s, identityBase, lc.OuterByLabels),
 		Alias: s.ResourceAttributesColumn,
@@ -492,23 +503,35 @@ func rangeValueExprFromMerged(e *syntax.RangeAggregationExpr, mergedCol chplan.E
 // single Map-shaped expression so the downstream Project synthesises a
 // per-stream identity that the RangeWindow GROUP BY can collapse to.
 //
-//	no Grouping        → nil (caller defaults to grouping on RA).
+//	no Grouping        → nil (caller defaults to grouping on identityBase).
 //	`by (k1, k2)`      → map('k1', RA['k1'], 'k2', RA['k2'])
 //	`by ()`            → map()       (single all-collapsed group)
-//	`without (k1, k2)` → mapFilter((k,v) -> NOT (k IN ('k1','k2')), RA)
+//	`without (k1, k2)` → mapFilter((k,v) -> NOT (k IN ('k1','k2')),
+//	                               withDetectedLevel(identityBase))
+//
+// `without` is exclusion semantics: it strips keys from the FULL series
+// identity the pipeline produced — `identityBase` (the parser-merged
+// labelset minus the unwrap target when the aggregation carries
+// `| unwrap`), augmented with the synthesized `detected_level` key the
+// no-grouping path also injects (so an enclosing `by (level)` /
+// `by (detected_level)` vector aggregation still resolves the severity
+// dimension; the injection happens BEFORE the strip so
+// `without (detected_level)` / `without (level)` removes it again).
+// Grouping on the raw ResourceAttributes column instead would silently
+// drop every parser-extracted label from the series identity.
 //
 // The `detected_level` family (`detected_level` + its `level` alias) is
 // resolved to the SeverityText-derived `multiIf(...)` normalisation
 // rather than a literal map lookup the seeder doesn't write — mirrors
 // the vector-aggregation alias surface so the two grouping layers
 // behave consistently.
-func rangeAggregationGroupBy(e *syntax.RangeAggregationExpr, s schema.Logs) (chplan.Expr, error) {
+func rangeAggregationGroupBy(e *syntax.RangeAggregationExpr, s schema.Logs, identityBase chplan.Expr) (chplan.Expr, error) {
 	if e.Grouping == nil {
 		return nil, nil
 	}
 	if e.Grouping.Without {
 		return &chplan.MapWithoutKeys{
-			Map:  &chplan.ColumnRef{Name: s.ResourceAttributesColumn},
+			Map:  withDetectedLevel(s, identityBase),
 			Keys: canonicalLevelKeys(e.Grouping.Groups),
 		}, nil
 	}

--- a/internal/logql/range_aggregation_test.go
+++ b/internal/logql/range_aggregation_test.go
@@ -820,10 +820,18 @@ func TestRangeAggregationGroupByEmitsLabelKeyAndValuePairs(t *testing.T) {
 		t.Fatalf("fixture invalid: Grouping=%v Groups=%v", ra.Grouping, ra.Grouping)
 	}
 
-	got, err := rangeAggregationGroupBy(ra, s)
+	got, err := rangeAggregationGroupBy(ra, s, &chplan.ColumnRef{Name: s.ResourceAttributesColumn})
 	if err != nil {
 		t.Fatalf("rangeAggregationGroupBy: %v", err)
 	}
+	assertRangeGroupByMapShape(t, got, ra)
+}
+
+// assertRangeGroupByMapShape pins the 2-args-per-label `map(...)` shape
+// for the explicit `by (...)` grouping path. Split out so the `by` and
+// `without` tests share the structural assertion.
+func assertRangeGroupByMapShape(t *testing.T, got chplan.Expr, ra *syntax.RangeAggregationExpr) {
+	t.Helper()
 	fc, ok := got.(*chplan.FuncCall)
 	if !ok {
 		t.Fatalf("rangeAggregationGroupBy -> %T, want *chplan.FuncCall", got)
@@ -865,5 +873,66 @@ func TestRangeAggregationGroupByEmitsLabelKeyAndValuePairs(t *testing.T) {
 		if _, isLit := fc.Args[valIdx].(*chplan.LitString); isLit {
 			t.Errorf("arg[%d] is a *chplan.LitString — expected a value expression for label %q", valIdx, label)
 		}
+	}
+}
+
+// TestRangeAggregationGroupByWithoutStripsFromIdentityBase pins the
+// `without (...)` grouping contract: the exclusion strips keys from the
+// FULL series identity the caller passes in (identityBase — the
+// parser-merged labelset minus the unwrap target), wrapped with the
+// synthesized detected_level key, NOT from the raw ResourceAttributes
+// column. Grouping `without (pod)` against raw ResourceAttributes
+// silently drops every parser-extracted label from the series identity
+// — the loki-compat `exhaustive/aggregations.yaml#Max avg duration by
+// level without service_name` failure, where the enclosing
+// `max by (level)` collapsed a 4-level matrix into one empty-level
+// series.
+func TestRangeAggregationGroupByWithoutStripsFromIdentityBase(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelLogs()
+
+	query := `avg_over_time({app="api"} | logfmt | unwrap latency [5m]) without (pod)`
+	expr, err := syntax.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	ra, ok := expr.(*syntax.RangeAggregationExpr)
+	if !ok {
+		t.Fatalf("ParseExpr(%q) -> %T, want *syntax.RangeAggregationExpr", query, expr)
+	}
+	if ra.Grouping == nil || !ra.Grouping.Without {
+		t.Fatalf("fixture invalid: Grouping=%v", ra.Grouping)
+	}
+
+	// The identityBase stand-in mirrors the unwrap+parser path: the
+	// materialised merged-labels column minus the unwrap target.
+	identityBase := &chplan.MapWithoutKeys{
+		Map:  &chplan.ColumnRef{Name: "_logql_merged_labels"},
+		Keys: []string{"latency"},
+	}
+	got, err := rangeAggregationGroupBy(ra, s, identityBase)
+	if err != nil {
+		t.Fatalf("rangeAggregationGroupBy: %v", err)
+	}
+
+	mwk, ok := got.(*chplan.MapWithoutKeys)
+	if !ok {
+		t.Fatalf("rangeAggregationGroupBy -> %T, want *chplan.MapWithoutKeys", got)
+	}
+	if len(mwk.Keys) != 1 || mwk.Keys[0] != "pod" {
+		t.Errorf("MapWithoutKeys.Keys = %v, want [pod]", mwk.Keys)
+	}
+
+	// The stripped map MUST be the detected_level-wrapped identityBase
+	// (a mapConcat FuncCall whose first arg is identityBase), so the
+	// parser-extracted labels survive into the series identity and an
+	// enclosing `by (level)` still resolves the severity dimension.
+	wrap, ok := mwk.Map.(*chplan.FuncCall)
+	if !ok || wrap.Name != "mapConcat" {
+		t.Fatalf("MapWithoutKeys.Map = %T (%v), want mapConcat FuncCall wrapping identityBase", mwk.Map, mwk.Map)
+	}
+	if len(wrap.Args) == 0 || !wrap.Args[0].Equal(identityBase) {
+		t.Errorf("mapConcat first arg != identityBase — `without` is not stripping from the full series identity")
 	}
 }

--- a/test/spec/chsql/aggregate_sum_without_empty.txtar
+++ b/test/spec/chsql/aggregate_sum_without_empty.txtar
@@ -1,0 +1,7 @@
+-- sql --
+SELECT `Attributes`, sum(`Value`) AS `total` FROM (SELECT * FROM `otel_metrics_gauge`) GROUP BY `Attributes`
+-- args --
+(none)
+-- chplan --
+Aggregate groupBy=[mapWithout(Attributes, [])] funcs=[sum(Value) AS total]
+  Scan(otel_metrics_gauge)

--- a/test/spec/logql/range_agg_without_grouping_unwrap.txtar
+++ b/test/spec/logql/range_agg_without_grouping_unwrap.txtar
@@ -1,0 +1,66 @@
+-- query.logql --
+max by (tier) (avg_over_time({job="api"} | logfmt | unwrap latency [5m]) without (pod))
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
+    (toDateTime64('2025-12-31 23:58:00', 9), 'tier=gold latency=10',   map('job', 'api', 'pod', 'p1')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'tier=gold latency=20',   map('job', 'api', 'pod', 'p2')),
+    (toDateTime64('2025-12-31 23:59:00', 9), 'tier=silver latency=30', map('job', 'api', 'pod', 'p1'));
+-- expected_rows --
+[
+  ["", {"tier": "gold"}, "2026-01-01T00:00:01Z", 15.0],
+  ["", {"tier": "silver"}, "2026-01-01T00:00:01Z", 30.0]
+]
+-- sql --
+SELECT ? AS `MetricName`, map(?, `gkey_0`) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`[?] AS `gkey_0`, max(`Value`) AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arrayAvg(window_vals), nan) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapFilter((k, v) -> NOT (k IN (?)), mapConcat(mapFilter((k, v) -> NOT (k IN (?)), `_logql_merged_labels`), mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`)))))) AS `ResourceAttributes`, `Timestamp`, toFloat64OrZero(`_logql_merged_labels`[?]) AS `Value` FROM (SELECT `ResourceAttributes`, `Timestamp`, `Body`, `SeverityText`, mapConcat(`ResourceAttributes`, mapApply((k, v) -> tuple(if(mapContains(`ResourceAttributes`, k), concat(k, ?), k), v), extractKeyValuePairs(`Body`, ?, ?, ?))) AS `_logql_merged_labels` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?)))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1) GROUP BY `ResourceAttributes`[?])
+-- args --
+[0] string = ""
+[1] string = "tier"
+[2] int64 = 9
+[3] string = "tier"
+[4] string = "pod"
+[5] string = "latency"
+[6] string = ""
+[7] string = "detected_level"
+[8] string = "trace"
+[9] string = "trc"
+[10] string = "trace"
+[11] string = "debug"
+[12] string = "dbg"
+[13] string = "debug"
+[14] string = "info"
+[15] string = "inf"
+[16] string = "information"
+[17] string = "info"
+[18] string = "warn"
+[19] string = "wrn"
+[20] string = "warning"
+[21] string = "warn"
+[22] string = "error"
+[23] string = "err"
+[24] string = "error"
+[25] string = "critical"
+[26] string = "critical"
+[27] string = "fatal"
+[28] string = "fatal"
+[29] string = "latency"
+[30] string = "_extracted"
+[31] string = "="
+[32] string = " "
+[33] string = "\""
+[34] string = "job"
+[35] string = "api"
+[36] string = "tier"
+-- chplan --
+Project ["" AS MetricName, map("tier", gkey_0) AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+  Aggregate groupBy=[ResourceAttributes["tier"] AS gkey_0] funcs=[max(Value) AS Value]
+    RangeWindow func=avg_over_time range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
+      Project [mapWithout(mapConcat(mapWithout(_logql_merged_labels, [latency]), mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))), [pod]) AS ResourceAttributes, Timestamp, toFloat64OrZero(_logql_merged_labels["latency"]) AS Value]
+        Project [ResourceAttributes, Timestamp, Body, SeverityText, mapConcat(ResourceAttributes, mapApply((k, v) -> tuple(if(mapContains(ResourceAttributes, k), concat(k, "_extracted"), k), v), extractKeyValuePairs(Body, "=", " ", "\""))) AS _logql_merged_labels]
+          Filter predicate=(ResourceAttributes["job"] = "api")
+            Scan(otel_logs)

--- a/test/spec/logql/vector_agg_without_empty_unwrap.txtar
+++ b/test/spec/logql/vector_agg_without_empty_unwrap.txtar
@@ -1,0 +1,60 @@
+-- query.logql --
+max without () (sum_over_time({job="api"} | logfmt | unwrap latency [5m]))
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
+    (toDateTime64('2025-12-31 23:58:00', 9), 'tier=gold latency=10', map('job', 'api', 'pod', 'p1')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'tier=gold latency=20', map('job', 'api', 'pod', 'p1'));
+-- expected_rows --
+[
+  ["", {"job": "api", "pod": "p1", "tier": "gold"}, "2026-01-01T00:00:01Z", 30.0]
+]
+-- sql --
+SELECT ? AS `MetricName`, `gkey_0` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes` AS `gkey_0`, max(`Value`) AS `Value` FROM (SELECT `ResourceAttributes`, arraySum(window_vals) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(mapFilter((k, v) -> NOT (k IN (?)), `_logql_merged_labels`), mapFilter((k, v) -> (v != ?), map(?, multiIf(((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, toFloat64OrZero(`_logql_merged_labels`[?]) AS `Value` FROM (SELECT `ResourceAttributes`, `Timestamp`, `Body`, `SeverityText`, mapConcat(`ResourceAttributes`, mapApply((k, v) -> tuple(if(mapContains(`ResourceAttributes`, k), concat(k, ?), k), v), extractKeyValuePairs(`Body`, ?, ?, ?))) AS `_logql_merged_labels` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?)))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1) GROUP BY `ResourceAttributes`)
+-- args --
+[0] string = ""
+[1] int64 = 9
+[2] string = "latency"
+[3] string = ""
+[4] string = "detected_level"
+[5] string = "trace"
+[6] string = "trc"
+[7] string = "trace"
+[8] string = "debug"
+[9] string = "dbg"
+[10] string = "debug"
+[11] string = "info"
+[12] string = "inf"
+[13] string = "information"
+[14] string = "info"
+[15] string = "warn"
+[16] string = "wrn"
+[17] string = "warning"
+[18] string = "warn"
+[19] string = "error"
+[20] string = "err"
+[21] string = "error"
+[22] string = "critical"
+[23] string = "critical"
+[24] string = "fatal"
+[25] string = "fatal"
+[26] string = "latency"
+[27] string = "_extracted"
+[28] string = "="
+[29] string = " "
+[30] string = "\""
+[31] string = "job"
+[32] string = "api"
+-- chplan --
+Project ["" AS MetricName, gkey_0 AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+  Aggregate groupBy=[mapWithout(ResourceAttributes, []) AS gkey_0] funcs=[max(Value) AS Value]
+    RangeWindow func=sum_over_time range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
+      Project [mapConcat(mapWithout(_logql_merged_labels, [latency]), mapFilter((k, v) -> (v != ""), map("detected_level", multiIf(((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, toFloat64OrZero(_logql_merged_labels["latency"]) AS Value]
+        Project [ResourceAttributes, Timestamp, Body, SeverityText, mapConcat(ResourceAttributes, mapApply((k, v) -> tuple(if(mapContains(ResourceAttributes, k), concat(k, "_extracted"), k), v), extractKeyValuePairs(Body, "=", " ", "\""))) AS _logql_merged_labels]
+          Filter predicate=(ResourceAttributes["job"] = "api")
+            Scan(otel_logs)


### PR DESCRIPTION
## Summary

The LogQL 100% badge was counting an unknowingly shrunken denominator: **8 metric queries in the vendored bench expanded to zero test cases** — silently absent from the 78-case total and from the upstream-skip baseline, with no rail noticing.

Root cause (confirmed; upstream grafana/loki main has the identical bug): the vendored registry defaulted `Directions` (gated on `Kind=='log'`) **before** defaulting `Kind`, so the 8 kind-less metric-shaped defs in `exhaustive/aggregations.yaml` got `Directions=''` and `ExpandQuery` appended nothing.

## Changes

1. **Registry fix** (cerberus-owned vendored snapshot): `Kind` defaults before `Directions`, inferred from the parsed query shape (mirrors `TestCase.Kind()`); divergence recorded in `VERSION` under `local_patches`. Upstream contribution noted as follow-up.
2. **Zero-expansion rail**: corpus load now hard-fails naming any def that expands to 0 cases — the missing rail, unit-tested plus a full-corpus pin (**86 cases**).
3. **The 2 real cerberus bugs the revived cases exposed, fixed at the source**:
   - LogQL range-aggregation `without(...)` grouped against raw `ResourceAttributes`, dropping parser-extracted labels from series identity (expected 4 series, got 1).
   - chsql `exprMapWithoutKeys` emitted `k IN ()` for zero keys — a ClickHouse error — now emits the identity map; same shape also fixed for PromQL `without()`. Covered by 2 chDB-roundtrip TXTARs + 1 chsql emit fixture + unit pins.
4. Harness hermeticity: reference Loki's ingester WAL disk-full threshold (90% of *host* disk) rejected all pushes on a full dev box — `disk_full_threshold: 0` for the minutes-lived differential stack.
5. Skip baseline verified **unchanged** (15 entries; none of the 8 were skip-true).

## Verification

Full local harness run: **total=86 passed=86 — 100.00%, brightgreen**; all 8 revived cases individually PASS. `just update-golden` + chdb spec suite green (540 spec tests).

## Test plan

- [ ] `compatibility/loki` green with the 86-case denominator
- [ ] `check` + `chdb` green (new fixtures + pins)

🤖 Generated with [Claude Code](https://claude.com/claude-code)