### PR TITLE
feat(traceql): implement metrics compare() — Traces Drilldown Comparison tab

### DIFF
--- a/compatibility/tempo/driver/corpus/smoke.txtar
+++ b/compatibility/tempo/driver/corpus/smoke.txtar
@@ -39,10 +39,11 @@
 #
 # Cases below cover the 7 shadow categories (attribute matchers per
 # scope (5), intrinsics (4), structural ops (4), set ops (3), inner
-# aggregates (2)) plus 6 metrics-pipeline cases (3 range + 3 instant)
+# aggregates (2)) plus 7 metrics-pipeline cases (4 range + 3 instant)
 # and a per-id smoke; later additions grew the spanSets and metrics
 # families (the count below tracks `grep -c '^-- name --'`).
-# Total: 38 cases.
+# Total: 39 cases — the compare() range case activated alongside
+# chplan.MetricsCompare.
 
 # --- Attribute matchers per scope (5) ---
 

--- a/compatibility/tempo/driver/corpus/smoke.txtar
+++ b/compatibility/tempo/driver/corpus/smoke.txtar
@@ -402,6 +402,33 @@ samples_non_negative
 groupby_labels_present:resource.service.name
 
 -- name --
+metrics_compare_status_error
+# `| compare({...}, topN)` — the baseline-vs-selection attribute split
+# Grafana Traces Drilldown's Comparison tab consumes. The differ
+# compares the full __meta_type series scheme (baseline / selection
+# value series + *_total series) against reference Tempo: label sets
+# by hash, sample grids point-for-point.
+#
+# topN=500 deliberately exceeds every per-attribute cardinality in the
+# seed (span names ~116, http.target 100, rootName 100, trace.index 25)
+# so neither backend truncates — upstream's top-N tie-break is an
+# unstable sort, and a truncated tie would make the case flaky rather
+# than prove anything. Full-inventory comparison is the stronger pin.
+-- query --
+{ } | compare({ status = error }, 500)
+-- endpoint --
+metrics_range
+-- step --
+60s
+-- expected_min_series --
+4
+-- expected_max_series --
+5000
+-- semantic_checks --
+samples_non_negative
+labels_match_query
+
+-- name --
 metrics_quantile_over_time_p95
 -- query --
 { } | quantile_over_time(duration, 0.95)

--- a/compatibility/tempo/driver/seeder.go
+++ b/compatibility/tempo/driver/seeder.go
@@ -103,6 +103,17 @@ const (
 	rootSpanDurationNs = int64(150 * time.Millisecond)
 )
 
+// seederScopeName / seederScopeVersion identify the OTLP
+// InstrumentationScope every pushed span rides under. The CH-side seed
+// mirrors them into the ScopeName / ScopeVersion columns so both
+// backends agree on TraceQL's `instrumentation:name` /
+// `instrumentation:version` intrinsics (exercised by compare()'s
+// attribute explosion).
+const (
+	seederScopeName    = "cerberus-tempo-compat-seeder"
+	seederScopeVersion = "1"
+)
+
 // services enumerates the synthetic service names baked into the
 // fixture. The names are intentionally non-collision with the e2e
 // seeder's set ("frontend" / "api" / "db") so a developer can run both
@@ -427,8 +438,8 @@ func pushOTLP(ctx context.Context, addr string, traces []*fixtureTrace, logger *
 				},
 				ScopeSpans: []*otlptrace.ScopeSpans{{
 					Scope: &commonv1.InstrumentationScope{
-						Name:    "cerberus-tempo-compat-seeder",
-						Version: "1",
+						Name:    seederScopeName,
+						Version: seederScopeVersion,
 					},
 					Spans: t.spans,
 				}},
