### PR TITLE
test(rejection-parity): every deliberate 422 differentially verified against reference

### DIFF
--- a/compatibility/cmd/rejection-parity/main.go
+++ b/compatibility/cmd/rejection-parity/main.go
@@ -1,0 +1,257 @@
+// Command rejection-parity is the differential harness for cerberus's
+// deliberate rejections. It consumes the rejection catalogue
+// (test/rejection-parity/catalogue.json — see that package's doc for
+// the full mechanism) and, for every class=rejection entry of the
+// selected head, sends the entry's trigger query to BOTH the reference
+// backend and cerberus, then compares the rejection *status class*:
+//
+//   - both 4xx                → parity (cerberus's rejection claim holds)
+//   - reference 2xx, cerberus 4xx → wrong_rejection — cerberus rejects a
+//     query the reference backend answers; a real bug to fix at the
+//     source (the `kind != nil` class), never an allow-list entry
+//   - cerberus 2xx            → stale_catalogue — the catalogue says
+//     cerberus rejects this, but the live binary accepts it; the
+//     catalogue needs regenerating
+//   - 5xx / transport failure → hard_error (infrastructure, not parity)
+//
+// Only the status class is compared — never message text — because
+// the two backends phrase rejections differently by construction.
+//
+// The corpus is the catalogue itself (rejectionparity.BuildCases), so
+// corpus-case count == catalogue rejection-entry count by
+// construction; the meta-tests under test/rejection-parity pin the
+// remaining legs of the ratchet (site scan == catalogue, triggers
+// exercise their sites).
+//
+// Exit semantics mirror the other compat drivers (task #68,
+// report-only): parity drift — including wrong_rejection — is recorded
+// in the JSON report and the stderr summary but does not change the
+// exit code. Only driver-wide hard errors (catalogue load, report
+// write) escalate to a non-zero rc.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	rejectionparity "github.com/tsouza/cerberus/test/rejection-parity"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "rejection-parity: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// CaseResult is one trigger query's outcome on both backends.
+type CaseResult struct {
+	// Name is the catalogue site key (greppable back to the
+	// error-construction site in the lowering source).
+	Name     string `json:"name"`
+	Endpoint string `json:"endpoint"`
+	Query    string `json:"query"`
+
+	RefStatus      int `json:"refStatus"`
+	CerberusStatus int `json:"cerberusStatus"`
+
+	// Verdict: "parity" | "wrong_rejection" | "stale_catalogue" |
+	// "hard_error".
+	Verdict string `json:"verdict"`
+	// Detail carries the transport error or a snippet of the
+	// unexpected response body for triage.
+	Detail string `json:"detail,omitempty"`
+}
+
+// Report is the on-disk JSON artifact.
+type Report struct {
+	Head           string       `json:"head"`
+	Total          int          `json:"total"`
+	Parity         int          `json:"parity"`
+	WrongRejection int          `json:"wrongRejection"`
+	StaleCatalogue int          `json:"staleCatalogue"`
+	HardErrors     int          `json:"hardErrors"`
+	Cases          []CaseResult `json:"cases"`
+}
+
+func run() error {
+	var (
+		head      = flag.String("head", "", "head to run: promql | logql | traceql")
+		catalogue = flag.String("catalogue", "test/rejection-parity/catalogue.json", "path to the rejection catalogue")
+		refURL    = flag.String("ref", "", "reference backend base URL")
+		cerbURL   = flag.String("cerberus", "", "cerberus base URL")
+		report    = flag.String("report", "", "JSON report output path")
+		timeout   = flag.Duration("timeout", 30*time.Second, "per-request HTTP timeout")
+	)
+	flag.Parse()
+	if *head == "" || *refURL == "" || *cerbURL == "" || *report == "" {
+		return fmt.Errorf("-head, -ref, -cerberus and -report are all required")
+	}
+
+	cat, err := rejectionparity.LoadCatalogue(*catalogue)
+	if err != nil {
+		return fmt.Errorf("load catalogue: %w", err)
+	}
+	cases, err := rejectionparity.BuildCases(cat, *head)
+	if err != nil {
+		return fmt.Errorf("build cases: %w", err)
+	}
+	if len(cases) == 0 {
+		return fmt.Errorf("catalogue has zero rejection entries for head %s", *head)
+	}
+
+	client := &http.Client{Timeout: *timeout}
+	now := time.Now().UTC()
+	rep := Report{Head: *head, Total: len(cases)}
+	for _, c := range cases {
+		res := runCase(client, c, *refURL, *cerbURL, now)
+		switch res.Verdict {
+		case "parity":
+			rep.Parity++
+		case "wrong_rejection":
+			rep.WrongRejection++
+		case "stale_catalogue":
+			rep.StaleCatalogue++
+		default:
+			rep.HardErrors++
+		}
+		rep.Cases = append(rep.Cases, res)
+	}
+
+	if err := writeReport(*report, rep); err != nil {
+		return fmt.Errorf("write report: %w", err)
+	}
+	fmt.Fprintf(os.Stderr,
+		"==> rejection-parity %s: total=%d parity=%d wrong_rejection=%d stale_catalogue=%d hard_errors=%d -> %s\n",
+		rep.Head, rep.Total, rep.Parity, rep.WrongRejection, rep.StaleCatalogue, rep.HardErrors, *report)
+	for _, c := range rep.Cases {
+		if c.Verdict != "parity" {
+			fmt.Fprintf(os.Stderr, "    [%s] %s (%s): ref=%d cerberus=%d query=%s\n",
+				c.Verdict, c.Name, c.Endpoint, c.RefStatus, c.CerberusStatus, c.Query)
+		}
+	}
+	return nil
+}
+
+// runCase fires the trigger query at both backends and classifies the
+// status pair.
+func runCase(client *http.Client, c rejectionparity.Case, refURL, cerbURL string, now time.Time) CaseResult {
+	res := CaseResult{Name: c.Name, Endpoint: c.Endpoint, Query: c.Query}
+
+	refStatus, refBody, refErr := fetch(client, buildURL(refURL, c, now))
+	cerbStatus, cerbBody, cerbErr := fetch(client, buildURL(cerbURL, c, now))
+	res.RefStatus, res.CerberusStatus = refStatus, cerbStatus
+
+	switch {
+	case refErr != nil:
+		res.Verdict = "hard_error"
+		res.Detail = "reference fetch: " + refErr.Error()
+	case cerbErr != nil:
+		res.Verdict = "hard_error"
+		res.Detail = "cerberus fetch: " + cerbErr.Error()
+	case refStatus/100 == 5 || cerbStatus/100 == 5:
+		res.Verdict = "hard_error"
+		res.Detail = fmt.Sprintf("5xx: ref=%q cerberus=%q", snippet(refBody), snippet(cerbBody))
+	case cerbStatus/100 == 2:
+		// The catalogue claims cerberus rejects this query; the live
+		// binary accepted it. The catalogue (or the lowering) moved —
+		// regenerate + re-curate.
+		res.Verdict = "stale_catalogue"
+		res.Detail = fmt.Sprintf("cerberus accepted (catalogue expects 4xx); ref=%q", snippet(refBody))
+	case refStatus/100 == 2:
+		// Cerberus rejects, reference answers: a wrong-rejection bug.
+		res.Verdict = "wrong_rejection"
+		res.Detail = fmt.Sprintf("reference accepted; cerberus said %q", snippet(cerbBody))
+	case refStatus/100 == 4 && cerbStatus/100 == 4:
+		res.Verdict = "parity"
+	default:
+		res.Verdict = "hard_error"
+		res.Detail = fmt.Sprintf("unclassifiable status pair; ref=%q cerberus=%q", snippet(refBody), snippet(cerbBody))
+	}
+	return res
+}
+
+// buildURL composes the per-endpoint query URL. The window is ±1h
+// around now — rejection parity is shape-based, not data-based, so
+// the window only needs to be syntactically valid.
+func buildURL(base string, c rejectionparity.Case, now time.Time) string {
+	start := now.Add(-1 * time.Hour)
+	end := now
+	u := strings.TrimRight(base, "/")
+	q := url.Values{}
+	switch c.Endpoint {
+	case rejectionparity.EndpointPromInstant:
+		u += "/api/v1/query"
+		q.Set("query", c.Query)
+		q.Set("time", strconv.FormatInt(end.Unix(), 10))
+	case rejectionparity.EndpointLogQLRange:
+		u += "/loki/api/v1/query_range"
+		q.Set("query", c.Query)
+		q.Set("start", strconv.FormatInt(start.UnixNano(), 10))
+		q.Set("end", strconv.FormatInt(end.UnixNano(), 10))
+		q.Set("step", "30")
+		q.Set("limit", "100")
+	case rejectionparity.EndpointTraceQLSearch:
+		u += "/api/search"
+		q.Set("q", c.Query)
+		q.Set("start", strconv.FormatInt(start.Unix(), 10))
+		q.Set("end", strconv.FormatInt(end.Unix(), 10))
+		q.Set("limit", "20")
+	case rejectionparity.EndpointTraceQLMetrics:
+		u += "/api/metrics/query_range"
+		q.Set("q", c.Query)
+		q.Set("start", strconv.FormatInt(start.Unix(), 10))
+		q.Set("end", strconv.FormatInt(end.Unix(), 10))
+		q.Set("step", "60s")
+	}
+	return u + "?" + q.Encode()
+}
+
+func fetch(client *http.Client, urlStr string) (int, []byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), client.Timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlStr, nil)
+	if err != nil {
+		return 0, nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return resp.StatusCode, nil, fmt.Errorf("read body: %w", err)
+	}
+	return resp.StatusCode, body, nil
+}
+
+func snippet(b []byte) string {
+	s := strings.TrimSpace(string(b))
+	if len(s) > 300 {
+		s = s[:300] + "…"
+	}
+	return s
+}
+
+func writeReport(path string, rep Report) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return err
+	}
+	out, err := json.MarshalIndent(rep, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(out, '\n'), 0o600)
+}

--- a/compatibility/loki/scripts/run-loki-compatibility.sh
+++ b/compatibility/loki/scripts/run-loki-compatibility.sh
@@ -147,6 +147,21 @@ set +e
 DRIVER_RC=$?
 set -e
 
+# Rejection-parity pass: every deliberate 422 in internal/logql must
+# also be rejected by reference Loki (status-class comparison, never
+# message text). The corpus is the rejection catalogue itself — see
+# test/rejection-parity/ and docs/compatibility.md. Report-only:
+# wrong_rejection verdicts land in the JSON report; only driver-level
+# infrastructure failures propagate (set -e).
+echo "==> running rejection-parity driver (logql)"
+(cd "$REPO_ROOT" && go run ./compatibility/cmd/rejection-parity \
+    -head logql \
+    -catalogue test/rejection-parity/catalogue.json \
+    -ref http://localhost:23100 \
+    -cerberus http://localhost:29092 \
+    -report "$ROOT_DIR/reports/rejection-parity.json")
+echo "==> rejection-parity report written to $ROOT_DIR/reports/rejection-parity.json"
+
 echo "==> report written to $REPORT"
 echo "==> score written to $SCORE"
 echo "==> summary:"

--- a/compatibility/prometheus/scripts/run-compatibility.sh
+++ b/compatibility/prometheus/scripts/run-compatibility.sh
@@ -143,6 +143,21 @@ if ! jq -e '.results | type == "array"' "$OUTPUT" >/dev/null 2>&1; then
     exit "$TESTER_RC"
 fi
 
