### PR TITLE
test(consumer-corpus): replay real Grafana request shapes through in-process handlers

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -71,10 +71,12 @@ spec-chdb:
     go test -tags chdb -count=1 ./test/spec/...
 
 # Run the chDB-tagged handler tests under internal/api/... plus the
-# chclienttest package itself. Same prerequisite as spec-chdb (libchdb
-# at the default install path). Mirrors the `chdb` CI job.
+# chclienttest package itself and the consumer-corpus replay lane
+# (test/consumer-corpus — captured Grafana request shapes executed
+# through chDB seeds). Same prerequisite as spec-chdb (libchdb at the
+# default install path). Mirrors the `chdb` CI job.
 test-chdb:
-    go test -tags chdb -count=1 ./internal/chclienttest/... ./internal/api/...
+    go test -tags chdb -count=1 ./internal/chclienttest/... ./internal/api/... ./test/consumer-corpus/...
 
 # Run the chDB-tagged property tests (rapid + from-scratch oracle).
 # Requires libchdb.so (see `just chdb-install`). Local default is rapid's

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -25,6 +25,7 @@ inside each layer.
 | 6b    | LogQL chDB roundtrip                | `test/spec/logql/*.txtar`                                                                         | Same as 6a for LogQL                                                                                                 | Same as 6a                                                                  |
 | 6c    | TraceQL chDB roundtrip              | `test/spec/traceql/*.txtar`                                                                       | Same as 6a for TraceQL                                                                                               | Same as 6a                                                                  |
 | 7     | HTTP handler conformance            | `internal/api/{prom,loki,tempo}/conformance_test.go`                                              | Wire-format drift, error envelope shape, header pins, range-param parsing, admission control                         | Real-network failure modes (Layer 10) and UX flows (Layer 9)                |
+| 7b    | Consumer-corpus replay              | `test/consumer-corpus/`                                                                           | Consumer-decode drift on captured Grafana request shapes (proto envelopes, bare JSON, drilldown queries)             | Shapes Grafana hasn't been observed sending — crawler mines captures        |
 | 8     | System / process lifecycle          | `internal/config/`, `internal/api/health/`, `cmd/cerberus/`, `internal/telemetry/`, `schema/ddl/` | Env-var contract, `/readyz` TTL coalescing, OTel telemetry attributes, signal-driven shutdown                        | Cross-process behaviour — Compose / k3d (Layer 9)                           |
 | 9     | Playwright UX flows                 | `test/e2e/playwright/*.spec.ts`                                                                   | Grafana Explore / Logs / Trace panel request sequences against cerberus's three datasource APIs                      | Pure backend logic — Layers 1–8                                             |
 | 10    | Chaos / failure-mode                | `internal/{chclient,api/{prom,loki,tempo,admit}}/chaos_test.go`, `test/regression/goleak_test.go` | CH-failure, mid-stream cursor faults, goroutine leaks, panic-mid-handler slot release, CH-disconnect circuit breaker | Long-tail platform-specific failures                                        |
@@ -34,10 +35,10 @@ inside each layer.
 
 | Gate                          | Workflow                                       | Trigger                            | Required PR check? | Scope                                                                                                             |
 | ----------------------------- | ---------------------------------------------- | ---------------------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------- |
-| `check`                       | `.github/workflows/ci.yml` (job `check`)       | PRs + push                         | Required           | `go test -race -cover ./...` (Layers 1, 2a, 2b, 3, 4, 5, 7, 8, 10 default)                                        |
+| `check`                       | `.github/workflows/ci.yml` (job `check`)       | PRs + push                         | Required           | `go test -race -cover ./...` (Layers 1, 2a, 2b, 3, 4, 5, 7, 7b stub lane, 8, 10 default)                          |
 | `lint`                        | `.github/workflows/ci.yml` (job `lint`)        | PRs + push                         | Required           | `golangci-lint` v2 + markdownlint + commitlint                                                                    |
 | `forbid-skip`                 | `.github/workflows/ci.yml` (job `forbid-skip`) | PRs + push                         | Required           | `t.Skip*` + discipline-erosion wording + soft-assertion + skip-additions                                          |
-| `probe`                       | `.github/workflows/chdb.yml` (job `probe`)     | PRs + push                         | Required           | chDB driver sanity (`TestChDBProbe`)                                                                              |
+| `probe`                       | `.github/workflows/chdb.yml` (job `probe`)     | PRs + push                         | Required           | chDB driver sanity (`TestChDBProbe`) + `just test-chdb` (api handler chdb tests, Layer 7b chdb lane)              |
 | `roundtrip (<ql>)`            | `.github/workflows/chdb.yml` matrix            | PRs + push                         | Required           | TXTAR chDB roundtrip for promql / logql / traceql (Layer 6a-c)                                                    |
 | `compatibility/<head>`        | `.github/workflows/compatibility.yml` matrix   | PRs + push + nightly               | Required           | Differential vs reference Prom / Loki / Tempo                                                                     |
 | `dashboard` (E2E)             | `.github/workflows/e2e.yml` (job `dashboard`)  | push-to-main + nightly + manual    | Informational      | k3d + cerberus + Grafana + Playwright (Layer 9)                                                                   |
@@ -121,6 +122,40 @@ to verify locally without rewriting.
 documented HTTP endpoint with representative payloads and asserts the
 wire envelope shape (`status`, `data.resultType`, content keys),
 response headers, error envelope, and admission-control 503 + `Retry-After`.
