### PR TITLE
fix(prom): report non-monotonic OTel Sums (UpDownCounters) as gauge in /api/v1/metadata

### DIFF
--- a/internal/api/prom/handler_chdb_label_values_test.go
+++ b/internal/api/prom/handler_chdb_label_values_test.go
@@ -40,15 +40,20 @@ const metaShapedGaugeDDL = `CREATE TABLE otel_metrics_gauge (
 
 // metaShapedSumDDL mirrors metaShapedGaugeDDL for the sum (counter)
 // table — needed so the metadata handler's per-table fetch doesn't 502
-// on missing-table errors. Same columns as gauge — the metadata SQL
-// only reads (MetricName, MetricDescription, MetricUnit).
+// on missing-table errors. Adds `IsMonotonic` on top of the shared
+// (MetricName, MetricDescription, MetricUnit) triple because the
+// metadata handler splits the sum table by monotonicity: monotonic
+// Sums report as Prom "counter", non-monotonic Sums (OTel
+// UpDownCounters) as "gauge". DEFAULT false keeps the column optional
+// for seeds that don't care about the type split.
 const metaShapedSumDDL = `CREATE TABLE otel_metrics_sum (
     MetricName String,
     MetricDescription String,
     MetricUnit String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
-    Value Float64
+    Value Float64,
+    IsMonotonic Bool DEFAULT false
 ) ENGINE = MergeTree() ORDER BY (MetricName, TimeUnix);`
 
 // metaShapedHistogramDDL completes the trio. The metadata-handler SQL
@@ -305,6 +310,75 @@ INSERT INTO otel_metrics_gauge (MetricName, MetricDescription, MetricUnit, Attri
 	if !equalStringSlice(values, want) {
 		t.Errorf("expected %v, got %v", want, values)
 	}
+}
+
+// TestMetadata_NonMonotonicSumIsGauge_ChDB pins the OTel→Prometheus
+// type mapping end-to-end against the real sum-table SQL: a monotonic
+// Sum reports as Prom "counter", a non-monotonic Sum (OTel
+// UpDownCounter — cerberus's own cerberus_query_inflight is one)
+// reports as "gauge". Before the IsMonotonic split every sum-table
+// metric typed "counter", which made Grafana's Metrics Drilldown wrap
+// UpDownCounters in rate() and render a flat-0 preview.
+func TestMetadata_NonMonotonicSumIsGauge_ChDB(t *testing.T) {
+	seedTime := time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC)
+	ts := seedTime.Format("2006-01-02 15:04:05.000")
+	seed := metaShapedGaugeDDL + metaShapedSumDDL + metaShapedHistogramDDL + fmt.Sprintf(`
+INSERT INTO otel_metrics_sum (MetricName, MetricDescription, MetricUnit, Attributes, TimeUnix, Value, IsMonotonic) VALUES
+    ('cerberus_queries_total',  'Total engine queries.',            '{query}', map('cerberus.ql', 'promql'), toDateTime64('%s', 9), 42.0, true),
+    ('cerberus_query_inflight', 'Currently-executing engine queries.', '{query}', map('cerberus.ql', 'promql'), toDateTime64('%s', 9), 3.0,  false);`,
+		ts, ts)
+
+	srv, _ := newChDBServer(t, seed)
+
+	assertTypes := func(t *testing.T, path string, want map[string]string) {
+		t.Helper()
+		resp, err := http.Get(srv.URL + path)
+		if err != nil {
+			t.Fatalf("GET %s: %v", path, err)
+		}
+		body := readBody(t, resp)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+		}
+		var parsed metadataResponse
+		if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+			t.Fatalf("unmarshal: %v\nbody=%s", err, body)
+		}
+		var grouped map[string][]prom.MetricMetaEntry
+		if err := json.Unmarshal(parsed.Data, &grouped); err != nil {
+			t.Fatalf("decode data: %v\nbody=%s", err, body)
+		}
+		if len(grouped) != len(want) {
+			t.Fatalf("%s: expected %d metrics, got %d: keys=%v",
+				path, len(want), len(grouped), keysOf(grouped))
+		}
+		for name, wantType := range want {
+			entries, ok := grouped[name]
+			if !ok || len(entries) != 1 {
+				t.Errorf("%s: expected exactly one entry for %q, got %+v",
+					path, name, grouped[name])
+				continue
+			}
+			if entries[0].Type != wantType {
+				t.Errorf("%s: %s type=%q, want %q",
+					path, name, entries[0].Type, wantType)
+			}
+		}
+	}
+
+	// Unfiltered listing: both metrics surface with their split types.
+	assertTypes(t, "/api/v1/metadata", map[string]string{
+		"cerberus_queries_total":  "counter",
+		"cerberus_query_inflight": "gauge",
+	})
+	// Filtered: the metric-name predicate ANDs with each monotonicity
+	// arm, so the UpDownCounter surfaces alone — and as gauge.
+	assertTypes(t, "/api/v1/metadata?metric=cerberus_query_inflight", map[string]string{
+		"cerberus_query_inflight": "gauge",
+	})
+	assertTypes(t, "/api/v1/metadata?metric=cerberus_queries_total", map[string]string{
+		"cerberus_queries_total": "counter",
+	})
 }
 
 // TestMetadata_TruncateAtLimit_ChDB pins truncateMetadata's

--- a/internal/api/prom/handler_test.go
+++ b/internal/api/prom/handler_test.go
@@ -27,6 +27,22 @@ type stubQuerier struct {
 	exemplarsErr error
 	lastSQL      string
 	lastArgs     []any
+
+	// metaCalls records every QueryMetricMeta invocation in order so
+	// metadata tests can assert the per-table fan-out (which SQL was
+	// issued under which reported metric type).
+	metaCalls []metaCall
+	// metaRowsFn, when set, answers each QueryMetricMeta call from the
+	// recorded call instead of the static metaRows slice — lets a test
+	// return different rows per fan-out arm.
+	metaRowsFn func(call metaCall) []chclient.MetricMetaRow
+}
+
+// metaCall is one recorded QueryMetricMeta invocation.
+type metaCall struct {
+	sql  string
+	kind string
+	args []any
 }
 
 func (s *stubQuerier) Query(_ context.Context, sql string, args ...any) ([]chclient.Sample, error) {
@@ -65,11 +81,16 @@ func (s *stubQuerier) QueryLabelSets(_ context.Context, sql string, args ...any)
 	return s.labelSets, nil
 }
 
-func (s *stubQuerier) QueryMetricMeta(_ context.Context, sql, _ string, args ...any) ([]chclient.MetricMetaRow, error) {
+func (s *stubQuerier) QueryMetricMeta(_ context.Context, sql, metricType string, args ...any) ([]chclient.MetricMetaRow, error) {
 	s.lastSQL = sql
 	s.lastArgs = args
+	call := metaCall{sql: sql, kind: metricType, args: args}
+	s.metaCalls = append(s.metaCalls, call)
 	if s.err != nil {
 		return nil, s.err
+	}
+	if s.metaRowsFn != nil {
+		return s.metaRowsFn(call), nil
 	}
 	return s.metaRows, nil
 }

--- a/internal/api/prom/metadata.go
+++ b/internal/api/prom/metadata.go
@@ -134,9 +134,10 @@ func (h *Handler) handleLabelValues(w http.ResponseWriter, r *http.Request) {
 }
 
 // MetricMetaEntry is one entry in the per-metric metadata array Prometheus
-// emits from /api/v1/metadata. Cerberus emits exactly one entry per
-// metric (multiple entries would be required only if the same metric
-// appears in multiple types — uncommon).
+// emits from /api/v1/metadata. Cerberus typically emits one entry per
+// metric; a name that appears under multiple types (e.g. a sum-table
+// metric written with both IsMonotonic values) yields one entry per
+// type, matching the Prometheus wire format's per-metric entry slice.
 type MetricMetaEntry struct {
 	Type string `json:"type"`
 	Help string `json:"help"`
@@ -145,7 +146,10 @@ type MetricMetaEntry struct {
 
 // handleMetadata implements GET /api/v1/metadata — per-metric type / help /
 // unit, sourced from the OTel `MetricDescription` and `MetricUnit` columns.
-// Type is derived from the source table: gauge / counter / histogram.
+// Type is derived from the source table — gauge / counter / histogram —
+// with the sum table further split on `IsMonotonic`: per the
+// OTel→Prometheus compatibility spec a non-monotonic Sum (UpDownCounter)
+// maps to Prom type "gauge", not "counter".
 //
 // The `metric` query parameter restricts the result to a single metric;
 // `limit` caps the number of metrics returned (per Prom convention).
@@ -188,19 +192,46 @@ func (h *Handler) handleMetadata(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// metricMetaSpec is one (table, reported type) arm of the metadata
+// fan-out. A non-nil monotonic narrows the arm to rows whose
+// IsMonotonic column matches — the sum table holds both OTel
+// monotonic Sums (Prom counters) and non-monotonic Sums /
+// UpDownCounters, which the OTel→Prometheus compatibility spec maps
+// to Prom type "gauge".
+type metricMetaSpec struct {
+	table     string
+	kind      string
+	monotonic *bool
+}
+
 func (h *Handler) fetchMetricMeta(ctx context.Context, metricName string) ([]chclient.MetricMetaRow, error) {
-	specs := []struct {
-		table string
-		kind  string
-	}{
-		{h.Schema.GaugeTable, "gauge"},
-		{h.Schema.SumTable, "counter"},
-		{h.Schema.HistogramTable, "histogram"},
+	monotonic, nonMonotonic := true, false
+	specs := []metricMetaSpec{
+		{table: h.Schema.GaugeTable, kind: "gauge"},
 	}
+	if h.Schema.IsMonotonicColumn != "" {
+		// Split the sum table by monotonicity: monotonic Sums are Prom
+		// counters; non-monotonic Sums (OTel UpDownCounters — queue
+		// depths, in-flight gauges, pool sizes) are Prom gauges.
+		// Reporting them as counters makes consumers like Grafana's
+		// Metrics Drilldown wrap them in rate(), which renders a
+		// meaningless flat-0 preview.
+		specs = append(
+			specs,
+			metricMetaSpec{table: h.Schema.SumTable, kind: "counter", monotonic: &monotonic},
+			metricMetaSpec{table: h.Schema.SumTable, kind: "gauge", monotonic: &nonMonotonic},
+		)
+	} else {
+		// Fallback for schema overrides whose sum table has no
+		// IsMonotonic column: without the discriminator every sum-table
+		// metric reports as counter (the pre-split behaviour).
+		specs = append(specs, metricMetaSpec{table: h.Schema.SumTable, kind: "counter"})
+	}
+	specs = append(specs, metricMetaSpec{table: h.Schema.HistogramTable, kind: "histogram"})
 
 	var out []chclient.MetricMetaRow
 	for _, spec := range specs {
-		sql, args := h.metricMetaSQL(spec.table, metricName)
+		sql, args := h.metricMetaSQL(spec.table, metricName, spec.monotonic)
 		rows, err := h.Client.QueryMetricMeta(ctx, sql, spec.kind, args...)
 		if err != nil {
 			return nil, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusBadGateway}
@@ -213,7 +244,9 @@ func (h *Handler) fetchMetricMeta(ctx context.Context, metricName string) ([]chc
 // metricMetaSQL builds the per-table metadata SQL. The result columns are
 // (MetricName, MetricDescription, MetricUnit). When metricName is empty
 // we list all distinct metrics; otherwise we filter to the named one.
-func (h *Handler) metricMetaSQL(table, metricName string) (string, []any) {
+// A non-nil monotonic adds a `IsMonotonic` / `NOT IsMonotonic` predicate
+// (combined via AND with the metric-name filter when both are present).
+func (h *Handler) metricMetaSQL(table, metricName string, monotonic *bool) (string, []any) {
 	nameCol := h.Schema.MetricNameColumn
 	descCol := h.Schema.MetricDescriptionColumn
 	unitCol := h.Schema.MetricUnitColumn
@@ -226,6 +259,17 @@ func (h *Handler) metricMetaSQL(table, metricName string) (string, []any) {
 		Select(chsql.Col(nameCol), anyCall(descCol), anyCall(unitCol)).
 		From(chsql.Col(table)).
 		GroupBy(chsql.Col(nameCol))
+
+	if monotonic != nil {
+		// Bare boolean-column predicate (`IsMonotonic` / `NOT
+		// IsMonotonic`) — no bound args, so the metric-name filter
+		// below keeps its positional slot.
+		pred := chsql.Col(h.Schema.IsMonotonicColumn)
+		if !*monotonic {
+			pred = chsql.Not(pred)
+		}
+		sb.Where(pred)
+	}
 
 	if metricName == "" {
 		sb.OrderBy(chsql.Col(nameCol), false)

--- a/internal/api/prom/metadata_test.go
+++ b/internal/api/prom/metadata_test.go
@@ -3,11 +3,13 @@ package prom_test
 import (
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/tsouza/cerberus/internal/api/prom"
 	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/schema"
 )
 
 // metadataResponse decodes the Prom metadata-endpoint shape — `data` is a
@@ -323,6 +325,191 @@ func TestMetadata_FilterByName(t *testing.T) {
 
 	if len(q.lastArgs) == 0 || q.lastArgs[0] != "up" {
 		t.Errorf("expected last query arg = 'up', got %v", q.lastArgs)
+	}
+}
+
+// TestMetadata_NonMonotonicSumIsGauge pins the OTel→Prometheus type
+// mapping for the sum table: monotonic Sums report as "counter",
+// non-monotonic Sums (OTel UpDownCounters — e.g. the in-flight-query
+// gauge cerberus itself emits) report as "gauge". Before the split the
+// handler typed every sum-table metric "counter", and Grafana's
+// Metrics Drilldown wrapped UpDownCounters in rate() — a flat-0 chart.
+func TestMetadata_NonMonotonicSumIsGauge(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{}
+	q.metaRowsFn = func(call metaCall) []chclient.MetricMetaRow {
+		if !strings.Contains(call.sql, "otel_metrics_sum") {
+			return nil
+		}
+		switch {
+		case strings.Contains(call.sql, "NOT `IsMonotonic`"):
+			return []chclient.MetricMetaRow{{
+				Name:        "cerberus_query_inflight",
+				Description: "Currently-executing engine queries.",
+				Unit:        "{query}",
+				Type:        call.kind,
+			}}
+		case strings.Contains(call.sql, "`IsMonotonic`"):
+			return []chclient.MetricMetaRow{{
+				Name:        "cerberus_queries_total",
+				Description: "Total engine queries.",
+				Unit:        "{query}",
+				Type:        call.kind,
+			}}
+		default:
+			t.Errorf("sum-table metadata SQL missing IsMonotonic predicate: %q", call.sql)
+			return nil
+		}
+	}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/metadata")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	var parsed metadataResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// (a) Fan-out shape: the sum table is queried exactly twice — once
+	// per monotonicity arm with the matching reported type — and the
+	// gauge / histogram arms carry no IsMonotonic predicate.
+	var sumCalls []metaCall
+	for _, call := range q.metaCalls {
+		if strings.Contains(call.sql, "otel_metrics_sum") {
+			sumCalls = append(sumCalls, call)
+			continue
+		}
+		if strings.Contains(call.sql, "IsMonotonic") {
+			t.Errorf("non-sum metadata SQL (kind=%s) must not filter IsMonotonic: %q",
+				call.kind, call.sql)
+		}
+	}
+	if len(sumCalls) != 2 {
+		t.Fatalf("expected 2 sum-table metadata queries, got %d: %+v",
+			len(sumCalls), sumCalls)
+	}
+	for _, call := range sumCalls {
+		nonMonotonic := strings.Contains(call.sql, "NOT `IsMonotonic`")
+		switch {
+		case nonMonotonic && call.kind != "gauge":
+			t.Errorf("NOT IsMonotonic arm reported type %q, want gauge; sql=%q",
+				call.kind, call.sql)
+		case !nonMonotonic && call.kind != "counter":
+			t.Errorf("IsMonotonic arm reported type %q, want counter; sql=%q",
+				call.kind, call.sql)
+		}
+	}
+
+	// (b) Wire result: the non-monotonic metric surfaces as gauge, the
+	// monotonic one as counter.
+	var grouped map[string][]prom.MetricMetaEntry
+	if err := json.Unmarshal(parsed.Data, &grouped); err != nil {
+		t.Fatalf("decode data: %v", err)
+	}
+	wantTypes := map[string]string{
+		"cerberus_query_inflight": "gauge",
+		"cerberus_queries_total":  "counter",
+	}
+	for name, wantType := range wantTypes {
+		entries, ok := grouped[name]
+		if !ok || len(entries) != 1 {
+			t.Errorf("expected exactly one entry for %q, got %+v", name, grouped[name])
+			continue
+		}
+		if entries[0].Type != wantType {
+			t.Errorf("%s: type=%q, want %q", name, entries[0].Type, wantType)
+		}
+	}
+}
+
+// TestMetadata_MonotonicFilterCombinesWithMetricName asserts the
+// `?metric=` filter ANDs with the per-arm IsMonotonic predicate rather
+// than replacing it — both clauses must land in the sum-table SQL and
+// the metric name stays the (only) bound arg.
+func TestMetadata_MonotonicFilterCombinesWithMetricName(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/metadata?metric=cerberus_query_inflight")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+
+	checked := 0
+	for _, call := range q.metaCalls {
+		if !strings.Contains(call.sql, "otel_metrics_sum") {
+			continue
+		}
+		checked++
+		if !strings.Contains(call.sql, "IsMonotonic") {
+			t.Errorf("sum arm missing IsMonotonic predicate: %q", call.sql)
+		}
+		if !strings.Contains(call.sql, "`MetricName` = ?") {
+			t.Errorf("sum arm missing metric-name filter: %q", call.sql)
+		}
+		if len(call.args) != 1 || call.args[0] != "cerberus_query_inflight" {
+			t.Errorf("sum arm args = %v, want [cerberus_query_inflight]", call.args)
+		}
+	}
+	if checked != 2 {
+		t.Fatalf("expected 2 sum-table metadata queries, got %d", checked)
+	}
+}
+
+// TestMetadata_NoMonotonicColumnFallsBackToCounter pins the documented
+// fallback for schema overrides whose sum table carries no IsMonotonic
+// column: a single counter-typed sum-table query (the pre-split
+// behaviour) with no IsMonotonic predicate.
+func TestMetadata_NoMonotonicColumnFallsBackToCounter(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{}
+	s := schema.DefaultOTelMetrics()
+	s.IsMonotonicColumn = ""
+	h := prom.New(q, s, nil)
+	mux := http.NewServeMux()
+	h.Mount(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/metadata")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+
+	var sumCalls []metaCall
+	for _, call := range q.metaCalls {
+		if strings.Contains(call.sql, "IsMonotonic") {
+			t.Errorf("no-IsMonotonic schema must not emit the predicate: %q", call.sql)
+		}
+		if strings.Contains(call.sql, "otel_metrics_sum") {
+			sumCalls = append(sumCalls, call)
+		}
+	}
+	if len(sumCalls) != 1 {
+		t.Fatalf("expected 1 sum-table metadata query in fallback mode, got %d", len(sumCalls))
+	}
+	if sumCalls[0].kind != "counter" {
+		t.Errorf("fallback sum arm reported type %q, want counter", sumCalls[0].kind)
 	}
 }
 


### PR DESCRIPTION
## Summary

Found by the Grafana crawl sweep: Metrics Drilldown rendered meaningless flat-0 previews for OTel UpDownCounters (e.g. `cerberus_query_inflight`).

`/api/v1/metadata` derived the Prom type purely from which OTel-CH table a metric lives in — every sum-table metric reported as `counter`, including **non-monotonic** Sums. Per the OTel→Prometheus compatibility spec a non-monotonic Sum maps to `gauge`; Grafana trusts the metadata and wrapped these metrics in `sum(rate(...))` — the rate of a value that goes up *and* down, rendered as flat 0.

## Fix

The sum-table metadata arm splits on the schema's `IsMonotonicColumn`: `WHERE IsMonotonic` → `counter`, `WHERE NOT IsMonotonic` → `gauge` (typed chsql frags, predicate ANDs with the `?metric=` filter). Gauge/histogram arms unchanged; schema overrides lacking an IsMonotonic column fall back to the legacy single counter-typed query.

## Tests

Unit tests pin the two-arm fan-out, the AND-combined name filter, and the no-column fallback (stubQuerier now records every QueryMetricMeta call). A chdb integration test seeds `otel_metrics_sum` with one monotonic + one non-monotonic metric and asserts the wire types end-to-end against the real DDL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