@@ -456,6 +467,7 @@ func insertCHTraces(ctx context.Context, conn driver.Conn, traces []*fixtureTrac
 	batch, err := conn.PrepareBatch(ctx, `INSERT INTO otel_traces (
         Timestamp, TraceId, SpanId, ParentSpanId,
         SpanName, SpanKind, ServiceName,
+        ScopeName, ScopeVersion,
         ResourceAttributes, SpanAttributes,
         Duration, StatusCode, StatusMessage
     )`)
@@ -478,6 +490,15 @@ func insertCHTraces(ctx context.Context, conn driver.Conn, traces []*fixtureTrac
 				s.Name,
 				spanKindCH[s.Kind],
 				t.service,
+				// The OTLP push wraps every span in the same
+				// InstrumentationScope (see pushOTLP); the OTel-CH exporter
+				// writes that scope into ScopeName / ScopeVersion, so the
+				// direct CH seed must mirror it — TraceQL's
+				// `instrumentation:name` / `instrumentation:version`
+				// intrinsics (surfaced by compare()'s select-all explosion)
+				// read these columns.
+				seederScopeName,
+				seederScopeVersion,
 				t.resAttrs,
 				keyValuesToMap(s.Attributes),
 				uint64(dur), //nolint:gosec // dur is positive (end > start)

--- a/go.mod
+++ b/go.mod
@@ -343,7 +343,7 @@ replace github.com/grafana/loki/v3 => github.com/tsouza/loki/v3 v3.0.0-cerberus-
 // tempo: narrow accessors on top of pkg/traceql to retire the unsafe.Pointer
 // + reflect.FieldByName shims in internal/traceql/. See docs/fork-tempo-
 // plan.md for the migration plan and accessor inventory.
-replace github.com/grafana/tempo => github.com/tsouza/tempo v0.0.3-cerberus-accessors
+replace github.com/grafana/tempo => github.com/tsouza/tempo v0.0.3-cerberus-accessors.0.20260611033556-0888855681c5
 
 // otelc: hoists the ClickHouse exporter's sqltemplates out of `internal/`
 // so cerberus can import them as the schema source-of-truth. collector-

--- a/go.sum
+++ b/go.sum
@@ -710,8 +710,8 @@ github.com/tsouza/opentelemetry-collector-contrib/pkg/translator/jaeger v0.0.2-c
 github.com/tsouza/opentelemetry-collector-contrib/pkg/translator/jaeger v0.0.2-cerberus-ddl/go.mod h1:UetIxoLmE+X0io7ookhE9J/6KoJSdmFzLFmcUiW/XzM=
 github.com/tsouza/prometheus v0.0.1-cerberus-parser h1:RjX9HKGVHPxLbtGKSbzWJ3bGFsmOEORWG2DX2Spg6oY=
 github.com/tsouza/prometheus v0.0.1-cerberus-parser/go.mod h1:orN7+39ySpDpDwh+EbN7UYpMHYNXrl0rabkpVMfMN4g=
-github.com/tsouza/tempo v0.0.3-cerberus-accessors h1:e7HawgDTaAE25M/8LC3zfDLvmrkqMg3Yow6RA+WVpUE=
-github.com/tsouza/tempo v0.0.3-cerberus-accessors/go.mod h1:tV3Pl9la00Ti1stc4RMsIa41zkx1i3mtxKKy13vXwt4=
+github.com/tsouza/tempo v0.0.3-cerberus-accessors.0.20260611033556-0888855681c5 h1:SyIUSwkCPDoxQoeXzwHdukx7VZbIu070rVemXnDYFb4=
+github.com/tsouza/tempo v0.0.3-cerberus-accessors.0.20260611033556-0888855681c5/go.mod h1:tV3Pl9la00Ti1stc4RMsIa41zkx1i3mtxKKy13vXwt4=
 github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31/go.mod h1:onvgF043R+lC5RZ8IT9rBXDaEDnpnw/Cl+HFiw+v/7Q=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/twmb/franz-go v1.21.0 h1:J3uB/poWgHD6VIilER2uCPFAZHDRXVFT+11pBgRKod4=

--- a/internal/api/tempo/export_test.go
+++ b/internal/api/tempo/export_test.go
@@ -9,6 +9,15 @@ var AlignMetricsWindowForTest = func(start, end time.Time, step time.Duration) (
 	return alignMetricsWindow(start, end, step)
 }
 
+// PostProcessCompareForTest / CompareAnchorGridForTest re-export the
+// compare() BaselineAggregator mirror so its top-N / totals / zero-fill
+// semantics can be pinned directly on synthetic row streams without a
+// handler round-trip.
+var (
+	PostProcessCompareForTest = postProcessCompare
+	CompareAnchorGridForTest  = compareAnchorGrid
+)
+
 // GroupBatchesForTest / GroupBatchesProtoForTest re-export the two
 // trace-by-ID assemblers so the determinism tests can drive the pure
 // assembly repeatedly (50 iterations, shuffled inputs) and compare

--- a/internal/api/tempo/grpc_exports.go
+++ b/internal/api/tempo/grpc_exports.go
@@ -200,6 +200,18 @@ func (h *Handler) ExecMetricsRange(ctx context.Context, query string, start, end
 	stages, inner := peelMetricsSecondStages(plan)
 	metrics, ok := unwrapMetricsAggregate(inner)
 	if !ok {
+		// `| compare({...}, topN)` routes through the BaselineAggregator
+		// mirror — same post-processed series the HTTP handler returns.
+		if cmp, cok := unwrapMetricsCompare(inner); cok {
+			if len(stages) > 0 {
+				return ExecMetricsRangeResult{}, fmt.Errorf("%w: traceql: second-stage %s over compare() is unsupported — compare() series carry the __meta_type split, not a scalar Value to rank or threshold", errLowerStage, stages[0].Op)
+			}
+			series, _, cerr := h.execCompareRange(ctx, query, plan, cmp, start, end, step)
+			if cerr != nil {
+				return ExecMetricsRangeResult{}, cerr
+			}
+			return ExecMetricsRangeResult{Series: series}, nil
+		}
 		return ExecMetricsRangeResult{}, fmt.Errorf("%w: query %q is not a TraceQL metrics-pipeline expression — MetricsQueryRange requires `| rate()`, `| count_over_time()`, `| *_over_time(...)` or `| quantile_over_time(...)`", errLowerStage, query)
 	}
 	if len(stages) > 0 && metrics.Op == chplan.MetricsOpQuantileOverTime {
@@ -309,6 +321,19 @@ func (h *Handler) ExecMetricsInstant(ctx context.Context, query string, start, e
 	stages, inner := peelMetricsSecondStages(plan)
 	metrics, ok := unwrapMetricsAggregate(inner)
 	if !ok {
+		// compare() instant — single anchor at `end` (Start = End, same
+		// rationale as handleMetricsQueryInstant's RangeWindow comment),
+		// then the per-series sample collapses to InstantSeries.Value.
+		if cmp, cok := unwrapMetricsCompare(inner); cok {
+			if len(stages) > 0 {
+				return ExecMetricsInstantResult{}, fmt.Errorf("%w: traceql: second-stage %s over compare() is unsupported — compare() series carry the __meta_type split, not a scalar Value to rank or threshold", errLowerStage, stages[0].Op)
+			}
+			series, _, cerr := h.execCompareRange(ctx, query, plan, cmp, end, end, step)
+			if cerr != nil {
+				return ExecMetricsInstantResult{}, cerr
+			}
+			return ExecMetricsInstantResult{Series: compareSeriesToInstant(series)}, nil
+		}
 		return ExecMetricsInstantResult{}, fmt.Errorf("%w: query %q is not a TraceQL metrics-pipeline expression — MetricsQueryInstant requires `| rate()`, `| count_over_time()`, `| *_over_time(...)` or `| quantile_over_time(...)`", errLowerStage, query)
 	}
 	if len(stages) > 0 && metrics.Op == chplan.MetricsOpQuantileOverTime {

--- a/internal/api/tempo/metrics_query_instant.go
+++ b/internal/api/tempo/metrics_query_instant.go
@@ -107,6 +107,29 @@ func (h *Handler) handleMetricsQueryInstant(w http.ResponseWriter, r *http.Reque
 	stages, inner := peelMetricsSecondStages(plan)
 	metrics, ok := unwrapMetricsAggregate(inner)
 	if !ok {
+		// `| compare({...}, topN)` follows its own post-processing path
+		// (the BaselineAggregator mirror); with a single anchor the
+		// per-series sample collapses to the InstantSeries.Value —
+		// translateQueryRangeToInstant semantics, same as the scalar ops.
+		if cmp, cok := unwrapMetricsCompare(inner); cok {
+			if len(stages) > 0 {
+				writeError(w, http.StatusUnprocessableEntity, "", "",
+					fmt.Errorf("traceql: second-stage %s over compare() is unsupported — compare() series carry the __meta_type split, not a scalar Value to rank or threshold", stages[0].Op))
+				return
+			}
+			// Start = End on purpose — see the RangeWindow comment below
+			// for why the instant anchor sits at `end` only.
+			series, headers, cerr := h.execCompareRange(ctx, q, plan, cmp, end, end, step)
+			if cerr != nil {
+				writeError(w, classifyMetricsQueryRangeErr(cerr), "", "", cerr)
+				return
+			}
+			writeEngineHeaders(w, headers)
+			writeJSON(w, http.StatusOK, MetricsQueryInstantResponse{
+				Series: compareSeriesToInstant(series),
+			})
+			return
+		}
 		writeError(w, http.StatusBadRequest, "", "",
 			fmt.Errorf("query %q is not a TraceQL metrics-pipeline expression — /api/metrics/query requires `| rate()`, `| count_over_time()`, `| *_over_time(...)` or `| quantile_over_time(...)`", q))
 		return

--- a/internal/api/tempo/metrics_query_range.go
+++ b/internal/api/tempo/metrics_query_range.go
@@ -276,36 +276,7 @@ func (h *Handler) handleMetricsQueryRange(w http.ResponseWriter, r *http.Request
 	stages, inner := peelMetricsSecondStages(plan)
 	metrics, ok := unwrapMetricsAggregate(inner)
 	if !ok {
-		// `| histogram_over_time(<attr>)` lowers to its own plan node
-		// (chplan.MetricsHistogramOverTime) because the per-bucket value
-		// is a distribution, not a scalar — route it through the
-		// histogram response shape (one series per (group, __bucket)).
-		if hist, hok := unwrapMetricsHistogram(inner); hok {
-			if len(stages) > 0 {
-				writeError(w, http.StatusUnprocessableEntity, "", "",
-					fmt.Errorf("traceql: second-stage %s over histogram_over_time is unsupported — the per-bucket distribution rows have no scalar Value to rank or threshold", stages[0].Op))
-				return
-			}
-			h.serveMetricsQueryRangeHistogram(ctx, w, q, plan, hist, start, end, step)
-			return
-		}
-		// `| compare({...}, topN)` lowers to its own plan node
-		// (chplan.MetricsCompare) — the output is the baseline-vs-
-		// selection attribute split Grafana Traces Drilldown's
-		// Comparison tab renders, not a scalar per series.
-		if cmp, cok := unwrapMetricsCompare(inner); cok {
-			if len(stages) > 0 {
-				// Upstream's parser already rejects this combination
-				// (ast_validate.go); defensive belt for pre-lowered plans.
-				writeError(w, http.StatusUnprocessableEntity, "", "",
-					fmt.Errorf("traceql: second-stage %s over compare() is unsupported — compare() series carry the __meta_type split, not a scalar Value to rank or threshold", stages[0].Op))
-				return
-			}
-			h.serveMetricsQueryRangeCompare(ctx, w, q, plan, cmp, start, end, step)
-			return
-		}
-		writeError(w, http.StatusBadRequest, "", "",
-			fmt.Errorf("query %q is not a TraceQL metrics-pipeline expression — /api/metrics/query_range requires `| rate()`, `| count_over_time()`, `| *_over_time(...)`, `| quantile_over_time(...)` or `| histogram_over_time(...)`", q))
+		h.serveMetricsQueryRangeNonScalar(ctx, w, q, plan, inner, stages, start, end, step)
 		return
 	}
 	if len(stages) > 0 && metrics.Op == chplan.MetricsOpQuantileOverTime {
@@ -396,6 +367,52 @@ func (h *Handler) handleMetricsQueryRange(w http.ResponseWriter, r *http.Request
 	writeJSON(w, http.StatusOK, MetricsQueryRangeResponse{
 		Series: series,
 	})
+}
+
+// serveMetricsQueryRangeNonScalar routes the metrics-pipeline shapes
+// that lower to their own plan node rather than a scalar-valued
+// chplan.MetricsAggregate:
+//
+//   - `| histogram_over_time(<attr>)` → chplan.MetricsHistogramOverTime:
+//     the per-bucket value is a distribution, so the response carries
+//     one series per (group, __bucket).
+//   - `| compare({...}, topN)` → chplan.MetricsCompare: the output is
+//     the baseline-vs-selection attribute split Grafana Traces
+//     Drilldown's Comparison tab renders (__meta_type label scheme).
+//
+// Second-stage wraps over either shape 422 — there is no scalar Value
+// to rank or threshold (compare() additionally rejects at the upstream
+// parser, ast_validate.go; the handler check is the defensive belt for
+// pre-lowered plans). Anything else 400s as a non-metrics query.
+func (h *Handler) serveMetricsQueryRangeNonScalar(
+	ctx context.Context,
+	w http.ResponseWriter,
+	q string,
+	plan, inner chplan.Node,
+	stages []*chplan.MetricsSecondStage,
+	start, end time.Time,
+	step time.Duration,
+) {
+	if hist, ok := unwrapMetricsHistogram(inner); ok {
+		if len(stages) > 0 {
+			writeError(w, http.StatusUnprocessableEntity, "", "",
+				fmt.Errorf("traceql: second-stage %s over histogram_over_time is unsupported — the per-bucket distribution rows have no scalar Value to rank or threshold", stages[0].Op))
+			return
+		}
+		h.serveMetricsQueryRangeHistogram(ctx, w, q, plan, hist, start, end, step)
+		return
+	}
+	if cmp, ok := unwrapMetricsCompare(inner); ok {
+		if len(stages) > 0 {
+			writeError(w, http.StatusUnprocessableEntity, "", "",
+				fmt.Errorf("traceql: second-stage %s over compare() is unsupported — compare() series carry the __meta_type split, not a scalar Value to rank or threshold", stages[0].Op))
+			return
+		}
+		h.serveMetricsQueryRangeCompare(ctx, w, q, plan, cmp, start, end, step)
+		return
+	}
+	writeError(w, http.StatusBadRequest, "", "",
+		fmt.Errorf("query %q is not a TraceQL metrics-pipeline expression — /api/metrics/query_range requires `| rate()`, `| count_over_time()`, `| *_over_time(...)`, `| quantile_over_time(...)` or `| histogram_over_time(...)`", q))
 }
 
 // classifyMetricsQueryRangeErr maps engine.QueryPlan failures to HTTP

--- a/internal/api/tempo/metrics_query_range.go
+++ b/internal/api/tempo/metrics_query_range.go
@@ -289,6 +289,21 @@ func (h *Handler) handleMetricsQueryRange(w http.ResponseWriter, r *http.Request
 			h.serveMetricsQueryRangeHistogram(ctx, w, q, plan, hist, start, end, step)
 			return
 		}
+		// `| compare({...}, topN)` lowers to its own plan node
+		// (chplan.MetricsCompare) — the output is the baseline-vs-
+		// selection attribute split Grafana Traces Drilldown's
+		// Comparison tab renders, not a scalar per series.
+		if cmp, cok := unwrapMetricsCompare(inner); cok {
+			if len(stages) > 0 {
+				// Upstream's parser already rejects this combination
+				// (ast_validate.go); defensive belt for pre-lowered plans.
+				writeError(w, http.StatusUnprocessableEntity, "", "",
+					fmt.Errorf("traceql: second-stage %s over compare() is unsupported — compare() series carry the __meta_type split, not a scalar Value to rank or threshold", stages[0].Op))
+				return
+			}
+			h.serveMetricsQueryRangeCompare(ctx, w, q, plan, cmp, start, end, step)
+			return
+		}
 		writeError(w, http.StatusBadRequest, "", "",
 			fmt.Errorf("query %q is not a TraceQL metrics-pipeline expression — /api/metrics/query_range requires `| rate()`, `| count_over_time()`, `| *_over_time(...)`, `| quantile_over_time(...)` or `| histogram_over_time(...)`", q))
 		return

--- a/internal/api/tempo/metrics_query_range_compare.go
+++ b/internal/api/tempo/metrics_query_range_compare.go
@@ -1,0 +1,358 @@
+package tempo
+
+import (
+	"context"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/engine"
+)
+
+// This file wires `| compare({...}, topN[, start, end])` into
+// `GET /api/metrics/query_range` + `GET /api/metrics/query` (and, via
+// ExecMetricsRange / ExecMetricsInstant in grpc_exports.go, the gRPC
+// streaming RPCs). The plan + SQL layers live in
+// chplan.MetricsCompare / chsql's emitRangeWindowCompare; the SQL
+// produces raw per-(cohort, attr, val, anchor) counts and this file
+// mirrors upstream Tempo's BaselineAggregator
+// (pkg/traceql/engine_metrics_compare.go) on top of the row stream:
+//
+//   - top-N per (cohort, attribute) by total count — the per-attribute
+//     series cap (`topN`, default 10);
+//   - per-(cohort, attribute) totals series counting EVERY occurrence
+//     (not just top-N survivors);
+//   - zero-filled anchor grids — upstream's per-series counts arrays
+//     are zero-initialised across every interval, so each series ships
+//     a sample at every grid anchor;
+//   - the `__meta_type` label scheme: `{__meta_type="baseline" |
+//     "selection", <attr>=<val>}` for value series and
+//     `{__meta_type="baseline_total" | "selection_total", <attr>="nil"}`
+//     for totals (the "nil" value mirrors the zero-Static label
+//     upstream's BaselineAggregator round-trips as the string "nil").
+//
+// Upstream also tracks a `{__meta_error="__too_many_values__"}` series
+// per attribute that exceeded topN — but those series carry no samples
+// and SeriesSet.ToProto drops sample-less series, so they never reach
+// the HTTP wire. Cerberus therefore doesn't synthesise them.
+
+// compareMetaTypeLabel is Tempo's `__meta_type` label key
+// (pkg/traceql/engine_metrics.go: internalLabelMetaType).
+const compareMetaTypeLabel = "__meta_type"
+
+// The four __meta_type values (engine_metrics_compare.go).
+const (
+	compareMetaBaseline       = "baseline"
+	compareMetaSelection      = "selection"
+	compareMetaBaselineTotal  = "baseline_total"
+	compareMetaSelectionTotal = "selection_total"
+)
+
+// compareNilLabelValue is the wire form of the value-less attribute
+// label on totals series: upstream emits a zero-value Static whose
+// AnyValue projection is the string "nil".
+const compareNilLabelValue = "nil"
+
+// Internal row-stream label keys — the Sample projection in
+// wrapCompareForSample surfaces the SQL columns under these names; the
+// post-processor consumes and never re-emits them.
+const (
+	compareRowSelLabel  = "__is_sel"
+	compareRowAttrLabel = "__attr"
+	compareRowValLabel  = "__val"
+)
+
+// unwrapMetricsCompare returns the MetricsCompare at the plan root (or
+// directly under a single Filter wrapper — mirroring
+// unwrapMetricsAggregate's forward-compat posture).
+func unwrapMetricsCompare(plan chplan.Node) (*chplan.MetricsCompare, bool) {
+	switch v := plan.(type) {
+	case *chplan.MetricsCompare:
+		return v, true
+	case *chplan.Filter:
+		if inner, ok := v.Input.(*chplan.MetricsCompare); ok {
+			return inner, true
+		}
+	}
+	return nil, false
+}
+
+// wrapCompareForSample wraps the matrix-shape RangeWindow with the
+// Sample projection the engine's row decoder expects. The cohort flag,
+// attribute name and attribute value ride the Attributes map under the
+// internal compareRow* keys; the post-processor turns them into the
+// wire `__meta_type` scheme.
+func wrapCompareForSample(rw *chplan.RangeWindow, m *chplan.MetricsCompare) chplan.Node {
+	selAlias, attrAlias, valAlias, valueAlias := compareAliases(m)
+	attrs := &chplan.FuncCall{
+		Name: "map",
+		Args: []chplan.Expr{
+			&chplan.LitString{V: compareRowSelLabel},
+			&chplan.FuncCall{Name: "toString", Args: []chplan.Expr{&chplan.ColumnRef{Name: selAlias}}},
+			&chplan.LitString{V: compareRowAttrLabel},
+			&chplan.FuncCall{Name: "toString", Args: []chplan.Expr{&chplan.ColumnRef{Name: attrAlias}}},
+			&chplan.LitString{V: compareRowValLabel},
+			&chplan.FuncCall{Name: "toString", Args: []chplan.Expr{&chplan.ColumnRef{Name: valAlias}}},
+		},
+	}
+	return &chplan.Project{
+		Input: rw,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.LitString{V: ""}, Alias: "MetricName"},
+			{Expr: attrs, Alias: "Attributes"},
+			{Expr: &chplan.ColumnRef{Name: "anchor_ts"}, Alias: "TimeUnix"},
+			{Expr: &chplan.ColumnRef{Name: valueAlias}, Alias: "Value"},
+		},
+	}
+}
+
+// compareAliases resolves the output aliases with the same defaults
+// the lowering and the chsql emitter pin.
+func compareAliases(m *chplan.MetricsCompare) (sel, attr, val, value string) {
+	sel, attr, val, value = m.SelAlias, m.AttrAlias, m.ValAlias, m.ValueAlias
+	if sel == "" {
+		sel = "is_selection"
+	}
+	if attr == "" {
+		attr = "attr"
+	}
+	if val == "" {
+		val = "val"
+	}
+	if value == "" {
+		value = "Value"
+	}
+	return sel, attr, val, value
+}
+
+// compareAnchorGrid materialises the matrix anchor set the chsql
+// emitters fan samples onto: `End - k*Step` for k = 0..N-1 where
+// N = (End-Start)/Step + 1, returned ascending. Must stay in lockstep
+// with the anchor arithmetic in internal/chsql/range_window.go
+// (anchorFanoutFrag / sampleAnchorFanoutFrag).
+func compareAnchorGrid(start, end time.Time, step time.Duration) []time.Time {
+	if step <= 0 {
+		return []time.Time{end}
+	}
+	span := end.Sub(start)
+	if span < 0 {
+		span = 0
+	}
+	n := int(span/step) + 1
+	out := make([]time.Time, n)
+	for k := 0; k < n; k++ {
+		out[n-1-k] = end.Add(-time.Duration(k) * step)
+	}
+	return out
+}
+
+// compareSeriesState accumulates one (cohort, attr, val) series'
+// per-anchor counts during the post-process fold.
+type compareSeriesState struct {
+	val    string
+	counts map[int64]float64 // anchor unix-nanos → count
+	total  float64
+}
+
+// postProcessCompare folds the raw (cohort, attr, val, anchor, count)
+// row stream into the wire series set — the cerberus-side equivalent
+// of upstream Tempo's BaselineAggregator.Results. `anchors` is the
+// full matrix grid (every series zero-fills across it); `topN` is the
+// per-(cohort, attribute) value cap.
+func postProcessCompare(samples []chclient.Sample, topN int, anchors []time.Time) []MetricsSeries {
+	type cohortAttr struct {
+		meta string // baseline | selection
+		attr string
+	}
+	values := map[cohortAttr]map[string]*compareSeriesState{}
+	totals := map[cohortAttr]map[int64]float64{}
+
+	for _, s := range samples {
+		attr := s.Labels[compareRowAttrLabel]
+		if attr == "" {
+			continue
+		}
+		meta := compareMetaBaseline
+		if s.Labels[compareRowSelLabel] == "1" || s.Labels[compareRowSelLabel] == "true" {
+			meta = compareMetaSelection
+		}
+		ca := cohortAttr{meta: meta, attr: attr}
+		val := s.Labels[compareRowValLabel]
+		ns := s.Timestamp.UnixNano()
+
+		vm, ok := values[ca]
+		if !ok {
+			vm = map[string]*compareSeriesState{}
+			values[ca] = vm
+		}
+		st, ok := vm[val]
+		if !ok {
+			st = &compareSeriesState{val: val, counts: map[int64]float64{}}
+			vm[val] = st
+		}
+		st.counts[ns] += s.Value
+		st.total += s.Value
+
+		tm, ok := totals[ca]
+		if !ok {
+			tm = map[int64]float64{}
+			totals[ca] = tm
+		}
+		tm[ns] += s.Value
+	}
+
+	gridSamples := func(counts map[int64]float64) []MetricsSample {
+		out := make([]MetricsSample, 0, len(anchors))
+		for _, a := range anchors {
+			out = append(out, MetricsSample{
+				TimestampMs: a.UnixMilli(),
+				Value:       counts[a.UnixNano()],
+			})
+		}
+		return out
+	}
+
+	series := make([]MetricsSeries, 0, len(values)*2)
+	addSeries := func(meta, attr, val string, counts map[int64]float64) {
+		series = append(series, MetricsSeries{
+			Labels: []MetricsLabel{
+				{Key: compareMetaTypeLabel, Value: meta},
+				{Key: attr, Value: val},
+			},
+			Samples:   gridSamples(counts),
+			Exemplars: []Exemplar{},
+		})
+	}
+
+	// Deterministic emission order: (meta, attr) keys sorted, then the
+	// top-N values per key (ties broken by value string ascending so two
+	// equal-count values rank stably — upstream's sort is unstable here,
+	// which only matters when topN truncates a tie).
+	cas := make([]cohortAttr, 0, len(values))
+	for ca := range values {
+		cas = append(cas, ca)
+	}
+	sort.Slice(cas, func(i, j int) bool {
+		if cas[i].meta != cas[j].meta {
+			return cas[i].meta < cas[j].meta
+		}
+		return cas[i].attr < cas[j].attr
+	})
+	for _, ca := range cas {
+		vm := values[ca]
+		states := make([]*compareSeriesState, 0, len(vm))
+		for _, st := range vm {
+			states = append(states, st)
+		}
+		sort.Slice(states, func(i, j int) bool {
+			if states[i].total != states[j].total {
+				return states[i].total > states[j].total
+			}
+			return states[i].val < states[j].val
+		})
+		n := len(states)
+		if topN > 0 && n > topN {
+			n = topN
+		}
+		for _, st := range states[:n] {
+			addSeries(ca.meta, ca.attr, st.val, st.counts)
+		}
+	}
+
+	// Totals series — one per (cohort, attribute), value label "nil".
+	totalMeta := func(meta string) string {
+		if meta == compareMetaSelection {
+			return compareMetaSelectionTotal
+		}
+		return compareMetaBaselineTotal
+	}
+	tcas := make([]cohortAttr, 0, len(totals))
+	for ca := range totals {
+		tcas = append(tcas, ca)
+	}
+	sort.Slice(tcas, func(i, j int) bool {
+		if tcas[i].meta != tcas[j].meta {
+			return tcas[i].meta < tcas[j].meta
+		}
+		return tcas[i].attr < tcas[j].attr
+	})
+	for _, ca := range tcas {
+		addSeries(totalMeta(ca.meta), ca.attr, compareNilLabelValue, totals[ca])
+	}
+
+	return series
+}
+
+// execCompareRange runs the matrix-shape pipeline for a lowered
+// compare() plan and returns the post-processed series list. Shared by
+// the HTTP range handler and the gRPC ExecMetricsRange path.
+func (h *Handler) execCompareRange(
+	ctx context.Context,
+	q string,
+	plan chplan.Node,
+	cmp *chplan.MetricsCompare,
+	start, end time.Time,
+	step time.Duration,
+) ([]MetricsSeries, map[string]string, error) {
+	rw := &chplan.RangeWindow{
+		Input:           plan,
+		Range:           step,
+		Step:            step,
+		Start:           start,
+		End:             end,
+		TimestampColumn: h.Schema.TimestampColumn,
+	}
+	wrapped := wrapCompareForSample(rw, cmp)
+
+	res, qerr := h.Engine.QueryPlan(ctx, metricsLang{}, wrapped, engine.Meta{
+		IsMetric:      true,
+		ResponseShape: "tempo-metrics-matrix",
+	})
+	if qerr != nil {
+		return nil, nil, qerr
+	}
+	h.Logger.Debug("cerberus tempo metrics_query_range compare",
+		"traceql", q, "start", start, "end", end, "step", step,
+		"sql", res.SQL, "args", res.Args)
+
+	series := postProcessCompare(res.Samples, cmp.TopN, compareAnchorGrid(start, end, step))
+	return series, res.Headers, nil
+}
+
+// serveMetricsQueryRangeCompare is the HTTP envelope over
+// execCompareRange.
+func (h *Handler) serveMetricsQueryRangeCompare(
+	ctx context.Context,
+	w http.ResponseWriter,
+	q string,
+	plan chplan.Node,
+	cmp *chplan.MetricsCompare,
+	start, end time.Time,
+	step time.Duration,
+) {
+	series, headers, err := h.execCompareRange(ctx, q, plan, cmp, start, end, step)
+	if err != nil {
+		writeError(w, classifyMetricsQueryRangeErr(err), "", "", err)
+		return
+	}
+	writeEngineHeaders(w, headers)
+	writeJSON(w, http.StatusOK, MetricsQueryRangeResponse{Series: series})
+}
+
+// compareSeriesToInstant collapses the post-processed range series to
+// Tempo's instant envelope — with a single anchor (step = end - start)
+// each series carries exactly one sample whose value becomes the
+// InstantSeries.Value (translateQueryRangeToInstant semantics).
+func compareSeriesToInstant(series []MetricsSeries) []MetricsInstantSeries {
+	out := make([]MetricsInstantSeries, 0, len(series))
+	for _, s := range series {
+		v := 0.0
+		if len(s.Samples) > 0 {
+			v = s.Samples[0].Value
+		}
+		out = append(out, MetricsInstantSeries{Labels: s.Labels, Value: v})
+	}
+	return out
+}

--- a/internal/api/tempo/metrics_query_range_compare_test.go
+++ b/internal/api/tempo/metrics_query_range_compare_test.go
@@ -1,0 +1,237 @@
+package tempo_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/api/tempo"
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+// compareRow builds one raw compare-SQL row as the engine's Sample
+// decoder surfaces it — the internal __is_sel / __attr / __val label
+// scheme the Sample projection (wrapCompareForSample) emits.
+func compareRow(isSel, attr, val string, ts time.Time, count float64) chclient.Sample {
+	return chclient.Sample{
+		Labels: map[string]string{
+			"__is_sel": isSel,
+			"__attr":   attr,
+			"__val":    val,
+		},
+		Timestamp: ts,
+		Value:     count,
+	}
+}
+
+// TestPostProcessCompare_Semantics pins the BaselineAggregator-mirror
+// fold: cohort split, per-(cohort, attr) top-N by total count,
+// per-attribute totals counting EVERY occurrence (including values the
+// top-N cap dropped), zero-filled anchor grids, and the __meta_type
+// label scheme.
+func TestPostProcessCompare_Semantics(t *testing.T) {
+	t.Parallel()
+
+	t0 := time.Date(2026, 5, 12, 10, 1, 0, 0, time.UTC)
+	t1 := t0.Add(time.Minute)
+	anchors := []time.Time{t0, t1}
+
+	samples := []chclient.Sample{
+		// baseline "name": three values — "a" (3 hits), "b" (2), "c" (1).
+		compareRow("0", "name", "a", t0, 2),
+		compareRow("0", "name", "a", t1, 1),
+		compareRow("0", "name", "b", t0, 2),
+		compareRow("0", "name", "c", t1, 1),
+		// selection "name": one value.
+		compareRow("1", "name", "a", t1, 4),
+	}
+
+	series := tempo.PostProcessCompareForTest(samples, 2, anchors)
+
+	type key struct{ meta, attr, val string }
+	got := map[key][]float64{}
+	for _, s := range series {
+		if len(s.Labels) != 2 {
+			t.Fatalf("series must carry exactly {__meta_type, <attr>}; got %+v", s.Labels)
+		}
+		if s.Labels[0].Key != "__meta_type" {
+			t.Fatalf("first label must be __meta_type (Tempo label order); got %+v", s.Labels)
+		}
+		if s.Exemplars == nil {
+			t.Errorf("series %+v: Exemplars must be the empty array, not null", s.Labels)
+		}
+		vals := make([]float64, len(s.Samples))
+		for i, smp := range s.Samples {
+			vals[i] = smp.Value
+			wantTS := anchors[i].UnixMilli()
+			if smp.TimestampMs != wantTS {
+				t.Errorf("series %+v sample[%d] ts=%d want %d (zero-filled full grid)", s.Labels, i, smp.TimestampMs, wantTS)
+			}
+		}
+		got[key{s.Labels[0].Value, s.Labels[1].Key, s.Labels[1].Value}] = vals
+	}
+
+	want := map[key][]float64{
+		// topN=2 keeps "a" (3) and "b" (2); "c" (1) is dropped from the
+		// value series but still counted in the totals.
+		{"baseline", "name", "a"}:          {2, 1},
+		{"baseline", "name", "b"}:          {2, 0},
+		{"selection", "name", "a"}:         {0, 4},
+		{"baseline_total", "name", "nil"}:  {4, 2},
+		{"selection_total", "name", "nil"}: {0, 4},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("series count = %d, want %d; got %v", len(got), len(want), got)
+	}
+	for k, w := range want {
+		g, ok := got[k]
+		if !ok {
+			t.Errorf("missing series %+v; got %v", k, got)
+			continue
+		}
+		if len(g) != len(w) {
+			t.Errorf("series %+v: %v want %v", k, g, w)
+			continue
+		}
+		for i := range w {
+			if g[i] != w[i] {
+				t.Errorf("series %+v sample[%d] = %g, want %g", k, i, g[i], w[i])
+			}
+		}
+	}
+}
+
+// TestCompareAnchorGrid_MatchesMatrixGrid — the Go-side grid must equal
+// the SQL emitters' end-inclusive [Start, End] anchor set.
+func TestCompareAnchorGrid_MatchesMatrixGrid(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC)
+	end := start.Add(3 * time.Minute)
+	got := tempo.CompareAnchorGridForTest(start, end, time.Minute)
+	if len(got) != 4 {
+		t.Fatalf("anchor count = %d, want 4", len(got))
+	}
+	for i, a := range got {
+		want := start.Add(time.Duration(i) * time.Minute)
+		if !a.Equal(want) {
+			t.Errorf("anchor[%d] = %v, want %v", i, a, want)
+		}
+	}
+}
+
+// TestMetricsQueryRange_CompareDrilldownVerbatim — consumer-grade: the
+// exact query Grafana Traces Drilldown's Comparison tab issues returns
+// 200 with the __meta_type-labelled series shape Grafana renders.
+// (Crawl signature traceql-metrics-compare-unsupported-422 pinned the
+// prior 422.)
+func TestMetricsQueryRange_CompareDrilldownVerbatim(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 5, 12, 10, 1, 0, 0, time.UTC)
+	q := &stubQuerier{samples: []chclient.Sample{
+		compareRow("0", "resource.service.name", "shop", ts, 3),
+		compareRow("1", "resource.service.name", "shop", ts, 1),
+	}}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	u := metricsQueryRangeURL(srv.URL,
+		"{nestedSetParent<0 && true} | compare({status = error}, 10)",
+		map[string]string{
+			"start": fixtureStartUnix,
+			"end":   fixtureEndUnix,
+			"step":  "60s",
+		})
+
+	resp, err := http.Get(u)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+
+	var body tempo.MetricsQueryRangeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// 2 value series + 2 totals series.
+	if len(body.Series) != 4 {
+		t.Fatalf("series count = %d, want 4: %+v", len(body.Series), body.Series)
+	}
+	metas := map[string]int{}
+	for _, s := range body.Series {
+		if len(s.Labels) == 0 || s.Labels[0].Key != "__meta_type" {
+			t.Fatalf("every compare() series must lead with __meta_type; got %+v", s.Labels)
+		}
+		metas[s.Labels[0].Value]++
+		// The aligned [10:00, 10:03] grid at 60s steps has 4 anchors;
+		// every series zero-fills across all of them.
+		if len(s.Samples) != 4 {
+			t.Errorf("series %+v has %d samples, want 4 (zero-filled grid)", s.Labels, len(s.Samples))
+		}
+		if s.Exemplars == nil {
+			t.Errorf("series %+v: exemplars must be [], not null", s.Labels)
+		}
+	}
+	for _, m := range []string{"baseline", "selection", "baseline_total", "selection_total"} {
+		if metas[m] != 1 {
+			t.Errorf("__meta_type=%s series count = %d, want 1 (got %v)", m, metas[m], metas)
+		}
+	}
+}
+
+// TestMetricsQueryInstant_Compare — the instant endpoint collapses each
+// compare() series to a single value (translateQueryRangeToInstant).
+func TestMetricsQueryInstant_Compare(t *testing.T) {
+	t.Parallel()
+
+	// Instant evaluation anchors at `end`.
+	end := time.Unix(1778580180, 0).UTC()
+	q := &stubQuerier{samples: []chclient.Sample{
+		compareRow("0", "status", "ok", end, 5),
+		compareRow("1", "status", "error", end, 2),
+	}}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	vals := url.Values{}
+	vals.Set("q", `{} | compare({status = error})`)
+	vals.Set("start", fixtureStartUnix)
+	vals.Set("end", fixtureEndUnix)
+	u := srv.URL + "/api/metrics/query?" + vals.Encode()
+
+	resp, err := http.Get(u)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+
+	var body tempo.MetricsQueryInstantResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Series) != 4 {
+		t.Fatalf("series count = %d, want 4: %+v", len(body.Series), body.Series)
+	}
+	byMeta := map[string]float64{}
+	for _, s := range body.Series {
+		if len(s.Labels) == 0 || s.Labels[0].Key != "__meta_type" {
+			t.Fatalf("instant compare() series must lead with __meta_type; got %+v", s.Labels)
+		}
+		byMeta[s.Labels[0].Value] = s.Value
+	}
+	if byMeta["baseline"] != 5 || byMeta["selection"] != 2 {
+		t.Errorf("instant values = %v, want baseline=5 selection=2", byMeta)
+	}
+	if byMeta["baseline_total"] != 5 || byMeta["selection_total"] != 2 {
+		t.Errorf("instant totals = %v, want baseline_total=5 selection_total=2", byMeta)
+	}
+}

--- a/internal/chplan/metrics_compare.go
+++ b/internal/chplan/metrics_compare.go
@@ -1,0 +1,138 @@
+package chplan
+
+// MetricsCompare is the lowered form of TraceQL's
+// `| compare({<selection>}, topN[, start, end])` metrics first-stage
+// operator (Grafana Traces Drilldown's "Comparison" tab).
+//
+// Reference semantics (grafana/tempo pkg/traceql/engine_metrics_compare.go,
+// consumed via the tsouza/tempo cerberus-accessors fork): every span
+// produced by the query's pipeline is split into two cohorts —
+// "selection" (spans matching the compare() filter, optionally further
+// restricted to a unix-nanosecond start/end window) and "baseline"
+// (everything else). For every attribute (name, value) carried by a
+// span, the engine counts occurrences per cohort per time interval.
+// The wire result is, per (cohort, attribute), the top-N values by
+// total count — series labelled with the `__meta_type` scheme
+// (baseline / selection / baseline_total / selection_total) — which
+// Tempo's BaselineAggregator assembles at the query frontend.
+//
+// Cerberus splits the same work between SQL and the Tempo HTTP handler:
+//
+//   - SQL (this node, emitted by internal/chsql/metrics_compare.go)
+//     produces the raw per-(cohort, attribute, value[, anchor]) counts:
+//     the span-attribute explosion is an arrayJoin over Pairs, the
+//     cohort flag is the Selection predicate projected as a 0/1 column.
+//   - The handler (internal/api/tempo/metrics_query_range_compare.go)
+//     mirrors Tempo's BaselineAggregator: top-N per (cohort, attribute)
+//     by total count, per-attribute totals series, zero-filled anchor
+//     grids, and the `__meta_type` label scheme.
+//
+// Fields:
+//
+//   - Selection: the lowered compare({...}) filter predicate — a boolean
+//     expression over a span row of Inner. When StartNs/EndNs are both
+//     set, the lowering has already AND-ed the timestamp window into
+//     this expression (mirroring MetricsCompare.isSelection upstream,
+//     which only evaluates the filter for spans inside the window and
+//     assigns everything else to the baseline).
+//   - TopN: the per-attribute series cap (upstream default 10). Carried
+//     on the IR for the handler's BaselineAggregator-equivalent; the
+//     SQL emits ALL observed values because the totals series must
+//     count every occurrence, not just the top-N survivors.
+//   - StartNs / EndNs: the optional selection window (unix nanoseconds,
+//     0 = unset). Carried for plan printing / Equal; the executable
+//     window predicate already lives inside Selection.
+//   - Pairs: the Array(Tuple(String, String)) expression enumerating
+//     every (attribute wire name, value) pair of a span row — the
+//     OTel-CH analogue of Tempo's `span.AllAttributesFunc` under
+//     `SecondPassSelectAll` (vparquet4): intrinsics (name / status /
+//     statusMessage / kind, trace-level rootName / rootServiceName,
+//     instrumentation:name / instrumentation:version), the well-known
+//     dedicated attributes with a 'nil' fallback for absent values,
+//     and the two attribute maps with scope prefixes. Built by the
+//     lowering (internal/traceql/metrics_compare.go) because it is
+//     schema-dependent.
+//   - RootLookup: optional relation resolving each trace's root span —
+//     one row per TraceId with the columns RootNameAlias /
+//     RootServiceAlias. The emitter LEFT JOINs it against Inner on
+//     TraceIDColumn so Pairs can reference the per-trace rootName /
+//     rootServiceName values (vparquet stores them as trace-level
+//     columns; OTel-CH must derive them). Nil disables the join (used
+//     by schemas where Pairs doesn't reference root columns).
+//   - TraceIDColumn: join key for RootLookup (OTel-CH: "TraceId").
+//   - RootNameAlias / RootServiceAlias: SELECT-list aliases RootLookup
+//     exposes and Pairs references ("__root_name" / "__root_service_name").
+//   - SelAlias / AttrAlias / ValAlias / ValueAlias: output column
+//     aliases — the cohort flag, attribute wire name, attribute value,
+//     and per-group count ("is_selection" / "attr" / "val" / "Value").
+//   - Inner: the underlying spanset relation (Filter / Scan tree from
+//     the query's `{...}` pipeline).
+//
+// Wrapping by chplan.RangeWindow produces the `/api/metrics/query_range`
+// matrix shape — one row per (cohort, attr, val, anchor_ts). Bare
+// emission collapses time — one row per (cohort, attr, val), ordered
+// deterministically for the TXTAR roundtrip layer.
+type MetricsCompare struct {
+	Selection        Expr
+	TopN             int
+	StartNs          int64
+	EndNs            int64
+	Pairs            Expr
+	RootLookup       Node
+	TraceIDColumn    string
+	RootNameAlias    string
+	RootServiceAlias string
+	SelAlias         string
+	AttrAlias        string
+	ValAlias         string
+	ValueAlias       string
+	Inner            Node
+}
+
+func (*MetricsCompare) planNode() {}
+
+func (m *MetricsCompare) Children() []Node {
+	if m.RootLookup == nil {
+		return []Node{m.Inner}
+	}
+	return []Node{m.Inner, m.RootLookup}
+}
+
+func (m *MetricsCompare) Equal(other Node) bool {
+	o, ok := other.(*MetricsCompare)
+	if !ok {
+		return false
+	}
+	if m.TopN != o.TopN || m.StartNs != o.StartNs || m.EndNs != o.EndNs ||
+		m.TraceIDColumn != o.TraceIDColumn ||
+		m.RootNameAlias != o.RootNameAlias || m.RootServiceAlias != o.RootServiceAlias ||
+		m.SelAlias != o.SelAlias || m.AttrAlias != o.AttrAlias ||
+		m.ValAlias != o.ValAlias || m.ValueAlias != o.ValueAlias {
+		return false
+	}
+	if (m.Selection == nil) != (o.Selection == nil) {
+		return false
+	}
+	if m.Selection != nil && !m.Selection.Equal(o.Selection) {
+		return false
+	}
+	if (m.Pairs == nil) != (o.Pairs == nil) {
+		return false
+	}
+	if m.Pairs != nil && !m.Pairs.Equal(o.Pairs) {
+		return false
+	}
+	if (m.RootLookup == nil) != (o.RootLookup == nil) {
+		return false
+	}
+	if m.RootLookup != nil && !m.RootLookup.Equal(o.RootLookup) {
+		return false
+	}
+	if (m.Inner == nil) != (o.Inner == nil) {
+		return false
+	}
+	if m.Inner == nil {
+		return true
+	}
+	return m.Inner.Equal(o.Inner)
+}

--- a/internal/chplan/metrics_compare_test.go
+++ b/internal/chplan/metrics_compare_test.go
@@ -1,0 +1,107 @@
+package chplan_test
+
+import (
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// newCompareFixture builds a fully-populated MetricsCompare for the
+// Equal-invariant tests; each negative case mutates one field.
+func newCompareFixture() *chplan.MetricsCompare {
+	return &chplan.MetricsCompare{
+		Selection: &chplan.Binary{
+			Op:    chplan.OpEq,
+			Left:  &chplan.ColumnRef{Name: "StatusCode"},
+			Right: &chplan.LitString{V: "Error"},
+		},
+		TopN:    10,
+		StartNs: 100,
+		EndNs:   200,
+		Pairs:   &chplan.FuncCall{Name: "array"},
+		RootLookup: &chplan.Aggregate{
+			Input:    &chplan.Scan{Table: "otel_traces"},
+			GroupBy:  []chplan.Expr{&chplan.ColumnRef{Name: "TraceId"}},
+			AggFuncs: []chplan.AggFunc{{Name: "any", Args: []chplan.Expr{&chplan.ColumnRef{Name: "SpanName"}}, Alias: "__root_name"}},
+		},
+		TraceIDColumn:    "TraceId",
+		RootNameAlias:    "__root_name",
+		RootServiceAlias: "__root_service_name",
+		SelAlias:         "is_selection",
+		AttrAlias:        "attr",
+		ValAlias:         "val",
+		ValueAlias:       "Value",
+		Inner:            &chplan.Scan{Table: "otel_traces"},
+	}
+}
+
+func TestMetricsCompare_Equal_Positive(t *testing.T) {
+	t.Parallel()
+	if !newCompareFixture().Equal(newCompareFixture()) {
+		t.Fatal("identical MetricsCompare trees should be Equal")
+	}
+}
+
+func TestMetricsCompare_Equal_Negative_Fields(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		mutate func(m *chplan.MetricsCompare)
+	}{
+		{"topN", func(m *chplan.MetricsCompare) { m.TopN = 5 }},
+		{"startNs", func(m *chplan.MetricsCompare) { m.StartNs = 0 }},
+		{"endNs", func(m *chplan.MetricsCompare) { m.EndNs = 999 }},
+		{"selection", func(m *chplan.MetricsCompare) {
+			m.Selection = &chplan.LitBool{V: true}
+		}},
+		{"selectionNil", func(m *chplan.MetricsCompare) { m.Selection = nil }},
+		{"pairs", func(m *chplan.MetricsCompare) {
+			m.Pairs = &chplan.FuncCall{Name: "arrayConcat"}
+		}},
+		{"pairsNil", func(m *chplan.MetricsCompare) { m.Pairs = nil }},
+		{"rootLookupNil", func(m *chplan.MetricsCompare) { m.RootLookup = nil }},
+		{"traceIDColumn", func(m *chplan.MetricsCompare) { m.TraceIDColumn = "Other" }},
+		{"rootNameAlias", func(m *chplan.MetricsCompare) { m.RootNameAlias = "x" }},
+		{"rootServiceAlias", func(m *chplan.MetricsCompare) { m.RootServiceAlias = "x" }},
+		{"selAlias", func(m *chplan.MetricsCompare) { m.SelAlias = "x" }},
+		{"attrAlias", func(m *chplan.MetricsCompare) { m.AttrAlias = "x" }},
+		{"valAlias", func(m *chplan.MetricsCompare) { m.ValAlias = "x" }},
+		{"valueAlias", func(m *chplan.MetricsCompare) { m.ValueAlias = "x" }},
+		{"inner", func(m *chplan.MetricsCompare) { m.Inner = &chplan.Scan{Table: "other"} }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			a, b := newCompareFixture(), newCompareFixture()
+			tc.mutate(b)
+			if a.Equal(b) || b.Equal(a) {
+				t.Errorf("MetricsCompare.Equal must detect %s divergence", tc.name)
+			}
+		})
+	}
+}
+
+func TestMetricsCompare_Equal_OtherNodeType(t *testing.T) {
+	t.Parallel()
+	if newCompareFixture().Equal(&chplan.Scan{Table: "otel_traces"}) {
+		t.Fatal("MetricsCompare.Equal(<other node type>) must be false")
+	}
+}
+
+// TestChildren_MetricsCompare — Children() exposes Inner (always) and
+// RootLookup (when set) so generic walkers descend into both relations.
+func TestChildren_MetricsCompare(t *testing.T) {
+	t.Parallel()
+
+	m := newCompareFixture()
+	kids := m.Children()
+	if len(kids) != 2 || kids[0] != m.Inner || kids[1] != m.RootLookup {
+		t.Errorf("Children() with RootLookup should return [Inner, RootLookup], got %v", kids)
+	}
+
+	m.RootLookup = nil
+	kids = m.Children()
+	if len(kids) != 1 || kids[0] != m.Inner {
+		t.Errorf("Children() without RootLookup should return [Inner], got %v", kids)
+	}
+}

--- a/internal/chplan/walk_invariants_test.go
+++ b/internal/chplan/walk_invariants_test.go
@@ -174,6 +174,18 @@ func TestMetricsHistogramOverTime_Walk_VisitsInner(t *testing.T) {
 	assertSentinels(t, visitScans(root), []string{"mhot_inner"})
 }
 
+func TestMetricsCompare_Walk_VisitsInnerAndRootLookup(t *testing.T) {
+	t.Parallel()
+	root := &chplan.MetricsCompare{
+		Selection:  &chplan.LitBool{V: true},
+		Pairs:      &chplan.FuncCall{Name: "array"},
+		Inner:      &chplan.Scan{Table: "mc_inner"},
+		RootLookup: &chplan.Scan{Table: "mc_roots"},
+	}
+	// Pre-order: Inner first, RootLookup second.
+	assertSentinels(t, visitScans(root), []string{"mc_inner", "mc_roots"})
+}
+
 func TestMetricsSecondStage_Walk_VisitsInput(t *testing.T) {
 	t.Parallel()
 	root := &chplan.MetricsSecondStage{

--- a/internal/chsql/emit.go
+++ b/internal/chsql/emit.go
@@ -80,6 +80,8 @@ func (e *emitter) emitNode(n chplan.Node) error {
 		return e.emitMetricsSecondStage(v)
 	case *chplan.MetricsHistogramOverTime:
 		return e.emitMetricsHistogramOverTime(v)
+	case *chplan.MetricsCompare:
+		return e.emitMetricsCompare(v)
 	case *chplan.RangeWindow:
 		return e.emitRangeWindow(v)
 	case *chplan.AbsentOverTime:

--- a/internal/chsql/metrics_compare.go
+++ b/internal/chsql/metrics_compare.go
@@ -1,0 +1,256 @@
+package chsql
+
+import (
+	"fmt"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// This file emits chplan.MetricsCompare — TraceQL's
+// `| compare({...}, topN[, start, end])` first-stage metrics operator.
+//
+// The SQL produces the RAW per-(cohort, attribute, value[, anchor])
+// counts; the Tempo HTTP handler
+// (internal/api/tempo/metrics_query_range_compare.go) mirrors upstream
+// Tempo's BaselineAggregator on top of the row stream — top-N per
+// (cohort, attribute), per-attribute totals, zero-filled anchor grids,
+// and the `__meta_type` label scheme. Top-N is deliberately NOT pushed
+// into the SQL: the totals series count every occurrence (not just the
+// top-N survivors), so the full value inventory must reach the handler
+// anyway.
+//
+// Bare shape (no RangeWindow wrapper — TXTAR / chdb layer):
+//
+//	SELECT `is_selection`, tupleElement(kv, ?) AS `attr`,
+//	       tupleElement(kv, ?) AS `val`, toFloat64(count(?)) AS `Value`
+//	FROM (
+//	  SELECT <Selection> AS `is_selection`, arrayJoin(<Pairs>) AS `kv`
+//	  FROM (<Inner>) [AS s LEFT JOIN (<RootLookup>) AS r ON s.<TraceID> = r.<TraceID>]
+//	)
+//	GROUP BY `is_selection`, `attr`, `val`
+//	ORDER BY `is_selection`, `attr`, `val`
+//
+// The ORDER BY pins a deterministic row order for the bare shape only
+// (GROUP BY output order is otherwise unspecified); the matrix shape
+// leaves ordering to the handler, matching the other metrics emitters.
+//
+// Matrix shape (RangeWindow wrapper — /api/metrics/query_range):
+//
+//	SELECT `is_selection`, `attr`, `val`, anchor_ts, toFloat64(count(?)) AS `Value`
+//	FROM (
+//	  SELECT `is_selection`, tupleElement(kv, ?) AS `attr`,
+//	         tupleElement(kv, ?) AS `val`, <sample-side anchor fanout> AS anchor_ts
+//	  FROM (
+//	    SELECT <Selection> AS `is_selection`, arrayJoin(<Pairs>) AS `kv`, <tsCol>
+//	    FROM (<Inner>) [LEFT JOIN <RootLookup>] [WHERE <(Start-range, End] bounds>]
+//	  )
+//	)
+//	GROUP BY `is_selection`, `attr`, `val`, anchor_ts
+//
+// Anchors with no rows emit nothing — the handler zero-fills the grid
+// (upstream's counts arrays are zero-initialised across all intervals).
+
+// compareJoinLeftAlias / compareJoinRightAlias are the bare table
+// aliases the LEFT JOIN uses. Following vector_join's `L`/`R`
+// convention; `s` (spans) / `r` (roots) read better in EXPLAIN output.
+const (
+	compareJoinLeftAlias  = "s"
+	compareJoinRightAlias = "r"
+)
+
+// compareBaseQuery builds the innermost SELECT — cohort flag +
+// arrayJoin'd attribute pairs (+ extraCols, used by the matrix path to
+// carry the timestamp column up to the fanout level) over Inner,
+// LEFT JOINed against RootLookup when present.
+func (e *emitter) compareBaseQuery(m *chplan.MetricsCompare, extraCols ...string) (*QueryBuilder, error) {
+	if m.Selection == nil {
+		return nil, fmt.Errorf("%w: MetricsCompare.Selection is nil", ErrUnsupported)
+	}
+	if m.Pairs == nil {
+		return nil, fmt.Errorf("%w: MetricsCompare.Pairs is nil", ErrUnsupported)
+	}
+	if m.Inner == nil {
+		return nil, fmt.Errorf("%w: MetricsCompare.Inner is nil", ErrUnsupported)
+	}
+	// Pre-flight chplan expressions so errors surface synchronously
+	// (mirrors emitMetricsAggregate's pre-flight loop).
+	if err := (&Builder{}).Expr(m.Selection); err != nil {
+		return nil, err
+	}
+	if err := (&Builder{}).Expr(m.Pairs); err != nil {
+		return nil, err
+	}
+
+	inner, err := e.subqueryFrag(m.Inner)
+	if err != nil {
+		return nil, err
+	}
+
+	qb := NewQuery()
+	if m.RootLookup != nil {
+		if m.TraceIDColumn == "" {
+			return nil, fmt.Errorf("%w: MetricsCompare.RootLookup set but TraceIDColumn empty", ErrUnsupported)
+		}
+		root, rerr := e.subqueryFrag(m.RootLookup)
+		if rerr != nil {
+			return nil, rerr
+		}
+		qb.From(aliasedFrag(inner, compareJoinLeftAlias)).
+			Join(
+				LeftJoin,
+				aliasedFrag(root, compareJoinRightAlias),
+				Eq(
+					qualColFrag(compareJoinLeftAlias, m.TraceIDColumn),
+					qualColFrag(compareJoinRightAlias, m.TraceIDColumn),
+				),
+			)
+	} else {
+		qb.From(inner)
+	}
+
+	sel := m.Selection
+	qb.SelectAs(func(b *Builder) { _ = b.Expr(sel) }, compareSelOut(m))
+	pairs := m.Pairs
+	qb.SelectAs(Call("arrayJoin", func(b *Builder) { _ = b.Expr(pairs) }), "kv")
+	for _, c := range extraCols {
+		col := c
+		qb.Select(func(b *Builder) { b.Ident(col) })
+	}
+	return qb, nil
+}
+
+// compareSelOut / compareAttrOut / compareValOut / compareValueOut
+// resolve the output aliases with the same defaults the lowering pins
+// (internal/traceql/metrics_compare.go).
+func compareSelOut(m *chplan.MetricsCompare) string {
+	if m.SelAlias != "" {
+		return m.SelAlias
+	}
+	return "is_selection"
+}
+
+func compareAttrOut(m *chplan.MetricsCompare) string {
+	if m.AttrAlias != "" {
+		return m.AttrAlias
+	}
+	return "attr"
+}
+
+func compareValOut(m *chplan.MetricsCompare) string {
+	if m.ValAlias != "" {
+		return m.ValAlias
+	}
+	return "val"
+}
+
+func compareValueOut(m *chplan.MetricsCompare) string {
+	if m.ValueAlias != "" {
+		return m.ValueAlias
+	}
+	return "Value"
+}
+
+// compareTupleElementFrag renders `tupleElement(kv, <idx>)` — the
+// attr (idx 1) / val (idx 2) projection out of the arrayJoin'd pair.
+// The index binds as a positional arg (clickhouse-go interpolates it
+// client-side, so CH sees the constant literal tupleElement requires).
+func compareTupleElementFrag(idx int64) Frag {
+	return func(b *Builder) {
+		b.sb.WriteString("tupleElement(kv, ")
+		b.Arg(idx)
+		b.sb.WriteByte(')')
+	}
+}
+
+// compareCountValueFrag renders `toFloat64(count(?))` with the bound
+// literal 1 — same reducer shape as the other metrics emitters, pinned
+// to Float64 so chclient.Sample.Value scans cleanly.
+func compareCountValueFrag() Frag {
+	return func(b *Builder) {
+		b.sb.WriteString("toFloat64(")
+		_ = b.Expr(&chplan.FuncCall{Name: "count", Args: []chplan.Expr{&chplan.LitInt{V: 1}}})
+		b.sb.WriteByte(')')
+	}
+}
+
+// emitMetricsCompare renders the bare (time-collapsed) shape.
+func (e *emitter) emitMetricsCompare(m *chplan.MetricsCompare) error {
+	base, err := e.compareBaseQuery(m)
+	if err != nil {
+		return err
+	}
+
+	selA, attrA, valA := compareSelOut(m), compareAttrOut(m), compareValOut(m)
+	outer := NewQuery().From(base.Frag())
+	outer.Select(Col(selA))
+	outer.SelectAs(compareTupleElementFrag(1), attrA)
+	outer.SelectAs(compareTupleElementFrag(2), valA)
+	outer.SelectAs(compareCountValueFrag(), compareValueOut(m))
+	outer.GroupBy(Col(selA), Col(attrA), Col(valA))
+	outer.OrderBy(Col(selA), false).OrderBy(Col(attrA), false).OrderBy(Col(valA), false)
+
+	e.emitSelect(outer)
+	return nil
+}
+
+// emitRangeWindowCompare renders the matrix shape — one row per
+// (cohort, attr, val, anchor) with the per-anchor count. Mirrors
+// emitRangeWindowHistogram's anchor machinery (sample-side fanout,
+// scan-bound pushdown); see the package comment at the top of this
+// file for the SQL skeleton.
+func (e *emitter) emitRangeWindowCompare(r *chplan.RangeWindow, m *chplan.MetricsCompare) error {
+	if r.TimestampColumn == "" {
+		return fmt.Errorf("%w: RangeWindow.TimestampColumn unset (required for MetricsCompare input)", ErrUnsupported)
+	}
+	if r.Step <= 0 {
+		return fmt.Errorf("%w: RangeWindow wrapping MetricsCompare requires Step > 0", ErrUnsupported)
+	}
+
+	end := endExprFrag(r)
+	stepNS := r.Step.Nanoseconds()
+	rangeDur := r.Range
+	if rangeDur == 0 {
+		rangeDur = r.Step
+	}
+	rangeNS := rangeDur.Nanoseconds()
+
+	var numAnchors int64
+	switch {
+	case r.OuterRange > 0:
+		numAnchors = r.OuterRange.Nanoseconds()/stepNS + 1
+	case !r.Start.IsZero() && !r.End.IsZero():
+		span := r.End.Sub(r.Start).Nanoseconds()
+		if span < 0 {
+			return fmt.Errorf("%w: RangeWindow.Start > End", ErrUnsupported)
+		}
+		numAnchors = span/stepNS + 1
+	default:
+		numAnchors = 1
+	}
+
+	tsCol := r.TimestampColumn
+	base, err := e.compareBaseQuery(m, tsCol)
+	if err != nil {
+		return err
+	}
+	maybePushInnerScanTimeBounds(base, r, tsCol, rangeNS)
+
+	selA, attrA, valA := compareSelOut(m), compareAttrOut(m), compareValOut(m)
+
+	fanout := NewQuery().From(base.Frag())
+	fanout.Select(Col(selA))
+	fanout.SelectAs(compareTupleElementFrag(1), attrA)
+	fanout.SelectAs(compareTupleElementFrag(2), valA)
+	fanout.SelectAs(
+		sampleAnchorFanoutFrag(end, func(b *Builder) { b.Ident(tsCol) }, stepNS, rangeNS, numAnchors),
+		RangeWindowAnchorAlias,
+	)
+
+	outer := NewQuery().From(fanout.Frag())
+	outer.Select(Col(selA), Col(attrA), Col(valA), Col(RangeWindowAnchorAlias))
+	outer.SelectAs(compareCountValueFrag(), compareValueOut(m))
+	outer.GroupBy(Col(selA), Col(attrA), Col(valA), Col(RangeWindowAnchorAlias))
+
+	e.emitSelect(outer)
+	return nil
+}

--- a/internal/chsql/metrics_compare_test.go
+++ b/internal/chsql/metrics_compare_test.go
@@ -1,0 +1,139 @@
+package chsql_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+)
+
+// compareNode builds a minimal valid MetricsCompare (no root lookup —
+// the join shape is covered by the lowering-level tests + TXTAR
+// fixtures; this file pins the emitter's own contract).
+func compareNode() *chplan.MetricsCompare {
+	return &chplan.MetricsCompare{
+		Selection: &chplan.Binary{
+			Op:    chplan.OpEq,
+			Left:  &chplan.ColumnRef{Name: "StatusCode"},
+			Right: &chplan.LitString{V: "Error"},
+		},
+		TopN: 10,
+		Pairs: &chplan.FuncCall{Name: "array", Args: []chplan.Expr{
+			&chplan.FuncCall{Name: "tuple", Args: []chplan.Expr{
+				&chplan.LitString{V: "name"},
+				&chplan.ColumnRef{Name: "SpanName"},
+			}},
+		}},
+		SelAlias:   "is_selection",
+		AttrAlias:  "attr",
+		ValAlias:   "val",
+		ValueAlias: "Value",
+		Inner:      &chplan.Scan{Table: "otel_traces"},
+	}
+}
+
+// TestEmitMetricsCompare_BareShape — bare emission groups by
+// (cohort, attr, val) with a deterministic ORDER BY and the Float64
+// count reducer.
+func TestEmitMetricsCompare_BareShape(t *testing.T) {
+	t.Parallel()
+
+	sql, _, err := chsql.Emit(context.Background(), compareNode())
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	for _, want := range []string{
+		"arrayJoin(array(tuple(",
+		"AS `is_selection`",
+		"tupleElement(kv, ?) AS `attr`",
+		"tupleElement(kv, ?) AS `val`",
+		"toFloat64(count(?)) AS `Value`",
+		"GROUP BY `is_selection`, `attr`, `val`",
+		"ORDER BY `is_selection`, `attr`, `val`",
+	} {
+		if !strings.Contains(sql, want) {
+			t.Errorf("bare SQL missing %q:\n%s", want, sql)
+		}
+	}
+	if strings.Contains(sql, "anchor_ts") {
+		t.Errorf("bare SQL must not contain the matrix anchor column:\n%s", sql)
+	}
+}
+
+// TestEmitRangeWindowCompare_MatrixShape — the RangeWindow wrap adds
+// the sample-side anchor fanout, the anchor GROUP BY axis, and the
+// (Start - range, End] scan-bound pushdown.
+func TestEmitRangeWindowCompare_MatrixShape(t *testing.T) {
+	t.Parallel()
+
+	rw := &chplan.RangeWindow{
+		Input:           compareNode(),
+		Range:           time.Minute,
+		Step:            time.Minute,
+		Start:           time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC),
+		End:             time.Date(2026, 5, 12, 10, 3, 0, 0, time.UTC),
+		TimestampColumn: "Timestamp",
+	}
+	sql, _, err := chsql.Emit(context.Background(), rw)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	for _, want := range []string{
+		"AS `anchor_ts`",
+		"GROUP BY `is_selection`, `attr`, `val`, `anchor_ts`",
+		"`Timestamp` > toDateTime64('2026-05-12 10:00:00.000000000', 9) - toIntervalNanosecond(60000000000)",
+		"`Timestamp` <= toDateTime64('2026-05-12 10:03:00.000000000', 9)",
+	} {
+		if !strings.Contains(sql, want) {
+			t.Errorf("matrix SQL missing %q:\n%s", want, sql)
+		}
+	}
+	if strings.Contains(sql, "ORDER BY") {
+		t.Errorf("matrix SQL must not pin an ORDER BY (the handler owns series assembly):\n%s", sql)
+	}
+}
+
+// TestEmitMetricsCompare_ErrorPaths — nil Selection / Pairs / Inner and
+// a non-positive matrix Step surface as synchronous emit errors.
+func TestEmitMetricsCompare_ErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		node chplan.Node
+		want string
+	}{
+		{"nilSelection", func() chplan.Node { m := compareNode(); m.Selection = nil; return m }(), "Selection is nil"},
+		{"nilPairs", func() chplan.Node { m := compareNode(); m.Pairs = nil; return m }(), "Pairs is nil"},
+		{"nilInner", func() chplan.Node { m := compareNode(); m.Inner = nil; return m }(), "Inner is nil"},
+		{"rootLookupWithoutTraceID", func() chplan.Node {
+			m := compareNode()
+			m.RootLookup = &chplan.Scan{Table: "otel_traces"}
+			m.TraceIDColumn = ""
+			return m
+		}(), "TraceIDColumn empty"},
+		{"matrixZeroStep", &chplan.RangeWindow{
+			Input:           compareNode(),
+			TimestampColumn: "Timestamp",
+		}, "requires Step > 0"},
+		{"matrixNoTsColumn", &chplan.RangeWindow{
+			Input: compareNode(),
+			Step:  time.Minute,
+		}, "TimestampColumn unset"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, _, err := chsql.Emit(context.Background(), tc.node)
+			if err == nil {
+				t.Fatalf("Emit should fail for %s", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q missing %q", err, tc.want)
+			}
+		})
+	}
+}

--- a/internal/chsql/range_window.go
+++ b/internal/chsql/range_window.go
@@ -269,6 +269,9 @@ func (e *emitter) emitRangeWindow(r *chplan.RangeWindow) error {
 	if h, ok := r.Input.(*chplan.MetricsHistogramOverTime); ok {
 		return e.emitRangeWindowHistogram(r, h)
 	}
+	if c, ok := r.Input.(*chplan.MetricsCompare); ok {
+		return e.emitRangeWindowCompare(r, c)
+	}
 	if r.Identity {
 		return e.emitRangeWindowIdentity(r)
 	}

--- a/internal/traceql/metrics_compare.go
+++ b/internal/traceql/metrics_compare.go
@@ -44,7 +44,6 @@ const (
 	compareSelAlias   = "is_selection"
 	compareAttrAlias  = "attr"
 	compareValAlias   = "val"
-	compareKVAlias    = "kv"
 	rootNameAlias     = "__root_name"
 	rootServiceAlias  = "__root_service_name"
 	compareNilLiteral = "nil"
@@ -70,13 +69,25 @@ var wellKnownResourceAttrs = []string{
 	"k8s.container.name",
 }
 
-// wellKnownSpanAttrs is the span-scoped slice of vparquet4's
+// wellKnownSpanAttrs is the span-scoped slice of vparquet's
 // WellKnownColumnLookups; same "nil"-fallback contract as
 // wellKnownResourceAttrs (spanCollector.KeepGroup's IsNull branch).
+//
+// The first three are the long-standing vparquet4 columns; the last
+// five are the OTel-semconv additions current Tempo main ships
+// (verified live against grafana/tempo:main-2f74ea8 by the
+// compatibility/tempo `metrics_compare_status_error` corpus case —
+// reference compare() output surfaces a "nil" bucket for each of
+// them on every span that lacks the attribute).
 var wellKnownSpanAttrs = []string{
 	"http.status_code",
 	"http.method",
 	"http.url",
+	"http.request.method",
+	"http.route",
+	"server.address",
+	"url.path",
+	"url.route",
 }
 
 // lowerMetricsCompare lowers `| compare({...}, topN[, start, end])`.

--- a/internal/traceql/metrics_compare.go
+++ b/internal/traceql/metrics_compare.go
@@ -1,0 +1,289 @@
+package traceql
+
+import (
+	"fmt"
+
+	"github.com/grafana/tempo/pkg/traceql"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// This file lowers TraceQL's `| compare({<selection>}, topN[, start, end])`
+// metrics first-stage operator (Grafana Traces Drilldown's "Comparison"
+// tab) into a chplan.MetricsCompare node.
+//
+// Reference semantics — grafana/tempo pkg/traceql/engine_metrics_compare.go
+// (consumed via the tsouza/tempo cerberus-accessors fork):
+//
+//   - Every span the pipeline produces is assigned to one of two
+//     cohorts: "selection" (the span matches the compare() filter and,
+//     when the optional start/end unix-nanosecond window is set, its
+//     start time falls in `(start, end]`) or "baseline" (everything
+//     else). See MetricsCompare.isSelection upstream.
+//   - For each span, every attribute the storage layer surfaces under
+//     `SecondPassSelectAll` is counted into per-(cohort, attribute,
+//     value) time-interval buckets, plus per-(cohort, attribute)
+//     totals. Duration-typed values and the span-start-time / trace-id
+//     / parent-id / nested-set intrinsics are excluded
+//     (MetricsCompare.processAttribute).
+//   - The wire result is the top-N values per (cohort, attribute) by
+//     total count, labelled `{__meta_type="baseline|selection", <attr>=<val>}`,
+//     plus `{__meta_type="baseline_total|selection_total", <attr>="nil"}`
+//     totals series (BaselineAggregator.Results).
+//
+// The SQL this node emits produces the raw per-(cohort, attr, value
+// [, anchor]) counts; the Tempo HTTP handler mirrors the
+// BaselineAggregator (top-N, totals, zero-fill, label scheme). See
+// internal/api/tempo/metrics_query_range_compare.go.
+
+// Output-column aliases for the compare SQL shape. The handler's
+// Sample projection references them; keeping them as constants pins
+// the lowering and the HTTP layer to the same names.
+const (
+	compareSelAlias   = "is_selection"
+	compareAttrAlias  = "attr"
+	compareValAlias   = "val"
+	compareKVAlias    = "kv"
+	rootNameAlias     = "__root_name"
+	rootServiceAlias  = "__root_service_name"
+	compareNilLiteral = "nil"
+)
+
+// wellKnownResourceAttrs are the resource-scoped attributes vparquet4
+// stores in dedicated columns (tempodb/encoding/vparquet4/block_traceql.go,
+// `WellKnownColumnLookups`). Under select-all, reference Tempo fetches
+// these columns for EVERY batch; a null cell (the resource lacks the
+// attribute) surfaces as the literal string "nil"
+// (batchCollector.KeepGroup's IsNull branch), producing a `"nil"`
+// value bucket in compare() output. Cerberus mirrors that with an
+// `if(mapContains(...), map[k], 'nil')` projection per key.
+var wellKnownResourceAttrs = []string{
+	"service.name",
+	"cluster",
+	"namespace",
+	"pod",
+	"container",
+	"k8s.cluster.name",
+	"k8s.namespace.name",
+	"k8s.pod.name",
+	"k8s.container.name",
+}
+
+// wellKnownSpanAttrs is the span-scoped slice of vparquet4's
+// WellKnownColumnLookups; same "nil"-fallback contract as
+// wellKnownResourceAttrs (spanCollector.KeepGroup's IsNull branch).
+var wellKnownSpanAttrs = []string{
+	"http.status_code",
+	"http.method",
+	"http.url",
+}
+
+// lowerMetricsCompare lowers `| compare({...}, topN[, start, end])`.
+//
+// `prev` is the lowered spanset prefix (the query's `{...}` pipeline),
+// same contract as lowerMetricsAggregate.
+func lowerMetricsCompare(prev chplan.Node, mc *traceql.MetricsCompare, s schema.Traces) (chplan.Node, error) {
+	f := mc.Filter()
+	if f == nil {
+		return nil, fmt.Errorf("traceql: compare() requires a selection spanset filter")
+	}
+	sel, err := lowerFieldExpr(f.Expression, s)
+	if err != nil {
+		return nil, err
+	}
+	if sel == nil {
+		return nil, fmt.Errorf("traceql: compare() selection filter lowered to no predicate")
+	}
+
+	startNs := int64(mc.Start())
+	endNs := int64(mc.End())
+	if startNs > 0 && endNs > 0 {
+		// Tempo's isSelection only evaluates the filter for spans whose
+		// start time falls in (start, end]; everything else is baseline.
+		// AND the window into the selection predicate so the SQL cohort
+		// flag reproduces that assignment exactly.
+		tsNs := &chplan.FuncCall{
+			Name: "toUnixTimestamp64Nano",
+			Args: []chplan.Expr{&chplan.ColumnRef{Name: s.TimestampColumn}},
+		}
+		window := &chplan.Binary{
+			Op:    chplan.OpAnd,
+			Left:  &chplan.Binary{Op: chplan.OpGt, Left: tsNs, Right: &chplan.LitInt{V: startNs}},
+			Right: &chplan.Binary{Op: chplan.OpLe, Left: tsNs, Right: &chplan.LitInt{V: endNs}},
+		}
+		sel = &chplan.Binary{Op: chplan.OpAnd, Left: window, Right: sel}
+	}
+
+	node := &chplan.MetricsCompare{
+		Selection:  sel,
+		TopN:       mc.TopN(),
+		StartNs:    startNs,
+		EndNs:      endNs,
+		Pairs:      compareAttrPairsExpr(s),
+		SelAlias:   compareSelAlias,
+		AttrAlias:  compareAttrAlias,
+		ValAlias:   compareValAlias,
+		ValueAlias: metricsValueAlias,
+		Inner:      prev,
+	}
+
+	// rootName / rootServiceName are trace-level columns in vparquet;
+	// OTel-CH derives them by joining each span's trace to its root span
+	// (empty ParentSpanId). Requires the parent-span-id, trace-id and
+	// service-name columns; schemas that blank any of them skip the two
+	// trace-scoped attributes rather than failing the whole query.
+	if s.ParentSpanIDColumn != "" && s.TraceIDColumn != "" && s.SpanNameColumn != "" && s.ServiceNameColumn != "" {
+		node.RootLookup = compareRootLookup(s)
+		node.TraceIDColumn = s.TraceIDColumn
+		node.RootNameAlias = rootNameAlias
+		node.RootServiceAlias = rootServiceAlias
+	}
+
+	return node, nil
+}
+
+// compareRootLookup builds the per-trace root-span relation:
+//
+//	SELECT <TraceId>, any(<SpanName>) AS __root_name,
+//	       any(<ServiceName>) AS __root_service_name
+//	FROM <spans> WHERE <ParentSpanId> = '' GROUP BY <TraceId>
+//
+// One row per trace; the compare emitter LEFT JOINs it on TraceId so
+// every span row carries its trace's rootName / rootServiceName —
+// mirroring vparquet's trace-level RootSpanName / RootServiceName
+// columns. Orphan traces (no root span in the scanned window) fall out
+// of the LEFT JOIN as empty strings.
+func compareRootLookup(s schema.Traces) chplan.Node {
+	return &chplan.Aggregate{
+		Input: &chplan.Filter{
+			Input: &chplan.Scan{Table: s.SpansTable},
+			Predicate: &chplan.Binary{
+				Op:    chplan.OpEq,
+				Left:  &chplan.ColumnRef{Name: s.ParentSpanIDColumn},
+				Right: &chplan.LitString{V: ""},
+			},
+		},
+		GroupBy: []chplan.Expr{&chplan.ColumnRef{Name: s.TraceIDColumn}},
+		AggFuncs: []chplan.AggFunc{
+			{Name: "any", Args: []chplan.Expr{&chplan.ColumnRef{Name: s.SpanNameColumn}}, Alias: rootNameAlias},
+			{Name: "any", Args: []chplan.Expr{&chplan.ColumnRef{Name: s.ServiceNameColumn}}, Alias: rootServiceAlias},
+		},
+	}
+}
+
+// compareAttrPairsExpr builds the Array(Tuple(String, String))
+// expression enumerating every (attribute wire name, value) pair of a
+// span row — the OTel-CH analogue of what reference Tempo's
+// `span.AllAttributesFunc` yields under SecondPassSelectAll, minus the
+// shapes compare() excludes:
+//
+//   - Duration-typed values (`duration`, `traceDuration`) — excluded by
+//     processAttribute's TypeDuration guard.
+//   - span:id / span:parentID / span start time / trace:id /
+//     nested-set positions — excluded by the select-all column set or
+//     processAttribute's intrinsic skip-list.
+//
+// Included, mirroring vparquet4's select-all column inventory:
+//
+//   - intrinsics: name, status (lowercased to Tempo's Status.String()
+//     forms), statusMessage, kind (lowercased to Kind.String() forms);
+//   - trace-level rootName / rootServiceName (via the RootLookup join);
+//   - instrumentation:name / instrumentation:version (scope columns);
+//   - the well-known dedicated attributes (vparquet4
+//     WellKnownColumnLookups) with the literal "nil" fallback for
+//     absent values — reference Tempo surfaces null dedicated-column
+//     cells as the string "nil";
+//   - every remaining ResourceAttributes / SpanAttributes entry,
+//     scope-prefixed (`resource.` / `span.`).
+//
+// Every value is projected as String — Tempo's typed AnyValue label
+// values (intValue / boolValue / doubleValue) canonicalise to the same
+// strings on the differ/Grafana side, and the OTel-CH maps store
+// attribute values as strings already.
+func compareAttrPairsExpr(s schema.Traces) chplan.Expr {
+	col := func(name string) chplan.Expr { return &chplan.ColumnRef{Name: name} }
+	lit := func(v string) chplan.Expr { return &chplan.LitString{V: v} }
+	call := func(name string, args ...chplan.Expr) chplan.Expr {
+		return &chplan.FuncCall{Name: name, Args: args}
+	}
+	pair := func(name string, val chplan.Expr) chplan.Expr {
+		return call("tuple", lit(name), call("toString", val))
+	}
+
+	fixed := []chplan.Expr{
+		pair("name", col(s.SpanNameColumn)),
+		pair("status", call("lower", col(s.StatusCodeColumn))),
+		pair("statusMessage", col(s.StatusMessageColumn)),
+		pair("kind", call("lower", col(s.SpanKindColumn))),
+	}
+	if s.ParentSpanIDColumn != "" && s.TraceIDColumn != "" && s.SpanNameColumn != "" && s.ServiceNameColumn != "" {
+		fixed = append(
+			fixed,
+			pair("rootName", &chplan.BareIdent{Name: rootNameAlias}),
+			pair("rootServiceName", &chplan.BareIdent{Name: rootServiceAlias}),
+		)
+	}
+	if s.ScopeNameColumn != "" {
+		fixed = append(fixed, pair("instrumentation:name", col(s.ScopeNameColumn)))
+	}
+	if s.ScopeVersionColumn != "" {
+		fixed = append(fixed, pair("instrumentation:version", col(s.ScopeVersionColumn)))
+	}
+
+	// Well-known dedicated attributes: present map entries surface
+	// verbatim, absent ones as the literal "nil" (reference Tempo's
+	// null-cell contract — see wellKnownResourceAttrs).
+	wellKnown := func(mapCol, scopePrefix string, keys []string) []chplan.Expr {
+		out := make([]chplan.Expr, 0, len(keys))
+		for _, k := range keys {
+			out = append(out, pair(
+				scopePrefix+k,
+				call(
+					"if",
+					call("mapContains", col(mapCol), lit(k)),
+					&chplan.MapAccess{Map: col(mapCol), Key: lit(k)},
+					lit(compareNilLiteral),
+				),
+			))
+		}
+		return out
+	}
+	fixed = append(fixed, wellKnown(s.ResourceAttributesColumn, "resource.", wellKnownResourceAttrs)...)
+	fixed = append(fixed, wellKnown(s.AttributesColumn, "span.", wellKnownSpanAttrs)...)
+
+	// Generic map attributes: scope-prefix every (key, value) entry that
+	// is NOT carried by a well-known dedicated column above.
+	generic := func(mapCol, scopePrefix string, exclude []string) chplan.Expr {
+		exq := make([]chplan.Expr, 0, len(exclude))
+		for _, k := range exclude {
+			exq = append(exq, lit(k))
+		}
+		t := &chplan.BareIdent{Name: "t"}
+		zipped := call("arrayZip", call("mapKeys", col(mapCol)), call("mapValues", col(mapCol)))
+		filtered := call(
+			"arrayFilter",
+			&chplan.Lambda{Params: []string{"t"}, Body: call(
+				"not",
+				call("has", call("array", exq...), call("tupleElement", t, &chplan.LitInt{V: 1})),
+			)},
+			zipped,
+		)
+		return call(
+			"arrayMap",
+			&chplan.Lambda{Params: []string{"t"}, Body: call(
+				"tuple",
+				call("concat", lit(scopePrefix), call("tupleElement", t, &chplan.LitInt{V: 1})),
+				call("toString", call("tupleElement", t, &chplan.LitInt{V: 2})),
+			)},
+			filtered,
+		)
+	}
+
+	return call(
+		"arrayConcat",
+		call("array", fixed...),
+		generic(s.ResourceAttributesColumn, "resource.", wellKnownResourceAttrs),
+		generic(s.AttributesColumn, "span.", wellKnownSpanAttrs),
+	)
+}

--- a/internal/traceql/metrics_compare_test.go
+++ b/internal/traceql/metrics_compare_test.go
@@ -1,0 +1,176 @@
+package traceql_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tempo "github.com/grafana/tempo/pkg/traceql"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/traceql"
+)
+
+// lowerCompare parses + lowers and unwraps the MetricsCompare node.
+func lowerCompare(t *testing.T, q string) *chplan.MetricsCompare {
+	t.Helper()
+	expr, err := tempo.Parse(q)
+	if err != nil {
+		t.Fatalf("Parse(%q): %v", q, err)
+	}
+	plan, err := traceql.Lower(context.Background(), expr, schema.DefaultOTelTraces())
+	if err != nil {
+		t.Fatalf("Lower(%q): %v", q, err)
+	}
+	switch v := plan.(type) {
+	case *chplan.MetricsCompare:
+		return v
+	case *chplan.Filter:
+		if inner, ok := v.Input.(*chplan.MetricsCompare); ok {
+			return inner
+		}
+	}
+	t.Fatalf("Lower(%q): expected *chplan.MetricsCompare (or Filter wrap), got %T", q, plan)
+	return nil
+}
+
+// TestLowerMetricsCompare_Defaults — `{} | compare({status = error})`
+// lowers with the upstream default topN=10, no selection window, and
+// the rootName/rootServiceName lookup join enabled on the default
+// OTel-CH schema.
+func TestLowerMetricsCompare_Defaults(t *testing.T) {
+	t.Parallel()
+
+	mc := lowerCompare(t, `{} | compare({status = error})`)
+	if mc.TopN != 10 {
+		t.Errorf("TopN = %d, want 10 (upstream default)", mc.TopN)
+	}
+	if mc.StartNs != 0 || mc.EndNs != 0 {
+		t.Errorf("window = (%d, %d], want unset", mc.StartNs, mc.EndNs)
+	}
+	if mc.RootLookup == nil {
+		t.Error("RootLookup = nil, want the per-trace root-span relation on the default schema")
+	}
+	if mc.TraceIDColumn != "TraceId" {
+		t.Errorf("TraceIDColumn = %q, want TraceId", mc.TraceIDColumn)
+	}
+	bin, ok := mc.Selection.(*chplan.Binary)
+	if !ok || bin.Op != chplan.OpEq {
+		t.Fatalf("Selection = %#v, want Binary OpEq on StatusCode", mc.Selection)
+	}
+	lit, ok := bin.Right.(*chplan.LitString)
+	if !ok || lit.V != "Error" {
+		t.Errorf("Selection RHS = %#v, want LitString 'Error' (OTel-CH TitleCase)", bin.Right)
+	}
+	if mc.Pairs == nil {
+		t.Fatal("Pairs = nil, want the span-attribute explosion expression")
+	}
+	if mc.Inner == nil {
+		t.Fatal("Inner = nil, want the lowered spanset prefix")
+	}
+}
+
+// TestLowerMetricsCompare_TopNAndWindow — the 4-arg form threads topN
+// and ANDs the (start, end] unix-nanosecond window into the selection
+// predicate (upstream isSelection: window first, then filter).
+func TestLowerMetricsCompare_TopNAndWindow(t *testing.T) {
+	t.Parallel()
+
+	mc := lowerCompare(t, `{} | compare({status = error}, 5, 1100, 1300)`)
+	if mc.TopN != 5 {
+		t.Errorf("TopN = %d, want 5", mc.TopN)
+	}
+	if mc.StartNs != 1100 || mc.EndNs != 1300 {
+		t.Errorf("window = (%d, %d], want (1100, 1300]", mc.StartNs, mc.EndNs)
+	}
+	outer, ok := mc.Selection.(*chplan.Binary)
+	if !ok || outer.Op != chplan.OpAnd {
+		t.Fatalf("Selection = %#v, want top-level AND(window, filter)", mc.Selection)
+	}
+	win, ok := outer.Left.(*chplan.Binary)
+	if !ok || win.Op != chplan.OpAnd {
+		t.Fatalf("Selection.Left = %#v, want AND(ts > start, ts <= end)", outer.Left)
+	}
+	lo, ok := win.Left.(*chplan.Binary)
+	if !ok || lo.Op != chplan.OpGt {
+		t.Fatalf("window lower bound = %#v, want OpGt (strict, upstream `spanStartTime > start`)", win.Left)
+	}
+	hi, ok := win.Right.(*chplan.Binary)
+	if !ok || hi.Op != chplan.OpLe {
+		t.Fatalf("window upper bound = %#v, want OpLe (inclusive, upstream `spanStartTime <= end`)", win.Right)
+	}
+}
+
+// TestLowerMetricsCompare_DrilldownVerbatim — the exact query Grafana
+// Traces Drilldown's Comparison tab issues (crawl signature
+// traceql-metrics-compare-unsupported-422) parses, lowers, and emits
+// SQL end to end.
+func TestLowerMetricsCompare_DrilldownVerbatim(t *testing.T) {
+	t.Parallel()
+
+	const q = `{nestedSetParent<0 && true} | compare({status = error}, 10)`
+	expr, err := tempo.Parse(q)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	plan, err := traceql.Lower(context.Background(), expr, schema.DefaultOTelTraces())
+	if err != nil {
+		t.Fatalf("Lower: %v", err)
+	}
+	sql, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("EmitString: %v", err)
+	}
+	for _, want := range []string{
+		"arrayJoin",    // attribute-pair explosion
+		"is_selection", // cohort flag
+		"LEFT JOIN",    // rootName / rootServiceName lookup
+		"ParentSpanId", // root-span predicate inside the lookup
+		"mapContains",  // well-known dedicated-attribute nil fallback
+		"tupleElement", // attr / val projection
+		"GROUP BY",     // per-(cohort, attr, val) counts
+	} {
+		if !strings.Contains(sql, want) {
+			t.Errorf("emitted SQL missing %q:\n%s", want, sql)
+		}
+	}
+}
+
+// TestLowerMetricsCompare_PairsSkipRootWithoutColumns — blanking the
+// parent-span-id column drops the root lookup (and the rootName /
+// rootServiceName pairs) instead of failing the query.
+func TestLowerMetricsCompare_PairsSkipRootWithoutColumns(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelTraces()
+	s.ParentSpanIDColumn = ""
+	expr, err := tempo.Parse(`{} | compare({status = error})`)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	plan, err := traceql.Lower(context.Background(), expr, s)
+	if err != nil {
+		t.Fatalf("Lower: %v", err)
+	}
+	mc, ok := plan.(*chplan.MetricsCompare)
+	if !ok {
+		if f, fok := plan.(*chplan.Filter); fok {
+			mc, ok = f.Input.(*chplan.MetricsCompare)
+		}
+		if !ok {
+			t.Fatalf("expected MetricsCompare, got %T", plan)
+		}
+	}
+	if mc.RootLookup != nil {
+		t.Error("RootLookup should be nil when ParentSpanIDColumn is blank")
+	}
+	sql, _, err := chsql.Emit(context.Background(), mc)
+	if err != nil {
+		t.Fatalf("EmitString: %v", err)
+	}
+	if strings.Contains(sql, "__root_name") {
+		t.Errorf("SQL must not reference __root_name without the lookup join:\n%s", sql)
+	}
+}

--- a/internal/traceql/metrics_pipeline.go
+++ b/internal/traceql/metrics_pipeline.go
@@ -43,6 +43,9 @@ func lowerMetricsPipeline(prev chplan.Node, mp traceql.FirstStageElement, s sche
 	if v, ok := mp.(*traceql.AverageOverTimeAggregator); ok {
 		return lowerAverageOverTime(prev, v, s)
 	}
+	if v, ok := mp.(*traceql.MetricsCompare); ok {
+		return lowerMetricsCompare(prev, v, s)
+	}
 	return nil, fmt.Errorf("traceql: metrics pipeline element %T is unsupported", mp)
 }
 

--- a/test/e2e/grafana/compose/dashboards/showcase-traceql.json
+++ b/test/e2e/grafana/compose/dashboards/showcase-traceql.json
@@ -3595,14 +3595,14 @@
     },
     {
      "cerberus": {
-      "expect": "error:MetricsCompare is unsupported",
-      "why": "compare() is a baseline-vs-selection split evaluated by Tempo's metrics engine; cerberus's metrics pipeline does not lower it yet. The pin fires the moment support lands and forces the upgrade to a nonempty contract."
+      "expect": "nonempty",
+      "why": "compare() lowers through chplan.MetricsCompare since feat/traceql-compare: the SQL explodes every span attribute into (cohort, attr, value) counts and the handler mirrors Tempo's BaselineAggregator (__meta_type series scheme). The seed always carries status=error spans, so the panel must render series — an empty result or a 422 regression re-fires this pin."
      },
      "datasource": {
       "type": "tempo",
       "uid": "cerberus-tempo"
      },
-     "description": "Cerberus rejects `{ } | compare({ status = error })` today; this panel pins the rejection bidirectionally.",
+     "description": "`{ } | compare({ status = error })` — baseline-vs-selection attribute split (Grafana Traces Drilldown's Comparison tab shape). Formerly a pinned 422 rejection; the contract flipped to nonempty when compare() support landed.",
      "fieldConfig": {
       "defaults": {
        "color": {
@@ -3683,7 +3683,7 @@
        "step": "15s"
       }
      ],
-     "title": "compare() \u2014 parity rejection",
+     "title": "compare() \u2014 baseline vs selection",
      "type": "timeseries"
     }
    ],

--- a/test/spec/chplan_print.go
+++ b/test/spec/chplan_print.go
@@ -304,6 +304,25 @@ func printNode(b *strings.Builder, n chplan.Node, depth int) {
 		if v.Inner != nil {
 			printNode(b, v.Inner, depth+1)
 		}
+	case *chplan.MetricsCompare:
+		// Pairs (the full span-attribute explosion) is deliberately
+		// summarised as present/absent — printing the whole arrayConcat
+		// tree would dwarf the rest of the golden without adding
+		// review signal; the SQL golden pins its exact shape.
+		fmt.Fprintf(b, "%sMetricsCompare topN=%d selection=%s", indent, v.TopN, printExpr(v.Selection))
+		if v.StartNs != 0 || v.EndNs != 0 {
+			fmt.Fprintf(b, " window=(%d, %d]", v.StartNs, v.EndNs)
+		}
+		if v.RootLookup != nil {
+			b.WriteString(" rootLookup=true")
+		}
+		if v.ValueAlias != "" {
+			fmt.Fprintf(b, " valueAlias=%s", v.ValueAlias)
+		}
+		b.WriteString("\n")
+		if v.Inner != nil {
+			printNode(b, v.Inner, depth+1)
+		}
 	case *chplan.AbsentOverTime:
 		fmt.Fprintf(b, "%sAbsentOverTime range=%s step=%s", indent, v.Range, v.Step)
 		if v.Offset != 0 {

--- a/test/spec/traceql/metrics_compare.txtar
+++ b/test/spec/traceql/metrics_compare.txtar
@@ -1,7 +1,7 @@
 -- query.traceql --
 { } | compare({ status = error })
 -- sql --
-SELECT `is_selection`, tupleElement(kv, ?) AS `attr`, tupleElement(kv, ?) AS `val`, toFloat64(count(?)) AS `Value` FROM (SELECT (`StatusCode` = ?) AS `is_selection`, arrayJoin(arrayConcat(array(tuple(?, toString(`SpanName`)), tuple(?, toString(lower(`StatusCode`))), tuple(?, toString(`StatusMessage`)), tuple(?, toString(lower(`SpanKind`))), tuple(?, toString(__root_name)), tuple(?, toString(__root_service_name)), tuple(?, toString(`ScopeName`)), tuple(?, toString(`ScopeVersion`)), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`SpanAttributes`, ?), `SpanAttributes`[?], ?))), tuple(?, toString(if(mapContains(`SpanAttributes`, ?), `SpanAttributes`[?], ?))), tuple(?, toString(if(mapContains(`SpanAttributes`, ?), `SpanAttributes`[?], ?)))), arrayMap(t -> tuple(concat(?, tupleElement(t, ?)), toString(tupleElement(t, ?))), arrayFilter(t -> not(has(array(?, ?, ?, ?, ?, ?, ?, ?, ?), tupleElement(t, ?))), arrayZip(mapKeys(`ResourceAttributes`), mapValues(`ResourceAttributes`)))), arrayMap(t -> tuple(concat(?, tupleElement(t, ?)), toString(tupleElement(t, ?))), arrayFilter(t -> not(has(array(?, ?, ?), tupleElement(t, ?))), arrayZip(mapKeys(`SpanAttributes`), mapValues(`SpanAttributes`)))))) AS `kv` FROM (SELECT * FROM `otel_traces` WHERE ?) AS s LEFT JOIN (SELECT `TraceId`, any(`SpanName`) AS `__root_name`, any(`ServiceName`) AS `__root_service_name` FROM (SELECT * FROM `otel_traces` WHERE (`ParentSpanId` = ?)) GROUP BY `TraceId`) AS r ON s.`TraceId` = r.`TraceId`) GROUP BY `is_selection`, `attr`, `val` ORDER BY `is_selection`, `attr`, `val`
+SELECT `is_selection`, tupleElement(kv, ?) AS `attr`, tupleElement(kv, ?) AS `val`, toFloat64(count(?)) AS `Value` FROM (SELECT (`StatusCode` = ?) AS `is_selection`, arrayJoin(arrayConcat(array(tuple(?, toString(`SpanName`)), tuple(?, toString(lower(`StatusCode`))), tuple(?, toString(`StatusMessage`)), tuple(?, toString(lower(`SpanKind`))), tuple(?, toString(__root_name)), tuple(?, toString(__root_service_name)), tuple(?, toString(`ScopeName`)), tuple(?, toString(`ScopeVersion`)), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`SpanAttributes`, ?), `SpanAttributes`[?], ?))), tuple(?, toString(if(mapContains(`SpanAttributes`, ?), `SpanAttributes`[?], ?))), tuple(?, toString(if(mapContains(`SpanAttributes`, ?), `SpanAttributes`[?], ?))), tuple(?, toString(if(mapContains(`SpanAttributes`, ?), `SpanAttributes`[?], ?))), tuple(?, toString(if(mapContains(`SpanAttributes`, ?), `SpanAttributes`[?], ?))), tuple(?, toString(if(mapContains(`SpanAttributes`, ?), `SpanAttributes`[?], ?))), tuple(?, toString(if(mapContains(`SpanAttributes`, ?), `SpanAttributes`[?], ?))), tuple(?, toString(if(mapContains(`SpanAttributes`, ?), `SpanAttributes`[?], ?)))), arrayMap(t -> tuple(concat(?, tupleElement(t, ?)), toString(tupleElement(t, ?))), arrayFilter(t -> not(has(array(?, ?, ?, ?, ?, ?, ?, ?, ?), tupleElement(t, ?))), arrayZip(mapKeys(`ResourceAttributes`), mapValues(`ResourceAttributes`)))), arrayMap(t -> tuple(concat(?, tupleElement(t, ?)), toString(tupleElement(t, ?))), arrayFilter(t -> not(has(array(?, ?, ?, ?, ?, ?, ?, ?), tupleElement(t, ?))), arrayZip(mapKeys(`SpanAttributes`), mapValues(`SpanAttributes`)))))) AS `kv` FROM (SELECT * FROM `otel_traces` WHERE ?) AS s LEFT JOIN (SELECT `TraceId`, any(`SpanName`) AS `__root_name`, any(`ServiceName`) AS `__root_service_name` FROM (SELECT * FROM `otel_traces` WHERE (`ParentSpanId` = ?)) GROUP BY `TraceId`) AS r ON s.`TraceId` = r.`TraceId`) GROUP BY `is_selection`, `attr`, `val` ORDER BY `is_selection`, `attr`, `val`
 -- args --
 [0] int64 = 1
 [1] int64 = 2
