### PR TITLE
ci: actionlint gate — just target, lefthook pre-push, CI lint step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,22 @@ jobs:
       - name: go-arch-lint
         run: go-arch-lint check
 
+      # actionlint validates the workflow files themselves (expression
+      # contexts, action inputs, shellcheck of run blocks). GitHub
+      # rejects invalid workflow files SERVER-side as zero-job
+      # "invalid workflow file" failure runs, which silently prevents
+      # required pull_request checks from ever being scheduled — the
+      # #749 secrets-in-step-if incident left a PR BLOCKED on four
+      # required contexts that could never report. Version pinned in
+      # lock-step with Justfile's ACTIONLINT_VERSION; no first-party
+      # Action exists, `go install` reuses setup-go's module cache
+      # (same pattern as go-arch-lint above).
+      - name: install actionlint
+        run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+
+      - name: actionlint
+        run: actionlint
+
       # commitlint runs over the PR's commit range. This used to be
       # wagoid/commitlint-github-action, but that action is Docker-based
       # and pulls its image from Docker Hub on every run — an anonymous

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,6 +295,7 @@ jobs:
           # `_\s*=\s*recover` discriminates a silent swallow from the
           # legitimate `r := recover(); if r == nil { t.Fatal(...) }`
           # assert-the-panic pattern used elsewhere in the repo.
+          # shellcheck disable=SC2016 # single-quoted perl one-liner: $vars are perl, not shell
           matches=$(git ls-files -z -- '*_test.go' ':!:compatibility/*/upstream/**' \
             | xargs -0 perl -0777 -ne '
                 while (/defer\s+recover\s*\(\s*\)|defer\s+func\s*\(\s*\)\s*\{[^{}]*_\s*=\s*recover\s*\(\s*\)/g) {
@@ -322,6 +323,7 @@ jobs:
           # Multi-line scan: detect `should_skip:` followed by a
           # block child (`- source:`) — i.e. a non-empty entry. The
           # accepted empty form `should_skip: []` does not match.
+          # shellcheck disable=SC2016 # single-quoted perl one-liner: $vars are perl, not shell
           matches=$(git ls-files -z -- \
               'compatibility/**/*.yml' \
               'compatibility/**/*.yaml' \

--- a/Justfile
+++ b/Justfile
@@ -8,6 +8,7 @@ GOFUMPT_VERSION := "v0.7.0"
 GOIMPORTS_VERSION := "latest"
 GREMLINS_VERSION := "v0.6.0"
 MARKDOWNLINT_VERSION := "v0.18.1"
+ACTIONLINT_VERSION := "v1.7.12"
 MODULE := "github.com/tsouza/cerberus"
 
 # Default: list recipes.
@@ -22,6 +23,7 @@ install-tools:
     go install mvdan.cc/gofumpt@{{GOFUMPT_VERSION}}
     go install golang.org/x/tools/cmd/goimports@{{GOIMPORTS_VERSION}}
     go install github.com/go-gremlins/gremlins/cmd/gremlins@{{GREMLINS_VERSION}}
+    go install github.com/rhysd/actionlint/cmd/actionlint@{{ACTIONLINT_VERSION}}
 
 # Install lefthook + activate git hooks. Idempotent; run once after clone.
 # Hooks defined in lefthook.yml run gofumpt / goimports / markdownlint-cli2 --fix
@@ -182,6 +184,16 @@ mutate-chdb:
 # Run Go linters.
 lint:
     golangci-lint run ./...
+
+# Validate GitHub Actions workflow files (expression contexts, action
+# inputs, shellcheck of run blocks). Deliberately separate from `lint`
+# (Go): workflow-file defects otherwise surface only as server-side
+# zero-job "invalid workflow file" failure runs, which silently
+# prevent required pull_request checks from ever being scheduled —
+# the #749 secrets-in-step-if incident left the PR BLOCKED on four
+# required contexts that could never report.
+lint-actions:
+    actionlint
 
 # Lint all Markdown files (run via npm exec; no global Node deps).
 lint-md:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -50,6 +50,18 @@ pre-push:
       tags: lint
       run: |
         golangci-lint run ./...
+    # Workflow-file validation. GitHub rejects invalid workflow files
+    # SERVER-side as zero-job "invalid workflow file" failure runs,
+    # which silently prevents required pull_request checks from ever
+    # being scheduled (the #749 secrets-in-step-if incident left a PR
+    # BLOCKED on four required contexts that could never report).
+    # actionlint catches expression-context violations, bad action
+    # inputs, and shellchecks run blocks before the push leaves the
+    # machine. Install via `just install-tools`.
+    actionlint:
+      tags: lint
+      run: |
+        just lint-actions
     markdownlint:
       tags: lint
       glob: "*.md"


### PR DESCRIPTION
## Summary

Closes the gap the #749 incident exposed: an invalid workflow file fails **server-side** as a zero-job "invalid workflow file" run, which silently prevents that file's required `pull_request` checks from ever being scheduled — #749 sat BLOCKED on four required contexts (`compatibility/*` ×3, `compose-smoke`) that could never report, while everything visible showed green. Nothing local validated workflow files.

Three layers, version-pinned in lock-step (`v1.7.12`):

- **Justfile**: `ACTIONLINT_VERSION` + `install-tools` entry + a dedicated `lint-actions` recipe — deliberately separate from the Go `lint` target.
- **lefthook pre-push**: `actionlint` command — the defect class now fails before a push leaves the machine.
- **ci.yml lint job**: install + run actionlint (`go install` reuses the setup-go cache; no first-party Action exists — same pattern as the adjacent go-arch-lint step).

actionlint pins the exact #749 rule (`context "secrets" is not allowed here` on `steps[*].if`) plus action-input validation and shellcheck over `run:` blocks. Current tree passes clean.

## Test plan

- [ ] `lint` green (now includes the actionlint step validating all workflow files)
- [ ] `check`/`forbid-skip` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)