### PR TITLE
test(perf): chDB CH-execution benches for ORDER BY prune + /series fan-out

### DIFF
--- a/test/perf/orderby_chdb_test.go
+++ b/test/perf/orderby_chdb_test.go
@@ -1,0 +1,275 @@
+//go:build chdb
+
+// Deliverable 1 (task #70): quantify the metrics-table ORDER BY decision.
+//
+// Production renders the OTel-CH metrics tables with
+//
+//	ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix))
+//
+// (ServiceName FIRST — see internal/chsql/tableshape.go:136). A
+// metric-name-first PromQL instant query with NO service.name matcher —
+// the common Grafana / Drilldown-Metrics case — cannot PK-range-prune on
+// the leading ServiceName key, so ClickHouse falls back to a generic
+// exclusion search that touches granules from every ServiceName block.
+//
+// This bench seeds two parallel MergeTree tables with byte-identical data
+// and contrasting sort keys:
+//
+//	svcfirst : (ServiceName, MetricName, Attributes, ts)  — production
+//	metric   : (MetricName, Attributes, ServiceName, ts)  — proposed fork patch
+//
+// then runs EXPLAIN indexes=1 (parts/granules pruned) + wall-clock timing
+// for two query shapes:
+//
+//	metric-only : WHERE MetricName = ?                    (no service filter)
+//	svc+metric  : WHERE ServiceName = ? AND MetricName = ?
+//
+// The numbers feed the RC1 accept-OTel-default vs patch-cerberus-ddl-fork
+// decision. Build-tagged `chdb`, same lane as the rest of the chDB execs.
+package perf
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	_ "github.com/chdb-io/chdb-go/chdb/driver" // registers "chdb" sql driver
+)
+
+// Data shape — representative of a mid-size OTel deployment:
+//
+//	nServices  distinct ServiceNames
+//	nMetrics   distinct MetricNames, EACH present under EVERY service
+//	nAttr      attribute-key cardinality per (service,metric)
+//	nTime      timestamps per series
+//
+// Total rows = nServices * nMetrics * nAttr * nTime.
+const (
+	nServices = 25
+	nMetrics  = 40
+	nAttr     = 20
+	nTime     = 30
+	// → 25 * 40 * 20 * 30 = 600,000 rows. (Scale up for sharper ratios.)
+)
+
+// makeInsert builds an INSERT … SELECT FROM numbers() that materialises the
+// full grid. The column derivations are arranged so that, regardless of the
+// destination sort key, the *same* logical rows land in the table — the only
+// difference between the two tables is the ORDER BY ClickHouse applies.
+//
+//	svc index   = (n / (nMetrics*nAttr*nTime)) % nServices
+//	metric idx  = (n / (nAttr*nTime))          % nMetrics
+//	attr idx    = (n / nTime)                  % nAttr
+//	time idx    =  n                           % nTime
+func makeInsert(table string, total int) string {
+	return fmt.Sprintf(`INSERT INTO %s
+SELECT
+    concat('service.', leftPad(toString(intDiv(number, %d) %% %d), 3, '0')) AS ServiceName,
+    concat('metric_', leftPad(toString(intDiv(number, %d) %% %d), 3, '0')) AS MetricName,
+    map('host', concat('h', toString(intDiv(number, %d) %% %d))) AS Attributes,
+    toDateTime64('2026-05-11 12:00:00', 9) + INTERVAL (number %% %d) SECOND AS TimeUnix,
+    toFloat64(number) AS Value
+FROM numbers(%d)`,
+		table,
+		nMetrics*nAttr*nTime, nServices, // ServiceName
+		nAttr*nTime, nMetrics, // MetricName
+		nTime, nAttr, // Attributes host
+		nTime, // TimeUnix
+		total, // numbers(total)
+	)
+}
+
+func ddlFor(table, orderBy string) string {
+	return fmt.Sprintf(`CREATE OR REPLACE TABLE %s (
+    ServiceName String,
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree() ORDER BY %s SETTINGS index_granularity = 8192;`, table, orderBy)
+}
+
+type explainStats struct {
+	keys     string
+	cond     string
+	parts    string
+	granules string
+}
+
+func runExplain(t *testing.T, db *sql.DB, query string) explainStats {
+	t.Helper()
+	rows, err := db.Query("EXPLAIN indexes=1 " + query)
+	if err != nil {
+		t.Fatalf("EXPLAIN: %v", err)
+	}
+	defer rows.Close()
+	var st explainStats
+	var capKeys bool
+	for rows.Next() {
+		var line string
+		if err := rows.Scan(&line); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		trim := trimSpace(line)
+		switch {
+		case trim == "Keys:":
+			capKeys = true
+		case capKeys && st.keys == "":
+			st.keys = trim
+			capKeys = false
+		case hasPrefix(trim, "Condition:"):
+			st.cond = trim
+		case hasPrefix(trim, "Parts:"):
+			st.parts = trim
+		case hasPrefix(trim, "Granules:"):
+			st.granules = trim
+		}
+	}
+	return st
+}
+
+// timeQuery runs `query` `iters` times and returns the best (min) wall time —
+// min is the most stable estimate of the floor cost under chDB's noisy
+// single-process engine.
+func timeQuery(t *testing.T, db *sql.DB, query string, iters int) time.Duration {
+	t.Helper()
+	best := time.Hour
+	for i := 0; i < iters; i++ {
+		start := time.Now()
+		rows, err := db.Query(query)
+		if err != nil {
+			t.Fatalf("query: %v", err)
+		}
+		var n int
+		for rows.Next() {
+			n++
+		}
+		rows.Close()
+		if d := time.Since(start); d < best {
+			best = d
+		}
+	}
+	return best
+}
+
+func TestOrderByDecision_ChDB(t *testing.T) {
+	db, err := sql.Open("chdb", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := db.Ping(); err != nil {
+		t.Fatal(err)
+	}
+
+	total := nServices * nMetrics * nAttr * nTime
+
+	tables := []struct {
+		name    string
+		orderBy string
+		label   string
+	}{
+		{"m_svcfirst", "(ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix))", "ServiceName-first (PRODUCTION)"},
+		{"m_metricfirst", "(MetricName, Attributes, ServiceName, toUnixTimestamp64Nano(TimeUnix))", "MetricName-first (PROPOSED)"},
+	}
+
+	for _, tb := range tables {
+		if _, err := db.Exec(ddlFor(tb.name, tb.orderBy)); err != nil {
+			t.Fatalf("ddl %s: %v", tb.name, err)
+		}
+		if _, err := db.Exec(makeInsert(tb.name, total)); err != nil {
+			t.Fatalf("insert %s: %v", tb.name, err)
+		}
+		// Force a single part so granule counts are comparable and not
+		// inflated by background-merge timing.
+		if _, err := db.Exec("OPTIMIZE TABLE " + tb.name + " FINAL"); err != nil {
+			t.Fatalf("optimize %s: %v", tb.name, err)
+		}
+	}
+
+	var totalGranules int64
+	_ = db.QueryRow(`SELECT count() FROM m_svcfirst`).Scan(new(int64))
+	db.QueryRow(`SELECT sum(marks) FROM system.parts WHERE table='m_svcfirst' AND active`).Scan(&totalGranules)
+
+	// Query shapes. The metric-only shape pins NO ServiceName (the common
+	// Grafana case). svc+metric pins both. We aggregate (sum+count) so the
+	// result set is a single row — chDB-go's parquet driver panics draining
+	// the ~15k-row raw projection — while the WHERE/PK-prune work (the thing
+	// being measured) is identical to the raw SELECT. EXPLAIN below uses the
+	// same predicate, so granule/part counts reflect the real scan.
+	metricOnly := "SELECT sum(Value), count() FROM %s WHERE MetricName = 'metric_020'"
+	svcMetric := "SELECT sum(Value), count() FROM %s WHERE ServiceName = 'service.012' AND MetricName = 'metric_020'"
+
+	const iters = 7
+
+	t.Logf("=== ORDER BY decision: %d rows (%d svc x %d metrics x %d attr x %d ts), total marks=%d ===",
+		total, nServices, nMetrics, nAttr, nTime, totalGranules)
+
+	type row struct {
+		shape, variant string
+		st             explainStats
+		wall           time.Duration
+	}
+	var results []row
+	for _, tb := range tables {
+		for _, q := range []struct {
+			shape string
+			tmpl  string
+		}{
+			{"metric-only", metricOnly},
+			{"svc+metric", svcMetric},
+		} {
+			query := fmt.Sprintf(q.tmpl, tb.name)
+			st := runExplain(t, db, query)
+			wall := timeQuery(t, db, query, iters)
+			results = append(results, row{q.shape, tb.label, st, wall})
+		}
+	}
+
+	t.Logf("%-12s | %-32s | %-12s | %-16s | %-10s | %s",
+		"shape", "ORDER BY", "PK keys", "parts", "granules", "best wall")
+	t.Log("-------------+----------------------------------+--------------+------------------+------------+----------")
+	for _, r := range results {
+		t.Logf("%-12s | %-32s | %-12s | %-16s | %-10s | %v",
+			r.shape, r.variant, r.st.keys,
+			stripPrefix(r.st.parts, "Parts: "),
+			stripPrefix(r.st.granules, "Granules: "),
+			r.wall.Round(time.Microsecond))
+	}
+
+	// Emit raw EXPLAIN blocks for the metric-only shape under both keys so
+	// the report can quote the exact ClickHouse plan + condition.
+	for _, tb := range tables {
+		t.Logf("--- EXPLAIN indexes=1  metric-only  [%s] ---", tb.label)
+		rows, _ := db.Query("EXPLAIN indexes=1 " + fmt.Sprintf(metricOnly, tb.name))
+		for rows.Next() {
+			var s string
+			rows.Scan(&s)
+			t.Log("    " + s)
+		}
+		rows.Close()
+	}
+}
+
+// --- tiny string helpers (avoid importing strings for two calls) ---
+
+func trimSpace(s string) string {
+	i, j := 0, len(s)
+	for i < j && (s[i] == ' ' || s[i] == '\t') {
+		i++
+	}
+	for j > i && (s[j-1] == ' ' || s[j-1] == '\t') {
+		j--
+	}
+	return s[i:j]
+}
+
+func hasPrefix(s, p string) bool { return len(s) >= len(p) && s[:len(p)] == p }
+
+func stripPrefix(s, p string) string {
+	if hasPrefix(s, p) {
+		return s[len(p):]
+	}
+	return s
+}

--- a/test/perf/series_fanout_chdb_test.go
+++ b/test/perf/series_fanout_chdb_test.go
@@ -1,0 +1,305 @@
+//go:build chdb
+
+// Deliverable 2 (task #70): diagnose the Drilldown-Metrics /api/v1/series
+// +600ms latency.
+//
+// handleSeries (internal/api/prom/metadata.go:327-363) runs a triple-nested
+// fan-out per request:
+//
+//	for each match[] selector m:
+//	  for each nameVariant in expandUnderscoredMetricNameMatcher(m):   // V
+//	    for each variant in expandBareHistogramMatcher(nameVariant):   // H
+//	      fetchSeries(variant)  ->  executeInstant  ->  Engine.Query   // 1 CH round-trip
+//
+// So a single histogram-shaped match[] request issues N×V×H *sequential*
+// ClickHouse round-trips, each a full parse→lower→optimize→emit→execute
+// instant query. The hypothesis: the demo's +600ms is fan-in (many fast
+// round-trips serialised) — not one slow query.
+//
+// This harness drives the real in-process Prom handler against a chDB
+// session via a round-trip-counting Querier decorator, measures N + the
+// per-trip / total wall time, then runs the equivalent single OR-joined
+// combined query (modelled on internal/api/loki/series.go:buildSeriesSQL)
+// to project the batched-into-one cost. It does NOT refactor the handler
+// (that's task #71) — it only proves the win is real and sizes it.
+package perf
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	_ "github.com/chdb-io/chdb-go/chdb/driver"
+
+	"github.com/tsouza/cerberus/internal/api/prom"
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chclienttest"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// countingQuerier wraps the chDB-backed Client and records every CH
+// round-trip the handler issues — both the direct Client.QueryStrings /
+// QueryLabelSets catalog paths and the Engine.Query / QueryCursor instant
+// paths that /series fans out over. Each method also records its own wall
+// time so the harness can report a per-trip breakdown.
+type countingQuerier struct {
+	// Embedded so the Querier methods the /series path does NOT exercise
+	// (QueryMetricMeta / QueryExemplars) are forwarded unmodified; the four
+	// methods below are overridden to count + time their round-trips.
+	*chclienttest.Client
+
+	inner *chclienttest.Client
+
+	mu     sync.Mutex
+	calls  int
+	perOp  []time.Duration
+	method []string
+}
+
+func (c *countingQuerier) record(method string, d time.Duration) {
+	c.mu.Lock()
+	c.calls++
+	c.perOp = append(c.perOp, d)
+	c.method = append(c.method, method)
+	c.mu.Unlock()
+}
+
+func (c *countingQuerier) Query(ctx context.Context, q string, a ...any) ([]chclient.Sample, error) {
+	t := time.Now()
+	r, err := c.inner.Query(ctx, q, a...)
+	c.record("Query", time.Since(t))
+	return r, err
+}
+
+func (c *countingQuerier) QueryCursor(ctx context.Context, q string, a ...any) (chclient.Cursor, error) {
+	t := time.Now()
+	r, err := c.inner.QueryCursor(ctx, q, a...)
+	c.record("QueryCursor", time.Since(t))
+	return r, err
+}
+
+func (c *countingQuerier) QueryStrings(ctx context.Context, q string, a ...any) ([]string, error) {
+	t := time.Now()
+	r, err := c.inner.QueryStrings(ctx, q, a...)
+	c.record("QueryStrings", time.Since(t))
+	return r, err
+}
+
+func (c *countingQuerier) QueryLabelSets(ctx context.Context, q string, a ...any) ([]map[string]string, error) {
+	t := time.Now()
+	r, err := c.inner.QueryLabelSets(ctx, q, a...)
+	c.record("QueryLabelSets", time.Since(t))
+	return r, err
+}
+
+func (c *countingQuerier) reset() {
+	c.mu.Lock()
+	c.calls = 0
+	c.perOp = nil
+	c.method = nil
+	c.mu.Unlock()
+}
+
+func (c *countingQuerier) snapshot() (int, []time.Duration, []string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	d := append([]time.Duration(nil), c.perOp...)
+	m := append([]string(nil), c.method...)
+	return c.calls, d, m
+}
+
+// seriesSeed builds the gauge / sum / histogram tables and a representative
+// Drilldown corpus. The histogram base name `http_server_request_duration`
+// triggers the H fan-out; the underscored form triggers the V fan-out
+// (dotted candidate `http.server.request.duration`).
+func seriesSeed() string {
+	const ts = `2026-05-11 12:00:00`
+	gaugeDDL := `CREATE OR REPLACE TABLE otel_metrics_gauge (
+	  ServiceName String, MetricName String, Attributes Map(String,String),
+	  TimeUnix DateTime64(9), Value Float64
+	) ENGINE = MergeTree() ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix));`
+	sumDDL := `CREATE OR REPLACE TABLE otel_metrics_sum (
+	  ServiceName String, MetricName String, Attributes Map(String,String),
+	  TimeUnix DateTime64(9), Value Float64
+	) ENGINE = MergeTree() ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix));`
+	histDDL := `CREATE OR REPLACE TABLE otel_metrics_histogram (
+	  ServiceName String, MetricName String, Attributes Map(String,String),
+	  TimeUnix DateTime64(9), Count UInt64, Sum Float64,
+	  BucketCounts Array(UInt64), ExplicitBounds Array(Float64)
+	) ENGINE = MergeTree() ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix));`
+
+	// Populate each table with several services × attribute combos so the
+	// instant queries do real granule work, not a single-row scan. now()
+	// anchors the rows inside the bare-selector staleness window the
+	// /series instant pipeline applies (Timestamp <= now, 5m lookback).
+	gaugeIns := `INSERT INTO otel_metrics_gauge SELECT
+	  concat('svc', toString(number % 8)),
+	  arrayElement(['http_server_active_requests','system_cpu_utilization','process_runtime_memory'], (number % 3) + 1),
+	  map('http.request.method', arrayElement(['GET','POST','PUT'], (number % 3)+1), 'host', concat('h', toString(number % 20))),
+	  now64(9) - INTERVAL (number % 60) SECOND,
+	  toFloat64(number)
+	FROM numbers(20000);`
+	sumIns := `INSERT INTO otel_metrics_sum SELECT
+	  concat('svc', toString(number % 8)),
+	  'http_server_request_duration_count',
+	  map('http.request.method', arrayElement(['GET','POST','PUT'], (number % 3)+1), 'host', concat('h', toString(number % 20))),
+	  now64(9) - INTERVAL (number % 60) SECOND,
+	  toFloat64(number)
+	FROM numbers(20000);`
+	histIns := `INSERT INTO otel_metrics_histogram SELECT
+	  concat('svc', toString(number % 8)),
+	  'http_server_request_duration',
+	  map('http.request.method', arrayElement(['GET','POST','PUT'], (number % 3)+1), 'host', concat('h', toString(number % 20))),
+	  now64(9) - INTERVAL (number % 60) SECOND,
+	  toUInt64(100 + number), toFloat64(number) / 2,
+	  [10,20,30,40], [0.1,0.5,1.0]
+	FROM numbers(20000);`
+
+	return gaugeDDL + sumDDL + histDDL + gaugeIns + sumIns + histIns
+}
+
+func TestSeriesFanout_ChDB(t *testing.T) {
+	inner := chclienttest.NewChDB(t)
+	inner.Seed(t, seriesSeed())
+	counter := &countingQuerier{Client: inner, inner: inner}
+
+	// Real prom handler over the counting client (Client == Engine.Client,
+	// so every round-trip — catalog + instant fan-out — flows through the
+	// counter).
+	h := prom.New(counter, schema.DefaultOTelMetrics(), nil)
+	mux := http.NewServeMux()
+	h.Mount(mux)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	// Representative Drilldown /series request: a histogram base name in
+	// Prom underscore grammar. This fires BOTH fan-out layers — V (dotted
+	// candidate) and H (the three classic-histogram companions).
+	matcher := `{__name__="http_server_request_duration"}`
+	reqURL := fmt.Sprintf("%s/api/v1/series?match[]=%s&start=%d&end=%d",
+		srv.URL, url.QueryEscape(matcher),
+		time.Now().Add(-1*time.Hour).Unix(), time.Now().Unix())
+
+	counter.reset()
+	start := time.Now()
+	resp, err := http.Get(reqURL)
+	if err != nil {
+		t.Fatalf("GET /series: %v", err)
+	}
+	totalWall := time.Since(start)
+	body := readAll(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+
+	n, perOp, methods := counter.snapshot()
+	var chSum time.Duration
+	for _, d := range perOp {
+		chSum += d
+	}
+
+	t.Logf("=== /api/v1/series fan-out diagnosis ===")
+	t.Logf("request matcher: %s", matcher)
+	t.Logf("CH round-trips issued (N): %d", n)
+	t.Logf("per-trip CH wall times:")
+	for i, d := range perOp {
+		t.Logf("    trip %2d  %-12s  %v", i+1, methods[i], d.Round(time.Microsecond))
+	}
+	t.Logf("sum of CH round-trip wall:   %v", chSum.Round(time.Microsecond))
+	t.Logf("end-to-end handler wall:     %v", totalWall.Round(time.Microsecond))
+	t.Logf("mean per-trip:               %v", (chSum / time.Duration(max1(n))).Round(time.Microsecond))
+
+	// --- Projected batched cost: one OR-joined combined query ---------
+	//
+	// Model the task #71 refactor: instead of N sequential instant queries,
+	// issue ONE query per table that ORs every variant's MetricName
+	// predicate together and projects distinct label sets. This is the
+	// shape internal/api/loki/series.go:buildSeriesSQL already uses for the
+	// Loki head. We run the equivalent combined SQL directly to size the
+	// floor cost of the batched path.
+	//
+	// The variant set for this request resolves to:
+	//   gauge/sum  candidates: http_server_request_duration{,_count,_sum,_bucket}
+	//   histogram  base:       http_server_request_duration
+	// A single UNION-ALL over the three tables, each filtering MetricName
+	// IN (...the request's variant names...), captures every row the
+	// fan-out would have touched in one round-trip.
+	db := openChDB(t)
+	combined := `
+SELECT DISTINCT MetricName, Attributes FROM (
+  SELECT MetricName, Attributes FROM otel_metrics_gauge
+    WHERE MetricName IN ('http_server_request_duration','http_server_request_duration_count','http_server_request_duration_sum','http_server_request_duration_bucket')
+  UNION ALL
+  SELECT MetricName, Attributes FROM otel_metrics_sum
+    WHERE MetricName IN ('http_server_request_duration','http_server_request_duration_count','http_server_request_duration_sum','http_server_request_duration_bucket')
+  UNION ALL
+  SELECT MetricName, Attributes FROM otel_metrics_histogram
+    WHERE MetricName = 'http_server_request_duration'
+)`
+	// chDB-go's parquet driver panics on large multi-column projections;
+	// wrap in count() so the result is one row. The WHERE / scan / DISTINCT
+	// work — what we're timing — is identical.
+	combinedCount := "SELECT count() FROM (" + combined + ")"
+	const iters = 7
+	best := time.Hour
+	for i := 0; i < iters; i++ {
+		s := time.Now()
+		var c int64
+		if err := db.QueryRow(combinedCount).Scan(&c); err != nil {
+			t.Fatalf("combined query: %v", err)
+		}
+		if d := time.Since(s); d < best {
+			best = d
+		}
+	}
+
+	t.Logf("--- projected batched (single combined query) ---")
+	t.Logf("combined-query round-trips:  1  (was %d)", n)
+	t.Logf("combined-query best wall:    %v", best.Round(time.Microsecond))
+	if chSum > 0 {
+		t.Logf("CH-time delta:               %v (fan-out)  ->  %v (combined)  =  %.1fx",
+			chSum.Round(time.Microsecond), best.Round(time.Microsecond),
+			float64(chSum)/float64(best))
+	}
+}
+
+func max1(n int) int {
+	if n < 1 {
+		return 1
+	}
+	return n
+}
+
+func openChDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("chdb", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.Ping(); err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+
+func readAll(t *testing.T, resp *http.Response) string {
+	t.Helper()
+	defer resp.Body.Close()
+	buf := make([]byte, 0, 4096)
+	tmp := make([]byte, 4096)
+	for {
+		n, err := resp.Body.Read(tmp)
+		buf = append(buf, tmp[:n]...)
+		if err != nil {
+			break
+		}
+	}
+	return string(buf)
+}


### PR DESCRIPTION
Adds the CH-execution measurement harness the perf-architecture assessment (task #69) found missing — the perf lane previously benched only Go-side construction, never SQL against ClickHouse. Two build-tagged (`chdb`) harnesses under `test/perf/`, run in the same lane as the existing chdb execs (default build excludes them; `go vet -tags chdb` clean).

These produced the RC1 perf decisions (task #70):

**`orderby_chdb_test.go` — metrics-table ORDER BY prune.** Byte-identical data in two MergeTree tables with contrasting sort keys, `EXPLAIN indexes=1` + wall timing. Result: for the common **metric-only** query (no `service.name` matcher), the production `(ServiceName, MetricName, …)` key reads **51/74 granules (69%, generic-exclusion search)** vs **3/74 (4%, binary search)** for `(MetricName, …)`; at 4.8M rows the gap is **15% vs 2%** granules (~8–17×). Service-pinned queries cost only +2 granules under MetricName-first. → motivates patching the cerberus-ddl fork to MetricName-first.

**`series_fanout_chdb_test.go` — Prom `/api/v1/series` round-trip count.** Drives the real handler over a round-trip-counting Querier. A histogram-base-name request issues **N=32 sequential CH round-trips** (V×H fan-out), ~330ms ≈ 100% of handler wall — confirming the demo's +600ms is **fan-in**, not a deep query. Projected single OR-joined query: **8.3ms (32→1 round-trips, ~40×)** → sizes the task-#71 batching win.

Grids default to 600k rows (moderate); bump the `n*` consts for sharper ratios. Harness only — no production code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)