### PR TITLE
test(surface-parity): function-surface conformance prober + inventory + drift ratchet (#51 P0)

### DIFF
--- a/test/surface-parity/doc.go
+++ b/test/surface-parity/doc.go
@@ -1,0 +1,61 @@
+// Package surfaceparity owns the function-surface conformance ledger —
+// the machine-readable inventory of every grammar symbol the three
+// upstream parsers accept, paired with cerberus's verdict (does the
+// parse → fold → lower → optimize → emit pipeline accept it?) and the
+// reference backend's verdict, classified into a four-way parity grid.
+//
+// Motivation: the sibling rejection-parity layer
+// (test/rejection-parity/) is SITE-based — it diffs cerberus's KNOWN
+// 422 code-sites against the reference. It structurally misses
+// functions cerberus *silently* fails to lower: a symbol that was
+// never wired never gets a rejection site, so it never enters that
+// catalogue, so no parity case ever diffs it. This layer inverts the
+// direction: it starts from the upstream parser's ACCEPTED grammar
+// (parser.Functions, the loki Op* consts, the tempo intrinsic +
+// metrics-op enums) and finds everything cerberus rejects that the
+// reference accepts — the wrong-rejection surface that drives the P2
+// burndown waves.
+//
+// The four classifications:
+//
+//   - parity-accept  — both cerberus and the reference accept. Healthy.
+//   - parity-reject  — both reject (e.g. an experimental PromQL fn the
+//     reference also gates off by default). Healthy.
+//   - wrong-reject   — cerberus 422s, the reference accepts. A real
+//     coverage gap: a symbol cerberus silently fails to lower. THIS is
+//     the class the layer exists to surface.
+//   - wrong-accept   — cerberus accepts, the reference rejects. A
+//     correctness risk: cerberus answers a query the reference won't.
+//
+// Reference oracle (the LIGHT path, no compat containers):
+//
+//   - PromQL: reference Prometheus v3.11.3 rejects functions /
+//     aggregators flagged Experimental in the parser
+//     (parser.Functions[name].Experimental, ItemType.IsExperimental-
+//     Aggregator) when --enable-feature=promql-experimental-functions
+//     is off (the compat harness default), and accepts the rest.
+//   - LogQL: reference Loki accepts exactly what syntax.ParseExpr
+//     (parse + validate) accepts — the same gate the wire path runs.
+//   - TraceQL: reference Tempo accepts exactly what traceql.Parse +
+//     traceql.Validate accept in-process.
+//
+// The inventory.json artifact is the authoritative ledger. The
+// meta-tests in inventory_test.go pin a three-leg ratchet modelled on
+// test/rejection-parity/catalogue_test.go:
+//
+//  1. TestInventoryIsRegenerable rescans the parser symbol tables,
+//     re-runs the cerberus + reference verdicts, and diffs the
+//     regenerated inventory byte-for-byte against the checked-in JSON
+//     (CERBERUS_UPDATE_INVENTORY=1 rewrites it).
+//  2. TestWrongRejectionsAreRatcheted pins the current wrong-reject set
+//     per head: a NEW wrong-reject (a symbol that regressed from
+//     accept, or a newly-added grammar symbol cerberus doesn't lower)
+//     fails CI red. A burndown that FIXES a wrong-reject also fails
+//     until the inventory is regenerated — the ledger moves in
+//     lock-step with the surface.
+//  3. TestWrongAcceptsAreRatcheted does the same for wrong-accepts.
+//
+// Regen mode (CERBERUS_UPDATE_INVENTORY=1, same env convention as the
+// rejection-parity catalogue + test/inventory) lets a P2 burndown that
+// closes a gap re-pin the ledger in the same PR.
+package surfaceparity

--- a/test/surface-parity/inventory.go
+++ b/test/surface-parity/inventory.go
@@ -1,0 +1,206 @@
+package surfaceparity
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+)
+
+// Verdict is a single backend's posture on a probe expression.
+type Verdict string
+
+const (
+	// VerdictAccept — the backend lowers/parses+validates the probe
+	// without error.
+	VerdictAccept Verdict = "accept"
+	// VerdictReject — the backend errors on the probe.
+	VerdictReject Verdict = "reject"
+)
+
+// Classification is the four-way parity grid cell for a symbol.
+type Classification string
+
+const (
+	// ClassParityAccept — both cerberus and the reference accept.
+	ClassParityAccept Classification = "parity-accept"
+	// ClassParityReject — both reject.
+	ClassParityReject Classification = "parity-reject"
+	// ClassWrongReject — cerberus rejects, reference accepts. The
+	// coverage gap this layer exists to surface.
+	ClassWrongReject Classification = "wrong-reject"
+	// ClassWrongAccept — cerberus accepts, reference rejects. A
+	// correctness risk.
+	ClassWrongAccept Classification = "wrong-accept"
+)
+
+// classify derives the parity cell from the two verdicts.
+func classify(cerberus, reference Verdict) Classification {
+	switch {
+	case cerberus == VerdictAccept && reference == VerdictAccept:
+		return ClassParityAccept
+	case cerberus == VerdictReject && reference == VerdictReject:
+		return ClassParityReject
+	case cerberus == VerdictReject && reference == VerdictAccept:
+		return ClassWrongReject
+	default:
+		return ClassWrongAccept
+	}
+}
+
+// Entry is one grammar symbol probed through both backends.
+type Entry struct {
+	// Head is "promql" / "logql" / "traceql".
+	Head string `json:"head"`
+	// Symbol is the stable grammar-symbol key: the upstream parser's
+	// own identifier for the function / aggregator / op / intrinsic
+	// (e.g. "fn:acos", "agg:topk", "op:atan2", "range:rate",
+	// "intrinsic:span:duration", "metric:quantile_over_time"). Greppable
+	// straight back to the parser symbol table.
+	Symbol string `json:"symbol"`
+	// Kind groups symbols for reporting: "function", "aggregator",
+	// "binary-op", "range-agg", "vector-agg", "parser-stage",
+	// "conv-fn", "label-fn", "intrinsic", "metrics-op", "modifier".
+	Kind string `json:"kind"`
+	// Probe is the synthesized canonical, domain-aware query that
+	// exercises the symbol against real seed metrics/labels/attributes.
+	Probe string `json:"probe"`
+	// Cerberus is cerberus's verdict on Probe (parse → lower → optimize
+	// → emit).
+	Cerberus Verdict `json:"cerberus"`
+	// Reference is the reference backend's modelled verdict on Probe.
+	Reference Verdict `json:"reference"`
+	// Class is the four-way classification derived from the two
+	// verdicts.
+	Class Classification `json:"class"`
+	// CerberusError is the cerberus rejection error (empty when
+	// cerberus accepts). Recorded so a wrong-reject entry carries the
+	// concrete failure a burndown fixes.
+	CerberusError string `json:"cerberus_error,omitempty"`
+	// ReferenceUnresolved flags a symbol whose reference verdict could
+	// not be determined in-process (needs a compat-container diff). The
+	// ratchet excludes these from the wrong-reject / wrong-accept sets
+	// so an undeterminable verdict can't masquerade as a clean parity.
+	ReferenceUnresolved bool `json:"reference_unresolved,omitempty"`
+	// Note carries any extra context (e.g. why reference is
+	// unresolved, or a domain caveat on the probe).
+	Note string `json:"note,omitempty"`
+}
+
+// Inventory is the checked-in JSON artifact
+// (test/surface-parity/inventory.json).
+type Inventory struct {
+	Source  string  `json:"source"`
+	Entries []Entry `json:"entries"`
+}
+
+const inventorySource = "in-process probe of the three upstream parser symbol tables " +
+	"(prometheus parser.Functions/aggregators/ops, loki syntax.Op* consts, tempo " +
+	"intrinsic + metrics-op enums); cerberus verdict = parse→fold→lower→optimize→emit, " +
+	"reference verdict = parser experimental flags (promql) / ParseExpr+validate (logql) " +
+	"/ Parse+Validate (traceql); generated + pinned by test/surface-parity"
+
+// Generate probes every symbol of every head and assembles the
+// inventory. The cerberus and reference verdicts are recomputed from
+// scratch each run, so the artifact is a pure function of the parser
+// symbol tables + the cerberus lowering — no curated fields survive
+// across regenerations (unlike the rejection-parity catalogue, every
+// field here is mechanically derived).
+func Generate() (*Inventory, error) {
+	inv := &Inventory{Source: inventorySource}
+	for _, head := range []string{"promql", "logql", "traceql"} {
+		entries, err := probeHead(head)
+		if err != nil {
+			return nil, fmt.Errorf("probe %s: %w", head, err)
+		}
+		inv.Entries = append(inv.Entries, entries...)
+	}
+	sort.SliceStable(inv.Entries, func(i, j int) bool {
+		a, b := inv.Entries[i], inv.Entries[j]
+		if a.Head != b.Head {
+			return headOrder(a.Head) < headOrder(b.Head)
+		}
+		return a.Symbol < b.Symbol
+	})
+	return inv, nil
+}
+
+func headOrder(head string) int {
+	switch head {
+	case "promql":
+		return 0
+	case "logql":
+		return 1
+	case "traceql":
+		return 2
+	}
+	return 3
+}
+
+// probeHead dispatches to the per-head prober.
+func probeHead(head string) ([]Entry, error) {
+	switch head {
+	case "promql":
+		return probePromQL()
+	case "logql":
+		return probeLogQL()
+	case "traceql":
+		return probeTraceQL()
+	}
+	return nil, fmt.Errorf("unknown head %q", head)
+}
+
+// LoadInventory reads + parses the checked-in artifact.
+func LoadInventory(path string) (*Inventory, error) {
+	raw, err := os.ReadFile(path) //nolint:gosec // repo-relative artifact path
+	if err != nil {
+		return nil, err
+	}
+	var inv Inventory
+	if err := json.Unmarshal(raw, &inv); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return &inv, nil
+}
+
+// MarshalInventory renders the canonical on-disk JSON form (2-space
+// indent + trailing newline) so the regenerate-and-diff test compares
+// byte-for-byte. Mirrors test/rejection-parity.MarshalCatalogue.
+func MarshalInventory(inv *Inventory) ([]byte, error) {
+	b, err := json.MarshalIndent(inv, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(b, '\n'), nil
+}
+
+// WrongRejections returns the wrong-reject entries for a head, in
+// inventory order, excluding reference-unresolved symbols.
+func (inv *Inventory) WrongRejections(head string) []Entry {
+	return inv.byClass(head, ClassWrongReject)
+}
+
+// WrongAccepts returns the wrong-accept entries for a head.
+func (inv *Inventory) WrongAccepts(head string) []Entry {
+	return inv.byClass(head, ClassWrongAccept)
+}
+
+func (inv *Inventory) byClass(head string, class Classification) []Entry {
+	var out []Entry
+	for _, e := range inv.Entries {
+		if e.Head == head && e.Class == class && !e.ReferenceUnresolved {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// SymbolKeys returns the sorted symbol keys of the given entries.
+func SymbolKeys(entries []Entry) []string {
+	out := make([]string, len(entries))
+	for i, e := range entries {
+		out[i] = e.Symbol
+	}
+	sort.Strings(out)
+	return out
+}

--- a/test/surface-parity/inventory.json
+++ b/test/surface-parity/inventory.json
@@ -1,0 +1,2094 @@
+{
+  "source": "in-process probe of the three upstream parser symbol tables (prometheus parser.Functions/aggregators/ops, loki syntax.Op* consts, tempo intrinsic + metrics-op enums); cerberus verdict = parse→fold→lower→optimize→emit, reference verdict = parser experimental flags (promql) / ParseExpr+validate (logql) / Parse+Validate (traceql); generated + pinned by test/surface-parity",
+  "entries": [
+    {
+      "head": "promql",
+      "symbol": "agg:avg",
+      "kind": "aggregator",
+      "probe": "avg(up)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "agg:bottomk",
+      "kind": "aggregator",
+      "probe": "bottomk(3, up)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "agg:count",
+      "kind": "aggregator",
+      "probe": "count(up)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "agg:count_values",
+      "kind": "aggregator",
+      "probe": "count_values(\"v\", up)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "agg:group",
+      "kind": "aggregator",
+      "probe": "group(up)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "agg:limit_ratio",
+      "kind": "aggregator",
+      "probe": "limit_ratio(0.5, up)",
+      "cerberus": "reject",
+      "reference": "reject",
+      "class": "parity-reject",
+      "cerberus_error": "promql: aggregation op limit_ratio is not yet supported"
+    },
+    {
+      "head": "promql",
+      "symbol": "agg:limitk",
+      "kind": "aggregator",
+      "probe": "limitk(3, up)",
+      "cerberus": "reject",
+      "reference": "reject",
+      "class": "parity-reject",
+      "cerberus_error": "promql: aggregation op limitk is not yet supported"
+    },
+    {
+      "head": "promql",
+      "symbol": "agg:max",
+      "kind": "aggregator",
+      "probe": "max(up)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "agg:min",
+      "kind": "aggregator",
+      "probe": "min(up)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "agg:quantile",
+      "kind": "aggregator",
+      "probe": "quantile(0.9, up)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "agg:stddev",
+      "kind": "aggregator",
+      "probe": "stddev(up)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "agg:stdvar",
+      "kind": "aggregator",
+      "probe": "stdvar(up)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "agg:sum",
+      "kind": "aggregator",
+      "probe": "sum(up)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "agg:topk",
+      "kind": "aggregator",
+      "probe": "topk(3, up)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:abs",
+      "kind": "function",
+      "probe": "abs(up)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:absent",
+      "kind": "function",
+      "probe": "absent(up)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:absent_over_time",
+      "kind": "function",
+      "probe": "absent_over_time(up[5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:acos",
+      "kind": "function",
+      "probe": "acos(up)",
+      "cerberus": "reject",
+      "reference": "accept",
+      "class": "wrong-reject",
+      "cerberus_error": "promql: function acos is not yet supported"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:acosh",
+      "kind": "function",
+      "probe": "acosh(up)",
+      "cerberus": "reject",
+      "reference": "accept",
+      "class": "wrong-reject",
+      "cerberus_error": "promql: function acosh is not yet supported"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:asin",
+      "kind": "function",
+      "probe": "asin(up)",
+      "cerberus": "reject",
+      "reference": "accept",
+      "class": "wrong-reject",
+      "cerberus_error": "promql: function asin is not yet supported"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:asinh",
+      "kind": "function",
+      "probe": "asinh(up)",
+      "cerberus": "reject",
+      "reference": "accept",
+      "class": "wrong-reject",
+      "cerberus_error": "promql: function asinh is not yet supported"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:atan",
+      "kind": "function",
+      "probe": "atan(up)",
+      "cerberus": "reject",
+      "reference": "accept",
+      "class": "wrong-reject",
+      "cerberus_error": "promql: function atan is not yet supported"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:atanh",
+      "kind": "function",
+      "probe": "atanh(up)",
+      "cerberus": "reject",
+      "reference": "accept",
+      "class": "wrong-reject",
+      "cerberus_error": "promql: function atanh is not yet supported"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:avg_over_time",
+      "kind": "function",
+      "probe": "avg_over_time(up[5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:ceil",
+      "kind": "function",
+      "probe": "ceil(up)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:changes",
+      "kind": "function",
+      "probe": "changes(http_server_request_duration_count[5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:clamp",
+      "kind": "function",
+      "probe": "clamp(up, 0.5, 0.5)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:clamp_max",
+      "kind": "function",
+      "probe": "clamp_max(up, 0.5)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:clamp_min",
+      "kind": "function",
+      "probe": "clamp_min(up, 0.5)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:cos",
+      "kind": "function",
+      "probe": "cos(up)",
+      "cerberus": "reject",
+      "reference": "accept",
+      "class": "wrong-reject",
+      "cerberus_error": "promql: function cos is not yet supported"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:cosh",
+      "kind": "function",
+      "probe": "cosh(up)",
+      "cerberus": "reject",
+      "reference": "accept",
+      "class": "wrong-reject",
+      "cerberus_error": "promql: function cosh is not yet supported"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:count_over_time",
+      "kind": "function",
+      "probe": "count_over_time(up[5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:day_of_month",
+      "kind": "function",
+      "probe": "day_of_month(up)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:day_of_week",
+      "kind": "function",
+      "probe": "day_of_week(up)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:day_of_year",
+      "kind": "function",
+      "probe": "day_of_year(up)",
+      "cerberus": "reject",
+      "reference": "accept",
+      "class": "wrong-reject",
+      "cerberus_error": "promql: function day_of_year is not yet supported"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:days_in_month",
+      "kind": "function",
+      "probe": "days_in_month(up)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:deg",
+      "kind": "function",
+      "probe": "deg(up)",
+      "cerberus": "reject",
+      "reference": "accept",
+      "class": "wrong-reject",
+      "cerberus_error": "promql: function deg is not yet supported"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:delta",
+      "kind": "function",
+      "probe": "delta(http_server_request_duration_count[5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:deriv",
+      "kind": "function",
+      "probe": "deriv(http_server_request_duration_count[5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:double_exponential_smoothing",
+      "kind": "function",
+      "probe": "double_exponential_smoothing(http_server_request_duration_count[5m], 0.5, 0.5)",
+      "cerberus": "accept",
+      "reference": "reject",
+      "class": "wrong-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:end",
+      "kind": "function",
+      "probe": "end()",
+      "cerberus": "reject",
+      "reference": "reject",
+      "class": "parity-reject",
+      "cerberus_error": "promql: function end is not yet supported"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:exp",
+      "kind": "function",
+      "probe": "exp(up)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:first_over_time",
+      "kind": "function",
+      "probe": "first_over_time(up[5m])",
+      "cerberus": "reject",
+      "reference": "reject",
+      "class": "parity-reject",
+      "cerberus_error": "unsupported: range function \"first_over_time\" is experimental and not supported by the PromQL head"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:floor",
+      "kind": "function",
+      "probe": "floor(up)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:histogram_avg",
+      "kind": "function",
+      "probe": "histogram_avg(showcase_latency_exp_hist)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:histogram_count",
+      "kind": "function",
+      "probe": "histogram_count(showcase_latency_exp_hist)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:histogram_fraction",
+      "kind": "function",
+      "probe": "histogram_fraction(0, 1, showcase_latency_exp_hist)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:histogram_quantile",
+      "kind": "function",
+      "probe": "histogram_quantile(0.9, showcase_latency_exp_hist)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:histogram_quantiles",
+      "kind": "function",
+      "probe": "histogram_quantiles(showcase_latency_exp_hist, \"q\", 0.5, 0.9)",
+      "cerberus": "reject",
+      "reference": "reject",
+      "class": "parity-reject",
+      "cerberus_error": "promql: function histogram_quantiles is not yet supported"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:histogram_stddev",
+      "kind": "function",
+      "probe": "histogram_stddev(showcase_latency_exp_hist)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:histogram_stdvar",
+      "kind": "function",
+      "probe": "histogram_stdvar(showcase_latency_exp_hist)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:histogram_sum",
+      "kind": "function",
+      "probe": "histogram_sum(showcase_latency_exp_hist)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:hour",
+      "kind": "function",
+      "probe": "hour(up)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:idelta",
+      "kind": "function",
+      "probe": "idelta(http_server_request_duration_count[5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:increase",
+      "kind": "function",
+      "probe": "increase(http_server_request_duration_count[5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:info",
+      "kind": "function",
+      "probe": "info(http_server_request_duration_count)",
+      "cerberus": "reject",
+      "reference": "reject",
+      "class": "parity-reject",
+      "cerberus_error": "promql: function info is not yet supported"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:irate",
+      "kind": "function",
+      "probe": "irate(http_server_request_duration_count[5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:label_join",
+      "kind": "function",
+      "probe": "label_join(up, \"dst\", \",\", \"job\")",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:label_replace",
+      "kind": "function",
+      "probe": "label_replace(up, \"dst\", \"$1\", \"job\", \"(.*)\")",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:last_over_time",
+      "kind": "function",
+      "probe": "last_over_time(up[5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:ln",
+      "kind": "function",
+      "probe": "ln(up)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:log10",
+      "kind": "function",
+      "probe": "log10(up)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:log2",
+      "kind": "function",
+      "probe": "log2(up)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:mad_over_time",
+      "kind": "function",
+      "probe": "mad_over_time(up[5m])",
+      "cerberus": "reject",
+      "reference": "reject",
+      "class": "parity-reject",
+      "cerberus_error": "emit: chsql: unsupported: range function \"mad_over_time\""
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:max_over_time",
+      "kind": "function",
+      "probe": "max_over_time(up[5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:min_over_time",
+      "kind": "function",
+      "probe": "min_over_time(up[5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:minute",
+      "kind": "function",
+      "probe": "minute(up)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:month",
+      "kind": "function",
+      "probe": "month(up)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:pi",
+      "kind": "function",
+      "probe": "pi()",
+      "cerberus": "reject",
+      "reference": "accept",
+      "class": "wrong-reject",
+      "cerberus_error": "promql: function pi is not yet supported"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:predict_linear",
+      "kind": "function",
+      "probe": "predict_linear(http_server_request_duration_count[5m], 0.5)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:present_over_time",
+      "kind": "function",
+      "probe": "present_over_time(up[5m])",
+      "cerberus": "reject",
+      "reference": "accept",
+      "class": "wrong-reject",
+      "cerberus_error": "emit: chsql: unsupported: range function \"present_over_time\""
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:quantile_over_time",
+      "kind": "function",
+      "probe": "quantile_over_time(0.5, up[5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:rad",
+      "kind": "function",
+      "probe": "rad(up)",
+      "cerberus": "reject",
+      "reference": "accept",
+      "class": "wrong-reject",
+      "cerberus_error": "promql: function rad is not yet supported"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:range",
+      "kind": "function",
+      "probe": "range()",
+      "cerberus": "reject",
+      "reference": "reject",
+      "class": "parity-reject",
+      "cerberus_error": "promql: function range is not yet supported"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:rate",
+      "kind": "function",
+      "probe": "rate(http_server_request_duration_count[5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:resets",
+      "kind": "function",
+      "probe": "resets(http_server_request_duration_count[5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:round",
+      "kind": "function",
+      "probe": "round(up, 0.5)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:scalar",
+      "kind": "function",
+      "probe": "scalar(up)",
+      "cerberus": "reject",
+      "reference": "accept",
+      "class": "wrong-reject",
+      "cerberus_error": "promql: function scalar is not yet supported"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:sgn",
+      "kind": "function",
+      "probe": "sgn(up)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:sin",
+      "kind": "function",
+      "probe": "sin(up)",
+      "cerberus": "reject",
+      "reference": "accept",
+      "class": "wrong-reject",
+      "cerberus_error": "promql: function sin is not yet supported"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:sinh",
+      "kind": "function",
+      "probe": "sinh(up)",
+      "cerberus": "reject",
+      "reference": "accept",
+      "class": "wrong-reject",
+      "cerberus_error": "promql: function sinh is not yet supported"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:sort",
+      "kind": "function",
+      "probe": "sort(up)",
+      "cerberus": "reject",
+      "reference": "accept",
+      "class": "wrong-reject",
+      "cerberus_error": "promql: function sort is not yet supported"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:sort_by_label",
+      "kind": "function",
+      "probe": "sort_by_label(up, \"s\")",
+      "cerberus": "reject",
+      "reference": "reject",
+      "class": "parity-reject",
+      "cerberus_error": "promql: function sort_by_label is not yet supported"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:sort_by_label_desc",
+      "kind": "function",
+      "probe": "sort_by_label_desc(up, \"s\")",
+      "cerberus": "reject",
+      "reference": "reject",
+      "class": "parity-reject",
+      "cerberus_error": "promql: function sort_by_label_desc is not yet supported"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:sort_desc",
+      "kind": "function",
+      "probe": "sort_desc(up)",
+      "cerberus": "reject",
+      "reference": "accept",
+      "class": "wrong-reject",
+      "cerberus_error": "promql: function sort_desc is not yet supported"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:sqrt",
+      "kind": "function",
+      "probe": "sqrt(up)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:start",
+      "kind": "function",
+      "probe": "start()",
+      "cerberus": "reject",
+      "reference": "reject",
+      "class": "parity-reject",
+      "cerberus_error": "promql: function start is not yet supported"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:stddev_over_time",
+      "kind": "function",
+      "probe": "stddev_over_time(up[5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:stdvar_over_time",
+      "kind": "function",
+      "probe": "stdvar_over_time(up[5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:step",
+      "kind": "function",
+      "probe": "step()",
+      "cerberus": "reject",
+      "reference": "reject",
+      "class": "parity-reject",
+      "cerberus_error": "promql: function step is not yet supported"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:sum_over_time",
+      "kind": "function",
+      "probe": "sum_over_time(up[5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:tan",
+      "kind": "function",
+      "probe": "tan(up)",
+      "cerberus": "reject",
+      "reference": "accept",
+      "class": "wrong-reject",
+      "cerberus_error": "promql: function tan is not yet supported"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:tanh",
+      "kind": "function",
+      "probe": "tanh(up)",
+      "cerberus": "reject",
+      "reference": "accept",
+      "class": "wrong-reject",
+      "cerberus_error": "promql: function tanh is not yet supported"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:time",
+      "kind": "function",
+      "probe": "time()",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:timestamp",
+      "kind": "function",
+      "probe": "timestamp(up)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:ts_of_first_over_time",
+      "kind": "function",
+      "probe": "ts_of_first_over_time(up[5m])",
+      "cerberus": "reject",
+      "reference": "reject",
+      "class": "parity-reject",
+      "cerberus_error": "emit: chsql: unsupported: range function \"ts_of_first_over_time\""
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:ts_of_last_over_time",
+      "kind": "function",
+      "probe": "ts_of_last_over_time(up[5m])",
+      "cerberus": "reject",
+      "reference": "reject",
+      "class": "parity-reject",
+      "cerberus_error": "emit: chsql: unsupported: range function \"ts_of_last_over_time\""
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:ts_of_max_over_time",
+      "kind": "function",
+      "probe": "ts_of_max_over_time(up[5m])",
+      "cerberus": "reject",
+      "reference": "reject",
+      "class": "parity-reject",
+      "cerberus_error": "emit: chsql: unsupported: range function \"ts_of_max_over_time\""
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:ts_of_min_over_time",
+      "kind": "function",
+      "probe": "ts_of_min_over_time(up[5m])",
+      "cerberus": "reject",
+      "reference": "reject",
+      "class": "parity-reject",
+      "cerberus_error": "emit: chsql: unsupported: range function \"ts_of_min_over_time\""
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:vector",
+      "kind": "function",
+      "probe": "vector(0.5)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "fn:year",
+      "kind": "function",
+      "probe": "year(up)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "mod:at",
+      "kind": "modifier",
+      "probe": "up @ 0",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "mod:at_end",
+      "kind": "modifier",
+      "probe": "up @ end()",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "mod:at_start",
+      "kind": "modifier",
+      "probe": "up @ start()",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "mod:offset",
+      "kind": "modifier",
+      "probe": "up offset 5m",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "op:add",
+      "kind": "binary-op",
+      "probe": "up + up",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "op:and",
+      "kind": "binary-op",
+      "probe": "up and up",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "op:atan2",
+      "kind": "binary-op",
+      "probe": "up atan2 up",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "op:div",
+      "kind": "binary-op",
+      "probe": "up / up",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "op:eql",
+      "kind": "binary-op",
+      "probe": "up == up",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "op:gte",
+      "kind": "binary-op",
+      "probe": "up \u003e= up",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "op:gtr",
+      "kind": "binary-op",
+      "probe": "up \u003e up",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "op:lss",
+      "kind": "binary-op",
+      "probe": "up \u003c up",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "op:lte",
+      "kind": "binary-op",
+      "probe": "up \u003c= up",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "op:mod",
+      "kind": "binary-op",
+      "probe": "up % up",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "op:mul",
+      "kind": "binary-op",
+      "probe": "up * up",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "op:neq",
+      "kind": "binary-op",
+      "probe": "up != up",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "op:or",
+      "kind": "binary-op",
+      "probe": "up or up",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "op:pow",
+      "kind": "binary-op",
+      "probe": "up ^ up",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "op:sub",
+      "kind": "binary-op",
+      "probe": "up - up",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "promql",
+      "symbol": "op:unless",
+      "kind": "binary-op",
+      "probe": "up unless up",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "conv:bytes",
+      "kind": "conv-fn",
+      "probe": "sum_over_time({service_name=\"gateway\"} | logfmt | unwrap bytes(size) [5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "conv:duration",
+      "kind": "conv-fn",
+      "probe": "sum_over_time({service_name=\"gateway\"} | logfmt | unwrap duration(took) [5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "conv:duration_seconds",
+      "kind": "conv-fn",
+      "probe": "sum_over_time({service_name=\"gateway\"} | logfmt | unwrap duration_seconds(took) [5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "label:decolorize",
+      "kind": "label-fn",
+      "probe": "{service_name=\"painter\"} | decolorize",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "label:drop",
+      "kind": "label-fn",
+      "probe": "{service_name=\"gateway\"} | logfmt | drop level",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "label:keep",
+      "kind": "label-fn",
+      "probe": "{service_name=\"gateway\"} | logfmt | keep level",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "label:label_format",
+      "kind": "label-fn",
+      "probe": "{service_name=\"gateway\"} | logfmt | label_format lvl=\"{{.level}}\"",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "label:label_replace",
+      "kind": "label-fn",
+      "probe": "label_replace(count_over_time({service_name=\"gateway\"}[5m]), \"dst\", \"$1\", \"service_name\", \"(.*)\")",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "label:line_format",
+      "kind": "label-fn",
+      "probe": "{service_name=\"gateway\"} | line_format \"{{.status}}\"",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "labelfilter:ip",
+      "kind": "label-filter",
+      "probe": "{service_name=\"gateway\"} | logfmt | remote_addr = ip(\"192.168.0.0/16\")",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "labelfilter:match",
+      "kind": "label-filter",
+      "probe": "{service_name=\"gateway\"} | logfmt | level = \"error\"",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "linefilter:eq",
+      "kind": "line-filter",
+      "probe": "{service_name=\"gateway\"} |= \"error\"",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "linefilter:neq",
+      "kind": "line-filter",
+      "probe": "{service_name=\"gateway\"} != \"error\"",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "linefilter:nre",
+      "kind": "line-filter",
+      "probe": "{service_name=\"gateway\"} !~ \"err.*\"",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "linefilter:re",
+      "kind": "line-filter",
+      "probe": "{service_name=\"gateway\"} |~ \"err.*\"",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "op:!=",
+      "kind": "binary-op",
+      "probe": "count_over_time({service_name=\"gateway\"}[5m]) != count_over_time({service_name=\"gateway\"}[5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "op:%",
+      "kind": "binary-op",
+      "probe": "count_over_time({service_name=\"gateway\"}[5m]) % count_over_time({service_name=\"gateway\"}[5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "op:*",
+      "kind": "binary-op",
+      "probe": "count_over_time({service_name=\"gateway\"}[5m]) * count_over_time({service_name=\"gateway\"}[5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "op:+",
+      "kind": "binary-op",
+      "probe": "count_over_time({service_name=\"gateway\"}[5m]) + count_over_time({service_name=\"gateway\"}[5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "op:-",
+      "kind": "binary-op",
+      "probe": "count_over_time({service_name=\"gateway\"}[5m]) - count_over_time({service_name=\"gateway\"}[5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "op:/",
+      "kind": "binary-op",
+      "probe": "count_over_time({service_name=\"gateway\"}[5m]) / count_over_time({service_name=\"gateway\"}[5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "op:\u003c",
+      "kind": "binary-op",
+      "probe": "count_over_time({service_name=\"gateway\"}[5m]) \u003c count_over_time({service_name=\"gateway\"}[5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "op:\u003c=",
+      "kind": "binary-op",
+      "probe": "count_over_time({service_name=\"gateway\"}[5m]) \u003c= count_over_time({service_name=\"gateway\"}[5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "op:==",
+      "kind": "binary-op",
+      "probe": "count_over_time({service_name=\"gateway\"}[5m]) == count_over_time({service_name=\"gateway\"}[5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "op:\u003e",
+      "kind": "binary-op",
+      "probe": "count_over_time({service_name=\"gateway\"}[5m]) \u003e count_over_time({service_name=\"gateway\"}[5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "op:\u003e=",
+      "kind": "binary-op",
+      "probe": "count_over_time({service_name=\"gateway\"}[5m]) \u003e= count_over_time({service_name=\"gateway\"}[5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "op:^",
+      "kind": "binary-op",
+      "probe": "count_over_time({service_name=\"gateway\"}[5m]) ^ count_over_time({service_name=\"gateway\"}[5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "op:and",
+      "kind": "binary-op",
+      "probe": "count_over_time({service_name=\"gateway\"}[5m]) and count_over_time({service_name=\"gateway\"}[5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "op:or",
+      "kind": "binary-op",
+      "probe": "count_over_time({service_name=\"gateway\"}[5m]) or count_over_time({service_name=\"gateway\"}[5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "op:unless",
+      "kind": "binary-op",
+      "probe": "count_over_time({service_name=\"gateway\"}[5m]) unless count_over_time({service_name=\"gateway\"}[5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "parser:json",
+      "kind": "parser-stage",
+      "probe": "{service_name=\"shop\"} | json",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "parser:logfmt",
+      "kind": "parser-stage",
+      "probe": "{service_name=\"gateway\"} | logfmt",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "parser:pattern",
+      "kind": "parser-stage",
+      "probe": "{service_name=\"proxy\"} | pattern \"\u003cmethod\u003e \u003cpath\u003e\"",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "parser:regexp",
+      "kind": "parser-stage",
+      "probe": "{service_name=\"gateway\"} | regexp \"(?P\u003clvl\u003e\\\\w+)\"",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "parser:unpack",
+      "kind": "parser-stage",
+      "probe": "{service_name=\"packer\"} | unpack",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "range:absent_over_time",
+      "kind": "range-agg",
+      "probe": "absent_over_time({service_name=\"gateway\"}[5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "range:avg_over_time",
+      "kind": "range-agg",
+      "probe": "avg_over_time({service_name=\"gateway\"} | logfmt | unwrap status [5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "range:bytes_over_time",
+      "kind": "range-agg",
+      "probe": "bytes_over_time({service_name=\"gateway\"}[5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "range:bytes_rate",
+      "kind": "range-agg",
+      "probe": "bytes_rate({service_name=\"gateway\"}[5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "range:count_over_time",
+      "kind": "range-agg",
+      "probe": "count_over_time({service_name=\"gateway\"}[5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "range:first_over_time",
+      "kind": "range-agg",
+      "probe": "first_over_time({service_name=\"gateway\"} | logfmt | unwrap status [5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "range:last_over_time",
+      "kind": "range-agg",
+      "probe": "last_over_time({service_name=\"gateway\"} | logfmt | unwrap status [5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "range:max_over_time",
+      "kind": "range-agg",
+      "probe": "max_over_time({service_name=\"gateway\"} | logfmt | unwrap status [5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "range:min_over_time",
+      "kind": "range-agg",
+      "probe": "min_over_time({service_name=\"gateway\"} | logfmt | unwrap status [5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "range:quantile_over_time",
+      "kind": "range-agg",
+      "probe": "quantile_over_time(0.9, {service_name=\"gateway\"} | logfmt | unwrap status [5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "range:rate",
+      "kind": "range-agg",
+      "probe": "rate({service_name=\"gateway\"}[5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "range:rate_counter",
+      "kind": "range-agg",
+      "probe": "rate_counter({service_name=\"gateway\"} | logfmt | unwrap status [5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "range:stddev_over_time",
+      "kind": "range-agg",
+      "probe": "stddev_over_time({service_name=\"gateway\"} | logfmt | unwrap status [5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "range:stdvar_over_time",
+      "kind": "range-agg",
+      "probe": "stdvar_over_time({service_name=\"gateway\"} | logfmt | unwrap status [5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "range:sum_over_time",
+      "kind": "range-agg",
+      "probe": "sum_over_time({service_name=\"gateway\"} | logfmt | unwrap status [5m])",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "vector:approx_topk",
+      "kind": "vector-agg",
+      "probe": "approx_topk(3, count_over_time({service_name=\"gateway\"}[5m]))",
+      "cerberus": "reject",
+      "reference": "accept",
+      "class": "wrong-reject",
+      "cerberus_error": "logql: aggregation operation \"approx_topk\" is unsupported"
+    },
+    {
+      "head": "logql",
+      "symbol": "vector:avg",
+      "kind": "vector-agg",
+      "probe": "avg(count_over_time({service_name=\"gateway\"}[5m]))",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "vector:bottomk",
+      "kind": "vector-agg",
+      "probe": "bottomk(3, count_over_time({service_name=\"gateway\"}[5m]))",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "vector:count",
+      "kind": "vector-agg",
+      "probe": "count(count_over_time({service_name=\"gateway\"}[5m]))",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "vector:max",
+      "kind": "vector-agg",
+      "probe": "max(count_over_time({service_name=\"gateway\"}[5m]))",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "vector:min",
+      "kind": "vector-agg",
+      "probe": "min(count_over_time({service_name=\"gateway\"}[5m]))",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "vector:sort",
+      "kind": "vector-agg",
+      "probe": "sort(count_over_time({service_name=\"gateway\"}[5m]))",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "vector:sort_desc",
+      "kind": "vector-agg",
+      "probe": "sort_desc(count_over_time({service_name=\"gateway\"}[5m]))",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "vector:stddev",
+      "kind": "vector-agg",
+      "probe": "stddev(count_over_time({service_name=\"gateway\"}[5m]))",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "vector:stdvar",
+      "kind": "vector-agg",
+      "probe": "stdvar(count_over_time({service_name=\"gateway\"}[5m]))",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "vector:sum",
+      "kind": "vector-agg",
+      "probe": "sum(count_over_time({service_name=\"gateway\"}[5m]))",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "logql",
+      "symbol": "vector:topk",
+      "kind": "vector-agg",
+      "probe": "topk(3, count_over_time({service_name=\"gateway\"}[5m]))",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "aggregate:avg",
+      "kind": "aggregate",
+      "probe": "{ resource.service.name = \"gateway\" } | avg(duration) \u003e 1ms",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "aggregate:count",
+      "kind": "aggregate",
+      "probe": "{ resource.service.name = \"gateway\" } | count() \u003e 0",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "aggregate:max",
+      "kind": "aggregate",
+      "probe": "{ resource.service.name = \"gateway\" } | max(duration) \u003e 1ms",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "aggregate:min",
+      "kind": "aggregate",
+      "probe": "{ resource.service.name = \"gateway\" } | min(duration) \u003e 1ms",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "aggregate:sum",
+      "kind": "aggregate",
+      "probe": "{ resource.service.name = \"gateway\" } | sum(duration) \u003e 1ms",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "intrinsic:duration",
+      "kind": "intrinsic",
+      "probe": "{ duration \u003e 1ms }",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "intrinsic:event:name",
+      "kind": "intrinsic",
+      "probe": "{ event:name = \"exception\" }",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "intrinsic:event:timeSinceStart",
+      "kind": "intrinsic",
+      "probe": "{ event:timeSinceStart \u003e 1ms }",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "intrinsic:instrumentation:name",
+      "kind": "intrinsic",
+      "probe": "{ instrumentation:name = \"showcase-instrumentation\" }",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "intrinsic:instrumentation:version",
+      "kind": "intrinsic",
+      "probe": "{ instrumentation:version = \"1.2.3\" }",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "intrinsic:kind",
+      "kind": "intrinsic",
+      "probe": "{ kind = server }",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "intrinsic:link:spanID",
+      "kind": "intrinsic",
+      "probe": "{ link:spanID != \"\" }",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "intrinsic:link:traceID",
+      "kind": "intrinsic",
+      "probe": "{ link:traceID != \"\" }",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "intrinsic:name",
+      "kind": "intrinsic",
+      "probe": "{ name = \"charge\" }",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "intrinsic:nestedSetLeft",
+      "kind": "intrinsic",
+      "probe": "{ nestedSetLeft \u003e 0 }",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "intrinsic:nestedSetParent",
+      "kind": "intrinsic",
+      "probe": "{ nestedSetParent \u003e 0 }",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "intrinsic:nestedSetRight",
+      "kind": "intrinsic",
+      "probe": "{ nestedSetRight \u003e 0 }",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "intrinsic:rootName",
+      "kind": "intrinsic",
+      "probe": "{ rootName = \"request\" }",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "intrinsic:rootServiceName",
+      "kind": "intrinsic",
+      "probe": "{ rootServiceName = \"gateway\" }",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "intrinsic:span:childCount",
+      "kind": "intrinsic",
+      "probe": "{ span:childCount \u003e 0 }",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "intrinsic:span:duration",
+      "kind": "intrinsic",
+      "probe": "{ span:duration \u003e 1ms }",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "intrinsic:span:id",
+      "kind": "intrinsic",
+      "probe": "{ span:id != \"\" }",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "intrinsic:span:kind",
+      "kind": "intrinsic",
+      "probe": "{ span:kind = server }",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "intrinsic:span:name",
+      "kind": "intrinsic",
+      "probe": "{ span:name = \"charge\" }",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "intrinsic:span:parentID",
+      "kind": "intrinsic",
+      "probe": "{ span:parentID != \"\" }",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "intrinsic:span:status",
+      "kind": "intrinsic",
+      "probe": "{ span:status = error }",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "intrinsic:span:statusMessage",
+      "kind": "intrinsic",
+      "probe": "{ span:statusMessage = \"card declined\" }",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "intrinsic:status",
+      "kind": "intrinsic",
+      "probe": "{ status = error }",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "intrinsic:statusMessage",
+      "kind": "intrinsic",
+      "probe": "{ statusMessage = \"card declined\" }",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "intrinsic:trace:duration",
+      "kind": "intrinsic",
+      "probe": "{ trace:duration \u003e 1ms }",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "intrinsic:trace:id",
+      "kind": "intrinsic",
+      "probe": "{ trace:id != \"\" }",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "intrinsic:trace:rootName",
+      "kind": "intrinsic",
+      "probe": "{ trace:rootName = \"request\" }",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "intrinsic:trace:rootService",
+      "kind": "intrinsic",
+      "probe": "{ trace:rootService = \"gateway\" }",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "intrinsic:traceDuration",
+      "kind": "intrinsic",
+      "probe": "{ traceDuration \u003e 1ms }",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "metric:avg_over_time",
+      "kind": "metrics-op",
+      "probe": "{ resource.service.name = \"gateway\" } | avg_over_time(duration)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "metric:bottomk",
+      "kind": "metrics-op",
+      "probe": "{ resource.service.name = \"gateway\" } | rate() by (name) | bottomk(3)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "metric:compare",
+      "kind": "metrics-op",
+      "probe": "{ resource.service.name = \"gateway\" } | compare({ status = error })",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "metric:count_over_time",
+      "kind": "metrics-op",
+      "probe": "{ resource.service.name = \"gateway\" } | count_over_time()",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "metric:histogram_over_time",
+      "kind": "metrics-op",
+      "probe": "{ resource.service.name = \"gateway\" } | histogram_over_time(duration)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "metric:max_over_time",
+      "kind": "metrics-op",
+      "probe": "{ resource.service.name = \"gateway\" } | max_over_time(duration)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "metric:min_over_time",
+      "kind": "metrics-op",
+      "probe": "{ resource.service.name = \"gateway\" } | min_over_time(duration)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "metric:quantile_over_time",
+      "kind": "metrics-op",
+      "probe": "{ resource.service.name = \"gateway\" } | quantile_over_time(duration, 0.9)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "metric:rate",
+      "kind": "metrics-op",
+      "probe": "{ resource.service.name = \"gateway\" } | rate()",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "metric:sum_over_time",
+      "kind": "metrics-op",
+      "probe": "{ resource.service.name = \"gateway\" } | sum_over_time(duration)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    },
+    {
+      "head": "traceql",
+      "symbol": "metric:topk",
+      "kind": "metrics-op",
+      "probe": "{ resource.service.name = \"gateway\" } | rate() by (name) | topk(3)",
+      "cerberus": "accept",
+      "reference": "accept",
+      "class": "parity-accept"
+    }
+  ]
+}

--- a/test/surface-parity/inventory_test.go
+++ b/test/surface-parity/inventory_test.go
@@ -1,0 +1,178 @@
+package surfaceparity
+
+import (
+	"os"
+	"sort"
+	"strings"
+	"testing"
+)
+
+const inventoryPath = "inventory.json"
+
+// TestInventoryIsRegenerable re-probes the three parser symbol tables,
+// re-runs the cerberus + reference verdicts, and diffs the regenerated
+// inventory byte-for-byte against the checked-in JSON. Set
+// CERBERUS_UPDATE_INVENTORY=1 to rewrite the artifact (the same
+// update-via-env convention as test/rejection-parity + test/inventory).
+// Because every field is mechanically derived, any drift — a parser
+// symbol added/removed upstream, a cerberus lowering that started or
+// stopped accepting a symbol — moves the artifact, and that move is a
+// reviewable diff.
+func TestInventoryIsRegenerable(t *testing.T) {
+	t.Parallel()
+
+	inv, err := Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	want, err := MarshalInventory(inv)
+	if err != nil {
+		t.Fatalf("MarshalInventory: %v", err)
+	}
+
+	if os.Getenv("CERBERUS_UPDATE_INVENTORY") != "" {
+		if err := os.WriteFile(inventoryPath, want, 0o644); err != nil {
+			t.Fatalf("write %s: %v", inventoryPath, err)
+		}
+		t.Logf("rewrote %s (%d entries)", inventoryPath, len(inv.Entries))
+		return
+	}
+
+	got, err := os.ReadFile(inventoryPath)
+	if err != nil {
+		t.Fatalf("read %s (rerun with CERBERUS_UPDATE_INVENTORY=1 to generate): %v", inventoryPath, err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("%s is stale relative to the parser symbol tables / cerberus lowering — "+
+			"rerun with CERBERUS_UPDATE_INVENTORY=1, review the diff, and commit it.\n"+
+			"--- want %d bytes, got %d bytes", inventoryPath, len(want), len(got))
+	}
+}
+
+// TestWrongRejectionsAreRatcheted pins the current wrong-reject set per
+// head. The checked-in inventory IS the pin: TestInventoryIsRegenerable
+// already fails on any drift, so this test asserts the higher-level
+// invariant the ratchet protects — the wrong-reject set may only
+// SHRINK relative to the committed ledger, never grow. A regression
+// (a symbol that flips from accept to wrong-reject) and a fix (a symbol
+// that leaves the wrong-reject set) both surface here against the
+// checked-in inventory, forcing a deliberate regeneration + review.
+func TestWrongRejectionsAreRatcheted(t *testing.T) {
+	t.Parallel()
+	assertRatchet(t, ClassWrongReject)
+}
+
+// TestWrongAcceptsAreRatcheted does the same for wrong-accepts — symbols
+// cerberus accepts that the reference rejects, a correctness risk.
+func TestWrongAcceptsAreRatcheted(t *testing.T) {
+	t.Parallel()
+	assertRatchet(t, ClassWrongAccept)
+}
+
+// assertRatchet re-probes live and compares the live set of `class`
+// symbols against the committed inventory's set, per head. New symbols
+// in the live set that aren't pinned fail (a regression or a new
+// upstream grammar symbol cerberus doesn't handle); pinned symbols
+// missing from the live set fail too (a fix that wasn't regenerated).
+// Either direction demands CERBERUS_UPDATE_INVENTORY=1 + review.
+func assertRatchet(t *testing.T, class Classification) {
+	t.Helper()
+
+	pinned, err := LoadInventory(inventoryPath)
+	if err != nil {
+		t.Fatalf("load %s (rerun TestInventoryIsRegenerable with CERBERUS_UPDATE_INVENTORY=1 to generate): %v", inventoryPath, err)
+	}
+	live, err := Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	for _, head := range []string{"promql", "logql", "traceql"} {
+		pinnedSet := classSet(pinned, head, class)
+		liveSet := classSet(live, head, class)
+
+		var appeared, healed []string
+		for sym := range liveSet {
+			if !pinnedSet[sym] {
+				appeared = append(appeared, sym)
+			}
+		}
+		for sym := range pinnedSet {
+			if !liveSet[sym] {
+				healed = append(healed, sym)
+			}
+		}
+		sort.Strings(appeared)
+		sort.Strings(healed)
+
+		if len(appeared) > 0 {
+			t.Errorf("%s %s: NEW symbols not in the committed inventory: %s\n"+
+				"a symbol regressed into %s — fix the cerberus lowering, or (if intended) "+
+				"rerun with CERBERUS_UPDATE_INVENTORY=1 and justify the diff in review",
+				head, class, strings.Join(appeared, ", "), class)
+		}
+		if len(healed) > 0 {
+			t.Errorf("%s %s: committed symbols no longer present live: %s\n"+
+				"a burndown fixed these — rerun with CERBERUS_UPDATE_INVENTORY=1 to re-pin the ledger",
+				head, class, strings.Join(healed, ", "))
+		}
+	}
+}
+
+func classSet(inv *Inventory, head string, class Classification) map[string]bool {
+	out := map[string]bool{}
+	for _, e := range inv.Entries {
+		if e.Head == head && e.Class == class && !e.ReferenceUnresolved {
+			out[e.Symbol] = true
+		}
+	}
+	return out
+}
+
+// TestInventoryShapeInvariants pins structural invariants that hold
+// regardless of which symbols are wrong-rejected: every entry carries a
+// non-empty probe + a valid head/verdict/class, no duplicate (head,
+// symbol) keys, and the class is consistent with the two verdicts.
+func TestInventoryShapeInvariants(t *testing.T) {
+	t.Parallel()
+
+	inv, err := LoadInventory(inventoryPath)
+	if err != nil {
+		t.Fatalf("load %s: %v", inventoryPath, err)
+	}
+	if len(inv.Entries) == 0 {
+		t.Fatalf("%s is empty", inventoryPath)
+	}
+	seen := map[string]bool{}
+	for _, e := range inv.Entries {
+		key := e.Head + "/" + e.Symbol
+		if seen[key] {
+			t.Errorf("duplicate entry %s", key)
+		}
+		seen[key] = true
+
+		switch e.Head {
+		case "promql", "logql", "traceql":
+		default:
+			t.Errorf("entry %s: unknown head %q", key, e.Head)
+		}
+		if strings.TrimSpace(e.Probe) == "" {
+			t.Errorf("entry %s: empty probe", key)
+		}
+		if e.Cerberus != VerdictAccept && e.Cerberus != VerdictReject {
+			t.Errorf("entry %s: invalid cerberus verdict %q", key, e.Cerberus)
+		}
+		if e.Reference != VerdictAccept && e.Reference != VerdictReject {
+			t.Errorf("entry %s: invalid reference verdict %q", key, e.Reference)
+		}
+		if want := classify(e.Cerberus, e.Reference); e.Class != want {
+			t.Errorf("entry %s: class %q inconsistent with verdicts (cerberus=%s reference=%s → %s)",
+				key, e.Class, e.Cerberus, e.Reference, want)
+		}
+		// A wrong-reject entry must carry the cerberus error it
+		// rejected with — that's the concrete failure a burndown fixes.
+		if e.Class == ClassWrongReject && strings.TrimSpace(e.CerberusError) == "" {
+			t.Errorf("entry %s: wrong-reject carries no cerberus_error", key)
+		}
+	}
+}

--- a/test/surface-parity/logql.go
+++ b/test/surface-parity/logql.go
@@ -1,0 +1,168 @@
+package surfaceparity
+
+import (
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+)
+
+// Domain-aware LogQL operands from the showcase seed
+// (test/e2e/seed/cmd/seed/showcase_logql.go). The gateway stream is
+// logfmt-formatted with real extractable fields; using it keeps parser
+// stages (logfmt/json/...) and unwrap fed structured input.
+const (
+	// logSelector selects a real seeded log stream.
+	logSelector = `{service_name="gateway"}`
+	// logUnwrapField is a real numeric field extractable from the
+	// gateway logfmt stream, suitable for unwrap + range aggregations.
+	logUnwrapField = "status"
+	// logShopSelector selects the JSON-formatted shop stream.
+	logShopSelector = `{service_name="shop"}`
+)
+
+// logProbe is one LogQL grammar symbol + its canonical probe. Probes
+// are full pipeline expressions (a stream selector is mandatory in
+// LogQL), shaped per op family.
+type logProbe struct {
+	symbol string
+	kind   string
+	probe  string
+}
+
+// logProbes enumerates the LogQL Op* surface — range aggregations,
+// vector aggregations, parser stages, conversion/label functions, line
+// + label filters, and binary ops — each with a domain-aware probe.
+// Internal/sharding-only ops (the __…__ -prefixed consts that have no
+// LogQL surface) are deliberately excluded: they are not part of the
+// accepted grammar, so they carry no parity meaning.
+var logProbes = []logProbe{
+	// Range aggregations over a log range (no unwrap).
+	{"range:" + syntax.OpRangeTypeCount, "range-agg", `count_over_time(` + logSelector + `[5m])`},
+	{"range:" + syntax.OpRangeTypeRate, "range-agg", `rate(` + logSelector + `[5m])`},
+	{"range:" + syntax.OpRangeTypeBytes, "range-agg", `bytes_over_time(` + logSelector + `[5m])`},
+	{"range:" + syntax.OpRangeTypeBytesRate, "range-agg", `bytes_rate(` + logSelector + `[5m])`},
+	{"range:" + syntax.OpRangeTypeAbsent, "range-agg", `absent_over_time(` + logSelector + `[5m])`},
+	// Range aggregations requiring an unwrap (numeric sample stream).
+	{"range:" + syntax.OpRangeTypeAvg, "range-agg", unwrapRange("avg_over_time")},
+	{"range:" + syntax.OpRangeTypeSum, "range-agg", unwrapRange("sum_over_time")},
+	{"range:" + syntax.OpRangeTypeMin, "range-agg", unwrapRange("min_over_time")},
+	{"range:" + syntax.OpRangeTypeMax, "range-agg", unwrapRange("max_over_time")},
+	{"range:" + syntax.OpRangeTypeStdvar, "range-agg", unwrapRange("stdvar_over_time")},
+	{"range:" + syntax.OpRangeTypeStddev, "range-agg", unwrapRange("stddev_over_time")},
+	{"range:" + syntax.OpRangeTypeQuantile, "range-agg", `quantile_over_time(0.9, ` + logSelector + ` | logfmt | unwrap ` + logUnwrapField + ` [5m])`},
+	{"range:" + syntax.OpRangeTypeFirst, "range-agg", unwrapRange("first_over_time")},
+	{"range:" + syntax.OpRangeTypeLast, "range-agg", unwrapRange("last_over_time")},
+	{"range:" + syntax.OpRangeTypeRateCounter, "range-agg", `rate_counter(` + logSelector + ` | logfmt | unwrap ` + logUnwrapField + ` [5m])`},
+
+	// Vector aggregations over a range-aggregation result.
+	{"vector:" + syntax.OpTypeSum, "vector-agg", vecAgg("sum")},
+	{"vector:" + syntax.OpTypeAvg, "vector-agg", vecAgg("avg")},
+	{"vector:" + syntax.OpTypeMax, "vector-agg", vecAgg("max")},
+	{"vector:" + syntax.OpTypeMin, "vector-agg", vecAgg("min")},
+	{"vector:" + syntax.OpTypeCount, "vector-agg", vecAgg("count")},
+	{"vector:" + syntax.OpTypeStddev, "vector-agg", vecAgg("stddev")},
+	{"vector:" + syntax.OpTypeStdvar, "vector-agg", vecAgg("stdvar")},
+	{"vector:" + syntax.OpTypeBottomK, "vector-agg", `bottomk(3, ` + rangeBody() + `)`},
+	{"vector:" + syntax.OpTypeTopK, "vector-agg", `topk(3, ` + rangeBody() + `)`},
+	{"vector:" + syntax.OpTypeSort, "vector-agg", `sort(` + rangeBody() + `)`},
+	{"vector:" + syntax.OpTypeSortDesc, "vector-agg", `sort_desc(` + rangeBody() + `)`},
+	{"vector:" + syntax.OpTypeApproxTopK, "vector-agg", `approx_topk(3, ` + rangeBody() + `)`},
+
+	// Parser stages.
+	{"parser:" + syntax.OpParserTypeJSON, "parser-stage", logShopSelector + ` | json`},
+	{"parser:" + syntax.OpParserTypeLogfmt, "parser-stage", logSelector + ` | logfmt`},
+	{"parser:" + syntax.OpParserTypeRegexp, "parser-stage", logSelector + ` | regexp "(?P<lvl>\\w+)"`},
+	{"parser:" + syntax.OpParserTypeUnpack, "parser-stage", `{service_name="packer"} | unpack`},
+	{"parser:" + syntax.OpParserTypePattern, "parser-stage", `{service_name="proxy"} | pattern "<method> <path>"`},
+
+	// Conversion functions (in an unwrap position).
+	{"conv:" + syntax.OpConvBytes, "conv-fn", `sum_over_time(` + logSelector + ` | logfmt | unwrap bytes(size) [5m])`},
+	{"conv:" + syntax.OpConvDuration, "conv-fn", `sum_over_time(` + logSelector + ` | logfmt | unwrap duration(took) [5m])`},
+	{"conv:" + syntax.OpConvDurationSeconds, "conv-fn", `sum_over_time(` + logSelector + ` | logfmt | unwrap duration_seconds(took) [5m])`},
+
+	// Label / line functions + label mutators.
+	{"label:" + syntax.OpFmtLine, "label-fn", logSelector + ` | line_format "{{.status}}"`},
+	{"label:" + syntax.OpFmtLabel, "label-fn", logSelector + ` | logfmt | label_format lvl="{{.level}}"`},
+	{"label:" + syntax.OpDrop, "label-fn", logSelector + ` | logfmt | drop level`},
+	{"label:" + syntax.OpKeep, "label-fn", logSelector + ` | logfmt | keep level`},
+	{"label:" + syntax.OpDecolorize, "label-fn", `{service_name="painter"} | decolorize`},
+
+	// Line filters.
+	{"linefilter:eq", "line-filter", logSelector + ` |= "error"`},
+	{"linefilter:neq", "line-filter", logSelector + ` != "error"`},
+	{"linefilter:re", "line-filter", logSelector + ` |~ "err.*"`},
+	{"linefilter:nre", "line-filter", logSelector + ` !~ "err.*"`},
+
+	// Label filters.
+	{"labelfilter:match", "label-filter", logSelector + ` | logfmt | level = "error"`},
+	{"labelfilter:ip", "label-filter", logSelector + ` | logfmt | remote_addr = ip("192.168.0.0/16")`},
+
+	// Binary ops between two metric queries.
+	{"op:" + syntax.OpTypeAdd, "binary-op", binOp("+")},
+	{"op:" + syntax.OpTypeSub, "binary-op", binOp("-")},
+	{"op:" + syntax.OpTypeMul, "binary-op", binOp("*")},
+	{"op:" + syntax.OpTypeDiv, "binary-op", binOp("/")},
+	{"op:" + syntax.OpTypeMod, "binary-op", binOp("%")},
+	{"op:" + syntax.OpTypePow, "binary-op", binOp("^")},
+	{"op:" + syntax.OpTypeCmpEQ, "binary-op", binOp("==")},
+	{"op:" + syntax.OpTypeNEQ, "binary-op", binOp("!=")},
+	{"op:" + syntax.OpTypeGT, "binary-op", binOp(">")},
+	{"op:" + syntax.OpTypeGTE, "binary-op", binOp(">=")},
+	{"op:" + syntax.OpTypeLT, "binary-op", binOp("<")},
+	{"op:" + syntax.OpTypeLTE, "binary-op", binOp("<=")},
+	{"op:" + syntax.OpTypeOr, "binary-op", setOp("or")},
+	{"op:" + syntax.OpTypeAnd, "binary-op", setOp("and")},
+	{"op:" + syntax.OpTypeUnless, "binary-op", setOp("unless")},
+
+	// label_replace function.
+	{"label:" + syntax.OpLabelReplace, "label-fn", `label_replace(` + rangeBody() + `, "dst", "$1", "service_name", "(.*)")`},
+}
+
+func unwrapRange(fn string) string {
+	return fn + `(` + logSelector + ` | logfmt | unwrap ` + logUnwrapField + ` [5m])`
+}
+
+func rangeBody() string {
+	return `count_over_time(` + logSelector + `[5m])`
+}
+
+func vecAgg(fn string) string {
+	return fn + `(` + rangeBody() + `)`
+}
+
+func binOp(op string) string {
+	return rangeBody() + ` ` + op + ` ` + rangeBody()
+}
+
+func setOp(op string) string {
+	return rangeBody() + ` ` + op + ` ` + rangeBody()
+}
+
+// referenceVerdictLogQL models reference Loki acceptance: the wire path
+// accepts exactly what syntax.ParseExpr (parse + validate) accepts. We
+// run that gate in-process — the LIGHT path, no compat container.
+func referenceVerdictLogQL(query string) Verdict {
+	if _, err := syntax.ParseExpr(query); err != nil {
+		return VerdictReject
+	}
+	return VerdictAccept
+}
+
+// probeLogQL enumerates the LogQL Op* surface and classifies each
+// symbol against cerberus + the in-process reference oracle.
+func probeLogQL() ([]Entry, error) {
+	var entries []Entry
+	for _, p := range logProbes {
+		cv, cerr := cerberusVerdictLogQL(p.probe)
+		ref := referenceVerdictLogQL(p.probe)
+		entries = append(entries, Entry{
+			Head:          "logql",
+			Symbol:        p.symbol,
+			Kind:          p.kind,
+			Probe:         p.probe,
+			Cerberus:      cv,
+			Reference:     ref,
+			Class:         classify(cv, ref),
+			CerberusError: cerr,
+		})
+	}
+	return entries, nil
+}

--- a/test/surface-parity/promql.go
+++ b/test/surface-parity/promql.go
@@ -1,0 +1,296 @@
+package surfaceparity
+
+import (
+	"fmt"
+	"sort"
+
+	promparser "github.com/prometheus/prometheus/promql/parser"
+)
+
+// Domain-aware probe operands drawn from the showcase seed
+// (test/e2e/seed/cmd/seed/main.go). Using real metric names + a real
+// label keeps the probe in the schema's accepted shape so a wrong arg
+// type/domain doesn't produce a false wrong-reject (the prototype
+// mis-flagged histogram_avg(up) by feeding a gauge to a histogram fn).
+const (
+	// promGauge is a real instantaneous gauge metric.
+	promGauge = "up"
+	// promCounter is a real monotonic-sum (counter) metric.
+	promCounter = "http_server_request_duration_count"
+	// promExpHist is a real native exponential-histogram metric — the
+	// correct input for histogram_quantile / histogram_avg /
+	// histogram_count / histogram_sum / histogram_stddev /
+	// histogram_stdvar / histogram_fraction.
+	promExpHist = "showcase_latency_exp_hist"
+	// promLabel is a real label present on the seed metrics.
+	promLabel = "job"
+)
+
+// promQLFunctionProbe synthesizes a canonical, type-and-domain-aware
+// call for a PromQL function given its arg-type signature. The aim is a
+// query that is well-typed for the reference parser AND fed the right
+// metric family, so the only axis under test is whether cerberus lowers
+// the symbol — not whether the probe is mistyped.
+func promQLFunctionProbe(fn *promparser.Function) string {
+	name := fn.Name
+	// Histogram-family value functions need a native histogram vector.
+	switch name {
+	case "histogram_count", "histogram_sum", "histogram_avg",
+		"histogram_stddev", "histogram_stdvar":
+		return fmt.Sprintf("%s(%s)", name, promExpHist)
+	case "histogram_quantile":
+		return fmt.Sprintf("histogram_quantile(0.9, %s)", promExpHist)
+	case "histogram_quantiles":
+		// Signature: (Vector, String, Scalar, Scalar...) — the input
+		// histogram vector first, then the output-label name, then the
+		// requested quantiles.
+		return fmt.Sprintf("histogram_quantiles(%s, \"q\", 0.5, 0.9)", promExpHist)
+	case "histogram_fraction":
+		return fmt.Sprintf("histogram_fraction(0, 1, %s)", promExpHist)
+	}
+	// label_join / label_replace have fixed, irregular signatures.
+	switch name {
+	case "label_join":
+		return fmt.Sprintf("label_join(%s, \"dst\", \",\", \"%s\")", promGauge, promLabel)
+	case "label_replace":
+		return fmt.Sprintf("label_replace(%s, \"dst\", \"$1\", \"%s\", \"(.*)\")", promGauge, promLabel)
+	}
+	// info takes a vector + optional label-matcher set.
+	if name == "info" {
+		return fmt.Sprintf("info(%s)", promCounter)
+	}
+	// Synthesize positionally from the declared arg types. Counters are
+	// fed to rate-shaped range functions; ranges become [5m] matrices.
+	// We emit exactly len(ArgTypes) args (the maximal *required* form):
+	// for a Variadic function the trailing arg(s) are optional, so the
+	// full ArgTypes list is always within the parser's "at most N
+	// argument(s)" bound — appending a synthetic extra variadic arg
+	// would over-shoot it and produce a parse error (a probe-synthesis
+	// false positive). Functions whose variadic genuinely takes more
+	// (label_join) carry hand-written probes above.
+	args := make([]string, 0, len(fn.ArgTypes))
+	for i, at := range fn.ArgTypes {
+		args = append(args, promArgFor(name, at, i))
+	}
+	if len(args) == 0 {
+		return fmt.Sprintf("%s()", name)
+	}
+	return fmt.Sprintf("%s(%s)", name, joinArgs(args))
+}
+
+// promArgFor produces one argument literal of the requested value type.
+// Matrix args use the counter metric for rate-shaped fns and the gauge
+// otherwise; vector args use the gauge; scalars/strings use literals.
+func promArgFor(fn string, at promparser.ValueType, idx int) string {
+	switch at {
+	case promparser.ValueTypeMatrix:
+		base := promGauge
+		if rateShaped(fn) {
+			base = promCounter
+		}
+		return base + "[5m]"
+	case promparser.ValueTypeVector:
+		return promGauge
+	case promparser.ValueTypeScalar:
+		// A scalar in (0,1) is well-typed everywhere a scalar arg
+		// appears here AND satisfies the domain constraints that
+		// otherwise reject the probe: clamp/round bounds, quantile
+		// levels, and the double_exponential_smoothing smoothing /
+		// trend factors (which must be strictly in (0,1)).
+		return "0.5"
+	case promparser.ValueTypeString:
+		return "\"s\""
+	default:
+		return "1"
+	}
+}
+
+// rateShaped reports whether a range function expects a counter (so the
+// probe feeds the monotonic-sum metric rather than the gauge).
+func rateShaped(fn string) bool {
+	switch fn {
+	case "rate", "irate", "increase", "delta", "idelta", "deriv",
+		"resets", "changes", "predict_linear", "double_exponential_smoothing":
+		return true
+	}
+	return false
+}
+
+func joinArgs(args []string) string {
+	out := ""
+	for i, a := range args {
+		if i > 0 {
+			out += ", "
+		}
+		out += a
+	}
+	return out
+}
+
+// promQLAggregatorProbe synthesizes a canonical aggregation expression.
+// Parameterised aggregators (topk/bottomk/quantile/count_values/limitk/
+// limit_ratio) carry their required scalar/string parameter.
+func promQLAggregatorProbe(op string) string {
+	switch op {
+	case "topk", "bottomk", "limitk":
+		return fmt.Sprintf("%s(3, %s)", op, promGauge)
+	case "limit_ratio":
+		return fmt.Sprintf("limit_ratio(0.5, %s)", promGauge)
+	case "quantile":
+		return fmt.Sprintf("quantile(0.9, %s)", promGauge)
+	case "count_values":
+		return fmt.Sprintf("count_values(\"v\", %s)", promGauge)
+	default:
+		return fmt.Sprintf("%s(%s)", op, promGauge)
+	}
+}
+
+// promAggregators is the aggregation-op set with the reference posture.
+// limitk / limit_ratio are experimental (parser.ItemType.IsExperimental-
+// Aggregator) — the reference gates them off by default exactly like
+// experimental functions.
+var promAggregators = []struct {
+	op           string
+	experimental bool
+}{
+	{"sum", false},
+	{"avg", false},
+	{"count", false},
+	{"min", false},
+	{"max", false},
+	{"group", false},
+	{"stddev", false},
+	{"stdvar", false},
+	{"topk", false},
+	{"bottomk", false},
+	{"count_values", false},
+	{"quantile", false},
+	{"limitk", true},
+	{"limit_ratio", true},
+}
+
+// promBinaryOps is the binary-operator set. Each probe applies the op
+// between two real vectors (or, for atan2, the trig binary op). All are
+// reference-accepted (no experimental binary ops in v3.x).
+var promBinaryOps = []struct {
+	sym   string
+	probe string
+}{
+	{"add", promGauge + " + " + promGauge},
+	{"sub", promGauge + " - " + promGauge},
+	{"mul", promGauge + " * " + promGauge},
+	{"div", promGauge + " / " + promGauge},
+	{"mod", promGauge + " % " + promGauge},
+	{"pow", promGauge + " ^ " + promGauge},
+	{"eql", promGauge + " == " + promGauge},
+	{"neq", promGauge + " != " + promGauge},
+	{"gtr", promGauge + " > " + promGauge},
+	{"lss", promGauge + " < " + promGauge},
+	{"gte", promGauge + " >= " + promGauge},
+	{"lte", promGauge + " <= " + promGauge},
+	{"and", promGauge + " and " + promGauge},
+	{"or", promGauge + " or " + promGauge},
+	{"unless", promGauge + " unless " + promGauge},
+	{"atan2", promGauge + " atan2 " + promGauge},
+}
+
+// promModifiers is the @ / offset modifier set. Both are core PromQL
+// (reference-accepted).
+var promModifiers = []struct {
+	sym   string
+	probe string
+}{
+	{"offset", promGauge + " offset 5m"},
+	{"at", promGauge + " @ 0"},
+	{"at_start", promGauge + " @ start()"},
+	{"at_end", promGauge + " @ end()"},
+}
+
+// probePromQL enumerates the PromQL parser symbol table, synthesizes a
+// domain-aware probe per symbol, runs the cerberus verdict, models the
+// reference verdict from the parser's experimental flags, and
+// classifies each.
+func probePromQL() ([]Entry, error) {
+	var entries []Entry
+
+	// Functions — parser.Functions is the authoritative map; its
+	// Experimental flag is the reference oracle.
+	names := make([]string, 0, len(promparser.Functions))
+	for name := range promparser.Functions {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		fn := promparser.Functions[name]
+		probe := promQLFunctionProbe(fn)
+		cv, cerr := cerberusVerdictPromQL(probe)
+		ref := VerdictAccept
+		if fn.Experimental {
+			ref = VerdictReject
+		}
+		entries = append(entries, Entry{
+			Head:          "promql",
+			Symbol:        "fn:" + name,
+			Kind:          "function",
+			Probe:         probe,
+			Cerberus:      cv,
+			Reference:     ref,
+			Class:         classify(cv, ref),
+			CerberusError: cerr,
+		})
+	}
+
+	// Aggregators.
+	for _, a := range promAggregators {
+		probe := promQLAggregatorProbe(a.op)
+		cv, cerr := cerberusVerdictPromQL(probe)
+		ref := VerdictAccept
+		if a.experimental {
+			ref = VerdictReject
+		}
+		entries = append(entries, Entry{
+			Head:          "promql",
+			Symbol:        "agg:" + a.op,
+			Kind:          "aggregator",
+			Probe:         probe,
+			Cerberus:      cv,
+			Reference:     ref,
+			Class:         classify(cv, ref),
+			CerberusError: cerr,
+		})
+	}
+
+	// Binary operators.
+	for _, b := range promBinaryOps {
+		cv, cerr := cerberusVerdictPromQL(b.probe)
+		ref := VerdictAccept
+		entries = append(entries, Entry{
+			Head:          "promql",
+			Symbol:        "op:" + b.sym,
+			Kind:          "binary-op",
+			Probe:         b.probe,
+			Cerberus:      cv,
+			Reference:     ref,
+			Class:         classify(cv, ref),
+			CerberusError: cerr,
+		})
+	}
+
+	// Modifiers.
+	for _, m := range promModifiers {
+		cv, cerr := cerberusVerdictPromQL(m.probe)
+		ref := VerdictAccept
+		entries = append(entries, Entry{
+			Head:          "promql",
+			Symbol:        "mod:" + m.sym,
+			Kind:          "modifier",
+			Probe:         m.probe,
+			Cerberus:      cv,
+			Reference:     ref,
+			Class:         classify(cv, ref),
+			CerberusError: cerr,
+		})
+	}
+
+	return entries, nil
+}

--- a/test/surface-parity/runner.go
+++ b/test/surface-parity/runner.go
@@ -1,0 +1,91 @@
+package surfaceparity
+
+import (
+	"context"
+	"time"
+
+	tempotraceql "github.com/grafana/tempo/pkg/traceql"
+	promparser "github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/logql"
+	"github.com/tsouza/cerberus/internal/optimizer"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/traceql"
+)
+
+// probeStart / probeEnd anchor the instant/range window used when
+// lowering probe expressions. A fixed deterministic window keeps the
+// generated SQL — and therefore the accept/reject verdict — stable
+// across runs.
+var (
+	probeStart = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	probeEnd   = probeStart.Add(5 * time.Minute)
+	probeStep  = 30 * time.Second
+)
+
+// cerberusVerdictPromQL runs one PromQL probe through the real cerberus
+// path the /api/v1/query_range handler uses — parse → lower (fold
+// included) → optimize → emit — and returns ACCEPT with empty error, or
+// REJECT with the failure. EnableExperimentalFunctions mirrors the
+// parser options the prom Lang adapter uses so the parse stage never
+// gates experimental fns out before cerberus's own lowering can have an
+// opinion.
+func cerberusVerdictPromQL(query string) (Verdict, string) {
+	p := promparser.NewParser(promparser.Options{EnableExperimentalFunctions: true})
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		// A probe that cerberus's own parser can't parse is a probe-
+		// synthesis bug, surfaced as a reject with a tagged message so
+		// it's distinguishable from a lowering rejection.
+		return VerdictReject, "probe-parse: " + err.Error()
+	}
+	plan, err := promql.LowerAtRange(context.Background(), expr, schema.DefaultOTelMetrics(), probeStart, probeEnd, probeStep)
+	if err != nil {
+		return VerdictReject, err.Error()
+	}
+	return emitVerdict(optimizer.DefaultWithSchema(schema.DefaultOTelMetrics()), plan)
+}
+
+// cerberusVerdictLogQL runs one LogQL probe through the path the Loki
+// range handler uses — ParseExprPermissive → lower → optimize → emit.
+func cerberusVerdictLogQL(query string) (Verdict, string) {
+	expr, err := logql.ParseExprPermissive(query)
+	if err != nil {
+		return VerdictReject, "probe-parse: " + err.Error()
+	}
+	plan, err := logql.LowerAtRange(context.Background(), expr, schema.DefaultOTelLogs(), probeStart, probeEnd, probeStep)
+	if err != nil {
+		return VerdictReject, err.Error()
+	}
+	return emitVerdict(optimizer.Default(), plan)
+}
+
+// cerberusVerdictTraceQL runs one TraceQL probe through the path the
+// tempo handler uses — traceql.Parse → lower → optimize → emit.
+func cerberusVerdictTraceQL(query string) (Verdict, string) {
+	expr, err := tempotraceql.Parse(query)
+	if err != nil {
+		return VerdictReject, "probe-parse: " + err.Error()
+	}
+	plan, err := traceql.Lower(context.Background(), expr, schema.DefaultOTelTraces())
+	if err != nil {
+		return VerdictReject, err.Error()
+	}
+	return emitVerdict(optimizer.Default(), plan)
+}
+
+// emitVerdict runs the optimizer + SQL emitter over a lowered plan,
+// completing the wire pipeline. A symbol that lowers but fails to emit
+// is still a cerberus rejection from the caller's point of view (the
+// HTTP request 500s/422s), so emit failure is a REJECT.
+func emitVerdict(driver *optimizer.Driver, plan chplan.Node) (Verdict, string) {
+	ctx := context.Background()
+	plan = driver.Run(ctx, plan)
+	if _, _, err := chsql.Emit(ctx, plan); err != nil {
+		return VerdictReject, "emit: " + err.Error()
+	}
+	return VerdictAccept, ""
+}

--- a/test/surface-parity/traceql.go
+++ b/test/surface-parity/traceql.go
@@ -1,0 +1,129 @@
+package surfaceparity
+
+import (
+	tempotraceql "github.com/grafana/tempo/pkg/traceql"
+)
+
+// Domain-aware TraceQL operands from the showcase seed
+// (test/e2e/seed/cmd/seed/showcase_traceql.go): real resource/span
+// attributes that match seeded spans.
+const (
+	tqlServiceName = `resource.service.name = "gateway"`
+)
+
+// tqlProbe is one TraceQL grammar symbol + its canonical probe.
+type tqlProbe struct {
+	symbol string
+	kind   string
+	probe  string
+}
+
+// tqlIntrinsicProbes enumerates the TraceQL intrinsic surface. Each
+// probe is a spanset filter that references the intrinsic in a
+// comparison whose RHS is type-appropriate. The scoped string form
+// (e.g. "span:duration", "trace:id") is the parser's canonical token.
+// Intrinsics the upstream parser marks structural-only or
+// not-yet-implemented are still probed — the reference oracle
+// (Parse+Validate) is what decides whether they're reference-accepted,
+// so a structural-only intrinsic naturally lands parity-reject rather
+// than being hand-excluded.
+var tqlIntrinsicProbes = []tqlProbe{
+	{"intrinsic:duration", "intrinsic", `{ duration > 1ms }`},
+	{"intrinsic:name", "intrinsic", `{ name = "charge" }`},
+	{"intrinsic:status", "intrinsic", `{ status = error }`},
+	{"intrinsic:statusMessage", "intrinsic", `{ statusMessage = "card declined" }`},
+	{"intrinsic:kind", "intrinsic", `{ kind = server }`},
+	{"intrinsic:span:childCount", "intrinsic", `{ span:childCount > 0 }`},
+	{"intrinsic:rootServiceName", "intrinsic", `{ rootServiceName = "gateway" }`},
+	{"intrinsic:rootName", "intrinsic", `{ rootName = "request" }`},
+	{"intrinsic:traceDuration", "intrinsic", `{ traceDuration > 1ms }`},
+	{"intrinsic:nestedSetLeft", "intrinsic", `{ nestedSetLeft > 0 }`},
+	{"intrinsic:nestedSetRight", "intrinsic", `{ nestedSetRight > 0 }`},
+	{"intrinsic:nestedSetParent", "intrinsic", `{ nestedSetParent > 0 }`},
+	{"intrinsic:event:name", "intrinsic", `{ event:name = "exception" }`},
+	{"intrinsic:event:timeSinceStart", "intrinsic", `{ event:timeSinceStart > 1ms }`},
+	{"intrinsic:link:spanID", "intrinsic", `{ link:spanID != "" }`},
+	{"intrinsic:link:traceID", "intrinsic", `{ link:traceID != "" }`},
+	{"intrinsic:instrumentation:name", "intrinsic", `{ instrumentation:name = "showcase-instrumentation" }`},
+	{"intrinsic:instrumentation:version", "intrinsic", `{ instrumentation:version = "1.2.3" }`},
+	{"intrinsic:trace:id", "intrinsic", `{ trace:id != "" }`},
+	{"intrinsic:span:id", "intrinsic", `{ span:id != "" }`},
+	{"intrinsic:span:parentID", "intrinsic", `{ span:parentID != "" }`},
+	{"intrinsic:span:status", "intrinsic", `{ span:status = error }`},
+	{"intrinsic:span:statusMessage", "intrinsic", `{ span:statusMessage = "card declined" }`},
+	{"intrinsic:span:duration", "intrinsic", `{ span:duration > 1ms }`},
+	{"intrinsic:span:name", "intrinsic", `{ span:name = "charge" }`},
+	{"intrinsic:span:kind", "intrinsic", `{ span:kind = server }`},
+	{"intrinsic:trace:rootName", "intrinsic", `{ trace:rootName = "request" }`},
+	{"intrinsic:trace:rootService", "intrinsic", `{ trace:rootService = "gateway" }`},
+	{"intrinsic:trace:duration", "intrinsic", `{ trace:duration > 1ms }`},
+}
+
+// tqlMetricsProbes enumerate the TraceQL metrics second-stage operator
+// surface. These are metrics-pipeline expressions (a spanset filter
+// piped into a metrics aggregation), the surface /api/metrics serves.
+var tqlMetricsProbes = []tqlProbe{
+	{"metric:rate", "metrics-op", `{ ` + tqlServiceName + ` } | rate()`},
+	{"metric:count_over_time", "metrics-op", `{ ` + tqlServiceName + ` } | count_over_time()`},
+	{"metric:min_over_time", "metrics-op", `{ ` + tqlServiceName + ` } | min_over_time(duration)`},
+	{"metric:max_over_time", "metrics-op", `{ ` + tqlServiceName + ` } | max_over_time(duration)`},
+	{"metric:avg_over_time", "metrics-op", `{ ` + tqlServiceName + ` } | avg_over_time(duration)`},
+	{"metric:sum_over_time", "metrics-op", `{ ` + tqlServiceName + ` } | sum_over_time(duration)`},
+	{"metric:quantile_over_time", "metrics-op", `{ ` + tqlServiceName + ` } | quantile_over_time(duration, 0.9)`},
+	{"metric:histogram_over_time", "metrics-op", `{ ` + tqlServiceName + ` } | histogram_over_time(duration)`},
+	{"metric:compare", "metrics-op", `{ ` + tqlServiceName + ` } | compare({ status = error })`},
+	{"metric:topk", "metrics-op", `{ ` + tqlServiceName + ` } | rate() by (name) | topk(3)`},
+	{"metric:bottomk", "metrics-op", `{ ` + tqlServiceName + ` } | rate() by (name) | bottomk(3)`},
+}
+
+// tqlAggregateProbes enumerate the first-stage spanset aggregates
+// (count/min/max/sum/avg) used in scalar-filter spanset pipelines.
+var tqlAggregateProbes = []tqlProbe{
+	{"aggregate:count", "aggregate", `{ ` + tqlServiceName + ` } | count() > 0`},
+	{"aggregate:max", "aggregate", `{ ` + tqlServiceName + ` } | max(duration) > 1ms`},
+	{"aggregate:min", "aggregate", `{ ` + tqlServiceName + ` } | min(duration) > 1ms`},
+	{"aggregate:sum", "aggregate", `{ ` + tqlServiceName + ` } | sum(duration) > 1ms`},
+	{"aggregate:avg", "aggregate", `{ ` + tqlServiceName + ` } | avg(duration) > 1ms`},
+}
+
+// referenceVerdictTraceQL models reference Tempo acceptance: the wire
+// path parses then validates. traceql.Parse runs the optimizing parse
+// (the same the tempo handler uses) and traceql.Validate runs the
+// reference's unsupported-feature gate — both in-process (the LIGHT
+// path, no compat container).
+func referenceVerdictTraceQL(query string) Verdict {
+	expr, err := tempotraceql.Parse(query)
+	if err != nil {
+		return VerdictReject
+	}
+	if err := tempotraceql.Validate(expr); err != nil {
+		return VerdictReject
+	}
+	return VerdictAccept
+}
+
+// probeTraceQL enumerates the TraceQL intrinsic + metrics-op + aggregate
+// surface and classifies each symbol against cerberus + the in-process
+// reference oracle.
+func probeTraceQL() ([]Entry, error) {
+	var entries []Entry
+	all := make([]tqlProbe, 0, len(tqlIntrinsicProbes)+len(tqlMetricsProbes)+len(tqlAggregateProbes))
+	all = append(all, tqlIntrinsicProbes...)
+	all = append(all, tqlMetricsProbes...)
+	all = append(all, tqlAggregateProbes...)
+	for _, p := range all {
+		cv, cerr := cerberusVerdictTraceQL(p.probe)
+		ref := referenceVerdictTraceQL(p.probe)
+		entries = append(entries, Entry{
+			Head:          "traceql",
+			Symbol:        p.symbol,
+			Kind:          p.kind,
+			Probe:         p.probe,
+			Cerberus:      cv,
+			Reference:     ref,
+			Class:         classify(cv, ref),
+			CerberusError: cerr,
+		})
+	}
+	return entries, nil
+}


### PR DESCRIPTION
The P0 of the surface-parity RC1 gate (#51). Where the rejection-parity layer (#783) is **site-based** (diffs cerberus's known 422 code-sites vs reference), this is **surface-based**: it starts from the upstream parser's *accepted grammar* and finds everything cerberus rejects that reference accepts (and vice-versa) — catching silent lowering gaps that were never catalogued.

## What it builds (`test/surface-parity/`)
3 probers (promql/logql/traceql) that enumerate each upstream parser's symbol table, synthesize a **domain-aware** probe per symbol (real seed metrics/labels/attrs — histogram fns get `showcase_latency_exp_hist`, etc.), run cerberus's real `parse → fold → lower → optimize → emit`, and classify vs an **in-process** reference oracle (no compat containers): PromQL = `parser.Functions[].Experimental` + `IsExperimentalAggregator`; LogQL = parse+validate; TraceQL = `traceql.Parse`+`Validate`. Plus `inventory.json` (228-symbol ledger) and `inventory_test.go` (byte-pin regen + wrong-reject/wrong-accept ratchets that fail CI on drift — verified red-on-drift, green-on-restore).

## Authoritative findings (drive #65/#66/#67)
- **PromQL — 20 wrong-rejects:** trig family (acos/asin/atan/cos/sin/tan/sinh/cosh/tanh/asinh/acosh/atanh), deg, rad, scalar, day_of_year, sort, sort_desc, present_over_time. (16 parity-rejects are genuinely experimental — not targets.)
- **PromQL — 1 wrong-accept:** `double_exponential_smoothing` — cerberus lowers an experimental fn reference gates off by default. A real divergence, now pinned.
- **LogQL — 1 wrong-reject:** `approx_topk`.
- **TraceQL — 0 wrong-rejects** — the post-burndown surface is fully at parity.

Every reference verdict was resolved in-process (no container diff needed). `go build`/`golangci-lint`/prober tests green.

Part of #51 (RC1 gate). The ratchet now guards the surface against regression while #65/#66/#67 burn the 22 entries to zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)