@@ -63,28 +63,53 @@ SELECT `is_selection`, tupleElement(kv, ?) AS `attr`, tupleElement(kv, ?) AS `va
 [57] string = "http.url"
 [58] string = "http.url"
 [59] string = "nil"
-[60] string = "resource."
-[61] int64 = 1
-[62] int64 = 2
-[63] string = "service.name"
-[64] string = "cluster"
-[65] string = "namespace"
-[66] string = "pod"
-[67] string = "container"
-[68] string = "k8s.cluster.name"
-[69] string = "k8s.namespace.name"
-[70] string = "k8s.pod.name"
-[71] string = "k8s.container.name"
-[72] int64 = 1
-[73] string = "span."
-[74] int64 = 1
-[75] int64 = 2
-[76] string = "http.status_code"
-[77] string = "http.method"
-[78] string = "http.url"
-[79] int64 = 1
-[80] bool = true
-[81] string = ""
+[60] string = "span.http.request.method"
+[61] string = "http.request.method"
+[62] string = "http.request.method"
+[63] string = "nil"
+[64] string = "span.http.route"
+[65] string = "http.route"
+[66] string = "http.route"
+[67] string = "nil"
+[68] string = "span.server.address"
+[69] string = "server.address"
+[70] string = "server.address"
+[71] string = "nil"
+[72] string = "span.url.path"
+[73] string = "url.path"
+[74] string = "url.path"
+[75] string = "nil"
+[76] string = "span.url.route"
+[77] string = "url.route"
+[78] string = "url.route"
+[79] string = "nil"
+[80] string = "resource."
+[81] int64 = 1
+[82] int64 = 2
+[83] string = "service.name"
+[84] string = "cluster"
+[85] string = "namespace"
+[86] string = "pod"
+[87] string = "container"
+[88] string = "k8s.cluster.name"
+[89] string = "k8s.namespace.name"
+[90] string = "k8s.pod.name"
+[91] string = "k8s.container.name"
+[92] int64 = 1
+[93] string = "span."
+[94] int64 = 1
+[95] int64 = 2
+[96] string = "http.status_code"
+[97] string = "http.method"
+[98] string = "http.url"
+[99] string = "http.request.method"
+[100] string = "http.route"
+[101] string = "server.address"
+[102] string = "url.path"
+[103] string = "url.route"
+[104] int64 = 1
+[105] bool = true
+[106] string = ""
 -- seed --
 CREATE TABLE otel_traces (
     Timestamp DateTime64(9),
@@ -122,8 +147,13 @@ INSERT INTO otel_traces VALUES
   [0, "rootName", "GET /home", 1],
   [0, "rootServiceName", "shop", 1],
   [0, "span.http.method", "GET", 1],
+  [0, "span.http.request.method", "nil", 1],
+  [0, "span.http.route", "nil", 1],
   [0, "span.http.status_code", "nil", 1],
   [0, "span.http.url", "nil", 1],
+  [0, "span.server.address", "nil", 1],
+  [0, "span.url.path", "nil", 1],
+  [0, "span.url.route", "nil", 1],
   [0, "status", "ok", 1],
   [0, "statusMessage", "", 1],
   [1, "instrumentation:name", "", 1],
@@ -142,8 +172,13 @@ INSERT INTO otel_traces VALUES
   [1, "rootName", "GET /home", 1],
   [1, "rootServiceName", "shop", 1],
   [1, "span.http.method", "nil", 1],
+  [1, "span.http.request.method", "nil", 1],
+  [1, "span.http.route", "nil", 1],
   [1, "span.http.status_code", "nil", 1],
   [1, "span.http.url", "nil", 1],
+  [1, "span.server.address", "nil", 1],
+  [1, "span.url.path", "nil", 1],
+  [1, "span.url.route", "nil", 1],
   [1, "status", "error", 1],
   [1, "statusMessage", "boom", 1]
 ]

--- a/test/spec/traceql/metrics_compare.txtar
+++ b/test/spec/traceql/metrics_compare.txtar
@@ -1,0 +1,153 @@
+-- query.traceql --
+{ } | compare({ status = error })
+-- sql --
+SELECT `is_selection`, tupleElement(kv, ?) AS `attr`, tupleElement(kv, ?) AS `val`, toFloat64(count(?)) AS `Value` FROM (SELECT (`StatusCode` = ?) AS `is_selection`, arrayJoin(arrayConcat(array(tuple(?, toString(`SpanName`)), tuple(?, toString(lower(`StatusCode`))), tuple(?, toString(`StatusMessage`)), tuple(?, toString(lower(`SpanKind`))), tuple(?, toString(__root_name)), tuple(?, toString(__root_service_name)), tuple(?, toString(`ScopeName`)), tuple(?, toString(`ScopeVersion`)), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`SpanAttributes`, ?), `SpanAttributes`[?], ?))), tuple(?, toString(if(mapContains(`SpanAttributes`, ?), `SpanAttributes`[?], ?))), tuple(?, toString(if(mapContains(`SpanAttributes`, ?), `SpanAttributes`[?], ?)))), arrayMap(t -> tuple(concat(?, tupleElement(t, ?)), toString(tupleElement(t, ?))), arrayFilter(t -> not(has(array(?, ?, ?, ?, ?, ?, ?, ?, ?), tupleElement(t, ?))), arrayZip(mapKeys(`ResourceAttributes`), mapValues(`ResourceAttributes`)))), arrayMap(t -> tuple(concat(?, tupleElement(t, ?)), toString(tupleElement(t, ?))), arrayFilter(t -> not(has(array(?, ?, ?), tupleElement(t, ?))), arrayZip(mapKeys(`SpanAttributes`), mapValues(`SpanAttributes`)))))) AS `kv` FROM (SELECT * FROM `otel_traces` WHERE ?) AS s LEFT JOIN (SELECT `TraceId`, any(`SpanName`) AS `__root_name`, any(`ServiceName`) AS `__root_service_name` FROM (SELECT * FROM `otel_traces` WHERE (`ParentSpanId` = ?)) GROUP BY `TraceId`) AS r ON s.`TraceId` = r.`TraceId`) GROUP BY `is_selection`, `attr`, `val` ORDER BY `is_selection`, `attr`, `val`
+-- args --
+[0] int64 = 1
+[1] int64 = 2
+[2] int64 = 1
+[3] string = "Error"
+[4] string = "name"
+[5] string = "status"
+[6] string = "statusMessage"
+[7] string = "kind"
+[8] string = "rootName"
+[9] string = "rootServiceName"
+[10] string = "instrumentation:name"
+[11] string = "instrumentation:version"
+[12] string = "resource.service.name"
+[13] string = "service.name"
+[14] string = "service.name"
+[15] string = "nil"
+[16] string = "resource.cluster"
+[17] string = "cluster"
+[18] string = "cluster"
+[19] string = "nil"
+[20] string = "resource.namespace"
+[21] string = "namespace"
+[22] string = "namespace"
+[23] string = "nil"
+[24] string = "resource.pod"
+[25] string = "pod"
+[26] string = "pod"
+[27] string = "nil"
+[28] string = "resource.container"
+[29] string = "container"
+[30] string = "container"
+[31] string = "nil"
+[32] string = "resource.k8s.cluster.name"
+[33] string = "k8s.cluster.name"
+[34] string = "k8s.cluster.name"
+[35] string = "nil"
+[36] string = "resource.k8s.namespace.name"
+[37] string = "k8s.namespace.name"
+[38] string = "k8s.namespace.name"
+[39] string = "nil"
+[40] string = "resource.k8s.pod.name"
+[41] string = "k8s.pod.name"
+[42] string = "k8s.pod.name"
+[43] string = "nil"
+[44] string = "resource.k8s.container.name"
+[45] string = "k8s.container.name"
+[46] string = "k8s.container.name"
+[47] string = "nil"
+[48] string = "span.http.status_code"
+[49] string = "http.status_code"
+[50] string = "http.status_code"
+[51] string = "nil"
+[52] string = "span.http.method"
+[53] string = "http.method"
+[54] string = "http.method"
+[55] string = "nil"
+[56] string = "span.http.url"
+[57] string = "http.url"
+[58] string = "http.url"
+[59] string = "nil"
+[60] string = "resource."
+[61] int64 = 1
+[62] int64 = 2
+[63] string = "service.name"
+[64] string = "cluster"
+[65] string = "namespace"
+[66] string = "pod"
+[67] string = "container"
+[68] string = "k8s.cluster.name"
+[69] string = "k8s.namespace.name"
+[70] string = "k8s.pod.name"
+[71] string = "k8s.container.name"
+[72] int64 = 1
+[73] string = "span."
+[74] int64 = 1
+[75] int64 = 2
+[76] string = "http.status_code"
+[77] string = "http.method"
+[78] string = "http.url"
+[79] int64 = 1
+[80] bool = true
+[81] string = ""
+-- seed --
+CREATE TABLE otel_traces (
+    Timestamp DateTime64(9),
+    TraceId String,
+    SpanId String,
+    ParentSpanId String,
+    SpanName LowCardinality(String),
+    SpanKind LowCardinality(String),
+    ServiceName LowCardinality(String),
+    StatusCode LowCardinality(String),
+    StatusMessage String,
+    ScopeName String,
+    ScopeVersion String,
+    ResourceAttributes Map(LowCardinality(String), String),
+    SpanAttributes Map(LowCardinality(String), String)
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    (toDateTime64(1778580030, 9), 't1', 's1', '', 'GET /home', 'Server', 'shop', 'Ok', '', '', '', map('service.name', 'shop'), map('http.method', 'GET')),
+    (toDateTime64(1778580040, 9), 't1', 's2', 's1', 'charge', 'Client', 'shop', 'Error', 'boom', '', '', map('service.name', 'shop'), map());
+-- expected_rows --
+[
+  [0, "instrumentation:name", "", 1],
+  [0, "instrumentation:version", "", 1],
+  [0, "kind", "server", 1],
+  [0, "name", "GET /home", 1],
+  [0, "resource.cluster", "nil", 1],
+  [0, "resource.container", "nil", 1],
+  [0, "resource.k8s.cluster.name", "nil", 1],
+  [0, "resource.k8s.container.name", "nil", 1],
+  [0, "resource.k8s.namespace.name", "nil", 1],
+  [0, "resource.k8s.pod.name", "nil", 1],
+  [0, "resource.namespace", "nil", 1],
+  [0, "resource.pod", "nil", 1],
+  [0, "resource.service.name", "shop", 1],
+  [0, "rootName", "GET /home", 1],
+  [0, "rootServiceName", "shop", 1],
+  [0, "span.http.method", "GET", 1],
+  [0, "span.http.status_code", "nil", 1],
+  [0, "span.http.url", "nil", 1],
+  [0, "status", "ok", 1],
+  [0, "statusMessage", "", 1],
+  [1, "instrumentation:name", "", 1],
+  [1, "instrumentation:version", "", 1],
+  [1, "kind", "client", 1],
+  [1, "name", "charge", 1],
+  [1, "resource.cluster", "nil", 1],
+  [1, "resource.container", "nil", 1],
+  [1, "resource.k8s.cluster.name", "nil", 1],
+  [1, "resource.k8s.container.name", "nil", 1],
+  [1, "resource.k8s.namespace.name", "nil", 1],
+  [1, "resource.k8s.pod.name", "nil", 1],
+  [1, "resource.namespace", "nil", 1],
+  [1, "resource.pod", "nil", 1],
+  [1, "resource.service.name", "shop", 1],
+  [1, "rootName", "GET /home", 1],
+  [1, "rootServiceName", "shop", 1],
+  [1, "span.http.method", "nil", 1],
+  [1, "span.http.status_code", "nil", 1],
+  [1, "span.http.url", "nil", 1],
+  [1, "status", "error", 1],
+  [1, "statusMessage", "boom", 1]
+]
+-- chplan --
+MetricsCompare topN=10 selection=(StatusCode = "Error") rootLookup=true valueAlias=Value
+  Filter predicate=true
+    Scan(otel_traces)

--- a/test/spec/traceql/metrics_compare_window.txtar
+++ b/test/spec/traceql/metrics_compare_window.txtar
@@ -1,0 +1,155 @@
+-- query.traceql --
+{ } | compare({ status = error }, 10, 1778580000000000000, 1778580060000000000)
+-- sql --
+SELECT `is_selection`, tupleElement(kv, ?) AS `attr`, tupleElement(kv, ?) AS `val`, toFloat64(count(?)) AS `Value` FROM (SELECT (((toUnixTimestamp64Nano(`Timestamp`) > ?) AND (toUnixTimestamp64Nano(`Timestamp`) <= ?)) AND (`StatusCode` = ?)) AS `is_selection`, arrayJoin(arrayConcat(array(tuple(?, toString(`SpanName`)), tuple(?, toString(lower(`StatusCode`))), tuple(?, toString(`StatusMessage`)), tuple(?, toString(lower(`SpanKind`))), tuple(?, toString(__root_name)), tuple(?, toString(__root_service_name)), tuple(?, toString(`ScopeName`)), tuple(?, toString(`ScopeVersion`)), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`SpanAttributes`, ?), `SpanAttributes`[?], ?))), tuple(?, toString(if(mapContains(`SpanAttributes`, ?), `SpanAttributes`[?], ?))), tuple(?, toString(if(mapContains(`SpanAttributes`, ?), `SpanAttributes`[?], ?)))), arrayMap(t -> tuple(concat(?, tupleElement(t, ?)), toString(tupleElement(t, ?))), arrayFilter(t -> not(has(array(?, ?, ?, ?, ?, ?, ?, ?, ?), tupleElement(t, ?))), arrayZip(mapKeys(`ResourceAttributes`), mapValues(`ResourceAttributes`)))), arrayMap(t -> tuple(concat(?, tupleElement(t, ?)), toString(tupleElement(t, ?))), arrayFilter(t -> not(has(array(?, ?, ?), tupleElement(t, ?))), arrayZip(mapKeys(`SpanAttributes`), mapValues(`SpanAttributes`)))))) AS `kv` FROM (SELECT * FROM `otel_traces` WHERE ?) AS s LEFT JOIN (SELECT `TraceId`, any(`SpanName`) AS `__root_name`, any(`ServiceName`) AS `__root_service_name` FROM (SELECT * FROM `otel_traces` WHERE (`ParentSpanId` = ?)) GROUP BY `TraceId`) AS r ON s.`TraceId` = r.`TraceId`) GROUP BY `is_selection`, `attr`, `val` ORDER BY `is_selection`, `attr`, `val`
+-- args --
+[0] int64 = 1
+[1] int64 = 2
+[2] int64 = 1
+[3] int64 = 1778580000000000000
+[4] int64 = 1778580060000000000
+[5] string = "Error"
+[6] string = "name"
+[7] string = "status"
+[8] string = "statusMessage"
+[9] string = "kind"
+[10] string = "rootName"
+[11] string = "rootServiceName"
+[12] string = "instrumentation:name"
+[13] string = "instrumentation:version"
+[14] string = "resource.service.name"
+[15] string = "service.name"
+[16] string = "service.name"
+[17] string = "nil"
+[18] string = "resource.cluster"
+[19] string = "cluster"
+[20] string = "cluster"
+[21] string = "nil"
+[22] string = "resource.namespace"
+[23] string = "namespace"
+[24] string = "namespace"
+[25] string = "nil"
+[26] string = "resource.pod"
+[27] string = "pod"
+[28] string = "pod"
+[29] string = "nil"
+[30] string = "resource.container"
+[31] string = "container"
+[32] string = "container"
+[33] string = "nil"
+[34] string = "resource.k8s.cluster.name"
+[35] string = "k8s.cluster.name"
+[36] string = "k8s.cluster.name"
+[37] string = "nil"
+[38] string = "resource.k8s.namespace.name"
+[39] string = "k8s.namespace.name"
+[40] string = "k8s.namespace.name"
+[41] string = "nil"
+[42] string = "resource.k8s.pod.name"
+[43] string = "k8s.pod.name"
+[44] string = "k8s.pod.name"
+[45] string = "nil"
+[46] string = "resource.k8s.container.name"
+[47] string = "k8s.container.name"
+[48] string = "k8s.container.name"
+[49] string = "nil"
+[50] string = "span.http.status_code"
+[51] string = "http.status_code"
+[52] string = "http.status_code"
+[53] string = "nil"
+[54] string = "span.http.method"
+[55] string = "http.method"
+[56] string = "http.method"
+[57] string = "nil"
+[58] string = "span.http.url"
+[59] string = "http.url"
+[60] string = "http.url"
+[61] string = "nil"
+[62] string = "resource."
+[63] int64 = 1
+[64] int64 = 2
+[65] string = "service.name"
+[66] string = "cluster"
+[67] string = "namespace"
+[68] string = "pod"
+[69] string = "container"
+[70] string = "k8s.cluster.name"
+[71] string = "k8s.namespace.name"
+[72] string = "k8s.pod.name"
+[73] string = "k8s.container.name"
+[74] int64 = 1
+[75] string = "span."
+[76] int64 = 1
+[77] int64 = 2
+[78] string = "http.status_code"
+[79] string = "http.method"
+[80] string = "http.url"
+[81] int64 = 1
+[82] bool = true
+[83] string = ""
+-- seed --
+CREATE TABLE otel_traces (
+    Timestamp DateTime64(9),
+    TraceId String,
+    SpanId String,
+    ParentSpanId String,
+    SpanName LowCardinality(String),
+    SpanKind LowCardinality(String),
+    ServiceName LowCardinality(String),
+    StatusCode LowCardinality(String),
+    StatusMessage String,
+    ScopeName String,
+    ScopeVersion String,
+    ResourceAttributes Map(LowCardinality(String), String),
+    SpanAttributes Map(LowCardinality(String), String)
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    (toDateTime64(1778580030, 9), 't1', 's1', '', 'a', 'Server', 'shop', 'Error', '', '', '', map('service.name', 'shop'), map()),
+    (toDateTime64(1778580090, 9), 't2', 's2', '', 'a', 'Server', 'shop', 'Error', '', '', '', map('service.name', 'shop'), map());
+-- expected_rows --
+[
+  [0, "instrumentation:name", "", 1],
+  [0, "instrumentation:version", "", 1],
+  [0, "kind", "server", 1],
+  [0, "name", "a", 1],
+  [0, "resource.cluster", "nil", 1],
+  [0, "resource.container", "nil", 1],
+  [0, "resource.k8s.cluster.name", "nil", 1],
+  [0, "resource.k8s.container.name", "nil", 1],
+  [0, "resource.k8s.namespace.name", "nil", 1],
+  [0, "resource.k8s.pod.name", "nil", 1],
+  [0, "resource.namespace", "nil", 1],
+  [0, "resource.pod", "nil", 1],
+  [0, "resource.service.name", "shop", 1],
+  [0, "rootName", "a", 1],
+  [0, "rootServiceName", "shop", 1],
+  [0, "span.http.method", "nil", 1],
+  [0, "span.http.status_code", "nil", 1],
+  [0, "span.http.url", "nil", 1],
+  [0, "status", "error", 1],
+  [0, "statusMessage", "", 1],
+  [1, "instrumentation:name", "", 1],
+  [1, "instrumentation:version", "", 1],
+  [1, "kind", "server", 1],
+  [1, "name", "a", 1],
+  [1, "resource.cluster", "nil", 1],
+  [1, "resource.container", "nil", 1],
+  [1, "resource.k8s.cluster.name", "nil", 1],
+  [1, "resource.k8s.container.name", "nil", 1],
+  [1, "resource.k8s.namespace.name", "nil", 1],
+  [1, "resource.k8s.pod.name", "nil", 1],
+  [1, "resource.namespace", "nil", 1],
+  [1, "resource.pod", "nil", 1],
+  [1, "resource.service.name", "shop", 1],
+  [1, "rootName", "a", 1],
+  [1, "rootServiceName", "shop", 1],
+  [1, "span.http.method", "nil", 1],
+  [1, "span.http.status_code", "nil", 1],
+  [1, "span.http.url", "nil", 1],
+  [1, "status", "error", 1],
+  [1, "statusMessage", "", 1]
+]
+-- chplan --
+MetricsCompare topN=10 selection=(((toUnixTimestamp64Nano(Timestamp) > 1778580000000000000) AND (toUnixTimestamp64Nano(Timestamp) <= 1778580060000000000)) AND (StatusCode = "Error")) window=(1778580000000000000, 1778580060000000000] rootLookup=true valueAlias=Value
+  Filter predicate=true
+    Scan(otel_traces)

--- a/test/spec/traceql/metrics_compare_window.txtar
+++ b/test/spec/traceql/metrics_compare_window.txtar
@@ -1,7 +1,7 @@
 -- query.traceql --
 { } | compare({ status = error }, 10, 1778580000000000000, 1778580060000000000)
 -- sql --
-SELECT `is_selection`, tupleElement(kv, ?) AS `attr`, tupleElement(kv, ?) AS `val`, toFloat64(count(?)) AS `Value` FROM (SELECT (((toUnixTimestamp64Nano(`Timestamp`) > ?) AND (toUnixTimestamp64Nano(`Timestamp`) <= ?)) AND (`StatusCode` = ?)) AS `is_selection`, arrayJoin(arrayConcat(array(tuple(?, toString(`SpanName`)), tuple(?, toString(lower(`StatusCode`))), tuple(?, toString(`StatusMessage`)), tuple(?, toString(lower(`SpanKind`))), tuple(?, toString(__root_name)), tuple(?, toString(__root_service_name)), tuple(?, toString(`ScopeName`)), tuple(?, toString(`ScopeVersion`)), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`SpanAttributes`, ?), `SpanAttributes`[?], ?))), tuple(?, toString(if(mapContains(`SpanAttributes`, ?), `SpanAttributes`[?], ?))), tuple(?, toString(if(mapContains(`SpanAttributes`, ?), `SpanAttributes`[?], ?)))), arrayMap(t -> tuple(concat(?, tupleElement(t, ?)), toString(tupleElement(t, ?))), arrayFilter(t -> not(has(array(?, ?, ?, ?, ?, ?, ?, ?, ?), tupleElement(t, ?))), arrayZip(mapKeys(`ResourceAttributes`), mapValues(`ResourceAttributes`)))), arrayMap(t -> tuple(concat(?, tupleElement(t, ?)), toString(tupleElement(t, ?))), arrayFilter(t -> not(has(array(?, ?, ?), tupleElement(t, ?))), arrayZip(mapKeys(`SpanAttributes`), mapValues(`SpanAttributes`)))))) AS `kv` FROM (SELECT * FROM `otel_traces` WHERE ?) AS s LEFT JOIN (SELECT `TraceId`, any(`SpanName`) AS `__root_name`, any(`ServiceName`) AS `__root_service_name` FROM (SELECT * FROM `otel_traces` WHERE (`ParentSpanId` = ?)) GROUP BY `TraceId`) AS r ON s.`TraceId` = r.`TraceId`) GROUP BY `is_selection`, `attr`, `val` ORDER BY `is_selection`, `attr`, `val`
+SELECT `is_selection`, tupleElement(kv, ?) AS `attr`, tupleElement(kv, ?) AS `val`, toFloat64(count(?)) AS `Value` FROM (SELECT (((toUnixTimestamp64Nano(`Timestamp`) > ?) AND (toUnixTimestamp64Nano(`Timestamp`) <= ?)) AND (`StatusCode` = ?)) AS `is_selection`, arrayJoin(arrayConcat(array(tuple(?, toString(`SpanName`)), tuple(?, toString(lower(`StatusCode`))), tuple(?, toString(`StatusMessage`)), tuple(?, toString(lower(`SpanKind`))), tuple(?, toString(__root_name)), tuple(?, toString(__root_service_name)), tuple(?, toString(`ScopeName`)), tuple(?, toString(`ScopeVersion`)), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], ?))), tuple(?, toString(if(mapContains(`SpanAttributes`, ?), `SpanAttributes`[?], ?))), tuple(?, toString(if(mapContains(`SpanAttributes`, ?), `SpanAttributes`[?], ?))), tuple(?, toString(if(mapContains(`SpanAttributes`, ?), `SpanAttributes`[?], ?))), tuple(?, toString(if(mapContains(`SpanAttributes`, ?), `SpanAttributes`[?], ?))), tuple(?, toString(if(mapContains(`SpanAttributes`, ?), `SpanAttributes`[?], ?))), tuple(?, toString(if(mapContains(`SpanAttributes`, ?), `SpanAttributes`[?], ?))), tuple(?, toString(if(mapContains(`SpanAttributes`, ?), `SpanAttributes`[?], ?))), tuple(?, toString(if(mapContains(`SpanAttributes`, ?), `SpanAttributes`[?], ?)))), arrayMap(t -> tuple(concat(?, tupleElement(t, ?)), toString(tupleElement(t, ?))), arrayFilter(t -> not(has(array(?, ?, ?, ?, ?, ?, ?, ?, ?), tupleElement(t, ?))), arrayZip(mapKeys(`ResourceAttributes`), mapValues(`ResourceAttributes`)))), arrayMap(t -> tuple(concat(?, tupleElement(t, ?)), toString(tupleElement(t, ?))), arrayFilter(t -> not(has(array(?, ?, ?, ?, ?, ?, ?, ?), tupleElement(t, ?))), arrayZip(mapKeys(`SpanAttributes`), mapValues(`SpanAttributes`)))))) AS `kv` FROM (SELECT * FROM `otel_traces` WHERE ?) AS s LEFT JOIN (SELECT `TraceId`, any(`SpanName`) AS `__root_name`, any(`ServiceName`) AS `__root_service_name` FROM (SELECT * FROM `otel_traces` WHERE (`ParentSpanId` = ?)) GROUP BY `TraceId`) AS r ON s.`TraceId` = r.`TraceId`) GROUP BY `is_selection`, `attr`, `val` ORDER BY `is_selection`, `attr`, `val`
 -- args --
 [0] int64 = 1
 [1] int64 = 2
@@ -65,28 +65,53 @@ SELECT `is_selection`, tupleElement(kv, ?) AS `attr`, tupleElement(kv, ?) AS `va
 [59] string = "http.url"
 [60] string = "http.url"
 [61] string = "nil"
