### PR TITLE
docs(performance): route-A-default + solver-exception invariant set (solver phase 0)

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -27,16 +27,43 @@ Everything below is in service of keeping that number flat.
 
 Two architectural invariants frame the whole approach:
 
-- **One query per request — no scatter-gather.** ClickHouse parallelises a
-  single MergeTree scan server-side, so cerberus never splits a query into
-  shards and merges client-side. Memory is bounded instead by
-  `max_memory_usage`, the sample budget, an 11k-point resolution cap, and a
-  streaming cursor. (Loki's query-frontend exists because object storage has
-  no parallel scan — that constraint doesn't transfer to CH.) This freezes the
-  execution architecture: there is no merge layer to add later.
+- **Route A is the default: one optimized plan → one CH statement.** The
+  overwhelming majority of traffic is solved by lowering, optimizing, and
+  emitting a *single* parameterised ClickHouse statement, with all reduction
+  pushed into ClickHouse — the leaf scan, the windowing, the aggregation all
+  happen server-side, where CH parallelises a single MergeTree scan across
+  cores. Route A bounds memory with `max_memory_usage`, the sample budget, an
+  11k-point resolution cap, and a streaming cursor; it is byte-identical to the
+  pipeline cerberus has always shipped. (Loki's query-frontend exists because
+  object storage has no parallel scan — that constraint doesn't transfer to CH,
+  so route A stays the default rather than a scatter-gather frontend.)
+- **The sharded-pushdown solver is the exception — off by default, narrow by
+  construction.** The old lock ("one CH query per request — no scatter-gather,
+  no merge layer to add later") was relaxed by the maintainer on 2026-06-12 for
+  the single class route A cannot solve bounded: high **anchor fan-out**
+  (`F = Range/Step`, e.g. `sum(rate(m[5m]))` at a fine step over a wide range),
+  where one statement's peak intermediate cardinality exceeds the CH memory cap.
+  For *that class only*, the `internal/solver` orchestrator
+  ([`query-solver-design.md`](query-solver-design.md)) re-anchors `K` deep
+  copies of the **same already-optimized plan** onto disjoint slices of the
+  anchor grid, emits each via the existing `chsql.Emit`, and concatenates the
+  result streams behind the existing cursor. There is **no new evaluator and no
+  new SQL template** — every shard runs the same compat-gated route-A SQL,
+  restricted to its anchor sub-grid. The solver stays off until a forced-route
+  compatibility lane proves zero diffs, and ineligible queries always stay on
+  route A. See [`evaluation-architecture.md`](evaluation-architecture.md) for
+  the operator classification the solver's safe set maps onto.
+- **All-or-nothing wire contract.** Whether a request is solved by route A or
+  fanned out across `K` shards, the client sees a single response: a shard
+  failure surfaces as one typed error (first-error-wins, cause-threaded), never
+  as a partial body. Sharding is an internal execution strategy, invisible at
+  the wire format.
 - **No caching.** Cerberus is a stateless query gateway, not a result cache.
+  This invariant is **unchanged** by the solver relaxation — the solver
+  re-emits and re-executes per request, it never memoises a previous result.
   The only TTL anywhere is the `/readyz` health probe. Speed comes from
-  emitting a better query, never from memoising a previous one.
+  emitting a better query (and, for the unbounded class, from dividing it),
+  never from caching a previous one.
 
 ## Where the speed comes from, layer by layer
 
@@ -162,6 +189,12 @@ rather than silently accepted.
   `just bench-report`.
 - [`engine.md`](engine.md) — the pipeline stages in depth: the IR algebra, the
   optimizer rule table, and the typed CH-native emitter.
+- [`query-solver-design.md`](query-solver-design.md) — the sharded-pushdown
+  solver: the eligibility signals, the slicing geometry, and the phased
+  migration that keeps route A the default.
+- [`evaluation-architecture.md`](evaluation-architecture.md) — the operator
+  classification (slice-invariant vs. not) the solver's safe set maps onto, and
+  the ceiling shapes time-slicing cannot reach.
 - [`test-strategy.md`](test-strategy.md) — the full test-layer map the perf
   lanes sit inside.
 - [`operations.md`](operations.md) — runtime memory, admission control, and

--- a/internal/chsql/emit.go
+++ b/internal/chsql/emit.go
@@ -5,6 +5,15 @@
 // ClickHouse driver. Every node type is emitted as a self-contained SELECT
 // statement and children are inlined as subqueries; PR6's optimizer is
 // expected to collapse trivial single-row subqueries.
+//
+// Emit always renders one plan into one CH statement. The default route A
+// executes exactly that statement per request. The sharded-pushdown solver
+// (internal/solver, docs/query-solver-design.md) does not change this: for
+// the narrow memory-unbounded anchor-fan-out class it re-anchors K deep copies
+// of the same optimized plan onto disjoint anchor slices and calls Emit once
+// per slice — no new SQL template, just the same per-statement emission run K
+// times. The relaxed "one statement per request" invariant lives in
+// docs/performance.md.
 package chsql
 
 import (

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -12,6 +12,18 @@
 // type stays inside the adapter, lowering happens inside Lang.Parse,
 // and the sample-row reshaping that used to live in each handler's
 // wrapWithSampleProjection helper moves behind Lang.ProjectSamples.
+//
+// Execution strategy: route A (the default for the overwhelming majority
+// of traffic) emits one optimized plan into one ClickHouse statement and
+// pushes all reduction into CH. The maintainer relaxed the old "one CH
+// query per request — no scatter-gather" lock on 2026-06-12 for the narrow
+// memory-unbounded anchor-fan-out class: the sharded-pushdown solver
+// (internal/solver, docs/query-solver-design.md) re-anchors K copies of the
+// same optimized plan onto disjoint anchor slices, emits each via chsql.Emit,
+// and concatenates the streams — no new evaluator, no new SQL template, and
+// the all-or-nothing wire contract preserved. The solver hooks the seam
+// between Optimizer.Run and chsql.Emit (see QueryPlan / QueryPlanCursor) and
+// is off by default. The relaxed invariant set lives in docs/performance.md.
 package engine
 
 import (


### PR DESCRIPTION
Phase-0 wave-1, docs-only (**zero code/behavior change**). Per `docs/query-solver-design.md` migration phase-0(h): the maintainer relaxed the "single CH query per request — no scatter-gather" lock on 2026-06-12, so the prose reviewers enforce must state the **new** invariant set, not the old one.

**`docs/performance.md`** — the "Two architectural invariants" block rewritten to four bullets:
- Route A (one optimized plan → one CH statement, all reduction in CH) **remains the default** and the overwhelming majority of traffic; byte-identical to the pipeline cerberus has always shipped.
- The sharded-pushdown solver (`internal/solver`, `docs/query-solver-design.md`) is the **exception** — off by default, narrow by construction — for the memory-unbounded high-anchor-fan-out class (`F=Range/Step`). Re-anchors K copies of the **same** optimized plan onto disjoint anchor slices and concatenates via the existing cursor; no new evaluator, no new SQL template; stays off until a forced-route compat lane proves zero diffs.
- All-or-nothing wire contract preserved (one typed error, first-error-wins, cause-threaded — never a partial body).
- No-caching invariant explicitly marked **unchanged**.

Cross-links to `docs/query-solver-design.md` + `docs/evaluation-architecture.md` added inline and in "See also".

**Comments only** (no code touched): `internal/chsql/emit.go` and `internal/engine/engine.go` package/seam comments updated so the old "one statement per request" prose no longer contradicts the relaxed architecture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)