### PR TITLE
chore(deps): pin tsouza/tempo at v0.0.4-cerberus-accessors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -343,7 +343,7 @@ replace github.com/grafana/loki/v3 => github.com/tsouza/loki/v3 v3.0.0-cerberus-
 // tempo: narrow accessors on top of pkg/traceql to retire the unsafe.Pointer
 // + reflect.FieldByName shims in internal/traceql/. See docs/fork-tempo-
 // plan.md for the migration plan and accessor inventory.
-replace github.com/grafana/tempo => github.com/tsouza/tempo v0.0.3-cerberus-accessors.0.20260611033556-0888855681c5
+replace github.com/grafana/tempo => github.com/tsouza/tempo v0.0.4-cerberus-accessors
 
 // otelc: hoists the ClickHouse exporter's sqltemplates out of `internal/`
 // so cerberus can import them as the schema source-of-truth. collector-

--- a/go.sum
+++ b/go.sum
@@ -710,8 +710,8 @@ github.com/tsouza/opentelemetry-collector-contrib/pkg/translator/jaeger v0.0.2-c
 github.com/tsouza/opentelemetry-collector-contrib/pkg/translator/jaeger v0.0.2-cerberus-ddl/go.mod h1:UetIxoLmE+X0io7ookhE9J/6KoJSdmFzLFmcUiW/XzM=
 github.com/tsouza/prometheus v0.0.1-cerberus-parser h1:RjX9HKGVHPxLbtGKSbzWJ3bGFsmOEORWG2DX2Spg6oY=
 github.com/tsouza/prometheus v0.0.1-cerberus-parser/go.mod h1:orN7+39ySpDpDwh+EbN7UYpMHYNXrl0rabkpVMfMN4g=
-github.com/tsouza/tempo v0.0.3-cerberus-accessors.0.20260611033556-0888855681c5 h1:SyIUSwkCPDoxQoeXzwHdukx7VZbIu070rVemXnDYFb4=
-github.com/tsouza/tempo v0.0.3-cerberus-accessors.0.20260611033556-0888855681c5/go.mod h1:tV3Pl9la00Ti1stc4RMsIa41zkx1i3mtxKKy13vXwt4=
+github.com/tsouza/tempo v0.0.4-cerberus-accessors h1:aaZdzRwoH2N0j6dLgJmlUqD8TMxAq6dKjq3iivaj2T4=
+github.com/tsouza/tempo v0.0.4-cerberus-accessors/go.mod h1:tV3Pl9la00Ti1stc4RMsIa41zkx1i3mtxKKy13vXwt4=
 github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31/go.mod h1:onvgF043R+lC5RZ8IT9rBXDaEDnpnw/Cl+HFiw+v/7Q=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/twmb/franz-go v1.21.0 h1:J3uB/poWgHD6VIilER2uCPFAZHDRXVFT+11pBgRKod4=


### PR DESCRIPTION
One-line follow-up to #776: swap the temporary pseudo-version pin for the now-minted `v0.0.4-cerberus-accessors` tag (same commit, same content — fork branch fast-forwarded and tag pushed with maintainer authorization). Restores the tags-only fork convention documented in docs/upstream-forks.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)