### PR TITLE
fix(tempo): emit spanSets + honour limit/spss on /api/search

### DIFF
--- a/compatibility/tempo/driver/corpus.go
+++ b/compatibility/tempo/driver/corpus.go
@@ -20,6 +20,11 @@
 //	                            omits the parameter so both backends return
 //	                            the unfiltered scope set
 //	-- step --                  step duration (e.g. "60s") — only for metrics_range
+//	-- spss --                  integer; sent as the `spss` (spans-per-spanset)
+//	                            URL param on search cases AND switches on the
+//	                            differ's spanSets comparison for the case (an
+//	                            explicit spss makes the capped-set semantics
+//	                            well-defined on both backends)
 //	-- expected_min_traces --   integer; minimum traces both sides must return
 //	-- expected_max_traces --   integer; maximum traces either side may return
 //	-- expected_min_values --   integer; minimum list cardinality for tag /
@@ -135,6 +140,13 @@ type CorpusCase struct {
 	// case is a validation error.
 	Step string
 
+	// Spss, when > 0, is sent as the `spss` (spans-per-spanset) URL
+	// param on search cases and switches on the differ's per-trace
+	// spanSets comparison (see differ.go::compareSpanSets). Zero leaves
+	// the param off and the spanSets fields uncompared. Only valid for
+	// endpoint=search.
+	Spss int
+
 	// ExpectedMinTraces / ExpectedMaxTraces bound the cardinality both
 	// backends must agree with. Zero (the default) disables the bound.
 	ExpectedMinTraces int
@@ -211,6 +223,7 @@ const (
 	secTagName          = "tag_name"
 	secScope            = "scope"
 	secStep             = "step"
+	secSpss             = "spss"
 	secMinTraces        = "expected_min_traces"
 	secMaxTraces        = "expected_max_traces"
 	secMinValues        = "expected_min_values"
@@ -263,6 +276,8 @@ func applySection(cur *CorpusCase, section, body string) error {
 		cur.Scope = body
 	case secStep:
 		cur.Step = body
+	case secSpss:
+		return applyIntSection(body, "spss", &cur.Spss)
 	case secMinTraces:
 		return applyIntSection(body, "expected_min_traces", &cur.ExpectedMinTraces)
 	case secMaxTraces:
@@ -354,6 +369,12 @@ func validateCase(cur CorpusCase, ord int) (CorpusCase, error) {
 	if cur.Scope != "" && cur.Endpoint != "tags_v2" {
 		return cur, fmt.Errorf("case %q: -- scope -- is only valid for endpoint=tags_v2 (got %s)", cur.Name, cur.Endpoint)
 	}
+	if cur.Spss != 0 && cur.Endpoint != "search" {
+		return cur, fmt.Errorf("case %q: -- spss -- is only valid for endpoint=search (got %s)", cur.Name, cur.Endpoint)
+	}
+	if cur.Spss < 0 {
+		return cur, fmt.Errorf("case %q: -- spss -- must be positive (got %d)", cur.Name, cur.Spss)
+	}
 	if cur.Endpoint == "metrics_range" && cur.Step == "" {
 		return cur, fmt.Errorf("case %q: endpoint=metrics_range requires -- step -- (e.g. \"60s\")", cur.Name)
 	}
@@ -376,7 +397,7 @@ func isTagEndpoint(ep string) bool {
 func isKnownSection(name string) bool {
 	switch name {
 	case secQuery, secEndpoint, secTraceIDTemplate, secTagName, secScope,
-		secStep,
+		secStep, secSpss,
 		secMinTraces, secMaxTraces, secMinValues, secMaxValues,
 		secValues, secScopes, secServices, secRootNameRE,
 		secMinSeries, secMaxSeries, secSamplesPerSeries, secSemanticChecks:

--- a/compatibility/tempo/driver/corpus/smoke.txtar
+++ b/compatibility/tempo/driver/corpus/smoke.txtar
@@ -261,6 +261,51 @@ search
 -- expected_max_traces --
 500
 
+# --- SpanSets (2) ---
+# Cases with an explicit -- spss -- switch on the differ's per-trace
+# spanSets comparison (spanID sets, matched totals, per-span
+# name/start/duration). Grafana's Traces Drilldown trace list
+# (tableType='spans') renders rows exclusively from
+# trace.spanSets[].spans, so a backend that omits them ships an empty
+# drilldown — exactly the regression these cases pin.
+
+-- name --
+spansets_resource_checkout_complete
+# Every span of a checkout trace matches the resource-scoped predicate
+# (1 root + 2-4 children = 3-5 spans per trace); spss=20 exceeds that,
+# so both backends return COMPLETE spansets and the differ compares the
+# exact spanID sets + per-span name/start/duration.
+-- query --
+{ resource.service.name = "checkout" }
+-- endpoint --
+search
+-- spss --
+20
+-- expected_min_traces --
+1
+-- expected_max_traces --
+200
+-- expected_services --
+checkout
+
+-- name --
+spansets_payments_spss_capped
+# 3-5 matched spans per trace against spss=1 — the cap truncates on
+# both sides, so the differ checks matched totals + kept-span counts
+# (the subset choice under the cap is unspecified upstream).
+-- query --
+{ resource.service.name = "payments" }
+-- endpoint --
+search
+-- spss --
+1
+-- expected_min_traces --
+1
+-- expected_max_traces --
+200
+-- expected_services --
+payments
+
 # --- Metrics pipeline: /api/metrics/query_range (3) ---
 # These hit cerberus's /api/metrics/query_range (implemented today —
 # see internal/api/tempo/metrics_query_range.go) and Tempo's native

--- a/compatibility/tempo/driver/diff.go
+++ b/compatibility/tempo/driver/diff.go
@@ -357,7 +357,12 @@ func compareForEndpoint(tc CorpusCase, tempoBody, cerbBody []byte) (Diff, error)
 	case "metrics_range", "metrics_instant":
 		return CompareMetrics(tempoBody, cerbBody, "tempo", "cerberus", DefaultDiffOptions())
 	default:
-		return Compare(tempoBody, cerbBody, "tempo", "cerberus", DefaultDiffOptions())
+		opts := DefaultDiffOptions()
+		// Corpus cases with an explicit -- spss -- opt into the per-trace
+		// spanSets diff: with the same cap on both sides the comparison
+		// is well-defined (see differ.go::compareSpanSets).
+		opts.CompareSpanSets = tc.Spss > 0
+		return Compare(tempoBody, cerbBody, "tempo", "cerberus", opts)
 	}
 }
 
@@ -382,6 +387,11 @@ func buildURL(base string, tc CorpusCase, backend string, startTS, endTS time.Ti
 		u.Path += "/api/search"
 		q.Set("q", tc.Query)
 		q.Set("limit", fmt.Sprintf("%d", searchLimit))
+		if tc.Spss > 0 {
+			// Explicit spans-per-spanset: both backends receive the same
+			// cap so the differ's spanSets comparison is well-defined.
+			q.Set("spss", fmt.Sprintf("%d", tc.Spss))
+		}
 		q.Set("start", fmt.Sprintf("%d", startTS.Unix()))
 		q.Set("end", fmt.Sprintf("%d", endTS.Unix()))
 	case "search_recent":

--- a/compatibility/tempo/driver/differ.go
+++ b/compatibility/tempo/driver/differ.go
@@ -64,6 +64,37 @@ type TraceSummary struct {
 	RootTraceName     string `json:"rootTraceName,omitempty"`
 	StartTimeUnixNano string `json:"startTimeUnixNano,omitempty"`
 	DurationMs        int    `json:"durationMs,omitempty"`
+	// SpanSet / SpanSets mirror tempopb.TraceSearchMetadata's matched-
+	// span lists. Compared only when DiffOptions.CompareSpanSets is on
+	// (corpus cases that set -- spss --), because the per-span subset a
+	// backend keeps under the spss cap is unspecified upstream and only
+	// an explicit spss makes the comparison well-defined.
+	SpanSet  *SpanSetJSON  `json:"spanSet,omitempty"`
+	SpanSets []SpanSetJSON `json:"spanSets,omitempty"`
+}
+
+// SpanSetJSON is the differ's view of one tempopb.SpanSet: the matched
+// spans (capped at the request's spss) plus the uncapped matched total.
+// proto3 JSON omits matched when 0; both backends emit it for any
+// non-trivial match, and the comparator falls back to len(spans) when
+// the field is absent.
+type SpanSetJSON struct {
+	Spans   []SpanJSON `json:"spans"`
+	Matched int        `json:"matched,omitempty"`
+}
+
+// SpanJSON is the differ's view of one tempopb.Span inside a SpanSet.
+// StartTimeUnixNano / DurationNanos are uint64 proto fields → decimal
+// strings on the wire. Attributes deliberately have no field here: the
+// attribute list Tempo attaches to each matched span is derived from
+// the query's condition columns (a presentation projection, not span
+// identity), and the comparator pins identity + timing — spanID, name,
+// start, duration — which is what Grafana's spans table renders.
+type SpanJSON struct {
+	SpanID            string `json:"spanID"`
+	Name              string `json:"name,omitempty"`
+	StartTimeUnixNano string `json:"startTimeUnixNano,omitempty"`
+	DurationNanos     string `json:"durationNanos,omitempty"`
 }
 
 // traceKey is the per-trace identifier used to align the two backends'
@@ -99,6 +130,12 @@ type DiffOptions struct {
 	AbsEpsilon float64
 	// RelEpsilon: relative tolerance for non-zero fields.
 	RelEpsilon float64
+	// CompareSpanSets enables the per-trace spanSets diff (spanID set,
+	// matched totals, per-span name/start/duration). Switched on for
+	// corpus cases that set -- spss -- : with an explicit spss both
+	// backends receive the same cap and the comparison is well-defined
+	// (see compareSpanSets for the capped-set semantics).
+	CompareSpanSets bool
 }
 
 // DefaultDiffOptions returns 1e-9 abs + rel — same defaults as the
@@ -293,7 +330,184 @@ func compareSummary(key string, a, b TraceSummary, aLabel, bLabel string, opts D
 		}
 	}
 
+	if opts.CompareSpanSets {
+		reasons = append(reasons, compareSpanSets(key, a, b, aLabel, bLabel)...)
+	}
+
 	return reasons
+}
+
+// flattenSpanSets folds a summary's spanSets into one (spans, matched)
+// pair: spans concatenated across sets, matched summed (a set whose
+// `matched` field is absent — proto3 JSON omits zero — counts its own
+// span list instead). Both backends emit a single set for spanset-
+// filter queries today; the fold keeps the comparator correct if either
+// ever emits the multi-set shape (`select()`-style projections).
+// Falls back to the legacy single `spanSet` field when `spanSets` is
+// absent so an older reference image still compares.
+func flattenSpanSets(t TraceSummary) (spans []SpanJSON, matched int) {
+	sets := t.SpanSets
+	if len(sets) == 0 && t.SpanSet != nil {
+		sets = []SpanSetJSON{*t.SpanSet}
+	}
+	for _, s := range sets {
+		spans = append(spans, s.Spans...)
+		if s.Matched > 0 {
+			matched += s.Matched
+		} else {
+			matched += len(s.Spans)
+		}
+	}
+	return spans, matched
+}
+
+// canonicalSpanID left-pads a hex SpanID to the canonical 16-char
+// lowercase form, mirroring canonicalTraceID — reference Tempo has
+// historically stripped leading zeros on the wire while cerberus emits
+// the fixed-width form, and equal 8-byte values must align.
+func canonicalSpanID(id string) string {
+	const canonicalLen = 16
+	id = strings.ToLower(id)
+	if len(id) >= canonicalLen {
+		return id
+	}
+	return strings.Repeat("0", canonicalLen-len(id)) + id
+}
+
+// compareSpanSets diffs the matched-span lists of two same-TraceID
+// summaries. Semantics:
+//
+//   - Asymmetric presence (one side has spans, the other none) is a
+//     real divergence — the side without spanSets breaks Grafana's
+//     tableType='spans' transform (the Traces Drilldown trace list).
+//   - The uncapped `matched` totals must agree exactly: both backends
+//     evaluated the same TraceQL over the same seed.
+//   - When the spss cap truncated either side (len(spans) < matched),
+//     only the kept-span COUNT is compared — upstream leaves the
+//     choice of which matched spans survive the cap unspecified, so a
+//     per-ID diff would flag spurious subset divergence.
+//   - When both sides are complete (len(spans) == matched), the spanID
+//     sets must match exactly, and per-span name / startTimeUnixNano /
+//     durationNanos are compared on the intersection.
+func compareSpanSets(key string, a, b TraceSummary, aLabel, bLabel string) []DiffReason {
+	var reasons []DiffReason
+	aSpans, aMatched := flattenSpanSets(a)
+	bSpans, bMatched := flattenSpanSets(b)
+
+	if (len(aSpans) == 0) != (len(bSpans) == 0) {
+		return append(reasons, DiffReason{
+			Kind: "field_mismatch",
+			Detail: fmt.Sprintf("key %s: spanSets %s=%d spans vs %s=%d spans (asymmetric presence)",
+				key, aLabel, len(aSpans), bLabel, len(bSpans)),
+		})
+	}
+	if len(aSpans) == 0 {
+		return reasons
+	}
+
+	if aMatched != bMatched {
+		reasons = append(reasons, DiffReason{
+			Kind: "field_mismatch",
+			Detail: fmt.Sprintf("key %s: spanSets matched %s=%d vs %s=%d",
+				key, aLabel, aMatched, bLabel, bMatched),
+		})
+	}
+	if len(aSpans) != len(bSpans) {
+		reasons = append(reasons, DiffReason{
+			Kind: "field_mismatch",
+			Detail: fmt.Sprintf("key %s: spanSets span count %s=%d vs %s=%d",
+				key, aLabel, len(aSpans), bLabel, len(bSpans)),
+		})
+	}
+	if len(aSpans) < aMatched || len(bSpans) < bMatched {
+		// Capped on at least one side — the count + matched checks above
+		// are the strongest order-insensitive assertions available.
+		return reasons
+	}
+
+	aByID := make(map[string]SpanJSON, len(aSpans))
+	for _, s := range aSpans {
+		aByID[canonicalSpanID(s.SpanID)] = s
+	}
+	bByID := make(map[string]SpanJSON, len(bSpans))
+	for _, s := range bSpans {
+		bByID[canonicalSpanID(s.SpanID)] = s
+	}
+	var ids []string
+	for id := range aByID {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	for _, id := range ids {
+		as := aByID[id]
+		bs, ok := bByID[id]
+		if !ok {
+			reasons = append(reasons, DiffReason{
+				Kind: "field_mismatch",
+				Detail: fmt.Sprintf("key %s: span %s present in %s but missing in %s",
+					key, id, aLabel, bLabel),
+			})
+			continue
+		}
+		if as.Name != bs.Name {
+			reasons = append(reasons, DiffReason{
+				Kind: "field_mismatch",
+				Detail: fmt.Sprintf("key %s span %s: name %s=%q vs %s=%q",
+					key, id, aLabel, as.Name, bLabel, bs.Name),
+			})
+		}
+		if !uintStringsEqual(as.StartTimeUnixNano, bs.StartTimeUnixNano) {
+			reasons = append(reasons, DiffReason{
+				Kind: "field_mismatch",
+				Detail: fmt.Sprintf("key %s span %s: startTimeUnixNano %s=%q vs %s=%q",
+					key, id, aLabel, as.StartTimeUnixNano, bLabel, bs.StartTimeUnixNano),
+			})
+		}
+		if !uintStringsEqual(as.DurationNanos, bs.DurationNanos) {
+			reasons = append(reasons, DiffReason{
+				Kind: "field_mismatch",
+				Detail: fmt.Sprintf("key %s span %s: durationNanos %s=%q vs %s=%q",
+					key, id, aLabel, as.DurationNanos, bLabel, bs.DurationNanos),
+			})
+		}
+	}
+	var extra []string
+	for id := range bByID {
+		if _, ok := aByID[id]; !ok {
+			extra = append(extra, id)
+		}
+	}
+	sort.Strings(extra)
+	for _, id := range extra {
+		reasons = append(reasons, DiffReason{
+			Kind: "field_mismatch",
+			Detail: fmt.Sprintf("key %s: span %s present in %s but missing in %s",
+				key, id, bLabel, aLabel),
+		})
+	}
+	return reasons
+}
+
+// uintStringsEqual compares two proto3-JSON uint64 decimal strings
+// numerically, treating the empty string as 0 (proto3 JSON omits zero
+// values). A parse failure on either side falls back to raw string
+// equality so malformed payloads still surface as a diff.
+func uintStringsEqual(a, b string) bool {
+	if a == b {
+		return true
+	}
+	an, errA := strconv.ParseUint(a, 10, 64)
+	if a == "" {
+		an, errA = 0, nil
+	}
+	bn, errB := strconv.ParseUint(b, 10, 64)
+	if b == "" {
+		bn, errB = 0, nil
+	}
+	if errA != nil || errB != nil {
+		return false
+	}
+	return an == bn
 }
 
 // valuesClose compares two floats with absolute + relative tolerance,

--- a/compatibility/tempo/driver/differ_test.go
+++ b/compatibility/tempo/driver/differ_test.go
@@ -605,3 +605,151 @@ func TestRenderReport_Roundtrip(t *testing.T) {
 		}
 	}
 }
+
+// spanSetsOpts returns DiffOptions with the spanSets comparison
+// switched on, as compareForEndpoint does for corpus cases that set
+// -- spss --.
+func spanSetsOpts() DiffOptions {
+	opts := DefaultDiffOptions()
+	opts.CompareSpanSets = true
+	return opts
+}
+
+func TestCompare_SpanSets_Identical(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"traces":[
+        {"traceID":"abc","rootServiceName":"checkout","rootTraceName":"GET /","durationMs":150,"startTimeUnixNano":"1000",
+         "spanSets":[{"spans":[
+            {"spanID":"0000000000000001","name":"GET /","startTimeUnixNano":"1000","durationNanos":"150000000"},
+            {"spanID":"0000000000000002","name":"db.query","startTimeUnixNano":"2000","durationNanos":"50000000"}
+         ],"matched":2}]}
+    ]}`)
+	d, err := Compare(body, body, "tempo", "cerberus", spanSetsOpts())
+	if err != nil {
+		t.Fatalf("Compare: %v", err)
+	}
+	if !d.Equal {
+		t.Fatalf("expected Equal, got %+v", d)
+	}
+}
+
+// TestCompare_SpanSets_AsymmetricPresenceFails pins the exact
+// regression the spss corpus cases exist for: a backend that returns
+// trace summaries WITHOUT spanSets (the pre-fix cerberus shape) must
+// diff against reference Tempo, because Grafana's tableType='spans'
+// transform renders zero rows for such summaries.
+func TestCompare_SpanSets_AsymmetricPresenceFails(t *testing.T) {
+	t.Parallel()
+	withSets := []byte(`{"traces":[
+        {"traceID":"abc","rootServiceName":"checkout","rootTraceName":"GET /","durationMs":150,"startTimeUnixNano":"1000",
+         "spanSets":[{"spans":[{"spanID":"0000000000000001","name":"GET /","startTimeUnixNano":"1000","durationNanos":"150000000"}],"matched":1}]}
+    ]}`)
+	withoutSets := []byte(`{"traces":[
+        {"traceID":"abc","rootServiceName":"checkout","rootTraceName":"GET /","durationMs":150,"startTimeUnixNano":"1000"}
+    ]}`)
+	d, err := Compare(withSets, withoutSets, "tempo", "cerberus", spanSetsOpts())
+	if err != nil {
+		t.Fatalf("Compare: %v", err)
+	}
+	if d.Equal {
+		t.Fatalf("expected diff (cerberus side omitted spanSets), got Equal")
+	}
+	found := false
+	for _, r := range d.Reasons {
+		if r.Kind == "field_mismatch" && strings.Contains(r.Detail, "asymmetric presence") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected asymmetric-presence reason, got %+v", d.Reasons)
+	}
+	// Without the opt-in, the same pair must still compare Equal (the
+	// non-spss corpus cases keep their historical comparison surface).
+	d, err = Compare(withSets, withoutSets, "tempo", "cerberus", DefaultDiffOptions())
+	if err != nil {
+		t.Fatalf("Compare: %v", err)
+	}
+	if !d.Equal {
+		t.Fatalf("CompareSpanSets off: expected Equal, got %+v", d.Reasons)
+	}
+}
+
+func TestCompare_SpanSets_MatchedMismatchFails(t *testing.T) {
+	t.Parallel()
+	a := []byte(`{"traces":[
+        {"traceID":"abc","startTimeUnixNano":"1000","durationMs":150,
+         "spanSets":[{"spans":[{"spanID":"01","startTimeUnixNano":"1000"}],"matched":5}]}
+    ]}`)
+	b := []byte(`{"traces":[
+        {"traceID":"abc","startTimeUnixNano":"1000","durationMs":150,
+         "spanSets":[{"spans":[{"spanID":"01","startTimeUnixNano":"1000"}],"matched":3}]}
+    ]}`)
+	d, err := Compare(a, b, "tempo", "cerberus", spanSetsOpts())
+	if err != nil {
+		t.Fatalf("Compare: %v", err)
+	}
+	if d.Equal {
+		t.Fatalf("expected matched-total diff, got Equal")
+	}
+}
+
+// TestCompare_SpanSets_CappedComparesCountsOnly: when the spss cap
+// truncated both sides (len(spans) < matched), the per-ID subset each
+// backend kept is unspecified upstream — equal counts + equal matched
+// totals must compare Equal even when the kept spanIDs differ.
+func TestCompare_SpanSets_CappedComparesCountsOnly(t *testing.T) {
+	t.Parallel()
+	a := []byte(`{"traces":[
+        {"traceID":"abc","startTimeUnixNano":"1000","durationMs":150,
+         "spanSets":[{"spans":[{"spanID":"0000000000000001","startTimeUnixNano":"1000"}],"matched":4}]}
+    ]}`)
+	b := []byte(`{"traces":[
+        {"traceID":"abc","startTimeUnixNano":"1000","durationMs":150,
+         "spanSets":[{"spans":[{"spanID":"0000000000000002","startTimeUnixNano":"2000"}],"matched":4}]}
+    ]}`)
+	d, err := Compare(a, b, "tempo", "cerberus", spanSetsOpts())
+	if err != nil {
+		t.Fatalf("Compare: %v", err)
+	}
+	if !d.Equal {
+		t.Fatalf("capped sets with equal counts must compare Equal; got %+v", d.Reasons)
+	}
+}
+
+// TestCompare_SpanSets_CompleteSetsDiffPerSpan: complete sets (matched
+// == len(spans)) compare spanID-by-spanID, with leading-zero
+// canonicalisation aligning Tempo's stripped form against cerberus's
+// fixed-width form, and per-span fields compared numerically.
+func TestCompare_SpanSets_CompleteSetsDiffPerSpan(t *testing.T) {
+	t.Parallel()
+	// Tempo side: stripped spanID + legacy single spanSet field only.
+	a := []byte(`{"traces":[
+        {"traceID":"abc","startTimeUnixNano":"1000","durationMs":150,
+         "spanSet":{"spans":[{"spanID":"1f","name":"GET /","startTimeUnixNano":"1000","durationNanos":"150000000"}],"matched":1}}
+    ]}`)
+	// Cerberus side: padded spanID, same span — must align.
+	b := []byte(`{"traces":[
+        {"traceID":"abc","startTimeUnixNano":"1000","durationMs":150,
+         "spanSets":[{"spans":[{"spanID":"000000000000001f","name":"GET /","startTimeUnixNano":"1000","durationNanos":"150000000"}],"matched":1}]}
+    ]}`)
+	d, err := Compare(a, b, "tempo", "cerberus", spanSetsOpts())
+	if err != nil {
+		t.Fatalf("Compare: %v", err)
+	}
+	if !d.Equal {
+		t.Fatalf("padded vs stripped spanIDs must align; got %+v", d.Reasons)
+	}
+
+	// Now flip one durationNanos — must surface as a per-span diff.
+	c := []byte(`{"traces":[
+        {"traceID":"abc","startTimeUnixNano":"1000","durationMs":150,
+         "spanSets":[{"spans":[{"spanID":"000000000000001f","name":"GET /","startTimeUnixNano":"1000","durationNanos":"999"}],"matched":1}]}
+    ]}`)
+	d, err = Compare(a, c, "tempo", "cerberus", spanSetsOpts())
+	if err != nil {
+		t.Fatalf("Compare: %v", err)
+	}
+	if d.Equal {
+		t.Fatalf("durationNanos divergence must diff, got Equal")
+	}
+}

--- a/internal/api/tempo/grpc/search.go
+++ b/internal/api/tempo/grpc/search.go
@@ -100,7 +100,12 @@ func (s *Service) Search(req *tempopb.SearchRequest, stream tempopb.StreamingQue
 		return mapEngineError(err)
 	}
 
-	summaries, missingRoots := tempo.ToTraceSummaries(samples)
+	// Honour the request's SpansPerSpanSet + Limit the same way the
+	// HTTP handler honours `spss` + `limit` (zero values fall back to
+	// Tempo's documented defaults inside the shared helpers), so the
+	// streaming path stays wire-equivalent with /api/search.
+	summaries, missingRoots := tempo.ToTraceSummaries(samples, int(req.SpansPerSpanSet))
+	summaries, missingRoots = tempo.TruncateSummaries(summaries, missingRoots, int(req.Limit))
 	if len(missingRoots) > 0 {
 		// Same best-effort policy the HTTP handler uses: log + ignore
 		// a follow-up lookup failure (the earliest-span fallback in
@@ -194,7 +199,7 @@ func toTempopbTraceMetadata(t tempo.TraceSummary) *tempopb.TraceSearchMetadata {
 	if v, err := strconv.ParseUint(t.StartTimeUnixNano, 10, 64); err == nil {
 		startNs = v
 	}
-	return &tempopb.TraceSearchMetadata{
+	out := &tempopb.TraceSearchMetadata{
 		TraceID:           t.TraceID,
 		RootServiceName:   t.RootServiceName,
 		RootTraceName:     t.RootTraceName,
@@ -202,6 +207,44 @@ func toTempopbTraceMetadata(t tempo.TraceSummary) *tempopb.TraceSearchMetadata {
 		//nolint:gosec // DurationMs is sourced from a TraceSummary populated by dateDiff(ms, …) over CH spans; field tops out at int32 in practice — uint32 cannot overflow.
 		DurationMs: uint32(t.DurationMs),
 	}
+	// Mirror the HTTP envelope's spanSets + legacy spanSet pair onto
+	// the proto fields so Grafana's streaming search consumers see the
+	// same matched-span lists the JSON path carries.
+	for i := range t.SpanSets {
+		out.SpanSets = append(out.SpanSets, toTempopbSpanSet(t.SpanSets[i]))
+	}
+	if t.SpanSet != nil {
+		out.SpanSet = toTempopbSpanSet(*t.SpanSet)
+	}
+	return out
+}
+
+// toTempopbSpanSet pivots the HTTP-envelope SpanSet onto tempopb's
+// proto shape. StartTimeUnixNano / DurationNanos arrive as the proto3
+// JSON decimal-string encoding of the uint64 fields; parse failures
+// land as 0 (defensive — TraceSummary populates them via FormatInt of
+// values that always round-trip).
+func toTempopbSpanSet(s tempo.SpanSet) *tempopb.SpanSet {
+	out := &tempopb.SpanSet{
+		//nolint:gosec // Matched counts CH result rows per trace; bounded far below uint32.
+		Matched: uint32(s.Matched),
+	}
+	for _, sp := range s.Spans {
+		var start, dur uint64
+		if v, err := strconv.ParseUint(sp.StartTimeUnixNano, 10, 64); err == nil {
+			start = v
+		}
+		if v, err := strconv.ParseUint(sp.DurationNanos, 10, 64); err == nil {
+			dur = v
+		}
+		out.Spans = append(out.Spans, &tempopb.Span{
+			SpanID:            sp.SpanID,
+			Name:              sp.Name,
+			StartTimeUnixNano: start,
+			DurationNanos:     dur,
+		})
+	}
+	return out
 }
 
 // searchFlusher batches TraceSearchMetadata entries into shards of a

--- a/internal/api/tempo/grpc/search_test.go
+++ b/internal/api/tempo/grpc/search_test.go
@@ -198,7 +198,10 @@ func TestSearch_FrameBatching(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	t.Cleanup(cancel)
-	stream, err := client.Search(ctx, &tempopb.SearchRequest{Query: "{}"})
+	// Limit must cover all 45 traces — Search honours
+	// SearchRequest.Limit (default 20, mirroring HTTP `limit`), which
+	// would otherwise truncate the stream to a single frame.
+	stream, err := client.Search(ctx, &tempopb.SearchRequest{Query: "{}", Limit: total})
 	if err != nil {
 		t.Fatalf("open stream: %v", err)
 	}
@@ -510,5 +513,99 @@ func TestSearch_ParseErrorMapsToInvalidArgument(t *testing.T) {
 	}
 	if st.Code() != codes.InvalidArgument {
 		t.Errorf("code: got %s, want InvalidArgument (err=%v)", st.Code(), recvErr)
+	}
+}
+
+// TestSearch_SpanSetsLimitAndSpss pins the gRPC mirror of the HTTP
+// /api/search spanSets contract: SearchRequest.SpansPerSpanSet caps
+// the spans per spanset (Matched keeps the uncapped total),
+// SearchRequest.Limit truncates the newest-first trace list, and the
+// proto envelope carries both SpanSets and the legacy SpanSet pair —
+// the same matched-span lists Grafana's tableType='spans' transform
+// reads on the JSON path.
+func TestSearch_SpanSetsLimitAndSpss(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 5, 19, 0, 0, 0, 0, time.UTC)
+	spanRow := func(traceID, spanID, name string, at time.Time, durNs int64) chclient.Sample {
+		return chclient.Sample{
+			MetricName: name,
+			Labels: map[string]string{
+				"service.name":            "svc",
+				"__cerberus_traceID":      traceID,
+				"__cerberus_parentSpanID": "0000000000000000",
+				"__cerberus_spanID":       spanID,
+			},
+			Timestamp: at,
+			Value:     float64(durNs),
+		}
+	}
+	traceOld := padHexTraceID(1)
+	traceNew := padHexTraceID(2)
+	rows := []chclient.Sample{
+		// Older trace — must fall off under Limit=1.
+		spanRow(traceOld, "0000000000000001", "old.root", ts, 5_000_000),
+		// Newer trace with two matched spans — SpansPerSpanSet=1 keeps
+		// the earlier one, Matched stays 2.
+		spanRow(traceNew, "000000000000000a", "new.root", ts.Add(time.Second), 7_000_000),
+		spanRow(traceNew, "000000000000000b", "new.child", ts.Add(time.Second+time.Millisecond), 3_000_000),
+	}
+	q := &stubCursorQuerier{rows: rows}
+	client, cleanup := dialServer(t, q)
+	t.Cleanup(cleanup)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	stream, err := client.Search(ctx, &tempopb.SearchRequest{
+		Query:           "{}",
+		Limit:           1,
+		SpansPerSpanSet: 1,
+	})
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
+	frames, err := drainSearch(t, stream)
+	if err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+	var traces []*tempopb.TraceSearchMetadata
+	for _, f := range frames {
+		traces = append(traces, f.Traces...)
+	}
+	if len(traces) != 1 {
+		t.Fatalf("Limit=1: got %d traces, want 1", len(traces))
+	}
+	tr := traces[0]
+	if tr.TraceID != traceNew {
+		t.Errorf("TraceID: got %q, want %q (newest-first ordering before Limit truncation)", tr.TraceID, traceNew)
+	}
+	if len(tr.SpanSets) != 1 {
+		t.Fatalf("SpanSets: got %d sets, want 1", len(tr.SpanSets))
+	}
+	set := tr.SpanSets[0]
+	if got, want := int(set.Matched), 2; got != want {
+		t.Errorf("Matched: got %d, want %d (uncapped total)", got, want)
+	}
+	if len(set.Spans) != 1 {
+		t.Fatalf("SpansPerSpanSet=1: got %d spans, want 1", len(set.Spans))
+	}
+	sp := set.Spans[0]
+	if sp.SpanID != "000000000000000a" {
+		t.Errorf("span identity: got %q, want 000000000000000a", sp.SpanID)
+	}
+	// Reference Tempo emits no span name inside search spanSets; the
+	// proto mirror must stay empty too (compat-differ-pinned).
+	if sp.Name != "" {
+		t.Errorf("span name: got %q, want empty", sp.Name)
+	}
+	if got, want := sp.StartTimeUnixNano, uint64(ts.Add(time.Second).UnixNano()); got != want {
+		t.Errorf("StartTimeUnixNano: got %d, want %d", got, want)
+	}
+	if got, want := sp.DurationNanos, uint64(7_000_000); got != want {
+		t.Errorf("DurationNanos: got %d, want %d", got, want)
+	}
+	// Legacy single-set field mirrors SpanSets[0].
+	if tr.SpanSet == nil || len(tr.SpanSet.Spans) != 1 || tr.SpanSet.Spans[0].SpanID != sp.SpanID {
+		t.Errorf("legacy SpanSet must mirror SpanSets[0]; got %+v", tr.SpanSet)
 	}
 }

--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -122,8 +122,12 @@ func (h *Handler) Lang() engine.Lang { return h.lang }
 // calling toTraceSummaries directly inside the tempo package; the
 // re-export exists purely so external callers don't depend on an
 // unexported helper.
-func ToTraceSummaries(samples []chclient.Sample) ([]TraceSummary, []string) {
-	return toTraceSummaries(samples)
+//
+// spss caps the spans collected into each summary's SpanSet (Tempo's
+// `spss` / SpansPerSpanSet request param); <= 0 applies
+// DefaultSpansPerSpanSet.
+func ToTraceSummaries(samples []chclient.Sample, spss int) ([]TraceSummary, []string) {
+	return toTraceSummaries(samples, spss)
 }
 
 // ResolveMissingRoots issues the follow-up CH lookup that recovers root-
@@ -217,6 +221,65 @@ func (h *Handler) handleVersion(w http.ResponseWriter, _ *http.Request) {
 	})
 }
 
+// DefaultSearchLimit / DefaultSpansPerSpanSet mirror reference Tempo's
+// /api/search request defaults (pkg/api ParseSearchRequest): at most 20
+// trace summaries per response, at most 3 spans per spanset. Exported so
+// the gRPC StreamingQuerier Search RPC (internal/api/tempo/grpc) applies
+// the same defaults when tempopb.SearchRequest leaves Limit /
+// SpansPerSpanSet unset.
+const (
+	DefaultSearchLimit     = 20
+	DefaultSpansPerSpanSet = 3
+)
+
+// positiveIntParam parses an integer query param, returning def when the
+// param is absent, malformed, or non-positive — mirroring reference
+// Tempo's lenient ParseSearchRequest handling (a bad `limit` falls back
+// to the default rather than erroring the search).
+func positiveIntParam(r *http.Request, name string, def int) int {
+	v := r.URL.Query().Get(name)
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		return def
+	}
+	return n
+}
+
+// TruncateSummaries enforces Tempo's `limit` request param on a
+// toTraceSummaries result: keeps the first `limit` summaries (the slice
+// arrives sorted startTimeUnixNano-desc, so these are the newest traces
+// — Tempo's ordering) and filters the missing-root TraceID list down to
+// the kept traces so the follow-up root lookup never queries traces the
+// response won't include. limit <= 0 applies DefaultSearchLimit.
+// Exported for the gRPC Search RPC, which shares the HTTP path's
+// summary pipeline.
+func TruncateSummaries(summaries []TraceSummary, missing []string, limit int) ([]TraceSummary, []string) {
+	if limit <= 0 {
+		limit = DefaultSearchLimit
+	}
+	if len(summaries) <= limit {
+		return summaries, missing
+	}
+	summaries = summaries[:limit]
+	if len(missing) == 0 {
+		return summaries, missing
+	}
+	kept := make(map[string]struct{}, len(summaries))
+	for _, t := range summaries {
+		kept[t.TraceID] = struct{}{}
+	}
+	filtered := missing[:0]
+	for _, id := range missing {
+		if _, ok := kept[id]; ok {
+			filtered = append(filtered, id)
+		}
+	}
+	return summaries, filtered
+}
+
 func (h *Handler) handleSearch(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query().Get("q")
 	if q == "" {
@@ -225,6 +288,13 @@ func (h *Handler) handleSearch(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, SearchResponse{Traces: []TraceSummary{}})
 		return
 	}
+	// Tempo's /api/search honours `limit` (max trace summaries, default
+	// 20) and `spss` (max spans per spanset, default 3). Grafana's
+	// Traces Drilldown sends both (limit=200&spss=10 for the trace
+	// list); ignoring them used to return every matching trace
+	// (observed live: 4937 summaries / ~755KB body for limit=200).
+	limit := positiveIntParam(r, "limit", DefaultSearchLimit)
+	spss := positiveIntParam(r, "spss", DefaultSpansPerSpanSet)
 
 	ctx := r.Context()
 	// Engine.Query runs parse → lower → wrap-projection → optimize →
@@ -238,7 +308,8 @@ func (h *Handler) handleSearch(w http.ResponseWriter, r *http.Request) {
 	}
 	h.Logger.Debug("cerberus tempo search", "traceql", q, "sql", res.SQL, "args", res.Args)
 
-	summaries, missingRoots := toTraceSummaries(res.Samples)
+	summaries, missingRoots := toTraceSummaries(res.Samples, spss)
+	summaries, missingRoots = TruncateSummaries(summaries, missingRoots, limit)
 	if len(missingRoots) > 0 {
 		// The result set lacked a root row for some traces — typical
 		// for structural-join queries (the join projects only matched
@@ -356,7 +427,7 @@ func (h *Handler) handleSearchRecent(w http.ResponseWriter, r *http.Request) {
 	}
 	h.Logger.Debug("cerberus tempo search/recent", "limit", limit, "sql", res.SQL, "args", res.Args)
 
-	summaries, missingRoots := toTraceSummaries(res.Samples)
+	summaries, missingRoots := toTraceSummaries(res.Samples, DefaultSpansPerSpanSet)
 	if len(missingRoots) > 0 {
 		roots, lookupErr := h.resolveTraceRoots(ctx, missingRoots)
 		if lookupErr != nil {
@@ -660,6 +731,14 @@ const (
 	// traceByIDKeyParentSpanID slot — same constant value, same
 	// namespace; the two paths never overlap.
 	searchKeyParentSpanID = traceByIDKeyParentSpanID
+	// searchKeySpanID is the reserved Labels key carrying the
+	// hex-encoded SpanId on /api/search responses. Reuses the
+	// traceByIDKeySpanID slot. toTraceSummaries groups the matched
+	// rows into per-trace SpanSets from it — Tempo's wire spec
+	// (tempopb.TraceSearchMetadata.spanSets) lists each matched span's
+	// spanID, and Grafana's tableType='spans' transform renders zero
+	// rows for a summary without them.
+	searchKeySpanID = traceByIDKeySpanID
 	// searchKeyTraceDurationNs is the reserved Labels key carrying
 	// the **whole-trace** wall-clock duration in nanoseconds. The
 	// spanset-aggregate wrap-projection populates it as
@@ -810,6 +889,8 @@ func canonicalSampleProjections(s schema.Traces) []chplan.Projection {
 		stripLeadingHexZeros(s.TraceIDColumn),
 		&chplan.LitString{V: searchKeyParentSpanID},
 		stripLeadingHexZeros(s.ParentSpanIDColumn),
+		&chplan.LitString{V: searchKeySpanID},
+		stripLeadingHexZeros(s.SpanIDColumn),
 	}}
 	mergedAttrs := &chplan.FuncCall{Name: "mapConcat", Args: []chplan.Expr{
 		&chplan.ColumnRef{Name: s.ResourceAttributesColumn},
@@ -848,6 +929,8 @@ func rQualifiedSampleProjections(s schema.Traces) []chplan.Projection {
 		stripLeadingHexZeros(s.TraceIDColumn),
 		&chplan.LitString{V: searchKeyParentSpanID},
 		stripLeadingHexZeros(s.ParentSpanIDColumn),
+		&chplan.LitString{V: searchKeySpanID},
+		stripLeadingHexZeros(s.SpanIDColumn),
 	}}
 	mergedAttrs := &chplan.FuncCall{Name: "mapConcat", Args: []chplan.Expr{
 		&chplan.ColumnRef{Name: s.ResourceAttributesColumn},
@@ -1138,6 +1221,25 @@ func spansetAggregateSampleProjections() []chplan.Projection {
 // reserved slot); the trace's RootService/RootTraceName then anchor
 // on the earliest-span fallback path.
 //
+// SpanSets: rows that carry the reserved `__cerberus_spanID` slot
+// (populated by canonicalSampleProjections / rQualifiedSampleProjections)
+// are additionally collected into one SpanSet per trace — Tempo's wire
+// spec lists each matched span (spanID, name, startTimeUnixNano,
+// durationNanos) and Grafana's tableType='spans' transform (the Traces
+// Drilldown trace list) renders rows exclusively from
+// trace.spanSets[].spans. The set is capped at `spss` spans (Tempo's
+// spans-per-spanset request param, default 3) with Matched carrying the
+// uncapped total; the kept spans are the earliest by start time
+// (spanID tie-break) so the cap is deterministic. Rows without the
+// spanID slot (legacy stub queriers, spanset-aggregate projections that
+// collapse spans into one row per trace) contribute no SpanSet and the
+// summary omits the fields — same wire shape as before.
+//
+// Output ordering matches Tempo's /api/search: traces sort by
+// startTimeUnixNano descending (newest first), TraceID ascending as
+// the deterministic tie-break. Callers enforce the request's `limit`
+// by truncating the returned slice.
+//
 // Returns (summaries, missingRootTraceIDs). `missingRootTraceIDs`
 // contains the stripped-zero-form TraceID of every trace whose result
 // set lacked a true root span — the structural-join SQL only returns
@@ -1145,39 +1247,11 @@ func spansetAggregateSampleProjections() []chplan.Projection {
 // filter queries (`{ status = error }`, `{ kind = consumer }`) only
 // match child spans. resolveTraceRoots fetches the real root from
 // otel_traces and patches the affected summaries.
-func toTraceSummaries(samples []chclient.Sample) ([]TraceSummary, []string) {
-	type acc struct {
-		traceID     string
-		serviceName string
-		traceName   string
-		startNS     int64
-		durationNS  int64
-		// rootStartNS pins the timestamp of the best root-span candidate
-		// seen so far (smallest start time wins ties). 0 means "no
-		// root span seen yet"; we anchor on the earliest-span fallback
-		// in that case.
-		rootStartNS int64
-		// earliestStartNS pins the earliest-by-timestamp span seen,
-		// regardless of root status. Used as the fallback anchor for
-		// truncated traces where no root is in the matched set.
-		earliestStartNS int64
-		// hasRoot is true once we've seen a span with ParentSpanId == "".
-		hasRoot bool
-		// sawParentSlot is true once any of the trace's rows supplied
-		// the reserved `__cerberus_parentSpanID` slot. When false the
-		// shaper can't distinguish root from child (e.g. legacy fixtures
-		// + stub queriers that never populate the slot), so the
-		// missing-root follow-up lookup is suppressed and the
-		// earliest-span fallback handles the trace alone.
-		sawParentSlot bool
-		// hasTraceDurationNs is set the first time a row supplies the
-		// `__cerberus_traceDurationNs` reserved-key entry. Once true,
-		// `durationNS` carries the trace-wide span and per-row Sample.
-		// Value contributions are ignored — they would otherwise pull
-		// the value back to the max single-span duration.
-		hasTraceDurationNs bool
+func toTraceSummaries(samples []chclient.Sample, spss int) ([]TraceSummary, []string) {
+	if spss <= 0 {
+		spss = DefaultSpansPerSpanSet
 	}
-	byTrace := map[string]*acc{}
+	byTrace := map[string]*summaryAcc{}
 	for _, s := range samples {
 		traceID, hasID := s.Labels[searchKeyTraceID]
 		// Group key prefers the real TraceID so multi-span traces
@@ -1189,67 +1263,16 @@ func toTraceSummaries(samples []chclient.Sample) ([]TraceSummary, []string) {
 		}
 		a, ok := byTrace[key]
 		if !ok {
-			a = &acc{traceID: traceID}
+			a = &summaryAcc{traceID: traceID}
 			byTrace[key] = a
 		}
 		ns := s.Timestamp.UnixNano()
 		if a.startNS == 0 || ns < a.startNS {
 			a.startNS = ns
 		}
-		// Whole-trace duration takes precedence when the wrap-projection
-		// surfaced one. The spanset-aggregate path emits a single row
-		// per trace so we just overwrite; the guard against per-row-
-		// Duration fallback ensures a mixed-shape stream (older fixture
-		// rows + aggregate rows on the same trace) doesn't pull the
-		// value down to a single span's max.
-		if v, ok := s.Labels[searchKeyTraceDurationNs]; ok && v != "" {
-			if ns, err := strconv.ParseInt(v, 10, 64); err == nil && ns >= 0 {
-				a.durationNS = ns
-				a.hasTraceDurationNs = true
-			}
-		} else if !a.hasTraceDurationNs && int64(s.Value) > a.durationNS {
-			a.durationNS = int64(s.Value)
-		}
-
-		// Resolve root-span metadata. The reserved __cerberus_parentSpanID
-		// slot carries the parent ID; an empty value (`""`), a single
-		// `"0"`, or the full 16-zero hex string (`"0000000000000000"`)
-		// all mean this row is the root span. The OTel-CH exporter
-		// writes ParentSpanId as a 16-char lowercase-hex string; the
-		// canonical/r-qualified projections now surface that column
-		// verbatim (post-#209 fix: no more leading-zero stripping on
-		// the OUTPUT side), so a true root span arrives as the full
-		// 16-char zero hex. The `""` / `"0"` forms are accepted for
-		// back-compat with legacy fixtures, stub queriers, and the
-		// pre-fix stripped projection variant respectively.
-		//
-		// When the slot is missing (older fixtures / stub queriers),
-		// treat every row as a non-root candidate so the fallback path
-		// runs — `parentID, hasParentSlot := ...` captures the
-		// "did we get the projection" signal independently of the
-		// emptiness check.
-		parentID, hasParentSlot := s.Labels[searchKeyParentSpanID]
-		if hasParentSlot {
-			a.sawParentSlot = true
-		}
-		isRoot := hasParentSlot && (parentID == "" || parentID == "0" || parentID == "0000000000000000")
-		svc := s.Labels["service.name"]
-		switch {
-		case isRoot && (!a.hasRoot || ns < a.rootStartNS):
-			// First root, or an earlier root (broken trace with
-			// multiple ParentSpanId="" spans — Tempo picks the
-			// earliest by start time, we mirror that).
-			a.hasRoot = true
-			a.rootStartNS = ns
-			a.serviceName = svc
-			a.traceName = s.MetricName
-		case !a.hasRoot && (a.earliestStartNS == 0 || ns < a.earliestStartNS):
-			// No root seen yet (truncated trace) — anchor on the
-			// earliest-by-timestamp child as a graceful fallback.
-			a.earliestStartNS = ns
-			a.serviceName = svc
-			a.traceName = s.MetricName
-		}
+		a.observeDuration(s)
+		a.observeSpan(s, ns)
+		a.observeRoot(s, ns)
 	}
 	out := make([]TraceSummary, 0, len(byTrace))
 	var missing []string
@@ -1261,13 +1284,21 @@ func toTraceSummaries(samples []chclient.Sample) ([]TraceSummary, []string) {
 		if tid == "" {
 			tid = k
 		}
-		out = append(out, TraceSummary{
+		summary := TraceSummary{
 			TraceID:           tid,
 			RootServiceName:   a.serviceName,
 			RootTraceName:     a.traceName,
 			StartTimeUnixNano: strconv.FormatInt(a.startNS, 10),
 			DurationMs:        int(a.durationNS / 1_000_000),
-		})
+		}
+		if set := a.buildSpanSet(spss); set != nil {
+			// Both fields carry the same set: spanSets is what Grafana's
+			// tableType='spans' transform consumes, spanSet is the legacy
+			// single-set field Tempo still emits for older readers.
+			summary.SpanSets = []SpanSet{*set}
+			summary.SpanSet = set
+		}
+		out = append(out, summary)
 		// Only flag traces where we actually have a real TraceID, the
 		// projection populated the __cerberus_parentSpanID slot for at
 		// least one row (so we can trust "no root present"), and no
@@ -1279,9 +1310,187 @@ func toTraceSummaries(samples []chclient.Sample) ([]TraceSummary, []string) {
 			missing = append(missing, a.traceID)
 		}
 	}
-	sort.Slice(out, func(i, j int) bool { return out[i].TraceID < out[j].TraceID })
+	sortSummariesStartDesc(out)
 	sort.Strings(missing)
 	return out, missing
+}
+
+// summaryAcc accumulates one trace's worth of /api/search rows while
+// toTraceSummaries groups the flat sample stream by TraceID.
+type summaryAcc struct {
+	traceID     string
+	serviceName string
+	traceName   string
+	startNS     int64
+	durationNS  int64
+	// rootStartNS pins the timestamp of the best root-span candidate
+	// seen so far (smallest start time wins ties). 0 means "no
+	// root span seen yet"; we anchor on the earliest-span fallback
+	// in that case.
+	rootStartNS int64
+	// earliestStartNS pins the earliest-by-timestamp span seen,
+	// regardless of root status. Used as the fallback anchor for
+	// truncated traces where no root is in the matched set.
+	earliestStartNS int64
+	// hasRoot is true once we've seen a span with ParentSpanId == "".
+	hasRoot bool
+	// sawParentSlot is true once any of the trace's rows supplied
+	// the reserved `__cerberus_parentSpanID` slot. When false the
+	// shaper can't distinguish root from child (e.g. legacy fixtures
+	// + stub queriers that never populate the slot), so the
+	// missing-root follow-up lookup is suppressed and the
+	// earliest-span fallback handles the trace alone.
+	sawParentSlot bool
+	// hasTraceDurationNs is set the first time a row supplies the
+	// `__cerberus_traceDurationNs` reserved-key entry. Once true,
+	// `durationNS` carries the trace-wide span and per-row Sample.
+	// Value contributions are ignored — they would otherwise pull
+	// the value back to the max single-span duration.
+	hasTraceDurationNs bool
+	// spans collects the matched-span rows (those carrying the
+	// reserved __cerberus_spanID slot) for the trace's SpanSet.
+	// Uncapped during accumulation; buildSpanSet sorts by
+	// (startTimeUnixNano, spanID) and truncates to spss.
+	spans []SpanSetSpan
+	// matched counts every matched-span row, including the ones
+	// the spss cap drops — surfaces as SpanSet.Matched.
+	matched int
+}
+
+// observeDuration folds one row into the trace-wide duration. The
+// whole-trace duration takes precedence when the wrap-projection
+// surfaced one (`__cerberus_traceDurationNs`). The spanset-aggregate
+// path emits a single row per trace so we just overwrite; the guard
+// against per-row-Duration fallback ensures a mixed-shape stream
+// (older fixture rows + aggregate rows on the same trace) doesn't pull
+// the value down to a single span's max.
+func (a *summaryAcc) observeDuration(s chclient.Sample) {
+	if v, ok := s.Labels[searchKeyTraceDurationNs]; ok && v != "" {
+		if ns, err := strconv.ParseInt(v, 10, 64); err == nil && ns >= 0 {
+			a.durationNS = ns
+			a.hasTraceDurationNs = true
+		}
+		return
+	}
+	if !a.hasTraceDurationNs && int64(s.Value) > a.durationNS {
+		a.durationNS = int64(s.Value)
+	}
+}
+
+// observeSpan collects the matched span for the trace's SpanSet. Only
+// rows that carry the reserved __cerberus_spanID slot qualify —
+// spanset-aggregate rows (one collapsed row per trace) and legacy
+// stub-querier rows don't, and their summaries omit spanSets entirely
+// rather than fabricating a span list.
+//
+// Name stays unset: reference Tempo emits `name: ""` for spans inside
+// /api/search spanSets on plain spanset-filter queries (verified live
+// against grafana/tempo by the compatibility differ — populating it
+// from SpanName produced a per-span field_mismatch on every matched
+// span), and Grafana's tableType='spans' transform derives its columns
+// from the trace-level fields + span timing, not span.name.
+func (a *summaryAcc) observeSpan(s chclient.Sample, ns int64) {
+	spanID, ok := s.Labels[searchKeySpanID]
+	if !ok || spanID == "" {
+		return
+	}
+	a.matched++
+	// DurationNanos: proto3 JSON encodes the uint64 as a decimal
+	// string and omits zero values; Sample.Value carries the per-row
+	// Duration column in nanoseconds on this path.
+	var durationNanos string
+	if d := int64(s.Value); d > 0 {
+		durationNanos = strconv.FormatInt(d, 10)
+	}
+	a.spans = append(a.spans, SpanSetSpan{
+		SpanID:            spanID,
+		StartTimeUnixNano: strconv.FormatInt(ns, 10),
+		DurationNanos:     durationNanos,
+	})
+}
+
+// observeRoot resolves root-span metadata for one row. The reserved
+// __cerberus_parentSpanID slot carries the parent ID; an empty value
+// (`""`), a single `"0"`, or the full 16-zero hex string
+// (`"0000000000000000"`) all mean this row is the root span. The
+// OTel-CH exporter writes ParentSpanId as a 16-char lowercase-hex
+// string; the canonical/r-qualified projections now surface that
+// column verbatim (post-#209 fix: no more leading-zero stripping on
+// the OUTPUT side), so a true root span arrives as the full 16-char
+// zero hex. The `""` / `"0"` forms are accepted for back-compat with
+// legacy fixtures, stub queriers, and the pre-fix stripped projection
+// variant respectively.
+//
+// When the slot is missing (older fixtures / stub queriers), treat
+// every row as a non-root candidate so the fallback path runs —
+// `parentID, hasParentSlot := ...` captures the "did we get the
+// projection" signal independently of the emptiness check.
+func (a *summaryAcc) observeRoot(s chclient.Sample, ns int64) {
+	parentID, hasParentSlot := s.Labels[searchKeyParentSpanID]
+	if hasParentSlot {
+		a.sawParentSlot = true
+	}
+	isRoot := hasParentSlot && (parentID == "" || parentID == "0" || parentID == "0000000000000000")
+	svc := s.Labels["service.name"]
+	switch {
+	case isRoot && (!a.hasRoot || ns < a.rootStartNS):
+		// First root, or an earlier root (broken trace with
+		// multiple ParentSpanId="" spans — Tempo picks the
+		// earliest by start time, we mirror that).
+		a.hasRoot = true
+		a.rootStartNS = ns
+		a.serviceName = svc
+		a.traceName = s.MetricName
+	case !a.hasRoot && (a.earliestStartNS == 0 || ns < a.earliestStartNS):
+		// No root seen yet (truncated trace) — anchor on the
+		// earliest-by-timestamp child as a graceful fallback.
+		a.earliestStartNS = ns
+		a.serviceName = svc
+		a.traceName = s.MetricName
+	}
+}
+
+// buildSpanSet materialises the trace's SpanSet: a deterministic spss
+// cap keeps the earliest spans by start time, spanID as the
+// total-order tie-break, so two runs over the same data (or two CH row
+// orders) emit the same set. Returns nil when no row carried the
+// reserved spanID slot (legacy / aggregate shapes) so the summary
+// omits the spanSet fields entirely.
+func (a *summaryAcc) buildSpanSet(spss int) *SpanSet {
+	if len(a.spans) == 0 {
+		return nil
+	}
+	sort.Slice(a.spans, func(i, j int) bool {
+		// StartTimeUnixNano is FormatInt of UnixNano — compare
+		// numerically, not lexically (string compare breaks across
+		// digit-count boundaries).
+		ti, _ := strconv.ParseInt(a.spans[i].StartTimeUnixNano, 10, 64)
+		tj, _ := strconv.ParseInt(a.spans[j].StartTimeUnixNano, 10, 64)
+		if ti != tj {
+			return ti < tj
+		}
+		return a.spans[i].SpanID < a.spans[j].SpanID
+	})
+	spans := a.spans
+	if len(spans) > spss {
+		spans = spans[:spss]
+	}
+	return &SpanSet{Spans: spans, Matched: a.matched}
+}
+
+// sortSummariesStartDesc applies Tempo's /api/search ordering:
+// startTimeUnixNano descending (newest trace first); upstream leaves
+// ties unspecified, so TraceID ascending is the deterministic
+// tie-break.
+func sortSummariesStartDesc(out []TraceSummary) {
+	sort.Slice(out, func(i, j int) bool {
+		si, _ := strconv.ParseInt(out[i].StartTimeUnixNano, 10, 64)
+		sj, _ := strconv.ParseInt(out[j].StartTimeUnixNano, 10, 64)
+		if si != sj {
+			return si > sj
+		}
+		return out[i].TraceID < out[j].TraceID
+	})
 }
 
 // traceBatch is the wire-format-agnostic intermediate the trace-by-ID

--- a/internal/api/tempo/handler_test.go
+++ b/internal/api/tempo/handler_test.go
@@ -3,9 +3,11 @@ package tempo_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -257,17 +259,19 @@ func TestSearch_GroupsByTraceID(t *testing.T) {
 	if len(sr.Traces) != 2 {
 		t.Fatalf("expected 2 distinct traces (grouped by real TraceID), got %d", len(sr.Traces))
 	}
-	// Results sort ascending by TraceID.
-	if sr.Traces[0].TraceID != traceA {
-		t.Errorf("[0] TraceID: got %q, want %q", sr.Traces[0].TraceID, traceA)
+	// Results sort by startTimeUnixNano descending (Tempo's /api/search
+	// ordering): trace B starts at 10:00:05 (newest) and leads; trace A
+	// (10:00:00) follows.
+	if sr.Traces[0].TraceID != traceB {
+		t.Errorf("[0] TraceID: got %q, want %q", sr.Traces[0].TraceID, traceB)
 	}
-	if sr.Traces[1].TraceID != traceB {
-		t.Errorf("[1] TraceID: got %q, want %q", sr.Traces[1].TraceID, traceB)
+	if sr.Traces[1].TraceID != traceA {
+		t.Errorf("[1] TraceID: got %q, want %q", sr.Traces[1].TraceID, traceA)
 	}
 	// DurationMs is the max of {200, 50}ms = 200ms across trace A's two spans.
-	if sr.Traces[0].DurationMs != 200 {
-		t.Errorf("[0] DurationMs: got %d, want 200 (max across grouped spans)",
-			sr.Traces[0].DurationMs)
+	if sr.Traces[1].DurationMs != 200 {
+		t.Errorf("[1] DurationMs: got %d, want 200 (max across grouped spans)",
+			sr.Traces[1].DurationMs)
 	}
 }
 
@@ -929,6 +933,277 @@ func TestSearch_SQLProjectsParentSpanId(t *testing.T) {
 	if !sawParentSpanIDKey {
 		t.Errorf("emitted SQL args must include reserved __cerberus_parentSpanID slot; got args=%v", q.lastArgs)
 	}
+	// The reserved __cerberus_spanID slot must ride the same map —
+	// toTraceSummaries builds the per-trace SpanSets from it, and
+	// Grafana's tableType='spans' transform (the Traces Drilldown
+	// trace list) renders zero rows for summaries without spanSets.
+	if !strings.Contains(q.lastSQL, "SpanId") {
+		t.Errorf("emitted SQL must project SpanId; got %s", q.lastSQL)
+	}
+	var sawSpanIDKey bool
+	for _, a := range q.lastArgs {
+		if s, ok := a.(string); ok && s == "__cerberus_spanID" {
+			sawSpanIDKey = true
+			break
+		}
+	}
+	if !sawSpanIDKey {
+		t.Errorf("emitted SQL args must include reserved __cerberus_spanID slot; got args=%v", q.lastArgs)
+	}
+}
+
+// searchSpanRow builds one canonical-projection /api/search row: a
+// root-anchored span with the reserved trace/span/parent ID slots the
+// wrap-projection emits. Value carries the per-row Duration in ns.
+func searchSpanRow(traceID, spanID, name string, ts time.Time, durNs int64) chclient.Sample {
+	return chclient.Sample{
+		MetricName: name,
+		Labels: map[string]string{
+			"service.name":            "checkout",
+			"__cerberus_traceID":      traceID,
+			"__cerberus_parentSpanID": "0000000000000000",
+			"__cerberus_spanID":       spanID,
+		},
+		Timestamp: ts,
+		Value:     float64(durNs),
+	}
+}
+
+// TestSearch_SpanSets pins the Tempo wire contract Grafana's Traces
+// Drilldown depends on: every /api/search trace summary carries the
+// matched spans under `spanSets` (and the legacy single-set `spanSet`),
+// with spanID, name, startTimeUnixNano + durationNanos in the proto3
+// JSON string-nanos encoding. Grafana's tempo resultTransformer
+// (tableType='spans') builds the trace-list table exclusively from
+// trace.spanSets[].spans — a summary without them renders "No data".
+func TestSearch_SpanSets(t *testing.T) {
+	t.Parallel()
+	const traceID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	start := time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC)
+	q := &stubQuerier{
+		samples: []chclient.Sample{
+			searchSpanRow(traceID, "0000000000000001", "GET /api/users", start, 150_000_000),
+			searchSpanRow(traceID, "0000000000000002", "db.query", start.Add(10*time.Millisecond), 50_000_000),
+		},
+	}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/search?q=%7B%7D")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	var sr tempo.SearchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&sr); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(sr.Traces) != 1 {
+		t.Fatalf("expected 1 trace, got %d", len(sr.Traces))
+	}
+	tr := sr.Traces[0]
+	if len(tr.SpanSets) != 1 {
+		t.Fatalf("spanSets: got %d sets, want 1 (%+v)", len(tr.SpanSets), tr)
+	}
+	set := tr.SpanSets[0]
+	if tr.SpanSet == nil {
+		t.Fatalf("legacy spanSet field must mirror spanSets[0]; got nil")
+	}
+	if got, want := len(tr.SpanSet.Spans), len(set.Spans); got != want {
+		t.Errorf("spanSet/spanSets[0] span count mismatch: %d vs %d", got, want)
+	}
+	if set.Matched != 2 {
+		t.Errorf("matched: got %d, want 2", set.Matched)
+	}
+	if len(set.Spans) != 2 {
+		t.Fatalf("spans: got %d, want 2", len(set.Spans))
+	}
+	// Spans sort by start time ascending; the 10:00:00.000 span leads.
+	s0 := set.Spans[0]
+	if s0.SpanID != "0000000000000001" {
+		t.Errorf("spans[0].spanID: got %q, want %q", s0.SpanID, "0000000000000001")
+	}
+	// Reference Tempo emits name="" for spans inside search spanSets
+	// (pinned by the compat differ's spansets corpus cases); cerberus
+	// mirrors that — a populated name here is a wire divergence.
+	if s0.Name != "" {
+		t.Errorf("spans[0].name: got %q, want empty (reference Tempo emits no span name in spanSets)", s0.Name)
+	}
+	if want := strconv.FormatInt(start.UnixNano(), 10); s0.StartTimeUnixNano != want {
+		t.Errorf("spans[0].startTimeUnixNano: got %q, want %q (decimal string nanos)", s0.StartTimeUnixNano, want)
+	}
+	if s0.DurationNanos != "150000000" {
+		t.Errorf("spans[0].durationNanos: got %q, want %q (decimal string nanos)", s0.DurationNanos, "150000000")
+	}
+}
+
+// TestSearch_SpanSets_SpssCap asserts the `spss` query param caps the
+// spans per spanset while `matched` keeps reporting the uncapped total
+// — the shape Grafana uses to render "showing N of M spans". Also pins
+// the default cap of 3 (Tempo's spans-per-spanset default) when the
+// param is absent.
+func TestSearch_SpanSets_SpssCap(t *testing.T) {
+	t.Parallel()
+	const traceID = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	start := time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC)
+	samples := make([]chclient.Sample, 0, 5)
+	for i := 0; i < 5; i++ {
+		samples = append(samples, searchSpanRow(
+			traceID,
+			"000000000000000"+strconv.Itoa(i+1),
+			"span."+strconv.Itoa(i),
+			start.Add(time.Duration(i)*time.Millisecond),
+			1_000_000,
+		))
+	}
+
+	fetch := func(t *testing.T, query string) tempo.TraceSummary {
+		t.Helper()
+		q := &stubQuerier{samples: samples}
+		srv := newServer(q, "v1.0.0-test")
+		t.Cleanup(srv.Close)
+		resp, err := http.Get(srv.URL + query)
+		if err != nil {
+			t.Fatalf("GET: %v", err)
+		}
+		defer resp.Body.Close()
+		var sr tempo.SearchResponse
+		if err := json.NewDecoder(resp.Body).Decode(&sr); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if len(sr.Traces) != 1 {
+			t.Fatalf("expected 1 trace, got %d", len(sr.Traces))
+		}
+		return sr.Traces[0]
+	}
+
+	// Explicit spss=2: two earliest spans kept, matched stays 5.
+	tr := fetch(t, "/api/search?q=%7B%7D&spss=2")
+	if len(tr.SpanSets) != 1 || len(tr.SpanSets[0].Spans) != 2 {
+		t.Fatalf("spss=2: got %+v, want exactly 2 spans in 1 set", tr.SpanSets)
+	}
+	if tr.SpanSets[0].Matched != 5 {
+		t.Errorf("spss=2 matched: got %d, want 5 (uncapped total)", tr.SpanSets[0].Matched)
+	}
+	if tr.SpanSets[0].Spans[0].SpanID != "0000000000000001" || tr.SpanSets[0].Spans[1].SpanID != "0000000000000002" {
+		t.Errorf("spss=2 must keep the earliest spans deterministically; got %+v", tr.SpanSets[0].Spans)
+	}
+
+	// Default (no spss param): Tempo's default of 3.
+	tr = fetch(t, "/api/search?q=%7B%7D")
+	if len(tr.SpanSets) != 1 || len(tr.SpanSets[0].Spans) != 3 {
+		t.Fatalf("default spss: got %+v, want exactly 3 spans in 1 set", tr.SpanSets)
+	}
+	if tr.SpanSets[0].Matched != 5 {
+		t.Errorf("default spss matched: got %d, want 5", tr.SpanSets[0].Matched)
+	}
+}
+
+// TestSearch_LimitEnforced asserts `limit` truncates the trace list to
+// the newest-first prefix (startTimeUnixNano descending — Tempo's
+// /api/search ordering) and that the default limit is 20. The live bug
+// this pins: the handler ignored limit entirely and returned 4937
+// summaries (~755KB) for the Traces Drilldown's limit=200 request.
+func TestSearch_LimitEnforced(t *testing.T) {
+	t.Parallel()
+	start := time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC)
+	samples := make([]chclient.Sample, 0, 25)
+	for i := 0; i < 25; i++ {
+		samples = append(samples, searchSpanRow(
+			// %032x keeps trace IDs unique + hex-valid.
+			fmt.Sprintf("%032x", i+1),
+			"0000000000000001",
+			"GET /",
+			start.Add(time.Duration(i)*time.Second),
+			1_000_000,
+		))
+	}
+
+	fetch := func(t *testing.T, query string) []tempo.TraceSummary {
+		t.Helper()
+		q := &stubQuerier{samples: samples}
+		srv := newServer(q, "v1.0.0-test")
+		t.Cleanup(srv.Close)
+		resp, err := http.Get(srv.URL + query)
+		if err != nil {
+			t.Fatalf("GET: %v", err)
+		}
+		defer resp.Body.Close()
+		var sr tempo.SearchResponse
+		if err := json.NewDecoder(resp.Body).Decode(&sr); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return sr.Traces
+	}
+
+	// Default limit: 20 of the 25 matches.
+	traces := fetch(t, "/api/search?q=%7B%7D")
+	if len(traces) != 20 {
+		t.Fatalf("default limit: got %d traces, want 20", len(traces))
+	}
+	// Newest trace (i=24, started latest) must lead.
+	if want := fmt.Sprintf("%032x", 25); traces[0].TraceID != want {
+		t.Errorf("[0] TraceID: got %q, want %q (startTimeUnixNano-desc ordering)", traces[0].TraceID, want)
+	}
+	// The 5 oldest traces (i=0..4) fall off the end.
+	if want := fmt.Sprintf("%032x", 6); traces[19].TraceID != want {
+		t.Errorf("[19] TraceID: got %q, want %q", traces[19].TraceID, want)
+	}
+
+	// Explicit limit=5.
+	traces = fetch(t, "/api/search?q=%7B%7D&limit=5")
+	if len(traces) != 5 {
+		t.Fatalf("limit=5: got %d traces, want 5", len(traces))
+	}
+	for i := 1; i < len(traces); i++ {
+		if traces[i-1].StartTimeUnixNano < traces[i].StartTimeUnixNano {
+			t.Errorf("traces not sorted startTimeUnixNano-desc at index %d: %q < %q",
+				i, traces[i-1].StartTimeUnixNano, traces[i].StartTimeUnixNano)
+		}
+	}
+
+	// Malformed / non-positive limits fall back to the default of 20
+	// (mirroring Tempo's lenient param parsing) rather than erroring.
+	if got := len(fetch(t, "/api/search?q=%7B%7D&limit=bogus")); got != 20 {
+		t.Errorf("limit=bogus: got %d traces, want 20 (default fallback)", got)
+	}
+}
+
+// TestSearch_NoSpanIDSlot_OmitsSpanSets pins the legacy-shape contract:
+// rows without the reserved __cerberus_spanID slot (stub queriers,
+// spanset-aggregate projections that collapse spans into one row per
+// trace) produce summaries with no spanSet / spanSets fields at all —
+// the JSON must omit the keys, not emit empty arrays.
+func TestSearch_NoSpanIDSlot_OmitsSpanSets(t *testing.T) {
+	t.Parallel()
+	q := &stubQuerier{
+		samples: []chclient.Sample{
+			{
+				MetricName: "GET /api/users",
+				Labels: map[string]string{
+					"service.name":       "frontend",
+					"__cerberus_traceID": "abababababababababababababababab",
+				},
+				Timestamp: time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC),
+				Value:     150_000_000,
+			},
+		},
+	}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/search?q=%7B%7D")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	body := readBody(t, resp)
+	if strings.Contains(body, "spanSet") {
+		t.Errorf("legacy rows without __cerberus_spanID must omit spanSet/spanSets keys; body=%s", body)
+	}
 }
 
 // TestSearch_SpansetAggregate_PerTrace asserts that
@@ -983,14 +1258,16 @@ func TestSearch_SpansetAggregate_PerTrace(t *testing.T) {
 	if len(sr.Traces) != 3 {
 		t.Fatalf("expected 3 traces (one per matching TraceID), got %d", len(sr.Traces))
 	}
-	if sr.Traces[0].TraceID != traceA || sr.Traces[0].RootServiceName != "checkout" || sr.Traces[0].RootTraceName != "POST /api/orders" {
-		t.Errorf("trace A summary mismatch: %+v", sr.Traces[0])
+	// Results sort by startTimeUnixNano descending: C (10:00:10) leads,
+	// then B (10:00:05), then A (10:00:00).
+	if sr.Traces[0].TraceID != traceC || sr.Traces[0].RootServiceName != "db" || sr.Traces[0].RootTraceName != "db.query" {
+		t.Errorf("trace C summary mismatch: %+v", sr.Traces[0])
 	}
 	if sr.Traces[1].TraceID != traceB || sr.Traces[1].RootServiceName != "frontend" || sr.Traces[1].RootTraceName != "GET /healthz" {
 		t.Errorf("trace B summary mismatch: %+v", sr.Traces[1])
 	}
-	if sr.Traces[2].TraceID != traceC || sr.Traces[2].RootServiceName != "db" || sr.Traces[2].RootTraceName != "db.query" {
-		t.Errorf("trace C summary mismatch: %+v", sr.Traces[2])
+	if sr.Traces[2].TraceID != traceA || sr.Traces[2].RootServiceName != "checkout" || sr.Traces[2].RootTraceName != "POST /api/orders" {
+		t.Errorf("trace A summary mismatch: %+v", sr.Traces[2])
 	}
 }
 

--- a/internal/api/tempo/types.go
+++ b/internal/api/tempo/types.go
@@ -22,6 +22,64 @@ type TraceSummary struct {
 	RootTraceName     string `json:"rootTraceName,omitempty"`
 	StartTimeUnixNano string `json:"startTimeUnixNano,omitempty"`
 	DurationMs        int    `json:"durationMs,omitempty"`
+	// SpanSet is the legacy single-set field Tempo still emits next to
+	// SpanSets (tempopb.TraceSearchMetadata field 6). Grafana's older
+	// transform paths read it; the modern tableType='spans' transform
+	// reads SpanSets. Cerberus populates both with the same set.
+	SpanSet *SpanSet `json:"spanSet,omitempty"`
+	// SpanSets carries the per-trace matched-span lists. Grafana's
+	// Tempo datasource (tableType='spans', used by the Traces Drilldown
+	// trace list) builds its spans table exclusively from
+	// trace.spanSets[].spans — a summary without it renders zero rows.
+	SpanSets []SpanSet `json:"spanSets,omitempty"`
+}
+
+// SpanSet mirrors tempopb.SpanSet's JSON shape: the spans the TraceQL
+// expression matched within one trace (capped at the request's `spss`
+// spans-per-spanset) plus the total matched count.
+type SpanSet struct {
+	Spans []SpanSetSpan `json:"spans"`
+	// Matched is the total number of spans the query matched in this
+	// trace — it exceeds len(Spans) when the spss cap truncated the
+	// list. proto3 JSON omits zero values, hence omitempty.
+	Matched int `json:"matched,omitempty"`
+}
+
+// SpanSetSpan mirrors tempopb.Span's JSON shape (one matched span
+// inside a SpanSet). StartTimeUnixNano and DurationNanos are uint64
+// proto fields, which proto3 JSON encodes as decimal strings — Grafana
+// parses them with parseInt, so the string form is load-bearing.
+//
+// Name mirrors the proto field but cerberus leaves it unset: reference
+// Tempo emits `name: ""` for spans inside /api/search spanSets on
+// plain spanset-filter queries (pinned by the compatibility differ's
+// spansets corpus cases), and the drop-in contract tracks reference
+// behaviour byte-for-byte.
+type SpanSetSpan struct {
+	SpanID            string     `json:"spanID"`
+	Name              string     `json:"name,omitempty"`
+	StartTimeUnixNano string     `json:"startTimeUnixNano"`
+	DurationNanos     string     `json:"durationNanos,omitempty"`
+	Attributes        []KeyValue `json:"attributes,omitempty"`
+}
+
+// KeyValue is the OTLP common.v1.KeyValue JSON shape used inside
+// SpanSetSpan.Attributes. Grafana's tempo resultTransformer reads
+// attr.value.<type>Value when deriving extra table columns from the
+// query's matched attributes.
+type KeyValue struct {
+	Key   string   `json:"key"`
+	Value AnyValue `json:"value"`
+}
+
+// AnyValue is the OTLP common.v1.AnyValue JSON shape — exactly one of
+// the typed fields is set. IntValue is a string because proto3 JSON
+// encodes int64 as a decimal string.
+type AnyValue struct {
+	StringValue *string  `json:"stringValue,omitempty"`
+	IntValue    *string  `json:"intValue,omitempty"`
+	BoolValue   *bool    `json:"boolValue,omitempty"`
+	DoubleValue *float64 `json:"doubleValue,omitempty"`
 }
 
 // SearchMetrics is Tempo's per-search aggregate block. Cerberus

--- a/test/e2e/playwright/tempo_traces_drilldown.spec.ts
+++ b/test/e2e/playwright/tempo_traces_drilldown.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * Traces Drilldown — trace-list regression spec.
+ *
+ * Pins the consumer-grade contract behind Grafana's Traces Drilldown
+ * (grafana-exploretraces-app) "Traces" tab: the tab badge must be
+ * non-zero and the span table must render rows whenever the backing
+ * `/api/search` window contains traces.
+ *
+ * Why this exists: the drilldown's trace list queries the Tempo
+ * datasource with queryType='traceql' / tableType='spans', and
+ * Grafana's tempo resultTransformer builds the spans table EXCLUSIVELY
+ * from `trace.spanSets[].spans`. Cerberus used to return trace
+ * summaries without `spanSets` (and ignored the request's `limit` +
+ * `spss` params), so every drilldown request got HTTP 200 with
+ * thousands of summaries — and the Traces tab still rendered badge 0 +
+ * "No data for selected query". API-status-only checks were blind to
+ * it; this spec asserts what the UI actually renders plus the wire
+ * field the transform consumes.
+ *
+ * Gate posture: NIGHTLY ONLY (auto-discovered by the `dashboard` job's
+ * unfiltered `npx playwright test` run in .github/workflows/e2e.yml;
+ * deliberately NOT in the compose-smoke job's explicit spec list —
+ * same pattern as iterate-drilldown-apps.spec.ts, because drilldown-app
+ * UIs are the highest UI-churn surface in Grafana).
+ *
+ * Grafana version pinning: selectors are tied to grafana/grafana:12.2.9
+ * + traces-drilldown 2.0.4 (tab accessible name is "Traces" with the
+ * count badge concatenated, e.g. "Traces20"). Re-audit on Grafana
+ * bumps — see helpers/README.md.
+ *
+ * Env:
+ *   GRAFANA_URL       default http://localhost:3000
+ *   GRAFANA_BASE_URL  honoured as a fallback for parity with
+ *                     compose_grafana_smoke.spec.ts
+ */
+
+import { test, expect, type Response } from '@playwright/test';
+
+const baseURL =
+  process.env.GRAFANA_URL ??
+  process.env.GRAFANA_BASE_URL ??
+  'http://localhost:3000';
+
+// The drilldown app root with the trace-list action view preselected.
+// var-ds pins the cerberus Tempo datasource so the spec doesn't depend
+// on it being the default; the time range matches the app's default
+// (last 30 minutes — the e2e stacks emit self-telemetry traces
+// continuously, so the window is never empty).
+const traceListURL =
+  '/a/grafana-exploretraces-app/explore' +
+  '?actionView=traceList&var-ds=cerberus-tempo&from=now-30m&to=now';
+
+test.describe('Traces Drilldown — trace list (tableType=spans)', () => {
+  test('Traces tab badge > 0 and span table renders rows', async ({ page }) => {
+    // The app boots its own React tree + fires a wave of datasource
+    // queries; budget generously for a cold ClickHouse.
+    test.setTimeout(180_000);
+
+    // Capture the drilldown's proxied /api/search responses so the
+    // wire shape is asserted alongside the rendered DOM — the badge
+    // and the table are both derived from spanSets, so a UI-only
+    // assertion could go stale silently if the app reshapes its DOM.
+    const searchBodies: unknown[] = [];
+    const onResponse = async (resp: Response) => {
+      const url = resp.url();
+      if (!url.includes('/api/search?') || resp.status() !== 200) {
+        return;
+      }
+      try {
+        searchBodies.push(await resp.json());
+      } catch {
+        // Non-JSON body on a search URL — leave it to the DOM
+        // assertions below to fail loudly if the list is empty.
+      }
+    };
+    page.on('response', onResponse);
+
+    await page.goto(`${baseURL}${traceListURL}`, {
+      waitUntil: 'domcontentloaded',
+    });
+
+    // The Traces tab renders its accessible name as "Traces<count>"
+    // (count badge concatenated). Poll until the badge leaves 0 —
+    // the trace-list query round-trips through cerberus + ClickHouse,
+    // so the first paint can legitimately show 0 while loading.
+    const tracesTab = page.getByRole('tab', { name: /^Traces/ });
+    await expect(tracesTab, 'Traces tab is present').toBeVisible({
+      timeout: 60_000,
+    });
+    await expect
+      .poll(
+        async () => {
+          const text = (await tracesTab.innerText()).replace(/\s+/g, '');
+          const m = text.match(/^Traces(\d+)$/);
+          return m ? Number(m[1]) : 0;
+        },
+        {
+          message:
+            'Traces tab badge must become non-zero (badge = rows of the ' +
+            'tableType=spans frame, built from /api/search spanSets)',
+          timeout: 90_000,
+        },
+      )
+      .toBeGreaterThan(0);
+
+    // The trace-list action view must NOT show the empty-state copy.
+    await expect(
+      page.getByText('No data for selected query'),
+      'trace list renders data, not the empty-state message',
+    ).toHaveCount(0);
+
+    // The span table itself renders at least one data row. Grafana's
+    // table panel exposes role=row including a header row, hence > 1.
+    const rows = page.getByRole('row');
+    await expect
+      .poll(async () => rows.count(), {
+        message: 'span table renders at least one data row',
+        timeout: 30_000,
+      })
+      .toBeGreaterThan(1);
+
+    page.off('response', onResponse);
+
+    // Wire-shape pin: at least one captured /api/search response must
+    // carry per-trace spanSets (and the legacy spanSet mirror) — the
+    // exact fields Grafana's resultTransformer reads. An empty traces
+    // window would have failed the badge assertion already.
+    type SearchBody = {
+      traces?: Array<{
+        spanSets?: Array<{ spans?: unknown[] }>;
+        spanSet?: { spans?: unknown[] };
+      }>;
+    };
+    const withTraces = (searchBodies as SearchBody[]).filter(
+      (b) => Array.isArray(b?.traces) && b.traces.length > 0,
+    );
+    expect(
+      withTraces.length,
+      'at least one /api/search response with traces was captured',
+    ).toBeGreaterThan(0);
+    for (const body of withTraces) {
+      for (const trace of body.traces ?? []) {
+        expect(
+          Array.isArray(trace.spanSets) && trace.spanSets.length > 0,
+          `every trace summary carries spanSets (got: ${JSON.stringify(trace).slice(0, 200)})`,
+        ).toBe(true);
+        expect(
+          (trace.spanSets?.[0]?.spans?.length ?? 0) > 0,
+          'spanSets[0].spans is non-empty',
+        ).toBe(true);
+        expect(
+          (trace.spanSet?.spans?.length ?? 0) > 0,
+          'legacy spanSet mirror is populated',
+        ).toBe(true);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Sixth crawl-sweep find (Traces Drilldown's trace list showed badge 0 + "No data for selected query" while every request returned HTTP 200): cerberus's `/api/search` omitted `spanSets` entirely — Grafana's `tableType='spans'` table is built exclusively from `trace.spanSets[].spans`. The handler also ignored `limit` and `spss` (observed live: 4937 summaries / ~755 KB returned for `limit=200`).

## Changes

- `internal/api/tempo`: `SpanSet`/`SpanSetSpan`/`KeyValue` wire types mirroring tempopb's proto3-JSON; matched spans grouped into one SpanSet per trace (capped at `spss`, default 3; `matched` carries the uncapped total; deterministic earliest-first selection); legacy `spanSet` populated; traces ordered `startTimeUnixNano`-desc (Tempo's ordering); `limit` enforced (default 20). Span name stays empty — reference Tempo emits `name=""` in search spanSets (differ-verified).
- gRPC `Search` honours `SearchRequest.Limit`/`SpansPerSpanSet` via shared `TruncateSummaries`, mirrors spanSets onto `tempopb.TraceSearchMetadata`.
- Compat harness: differ compares spanSets (spanID sets, matched totals, per-span start/duration; count-only when the spss cap truncated either side); two new corpus cases. Local differential run: **35/35 vs reference Tempo**.
- Playwright (nightly): `tempo_traces_drilldown.spec.ts` pins the consumer-grade contract — Traces tab badge > 0, span table rows, spanSets on the wire. Verified live: badge went 0 → 100 against Grafana 12.2.9 + fixed cerberus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
