### PR TITLE
feat(logql): implement approx_topk — close the LogQL surface-parity gap (#66)

### DIFF
--- a/internal/logql/vector_aggregation.go
+++ b/internal/logql/vector_aggregation.go
@@ -15,16 +15,16 @@ import (
 // excluded ones for `without`), apply the aggregator on the inner
 // stream's `value` column.
 //
-// `topk` / `bottomk` change output shape (K rows per group) and route
-// to [lowerTopK]; `sort` / `sort_desc` reorder rather than aggregate
-// and route to [lowerSort].
+// `topk` / `bottomk` / `approx_topk` change output shape (K rows per
+// group) and route to [lowerTopK]; `sort` / `sort_desc` reorder rather
+// than aggregate and route to [lowerSort].
 func lowerVectorAggregation(e *syntax.VectorAggregationExpr, s schema.Logs, lc lowerCtx) (chplan.Node, error) {
 	if e.Left == nil {
 		return nil, fmt.Errorf("logql: vector-aggregation has nil inner")
 	}
 
 	switch e.Operation {
-	case syntax.OpTypeTopK, syntax.OpTypeBottomK:
+	case syntax.OpTypeTopK, syntax.OpTypeBottomK, syntax.OpTypeApproxTopK:
 		return lowerTopK(e, s, lc)
 	case syntax.OpTypeSort, syntax.OpTypeSortDesc:
 		return lowerSort(e, s, lc)
@@ -236,10 +236,11 @@ func canonicalLevelKeys(groups []string) []string {
 	return out
 }
 
-// lowerTopK lowers LogQL `topk(K, expr)` / `bottomk(K, expr)` —
-// optionally with `by (...)` / `without (...)` partitioning — into a
-// chplan.TopK over the Sample-shaped inner plan. Mirrors PromQL's
-// lowerTopK (internal/promql/lower.go).
+// lowerTopK lowers LogQL `topk(K, expr)` / `bottomk(K, expr)` /
+// `approx_topk(K, expr)` — optionally with `by (...)` / `without (...)`
+// partitioning (topk/bottomk only; approx_topk forbids grouping at the
+// parser) — into a chplan.TopK over the Sample-shaped inner plan.
+// Mirrors PromQL's lowerTopK (internal/promql/lower.go).
 //
 // Reference semantics (pkg/logql/evaluator.go::VectorAggEvaluator,
 // OpTypeTopK / OpTypeBottomK arms): per evaluation step and per
@@ -248,6 +249,17 @@ func canonicalLevelKeys(groups []string) []string {
 // label set; the grouping only partitions, it never projects labels.
 // The parser guarantees K > 0 (mustNewVectorAggregationExpr rejects
 // `topk(0, ...)` with "must be greater than 0").
+//
+// `approx_topk(K, expr)` is Loki's probabilistic top-k: upstream
+// approximates the K largest series via a count-min sketch + heap
+// because the candidate set can be too large to sort exactly at query
+// time. Over ClickHouse cerberus has no such constraint, so it computes
+// the EXACT top-K — a correctness superset of the approximation (the
+// caller gets the true K largest series, never a sketch artefact).
+// approx_topk therefore routes through the identical descending-top-K
+// lowering as `topk`; the parser forbids its grouping clause and
+// defaults a non-nil empty Grouping, so [topKPartition] yields the
+// single global K-window upstream's ungrouped approx_topk produces.
 //
 // The inner plan is re-shaped to the canonical Sample contract first
 // ([sampleShapeOverLogInner]) so the partition keys resolve against
@@ -271,8 +283,11 @@ func lowerTopK(e *syntax.VectorAggregationExpr, s schema.Logs, lc lowerCtx) (chp
 		K:        int64(e.Params),
 		By:       by,
 		SortExpr: &chplan.ColumnRef{Name: rangeAggSynthValueColumn},
-		Desc:     e.Operation == syntax.OpTypeTopK,
-		Columns:  []string{"MetricName", "Attributes", "TimeUnix", rangeAggSynthValueColumn},
+		// topk + approx_topk keep the LARGEST K (descending); bottomk
+		// keeps the smallest. approx_topk is exact-top-k here (see
+		// lowerTopK doc), so it shares topk's descending sort.
+		Desc:    e.Operation == syntax.OpTypeTopK || e.Operation == syntax.OpTypeApproxTopK,
+		Columns: []string{"MetricName", "Attributes", "TimeUnix", rangeAggSynthValueColumn},
 	}, nil
 }
 

--- a/test/e2e/grafana/compose/dashboards/showcase-logql.json
+++ b/test/e2e/grafana/compose/dashboards/showcase-logql.json
@@ -3845,14 +3845,14 @@
     },
     {
      "cerberus": {
-      "expect": "error:aggregation operation",
-      "why": "Cerberus rejects this construct today; the declaration is a bidirectional parity pin \u2014 the panel FAILS the sweep the moment support lands, forcing the contract (and this dashboard) to be updated alongside the feature."
+      "expect": "nonempty",
+      "why": "Cerberus implements approx_topk (routed to exact top-k over ClickHouse, a correctness superset of Loki\u0027s sketch); the panel asserts a live nonempty result. Flipped per the bidirectional ratchet when the surface burndown landed support."
      },
      "datasource": {
       "type": "loki",
       "uid": "cerberus-loki"
      },
-     "description": "The probabilistic approx_topk aggregation is rejected.",
+     "description": "Cerberus implements `approx_topk` (exact top-k, #66).",
      "fieldConfig": {
       "defaults": {
        "color": {
@@ -3933,7 +3933,7 @@
        "refId": "A"
       }
      ],
-     "title": "approx_topk \u2014 parity rejection",
+     "title": "approx_topk",
      "type": "timeseries"
     },
     {

--- a/test/rejection-parity/catalogue.json
+++ b/test/rejection-parity/catalogue.json
@@ -250,8 +250,8 @@
       "head": "logql",
       "site": "internal/logql/vector_aggregation.go:buildVectorAggFunc#3cb2166f",
       "message": "logql: aggregation operation %q is unsupported",
-      "class": "rejection",
-      "trigger_query": "approx_topk(2, rate({app=\"x\"}[5m]))"
+      "class": "internal",
+      "rationale": "every vector-aggregation op the LogQL grammar accepts is handled: sum/avg/min/max/count/stddev/stdvar build an AggFunc here, and topk/bottomk/sort/sort_desc/approx_topk route to lowerTopK/lowerSort before this switch. The only remaining op constant (__count_min_sketch__) is a shard-mapper internal the parser never yields from a wire query, so the default arm is unreachable."
     },
     {
       "head": "logql",

--- a/test/spec/logql/approx_topk.txtar
+++ b/test/spec/logql/approx_topk.txtar
@@ -1,0 +1,68 @@
+-- query.logql --
+approx_topk(2, sum by (env) (rate({job="api"}[5m])))
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
+    ResourceAttributes Map(String, String),
+    ServiceName String DEFAULT ''
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
+    (toDateTime64('2025-12-31 23:58:00', 9), 'p1', map('job', 'api', 'env', 'prod')),
+    (toDateTime64('2025-12-31 23:58:20', 9), 'p2', map('job', 'api', 'env', 'prod')),
+    (toDateTime64('2025-12-31 23:58:40', 9), 'p3', map('job', 'api', 'env', 'prod')),
+    (toDateTime64('2025-12-31 23:59:00', 9), 'd1', map('job', 'api', 'env', 'dev')),
+    (toDateTime64('2025-12-31 23:59:20', 9), 'd2', map('job', 'api', 'env', 'dev')),
+    (toDateTime64('2025-12-31 23:59:40', 9), 's1', map('job', 'api', 'env', 'staging'));
+-- expected_rows --
+[
+  ["", {"env": "dev"}, "2026-01-01T00:00:01Z", 0.006666666666666667],
+  ["", {"env": "prod"}, "2026-01-01T00:00:01Z", 0.01]
+]
+-- args --
+[0] string = ""
+[1] string = "env"
+[2] int64 = 9
+[3] string = "env"
+[4] float64 = 300
+[5] string = ""
+[6] string = "detected_level"
+[7] string = ""
+[8] string = "unknown"
+[9] string = "trace"
+[10] string = "trc"
+[11] string = "trace"
+[12] string = "debug"
+[13] string = "dbg"
+[14] string = "debug"
+[15] string = "info"
+[16] string = "inf"
+[17] string = "information"
+[18] string = "info"
+[19] string = "warn"
+[20] string = "wrn"
+[21] string = "warning"
+[22] string = "warn"
+[23] string = "error"
+[24] string = "err"
+[25] string = "error"
+[26] string = "critical"
+[27] string = "critical"
+[28] string = "fatal"
+[29] string = "fatal"
+[30] int64 = 1
+[31] string = "job"
+[32] string = "api"
+[33] string = "env"
+-- chplan --
+TopK k=2 sort=Value DESC columns=[MetricName, Attributes, TimeUnix, Value]
+  Project [MetricName AS MetricName, Attributes AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
+    Project ["" AS MetricName, map("env", gkey_0) AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+      Aggregate groupBy=[ResourceAttributes["env"] AS gkey_0] funcs=[sum(Value) AS Value]
+        RangeWindow func=log_rate range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
+          Project [mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf((lower(SeverityText) = ""), "unknown", ((lower(SeverityText) = "trace") OR (lower(SeverityText) = "trc")), "trace", ((lower(SeverityText) = "debug") OR (lower(SeverityText) = "dbg")), "debug", (((lower(SeverityText) = "info") OR (lower(SeverityText) = "inf")) OR (lower(SeverityText) = "information")), "info", (((lower(SeverityText) = "warn") OR (lower(SeverityText) = "wrn")) OR (lower(SeverityText) = "warning")), "warn", ((lower(SeverityText) = "error") OR (lower(SeverityText) = "err")), "error", (lower(SeverityText) = "critical"), "critical", (lower(SeverityText) = "fatal"), "fatal", lower(SeverityText))))) AS ResourceAttributes, Timestamp, 1 AS Value]
+            Filter predicate=(ResourceAttributes["job"] = "api")
+              Scan(otel_logs)
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT ? AS `MetricName`, map(?, `gkey_0`) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`[?] AS `gkey_0`, sum(`Value`) AS `Value` FROM (SELECT `ResourceAttributes`, if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0) AS `Value` FROM (SELECT `ResourceAttributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `ResourceAttributes`, arrayFilter(p -> tupleElement(p, 1) > now64(9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= now64(9), series_array) AS `window_pairs` FROM (SELECT `ResourceAttributes`, arraySort(groupArray((`Timestamp`, `Value`))) AS `series_array` FROM (SELECT mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf((lower(`SeverityText`) = ?), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, (((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)) OR (lower(`SeverityText`) = ?)), ?, ((lower(`SeverityText`) = ?) OR (lower(`SeverityText`) = ?)), ?, (lower(`SeverityText`) = ?), ?, (lower(`SeverityText`) = ?), ?, lower(`SeverityText`))))) AS `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) GROUP BY `ResourceAttributes`))) WHERE length(`window_vals`) >= 1) GROUP BY `ResourceAttributes`[?]))) ORDER BY `Value` DESC LIMIT 2)

--- a/test/surface-parity/inventory.json
+++ b/test/surface-parity/inventory.json
@@ -1581,10 +1581,9 @@
       "symbol": "vector:approx_topk",
       "kind": "vector-agg",
       "probe": "approx_topk(3, count_over_time({service_name=\"gateway\"}[5m]))",
-      "cerberus": "reject",
+      "cerberus": "accept",
       "reference": "accept",
-      "class": "wrong-reject",
-      "cerberus_error": "logql: aggregation operation \"approx_topk\" is unsupported"
+      "class": "parity-accept"
     },
     {
       "head": "logql",


### PR DESCRIPTION
Implements the one LogQL surface wrong-rejection found by the #64 prober (#792): `approx_topk` (cerberus 422'd it; reference Loki accepts).

**Fix:** in `internal/logql/vector_aggregation.go::lowerVectorAggregation`, route `syntax.OpTypeApproxTopK` to the same `chplan.TopK` path as `topk`/`bottomk` (descending K-window). Over ClickHouse cerberus computes the **exact** top-k — a correctness superset of Loki's count-min-sketch approximation; the parser forbids grouping on approx_topk so the ungrouped global K-window matches upstream semantics. Typed chsql/chplan only.

**Surface parity:** `logql wrong-reject = 0` (was 1). `test/surface-parity/inventory.json` regenerated — `approx_topk` moved wrong-reject → parity-accept. Ratchet green (`TestWrongRejectionsAreRatcheted`, `TestInventoryIsRegenerable`).

**Artifacts:** new `test/spec/logql/approx_topk.txtar` (chdb roundtrip returns the 2 highest series, dropping the rest — exactly top-k); `test/rejection-parity/catalogue.json` reclassified the now-unreachable `buildVectorAggFunc` default arm `rejection`→`internal` (every grammar vector-agg op is now handled). build/lint/logql/chsql/spec/surface-parity/rejection-parity all green.

Part of #51. After this + #65 (PromQL 20) + #74 (double_exp gate), the surface-parity gate closes (TraceQL already 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)