### PR TITLE
fix(telemetry): pin explicit bucket boundaries on self-metric histograms

### DIFF
--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -108,6 +108,44 @@ type Instruments struct {
 	QueryInflight metric.Int64UpDownCounter
 }
 
+// Histogram bucket boundaries, one ladder per instrument, matched to the
+// unit + magnitude each instrument actually records.
+//
+// These exist because the OTel Go SDK's default explicit-bucket layout —
+// [0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500,
+// 10000] — is millisecond-shaped, while cerberus's duration instruments
+// record seconds (see QueryTimer.Done / StageTimer.Done). Without
+// explicit boundaries every real observation (2ms–1s) collapsed into the
+// (0,5] bucket, so histogram_quantile(0.95) linearly interpolated a flat
+// 0.95×5 = 4.75s for every query language. The row/byte instruments had
+// the same defect: a millisecond ladder is meaningless for row and byte
+// counts.
+//
+// Exported so tests assert against the single source of truth.
+var (
+	// QueryDurationBoundaries covers end-to-end query wall-clock in
+	// seconds: Prometheus DefBuckets plus a 30s tail for pathological
+	// slow queries.
+	QueryDurationBoundaries = []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30}
+
+	// StageDurationBoundaries covers per-pipeline-stage wall-clock in
+	// seconds. Stages (parse / lower / optimize / emit) are much faster
+	// than whole queries, so the ladder starts at 1ms.
+	StageDurationBoundaries = []float64{0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5}
+
+	// RulesAppliedBoundaries covers the optimizer's per-query change
+	// count — small integers, so a near-unit ladder.
+	RulesAppliedBoundaries = []float64{0, 1, 2, 3, 5, 8, 13, 21}
+
+	// RowsReadBoundaries covers ClickHouse rows read per query —
+	// decade-exponential from 100 rows to 100M rows.
+	RowsReadBoundaries = []float64{100, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8}
+
+	// BytesReadBoundaries covers ClickHouse bytes read per query —
+	// decade-exponential from 10KB to 10GB.
+	BytesReadBoundaries = []float64{1e4, 1e5, 1e6, 1e7, 1e8, 1e9, 1e10}
+)
+
 var (
 	cacheMu sync.Mutex
 	cache   *Instruments
@@ -156,6 +194,7 @@ func mustBuild(meter metric.Meter) *Instruments {
 		"cerberus_queries_duration_seconds",
 		metric.WithDescription("End-to-end query wall-clock, seconds."),
 		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(QueryDurationBoundaries...),
 	)
 	if err != nil {
 		panic("telemetry: build queries_duration: " + err.Error())
@@ -164,6 +203,7 @@ func mustBuild(meter metric.Meter) *Instruments {
 		"cerberus_pipeline_stage_duration_seconds",
 		metric.WithDescription("Per-stage pipeline wall-clock, seconds."),
 		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(StageDurationBoundaries...),
 	)
 	if err != nil {
 		panic("telemetry: build stage_duration: " + err.Error())
@@ -172,6 +212,7 @@ func mustBuild(meter metric.Meter) *Instruments {
 		"cerberus_optimizer_rules_applied",
 		metric.WithDescription("Optimizer rule invocations that changed the plan."),
 		metric.WithUnit("{rule}"),
+		metric.WithExplicitBucketBoundaries(RulesAppliedBoundaries...),
 	)
 	if err != nil {
 		panic("telemetry: build rules_applied: " + err.Error())
@@ -180,6 +221,7 @@ func mustBuild(meter metric.Meter) *Instruments {
 		"cerberus_clickhouse_rows_read",
 		metric.WithDescription("ClickHouse rows read per query (sum of Progress events)."),
 		metric.WithUnit("{row}"),
+		metric.WithExplicitBucketBoundaries(RowsReadBoundaries...),
 	)
 	if err != nil {
 		panic("telemetry: build rows_read: " + err.Error())
@@ -188,6 +230,7 @@ func mustBuild(meter metric.Meter) *Instruments {
 		"cerberus_clickhouse_bytes_read",
 		metric.WithDescription("ClickHouse bytes read per query (sum of Progress events)."),
 		metric.WithUnit("By"),
+		metric.WithExplicitBucketBoundaries(BytesReadBoundaries...),
 	)
 	if err != nil {
 		panic("telemetry: build bytes_read: " + err.Error())

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -65,6 +65,137 @@ func metricNames(sm metricdata.ScopeMetrics) []string {
 	return names
 }
 
+// bucketFor returns the index of the histogram bucket an observation of
+// value lands in, given the explicit bounds: the first i with
+// value <= bounds[i], or len(bounds) for the +Inf overflow bucket.
+// Mirrors the OTel SDK's bucket assignment (upper-bound inclusive).
+func bucketFor(bounds []float64, value float64) int {
+	for i, b := range bounds {
+		if value <= b {
+			return i
+		}
+	}
+	return len(bounds)
+}
+
+// histogramBounds extracts (Bounds, BucketCounts, Count) from a histogram
+// metric regardless of its point type (float64 vs int64). Fails the test
+// when the metric carries more or fewer than one datapoint — every case
+// in TestHistogramBucketBoundaries records exactly one observation
+// without attributes.
+func histogramBounds(t *testing.T, m metricdata.Metrics) ([]float64, []uint64, uint64) {
+	t.Helper()
+	switch h := m.Data.(type) {
+	case metricdata.Histogram[float64]:
+		if len(h.DataPoints) != 1 {
+			t.Fatalf("%s: got %d DPs want 1", m.Name, len(h.DataPoints))
+		}
+		dp := h.DataPoints[0]
+		return dp.Bounds, dp.BucketCounts, dp.Count
+	case metricdata.Histogram[int64]:
+		if len(h.DataPoints) != 1 {
+			t.Fatalf("%s: got %d DPs want 1", m.Name, len(h.DataPoints))
+		}
+		dp := h.DataPoints[0]
+		return dp.Bounds, dp.BucketCounts, dp.Count
+	default:
+		t.Fatalf("%s: unexpected data type %T", m.Name, m.Data)
+		return nil, nil, 0
+	}
+}
+
+// TestHistogramBucketBoundaries pins every histogram instrument to its
+// exported explicit-bucket ladder. Regression test for the flat-4.75s
+// p95 bug: the instruments used to be built without
+// WithExplicitBucketBoundaries, inheriting the OTel SDK's
+// millisecond-shaped defaults [0, 5, 10, ..., 10000] while recording
+// seconds — every real query duration (2ms–1s) collapsed into the (0,5]
+// bucket and histogram_quantile(0.95) interpolated 0.95×5 = 4.75s for
+// every cerberus_ql. The test asserts what the dashboard consumer
+// actually depends on: the exported datapoint Bounds match the
+// seconds-scale (resp. count-scale) ladders, and a representative
+// observation lands in its mid-ladder bucket rather than the first one.
+func TestHistogramBucketBoundaries(t *testing.T) {
+	cases := []struct {
+		metricName string
+		record     func(ctx context.Context)
+		wantBounds []float64
+		value      float64 // representative observation recorded by record
+	}{
+		{
+			metricName: "cerberus_queries_duration_seconds",
+			record: func(ctx context.Context) {
+				telemetry.Get().QueryDuration.Record(ctx, 0.3)
+			},
+			wantBounds: telemetry.QueryDurationBoundaries,
+			value:      0.3, // a realistic query duration → (0.25, 0.5]
+		},
+		{
+			metricName: "cerberus_pipeline_stage_duration_seconds",
+			record: func(ctx context.Context) {
+				telemetry.Get().StageDuration.Record(ctx, 0.003)
+			},
+			wantBounds: telemetry.StageDurationBoundaries,
+			value:      0.003, // a realistic stage duration → (0.0025, 0.005]
+		},
+		{
+			metricName: "cerberus_optimizer_rules_applied",
+			record: func(ctx context.Context) {
+				telemetry.Get().RulesApplied.Record(ctx, 2)
+			},
+			wantBounds: telemetry.RulesAppliedBoundaries,
+			value:      2, // → (1, 2]
+		},
+		{
+			metricName: "cerberus_clickhouse_rows_read",
+			record: func(ctx context.Context) {
+				telemetry.Get().ClickHouseRowsRead.Record(ctx, 50_000)
+			},
+			wantBounds: telemetry.RowsReadBoundaries,
+			value:      50_000, // → (1e4, 1e5]
+		},
+		{
+			metricName: "cerberus_clickhouse_bytes_read",
+			record: func(ctx context.Context) {
+				telemetry.Get().ClickHouseBytesRead.Record(ctx, 5_000_000)
+			},
+			wantBounds: telemetry.BytesReadBoundaries,
+			value:      5_000_000, // → (1e6, 1e7]
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.metricName, func(t *testing.T) {
+			reader := installManualReader(t)
+			tc.record(t.Context())
+
+			sm := collect(t, reader)
+			m := findMetric(t, sm, tc.metricName)
+			bounds, counts, count := histogramBounds(t, m)
+
+			// (a) The exported bounds ARE the instrument's bounds — i.e.
+			// not the SDK's millisecond-shaped defaults.
+			assert.Equal(t, tc.wantBounds, bounds,
+				"%s: datapoint Bounds must match the exported boundary ladder", tc.metricName)
+
+			// (b) The representative observation lands in its mid-ladder
+			// bucket, not the first one (where the ms-default layout
+			// dumped every seconds-scale value).
+			if count != 1 {
+				t.Fatalf("%s: count = %d, want 1", tc.metricName, count)
+			}
+			wantBucket := bucketFor(tc.wantBounds, tc.value)
+			if wantBucket == 0 {
+				t.Fatalf("%s: representative value %v falls in the first bucket — pick a mid-ladder value", tc.metricName, tc.value)
+			}
+			if got := counts[wantBucket]; got != 1 {
+				t.Errorf("%s: observation %v landed in counts=%v, want 1 in bucket %d (%v, %v]",
+					tc.metricName, tc.value, counts, wantBucket,
+					tc.wantBounds[wantBucket-1], tc.wantBounds[wantBucket])
+			}
+		})
+	}
+}
+
 // TestObserveQuery_RecordsCounterAndDuration covers the QueryTimer
 // happy path: a single Done(ResultOK) call must bump
 // cerberus_queries_total by one and record a point on


### PR DESCRIPTION
## Summary

Found by the Grafana crawl sweep: the cerberus dashboard showed an **identical flat 4.75s p95 line** for promql, logql, and traceql — a number too suspicious to be real, and it wasn't.

The five histogram instruments in `internal/telemetry` were built without `metric.WithExplicitBucketBoundaries`, inheriting the OTel Go SDK's default explicit-bucket ladder `[0, 5, 10, 25, …, 10000]` — millisecond-shaped — while `QueryTimer.Done` / `StageTimer.Done` record **seconds**. Every real duration (2 ms–1.06 s) collapsed into the `(0,5]` bucket and `histogram_quantile(0.95)` interpolated 0.95 × 5 = **4.75** for every head. Verified live: wire `le` buckets were `0,5,10,…,10000`, p95 exactly 4.75 across all three languages.

## Fix

Each instrument pins a ladder matched to its unit and magnitude (exported as package vars — single source of truth for the tests):

| Instrument | Ladder |
|---|---|
| `cerberus_queries_duration_seconds` | Prometheus DefBuckets + 30 s tail |
| `cerberus_pipeline_stage_duration_seconds` | 1 ms–5 s sub-second ladder |
| `cerberus_optimizer_rules_applied` | small-count ladder |
| `cerberus_clickhouse_rows_read` | decade-exponential 100–1e8 |
| `cerberus_clickhouse_bytes_read` | decade-exponential 10 KB–10 GB |

## Tests

`TestHistogramBucketBoundaries` collects via the SDK ManualReader and asserts per instrument that exported `Bounds` equal the pinned ladder (not the ms defaults) and that a representative 0.3 s observation lands mid-ladder in `(0.25, 0.5]`, not the first bucket.

ExplicitBounds are per-datapoint in the OTel-CH schema — no DDL or dashboard change; old ms-bounded datapoints age out via TTL (quantile windows spanning the deploy briefly mix layouts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