+
+### Layer 7b — Consumer-corpus replay
+
+`test/consumer-corpus/` is the shift-left lane for consumer-contract
+bugs: a corpus of REAL request shapes Grafana sends
+(`grafana-<version>/*.json`, one entry per file with provenance,
+the Grafana-side request, and per-entry expectations), replayed
+against the in-process handlers and decoded EXACTLY as the consumer
+decodes — strict gogo/proto unmarshal into `tempopb` types for the
+Tempo proto endpoints, bare logproto-shaped JSON for Loki, Prom API
+envelopes for Prometheus. The 2026-06 incident week (bare `Trace` vs
+`TraceByIDResponse` #764, enveloped `detected_fields` #774, missing
+`spanSets` #770, drilldown `<groupBy> != nil` 422s, blank regex
+`__name__` breakdowns #769) was only caught by the e2e browser stack;
+every one of those is reproducible here at unit cost.
+
+Two lanes share the corpus: the default-tag lane (runs in `check`)
+backs handlers with canned-row stubs and pins routing, status, and
+consumer decodability; the `chdb`-tagged lane (runs in the chdb
+workflow's `probe` job via `just test-chdb`) executes the full
+parse → lower → optimize → emit → chDB pipeline over small seeds and
+additionally evaluates each entry's data predicates. A ratchet
+meta-test forbids corpus shrink (total + per-datasource entry floors
+are raise-only) and rejects entries naming decoders / predicates /
+stub fixtures the harness doesn't implement.
+
+Division of labour with Layers 7 and 9: Layer 7 pins cerberus's OWN
+wire contract endpoint by endpoint; Layer 7b pins what GRAFANA
+actually sends and reads, request by captured request. The e2e
+crawler and drilldown specs (Layer 9) are the corpus MINERS — when a
+Grafana bump introduces a new request shape, capture it into a new
+version-keyed corpus directory rather than widening assertions in
+place. Known-unfixed bugs stay as failing entries (never tolerated,
+never allow-listed): a red corpus entry is the layer doing its job.
 
 ### Layer 8 — System / process lifecycle
 

--- a/test/consumer-corpus/corpus.go
+++ b/test/consumer-corpus/corpus.go
@@ -1,0 +1,193 @@
+package consumercorpus
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// Entry is one captured consumer request shape plus the contract its
+// consumer enforces on the response.
+type Entry struct {
+	// Name is the unique entry identifier (kebab-case, used as the
+	// subtest name). Must match the file's base name without .json.
+	Name string `json:"name"`
+	// Datasource routes the entry to the right handler: "prom",
+	// "loki", or "tempo".
+	Datasource string `json:"datasource"`
+	// Consumer names the exact Grafana code path that issues this
+	// request and decodes its response (plugin + version surface).
+	Consumer string `json:"consumer"`
+	// Provenance records where the shape was captured from — live
+	// stack, spec file, upstream app source — one string per line.
+	Provenance []string `json:"provenance"`
+	// GrafanaRequest is the Grafana-side request that produced this
+	// downstream request (e.g. the /api/ds/query body, or the
+	// drilldown app URL). Informational but mandatory: it ties the
+	// entry back to the consumer behaviour it pins.
+	GrafanaRequest map[string]any `json:"grafana_request"`
+	// Request is the HTTP request cerberus receives.
+	Request RequestSpec `json:"request"`
+	// Stub names the canned-row fixture the default (stub) lane backs
+	// the handler with. See stub.go for the fixture registry.
+	Stub string `json:"stub"`
+	// Expect declares the consumer contract.
+	Expect Expect `json:"expect"`
+
+	// Version is the corpus directory the entry was loaded from
+	// (e.g. "grafana-12.2.9"). Populated by Load, not by the file.
+	Version string `json:"-"`
+}
+
+// RequestSpec is the wire request cerberus receives. Query values and
+// the path may carry ${TOKEN} placeholders (e.g. ${START_UNIX},
+// ${TRACE_ID}) that each replay lane expands against its own seed
+// anchors — see replay.go.
+type RequestSpec struct {
+	Method  string            `json:"method"`
+	Path    string            `json:"path"`
+	Query   map[string]string `json:"query,omitempty"`
+	Headers map[string]string `json:"headers,omitempty"`
+}
+
+// Expect declares the per-entry consumer contract.
+type Expect struct {
+	// Status is the expected HTTP status (0 means 200).
+	Status int `json:"status,omitempty"`
+	// Decode names the consumer decoder from the registry in
+	// replay.go. The decode itself is an assertion: it mirrors the
+	// exact unmarshal the consumer performs and fails on drift.
+	Decode string `json:"decode"`
+	// Wire predicates run in BOTH lanes — they must hold for the
+	// stub fixture's canned rows as well as for the chdb seed.
+	Wire []string `json:"wire,omitempty"`
+	// Data predicates run in the chdb lane only — they assert
+	// data-bearing properties the stub lane's canned rows don't
+	// faithfully reproduce (row counts through real SQL, value
+	// sanity through real execution).
+	Data []string `json:"data,omitempty"`
+}
+
+// versionDirRE pins the version-keyed directory convention.
+var versionDirRE = regexp.MustCompile(`^grafana-\d+\.\d+\.\d+$`)
+
+// validDatasources is the closed set of handler routes.
+var validDatasources = map[string]bool{"prom": true, "loki": true, "tempo": true}
+
+// Load reads every corpus entry under dir (each version-keyed
+// subdirectory), strictly decoding and validating each file. The
+// returned slice is sorted by (version, name) for deterministic
+// iteration.
+func Load(dir string) ([]Entry, error) {
+	versions, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("consumercorpus: read corpus root %s: %w", dir, err)
+	}
+	var entries []Entry
+	seen := map[string]bool{}
+	for _, v := range versions {
+		if !v.IsDir() {
+			continue
+		}
+		if !versionDirRE.MatchString(v.Name()) {
+			return nil, fmt.Errorf("consumercorpus: corpus subdirectory %q does not match the version-keyed convention %s", v.Name(), versionDirRE)
+		}
+		files, err := os.ReadDir(filepath.Join(dir, v.Name()))
+		if err != nil {
+			return nil, fmt.Errorf("consumercorpus: read version dir %s: %w", v.Name(), err)
+		}
+		for _, f := range files {
+			if f.IsDir() || !strings.HasSuffix(f.Name(), ".json") {
+				return nil, fmt.Errorf("consumercorpus: %s/%s is not a corpus entry (.json files only)", v.Name(), f.Name())
+			}
+			path := filepath.Join(dir, v.Name(), f.Name())
+			e, err := loadEntry(path)
+			if err != nil {
+				return nil, err
+			}
+			e.Version = v.Name()
+			key := e.Version + "/" + e.Name
+			if seen[key] {
+				return nil, fmt.Errorf("consumercorpus: duplicate entry name %s", key)
+			}
+			seen[key] = true
+			if want := strings.TrimSuffix(f.Name(), ".json"); e.Name != want {
+				return nil, fmt.Errorf("consumercorpus: %s: entry name %q must match file base name %q", path, e.Name, want)
+			}
+			entries = append(entries, e)
+		}
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Version != entries[j].Version {
+			return entries[i].Version < entries[j].Version
+		}
+		return entries[i].Name < entries[j].Name
+	})
+	return entries, nil
+}
+
+// loadEntry strictly decodes and validates one corpus file.
+func loadEntry(path string) (Entry, error) {
+	buf, err := os.ReadFile(path)
+	if err != nil {
+		return Entry{}, fmt.Errorf("consumercorpus: read %s: %w", path, err)
+	}
+	dec := json.NewDecoder(bytes.NewReader(buf))
+	dec.DisallowUnknownFields()
+	var e Entry
+	if err := dec.Decode(&e); err != nil {
+		return Entry{}, fmt.Errorf("consumercorpus: decode %s: %w", path, err)
+	}
+	if err := e.validate(); err != nil {
+		return Entry{}, fmt.Errorf("consumercorpus: %s: %w", path, err)
+	}
+	return e, nil
+}
+
+// validate enforces the per-entry schema invariants the ratchet
+// meta-test relies on.
+func (e Entry) validate() error {
+	switch {
+	case e.Name == "":
+		return fmt.Errorf("name is required")
+	case !validDatasources[e.Datasource]:
+		return fmt.Errorf("datasource %q must be one of prom/loki/tempo", e.Datasource)
+	case e.Consumer == "":
+		return fmt.Errorf("consumer is required")
+	case len(e.Provenance) == 0:
+		return fmt.Errorf("provenance is required — every entry must say where its shape was captured from")
+	case len(e.GrafanaRequest) == 0:
+		return fmt.Errorf("grafana_request is required — every entry must carry the Grafana-side request that produced it")
+	case e.Request.Method == "":
+		return fmt.Errorf("request.method is required")
+	case e.Request.Path == "":
+		return fmt.Errorf("request.path is required")
+	case e.Stub == "":
+		return fmt.Errorf("stub fixture name is required (use \"empty\" when the wire contract needs no canned rows)")
+	case e.Expect.Decode == "":
+		return fmt.Errorf("expect.decode is required — an entry that doesn't decode as its consumer pins nothing")
+	}
+	for _, p := range append(append([]string{}, e.Expect.Wire...), e.Expect.Data...) {
+		if _, _, err := splitPredicate(p); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// splitPredicate parses "name" or "name:arg" predicate strings.
+func splitPredicate(p string) (name, arg string, err error) {
+	if p == "" {
+		return "", "", fmt.Errorf("empty predicate")
+	}
+	name, arg, _ = strings.Cut(p, ":")
+	if name == "" {
+		return "", "", fmt.Errorf("predicate %q has no name", p)
+	}
+	return name, arg, nil
+}

--- a/test/consumer-corpus/corpus.go
+++ b/test/consumer-corpus/corpus.go
@@ -131,9 +131,12 @@ func Load(dir string) ([]Entry, error) {
 	return entries, nil
 }
 
-// loadEntry strictly decodes and validates one corpus file.
+// loadEntry strictly decodes and validates one corpus file. The path
+// is always a ReadDir-enumerated name joined under the embedded corpus
+// root (never caller input) — restated via Clean so gosec G304 can see
+// the containment.
 func loadEntry(path string) (Entry, error) {
-	buf, err := os.ReadFile(path)
+	buf, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
 		return Entry{}, fmt.Errorf("consumercorpus: read %s: %w", path, err)
 	}

--- a/test/consumer-corpus/doc.go
+++ b/test/consumer-corpus/doc.go
@@ -1,0 +1,50 @@
+// Package consumercorpus is the consumer-contract replay layer: a
+// corpus of REAL request shapes Grafana sends to cerberus's three
+// datasource APIs, replayed against the in-process HTTP handlers and
+// decoded EXACTLY as the consumer decodes them (strict gogo/protobuf
+// unmarshal into tempopb types for the Tempo proto endpoints, bare
+// logproto-shaped JSON for Loki, Prom API envelopes for Prometheus).
+//
+// Why this layer exists: a week of incidents (2026-06) showed that
+// consumer-contract bugs — /api/v2/traces serving a bare Trace where
+// Grafana 12 strict-decodes a TraceByIDResponse envelope (#764),
+// detected_fields wrapped in a query envelope where Grafana reads
+// top-level `fields` (#774), /api/search omitting spanSets (#770),
+// Traces Drilldown breakdown queries 422ing on `<groupBy> != nil` —
+// were only caught by the e2e browser stack (minutes per run, needs
+// k3d/compose). Every one of them is detectable in-process at unit
+// cost: replay the captured request, decode as the consumer, assert
+// the contract. This package does exactly that, in two lanes:
+//
+//   - replay_test.go (default build tags, runs in the `check` CI
+//     lane): handlers are backed by canned-row stub queriers, so the
+//     lane pins routing, status codes, envelope/wire shapes, and
+//     consumer decodability.
+//   - replay_chdb_test.go (`chdb` build tag, runs in the chdb CI
+//     lane via `just test-chdb`): handlers are backed by a seeded
+//     chDB session, so the lane additionally pins data-bearing
+//     predicates (non-empty results, value sanity) through the full
+//     parse → lower → optimize → emit → execute pipeline.
+//
+// # Corpus layout and refresh flow
+//
+// Corpus entries live in version-keyed directories named after the
+// Grafana release whose request shapes they capture:
+//
+//	test/consumer-corpus/grafana-12.2.9/*.json
+//
+// Each file is ONE entry: the request cerberus receives, the
+// Grafana-side request that produced it (provenance), and the
+// per-entry expectations (status, consumer decoder, wire predicates,
+// chdb-only data predicates). See corpus.go for the schema.
+//
+// Refresh flow: the corpus is a snapshot, mined from live stacks.
+// The e2e crawler (test/e2e/playwright/crawl/) and the drilldown
+// specs are the corpus miners — when they observe a new request
+// shape Grafana sends (typically after a Grafana version bump), the
+// shape is captured into a NEW version-keyed directory
+// (grafana-<next-version>/) and the old directory stays as long as
+// that Grafana version is supported by the e2e stacks. The ratchet
+// meta-test (ratchet_test.go) forbids shrinking the corpus: entry
+// counts may only grow, and per-datasource minimums are pinned.
+package consumercorpus

--- a/test/consumer-corpus/grafana-12.2.9/detected-fields.json
+++ b/test/consumer-corpus/grafana-12.2.9/detected-fields.json
@@ -1,0 +1,45 @@
+{
+  "name": "detected-fields",
+  "datasource": "loki",
+  "consumer": "Grafana 12.2.9 Logs Drilldown (grafana-lokiexplore-app) fields badge + breakdown — reads body.fields at the TOP level",
+  "provenance": [
+    "Captured from the live compose stack during the 'Fields: 0' incident (#774): Logs Drilldown",
+    "(and the Loki datasource's detected-fields side panel) calls /loki/api/v1/detected_fields with",
+    "query + limit + line_limit and reads `fields` at the TOP level — upstream Loki serializes",
+    "logproto.DetectedFieldsResponse BARE (pkg/util/marshal WriteDetectedFieldsResponseJSON), with",
+    "NO {status, data} envelope. Cerberus once wrapped the payload in the query-API envelope; every",
+    "drilldown service page then showed zero fields while the request returned 200 — invisible to",
+    "status-code oracles.",
+    "Shape reconstructed from test/e2e/playwright/loki_ux.spec.ts (detected fields test) and",
+    "internal/api/loki/detected_fields_chdb_test.go."
+  ],
+  "grafana_request": {
+    "path": "GET /api/datasources/proxy/uid/cerberus-loki/loki/api/v1/detected_fields",
+    "query": {
+      "query": "{service_name=\"api\"}",
+      "limit": "1000",
+      "line_limit": "1000",
+      "start": "${START_NS}",
+      "end": "${END_NS}"
+    }
+  },
+  "request": {
+    "method": "GET",
+    "path": "/loki/api/v1/detected_fields",
+    "query": {
+      "query": "{service_name=\"api\"}",
+      "limit": "1000",
+      "line_limit": "1000",
+      "start": "${START_NS}",
+      "end": "${END_NS}"
+    },
+    "headers": {}
+  },
+  "stub": "loki-detected-fields",
+  "expect": {
+    "status": 200,
+    "decode": "loki-detected-fields",
+    "wire": ["fields-min:1", "fields-shape", "field-typed:duration=duration"],
+    "data": ["fields-min:3", "field-typed:detected_level=string"]
+  }
+}

--- a/test/consumer-corpus/grafana-12.2.9/drilldown-breakdown-rate-by-kind.json
+++ b/test/consumer-corpus/grafana-12.2.9/drilldown-breakdown-rate-by-kind.json
@@ -1,0 +1,46 @@
+{
+  "name": "drilldown-breakdown-rate-by-kind",
+  "datasource": "tempo",
+  "consumer": "Grafana 12.2.9 Traces Drilldown (grafana-exploretraces-app 2.0.4) Breakdown tab — rate() by(kind) bar charts",
+  "provenance": [
+    "Maintainer-captured from the live compose stack (2026-06-10): the Breakdown tab stamps",
+    "{nestedSetParent<0 && true && <groupBy> != nil} | rate() by(<groupBy>) for every group-by",
+    "candidate, including the intrinsics kind / status / name. Cerberus 422'd the intrinsic",
+    "`!= nil` guard ('nil comparison on intrinsic ... is unsupported' — see",
+    "internal/traceql/lower.go lowerUnaryOperation), blanking the breakdown panel for those",
+    "group-bys while resource.* attribute group-bys worked.",
+    "Query shape mirrors the attribute form pinned in internal/traceql/lower.go's doc comment",
+    "and the breakdown scenes of the upstream traces-drilldown app."
+  ],
+  "grafana_request": {
+    "path": "POST /api/ds/query",
+    "body": {
+      "queries": [
+        {
+          "refId": "A",
+          "datasource": { "type": "tempo", "uid": "cerberus-tempo" },
+          "queryType": "traceql",
+          "query": "{nestedSetParent<0 && true && kind != nil} | rate() by(kind)"
+        }
+      ]
+    }
+  },
+  "request": {
+    "method": "GET",
+    "path": "/api/metrics/query_range",
+    "query": {
+      "q": "{nestedSetParent<0 && true && kind != nil} | rate() by(kind)",
+      "start": "${START_UNIX}",
+      "end": "${END_UNIX}",
+      "step": "60s"
+    },
+    "headers": {}
+  },
+  "stub": "empty",
+  "expect": {
+    "status": 200,
+    "decode": "tempo-metrics-range",
+    "wire": ["exemplars-not-null"],
+    "data": ["series-min:1", "every-series-label-key:kind"]
+  }
+}

--- a/test/consumer-corpus/grafana-12.2.9/drilldown-breakdown-rate-by-name.json
+++ b/test/consumer-corpus/grafana-12.2.9/drilldown-breakdown-rate-by-name.json
@@ -1,0 +1,42 @@
+{
+  "name": "drilldown-breakdown-rate-by-name",
+  "datasource": "tempo",
+  "consumer": "Grafana 12.2.9 Traces Drilldown (grafana-exploretraces-app 2.0.4) Breakdown tab — rate() by(name) bar charts",
+  "provenance": [
+    "Maintainer-captured from the live compose stack (2026-06-10): the Breakdown tab stamps",
+    "{nestedSetParent<0 && true && <groupBy> != nil} | rate() by(<groupBy>) for every group-by",
+    "candidate. `name` is an intrinsic, so cerberus 422'd the `!= nil` guard (see the",
+    "drilldown-breakdown-rate-by-kind sibling entry for the full incident shape)."
+  ],
+  "grafana_request": {
+    "path": "POST /api/ds/query",
+    "body": {
+      "queries": [
+        {
+          "refId": "A",
+          "datasource": { "type": "tempo", "uid": "cerberus-tempo" },
+          "queryType": "traceql",
+          "query": "{nestedSetParent<0 && true && name != nil} | rate() by(name)"
+        }
+      ]
+    }
+  },
+  "request": {
+    "method": "GET",
+    "path": "/api/metrics/query_range",
+    "query": {
+      "q": "{nestedSetParent<0 && true && name != nil} | rate() by(name)",
+      "start": "${START_UNIX}",
+      "end": "${END_UNIX}",
+      "step": "60s"
+    },
+    "headers": {}
+  },
+  "stub": "empty",
+  "expect": {
+    "status": 200,
+    "decode": "tempo-metrics-range",
+    "wire": ["exemplars-not-null"],
+    "data": ["series-min:1", "every-series-label-key:name"]
+  }
+}

--- a/test/consumer-corpus/grafana-12.2.9/drilldown-breakdown-rate-by-service-name.json
+++ b/test/consumer-corpus/grafana-12.2.9/drilldown-breakdown-rate-by-service-name.json
@@ -1,0 +1,42 @@
+{
+  "name": "drilldown-breakdown-rate-by-service-name",
+  "datasource": "tempo",
+  "consumer": "Grafana 12.2.9 Traces Drilldown (grafana-exploretraces-app 2.0.4) Breakdown tab — rate() by(resource.service.name) bar charts",
+  "provenance": [
+    "The resource-attribute form of the Breakdown tab's group-by family (see the",
+    "drilldown-breakdown-rate-by-kind sibling for the intrinsic forms): the `!= nil` guard on an",
+    "attribute lowers to mapContains(ResourceAttributes, 'service.name') — the load-bearing shape",
+    "documented in internal/traceql/lower.go lowerUnaryOperation, stamped on every breakdown view."
+  ],
+  "grafana_request": {
+    "path": "POST /api/ds/query",
+    "body": {
+      "queries": [
+        {
+          "refId": "A",
+          "datasource": { "type": "tempo", "uid": "cerberus-tempo" },
+          "queryType": "traceql",
+          "query": "{nestedSetParent<0 && true && resource.service.name != nil} | rate() by(resource.service.name)"
+        }
+      ]
+    }
+  },
+  "request": {
+    "method": "GET",
+    "path": "/api/metrics/query_range",
+    "query": {
+      "q": "{nestedSetParent<0 && true && resource.service.name != nil} | rate() by(resource.service.name)",
+      "start": "${START_UNIX}",
+      "end": "${END_UNIX}",
+      "step": "60s"
+    },
+    "headers": {}
+  },
+  "stub": "empty",
+  "expect": {
+    "status": 200,
+    "decode": "tempo-metrics-range",
+    "wire": ["exemplars-not-null"],
+    "data": ["series-min:1", "every-series-label-key:resource.service.name"]
+  }
+}

--- a/test/consumer-corpus/grafana-12.2.9/drilldown-breakdown-rate-by-status.json
+++ b/test/consumer-corpus/grafana-12.2.9/drilldown-breakdown-rate-by-status.json
@@ -1,0 +1,42 @@
+{
+  "name": "drilldown-breakdown-rate-by-status",
+  "datasource": "tempo",
+  "consumer": "Grafana 12.2.9 Traces Drilldown (grafana-exploretraces-app 2.0.4) Breakdown tab — rate() by(status) bar charts",
+  "provenance": [
+    "Maintainer-captured from the live compose stack (2026-06-10): the Breakdown tab stamps",
+    "{nestedSetParent<0 && true && <groupBy> != nil} | rate() by(<groupBy>) for every group-by",
+    "candidate. `status` is an intrinsic, so cerberus 422'd the `!= nil` guard (see the",
+    "drilldown-breakdown-rate-by-kind sibling entry for the full incident shape)."
+  ],
+  "grafana_request": {
+    "path": "POST /api/ds/query",
+    "body": {
+      "queries": [
+        {
+          "refId": "A",
+          "datasource": { "type": "tempo", "uid": "cerberus-tempo" },
+          "queryType": "traceql",
+          "query": "{nestedSetParent<0 && true && status != nil} | rate() by(status)"
+        }
+      ]
+    }
+  },
+  "request": {
+    "method": "GET",
+    "path": "/api/metrics/query_range",
+    "query": {
+      "q": "{nestedSetParent<0 && true && status != nil} | rate() by(status)",
+      "start": "${START_UNIX}",
+      "end": "${END_UNIX}",
+      "step": "60s"
+    },
+    "headers": {}
+  },
+  "stub": "empty",
+  "expect": {
+    "status": 200,
+    "decode": "tempo-metrics-range",
+    "wire": ["exemplars-not-null"],
+    "data": ["series-min:1", "every-series-label-key:status"]
+  }
+}

--- a/test/consumer-corpus/grafana-12.2.9/drilldown-comparison-compare.json
+++ b/test/consumer-corpus/grafana-12.2.9/drilldown-comparison-compare.json
@@ -1,0 +1,47 @@
+{
+  "name": "drilldown-comparison-compare",
+  "datasource": "tempo",
+  "consumer": "Grafana 12.2.9 Traces Drilldown (grafana-exploretraces-app 2.0.4) Comparison tab — compare() cohort split keyed on __meta_type",
+  "provenance": [
+    "Captured from the live compose stack (crawl signature traceql-metrics-compare-unsupported-422,",
+    "fixed by #776): the Comparison tab issues",
+    "{nestedSetParent<0 && true} | compare({status = error}, 10) through /api/metrics/query_range and",
+    "splits the returned series into baseline/selection cohorts on the LEADING __meta_type label.",
+    "Shape verbatim from internal/api/tempo/metrics_query_range_compare_test.go",
+    "(TestMetricsQueryRange_CompareDrilldownVerbatim)."
+  ],
+  "grafana_request": {
+    "path": "POST /api/ds/query",
+    "body": {
+      "queries": [
+        {
+          "refId": "A",
+          "datasource": { "type": "tempo", "uid": "cerberus-tempo" },
+          "queryType": "traceql",
+          "query": "{nestedSetParent<0 && true} | compare({status = error}, 10)"
+        }
+      ]
+    }
+  },
+  "request": {
+    "method": "GET",
+    "path": "/api/metrics/query_range",
+    "query": {
+      "q": "{nestedSetParent<0 && true} | compare({status = error}, 10)",
+      "start": "${START_UNIX}",
+      "end": "${END_UNIX}",
+      "step": "60s"
+    },
+    "headers": {}
+  },
+  "stub": "tempo-compare",
+  "expect": {
+    "status": 200,
+    "decode": "tempo-metrics-range",
+    "wire": [
+      "compare-meta-types:baseline,selection,baseline_total,selection_total",
+      "exemplars-not-null"
+    ],
+    "data": ["series-min:4"]
+  }
+}

--- a/test/consumer-corpus/grafana-12.2.9/drilldown-duration-avg-by.json
+++ b/test/consumer-corpus/grafana-12.2.9/drilldown-duration-avg-by.json
@@ -1,0 +1,50 @@
+{
+  "name": "drilldown-duration-avg-by",
+  "datasource": "loki",
+  "consumer": "Grafana 12.2.9 Logs Drilldown (grafana-lokiexplore-app) duration-field breakdown — avg by over unwrap duration()",
+  "provenance": [
+    "The avg-by sibling of drilldown-duration-sum-by (see that entry for the incident shape, the",
+    "µs-row rationale, and the per-row degradation contract reference Loki enforces on",
+    "unparseable duration values).",
+    "Query shape verbatim from internal/logql/range_aggregation_test.go",
+    "(`avg by (level) (avg_over_time(... | logfmt | duration != \"\" | unwrap duration(duration) ...))`)",
+    "and test/spec/logql/edge_nested_max_avg_by_unwrap.txtar."
+  ],
+  "grafana_request": {
+    "path": "POST /api/ds/query",
+    "body": {
+      "queries": [
+        {
+          "refId": "A",
+          "datasource": { "type": "loki", "uid": "cerberus-loki" },
+          "queryType": "range",
+          "expr": "avg by (level) (avg_over_time({service_name=\"api\"} | logfmt | duration != \"\" | unwrap duration(duration) [$__auto]))"
+        }
+      ]
+    }
+  },
+  "request": {
+    "method": "GET",
+    "path": "/loki/api/v1/query_range",
+    "query": {
+      "query": "avg by (level) (avg_over_time({service_name=\"api\"} | logfmt | duration != \"\" | unwrap duration(duration) [5m]))",
+      "start": "${START_NS}",
+      "end": "${END_NS}",
+      "step": "60"
+    },
+    "headers": {}
+  },
+  "stub": "empty",
+  "expect": {
+    "status": 200,
+    "decode": "loki-envelope",
+    "wire": ["resulttype:matrix"],
+    "data": [
+      "result-min:1",
+      "every-series-metric-label:level",
+      "matrix-values-finite-positive",
+      "matrix-max-value:10",
+      "series-max-value:level=error,0.41"
+    ]
+  }
+}

--- a/test/consumer-corpus/grafana-12.2.9/drilldown-duration-sum-by.json
+++ b/test/consumer-corpus/grafana-12.2.9/drilldown-duration-sum-by.json
@@ -1,0 +1,60 @@
+{
+  "name": "drilldown-duration-sum-by",
+  "datasource": "loki",
+  "consumer": "Grafana 12.2.9 Logs Drilldown (grafana-lokiexplore-app) duration-field breakdown — sum by over unwrap duration()",
+  "provenance": [
+    "Logs Drilldown classifies detected fields by type; for duration-typed fields its breakdown",
+    "scenes stamp sum by / avg by aggregations over `| logfmt | <field> != \"\" | unwrap",
+    "duration(<field>) [$__auto]` (Grafana interpolates $__auto to a concrete range before the",
+    "request reaches the Loki API).",
+    "Query shape verbatim from the repo's pinned drilldown forms:",
+    "test/spec/logql/edge_nested_max_avg_by_unwrap.txtar and",
+    "internal/logql/range_aggregation_test.go (sum_over_time-unwrap-duration-postfilter).",
+    "The chdb seed carries a sub-millisecond `duration=812µs` row plus an unparseable",
+    "`duration=oops` row. Incident (k3d crawl lane, run 27327766381, Logs Drilldown service pages):",
+    "cerberus fed label values straight into CH parseTimeDelta, which throws on the first value it",
+    "can't parse — including Go's Duration.String() micro-sign form on ClickHouse 24.8 — aborting",
+    "the whole panel query. Reference Loki NEVER aborts: unparseable unwrap sources degrade",
+    "per-row to 0-valued samples in an __error__-stamped bypass series",
+    "(pkg/logql/log/metrics_extraction.go). The data predicates pin that contract: 200 + grouped",
+    "series present + non-error values inside the unit-sanity bounds (all parseable durations are",
+    "<= 1.8 s summed; a µs row misparsed as ms or s breaches series-max-value)."
+  ],
+  "grafana_request": {
+    "path": "POST /api/ds/query",
+    "body": {
+      "queries": [
+        {
+          "refId": "A",
+          "datasource": { "type": "loki", "uid": "cerberus-loki" },
+          "queryType": "range",
+          "expr": "sum by (level) (sum_over_time({service_name=\"api\"} | logfmt | duration != \"\" | unwrap duration(duration) [$__auto]))"
+        }
+      ]
+    }
+  },
+  "request": {
+    "method": "GET",
+    "path": "/loki/api/v1/query_range",
+    "query": {
+      "query": "sum by (level) (sum_over_time({service_name=\"api\"} | logfmt | duration != \"\" | unwrap duration(duration) [5m]))",
+      "start": "${START_NS}",
+      "end": "${END_NS}",
+      "step": "60"
+    },
+    "headers": {}
+  },
+  "stub": "empty",
+  "expect": {
+    "status": 200,
+    "decode": "loki-envelope",
+    "wire": ["resulttype:matrix"],
+    "data": [
+      "result-min:1",
+      "every-series-metric-label:level",
+      "matrix-values-finite-positive",
+      "matrix-max-value:10",
+      "series-max-value:level=error,0.41"
+    ]
+  }
+}

--- a/test/consumer-corpus/grafana-12.2.9/drilldown-label-values-match.json
+++ b/test/consumer-corpus/grafana-12.2.9/drilldown-label-values-match.json
@@ -1,0 +1,33 @@
+{
+  "name": "drilldown-label-values-match",
+  "datasource": "prom",
+  "consumer": "Grafana 12.2.9 Metrics Drilldown (grafana-metricsdrilldown-app) — /api/v1/label/<name>/values with a match[] selector",
+  "provenance": [
+    "The group-by value discovery the breakdown tab runs once a label key is picked:",
+    "/api/v1/label/cerberus_ql/values?match[]={__name__=~\".*cerberus_query_inflight.*\"}. Rides the",
+    "same regex-__name__ lowering as the labels/series arms (#769).",
+    "Shape reconstructed from internal/api/prom/handler_chdb_label_values_test.go",
+    "(TestLabelValues_MatchSelector_ChDB) and the #769 commit message."
+  ],
+  "grafana_request": {
+    "path": "GET /api/datasources/uid/cerberus-prom/resources/api/v1/label/cerberus_ql/values",
+    "query": { "match[]": "{__name__=~\".*cerberus_query_inflight.*\"}" }
+  },
+  "request": {
+    "method": "GET",
+    "path": "/api/v1/label/cerberus_ql/values",
+    "query": {
+      "match[]": "{__name__=~\".*cerberus_query_inflight.*\"}",
+      "start": "${START_UNIX}",
+      "end": "${END_UNIX}"
+    },
+    "headers": {}
+  },
+  "stub": "prom-label-values",
+  "expect": {
+    "status": 200,
+    "decode": "prom-strings",
+    "wire": ["strings-contains:promql"],
+    "data": ["strings-contains:logql", "strings-contains:traceql"]
+  }
+}

--- a/test/consumer-corpus/grafana-12.2.9/drilldown-labels-regex-match.json
+++ b/test/consumer-corpus/grafana-12.2.9/drilldown-labels-regex-match.json
@@ -1,0 +1,33 @@
+{
+  "name": "drilldown-labels-regex-match",
+  "datasource": "prom",
+  "consumer": "Grafana 12.2.9 Metrics Drilldown (grafana-metricsdrilldown-app) — /api/v1/labels with a regex __name__ match[] selector",
+  "provenance": [
+    "The labels-discovery arm of the #769 incident: Metrics Drilldown's breakdown tab lists the",
+    "label keys of each metric via /api/v1/labels?match[]={__name__=~\".*<metric>.*\"}. Before the",
+    "fix the regex selector resolved against the gauge table only and never matched sum-stored",
+    "metrics, so the tab offered no group-by candidates.",
+    "Shape reconstructed from internal/api/prom/handler_chdb_regex_name_matcher_test.go."
+  ],
+  "grafana_request": {
+    "path": "GET /api/datasources/uid/cerberus-prom/resources/api/v1/labels",
+    "query": { "match[]": "{__name__=~\".*cerberus_query_inflight.*\"}" }
+  },
+  "request": {
+    "method": "GET",
+    "path": "/api/v1/labels",
+    "query": {
+      "match[]": "{__name__=~\".*cerberus_query_inflight.*\"}",
+      "start": "${START_UNIX}",
+      "end": "${END_UNIX}"
+    },
+    "headers": {}
+  },
+  "stub": "prom-labels",
+  "expect": {
+    "status": 200,
+    "decode": "prom-strings",
+    "wire": ["strings-contains:cerberus_ql"],
+    "data": ["strings-contains:__name__"]
+  }
+}

--- a/test/consumer-corpus/grafana-12.2.9/drilldown-regex-name-instant-query.json
+++ b/test/consumer-corpus/grafana-12.2.9/drilldown-regex-name-instant-query.json
@@ -1,0 +1,44 @@
+{
+  "name": "drilldown-regex-name-instant-query",
+  "datasource": "prom",
+  "consumer": "Grafana 12.2.9 Metrics Drilldown (grafana-metricsdrilldown-app) — instant query with a regex __name__ selector",
+  "provenance": [
+    "Captured from the live compose stack during the blank-breakdown-tab incident (#769): Metrics",
+    "Drilldown stamps {__name__=~\".*<metric>.*\"} selectors for every metric it lists. Two gaps made",
+    "the shape return empty: gauge-only table routing for regex/name-less selectors (sum-stored",
+    "metrics like cerberus_query_inflight returned nothing) and no Prom-normalisation bridge for",
+    "regex values against OTel-dotted stored names.",
+    "Shape reconstructed from internal/api/prom/handler_chdb_regex_name_matcher_test.go and the",
+    "#769 commit message."
+  ],
+  "grafana_request": {
+    "path": "POST /api/ds/query",
+    "body": {
+      "queries": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "cerberus-prom" },
+          "expr": "{__name__=~\".*cerberus_query_inflight.*\"}",
+          "instant": true,
+          "range": false
+        }
+      ]
+    }
+  },
+  "request": {
+    "method": "GET",
+    "path": "/api/v1/query",
+    "query": {
+      "query": "{__name__=~\".*cerberus_query_inflight.*\"}",
+      "time": "${END_UNIX}"
+    },
+    "headers": {}
+  },
+  "stub": "prom-vector",
+  "expect": {
+    "status": 200,
+    "decode": "prom-envelope",
+    "wire": ["resulttype:vector", "result-min:1", "every-series-metric-label:cerberus_ql"],
+    "data": ["result-min:3"]
+  }
+}

