### PR TITLE
fix(prom): deterministic range-query series order + symmetric compat comparer sort

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,12 @@ test/e2e/playwright/playwright-report/
 /compatibility/loki/cmd/seed/seed
 /compatibility/prometheus/cmd/seed/seed
 /test/e2e/seed/cmd/seed/seed
+
+# Transient compatibility-harness outputs (run-compatibility.sh writes
+# these next to the config; they're per-run artifacts uploaded by CI, not
+# source). The prometheus harness emits the tester report + the
+# shields.io badge score + the rejection-parity report.
+/compatibility/prometheus/report.json
+/compatibility/prometheus/compat-score.json
+/compatibility/prometheus/rejection-parity.json
+/compatibility/prometheus/upstream/promql/cmd/promql-compliance-tester/promql-compliance-tester

--- a/compatibility/prometheus/scripts/run-compatibility.sh
+++ b/compatibility/prometheus/scripts/run-compatibility.sh
@@ -69,6 +69,39 @@ docker compose up -d --build --wait clickhouse prometheus cerberus
 echo "==> running seeder (go run ./cmd/seed)"
 (cd "$ROOT_DIR/../.." && go run ./compatibility/prometheus/cmd/seed/)
 
+# Patch an upstream tester bug before building: the comparer
+# (upstream/promql/comparer/comparer.go) sorts ONLY the test backend's
+# matrix — `sort.Sort(testResult.(model.Matrix))` — and then diffs it
+# against the reference matrix in the reference's NATIVE return order.
+# Those two orders are NOT the same: `model.Matrix.Less` (prometheus/
+# common) orders series by LABEL COUNT first (LabelSet.Before:
+# `if len(ls) < len(o) { return true }`), then lexicographically;
+# reference Prometheus returns series in pure lexicographic
+# (labels.Compare) order. For a selector whose matched series have
+# DIFFERENT label counts — e.g. `{job="demo", __name__!~"..."}` mixes
+# `up{instance,job}` (2 labels) with `demo_disk_total_bytes{device,
+# instance,job}` (3 labels) — the count-first test sort and the
+# lexicographic reference order diverge, and the order-sensitive
+# `cmp.Diff` reports a spurious mismatch even though both backends
+# returned byte-identical series + samples (verified: sorting BOTH
+# matrices yields zero diff). The one-line fix sorts the reference
+# matrix with the same `model.Matrix.Sort` so the two sides are ordered
+# identically before the diff. Idempotent (the grep guard skips a
+# re-patch); applied to the vendored source before the build because the
+# submodule pins upstream `prometheus/compliance` and carrying a fork
+# just for this is heavier than a build-time patch. Upstream bug; a PR
+# to prometheus/compliance to sort both sides would retire this.
+echo "==> patching promql-compliance-tester comparer (symmetric matrix sort)"
+COMPARER="$ROOT_DIR/upstream/promql/comparer/comparer.go"
+if ! grep -q 'sort.Sort(refResult.(model.Matrix))' "$COMPARER"; then
+    # Insert the reference sort immediately after the existing test sort.
+    perl -0pi -e 's/(\tsort\.Sort\(testResult\.\(model\.Matrix\)\)\n)/$1\tsort.Sort(refResult.(model.Matrix))\n/' "$COMPARER"
+    if ! grep -q 'sort.Sort(refResult.(model.Matrix))' "$COMPARER"; then
+        echo "ERROR: failed to patch comparer.go symmetric sort (upstream layout changed?)" >&2
+        exit 2
+    fi
+fi
+
 echo "==> building promql-compliance-tester"
 TESTER_DIR="$ROOT_DIR/upstream/promql/cmd/promql-compliance-tester"
 TESTER_BIN="$ROOT_DIR/upstream/promql/cmd/promql-compliance-tester/promql-compliance-tester"

--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -955,6 +955,17 @@ func matrixFromCursor(
 	}
 
 	bySeries := map[string]*seriesState{}
