### PR TITLE
fix(loki): serve detected_fields bare per upstream + structured-metadata field derivation

### DIFF
--- a/compatibility/loki/README.md
+++ b/compatibility/loki/README.md
@@ -133,6 +133,29 @@ that lives OUTSIDE the AGPL `upstream/` boundary:
   `${SELECTOR}` / `${LABEL_NAME}` / `${LABEL_VALUE}` template vars to
   concrete values produced by the seeder under `cmd/seed/`.
 
+## Detected-fields differential pass
+
+Beyond the query corpus, the driver runs a per-service differential
+over `GET /loki/api/v1/detected_fields` (range lane only — the
+endpoint has no instant flavour). Grafana's Logs Drilldown drives
+every service page off this endpoint and reads `body.fields` at the
+top level — upstream serializes `logproto.DetectedFieldsResponse`
+BARE (no `{status, data}` envelope), so a 200 with the wrong shape
+renders "Fields: 0" while every status-code probe stays green. The
+pass decodes both backends' responses exactly as the consumer does
+and diffs the field sets — label, type, cardinality, parsers, and
+jsonPath all participate. Results join the same report + score
+pipeline as the corpus cases; there is no separate bucket and no
+allow-list.
+
+Comparability is held by the seeder: the CH `LogAttributes` map
+carries the same key set `pushLoki` sends as structured metadata
+(`detected_level`), and both backends compile the same
+`axiomhq/hyperloglog` version, so cardinality estimates are
+bit-identical when both sides observed the same values. The pass
+queries with a `line_limit` above the per-service row count so
+neither backend truncates the peek window.
+
 ## Upstream-skip baseline
 
 The vendored corpus contains ~15 queries upstream marks `skip: true`

--- a/compatibility/loki/cmd/loki-compliance-tester/detected_fields.go
+++ b/compatibility/loki/cmd/loki-compliance-tester/detected_fields.go
@@ -1,0 +1,259 @@
+package main
+
+// Differential pass for GET /loki/api/v1/detected_fields.
+//
+// The bench corpus only exercises /query + /query_range, but Grafana's
+// Logs Drilldown drives every service page off /detected_fields — a
+// 200 with the wrong shape (or wrong field semantics) renders
+// "Fields: 0" while every status-code oracle stays green. This pass
+// closes that gap: for every seeded service it requests the endpoint
+// from both backends, decodes the BARE top-level wire shape exactly as
+// the consumer does, and diffs the field sets — label, type,
+// cardinality, parsers, and jsonPath all participate. No allow-list:
+// any divergence from reference Loki is a real cerberus bug.
+//
+// Comparability contract (held by the seeder, see cmd/seed/main.go):
+// the CH `LogAttributes` map carries the same key set pushLoki sends
+// as structured metadata, and both backends compile the same
+// axiomhq/hyperloglog version, so cardinality estimates are
+// bit-identical when both sides observed the same value sets. The
+// per-service line_limit below exceeds the per-service row count so
+// neither backend truncates the peek window.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	bench "github.com/tsouza/cerberus/compatibility/loki/upstream/loki-bench"
+)
+
+// detectedFieldsLineLimit must exceed entriesPerService (1440 — see
+// cmd/seed/main.go) so both backends parse EVERY seeded row for the
+// selector: a truncated peek window would make the hyperloglog
+// cardinality estimates depend on tie-breaking order instead of data.
+const detectedFieldsLineLimit = 2000
+
+// detectedFieldWire mirrors upstream logproto.DetectedField's JSON
+// surface — the shape Grafana's Logs Drilldown decodes.
+type detectedFieldWire struct {
+	Label       string   `json:"label"`
+	Type        string   `json:"type"`
+	Cardinality uint64   `json:"cardinality"`
+	Parsers     []string `json:"parsers"`
+	JSONPath    []string `json:"jsonPath"`
+}
+
+// detectedFieldsWire is the BARE top-level response body — upstream
+// serializes logproto.DetectedFieldsResponse verbatim (no {status,
+// data} envelope; see pkg/util/marshal WriteDetectedFieldsResponseJSON).
+type detectedFieldsWire struct {
+	Fields []detectedFieldWire `json:"fields"`
+	Limit  uint32              `json:"limit"`
+}
+
+// compareDetectedFieldsAll runs the per-service detected-fields
+// differential and returns one Result per seeded service. Results feed
+// the same report + score pipeline as the corpus cases.
+func compareDetectedFieldsAll(c *http.Client, f flags, metadata *bench.DatasetMetadata) []Result {
+	services := make([]string, 0, len(metadata.ByServiceName))
+	for svc := range metadata.ByServiceName {
+		services = append(services, svc)
+	}
+	sort.Strings(services)
+
+	var results []Result
+	for _, svc := range services {
+		selectors := metadata.ByServiceName[svc]
+		if len(selectors) == 0 {
+			continue
+		}
+		// One stream per service in the seeded fixture; the first
+		// selector is the full label-set selector for that stream.
+		results = append(results, compareDetectedFieldsOne(
+			c, f, svc, selectors[0], metadata.TimeRange.Start, metadata.TimeRange.End,
+		))
+	}
+	return results
+}
+
+func compareDetectedFieldsOne(c *http.Client, f flags, service, selector string, start, end time.Time) Result {
+	result := Result{TestCase: TestCase{
+		Query:       selector,
+		Source:      "detected-fields",
+		Description: "detected_fields parity: service=" + service,
+		Kind:        "detected_fields",
+		Direction:   "backward",
+		Start:       start.UTC().Format(time.RFC3339Nano),
+		End:         end.UTC().Format(time.RFC3339Nano),
+	}}
+
+	type fetched struct {
+		body detectedFieldsWire
+		err  error
+	}
+	out := make([]fetched, 2)
+	done := make(chan int, 2)
+	for idx, addr := range []string{f.addr1, f.addr2} {
+		idx, addr := idx, addr
+		go func() {
+			body, err := fetchDetectedFields(c, addr, selector, start, end)
+			out[idx] = fetched{body: body, err: err}
+			done <- idx
+		}()
+	}
+	<-done
+	<-done
+
+	refErr, testErr := out[0].err, out[1].err
+	switch {
+	case refErr != nil:
+		result.UnexpectedFailure = fmt.Sprintf("reference (-addr-1) failed: %v", refErr)
+		return result
+	case testErr != nil:
+		result.UnexpectedFailure = testErr.Error()
+		result.Unsupported = isUnsupportedErr(testErr)
+		return result
+	}
+
+	expected, actual := out[0].body, out[1].body
+	if len(expected.Fields) == 0 {
+		// Same convention as the corpus path: an empty baseline is a
+		// harness/seed problem, not a parity datapoint.
+		result.UnexpectedFailure = "baseline returned empty"
+		return result
+	}
+	if len(actual.Fields) == 0 {
+		result.UnexpectedFailure = "test endpoint returned empty"
+		return result
+	}
+	if diff := diffDetectedFields(expected, actual); diff != "" {
+		result.Diff = diff
+	}
+	return result
+}
+
+func fetchDetectedFields(c *http.Client, addr, selector string, start, end time.Time) (detectedFieldsWire, error) {
+	base := strings.TrimRight(addr, "/")
+	params := url.Values{}
+	params.Set("query", selector)
+	params.Set("start", strconv.FormatInt(start.UnixNano(), 10))
+	params.Set("end", strconv.FormatInt(end.UnixNano(), 10))
+	params.Set("line_limit", strconv.Itoa(detectedFieldsLineLimit))
+
+	req, err := http.NewRequest(http.MethodGet, base+"/loki/api/v1/detected_fields?"+params.Encode(), nil)
+	if err != nil {
+		return detectedFieldsWire{}, fmt.Errorf("new request: %w", err)
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return detectedFieldsWire{}, fmt.Errorf("http call: %w", err)
+	}
+	defer resp.Body.Close()
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, 16<<20))
+	if readErr != nil {
+		return detectedFieldsWire{}, fmt.Errorf("read body: %w", readErr)
+	}
+	if resp.StatusCode != http.StatusOK {
+		snippet := strings.TrimSpace(string(body))
+		if len(snippet) > 400 {
+			snippet = snippet[:400] + "…"
+		}
+		return detectedFieldsWire{}, fmt.Errorf("status=%d body=%s", resp.StatusCode, snippet)
+	}
+
+	// Consumer-grade decode: the response must be the BARE
+	// DetectedFieldsResponse. An enveloped body decodes to zero fields
+	// here — exactly what Grafana would see — and surfaces as
+	// "test endpoint returned empty" / a field-set diff upstream of
+	// this function.
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(body, &top); err != nil {
+		return detectedFieldsWire{}, fmt.Errorf("decode top-level object: %w", err)
+	}
+	if _, ok := top["data"]; ok {
+		return detectedFieldsWire{}, fmt.Errorf("response carries a {status,data} envelope; upstream serializes DetectedFieldsResponse bare: %s", body)
+	}
+	var decoded detectedFieldsWire
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return detectedFieldsWire{}, fmt.Errorf("decode: %w", err)
+	}
+	return decoded, nil
+}
+
+// diffDetectedFields compares the two field sets (order-insensitive —
+// upstream iterates a Go map so its output order is random) and
+// returns a human-readable diff, or "" when they match.
+func diffDetectedFields(expected, actual detectedFieldsWire) string {
+	exp := fieldMap(expected.Fields)
+	act := fieldMap(actual.Fields)
+
+	var diffs []string
+	for _, label := range sortedFieldLabels(exp) {
+		e := exp[label]
+		a, ok := act[label]
+		if !ok {
+			diffs = append(diffs, fmt.Sprintf("field %q missing from test endpoint", label))
+			continue
+		}
+		if e.Type != a.Type {
+			diffs = append(diffs, fmt.Sprintf("field %q type: expected=%q actual=%q", label, e.Type, a.Type))
+		}
+		if e.Cardinality != a.Cardinality {
+			diffs = append(diffs, fmt.Sprintf("field %q cardinality: expected=%d actual=%d", label, e.Cardinality, a.Cardinality))
+		}
+		if !sameStringSet(e.Parsers, a.Parsers) {
+			diffs = append(diffs, fmt.Sprintf("field %q parsers: expected=%v actual=%v", label, e.Parsers, a.Parsers))
+		}
+		if !slices.Equal(e.JSONPath, a.JSONPath) {
+			diffs = append(diffs, fmt.Sprintf("field %q jsonPath: expected=%v actual=%v", label, e.JSONPath, a.JSONPath))
+		}
+	}
+	for _, label := range sortedFieldLabels(act) {
+		if _, ok := exp[label]; !ok {
+			diffs = append(diffs, fmt.Sprintf("field %q unexpected on test endpoint", label))
+		}
+	}
+	if expected.Limit != actual.Limit {
+		diffs = append(diffs, fmt.Sprintf("limit: expected=%d actual=%d", expected.Limit, actual.Limit))
+	}
+	return strings.Join(diffs, "; ")
+}
+
+func fieldMap(fields []detectedFieldWire) map[string]detectedFieldWire {
+	m := make(map[string]detectedFieldWire, len(fields))
+	for _, f := range fields {
+		m[f.Label] = f
+	}
+	return m
+}
+
+func sortedFieldLabels(m map[string]detectedFieldWire) []string {
+	labels := make([]string, 0, len(m))
+	for l := range m {
+		labels = append(labels, l)
+	}
+	sort.Strings(labels)
+	return labels
+}
+
+// sameStringSet compares two parser lists as sets: the upstream
+// handler appends parser names in row-processing order, which is not
+// part of the contract.
+func sameStringSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	as := slices.Clone(a)
+	bs := slices.Clone(b)
+	sort.Strings(as)
+	sort.Strings(bs)
+	return slices.Equal(as, bs)
+}

