### PR TITLE
test(perf): CI-gating regression guards for the landed perf wins (#73)

### DIFF
--- a/.github/workflows/chdb.yml
+++ b/.github/workflows/chdb.yml
@@ -164,3 +164,45 @@ jobs:
 
       - name: Run TXTAR round-trip (${{ matrix.ql }})
         run: go test -tags chdb -count=1 ./test/spec/${{ matrix.ql }}/...
+
+  # `perf-guards` runs the chDB-tagged deterministic perf-regression
+  # ASSERTIONS under test/perf/ — the load-bearing fix for task #73.
+  # Before this job, test/perf compiled under the `chdb` tag but ran in
+  # NO CI lane (nothing invoked `./test/perf/...`), so the harnesses only
+  # `t.Logf`'d and could never fail. The tests are now assertion-pins, not
+  # wall-clock benchmarks, so they belong on a gating lane:
+  #
+  #   - TestOrderByDecision_ChDB: EXPLAIN indexes=1 granule-prune ratio
+  #     floor (≥4×) proving the cerberus-ddl MetricName-first metrics
+  #     ORDER BY win (#791) still holds against a byte-identical
+  #     ServiceName-first table.
+  #   - TestSeriesFanout_ChDB: a don't-regress-upward /series round-trip
+  #     ceiling (the #790 fan-in batching is held off main, so this pins
+  #     the current N rather than asserting ==1).
+  #
+  # Wall-clock perf stays in the informational `perf-benchmark.yml`
+  # (benchstat, never gates) to avoid runner-variance flake; only the
+  # deterministic structural assertions gate here.
+  perf-guards:
+    name: perf-guards
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just
+
+      - name: Install libchdb.so
+        run: just chdb-install
+
+      - name: Run perf regression guards (chDB)
+        run: just perf-chdb

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -13,6 +13,12 @@ name: perf-benchmark
 # Go test runner auto-scale b.N to amortise setup over many iterations
 # (critical for the sub-µs PromQL/LogQL lower benches). `-cpu=1` pins
 # GOMAXPROCS=1 to avoid the multi-core sampling cost.
+#
+# This lane is INFORMATIONAL by design (benchstat deltas, runner-variance
+# prone) and never gates. The deterministic perf-regression ASSERTIONS —
+# the metrics ORDER BY granule-prune ratio floor and the /series
+# round-trip baseline — live in the `perf-guards` job of chdb.yml and DO
+# gate. Keep wall-clock here; keep structural assertions there.
 
 on:
   pull_request:

--- a/Justfile
+++ b/Justfile
@@ -84,6 +84,17 @@ test-chdb:
 property:
     go test -tags chdb -count=1 ./test/property/...
 
+# Run the chDB-tagged perf regression guards (test/perf). These are
+# deterministic ASSERTION pins — not wall-clock benchmarks — that bite a
+# regression of the landed perf wins: the metrics-table MetricName-first
+# ORDER BY granule prune (EXPLAIN indexes=1 ratio floor) and the /series
+# fan-out round-trip baseline. Requires libchdb.so (see `just chdb-install`).
+# Mirrors the `perf-guards` CI job in chdb.yml. Distinct from the
+# informational `perf-benchmark.yml` lane, which only reports benchstat
+# deltas and never gates.
+perf-chdb:
+    go test -tags chdb -count=1 ./test/perf/...
+
 # Run the chclient testcontainers integration tests against a real
 # ClickHouse container. Requires Docker. Gated behind the `integration`
 # build tag so regular `just test` doesn't pull in Docker.

--- a/internal/api/prom/handler_streaming_alloc_test.go
+++ b/internal/api/prom/handler_streaming_alloc_test.go
@@ -1,0 +1,121 @@
+package prom_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// TestStreamingCursorHeapStaysBounded is the deterministic check-gate
+// guard for the streaming-cursor RAM win (the streaming cursor + memory /
+// sample caps that landed on main). The companion benchmark
+// BenchmarkStreamingCursor_1M_Points reads the same HeapInuse delta but
+// only *reports* it as a soft metric — it never fails, and it runs in no
+// gating lane. This test converts that soft signal into a hard, always-on
+// assertion.
+//
+// The invariant under test is the defining property of a streaming
+// cursor: the RETAINED heap after draining a result is bounded by the
+// concurrent working set (per-series matrix rows + JSON envelope), NOT by
+// the total number of rows pulled from ClickHouse. The handler walks the
+// cursor one Sample at a time (fakeCountingCursor keeps only the current
+// row resident), and each drained Sample becomes garbage once it is
+// folded into the per-series matrix and encoded — so a 10× larger result
+// over the SAME series fan-out retains essentially the same heap.
+//
+// A regression that buffered the full result — e.g. materialising every
+// chclient.Sample into one big slice before encoding, or holding the raw
+// rows alongside the matrix — would retain heap proportional to the row
+// count: ~1M Samples, each carrying a label map, is tens-to-hundreds of
+// MB resident. This test drives 1M rows and asserts the post-GC retained
+// HeapInuse delta stays under a generous absolute ceiling that the real
+// streaming path clears by two orders of magnitude (~0.2 MB observed)
+// while a full-buffering regression blows straight through.
+//
+// Why retained heap, not allocs-per-op: cumulative allocations scale
+// linearly with sample count even for a perfect streaming path (every
+// sample is decoded → label-mapped → JSON-encoded, each step allocating
+// transient garbage), so an alloc-per-op ceiling would be a brittle
+// magic number that bites the streaming path itself. The *retained* set
+// after GC is the metric that distinguishes streaming (bounded) from
+// buffering (linear), and it is the quantity the original benchmark
+// measured.
+func TestStreamingCursorHeapStaysBounded(t *testing.T) {
+	// retainedHeapDelta drives query_range against a cursorQuerier
+	// synthesising totalRows samples over a fixed 1000-series fan-out a
+	// few times, then returns the post-GC HeapInuse growth over the
+	// pre-request baseline. Multiple iterations + an explicit GC keep the
+	// measurement deterministic (no wall-clock, no allocation counting).
+	retainedHeapDelta := func(t *testing.T, totalRows int) float64 {
+		t.Helper()
+		const seriesCount = 1000
+		samplesPerSer := totalRows / seriesCount
+		start := time.Unix(1700000000, 0).UTC()
+		end := start.Add(time.Duration(samplesPerSer-1) * time.Second)
+		q := &cursorQuerier{
+			total:      totalRows,
+			seriesMod:  samplesPerSer,
+			stepNanos:  int64(time.Second),
+			startUnix:  start.Unix(),
+			metricName: "up",
+			stopAt:     -1,
+		}
+		srv := newServer(q)
+		t.Cleanup(srv.Close)
+		url := fmt.Sprintf("%s/api/v1/query_range?query=up&start=%d&end=%d&step=1",
+			srv.URL, start.Unix(), end.Unix())
+
+		// Establish the baseline AFTER the server + transport pools are
+		// warm so their one-time allocations don't count as result-set
+		// retention.
+		if resp, err := http.Get(url); err == nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+		}
+		runtime.GC()
+		var baseline runtime.MemStats
+		runtime.ReadMemStats(&baseline)
+
+		for i := 0; i < 3; i++ {
+			resp, err := http.Get(url)
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+		}
+
+		runtime.GC()
+		var after runtime.MemStats
+		runtime.ReadMemStats(&after)
+
+		var deltaBytes uint64
+		if after.HeapInuse > baseline.HeapInuse {
+			deltaBytes = after.HeapInuse - baseline.HeapInuse
+		}
+		return float64(deltaBytes) / (1024 * 1024)
+	}
+
+	const totalRows = 1_000_000 // 1000 series × 1000 points
+
+	deltaMB := retainedHeapDelta(t, totalRows)
+	t.Logf("retained HeapInuse delta after draining %d rows (1000 series): %.2f MB", totalRows, deltaMB)
+
+	// Streaming clears this by ~150× (observed ~0.2 MB). A full-buffering
+	// regression that retains the ~1M-Sample result (each Sample carries a
+	// label map) retains tens-to-hundreds of MB and blows through. The
+	// 32 MB ceiling is generous enough to absorb GC-timing jitter in the
+	// retained set yet far below any linear-in-rows regression.
+	const maxRetainedMB = 32.0
+	if deltaMB > maxRetainedMB {
+		t.Fatalf("streaming-cursor RAM regression: draining %d rows over 1000 series "+
+			"retained %.2f MB of heap, exceeding the %.0f MB ceiling. Retained heap is "+
+			"scaling with total row count — the cursor path is buffering the full result "+
+			"instead of streaming it sample-by-sample (the per-sample garbage should be "+
+			"collected once folded into the matrix + encoded).",
+			totalRows, deltaMB, maxRetainedMB)
+	}
+}

