### PR TITLE
fix(promql): make regex __name__ matchers first-class — gauge+sum fan-out + Prom-normalized match

### DIFF
--- a/compatibility/prometheus/cerberus-test-queries.yml
+++ b/compatibility/prometheus/cerberus-test-queries.yml
@@ -50,6 +50,16 @@ test_cases:
   - query: '{type="free", instance!="demo.promlabs.com:10000"}'
   - query: '{__name__=~".*"}'
     should_fail: true
+    # Regex-only `__name__` matchers carry no literal name for cerberus's
+    # table heuristic, so the scan must fan across the gauge AND sum
+    # tables. `demo_cpu_usage_seconds_total` is seeded into
+    # `otel_metrics_sum`: before the fan-out cerberus scanned only the
+    # gauge table and returned empty while reference Prometheus returned
+    # the 9 cpu series. The negated form must likewise exclude matching
+    # series from BOTH tables, not just the gauge arm.
+  - query: '{__name__=~"demo_cpu_usage_seconds.*"}'
+  - query: '{__name__=~"demo_memory_usage_byte.+"}'
+  - query: '{job="demo", __name__!~"demo_cpu_usage_seconds.*"}'
   - query: "nonexistent_metric_name"
   - query: 'demo_memory_usage_bytes offset {{.offset}}'
     variant_args: ['offset']