--- a/test/consumer-corpus/grafana-12.2.9/drilldown-series-regex-match.json
+++ b/test/consumer-corpus/grafana-12.2.9/drilldown-series-regex-match.json
@@ -1,0 +1,31 @@
+{
+  "name": "drilldown-series-regex-match",
+  "datasource": "prom",
+  "consumer": "Grafana 12.2.9 Metrics Drilldown (grafana-metricsdrilldown-app) — /api/v1/series with a regex __name__ match[] selector",
+  "provenance": [
+    "The series-discovery arm of the #769 incident: /api/v1/series?match[]={__name__=~\".*<metric>.*\"}",
+    "returned empty for sum-stored metrics before the gauge+sum fan-out fix.",
+    "Shape reconstructed from internal/api/prom/handler_chdb_regex_name_matcher_test.go."
+  ],
+  "grafana_request": {
+    "path": "GET /api/datasources/uid/cerberus-prom/resources/api/v1/series",
+    "query": { "match[]": "{__name__=~\".*cerberus_query_inflight.*\"}" }
+  },
+  "request": {
+    "method": "GET",
+    "path": "/api/v1/series",
+    "query": {
+      "match[]": "{__name__=~\".*cerberus_query_inflight.*\"}",
+      "start": "${START_UNIX}",
+      "end": "${END_UNIX}"
+    },
+    "headers": {}
+  },
+  "stub": "prom-series",
+  "expect": {
+    "status": 200,
+    "decode": "prom-series",
+    "wire": ["series-count-min:1", "every-series-has-label:cerberus_ql"],
+    "data": ["series-count-min:3"]
+  }
+}

--- a/test/consumer-corpus/grafana-12.2.9/drilldown-structure-select-nested-set.json
+++ b/test/consumer-corpus/grafana-12.2.9/drilldown-structure-select-nested-set.json
@@ -1,0 +1,52 @@
+{
+  "name": "drilldown-structure-select-nested-set",
+  "datasource": "tempo",
+  "consumer": "Grafana 12.2.9 Traces Drilldown (grafana-exploretraces-app 2.0.4) Structure tab — mergeTraces reads nestedSet* intValues, service.name, name, status",
+  "provenance": [
+    "Captured from the live compose stack (Structure tab blank, fixed by #775): the tab's buildQuery",
+    "(StructureScene.tsx) issues the structural union with",
+    "| select(status, resource.service.name, name, nestedSetParent, nestedSetLeft, nestedSetRight)",
+    "and its utils.ts nestedSetLeft() THROWS when any span lacks the nestedSet* intValue attributes;",
+    "tree-node.ts nodeName composes `${svcName}:${spanName}` from the string attributes.",
+    "Query verbatim from internal/api/tempo/search_select_nested_set_chdb_test.go and",
+    "test/spec/traceql/select_nested_set_drilldown_structure.txtar."
+  ],
+  "grafana_request": {
+    "path": "POST /api/ds/query",
+    "body": {
+      "queries": [
+        {
+          "refId": "A",
+          "datasource": { "type": "tempo", "uid": "cerberus-tempo" },
+          "queryType": "traceql",
+          "query": "({nestedSetParent<0} &>> { kind = server }) || ({nestedSetParent<0}) | select(status, resource.service.name, name, nestedSetParent, nestedSetLeft, nestedSetRight)"
+        }
+      ]
+    }
+  },
+  "request": {
+    "method": "GET",
+    "path": "/api/search",
+    "query": {
+      "q": "({nestedSetParent<0} &>> { kind = server }) || ({nestedSetParent<0}) | select(status, resource.service.name, name, nestedSetParent, nestedSetLeft, nestedSetRight)",
+      "limit": "20",
+      "spss": "20",
+      "start": "${START_UNIX}",
+      "end": "${END_UNIX}"
+    },
+    "headers": {}
+  },
+  "stub": "tempo-search-select",
+  "expect": {
+    "status": 200,
+    "decode": "tempo-search",
+    "wire": [
+      "traces-min:1",
+      "every-trace-has-spansets",
+      "every-span-int-attr:nestedSetParent,nestedSetLeft,nestedSetRight",
+      "some-span-int-attr:nestedSetParent=-1",
+      "some-span-str-attr:status=error"
+    ],
+    "data": ["traces-min:2"]
+  }
+}