-[62] string = "resource."
-[63] int64 = 1
-[64] int64 = 2
-[65] string = "service.name"
-[66] string = "cluster"
-[67] string = "namespace"
-[68] string = "pod"
-[69] string = "container"
-[70] string = "k8s.cluster.name"
-[71] string = "k8s.namespace.name"
-[72] string = "k8s.pod.name"
-[73] string = "k8s.container.name"
-[74] int64 = 1
-[75] string = "span."
-[76] int64 = 1
-[77] int64 = 2
-[78] string = "http.status_code"
-[79] string = "http.method"
-[80] string = "http.url"
-[81] int64 = 1
-[82] bool = true
-[83] string = ""
+[62] string = "span.http.request.method"
+[63] string = "http.request.method"
+[64] string = "http.request.method"
+[65] string = "nil"
+[66] string = "span.http.route"
+[67] string = "http.route"
+[68] string = "http.route"
+[69] string = "nil"
+[70] string = "span.server.address"
+[71] string = "server.address"
+[72] string = "server.address"
+[73] string = "nil"
+[74] string = "span.url.path"
+[75] string = "url.path"
+[76] string = "url.path"
+[77] string = "nil"
+[78] string = "span.url.route"
+[79] string = "url.route"
+[80] string = "url.route"
+[81] string = "nil"
+[82] string = "resource."
+[83] int64 = 1
+[84] int64 = 2
+[85] string = "service.name"
+[86] string = "cluster"
+[87] string = "namespace"
+[88] string = "pod"
+[89] string = "container"
+[90] string = "k8s.cluster.name"
+[91] string = "k8s.namespace.name"
+[92] string = "k8s.pod.name"
+[93] string = "k8s.container.name"
+[94] int64 = 1
+[95] string = "span."
+[96] int64 = 1
+[97] int64 = 2
+[98] string = "http.status_code"
+[99] string = "http.method"
+[100] string = "http.url"
+[101] string = "http.request.method"
+[102] string = "http.route"
+[103] string = "server.address"
+[104] string = "url.path"
+[105] string = "url.route"
+[106] int64 = 1
+[107] bool = true
+[108] string = ""
 -- seed --
 CREATE TABLE otel_traces (
     Timestamp DateTime64(9),
@@ -124,8 +149,13 @@ INSERT INTO otel_traces VALUES
   [0, "rootName", "a", 1],
   [0, "rootServiceName", "shop", 1],
   [0, "span.http.method", "nil", 1],
+  [0, "span.http.request.method", "nil", 1],
+  [0, "span.http.route", "nil", 1],
   [0, "span.http.status_code", "nil", 1],
   [0, "span.http.url", "nil", 1],
+  [0, "span.server.address", "nil", 1],
+  [0, "span.url.path", "nil", 1],
+  [0, "span.url.route", "nil", 1],
   [0, "status", "error", 1],
   [0, "statusMessage", "", 1],
   [1, "instrumentation:name", "", 1],
@@ -144,8 +174,13 @@ INSERT INTO otel_traces VALUES
   [1, "rootName", "a", 1],
   [1, "rootServiceName", "shop", 1],
   [1, "span.http.method", "nil", 1],
+  [1, "span.http.request.method", "nil", 1],
+  [1, "span.http.route", "nil", 1],
   [1, "span.http.status_code", "nil", 1],
   [1, "span.http.url", "nil", 1],
+  [1, "span.server.address", "nil", 1],
+  [1, "span.url.path", "nil", 1],
+  [1, "span.url.route", "nil", 1],
   [1, "status", "error", 1],
   [1, "statusMessage", "", 1]
 ]


