### PR TITLE
fix(promql): pin @-modifier anchor across the step grid in range-vector funcs (route-A parity)

### DIFF
--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -1504,16 +1504,36 @@ func lowerRangeVectorCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chpla
 		ValueColumn:     s.ValueColumn,
 		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}},
 	}
-	// In range mode, fan the range function across the request's step
-	// grid: each anchor in [start, end] (spaced by step) emits one row
-	// per series with the per-anchor function value. The emitter
-	// already supports this via OuterRange + Step (the matrix path used
-	// by subqueries); we just need to flip the switch when LowerAtRange
-	// threaded a non-zero step. Without this, `rate(m[5m])` over
-	// query_range degenerates to a single anchor at end_ts and the
-	// matrix pivot only sees one sample per series — the same root
-	// cause as the bare-selector range-mode bug Pool-AK is fixing.
-	if ctx.step > 0 && !ctx.start.IsZero() && !ctx.end.IsZero() {
+	rangeMode := ctx.step > 0 && !ctx.start.IsZero() && !ctx.end.IsZero()
+	pinned := hasAbsoluteAt(vs)
+	switch {
+	case rangeMode && pinned:
+		// `@`-pinned range-vector call (`rate(m[5m] @ <ts>)`,
+		// `... @ start()` / `@ end()`) under query_range. Reference
+		// PromQL evaluates the SAME pinned window [anchor - range,
+		// anchor] at EVERY step in [start, end] — the `@` fixes the
+		// anchor, only the OUTPUT timestamps vary. The bare matrix
+		// fan-out below would instead re-anchor the window onto each
+		// step grid point (the clobber overwrites rw.End with
+		// ctx.end), so the pin is lost and `rate(m[5m] @ T)` fans the
+		// rate across the grid rather than broadcasting the single
+		// pinned value. Keep rw as the INSTANT shape (Step=0,
+		// End=anchor.End, no OuterRange) — it produces one row per
+		// series at the pinned window — then broadcast that value
+		// across the step grid via a CrossJoin(StepGrid). This is the
+		// range-vector sibling of wrapRangeAbsoluteAtBroadcast (the
+		// bare-selector `@`-pin path).
+		return wrapRangeWindowAtBroadcast(rw, ctx, s, c.Func.Name, metricNameFromMatchers(vs.LabelMatchers)), nil
+	case rangeMode:
+		// In range mode, fan the range function across the request's step
+		// grid: each anchor in [start, end] (spaced by step) emits one row
+		// per series with the per-anchor function value. The emitter
+		// already supports this via OuterRange + Step (the matrix path used
+		// by subqueries); we just need to flip the switch when LowerAtRange
+		// threaded a non-zero step. Without this, `rate(m[5m])` over
+		// query_range degenerates to a single anchor at end_ts and the
+		// matrix pivot only sees one sample per series — the same root
+		// cause as the bare-selector range-mode bug Pool-AK is fixing.
 		rw.Start = ctx.start.UTC()
 		rw.End = ctx.end.UTC()
 		rw.Step = ctx.step
@@ -1589,6 +1609,45 @@ func wrapRangeWindowPreserveName(rw *chplan.RangeWindow, s schema.Metrics, name 
 			{Expr: &chplan.ColumnRef{Name: s.ValueColumn}, Alias: s.ValueColumn},
 		},
 	}
+}
+
+// wrapRangeWindowAtBroadcast broadcasts an INSTANT-shape range-vector
+// RangeWindow (rate / increase / *_over_time / ...) pinned by an
+// absolute `@` modifier across the request's step grid. The pinned
+// window is evaluated ONCE (rw is left in its instant shape: Step=0,
+// End=anchor.End), yielding one row per series with the canonical
+// `(Attributes, Value)` shape the instant range emitter produces. A
+// CrossJoin with a StepGrid spanning [start, end] then fans that single
+// per-series value across every step timestamp, and the outer Project
+// restores the matrix 4-column contract `(Attributes, anchor_ts,
+// anchor_ts AS TimeUnix, Value)` the non-pinned range path emits — so
+// downstream consumers (aggregations, arithmetic) see the identical
+// column shape whether or not the inner carried an `@` pin.
+//
+// `last_over_time` / `first_over_time` preserve `__name__`
+// (dropName=false in Prom); for them the projection pins MetricName to
+// the matcher's literal name and exposes the canonical 4-column Sample
+// contract `(MetricName, Attributes, anchor_ts AS TimeUnix, Value)`,
+// mirroring wrapRangeWindowPreserveName's matrix branch. Every other
+// range fn drops `__name__`, so MetricName is omitted.
+func wrapRangeWindowAtBroadcast(rw *chplan.RangeWindow, ctx lowerCtx, s schema.Metrics, fn, name string) chplan.Node {
+	grid := &chplan.StepGrid{Start: ctx.start.UTC(), End: ctx.end.UTC(), Step: ctx.step}
+	joined := &chplan.CrossJoin{Left: grid, Right: rw}
+
+	preserveName := fn == "last_over_time" || fn == "first_over_time"
+	projections := make([]chplan.Projection, 0, 4)
+	if preserveName {
+		projections = append(projections,
+			chplan.Projection{Expr: &chplan.LitString{V: name}, Alias: s.MetricNameColumn})
+	}
+	projections = append(
+		projections,
+		chplan.Projection{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
+		chplan.Projection{Expr: &chplan.ColumnRef{Name: "anchor_ts"}, Alias: "anchor_ts"},
+		chplan.Projection{Expr: &chplan.ColumnRef{Name: "anchor_ts"}, Alias: s.TimestampColumn},
+		chplan.Projection{Expr: &chplan.ColumnRef{Name: s.ValueColumn}, Alias: s.ValueColumn},
+	)
+	return &chplan.Project{Input: joined, Projections: projections}
 }
 
 // lowerAggregate handles `sum by (job) (...)`, `sum without (instance) (...)`,

--- a/internal/promql/subquery.go
+++ b/internal/promql/subquery.go
@@ -352,23 +352,53 @@ func lowerOuterRangeFnOverSubquery(
 		return nil, err
 	}
 
+	anchor, err := subqueryAnchor(sub, ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	rw := &chplan.RangeWindow{
 		Input:           inner,
 		Func:            outer.Func.Name,
 		Range:           sub.Range,
+		Offset:          anchor.Offset,
 		TimestampColumn: "anchor_ts",
 		ValueColumn:     s.ValueColumn,
 		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}},
 	}