--- a/internal/api/prom/handler_chdb_regex_name_matcher_test.go
+++ b/internal/api/prom/handler_chdb_regex_name_matcher_test.go
@@ -1,0 +1,219 @@
+//go:build chdb
+
+// chDB-backed pins for regex `__name__` matchers on the catalog
+// surfaces. Grafana's Metrics Drilldown breakdown tab sends
+// `match[]={__name__=~".*<metric>.*"}` for every metric it lists, so
+// these selectors must resolve on /api/v1/labels and /api/v1/series
+// for metrics that are (a) stored in the SUM table — a regex carries
+// no literal name for the suffix heuristic, so the scan must fan
+// across (Gauge, Sum) instead of defaulting to gauge-only — and
+// (b) stored under OTel-dotted names — the catalog advertises the
+// Prom-normalised (underscored) spelling, so the regex must also be
+// evaluated against `replaceRegexpAll(MetricName, '[^a-zA-Z0-9_:]',
+// '_')`, not just the raw stored name. Before the fix both shapes
+// returned empty everywhere, blanking the breakdown tab.
+
+package prom_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"testing"
+	"time"
+)
+
+// regexNameSeed builds gauge + sum tables and seeds a sum-stored
+// UpDownCounter (`cerberus_query_inflight`, one row per query language)
+// plus a gauge decoy row (`up`) that the regex must filter out. The
+// seed timestamp is "now" because the labels / series matcher paths
+// anchor their LWR window at request time (no start/end is forwarded
+// for /api/v1/labels; /api/v1/series always anchors at now).
+func regexNameSeed(t *testing.T) string {
+	t.Helper()
+	ts := time.Now().UTC().Format("2006-01-02 15:04:05.000")
+	return metaShapedGaugeDDL + metaShapedSumDDL + fmt.Sprintf(`
+INSERT INTO otel_metrics_gauge (MetricName, MetricDescription, MetricUnit, Attributes, TimeUnix, Value) VALUES
+    ('up', '', '', map('job', 'api'), toDateTime64('%[1]s', 9), 1.0);
+INSERT INTO otel_metrics_sum (MetricName, MetricDescription, MetricUnit, Attributes, TimeUnix, Value) VALUES
+    ('cerberus_query_inflight', '', '', map('cerberus_ql', 'promql'),  toDateTime64('%[1]s', 9), 2.0),
+    ('cerberus_query_inflight', '', '', map('cerberus_ql', 'logql'),   toDateTime64('%[1]s', 9), 1.0),
+    ('cerberus_query_inflight', '', '', map('cerberus_ql', 'traceql'), toDateTime64('%[1]s', 9), 0.0);`,
+		ts)
+}
+
+// dottedNameSeed seeds a gauge-stored OTel-dotted metric
+// (`container.cpu.usage`) plus a dotted decoy that the underscored
+// regex must not match.
+func dottedNameSeed(t *testing.T) string {
+	t.Helper()
+	ts := time.Now().UTC().Format("2006-01-02 15:04:05.000")
+	return metaShapedGaugeDDL + metaShapedSumDDL + fmt.Sprintf(`
+INSERT INTO otel_metrics_gauge (MetricName, MetricDescription, MetricUnit, Attributes, TimeUnix, Value) VALUES
+    ('container.cpu.usage',    '', '', map('core', '0'), toDateTime64('%[1]s', 9), 0.42),
+    ('container.memory.usage', '', '', map('core', '0'), toDateTime64('%[1]s', 9), 1024.0);`,
+		ts)
+}
+
+// decodeStringData unmarshals the `data` array of a labels-shaped
+// response and fails the test with the full body on error.
+func decodeStringData(t *testing.T, body string) []string {
+	t.Helper()
+	var parsed metadataResponse
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v\nbody=%s", err, body)
+	}
+	if parsed.Status != "success" {
+		t.Fatalf("status=%q err=%s body=%s", parsed.Status, parsed.Error, body)
+	}
+	var values []string
+	if err := json.Unmarshal(parsed.Data, &values); err != nil {
+		t.Fatalf("decode data: %v\nbody=%s", err, body)
+	}
+	return values
+}
+
+// decodeSeriesData unmarshals the `data` array of a /api/v1/series
+// response into label maps.
+func decodeSeriesData(t *testing.T, body string) []map[string]string {
+	t.Helper()
+	var parsed metadataResponse
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v\nbody=%s", err, body)
+	}
+	if parsed.Status != "success" {
+		t.Fatalf("status=%q err=%s body=%s", parsed.Status, parsed.Error, body)
+	}
+	var sets []map[string]string
+	if err := json.Unmarshal(parsed.Data, &sets); err != nil {
+		t.Fatalf("decode data: %v\nbody=%s", err, body)
+	}
+	return sets
+}
+
+// TestLabels_RegexNameMatcher_SumStored_ChDB pins the Drilldown
+// breakdown-tab shape end-to-end: `/api/v1/labels` with
+// `match[]={__name__=~".*cerberus_query_inflight.*"}` must return the
+// full label-name set of the sum-stored metric — `__name__` plus
+// `cerberus_ql` — not just the unconditional `__name__` entry the
+// handler emits even when the matcher matches nothing (which is
+// exactly what the gauge-only table fallback produced).
+func TestLabels_RegexNameMatcher_SumStored_ChDB(t *testing.T) {
+	srv, _ := newChDBServer(t, regexNameSeed(t))
+
+	u := srv.URL + "/api/v1/labels?match%5B%5D=" +
+		url.QueryEscape(`{__name__=~".*cerberus_query_inflight.*"}`)
+	resp, err := http.Get(u)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	values := decodeStringData(t, body)
+	want := []string{"__name__", "cerberus_ql"}
+	if !equalStringSlice(values, want) {
+		t.Errorf("label names: expected %v, got %v", want, values)
+	}
+}
+
+// TestSeries_RegexNameMatcher_SumStored_ChDB asserts /api/v1/series
+// with the same regex matcher returns all three per-language series of
+// the sum-stored metric, each carrying the `__name__` +
+// `cerberus_ql` labels Grafana renders as chips.
+func TestSeries_RegexNameMatcher_SumStored_ChDB(t *testing.T) {
+	srv, _ := newChDBServer(t, regexNameSeed(t))
+
+	u := srv.URL + "/api/v1/series?match%5B%5D=" +
+		url.QueryEscape(`{__name__=~".*cerberus_query_inflight.*"}`)
+	resp, err := http.Get(u)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	sets := decodeSeriesData(t, body)
+	if len(sets) != 3 {
+		t.Fatalf("expected 3 series, got %d: %v\nbody=%s", len(sets), sets, body)
+	}
+	gotQL := make([]string, 0, len(sets))
+	for _, lset := range sets {
+		if lset["__name__"] != "cerberus_query_inflight" {
+			t.Errorf("series __name__: expected cerberus_query_inflight, got %q (%v)",
+				lset["__name__"], lset)
+		}
+		gotQL = append(gotQL, lset["cerberus_ql"])
+	}
+	sort.Strings(gotQL)
+	wantQL := []string{"logql", "promql", "traceql"}
+	if !equalStringSlice(gotQL, wantQL) {
+		t.Errorf("cerberus_ql values: expected %v, got %v", wantQL, gotQL)
+	}
+}
+
+// TestSeries_RegexNameMatcher_UnderscoredMatchesDotted_ChDB pins the
+// Prom-normalisation bridge for regex values: the catalog advertises
+// `container_cpu_usage` for the dotted-stored `container.cpu.usage`,
+// and Drilldown echoes the underscored spelling back inside
+// `match[]={__name__=~".*container_cpu_usage.*"}`. The series must
+// resolve (via the normalised-MetricName regex arm) and surface under
+// the same Prom-grammar name the catalog advertised. The dotted decoy
+// (`container.memory.usage`) must stay excluded.
+func TestSeries_RegexNameMatcher_UnderscoredMatchesDotted_ChDB(t *testing.T) {
+	srv, _ := newChDBServer(t, dottedNameSeed(t))
+
+	u := srv.URL + "/api/v1/series?match%5B%5D=" +
+		url.QueryEscape(`{__name__=~".*container_cpu_usage.*"}`)
+	resp, err := http.Get(u)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	sets := decodeSeriesData(t, body)
+	if len(sets) != 1 {
+		t.Fatalf("expected exactly 1 series, got %d: %v\nbody=%s", len(sets), sets, body)
+	}
+	want := map[string]string{"__name__": "container_cpu_usage", "core": "0"}
+	got := sets[0]
+	if len(got) != len(want) {
+		t.Fatalf("series labels: expected %v, got %v", want, got)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("series label %q: expected %q, got %q", k, v, got[k])
+		}
+	}
+}
+
+// TestLabels_RegexNameMatcher_UnderscoredMatchesDotted_ChDB is the
+// /api/v1/labels sibling of the series pin above: the underscored
+// regex must surface the dotted-stored metric's label-name set
+// (`__name__` + `core`), proving labelKeysForMatcher's lowering picks
+// up the normalised-MetricName regex arm.
+func TestLabels_RegexNameMatcher_UnderscoredMatchesDotted_ChDB(t *testing.T) {
+	srv, _ := newChDBServer(t, dottedNameSeed(t))
+
+	u := srv.URL + "/api/v1/labels?match%5B%5D=" +
+		url.QueryEscape(`{__name__=~".*container_cpu_usage.*"}`)
+	resp, err := http.Get(u)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	values := decodeStringData(t, body)
+	want := []string{"__name__", "core"}
+	if !equalStringSlice(values, want) {
+		t.Errorf("label names: expected %v, got %v", want, values)
+	}
+}

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -146,7 +146,15 @@ func lowerVectorSelector(v *parser.VectorSelector, s schema.Metrics, ctx lowerCt
 	// route to a single table via TableFor; histogram-companion +
 	// bucket selectors below override to the histogram table without
 	// touching the union path. Existing fixtures stay byte-stable.
-	tables := []string{s.GaugeTable}
+	//
+	// When the selector carries no MatchEqual `__name__` (a regex name
+	// matcher, a negated matcher, or no name matcher at all) the scan
+	// fans across the same (Gauge, Sum) pair the unsuffixed arm uses —
+	// see schema.Metrics.TablesForUnknownName. A gauge-only fallback
+	// here made `{__name__=~".*cerberus_query_inflight.*"}` (the exact
+	// shape Grafana's Metrics Drilldown breakdown tab sends) return
+	// empty for every sum-stored metric.
+	tables := s.TablesForUnknownName()
 	if metricName != "" {
 		tables = s.TablesFor(metricName)
 	}
@@ -1151,10 +1159,20 @@ func matcherToExpr(m *labels.Matcher, s schema.Metrics) chplan.Expr {
 //     (a user excluding the advertised alias expects the dotted
 //     storage rows excluded too — the candidates are one logical
 //     series set, so the negation must reject every spelling).
-//   - regex matchers (`=~` / `!~`) keep the single-comparison shape
-//     against the raw stored name: a regex is an explicit user-chosen
-//     pattern and re-expanding it across the candidate powerset would
-//     change its meaning.
+//   - `__name__=~"<re>"`  → `match(MetricName, re) OR
+//     match(replaceRegexpAll(MetricName, '[^a-zA-Z0-9_:]', '_'), re)`.
+//     The regex cannot be re-expanded across the candidate powerset
+//     (that would change its meaning), so instead the COLUMN side is
+//     normalised: the second arm mirrors `format.OTelToPromMetric` in
+//     SQL so an underscored pattern (`.*container_cpu_usage.*`, the
+//     exact shape Grafana's Metrics Drilldown breakdown tab sends for
+//     every catalog-advertised name) matches rows whose stored name is
+//     still dotted (`container.cpu.usage`). The leading-digit `_`
+//     prefix `OTelToPromMetric` applies is not mirrored — OTel metric
+//     names never start with a digit.
+//   - `__name__!~"<re>"` → `NOT match(MetricName, re) AND NOT
+//     match(<normalised>, re)`: the raw and normalised spellings are
+//     one logical series set, so the negation must reject both.
 //
 // Values with no rewritable underscore (`up`, `gen`) — and values that
 // produce a single candidate — keep the legacy single-comparison
@@ -1162,11 +1180,39 @@ func matcherToExpr(m *labels.Matcher, s schema.Metrics) chplan.Expr {
 // `isCheapPredicate`-shaped (Binary over ColumnRef / LitString), so
 // the optimizer's PREWHERE promotion treats it exactly like the
 // single equality it replaces.
+// promMetricNormalizePattern is the SQL-side mirror of
+// [format.OTelToPromMetric]: every byte outside the Prom metric-name
+// grammar `[a-zA-Z0-9_:]` is rewritten to `_`. Used by the regex
+// `__name__` arm of [metricNamePredicate] to compare the
+// Prom-normalised spelling of a stored (possibly dotted) MetricName
+// against the user's regex. Keep in lock-step with the Go-side
+// normaliser in internal/api/format/otelname.go.
+const promMetricNormalizePattern = "[^a-zA-Z0-9_:]"
+
 func metricNamePredicate(m *labels.Matcher, s schema.Metrics) chplan.Expr {
 	single := &chplan.Binary{
 		Op:    matchOp(m.Type),
 		Left:  &chplan.ColumnRef{Name: s.MetricNameColumn},
 		Right: &chplan.LitString{V: m.Value},
+	}
+	if m.Type == labels.MatchRegexp || m.Type == labels.MatchNotRegexp {
+		normalized := &chplan.Binary{
+			Op: matchOp(m.Type),
+			Left: &chplan.FuncCall{
+				Name: "replaceRegexpAll",
+				Args: []chplan.Expr{
+					&chplan.ColumnRef{Name: s.MetricNameColumn},
+					&chplan.LitString{V: promMetricNormalizePattern},
+					&chplan.LitString{V: "_"},
+				},
+			},
+			Right: &chplan.LitString{V: m.Value},
+		}
+		fold := chplan.OpOr
+		if m.Type == labels.MatchNotRegexp {
+			fold = chplan.OpAnd
+		}
+		return &chplan.Binary{Op: fold, Left: single, Right: normalized}
 	}
 	if m.Type != labels.MatchEqual && m.Type != labels.MatchNotEqual {
 		return single

--- a/internal/schema/otel.go
+++ b/internal/schema/otel.go
@@ -492,6 +492,30 @@ func (m Metrics) TablesFor(metricName string) []string {
 	// Unsuffixed name: could be Gauge (the v0.1 default) OR Sum (the
 	// OTel-hostmetrics / sqlquery shape). Fan the scan across both so
 	// the matcher finds rows wherever the upstream emitter dropped them.
+	return m.TablesForUnknownName()
+}
+
+// TablesForUnknownName returns the candidate tables for a selector whose
+// `__name__` cannot be pinned to a literal at plan time — a regex
+// matcher (`{__name__=~".*inflight.*"}`), a negated matcher, or no
+// `__name__` matcher at all. The suffix heuristics in [Metrics.TablesFor]
+// need a concrete name to dispatch on; without one, the only safe
+// plain-Sample candidate set is the same (Gauge, Sum) pair the
+// unsuffixed arm returns: Gauge first for byte-stable SQL on
+// gauge-only deployments, Sum second so metrics the OTel emitters
+// store as cumulative sums under bare names (`cerberus_query_inflight`,
+// `system_*`, `otelcol_*`) resolve too. Grafana's Metrics Drilldown
+// breakdown tab sends `match[]={__name__=~".*<metric>.*"}` for every
+// metric, so a gauge-only fallback here silently blanks the breakdown
+// surface for every sum-stored metric.
+//
+// The histogram / exp-histogram tables cannot join this candidate set:
+// their row shape (Count / Sum / BucketCounts, no Value column) is
+// disjoint from the Sample contract the `merge()` fan-out requires, so
+// surfacing classic-histogram series under regex name matchers needs
+// the per-arm UnionAll lowering (see the `_count` / `_sum` companion
+// path) — out of scope for the unknown-name fan-out.
+func (m Metrics) TablesForUnknownName() []string {
 	if m.SumTable != "" && m.SumTable != m.GaugeTable {
 		return []string{m.GaugeTable, m.SumTable}
 	}

--- a/test/spec/promql/not_regex_name_matcher_excludes_dotted.txtar
+++ b/test/spec/promql/not_regex_name_matcher_excludes_dotted.txtar
@@ -1,0 +1,42 @@
+# `__name__!~"<re>"` must reject BOTH spellings of a series — the raw
+# stored name and its Prom-normalised alias — because the catalog
+# advertises the normalised form as the same logical series. The
+# dotted-stored `container.cpu.usage` row must be excluded by the
+# underscored negative regex (via the NOT match(<normalised>, re) arm);
+# only the unrelated `up` series survives.
+
+-- query.promql --
+{job="api", __name__!~".*container_cpu_usage.*"}
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('container.cpu.usage', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 0.42),
+    ('up', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 1.0);
+-- expected_rows --
+[
+  ["up", {"job": "api"}, "2026-01-01T00:00:00Z", 1]
+]
+-- sql --
+SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') PREWHERE NOT match(`MetricName`, ?) AND (`Attributes`[?] = ?) WHERE NOT match(replaceRegexpAll(`MetricName`, ?, ?), ?) AND (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)
+-- args --
+[0] string = ".*container_cpu_usage.*"
+[1] string = "job"
+[2] string = "api"
+[3] string = "[^a-zA-Z0-9_:]"
+[4] string = "_"
+[5] string = ".*container_cpu_usage.*"
+[6] string = "2026-01-01 00:00:01.000000000"
+[7] int64 = 9
+[8] string = "2026-01-01 00:00:01.000000000"
+[9] int64 = 9
+[10] int64 = 300000000000
+-- chplan --
+Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+  Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+    Filter predicate=((((Attributes["job"] = "api") AND ((MetricName !~ ".*container_cpu_usage.*") AND (replaceRegexpAll(MetricName, "[^a-zA-Z0-9_:]", "_") !~ ".*container_cpu_usage.*"))) AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+      Scan(merge(otel_metrics_gauge|otel_metrics_sum))

--- a/test/spec/promql/regex_name_matcher_scans_sum_table.txtar
+++ b/test/spec/promql/regex_name_matcher_scans_sum_table.txtar
@@ -1,0 +1,53 @@
+# A regex-only `__name__` matcher carries no literal name for the table
+# heuristic, so the scan must fan across (Gauge, Sum) — the same pair the
+# unsuffixed arm uses. `cerberus_query_inflight` is stored in the SUM
+# table (UpDownCounter): before the TablesForUnknownName fan-out the
+# gauge-only fallback returned zero rows for exactly this selector shape,
+# which is what Grafana's Metrics Drilldown breakdown tab sends
+# (`match[]={__name__=~".*<metric>.*"}`) for every metric. The decoy
+# gauge row proves the regex still filters by name across the merge.
+
+-- query.promql --
+{__name__=~".*cerberus_query_inflight.*"}
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 1.0);
+INSERT INTO otel_metrics_sum VALUES
+    ('cerberus_query_inflight', map('cerberus_ql', 'promql'), toDateTime64('2026-01-01 00:00:00', 9), 2.0),
+    ('cerberus_query_inflight', map('cerberus_ql', 'logql'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('cerberus_query_inflight', map('cerberus_ql', 'traceql'), toDateTime64('2026-01-01 00:00:00', 9), 0.0);
+-- expected_rows --
+[
+  ["cerberus_query_inflight", {"cerberus_ql": "logql"}, "2026-01-01T00:00:00Z", 1],
+  ["cerberus_query_inflight", {"cerberus_ql": "promql"}, "2026-01-01T00:00:00Z", 2],
+  ["cerberus_query_inflight", {"cerberus_ql": "traceql"}, "2026-01-01T00:00:00Z", 0]
+]
+-- sql --
+SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (match(`MetricName`, ?) OR match(replaceRegexpAll(`MetricName`, ?, ?), ?)) AND (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)
+-- args --
+[0] string = ".*cerberus_query_inflight.*"
+[1] string = "[^a-zA-Z0-9_:]"
+[2] string = "_"
+[3] string = ".*cerberus_query_inflight.*"
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] string = "2026-01-01 00:00:01.000000000"
+[7] int64 = 9
+[8] int64 = 300000000000
+-- chplan --
+Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+  Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+    Filter predicate=((((MetricName =~ ".*cerberus_query_inflight.*") OR (replaceRegexpAll(MetricName, "[^a-zA-Z0-9_:]", "_") =~ ".*cerberus_query_inflight.*")) AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+      Scan(merge(otel_metrics_gauge|otel_metrics_sum))

--- a/test/spec/promql/regex_name_matcher_underscored_matches_dotted.txtar
+++ b/test/spec/promql/regex_name_matcher_underscored_matches_dotted.txtar
@@ -1,0 +1,42 @@
+# The `__name__` catalog advertises Prom-normalised spellings
+# (`container.cpu.usage` → `container_cpu_usage` via OTelToPromMetric),
+# and Grafana's Metrics Drilldown echoes them back as underscored
+# regexes. The regex arm of metricNamePredicate must therefore also
+# match against the SQL-normalised MetricName
+# (replaceRegexpAll(MetricName, '[^a-zA-Z0-9_:]', '_')) — the raw-name
+# arm alone can never match the dotted storage. The decoy row proves
+# the normalised arm still filters by name.
+
+-- query.promql --
+{__name__=~".*container_cpu_usage.*"}
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('container.cpu.usage', map('core', '0'), toDateTime64('2026-01-01 00:00:00', 9), 0.42),
+    ('container.memory.usage', map('core', '0'), toDateTime64('2026-01-01 00:00:00', 9), 1024.0);
+-- expected_rows --
+[
+  ["container.cpu.usage", {"core": "0"}, "2026-01-01T00:00:00Z", 0.42]
+]
+-- sql --
+SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (match(`MetricName`, ?) OR match(replaceRegexpAll(`MetricName`, ?, ?), ?)) AND (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)
+-- args --
+[0] string = ".*container_cpu_usage.*"
+[1] string = "[^a-zA-Z0-9_:]"
+[2] string = "_"
+[3] string = ".*container_cpu_usage.*"
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] string = "2026-01-01 00:00:01.000000000"
+[7] int64 = 9
+[8] int64 = 300000000000
+-- chplan --
+Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+  Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+    Filter predicate=((((MetricName =~ ".*container_cpu_usage.*") OR (replaceRegexpAll(MetricName, "[^a-zA-Z0-9_:]", "_") =~ ".*container_cpu_usage.*")) AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+      Scan(merge(otel_metrics_gauge|otel_metrics_sum))


### PR DESCRIPTION
## Summary

Fifth crawl-sweep find: Grafana Metrics Drilldown's **breakdown tab** sends `match[]={__name__=~".*<metric>.*"}` for every metric it lists, and that selector shape returned **empty** on `/api/v1/query`, `/api/v1/series`, and `/api/v1/labels` — two independent gaps:

1. **Gauge-only table routing**: `lowerVectorSelector` resolved candidate tables via `metricNameFromMatchers`, which only recognizes `MatchEqual` `__name__` matchers. Regex-pinned (or name-less) selectors fell back to a gauge-only scan, so sum-stored metrics (`cerberus_query_inflight`, `system_*`, `otelcol_*`) returned nothing. The scan now fans across the same (Gauge, Sum) pair the unsuffixed-name arm uses, via a new `schema.Metrics.TablesForUnknownName` helper shared with `TablesFor`.
2. **No Prom-normalization bridge for regex values**: the `__name__` catalog advertises Prom-grammar names (dots → underscores) but regex matchers lowered to `match()` against the raw stored name only — `.*container_cpu_usage.*` could never match the dotted-stored `container.cpu.usage`. `metricNamePredicate` now emits a second regex arm against `replaceRegexpAll(MetricName, '[^a-zA-Z0-9_:]', '_')` — OR'd for `=~`, AND'd (negated) for `!~` — mirroring #765's equality-side fan-out.

## Tests

- 3 TXTAR roundtrip fixtures (sum-table fan-out; underscored regex vs dotted storage; negative regex excluding both spellings).
- 4 chdb handler pins for `/api/v1/labels` + `/api/v1/series` — verified to fail on the unfixed code with the exact live symptoms.
- 3 prom compatibility corpus entries diffing the regex / negated-regex name shapes against reference Prometheus on sum-table-seeded data.

## Out of scope

Histogram-table arms under regex name matchers (disjoint column shape needs the per-arm UnionAll lowering, not the merge() path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
