### PR TITLE
feat(e2e): deterministic Grafana surface crawler — BFS + oracle library + inventory ratchet, CI-wired

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -212,6 +212,14 @@ jobs:
           # never which rules run — see
           # test/e2e/playwright/helpers/depth.ts.
           SWEEP_DEPTH: ${{ github.event_name == 'schedule' && 'full' || 'lean' }}
+          # Opt the crawl suite (crawl/**) in. The crawler pins the
+          # COMPOSE stack's surface inventory
+          # (test/e2e/playwright/crawl/grafana-surface-inventory.json);
+          # the k3d dashboard job leaves this unset so its
+          # auto-discovery run doesn't diff a different stack's
+          # surface set against the compose pin. See the testIgnore
+          # comment in test/e2e/playwright/playwright.config.ts.
+          CRAWL_STACK: compose
         run: |
           # Phase-1 panel-shape spec (iterate-panel-shape.spec.ts) runs
           # alongside the catch-net smoke. It enumerates every
@@ -257,6 +265,23 @@ jobs:
           # cerberus publishes and probes /api/v1/series for each.
           # Pins the user's #8 sweep finding: the labels chip must not
           # surface "Unable to fetch labels" for any published metric.
+          #
+          # crawl/ suite (P4/P5 — the deterministic Grafana crawler):
+          #   - crawl/crawl.spec.ts BFS-walks every same-origin surface
+          #     reachable from the Grafana root with universal per-page
+          #     oracles (console errors, datasource-API non-2xx +
+          #     tunneled errors, panel tri-state, crash banners) and
+          #     pins the visited set against
+          #     crawl/grafana-surface-inventory.json. SWEEP_DEPTH
+          #     drives the lane: lean (PR gate) = root + nav + one
+          #     representative per drilldown app; full (this job's
+          #     nightly schedule run) = exhaustive BFS under a hard
+          #     page cap.
+          #   - crawl/dsquery.spec.ts replays consumer-grade queries
+          #     through POST /api/ds/query (the plugin BACKEND — a
+          #     decode layer the datasource-proxy probes never touch).
+          #   - crawl/lints.spec.ts carries the data-quality lints
+          #     (histogram degeneracy, identical-quantile-series).
           npx playwright test \
             compose_grafana_smoke.spec.ts \
             iterate-panel-shape.spec.ts \
@@ -265,6 +290,9 @@ jobs:
             iterate-panel-kiosk.spec.ts \
             iterate-all-dashboards.spec.ts \
             iterate-metrics-explorer.spec.ts \
+            crawl/crawl.spec.ts \
+            crawl/dsquery.spec.ts \
+            crawl/lints.spec.ts \
             --reporter=list
 
       - name: upload Playwright report on failure

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -224,6 +224,88 @@ Prior PRs #504 and #664 carry pattern-#3 refactors. They are not
 reverted (their diffs are now load-bearing for the published
 thresholds), but new violations should follow remedy #1 or #2.
 