--- a/test/consumer-corpus/grafana-12.2.9/logs-panel-streams.json
+++ b/test/consumer-corpus/grafana-12.2.9/logs-panel-streams.json
@@ -1,0 +1,48 @@
+{
+  "name": "logs-panel-streams",
+  "datasource": "loki",
+  "consumer": "Grafana 12.2.9 Logs Drilldown / Explore logs panel — streams envelope decode (queryType=range)",
+  "provenance": [
+    "The baseline log-lines request every Logs Drilldown service page and Explore logs panel",
+    "issues: a stream selector over query_range with limit + direction. Pinned so the envelope",
+    "(status/data/resultType=streams) and the per-stream values shape stay decodable by the Loki",
+    "datasource backend.",
+    "Shape reconstructed from test/e2e/playwright/loki_ux.spec.ts and",
+    "internal/api/loki/handler_test.go (TestQueryRange_Streams_DefaultLimitClampsResponse)."
+  ],
+  "grafana_request": {
+    "path": "POST /api/ds/query",
+    "body": {
+      "queries": [
+        {
+          "refId": "A",
+          "datasource": { "type": "loki", "uid": "cerberus-loki" },
+          "queryType": "range",
+          "expr": "{service_name=\"api\"}",
+          "maxLines": 100,
+          "direction": "backward"
+        }
+      ]
+    }
+  },
+  "request": {
+    "method": "GET",
+    "path": "/loki/api/v1/query_range",
+    "query": {
+      "query": "{service_name=\"api\"}",
+      "start": "${START_NS}",
+      "end": "${END_NS}",
+      "step": "60",
+      "limit": "100",
+      "direction": "backward"
+    },
+    "headers": {}
+  },
+  "stub": "loki-streams",
+  "expect": {
+    "status": 200,
+    "decode": "loki-envelope",
+    "wire": ["resulttype:streams", "result-min:1"],
+    "data": ["streams-values-min:6"]
+  }
+}

--- a/test/consumer-corpus/grafana-12.2.9/metadata.json
+++ b/test/consumer-corpus/grafana-12.2.9/metadata.json
@@ -1,0 +1,29 @@
+{
+  "name": "metadata",
+  "datasource": "prom",
+  "consumer": "Grafana 12.2.9 Metrics Drilldown (grafana-metricsdrilldown-app) metric catalogue — /api/v1/metadata type/help/unit map",
+  "provenance": [
+    "Metrics Drilldown boots by listing every metric with its type from /api/v1/metadata; the type",
+    "drives which query shapes it stamps (counter → rate(), gauge → avg, histogram → quantile",
+    "panels). The non-monotonic-Sum-as-gauge contract was pinned by #768 after UpDownCounters were",
+    "misreported as counters and the app stamped rate() over them.",
+    "Shape reconstructed from internal/api/prom/metadata_test.go and the #768 commit message."
+  ],
+  "grafana_request": {
+    "path": "GET /api/datasources/uid/cerberus-prom/resources/api/v1/metadata",
+    "query": {}
+  },
+  "request": {
+    "method": "GET",
+    "path": "/api/v1/metadata",
+    "query": {},
+    "headers": {}
+  },
+  "stub": "prom-metadata",
+  "expect": {
+    "status": 200,
+    "decode": "prom-metadata",
+    "wire": ["metadata-contains:cerberus_query_inflight"],
+    "data": ["metadata-contains:up"]
+  }
+}

--- a/test/consumer-corpus/grafana-12.2.9/search-spansets.json
+++ b/test/consumer-corpus/grafana-12.2.9/search-spansets.json
@@ -1,0 +1,50 @@
+{
+  "name": "search-spansets",
+  "datasource": "tempo",
+  "consumer": "Grafana 12.2.9 Traces Drilldown (grafana-exploretraces-app 2.0.4) trace list — tableType='spans' transform reads traces[].spanSets[].spans",
+  "provenance": [
+    "Captured from the live compose stack during the Traces-tab 'badge 0 + No data' incident (#770):",
+    "the drilldown's trace list queries the Tempo datasource with queryType='traceql' /",
+    "tableType='spans'; the plugin backend proxies GET /api/search?q={}&limit=<n>&spss=<n>&start&end.",
+    "Grafana's tempo resultTransformer builds the spans table EXCLUSIVELY from",
+    "trace.spanSets[].spans — cerberus used to return summaries without spanSets (and ignored",
+    "limit + spss), so every request got HTTP 200 and the tab rendered nothing.",
+    "Shape reconstructed from test/e2e/playwright/tempo_traces_drilldown.spec.ts and",
+    "internal/api/tempo/handler_test.go (TestSearch_SpanSets)."
+  ],
+  "grafana_request": {
+    "path": "POST /api/ds/query",
+    "body": {
+      "queries": [
+        {
+          "refId": "A",
+          "datasource": { "type": "tempo", "uid": "cerberus-tempo" },
+          "queryType": "traceql",
+          "query": "{}",
+          "limit": 20,
+          "spss": 3,
+          "tableType": "spans"
+        }
+      ]
+    }
+  },
+  "request": {
+    "method": "GET",
+    "path": "/api/search",
+    "query": {
+      "q": "{}",
+      "limit": "20",
+      "spss": "3",
+      "start": "${START_UNIX}",
+      "end": "${END_UNIX}"
+    },
+    "headers": {}
+  },
+  "stub": "tempo-search",
+  "expect": {
+    "status": 200,
+    "decode": "tempo-search",
+    "wire": ["traces-min:1", "traces-max:20", "every-trace-has-spansets", "spanset-spans-max:3"],
+    "data": ["traces-min:2"]
+  }
+}

--- a/test/consumer-corpus/grafana-12.2.9/trace-by-id-v1-proto.json
+++ b/test/consumer-corpus/grafana-12.2.9/trace-by-id-v1-proto.json
@@ -1,0 +1,39 @@
+{
+  "name": "trace-by-id-v1-proto",
+  "datasource": "tempo",
+  "consumer": "Grafana Tempo datasource backend (pre-v2 path) — strict gogo/proto decode of bare tempopb.Trace",
+  "provenance": [
+    "The v1 sibling of trace-by-id-v2-proto: GET /api/traces/{id} serves the BARE proto trace (no",
+    "TraceByIDResponse envelope). The v1↔v2 divergence is exactly one envelope level — pinning both",
+    "shapes keeps a future refactor from flipping either direction (#764 regression class).",
+    "Shape reconstructed from internal/api/tempo/handler_trace_v2_test.go (v1/v2 byte-identity pin)."
+  ],
+  "grafana_request": {
+    "path": "POST /api/ds/query",
+    "body": {
+      "queries": [
+        {
+          "refId": "A",
+          "datasource": { "type": "tempo", "uid": "cerberus-tempo" },
+          "queryType": "traceId",
+          "query": "${TRACE_ID}",
+          "limit": 20,
+          "tableType": "traces"
+        }
+      ]
+    }
+  },
+  "request": {
+    "method": "GET",
+    "path": "/api/traces/${TRACE_ID}",
+    "query": {},
+    "headers": { "Accept": "application/protobuf" }
+  },
+  "stub": "tempo-trace-by-id",
+  "expect": {
+    "status": 200,
+    "decode": "tempo-trace-v1-proto",
+    "wire": ["trace-resource-spans-min:1"],
+    "data": ["trace-resource-spans-min:1"]
+  }
+}

--- a/test/consumer-corpus/grafana-12.2.9/trace-by-id-v2-proto.json
+++ b/test/consumer-corpus/grafana-12.2.9/trace-by-id-v2-proto.json
@@ -1,0 +1,44 @@
+{
+  "name": "trace-by-id-v2-proto",
+  "datasource": "tempo",
+  "consumer": "Grafana 12.2.9 Tempo datasource backend — strict gogo/proto decode of tempopb.TraceByIDResponse (queryType=traceId)",
+  "provenance": [
+    "Captured from the live compose stack during the 2026-06 Grafana-12 trace-by-id outage (#764).",
+    "Grafana's Tempo frontend reclassifies a bare-hex Explore query to queryType=traceId; the plugin",
+    "backend then issues GET /api/v2/traces/{id} with Accept: application/protobuf and unmarshals the",
+    "body as tempopb.TraceByIDResponse BEFORE converting to OTLP. Cerberus used to serve the same bare",
+    "*tempopb.Trace bytes as the v1 endpoint; the decode misaligned one message level deep and died",
+    "inside a KeyValue ('proto: KeyValue: wiretype end group for non-group' → 'An error occurred",
+    "within the plugin' in Explore).",
+    "Request shape reconstructed from internal/api/tempo/handler_trace_v2_test.go and",
+    "test/e2e/playwright/tempo_traces.spec.ts (the queryType reclassification pin)."
+  ],
+  "grafana_request": {
+    "path": "POST /api/ds/query",
+    "body": {
+      "queries": [
+        {
+          "refId": "A",
+          "datasource": { "type": "tempo", "uid": "cerberus-tempo" },
+          "queryType": "traceId",
+          "query": "${TRACE_ID}",
+          "limit": 20,
+          "tableType": "traces"
+        }
+      ]
+    }
+  },
+  "request": {
+    "method": "GET",
+    "path": "/api/v2/traces/${TRACE_ID}",
+    "query": { "start": "${START_UNIX}", "end": "${END_UNIX}" },
+    "headers": { "Accept": "application/protobuf" }
+  },
+  "stub": "tempo-trace-by-id",
+  "expect": {
+    "status": 200,
+    "decode": "tempo-trace-v2-proto",
+    "wire": ["trace-present", "metrics-block-present", "trace-resource-spans-min:1"],
+    "data": ["trace-resource-spans-min:1"]
+  }
+}

--- a/test/consumer-corpus/ratchet_test.go
+++ b/test/consumer-corpus/ratchet_test.go
@@ -1,0 +1,68 @@
+package consumercorpus
+
+import "testing"
+
+// Corpus floors. These are RAISE-ONLY: when entries are added the
+// floors move up to match; lowering one (or deleting entries without
+// replacing them) is a corpus shrink, which this meta-test exists to
+// forbid. The corpus is the project's record of what Grafana actually
+// sends — shrinking it silently un-pins a consumer contract.
+const (
+	minTotalEntries = 18
+	minTempoEntries = 9
+	minLokiEntries  = 4
+	minPromEntries  = 5
+)
+
+// TestConsumerCorpus_Ratchet pins the corpus census and the per-entry
+// schema discipline:
+//
+//   - total + per-datasource entry counts may only grow,
+//   - every entry names a decoder, stub fixture, and predicates the
+//     harness actually implements (a typo'd name would otherwise rot
+//     as a never-evaluated string),
+//   - every entry carries provenance + the Grafana-side request
+//     (enforced by Load via Entry.validate).
+func TestConsumerCorpus_Ratchet(t *testing.T) {
+	t.Parallel()
+
+	entries, err := Load(".")
+	if err != nil {
+		t.Fatalf("load corpus: %v", err)
+	}
+
+	byDS := map[string]int{}
+	for _, e := range entries {
+		byDS[e.Datasource]++
+
+		if !KnownDecoder(e.Expect.Decode) {
+			t.Errorf("%s/%s: decoder %q is not registered in the harness", e.Version, e.Name, e.Expect.Decode)
+		}
+		if !KnownStubFixture(e.Stub) {
+			t.Errorf("%s/%s: stub fixture %q is not registered in the harness", e.Version, e.Name, e.Stub)
+		}
+		for _, p := range append(append([]string{}, e.Expect.Wire...), e.Expect.Data...) {
+			name, _, err := splitPredicate(p)
+			if err != nil {
+				t.Errorf("%s/%s: %v", e.Version, e.Name, err)
+				continue
+			}
+			if !KnownPredicate(name) {
+				t.Errorf("%s/%s: predicate %q is not registered in the harness", e.Version, e.Name, name)
+			}
+		}
+		if len(e.Expect.Wire)+len(e.Expect.Data) == 0 {
+			t.Errorf("%s/%s: entry declares no predicates beyond decode — add at least one shape predicate", e.Version, e.Name)
+		}
+	}
+
+	if got := len(entries); got < minTotalEntries {
+		t.Errorf("corpus shrank: %d entries, floor is %d", got, minTotalEntries)
+	}
+	floors := map[string]int{"tempo": minTempoEntries, "loki": minLokiEntries, "prom": minPromEntries}
+	for ds, floor := range floors {
+		if byDS[ds] < floor {
+			t.Errorf("corpus shrank for %s: %d entries, floor is %d", ds, byDS[ds], floor)
+		}
+	}
+}

