### PR TITLE
fix(tempo): duration histogram buckets per reference + flat-IN root lookup past the parser-depth cliff

### DIFF
--- a/compatibility/tempo/driver/corpus/smoke.txtar
+++ b/compatibility/tempo/driver/corpus/smoke.txtar
@@ -355,7 +355,7 @@ search
 -- expected_max_traces --
 500
 
-# --- Metrics pipeline: /api/metrics/query_range (3) ---
+# --- Metrics pipeline: /api/metrics/query_range (4) ---
 # These hit cerberus's /api/metrics/query_range (implemented today —
 # see internal/api/tempo/metrics_query_range.go) and Tempo's native
 # /api/metrics/query_range. The wire shape is `{series:[{labels,
@@ -405,6 +405,31 @@ groupby_labels_present:resource.service.name
 metrics_quantile_over_time_p95
 -- query --
 { } | quantile_over_time(duration, 0.95)
+-- endpoint --
+metrics_range
+-- step --
+60s
+-- expected_min_series --
+1
+-- expected_max_series --
+50
+-- semantic_checks --
+samples_non_negative
+
+# Duration histogram — pins the `__bucket` series-label unit + value
+# differentially against reference Tempo. The bucket edge must be
+# Log2Bucketize(Duration_ns) / 1e9 — the next power of two in
+# nanoseconds, rebased to SECONDS (pkg/traceql/ast_metrics.go
+# bucketizeDuration) — and its textual form must align with the
+# stringified doubleValue Tempo emits, because the differ keys series
+# by the label set. Cerberus's pre-fix shape emitted the raw log2
+# exponent divided by 1e9 (~1e-8 "buckets" for µs-scale spans), so
+# every histogram series mismatched reference; this case keeps that
+# from regressing. One series per observed (power-of-two) bucket edge.
+-- name --
+metrics_histogram_over_time_duration
+-- query --
+{ } | histogram_over_time(duration)
 -- endpoint --
 metrics_range
 -- step --

--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -318,6 +318,14 @@ func (h *Handler) handleSearch(w http.ResponseWriter, r *http.Request) {
 		// follow-up lookup against otel_traces filtered to root spans
 		// of the affected TraceIDs and patch RootServiceName /
 		// RootTraceName before responding.
+		//
+		// A lookup failure WARN-degrades (the earliest-span fallback
+		// stays in place) instead of failing the search — mirroring
+		// reference Tempo, where root metadata is best-effort by
+		// design: a search whose root span is unavailable still
+		// returns 200 with placeholder root fields
+		// (modules/frontend/combiner/search.go sets
+		// search.RootSpanNotYetReceivedText), never an error.
 		roots, lookupErr := h.resolveTraceRoots(ctx, missingRoots)
 		if lookupErr != nil {
 			h.Logger.Warn("cerberus tempo root-span lookup failed",

--- a/internal/api/tempo/metrics_query_range_histogram.go
+++ b/internal/api/tempo/metrics_query_range_histogram.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/chplan"
 	"github.com/tsouza/cerberus/internal/engine"
 )
@@ -140,10 +141,42 @@ func (h *Handler) serveMetricsQueryRangeHistogram(
 		"traceql", q, "start", start, "end", end, "step", step,
 		"sql", res.SQL, "args", res.Args)
 
+	normalizeHistogramBucketLabels(res.Samples)
 	series := toMetricsSeriesWithNames(res.Samples, histogramLabelNames(hist))
 
 	writeEngineHeaders(w, res.Headers)
 	writeJSON(w, http.StatusOK, MetricsQueryRangeResponse{
 		Series: series,
 	})
+}
+
+// normalizeHistogramBucketLabels rewrites each sample's `__bucket`
+// label value from ClickHouse's Float64 `toString` rendering to Go's
+// shortest round-trip form (strconv 'g'/-1 — what `fmt.Sprint(float64)`
+// produces). The bucket edge is a float that rides the wire as a
+// string label on histogram series, and it is part of the series
+// identity, so its textual form must be deterministic and match what
+// consumers derive from reference Tempo's `doubleValue` projection.
+// CH and Go disagree on small magnitudes — CH `toString(1.024e-6)`
+// renders "0.000001024" while Go renders "1.024e-06" — so sub-100µs
+// duration buckets would otherwise never align with a
+// reference-Tempo-derived form (the tempo compatibility differ
+// stringifies Tempo's doubleValue with fmt.Sprint before keying
+// series). Values that don't parse as floats pass through untouched —
+// defensive only; the SQL projection always emits a Float64 string.
+//
+// Mutates the samples' Labels maps in place (map values are shared by
+// reference; the slice itself is unchanged).
+func normalizeHistogramBucketLabels(samples []chclient.Sample) {
+	for _, s := range samples {
+		raw, ok := s.Labels[tempoQuantileBucketLabel]
+		if !ok {
+			continue
+		}
+		f, err := strconv.ParseFloat(raw, 64)
+		if err != nil {
+			continue
+		}
+		s.Labels[tempoQuantileBucketLabel] = strconv.FormatFloat(f, 'g', -1, 64)
+	}
 }

--- a/internal/api/tempo/metrics_query_range_histogram_chdb_test.go
+++ b/internal/api/tempo/metrics_query_range_histogram_chdb_test.go
@@ -1,0 +1,139 @@
+//go:build chdb
+
+// chDB-backed end-to-end pin for `| histogram_over_time(duration)` on
+// /api/metrics/query_range: parse → lower → emit → embedded ClickHouse
+// → response shaping. Pins the three reference-Tempo contracts the
+// crawl found broken or at risk:
+//
+//  1. Bucket UNIT + VALUE: the `__bucket` label is Log2Bucketize(ns)
+//     rebased to SECONDS — the duration rounded UP to the next power
+//     of two nanoseconds, divided by 1e9 (pkg/traceql/ast_metrics.go
+//     bucketizeDuration). Pre-fix cerberus emitted the raw log2
+//     exponent divided by 1e9 (~3e-08 for a 1.024µs span) instead of
+//     1.024e-06.
+//  2. Label FORM: the bucket label string uses Go's shortest float
+//     rendering ("1.024e-06"), not ClickHouse's ("0.000001024"), so
+//     series keys align with what consumers derive from Tempo's
+//     doubleValue wire shape.
+//  3. ZERO-FILL: every observed (group, __bucket) series reaches the
+//     wire dense — one sample per grid anchor, 0 where no span lands
+//     — because upstream histogram series ride
+//     NewCountOverTimeAggregator and SeriesSet.ToProto skips only NaN.
+package tempo_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/api/tempo"
+	"github.com/tsouza/cerberus/internal/chclienttest"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+func TestMetricsQueryRangeHistogram_DurationBucketsSeconds_ChDB(t *testing.T) {
+	c := chclienttest.NewChDB(t)
+	c.Seed(t, `CREATE TABLE otel_traces (
+    TraceId String,
+    SpanId String,
+    ParentSpanId String,
+    SpanName String,
+    Duration Int64,
+    Timestamp DateTime64(9),
+    SpanAttributes Map(String, String),
+    ResourceAttributes Map(String, String)
+) ENGINE = MergeTree() ORDER BY (Timestamp);`)
+	// Two spans inside the [10:00, 10:03] query window:
+	//   - 1024 ns  (2^10, exact power of two) at 10:01:30 → bucket
+	//     1024/1e9 = 1.024e-06 s, anchor 10:02.
+	//   - 1e8 ns   (100ms)                    at 10:00:30 → bucket
+	//     2^ceil(log2(1e8))/1e9 = 134217728/1e9 = 0.134217728 s,
+	//     anchor 10:01.
+	c.Seed(t, `INSERT INTO otel_traces VALUES
+    ('a0000000000000000000000000000001', '1000000000000001', '', 'fast', 1024, toDateTime64('2026-05-12 10:01:30.000000000', 9), map(), map('service.name', 'svc')),
+    ('a0000000000000000000000000000002', '1000000000000002', '', 'slow', 100000000, toDateTime64('2026-05-12 10:00:30.000000000', 9), map(), map('service.name', 'svc'));`)
+
+	h := tempo.New(c, schema.DefaultOTelTraces(), "v-test", nil)
+	mux := http.NewServeMux()
+	h.Mount(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	u := metricsQueryRangeURL(srv.URL, "{} | histogram_over_time(duration)", map[string]string{
+		"start": fixtureStartUnix, // 2026-05-12T10:00:00Z
+		"end":   fixtureEndUnix,   // +3m
+		"step":  "60s",
+	})
+	resp, err := http.Get(u)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+
+	var out tempo.MetricsQueryRangeResponse
+	if err := json.Unmarshal([]byte(body), &out); err != nil {
+		t.Fatalf("decode: %v\nbody: %s", err, body)
+	}
+	if len(out.Series) != 2 {
+		t.Fatalf("expected 2 series (one per bucket), got %d: %s", len(out.Series), body)
+	}
+
+	bySeries := map[string]tempo.MetricsSeries{}
+	for _, s := range out.Series {
+		if len(s.Labels) != 1 || s.Labels[0].Key != "__bucket" {
+			t.Fatalf("expected single __bucket label, got %+v", s.Labels)
+		}
+		bySeries[s.Labels[0].Value] = s
+	}
+
+	// Contract 1 + 2: bucket values in seconds, Go shortest-form
+	// rendering. The pre-fix shape surfaced "1e-08"-magnitude buckets
+	// (log2 exponent / 1e9); the CH string form would have been
+	// "0.000001024".
+	fast, ok := bySeries["1.024e-06"]
+	if !ok {
+		t.Fatalf("missing __bucket=1.024e-06 series (got %v): %s", labelValues(bySeries), body)
+	}
+	slow, ok := bySeries["0.134217728"]
+	if !ok {
+		t.Fatalf("missing __bucket=0.134217728 series (got %v): %s", labelValues(bySeries), body)
+	}
+
+	// Contract 3: dense series — 4 grid anchors (10:00..10:03 at 60s),
+	// zero-filled outside the span's anchor.
+	wantAnchorsMs := []int64{
+		1778580000000, // 10:00
+		1778580060000, // 10:01
+		1778580120000, // 10:02
+		1778580180000, // 10:03
+	}
+	assertSamples := func(name string, s tempo.MetricsSeries, wantValues []float64) {
+		t.Helper()
+		if len(s.Samples) != len(wantAnchorsMs) {
+			t.Fatalf("%s: expected %d zero-filled samples, got %d: %+v", name, len(wantAnchorsMs), len(s.Samples), s.Samples)
+		}
+		for i, sm := range s.Samples {
+			if sm.TimestampMs != wantAnchorsMs[i] {
+				t.Errorf("%s: sample[%d] ts = %d, want %d", name, i, sm.TimestampMs, wantAnchorsMs[i])
+			}
+			if sm.Value != wantValues[i] {
+				t.Errorf("%s: sample[%d] value = %g, want %g", name, i, sm.Value, wantValues[i])
+			}
+		}
+	}
+	assertSamples("fast bucket", fast, []float64{0, 0, 1, 0})
+	assertSamples("slow bucket", slow, []float64{0, 1, 0, 0})
+}
+
+// labelValues lists the map keys for failure messages.
+func labelValues(m map[string]tempo.MetricsSeries) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/api/tempo/metrics_query_range_histogram_test.go
+++ b/internal/api/tempo/metrics_query_range_histogram_test.go
@@ -141,3 +141,61 @@ func TestMetricsQueryRangeHistogram_GroupBy(t *testing.T) {
 		}
 	}
 }