--- a/internal/chsql/range_window_value_float64_test.go
+++ b/internal/chsql/range_window_value_float64_test.go
@@ -1,0 +1,209 @@
+package chsql_test
+
+import (
+	"context"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+)
+
+// valueExprRe extracts the outer-SELECT Value expression — the text
+// between the leading `\`Attributes\`, ` projection and the Value alias.
+// The over-time emitters render the outer projection as
+//
+//	SELECT `Attributes`, <value-expr> AS `Value` FROM ( ... )
+//
+// or, for the pairs-path reducers (irate / deriv), with a bare
+//
+//	SELECT `Attributes`, <value-expr> AS Value FROM ( ... )
+//
+// The alias (` AS `Value“ or ` AS Value`) immediately precedes the first
+// outer ` FROM `, so we anchor the capture on the Attributes prefix and
+// terminate on ` AS Value`/` AS `Value“ before ` FROM `. The capture is
+// greedy up to the *last* alias-before-FROM so a nested ` AS ` inside the
+// expression itself (none today, but defensive) can't truncate it early.
+var valueExprRe = regexp.MustCompile("(?s)SELECT `Attributes`, (.*) AS `?Value`? FROM ")
+
+// floatProducingTokens are the ClickHouse constructs that GUARANTEE the
+// Value expression scans into a Go *float64 (cerberus's prod clickhouse-go
+// scan type — see chclient.Cursor.Sample). Each is either an explicit
+// cast / float fn, or an operation whose CH return type is Float64
+// because at least one operand is Float64 (window_vals is a Float64
+// array, so arraySum / arrayAvg / arrayMin / arrayMax / element indexing
+// over it are Float64; division promotes to Float64; nan is Float64).
+//
+// The list is deliberately the *float-safe allow-set*. A reducer whose
+// Value expression contains NONE of these is, by construction, an
+// integer-typed leak: a bare `1`, `length(window_vals)` (UInt64),
+// `count(...)` (UInt64), or `countIf(...)` (UInt64) projected raw. That
+// is exactly the bug that bit present_over_time (a `toFloat64(1)` →
+// `1` revert): prod's strict `*float64` scan 502s on a UInt8/UInt64
+// Value, while the lenient chDB roundtrip silently coerces it — so the
+// chdb goldens DON'T catch it. This allow-set does.
+var floatProducingTokens = []string{
+	"toFloat64(",             // explicit cast — present_over_time, count_over_time, holt_winters …
+	"CAST(",                  // explicit CAST(... AS Float64) — resets / changes
+	"arraySum(",              // sum_over_time — Float64 array → Float64
+	"arrayAvg(",              // avg_over_time
+	"arrayMin(",              // min_over_time
+	"arrayMax(",              // max_over_time
+	"window_vals[",           // first/last_over_time element indexing — Float64 element
+	"sqrt(",                  // stddev_over_time
+	"arrayWithConstant(",     // stdvar_over_time two-pass variance (arrayAvg inside)
+	"simpleLinearRegression", // deriv slope — Float64 tuple element
+	"nan",                    // empty-window sentinel — Float64
+	" / ",                    // division promotes to Float64 (rate, two-pass variance)
+}
+
+// integerLeakTokens are CH constructs that, when they appear in the
+// Value expression *without* a surrounding float-producing wrapper,
+// return an integer type (UInt8 / UInt64) and therefore 502 the prod
+// `*float64` scan. We only flag them when no float token is present —
+// `toFloat64(length(...))` is fine, a bare `length(...)` is not.
+var integerLeakTokens = []string{
+	"length(",
+	"count(",
+	"countIf(",
+}
+
+// bareIntLiteralRe matches a Value expression that is *exactly* an
+// integer literal (e.g. `1`, `0`) with no wrapping function — the
+// canonical present_over_time leak shape (`toFloat64(1)` regressed to
+// `1`).
+var bareIntLiteralRe = regexp.MustCompile(`^-?\d+$`)
+
+// allPromQLOverTimeReducers is the full set of PromQL range-vector
+// functions cerberus's over-time emitter renders through
+// emitRangeWindowOverTime / the dedicated reducer emitters. present_over_time
+// leads the list because it is the function whose UInt8 leak motivated
+// this guard. last/first_over_time go through the same windowed-array
+// path. rate / increase / delta / irate / idelta / deriv / resets /
+// changes are the derived-shape reducers; each must also project Float64.
+var allPromQLOverTimeReducers = []string{
+	"present_over_time",
+	"sum_over_time",
+	"avg_over_time",
+	"min_over_time",
+	"max_over_time",
+	"count_over_time",
+	"last_over_time",
+	"stddev_over_time",
+	"stdvar_over_time",
+	"rate",
+	"increase",
+	"delta",
+	"irate",
+	"idelta",
+	"deriv",
+	"resets",
+	"changes",
+}
+
+// TestOverTimeValueColumnIsFloat64 is the shift-left guard for the
+// present_over_time-class UInt8 leak: cerberus's production clickhouse-go
+// scans the metrics Value column strictly as *float64, so an emitter that
+// projects an integer-typed Value (a bare `1`, `length(...)`, `count(...)`,
+// `countIf(...)`) returns a 502 in prod — but PASSES the lenient chDB
+// roundtrip goldens, which silently coerce the integer. This unit test
+// closes that gap by emitting each PromQL over-time reducer's RangeWindow
+// and asserting the projected Value expression is Float64-typed.
+//
+// The assertion is structural, not a brittle exact-string pin: the Value
+// expression must contain at least one float-PRODUCING construct
+// (toFloat64 / arraySum / arrayAvg / division / nan / …) AND must not be
+// a bare integer literal or an unwrapped integer aggregate. Reverting
+// present_over_time's `toFloat64(1)` to `1`, or count_over_time's
+// `toFloat64(length(...))` to `length(...)`, makes this test go RED on
+// the always-on `check` gate — before the change can reach prod and 502.
+func TestOverTimeValueColumnIsFloat64(t *testing.T) {
+	t.Parallel()
+
+	for _, fn := range allPromQLOverTimeReducers {
+		fn := fn
+		t.Run(fn, func(t *testing.T) {
+			t.Parallel()
+			plan := &chplan.RangeWindow{
+				Input:           &chplan.Scan{Table: "otel_metrics_gauge"},
+				Func:            fn,
+				TimestampColumn: "TimeUnix",
+				ValueColumn:     "Value",
+				GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+			}
+			sql, _, err := chsql.Emit(context.Background(), plan)
+			if err != nil {
+				t.Fatalf("Emit(%s): %v", fn, err)
+			}
+
+			valueExpr := extractValueExpr(t, fn, sql)
+			assertFloat64ValueExpr(t, fn, valueExpr, sql)
+		})
+	}
+}
+
+// extractValueExpr pulls the `<expr> AS \`Value\“ text out of the outer
+// SELECT. Every over-time emitter renders the same outer shape; if a
+// future emitter diverges, the regex miss fails loudly rather than
+// silently skipping the type check.
+func extractValueExpr(t *testing.T, fn, sql string) string {
+	t.Helper()
+	m := valueExprRe.FindStringSubmatch(sql)
+	if m == nil {
+		t.Fatalf("Emit(%s): could not locate `<expr> AS \\`Value\\`` in outer SELECT — "+
+			"the over-time outer projection shape changed; update extractValueExpr "+
+			"so the Float64 type-check keeps biting.\nSQL: %s", fn, sql)
+	}
+	// Trim leading/trailing whitespace for the literal checks below.
+	return strings.TrimSpace(m[1])
+}
+
+// assertFloat64ValueExpr is the type-check core. The Value expression
+// must contain a float-producing token AND must not be an unwrapped
+// integer aggregate or bare integer literal.
+func assertFloat64ValueExpr(t *testing.T, fn, valueExpr, sql string) {
+	t.Helper()
+
+	// A bare integer literal Value (`1`, `0`) is the canonical leak.
+	if bareIntLiteralRe.MatchString(valueExpr) {
+		t.Fatalf("Emit(%s): Value expression %q is a BARE INTEGER LITERAL — "+
+			"prod clickhouse-go scans Value as *float64 and 502s on a UInt8 Value "+
+			"(this is the present_over_time `toFloat64(1)`→`1` regression). Wrap in "+
+			"toFloat64(...).\nSQL: %s", fn, valueExpr, sql)
+	}
+
+	hasFloat := false
+	for _, tok := range floatProducingTokens {
+		if strings.Contains(valueExpr, tok) {
+			hasFloat = true
+			break
+		}
+	}
+	if !hasFloat {
+		t.Fatalf("Emit(%s): Value expression %q contains NO float-producing construct "+
+			"(%v) — it projects an integer type that prod's strict *float64 scan rejects "+
+			"with a 502, while the lenient chDB roundtrip silently coerces it. Wrap the "+
+			"reducer in toFloat64(...) / CAST(... AS Float64).\nSQL: %s",
+			fn, valueExpr, floatProducingTokens, sql)
+	}
+
+	// Defence-in-depth: an integer aggregate that is NOT inside any float
+	// wrapper. We've already confirmed hasFloat above, so if an integer
+	// leak token is present, it must be wrapped — but flag the specific
+	// dangerous shape `<intagg>(...) AS Value` with no float token at the
+	// expression head. The hasFloat gate already covers the unwrapped
+	// case (a bare `length(window_vals)` has no float token); this is an
+	// explanatory cross-check that the wrapper actually encloses the
+	// integer aggregate rather than sitting in an unrelated subexpression.
+	for _, tok := range integerLeakTokens {
+		if strings.HasPrefix(valueExpr, tok) {
+			// Expression LEADS with an integer aggregate. The only safe
+			// lead is a float wrapper; leading with length(/count(/countIf(
+			// means the integer result is the projected Value.
+			t.Fatalf("Emit(%s): Value expression %q LEADS with integer aggregate %q "+
+				"(returns UInt64) — prod's *float64 scan 502s. Wrap in toFloat64(...).\n"+
+				"SQL: %s", fn, valueExpr, tok, sql)
+		}
+	}
+}

