### PR TITLE
fix(justfile): update-golden regenerates chdb-tagged expected_rows too

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ Top-level reading order for any new contributor (human or agent):
 
 ## Common workflows
 
-- **Add a TXTAR fixture** — use the `/cerberus:add-fixture` skill (under `.claude/skills/`). It creates `test/spec/<ql>/<name>.txtar` with the right section headers (`-- input --`, `-- sql --`, `-- chplan --`, optional `-- seed --` / `-- expected_rows --`); run `just update-golden` after the implementation lands to fill in expected sections.
+- **Add a TXTAR fixture** — use the `/cerberus:add-fixture` skill (under `.claude/skills/`). It creates `test/spec/<ql>/<name>.txtar` with the right section headers (`-- input --`, `-- sql --`, `-- chplan --`, optional `-- seed --` / `-- expected_rows --`); run `just update-golden` after the implementation lands to fill in expected sections — it covers both the default-tag text goldens and the chdb-tagged `-- expected_rows --` cells (requires libchdb.so via `just chdb-install`).
 - **Add an optimizer rule** — use the `/cerberus:add-optimizer-rule` skill. Scaffolds `internal/optimizer/<name>.go` + test + TXTAR fixtures.
 - **Add a property test** — add a row to the generator + oracle under `test/property/{gen,oracle}/` and a case to `test/property/promql_test.go`. The framework wires `rapid.Check` → dataset gen → chDB exec → oracle → comparator; you only swap the data shape + oracle. Build-tagged `chdb`; runs in the `chdb` workflow only.
 - **Bump parser deps** — use the `/cerberus:bump-parser-deps` skill. Runs `go get -u` on the three upstream parsers, runs `go mod tidy`, captures the diff for the PR description.

--- a/Justfile
+++ b/Justfile
@@ -145,9 +145,17 @@ coverage:
       }' cover-merged.out | sort -rn
 
 # Regenerate TXTAR golden sections in test/spec/**/*.txtar from current output.
+# Two lanes: the default-tag pass rewrites `-- sql --` / `-- chplan --`
+# text goldens, then a chdb-tagged pass (mirroring `just spec-chdb`)
+# rewrites the `-- expected_rows --` round-trip cells, which only execute
+# under that build tag. Requires libchdb.so (`just chdb-install`) — the
+# recipe fails fast without it rather than leaving stale expected_rows
+# behind (the PR #758 failure mode).
 # Review `git diff test/spec/` before committing.
 update-golden:
+    @test -f "{{CHDB_INSTALL_PATH}}" || { echo "error: {{CHDB_INSTALL_PATH}} not found — run 'just chdb-install' first; without it the chdb-tagged -- expected_rows -- sections cannot regenerate and go stale" >&2; exit 1; }
     GOLDEN_UPDATE=1 go test ./...
+    GOLDEN_UPDATE=1 go test -tags chdb -count=1 ./test/spec/...
     @echo
     @echo "Diff of regenerated fixtures:"
     @git --no-pager diff --stat test/spec/ || true

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -109,8 +109,11 @@ idempotency.
 Fixtures with both `-- seed --` and `-- expected_rows --` sections run
 under the `chdb` build tag. The runner DDL-applies the OTel-CH schema,
 loads the seed rows, executes the emitted SQL, and compares the result
-set to `expected_rows`. Use `just update-golden` and `just spec-chdb`
-locally.
+set to `expected_rows`. `just update-golden` regenerates this layer too
+— it runs a second, chdb-tagged pass over `./test/spec/...` so
+`expected_rows` cells can never go stale behind a `-- sql --` change
+(it requires libchdb.so; see `just chdb-install`). Use `just spec-chdb`
+to verify locally without rewriting.
 
 ### Layer 7 — HTTP handler conformance
 

--- a/test/spec/runner.go
+++ b/test/spec/runner.go
@@ -90,7 +90,7 @@ func Walk(t *testing.T, dir string, fn func(t *testing.T, c *Case)) {
 // disk in c. When GOLDEN_UPDATE=1 is set, mismatches rewrite the section
 // in-place instead of failing — so the dev flow is:
 //
-//	GOLDEN_UPDATE=1 just test-spec       # regenerate fixtures
+//	just update-golden                   # regenerate fixtures (both lanes)
 //	git diff                             # review the new expected output
 //	git add test/spec && git commit ...
 //


### PR DESCRIPTION
## Summary

`just update-golden` regenerated the `-- sql --` / `-- chplan --` TXTAR sections but never the chdb-tagged `-- expected_rows --` cells — those are only rewritten under `go test -tags chdb`, which the recipe didn't run. This bit PR #758: three stale `expected_rows` cells survived a lowering change and only failed later in the CI `roundtrip (logql)` lane.

## Changes

- **`Justfile` `update-golden`**: now (1) fails fast with a pointer to `just chdb-install` if `libchdb.so` is absent — loud failure instead of silently leaving `expected_rows` stale, (2) runs the existing default-tag lane, (3) runs a second `GOLDEN_UPDATE=1 go test -tags chdb -count=1 ./test/spec/...` pass, mirroring `just spec-chdb`'s invocation exactly. The `runner_chdb.go` GOLDEN_UPDATE rewrite path already existed; it was just never reached by the recipe.
- **`test/spec/runner.go`**: fix stale doc comment referencing a nonexistent `just test-spec` recipe.
- **`docs/test-strategy.md`** + **`CLAUDE.md`**: document that `update-golden` now covers both lanes (and requires libchdb); `spec-chdb` is verify-without-rewrite.

## Verification

- Clean-tree `just update-golden`: exit 0, both lanes green, zero diff under `test/spec/**/*.txtar`.
- Coverage proof: hand-corrupted one `-- expected_rows --` cell (`0.01` → `9999.99`) in `test/spec/logql/agg_by_severity.txtar`, re-ran — the chdb lane restored it, tree left clean.
- `test/regression/justfile_test.go` pins unaffected (recipe uses Just interpolation, no `$$` shell vars).

Closes task #29 (update-golden chdb-tagged expected_rows coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