+# Rejection-parity pass: every deliberate 422 in internal/promql must
+# also be rejected by reference Prometheus (status-class comparison,
+# never message text). The corpus is the rejection catalogue itself —
+# see test/rejection-parity/ and docs/compatibility.md. Report-only:
+# wrong_rejection verdicts land in the JSON report; only driver-level
+# infrastructure failures propagate (set -e).
+echo "==> running rejection-parity driver (promql)"
+(cd "$ROOT_DIR/../.." && go run ./compatibility/cmd/rejection-parity \
+    -head promql \
+    -catalogue test/rejection-parity/catalogue.json \
+    -ref http://localhost:29090 \
+    -cerberus http://localhost:29091 \
+    -report "$ROOT_DIR/rejection-parity.json")
+echo "==> rejection-parity report written to $ROOT_DIR/rejection-parity.json"
+
 # Build + run the in-tree scorer. The scorer reads report.json and
 # writes the shields.io endpoint-badge compat-score JSON to $SCORE.
 # Its own exit is propagated — a scorer failure means the harness

--- a/compatibility/tempo/scripts/run-tempo-compatibility.sh
+++ b/compatibility/tempo/scripts/run-tempo-compatibility.sh
@@ -143,6 +143,21 @@ set +e
 DIFF_RC=$?
 set -e
 
+# Rejection-parity pass: every deliberate 422 in internal/traceql must
+# also be rejected by reference Tempo (status-class comparison, never
+# message text). The corpus is the rejection catalogue itself — see
+# test/rejection-parity/ and docs/compatibility.md. Report-only:
+# wrong_rejection verdicts land in the JSON report; only driver-level
+# infrastructure failures propagate (set -e).
+echo "==> running rejection-parity driver (traceql)"
+(cd "$REPO_ROOT" && go run ./compatibility/cmd/rejection-parity \
+    -head traceql \
+    -catalogue test/rejection-parity/catalogue.json \
+    -ref http://localhost:23200 \
+    -cerberus http://localhost:29092 \
+    -report "$REPORT_DIR/rejection-parity.json")
+echo "==> rejection-parity report written to $REPORT_DIR/rejection-parity.json"
+
 echo "==> differ exited with rc=$DIFF_RC"
 echo "==> report at $REPORT_DIR/diff.md"
 echo "==> score at $REPORT_DIR/compat-score.json"

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -113,6 +113,51 @@ loki-compliance-tester \
 
 See `compatibility/loki/README.md` for the full mechanism.
 
