### PR TITLE
test(e2e): P1 of the Grafana traversal program — validity oracle, panel contracts, option pinning, sweep depth

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,9 +3,14 @@ name: e2e
 # End-to-end test umbrella. Hosts both:
 #   - `compose-smoke` — repo-root quickstart compose stack smoke
 #     (`docker compose up --wait`) + Grafana Playwright catch-net.
-#     Runs on pull_request + push-to-main. Required status check on
-#     branch protection — DO NOT rename the job (the check name is
-#     pinned to `compose-smoke`).
+#     Runs on pull_request + push-to-main at SWEEP_DEPTH=lean (the
+#     required PR gate) and on the nightly schedule at
+#     SWEEP_DEPTH=full. The clickhouse / host / otelcol dashboards
+#     are compose-only surfaces (their receivers don't run in the
+#     k3d stack), so the nightly full-depth sweep of them has to
+#     happen HERE — the dashboard job can't cover them. Required
+#     status check on branch protection — DO NOT rename the job
+#     (the check name is pinned to `compose-smoke`).
 #   - `dashboard` — full-stack k3d + cerberus + Grafana + Playwright
 #     smoke. Runs on push-to-main + nightly + manual dispatch only.
 #     Informational on merges, not a PR gate; regressions are caught
@@ -53,8 +58,9 @@ jobs:
   # See `.github/workflows/ci.yml` for the rationale + filter convention.
   # Docs-only PRs short-circuit the compose-smoke job (Docker compose
   # build + Grafana Playwright catch-net are pointless when no code
-  # changed). Runs on pull_request only — push/schedule/dispatch skip
-  # straight to the smoke job.
+  # changed). Runs on pull_request only — push and schedule bypass the
+  # docs-only gate and go straight to the smoke job (a nightly run has
+  # no diff to filter on).
   changes:
     name: changes
     if: github.event_name == 'pull_request'
@@ -94,14 +100,19 @@ jobs:
   compose-smoke:
     name: compose-smoke
     needs: changes
-    # Runs on pull_request + push-to-main only. On schedule /
-    # workflow_dispatch the compose stack adds no signal over the
-    # dashboard job. `needs.changes` only runs on pull_request, so
-    # we have to tolerate it being skipped on push (always() unwraps
-    # the skip, and the docs-only short-circuit only applies on PR).
+    # Lane doctrine: PR + push run at SWEEP_DEPTH=lean (the required
+    # fast-feedback gate); the nightly schedule runs at
+    # SWEEP_DEPTH=full. The schedule lane exists because the
+    # clickhouse / host / otelcol dashboards are compose-only
+    # surfaces — the k3d dashboard job's collector intentionally
+    # doesn't run their receivers — so full-depth coverage of them
+    # has to live in this job. `needs.changes` only runs on
+    # pull_request, so we have to tolerate it being absent on
+    # push/schedule (always() unwraps the skip, and the docs-only
+    # short-circuit only applies on PR).
     if: |
       always() &&