--- a/compatibility/loki/cmd/loki-compliance-tester/detected_fields_test.go
+++ b/compatibility/loki/cmd/loki-compliance-tester/detected_fields_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestDiffDetectedFields_Match — identical field sets (order-
+// insensitive, parser-order-insensitive) produce no diff.
+func TestDiffDetectedFields_Match(t *testing.T) {
+	expected := detectedFieldsWire{
+		Fields: []detectedFieldWire{
+			{Label: "status", Type: "int", Cardinality: 7, Parsers: []string{"json", "logfmt"}, JSONPath: []string{"status"}},
+			{Label: "detected_level", Type: "string", Cardinality: 4, Parsers: nil},
+		},
+		Limit: 1000,
+	}
+	actual := detectedFieldsWire{
+		Fields: []detectedFieldWire{
+			{Label: "detected_level", Type: "string", Cardinality: 4, Parsers: nil},
+			{Label: "status", Type: "int", Cardinality: 7, Parsers: []string{"logfmt", "json"}, JSONPath: []string{"status"}},
+		},
+		Limit: 1000,
+	}
+	if diff := diffDetectedFields(expected, actual); diff != "" {
+		t.Fatalf("unexpected diff: %s", diff)
+	}
+}
+
+// TestDiffDetectedFields_Divergences — every compared dimension
+// (presence, type, cardinality, parsers, jsonPath, limit) surfaces in
+// the diff string.
+func TestDiffDetectedFields_Divergences(t *testing.T) {
+	expected := detectedFieldsWire{
+		Fields: []detectedFieldWire{
+			{Label: "status", Type: "int", Cardinality: 7, Parsers: []string{"json"}, JSONPath: []string{"status"}},
+			{Label: "missing", Type: "string", Cardinality: 1, Parsers: nil},
+		},
+		Limit: 1000,
+	}
+	actual := detectedFieldsWire{
+		Fields: []detectedFieldWire{
+			{Label: "status", Type: "string", Cardinality: 9, Parsers: []string{"logfmt"}, JSONPath: nil},
+			{Label: "extra", Type: "string", Cardinality: 1, Parsers: nil},
+		},
+		Limit: 500,
+	}
+	diff := diffDetectedFields(expected, actual)
+	for _, want := range []string{
+		`field "missing" missing from test endpoint`,
+		`field "status" type: expected="int" actual="string"`,
+		`field "status" cardinality: expected=7 actual=9`,
+		`field "status" parsers: expected=[json] actual=[logfmt]`,
+		`field "status" jsonPath: expected=[status] actual=[]`,
+		`field "extra" unexpected on test endpoint`,
+		`limit: expected=1000 actual=500`,
+	} {
+		if !strings.Contains(diff, want) {
+			t.Errorf("diff missing %q; got: %s", want, diff)
+		}
+	}
+}
+
+// TestFetchDetectedFields_RejectsEnvelope — a {status, data} envelope
+// (the exact bug class this pass exists for) is a hard fetch error,
+// not a silent zero-field decode.
+func TestFetchDetectedFields_RejectsEnvelope(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"success","data":{"fields":[{"label":"a","type":"string","cardinality":1}],"limit":1000}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := &http.Client{Timeout: 5 * time.Second}
+	_, err := fetchDetectedFields(c, srv.URL, `{service_name="api"}`, time.Unix(0, 0), time.Unix(60, 0))
+	if err == nil {
+		t.Fatal("expected envelope rejection, got nil error")
+	}
+	if !strings.Contains(err.Error(), "envelope") {
+		t.Fatalf("error should name the envelope: %v", err)
+	}
+}
+
+// TestFetchDetectedFields_DecodesBareShape — the bare upstream shape
+// decodes with fields + limit intact and the line_limit/window params
+// reach the backend.
+func TestFetchDetectedFields_DecodesBareShape(t *testing.T) {
+	var gotQuery, gotLineLimit string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query().Get("query")
+		gotLineLimit = r.URL.Query().Get("line_limit")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"fields":[{"label":"status","type":"int","cardinality":7,"parsers":["logfmt"]}],"limit":1000}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := &http.Client{Timeout: 5 * time.Second}
+	body, err := fetchDetectedFields(c, srv.URL, `{service_name="api"}`, time.Unix(0, 0), time.Unix(60, 0))
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if gotQuery != `{service_name="api"}` {
+		t.Errorf("query param: %q", gotQuery)
+	}
+	if gotLineLimit != "2000" {
+		t.Errorf("line_limit param: %q want 2000", gotLineLimit)
+	}
+	if len(body.Fields) != 1 || body.Fields[0].Label != "status" || body.Limit != 1000 {
+		t.Errorf("decoded body: %+v", body)
+	}
+}

