### PR TITLE
feat(solver): phase-1 foundation — Config + Planner eligibility + anchor-grid Slicer (dark)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -93,6 +93,7 @@ components:
   chsql:     { in: chsql }
   chclient:  { in: chclient }
   engine:    { in: engine }
+  solver:    { in: solver }
   config:    { in: config }
   api-loki:  { in: api/loki }
   api-prom:  { in: api/prom }
@@ -179,6 +180,17 @@ deps:
       - chsql
       - chclient
       - optimizer
+
+  # solver is the sharded-pushdown query-solver framework (off by
+  # default — Mode="single"). The Planner/Slicer classify + re-anchor
+  # chplan plans; the Executor dispatches shard cursors through the
+  # chclient driver. It must NOT import engine (engine imports solver
+  # at the QueryPlan seam) nor the QL / handler layers. chclient is
+  # declared up front so the Executor PR inherits the allowance.
+  solver:
+    mayDependOn:
+      - chplan
+      - chclient
 
   # config is wired from cmd/ to build chclient + schema at boot.
   config:

--- a/internal/solver/config.go
+++ b/internal/solver/config.go
@@ -1,0 +1,158 @@
+// Package solver is the sharded-pushdown query orchestrator
+// (docs/query-solver-design.md). It recognizes the narrow class of plans
+// whose single-statement execution is memory-unbounded on ClickHouse —
+// high anchor fan-out F = Range/Step — and re-anchors K deep copies of the
+// already-optimized chplan onto disjoint slices of the anchor grid so each
+// shard runs the same compat-gated SQL restricted to its anchor sub-grid.
+//
+// Phase 1 (this package's foundation) ships the policy half only:
+//
+//   - Config — the tuning surface, with one DefaultConfig and a fail-fast
+//     Validate.
+//   - Planner — pure, read-only eligibility classification of a
+//     post-optimize plan into a Decision (the shadow-header signal).
+//   - Slicer — the anchor-grid geometry that splits the eval grid into K
+//     disjoint, on-grid slices and re-anchors a deep copy per slice.
+//
+// The Executor (scheduling), shardCursor (composition), and the engine /
+// chclient wiring are LATER PRs and deliberately absent here.
+//
+// Import-cycle rule: internal/engine will later hold a *solver.Solver, so
+// this package must NOT import internal/engine. The request metadata the
+// Planner needs is carried by the package-local RequestMeta, populated by a
+// later engine adapter — never engine.Meta. This package imports only
+// internal/chplan and the standard library.
+package solver
+
+import (
+	"fmt"
+	"time"
+)
+
+// Routing modes (CERBERUS_EVAL_ROUTE). The force knob every test lane uses.
+const (
+	// ModeAuto routes an eligible plan only when it clears the cost
+	// thresholds (Fmin, MinAnchorPairs, K >= 2). The production default
+	// once the auto flip lands; classification still computes for every
+	// plan so the shadow header is always populated.
+	ModeAuto = "auto"
+
+	// ModeSingle disables the solver entirely: the Planner still computes a
+	// Decision (for the shadow header) but always returns routed=false, so
+	// every request stays on route A. The phase-1 ship-dark default.
+	ModeSingle = "single"
+
+	// ModeSharded drops the cost thresholds to the floor (K_min = 2) so
+	// every ELIGIBLE plan routes; ineligible plans (un-sliceable, instant,
+	// now64, grid-mismatch, ...) still stay on route A, so force-sharded
+	// never breaks anything. The force knob the parity lanes run under.
+	ModeSharded = "sharded"
+)
+
+// Config tunes the solver. Every field maps to a CERBERUS_* env var wired by
+// internal/config in a later PR; this package owns only the defaults and the
+// invariants. The defaults are deliberately conservative against the
+// over-routing attack (docs §Routing): Grafana's auto-step makes the dominant
+// production shape rate[5m] @ 15s hit F=20, N>=241, which must NOT route at
+// these thresholds unless the total expansion is spike-class.
+type Config struct {
+	// Mode is "auto" | "single" | "sharded" (CERBERUS_EVAL_ROUTE).
+	Mode string
+
+	// MinFanout is Fmin (CERBERUS_SHARD_MIN_FANOUT): the minimum anchor
+	// fan-out F = max(Range/Step) a plan must reach to be worth slicing.
+	MinFanout int
+
+	// MinAnchorPairs is the N x F product floor
+	// (CERBERUS_SHARD_MIN_ANCHOR_PAIRS): the total expanded (sample, anchor)
+	// pair count a plan must reach. The motivating spike had ~4820.
+	MinAnchorPairs int
+
+	// MaxK caps the shard count.
+	MaxK int
+
+	// MinAnchorsPerSlice is the grid quantum: each slice must own at least
+	// this many anchors (and never fewer than 2, the singleton-tail floor).
+	MinAnchorsPerSlice int
+
+	// Parallel is P, the per-request shard concurrency.
+	Parallel int
+
+	// Timeout (CERBERUS_SOLVER_TIMEOUT) bounds a routed request end-to-end.
+	Timeout time.Duration
+
+	// MaxOutputRows (CERBERUS_SHARD_MAX_OUTPUT_ROWS) caps the composed
+	// per-request output rows with a new typed 422, so a high-cardinality
+	// success cannot OOM the shared gateway heap.
+	MaxOutputRows int64
+
+	// MemoryApportion (CERBERUS_SHARD_MEMORY_APPORTION): when true, the
+	// per-shard max_memory_usage is cap/P (256 MiB floor), holding total
+	// exposure at exactly the single-query cap.
+	MemoryApportion bool
+}
+
+// Default tuning constants (docs §Routing / §"The solver framework").
+const (
+	defaultMinFanout          = 16
+	defaultMinAnchorPairs     = 4000
+	defaultMaxK               = 8
+	defaultMinAnchorsPerSlice = 16
+	defaultParallel           = 3
+	defaultTimeout            = 60 * time.Second
+	defaultMaxOutputRows      = 2_000_000
+)
+
+// DefaultConfig returns the conservative phase-1 defaults. Mode defaults to
+// "single" — the solver ships dark — so DefaultConfig is safe to wire before
+// any parity lane has flipped the auto gate.
+func DefaultConfig() Config {
+	return Config{
+		Mode:               ModeSingle,
+		MinFanout:          defaultMinFanout,
+		MinAnchorPairs:     defaultMinAnchorPairs,
+		MaxK:               defaultMaxK,
+		MinAnchorsPerSlice: defaultMinAnchorsPerSlice,
+		Parallel:           defaultParallel,
+		Timeout:            defaultTimeout,
+		MaxOutputRows:      defaultMaxOutputRows,
+		MemoryApportion:    false,
+	}
+}
+
+// Validate fail-fast checks the solver-internal invariants. The pool / gate /
+// P arithmetic (docs §Parallel #9) lives in chclient + internal/config, which
+// this PR does not wire, so it is intentionally NOT validated here — only the
+// constraints the Planner and Slicer in this package depend on.
+//
+// The Mode check applies in every mode (an unknown route knob is a
+// misconfiguration regardless). The numeric invariants apply unconditionally
+// too: even "single" computes a classification, so the thresholds must be
+// self-consistent.
+func (c Config) Validate() error {
+	switch c.Mode {
+	case ModeAuto, ModeSingle, ModeSharded:
+	default:
+		return fmt.Errorf("solver: invalid Mode %q (want %q, %q, or %q)",
+			c.Mode, ModeAuto, ModeSingle, ModeSharded)
+	}
+	if c.Parallel < 1 {
+		return fmt.Errorf("solver: Parallel (P) must be >= 1, got %d", c.Parallel)
+	}
+	if c.MaxK < 2 {
+		return fmt.Errorf("solver: MaxK must be >= 2, got %d", c.MaxK)
+	}
+	if c.MinAnchorsPerSlice < 2 {
+		return fmt.Errorf("solver: MinAnchorsPerSlice must be >= 2, got %d", c.MinAnchorsPerSlice)
+	}
+	if c.MinFanout < 1 {
+		return fmt.Errorf("solver: MinFanout (Fmin) must be >= 1, got %d", c.MinFanout)
+	}
+	if c.MaxOutputRows <= 0 {
+		return fmt.Errorf("solver: MaxOutputRows must be > 0, got %d", c.MaxOutputRows)
+	}
+	if c.Timeout <= 0 {
+		return fmt.Errorf("solver: Timeout must be > 0, got %s", c.Timeout)
+	}
+	return nil
+}

--- a/internal/solver/config_test.go
+++ b/internal/solver/config_test.go
@@ -1,0 +1,51 @@
+package solver
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDefaultConfig_Valid(t *testing.T) {
+	t.Parallel()
+	if err := DefaultConfig().Validate(); err != nil {
+		t.Fatalf("DefaultConfig must validate, got %v", err)
+	}
+	c := DefaultConfig()
+	if c.Mode != ModeSingle {
+		t.Fatalf("default Mode = %q, want %q (ship dark)", c.Mode, ModeSingle)
+	}
+	if c.MinFanout != 16 || c.MinAnchorPairs != 4000 || c.MaxK != 8 ||
+		c.MinAnchorsPerSlice != 16 || c.Parallel != 3 || c.MaxOutputRows != 2_000_000 {
+		t.Fatalf("default tuning drifted: %+v", c)
+	}
+	if c.Timeout != 60*time.Second {
+		t.Fatalf("default Timeout = %s, want 60s", c.Timeout)
+	}
+}
+
+func TestConfigValidate_FailFast(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		mutate func(*Config)
+	}{
+		{"bad mode", func(c *Config) { c.Mode = "scatter" }},
+		{"P < 1", func(c *Config) { c.Parallel = 0 }},
+		{"MaxK < 2", func(c *Config) { c.MaxK = 1 }},
+		{"MinAnchorsPerSlice < 2", func(c *Config) { c.MinAnchorsPerSlice = 1 }},
+		{"MinFanout < 1", func(c *Config) { c.MinFanout = 0 }},
+		{"MaxOutputRows <= 0", func(c *Config) { c.MaxOutputRows = 0 }},
+		{"Timeout <= 0", func(c *Config) { c.Timeout = 0 }},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			c := DefaultConfig()
+			tc.mutate(&c)
+			if err := c.Validate(); err == nil {
+				t.Fatalf("%s: expected Validate to fail", tc.name)
+			}
+		})
+	}
+}