-      (github.event_name == 'pull_request' || github.event_name == 'push') &&
+      (github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'schedule') &&
       (github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -175,6 +186,13 @@ jobs:
           GRAFANA_BASE_URL: http://localhost:3000
           GRAFANA_URL: http://localhost:3000
           CERBERUS_URL: http://localhost:8080
+          # Depth doctrine: PR/push = lean (required gate, fewest
+          # states), nightly schedule = full (every dashboard's
+          # browser render, showcase family included). The depth
+          # flag only changes how many STATES the sweeps visit,
+          # never which rules run — see
+          # test/e2e/playwright/helpers/depth.ts.
+          SWEEP_DEPTH: ${{ github.event_name == 'schedule' && 'full' || 'lean' }}
         run: |
           # Phase-1 panel-shape spec (iterate-panel-shape.spec.ts) runs
           # alongside the catch-net smoke. It enumerates every

--- a/test/e2e/playwright/expectation-contracts.spec.ts
+++ b/test/e2e/playwright/expectation-contracts.spec.ts
@@ -1,0 +1,298 @@
+/**
+ * cerberus.expect contract meta-rules + unit tests — stack-free.
+ *
+ * Two halves:
+ *
+ *   1. Unit tests for helpers/expectations.ts: readPanelExpectation
+ *      parsing (default / declared / malformed) and the BIDIRECTIONAL
+ *      enforceExpectation semantics (a declared 'empty' that returns
+ *      series fails; a declared 'error:<s>' that succeeds or errors
+ *      differently fails; the default 'nonempty' with zero series
+ *      fails — the pre-existing sweep rule).
+ *
+ *   2. Meta-rules over BOTH provisioned dashboard directories
+ *      (test/e2e/grafana/compose/dashboards + test/e2e/grafana/
+ *      dashboards), read from disk at spec-build time:
+ *
+ *        - ops-family dashboards — every file NOT prefixed
+ *          `showcase-` (today: cerberus, clickhouse, host, otelcol)
+ *          — must not carry ANY cerberus.expect declaration.
+ *          Non-default expectations are a showcase-family privilege.
+ *        - every non-default declaration anywhere must carry a
+ *          non-empty `why`.
+ *        - every declaration that exists must parse — a malformed
+ *          contract fails here, before any live sweep consumes it.
+ *
+ *      Today zero declarations exist, so the meta-rules pass on the
+ *      current tree; they are the ratchet for the P2+ showcase
+ *      dashboards.
+ *
+ * Run via:
+ *   cd test/e2e/playwright && npx playwright test expectation-contracts.spec.ts
+ */
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { expect, test } from '@playwright/test';
+
+import {
+  enforceExpectation,
+  isNonDefaultExpectation,
+  readPanelExpectation,
+} from './helpers/index.js';
+
+// --- Unit tests: readPanelExpectation ---------------------------------------
+
+test('readPanelExpectation defaults to undeclared nonempty when absent', () => {
+  expect(readPanelExpectation({ title: 'p' })).toEqual({
+    expect: 'nonempty',
+    declared: false,
+  });
+  expect(readPanelExpectation(undefined)).toEqual({
+    expect: 'nonempty',
+    declared: false,
+  });
+  expect(readPanelExpectation(null)).toEqual({
+    expect: 'nonempty',
+    declared: false,
+  });
+});
+
+test('readPanelExpectation parses each declared kind', () => {
+  expect(
+    readPanelExpectation({ cerberus: { expect: 'nonempty' } }),
+  ).toEqual({ expect: 'nonempty', declared: true });
+  expect(
+    readPanelExpectation({
+      cerberus: { expect: 'empty', why: 'quantile over absent buckets' },
+    }),
+  ).toEqual({
+    expect: 'empty',
+    declared: true,
+    why: 'quantile over absent buckets',
+  });
+  expect(
+    readPanelExpectation({
+      cerberus: { expect: 'error:parse error', why: 'showcases the 400 path' },
+    }),
+  ).toEqual({
+    expect: 'error:parse error',
+    declared: true,
+    why: 'showcases the 400 path',
+  });
+});
+
+test('readPanelExpectation throws on malformed declarations', () => {
+  expect(() => readPanelExpectation({ cerberus: 'nonempty' })).toThrow(
+    /must be an object/,
+  );
+  expect(() => readPanelExpectation({ cerberus: {} })).toThrow(
+    /expect must be a string/,
+  );
+  expect(() =>
+    readPanelExpectation({ cerberus: { expect: 'sometimes' } }),
+  ).toThrow(/'nonempty' \| 'empty' \| 'error:<substring>'/);
+  expect(() =>
+    readPanelExpectation({ cerberus: { expect: 'error:' } }),
+  ).toThrow(/'nonempty' \| 'empty' \| 'error:<substring>'/);
+  expect(() =>
+    readPanelExpectation({ cerberus: { expect: 'empty', why: 42 } }),
+  ).toThrow(/why must be a string/);
+});
+
+test('isNonDefaultExpectation flags only declared non-nonempty contracts', () => {
+  expect(
+    isNonDefaultExpectation({ expect: 'nonempty', declared: false }),
+  ).toBe(false);
+  expect(
+    isNonDefaultExpectation({ expect: 'nonempty', declared: true }),
+  ).toBe(false);
+  expect(isNonDefaultExpectation({ expect: 'empty', declared: true })).toBe(
+    true,
+  );
+  expect(
+    isNonDefaultExpectation({ expect: 'error:boom', declared: true }),
+  ).toBe(true);
+});
+
+// --- Unit tests: enforceExpectation (bidirectional) --------------------------
+
+test('enforce nonempty: series present passes, zero series violates', () => {
+  const e = readPanelExpectation({});
+  expect(enforceExpectation(e, { seriesCount: 3, status: 200 })).toEqual([]);
+  const v = enforceExpectation(e, { seriesCount: 0, status: 200 });
+  expect(v).toHaveLength(1);
+  expect(v[0]).toContain('returned no series');
+});
+
+test('enforce nonempty: non-2xx status violates', () => {
+  const e = readPanelExpectation({});
+  const v = enforceExpectation(e, {
+    seriesCount: 0,
+    status: 500,
+    errorBody: 'upstream exploded',
+  });
+  expect(v).toHaveLength(1);
+  expect(v[0]).toContain('HTTP 500');
+  expect(v[0]).toContain('upstream exploded');
+});
+
+test('enforce empty: zero series passes, any series violates (bidirectional pin)', () => {
+  const e = readPanelExpectation({
+    cerberus: { expect: 'empty', why: 'defined-empty result' },
+  });
+  expect(enforceExpectation(e, { seriesCount: 0, status: 200 })).toEqual([]);
+  const v = enforceExpectation(e, { seriesCount: 2, status: 200 });
+  expect(v).toHaveLength(1);
+  expect(v[0]).toContain(
+    'declared-empty panel returned 2 series (the feature it showcases broke)',
+  );
+});
+
+test('enforce empty: non-2xx still violates (empty != error)', () => {
+  const e = readPanelExpectation({
+    cerberus: { expect: 'empty', why: 'defined-empty result' },
+  });
+  const v = enforceExpectation(e, { seriesCount: 0, status: 502 });
+  expect(v).toHaveLength(1);
+  expect(v[0]).toContain('HTTP 502');
+});
+
+test('enforce error: matching error passes', () => {
+  const e = readPanelExpectation({
+    cerberus: { expect: 'error:parse error', why: 'showcases the 400 path' },
+  });
+  expect(
+    enforceExpectation(e, {
+      seriesCount: 0,
+      status: 400,
+      errorBody: '{"status":"error","error":"parse error at char 3"}',
+    }),
+  ).toEqual([]);
+});
+
+test('enforce error: a 2xx success violates (the showcased error stopped firing)', () => {
+  const e = readPanelExpectation({
+    cerberus: { expect: 'error:parse error', why: 'showcases the 400 path' },
+  });
+  const v = enforceExpectation(e, { seriesCount: 1, status: 200 });
+  expect(v).toHaveLength(1);
+  expect(v[0]).toContain('but the probe succeeded with HTTP 200');
+});
+
+test('enforce error: an error without the declared substring violates', () => {
+  const e = readPanelExpectation({
+    cerberus: { expect: 'error:parse error', why: 'showcases the 400 path' },
+  });
+  const v = enforceExpectation(e, {
+    seriesCount: 0,
+    status: 500,
+    errorBody: 'something else broke',
+  });
+  expect(v).toHaveLength(1);
+  expect(v[0]).toContain('does not contain the declared substring');
+  expect(v[0]).toContain('something else broke');
+});
+
+// --- Meta-rules over the provisioned dashboard directories -------------------
+
+const DASHBOARD_DIRS = [
+  resolve(__dirname, '..', 'grafana', 'compose', 'dashboards'),
+  resolve(__dirname, '..', 'grafana', 'dashboards'),
+];
+
+type RawPanel = {
+  type?: string;
+  title?: string;
+  cerberus?: unknown;
+  panels?: RawPanel[];
+};
+
+type Declaration = {
+  file: string;
+  panelTitle: string;
+  expectation: ReturnType<typeof readPanelExpectation>;
+};
+
+function walkPanels(
+  panels: RawPanel[],
+  visit: (p: RawPanel) => void,
+): void {
+  for (const p of panels) {
+    visit(p);
+    if (p.panels !== undefined) walkPanels(p.panels, visit);
+  }
+}
+
+function scanDashboards(): {
+  files: string[];
+  declarations: Declaration[];
+} {
+  const files: string[] = [];
+  const declarations: Declaration[] = [];
+  for (const dir of DASHBOARD_DIRS) {
+    for (const entry of readdirSync(dir)) {
+      if (!entry.endsWith('.json')) continue;
+      const rel = `${dir}/${entry}`;
+      files.push(rel);
+      const json = JSON.parse(readFileSync(join(dir, entry), 'utf8')) as {
+        panels?: RawPanel[];
+      };
+      walkPanels(json.panels ?? [], (p) => {
+        // readPanelExpectation throws on malformed declarations —
+        // a broken contract fails this meta-spec before any live
+        // sweep consumes it.
+        const expectation = readPanelExpectation(p);
+        if (expectation.declared) {
+          declarations.push({
+            file: rel,
+            panelTitle: p.title ?? '<untitled>',
+            expectation,
+          });
+        }
+      });
+    }
+  }
+  return { files, declarations };
+}
+
+test('dashboard catalog: both provisioning dirs are non-empty and parseable', () => {
+  const { files } = scanDashboards();
+  for (const dir of DASHBOARD_DIRS) {
+    expect(
+      files.filter((f) => f.startsWith(dir)).length,
+      `at least one dashboard JSON under ${dir}`,
+    ).toBeGreaterThan(0);
+  }
+});
+
+test('ops-family dashboards carry no cerberus.expect declarations', () => {
+  // Every dashboard file not prefixed `showcase-` is ops-family —
+  // its panels graph the live stack, so a non-default expectation
+  // would mask a real regression. Declarations (even an explicit
+  // default 'nonempty') are a showcase-family privilege.
+  const { declarations } = scanDashboards();
+  const opsDeclarations = declarations.filter(
+    (d) => !d.file.split('/').pop()!.startsWith('showcase-'),
+  );
+  expect(
+    opsDeclarations.map((d) => `${d.file} panel "${d.panelTitle}"`),
+    'ops-family dashboards must not declare cerberus.expect',
+  ).toEqual([]);
+});
+
+test('every non-default cerberus.expect declaration carries a non-empty why', () => {
+  const { declarations } = scanDashboards();
+  const missingWhy = declarations.filter(
+    (d) =>
+      isNonDefaultExpectation(d.expectation) &&
+      (d.expectation.why === undefined || d.expectation.why.trim() === ''),
+  );
+  expect(
+    missingWhy.map(
+      (d) =>
+        `${d.file} panel "${d.panelTitle}" expect=${d.expectation.expect}`,
+    ),
+    'non-default declarations must explain themselves via why',
+  ).toEqual([]);
+});

--- a/test/e2e/playwright/helpers-validity.spec.ts
+++ b/test/e2e/playwright/helpers-validity.spec.ts
@@ -1,0 +1,620 @@
+/**
+ * Stack-free unit tests for the validity-oracle library
+ * (helpers/validity.ts). Table-driven: every fixture is a captured-
+ * response-shaped literal; valid fixtures must produce zero
+ * violations, and each violation class must produce its named
+ * violation string. No Grafana / cerberus stack is required — run
+ * anywhere via:
+ *
+ *   cd test/e2e/playwright && npx playwright test helpers-validity.spec.ts
+ */
+
+import { expect, test } from '@playwright/test';
+
+import {
+  type ValidityContext,
+  parseSampleValue,
+  validateLokiResponse,
+  validatePromResponse,
+  validateTempoResponse,
+} from './helpers/index.js';
+
+// A fixed window every fixture below stays inside: [1000, 1300] with
+// step 15 — i.e. valid matrix timestamps are 1000, 1015, 1030, …
+const CTX: ValidityContext = { fromSec: 1000, toSec: 1300, stepSec: 15 };
+
+function promMatrix(
+  series: Array<{ metric: Record<string, string>; values: Array<[number, string]> }>,
+): unknown {
+  return { status: 'success', data: { resultType: 'matrix', result: series } };
+}
+
+function promVector(
+  series: Array<{ metric: Record<string, string>; value: [number, string] }>,
+): unknown {
+  return { status: 'success', data: { resultType: 'vector', result: series } };
+}
+
+// --- parseSampleValue --------------------------------------------------------
+
+test('parseSampleValue classifies finite, non-finite, and garbage tokens', () => {
+  expect(parseSampleValue('1.5')).toEqual({ kind: 'finite', value: 1.5 });
+  expect(parseSampleValue('-2e3')).toEqual({ kind: 'finite', value: -2000 });
+  expect(parseSampleValue(42)).toEqual({ kind: 'finite', value: 42 });
+  expect(parseSampleValue('NaN')).toEqual({ kind: 'nonfinite', token: 'NaN' });
+  expect(parseSampleValue('+Inf')).toEqual({ kind: 'nonfinite', token: '+Inf' });
+  expect(parseSampleValue('-Inf')).toEqual({ kind: 'nonfinite', token: '-Inf' });
+  expect(parseSampleValue('bogus')).toEqual({ kind: 'garbage', token: 'bogus' });
+  expect(parseSampleValue('')).toEqual({ kind: 'garbage', token: '' });
+  expect(parseSampleValue(null)).toEqual({ kind: 'garbage', token: 'null' });
+});
+
+// --- validatePromResponse ----------------------------------------------------
+
+test('prom: a well-formed matrix passes', () => {
+  const body = promMatrix([
+    {
+      metric: { __name__: 'up', job: 'cerberus' },
+      values: [
+        [1000, '1'],
+        [1015, '1'],
+        [1300, '0'],
+      ],
+    },
+  ]);
+  expect(validatePromResponse(body, CTX)).toEqual([]);
+});
+
+test('prom: a well-formed vector passes', () => {
+  const body = promVector([
+    { metric: { job: 'cerberus' }, value: [1234, '0.5'] },
+  ]);
+  expect(
+    validatePromResponse(body, { ...CTX, expectResultType: 'vector' }),
+  ).toEqual([]);
+});
+
+test('prom: an empty matrix passes (shows-data is a different oracle level)', () => {
+  expect(validatePromResponse(promMatrix([]), CTX)).toEqual([]);
+});
+
+test('prom: error envelope produces a status violation', () => {
+  const body = {
+    status: 'error',
+    errorType: 'bad_data',
+    error: 'parse error',
+  };
+  const v = validatePromResponse(body, CTX);
+  expect(v).toHaveLength(1);
+  expect(v[0]).toContain('status="error"');
+  expect(v[0]).toContain('parse error');
+});
+
+test('prom: non-object body produces an envelope violation', () => {
+  const v = validatePromResponse('not json', CTX);
+  expect(v).toHaveLength(1);
+  expect(v[0]).toContain('body is not a JSON object');
+});
+
+test('prom: resultType mismatch against the endpoint expectation', () => {
+  const v = validatePromResponse(promMatrix([]), {
+    ...CTX,
+    expectResultType: 'vector',
+  });
+  expect(v).toHaveLength(1);
+  expect(v[0]).toContain('resultType "matrix" (want "vector")');
+});
+
+test('prom: NaN sample is rejected by default', () => {
+  const body = promMatrix([
+    { metric: {}, values: [[1000, 'NaN']] },
+  ]);
+  const v = validatePromResponse(body, CTX);
+  expect(v).toHaveLength(1);
+  expect(v[0]).toContain('non-finite sample value "NaN"');
+});
+
+test('prom: +Inf sample is rejected by default', () => {
+  const body = promVector([{ metric: {}, value: [1000, '+Inf'] }]);
+  const v = validatePromResponse(body, CTX);
+  expect(v).toHaveLength(1);
+  expect(v[0]).toContain('non-finite sample value "+Inf"');
+});
+
+test('prom: NaN/Inf accepted when ctx.allowNaN is set', () => {
+  const body = promMatrix([
+    {
+      metric: {},
+      values: [
+        [1000, 'NaN'],
+        [1015, '+Inf'],
+        [1030, '-Inf'],
+      ],
+    },
+  ]);
+  expect(validatePromResponse(body, { ...CTX, allowNaN: true })).toEqual([]);
+});
+
+test('prom: garbage value string is rejected even under allowNaN', () => {
+  const body = promMatrix([{ metric: {}, values: [[1000, 'wat']] }]);
+  const v = validatePromResponse(body, { ...CTX, allowNaN: true });
+  expect(v).toHaveLength(1);
+  expect(v[0]).toContain('sample value "wat" is not numeric');
+});
+
+test('prom: timestamp before fromSec violates the window rule', () => {
+  const body = promMatrix([{ metric: {}, values: [[985, '1']] }]);
+  const v = validatePromResponse(body, CTX);
+  expect(v).toHaveLength(1);
+  expect(v[0]).toContain('timestamp 985 outside query window [1000, 1300]');
+});
+
+test('prom: timestamp after toSec violates the window rule', () => {
+  const body = promVector([{ metric: {}, value: [1301, '1'] }]);
+  const v = validatePromResponse(body, CTX);
+  expect(v).toHaveLength(1);
+  expect(v[0]).toContain('timestamp 1301 outside query window');
+});
+
+test('prom: window bounds are inclusive on both ends', () => {
+  const body = promMatrix([
+    {
+      metric: {},
+      values: [
+        [1000, '1'],
+        [1300, '1'],
+      ],
+    },
+  ]);
+  expect(validatePromResponse(body, CTX)).toEqual([]);
+});
+
+test('prom: matrix timestamp off the step grid is a violation', () => {
+  const body = promMatrix([{ metric: {}, values: [[1007, '1']] }]);
+  const v = validatePromResponse(body, CTX);
+  expect(v).toHaveLength(1);
+  expect(v[0]).toContain('not step-aligned to anchor 1000 (step=15s)');
+});
+
+test('prom: vector timestamps are not step-checked', () => {
+  // Instant queries answer at the evaluation time, not on a grid.
+  const body = promVector([{ metric: {}, value: [1007, '1'] }]);
+  expect(validatePromResponse(body, CTX)).toEqual([]);
+});
+
+test('prom: counter-rate expr class rejects negative values', () => {
+  const body = promMatrix([
+    {
+      metric: {},
+      values: [
+        [1000, '0.5'],
+        [1015, '-0.25'],
+      ],
+    },
+  ]);
+  const v = validatePromResponse(body, { ...CTX, exprClass: 'counter-rate' });
+  expect(v).toHaveLength(1);
+  expect(v[0]).toContain('counter-shaped expression produced negative value -0.25');
+});
+
+test('prom: counter-rate expr class accepts zero and positive values', () => {
+  const body = promMatrix([
+    {
+      metric: {},
+      values: [
+        [1000, '0'],
+        [1015, '3.5'],
+      ],
+    },
+  ]);
+  expect(
+    validatePromResponse(body, { ...CTX, exprClass: 'counter-rate' }),
+  ).toEqual([]);
+});
+
+test('prom: unconstrained expr class accepts negative values', () => {
+  const body = promMatrix([{ metric: {}, values: [[1000, '-3']] }]);
+  expect(
+    validatePromResponse(body, { ...CTX, exprClass: 'unconstrained' }),
+  ).toEqual([]);
+});
+
+test('prom: byKeys exact keyset passes when every series matches', () => {
+  const body = promMatrix([
+    { metric: { cerberus_ql: 'promql' }, values: [[1000, '1']] },
+    { metric: { __name__: 'x', cerberus_ql: 'logql' }, values: [[1000, '2']] },
+  ]);
+  expect(
+    validatePromResponse(body, { ...CTX, byKeys: ['cerberus_ql'] }),
+  ).toEqual([]);
+});
+
+test('prom: byKeys missing key produces a keyset violation', () => {
+  const body = promMatrix([
+    { metric: { other: 'x' }, values: [[1000, '1']] },
+  ]);
+  const v = validatePromResponse(body, { ...CTX, byKeys: ['cerberus_ql'] });
+  expect(v).toHaveLength(1);
+  expect(v[0]).toContain('missing=[cerberus_ql]');
+  expect(v[0]).toContain('extra=[other]');
+});
+
+test('prom: byKeys extra key produces a keyset violation', () => {
+  const body = promMatrix([
+    {
+      metric: { cerberus_ql: 'promql', instance: 'host-1' },
+      values: [[1000, '1']],
+    },
+  ]);
+  const v = validatePromResponse(body, { ...CTX, byKeys: ['cerberus_ql'] });
+  expect(v).toHaveLength(1);
+  expect(v[0]).toContain('extra=[instance]');
+});
+
+test('prom: byKeys ignores __name__ in the keyset comparison', () => {
+  const body = promVector([
+    { metric: { __name__: 'foo', a: '1', b: '2' }, value: [1000, '1'] },
+  ]);
+  expect(validatePromResponse(body, { ...CTX, byKeys: ['a', 'b'] })).toEqual([]);
+});
+
+test('prom: well-formed histogram bucket frames pass', () => {
+  const body = promMatrix([
+    {
+      metric: { le: '0.1', job: 'a' },
+      values: [
+        [1000, '1'],
+        [1015, '2'],
+      ],
+    },
+    {
+      metric: { le: '0.5', job: 'a' },
+      values: [
+        [1000, '3'],
+        [1015, '3'],
+      ],
+    },
+    {
+      metric: { le: '+Inf', job: 'a' },
+      values: [
+        [1000, '4'],
+        [1015, '5'],
+      ],
+    },
+  ]);
+  expect(validatePromResponse(body, CTX)).toEqual([]);
+});
+
+test('prom: duplicate le boundary is a violation', () => {
+  const body = promMatrix([
+    { metric: { le: '0.5', job: 'a' }, values: [[1000, '1']] },
+    { metric: { le: '0.5', job: 'a' }, values: [[1000, '2']] },
+  ]);
+  const v = validatePromResponse(body, CTX);
+  expect(v).toHaveLength(1);
+  expect(v[0]).toContain('duplicate le boundary "0.5"');
+});
+
+test('prom: cumulative count decreasing across ascending le is a violation', () => {
+  const body = promMatrix([
+    { metric: { le: '0.1', job: 'a' }, values: [[1000, '5']] },
+    { metric: { le: '+Inf', job: 'a' }, values: [[1000, '3']] },
+  ]);
+  const v = validatePromResponse(body, CTX);
+  expect(v).toHaveLength(1);
+  expect(v[0]).toContain('cumulative count decreasing at ts=1000');
+  expect(v[0]).toContain('le="0.1"');
+  expect(v[0]).toContain('le="+Inf"');
+});
+
+test('prom: histogram groups are partitioned by the non-le labels', () => {
+  // Two different jobs each carry a le=0.5 bucket — NOT a duplicate,
+  // and the cumulative rule applies within each group only.
+  const body = promMatrix([
+    { metric: { le: '0.5', job: 'a' }, values: [[1000, '5']] },
+    { metric: { le: '0.5', job: 'b' }, values: [[1000, '1']] },
+    { metric: { le: '+Inf', job: 'a' }, values: [[1000, '5']] },
+    { metric: { le: '+Inf', job: 'b' }, values: [[1000, '2']] },
+  ]);
+  expect(validatePromResponse(body, CTX)).toEqual([]);
+});
+
+test('prom: violations aggregate rather than throw-first', () => {
+  const body = promMatrix([
+    {
+      metric: {},
+      values: [
+        [985, 'NaN'],
+        [1007, 'wat'],
+      ],
+    },
+  ]);
+  const v = validatePromResponse(body, CTX);
+  // ts-out-of-window + non-finite + step-misaligned + garbage = 4.
+  expect(v.length).toBe(4);
+});
+
+test('prom: where prefix lands in every violation string', () => {
+  const body = promMatrix([{ metric: {}, values: [[985, '1']] }]);
+  const v = validatePromResponse(body, { ...CTX, where: 'panel="QPS"' });
+  expect(v).toHaveLength(1);
+  expect(v[0]).toContain('panel="QPS"');
+});
+
+// --- validateLokiResponse ----------------------------------------------------
+
+function lokiStreams(
+  streams: Array<{ stream: Record<string, string>; values: Array<[string, string]> }>,
+): unknown {
+  return { status: 'success', data: { resultType: 'streams', result: streams } };
+}
+
+test('loki: a well-formed streams response passes', () => {
+  const body = lokiStreams([
+    {
+      stream: { service_name: 'cerberus', detected_level: 'info' },
+      values: [
+        ['1000000000000', 'request served'],
+        ['1300000000000', 'another line'],
+      ],
+    },
+  ]);
+  expect(validateLokiResponse(body, CTX)).toEqual([]);
+});
+
+test('loki: severity outside the vocabulary is a violation', () => {
+  const body = lokiStreams([
+    {
+      stream: { detected_level: 'noisy' },
+      values: [['1000000000000', 'x']],
+    },
+  ]);
+  const v = validateLokiResponse(body, CTX);
+  expect(v).toHaveLength(1);
+  expect(v[0]).toContain('severity "noisy" outside');
+});
+
+test('loki: severity matching is case-insensitive across both label names', () => {
+  const ok = lokiStreams([
+    { stream: { detected_level: 'warn' }, values: [['1000000000000', 'x']] },
+    { stream: { SeverityText: 'Error' }, values: [['1000000000000', 'y']] },
+    { stream: { SeverityText: 'FATAL' }, values: [['1000000000000', 'z']] },
+  ]);
+  expect(validateLokiResponse(ok, CTX)).toEqual([]);
+});
+
+test('loki: a stream with no severity label passes (label is optional)', () => {
+  const body = lokiStreams([
+    { stream: { service_name: 'cerberus' }, values: [['1000000000000', 'x']] },
+  ]);
+  expect(validateLokiResponse(body, CTX)).toEqual([]);
+});
+
+test('loki: log timestamp outside the window is a violation', () => {
+  const body = lokiStreams([
+    { stream: {}, values: [['999999999999', 'too early']] },
+  ]);
+  const v = validateLokiResponse(body, CTX);
+  expect(v).toHaveLength(1);
+  expect(v[0]).toContain('outside query window');
+});
+
+test('loki: non-nanosecond timestamp string is a violation', () => {
+  const body = lokiStreams([{ stream: {}, values: [['abc', 'x']] }]);
+  const v = validateLokiResponse(body, CTX);
+  expect(v).toHaveLength(1);
+  expect(v[0]).toContain('is not a nanosecond string');
+});
+
+test('loki: empty log line body is a violation', () => {
+  const body = lokiStreams([{ stream: {}, values: [['1000000000000', '']] }]);
+  const v = validateLokiResponse(body, CTX);
+  expect(v).toHaveLength(1);
+  expect(v[0]).toContain('log line body is empty');
+});
+
+test('loki: metric matrix results reuse the prom numeric/ts rules', () => {
+  const ok = {
+    status: 'success',
+    data: {
+      resultType: 'matrix',
+      result: [{ metric: { SeverityText: 'ERROR' }, values: [[1015, '0.2']] }],
+    },
+  };
+  expect(validateLokiResponse(ok, CTX)).toEqual([]);
+
+  const bad = {
+    status: 'success',
+    data: {
+      resultType: 'matrix',
+      result: [{ metric: {}, values: [[1007, 'NaN']] }],
+    },
+  };
+  const v = validateLokiResponse(bad, CTX);
+  expect(v.length).toBe(2); // non-finite + step-misaligned
+  expect(v.join('\n')).toContain('non-finite sample value');
+  expect(v.join('\n')).toContain('not step-aligned');
+});
+
+test('loki: error envelope produces a status violation', () => {
+  const v = validateLokiResponse({ status: 'error', error: 'boom' }, CTX);
+  expect(v).toHaveLength(1);
+  expect(v[0]).toContain('status="error"');
+});
+
+test('loki: unrecognised resultType is a violation', () => {
+  const v = validateLokiResponse(
+    { status: 'success', data: { resultType: 'wobble', result: [] } },
+    CTX,
+  );
+  expect(v).toHaveLength(1);
+  expect(v[0]).toContain('unrecognised loki resultType "wobble"');
+});
+
+// --- validateTempoResponse ---------------------------------------------------
+
+test('tempo search: well-formed results pass', () => {
+  const body = {
+    traces: [
+      {
+        traceID: '0123456789abcdef0123456789abcdef',
+        rootServiceName: 'cerberus',
+        durationMs: 12,
+        startTimeUnixNano: '1000000000000',
+      },
+    ],
+  };
+  expect(validateTempoResponse(body, CTX)).toEqual([]);
+});
+
+test('tempo search: empty traces array passes (shows-data is level 1)', () => {
+  expect(validateTempoResponse({ traces: [] }, CTX)).toEqual([]);
+});
+
+test('tempo search: non-canonical traceID is a violation', () => {
+  const cases = [
+    'ABCDEF0123456789ABCDEF0123456789', // uppercase
+    'abc123', // short / un-padded
+    '0123456789abcdef0123456789abcdeg', // non-hex
+  ];
+  for (const traceID of cases) {
+    const v = validateTempoResponse({ traces: [{ traceID }] }, CTX);
+    expect(v).toHaveLength(1);
+    expect(v[0]).toContain('not 32-lowercase-hex');
+  }
+});
+
+test('tempo search: negative duration is a violation', () => {
+  const body = {
+    traces: [
+      { traceID: '0123456789abcdef0123456789abcdef', durationMs: -5 },
+    ],
+  };
+  const v = validateTempoResponse(body, CTX);
+  expect(v).toHaveLength(1);
+  expect(v[0]).toContain('durationMs -5 is negative or non-numeric');
+});
+
+test('tempo search: unparseable startTimeUnixNano is a violation', () => {
+  const body = {
+    traces: [
+      {
+        traceID: '0123456789abcdef0123456789abcdef',
+        startTimeUnixNano: 'soon',
+      },
+    ],
+  };
+  const v = validateTempoResponse(body, CTX);
+  expect(v).toHaveLength(1);
+  expect(v[0]).toContain('does not parse as a positive integer');
+});
+
+test('tempo trace-by-id: consistent parent links + kinds pass', () => {
+  const body = {
+    batches: [
+      {
+        resource: {},
+        scopeSpans: [
+          {
+            spans: [
+              { spanId: 'aaaa', kind: 'SPAN_KIND_SERVER' },
+              { spanId: 'bbbb', parentSpanId: 'aaaa', kind: 'SPAN_KIND_CLIENT' },
+              { spanId: 'cccc', parentSpanId: 'bbbb', kind: 3 },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+  expect(validateTempoResponse(body, CTX)).toEqual([]);
+});
+
+test('tempo trace-by-id: orphaned parentSpanId is a violation', () => {
+  const body = {
+    batches: [
+      {
+        scopeSpans: [
+          {
+            spans: [{ spanId: 'aaaa', parentSpanId: 'ffff' }],
+          },
+        ],
+      },
+    ],
+  };
+  const v = validateTempoResponse(body, CTX);
+  expect(v).toHaveLength(1);
+  expect(v[0]).toContain('parentSpanId "ffff" not present');
+});
+
+test('tempo trace-by-id: empty parentSpanId means root span (valid)', () => {
+  const body = {
+    resourceSpans: [
+      { scopeSpans: [{ spans: [{ spanId: 'aaaa', parentSpanId: '' }] }] },
+    ],
+  };
+  expect(validateTempoResponse(body, CTX)).toEqual([]);
+});
+
+test('tempo trace-by-id: span kind outside the OTLP enum is a violation', () => {
+  const body = {
+    batches: [
+      { scopeSpans: [{ spans: [{ spanId: 'aaaa', kind: 'SPAN_KIND_BOGUS' }] }] },
+    ],
+  };
+  const v = validateTempoResponse(body, CTX);
+  expect(v).toHaveLength(1);
+  expect(v[0]).toContain('span kind "SPAN_KIND_BOGUS" outside the OTLP enum');
+
+  const numeric = {
+    batches: [{ scopeSpans: [{ spans: [{ spanId: 'aaaa', kind: 7 }] }] }],
+  };
+  const v2 = validateTempoResponse(numeric, CTX);
+  expect(v2).toHaveLength(1);
+  expect(v2[0]).toContain('span kind 7 outside the OTLP enum');
+});
+
+test('tempo trace-by-id: zero spans is a violation (a trace cannot be empty)', () => {
+  const v = validateTempoResponse({ batches: [] }, CTX);
+  expect(v).toHaveLength(1);
+  expect(v[0]).toContain('no spans found');
+});
+
+test('tempo metrics: well-formed series pass', () => {
+  const body = {
+    series: [
+      {
+        labels: [{ key: 'resource.service.name', value: { stringValue: 'cerberus' } }],
+        samples: [
+          { timestampMs: 1000_000, value: 1.5 },
+          { timestampMs: 1300_000, value: 0 },
+        ],
+      },
+    ],
+  };
+  expect(validateTempoResponse(body, CTX)).toEqual([]);
+});
+
+test('tempo metrics: timestampMs outside the window is a violation', () => {
+  const body = {
+    series: [{ samples: [{ timestampMs: 1300_001, value: 1 }] }],
+  };
+  const v = validateTempoResponse(body, CTX);
+  expect(v).toHaveLength(1);
+  expect(v[0]).toContain('timestampMs 1300001 outside query window');
+});
+
+test('tempo metrics: non-finite value is rejected unless allowNaN', () => {
+  const body = {
+    series: [{ samples: [{ timestampMs: 1000_000, value: Number.NaN }] }],
+  };
+  const v = validateTempoResponse(body, CTX);
+  expect(v).toHaveLength(1);
+  expect(v[0]).toContain('non-finite sample value');
+  expect(validateTempoResponse(body, { ...CTX, allowNaN: true })).toEqual([]);
+});
+
+test('tempo: unrecognised body shape is a violation', () => {
+  const v = validateTempoResponse({ surprise: true }, CTX);
+  expect(v).toHaveLength(1);
+  expect(v[0]).toContain('unrecognised tempo response shape');
+});

--- a/test/e2e/playwright/helpers-variables.spec.ts
+++ b/test/e2e/playwright/helpers-variables.spec.ts
@@ -1,0 +1,285 @@
+/**
+ * Stack-free unit tests for the template-variable contracts
+ * (helpers/variables.ts): pin parsing, the set-equality matcher, the
+ * variable-query parser for all three heads, the proxy-path builder,
+ * and the response-shape extractors. The live resolution path
+ * (resolveVariableOptions / checkDashboardVariable) is exercised by
+ * iterate-all-dashboards.spec.ts once dashboards gain variables (P3);
+ * the pure halves are pinned here. Run via:
+ *
+ *   cd test/e2e/playwright && npx playwright test helpers-variables.spec.ts
+ */
+
+import { expect, test } from '@playwright/test';
+
+import {
+  checkVariableOptions,
+  compareOptionSets,
+  extractVariableOptions,
+  parseVariableQuery,
+  readVariablePin,
+  variableOptionsPath,
+} from './helpers/index.js';
+
+// --- readVariablePin ---------------------------------------------------------
+
+test('readVariablePin returns null when no pin is declared', () => {
+  expect(readVariablePin({ name: 'ql', type: 'query' })).toBeNull();
+  expect(readVariablePin({ name: 'ql', cerberus: {} })).toBeNull();
+  expect(readVariablePin(undefined)).toBeNull();
+});
+
+test('readVariablePin returns the declared option pin', () => {
+  expect(
+    readVariablePin({
+      name: 'ql',
+      cerberus: { expectOptions: ['promql', 'logql', 'traceql'] },
+    }),
+  ).toEqual(['promql', 'logql', 'traceql']);
+});
+
+test('readVariablePin throws on malformed pins', () => {
+  expect(() => readVariablePin({ cerberus: 'pin' })).toThrow(
+    /must be an object/,
+  );
+  expect(() => readVariablePin({ cerberus: { expectOptions: [] } })).toThrow(
+    /non-empty array/,
+  );
+  expect(() =>
+    readVariablePin({ cerberus: { expectOptions: ['ok', 42] } }),
+  ).toThrow(/non-empty strings/);
+  expect(() =>
+    readVariablePin({ cerberus: { expectOptions: 'promql' } }),
+  ).toThrow(/non-empty array/);
+});
+
+// --- compareOptionSets / checkVariableOptions --------------------------------
+
+test('compareOptionSets passes on set equality regardless of order', () => {
+  expect(compareOptionSets(['b', 'a'], ['a', 'b'])).toEqual([]);
+  expect(compareOptionSets(['x'], ['x'])).toEqual([]);
+});
+
+test('compareOptionSets reports pinned options missing from the live set', () => {
+  const v = compareOptionSets(['promql'], ['promql', 'logql']);
+  expect(v).toHaveLength(1);
+  expect(v[0]).toContain('pinned options missing from the live set: [logql]');
+});
+
+test('compareOptionSets reports live options the pin does not expect', () => {
+  const v = compareOptionSets(['promql', 'sqlql'], ['promql']);
+  expect(v).toHaveLength(1);
+  expect(v[0]).toContain('live options not in the pin: [sqlql]');
+});
+
+test('compareOptionSets reports both directions at once', () => {
+  const v = compareOptionSets(['a', 'c'], ['a', 'b']);
+  expect(v).toHaveLength(2);
+  expect(v.join('\n')).toContain('missing from the live set: [b]');
+  expect(v.join('\n')).toContain('not in the pin: [c]');
+});
+
+test('compareOptionSets rejects duplicated live options', () => {
+  const v = compareOptionSets(['a', 'a', 'b'], ['a', 'b']);
+  expect(v).toHaveLength(1);
+  expect(v[0]).toContain('duplicate options [a]');
+});
+
+test('checkVariableOptions applies the pin when present', () => {
+  expect(checkVariableOptions(['a', 'b'], ['b', 'a'])).toEqual([]);
+  expect(checkVariableOptions(['a', 'b'], ['a'])).toHaveLength(1);
+});
+
+test('checkVariableOptions requires non-empty options when unpinned', () => {
+  expect(checkVariableOptions(null, ['anything'])).toEqual([]);
+  const v = checkVariableOptions(null, []);
+  expect(v).toHaveLength(1);
+  expect(v[0]).toContain('zero options');
+});
+
+// --- parseVariableQuery ------------------------------------------------------
+
+test('parseVariableQuery: prom label_values without selector', () => {
+  expect(parseVariableQuery('prometheus', 'label_values(cerberus_ql)')).toEqual(
+    { kind: 'prom-label-values', label: 'cerberus_ql' },
+  );
+});
+
+test('parseVariableQuery: prom label_values with selector', () => {
+  expect(
+    parseVariableQuery(
+      'prometheus',
+      'label_values(cerberus_queries_total{result="ok"}, cerberus_ql)',
+    ),
+  ).toEqual({
+    kind: 'prom-label-values',
+    label: 'cerberus_ql',
+    selector: 'cerberus_queries_total{result="ok"}',
+  });
+});
+
+test('parseVariableQuery: prom label_names + object-wrapped query', () => {
+  expect(parseVariableQuery('prometheus', 'label_names()')).toEqual({
+    kind: 'prom-label-names',
+  });
+  expect(
+    parseVariableQuery('prometheus', {
+      query: 'label_values(up, job)',
+      refId: 'PrometheusVariableQueryEditor-VariableQuery',
+    }),
+  ).toEqual({ kind: 'prom-label-values', label: 'job', selector: 'up' });
+});
+
+test('parseVariableQuery: prom rejects unrecognised query strings', () => {
+  expect(() => parseVariableQuery('prometheus', 'metrics(up)')).toThrow(
+    /unrecognised prometheus variable query/,
+  );
+  expect(() => parseVariableQuery('prometheus', 42)).toThrow(
+    /neither a string nor \{query\}/,
+  );
+});
+
+test('parseVariableQuery: loki object + string forms', () => {
+  expect(
+    parseVariableQuery('loki', { type: 1, label: 'service_name', refId: 'x' }),
+  ).toEqual({ kind: 'loki-label-values', label: 'service_name' });
+  expect(parseVariableQuery('loki', { type: 0, refId: 'x' })).toEqual({
+    kind: 'loki-label-names',
+  });
+  expect(parseVariableQuery('loki', 'label_values(service_name)')).toEqual({
+    kind: 'loki-label-values',
+    label: 'service_name',
+  });
+  expect(parseVariableQuery('loki', 'label_names()')).toEqual({
+    kind: 'loki-label-names',
+  });
+});
+
+test('parseVariableQuery: loki rejects unrecognised shapes', () => {
+  expect(() => parseVariableQuery('loki', { type: 9 })).toThrow(
+    /unrecognised loki variable query/,
+  );
+  expect(() => parseVariableQuery('loki', 7)).toThrow(
+    /unrecognised loki variable query/,
+  );
+});
+
+test('parseVariableQuery: tempo tag names + tag values', () => {
+  expect(parseVariableQuery('tempo', { type: 0, refId: 'x' })).toEqual({
+    kind: 'tempo-tag-names',
+  });
+  expect(
+    parseVariableQuery('tempo', { type: 1, label: 'service.name', refId: 'x' }),
+  ).toEqual({ kind: 'tempo-tag-values', tag: 'service.name' });
+  expect(() => parseVariableQuery('tempo', 'tags()')).toThrow(
+    /unrecognised tempo variable query/,
+  );
+});
+
+test('parseVariableQuery: unknown datasource type throws', () => {
+  expect(() => parseVariableQuery('opentsdb', 'label_values(x)')).toThrow(
+    /has no variable-query lookup/,
+  );
+});
+
+// --- variableOptionsPath -----------------------------------------------------
+
+test('variableOptionsPath builds the per-head proxy lookups', () => {
+  expect(
+    variableOptionsPath('prom-uid', { kind: 'prom-label-names' }),
+  ).toBe('/api/datasources/proxy/uid/prom-uid/api/v1/labels');
+  expect(
+    variableOptionsPath('prom-uid', {
+      kind: 'prom-label-values',
+      label: 'cerberus_ql',
+    }),
+  ).toBe(
+    '/api/datasources/proxy/uid/prom-uid/api/v1/label/cerberus_ql/values',
+  );
+  expect(
+    variableOptionsPath('prom-uid', {
+      kind: 'prom-label-values',
+      label: 'job',
+      selector: 'up{a="b"}',
+    }),
+  ).toBe(
+    '/api/datasources/proxy/uid/prom-uid/api/v1/label/job/values?match[]=' +
+      encodeURIComponent('up{a="b"}'),
+  );
+  expect(variableOptionsPath('loki-uid', { kind: 'loki-label-names' })).toBe(
+    '/api/datasources/proxy/uid/loki-uid/loki/api/v1/labels',
+  );
+  expect(
+    variableOptionsPath('loki-uid', {
+      kind: 'loki-label-values',
+      label: 'service_name',
+    }),
+  ).toBe(
+    '/api/datasources/proxy/uid/loki-uid/loki/api/v1/label/service_name/values',
+  );
+  expect(variableOptionsPath('tempo-uid', { kind: 'tempo-tag-names' })).toBe(
+    '/api/datasources/proxy/uid/tempo-uid/api/v2/search/tags',
+  );
+  expect(
+    variableOptionsPath('tempo-uid', {
+      kind: 'tempo-tag-values',
+      tag: 'service.name',
+    }),
+  ).toBe(
+    '/api/datasources/proxy/uid/tempo-uid/api/v2/search/tag/service.name/values',
+  );
+});
+
+// --- extractVariableOptions --------------------------------------------------
+
+test('extractVariableOptions: prom/loki success-data envelopes', () => {
+  const body = { status: 'success', data: ['promql', 'logql'] };
+  expect(
+    extractVariableOptions({ kind: 'prom-label-values', label: 'x' }, body),
+  ).toEqual(['promql', 'logql']);
+  expect(
+    extractVariableOptions({ kind: 'loki-label-names' }, body),
+  ).toEqual(['promql', 'logql']);
+});
+
+test('extractVariableOptions: prom envelope mismatch throws', () => {
+  expect(() =>
+    extractVariableOptions(
+      { kind: 'prom-label-values', label: 'x' },
+      { status: 'error', error: 'boom' },
+    ),
+  ).toThrow(/not a success\/data envelope/);
+});
+
+test('extractVariableOptions: tempo v2 tags scopes union', () => {
+  const body = {
+    scopes: [
+      { name: 'resource', tags: ['service.name', 'host.name'] },
+      { name: 'span', tags: ['http.method', 'service.name'] },
+    ],
+  };
+  expect(
+    extractVariableOptions({ kind: 'tempo-tag-names' }, body).sort(),
+  ).toEqual(['host.name', 'http.method', 'service.name']);
+});
+
+test('extractVariableOptions: tempo v2 tag values', () => {
+  const body = {
+    tagValues: [
+      { type: 'string', value: 'cerberus' },
+      { type: 'string', value: 'sample-app' },
+    ],
+  };
+  expect(
+    extractVariableOptions({ kind: 'tempo-tag-values', tag: 't' }, body),
+  ).toEqual(['cerberus', 'sample-app']);
+});
+
+test('extractVariableOptions: tempo shape mismatch throws', () => {
+  expect(() =>
+    extractVariableOptions({ kind: 'tempo-tag-names' }, { tagValues: [] }),
+  ).toThrow(/no scopes array/);
+  expect(() =>
+    extractVariableOptions({ kind: 'tempo-tag-values', tag: 't' }, { scopes: [] }),
+  ).toThrow(/no tagValues array/);
+});

--- a/test/e2e/playwright/helpers.spec.ts
+++ b/test/e2e/playwright/helpers.spec.ts
@@ -50,6 +50,8 @@ import {
   iteratePanels,
   iterateDrilldownApps,
   isAppInstalled,
+  describeSweepDepth,
+  sweepDepth,
   DRILLDOWN_APPS,
 } from './helpers/index.js';
 
@@ -760,6 +762,42 @@ test('expectedByKeysForDsType dispatches per dsType', () => {
   ).toEqual(['resource.service.name']);
   // Unknown dsType → empty (the iterator skips these targets).
   expect(expectedByKeysForDsType('rate(foo[5m])', 'opentsdb')).toEqual([]);
+});
+
+// --- SWEEP_DEPTH plumbing ----------------------------------------------------
+
+test('sweepDepth defaults to lean and honours SWEEP_DEPTH', () => {
+  const saved = process.env.SWEEP_DEPTH;
+  try {
+    delete process.env.SWEEP_DEPTH;
+    expect(sweepDepth()).toBe('lean');
+    process.env.SWEEP_DEPTH = 'lean';
+    expect(sweepDepth()).toBe('lean');
+    process.env.SWEEP_DEPTH = 'full';
+    expect(sweepDepth()).toBe('full');
+  } finally {
+    if (saved === undefined) delete process.env.SWEEP_DEPTH;
+    else process.env.SWEEP_DEPTH = saved;
+  }
+});
+
+test('sweepDepth throws on a typo rather than silently falling back', () => {
+  const saved = process.env.SWEEP_DEPTH;
+  try {
+    process.env.SWEEP_DEPTH = 'FULL';
+    expect(() => sweepDepth()).toThrow(/must be 'lean' or 'full'/);
+    process.env.SWEEP_DEPTH = 'deep';
+    expect(() => sweepDepth()).toThrow(/must be 'lean' or 'full'/);
+  } finally {
+    if (saved === undefined) delete process.env.SWEEP_DEPTH;
+    else process.env.SWEEP_DEPTH = saved;
+  }
+});
+
+test('describeSweepDepth documents each depth distinctly', () => {
+  expect(describeSweepDepth('lean')).toContain('lean');
+  expect(describeSweepDepth('full')).toContain('full');
+  expect(describeSweepDepth('lean')).not.toBe(describeSweepDepth('full'));
 });
 
 // --- Live-Grafana tests -----------------------------------------------------

--- a/test/e2e/playwright/helpers/assertions.ts
+++ b/test/e2e/playwright/helpers/assertions.ts
@@ -39,6 +39,48 @@ export type DsQueryResponse = {
 };
 
 /**
+ * Collect every label key observed across every frame of a
+ * /api/ds/query response. Shared by the label-shape assertions below
+ * and exported for any sweep that needs the raw observed set.
+ *
+ * Empty-string label values still count as the key being *present* —
+ * the collection is about schema, not value. The value-side check
+ * (anonymous bucket fallback) lives in the phase-1 spec, not here.
+ */
+export function collectFrameLabelKeys(response: DsQueryResponse): Set<string> {
+  const observed = new Set<string>();
+  for (const target of Object.values(response.results ?? {})) {
+    for (const frame of target.frames ?? []) {
+      for (const field of frame.schema?.fields ?? []) {
+        for (const labelKey of Object.keys(field.labels ?? {})) {
+          observed.add(labelKey);
+        }
+      }
+    }
+  }
+  return observed;
+}
+
+/**
+ * Pure set-diff between an observed label keyset and the expected
+ * by-keys. `missing` = expected keys not observed; `extra` = observed
+ * keys not expected. Shared with helpers/validity.ts, whose exact-
+ * keyset rule consumes both sides; the presence-only assertions below
+ * consume `missing` only.
+ */
+export function diffLabelKeys(
+  observed: Iterable<string>,
+  expected: string[],
+): { missing: string[]; extra: string[] } {
+  const observedSet = new Set(observed);
+  const expectedSet = new Set(expected);
+  return {
+    missing: expected.filter((k) => !observedSet.has(k)),
+    extra: [...observedSet].filter((k) => !expectedSet.has(k)).sort(),
+  };
+}
+
+/**
  * For each key in `byKeys`, assert that at least one frame in the
  * response carries that key in `schema.fields[].labels`.
  *
@@ -53,21 +95,8 @@ export function assertLabelShape(
   byKeys: string[],
 ): void {
   if (byKeys.length === 0) return;
-  const observed = new Set<string>();
-  for (const target of Object.values(response.results ?? {})) {
-    for (const frame of target.frames ?? []) {
-      for (const field of frame.schema?.fields ?? []) {
-        for (const labelKey of Object.keys(field.labels ?? {})) {
-          // Empty-string label values still count as the key being
-          // *present* — the assertion is about schema, not value.
-          // The value-side check (anonymous bucket fallback) lives in
-          // the phase-1 spec, not here.
-          observed.add(labelKey);
-        }
-      }
-    }
-  }
-  const missing = byKeys.filter((k) => !observed.has(k));
+  const observed = collectFrameLabelKeys(response);
+  const { missing } = diffLabelKeys(observed, byKeys);
   if (missing.length > 0) {
     throw new Error(
       `assertLabelShape: expected labels [${byKeys.join(', ')}] but only saw [${[
@@ -94,16 +123,7 @@ export function assertLabelAbsent(
   withoutKeys: string[],
 ): void {
   if (withoutKeys.length === 0) return;
-  const observed = new Set<string>();
-  for (const target of Object.values(response.results ?? {})) {
-    for (const frame of target.frames ?? []) {
-      for (const field of frame.schema?.fields ?? []) {
-        for (const labelKey of Object.keys(field.labels ?? {})) {
-          observed.add(labelKey);
-        }
-      }
-    }
-  }
+  const observed = collectFrameLabelKeys(response);
   const leaked = withoutKeys.filter((k) => observed.has(k));
   if (leaked.length > 0) {
     throw new Error(

--- a/test/e2e/playwright/helpers/depth.ts
+++ b/test/e2e/playwright/helpers/depth.ts
@@ -1,0 +1,51 @@
+/**
+ * SWEEP_DEPTH plumbing.
+ *
+ * The dashboard sweeps run in two depths:
+ *
+ *   - 'lean' (default) — the per-PR gate. Probes every consumption
+ *     surface at the API layer; browser renders are restricted to
+ *     the ops-family dashboards.
+ *   - 'full' — the nightly lane. Everything 'lean' does PLUS the
+ *     browser render of every dashboard (including the
+ *     showcase-prefixed family as it lands in P2+).
+ *
+ * THE INVARIANT: depth never changes which RULES run — only how many
+ * STATES they run against. A check that exists at 'lean' asserts the
+ * exact same contract at 'full'; 'full' just visits more (dashboard
+ * × render-path × range) states. Anything else would make the PR
+ * gate and the nightly lane diverge on semantics rather than
+ * coverage, and a nightly-only failure would stop being "more
+ * surface" and start being "different rules".
+ *
+ * CI wiring: .github/workflows/e2e.yml sets SWEEP_DEPTH=full on the
+ * nightly schedule and leaves the default ('lean') for pull_request
+ * + push lanes.
+ */
+
+export type SweepDepth = 'lean' | 'full';
+
+/**
+ * Resolve the active sweep depth from the SWEEP_DEPTH env var.
+ * Default 'lean'; anything other than 'lean' / 'full' throws — a
+ * typo'd depth must fail the run, not silently fall back.
+ */
+export function sweepDepth(): SweepDepth {
+  const raw = process.env.SWEEP_DEPTH ?? 'lean';
+  if (raw === 'lean' || raw === 'full') return raw;
+  throw new Error(
+    `sweepDepth: SWEEP_DEPTH must be 'lean' or 'full', got ${JSON.stringify(raw)}`,
+  );
+}
+
+/**
+ * One-line description of the active depth for the CI run record.
+ * Specs that branch on depth log this once (the document pattern) so
+ * a run's coverage shape is visible in the job output without
+ * reverse-engineering it from the test counts.
+ */
+export function describeSweepDepth(depth: SweepDepth = sweepDepth()): string {
+  return depth === 'full'
+    ? 'sweep depth: full (nightly lane — browser-renders every dashboard, including the showcase family)'
+    : 'sweep depth: lean (PR gate — API-layer probes everywhere; browser renders for ops-family dashboards only)';
+}

--- a/test/e2e/playwright/helpers/expectations.ts
+++ b/test/e2e/playwright/helpers/expectations.ts
@@ -1,0 +1,169 @@
+/**
+ * cerberus.expect panel contracts.
+ *
+ * A dashboard panel may declare its expected sweep outcome via a
+ * custom `cerberus` field in its JSON:
+ *
+ *   { "cerberus": { "expect": "nonempty", "why": "…" } }
+ *   { "cerberus": { "expect": "empty", "why": "…" } }
+ *   { "cerberus": { "expect": "error:<substring>", "why": "…" } }
+ *
+ * Absent declaration = the default contract: the panel must return
+ * data ('nonempty'). Declarations are BIDIRECTIONAL pins, not
+ * tolerances:
+ *
+ *   - a panel declared 'empty' that returns series is a violation —
+ *     the feature it showcases (a query shape whose defined result
+ *     is empty) broke;
+ *   - a panel declared 'error:<s>' that succeeds, or that errors
+ *     with a body not containing <s>, is a violation;
+ *   - the default 'nonempty' panel returning zero series is a
+ *     violation (the pre-existing sweep behaviour).
+ *
+ * Family policy (enforced stack-free by
+ * expectation-contracts.spec.ts): ops-family dashboards (any file
+ * not prefixed `showcase-`) must not carry ANY cerberus.expect
+ * declaration — non-default expectations are a showcase-family
+ * privilege — and every non-default declaration anywhere must carry
+ * a non-empty `why`.
+ */
+
+/** The declared outcome contract for a panel. */
+export type ExpectKind = 'nonempty' | 'empty' | `error:${string}`;
+
+export type PanelExpectation = {
+  expect: ExpectKind;
+  /** true iff the dashboard JSON carries an explicit declaration. */
+  declared: boolean;
+  why?: string;
+};
+
+/** What the sweep observed when it probed the panel's target. */
+export type ObservedOutcome = {
+  /** Series / streams / traces count; <= 0 means no data. */
+  seriesCount: number;
+  /** HTTP status of the probe response. */
+  status: number;
+  /** Raw response body, used for error-substring matching. */
+  errorBody?: string;
+};
+
+/**
+ * Parse `panel.cerberus` into a `PanelExpectation`. An absent
+ * declaration yields the default `{ expect: 'nonempty', declared:
+ * false }`. A malformed declaration THROWS — a contract that cannot
+ * be parsed must fail the sweep loudly, never degrade to a default.
+ */
+export function readPanelExpectation(panelJson: unknown): PanelExpectation {
+  if (panelJson === null || typeof panelJson !== 'object') {
+    return { expect: 'nonempty', declared: false };
+  }
+  const cerberus = (panelJson as Record<string, unknown>).cerberus;
+  if (cerberus === undefined) {
+    return { expect: 'nonempty', declared: false };
+  }
+  if (cerberus === null || typeof cerberus !== 'object') {
+    throw new Error(
+      `readPanelExpectation: panel.cerberus must be an object, got ${JSON.stringify(cerberus)}`,
+    );
+  }
+  const c = cerberus as Record<string, unknown>;
+  const expect = c.expect;
+  if (typeof expect !== 'string') {
+    throw new Error(
+      `readPanelExpectation: panel.cerberus.expect must be a string, got ${JSON.stringify(expect)}`,
+    );
+  }
+  const valid =
+    expect === 'nonempty' ||
+    expect === 'empty' ||
+    (expect.startsWith('error:') && expect.length > 'error:'.length);
+  if (!valid) {
+    throw new Error(
+      `readPanelExpectation: panel.cerberus.expect must be ` +
+        `'nonempty' | 'empty' | 'error:<substring>', got ${JSON.stringify(expect)}`,
+    );
+  }
+  if (c.why !== undefined && typeof c.why !== 'string') {
+    throw new Error(
+      `readPanelExpectation: panel.cerberus.why must be a string, got ${JSON.stringify(c.why)}`,
+    );
+  }
+  return {
+    expect: expect as ExpectKind,
+    declared: true,
+    ...(c.why !== undefined ? { why: c.why } : {}),
+  };
+}
+
+/** True iff the expectation deviates from the default contract. */
+export function isNonDefaultExpectation(e: PanelExpectation): boolean {
+  return e.declared && e.expect !== 'nonempty';
+}
+
+/**
+ * Enforce a panel expectation against the observed probe outcome.
+ * Returns a string[] of violations (empty = the contract holds), so
+ * sweeps aggregate across panels.
+ *
+ * The check is bidirectional in every branch — a declared
+ * expectation that is no longer met is just as much a failure as
+ * the default contract breaking.
+ */
+export function enforceExpectation(
+  expectation: PanelExpectation,
+  observed: ObservedOutcome,
+): string[] {
+  const out: string[] = [];
+  const ok2xx = observed.status >= 200 && observed.status <= 299;
+
+  if (expectation.expect === 'nonempty' || expectation.expect === 'empty') {
+    if (!ok2xx) {
+      out.push(
+        `expected a successful response but got HTTP ${observed.status}` +
+          (observed.errorBody !== undefined && observed.errorBody !== ''
+            ? `: ${truncate(observed.errorBody, 300)}`
+            : ''),
+      );
+      return out;
+    }
+    if (expectation.expect === 'empty' && observed.seriesCount > 0) {
+      out.push(
+        `declared-empty panel returned ${observed.seriesCount} series ` +
+          `(the feature it showcases broke)`,
+      );
+    }
+    if (expectation.expect === 'nonempty' && observed.seriesCount <= 0) {
+      out.push(
+        `panel returned no series (count=${observed.seriesCount}); ` +
+          `the default contract is nonempty — fix the bug at the source ` +
+          `(cerberus code, seed, dashboard, or panel expression)`,
+      );
+    }
+    return out;
+  }
+
+  // 'error:<substring>' — the panel showcases a defined error.
+  const want = expectation.expect.slice('error:'.length);
+  if (ok2xx) {
+    out.push(
+      `declared error:${JSON.stringify(want)} but the probe succeeded with ` +
+        `HTTP ${observed.status} (${observed.seriesCount} series) — the ` +
+        `error the panel showcases no longer fires`,
+    );
+    return out;
+  }
+  const body = observed.errorBody ?? '';
+  if (!body.includes(want)) {
+    out.push(
+      `declared error:${JSON.stringify(want)} and got HTTP ` +
+        `${observed.status}, but the error body does not contain the ` +
+        `declared substring: ${truncate(body, 300)}`,
+    );
+  }
+  return out;
+}
+
+function truncate(s: string, n: number): string {
+  return s.length <= n ? s : `${s.slice(0, n)}…<truncated, ${s.length} chars>`;
+}

--- a/test/e2e/playwright/helpers/index.ts
+++ b/test/e2e/playwright/helpers/index.ts
@@ -17,3 +17,4 @@ export * from './probes.js';
 export * from './validity.js';
 export * from './expectations.js';
 export * from './variables.js';
+export * from './depth.js';

--- a/test/e2e/playwright/helpers/index.ts
+++ b/test/e2e/playwright/helpers/index.ts
@@ -14,3 +14,4 @@ export * from './sweep.js';
 export * from './drilldown.js';
 export * from './dom.js';
 export * from './probes.js';
+export * from './validity.js';

--- a/test/e2e/playwright/helpers/index.ts
+++ b/test/e2e/playwright/helpers/index.ts
@@ -16,3 +16,4 @@ export * from './dom.js';
 export * from './probes.js';
 export * from './validity.js';
 export * from './expectations.js';
+export * from './variables.js';

--- a/test/e2e/playwright/helpers/index.ts
+++ b/test/e2e/playwright/helpers/index.ts
@@ -15,3 +15,4 @@ export * from './drilldown.js';
 export * from './dom.js';
 export * from './probes.js';
 export * from './validity.js';
+export * from './expectations.js';

--- a/test/e2e/playwright/helpers/validity.ts
+++ b/test/e2e/playwright/helpers/validity.ts
@@ -1,0 +1,745 @@
+/**
+ * Validity-oracle library — level-3 ("valid-data") frame contracts.
+ *
+ * The three-level oracle for every Grafana consumption surface is:
+ *
+ *   1. shows-data  — the response carries ≥ 1 series / stream / trace
+ *                    (enforced by the sweeps via helpers/expectations.ts).
+ *   2. no-errors   — 2xx status, no tunneled envelope error.
+ *   3. valid-data  — the *contents* of the frames honour the wire
+ *                    contract of the head that produced them. That is
+ *                    this module.
+ *
+ * Every validator here is a PURE function over a captured response
+ * body: no I/O, no Playwright fixtures, fully unit-testable
+ * (helpers-validity.spec.ts runs them stack-free). Each returns a
+ * `string[]` of violations — empty means valid — so sweeps can
+ * AGGREGATE findings across panels rather than throw on the first.
+ *
+ * The validators deliberately re-implement nothing that already
+ * exists: by-key extraction lives in helpers/query-shape.ts
+ * (`expectedByKeysForDsType`), and the label-key set diff is shared
+ * with helpers/assertions.ts (`diffLabelKeys`).
+ */
+
+import { diffLabelKeys } from './assertions.js';
+
+/** Prometheus API result types the validators understand. */
+export type PromResultType = 'matrix' | 'vector' | 'scalar' | 'string';
+
+/**
+ * Expression classes that constrain the sample-value domain.
+ *
+ *   - 'counter-rate'  — rate() / increase() / irate() / resets() /
+ *     count_over_time()-style counter shapes: every value must be
+ *     >= 0 (a negative rate means the engine mis-handled a counter
+ *     reset or emitted a fabricated delta).
+ *   - 'unconstrained' — no domain constraint beyond finiteness.
+ */
+export type ExprClass = 'counter-rate' | 'unconstrained';
+
+/**
+ * Per-query context the caller derives from the request it fired.
+ *
+ * `allowNaN` exists because a small set of PromQL expression classes
+ * define NaN as a legitimate result (e.g. histogram_quantile over
+ * empty buckets, 0/0 divisions). The CALLER opts in per expression;
+ * the default is the strict contract: every sample must be finite.
+ */
+export type ValidityContext = {
+  /** Inclusive lower bound of the query window, unix seconds. */
+  fromSec: number;
+  /** Inclusive upper bound of the query window, unix seconds. */
+  toSec: number;
+  /**
+   * Range-query step in seconds. When set, every matrix timestamp
+   * must be step-aligned to the `fromSec` anchor (Prometheus range
+   * semantics: samples land on `start + k*step`).
+   */
+  stepSec?: number;
+  /**
+   * The resultType the endpoint contract promises — `query_range`
+   * answers `matrix`, instant `query` answers `vector` (or `scalar`
+   * for scalar expressions). Unset = any resultType accepted.
+   */
+  expectResultType?: PromResultType;
+  /** Accept NaN/±Inf sample values (see type doc). Default: reject. */
+  allowNaN?: boolean;
+  /** Domain constraint derived from the expression shape. */
+  exprClass?: ExprClass;
+  /**
+   * When non-empty: every result series' label keyset (minus
+   * `__name__`) must equal EXACTLY this set — the post-aggregation
+   * contract of `sum by (k1, k2) (…)`. Derive via
+   * `expectedByKeysForDsType` from helpers/query-shape.ts.
+   */
+  byKeys?: string[];
+  /** Free-form prefix for violation strings (panel / target id). */
+  where?: string;
+};
+
+// ---------------------------------------------------------------------------
+// Shared numeric / timestamp primitives
+// ---------------------------------------------------------------------------
+
+// Strict float token — what a well-formed finite Prometheus sample
+// value string looks like. `Number('')` is 0 and `Number('1x')` is
+// NaN, so a regex gate distinguishes "garbage string" from the
+// well-known non-finite tokens below.
+const FLOAT_RE = /^[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?$/;
+const NONFINITE_RE = /^([+-]?Inf(inity)?|NaN)$/;
+
+type ParsedSample =
+  | { kind: 'finite'; value: number }
+  | { kind: 'nonfinite'; token: string }
+  | { kind: 'garbage'; token: string };
+
+/**
+ * Parse a Prometheus-style sample value. Accepts the wire encodings
+ * the upstream APIs emit: a JSON string (`"1.5"`, `"NaN"`, `"+Inf"`)
+ * or a raw JSON number (Tempo metrics emit float64 directly).
+ */
+export function parseSampleValue(raw: unknown): ParsedSample {
+  if (typeof raw === 'number') {
+    return Number.isFinite(raw)
+      ? { kind: 'finite', value: raw }
+      : { kind: 'nonfinite', token: String(raw) };
+  }
+  if (typeof raw === 'string') {
+    if (FLOAT_RE.test(raw)) return { kind: 'finite', value: Number(raw) };
+    if (NONFINITE_RE.test(raw)) return { kind: 'nonfinite', token: raw };
+    return { kind: 'garbage', token: raw };
+  }
+  return { kind: 'garbage', token: JSON.stringify(raw) };
+}
+
+function checkSampleValue(
+  raw: unknown,
+  ctx: ValidityContext,
+  where: string,
+  out: string[],
+): void {
+  const parsed = parseSampleValue(raw);
+  if (parsed.kind === 'garbage') {
+    out.push(`${where}: sample value ${JSON.stringify(parsed.token)} is not numeric`);
+    return;
+  }
+  if (parsed.kind === 'nonfinite') {
+    if (!ctx.allowNaN) {
+      out.push(
+        `${where}: non-finite sample value "${parsed.token}" (NaN/Inf rejected; ` +
+          `set allowNaN only for expr classes where NaN is the defined result)`,
+      );
+    }
+    return;
+  }
+  if (ctx.exprClass === 'counter-rate' && parsed.value < 0) {
+    out.push(
+      `${where}: counter-shaped expression produced negative value ${parsed.value}`,
+    );
+  }
+}
+
+// Step-alignment float tolerance. Prom timestamps are second-precision
+// floats; 1ms slack absorbs the float noise without admitting a real
+// misalignment (the smallest step the dashboards use is 15s).
+const STEP_EPSILON_SEC = 1e-3;
+
+function checkTimestampSec(
+  ts: unknown,
+  ctx: ValidityContext,
+  stepAligned: boolean,
+  where: string,
+  out: string[],
+): void {
+  if (typeof ts !== 'number' || !Number.isFinite(ts)) {
+    out.push(`${where}: timestamp ${JSON.stringify(ts)} is not a finite number`);
+    return;
+  }
+  if (ts < ctx.fromSec || ts > ctx.toSec) {
+    out.push(
+      `${where}: timestamp ${ts} outside query window [${ctx.fromSec}, ${ctx.toSec}]`,
+    );
+  }
+  if (stepAligned && ctx.stepSec !== undefined && ctx.stepSec > 0) {
+    const offset = (ts - ctx.fromSec) % ctx.stepSec;
+    const dist = Math.min(Math.abs(offset), Math.abs(ctx.stepSec - Math.abs(offset)));
+    if (dist > STEP_EPSILON_SEC) {
+      out.push(
+        `${where}: timestamp ${ts} not step-aligned to anchor ${ctx.fromSec} (step=${ctx.stepSec}s)`,
+      );
+    }
+  }
+}
+
+function prefix(ctx: ValidityContext): string {
+  return ctx.where ? `${ctx.where}` : '';
+}
+
+function loc(ctx: ValidityContext, detail: string): string {
+  const p = prefix(ctx);
+  return p === '' ? detail : `${p} ${detail}`;
+}
+
+// ---------------------------------------------------------------------------
+// Prometheus
+// ---------------------------------------------------------------------------
+
+type PromSeries = {
+  metric?: Record<string, string>;
+  values?: unknown[];
+  value?: unknown;
+};
+
+/**
+ * Validate a Prometheus `/api/v1/query` / `/api/v1/query_range`
+ * response body against the level-3 frame contract:
+ *
+ *   - envelope `status === 'success'`;
+ *   - `data.resultType` matches the endpoint expectation;
+ *   - every sample value parses numeric — NaN/Inf rejected unless
+ *     `ctx.allowNaN`;
+ *   - every timestamp within `[fromSec, toSec]` inclusive and (for
+ *     matrix results) step-aligned to `ctx.stepSec`;
+ *   - `ctx.exprClass === 'counter-rate'` ⇒ all values >= 0;
+ *   - histogram frames (`le` label present): `le` values ascending
+ *     and per-timestamp cumulative counts non-decreasing across the
+ *     ascending buckets;
+ *   - `ctx.byKeys` non-empty ⇒ every series' label keyset (minus
+ *     `__name__`) equals exactly that set.
+ */
+export function validatePromResponse(
+  body: unknown,
+  ctx: ValidityContext,
+): string[] {
+  const out: string[] = [];
+  const env = promEnvelope(body, ctx, out);
+  if (env === null) return out;
+  const { resultType, result } = env;
+
+  if (
+    ctx.expectResultType !== undefined &&
+    resultType !== ctx.expectResultType
+  ) {
+    out.push(
+      loc(ctx, `envelope: resultType "${resultType}" (want "${ctx.expectResultType}")`),
+    );
+  }
+
+  if (resultType === 'scalar' || resultType === 'string') {
+    // data.result is a single [ts, value] pair.
+    const pair = result as unknown;
+    if (!Array.isArray(pair) || pair.length !== 2) {
+      out.push(loc(ctx, `scalar: result is not a [ts, value] pair`));
+      return out;
+    }
+    checkTimestampSec(pair[0], ctx, false, loc(ctx, 'scalar'), out);
+    if (resultType === 'scalar') {
+      checkSampleValue(pair[1], ctx, loc(ctx, 'scalar'), out);
+    }
+    return out;
+  }
+
+  if (!Array.isArray(result)) {
+    out.push(loc(ctx, `envelope: data.result is not an array`));
+    return out;
+  }
+  const series = result as PromSeries[];
+
+  for (const [i, s] of series.entries()) {
+    const sWhere = loc(ctx, `series[${i}]`);
+    if (resultType === 'matrix') {
+      for (const pair of asPairs(s.values, sWhere, out)) {
+        checkTimestampSec(pair[0], ctx, true, sWhere, out);
+        checkSampleValue(pair[1], ctx, sWhere, out);
+      }
+    } else {
+      // vector
+      const pair = s.value;
+      if (!Array.isArray(pair) || pair.length !== 2) {
+        out.push(`${sWhere}: vector sample is not a [ts, value] pair`);
+      } else {
+        checkTimestampSec(pair[0], ctx, false, sWhere, out);
+        checkSampleValue(pair[1], ctx, sWhere, out);
+      }
+    }
+
+    if (ctx.byKeys !== undefined && ctx.byKeys.length > 0) {
+      const keys = Object.keys(s.metric ?? {}).filter((k) => k !== '__name__');
+      const diff = diffLabelKeys(keys, ctx.byKeys);
+      if (diff.missing.length > 0 || diff.extra.length > 0) {
+        out.push(
+          `${sWhere}: label keyset [${keys.sort().join(', ')}] != by-keys ` +
+            `[${[...ctx.byKeys].sort().join(', ')}] ` +
+            `(missing=[${diff.missing.join(', ')}] extra=[${diff.extra.join(', ')}])`,
+        );
+      }
+    }
+  }
+
+  out.push(...validateHistogramBuckets(series, ctx));
+  return out;
+}
+
+function promEnvelope(
+  body: unknown,
+  ctx: ValidityContext,
+  out: string[],
+): { resultType: string; result: unknown } | null {
+  if (body === null || typeof body !== 'object') {
+    out.push(loc(ctx, `envelope: body is not a JSON object`));
+    return null;
+  }
+  const b = body as Record<string, unknown>;
+  if (b.status !== 'success') {
+    out.push(
+      loc(
+        ctx,
+        `envelope: status=${JSON.stringify(b.status)} (want "success")` +
+          (typeof b.error === 'string' ? ` error=${b.error}` : ''),
+      ),
+    );
+    return null;
+  }
+  const data = b.data;
+  if (data === null || typeof data !== 'object') {
+    out.push(loc(ctx, `envelope: data is not a JSON object`));
+    return null;
+  }
+  const d = data as Record<string, unknown>;
+  if (typeof d.resultType !== 'string') {
+    out.push(loc(ctx, `envelope: data.resultType missing`));
+    return null;
+  }
+  return { resultType: d.resultType, result: d.result };
+}
+
+function asPairs(
+  values: unknown,
+  where: string,
+  out: string[],
+): unknown[][] {
+  if (!Array.isArray(values)) {
+    out.push(`${where}: matrix series carries no values array`);
+    return [];
+  }
+  const pairs: unknown[][] = [];
+  for (const v of values) {
+    if (!Array.isArray(v) || v.length !== 2) {
+      out.push(`${where}: matrix sample is not a [ts, value] pair`);
+      continue;
+    }
+    pairs.push(v);
+  }
+  return pairs;
+}
+
+// Cumulative-bucket float tolerance: rate() over adjacent buckets can
+// produce sub-nano float noise where a higher bucket dips below a
+// lower one without any real monotonicity break.
+const CUMULATIVE_EPSILON = 1e-9;
+
+/**
+ * Histogram bucket-frame contract: among the series that carry an
+ * `le` label, group by the remaining label set; within each group
+ * the parsed `le` boundaries must be strictly ascending (after
+ * sorting; a duplicate boundary is a violation) and, per timestamp,
+ * the cumulative counts must be non-decreasing as `le` grows.
+ */
+function validateHistogramBuckets(
+  series: PromSeries[],
+  ctx: ValidityContext,
+): string[] {
+  const out: string[] = [];
+  type Bucket = { le: number; leRaw: string; samples: Map<number, number> };
+  const groups = new Map<string, Bucket[]>();
+
+  for (const s of series) {
+    const metric = s.metric ?? {};
+    const leRaw = metric.le;
+    if (leRaw === undefined) continue;
+    const le = parseLe(leRaw);
+    const groupKey = JSON.stringify(
+      Object.entries(metric)
+        .filter(([k]) => k !== 'le')
+        .sort(([a], [b]) => a.localeCompare(b)),
+    );
+    const samples = new Map<number, number>();
+    const pairs: unknown[] =
+      s.values !== undefined ? (Array.isArray(s.values) ? s.values : []) : s.value !== undefined ? [s.value] : [];
+    for (const p of pairs) {
+      if (!Array.isArray(p) || p.length !== 2) continue;
+      const parsed = parseSampleValue(p[1]);
+      if (parsed.kind !== 'finite' || typeof p[0] !== 'number') continue;
+      samples.set(p[0], parsed.value);
+    }
+    const bucket: Bucket = { le, leRaw: String(leRaw), samples };
+    const existing = groups.get(groupKey);
+    if (existing === undefined) groups.set(groupKey, [bucket]);
+    else existing.push(bucket);
+  }
+
+  for (const [groupKey, buckets] of groups) {
+    if (buckets.some((b) => Number.isNaN(b.le))) {
+      const bad = buckets.filter((b) => Number.isNaN(b.le)).map((b) => b.leRaw);
+      out.push(
+        loc(ctx, `histogram ${groupKey}: unparseable le boundary [${bad.join(', ')}]`),
+      );
+      continue;
+    }
+    buckets.sort((a, b) => a.le - b.le);
+    for (let i = 1; i < buckets.length; i++) {
+      const prev = buckets[i - 1]!;
+      const cur = buckets[i]!;
+      if (cur.le === prev.le) {
+        out.push(
+          loc(
+            ctx,
+            `histogram ${groupKey}: duplicate le boundary "${cur.leRaw}" — le values must be ascending`,
+          ),
+        );
+        continue;
+      }
+      for (const [ts, prevVal] of prev.samples) {
+        const curVal = cur.samples.get(ts);
+        if (curVal === undefined) continue;
+        if (curVal < prevVal - CUMULATIVE_EPSILON) {
+          out.push(
+            loc(
+              ctx,
+              `histogram ${groupKey}: cumulative count decreasing at ts=${ts} ` +
+                `(le="${prev.leRaw}" → ${prevVal}, le="${cur.leRaw}" → ${curVal})`,
+            ),
+          );
+        }
+      }
+    }
+  }
+  return out;
+}
+
+function parseLe(raw: string): number {
+  if (NONFINITE_RE.test(raw)) {
+    return raw.startsWith('-') ? -Infinity : raw === 'NaN' ? NaN : Infinity;
+  }
+  return FLOAT_RE.test(raw) ? Number(raw) : NaN;
+}
+
+// ---------------------------------------------------------------------------
+// Loki
+// ---------------------------------------------------------------------------
+
+/**
+ * Severity vocabulary for the level-3 log contract. The
+ * `detected_level` / `SeverityText` labels, when present on a
+ * stream, must case-insensitively match one of these.
+ */
+export const LOG_SEVERITY_LEVELS = new Set([
+  'TRACE',
+  'DEBUG',
+  'INFO',
+  'WARN',
+  'ERROR',
+  'FATAL',
+]);
+
+/**
+ * Validate a Loki `/loki/api/v1/query_range` (or instant `query`)
+ * response body:
+ *
+ *   - envelope `status === 'success'` + recognised resultType;
+ *   - streams: every log line's timestamp within the query window,
+ *     severity label (detected_level / SeverityText, when present)
+ *     within {TRACE, DEBUG, INFO, WARN, ERROR, FATAL} case-
+ *     insensitively, and the line body non-empty;
+ *   - metric results (matrix / vector): the same numeric + timestamp
+ *     rules as the Prometheus validator.
+ */
+export function validateLokiResponse(
+  body: unknown,
+  ctx: ValidityContext,
+): string[] {
+  const out: string[] = [];
+  const env = promEnvelope(body, ctx, out);
+  if (env === null) return out;
+  const { resultType, result } = env;
+
+  if (resultType === 'matrix' || resultType === 'vector') {
+    // Metric-producing LogQL — identical frame rules to Prometheus.
+    // Re-wrap so the prom validator sees the envelope it expects and
+    // the endpoint-expectation check still applies.
+    return validatePromResponse(
+      { status: 'success', data: { resultType, result } },
+      ctx,
+    );
+  }
+  if (resultType !== 'streams') {
+    out.push(loc(ctx, `envelope: unrecognised loki resultType "${resultType}"`));
+    return out;
+  }
+  if (ctx.expectResultType !== undefined) {
+    // The caller asked for a metric shape but got streams.
+    out.push(
+      loc(ctx, `envelope: resultType "streams" (want "${ctx.expectResultType}")`),
+    );
+  }
+
+  if (!Array.isArray(result)) {
+    out.push(loc(ctx, `envelope: data.result is not an array`));
+    return out;
+  }
+  const fromNs = ctx.fromSec * 1e9;
+  const toNs = ctx.toSec * 1e9;
+  for (const [i, entry] of (result as unknown[]).entries()) {
+    const sWhere = loc(ctx, `stream[${i}]`);
+    if (entry === null || typeof entry !== 'object') {
+      out.push(`${sWhere}: not an object`);
+      continue;
+    }
+    const e = entry as { stream?: Record<string, string>; values?: unknown[] };
+    const labels = e.stream ?? {};
+
+    const severity = labels.detected_level ?? labels.SeverityText;
+    if (
+      severity !== undefined &&
+      !LOG_SEVERITY_LEVELS.has(severity.toUpperCase())
+    ) {
+      out.push(
+        `${sWhere}: severity "${severity}" outside ` +
+          `{${[...LOG_SEVERITY_LEVELS].join(', ')}} (case-insensitive)`,
+      );
+    }
+
+    if (!Array.isArray(e.values)) {
+      out.push(`${sWhere}: stream carries no values array`);
+      continue;
+    }
+    for (const [j, v] of e.values.entries()) {
+      const lWhere = `${sWhere} line[${j}]`;
+      if (!Array.isArray(v) || v.length < 2) {
+        out.push(`${lWhere}: not a [tsNano, line] pair`);
+        continue;
+      }
+      const [tsRaw, line] = v as [unknown, unknown];
+      if (typeof tsRaw !== 'string' || !/^\d+$/.test(tsRaw)) {
+        out.push(`${lWhere}: timestamp ${JSON.stringify(tsRaw)} is not a nanosecond string`);
+      } else {
+        const tsNs = Number(tsRaw);
+        if (tsNs < fromNs || tsNs > toNs) {
+          out.push(
+            `${lWhere}: timestamp ${tsRaw} outside query window ` +
+              `[${ctx.fromSec}, ${ctx.toSec}] (seconds)`,
+          );
+        }
+      }
+      if (typeof line !== 'string' || line.length === 0) {
+        out.push(`${lWhere}: log line body is empty`);
+      }
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Tempo
+// ---------------------------------------------------------------------------
+
+// Canonical trace id — 32 lowercase hex chars (cerberus emits the
+// zero-padded canonical form; see PR #656).
+const TRACE_ID_RE = /^[0-9a-f]{32}$/;
+
+const SPAN_KIND_STRINGS = new Set([
+  'SPAN_KIND_UNSPECIFIED',
+  'SPAN_KIND_INTERNAL',
+  'SPAN_KIND_SERVER',
+  'SPAN_KIND_CLIENT',
+  'SPAN_KIND_PRODUCER',
+  'SPAN_KIND_CONSUMER',
+]);
+
+/**
+ * Validate a Tempo response body. The three response families the
+ * head serves are dispatched on shape:
+ *
+ *   - search (`{traces: [...]}`)  — every traceID is 32-lowercase-hex
+ *     (cerberus emits canonical zero-padded ids, PR #656), durations
+ *     are >= 0, and startTimeUnixNano parses as a positive integer;
+ *   - trace-by-id (`{batches: [...]}` / `{resourceSpans: [...]}`) —
+ *     every span's parentSpanId is either empty or present in the
+ *     trace's own span set, and span kind is within the OTLP enum;
+ *   - metrics (`{series: [...]}`) — the same numeric + timestamp
+ *     rules as the Prometheus validator (timestampMs within the
+ *     window, values finite unless ctx.allowNaN).
+ */
+export function validateTempoResponse(
+  body: unknown,
+  ctx: ValidityContext,
+): string[] {
+  const out: string[] = [];
+  if (body === null || typeof body !== 'object') {
+    out.push(loc(ctx, `envelope: body is not a JSON object`));
+    return out;
+  }
+  const b = body as Record<string, unknown>;
+  if (Array.isArray(b.traces) || ('traces' in b && b.traces === null)) {
+    validateTempoSearch(b, ctx, out);
+    return out;
+  }
+  if (Array.isArray(b.batches) || Array.isArray(b.resourceSpans)) {
+    validateTempoTrace(b, ctx, out);
+    return out;
+  }
+  if (Array.isArray(b.series)) {
+    validateTempoMetrics(b, ctx, out);
+    return out;
+  }
+  out.push(
+    loc(
+      ctx,
+      `envelope: unrecognised tempo response shape (no traces/batches/resourceSpans/series key)`,
+    ),
+  );
+  return out;
+}
+
+function validateTempoSearch(
+  b: Record<string, unknown>,
+  ctx: ValidityContext,
+  out: string[],
+): void {
+  const traces = Array.isArray(b.traces) ? b.traces : [];
+  for (const [i, t] of (traces as unknown[]).entries()) {
+    const tWhere = loc(ctx, `trace[${i}]`);
+    if (t === null || typeof t !== 'object') {
+      out.push(`${tWhere}: not an object`);
+      continue;
+    }
+    const trace = t as Record<string, unknown>;
+    if (typeof trace.traceID !== 'string' || !TRACE_ID_RE.test(trace.traceID)) {
+      out.push(
+        `${tWhere}: traceID ${JSON.stringify(trace.traceID)} is not ` +
+          `32-lowercase-hex (canonical form per PR #656)`,
+      );
+    }
+    if (trace.durationMs !== undefined) {
+      if (typeof trace.durationMs !== 'number' || trace.durationMs < 0) {
+        out.push(`${tWhere}: durationMs ${JSON.stringify(trace.durationMs)} is negative or non-numeric`);
+      }
+    }
+    if (trace.startTimeUnixNano !== undefined) {
+      const raw = trace.startTimeUnixNano;
+      const okString = typeof raw === 'string' && /^\d+$/.test(raw) && raw !== '0';
+      const okNumber = typeof raw === 'number' && Number.isFinite(raw) && raw > 0;
+      if (!okString && !okNumber) {
+        out.push(
+          `${tWhere}: startTimeUnixNano ${JSON.stringify(raw)} does not parse as a positive integer`,
+        );
+      }
+    }
+  }
+}
+
+type RawSpan = Record<string, unknown>;
+
+function validateTempoTrace(
+  b: Record<string, unknown>,
+  ctx: ValidityContext,
+  out: string[],
+): void {
+  // Tempo serves the OTLP trace JSON under `batches` (tempopb) or
+  // `resourceSpans` (raw OTLP); scopes nest under `scopeSpans` (or
+  // the legacy `instrumentationLibrarySpans`).
+  const batches = (
+    Array.isArray(b.batches) ? b.batches : (b.resourceSpans as unknown[])
+  ) as unknown[];
+  const spans: RawSpan[] = [];
+  for (const batch of batches) {
+    if (batch === null || typeof batch !== 'object') continue;
+    const bb = batch as Record<string, unknown>;
+    const scopes = (
+      Array.isArray(bb.scopeSpans)
+        ? bb.scopeSpans
+        : Array.isArray(bb.instrumentationLibrarySpans)
+          ? bb.instrumentationLibrarySpans
+          : []
+    ) as unknown[];
+    for (const scope of scopes) {
+      if (scope === null || typeof scope !== 'object') continue;
+      const ss = (scope as Record<string, unknown>).spans;
+      if (!Array.isArray(ss)) continue;
+      for (const s of ss) {
+        if (s !== null && typeof s === 'object') spans.push(s as RawSpan);
+      }
+    }
+  }
+  if (spans.length === 0) {
+    out.push(loc(ctx, `trace: no spans found in trace-by-id response`));
+    return;
+  }
+  const spanIds = new Set<string>();
+  for (const s of spans) {
+    if (typeof s.spanId === 'string') spanIds.add(s.spanId);
+  }
+  for (const [i, s] of spans.entries()) {
+    const sWhere = loc(ctx, `span[${i}]`);
+    const parent = s.parentSpanId;
+    if (
+      parent !== undefined &&
+      parent !== null &&
+      parent !== '' &&
+      !(typeof parent === 'string' && spanIds.has(parent))
+    ) {
+      out.push(
+        `${sWhere}: parentSpanId ${JSON.stringify(parent)} not present in the trace's span set`,
+      );
+    }
+    const kind = s.kind;
+    const kindOk =
+      kind === undefined ||
+      (typeof kind === 'string' && SPAN_KIND_STRINGS.has(kind)) ||
+      (typeof kind === 'number' && Number.isInteger(kind) && kind >= 0 && kind <= 5);
+    if (!kindOk) {
+      out.push(`${sWhere}: span kind ${JSON.stringify(kind)} outside the OTLP enum`);
+    }
+  }
+}
+
+function validateTempoMetrics(
+  b: Record<string, unknown>,
+  ctx: ValidityContext,
+  out: string[],
+): void {
+  const fromMs = ctx.fromSec * 1000;
+  const toMs = ctx.toSec * 1000;
+  const series = b.series as unknown[];
+  for (const [i, s] of series.entries()) {
+    const sWhere = loc(ctx, `series[${i}]`);
+    if (s === null || typeof s !== 'object') {
+      out.push(`${sWhere}: not an object`);
+      continue;
+    }
+    const samples = (s as Record<string, unknown>).samples;
+    if (!Array.isArray(samples)) {
+      out.push(`${sWhere}: series carries no samples array`);
+      continue;
+    }
+    for (const [j, sample] of samples.entries()) {
+      const pWhere = `${sWhere} sample[${j}]`;
+      if (sample === null || typeof sample !== 'object') {
+        out.push(`${pWhere}: not an object`);
+        continue;
+      }
+      const p = sample as Record<string, unknown>;
+      const tsMs = p.timestampMs;
+      if (typeof tsMs !== 'number' || !Number.isFinite(tsMs)) {
+        out.push(`${pWhere}: timestampMs ${JSON.stringify(tsMs)} is not a finite number`);
+      } else if (tsMs < fromMs || tsMs > toMs) {
+        out.push(
+          `${pWhere}: timestampMs ${tsMs} outside query window ` +
+            `[${fromMs}, ${toMs}]`,
+        );
+      }
+      checkSampleValue(p.value, ctx, pWhere, out);
+    }
+  }
+}

--- a/test/e2e/playwright/helpers/variables.ts
+++ b/test/e2e/playwright/helpers/variables.ts
@@ -1,0 +1,410 @@
+/**
+ * Dashboard template-variable contracts.
+ *
+ * Same contract philosophy as the panel-level cerberus.expect block
+ * (helpers/expectations.ts): a variable may pin its EXACT option set
+ * via a custom field on its templating.list entry —
+ *
+ *   { "name": "ql", "type": "query", …,
+ *     "cerberus": { "expectOptions": ["promql", "logql", "traceql"] } }
+ *
+ * Pinned variables are asserted for SET EQUALITY with the live
+ * options (order-insensitive, exact membership both ways — a missing
+ * option means the data feeding it dried up, an unexpected option
+ * means the variable query broadened). Variables without a pin are
+ * asserted non-empty only: a variable with zero options is always a
+ * bug (the dropdown renders blank and every dependent panel
+ * collapses).
+ *
+ * Live resolution mirrors what Grafana 12 does when it opens the
+ * variable dropdown: for `query` variables it evaluates the variable
+ * query against the datasource. We resolve through the datasource
+ * proxy — the same wire Grafana's own label_values()/label/tag
+ * lookups travel — implementing the three cerberus heads:
+ *
+ *   - prometheus: `label_values(label)` / `label_values(selector,
+ *     label)` / `label_names()` → /api/v1/label/<label>/values
+ *     (+ match[]) / /api/v1/labels;
+ *   - loki: the LokiVariableQuery object ({type: 0|1, label}) or the
+ *     equivalent string forms → /loki/api/v1/labels /
+ *     /loki/api/v1/label/<label>/values;
+ *   - tempo: the TempoVariableQuery object ({type: 0|1, label}) →
+ *     /api/v2/search/tags / /api/v2/search/tag/<tag>/values.
+ *
+ * Static variable types (custom / interval / constant / textbox)
+ * resolve from the dashboard JSON itself; `datasource` variables
+ * resolve via /api/datasources.
+ */
+
+import type { APIRequestContext } from '@playwright/test';
+
+import { diffLabelKeys } from './assertions.js';
+
+/** templating.list entry shape (the slice the contracts consume). */
+export type VariableJSON = {
+  name?: string;
+  type?: string;
+  query?: unknown;
+  datasource?: { type?: string; uid?: string } | string | null;
+  /** cerberus contract block: { expectOptions: string[] }. */
+  cerberus?: unknown;
+};
+
+/**
+ * Read a variable's declared option pin. Returns null when the
+ * variable carries no pin; THROWS on a malformed declaration — a
+ * contract that cannot be parsed must fail loudly, never degrade.
+ */
+export function readVariablePin(variableJson: unknown): string[] | null {
+  if (variableJson === null || typeof variableJson !== 'object') return null;
+  const cerberus = (variableJson as Record<string, unknown>).cerberus;
+  if (cerberus === undefined) return null;
+  if (cerberus === null || typeof cerberus !== 'object') {
+    throw new Error(
+      `readVariablePin: variable.cerberus must be an object, got ${JSON.stringify(cerberus)}`,
+    );
+  }
+  const expectOptions = (cerberus as Record<string, unknown>).expectOptions;
+  if (expectOptions === undefined) return null;
+  if (
+    !Array.isArray(expectOptions) ||
+    expectOptions.length === 0 ||
+    expectOptions.some((o) => typeof o !== 'string' || o === '')
+  ) {
+    throw new Error(
+      `readVariablePin: cerberus.expectOptions must be a non-empty array of ` +
+        `non-empty strings, got ${JSON.stringify(expectOptions)}`,
+    );
+  }
+  return expectOptions as string[];
+}
+
+/**
+ * Order-insensitive set-equality check between the live options and
+ * a pin. Returns violations for BOTH directions: pinned options the
+ * live set is missing, and live options the pin doesn't expect.
+ * Duplicated live options are also a violation (a variable dropdown
+ * must not repeat entries).
+ */
+export function compareOptionSets(
+  observed: string[],
+  expected: string[],
+): string[] {
+  const out: string[] = [];
+  const dupes = observed.filter((o, i) => observed.indexOf(o) !== i);
+  if (dupes.length > 0) {
+    out.push(`duplicate options [${[...new Set(dupes)].sort().join(', ')}]`);
+  }
+  const { missing, extra } = diffLabelKeys(observed, expected);
+  if (missing.length > 0) {
+    out.push(
+      `pinned options missing from the live set: [${missing.join(', ')}]`,
+    );
+  }
+  if (extra.length > 0) {
+    out.push(
+      `live options not in the pin: [${extra.join(', ')}] — extend the pin ` +
+        `or fix the variable query`,
+    );
+  }
+  return out;
+}
+
+/**
+ * Apply the variable contract to a resolved option set: pinned →
+ * exact set equality; unpinned → non-empty (zero options is always a
+ * bug). Pure — unit-tested stack-free; the live path feeds it from
+ * `resolveVariableOptions`.
+ */
+export function checkVariableOptions(
+  pin: string[] | null,
+  observed: string[],
+): string[] {
+  if (pin !== null) return compareOptionSets(observed, pin);
+  if (observed.length === 0) {
+    return ['variable resolved zero options (a blank dropdown is always a bug)'];
+  }
+  return [];
+}
+
+// ---------------------------------------------------------------------------
+// Variable-query parsing (pure)
+// ---------------------------------------------------------------------------
+
+export type ParsedVariableQuery =
+  | { kind: 'prom-label-names' }
+  | { kind: 'prom-label-values'; label: string; selector?: string }
+  | { kind: 'loki-label-names' }
+  | { kind: 'loki-label-values'; label: string }
+  | { kind: 'tempo-tag-names' }
+  | { kind: 'tempo-tag-values'; tag: string };
+
+const LABEL_VALUES_RE = /^label_values\(\s*(?:(.+?)\s*,\s*)?([a-zA-Z_][a-zA-Z0-9_]*)\s*\)$/;
+const LABEL_NAMES_RE = /^label_names\(\s*\)$/;
+
+/**
+ * Parse a templating.list entry's `query` for the given datasource
+ * type into a typed lookup. Grafana 12 persists:
+ *
+ *   - prometheus: a string (`label_values(up, job)`) or an object
+ *     `{ query: '<string>', refId }`;
+ *   - loki:  `{ type: 0|1, label?, stream?, refId }` (0 = label
+ *     names, 1 = label values) or the legacy string forms;
+ *   - tempo: `{ type: 0|1, label?, refId }` (0 = tag/label names,
+ *     1 = tag values for `label`).
+ *
+ * Throws on anything it cannot classify — an unparseable variable
+ * query must fail the sweep, not silently resolve to nothing.
+ */
+export function parseVariableQuery(
+  dsType: string,
+  query: unknown,
+): ParsedVariableQuery {
+  const t = dsType.toLowerCase();
+  if (t === 'prometheus') {
+    const q =
+      typeof query === 'string'
+        ? query
+        : query !== null &&
+            typeof query === 'object' &&
+            typeof (query as Record<string, unknown>).query === 'string'
+          ? ((query as Record<string, unknown>).query as string)
+          : null;
+    if (q === null) {
+      throw new Error(
+        `parseVariableQuery: prometheus variable query is neither a string nor {query}: ${JSON.stringify(query)}`,
+      );
+    }
+    const trimmed = q.trim();
+    if (LABEL_NAMES_RE.test(trimmed)) return { kind: 'prom-label-names' };
+    const m = LABEL_VALUES_RE.exec(trimmed);
+    if (m !== null) {
+      const selector = m[1];
+      const label = m[2]!;
+      return selector !== undefined
+        ? { kind: 'prom-label-values', label, selector }
+        : { kind: 'prom-label-values', label };
+    }
+    throw new Error(
+      `parseVariableQuery: unrecognised prometheus variable query ${JSON.stringify(trimmed)} ` +
+        `(expected label_values(...) or label_names())`,
+    );
+  }
+
+  if (t === 'loki') {
+    if (query !== null && typeof query === 'object') {
+      const o = query as Record<string, unknown>;
+      if (o.type === 0) return { kind: 'loki-label-names' };
+      if (o.type === 1 && typeof o.label === 'string' && o.label !== '') {
+        return { kind: 'loki-label-values', label: o.label };
+      }
+      throw new Error(
+        `parseVariableQuery: unrecognised loki variable query object ${JSON.stringify(query)}`,
+      );
+    }
+    if (typeof query === 'string') {
+      const trimmed = query.trim();
+      if (LABEL_NAMES_RE.test(trimmed)) return { kind: 'loki-label-names' };
+      const m = LABEL_VALUES_RE.exec(trimmed);
+      if (m !== null && m[1] === undefined) {
+        return { kind: 'loki-label-values', label: m[2]! };
+      }
+    }
+    throw new Error(
+      `parseVariableQuery: unrecognised loki variable query ${JSON.stringify(query)}`,
+    );
+  }
+
+  if (t === 'tempo') {
+    if (query !== null && typeof query === 'object') {
+      const o = query as Record<string, unknown>;
+      if (o.type === 0) return { kind: 'tempo-tag-names' };
+      if (o.type === 1 && typeof o.label === 'string' && o.label !== '') {
+        return { kind: 'tempo-tag-values', tag: o.label };
+      }
+    }
+    throw new Error(
+      `parseVariableQuery: unrecognised tempo variable query ${JSON.stringify(query)} ` +
+        `(expected {type: 0|1, label})`,
+    );
+  }
+
+  throw new Error(
+    `parseVariableQuery: datasource type "${dsType}" has no variable-query lookup`,
+  );
+}
+
+/**
+ * Datasource-proxy path (relative to the Grafana base URL) that
+ * resolves a parsed variable query. Pure — unit-testable; the live
+ * resolver concatenates it with the base URL.
+ */
+export function variableOptionsPath(
+  dsUid: string,
+  parsed: ParsedVariableQuery,
+): string {
+  const proxy = `/api/datasources/proxy/uid/${dsUid}`;
+  switch (parsed.kind) {
+    case 'prom-label-names':
+      return `${proxy}/api/v1/labels`;
+    case 'prom-label-values':
+      return (
+        `${proxy}/api/v1/label/${encodeURIComponent(parsed.label)}/values` +
+        (parsed.selector !== undefined
+          ? `?match[]=${encodeURIComponent(parsed.selector)}`
+          : '')
+      );
+    case 'loki-label-names':
+      return `${proxy}/loki/api/v1/labels`;
+    case 'loki-label-values':
+      return `${proxy}/loki/api/v1/label/${encodeURIComponent(parsed.label)}/values`;
+    case 'tempo-tag-names':
+      return `${proxy}/api/v2/search/tags`;
+    case 'tempo-tag-values':
+      return `${proxy}/api/v2/search/tag/${encodeURIComponent(parsed.tag)}/values`;
+  }
+}
+
+/**
+ * Extract the option strings from a lookup response body. Pure —
+ * unit-testable against captured fixtures. Throws on a body that
+ * doesn't match the endpoint's wire shape.
+ */
+export function extractVariableOptions(
+  parsed: ParsedVariableQuery,
+  body: unknown,
+): string[] {
+  const b = (body ?? {}) as Record<string, unknown>;
+  switch (parsed.kind) {
+    case 'prom-label-names':
+    case 'prom-label-values':
+    case 'loki-label-names':
+    case 'loki-label-values': {
+      // {status: 'success', data: [string, …]}
+      if (b.status !== 'success' || !Array.isArray(b.data)) {
+        throw new Error(
+          `extractVariableOptions: ${parsed.kind} body is not a success/data envelope: ${JSON.stringify(body).slice(0, 300)}`,
+        );
+      }
+      return (b.data as unknown[]).map((v) => String(v));
+    }
+    case 'tempo-tag-names': {
+      // v2: {scopes: [{name, tags: [string, …]}, …]}
+      if (!Array.isArray(b.scopes)) {
+        throw new Error(
+          `extractVariableOptions: tempo-tag-names body carries no scopes array: ${JSON.stringify(body).slice(0, 300)}`,
+        );
+      }
+      const tags = new Set<string>();
+      for (const scope of b.scopes as Array<Record<string, unknown>>) {
+        if (!Array.isArray(scope.tags)) continue;
+        for (const tag of scope.tags as unknown[]) tags.add(String(tag));
+      }
+      return [...tags];
+    }
+    case 'tempo-tag-values': {
+      // v2: {tagValues: [{type, value}, …]}
+      if (!Array.isArray(b.tagValues)) {
+        throw new Error(
+          `extractVariableOptions: tempo-tag-values body carries no tagValues array: ${JSON.stringify(body).slice(0, 300)}`,
+        );
+      }
+      return (b.tagValues as Array<Record<string, unknown>>).map((v) =>
+        String(v.value),
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Live resolution + the full per-variable check
+// ---------------------------------------------------------------------------
+
+function normaliseDs(
+  ds: { type?: string; uid?: string } | string | null | undefined,
+): { type: string; uid: string } {
+  if (ds === undefined || ds === null) return { type: '', uid: '' };
+  if (typeof ds === 'string') return { type: '', uid: ds };
+  return { type: ds.type ?? '', uid: ds.uid ?? '' };
+}
+
+/**
+ * Resolve a variable's live option set. `query` variables go through
+ * the datasource proxy (the three head-specific lookups above);
+ * static types resolve from the dashboard JSON; `datasource`
+ * variables enumerate /api/datasources.
+ */
+export async function resolveVariableOptions(
+  request: APIRequestContext,
+  baseURL: string,
+  variable: VariableJSON,
+): Promise<string[]> {
+  const vType = variable.type ?? 'query';
+
+  if (vType === 'custom' || vType === 'interval') {
+    const q = typeof variable.query === 'string' ? variable.query : '';
+    return q
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => s !== '');
+  }
+  if (vType === 'constant' || vType === 'textbox') {
+    const q = typeof variable.query === 'string' ? variable.query.trim() : '';
+    return q === '' ? [] : [q];
+  }
+  if (vType === 'datasource') {
+    const wantType = typeof variable.query === 'string' ? variable.query : '';
+    const resp = await request.get(`${baseURL}/api/datasources`);
+    if (resp.status() < 200 || resp.status() > 299) {
+      throw new Error(
+        `resolveVariableOptions: GET /api/datasources → ${resp.status()}`,
+      );
+    }
+    const list = (await resp.json()) as Array<{ name?: string; type?: string }>;
+    return list
+      .filter((d) => wantType === '' || d.type === wantType)
+      .map((d) => d.name ?? '');
+  }
+  if (vType !== 'query') {
+    throw new Error(
+      `resolveVariableOptions: variable "${variable.name ?? '<unnamed>'}" has ` +
+        `type "${vType}", which has no option-resolution path here — add one ` +
+        `before provisioning such a variable`,
+    );
+  }
+
+  const ds = normaliseDs(variable.datasource);
+  if (ds.uid === '') {
+    throw new Error(
+      `resolveVariableOptions: query variable "${variable.name ?? '<unnamed>'}" carries no datasource uid`,
+    );
+  }
+  const parsed = parseVariableQuery(ds.type, variable.query);
+  const path = variableOptionsPath(ds.uid, parsed);
+  const resp = await request.get(`${baseURL}${path}`);
+  if (resp.status() < 200 || resp.status() > 299) {
+    throw new Error(
+      `resolveVariableOptions: GET ${path} → ${resp.status()} for variable ` +
+        `"${variable.name ?? '<unnamed>'}"`,
+    );
+  }
+  return extractVariableOptions(parsed, await resp.json());
+}
+
+/**
+ * The full per-variable contract the dashboard sweeps call: resolve
+ * the live options, then apply the pin (set equality) or the
+ * non-empty default. Returns violations prefixed with the variable
+ * name so the caller can aggregate across a dashboard.
+ */
+export async function checkDashboardVariable(
+  request: APIRequestContext,
+  baseURL: string,
+  variable: VariableJSON,
+): Promise<string[]> {
+  const pin = readVariablePin(variable);
+  const options = await resolveVariableOptions(request, baseURL, variable);
+  return checkVariableOptions(pin, options).map(
+    (v) => `variable "${variable.name ?? '<unnamed>'}": ${v}`,
+  );
+}

--- a/test/e2e/playwright/iterate-all-dashboards.spec.ts
+++ b/test/e2e/playwright/iterate-all-dashboards.spec.ts
@@ -60,6 +60,8 @@ import {
 } from '@playwright/test';
 
 import {
+  type VariableJSON,
+  checkDashboardVariable,
   enforceExpectation,
   generateSelfTraffic,
   readPanelExpectation,
@@ -101,6 +103,7 @@ type DashboardJSON = {
   uid: string;
   title: string;
   panels?: PanelJSON[];
+  templating?: { list?: VariableJSON[] };
 };
 
 type PanelJSON = {
@@ -144,6 +147,7 @@ type DiscoveredDashboard = {
   title: string;
   filename: string;
   panels: FlatPanel[];
+  variables: VariableJSON[];
 };
 
 /**
@@ -187,6 +191,7 @@ function discoverDashboards(): DiscoveredDashboard[] {
       title: json.title,
       filename: entry,
       panels: flattenPanels(json.panels ?? []),
+      variables: json.templating?.list ?? [],
     });
   }
   // Sort for deterministic test order regardless of readdir() ordering.
@@ -471,9 +476,26 @@ test.describe('iterate-all-dashboards: full provisioned-dashboard sweep', () => 
           });
         }
       }
+      // 3. Template-variable contracts — every variable's options
+      //    resolve live (the same lookups Grafana fires for the
+      //    dropdown); pinned variables (cerberus.expectOptions) get
+      //    set equality, unpinned ones non-emptiness. Today no
+      //    provisioned dashboard carries variables, so the loop is a
+      //    no-op — the path goes live the moment one lands (P3).
+      const variableViolations: string[] = [];
+      for (const variable of d.variables) {
+        variableViolations.push(
+          ...(await checkDashboardVariable(request, baseURL, variable)),
+        );
+      }
+      expect(
+        variableViolations,
+        `dashboard ${d.uid}: variable contracts violated:\n  - ${variableViolations.join('\n  - ')}`,
+      ).toEqual([]);
+
       // eslint-disable-next-line no-console
       console.log(
-        `iterate-all-dashboards: dashboard=${d.uid} probed=${probedTargets} non_empty=${nonEmptyTargets}`,
+        `iterate-all-dashboards: dashboard=${d.uid} probed=${probedTargets} non_empty=${nonEmptyTargets} variables=${d.variables.length}`,
       );
     });
   }

--- a/test/e2e/playwright/iterate-all-dashboards.spec.ts
+++ b/test/e2e/playwright/iterate-all-dashboards.spec.ts
@@ -62,9 +62,11 @@ import {
 import {
   type VariableJSON,
   checkDashboardVariable,
+  describeSweepDepth,
   enforceExpectation,
   generateSelfTraffic,
   readPanelExpectation,
+  sweepDepth,
 } from './helpers/index.js';
 
 // Self-traffic warmup so cerberus panels have populated counters
@@ -419,6 +421,14 @@ async function captureAndAssertDsQuery(
 
 const dashboards = discoverDashboards();
 
+// SWEEP_DEPTH gates how many STATES the sweep visits, never which
+// rules run: at 'lean' (the per-PR default) the browser render is
+// restricted to ops-family dashboards — showcase-prefixed boards get
+// API-layer probes only; at 'full' (nightly) every dashboard also
+// renders in the browser. Today no showcase- dashboard exists, so
+// both depths execute the exact same set of checks.
+const depth = sweepDepth();
+
 test.describe('iterate-all-dashboards: full provisioned-dashboard sweep', () => {
   test.describe.configure({ mode: 'serial' });
 
@@ -426,6 +436,8 @@ test.describe('iterate-all-dashboards: full provisioned-dashboard sweep', () => 
     // Log the catalog so the CI run record shows which dashboards
     // were swept. Use `console.log` rather than `test.info().annotations`
     // because the latter doesn't render in the GitHub Actions summary.
+    // eslint-disable-next-line no-console
+    console.log(describeSweepDepth(depth));
     // eslint-disable-next-line no-console
     console.log(
       `iterate-all-dashboards: discovered ${dashboards.length} dashboards in ${DASHBOARDS_DIR}:`,
@@ -452,14 +464,20 @@ test.describe('iterate-all-dashboards: full provisioned-dashboard sweep', () => 
         process.env.GRAFANA_BASE_URL ?? process.env.GRAFANA_URL ?? 'http://localhost:3000';
 
       // 1. Navigate to /d/<uid> and capture all datasource traffic.
-      const navFailures = await captureAndAssertDsQuery(
-        page,
-        `${baseURL}/d/${d.uid}`,
-      );
-      expect(
-        navFailures,
-        `dashboard ${d.uid}: navigation surfaced datasource errors:\n  - ${navFailures.join('\n  - ')}`,
-      ).toEqual([]);
+      //    Depth-gated state count (rules unchanged): 'lean' renders
+      //    ops-family dashboards only — showcase-prefixed boards are
+      //    covered by the API-layer probes below per PR and get their
+      //    browser render on the nightly 'full' lane.
+      if (depth === 'full' || !d.filename.startsWith('showcase-')) {
+        const navFailures = await captureAndAssertDsQuery(
+          page,
+          `${baseURL}/d/${d.uid}`,
+        );
+        expect(
+          navFailures,
+          `dashboard ${d.uid}: navigation surfaced datasource errors:\n  - ${navFailures.join('\n  - ')}`,
+        ).toEqual([]);
+      }
 
       // 2. Per-target probe — fires the panel's PromQL/LogQL/TraceQL
       //    expression through the datasource proxy.

--- a/test/e2e/playwright/iterate-all-dashboards.spec.ts
+++ b/test/e2e/playwright/iterate-all-dashboards.spec.ts
@@ -59,7 +59,11 @@ import {
   type Response,
 } from '@playwright/test';
 
-import { generateSelfTraffic } from './helpers/index.js';
+import {
+  enforceExpectation,
+  generateSelfTraffic,
+  readPanelExpectation,
+} from './helpers/index.js';
 
 // Self-traffic warmup so cerberus panels have populated counters
 // before we sweep them. Same value the other phase specs use.
@@ -106,6 +110,8 @@ type PanelJSON = {
   datasource?: { type?: string; uid?: string } | string;
   targets?: TargetJSON[];
   panels?: PanelJSON[]; // nested under rows
+  /** cerberus.expect contract block — see helpers/expectations.ts. */
+  cerberus?: unknown;
 };
 
 type TargetJSON = {
@@ -122,6 +128,8 @@ type FlatPanel = {
   dsType: string;
   dsUid: string;
   targets: FlatTarget[];
+  /** Raw cerberus.expect contract block, parsed at probe time. */
+  cerberus?: unknown;
 };
 
 type FlatTarget = {
@@ -216,6 +224,7 @@ function normalisePanel(p: PanelJSON): FlatPanel {
     dsType: panelDs.type,
     dsUid: panelDs.uid,
     targets,
+    cerberus: p.cerberus,
   };
 }
 
@@ -478,40 +487,60 @@ async function probeTarget(
   t: FlatTarget,
   onCount: (count: number) => void,
 ): Promise<void> {
+  // The panel's declared contract — absent declaration is the default
+  // {expect: 'nonempty'} (every current dashboard panel; non-default
+  // declarations are a showcase-family privilege enforced by
+  // expectation-contracts.spec.ts). enforceExpectation is the
+  // BIDIRECTIONAL gate: a declared-empty panel that returns series
+  // fails just as loudly as a default panel that returns none.
+  const expectation = readPanelExpectation(panel);
+  const isErrorContract = expectation.expect.startsWith('error:');
+
   const resp = await request.get(url);
   const status = resp.status();
-  // HTTP status is a hard fail — a 5xx anywhere means the gateway
-  // dropped the query.
-  expect(
-    status,
-    `dashboard=${d.uid} panel="${panel.title}" target=${t.refId}: ${url} → ${status}`,
-  ).toBe(200);
+  const bodyText = await resp.text();
 
-  let body: unknown;
-  try {
-    body = await resp.json();
-  } catch (err) {
-    throw new Error(
-      `dashboard=${d.uid} panel="${panel.title}" target=${t.refId}: body not JSON: ${
-        (err as Error).message
-      }`,
-    );
+  let count = 0;
+  if (status >= 200 && status <= 299) {
+    let body: unknown;
+    try {
+      body = JSON.parse(bodyText);
+    } catch (err) {
+      throw new Error(
+        `dashboard=${d.uid} panel="${panel.title}" target=${t.refId}: body not JSON: ${
+          (err as Error).message
+        }`,
+      );
+    }
+
+    if (!isErrorContract) {
+      // A 2xx body tunnelling an envelope error is a failure for the
+      // nonempty/empty contracts; an error-declared panel is judged
+      // on the error substring by enforceExpectation instead.
+      const errMsg = envelopeError(body);
+      expect(
+        errMsg,
+        `dashboard=${d.uid} panel="${panel.title}" target=${t.refId}: envelope error: ${errMsg ?? ''}`,
+      ).toBeNull();
+    }
+
+    count = resultCount(body, t.dsType);
   }
-
-  const errMsg = envelopeError(body);
-  expect(
-    errMsg,
-    `dashboard=${d.uid} panel="${panel.title}" target=${t.refId}: envelope error: ${errMsg ?? ''}`,
-  ).toBeNull();
-
-  const count = resultCount(body, t.dsType);
   onCount(count);
 
-  // Hard-assert non-empty. An empty result is a real bug in the
-  // cerberus code, the seed, the dashboard, or the panel expression;
-  // mask nothing.
+  // An empty result on a default panel is a real bug in the cerberus
+  // code, the seed, the dashboard, or the panel expression; mask
+  // nothing. Equally, a declared expectation that no longer holds is
+  // a broken showcase.
+  const violations = enforceExpectation(expectation, {
+    seriesCount: count,
+    status,
+    errorBody: bodyText,
+  });
   expect(
-    count,
-    `dashboard=${d.uid} panel="${panel.title}" target=${t.refId} expr="${t.expr}": empty result`,
-  ).toBeGreaterThan(0);
+    violations,
+    `dashboard=${d.uid} panel="${panel.title}" target=${t.refId} expr="${t.expr}" ` +
+      `(declared=${expectation.declared ? expectation.expect : 'default:nonempty'}): ` +
+      violations.join('; '),
+  ).toEqual([]);
 }


### PR DESCRIPTION
## Summary

Phase 1 of the designed Grafana exhaustive-traversal program (locked design: deterministic skeleton + budgeted crawler, two dashboard families, three-level oracle). Foundations only — behaviour today is byte-identical; every new rule activates as P2+ dashboards adopt it.

1. **`helpers/validity.ts`** — the API-layer validity oracle as pure violation-returning validators: envelope/resultType, numeric samples (NaN/Inf rejected unless the expr class permits), window-inclusive + step-aligned timestamps, counter/rate non-negativity, histogram `le` ascending + per-timestamp cumulative monotonicity, exact by-key sets (shared with the existing shape rule), Loki severity vocabulary + non-empty lines, Tempo canonical 32-hex trace IDs + parent-ref closure + kind enum. **53 stack-free tests.**
2. **`helpers/expectations.ts`** — in-panel `cerberus.expect` contracts (`nonempty` default | `empty` | `error:<substring>`), enforced **bidirectionally** (a declared-empty panel returning series FAILS). Meta-ratchet: ops-family dashboards may declare nothing; non-default declarations require `why`. `iterate-all-dashboards` now routes through the contract path (identical behaviour on today's zero-declaration tree).
3. **`helpers/variables.ts`** — template-variable option pinning (`cerberus.expectOptions`, order-insensitive set-equality both ways; unpinned variables must be non-empty), live resolution for Prom/Loki/Tempo variable queries. Wired; no-op until P3 dashboards gain variables. **24 unit tests.**
4. **`helpers/depth.ts`** — `SWEEP_DEPTH` (lean|full): switches state-counts only, never rules.
5. **e2e.yml** — compose-smoke gains the nightly schedule at `SWEEP_DEPTH=full`, closing the coverage gap for the compose-only clickhouse/host/otelcol dashboards; PR lane stays lean. Comments rewritten to the new doctrine.

## Test plan

- [ ] `compose-smoke` (lean) green — behaviour identical today
- [ ] dashboard job auto-discovers the 3 new stack-free spec files
- [ ] tonight's schedule exercises the first `SWEEP_DEPTH=full` compose run

🤖 Generated with [Claude Code](https://claude.com/claude-code)