+
+// TestMetricsQueryRangeHistogram_BucketLabelNormalisation pins the
+// wire form of the `__bucket` label value to Go's shortest round-trip
+// float rendering (strconv 'g'/-1, what fmt.Sprint(float64) produces —
+// the same form a consumer derives from reference Tempo's doubleValue
+// projection). ClickHouse's `toString(Float64)` disagrees with Go on
+// small magnitudes — CH renders 1.024e-6 as "0.000001024" — so without
+// the handler-side rewrite, sub-100µs duration buckets would carry a
+// CH-version-dependent label that never aligns with reference Tempo's
+// (the tempo compatibility differ keys series by the stringified
+// label set).
+func TestMetricsQueryRangeHistogram_BucketLabelNormalisation(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 5, 12, 10, 1, 0, 0, time.UTC)
+	q := &stubQuerier{samples: []chclient.Sample{
+		// CH toString rendering of the 1.024µs bucket (2^10 ns / 1e9).
+		{Labels: map[string]string{"__bucket": "0.000001024"}, Timestamp: ts, Value: 3},
+		// Values Go renders identically must pass through unchanged.
+		{Labels: map[string]string{"__bucket": "0.25"}, Timestamp: ts, Value: 5},
+	}}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	u := metricsQueryRangeURL(srv.URL, "{} | histogram_over_time(duration)", map[string]string{
+		"start": fixtureStartUnix,
+		"end":   fixtureEndUnix,
+		"step":  "60s",
+	})
+	resp, err := http.Get(u)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+
+	var body tempo.MetricsQueryRangeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Series) != 2 {
+		t.Fatalf("expected 2 series, got %d: %+v", len(body.Series), body)
+	}
+	got := map[string]bool{}
+	for _, s := range body.Series {
+		if len(s.Labels) != 1 || s.Labels[0].Key != "__bucket" {
+			t.Fatalf("expected single __bucket label, got %+v", s.Labels)
+		}
+		got[s.Labels[0].Value] = true
+	}
+	for _, want := range []string{"1.024e-06", "0.25"} {
+		if !got[want] {
+			t.Errorf("missing __bucket=%q on the wire (got %v) — bucket labels must use Go's shortest float form", want, got)
+		}
+	}
+}