-	// Range mode: the outer reducer in `max_over_time(rate(m[5m])[1h:5m])`
-	// must fan across the request's step grid so each anchor in
-	// [start, end] emits its own per-window reduction. Without this the
-	// outer RangeWindow keeps Step=0 and collapses to a single anchor at
-	// end_ts (compat-lane: 502 / single-point matrix). Mirrors the
-	// `lowerRangeVectorCall` matrix fan-out introduced for bare
-	// range-vector calls — the same gate (ctx.step > 0 with start/end
-	// threaded through LowerAtRange) applies here.
-	if ctx.step > 0 && !ctx.start.IsZero() && !ctx.end.IsZero() {
+
+	rangeMode := ctx.step > 0 && !ctx.start.IsZero() && !ctx.end.IsZero()
+	pinned := sub.Timestamp != nil || sub.StartOrEnd != 0
+
+	switch {
+	case rangeMode && pinned:
+		// `@`-pinned subquery under query_range
+		// (`max_over_time(rate(m[5m])[10m:1m] @ <ts>)`,
+		// `... @ start()` / `@ end()`). The `@` fixes the WHOLE subquery
+		// evaluation at the anchor, so every output step reduces the SAME
+		// pinned window `(anchor - sub.Range, anchor]` and emits an
+		// identical per-series value. The bare matrix fan-out below would
+		// instead re-anchor the outer reducer onto each step grid point
+		// (overwriting rw.End with ctx.end) AND widen the inner grid out
+		// to ctx.end — so the pin is lost and later-than-anchor inner
+		// samples leak into the reduction. Keep the outer reducer as the
+		// INSTANT shape (Step=0, End=anchor.End, OuterRange=0) — it
+		// reduces the pinned window once per series — widen the inner
+		// spine to exactly the pinned window, then broadcast the single
+		// per-series value across the step grid. The range-vector sibling
+		// of this guard lives in `lowerRangeVectorCall`.
+		rw.End = anchor.End
+		widenSubquerySpine(inner, anchor.End.Add(-sub.Range), anchor.End)
+		return wrapRangeWindowAtBroadcast(rw, ctx, s, outer.Func.Name, ""), nil
+	case rangeMode:
+		// Range mode: the outer reducer in `max_over_time(rate(m[5m])[1h:5m])`
+		// must fan across the request's step grid so each anchor in
+		// [start, end] emits its own per-window reduction. Without this the
+		// outer RangeWindow keeps Step=0 and collapses to a single anchor at
+		// end_ts (compat-lane: 502 / single-point matrix). Mirrors the
+		// `lowerRangeVectorCall` matrix fan-out introduced for bare
+		// range-vector calls — the same gate (ctx.step > 0 with start/end
+		// threaded through LowerAtRange) applies here.
 		rw.Start = ctx.start.UTC()
 		rw.End = ctx.end.UTC()
 		rw.Step = ctx.step

--- a/test/perf/cardinality-baseline.json
+++ b/test/perf/cardinality-baseline.json
@@ -2450,6 +2450,16 @@
     "max_recursion_depth": 0
   },
   {
+    "fixture": "promql/edge_max_over_time_subquery_at_pinned",
+    "fan_factor": 1,
+    "scan_rows": 6,
+    "peak_intermediate": 6,
+    "has_cross_join": true,
+    "has_array_join": true,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0
+  },
+  {
     "fixture": "promql/edge_max_over_time_subquery_step_default",
     "fan_factor": 1,
     "scan_rows": 2,
@@ -2496,6 +2506,16 @@
     "peak_intermediate": 1,
     "has_cross_join": false,
     "has_array_join": false,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0
+  },
+  {
+    "fixture": "promql/edge_rate_at_timestamp_range_pinned",
+    "fan_factor": 1,
+    "scan_rows": 6,
+    "peak_intermediate": 6,
+    "has_cross_join": true,
+    "has_array_join": true,
     "has_recursive_cte": false,
     "max_recursion_depth": 0
   },

--- a/test/spec/promql/edge_max_over_time_subquery_at_pinned.txtar
+++ b/test/spec/promql/edge_max_over_time_subquery_at_pinned.txtar
@@ -1,0 +1,43 @@
+-- query.promql --
+max_over_time(rate(http_requests_total[5m])[10m:1m] @ 1767225600)
+-- range_step --
+60s
+-- args --
+[0] string = "http_requests_total"
+[1] string = "http.requests.total"
+[2] string = "http.requests_total"
+[3] string = "http_requests.total"
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('http_requests_total', map('job', 'api'), toDateTime64('2025-12-31 23:51:00', 9), 10.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2025-12-31 23:53:00', 9), 25.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2025-12-31 23:55:00', 9), 40.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2025-12-31 23:57:00', 9), 60.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2025-12-31 23:59:00', 9), 90.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:01:00', 9), 100000.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:04:00', 9), 200000.0);
+-- expected_rows --
+[
+  [{"job": "api"}, "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z", 0.25],
+  [{"job": "api"}, "2026-01-01T00:01:00Z", "2026-01-01T00:01:00Z", 0.25],
+  [{"job": "api"}, "2026-01-01T00:02:00Z", "2026-01-01T00:02:00Z", 0.25],
+  [{"job": "api"}, "2026-01-01T00:03:00Z", "2026-01-01T00:03:00Z", 0.25],
+  [{"job": "api"}, "2026-01-01T00:04:00Z", "2026-01-01T00:04:00Z", 0.25],
+  [{"job": "api"}, "2026-01-01T00:05:00Z", "2026-01-01T00:05:00Z", 0.25]
+]
+-- chplan --
+Project [Attributes AS Attributes, anchor_ts AS anchor_ts, anchor_ts AS TimeUnix, Value AS Value]
+  CrossJoin
+    StepGrid start=2026-01-01T00:00:00.000000000Z end=2026-01-01T00:05:00.000000000Z step=1m0s
+    RangeWindow func=max_over_time range=10m0s step=0s ts=anchor_ts value=Value groupBy=[Attributes] start=0001-01-01T00:00:00Z end=2026-01-01T00:00:00Z
+      RangeWindow func=rate range=5m0s step=1m0s outerRange=10m0s ts=TimeUnix value=Value groupBy=[Attributes] start=2025-12-31T23:50:00Z end=2026-01-01T00:00:00Z
+        Filter predicate=(MetricName IN ("http_requests_total", "http.requests.total", "http.requests_total", "http_requests.total"))
+          Scan(otel_metrics_sum)
+-- sql --
+SELECT `Attributes` AS `Attributes`, `anchor_ts` AS `anchor_ts`, `anchor_ts` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM (SELECT arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:00:00.000000000', 9) + toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts`) AS L CROSS JOIN (SELECT `Attributes`, if(length(window_vals) > 0, arrayMax(window_vals), nan) AS `Value` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) > toDateTime64('2026-01-01 00:00:00.000000000', 9) - toIntervalNanosecond(600000000000) AND tupleElement(p, 1) <= toDateTime64('2026-01-01 00:00:00.000000000', 9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`anchor_ts`, `Value`))) AS `series_array` FROM (SELECT `Attributes`, `anchor_ts`, anchor_ts AS `TimeUnix`, if(sampled_interval > 0, counter_delta * (sampled_interval + if(counter_delta > 0 AND first_val >= 0, least(duration_to_start, sampled_interval * first_val / counter_delta), duration_to_start) + duration_to_end) / sampled_interval / 300, nan) AS `Value` FROM (SELECT `Attributes`, `anchor_ts`, `window_vals`, `counter_delta`, `first_val`, toFloat64(dateDiff('nanosecond', first_ts, last_ts)) / 1e9 AS `sampled_interval`, if(toFloat64(dateDiff('nanosecond', anchor_ts - toIntervalNanosecond(300000000000), first_ts)) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', anchor_ts - toIntervalNanosecond(300000000000), first_ts)) / 1e9) AS `duration_to_start`, if(toFloat64(dateDiff('nanosecond', last_ts, anchor_ts)) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', last_ts, anchor_ts)) / 1e9) AS `duration_to_end` FROM (SELECT `Attributes`, `anchor_ts`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta`, tupleElement(window_pairs[1], 1) AS `first_ts`, tupleElement(window_pairs[length(window_pairs)], 1) AS `last_ts`, tupleElement(window_pairs[1], 2) AS `first_val` FROM (SELECT `Attributes`, `anchor_ts`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `window_pairs` FROM (SELECT `Attributes`, `TimeUnix`, `Value`, arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:00:00.000000000', 9) - toIntervalNanosecond(i * 60000000000), range(greatest(0, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:00:00.000000000', 9)) - 300000000000, toInt64(60000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:00:00.000000000', 9)) - 300000000000, toInt64(60000000000)) < 0) + 1), least(11, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:00:00.000000000', 9)), toInt64(60000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:00:00.000000000', 9)), toInt64(60000000000)) < 0) + 1)))) AS `anchor_ts` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` IN (?, ?, ?, ?))) WHERE `TimeUnix` > toDateTime64('2025-12-31 23:50:00.000000000', 9) - toIntervalNanosecond(300000000000) AND `TimeUnix` <= toDateTime64('2026-01-01 00:00:00.000000000', 9)) GROUP BY `Attributes`, `anchor_ts`))) WHERE length(`window_vals`) >= 2) GROUP BY `Attributes`))) WHERE length(`window_vals`) >= 1) AS R)

--- a/test/spec/promql/edge_rate_at_timestamp_range_pinned.txtar
+++ b/test/spec/promql/edge_rate_at_timestamp_range_pinned.txtar
@@ -1,0 +1,37 @@
+-- query.promql --
+rate(http_requests_total[5m] @ 1767225600)
+-- range_step --
+60s
+-- args --
+[0] string = "http_requests_total"
+[1] string = "http.requests.total"
+[2] string = "http.requests_total"
+[3] string = "http_requests.total"
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('http_requests_total', map('job', 'api'), toDateTime64('2025-12-31 23:56:00', 9), 10.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2025-12-31 23:59:00', 9), 40.0);
+-- expected_rows --
+[
+  [{"job": "api"}, "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z", 0.16666666666666666],
+  [{"job": "api"}, "2026-01-01T00:01:00Z", "2026-01-01T00:01:00Z", 0.16666666666666666],
+  [{"job": "api"}, "2026-01-01T00:02:00Z", "2026-01-01T00:02:00Z", 0.16666666666666666],
+  [{"job": "api"}, "2026-01-01T00:03:00Z", "2026-01-01T00:03:00Z", 0.16666666666666666],
+  [{"job": "api"}, "2026-01-01T00:04:00Z", "2026-01-01T00:04:00Z", 0.16666666666666666],
+  [{"job": "api"}, "2026-01-01T00:05:00Z", "2026-01-01T00:05:00Z", 0.16666666666666666]
+]
+-- chplan --
+Project [Attributes AS Attributes, anchor_ts AS anchor_ts, anchor_ts AS TimeUnix, Value AS Value]
+  CrossJoin
+    StepGrid start=2026-01-01T00:00:00.000000000Z end=2026-01-01T00:05:00.000000000Z step=1m0s
+    RangeWindow func=rate range=5m0s step=0s ts=TimeUnix value=Value groupBy=[Attributes] start=0001-01-01T00:00:00Z end=2026-01-01T00:00:00Z
+      Filter predicate=(MetricName IN ("http_requests_total", "http.requests.total", "http.requests_total", "http_requests.total"))
+        Scan(otel_metrics_sum)
+-- sql --
+SELECT `Attributes` AS `Attributes`, `anchor_ts` AS `anchor_ts`, `anchor_ts` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM (SELECT arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:00:00.000000000', 9) + toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts`) AS L CROSS JOIN (SELECT `Attributes`, if(sampled_interval > 0, counter_delta * (sampled_interval + if(counter_delta > 0 AND first_val >= 0, least(duration_to_start, sampled_interval * first_val / counter_delta), duration_to_start) + duration_to_end) / sampled_interval / 300, nan) AS `Value` FROM (SELECT `Attributes`, `window_vals`, `counter_delta`, `first_val`, toFloat64(dateDiff('nanosecond', first_ts, last_ts)) / 1e9 AS `sampled_interval`, if(toFloat64(dateDiff('nanosecond', toDateTime64('2026-01-01 00:00:00.000000000', 9) - toIntervalNanosecond(300000000000), first_ts)) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', toDateTime64('2026-01-01 00:00:00.000000000', 9) - toIntervalNanosecond(300000000000), first_ts)) / 1e9) AS `duration_to_start`, if(toFloat64(dateDiff('nanosecond', last_ts, toDateTime64('2026-01-01 00:00:00.000000000', 9))) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', last_ts, toDateTime64('2026-01-01 00:00:00.000000000', 9))) / 1e9) AS `duration_to_end` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta`, tupleElement(window_pairs[1], 1) AS `first_ts`, tupleElement(window_pairs[length(window_pairs)], 1) AS `last_ts`, tupleElement(window_pairs[1], 2) AS `first_val` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) > toDateTime64('2026-01-01 00:00:00.000000000', 9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= toDateTime64('2026-01-01 00:00:00.000000000', 9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` IN (?, ?, ?, ?))) GROUP BY `Attributes`)))) WHERE length(`window_vals`) >= 2) AS R)