--- a/internal/chsql/tableshape_orderby_test.go
+++ b/internal/chsql/tableshape_orderby_test.go
@@ -1,0 +1,81 @@
+package chsql
+
+import (
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestMetricsTableShapeLeadsWithMetricName is the cheap, always-on
+// check-gate guard for the landed metrics-table ORDER BY win (#791):
+// every OTel-CH metrics table's TableShape.SortColumns must lead with
+// MetricName, in the exact order
+//
+//	[MetricName, Attributes, ServiceName, TimeUnix]
+//
+// This pins the cerberus-ddl fork's ORDER BY decision *in cerberus's
+// own granule-pruning model*. The emitter ranks predicates by their
+// position in SortColumns (see SortRank / emitFilter), so a regression
+// that re-led the sort key with ServiceName — the OTel upstream default
+// — would silently re-introduce the generic-exclusion granule scan the
+// fork patch was built to avoid (measured 8–17× more granules touched
+// on the common metric-name-first, no-service.name Grafana query; see
+// test/perf/orderby_chdb_test.go for the chDB EXPLAIN proof).
+//
+// Unlike that chDB harness, this test compiles under the default tag and
+// runs on the always-on `check` gate, so an in-repo revert of
+// tableshape.go's metricsShape ordering fails instantly on every PR —
+// no libchdb.so, no EXPLAIN, no wall-clock. It is a pure-function pin
+// over the static shape table.
+func TestMetricsTableShapeLeadsWithMetricName(t *testing.T) {
+	t.Parallel()
+
+	m := schema.DefaultOTelMetrics()
+
+	want := []string{
+		m.MetricNameColumn,  // "MetricName" — MUST be rank 0
+		m.AttributesColumn,  // "Attributes"
+		m.ServiceNameColumn, // "ServiceName"
+		m.TimestampColumn,   // "TimeUnix"
+	}
+
+	// All five metrics tables share the single metricsShape value, so the
+	// pin must hold for each — a future per-table override that diverged
+	// the gauge table's sort key from the histogram table's would also be
+	// caught here.
+	tables := map[string]string{
+		"gauge":     m.GaugeTable,
+		"sum":       m.SumTable,
+		"histogram": m.HistogramTable,
+		"exphist":   m.ExpHistogramTable,
+		"summary":   m.SummaryTable,
+	}
+
+	for label, tbl := range tables {
+		shape := tableShapeFor(tbl)
+		got := shape.SortColumns
+
+		if len(got) != len(want) {
+			t.Fatalf("%s table %q: SortColumns length = %d (%v), want %d (%v)",
+				label, tbl, len(got), got, len(want), want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("%s table %q: SortColumns[%d] = %q, want %q "+
+					"(full got=%v, want=%v).\n"+
+					"The metrics ORDER BY MUST lead with MetricName — leading with "+
+					"ServiceName (the OTel upstream default) re-introduces the "+
+					"generic-exclusion granule scan the cerberus-ddl fork patch "+
+					"removed (8–17× more granules on metric-name-first queries).",
+					label, tbl, i, got[i], want[i], got, want)
+			}
+		}
+
+		// MetricName MUST be the leading (rank-0) sort column — the
+		// single most load-bearing fact for the granule-prune win.
+		if r := shape.SortRank(m.MetricNameColumn); r != 0 {
+			t.Fatalf("%s table %q: SortRank(MetricName) = %d, want 0 "+
+				"(MetricName must lead the ORDER BY)", label, tbl, r)
+		}
+	}
+}

--- a/test/perf/orderby_chdb_test.go
+++ b/test/perf/orderby_chdb_test.go
@@ -63,7 +63,8 @@ const (
 //	attr idx    = (n / nTime)                  % nAttr
 //	time idx    =  n                           % nTime
 func makeInsert(table string, total int) string {
-	return fmt.Sprintf(`INSERT INTO %s
+	return fmt.Sprintf(
+		`INSERT INTO %s
 SELECT
     concat('service.', leftPad(toString(intDiv(number, %d) %% %d), 3, '0')) AS ServiceName,
     concat('metric_', leftPad(toString(intDiv(number, %d) %% %d), 3, '0')) AS MetricName,
@@ -95,6 +96,16 @@ type explainStats struct {
 	cond     string
 	parts    string
 	granules string
+}
+
+// explainRow pairs a query shape + sort-key variant with its parsed
+// EXPLAIN stats and best wall time. Hoisted to package scope (from a
+// local type inside TestOrderByDecision_ChDB) so the granule-prune
+// assertion helpers can range over the collected results.
+type explainRow struct {
+	shape, variant string
+	st             explainStats
+	wall           time.Duration
 }
 
 func runExplain(t *testing.T, db *sql.DB, query string) explainStats {
@@ -206,12 +217,7 @@ func TestOrderByDecision_ChDB(t *testing.T) {
 	t.Logf("=== ORDER BY decision: %d rows (%d svc x %d metrics x %d attr x %d ts), total marks=%d ===",
 		total, nServices, nMetrics, nAttr, nTime, totalGranules)
 
-	type row struct {
-		shape, variant string
-		st             explainStats
-		wall           time.Duration
-	}
-	var results []row
+	var results []explainRow
 	for _, tb := range tables {
 		for _, q := range []struct {
 			shape string
@@ -223,7 +229,7 @@ func TestOrderByDecision_ChDB(t *testing.T) {
 			query := fmt.Sprintf(q.tmpl, tb.name)
 			st := runExplain(t, db, query)
 			wall := timeQuery(t, db, query, iters)
-			results = append(results, row{q.shape, tb.label, st, wall})
+			results = append(results, explainRow{q.shape, tb.label, st, wall})
 		}
 	}
 
@@ -250,6 +256,95 @@ func TestOrderByDecision_ChDB(t *testing.T) {
 		}
 		rows.Close()
 	}
+
+	// --- ASSERTION: granule-prune ratio floor (guards #791) ---------------
+	//
+	// The landed cerberus-ddl fork patch leads the metrics ORDER BY with
+	// MetricName so the common metric-name-first query (NO service.name
+	// matcher — the Grafana / Drilldown-Metrics default) binary-searches
+	// the PK instead of falling to a generic-exclusion scan that touches
+	// granules from every ServiceName block. The measured win on this grid
+	// is 8–17× fewer granules read on the metric-only shape.
+	//
+	// We assert a generous ratio FLOOR (≥4×), not an absolute granule
+	// count: the absolute number is index_granularity-dependent and would
+	// drift if CH changed the default or the grid scaled, but the *ratio*
+	// between the two sort keys on byte-identical data is the structural
+	// property the fork patch buys. The fixed-grid OPTIMIZE … FINAL
+	// single-part setup above makes both granule counts deterministic. A
+	// regression that re-led the sort key with ServiceName (the OTel
+	// upstream default) collapses the ratio toward 1× and trips this floor.
+	svcFirstGranules := selectedGranulesFor(t, results, "metric-only", "ServiceName-first (PRODUCTION)")
+	metricFirstGranules := selectedGranulesFor(t, results, "metric-only", "MetricName-first (PROPOSED)")
+
+	t.Logf("metric-only granule prune: svcfirst=%d  metricfirst=%d  ratio=%.1fx",
+		svcFirstGranules, metricFirstGranules, float64(svcFirstGranules)/float64(maxInt1(metricFirstGranules)))
+
+	if metricFirstGranules <= 0 {
+		t.Fatalf("metric-first metric-only query read %d granules — EXPLAIN parse is "+
+			"degenerate (expected ≥1 selected granule); cannot evaluate the prune ratio",
+			metricFirstGranules)
+	}
+	const minRatio = 4 // generous floor vs the measured 8–17×
+	if metricFirstGranules*minRatio > svcFirstGranules {
+		t.Fatalf("metrics ORDER BY granule-prune regression: the metric-name-first key "+
+			"read %d granules and the service-name-first key read %d — only %.1f× fewer, "+
+			"below the %d× floor. The cerberus-ddl fork's MetricName-first ORDER BY win "+
+			"(measured 8–17× on this grid) has regressed; the leading sort key is no "+
+			"longer letting a no-service.name query PK-range-prune.",
+			metricFirstGranules, svcFirstGranules,
+			float64(svcFirstGranules)/float64(metricFirstGranules), minRatio)
+	}
+}
+
+// selectedGranulesFor pulls the count of SELECTED granules (the
+// numerator of ClickHouse's `Granules: <selected>/<total>` EXPLAIN line)
+// for the result row matching the given shape + variant label. The
+// selected count is the granules ClickHouse actually reads after PK
+// pruning — the quantity the ORDER BY win reduces.
+func selectedGranulesFor(t *testing.T, results []explainRow, shape, variant string) int {
+	t.Helper()
+	for _, r := range results {
+		if r.shape == shape && r.variant == variant {
+			g := parseSelectedGranules(r.st.granules)
+			if g < 0 {
+				t.Fatalf("could not parse selected granules from %q (shape=%s variant=%s)",
+					r.st.granules, shape, variant)
+			}
+			return g
+		}
+	}
+	t.Fatalf("no result row for shape=%s variant=%s", shape, variant)
+	return -1
+}
+
+// parseSelectedGranules extracts the leading integer from a
+// `Granules: <selected>/<total>` EXPLAIN line. Returns -1 on a shape it
+// can't parse.
+func parseSelectedGranules(s string) int {
+	s = stripPrefix(trimSpace(s), "Granules: ")
+	// s is now "<selected>/<total>" (or just "<selected>" defensively).
+	n := 0
+	seen := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c < '0' || c > '9' {
+			break
+		}
+		n = n*10 + int(c-'0')
+		seen = true
+	}
+	if !seen {
+		return -1
+	}
+	return n
+}
+
+func maxInt1(n int) int {
+	if n < 1 {
+		return 1
+	}
+	return n
 }
 
 // --- tiny string helpers (avoid importing strings for two calls) ---

--- a/test/perf/series_fanout_chdb_test.go
+++ b/test/perf/series_fanout_chdb_test.go
@@ -119,7 +119,9 @@ func (c *countingQuerier) snapshot() (int, []time.Duration, []string) {
 // triggers the H fan-out; the underscored form triggers the V fan-out
 // (dotted candidate `http.server.request.duration`).
 func seriesSeed() string {
-	const ts = `2026-05-11 12:00:00`
+	// Rows are anchored at now64(9) below (inside the staleness window the
+	// /series bare-selector instant pipeline applies), so no fixed-timestamp
+	// literal is needed here.
 	gaugeDDL := `CREATE OR REPLACE TABLE otel_metrics_gauge (
 	  ServiceName String, MetricName String, Attributes Map(String,String),
 	  TimeUnix DateTime64(9), Value Float64
@@ -266,6 +268,42 @@ SELECT DISTINCT MetricName, Attributes FROM (
 		t.Logf("CH-time delta:               %v (fan-out)  ->  %v (combined)  =  %.1fx",
 			chSum.Round(time.Microsecond), best.Round(time.Microsecond),
 			float64(chSum)/float64(best))
+	}
+
+	// --- ASSERTION: don't-regress-upward round-trip baseline -------------
+	//
+	// IMPORTANT SCOPE NOTE: the /series fan-in batching (#790) that would
+	// collapse this triple-nested fan-out into a SINGLE combined query is
+	// HELD — it is NOT on main. So this guard deliberately does NOT assert
+	// `n == 1` (that lands as part of the #790 follow-up, at which point
+	// flip the ceiling below to `if n != 1` and delete this note). What it
+	// CAN do today is pin the CURRENT round-trip count as a regression
+	// ceiling: the matcher above (`{__name__="http_server_request_duration"}`)
+	// fans out over the V (dotted-candidate) × H (classic-histogram
+	// companion) variant cross-product, and a bug that added a new
+	// expansion layer — or made an existing one multiply instead of union —
+	// would inflate N. The ceiling bites that explosion without pretending
+	// the batching shipped.
+	//
+	// The ceiling is set generously above the observed count (32 at the
+	// time of writing) so normal variant-set drift (a companion suffix
+	// added/removed) doesn't flake it, while a multiplicative blow-up
+	// (e.g. fanning the H layer over every gauge row, or a doubled V pass)
+	// trips it. When #790 lands and N drops to 1, replace this block with
+	// the exact `n == 1` assertion.
+	const maxRoundTrips = 64
+	if n > maxRoundTrips {
+		t.Fatalf("/series fan-out round-trip regression: a single histogram-shaped "+
+			"match[] request issued %d sequential ClickHouse round-trips, exceeding the "+
+			"%d ceiling. The V×H variant expansion has blown up (a new expansion layer, "+
+			"or an existing one multiplying instead of unioning). NOTE: the #790 fan-in "+
+			"batching that collapses this to 1 round-trip is held off main; when it lands, "+
+			"swap this ceiling for `n == 1`.", n, maxRoundTrips)
+	}
+	if n < 1 {
+		t.Fatalf("/series request issued %d round-trips — the counting Querier saw no "+
+			"CH traffic, so the harness isn't exercising the fan-out path it claims to "+
+			"measure", n)
 	}
 }
 


### PR DESCRIPTION
Closes the perf regression-suite (#73, last substantive item of #68). The perf lane was informational-only and the `test/perf/` chDB harnesses (#789) *asserted nothing and ran in no CI lane* — a revert of any perf win passed silently. This adds **deterministic, CI-gating** assertion-pins (the CockroachDB/TiDB model: gate on plan/cost artifacts, never wall-clock).

## Guards (file → assertion → lane)
1. **CI wiring (load-bearing):** `Justfile perf-chdb` + a `perf-guards` job in `chdb.yml` running `just perf-chdb`. `test/perf/` now actually gates (it ran nowhere before). `perf-benchmark.yml` stays informational.
2. **ORDER BY granule prune** (`test/perf/orderby_chdb_test.go`, chdb lane): `EXPLAIN indexes=1` asserts MetricName-first reads **≥4×** fewer granules than ServiceName-first on the metric-only query (measured 17×). Verified RED on a ServiceName-first revert.
3. **Cheap always-on ORDER BY pin** (`internal/chsql/tableshape_orderby_test.go`, `check` gate, no chDB): `metricsShape.SortColumns` leads with MetricName for all 5 tables. Catches an in-repo `tableshape.go` revert instantly.
4. **Streaming RAM ceiling** (`internal/api/prom/handler_streaming_alloc_test.go`, `check` gate): 1M rows/1000 series → retained `HeapInuse` delta < 32 MB (streaming ~0.2 MB; full-buffering regression ~390 MB). Retained-heap over `AllocsPerOp` deliberately (cumulative allocs scale with samples even when streaming correctly).
5. **Value-is-Float64 emit guard** (`internal/chsql/range_window_value_float64_test.go`, `check` gate): emits all 17 over-time reducers' IR, asserts the Value expr is Float64-typed. Verified RED on both leak shapes (`present_over_time` bare `1`; `count_over_time` unwrapped `length(...)`) — catches the UInt8 leak that 502s prod's strict `*float64` scan but passes lenient chDB.

The held #790 fan-in `==1` round-trip assertion is **not** included (no fan-in on main); `series_fanout_chdb_test.go` instead pins the current N as a don't-regress-upward ceiling with a note for the #790 follow-up.

`go build` (±chdb) clean; touched-package lint clean; 20 check-gate tests + the chdb perf lane pass; every guard verified RED on a simulated regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)