### PR DESCRIPTION
## Summary

Implements TraceQL metrics **`compare()`** — the last crawl-backlog feature gap. Grafana Traces Drilldown's Comparison tab issues `{nestedSetParent<0 && true} | compare({status = error}, 10)`; cerberus 422'd. Reference semantics implemented from Tempo source (`engine_metrics_compare.go` + `vparquet4` select-all + frontend `BaselineAggregator`):

- Every pipeline span is assigned **selection** (matches the filter; optional `(start, end]` ns window) or **baseline**; every storage-surfaced attribute is counted per (cohort, attr, value, interval) plus per-(cohort, attr) totals; duration/start-time/trace-id/nested-set attributes excluded.
- Output: top-N values per (cohort, attr) as `{__meta_type="baseline|selection", <attr>=<val>}` plus `*_total` series, zero-filled grids; sample-less series dropped (so `__meta_error` never reaches the wire — matches reference `ToProto`).
- Well-known dedicated columns surface `'nil'` buckets; `rootName`/`rootServiceName` ride every span via a per-trace root-lookup relation.

## Pipeline

New `chplan.MetricsCompare` IR node (walk/equal/print registered) → typed chsql emission (bare deterministic shape for chdb; matrix shape with sample-side anchor fanout + LEFT JOIN root lookup) → `postProcessCompare` mirroring BaselineAggregator in `/api/metrics/query_range`, `/api/metrics/query`, and both gRPC metrics RPCs. Second-stage-over-compare 422s (parser rejects upstream too).

