### PR TITLE
fix(test/e2e/k3d): anonymous org role Viewer → Admin — Grafana 12 Metrics Drilldown denies Viewer

### DIFF
--- a/test/e2e/k3s/grafana.yaml
+++ b/test/e2e/k3s/grafana.yaml
@@ -122,8 +122,16 @@ spec:
               value: admin
             - name: GF_AUTH_ANONYMOUS_ENABLED
               value: "true"
+            # Admin, matching the compose stack: Grafana 12's Metrics
+            # Drilldown app denies the Viewer role outright ("Access
+            # denied — You do not have permission to see this page",
+            # run 27276109296), which hard-failed the drilldown sweep
+            # in k3d while compose (anonymous Admin) passed the same
+            # spec. This is an ephemeral throwaway test cluster — the
+            # same justification compose documents for its Admin
+            # anonymous session.
             - name: GF_AUTH_ANONYMOUS_ORG_ROLE
-              value: Viewer
+              value: Admin
             - name: GF_USERS_DEFAULT_THEME
               value: dark
             # Deliberately NO GF_INSTALL_PLUGINS for the drilldown


### PR DESCRIPTION
## Summary

Run 27276109296: **restarts 0** (gate clean — crash saga still closed, import flake gone) — the only failure was the drilldown sweep hitting *"Access denied — You do not have permission to see this page"* on `grafana-metricsdrilldown-app`: Grafana 12.2 gates the app above the Viewer role. Compose already runs anonymous **Admin** (documented: ephemeral throwaway stack, signout hidden); k3d was still **Viewer** — the last auth asymmetry between the stacks. Aligned with the same justification.

## Test plan

- [ ] dashboard job green on the merge push — with restarts at 0, import verification in (#753), and this role fix, this should be the first fully green gated run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)