--- a/test/consumer-corpus/replay.go
+++ b/test/consumer-corpus/replay.go
@@ -31,7 +31,7 @@ func Replay(client *http.Client, baseURL string, e Entry, tokens map[string]stri
 	if err != nil {
 		return []error{fmt.Errorf("request failed: %w", err)}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return []error{fmt.Errorf("read body: %w", err)}

--- a/test/consumer-corpus/replay.go
+++ b/test/consumer-corpus/replay.go
@@ -1,0 +1,1039 @@
+package consumercorpus
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/grafana/tempo/pkg/tempopb"
+)
+
+// Replay sends entry e against baseURL (an httptest server hosting the
+// entry's datasource handler), expands ${TOKEN} placeholders from
+// tokens, and returns every contract violation found — status
+// mismatch, consumer-decode failure, failed predicates. includeData
+// selects whether the chdb-only Data predicates run.
+//
+// All checks run; the slice aggregates every failure so a corpus run
+// reports the full picture instead of stopping at the first mismatch.
+func Replay(client *http.Client, baseURL string, e Entry, tokens map[string]string, includeData bool) []error {
+	req, err := buildRequest(baseURL, e, tokens)
+	if err != nil {
+		return []error{err}
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return []error{fmt.Errorf("request failed: %w", err)}
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return []error{fmt.Errorf("read body: %w", err)}
+	}
+
+	wantStatus := e.Expect.Status
+	if wantStatus == 0 {
+		wantStatus = http.StatusOK
+	}
+	var errs []error
+	if resp.StatusCode != wantStatus {
+		errs = append(errs, fmt.Errorf("status = %d, want %d; body: %s", resp.StatusCode, wantStatus, truncate(body, 500)))
+		// A wrong status makes decode + predicate output pure noise;
+		// the status error already carries the body.
+		return errs
+	}
+
+	dec, ok := decoders[e.Expect.Decode]
+	if !ok {
+		return append(errs, fmt.Errorf("unknown decoder %q", e.Expect.Decode))
+	}
+	v, err := dec(resp.Header, body)
+	if err != nil {
+		return append(errs, fmt.Errorf("consumer decode (%s): %w; body: %s", e.Expect.Decode, err, truncate(body, 500)))
+	}
+
+	preds := append([]string{}, e.Expect.Wire...)
+	if includeData {
+		preds = append(preds, e.Expect.Data...)
+	}
+	for _, p := range preds {
+		name, arg, err := splitPredicate(p)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		fn, ok := predicates[name]
+		if !ok {
+			errs = append(errs, fmt.Errorf("unknown predicate %q", name))
+			continue
+		}
+		if err := fn(v, arg); err != nil {
+			errs = append(errs, fmt.Errorf("predicate %s: %w", p, err))
+		}
+	}
+	return errs
+}
+
+// buildRequest assembles the entry's HTTP request with token expansion
+// applied to the path and every query value.
+func buildRequest(baseURL string, e Entry, tokens map[string]string) (*http.Request, error) {
+	path, err := expandTokens(e.Request.Path, tokens)
+	if err != nil {
+		return nil, err
+	}
+	vals := url.Values{}
+	for k, v := range e.Request.Query {
+		ev, err := expandTokens(v, tokens)
+		if err != nil {
+			return nil, err
+		}
+		vals.Set(k, ev)
+	}
+	u := baseURL + path
+	if len(vals) > 0 {
+		u += "?" + vals.Encode()
+	}
+	req, err := http.NewRequest(e.Request.Method, u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	for k, v := range e.Request.Headers {
+		req.Header.Set(k, v)
+	}
+	return req, nil
+}
+
+// expandTokens substitutes every ${NAME} placeholder and errors on
+// placeholders the lane didn't provide — an unexpanded token would
+// silently turn into a bogus literal parameter.
+func expandTokens(s string, tokens map[string]string) (string, error) {
+	out := s
+	for k, v := range tokens {
+		out = strings.ReplaceAll(out, "${"+k+"}", v)
+	}
+	if i := strings.Index(out, "${"); i >= 0 {
+		return "", fmt.Errorf("unexpanded token in %q — the replay lane must provide it", s)
+	}
+	return out, nil
+}
+
+func truncate(b []byte, n int) string {
+	if len(b) <= n {
+		return string(b)
+	}
+	return string(b[:n]) + "…"
+}
+
+// --- Consumer-view response types ----------------------------------
+//
+// These structs mirror what each consumer READS, field by field.
+// Where the consumer strict-decodes (gogo proto), we strict-decode;
+// where the consumer is JavaScript reading named keys (JSON.parse),
+// the struct pins exactly those keys.
+
+// searchView is the field set Grafana's Tempo datasource
+// resultTransformer reads from /api/search (tableType='spans' builds
+// the trace-list table exclusively from traces[].spanSets[].spans).
+type searchView struct {
+	Traces []searchTrace `json:"traces"`
+}
+
+type searchTrace struct {
+	TraceID  string          `json:"traceID"`
+	SpanSets []searchSpanSet `json:"spanSets"`
+	SpanSet  *searchSpanSet  `json:"spanSet"`
+}
+
+type searchSpanSet struct {
+	Spans []searchSpan `json:"spans"`
+}
+
+type searchSpan struct {
+	SpanID            string       `json:"spanID"`
+	Name              string       `json:"name"`
+	StartTimeUnixNano string       `json:"startTimeUnixNano"`
+	DurationNanos     string       `json:"durationNanos"`
+	Attributes        []searchAttr `json:"attributes"`
+}
+
+type searchAttr struct {
+	Key   string `json:"key"`
+	Value struct {
+		StringValue *string `json:"stringValue"`
+		IntValue    *string `json:"intValue"`
+	} `json:"value"`
+}
+
+// metricsRangeView is the field set the Traces Drilldown scenes read
+// from /api/metrics/query_range — tempopb QueryRangeResponse rendered
+// through gogo jsonpb (labels as KeyValue+AnyValue, samples with
+// timestampMs).
+type metricsRangeView struct {
+	Series []metricsSeriesView `json:"series"`
+}
+
+type metricsSeriesView struct {
+	Labels []struct {
+		Key   string `json:"key"`
+		Value struct {
+			StringValue string `json:"stringValue"`
+		} `json:"value"`
+	} `json:"labels"`
+	Samples []struct {
+		TimestampMs int64   `json:"timestampMs"`
+		Value       float64 `json:"value"`
+	} `json:"samples"`
+	Exemplars json.RawMessage `json:"exemplars"`
+}
+
+// detectedFieldsView is the bare logproto.DetectedFieldsResponse JSON
+// shape Logs Drilldown reads: top-level `fields`, NO {status, data}
+// envelope (upstream pkg/util/marshal WriteDetectedFieldsResponseJSON).
+type detectedFieldsView struct {
+	Fields []detectedFieldView
+	Limit  json.RawMessage
+	// raw keeps the top-level key set so the bare-envelope contract
+	// (no status/data wrapper) is assertable.
+	raw map[string]json.RawMessage
+}
+
+type detectedFieldView struct {
+	Label       string          `json:"label"`
+	Type        string          `json:"type"`
+	Cardinality float64         `json:"cardinality"`
+	Parsers     json.RawMessage `json:"parsers"`
+}
+
+// lokiEnvelopeView is the Loki query-API envelope Grafana's Loki
+// datasource backend decodes from /loki/api/v1/query_range.
+type lokiEnvelopeView struct {
+	ResultType string
+	Matrix     []matrixSeriesView
+	Streams    []streamView
+}
+
+type matrixSeriesView struct {
+	Metric map[string]string `json:"metric"`
+	Values [][2]any          `json:"values"`
+}
+
+type streamView struct {
+	Stream map[string]string `json:"stream"`
+	Values [][2]string       `json:"values"`
+}
+
+// promEnvelopeView is the Prometheus query-API envelope.
+type promEnvelopeView struct {
+	ResultType string
+	Vector     []vectorSampleView
+	Matrix     []matrixSeriesView
+}
+
+type vectorSampleView struct {
+	Metric map[string]string `json:"metric"`
+	Value  [2]any            `json:"value"`
+}
+
+// promStringsView is the /api/v1/labels and /api/v1/label/X/values
+// data shape.
+type promStringsView struct{ Data []string }
+
+// promSeriesView is the /api/v1/series data shape.
+type promSeriesView struct{ Data []map[string]string }
+
+// promMetadataView is the /api/v1/metadata data shape.
+type promMetadataView struct {
+	Data map[string][]struct {
+		Type string `json:"type"`
+		Help string `json:"help"`
+		Unit string `json:"unit"`
+	}
+}
+
+// --- Decoder registry ------------------------------------------------
+
+type decodeFunc func(h http.Header, body []byte) (any, error)
+
+var decoders = map[string]decodeFunc{
+	// Grafana 12's Tempo plugin backend unmarshals the
+	// /api/v2/traces/{id} proto body as tempopb.TraceByIDResponse —
+	// the exact decode that died one message level deep when cerberus
+	// served un-enveloped Trace bytes (#764).
+	"tempo-trace-v2-proto": func(h http.Header, body []byte) (any, error) {
+		if ct := h.Get("Content-Type"); ct != "application/protobuf" {
+			return nil, fmt.Errorf("Content-Type = %q, want application/protobuf", ct)
+		}
+		v := &tempopb.TraceByIDResponse{}
+		if err := proto.Unmarshal(body, v); err != nil {
+			return nil, fmt.Errorf("tempopb.TraceByIDResponse unmarshal: %w", err)
+		}
+		return v, nil
+	},
+	// The v1 endpoint serves the bare trace (pre-Grafana-12 decode
+	// and the v1↔v2 divergence pin).
+	"tempo-trace-v1-proto": func(h http.Header, body []byte) (any, error) {
+		if ct := h.Get("Content-Type"); ct != "application/protobuf" {
+			return nil, fmt.Errorf("Content-Type = %q, want application/protobuf", ct)
+		}
+		v := &tempopb.Trace{}
+		if err := proto.Unmarshal(body, v); err != nil {
+			return nil, fmt.Errorf("tempopb.Trace unmarshal: %w", err)
+		}
+		return v, nil
+	},
+	"tempo-search": func(_ http.Header, body []byte) (any, error) {
+		var v searchView
+		if err := json.Unmarshal(body, &v); err != nil {
+			return nil, err
+		}
+		if v.Traces == nil {
+			return nil, fmt.Errorf("traces is null — Tempo serves [], and Grafana iterates it unconditionally")
+		}
+		return &v, nil
+	},
+	"tempo-metrics-range": func(_ http.Header, body []byte) (any, error) {
+		var v metricsRangeView
+		if err := json.Unmarshal(body, &v); err != nil {
+			return nil, err
+		}
+		return &v, nil
+	},
+	"loki-detected-fields": func(_ http.Header, body []byte) (any, error) {
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(body, &raw); err != nil {
+			return nil, err
+		}
+		// The consumer reads body.fields at the TOP level; a {status,
+		// data} wrapper renders "Fields: 0" with HTTP 200 (#774).
+		if _, ok := raw["status"]; ok {
+			return nil, fmt.Errorf("body carries a top-level \"status\" key — detected_fields is served BARE, not in the query-API envelope")
+		}
+		if _, ok := raw["data"]; ok {
+			return nil, fmt.Errorf("body carries a top-level \"data\" key — detected_fields is served BARE, not in the query-API envelope")
+		}
+		fieldsRaw, ok := raw["fields"]
+		if !ok {
+			return nil, fmt.Errorf("top-level \"fields\" key missing")
+		}
+		v := detectedFieldsView{Limit: raw["limit"], raw: raw}
+		if err := json.Unmarshal(fieldsRaw, &v.Fields); err != nil {
+			return nil, fmt.Errorf("fields decode: %w", err)
+		}
+		if v.Fields == nil {
+			return nil, fmt.Errorf("fields is null, want an array")
+		}
+		return &v, nil
+	},
+	"loki-envelope": func(_ http.Header, body []byte) (any, error) {
+		var env struct {
+			Status string `json:"status"`
+			Data   struct {
+				ResultType string          `json:"resultType"`
+				Result     json.RawMessage `json:"result"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(body, &env); err != nil {
+			return nil, err
+		}
+		if env.Status != "success" {
+			return nil, fmt.Errorf("status = %q, want success; body: %s", env.Status, truncate(body, 300))
+		}
+		v := lokiEnvelopeView{ResultType: env.Data.ResultType}
+		switch env.Data.ResultType {
+		case "matrix", "vector":
+			if err := json.Unmarshal(env.Data.Result, &v.Matrix); err != nil {
+				return nil, fmt.Errorf("%s result decode: %w", env.Data.ResultType, err)
+			}
+		case "streams":
+			if err := json.Unmarshal(env.Data.Result, &v.Streams); err != nil {
+				return nil, fmt.Errorf("streams result decode: %w", err)
+			}
+		default:
+			return nil, fmt.Errorf("resultType = %q, want matrix/vector/streams", env.Data.ResultType)
+		}
+		return &v, nil
+	},
+	"prom-envelope": func(_ http.Header, body []byte) (any, error) {
+		var env struct {
+			Status string `json:"status"`
+			Data   struct {
+				ResultType string          `json:"resultType"`
+				Result     json.RawMessage `json:"result"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(body, &env); err != nil {
+			return nil, err
+		}
+		if env.Status != "success" {
+			return nil, fmt.Errorf("status = %q, want success; body: %s", env.Status, truncate(body, 300))
+		}
+		v := promEnvelopeView{ResultType: env.Data.ResultType}
+		switch env.Data.ResultType {
+		case "vector":
+			if err := json.Unmarshal(env.Data.Result, &v.Vector); err != nil {
+				return nil, fmt.Errorf("vector result decode: %w", err)
+			}
+		case "matrix":
+			if err := json.Unmarshal(env.Data.Result, &v.Matrix); err != nil {
+				return nil, fmt.Errorf("matrix result decode: %w", err)
+			}
+		default:
+			return nil, fmt.Errorf("resultType = %q, want vector/matrix", env.Data.ResultType)
+		}
+		return &v, nil
+	},
+	"prom-strings": func(_ http.Header, body []byte) (any, error) {
+		var env struct {
+			Status string   `json:"status"`
+			Data   []string `json:"data"`
+		}
+		if err := json.Unmarshal(body, &env); err != nil {
+			return nil, err
+		}
+		if env.Status != "success" {
+			return nil, fmt.Errorf("status = %q, want success; body: %s", env.Status, truncate(body, 300))
+		}
+		if env.Data == nil {
+			return nil, fmt.Errorf("data is null, want an array")
+		}
+		return &promStringsView{Data: env.Data}, nil
+	},
+	"prom-series": func(_ http.Header, body []byte) (any, error) {
+		var env struct {
+			Status string              `json:"status"`
+			Data   []map[string]string `json:"data"`
+		}
+		if err := json.Unmarshal(body, &env); err != nil {
+			return nil, err
+		}
+		if env.Status != "success" {
+			return nil, fmt.Errorf("status = %q, want success; body: %s", env.Status, truncate(body, 300))
+		}
+		if env.Data == nil {
+			return nil, fmt.Errorf("data is null, want an array")
+		}
+		return &promSeriesView{Data: env.Data}, nil
+	},
+	"prom-metadata": func(_ http.Header, body []byte) (any, error) {
+		var env struct {
+			Status string `json:"status"`
+			Data   map[string][]struct {
+				Type string `json:"type"`
+				Help string `json:"help"`
+				Unit string `json:"unit"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(body, &env); err != nil {
+			return nil, err
+		}
+		if env.Status != "success" {
+			return nil, fmt.Errorf("status = %q, want success; body: %s", env.Status, truncate(body, 300))
+		}
+		return &promMetadataView{Data: env.Data}, nil
+	},
+}
+
+// --- Predicate registry ----------------------------------------------
+
+type predicateFunc func(v any, arg string) error
+
+var predicates = map[string]predicateFunc{
+	// tempopb proto predicates.
+	"trace-present": func(v any, _ string) error {
+		r, ok := v.(*tempopb.TraceByIDResponse)
+		if !ok {
+			return typeErr(v)
+		}
+		if r.Trace == nil {
+			return fmt.Errorf("envelope.Trace is nil — the trace must ride field 1 of TraceByIDResponse")
+		}
+		return nil
+	},
+	"metrics-block-present": func(v any, _ string) error {
+		r, ok := v.(*tempopb.TraceByIDResponse)
+		if !ok {
+			return typeErr(v)
+		}
+		if r.Metrics == nil {
+			return fmt.Errorf("envelope.Metrics is nil — reference Tempo always emits the (zero) metrics block")
+		}
+		return nil
+	},
+	"trace-resource-spans-min": func(v any, arg string) error {
+		n, err := intArg(arg)
+		if err != nil {
+			return err
+		}
+		var got int
+		switch r := v.(type) {
+		case *tempopb.TraceByIDResponse:
+			if r.Trace == nil {
+				return fmt.Errorf("envelope.Trace is nil")
+			}
+			got = len(r.Trace.ResourceSpans)
+		case *tempopb.Trace:
+			got = len(r.ResourceSpans)
+		default:
+			return typeErr(v)
+		}
+		if got < n {
+			return fmt.Errorf("resourceSpans = %d, want >= %d", got, n)
+		}
+		return nil
+	},
+
+	// tempo /api/search predicates.
+	"traces-min": searchCount(func(n, want int) error {
+		if n < want {
+			return fmt.Errorf("traces = %d, want >= %d", n, want)
+		}
+		return nil
+	}),
+	"traces-max": searchCount(func(n, want int) error {
+		if n > want {
+			return fmt.Errorf("traces = %d, want <= %d (the request's limit param)", n, want)
+		}
+		return nil
+	}),
+	"every-trace-has-spansets": func(v any, _ string) error {
+		s, ok := v.(*searchView)
+		if !ok {
+			return typeErr(v)
+		}
+		for _, tr := range s.Traces {
+			if len(tr.SpanSets) == 0 {
+				return fmt.Errorf("trace %s has no spanSets — Grafana's tableType='spans' transform renders zero rows without them (#770)", tr.TraceID)
+			}
+			if tr.SpanSet == nil {
+				return fmt.Errorf("trace %s has no legacy spanSet mirror (tempopb field 6)", tr.TraceID)
+			}
+			for i, set := range tr.SpanSets {
+				if len(set.Spans) == 0 {
+					return fmt.Errorf("trace %s spanSets[%d].spans is empty", tr.TraceID, i)
+				}
+			}
+		}
+		return nil
+	},
+	"spanset-spans-max": func(v any, arg string) error {
+		s, ok := v.(*searchView)
+		if !ok {
+			return typeErr(v)
+		}
+		n, err := intArg(arg)
+		if err != nil {
+			return err
+		}
+		for _, tr := range s.Traces {
+			for i, set := range tr.SpanSets {
+				if len(set.Spans) > n {
+					return fmt.Errorf("trace %s spanSets[%d] carries %d spans, want <= %d (the request's spss param)", tr.TraceID, i, len(set.Spans), n)
+				}
+			}
+		}
+		return nil
+	},
+	// every-span-int-attr asserts every spanSet span carries each of
+	// the comma-separated keys as an OTLP intValue attribute. The
+	// Traces Drilldown structure tab's utils.ts nestedSetLeft()
+	// THROWS when these are missing.
+	"every-span-int-attr": func(v any, arg string) error {
+		s, ok := v.(*searchView)
+		if !ok {
+			return typeErr(v)
+		}
+		keys := strings.Split(arg, ",")
+		for _, tr := range s.Traces {
+			for _, set := range tr.SpanSets {
+				for _, sp := range set.Spans {
+					for _, key := range keys {
+						if !spanHasIntAttr(sp, key, nil) {
+							return fmt.Errorf("trace %s span %s lacks intValue attribute %q", tr.TraceID, sp.SpanID, key)
+						}
+					}
+				}
+			}
+		}
+		return nil
+	},
+	// some-span-int-attr asserts at least one span carries key=value
+	// as an intValue attribute (form "key=value").
+	"some-span-int-attr": func(v any, arg string) error {
+		s, ok := v.(*searchView)
+		if !ok {
+			return typeErr(v)
+		}
+		key, val, found := strings.Cut(arg, "=")
+		if !found {
+			return fmt.Errorf("arg %q must be key=value", arg)
+		}
+		for _, tr := range s.Traces {
+			for _, set := range tr.SpanSets {
+				for _, sp := range set.Spans {
+					if spanHasIntAttr(sp, key, &val) {
+						return nil
+					}
+				}
+			}
+		}
+		return fmt.Errorf("no span carries intValue attribute %s=%s", key, val)
+	},
+	// some-span-str-attr mirrors some-span-int-attr for stringValue.
+	"some-span-str-attr": func(v any, arg string) error {
+		s, ok := v.(*searchView)
+		if !ok {
+			return typeErr(v)
+		}
+		key, val, found := strings.Cut(arg, "=")
+		if !found {
+			return fmt.Errorf("arg %q must be key=value", arg)
+		}
+		for _, tr := range s.Traces {
+			for _, set := range tr.SpanSets {
+				for _, sp := range set.Spans {
+					for _, a := range sp.Attributes {
+						if a.Key == key && a.Value.StringValue != nil && *a.Value.StringValue == val {
+							return nil
+						}
+					}
+				}
+			}
+		}
+		return fmt.Errorf("no span carries stringValue attribute %s=%s", key, val)
+	},
+
+	// tempo /api/metrics/query_range predicates.
+	"series-min": func(v any, arg string) error {
+		m, ok := v.(*metricsRangeView)
+		if !ok {
+			return typeErr(v)
+		}
+		n, err := intArg(arg)
+		if err != nil {
+			return err
+		}
+		if len(m.Series) < n {
+			return fmt.Errorf("series = %d, want >= %d", len(m.Series), n)
+		}
+		return nil
+	},
+	// every-series-label-key asserts each series carries a label with
+	// the given key — the breakdown scenes key their bar charts on the
+	// group-by attribute.
+	"every-series-label-key": func(v any, arg string) error {
+		m, ok := v.(*metricsRangeView)
+		if !ok {
+			return typeErr(v)
+		}
+		for i, s := range m.Series {
+			found := false
+			for _, l := range s.Labels {
+				if l.Key == arg {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return fmt.Errorf("series[%d] lacks label key %q (labels: %+v)", i, arg, s.Labels)
+			}
+		}
+		return nil
+	},
+	// compare-meta-types asserts each comma-separated __meta_type
+	// value appears as the LEADING label of at least one series —
+	// the Comparison tab splits cohorts on it.
+	"compare-meta-types": func(v any, arg string) error {
+		m, ok := v.(*metricsRangeView)
+		if !ok {
+			return typeErr(v)
+		}
+		seen := map[string]bool{}
+		for _, s := range m.Series {
+			if len(s.Labels) == 0 || s.Labels[0].Key != "__meta_type" {
+				return fmt.Errorf("compare() series must lead with __meta_type (Tempo label order); got %+v", s.Labels)
+			}
+			seen[s.Labels[0].Value.StringValue] = true
+		}
+		for _, want := range strings.Split(arg, ",") {
+			if !seen[want] {
+				return fmt.Errorf("no series with __meta_type=%s (got %v)", want, seen)
+			}
+		}
+		return nil
+	},
+	"exemplars-not-null": func(v any, _ string) error {
+		m, ok := v.(*metricsRangeView)
+		if !ok {
+			return typeErr(v)
+		}
+		for i, s := range m.Series {
+			if string(s.Exemplars) == "" || string(s.Exemplars) == "null" {
+				return fmt.Errorf("series[%d].exemplars is %q, want a JSON array (stable envelope contract)", i, s.Exemplars)
+			}
+		}
+		return nil
+	},
+
+	// loki detected_fields predicates.
+	"fields-min": func(v any, arg string) error {
+		d, ok := v.(*detectedFieldsView)
+		if !ok {
+			return typeErr(v)
+		}
+		n, err := intArg(arg)
+		if err != nil {
+			return err
+		}
+		if len(d.Fields) < n {
+			return fmt.Errorf("fields = %d, want >= %d", len(d.Fields), n)
+		}
+		return nil
+	},
+	"fields-shape": func(v any, _ string) error {
+		d, ok := v.(*detectedFieldsView)
+		if !ok {
+			return typeErr(v)
+		}
+		for i, f := range d.Fields {
+			if f.Label == "" {
+				return fmt.Errorf("fields[%d].label is empty", i)
+			}
+			if f.Type == "" {
+				return fmt.Errorf("fields[%d] (%s) has empty type", i, f.Label)
+			}
+			if f.Cardinality <= 0 {
+				return fmt.Errorf("fields[%d] (%s) cardinality = %v, want > 0", i, f.Label, f.Cardinality)
+			}
+			if len(f.Parsers) == 0 {
+				return fmt.Errorf("fields[%d] (%s) parsers key missing — it is always on the wire (null for structured metadata)", i, f.Label)
+			}
+		}
+		return nil
+	},
+	"field-typed": func(v any, arg string) error {
+		d, ok := v.(*detectedFieldsView)
+		if !ok {
+			return typeErr(v)
+		}
+		label, typ, found := strings.Cut(arg, "=")
+		if !found {
+			return fmt.Errorf("arg %q must be label=type", arg)
+		}
+		for _, f := range d.Fields {
+			if f.Label == label {
+				if f.Type != typ {
+					return fmt.Errorf("field %s type = %q, want %q", label, f.Type, typ)
+				}
+				return nil
+			}
+		}
+		return fmt.Errorf("field %s absent from detected fields", label)
+	},
+
+	// loki/prom envelope predicates.
+	"resulttype": func(v any, arg string) error {
+		switch e := v.(type) {
+		case *lokiEnvelopeView:
+			if e.ResultType != arg {
+				return fmt.Errorf("resultType = %q, want %q", e.ResultType, arg)
+			}
+		case *promEnvelopeView:
+			if e.ResultType != arg {
+				return fmt.Errorf("resultType = %q, want %q", e.ResultType, arg)
+			}
+		default:
+			return typeErr(v)
+		}
+		return nil
+	},
+	"result-min": func(v any, arg string) error {
+		n, err := intArg(arg)
+		if err != nil {
+			return err
+		}
+		var got int
+		switch e := v.(type) {
+		case *lokiEnvelopeView:
+			got = len(e.Matrix) + len(e.Streams)
+		case *promEnvelopeView:
+			got = len(e.Vector) + len(e.Matrix)
+		default:
+			return typeErr(v)
+		}
+		if got < n {
+			return fmt.Errorf("result entries = %d, want >= %d", got, n)
+		}
+		return nil
+	},
+	// matrix-values-finite-positive: every matrix sample parses as a
+	// finite float > 0. A duration misparse surfaces here either as a
+	// CH error upstream (status != 200) or as garbage values. Series
+	// stamped with __error__ are excluded from the bound: reference
+	// Loki degrades unparseable unwrap sources to 0-valued samples in
+	// an __error__-labelled bypass series rather than aborting, so 0
+	// is the CORRECT value there.
+	"matrix-values-finite-positive": func(v any, _ string) error {
+		series, err := matrixOf(v)
+		if err != nil {
+			return err
+		}
+		for _, s := range series {
+			if _, errStamped := s.Metric["__error__"]; errStamped {
+				continue
+			}
+			for _, pt := range s.Values {
+				f, err := samplePointValue(pt)
+				if err != nil {
+					return err
+				}
+				if math.IsNaN(f) || math.IsInf(f, 0) || f <= 0 {
+					return fmt.Errorf("series %v sample value %v, want a finite positive float", s.Metric, f)
+				}
+			}
+		}
+		return nil
+	},
+	// matrix-max-value: every matrix sample value <= arg. For the
+	// drilldown duration queries this is the unit-sanity oracle: the
+	// seeded durations are all <= 1.5 SECONDS, so a value above the
+	// bound means a sub-second duration was misparsed (e.g. "812µs"
+	// read as 812 of some larger unit).
+	"matrix-max-value": func(v any, arg string) error {
+		bound, err := strconv.ParseFloat(arg, 64)
+		if err != nil {
+			return fmt.Errorf("arg %q is not a float: %w", arg, err)
+		}
+		series, err := matrixOf(v)
+		if err != nil {
+			return err
+		}
+		for _, s := range series {
+			for _, pt := range s.Values {
+				f, err := samplePointValue(pt)
+				if err != nil {
+					return err
+				}
+				if f > bound {
+					return fmt.Errorf("series %v sample value %g exceeds the unit-sanity bound %g", s.Metric, f, bound)
+				}
+			}
+		}
+		return nil
+	},
+	// series-max-value (arg "label=value,bound"): the matrix series
+	// carrying label=value must exist and every one of its sample
+	// values must be <= bound. This is the sharp per-series unit
+	// oracle: e.g. the seeded error-level durations sum to ~0.4008 s,
+	// so a µs row misparsed as ms (×1000) or s (×10⁶) breaches the
+	// bound while the correct parse stays under it.
+	"series-max-value": func(v any, arg string) error {
+		spec, boundStr, found := strings.Cut(arg, ",")
+		if !found {
+			return fmt.Errorf("arg %q must be label=value,bound", arg)
+		}
+		key, val, found := strings.Cut(spec, "=")
+		if !found {
+			return fmt.Errorf("arg %q must be label=value,bound", arg)
+		}
+		bound, err := strconv.ParseFloat(boundStr, 64)
+		if err != nil {
+			return fmt.Errorf("bound %q is not a float: %w", boundStr, err)
+		}
+		series, err := matrixOf(v)
+		if err != nil {
+			return err
+		}
+		matched := false
+		for _, s := range series {
+			if s.Metric[key] != val {
+				continue
+			}
+			matched = true
+			for _, pt := range s.Values {
+				f, err := samplePointValue(pt)
+				if err != nil {
+					return err
+				}
+				if f > bound {
+					return fmt.Errorf("series %v sample value %g exceeds the per-series bound %g", s.Metric, f, bound)
+				}
+			}
+		}
+		if !matched {
+			return fmt.Errorf("no matrix series with %s=%s", key, val)
+		}
+		return nil
+	},
+	"streams-values-min": func(v any, arg string) error {
+		e, ok := v.(*lokiEnvelopeView)
+		if !ok {
+			return typeErr(v)
+		}
+		n, err := intArg(arg)
+		if err != nil {
+			return err
+		}
+		total := 0
+		for _, s := range e.Streams {
+			total += len(s.Values)
+		}
+		if total < n {
+			return fmt.Errorf("total stream values = %d, want >= %d", total, n)
+		}
+		return nil
+	},
+	// every-series-metric-label: each matrix/vector entry carries the
+	// given label key — the by(<label>) grouping contract.
+	"every-series-metric-label": func(v any, arg string) error {
+		var metrics []map[string]string
+		switch e := v.(type) {
+		case *lokiEnvelopeView:
+			for _, s := range e.Matrix {
+				metrics = append(metrics, s.Metric)
+			}
+		case *promEnvelopeView:
+			for _, s := range e.Vector {
+				metrics = append(metrics, s.Metric)
+			}
+			for _, s := range e.Matrix {
+				metrics = append(metrics, s.Metric)
+			}
+		default:
+			return typeErr(v)
+		}
+		for i, m := range metrics {
+			if _, ok := m[arg]; !ok {
+				return fmt.Errorf("result[%d] metric %v lacks label %q", i, m, arg)
+			}
+		}
+		return nil
+	},
+
+	// prom strings/series/metadata predicates.
+	"strings-contains": func(v any, arg string) error {
+		s, ok := v.(*promStringsView)
+		if !ok {
+			return typeErr(v)
+		}
+		for _, x := range s.Data {
+			if x == arg {
+				return nil
+			}
+		}
+		return fmt.Errorf("%q absent from data %v", arg, s.Data)
+	},
+	"series-count-min": func(v any, arg string) error {
+		s, ok := v.(*promSeriesView)
+		if !ok {
+			return typeErr(v)
+		}
+		n, err := intArg(arg)
+		if err != nil {
+			return err
+		}
+		if len(s.Data) < n {
+			return fmt.Errorf("series = %d, want >= %d", len(s.Data), n)
+		}
+		return nil
+	},
+	"every-series-has-label": func(v any, arg string) error {
+		s, ok := v.(*promSeriesView)
+		if !ok {
+			return typeErr(v)
+		}
+		for i, m := range s.Data {
+			if _, ok := m[arg]; !ok {
+				return fmt.Errorf("series[%d] %v lacks label %q", i, m, arg)
+			}
+		}
+		return nil
+	},
+	"metadata-contains": func(v any, arg string) error {
+		m, ok := v.(*promMetadataView)
+		if !ok {
+			return typeErr(v)
+		}
+		rows, present := m.Data[arg]
+		if !present {
+			return fmt.Errorf("metric %q absent from metadata (got %d metrics)", arg, len(m.Data))
+		}
+		if len(rows) == 0 || rows[0].Type == "" {
+			return fmt.Errorf("metric %q metadata carries no typed entry: %+v", arg, rows)
+		}
+		return nil
+	},
+}
+
+// searchCount adapts a count comparison over searchView.Traces.
+func searchCount(cmp func(n, want int) error) predicateFunc {
+	return func(v any, arg string) error {
+		s, ok := v.(*searchView)
+		if !ok {
+			return typeErr(v)
+		}
+		n, err := intArg(arg)
+		if err != nil {
+			return err
+		}
+		return cmp(len(s.Traces), n)
+	}
+}
+
+func spanHasIntAttr(sp searchSpan, key string, val *string) bool {
+	for _, a := range sp.Attributes {
+		if a.Key == key && a.Value.IntValue != nil && (val == nil || *a.Value.IntValue == *val) {
+			return true
+		}
+	}
+	return false
+}
+
+func matrixOf(v any) ([]matrixSeriesView, error) {
+	switch e := v.(type) {
+	case *lokiEnvelopeView:
+		return e.Matrix, nil
+	case *promEnvelopeView:
+		return e.Matrix, nil
+	}
+	return nil, typeErr(v)
+}
+
+// samplePointValue extracts the stringified float from a [ts, "v"]
+// sample pair.
+func samplePointValue(pt [2]any) (float64, error) {
+	s, ok := pt[1].(string)
+	if !ok {
+		return 0, fmt.Errorf("sample value %v is not the stringified-float wire shape", pt[1])
+	}
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, fmt.Errorf("sample value %q does not parse as float: %w", s, err)
+	}
+	return f, nil
+}
+
+func intArg(arg string) (int, error) {
+	n, err := strconv.Atoi(arg)
+	if err != nil {
+		return 0, fmt.Errorf("predicate arg %q is not an integer: %w", arg, err)
+	}
+	return n, nil
+}
+
+func typeErr(v any) error {
+	return fmt.Errorf("predicate not applicable to decoded type %T", v)
+}
+
+// KnownDecoder reports whether name is a registered decoder — used by
+// the ratchet meta-test to reject corpus entries that name decoders
+// the harness can't run.
+func KnownDecoder(name string) bool { _, ok := decoders[name]; return ok }
+
+// KnownPredicate mirrors KnownDecoder for predicate names.
+func KnownPredicate(name string) bool { _, ok := predicates[name]; return ok }

--- a/test/consumer-corpus/replay_chdb_test.go
+++ b/test/consumer-corpus/replay_chdb_test.go
@@ -1,0 +1,232 @@
+//go:build chdb
+
+// chDB-backed corpus replay: the same consumer-captured requests as
+// the stub lane, but executed through the FULL pipeline — parse →
+// lower → optimize → emit → ClickHouse (chDB) → response shaping —
+// against small deterministic seeds. This lane additionally evaluates
+// each entry's `expect.data` predicates (non-empty results, grouping
+// labels, value/unit sanity), which canned stub rows cannot pin.
+package consumercorpus
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/api/loki"
+	"github.com/tsouza/cerberus/internal/api/prom"
+	"github.com/tsouza/cerberus/internal/api/tempo"
+	"github.com/tsouza/cerberus/internal/chclienttest"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// --- Traces seed -----------------------------------------------------
+//
+// Anchor 2026-05-01T10:00:00Z. Two traces:
+//
+//	trace A (a…01): the 4-span tree from
+//	internal/api/tempo/search_select_nested_set_chdb_test.go —
+//	r1 GET /home (Server, frontend, root)
+//	├─ c1 auth     (Internal, auth)
+//	└─ c2 checkout (Server, checkout, Error)
+//	   └─ g1 db    (Client, db)
+//	trace B (b…02): a single Error root (Server, payments) so the
+//	Comparison tab's compare({status = error}) selection cohort is
+//	non-empty among ROOT spans ({nestedSetParent<0} scopes the outer
+//	filter to roots).
+const tracesChDBSeed = `CREATE TABLE otel_traces (
+    TraceId String,
+    SpanId String,
+    ParentSpanId String,
+    SpanName String,
+    SpanKind LowCardinality(String),
+    ServiceName LowCardinality(String),
+    Duration Int64,
+    Timestamp DateTime64(9),
+    StatusCode LowCardinality(String),
+    StatusMessage String,
+    ScopeName String,
+    ScopeVersion String,
+    SpanAttributes Map(String, String),
+    ResourceAttributes Map(String, String)
+) ENGINE = MergeTree() ORDER BY (Timestamp);
+INSERT INTO otel_traces VALUES
+    ('a0000000000000000000000000000001', '1000000000000001', '', 'GET /home', 'Server', 'frontend', 1000, toDateTime64('2026-05-01 10:00:00.000000001', 9), 'Unset', '', '', '', map(), map('service.name', 'frontend')),
+    ('a0000000000000000000000000000001', '1000000000000002', '1000000000000001', 'auth', 'Internal', 'auth', 500, toDateTime64('2026-05-01 10:00:00.000000002', 9), 'Unset', '', '', '', map(), map('service.name', 'auth')),
+    ('a0000000000000000000000000000001', '1000000000000003', '1000000000000001', 'checkout', 'Server', 'checkout', 700, toDateTime64('2026-05-01 10:00:00.000000003', 9), 'Error', '', '', '', map(), map('service.name', 'checkout')),
+    ('a0000000000000000000000000000001', '1000000000000004', '1000000000000003', 'db', 'Client', 'db', 300, toDateTime64('2026-05-01 10:00:00.000000004', 9), 'Unset', '', '', '', map(), map('service.name', 'db')),
+    ('b0000000000000000000000000000002', '2000000000000001', '', 'POST /pay', 'Server', 'payments', 900, toDateTime64('2026-05-01 10:00:30.000000001', 9), 'Error', 'card declined', '', '', map(), map('service.name', 'payments'));`
+
+// chdbTraceID is the trace the chdb lane resolves ${TRACE_ID} to.
+const chdbTraceID = "a0000000000000000000000000000001"
+
+var chdbTracesAnchor = time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+
+// --- Logs seed -------------------------------------------------------
+//
+// Anchor 2026-01-01T00:00:00Z, one row per 15 s, all in the
+// {service_name="api"} stream. Bodies are logfmt with a duration
+// field whose values cover ms / s / µs plus one unparseable value
+// ("oops"): real OTel log bodies carry Go's Duration.String() µ-sign
+// form AND occasional garbage, and reference Loki NEVER aborts on
+// either — an unparseable unwrap source degrades per-row to a
+// 0-valued sample in an __error__-stamped series
+// (pkg/logql/log/metrics_extraction.go), it does not turn the whole
+// query into an error. LogAttributes carries a structured-metadata
+// field so detected_fields surfaces both parser classes.
+const logsChDBSeed = `CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    SeverityText LowCardinality(String),
+    SeverityNumber UInt8 DEFAULT 0,
+    Body String,
+    LogAttributes Map(String, String),
+    ResourceAttributes Map(String, String),
+    ServiceName LowCardinality(String) DEFAULT '',
+    ScopeName String DEFAULT '',
+    ScopeVersion String DEFAULT '',
+    EventName LowCardinality(String) DEFAULT '',
+    TraceId String DEFAULT '',
+    SpanId String DEFAULT '',
+    TraceFlags UInt8 DEFAULT 0
+) ENGINE = MergeTree ORDER BY Timestamp;
+INSERT INTO otel_logs (Timestamp, SeverityText, Body, LogAttributes, ResourceAttributes) VALUES
+    (toDateTime64('2026-01-01 00:00:00', 9), 'INFO',  'level=info duration=100ms msg=ok id=1',   map('detected_level', 'info'),  map('service_name', 'api')),
+    (toDateTime64('2026-01-01 00:00:15', 9), 'INFO',  'level=info duration=200ms msg=ok id=2',   map('detected_level', 'info'),  map('service_name', 'api')),
+    (toDateTime64('2026-01-01 00:00:30', 9), 'ERROR', 'level=error duration=400ms msg=boom id=3', map('detected_level', 'error'), map('service_name', 'api')),
+    (toDateTime64('2026-01-01 00:00:45', 9), 'ERROR', 'level=error duration=812µs msg=boom id=4', map('detected_level', 'error'), map('service_name', 'api')),
+    (toDateTime64('2026-01-01 00:01:00', 9), 'INFO',  'level=info duration=1.5s msg=ok id=5',    map('detected_level', 'info'),  map('service_name', 'api')),
+    (toDateTime64('2026-01-01 00:01:15', 9), 'ERROR', 'level=error duration=oops msg=boom id=6',  map('detected_level', 'error'), map('service_name', 'api'));`
+
+var chdbLogsAnchor = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// --- Metrics seed ----------------------------------------------------
+//
+// Mirrors regexNameSeed in
+// internal/api/prom/handler_chdb_regex_name_matcher_test.go: a
+// sum-stored UpDownCounter (cerberus_query_inflight) plus a gauge
+// decoy. NOW-anchored because the labels / series matcher paths anchor
+// their lookback window at request time. The rows sit two minutes in
+// the past so that BOTH anchoring styles cover them: the explicit
+// `time=${END_UNIX}` instant query (whole-second truncation would
+// otherwise place a now-anchored row just AFTER the requested instant)
+// and the request-time-anchored matcher paths. All three metric tables
+// are created — the metadata handler and the bare-histogram matcher
+// fan-out read every table regardless of which carry rows.
+func metricsChDBSeed(now time.Time) string {
+	ts := now.Add(-2 * time.Minute).UTC().Format("2006-01-02 15:04:05.000")
+	return `CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    MetricDescription String,
+    MetricUnit String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree() ORDER BY (MetricName, TimeUnix);
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    MetricDescription String,
+    MetricUnit String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64,
+    IsMonotonic Bool DEFAULT false
+) ENGINE = MergeTree() ORDER BY (MetricName, TimeUnix);
+CREATE TABLE otel_metrics_histogram (
+    MetricName String,
+    MetricDescription String,
+    MetricUnit String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    BucketCounts Array(UInt64),
+    ExplicitBounds Array(Float64)
+) ENGINE = MergeTree() ORDER BY (MetricName, TimeUnix);
+INSERT INTO otel_metrics_gauge (MetricName, MetricDescription, MetricUnit, Attributes, TimeUnix, Value) VALUES
+    ('up', '', '', map('job', 'api'), toDateTime64('` + ts + `', 9), 1.0);
+INSERT INTO otel_metrics_sum (MetricName, MetricDescription, MetricUnit, Attributes, TimeUnix, Value) VALUES
+    ('cerberus_query_inflight', 'in-flight queries', '', map('cerberus_ql', 'promql'),  toDateTime64('` + ts + `', 9), 2.0),
+    ('cerberus_query_inflight', 'in-flight queries', '', map('cerberus_ql', 'logql'),   toDateTime64('` + ts + `', 9), 1.0),
+    ('cerberus_query_inflight', 'in-flight queries', '', map('cerberus_ql', 'traceql'), toDateTime64('` + ts + `', 9), 0.0);`
+}
+
+// chdbTokens mirrors StubTokens for the chdb lane's seed anchors.
+func chdbTokens(datasource string, now time.Time) map[string]string {
+	var start, end time.Time
+	traceID := chdbTraceID
+	switch datasource {
+	case "tempo":
+		start, end = chdbTracesAnchor.Add(-2*time.Minute), chdbTracesAnchor.Add(3*time.Minute)
+	case "loki":
+		start, end = chdbLogsAnchor.Add(-1*time.Minute), chdbLogsAnchor.Add(5*time.Minute)
+	case "prom":
+		start, end = now.Add(-15*time.Minute), now
+	}
+	return map[string]string{
+		"START_UNIX": fmt.Sprintf("%d", start.Unix()),
+		"END_UNIX":   fmt.Sprintf("%d", end.Unix()),
+		"START_NS":   fmt.Sprintf("%d", start.UnixNano()),
+		"END_NS":     fmt.Sprintf("%d", end.UnixNano()),
+		"TRACE_ID":   traceID,
+	}
+}
+
+// TestConsumerCorpus_Replay_ChDB replays every corpus entry against
+// chDB-seeded in-process handlers, evaluating wire AND data
+// predicates. Entries run as independent subtests so a single run
+// reports every violated contract — no early exit, no tolerated
+// failures.
+func TestConsumerCorpus_Replay_ChDB(t *testing.T) {
+	entries, err := Load(".")
+	if err != nil {
+		t.Fatalf("load corpus: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("corpus is empty")
+	}
+
+	now := time.Now()
+
+	// Every entry gets its own chdb session + seed, mirroring the
+	// repo-wide chclienttest.NewChDB(t)-per-test convention. Sharing
+	// one session across entries is NOT safe here: corpus entries
+	// that pin known-broken queries surface real ClickHouse
+	// exceptions, and chdb-go v1.11.0 follows an exception-bearing
+	// query with corrupted parquet result buffers on subsequent
+	// queries (deterministic `reading page index of parquet file`
+	// panic inside the driver). Per-entry sessions keep each replay
+	// hermetic.
+	newServer := func(t *testing.T, datasource string) *httptest.Server {
+		t.Helper()
+		c := chclienttest.NewChDB(t)
+		mux := http.NewServeMux()
+		switch datasource {
+		case "tempo":
+			c.Seed(t, tracesChDBSeed)
+			tempo.New(c, schema.DefaultOTelTraces(), "v0.0.0-corpus", nil).Mount(mux)
+		case "loki":
+			c.Seed(t, logsChDBSeed)
+			loki.New(c, schema.DefaultOTelLogs(), nil).Mount(mux)
+		case "prom":
+			c.Seed(t, metricsChDBSeed(now))
+			prom.New(c, schema.DefaultOTelMetrics(), nil).Mount(mux)
+		default:
+			t.Fatalf("unknown datasource %q", datasource)
+		}
+		srv := httptest.NewServer(mux)
+		t.Cleanup(srv.Close)
+		return srv
+	}
+
+	for _, e := range entries {
+		e := e
+		t.Run(e.Version+"/"+e.Name, func(t *testing.T) {
+			srv := newServer(t, e.Datasource)
+			for _, err := range Replay(srv.Client(), srv.URL, e, chdbTokens(e.Datasource, now), true) {
+				t.Errorf("%v", err)
+			}
+		})
+	}
+}

--- a/test/consumer-corpus/replay_test.go
+++ b/test/consumer-corpus/replay_test.go
@@ -1,0 +1,65 @@
+package consumercorpus
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/api/loki"
+	"github.com/tsouza/cerberus/internal/api/prom"
+	"github.com/tsouza/cerberus/internal/api/tempo"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// newStubServer builds the entry's datasource handler over the named
+// canned-row fixture, mirroring how internal/api/*/conformance tests
+// construct handlers.
+func newStubServer(t *testing.T, datasource, fixture string) *httptest.Server {
+	t.Helper()
+	q, err := StubFixture(fixture)
+	if err != nil {
+		t.Fatalf("stub fixture: %v", err)
+	}
+	mux := http.NewServeMux()
+	switch datasource {
+	case "prom":
+		prom.New(q, schema.DefaultOTelMetrics(), nil).Mount(mux)
+	case "loki":
+		loki.New(q, schema.DefaultOTelLogs(), nil).Mount(mux)
+	case "tempo":
+		tempo.New(q, schema.DefaultOTelTraces(), "v0.0.0-corpus", nil).Mount(mux)
+	default:
+		t.Fatalf("unknown datasource %q", datasource)
+	}
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestConsumerCorpus_Replay_Stub replays every corpus entry against
+// stub-backed in-process handlers and asserts the wire-level consumer
+// contract: HTTP status, the exact consumer decode, and the wire
+// predicates. Each entry is an independent subtest, so a run always
+// reports EVERY violated entry — no early exit, no tolerated
+// failures.
+func TestConsumerCorpus_Replay_Stub(t *testing.T) {
+	t.Parallel()
+
+	entries, err := Load(".")
+	if err != nil {
+		t.Fatalf("load corpus: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("corpus is empty")
+	}
+	for _, e := range entries {
+		e := e
+		t.Run(e.Version+"/"+e.Name, func(t *testing.T) {
+			t.Parallel()
+			srv := newStubServer(t, e.Datasource, e.Stub)
+			for _, err := range Replay(srv.Client(), srv.URL, e, StubTokens(e.Datasource), false) {
+				t.Errorf("%v", err)
+			}
+		})
+	}
+}

--- a/test/consumer-corpus/stub.go
+++ b/test/consumer-corpus/stub.go
@@ -1,0 +1,315 @@
+package consumercorpus
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+// StubQuerier serves canned rows for every Querier method the three
+// handlers (api/prom, api/loki, api/tempo) define. It is the default
+// lane's backend: requests flow through the full handler pipeline
+// (param parsing, QL parse, lowering, SQL emission, response shaping)
+// and only the ClickHouse execution step is replaced by canned rows.
+//
+// The canned-row shapes mirror the wire projections the engine's
+// wrap-projections emit (reserved __cerberus_* label slots etc.) —
+// they are lifted from the per-handler stub fixtures in
+// internal/api/*/conformance_test.go and friends.
+type StubQuerier struct {
+	Samples      []chclient.Sample
+	Strings      []string
+	LabelSets    []map[string]string
+	MetaRows     []chclient.MetricMetaRow
+	DetectedRows []chclient.DetectedFieldRow
+}
+
+func (s *StubQuerier) Query(context.Context, string, ...any) ([]chclient.Sample, error) {
+	return s.Samples, nil
+}
+
+func (s *StubQuerier) QueryCursor(context.Context, string, ...any) (chclient.Cursor, error) {
+	return &sliceCursor{samples: s.Samples}, nil
+}
+
+func (s *StubQuerier) QueryStrings(context.Context, string, ...any) ([]string, error) {
+	return s.Strings, nil
+}
+
+func (s *StubQuerier) QueryLabelSets(context.Context, string, ...any) ([]map[string]string, error) {
+	return s.LabelSets, nil
+}
+
+func (s *StubQuerier) QueryMetricMeta(_ context.Context, _, metricType string, _ ...any) ([]chclient.MetricMetaRow, error) {
+	// The metadata handler fans out once per table kind and stamps
+	// the kind itself; serve the canned rows only for the kind they
+	// declare so the fan-out doesn't triple-report.
+	var out []chclient.MetricMetaRow
+	for _, r := range s.MetaRows {
+		if r.Type == metricType {
+			out = append(out, r)
+		}
+	}
+	return out, nil
+}
+
+func (s *StubQuerier) QueryExemplars(context.Context, string, ...any) ([]chclient.ExemplarRow, error) {
+	return nil, nil
+}
+
+func (s *StubQuerier) QueryDetectedFieldRows(context.Context, string, ...any) ([]chclient.DetectedFieldRow, error) {
+	return s.DetectedRows, nil
+}
+
+func (s *StubQuerier) QueryTimestampedLines(context.Context, string, ...any) ([]chclient.TimestampedLine, error) {
+	return nil, nil
+}
+
+func (s *StubQuerier) QueryIndexStats(context.Context, string, ...any) (chclient.IndexStatsRow, error) {
+	return chclient.IndexStatsRow{}, nil
+}
+
+func (s *StubQuerier) QueryIndexVolume(context.Context, string, ...any) ([]chclient.IndexVolumeRow, error) {
+	return nil, nil
+}
+
+// sliceCursor adapts canned samples to the chclient.Cursor contract.
+type sliceCursor struct {
+	samples []chclient.Sample
+	i       int
+}
+
+func (c *sliceCursor) Next() bool {
+	if c.i >= len(c.samples) {
+		return false
+	}
+	c.i++
+	return true
+}
+
+func (c *sliceCursor) Sample() chclient.Sample { return c.samples[c.i-1] }
+func (c *sliceCursor) Err() error              { return nil }
+func (c *sliceCursor) Close() error            { return nil }
+
+// Stub-lane time anchors. Every canned fixture timestamps its rows
+// against these, and StubTokens derives the request windows from the
+// same values, so windows and rows always agree.
+var (
+	stubTempoAnchor = time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC)
+	stubLokiAnchor  = time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+	stubPromAnchor  = time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+)
+
+// StubTraceID is the trace the trace-by-id fixtures carry; the
+// stub lane resolves ${TRACE_ID} to it.
+const StubTraceID = "f48694fee9f78da6f98ec5a8cd7d3274"
+
+// StubTokens returns the ${TOKEN} map for the stub lane, per
+// datasource.
+func StubTokens(datasource string) map[string]string {
+	var start, end time.Time
+	switch datasource {
+	case "tempo":
+		start, end = stubTempoAnchor, stubTempoAnchor.Add(3*time.Minute)
+	case "loki":
+		start, end = stubLokiAnchor, stubLokiAnchor.Add(5*time.Minute)
+	case "prom":
+		start, end = stubPromAnchor.Add(-5*time.Minute), stubPromAnchor
+	}
+	return map[string]string{
+		"START_UNIX": fmt.Sprintf("%d", start.Unix()),
+		"END_UNIX":   fmt.Sprintf("%d", end.Unix()),
+		"START_NS":   fmt.Sprintf("%d", start.UnixNano()),
+		"END_NS":     fmt.Sprintf("%d", end.UnixNano()),
+		"TRACE_ID":   StubTraceID,
+	}
+}
+
+// StubFixture resolves a corpus entry's named stub fixture.
+func StubFixture(name string) (*StubQuerier, error) {
+	fn, ok := stubFixtures[name]
+	if !ok {
+		return nil, fmt.Errorf("unknown stub fixture %q", name)
+	}
+	return fn(), nil
+}
+
+// KnownStubFixture reports fixture-name validity for the ratchet.
+func KnownStubFixture(name string) bool { _, ok := stubFixtures[name]; return ok }
+
+var stubFixtures = map[string]func() *StubQuerier{
+	// empty backs entries whose default-lane contract is routing +
+	// status + envelope decodability with no canned rows (e.g. the
+	// drilldown breakdown queries, whose historical failure mode was
+	// a 422 at parse/lower time — before any SQL runs).
+	"empty": func() *StubQuerier { return &StubQuerier{} },
+
+	// tempo-trace-by-id mirrors traceByIDFixtureSamples in
+	// internal/api/tempo/handler_trace_v2_test.go: the reserved-key
+	// label contract the engine's trace-by-id wrap-projection emits.
+	"tempo-trace-by-id": func() *StubQuerier {
+		span := func(svc, name, spanID, parentID string, at time.Time) chclient.Sample {
+			return chclient.Sample{
+				MetricName: name,
+				Labels: map[string]string{
+					"service.name":             svc,
+					"__cerberus_traceID":       StubTraceID,
+					"__cerberus_spanID":        spanID,
+					"__cerberus_parentSpanID":  parentID,
+					"__cerberus_spanKind":      "Server",
+					"__cerberus_statusCode":    "Ok",
+					"__cerberus_spanAttrsJSON": `{"http.method":"GET"}`,
+				},
+				Timestamp: at,
+				Value:     1_500_000,
+			}
+		}
+		return &StubQuerier{Samples: []chclient.Sample{
+			span("frontend", "GET /", "aaaa000000000001", "", stubTempoAnchor),
+			span("backend", "SELECT users", "bbbb000000000002", "aaaa000000000001", stubTempoAnchor.Add(2*time.Millisecond)),
+		}}
+	},
+
+	// tempo-search mirrors searchSpanRow in
+	// internal/api/tempo/handler_test.go: canonical /api/search rows
+	// with the reserved trace/span/parent ID slots toTraceSummaries
+	// pivots into spanSets.
+	"tempo-search": func() *StubQuerier {
+		row := func(spanID, name string, at time.Time, durNs float64) chclient.Sample {
+			return chclient.Sample{
+				MetricName: name,
+				Labels: map[string]string{
+					"service.name":            "checkout",
+					"__cerberus_traceID":      StubTraceID,
+					"__cerberus_parentSpanID": "0000000000000000",
+					"__cerberus_spanID":       spanID,
+				},
+				Timestamp: at,
+				Value:     durNs,
+			}
+		}
+		return &StubQuerier{Samples: []chclient.Sample{
+			row("0000000000000001", "GET /api/users", stubTempoAnchor, 150_000_000),
+			row("0000000000000002", "db.query", stubTempoAnchor.Add(10*time.Millisecond), 50_000_000),
+		}}
+	},
+
+	// tempo-search-select mirrors the select() rows in
+	// internal/api/tempo/search_select_attrs_test.go: selected values
+	// ride reserved __cerberus_sel_* slots (int-typed nested-set
+	// intrinsics, string-typed attributes, the span name).
+	"tempo-search-select": func() *StubQuerier {
+		return &StubQuerier{Samples: []chclient.Sample{
+			{
+				MetricName: "GET /home",
+				Labels: map[string]string{
+					"service.name":                       "frontend",
+					"__cerberus_traceID":                 StubTraceID,
+					"__cerberus_parentSpanID":            "",
+					"__cerberus_spanID":                  "1000000000000001",
+					"__cerberus_sel_name":                "GET /home",
+					"__cerberus_sel_int_nestedSetParent": "-1",
+					"__cerberus_sel_int_nestedSetLeft":   "1",
+					"__cerberus_sel_int_nestedSetRight":  "8",
+					"__cerberus_sel_str_status":          "unset",
+					"__cerberus_sel_str_service.name":    "frontend",
+				},
+				Timestamp: stubTempoAnchor,
+				Value:     1000,
+			},
+			{
+				MetricName: "checkout",
+				Labels: map[string]string{
+					"service.name":                       "checkout",
+					"__cerberus_traceID":                 StubTraceID,
+					"__cerberus_parentSpanID":            "1000000000000001",
+					"__cerberus_spanID":                  "1000000000000003",
+					"__cerberus_sel_name":                "checkout",
+					"__cerberus_sel_int_nestedSetParent": "1",
+					"__cerberus_sel_int_nestedSetLeft":   "4",
+					"__cerberus_sel_int_nestedSetRight":  "7",
+					"__cerberus_sel_str_status":          "error",
+					"__cerberus_sel_str_service.name":    "checkout",
+				},
+				Timestamp: stubTempoAnchor.Add(2 * time.Millisecond),
+				Value:     700,
+			},
+		}}
+	},
+
+	// tempo-compare mirrors compareRow in
+	// internal/api/tempo/metrics_query_range_compare_test.go: the raw
+	// __is_sel / __attr / __val projection wrapCompareForSample emits.
+	"tempo-compare": func() *StubQuerier {
+		row := func(isSel, attr, val string, count float64) chclient.Sample {
+			return chclient.Sample{
+				Labels:    map[string]string{"__is_sel": isSel, "__attr": attr, "__val": val},
+				Timestamp: stubTempoAnchor.Add(time.Minute),
+				Value:     count,
+			}
+		}
+		return &StubQuerier{Samples: []chclient.Sample{
+			row("0", "resource.service.name", "shop", 3),
+			row("1", "resource.service.name", "shop", 1),
+		}}
+	},
+
+	// loki-detected-fields mirrors the logfmt fixture in
+	// internal/api/loki/detected_fields_test.go (duration-typed field
+	// included — the type drives Logs Drilldown's unwrap query
+	// generation).
+	"loki-detected-fields": func() *StubQuerier {
+		return &StubQuerier{DetectedRows: []chclient.DetectedFieldRow{
+			{Line: `level=info method=GET status=200 duration=12ms`},
+			{Line: `level=error method=POST status=500 duration=1s`},
+		}}
+	},
+
+	// loki-streams: log lines ride MetricName (the body slot of the
+	// log-sample projection) with stream labels in Labels.
+	"loki-streams": func() *StubQuerier {
+		return &StubQuerier{Samples: []chclient.Sample{
+			{MetricName: "level=info duration=100ms msg=ok id=1", Labels: map[string]string{"service_name": "api"}, Timestamp: stubLokiAnchor},
+			{MetricName: "level=error duration=400ms msg=boom id=2", Labels: map[string]string{"service_name": "api"}, Timestamp: stubLokiAnchor.Add(time.Second)},
+		}}
+	},
+
+	// prom-vector: an instant-vector result for the Metrics Drilldown
+	// regex __name__ selector.
+	"prom-vector": func() *StubQuerier {
+		return &StubQuerier{Samples: []chclient.Sample{
+			{MetricName: "cerberus_query_inflight", Labels: map[string]string{"cerberus_ql": "promql"}, Timestamp: stubPromAnchor, Value: 2},
+			{MetricName: "cerberus_query_inflight", Labels: map[string]string{"cerberus_ql": "logql"}, Timestamp: stubPromAnchor, Value: 1},
+		}}
+	},
+
+	// prom-labels: /api/v1/labels string rows.
+	"prom-labels": func() *StubQuerier {
+		return &StubQuerier{Strings: []string{"__name__", "cerberus_ql"}}
+	},
+
+	// prom-label-values: /api/v1/label/cerberus_ql/values rows.
+	"prom-label-values": func() *StubQuerier {
+		return &StubQuerier{Strings: []string{"logql", "promql", "traceql"}}
+	},
+
+	// prom-series: /api/v1/series reuses the instant-query pipeline
+	// (fetchSeries → executeInstant), so the canned rows are Samples;
+	// the handler dedupes them into label sets.
+	"prom-series": func() *StubQuerier {
+		return &StubQuerier{Samples: []chclient.Sample{
+			{MetricName: "cerberus_query_inflight", Labels: map[string]string{"cerberus_ql": "promql"}, Timestamp: stubPromAnchor, Value: 2},
+			{MetricName: "cerberus_query_inflight", Labels: map[string]string{"cerberus_ql": "logql"}, Timestamp: stubPromAnchor, Value: 1},
+		}}
+	},
+
+	// prom-metadata: /api/v1/metadata rows (one per table-kind
+	// fan-out arm the stub answers).
+	"prom-metadata": func() *StubQuerier {
+		return &StubQuerier{MetaRows: []chclient.MetricMetaRow{
+			{Name: "cerberus_query_inflight", Description: "in-flight queries", Unit: "", Type: "gauge"},
+		}}
+	},
+}


### PR DESCRIPTION
## Summary

New cheap test layer (shift-left doctrine): **real Grafana 12.2.9 request shapes replayed through the in-process handlers in the default `check` lane** — consumer-contract bugs caught at unit cost instead of e2e. This week's incident census this layer would have caught in-process: the v2 `TraceByIDResponse` strict-decode break, `queryType traceId` routing, the detected_fields envelope, the Drilldown `<groupBy> != nil` 422s (maintainer-found), and the spanSets omission.

## What's in `test/consumer-corpus/`

- **Version-keyed corpus** (`grafana-12.2.9/*.json`): verbatim request shapes with provenance — tempo trace-by-id (`queryType: traceId`), search with `limit`/`spss`, Traces Drilldown breakdown/comparison/structure queries (incl. `{nestedSetParent<0 && true && <groupBy> != nil} | rate() by(<groupBy>)` for kind/status/name and `compare({status=error},10)`), loki detected_fields, Logs Drilldown duration aggregations, prom Metrics Drilldown regex `match[]` shapes.
- **Replay harness**: httptest handlers (+chdb-backed querier where execution is needed), decoding responses **as the consumer does** — strict gogo unmarshal into tempopb, bare logproto JSON, Prom envelopes — with per-entry expectations declared in the corpus files; all entries run, all failures reported (no early exit).
- **Ratchet**: corpus shrink-forbidden meta-test (total + per-datasource minimums); refresh flow documented (the nightly crawler mines new captures; Grafana bumps get a new version directory).
- Layer placement documented in `docs/test-strategy.md`.

## Provenance note

The implementing agent's session ended awaiting the nil-comparison fix; its commit was rebased onto current main (which now has #780 + #781), the full suite verified green (39 chdb-lane assertions), and two lint findings fixed in a follow-up commit (errcheck on Body.Close, gosec G304 via Clean + containment comment).

Closes task #52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
