### PR TITLE
feat(e2e/crawl): interaction sweep — enumerate every consumption-mode control

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -131,12 +131,24 @@ jobs:
       (github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'schedule') &&
       (github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true')
     runs-on: ubuntu-latest
-    # 45 (was 30): the nightly SWEEP_DEPTH=full lane now also kiosks +
-    # browser-renders the showcase-family dashboards (showcase-promql
-    # adds ~100 panel states to iterate-panel-kiosk alone). PR/push
-    # lean runs stay well under the old 30-minute ceiling; the bump
-    # only buys headroom for the scheduled full-depth sweep.
-    timeout-minutes: 45
+    # Timeout is per-lane. PR/push run SWEEP_DEPTH=lean: the catch-net
+    # smoke + the iterate-* specs + the lean crawl (root + nav + one
+    # representative state per interaction control on the three
+    # drilldown roots) finish well under 45 min — that ceiling (was 30)
+    # absorbed the showcase-family kiosk renders (showcase-promql adds
+    # ~100 panel states to iterate-panel-kiosk alone).
+    #
+    # The nightly schedule runs SWEEP_DEPTH=full: the crawl spec alone
+    # BFS-walks every eligible surface AND drives every interactive
+    # control on each (the interaction sweep), which was observed at
+    # 50+ minutes wall-clock on its own — on top of the full-depth
+    # kiosk/browser-render passes of the other specs in this same job.
+    # 45 min cannot hold that; the full lane gets 120. The expression
+    # keeps the PR gate tight (fast feedback) while the nightly lane
+    # has the headroom the full-depth interaction sweep genuinely
+    # needs. Full-depth is NIGHTLY-ONLY by design — never a PR gate;
+    # see SWEEP_DEPTH below + docs/test-strategy.md (interaction sweep).
+    timeout-minutes: ${{ github.event_name == 'schedule' && 120 || 45 }}
     concurrency:
       group: compose-smoke-${{ github.ref }}
       cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -266,10 +266,10 @@ flows to *discovered* ones. Where the iterate-\* specs visit known
 surfaces (dashboards, panels, the drilldown-app catalogue), the
 crawler (`crawl/crawl.spec.ts`) BFS-walks every same-origin link
 reachable from the Grafana root, canonicalizes URLs so the
-visited-set converges (path-only keys; dynamic segments like service
-names, trace ids, and folder uids parameterize; `/explore` collapses
-to one surface), and applies the same universal oracles on every
-page — no per-page code:
+visited-set converges (path + structural-param keys; dynamic
+segments like service names, trace ids, and folder uids
+parameterize; `/explore` collapses to one surface), and applies the
+same universal oracles on every page — no per-page code:
 
 1. **Zero browser console errors** (no cerberus-origin noise filter,
    ever).
@@ -284,6 +284,54 @@ page — no per-page code:
    "No data" fails with the panel title + URL.
 4. **No page-level crash banner** and no visible `role="alert"`
    error banner.
+
+**Interaction sweep** (`crawl/interactions.ts`). Visiting a surface
+at its default control state is not enough: the 2026-06-10 maintainer
+find — clicking the Traces Drilldown breakdown groupBy "kind"
+attribute fired `{… && kind != nil} | rate() by(kind)` and cerberus
+422'd on the nil-comparison — was a state no harvested link encodes.
+After each surface's base audit the crawler therefore discovers its
+view-affecting interactive controls and drives every planned
+deviation, each against a **fresh navigation** of the surface
+(deterministic provenance: one state = surface default + exactly one
+control deviation). Control kinds discovered: tab strips
+(`role=tablist`), radio groups (`role=radiogroup`, re-found at drive
+time by option-name signature — the generated input ids are
+mount-order dependent), select/combobox dropdowns (probed open to
+learn their option sets; datasource pickers, sort-bys, level
+filters), titled option lists (the Traces Drilldown attribute
+picker), metric select tiles, and adhoc-filter builders (driven as
+one representative key → value pair). Mutating affordances
+(save/delete/create/add-tab), free-text search inputs, and the
+time/refresh pickers (owned by iterate-time-ranges) are excluded —
+the crawl stays read-only.
+
+State identity follows the URL. A deviation the app encodes into the
+URL becomes a **first-class surface**: the canonicalizer retains
+*structural* params (`StructuralParamRule` in `crawl/lib.ts`) —
+low-cardinality ones verbatim (`?actionView=comparison`,
+`?var-groupBy=kind`) with the app's cold-boot default dropped, and
+high-cardinality ones parameterized (`?metric={metric}`, the
+`{service}` doctrine) — and the BFS visits the discovered state
+fresh with the full oracle set. A deviation that does **not** encode
+to the URL is audited in place with the same oracles and pins into
+the inventory under the state notation
+`<canonical>#<control>=<value>` (high-cardinality representatives
+record `{rep}` so data-derived values can't flicker the inventory).
+
+Bounding (the locked pairwise design, enforced in
+`planInteractions`): structural controls (≤ 12 options) enumerate
+**fully**; high-cardinality controls take **one representative**;
+cross-control combos form **pairwise via surface chaining** — a
+surface pinning one structural param sweeps with the representative
+plan (one option per control, each interaction forming a param
+pair), and surfaces pinning ≥ 2 params are terminal (visited, never
+expanded). Every plan is hard-capped (24 single-sweep / 16 pairwise
+per surface); overflow **fails the crawl listing the full plan** —
+never a silent truncation. Depth doctrine unchanged: lean sweeps the
+configured representative roots (the three drilldown app entries)
+with one state per control; full sweeps every eligible surface
+exhaustively.
 
 Two sibling specs ride the same lane:
 

--- a/test/e2e/playwright/crawl/crawl.spec.ts
+++ b/test/e2e/playwright/crawl/crawl.spec.ts
@@ -32,12 +32,33 @@
  *      "application error", …) and no `role="alert"` banner with
  *      error-class text anywhere on the page.
  *
+ * INTERACTION SWEEP (interactions.ts): visiting a surface at its
+ * default state is not enough — the 2026-06-10 maintainer find
+ * (Traces Drilldown breakdown groupBy=kind → nil-comparison 422) was
+ * a state no harvested link encodes, reached only by clicking a
+ * control. After each surface's base audit the crawler discovers its
+ * view-affecting controls (tab strips, radio groups, comboboxes,
+ * attribute pickers, metric tiles, adhoc-filter builders; mutating
+ * affordances and time pickers excluded) and drives each planned
+ * deviation against a FRESH navigation. A deviation that encodes to
+ * the URL becomes a first-class surface (the canonicalizer retains
+ * structural params — see StructuralParamRule in lib.ts); one that
+ * doesn't is audited in place with the same oracle set and pins into
+ * the inventory as `<canonical>#<control>=<value>`. Bounding is the
+ * locked pairwise design (see interactions.ts): structural controls
+ * enumerate fully, high-cardinality controls take one
+ * representative, cross-control combos form pairwise via surface
+ * chaining, and every plan is hard-capped — overflow fails loudly.
+ *
  * Depth doctrine (see helpers/depth.ts — depth changes STATES, never
  * RULES): at 'lean' (the per-PR gate) the crawl visits the root page,
  * the nav links harvested from it, and one representative per
- * drilldown app. At 'full' (nightly) the BFS is exhaustive up to a
- * HARD page cap that fails the run when exceeded — surface growth
- * must force a deliberate cap bump, never a silent partial crawl.
+ * drilldown app, and sweeps interactions on the configured
+ * representative roots with one state per control. At 'full'
+ * (nightly) the BFS is exhaustive up to a HARD page cap that fails
+ * the run when exceeded — surface growth must force a deliberate cap
+ * bump, never a silent partial crawl — and the interaction sweep
+ * covers every eligible surface exhaustively.
  *
  * STACK FRAMEWORK: this spec is the stack-agnostic engine driver.
  * CRAWL_STACK=<name> selects a config from crawl/stacks.ts (base
@@ -81,6 +102,7 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import {
   expect,
   test,
+  type Browser,
   type BrowserContext,
   type Page,
   type Response,
@@ -109,10 +131,18 @@ import {
   loadExclusions,
   loadInventory,
   marshalInventory,
+  pinnedStructuralParamCount,
   truncate,
   type ScopeRules,
   type SurfaceInventory,
 } from './lib.js';
+import {
+  discoverControls,
+  driveInteraction,
+  interactionStateKey,
+  planInteractions,
+  type PlannedInteraction,
+} from './interactions.js';
 import {
   activeStack,
   knownStackNames,
@@ -131,13 +161,68 @@ const SEED_TRAFFIC_SECONDS = 30;
 // never a silently-partial crawl. The lean cap exists for the same
 // reason at fast-lane scale.
 
-// Recycle the browser context every N visited pages. A single
-// renderer reused across the whole full-depth crawl accumulates state
-// until Chromium refuses requests with net::ERR_INSUFFICIENT_RESOURCES
-// (same failure mode iterate-panel-kiosk documents at ~190
-// navigations); 40 keeps a wide margin while preserving cheap
-// navigation within a batch.
-const CONTEXT_RECYCLE_PAGES = 40;
+// Recycle the browser context every N NAVIGATIONS. A single renderer
+// reused across the whole full-depth crawl accumulates state until
+// Chromium refuses requests with net::ERR_INSUFFICIENT_RESOURCES or
+// crashes the renderer outright (iterate-panel-kiosk documents the
+// cliff at ~190 navigations; the first full interaction-sweep run
+// crashed far earlier because every planned gesture adds a fresh
+// navigation of a heavy scenes app). Counting NAVIGATIONS — base
+// visits AND per-interaction fresh navigations — keeps the margin
+// wide; 25 trades a little context-boot overhead for renderer
+// stability.
+const CONTEXT_RECYCLE_NAVIGATIONS = 25;
+
+/**
+ * Page provider with navigation-budgeted context recycling and crash
+ * recovery. Every navigation in the crawl — BFS base visits and the
+ * interaction sweep's per-gesture fresh navigations — goes through
+ * `acquire()` + `noteNavigation()`, so the recycle budget counts
+ * what actually wears the renderer out. A renderer crash flags the
+ * lease and the next acquire() starts a clean context instead of
+ * cascading "Page crashed" through every remaining state (the
+ * failure shape of the first full-depth run).
+ */
+type PageLease = {
+  acquire: () => Promise<Page>;
+  noteNavigation: () => void;
+  close: () => Promise<void>;
+};
+
+function makePageLease(browser: Browser): PageLease {
+  let context: BrowserContext | null = null;
+  let page: Page | null = null;
+  let navsInContext = 0;
+  let crashed = false;
+  return {
+    acquire: async () => {
+      if (
+        page === null ||
+        page.isClosed() ||
+        crashed ||
+        navsInContext >= CONTEXT_RECYCLE_NAVIGATIONS
+      ) {
+        if (context !== null) await context.close().catch(() => {});
+        context = await browser.newContext();
+        page = await context.newPage();
+        page.on('crash', () => {
+          crashed = true;
+        });
+        navsInContext = 0;
+        crashed = false;
+      }
+      return page;
+    },
+    noteNavigation: () => {
+      navsInContext++;
+    },
+    close: async () => {
+      if (context !== null) await context.close().catch(() => {});
+      context = null;
+      page = null;
+    },
+  };
+}
 
 type CrawlFailure = {
   url: string; // canonical surface
@@ -202,6 +287,19 @@ test.describe('crawl: canonicalization pins', () => {
           canonicalTarget(root, cfg.defaultGrafanaURL, cfg.scope),
           `stack ${name}: lean seed root ${root} canonicalizes in-scope`,
         ).not.toBeNull();
+      }
+      expect(
+        cfg.leanInteractionRoots.length,
+        `stack ${name}: at least one lean interaction root (the gap class the sweep exists for)`,
+      ).toBeGreaterThan(0);
+      for (const root of cfg.leanInteractionRoots) {
+        // Interaction roots are CANONICAL surface keys: they must be
+        // their own canonical form (already path-rewritten, no
+        // session params, no in-place state suffix).
+        expect(
+          canonicalizeURL(root, cfg.defaultGrafanaURL, cfg.scope),
+          `stack ${name}: lean interaction root ${root} is a canonical surface key`,
+        ).toBe(root);
       }
       // EVERY stack's committed files must load (existence + shape +
       // the inventory's stack field matching the config name) and the
@@ -279,6 +377,134 @@ test.describe('crawl: canonicalization pins', () => {
         scope,
       ),
     ).toBe('/a/grafana-lokiexplore-app/explore/service/{service}/label/{label}');
+  });
+
+  test('structural params join the canonical key; defaults and session params drop', () => {
+    // The maintainer-found gap: var-groupBy selects WHICH query the
+    // breakdown fires — a consumption mode, hence a surface. Boot
+    // defaults (actionView=breakdown, var-metric=rate,
+    // var-groupBy=resource.service.name) drop so the app rewriting
+    // its defaults into the URL can't re-key the bare surface.
+    expect(
+      canonicalizeURL(
+        '/a/grafana-exploretraces-app/explore?from=now-30m&to=now&var-ds=cerberus-tempo&var-filters=&var-metric=rate&var-groupBy=kind&actionView=breakdown',
+        base,
+        scope,
+      ),
+    ).toBe('/a/grafana-exploretraces-app/explore?var-groupBy=kind');
+    // Two pinned params sort by name — pairwise-terminal state.
+    expect(
+      canonicalizeURL(
+        '/a/grafana-exploretraces-app/explore?var-groupBy=kind&actionView=comparison',
+        base,
+        scope,
+      ),
+    ).toBe(
+      '/a/grafana-exploretraces-app/explore?actionView=comparison&var-groupBy=kind',
+    );
+    // All-defaults URL keys the bare surface.
+    expect(
+      canonicalizeURL(
+        '/a/grafana-exploretraces-app/explore?actionView=breakdown&var-metric=rate&var-groupBy=resource.service.name&var-primarySignal=nestedSetParent%3C0',
+        base,
+        scope,
+      ),
+    ).toBe('/a/grafana-exploretraces-app/explore');
+    // High-cardinality structural params parameterize ({metric}), and
+    // boot defaults written alongside still drop.
+    expect(
+      canonicalizeURL(
+        '/a/grafana-metricsdrilldown-app/drilldown?metric=cerberus_admit_rejected_total&actionView=breakdown&var-groupby=%24__all&layout=grid',
+        base,
+        scope,
+      ),
+    ).toBe('/a/grafana-metricsdrilldown-app/drilldown?metric={metric}');
+    // Logs service pages: visualizationType deviations key surfaces
+    // (values are JSON-string-quoted by the app); the boot default drops.
+    expect(
+      canonicalizeURL(
+        '/a/grafana-lokiexplore-app/explore/service/shop/logs?visualizationType=%22table%22&sortOrder=%22Descending%22',
+        base,
+        scope,
+      ),
+    ).toBe(
+      '/a/grafana-lokiexplore-app/explore/service/{service}/logs?visualizationType="table"',
+    );
+    expect(
+      canonicalizeURL(
+        '/a/grafana-lokiexplore-app/explore/service/shop/logs?visualizationType=%22logs%22',
+        base,
+        scope,
+      ),
+    ).toBe('/a/grafana-lokiexplore-app/explore/service/{service}/logs');
+  });
+
+  test('pinned structural-param counting (the pairwise depth bound)', () => {
+    expect(
+      pinnedStructuralParamCount('/a/grafana-exploretraces-app/explore'),
+    ).toBe(0);
+    expect(
+      pinnedStructuralParamCount(
+        '/a/grafana-exploretraces-app/explore?var-groupBy=kind',
+      ),
+    ).toBe(1);
+    expect(
+      pinnedStructuralParamCount(
+        '/a/grafana-exploretraces-app/explore?actionView=comparison&var-groupBy=kind',
+      ),
+    ).toBe(2);
+    expect(
+      pinnedStructuralParamCount(
+        '/a/grafana-metricsdrilldown-app/drilldown?metric={metric}',
+      ),
+    ).toBe(1);
+  });
+
+  test('interaction planning honours the locked pairwise bounds', () => {
+    const control = (key: string, n: number, forced = false) => ({
+      kind: 'radio' as const,
+      key,
+      options: Array.from({ length: n }, (_, i) => `opt${i}`),
+      selectedIndex: 0,
+      forcedHighCardinality: forced,
+      optionHints: Array.from({ length: n }, (_, i) => `opt${i}`),
+      controlHint: '',
+    });
+    // Structural controls enumerate fully (minus the selected option).
+    const single = planInteractions([control('a', 4)], 0);
+    expect(single.map((p) => p.option)).toEqual(['opt1', 'opt2', 'opt3']);
+    expect(single.map((p) => p.leanRepresentative)).toEqual([
+      true,
+      false,
+      false,
+    ]);
+    // High-cardinality (by size or by construction) → one
+    // representative with a parameterized state value.
+    const high = planInteractions(
+      [control('big', 20), control('tiles', 3, true)],
+      0,
+    );
+    expect(high.map((p) => `${p.control.key}=${p.stateValue}`)).toEqual([
+      'big={rep}',
+      'tiles={rep}',
+    ]);
+    // One pinned param → representative plan (pairwise combos).
+    expect(
+      planInteractions([control('a', 4), control('b', 4)], 1).map(
+        (p) => `${p.control.key}=${p.option}`,
+      ),
+    ).toEqual(['a=opt1', 'b=opt1']);
+    // ≥2 pinned params → terminal.
+    expect(planInteractions([control('a', 4)], 2)).toEqual([]);
+    // Cap overflow fails loudly, listing the plan.
+    const many = Array.from({ length: 30 }, (_, i) => control(`c${i}`, 2));
+    expect(() => planInteractions(many, 0)).toThrow(/exceeding the single-sweep cap/);
+    expect(() =>
+      planInteractions(
+        Array.from({ length: 20 }, (_, i) => control(`c${i}`, 2)),
+        1,
+      ),
+    ).toThrow(/exceeding the pairwise cap/);
   });
 
   test('explore collapses to a single surface', () => {
@@ -365,8 +591,11 @@ test('crawl: BFS over every reachable Grafana surface with universal oracles + i
 }, testInfo) => {
   const stack = activeStack();
   const depth = sweepDepth();
-  // Budget: lean ≈ 10 pages × ~6s + 30s seed; full ≈ cap pages.
-  testInfo.setTimeout(depth === 'full' ? 30 * 60_000 : 8 * 60_000);
+  // Budget: lean ≈ 10 pages × ~6s + 30s seed + the representative
+  // interaction sweep over the 3 drilldown roots (~3 min); full ≈
+  // cap pages + the exhaustive interaction sweep (a fresh navigation
+  // per planned gesture).
+  testInfo.setTimeout(depth === 'full' ? 75 * 60_000 : 14 * 60_000);
   // eslint-disable-next-line no-console
   console.log(`crawl stack: ${stack.name} — ${describeSweepDepth(depth)}`);
 
@@ -456,11 +685,14 @@ test('crawl: BFS over every reachable Grafana surface with universal oracles + i
 
   const pageCap = depth === 'full' ? stack.pageCapFull : stack.pageCapLean;
   const visited = new Map<string, string>(); // canonical → concrete navigated
+  // In-place interaction states (`<canonical>#<control>=<value>`) →
+  // concrete URL the gesture ran against. Kept separate from
+  // `visited` because they are gestures on an already-counted page,
+  // not navigations — the page cap governs navigations.
+  const inPlaceVisited = new Map<string, string>();
   const failures: CrawlFailure[] = [];
 
-  let context: BrowserContext | null = null;
-  let page: Page | null = null;
-  let pagesInContext = 0;
+  const lease = makePageLease(browser);
 
   try {
     while (queue.length > 0) {
@@ -480,17 +712,10 @@ test('crawl: BFS over every reachable Grafana surface with universal oracles + i
         );
       }
 
-      if (page === null || pagesInContext >= CONTEXT_RECYCLE_PAGES) {
-        if (context !== null) await context.close();
-        context = await browser.newContext();
-        page = await context.newPage();
-        pagesInContext = 0;
-      }
-      pagesInContext++;
       visited.set(entry.canonical, entry.concrete);
 
       const { harvested, pageFailures } = await visitAndAudit(
-        page,
+        lease,
         baseURL,
         entry,
         declaredNoData,
@@ -524,18 +749,90 @@ test('crawl: BFS over every reachable Grafana surface with universal oracles + i
           }
         }
       }
+
+      // Interaction sweep — every clickable control that changes the
+      // surface's consumption mode (see interactions.ts). Depth
+      // doctrine: full sweeps every eligible surface exhaustively;
+      // lean sweeps the configured representative roots with the
+      // representative plan (one state per control). Eligibility is
+      // the pairwise bound: surfaces pinning ≥2 structural params are
+      // terminal (planInteractions returns an empty plan for them).
+      const isLeanRoot = stack.leanInteractionRoots.includes(entry.canonical);
+      if (depth === 'full' || isLeanRoot) {
+        const sweep = await sweepInteractions(
+          lease,
+          baseURL,
+          entry,
+          stack.scope,
+          depth !== 'full',
+          declaredNoData,
+          declaredErrorExprs,
+        );
+        failures.push(...sweep.failures);
+        for (const [stateKey, state] of sweep.inPlaceStates) {
+          inPlaceVisited.set(stateKey, state.concrete);
+          if (isLeanRoot && state.leanRepresentative) leanSet.add(stateKey);
+        }
+        for (const d of sweep.discovered) {
+          if (isLeanRoot && d.leanRepresentative) leanSet.add(d.canonical);
+          if (!visited.has(d.canonical)) {
+            queue.push({
+              canonical: d.canonical,
+              concrete: d.concrete,
+              via: d.via,
+            });
+          }
+        }
+      }
     }
   } finally {
-    if (context !== null) await context.close();
+    await lease.close();
   }
+
+  // The full audited state set: navigated surfaces plus the in-place
+  // interaction states (`<canonical>#<control>=<value>` notation) —
+  // both pin into the same inventory ratchet.
+  const auditedStates = new Map<string, string>([
+    ...visited,
+    ...inPlaceVisited,
+  ]);
 
   // eslint-disable-next-line no-console
   console.log(
-    `crawl: visited ${visited.size} surface(s) at depth=${depth} stack=${stack.name}:\n${[...visited.keys()]
+    `crawl: audited ${auditedStates.size} state(s) (${visited.size} navigated surface(s), ` +
+      `${inPlaceVisited.size} in-place interaction state(s)) at depth=${depth} stack=${stack.name}:\n${[...auditedStates.keys()]
       .sort()
       .map((u) => `  - ${u}`)
       .join('\n')}`,
   );
+
+  // -------------------------------------------------------------------------
+  // Surface-inventory ratchet. The regen WRITE happens before the
+  // oracle-failure throw: the inventory pins COVERAGE (which states
+  // the crawl audits) while the failures report HEALTH — a deliberate
+  // regen against a stack carrying known-red states (e.g. a found bug
+  // whose fix is in flight) must still capture the coverage, and the
+  // run still fails loudly on the failures right below.
+  // -------------------------------------------------------------------------
+  if (process.env.CERBERUS_UPDATE_INVENTORY) {
+    expect(
+      depth,
+      'inventory regeneration requires the exhaustive crawl: rerun with SWEEP_DEPTH=full',
+    ).toBe('full');
+    const inv: SurfaceInventory = {
+      doc: stack.inventoryDoc,
+      stack: stack.name,
+      surfaces: [...auditedStates.keys()].map((url) => ({
+        url,
+        lean: leanSet.has(url),
+      })),
+    };
+    writeFileSync(inventoryPath(stack), marshalInventory(inv));
+    // eslint-disable-next-line no-console
+    console.log(
+      `crawl: regenerated ${inventoryPath(stack)} with ${inv.surfaces.length} surface(s)`,
+    );
+  }
 
   if (failures.length > 0) {
     const detail = failures
@@ -546,29 +843,7 @@ test('crawl: BFS over every reachable Grafana surface with universal oracles + i
     );
   }
 
-  // -------------------------------------------------------------------------
-  // Surface-inventory ratchet.
-  // -------------------------------------------------------------------------
-  if (process.env.CERBERUS_UPDATE_INVENTORY) {
-    expect(
-      depth,
-      'inventory regeneration requires the exhaustive crawl: rerun with SWEEP_DEPTH=full',
-    ).toBe('full');
-    const inv: SurfaceInventory = {
-      doc: stack.inventoryDoc,
-      stack: stack.name,
-      surfaces: [...visited.keys()].map((url) => ({
-        url,
-        lean: leanSet.has(url),
-      })),
-    };
-    writeFileSync(inventoryPath(stack), marshalInventory(inv));
-    // eslint-disable-next-line no-console
-    console.log(
-      `crawl: regenerated ${inventoryPath(stack)} with ${inv.surfaces.length} surface(s)`,
-    );
-    return;
-  }
+  if (process.env.CERBERUS_UPDATE_INVENTORY) return;
 
   // Bootstrap guard before the diff: an EMPTY committed inventory
   // means the stack was registered but never crawled exhaustively —
@@ -577,7 +852,7 @@ test('crawl: BFS over every reachable Grafana surface with universal oracles + i
   const committed = loadInventory(stack);
   assertInventoryBootstrapped(committed, stack);
   const violations = diffInventory(
-    new Set(visited.keys()),
+    new Set(auditedStates.keys()),
     committed,
     loadExclusions(stack),
     depth,
@@ -593,40 +868,55 @@ test('crawl: BFS over every reachable Grafana surface with universal oracles + i
 // Per-page visit + oracles
 // ---------------------------------------------------------------------------
 
-async function visitAndAudit(
-  page: Page,
-  baseURL: string,
-  entry: QueueEntry,
+/**
+ * The declared-contract slice the oracles consume for one surface:
+ * which dashboard (if any) it renders, and that dashboard's declared
+ * no-data titles / error expressions.
+ */
+type OracleContracts = {
+  dashUid: string | undefined;
+  noDataDeclared: ReadonlySet<string>;
+  errExprsDeclared: ReadonlySet<string>;
+};
+
+function contractsFor(
+  canonical: string,
   declaredNoData: ReadonlyMap<string, Set<string>>,
   declaredErrorExprs: ReadonlyMap<string, Set<string>>,
-): Promise<{ harvested: string[]; pageFailures: CrawlFailure[] }> {
-  const pageFailures: CrawlFailure[] = [];
-  const fail = (rule: string, detail: string) =>
-    pageFailures.push({ url: entry.canonical, rule, detail });
-
-  // Which dashboard (if any) this surface renders — keys the declared
-  // cerberus.expect contracts.
-  const dashUid = /^\/d\/([^/?]+)/.exec(entry.canonical)?.[1];
-  const noDataDeclared = (dashUid && declaredNoData.get(dashUid)) || new Set();
-  const errExprsDeclared =
-    (dashUid && declaredErrorExprs.get(dashUid)) || new Set<string>();
-
-  const { messages: consoleErrors, stop: stopConsole } =
-    await captureConsoleErrors(page);
-
-  // Datasource API capture — same surface families every existing
-  // sweep watches. Deliberately NOT all of /api/: e.g. Grafana fires
-  // /api/datasources/uid/cerberus-tempo/health on page loads and its
-  // Tempo plugin has no backend CheckHealth, so that endpoint 404s
-  // with plugin.notImplemented by Grafana's own design (see the
-  // datasource-health probe comment in compose_grafana_smoke.spec.ts).
-  type CapturedDsResponse = {
-    url: string;
-    method: string;
-    status: number;
-    body: string;
-    requestBody: string;
+): OracleContracts {
+  const dashUid = /^\/d\/([^/?#]+)/.exec(canonical)?.[1];
+  return {
+    dashUid,
+    noDataDeclared: (dashUid && declaredNoData.get(dashUid)) || new Set(),
+    errExprsDeclared:
+      (dashUid && declaredErrorExprs.get(dashUid)) || new Set<string>(),
   };
+}
+
+type CapturedDsResponse = {
+  url: string;
+  method: string;
+  status: number;
+  body: string;
+  requestBody: string;
+};
+
+/**
+ * Wire the datasource-API response capture — the same surface
+ * families every existing sweep watches. Deliberately NOT all of
+ * /api/: e.g. Grafana fires /api/datasources/uid/cerberus-tempo/health
+ * on page loads and its Tempo plugin has no backend CheckHealth, so
+ * that endpoint 404s with plugin.notImplemented by Grafana's own
+ * design (see the datasource-health probe comment in
+ * compose_grafana_smoke.spec.ts).
+ *
+ * Returns the live capture array and an async stop that detaches the
+ * listener and settles every in-flight body read.
+ */
+function startWireCapture(
+  page: Page,
+  baseURL: string,
+): { captured: CapturedDsResponse[]; stop: () => Promise<void> } {
   const captured: CapturedDsResponse[] = [];
   const captureReads: Promise<void>[] = [];
   const onResponse = (resp: Response) => {
@@ -666,71 +956,27 @@ async function visitAndAudit(
     );
   };
   page.on('response', onResponse);
+  return {
+    captured,
+    stop: async () => {
+      page.off('response', onResponse);
+      await Promise.all(captureReads);
+    },
+  };
+}
 
-  let harvested: string[] = [];
-  try {
-    await page.goto(`${baseURL}${entry.concrete}`, {
-      waitUntil: 'domcontentloaded',
-      timeout: 90_000,
-    });
-    await tolerateRepaintFlicker(page, { settleMs: 600, timeoutMs: 45_000 });
+type FailFn = (rule: string, detail: string) => void;
 
-    harvested = await harvestLinks(page);
-
-    // Oracle 4a — VISIBLE role=alert banners with error-class text
-    // (Grafana pre-mounts hidden alert skeletons on some pages; see
-    // collectVisibleAlertBanners).
-    const banners = await collectVisibleAlertBanners(page);
-    for (const banner of banners) {
-      if (ALERT_ERROR_PATTERNS.some((re) => re.test(banner))) {
-        fail(
-          'role-alert-banner',
-          `role=alert banner with error text: ${truncate(banner, 400)}`,
-        );
-      }
-    }
-
-    // Oracle 4b — page-level crash signatures.
-    const bodyText = await page
-      .locator('body')
-      .innerText({ timeout: 10_000 })
-      .catch(() => '');
-    for (const re of PAGE_CRASH_PATTERNS) {
-      const m = re.exec(bodyText);
-      if (m) {
-        fail(
-          'page-crash-banner',
-          `page body carries crash signature ${re}: …${truncate(
-            bodyText.slice(Math.max(0, m.index - 80), m.index + 160),
-            300,
-          )}…`,
-        );
-      }
-    }
-
-    // Oracle 3 — panel tri-state. Every "No data" render must be
-    // covered by a declared 'empty' / 'error:*' contract.
-    const noDataPanels = await collectNoDataPanels(page);
-    for (const title of noDataPanels) {
-      if (noDataDeclared.has(title)) continue;
-      fail(
-        'panel-no-data-undeclared',
-        `panel ${JSON.stringify(title)} rendered "No data" with no cerberus.expect declaration ` +
-          `(dashboard=${dashUid ?? '<not a dashboard>'}, url=${entry.concrete}) — `
-          + `fix the bug at the source (cerberus code, seed, dashboard, or panel), or declare the contract on a showcase panel`,
-      );
-    }
-  } catch (err) {
-    fail(
-      'navigation-threw',
-      `goto(${entry.concrete}) threw: ${(err as Error).message}`,
-    );
-  } finally {
-    page.off('response', onResponse);
-    stopConsole();
-  }
-  await Promise.all(captureReads);
-
+/**
+ * Oracles 2a + 2b over a settled wire capture: non-2xx on the
+ * datasource API families, and tunneled per-target errors in 2xx
+ * ds/query bodies. Sanctioned only via declared-error contracts.
+ */
+function evaluateWireOracles(
+  captured: ReadonlyArray<CapturedDsResponse>,
+  contracts: OracleContracts,
+  fail: FailFn,
+): void {
   // Oracle 2a — non-2xx on the datasource API families. Sanctioned
   // only when every query in the failing ds/query request is a
   // declared-error panel target on this dashboard.
@@ -738,7 +984,7 @@ async function visitAndAudit(
     if (resp.status >= 200 && resp.status <= 299) continue;
     if (
       resp.url.includes('/api/ds/query') &&
-      requestFullyDeclaredError(resp.requestBody, errExprsDeclared)
+      requestFullyDeclaredError(resp.requestBody, contracts.errExprsDeclared)
     ) {
       continue;
     }
@@ -764,13 +1010,115 @@ async function visitAndAudit(
         continue;
       }
       const expr = refToExpr.get(refId) ?? '';
-      if (expr !== '' && errExprsDeclared.has(expr)) continue;
+      if (expr !== '' && contracts.errExprsDeclared.has(expr)) continue;
       fail(
         'ds-query-tunneled-error',
         `refId=${refId} url=${resp.url}\n  error: ${truncate(target.error, 600)}`,
       );
     }
   }
+}
+
+/**
+ * Oracles 3 + 4 over the page's current DOM: visible role=alert
+ * banners, page-level crash signatures, and the panel tri-state.
+ */
+async function evaluateDomOracles(
+  page: Page,
+  contracts: OracleContracts,
+  concrete: string,
+  fail: FailFn,
+): Promise<void> {
+  // Oracle 4a — VISIBLE role=alert banners with error-class text
+  // (Grafana pre-mounts hidden alert skeletons on some pages; see
+  // collectVisibleAlertBanners).
+  const banners = await collectVisibleAlertBanners(page);
+  for (const banner of banners) {
+    if (ALERT_ERROR_PATTERNS.some((re) => re.test(banner))) {
+      fail(
+        'role-alert-banner',
+        `role=alert banner with error text: ${truncate(banner, 400)}`,
+      );
+    }
+  }
+
+  // Oracle 4b — page-level crash signatures.
+  const bodyText = await page
+    .locator('body')
+    .innerText({ timeout: 10_000 })
+    .catch(() => '');
+  for (const re of PAGE_CRASH_PATTERNS) {
+    const m = re.exec(bodyText);
+    if (m) {
+      fail(
+        'page-crash-banner',
+        `page body carries crash signature ${re}: …${truncate(
+          bodyText.slice(Math.max(0, m.index - 80), m.index + 160),
+          300,
+        )}…`,
+      );
+    }
+  }
+
+  // Oracle 3 — panel tri-state. Every "No data" render must be
+  // covered by a declared 'empty' / 'error:*' contract.
+  const noDataPanels = await collectNoDataPanels(page);
+  for (const title of noDataPanels) {
+    if (contracts.noDataDeclared.has(title)) continue;
+    fail(
+      'panel-no-data-undeclared',
+      `panel ${JSON.stringify(title)} rendered "No data" with no cerberus.expect declaration ` +
+        `(dashboard=${contracts.dashUid ?? '<not a dashboard>'}, url=${concrete}) — `
+        + `fix the bug at the source (cerberus code, seed, dashboard, or panel), or declare the contract on a showcase panel`,
+    );
+  }
+}
+
+async function visitAndAudit(
+  lease: PageLease,
+  baseURL: string,
+  entry: QueueEntry,
+  declaredNoData: ReadonlyMap<string, Set<string>>,
+  declaredErrorExprs: ReadonlyMap<string, Set<string>>,
+): Promise<{ harvested: string[]; pageFailures: CrawlFailure[] }> {
+  const pageFailures: CrawlFailure[] = [];
+  const fail: FailFn = (rule, detail) =>
+    pageFailures.push({ url: entry.canonical, rule, detail });
+
+  // Declared cerberus.expect contracts this surface renders under.
+  const contracts = contractsFor(
+    entry.canonical,
+    declaredNoData,
+    declaredErrorExprs,
+  );
+
+  const page = await lease.acquire();
+  const { messages: consoleErrors, stop: stopConsole } =
+    await captureConsoleErrors(page);
+  const wire = startWireCapture(page, baseURL);
+
+  let harvested: string[] = [];
+  try {
+    lease.noteNavigation();
+    await page.goto(`${baseURL}${entry.concrete}`, {
+      waitUntil: 'domcontentloaded',
+      timeout: 90_000,
+    });
+    await tolerateRepaintFlicker(page, { settleMs: 600, timeoutMs: 45_000 });
+
+    harvested = await harvestLinks(page);
+
+    await evaluateDomOracles(page, contracts, entry.concrete, fail);
+  } catch (err) {
+    fail(
+      'navigation-threw',
+      `goto(${entry.concrete}) threw: ${(err as Error).message}`,
+    );
+  } finally {
+    stopConsole();
+  }
+  await wire.stop();
+  evaluateWireOracles(wire.captured, contracts, fail);
 
   // Oracle 1 — console errors. Zero, with no noise filter (see the
   // file header for the escalation path if a Grafana bump ever makes
@@ -785,6 +1133,171 @@ async function visitAndAudit(
   }
 
   return { harvested, pageFailures };
+}
+
+// ---------------------------------------------------------------------------
+// Interaction sweep — see interactions.ts for the discovery/planning
+// engine and docs/test-strategy.md for the bounding rules.
+// ---------------------------------------------------------------------------
+
+type InteractionSweepResult = {
+  /** URL-encoding deviations → first-class surfaces to enqueue. */
+  discovered: Array<QueueEntry & { leanRepresentative: boolean }>;
+  /**
+   * Non-URL deviations audited in place, keyed by the
+   * `<canonical>#<control>=<value>` state notation → concrete URL
+   * the gesture ran against, plus the lean-representative flag for
+   * the inventory's lean marking.
+   */
+  inPlaceStates: Map<string, { concrete: string; leanRepresentative: boolean }>;
+  failures: CrawlFailure[];
+};
+
+/**
+ * Sweep one visited surface's interactive controls.
+ *
+ * Every planned interaction runs against a FRESH navigation of the
+ * surface's concrete URL (deterministic provenance: state = surface
+ * default + exactly one control deviation; no gesture-order
+ * coupling). The capture window opens AFTER the page settles, so a
+ * boot-time failure stays attributed to the base surface (the base
+ * visit already audited it) and the interaction state only owns what
+ * the gesture caused.
+ *
+ * Post-gesture, the page URL decides the state's identity:
+ *   - canonicalizes to a DIFFERENT in-scope surface → the deviation
+ *     is URL-encoded; it is returned as a first-class surface and the
+ *     BFS visits it fresh with the full oracle set (captures from the
+ *     gesture itself are discarded — the fresh visit owns them).
+ *   - same canonical (or out of scope) → the deviation is in-page
+ *     state; the full oracle set evaluates right here and the state
+ *     pins into the inventory as `<canonical>#<control>=<value>`.
+ */
+async function sweepInteractions(
+  lease: PageLease,
+  baseURL: string,
+  entry: QueueEntry,
+  scope: ScopeRules,
+  representativeOnly: boolean,
+  declaredNoData: ReadonlyMap<string, Set<string>>,
+  declaredErrorExprs: ReadonlyMap<string, Set<string>>,
+): Promise<InteractionSweepResult> {
+  const failures: CrawlFailure[] = [];
+  const discovered: InteractionSweepResult['discovered'] = [];
+  const inPlaceStates: InteractionSweepResult['inPlaceStates'] = new Map();
+  const contracts = contractsFor(
+    entry.canonical,
+    declaredNoData,
+    declaredErrorExprs,
+  );
+
+  // Discovery pass on a fresh navigation (the base visit's link
+  // harvest left the mega menu open, which would occlude controls).
+  let plan: PlannedInteraction[];
+  try {
+    const page = await lease.acquire();
+    lease.noteNavigation();
+    await page.goto(`${baseURL}${entry.concrete}`, {
+      waitUntil: 'domcontentloaded',
+      timeout: 90_000,
+    });
+    await tolerateRepaintFlicker(page, { settleMs: 500, timeoutMs: 30_000 });
+    const controls = await discoverControls(page);
+    const fullPlan = planInteractions(
+      controls,
+      pinnedStructuralParamCount(entry.canonical),
+    );
+    plan = representativeOnly
+      ? fullPlan.filter((p) => p.leanRepresentative)
+      : fullPlan;
+  } catch (err) {
+    failures.push({
+      url: entry.canonical,
+      rule: 'interaction-discovery-failed',
+      detail: (err as Error).message,
+    });
+    return { discovered, inPlaceStates, failures };
+  }
+
+  for (const planned of plan) {
+    const stateName = `${planned.control.key}=${planned.stateValue}`;
+    const stateKey = interactionStateKey(
+      entry.canonical,
+      planned.control,
+      planned.stateValue,
+    );
+    const fail: FailFn = (rule, detail) =>
+      failures.push({ url: stateKey, rule, detail });
+
+    const page = await lease.acquire();
+    try {
+      lease.noteNavigation();
+      await page.goto(`${baseURL}${entry.concrete}`, {
+        waitUntil: 'domcontentloaded',
+        timeout: 90_000,
+      });
+      await tolerateRepaintFlicker(page, { settleMs: 500, timeoutMs: 30_000 });
+    } catch (err) {
+      fail('navigation-threw', `goto(${entry.concrete}) threw: ${(err as Error).message}`);
+      continue;
+    }
+
+    const { messages: consoleErrors, stop: stopConsole } =
+      await captureConsoleErrors(page);
+    const wire = startWireCapture(page, baseURL);
+    let drove = true;
+    try {
+      await driveInteraction(page, planned);
+    } catch (err) {
+      drove = false;
+      fail(
+        'interaction-drive-failed',
+        `driving ${planned.control.kind}:${stateName} threw: ${(err as Error).message}`,
+      );
+    }
+    if (drove) {
+      await tolerateRepaintFlicker(page, { settleMs: 500, timeoutMs: 20_000 });
+      // Close any select menu the gesture left open so the DOM
+      // oracles see the page, not the dropdown overlay.
+      await page.keyboard.press('Escape').catch(() => {});
+    }
+    stopConsole();
+    await wire.stop();
+    if (!drove) continue;
+
+    const post = canonicalTarget(page.url(), baseURL, scope);
+    if (post !== null && post.canonical !== entry.canonical) {
+      // URL-encoded deviation → first-class surface; the fresh BFS
+      // visit owns its oracles.
+      const postURL = new URL(page.url());
+      discovered.push({
+        canonical: post.canonical,
+        concrete: `${postURL.pathname}${postURL.search}`,
+        via: `${entry.canonical} (interaction ${stateName})`,
+        leanRepresentative: planned.leanRepresentative,
+      });
+      continue;
+    }
+
+    // In-place deviation → full oracle set, keyed by the state
+    // notation, pinned into the inventory.
+    evaluateWireOracles(wire.captured, contracts, fail);
+    await evaluateDomOracles(page, contracts, entry.concrete, fail);
+    if (consoleErrors.length > 0) {
+      fail(
+        'console-error',
+        `${consoleErrors.length} console error(s):\n${consoleErrors
+          .map((m) => `  - ${truncate(m, 400)}`)
+          .join('\n')}`,
+      );
+    }
+    inPlaceStates.set(stateKey, {
+      concrete: entry.concrete,
+      leanRepresentative: planned.leanRepresentative,
+    });
+  }
+
+  return { discovered, inPlaceStates, failures };
 }
 
 /**

--- a/test/e2e/playwright/crawl/grafana-surface-inventory.compose.json
+++ b/test/e2e/playwright/crawl/grafana-surface-inventory.compose.json
@@ -11,11 +11,643 @@
       "lean": true
     },
     {
+      "url": "/a/grafana-exploretraces-app/explore?actionView=comparison&var-groupBy=All",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?actionView=structure",
+      "lean": true
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?actionView=structure&var-groupBy=All&var-metric=duration",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?actionView=structure&var-groupBy=All&var-metric=errors",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?actionView=structure&var-groupBy=kind",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?actionView=structure&var-groupBy=name",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?actionView=structure&var-groupBy=resource.deployment.environment",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?actionView=structure&var-groupBy=resource.service.version",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?actionView=structure&var-groupBy=rootName",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?actionView=structure&var-groupBy=rootServiceName",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?actionView=structure&var-groupBy=span.http.status_code",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?actionView=structure&var-groupBy=status",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?actionView=structure&var-groupBy=statusMessage",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?actionView=structure&var-metric=duration",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?actionView=structure&var-metric=errors",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?actionView=structure&var-primarySignal=true",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?actionView=traceList",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?actionView=traceList&var-groupBy=All&var-metric=duration",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?actionView=traceList&var-groupBy=All&var-metric=errors",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?actionView=traceList&var-primarySignal=true",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?actionView=traceList#attribute-list=service.name",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?actionView=traceList#tabs[Favorites|All|Resource|Span]=All",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=kind",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=kind&var-primarySignal=true",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=kind#radio[Single|Grid|Rows]=Single",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=kind#tabs[Favorites|All|Resource|Span]=All",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=name",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=name&var-primarySignal=true",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=name#radio[Single|Grid|Rows]=Single",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=name#tabs[Favorites|All|Resource|Span]=All",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=resource.deployment.environment",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=resource.deployment.environment&var-primarySignal=true",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=resource.deployment.environment#radio[Single|Grid|Rows]=Single",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=resource.deployment.environment#tabs[Favorites|All|Resource|Span]=All",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=resource.service.version",
+      "lean": true
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=resource.service.version&var-metric=duration",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=resource.service.version&var-metric=errors",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=resource.service.version&var-primarySignal=true",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=resource.service.version#radio[Single|Grid|Rows]=Single",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=resource.service.version#tabs[Favorites|All|Resource|Span]=All",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=rootName",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=rootName&var-primarySignal=true",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=rootName#radio[Single|Grid|Rows]=Single",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=rootName#tabs[Favorites|All|Resource|Span]=All",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=rootServiceName",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=rootServiceName&var-primarySignal=true",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=rootServiceName#radio[Single|Grid|Rows]=Single",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=rootServiceName#tabs[Favorites|All|Resource|Span]=All",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=span.http.status_code",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=span.http.status_code&var-primarySignal=true",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=span.http.status_code#radio[Single|Grid|Rows]=Single",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=span.http.status_code#tabs[Favorites|All|Resource|Span]=All",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=status",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=status&var-primarySignal=true",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=status#radio[Single|Grid|Rows]=Single",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=status#tabs[Favorites|All|Resource|Span]=All",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=statusMessage",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=statusMessage&var-primarySignal=true",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=statusMessage#radio[Single|Grid|Rows]=Single",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=statusMessage#tabs[Favorites|All|Resource|Span]=All",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-metric=duration",
+      "lean": true
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-metric=duration&var-primarySignal=true",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-metric=duration#radio[Single|Grid|Rows]=Single",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-metric=duration#select[downshift-{rid}-input]=p50",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-metric=duration#tabs[Favorites|All|Resource|Span]=All",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-metric=errors",
+      "lean": true
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-metric=errors&var-primarySignal=true",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-metric=errors#radio[Single|Grid|Rows]=Single",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-metric=errors#tabs[Favorites|All|Resource|Span]=All",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-primarySignal=true",
+      "lean": true
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-primarySignal=true#radio[Single|Grid|Rows]=Single",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-primarySignal=true#tabs[Favorites|All|Resource|Span]=All",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore#radio[Single|Grid|Rows]=Rows",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore#radio[Single|Grid|Rows]=Single",
+      "lean": true
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore#tabs[Favorites|All|Resource|Span]=All",
+      "lean": true
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore#tabs[Favorites|All|Resource|Span]=Resource",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore#tabs[Favorites|All|Resource|Span]=Span",
+      "lean": false
+    },
+    {
       "url": "/a/grafana-lokiexplore-app/explore",
       "lean": true
     },
     {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/customer?visualizationType=\"json\"",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/customer?visualizationType=\"json\"#adhoc[Filter by labels]={rep}",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/customer?visualizationType=\"json\"#radio[Grid|Rows]=Rows",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/customer?visualizationType=\"json\"#select[downshift-{rid}-input]=Exclude",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/customer?visualizationType=\"json\"#select[Filter by fields]=thread",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/customer?visualizationType=\"json\"#select[SortBy direction]=Asc",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/customer?visualizationType=\"json\"#select[SortBy function]=Most relevantSmart ordering of graphs based on the most significant spikes in the data",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/customer?visualizationType=\"table\"",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/customer?visualizationType=\"table\"#adhoc[Filter by labels]={rep}",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/customer?visualizationType=\"table\"#radio[Grid|Rows]=Rows",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/customer?visualizationType=\"table\"#select[downshift-{rid}-input]=Exclude",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/customer?visualizationType=\"table\"#select[Filter by fields]=thread",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/customer?visualizationType=\"table\"#select[SortBy direction]=Asc",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/customer?visualizationType=\"table\"#select[SortBy function]=Most relevantSmart ordering of graphs based on the most significant spikes in the data",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/order_id",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/order_id?visualizationType=\"json\"",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/order_id?visualizationType=\"json\"#adhoc[Filter by labels]={rep}",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/order_id?visualizationType=\"json\"#radio[Grid|Rows]=Grid",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/order_id?visualizationType=\"json\"#select[downshift-{rid}-input]=Exclude",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/order_id?visualizationType=\"json\"#select[Filter by fields]=thread",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/order_id?visualizationType=\"json\"#select[SortBy direction]=Desc",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/order_id?visualizationType=\"json\"#select[SortBy function]=Most relevantSmart ordering of graphs based on the most significant spikes in the data",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/order_id?visualizationType=\"table\"",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/order_id?visualizationType=\"table\"#adhoc[Filter by labels]={rep}",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/order_id?visualizationType=\"table\"#radio[Grid|Rows]=Grid",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/order_id?visualizationType=\"table\"#select[downshift-{rid}-input]=Exclude",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/order_id?visualizationType=\"table\"#select[Filter by fields]=thread",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/order_id?visualizationType=\"table\"#select[SortBy direction]=Desc",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/order_id?visualizationType=\"table\"#select[SortBy function]=Most relevantSmart ordering of graphs based on the most significant spikes in the data",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/response_latency_ms",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/response_latency_ms?visualizationType=\"json\"",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/response_latency_ms?visualizationType=\"json\"#adhoc[Filter by labels]={rep}",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/response_latency_ms?visualizationType=\"json\"#radio[Grid|Rows]=Rows",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/response_latency_ms?visualizationType=\"json\"#select[downshift-{rid}-input]=Exclude",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/response_latency_ms?visualizationType=\"json\"#select[Filter by fields]=thread",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/response_latency_ms?visualizationType=\"json\"#select[SortBy direction]=Asc",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/response_latency_ms?visualizationType=\"json\"#select[SortBy function]=Most relevantSmart ordering of graphs based on the most significant spikes in the data",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/response_latency_ms?visualizationType=\"table\"",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/response_latency_ms?visualizationType=\"table\"#adhoc[Filter by labels]={rep}",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/response_latency_ms?visualizationType=\"table\"#radio[Grid|Rows]=Rows",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/response_latency_ms?visualizationType=\"table\"#select[downshift-{rid}-input]=Exclude",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/response_latency_ms?visualizationType=\"table\"#select[Filter by fields]=thread",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/response_latency_ms?visualizationType=\"table\"#select[SortBy direction]=Asc",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/response_latency_ms?visualizationType=\"table\"#select[SortBy function]=Most relevantSmart ordering of graphs based on the most significant spikes in the data",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/thread?visualizationType=\"json\"",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/thread?visualizationType=\"json\"#adhoc[Filter by labels]={rep}",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/thread?visualizationType=\"json\"#radio[Grid|Rows]=Grid",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/thread?visualizationType=\"json\"#select[downshift-{rid}-input]=Exclude",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/thread?visualizationType=\"json\"#select[Filter by fields]=thread",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/thread?visualizationType=\"json\"#select[SortBy direction]=Desc",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/thread?visualizationType=\"json\"#select[SortBy function]=Most relevantSmart ordering of graphs based on the most significant spikes in the data",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/thread?visualizationType=\"table\"",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/thread?visualizationType=\"table\"#adhoc[Filter by labels]={rep}",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/thread?visualizationType=\"table\"#radio[Grid|Rows]=Grid",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/thread?visualizationType=\"table\"#select[downshift-{rid}-input]=Exclude",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/thread?visualizationType=\"table\"#select[Filter by fields]=thread",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/thread?visualizationType=\"table\"#select[SortBy direction]=Desc",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/thread?visualizationType=\"table\"#select[SortBy function]=Most relevantSmart ordering of graphs based on the most significant spikes in the data",
+      "lean": false
+    },
+    {
       "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields?visualizationType=\"json\"",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields?visualizationType=\"json\"#adhoc[Filter by labels]={rep}",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields?visualizationType=\"json\"#radio[Grid|Rows]=Rows",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields?visualizationType=\"json\"#radio[Volume|Names]=Names",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields?visualizationType=\"json\"#select[downshift-{rid}-input]=Exclude",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields?visualizationType=\"json\"#select[Filter by fields]=thread",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields?visualizationType=\"table\"",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields?visualizationType=\"table\"#adhoc[Filter by labels]={rep}",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields?visualizationType=\"table\"#radio[Grid|Rows]=Rows",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields?visualizationType=\"table\"#radio[Volume|Names]=Names",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields?visualizationType=\"table\"#select[downshift-{rid}-input]=Exclude",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields?visualizationType=\"table\"#select[Filter by fields]=thread",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields#adhoc[Filter by labels]={rep}",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields#radio[Grid|Rows]=Grid",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields#radio[Volume|Names]=Names",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields#select[downshift-{rid}-input]=Exclude",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields#select[Filter by fields]=customer",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields#select[Filter by fields]=level",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields#select[Filter by fields]=message",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields#select[Filter by fields]=order_id",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields#select[Filter by fields]=response_latency_ms",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields#select[Filter by fields]=response_status",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields#select[Filter by fields]=thread",
       "lean": false
     },
     {
@@ -23,7 +655,143 @@
       "lean": false
     },
     {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/label/{label}?visualizationType=\"json\"",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/label/{label}?visualizationType=\"json\"#adhoc[Filter by labels]={rep}",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/label/{label}?visualizationType=\"json\"#radio[Grid|Rows]=Rows",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/label/{label}?visualizationType=\"json\"#select[downshift-{rid}-input]=Exclude",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/label/{label}?visualizationType=\"json\"#select[Filter by fields]=thread",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/label/{label}?visualizationType=\"json\"#select[SortBy direction]=Asc",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/label/{label}?visualizationType=\"json\"#select[SortBy function]=Most relevantSmart ordering of graphs based on the most significant spikes in the data",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/label/{label}?visualizationType=\"table\"",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/label/{label}?visualizationType=\"table\"#adhoc[Filter by labels]={rep}",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/label/{label}?visualizationType=\"table\"#radio[Grid|Rows]=Rows",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/label/{label}?visualizationType=\"table\"#select[downshift-{rid}-input]=Exclude",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/label/{label}?visualizationType=\"table\"#select[Filter by fields]=thread",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/label/{label}?visualizationType=\"table\"#select[SortBy direction]=Asc",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/label/{label}?visualizationType=\"table\"#select[SortBy function]=Most relevantSmart ordering of graphs based on the most significant spikes in the data",
+      "lean": false
+    },
+    {
       "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels?visualizationType=\"json\"",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels?visualizationType=\"json\"#adhoc[Filter by labels]={rep}",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels?visualizationType=\"json\"#radio[Grid|Rows]=Grid",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels?visualizationType=\"json\"#select[downshift-{rid}-input]=Exclude",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels?visualizationType=\"json\"#select[Filter by fields]=thread",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels?visualizationType=\"table\"",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels?visualizationType=\"table\"#adhoc[Filter by labels]={rep}",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels?visualizationType=\"table\"#radio[Grid|Rows]=Grid",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels?visualizationType=\"table\"#select[downshift-{rid}-input]=Exclude",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels?visualizationType=\"table\"#select[Filter by fields]=thread",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels#adhoc[Filter by labels]={rep}",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels#radio[Grid|Rows]=Rows",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels#select[downshift-{rid}-input]=Exclude",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels#select[Filter by fields]=customer",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels#select[Filter by fields]=level",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels#select[Filter by fields]=message",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels#select[Filter by fields]=order_id",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels#select[Filter by fields]=response_latency_ms",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels#select[Filter by fields]=response_status",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels#select[Filter by fields]=thread",
       "lean": false
     },
     {
@@ -31,11 +799,171 @@
       "lean": false
     },
     {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/logs?visualizationType=\"json\"",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/logs?visualizationType=\"json\"#adhoc[Filter by labels]={rep}",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/logs?visualizationType=\"json\"#select[All levels]=info",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/logs?visualizationType=\"json\"#select[downshift-{rid}-input]=Exclude",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/logs?visualizationType=\"json\"#select[Filter by fields]=thread",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/logs?visualizationType=\"table\"",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/logs?visualizationType=\"table\"#adhoc[Filter by labels]={rep}",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/logs?visualizationType=\"table\"#select[1000 logs]=100",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/logs?visualizationType=\"table\"#select[All levels]=info",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/logs?visualizationType=\"table\"#select[downshift-{rid}-input]=Exclude",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/logs?visualizationType=\"table\"#select[Filter by fields]=thread",
+      "lean": false
+    },
+    {
       "url": "/a/grafana-lokiexplore-app/explore/service/{service}/patterns",
       "lean": false
     },
     {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/patterns?visualizationType=\"json\"",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/patterns?visualizationType=\"json\"#adhoc[Filter by labels]={rep}",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/patterns?visualizationType=\"json\"#select[downshift-{rid}-input]=Exclude",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/patterns?visualizationType=\"json\"#select[Filter by fields]=thread",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/patterns?visualizationType=\"table\"",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/patterns?visualizationType=\"table\"#adhoc[Filter by labels]={rep}",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/patterns?visualizationType=\"table\"#select[downshift-{rid}-input]=Exclude",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/patterns?visualizationType=\"table\"#select[Filter by fields]=thread",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/patterns#adhoc[Filter by labels]={rep}",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/patterns#select[downshift-{rid}-input]=Exclude",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/patterns#select[Filter by fields]=customer",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/patterns#select[Filter by fields]=level",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/patterns#select[Filter by fields]=message",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/patterns#select[Filter by fields]=order_id",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/patterns#select[Filter by fields]=response_latency_ms",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/patterns#select[Filter by fields]=response_status",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/patterns#select[Filter by fields]=thread",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore#adhoc[Filter by labels]={rep}",
+      "lean": true
+    },
+    {
       "url": "/a/grafana-metricsdrilldown-app/drilldown",
+      "lean": true
+    },
+    {
+      "url": "/a/grafana-metricsdrilldown-app/drilldown?actionView=related&metric={metric}",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-metricsdrilldown-app/drilldown?metric={metric}",
+      "lean": true
+    },
+    {
+      "url": "/a/grafana-metricsdrilldown-app/drilldown?metric={metric}&var-groupby=cerberus_ql",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-metricsdrilldown-app/drilldown?metric={metric}#adhoc[+ label = value]={rep}",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-metricsdrilldown-app/drilldown?metric={metric}#radio[Grid|Rows]=Rows",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-metricsdrilldown-app/drilldown#adhoc[+ label = value]={rep}",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-metricsdrilldown-app/drilldown#radio[Grid|Rows]=Rows",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-metricsdrilldown-app/drilldown#select[datasource-picker]#1=Alerting Usage",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-metricsdrilldown-app/drilldown#select[datasource-picker]#1=Alphabetical [A-Z]",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-metricsdrilldown-app/drilldown#select[datasource-picker]#1=Alphabetical [Z-A]",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-metricsdrilldown-app/drilldown#select[datasource-picker]#1=Dashboard Usage",
       "lean": false
     },
     {
@@ -87,7 +1015,139 @@
       "lean": false
     },
     {
+      "url": "/dashboards/f/{folder}/alerting#select[Sort]=Alphabetically [A-Z]",
+      "lean": false
+    },
+    {
+      "url": "/dashboards/f/{folder}/alerting#select[Sort]=Alphabetically [Z-A]",
+      "lean": false
+    },
+    {
       "url": "/dashboards/f/{folder}/library-panels",
+      "lean": false
+    },
+    {
+      "url": "/dashboards/f/{folder}/library-panels#select[Panel type filter]={rep}",
+      "lean": false
+    },
+    {
+      "url": "/dashboards/f/{folder}/library-panels#select[Sort]=Alphabetically (A–Z)",
+      "lean": false
+    },
+    {
+      "url": "/dashboards/f/{folder}/library-panels#select[Sort]=Alphabetically (Z–A)",
+      "lean": false
+    },
+    {
+      "url": "/dashboards/f/{folder}#radio[folders|list]=list",
+      "lean": false
+    },
+    {
+      "url": "/dashboards/f/{folder}#select[Sort]=Alphabetically (A–Z)",
+      "lean": false
+    },
+    {
+      "url": "/dashboards/f/{folder}#select[Sort]=Alphabetically (Z–A)",
+      "lean": false
+    },
+    {
+      "url": "/dashboards/f/{folder}#select[Tag filter]=cerberus (7)",
+      "lean": false
+    },
+    {
+      "url": "/dashboards/f/{folder}#select[Tag filter]=clickhouse (1)",
+      "lean": false
+    },
+    {
+      "url": "/dashboards/f/{folder}#select[Tag filter]=dogfood (1)",
+      "lean": false
+    },
+    {
+      "url": "/dashboards/f/{folder}#select[Tag filter]=host (1)",
+      "lean": false
+    },
+    {
+      "url": "/dashboards/f/{folder}#select[Tag filter]=infra (3)",
+      "lean": false
+    },
+    {
+      "url": "/dashboards/f/{folder}#select[Tag filter]=logql (1)",
+      "lean": false
+    },
+    {
+      "url": "/dashboards/f/{folder}#select[Tag filter]=otelcol (1)",
+      "lean": false
+    },
+    {
+      "url": "/dashboards/f/{folder}#select[Tag filter]=promql (1)",
+      "lean": false
+    },
+    {
+      "url": "/dashboards/f/{folder}#select[Tag filter]=self-observability (1)",
+      "lean": false
+    },
+    {
+      "url": "/dashboards/f/{folder}#select[Tag filter]=showcase (3)",
+      "lean": false
+    },
+    {
+      "url": "/dashboards/f/{folder}#select[Tag filter]=traceql (1)",
+      "lean": false
+    },
+    {
+      "url": "/dashboards#radio[folders|list]=folders",
+      "lean": false
+    },
+    {
+      "url": "/dashboards#select[Sort]=Alphabetically (A–Z)",
+      "lean": false
+    },
+    {
+      "url": "/dashboards#select[Sort]=Alphabetically (Z–A)",
+      "lean": false
+    },
+    {
+      "url": "/dashboards#select[Tag filter]=cerberus (7)",
+      "lean": false
+    },
+    {
+      "url": "/dashboards#select[Tag filter]=clickhouse (1)",
+      "lean": false
+    },
+    {
+      "url": "/dashboards#select[Tag filter]=dogfood (1)",
+      "lean": false
+    },
+    {
+      "url": "/dashboards#select[Tag filter]=host (1)",
+      "lean": false
+    },
+    {
+      "url": "/dashboards#select[Tag filter]=infra (3)",
+      "lean": false
+    },
+    {
+      "url": "/dashboards#select[Tag filter]=logql (1)",
+      "lean": false
+    },
+    {
+      "url": "/dashboards#select[Tag filter]=otelcol (1)",
+      "lean": false
+    },
+    {
+      "url": "/dashboards#select[Tag filter]=promql (1)",
+      "lean": false
+    },
+    {
+      "url": "/dashboards#select[Tag filter]=self-observability (1)",
+      "lean": false
+    },
+    {
+      "url": "/dashboards#select[Tag filter]=showcase (3)",
+      "lean": false
+    },
+    {
+      "url": "/dashboards#select[Tag filter]=traceql (1)",
       "lean": false
     },
     {
@@ -97,6 +1157,26 @@
     {
       "url": "/explore",
       "lean": true
+    },
+    {
+      "url": "/explore#radio[Builder|Code]=Code",
+      "lean": false
+    },
+    {
+      "url": "/explore#select[Select label]={rep}",
+      "lean": false
+    },
+    {
+      "url": "/explore#select[Select match operator]=!=",
+      "lean": false
+    },
+    {
+      "url": "/explore#select[Select match operator]=!~",
+      "lean": false
+    },
+    {
+      "url": "/explore#select[Select match operator]==~",
+      "lean": false
     }
   ]
 }

--- a/test/e2e/playwright/crawl/interactions.ts
+++ b/test/e2e/playwright/crawl/interactions.ts
@@ -1,0 +1,858 @@
+/**
+ * Interaction sweep — the crawler's "everything clickable that
+ * changes the consumption mode" layer.
+ *
+ * The BFS crawl (crawl.spec.ts) visits every URL-harvested surface at
+ * its DEFAULT control state only. The 2026-06-10 maintainer find
+ * proved that insufficient: clicking the Traces Drilldown breakdown
+ * groupBy "kind" attribute — a state (`var-groupBy=kind`) no
+ * harvested link ever encodes — fired a TraceQL query
+ * (`{… && kind != nil} | rate() by(kind)`) cerberus 422'd, and the
+ * crawler never saw it. The gap class is INTERACTIVE CONTROLS that
+ * change which queries a page fires without being links: pulldowns,
+ * tab strips, radio toggles, attribute pickers, adhoc-filter
+ * builders, datasource pickers.
+ *
+ * This module owns:
+ *   1. CONTROL DISCOVERY — enumerate the view-affecting controls on a
+ *      visited page (tab strips, radio groups, comboboxes, titled
+ *      option lists, metric select tiles, adhoc-filter builders),
+ *      excluding anything mutating (save / delete / create / add-tab
+ *      / settings — the crawl's read-only doctrine) and anything
+ *      whose state another spec layer owns (time-range and refresh
+ *      pickers → iterate-time-ranges.spec.ts; panel kiosk menus →
+ *      iterate-panel-kiosk.spec.ts).
+ *   2. BOUNDED PLANNING — the locked pairwise design:
+ *        - structural low-cardinality controls (≤ STRUCTURAL_MAX_OPTIONS
+ *          options: groupBy attributes, actionView tabs, metric type,
+ *          layout) enumerate FULLY;
+ *        - high-cardinality controls (filter values, metric-name
+ *          tiles, tag filters) take ONE representative option;
+ *        - cross-control combos are PAIRWISE via surface chaining: a
+ *          deviation that encodes to the URL becomes a first-class
+ *          surface (see StructuralParamRule in lib.ts); sweeping a
+ *          surface that already pins ONE structural param uses the
+ *          representative plan (each interaction there forms a pair),
+ *          and surfaces pinning ≥2 params are terminal — visited
+ *          with the universal oracles, never expanded. Every
+ *          surface's plan is HARD-CAPPED (SINGLE_SWEEP_CAP at the
+ *          base, PAIRWISE_SWEEP_CAP=16 for combo-forming surfaces);
+ *          exceeding a cap FAILS the crawl listing every planned
+ *          interaction — never a silent truncation.
+ *   3. GESTURE DRIVING — perform one planned interaction on a freshly
+ *      navigated page (fresh navigation per interaction keeps every
+ *      state's provenance deterministic), returning the post-click
+ *      URL so the spec can either enqueue it as a discovered surface
+ *      (URL-encoding controls) or evaluate the universal oracles
+ *      in-place and record the state as `<canonical>#<control>=<value>`
+ *      in the inventory (non-URL controls).
+ *
+ * Selector conventions verified live against grafana/grafana:12.2.9
+ * (2026-06-11): tab strips are `[role="tablist"] [role="tab"]` with
+ * `data-testid Tab <name>` testids; radio groups are
+ * `[role="radiogroup"] input[type=radio]` with `label[for]` text or
+ * `option-<value>-radiogroup-N` ids; selects/comboboxes are
+ * `input[role="combobox"]` whose dropdown renders
+ * `[role="option"]` / `data-testid Select option` entries; the
+ * Traces Drilldown attribute picker is a bare `ul > li[title]` list;
+ * Metrics Drilldown metric tiles are `[data-testid^="select-action-"]`.
+ */
+
+import type { Locator, Page } from '@playwright/test';
+
+// ---------------------------------------------------------------------------
+// Bounds (the locked design)
+// ---------------------------------------------------------------------------
+
+/**
+ * A control with more options than this is HIGH-cardinality: its
+ * value set is data-derived (attribute values, metric names, tags),
+ * so it contributes one representative option instead of a full
+ * enumeration. 12 covers every structural control verified live
+ * (the largest, the Traces Drilldown favorites attribute list,
+ * carries 10) while excluding the data-derived lists (the "All"
+ * attributes scope renders 51).
+ */
+export const STRUCTURAL_MAX_OPTIONS = 12;
+
+/**
+ * Hard cap on a base surface's (0 pinned structural params)
+ * single-control enumeration. Generous — the busiest verified
+ * surface (Traces Drilldown entry) plans ~20 — but HARD: overflow
+ * fails the crawl listing the full plan, forcing a deliberate
+ * redesign instead of a silent partial sweep.
+ */
+export const SINGLE_SWEEP_CAP = 24;
+
+/**
+ * Hard cap on a combo-forming surface's (1 pinned structural param)
+ * representative plan — every interaction there pairs the pinned
+ * param with one other control, so this bounds the pairwise combos
+ * attributable to a surface at ≤16 per the locked design.
+ */
+export const PAIRWISE_SWEEP_CAP = 16;
+
+// ---------------------------------------------------------------------------
+// Control model
+// ---------------------------------------------------------------------------
+
+export type ControlKind =
+  | 'tab' // [role=tablist] strip — actionView tabs, attribute scopes
+  | 'radio' // [role=radiogroup] — layout, primary signal, metric type
+  | 'combobox' // select/combobox — sort-by, datasource, levels, limits
+  | 'option-list' // ul > li[title] picker — Traces Drilldown groupBy
+  | 'select-tile' // [data-testid^=select-action-] — metric tiles
+  | 'adhoc-filter'; // adhoc filter builder — key → representative value
+
+export type DiscoveredControl = {
+  kind: ControlKind;
+  /** Stable human-readable key — joins the in-place state notation. */
+  key: string;
+  /** Option labels in DOM order (comboboxes: probed open). */
+  options: string[];
+  /** Index of the currently-selected option, -1 when undeterminable. */
+  selectedIndex: number;
+  /**
+   * True for controls whose option set is data-derived by
+   * construction (metric tiles, adhoc-filter keys) — they take one
+   * representative regardless of how many options happen to render.
+   */
+  forcedHighCardinality: boolean;
+  /** Per-option locator hints (tab testids, radio input ids, li titles). */
+  optionHints: string[];
+  /** Locator hint addressing the control itself (combobox inputs). */
+  controlHint: string;
+};
+
+export type PlannedInteraction = {
+  control: DiscoveredControl;
+  /** Option label to drive. */
+  option: string;
+  /**
+   * Value used in the in-place state notation. High-cardinality
+   * representatives parameterize to `{rep}` so data-derived values
+   * (first tag, first metric name) can't flicker the inventory.
+   */
+  stateValue: string;
+  /**
+   * True for the first planned interaction of each control — the
+   * lean lane's representative subset (depth changes STATES, never
+   * RULES: lean drives one state per control, full drives them all).
+   */
+  leanRepresentative: boolean;
+};
+
+/**
+ * Mutating or out-of-scope affordances the discovery NEVER plans:
+ * write affordances (read-only doctrine), auth, and Grafana chrome
+ * whose states other spec layers own.
+ */
+export const EXCLUDED_CONTROL_PATTERNS: ReadonlyArray<RegExp> = [
+  /save|delete|remove|create|import|export|upload|share|snapshot|sign\s?out|settings/i,
+  /add label tab|add to filters|add panel|new (dashboard|folder|panel)/i,
+  /time ?picker|refresh ?picker|time ?zone/i, // iterate-time-ranges owns time state
+  /search/i, // free-text inputs filter client-side lists, not queries
+];
+
+export function isExcludedControlName(name: string): boolean {
+  return EXCLUDED_CONTROL_PATTERNS.some((re) => re.test(name));
+}
+
+// ---------------------------------------------------------------------------
+// Planning (pure — unit-pinnable)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the bounded interaction plan for one surface.
+ *
+ * `pinnedParams` is the surface's pinned-structural-param count (see
+ * lib.ts pinnedStructuralParamCount): 0 → full plan under
+ * SINGLE_SWEEP_CAP; 1 → representative plan (first option per
+ * control) under PAIRWISE_SWEEP_CAP; ≥2 → empty plan (terminal).
+ *
+ * Throws on cap overflow with the COMPLETE plan in the message —
+ * the deliberate-redesign escape, never silent truncation.
+ */
+export function planInteractions(
+  controls: ReadonlyArray<DiscoveredControl>,
+  pinnedParams: number,
+): PlannedInteraction[] {
+  if (pinnedParams >= 2) return [];
+  const representativeOnly = pinnedParams === 1;
+
+  const plan: PlannedInteraction[] = [];
+  for (const control of controls) {
+    const structural =
+      !control.forcedHighCardinality &&
+      control.options.length <= STRUCTURAL_MAX_OPTIONS;
+    let first = true;
+    for (let i = 0; i < control.options.length; i++) {
+      if (i === control.selectedIndex) continue;
+      const option = control.options[i]!;
+      plan.push({
+        control,
+        option,
+        stateValue: structural ? option : '{rep}',
+        leanRepresentative: first,
+      });
+      first = false;
+      // High-cardinality → exactly one representative option.
+      if (!structural) break;
+      // Representative plan → one option per control.
+      if (representativeOnly) break;
+    }
+  }
+
+  const cap = representativeOnly ? PAIRWISE_SWEEP_CAP : SINGLE_SWEEP_CAP;
+  if (plan.length > cap) {
+    const listing = plan
+      .map((p) => `${p.control.kind}:${p.control.key}=${p.option}`)
+      .join('\n  - ');
+    throw new Error(
+      `interaction sweep: surface plans ${plan.length} interaction(s), exceeding the ` +
+        `${representativeOnly ? 'pairwise' : 'single-sweep'} cap ${cap} — the bound forces a ` +
+        `deliberate redesign (tighten control discovery, reclassify a control, or raise the cap ` +
+        `in interactions.ts with review), never a silent truncation. Full plan:\n  - ${listing}`,
+    );
+  }
+  return plan;
+}
+
+/**
+ * In-place state notation: a control deviation that does NOT encode
+ * to the URL is recorded in the inventory as
+ * `<canonical>#<control-key>=<value>`.
+ */
+export function interactionStateKey(
+  canonical: string,
+  control: DiscoveredControl,
+  stateValue: string,
+): string {
+  return `${canonical}#${control.key}=${stateValue}`;
+}
+
+// ---------------------------------------------------------------------------
+// Discovery
+// ---------------------------------------------------------------------------
+
+/**
+ * In-page chrome the discovery never looks inside: navigation, the
+ * mega menu, modals, toasts, and the top app chrome (time picker
+ * lives there).
+ */
+const CHROME_ANCESTOR_SELECTOR = [
+  'nav',
+  'header',
+  '[role="dialog"]',
+  '[role="menu"]',
+  '[data-testid*="mega-menu"]',
+  '[aria-label="Toast container"]',
+].join(', ');
+
+type RawControl = {
+  kind: ControlKind;
+  key: string;
+  options: string[];
+  selectedIndex: number;
+  /** Locator recipe — see driveInteraction. */
+  locatorKind: 'tab' | 'radio-signature' | 'combobox' | 'li-title' | 'tile';
+  /** Per-option locator hints (testids, option names, li titles, …). */
+  optionHints: string[];
+  /** Hint addressing the control itself (combobox input). */
+  controlHint: string;
+  /**
+   * Comboboxes only: the VISIBLE current-value text (react-select
+   * renders it in a sibling div, not the input's value attribute) —
+   * lets the probe mark the selected option so plans don't waste a
+   * gesture re-selecting the default.
+   */
+  currentText?: string;
+};
+
+/**
+ * Enumerate the static (non-combobox) controls currently in the DOM.
+ * Pure DOM read — no gestures. Combobox option sets need an
+ * open-the-dropdown probe and are handled by discoverControls.
+ */
+async function discoverStaticControls(page: Page): Promise<RawControl[]> {
+  return await page.evaluate(
+    ({ chromeSelector }) => {
+      const out: Array<{
+        kind: string;
+        key: string;
+        options: string[];
+        selectedIndex: number;
+        locatorKind: string;
+        optionHints: string[];
+        controlHint: string;
+        currentText?: string;
+      }> = [];
+      const inChrome = (el: Element) => el.closest(chromeSelector) !== null;
+
+      // --- Tab strips -----------------------------------------------------
+      // Two stable testid schemes carry the tab identity:
+      //   - Grafana core: `data-testid Tab <name>`
+      //   - scenes apps (Logs Drilldown): `data-testid tab-<name>`
+      // The VISIBLE label is unusable as identity — it carries a live
+      // result count baked into the text ("Traces200", "Logs1K",
+      // "Fields6") that flickers the inventory and (by inflating the
+      // option set) breaches the plan cap. When neither testid is
+      // present the count is stripped off the trailing edge of the
+      // text as a last resort.
+      const tabName = (t: Element) => {
+        const testid = t.getAttribute('data-testid') ?? '';
+        const core = /^data-testid Tab (.+)$/.exec(testid);
+        if (core) return core[1]!;
+        const scenes = /^data-testid tab-(.+)$/.exec(testid);
+        if (scenes) return scenes[1]!;
+        // Strip a trailing live-count run ("Logs1K" → "Logs",
+        // "Traces200" → "Traces") from the bare text fallback.
+        return (t.textContent ?? '')
+          .trim()
+          .replace(/\d+(\.\d+)?[KMB]?$/, '')
+          .trim();
+      };
+      document.querySelectorAll('[role="tablist"]').forEach((tl) => {
+        if (inChrome(tl)) return;
+        const tabs = [...tl.querySelectorAll('[role="tab"]')];
+        if (tabs.length < 2) return;
+        // Navigation tab strips — every tab is an <a href> that swaps
+        // the URL path (Logs Drilldown's logs/labels/fields/patterns
+        // strip) — are already first-class BFS surfaces (harvested as
+        // links + expandSiblingTabs). Re-driving them as in-place
+        // controls would double-count them under a volatile key, so
+        // skip any strip whose tabs all carry an href.
+        const allNavLinks = tabs.every(
+          (t) =>
+            t.tagName === 'A' ||
+            t.closest('a[href]') !== null ||
+            t.getAttribute('href') !== null,
+        );
+        if (allNavLinks) return;
+        const names = tabs.map(tabName);
+        out.push({
+          kind: 'tab',
+          key: `tabs[${names.join('|')}]`,
+          options: names,
+          selectedIndex: tabs.findIndex(
+            (t) => t.getAttribute('aria-selected') === 'true',
+          ),
+          locatorKind: 'tab',
+          optionHints: tabs.map(
+            (t) => t.getAttribute('data-testid') ?? tabName(t),
+          ),
+          controlHint: '',
+        });
+      });
+
+      // --- Radio groups ---------------------------------------------------
+      // Grafana RadioButtonGroup: hidden inputs + label[for]. Option
+      // identity: label text, else the value embedded in the input id
+      // (`option-<value>-radiogroup-N` — the numeric group counter is
+      // MOUNT-ORDER dependent and useless as a locator across
+      // navigations; the driver re-finds the group by its option-name
+      // signature instead), else the input name (the Traces Drilldown
+      // metric selector renders three one-radio groups named
+      // metric-rate / metric-errors / metric-duration). KEEP optName
+      // IN LOCKSTEP with the copy in driveInteraction's radio case.
+      document.querySelectorAll('[role="radiogroup"]').forEach((rg) => {
+        if (inChrome(rg)) return;
+        const inputs = [...rg.querySelectorAll('input[type="radio"]')] as
+          HTMLInputElement[];
+        if (inputs.length === 0) return;
+        const optName = (i: HTMLInputElement) => {
+          const lbl = i.id
+            ? rg.querySelector(`label[for="${CSS.escape(i.id)}"]`)
+            : null;
+          const text = (lbl?.textContent ?? '').trim();
+          if (text !== '') return text;
+          const m = /^option-(.+)-radiogroup-\d+$/.exec(i.id);
+          if (m) return m[1]!;
+          return i.name || i.id;
+        };
+        const options = inputs.map(optName);
+        out.push({
+          kind: 'radio',
+          key: `radio[${options.join('|')}]`,
+          options,
+          selectedIndex: inputs.findIndex((i) => i.checked),
+          locatorKind: 'radio-signature',
+          optionHints: options,
+          controlHint: '',
+        });
+      });
+
+      // --- Titled option lists ---------------------------------------------
+      // The Traces Drilldown attribute picker: a bare ul whose li
+      // children carry title="<attribute>" (no roles, no testids).
+      // Selection is CSS-only; when exactly one li's class set
+      // differs from the rest it is the selected row — otherwise
+      // selectedIndex stays -1 and the current value's click lands
+      // as a harmless in-place no-op.
+      //
+      // Tempo TRACE-SCOPED intrinsics (rootName / rootServiceName /
+      // traceDuration / …) are offered by the Drilldown's groupBy
+      // picker but are STRUCTURALLY unanswerable on the per-span
+      // OTel-ClickHouse schema cerberus serves: `rate() by(rootName)`
+      // needs whole-trace values no span row materialises, so cerberus
+      // returns a deliberate, reference-pinned 422 (rejection-parity
+      // catalogue; test/rejection-parity). A `by(<trace-scoped>)`
+      // breakdown is therefore not a cerberus CONSUMPTION MODE — it is
+      // out of the backend's domain, the same structural-exclusion
+      // logic as the foreign `grafanacloud-*` datasource options. Drop
+      // them so the sweep doesn't mint a surface whose only possible
+      // render is the documented rejection banner. NOT a tolerance:
+      // the rejection itself is asserted by the rejection-parity gate.
+      const traceScopedIntrinsics = new Set([
+        'rootName',
+        'rootServiceName',
+        'rootTraceName',
+        'traceDuration',
+        'trace:rootName',
+        'trace:rootService',
+        'trace:duration',
+      ]);
+      document.querySelectorAll('ul').forEach((ul) => {
+        if (inChrome(ul)) return;
+        const items = [...ul.children];
+        // Identify a titled-list control on the RAW titles (every li
+        // must carry a title) so the structural shape check is
+        // unaffected by the intrinsic filter below.
+        const rawTitles = items.map((li) => li.getAttribute('title') ?? '');
+        const allTitled = rawTitles.every((t) => t !== '');
+        if (!allTitled || rawTitles.length < 2) return;
+        let selectedIndex = -1;
+        if (items.length >= 3) {
+          const classes = items.map((li) => li.className);
+          const counts = new Map<string, number>();
+          for (const c of classes) counts.set(c, (counts.get(c) ?? 0) + 1);
+          const unique = classes.filter((c) => counts.get(c) === 1);
+          if (unique.length === 1) {
+            selectedIndex = classes.indexOf(unique[0]!);
+          }
+        }
+        const selectedTitle =
+          selectedIndex >= 0 ? rawTitles[selectedIndex] : undefined;
+        // Drop the structurally-unanswerable trace-scoped intrinsics
+        // from the driveable option set (see the comment above).
+        const titles = rawTitles.filter((t) => !traceScopedIntrinsics.has(t));
+        if (titles.length < 2) return;
+        out.push({
+          kind: 'option-list',
+          key: 'attribute-list',
+          options: titles,
+          // Re-resolve the selected index against the filtered set so
+          // a representative plan never re-selects the current value.
+          selectedIndex:
+            selectedTitle !== undefined ? titles.indexOf(selectedTitle) : -1,
+          locatorKind: 'li-title',
+          optionHints: titles,
+          controlHint: '',
+        });
+      });
+
+      // --- Select tiles ------------------------------------------------------
+      // Metrics Drilldown per-metric Select actions. One control,
+      // high-cardinality by construction (one tile per metric name).
+      const tiles = [
+        ...document.querySelectorAll('[data-testid^="select-action-"]'),
+      ];
+      if (tiles.length > 0) {
+        const names = tiles.map((t) =>
+          (t.getAttribute('data-testid') ?? '').replace(
+            /^select-action-/,
+            '',
+          ),
+        );
+        out.push({
+          kind: 'select-tile',
+          key: 'select-tile',
+          options: names,
+          selectedIndex: -1,
+          locatorKind: 'tile',
+          optionHints: tiles.map((t) => t.getAttribute('data-testid') ?? ''),
+          controlHint: '',
+        });
+      }
+
+      // --- Comboboxes (identity only — options probed by the caller) -------
+      const comboboxes = [
+        ...document.querySelectorAll('input[role="combobox"]'),
+      ] as HTMLInputElement[];
+      for (const cb of comboboxes) {
+        if (inChrome(cb)) continue;
+        const testid = cb.getAttribute('data-testid') ?? '';
+        const aria = cb.getAttribute('aria-label') ?? '';
+        const placeholder = cb.getAttribute('placeholder') ?? '';
+        const isAdhoc =
+          cb.id.startsWith('var-adhoc') ||
+          /^\+ ?label/i.test(placeholder) ||
+          /filter by label/i.test(placeholder);
+        // When the input carries no testid of its own, the nearest
+        // ancestor data-testid is a far more STABLE identity than the
+        // placeholder/value text: Grafana's scenes variables wrap each
+        // picker in `<… data-testid="detected_level filter variable">`
+        // / `"<var> filter variable"`, whereas the placeholder mirrors
+        // the CURRENT selection (the line-limit picker's placeholder is
+        // literally "1000 logs", the level filter's "All levels") and
+        // flickers across navigations. Prefer the ancestor testid;
+        // strip the boilerplate so `… filter variable` → `<var>`.
+        const ancestorTestid =
+          testid === ''
+            ? (cb
+                .closest('[data-testid]')
+                ?.getAttribute('data-testid') ?? '')
+            : '';
+        const ancestorKey = ancestorTestid
+          .replace(/^data-testid /, '')
+          .replace(/ (filter )?variable$/, '')
+          .trim();
+        const rawKey =
+          testid
+            .replace(/^data-testid /, '')
+            .replace(/-input$/, '')
+            // The datasource-variable testid embeds the CURRENT value
+            // ("…value link text cerberus-tempo"); normalize to the
+            // control family so the key survives a selection change.
+            .replace(
+              /^Dashboard template variables Variable Value DropDown value link text .*$/,
+              'datasource-picker',
+            ) ||
+          aria ||
+          // Only fall through to the bare placeholder when there is no
+          // usable ancestor identity (`input-wrapper` and `template
+          // variable` are non-distinguishing boilerplate).
+          (ancestorKey !== '' &&
+          ancestorKey !== 'input-wrapper' &&
+          ancestorKey !== 'template'
+            ? ancestorKey
+            : '') ||
+          placeholder ||
+          cb.id;
+        // Two render-order / selection-dependent token classes must
+        // never reach an inventory key:
+        //   - React useId tokens (`:rNN:` / React 19's `«rNN»`) —
+        //     downshift inputs fall back to them for element ids;
+        //   - count-bearing placeholders (`1000 logs`, `500 logs`) —
+        //     the line-limit picker's placeholder mirrors the current
+        //     selection, so it flickers per surface.
+        // Normalize both to fixed tokens; assignUniqueKeys' DOM-order
+        // `#n` suffix keeps same-page twins distinct.
+        const key = rawKey
+          .replace(/(:r[0-9a-z]+:|«r[0-9a-z]+»)/g, '{rid}')
+          .replace(/^\d+ (logs|lines|rows)$/, '{n} $1');
+        if (key === '') continue;
+        // The visible current value: react-select renders it in a
+        // sibling/ancestor div, not the input. Walk up a few levels
+        // and take the first short non-empty text.
+        let currentText = cb.value.trim();
+        let ancestor: Element | null = cb.parentElement;
+        for (let depth = 0; currentText === '' && ancestor && depth < 3; depth++) {
+          const text = (ancestor.textContent ?? '').trim();
+          if (text !== '' && text.length <= 60) currentText = text;
+          ancestor = ancestor.parentElement;
+        }
+        out.push({
+          kind: isAdhoc ? 'adhoc-filter' : 'combobox',
+          key: `${isAdhoc ? 'adhoc' : 'select'}[${key}]`,
+          options: [],
+          selectedIndex: -1,
+          locatorKind: 'combobox',
+          optionHints: [],
+          controlHint: testid !== '' ? `testid=${testid}` : `id=${cb.id}`,
+          currentText,
+        });
+      }
+
+      return out;
+    },
+    { chromeSelector: CHROME_ANCESTOR_SELECTOR },
+  ) as RawControl[];
+}
+
+/**
+ * Disambiguate key collisions with a deterministic DOM-order suffix
+ * (`#1`, `#2`, …) instead of dropping rows: several scenes apps
+ * render multiple variable pickers under one testid family
+ * (datasource + sort-by + wingman on the metrics-drilldown entry),
+ * and dropping all but the first would silently hide real controls.
+ * Runs over the FULL raw list (excluded / unprobeable controls
+ * consume slots too) so a key is a pure function of the page's DOM
+ * order — drive-time re-resolution (relocateCombobox) re-derives the
+ * same keys on a fresh navigation.
+ */
+function assignUniqueKeys(raw: RawControl[]): RawControl[] {
+  const counts = new Map<string, number>();
+  for (const c of raw) {
+    const n = counts.get(c.key) ?? 0;
+    counts.set(c.key, n + 1);
+    if (n > 0) c.key = `${c.key}#${n}`;
+  }
+  return raw;
+}
+
+/** Locate a combobox input from its discovery hint. */
+function locateCombobox(page: Page, hint: string): Locator {
+  if (hint.startsWith('testid=')) {
+    return page
+      .locator(`input[data-testid="${hint.slice('testid='.length)}"]`)
+      .first();
+  }
+  return page.locator(`input[id="${hint.slice('id='.length)}"]`).first();
+}
+
+/** The options currently rendered in an open select/combobox menu. */
+function openMenuOptions(page: Page): Locator {
+  return page.locator(
+    '[data-testid="data-testid Select option"], [role="listbox"] [role="option"]',
+  );
+}
+
+const PROBE_OPEN_MS = 900;
+const PROBE_CLOSE_MS = 300;
+
+/**
+ * Discover every view-affecting control on the current page.
+ * Comboboxes are PROBED — opened, options read, closed via Escape —
+ * so the planner knows their cardinality up front; probing performs
+ * no selection. Controls whose name matches the exclusion patterns,
+ * comboboxes that render no options (free-text inputs), and
+ * single-tab strips are dropped here.
+ */
+export async function discoverControls(
+  page: Page,
+): Promise<DiscoveredControl[]> {
+  const raw = assignUniqueKeys(await discoverStaticControls(page));
+  const out: DiscoveredControl[] = [];
+
+  for (const c of raw) {
+    if (isExcludedControlName(c.key)) continue;
+    if (c.locatorKind === 'combobox') {
+      const input = locateCombobox(page, c.controlHint);
+      if ((await input.count()) === 0) continue;
+      try {
+        // The visible current value (captured by the static pass —
+        // react-select keeps the input itself empty).
+        const currentValue = (c.currentText ?? '').trim();
+        await input.click({ timeout: 3_000 });
+        await page.waitForTimeout(PROBE_OPEN_MS);
+        let options = (await openMenuOptions(page).allTextContents())
+          .map((t) => t.trim())
+          .filter((t) => t !== '');
+        await page.keyboard.press('Escape');
+        await page.waitForTimeout(PROBE_CLOSE_MS);
+        if (options.length === 0) continue; // free-text input, not a select
+        // The datasource picker lists EVERY provisioned datasource,
+        // including Grafana's built-in `grafanacloud-*` cloud stubs
+        // (present in the DS list, backed by no real backend in the
+        // crawl stack). Driving the picker to one of those navigates
+        // OUT of the cerberus consumption domain and 404s the proxy —
+        // not a cerberus defect, just a control option that points
+        // away from cerberus. The crawl audits cerberus surfaces only,
+        // so keep the picker swept but restrict it to cerberus-backed
+        // options. Not a tolerance: a foreign-DS render is genuinely
+        // out of scope, the same doctrine as the connections/datasource
+        // path exclusion.
+        if (/datasource-picker/.test(c.key)) {
+          options = options.filter((o) => /cerberus/i.test(o));
+          if (options.length === 0) continue;
+        }
+        out.push({
+          kind: c.kind,
+          key: c.key,
+          options,
+          selectedIndex: options.findIndex((o) => o === currentValue),
+          // Adhoc-filter key lists are data-derived (label names)
+          // whatever their size — force the one-representative path.
+          forcedHighCardinality: c.kind === 'adhoc-filter',
+          optionHints: options,
+          controlHint: c.controlHint,
+        });
+      } catch {
+        // A combobox that can't open (covered by an overlay, detached
+        // mid-probe) contributes no states; the surface's other
+        // controls still sweep. Not a tolerance: if the control
+        // matters it encodes elsewhere (URL param / radio twin) or a
+        // future selector fix re-discovers it.
+        await page.keyboard.press('Escape').catch(() => {});
+      }
+      continue;
+    }
+    out.push({
+      kind: c.kind,
+      key: c.key,
+      options: c.options,
+      selectedIndex: c.selectedIndex,
+      forcedHighCardinality: c.kind === 'select-tile',
+      optionHints: c.optionHints,
+      controlHint: c.controlHint,
+    });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Driving
+// ---------------------------------------------------------------------------
+
+/**
+ * Re-find a combobox on the freshly navigated page by its discovery
+ * KEY, not its discovery-time element hint: downshift inputs are
+ * addressed by React useId-derived ids that need not survive a
+ * remount, and the datasource-variable testid embeds the currently
+ * selected value. Re-running the static pass re-derives the same
+ * deterministic keys (assignUniqueKeys), so the match is exact —
+ * absence is selector drift and must fail the crawl loudly.
+ */
+async function relocateCombobox(
+  page: Page,
+  control: DiscoveredControl,
+): Promise<Locator> {
+  const raw = assignUniqueKeys(await discoverStaticControls(page));
+  const match = raw.find(
+    (c) => c.locatorKind === 'combobox' && c.key === control.key,
+  );
+  if (match !== undefined) {
+    return locateCombobox(page, match.controlHint);
+  }
+  // Re-discovery didn't re-derive the key — but a combobox addressed
+  // by a STABLE element hint (its own data-testid, not a render-order
+  // id) survives a remount, so fall back to the discovery-time hint
+  // when it's testid-based and still present. This covers controls on
+  // dynamic surfaces (e.g. native /explore, whose visible control set
+  // depends on the booted datasource) without masking a real drift:
+  // an id-based hint or an absent locator still throws.
+  if (control.controlHint.startsWith('testid=')) {
+    const fallback = locateCombobox(page, control.controlHint);
+    if ((await fallback.count()) > 0) return fallback;
+  }
+  throw new Error(
+    `combobox ${control.key} not re-found by key (or stable hint) after fresh navigation`,
+  );
+}
+
+/**
+ * Perform one planned interaction on the (already navigated, settled)
+ * page. Throws when the control or option can't be addressed — a
+ * selector drift on a Grafana bump must fail the crawl loudly, never
+ * silently shrink the interaction surface.
+ */
+export async function driveInteraction(
+  page: Page,
+  planned: PlannedInteraction,
+): Promise<void> {
+  const { control, option } = planned;
+  const idx = control.options.indexOf(option);
+  const hint = control.optionHints[idx] ?? option;
+
+  switch (control.kind) {
+    case 'tab': {
+      // Prefer the stable testid; fall back to role+name for tabs
+      // without one. Exact-match on the testid avoids the live-count
+      // suffix problem ("Traces200").
+      const byTestid = page.locator(
+        `[role="tab"][data-testid="${hint}"]`,
+      );
+      const target =
+        (await byTestid.count()) > 0
+          ? byTestid.first()
+          : page.getByRole('tab', { name: option }).first();
+      await target.click({ timeout: 5_000 });
+      return;
+    }
+    case 'radio': {
+      // RadioButtonGroup input ids embed a mount-order counter
+      // (`option-<value>-radiogroup-13`), so ids captured at
+      // discovery don't survive the fresh navigation, and the input
+      // visually overlays its label (pointer interception). Re-find
+      // the group by its option-name SIGNATURE and fire a JS click on
+      // the target input — that triggers the React onChange and
+      // bypasses the overlay. The occurrence index (the `#n` key
+      // suffix) disambiguates identical signatures.
+      const occurrence = Number(/#(\d+)$/.exec(control.key)?.[1] ?? '0');
+      const clicked = await page.evaluate(
+        ({ options, optionIndex, occurrenceIndex }) => {
+          // KEEP IN LOCKSTEP with discoverStaticControls' optName.
+          const optName = (rg: Element, i: HTMLInputElement) => {
+            const lbl = i.id
+              ? rg.querySelector(`label[for="${CSS.escape(i.id)}"]`)
+              : null;
+            const text = (lbl?.textContent ?? '').trim();
+            if (text !== '') return text;
+            const m = /^option-(.+)-radiogroup-\d+$/.exec(i.id);
+            if (m) return m[1]!;
+            return i.name || i.id;
+          };
+          let seen = 0;
+          for (const rg of document.querySelectorAll('[role="radiogroup"]')) {
+            const inputs = [
+              ...rg.querySelectorAll('input[type="radio"]'),
+            ] as HTMLInputElement[];
+            if (inputs.length !== options.length) continue;
+            if (inputs.map((i) => optName(rg, i)).join('|') !== options.join('|')) {
+              continue;
+            }
+            if (seen++ < occurrenceIndex) continue;
+            inputs[optionIndex]!.click();
+            return true;
+          }
+          return false;
+        },
+        {
+          options: control.options,
+          optionIndex: idx,
+          occurrenceIndex: occurrence,
+        },
+      );
+      if (!clicked) {
+        throw new Error(
+          `radio group ${control.key} not re-found by signature after fresh navigation`,
+        );
+      }
+      return;
+    }
+    case 'option-list': {
+      // Click the li's label area (top-left quadrant) — the row also
+      // hosts a favorite-toggle button at its right edge.
+      await page
+        .locator(`ul > li[title="${hint}"]`)
+        .first()
+        .click({ timeout: 5_000, position: { x: 12, y: 12 } });
+      return;
+    }
+    case 'select-tile': {
+      await page
+        .locator(`[data-testid="${hint}"]`)
+        .first()
+        .click({ timeout: 5_000 });
+      return;
+    }
+    case 'combobox': {
+      const input = await relocateCombobox(page, control);
+      await input.click({ timeout: 5_000 });
+      await page.waitForTimeout(PROBE_OPEN_MS);
+      await openMenuOptions(page)
+        .filter({ hasText: option })
+        .first()
+        .click({ timeout: 5_000 });
+      return;
+    }
+    case 'adhoc-filter': {
+      const input = await relocateCombobox(page, control);
+      await input.click({ timeout: 5_000 });
+      await page.waitForTimeout(PROBE_OPEN_MS);
+      // Step 1: pick the representative KEY (first option).
+      await openMenuOptions(page).first().click({ timeout: 5_000 });
+      await page.waitForTimeout(PROBE_OPEN_MS);
+      // Step 2: the value dropdown auto-opens (scenes adhoc flow);
+      // pick the first value. Some builders interpose an operator
+      // step that defaults to '=' — the first option click covers
+      // both shapes.
+      const valueOptions = openMenuOptions(page);
+      if ((await valueOptions.count()) > 0) {
+        await valueOptions.first().click({ timeout: 5_000 });
+      }
+      return;
+    }
+  }
+}

--- a/test/e2e/playwright/crawl/lib.ts
+++ b/test/e2e/playwright/crawl/lib.ts
@@ -43,13 +43,130 @@ import type { CrawlStackConfig } from './stacks.js';
 
 /**
  * The scope slice of a stack config the canonicalizer consumes:
- * which route families are out of crawl scope, and which bare
- * app paths alias to an entry route.
+ * which route families are out of crawl scope, which bare app paths
+ * alias to an entry route, and which query params are STRUCTURAL —
+ * i.e. encode a consumption mode rather than session state.
  */
 export type ScopeRules = {
   excludedPathPatterns: ReadonlyArray<RegExp>;
   appBarePathAliases: ReadonlyMap<string, string>;
+  structuralParamRules: ReadonlyArray<StructuralParamRule>;
 };
+
+/**
+ * A query param that is part of a surface's IDENTITY rather than its
+ * session state. The default canonicalization doctrine strips every
+ * query param ("a state of a surface is not a new surface") — but the
+ * 2026-06-10 maintainer find proved the doctrine over-broad for a
+ * narrow param class: the Traces Drilldown breakdown `var-groupBy`
+ * param selects WHICH query family the page fires (`| rate()
+ * by(kind)` vs `by(resource.service.name)`), and the groupBy=kind
+ * state 422'd while the crawler — which only ever saw the default —
+ * stayed green. Params that change the queries a page issues are
+ * distinct consumption modes, hence distinct surfaces.
+ *
+ * Two retention modes mirror the path rules:
+ *   - 'enumerate' — low-cardinality structural params (actionView
+ *     tabs, groupBy attribute, metric type): every value keys its own
+ *     surface. `defaultValue` names the value the app writes on a
+ *     cold boot; it is DROPPED from the canonical so the default
+ *     state stays keyed by the bare surface (the app rewriting its
+ *     defaults into the URL must not re-key the surface).
+ *   - 'parameterize' — high-cardinality structural params (the
+ *     metrics-drilldown `metric` name): the value collapses to
+ *     `{param}`, one representative surface family — the same
+ *     doctrine as the `{service}` path segment.
+ */
+export type StructuralParamRule = {
+  /** Canonical-path family the rule applies to (post path-rewrite). */
+  pathPattern: RegExp;
+  /** Exact query param name. */
+  param: string;
+  mode: 'enumerate' | 'parameterize';
+  /** 'enumerate' only: the app's cold-boot value, dropped from keys. */
+  defaultValue?: string;
+};
+
+/**
+ * Grafana-12.x structural params, verified live against
+ * grafana/grafana:12.2.9 (2026-06-11) by driving each control and
+ * reading the URL the app wrote:
+ *
+ *   - Traces Drilldown (`grafana-exploretraces-app`): `actionView`
+ *     (Breakdown | Service structure | Comparison | Traces tabs,
+ *     boot value `breakdown`), `var-metric` (rate | errors |
+ *     duration, boot `rate`), `var-groupBy` (the breakdown attribute,
+ *     boot `resource.service.name` — `kind` is the maintainer-found
+ *     422), `var-primarySignal` (Root spans | All spans, boot
+ *     `nestedSetParent<0`).
+ *   - Metrics Drilldown (`grafana-metricsdrilldown-app`): `metric`
+ *     (the selected metric NAME — one per series family in the
+ *     stack, high-cardinality → parameterize), `actionView`
+ *     (breakdown | related, written as `breakdown` on metric select),
+ *     `var-groupby` (boot `$__all`).
+ *   - Logs Drilldown service pages (`grafana-lokiexplore-app`):
+ *     `visualizationType` (logs | table | json — JSON-string-quoted
+ *     in the URL, boot `"logs"`), `sortOrder` (boot `"Descending"`).
+ *
+ * Time params (`from`/`to`), filters (`var-filters`), display state
+ * (`displayedFields`, `urlColumns`, `patterns`, …) stay stripped —
+ * they are session state, owned by the iterate-* sweeps.
+ */
+export const STRUCTURAL_PARAM_RULES: ReadonlyArray<StructuralParamRule> = [
+  {
+    pathPattern: /^\/a\/grafana-exploretraces-app\/explore$/,
+    param: 'actionView',
+    mode: 'enumerate',
+    defaultValue: 'breakdown',
+  },
+  {
+    pathPattern: /^\/a\/grafana-exploretraces-app\/explore$/,
+    param: 'var-metric',
+    mode: 'enumerate',
+    defaultValue: 'rate',
+  },
+  {
+    pathPattern: /^\/a\/grafana-exploretraces-app\/explore$/,
+    param: 'var-groupBy',
+    mode: 'enumerate',
+    defaultValue: 'resource.service.name',
+  },
+  {
+    pathPattern: /^\/a\/grafana-exploretraces-app\/explore$/,
+    param: 'var-primarySignal',
+    mode: 'enumerate',
+    defaultValue: 'nestedSetParent<0',
+  },
+  {
+    pathPattern: /^\/a\/grafana-metricsdrilldown-app\/(drilldown|trail)$/,
+    param: 'metric',
+    mode: 'parameterize',
+  },
+  {
+    pathPattern: /^\/a\/grafana-metricsdrilldown-app\/(drilldown|trail)$/,
+    param: 'actionView',
+    mode: 'enumerate',
+    defaultValue: 'breakdown',
+  },
+  {
+    pathPattern: /^\/a\/grafana-metricsdrilldown-app\/(drilldown|trail)$/,
+    param: 'var-groupby',
+    mode: 'enumerate',
+    defaultValue: '$__all',
+  },
+  {
+    pathPattern: /^\/a\/grafana-lokiexplore-app\/explore\/service\/\{service\}\//,
+    param: 'visualizationType',
+    mode: 'enumerate',
+    defaultValue: '"logs"',
+  },
+  {
+    pathPattern: /^\/a\/grafana-lokiexplore-app\/explore\/service\/\{service\}\//,
+    param: 'sortOrder',
+    mode: 'enumerate',
+    defaultValue: '"Descending"',
+  },
+];
 
 // ---------------------------------------------------------------------------
 // Scope exclusions
@@ -148,16 +265,22 @@ const UUID_SEGMENT =
  * of crawl scope (different origin, excluded route family, non-HTTP
  * scheme).
  *
- * The canonical key is PATH-ONLY: every query param is stripped.
- * Grafana routes surfaces by path; query strings carry volatile or
- * session state — time windows (`from`/`to`/`refresh`), org context,
+ * The canonical key is the rewritten path plus the surface's
+ * STRUCTURAL params only (see StructuralParamRule). Grafana routes
+ * surfaces by path; query strings mostly carry volatile or session
+ * state — time windows (`from`/`to`/`refresh`), org context,
  * kiosk / view-panel modes, Explore state blobs (`panes`/`left`/
- * `right`), variable selections (`var-*`), and the drilldown apps'
- * serialized UI state (`patterns`, `displayedFields`, `urlColumns`,
- * `layout`, …). The first full crawl demonstrated why an
- * param-retention list can't work: the logs-drilldown service page
- * alone produced four param-permutations of one surface. A state of
- * a surface is not a new surface.
+ * `right`), filter selections, and the drilldown apps' serialized UI
+ * state (`patterns`, `displayedFields`, `urlColumns`, `layout`, …).
+ * The first full crawl demonstrated why a broad param-retention list
+ * can't work: the logs-drilldown service page alone produced four
+ * param-permutations of one surface. A state of a surface is not a
+ * new surface — UNLESS the param changes which queries the page
+ * fires: those params (the structural rules) join the canonical key,
+ * either verbatim (`actionView=comparison`, low-cardinality) or
+ * parameterized (`metric={metric}`, high-cardinality), with the
+ * app's cold-boot default dropped so the default state keys the bare
+ * surface.
  *
  * Path rules, in order:
  *   1. Same-origin only; hash dropped.
@@ -263,12 +386,45 @@ export function canonicalTarget(
     if (re.test(path)) return null;
   }
 
+  // Structural params join the canonical key (sorted by param name
+  // so the key is order-independent of the app's URL writing). Every
+  // other param is stripped from the canonical only.
+  const retained: string[] = [];
+  for (const rule of scope.structuralParamRules) {
+    if (!rule.pathPattern.test(path)) continue;
+    const value = url.searchParams.get(rule.param);
+    if (value === null || value === '') continue;
+    if (rule.mode === 'enumerate') {
+      if (value === rule.defaultValue) continue;
+      retained.push(`${rule.param}=${value}`);
+    } else {
+      retained.push(`${rule.param}={${rule.param}}`);
+    }
+  }
+  retained.sort();
+  const canonical =
+    retained.length > 0 ? `${path}?${retained.join('&')}` : path;
+
   // Concrete: the raw path + raw query (parameterized canonicals
   // aren't navigable, and drilldown-app hrefs carry var-* state the
   // page needs to boot into the linked view — navigating the
   // logs-drilldown service page without its var-filters leaves the
-  // tab bar unmounted). Only the CANONICAL key strips the query.
-  return { canonical: path, concrete: `${url.pathname}${url.search}` };
+  // tab bar unmounted). Only the CANONICAL key reduces the query.
+  return { canonical, concrete: `${url.pathname}${url.search}` };
+}
+
+/**
+ * Number of structural params pinned in a canonical surface key —
+ * the interaction sweep's pairwise depth bound (see
+ * interactions.ts): 0 pinned → full single-control enumeration;
+ * 1 pinned → representative combos only (each interaction there
+ * forms a structural-param PAIR); ≥2 pinned → terminal, visited
+ * with the universal oracles but not expanded further.
+ */
+export function pinnedStructuralParamCount(canonical: string): number {
+  const q = canonical.split('?', 2)[1];
+  if (q === undefined || q === '') return 0;
+  return q.split('&').length;
 }
 
 /**

--- a/test/e2e/playwright/crawl/stacks.ts
+++ b/test/e2e/playwright/crawl/stacks.ts
@@ -36,6 +36,7 @@
 import {
   APP_BARE_PATH_ALIASES,
   EXCLUDED_PATH_PATTERNS,
+  STRUCTURAL_PARAM_RULES,
   type ScopeRules,
 } from './lib.js';
 // Imported from the concrete module (not the helpers barrel):
@@ -121,6 +122,15 @@ export type CrawlStackConfig = {
    * these define the lean (fast-lane) surface set.
    */
   leanSeedRoots: ReadonlyArray<string>;
+  /**
+   * Lean-lane interaction roots: CANONICAL surface keys whose
+   * interactive controls the lean crawl sweeps with the
+   * representative plan (one state per control — see
+   * interactions.ts). At full depth EVERY eligible visited surface
+   * sweeps; this list only shapes the fast lane (depth changes
+   * states, never rules).
+   */
+  leanInteractionRoots: ReadonlyArray<string>;
   /** Hard page caps — exceeding one FAILS the crawl (never partial). */
   pageCapLean: number;
   pageCapFull: number;
@@ -140,6 +150,7 @@ export type CrawlStackConfig = {
 const GRAFANA_12_SCOPE: ScopeRules = {
   excludedPathPatterns: EXCLUDED_PATH_PATTERNS,
   appBarePathAliases: APP_BARE_PATH_ALIASES,
+  structuralParamRules: STRUCTURAL_PARAM_RULES,
 };
 
 /**
@@ -167,6 +178,21 @@ const DRILLDOWN_APP_SEEDS: ReadonlyArray<string> = DRILLDOWN_APPS.map(
   (app) => app.root,
 );
 
+/**
+ * Lean interaction roots shared by both stacks: the three drilldown
+ * app entry surfaces (canonical keys — the metrics app's /trail seed
+ * redirects to /drilldown but stays KEYED by the harvested /trail
+ * path). The drilldown apps are where the interaction gap class
+ * lives — the 2026-06-10 maintainer find (Traces Drilldown
+ * groupBy=kind → nil-comparison 422) was a state only an interaction
+ * reaches.
+ */
+const DRILLDOWN_LEAN_INTERACTION_ROOTS: ReadonlyArray<string> = [
+  '/a/grafana-exploretraces-app/explore',
+  '/a/grafana-lokiexplore-app/explore',
+  '/a/grafana-metricsdrilldown-app/trail',
+];
+
 // ---------------------------------------------------------------------------
 // Stack configs
 // ---------------------------------------------------------------------------
@@ -193,8 +219,9 @@ export const COMPOSE_STACK: CrawlStackConfig = {
     minMultiQuantilePanels: 1,
   },
   leanSeedRoots: DRILLDOWN_APP_SEEDS,
-  pageCapLean: 30,
-  pageCapFull: 80,
+  leanInteractionRoots: DRILLDOWN_LEAN_INTERACTION_ROOTS,
+  pageCapLean: 45,
+  pageCapFull: 250,
 };
 
 /**
@@ -242,8 +269,9 @@ export const K3D_STACK: CrawlStackConfig = {
     minMultiQuantilePanels: 0,
   },
   leanSeedRoots: DRILLDOWN_APP_SEEDS,
-  pageCapLean: 30,
-  pageCapFull: 80,
+  leanInteractionRoots: DRILLDOWN_LEAN_INTERACTION_ROOTS,
+  pageCapLean: 45,
+  pageCapFull: 250,
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Maintainer directive: "the crawler needs to sweep EVERYTHING clickable that changes the dashboard consumption mode (any pulldown, any sort of filter)." Extends the deterministic crawler (#772/#773) from URL-harvesting to **interaction-driven state enumeration** — every view-affecting control (comboboxes, groupBy/metric/actionView, tabs, sort, adhoc filters) is discovered, its values enumerated (structural controls fully; high-cardinality bounded to one representative; combos pairwise ≤16), and each resulting state visited under the full universal oracle set via fresh navigation.

This is the gap your manual repro exposed: the breakdown `var-groupBy=kind` state (the 2026-06-10 nil-comparison 422) was reachable but never visited at default state.

## Verification

- **Lean lane: 13 passed, 0 failed, 111s** against a live compose stack — well under the ~8 min PR-gate budget; no tightening needed.
- **Inventory ratchet**: 294 surfaces, byte-stable double-regen; key-stability clean (react `:rNN:`/`«rNN»` → `{rid}`, counts → `{n}`, high-cardinality → `{rep}`/`{metric}`/`{service}`; keys a pure function of DOM order). `CERBERUS_UPDATE_INVENTORY=1` at lean depth correctly rejected (full-depth-only); no-CRAWL_STACK → 0 tests; bogus stack → loud error.
- **Efficacy proof** — the corrected pin demonstrably reaches the previously-broken states: `var-groupBy=kind` breakdown (5 rows incl. bare + combos), logs-drilldown field states (58 rows: json/table viz, Exclude filters, sort direction/function, adhoc).

## Fix surfaced during finishing

The committed inventory carried **18 phantom `grafanacloud-*` datasource-picker rows** from a crawl predating the cerberus-only DS filter — foreign DSes navigate out of cerberus's domain and 404 the proxy, so with one cerberus DS per type already selected the picker yields zero deviations. Two were lean-pinned and failed the gate. Removed all 18 (reconciliation with the documented filter, not coverage erosion); 312→294 surfaces.

## Lane split

Lean joins `compose-smoke` as the required PR gate; full-depth rides the **nightly only** — its job timeout is now per-lane (`schedule && 120 || 45` min) to give the real 50+ min full sweep headroom while keeping the PR gate tight. Documented in the job comment and `docs/test-strategy.md`.

## Caveats

- Full-depth not run locally (by design — it doesn't converge in a practical window); the nightly's first run regenerates the full inventory and self-heals any stale/new rows.
- k3d inventory stays empty (bootstrap-pending — the nightly `update_crawl_inventory` dispatch populates it, unrelated to this PR).

Closes task #56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
