### PR TITLE
perf(promql): single-pass as-of RangeLWR for query_range bare selectors (#68)

### DIFF
--- a/internal/chplan/range_lwr.go
+++ b/internal/chplan/range_lwr.go
@@ -1,0 +1,93 @@
+package chplan
+
+import "time"
+
+// RangeLWR is the single-pass, bounded last-with-respect-to (LWR) plan
+// node for a BARE instant-vector selector evaluated over a PromQL
+// `query_range` window. It replaces the O(rows × anchors) StepGrid
+// CROSS JOIN + per-anchor argMax shape the lowering previously emitted
+// (see internal/promql/lower.go:wrapRangeLatestPerSeries) with an
+// O(rows × lookback/step) sample-side fan-out that does NOT scale with
+// the anchor count N.
+//
+// Semantics (identical to the StepGrid path it supersedes):
+//
+//   - The eval grid is `[Start, End]` spaced by Step, end-inclusive
+//     (N = (End-Start)/Step + 1 anchors).
+//   - At each anchor `t` the value is the most-recent sample in the
+//     half-open staleness window `(t - Offset - Lookback, t - Offset]`
+//     (default Lookback = 5m). When no sample falls in that window the
+//     anchor produces NO row — the PromQL staleness gap.
+//   - Output schema is the canonical 4-column Sample contract:
+//     `(MetricNameCol, AttributesCol, TimeUnix = anchor_ts, ValueCol)`
+//     — one row per (series, anchor) that had a sample, with TimeUnix
+//     set to the UNSHIFTED grid anchor (the Offset shifts only the
+//     membership window, not the emitted timestamp).
+//
+// The emitter (internal/chsql.emitRangeLWR) renders this as a single
+// pass over Input: each sample row fans out (via arrayJoin over a
+// bounded `range(lo, hi)` index set) to ONLY the ≤ Lookback/Step + 1
+// anchors whose staleness window contains it, then a
+// `GROUP BY (series, anchor_ts)` with `argMax(Value, TimeUnix)` collapses
+// each (series, anchor) bucket to its newest in-window sample. Because
+// each sample touches a bounded, N-independent number of anchors the
+// intermediate (sample, anchor) cardinality is `rows × (Lookback/Step)`,
+// constant in the grid width — the linear-in-N blowup is gone.
+//
+// Input is the matchers-filtered scan (Scan, or Filter-over-Scan, or the
+// gauge+sum merge() Scan / companion UnionAll). It must expose the
+// MetricNameCol / AttributesCol / TimestampCol / ValueCol columns under
+// those names; the dual-table gauge+sum merge for unsuffixed names is
+// preserved transparently because it lives inside Input's Scan
+// (UnionTables → CH `merge(...)`).
+type RangeLWR struct {
+	Input Node
+
+	// Start / End define the eval grid; Step is the grid spacing.
+	Start time.Time
+	End   time.Time
+	Step  time.Duration
+
+	// Lookback is the staleness horizon (instantLookback, default 5m).
+	// The per-anchor window is `(anchor - Offset - Lookback, anchor - Offset]`.
+	Lookback time.Duration
+
+	// Offset is the PromQL `offset` modifier folded onto the selector.
+	// It shifts the membership window back by Offset (a negative Offset
+	// shifts it forward) WITHOUT moving the emitted anchor timestamp.
+	Offset time.Duration
+
+	// Column names on Input (canonical OTel-CH: MetricName / Attributes /
+	// TimeUnix / Value).
+	MetricNameCol string
+	AttributesCol string
+	TimestampCol  string
+	ValueCol      string
+}
+
+func (*RangeLWR) planNode() {}
+
+func (r *RangeLWR) Children() []Node { return []Node{r.Input} }
+
+func (r *RangeLWR) Equal(other Node) bool {
+	o, ok := other.(*RangeLWR)
+	if !ok {
+		return false
+	}
+	if !r.Start.Equal(o.Start) || !r.End.Equal(o.End) {
+		return false
+	}
+	if r.Step != o.Step || r.Lookback != o.Lookback || r.Offset != o.Offset {
+		return false
+	}
+	if r.MetricNameCol != o.MetricNameCol || r.AttributesCol != o.AttributesCol {
+		return false
+	}
+	if r.TimestampCol != o.TimestampCol || r.ValueCol != o.ValueCol {
+		return false
+	}
+	if r.Input == nil || o.Input == nil {
+		return r.Input == nil && o.Input == nil
+	}
+	return r.Input.Equal(o.Input)
+}

--- a/internal/chplan/range_lwr_test.go
+++ b/internal/chplan/range_lwr_test.go
@@ -1,0 +1,113 @@
+package chplan_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+func newRangeLWR() *chplan.RangeLWR {
+	return &chplan.RangeLWR{
+		Input:         &chplan.Scan{Table: "otel_metrics_gauge"},
+		Start:         time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		End:           time.Date(2026, 1, 1, 0, 5, 0, 0, time.UTC),
+		Step:          30 * time.Second,
+		Lookback:      5 * time.Minute,
+		Offset:        0,
+		MetricNameCol: "MetricName",
+		AttributesCol: "Attributes",
+		TimestampCol:  "TimeUnix",
+		ValueCol:      "Value",
+	}
+}
+
+func TestRangeLWR_Equal_Positive(t *testing.T) {
+	t.Parallel()
+	if !newRangeLWR().Equal(newRangeLWR()) {
+		t.Fatalf("identical RangeLWR trees should be Equal")
+	}
+}
+
+func TestRangeLWR_Equal_Negative_Step(t *testing.T) {
+	t.Parallel()
+	a := newRangeLWR()
+	b := newRangeLWR()
+	b.Step = time.Minute
+	if a.Equal(b) {
+		t.Errorf("different Step should not be Equal")
+	}
+}
+
+func TestRangeLWR_Equal_Negative_Offset(t *testing.T) {
+	t.Parallel()
+	a := newRangeLWR()
+	b := newRangeLWR()
+	b.Offset = -5 * time.Minute
+	if a.Equal(b) {
+		t.Errorf("different Offset should not be Equal")
+	}
+}
+
+func TestRangeLWR_Equal_Negative_Lookback(t *testing.T) {
+	t.Parallel()
+	a := newRangeLWR()
+	b := newRangeLWR()
+	b.Lookback = time.Minute
+	if a.Equal(b) {
+		t.Errorf("different Lookback should not be Equal")
+	}
+}
+
+func TestRangeLWR_Equal_Negative_Cols(t *testing.T) {
+	t.Parallel()
+	a := newRangeLWR()
+	b := newRangeLWR()
+	b.ValueCol = "OtherValue"
+	if a.Equal(b) {
+		t.Errorf("different ValueCol should not be Equal")
+	}
+}
+
+func TestRangeLWR_Equal_Negative_Input(t *testing.T) {
+	t.Parallel()
+	a := newRangeLWR()
+	b := newRangeLWR()
+	b.Input = &chplan.Scan{Table: "otel_metrics_sum"}
+	if a.Equal(b) {
+		t.Errorf("different Input should not be Equal")
+	}
+}
+
+func TestRangeLWR_Equal_Negative_Type(t *testing.T) {
+	t.Parallel()
+	if newRangeLWR().Equal(&chplan.Scan{Table: "otel_metrics_gauge"}) {
+		t.Errorf("RangeLWR should not equal a Scan")
+	}
+}
+
+func TestRangeLWR_Children_ReturnsExactlyInput(t *testing.T) {
+	t.Parallel()
+	input := &chplan.Scan{Table: "t"}
+	r := &chplan.RangeLWR{Input: input}
+	kids := r.Children()
+	if len(kids) != 1 || kids[0] != input {
+		t.Errorf("RangeLWR.Children() should return [Input], got %v", kids)
+	}
+}
+
+func TestRangeLWR_Walk_VisitsInput(t *testing.T) {
+	t.Parallel()
+	input := &chplan.Scan{Table: "t"}
+	root := &chplan.RangeLWR{Input: input}
+	var sawInput bool
+	chplan.Walk(root, func(n chplan.Node) bool {
+		if n == input {
+			sawInput = true
+		}
+		return true
+	})
+	if !sawInput {
+		t.Errorf("Walk over RangeLWR should visit its Input")
+	}
+}

--- a/internal/chsql/emit.go
+++ b/internal/chsql/emit.go
@@ -84,6 +84,8 @@ func (e *emitter) emitNode(n chplan.Node) error {
 		return e.emitMetricsCompare(v)
 	case *chplan.RangeWindow:
 		return e.emitRangeWindow(v)
+	case *chplan.RangeLWR:
+		return e.emitRangeLWR(v)
 	case *chplan.AbsentOverTime:
 		return e.emitAbsentOverTime(v)
 	case *chplan.HistogramQuantile:

--- a/internal/chsql/range_lwr.go
+++ b/internal/chsql/range_lwr.go
@@ -1,0 +1,212 @@
+package chsql
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// emitRangeLWR renders a chplan.RangeLWR — the single-pass, bounded
+// sample-side fan-out that supersedes the StepGrid CROSS JOIN +
+// per-anchor argMax shape for a bare instant-vector selector evaluated
+// over a PromQL `query_range` window.
+//
+// SQL skeleton (N = (End-Start)/Step + 1 grid anchors, but the
+// intermediate cardinality is rows × (Lookback/Step + 1), constant in
+// N):
+//
+//	SELECT MetricName, Attributes, anchor_ts AS TimeUnix,
+//	       argMax(Value, TimeUnix) AS Value
+//	FROM (
+//	  SELECT MetricName, Attributes, TimeUnix, Value,
+//	         arrayJoin(arrayMap(i -> <grid_base> - toIntervalNanosecond(i * <stepNS>),
+//	                   range(greatest(0, floorIdx(dist - lookback)),
+//	                         least(<N>, floorIdx(dist))))) AS anchor_ts
+//	  FROM (<Input>)
+//	)
+//	GROUP BY MetricName, Attributes, anchor_ts
+//
+// where `dist = dateDiff('nanosecond', TimeUnix, <shift_base>)` is the
+// sample's distance behind the newest OFFSET-SHIFTED anchor. The two
+// bases differ only by the offset:
+//
+//   - <shift_base> = End - Offset  — drives window membership: a sample
+//     at ts belongs to anchor i iff `ts <= shiftBase - i*step` (the
+//     `(t - Offset - Lookback, t - Offset]` window's right edge) and
+//     `ts > shiftBase - i*step - Lookback` (its left edge). This is the
+//     EXACT half-open window the StepGrid Filter applied
+//     (`TimeUnix <= anchor_ts - Offset AND TimeUnix > anchor_ts - Offset
+//   - Lookback`).
+//   - <grid_base>  = End          — the value emitted as anchor_ts /
+//     TimeUnix. The Offset shifts the membership window but NOT the
+//     reported sample timestamp, so the emitted anchor stays on the
+//     unshifted `[Start, End]` grid (matching the StepGrid's anchor_ts).
+//
+// Because the index `i` is identical for both bases (they differ by the
+// constant Offset, which cancels in `shiftBase - i*step` vs the membership
+// inequalities), a single `range(lo, hi)` drives both: each sample fans
+// to the same ≤ Lookback/Step + 1 anchors and the arrayMap body emits the
+// unshifted grid anchor for each. The `argMax(Value, TimeUnix)` per
+// (series, anchor) bucket then collapses to the newest in-window sample —
+// the LWR-canonical "latest sample in the staleness window". An anchor
+// with no sample in its window receives no fanned row and so produces no
+// GROUP BY row — preserving Prom's staleness gap.
+//
+// Zero Start/End (the deterministic fixture shape) falls back to
+// `now64(9)` for both bases via timeOrNowFrag.
+func (e *emitter) emitRangeLWR(r *chplan.RangeLWR) error {
+	if r.Step <= 0 {
+		return fmt.Errorf("%w: RangeLWR requires Step > 0", ErrUnsupported)
+	}
+	if r.Input == nil {
+		return fmt.Errorf("%w: RangeLWR.Input is nil", ErrUnsupported)
+	}
+	if r.TimestampCol == "" || r.ValueCol == "" || r.MetricNameCol == "" || r.AttributesCol == "" {
+		return fmt.Errorf("%w: RangeLWR requires MetricName/Attributes/Timestamp/Value column names", ErrUnsupported)
+	}
+
+	stepNS := r.Step.Nanoseconds()
+	lookbackNS := r.Lookback.Nanoseconds()
+
+	// End-inclusive anchor count across the [Start, End] grid. When the
+	// grid bounds are absent (the now64(9) fixture shape) a single anchor
+	// is the only deterministic choice; the bounded fanout still applies.
+	var numAnchors int64 = 1
+	if !r.Start.IsZero() && !r.End.IsZero() {
+		span := r.End.Sub(r.Start).Nanoseconds()
+		if span < 0 {
+			return fmt.Errorf("%w: RangeLWR.Start > End", ErrUnsupported)
+		}
+		numAnchors = span/stepNS + 1
+	}
+
+	// Membership base (offset-shifted newest anchor) and value base
+	// (unshifted grid anchor). Offset folds onto the membership base only.
+	shiftBase := func(b *Builder) {
+		base := timeOrNowFrag(r.End)
+		if r.Offset != 0 {
+			b.sb.WriteByte('(')
+			base(b)
+			b.sb.WriteString(" - toIntervalNanosecond(")
+			b.sb.WriteString(strconv.FormatInt(r.Offset.Nanoseconds(), 10))
+			b.sb.WriteString("))")
+			return
+		}
+		base(b)
+	}
+	gridBase := timeOrNowFrag(r.End)
+
+	inner, err := e.subqueryFrag(r.Input)
+	if err != nil {
+		return err
+	}
+
+	tsIdent := func(b *Builder) { b.Ident(r.TimestampCol) }
+
+	// Sample-fanout SELECT: project the series-identity columns + the raw
+	// (TimeUnix, Value) pair, then fan each sample across only the anchors
+	// whose staleness window contains it. The arrayMap body emits the
+	// UNSHIFTED grid anchor; the index bounds are computed against the
+	// SHIFTED membership base.
+	fanout := NewQuery().From(inner)
+	fanout.Select(Col(r.MetricNameCol))
+	fanout.Select(Col(r.AttributesCol))
+	fanout.Select(Col(r.TimestampCol))
+	fanout.Select(Col(r.ValueCol))
+	fanout.Select(rawAs(
+		lwrAnchorFanoutFrag(gridBase, shiftBase, tsIdent, stepNS, lookbackNS, numAnchors),
+		"anchor_ts",
+	))
+
+	// Collapse SELECT: collapse each (series, anchor) bucket to its newest
+	// in-window sample via argMax(Value, TimeUnix). The anchor stays under
+	// its own `anchor_ts` alias here — NOT re-aliased to TimeUnix — so the
+	// `TimeUnix` reference inside argMax resolves to the INNER per-sample
+	// timestamp column rather than the SELECT-list output alias. (CH's
+	// analyzer resolves a same-SELECT output alias ahead of a source
+	// column of the same name; aliasing anchor_ts → TimeUnix in this
+	// SELECT would shadow the argMax's TimeUnix argument with the constant
+	// per-group anchor, collapsing argMax to an arbitrary sample. The
+	// re-alias is deferred to the outer Project below.)
+	const lwrValueAlias = "lwr_value"
+	collapse := NewQuery().From(fanout.Frag())
+	collapse.Select(Col(r.MetricNameCol))
+	collapse.Select(Col(r.AttributesCol))
+	collapse.Select(Col("anchor_ts"))
+	collapse.Select(rawAs(
+		aggFuncFrag(chplan.AggFunc{
+			Name: "argMax",
+			Args: []chplan.Expr{
+				&chplan.ColumnRef{Name: r.ValueCol},
+				&chplan.ColumnRef{Name: r.TimestampCol},
+			},
+		}),
+		lwrValueAlias,
+	))
+	collapse.GroupBy(Col(r.MetricNameCol), Col(r.AttributesCol), Col("anchor_ts"))
+
+	// Outer SELECT: re-alias anchor_ts → TimeUnix and lwr_value → Value so
+	// the canonical 4-column Sample contract holds for downstream
+	// consumers. Splitting the re-alias into its own SELECT keeps the
+	// collapse SELECT's argMax(Value, TimeUnix) reference unshadowed.
+	outer := NewQuery().From(collapse.Frag())
+	outer.Select(As(Col(r.MetricNameCol), r.MetricNameCol))
+	outer.Select(As(Col(r.AttributesCol), r.AttributesCol))
+	outer.Select(As(verbatim("anchor_ts"), r.TimestampCol))
+	outer.Select(As(verbatim(lwrValueAlias), r.ValueCol))
+
+	e.emitSelect(outer)
+	return nil
+}
+
+// lwrAnchorFanoutFrag renders the LWR sample-side anchor fan-out:
+//
+//	arrayJoin(arrayMap(i -> <gridBase> - toIntervalNanosecond(i * <stepNS>),
+//	          range(greatest(0, floorIdx(dist - lookback)),
+//	                least(<N>, floorIdx(dist)))))
+//
+// where `dist = dateDiff('nanosecond', <ts>, <shiftBase>)` is the
+// sample's distance behind the newest offset-shifted anchor. A sample at
+// ts belongs to exactly the anchors a_i = shiftBase - i*step whose
+// left-open / right-closed staleness window `(a_i - lookback, a_i]`
+// contains it:
+//
+//	ts <= a_i             ⇔  i*step <= dist             ⇔  i <= floor(dist / step)
+//	ts >  a_i - lookback  ⇔  i*step >  dist - lookback  ⇔  i >= floor((dist - lookback)/step) + 1
+//
+// — at most lookback/step + 1 indices per sample, independent of the grid
+// width N. The clamps map both raw bounds through the same monotone
+// greatest/least into [0, N], so out-of-grid samples degenerate to an
+// empty `range(lo, hi)` (`arrayJoin([])` drops the row). The emitted
+// anchor value uses <gridBase> (unshifted) while the index math uses
+// <shiftBase> — the offset shifts the membership window, not the reported
+// timestamp.
+//
+// This is the LWR sibling of sampleAnchorFanoutFrag: same bounded-index
+// machinery (writeAnchorGridFloorIdx), but the arrayMap body emits the
+// unshifted grid anchor so an offset query reports the grid timestamp,
+// and the window width is the staleness lookback rather than a PromQL
+// range-vector `[range]`.
+func lwrAnchorFanoutFrag(gridBase, shiftBase, ts Frag, stepNS, lookbackNS, numAnchors int64) Frag {
+	dist := func(b *Builder) {
+		b.sb.WriteString("dateDiff('nanosecond', ")
+		ts(b)
+		b.sb.WriteString(", ")
+		shiftBase(b)
+		b.sb.WriteByte(')')
+	}
+	return func(b *Builder) {
+		b.sb.WriteString("arrayJoin(arrayMap(i -> ")
+		gridBase(b)
+		b.sb.WriteString(" - toIntervalNanosecond(i * ")
+		b.sb.WriteString(strconv.FormatInt(stepNS, 10))
+		b.sb.WriteString("), range(greatest(0, ")
+		writeAnchorGridFloorIdx(b, dist, -lookbackNS, stepNS)
+		b.sb.WriteString("), least(")
+		b.sb.WriteString(strconv.FormatInt(numAnchors, 10))
+		b.sb.WriteString(", ")
+		writeAnchorGridFloorIdx(b, dist, 0, stepNS)
+		b.sb.WriteString("))))")
+	}
+}

--- a/internal/chsql/range_lwr_test.go
+++ b/internal/chsql/range_lwr_test.go
@@ -1,0 +1,107 @@
+package chsql_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+)
+
+// TestEmitRangeLWR_SinglePassShape pins the structural invariants of the
+// RangeLWR emitter: a bounded sample-side fan-out (arrayJoin over a
+// `range(greatest(0, ...), least(N, ...))` index set), a per-(series,
+// anchor) argMax collapse, and the unshadowed re-alias — and crucially the
+// ABSENCE of the old StepGrid CROSS JOIN shape. This is the cheap guard
+// that the single-pass rewrite stays single-pass even if a future edit
+// re-touches the emitter; the byte-exact SQL is pinned by the TXTAR
+// goldens (test/spec/promql/*.txtar).
+func TestEmitRangeLWR_SinglePassShape(t *testing.T) {
+	t.Parallel()
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	plan := &chplan.RangeLWR{
+		Input:         &chplan.Scan{Table: "otel_metrics_gauge"},
+		Start:         start,
+		End:           start.Add(5 * time.Minute),
+		Step:          30 * time.Second,
+		Lookback:      5 * time.Minute,
+		MetricNameCol: "MetricName",
+		AttributesCol: "Attributes",
+		TimestampCol:  "TimeUnix",
+		ValueCol:      "Value",
+	}
+	sql, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	// MUST be single-pass: no CROSS JOIN, no StepGrid grid fan-out.
+	if strings.Contains(sql, "CROSS JOIN") {
+		t.Errorf("RangeLWR emit must NOT contain a CROSS JOIN (single-pass invariant); got:\n%s", sql)
+	}
+	// MUST carry the bounded sample-side fan-out: arrayJoin over a clamped
+	// range, anchored on the grid base walking BACK by i*step.
+	for _, want := range []string{
+		"arrayJoin(arrayMap(i ->",
+		"range(greatest(0,",
+		"least(11,", // (5m / 30s) + 1 = 11 anchors
+		"argMax(`Value`, `TimeUnix`)",
+		"GROUP BY `MetricName`, `Attributes`, `anchor_ts`",
+		"anchor_ts AS `TimeUnix`",
+	} {
+		if !strings.Contains(sql, want) {
+			t.Errorf("RangeLWR emit missing %q; got:\n%s", want, sql)
+		}
+	}
+}
+
+// TestEmitRangeLWR_OffsetShiftsWindowNotAnchor pins that a non-zero Offset
+// folds onto the MEMBERSHIP base (the dateDiff target) but the emitted
+// anchor stays on the unshifted grid base — `offset` shifts the staleness
+// window, not the reported timestamp.
+func TestEmitRangeLWR_OffsetShiftsWindowNotAnchor(t *testing.T) {
+	t.Parallel()
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	plan := &chplan.RangeLWR{
+		Input:         &chplan.Scan{Table: "otel_metrics_gauge"},
+		Start:         start,
+		End:           start.Add(5 * time.Minute),
+		Step:          time.Minute,
+		Lookback:      5 * time.Minute,
+		Offset:        -5 * time.Minute, // forward shift
+		MetricNameCol: "MetricName",
+		AttributesCol: "Attributes",
+		TimestampCol:  "TimeUnix",
+		ValueCol:      "Value",
+	}
+	sql, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	// The membership base subtracts the (negative) offset → forward shift.
+	if !strings.Contains(sql, "toIntervalNanosecond(-300000000000)") {
+		t.Errorf("offset emit must fold the offset onto the membership base; got:\n%s", sql)
+	}
+	// The emitted anchor still walks back from the unshifted End grid.
+	if !strings.Contains(sql, "toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(i * 60000000000)") {
+		t.Errorf("offset emit must keep the anchor on the unshifted grid base; got:\n%s", sql)
+	}
+}
+
+// TestEmitRangeLWR_RejectsZeroStep guards the Step > 0 precondition.
+func TestEmitRangeLWR_RejectsZeroStep(t *testing.T) {
+	t.Parallel()
+	plan := &chplan.RangeLWR{
+		Input:         &chplan.Scan{Table: "otel_metrics_gauge"},
+		Step:          0,
+		MetricNameCol: "MetricName",
+		AttributesCol: "Attributes",
+		TimestampCol:  "TimeUnix",
+		ValueCol:      "Value",
+	}
+	if _, _, err := chsql.Emit(context.Background(), plan); err == nil {
+		t.Errorf("RangeLWR with Step=0 should error")
+	}
+}

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -796,142 +796,57 @@ func wrapInstantLatestPerSeries(scan chplan.Node, pred chplan.Expr, anchor evalA
 }
 
 // wrapRangeLatestPerSeries builds the per-step LWR for a vector
-// selector evaluated over a query_range window. The shape is:
+// selector evaluated over a query_range window. It emits a single
+// chplan.RangeLWR node:
 //
-//	Project [MetricName, Attributes, anchor_ts AS TimeUnix, lwr_value AS Value]
-//	  Aggregate by (MetricName, Attributes, anchor_ts) funcs=[argMax(Value, TimeUnix) AS lwr_value]
-//	    Filter (anchor_ts - <offset> >= TimeUnix AND TimeUnix > anchor_ts - <offset> - 5m)
-//	      CrossJoin(StepGrid(start, end, step), Scan + matchers_filter)
+//	RangeLWR step=<step> lookback=5m [offset=<o>] ts=TimeUnix value=Value start=<s> end=<e>
+//	  Scan + matchers_filter
 //
-// At each step `t = start, start+step, ..., end` the StepGrid emits one
-// `anchor_ts = t` row; the CrossJoin pairs that with every raw sample row,
-// the Filter trims to the per-step LWR window `(t-offset-5m, t-offset]`,
-// the Aggregate collapses to one row per (series, anchor) carrying the
-// latest-in-window Value, and the outer Project exposes the canonical
-// (MetricName, Attributes, TimeUnix, Value) shape with TimeUnix = anchor_ts.
+// The RangeLWR emitter (internal/chsql.emitRangeLWR) renders the
+// single-pass, bounded sample-side fan-out: each sample fans out to ONLY
+// the ≤ lookback/step + 1 anchors whose staleness window
+// `(anchor - offset - 5m, anchor - offset]` contains it, then a
+// `GROUP BY (MetricName, Attributes, anchor_ts)` with
+// `argMax(Value, TimeUnix)` collapses each (series, anchor) bucket to its
+// newest in-window sample. The output is the canonical 4-column Sample
+// contract `(MetricName, Attributes, TimeUnix = anchor_ts, Value)`, one
+// row per (series, anchor) that had data — identical to the shape the
+// prior StepGrid CROSS JOIN + per-anchor argMax produced, but at
+// O(rows × lookback/step) intermediate cardinality (constant in the grid
+// width N) instead of O(rows × N).
+//
+// The half-open window edges, the offset-shifts-the-window-not-the-anchor
+// semantics, and the staleness-gap "no sample → no row" rule are all
+// preserved by the RangeLWR emitter (see range_lwr.go). The
+// `@<absolute>` pinned-anchor shape is routed away upstream
+// (wrapRangeAbsoluteAtBroadcast), so anchor.End is zero here and only
+// anchor.Offset shifts the window.
 //
 // Output schema preservation lets the surrounding plan tree (aggregations,
 // arithmetic, instant fns) keep consuming the same column shape it did
-// before — the difference vs the instant LWR wrap is that each (series)
-// produces N rows (one per step inside `[start, end]` that had data) rather
-// than a single row at `end_ts`.
+// before — each (series) produces N rows (one per step inside
+// `[start, end]` that had data) rather than a single row at `end_ts`.
 func wrapRangeLatestPerSeries(scan chplan.Node, pred chplan.Expr, anchor evalAnchor, ctx lowerCtx, s schema.Metrics) chplan.Node {
-	const (
-		anchorCol     = "anchor_ts"
-		lwrValueAlias = "lwr_value"
-	)
-	anchorRef := &chplan.ColumnRef{Name: anchorCol}
-	// `@`/offset modifiers shift the LWR window against the per-step
-	// anchor: `up offset 5m` over a step at `t` evaluates the latest
-	// sample in `(t-5m-5m, t-5m]`. The shift is `(anchor_ts - offset)`
-	// for the upper bound and `(anchor_ts - offset - lookback)` for the
-	// strict lower bound.
-	//
-	// When the modifier is `@<absolute>` (no offset, ctx.end ignored)
-	// the per-step semantics still apply — Prom queries with `@ start()`
-	// over a range query keep a single anchor across all steps. That
-	// shape is rare enough that the wrap below falls back to a per-step
-	// anchor (i.e., the user's intent is preserved when they don't pin
-	// the absolute @ modifier).
-	var upperBound chplan.Expr = anchorRef
-	// Negative offsets shift the lookback window FORWARD in time relative
-	// to each step's anchor (Prom evaluates `metric offset -5m` at
-	// `t - (-5m) = t + 5m`). The subtraction below handles the sign
-	// correctly — `anchor_ts - toIntervalNanosecond(-300_000_000_000)`
-	// renders as `anchor_ts + 5m` per CH interval arithmetic. The
-	// guard checks `!= 0` rather than `> 0` so the negative case isn't
-	// silently zeroed.
-	if anchor.Offset != 0 {
-		upperBound = &chplan.Binary{
-			Op:   chplan.OpSub,
-			Left: anchorRef,
-			Right: &chplan.FuncCall{
-				Name: "toIntervalNanosecond",
-				Args: []chplan.Expr{&chplan.LitInt{V: anchor.Offset.Nanoseconds()}},
-			},
-		}
-	}
-	// `TimeUnix <= anchor_ts - offset` (non-strict upper)
-	lwrUpper := &chplan.Binary{
-		Op:    chplan.OpLe,
-		Left:  &chplan.ColumnRef{Name: s.TimestampColumn},
-		Right: upperBound,
-	}
-	// `TimeUnix > anchor_ts - offset - lookback` (strict lower)
-	lookbackNs := instantLookback.Nanoseconds() + anchor.Offset.Nanoseconds()
-	lowerBound := &chplan.Binary{
-		Op:   chplan.OpSub,
-		Left: anchorRef,
-		Right: &chplan.FuncCall{
-			Name: "toIntervalNanosecond",
-			Args: []chplan.Expr{&chplan.LitInt{V: lookbackNs}},
-		},
-	}
-	lwrLower := &chplan.Binary{
-		Op:    chplan.OpGt,
-		Left:  &chplan.ColumnRef{Name: s.TimestampColumn},
-		Right: lowerBound,
-	}
-
 	// Inner Scan/Filter — apply matchers via PREWHERE-eligible filter
 	// the optimizer already promotes. The `(scan, pred)` split keeps the
 	// downstream PREWHERE path unchanged; when pred is nil (no matchers)
-	// the scan flows directly into the CrossJoin.
+	// the scan flows directly into the RangeLWR.
 	rawSide := scan
 	if pred != nil {
 		rawSide = &chplan.Filter{Input: scan, Predicate: pred}
 	}
 
-	stepGrid := &chplan.StepGrid{
-		Start: ctx.start.UTC(),
-		End:   ctx.end.UTC(),
-		Step:  ctx.step,
-	}
-	joined := &chplan.CrossJoin{
-		Left:  stepGrid,
-		Right: rawSide,
-	}
-
-	// Filter to the per-step LWR window.
-	filterPred := chplan.Expr(&chplan.Binary{
-		Op: chplan.OpAnd, Left: lwrUpper, Right: lwrLower,
-	})
-	filtered := &chplan.Filter{Input: joined, Predicate: filterPred}
-
-	// Aggregate per (MetricName, Attributes, anchor_ts) collapsing to
-	// the latest sample in the per-step window. The argMax over
-	// TimeUnix gives the LWR-canonical "newest sample in window".
-	agg := &chplan.Aggregate{
-		Input: filtered,
-		GroupBy: []chplan.Expr{
-			&chplan.ColumnRef{Name: s.MetricNameColumn},
-			&chplan.ColumnRef{Name: s.AttributesColumn},
-			anchorRef,
-		},
-		GroupByAliases: []string{s.MetricNameColumn, s.AttributesColumn, anchorCol},
-		AggFuncs: []chplan.AggFunc{
-			{
-				Name: "argMax",
-				Args: []chplan.Expr{
-					&chplan.ColumnRef{Name: s.ValueColumn},
-					&chplan.ColumnRef{Name: s.TimestampColumn},
-				},
-				Alias: lwrValueAlias,
-			},
-		},
-	}
-
-	// Outer Project re-aliases anchor_ts → TimeUnix so the canonical
-	// 4-column Sample contract holds for downstream consumers
-	// (aggregations, arithmetic, instant fns, the handler-side pivot).
-	return &chplan.Project{
-		Input: agg,
-		Projections: []chplan.Projection{
-			{Expr: &chplan.ColumnRef{Name: s.MetricNameColumn}, Alias: s.MetricNameColumn},
-			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
-			{Expr: anchorRef, Alias: s.TimestampColumn},
-			{Expr: &chplan.ColumnRef{Name: lwrValueAlias}, Alias: s.ValueColumn},
-		},
+	return &chplan.RangeLWR{
+		Input:         rawSide,
+		Start:         ctx.start.UTC(),
+		End:           ctx.end.UTC(),
+		Step:          ctx.step,
+		Lookback:      instantLookback,
+		Offset:        anchor.Offset,
+		MetricNameCol: s.MetricNameColumn,
+		AttributesCol: s.AttributesColumn,
+		TimestampCol:  s.TimestampColumn,
+		ValueCol:      s.ValueColumn,
 	}
 }
 

--- a/test/perf/range_lwr_scaling_chdb_test.go
+++ b/test/perf/range_lwr_scaling_chdb_test.go
@@ -1,0 +1,363 @@
+//go:build chdb
+
+// Perf guard (RC1 PromQL query_range LWR): the bare instant-vector
+// `query_range` LWR path used to emit an N-anchor StepGrid CROSS JOIN +
+// a correlated per-anchor staleness Filter + a per-(series, anchor)
+// argMax — an O(rows × anchors) shape whose wall time scaled LINEARLY
+// with the anchor count N (measured on main: N=61/121/241 → ~480/951/
+// 1855ms for a fixed row set, ~100× the single-instant argMax). The
+// CROSS JOIN materialised ~rows × (lookback/step) (sample, anchor)
+// membership rows — at N=241 / step=6m / lookback=5m every sample landed
+// in ~40 overlapping windows, a ~37× blow-up over the scan.
+//
+// The fix (internal/chplan.RangeLWR + internal/chsql.emitRangeLWR)
+// replaces the CROSS JOIN with a single-pass, bounded sample-side
+// fan-out: each sample fans out (via arrayJoin over a bounded
+// `range(lo, hi)` index set) to ONLY the ≤ lookback/step + 1 anchors
+// whose staleness window `(anchor - lookback, anchor]` contains it, then
+// `GROUP BY (series, anchor) argMax(Value, TimeUnix)` collapses each
+// bucket. The intermediate (sample, anchor) cardinality is
+// rows × (lookback/step + 1) — CONSTANT in the grid width N — so wall
+// time stops scaling with N.
+//
+// This guard pins both invariants against regression:
+//
+//  1. Scaling: hold the row set + window + lookback fixed and vary the
+//     step so the anchor count N grows (61 → 121 → 241). The new path's
+//     wall time stays ~flat (sub-linear) in N; the old CROSS JOIN path's
+//     grows linearly. The assertion is on the RATIO (new is much flatter
+//     than old), not absolute ms, so it's portable across runner speeds.
+//
+//  2. Intermediate cardinality: the new fan-out's (sample, anchor) row
+//     count is bounded by rows × (lookback/step + 1) and is INDEPENDENT
+//     of N (it shrinks as step grows because fewer anchors fit in the
+//     lookback window), whereas the old shape's grows with the grid.
+//
+// Build-tagged `chdb`, same lane as the other chDB execs (#70/#789).
+package perf
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	_ "github.com/chdb-io/chdb-go/chdb/driver"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// rangeLWRSeed builds a single gauge table with a moderate series fan-out
+// and many samples per series across a fixed 24h window, so the per-anchor
+// fan-out has real granule work to do. The row count is FIXED regardless
+// of the query's step, isolating the anchor-count variable.
+func rangeLWRSeed() string {
+	ddl := `CREATE TABLE otel_metrics_gauge (
+	  ServiceName String, MetricName String, Attributes Map(String,String),
+	  TimeUnix DateTime64(9), Value Float64
+	) ENGINE = MergeTree()
+	ORDER BY (MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix));`
+	// 200 series × ~900 samples (one every 96s over 24h) = 180k rows —
+	// in the same ballpark as the verified ~181k scan-row figure.
+	ins := `INSERT INTO otel_metrics_gauge SELECT
+	  'svc',
+	  'demo_memory_usage_bytes',
+	  map('instance', concat('i', toString(number % 200))),
+	  toDateTime64('2026-01-01 00:00:00', 9) + toIntervalSecond((intDiv(number, 200)) * 96),
+	  toFloat64(number)
+	FROM numbers(180000);`
+	return ddl + ins
+}
+
+// emitRangeLWRSQL lowers `demo_memory_usage_bytes` over a query_range
+// window [start, end] spaced by step and returns the emitted SQL + args.
+func emitRangeLWRSQL(t *testing.T, start, end time.Time, step time.Duration) (string, []any) {
+	t.Helper()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	expr, err := p.ParseExpr("demo_memory_usage_bytes")
+	if err != nil {
+		t.Fatalf("ParseExpr: %v", err)
+	}
+	plan, err := promql.LowerAtRange(context.Background(), expr, schema.DefaultOTelMetrics(), start, end, step)
+	if err != nil {
+		t.Fatalf("LowerAtRange: %v", err)
+	}
+	sqlText, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	return sqlText, args
+}
+
+// oldCrossJoinSQL reconstructs the PRE-fix StepGrid CROSS JOIN + per-anchor
+// argMax shape verbatim, so the guard can contrast its scaling against the
+// new single-pass path on identical data. This is the exact shape
+// internal/promql/lower.go:wrapRangeLatestPerSeries emitted before the
+// RangeLWR rework (a StepGrid arrayJoin grid, a CROSS JOIN against the
+// scan, the per-anchor staleness Filter, and the per-(series, anchor)
+// argMax). Kept inline (not emitted) precisely because the fix DELETED the
+// emitter for it — the guard pins that the deleted shape was the slow one.
+func oldCrossJoinSQL(start, end time.Time, step, lookback time.Duration) string {
+	stepNS := step.Nanoseconds()
+	numAnchors := end.Sub(start).Nanoseconds()/stepNS + 1
+	startLit := start.UTC().Format("2006-01-02 15:04:05.000000000")
+	return fmt.Sprintf(`SELECT MetricName, Attributes, anchor_ts AS TimeUnix, argMax(Value, TimeUnix) AS Value FROM (
+  SELECT * FROM (
+    SELECT arrayJoin(arrayMap(i -> toDateTime64('%s', 9) + toIntervalNanosecond(i * %d), range(0, %d))) AS anchor_ts
+  ) AS L CROSS JOIN (
+    SELECT * FROM otel_metrics_gauge WHERE MetricName = 'demo_memory_usage_bytes'
+  ) AS R
+) WHERE (TimeUnix <= anchor_ts AND TimeUnix > anchor_ts - toIntervalNanosecond(%d))
+GROUP BY MetricName, Attributes, anchor_ts`,
+		startLit, stepNS, numAnchors, lookback.Nanoseconds())
+}
+
+// bestOf runs q `iters` times and returns the fastest wall time (min
+// strips scheduler / GC jitter — the floor is what we compare). args binds
+// the `?` placeholders the emitted SQL carries (the inline-literal old
+// shape passes no args).
+func bestOf(t *testing.T, db *sql.DB, q string, args []any, iters int) time.Duration {
+	t.Helper()
+	best := time.Hour
+	for i := 0; i < iters; i++ {
+		s := time.Now()
+		var c int64
+		// Wrap in count() so chDB-go's parquet driver returns one row —
+		// the GROUP BY / fan-out / scan work being timed is identical.
+		if err := db.QueryRow("SELECT count() FROM ("+q+")", args...).Scan(&c); err != nil {
+			t.Fatalf("query: %v\nSQL: %s", err, q)
+		}
+		if d := time.Since(s); d < best {
+			best = d
+		}
+	}
+	return best
+}
+
+// fanoutCardinality counts the (sample, anchor) membership rows the inner
+// fan-out produces BEFORE the GROUP BY collapse — the intermediate blow-up
+// the fix targets. For the new path it strips the outer collapse SELECT and
+// counts the fan-out subquery; for the old path it counts the CROSS JOIN +
+// staleness Filter rows.
+func fanoutCardinality(t *testing.T, db *sql.DB, innerCountSQL string) int64 {
+	t.Helper()
+	var c int64
+	if err := db.QueryRow(innerCountSQL).Scan(&c); err != nil {
+		t.Fatalf("cardinality query: %v\nSQL: %s", err, innerCountSQL)
+	}
+	return c
+}
+
+func TestRangeLWR_Scaling_ChDB(t *testing.T) {
+	db := openChDB(t)
+	if _, err := db.Exec("CREATE DATABASE IF NOT EXISTS default"); err != nil {
+		t.Fatalf("create db: %v", err)
+	}
+	// Seed once; the row set is identical across every step variant.
+	for _, stmt := range splitSQL(rangeLWRSeed()) {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("seed: %v\n%s", err, stmt)
+		}
+	}
+
+	const lookback = 5 * time.Minute
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	// Fixed 24h window; vary the step so anchor count N = 24h/step + 1
+	// grows 61 → 121 → 241 while the row set stays put.
+	end := start.Add(24 * time.Hour)
+	steps := []struct {
+		step time.Duration
+		n    int64
+	}{
+		{24 * time.Hour / 60, 61},   // 24m  → 61 anchors
+		{24 * time.Hour / 120, 121}, // 12m  → 121 anchors
+		{24 * time.Hour / 240, 241}, // 6m   → 241 anchors
+	}
+
+	const iters = 5
+	type row struct {
+		n                int64
+		newWall, oldWall time.Duration
+		newCard, oldCard int64
+	}
+	results := make([]row, 0, len(steps))
+
+	for _, sc := range steps {
+		newSQL, newArgs := emitRangeLWRSQL(t, start, end, sc.step)
+		oldSQL := oldCrossJoinSQL(start, end, sc.step, lookback)
+
+		newWall := bestOf(t, db, newSQL, newArgs, iters)
+		oldWall := bestOf(t, db, oldSQL, nil, iters)
+
+		// Intermediate (sample, anchor) cardinality before the collapse.
+		newCard := fanoutCardinality(t, db, "SELECT count() FROM ("+newFanoutInner(start, end, sc.step, lookback)+")")
+		oldCard := fanoutCardinality(t, db, "SELECT count() FROM ("+oldFanoutInner(start, end, sc.step, lookback)+")")
+
+		results = append(results, row{sc.n, newWall, oldWall, newCard, oldCard})
+		t.Logf("N=%-4d  new=%-10v old=%-10v   new_card=%-10d old_card=%-10d",
+			sc.n, newWall.Round(time.Microsecond), oldWall.Round(time.Microsecond), newCard, oldCard)
+	}
+
+	first, last := results[0], results[len(results)-1]
+
+	var scanRows int64
+	if err := db.QueryRow("SELECT count() FROM otel_metrics_gauge").Scan(&scanRows); err != nil {
+		t.Fatalf("scan count: %v", err)
+	}
+
+	// --- Invariant 1: new path is FAR faster + scales FLATTER than old --
+	//
+	// The headline win: the old O(rows×anchors) CROSS JOIN wall grows
+	// linearly in N (measured here ~593→2409ms across the 4× N sweep,
+	// matching the verified main-branch ~480→1855ms), while the new
+	// single-pass path stays in the tens of ms. Two robust, runner-
+	// portable assertions (no absolute-ms thresholds):
+	//
+	//  (a) At the largest N the new path is DRAMATICALLY faster than old —
+	//      require ≥5× (observed ~46×). A regression that reinstated the
+	//      CROSS JOIN would collapse this margin.
+	//  (b) The new path scales STRICTLY FLATTER in N than the old: its
+	//      growth ratio across the 4× N sweep is clearly below the old's.
+	//      (The new growth is dominated by the bounded fan-out's
+	//      lookback/step window-overlap factor + fixed per-query overhead,
+	//      NOT by the grid width — so it stays well under the old's
+	//      linear-in-N growth.)
+	newGrowth := ratio(last.newWall, first.newWall)
+	oldGrowth := ratio(last.oldWall, first.oldWall)
+	t.Logf("growth over 4x N:  new=%.2fx  old=%.2fx", newGrowth, oldGrowth)
+
+	speedup := ratio(last.oldWall, last.newWall)
+	t.Logf("at N=%d: new=%v old=%v  speedup=%.1fx", last.n,
+		last.newWall.Round(time.Microsecond), last.oldWall.Round(time.Microsecond), speedup)
+	if speedup < 5.0 {
+		t.Errorf("RangeLWR perf regression: at N=%d the single-pass path is only %.1fx faster than the "+
+			"old CROSS JOIN shape (new=%v old=%v); want ≥5x. A collapsed margin means the "+
+			"O(rows×anchors) fan-out shape regressed back in.", last.n, speedup, last.newWall, last.oldWall)
+	}
+	// Require the old shape to actually exhibit linear-in-N growth (so the
+	// guard is meaningfully seeded) and the new shape to scale clearly
+	// flatter. The 0.8× factor leaves headroom for the new path's small-
+	// absolute-time noise while still catching a regression that made the
+	// new path track N as steeply as the old.
+	if oldGrowth > 2.0 && newGrowth >= oldGrowth*0.8 {
+		t.Errorf("RangeLWR scaling regression: new-path growth %.2fx is not clearly flatter than the "+
+			"old CROSS JOIN growth %.2fx across the 4x N sweep — the single-pass rework must scale "+
+			"strictly better in the anchor count.", newGrowth, oldGrowth)
+	}
+
+	// --- Invariant 2: new intermediate cardinality is BOUNDED, not N×rows
+	//
+	// The new fan-out's (sample, anchor) count is rows × (lookback/step+1)
+	// — it grows only as fast as lookback/step (the window-overlap factor),
+	// NOT as rows × N. The decisive contrast: at N=241 the new path's
+	// intermediate is ~0.9× the scan rows, while the old shape forces CH to
+	// build a rows × N (~241×) gross CROSS JOIN before the staleness Filter
+	// prunes it. We pin that the new card stays a SMALL multiple of the
+	// scan (here ≤ a few × scan_rows across the sweep) and is dwarfed by
+	// rows × N — that's the bounded-fan-out invariant. (The post-Filter
+	// membership count is identical for both shapes by construction —
+	// old_card == new_card in the log — so the win is the gross product CH
+	// must materialise, asserted below.)
+	if last.newCard > scanRows*3 {
+		t.Errorf("RangeLWR cardinality regression: new fan-out (sample,anchor) rows = %d at N=%d, "+
+			"exceeding 3× the scan rows (%d) — the bounded fan-out rows×(lookback/step+1) blew up. A "+
+			"value tracking rows×N means the bounded index range degenerated to the full grid.",
+			last.newCard, last.n, scanRows)
+	}
+
+	// Gross CROSS JOIN materialisation (rows × N) the old shape forces,
+	// contrasted with the new path's scan rows (rows, no fan multiplier in
+	// the gross product). This is the headline blow-up the fix removes.
+	oldGross := scanRows * last.n
+	t.Logf("at N=%d: scan_rows=%d  old_gross_crossjoin=%d (%.0fx)  new_intermediate=%d (%.1fx)",
+		last.n, scanRows, oldGross, float64(oldGross)/float64(scanRows),
+		last.newCard, float64(last.newCard)/float64(scanRows))
+
+	if oldGross <= scanRows*int64(2) {
+		t.Errorf("expected the old CROSS JOIN to materialise rows×N >> rows; got gross=%d vs scan=%d "+
+			"(the perf-bug premise — a CROSS JOIN blow-up — is not reproduced, so the guard is "+
+			"mis-seeded).", oldGross, scanRows)
+	}
+}
+
+func ratio(a, b time.Duration) float64 {
+	if b <= 0 {
+		return 1
+	}
+	return float64(a) / float64(b)
+}
+
+// newFanoutInner is the bounded sample-side fan-out subquery the RangeLWR
+// emitter produces, BEFORE the GROUP BY collapse — one row per (sample,
+// covered anchor). Mirrors internal/chsql.lwrAnchorFanoutFrag (no offset).
+// Counting its rows measures the new path's intermediate cardinality.
+func newFanoutInner(start, end time.Time, step, lookback time.Duration) string {
+	stepNS := step.Nanoseconds()
+	numAnchors := end.Sub(start).Nanoseconds()/stepNS + 1
+	endLit := end.UTC().Format("2006-01-02 15:04:05.000000000")
+	dist := fmt.Sprintf("dateDiff('nanosecond', TimeUnix, toDateTime64('%s', 9))", endLit)
+	floorIdx := func(addNS int64) string {
+		num := dist
+		if addNS < 0 {
+			num = fmt.Sprintf("%s - %d", dist, -addNS)
+		}
+		return fmt.Sprintf("intDiv(%s, toInt64(%d)) - (modulo(%s, toInt64(%d)) < 0) + 1",
+			num, stepNS, num, stepNS)
+	}
+	return fmt.Sprintf(`SELECT TimeUnix, Value,
+  arrayJoin(arrayMap(i -> toDateTime64('%s', 9) - toIntervalNanosecond(i * %d),
+    range(greatest(0, %s), least(%d, %s)))) AS anchor_ts
+FROM otel_metrics_gauge WHERE MetricName = 'demo_memory_usage_bytes'`,
+		endLit, stepNS, floorIdx(-lookback.Nanoseconds()), numAnchors, floorIdx(0))
+}
+
+// oldFanoutInner is the PRE-fix CROSS JOIN + staleness Filter subquery,
+// BEFORE the per-(series, anchor) argMax — one row per (sample, covered
+// anchor). Same membership count as newFanoutInner; the contrast is the
+// GROSS CROSS JOIN (rows × N) CH must build before the Filter prunes it.
+func oldFanoutInner(start, end time.Time, step, lookback time.Duration) string {
+	stepNS := step.Nanoseconds()
+	numAnchors := end.Sub(start).Nanoseconds()/stepNS + 1
+	startLit := start.UTC().Format("2006-01-02 15:04:05.000000000")
+	return fmt.Sprintf(`SELECT TimeUnix, Value, anchor_ts FROM (
+  SELECT * FROM (
+    SELECT arrayJoin(arrayMap(i -> toDateTime64('%s', 9) + toIntervalNanosecond(i * %d), range(0, %d))) AS anchor_ts
+  ) AS L CROSS JOIN (
+    SELECT * FROM otel_metrics_gauge WHERE MetricName = 'demo_memory_usage_bytes'
+  ) AS R
+) WHERE (TimeUnix <= anchor_ts AND TimeUnix > anchor_ts - toIntervalNanosecond(%d))`,
+		startLit, stepNS, numAnchors, lookback.Nanoseconds())
+}
+
+// splitSQL splits a multi-statement seed string on `;` boundaries,
+// dropping empties so each statement runs as its own db.Exec.
+func splitSQL(s string) []string {
+	out := make([]string, 0, 4)
+	for _, part := range splitOnSemicolon(s) {
+		p := trimSpace(part)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func splitOnSemicolon(s string) []string {
+	var parts []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == ';' {
+			parts = append(parts, s[start:i])
+			start = i + 1
+		}
+	}
+	if start < len(s) {
+		parts = append(parts, s[start:])
+	}
+	return parts
+}

--- a/test/spec/chplan_print.go
+++ b/test/spec/chplan_print.go
@@ -190,6 +190,22 @@ func printNode(b *strings.Builder, n chplan.Node, depth int) {
 		}
 		b.WriteString("\n")
 		printNode(b, v.Input, depth+1)
+	case *chplan.RangeLWR:
+		fmt.Fprintf(b, "%sRangeLWR step=%s lookback=%s", indent, v.Step, v.Lookback)
+		if v.Offset != 0 {
+			fmt.Fprintf(b, " offset=%s", v.Offset)
+		}
+		if v.TimestampCol != "" {
+			fmt.Fprintf(b, " ts=%s", v.TimestampCol)
+		}
+		if v.ValueCol != "" {
+			fmt.Fprintf(b, " value=%s", v.ValueCol)
+		}
+		if !v.Start.IsZero() || !v.End.IsZero() {
+			fmt.Fprintf(b, " start=%s end=%s", v.Start.UTC().Format("2006-01-02T15:04:05Z"), v.End.UTC().Format("2006-01-02T15:04:05Z"))
+		}
+		b.WriteString("\n")
+		printNode(b, v.Input, depth+1)
 	case *chplan.VectorJoin:
 		fmt.Fprintf(b, "%sVectorJoin op=%s match=%s card=%s",
 			indent, v.Op, printVectorMatch(v.Match), printVectorCard(v.Card))

--- a/test/spec/promql/binop_time_arith_range.txtar
+++ b/test/spec/promql/binop_time_arith_range.txtar
@@ -41,15 +41,10 @@ INSERT INTO otel_metrics_sum VALUES
 [3] string = "http.requests.total"
 [4] string = "http.requests_total"
 [5] string = "http_requests.total"
-[6] int64 = 300000000000
 -- chplan --
 Project ["" AS MetricName, Attributes, TimeUnix, (toFloat64((toUnixTimestamp64Nano(TimeUnix) / 1000000000)) + Value) AS Value]
-  Project [MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS TimeUnix, lwr_value AS Value]
-    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS anchor_ts] funcs=[argMax(Value, TimeUnix) AS lwr_value]
-      Filter predicate=((TimeUnix <= anchor_ts) AND (TimeUnix > (anchor_ts - toIntervalNanosecond(300000000000))))
-        CrossJoin
-          StepGrid start=2026-01-01T00:00:00.000000000Z end=2026-01-01T00:05:00.000000000Z step=30s
-          Filter predicate=(MetricName IN ("http_requests_total", "http.requests.total", "http.requests_total", "http_requests.total"))
-            Scan(otel_metrics_sum)
+  RangeLWR step=30s lookback=5m0s ts=TimeUnix value=Value start=2026-01-01T00:00:00Z end=2026-01-01T00:05:00Z
+    Filter predicate=(MetricName IN ("http_requests_total", "http.requests.total", "http.requests_total", "http_requests.total"))
+      Scan(otel_metrics_sum)
 -- sql --
-SELECT ? AS `MetricName`, `Attributes`, `TimeUnix`, (toFloat64((toUnixTimestamp64Nano(`TimeUnix`) / ?)) + `Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `anchor_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT * FROM (SELECT arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:00:00.000000000', 9) + toIntervalNanosecond(i * 30000000000), range(0, 11))) AS `anchor_ts`) AS L CROSS JOIN (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` IN (?, ?, ?, ?))) AS R) WHERE ((`TimeUnix` <= `anchor_ts`) AND (`TimeUnix` > (`anchor_ts` - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`, `anchor_ts`))
+SELECT ? AS `MetricName`, `Attributes`, `TimeUnix`, (toFloat64((toUnixTimestamp64Nano(`TimeUnix`) / ?)) + `Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, anchor_ts AS `TimeUnix`, lwr_value AS `Value` FROM (SELECT `MetricName`, `Attributes`, `anchor_ts`, argMax(`Value`, `TimeUnix`) AS lwr_value FROM (SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value`, arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(i * 30000000000), range(greatest(0, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) < 0) + 1), least(11, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) < 0) + 1)))) AS anchor_ts FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` IN (?, ?, ?, ?)))) GROUP BY `MetricName`, `Attributes`, `anchor_ts`))

--- a/test/spec/promql/bottomk_range_bare.txtar
+++ b/test/spec/promql/bottomk_range_bare.txtar
@@ -77,15 +77,10 @@ INSERT INTO otel_metrics_gauge VALUES
 [5] string = "demo_memory.usage.bytes"
 [6] string = "demo_memory.usage_bytes"
 [7] string = "demo_memory_usage.bytes"
-[8] int64 = 300000000000
 -- chplan --
 TopK k=5 sort=Value ASC by=[TimeUnix] columns=[MetricName, Attributes, TimeUnix, Value]
-  Project [MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS TimeUnix, lwr_value AS Value]
-    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS anchor_ts] funcs=[argMax(Value, TimeUnix) AS lwr_value]
-      Filter predicate=((TimeUnix <= anchor_ts) AND (TimeUnix > (anchor_ts - toIntervalNanosecond(300000000000))))
-        CrossJoin
-          StepGrid start=2026-01-01T00:00:00.000000000Z end=2026-01-01T00:05:00.000000000Z step=30s
-          Filter predicate=(MetricName IN ("demo_memory_usage_bytes", "demo.memory.usage.bytes", "demo.memory.usage_bytes", "demo.memory_usage.bytes", "demo.memory_usage_bytes", "demo_memory.usage.bytes", "demo_memory.usage_bytes", "demo_memory_usage.bytes"))
-            Scan(merge(otel_metrics_gauge|otel_metrics_sum))
+  RangeLWR step=30s lookback=5m0s ts=TimeUnix value=Value start=2026-01-01T00:00:00Z end=2026-01-01T00:05:00Z
+    Filter predicate=(MetricName IN ("demo_memory_usage_bytes", "demo.memory.usage.bytes", "demo.memory.usage_bytes", "demo.memory_usage.bytes", "demo.memory_usage_bytes", "demo_memory.usage.bytes", "demo_memory.usage_bytes", "demo_memory_usage.bytes"))
+      Scan(merge(otel_metrics_gauge|otel_metrics_sum))
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `anchor_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT * FROM (SELECT arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:00:00.000000000', 9) + toIntervalNanosecond(i * 30000000000), range(0, 11))) AS `anchor_ts`) AS L CROSS JOIN (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?))) AS R) WHERE ((`TimeUnix` <= `anchor_ts`) AND (`TimeUnix` > (`anchor_ts` - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`, `anchor_ts`)) ORDER BY `Value` LIMIT 5 BY `TimeUnix`)
+SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, anchor_ts AS `TimeUnix`, lwr_value AS `Value` FROM (SELECT `MetricName`, `Attributes`, `anchor_ts`, argMax(`Value`, `TimeUnix`) AS lwr_value FROM (SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value`, arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(i * 30000000000), range(greatest(0, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) < 0) + 1), least(11, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) < 0) + 1)))) AS anchor_ts FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?)))) GROUP BY `MetricName`, `Attributes`, `anchor_ts`)) ORDER BY `Value` LIMIT 5 BY `TimeUnix`)

--- a/test/spec/promql/bottomk_range_by_instance.txtar
+++ b/test/spec/promql/bottomk_range_by_instance.txtar
@@ -77,16 +77,11 @@ INSERT INTO otel_metrics_gauge VALUES
 [5] string = "demo_memory.usage.bytes"
 [6] string = "demo_memory.usage_bytes"
 [7] string = "demo_memory_usage.bytes"
-[8] int64 = 300000000000
-[9] string = "instance"
+[8] string = "instance"
 -- chplan --
 TopK k=5 sort=Value ASC by=[Attributes["instance"], TimeUnix] columns=[MetricName, Attributes, TimeUnix, Value]
-  Project [MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS TimeUnix, lwr_value AS Value]
-    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS anchor_ts] funcs=[argMax(Value, TimeUnix) AS lwr_value]
-      Filter predicate=((TimeUnix <= anchor_ts) AND (TimeUnix > (anchor_ts - toIntervalNanosecond(300000000000))))
-        CrossJoin
-          StepGrid start=2026-01-01T00:00:00.000000000Z end=2026-01-01T00:05:00.000000000Z step=30s
-          Filter predicate=(MetricName IN ("demo_memory_usage_bytes", "demo.memory.usage.bytes", "demo.memory.usage_bytes", "demo.memory_usage.bytes", "demo.memory_usage_bytes", "demo_memory.usage.bytes", "demo_memory.usage_bytes", "demo_memory_usage.bytes"))
-            Scan(merge(otel_metrics_gauge|otel_metrics_sum))
+  RangeLWR step=30s lookback=5m0s ts=TimeUnix value=Value start=2026-01-01T00:00:00Z end=2026-01-01T00:05:00Z
+    Filter predicate=(MetricName IN ("demo_memory_usage_bytes", "demo.memory.usage.bytes", "demo.memory.usage_bytes", "demo.memory_usage.bytes", "demo.memory_usage_bytes", "demo_memory.usage.bytes", "demo_memory.usage_bytes", "demo_memory_usage.bytes"))
+      Scan(merge(otel_metrics_gauge|otel_metrics_sum))
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `anchor_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT * FROM (SELECT arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:00:00.000000000', 9) + toIntervalNanosecond(i * 30000000000), range(0, 11))) AS `anchor_ts`) AS L CROSS JOIN (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?))) AS R) WHERE ((`TimeUnix` <= `anchor_ts`) AND (`TimeUnix` > (`anchor_ts` - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`, `anchor_ts`)) ORDER BY `Value` LIMIT 5 BY `Attributes`[?], `TimeUnix`)
+SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, anchor_ts AS `TimeUnix`, lwr_value AS `Value` FROM (SELECT `MetricName`, `Attributes`, `anchor_ts`, argMax(`Value`, `TimeUnix`) AS lwr_value FROM (SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value`, arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(i * 30000000000), range(greatest(0, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) < 0) + 1), least(11, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) < 0) + 1)))) AS anchor_ts FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?)))) GROUP BY `MetricName`, `Attributes`, `anchor_ts`)) ORDER BY `Value` LIMIT 5 BY `Attributes`[?], `TimeUnix`)

--- a/test/spec/promql/bottomk_range_without_empty.txtar
+++ b/test/spec/promql/bottomk_range_without_empty.txtar
@@ -77,15 +77,10 @@ INSERT INTO otel_metrics_gauge VALUES
 [5] string = "demo_memory.usage.bytes"
 [6] string = "demo_memory.usage_bytes"
 [7] string = "demo_memory_usage.bytes"
-[8] int64 = 300000000000
 -- chplan --
 TopK k=5 sort=Value ASC by=[Attributes, TimeUnix] columns=[MetricName, Attributes, TimeUnix, Value]
-  Project [MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS TimeUnix, lwr_value AS Value]
-    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS anchor_ts] funcs=[argMax(Value, TimeUnix) AS lwr_value]
-      Filter predicate=((TimeUnix <= anchor_ts) AND (TimeUnix > (anchor_ts - toIntervalNanosecond(300000000000))))
-        CrossJoin
-          StepGrid start=2026-01-01T00:00:00.000000000Z end=2026-01-01T00:05:00.000000000Z step=30s
-          Filter predicate=(MetricName IN ("demo_memory_usage_bytes", "demo.memory.usage.bytes", "demo.memory.usage_bytes", "demo.memory_usage.bytes", "demo.memory_usage_bytes", "demo_memory.usage.bytes", "demo_memory.usage_bytes", "demo_memory_usage.bytes"))
-            Scan(merge(otel_metrics_gauge|otel_metrics_sum))
+  RangeLWR step=30s lookback=5m0s ts=TimeUnix value=Value start=2026-01-01T00:00:00Z end=2026-01-01T00:05:00Z
+    Filter predicate=(MetricName IN ("demo_memory_usage_bytes", "demo.memory.usage.bytes", "demo.memory.usage_bytes", "demo.memory_usage.bytes", "demo.memory_usage_bytes", "demo_memory.usage.bytes", "demo_memory.usage_bytes", "demo_memory_usage.bytes"))
+      Scan(merge(otel_metrics_gauge|otel_metrics_sum))
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `anchor_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT * FROM (SELECT arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:00:00.000000000', 9) + toIntervalNanosecond(i * 30000000000), range(0, 11))) AS `anchor_ts`) AS L CROSS JOIN (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?))) AS R) WHERE ((`TimeUnix` <= `anchor_ts`) AND (`TimeUnix` > (`anchor_ts` - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`, `anchor_ts`)) ORDER BY `Value` LIMIT 5 BY `Attributes`, `TimeUnix`)
+SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, anchor_ts AS `TimeUnix`, lwr_value AS `Value` FROM (SELECT `MetricName`, `Attributes`, `anchor_ts`, argMax(`Value`, `TimeUnix`) AS lwr_value FROM (SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value`, arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(i * 30000000000), range(greatest(0, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) < 0) + 1), least(11, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) < 0) + 1)))) AS anchor_ts FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?)))) GROUP BY `MetricName`, `Attributes`, `anchor_ts`)) ORDER BY `Value` LIMIT 5 BY `Attributes`, `TimeUnix`)

--- a/test/spec/promql/bottomk_range_without_instance.txtar
+++ b/test/spec/promql/bottomk_range_without_instance.txtar
@@ -77,16 +77,11 @@ INSERT INTO otel_metrics_gauge VALUES
 [5] string = "demo_memory.usage.bytes"
 [6] string = "demo_memory.usage_bytes"
 [7] string = "demo_memory_usage.bytes"
-[8] int64 = 300000000000
-[9] string = "instance"
+[8] string = "instance"
 -- chplan --
 TopK k=5 sort=Value ASC by=[mapWithout(Attributes, [instance]), TimeUnix] columns=[MetricName, Attributes, TimeUnix, Value]
-  Project [MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS TimeUnix, lwr_value AS Value]
-    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS anchor_ts] funcs=[argMax(Value, TimeUnix) AS lwr_value]
-      Filter predicate=((TimeUnix <= anchor_ts) AND (TimeUnix > (anchor_ts - toIntervalNanosecond(300000000000))))
-        CrossJoin
-          StepGrid start=2026-01-01T00:00:00.000000000Z end=2026-01-01T00:05:00.000000000Z step=30s
-          Filter predicate=(MetricName IN ("demo_memory_usage_bytes", "demo.memory.usage.bytes", "demo.memory.usage_bytes", "demo.memory_usage.bytes", "demo.memory_usage_bytes", "demo_memory.usage.bytes", "demo_memory.usage_bytes", "demo_memory_usage.bytes"))
-            Scan(merge(otel_metrics_gauge|otel_metrics_sum))
+  RangeLWR step=30s lookback=5m0s ts=TimeUnix value=Value start=2026-01-01T00:00:00Z end=2026-01-01T00:05:00Z
+    Filter predicate=(MetricName IN ("demo_memory_usage_bytes", "demo.memory.usage.bytes", "demo.memory.usage_bytes", "demo.memory_usage.bytes", "demo.memory_usage_bytes", "demo_memory.usage.bytes", "demo_memory.usage_bytes", "demo_memory_usage.bytes"))
+      Scan(merge(otel_metrics_gauge|otel_metrics_sum))
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `anchor_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT * FROM (SELECT arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:00:00.000000000', 9) + toIntervalNanosecond(i * 30000000000), range(0, 11))) AS `anchor_ts`) AS L CROSS JOIN (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?))) AS R) WHERE ((`TimeUnix` <= `anchor_ts`) AND (`TimeUnix` > (`anchor_ts` - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`, `anchor_ts`)) ORDER BY `Value` LIMIT 5 BY mapFilter((k, v) -> NOT (k IN (?)), `Attributes`), `TimeUnix`)
+SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, anchor_ts AS `TimeUnix`, lwr_value AS `Value` FROM (SELECT `MetricName`, `Attributes`, `anchor_ts`, argMax(`Value`, `TimeUnix`) AS lwr_value FROM (SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value`, arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(i * 30000000000), range(greatest(0, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) < 0) + 1), least(11, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) < 0) + 1)))) AS anchor_ts FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?)))) GROUP BY `MetricName`, `Attributes`, `anchor_ts`)) ORDER BY `Value` LIMIT 5 BY mapFilter((k, v) -> NOT (k IN (?)), `Attributes`), `TimeUnix`)

--- a/test/spec/promql/offset_negative.txtar
+++ b/test/spec/promql/offset_negative.txtar
@@ -45,15 +45,9 @@ INSERT INTO otel_metrics_gauge VALUES
 [5] string = "demo_memory.usage.bytes"
 [6] string = "demo_memory.usage_bytes"
 [7] string = "demo_memory_usage.bytes"
-[8] int64 = -300000000000
-[9] int64 = 0
 -- chplan --
-Project [MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS TimeUnix, lwr_value AS Value]
-  Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS anchor_ts] funcs=[argMax(Value, TimeUnix) AS lwr_value]
-    Filter predicate=((TimeUnix <= (anchor_ts - toIntervalNanosecond(-300000000000))) AND (TimeUnix > (anchor_ts - toIntervalNanosecond(0))))
-      CrossJoin
-        StepGrid start=2026-01-01T00:00:00.000000000Z end=2026-01-01T00:05:00.000000000Z step=1m0s
-        Filter predicate=(MetricName IN ("demo_memory_usage_bytes", "demo.memory.usage.bytes", "demo.memory.usage_bytes", "demo.memory_usage.bytes", "demo.memory_usage_bytes", "demo_memory.usage.bytes", "demo_memory.usage_bytes", "demo_memory_usage.bytes"))
-          Scan(merge(otel_metrics_gauge|otel_metrics_sum))
+RangeLWR step=1m0s lookback=5m0s offset=-5m0s ts=TimeUnix value=Value start=2026-01-01T00:00:00Z end=2026-01-01T00:05:00Z
+  Filter predicate=(MetricName IN ("demo_memory_usage_bytes", "demo.memory.usage.bytes", "demo.memory.usage_bytes", "demo.memory_usage.bytes", "demo.memory_usage_bytes", "demo_memory.usage.bytes", "demo_memory.usage_bytes", "demo_memory_usage.bytes"))
+    Scan(merge(otel_metrics_gauge|otel_metrics_sum))
 -- sql --
-SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `anchor_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT * FROM (SELECT arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:00:00.000000000', 9) + toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts`) AS L CROSS JOIN (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?))) AS R) WHERE ((`TimeUnix` <= (`anchor_ts` - toIntervalNanosecond(?))) AND (`TimeUnix` > (`anchor_ts` - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`, `anchor_ts`)
+SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, anchor_ts AS `TimeUnix`, lwr_value AS `Value` FROM (SELECT `MetricName`, `Attributes`, `anchor_ts`, argMax(`Value`, `TimeUnix`) AS lwr_value FROM (SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value`, arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(i * 60000000000), range(greatest(0, intDiv(dateDiff('nanosecond', `TimeUnix`, (toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(-300000000000))) - 300000000000, toInt64(60000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, (toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(-300000000000))) - 300000000000, toInt64(60000000000)) < 0) + 1), least(6, intDiv(dateDiff('nanosecond', `TimeUnix`, (toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(-300000000000))), toInt64(60000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, (toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(-300000000000))), toInt64(60000000000)) < 0) + 1)))) AS anchor_ts FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?)))) GROUP BY `MetricName`, `Attributes`, `anchor_ts`)

--- a/test/spec/promql/topk_range_bare.txtar
+++ b/test/spec/promql/topk_range_bare.txtar
@@ -77,15 +77,10 @@ INSERT INTO otel_metrics_gauge VALUES
 [5] string = "demo_memory.usage.bytes"
 [6] string = "demo_memory.usage_bytes"
 [7] string = "demo_memory_usage.bytes"
-[8] int64 = 300000000000
 -- chplan --
 TopK k=5 sort=Value DESC by=[TimeUnix] columns=[MetricName, Attributes, TimeUnix, Value]
-  Project [MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS TimeUnix, lwr_value AS Value]
-    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS anchor_ts] funcs=[argMax(Value, TimeUnix) AS lwr_value]
-      Filter predicate=((TimeUnix <= anchor_ts) AND (TimeUnix > (anchor_ts - toIntervalNanosecond(300000000000))))
-        CrossJoin
-          StepGrid start=2026-01-01T00:00:00.000000000Z end=2026-01-01T00:05:00.000000000Z step=30s
-          Filter predicate=(MetricName IN ("demo_memory_usage_bytes", "demo.memory.usage.bytes", "demo.memory.usage_bytes", "demo.memory_usage.bytes", "demo.memory_usage_bytes", "demo_memory.usage.bytes", "demo_memory.usage_bytes", "demo_memory_usage.bytes"))
-            Scan(merge(otel_metrics_gauge|otel_metrics_sum))
+  RangeLWR step=30s lookback=5m0s ts=TimeUnix value=Value start=2026-01-01T00:00:00Z end=2026-01-01T00:05:00Z
+    Filter predicate=(MetricName IN ("demo_memory_usage_bytes", "demo.memory.usage.bytes", "demo.memory.usage_bytes", "demo.memory_usage.bytes", "demo.memory_usage_bytes", "demo_memory.usage.bytes", "demo_memory.usage_bytes", "demo_memory_usage.bytes"))
+      Scan(merge(otel_metrics_gauge|otel_metrics_sum))
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `anchor_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT * FROM (SELECT arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:00:00.000000000', 9) + toIntervalNanosecond(i * 30000000000), range(0, 11))) AS `anchor_ts`) AS L CROSS JOIN (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?))) AS R) WHERE ((`TimeUnix` <= `anchor_ts`) AND (`TimeUnix` > (`anchor_ts` - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`, `anchor_ts`)) ORDER BY `Value` DESC LIMIT 5 BY `TimeUnix`)
+SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, anchor_ts AS `TimeUnix`, lwr_value AS `Value` FROM (SELECT `MetricName`, `Attributes`, `anchor_ts`, argMax(`Value`, `TimeUnix`) AS lwr_value FROM (SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value`, arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(i * 30000000000), range(greatest(0, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) < 0) + 1), least(11, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) < 0) + 1)))) AS anchor_ts FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?)))) GROUP BY `MetricName`, `Attributes`, `anchor_ts`)) ORDER BY `Value` DESC LIMIT 5 BY `TimeUnix`)

--- a/test/spec/promql/topk_range_by_instance.txtar
+++ b/test/spec/promql/topk_range_by_instance.txtar
@@ -77,16 +77,11 @@ INSERT INTO otel_metrics_gauge VALUES
 [5] string = "demo_memory.usage.bytes"
 [6] string = "demo_memory.usage_bytes"
 [7] string = "demo_memory_usage.bytes"
-[8] int64 = 300000000000
-[9] string = "instance"
+[8] string = "instance"
 -- chplan --
 TopK k=5 sort=Value DESC by=[Attributes["instance"], TimeUnix] columns=[MetricName, Attributes, TimeUnix, Value]
-  Project [MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS TimeUnix, lwr_value AS Value]
-    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS anchor_ts] funcs=[argMax(Value, TimeUnix) AS lwr_value]
-      Filter predicate=((TimeUnix <= anchor_ts) AND (TimeUnix > (anchor_ts - toIntervalNanosecond(300000000000))))
-        CrossJoin
-          StepGrid start=2026-01-01T00:00:00.000000000Z end=2026-01-01T00:05:00.000000000Z step=30s
-          Filter predicate=(MetricName IN ("demo_memory_usage_bytes", "demo.memory.usage.bytes", "demo.memory.usage_bytes", "demo.memory_usage.bytes", "demo.memory_usage_bytes", "demo_memory.usage.bytes", "demo_memory.usage_bytes", "demo_memory_usage.bytes"))
-            Scan(merge(otel_metrics_gauge|otel_metrics_sum))
+  RangeLWR step=30s lookback=5m0s ts=TimeUnix value=Value start=2026-01-01T00:00:00Z end=2026-01-01T00:05:00Z
+    Filter predicate=(MetricName IN ("demo_memory_usage_bytes", "demo.memory.usage.bytes", "demo.memory.usage_bytes", "demo.memory_usage.bytes", "demo.memory_usage_bytes", "demo_memory.usage.bytes", "demo_memory.usage_bytes", "demo_memory_usage.bytes"))
+      Scan(merge(otel_metrics_gauge|otel_metrics_sum))
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `anchor_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT * FROM (SELECT arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:00:00.000000000', 9) + toIntervalNanosecond(i * 30000000000), range(0, 11))) AS `anchor_ts`) AS L CROSS JOIN (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?))) AS R) WHERE ((`TimeUnix` <= `anchor_ts`) AND (`TimeUnix` > (`anchor_ts` - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`, `anchor_ts`)) ORDER BY `Value` DESC LIMIT 5 BY `Attributes`[?], `TimeUnix`)
+SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, anchor_ts AS `TimeUnix`, lwr_value AS `Value` FROM (SELECT `MetricName`, `Attributes`, `anchor_ts`, argMax(`Value`, `TimeUnix`) AS lwr_value FROM (SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value`, arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(i * 30000000000), range(greatest(0, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) < 0) + 1), least(11, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) < 0) + 1)))) AS anchor_ts FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?)))) GROUP BY `MetricName`, `Attributes`, `anchor_ts`)) ORDER BY `Value` DESC LIMIT 5 BY `Attributes`[?], `TimeUnix`)

--- a/test/spec/promql/topk_range_without_empty.txtar
+++ b/test/spec/promql/topk_range_without_empty.txtar
@@ -77,15 +77,10 @@ INSERT INTO otel_metrics_gauge VALUES
 [5] string = "demo_memory.usage.bytes"
 [6] string = "demo_memory.usage_bytes"
 [7] string = "demo_memory_usage.bytes"
-[8] int64 = 300000000000
 -- chplan --
 TopK k=5 sort=Value DESC by=[Attributes, TimeUnix] columns=[MetricName, Attributes, TimeUnix, Value]
-  Project [MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS TimeUnix, lwr_value AS Value]
-    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS anchor_ts] funcs=[argMax(Value, TimeUnix) AS lwr_value]
-      Filter predicate=((TimeUnix <= anchor_ts) AND (TimeUnix > (anchor_ts - toIntervalNanosecond(300000000000))))
-        CrossJoin
-          StepGrid start=2026-01-01T00:00:00.000000000Z end=2026-01-01T00:05:00.000000000Z step=30s
-          Filter predicate=(MetricName IN ("demo_memory_usage_bytes", "demo.memory.usage.bytes", "demo.memory.usage_bytes", "demo.memory_usage.bytes", "demo.memory_usage_bytes", "demo_memory.usage.bytes", "demo_memory.usage_bytes", "demo_memory_usage.bytes"))
-            Scan(merge(otel_metrics_gauge|otel_metrics_sum))
+  RangeLWR step=30s lookback=5m0s ts=TimeUnix value=Value start=2026-01-01T00:00:00Z end=2026-01-01T00:05:00Z
+    Filter predicate=(MetricName IN ("demo_memory_usage_bytes", "demo.memory.usage.bytes", "demo.memory.usage_bytes", "demo.memory_usage.bytes", "demo.memory_usage_bytes", "demo_memory.usage.bytes", "demo_memory.usage_bytes", "demo_memory_usage.bytes"))
+      Scan(merge(otel_metrics_gauge|otel_metrics_sum))
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `anchor_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT * FROM (SELECT arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:00:00.000000000', 9) + toIntervalNanosecond(i * 30000000000), range(0, 11))) AS `anchor_ts`) AS L CROSS JOIN (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?))) AS R) WHERE ((`TimeUnix` <= `anchor_ts`) AND (`TimeUnix` > (`anchor_ts` - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`, `anchor_ts`)) ORDER BY `Value` DESC LIMIT 5 BY `Attributes`, `TimeUnix`)
+SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, anchor_ts AS `TimeUnix`, lwr_value AS `Value` FROM (SELECT `MetricName`, `Attributes`, `anchor_ts`, argMax(`Value`, `TimeUnix`) AS lwr_value FROM (SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value`, arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(i * 30000000000), range(greatest(0, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) < 0) + 1), least(11, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) < 0) + 1)))) AS anchor_ts FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?)))) GROUP BY `MetricName`, `Attributes`, `anchor_ts`)) ORDER BY `Value` DESC LIMIT 5 BY `Attributes`, `TimeUnix`)

--- a/test/spec/promql/topk_range_without_instance.txtar
+++ b/test/spec/promql/topk_range_without_instance.txtar
@@ -77,16 +77,11 @@ INSERT INTO otel_metrics_gauge VALUES
 [5] string = "demo_memory.usage.bytes"
 [6] string = "demo_memory.usage_bytes"
 [7] string = "demo_memory_usage.bytes"
-[8] int64 = 300000000000
-[9] string = "instance"
+[8] string = "instance"
 -- chplan --
 TopK k=5 sort=Value DESC by=[mapWithout(Attributes, [instance]), TimeUnix] columns=[MetricName, Attributes, TimeUnix, Value]
-  Project [MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS TimeUnix, lwr_value AS Value]
-    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS anchor_ts] funcs=[argMax(Value, TimeUnix) AS lwr_value]
-      Filter predicate=((TimeUnix <= anchor_ts) AND (TimeUnix > (anchor_ts - toIntervalNanosecond(300000000000))))
-        CrossJoin
-          StepGrid start=2026-01-01T00:00:00.000000000Z end=2026-01-01T00:05:00.000000000Z step=30s
-          Filter predicate=(MetricName IN ("demo_memory_usage_bytes", "demo.memory.usage.bytes", "demo.memory.usage_bytes", "demo.memory_usage.bytes", "demo.memory_usage_bytes", "demo_memory.usage.bytes", "demo_memory.usage_bytes", "demo_memory_usage.bytes"))
-            Scan(merge(otel_metrics_gauge|otel_metrics_sum))
+  RangeLWR step=30s lookback=5m0s ts=TimeUnix value=Value start=2026-01-01T00:00:00Z end=2026-01-01T00:05:00Z
+    Filter predicate=(MetricName IN ("demo_memory_usage_bytes", "demo.memory.usage.bytes", "demo.memory.usage_bytes", "demo.memory_usage.bytes", "demo.memory_usage_bytes", "demo_memory.usage.bytes", "demo_memory.usage_bytes", "demo_memory_usage.bytes"))
+      Scan(merge(otel_metrics_gauge|otel_metrics_sum))
 -- sql --
-SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `anchor_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT * FROM (SELECT arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:00:00.000000000', 9) + toIntervalNanosecond(i * 30000000000), range(0, 11))) AS `anchor_ts`) AS L CROSS JOIN (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?))) AS R) WHERE ((`TimeUnix` <= `anchor_ts`) AND (`TimeUnix` > (`anchor_ts` - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`, `anchor_ts`)) ORDER BY `Value` DESC LIMIT 5 BY mapFilter((k, v) -> NOT (k IN (?)), `Attributes`), `TimeUnix`)
+SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, anchor_ts AS `TimeUnix`, lwr_value AS `Value` FROM (SELECT `MetricName`, `Attributes`, `anchor_ts`, argMax(`Value`, `TimeUnix`) AS lwr_value FROM (SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value`, arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(i * 30000000000), range(greatest(0, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) < 0) + 1), least(11, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) < 0) + 1)))) AS anchor_ts FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?)))) GROUP BY `MetricName`, `Attributes`, `anchor_ts`)) ORDER BY `Value` DESC LIMIT 5 BY mapFilter((k, v) -> NOT (k IN (?)), `Attributes`), `TimeUnix`)


### PR DESCRIPTION
## What

Eliminates the verified RC1-blocking `query_range` performance gap (task #75, reopened #68). PromQL **range queries over a bare instant-vector selector** previously emitted an O(rows × anchors) shape: a `CROSS JOIN` of the N-anchor step grid against the metric scan + a correlated per-anchor staleness predicate, with `argMax(Value, TimeUnix)` recomputed per (series, anchor). Verified on main: wall time scaled **linearly** with the step-grid width (N=61/121/241 → ~480/951/1855ms), independent of `read_rows` (pruning was already fine — this is a query-*shape* cost, not a scan cost).

## How

New single-pass **as-of** strategy:
- **`chplan.RangeLWR`** node (`internal/chplan/range_lwr.go`) — `{Input, Start, End, Step, Lookback, Offset, …}`; the two `wrapRangeLatestPerSeries` call sites in `internal/promql/lower.go` now build it (lowering selection unchanged).
- **`chsql.emitRangeLWR`** (`internal/chsql/range_lwr.go`) — bounded **sample-side fan-out**: each sample `arrayJoin`s only over the ≤ `lookback/step + 1` anchors whose half-open `(anchor − offset − lookback, anchor − offset]` window contains it, then `GROUP BY (series, anchor) argMax(Value, TimeUnix)` collapses each bucket. Intermediate cardinality is `rows × (lookback/step + 1)` — **independent of grid width N**. Reuses the existing floor-division fan-out machinery (same idiom as the rate path); typed chsql only, no raw SQL, no `unsafe`.

## Correctness (preserved exactly)

- **chDB spec roundtrips: byte-identical `expected_rows`** to the old shape on every affected fixture — only `-- sql --`/`-- chplan --`/`-- args --` golden sections changed, not one result cell. Differential-equivalence proof vs the compat-green old shape.
- Half-open lookback window, **offset shifts the window not the anchor** (negative offsets verified via `offset_negative.txtar`), gauge+sum `merge()` dual-table, staleness-gap "no sample → no row", canonical 4-column output, `Value` stays Float64.
- Fixed a subtle `argMax(Value, TimeUnix)` alias-shadowing bug (output alias `TimeUnix` shadowed the argMax arg → split into a collapse SELECT + thin re-alias Project).
- topk/bottomk/sum range wrappers consume `RangeLWR` output as a drop-in. Rate/`*_over_time` + histogram-companion StepGrid paths untouched.

## Perf proof

`test/perf/range_lwr_scaling_chdb_test.go` (in-process chDB, 180k-row set, 24h window, lookback 5m, varying step):

| N | new | old | speedup |
|---|-----|-----|---------|
| 61  | 23 ms | 600 ms | 26× |
| 121 | 26 ms | 1177 ms | 45× |
| 241 | **43 ms** | **2255 ms** | **52×** |

New scaling **1.88×** vs old **3.76×** across a 4× N sweep; the 43M-row CROSS JOIN intermediate at N=241 → 156k (0.9× scan). The guard asserts ≥5× speedup + strictly-flatter scaling + bounded fan-out (regression pin — closes the measurement-axis hole that let #68 miss this).

## Note

`compatibility/prometheus` (the differential arbiter) runs on this PR in CI — local docker compat wasn't run (host constraint), but the chDB roundtrips already prove byte-identical output on exactly the LWR queries the compat tester sweeps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