+## Rejection parity
+
+Cerberus's deliberate rejections — the HTTP 422 "valid query, but the
+lowering refuses it" paths in `internal/{promql,logql,traceql}` — are
+claims about reference behaviour: "the reference backend cannot answer
+this either". Historically nothing verified those claims
+differentially, which is how `kind != nil` ended up rejected by
+cerberus while reference Tempo accepts it. The rejection-parity layer
+closes that gap:
+
+1. **Catalogue** — `test/rejection-parity/catalogue.json` is the
+   machine-readable inventory of every prefixed error-construction
+   site in the three lowerings, derived by a go/ast scan
+   (`test/rejection-parity`). Every site is classified either
+   `rejection` (reachable from a parseable query; carries a minimal
+   trigger query) or `internal` (parser-enforced shape, invariant, or
+   `%w` wrapper; carries a rationale).
+2. **Meta-tests** — `go test ./test/rejection-parity/` pins the
+   ratchet: the scanned-site set must equal the catalogue
+   (regenerable via `CERBERUS_UPDATE_INVENTORY=1`, mirroring
+   `test/inventory`), every entry must be classified, every
+   `rejection` trigger must parse with the head's reference parser
+   AND fail the head's lowering with the catalogued message, and the
+   parity corpus is derived 1:1 from the rejection entries. Adding a
+   new rejection to a lowering therefore *requires* a catalogue entry,
+   a trigger query, and — by construction — a parity case.
+3. **Parity driver** — `compatibility/cmd/rejection-parity` runs
+   inside each harness (wired into the three run scripts, after the
+   main tester) and sends every trigger query to both backends. It
+   compares the rejection **status class** only (both 4xx = parity);
+   message text is never compared. Verdicts:
+   - `parity` — both backends reject; the claim holds.
+   - `wrong_rejection` — the reference backend accepts a query
+     cerberus rejects: a real bug to fix at the source (the
+     `kind != nil` class). There is no allow-list for these.
+   - `stale_catalogue` — cerberus accepted a query the catalogue says
+     it rejects; regenerate + re-curate the catalogue.
+   - `hard_error` — 5xx / transport failure (infrastructure).
+
+   Reports land at `compatibility/prometheus/rejection-parity.json`,
+   `compatibility/loki/reports/rejection-parity.json`, and
+   `compatibility/tempo/reports/rejection-parity.json`. Like the main
+   testers (task #68), the driver is report-only: verdicts never
+   change the exit code; only infrastructure failures do.
+
 ## CI integration
 
 `.github/workflows/compatibility.yml` runs all three harnesses:

--- a/test/rejection-parity/catalogue.go
+++ b/test/rejection-parity/catalogue.go
@@ -1,0 +1,419 @@
+package rejectionparity
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// heads maps each lowering package directory (relative to the repo
+// root) to its head identifier. The head identifier doubles as the
+// required error-message prefix ("promql: ..."), which every error
+// site in the three packages carries by convention.
+var heads = map[string]string{
+	"internal/promql":  "promql",
+	"internal/logql":   "logql",
+	"internal/traceql": "traceql",
+}
+
+// Site is one error-construction site discovered by ScanSites: a
+// fmt.Errorf / errors.New call in a lowering package whose format
+// string starts with the head prefix.
+type Site struct {
+	// Head is "promql" / "logql" / "traceql".
+	Head string `json:"head"`
+	// Site is the stable identifier
+	// "internal/<head>/<file>.go:<func>#<hash8>[-<n>]" where <hash8>
+	// is the first 8 hex chars of sha256(Message) and <n> is the
+	// 1-based ordinal appended only when the same message is
+	// constructed more than once inside the same function. Line
+	// numbers are deliberately excluded so unrelated edits don't
+	// churn the catalogue; hashing the message (rather than counting
+	// positionally) keeps keys stable when an unrelated error site is
+	// inserted earlier in the function.
+	Site string `json:"site"`
+	// Message is the raw format string of the error constructor —
+	// verbs (%s / %d / %T / %w / ...) included. The exerciser test
+	// matches lowering errors against the literal fragments between
+	// the verbs (see MessageFragments / ErrorMatchesMessage).
+	Message string `json:"message"`
+}
+
+// Entry is one catalogued site plus its curated classification.
+type Entry struct {
+	Site
+
+	// Class is the curated classification:
+	//
+	//   "rejection" — reachable from a parseable query: a deliberate
+	//                 semantic rejection whose parity against the
+	//                 reference backend the compat harnesses verify.
+	//                 Requires TriggerQuery (+ Endpoint for traceql
+	//                 metrics-pipeline sites).
+	//   "internal"  — not reachable from a parseable query through the
+	//                 HTTP query endpoints: parser-enforced shapes,
+	//                 internal invariants, error-propagation wrappers
+	//                 (%w), or paths only reachable via non-wire entry
+	//                 points. Requires Rationale.
+	//
+	// The verify test fails on any other value (including ""), so a
+	// new rejection site cannot land unclassified.
+	Class string `json:"class"`
+
+	// TriggerQuery (class=rejection) is a minimal concrete query that
+	// parses with the head's reference parser and fails this site's
+	// lowering with this site's message. Pinned by
+	// TestRejectionTriggersExerciseSites.
+	TriggerQuery string `json:"trigger_query,omitempty"`
+
+	// Endpoint (class=rejection) selects the HTTP endpoint the parity
+	// driver sends TriggerQuery to. Empty means the head default
+	// (DefaultEndpoint). TraceQL metrics-pipeline rejections set
+	// "traceql_metrics" because /api/search does not accept metrics
+	// expressions.
+	Endpoint string `json:"endpoint,omitempty"`
+
+	// Rationale (class=internal) documents why the site is not a
+	// wire-reachable semantic rejection.
+	Rationale string `json:"rationale,omitempty"`
+}
+
+// Catalogue is the checked-in JSON artifact shape
+// (test/rejection-parity/catalogue.json).
+type Catalogue struct {
+	Source  string  `json:"source"`
+	Entries []Entry `json:"entries"`
+}
+
+// catalogueSource documents how the mechanical half is derived.
+const catalogueSource = "go/ast scan of fmt.Errorf/errors.New sites in " +
+	"internal/{promql,logql,traceql} (non-test files); classification + " +
+	"trigger queries are curated and pinned by test/rejection-parity"
+
+// Endpoint identifiers consumed by compatibility/cmd/rejection-parity.
+const (
+	EndpointPromInstant    = "promql_instant"
+	EndpointLogQLRange     = "logql_range"
+	EndpointTraceQLSearch  = "traceql_search"
+	EndpointTraceQLMetrics = "traceql_metrics"
+)
+
+// DefaultEndpoint returns the per-head endpoint used when an entry
+// does not override it.
+func DefaultEndpoint(head string) string {
+	switch head {
+	case "promql":
+		return EndpointPromInstant
+	case "logql":
+		return EndpointLogQLRange
+	case "traceql":
+		return EndpointTraceQLSearch
+	}
+	return ""
+}
+
+// ValidEndpoint reports whether ep is a recognised endpoint for head.
+func ValidEndpoint(head, ep string) bool {
+	switch head {
+	case "promql":
+		return ep == EndpointPromInstant
+	case "logql":
+		return ep == EndpointLogQLRange
+	case "traceql":
+		return ep == EndpointTraceQLSearch || ep == EndpointTraceQLMetrics
+	}
+	return false
+}
+
+// Case is one parity-corpus case derived from a rejection entry. The
+// driver sends Query to Endpoint on both backends and asserts both
+// reject (4xx).
+type Case struct {
+	// Name is the catalogue site key — stable, unique, and greppable
+	// straight back to the error-construction site.
+	Name string `json:"name"`
+	Head string `json:"head"`
+	// Endpoint is resolved (entry override or head default).
+	Endpoint string `json:"endpoint"`
+	Query    string `json:"query"`
+}
+
+// BuildCases derives the parity corpus for one head from the
+// catalogue: exactly one case per class=rejection entry, no more, no
+// fewer. The 1:1 derivation is the "corpus-case count == catalogue
+// count" leg of the ratchet — there is no separate corpus file to
+// drift.
+func BuildCases(cat *Catalogue, head string) ([]Case, error) {
+	var out []Case
+	for _, e := range cat.Entries {
+		if e.Head != head || e.Class != "rejection" {
+			continue
+		}
+		if strings.TrimSpace(e.TriggerQuery) == "" {
+			return nil, fmt.Errorf("rejection entry %s has no trigger query", e.Site.Site)
+		}
+		ep := e.Endpoint
+		if ep == "" {
+			ep = DefaultEndpoint(head)
+		}
+		if !ValidEndpoint(head, ep) {
+			return nil, fmt.Errorf("rejection entry %s: endpoint %q invalid for head %s", e.Site.Site, ep, head)
+		}
+		out = append(out, Case{Name: e.Site.Site, Head: head, Endpoint: ep, Query: e.TriggerQuery})
+	}
+	return out, nil
+}
+
+// ScanSites walks the three lowering packages under repoRoot and
+// returns every prefixed error-construction site, sorted by site key.
+// Test files and testdata are excluded — they construct errors for
+// assertions, not for the wire.
+func ScanSites(repoRoot string) ([]Site, error) {
+	var out []Site
+	for dir, head := range heads {
+		sites, err := scanDir(filepath.Join(repoRoot, dir), dir, head)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, sites...)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Site < out[j].Site })
+	return out, nil
+}
+
+func scanDir(absDir, relDir, head string) ([]Site, error) {
+	entries, err := os.ReadDir(absDir)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", absDir, err)
+	}
+	var out []Site
+	for _, de := range entries {
+		name := de.Name()
+		if de.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		sites, err := scanFile(filepath.Join(absDir, name), relDir+"/"+name, head)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, sites...)
+	}
+	return out, nil
+}
+
+// scanFile parses one source file and extracts the prefixed
+// error-construction sites, assigning per-(func, message) ordinals.
+func scanFile(absPath, relPath, head string) ([]Site, error) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, absPath, nil, 0)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", absPath, err)
+	}
+	prefix := head + ": "
+	var out []Site
+	for _, decl := range f.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if ok && fn.Body != nil {
+			out = append(out, scanFunc(fn, relPath, head, prefix)...)
+		}
+	}
+	return out, nil
+}
+
+// scanFunc walks one function body for error constructors. The site
+// key embeds a hash of the message so it stays stable when an
+// unrelated error site is inserted earlier in the function; a repeat
+// ordinal is appended only for the rare case of the same message
+// constructed twice in the same function.
+func scanFunc(fn *ast.FuncDecl, relPath, head, prefix string) []Site {
+	var out []Site
+	seen := map[string]int{}
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok || len(call.Args) == 0 {
+			return true
+		}
+		if !isErrorConstructor(call.Fun) {
+			return true
+		}
+		msg, ok := stringLiteral(call.Args[0])
+		if !ok || !strings.HasPrefix(msg, prefix) {
+			return true
+		}
+		seen[msg]++
+		sum := sha256.Sum256([]byte(msg))
+		key := fmt.Sprintf("%s:%s#%s", relPath, fn.Name.Name, hex.EncodeToString(sum[:4]))
+		if seen[msg] > 1 {
+			key = fmt.Sprintf("%s-%d", key, seen[msg])
+		}
+		out = append(out, Site{Head: head, Site: key, Message: msg})
+		return true
+	})
+	return out
+}
+
+// isErrorConstructor matches fmt.Errorf and errors.New selector calls.
+func isErrorConstructor(fun ast.Expr) bool {
+	sel, ok := fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	switch {
+	case pkg.Name == "fmt" && sel.Sel.Name == "Errorf":
+		return true
+	case pkg.Name == "errors" && sel.Sel.Name == "New":
+		return true
+	}
+	return false
+}
+
+// stringLiteral folds an expression into its constant string value:
+// a plain string literal or a `+` concatenation of string literals.
+func stringLiteral(e ast.Expr) (string, bool) {
+	switch v := e.(type) {
+	case *ast.BasicLit:
+		if v.Kind != token.STRING {
+			return "", false
+		}
+		s, err := strconv.Unquote(v.Value)
+		if err != nil {
+			return "", false
+		}
+		return s, true
+	case *ast.BinaryExpr:
+		if v.Op != token.ADD {
+			return "", false
+		}
+		l, ok := stringLiteral(v.X)
+		if !ok {
+			return "", false
+		}
+		r, ok := stringLiteral(v.Y)
+		if !ok {
+			return "", false
+		}
+		return l + r, true
+	case *ast.ParenExpr:
+		return stringLiteral(v.X)
+	}
+	return "", false
+}
+
+// Generate scans repoRoot and merges the result with the previous
+// catalogue: sites present in prev keep their curated classification
+// (class / trigger query / endpoint / rationale); new sites land with
+// an empty class so the verify test demands curation; sites that
+// disappeared from the source are dropped. Shrink and growth are both
+// therefore deliberate, reviewable diffs.
+func Generate(repoRoot string, prev *Catalogue) (*Catalogue, error) {
+	sites, err := ScanSites(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	prevByKey := map[string]Entry{}
+	if prev != nil {
+		for _, e := range prev.Entries {
+			prevByKey[e.Site.Site] = e
+		}
+	}
+	out := &Catalogue{Source: catalogueSource}
+	for _, s := range sites {
+		e := Entry{Site: s}
+		if p, ok := prevByKey[s.Site]; ok {
+			e.Class = p.Class
+			e.TriggerQuery = p.TriggerQuery
+			e.Endpoint = p.Endpoint
+			e.Rationale = p.Rationale
+		}
+		out.Entries = append(out.Entries, e)
+	}
+	return out, nil
+}
+
+// LoadCatalogue reads + parses the checked-in artifact.
+func LoadCatalogue(path string) (*Catalogue, error) {
+	raw, err := os.ReadFile(path) //nolint:gosec // repo-relative artifact path
+	if err != nil {
+		return nil, err
+	}
+	var cat Catalogue
+	if err := json.Unmarshal(raw, &cat); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return &cat, nil
+}
+
+// MarshalCatalogue renders the canonical on-disk JSON form (2-space
+// indent + trailing newline) so the regenerate-and-diff test compares
+// byte-for-byte. Mirrors test/inventory.MarshalInventory.
+func MarshalCatalogue(cat *Catalogue) ([]byte, error) {
+	b, err := json.MarshalIndent(cat, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(b, '\n'), nil
+}
+
+// MessageFragments splits a fmt format string into its literal
+// fragments — the chunks between %-verbs — trimmed of whitespace.
+// Empty fragments are dropped.
+func MessageFragments(format string) []string {
+	var frags []string
+	var cur strings.Builder
+	flush := func() {
+		if s := strings.TrimSpace(cur.String()); s != "" {
+			frags = append(frags, s)
+		}
+		cur.Reset()
+	}
+	runes := []rune(format)
+	for i := 0; i < len(runes); i++ {
+		if runes[i] != '%' {
+			cur.WriteRune(runes[i])
+			continue
+		}
+		if i+1 < len(runes) && runes[i+1] == '%' {
+			cur.WriteRune('%')
+			i++
+			continue
+		}
+		// Skip the verb: flags / width / precision then the verb rune.
+		flush()
+		j := i + 1
+		for j < len(runes) && strings.ContainsRune("+-# 0123456789.[]*", runes[j]) {
+			j++
+		}
+		i = j // consume the verb rune itself via the loop increment
+	}
+	flush()
+	return frags
+}
+
+// ErrorMatchesMessage reports whether errStr contains every literal
+// fragment of the format string, in order. This is the comparison the
+// exerciser test uses to attribute a lowering error to a catalogue
+// site without being brittle about the interpolated values.
+func ErrorMatchesMessage(errStr, format string) bool {
+	rest := errStr
+	for _, frag := range MessageFragments(format) {
+		idx := strings.Index(rest, frag)
+		if idx < 0 {
+			return false
+		}
+		rest = rest[idx+len(frag):]
+	}
+	return true
+}

--- a/test/rejection-parity/catalogue.json
+++ b/test/rejection-parity/catalogue.json
@@ -73,7 +73,7 @@
     },
     {
       "head": "logql",
-      "site": "internal/logql/lower.go:labelFiltererToExpr#6274bc0d",
+      "site": "internal/logql/lower.go:labelFiltererLower#6274bc0d",
       "message": "logql: unsupported label filterer %T",
       "class": "rejection",
       "trigger_query": "{app=\"x\"} | addr = ip(\"127.0.0.1\")"
@@ -955,6 +955,34 @@
     },
     {
       "head": "traceql",
+      "site": "internal/traceql/lower.go:lowerIntrinsicNilComparison#07654c50",
+      "message": "traceql: nil comparison on intrinsic %s is unsupported — the configured schema has no events column",
+      "class": "internal",
+      "rationale": "the default OTel-CH traces schema configures an events column; reachable only under a schema override that drops it"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:lowerIntrinsicNilComparison#284df75f",
+      "message": "traceql: intrinsic %s requires per-span child counts the OTel ClickHouse schema does not materialise",
+      "class": "internal",
+      "rationale": "the pinned tempo parser rejects the childCount spelling (\"unexpected childCount\"), so the arm is unreachable from a parseable query"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:lowerIntrinsicNilComparison#5c445f2a",
+      "message": "traceql: %s = nil is not valid because intrinsics cannot be nil",
+      "class": "rejection",
+      "trigger_query": "{ kind = nil }"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:lowerIntrinsicNilComparison#e2d1d3a8",
+      "message": "traceql: nil comparison on intrinsic %s is unsupported — the configured schema has no links column",
+      "class": "internal",
+      "rationale": "the default OTel-CH traces schema configures a links column; reachable only under a schema override that drops it"
+    },
+    {
+      "head": "traceql",
       "site": "internal/traceql/lower.go:lowerMetricsFilter#20c8f8b5",
       "message": "traceql: metrics filter operator %s is not a supported threshold comparison",
       "class": "internal",
@@ -1008,6 +1036,27 @@
       "message": "traceql: intrinsic %s is unsupported — the OTel ClickHouse schema does not materialise nested-set positions",
       "class": "rejection",
       "trigger_query": "{ nestedSetLeft = 1 }"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:lowerNilComparison#aa8b5044",
+      "message": "traceql: instrumentation-scoped attribute %q is unsupported — the OTel ClickHouse traces schema has no scope-attributes column (instrumentation:name / instrumentation:version map to ScopeName / ScopeVersion)",
+      "class": "rejection",
+      "trigger_query": "{ instrumentation.foo != nil }"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:lowerNilComparison#dbf30854",
+      "message": "traceql: nil comparison on %s.%s is unsupported — the configured schema has no %s column",
+      "class": "internal",
+      "rationale": "the default OTel-CH traces schema configures attribute columns for every scope this branch checks; reachable only under a schema override that drops one"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:lowerNilComparison#fca86ae4",
+      "message": "traceql: %s = nil is not valid because resource.service.name cannot be nil",
+      "class": "rejection",
+      "trigger_query": "{ resource.service.name = nil }"
     },
     {
       "head": "traceql",
@@ -1089,13 +1138,6 @@
     },
     {
       "head": "traceql",
-      "site": "internal/traceql/lower.go:lowerUnaryOperation#415441d4",
-      "message": "traceql: nil comparison on intrinsic %s is unsupported — OTel-CH intrinsic columns are always present",
-      "class": "rejection",
-      "trigger_query": "{ kind != nil }"
-    },
-    {
-      "head": "traceql",
       "site": "internal/traceql/lower.go:lowerUnaryOperation#5f9f3466",
       "message": "traceql: unary operator %s is unsupported",
       "class": "rejection",
@@ -1107,13 +1149,6 @@
       "message": "traceql: %s operand %T is unsupported — nil comparisons require an attribute reference",
       "class": "rejection",
       "trigger_query": "{ (span.a + 1) != nil }"
-    },
-    {
-      "head": "traceql",
-      "site": "internal/traceql/lower.go:lowerUnaryOperation#ae3df2c6",
-      "message": "traceql: nil comparison on %s.%s is unsupported",
-      "class": "rejection",
-      "trigger_query": "{ link.foo != nil }"
     },
     {
       "head": "traceql",

--- a/test/rejection-parity/catalogue.json
+++ b/test/rejection-parity/catalogue.json
@@ -1,0 +1,1245 @@
+{
+  "source": "go/ast scan of fmt.Errorf/errors.New sites in internal/{promql,logql,traceql} (non-test files); classification + trigger queries are curated and pinned by test/rejection-parity",
+  "entries": [
+    {
+      "head": "logql",
+      "site": "internal/logql/binary.go:logqlBinaryOp#e845ca95",
+      "message": "logql: binary op %s unsupported (logical ops `and`/`or`/`unless` are not supported)",
+      "class": "rejection",
+      "trigger_query": "rate({app=\"x\"}[5m]) and rate({app=\"x\"}[5m])"
+    },
+    {
+      "head": "logql",
+      "site": "internal/logql/binary.go:lowerBinary#4879747f",
+      "message": "logql: binary expression has nil leg(s)",
+      "class": "internal",
+      "rationale": "internal invariant: the pinned parser never yields a binary expression with nil legs"
+    },
+    {
+      "head": "logql",
+      "site": "internal/logql/binary.go:lowerBinary#e16a89f2",
+      "message": "logql: scalar-only binary expression not folded (op %s) — internal invariant violation",
+      "class": "internal",
+      "rationale": "internal invariant (the message says so): scalar-only binaries are constant-folded before this branch"
+    },
+    {
+      "head": "logql",
+      "site": "internal/logql/binary.go:lowerVectorVector#e04c7f18",
+      "message": "logql: 'bool' modifier is only allowed on comparison binary ops",
+      "class": "rejection",
+      "trigger_query": "rate({app=\"x\"}[5m]) + bool rate({app=\"x\"}[5m])"
+    },
+    {
+      "head": "logql",
+      "site": "internal/logql/binary.go:vectorMatchingFromOpts#64179012",
+      "message": "logql: unsupported vector-matching cardinality %d",
+      "class": "internal",
+      "rationale": "LogQL's VectorMatchCardinality enum stops at CardOneToMany; no parser-producible value reaches the default arm"
+    },
+    {
+      "head": "logql",
+      "site": "internal/logql/binary.go:vectorMatchingFromOpts#89d11456",
+      "message": "logql: many-to-many matching not allowed: matching labels must be unique on one side; use group_left/group_right when projecting include labels",
+      "class": "internal",
+      "rationale": "include labels require group_left/group_right in the grammar, which set many-to-one / one-to-many cardinality; include with one-to-one is not parser-producible"
+    },
+    {
+      "head": "logql",
+      "site": "internal/logql/label_fns.go:lowerLabelReplace#997ce6c3",
+      "message": "logql: label_replace has nil inner",
+      "class": "internal",
+      "rationale": "internal invariant: the parser never yields label_replace with a nil inner expression"
+    },
+    {
+      "head": "logql",
+      "site": "internal/logql/lower.go:jsonExpressionMergeLabels#9cb94bcf",
+      "message": "logql: `| json` expression has empty identifier",
+      "class": "internal",
+      "rationale": "the grammar requires a non-empty identifier on `| json foo=...` expression stages; an empty identifier is a parse error"
+    },
+    {
+      "head": "logql",
+      "site": "internal/logql/lower.go:jsonExtractStringExpr#427e92de",
+      "message": "logql: unsupported JSON path segment type %T in %q",
+      "class": "internal",
+      "rationale": "the upstream jsonpath parser produces only string and array-index segments, both handled"
+    },
+    {
+      "head": "logql",
+      "site": "internal/logql/lower.go:jsonExtractStringExpr#e6040681",
+      "message": "logql: invalid `| json` path %q: %w",
+      "class": "rejection",
+      "trigger_query": "{app=\"x\"} | json foo=\"bar[\""
+    },
+    {
+      "head": "logql",
+      "site": "internal/logql/lower.go:labelFiltererToExpr#6274bc0d",
+      "message": "logql: unsupported label filterer %T",
+      "class": "rejection",
+      "trigger_query": "{app=\"x\"} | addr = ip(\"127.0.0.1\")"
+    },
+    {
+      "head": "logql",
+      "site": "internal/logql/lower.go:lineFilterOp#155249b0",
+      "message": "logql: line-filter op %s is not yet supported (`|\u003e` pattern filters land in M3.2)",
+      "class": "rejection",
+      "trigger_query": "{app=\"x\"} |\u003e \"\u003c_\u003e level=error\""
+    },
+    {
+      "head": "logql",
+      "site": "internal/logql/lower.go:lineFilterPart#c0244416",
+      "message": "logql: line-filter `ip(...)` is not yet supported",
+      "class": "rejection",
+      "trigger_query": "{app=\"x\"} |= ip(\"127.0.0.1\")"
+    },
+    {
+      "head": "logql",
+      "site": "internal/logql/lower.go:logfmtExpressionMergeLabels#dcff5a88",
+      "message": "logql: `| logfmt` expression has empty identifier",
+      "class": "internal",
+      "rationale": "the grammar requires a non-empty identifier on `| logfmt foo=...` expression stages; an empty identifier is a parse error"
+    },
+    {
+      "head": "logql",
+      "site": "internal/logql/lower.go:lower#5da77ba7",
+      "message": "logql: unsupported expression %T",
+      "class": "rejection",
+      "trigger_query": "variants(count_over_time({app=\"x\"}[5m])) of ({app=\"x\"}[5m])"
+    },
+    {
+      "head": "logql",
+      "site": "internal/logql/lower.go:lowerStage#0809f4e6",
+      "message": "logql: pipeline stage %T is not yet supported",
+      "class": "internal",
+      "rationale": "type-switch default: every pipeline-stage type the pinned parser produces is handled"
+    },
+    {
+      "head": "logql",
+      "site": "internal/logql/lower.go:lowerStage#a7242d58",
+      "message": "logql: parser stage `| %s` is not yet supported",
+      "class": "internal",
+      "rationale": "every LineParserExpr op the pinned grammar produces (json / regexp / unpack / pattern) is handled; bare `| logfmt` parses as LogfmtParserExpr"
+    },
+    {
+      "head": "logql",
+      "site": "internal/logql/lower.go:regexpMergeLabels#6038cf5d",
+      "message": "logql: `| regexp` pattern %q has no named captures",
+      "class": "internal",
+      "rationale": "the parser pre-validates capture-less regexp patterns as a parse error"
+    },
+    {
+      "head": "logql",
+      "site": "internal/logql/lower.go:regexpMergeLabels#83255883",
+      "message": "logql: invalid `| regexp` pattern %q: %w",
+      "class": "internal",
+      "rationale": "the parser pre-validates the regexp; a compile failure is a parse error"
+    },
+    {
+      "head": "logql",
+      "site": "internal/logql/lower.go:regexpMergeLabels#e2424d2e",
+      "message": "logql: `| regexp` pattern has duplicate named capture %q",
+      "class": "internal",
+      "rationale": "the parser pre-validates duplicate named captures as a parse error"
+    },
+    {
+      "head": "logql",
+      "site": "internal/logql/lower.go:regexpMergeLabels#fabd1568",
+      "message": "logql: `| regexp` requires a non-empty pattern",
+      "class": "internal",
+      "rationale": "the parser pre-validates `| regexp \"\"` (\"at least one named capture must be supplied\") as a parse error"
+    },
+    {
+      "head": "logql",
+      "site": "internal/logql/range_aggregation.go:lowerLogRange#b8257b72",
+      "message": "logql: range-aggregation inner is %T (not MatchersExpr or PipelineExpr)",
+      "class": "internal",
+      "rationale": "the pinned parser yields only MatchersExpr / PipelineExpr as log-range inners"
+    },
+    {
+      "head": "logql",
+      "site": "internal/logql/range_aggregation.go:lowerRangeAggregation#1a3d0c76",
+      "message": "logql: quantile_over_time requires a phi parameter",
+      "class": "internal",
+      "rationale": "the parser rejects quantile_over_time without a parameter before lowering"
+    },
+    {
+      "head": "logql",
+      "site": "internal/logql/range_aggregation.go:lowerRangeAggregation#de7d6b8c",
+      "message": "logql: range-aggregation has nil inner",
+      "class": "internal",
+      "rationale": "internal invariant: the parser never yields a range aggregation with a nil inner"
+    },
+    {
+      "head": "logql",
+      "site": "internal/logql/range_aggregation.go:rangeFuncName#b1ec3bca",
+      "message": "logql: range op %s is not yet supported",
+      "class": "rejection",
+      "trigger_query": "first_over_time({app=\"x\"} | unwrap foo [5m])"
+    },
+    {
+      "head": "logql",
+      "site": "internal/logql/range_aggregation.go:rangeValueExpr#23b3f454",
+      "message": "logql: %s does not accept `| unwrap`",
+      "class": "internal",
+      "rationale": "the parser rejects bytes_rate / bytes_over_time with `| unwrap` (\"invalid aggregation ... with unwrap\"); guard kept against a future parser loosening"
+    },
+    {
+      "head": "logql",
+      "site": "internal/logql/range_aggregation.go:rangeValueExpr#34122fa8",
+      "message": "logql: %s requires an `| unwrap` clause",
+      "class": "internal",
+      "rationale": "the parser rejects sum_over_time-family operations without `| unwrap` (\"invalid aggregation ... without unwrap\")"
+    },
+    {
+      "head": "logql",
+      "site": "internal/logql/range_aggregation.go:rangeValueExpr#b1ec3bca",
+      "message": "logql: range op %s is not yet supported",
+      "class": "rejection",
+      "trigger_query": "absent_over_time({app=\"x\"}[5m])"
+    },
+    {
+      "head": "logql",
+      "site": "internal/logql/range_aggregation.go:rangeValueExprFromMerged#3d7b48c7",
+      "message": "logql: rangeValueExprFromMerged called without `| unwrap`",
+      "class": "internal",
+      "rationale": "internal invariant: the caller routes only unwrap-carrying range aggregations here"
+    },
+    {
+      "head": "logql",
+      "site": "internal/logql/range_aggregation.go:unwrapValueExpr#ad5af60c",
+      "message": "logql: `| unwrap` has empty identifier",
+      "class": "internal",
+      "rationale": "the grammar requires a non-empty unwrap identifier; an empty one is a parse error"
+    },
+    {
+      "head": "logql",
+      "site": "internal/logql/range_aggregation.go:unwrapValueExpr#bbe4735f",
+      "message": "logql: unsupported unwrap conversion %q",
+      "class": "internal",
+      "rationale": "every conversion the grammar accepts (bytes / duration / duration_seconds) is handled"
+    },
+    {
+      "head": "logql",
+      "site": "internal/logql/vector_aggregation.go:buildVectorAggFunc#3cb2166f",
+      "message": "logql: aggregation operation %q is unsupported",
+      "class": "rejection",
+      "trigger_query": "approx_topk(2, rate({app=\"x\"}[5m]))"
+    },
+    {
+      "head": "logql",
+      "site": "internal/logql/vector_aggregation.go:buildVectorAggFunc#7f5d7559",
+      "message": "logql: %s changes output shape and is unsupported",
+      "class": "rejection",
+      "trigger_query": "topk(2, rate({app=\"x\"}[5m]))"
+    },
+    {
+      "head": "logql",
+      "site": "internal/logql/vector_aggregation.go:buildVectorAggFunc#f01faed5",
+      "message": "logql: %s requires output ordering rather than aggregation",
+      "class": "rejection",
+      "trigger_query": "sort(rate({app=\"x\"}[5m]))"
+    },
+    {
+      "head": "logql",
+      "site": "internal/logql/vector_aggregation.go:lowerVectorAggregation#4f64fcaa",
+      "message": "logql: vector-aggregation inner is not an Expr (%T)",
+      "class": "internal",
+      "rationale": "internal invariant: the parser's vector-aggregation inner always implements syntax.Expr"
+    },
+    {
+      "head": "logql",
+      "site": "internal/logql/vector_aggregation.go:lowerVectorAggregation#9210acc4",
+      "message": "logql: vector-aggregation has nil inner",
+      "class": "internal",
+      "rationale": "internal invariant: the parser never yields a vector aggregation with a nil inner"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/absent.go:lowerAbsent#079d2385",
+      "message": "promql: absent() expects 1 argument, got %d",
+      "class": "internal",
+      "rationale": "parser-enforced arity: parser.Functions pins absent at exactly one argument"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/absent.go:lowerAbsent#9647959d",
+      "message": "promql: absent() argument must be an instant-vector selector, got %T",
+      "class": "rejection",
+      "trigger_query": "absent(sum(up))"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/absent.go:lowerAbsentOverTime#5fccc59e",
+      "message": "promql: matrix selector's inner must be a VectorSelector, got %T",
+      "class": "internal",
+      "rationale": "the parser only builds MatrixSelector around a VectorSelector"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/absent.go:lowerAbsentOverTime#e8585e71",
+      "message": "promql: absent_over_time() expects 1 argument, got %d",
+      "class": "internal",
+      "rationale": "parser-enforced arity: parser.Functions pins absent_over_time at exactly one argument"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/absent.go:lowerAbsentOverTime#fef55d6c",
+      "message": "promql: absent_over_time() argument must be a range-vector selector, got %T",
+      "class": "internal",
+      "rationale": "subquery arguments are intercepted by lowerOuterRangeFnOverSubquery; the parser's typechecker admits only matrix-typed arguments otherwise"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/binary.go:lowerBinary#47ece6fd",
+      "message": "promql: scalar-only binary expression not folded (op %s) — internal invariant violation",
+      "class": "internal",
+      "rationale": "internal invariant (the message says so): scalar-only binaries are constant-folded before this branch"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/binary.go:lowerVectorSetOp#6cdf660e",
+      "message": "promql: 'bool' modifier is only allowed on comparison binary ops",
+      "class": "internal",
+      "rationale": "the parser rejects `bool` on non-comparison operators (\"bool modifier can only be used on comparison operators\")"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/binary.go:lowerVectorVector#27f7a326",
+      "message": "promql: many-to-many matching not allowed: matching labels must be unique on one side; use group_left/group_right when projecting include labels",
+      "class": "internal",
+      "rationale": "include labels require group_left/group_right in the grammar, which set many-to-one / one-to-many cardinality; include with one-to-one is not parser-producible"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/binary.go:lowerVectorVector#6cdf660e",
+      "message": "promql: 'bool' modifier is only allowed on comparison binary ops",
+      "class": "internal",
+      "rationale": "the parser rejects `bool` on non-comparison operators (\"bool modifier can only be used on comparison operators\")"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/binary.go:lowerVectorVector#81f45a15",
+      "message": "promql: many-to-many matching not allowed: matching labels must be unique on one side",
+      "class": "internal",
+      "rationale": "CardManyToMany arises only from set operators, which route to lowerVectorSetOp before this check"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/binary.go:lowerVectorVector#bfcc1402",
+      "message": "promql: unsupported vector-matching cardinality %d",
+      "class": "internal",
+      "rationale": "the parser's VectorMatchCardinality enum values are all handled; no parser-producible value reaches the default arm"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/binary.go:promBinaryOp#2d85dac3",
+      "message": "promql: vector set op %s should route through lowerVectorSetOp",
+      "class": "internal",
+      "rationale": "internal routing invariant: set operators are dispatched to lowerVectorSetOp before op mapping"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/binary.go:promBinaryOp#63a5ec6e",
+      "message": "promql: binary op %s unsupported",
+      "class": "rejection",
+      "trigger_query": "up atan2 up"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/binary.go:promVectorSetOpKind#46b4e78e",
+      "message": "promql: not a vector set operator: %s",
+      "class": "internal",
+      "rationale": "internal routing invariant: only parser set-operator tokens reach this mapper"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/date_fns.go:lowerDateFn#2f3ea020",
+      "message": "promql: unknown date function %s",
+      "class": "internal",
+      "rationale": "internal dispatch: lowerCall routes only the known date-function names here"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/date_fns.go:lowerDateFn#ab4896c1",
+      "message": "promql: %s expects 0 or 1 argument, got %d",
+      "class": "internal",
+      "rationale": "parser-enforced arity: the date functions are declared variadic 0..1 in parser.Functions (\"expected at most 1 argument(s)\")"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/date_fns.go:lowerDateFnNoArg#2f3ea020",
+      "message": "promql: unknown date function %s",
+      "class": "internal",
+      "rationale": "internal dispatch: lowerCall routes only the known date-function names here"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/histogram_quantile.go:lowerHistogramQuantile#4f2f135d",
+      "message": "promql: histogram_quantile second argument must be a histogram VectorSelector",
+      "class": "rejection",
+      "trigger_query": "histogram_quantile(0.9, sum(up))"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/histogram_quantile.go:lowerHistogramQuantile#afa8cb1f",
+      "message": "promql: histogram_quantile expects 2 arguments, got %d",
+      "class": "internal",
+      "rationale": "parser-enforced arity: parser.Functions pins histogram_quantile at exactly two arguments"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/histogram_quantile.go:lowerHistogramQuantile#c2bd1263",
+      "message": "promql: histogram_quantile requires a scalar-literal phi (computed phi is unsupported)",
+      "class": "rejection",
+      "trigger_query": "histogram_quantile(scalar(up), foo_bucket)"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/instant_fns.go:lowerClamp#1384ae1f",
+      "message": "promql: %s requires a scalar-literal bound",
+      "class": "rejection",
+      "trigger_query": "clamp_min(up, scalar(up))"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/instant_fns.go:lowerClamp#3cee2409",
+      "message": "promql: clamp requires scalar-literal bounds for min and max",
+      "class": "rejection",
+      "trigger_query": "clamp(up, scalar(up), 1)"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/instant_fns.go:lowerClamp#dd15dfed",
+      "message": "promql: clamp expects 3 arguments, got %d",
+      "class": "internal",
+      "rationale": "parser-enforced arity for clamp (three arguments)"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/instant_fns.go:lowerClamp#e15d3cf4",
+      "message": "promql: unknown clamp function %s",
+      "class": "internal",
+      "rationale": "internal dispatch: lowerCall routes only clamp / clamp_min / clamp_max here"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/instant_fns.go:lowerClamp#f69a3fbc",
+      "message": "promql: %s expects 2 arguments, got %d",
+      "class": "internal",
+      "rationale": "parser-enforced arity for clamp_min / clamp_max (two arguments)"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/instant_fns.go:lowerInstantFn#ce14c98d",
+      "message": "promql: %s with %d arguments is unsupported (instant math fns are unary)",
+      "class": "internal",
+      "rationale": "parser-enforced arity: the unary instant math functions are pinned at one argument in parser.Functions"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/instant_fns.go:lowerRoundToNearest#d04df84f",
+      "message": "promql: round(v, to_nearest) requires a scalar literal to_nearest",
+      "class": "rejection",
+      "trigger_query": "round(up, scalar(up))"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/label_fns.go:lowerLabelJoin#c71ab88a",
+      "message": "promql: label_join expects at least 3 arguments (v, dst, separator[, src…]), got %d",
+      "class": "internal",
+      "rationale": "parser-enforced arity: label_join requires at least three arguments"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/label_fns.go:lowerLabelReplace#8c37a823",
+      "message": "promql: label_replace expects 5 arguments, got %d",
+      "class": "internal",
+      "rationale": "parser-enforced arity: label_replace requires exactly five arguments"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/label_fns.go:stringArg#4c3f7595",
+      "message": "promql: %s(%s) requires a string literal, got %T",
+      "class": "internal",
+      "rationale": "the parser's typechecker admits only string literals in string-typed argument slots (PromQL has no other string-producing expression)"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/lower.go:buildAggFunc#10cb81b8",
+      "message": "promql: quantile(phi, ...) requires a scalar literal phi (computed phi is unsupported)",
+      "class": "rejection",
+      "trigger_query": "quantile(scalar(up), up)"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/lower.go:buildAggFunc#54d1c35e",
+      "message": "promql: aggregation %s does not take a parameter",
+      "class": "internal",
+      "rationale": "the parser rejects a parameter on non-parameterised aggregations (\"wrong number of arguments for aggregate expression\")"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/lower.go:buildAggFunc#80287dba",
+      "message": "promql: group() does not take a parameter",
+      "class": "internal",
+      "rationale": "the parser rejects a parameter on group() (\"wrong number of arguments for aggregate expression\")"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/lower.go:buildAggFunc#a6e9df79",
+      "message": "promql: aggregation op %s is not yet supported",
+      "class": "rejection",
+      "trigger_query": "limitk(2, up)"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/lower.go:buildAggFunc#e759e84f",
+      "message": "promql: %s changes output shape and lands with M1.7 result shaping",
+      "class": "internal",
+      "rationale": "count_values is intercepted by lowerCountValues / lowerSubqueryOverCountValues on every parser-producible path before buildAggFunc is consulted"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/lower.go:lower#d33d0084",
+      "message": "promql: unsupported expression %T",
+      "class": "rejection",
+      "trigger_query": "\"a string literal\""
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/lower.go:lowerCall#ab321c46",
+      "message": "promql: function %s is not yet supported",
+      "class": "rejection",
+      "trigger_query": "histogram_count(up)"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/lower.go:lowerCountValues#49c20b7b",
+      "message": "promql: count_values requires a string-literal label name as the first arg",
+      "class": "internal",
+      "rationale": "the parser's typechecker admits only a string literal as count_values' first argument"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/lower.go:lowerCountValues#fc5b1a1a",
+      "message": "promql: count_values requires a non-empty label name",
+      "class": "rejection",
+      "trigger_query": "count_values(\"\", up)"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/lower.go:lowerRangeVectorCall#064574ba",
+      "message": "promql: %s expects exactly 1 argument, got %d",
+      "class": "internal",
+      "rationale": "parser-enforced arity: the range-vector functions are pinned at one argument in parser.Functions"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/lower.go:lowerRangeVectorCall#5fccc59e",
+      "message": "promql: matrix selector's inner must be a VectorSelector, got %T",
+      "class": "internal",
+      "rationale": "the parser only builds MatrixSelector around a VectorSelector"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/lower.go:lowerRangeVectorCall#ccda8b22",
+      "message": "promql: %s argument must be a range-vector selector, got %T",
+      "class": "internal",
+      "rationale": "subquery arguments are intercepted by lowerOuterRangeFnOverSubquery; the parser's typechecker admits only matrix-typed arguments otherwise"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/lower.go:lowerTopK#447d7d0e",
+      "message": "promql: %s K must be \u003e 0",
+      "class": "rejection",
+      "trigger_query": "topk(0, up)"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/lower.go:lowerTopK#624096c7",
+      "message": "promql: %s K must be a non-negative integer literal, got %v",
+      "class": "rejection",
+      "trigger_query": "topk(1.5, up)"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/lower.go:lowerTopKComputed#8af012e4",
+      "message": "promql: %s K must be a scalar literal or scalar(\u003cvector\u003e); computed-K with other shapes is not yet supported",
+      "class": "rejection",
+      "trigger_query": "topk(scalar(up) * 2, up)"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/lower.go:lowerTopKComputed#9dcfc5e7",
+      "message": "promql: %s K: %w",
+      "class": "internal",
+      "rationale": "error-propagation wrapper (%w): the wrapped scalar-lowering rejection is catalogued at its origin"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/lower.go:lowerTopKComputed#e4c25bc2",
+      "message": "promql: %s K: scalar() expects 1 argument, got %d",
+      "class": "internal",
+      "rationale": "parser-enforced arity: scalar() is pinned at one argument in parser.Functions"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/lower.go:plainAggCH#a6e9df79",
+      "message": "promql: aggregation op %s is not yet supported",
+      "class": "internal",
+      "rationale": "the only caller (buildAggFunc) pre-filters to the seven operators this mapper handles"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/modifiers.go:anchorFromSelector#394bcda7",
+      "message": "promql: `@ end()` modifier requires query range context (use LowerAt)",
+      "class": "internal",
+      "rationale": "the query endpoints always lower via LowerAtRange with the request window, so range context is always present; plain Lower is reached only from the matcher-metadata path, which carries no @ modifiers"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/modifiers.go:anchorFromSelector#91490634",
+      "message": "promql: `@ start()` modifier requires query range context (use LowerAt)",
+      "class": "internal",
+      "rationale": "the query endpoints always lower via LowerAtRange with the request window, so range context is always present; plain Lower is reached only from the matcher-metadata path, which carries no @ modifiers"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/modifiers.go:anchorFromSelector#df7f6e9a",
+      "message": "promql: unexpected StartOrEnd token %v",
+      "class": "internal",
+      "rationale": "the parser yields only START / END / 0 in StartOrEnd"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/range_fns.go:lowerHoltWinters#0ff3d8b3",
+      "message": "promql: holt_winters smoothing factor must be in (0, 1), got %v",
+      "class": "rejection",
+      "trigger_query": "double_exponential_smoothing(foo[5m], 2, 0.5)"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/range_fns.go:lowerHoltWinters#15e82804",
+      "message": "promql: holt_winters requires scalar-literal smoothing and trend factors",
+      "class": "rejection",
+      "trigger_query": "double_exponential_smoothing(foo[5m], scalar(up), 0.5)"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/range_fns.go:lowerHoltWinters#2db9f2aa",
+      "message": "promql: holt_winters trend factor must be in (0, 1), got %v",
+      "class": "rejection",
+      "trigger_query": "double_exponential_smoothing(foo[5m], 0.5, 2)"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/range_fns.go:lowerHoltWinters#ceef5c3b",
+      "message": "promql: holt_winters expects 3 arguments, got %d",
+      "class": "internal",
+      "rationale": "parser-enforced arity: double_exponential_smoothing is pinned at three arguments"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/range_fns.go:lowerPredictLinear#2b0de462",
+      "message": "promql: predict_linear expects 2 arguments, got %d",
+      "class": "internal",
+      "rationale": "parser-enforced arity: predict_linear is pinned at two arguments"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/range_fns.go:lowerPredictLinear#efcc690d",
+      "message": "promql: predict_linear requires a scalar-literal predict horizon (computed t is unsupported)",
+      "class": "rejection",
+      "trigger_query": "predict_linear(foo[5m], scalar(up))"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/range_fns.go:lowerQuantileOverTime#2990bde1",
+      "message": "promql: quantile_over_time requires a scalar-literal phi (computed phi is unsupported)",
+      "class": "rejection",
+      "trigger_query": "quantile_over_time(scalar(up), foo[5m])"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/range_fns.go:lowerQuantileOverTime#682124f4",
+      "message": "promql: quantile_over_time expects 2 arguments, got %d",
+      "class": "internal",
+      "rationale": "parser-enforced arity: quantile_over_time is pinned at two arguments"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/range_fns.go:matrixAndSelector#5fccc59e",
+      "message": "promql: matrix selector's inner must be a VectorSelector, got %T",
+      "class": "internal",
+      "rationale": "the parser only builds MatrixSelector around a VectorSelector"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/range_fns.go:matrixAndSelector#ce0c72b5",
+      "message": "promql: %s first argument must be a range-vector selector, got %T",
+      "class": "internal",
+      "rationale": "subquery arguments are intercepted by lowerOuterRangeFnOverSubquery; the parser's typechecker admits only matrix-typed arguments otherwise"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/subquery.go:buildSubqueryAggFunc#534fdfbe",
+      "message": "promql: subquery over %s aggregation is not supported",
+      "class": "internal",
+      "rationale": "the caller (lowerSubqueryOverAggregate) pre-filters to the supported aggregation op set before consulting this builder"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/subquery.go:buildSubqueryAggFunc#99558bfa",
+      "message": "promql: subquery over quantile(phi, ...) requires a scalar literal phi",
+      "class": "rejection",
+      "trigger_query": "max_over_time(quantile(scalar(up), up)[5m:1m])"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/subquery.go:lowerOuterRangeFnOverSubquery#b8fba661",
+      "message": "promql: %s does not accept a subquery argument",
+      "class": "rejection",
+      "trigger_query": "irate(up[5m:1m])"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/subquery.go:lowerSubquery#2174bfb8",
+      "message": "promql: subquery range must be positive, got %s",
+      "class": "internal",
+      "rationale": "the parser rejects non-positive subquery ranges (\"duration must be greater than 0\")"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/subquery.go:lowerSubquery#91084197",
+      "message": "promql: subquery step must be positive, got %s",
+      "class": "internal",
+      "rationale": "the parser rejects non-positive subquery steps (\"duration must be greater than 0\")"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/subquery.go:lowerSubquery#a374d4b2",
+      "message": "promql: subquery over %T is unsupported",
+      "class": "rejection",
+      "trigger_query": "max_over_time((-up)[5m:1m])"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/subquery.go:lowerSubqueryInnerMatrix#3a78d724",
+      "message": "promql: subquery over aggregation of %T is unsupported",
+      "class": "rejection",
+      "trigger_query": "max_over_time(sum(up + up)[5m:1m])"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/subquery.go:lowerSubqueryOverAggregate#534fdfbe",
+      "message": "promql: subquery over %s aggregation is not supported",
+      "class": "rejection",
+      "trigger_query": "max_over_time(stddev(up)[5m:1m])"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/subquery.go:lowerSubqueryOverCall#1796796f",
+      "message": "promql: subquery inner %s expects exactly 1 argument, got %d",
+      "class": "rejection",
+      "trigger_query": "max_over_time(label_replace(up, \"a\", \"b\", \"c\", \"d.*\")[5m:1m])"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/subquery.go:lowerSubqueryOverCall#a2b5a42c",
+      "message": "promql: subquery inner %s must wrap a MatrixSelector, got %T",
+      "class": "rejection",
+      "trigger_query": "max_over_time(absent(up)[5m:1m])"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/subquery.go:lowerSubqueryOverCall#df8fa0f7",
+      "message": "promql: subquery inner matrix selector must wrap a VectorSelector, got %T",
+      "class": "internal",
+      "rationale": "the parser only builds MatrixSelector around a VectorSelector"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/subquery.go:lowerSubqueryOverCallSubquery#4050ccb7",
+      "message": "promql: inner subquery range must be positive, got %s",
+      "class": "internal",
+      "rationale": "the parser rejects non-positive subquery ranges (\"duration must be greater than 0\")"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/subquery.go:lowerSubqueryOverCallSubquery#b8fba661",
+      "message": "promql: %s does not accept a subquery argument",
+      "class": "rejection",
+      "trigger_query": "max_over_time(irate(foo[5m:1m])[10m:1m])"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/subquery.go:lowerSubqueryOverCountValues#49c20b7b",
+      "message": "promql: count_values requires a string-literal label name as the first arg",
+      "class": "internal",
+      "rationale": "the parser's typechecker admits only a string literal as count_values' first argument"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/subquery.go:lowerSubqueryOverCountValues#fc5b1a1a",
+      "message": "promql: count_values requires a non-empty label name",
+      "class": "rejection",
+      "trigger_query": "max_over_time(count_values(\"\", up)[5m:1m])"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/subquery.go:lowerSubqueryOverSubquery#4050ccb7",
+      "message": "promql: inner subquery range must be positive, got %s",
+      "class": "internal",
+      "rationale": "the parser rejects non-positive subquery ranges (\"duration must be greater than 0\")"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/subquery.go:lowerSubqueryOverTopK#1455acf5",
+      "message": "promql: subquery over %s requires a scalar literal K",
+      "class": "rejection",
+      "trigger_query": "max_over_time(topk(scalar(up), up)[5m:1m])"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/subquery.go:lowerSubqueryOverTopK#aeaed3a9",
+      "message": "promql: subquery over %s K must be \u003e 0",
+      "class": "rejection",
+      "trigger_query": "max_over_time(topk(0, up)[5m:1m])"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/subquery.go:lowerSubqueryOverTopK#dbc88c34",
+      "message": "promql: subquery over %s K must be a non-negative integer literal, got %v",
+      "class": "rejection",
+      "trigger_query": "max_over_time(topk(1.5, up)[5m:1m])"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/subquery.go:subqueryAnchor#1306ccfc",
+      "message": "promql: subquery `@ start()` modifier requires query range context (use LowerAt)",
+      "class": "internal",
+      "rationale": "the query endpoints always lower via LowerAtRange with the request window, so range context is always present"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/subquery.go:subqueryAnchor#92800419",
+      "message": "promql: subquery `@ end()` modifier requires query range context (use LowerAt)",
+      "class": "internal",
+      "rationale": "the query endpoints always lower via LowerAtRange with the request window, so range context is always present"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/subquery.go:subqueryAnchor#a34bee25",
+      "message": "promql: unexpected subquery StartOrEnd token %v",
+      "class": "internal",
+      "rationale": "the parser yields only START / END / 0 in StartOrEnd"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/synthetic.go:lowerTime#99c84578",
+      "message": "promql: time() takes no arguments, got %d",
+      "class": "internal",
+      "rationale": "parser-enforced arity: time() takes no arguments"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/synthetic.go:lowerVector#7cb6213b",
+      "message": "promql: vector() expects 1 argument, got %d",
+      "class": "internal",
+      "rationale": "parser-enforced arity: vector() is pinned at one argument"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/synthetic.go:lowerVector#a33e7d9b",
+      "message": "promql: vector() requires a scalar-foldable argument or time()",
+      "class": "rejection",
+      "trigger_query": "vector(scalar(up))"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/unary.go:lowerUnary#518e89c7",
+      "message": "promql: unary operand: %w",
+      "class": "internal",
+      "rationale": "error-propagation wrapper (%w): the wrapped rejection is catalogued at its origin"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/unary.go:lowerUnary#fe35064b",
+      "message": "promql: unsupported unary op %v",
+      "class": "internal",
+      "rationale": "the parser yields only +/- unary operators"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/aggregate.go:lowerAggregate#813b68dc",
+      "message": "traceql: aggregate `%s` has nil inner expression",
+      "class": "internal",
+      "rationale": "internal invariant: the parser never yields an aggregate with a nil inner expression"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/aggregate.go:mapAggregateOp#06d8a73f",
+      "message": "traceql: aggregate op %q is unsupported",
+      "class": "internal",
+      "rationale": "the grammar's aggregate ops (count / max / min / sum / avg) are all mapped; no parser-producible op reaches the default arm"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/group_coalesce.go:lowerGroup#7f6c3db0",
+      "message": "traceql: `| group(...)` requires a field expression",
+      "class": "internal",
+      "rationale": "the grammar requires an expression inside by(...); a missing field expression is a parse error"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:evalIntCmp#e6d8e3f6",
+      "message": "traceql: operator %s is unsupported on nestedSetParent",
+      "class": "internal",
+      "rationale": "non-comparison operators never reach the nested-set evaluation: regex / arithmetic shapes fail the integer-literal check first"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:lowerAttribute#65f505d3",
+      "message": "traceql: intrinsic %s is only supported in comparisons (equality / inequality / regex)",
+      "class": "rejection",
+      "trigger_query": "{} | by(event:name)"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:lowerAttribute#aa8b5044",
+      "message": "traceql: instrumentation-scoped attribute %q is unsupported — the OTel ClickHouse traces schema has no scope-attributes column (instrumentation:name / instrumentation:version map to ScopeName / ScopeVersion)",
+      "class": "rejection",
+      "trigger_query": "{ instrumentation.foo = \"x\" }"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:lowerAttributeExpr#5268500a",
+      "message": "traceql: %s.%s used outside a comparison; only equality / inequality / regex filters on link.* and event.* are supported",
+      "class": "rejection",
+      "trigger_query": "{ event.name }"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:lowerAttributeExpr#782c14d3",
+      "message": "traceql: intrinsic %s is only supported in root-ness comparisons (e.g. nestedSetParent \u003c 0) and select() projections",
+      "class": "rejection",
+      "trigger_query": "{} | by(nestedSetParent)"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:lowerChainedSecondStage#9a3a2523",
+      "message": "traceql: chained second-stage element/separator length mismatch (%d vs %d)",
+      "class": "internal",
+      "rationale": "internal invariant: upstream's ChainedSecondStage keeps Elements and Separators in lock-step"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:lowerChainedSecondStage#add566ca",
+      "message": "traceql: chained second-stage has no elements",
+      "class": "internal",
+      "rationale": "internal invariant: the parser never yields a chained second stage with zero elements"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:lowerFieldExpr#3f3859bf",
+      "message": "traceql: field expression %T is unsupported",
+      "class": "internal",
+      "rationale": "type-switch default: every field-expression type the pinned grammar produces is handled"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:lowerFollowingElement#2dc247dc",
+      "message": "traceql: pipeline tail element %T is unsupported",
+      "class": "internal",
+      "rationale": "type-switch default: every pipeline-tail element type the pinned grammar produces is handled"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:lowerMetricsFilter#20c8f8b5",
+      "message": "traceql: metrics filter operator %s is not a supported threshold comparison",
+      "class": "internal",
+      "rationale": "the grammar restricts metrics-filter operators to the six threshold comparisons, all of which pass isThresholdBinaryOp"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:lowerMetricsFilter#b2411d4d",
+      "message": "traceql: metrics filter operator %s: %w",
+      "class": "internal",
+      "rationale": "error-propagation wrapper (%w): the grammar restricts metrics-filter operators to the six threshold comparisons, all mapped"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:lowerMetricsSecondStage#86ae75c3",
+      "message": "traceql: metrics second-stage element %T is unsupported",
+      "class": "internal",
+      "rationale": "type-switch default: every metrics second-stage element type the pinned grammar produces is handled"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:lowerNestedSetBinary#384e88f3",
+      "message": "traceql: %s comparisons support only integer literals",
+      "class": "rejection",
+      "trigger_query": "{ nestedSetParent = span.a }"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:lowerNestedSetBinary#384e88f3-2",
+      "message": "traceql: %s comparisons support only integer literals",
+      "class": "rejection",
+      "trigger_query": "{ span.a = nestedSetParent }"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:lowerNestedSetBinary#8e3d5d8d",
+      "message": "traceql: nestedSetParent %s %d depends on nested-set positions the OTel ClickHouse schema does not materialise — only root-ness tests (e.g. nestedSetParent \u003c 0) are supported",
+      "class": "rejection",
+      "trigger_query": "{ nestedSetParent = 5 }"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:lowerNestedSetBinary#96d89a10",
+      "message": "traceql: nestedSetParent comparisons support only integer literals, got %s",
+      "class": "rejection",
+      "trigger_query": "{ nestedSetParent = 1.5 }"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:lowerNestedSetBinary#ae545728",
+      "message": "traceql: intrinsic %s is unsupported — the OTel ClickHouse schema does not materialise nested-set positions",
+      "class": "rejection",
+      "trigger_query": "{ nestedSetLeft = 1 }"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:lowerPipelineElement#3ea8ac7a",
+      "message": "traceql: pipeline element %T is unsupported",
+      "class": "internal",
+      "rationale": "type-switch default: every pipeline element type the pinned grammar produces is handled"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:lowerRoot#3bb91b26",
+      "message": "traceql: empty pipeline",
+      "class": "internal",
+      "rationale": "internal invariant: tempo's Parse never returns an empty pipeline without an error"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:lowerRoot#e52d8be5",
+      "message": "traceql: nil RootExpr",
+      "class": "internal",
+      "rationale": "internal invariant: tempo's Parse never returns a nil RootExpr without an error"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:lowerScalarExpr#187e881e",
+      "message": "traceql: scalar expression %T is unsupported",
+      "class": "rejection",
+      "trigger_query": "{} | count() \u003e 1 + 1"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:lowerScalarFilter#37e7c55d",
+      "message": "traceql: scalar-filter RHS must be a literal, got %T",
+      "class": "rejection",
+      "trigger_query": "{} | count() \u003e count()"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:lowerScalarFilter#ead2eeaf",
+      "message": "traceql: scalar-filter LHS must aggregate to a series (count() / sum(...) / avg(...) / min(...) / max(...)), got %T",
+      "class": "rejection",
+      "trigger_query": "{} | 1 \u003e 2"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:lowerSpansetExpr#e8ccb6b4",
+      "message": "traceql: spanset expression %T is unsupported",
+      "class": "rejection",
+      "trigger_query": "({} | count() \u003e 1) \u0026\u0026 ({} | count() \u003e 1)"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:lowerStatic#218e2332",
+      "message": "traceql: static status literal has no Status() value",
+      "class": "internal",
+      "rationale": "internal invariant: a TypeStatus static always carries a Status value"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:lowerStatic#25110d71",
+      "message": "traceql: static literal type %s is unsupported",
+      "class": "internal",
+      "rationale": "every static type the pinned grammar produces in lowerable positions (int / float / string / bool / duration / status / kind) is handled; array statics do not parse"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:lowerStatic#567e5794",
+      "message": "traceql: static kind literal has no Kind() value",
+      "class": "internal",
+      "rationale": "internal invariant: a TypeKind static always carries a Kind value"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:lowerTopKBottomK#78efd9fa",
+      "message": "traceql: %s(%d): limit must be \u003e 0",
+      "class": "rejection",
+      "trigger_query": "{} | rate() by (span.name) | topk(0)",
+      "endpoint": "traceql_metrics"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:lowerUnaryOperation#415441d4",
+      "message": "traceql: nil comparison on intrinsic %s is unsupported — OTel-CH intrinsic columns are always present",
+      "class": "rejection",
+      "trigger_query": "{ kind != nil }"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:lowerUnaryOperation#5f9f3466",
+      "message": "traceql: unary operator %s is unsupported",
+      "class": "rejection",
+      "trigger_query": "{ !(span.foo = 1) }"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:lowerUnaryOperation#76707682",
+      "message": "traceql: %s operand %T is unsupported — nil comparisons require an attribute reference",
+      "class": "rejection",
+      "trigger_query": "{ (span.a + 1) != nil }"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:lowerUnaryOperation#ae3df2c6",
+      "message": "traceql: nil comparison on %s.%s is unsupported",
+      "class": "rejection",
+      "trigger_query": "{ link.foo != nil }"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:mapBinaryOp#786cde25",
+      "message": "traceql: operator %s is unsupported",
+      "class": "internal",
+      "rationale": "every operator the pinned grammar yields in binary positions is mapped; unary operators route through lowerUnaryOperation"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:mapSecondStageOp#76dac09c",
+      "message": "traceql: second-stage op %s is not supported",
+      "class": "internal",
+      "rationale": "the grammar's metrics second stages are exactly topk / bottomk, both mapped"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:mapStructuralOp#753a4362",
+      "message": "traceql: spanset op %s is not a structural relation",
+      "class": "internal",
+      "rationale": "callers pre-filter to the structural operator set before consulting this mapper"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:unsupportedIntrinsicErr#284df75f",
+      "message": "traceql: intrinsic %s requires per-span child counts the OTel ClickHouse schema does not materialise",
+      "class": "internal",
+      "rationale": "the pinned tempo parser rejects the childCount spelling (\"unexpected childCount\"), so the arm is unreachable from a parseable query"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:unsupportedIntrinsicErr#3c6b93ea",
+      "message": "traceql: intrinsic %s requires per-event timestamp arithmetic against the Events Nested column and is unsupported",
+      "class": "rejection",
+      "trigger_query": "{ event:timeSinceStart \u003e 1s }"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:unsupportedIntrinsicErr#471b92bc",
+      "message": "traceql: intrinsic %s is trace-scoped — the OTel ClickHouse schema stores one row per span and does not materialise whole-trace values",
+      "class": "rejection",
+      "trigger_query": "{ traceDuration \u003e 1s }"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:unsupportedIntrinsicErr#782c14d3",
+      "message": "traceql: intrinsic %s is only supported in root-ness comparisons (e.g. nestedSetParent \u003c 0) and select() projections",
+      "class": "rejection",
+      "trigger_query": "{} | min(nestedSetLeft) \u003e 0"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/lower.go:unsupportedIntrinsicErr#86d3eeb3",
+      "message": "traceql: intrinsic %s has no OTel ClickHouse backing column and is unsupported",
+      "class": "internal",
+      "rationale": "every intrinsic the pinned grammar parses either has a backing column, a dedicated arm above, or is intercepted earlier; no parseable intrinsic reaches the default arm"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/metrics_compare.go:lowerMetricsCompare#14f543c1",
+      "message": "traceql: compare() selection filter lowered to no predicate",
+      "class": "internal",
+      "rationale": "every parseable compare() selection filter (including `{}` and constant-true filters) lowers to a predicate"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/metrics_compare.go:lowerMetricsCompare#23f37ac7",
+      "message": "traceql: compare() requires a selection spanset filter",
+      "class": "internal",
+      "rationale": "the grammar requires a spanset-filter argument on compare(); Filter() is never nil for a parseable query"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/metrics_pipeline.go:lowerMetricsAggregate#c5a17af0",
+      "message": "traceql: quantile_over_time requires at least one quantile",
+      "class": "internal",
+      "rationale": "the grammar requires at least one quantile argument on quantile_over_time"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/metrics_pipeline.go:lowerMetricsGroupBy#26b9b81a",
+      "message": "traceql: empty by(...) group key",
+      "class": "internal",
+      "rationale": "the grammar rejects an empty by() group key as a parse error"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/metrics_pipeline.go:lowerMetricsHistogramOverTime#3fe5309b",
+      "message": "traceql: histogram_over_time requires an attribute operand",
+      "class": "internal",
+      "rationale": "the grammar admits only attribute operands inside histogram_over_time(...)"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/metrics_pipeline.go:lowerMetricsPipeline#d4c9f593",
+      "message": "traceql: metrics pipeline element %T is unsupported",
+      "class": "internal",
+      "rationale": "type-switch default: every metrics pipeline element type the pinned grammar produces is handled"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/metrics_pipeline.go:mapMetricsAggregateOp#a456c01c",
+      "message": "traceql: histogram_over_time must lower via lowerMetricsHistogramOverTime",
+      "class": "internal",
+      "rationale": "internal routing invariant: histogram_over_time is dispatched to lowerMetricsHistogramOverTime before this mapper"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/metrics_pipeline.go:mapMetricsAggregateOp#e363ec48",
+      "message": "traceql: metrics aggregate op %s is unsupported",
+      "class": "internal",
+      "rationale": "every metrics aggregate op the pinned grammar produces is mapped"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/metrics_pipeline.go:metricsAggregateAttr#937cdd96",
+      "message": "traceql: %s requires an attribute operand",
+      "class": "internal",
+      "rationale": "the grammar admits only attribute operands inside the *_over_time(...) metrics aggregates"
+    },
+    {
+      "head": "traceql",
+      "site": "internal/traceql/select.go:lowerSelect#bba2e3bc",
+      "message": "traceql: `| select(...)` requires at least one attribute",
+      "class": "internal",
+      "rationale": "the grammar rejects an empty select() as a parse error"
+    }
+  ]
+}

--- a/test/rejection-parity/catalogue_test.go
+++ b/test/rejection-parity/catalogue_test.go
@@ -1,0 +1,236 @@
+package rejectionparity
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	tempotraceql "github.com/grafana/tempo/pkg/traceql"
+	promparser "github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/logql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/traceql"
+)
+
+const (
+	repoRoot      = "../.."
+	cataloguePath = "catalogue.json"
+)
+
+// TestCatalogueIsRegenerable rescans the three lowering packages and
+// diffs the regenerated catalogue byte-for-byte against the checked-in
+// JSON. Set CERBERUS_UPDATE_INVENTORY=1 to rewrite the artifact (the
+// same update-via-env convention as test/inventory). Regeneration
+// preserves the curated fields of surviving sites; new sites land
+// unclassified (and then fail TestCatalogueEntriesAreClassified until
+// curated), removed sites drop out. Both directions are deliberate,
+// reviewable diffs — a rejection site can neither appear nor vanish
+// without the catalogue (and therefore the parity corpus) moving in
+// lock-step.
+func TestCatalogueIsRegenerable(t *testing.T) {
+	t.Parallel()
+
+	prev, err := LoadCatalogue(cataloguePath)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("load %s: %v", cataloguePath, err)
+	}
+	cat, err := Generate(repoRoot, prev)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	want, err := MarshalCatalogue(cat)
+	if err != nil {
+		t.Fatalf("MarshalCatalogue: %v", err)
+	}
+
+	if os.Getenv("CERBERUS_UPDATE_INVENTORY") != "" {
+		if err := os.WriteFile(cataloguePath, want, 0o644); err != nil {
+			t.Fatalf("write %s: %v", cataloguePath, err)
+		}
+		t.Logf("rewrote %s (%d entries)", cataloguePath, len(cat.Entries))
+		return
+	}
+
+	got, err := os.ReadFile(cataloguePath)
+	if err != nil {
+		t.Fatalf("read %s (rerun with CERBERUS_UPDATE_INVENTORY=1 to generate): %v", cataloguePath, err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("%s is stale relative to the lowering sources — rerun with "+
+			"CERBERUS_UPDATE_INVENTORY=1, curate any new entries, and commit the diff.\n"+
+			"--- want %d bytes, got %d bytes", cataloguePath, len(want), len(got))
+	}
+}
+
+// TestCatalogueEntriesAreClassified is the curation gate: every
+// scanned site must be classified, rejection entries must carry a
+// trigger query + valid endpoint, and internal entries must justify
+// themselves with a rationale. An unclassified entry (the regen
+// default for a new rejection site) fails here — a new deliberate
+// rejection cannot land without a parity-corpus case.
+func TestCatalogueEntriesAreClassified(t *testing.T) {
+	t.Parallel()
+
+	cat := loadCatalogue(t)
+	seen := map[string]bool{}
+	for _, e := range cat.Entries {
+		if seen[e.Site.Site] {
+			t.Errorf("entry %s is listed twice", e.Site.Site)
+		}
+		seen[e.Site.Site] = true
+		switch e.Class {
+		case "rejection":
+			if strings.TrimSpace(e.TriggerQuery) == "" {
+				t.Errorf("rejection entry %s has no trigger query", e.Site.Site)
+			}
+			ep := e.Endpoint
+			if ep == "" {
+				ep = DefaultEndpoint(e.Head)
+			}
+			if !ValidEndpoint(e.Head, ep) {
+				t.Errorf("rejection entry %s: endpoint %q invalid for head %s", e.Site.Site, ep, e.Head)
+			}
+			if e.Rationale != "" {
+				t.Errorf("rejection entry %s carries a rationale — rationales belong to internal entries; a rejection justifies itself via its trigger query", e.Site.Site)
+			}
+		case "internal":
+			if strings.TrimSpace(e.Rationale) == "" {
+				t.Errorf("internal entry %s carries no rationale — every internal classification must justify why the site is not wire-reachable", e.Site.Site)
+			}
+			if e.TriggerQuery != "" || e.Endpoint != "" {
+				t.Errorf("internal entry %s carries trigger query / endpoint — those belong to rejection entries", e.Site.Site)
+			}
+		default:
+			t.Errorf("entry %s is unclassified (class=%q) — classify as rejection (with trigger query) or internal (with rationale)", e.Site.Site, e.Class)
+		}
+	}
+}
+
+// TestRejectionTriggersExerciseSites is the centrepiece pin: for every
+// class=rejection entry, the trigger query (a) parses with the head's
+// reference parser — proving the rejection is semantic, not a parse
+// error — and (b) fails the head's lowering with an error matching the
+// site's message — proving the trigger actually exercises the
+// catalogued site, so the parity corpus diffs the claim the site makes
+// and not some other failure.
+func TestRejectionTriggersExerciseSites(t *testing.T) {
+	t.Parallel()
+
+	cat := loadCatalogue(t)
+	for _, e := range cat.Entries {
+		if e.Class != "rejection" {
+			continue
+		}
+		e := e
+		t.Run(e.Site.Site, func(t *testing.T) {
+			t.Parallel()
+			errStr := lowerTrigger(t, e)
+			if !ErrorMatchesMessage(errStr, e.Message) {
+				t.Fatalf("trigger %q failed lowering with %q, which does not match the catalogued message %q — the trigger exercises a different site",
+					e.TriggerQuery, errStr, e.Message)
+			}
+		})
+	}
+}
+
+// TestParityCorpusMatchesCatalogue pins the third leg of the ratchet:
+// the parity-corpus case set the compat driver runs is derived 1:1
+// from the rejection entries — same count, same site keys — for every
+// head. BuildCases is the same function the driver binary calls, so
+// the corpus cannot drift from the catalogue.
+func TestParityCorpusMatchesCatalogue(t *testing.T) {
+	t.Parallel()
+
+	cat := loadCatalogue(t)
+	for _, head := range []string{"promql", "logql", "traceql"} {
+		cases, err := BuildCases(cat, head)
+		if err != nil {
+			t.Fatalf("BuildCases(%s): %v", head, err)
+		}
+		var rejections []string
+		for _, e := range cat.Entries {
+			if e.Head == head && e.Class == "rejection" {
+				rejections = append(rejections, e.Site.Site)
+			}
+		}
+		if len(cases) != len(rejections) {
+			t.Fatalf("head %s: %d parity cases for %d rejection entries", head, len(cases), len(rejections))
+		}
+		for i, c := range cases {
+			if c.Name != rejections[i] {
+				t.Fatalf("head %s: case %d is %s, want %s", head, i, c.Name, rejections[i])
+			}
+		}
+		if len(cases) == 0 {
+			t.Fatalf("head %s: zero parity cases — the catalogue lost its rejection entries", head)
+		}
+	}
+}
+
+// lowerTrigger parses + lowers one trigger query through the same
+// entrypoints the HTTP handlers use and returns the lowering error
+// string. Parse failures and lowering successes are both fatal — a
+// trigger must be a valid-language query that the lowering rejects.
+func lowerTrigger(t *testing.T, e Entry) string {
+	t.Helper()
+	ctx := context.Background()
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(5 * time.Minute)
+
+	switch e.Head {
+	case "promql":
+		p := promparser.NewParser(promparser.Options{EnableExperimentalFunctions: true})
+		expr, err := p.ParseExpr(e.TriggerQuery)
+		if err != nil {
+			t.Fatalf("trigger %q does not parse as PromQL: %v", e.TriggerQuery, err)
+		}
+		// Instant query shape: the prom Lang adapter always lowers via
+		// LowerAtRange; /api/v1/query leaves Step at zero.
+		_, lerr := promql.LowerAtRange(ctx, expr, schema.DefaultOTelMetrics(), end, end, 0)
+		if lerr == nil {
+			t.Fatalf("trigger %q lowered successfully — the catalogued rejection is unreachable via this query", e.TriggerQuery)
+		}
+		return lerr.Error()
+	case "logql":
+		// ParseExprPermissive is the parse entrypoint the wire path
+		// uses (internal/logql/lang.go Parse); mirror it so the
+		// exerciser proves wire-level reachability.
+		expr, err := logql.ParseExprPermissive(e.TriggerQuery)
+		if err != nil {
+			t.Fatalf("trigger %q does not parse as LogQL: %v", e.TriggerQuery, err)
+		}
+		_, lerr := logql.LowerAtRange(ctx, expr, schema.DefaultOTelLogs(), start, end, 30*time.Second)
+		if lerr == nil {
+			t.Fatalf("trigger %q lowered successfully — the catalogued rejection is unreachable via this query", e.TriggerQuery)
+		}
+		return lerr.Error()
+	case "traceql":
+		expr, err := tempotraceql.Parse(e.TriggerQuery)
+		if err != nil {
+			t.Fatalf("trigger %q does not parse as TraceQL: %v", e.TriggerQuery, err)
+		}
+		_, lerr := traceql.Lower(ctx, expr, schema.DefaultOTelTraces())
+		if lerr == nil {
+			t.Fatalf("trigger %q lowered successfully — the catalogued rejection is unreachable via this query", e.TriggerQuery)
+		}
+		return lerr.Error()
+	}
+	t.Fatalf("entry %s has unknown head %q", e.Site.Site, e.Head)
+	return ""
+}
+
+func loadCatalogue(t *testing.T) *Catalogue {
+	t.Helper()
+	cat, err := LoadCatalogue(cataloguePath)
+	if err != nil {
+		t.Fatalf("load %s (rerun TestCatalogueIsRegenerable with CERBERUS_UPDATE_INVENTORY=1 to generate): %v", cataloguePath, err)
+	}
+	if len(cat.Entries) == 0 {
+		t.Fatalf("%s is empty", cataloguePath)
+	}
+	return cat
+}

--- a/test/rejection-parity/doc.go
+++ b/test/rejection-parity/doc.go
@@ -1,0 +1,41 @@
+// Package rejectionparity owns the deliberate-rejection catalogue —
+// the machine-readable inventory of every error-construction site in
+// the three lowerings (internal/promql, internal/logql,
+// internal/traceql) that can surface as an HTTP 422 "query is valid
+// <QL> but cerberus rejects it" response.
+//
+// Motivation: a deliberate rejection is a CLAIM about reference
+// behaviour ("the reference backend cannot answer this either") that
+// no other test layer verifies differentially. The `kind != nil`
+// incident proved the failure mode: cerberus rejected a query
+// reference Tempo accepts, and every test layer was blind to it
+// because rejections were never diffed against the reference. This
+// package makes that class of wrong belief impossible to pin
+// silently:
+//
+//  1. ScanSites enumerates every `fmt.Errorf("<head>: ...")` /
+//     `errors.New("<head>: ...")` construction site in the three
+//     lowering packages via go/ast — the mechanical universe of
+//     rejection candidates.
+//  2. catalogue.json classifies every site as either `rejection`
+//     (reachable from a parseable query; carries a minimal
+//     trigger query) or `internal` (defensive / invariant /
+//     error-propagation wrapper; carries a rationale).
+//  3. The meta-tests in catalogue_test.go pin the three-way ratchet:
+//     scanned-site set == catalogue set (regenerable via
+//     CERBERUS_UPDATE_INVENTORY=1), every `rejection` entry's trigger
+//     query parses AND fails lowering with the site's message, and
+//     the parity-corpus case set is derived 1:1 from the `rejection`
+//     entries via BuildCases.
+//  4. compatibility/cmd/rejection-parity consumes BuildCases inside
+//     each compat harness and asserts the REFERENCE backend also
+//     rejects every trigger query. Reference accepting is a
+//     wrong-rejection bug to fix at the source — never an allow-list
+//     entry.
+//
+// Adding a new rejection to a lowering therefore requires: a
+// catalogue entry (the regen test fails without it), a trigger query
+// (the exerciser test fails without it), and — by construction — a
+// parity-corpus case the next compat run diffs against the reference
+// backend.
+package rejectionparity


### PR DESCRIPTION
## Summary

New shift-left layer (maintainer-driven): **every deliberate rejection in the three lowerings is now a verified claim, not a belief.** Motivated by the `kind != nil` incident — a 422 cerberus invented that reference Tempo accepts, invisible to every test layer because rejections were never diffed.

## What's in the box

- **Catalogue** (`test/rejection-parity/catalogue.json`): go/ast scan of all 182 error sites in `internal/{promql,logql,traceql}` — 67 curated as differential rejections with minimal verified trigger queries, 115 classified internal with rationale. Site keys hash the message so unrelated edits don't churn.
- **Meta-tests**: regen-and-diff vs live scan; every trigger parses with the head's reference parser and fails cerberus's lowering with the catalogued message; parity corpus derived 1:1 (`corpus count == catalogue count` by construction).
- **Driver** (`compatibility/cmd/rejection-parity`): status-class-only differential (both-4xx = parity, never message text), wired into all three compat run scripts, report-only per the compat-lane design.
- Mechanism proof: the pre-#781 run flagged `{kind != nil}` as wrong_rejection; post-rebase those entries vanished and the new reference-mirroring rejections verify as parity — exactly the designed reconciliation.

## Headline finding: 49 wrong rejections (reference accepts, cerberus 422s)

- **PromQL 25/33**: incl. `absent(sum(...))`, `atan2`, `histogram_quantile` over aggregates/scalar args, the native-histogram fn family (`histogram_count` etc.), `topk(0,...)`/fractional-k, string literals, `vector(scalar(...))`, `irate` over subqueries, and 9 subquery-over-X shapes.
- **LogQL 9/12**: `and` set-op on sample exprs, `+ bool`, `ip()` label+line filters, `|>` pattern filter, `first_over_time`, `absent_over_time`, `topk`, `sort`.
- **TraceQL 15/22**: nested-set intrinsics in filter positions (`{nestedSetParent = 5}` — currently *showcase-pinned as rejections*, same wrong-pin class as #654), `traceDuration`/`event:timeSinceStart` comparisons, instrumentation-scope attrs, `event.name` bare, scalar-pipeline `&&`, unary `!`, `by(event:name)`/`by(nestedSetParent)`, `min(nestedSetLeft)` second-stage.

Each is a fix task; none allowlisted. Two parity passes are data/config-sensitive (documented); two reference-side 5xx hard-errors classified separately.

Closes task #57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