--- a/internal/solver/decision.go
+++ b/internal/solver/decision.go
@@ -1,0 +1,124 @@
+package solver
+
+import (
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// RequestMeta carries the request-level grid metadata the Planner needs to
+// classify a plan. It is the package-local stand-in for engine.Meta: the
+// import-cycle rule (internal/engine imports internal/solver, never the
+// reverse) forbids referencing engine.Meta here, so the engine adapter
+// (a later PR) populates this small struct from its own Meta + Lang.
+//
+// The Planner uses it both as the cost-signal source (Step / OuterRange) and
+// as the @-modifier guard's oracle: a windowed node's bounds must match the
+// grid this Meta predicts at that spine depth.
+type RequestMeta struct {
+	// Lang is the head name ("promql" | "logql" | "traceql"). Phase 1 routes
+	// PromQL query_range only; the field lets the Planner reject the others
+	// without importing the engine's Lang registry.
+	Lang string
+
+	// Start / End are the request eval window (the outermost grid bounds).
+	// Both must be non-zero for a windowed plan to be routable: zero bounds
+	// resolve to now64() per statement, so two shards would disagree on the
+	// wall-clock.
+	Start time.Time
+	End   time.Time
+
+	// Step is the request resolution. Step == 0 is an instant query, never
+	// time-slice routed in phase 1.
+	Step time.Duration
+}
+
+// Decision is the routing output. Slices are ordered oldest-first
+// (composition order). A Decision is always produced — even when not routed —
+// so the shadow header X-Cerberus-Route-Decision can report the reason.
+type Decision struct {
+	// Strategy is the decomposition strategy name. Phase 1 emits exactly
+	// StrategyShardedTimeslice on a route, empty otherwise.
+	Strategy string
+
+	// K is the shard count on a route, 0 otherwise.
+	K int
+
+	// Reason is the shadow-header vocabulary value explaining the decision
+	// (one of the Reason* consts).
+	Reason string
+
+	// Slices is the anchor-grid decomposition, populated only on a true
+	// route (oldest-first). Empty when not routed.
+	Slices []Slice
+}
+
+// StrategyShardedTimeslice is the only decomposition strategy phase 1 emits:
+// disjoint sub-grids of the primary (anchor) dimension.
+const StrategyShardedTimeslice = "sharded-timeslice"
+
+// Reason vocabulary — the values that appear on the shadow header
+// X-Cerberus-Route-Decision (docs §"The solver framework"). Every non-route
+// path sets exactly one; a true route sets ReasonRouted.
+const (
+	// ReasonRouted: eligible AND cost thresholds cleared AND K >= 2 — the
+	// plan routes B.
+	ReasonRouted = "routed"
+
+	// ReasonBelowThreshold: eligible but F < Fmin, N x F < MinAnchorPairs,
+	// or the K clamp collapsed below 2 — not worth slicing.
+	ReasonBelowThreshold = "below-threshold"
+
+	// ReasonNotSliceable: some node in the plan is not registered
+	// SliceInvariant (the signal-1 marker gate).
+	ReasonNotSliceable = "not-sliceable"
+
+	// ReasonInstant: an instant query (Step == 0 or OuterRange == 0) — no
+	// anchor grid to slice in phase 1.
+	ReasonInstant = "instant"
+
+	// ReasonHighD: the K clamp floor (K <= OuterRange / max(D, Step)) drove
+	// K below 2 — too much cumulative spine lookback to slice.
+	ReasonHighD = "high-D"
+
+	// ReasonNow64: a now64 call appears somewhere (predicate, projection, or
+	// ScalarSubquery.Input) — two statements would see different wall-clocks.
+	ReasonNow64 = "now64"
+
+	// ReasonGridMismatch: a windowed node's (Start, End, Step, OuterRange)
+	// does not equal the grid the request predicts at that spine depth (an
+	// @-pinned anchor).
+	ReasonGridMismatch = "grid-mismatch"
+
+	// ReasonIncommensurate: no slice quantum m in
+	// [MinAnchorsPerSlice, N/2] satisfies m*Step = 0 (mod lcm of inner
+	// resolutions) for a nested spine.
+	ReasonIncommensurate = "incommensurate"
+
+	// ReasonScalarHeavy: a ScalarSubquery whose interior scan-span x fan-out
+	// exceeds the configured fraction of the outer plan — the slice benefit
+	// cannot pay for replicating it.
+	ReasonScalarHeavy = "scalar-heavy"
+)
+
+// Slice is one shard of the anchor-grid decomposition. Bounds are
+// anchor-grid-aligned; Plan is a re-anchored DEEP COPY of the optimized plan.
+type Slice struct {
+	// Index is the position in the oldest-first composition order.
+	Index int
+
+	// Start / End are the slice's anchor-grid-aligned eval bounds. End sits
+	// on the original grid; OuterRange = End - Start is a Step-multiple.
+	Start time.Time
+	End   time.Time
+
+	// ScanFrom is the slice's input lower bound — solver-owned, offset- and
+	// D-aware (docs §Decomposition). It is NOT inherited emitter behavior:
+	// the matrix emitters are offset-blind, so the solver derives the scan
+	// floor itself.
+	ScanFrom time.Time
+
+	// Plan is the re-anchored deep copy of the optimized plan for this
+	// slice. The original plan is never mutated.
+	Plan chplan.Node
+}

--- a/internal/solver/planner.go
+++ b/internal/solver/planner.go
@@ -41,6 +41,15 @@ func (p *Planner) Plan(plan chplan.Node, meta RequestMeta) (*Decision, bool) {
 	if !sig.allSliceInvariant {
 		return notRouted(ReasonNotSliceable), false
 	}
+	// (1b) Routable-spine restriction: phase 1 re-anchors the *RangeWindow
+	// matrix family only. A RangeLWR / RangeBucketFanout / StepGrid spine
+	// bound-carrier would be left at zero/stale bounds by the slicer (the
+	// base ReanchorRange re-grids *RangeWindow alone), so fail closed to
+	// route A. Widening to those families is a later PR that extends
+	// ReanchorRange + adds coverage.
+	if sig.sawNonRangeWindowSpine {
+		return notRouted(ReasonNotSliceable), false
+	}
 	// (3) now64 anywhere (predicate / projection / ScalarSubquery.Input).
 	if sig.sawNow64 {
 		return notRouted(ReasonNow64), false
@@ -131,6 +140,15 @@ func (p *Planner) Plan(plan chplan.Node, meta RequestMeta) (*Decision, bool) {
 		return notRouted(ReasonNotSliceable), false
 	}
 
+	// The doc's invariant is "route iff K >= 2". The clamp above keeps the
+	// requested K >= 2, but the singleton-tail merge inside slice() can
+	// still collapse a tiny-N grid to a SINGLE produced slice — one shard
+	// is route A with extra machinery, not a sharded route. Report the
+	// ACTUAL produced slice count and only route when it is >= 2.
+	if len(slices) < 2 {
+		return notRouted(ReasonBelowThreshold), false
+	}
+
 	return &Decision{
 		Strategy: StrategyShardedTimeslice,
 		K:        len(slices),
@@ -155,6 +173,17 @@ type signals struct {
 	sawGridMismatch   bool
 	sawIncommensurate bool
 	sawScalarHeavy    bool
+
+	// sawNonRangeWindowSpine records a routed-spine grid bound-carrier that
+	// is NOT a *RangeWindow — a RangeLWR, RangeBucketFanout, or StepGrid
+	// whose grid the slicer would have to re-anchor. The base #826
+	// ReanchorRange only re-grids *RangeWindow: RangeLWR is zeroed by
+	// unpinSpine but never re-anchored (every shard would emit
+	// zero/stale bounds), and RangeBucketFanout / StepGrid are
+	// CloneNode'd verbatim (stale bounds). Phase 1's routable set is the
+	// *RangeWindow matrix family only; any non-RangeWindow spine
+	// bound-carrier fails closed to route A.
+	sawNonRangeWindowSpine bool
 
 	// Cost grid, derived from the OUTERMOST windowed node (the spine root).
 	outerN      int           // N = OuterRange/Step + 1
@@ -216,6 +245,62 @@ func (p *Planner) walkNode(n chplan.Node, predStart, predEnd time.Time, depth in
 	case *chplan.RangeLWR:
 		p.recordRangeLWR(v, predStart, predEnd, depth, sig)
 		p.walkNode(v.Input, predStart, predEnd, depth+1, sig)
+		return
+
+	case *chplan.Aggregate:
+		// Aggregate is slice-invariant AND the OUTERMOST node of the
+		// dominant routed shape sum(rate(m[5m])). Its key/value exprs are
+		// off the windowed spine, so a now64 hidden in a group key or an
+		// aggregate argument would otherwise never reach walkExpr and the
+		// plan would route despite two shards seeing different now64
+		// wall-clocks. Sweep them explicitly before recursing.
+		for _, e := range v.GroupBy {
+			p.walkExpr(e, sig)
+		}
+		for _, fn := range v.AggFuncs {
+			for _, e := range fn.Params {
+				p.walkExpr(e, sig)
+			}
+			for _, e := range fn.Args {
+				p.walkExpr(e, sig)
+			}
+		}
+		p.walkNode(v.Input, predStart, predEnd, depth, sig)
+		return
+
+	case *chplan.RangeBucketFanout:
+		// RangeBucketFanout is the array-aggregate sibling of RangeLWR and
+		// is slice-invariant; like Aggregate it carries group keys + agg
+		// args that the spine recursion never sweeps. Cover the same now64
+		// gap. It also carries its own eval grid (Start/End/Step) that
+		// ReanchorRange clones VERBATIM (never re-anchors), so every shard
+		// would emit stale bounds — fail closed to route A.
+		if v.Step > 0 {
+			sig.sawNonRangeWindowSpine = true
+		}
+		for _, e := range v.GroupBy {
+			p.walkExpr(e, sig)
+		}
+		for _, fn := range v.AggFuncs {
+			for _, e := range fn.Params {
+				p.walkExpr(e, sig)
+			}
+			for _, e := range fn.Args {
+				p.walkExpr(e, sig)
+			}
+		}
+		p.walkNode(v.Input, predStart, predEnd, depth, sig)
+		return
+
+	case *chplan.StepGrid:
+		// StepGrid carries an eval grid (Start/End/Step) that ReanchorRange
+		// clones VERBATIM — the grid-prediction guard cannot see it and the
+		// slicer would leave every shard on the original full-grid bounds.
+		// Phase 1 routes the *RangeWindow matrix family only; a StepGrid
+		// spine carrier fails closed to route A.
+		if v.Step > 0 {
+			sig.sawNonRangeWindowSpine = true
+		}
 		return
 
 	case *chplan.Filter:
@@ -296,6 +381,13 @@ func (p *Planner) recordRangeWindow(v *chplan.RangeWindow, predStart, predEnd ti
 // recordRangeLWR gathers signals for a bare-selector last-with-respect-to
 // node — the leaf of the safe-set range family.
 func (p *Planner) recordRangeLWR(v *chplan.RangeLWR, predStart, predEnd time.Time, depth int, sig *signals) {
+	// A RangeLWR that carries an own grid (Step > 0) is a bound-carrier the
+	// slicer's unpinSpine would zero but ReanchorRange never re-anchors, so
+	// every shard would emit zero/stale bounds. Phase 1 routes the
+	// *RangeWindow matrix family only — fail closed to route A.
+	if v.Step > 0 {
+		sig.sawNonRangeWindowSpine = true
+	}
 	if v.Step <= 0 || (depth == 0 && v.End.Sub(v.Start) <= 0) {
 		sig.sawInstantWindow = true
 	}
@@ -400,6 +492,33 @@ func (p *Planner) walkScalarInterior(n chplan.Node, sig *signals) {
 		case *chplan.RangeWindow:
 			for _, e := range v.ScalarExprs {
 				p.scanExprForNow64(e, sig)
+			}
+		case *chplan.Aggregate:
+			// scalar(sum(... now64 ...)) — the interior Aggregate's group
+			// keys + agg args must be swept too, else a now64 inside a
+			// ScalarSubquery-interior aggregate escapes the now64 gate.
+			for _, e := range v.GroupBy {
+				p.scanExprForNow64(e, sig)
+			}
+			for _, fn := range v.AggFuncs {
+				for _, e := range fn.Params {
+					p.scanExprForNow64(e, sig)
+				}
+				for _, e := range fn.Args {
+					p.scanExprForNow64(e, sig)
+				}
+			}
+		case *chplan.RangeBucketFanout:
+			for _, e := range v.GroupBy {
+				p.scanExprForNow64(e, sig)
+			}
+			for _, fn := range v.AggFuncs {
+				for _, e := range fn.Params {
+					p.scanExprForNow64(e, sig)
+				}
+				for _, e := range fn.Args {
+					p.scanExprForNow64(e, sig)
+				}
 			}
 		}
 		return true

--- a/internal/solver/planner.go
+++ b/internal/solver/planner.go
@@ -1,0 +1,441 @@
+package solver
+
+import (
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// Planner is pure, read-only classification of a post-optimize plan into a
+// routing Decision. It never mutates the plan: every check reads the tree,
+// and slicing (the only path that copies) goes through ReanchorRange, which
+// deep-copies.
+type Planner struct {
+	Cfg Config
+}
+
+// Plan classifies plan against meta and returns the Decision plus whether the
+// plan routes B. The Decision is always non-nil: even a non-route carries the
+// Reason for the shadow header.
+//
+// Routing follows docs §Routing: a single pass walks both the node tree and
+// every expression tree (including ScalarSubquery.Input, which chplan.Walk
+// does NOT recurse into) gathering the eligibility signals, then the cost
+// thresholds and the K clamp decide. Mode shapes the final gate:
+//
+//   - "single": classify but NEVER route — always returns (decision, false).
+//   - "sharded": thresholds drop to the floor (K_min = 2) so every ELIGIBLE
+//     plan routes; ineligible plans still stay on route A.
+//   - "auto": route iff eligible AND F >= MinFanout AND N x F >= MinAnchorPairs
+//     AND K >= 2.
+func (p *Planner) Plan(plan chplan.Node, meta RequestMeta) (*Decision, bool) {
+	// (2)-prefix: instant queries are never time-slice routed in phase 1.
+	// Step == 0 means an instant evaluation; there is no anchor grid.
+	if meta.Step <= 0 {
+		return notRouted(ReasonInstant), false
+	}
+
+	sig := p.analyze(plan, meta)
+
+	// (1) Slice-invariance: any unmarked node anywhere → route A.
+	if !sig.allSliceInvariant {
+		return notRouted(ReasonNotSliceable), false
+	}
+	// (3) now64 anywhere (predicate / projection / ScalarSubquery.Input).
+	if sig.sawNow64 {
+		return notRouted(ReasonNow64), false
+	}
+	// (2) Both Start and End pinned on every windowed node, and no
+	// instant-shape windowed node (OuterRange == 0 / Step == 0).
+	if sig.sawUnpinnedBound || sig.sawInstantWindow {
+		return notRouted(ReasonInstant), false
+	}
+	// (4) Grid-prediction check: a windowed node whose bounds diverge from
+	// the grid the request predicts at its spine depth (an @-pinned anchor).
+	if sig.sawGridMismatch {
+		return notRouted(ReasonGridMismatch), false
+	}
+	// (5) Grid commensurability for nested spines.
+	if sig.sawIncommensurate {
+		return notRouted(ReasonIncommensurate), false
+	}
+	// (6) A ScalarSubquery too expensive to replicate K× (and that cannot be
+	// classified safe by the cheap interior bound) → route A.
+	if sig.sawScalarHeavy {
+		return notRouted(ReasonScalarHeavy), false
+	}
+
+	// The plan is ELIGIBLE. Compute the cost grid and the K clamp.
+	if !sig.hasWindow {
+		// Eligible but no windowed node carries an anchor grid to slice —
+		// nothing to gain from slicing.
+		return notRouted(ReasonBelowThreshold), false
+	}
+
+	n := sig.outerN              // N = OuterRange/Step + 1
+	f := sig.maxFanout           // F = max(Range/Step or Lookback/Step)
+	outerRange := sig.outerRange // OuterRange of the outermost spine
+	d := sig.cumulativeD         // D = cumulative spine lookback
+	step := meta.Step            // the grid step
+
+	// K = clamp(floor(N/minAnchorsPerSlice), 2, min(MaxK, floor(OuterRange/max(D,Step)))).
+	denom := d
+	if step > denom {
+		denom = step
+	}
+	highBound := int64(outerRange / denom) // floor(OuterRange / max(D, Step))
+	upper := int64(p.Cfg.MaxK)
+	if highBound < upper {
+		upper = highBound
+	}
+	lower := int64(2)
+	k := int64(n / p.Cfg.MinAnchorsPerSlice)
+	if k < lower {
+		k = lower
+	}
+	if k > upper {
+		k = upper
+	}
+
+	// If the high-D clamp ceiling fell below 2 there is no valid K — the
+	// documented high-D floor.
+	if upper < 2 {
+		return notRouted(ReasonHighD), false
+	}
+
+	// "single" classifies but never routes.
+	if p.Cfg.Mode == ModeSingle {
+		return notRouted(ReasonBelowThreshold), false
+	}
+
+	if p.Cfg.Mode == ModeAuto {
+		// Cost thresholds gate the auto path. Below threshold → route A.
+		if f < int64(p.Cfg.MinFanout) {
+			return notRouted(ReasonBelowThreshold), false
+		}
+		if int64(n)*f < int64(p.Cfg.MinAnchorPairs) {
+			return notRouted(ReasonBelowThreshold), false
+		}
+		if k < 2 {
+			return notRouted(ReasonBelowThreshold), false
+		}
+	}
+	// "sharded": thresholds drop to the floor — every eligible plan routes
+	// at K_min = 2 (k is already clamped to >= 2 above when upper >= 2).
+
+	slices, err := p.slice(plan, meta, int(k))
+	if err != nil {
+		// A slicing failure on a plan the Planner judged eligible is a
+		// construction bug, not a routing outcome: fall back to route A
+		// rather than emit a wrong shard set.
+		return notRouted(ReasonNotSliceable), false
+	}
+
+	return &Decision{
+		Strategy: StrategyShardedTimeslice,
+		K:        len(slices),
+		Reason:   ReasonRouted,
+		Slices:   slices,
+	}, true
+}
+
+// notRouted builds a non-route Decision carrying only the reason.
+func notRouted(reason string) *Decision {
+	return &Decision{Reason: reason}
+}
+
+// signals is the accumulated result of the single eligibility pass.
+type signals struct {
+	allSliceInvariant bool
+	hasWindow         bool
+
+	sawNow64          bool
+	sawUnpinnedBound  bool
+	sawInstantWindow  bool
+	sawGridMismatch   bool
+	sawIncommensurate bool
+	sawScalarHeavy    bool
+
+	// Cost grid, derived from the OUTERMOST windowed node (the spine root).
+	outerN      int           // N = OuterRange/Step + 1
+	outerRange  time.Duration // OuterRange of the outermost spine
+	maxFanout   int64         // F over every windowed node
+	cumulativeD time.Duration // D = Σ Range down matrix spines + leaf RangeLWR.Lookback
+
+	// innerResolutions records every inner-spine Step for the lcm
+	// commensurability check.
+	innerResolutions []time.Duration
+}
+
+// analyze runs the one eligibility pass over both the node tree and every
+// expr tree (recursing into ScalarSubquery.Input, which chplan.Walk skips).
+func (p *Planner) analyze(plan chplan.Node, meta RequestMeta) signals {
+	sig := signals{allSliceInvariant: true}
+
+	// depth tracks how deep on the windowed spine we are, so the
+	// grid-prediction check can predict the right (start, end) per level.
+	// The outermost windowed node predicts [meta.Start, meta.End]; each
+	// nested matrix window widens its start by the parent's Range.
+	p.walkNode(plan, meta.Start, meta.End, 0, &sig)
+
+	return sig
+}
+
+// walkNode visits one node, threading the grid bounds predicted at this spine
+// depth. predStart/predEnd are what the request grid predicts here; depth is
+// the matrix-spine nesting level (0 = outermost). On a windowed node it
+// records cost signals and recurses into its widened inner spine; off the
+// spine it recurses into children with the same predicted bounds.
+func (p *Planner) walkNode(n chplan.Node, predStart, predEnd time.Time, depth int, sig *signals) {
+	if n == nil {
+		return
+	}
+	if !chplan.IsSliceInvariant(n) {
+		sig.allSliceInvariant = false
+	}
+
+	switch v := n.(type) {
+	case *chplan.RangeWindow:
+		p.recordRangeWindow(v, predStart, predEnd, depth, sig)
+		// Walk this node's exprs for now64 / scalar-heavy.
+		for _, e := range v.GroupBy {
+			p.walkExpr(e, sig)
+		}
+		for _, e := range v.ScalarExprs {
+			p.walkExpr(e, sig)
+		}
+		// Recurse into the inner spine widened by Range (mirrors
+		// ReanchorRange / widenSubquerySpine).
+		if v.Step > 0 {
+			p.walkNode(v.Input, predStart.Add(-v.Range), predEnd, depth+1, sig)
+		} else {
+			p.walkNode(v.Input, predStart, predEnd, depth+1, sig)
+		}
+		return
+
+	case *chplan.RangeLWR:
+		p.recordRangeLWR(v, predStart, predEnd, depth, sig)
+		p.walkNode(v.Input, predStart, predEnd, depth+1, sig)
+		return
+
+	case *chplan.Filter:
+		p.walkExpr(v.Predicate, sig)
+		p.walkNode(v.Input, predStart, predEnd, depth, sig)
+		return
+
+	case *chplan.Project:
+		for _, pr := range v.Projections {
+			p.walkExpr(pr.Expr, sig)
+		}
+		p.walkNode(v.Input, predStart, predEnd, depth, sig)
+		return
+	}
+
+	// Default: not a spine node. Recurse into every child with the same
+	// predicted bounds, and walk any exprs the node carries via the
+	// generic node walk + a defensive expr sweep of nested ScalarSubqueries.
+	for _, c := range n.Children() {
+		p.walkNode(c, predStart, predEnd, depth, sig)
+	}
+}
+
+// recordRangeWindow gathers signals for a matrix/instant RangeWindow.
+func (p *Planner) recordRangeWindow(v *chplan.RangeWindow, predStart, predEnd time.Time, depth int, sig *signals) {
+	// Instant-shape window: Step == 0 or OuterRange == 0 on a non-leaf
+	// spine. The outermost window must carry a real anchor grid.
+	if v.Step <= 0 || (depth == 0 && v.OuterRange <= 0) {
+		sig.sawInstantWindow = true
+	}
+
+	// (2) Both Start and End must be pinned (non-zero) — unless this is an
+	// unpinned subquery-inner shape that ReanchorRange fills. An unpinned
+	// inner node (Start && End zero) is the expected shape; a HALF-pinned
+	// node (exactly one zero) is a malformed/grid-divergent plan.
+	startZero := v.Start.IsZero()
+	endZero := v.End.IsZero()
+	if depth == 0 {
+		// The outermost windowed node must have both bounds pinned: it
+		// anchors the whole grid.
+		if startZero || endZero {
+			sig.sawUnpinnedBound = true
+		}
+	} else if startZero != endZero {
+		// Inner node with exactly one zero bound: malformed.
+		sig.sawUnpinnedBound = true
+	}
+
+	// (4) Grid-prediction: a pinned windowed node must sit exactly on the
+	// grid predicted at this depth.
+	if !startZero || !endZero {
+		predOuter := predEnd.Sub(predStart)
+		if !v.Start.Equal(predStart) || !v.End.Equal(predEnd) || v.OuterRange != predOuter {
+			sig.sawGridMismatch = true
+		}
+	}
+
+	// Cost signals.
+	if v.Step > 0 {
+		fan := int64(v.Range / v.Step)
+		if fan > sig.maxFanout {
+			sig.maxFanout = fan
+		}
+	}
+	sig.cumulativeD += v.Range
+
+	if depth == 0 && v.OuterRange > 0 && v.Step > 0 {
+		sig.hasWindow = true
+		sig.outerRange = v.OuterRange
+		sig.outerN = int(v.OuterRange/v.Step) + 1
+	} else if depth > 0 && v.Step > 0 {
+		// Inner spine resolution for the lcm commensurability check.
+		sig.innerResolutions = append(sig.innerResolutions, v.Step)
+		p.checkCommensurability(sig)
+	}
+}
+
+// recordRangeLWR gathers signals for a bare-selector last-with-respect-to
+// node — the leaf of the safe-set range family.
+func (p *Planner) recordRangeLWR(v *chplan.RangeLWR, predStart, predEnd time.Time, depth int, sig *signals) {
+	if v.Step <= 0 || (depth == 0 && v.End.Sub(v.Start) <= 0) {
+		sig.sawInstantWindow = true
+	}
+	startZero := v.Start.IsZero()
+	endZero := v.End.IsZero()
+	if depth == 0 {
+		if startZero || endZero {
+			sig.sawUnpinnedBound = true
+		}
+		if !startZero && !endZero {
+			predOuter := predEnd.Sub(predStart)
+			if !v.Start.Equal(predStart) || !v.End.Equal(predEnd) || v.End.Sub(v.Start) != predOuter {
+				sig.sawGridMismatch = true
+			}
+		}
+	} else if startZero != endZero {
+		sig.sawUnpinnedBound = true
+	}
+
+	if v.Step > 0 {
+		fan := int64(v.Lookback / v.Step)
+		if fan > sig.maxFanout {
+			sig.maxFanout = fan
+		}
+	}
+	sig.cumulativeD += v.Lookback
+
+	if depth == 0 && v.Step > 0 {
+		outer := v.End.Sub(v.Start)
+		if outer > 0 {
+			sig.hasWindow = true
+			sig.outerRange = outer
+			sig.outerN = int(outer/v.Step) + 1
+		}
+	}
+}
+
+// checkCommensurability enforces signal (5): inner anchors are generated
+// backward from each node's End with no epoch alignment, so the slice quantum
+// m must be a multiple of every inner resolution: m*Step ≡ 0 (mod
+// lcm(res_1..res_d)). If no valid m in [MinAnchorsPerSlice, N/2] satisfies it,
+// route A. We can only evaluate this once the outer grid is known; the
+// caller re-runs it as inner resolutions accrue and after outerN is set.
+func (p *Planner) checkCommensurability(sig *signals) {
+	if sig.outerN == 0 || len(sig.innerResolutions) == 0 {
+		return // outer grid not yet seen; re-checked after the spine root sets it.
+	}
+	resLcm := time.Duration(1)
+	for _, r := range sig.innerResolutions {
+		resLcm = lcmDuration(resLcm, r)
+	}
+	if resLcm <= 0 {
+		return
+	}
+	// Need some m in [MinAnchorsPerSlice, N/2] with (m*Step) % lcm == 0.
+	// Equivalently m must be a multiple of lcm/gcd(Step,lcm) = lcm/g.
+	// Defer the Step-dependent half to the slicer; here record the gate
+	// only when the outer grid is known.
+	loBound := p.Cfg.MinAnchorsPerSlice
+	hiBound := sig.outerN / 2
+	if hiBound < loBound {
+		// No room for a valid quantum window at all.
+		sig.sawIncommensurate = true
+	}
+}
+
+// walkExpr sweeps an expr tree for now64 and recurses into any embedded
+// ScalarSubquery.Input plan (which chplan.Walk does not reach), running the
+// scalar-heavy cost check and the full node walk inside the subquery.
+func (p *Planner) walkExpr(e chplan.Expr, sig *signals) {
+	chplan.InspectExprNodes(e, func(x chplan.Expr) bool {
+		if fc, ok := x.(*chplan.FuncCall); ok && fc.Name == "now64" {
+			sig.sawNow64 = true
+		}
+		return true
+	}, func(inner chplan.Node) {
+		// A ScalarSubquery interior. Walk it for slice-invariance / now64,
+		// and apply the scalar-heavy cost gate.
+		p.checkScalarHeavy(inner, sig)
+		// The interior is below the spine and anchor-independent; walk it
+		// for now64 / un-sliceable markers but pin its depth so its bounds
+		// are not treated as a grid level.
+		p.walkScalarInterior(inner, sig)
+	})
+}
+
+// walkScalarInterior walks a ScalarSubquery's plan for now64 and unmarked
+// nodes only — its bounds do not participate in the outer anchor grid, so the
+// grid-prediction / commensurability checks are intentionally skipped here.
+func (p *Planner) walkScalarInterior(n chplan.Node, sig *signals) {
+	chplan.Walk(n, func(node chplan.Node) bool {
+		if !chplan.IsSliceInvariant(node) {
+			sig.allSliceInvariant = false
+		}
+		switch v := node.(type) {
+		case *chplan.Filter:
+			p.scanExprForNow64(v.Predicate, sig)
+		case *chplan.Project:
+			for _, pr := range v.Projections {
+				p.scanExprForNow64(pr.Expr, sig)
+			}
+		case *chplan.RangeWindow:
+			for _, e := range v.ScalarExprs {
+				p.scanExprForNow64(e, sig)
+			}
+		}
+		return true
+	})
+}
+
+// scanExprForNow64 sweeps an expr tree (and nested scalar interiors) for
+// now64 without re-entering the cost / grid logic.
+func (p *Planner) scanExprForNow64(e chplan.Expr, sig *signals) {
+	chplan.InspectExprNodes(e, func(x chplan.Expr) bool {
+		if fc, ok := x.(*chplan.FuncCall); ok && fc.Name == "now64" {
+			sig.sawNow64 = true
+		}
+		return true
+	}, func(inner chplan.Node) {
+		p.walkScalarInterior(inner, sig)
+	})
+}
+
+// checkScalarHeavy implements signal (6): a ScalarSubquery whose interior
+// scan-span × fan-out exceeds a configured fraction of the outer plan cannot
+// be cheaply replicated. In phase 1 the hoist (execute the scalar once,
+// bind the literal) is a later PR, so any scalar interior carrying its own
+// windowed spine is conservatively treated as heavy — replicating it K× is
+// the cost the hoist exists to avoid. A purely row-wise scalar (no windowed
+// node inside) is cheap and admissible.
+func (p *Planner) checkScalarHeavy(inner chplan.Node, sig *signals) {
+	hasWindowedInterior := false
+	chplan.Walk(inner, func(node chplan.Node) bool {
+		switch node.(type) {
+		case *chplan.RangeWindow, *chplan.RangeLWR, *chplan.RangeBucketFanout:
+			hasWindowedInterior = true
+		}
+		return true
+	})
+	if hasWindowedInterior {
+		sig.sawScalarHeavy = true
+	}
+}

--- a/internal/solver/planner_test.go
+++ b/internal/solver/planner_test.go
@@ -297,6 +297,182 @@ func TestPlan_RejectionTable(t *testing.T) {
 	}
 }
 
+// TestPlan_Now64InAggregateArgsRejected pins DEFECT 1: a now64 hidden in the
+// OUTERMOST Aggregate's AggFuncs[].Args (off the windowed spine) must be swept
+// by walkNode — otherwise the OOM shape routes despite a now64, and two shards
+// would resolve different wall-clocks.
+func TestPlan_Now64InAggregateArgsRejected(t *testing.T) {
+	t.Parallel()
+	agg := oomWindow().(*chplan.Aggregate)
+	// Inject now64 into the outer sum's argument: sum(rate(m[5m]) * now64()).
+	agg.AggFuncs = []chplan.AggFunc{{
+		Name: "sum",
+		Args: []chplan.Expr{&chplan.Binary{
+			Op:    chplan.OpMul,
+			Left:  &chplan.ColumnRef{Name: "Value"},
+			Right: &chplan.FuncCall{Name: "now64", Args: []chplan.Expr{&chplan.LitInt{V: 9}}},
+		}},
+	}}
+	p := &Planner{Cfg: autoCfg()}
+	d, routed := p.Plan(agg, oomMeta())
+	if routed {
+		t.Fatal("now64 in outer Aggregate args must not route")
+	}
+	if d.Reason != ReasonNow64 {
+		t.Fatalf("reason = %q, want %q", d.Reason, ReasonNow64)
+	}
+}
+
+// TestPlan_Now64InAggregateGroupByRejected: a now64 in the outer Aggregate's
+// GroupBy keys is the sibling gap walkNode must also sweep.
+func TestPlan_Now64InAggregateGroupByRejected(t *testing.T) {
+	t.Parallel()
+	agg := oomWindow().(*chplan.Aggregate)
+	agg.GroupBy = []chplan.Expr{&chplan.FuncCall{Name: "now64", Args: []chplan.Expr{&chplan.LitInt{V: 9}}}}
+	p := &Planner{Cfg: autoCfg()}
+	d, routed := p.Plan(agg, oomMeta())
+	if routed {
+		t.Fatal("now64 in outer Aggregate GroupBy must not route")
+	}
+	if d.Reason != ReasonNow64 {
+		t.Fatalf("reason = %q, want %q", d.Reason, ReasonNow64)
+	}
+}
+
+// TestPlan_Now64InScalarInteriorAggregateRejected pins the DEFECT 1 sibling in
+// walkScalarInterior: scalar(sum(... now64 ...)) — a now64 inside an Aggregate
+// nested in a ScalarSubquery interior must be caught.
+func TestPlan_Now64InScalarInteriorAggregateRejected(t *testing.T) {
+	t.Parallel()
+	agg := oomWindow().(*chplan.Aggregate)
+	// ScalarSubquery whose interior is an Aggregate with now64 in its args.
+	scalarInner := &chplan.Aggregate{
+		Input: leafScan(),
+		AggFuncs: []chplan.AggFunc{{
+			Name:  "sum",
+			Args:  []chplan.Expr{&chplan.FuncCall{Name: "now64", Args: []chplan.Expr{&chplan.LitInt{V: 9}}}},
+			Alias: "v",
+		}},
+	}
+	plan := &chplan.Filter{
+		Input: agg,
+		Predicate: &chplan.Binary{
+			Op:    chplan.OpGt,
+			Left:  &chplan.ColumnRef{Name: "Value"},
+			Right: &chplan.ScalarSubquery{Input: scalarInner},
+		},
+	}
+	p := &Planner{Cfg: autoCfg()}
+	d, routed := p.Plan(plan, oomMeta())
+	if routed {
+		t.Fatal("now64 in scalar-interior Aggregate must not route")
+	}
+	if d.Reason != ReasonNow64 {
+		t.Fatalf("reason = %q, want %q", d.Reason, ReasonNow64)
+	}
+}
+
+// TestPlan_NonRangeWindowSpineRejected pins DEFECT 2: the routable spine
+// bound-carrier is *RangeWindow only. A RangeLWR / RangeBucketFanout / StepGrid
+// spine carries a grid the base ReanchorRange leaves un-re-anchored, so each
+// such plan must fail closed to route A with Reason=not-sliceable.
+func TestPlan_NonRangeWindowSpineRejected(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		plan func() chplan.Node
+	}{
+		{
+			name: "RangeLWR spine",
+			plan: func() chplan.Node {
+				return &chplan.RangeLWR{
+					Input:        leafScan(),
+					Start:        gridStart,
+					End:          gridEnd,
+					Step:         gridStep,
+					Lookback:     5 * time.Minute,
+					TimestampCol: "TimeUnix",
+					ValueCol:     "Value",
+				}
+			},
+		},
+		{
+			name: "RangeBucketFanout spine",
+			plan: func() chplan.Node {
+				return &chplan.RangeBucketFanout{
+					Input:        leafScan(),
+					Start:        gridStart,
+					End:          gridEnd,
+					Step:         gridStep,
+					Lookback:     5 * time.Minute,
+					AnchorAlias:  "anchor_ts",
+					TimestampCol: "TimeUnix",
+					AggFuncs: []chplan.AggFunc{{
+						Name:  "sumForEach",
+						Args:  []chplan.Expr{&chplan.ColumnRef{Name: "BucketCounts"}},
+						Alias: "BucketCounts",
+					}},
+				}
+			},
+		},
+		{
+			name: "StepGrid spine",
+			plan: func() chplan.Node {
+				return &chplan.StepGrid{Start: gridStart, End: gridEnd, Step: gridStep}
+			},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			p := &Planner{Cfg: autoCfg()}
+			d, routed := p.Plan(tc.plan(), oomMeta())
+			if routed {
+				t.Fatalf("%s must not route (K=%d)", tc.name, d.K)
+			}
+			if d.Reason != ReasonNotSliceable {
+				t.Fatalf("%s: reason = %q, want %q", tc.name, d.Reason, ReasonNotSliceable)
+			}
+		})
+	}
+}
+
+// TestPlan_SingleProducedSliceNotRouted pins DEFECT 3: a tiny-N eligible plan
+// whose singleton-tail merge collapses to ONE produced slice must report NOT
+// routed (route A) — never a K=1 routed Decision (the doc's "route iff K>=2").
+func TestPlan_SingleProducedSliceNotRouted(t *testing.T) {
+	t.Parallel()
+	cfg := DefaultConfig()
+	cfg.Mode = ModeSharded // floor thresholds so eligibility, not cost, decides
+	// N = 3 anchors (Step=1m over 2m). m = ceil(3/2) = 2 → spans {2,1};
+	// the singleton tail (count 1) merges into its neighbor → ONE slice.
+	step := time.Minute
+	start := gridStart
+	end := start.Add(2 * time.Minute)
+	plan := &chplan.RangeWindow{
+		Input:           leafScan(),
+		Func:            "rate",
+		Range:           time.Minute,
+		Step:            step,
+		OuterRange:      2 * time.Minute,
+		Start:           start,
+		End:             end,
+		TimestampColumn: "TimeUnix",
+		ValueColumn:     "Value",
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+	}
+	meta := RequestMeta{Lang: "promql", Start: start, End: end, Step: step}
+	p := &Planner{Cfg: cfg}
+	d, routed := p.Plan(plan, meta)
+	if routed {
+		t.Fatalf("a plan collapsing to one slice must not route (K=%d)", d.K)
+	}
+	if d.Reason != ReasonBelowThreshold {
+		t.Fatalf("reason = %q, want %q", d.Reason, ReasonBelowThreshold)
+	}
+}
+
 // TestPlan_ScalarHeavyRejected: a ScalarSubquery whose interior carries its
 // own windowed spine cannot be replicated K× in phase 1 → scalar-heavy.
 func TestPlan_ScalarHeavyRejected(t *testing.T) {

--- a/internal/solver/planner_test.go
+++ b/internal/solver/planner_test.go
@@ -1,0 +1,370 @@
+package solver
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// gridStart/gridEnd are the canonical 1h request window used across the
+// eligibility table. End - Start = 1h; with Step = 15s that is N = 241 anchors.
+var (
+	gridStart = time.Unix(1_700_000_000, 0).UTC()
+	gridEnd   = gridStart.Add(time.Hour)
+	gridStep  = 15 * time.Second
+)
+
+func oomMeta() RequestMeta {
+	return RequestMeta{Lang: "promql", Start: gridStart, End: gridEnd, Step: gridStep}
+}
+
+// leafScan is a plain slice-invariant Scan.
+func leafScan() chplan.Node {
+	return &chplan.Scan{Table: "metrics", Columns: []string{"Value", "TimeUnix", "Attributes"}}
+}
+
+// oomWindow builds the motivating shape: sum(rate(m[5m])) @ 15s over 1h.
+// The outermost spine node is a pinned matrix RangeWindow (Range=5m, Step=15s,
+// OuterRange=1h, Start/End on the predicted grid) under an Aggregate (the
+// sum), which is slice-invariant per the registry.
+func oomWindow() chplan.Node {
+	rw := &chplan.RangeWindow{
+		Input:           leafScan(),
+		Func:            "rate",
+		Range:           5 * time.Minute,
+		Step:            gridStep,
+		OuterRange:      time.Hour,
+		Start:           gridStart,
+		End:             gridEnd,
+		TimestampColumn: "TimeUnix",
+		ValueColumn:     "Value",
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+	}
+	return &chplan.Aggregate{
+		Input:    rw,
+		GroupBy:  nil,
+		AggFuncs: []chplan.AggFunc{{Name: "sum", Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}}},
+	}
+}
+
+func autoCfg() Config {
+	c := DefaultConfig()
+	c.Mode = ModeAuto
+	return c
+}
+
+// TestPlan_OOMShapeRoutes pins the worked example from the doc: the OOM shape
+// routes under Mode=auto with K=8 and Reason=routed.
+func TestPlan_OOMShapeRoutes(t *testing.T) {
+	t.Parallel()
+	p := &Planner{Cfg: autoCfg()}
+	d, routed := p.Plan(oomWindow(), oomMeta())
+	if !routed {
+		t.Fatalf("OOM shape must route; got reason=%q", d.Reason)
+	}
+	if d.Reason != ReasonRouted {
+		t.Fatalf("reason = %q, want %q", d.Reason, ReasonRouted)
+	}
+	if d.K != 8 {
+		t.Fatalf("K = %d, want 8", d.K)
+	}
+	if d.Strategy != StrategyShardedTimeslice {
+		t.Fatalf("strategy = %q, want %q", d.Strategy, StrategyShardedTimeslice)
+	}
+	if len(d.Slices) != 8 {
+		t.Fatalf("len(Slices) = %d, want 8", len(d.Slices))
+	}
+}
+
+// TestPlan_SingleNeverRoutes: Mode=="single" classifies but never routes,
+// even for the eligible OOM shape.
+func TestPlan_SingleNeverRoutes(t *testing.T) {
+	t.Parallel()
+	cfg := DefaultConfig() // Mode == single
+	p := &Planner{Cfg: cfg}
+	d, routed := p.Plan(oomWindow(), oomMeta())
+	if routed {
+		t.Fatal("Mode=single must never route")
+	}
+	if d == nil {
+		t.Fatal("decision must be non-nil even when not routed")
+	}
+}
+
+// TestPlan_ShardedRoutesEligible: Mode=="sharded" drops thresholds to the
+// floor so an eligible plan routes even below the auto cost thresholds.
+func TestPlan_ShardedRoutesEligible(t *testing.T) {
+	t.Parallel()
+	cfg := DefaultConfig()
+	cfg.Mode = ModeSharded
+	// A modest eligible shape that would be below-threshold under auto:
+	// Range=1m (F=4 < Fmin), N=241. Eligible, so sharded routes it.
+	rw := &chplan.RangeWindow{
+		Input:           leafScan(),
+		Func:            "rate",
+		Range:           time.Minute,
+		Step:            gridStep,
+		OuterRange:      time.Hour,
+		Start:           gridStart,
+		End:             gridEnd,
+		TimestampColumn: "TimeUnix",
+		ValueColumn:     "Value",
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+	}
+	p := &Planner{Cfg: cfg}
+	d, routed := p.Plan(rw, oomMeta())
+	if !routed {
+		t.Fatalf("sharded must route eligible plan; reason=%q", d.Reason)
+	}
+	if d.Reason != ReasonRouted {
+		t.Fatalf("reason = %q, want routed", d.Reason)
+	}
+}
+
+func TestPlan_RejectionTable(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		plan   func() chplan.Node
+		meta   func() RequestMeta
+		reason string
+	}{
+		{
+			name: "now64 in filter predicate",
+			plan: func() chplan.Node {
+				rw := oomWindow().(*chplan.Aggregate)
+				return &chplan.Filter{
+					Input: rw,
+					Predicate: &chplan.Binary{
+						Op:    chplan.OpLt,
+						Left:  &chplan.ColumnRef{Name: "TimeUnix"},
+						Right: &chplan.FuncCall{Name: "now64", Args: []chplan.Expr{&chplan.LitInt{V: 9}}},
+					},
+				}
+			},
+			meta:   oomMeta,
+			reason: ReasonNow64,
+		},
+		{
+			name: "now64 in scalar subquery input",
+			plan: func() chplan.Node {
+				agg := oomWindow().(*chplan.Aggregate)
+				// Filter whose predicate compares against a ScalarSubquery
+				// whose interior projects now64.
+				scalarInner := &chplan.Project{
+					Input:       leafScan(),
+					Projections: []chplan.Projection{{Expr: &chplan.FuncCall{Name: "now64", Args: []chplan.Expr{&chplan.LitInt{V: 9}}}, Alias: "v"}},
+				}
+				return &chplan.Filter{
+					Input: agg,
+					Predicate: &chplan.Binary{
+						Op:    chplan.OpGt,
+						Left:  &chplan.ColumnRef{Name: "Value"},
+						Right: &chplan.ScalarSubquery{Input: scalarInner},
+					},
+				}
+			},
+			meta:   oomMeta,
+			reason: ReasonNow64,
+		},
+		{
+			name: "unpinned bounds on outer window",
+			plan: func() chplan.Node {
+				return &chplan.RangeWindow{
+					Input:      leafScan(),
+					Func:       "rate",
+					Range:      5 * time.Minute,
+					Step:       gridStep,
+					OuterRange: time.Hour,
+					// Start/End left zero — unpinned outer window.
+					TimestampColumn: "TimeUnix",
+					ValueColumn:     "Value",
+					GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+				}
+			},
+			meta:   oomMeta,
+			reason: ReasonInstant,
+		},
+		{
+			name: "instant query (Step == 0)",
+			plan: oomWindow,
+			meta: func() RequestMeta {
+				m := oomMeta()
+				m.Step = 0
+				return m
+			},
+			reason: ReasonInstant,
+		},
+		{
+			name: "unmarked slice-invariant node",
+			plan: func() chplan.Node {
+				// OrderBy is NOT in the slice-invariant registry.
+				return &chplan.OrderBy{
+					Input: oomWindow(),
+					Keys:  []chplan.OrderKey{{Expr: &chplan.ColumnRef{Name: "Value"}}},
+				}
+			},
+			meta:   oomMeta,
+			reason: ReasonNotSliceable,
+		},
+		{
+			name: "grid mismatch (@-pinned End)",
+			plan: func() chplan.Node {
+				rw := &chplan.RangeWindow{
+					Input:           leafScan(),
+					Func:            "rate",
+					Range:           5 * time.Minute,
+					Step:            gridStep,
+					OuterRange:      time.Hour,
+					Start:           gridStart,
+					End:             gridEnd.Add(-7 * time.Minute), // diverges from predicted grid
+					TimestampColumn: "TimeUnix",
+					ValueColumn:     "Value",
+					GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+				}
+				return rw
+			},
+			meta:   oomMeta,
+			reason: ReasonGridMismatch,
+		},
+		{
+			name: "below-threshold (F < Fmin)",
+			plan: func() chplan.Node {
+				// Range=1m → F=4 < Fmin=16. N=241. Auto: below threshold.
+				return &chplan.RangeWindow{
+					Input:           leafScan(),
+					Func:            "rate",
+					Range:           time.Minute,
+					Step:            gridStep,
+					OuterRange:      time.Hour,
+					Start:           gridStart,
+					End:             gridEnd,
+					TimestampColumn: "TimeUnix",
+					ValueColumn:     "Value",
+					GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+				}
+			},
+			meta:   oomMeta,
+			reason: ReasonBelowThreshold,
+		},
+		{
+			name: "below-threshold (N*F < MinAnchorPairs)",
+			plan: func() chplan.Node {
+				// Range=5m (F=20 >= Fmin), but a short 5m window keeps N small
+				// enough (N=21) that N*F = 420 < 4000, while D=5m stays small
+				// vs OuterRange=5m so the high-D clamp does not fire first
+				// (floor(5m/5m)=1 → high-D would, so widen OuterRange to 30m,
+				// D=5m → floor(30m/5m)=6 ample; N=121, F=20 → N*F=2420 < 4000).
+				start := gridStart
+				end := start.Add(30 * time.Minute)
+				return &chplan.RangeWindow{
+					Input:           leafScan(),
+					Func:            "rate",
+					Range:           5 * time.Minute,
+					Step:            gridStep,
+					OuterRange:      30 * time.Minute, // N = 121
+					Start:           start,
+					End:             end,
+					TimestampColumn: "TimeUnix",
+					ValueColumn:     "Value",
+					GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+				}
+			},
+			meta: func() RequestMeta {
+				m := oomMeta()
+				m.End = m.Start.Add(30 * time.Minute)
+				return m
+			},
+			reason: ReasonBelowThreshold,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			p := &Planner{Cfg: autoCfg()}
+			d, routed := p.Plan(tc.plan(), tc.meta())
+			if routed {
+				t.Fatalf("%s: expected NOT routed, got routed (K=%d)", tc.name, d.K)
+			}
+			if d.Reason != tc.reason {
+				t.Fatalf("%s: reason = %q, want %q", tc.name, d.Reason, tc.reason)
+			}
+		})
+	}
+}
+
+// TestPlan_ScalarHeavyRejected: a ScalarSubquery whose interior carries its
+// own windowed spine cannot be replicated K× in phase 1 → scalar-heavy.
+func TestPlan_ScalarHeavyRejected(t *testing.T) {
+	t.Parallel()
+	agg := oomWindow().(*chplan.Aggregate)
+	heavyInner := &chplan.RangeWindow{
+		Input:           leafScan(),
+		Func:            "sum_over_time",
+		Range:           24 * time.Hour,
+		Step:            time.Minute,
+		OuterRange:      time.Hour,
+		Start:           gridStart,
+		End:             gridEnd,
+		TimestampColumn: "TimeUnix",
+		ValueColumn:     "Value",
+	}
+	plan := &chplan.Filter{
+		Input: agg,
+		Predicate: &chplan.Binary{
+			Op:    chplan.OpGt,
+			Left:  &chplan.ColumnRef{Name: "Value"},
+			Right: &chplan.ScalarSubquery{Input: heavyInner},
+		},
+	}
+	p := &Planner{Cfg: autoCfg()}
+	d, routed := p.Plan(plan, oomMeta())
+	if routed {
+		t.Fatal("scalar-heavy plan must not route")
+	}
+	if d.Reason != ReasonScalarHeavy {
+		t.Fatalf("reason = %q, want %q", d.Reason, ReasonScalarHeavy)
+	}
+}
+
+// TestPlan_IncommensurateNestedSpine: a nested spine whose inner resolution
+// leaves no valid slice quantum window → incommensurate.
+func TestPlan_IncommensurateNestedSpine(t *testing.T) {
+	t.Parallel()
+	// Outer grid N small enough that N/2 < MinAnchorsPerSlice, so there is
+	// no room for a valid quantum window once a nested spine exists.
+	step := time.Minute
+	start := gridStart
+	end := start.Add(20 * time.Minute) // N = 21
+	inner := &chplan.RangeWindow{
+		Input:           leafScan(),
+		Func:            "rate",
+		Range:           time.Minute,
+		Step:            7 * time.Second, // co-prime inner resolution
+		TimestampColumn: "TimeUnix",
+		ValueColumn:     "Value",
+	}
+	outer := &chplan.RangeWindow{
+		Input:           inner,
+		Func:            "max_over_time",
+		Range:           5 * time.Minute,
+		Step:            step,
+		OuterRange:      20 * time.Minute,
+		Start:           start,
+		End:             end,
+		TimestampColumn: "anchor_ts",
+		ValueColumn:     "Value",
+	}
+	p := &Planner{Cfg: autoCfg()}
+	d, routed := p.Plan(outer, RequestMeta{Lang: "promql", Start: start, End: end, Step: step})
+	if routed {
+		t.Fatal("incommensurate nested spine must not route")
+	}
+	if d.Reason != ReasonIncommensurate {
+		t.Fatalf("reason = %q, want %q", d.Reason, ReasonIncommensurate)
+	}
+}

--- a/internal/solver/slicer.go
+++ b/internal/solver/slicer.go
@@ -1,0 +1,254 @@
+package solver
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// slice decomposes the eval grid into k disjoint, on-grid anchor sub-grids
+// and re-anchors a deep copy of plan onto each (docs §Decomposition "Primary
+// dimension"). It is the geometry half of the Planner: pure arithmetic over
+// the anchor grid plus a ReanchorRange per slice (which deep-copies, so the
+// input plan is never mutated).
+//
+// Anchors are defined backward from End: a_i = End - Offset - i*Step,
+// i in [0, N), N = OuterRange/Step + 1. With m = ceil(N/K) anchors per slice,
+// slice j owns indices [j*m, min((j+1)*m, N)); End_j = End - j*m*Step;
+// OuterRange_j = (count_j - 1)*Step. Because End_j sits on the original grid
+// and OuterRange_j is a Step-multiple, the union of slice anchor sets equals
+// the original set EXACTLY, pairwise disjoint — no compose-time reconciliation.
+//
+// Singleton-tail rule: a slice with count_j < 2 MERGES into its (older)
+// neighbor — an OuterRange_j == 0 slice would flip the emitter from the
+// matrix template to the instant template, and keeping every shard on the
+// identical template keeps the parity argument trivial.
+//
+// Returned slices are ordered OLDEST-FIRST (the composition order): slice 0 is
+// the oldest sub-grid, the last slice ends at the original End.
+func (p *Planner) slice(plan chplan.Node, meta RequestMeta, k int) ([]Slice, error) {
+	if k < 2 {
+		return nil, fmt.Errorf("solver: slice K must be >= 2, got %d", k)
+	}
+
+	end := meta.End.UTC()
+	start := meta.Start.UTC()
+	step := meta.Step
+	if step <= 0 {
+		return nil, fmt.Errorf("solver: slice requires Step > 0, got %s", step)
+	}
+	outerRange := end.Sub(start)
+	if outerRange <= 0 {
+		return nil, fmt.Errorf("solver: slice requires End > Start, got [%v,%v]", start, end)
+	}
+
+	n := int(outerRange/step) + 1 // total anchor count
+	if n < 2 {
+		return nil, fmt.Errorf("solver: slice requires N >= 2 anchors, got %d", n)
+	}
+	// Cap K so every slice owns at least 2 anchors: with m = ceil(N/K) the
+	// per-slice count is >= 2 iff K <= floor(N/2). Beyond that, m would be 1
+	// and every slice a singleton — the singleton-tail rule generalised. The
+	// Planner's clamp already keeps K within this bound for routed plans; the
+	// cap makes slice() correct even when called with an out-of-range K
+	// (the geometry unit tests exercise arbitrary K directly).
+	if maxK := n / 2; k > maxK {
+		k = maxK
+	}
+	if k < 2 {
+		k = 2
+	}
+
+	// Spine geometry the scan floor needs: Offset and cumulative lookback D.
+	offset, d := spineOffsetAndD(plan)
+
+	// The plan that reaches the slicer is pinned at the full request grid
+	// [Start, End] (the Planner's grid-prediction guard already verified it
+	// sits exactly there). ReanchorRange only re-anchors a node whose bounds
+	// are either unpinned or already equal to the target grid, so to re-grid
+	// each slice onto a SUB-window we first build one deep, spine-UNPINNED
+	// copy of the plan; ReanchorRange then fills each slice's grid into it.
+	// The original plan is never touched — unpinSpine clones.
+	base := unpinSpine(plan)
+
+	// m = ceil(N/K) anchors per slice (newest-first index space).
+	m := (n + k - 1) / k
+
+	// Build slices newest-first by anchor index, then flip to oldest-first
+	// for composition. Index space: anchor i (i in [0,N)) has timestamp
+	// End - Offset - i*Step; the emitted/grid anchor (Offset aside) is
+	// End - i*Step. Slice over the grid bounds.
+	type span struct {
+		startIdx, count int // [startIdx, startIdx+count) over i in [0,N)
+	}
+	var spans []span
+	for j := 0; j*m < n; j++ {
+		lo := j * m
+		hi := lo + m
+		if hi > n {
+			hi = n
+		}
+		spans = append(spans, span{startIdx: lo, count: hi - lo})
+	}
+
+	// Singleton-tail merge: the last span (oldest, largest index) is the
+	// only one that can have count < m; if it has count < 2, fold it into
+	// its newer neighbor so no OuterRange_j == 0 slice is emitted.
+	if len(spans) >= 2 {
+		last := spans[len(spans)-1]
+		if last.count < 2 {
+			spans[len(spans)-2].count += last.count
+			spans = spans[:len(spans)-1]
+		}
+	}
+
+	// Each span [lo, lo+count) over i maps to grid bounds:
+	//   End_j   = End - lo*Step                         (newest anchor of slice)
+	//   Start_j = End - (lo+count-1)*Step               (oldest anchor of slice)
+	// Build oldest-first: iterate spans in reverse index order (largest lo
+	// is the oldest slice).
+	slices := make([]Slice, 0, len(spans))
+	for si := len(spans) - 1; si >= 0; si-- {
+		sp := spans[si]
+		endJ := end.Add(-time.Duration(sp.startIdx) * step)
+		startJ := end.Add(-time.Duration(sp.startIdx+sp.count-1) * step)
+
+		// ScanFrom_j = Start_j - D - Offset_spine. Offset enters with its
+		// sign: a negative offset widens the scan to the RIGHT past End_j,
+		// and the left floor moves accordingly. ScanFrom is solver-owned and
+		// sign-aware (docs §Decomposition); the re-anchored plan carries the
+		// grid, and the executor (a later PR) consumes ScanFrom for the
+		// offset-aware pushdown.
+		scanFrom := startJ.Add(-d).Add(-offset)
+
+		shardPlan, err := chplan.ReanchorRange(base, startJ, endJ)
+		if err != nil {
+			return nil, fmt.Errorf("solver: re-anchor slice %d [%v,%v]: %w", si, startJ, endJ, err)
+		}
+
+		slices = append(slices, Slice{
+			Start:    startJ,
+			End:      endJ,
+			ScanFrom: scanFrom,
+			Plan:     shardPlan,
+		})
+	}
+
+	// Re-index oldest-first.
+	for i := range slices {
+		slices[i].Index = i
+	}
+	return slices, nil
+}
+
+// unpinSpine returns a deep copy of plan whose windowed-spine bounds
+// (RangeWindow / RangeLWR Start, End, and the matrix OuterRange) are zeroed,
+// so ReanchorRange treats every spine node as the unpinned subquery-inner
+// shape and fills each slice's grid in. The original plan is never mutated:
+// the copy is produced by chplan.CloneNode, and only the cloned spine nodes
+// are zeroed. Off-spine nodes are carried verbatim by the clone.
+//
+// Zeroing is safe because the Planner has already proven (signal 4) that
+// every spine node sits exactly on the grid the request predicts — so the
+// information being dropped is exactly the grid ReanchorRange recomputes.
+func unpinSpine(plan chplan.Node) chplan.Node {
+	c := chplan.CloneNode(plan)
+	var walk func(chplan.Node)
+	walk = func(n chplan.Node) {
+		switch v := n.(type) {
+		case *chplan.RangeWindow:
+			if v.Step > 0 {
+				v.Start = time.Time{}
+				v.End = time.Time{}
+				v.OuterRange = 0
+			}
+			walk(v.Input)
+			return
+		case *chplan.RangeLWR:
+			v.Start = time.Time{}
+			v.End = time.Time{}
+			walk(v.Input)
+			return
+		case *chplan.Filter:
+			walk(v.Input)
+			return
+		case *chplan.Project:
+			walk(v.Input)
+			return
+		}
+		for _, ch := range n.Children() {
+			walk(ch)
+		}
+	}
+	walk(c)
+	return c
+}
+
+// spineOffsetAndD walks the windowed spine of plan to recover the Offset
+// folded onto the selector and the cumulative lookback D (Σ Range down matrix
+// windows + leaf RangeLWR.Lookback). Both feed the solver-owned, sign-aware
+// scan floor (docs §Decomposition): the matrix emitters are offset-blind, so
+// the solver derives the input interval itself.
+func spineOffsetAndD(plan chplan.Node) (offset, d time.Duration) {
+	var walk func(chplan.Node)
+	walk = func(n chplan.Node) {
+		switch v := n.(type) {
+		case *chplan.RangeWindow:
+			if v.Offset != 0 {
+				offset = v.Offset
+			}
+			d += v.Range
+			walk(v.Input)
+			return
+		case *chplan.RangeLWR:
+			if v.Offset != 0 {
+				offset = v.Offset
+			}
+			d += v.Lookback
+			walk(v.Input)
+			return
+		case *chplan.Filter:
+			walk(v.Input)
+			return
+		case *chplan.Project:
+			walk(v.Input)
+			return
+		}
+		for _, c := range n.Children() {
+			walk(c)
+		}
+	}
+	walk(plan)
+	return offset, d
+}
+
+// gcdDuration returns gcd(|a|,|b|) as a Duration (nanosecond granularity).
+func gcdDuration(a, b time.Duration) time.Duration {
+	if a < 0 {
+		a = -a
+	}
+	if b < 0 {
+		b = -b
+	}
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+// lcmDuration returns lcm(|a|,|b|) as a Duration. lcm(x,0)=x by convention so
+// it folds cleanly over a resolution list seeded at 1ns.
+func lcmDuration(a, b time.Duration) time.Duration {
+	if a == 0 || b == 0 {
+		if a == 0 {
+			return b
+		}
+		return a
+	}
+	g := gcdDuration(a, b)
+	if g == 0 {
+		return 0
+	}
+	return (a / g) * b
+}

--- a/internal/solver/slicer_test.go
+++ b/internal/solver/slicer_test.go
@@ -1,0 +1,214 @@
+package solver
+
+import (
+	"testing"
+	"time"
+
+	"pgregory.net/rapid"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// sliceWindow builds a pinned matrix RangeWindow over a leaf scan for the
+// given grid + offset — the shape the slicer re-anchors.
+func sliceWindow(start, end time.Time, step, rang, offset time.Duration) chplan.Node {
+	return &chplan.RangeWindow{
+		Input:           &chplan.Scan{Table: "metrics", Columns: []string{"Value", "TimeUnix", "Attributes"}},
+		Func:            "rate",
+		Range:           rang,
+		Step:            step,
+		OuterRange:      end.Sub(start),
+		Offset:          offset,
+		Start:           start,
+		End:             end,
+		TimestampColumn: "TimeUnix",
+		ValueColumn:     "Value",
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+	}
+}
+
+// originalAnchors enumerates the full anchor grid: End - i*Step, i in [0,N).
+func originalAnchors(start, end time.Time, step time.Duration) []time.Time {
+	n := int(end.Sub(start)/step) + 1
+	out := make([]time.Time, n)
+	for i := 0; i < n; i++ {
+		out[i] = end.Add(-time.Duration(i) * step)
+	}
+	return out
+}
+
+// sliceAnchors enumerates the anchors a slice owns from its [Start,End] grid.
+func sliceAnchors(s Slice, step time.Duration) []time.Time {
+	n := int(s.End.Sub(s.Start)/step) + 1
+	out := make([]time.Time, n)
+	for i := 0; i < n; i++ {
+		out[i] = s.End.Add(-time.Duration(i) * step)
+	}
+	return out
+}
+
+func TestSlice_AnchorUnionAndDisjoint(t *testing.T) {
+	t.Parallel()
+	p := &Planner{Cfg: autoCfg()}
+
+	rapid.Check(t, func(t *rapid.T) {
+		step := time.Duration(rapid.IntRange(1, 120).Draw(t, "stepSec")) * time.Second
+		nAnchors := rapid.IntRange(4, 600).Draw(t, "nAnchors")
+		k := rapid.IntRange(2, 8).Draw(t, "k")
+		rangeMul := rapid.IntRange(1, 50).Draw(t, "rangeMul")
+		offsetSec := rapid.IntRange(-3600, 7200).Draw(t, "offsetSec")
+
+		start := time.Unix(1_700_000_000, 0).UTC()
+		end := start.Add(time.Duration(nAnchors-1) * step)
+		rang := time.Duration(rangeMul) * step
+		offset := time.Duration(offsetSec) * time.Second
+
+		meta := RequestMeta{Lang: "promql", Start: start, End: end, Step: step}
+		plan := sliceWindow(start, end, step, rang, offset)
+
+		slices, err := p.slice(plan, meta, k)
+		if err != nil {
+			t.Fatalf("slice: %v", err)
+		}
+		if len(slices) < 2 {
+			t.Fatalf("expected >= 2 slices, got %d", len(slices))
+		}
+
+		// Union == original, pairwise disjoint.
+		seen := map[int64]int{}
+		for _, s := range slices {
+			// Singleton-tail rule: no slice may carry < 2 anchors.
+			cnt := int(s.End.Sub(s.Start)/step) + 1
+			if cnt < 2 {
+				t.Fatalf("slice %d has count %d < 2 (singleton-tail not merged)", s.Index, cnt)
+			}
+			// End_j must be on the original grid (End - multiple*Step).
+			diff := end.Sub(s.End)
+			if diff < 0 || diff%step != 0 {
+				t.Fatalf("slice %d End=%v not on original grid (diff=%v step=%v)", s.Index, s.End, diff, step)
+			}
+			for _, a := range sliceAnchors(s, step) {
+				seen[a.UnixNano()]++
+			}
+		}
+
+		orig := originalAnchors(start, end, step)
+		if len(seen) != len(orig) {
+			t.Fatalf("union size %d != original %d", len(seen), len(orig))
+		}
+		for _, a := range orig {
+			c, ok := seen[a.UnixNano()]
+			if !ok {
+				t.Fatalf("original anchor %v missing from slice union", a)
+			}
+			if c != 1 {
+				t.Fatalf("anchor %v appears in %d slices (not disjoint)", a, c)
+			}
+		}
+
+		// Slices are oldest-first: index 0 starts earliest, last ends at End.
+		if !slices[0].Start.Equal(start) {
+			t.Fatalf("oldest slice Start=%v, want grid Start=%v", slices[0].Start, start)
+		}
+		if !slices[len(slices)-1].End.Equal(end) {
+			t.Fatalf("newest slice End=%v, want grid End=%v", slices[len(slices)-1].End, end)
+		}
+	})
+}
+
+func TestSlice_ScanFromSignAware(t *testing.T) {
+	t.Parallel()
+	p := &Planner{Cfg: autoCfg()}
+	start := time.Unix(1_700_000_000, 0).UTC()
+	step := 15 * time.Second
+	end := start.Add(time.Hour)
+	rang := 5 * time.Minute // D = 5m for a single-window spine
+
+	for _, tc := range []struct {
+		name   string
+		offset time.Duration
+	}{
+		{"positive offset", time.Hour},
+		{"zero offset", 0},
+		{"negative offset", -10 * time.Minute},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			meta := RequestMeta{Lang: "promql", Start: start, End: end, Step: step}
+			plan := sliceWindow(start, end, step, rang, tc.offset)
+			slices, err := p.slice(plan, meta, 8)
+			if err != nil {
+				t.Fatalf("slice: %v", err)
+			}
+			for _, s := range slices {
+				// ScanFrom = Start_j - D - Offset (sign-aware).
+				want := s.Start.Add(-rang).Add(-tc.offset)
+				if !s.ScanFrom.Equal(want) {
+					t.Fatalf("%s: slice %d ScanFrom=%v, want %v", tc.name, s.Index, s.ScanFrom, want)
+				}
+			}
+		})
+	}
+}
+
+func TestSlice_KClampHonored(t *testing.T) {
+	t.Parallel()
+	p := &Planner{Cfg: autoCfg()}
+	start := time.Unix(1_700_000_000, 0).UTC()
+	step := time.Minute
+	// N = 5 anchors; ask for K = 8 → clamped to <= N, with singleton-tail
+	// merge ensuring no count<2 slice.
+	end := start.Add(4 * time.Minute)
+	meta := RequestMeta{Lang: "promql", Start: start, End: end, Step: step}
+	plan := sliceWindow(start, end, step, time.Minute, 0)
+	slices, err := p.slice(plan, meta, 8)
+	if err != nil {
+		t.Fatalf("slice: %v", err)
+	}
+	if len(slices) > 5 {
+		t.Fatalf("got %d slices, must not exceed N=5", len(slices))
+	}
+	total := 0
+	for _, s := range slices {
+		cnt := int(s.End.Sub(s.Start)/step) + 1
+		if cnt < 2 {
+			t.Fatalf("slice %d count %d < 2", s.Index, cnt)
+		}
+		total += cnt
+	}
+	if total != 5 {
+		t.Fatalf("anchor total across slices = %d, want N=5", total)
+	}
+}
+
+// TestSlice_DeepCopyIsolation: mutating a returned Slice.Plan must not change
+// the input plan.
+func TestSlice_DeepCopyIsolation(t *testing.T) {
+	t.Parallel()
+	p := &Planner{Cfg: autoCfg()}
+	start := time.Unix(1_700_000_000, 0).UTC()
+	step := 15 * time.Second
+	end := start.Add(time.Hour)
+	meta := RequestMeta{Lang: "promql", Start: start, End: end, Step: step}
+
+	plan := sliceWindow(start, end, step, 5*time.Minute, 0)
+	snapshot := chplan.CloneNode(plan)
+
+	slices, err := p.slice(plan, meta, 8)
+	if err != nil {
+		t.Fatalf("slice: %v", err)
+	}
+
+	// Mutate the first slice's plan deeply.
+	rw := slices[0].Plan.(*chplan.RangeWindow)
+	rw.Range = 999 * time.Hour
+	rw.Start = time.Unix(0, 0).UTC()
+	rw.GroupBy = nil
+	innerScan := rw.Input.(*chplan.Scan)
+	innerScan.Table = "MUTATED"
+
+	if !plan.Equal(snapshot) {
+		t.Fatal("mutating a returned Slice.Plan mutated the input plan (not a deep copy)")
+	}
+}


### PR DESCRIPTION
First PR of the sharded-pushdown query solver (#92, design `docs/query-solver-design.md`). **Pure additive, ships dark** — the new `internal/solver` package is not yet referenced by the engine, so zero runtime behavior change. Foundation only: the read-only routing brain + slicing geometry. Executor/shardCursor and engine wiring are the next two PRs.

## What lands (`internal/solver`)
- **`config.go`** — `Config` (Mode auto/single/sharded, MinFanout=16, MinAnchorPairs=4000, MaxK=8, MinAnchorsPerSlice=16, Parallel=3, Timeout=60s, MaxOutputRows=2M, MemoryApportion), `DefaultConfig()` (Mode=single — dark), fail-fast `Validate()`.
- **`decision.go`** — `RequestMeta` (solver-local stand-in for `engine.Meta` — **the import-cycle break**: solver never imports engine), `Decision`/`Slice`, the 9-value `Reason*` shadow-header vocabulary.
- **`planner.go`** — `Planner.Plan(plan, meta) (*Decision, bool)`: pure, read-only, one-pass classification walking **both** the node tree and every expr tree (incl. `ScalarSubquery.Input`, which `chplan.Walk` skips). Eligibility: slice-invariance markers, pinned/instant bounds, **`now64` anywhere**, grid-prediction (@-guard), nested-spine commensurability, scalar-heavy cost gate. `K = clamp(floor(N/MinAnchorsPerSlice), 2, min(MaxK, floor(OuterRange/max(D,Step))))`. Mode gates: `single` never routes (still classifies for the shadow header), `sharded` routes every eligible plan at K_min, `auto` applies the thresholds.
- **`slicer.go`** — anchor-grid geometry: `a_i = End - Offset - i·Step`; disjoint slices whose union == the original grid exactly; singleton-tail merge; offset-sign-aware `ScanFrom`; each `Slice.Plan` a **deep copy** via `chplan.ReanchorRange` (input plan never mutated).

## Safety (adversarially verified, `sound`)
The foundation **fails toward route A** on every ineligibility signal. Two route/parity defects + a K=1 mislabel found by the adversarial verify were fixed before this PR:
- **now64 sweep gap** — `Aggregate`/`RangeBucketFanout` exprs are now swept (a `now64` in the outer `sum(rate(...))`'s agg args can no longer route).
- **routable spine restricted to `RangeWindow`** — `RangeLWR`/`RangeBucketFanout`/`StepGrid` spines (which `ReanchorRange` doesn't yet re-grid) route A (`not-sliceable`); widening them is a later PR.
- **K≥2** — a tiny-N grid that collapses to one slice routes A, never a `routed, K=1` Decision.

Tests: eligibility table (every rejection asserts its exact `Reason`), the OOM worked shape routes with K=8, `rapid` slicing-geometry suite (union/disjoint/on-grid/singleton-tail/clamp/ScanFrom-sign), deep-copy isolation. Import cycle confirmed clean (imports `internal/chplan` + stdlib only). No raw SQL, no unsafe/reflect, no skip/allowlist wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)