### PR TITLE
ci(chdb): publish roundtrip matrix contexts on docs-only PRs (unblock required checks)

### DIFF
--- a/.github/workflows/chdb.yml
+++ b/.github/workflows/chdb.yml
@@ -137,10 +137,23 @@ jobs:
   #
   # Matrix entries run in parallel (`fail-fast: false`) so a regression
   # in one head doesn't mask regressions in the others.
+  #
+  # DOCS-ONLY GUARD IS PER-STEP, NOT JOB-LEVEL — deliberately. The three
+  # `roundtrip (<ql>)` matrix legs are required status checks on `main`.
+  # A *job-level* `if: docs_only != 'true'` would skip the job before the
+  # matrix expands, so the contexts `roundtrip (promql/logql/traceql)`
+  # are never created and branch protection blocks every docs-only PR
+  # forever with "Expected — Waiting for status to be reported" (a plain
+  # skipped non-matrix job reports its named context and resolves, but a
+  # skipped matrix job never publishes its per-leg names). Instead the
+  # job always runs so the matrix expands and each leg's context is
+  # published; the docs-only guard sits on the work steps, so on a
+  # docs-only PR every step is skipped and each leg concludes `success`
+  # in seconds (no chDB compile/run) — satisfying the required check
+  # without doing the work. Do NOT hoist this back to the job level.
   roundtrip:
     name: roundtrip (${{ matrix.ql }})
     needs: changes
-    if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
@@ -149,20 +162,25 @@ jobs:
         ql: [promql, logql, traceql]
     steps:
       - uses: actions/checkout@v6
+        if: needs.changes.outputs.docs_only != 'true'
 
       - uses: actions/setup-go@v6
+        if: needs.changes.outputs.docs_only != 'true'
         with:
           go-version-file: 'go.mod'
           cache: true
 
       - uses: taiki-e/install-action@v2
+        if: needs.changes.outputs.docs_only != 'true'
         with:
           tool: just
 
       - name: Install libchdb.so
+        if: needs.changes.outputs.docs_only != 'true'
         run: just chdb-install
 
       - name: Run TXTAR round-trip (${{ matrix.ql }})
+        if: needs.changes.outputs.docs_only != 'true'
         run: go test -tags chdb -count=1 ./test/spec/${{ matrix.ql }}/...
 
   # `perf-guards` runs the chDB-tagged deterministic perf-regression


### PR DESCRIPTION
## Problem

Pure-docs-only PRs (e.g. #801) get permanently blocked: the required checks `roundtrip (promql)`, `roundtrip (logql)`, `roundtrip (traceql)` sit forever as **"Expected — Waiting for status to be reported."**

## Root cause

`chdb.yml`'s `roundtrip` job is a **matrix** (`ql: [promql, logql, traceql]`) carrying a **job-level** `if: needs.changes.outputs.docs_only != 'true'`. On a docs-only PR the job is skipped *before the matrix expands*, so the three per-leg check contexts are never created. Branch protection requires those exact context names, so it waits indefinitely.

Non-matrix skipped jobs (`check`, `probe`, `compatibility/*`, `compose-smoke`) are fine — a skipped job *does* publish its single named context, which GitHub treats as satisfied. Only the **matrix** legs vanish when skipped at job level.

## Fix

Move the `docs_only` guard from the **job level** to the **work steps**. The job now always runs (so the matrix expands and `roundtrip (promql/logql/traceql)` contexts are published), but on a docs-only PR every step is `if`-skipped, so each leg concludes **`success`** in seconds — no chDB compile/run. Required checks satisfied; compute still saved on docs-only changes. A prominent comment documents why it must not be hoisted back to the job level.

actionlint clean. Unblocks #801 (RC1 docs correctness pass) and every future docs-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