--- a/internal/api/tempo/root_lookup.go
+++ b/internal/api/tempo/root_lookup.go
@@ -146,20 +146,27 @@ func (h *Handler) resolveTraceRoots(ctx context.Context, traceIDs []string) (map
 // span within the same GROUP BY group — keeping the lookup a single
 // round trip while distinguishing root vs. non-root rows.
 func buildRootLookupPlan(s schema.Traces, traceIDs []string) chplan.Node {
-	// Filter predicate: TraceId IN (<padded-id-1>, <padded-id-2>, ...).
-	// Without an `IN` chplan expression this renders as a flat OR-chain
-	// of Eq predicates — CH planner collapses to a constant-set lookup
-	// at execute time. Restricting to TraceId only lets the trace
-	// start / end aggregates see every span of the trace; argMinIf
-	// (below) carries the ParentSpanId restriction on the root-span
-	// identifying aggregates so the same group computes both.
-	traceMatch := orEqLiterals(s.TraceIDColumn, padTraceIDs(traceIDs))
+	// Filter predicate: TraceId IN (<padded-id-1>, <padded-id-2>, ...)
+	// as a single flat chplan.InList. The flatness is load-bearing: the
+	// previous shape rendered a nested OR-chain of Eq predicates, whose
+	// ClickHouse parser AST deepens by one level per trace ID — at
+	// ~1000 IDs the query trips `max_parser_depth` (default 1000) with
+	// code 306 ("Maximum parse depth exceeded"; observed in
+	// compose-smoke run 27307036248 with missing=1006) and the search
+	// response silently loses its root decoration. The IN tuple's
+	// elements are AST siblings, so parse depth stays constant no
+	// matter how many traces need root enrichment. Restricting to
+	// TraceId only lets the trace start / end aggregates see every span
+	// of the trace; argMinIf (below) carries the ParentSpanId
+	// restriction on the root-span identifying aggregates so the same
+	// group computes both.
+	traceMatch := inStringList(s.TraceIDColumn, padTraceIDs(traceIDs))
 
 	// rootCond expresses ParentSpanId IN ('', '0000000000000000') — the
 	// on-disk root marker (pre-strip empty form + canonical 16-char
 	// zero form). Reused inside both argMinIf aggregates so they pick
 	// the root span among each TraceId group.
-	rootCond := orEqLiterals(s.ParentSpanIDColumn, []string{"", "0000000000000000"})
+	rootCond := inStringList(s.ParentSpanIDColumn, []string{"", "0000000000000000"})
 
 	// argMinIf(SpanName, Timestamp, rootCond) AS RootSpanName.
 	aggSpanName := chplan.AggFunc{
@@ -256,12 +263,19 @@ func buildRootLookupPlan(s schema.Traces, traceIDs []string) chplan.Node {
 	}
 }
 
-// orEqLiterals returns `<col> = <v1> OR <col> = <v2> OR ...` as a
-// nested chplan.Binary OR-chain. Returns a single Eq when len(vals) ==
-// 1, and a guaranteed-false (`<col> = <col> AND 1=0`-equivalent) when
-// vals is empty — but the caller (resolveTraceRoots) guards against
-// the empty case so the branch is unreachable in production.
-func orEqLiterals(col string, vals []string) chplan.Expr {
+// inStringList returns `<col> IN (<v1>, <v2>, ...)` as a single flat
+// chplan.InList over string literals. Returns a guaranteed-false
+// (`1 = 0`) predicate when vals is empty — CH rejects an empty IN
+// list, and the caller (resolveTraceRoots) guards against the empty
+// case anyway, so the branch only keeps the helper total over its
+// input.
+//
+// Replaces the previous orEqLiterals OR-chain: that shape nested one
+// Binary per value and blew ClickHouse's max_parser_depth (default
+// 1000, error code 306) once a search returned >1000 traces needing
+// root enrichment. InList parses at constant depth regardless of
+// len(vals); see chplan.InList for the contract.
+func inStringList(col string, vals []string) chplan.Expr {
 	if len(vals) == 0 {
 		// Guaranteed-false: 1 = 0. CH evaluates this at planning time
 		// and short-circuits the filter; we should never hit this
@@ -272,18 +286,14 @@ func orEqLiterals(col string, vals []string) chplan.Expr {
 			Right: &chplan.LitInt{V: 0},
 		}
 	}
-	eq := func(v string) chplan.Expr {
-		return &chplan.Binary{
-			Op:    chplan.OpEq,
-			Left:  &chplan.ColumnRef{Name: col},
-			Right: &chplan.LitString{V: v},
-		}
+	list := make([]chplan.Expr, 0, len(vals))
+	for _, v := range vals {
+		list = append(list, &chplan.LitString{V: v})
 	}
-	out := eq(vals[0])
-	for i := 1; i < len(vals); i++ {
-		out = &chplan.Binary{Op: chplan.OpOr, Left: out, Right: eq(vals[i])}
+	return &chplan.InList{
+		Left: &chplan.ColumnRef{Name: col},
+		List: list,
 	}
-	return out
 }
 
 // padTraceIDs left-pads each stripped-zero TraceID back to the

--- a/internal/api/tempo/root_lookup_chdb_test.go
+++ b/internal/api/tempo/root_lookup_chdb_test.go
@@ -1,0 +1,77 @@
+//go:build chdb
+
+// chDB-backed regression pin for the /api/search root-span lookup's
+// parse depth. The pre-fix lookup rendered the trace-ID filter as a
+// nested OR-chain — one ClickHouse AST level per trace ID — and blew
+// `max_parser_depth` (default 1000) with code 306 ("Maximum parse
+// depth (1000) exceeded. Consider rising max_parser_depth") once a
+// search returned >1000 traces needing root enrichment (compose-smoke
+// run 27307036248, missing=1006). The failure WARN-degraded: search
+// responses silently lost their root decoration. The fix renders a
+// single flat `TraceId IN (...)` (chplan.InList), whose parse depth is
+// constant in the ID count; this test executes the real lookup against
+// an embedded ClickHouse at N=1500 — comfortably past the 1000-depth
+// cliff — and asserts the lookup both parses and recovers the seeded
+// trace's root metadata.
+package tempo_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/api/tempo"
+	"github.com/tsouza/cerberus/internal/chclienttest"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+func TestResolveMissingRoots_ParseDepthFlatAt1500IDs_ChDB(t *testing.T) {
+	c := chclienttest.NewChDB(t)
+	c.Seed(t, `CREATE TABLE otel_traces (
+    TraceId String,
+    SpanId String,
+    ParentSpanId String,
+    SpanName String,
+    Duration Int64,
+    Timestamp DateTime64(9),
+    ResourceAttributes Map(String, String)
+) ENGINE = MergeTree() ORDER BY (Timestamp);`)
+	// One real trace among the 1500 looked-up IDs: a root span (empty
+	// ParentSpanId) plus a child, 1.5s wall-clock end to end. The other
+	// 1499 IDs have no rows — the lookup legitimately returns nothing
+	// for them and the caller's fallback stays in place.
+	c.Seed(t, `INSERT INTO otel_traces VALUES
+    ('a0000000000000000000000000000001', '1000000000000001', '', 'GET /home', 1000000000, toDateTime64('2026-05-01 10:00:00.000000000', 9), map('service.name', 'frontend')),
+    ('a0000000000000000000000000000001', '1000000000000002', '1000000000000001', 'auth', 500000000, toDateTime64('2026-05-01 10:00:01.000000000', 9), map('service.name', 'auth'));`)
+
+	h := tempo.New(c, schema.DefaultOTelTraces(), "v-test", nil)
+
+	const seededTraceID = "a0000000000000000000000000000001"
+	missing := make([]string, 0, 1500)
+	missing = append(missing, seededTraceID)
+	for i := 1; i < 1500; i++ {
+		missing = append(missing, fmt.Sprintf("b%031x", i))
+	}
+	summaries := []tempo.TraceSummary{{
+		TraceID:         seededTraceID,
+		RootServiceName: "fallback-svc",
+		RootTraceName:   "fallback-name",
+		DurationMs:      1,
+	}}
+
+	// Pre-fix this returned the CH parse error (code 306) once
+	// len(missing) pushed the OR-chain past max_parser_depth.
+	if err := h.ResolveMissingRoots(context.Background(), summaries, missing); err != nil {
+		t.Fatalf("ResolveMissingRoots with %d IDs: %v", len(missing), err)
+	}
+
+	if summaries[0].RootTraceName != "GET /home" || summaries[0].RootServiceName != "frontend" {
+		t.Errorf("root metadata = (%q, %q), want (frontend root recovered): (\"GET /home\", \"frontend\")",
+			summaries[0].RootTraceName, summaries[0].RootServiceName)
+	}
+	// Trace-wide wall clock: child starts 1s after the root and runs
+	// 0.5s — max(ts+dur) - min(ts) = 1.5s.
+	if summaries[0].DurationMs != 1500 {
+		t.Errorf("DurationMs = %d, want 1500 (trace-wide wall-clock span)", summaries[0].DurationMs)
+	}
+}

--- a/internal/api/tempo/root_lookup_test.go
+++ b/internal/api/tempo/root_lookup_test.go
@@ -2,6 +2,7 @@ package tempo
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -138,7 +139,7 @@ func TestBuildRootLookupPlan_SQLShape(t *testing.T) {
 		}
 	}
 
-	// Empty parent-span-id literal must appear so the OR-chain matches
+	// Empty parent-span-id literal must appear so the IN list matches
 	// the OTel-CH on-disk empty form (hex.EncodeToString(nil) → "").
 	var sawEmptyParent bool
 	for _, a := range args {
@@ -150,7 +151,7 @@ func TestBuildRootLookupPlan_SQLShape(t *testing.T) {
 	if !sawEmptyParent {
 		t.Errorf("expected empty-string ParentSpanId literal in args; got %v", args)
 	}
-	// 16-char zero form must appear so the OR-chain also matches
+	// 16-char zero form must appear so the IN list also matches
 	// producers that store the canonical hex-encoded all-zero shape.
 	var sawZeroParent bool
 	for _, a := range args {
@@ -161,6 +162,74 @@ func TestBuildRootLookupPlan_SQLShape(t *testing.T) {
 	}
 	if !sawZeroParent {
 		t.Errorf("expected 16-char-zero ParentSpanId literal in args; got %v", args)
+	}
+}
+
+// TestBuildRootLookupPlan_FlatParseDepth pins the O(1)-parse-depth
+// IN-list shape of the trace-ID filter. The pre-fix shape rendered a
+// nested OR-chain of equality predicates — one ClickHouse AST level
+// per trace ID — and blew `max_parser_depth` (default 1000, error
+// code 306) once a search returned >1000 traces needing root
+// enrichment (compose-smoke run 27307036248: "Maximum parse depth
+// (1000) exceeded", missing=1006), silently dropping the root
+// decoration from the response.
+//
+// Parenthesis nesting in the emitted SQL is a faithful proxy for CH
+// parse depth here (every OR-chain level emitted a paren pair), so the
+// regression contract is: the maximum paren depth at N=2000 IDs must
+// equal the depth at N=2 — i.e. depth must not scale with ID count.
+func TestBuildRootLookupPlan_FlatParseDepth(t *testing.T) {
+	t.Parallel()
+
+	depthFor := func(n int) int {
+		t.Helper()
+		ids := make([]string, 0, n)
+		for i := range n {
+			// Distinct, full-width hex IDs (no leading-zero stripping
+			// ambiguity) so each contributes one IN element.
+			ids = append(ids, fmt.Sprintf("%032x", i+1))
+		}
+		plan := buildRootLookupPlan(schema.DefaultOTelTraces(), ids)
+		sql, args, err := chsql.Emit(context.Background(), plan)
+		if err != nil {
+			t.Fatalf("Emit with %d IDs: %v", n, err)
+		}
+		if len(args) < n {
+			t.Fatalf("expected >= %d bound args (one per trace ID), got %d", n, len(args))
+		}
+		depth, maxDepth := 0, 0
+		for _, c := range sql {
+			switch c {
+			case '(':
+				depth++
+				if depth > maxDepth {
+					maxDepth = depth
+				}
+			case ')':
+				depth--
+			}
+		}
+		return maxDepth
+	}
+
+	d2 := depthFor(2)
+	d2000 := depthFor(2000)
+	if d2000 != d2 {
+		t.Errorf("paren depth scales with trace-ID count: depth(N=2000)=%d, depth(N=2)=%d — the trace filter must stay a flat IN list", d2000, d2)
+	}
+
+	// The trace filter must render as a single flat IN over the
+	// TraceId column, not an OR-chain.
+	plan := buildRootLookupPlan(schema.DefaultOTelTraces(), []string{"17", "abc"})
+	sql, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if !strings.Contains(sql, "`TraceId` IN (") {
+		t.Errorf("expected flat `TraceId IN (...)` filter; got %s", sql)
+	}
+	if strings.Contains(sql, " OR ") {
+		t.Errorf("expected no OR-chain anywhere in the lookup SQL; got %s", sql)
 	}
 }
 

--- a/internal/chplan/in_list.go
+++ b/internal/chplan/in_list.go
@@ -1,0 +1,45 @@
+package chplan
+
+// InList is a flat membership test: `<Left> IN (<List[0]>, <List[1]>, ...)`.
+//
+// The flat shape is load-bearing, not cosmetic. An equivalent nested
+// OR-chain of equality Binary nodes grows ClickHouse's parser AST
+// depth linearly with the element count, and CH rejects queries past
+// `max_parser_depth` (default 1000) with code 306 ("Maximum parse
+// depth exceeded"). The /api/search root-span lookup hit exactly that
+// when a search returned >1000 traces needing root enrichment. An IN
+// tuple parses at constant depth regardless of List length, so plans
+// built from caller-controlled collections (trace-ID sets, label
+// allow-sets) must use InList instead of an OR-chain.
+//
+// The emitter renders each List element positionally inside a single
+// parenthesised tuple; literal elements ride the usual `?` bound-arg
+// path. List must be non-empty — CH rejects an empty IN list with
+// "Function 'in' is supported only if the second argument is non-empty"
+// — and the emitter surfaces ErrUnsupported for it; callers expressing
+// "match nothing" should emit a constant-false predicate instead.
+type InList struct {
+	Left Expr
+	List []Expr
+}
+
+func (*InList) exprNode() {}
+
+func (i *InList) Equal(other Expr) bool {
+	o, ok := other.(*InList)
+	if !ok || len(i.List) != len(o.List) {
+		return false
+	}
+	if (i.Left == nil) != (o.Left == nil) {
+		return false
+	}
+	if i.Left != nil && !i.Left.Equal(o.Left) {
+		return false
+	}
+	for k := range i.List {
+		if !i.List[k].Equal(o.List[k]) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/chplan/in_list_test.go
+++ b/internal/chplan/in_list_test.go
@@ -1,0 +1,61 @@
+package chplan_test
+
+import (
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// Equal-invariant coverage for chplan.InList, mirroring the
+// positive/negative pattern in equal_invariants_test.go: structurally
+// identical values compare Equal; values differing in exactly one
+// load-bearing field do not, symmetrically.
+
+func inListFixture() *chplan.InList {
+	return &chplan.InList{
+		Left: &chplan.ColumnRef{Name: "TraceId"},
+		List: []chplan.Expr{
+			&chplan.LitString{V: "a"},
+			&chplan.LitString{V: "b"},
+		},
+	}
+}
+
+func TestInList_Equal_Positive(t *testing.T) {
+	t.Parallel()
+	a, b := inListFixture(), inListFixture()
+	if !a.Equal(b) || !b.Equal(a) {
+		t.Errorf("structurally identical InList values must compare Equal (both directions)")
+	}
+}
+
+func TestInList_Equal_Negative(t *testing.T) {
+	t.Parallel()
+	cases := map[string]chplan.Expr{
+		"different left": &chplan.InList{
+			Left: &chplan.ColumnRef{Name: "SpanId"},
+			List: []chplan.Expr{&chplan.LitString{V: "a"}, &chplan.LitString{V: "b"}},
+		},
+		"nil left": &chplan.InList{
+			List: []chplan.Expr{&chplan.LitString{V: "a"}, &chplan.LitString{V: "b"}},
+		},
+		"different list element": &chplan.InList{
+			Left: &chplan.ColumnRef{Name: "TraceId"},
+			List: []chplan.Expr{&chplan.LitString{V: "a"}, &chplan.LitString{V: "z"}},
+		},
+		"different list length": &chplan.InList{
+			Left: &chplan.ColumnRef{Name: "TraceId"},
+			List: []chplan.Expr{&chplan.LitString{V: "a"}},
+		},
+		"other type": &chplan.LitString{V: "a"},
+	}
+	base := inListFixture()
+	for name, other := range cases {
+		if base.Equal(other) {
+			t.Errorf("%s: Equal must be false", name)
+		}
+		if other.Equal(base) {
+			t.Errorf("%s: Equal must be false symmetrically", name)
+		}
+	}
+}

--- a/internal/chplan/metrics_histogram_over_time.go
+++ b/internal/chplan/metrics_histogram_over_time.go
@@ -12,10 +12,11 @@ package chplan
 //
 // Bucketing follows Tempo's runtime semantics (pkg/traceql/ast_metrics.go,
 // `bucketizeFnFor`): each span's <attr> is rounded up to the nearest
-// power of two and that log2-bucket key becomes an extra group-by
-// column alongside the user-supplied GroupBy. Durations are emitted in
+// power of two (`Log2Bucketize(v)` = `2^ceil(log2(v))` for v >= 2) and
+// that power-of-two bucket key becomes an extra group-by column
+// alongside the user-supplied GroupBy. Durations are emitted in
 // seconds (matches Tempo's `Log2Bucketize(d) / float64(time.Second)`);
-// other numeric attributes carry the raw `log2(ceil(v))` value.
+// other numeric attributes carry the raw `Log2Bucketize(v)` value.
 // Spans with <attr> < 2 are dropped (Tempo's bucketizeDuration /
 // bucketizeAttribute return `NewStaticNil()` for that range).
 //
@@ -31,10 +32,11 @@ package chplan
 //   - Attr: the operand expression (the lowered `duration` /
 //     `span.<attr>` / `resource.<attr>` reference). Required.
 //   - IsDuration: when true, the emitter renders the bucket key as
-//     log2(<attr>) / 1e9 so the bucket label reads in seconds (matches
-//     Tempo's bucketizeDuration); when false, the bucket key is the
-//     bare log2(<attr>) (matches Tempo's bucketizeAttribute on int /
-//     duration cases — duration attrs encode as nanos already).
+//     pow(2, ceil(log2(toFloat64(<attr>)))) / 1e9 so the bucket label
+//     reads in seconds (matches Tempo's bucketizeDuration); when false,
+//     the bucket key is the raw pow(2, ceil(log2(toFloat64(<attr>))))
+//     (matches Tempo's bucketizeAttribute on int / duration cases —
+//     duration attrs encode as nanos already).
 //   - GroupBy: the user-supplied `by(...)` label expressions; parallel
 //     to GroupByAliases for SELECT-list aliasing.
 //   - GroupByAliases: SQL SELECT-list alias for each GroupBy entry.

--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -320,6 +320,8 @@ func (b *Builder) Expr(x chplan.Expr) error {
 		return nil
 	case *chplan.Binary:
 		return b.exprBinary(v)
+	case *chplan.InList:
+		return b.exprInList(v)
 	case *chplan.FuncCall:
 		return b.exprFunc(v)
 	case *chplan.MapAccess:
@@ -492,6 +494,46 @@ func (b *Builder) exprBinary(bx *chplan.Binary) error {
 		return err
 	}
 	b.sb.WriteByte(')')
+	return nil
+}
+
+// exprInList renders chplan.InList as `(<left> IN (<e0>, <e1>, ...))`
+// — a single flat tuple membership test. The flatness is the point:
+// the equivalent nested OR-chain of equality Binary nodes deepens
+// ClickHouse's parser AST by one level per element and trips
+// `max_parser_depth` (default 1000, error code 306) around 1000
+// elements — the /api/search root-span lookup hit exactly that on
+// >1000-trace result sets. The IN tuple's elements are siblings in
+// the AST, so parse depth stays constant no matter how long List is.
+//
+// Literal elements ride the usual positional `?` bound-arg path via
+// b.Expr. The outer parens keep the rendered fragment self-delimiting
+// when composed into a larger predicate (same posture as exprBinary's
+// default arm).
+func (b *Builder) exprInList(v *chplan.InList) error {
+	if v.Left == nil {
+		return fmt.Errorf("%w: chplan.InList requires a left operand", ErrUnsupported)
+	}
+	if len(v.List) == 0 {
+		// CH rejects `x IN ()` with "Function 'in' is supported only if
+		// the second argument is non-empty"; surface the misuse here
+		// rather than shipping unparseable SQL.
+		return fmt.Errorf("%w: chplan.InList requires a non-empty list", ErrUnsupported)
+	}
+	b.sb.WriteByte('(')
+	if err := b.Expr(v.Left); err != nil {
+		return err
+	}
+	b.sb.WriteString(" IN (")
+	for i, e := range v.List {
+		if i > 0 {
+			b.sb.WriteString(", ")
+		}
+		if err := b.Expr(e); err != nil {
+			return err
+		}
+	}
+	b.sb.WriteString("))")
 	return nil
 }
 

--- a/internal/chsql/histogram_over_time.go
+++ b/internal/chsql/histogram_over_time.go
@@ -12,16 +12,18 @@ import (
 // the SELECT-list and the GROUP BY:
 //
 //	SELECT [<group cols>,]
-//	       log2(<attr>) [/ 1e9] AS `__bucket`,
+//	       pow(2, ceil(log2(toFloat64(<attr>)))) [/ 1e9] AS `__bucket`,
 //	       count(1) AS `Value`
 //	FROM (<Inner>)
 //	WHERE <attr> >= 2
 //	GROUP BY [<group cols>,] `__bucket`
 //
 // Bucketing follows Tempo's `bucketizeFnFor` (pkg/traceql/ast_metrics.go):
-// each row contributes 1 to a bucket keyed by `log2(ceil(<attr>))`.
-// When IsDuration is true the attribute is in nanoseconds and the
-// bucket key is divided by 1e9 so the label reads in seconds — matching
+// each row contributes 1 to a bucket keyed by `Log2Bucketize(<attr>)` —
+// the value rounded UP to the next power of two (engine_metrics.go's
+// `Log2Bucketize`, equivalent to `2^ceil(log2(v))` for v >= 2). When
+// IsDuration is true the attribute is in nanoseconds and the bucket
+// key is divided by 1e9 so the label reads in seconds — matching
 // `bucketizeDuration`'s `Log2Bucketize(d) / float64(time.Second)`.
 //
 // Spans with <attr> < 2 are dropped (bucketizeDuration /
@@ -102,10 +104,25 @@ func (e *emitter) emitMetricsHistogramOverTime(m *chplan.MetricsHistogramOverTim
 	return nil
 }
 
-// histogramBucketFrag renders the `log2(<attr>) [/ 1e9]` bucket-key
-// expression. The `/ 1e9` divisor applies only when isDuration is true
-// (the attribute carries nanoseconds and the bucket label should read
-// in seconds, matching Tempo's bucketizeDuration).
+// histogramBucketFrag renders the
+// `pow(2, ceil(log2(toFloat64(<attr>)))) [/ 1e9]` bucket-key
+// expression — the value rounded UP to the next power of two, exactly
+// Tempo's `Log2Bucketize` (pkg/traceql/engine_metrics.go: for v >= 2,
+// `1 << (64 - bits.LeadingZeros64(v-1))` == `2^ceil(log2(v))`; exact
+// powers of two map to themselves under both forms because IEEE log2
+// of an exact power of two is exact). The `/ 1e9` divisor applies only
+// when isDuration is true (the attribute carries nanoseconds and the
+// bucket label must read in seconds, matching bucketizeDuration's
+// `Log2Bucketize(d) / float64(time.Second)`).
+//
+// The pre-fix shape emitted the bare exponent (`log2(<attr>)`, and for
+// durations `log2(<attr>) / 1e9` — the exponent itself divided by 1e9)
+// instead of the power-of-two value, so a 1.024µs span surfaced bucket
+// ~1e-08 where reference Tempo reports 1.024e-06 seconds. Mirrors
+// quantileBucketFrag (internal/chsql/range_window.go), which always
+// carried the correct pow/ceil form; the operand differs (raw column
+// expression here vs the seconds-rebased `metric_arg` alias there) so
+// no `* 1e9` recovery multiply appears in this frag.
 //
 // The divisor is rendered as the literal `1000000000` rather than a
 // bound argument: it's part of the query shape, not user data, and the
@@ -113,7 +130,9 @@ func (e *emitter) emitMetricsHistogramOverTime(m *chplan.MetricsHistogramOverTim
 func histogramBucketFrag(attr chplan.Expr, isDuration bool) Frag {
 	attrFrag := func(b *Builder) { _ = b.Expr(attr) }
 	return func(b *Builder) {
-		Call("log2", attrFrag)(b)
+		b.sb.WriteString("pow(2, ceil(log2(toFloat64(")
+		attrFrag(b)
+		b.sb.WriteString("))))")
 		if isDuration {
 			// "/ 1e9" — inline divisor (query-shape constant, not user
 			// data); appended via direct write because the surrounding
@@ -129,36 +148,56 @@ func histogramBucketFrag(attr chplan.Expr, isDuration bool) Frag {
 //
 // Each per-span row is fanned across only the anchors whose window
 // contains its timestamp (sample-side fanout, ≤ range/step + 1 anchors
-// per row — see sampleAnchorFanoutFrag; the previous shape fanned
-// every row across the full N-anchor grid and re-filtered per
-// (row, anchor) in an outer WHERE); the outer SELECT groups by
-// (<user group-by>, bucket, anchor_ts) and applies `count(1)` per
-// bucket. SQL skeleton (N = (End-Start)/Step + 1 or OuterRange/Step + 1):
+// per row — see sampleAnchorFanoutFrag); a UNION ALL generator arm
+// pins one zero row per (observed series, grid anchor); the outer
+// SELECT groups by (<user group-by>, bucket, anchor_ts) and reduces
+// `sum(in_window)` per bucket. SQL skeleton (N = (End-Start)/Step + 1
+// or OuterRange/Step + 1):
 //
-//	SELECT [<group cols>,] `__bucket`, anchor_ts, count(1) AS `Value`
+//	SELECT [<group cols>,] `__bucket`, anchor_ts, toFloat64(sum(in_window)) AS `Value`
 //	FROM (
-//	  SELECT [<group cols>,]
-//	         log2(<Attr>) [/ 1e9] AS `__bucket`,
-//	         arrayJoin(arrayMap(i -> <anchor_base> - toIntervalNanosecond(i * <step_ns>),
-//	                   range(<covered-anchor index bounds>))) AS anchor_ts
-//	  FROM (<Inner>)
-//	  WHERE <Attr> >= 2
+//	  (SELECT [<group cols>,]
+//	          pow(2, ceil(log2(toFloat64(<Attr>)))) [/ 1e9] AS `__bucket`,
+//	          arrayJoin(arrayMap(i -> <anchor_base> - toIntervalNanosecond(i * <step_ns>),
+//	                    range(<covered-anchor index bounds>))) AS anchor_ts,
+//	          1 AS in_window
+//	   FROM (<Inner>)
+//	   WHERE <Attr> >= 2)
+//	  UNION ALL
+//	  (SELECT [<group cols>,] `__bucket`,
+//	          arrayJoin(arrayMap(i -> ..., range(0, <N>))) AS anchor_ts,
+//	          0 AS in_window
+//	   FROM (SELECT [<group cols>,] <bucket expr> AS `__bucket`
+//	         FROM (<Inner>) WHERE <Attr> >= 2
+//	         GROUP BY [<group cols>,] `__bucket`))
 //	)
 //	GROUP BY [<group cols>,] `__bucket`, anchor_ts
 //
-// The bucket column is computed in the inner SELECT (alongside the
+// The bucket column is computed in the inner SELECTs (alongside the
 // arrayJoined anchors) so the outer GROUP BY can reference it
-// by alias without recomputing the log2.
+// by alias without recomputing the bucketize expression.
 //
 // The per-anchor window is left-open / right-closed
 // (`(anchor_ts - range, anchor_ts]`) — encoded by the sample-side
 // index bounds (strict floor+1 lower / inclusive floor upper; see
 // sampleAnchorFanoutFrag) — same bucket semantics as the
 // non-histogram metrics emitter (emitRangeWindowMetrics) and Tempo
-// upstream's `IntervalMapperQueryRange`. Anchors with no in-window
-// rows emit no (group, bucket, anchor) row, exactly as the previous
-// WHERE-filtered shape (histogram zero-fill, when needed, lives in
-// the handler's HistogramAggregator post-pass, not the SQL).
+// upstream's `IntervalMapperQueryRange`.
+//
+// Zero-fill: upstream histogram_over_time runs on
+// NewCountOverTimeAggregator (ast_metrics.go init switch), whose
+// per-interval counts start at zero, and SeriesSet.ToProto skips only
+// NaN values — so every (group, __bucket) series Tempo observes
+// anywhere in the window reaches the wire DENSE, carrying a 0 sample
+// at every grid anchor with no in-window spans. Same wire posture as
+// count_over_time / rate (see metricsOpZeroFillsEmptyBuckets). The
+// generator arm discovers the distinct (group, __bucket) series from
+// the same bounded scan the sample arm reads and fans each across the
+// full anchor grid with `0 AS in_window`, so the outer
+// `sum(in_window)` pins empty anchors at 0 instead of dropping the
+// row. A fully-empty scan yields no discovered series and therefore
+// no output rows — matching Tempo, which emits no series at all in
+// that case.
 func (e *emitter) emitRangeWindowHistogram(r *chplan.RangeWindow, m *chplan.MetricsHistogramOverTime) error {
 	if r.TimestampColumn == "" {
 		return fmt.Errorf("%w: RangeWindow.TimestampColumn unset (required for MetricsHistogramOverTime input)", ErrUnsupported)
@@ -219,8 +258,8 @@ func (e *emitter) emitRangeWindowHistogram(r *chplan.RangeWindow, m *chplan.Metr
 		valueAlias = "Value"
 	}
 
-	// Inner SELECT: group-by cols, bucket, attr filter, sample-side
-	// anchor fanout.
+	// Sample arm: group-by cols, bucket, attr filter, sample-side
+	// anchor fanout, `1 AS in_window` marker.
 	groupAliases := outerGroupAliases(m.GroupBy, m.GroupByAliases)
 	innerSb := NewQuery().From(inner)
 	for i, g := range m.GroupBy {
@@ -234,28 +273,63 @@ func (e *emitter) emitRangeWindowHistogram(r *chplan.RangeWindow, m *chplan.Metr
 		sampleAnchorFanoutFrag(end, func(b *Builder) { b.Ident(tsCol) }, stepNS, rangeNS, numAnchors),
 		"anchor_ts",
 	)
+	innerSb.SelectAs(InlineLit(int64(1)), "in_window")
 	// Push the <attr> >= 2 filter into the inner SELECT so the anchor
 	// fanout doesn't multiply work for rows that drop anyway.
 	attrExpr := m.Attr
-	innerSb.Where(func(b *Builder) {
+	attrGuard := func(b *Builder) {
 		_ = b.Expr(attrExpr)
 		b.sb.WriteString(" >= 2")
-	})
+	}
+	innerSb.Where(attrGuard)
+	// Same Start/End scan-bound pushdown as the non-histogram metrics
+	// emitter — see maybePushInnerScanTimeBounds.
+	maybePushInnerScanTimeBounds(innerSb, r, tsCol, rangeNS)
 
-	// Outer SELECT: group-by + bucket + anchor_ts; count(1) per bucket.
-	outerSb := NewQuery().From(innerSb.Frag())
+	// Generator arm: one `0 AS in_window` row per (observed (group,
+	// __bucket) series, grid anchor). Series discovery replays the
+	// same bounded scan + bucketize the sample arm reads, GROUPed by
+	// (group aliases…, __bucket) so each observed series fans across
+	// the full grid exactly once.
+	disc := NewQuery().From(inner)
+	for i, g := range m.GroupBy {
+		expr := g
+		alias := groupAliases[i]
+		disc.SelectAs(func(b *Builder) { _ = b.Expr(expr) }, alias)
+	}
+	disc.SelectAs(histogramBucketFrag(m.Attr, m.IsDuration), bucketAlias)
+	disc.Where(attrGuard)
+	maybePushInnerScanTimeBounds(disc, r, tsCol, rangeNS)
+	discKeys := make([]Frag, 0, len(groupAliases)+1)
+	for _, alias := range groupAliases {
+		a := alias
+		discKeys = append(discKeys, func(b *Builder) { b.Ident(a) })
+	}
+	discKeys = append(discKeys, Col(bucketAlias))
+	disc.GroupBy(discKeys...)
+
+	grid := NewQuery().From(disc.Frag())
+	for _, alias := range groupAliases {
+		a := alias
+		grid.Select(func(b *Builder) { b.Ident(a) })
+	}
+	grid.Select(Col(bucketAlias))
+	grid.SelectAs(anchorFanoutFrag(end, stepNS, numAnchors), "anchor_ts")
+	grid.SelectAs(InlineLit(int64(0)), "in_window")
+
+	// Outer SELECT: group-by + bucket + anchor_ts; sum(in_window) per
+	// (series, anchor) — sample-arm rows contribute 1 each, generator
+	// rows pin empty anchors at 0.
+	outerSb := NewQuery().From(Paren(UnionAll(innerSb.Frag(), grid.Frag())))
 	for _, alias := range groupAliases {
 		a := alias
 		outerSb.Select(func(b *Builder) { b.Ident(a) })
 	}
 	outerSb.Select(Col(bucketAlias))
 	outerSb.Select(Col("anchor_ts"))
-	countFunc := chplan.AggFunc{
-		Name:  "count",
-		Args:  []chplan.Expr{&chplan.LitInt{V: 1}},
-		Alias: valueAlias,
-	}
-	outerSb.Select(aggFuncFrag(countFunc))
+	outerSb.SelectAs(func(b *Builder) {
+		b.sb.WriteString("toFloat64(sum(in_window))")
+	}, valueAlias)
 
 	// GROUP BY group aliases + bucket + anchor_ts.
 	groupFrags := make([]Frag, 0, len(groupAliases)+2)

--- a/internal/chsql/histogram_over_time.go
+++ b/internal/chsql/histogram_over_time.go
@@ -286,41 +286,23 @@ func (e *emitter) emitRangeWindowHistogram(r *chplan.RangeWindow, m *chplan.Metr
 	// emitter — see maybePushInnerScanTimeBounds.
 	maybePushInnerScanTimeBounds(innerSb, r, tsCol, rangeNS)
 
-	// Generator arm: one `0 AS in_window` row per (observed (group,
-	// __bucket) series, grid anchor). Series discovery replays the
-	// same bounded scan + bucketize the sample arm reads, GROUPed by
-	// (group aliases…, __bucket) so each observed series fans across
-	// the full grid exactly once.
-	disc := NewQuery().From(inner)
-	for i, g := range m.GroupBy {
-		expr := g
-		alias := groupAliases[i]
-		disc.SelectAs(func(b *Builder) { _ = b.Expr(expr) }, alias)
-	}
-	disc.SelectAs(histogramBucketFrag(m.Attr, m.IsDuration), bucketAlias)
-	disc.Where(attrGuard)
-	maybePushInnerScanTimeBounds(disc, r, tsCol, rangeNS)
-	discKeys := make([]Frag, 0, len(groupAliases)+1)
-	for _, alias := range groupAliases {
-		a := alias
-		discKeys = append(discKeys, func(b *Builder) { b.Ident(a) })
-	}
-	discKeys = append(discKeys, Col(bucketAlias))
-	disc.GroupBy(discKeys...)
-
-	grid := NewQuery().From(disc.Frag())
-	for _, alias := range groupAliases {
-		a := alias
-		grid.Select(func(b *Builder) { b.Ident(a) })
-	}
-	grid.Select(Col(bucketAlias))
-	grid.SelectAs(anchorFanoutFrag(end, stepNS, numAnchors), "anchor_ts")
-	grid.SelectAs(InlineLit(int64(0)), "in_window")
+	grid := histogramZeroFillGridArm(histogramZeroFillArgs{
+		inner:        inner,
+		r:            r,
+		m:            m,
+		groupAliases: groupAliases,
+		bucketAlias:  bucketAlias,
+		attrGuard:    attrGuard,
+		end:          end,
+		stepNS:       stepNS,
+		rangeNS:      rangeNS,
+		numAnchors:   numAnchors,
+	})
 
 	// Outer SELECT: group-by + bucket + anchor_ts; sum(in_window) per
 	// (series, anchor) — sample-arm rows contribute 1 each, generator
 	// rows pin empty anchors at 0.
-	outerSb := NewQuery().From(Paren(UnionAll(innerSb.Frag(), grid.Frag())))
+	outerSb := NewQuery().From(Paren(UnionAll(innerSb.Frag(), grid)))
 	for _, alias := range groupAliases {
 		a := alias
 		outerSb.Select(func(b *Builder) { b.Ident(a) })
@@ -342,4 +324,59 @@ func (e *emitter) emitRangeWindowHistogram(r *chplan.RangeWindow, m *chplan.Metr
 
 	e.emitSelect(outerSb)
 	return nil
+}
+
+// histogramZeroFillArgs bundles the inputs histogramZeroFillGridArm
+// shares with emitRangeWindowHistogram's sample arm — the bounded
+// inner scan, the grid geometry, and the per-row bucket/guard frags.
+type histogramZeroFillArgs struct {
+	inner        Frag
+	r            *chplan.RangeWindow
+	m            *chplan.MetricsHistogramOverTime
+	groupAliases []string
+	bucketAlias  string
+	attrGuard    Frag
+	end          Frag
+	stepNS       int64
+	rangeNS      int64
+	numAnchors   int64
+}
+
+// histogramZeroFillGridArm builds the generator arm of the histogram
+// matrix path's zero-fill UNION ALL: one `0 AS in_window` row per
+// (observed (group, __bucket) series, grid anchor). Series discovery
+// replays the same bounded scan + bucketize expression the sample arm
+// reads, GROUPed by (group aliases…, __bucket) so each observed series
+// fans across the full grid exactly once. The histogram counterpart of
+// metricsZeroFillGridArm (range_window.go) — separate because the
+// series identity here includes the synthesised bucket column, which
+// the discovery query must compute rather than carry as a constant
+// extra column.
+func histogramZeroFillGridArm(a histogramZeroFillArgs) Frag {
+	disc := NewQuery().From(a.inner)
+	for i, g := range a.m.GroupBy {
+		expr := g
+		alias := a.groupAliases[i]
+		disc.SelectAs(func(b *Builder) { _ = b.Expr(expr) }, alias)
+	}
+	disc.SelectAs(histogramBucketFrag(a.m.Attr, a.m.IsDuration), a.bucketAlias)
+	disc.Where(a.attrGuard)
+	maybePushInnerScanTimeBounds(disc, a.r, a.r.TimestampColumn, a.rangeNS)
+	discKeys := make([]Frag, 0, len(a.groupAliases)+1)
+	for _, alias := range a.groupAliases {
+		al := alias
+		discKeys = append(discKeys, func(b *Builder) { b.Ident(al) })
+	}
+	discKeys = append(discKeys, Col(a.bucketAlias))
+	disc.GroupBy(discKeys...)
+
+	grid := NewQuery().From(disc.Frag())
+	for _, alias := range a.groupAliases {
+		al := alias
+		grid.Select(func(b *Builder) { b.Ident(al) })
+	}
+	grid.Select(Col(a.bucketAlias))
+	grid.SelectAs(anchorFanoutFrag(a.end, a.stepNS, a.numAnchors), "anchor_ts")
+	grid.SelectAs(InlineLit(int64(0)), "in_window")
+	return grid.Frag()
 }

--- a/internal/chsql/histogram_over_time_test.go
+++ b/internal/chsql/histogram_over_time_test.go
@@ -31,9 +31,10 @@ func TestEmitMetricsHistogramOverTimeBare(t *testing.T) {
 		t.Fatalf("Emit: %v", err)
 	}
 
-	// Bucket key: log2(Duration) / 1e9 for the duration intrinsic.
-	if !strings.Contains(sql, "log2(`Duration`) / 1000000000 AS `__bucket`") {
-		t.Errorf("expected `log2(Duration) / 1e9 AS __bucket`, SQL=%s", sql)
+	// Bucket key: the next power of two (Tempo's Log2Bucketize), divided
+	// by 1e9 for the duration intrinsic so the label reads in seconds.
+	if !strings.Contains(sql, "pow(2, ceil(log2(toFloat64(`Duration`)))) / 1000000000 AS `__bucket`") {
+		t.Errorf("expected `pow(2, ceil(log2(toFloat64(Duration)))) / 1e9 AS __bucket`, SQL=%s", sql)
 	}
 	// count(1) AS Value reducer (wrapped in toFloat64 so the column
 	// scans into chclient.Sample.Value's *float64 — clickhouse-go/v2
@@ -60,7 +61,10 @@ func TestEmitMetricsHistogramOverTimeBare(t *testing.T) {
 }
 
 // TestEmitMetricsHistogramOverTimeNonDuration confirms the bucket key
-// for non-duration attributes is the bare log2(<attr>) (no / 1e9).
+// for non-duration attributes is the raw next-power-of-two
+// `pow(2, ceil(log2(toFloat64(<attr>))))` (no / 1e9) — Tempo's
+// bucketizeAttribute TypeInt arm applies Log2Bucketize without the
+// seconds rebase.
 func TestEmitMetricsHistogramOverTimeNonDuration(t *testing.T) {
 	t.Parallel()
 
@@ -76,8 +80,8 @@ func TestEmitMetricsHistogramOverTimeNonDuration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Emit: %v", err)
 	}
-	if !strings.Contains(sql, "log2(`BodySize`) AS `__bucket`") {
-		t.Errorf("expected `log2(BodySize) AS __bucket` (no /1e9), SQL=%s", sql)
+	if !strings.Contains(sql, "pow(2, ceil(log2(toFloat64(`BodySize`)))) AS `__bucket`") {
+		t.Errorf("expected `pow(2, ceil(log2(toFloat64(BodySize)))) AS __bucket` (no /1e9), SQL=%s", sql)
 	}
 	if strings.Contains(sql, "/ 1000000000") {
 		t.Errorf("expected no /1e9 divisor for non-duration attr, SQL=%s", sql)
@@ -114,7 +118,11 @@ func TestEmitMetricsHistogramOverTimeByLabel(t *testing.T) {
 // TestEmitRangeWindowHistogramMatrix exercises the matrix-shape path
 // (RangeWindow wrapping MetricsHistogramOverTime). Confirms the
 // sample-side arrayJoin anchor fanout, the bucket column threading
-// into the outer GROUP BY, and the per-anchor count(1) reducer.
+// into the outer GROUP BY, and the zero-fill UNION ALL +
+// sum(in_window) reducer that pins a 0 sample at every grid anchor of
+// every observed (group, __bucket) series — upstream histogram series
+// ride NewCountOverTimeAggregator, whose counts reach the wire dense
+// (SeriesSet.ToProto skips only NaN, never 0).
 func TestEmitRangeWindowHistogramMatrix(t *testing.T) {
 	t.Parallel()
 
@@ -146,12 +154,26 @@ func TestEmitRangeWindowHistogramMatrix(t *testing.T) {
 	if !strings.Contains(sql, "least(6, intDiv(dateDiff('nanosecond', `Timestamp`, ") {
 		t.Errorf("expected sample-side anchor bound least(6, ...), SQL=%s", sql)
 	}
-	if !strings.Contains(sql, "log2(`Duration`) / 1000000000 AS `__bucket`") {
+	if !strings.Contains(sql, "pow(2, ceil(log2(toFloat64(`Duration`)))) / 1000000000 AS `__bucket`") {
 		t.Errorf("expected bucket key in inner SELECT, SQL=%s", sql)
 	}
-	// count(1) reducer wrapped in toFloat64 — see the bare-emission test.
-	if !strings.Contains(sql, "toFloat64(count(?)) AS `Value`") {
-		t.Errorf("expected toFloat64(count(1)) reducer in outer SELECT, SQL=%s", sql)
+	// Zero-fill: sum(in_window) reducer over a UNION ALL of the sample
+	// arm (in_window = 1) and the per-(series, anchor) generator arm
+	// (in_window = 0), so empty grid anchors surface as 0 samples
+	// instead of dropping — matching Tempo's dense count-based
+	// histogram series.
+	if !strings.Contains(sql, "toFloat64(sum(in_window)) AS `Value`") {
+		t.Errorf("expected toFloat64(sum(in_window)) reducer in outer SELECT, SQL=%s", sql)
+	}
+	if !strings.Contains(sql, "UNION ALL") {
+		t.Errorf("expected zero-fill UNION ALL generator arm, SQL=%s", sql)
+	}
+	if !strings.Contains(sql, "1 AS `in_window`") || !strings.Contains(sql, "0 AS `in_window`") {
+		t.Errorf("expected in_window markers on both arms, SQL=%s", sql)
+	}
+	// The generator arm discovers observed series GROUPed by bucket.
+	if !strings.Contains(sql, "GROUP BY `__bucket`)") {
+		t.Errorf("expected per-bucket series discovery in the generator arm, SQL=%s", sql)
 	}
 	// Outer GROUP BY includes both bucket and anchor.
 	if !strings.Contains(sql, "GROUP BY `__bucket`, `anchor_ts`") {

--- a/internal/chsql/in_list_test.go
+++ b/internal/chsql/in_list_test.go
@@ -1,0 +1,99 @@
+package chsql
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// TestExprInList_Flat pins the rendered shape: a single parenthesised
+// `IN` tuple with one positional placeholder per literal element. The
+// flat tuple is the whole point of chplan.InList — the equivalent
+// OR-chain nests one ClickHouse AST level per element and trips
+// max_parser_depth (default 1000, code 306) around 1000 elements.
+func TestExprInList_Flat(t *testing.T) {
+	t.Parallel()
+
+	b := &Builder{}
+	err := b.Expr(&chplan.InList{
+		Left: &chplan.ColumnRef{Name: "TraceId"},
+		List: []chplan.Expr{
+			&chplan.LitString{V: "a"},
+			&chplan.LitString{V: "b"},
+			&chplan.LitString{V: "c"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Expr: %v", err)
+	}
+	if got, want := b.String(), "(`TraceId` IN (?, ?, ?))"; got != want {
+		t.Errorf("rendered SQL = %q, want %q", got, want)
+	}
+	if got, want := b.Args(), []any{"a", "b", "c"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("bound args = %v, want %v", got, want)
+	}
+}
+
+// TestExprInList_ConstantParenDepth asserts the rendered nesting depth
+// does not scale with the element count — the regression contract the
+// /api/search root-span lookup relies on for >1000-trace result sets.
+func TestExprInList_ConstantParenDepth(t *testing.T) {
+	t.Parallel()
+
+	depthFor := func(n int) int {
+		t.Helper()
+		list := make([]chplan.Expr, 0, n)
+		for i := range n {
+			list = append(list, &chplan.LitInt{V: int64(i)})
+		}
+		b := &Builder{}
+		if err := b.Expr(&chplan.InList{Left: &chplan.ColumnRef{Name: "c"}, List: list}); err != nil {
+			t.Fatalf("Expr with %d elements: %v", n, err)
+		}
+		depth, maxDepth := 0, 0
+		for _, ch := range b.String() {
+			switch ch {
+			case '(':
+				depth++
+				if depth > maxDepth {
+					maxDepth = depth
+				}
+			case ')':
+				depth--
+			}
+		}
+		return maxDepth
+	}
+	if d2, d2000 := depthFor(2), depthFor(2000); d2000 != d2 {
+		t.Errorf("paren depth scales with element count: depth(2000)=%d, depth(2)=%d", d2000, d2)
+	}
+}
+
+// TestExprInList_Errors covers the two misuse shapes the emitter
+// rejects synchronously: a nil left operand and an empty list (CH
+// rejects `x IN ()` at parse time, so shipping it would be a deferred
+// failure).
+func TestExprInList_Errors(t *testing.T) {
+	t.Parallel()
+
+	for name, in := range map[string]*chplan.InList{
+		"nil left":   {List: []chplan.Expr{&chplan.LitInt{V: 1}}},
+		"empty list": {Left: &chplan.ColumnRef{Name: "c"}},
+	} {
+		b := &Builder{}
+		err := b.Expr(in)
+		if err == nil {
+			t.Errorf("%s: expected error, got nil", name)
+			continue
+		}
+		if !errors.Is(err, ErrUnsupported) {
+			t.Errorf("%s: expected ErrUnsupported, got %v", name, err)
+		}
+		if !strings.Contains(err.Error(), "InList") {
+			t.Errorf("%s: error should name InList, got %v", name, err)
+		}
+	}
+}

--- a/internal/chsql/in_list_test.go
+++ b/internal/chsql/in_list_test.go
@@ -74,8 +74,8 @@ func TestExprInList_ConstantParenDepth(t *testing.T) {
 
 // TestExprInList_Errors covers the two misuse shapes the emitter
 // rejects synchronously: a nil left operand and an empty list (CH
-// rejects `x IN ()` at parse time, so shipping it would be a deferred
-// failure).
+// rejects `x IN ()` at parse time, so shipping it would only surface
+// the failure later, at query execution).
 func TestExprInList_Errors(t *testing.T) {
 	t.Parallel()
 

--- a/internal/chsql/prewhere.go
+++ b/internal/chsql/prewhere.go
@@ -35,6 +35,11 @@ func collectColumnRefs(e chplan.Expr) []string {
 		case *chplan.Binary:
 			walk(v.Left)
 			walk(v.Right)
+		case *chplan.InList:
+			walk(v.Left)
+			for _, item := range v.List {
+				walk(item)
+			}
 		case *chplan.FuncCall:
 			for _, a := range v.Args {
 				walk(a)
@@ -88,6 +93,19 @@ func isCheapPredicate(e chplan.Expr) bool {
 		return true
 	case *chplan.Binary:
 		return isCheapPredicate(v.Left) && isCheapPredicate(v.Right)
+	case *chplan.InList:
+		// A flat IN over cheap elements is a constant-set membership
+		// check — CH builds the set once and probes per row; same cost
+		// class as the equivalent OR-chain of equality comparisons.
+		if !isCheapPredicate(v.Left) {
+			return false
+		}
+		for _, item := range v.List {
+			if !isCheapPredicate(item) {
+				return false
+			}
+		}
+		return true
 	case *chplan.MapAccess:
 		return isCheapPredicate(v.Map) && isCheapPredicate(v.Key)
 	case *chplan.LineContent:

--- a/internal/optimizer/projection_pushdown.go
+++ b/internal/optimizer/projection_pushdown.go
@@ -174,6 +174,11 @@ func walkExpr(e chplan.Expr, visit func(chplan.Expr)) {
 	case *chplan.Binary:
 		walkExpr(v.Left, visit)
 		walkExpr(v.Right, visit)
+	case *chplan.InList:
+		walkExpr(v.Left, visit)
+		for _, e := range v.List {
+			walkExpr(e, visit)
+		}
 	case *chplan.FuncCall:
 		for _, a := range v.Args {
 			walkExpr(a, visit)

--- a/internal/traceql/metrics_pipeline.go
+++ b/internal/traceql/metrics_pipeline.go
@@ -71,8 +71,9 @@ func lowerMetricsPipeline(prev chplan.Node, mp traceql.FirstStageElement, s sche
 // scalar, so it warrants a distinct IR shape from the scalar
 // MetricsAggregate. Bucketing mirrors Tempo's bucketizeFnFor: each
 // span's <attr> is rounded up to the nearest power of two
-// (log2(ceil(v))); durations additionally divide by 1e9 so the bucket
-// label reads in seconds.
+// (Log2Bucketize, `2^ceil(log2(v))`); durations additionally divide
+// the resulting power of two by 1e9 so the bucket label reads in
+// seconds.
 func lowerMetricsAggregate(prev chplan.Node, agg *traceql.MetricsAggregate, s schema.Traces) (chplan.Node, error) {
 	op := agg.Op()
 	if op == traceql.MetricsAggregateHistogramOverTime {
@@ -284,8 +285,9 @@ const histogramBucketAlias = "__bucket"
 //
 // Bucketing follows Tempo's `bucketizeFnFor`: duration attrs (the
 // `duration` intrinsic, or attributes typed as TypeDuration) emit
-// `log2(<attr>) / 1e9` so the bucket reads in seconds; other numeric
-// attrs emit the raw `log2(<attr>)`. The runtime drops spans with
+// `pow(2, ceil(log2(toFloat64(<attr>)))) / 1e9` so the bucket reads in
+// seconds; other numeric attrs emit the raw next power of two
+// `pow(2, ceil(log2(toFloat64(<attr>))))`. The runtime drops spans with
 // <attr> < 2 (bucketizeDuration / bucketizeAttribute return
 // NewStaticNil()); the SQL emitter mirrors that with a WHERE filter on
 // the operand.

--- a/test/spec/chplan_print.go
+++ b/test/spec/chplan_print.go
@@ -388,6 +388,12 @@ func printExpr(e chplan.Expr) string {
 		return strconv.FormatBool(v.V)
 	case *chplan.Binary:
 		return fmt.Sprintf("(%s %s %s)", printExpr(v.Left), v.Op, printExpr(v.Right))
+	case *chplan.InList:
+		items := make([]string, len(v.List))
+		for i, e := range v.List {
+			items[i] = printExpr(e)
+		}
+		return fmt.Sprintf("(%s IN (%s))", printExpr(v.Left), strings.Join(items, ", "))
 	case *chplan.FuncCall:
 		args := make([]string, len(v.Args))
 		for i, a := range v.Args {

--- a/test/spec/traceql/metrics_histogram_over_time_attr.txtar
+++ b/test/spec/traceql/metrics_histogram_over_time_attr.txtar
@@ -1,7 +1,7 @@
 -- query.traceql --
 {} | histogram_over_time(duration)
 -- sql --
-SELECT log2(`Duration`) / 1000000000 AS `__bucket`, toFloat64(count(?)) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE ?) WHERE `Duration` >= 2 GROUP BY `__bucket`
+SELECT pow(2, ceil(log2(toFloat64(`Duration`)))) / 1000000000 AS `__bucket`, toFloat64(count(?)) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE ?) WHERE `Duration` >= 2 GROUP BY `__bucket`
 -- args --
 [0] int64 = 1
 [1] bool = true
@@ -15,7 +15,7 @@ INSERT INTO otel_traces VALUES
     (1024);
 -- expected_rows --
 [
-  [1.0e-08, 3]
+  [0.000001024, 3]
 ]
 -- chplan --
 MetricsHistogramOverTime attr=Duration duration=true bucketAlias=__bucket valueAlias=Value

--- a/test/spec/traceql/metrics_histogram_over_time_by.txtar
+++ b/test/spec/traceql/metrics_histogram_over_time_by.txtar
@@ -1,7 +1,7 @@
 -- query.traceql --
 {} | histogram_over_time(duration) by (resource.service.name)
 -- sql --
-SELECT `ResourceAttributes`[?] AS `service.name`, log2(`Duration`) / 1000000000 AS `__bucket`, toFloat64(count(?)) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE ?) WHERE `Duration` >= 2 GROUP BY `ResourceAttributes`[?], `__bucket`
+SELECT `ResourceAttributes`[?] AS `service.name`, pow(2, ceil(log2(toFloat64(`Duration`)))) / 1000000000 AS `__bucket`, toFloat64(count(?)) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE ?) WHERE `Duration` >= 2 GROUP BY `ResourceAttributes`[?], `__bucket`
 -- args --
 [0] string = "service.name"
 [1] int64 = 1
@@ -18,7 +18,7 @@ INSERT INTO otel_traces VALUES
     (map('service.name', 'frontend'), 1024);
 -- expected_rows --
 [
-  ["frontend", 1.0e-08, 3]
+  ["frontend", 0.000001024, 3]
 ]
 -- chplan --
 MetricsHistogramOverTime attr=Duration duration=true groupBy=[ResourceAttributes["service.name"] AS service.name|resource.service.name] bucketAlias=__bucket valueAlias=Value

--- a/test/spec/traceql/metrics_histogram_over_time_empty.txtar
+++ b/test/spec/traceql/metrics_histogram_over_time_empty.txtar
@@ -1,7 +1,7 @@
 -- query.traceql --
 { resource.service.name = "frontend" } | histogram_over_time(duration)
 -- sql --
-SELECT log2(`Duration`) / 1000000000 AS `__bucket`, toFloat64(count(?)) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) WHERE `Duration` >= 2 GROUP BY `__bucket`
+SELECT pow(2, ceil(log2(toFloat64(`Duration`)))) / 1000000000 AS `__bucket`, toFloat64(count(?)) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) WHERE `Duration` >= 2 GROUP BY `__bucket`
 -- args --
 [0] int64 = 1
 [1] string = "service.name"
@@ -17,7 +17,7 @@ INSERT INTO otel_traces VALUES
     (map('service.name', 'backend'),  4096);
 -- expected_rows --
 [
-  [1.0e-08, 2]
+  [0.000001024, 2]
 ]
 -- chplan --
 MetricsHistogramOverTime attr=Duration duration=true bucketAlias=__bucket valueAlias=Value


### PR DESCRIPTION
## Summary

The final two crawl-backlog findings — both investigated to verdict, both real cerberus bugs, both fixed at source.

## 1. `histogram_over_time(duration)` emitted nonsense bucket keys (ns-scale signature)

`histogramBucketFrag` emitted `log2(Duration)/1e9` — the raw log2 **exponent** divided by 1e9 (a 1.024 µs span surfaced `__bucket≈3e-08`). Reference Tempo (`ast_metrics.go bucketizeDuration` + `Log2Bucketize`) emits the value rounded up to the next power-of-two nanoseconds, divided by 1e9 — seconds as floats (1.024 µs → `1.024e-06`). Cerberus's quantile path already had the correct form; only the histogram path was wrong.

Two more gaps fixed while making the wire actually match reference:
- `__bucket` label normalized to Go shortest-float form (CH renders `"0.000001024"` where Tempo stringifies `"1.024e-06"` — the label is series identity on the wire).
- Zero-fill: Tempo histogram series are dense with 0-samples at empty anchors; cerberus dropped them. Added the UNION-ALL generator arm + `sum(in_window)` reducer (same idiom as count/rate/quantile).

Tests: regenerated goldens pin `[1.024e-06, 3]` for 1024 ns spans through chdb; HTTP-level label-normalization test; end-to-end chdb test pinning unit+form+zero-fill; new compat corpus case `metrics_histogram_over_time_duration` diffed against reference Tempo (exercised by the required `compatibility/tempo` gate).

## 2. Root-span lookup blew ClickHouse's parser depth (WARN `code: 306`, `missing=1006`)

`orEqLiterals` built the TraceId filter as a nested `Binary{OpOr}` chain — one parser AST level per trace ID — tripping `max_parser_depth` (1000) at ~1000 IDs and silently degrading search-result root decoration. **Reproduced in embedded CH**: OR-chain ×1100 → `TOO_DEEP_RECURSION`; flat IN ×2000 → fine.

Fix: new typed `chplan.InList` expr emitting a flat `col IN (?, ?, …)` tuple — O(1) depth — wired through emitter, printer, optimizer walk, and PREWHERE classification. WARN-degrade kept deliberately: reference Tempo treats root metadata as best-effort (returns 200 with placeholder root text, never an error); documented at the call site.

Tests: emitted-SQL paren depth at N=2000 equals N=2; chdb execution of the real lookup at N=1500 (past the cliff) recovering seeded root identity; InList emission/Equal pins.

## Verification

4215 non-chdb tests green across 26 packages; chdb lanes green; golangci-lint + all lefthook gates passed. Tempo compat harness runs in CI (local disk too tight for the harness stack — nothing was started or left behind).

Closes task #47 — the crawl backlog is now fully landed or in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
