### PR TITLE
fix(promql): exact arraySort interpolation for quantile_over_time literal phi (route-A parity)

### DIFF
--- a/internal/promql/range_fns.go
+++ b/internal/promql/range_fns.go
@@ -235,13 +235,23 @@ func lowerQuantileOverTime(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chpl
 		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}},
 	}
 
-	// Literal phi: detect compile-time out-of-range phi. CH's quantile
-	// aggregate errors on phi outside [0, 1]; substitute a safe phi for
-	// the inner aggregate and post-Project the Value column to the
-	// PromQL-spec Inf-valued constant. NaN phi rides the same path
-	// (CH would also error on `quantile(NaN)`) and is materialised
-	// as a NaN literal in the post-Project — empty windows still
+	// Literal phi: detect compile-time out-of-range phi. PromQL's
+	// quantile() returns -Inf for phi<0, +Inf for phi>1, NaN for NaN.
+	// For an OUT-OF-RANGE / NaN literal the inner aggregate is fed a
+	// safe sentinel phi (0.5 — value discarded) and the Value column is
+	// post-Projected to the PromQL-spec constant; empty windows still
 	// produce `nan` via the emitter's length-guarded `if`.
+	//
+	// For an IN-RANGE literal phi we route through the SAME exact
+	// arraySort + linear-interpolation branch the computed-phi path
+	// uses (RangeWindow.ScalarExprs), materialising phi as a LitFloat.
+	// This replaces CH's approximate t-digest `quantile()` aggregate —
+	// which diverges from reference PromQL on larger windows — with
+	// Prometheus's exact `quantile()` formula (rank = phi*(N-1), linear
+	// interpolation between the two nearest ranks). The emitter's
+	// multiIf domain guards (isNaN / <0 / >1) are constant-folded by CH
+	// for the literal; the single-sample window falls out naturally
+	// (rank=0 → sorted[0]).
 	//
 	// Computed phi: the emitter's ScalarExprs path embeds the runtime
 	// domain rules (multiIf over isNaN / <0 / >1) directly in the
@@ -252,11 +262,14 @@ func lowerQuantileOverTime(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chpl
 	)
 	if phiOK {
 		infValue, replaceValue = outOfRangePhiInf(phi)
-		emitPhi := phi
 		if replaceValue {
-			emitPhi = 0.5
+			// Out-of-range / NaN literal: feed a safe sentinel to the
+			// inner aggregate and fold the spec value via post-Project.
+			window.Scalars = []float64{0.5}
+		} else {
+			// In-range literal: exact interpolation via ScalarExprs.
+			window.ScalarExprs = []chplan.Expr{&chplan.LitFloat{V: phi}}
 		}
-		window.Scalars = []float64{emitPhi}
 	} else {
 		window.ScalarExprs = []chplan.Expr{phiExpr}
 	}

--- a/test/perf/cardinality-baseline.json
+++ b/test/perf/cardinality-baseline.json
@@ -3530,6 +3530,16 @@
     "max_recursion_depth": 0
   },
   {
+    "fixture": "promql/quantile_over_time_p95_exact_interp",
+    "fan_factor": 1,
+    "scan_rows": 10000,
+    "peak_intermediate": 10000,
+    "has_cross_join": false,
+    "has_array_join": false,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0
+  },
+  {
     "fixture": "promql/quantile_over_time_q_above_one",
     "fan_factor": 1,
     "scan_rows": 5,

--- a/test/spec/promql/quantile_over_time_p95_exact_interp.txtar
+++ b/test/spec/promql/quantile_over_time_p95_exact_interp.txtar
@@ -7,15 +7,15 @@ CREATE TABLE otel_metrics_gauge (
     TimeUnix DateTime64(9),
     Value Float64
 ) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
-INSERT INTO otel_metrics_gauge VALUES
-    ('latency_ms', map('endpoint', '/api/v1'), toDateTime64('1970-01-01 00:06:40', 9), 100.0),
-    ('latency_ms', map('endpoint', '/api/v1'), toDateTime64('1970-01-01 00:07:00', 9), 100.0),
-    ('latency_ms', map('endpoint', '/api/v1'), toDateTime64('1970-01-01 00:07:30', 9), 100.0),
-    ('latency_ms', map('endpoint', '/api/v1'), toDateTime64('1970-01-01 00:08:00', 9), 100.0),
-    ('latency_ms', map('endpoint', '/api/v1'), toDateTime64('1970-01-01 00:08:20', 9), 100.0);
+INSERT INTO otel_metrics_gauge
+    SELECT 'latency_ms',
+           map('endpoint', '/api/v1'),
+           toDateTime64('1970-01-01 00:05:00', 9) + toIntervalNanosecond(number * 1000000),
+           exp(toFloat64(number) / 500.0)
+    FROM numbers(10000);
 -- expected_rows --
 [
-  [{"endpoint": "/api/v1"}, 100.0]
+  [{"endpoint": "/api/v1"}, 178143523.48176438]
 ]
 -- args --
 [0] float64 = 0.95


### PR DESCRIPTION
Phase-0(d) route-A exactness gap. `quantile_over_time(phi, m[range])` with a **computed** phi already used the exact `arraySort` + linear-interpolation branch, but the **literal-phi** path (e.g. `quantile_over_time(0.95, m[5m])`) emitted an approximate CH quantile. Reference PromQL computes the exact φ-quantile with linear interpolation at rank `φ·(N-1)`.

## Fix
- `range_fns.go` — literal in-range phi now routes through `window.ScalarExprs = [LitFloat{phi}]`, the **same emitter slot** the computed-phi path uses. Both render the identical `multiIf(isNaN, nan; <0, -Inf; >1, +Inf; arraySort + linear-interp at rank=phi*(N-1) with least() upper-rank clamp)` — not a second/new formula; only the phi term differs (bound literal vs correlated subquery).
- Edge semantics preserved: literal `-0.5 → -Inf`, `1.5 → +Inf` (unchanged sentinel + post-Project branch), `NaN → NaN`, empty window filtered, single-sample falls out naturally (rank 0).

## Verification (adversarial)
- New `quantile_over_time_p95_exact_interp` fixture: 10 000 samples, exp-spread distribution, phi=0.95 → rank 9499.05 → `exp(9499/500)*0.95 + exp(9500/500)*0.05 = 178143523.48…` — **bit-exact** to the regenerated golden.
- No drift: computed-phi (`scalar_phi`), `q_negative`, `q_above_one` fixtures byte-identical. `cardinality-baseline.json +10` is the required row for the new 10k-row fixture (fan_factor 1, no joins). Typed `chplan.LitFloat`, no raw SQL. CI `compatibility/prometheus` is the final arbiter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)