+	// order records first-seen canonical keys so the output series order
+	// is deterministic; it is sorted below so the matrix is emitted in
+	// canonical label order. Reference Prometheus returns range-query
+	// series sorted by labels, and the prometheus/compliance differential
+	// tester compares the two `model.Matrix` slices ORDER-SENSITIVELY
+	// (cmp.Diff, no pre-sort) — so an unsorted matrix (Go map iteration
+	// order) diffs against reference even when every series + sample is
+	// identical. The instant sibling matrixFromSamples already sorts; this
+	// path must match. (Compat query `{job="demo", __name__!~"..."}`
+	// diverged purely on series order before this.)
+	order := make([]string, 0)
 	for cursor.Next() {
 		s := cursor.Sample()
 		labels := format.NormalizeLabelMap(format.WithMetricName(s.Labels, s.MetricName))
@@ -963,15 +974,18 @@ func matrixFromCursor(
 		if !ok {
 			st = &seriesState{labels: labels}
 			bySeries[key] = st
+			order = append(order, key)
 		}
 		st.rows = append(st.rows, s)
 	}
 	if err := cursor.Err(); err != nil {
 		return nil, err
 	}
+	sort.Strings(order)
 
 	out := make([]MatrixSample, 0, len(bySeries))
-	for _, st := range bySeries {
+	for _, key := range order {
+		st := bySeries[key]
 		// Inline insertion sort by Timestamp ascending — rows are
 		// typically already nearly sorted from CH but the CrossJoin
 		// + Aggregate plan shapes the rework introduces do not

--- a/internal/api/prom/matrix_order_test.go
+++ b/internal/api/prom/matrix_order_test.go
@@ -1,0 +1,100 @@
+package prom
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/api/format"
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+// TestMatrixFromCursor_SortsSeriesByCanonicalKey pins the deterministic,
+// canonical-label-sorted output order of the range-query matrix pivot.
+//
+// Reference Prometheus returns query_range series sorted by labels, and
+// the prometheus/compliance differential tester compares the two
+// `model.Matrix` results ORDER-SENSITIVELY. matrixFromCursor previously
+// emitted series in Go-map iteration order (non-deterministic), so a
+// label-only selector whose matched series have varying label counts
+// (e.g. `{job="demo", __name__!~"..."}` mixes `up{instance,job}` with
+// `demo_disk_total_bytes{device,instance,job}`) returned an unsorted
+// matrix that diffed against reference even though every series + sample
+// was identical. This guard feeds samples in a deliberately jumbled,
+// label-count-varying order and asserts the output is canonical-key
+// sorted — matching the instant sibling matrixFromSamples and Prom's
+// API contract.
+func TestMatrixFromCursor_SortsSeriesByCanonicalKey(t *testing.T) {
+	t.Parallel()
+	ts := time.Unix(1778457600, 0).UTC()
+	// Deliberately jumbled input order, mixing 2-label and 3-label series
+	// (the label-count variance that tripped the upstream tester's sort).
+	samples := []chclient.Sample{
+		{MetricName: "demo_num_cpus", Labels: map[string]string{"instance": "h2", "job": "demo"}, Timestamp: ts, Value: 4},
+		{MetricName: "demo_disk_total_bytes", Labels: map[string]string{"device": "sda1", "instance": "h1", "job": "demo"}, Timestamp: ts, Value: 100},
+		{MetricName: "up", Labels: map[string]string{"instance": "h1", "job": "demo"}, Timestamp: ts, Value: 1},
+		{MetricName: "demo_num_cpus", Labels: map[string]string{"instance": "h1", "job": "demo"}, Timestamp: ts, Value: 4},
+		{MetricName: "demo_disk_total_bytes", Labels: map[string]string{"device": "sda1", "instance": "h0", "job": "demo"}, Timestamp: ts, Value: 100},
+		{MetricName: "up", Labels: map[string]string{"instance": "h0", "job": "demo"}, Timestamp: ts, Value: 1},
+	}
+
+	out, err := matrixFromCursor(&orderTestCursor{samples: samples, idx: -1}, ts.Add(-time.Hour), ts.Add(time.Hour), 10*time.Second)
+	if err != nil {
+		t.Fatalf("matrixFromCursor: %v", err)
+	}
+	if len(out) != len(samples) {
+		t.Fatalf("expected %d series, got %d", len(samples), len(out))
+	}
+
+	// The output order must be non-decreasing by the SAME canonical key
+	// the pivot groups + sorts on (format.CanonicalKey over the
+	// normalised label map). The emitted ms.Metric already carries the
+	// normalised labels incl. __name__, so CanonicalKey of it reproduces
+	// the sort key.
+	keys := make([]string, len(out))
+	for i, ms := range out {
+		keys[i] = format.CanonicalKey(ms.Metric)
+	}
+	for i := 1; i < len(keys); i++ {
+		if keys[i-1] > keys[i] {
+			t.Errorf("matrix series not sorted: series[%d]=%q > series[%d]=%q\nfull order: %v",
+				i-1, keys[i-1], i, keys[i], keys)
+		}
+	}
+
+	// Determinism: a second pivot over the reversed input yields the
+	// identical order.
+	out2, err := matrixFromCursor(&orderTestCursor{samples: reverseSamples(samples), idx: -1}, ts.Add(-time.Hour), ts.Add(time.Hour), 10*time.Second)
+	if err != nil {
+		t.Fatalf("matrixFromCursor (run 2): %v", err)
+	}
+	for i := range out {
+		if format.CanonicalKey(out[i].Metric) != format.CanonicalKey(out2[i].Metric) {
+			t.Fatalf("non-deterministic order at %d: %v vs %v", i, out[i].Metric, out2[i].Metric)
+		}
+	}
+}
+
+func reverseSamples(in []chclient.Sample) []chclient.Sample {
+	out := make([]chclient.Sample, len(in))
+	for i, s := range in {
+		out[len(in)-1-i] = s
+	}
+	return out
+}
+
+// orderTestCursor is a minimal in-package chclient.Cursor over a fixed
+// sample slice (handler_test.go's sliceCursor lives in the external
+// prom_test package, out of reach of this internal-package test that
+// must call the unexported matrixFromCursor).
+type orderTestCursor struct {
+	samples []chclient.Sample
+	idx     int
+}
+
+func (c *orderTestCursor) Next() bool {
+	c.idx++
+	return c.idx < len(c.samples)
+}
+func (c *orderTestCursor) Sample() chclient.Sample { return c.samples[c.idx] }
+func (c *orderTestCursor) Err() error              { return nil }
+func (c *orderTestCursor) Close() error            { return nil }


### PR DESCRIPTION
## What

Two related fixes that make PromQL **range-query** series order deterministic and bring the demo compat score to a true **574/574** — while keeping the compatibility harness **report-only** (no gate/scorer change).

Surfaced while verifying the RangeLWR work; root-caused + verified independently.

## (a) cerberus: deterministic range-query series order

`internal/api/prom/matrixFromCursor` iterated the `bySeries` map directly, so range responses came back in **non-deterministic Go map-iteration order** — unlike the instant sibling `matrixFromSamples`, which already sorts. Fix: record first-seen canonical keys and `sort.Strings` them, emitting series in canonical label order (matches the instant path + Prometheus's sorted-range contract). New regression test `matrix_order_test.go`.

## (b) harness: symmetric comparer sort (build-time patch)

The vendored `prometheus/compliance` comparer sorts **only the test matrix** (`sort.Sort(testResult.(model.Matrix))`, where `model.Matrix.Less` orders by **label count first**) and diffs it against reference Prometheus's **lexicographic** native order. For a selector mixing 2-label and 3-label series (`{job="demo", __name__!~"demo_cpu_usage_seconds.*"}`), those orders diverge and the order-sensitive `cmp.Diff` reports a **spurious** mismatch even though both backends return byte-identical series + samples. `run-compatibility.sh` now idempotently patches the vendored comparer to sort the **reference** matrix too (one line, before build) so both sides order identically. Upstream bug; a PR to prometheus/compliance would retire the patch.

Net: the previously-"diverged" query was a false positive (pure ordering); with (a)+(b) it's a true match → **574/574, 100%**.

## Scope (deliberately minimal)

This does **not** touch the scorer or flip the gate — `compatibility/prometheus` stays report-only, per the maintainer decision. (The strict-gate-on-<100% option was considered and held separately.)

shellcheck clean; `go build` + the new determinism test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
