### PR TITLE
fix(traceql): nil comparisons per reference — intrinsic exists is constant-true, attribute existence via map presence

### DIFF
--- a/compatibility/tempo/README.md
+++ b/compatibility/tempo/README.md
@@ -82,19 +82,20 @@ relative epsilon.
 The TXTAR corpus is the single source of truth for which Tempo HTTP
 shapes the differ exercises.
 
-| Category                | Endpoint kind     | Wire shape                                      | Diff strategy                                          |
-| ----------------------- | ----------------- | ----------------------------------------------- | ------------------------------------------------------ |
-| Attribute matchers      | `search`          | `{traces:[TraceSummary]}`                       | TraceID set diff (real hex IDs match byte-for-byte)    |
-| Intrinsics              | `search`          | same                                            | same                                                   |
-| Structural ops          | `search`          | same                                            | same                                                   |
-| Set ops                 | `search`          | same                                            | same                                                   |
-| Inner aggregates        | `search`          | same                                            | same                                                   |
-| Metrics pipeline        | `metrics_*`       | Prom series envelope                            | Semantic invariants + structural diff                  |
-| Per-id round trip       | `traces`          | `{trace:{...}}`                                 | Trace-ID derivation from seeder template + status-2xx  |
-| Tag names V1            | `tags_v1`         | `{tagNames:[string]}`                           | Set diff over the flat list                            |
-| Tag names V2            | `tags_v2`         | `{scopes:[{name, tags}]}`                       | Set diff over flattened tags + per-scope-name diff     |
-| Tag values V1           | `tag_values_v1`   | `{tagValues:[string]}`                          | Set diff over the flat list                            |
-| Tag values V2           | `tag_values_v2`   | `{tagValues:[{type, value}]}`                   | Set diff over `Value` + `Type`-field diff on overlap   |
+| Category                | Endpoint kind        | Wire shape                                      | Diff strategy                                          |
+| ----------------------- | -------------------- | ----------------------------------------------- | ------------------------------------------------------ |
+| Attribute matchers      | `search`             | `{traces:[TraceSummary]}`                       | TraceID set diff (real hex IDs match byte-for-byte)    |
+| Intrinsics              | `search`             | same                                            | same                                                   |
+| Structural ops          | `search`             | same                                            | same                                                   |
+| Set ops                 | `search`             | same                                            | same                                                   |
+| Inner aggregates        | `search`             | same                                            | same                                                   |
+| Nil comparisons         | `search`/`metrics_*` | same per endpoint                               | same per endpoint (incl. unspecified-kind boundary)    |
+| Metrics pipeline        | `metrics_*`          | Prom series envelope                            | Semantic invariants + structural diff                  |
+| Per-id round trip       | `traces`             | `{trace:{...}}`                                 | Trace-ID derivation from seeder template + status-2xx  |
+| Tag names V1            | `tags_v1`            | `{tagNames:[string]}`                           | Set diff over the flat list                            |
+| Tag names V2            | `tags_v2`            | `{scopes:[{name, tags}]}`                       | Set diff over flattened tags + per-scope-name diff     |
+| Tag values V1           | `tag_values_v1`      | `{tagValues:[string]}`                          | Set diff over the flat list                            |
+| Tag values V2           | `tag_values_v2`      | `{tagValues:[{type, value}]}`                   | Set diff over `Value` + `Type`-field diff on overlap   |
 
 The tag endpoints pin three classes of subset assertion:
 

--- a/compatibility/tempo/driver/corpus/smoke.txtar
+++ b/compatibility/tempo/driver/corpus/smoke.txtar
@@ -40,10 +40,11 @@
 # Cases below cover the 7 shadow categories (attribute matchers per
 # scope (5), intrinsics (4), structural ops (4), set ops (3), inner
 # aggregates (2)) plus 7 metrics-pipeline cases (4 range + 3 instant)
-# and a per-id smoke; later additions grew the spanSets and metrics
-# families (the count below tracks `grep -c '^-- name --'`).
-# Total: 39 cases — the compare() range case activated alongside
-# chplan.MetricsCompare.
+# and a per-id smoke; later additions grew the spanSets, metrics, and
+# nil-comparison families (the count below tracks
+# `grep -c '^-- name --'`).
+# Total: 48 cases — the nil-comparison family activated alongside the
+# Traces Drilldown breakdown fix (intrinsic `!= nil` lowering).
 
 # --- Attribute matchers per scope (5) ---
 
@@ -711,3 +712,135 @@ tag_values_v2
 0
 -- expected_max_values --
 0
+
+# --- Nil comparisons (Traces Drilldown breakdown shapes) ---
+# Grafana Traces Drilldown appends `&& <groupBy> != nil` to EVERY
+# breakdown query, so nil comparisons on intrinsics are a load-bearing
+# consumer shape. Reference semantics (pkg/traceql): `<x> != nil`
+# evaluates OpExists — true iff x resolves to a non-nil static. For
+# intrinsics that is true on EVERY span (vparquet4 stores them as
+# required parquet columns and the span collector adds the static
+# unconditionally) — including the seeder's SPAN_KIND_UNSPECIFIED
+# children, which pin that `kind != nil` is constant-true, NOT an
+# enum-zero check. For attributes it is key existence. The rejected
+# forms (`<intrinsic> = nil`, `resource.service.name = nil` — both
+# 400 on reference, ast_validate.go) cannot ride the corpus (200-shaped
+# cases only); internal/traceql/nested_set_nil_test.go pins them.
+
+-- name --
+kind_not_nil
+-- query --
+{ kind != nil }
+-- endpoint --
+search
+# Matches every span — every trace, including the unspecified-kind
+# carriers — on both backends.
+-- expected_min_traces --
+1
+-- expected_max_traces --
+500
+
+-- name --
+kind_not_nil_unspecified_carrier
+# Conjunction pins the boundary span directly: the child.index=0 spans
+# of every-5th trace carry SPAN_KIND_UNSPECIFIED, so a backend that
+# lowered `kind != nil` to SpanKind != 'Unspecified' returns zero
+# traces here while reference returns the carriers.
+-- query --
+{ kind != nil && span.child.index = "0" && span.kind = "SPAN_KIND_UNSPECIFIED" }
+-- endpoint --
+search
+-- expected_min_traces --
+1
+-- expected_max_traces --
+500
+
+-- name --
+status_not_nil
+-- query --
+{ status != nil }
+-- endpoint --
+search
+-- expected_min_traces --
+1
+-- expected_max_traces --
+500
+
+-- name --
+name_not_nil
+-- query --
+{ name != nil }
+-- endpoint --
+search
+-- expected_min_traces --
+1
+-- expected_max_traces --
+500
+
+-- name --
+span_http_method_eq_nil
+# Root spans carry http.method; children do not — every trace matches
+# through its children on both backends.
+-- query --
+{ span.http.method = nil }
+-- endpoint --
+search
+-- expected_min_traces --
+1
+-- expected_max_traces --
+500
+
+-- name --
+resource_deployment_env_not_nil
+-- query --
+{ resource.deployment.env != nil }
+-- endpoint --
+search
+-- expected_min_traces --
+1
+-- expected_max_traces --
+500
+
+-- name --
+drilldown_breakdown_kind_not_nil
+# The VERBATIM query the Drilldown breakdown tab sends for the "kind"
+# groupBy (maintainer repro). Differential on the full series scheme:
+# acceptance (pre-fix cerberus 422'd the `kind != nil` clause) plus
+# by(kind) label-value parity — values must be reference's lowercase
+# Static.EncodeToString form ("server"), not the TitleCase OTel-CH
+# column payload ("Server"). The root-only filter keeps the Server
+# roots; the unspecified-kind boundary lives in the all-spans case
+# below.
+-- query --
+{nestedSetParent<0 && true && kind != nil} | rate() by(kind)
+-- endpoint --
+metrics_range
+-- step --
+60s
+-- expected_min_series --
+1
+-- expected_max_series --
+50
+-- semantic_checks --
+samples_non_negative
+groupby_labels_present:kind
+
+-- name --
+metrics_rate_by_kind_all_spans
+# by(kind) over ALL spans — every kind group in the fixture surfaces,
+# including the "unspecified" group from the boundary carriers; the
+# differ's label-set hashing pins cerberus's group values against
+# reference's lowercase wire form for every kind enum word at once.
+-- query --
+{ kind != nil } | rate() by(kind)
+-- endpoint --
+metrics_range
+-- step --
+60s
+-- expected_min_series --
+1
+-- expected_max_series --
+50
+-- semantic_checks --
+samples_non_negative
+groupby_labels_present:kind