+## Grafana surface crawler (Layer 9 extension)
+
+`test/e2e/playwright/crawl/` extends Layer 9 from *enumerated* UX
+flows to *discovered* ones. Where the iterate-\* specs visit known
+surfaces (dashboards, panels, the drilldown-app catalogue), the
+crawler (`crawl/crawl.spec.ts`) BFS-walks every same-origin link
+reachable from the Grafana root, canonicalizes URLs so the
+visited-set converges (path-only keys; dynamic segments like service
+names, trace ids, and folder uids parameterize; `/explore` collapses
+to one surface), and applies the same universal oracles on every
+page — no per-page code:
+
+1. **Zero browser console errors** (no cerberus-origin noise filter,
+   ever).
+2. **Zero non-2xx responses** on the datasource API families
+   (`/api/ds/query`, `/api/dashboards/`,
+   `/api/datasources/proxy/uid/`, `…/resources/`) and zero tunneled
+   `.results.<refId>.error` bodies — the only sanctioned failures are
+   those attributable to a panel's declared
+   `cerberus.expect: "error:<substring>"` contract.
+3. **Panel tri-state**: every rendered panel ends in
+   has-data | declared-empty | declared-error; an undeclared
+   "No data" fails with the panel title + URL.
+4. **No page-level crash banner** and no visible `role="alert"`
+   error banner.
+
+Two sibling specs ride the same lane:
+
+- `crawl/dsquery.spec.ts` — consumer-grade replays through
+  `POST /api/ds/query`, the datasource plugin **backend**. The plugin
+  decode layer (frames, RFC3339 shapes, enums) fails on wire drift
+  the datasource-proxy probes pass through, so this is a distinct
+  oracle, not duplication. (Tempo replays only `queryType: traceId`
+  — the Tempo plugin backend rejects TraceQL search by design.)
+- `crawl/lints.spec.ts` — deterministic data-quality lints. Each lint
+  pins a named incident class: histogram degeneracy (all observations
+  in one bucket fabricating constant quantiles) on every histogram
+  family a quantile panel consumes, and identical-quantile-series
+  (p50 ≡ p95 bitwise — the same single-bucket signature).
+
+**Lane shape.** The crawl suite runs in the `compose-smoke` job only
+(`CRAWL_STACK=compose` opts it in; the k3d `dashboard` job's
+auto-discovery ignores `crawl/**` because the inventory pins the
+compose stack's surface set). `SWEEP_DEPTH` follows the standard
+doctrine — depth changes states, never rules: `lean` (PR gate) visits
+root + nav + one representative per drilldown app; `full` (nightly)
+crawls exhaustively under a **hard page cap that fails the run when
+exceeded**, so surface growth forces a deliberate cap bump.
+
+**The surface-inventory ratchet.**
+`crawl/grafana-surface-inventory.json` pins the canonical visited
+set (mirroring `test/inventory/`'s regenerability convention). A
+newly discovered surface — e.g. a Grafana bump adding an app page —
+fails the crawl until the inventory is regenerated deliberately:
+
+```sh
+# against a healthy compose stack
+CERBERUS_UPDATE_INVENTORY=1 SWEEP_DEPTH=full CRAWL_STACK=compose \
+  npx playwright test crawl/crawl.spec.ts
+```
+
+Coverage shrink (a pinned surface no longer visited) fails
+symmetrically and has no regen escape. The exclusions file
+(`crawl/grafana-surface-exclusions.json`) is empty by design and
+shrink-biased; an entry must document genuine impossibility, and a
+URL in both files fails as a stale exclusion.
+
+**Doctrine: the AI sweep generates oracle classes; CI runs them.**
+The crawler exists because an off-CI AI screenshot sweep (2026-06-09)
+found 34 unique error signatures across 55 BFS-visited pages —
+several on surfaces no enumerated spec visits. Every find decomposed
+into a deterministic signal once named; the AI's irreplaceable role
+is *discovering which invariants to check*. When a future sweep (or a
+human) finds a new bug class: name the deterministic signal, cite the
+incident in a comment, implement it — as a universal per-page oracle
+in `crawl/crawl.spec.ts` if it applies everywhere, or as a lint in
+`crawl/lints.spec.ts` if it's an API-level data-quality rule — and
+aggregate violations into the existing `failures[]` reporting. Never
+per-surface tolerance lists: if a lint can't be deterministic without
+one, narrow its scope by *consumption* (see the
+histogram-degeneracy lint's quantile-panel scoping for the pattern).
+
 ## Regression meta-tests
 
 `test/regression/` pins past CI failures so they can't silently

--- a/test/e2e/playwright/crawl/crawl.spec.ts
+++ b/test/e2e/playwright/crawl/crawl.spec.ts
@@ -1,0 +1,752 @@
+/**
+ * Grafana surface crawler — BFS from the root page with universal
+ * per-page oracles.
+ *
+ * Where the iterate-* specs enumerate KNOWN surfaces (dashboards,
+ * panels, drilldown catalogue entries), the crawler DISCOVERS
+ * surfaces: it BFS-walks every same-origin link reachable from the
+ * Grafana root, canonicalizes URLs so the visited-set converges (see
+ * crawl/lib.ts), and applies the same four oracles on every page it
+ * lands on — no per-page code:
+ *
+ *   1. zero browser console errors. No cerberus-origin noise filter,
+ *      ever (Q5 policy); there is currently no upstream-Grafana
+ *      filter either — if a Grafana bump introduces an unfixable
+ *      upstream console error, follow the precedent set by
+ *      KIOSK_UPSTREAM_GRAFANA_CONSOLE_NOISE in
+ *      iterate-panel-kiosk.spec.ts (single narrowly-scoped regex +
+ *      upstream issue reference), never a broad filter.
+ *   2. zero non-2xx responses on the datasource API surface families
+ *      (`/api/ds/query`, `/api/dashboards/`,
+ *      `/api/datasources/proxy/uid/`, `/api/datasources/uid/…/resources/`
+ *      — the same capture set every existing sweep watches), and zero
+ *      tunneled `.results.<refId>.error` in 2xx ds/query bodies. The
+ *      ONLY sanctioned failures are those attributable to a panel
+ *      with a declared `cerberus.expect: "error:<substring>"`
+ *      contract on the dashboard being rendered.
+ *   3. panel tri-state: every rendered panel must end in
+ *      has-data | declared-empty | declared-error. A "No data" panel
+ *      without a cerberus.expect declaration fails with the panel
+ *      title + page URL in the message.
+ *   4. no page-level crash banner ("an unexpected error happened",
+ *      "application error", …) and no `role="alert"` banner with
+ *      error-class text anywhere on the page.
+ *
+ * Depth doctrine (see helpers/depth.ts — depth changes STATES, never
+ * RULES): at 'lean' (the per-PR gate) the crawl visits the root page,
+ * the nav links harvested from it, and one representative per
+ * drilldown app. At 'full' (nightly) the BFS is exhaustive up to a
+ * HARD page cap that fails the run when exceeded — surface growth
+ * must force a deliberate cap bump, never a silent partial crawl.
+ *
+ * The visited-set is pinned by crawl/grafana-surface-inventory.json
+ * (the ratchet): a new surface (e.g. a Grafana bump adds an app page)
+ * fails the run until the inventory is regenerated deliberately via
+ *
+ *   CERBERUS_UPDATE_INVENTORY=1 SWEEP_DEPTH=full CRAWL_STACK=compose \
+ *     npx playwright test crawl/crawl.spec.ts
+ *
+ * against the compose stack — mirroring the test/inventory/
+ * convention. Coverage shrink (a pinned surface no longer visited)
+ * fails symmetrically and has no regen escape: fix the regression.
+ *
+ * Motivation: an off-CI AI screenshot sweep (2026-06-09) found 34
+ * unique error signatures across 55 BFS-visited pages, several on
+ * surfaces no enumerated spec visits (drilldown-app tabs,
+ * logs-drilldown service pages, traces-drilldown comparison). The AI
+ * sweep's irreplaceable role is DISCOVERING which invariants to
+ * check, off-CI; this crawler carries the accumulated deterministic
+ * versions in CI forever.
+ *
+ * Env:
+ *   GRAFANA_URL / GRAFANA_BASE_URL   default http://localhost:3000
+ *   CERBERUS_URL                     default http://localhost:8080
+ *   SWEEP_DEPTH                      'lean' (default) | 'full'
+ *   CERBERUS_UPDATE_INVENTORY        regen the surface inventory
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import {
+  expect,
+  test,
+  type BrowserContext,
+  type Page,
+  type Response,
+} from '@playwright/test';
+
+import {
+  DRILLDOWN_APPS,
+  captureConsoleErrors,
+  describeSweepDepth,
+  generateSelfTraffic,
+  iterateDashboards,
+  readPanelExpectation,
+  sweepDepth,
+  tolerateRepaintFlicker,
+} from '../helpers/index.js';
+import {
+  ALERT_ERROR_PATTERNS,
+  PAGE_CRASH_PATTERNS,
+  canonicalTarget,
+  canonicalizeURL,
+  collectVisibleAlertBanners,
+  diffInventory,
+  expandSiblingTabs,
+  harvestLinks,
+  inventoryPath,
+  loadExclusions,
+  loadInventory,
+  marshalInventory,
+  truncate,
+  type SurfaceInventory,
+} from './lib.js';
+
+// Self-traffic warmup — same rationale + value as the iterate-* specs:
+// without populated counters/streams/traces, a "No data" panel on a
+// fresh stack is indistinguishable from a real regression.
+const SEED_TRAFFIC_SECONDS = 30;
+
+// Hard page caps. The FULL cap fails the run when the frontier is
+// still non-empty at the cap — surface growth (a Grafana bump adding
+// pages) must force a deliberate, reviewed cap bump in this file,
+// never a silently-partial crawl. The lean cap exists for the same
+// reason at PR scale.
+const PAGE_CAP_FULL = 80;
+const PAGE_CAP_LEAN = 30;
+
+// Recycle the browser context every N visited pages. A single
+// renderer reused across the whole full-depth crawl accumulates state
+// until Chromium refuses requests with net::ERR_INSUFFICIENT_RESOURCES
+// (same failure mode iterate-panel-kiosk documents at ~190
+// navigations); 40 keeps a wide margin while preserving cheap
+// navigation within a batch.
+const CONTEXT_RECYCLE_PAGES = 40;
+
+type CrawlFailure = {
+  url: string; // canonical surface
+  rule: string;
+  detail: string;
+};
+
+type QueueEntry = {
+  canonical: string;
+  /** Concrete URL (path + query) actually navigated for this surface. */
+  concrete: string;
+  /** Canonical URL of the page that first discovered this surface. */
+  via: string;
+};
+
+// ---------------------------------------------------------------------------
+// Canonicalization pins — pure-function regression pins for the rules
+// the inventory's stability depends on. A rule drift that re-keys
+// surfaces would otherwise surface as a confusing inventory diff.
+// ---------------------------------------------------------------------------
+
+test.describe('crawl: canonicalization pins', () => {
+  const base = 'http://localhost:3000';
+
+  test('canonical keys are path-only — volatile and session-state params are stripped', () => {
+    expect(
+      canonicalizeURL(
+        '/d/abc/some-slug?orgId=1&from=now-1h&to=now&refresh=10s&viewPanel=4&kiosk',
+        base,
+      ),
+    ).toBe('/d/abc');
+    // Drilldown-app session state (patterns/displayedFields/layout/…)
+    // is a state of the surface, not a new surface — the first full
+    // crawl produced four param-permutations of this one page.
+    expect(
+      canonicalizeURL(
+        '/a/grafana-lokiexplore-app/explore/service/cerberus/logs?patterns=%5B%5D&displayedFields=%5B%5D&visualizationType=%22logs%22',
+        base,
+      ),
+    ).toBe('/a/grafana-lokiexplore-app/explore/service/{service}/logs');
+    expect(canonicalizeURL('/dashboards?tag=b&tag=a&orgId=1', base)).toBe(
+      '/dashboards',
+    );
+    expect(canonicalizeURL('/?orgId=1', base)).toBe('/');
+  });
+
+  test('bare app redirectors alias to their entry route', () => {
+    expect(canonicalTarget('/a/grafana-exploretraces-app', base)).toEqual({
+      canonical: '/a/grafana-exploretraces-app/explore',
+      concrete: '/a/grafana-exploretraces-app/explore',
+    });
+    expect(canonicalizeURL('/a/grafana-metricsdrilldown-app', base)).toBe(
+      '/a/grafana-metricsdrilldown-app/drilldown',
+    );
+  });
+
+  test('provisioning-minted folder uids parameterize and slugs drop', () => {
+    expect(canonicalizeURL('/dashboards/f/efor9e5025vcwb', base)).toBe(
+      '/dashboards/f/{folder}',
+    );
+    expect(
+      canonicalizeURL('/dashboards/f/efor9e5025vcwb/cerberus', base),
+    ).toBe('/dashboards/f/{folder}');
+    expect(
+      canonicalizeURL('/dashboards/f/efor9e5025vcwb/cerberus/alerting', base),
+    ).toBe('/dashboards/f/{folder}/alerting');
+  });
+
+  test('data-derived label segments parameterize', () => {
+    expect(
+      canonicalizeURL(
+        '/a/grafana-lokiexplore-app/explore/service/shop/label/detected_level',
+        base,
+      ),
+    ).toBe('/a/grafana-lokiexplore-app/explore/service/{service}/label/{label}');
+  });
+
+  test('explore collapses to a single surface', () => {
+    expect(
+      canonicalizeURL('/explore?panes=%7B%22x%22%3A1%7D&schemaVersion=1', base),
+    ).toBe('/explore');
+    expect(canonicalizeURL('/explore/metrics', base)).toBe('/explore');
+  });
+
+  test('dynamic path segments parameterize', () => {
+    expect(
+      canonicalizeURL(
+        '/a/grafana-lokiexplore-app/explore/service/cerberus/logs?var-ds=x',
+        base,
+      ),
+    ).toBe('/a/grafana-lokiexplore-app/explore/service/{service}/logs');
+    expect(
+      canonicalizeURL(
+        '/a/grafana-exploretraces-app/trace/0123456789abcdef0123456789abcdef',
+        base,
+      ),
+    ).toBe('/a/grafana-exploretraces-app/trace/{hex}');
+  });
+
+  test('committed inventory + exclusions files are internally consistent', () => {
+    // Stack-free meta-checks (the live diff runs at the end of the
+    // crawl): the inventory round-trips byte-for-byte through the
+    // canonical marshaller (so regeneration is reproducible — the
+    // test/inventory/ convention), is non-empty, carries a non-empty
+    // lean subset, and the exclusions file is sound (rationales
+    // present, no URL in both files).
+    const inv = loadInventory();
+    const exc = loadExclusions();
+    expect(inv.surfaces.length, 'inventory is non-empty').toBeGreaterThan(0);
+    expect(
+      inv.surfaces.filter((s) => s.lean).length,
+      'lean subset is non-empty',
+    ).toBeGreaterThan(0);
+    expect(readFileSync(inventoryPath(), 'utf8')).toBe(marshalInventory(inv));
+    const inventoryUrls = new Set(inv.surfaces.map((s) => s.url));
+    for (const e of exc.exclusions) {
+      expect(e.rationale.trim(), `exclusion ${e.url} rationale`).not.toBe('');
+      expect(
+        inventoryUrls.has(e.url),
+        `exclusion ${e.url} must not also be a pinned inventory surface`,
+      ).toBe(false);
+    }
+  });
+
+  test('out-of-scope routes return null', () => {
+    expect(canonicalizeURL('/alerting/list', base)).toBeNull();
+    expect(canonicalizeURL('/admin/settings', base)).toBeNull();
+    expect(canonicalizeURL('/connections/datasources', base)).toBeNull();
+    expect(canonicalizeURL('/dashboard/new', base)).toBeNull();
+    expect(canonicalizeURL('/d/abc/edit', base)).toBeNull();
+    expect(canonicalizeURL('/d-solo/abc?panelId=2', base)).toBeNull();
+    expect(canonicalizeURL('/login', base)).toBeNull();
+    expect(canonicalizeURL('/api/search', base)).toBeNull();
+    expect(canonicalizeURL('https://grafana.com/docs', base)).toBeNull();
+    expect(canonicalizeURL('mailto:x@example.com', base)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The crawl
+// ---------------------------------------------------------------------------
+
+test('crawl: BFS over every reachable Grafana surface with universal oracles + inventory ratchet', async ({
+  browser,
+  request,
+}, testInfo) => {
+  const depth = sweepDepth();
+  // Budget: lean ≈ 10 pages × ~6s + 30s seed; full ≈ cap (80) pages.
+  testInfo.setTimeout(depth === 'full' ? 30 * 60_000 : 8 * 60_000);
+  // eslint-disable-next-line no-console
+  console.log(describeSweepDepth(depth));
+
+  const baseURL =
+    process.env.GRAFANA_URL ??
+    process.env.GRAFANA_BASE_URL ??
+    'http://localhost:3000';
+
+  await generateSelfTraffic(request, SEED_TRAFFIC_SECONDS);
+
+  // Declared cerberus.expect contracts, keyed by dashboard uid. The
+  // crawler consumes them two ways:
+  //   - declaredNoData: panel titles whose 'empty' / 'error:*'
+  //     declaration legitimizes a "No data" render (tri-state oracle).
+  //   - declaredErrorExprs: target expressions of declared-error
+  //     panels — the only sanctioned source of non-2xx / tunneled
+  //     ds/query failures on that dashboard's page.
+  const dashboards = await iterateDashboards(request, baseURL);
+  const declaredNoData = new Map<string, Set<string>>();
+  const declaredErrorExprs = new Map<string, Set<string>>();
+  for (const d of dashboards) {
+    const noData = new Set<string>();
+    const errExprs = new Set<string>();
+    for (const p of d.panels) {
+      const e = readPanelExpectation(p);
+      if (!e.declared || e.expect === 'nonempty') continue;
+      noData.add(p.title);
+      if (e.expect.startsWith('error:')) {
+        for (const t of p.targets) {
+          const expr = (t.expr ?? t.query ?? '').trim();
+          if (expr !== '') errExprs.add(expr);
+        }
+      }
+    }
+    declaredNoData.set(d.uid, noData);
+    declaredErrorExprs.set(d.uid, errExprs);
+  }
+
+  // Seed frontier. Order is load-bearing for determinism: root first
+  // (its harvest defines the lean nav set), then the drilldown app
+  // representatives, then — at full depth — every provisioned
+  // dashboard (also reachable via /dashboards, but seeding them makes
+  // the crawl independent of the browse-page's pagination/virtualised
+  // list rendering).
+  const queue: QueueEntry[] = [{ canonical: '/', concrete: '/', via: '<seed>' }];
+  for (const app of DRILLDOWN_APPS) {
+    const target = canonicalTarget(app.root, baseURL);
+    if (target === null) {
+      throw new Error(
+        `crawl: drilldown app root ${app.root} canonicalizes out of scope — fix the catalogue or the exclusion rules`,
+      );
+    }
+    // Navigate the catalogue's concrete root (it may pin a var-ds the
+    // entry route needs on a cold context), keyed by the canonical.
+    queue.push({
+      canonical: target.canonical,
+      concrete: new URL(app.root, baseURL).pathname + new URL(app.root, baseURL).search,
+      via: '<seed:app>',
+    });
+  }
+  // The lean surface set: root + the drilldown-app representatives
+  // (the nav links harvested from the root page join it during the
+  // root visit below). Snapshot BEFORE the full-depth dashboard
+  // seeds — dashboards are full-lane states (their per-PR coverage
+  // is the API-layer iterate-all-dashboards probes).
+  const leanSet = new Set<string>(queue.map((q) => q.canonical));
+  if (depth === 'full') {
+    for (const d of [...dashboards].sort((a, b) => a.uid.localeCompare(b.uid))) {
+      queue.push({
+        canonical: `/d/${d.uid}`,
+        concrete: `/d/${d.uid}`,
+        via: '<seed:dashboard>',
+      });
+    }
+  }
+
+  const pageCap = depth === 'full' ? PAGE_CAP_FULL : PAGE_CAP_LEAN;
+  const visited = new Map<string, string>(); // canonical → concrete navigated
+  const failures: CrawlFailure[] = [];
+
+  let context: BrowserContext | null = null;
+  let page: Page | null = null;
+  let pagesInContext = 0;
+
+  try {
+    while (queue.length > 0) {
+      const entry = queue.shift()!;
+      if (visited.has(entry.canonical)) continue;
+
+      if (visited.size >= pageCap) {
+        const remaining = [
+          entry,
+          ...queue.filter((q) => !visited.has(q.canonical)),
+        ]
+          .map((q) => `${q.canonical} (via ${q.via})`)
+          .filter((v, i, a) => a.indexOf(v) === i);
+        throw new Error(
+          `crawl: page cap ${pageCap} (${depth}) exceeded with ${remaining.length} surface(s) still queued — ` +
+            `surface growth must be absorbed by a deliberate cap bump in crawl.spec.ts, not a partial crawl:\n  - ${remaining.join('\n  - ')}`,
+        );
+      }
+
+      if (page === null || pagesInContext >= CONTEXT_RECYCLE_PAGES) {
+        if (context !== null) await context.close();
+        context = await browser.newContext();
+        page = await context.newPage();
+        pagesInContext = 0;
+      }
+      pagesInContext++;
+      visited.set(entry.canonical, entry.concrete);
+
+      const { harvested, pageFailures } = await visitAndAudit(
+        page,
+        baseURL,
+        entry,
+        declaredNoData,
+        declaredErrorExprs,
+      );
+      failures.push(...pageFailures);
+
+      // Lean visits the seed set + the nav links harvested from the
+      // root page only; full expands from every page. Same harvest
+      // RULE, fewer expansion states (depth doctrine).
+      if (depth === 'full' || entry.canonical === '/') {
+        const canonicals = new Map<string, string>();
+        for (const href of harvested) {
+          const target = canonicalTarget(href, baseURL);
+          if (target === null || visited.has(target.canonical)) continue;
+          if (!canonicals.has(target.canonical)) {
+            canonicals.set(target.canonical, target.concrete);
+          }
+        }
+        for (const [canonical, concrete] of [...canonicals.entries()].sort(
+          ([a], [b]) => a.localeCompare(b),
+        )) {
+          queue.push({ canonical, concrete, via: entry.canonical });
+          if (entry.canonical === '/') leanSet.add(canonical);
+          // Known sibling-route families expand deterministically —
+          // see expandSiblingTabs.
+          for (const sib of expandSiblingTabs(canonical, concrete)) {
+            if (!visited.has(sib.canonical) && !canonicals.has(sib.canonical)) {
+              queue.push({ ...sib, via: `${entry.canonical} (sibling)` });
+            }
+          }
+        }
+      }
+    }
+  } finally {
+    if (context !== null) await context.close();
+  }
+
+  // eslint-disable-next-line no-console
+  console.log(
+    `crawl: visited ${visited.size} surface(s) at depth=${depth}:\n${[...visited.keys()]
+      .sort()
+      .map((u) => `  - ${u}`)
+      .join('\n')}`,
+  );
+
+  if (failures.length > 0) {
+    const detail = failures
+      .map((f) => `[crawl:${f.url}] ${f.rule}: ${f.detail}`)
+      .join('\n\n');
+    throw new Error(
+      `crawl oracles violated on ${failures.length} surface state(s):\n\n${detail}`,
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Surface-inventory ratchet.
+  // -------------------------------------------------------------------------
+  if (process.env.CERBERUS_UPDATE_INVENTORY) {
+    expect(
+      depth,
+      'inventory regeneration requires the exhaustive crawl: rerun with SWEEP_DEPTH=full',
+    ).toBe('full');
+    const inv: SurfaceInventory = {
+      doc:
+        'Pinned canonical Grafana surface set for the compose stack, emitted by ' +
+        'test/e2e/playwright/crawl/crawl.spec.ts. lean=true rows are the per-PR crawl ' +
+        '(root + nav + one representative per drilldown app); every row is crawled nightly. ' +
+        'Regenerate deliberately against a healthy compose stack with: ' +
+        'CERBERUS_UPDATE_INVENTORY=1 SWEEP_DEPTH=full CRAWL_STACK=compose npx playwright test crawl/crawl.spec.ts',
+      stack: 'compose',
+      surfaces: [...visited.keys()].map((url) => ({
+        url,
+        lean: leanSet.has(url),
+      })),
+    };
+    writeFileSync(inventoryPath(), marshalInventory(inv));
+    // eslint-disable-next-line no-console
+    console.log(
+      `crawl: regenerated ${inventoryPath()} with ${inv.surfaces.length} surface(s)`,
+    );
+    return;
+  }
+
+  const violations = diffInventory(
+    new Set(visited.keys()),
+    loadInventory(),
+    loadExclusions(),
+    depth,
+  );
+  expect(
+    violations,
+    `surface-inventory ratchet violated:\n  - ${violations.join('\n  - ')}`,
+  ).toEqual([]);
+});
+
+// ---------------------------------------------------------------------------
+// Per-page visit + oracles
+// ---------------------------------------------------------------------------
+
+async function visitAndAudit(
+  page: Page,
+  baseURL: string,
+  entry: QueueEntry,
+  declaredNoData: ReadonlyMap<string, Set<string>>,
+  declaredErrorExprs: ReadonlyMap<string, Set<string>>,
+): Promise<{ harvested: string[]; pageFailures: CrawlFailure[] }> {
+  const pageFailures: CrawlFailure[] = [];
+  const fail = (rule: string, detail: string) =>
+    pageFailures.push({ url: entry.canonical, rule, detail });
+
+  // Which dashboard (if any) this surface renders — keys the declared
+  // cerberus.expect contracts.
+  const dashUid = /^\/d\/([^/?]+)/.exec(entry.canonical)?.[1];
+  const noDataDeclared = (dashUid && declaredNoData.get(dashUid)) || new Set();
+  const errExprsDeclared =
+    (dashUid && declaredErrorExprs.get(dashUid)) || new Set<string>();
+
+  const { messages: consoleErrors, stop: stopConsole } =
+    await captureConsoleErrors(page);
+
+  // Datasource API capture — same surface families every existing
+  // sweep watches. Deliberately NOT all of /api/: e.g. Grafana fires
+  // /api/datasources/uid/cerberus-tempo/health on page loads and its
+  // Tempo plugin has no backend CheckHealth, so that endpoint 404s
+  // with plugin.notImplemented by Grafana's own design (see the
+  // datasource-health probe comment in compose_grafana_smoke.spec.ts).
+  type CapturedDsResponse = {
+    url: string;
+    method: string;
+    status: number;
+    body: string;
+    requestBody: string;
+  };
+  const captured: CapturedDsResponse[] = [];
+  const captureReads: Promise<void>[] = [];
+  const onResponse = (resp: Response) => {
+    const u = resp.url();
+    const isDsQuery = u.includes('/api/ds/query');
+    if (
+      !isDsQuery &&
+      !u.includes('/api/dashboards/') &&
+      !u.includes('/api/datasources/proxy/uid/') &&
+      !(u.includes('/api/datasources/uid/') && u.includes('/resources/'))
+    ) {
+      return;
+    }
+    const status = resp.status();
+    const method = resp.request().method();
+    const requestBody = resp.request().postData() ?? '';
+    captureReads.push(
+      (async () => {
+        let body = '';
+        // Read bodies for failures always, and for ds/query 2xx too
+        // (the tunneled-error oracle needs them).
+        if (status < 200 || status > 299 || isDsQuery) {
+          try {
+            body = await resp.text();
+          } catch {
+            body = '<unreadable>';
+          }
+        }
+        captured.push({
+          url: u.startsWith(baseURL) ? u.slice(baseURL.length) : u,
+          method,
+          status,
+          body,
+          requestBody,
+        });
+      })(),
+    );
+  };
+  page.on('response', onResponse);
+
+  let harvested: string[] = [];
+  try {
+    await page.goto(`${baseURL}${entry.concrete}`, {
+      waitUntil: 'domcontentloaded',
+      timeout: 90_000,
+    });
+    await tolerateRepaintFlicker(page, { settleMs: 600, timeoutMs: 45_000 });
+
+    harvested = await harvestLinks(page);
+
+    // Oracle 4a — VISIBLE role=alert banners with error-class text
+    // (Grafana pre-mounts hidden alert skeletons on some pages; see
+    // collectVisibleAlertBanners).
+    const banners = await collectVisibleAlertBanners(page);
+    for (const banner of banners) {
+      if (ALERT_ERROR_PATTERNS.some((re) => re.test(banner))) {
+        fail(
+          'role-alert-banner',
+          `role=alert banner with error text: ${truncate(banner, 400)}`,
+        );
+      }
+    }
+
+    // Oracle 4b — page-level crash signatures.
+    const bodyText = await page
+      .locator('body')
+      .innerText({ timeout: 10_000 })
+      .catch(() => '');
+    for (const re of PAGE_CRASH_PATTERNS) {
+      const m = re.exec(bodyText);
+      if (m) {
+        fail(
+          'page-crash-banner',
+          `page body carries crash signature ${re}: …${truncate(
+            bodyText.slice(Math.max(0, m.index - 80), m.index + 160),
+            300,
+          )}…`,
+        );
+      }
+    }
+
+    // Oracle 3 — panel tri-state. Every "No data" render must be
+    // covered by a declared 'empty' / 'error:*' contract.
+    const noDataPanels = await collectNoDataPanels(page);
+    for (const title of noDataPanels) {
+      if (noDataDeclared.has(title)) continue;
+      fail(
+        'panel-no-data-undeclared',
+        `panel ${JSON.stringify(title)} rendered "No data" with no cerberus.expect declaration ` +
+          `(dashboard=${dashUid ?? '<not a dashboard>'}, url=${entry.concrete}) — `
+          + `fix the bug at the source (cerberus code, seed, dashboard, or panel), or declare the contract on a showcase panel`,
+      );
+    }
+  } catch (err) {
+    fail(
+      'navigation-threw',
+      `goto(${entry.concrete}) threw: ${(err as Error).message}`,
+    );
+  } finally {
+    page.off('response', onResponse);
+    stopConsole();
+  }
+  await Promise.all(captureReads);
+
+  // Oracle 2a — non-2xx on the datasource API families. Sanctioned
+  // only when every query in the failing ds/query request is a
+  // declared-error panel target on this dashboard.
+  for (const resp of captured) {
+    if (resp.status >= 200 && resp.status <= 299) continue;
+    if (
+      resp.url.includes('/api/ds/query') &&
+      requestFullyDeclaredError(resp.requestBody, errExprsDeclared)
+    ) {
+      continue;
+    }
+    fail(
+      'http-non-2xx',
+      `${resp.method} ${resp.url} → ${resp.status}\n  body: ${truncate(resp.body, 600)}`,
+    );
+  }
+
+  // Oracle 2b — tunneled per-target errors in 2xx ds/query bodies.
+  for (const resp of captured) {
+    if (!resp.url.includes('/api/ds/query')) continue;
+    if (resp.status < 200 || resp.status > 299) continue;
+    let parsed: { results?: Record<string, { error?: string }> };
+    try {
+      parsed = JSON.parse(resp.body) as typeof parsed;
+    } catch {
+      continue; // streamed/chunked ds/query bodies have no JSON envelope
+    }
+    const refToExpr = refIdToExpr(resp.requestBody);
+    for (const [refId, target] of Object.entries(parsed.results ?? {})) {
+      if (!target || typeof target.error !== 'string' || target.error === '') {
+        continue;
+      }
+      const expr = refToExpr.get(refId) ?? '';
+      if (expr !== '' && errExprsDeclared.has(expr)) continue;
+      fail(
+        'ds-query-tunneled-error',
+        `refId=${refId} url=${resp.url}\n  error: ${truncate(target.error, 600)}`,
+      );
+    }
+  }
+
+  // Oracle 1 — console errors. Zero, with no noise filter (see the
+  // file header for the escalation path if a Grafana bump ever makes
+  // one unavoidable).
+  if (consoleErrors.length > 0) {
+    fail(
+      'console-error',
+      `${consoleErrors.length} console error(s):\n${consoleErrors
+        .map((m) => `  - ${truncate(m, 400)}`)
+        .join('\n')}`,
+    );
+  }
+
+  return { harvested, pageFailures };
+}
+
+/**
+ * Map refId → expr/query from a ds/query request body. Returns an
+ * empty map for non-JSON bodies.
+ */
+function refIdToExpr(requestBody: string): Map<string, string> {
+  const out = new Map<string, string>();
+  try {
+    const parsed = JSON.parse(requestBody) as {
+      queries?: Array<{ refId?: string; expr?: string; query?: string }>;
+    };
+    for (const q of parsed.queries ?? []) {
+      const expr = (q.expr ?? q.query ?? '').trim();
+      if (q.refId) out.set(q.refId, expr);
+    }
+  } catch {
+    // fallthrough — empty map; caller treats every refId as undeclared
+  }
+  return out;
+}
+
+/**
+ * True iff the ds/query request body contains ≥1 query and EVERY
+ * query expression is a declared-error panel target. Only then is a
+ * non-2xx response the declared, showcased outcome.
+ */
+function requestFullyDeclaredError(
+  requestBody: string,
+  declared: ReadonlySet<string>,
+): boolean {
+  if (declared.size === 0) return false;
+  const exprs = [...refIdToExpr(requestBody).values()];
+  return exprs.length > 0 && exprs.every((e) => e !== '' && declared.has(e));
+}
+
+/**
+ * Collect the titles of panels currently rendering Grafana's
+ * "No data" placeholder. Title resolution walks up from the "No
+ * data" node to the panel container and reads the panel-header
+ * testid (`data-testid Panel header <title>` — Grafana's
+ * @grafana/e2e-selectors convention, same one
+ * compose_grafana_smoke.spec.ts keys on).
+ */
+async function collectNoDataPanels(page: Page): Promise<string[]> {
+  return await page.evaluate(() => {
+    const out: string[] = [];
+    const isNoData = (el: Element) =>
+      (el.textContent ?? '').trim() === 'No data';
+    const candidates = [
+      ...document.querySelectorAll(
+        '[data-testid="data-testid Panel data error message"]',
+      ),
+      ...[...document.querySelectorAll('div, span, p')].filter(isNoData),
+    ];
+    const seen = new Set<Element>();
+    for (const el of candidates) {
+      if (!isNoData(el)) continue;
+      const panel =
+        el.closest('[data-viz-panel-key]') ??
+        el.closest('section[data-testid^="data-testid Panel"]') ??
+        el.closest('.panel-container');
+      if (!panel || seen.has(panel)) continue;
+      seen.add(panel);
+      const header = panel.querySelector('[data-testid^="data-testid Panel header"]');
+      const headerTestId = header?.getAttribute('data-testid') ?? '';
+      const title =
+        headerTestId.replace(/^data-testid Panel header ?/, '') ||
+        panel.querySelector('h2')?.textContent?.trim() ||
+        '<untitled panel>';
+      out.push(title);
+    }
+    return [...new Set(out)];
+  });
+}

--- a/test/e2e/playwright/crawl/dsquery.spec.ts
+++ b/test/e2e/playwright/crawl/dsquery.spec.ts
@@ -1,0 +1,289 @@
+/**
+ * Consumer-grade /api/ds/query replays — the Grafana PLUGIN BACKEND
+ * path, not the datasource proxy.
+ *
+ * Why this exists on top of the proxy-level probes
+ * (iterate-all-dashboards fires `/api/datasources/proxy/uid/…`): the
+ * 2026-06-09 AI sweep found two bug layers that are INVISIBLE at the
+ * proxy level. `POST /api/ds/query` routes through each datasource
+ * plugin's Go backend, which parses cerberus's wire responses into
+ * data frames — a response that is valid enough for the proxy
+ * pass-through can still fail the plugin's stricter decode (frame
+ * schema, RFC3339 shapes, enum values), and Grafana then tunnels the
+ * failure into `.results.<refId>.error` or a 4xx/5xx envelope.
+ *
+ * The replay set per provisioned datasource:
+ *   - prometheus: one instant query + one range query.
+ *   - loki: one log-stream range query + one metric range query.
+ *   - tempo: one trace-by-id lookup via `queryType: "traceId"`.
+ *     The Tempo plugin backend supports ONLY trace-by-id: it rejects
+ *     `traceql` / `traceqlSearch` query types with "backend TraceQL
+ *     search queries are not supported" / "unsupported query type"
+ *     (verified against grafana/grafana:12.2.9 — search runs through
+ *     the frontend + datasource proxy instead, which the crawler and
+ *     iterate-* specs cover). The trace id is harvested live from a
+ *     proxy `/api/search` probe so the replay always targets a trace
+ *     the stack actually ingested.
+ *
+ * Every replay asserts: HTTP 2xx, no `.results.<refId>.error`, no
+ * `.results.<refId>.errorSource`, and ≥1 frame with a non-empty
+ * value column — these queries target self-telemetry the seed
+ * traffic guarantees is present, so an empty frame set is a real
+ * regression (cerberus wire shape, plugin decode, or seed), never a
+ * state to mask.
+ *
+ * Env:
+ *   GRAFANA_URL / GRAFANA_BASE_URL   default http://localhost:3000
+ *   CERBERUS_URL                     default http://localhost:8080
+ */
+
+import {
+  expect,
+  test,
+  type APIRequestContext,
+} from '@playwright/test';
+
+import { generateSelfTraffic } from '../helpers/index.js';
+import { truncate } from './lib.js';
+
+const SEED_TRAFFIC_SECONDS = 20;
+
+type DataSourceEntry = {
+  uid: string;
+  type: string;
+  name: string;
+};
+
+type DsQueryResults = {
+  results?: Record<
+    string,
+    {
+      error?: string;
+      errorSource?: string;
+      status?: number;
+      frames?: Array<{
+        schema?: { fields?: Array<{ name?: string }> };
+        data?: { values?: unknown[][] };
+      }>;
+    }
+  >;
+};
+
+type Replay = {
+  label: string;
+  /** The single query object POSTed under `queries[]`. */
+  query: Record<string, unknown>;
+  /** Whether ≥1 frame with ≥1 value row is required. */
+  requireData: boolean;
+};
+
+function baseURL(): string {
+  return (
+    process.env.GRAFANA_URL ??
+    process.env.GRAFANA_BASE_URL ??
+    'http://localhost:3000'
+  );
+}
+
+async function listDatasources(
+  request: APIRequestContext,
+): Promise<DataSourceEntry[]> {
+  const resp = await request.get(`${baseURL()}/api/datasources`);
+  expect(resp.status(), '/api/datasources status').toBe(200);
+  const all = (await resp.json()) as DataSourceEntry[];
+  return all.filter((d) =>
+    ['prometheus', 'loki', 'tempo'].includes(d.type),
+  );
+}
+
+/**
+ * Harvest a real trace id from the stack via the datasource proxy
+ * search endpoint — the replay must target a trace that exists.
+ */
+async function harvestTraceID(
+  request: APIRequestContext,
+  tempoUid: string,
+): Promise<string> {
+  const resp = await request.get(
+    `${baseURL()}/api/datasources/proxy/uid/${tempoUid}/api/search?q=${encodeURIComponent('{}')}&limit=5`,
+  );
+  expect(
+    resp.status(),
+    `proxy /api/search via ${tempoUid} (trace-id harvest)`,
+  ).toBe(200);
+  const body = (await resp.json()) as {
+    traces?: Array<{ traceID?: string }>;
+  };
+  const id = body.traces?.[0]?.traceID ?? '';
+  expect(
+    id,
+    'at least one trace present after seed traffic (empty search = real bug)',
+  ).toMatch(/^[0-9a-f]{32}$/);
+  return id;
+}
+
+function replaysFor(ds: DataSourceEntry, traceID: string): Replay[] {
+  const datasource = { type: ds.type, uid: ds.uid };
+  switch (ds.type) {
+    case 'prometheus':
+      return [
+        {
+          label: 'prom-instant',
+          query: {
+            refId: 'A',
+            datasource,
+            expr: 'cerberus_queries_total',
+            instant: true,
+            range: false,
+            format: 'time_series',
+            intervalMs: 15_000,
+            maxDataPoints: 500,
+          },
+          requireData: true,
+        },
+        {
+          label: 'prom-range',
+          query: {
+            refId: 'A',
+            datasource,
+            expr: 'sum by (cerberus_ql) (rate(cerberus_queries_total[5m]))',
+            instant: false,
+            range: true,
+            format: 'time_series',
+            intervalMs: 15_000,
+            maxDataPoints: 500,
+          },
+          requireData: true,
+        },
+      ];
+    case 'loki':
+      return [
+        {
+          label: 'loki-stream-range',
+          query: {
+            refId: 'A',
+            datasource,
+            expr: '{service_name=~".+"}',
+            queryType: 'range',
+            maxLines: 100,
+          },
+          requireData: true,
+        },
+        {
+          label: 'loki-metric-range',
+          query: {
+            refId: 'A',
+            datasource,
+            expr: 'sum(count_over_time({service_name=~".+"}[5m]))',
+            queryType: 'range',
+          },
+          requireData: true,
+        },
+      ];
+    case 'tempo':
+      return [
+        {
+          label: 'tempo-trace-by-id',
+          query: {
+            refId: 'A',
+            datasource,
+            // queryType traceId is the ONLY backend-supported Tempo
+            // query type — see the file header.
+            queryType: 'traceId',
+            query: traceID,
+          },
+          requireData: true,
+        },
+      ];
+    default:
+      throw new Error(`replaysFor: unhandled datasource type ${ds.type}`);
+  }
+}
+
+test('ds-query replays: every provisioned datasource answers through the plugin backend with data and no tunneled errors', async ({
+  request,
+}, testInfo) => {
+  testInfo.setTimeout(5 * 60_000);
+
+  await generateSelfTraffic(request, SEED_TRAFFIC_SECONDS);
+
+  const datasources = await listDatasources(request);
+  expect(
+    datasources.length,
+    'at least one prometheus/loki/tempo datasource provisioned',
+  ).toBeGreaterThan(0);
+
+  const tempoUid = datasources.find((d) => d.type === 'tempo')?.uid;
+  const traceID = tempoUid ? await harvestTraceID(request, tempoUid) : '';
+
+  const failures: string[] = [];
+  const nowMs = Date.now();
+  const fromMs = nowMs - 5 * 60_000;
+
+  for (const ds of datasources.sort((a, b) => a.uid.localeCompare(b.uid))) {
+    for (const replay of replaysFor(ds, traceID)) {
+      const where = `[${ds.uid}:${replay.label}]`;
+      const resp = await request.post(`${baseURL()}/api/ds/query`, {
+        data: {
+          queries: [replay.query],
+          from: String(fromMs),
+          to: String(nowMs),
+        },
+      });
+      const status = resp.status();
+      const bodyText = await resp.text();
+      if (status < 200 || status > 299) {
+        failures.push(
+          `${where} POST /api/ds/query → ${status}\n  body: ${truncate(bodyText, 600)}`,
+        );
+        continue;
+      }
+      let parsed: DsQueryResults;
+      try {
+        parsed = JSON.parse(bodyText) as DsQueryResults;
+      } catch (err) {
+        failures.push(
+          `${where} 2xx body is not JSON: ${(err as Error).message}\n  body: ${truncate(bodyText, 300)}`,
+        );
+        continue;
+      }
+      const result = parsed.results?.A;
+      if (!result) {
+        failures.push(`${where} response carries no results.A entry`);
+        continue;
+      }
+      if (typeof result.error === 'string' && result.error !== '') {
+        failures.push(
+          `${where} tunneled results.A.error: ${truncate(result.error, 600)}` +
+            (result.errorSource ? ` (errorSource=${result.errorSource})` : ''),
+        );
+        continue;
+      }
+      const frames = result.frames ?? [];
+      if (replay.requireData) {
+        const valueRows = frames.reduce(
+          (acc, f) =>
+            acc +
+            (f.data?.values?.reduce(
+              (m, col) => Math.max(m, Array.isArray(col) ? col.length : 0),
+              0,
+            ) ?? 0),
+          0,
+        );
+        if (frames.length === 0 || valueRows === 0) {
+          failures.push(
+            `${where} expected ≥1 frame with data, got frames=${frames.length} valueRows=${valueRows} — ` +
+              `the seed traffic guarantees this query returns data; an empty frame set is a real bug ` +
+              `(cerberus wire shape, plugin decode, or seed)`,
+          );
+        }
+      }
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new Error(
+      `ds-query replay failures (${failures.length}):\n\n${failures.join('\n\n')}`,
+    );
+  }
+});

--- a/test/e2e/playwright/crawl/dsquery.spec.ts
+++ b/test/e2e/playwright/crawl/dsquery.spec.ts
@@ -43,7 +43,10 @@ import {
   type APIRequestContext,
 } from '@playwright/test';
 
-import { generateSelfTraffic } from '../helpers/index.js';
+import {
+  awaitSelfTelemetryRangeSignal,
+  generateSelfTraffic,
+} from '../helpers/index.js';
 import { truncate } from './lib.js';
 
 const SEED_TRAFFIC_SECONDS = 20;
@@ -206,6 +209,12 @@ test('ds-query replays: every provisioned datasource answers through the plugin 
   testInfo.setTimeout(5 * 60_000);
 
   await generateSelfTraffic(request, SEED_TRAFFIC_SECONDS);
+  // rate()-over-range replays need ≥2 exported telemetry samples in
+  // the lookback window — on a freshly-booted stack the seed traffic
+  // alone doesn't guarantee that yet (see the helper doc; verified
+  // red on a healthy stack at ~2min uptime, 2026-06-10). Bounded
+  // wait, loud deadline failure — never a skip.
+  await awaitSelfTelemetryRangeSignal(request);
 
   const datasources = await listDatasources(request);
   expect(

--- a/test/e2e/playwright/crawl/grafana-surface-exclusions.json
+++ b/test/e2e/playwright/crawl/grafana-surface-exclusions.json
@@ -1,0 +1,4 @@
+{
+  "doc": "Surfaces deliberately not crawled despite being discovered in-scope. Every entry MUST carry a non-empty rationale explaining why the surface is genuinely uncrawlable (no workaround exists) — an exclusion is documentation of impossibility, never a tolerance for a failing page. A URL may not appear in both this file and grafana-surface-inventory.json (that would be a stale exclusion; the crawl fails on it). This set is intentionally EMPTY today and should stay shrink-biased: before adding a row, fix the bug at the source (cerberus code, seed, dashboard, panel, or crawl scope rule).",
+  "exclusions": []
+}

--- a/test/e2e/playwright/crawl/grafana-surface-inventory.json
+++ b/test/e2e/playwright/crawl/grafana-surface-inventory.json
@@ -1,0 +1,106 @@
+{
+  "doc": "Pinned canonical Grafana surface set for the compose stack, emitted by test/e2e/playwright/crawl/crawl.spec.ts. lean=true rows are the per-PR crawl (root + nav + one representative per drilldown app); every row is crawled nightly. Regenerate deliberately against a healthy compose stack with: CERBERUS_UPDATE_INVENTORY=1 SWEEP_DEPTH=full CRAWL_STACK=compose npx playwright test crawl/crawl.spec.ts",
+  "stack": "compose",
+  "surfaces": [
+    {
+      "url": "/",
+      "lean": true
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore",
+      "lean": true
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore",
+      "lean": true
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/label/detected_level",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/label/service_name",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/logs",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/patterns",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-metricsdrilldown-app/drilldown",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-metricsdrilldown-app/trail",
+      "lean": true
+    },
+    {
+      "url": "/a/grafana-pyroscope-app/explore",
+      "lean": false
+    },
+    {
+      "url": "/d/cerberus-self",
+      "lean": false
+    },
+    {
+      "url": "/d/clickhouse-observability",
+      "lean": false
+    },
+    {
+      "url": "/d/host-observability",
+      "lean": false
+    },
+    {
+      "url": "/d/otelcol-observability",
+      "lean": false
+    },
+    {
+      "url": "/d/showcase-logql",
+      "lean": false
+    },
+    {
+      "url": "/d/showcase-promql",
+      "lean": false
+    },
+    {
+      "url": "/d/showcase-traceql",
+      "lean": false
+    },
+    {
+      "url": "/dashboards",
+      "lean": true
+    },
+    {
+      "url": "/dashboards/f/{folder}/cerberus",
+      "lean": false
+    },
+    {
+      "url": "/dashboards/f/{folder}/cerberus/alerting",
+      "lean": false
+    },
+    {
+      "url": "/dashboards/f/{folder}/cerberus/library-panels",
+      "lean": false
+    },
+    {
+      "url": "/drilldown",
+      "lean": true
+    },
+    {
+      "url": "/explore",
+      "lean": true
+    }
+  ]
+}

--- a/test/e2e/playwright/crawl/grafana-surface-inventory.json
+++ b/test/e2e/playwright/crawl/grafana-surface-inventory.json
@@ -19,11 +19,7 @@
       "lean": false
     },
     {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/label/detected_level",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/label/service_name",
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/label/{label}",
       "lean": false
     },
     {
@@ -83,15 +79,15 @@
       "lean": true
     },
     {
-      "url": "/dashboards/f/{folder}/cerberus",
+      "url": "/dashboards/f/{folder}",
       "lean": false
     },
     {
-      "url": "/dashboards/f/{folder}/cerberus/alerting",
+      "url": "/dashboards/f/{folder}/alerting",
       "lean": false
     },
     {
-      "url": "/dashboards/f/{folder}/cerberus/library-panels",
+      "url": "/dashboards/f/{folder}/library-panels",
       "lean": false
     },
     {

--- a/test/e2e/playwright/crawl/lib.ts
+++ b/test/e2e/playwright/crawl/lib.ts
@@ -1,0 +1,534 @@
+/**
+ * Grafana surface-crawler library.
+ *
+ * The crawler (crawl.spec.ts) BFS-walks the live Grafana UI from the
+ * root page, harvesting same-origin links per page, and applies the
+ * same universal oracle set on EVERY visited page. This module holds
+ * the deterministic plumbing — URL canonicalization, scope
+ * exclusions, the surface-inventory file format — so the spec stays a
+ * thin driver and the rules are unit-pinnable.
+ *
+ * Why a crawler on top of the enumerated iterate-* specs: an off-CI
+ * AI screenshot sweep (2026-06-09) found 34 unique error signatures
+ * across 55 BFS-visited pages — several on surfaces NO enumerated
+ * spec visits (drilldown-app tabs, logs-drilldown service pages,
+ * traces-drilldown comparison view). Every find decomposed into a
+ * deterministic signal once named; the crawler carries those signals
+ * in CI forever, and the committed surface inventory
+ * (grafana-surface-inventory.json) makes coverage growth explicit
+ * and shrink impossible.
+ *
+ * Determinism: the visited-set converges because canonicalization
+ * strips volatile params (time ranges, session-state blobs) and
+ * parameterizes dynamic path segments (service names, trace ids).
+ * Two crawls of the same provisioned stack + pinned Grafana version
+ * yield the same canonical set.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { Page } from '@playwright/test';
+
+// ---------------------------------------------------------------------------
+// Scope exclusions
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical paths the crawler never navigates. The crawl is strictly
+ * read-only — no mutations, no auth flows, no admin surfaces. Each
+ * exclusion family is structural (the route class can never be a
+ * cerberus consumption surface), NOT a tolerance for a failing page:
+ *
+ *   - auth flows (`/login`, `/logout`, `/signup`, `/verify`) — anonymous
+ *     auth is on in the stacks; driving auth would mutate session state.
+ *   - admin / org / user / connections / plugin-config — Grafana
+ *     management UI, no datasource traffic, write affordances.
+ *   - alerting — no cerberus alerting integration is provisioned; the
+ *     surface is Grafana-internal.
+ *   - create / edit / save routes — write affordances (`/dashboard/new`,
+ *     folder creation, panel edit). Read-only crawl.
+ *   - `/d-solo/` — the single-panel render path; per-panel render
+ *     coverage is owned by iterate-panel-kiosk.spec.ts (`?viewPanel`),
+ *     and one /d-solo link per panel would blow the page budget with
+ *     duplicate states.
+ *   - `/goto/` — short-link redirector (volatile token in the path).
+ *   - `/api/`, `/apis/`, `/public/`, `/swagger`, `/metrics` — not UI
+ *     pages; API behaviour is asserted by the response capture on the
+ *     pages that call them.
+ */
+export const EXCLUDED_PATH_PATTERNS: ReadonlyArray<RegExp> = [
+  /^\/login(\/|$)/,
+  /^\/logout(\/|$)/,
+  /^\/signup(\/|$)/,
+  /^\/verify(\/|$)/,
+  /^\/user(\/|$)/,
+  /^\/profile(\/|$)/,
+  /^\/admin(\/|$)/,
+  /^\/org(\/|$)/,
+  /^\/connections(\/|$)/,
+  /^\/plugins(\/|$)/,
+  /^\/alerting(\/|$)/,
+  /^\/a\/grafana-easystart-app(\/|$)/, // "connect data" onboarding app — write affordances
+  /^\/dashboard\/new(\/|$)/,
+  /^\/dashboard\/import(\/|$)/,
+  /^\/dashboards\/folder\/new(\/|$)/,
+  /^\/d-solo\//,
+  /^\/goto\//,
+  /^\/api(s)?\//,
+  /^\/public\//,
+  /^\/swagger(\/|$)/,
+  /^\/metrics(\/|$)/,
+  /^\/playlists(\/|$)/, // playlist play mutates view state on a timer
+  /\/edit(\/|$)/,
+  /\/new$/,
+];
+
+/**
+ * Bare `/a/<app-id>` paths are client-side REDIRECTORS into each
+ * app's entry route — Grafana's app loader boots the plugin and
+ * immediately replaces the URL (verified live: both paths land on
+ * the identical entry URL). They alias to the entry route so the
+ * crawl visits each app exactly once.
+ *
+ * Why this matters beyond dedupe: the grafana-exploretraces-app
+ * RE-ENTRY boot (second mount in one browser context) restores its
+ * persisted filter state with an empty primary-signal and fires the
+ * malformed TraceQL `{ && true}` — which reference Tempo 2.7 rejects
+ * with the byte-identical "syntax error: unexpected &&" 400 cerberus
+ * returns (verified against grafana/tempo:2.7.1; the upstream
+ * tempo parser rejects it at parse stage). An upstream app-state
+ * bug, not a cerberus surface — collapsing the redirector onto the
+ * entry route keeps the crawl to one deterministic boot per app, the
+ * same posture iterate-drilldown-apps.spec.ts takes (one fresh-page
+ * visit per catalogue entry).
+ */
+export const APP_BARE_PATH_ALIASES: ReadonlyMap<string, string> = new Map([
+  ['/a/grafana-lokiexplore-app', '/a/grafana-lokiexplore-app/explore'],
+  ['/a/grafana-exploretraces-app', '/a/grafana-exploretraces-app/explore'],
+  ['/a/grafana-metricsdrilldown-app', '/a/grafana-metricsdrilldown-app/drilldown'],
+  ['/a/grafana-pyroscope-app', '/a/grafana-pyroscope-app/explore'],
+]);
+
+// ---------------------------------------------------------------------------
+// Canonicalization
+// ---------------------------------------------------------------------------
+
+/** 16+ hex chars — trace ids (32), span ids (16), short-url tokens. */
+const HEX_SEGMENT = /^[0-9a-f]{16,64}$/;
+/** UUID path segments (Grafana folder/library-panel uids are NOT UUIDs). */
+const UUID_SEGMENT =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+/**
+ * Canonicalize a harvested href against the Grafana base URL,
+ * returning both the canonical surface key and the concrete URL the
+ * crawler should navigate for it. Returns null when the URL is out
+ * of crawl scope (different origin, excluded route family, non-HTTP
+ * scheme).
+ *
+ * The canonical key is PATH-ONLY: every query param is stripped.
+ * Grafana routes surfaces by path; query strings carry volatile or
+ * session state — time windows (`from`/`to`/`refresh`), org context,
+ * kiosk / view-panel modes, Explore state blobs (`panes`/`left`/
+ * `right`), variable selections (`var-*`), and the drilldown apps'
+ * serialized UI state (`patterns`, `displayedFields`, `urlColumns`,
+ * `layout`, …). The first full crawl demonstrated why an
+ * param-retention list can't work: the logs-drilldown service page
+ * alone produced four param-permutations of one surface. A state of
+ * a surface is not a new surface.
+ *
+ * Path rules, in order:
+ *   1. Same-origin only; hash dropped.
+ *   2. Excluded route families → null (checked on the RAW path,
+ *      before any rewriting, so `/d/<uid>/edit` can't slip past via
+ *      the slug-drop; and re-checked after, so no rewrite can map
+ *      into an excluded family).
+ *   3. `/explore...` collapses to `/explore` — every Explore
+ *      permutation is one surface.
+ *   4. Bare `/a/<app-id>` redirector paths alias to the app's entry
+ *      route (see APP_BARE_PATH_ALIASES) — the concrete URL becomes
+ *      the entry route too.
+ *   5. `/d/<uid>/<slug>` drops the cosmetic slug → `/d/<uid>`.
+ *   6. Dynamic path segments parameterize (the canonical is a
+ *      surface FAMILY; the concrete first-seen instance is what the
+ *      crawler navigates):
+ *        - `/dashboards/f/<folder-uid>` → `{folder}` (provisioned
+ *          folder uids are minted at stack-boot time — pinning a
+ *          concrete one would break the inventory on every rebuild);
+ *        - the segment after `service` (logs-drilldown service
+ *          pages) → `{service}`;
+ *        - 16+-hex and UUID segments → `{hex}` (trace / span ids).
+ */
+export function canonicalTarget(
+  href: string,
+  baseURL: string,
+): { canonical: string; concrete: string } | null {
+  let url: URL;
+  let base: URL;
+  try {
+    base = new URL(baseURL);
+    url = new URL(href, baseURL);
+  } catch {
+    return null;
+  }
+  if (url.origin !== base.origin) return null;
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+
+  let path = url.pathname.replace(/\/+$/, '');
+  if (path === '') path = '/';
+
+  // Exclusions on the raw path, before any rewriting.
+  for (const re of EXCLUDED_PATH_PATTERNS) {
+    if (re.test(path)) return null;
+  }
+
+  // Explore collapses wholesale — session state is not a surface.
+  if (path === '/explore' || path.startsWith('/explore/')) {
+    return { canonical: '/explore', concrete: '/explore' };
+  }
+
+  // Bare app redirector → entry route (canonical AND concrete).
+  const alias = APP_BARE_PATH_ALIASES.get(path);
+  if (alias !== undefined) {
+    return { canonical: alias, concrete: alias };
+  }
+
+  // /d/<uid>/<slug> → /d/<uid>.
+  const dashMatch = /^\/d\/([^/]+)(?:\/.*)?$/.exec(path);
+  if (dashMatch) {
+    path = `/d/${dashMatch[1]}`;
+  }
+
+  // /dashboards/f/<uid>[/<slug>][/<tab>…] → /dashboards/f/{folder}[/<tab>…].
+  // The folder uid is minted at provisioning time and the slug is the
+  // cosmetic title; harvested hrefs carry the slugged and unslugged
+  // forms interchangeably depending on which page rendered the link,
+  // so both must key one surface family or the inventory flickers.
+  const folderMatch = /^\/dashboards\/f\/([^/]+)(?:\/[^/]+)?(\/.*)?$/.exec(
+    path,
+  );
+  if (folderMatch) {
+    path = `/dashboards/f/{folder}${folderMatch[2] ?? ''}`;
+  }
+
+  // Parameterize dynamic segments.
+  const segments = path.split('/');
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i] ?? '';
+    if (HEX_SEGMENT.test(seg) || UUID_SEGMENT.test(seg)) {
+      segments[i] = '{hex}';
+      continue;
+    }
+    // Logs-drilldown service pages: the segment AFTER 'service' is the
+    // service name harvested from live data; the segment after
+    // 'label' is a label NAME from live data (the labels-tab drill).
+    // Both parameterize to one representative per route family.
+    if (i >= 1 && segments[i - 1] === 'service') {
+      segments[i] = '{service}';
+      continue;
+    }
+    if (i >= 1 && segments[i - 1] === 'label') {
+      segments[i] = '{label}';
+    }
+  }
+  path = segments.join('/');
+  if (path === '') path = '/';
+
+  // Re-check after rewriting — no rewrite may land in-scope a URL
+  // whose canonical form is excluded.
+  for (const re of EXCLUDED_PATH_PATTERNS) {
+    if (re.test(path)) return null;
+  }
+
+  // Concrete: the raw path + raw query (parameterized canonicals
+  // aren't navigable, and drilldown-app hrefs carry var-* state the
+  // page needs to boot into the linked view — navigating the
+  // logs-drilldown service page without its var-filters leaves the
+  // tab bar unmounted). Only the CANONICAL key strips the query.
+  return { canonical: path, concrete: `${url.pathname}${url.search}` };
+}
+
+/**
+ * Known sibling-route families: when the crawl discovers one member,
+ * it deterministically enqueues the rest — tab links inside scenes
+ * apps mount only after the page's first query wave resolves, so
+ * harvest-only discovery of them is timing-sensitive (run-to-run
+ * inventory flicker), while the route family itself is fixed by the
+ * pinned app version.
+ *
+ * Today: the logs-drilldown service page tabs (verified live against
+ * grafana-lokiexplore-app on grafana/grafana:12.2.9).
+ */
+export function expandSiblingTabs(
+  canonical: string,
+  concrete: string,
+): Array<{ canonical: string; concrete: string }> {
+  const m = /^(\/a\/grafana-lokiexplore-app\/explore\/service\/\{service\})\/([a-z]+)$/.exec(
+    canonical,
+  );
+  if (!m) return [];
+  const tabs = ['logs', 'labels', 'fields', 'patterns'];
+  const current = m[2] ?? '';
+  const [concretePath, concreteQuery = ''] = concrete.split('?', 2);
+  const concreteBase = (concretePath ?? '').replace(/\/[a-z]+$/, '');
+  return tabs
+    .filter((t) => t !== current)
+    .map((t) => ({
+      canonical: `${m[1]}/${t}`,
+      concrete: `${concreteBase}/${t}${concreteQuery ? `?${concreteQuery}` : ''}`,
+    }));
+}
+
+/** Canonical-only convenience wrapper (the pin tests use this). */
+export function canonicalizeURL(
+  href: string,
+  baseURL: string,
+): string | null {
+  return canonicalTarget(href, baseURL)?.canonical ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Link harvesting
+// ---------------------------------------------------------------------------
+
+/**
+ * Harvest every same-document `<a href>` currently in the DOM,
+ * returning raw href strings (canonicalization is the caller's job).
+ *
+ * Before harvesting, the helper opens Grafana's mega menu if the
+ * toggle is present — the nav tree only mounts its links while the
+ * menu is open (Grafana 12.x renders the collapsed menu without
+ * anchors). Opening the menu is a read-only UI gesture.
+ */
+export async function harvestLinks(page: Page): Promise<string[]> {
+  // Open the mega menu so nav links mount. The toggle carries
+  // aria-label "Open menu" when closed; if it's absent or already
+  // open ("Close menu"), proceed with whatever the DOM has.
+  const toggle = page.locator('[aria-label="Open menu"]').first();
+  if ((await toggle.count()) > 0) {
+    await toggle.click({ timeout: 5_000 }).catch(() => {
+      // A nav overlay can obscure the toggle on narrow layouts; links
+      // already in the DOM are still harvested below.
+    });
+    await page.waitForTimeout(300);
+  }
+  const hrefs = await page
+    .locator('a[href]')
+    .evaluateAll((nodes) =>
+      nodes
+        .map((n) => n.getAttribute('href') ?? '')
+        .filter((h) => h.length > 0),
+    );
+  return hrefs;
+}
+
+// ---------------------------------------------------------------------------
+// Page-crash banner signatures
+// ---------------------------------------------------------------------------
+
+/**
+ * Substrings on a `role="alert"` banner that classify it as an
+ * error-state surface. Mirrors ALERT_ERROR_PATTERNS in
+ * iterate-panel-kiosk.spec.ts — kept in lockstep so a banner that
+ * fails the kiosk sweep also fails the crawl.
+ */
+export const ALERT_ERROR_PATTERNS: ReadonlyArray<RegExp> = [
+  /error/i,
+  /failed/i,
+  /illegal wiretype/i,
+  /plugin\.downstream/i,
+  /unable to/i,
+];
+
+/**
+ * Read every VISIBLE `role="alert"` banner's text. The crawler can't
+ * reuse helpers/dom.ts's captureRoleAlertBanners verbatim: Grafana
+ * pre-mounts a hidden alert skeleton on some pages (`display:none;
+ * opacity:0` — e.g. an "Unknown error" toast template on /explore,
+ * found by the first crawl run) that never renders to the user.
+ * Visibility-filtering is a correctness fix for the oracle (assert
+ * what a user can see), not a tolerance: a banner that actually
+ * displays still fails the crawl.
+ */
+export async function collectVisibleAlertBanners(
+  page: Page,
+): Promise<string[]> {
+  return await page
+    .locator('[role="alert"]')
+    .evaluateAll((nodes) =>
+      nodes
+        .filter((n) =>
+          (n as HTMLElement).checkVisibility
+            ? (n as HTMLElement).checkVisibility({
+                checkOpacity: true,
+                checkVisibilityCSS: true,
+              })
+            : true,
+        )
+        .map((n) => (n.textContent ?? '').trim())
+        .filter((s) => s.length > 0),
+    );
+}
+
+/**
+ * Page-level crash signatures: React error boundaries and Grafana's
+ * top-level failure pages render one of these phrases in the body.
+ * Any visited page whose text content carries one fails the crawl
+ * loudly — these are whole-page failures, not per-panel states.
+ */
+export const PAGE_CRASH_PATTERNS: ReadonlyArray<RegExp> = [
+  /an unexpected error happened/i,
+  /application error/i,
+  /something went wrong/i,
+  /if you keep getting this error/i,
+];
+
+// ---------------------------------------------------------------------------
+// Surface inventory (the ratchet)
+// ---------------------------------------------------------------------------
+
+/**
+ * One pinned crawl surface. `url` is the canonical form produced by
+ * canonicalizeURL. `lean: true` marks the surfaces the lean (per-PR)
+ * crawl visits: the root page, the nav links harvested from it, and
+ * one representative per drilldown app. Every surface is visited at
+ * 'full' depth.
+ */
+export type InventorySurface = {
+  url: string;
+  lean: boolean;
+};
+
+export type SurfaceInventory = {
+  /** Free-text header documenting the regen convention. */
+  doc: string;
+  /** Stack the inventory pins (only the compose stack is crawled). */
+  stack: string;
+  surfaces: InventorySurface[];
+};
+
+export type SurfaceExclusion = {
+  url: string;
+  rationale: string;
+};
+
+export type SurfaceExclusions = {
+  doc: string;
+  exclusions: SurfaceExclusion[];
+};
+
+export const INVENTORY_FILENAME = 'grafana-surface-inventory.json';
+export const EXCLUSIONS_FILENAME = 'grafana-surface-exclusions.json';
+
+export function inventoryPath(): string {
+  return join(__dirname, INVENTORY_FILENAME);
+}
+
+export function exclusionsPath(): string {
+  return join(__dirname, EXCLUSIONS_FILENAME);
+}
+
+export function loadInventory(): SurfaceInventory {
+  const raw = readFileSync(inventoryPath(), 'utf8');
+  const parsed = JSON.parse(raw) as SurfaceInventory;
+  if (!Array.isArray(parsed.surfaces)) {
+    throw new Error(
+      `loadInventory: ${INVENTORY_FILENAME} has no surfaces[] array`,
+    );
+  }
+  return parsed;
+}
+
+export function loadExclusions(): SurfaceExclusions {
+  const raw = readFileSync(exclusionsPath(), 'utf8');
+  const parsed = JSON.parse(raw) as SurfaceExclusions;
+  if (!Array.isArray(parsed.exclusions)) {
+    throw new Error(
+      `loadExclusions: ${EXCLUSIONS_FILENAME} has no exclusions[] array`,
+    );
+  }
+  return parsed;
+}
+
+/**
+ * Render the canonical serialized form of an inventory — sorted by
+ * URL, two-space indent, trailing newline — so regeneration is
+ * byte-for-byte reproducible (mirrors test/inventory/'s
+ * MarshalInventory convention).
+ */
+export function marshalInventory(inv: SurfaceInventory): string {
+  const sorted = [...inv.surfaces].sort((a, b) => a.url.localeCompare(b.url));
+  return `${JSON.stringify({ doc: inv.doc, stack: inv.stack, surfaces: sorted }, null, 2)}\n`;
+}
+
+/**
+ * Compare a crawl's visited set against the committed inventory for
+ * the active depth. Returns human-readable violations (empty = the
+ * ratchet holds):
+ *
+ *   - a visited surface missing from the inventory → coverage GREW
+ *     (e.g. a Grafana bump added an app page); regenerate the
+ *     inventory deliberately via CERBERUS_UPDATE_INVENTORY=1.
+ *   - an inventory surface (for this depth) the crawl didn't visit →
+ *     coverage SHRANK; that is a regression to fix, never a row to
+ *     delete silently.
+ *   - a surface listed in both the inventory and the exclusions file
+ *     → stale exclusion.
+ *   - an exclusion without a rationale → unsound exclusion.
+ */
+export function diffInventory(
+  visited: ReadonlySet<string>,
+  inventory: SurfaceInventory,
+  exclusions: SurfaceExclusions,
+  depth: 'lean' | 'full',
+): string[] {
+  const out: string[] = [];
+
+  const excluded = new Set<string>();
+  for (const e of exclusions.exclusions) {
+    if (!e.rationale || e.rationale.trim() === '') {
+      out.push(
+        `exclusion ${JSON.stringify(e.url)} has no rationale — every exclusion must document why the surface is genuinely uncrawlable`,
+      );
+    }
+    if (excluded.has(e.url)) {
+      out.push(`exclusion ${JSON.stringify(e.url)} is listed twice`);
+    }
+    excluded.add(e.url);
+  }
+
+  const expected = new Set<string>();
+  for (const s of inventory.surfaces) {
+    if (excluded.has(s.url)) {
+      out.push(
+        `surface ${JSON.stringify(s.url)} is in BOTH the inventory and the exclusions file — a crawled surface cannot be excluded (stale exclusion)`,
+      );
+    }
+    if (depth === 'full' || s.lean) expected.add(s.url);
+  }
+
+  for (const url of [...visited].sort()) {
+    if (!expected.has(url)) {
+      out.push(
+        `NEW surface ${JSON.stringify(url)} visited but not pinned in ${INVENTORY_FILENAME} — coverage grew; regenerate deliberately with CERBERUS_UPDATE_INVENTORY=1 SWEEP_DEPTH=full`,
+      );
+    }
+  }
+  for (const url of [...expected].sort()) {
+    if (!visited.has(url)) {
+      out.push(
+        `pinned surface ${JSON.stringify(url)} (${depth} set) was NOT visited — coverage shrank; fix the crawl/stack regression, never delete the row to make this pass`,
+      );
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Misc
+// ---------------------------------------------------------------------------
+
+export function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return `${s.slice(0, max)}…<truncated, ${s.length - max} more char(s)>`;
+}

--- a/test/e2e/playwright/crawl/lints.spec.ts
+++ b/test/e2e/playwright/crawl/lints.spec.ts
@@ -56,6 +56,7 @@ import {
 } from '@playwright/test';
 
 import {
+  awaitSelfTelemetryRangeSignal,
   generateSelfTraffic,
   iterateDashboards,
   type Dashboard,
@@ -171,6 +172,11 @@ test('lints: histogram families behind quantile panels are non-degenerate + mult
   testInfo.setTimeout(5 * 60_000);
 
   await generateSelfTraffic(request, SEED_TRAFFIC_SECONDS);
+  // Both lints judge rate()-over-range shapes; on a freshly-booted
+  // stack the telemetry export cadence can lag the seed traffic (see
+  // awaitSelfTelemetryRangeSignal). The bounded wait keeps the
+  // judged-input assertions below honest without a boot race.
+  await awaitSelfTelemetryRangeSignal(request);
 
   const dashboards = await iterateDashboards(request, baseURL());
   const failures: string[] = [];
@@ -185,6 +191,7 @@ test('lints: histogram families behind quantile panels are non-degenerate + mult
     'at least one provisioned quantile panel consumes a classic histogram family',
   ).toBeGreaterThan(0);
 
+  let judgedFamilies = 0;
   for (const { dsUid, family, where } of [...families.values()].sort((a, b) =>
     `${a.dsUid}|${a.family}`.localeCompare(`${b.dsUid}|${b.family}`),
   )) {
@@ -211,11 +218,12 @@ test('lints: histogram families behind quantile panels are non-degenerate + mult
       .sort((a, b) => a.le - b.le);
     const total = buckets[buckets.length - 1]?.cumulative ?? 0;
     if (total < HISTOGRAM_COUNT_FLOOR) {
-      // Below the floor the spread carries no signal; the run-level
-      // sanity assertion below catches a seed regression that would
-      // leave EVERY family under-observed.
+      // Below the floor the spread carries no signal; the
+      // judgedFamilies assertion after this loop catches a seed
+      // regression that would leave EVERY family under-observed.
       continue;
     }
+    judgedFamilies++;
     let populated = 0;
     let prev = 0;
     for (const b of buckets) {
@@ -232,10 +240,22 @@ test('lints: histogram families behind quantile panels are non-degenerate + mult
     }
   }
 
+  // Vacuous-pass guard: lint 1 silently `continue`s on under-floor
+  // families, so without this assertion a seed/export regression that
+  // starves EVERY family would let the lint pass having judged
+  // nothing. (This assertion was claimed by the loop comment from day
+  // one but only landed with the adversarial-verification fix.)
+  expect(
+    judgedFamilies,
+    `lint 1 judged no histogram family: all ${families.size} quantile-consumed families are below ` +
+      `the ${HISTOGRAM_COUNT_FLOOR}-observation floor after seed traffic — seed/export regression`,
+  ).toBeGreaterThan(0);
+
   // -------------------------------------------------------------------------
   // Lint 2 — identical-series suspicion across multi-quantile panels.
   // -------------------------------------------------------------------------
   let multiQuantilePanels = 0;
+  let comparedPanels = 0;
   for (const d of dashboards) {
     for (const p of d.panels) {
       const quantileTargets = p.targets
@@ -277,6 +297,7 @@ test('lints: histogram families behind quantile panels are non-degenerate + mult
         );
       }
       if (!allNonEmpty || canonicalSets.length < 2) continue;
+      comparedPanels++;
       const first = canonicalSets[0];
       if (canonicalSets.every((c) => c === first)) {
         failures.push(
@@ -292,6 +313,16 @@ test('lints: histogram families behind quantile panels are non-degenerate + mult
   expect(
     multiQuantilePanels,
     'at least one provisioned panel carries ≥2 distinct histogram_quantile targets (lint 2 has real input)',
+  ).toBeGreaterThan(0);
+  // Vacuous-pass guard, same shape as lint 1's: empty matrices make
+  // lint 2 `continue` (iterate-all-dashboards owns the nonempty
+  // contract — no double-report), so a regression emptying every
+  // multi-quantile panel would otherwise let the lint pass having
+  // compared nothing.
+  expect(
+    comparedPanels,
+    `lint 2 compared no panel: all ${multiQuantilePanels} multi-quantile panel(s) returned ≥1 empty ` +
+      `matrix over the probe window — the underlying series are gone (seed/export/query regression)`,
   ).toBeGreaterThan(0);
 
   if (failures.length > 0) {

--- a/test/e2e/playwright/crawl/lints.spec.ts
+++ b/test/e2e/playwright/crawl/lints.spec.ts
@@ -1,0 +1,302 @@
+/**
+ * Data-quality lints — API-level, deterministic.
+ *
+ * Each lint pins a bug CLASS the 2026-06-09 AI sweep found on the
+ * live stack as a deterministic check. The doctrine: the AI sweep's
+ * job is to DISCOVER new oracle classes off-CI; once a find is named,
+ * its deterministic version lands here and CI carries it forever.
+ *
+ * Lint 1 — histogram degeneracy. Incident: cerberus's own
+ * query-duration histogram shipped with default millisecond-scaled
+ * bucket boundaries while observations were recorded in seconds, so
+ * EVERY observation landed in a single bucket and
+ * histogram_quantile() fabricated a constant 4.75s p95 (the
+ * interpolation midpoint of the one populated bucket) regardless of
+ * real latency. Deterministic signal: for every histogram family a
+ * provisioned quantile panel consumes, once the family has a
+ * meaningful observation count, the observations must span more than
+ * one bucket. The lint is scoped to quantile-CONSUMED families on
+ * purpose: a histogram nobody quantiles can be legitimately
+ * single-bucket (e.g. http_server_request_body_size on a stack whose
+ * seed traffic is all GET requests — every body is 0 bytes), so an
+ * all-families rule would either false-positive or grow an exclusion
+ * list; scoping to the families that feed histogram_quantile panels
+ * keeps the rule honest and exclusion-free.
+ *
+ * Lint 2 — identical-series suspicion. Same incident, second
+ * signature: with all observations in one bucket, the p50 and p95
+ * targets of the same panel family returned BITWISE-IDENTICAL series
+ * (interpolation collapses to the same midpoint for every quantile).
+ * Deterministic signal: a panel with ≥2 histogram_quantile targets
+ * (distinct quantile parameters) whose result sets are bitwise
+ * identical over the probe window fails.
+ *
+ * NOT duplicated here: catalog↔query consistency (every advertised
+ * __name__ is queryable) and metadata↔storage type consistency are
+ * already pinned at the Go layer by the tests landed with PRs #765
+ * and #768 — this file only carries the lint classes that need live
+ * Grafana-shaped traffic.
+ *
+ * Adding a lint when a new bug class is found: name the deterministic
+ * signal in a comment (cite the incident), implement it against the
+ * datasource-proxy API, and aggregate violations into the failures[]
+ * array — never per-lint tolerance lists; if a lint can't be made
+ * deterministic without one, its scope is wrong (see lint 1's
+ * dashboard-scoping for the pattern).
+ *
+ * Env:
+ *   GRAFANA_URL / GRAFANA_BASE_URL   default http://localhost:3000
+ *   CERBERUS_URL                     default http://localhost:8080
+ */
+
+import {
+  expect,
+  test,
+  type APIRequestContext,
+} from '@playwright/test';
+
+import {
+  generateSelfTraffic,
+  iterateDashboards,
+  type Dashboard,
+} from '../helpers/index.js';
+import { truncate } from './lib.js';
+
+const SEED_TRAFFIC_SECONDS = 30;
+
+// Minimum total observation count before lint 1 judges a family.
+// Below the floor the bucket spread carries no signal (a family with
+// 3 observations can legitimately sit in one bucket); the seed
+// traffic drives every quantile-consumed family well past it.
+const HISTOGRAM_COUNT_FLOOR = 10;
+
+const QUERY_WINDOW_SECONDS = 5 * 60;
+const QUERY_STEP_SECONDS = 15;
+
+function baseURL(): string {
+  return (
+    process.env.GRAFANA_URL ??
+    process.env.GRAFANA_BASE_URL ??
+    'http://localhost:3000'
+  );
+}
+
+type PromVector = Array<{
+  metric: Record<string, string>;
+  value: [number, string];
+}>;
+
+type PromMatrix = Array<{
+  metric: Record<string, string>;
+  values: Array<[number, string]>;
+}>;
+
+async function promInstant(
+  request: APIRequestContext,
+  dsUid: string,
+  query: string,
+): Promise<PromVector> {
+  const url =
+    `${baseURL()}/api/datasources/proxy/uid/${dsUid}/api/v1/query` +
+    `?query=${encodeURIComponent(query)}`;
+  const resp = await request.get(url);
+  expect(resp.status(), `GET ${url}`).toBe(200);
+  const body = (await resp.json()) as {
+    status?: string;
+    data?: { result?: PromVector };
+  };
+  expect(body.status, `prom envelope status for ${query}`).toBe('success');
+  return body.data?.result ?? [];
+}
+
+async function promRange(
+  request: APIRequestContext,
+  dsUid: string,
+  query: string,
+  nowSec: number,
+): Promise<PromMatrix> {
+  const url =
+    `${baseURL()}/api/datasources/proxy/uid/${dsUid}/api/v1/query_range` +
+    `?query=${encodeURIComponent(query)}` +
+    `&start=${nowSec - QUERY_WINDOW_SECONDS}&end=${nowSec}&step=${QUERY_STEP_SECONDS}`;
+  const resp = await request.get(url);
+  expect(resp.status(), `GET ${url}`).toBe(200);
+  const body = (await resp.json()) as {
+    status?: string;
+    data?: { result?: PromMatrix };
+  };
+  expect(body.status, `prom envelope status for ${query}`).toBe('success');
+  return body.data?.result ?? [];
+}
+
+/**
+ * Histogram families consumed by histogram_quantile(...) panel
+ * targets, with the prometheus datasource uid each panel queries
+ * through, keyed `<dsUid>|<family>`. Extraction matches the classic
+ * `<family>_bucket` token inside a histogram_quantile call — native
+ * (bucket-less) histogram quantiles have no classic bucket family to
+ * lint and are exercised by their own showcase fixtures.
+ */
+function quantileConsumedFamilies(
+  dashboards: Dashboard[],
+): Map<string, { dsUid: string; family: string; where: string }> {
+  const out = new Map<string, { dsUid: string; family: string; where: string }>();
+  for (const d of dashboards) {
+    for (const p of d.panels) {
+      for (const t of p.targets) {
+        const expr = (t.expr ?? t.query ?? '').trim();
+        if (!expr.includes('histogram_quantile')) continue;
+        const dsUid = t.datasource?.uid ?? p.datasource?.uid ?? '';
+        if (dsUid === '') continue;
+        for (const m of expr.matchAll(
+          /([a-zA-Z_:][a-zA-Z0-9_:]*)_bucket/g,
+        )) {
+          const family = m[1] ?? '';
+          if (family === '') continue;
+          out.set(`${dsUid}|${family}`, {
+            dsUid,
+            family,
+            where: `${d.uid} :: ${p.title}`,
+          });
+        }
+      }
+    }
+  }
+  return out;
+}
+
+test('lints: histogram families behind quantile panels are non-degenerate + multi-quantile panels differ', async ({
+  request,
+}, testInfo) => {
+  testInfo.setTimeout(5 * 60_000);
+
+  await generateSelfTraffic(request, SEED_TRAFFIC_SECONDS);
+
+  const dashboards = await iterateDashboards(request, baseURL());
+  const failures: string[] = [];
+  const nowSec = Math.floor(Date.now() / 1000);
+
+  // -------------------------------------------------------------------------
+  // Lint 1 — histogram degeneracy on quantile-consumed families.
+  // -------------------------------------------------------------------------
+  const families = quantileConsumedFamilies(dashboards);
+  expect(
+    families.size,
+    'at least one provisioned quantile panel consumes a classic histogram family',
+  ).toBeGreaterThan(0);
+
+  for (const { dsUid, family, where } of [...families.values()].sort((a, b) =>
+    `${a.dsUid}|${a.family}`.localeCompare(`${b.dsUid}|${b.family}`),
+  )) {
+    const vector = await promInstant(
+      request,
+      dsUid,
+      `sum by (le) (${family}_bucket)`,
+    );
+    if (vector.length === 0) {
+      failures.push(
+        `[lint:histogram-degeneracy] ${family}: quantile panel (${where}) consumes a family ` +
+          `with NO bucket series on the wire — the panel is quantiling nothing`,
+      );
+      continue;
+    }
+    const buckets = vector
+      .map((s) => ({
+        le:
+          s.metric.le === '+Inf' || s.metric.le === 'Inf'
+            ? Number.POSITIVE_INFINITY
+            : Number(s.metric.le),
+        cumulative: Number(s.value[1]),
+      }))
+      .sort((a, b) => a.le - b.le);
+    const total = buckets[buckets.length - 1]?.cumulative ?? 0;
+    if (total < HISTOGRAM_COUNT_FLOOR) {
+      // Below the floor the spread carries no signal; the run-level
+      // sanity assertion below catches a seed regression that would
+      // leave EVERY family under-observed.
+      continue;
+    }
+    let populated = 0;
+    let prev = 0;
+    for (const b of buckets) {
+      if (b.cumulative - prev > 0) populated++;
+      prev = b.cumulative;
+    }
+    if (populated <= 1) {
+      failures.push(
+        `[lint:histogram-degeneracy] ${family} (panel: ${where}): all ${total} observations ` +
+          `landed in a single bucket (of ${buckets.length}) — bucket boundaries don't match the ` +
+          `observed value scale (the ms-default-buckets fabricated-p95 incident class); fix the ` +
+          `instrument's bucket boundaries or the recorded unit at the source`,
+      );
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Lint 2 — identical-series suspicion across multi-quantile panels.
+  // -------------------------------------------------------------------------
+  let multiQuantilePanels = 0;
+  for (const d of dashboards) {
+    for (const p of d.panels) {
+      const quantileTargets = p.targets
+        .map((t) => ({
+          expr: (t.expr ?? t.query ?? '').trim(),
+          dsUid: t.datasource?.uid ?? p.datasource?.uid ?? '',
+        }))
+        .filter((t) => /histogram_quantile\s*\(/.test(t.expr));
+      const distinctExprs = new Set(quantileTargets.map((t) => t.expr));
+      if (distinctExprs.size < 2) continue;
+      multiQuantilePanels++;
+
+      const canonicalSets: string[] = [];
+      let allNonEmpty = true;
+      for (const t of quantileTargets) {
+        const matrix = await promRange(request, t.dsUid, t.expr, nowSec);
+        if (matrix.length === 0) {
+          // The bidirectional nonempty contract on this panel is
+          // enforced by iterate-all-dashboards; an empty result here
+          // means that gate is already failing — don't double-report.
+          allNonEmpty = false;
+          continue;
+        }
+        canonicalSets.push(
+          JSON.stringify(
+            matrix
+              .map((s) => ({
+                metric: Object.fromEntries(
+                  Object.entries(s.metric).sort(([a], [b]) =>
+                    a.localeCompare(b),
+                  ),
+                ),
+                values: s.values.map(([, v]) => v),
+              }))
+              .sort((a, b) =>
+                JSON.stringify(a.metric).localeCompare(JSON.stringify(b.metric)),
+              ),
+          ),
+        );
+      }
+      if (!allNonEmpty || canonicalSets.length < 2) continue;
+      const first = canonicalSets[0];
+      if (canonicalSets.every((c) => c === first)) {
+        failures.push(
+          `[lint:identical-quantile-series] ${d.uid} :: ${p.title}: all ${canonicalSets.length} ` +
+            `histogram_quantile targets returned bitwise-identical series over the ${QUERY_WINDOW_SECONDS}s ` +
+            `window — distinct quantiles collapsing to one value is the single-populated-bucket ` +
+            `signature (fabricated-quantile incident class). Targets:\n` +
+            quantileTargets.map((t) => `    - ${truncate(t.expr, 200)}`).join('\n'),
+        );
+      }
+    }
+  }
+  expect(
+    multiQuantilePanels,
+    'at least one provisioned panel carries ≥2 distinct histogram_quantile targets (lint 2 has real input)',
+  ).toBeGreaterThan(0);
+
+  if (failures.length > 0) {
+    throw new Error(
+      `data-quality lints violated (${failures.length}):\n\n${failures.join('\n\n')}`,
+    );
+  }
+});

--- a/test/e2e/playwright/helpers/sweep.ts
+++ b/test/e2e/playwright/helpers/sweep.ts
@@ -163,3 +163,72 @@ export async function generateSelfTraffic(
     await new Promise((r) => setTimeout(r, 250));
   }
 }
+
+/**
+ * Block until cerberus's own self-telemetry supports rate()-over-range
+ * queries, or throw after `deadlineSec`.
+ *
+ * Why generateSelfTraffic alone is not enough: it guarantees REQUESTS
+ * happened, but the metrics they tick reach ClickHouse on the OTel
+ * export cadence — and `rate(x[5m])` needs at least TWO exported
+ * samples inside the lookback window before it yields a single point.
+ * On a freshly-booted compose stack (the exact state the compose-smoke
+ * CI job creates: `docker compose up --wait` then straight into
+ * Playwright) the first range probe can land when only one sample
+ * exists, and a range query over guaranteed-seeded traffic comes back
+ * EMPTY — adversarial verification on 2026-06-10 reproduced exactly
+ * that red on a healthy stack at ~2min uptime.
+ *
+ * The wait polls cerberus DIRECTLY (not through Grafana) on purpose:
+ * it isolates "the data exists on the wire" from "the consumer decodes
+ * it", so the caller's plugin-backend / lint assertions stay
+ * unconditional — once this returns, an empty frame set or a vacuous
+ * lint pass is a real bug, never a boot race. The deadline failure is
+ * loud and actionable (a seed/export regression), never a skip.
+ */
+export async function awaitSelfTelemetryRangeSignal(
+  request: APIRequestContext,
+  deadlineSec = 120,
+): Promise<void> {
+  const cerberusURL = process.env.CERBERUS_URL ?? DEFAULT_CERBERUS_URL;
+  const expr = 'sum(rate(cerberus_queries_total[5m]))';
+  const deadline = Date.now() + deadlineSec * 1000;
+  let lastBody = '';
+  for (;;) {
+    // The probe window deliberately ends 30s in the PAST and demands
+    // >=3 points: Grafana's Prometheus plugin backend step-aligns the
+    // replay window, which can exclude the single newest evaluation
+    // step — a probe satisfied by one fresh point green-lit a replay
+    // that still saw zero rows (reproduced on the 2026-06-10
+    // cold-boot verification). Requiring margin makes "probe passed"
+    // imply "any consumer window over the same range has data".
+    const nowSec = Math.floor(Date.now() / 1000) - 30;
+    const url =
+      `${cerberusURL}/api/v1/query_range?query=${encodeURIComponent(expr)}` +
+      `&start=${nowSec - 300}&end=${nowSec}&step=15`;
+    try {
+      const resp = await request.get(url);
+      lastBody = await resp.text();
+      if (resp.status() === 200) {
+        const parsed = JSON.parse(lastBody) as {
+          data?: { result?: Array<{ values?: unknown[] }> };
+        };
+        const points = (parsed.data?.result ?? []).reduce(
+          (acc, s) => acc + (s.values?.length ?? 0),
+          0,
+        );
+        if (points >= 3) return;
+      }
+    } catch {
+      // transient — the deadline below is the failure path
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `awaitSelfTelemetryRangeSignal: ${expr} returned <3 points within ${deadlineSec}s of seed traffic — ` +
+          `cerberus self-telemetry is not reaching ClickHouse (seed, OTel export, or ingest regression). ` +
+          `Last response: ${lastBody.slice(0, 400)}`,
+      );
+    }
+    await new Promise((r) => setTimeout(r, 5_000));
+  }
+}

--- a/test/e2e/playwright/playwright.config.ts
+++ b/test/e2e/playwright/playwright.config.ts
@@ -15,6 +15,16 @@ const grafanaURL = process.env.GRAFANA_URL ?? 'http://localhost:3000';
 
 export default defineConfig({
   testDir: '.',
+  // The crawl suite (crawl/**) pins the COMPOSE stack's surface
+  // inventory (crawl/grafana-surface-inventory.json) — running it
+  // against the k3d stack would diff a different provisioned surface
+  // set against the compose pin and fail on coverage, not on bugs.
+  // The compose-smoke job opts in with CRAWL_STACK=compose; the k3d
+  // dashboard job (plain `npx playwright test` auto-discovery) leaves
+  // the env unset and keeps its existing iterate-* coverage. This is
+  // lane targeting (which stack a suite asserts against), not failure
+  // masking — the crawl rules run unchanged wherever the suite runs.
+  testIgnore: process.env.CRAWL_STACK === 'compose' ? [] : ['crawl/**'],
   timeout: 60_000,
   expect: { timeout: 10_000 },
   fullyParallel: true,


### PR DESCRIPTION
## Summary

The CI-runnable Grafana crawler (traversal program P4/P5): a deterministic, no-AI version of the screenshot-based sweep that found 6 real bug classes tonight. BFS-visits every Grafana surface and applies a universal oracle library — the AI sweep's role is reduced to discovering *new* oracle classes off-CI; CI runs the accumulated deterministic versions forever (doctrine documented in `docs/test-strategy.md`).

## What's in the box (`test/e2e/playwright/crawl/`)

- **`lib.ts`** — BFS engine: URL canonicalization (path-only keys; `{service}`/`{label}`/`{hex}`/`{folder}` parameterization; `/explore` collapse; bare `/a/<app-id>` redirector aliases), read-only scope exclusions (auth/admin/alerting/edit/new/d-solo/goto), mega-menu link harvest, inventory load/marshal/diff.
- **`crawl.spec.ts`** — the crawler + 4 universal per-page oracles: zero console errors (**no noise filter**); zero non-2xx + zero tunneled errors on datasource API families (sanctioned only by in-panel `cerberus.expect: error:*` contracts matched against ds/query request bodies); panel tri-state has-data | declared-empty | declared-error; page-crash/role-alert banners. Plus canonicalization pins and the inventory consistency pins.
- **`dsquery.spec.ts`** — consumer-grade `POST /api/ds/query` plugin-backend replays per datasource (prom instant+range, loki stream+metric, tempo trace-by-id with `queryType: traceId`) — the layer where two of tonight's bugs were invisible to proxy-level checks.
- **`lints.spec.ts`** — histogram-degeneracy (scoped to quantile-consumed families) + identical-quantile-series, each citing tonight's incident; catalog/metadata consistency deliberately delegated to the #765/#768 Go ratchets.
- **`grafana-surface-inventory.json`** — 24 pinned surfaces (7 lean); new surfaces fail CI until inventoried (`CERBERUS_UPDATE_INVENTORY=1` regen), shrink impossible; exclusions file empty with rationale header.
- **CI**: crawl specs join the PR-gating `compose-smoke` list under `CRAWL_STACK=compose`; full lane rides the nightly `SWEEP_DEPTH=full` switch; `testIgnore` keeps the k3d job's auto-discovery out. actionlint clean.

## Adversarial verification (second agent, fault-injection against a live stack)

- Nonexistent metric in a dashboard → tri-state oracle fails naming panel + URL ✓ (the admit-counter class, PR-gated at lean)
- Single-bucket histogram pointed at a quantile panel → degeneracy lint fails with bucket census ✓ (the 4.75s-p95 class)
- Bogus trace id through ds/query → loud failure ✓ (the v2-envelope class)
- Inventory row deleted → ratchet fails ✓; regen twice → byte-stable ✓; no `CRAWL_STACK` → 0 tests discovered ✓
- Two trust fixes pushed by the verifier: a self-telemetry range-signal gate (prom-range replay was red on a cold stack — `rate([5m])` needs ≥3 exported points; deadline expiry throws loudly) and vacuity guards on both lints (`judgedFamilies > 0` / `comparedPanels > 0`).
- Escape-hatch scan clean: no expect.soft, no tolerance lists, no console noise filters.

**Runtimes**: lean 47 s wall-clock, full 2.9 min, dsquery+lints 31 s. Two consecutive full crawls produced identical surface sets.

## Known residual gaps (documented in code)

Wrong-but-200 row sets aren't caught at the browser layer (that's the Go ratchets' job); tunneled-error oracle skips streamed bodies; inventory pins the compose stack only — the stack-agnostic generalization (one engine, per-stack configs/inventories, k3d as second consumer) is the next phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
