### PR TITLE
fix(api/tempo): deterministic trace-by-id batch assembly + fail CI on flaky tests

### DIFF
--- a/internal/api/tempo/export_test.go
+++ b/internal/api/tempo/export_test.go
@@ -8,3 +8,13 @@ import "time"
 var AlignMetricsWindowForTest = func(start, end time.Time, step time.Duration) (time.Time, time.Time) {
 	return alignMetricsWindow(start, end, step)
 }
+
+// GroupBatchesForTest / GroupBatchesProtoForTest re-export the two
+// trace-by-ID assemblers so the determinism tests can drive the pure
+// assembly repeatedly (50 iterations, shuffled inputs) and compare
+// serialized outputs byte-for-byte without a handler round-trip per
+// iteration.
+var (
+	GroupBatchesForTest      = groupBatches
+	GroupBatchesProtoForTest = groupBatchesProto
+)

--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -1206,41 +1206,110 @@ func toTraceSummaries(samples []chclient.Sample) ([]TraceSummary, []string) {
 	return out, missing
 }
 
-// groupBatches converts a flat span list into Tempo's `batches` shape
-// (one batch per distinct ResourceAttributes set). The wrap-projection
-// for /api/traces/{id} (see traceByIDProjections) smuggles span-detail
-// fields (TraceId / SpanId / ParentSpanId / SpanKind / StatusCode plus
-// the SpanAttributes map) inside chclient.Sample.Labels under reserved
-// keys; we split them back out into the SpanEntry fields Grafana's
-// trace-view consumes and keep ResourceAttributes (un-prefixed entries)
-// on the Resource.Attributes map.
-func groupBatches(samples []chclient.Sample) []ResourceSpans {
-	bucket := map[string]*ResourceSpans{}
+// traceBatch is the wire-format-agnostic intermediate the trace-by-ID
+// assemblers consume: one entry per distinct ResourceAttributes set, in
+// deterministic order, with the per-span rows already sorted. Both
+// groupBatches (JSON) and groupBatchesProto (proto) map this shape onto
+// their wire types, so batch / span ordering can never diverge between
+// the two Accept-negotiated paths — or between two sequential calls
+// (the e2e "v2 is a byte-for-byte alias of v1" pin fetches the same
+// trace twice and compares bodies byte-for-byte).
+type traceBatch struct {
+	resourceAttrs map[string]string
+	spans         []traceSpanRow
+}
+
+// traceSpanRow carries one sample plus its splitTraceByIDLabels
+// partition (span attributes + reserved-key metadata).
+type traceSpanRow struct {
+	sample    chclient.Sample
+	spanAttrs map[string]string
+	meta      map[string]string
+}
+
+// groupTraceBatches buckets a flat span list by resource-attribute set
+// and returns the batches in a fully deterministic order, independent
+// of both Go map iteration and the row order ClickHouse happened to
+// return:
+//
+//   - Batches sort by resource service.name first (the field Grafana's
+//     "Processes" tab leads with), then by the canonical resource-attr
+//     string (format.CanonicalKey) as the total-order tie-break.
+//   - Spans within a batch sort by StartTimeUnixNano, then by SpanID.
+//
+// Without this, the bucket map's iteration order (JSON path) and the
+// CH result-row order (span order, both paths) made two sequential
+// fetches of the same trace intermittently differ — see the retry-
+// masked flake in k3d e2e run 27284868985.
+func groupTraceBatches(samples []chclient.Sample) []traceBatch {
+	bucket := map[string]*traceBatch{}
+	keys := make([]string, 0)
 	for _, s := range samples {
 		resourceAttrs, spanAttrs, meta := splitTraceByIDLabels(s.Labels)
 		// Group by resource-attribute set so Grafana's "Processes" tab
 		// gets one batch per service.
 		key := format.CanonicalKey(resourceAttrs)
-		rs, ok := bucket[key]
+		b, ok := bucket[key]
 		if !ok {
-			rs = &ResourceSpans{Resource: Resource{Attributes: resourceAttrs}}
-			bucket[key] = rs
+			b = &traceBatch{resourceAttrs: resourceAttrs}
+			bucket[key] = b
+			keys = append(keys, key)
 		}
-		rs.Spans = append(rs.Spans, SpanEntry{
-			TraceID:           meta[traceByIDKeyTraceID],
-			SpanID:            meta[traceByIDKeySpanID],
-			ParentSpanID:      meta[traceByIDKeyParentSpanID],
-			Name:              s.MetricName,
-			Kind:              meta[traceByIDKeySpanKind],
-			StartTimeUnixNano: strconv.FormatInt(s.Timestamp.UnixNano(), 10),
-			DurationNanos:     int64(s.Value),
-			Status:            SpanStatus{Code: meta[traceByIDKeyStatusCode]},
-			Attributes:        spanAttrs,
-		})
+		b.spans = append(b.spans, traceSpanRow{sample: s, spanAttrs: spanAttrs, meta: meta})
 	}
-	out := make([]ResourceSpans, 0, len(bucket))
-	for _, rs := range bucket {
-		out = append(out, *rs)
+	sort.Slice(keys, func(i, j int) bool {
+		si := bucket[keys[i]].resourceAttrs["service.name"]
+		sj := bucket[keys[j]].resourceAttrs["service.name"]
+		if si != sj {
+			return si < sj
+		}
+		return keys[i] < keys[j]
+	})
+	out := make([]traceBatch, 0, len(keys))
+	for _, k := range keys {
+		b := bucket[k]
+		sort.Slice(b.spans, func(i, j int) bool {
+			ti := b.spans[i].sample.Timestamp.UnixNano()
+			tj := b.spans[j].sample.Timestamp.UnixNano()
+			if ti != tj {
+				return ti < tj
+			}
+			return b.spans[i].meta[traceByIDKeySpanID] < b.spans[j].meta[traceByIDKeySpanID]
+		})
+		out = append(out, *b)
+	}
+	return out
+}
+
+// groupBatches converts a flat span list into Tempo's `batches` shape
+// (one batch per distinct ResourceAttributes set). The wrap-projection
+// for /api/traces/{id} (see traceByIDProjections) smuggles span-detail
+// fields (TraceId / SpanId / ParentSpanId / SpanKind / StatusCode plus
+// the SpanAttributes map) inside chclient.Sample.Labels under reserved
+// keys; groupTraceBatches splits them back out (via
+// splitTraceByIDLabels) and owns the deterministic batch / span order;
+// this helper only maps the intermediate onto the SpanEntry fields
+// Grafana's trace-view consumes, keeping ResourceAttributes
+// (un-prefixed entries) on the Resource.Attributes map.
+func groupBatches(samples []chclient.Sample) []ResourceSpans {
+	groups := groupTraceBatches(samples)
+	out := make([]ResourceSpans, 0, len(groups))
+	for _, g := range groups {
+		rs := ResourceSpans{Resource: Resource{Attributes: g.resourceAttrs}}
+		for _, row := range g.spans {
+			rs.Spans = append(rs.Spans, SpanEntry{
+				TraceID:           row.meta[traceByIDKeyTraceID],
+				SpanID:            row.meta[traceByIDKeySpanID],
+				ParentSpanID:      row.meta[traceByIDKeyParentSpanID],
+				Name:              row.sample.MetricName,
+				Kind:              row.meta[traceByIDKeySpanKind],
+				StartTimeUnixNano: strconv.FormatInt(row.sample.Timestamp.UnixNano(), 10),
+				DurationNanos:     int64(row.sample.Value),
+				Status:            SpanStatus{Code: row.meta[traceByIDKeyStatusCode]},
+				Attributes:        row.spanAttrs,
+			})
+		}
+		out = append(out, rs)
 	}
 	return out
 }

--- a/internal/api/tempo/handler_trace_determinism_test.go
+++ b/internal/api/tempo/handler_trace_determinism_test.go
@@ -1,0 +1,237 @@
+package tempo_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/gogo/protobuf/proto"
+
+	"github.com/tsouza/cerberus/internal/api/tempo"
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+// shuffleProneTraceSamples builds a multi-resource span set engineered
+// to expose any map-iteration / input-order dependence in the
+// trace-by-ID assemblers:
+//
+//   - 8 distinct resource buckets (7 service.names; "dup" appears twice
+//     with different extra resource attrs), so an assembler that emits
+//     batches in Go map-iteration order has a 1-in-8! chance of
+//     matching the sorted order on any given call.
+//   - Input order is deliberately NOT the contract order: services are
+//     interleaved, the earliest "frontend" span arrives last, and the
+//     two same-timestamp "frontend" spans arrive with their SpanIDs in
+//     descending order.
+//
+// This is the fixture the k3d e2e flake reduced to: run 27284868985
+// saw /api/traces and /api/v2/traces return the SAME trace with the
+// resource batches in DIFFERENT order (v1 led with "frontend", v2 with
+// "api"), because groupBatches emitted its bucket map in iteration
+// order.
+func shuffleProneTraceSamples() []chclient.Sample {
+	ts := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	span := func(svc, name, spanID, parentID string, at time.Time, extraResource map[string]string) chclient.Sample {
+		labels := map[string]string{
+			"service.name":             svc,
+			"__cerberus_traceID":       "f48694fee9f78da6f98ec5a8cd7d3274",
+			"__cerberus_spanID":        spanID,
+			"__cerberus_parentSpanID":  parentID,
+			"__cerberus_spanKind":      "Server",
+			"__cerberus_statusCode":    "Ok",
+			"__cerberus_spanAttrsJSON": `{"http.method":"GET"}`,
+		}
+		for k, v := range extraResource {
+			labels[k] = v
+		}
+		return chclient.Sample{
+			MetricName: name,
+			Labels:     labels,
+			Timestamp:  at,
+			Value:      1_000_000,
+		}
+	}
+	return []chclient.Sample{
+		// Same-timestamp pair, SpanIDs supplied in DESCENDING order so
+		// the SpanID tie-break has to actually reorder them.
+		span("frontend", "GET /b", "bbbb000000000002", "cccc000000000003", ts.Add(10*time.Millisecond), nil),
+		span("queue", "publish", "1111000000000001", "", ts.Add(2*time.Millisecond), nil),
+		span("frontend", "GET /a", "aaaa000000000001", "cccc000000000003", ts.Add(10*time.Millisecond), nil),
+		span("api", "POST /v1", "2222000000000002", "", ts.Add(3*time.Millisecond), nil),
+		span("dup", "dup-b", "3333000000000003", "", ts.Add(4*time.Millisecond), map[string]string{"zone": "b"}),
+		span("backend", "work", "4444000000000004", "", ts.Add(5*time.Millisecond), nil),
+		span("dup", "dup-a", "5555000000000005", "", ts.Add(6*time.Millisecond), map[string]string{"zone": "a"}),
+		span("cache", "lookup", "6666000000000006", "", ts.Add(7*time.Millisecond), nil),
+		span("db", "select", "7777000000000007", "", ts.Add(8*time.Millisecond), nil),
+		// Earliest frontend span arrives LAST in input order, so the
+		// StartTimeUnixNano sort has to move it to the front of its batch.
+		span("frontend", "GET /c", "cccc000000000003", "", ts, nil),
+	}
+}
+
+// TestGroupBatches_OrderContract pins the documented sort contract on
+// the JSON assembler:
+//
+//   - batches sort by resource service.name, then by the canonical
+//     resource-attribute string (so two "dup" services tie-break on
+//     their remaining attrs);
+//   - spans within a batch sort by StartTimeUnixNano, then SpanID.
+func TestGroupBatches_OrderContract(t *testing.T) {
+	t.Parallel()
+
+	batches := tempo.GroupBatchesForTest(shuffleProneTraceSamples())
+
+	wantServices := []string{"api", "backend", "cache", "db", "dup", "dup", "frontend", "queue"}
+	if got, want := len(batches), len(wantServices); got != want {
+		t.Fatalf("batch count=%d, want %d", got, want)
+	}
+	for i, b := range batches {
+		if got := b.Resource.Attributes["service.name"]; got != wantServices[i] {
+			t.Errorf("batch[%d] service.name=%q, want %q", i, got, wantServices[i])
+		}
+	}
+
+	// The two "dup" batches tie-break on the canonical resource-attr
+	// string: zone=a sorts before zone=b.
+	if got := batches[4].Resource.Attributes["zone"]; got != "a" {
+		t.Errorf("batch[4] (first dup) zone=%q, want %q", got, "a")
+	}
+	if got := batches[5].Resource.Attributes["zone"]; got != "b" {
+		t.Errorf("batch[5] (second dup) zone=%q, want %q", got, "b")
+	}
+
+	// Frontend batch: earliest span first (despite arriving last in
+	// input order), then the same-timestamp pair ordered by SpanID.
+	frontend := batches[6]
+	wantSpanIDs := []string{"cccc000000000003", "aaaa000000000001", "bbbb000000000002"}
+	if got, want := len(frontend.Spans), len(wantSpanIDs); got != want {
+		t.Fatalf("frontend span count=%d, want %d", got, want)
+	}
+	for i, sp := range frontend.Spans {
+		if sp.SpanID != wantSpanIDs[i] {
+			t.Errorf("frontend span[%d] SpanID=%q, want %q", i, sp.SpanID, wantSpanIDs[i])
+		}
+	}
+}
+
+// TestGroupBatchesProto_OrderContract pins the same contract on the
+// proto assembler — both siblings consume groupTraceBatches, so the
+// orders must be identical between the two wire shapes.
+func TestGroupBatchesProto_OrderContract(t *testing.T) {
+	t.Parallel()
+
+	trace := tempo.GroupBatchesProtoForTest(shuffleProneTraceSamples())
+
+	wantServices := []string{"api", "backend", "cache", "db", "dup", "dup", "frontend", "queue"}
+	if got, want := len(trace.ResourceSpans), len(wantServices); got != want {
+		t.Fatalf("ResourceSpans count=%d, want %d", got, want)
+	}
+	for i, rs := range trace.ResourceSpans {
+		var svc string
+		for _, kv := range rs.Resource.Attributes {
+			if kv.Key == "service.name" {
+				svc = kv.Value.GetStringValue()
+			}
+		}
+		if svc != wantServices[i] {
+			t.Errorf("ResourceSpans[%d] service.name=%q, want %q", i, svc, wantServices[i])
+		}
+	}
+
+	// Frontend bucket span order matches the JSON path: start time
+	// ascending, SpanID tie-break. Proto carries raw bytes; the hex
+	// fixture IDs have no leading zeros so the byte order mirrors the
+	// hex-string order.
+	frontend := trace.ResourceSpans[6].ScopeSpans[0].Spans
+	wantSpanIDs := [][]byte{
+		{0xcc, 0xcc, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03},
+		{0xaa, 0xaa, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01},
+		{0xbb, 0xbb, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02},
+	}
+	if got, want := len(frontend), len(wantSpanIDs); got != want {
+		t.Fatalf("frontend span count=%d, want %d", got, want)
+	}
+	for i, sp := range frontend {
+		if !bytes.Equal(sp.SpanId, wantSpanIDs[i]) {
+			t.Errorf("frontend span[%d] SpanId=%x, want %x", i, sp.SpanId, wantSpanIDs[i])
+		}
+	}
+}
+
+// TestGroupBatches_RepeatedAssemblyIsByteIdentical assembles the same
+// multi-resource span set 50 times through BOTH wire paths and asserts
+// every serialized output is byte-identical to the first. Before the
+// groupTraceBatches sort landed, the JSON path emitted batches in Go
+// map-iteration order, so two sequential fetches of the same trace
+// intermittently differed — the retry-masked "v2 is a byte-for-byte
+// alias of v1" e2e flake in k3d run 27284868985.
+func TestGroupBatches_RepeatedAssemblyIsByteIdentical(t *testing.T) {
+	t.Parallel()
+
+	samples := shuffleProneTraceSamples()
+
+	firstJSON, err := json.Marshal(tempo.TraceByIDResponse{Batches: tempo.GroupBatchesForTest(samples)})
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	firstProto, err := proto.Marshal(tempo.GroupBatchesProtoForTest(samples))
+	if err != nil {
+		t.Fatalf("proto.Marshal: %v", err)
+	}
+
+	for i := 1; i < 50; i++ {
+		gotJSON, err := json.Marshal(tempo.TraceByIDResponse{Batches: tempo.GroupBatchesForTest(samples)})
+		if err != nil {
+			t.Fatalf("iteration %d: json.Marshal: %v", i, err)
+		}
+		if !bytes.Equal(gotJSON, firstJSON) {
+			t.Fatalf("iteration %d: JSON body diverged from iteration 0:\n first=%s\n   got=%s", i, firstJSON, gotJSON)
+		}
+		gotProto, err := proto.Marshal(tempo.GroupBatchesProtoForTest(samples))
+		if err != nil {
+			t.Fatalf("iteration %d: proto.Marshal: %v", i, err)
+		}
+		if !bytes.Equal(gotProto, firstProto) {
+			t.Fatalf("iteration %d: proto body diverged from iteration 0 (first=%x got=%x)", i, firstProto, gotProto)
+		}
+	}
+}
+
+// TestGroupBatches_InputOrderIndependent reverses the sample slice and
+// asserts both wire outputs are byte-identical to the forward-order
+// assembly. The CH result-row order is an implementation detail of the
+// scan; the assembled trace must not depend on it.
+func TestGroupBatches_InputOrderIndependent(t *testing.T) {
+	t.Parallel()
+
+	forward := shuffleProneTraceSamples()
+	reversed := make([]chclient.Sample, len(forward))
+	for i, s := range forward {
+		reversed[len(forward)-1-i] = s
+	}
+
+	fwdJSON, err := json.Marshal(tempo.TraceByIDResponse{Batches: tempo.GroupBatchesForTest(forward)})
+	if err != nil {
+		t.Fatalf("json.Marshal forward: %v", err)
+	}
+	revJSON, err := json.Marshal(tempo.TraceByIDResponse{Batches: tempo.GroupBatchesForTest(reversed)})
+	if err != nil {
+		t.Fatalf("json.Marshal reversed: %v", err)
+	}
+	if !bytes.Equal(fwdJSON, revJSON) {
+		t.Fatalf("JSON body depends on input row order:\n forward=%s\nreversed=%s", fwdJSON, revJSON)
+	}
+
+	fwdProto, err := proto.Marshal(tempo.GroupBatchesProtoForTest(forward))
+	if err != nil {
+		t.Fatalf("proto.Marshal forward: %v", err)
+	}
+	revProto, err := proto.Marshal(tempo.GroupBatchesProtoForTest(reversed))
+	if err != nil {
+		t.Fatalf("proto.Marshal reversed: %v", err)
+	}
+	if !bytes.Equal(fwdProto, revProto) {
+		t.Fatalf("proto body depends on input row order (forward=%x reversed=%x)", fwdProto, revProto)
+	}
+}

--- a/internal/api/tempo/handler_trace_proto.go
+++ b/internal/api/tempo/handler_trace_proto.go
@@ -9,7 +9,6 @@ import (
 	resourcev1 "github.com/grafana/tempo/pkg/tempopb/resource/v1"
 	tracev1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
 
-	"github.com/tsouza/cerberus/internal/api/format"
 	"github.com/tsouza/cerberus/internal/chclient"
 )
 
@@ -60,62 +59,56 @@ func negotiateTraceByIDProto(accept string) bool {
 //     byte-array trace/span IDs and enum-int kind/status fields.
 //   - The two structures diverge on type (string-keyed map vs
 //     []*KeyValue) and on identifier encoding (hex string vs raw bytes),
-//     so a single helper would either over-abstract or carry a tag
-//     parameter that costs more than it saves. Keeping them as siblings
-//     fed by the same Sample slice + the same splitTraceByIDLabels
-//     partition means the two paths can never drift on field
-//     semantics — both call splitTraceByIDLabels, both group by the
-//     same format.CanonicalKey, both pull SpanKind / StatusCode out
-//     of the meta map.
+//     so a single wire-emitting helper would either over-abstract or
+//     carry a tag parameter that costs more than it saves. Instead both
+//     consume the same groupTraceBatches intermediate (see handler.go),
+//     which owns the splitTraceByIDLabels partition, the
+//     format.CanonicalKey bucketing, and — critically — the
+//     deterministic batch order (service.name, then canonical
+//     resource-attr string) and span order (StartTimeUnixNano, then
+//     SpanID). The two paths can therefore never drift on field
+//     semantics or on ordering.
 //
 // The parity test in handler_trace_proto_test.go pins this equivalence
 // (same span count, same trace ID, same attribute keys) so a future
 // edit to one helper that forgets the other surfaces in CI.
 func groupBatchesProto(samples []chclient.Sample) *tempopb.Trace {
-	bucket := map[string]*tracev1.ResourceSpans{}
-	keys := []string{} // stable order so the marshaled body is deterministic
-	for _, s := range samples {
-		resourceAttrs, spanAttrs, meta := splitTraceByIDLabels(s.Labels)
-		key := format.CanonicalKey(resourceAttrs)
-		rs, ok := bucket[key]
-		if !ok {
-			rs = &tracev1.ResourceSpans{
-				Resource: &resourcev1.Resource{
-					Attributes: attrMapToKVList(resourceAttrs),
-				},
-				ScopeSpans: []*tracev1.ScopeSpans{{
-					// One ScopeSpans per ResourceSpans is enough — cerberus
-					// flattens the scope dimension on the JSON path
-					// (groupBatches' ResourceSpans has no scope_spans
-					// field), so mirroring "one ScopeSpans bucket" keeps
-					// the two outputs structurally aligned.
-					Scope: nil,
-				}},
-			}
-			bucket[key] = rs
-			keys = append(keys, key)
+	groups := groupTraceBatches(samples)
+	out := &tempopb.Trace{ResourceSpans: make([]*tracev1.ResourceSpans, 0, len(groups))}
+	for _, g := range groups {
+		rs := &tracev1.ResourceSpans{
+			Resource: &resourcev1.Resource{
+				Attributes: attrMapToKVList(g.resourceAttrs),
+			},
+			ScopeSpans: []*tracev1.ScopeSpans{{
+				// One ScopeSpans per ResourceSpans is enough — cerberus
+				// flattens the scope dimension on the JSON path
+				// (groupBatches' ResourceSpans has no scope_spans
+				// field), so mirroring "one ScopeSpans bucket" keeps
+				// the two outputs structurally aligned.
+				Scope: nil,
+			}},
 		}
-		rs.ScopeSpans[0].Spans = append(rs.ScopeSpans[0].Spans, &tracev1.Span{
-			TraceId:           hexToBytesPadded(meta[traceByIDKeyTraceID], 16),
-			SpanId:            hexToBytesPadded(meta[traceByIDKeySpanID], 8),
-			ParentSpanId:      hexToBytesPadded(meta[traceByIDKeyParentSpanID], 8),
-			Name:              s.MetricName,
-			Kind:              spanKindFromCH(meta[traceByIDKeySpanKind]),
-			StartTimeUnixNano: uint64(s.Timestamp.UnixNano()),
-			// DurationNanos is carried as Value on the Sample; the proto
-			// shape has no Duration field, so we encode start + end so
-			// EndTimeUnixNano - StartTimeUnixNano = the duration the JSON
-			// path exposes verbatim. durationNanosFromValue clamps the
-			// float64 duration to a non-negative uint64 so the gosec G115
-			// signed-to-unsigned conversion check stays happy on the cast.
-			EndTimeUnixNano: uint64(s.Timestamp.UnixNano()) + durationNanosFromValue(s.Value),
-			Status:          &tracev1.Status{Code: statusCodeFromCH(meta[traceByIDKeyStatusCode])},
-			Attributes:      attrMapToKVList(spanAttrs),
-		})
-	}
-	out := &tempopb.Trace{ResourceSpans: make([]*tracev1.ResourceSpans, 0, len(bucket))}
-	for _, k := range keys {
-		out.ResourceSpans = append(out.ResourceSpans, bucket[k])
+		for _, row := range g.spans {
+			rs.ScopeSpans[0].Spans = append(rs.ScopeSpans[0].Spans, &tracev1.Span{
+				TraceId:           hexToBytesPadded(row.meta[traceByIDKeyTraceID], 16),
+				SpanId:            hexToBytesPadded(row.meta[traceByIDKeySpanID], 8),
+				ParentSpanId:      hexToBytesPadded(row.meta[traceByIDKeyParentSpanID], 8),
+				Name:              row.sample.MetricName,
+				Kind:              spanKindFromCH(row.meta[traceByIDKeySpanKind]),
+				StartTimeUnixNano: uint64(row.sample.Timestamp.UnixNano()),
+				// DurationNanos is carried as Value on the Sample; the proto
+				// shape has no Duration field, so we encode start + end so
+				// EndTimeUnixNano - StartTimeUnixNano = the duration the JSON
+				// path exposes verbatim. durationNanosFromValue clamps the
+				// float64 duration to a non-negative uint64 so the gosec G115
+				// signed-to-unsigned conversion check stays happy on the cast.
+				EndTimeUnixNano: uint64(row.sample.Timestamp.UnixNano()) + durationNanosFromValue(row.sample.Value),
+				Status:          &tracev1.Status{Code: statusCodeFromCH(row.meta[traceByIDKeyStatusCode])},
+				Attributes:      attrMapToKVList(row.spanAttrs),
+			})
+		}
+		out.ResourceSpans = append(out.ResourceSpans, rs)
 	}
 	return out
 }

--- a/test/e2e/playwright/playwright.config.ts
+++ b/test/e2e/playwright/playwright.config.ts
@@ -20,6 +20,11 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
+  // A pass-on-retry is a masked intermittent bug; the suite must
+  // surface it red in CI (run 27284868985 went green over a real
+  // non-determinism bug — the trace-by-id batch-order flake — exactly
+  // this way). Locally (no CI env) retries still help iteration.
+  failOnFlakyTests: !!process.env.CI,
   workers: process.env.CI ? 1 : undefined,
   reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
 


### PR DESCRIPTION
## Summary

Root-cause fix for the retry-masked flake flagged in run 27284868985: `tempo_traces.spec.ts`'s v1==v2 byte-parity check failed intermittently because **trace-by-id batch assembly was non-deterministic** — `groupBatches` (JSON path) iterated a Go map to emit resource batches (random order per call), and span order in BOTH wire paths followed ClickHouse row order. Two sequential fetches of the same trace could legitimately differ. The suite then went green because Playwright retries mark a pass-on-retry as *flaky* and exit 0 — masking the real bug.

## Changes

1. **Shared deterministic assembly** (`groupTraceBatches`, consumed by both JSON and proto paths): batches sort by resource `service.name` then canonical-attr-string tie-break; spans sort by `startTimeUnixNano` then span ID. Pinned by a shuffle-prone 8-bucket fixture: explicit sort-contract assertions, 50 repeated assemblies byte-identical through both serializations, input-row-order independence. 341 package tests pass.
2. **`failOnFlakyTests: !!process.env.CI`** in the shared playwright config (first-class in the pinned 1.60.0): a pass-on-retry is a masked intermittent bug and now turns the run red in CI; local retries still help iteration. Applies to both e2e lanes — **previously masked latent flakes will now surface red**, each a real bug to fix per doctrine.

The trace-by-id sort contract is wire-visible (documented order replaces random order); Grafana's trace view is order-agnostic, and the v1==v2 parity pin now holds by construction.

## Test plan

- [ ] `check` green (determinism pins)
- [ ] dashboard + compose-smoke lanes green under `failOnFlakyTests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