--- a/compatibility/tempo/driver/seeder.go
+++ b/compatibility/tempo/driver/seeder.go
@@ -120,9 +120,11 @@ const (
 // harnesses against the same CH without trace-id confusion.
 var services = []string{"checkout", "payments", "search", "shipping"}
 
-// spanKinds rotates per child span. Mirrors the OTLP enum values 1..5
-// (UNSPECIFIED is skipped — every span in the fixture is an explicit
-// kind).
+// spanKinds rotates per child span. Mirrors the OTLP enum values 1..5;
+// on top of the rotation, newTrace pins one deterministic child per
+// every-5th trace to SPAN_KIND_UNSPECIFIED (enum 0) so the corpus can
+// differentiate nil-comparison semantics on the kind intrinsic at the
+// reference boundary (see the unspecified-kind note in newTrace).
 var spanKinds = []otlptrace.Span_SpanKind{
 	otlptrace.Span_SPAN_KIND_INTERNAL,
 	otlptrace.Span_SPAN_KIND_SERVER,
@@ -132,14 +134,16 @@ var spanKinds = []otlptrace.Span_SpanKind{
 }
 
 // span kind → cerberus CH SpanKind column literal. Mirrors the
-// `SpanKind` enum the OTel-CH exporter writes; matches the strings
-// used in test/e2e/seed/cmd/seed/main.go.
+// `SpanKind` enum the OTel-CH exporter writes (`span.Kind().String()`
+// over pdata's ptrace.SpanKind — "Unspecified" for the zero enum);
+// matches the strings used in test/e2e/seed/cmd/seed/main.go.
 var spanKindCH = map[otlptrace.Span_SpanKind]string{
-	otlptrace.Span_SPAN_KIND_INTERNAL: "Internal",
-	otlptrace.Span_SPAN_KIND_SERVER:   "Server",
-	otlptrace.Span_SPAN_KIND_CLIENT:   "Client",
-	otlptrace.Span_SPAN_KIND_PRODUCER: "Producer",
-	otlptrace.Span_SPAN_KIND_CONSUMER: "Consumer",
+	otlptrace.Span_SPAN_KIND_UNSPECIFIED: "Unspecified",
+	otlptrace.Span_SPAN_KIND_INTERNAL:    "Internal",
+	otlptrace.Span_SPAN_KIND_SERVER:      "Server",
+	otlptrace.Span_SPAN_KIND_CLIENT:      "Client",
+	otlptrace.Span_SPAN_KIND_PRODUCER:    "Producer",
+	otlptrace.Span_SPAN_KIND_CONSUMER:    "Consumer",
 }
 
 // fixtureTrace is the in-memory representation of one trace, shared
@@ -317,6 +321,18 @@ func newTrace(start time.Time, svc string, svcIdx, traceIdx int) *fixtureTrace {
 	for c := 0; c < childCount; c++ {
 		childID := deriveSpanID(svc, traceIdx, c+1)
 		childKind := spanKinds[(c+traceIdx)%len(spanKinds)]
+		// One deterministic child per every-5th trace carries
+		// SPAN_KIND_UNSPECIFIED (OTLP enum 0; OTel-CH writes
+		// SpanKind='Unspecified'). This pins the nil-comparison
+		// boundary differentially: reference Tempo's `kind != nil`
+		// matches EVERY span — vparquet4 stores Kind as a required
+		// parquet column and the engine's OpExists only tests for the
+		// nil static — so unspecified-kind spans must match too. A
+		// backend that lowered `kind != nil` to an enum-zero check
+		// (SpanKind != 'Unspecified') would drop these spans and diff.
+		if c == 0 && traceIdx%5 == 2 {
+			childKind = otlptrace.Span_SPAN_KIND_UNSPECIFIED
+		}
 		childStart := ts.Add(time.Duration(10*(c+1)) * time.Millisecond)
 		childDur := time.Duration(20*(c+1)) * time.Millisecond
 		// Status alternates: every 5th child reports Error so the

--- a/internal/api/tempo/metrics_query_range_drilldown_chdb_test.go
+++ b/internal/api/tempo/metrics_query_range_drilldown_chdb_test.go
@@ -1,0 +1,136 @@
+//go:build chdb
+
+// chDB-backed end-to-end pin for the VERBATIM query Grafana Traces
+// Drilldown's breakdown tab issues when the user clicks the "kind"
+// groupBy:
+//
+//	{nestedSetParent<0 && true && kind != nil} | rate() by(kind)
+//
+// The Drilldown app appends `&& <groupBy> != nil` to EVERY breakdown
+// query, so a backend that rejects nil comparisons on intrinsics
+// breaks every intrinsic breakdown (kind, status, name, ...). Three
+// contracts pinned here:
+//
+//  1. ACCEPTANCE: the request returns 200, not the pre-fix 422
+//     ("traceql: nil comparison on intrinsic kind is unsupported").
+//  2. SEMANTICS: `kind != nil` matches EVERY span — reference Tempo
+//     stores intrinsics as required parquet columns and its OpExists
+//     only tests the nil static (pkg/traceql ast_execute.go), so even
+//     a SPAN_KIND_UNSPECIFIED root span lands in the breakdown (as
+//     its own group), and is NOT filtered by an enum-zero check.
+//  3. WIRE FORM: `by(kind)` label values are reference Tempo's
+//     lowercase Static.EncodeToString form ("server", "unspecified"),
+//     not the TitleCase OTel-CH column payload ("Server").
+package tempo_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/api/tempo"
+	"github.com/tsouza/cerberus/internal/chclienttest"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+func TestMetricsQueryRange_DrilldownBreakdownKind_ChDB(t *testing.T) {
+	c := chclienttest.NewChDB(t)
+	c.Seed(t, `CREATE TABLE otel_traces (
+    TraceId String,
+    SpanId String,
+    ParentSpanId String,
+    SpanName String,
+    SpanKind LowCardinality(String),
+    Duration Int64,
+    Timestamp DateTime64(9),
+    SpanAttributes Map(String, String),
+    ResourceAttributes Map(String, String)
+) ENGINE = MergeTree() ORDER BY (Timestamp);`)
+	// Four spans inside the [10:00, 10:03] query window:
+	//   - two Server ROOT spans (10:00:30 → anchor 10:01;
+	//     10:01:30 → anchor 10:02),
+	//   - one Unspecified-kind ROOT span (10:01:30 → anchor 10:02) —
+	//     `kind != nil` must keep it (constant-TRUE semantics),
+	//   - one Client CHILD span — `nestedSetParent<0` must drop it,
+	//     so no "client" series may surface.
+	c.Seed(t, `INSERT INTO otel_traces VALUES
+    ('a0000000000000000000000000000001', '1000000000000001', '', 'root-a', 'Server', 1000000, toDateTime64('2026-05-12 10:00:30.000000000', 9), map(), map('service.name', 'svc')),
+    ('a0000000000000000000000000000002', '1000000000000002', '', 'root-b', 'Server', 1000000, toDateTime64('2026-05-12 10:01:30.000000000', 9), map(), map('service.name', 'svc')),
+    ('a0000000000000000000000000000003', '1000000000000003', '', 'root-c', 'Unspecified', 1000000, toDateTime64('2026-05-12 10:01:30.000000000', 9), map(), map('service.name', 'svc')),
+    ('a0000000000000000000000000000001', '1000000000000004', '1000000000000001', 'child', 'Client', 1000000, toDateTime64('2026-05-12 10:01:30.000000000', 9), map(), map('service.name', 'svc'));`)
+
+	h := tempo.New(c, schema.DefaultOTelTraces(), "v-test", nil)
+	mux := http.NewServeMux()
+	h.Mount(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	u := metricsQueryRangeURL(srv.URL, "{nestedSetParent<0 && true && kind != nil} | rate() by(kind)", map[string]string{
+		"start": fixtureStartUnix, // 2026-05-12T10:00:00Z
+		"end":   fixtureEndUnix,   // +3m
+		"step":  "60s",
+	})
+	resp, err := http.Get(u)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s — the Drilldown breakdown query must not be rejected", resp.StatusCode, body)
+	}
+
+	var out tempo.MetricsQueryRangeResponse
+	if err := json.Unmarshal([]byte(body), &out); err != nil {
+		t.Fatalf("decode: %v\nbody: %s", err, body)
+	}
+	if len(out.Series) != 2 {
+		t.Fatalf("expected 2 series (server + unspecified; client child excluded by nestedSetParent<0), got %d: %s", len(out.Series), body)
+	}
+
+	bySeries := map[string]tempo.MetricsSeries{}
+	for _, s := range out.Series {
+		if len(s.Labels) != 1 || s.Labels[0].Key != "kind" {
+			t.Fatalf("expected single `kind` label, got %+v", s.Labels)
+		}
+		bySeries[s.Labels[0].Value] = s
+	}
+
+	server, ok := bySeries["server"]
+	if !ok {
+		t.Fatalf("missing kind=server series (lowercase reference wire form); got %v: %s", labelValues(bySeries), body)
+	}
+	unspecified, ok := bySeries["unspecified"]
+	if !ok {
+		t.Fatalf("missing kind=unspecified series — `kind != nil` must match SPAN_KIND_UNSPECIFIED spans too (got %v): %s", labelValues(bySeries), body)
+	}
+	if _, ok := bySeries["client"]; ok {
+		t.Fatalf("kind=client series must not surface — the child span fails nestedSetParent<0: %s", body)
+	}
+
+	// rate() = spans per second per 60s anchor; dense zero-filled grid
+	// across the 4 anchors (10:00..10:03).
+	wantAnchorsMs := []int64{
+		1778580000000, // 10:00
+		1778580060000, // 10:01
+		1778580120000, // 10:02
+		1778580180000, // 10:03
+	}
+	perSpanRate := 1.0 / 60.0
+	assertSamples := func(name string, s tempo.MetricsSeries, wantValues []float64) {
+		t.Helper()
+		if len(s.Samples) != len(wantAnchorsMs) {
+			t.Fatalf("%s: expected %d zero-filled samples, got %d: %+v", name, len(wantAnchorsMs), len(s.Samples), s.Samples)
+		}
+		for i, sm := range s.Samples {
+			if sm.TimestampMs != wantAnchorsMs[i] {
+				t.Errorf("%s: sample[%d] ts = %d, want %d", name, i, sm.TimestampMs, wantAnchorsMs[i])
+			}
+			if sm.Value != wantValues[i] {
+				t.Errorf("%s: sample[%d] value = %g, want %g", name, i, sm.Value, wantValues[i])
+			}
+		}
+	}
+	assertSamples("kind=server", server, []float64{0, perSpanRate, perSpanRate, 0})
+	assertSamples("kind=unspecified", unspecified, []float64{0, 0, perSpanRate, 0})
+}

--- a/internal/chplan/equal_invariants_test.go
+++ b/internal/chplan/equal_invariants_test.go
@@ -1466,6 +1466,21 @@ func TestNestedArrayExists_Equal_Negative_SubField(t *testing.T) {
 	}
 }
 
+func TestNestedArrayExists_Equal_Negative_Presence(t *testing.T) {
+	t.Parallel()
+	a := &chplan.NestedArrayExists{
+		Column: "Events", SubField: "Attributes", Key: "k",
+		Presence: chplan.PresenceHasKey,
+	}
+	b := &chplan.NestedArrayExists{
+		Column: "Events", SubField: "Attributes", Key: "k",
+		Presence: chplan.PresenceLacksKey,
+	}
+	if a.Equal(b) {
+		t.Errorf("different Presence should not be Equal")
+	}
+}
+
 func TestNestedArrayExists_Equal_Negative_Value(t *testing.T) {
 	t.Parallel()
 	a := &chplan.NestedArrayExists{

--- a/internal/chplan/nested_array_exists.go
+++ b/internal/chplan/nested_array_exists.go
@@ -25,7 +25,41 @@ type NestedArrayExists struct {
 	Key      string
 	Op       BinaryOp
 	Value    Expr
+	// Presence switches the node from a value comparison (the zero
+	// value, PresenceCompare: `x[Key] <Op> <Value>`) to an existence
+	// probe — the lowering of TraceQL nil comparisons on event./link.
+	// scoped attributes and nested intrinsics. When Presence is not
+	// PresenceCompare, Op and Value are unused (Value is nil).
+	Presence NestedPresence
 }
+
+// NestedPresence enumerates the existence-probe modes of
+// NestedArrayExists. Reference Tempo evaluates `<attr> != nil` as
+// "the attribute resolves to a non-nil static" (pkg/traceql
+// ast_execute.go OpExists) — for event./link. scoped attributes that
+// means "at least one Nested-array element carries the key", and for
+// the nested intrinsics (event:name / link:traceID / link:spanID,
+// required sub-fields of every element) simply "at least one element
+// exists".
+type NestedPresence int
+
+const (
+	// PresenceCompare is the default value-comparison rendering:
+	// arrayExists(x -> x[Key] <Op> <Value>, Column.SubField).
+	PresenceCompare NestedPresence = iota
+	// PresenceHasKey renders `<attr> != nil`:
+	// arrayExists(x -> mapContains(x, Key), Column.SubField); with an
+	// empty Key the probe degenerates to notEmpty(Column.SubField)
+	// (any element at all — the nested-intrinsic form).
+	PresenceHasKey
+	// PresenceLacksKey renders `<attr> = nil`:
+	// arrayExists(x -> not(mapContains(x, Key)), Column.SubField) —
+	// at least one element that lacks the key, mirroring reference
+	// Tempo's per-element nil sentinel (vparquet4 collectors surface
+	// fetched-but-null attribute cells as the "nil" static that
+	// OpNotExists matches).
+	PresenceLacksKey
+)
 
 func (*NestedArrayExists) exprNode() {}
 
@@ -34,7 +68,7 @@ func (n *NestedArrayExists) Equal(other Expr) bool {
 	if !ok {
 		return false
 	}
-	if n.Column != o.Column || n.SubField != o.SubField || n.Key != o.Key || n.Op != o.Op {
+	if n.Column != o.Column || n.SubField != o.SubField || n.Key != o.Key || n.Op != o.Op || n.Presence != o.Presence {
 		return false
 	}
 	if n.Value == nil || o.Value == nil {

--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -416,7 +416,42 @@ func (b *Builder) exprSubscript(s *chplan.Subscript) error {
 //     infix spelling the generic branch writes is a server-side
 //     syntax error (the bug TraceQL `{ event.foo =~ "..." }` hit
 //     before the showcase pinned it).
+//   - Presence != PresenceCompare renders the existence probes for
+//     TraceQL nil comparisons: `arrayExists(x -> mapContains(x, ?),
+//     …)` (HasKey), `arrayExists(x -> not(mapContains(x, ?)), …)`
+//     (LacksKey), and `notEmpty(…)` for the empty-Key HasKey form
+//     (nested intrinsics — any element at all).
 func (b *Builder) exprNestedArrayExists(n *chplan.NestedArrayExists) error {
+	switch n.Presence {
+	case chplan.PresenceHasKey, chplan.PresenceLacksKey:
+		if n.Key == "" {
+			// Any-element probe (event:name != nil and friends): the
+			// sub-field is a required column of every Nested element,
+			// so presence of any element answers the probe.
+			if n.Presence == chplan.PresenceLacksKey {
+				b.sb.WriteString("empty(")
+			} else {
+				b.sb.WriteString("notEmpty(")
+			}
+			b.QualIdent(n.Column, n.SubField)
+			b.sb.WriteByte(')')
+			return nil
+		}
+		b.sb.WriteString("arrayExists(x -> ")
+		if n.Presence == chplan.PresenceLacksKey {
+			b.sb.WriteString("not(mapContains(x, ")
+			b.Arg(n.Key)
+			b.sb.WriteString("))")
+		} else {
+			b.sb.WriteString("mapContains(x, ")
+			b.Arg(n.Key)
+			b.sb.WriteByte(')')
+		}
+		b.sb.WriteString(", ")
+		b.QualIdent(n.Column, n.SubField)
+		b.sb.WriteByte(')')
+		return nil
+	}
 	b.sb.WriteString("arrayExists(x -> ")
 	elem := func() {
 		b.sb.WriteByte('x')

--- a/internal/traceql/lower.go
+++ b/internal/traceql/lower.go
@@ -603,16 +603,48 @@ func lowerFieldExpr(e traceql.FieldExpression, s schema.Traces) (chplan.Expr, er
 // and `<attr> = nil` / `nil = <attr>` to UnaryOperation{OpNotExists}
 // (the grammar rewrites the nil comparison — see upstream expr.y).
 // Grafana's first-party Traces Drilldown app (preinstalled since
-// Grafana 12.x) issues `resource.service.name != nil` on every
-// breakdown view, so the existence test is a load-bearing shape.
+// Grafana 12.x) appends `&& <groupBy> != nil` to EVERY breakdown
+// query — including intrinsic group-bys like
+// `{nestedSetParent<0 && true && kind != nil} | rate() by(kind)` —
+// so both the attribute and the intrinsic existence forms are
+// load-bearing shapes.
 //
-// Existence lowers to ClickHouse `mapContains(<carrier>, '<key>')`
-// against the Map(String, String) attribute carrier for the
-// attribute's scope (SpanAttributes / ResourceAttributes — the same
-// scope mapping lowerAttribute uses). Intrinsics are rejected: OTel-CH
-// materialises every intrinsic as a non-nullable column, so an
-// existence probe on one is almost certainly a query bug — surfacing
-// the gap beats inventing always-true SQL.
+// Reference semantics (tsouza/tempo fork, pkg/traceql):
+//
+//   - `x != nil` (OpExists) evaluates to `static.Type != TypeNil`
+//     after executing x against the span (ast_execute.go). Intrinsic
+//     columns are required parquet fields (vparquet4 schema.go: Kind,
+//     StatusCode, Name, DurationNano, …) and the vparquet4 span
+//     collector adds the intrinsic static unconditionally — even
+//     kind=SPAN_KIND_UNSPECIFIED becomes a non-nil TypeKind static
+//     (block_traceql.go spanCollector). So `<intrinsic> != nil`
+//     matches EVERY span — it is a constant TRUE, not an
+//     enum-zero/empty-string check. OTel-CH mirrors this exactly:
+//     every intrinsic column is always present.
+//   - `<intrinsic> = nil` (OpNotExists) is rejected by reference
+//     validation: "X = nil is not valid because intrinsics cannot be
+//     nil" (ast_validate.go UnaryOperation.validate), double-enforced
+//     by vparquet4 checkConditions. Same for `resource.service.name
+//     = nil`.
+//   - `<span|resource attr> != nil` ≡ the attribute key exists on the
+//     span — `mapContains(<carrier>, '<key>')`; `= nil` is the
+//     negation (missing attributes surface as the nil sentinel the
+//     OpNotExists branch matches — ast_execute.go + vparquet4
+//     collectors).
+//   - `<event.|link. attr> != nil` ≡ at least one event/link carries
+//     the key (event attrs resolve per fetched Nested element);
+//     `= nil` ≡ at least one event/link element LACKS the key (the
+//     collectors surface fetched-but-null per-element attribute cells
+//     as the matchable nil sentinel; spans with no elements at all
+//     execute to StaticNil, which OpNotExists does NOT match —
+//     Static.Equals is false when either side is TypeNil).
+//   - Nested intrinsics (event:name / event:timeSinceStart /
+//     link:traceID / link:spanID) `!= nil` ≡ the span has at least
+//     one event/link: the sub-fields are required within each
+//     element, so any element answers the probe.
+//   - `childCount` conditions (any op, including != nil) error in
+//     reference vparquet4 (checkConditions: "intrinsic 'childCount'
+//     not supported in vParquet4") — keep rejecting.
 func lowerUnaryOperation(u traceql.UnaryOperation, s schema.Traces) (chplan.Expr, error) {
 	switch u.Op {
 	case traceql.OpExists, traceql.OpNotExists:
@@ -620,26 +652,114 @@ func lowerUnaryOperation(u traceql.UnaryOperation, s schema.Traces) (chplan.Expr
 		if !ok {
 			return nil, fmt.Errorf("traceql: %s operand %T is unsupported — nil comparisons require an attribute reference", u.Op, u.Expression)
 		}
-		if attr.Intrinsic != traceql.IntrinsicNone {
-			return nil, fmt.Errorf("traceql: nil comparison on intrinsic %s is unsupported — OTel-CH intrinsic columns are always present", attr.Intrinsic)
-		}
-		if attr.Scope == traceql.AttributeScopeLink || attr.Scope == traceql.AttributeScopeEvent {
-			return nil, fmt.Errorf("traceql: nil comparison on %s.%s is unsupported", attr.Scope, attr.Name)
-		}
-		carrier := s.AttributesColumn
-		if attr.Scope == traceql.AttributeScopeResource {
-			carrier = s.ResourceAttributesColumn
-		}
-		contains := &chplan.FuncCall{Name: "mapContains", Args: []chplan.Expr{
-			&chplan.ColumnRef{Name: carrier},
-			&chplan.LitString{V: attr.Name},
-		}}
-		if u.Op == traceql.OpNotExists {
-			return &chplan.FuncCall{Name: "not", Args: []chplan.Expr{contains}}, nil
-		}
-		return contains, nil
+		return lowerNilComparison(u.Op, attr, s)
 	}
 	return nil, fmt.Errorf("traceql: unary operator %s is unsupported", u.Op)
+}
+
+// lowerNilComparison lowers `<attr> != nil` (OpExists) / `<attr> = nil`
+// (OpNotExists) per the reference semantics documented on
+// lowerUnaryOperation.
+func lowerNilComparison(op traceql.Operator, attr traceql.Attribute, s schema.Traces) (chplan.Expr, error) {
+	if attr.Intrinsic != traceql.IntrinsicNone {
+		return lowerIntrinsicNilComparison(op, attr, s)
+	}
+	if op == traceql.OpNotExists &&
+		attr.Scope == traceql.AttributeScopeResource && attr.Name == "service.name" {
+		// Reference rejection (pkg/traceql/ast_validate.go):
+		// resource.service.name is mandatory on every OTLP resource.
+		return nil, fmt.Errorf("traceql: %s = nil is not valid because resource.service.name cannot be nil", attr)
+	}
+	if attr.Scope == traceql.AttributeScopeLink || attr.Scope == traceql.AttributeScopeEvent {
+		col, key, ok := nestedAttrTarget(attr, s)
+		if !ok {
+			return nil, fmt.Errorf("traceql: nil comparison on %s.%s is unsupported — the configured schema has no %s column", attr.Scope, attr.Name, attr.Scope)
+		}
+		presence := chplan.PresenceHasKey
+		if op == traceql.OpNotExists {
+			presence = chplan.PresenceLacksKey
+		}
+		return &chplan.NestedArrayExists{
+			Column:   col,
+			SubField: "Attributes",
+			Key:      key,
+			Presence: presence,
+		}, nil
+	}
+	carrier := s.AttributesColumn
+	switch attr.Scope {
+	case traceql.AttributeScopeResource:
+		carrier = s.ResourceAttributesColumn
+	case traceql.AttributeScopeInstrumentation:
+		// Same boundary as lowerAttribute: the OTel-CH traces schema
+		// materialises no scope-attributes map, so an existence probe
+		// against it cannot be answered — reject instead of silently
+		// reading SpanAttributes.
+		if s.ScopeAttributesColumn == "" {
+			return nil, fmt.Errorf(
+				"traceql: instrumentation-scoped attribute %q is unsupported — the OTel ClickHouse traces schema has no scope-attributes column (instrumentation:name / instrumentation:version map to ScopeName / ScopeVersion)",
+				attr.Name,
+			)
+		}
+		carrier = s.ScopeAttributesColumn
+	}
+	contains := &chplan.FuncCall{Name: "mapContains", Args: []chplan.Expr{
+		&chplan.ColumnRef{Name: carrier},
+		&chplan.LitString{V: attr.Name},
+	}}
+	if op == traceql.OpNotExists {
+		return &chplan.FuncCall{Name: "not", Args: []chplan.Expr{contains}}, nil
+	}
+	return contains, nil
+}
+
+// lowerIntrinsicNilComparison lowers nil comparisons whose subject is
+// an intrinsic. See lowerUnaryOperation for the reference-semantics
+// derivation of each branch.
+func lowerIntrinsicNilComparison(op traceql.Operator, attr traceql.Attribute, s schema.Traces) (chplan.Expr, error) {
+	if op == traceql.OpNotExists {
+		// Reference rejection (pkg/traceql/ast_validate.go
+		// UnaryOperation.validate; vparquet4 checkConditions repeats
+		// it at fetch time).
+		return nil, fmt.Errorf("traceql: %s = nil is not valid because intrinsics cannot be nil", attr.Intrinsic)
+	}
+	switch attr.Intrinsic {
+	case traceql.IntrinsicChildCount:
+		// Reference errors on every childCount condition (vparquet4
+		// checkConditions: "not supported in vParquet4").
+		return nil, fmt.Errorf(
+			"traceql: intrinsic %s requires per-span child counts the OTel ClickHouse schema does not materialise", attr.Intrinsic,
+		)
+	case traceql.IntrinsicEventName, traceql.IntrinsicEventTimeSinceStart:
+		if s.EventsColumn == "" {
+			return nil, fmt.Errorf("traceql: nil comparison on intrinsic %s is unsupported — the configured schema has no events column", attr.Intrinsic)
+		}
+		// ≥1 event: Events.Name is a required sub-field of every
+		// Nested element, so element presence answers the probe.
+		return &chplan.NestedArrayExists{
+			Column:   s.EventsColumn,
+			SubField: "Name",
+			Presence: chplan.PresenceHasKey,
+		}, nil
+	case traceql.IntrinsicLinkTraceID, traceql.IntrinsicLinkSpanID:
+		if s.LinksColumn == "" {
+			return nil, fmt.Errorf("traceql: nil comparison on intrinsic %s is unsupported — the configured schema has no links column", attr.Intrinsic)
+		}
+		// ≥1 link, same shape as the event probe.
+		return &chplan.NestedArrayExists{
+			Column:   s.LinksColumn,
+			SubField: "TraceId",
+			Presence: chplan.PresenceHasKey,
+		}, nil
+	}
+	// Every other intrinsic — kind, status, name, duration,
+	// statusMessage, trace/span IDs, parent, nested-set positions,
+	// trace-scoped values (rootName / rootServiceName /
+	// traceDuration), instrumentation:name/version — is an
+	// always-present value in reference Tempo (required parquet
+	// columns + unconditional collector statics), so the existence
+	// probe is TRUE for every span.
+	return &chplan.LitBool{V: true}, nil
 }
 
 // fieldExprAttribute unwraps a FieldExpression into its Attribute when

--- a/internal/traceql/metrics_pipeline.go
+++ b/internal/traceql/metrics_pipeline.go
@@ -364,7 +364,7 @@ func lowerMetricsGroupBy(attrs []traceql.Attribute, s schema.Traces) ([]chplan.E
 		if err != nil {
 			return nil, nil, nil, err
 		}
-		exprs = append(exprs, expr)
+		exprs = append(exprs, wireNormalizeGroupValue(a, expr))
 		// SQL alias is the bare attribute path (`a.Name` is set by
 		// traceql.NewAttribute / NewScopedAttribute / NewIntrinsic to
 		// either the carrier-map key, e.g. `service.name`, or the
@@ -378,4 +378,23 @@ func lowerMetricsGroupBy(attrs []traceql.Attribute, s schema.Traces) ([]chplan.E
 		display = append(display, a.String())
 	}
 	return exprs, aliases, display, nil
+}
+
+// wireNormalizeGroupValue maps a group-by expression's ClickHouse
+// payload to reference Tempo's wire form for the enum-typed
+// intrinsics. OTel-CH stores TitleCase enum words for SpanKind /
+// StatusCode ("Server", "Unspecified", "Error") while reference
+// Tempo renders group-by label values through
+// `Static.EncodeToString` — lowercase "server" / "unspecified" /
+// "error" (pkg/traceql engine.go AsAnyValue → EncodeToString; Kind /
+// Status stringers in enum_statics.go). Wrapping the group expression
+// in `lower(...)` makes both the GROUP BY key and the projected label
+// value match reference. Mirrors classifySelectedProjection's
+// treatment of the same columns on the `| select(...)` path.
+func wireNormalizeGroupValue(a traceql.Attribute, e chplan.Expr) chplan.Expr {
+	switch a.Intrinsic {
+	case traceql.IntrinsicKind, traceql.IntrinsicStatus:
+		return &chplan.FuncCall{Name: "lower", Args: []chplan.Expr{e}}
+	}
+	return e
 }

--- a/internal/traceql/nested_set_nil_test.go
+++ b/internal/traceql/nested_set_nil_test.go
@@ -168,9 +168,14 @@ func TestLower_RootIdiomLiteralVariants(t *testing.T) {
 	}
 }
 
-// TestLower_NilComparisonRejections pins the unsupported nil-comparison
-// operands: intrinsics (always materialised in OTel-CH) and link/event
-// scopes (Nested columns need the arrayExists shape, not mapContains).
+// TestLower_NilComparisonRejections pins the nil-comparison forms
+// reference Tempo itself rejects — and ONLY those. Reference
+// validation (pkg/traceql/ast_validate.go UnaryOperation.validate)
+// rejects `= nil` on every intrinsic and on resource.service.name;
+// vparquet4's checkConditions errors on any childCount condition.
+// Everything else — including `!= nil` on intrinsics, which the
+// Traces Drilldown app stamps on every intrinsic breakdown groupBy —
+// must lower (see TestLower_NilComparisonSemantics).
 func TestLower_NilComparisonRejections(t *testing.T) {
 	t.Parallel()
 
@@ -181,14 +186,29 @@ func TestLower_NilComparisonRejections(t *testing.T) {
 		wantSub string
 	}{
 		{
-			name:    "intrinsic_always_present",
-			query:   `{ name != nil }`,
-			wantSub: "intrinsic",
+			name:    "intrinsic_eq_nil_kind",
+			query:   `{ kind = nil }`,
+			wantSub: "intrinsics cannot be nil",
 		},
 		{
-			name:    "event_scope_unsupported",
-			query:   `{ event.message != nil }`,
-			wantSub: "unsupported",
+			name:    "intrinsic_eq_nil_name",
+			query:   `{ name = nil }`,
+			wantSub: "intrinsics cannot be nil",
+		},
+		{
+			name:    "intrinsic_eq_nil_literal_first",
+			query:   `{ nil = status }`,
+			wantSub: "intrinsics cannot be nil",
+		},
+		{
+			name:    "resource_service_name_eq_nil",
+			query:   `{ resource.service.name = nil }`,
+			wantSub: "resource.service.name cannot be nil",
+		},
+		{
+			name:    "child_count_not_nil",
+			query:   `{ span:childCount != nil }`,
+			wantSub: "child counts",
 		},
 	}
 	for _, tc := range cases {
@@ -204,6 +224,67 @@ func TestLower_NilComparisonRejections(t *testing.T) {
 			}
 			if !strings.Contains(err.Error(), tc.wantSub) {
 				t.Errorf("Lower(%q) error %q does not contain %q", tc.query, err, tc.wantSub)
+			}
+		})
+	}
+}
+
+// TestLower_NilComparisonSemantics pins the lowered predicate for every
+// accepted nil-comparison shape, derived from reference Tempo:
+//
+//   - `<intrinsic> != nil` is TRUE for every span (vparquet4 stores
+//     intrinsics as required parquet columns and the span collector
+//     adds the static unconditionally — kind=SPAN_KIND_UNSPECIFIED,
+//     empty name, and unset status all still satisfy `!= nil`).
+//   - attribute `!= nil` / `= nil` probe the scope's attribute map.
+//   - event./link. attribute probes quantify over the Nested elements
+//     (≥1 element carrying / lacking the key).
+//   - nested intrinsics (event:name / link:traceID) probe element
+//     presence (≥1 event / ≥1 link).
+func TestLower_NilComparisonSemantics(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelTraces()
+	cases := []struct {
+		query         string
+		wantPredicate string
+	}{
+		// Intrinsics: constant TRUE — pinned for each intrinsic the
+		// Traces Drilldown breakdown tab group-bys on.
+		{`{ kind != nil }`, `true`},
+		{`{ status != nil }`, `true`},
+		{`{ name != nil }`, `true`},
+		{`{ duration != nil }`, `true`},
+		{`{ statusMessage != nil }`, `true`},
+		{`{ nil != kind }`, `true`},
+		{`{ nestedSetParent != nil }`, `true`},
+		// Attribute scopes: map-key existence on the scope carrier.
+		{`{ span.http.method != nil }`, `mapContains(SpanAttributes, "http.method")`},
+		{`{ resource.service.name != nil }`, `mapContains(ResourceAttributes, "service.name")`},
+		{`{ span.http.method = nil }`, `not(mapContains(SpanAttributes, "http.method"))`},
+		// Event / link attributes: per-element key probes.
+		{`{ event.message != nil }`, `nestedArrayExists(Events.Attributes hasKey "message")`},
+		{`{ event.message = nil }`, `nestedArrayExists(Events.Attributes lacksKey "message")`},
+		{`{ link.opentracing.ref_type != nil }`, `nestedArrayExists(Links.Attributes hasKey "opentracing.ref_type")`},
+		// Nested intrinsics: element presence.
+		{`{ event:name != nil }`, `nestedArrayNotEmpty(Events.Name)`},
+		{`{ link:traceID != nil }`, `nestedArrayNotEmpty(Links.TraceId)`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.query, func(t *testing.T) {
+			t.Parallel()
+			expr, err := tempo.Parse(tc.query)
+			if err != nil {
+				t.Fatalf("Parse(%q): %v", tc.query, err)
+			}
+			plan, err := traceql.Lower(context.Background(), expr, s)
+			if err != nil {
+				t.Fatalf("Lower(%q): %v — reference Tempo accepts this nil comparison", tc.query, err)
+			}
+			printed := spec.PrintChplan(plan)
+			want := "Filter predicate=" + tc.wantPredicate + "\n"
+			if !strings.Contains(printed, want) {
+				t.Errorf("Lower(%q) plan:\n%s\nwant a filter with %s", tc.query, printed, want)
 			}
 		})
 	}

--- a/test/spec/chplan_print.go
+++ b/test/spec/chplan_print.go
@@ -445,6 +445,20 @@ func printExpr(e chplan.Expr) string {
 		}
 		return fmt.Sprintf("lineContent(%s, %q, %s)", printExpr(v.Source), v.Pattern, flags)
 	case *chplan.NestedArrayExists:
+		switch v.Presence {
+		case chplan.PresenceHasKey:
+			if v.Key == "" {
+				return fmt.Sprintf("nestedArrayNotEmpty(%s.%s)", v.Column, v.SubField)
+			}
+			return fmt.Sprintf("nestedArrayExists(%s.%s hasKey %q)",
+				v.Column, v.SubField, v.Key)
+		case chplan.PresenceLacksKey:
+			if v.Key == "" {
+				return fmt.Sprintf("nestedArrayEmpty(%s.%s)", v.Column, v.SubField)
+			}
+			return fmt.Sprintf("nestedArrayExists(%s.%s lacksKey %q)",
+				v.Column, v.SubField, v.Key)
+		}
 		if v.Key == "" {
 			// Direct-subfield comparison (nested intrinsics like
 			// event:name → Events.Name) — no map-key lookup.

--- a/test/spec/traceql/by_intrinsic_and_attr.txtar
+++ b/test/spec/traceql/by_intrinsic_and_attr.txtar
@@ -1,7 +1,7 @@
 -- query.traceql --
 {} | count_over_time() by (kind, resource.service.name)
 -- sql --
-SELECT `SpanKind` AS `kind`, `ResourceAttributes`[?] AS `service.name`, toFloat64(count(?)) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE ?) GROUP BY `SpanKind`, `ResourceAttributes`[?]
+SELECT lower(`SpanKind`) AS `kind`, `ResourceAttributes`[?] AS `service.name`, toFloat64(count(?)) AS `Value` FROM (SELECT * FROM `otel_traces` WHERE ?) GROUP BY lower(`SpanKind`), `ResourceAttributes`[?]
 -- args --
 [0] string = "service.name"
 [1] int64 = 1
@@ -19,9 +19,9 @@ INSERT INTO otel_traces VALUES
     (map('service.name', 'frontend'), 'Client');
 -- expected_rows --
 [
-  ["Client", "frontend", 4]
+  ["client", "frontend", 4]
 ]
 -- chplan --
-MetricsAggregate op=count_over_time groupBy=[SpanKind AS kind, ResourceAttributes["service.name"] AS service.name|resource.service.name] valueAlias=Value
+MetricsAggregate op=count_over_time groupBy=[lower(SpanKind) AS kind, ResourceAttributes["service.name"] AS service.name|resource.service.name] valueAlias=Value
   Filter predicate=true
     Scan(otel_traces)

--- a/test/spec/traceql/drilldown_breakdown_kind_rate.txtar
+++ b/test/spec/traceql/drilldown_breakdown_kind_rate.txtar
@@ -1,0 +1,29 @@
+-- query.traceql --
+{nestedSetParent<0 && true && kind != nil} | rate() by(kind)
+-- sql --
+SELECT lower(`SpanKind`) AS `kind`, toFloat64(count(?)) AS `Value` FROM (SELECT * FROM `otel_traces` PREWHERE (`ParentSpanId` = ?) AND ? WHERE ?) GROUP BY lower(`SpanKind`)
+-- args --
+[0] int64 = 1
+[1] string = ""
+[2] bool = true
+[3] bool = true
+-- seed --
+CREATE TABLE otel_traces (
+    SpanId String,
+    ParentSpanId String,
+    SpanKind LowCardinality(String)
+) ENGINE = MergeTree ORDER BY SpanId;
+INSERT INTO otel_traces (SpanId, ParentSpanId, SpanKind) VALUES
+    ('aaaa', '', 'Server'),
+    ('bbbb', '', 'Server'),
+    ('cccc', '', 'Unspecified'),
+    ('dddd', 'aaaa', 'Client');
+-- expected_rows --
+[
+  ["server", 2],
+  ["unspecified", 1]
+]
+-- chplan --
+MetricsAggregate op=rate groupBy=[lower(SpanKind) AS kind] valueAlias=Value
+  Filter predicate=(((ParentSpanId = "") AND true) AND true)
+    Scan(otel_traces)

--- a/test/spec/traceql/event_attr_eq_nil.txtar
+++ b/test/spec/traceql/event_attr_eq_nil.txtar
@@ -1,0 +1,19 @@
+-- query.traceql --
+{ event.exception.type = nil }
+-- sql --
+SELECT * FROM `otel_traces` WHERE arrayExists(x -> not(mapContains(x, ?)), `Events`.`Attributes`)
+-- args --
+[0] string = "exception.type"
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    `Events.Attributes` Array(Map(String, String)) MATERIALIZED if(_idx = 0, [map('exception.type', 'IOError')], if(_idx = 1, [map('name', 'log')], []))
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1), (2);
+-- expected_rows --
+[
+  [1]
+]
+-- chplan --
+Filter predicate=nestedArrayExists(Events.Attributes lacksKey "exception.type")
+  Scan(otel_traces)

--- a/test/spec/traceql/event_attr_not_nil.txtar
+++ b/test/spec/traceql/event_attr_not_nil.txtar
@@ -1,0 +1,19 @@
+-- query.traceql --
+{ event.exception.type != nil }
+-- sql --
+SELECT * FROM `otel_traces` WHERE arrayExists(x -> mapContains(x, ?), `Events`.`Attributes`)
+-- args --
+[0] string = "exception.type"
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    `Events.Attributes` Array(Map(String, String)) MATERIALIZED if(_idx = 0, [map('exception.type', 'IOError')], if(_idx = 1, [map('name', 'log')], []))
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1), (2);
+-- expected_rows --
+[
+  [0]
+]
+-- chplan --
+Filter predicate=nestedArrayExists(Events.Attributes hasKey "exception.type")
+  Scan(otel_traces)

--- a/test/spec/traceql/event_name_not_nil.txtar
+++ b/test/spec/traceql/event_name_not_nil.txtar
@@ -1,0 +1,20 @@
+-- query.traceql --
+{ event:name != nil }
+-- sql --
+SELECT * FROM `otel_traces` WHERE notEmpty(`Events`.`Name`)
+-- args --
+(none)
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    `Events.Name` Array(LowCardinality(String)) MATERIALIZED if(_idx = 0, ['exception'], if(_idx = 1, ['log', 'retry'], []))
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1), (2);
+-- expected_rows --
+[
+  [0],
+  [1]
+]
+-- chplan --
+Filter predicate=nestedArrayNotEmpty(Events.Name)
+  Scan(otel_traces)

--- a/test/spec/traceql/intrinsic_not_nil_kind.txtar
+++ b/test/spec/traceql/intrinsic_not_nil_kind.txtar
@@ -1,0 +1,24 @@
+-- query.traceql --
+{ kind != nil }
+-- sql --
+SELECT * FROM `otel_traces` WHERE ?
+-- args --
+[0] bool = true
+-- seed --
+CREATE TABLE otel_traces (
+    SpanId String,
+    SpanKind LowCardinality(String)
+) ENGINE = MergeTree ORDER BY SpanId;
+INSERT INTO otel_traces (SpanId, SpanKind) VALUES
+    ('aaaa', 'Server'),
+    ('bbbb', 'Unspecified'),
+    ('cccc', 'Client');
+-- expected_rows --
+[
+  ["aaaa", "Server"],
+  ["bbbb", "Unspecified"],
+  ["cccc", "Client"]
+]
+-- chplan --
+Filter predicate=true
+  Scan(otel_traces)

--- a/test/spec/traceql/link_traceid_not_nil.txtar
+++ b/test/spec/traceql/link_traceid_not_nil.txtar
@@ -1,0 +1,19 @@
+-- query.traceql --
+{ link:traceID != nil }
+-- sql --
+SELECT * FROM `otel_traces` WHERE notEmpty(`Links`.`TraceId`)
+-- args --
+(none)
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    `Links.TraceId` Array(String) MATERIALIZED if(_idx = 0, ['aaaabbbbccccddddaaaabbbbccccdddd'], [])
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1);
+-- expected_rows --
+[
+  [0]
+]
+-- chplan --
+Filter predicate=nestedArrayNotEmpty(Links.TraceId)
+  Scan(otel_traces)


### PR DESCRIPTION
## Summary

Maintainer-reported live bug: Traces Drilldown's breakdown groupBy appends `&& <groupBy> != nil` to every query; cerberus's deliberate "nil comparison on intrinsic is unsupported" 422 broke every intrinsic groupBy — a wrong belief about reference behavior pinned as a contract.

## Reference semantics implemented (cited from the fork source, proven live)

- `x != nil` is `OpExists`; intrinsics are **required** parquet fields added unconditionally by the span collector, so `<intrinsic> != nil` matches **every span including `SPAN_KIND_UNSPECIFIED`** — constant TRUE, not an enum-zero check (proven by the `kind_not_nil_unspecified_carrier` corpus case against live reference).
- The only rejections reference itself makes — and the only ones kept, reference-worded: `<intrinsic> = nil`, `resource.service.name = nil`, childCount conditions.
- Attributes: `!= nil` ≡ key exists, `= nil` ≡ key absent; event/link scopes quantify per Nested element; nested intrinsics (`event:name`, `link:traceID/spanID`) `!= nil` ≡ ≥1 element.

## Changes

- `lowerNilComparison`/`lowerIntrinsicNilComparison` in the traceql lowering; new `Presence` mode on `NestedArrayExists` (`arrayExists(mapContains)` / `notEmpty`) for event/link attribute existence; instrumentation-scope probes reject like value comparisons instead of silently reading SpanAttributes.
- **Bonus pre-existing parity bug fixed**: `by(kind)`/`by(status)` wire labels were OTel-CH TitleCase (`Server`); reference encodes lowercase (`server`/`unspecified`/`error`) — group values now wrap in `lower()`.
- Compat seeder gains a `SPAN_KIND_UNSPECIFIED` carrier to pin the boundary.

## Verification

- Verbatim maintainer repro through `/api/metrics/query_range` (chdb): 200 with `kind=server`/`kind=unspecified` series, dense grids.
- **Live differential vs reference Tempo: 48/48 (100%)** including all 8 new nil-comparison cases.
- 6 new TXTAR chdb roundtrips; rejection tests rewritten to pin only reference-rejected forms (15 accepted shapes pinned positively); 4139+ tests green; no showcase/inventory flips needed (verified — no error-pins covered nil shapes).

## Caveats

Nil on computed expressions (`span.a + 1 != nil`) stays rejected (no consumer issues it; needs arithmetic nil-propagation); unscoped-attribute existence keeps the pre-existing span-carrier resolution.

Closes task #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