## Contract flips

Showcase compare() panel: `error:` pin → **nonempty** contract (bidirectional ratchet). Inventory already collects `metric:compare`; exclusions file remains empty.

## Verification

- 4218 default-tag tests green; chdb lanes green; two chdb TXTAR roundtrips with exact expected_rows (cohort split, `'nil'` fallback, enum lowercasing, root propagation, ns-window assignment).
- Consumer-grade: the verbatim Drilldown query through the HTTP handler → 200 with the full 4-way `__meta_type` scheme.
- **Live differential vs reference Tempo (`main-2f74ea8`): 37/37 cases, with the compare() case matching all 564 canonical series point-for-point.** The first run (540/564) exposed two real gaps fixed here: seeder now writes ScopeName/ScopeVersion to CH, and 5 newer well-known span attrs added (`http.request.method`, `http.route`, `server.address`, `url.path`, `url.route`).

## Maintainer action required (fork tag)

`compare()` needed 4 accessor methods on the fork (`MetricsCompare` fields are unexported). The commit is pushed as `feat/metrics-compare-accessors` on tsouza/tempo (`0888855`, exactly 1 ahead of `cerberus-accessors`); both the implementing agent and the orchestrator were permission-blocked from mutating the fork. `go.mod` temporarily pins the **pseudo-version** `v0.0.3-cerberus-accessors.0.20260611033556-0888855681c5` (resolves; verified). To restore the tags-only convention:

```sh
# in tsouza/tempo
git push origin 0888855681c5f710d8cdda4cd814a247071455f0:cerberus-accessors   # fast-forward
git tag v0.0.4-cerberus-accessors 0888855681c5f710d8cdda4cd814a247071455f0 && git push origin v0.0.4-cerberus-accessors
```

then a one-line `go.mod` bump to the tag (happy to do that PR on request).

## Other caveats

Root-lookup subquery is time-unbounded (roots can precede the window) — fine at compat scale, bounded-pushdown candidate later. Label values ship as `stringValue` vs reference's typed AnyValues — canonicalized identically by both the differ and Grafana (proven by the 100% run).

Closes task #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
