### PR TITLE
docs: restructure README — quickstart-first, delegate deep-dives to docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,265 +29,6 @@ corpus is and what each score actually measures.
 
 ---
 
-## Why cerberus?
-
-Metrics, logs, and traces almost never live in one store. The usual
-answer is Prometheus + Loki + Tempo — three retention policies, three
-index strategies, three storage bills, three on-call playbooks. The
-duplication is real and it doesn't buy anything: the OTLP payload going
-into each store is largely the same data, just sliced for a different
-query language.
-
-ClickHouse is a great single store for all three signals. The piece
-that has been missing is the **query side**: dashboards, alerts, and
-CLIs speak PromQL / LogQL / TraceQL, not SQL. Cerberus closes that
-gap. Point Grafana at cerberus as three datasources (Prometheus, Loki,
-Tempo) and the queries you already have keep working — translated into
-optimised ClickHouse SQL underneath.
-
-- **No Grafana plugin.** Cerberus speaks each upstream HTTP API verbatim
-  (`/api/v1/query_range`, `/loki/api/v1/query_range`, `/api/search`,
-  `/api/traces/<id>`, …). Grafana sees three normal datasources.
-- **No custom QL.** PromQL, LogQL, TraceQL — exactly as your dashboards
-  and alerts already use them.
-- **No reinvented parsers.** Cerberus imports
-  `prometheus/promql/parser`, `grafana/loki/v3/pkg/logql/syntax`, and
-  `grafana/tempo/pkg/traceql` directly. If upstream parses it, cerberus
-  parses it.
-
-## Status
-
-**Release candidate — `v1.0.0-RC1`.** PromQL, LogQL, and TraceQL parse +
-lowering are in place; the pattern-based optimiser, the typed `chsql`
-SQL emitter, and the shared `internal/engine` pipeline drive every
-query end to end. Self-observability is wired across all three OTel pillars (logs +
-metrics + traces, all OTLP-exported); operational scaffolding
-(`/readyz`, admission control, `docker compose up` for one-command
-local dev) is in place. Upstream parser shims are routed through the
-[`tsouza/tempo:cerberus-accessors`](https://github.com/tsouza/tempo/tree/cerberus-accessors)
-fork; the schema source of truth is
-[`tsouza/opentelemetry-collector-contrib:cerberus-ddl`](https://github.com/tsouza/opentelemetry-collector-contrib/tree/cerberus-ddl).
-See [`CHANGELOG.md`](CHANGELOG.md) for the per-release breakdown.
-
-## Architecture
-
-Cerberus has **one** query pipeline, not three. Each query language has
-its own parser and its own response shape, but the work in the middle —
-lowering to a shared plan IR, optimising, emitting ClickHouse SQL,
-streaming results — is identical. The three HTTP heads plug in as thin
-`Lang` adapters; the engine owns the parse → optimize → emit → execute
-loop and the telemetry around it.
-
-```text
-   PromQL                LogQL                TraceQL
-     │                     │                     │
-     ▼                     ▼                     ▼
-prometheus/        grafana/loki/v3/         grafana/tempo/
-promql/parser      pkg/logql/syntax         pkg/traceql        ← reference upstream parsers, imported directly
-     │                     │                     │
-     │      per-QL lowering (head → chplan)      │
-     ▼                     ▼                     ▼
- ┌──────────────────────────────────────────────────┐
- │           internal/chplan — shared IR            │   Scan • Filter • Project •
- │  one algebra; the optimiser and the emitter      │   Aggregate • RangeWindow •
- │  don't know which head produced the plan         │   Limit • expression tree
- └──────────────────────────────────────────────────┘
-                       │
-                       ▼
- ┌──────────────────────────────────────────────────┐
- │          internal/optimizer — rule-based         │   Catalyst-style batches:
- │  Analyzer (semantic, idempotent) → Once          │   • constant fold (semantic + heuristic)
- │  (heuristic, idempotent) → FixedPoint(n)         │   • predicate pushdown + filter fusion
- │  (rules that unlock each other; iterates until   │   • filter ↔ project / aggregate /
- │  no rule fires)                                  │     range-window transposes
- │                                                  │   • projection pushdown (late materialisation)
- │                                                  │   • MV substitution (rollup view rewrite)
- └──────────────────────────────────────────────────┘
-                       │
-                       ▼
- ┌──────────────────────────────────────────────────┐
- │           internal/chsql — typed emitter         │   • parameterised, escape-free
- │  QueryBuilder slots + typed Frag constructors;   │   • PREWHERE promotion on Filter(Scan)
- │  the typed surface is closed — external packages │   • sort-key-aware predicate ordering
- │  cannot compose raw SQL by construction          │   • streaming clickhouse-go/v2 cursor
- └──────────────────────────────────────────────────┘
-                       │
-                       ▼
-                  ClickHouse
-```
-
-The three heads share one engine — [`internal/engine/`](internal/engine).
-Each head implements `Lang` (`Parse` + `ProjectSamples`); the engine
-holds the optimiser, the ClickHouse `Querier`, and the OTel spans
-around each pipeline stage. See [`docs/engine.md`](docs/engine.md) for
-the contract, the request lifecycle, and the extension points.
-
-### One IR for three languages — `internal/chplan`
-
-A small algebra (`Scan`, `Filter`, `Project`, `Aggregate`,
-`RangeWindow`, `Limit` + an expression tree) is the meeting point of
-all three heads. The optimiser, the SQL emitter, and the engine work
-over this IR; they don't know which head produced the plan. **New
-optimisations cost one implementation, not three.**
-
-### A real rule-based optimiser — `internal/optimizer`
-
-Catalyst- and DataFusion-style: rules are grouped into batches with
-three strategies — `Analyzer` (semantic, must-run, idempotent — panics
-on contract violation), `Once` (idempotent heuristics, single pass),
-and `FixedPoint(n)` (rules that unlock each other; iterates until no
-rule reports a change or `n` iterations have elapsed). The default
-pipeline ships:
-
-| Stage                            | Rules                                                                                              | What it buys                                                                                        |
-| -------------------------------- | -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| Analyzer — pure-literal fold     | `ConstantFoldSemantic`                                                                             | Downstream rules can assume pure-literal subtrees have collapsed to a single `Lit`                  |
-| Once — heuristic fold            | `ConstantFoldHeuristic`                                                                            | Boolean identity simplification (`true AND X → X`, `false OR X → X`)                                |
-| FixedPoint — predicate pushdown  | `FilterFusion`, `FilterProjectTranspose`, `FilterAggregateTranspose`, `FilterRangeWindowTranspose` | Filters move below projections / aggregates / range windows so CH skip-indexes can fire on a `Scan` |
-| FixedPoint — projection pushdown | `ProjectionPushdown`                                                                               | Late materialisation: wide columns are only resolved after `LIMIT` cuts the row set                 |
-| FixedPoint — MV substitution     | `MVSubstitution`                                                                                   | Swaps `RangeWindow(Scan(otel_metrics_*))` to a pre-aggregated rollup view when the rewrite is safe  |
-
-The optimiser is gated by termination, decision-pin, rule-interaction,
-property, and gremlins (mutation) tests.
-
-### Typed SQL — `internal/chsql`
-
-Every emitted byte goes through a typed builder. Query shapes compose
-through `QueryBuilder` slots (`.Select` / `.From` / `.Where` /
-`.GroupBy` / `.OrderBy` / `.Limit` / `.Prewhere` / `.Join` /
-`.WithRecursive`); expressions compose through typed `Frag`
-constructors (`Eq`, `And`, `Or`, `Paren`, `Cast`, `In`, `Like`, `Add`,
-`Call`, `Array`, `Subscript`, `If`, `Lambda1`, `Subquery`,
-`BareIdent`, `InlineLit`, …). **External packages cannot produce raw
-SQL by construction** — the typed Frag surface is closed, and adding a
-new shape means adding a new typed constructor.
-
-The emitter is also CH-native rather than ANSI-ish:
-
-- **`PREWHERE` promotion** fuses `Filter(Scan)` into a single
-  `SELECT … FROM <table> [PREWHERE …] WHERE …`, partitions conjuncts
-  into a sort-prefix bucket / skip-index bucket / rest, and promotes
-  cheap predicates that touch no wide column into `PREWHERE` when the
-  projection reads any wide column.
-- **`WITH RECURSIVE`** for label-set / trace-graph traversal.
-- **Streaming `clickhouse-go/v2` cursor** — bounded RSS, no row buffer
-  on the hot path; the engine's `QueryCursor` opens a streaming
-  cursor when the underlying client implements `CursorQuerier`.
-
-### Schema — drop-in OTel
-
-Defaults to the
-[OpenTelemetry ClickHouse Exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/clickhouseexporter)
-layout (`otel_metrics_*`, `otel_logs`, `otel_traces`). The schema
-source of truth is the upstream OTel-CH exporter via the
-[`tsouza/opentelemetry-collector-contrib:cerberus-ddl`](https://github.com/tsouza/opentelemetry-collector-contrib/tree/cerberus-ddl)
-fork — cerberus consumes the same DDL templates the production
-exporter emits, so a deployment where the exporter writes and cerberus
-reads sees one schema across both sides. A thin YAML override config
-supports SigNoz schemas and custom column layouts.
-
-## Compatibility harnesses
-
-Correctness for each query language is gated by a **differential
-harness**: cerberus and a reference engine answer the same corpus of
-queries against the same seeded data, and the responses are diffed
-case-for-case. Unit-level golden tests pin SQL bytes; the harnesses
-pin **observed semantics on real ClickHouse** against an upstream
-oracle, which is what catches the gap between "the SQL we emit looks
-right" and "the rows ClickHouse returns are right". Each harness lives
-under `compatibility/<head>/`.
-
-### PromQL — `prometheus/compliance`
-
-- **Reference**: bundled Prometheus engine, queried side-by-side with cerberus.
-- **Corpus**: vendored
-  [`prometheus/compliance/promql/promql-test-queries.yml`](https://github.com/prometheus/compliance).
-- **Driver**: upstream `promql-compliance-tester`.
-- **Today**: **536/536** cases pass; no allow-list exists.
-
-### LogQL — `grafana/loki:pkg/logql/bench`
-
-- **Reference**: Loki single-binary container, queried side-by-side with cerberus.
-- **Corpus**: vendored
-  [`grafana/loki:pkg/logql/bench/queries/{fast,regression,exhaustive}`](https://github.com/grafana/loki/tree/main/pkg/logql/bench/queries).
-- **Driver**: cerberus-owned `loki-compliance-tester`, shape-compatible
-  JSON report with the Prom driver so both feed a single downstream
-  analyser.
-- **Today**: shipped and gating. The full stack — seeder, driver, and
-  the widened corpus whose `${SELECTOR}` / `${LABEL_*}` templates resolve
-  off `dataset_metadata.json` — runs as the required `compatibility/loki`
-  PR check; no allow-list exists.
-
-### TraceQL — cerberus-owned driver
-
-- **Reference**: Tempo monolithic container.
-- **Corpus**: cerberus-owned TXTAR corpus, patterned on `cmd/tempo-vulture`.
-- **Driver**: cerberus-owned binary with `seed` + `diff` subcommands
-  (OTLP push to Tempo + direct CH `INSERT` to cerberus, both from one
-  in-memory fixture so per-span fields stay 1:1 across both read paths).
-- **Today**: shipped and gating. `/api/search`, `/api/traces/<id>`, the
-  four tag / tag-values endpoints (V1 + V2), and the metrics endpoints
-  (`/api/metrics/query_range` + `/api/metrics/query`) all run under the
-  required `compatibility/tempo` PR check; no allow-list exists.
-
-Each harness ships as a Docker Compose stack — reference engine,
-cerberus, ClickHouse, and a one-shot seeder. Local execution:
-
-```sh
-just compat-promql      # PromQL  — prometheus/compliance
-just compat-logql       # LogQL   — grafana/loki pkg/logql/bench
-just compat-traceql     # TraceQL — tempo-vulture-patterned driver
-just compat-all         # run all three
-```
-
-The unified workflow at
-[`.github/workflows/compatibility.yml`](.github/workflows/compatibility.yml)
-runs all three on push-to-main + nightly + manual dispatch. Per-head
-JSON reports are uploaded as artefacts; on `push: main` only the
-workflow commits a fresh `compat-score.json` to the orphan
-`compat-scores` branch under `badges/<head>.json` — the source the
-shields.io endpoint badges at the top of this README read from.
-
-All three harness jobs — `compatibility/{prometheus,loki,tempo}` —
-are required PR status checks on `main`; per-head shields.io badges
-read off the `compat-scores` orphan branch.
-
-**No allow-lists.** No harness carries an expected-failures or skip
-overlay: every diff against the reference backend is a real bug to
-fix at the source (cerberus code, seeder, or reference config). The
-only pinned exclusion set is
-[`compatibility/loki/upstream-skip-baseline.txt`](compatibility/loki/upstream-skip-baseline.txt),
-which records the corpus entries *upstream itself* marks `skip: true`
-(no reference baseline exists for those); the harness fails on any
-drift in that set.
-
-See [`docs/compatibility.md`](docs/compatibility.md) for the full
-playbook (local reproduction, report shape, adding test cases, and the
-`upstream-skip-baseline.txt` drift contract).
-
-## Testing
-
-Cerberus is tested in 11 layers — AST shape pinning, plan-IR
-invariants, optimizer properties, emitted-SQL goldens, chDB-backed
-roundtrips, HTTP wire conformance, system lifecycle, differential
-harnesses, Playwright UX flows, chaos / goleak, perf benchmarks with
-alloc regressions, and an oracle-based property framework. See
-[`docs/test-strategy.md`](docs/test-strategy.md) for the canonical
-layer map, CI-gate inventory, gremlins phased rollout, and per-layer
-recipes for adding a new test.
-
-Quick reference:
-
-| Layer family     | What it covers                                                                    | How to run                                          |
-| ---------------- | --------------------------------------------------------------------------------- | --------------------------------------------------- |
-| **Unit**         | Per-package logic, `Equal` contracts, optimizer rule kernels, Frag goldens        | `just test`                                         |
-| **Spec (TXTAR)** | `<QL> → expected SQL` + chplan IR snapshots + optional chDB roundtrip             | `just test`; `just spec-chdb` for roundtrip lane    |
-| **Property**     | Oracle-based property tests with `rapid` shrinking and chDB execution             | `just property`                                     |
-| **Integration**  | `chclient` against a real ClickHouse via testcontainers                           | `just chclient-integration`                         |
-| **E2E**          | k3d cluster with CH + Grafana + cerberus; Grafana Playwright smoke                | `just e2e`                                          |
-| **Compat**       | Differential parity vs reference Prom / Loki / Tempo                              | `just compat-all` (per-head recipes below)          |
-| **Mutation**     | Gremlins matrix — see `docs/test-strategy.md` § "Gremlins phased rollout" for bar | `just mutate` (slow, nightly in CI)                 |
-
 ## Quick start
 
 Cerberus is a single stateless binary configured entirely via
@@ -310,14 +51,12 @@ up Grafana pre-provisioned with cerberus as three datasources (Prom +
 Loki + Tempo). ClickHouse data persists in a named volume; use
 `docker compose down -v` to wipe it.
 
-The quickstart is tuned for time-to-first-panel rather than steady-state
-throughput: the cerberus OTel SDK flushes metrics every `10s`
-(`CERBERUS_OTLP_EXPORT_INTERVAL`) and the bundled OTel Collector
-batches every `1s`, so a fresh dashboard populates within ~30s of
-`docker compose up`. Production deployments running cerberus at scale
-should raise the interval back up (e.g. `CERBERUS_OTLP_EXPORT_INTERVAL=60s`)
-to cut collector load — the SDK default if the env var is unset is 60s
-to match upstream OTel.
+The quickstart is tuned for time-to-first-panel: the cerberus OTel SDK
+flushes metrics every `10s` (`CERBERUS_OTLP_EXPORT_INTERVAL`) and the
+bundled collector batches every `1s`, so a fresh dashboard populates
+within ~30s. Deployments running at scale should raise the interval to
+cut collector load — see
+[`docs/operations.md`](docs/operations.md) for the env-var contract.
 
 ### From a published release
 
@@ -357,6 +96,165 @@ just e2e-seed          # ingest sample OTel data
 just e2e-run           # Go E2E tests + Grafana playwright smoke
 just e2e-down          # tear down
 ```
+
+## Why cerberus?
+
+Metrics, logs, and traces almost never live in one store. The usual
+answer is Prometheus + Loki + Tempo — three retention policies, three
+index strategies, three storage bills, three on-call playbooks. The
+duplication doesn't buy anything: the OTLP payload going into each store
+is largely the same data, just sliced for a different query language.
+ClickHouse is a great single store for all three signals; the missing
+piece is the **query side**. Point Grafana at cerberus as three
+datasources (Prometheus, Loki, Tempo) and the queries you already have
+keep working — translated into optimised ClickHouse SQL underneath.
+
+- **No Grafana plugin.** Cerberus speaks each upstream HTTP API verbatim
+  (`/api/v1/query_range`, `/loki/api/v1/query_range`, `/api/search`,
+  `/api/traces/<id>`, …). Grafana sees three normal datasources.
+- **No custom QL.** PromQL, LogQL, TraceQL — exactly as your dashboards
+  and alerts already use them.
+- **No reinvented parsers.** Cerberus imports
+  `prometheus/promql/parser`, `grafana/loki/v3/pkg/logql/syntax`, and
+  `grafana/tempo/pkg/traceql` directly. If upstream parses it, cerberus
+  parses it.
+
+## Status
+
+**Release candidate — `v1.0.0-RC1`.** PromQL, LogQL, and TraceQL parse +
+lowering are in place; the pattern-based optimiser, the typed `chsql`
+SQL emitter, and the shared `internal/engine` pipeline drive every
+query end to end. Self-observability is wired across all three OTel
+pillars (logs + metrics + traces, all OTLP-exported); operational
+scaffolding (`/readyz`, admission control, one-command local dev) is in
+place. Upstream parser shims route through the
+[`tsouza/tempo:cerberus-accessors`](https://github.com/tsouza/tempo/tree/cerberus-accessors)
+fork; the schema source of truth is
+[`tsouza/opentelemetry-collector-contrib:cerberus-ddl`](https://github.com/tsouza/opentelemetry-collector-contrib/tree/cerberus-ddl).
+See [`CHANGELOG.md`](CHANGELOG.md) for the per-release breakdown.
+
+## Architecture
+
+Cerberus has **one** query pipeline, not three. Each query language has
+its own parser and its own response shape, but the work in the middle —
+lowering to a shared plan IR, optimising, emitting ClickHouse SQL,
+streaming results — is identical. The three HTTP heads plug in as thin
+`Lang` adapters; the engine owns the parse → optimize → emit → execute
+loop and the telemetry around it.
+
+```text
+   PromQL                LogQL                TraceQL
+     │                     │                     │
+     ▼                     ▼                     ▼
+prometheus/        grafana/loki/v3/         grafana/tempo/
+promql/parser      pkg/logql/syntax         pkg/traceql        ← reference upstream parsers, imported directly
+     │                     │                     │
+     │      per-QL lowering (head → chplan)      │
+     ▼                     ▼                     ▼
+ ┌──────────────────────────────────────────────────┐
+ │           internal/chplan — shared IR            │   Scan • Filter • Project •
+ │  one algebra; the optimiser and the emitter      │   Aggregate • RangeWindow •
+ │  don't know which head produced the plan         │   Limit • expression tree
+ └──────────────────────────────────────────────────┘
+                       │
+                       ▼
+ ┌──────────────────────────────────────────────────┐
+ │          internal/optimizer — rule-based         │   Catalyst-style batches:
+ │  Analyzer (semantic) → Once (heuristic) →        │   fold • predicate pushdown •
+ │  FixedPoint (rules that unlock each other)       │   transposes • projection pushdown •
+ │                                                  │   MV substitution
+ └──────────────────────────────────────────────────┘
+                       │
+                       ▼
+ ┌──────────────────────────────────────────────────┐
+ │           internal/chsql — typed emitter         │   • parameterised, escape-free
+ │  QueryBuilder slots + typed Frag constructors;   │   • PREWHERE promotion on Filter(Scan)
+ │  the typed surface is closed — external packages │   • sort-key-aware predicate ordering
+ │  cannot compose raw SQL by construction          │   • streaming clickhouse-go/v2 cursor
+ └──────────────────────────────────────────────────┘
+                       │
+                       ▼
+                  ClickHouse
+```
+
+The three heads share one engine — [`internal/engine/`](internal/engine).
+Each head implements `Lang` (`Parse` + `ProjectSamples`); the engine
+holds the optimiser, the ClickHouse `Querier`, and the OTel spans around
+each pipeline stage. The shared `internal/chplan` algebra is the meeting
+point of all three heads, so **new optimisations cost one
+implementation, not three** — the Catalyst-style rule-based optimiser,
+the closed typed-Frag `chsql` emitter (CH-native `PREWHERE` /
+`WITH RECURSIVE` / streaming cursor), and the drop-in OTel schema all
+work over that one IR.
+
+See [`docs/engine.md`](docs/engine.md) for the `Lang` contract, the
+request lifecycle, and the in-depth per-stage breakdown (IR algebra,
+the optimiser rule table, the typed-SQL emitter, and the OTel schema).
+
+## Compatibility harnesses
+
+Correctness for each query language is gated by a **differential
+harness**: cerberus and a reference engine answer the same corpus of
+queries against the same seeded data, and the responses are diffed
+case-for-case. Golden tests pin SQL bytes; the harnesses pin **observed
+semantics on real ClickHouse** against an upstream oracle — the gap
+between "the SQL we emit looks right" and "the rows ClickHouse returns
+are right". Each harness lives under `compatibility/<head>/`.
+
+| Head    | Reference + corpus                                          | Required gate              |
+| ------- | ----------------------------------------------------------- | -------------------------- |
+| PromQL  | bundled Prometheus engine vs `prometheus/compliance` corpus | `compatibility/prometheus` |
+| LogQL   | reference Loki vs `grafana/loki:pkg/logql/bench` corpus     | `compatibility/loki`       |
+| TraceQL | reference Tempo vs cerberus-owned TXTAR corpus              | `compatibility/tempo`      |
+
+Each harness ships as a Docker Compose stack — reference engine,
+cerberus, ClickHouse, and a one-shot seeder. Local execution:
+
+```sh
+just compat-promql      # PromQL  — prometheus/compliance
+just compat-logql       # LogQL   — grafana/loki pkg/logql/bench
+just compat-traceql     # TraceQL — tempo-vulture-patterned driver
+just compat-all         # run all three
+```
+
+The unified workflow at
+[`.github/workflows/compatibility.yml`](.github/workflows/compatibility.yml)
+runs all three on PRs + push-to-main + nightly + manual dispatch. All
+three jobs are required PR status checks on `main`; per-head shields.io
+badges read off the `compat-scores` orphan branch.
+
+**No allow-lists.** No harness carries an expected-failures or skip
+overlay: every diff against the reference backend is a real bug to fix
+at the source. The only pinned exclusion set is
+[`compatibility/loki/upstream-skip-baseline.txt`](compatibility/loki/upstream-skip-baseline.txt),
+which records corpus entries *upstream itself* marks `skip: true`; the
+harness fails on any drift in that set.
+
+See [`docs/compatibility.md`](docs/compatibility.md) for the full
+playbook — per-head driver / endpoint detail, local reproduction, report
+shape, rejection parity, adding test cases, and the
+`upstream-skip-baseline.txt` drift contract.
+
+## Testing
+
+Cerberus is tested in 11 layers spanning AST-shape pinning, plan-IR
+invariants, optimizer properties, emitted-SQL goldens, chDB-backed
+roundtrips, HTTP wire conformance, system lifecycle, differential
+harnesses, Playwright UX flows, chaos / goleak, perf benchmarks, and an
+oracle-based property framework. See
+[`docs/test-strategy.md`](docs/test-strategy.md) for the canonical
+layer map, CI-gate inventory, gremlins phased rollout, and per-layer
+recipes. Quick reference:
+
+| Layer family     | What it covers                                                                    | How to run                                          |
+| ---------------- | --------------------------------------------------------------------------------- | --------------------------------------------------- |
+| **Unit**         | Per-package logic, `Equal` contracts, optimizer rule kernels, Frag goldens        | `just test`                                         |
+| **Spec (TXTAR)** | `<QL> → expected SQL` + chplan IR snapshots + optional chDB roundtrip             | `just test`; `just spec-chdb` for roundtrip lane    |
+| **Property**     | Oracle-based property tests with `rapid` shrinking and chDB execution             | `just property`                                     |
+| **Integration**  | `chclient` against a real ClickHouse via testcontainers                           | `just chclient-integration`                         |
+| **E2E**          | k3d cluster with CH + Grafana + cerberus; Grafana Playwright smoke                | `just e2e`                                          |
+| **Compat**       | Differential parity vs reference Prom / Loki / Tempo                              | `just compat-all` (per-head recipes above)          |
+| **Mutation**     | Gremlins matrix — see `docs/test-strategy.md` § "Gremlins phased rollout" for bar | `just mutate` (slow, nightly in CI)                 |
 
 ## Project structure
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -13,7 +13,42 @@ fixture over the same time window.
 
 Scores are published to the orphan
 [`compat-scores`](https://github.com/tsouza/cerberus/tree/compat-scores)
-branch as shields.io badge JSON; the README shows them live.
+branch as shields.io badge JSON; the README shows them live. On
+`push: main` the workflow commits a fresh `compat-score.json` under
+`badges/<head>.json`, which the shields.io endpoint badges read from.
+
+## Per-head detail
+
+### PromQL — `prometheus/compliance`
+
+- **Driver**: upstream `promql-compliance-tester`.
+- **Corpus**: vendored
+  [`prometheus/compliance/promql/promql-test-queries.yml`](https://github.com/prometheus/compliance).
+- **Today**: **536/536** cases pass; no allow-list exists.
+
+### LogQL — `grafana/loki:pkg/logql/bench`
+
+- **Driver**: cerberus-owned `loki-compliance-tester`, shape-compatible
+  JSON report with the Prom driver so both feed a single downstream
+  analyser.
+- **Corpus**: vendored
+  [`grafana/loki:pkg/logql/bench/queries/{fast,regression,exhaustive}`](https://github.com/grafana/loki/tree/main/pkg/logql/bench/queries);
+  the widened corpus's `${SELECTOR}` / `${LABEL_*}` templates resolve
+  off `dataset_metadata.json`.
+- **Today**: shipped and gating as the required `compatibility/loki` PR
+  check; no allow-list exists.
+
+### TraceQL — cerberus-owned driver
+
+- **Driver**: cerberus-owned binary with `seed` + `diff` subcommands
+  (OTLP push to Tempo + direct CH `INSERT` to cerberus, both from one
+  in-memory fixture so per-span fields stay 1:1 across both read paths),
+  patterned on `cmd/tempo-vulture`.
+- **Corpus**: cerberus-owned TXTAR corpus.
+- **Today**: shipped and gating. `/api/search`, `/api/traces/<id>`, the
+  four tag / tag-values endpoints (V1 + V2), and the metrics endpoints
+  (`/api/metrics/query_range` + `/api/metrics/query`) all run under the
+  required `compatibility/tempo` PR check; no allow-list exists.
 
 ## Local run
 

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -202,6 +202,76 @@ error types — `parseStageError` in the Prom adapter,
 so the handler can map them to the right HTTP status without
 losing the cause.
 
+## Pipeline stages in depth
+
+The middle of the pipeline — lower → optimize → emit → schema
+resolution — is the part the three heads share. Each stage is
+described below.
+
+### One IR for three languages — `internal/chplan`
+
+A small algebra (`Scan`, `Filter`, `Project`, `Aggregate`,
+`RangeWindow`, `Limit` + an expression tree) is the meeting point of
+all three heads. The optimiser, the SQL emitter, and the engine work
+over this IR; they don't know which head produced the plan. **New
+optimisations cost one implementation, not three.**
+
+### A real rule-based optimiser — `internal/optimizer`
+
+Catalyst- and DataFusion-style: rules are grouped into batches with
+three strategies — `Analyzer` (semantic, must-run, idempotent — panics
+on contract violation), `Once` (idempotent heuristics, single pass),
+and `FixedPoint(n)` (rules that unlock each other; iterates until no
+rule reports a change or `n` iterations have elapsed). The default
+pipeline ships:
+
+| Stage                            | Rules                                                                                              | What it buys                                                                                        |
+| -------------------------------- | -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| Analyzer — pure-literal fold     | `ConstantFoldSemantic`                                                                             | Downstream rules can assume pure-literal subtrees have collapsed to a single `Lit`                  |
+| Once — heuristic fold            | `ConstantFoldHeuristic`                                                                            | Boolean identity simplification (`true AND X → X`, `false OR X → X`)                                |
+| FixedPoint — predicate pushdown  | `FilterFusion`, `FilterProjectTranspose`, `FilterAggregateTranspose`, `FilterRangeWindowTranspose` | Filters move below projections / aggregates / range windows so CH skip-indexes can fire on a `Scan` |
+| FixedPoint — projection pushdown | `ProjectionPushdown`                                                                               | Late materialisation: wide columns are only resolved after `LIMIT` cuts the row set                 |
+| FixedPoint — MV substitution     | `MVSubstitution`                                                                                   | Swaps `RangeWindow(Scan(otel_metrics_*))` to a pre-aggregated rollup view when the rewrite is safe  |
+
+The optimiser is gated by termination, decision-pin, rule-interaction,
+property, and gremlins (mutation) tests.
+
+### Typed SQL — `internal/chsql`
+
+Every emitted byte goes through a typed builder. Query shapes compose
+through `QueryBuilder` slots (`.Select` / `.From` / `.Where` /
+`.GroupBy` / `.OrderBy` / `.Limit` / `.Prewhere` / `.Join` /
+`.WithRecursive`); expressions compose through typed `Frag`
+constructors (`Eq`, `And`, `Or`, `Paren`, `Cast`, `In`, `Like`, `Add`,
+`Call`, `Array`, `Subscript`, `If`, `Lambda1`, `Subquery`,
+`BareIdent`, `InlineLit`, …). **External packages cannot produce raw
+SQL by construction** — the typed Frag surface is closed, and adding a
+new shape means adding a new typed constructor.
+
+The emitter is also CH-native rather than ANSI-ish:
+
+- **`PREWHERE` promotion** fuses `Filter(Scan)` into a single
+  `SELECT … FROM <table> [PREWHERE …] WHERE …`, partitions conjuncts
+  into a sort-prefix bucket / skip-index bucket / rest, and promotes
+  cheap predicates that touch no wide column into `PREWHERE` when the
+  projection reads any wide column.
+- **`WITH RECURSIVE`** for label-set / trace-graph traversal.
+- **Streaming `clickhouse-go/v2` cursor** — bounded RSS, no row buffer
+  on the hot path; the engine's `QueryCursor` opens a streaming
+  cursor when the underlying client implements `CursorQuerier`.
+
+### Schema — drop-in OTel
+
+Defaults to the
+[OpenTelemetry ClickHouse Exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/clickhouseexporter)
+layout (`otel_metrics_*`, `otel_logs`, `otel_traces`). The schema
+source of truth is the upstream OTel-CH exporter via the
+[`tsouza/opentelemetry-collector-contrib:cerberus-ddl`](https://github.com/tsouza/opentelemetry-collector-contrib/tree/cerberus-ddl)
+fork — cerberus consumes the same DDL templates the production
+exporter emits, so a deployment where the exporter writes and cerberus
+reads sees one schema across both sides. A thin YAML override config
+supports SigNoz schemas and custom column layouts.
+
 ## Adding a new query head
 
 To add a fourth query head, three pieces are needed:


### PR DESCRIPTION
## What

Restructures `README.md` so the **Quick start is first** (was buried at line ~291 of 398) and the file is meaningfully shorter — **398 → 296 lines** — without losing information: the deep-dive content is **relocated** into the docs that already own it, not deleted.

## Changes

- **Quick start → line 32**, right after the intro/badges (the `docker compose up --wait` block is the strongest hook). All three subsections kept intact (Docker Compose / published release / local dev).
- **Why / Status** tightened; Status stays RC (`v1.0.0-RC1`, no "alpha" — preserves #801).
- **Architecture**: keeps the prose intro + ASCII diagram + a summary paragraph; the four deep-dive subsections (chplan IR, optimizer rule table, typed chsql/PREWHERE/WITH-RECURSIVE, OTel schema) are **moved verbatim into `docs/engine.md`** (new "Pipeline stages in depth" section) with a link out.
- **Compatibility**: the three per-head subsections compressed to a short table + commands + link; the per-head driver names, the 536/536 PromQL count, the template-var note, and the full TraceQL endpoint inventory **moved into `docs/compatibility.md`** ("Per-head detail").
- **Testing**: compressed to a one-paragraph summary + quick-ref table + link (the 11-layer map already lives in `docs/test-strategy.md`).

## Why 296, not ~230

The ASCII architecture diagram (~48 lines), the project-structure tree (~28), and the three quickstart code blocks are all keep-intact content — together a ~290-line floor. Everything trimmable was trimmed.

## Verification

markdownlint-cli2 clean (0 errors) on all three changed files. All README relative links + the relocated-doc links verified to resolve. All #801 factual corrections preserved (RC framing, 11 layers, unified compatibility.yml, no-allow-lists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