--- a/compatibility/loki/cmd/loki-compliance-tester/main.go
+++ b/compatibility/loki/cmd/loki-compliance-tester/main.go
@@ -164,6 +164,20 @@ func run() error {
 
 	results := compareAll(cases, f, isInstant)
 
+	// Detected-fields differential (range lane only — the endpoint has
+	// no instant flavour): one case per seeded service, diffing
+	// /loki/api/v1/detected_fields between the two backends. The
+	// results join the same report + score pipeline as the corpus
+	// cases — no separate bucket, no allow-list.
+	if !isInstant {
+		metadata, err := bench.LoadMetadata(f.metadataDir)
+		if err != nil {
+			return fmt.Errorf("LoadMetadata(%s) for detected-fields pass: %w", f.metadataDir, err)
+		}
+		httpClient := &http.Client{Timeout: f.timeout}
+		results = append(results, compareDetectedFieldsAll(httpClient, f, metadata)...)
+	}
+
 	report := Report{
 		TotalResults:   len(results),
 		IncludePassing: true,

--- a/compatibility/loki/cmd/seed/main.go
+++ b/compatibility/loki/cmd/seed/main.go
@@ -516,11 +516,15 @@ func insertCHLogs(ctx context.Context, conn driver.Conn, streams []stream) error
 		}
 		for _, e := range s.entries {
 			level := e.level
-			// LogAttributes carries per-record attributes — the severity
-			// markers Loki materialises as structured metadata. Stream
-			// labels live in resourceAttrs above, not here.
+			// LogAttributes carries per-record attributes — the OTel-CH
+			// analogue of Loki's structured metadata. The key set MUST
+			// mirror what pushLoki sends as structured metadata
+			// (detected_level only): the /detected_fields differential
+			// compares the two backends' structured-metadata-derived
+			// fields, so any CH-only key here would surface as a
+			// permanent parity diff. Stream labels live in
+			// resourceAttrs above, not here.
 			logAttrs := map[string]string{
-				"level":          strings.ToLower(level),
 				"detected_level": strings.ToLower(level),
 			}
 			if err := batch.Append(

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,9 @@ go 1.26.2
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.46.0
+	github.com/axiomhq/hyperloglog v0.2.6
 	github.com/chdb-io/chdb-go v1.11.0
+	github.com/dustin/go-humanize v1.0.1
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/snappy v1.0.0
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
@@ -74,7 +76,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.42.1 // indirect
 	github.com/aws/smithy-go v1.25.1 // indirect
-	github.com/axiomhq/hyperloglog v0.2.6 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/bboreham/go-loser v0.0.0-20230920113527-fcc2c21820a3 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -99,7 +100,6 @@ require (
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/go-connections v0.7.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
-	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/edsrzf/mmap-go v1.2.1-0.20241212181136-fad1cd13edbd // indirect
 	github.com/efficientgo/core v1.0.0-rc.3 // indirect

--- a/internal/api/loki/chaos_test.go
+++ b/internal/api/loki/chaos_test.go
@@ -25,6 +25,7 @@ import (
 type chaosQuerier struct {
 	samples      []chclient.Sample
 	stringRows   []string
+	detectedRows []chclient.DetectedFieldRow
 	tsLines      []chclient.TimestampedLine
 	labelSets    []map[string]string
 	statsRow     chclient.IndexStatsRow
@@ -55,6 +56,14 @@ func (c *chaosQuerier) QueryStrings(_ context.Context, _ string, _ ...any) ([]st
 		return nil, c.err
 	}
 	return c.stringRows, nil
+}
+
+func (c *chaosQuerier) QueryDetectedFieldRows(_ context.Context, _ string, _ ...any) ([]chclient.DetectedFieldRow, error) {
+	c.calls.Add(1)
+	if c.err != nil {
+		return nil, c.err
+	}
+	return c.detectedRows, nil
 }
 
 func (c *chaosQuerier) QueryTimestampedLines(_ context.Context, _ string, _ ...any) ([]chclient.TimestampedLine, error) {

--- a/internal/api/loki/conformance_test.go
+++ b/internal/api/loki/conformance_test.go
@@ -424,23 +424,46 @@ func TestConformance_LokiIndexVolumeWire(t *testing.T) {
 	}
 }
 
-// TestConformance_LokiDetectedFieldsWire — `data: {fields, limit,
-// line_limit}` matches upstream Loki's documented shape.
+// TestConformance_LokiDetectedFieldsWire pins the BARE top-level wire
+// shape upstream Loki serializes for /loki/api/v1/detected_fields —
+// `{"fields":[{label,type,cardinality,parsers,jsonPath}],"limit":N}`
+// with NO {status, data} envelope (upstream's
+// WriteDetectedFieldsResponseJSON writes logproto.DetectedFieldsResponse
+// verbatim; see pkg/util/marshal/marshal.go). The decode below reads
+// `body.fields` exactly as Grafana's Logs Drilldown does — the
+// post-incident doctrine for the "Fields: 0" bug class: a 200 with an
+// enveloped body is invisible to status-code oracles, so the test IS
+// the consumer.
 func TestConformance_LokiDetectedFieldsWire(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name string
-		rows []string
+		name        string
+		rows        []chclient.DetectedFieldRow
+		wantParsers []string
 	}{
-		{"json_lines", []string{`{"user_id":42,"action":"login"}`, `{"user_id":7,"action":"logout"}`}},
-		{"logfmt_lines", []string{`user_id=42 action=login`, `user_id=7 action=logout`}},
+		{
+			"json_lines",
+			[]chclient.DetectedFieldRow{
+				{Line: `{"user_id":42,"action":"login"}`},
+				{Line: `{"user_id":7,"action":"logout"}`},
+			},
+			[]string{"json"},
+		},
+		{
+			"logfmt_lines",
+			[]chclient.DetectedFieldRow{
+				{Line: `user_id=42 action=login`},
+				{Line: `user_id=7 action=logout`},
+			},
+			[]string{"logfmt"},
+		},
 	}
 	for _, c := range cases {
 		c := c
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
-			srv := newServer(&stubQuerier{stringRows: c.rows})
+			srv := newServer(&stubQuerier{detectedRows: c.rows})
 			t.Cleanup(srv.Close)
 			resp, err := http.Get(srv.URL +
 				`/loki/api/v1/detected_fields?query=%7Bjob%3D%22api%22%7D&start=1717995600&end=1717999200`)
@@ -452,20 +475,98 @@ func TestConformance_LokiDetectedFieldsWire(t *testing.T) {
 				body, _ := io.ReadAll(resp.Body)
 				t.Fatalf("status=%d body=%s", resp.StatusCode, body)
 			}
-			var env struct {
-				Status string                  `json:"status"`
-				Data   loki.DetectedFieldsData `json:"data"`
+			raw, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("read body: %v", err)
 			}
-			if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
-				t.Fatalf("decode: %v", err)
+
+			// Regression pin: the {status, data} query-API envelope is
+			// GONE. Grafana reads body.fields directly — an enveloped
+			// 200 renders every Logs Drilldown service page with
+			// "Fields: 0".
+			var top map[string]json.RawMessage
+			if err := json.Unmarshal(raw, &top); err != nil {
+				t.Fatalf("decode top-level object: %v", err)
 			}
-			if env.Status != "success" {
-				t.Errorf("status: got %q, want success", env.Status)
+			if _, ok := top["status"]; ok {
+				t.Fatalf("response carries the query-API envelope (top-level \"status\"); upstream serializes DetectedFieldsResponse bare: %s", raw)
 			}
-			if env.Data.Limit == 0 || env.Data.LineLimit == 0 {
-				t.Errorf("limits not echoed: %+v", env.Data)
+			if _, ok := top["data"]; ok {
+				t.Fatalf("response carries the query-API envelope (top-level \"data\"); upstream serializes DetectedFieldsResponse bare: %s", raw)
+			}
+			if _, ok := top["fields"]; !ok {
+				t.Fatalf("top-level \"fields\" missing — the consumer decodes body.fields: %s", raw)
+			}
+
+			// Consumer decode: exactly what the Logs Drilldown app /
+			// Loki datasource frontend reads.
+			var body struct {
+				Fields []loki.DetectedField `json:"fields"`
+				Limit  uint32               `json:"limit"`
+			}
+			if err := json.Unmarshal(raw, &body); err != nil {
+				t.Fatalf("decode as consumer: %v", err)
+			}
+			if len(body.Fields) == 0 {
+				t.Fatalf("fields empty — Logs Drilldown would render \"Fields: 0\": %s", raw)
+			}
+			if body.Limit == 0 {
+				t.Errorf("limit not echoed alongside non-empty fields: %s", raw)
+			}
+			for _, f := range body.Fields {
+				if f.Label == "" {
+					t.Errorf("field with empty label: %s", raw)
+				}
+				if f.Type == "" {
+					t.Errorf("field %q with empty type: %s", f.Label, raw)
+				}
+				if f.Cardinality == 0 {
+					t.Errorf("field %q with zero cardinality: %s", f.Label, raw)
+				}
+				if len(f.Parsers) != len(c.wantParsers) || f.Parsers[0] != c.wantParsers[0] {
+					t.Errorf("field %q parsers=%v want %v", f.Label, f.Parsers, c.wantParsers)
+				}
 			}
 		})
+	}
+}
+
+// TestConformance_LokiDetectedFieldsWire_StructuredMetadataParsersNull
+// — fields derived from structured metadata only (LogAttributes, no
+// line parse) serialize `"parsers":null`: upstream's logproto JSON tag
+// has NO omitempty on parsers, and the upstream handler nils the slice
+// out when no parser produced the field.
+func TestConformance_LokiDetectedFieldsWire_StructuredMetadataParsersNull(t *testing.T) {
+	t.Parallel()
+
+	srv := newServer(&stubQuerier{detectedRows: []chclient.DetectedFieldRow{
+		{Line: "plain unparseable text", Attributes: map[string]string{"detected_level": "warn"}},
+	}})
+	t.Cleanup(srv.Close)
+	resp, err := http.Get(srv.URL +
+		`/loki/api/v1/detected_fields?query=%7Bjob%3D%22api%22%7D&start=1717995600&end=1717999200`)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	var body struct {
+		Fields []struct {
+			Label   string          `json:"label"`
+			Parsers json.RawMessage `json:"parsers"`
+		} `json:"fields"`
+	}
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Fields) != 1 || body.Fields[0].Label != "detected_level" {
+		t.Fatalf("want exactly the detected_level field, got: %s", raw)
+	}
+	if got := strings.TrimSpace(string(body.Fields[0].Parsers)); got != "null" {
+		t.Errorf("structured-metadata field parsers=%s want null on the wire", got)
 	}
 }
 

--- a/internal/api/loki/detected_fields.go
+++ b/internal/api/loki/detected_fields.go
@@ -2,6 +2,7 @@ package loki
 
 import (
 	"errors"
+	"math"
 	"net/http"
 	"slices"
 	"sort"
@@ -137,9 +138,12 @@ func (h *Handler) handleDetectedFields(w http.ResponseWriter, r *http.Request) {
 	fields := detectFields(rows, limit)
 
 	resp := DetectedFieldsResponse{Fields: fields}
-	// Mirror upstream: the limit is echoed only when fields exist.
-	if len(fields) > 0 {
-		resp.Limit = uint32(limit) //nolint:gosec // parsePositiveInt rejects negatives; bounded by the query-param domain.
+	// Mirror upstream: the limit is echoed only when fields exist. The
+	// range guard is re-stated locally — parsePositiveInt already
+	// enforces it, but neither gosec G115 nor CodeQL sees across the
+	// call, and a provably-safe conversion beats a suppression.
+	if len(fields) > 0 && limit > 0 && int64(limit) <= math.MaxUint32 {
+		resp.Limit = uint32(limit)
 	}
 	writeJSON(w, http.StatusOK, resp)
 }
@@ -375,15 +379,18 @@ func sortedKeys(m map[string]string) []string {
 }
 
 // parsePositiveInt parses an optional integer query parameter. Empty
-// input returns the default; non-numeric or non-positive input is
-// rejected with a 400.
+// input returns the default; non-numeric, non-positive, or
+// out-of-range input is rejected with a 400. The upper bound keeps
+// the value inside uint32 (the wire type of the echoed `limit` —
+// logproto.DetectedFieldsResponse.limit) so the int->uint32
+// conversion at the response site cannot wrap.
 func parsePositiveInt(raw string, def int) (int, error) {
 	if raw == "" {
 		return def, nil
 	}
 	n, err := strconv.Atoi(raw)
-	if err != nil || n <= 0 {
-		return 0, errors.New("parameter must be a positive integer")
+	if err != nil || n <= 0 || int64(n) > math.MaxUint32 {
+		return 0, errors.New("parameter must be a positive integer no larger than 4294967295")
 	}
 	return n, nil
 }

--- a/internal/api/loki/detected_fields.go
+++ b/internal/api/loki/detected_fields.go
@@ -2,6 +2,7 @@ package loki
 
 import (
 	"errors"
+	"math"
 	"net/http"
 	"slices"
 	"sort"
@@ -103,18 +104,16 @@ func (h *Handler) handleDetectedFields(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	lineLimit32, err := parsePositiveUint32(r.URL.Query().Get("line_limit"), defaultDetectedFieldsLineLimit)
+	lineLimit, err := parsePositiveInt31(r.URL.Query().Get("line_limit"), defaultDetectedFieldsLineLimit)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, ErrBadData, err)
 		return
 	}
-	lineLimit := int(lineLimit32)
-	limit32, err := parsePositiveUint32(r.URL.Query().Get("limit"), defaultDetectedFieldsLimit)
+	limit, err := parsePositiveInt31(r.URL.Query().Get("limit"), defaultDetectedFieldsLimit)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, ErrBadData, err)
 		return
 	}
-	limit := int(limit32)
 
 	matchers, err := selectorMatchers(q)
 	if err != nil {
@@ -140,10 +139,12 @@ func (h *Handler) handleDetectedFields(w http.ResponseWriter, r *http.Request) {
 
 	resp := DetectedFieldsResponse{Fields: fields}
 	// Mirror upstream: the limit is echoed only when fields exist.
-	// limit32 is uint32 from parse time (ParseUint bitSize 32), so the
-	// wire value needs no conversion at all.
-	if len(fields) > 0 {
-		resp.Limit = limit32
+	// parsePositiveInt31 already bounds limit, but the guard is
+	// restated on the SAME variable so both gosec G115 and CodeQL
+	// go/incorrect-integer-conversion can prove the uint32 conversion
+	// locally (neither follows the bound across the helper call).
+	if len(fields) > 0 && limit > 0 && limit <= math.MaxInt32 {
+		resp.Limit = uint32(limit)
 	}
 	writeJSON(w, http.StatusOK, resp)
 }
@@ -378,19 +379,20 @@ func sortedKeys(m map[string]string) []string {
 	return keys
 }
 
-// parsePositiveUint32 parses an optional integer query parameter.
+// parsePositiveInt31 parses an optional integer query parameter.
 // Empty input returns the default; non-numeric, non-positive, or
 // out-of-range input is rejected with a 400. ParseUint with bitSize
-// 32 bounds the value to uint32 — the wire type of the echoed
-// `limit` (logproto.DetectedFieldsResponse.limit) — so no unbounded
-// integer conversion exists anywhere downstream.
-func parsePositiveUint32(raw string, def uint32) (uint32, error) {
+// 31 bounds the value to MaxInt32, which fits int on every
+// architecture AND uint32 on the wire (the echoed `limit` is
+// logproto.DetectedFieldsResponse.limit), so every downstream
+// conversion is provably in range.
+func parsePositiveInt31(raw string, def int) (int, error) {
 	if raw == "" {
 		return def, nil
 	}
-	n, err := strconv.ParseUint(raw, 10, 32)
+	n, err := strconv.ParseUint(raw, 10, 31)
 	if err != nil || n == 0 {
-		return 0, errors.New("parameter must be a positive integer no larger than 4294967295")
+		return 0, errors.New("parameter must be a positive integer no larger than 2147483647")
 	}
-	return uint32(n), nil
+	return int(n), nil
 }

--- a/internal/api/loki/detected_fields.go
+++ b/internal/api/loki/detected_fields.go
@@ -2,7 +2,6 @@ package loki
 
 import (
 	"errors"
-	"math"
 	"net/http"
 	"slices"
 	"sort"
@@ -104,16 +103,18 @@ func (h *Handler) handleDetectedFields(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	lineLimit, err := parsePositiveInt(r.URL.Query().Get("line_limit"), defaultDetectedFieldsLineLimit)
+	lineLimit32, err := parsePositiveUint32(r.URL.Query().Get("line_limit"), defaultDetectedFieldsLineLimit)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, ErrBadData, err)
 		return
 	}
-	limit, err := parsePositiveInt(r.URL.Query().Get("limit"), defaultDetectedFieldsLimit)
+	lineLimit := int(lineLimit32)
+	limit32, err := parsePositiveUint32(r.URL.Query().Get("limit"), defaultDetectedFieldsLimit)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, ErrBadData, err)
 		return
 	}
+	limit := int(limit32)
 
 	matchers, err := selectorMatchers(q)
 	if err != nil {
@@ -138,12 +139,11 @@ func (h *Handler) handleDetectedFields(w http.ResponseWriter, r *http.Request) {
 	fields := detectFields(rows, limit)
 
 	resp := DetectedFieldsResponse{Fields: fields}
-	// Mirror upstream: the limit is echoed only when fields exist. The
-	// range guard is re-stated locally — parsePositiveInt already
-	// enforces it, but neither gosec G115 nor CodeQL sees across the
-	// call, and a provably-safe conversion beats a suppression.
-	if len(fields) > 0 && limit > 0 && int64(limit) <= math.MaxUint32 {
-		resp.Limit = uint32(limit)
+	// Mirror upstream: the limit is echoed only when fields exist.
+	// limit32 is uint32 from parse time (ParseUint bitSize 32), so the
+	// wire value needs no conversion at all.
+	if len(fields) > 0 {
+		resp.Limit = limit32
 	}
 	writeJSON(w, http.StatusOK, resp)
 }
@@ -378,19 +378,19 @@ func sortedKeys(m map[string]string) []string {
 	return keys
 }
 
-// parsePositiveInt parses an optional integer query parameter. Empty
-// input returns the default; non-numeric, non-positive, or
-// out-of-range input is rejected with a 400. The upper bound keeps
-// the value inside uint32 (the wire type of the echoed `limit` —
-// logproto.DetectedFieldsResponse.limit) so the int->uint32
-// conversion at the response site cannot wrap.
-func parsePositiveInt(raw string, def int) (int, error) {
+// parsePositiveUint32 parses an optional integer query parameter.
+// Empty input returns the default; non-numeric, non-positive, or
+// out-of-range input is rejected with a 400. ParseUint with bitSize
+// 32 bounds the value to uint32 — the wire type of the echoed
+// `limit` (logproto.DetectedFieldsResponse.limit) — so no unbounded
+// integer conversion exists anywhere downstream.
+func parsePositiveUint32(raw string, def uint32) (uint32, error) {
 	if raw == "" {
 		return def, nil
 	}
-	n, err := strconv.Atoi(raw)
-	if err != nil || n <= 0 || int64(n) > math.MaxUint32 {
+	n, err := strconv.ParseUint(raw, 10, 32)
+	if err != nil || n == 0 {
 		return 0, errors.New("parameter must be a positive integer no larger than 4294967295")
 	}
-	return n, nil
+	return uint32(n), nil
 }

--- a/internal/api/loki/detected_fields.go
+++ b/internal/api/loki/detected_fields.go
@@ -1,17 +1,21 @@
 package loki
 
 import (
-	"encoding/json"
 	"errors"
 	"net/http"
+	"slices"
 	"sort"
 	"strconv"
-	"strings"
 	"time"
 
+	"github.com/axiomhq/hyperloglog"
+	"github.com/dustin/go-humanize"
 	loglib "github.com/grafana/loki/v3/pkg/logql/log"
+	"github.com/grafana/loki/v3/pkg/logqlmodel"
 	"github.com/prometheus/prometheus/model/labels"
 
+	"github.com/tsouza/cerberus/internal/api/format"
+	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/chsql"
 	"github.com/tsouza/cerberus/internal/logql"
 	"github.com/tsouza/cerberus/internal/schema"
@@ -28,42 +32,63 @@ const defaultDetectedFieldsLineLimit = 1000
 // payload exposing thousands of unique keys.
 const defaultDetectedFieldsLimit = 1000
 
-// detectedFieldsCardinalityCap caps the per-field value SET size used
-// to compute the response cardinality count. Only the cardinality
-// number is reported on the wire (not the values themselves), so the
-// cap defends against memory blow-up on high-cardinality fields like
-// `request_id` / `trace_id` / `user_id`. Cardinality numbers above the
-// cap saturate; for realistic Loki streams 1024 distinct values is
-// well above the threshold where the field stops being useful as a
-// faceting dimension anyway.
-const detectedFieldsCardinalityCap = 1024
-
-// DetectedField is one entry in the /detected_fields response. Mirrors
-// the upstream Loki shape Grafana expects.
+// DetectedField is one entry in the /detected_fields response. The
+// JSON tags mirror upstream Loki's logproto.DetectedField exactly
+// (pkg/logproto/logproto.pb.go): label / type / cardinality are
+// omitempty, `parsers` is ALWAYS emitted (null when the field came
+// from structured metadata only — upstream nils the slice out before
+// marshalling), and `jsonPath` carries the original JSON path
+// components when the json parser extracted the field.
 type DetectedField struct {
-	Label       string `json:"label"`
-	Type        string `json:"type"`
-	Cardinality uint64 `json:"cardinality"`
+	Label       string   `json:"label,omitempty"`
+	Type        string   `json:"type,omitempty"`
+	Cardinality uint64   `json:"cardinality,omitempty"`
+	Parsers     []string `json:"parsers"`
+	JSONPath    []string `json:"jsonPath,omitempty"`
 }
 
-// DetectedFieldsData is the body of a /loki/api/v1/detected_fields
-// response. `fields` holds the heuristic results; `limit` and
-// `line_limit` echo what the handler actually applied.
-type DetectedFieldsData struct {
-	Fields    []DetectedField `json:"fields"`
-	Limit     int             `json:"limit"`
-	LineLimit int             `json:"line_limit"`
+// DetectedFieldsResponse is the body of a /loki/api/v1/detected_fields
+// response. Upstream Loki serializes logproto.DetectedFieldsResponse
+// BARE at the top level (pkg/util/marshal/marshal.go,
+// WriteDetectedFieldsResponseJSON writes the struct verbatim via
+// jsoniter) — there is NO {status, data} envelope on this endpoint.
+// Grafana's Logs Drilldown reads `body.fields` directly; wrapping the
+// payload renders every service page with "Fields: 0".
+//
+// `limit` echoes the applied field cap, and — mirroring upstream —
+// is only set when at least one field was detected ("otherwise all
+// they get is the field limit, which is a bit confusing", per the
+// upstream handler).
+type DetectedFieldsResponse struct {
+	Fields []DetectedField `json:"fields,omitempty"`
+	Limit  uint32          `json:"limit,omitempty"`
 }
 
 // handleDetectedFields implements GET /loki/api/v1/detected_fields. The
-// upstream Loki feature peeks at the first N matching rows and returns
-// the JSON / logfmt keys it can extract from each Body. Cerberus's
-// implementation matches the contract:
+// upstream Loki feature peeks at the first N matching rows (newest
+// first) and reports every field it can derive from each record.
+// Cerberus mirrors the upstream frontend implementation
+// (pkg/querier/queryrange/detected_fields.go) on top of the OTel-CH
+// schema:
 //
-//   - SQL fetches Body (most-recent-first, capped at line_limit).
-//   - Per-row JSON and logfmt parsing happens in Go (post-process).
-//   - Each unique field name is reported with the dominant scalar type
-//     (string / int / float / bool / duration / bytes) and cardinality.
+//   - SQL fetches (Body, LogAttributes, ResourceAttributes), newest
+//     first, capped at line_limit.
+//   - LogAttributes is the structured-metadata source: every key
+//     becomes a field with a nil parser list (Loki's OTLP ingestion
+//     maps log-record attributes to structured metadata, so the
+//     OTel-CH LogAttributes map is the same data on the CH side).
+//   - Body is parsed with Loki's own json parser first, falling back
+//     to logfmt — the per-field `parsers` list records which one hit,
+//     and json-extracted fields carry their original `jsonPath`.
+//   - Types follow upstream determineType (int → float → boolean →
+//     duration → bytes → string), re-detected per record so the last
+//     record processed wins — exactly the upstream loop.
+//   - Cardinality is a hyperloglog estimate over the observed values
+//     (same sketch library upstream uses, so estimates match a
+//     reference Loki fed the same records).
+//
+// Cerberus serves only the fields variant; the sibling
+// /detected_field/{name}/values endpoint is not mounted.
 //
 // https://grafana.com/docs/loki/latest/reference/loki-http-api/#detected-fields
 func (h *Handler) handleDetectedFields(w http.ResponseWriter, r *http.Request) {
@@ -102,38 +127,48 @@ func (h *Handler) handleDetectedFields(w http.ResponseWriter, r *http.Request) {
 	}
 	h.Logger.Debug("cerberus loki detected_fields", "logql", q, "sql", sqlStr, "args", args)
 
-	lines, err := h.Client.QueryStrings(r.Context(), sqlStr, args...)
+	rows, err := h.Client.QueryDetectedFieldRows(r.Context(), sqlStr, args...)
 	if err != nil {
 		h.Logger.Error("cerberus loki detected_fields CH query failed", "err", err, "sql", sqlStr)
 		h.respondError(w, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusBadGateway})
 		return
 	}
 
-	fields := detectFields(lines, limit)
+	fields := detectFields(rows, limit)
 
-	writeJSON(w, http.StatusOK, Response{
-		Status: "success",
-		Data: DetectedFieldsData{
-			Fields:    fields,
-			Limit:     limit,
-			LineLimit: lineLimit,
-		},
-	})
+	resp := DetectedFieldsResponse{Fields: fields}
+	// Mirror upstream: the limit is echoed only when fields exist.
+	if len(fields) > 0 {
+		resp.Limit = uint32(limit) //nolint:gosec // parsePositiveInt rejects negatives; bounded by the query-param domain.
+	}
+	writeJSON(w, http.StatusOK, resp)
 }
 
 // buildDetectedFieldsSQL renders:
 //
-//	SELECT `Body` AS line
+//	SELECT `Body` AS `line`, `LogAttributes` AS `log_attributes`,
+//	       `ResourceAttributes` AS `stream_labels`
 //	FROM `otel_logs`
 //	WHERE <matchers> AND <time bounds>
 //	ORDER BY `Timestamp` DESC
 //	LIMIT <lineLimit>
 //
+// The projection aliases are deliberately DISTINCT from the source
+// column names: the selector predicate references the raw
+// `ResourceAttributes` map in WHERE, and a same-name alias would
+// shadow the column once a test harness (chclienttest) rewrites the
+// projection to toJSONString(...) — CH resolves WHERE identifiers
+// against SELECT aliases first.
+//
 // The peek window is small (1000 rows by default) — CH executes this as
 // a top-N scan on the primary key, comparable to /index/stats.
 func buildDetectedFieldsSQL(s schema.Logs, matchers []*labels.Matcher, start, end time.Time, lineLimit int) (string, []any, error) {
 	sb := chsql.NewQuery().
-		Select(chsql.As(chsql.Col(s.BodyColumn), "line")).
+		Select(
+			chsql.As(chsql.Col(s.BodyColumn), "line"),
+			chsql.As(chsql.Col(s.AttributesColumn), "log_attributes"),
+			chsql.As(chsql.Col(s.ResourceAttributesColumn), "stream_labels"),
+		).
 		From(chsql.Col(s.LogsTable))
 
 	pred := logql.SelectorPredicate(matchers, s)
@@ -157,183 +192,186 @@ func buildDetectedFieldsSQL(s schema.Logs, matchers []*labels.Matcher, start, en
 	return sqlStr, args, nil
 }
 
-// detectFields runs the heuristic over the peek window. For each line:
-//
-//  1. attempt JSON object parse — every top-level scalar value becomes
-//     a field whose type is inferred from the JSON kind.
-//  2. attempt logfmt parse (key=value pairs) — each value is sniffed
-//     for int / float / bool / duration / bytes / string.
-//
-// Field types collapse via `mergeType`: identical → preserved;
-// otherwise downgraded to "string". Returns the field list sorted by
-// label name, truncated at limit.
-func detectFields(lines []string, limit int) []DetectedField {
-	type acc struct {
-		typ    string
-		values map[string]struct{}
-	}
-	fields := map[string]*acc{}
+// parsedField accumulates the per-field state across the peek window.
+// Mirrors upstream's parsedFields struct: a hyperloglog sketch for
+// cardinality, the most recent type detection, the set of parsers
+// that produced the field, and the JSON path when applicable.
+type parsedField struct {
+	sketch   *hyperloglog.Sketch
+	typ      string
+	parsers  []string
+	jsonPath []string
+}
 
-	addValue := func(name, typ, raw string) {
-		a, ok := fields[name]
-		if !ok {
-			a = &acc{typ: typ, values: map[string]struct{}{}}
-			fields[name] = a
-		} else {
-			a.typ = mergeType(a.typ, typ)
+func newParsedField(parsers []string) *parsedField {
+	return &parsedField{
+		sketch:  hyperloglog.New(),
+		typ:     "string",
+		parsers: parsers,
+	}
+}
+
+// detectFields runs the upstream detected-fields loop over the peek
+// window (mirrors pkg/querier/queryrange/detected_fields.go,
+// parseDetectedFields). For each row:
+//
+//  1. every LogAttributes entry (the structured-metadata analogue)
+//     becomes a field with an empty parser list,
+//  2. the Body is parsed — Loki's json parser first, logfmt fallback —
+//     and each extracted key becomes a field tagged with the parser
+//     that produced it (collisions with stream labels surface as
+//     `<key>_extracted`, exactly as the upstream labels builder does).
+//
+// The field type is re-detected once per row from the first observed
+// value, so the last row processed wins — upstream semantics, NOT a
+// merge-to-string collapse. `limit` caps the number of DISTINCT fields
+// tracked (rows keep contributing values to already-tracked fields).
+//
+// Keys iterate in sorted order so the (map-ordered upstream) loop is
+// deterministic in cerberus; the output is sorted by label.
+func detectFields(rows []chclient.DetectedFieldRow, limit int) []DetectedField {
+	fields := map[string]*parsedField{}
+	fieldCount := 0
+	emptyParsers := []string{}
+
+	track := func(name string, parsers []string) *parsedField {
+		df, ok := fields[name]
+		if !ok && fieldCount < limit {
+			df = newParsedField(parsers)
+			fields[name] = df
+			fieldCount++
 		}
-		// Cap the per-field value set to defend against blow-up on
-		// high-cardinality fields (request_id, etc.) — we only need the
-		// cardinality COUNT, not the actual values.
-		if len(a.values) < detectedFieldsCardinalityCap {
-			a.values[raw] = struct{}{}
-		}
+		return df
 	}
 
-	for _, line := range lines {
-		// JSON object detection.
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "{") {
-			obj := map[string]json.RawMessage{}
-			if err := json.Unmarshal([]byte(trimmed), &obj); err == nil {
-				for k, raw := range obj {
-					typ, val := classifyJSON(raw)
-					addValue(k, typ, val)
-				}
-				// JSON wins — don't double-parse as logfmt.
+	for _, row := range rows {
+		// Structured metadata: the normalised LogAttributes map. Keys
+		// are normalised through the same OTel→Prom grammar the rest
+		// of the Loki surface applies, so a field reported here is
+		// queryable as written.
+		structuredMetadata := format.NormalizeLabelMap(row.Attributes)
+		for _, k := range sortedKeys(structuredMetadata) {
+			df := track(k, emptyParsers)
+			if df == nil {
 				continue
 			}
+			v := structuredMetadata[k]
+			df.typ = determineFieldType(v)
+			df.sketch.Insert([]byte(v))
 		}
-		// Logfmt: reuse Loki's own parser so the result matches what
-		// `| logfmt` would yield in a pipeline.
-		extracted, ok := parseLogfmt(line)
-		if !ok {
-			continue
-		}
-		for k, v := range extracted {
-			addValue(k, classifyScalar(v), v)
+
+		// Body parsing: seed the labels builder with the stream labels
+		// so parsed keys that shadow a stream label rename to
+		// `<key>_extracted`, matching upstream.
+		streamLbls := labels.FromMap(format.NormalizeLabelMap(row.Resource))
+		entryLbls := loglib.NewBaseLabelsBuilder().ForLabels(streamLbls, labels.StableHash(streamLbls))
+		parsedLabels, parsers := parseLine(row.Line, entryLbls)
+		for _, k := range sortedKeys(parsedLabels) {
+			df := track(k, parsers)
+			if df == nil {
+				continue
+			}
+			for _, parser := range parsers {
+				if !slices.Contains(df.parsers, parser) {
+					df.parsers = append(df.parsers, parser)
+				}
+			}
+			// If we parsed with JSON, record the original JSON path.
+			if slices.Contains(parsers, "json") {
+				df.jsonPath = entryLbls.GetJSONPath(k)
+			}
+			v := parsedLabels[k]
+			df.typ = determineFieldType(v)
+			df.sketch.Insert([]byte(v))
 		}
 	}
 
 	out := make([]DetectedField, 0, len(fields))
-	for k, a := range fields {
+	for k, df := range fields {
+		p := df.parsers
+		if len(p) == 0 {
+			p = nil
+		}
 		out = append(out, DetectedField{
 			Label:       k,
-			Type:        a.typ,
-			Cardinality: uint64(len(a.values)),
+			Type:        df.typ,
+			Cardinality: df.sketch.Estimate(),
+			Parsers:     p,
+			JSONPath:    df.jsonPath,
 		})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Label < out[j].Label })
-	if limit > 0 && len(out) > limit {
-		out = out[:limit]
-	}
 	return out
 }
 
-// classifyJSON returns (type-tag, stringified-value) for a JSON token.
-// Object / array values are stringified as their raw JSON; scalar
-// strings unwrap the quoted form so cardinality dedup works on the
-// payload, not the quoted form.
-func classifyJSON(raw json.RawMessage) (string, string) {
-	trimmed := strings.TrimSpace(string(raw))
-	if trimmed == "" {
-		return "string", ""
-	}
-	switch trimmed[0] {
-	case '"':
-		var s string
-		if err := json.Unmarshal(raw, &s); err == nil {
-			return classifyScalar(s), s
+// parseLine runs Loki's own line parsers over a log body: json first
+// (capturing JSON paths), logfmt as the fallback — the exact cascade
+// upstream's parseEntry uses. Returns the extracted (key → value) map
+// (logqlmodel error labels dropped) plus the single-parser list that
+// produced it; (nil, nil) when neither parser accepts the line.
+func parseLine(line string, lbls *loglib.LabelsBuilder) (map[string]string, []string) {
+	parser := "json"
+	jsonParser := loglib.NewJSONParser(true)
+	_, jsonSuccess := jsonParser.Process(0, []byte(line), lbls)
+	if !jsonSuccess || lbls.HasErr() {
+		lbls.Reset()
+
+		logfmtParser := loglib.NewLogfmtParser(false, false)
+		parser = "logfmt"
+		_, logfmtSuccess := logfmtParser.Process(0, []byte(line), lbls)
+		if !logfmtSuccess || lbls.HasErr() {
+			return nil, nil
 		}
-		return "string", trimmed
-	case 't', 'f':
-		return "boolean", trimmed
-	case 'n':
-		return "string", trimmed
-	case '{', '[':
-		return "string", trimmed
 	}
-	// numeric: int vs float.
-	if _, err := strconv.ParseInt(trimmed, 10, 64); err == nil {
-		return "int", trimmed
+
+	out := map[string]string{}
+	lbls.LabelsResult().Parsed().Range(func(l labels.Label) {
+		if l.Name == logqlmodel.ErrorLabel || l.Name == logqlmodel.ErrorDetailsLabel ||
+			l.Name == logqlmodel.PreserveErrorLabel {
+			return
+		}
+		out[l.Name] = l.Value
+	})
+	if len(out) == 0 {
+		return nil, nil
 	}
-	if _, err := strconv.ParseFloat(trimmed, 64); err == nil {
-		return "float", trimmed
-	}
-	return "string", trimmed
+	return out, []string{parser}
 }
 
-// classifyScalar sniffs a string value and picks the best-fit type tag.
-// The vocabulary matches Loki's documented set: string / int / float /
-// boolean / duration / bytes.
-func classifyScalar(v string) string {
-	if v == "" {
-		return "string"
-	}
-	if v == "true" || v == "false" {
-		return "boolean"
-	}
-	if _, err := strconv.ParseInt(v, 10, 64); err == nil {
+// determineFieldType sniffs a value and picks the upstream type tag.
+// The cascade order is upstream's determineType verbatim: int → float
+// → boolean → duration → bytes → string. Note boolean uses
+// strconv.ParseBool but sits AFTER the numeric probes, so "1" is an
+// int, not a boolean; bytes uses humanize.ParseBytes ("10MB",
+// "1.5GiB", ...), the same parser upstream calls.
+func determineFieldType(value string) string {
+	if _, err := strconv.ParseInt(value, 10, 64); err == nil {
 		return "int"
 	}
-	if _, err := strconv.ParseFloat(v, 64); err == nil {
+	if _, err := strconv.ParseFloat(value, 64); err == nil {
 		return "float"
 	}
-	if _, err := time.ParseDuration(v); err == nil {
+	if _, err := strconv.ParseBool(value); err == nil {
+		return "boolean"
+	}
+	if _, err := time.ParseDuration(value); err == nil {
 		return "duration"
 	}
-	if isBytesLiteral(v) {
+	if _, err := humanize.ParseBytes(value); err == nil {
 		return "bytes"
 	}
 	return "string"
 }
 
-// isBytesLiteral detects payload-size suffixes like "10KB", "1.5MiB".
-// Conservatively gated on a small whitelist — anything fancier and the
-// caller falls back to "string".
-func isBytesLiteral(v string) bool {
-	suffixes := []string{"B", "KB", "MB", "GB", "TB", "KiB", "MiB", "GiB", "TiB"}
-	for _, suf := range suffixes {
-		if !strings.HasSuffix(v, suf) {
-			continue
-		}
-		num := strings.TrimSuffix(v, suf)
-		if num == "" {
-			continue
-		}
-		if _, err := strconv.ParseFloat(num, 64); err == nil {
-			return true
-		}
+// sortedKeys returns the map's keys in sorted order — the determinism
+// shim for the upstream loops that iterate Go maps directly.
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
 	}
-	return false
-}
-
-// mergeType collapses two type tags observed for the same field across
-// rows. Identical → preserved; mismatched → "string" (the universal
-// downgrade). Anything else: pick the loser deterministically.
-func mergeType(a, b string) string {
-	if a == b {
-		return a
-	}
-	return "string"
-}
-
-// parseLogfmt runs Loki's logfmt parser over a line. Returns the
-// extracted (key, value) map plus true if the parser accepted the line.
-// The parser's hint argument lets it skip records it can't classify;
-// we want every key, so the hint is unset.
-func parseLogfmt(line string) (map[string]string, bool) {
-	parser := loglib.NewLogfmtParser(false, false)
-	lbs := loglib.NewBaseLabelsBuilder().ForLabels(labels.EmptyLabels(), 0)
-	_, ok := parser.Process(0, []byte(line), lbs)
-	if !ok {
-		return nil, false
-	}
-	out := map[string]string{}
-	lbs.LabelsResult().Labels().Range(func(l labels.Label) {
-		out[l.Name] = l.Value
-	})
-	return out, len(out) > 0
+	sort.Strings(keys)
+	return keys
 }
 
 // parsePositiveInt parses an optional integer query parameter. Empty

--- a/internal/api/loki/detected_fields_chdb_test.go
+++ b/internal/api/loki/detected_fields_chdb_test.go
@@ -1,0 +1,139 @@
+//go:build chdb
+
+// chDB-backed end-to-end coverage for /loki/api/v1/detected_fields.
+// The default (untagged) test lane exercises the handler against a
+// stubQuerier that hand-feeds canned (Body, LogAttributes,
+// ResourceAttributes) rows; this file round-trips the same flow through
+// real ClickHouse semantics: the handler emits the three-column peek
+// SQL, chDB executes it against a seeded otel_logs table (Map columns
+// included), and the response is decoded back exactly as Grafana's
+// Logs Drilldown reads it — top-level `fields`, no envelope.
+
+package loki_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/api/loki"
+)
+
+// detectedFieldsLogsDDL is the minimal otel_logs projection
+// buildDetectedFieldsSQL touches: the three selected columns plus the
+// Timestamp ordering key. Engine = Memory — the peek SQL is a straight
+// SELECT ... ORDER BY Timestamp DESC LIMIT N with no optimizer passes.
+const detectedFieldsLogsDDL = `CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    LogAttributes Map(String, String),
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;`
+
+// TestDetectedFields_ChDB_Roundtrip seeds otel_logs with logfmt bodies
+// + LogAttributes structured metadata, exercises the handler end-to-end
+// through chDB, and asserts the consumer-decoded response carries:
+//   - the logfmt-parsed fields (status / latency) with parser tags,
+//   - the structured-metadata field (detected_level) with nil parsers,
+//   - cardinalities that match the seeded distinct-value counts,
+//   - the selector predicate + time bounds applied in CH (an
+//     out-of-window row and a non-matching stream are excluded).
+func TestDetectedFields_ChDB_Roundtrip(t *testing.T) {
+	base := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
+	const tsFmt = "2006-01-02 15:04:05.000"
+
+	type seedRow struct {
+		dt    time.Duration
+		body  string
+		level string
+		job   string
+	}
+	seedRows := []seedRow{
+		{0 * time.Second, "status=200 latency=5ms", "info", "api"},
+		{1 * time.Second, "status=500 latency=22ms", "error", "api"},
+		{2 * time.Second, "status=200 latency=9ms", "info", "api"},
+		// Different stream — the {job="api"} selector must exclude it.
+		{3 * time.Second, "status=301 latency=2ms", "warn", "web"},
+		// Outside the request window — the time bound must exclude it.
+		{2 * time.Hour, "status=418 latency=1ms", "debug", "api"},
+	}
+
+	var inserts strings.Builder
+	inserts.WriteString("INSERT INTO otel_logs (Timestamp, Body, LogAttributes, ResourceAttributes) VALUES\n")
+	for i, row := range seedRows {
+		ts := base.Add(row.dt).Format(tsFmt)
+		comma := ","
+		if i == len(seedRows)-1 {
+			comma = ";"
+		}
+		fmt.Fprintf(&inserts,
+			"    (toDateTime64('%s', 9), '%s', map('detected_level', '%s'), map('job', '%s'))%s\n",
+			ts, row.body, row.level, row.job, comma)
+	}
+
+	srv, _ := newChDBPatternsServer(t, detectedFieldsLogsDDL+inserts.String())
+
+	startUnix := base.Add(-1 * time.Minute).Unix()
+	endUnix := base.Add(1 * time.Minute).Unix()
+	url := fmt.Sprintf(
+		`%s/loki/api/v1/detected_fields?query=%%7Bjob%%3D%%22api%%22%%7D&start=%d&end=%d`,
+		srv.URL, startUnix, endUnix,
+	)
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+
+	// Decode exactly as the consumer does: bare top-level fields.
+	var out loki.DetectedFieldsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	byLabel := map[string]loki.DetectedField{}
+	for _, f := range out.Fields {
+		byLabel[f.Label] = f
+	}
+
+	status, ok := byLabel["status"]
+	if !ok {
+		t.Fatalf("status missing from fields: %+v", out.Fields)
+	}
+	if status.Type != "int" {
+		t.Errorf("status.type=%q want int", status.Type)
+	}
+	// In-window api rows carry status ∈ {200, 500}: the web stream's
+	// 301 and the out-of-window 418 must not contribute.
+	if status.Cardinality != 2 {
+		t.Errorf("status.cardinality=%d want 2 (selector + window applied in CH)", status.Cardinality)
+	}
+	if len(status.Parsers) != 1 || status.Parsers[0] != "logfmt" {
+		t.Errorf("status.parsers=%v want [logfmt]", status.Parsers)
+	}
+
+	latency, ok := byLabel["latency"]
+	if !ok {
+		t.Fatalf("latency missing from fields: %+v", out.Fields)
+	}
+	if latency.Type != "duration" {
+		t.Errorf("latency.type=%q want duration", latency.Type)
+	}
+
+	level, ok := byLabel["detected_level"]
+	if !ok {
+		t.Fatalf("detected_level missing from fields: %+v", out.Fields)
+	}
+	if level.Parsers != nil {
+		t.Errorf("detected_level.parsers=%v want nil (structured metadata)", level.Parsers)
+	}
+	if level.Cardinality != 2 {
+		t.Errorf("detected_level.cardinality=%d want 2 (info+error)", level.Cardinality)
+	}
+}

--- a/internal/api/loki/detected_fields_test.go
+++ b/internal/api/loki/detected_fields_test.go
@@ -2,53 +2,62 @@ package loki_test
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
 
 	"github.com/tsouza/cerberus/internal/api/loki"
+	"github.com/tsouza/cerberus/internal/chclient"
 )
 
-type detectedFieldsResponse struct {
-	Status string                  `json:"status"`
-	Data   loki.DetectedFieldsData `json:"data"`
-	Error  string                  `json:"error"`
-}
-
-// TestDetectedFields_JSON exercises the JSON detection branch. A row
-// with `{"status":200,"path":"/x"}` should yield two fields with
-// typed inference.
-func TestDetectedFields_JSON(t *testing.T) {
-	t.Parallel()
-
-	q := &stubQuerier{stringRows: []string{
-		`{"status":200,"path":"/api","ok":true}`,
-		`{"status":404,"path":"/api","ok":false}`,
-	}}
-	srv := newServer(q)
-	t.Cleanup(srv.Close)
-
-	resp, err := http.Get(srv.URL +
-		`/loki/api/v1/detected_fields?query=%7Bjob%3D%22api%22%7D`)
+// getDetectedFields issues the request and decodes the body EXACTLY as
+// the consumer (Grafana's Logs Drilldown / Loki datasource) does: the
+// upstream wire shape is the BARE logproto.DetectedFieldsResponse —
+// top-level `fields` + `limit`, no {status, data} envelope.
+func getDetectedFields(t *testing.T, url string) loki.DetectedFieldsResponse {
+	t.Helper()
+	resp, err := http.Get(url)
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("status=%d", resp.StatusCode)
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
 	}
-
-	var out detectedFieldsResponse
+	var out loki.DetectedFieldsResponse
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if out.Status != "success" {
-		t.Fatalf("status=%q", out.Status)
-	}
+	return out
+}
+
+func fieldsByLabel(fields []loki.DetectedField) map[string]loki.DetectedField {
 	byLabel := map[string]loki.DetectedField{}
-	for _, f := range out.Data.Fields {
+	for _, f := range fields {
 		byLabel[f.Label] = f
 	}
+	return byLabel
+}
+
+// TestDetectedFields_JSON exercises the JSON detection branch. Rows
+// with JSON bodies yield typed fields tagged with the "json" parser
+// and their original jsonPath.
+func TestDetectedFields_JSON(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{detectedRows: []chclient.DetectedFieldRow{
+		{Line: `{"status":200,"path":"/api","ok":true}`},
+		{Line: `{"status":404,"path":"/api","ok":false}`},
+	}}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	out := getDetectedFields(t, srv.URL+
+		`/loki/api/v1/detected_fields?query=%7Bjob%3D%22api%22%7D`)
+
+	byLabel := fieldsByLabel(out.Fields)
 	if got := byLabel["status"].Type; got != "int" {
 		t.Errorf("status.type=%q want int", got)
 	}
@@ -61,9 +70,27 @@ func TestDetectedFields_JSON(t *testing.T) {
 	if got := byLabel["status"].Cardinality; got != 2 {
 		t.Errorf("status.cardinality=%d want 2", got)
 	}
+	for _, label := range []string{"status", "path", "ok"} {
+		f := byLabel[label]
+		if len(f.Parsers) != 1 || f.Parsers[0] != "json" {
+			t.Errorf("%s.parsers=%v want [json]", label, f.Parsers)
+		}
+		if len(f.JSONPath) != 1 || f.JSONPath[0] != label {
+			t.Errorf("%s.jsonPath=%v want [%s]", label, f.JSONPath, label)
+		}
+	}
+	if out.Limit == 0 {
+		t.Errorf("limit not echoed alongside non-empty fields: %+v", out)
+	}
 
-	// SQL sanity: ordering by Timestamp DESC + LIMIT.
+	// SQL sanity: the peek window selects all three field sources,
+	// ordered by Timestamp DESC + LIMIT.
 	lastSQL := q.LastSQL()
+	for _, col := range []string{"`Body`", "`LogAttributes`", "`ResourceAttributes`"} {
+		if !strings.Contains(lastSQL, col) {
+			t.Errorf("missing %s projection: %q", col, lastSQL)
+		}
+	}
 	if !strings.Contains(lastSQL, "ORDER BY `Timestamp` DESC") {
 		t.Errorf("missing ORDER BY DESC: %q", lastSQL)
 	}
@@ -72,35 +99,23 @@ func TestDetectedFields_JSON(t *testing.T) {
 	}
 }
 
-// TestDetectedFields_Logfmt covers the logfmt branch: free-form
-// key=value lines.
+// TestDetectedFields_Logfmt covers the logfmt fallback branch:
+// free-form key=value lines tagged with the "logfmt" parser, no
+// jsonPath.
 func TestDetectedFields_Logfmt(t *testing.T) {
 	t.Parallel()
 
-	q := &stubQuerier{stringRows: []string{
-		`level=info method=GET status=200 duration=12ms`,
-		`level=error method=POST status=500 duration=1s`,
+	q := &stubQuerier{detectedRows: []chclient.DetectedFieldRow{
+		{Line: `level=info method=GET status=200 duration=12ms`},
+		{Line: `level=error method=POST status=500 duration=1s`},
 	}}
 	srv := newServer(q)
 	t.Cleanup(srv.Close)
 
-	resp, err := http.Get(srv.URL +
+	out := getDetectedFields(t, srv.URL+
 		`/loki/api/v1/detected_fields?query=%7Bjob%3D%22api%22%7D`)
-	if err != nil {
-		t.Fatalf("GET: %v", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("status=%d", resp.StatusCode)
-	}
-	var out detectedFieldsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	byLabel := map[string]loki.DetectedField{}
-	for _, f := range out.Data.Fields {
-		byLabel[f.Label] = f
-	}
+
+	byLabel := fieldsByLabel(out.Fields)
 	if got := byLabel["duration"].Type; got != "duration" {
 		t.Errorf("duration.type=%q want duration", got)
 	}
@@ -110,32 +125,166 @@ func TestDetectedFields_Logfmt(t *testing.T) {
 	if got := byLabel["level"].Type; got != "string" {
 		t.Errorf("level.type=%q want string", got)
 	}
+	f := byLabel["status"]
+	if len(f.Parsers) != 1 || f.Parsers[0] != "logfmt" {
+		t.Errorf("status.parsers=%v want [logfmt]", f.Parsers)
+	}
+	if len(f.JSONPath) != 0 {
+		t.Errorf("status.jsonPath=%v want empty for logfmt", f.JSONPath)
+	}
 }
 
-// TestDetectedFields_Empty — no rows returned → empty fields list (not
-// nil — Grafana renders an empty array gracefully but errors on null).
-func TestDetectedFields_Empty(t *testing.T) {
+// TestDetectedFields_StructuredMetadata — LogAttributes entries (the
+// OTel-CH structured-metadata analogue) are reported as fields with a
+// NULL parser list, exactly as upstream Loki reports fields that come
+// from structured metadata rather than line parsing.
+func TestDetectedFields_StructuredMetadata(t *testing.T) {
 	t.Parallel()
 
-	q := &stubQuerier{stringRows: nil}
+	q := &stubQuerier{detectedRows: []chclient.DetectedFieldRow{
+		{Line: `plain text line`, Attributes: map[string]string{"detected_level": "info"}},
+		{Line: `another plain line`, Attributes: map[string]string{"detected_level": "error"}},
+	}}
 	srv := newServer(q)
 	t.Cleanup(srv.Close)
 
-	resp, err := http.Get(srv.URL +
+	out := getDetectedFields(t, srv.URL+
 		`/loki/api/v1/detected_fields?query=%7Bjob%3D%22api%22%7D`)
-	if err != nil {
-		t.Fatalf("GET: %v", err)
+
+	byLabel := fieldsByLabel(out.Fields)
+	f, ok := byLabel["detected_level"]
+	if !ok {
+		t.Fatalf("detected_level missing from fields: %+v", out.Fields)
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("status=%d", resp.StatusCode)
+	if f.Parsers != nil {
+		t.Errorf("detected_level.parsers=%v want nil (structured metadata)", f.Parsers)
 	}
-	var out detectedFieldsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
-		t.Fatalf("decode: %v", err)
+	if f.Type != "string" {
+		t.Errorf("detected_level.type=%q want string", f.Type)
 	}
-	if len(out.Data.Fields) != 0 {
-		t.Fatalf("fields=%+v want []", out.Data.Fields)
+	if f.Cardinality != 2 {
+		t.Errorf("detected_level.cardinality=%d want 2", f.Cardinality)
+	}
+}
+
+// TestDetectedFields_MetadataAndParsedMerge — a key present both in
+// LogAttributes AND parseable from the line accumulates the parser
+// list (upstream merges the two sources into one field entry).
+func TestDetectedFields_MetadataAndParsedMerge(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{detectedRows: []chclient.DetectedFieldRow{
+		{Line: `level=info msg=ok`, Attributes: map[string]string{"level": "info"}},
+	}}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	out := getDetectedFields(t, srv.URL+
+		`/loki/api/v1/detected_fields?query=%7Bjob%3D%22api%22%7D`)
+
+	byLabel := fieldsByLabel(out.Fields)
+	f, ok := byLabel["level"]
+	if !ok {
+		t.Fatalf("level missing from fields: %+v", out.Fields)
+	}
+	if len(f.Parsers) != 1 || f.Parsers[0] != "logfmt" {
+		t.Errorf("level.parsers=%v want [logfmt] after metadata+parsed merge", f.Parsers)
+	}
+}
+
+// TestDetectedFields_StreamLabelCollision — a parsed key that shadows
+// a stream label (ResourceAttributes) is renamed `<key>_extracted`,
+// mirroring upstream Loki's labels-builder collision policy.
+func TestDetectedFields_StreamLabelCollision(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{detectedRows: []chclient.DetectedFieldRow{
+		{
+			Line:     `service_name=other msg=hello`,
+			Resource: map[string]string{"service_name": "api"},
+		},
+	}}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	out := getDetectedFields(t, srv.URL+
+		`/loki/api/v1/detected_fields?query=%7Bjob%3D%22api%22%7D`)
+
+	byLabel := fieldsByLabel(out.Fields)
+	if _, ok := byLabel["service_name_extracted"]; !ok {
+		t.Errorf("expected service_name_extracted for stream-label collision, got: %+v", out.Fields)
+	}
+	if _, ok := byLabel["service_name"]; ok {
+		t.Errorf("raw service_name must not be reported as a detected field (it is a stream label): %+v", out.Fields)
+	}
+}
+
+// TestDetectedFields_TypeFollowsLastRow — upstream re-detects the type
+// per record and lets the LAST processed record win; there is no
+// merge-to-string collapse.
+func TestDetectedFields_TypeFollowsLastRow(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{detectedRows: []chclient.DetectedFieldRow{
+		{Line: `v=12`},
+		{Line: `v=hello`},
+	}}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	out := getDetectedFields(t, srv.URL+
+		`/loki/api/v1/detected_fields?query=%7Bjob%3D%22api%22%7D`)
+
+	byLabel := fieldsByLabel(out.Fields)
+	if got := byLabel["v"].Type; got != "string" {
+		t.Errorf("v.type=%q want string (last row wins)", got)
+	}
+	if got := byLabel["v"].Cardinality; got != 2 {
+		t.Errorf("v.cardinality=%d want 2", got)
+	}
+}
+
+// TestDetectedFields_LimitCapsDistinctFields — `limit` caps the number
+// of DISTINCT fields tracked (upstream stops admitting new field names
+// once the cap is hit; existing ones keep accumulating).
+func TestDetectedFields_LimitCapsDistinctFields(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{detectedRows: []chclient.DetectedFieldRow{
+		{Line: `{"a":1,"b":2,"c":3}`},
+	}}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	out := getDetectedFields(t, srv.URL+
+		`/loki/api/v1/detected_fields?query=%7Bjob%3D%22api%22%7D&limit=2`)
+
+	if len(out.Fields) != 2 {
+		t.Fatalf("fields=%d want 2 (limit cap): %+v", len(out.Fields), out.Fields)
+	}
+	if out.Limit != 2 {
+		t.Errorf("limit echo=%d want 2", out.Limit)
+	}
+}
+
+// TestDetectedFields_Empty — no rows returned → upstream omits both
+// `fields` and `limit` (omitempty), so the body decodes to the zero
+// response. The consumer renders this as "no fields", which is correct
+// for genuinely empty data.
+func TestDetectedFields_Empty(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{detectedRows: nil}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	out := getDetectedFields(t, srv.URL+
+		`/loki/api/v1/detected_fields?query=%7Bjob%3D%22api%22%7D`)
+	if len(out.Fields) != 0 {
+		t.Fatalf("fields=%+v want []", out.Fields)
+	}
+	if out.Limit != 0 {
+		t.Fatalf("limit=%d want omitted on empty fields", out.Limit)
 	}
 }
 
@@ -160,6 +309,7 @@ func TestDetectedFields_BadInput(t *testing.T) {
 			if err != nil {
 				t.Fatalf("GET: %v", err)
 			}
+			defer resp.Body.Close()
 			if resp.StatusCode != http.StatusBadRequest {
 				t.Fatalf("expected 400, got %d", resp.StatusCode)
 			}

--- a/internal/api/loki/detected_fields_test.go
+++ b/internal/api/loki/detected_fields_test.go
@@ -299,12 +299,13 @@ func TestDetectedFields_BadInput(t *testing.T) {
 		{"missing query", `/loki/api/v1/detected_fields?start=1&end=2`},
 		{"bad query", `/loki/api/v1/detected_fields?query=%7Bnot+a+selector`},
 		{"bad line_limit", `/loki/api/v1/detected_fields?query=%7Bjob%3D%22api%22%7D&line_limit=-1`},
-		// limit is echoed on the wire as logproto's uint32; a value
-		// past math.MaxUint32 must be rejected at parse time, not
-		// wrapped by the int->uint32 conversion (CodeQL
-		// go/incorrect-integer-conversion on PR #774).
+		// limits are bounded to MaxInt32 at parse time (ParseUint
+		// bitSize 31) so neither the wire uint32 nor a 32-bit int can
+		// ever wrap (CodeQL go/incorrect-integer-conversion on PR
+		// #774). Pin both the int32 and the uint32 boundary.
+		{"limit above int32", `/loki/api/v1/detected_fields?query=%7Bjob%3D%22api%22%7D&limit=2147483648`},
 		{"limit above uint32", `/loki/api/v1/detected_fields?query=%7Bjob%3D%22api%22%7D&limit=4294967296`},
-		{"line_limit above uint32", `/loki/api/v1/detected_fields?query=%7Bjob%3D%22api%22%7D&line_limit=4294967296`},
+		{"line_limit above int32", `/loki/api/v1/detected_fields?query=%7Bjob%3D%22api%22%7D&line_limit=2147483648`},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/api/loki/detected_fields_test.go
+++ b/internal/api/loki/detected_fields_test.go
@@ -299,6 +299,12 @@ func TestDetectedFields_BadInput(t *testing.T) {
 		{"missing query", `/loki/api/v1/detected_fields?start=1&end=2`},
 		{"bad query", `/loki/api/v1/detected_fields?query=%7Bnot+a+selector`},
 		{"bad line_limit", `/loki/api/v1/detected_fields?query=%7Bjob%3D%22api%22%7D&line_limit=-1`},
+		// limit is echoed on the wire as logproto's uint32; a value
+		// past math.MaxUint32 must be rejected at parse time, not
+		// wrapped by the int->uint32 conversion (CodeQL
+		// go/incorrect-integer-conversion on PR #774).
+		{"limit above uint32", `/loki/api/v1/detected_fields?query=%7Bjob%3D%22api%22%7D&limit=4294967296`},
+		{"line_limit above uint32", `/loki/api/v1/detected_fields?query=%7Bjob%3D%22api%22%7D&line_limit=4294967296`},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -34,6 +34,7 @@ import (
 type Querier interface {
 	Query(ctx context.Context, sql string, args ...any) ([]chclient.Sample, error)
 	QueryStrings(ctx context.Context, sql string, args ...any) ([]string, error)
+	QueryDetectedFieldRows(ctx context.Context, sql string, args ...any) ([]chclient.DetectedFieldRow, error)
 	QueryTimestampedLines(ctx context.Context, sql string, args ...any) ([]chclient.TimestampedLine, error)
 	QueryIndexStats(ctx context.Context, sql string, args ...any) (chclient.IndexStatsRow, error)
 	QueryIndexVolume(ctx context.Context, sql string, args ...any) ([]chclient.IndexVolumeRow, error)

--- a/internal/api/loki/handler_test.go
+++ b/internal/api/loki/handler_test.go
@@ -39,10 +39,15 @@ type stubQuerier struct {
 	volumeRows []chclient.IndexVolumeRow
 	volumeErr  error
 
-	// /labels, /label/{name}/values, /detected_fields share a
-	// single-column string-row result shape; reuse the same channel.
+	// /labels and /label/{name}/values share a single-column
+	// string-row result shape; reuse the same channel.
 	stringRows []string
 	stringsErr error
+
+	// /detected_fields canned (Body, LogAttributes, ResourceAttributes)
+	// rows.
+	detectedRows []chclient.DetectedFieldRow
+	detectedErr  error
 
 	// /series canned label-set rows.
 	labelSets    []map[string]string
@@ -95,6 +100,18 @@ func (s *stubQuerier) QueryStrings(_ context.Context, sql string, args ...any) (
 	s.lastSQL = sql
 	s.lastArgs = args
 	rows, err := s.stringRows, s.stringsErr
+	s.mu.Unlock()
+	if err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+func (s *stubQuerier) QueryDetectedFieldRows(_ context.Context, sql string, args ...any) ([]chclient.DetectedFieldRow, error) {
+	s.mu.Lock()
+	s.lastSQL = sql
+	s.lastArgs = args
+	rows, err := s.detectedRows, s.detectedErr
 	s.mu.Unlock()
 	if err != nil {
 		return nil, err

--- a/internal/api/loki/patterns.go
+++ b/internal/api/loki/patterns.go
@@ -86,11 +86,12 @@ func (h *Handler) handlePatterns(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, ErrBadData, err)
 		return
 	}
-	lineLimit, err := parsePositiveInt(r.URL.Query().Get("line_limit"), defaultPatternsLineLimit)
+	lineLimit32, err := parsePositiveUint32(r.URL.Query().Get("line_limit"), defaultPatternsLineLimit)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, ErrBadData, err)
 		return
 	}
+	lineLimit := int(lineLimit32)
 
 	sqlStr, args, err := buildPatternsSQL(h.Schema, matchers, start, end, lineLimit)
 	if err != nil {

--- a/internal/api/loki/patterns.go
+++ b/internal/api/loki/patterns.go
@@ -86,12 +86,11 @@ func (h *Handler) handlePatterns(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, ErrBadData, err)
 		return
 	}
-	lineLimit32, err := parsePositiveUint32(r.URL.Query().Get("line_limit"), defaultPatternsLineLimit)
+	lineLimit, err := parsePositiveInt31(r.URL.Query().Get("line_limit"), defaultPatternsLineLimit)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, ErrBadData, err)
 		return
 	}
-	lineLimit := int(lineLimit32)
 
 	sqlStr, args, err := buildPatternsSQL(h.Schema, matchers, start, end, lineLimit)
 	if err != nil {

--- a/internal/api/loki/tail_test.go
+++ b/internal/api/loki/tail_test.go
@@ -87,6 +87,10 @@ func (s *tailStubQuerier) QueryStrings(_ context.Context, _ string, _ ...any) ([
 	return s.stringRows, s.stringsErr
 }
 
+func (s *tailStubQuerier) QueryDetectedFieldRows(_ context.Context, _ string, _ ...any) ([]chclient.DetectedFieldRow, error) {
+	return nil, nil
+}
+
 func (s *tailStubQuerier) QueryTimestampedLines(_ context.Context, _ string, _ ...any) ([]chclient.TimestampedLine, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/chclient/client.go
+++ b/internal/chclient/client.go
@@ -388,6 +388,64 @@ func (c *Client) QueryStrings(ctx context.Context, sql string, args ...any) ([]s
 	return out, nil
 }
 
+// DetectedFieldRow is one (Body, LogAttributes, ResourceAttributes)
+// tuple from the peek-window SQL backing /loki/api/v1/detected_fields.
+// Line carries the raw log body the handler runs the JSON / logfmt
+// detection over; Attributes carries the record-level attribute map
+// (Loki's structured-metadata analogue in the OTel-CH schema);
+// Resource carries the stream-identity label map the parser uses for
+// collision renaming (a parsed key that shadows a stream label is
+// surfaced as `<key>_extracted`, mirroring upstream Loki).
+type DetectedFieldRow struct {
+	Line       string
+	Attributes map[string]string
+	Resource   map[string]string
+}
+
+// QueryDetectedFieldRows runs sql and decodes a (String,
+// Map(String,String), Map(String,String)) three-column result set into
+// a flat slice. Used by /loki/api/v1/detected_fields to feed the
+// field-detection heuristic — the handler needs the body for parsing
+// plus both attribute maps for structured-metadata fields and
+// stream-label collision handling.
+//
+// Guarded by the circuit breaker (see [Client] doc).
+func (c *Client) QueryDetectedFieldRows(ctx context.Context, sql string, args ...any) ([]DetectedFieldRow, error) {
+	if !c.br.allow() {
+		return nil, fmt.Errorf("chclient: query: %w", ErrCircuitOpen)
+	}
+	ctx = c.queryContext(ctx)
+	ctx, span := startExecuteSpan(ctx, sql, c.addr)
+	defer span.End()
+	defer flushProgress(ctx)
+	rows, err := c.conn.Query(ctx, sql, args...)
+	c.br.record(ctx, err)
+	if err != nil {
+		span.RecordError(err)
+		return nil, fmt.Errorf("chclient: query: %w", wrapMemoryLimit(err, c.maxMemory))
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+
+	var out []DetectedFieldRow
+	for rows.Next() {
+		var (
+			line     string
+			attrs    map[string]string
+			resource map[string]string
+		)
+		if err := rows.Scan(&line, &attrs, &resource); err != nil {
+			return nil, fmt.Errorf("chclient: scan: %w", err)
+		}
+		out = append(out, DetectedFieldRow{Line: line, Attributes: attrs, Resource: resource})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("chclient: rows.Err: %w", wrapMemoryLimit(err, c.maxMemory))
+	}
+	return out, nil
+}
+
 // TimestampedLine is one (Timestamp, Body) tuple from the peek-window
 // SQL backing /loki/api/v1/patterns. The timestamp is the row's
 // DateTime64 value verbatim; the body is the raw log line. The drain

--- a/internal/chclienttest/client.go
+++ b/internal/chclienttest/client.go
@@ -185,6 +185,49 @@ func (c *Client) QueryStrings(ctx context.Context, query string, args ...any) ([
 	return out, nil
 }
 
+// QueryDetectedFieldRows runs sql and decodes a (String,
+// Map(String,String), Map(String,String)) three-column result set into
+// chclient.DetectedFieldRow tuples. Used by /loki/api/v1/detected_fields.
+// The two Map columns are wrapped server-side in toJSONString(...) by
+// rewriteMapProjections and decoded back on the Go side per the chDB
+// driver Map-panic probe.
+func (c *Client) QueryDetectedFieldRows(ctx context.Context, query string, args ...any) ([]chclient.DetectedFieldRow, error) {
+	if c.err != nil {
+		return nil, c.err
+	}
+	rewritten := rewriteMapProjections(query)
+	rows, err := c.db.QueryContext(ctx, rewritten, args...)
+	if err != nil {
+		return nil, fmt.Errorf("chclienttest: query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []chclient.DetectedFieldRow
+	for rows.Next() {
+		var (
+			line         string
+			attrsJSON    string
+			resourceJSON string
+		)
+		if err := rows.Scan(&line, &attrsJSON, &resourceJSON); err != nil {
+			return nil, fmt.Errorf("chclienttest: scan: %w", err)
+		}
+		attrs, err := decodeMapJSON(attrsJSON)
+		if err != nil {
+			return nil, err
+		}
+		resource, err := decodeMapJSON(resourceJSON)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, chclient.DetectedFieldRow{Line: line, Attributes: attrs, Resource: resource})
+	}
+	if err := tolerantRowsErr(rows.Err()); err != nil {
+		return nil, fmt.Errorf("chclienttest: rows.Err: %w", err)
+	}
+	return out, nil
+}
+
 // QueryTimestampedLines runs sql and decodes a (DateTime64, String)
 // two-column result set into chclient.TimestampedLine tuples. Used by
 // /loki/api/v1/patterns to feed the drain template miner.

--- a/internal/chclienttest/rewrite.go
+++ b/internal/chclienttest/rewrite.go
@@ -31,12 +31,21 @@ func tolerantRowsErr(err error) error {
 // (String),String)). Without the toJSONString wrap chDB's parquet driver
 // panics decoding the column as a Go string in the chclienttest scan
 // path — same Map-panic probe Attributes / ResourceAttributes hit.
+// log_attributes / stream_labels are the aliases
+// loki.buildDetectedFieldsSQL projects for `LogAttributes` /
+// `ResourceAttributes` — distinct from the source column names so the
+// toJSONString wrap can't shadow the raw map the WHERE predicate
+// references (CH resolves WHERE identifiers against SELECT aliases
+// first).
 var mapColumnNames = []string{
 	"Attributes",
 	"ExemplarAttributes",
+	"LogAttributes",
 	"ResourceAttributes",
 	"ScopeAttributes",
 	"SpanAttributes",
+	"log_attributes",
+	"stream_labels",
 }
 
 func isMapColumn(name string) bool {

--- a/test/e2e/playwright/loki_ux.spec.ts
+++ b/test/e2e/playwright/loki_ux.spec.ts
@@ -98,21 +98,55 @@ test.describe('Loki UX — Logs panel flows', () => {
     expect(body.data.result.length, '≥1 stream after chain').toBeGreaterThan(0);
   });
 
-  test('detected fields: side-panel API returns extractable keys', async ({ request }) => {
-    // The Logs panel "Detected fields" side panel calls
-    // /loki/api/v1/detected_fields. The seed bodies are plain text
-    // (not JSON), so the heuristic should still return a deterministic
-    // (possibly empty) fields array — what matters is the envelope.
+  test('detected fields: bare top-level shape + non-empty fields (Logs Drilldown decode)', async ({
+    request,
+  }) => {
+    // Grafana's Logs Drilldown (and the Loki datasource's detected-
+    // fields side panel) call /loki/api/v1/detected_fields and read
+    // `body.fields` at the TOP LEVEL — upstream Loki serializes
+    // logproto.DetectedFieldsResponse bare, with NO {status, data}
+    // envelope (pkg/util/marshal WriteDetectedFieldsResponseJSON).
+    //
+    // Regression pin for the "Fields: 0" bug class: cerberus once
+    // wrapped this payload in the query-API envelope; every drilldown
+    // service page then showed zero fields while the request returned
+    // 200, invisible to status-code oracles. This test decodes the
+    // response exactly as the consumer does and requires real fields.
+    //
+    // The seed guarantees a non-empty result for {service_name="api"}:
+    // LogAttributes carries `thread` (structured metadata source) and
+    // every body ends in `id=<n>` (logfmt-extractable).
     const { start, end } = last5MinWindow();
     const q = encodeURIComponent('{service_name="api"}');
     const url = `${lokiProxy}/detected_fields?query=${q}&start=${start * 1e9}&end=${end * 1e9}`;
     const resp = await request.get(url);
     expect(resp.status()).toBe(200);
     const body = await resp.json();
-    expect(body.status).toBe('success');
-    expect(Array.isArray(body.data.fields), 'data.fields is an array').toBe(true);
-    expect(typeof body.data.limit, 'data.limit is numeric').toBe('number');
-    expect(typeof body.data.line_limit, 'data.line_limit is numeric').toBe('number');
+
+    // Envelope is GONE — body.fields, not body.data.fields.
+    expect(body.status, 'no {status,...} envelope').toBeUndefined();
+    expect(body.data, 'no {data:...} envelope').toBeUndefined();
+    expect(Array.isArray(body.fields), 'top-level fields is an array').toBe(true);
+    expect(body.fields.length, 'drilldown fields badge > 0').toBeGreaterThan(0);
+    expect(typeof body.limit, 'limit echoed for non-empty fields').toBe('number');
+
+    for (const field of body.fields) {
+      expect(typeof field.label, 'field.label is a string').toBe('string');
+      expect(field.label.length, 'field.label is non-empty').toBeGreaterThan(0);
+      expect(typeof field.type, 'field.type is a string').toBe('string');
+      expect(typeof field.cardinality, 'field.cardinality is numeric').toBe('number');
+      expect(field.cardinality, 'field.cardinality > 0').toBeGreaterThan(0);
+      // parsers is ALWAYS on the wire: null for structured-metadata
+      // fields, ["json"] / ["logfmt"] for body-parsed ones.
+      expect('parsers' in field, 'field.parsers key present').toBe(true);
+    }
+
+    // The structured-metadata source (LogAttributes.thread) reports
+    // with parsers=null, mirroring upstream Loki's structured-metadata
+    // fields.
+    const thread = body.fields.find((f: { label: string }) => f.label === 'thread');
+    expect(thread, 'LogAttributes-backed `thread` field detected').toBeTruthy();
+    expect(thread.parsers, 'structured-metadata field has null parsers').toBeNull();
   });
 
   test('patterns: the /patterns endpoint extracts drain clusters from log bodies', async ({

--- a/test/regression/goleak_test.go
+++ b/test/regression/goleak_test.go
@@ -211,6 +211,10 @@ func (s *lokiStub) QueryStrings(_ context.Context, _ string, _ ...any) ([]string
 	return nil, nil
 }
 
+func (s *lokiStub) QueryDetectedFieldRows(_ context.Context, _ string, _ ...any) ([]chclient.DetectedFieldRow, error) {
+	return nil, nil
+}
+
 func (s *lokiStub) QueryTimestampedLines(_ context.Context, _ string, _ ...any) ([]chclient.TimestampedLine, error) {
 	return nil, nil
 }


### PR DESCRIPTION
## Summary

Crawl-confirmed bug cluster: every Logs Drilldown service page showed **"Fields: 0"** while requests returned 200. Two gaps, both fixed against upstream Loki's exact wire shape (cited from the pinned fork, byte-identical to grafana/loki v3.7.0):

1. **Envelope**: cerberus wrapped `/loki/api/v1/detected_fields` in the query-API `{"status":"success","data":{...}}` envelope; upstream serializes `logproto.DetectedFieldsResponse` **bare** (`pkg/util/marshal/marshal.go:180`). Grafana reads `body.fields` → undefined → 0.
2. **Field sources**: the handler only parsed `Body`; upstream also derives fields from structured metadata, with JSON-first/logfmt-fallback parsing, `<key>_extracted` collision handling, per-record type detection (int→float→boolean→duration→bytes→string), HLL cardinality, and `parsers: null` for metadata-only fields — all mirrored, with `LogAttributes` as structured metadata and `ResourceAttributes` as stream labels via typed chsql.

## Tests

- Conformance pin decodes the raw body as the consumer does: top-level `fields` required, top-level `status`/`data` are hard failures (regression pin on the envelope).
- New chdb roundtrip (`TestDetectedFields_ChDB_Roundtrip`).
- **Compat harness**: new per-service `/detected_fields` differential pass vs reference Loki (label/type/cardinality/parsers/jsonPath; envelope = hard error; no allowlists). Live run: **99/99 including 13/13 new detected-fields cases**, bit-exact HLL cardinality.
- `loki_ux.spec.ts`: the previous test **pinned the buggy envelope** (`body.data.fields`) — rewritten to decode as Logs Drilldown does, asserting envelope-gone + a structured-metadata field with `parsers: null`.

## Notes

- `/detected_field/{name}/values` sibling endpoint remains unmounted (pre-existing scope, unchanged).
- Seeder drops its CH-only `LogAttributes["level"]` key so both compat backends ingest equivalent structured metadata (matches what dataset_metadata.json documented).
- hyperloglog + go-humanize promoted to direct deps (same versions Loki 3.7.0 compiles).

Closes task #44 (first of the crawl backlog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