### PR DESCRIPTION
Phase-0(d) route-A parity bug. `lowerRangeVectorCall` (and the twin in `subquery.go`) unconditionally overwrote the range window's `Start`/`End` with the step grid whenever `ctx.step > 0`, **ignoring an `@`-pinned anchor**. So a range query of `rate(m[5m] @ T)` fanned the rate across the step grid instead of pinning the window at `T`. Reference PromQL returns the **same** value (rate over `[T-5m, T]`) at every step.

## Fix
- `lower.go` — gate the step-grid clobber on `pinned := hasAbsoluteAt(vs)` (`vs.Timestamp != nil || vs.StartOrEnd != 0`). When pinned, evaluate the single window once and broadcast it across the step grid via a new typed `wrapRangeWindowAtBroadcast` (inner RangeWindow pinned to instant shape, `CrossJoin`ed with a `StepGrid`).
- `subquery.go:371` — the **same root-cause twin** for pinned subqueries (`rw.End = ctx.end` clobber) is fixed the same way: branch `rangeMode && pinned` *before* the clobber block, widen the spine to exactly the pinned window.
- Bare `rate(m[5m])` / bare `offset` (non-pinned) fall through to the original byte-identical per-step path — `hasAbsoluteAt` excludes bare offset.

## Verification (adversarial)
- `edge_rate_at_timestamp_range_pinned`: `rate(...[5m] @ 1767225600)` over 6 steps → **constant 0.16666…** at every step; chplan shows the pinned instant window × StepGrid.
- `edge_max_over_time_subquery_at_pinned`: seed plants huge post-anchor spikes (100000/200000) that would blow up the result if the pin leaked — result stays **constant 0.25**, spine widened to exactly `[anchor-10m, anchor]`.
- No non-pinned range fixture changed; only the 2 new `@` fixtures + their baseline rows. Typed chplan nodes only, no raw SQL. CI `compatibility/prometheus` is the final numeric arbiter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)