### PR TITLE
perf(optimizer): flatten left-assoc set-op chains into one N-ary pass

### DIFF
--- a/internal/chplan/clone.go
+++ b/internal/chplan/clone.go
@@ -122,6 +122,8 @@ func cloneCompositeNode(n Node) Node {
 		c.Right = CloneNode(v.Right)
 		c.Match.Labels = cloneStrings(v.Match.Labels)
 		return &c
+	case *NaryVectorSetOp:
+		return cloneNaryVectorSetOp(v)
 	case *HistogramQuantile:
 		c := *v
 		c.Input = CloneNode(v.Input)
@@ -172,6 +174,19 @@ func cloneCompositeNode(n Node) Node {
 	default:
 		panic(fmt.Sprintf("chplan.CloneNode: unhandled Node type %T — extend the switch in clone.go", n))
 	}
+}
+
+// cloneNaryVectorSetOp deep-copies a linearised N-ary vector set-op node,
+// cloning every arm and the match-modifier label slice. Split out of
+// cloneCompositeNode so that switch stays within the funlen budget.
+func cloneNaryVectorSetOp(v *NaryVectorSetOp) Node {
+	c := *v
+	c.Arms = make([]Node, len(v.Arms))
+	for i, arm := range v.Arms {
+		c.Arms[i] = CloneNode(arm)
+	}
+	c.Match.Labels = cloneStrings(v.Match.Labels)
+	return &c
 }
 
 // cloneExpr returns a deep copy of e. Exhaustive over every concrete Expr

--- a/internal/chplan/clone_test.go
+++ b/internal/chplan/clone_test.go
@@ -51,6 +51,10 @@ func allNodeKinds() []chplan.Node {
 			Include: []string{"inst"}, ValueColumn: "Value",
 		},
 		&chplan.VectorSetOp{Left: leaf, Right: &chplan.Scan{Table: "r"}, Match: chplan.VectorMatch{Labels: []string{"job"}}, ValueColumn: "Value"},
+		&chplan.NaryVectorSetOp{
+			Arms: []chplan.Node{leaf, &chplan.Scan{Table: "r"}, &chplan.Scan{Table: "s"}},
+			Op:   chplan.VectorSetOr, Match: chplan.VectorMatch{Labels: []string{"job"}}, ValueColumn: "Value",
+		},
 		&chplan.HistogramQuantile{Input: leaf, Phi: 0.9, GroupBy: []chplan.Expr{expr}, GroupByAliases: []string{"g0"}, BucketCountsColumn: "BucketCounts"},
 		&chplan.HistogramQuantileNative{Input: leaf, Phi: 0.9, GroupBy: []chplan.Expr{expr}, GroupByAliases: []string{"g0"}, ScaleColumn: "Scale"},
 		&chplan.MetricsAggregate{Attr: expr, GroupBy: []chplan.Expr{expr}, GroupByAliases: []string{"g0"}, GroupByDisplayNames: []string{"g"}, Quantiles: []float64{0.5}, Inner: leaf},
@@ -100,7 +104,7 @@ func TestCloneNodeExhaustive(t *testing.T) {
 	// Lock-step guard: every concrete planNode() implementer in chplan must
 	// appear here. When this count drifts, a Node type was added — extend
 	// allNodeKinds AND the CloneNode switch in clone.go.
-	const wantNodeTypes = 26
+	const wantNodeTypes = 27
 	if len(nodes) != wantNodeTypes {
 		t.Fatalf("expected %d Node types, listed %d — a Node type was added: "+
 			"extend allNodeKinds + CloneNode", wantNodeTypes, len(nodes))

--- a/internal/chplan/nary_vector_set_op.go
+++ b/internal/chplan/nary_vector_set_op.go
@@ -1,0 +1,90 @@
+package chplan
+
+// NaryVectorSetOp is the linearised form of a left-associative chain of
+// the SAME associative PromQL vector set-operator — `a or b or c or …`
+// or `a and b and c and …`. The PromQL parser produces a left-leaning
+// binary tree (`((a or b) or c) or d`), which the binary VectorSetOp
+// emitter renders as one windowed pass PER nesting LEVEL. The
+// optimizer's FlattenVectorSetOp rule collapses such a chain into a
+// single NaryVectorSetOp carrying every arm in left-to-right order, and
+// the chsql emitter renders it as ONE windowed single-pass over the
+// arms' UNION ALL — so a K-arm chain scans each arm exactly once
+// instead of re-wrapping the accumulated left subtree K-1 times.
+//
+// Only the two associative set-ops are representable here:
+//
+//   - VectorSetOr  (`or`)  — union with later-arm anti-join. Each
+//     signature is owned by its EARLIEST contributing arm; that arm's
+//     rows survive, every later arm's rows for the same signature drop.
+//   - VectorSetAnd (`and`) — semi-join intersection. Arm-0's rows
+//     survive iff their signature appears in EVERY arm.
+//
+// `unless` is deliberately NOT representable: `a unless b unless c`
+// is `(a unless b) unless c`, and `unless` is not associative
+// (`a unless (b unless c)` differs), so flattening it would change
+// results. The flatten rule only ever targets `or` / `and`, and Op is
+// validated to one of those two by the emitter.
+//
+// The match key (Match / AttributesColumn) and the canonical Sample
+// column names are shared across all arms — the flatten rule only
+// collapses a chain whose links agree on every one of these, so the
+// single N-ary node carries one copy. Arms keep the same per-arm output
+// shape the binary node required (each arm canonicalised to the 4-column
+// Sample tuple at emit time).
+type NaryVectorSetOp struct {
+	// Arms lists the chain's operands in stable left-to-right source
+	// order. A well-formed NaryVectorSetOp always has at least two arms
+	// — the flatten rule never mints a degenerate single-arm node, and
+	// the emitter rejects fewer than two.
+	Arms []Node
+	// Op is the associative set-operator the whole chain shares. Only
+	// VectorSetOr / VectorSetAnd are valid; VectorSetUnless is rejected
+	// by the emitter because `unless` is not associative.
+	Op    VectorSetOpKind
+	Match VectorMatch
+
+	MetricNameColumn string
+	AttributesColumn string
+	TimestampColumn  string
+	ValueColumn      string
+}
+
+func (*NaryVectorSetOp) planNode() {}
+
+// Children returns the per-arm subtrees in stable left-to-right order,
+// matching the Node depth-first visitor contract.
+func (s *NaryVectorSetOp) Children() []Node {
+	out := make([]Node, len(s.Arms))
+	copy(out, s.Arms)
+	return out
+}
+
+// Equal reports positional structural equality with another
+// NaryVectorSetOp. Arm order is significant: `or` linearisation keeps
+// earliest-arm-wins semantics, so re-ordering arms changes the emitted
+// result, mirroring the order-sensitive equality every other plan node
+// uses.
+func (s *NaryVectorSetOp) Equal(other Node) bool {
+	o, ok := other.(*NaryVectorSetOp)
+	if !ok {
+		return false
+	}
+	if s.Op != o.Op || !s.Match.Equal(o.Match) {
+		return false
+	}
+	if s.MetricNameColumn != o.MetricNameColumn ||
+		s.AttributesColumn != o.AttributesColumn ||
+		s.TimestampColumn != o.TimestampColumn ||
+		s.ValueColumn != o.ValueColumn {
+		return false
+	}
+	if len(s.Arms) != len(o.Arms) {
+		return false
+	}
+	for i := range s.Arms {
+		if !s.Arms[i].Equal(o.Arms[i]) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/chplan/sliceinvariant_test.go
+++ b/internal/chplan/sliceinvariant_test.go
@@ -63,11 +63,15 @@ func TestIsSliceInvariant_UnregisteredKinds(t *testing.T) {
 		}
 	}
 
-	// 26 total node kinds, 9 registered → 17 must be default-denied. If this
+	// 27 total node kinds, 9 registered → 18 must be default-denied. If this
 	// drifts, a node kind was added: decide explicitly whether it is
 	// slice-invariant (extend sliceInvariantKinds + the registered set here)
 	// or not (it falls into the default-deny count).
-	const wantUnregistered = 26 - 9
+	//
+	// NaryVectorSetOp is deliberately default-denied: like VectorSetOp it is
+	// a set-op family node, absent from sliceInvariantKinds until its own
+	// slice-invariance proof + §Parity lanes land.
+	const wantUnregistered = 27 - 9
 	if unregisteredSeen != wantUnregistered {
 		t.Fatalf("expected %d default-denied node kinds, saw %d — a node kind was added; "+
 			"make an explicit slice-invariance decision", wantUnregistered, unregisteredSeen)

--- a/internal/chsql/emit.go
+++ b/internal/chsql/emit.go
@@ -129,6 +129,8 @@ func (e *emitter) emitNode(n chplan.Node) error {
 		return e.emitVectorJoin(v)
 	case *chplan.VectorSetOp:
 		return e.emitVectorSetOp(v)
+	case *chplan.NaryVectorSetOp:
+		return e.emitNaryVectorSetOp(v)
 	case *chplan.StructuralJoin:
 		return e.emitStructuralJoin(v)
 	case *chplan.NestedSetAnnotate:

--- a/internal/chsql/nary_vector_set_op.go
+++ b/internal/chsql/nary_vector_set_op.go
@@ -1,0 +1,223 @@
+package chsql
+
+import (
+	"fmt"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// emitNaryVectorSetOp renders the linearised N-ary form of an
+// associative PromQL vector set-op chain (`a or b or c …` /
+// `a and b and c …`) as ONE windowed single-pass over the arms'
+// UNION ALL — the true-linearisation the optimizer's FlattenVectorSetOp
+// rule unlocks.
+//
+// The binary VectorSetOp emitter already collapses a single `a or b`
+// into one windowed pass (#88), but a left-assoc chain stays nested:
+// `((a or b) or c) or d` wraps the previous windowed SELECT in another
+// windowed SELECT per level, so a K-arm chain runs K-1 stacked window
+// passes. Flattening to a single NaryVectorSetOp lets this emitter tag
+// every arm with its source position and decide survival with ONE
+// window aggregate over the unified arms — each arm is scanned exactly
+// once.
+//
+//	SELECT MetricName, Attributes, TimeUnix, Value FROM (
+//	  SELECT MetricName, Attributes, TimeUnix, Value, _setop_side,
+//	         <survival window> AS _setop_<flag>
+//	    FROM (
+//	      (SELECT <canonical arm0 cols>, 0 AS _setop_side FROM (<a>))
+//	      UNION ALL
+//	      (SELECT <canonical arm1 cols>, 1 AS _setop_side FROM (<b>))
+//	      UNION ALL … one arm per chain link, side = source position
+//	    )
+//	) WHERE <survival predicate>
+//
+// The survival shape differs by operator, but both reduce to a SINGLE
+// window aggregate partitioned by the match-key signature:
+//
+//   - `or`  — earliest-arm-wins. `_setop_min_side =
+//     min(_setop_side) OVER (PARTITION BY <sig>)` is the lowest arm
+//     index that contributed a row for the signature. A row survives
+//     iff `_setop_side = _setop_min_side`: the earliest arm's rows all
+//     pass; every later arm's rows for the same signature drop. This
+//     generalises the binary `_setop_has_left = 0` test (where the only
+//     two indices are 0 / 1) to K arms and is byte-identical to the
+//     nested left-assoc `or` result.
+//   - `and` — present-in-every-arm. `_setop_sides =
+//     groupBitOr(bitShiftLeft(1, _setop_side)) OVER (PARTITION BY
+//     <sig>)` is the bitmask of arms that contributed a row for the
+//     signature. Only arm-0 rows survive (`and` keeps the LHS values),
+//     and only when the mask is all-ones — `(1 << K) - 1` — i.e. the
+//     signature appears in EVERY arm. This matches the nested
+//     left-assoc semi-join `((a and b) and c)` exactly: a row of `a`
+//     survives iff its signature is present in `b` and in `c`.
+//
+// Each arm is canonicalised to the 4-column Sample tuple
+// (MetricName, Attributes, TimeUnix, Value) via the same per-arm
+// shape-normalisation the binary emitter uses, so positional UNION-ALL
+// column unification never hits the String-vs-Map (NO_COMMON_TYPE)
+// supertype error when an arm is a derived-shape RangeWindow /
+// Aggregate that drops `__name__`. The side marker is appended as a 5th
+// column, always last, so it never disturbs that unification. The
+// window-bearing inner SELECT projects `_setop_side` explicitly so the
+// outer WHERE can bind it (CH 24.x cannot resolve a UNION-arm alias
+// from a window-SELECT's own WHERE).
+func (e *emitter) emitNaryVectorSetOp(s *chplan.NaryVectorSetOp) error {
+	if err := e.validateNaryVectorSetOpShape(s); err != nil {
+		return err
+	}
+
+	sig := matchKeyGroupExprFrag(s.Match, s.AttributesColumn)
+	outCols := naryVectorSetOpOutputCols(s)
+
+	sideArms := make([]Frag, len(s.Arms))
+	for i, arm := range s.Arms {
+		armFrag, err := e.subqueryFrag(arm)
+		if err != nil {
+			return err
+		}
+		canonical := naryVectorSetOpCanonicalArmFrag(s, arm, armFrag)
+		sideArms[i] = naryVectorSetOpSideArmFrag(s, canonical, i)
+	}
+
+	switch s.Op {
+	case chplan.VectorSetOr:
+		// earliest-arm-wins: survive iff this row's side is the minimum
+		// side present for its signature.
+		windowed := NewQuery().
+			Select(append(
+				outCols,
+				Col(setOpSideCol),
+				As(
+					Window(Call("min", Col(setOpSideCol)), []Frag{sig}, nil),
+					narySetOpMinSideCol,
+				),
+			)...).
+			From(Paren(UnionAll(sideArms...)))
+		outer := NewQuery().
+			Select(outCols...).
+			From(windowed.Frag()).
+			Where(Eq(Col(setOpSideCol), Col(narySetOpMinSideCol)))
+		e.emitSelect(outer)
+		return nil
+	case chplan.VectorSetAnd:
+		// present-in-every-arm: keep arm-0 rows whose signature's
+		// contributing-arm bitmask is all-ones (every arm present).
+		fullMask := (int64(1) << uint(len(s.Arms))) - 1
+		windowed := NewQuery().
+			Select(append(
+				outCols,
+				Col(setOpSideCol),
+				As(
+					Window(
+						Call("groupBitOr", narySetOpSideBitFrag()),
+						[]Frag{sig},
+						nil,
+					),
+					narySetOpSidesMaskCol,
+				),
+			)...).
+			From(Paren(UnionAll(sideArms...)))
+		outer := NewQuery().
+			Select(outCols...).
+			From(windowed.Frag()).
+			Where(And(
+				Eq(Col(setOpSideCol), InlineLit(0)),
+				Eq(Col(narySetOpSidesMaskCol), InlineLit(fullMask)),
+			))
+		e.emitSelect(outer)
+		return nil
+	}
+	return fmt.Errorf("%w: n-ary vector set op %q", ErrUnsupported, s.Op)
+}
+
+// Synthetic bare-identifier column names the NaryVectorSetOp single-pass
+// emission pins, alongside setOpSideCol (shared with the binary
+// emitter). `_setop_min_side` carries the earliest contributing arm
+// index per signature for the `or` survival test; `_setop_sides_mask`
+// carries the contributing-arm bitmask for the `and` test. Neither name
+// takes user input; both match CH's bare-identifier grammar.
+const (
+	narySetOpMinSideCol   = "_setop_min_side"
+	narySetOpSidesMaskCol = "_setop_sides_mask"
+)
+
+// narySetOpSideBitFrag renders `bitShiftLeft(toUInt64(1), _setop_side)`
+// — the single-arm bit contributed to the per-signature
+// contributing-arm bitmask aggregated by `groupBitOr` for the `and`
+// survival test. toUInt64 keeps the shift width safe up to 64 arms,
+// well past any realistic chain length.
+func narySetOpSideBitFrag() Frag {
+	return Call("bitShiftLeft", Call("toUInt64", InlineLit(1)), Col(setOpSideCol))
+}
+
+// naryVectorSetOpSideArmFrag wraps an already-canonicalised arm Frag in
+// `SELECT MetricName, Attributes, TimeUnix, Value, <side> AS _setop_side
+// FROM (<arm>)` so the single-pass UNION ALL carries the source-position
+// marker as a 5th column. The marker is an inline shape constant (the
+// arm's index), not user data, so InlineLit is correct.
+func naryVectorSetOpSideArmFrag(s *chplan.NaryVectorSetOp, armFrag Frag, side int) Frag {
+	q := NewQuery().
+		Select(append(
+			naryVectorSetOpOutputCols(s),
+			As(InlineLit(side), setOpSideCol),
+		)...).
+		From(armFrag)
+	return Paren(q.Frag())
+}
+
+// naryVectorSetOpOutputCols returns the canonical 4-column Sample
+// projection (MetricName, Attributes, TimeUnix, Value) every
+// NaryVectorSetOp arm + outer SELECT pins, matching the binary
+// emitter's vectorSetOpOutputCols shape so the round-trip runner can
+// recognise the Map column.
+func naryVectorSetOpOutputCols(s *chplan.NaryVectorSetOp) []Frag {
+	return []Frag{
+		Col(s.MetricNameColumn),
+		Col(s.AttributesColumn),
+		Col(s.TimestampColumn),
+		Col(s.ValueColumn),
+	}
+}
+
+// naryVectorSetOpCanonicalArmFrag canonicalises one arm to the 4-column
+// Sample tuple, reusing the binary emitter's shape-classification logic
+// via a synthesised VectorSetOp view that carries the shared column
+// names. Derived-shape arms (RangeWindow / Aggregate / …) get their
+// missing MetricName / TimeUnix synthesised exactly as the binary path
+// does, so a flattened chain emits byte-identical arm projections to the
+// nested form it replaces.
+func naryVectorSetOpCanonicalArmFrag(s *chplan.NaryVectorSetOp, arm chplan.Node, armFrag Frag) Frag {
+	view := &chplan.VectorSetOp{
+		Op:               s.Op,
+		Match:            s.Match,
+		MetricNameColumn: s.MetricNameColumn,
+		AttributesColumn: s.AttributesColumn,
+		TimestampColumn:  s.TimestampColumn,
+		ValueColumn:      s.ValueColumn,
+	}
+	return vectorSetOpCanonicalArmFrag(view, arm, armFrag)
+}
+
+// validateNaryVectorSetOpShape rejects a NaryVectorSetOp the flatten
+// rule should never have produced: fewer than two arms, an unset
+// canonical column name, or a non-associative operator. `unless` is not
+// associative, so it must never reach the N-ary node — the flatten rule
+// only ever linearises `or` / `and` chains.
+func (e *emitter) validateNaryVectorSetOpShape(s *chplan.NaryVectorSetOp) error {
+	switch {
+	case len(s.Arms) < 2:
+		return fmt.Errorf("%w: NaryVectorSetOp needs >= 2 arms, got %d", ErrUnsupported, len(s.Arms))
+	case s.AttributesColumn == "":
+		return fmt.Errorf("%w: NaryVectorSetOp.AttributesColumn unset", ErrUnsupported)
+	case s.MetricNameColumn == "":
+		return fmt.Errorf("%w: NaryVectorSetOp.MetricNameColumn unset", ErrUnsupported)
+	case s.TimestampColumn == "":
+		return fmt.Errorf("%w: NaryVectorSetOp.TimestampColumn unset", ErrUnsupported)
+	case s.ValueColumn == "":
+		return fmt.Errorf("%w: NaryVectorSetOp.ValueColumn unset", ErrUnsupported)
+	case s.Op != chplan.VectorSetOr && s.Op != chplan.VectorSetAnd:
+		return fmt.Errorf("%w: NaryVectorSetOp op %q is not associative", ErrUnsupported, s.Op)
+	}
+	return nil
+}

--- a/internal/chsql/nary_vector_set_op_test.go
+++ b/internal/chsql/nary_vector_set_op_test.go
@@ -1,0 +1,102 @@
+package chsql_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+)
+
+func narySetOpArm(table string) chplan.Node {
+	return &chplan.Project{
+		Input: &chplan.Scan{Table: table},
+		Projections: []chplan.Projection{
+			{Expr: &chplan.ColumnRef{Name: "MetricName"}, Alias: "MetricName"},
+			{Expr: &chplan.ColumnRef{Name: "Attributes"}, Alias: "Attributes"},
+			{Expr: &chplan.ColumnRef{Name: "TimeUnix"}, Alias: "TimeUnix"},
+			{Expr: &chplan.ColumnRef{Name: "Value"}, Alias: "Value"},
+		},
+	}
+}
+
+func naryOp(op chplan.VectorSetOpKind, tables ...string) *chplan.NaryVectorSetOp {
+	arms := make([]chplan.Node, len(tables))
+	for i, tbl := range tables {
+		arms[i] = narySetOpArm(tbl)
+	}
+	return &chplan.NaryVectorSetOp{
+		Arms: arms, Op: op,
+		MetricNameColumn: "MetricName", AttributesColumn: "Attributes",
+		TimestampColumn: "TimeUnix", ValueColumn: "Value",
+	}
+}
+
+// TestEmitNaryVectorSetOp_OrThreeArms pins the `or` single-pass shape:
+// ONE UNION ALL over all three side-tagged arms, ONE min-side window
+// partitioned by the signature, and the earliest-arm-wins WHERE.
+func TestEmitNaryVectorSetOp_OrThreeArms(t *testing.T) {
+	t.Parallel()
+	sql, _, err := chsql.Emit(context.Background(), naryOp(chplan.VectorSetOr, "a", "b", "c"))
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	// Exactly two UNION ALLs join three arms into one pass (not nested).
+	if got := strings.Count(sql, "UNION ALL"); got != 2 {
+		t.Errorf("UNION ALL count = %d, want 2 (single flat 3-arm union); sql=%s", got, sql)
+	}
+	// One min-side window, one survival predicate.
+	if !strings.Contains(sql, "min(`_setop_side`) OVER (PARTITION BY `Attributes`)") {
+		t.Errorf("missing min-side window over the signature; sql=%s", sql)
+	}
+	if !strings.Contains(sql, "WHERE `_setop_side` = `_setop_min_side`") {
+		t.Errorf("missing earliest-arm-wins survival predicate; sql=%s", sql)
+	}
+	// Each arm tags a distinct side index 0/1/2.
+	for _, side := range []string{"0 AS `_setop_side`", "1 AS `_setop_side`", "2 AS `_setop_side`"} {
+		if !strings.Contains(sql, side) {
+			t.Errorf("missing side tag %q; sql=%s", side, sql)
+		}
+	}
+}
+
+// TestEmitNaryVectorSetOp_AndThreeArms pins the `and` single-pass shape:
+// ONE UNION ALL, ONE groupBitOr window, and the present-in-every-arm
+// WHERE that keeps arm-0 rows whose mask is all-ones (`(1<<3)-1 = 7`).
+func TestEmitNaryVectorSetOp_AndThreeArms(t *testing.T) {
+	t.Parallel()
+	sql, _, err := chsql.Emit(context.Background(), naryOp(chplan.VectorSetAnd, "a", "b", "c"))
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if got := strings.Count(sql, "UNION ALL"); got != 2 {
+		t.Errorf("UNION ALL count = %d, want 2; sql=%s", got, sql)
+	}
+	if !strings.Contains(sql, "groupBitOr(") || !strings.Contains(sql, "OVER (PARTITION BY `Attributes`)") {
+		t.Errorf("missing groupBitOr signature window; sql=%s", sql)
+	}
+	if !strings.Contains(sql, "`_setop_side` = 0") || !strings.Contains(sql, "`_setop_sides_mask` = 7") {
+		t.Errorf("missing present-in-every-arm survival predicate (mask 7); sql=%s", sql)
+	}
+}
+
+// TestEmitNaryVectorSetOp_RejectsUnlessOp proves `unless` can never reach
+// the N-ary emitter — it is not associative, so the validator rejects it.
+func TestEmitNaryVectorSetOp_RejectsUnlessOp(t *testing.T) {
+	t.Parallel()
+	n := naryOp(chplan.VectorSetUnless, "a", "b")
+	if _, _, err := chsql.Emit(context.Background(), n); err == nil {
+		t.Fatal("expected error emitting a non-associative `unless` N-ary node")
+	}
+}
+
+// TestEmitNaryVectorSetOp_RejectsSingleArm proves a degenerate 1-arm node
+// is rejected — the flatten rule never mints one.
+func TestEmitNaryVectorSetOp_RejectsSingleArm(t *testing.T) {
+	t.Parallel()
+	n := naryOp(chplan.VectorSetOr, "a")
+	if _, _, err := chsql.Emit(context.Background(), n); err == nil {
+		t.Fatal("expected error emitting a single-arm N-ary node")
+	}
+}

--- a/internal/optimizer/flatten_vector_set_op.go
+++ b/internal/optimizer/flatten_vector_set_op.go
@@ -1,0 +1,130 @@
+package optimizer
+
+import "github.com/tsouza/cerberus/internal/chplan"
+
+// FlattenVectorSetOp linearises a left-associative chain of the SAME
+// associative PromQL vector set-op — `a or b or c …` or
+// `a and b and c …` — into one N-ary chplan.NaryVectorSetOp.
+//
+// The PromQL parser produces a left-leaning binary tree:
+// `a or b or c or d` parses as `((a or b) or c) or d`, lowered to
+// `VectorSetOp(VectorSetOp(VectorSetOp(a, b), c), d)`. The binary chsql
+// emitter renders each nesting level as its own windowed single-pass
+// (#88), so a K-arm chain runs K-1 stacked window passes over the
+// re-accumulated left subtree. Collapsing the chain to a single
+// NaryVectorSetOp lets the emitter scan each arm exactly once under one
+// window aggregate — true linearisation.
+//
+// PARITY: the rewrite changes execution SHAPE, not results. For `or`
+// the N-ary "earliest-arm-wins" survival test is byte-identical to the
+// nested left-assoc anti-join; for `and` the "present-in-every-arm"
+// test is byte-identical to the nested semi-join. See
+// internal/chsql/nary_vector_set_op.go for the survival-shape proof.
+//
+// Only `or` / `and` are flattened — both are associative, so reordering
+// the binary nesting into one N-ary node preserves results. `unless` is
+// NOT associative (`a unless (b unless c) != (a unless b) unless c`),
+// so the rule deliberately skips it; an `unless` chain keeps its binary
+// VectorSetOp shape.
+//
+// The rule fires bottom-up to a fixpoint: the innermost `(a or b)`
+// flattens first into NaryVectorSetOp(a, b); the next level
+// `(NaryVectorSetOp(a, b) or c)` then absorbs the already-flattened left
+// child's arms into NaryVectorSetOp(a, b, c); and so on up the chain.
+// Only the LEFT child is absorbed (matching the parser's left-leaning
+// nesting) so `or`'s earliest-arm-wins ordering is preserved exactly —
+// the right operand is always a single arm in a left-assoc chain.
+//
+// Two links of a chain are mergeable only when they agree on the
+// operator, the match modifier (default / on / ignoring), and every
+// canonical Sample column name. A chain whose links disagree on any of
+// these isn't a single associative chain and is left untouched.
+type FlattenVectorSetOp struct{}
+
+func (FlattenVectorSetOp) Name() string { return "flatten-vector-set-op" }
+
+func (FlattenVectorSetOp) Apply(n chplan.Node) (chplan.Node, bool) {
+	binary, ok := n.(*chplan.VectorSetOp)
+	if !ok {
+		return n, false
+	}
+	if !flattenableVectorSetOp(binary.Op) {
+		return n, false
+	}
+
+	// Gather the left-leaning chain's arms in left-to-right source
+	// order. The left child is absorbed when it's a same-shaped binary
+	// VectorSetOp or an already-flattened NaryVectorSetOp; otherwise it
+	// is a single arm.
+	arms, absorbed := flattenLeftArms(binary)
+	if !absorbed {
+		return n, false
+	}
+	arms = append(arms, binary.Right)
+
+	return &chplan.NaryVectorSetOp{
+		Arms:             arms,
+		Op:               binary.Op,
+		Match:            binary.Match,
+		MetricNameColumn: binary.MetricNameColumn,
+		AttributesColumn: binary.AttributesColumn,
+		TimestampColumn:  binary.TimestampColumn,
+		ValueColumn:      binary.ValueColumn,
+	}, true
+}
+
+// flattenLeftArms returns the arms contributed by the left child of a
+// binary VectorSetOp, in left-to-right order, plus whether the child was
+// an absorbable same-shaped chain link. When the left child is a
+// matching binary VectorSetOp its own (recursively gathered) arms are
+// returned; when it's an already-flattened NaryVectorSetOp its arms are
+// spliced in; otherwise the left child is a single opaque arm.
+func flattenLeftArms(binary *chplan.VectorSetOp) (arms []chplan.Node, absorbed bool) {
+	switch left := binary.Left.(type) {
+	case *chplan.VectorSetOp:
+		if !sameVectorSetOpShape(binary, left.Op, left.Match,
+			left.MetricNameColumn, left.AttributesColumn,
+			left.TimestampColumn, left.ValueColumn) {
+			return []chplan.Node{binary.Left}, true
+		}
+		inner, _ := flattenLeftArms(left)
+		return append(inner, left.Right), true
+	case *chplan.NaryVectorSetOp:
+		if !sameVectorSetOpShape(binary, left.Op, left.Match,
+			left.MetricNameColumn, left.AttributesColumn,
+			left.TimestampColumn, left.ValueColumn) {
+			return []chplan.Node{binary.Left}, true
+		}
+		out := make([]chplan.Node, len(left.Arms))
+		copy(out, left.Arms)
+		return out, true
+	default:
+		return []chplan.Node{binary.Left}, true
+	}
+}
+
+// flattenableVectorSetOp reports whether op is one of the two
+// associative set-operators the flatten rule linearises. `unless` is
+// excluded because it is not associative.
+func flattenableVectorSetOp(op chplan.VectorSetOpKind) bool {
+	return op == chplan.VectorSetOr || op == chplan.VectorSetAnd
+}
+
+// sameVectorSetOpShape reports whether a candidate chain link agrees
+// with the root binary node on the operator, match modifier, and every
+// canonical Sample column name — the full set of fields the N-ary node
+// carries once for the whole chain. Two links that disagree on any of
+// these are not part of one associative chain and must not be merged.
+func sameVectorSetOpShape(
+	root *chplan.VectorSetOp,
+	op chplan.VectorSetOpKind,
+	match chplan.VectorMatch,
+	metricName, attributes, timestamp, value string,
+) bool {
+	return root.Op == op &&
+		root.Match.Equal(match) &&
+		root.MetricNameColumn == metricName &&
+		root.AttributesColumn == attributes &&
+		root.TimestampColumn == timestamp &&
+		root.ValueColumn == value
+}

--- a/internal/optimizer/flatten_vector_set_op_test.go
+++ b/internal/optimizer/flatten_vector_set_op_test.go
@@ -1,0 +1,181 @@
+package optimizer_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/optimizer"
+)
+
+// cols is the shared canonical-column setter every VectorSetOp /
+// NaryVectorSetOp in this file uses, so the flatten rule's
+// same-shape guard is satisfied across chain links.
+func setOpCols(metric, attrs, ts, val string) func(op chplan.VectorSetOpKind, l, r chplan.Node) *chplan.VectorSetOp {
+	return func(op chplan.VectorSetOpKind, l, r chplan.Node) *chplan.VectorSetOp {
+		return &chplan.VectorSetOp{
+			Left: l, Right: r, Op: op,
+			MetricNameColumn: metric, AttributesColumn: attrs,
+			TimestampColumn: ts, ValueColumn: val,
+		}
+	}
+}
+
+func tableScan(name string) *chplan.Scan { return &chplan.Scan{Table: name} }
+
+// TestFlattenVectorSetOp_OrChainOfFour linearises
+// `((a or b) or c) or d` into one NaryVectorSetOp with four arms in
+// source order.
+func TestFlattenVectorSetOp_OrChainOfFour(t *testing.T) {
+	t.Parallel()
+	mk := setOpCols("MetricName", "Attributes", "TimeUnix", "Value")
+	a, b, c, d := tableScan("a"), tableScan("b"), tableScan("c"), tableScan("d")
+	in := mk(chplan.VectorSetOr,
+		mk(chplan.VectorSetOr,
+			mk(chplan.VectorSetOr, a, b),
+			c),
+		d)
+
+	out := optimizer.New(optimizer.FlattenVectorSetOp{}).Run(context.Background(), in)
+
+	nary, ok := out.(*chplan.NaryVectorSetOp)
+	if !ok {
+		t.Fatalf("expected *NaryVectorSetOp, got %T", out)
+	}
+	if nary.Op != chplan.VectorSetOr {
+		t.Errorf("Op = %q, want or", nary.Op)
+	}
+	if len(nary.Arms) != 4 {
+		t.Fatalf("Arms = %d, want 4", len(nary.Arms))
+	}
+	want := []string{"a", "b", "c", "d"}
+	for i, arm := range nary.Arms {
+		s, ok := arm.(*chplan.Scan)
+		if !ok || s.Table != want[i] {
+			t.Errorf("arm[%d] = %#v, want Scan(%s)", i, arm, want[i])
+		}
+	}
+}
+
+// TestFlattenVectorSetOp_AndChain linearises an `and` chain the same
+// way; `and` is associative so it flattens too.
+func TestFlattenVectorSetOp_AndChain(t *testing.T) {
+	t.Parallel()
+	mk := setOpCols("MetricName", "Attributes", "TimeUnix", "Value")
+	a, b, c := tableScan("a"), tableScan("b"), tableScan("c")
+	in := mk(chplan.VectorSetAnd, mk(chplan.VectorSetAnd, a, b), c)
+
+	out := optimizer.New(optimizer.FlattenVectorSetOp{}).Run(context.Background(), in)
+
+	nary, ok := out.(*chplan.NaryVectorSetOp)
+	if !ok {
+		t.Fatalf("expected *NaryVectorSetOp, got %T", out)
+	}
+	if nary.Op != chplan.VectorSetAnd || len(nary.Arms) != 3 {
+		t.Fatalf("got op=%q arms=%d, want and/3", nary.Op, len(nary.Arms))
+	}
+}
+
+// TestFlattenVectorSetOp_UnlessNeverFlattens proves `unless` keeps its
+// binary shape — it is NOT associative, so flattening would change
+// results.
+func TestFlattenVectorSetOp_UnlessNeverFlattens(t *testing.T) {
+	t.Parallel()
+	mk := setOpCols("MetricName", "Attributes", "TimeUnix", "Value")
+	a, b, c := tableScan("a"), tableScan("b"), tableScan("c")
+	in := mk(chplan.VectorSetUnless, mk(chplan.VectorSetUnless, a, b), c)
+
+	out := optimizer.New(optimizer.FlattenVectorSetOp{}).Run(context.Background(), in)
+
+	if _, ok := out.(*chplan.NaryVectorSetOp); ok {
+		t.Fatal("unless chain must NOT flatten into NaryVectorSetOp")
+	}
+	if _, ok := out.(*chplan.VectorSetOp); !ok {
+		t.Fatalf("unless chain should stay a binary VectorSetOp, got %T", out)
+	}
+}
+
+// TestFlattenVectorSetOp_MixedOpsDoNotMerge keeps a chain whose links
+// disagree on the operator un-merged across the boundary: `(a and b) or
+// c` flattens the inner `and` and the outer `or` but never fuses the
+// two different operators into one node.
+func TestFlattenVectorSetOp_MixedOpsDoNotMerge(t *testing.T) {
+	t.Parallel()
+	mk := setOpCols("MetricName", "Attributes", "TimeUnix", "Value")
+	a, b, c := tableScan("a"), tableScan("b"), tableScan("c")
+	in := mk(chplan.VectorSetOr, mk(chplan.VectorSetAnd, a, b), c)
+
+	out := optimizer.New(optimizer.FlattenVectorSetOp{}).Run(context.Background(), in)
+
+	nary, ok := out.(*chplan.NaryVectorSetOp)
+	if !ok {
+		t.Fatalf("expected outer *NaryVectorSetOp(or), got %T", out)
+	}
+	if nary.Op != chplan.VectorSetOr || len(nary.Arms) != 2 {
+		t.Fatalf("outer got op=%q arms=%d, want or/2", nary.Op, len(nary.Arms))
+	}
+	// arm[0] is the flattened inner `and`; arm[1] is c.
+	innerAnd, ok := nary.Arms[0].(*chplan.NaryVectorSetOp)
+	if !ok || innerAnd.Op != chplan.VectorSetAnd || len(innerAnd.Arms) != 2 {
+		t.Fatalf("arm[0] should be a flattened and-node, got %#v", nary.Arms[0])
+	}
+	if s, ok := nary.Arms[1].(*chplan.Scan); !ok || s.Table != "c" {
+		t.Errorf("arm[1] = %#v, want Scan(c)", nary.Arms[1])
+	}
+}
+
+// TestFlattenVectorSetOp_DifferingMatchDoesNotMerge leaves a chain
+// whose links use different match modifiers (default vs on(job))
+// un-flattened across the mismatch — they are not one associative
+// chain.
+func TestFlattenVectorSetOp_DifferingMatchDoesNotMerge(t *testing.T) {
+	t.Parallel()
+	a, b, c := tableScan("a"), tableScan("b"), tableScan("c")
+	inner := &chplan.VectorSetOp{
+		Left: a, Right: b, Op: chplan.VectorSetOr,
+		Match:            chplan.VectorMatch{Labels: []string{"job"}, On: true},
+		MetricNameColumn: "MetricName", AttributesColumn: "Attributes",
+		TimestampColumn: "TimeUnix", ValueColumn: "Value",
+	}
+	outerNode := &chplan.VectorSetOp{
+		Left: inner, Right: c, Op: chplan.VectorSetOr,
+		Match:            chplan.VectorMatch{}, // default, differs from inner
+		MetricNameColumn: "MetricName", AttributesColumn: "Attributes",
+		TimestampColumn: "TimeUnix", ValueColumn: "Value",
+	}
+
+	out := optimizer.New(optimizer.FlattenVectorSetOp{}).Run(context.Background(), outerNode)
+
+	nary, ok := out.(*chplan.NaryVectorSetOp)
+	if !ok {
+		t.Fatalf("expected outer *NaryVectorSetOp, got %T", out)
+	}
+	// The outer default-match node has two arms: the inner on(job) chain
+	// (itself flattened) and c — they must NOT be spliced flat because the
+	// match modifiers differ.
+	if len(nary.Arms) != 2 {
+		t.Fatalf("outer arms = %d, want 2 (no cross-match splice)", len(nary.Arms))
+	}
+	if _, ok := nary.Arms[0].(*chplan.NaryVectorSetOp); !ok {
+		t.Errorf("arm[0] should be the separately-flattened on(job) chain, got %T", nary.Arms[0])
+	}
+}
+
+// TestFlattenVectorSetOp_SingleBinaryFlattensToTwoArms confirms a lone
+// `a or b` becomes a 2-arm N-ary node (the emitter handles >= 2 arms
+// uniformly, so even the degenerate binary collapses cleanly).
+func TestFlattenVectorSetOp_SingleBinaryFlattensToTwoArms(t *testing.T) {
+	t.Parallel()
+	mk := setOpCols("MetricName", "Attributes", "TimeUnix", "Value")
+	in := mk(chplan.VectorSetOr, tableScan("a"), tableScan("b"))
+
+	out := optimizer.New(optimizer.FlattenVectorSetOp{}).Run(context.Background(), in)
+
+	nary, ok := out.(*chplan.NaryVectorSetOp)
+	if !ok {
+		t.Fatalf("expected *NaryVectorSetOp, got %T", out)
+	}
+	if len(nary.Arms) != 2 {
+		t.Fatalf("Arms = %d, want 2", len(nary.Arms))
+	}
+}

--- a/internal/optimizer/rewrite_children_exhaustive_test.go
+++ b/internal/optimizer/rewrite_children_exhaustive_test.go
@@ -106,8 +106,9 @@ func allNodeCases() []nodeExhaustivenessCase {
 		//     two-child path. ---
 		{"MetricsCompare", &chplan.MetricsCompare{Inner: sentinelChild(), RootLookup: sentinelChild()}, false},
 
-		// --- multi-arm interior node ---
+		// --- multi-arm interior nodes ---
 		{"UnionAll", &chplan.UnionAll{Inputs: []chplan.Node{sentinelChild(), sentinelChild()}}, false},
+		{"NaryVectorSetOp", &chplan.NaryVectorSetOp{Arms: []chplan.Node{sentinelChild(), sentinelChild()}}, false},
 
 		// --- Left/Right binary interior nodes ---
 		{"CrossJoin", &chplan.CrossJoin{Left: sentinelChild(), Right: sentinelChild()}, false},
@@ -122,7 +123,7 @@ func allNodeCases() []nodeExhaustivenessCase {
 // implementations. Cross-checked against
 // `grep -rn 'planNode()' internal/chplan/*.go`. Bump this (and add a table
 // row + a rewriteChildren arm) when a new Node type lands.
-const expectedNodeTypeCount = 26
+const expectedNodeTypeCount = 27
 
 // TestRewriteChildren_TableCoversEveryNodeType is the count guard. If a new
 // chplan.Node type is added without a corresponding allNodeCases() row, the

--- a/internal/optimizer/rule.go
+++ b/internal/optimizer/rule.go
@@ -110,6 +110,16 @@ func NewWithBatches(batches ...Batch) *Driver {
 //     nested Projects. Only one pass changes anything in the current
 //     rule set, but the FixedPoint strategy lets additional rules join
 //     the batch without changing wiring.
+//   - "optimizer.set-op-linearize" (FixedPoint) — FlattenVectorSetOp
+//     collapses a left-assoc chain of the SAME associative vector
+//     set-op (`a or b or c …` / `a and b and c …`) into one N-ary
+//     NaryVectorSetOp so the emitter renders ONE windowed single-pass
+//     instead of one per nesting level. Runs last so the per-arm
+//     subtrees have already been rewritten (pushdown / projection)
+//     before they're frozen into N-ary arms. Iterates bottom-up: each
+//     level absorbs the already-flattened left child until the whole
+//     chain is one node. Parity-preserving — changes execution shape,
+//     not results; `unless` is skipped (not associative).
 //
 // Order matters across batches: the analyzer batch runs first
 // (must-run); the heuristic constant fold then canonicalises bool
@@ -136,6 +146,11 @@ func Default() *Driver {
 			Name:     "optimizer.projection",
 			Strategy: FixedPoint(defaultMaxIterations),
 			Rules:    []Rule{ProjectionPushdown{}},
+		},
+		Batch{
+			Name:     "optimizer.set-op-linearize",
+			Strategy: FixedPoint(defaultMaxIterations),
+			Rules:    []Rule{FlattenVectorSetOp{}},
 		},
 	)
 }
@@ -493,6 +508,25 @@ func rewriteIrregularNode(n chplan.Node, fn func(chplan.Node) (chplan.Node, bool
 		}
 		cp := *v
 		cp.Inputs = newInputs
+		return &cp, true, true
+	case *chplan.NaryVectorSetOp:
+		// Recurse into each arm so rules already applied to the binary
+		// VectorSetOp's Left / Right children keep firing once the
+		// flatten rule has linearised the chain into N arms.
+		newArms := make([]chplan.Node, len(v.Arms))
+		ch := false
+		for i, arm := range v.Arms {
+			newArm, c := fn(arm)
+			if c {
+				ch = true
+			}
+			newArms[i] = newArm
+		}
+		if !ch {
+			return v, false, true
+		}
+		cp := *v
+		cp.Arms = newArms
 		return &cp, true, true
 	case *chplan.MetricsCompare:
 		// Inner is the always-present child; RootLookup is an optional

--- a/test/perf/scaling/construct_setop_chain_test.go
+++ b/test/perf/scaling/construct_setop_chain_test.go
@@ -16,38 +16,32 @@
 //     evaluates such CTEs INLINE at every reference, so the EXECUTION fan-out
 //     survived even though the SQL text went linear. This harness caught that
 //     (filed #88).
-//   - Gen #814 (current main): replaced the per-arm CTE with a single-pass
-//     `A UNION ALL B` tagging each row `0/1 AS _setop_side`, then
+//   - Gen #814 (superseded for chains >2): replaced the per-arm CTE with a
+//     single-pass `A UNION ALL B` tagging each row `0/1 AS _setop_side`, then
 //     `max(_setop_side=0) OVER (PARTITION BY <sig>) AS _setop_has_left` and a
 //     final `WHERE _setop_side = 0 OR _setop_has_left = 0`. Each BINARY set-op
 //     now scans both arms EXACTLY ONCE — the data re-execution is gone, and the
 //     peak intermediate is now a tiny bounded constant (3 -> 5 -> 9 rows across
 //     K=2/4/8, the disjoint-arm row count, NOT a fan-out). The cardinality axis
-//     is genuinely flat.
+//     is genuinely flat. But `m0 or m1 or m2 ...` still lowered LEFT-ASSOC into
+//     K nested binary levels, each wrapping the prior level's whole relation in
+//     ANOTHER `UNION ALL` + window-partition pass, so the COMPUTE (wall) tracked
+//     K structurally (~2.6x/level) even though the intermediate stayed tiny.
+//   - Gen #90 (current main): N-ARY LINEARISATION. The optimizer's
+//     FlattenVectorSetOp rule collapses the left-assoc nested binary chain into
+//     ONE chplan.NaryVectorSetOp, and the emitter renders it as a SINGLE
+//     `UNION ALL` over all K arms with per-arm `_setop_side` tags + ONE
+//     `min(_setop_side) OVER (PARTITION BY <sig>)` window over the combined
+//     relation. The whole chain is now O(rows) in one scan — the K nested
+//     window passes are gone — so the wall axis is genuinely (sub-)linear and
+//     the quarantine is removed.
 //
 // THE REAL MULTIPLIER is the chain depth K. Param = K, swept 2 -> 4 -> 8.
 //
-// RESIDUAL FINDING (this harness, on post-#814 main): the EXECUTION wall-time
-// is STILL super-linear — measured on in-process chDB, ~2.6x PER LEVEL
-// (K=2/4/8 -> ~24ms / 71ms / 327ms, a ~13.7x blow-up over the 4x K sweep)
-// while the intermediate stays at 3 -> 9 rows. #814 made each BINARY set-op
-// single-pass, but `m0 or m1 or m2 ...` still lowers LEFT-ASSOCIATIVELY into K
-// nested binary levels, and each level wraps the prior level's whole relation
-// in ANOTHER `UNION ALL` + window-partition pass. So CH re-scans the
-// accumulated inner result at every level: each level is individually
-// single-pass and the row count stays tiny, but the COMPUTE tracks K
-// structurally. The static fan-out linter (#811) does not cover this shape (it
-// keys on cross-join / arrayJoin-into-join / uncapped-recursion /
-// correlated-subquery, not depth-of-nesting), so only this harness's chDB wall
-// sweep surfaces it.
-//
-// The true fix is N-ary linearisation (#90): flatten the left-assoc nested
-// binary chain into ONE single-pass — a single `UNION ALL` over all K arms with
-// per-arm side tags, one window partition over the combined relation — so the
-// whole chain is O(rows) in one scan instead of O(rows x K) nested passes.
-// Until #90 lands the wall axis is QUARANTINED via KnownSuperlinear (the
-// cardinality axis still hard-gates), so the harness stays green-on-main
-// without weakening the assertion — the violation is logged loudly every run.
+// Because the harness now runs the chain through the optimizer (so the flatten
+// rule fires), both axes — peak intermediate cardinality AND wall time — hard-
+// gate. The static fan-out linter (#811) does not cover depth-of-nesting, so
+// this harness's chDB sweep is the gate that proves the linearisation holds.
 package scaling
 
 import (
@@ -60,6 +54,7 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/optimizer"
 	"github.com/tsouza/cerberus/internal/promql"
 	"github.com/tsouza/cerberus/internal/schema"
 )
@@ -83,17 +78,10 @@ func init() {
 		// exponential re-materialisation regression blows straight past.
 		CardinalityBound: float64(maxK + 2),
 		SubLinearSlack:   0.9,
-		// Post-#814 the data re-execution is gone (each binary set-op is
-		// single-pass; intermediate stays 3->9 rows) but the wall is still
-		// super-linear: `m0 or m1 or ...` lowers left-assoc into K nested
-		// binary levels, each wrapping the prior relation in another
-		// UNION-ALL+window pass, so compute tracks K (~2.6x/level).
-		// Quarantine the wall axis as a documented, tracked finding (the
-		// cardinality axis below still hard-gates); see the package doc above
-		// for the full diagnosis. True fix tracked as #90 (N-ary flatten).
-		KnownSuperlinear: "set-op left-assoc K-level nesting: post-#814 each binary `or` is single-pass " +
-			"and the intermediate is bounded, but K nested levels each re-scan the accumulated inner " +
-			"relation, so wall ~2.6x/level. True fix = N-ary single-pass flatten (#90).",
+		// Post-#90 the chain flattens into ONE NaryVectorSetOp single-pass
+		// (one UNION ALL over all K arms + one window partition), so both the
+		// intermediate (3->9 rows, disjoint arms) AND the wall are (sub-)linear
+		// in K. No quarantine — both axes hard-gate. See the package doc above.
 		Seed: func() string {
 			return setOpChainSeed(maxK)
 		},
@@ -174,6 +162,11 @@ func emitSetOpChainSQL(t *testing.T, op string, k int) (string, []any) {
 	if err != nil {
 		t.Fatalf("LowerAt(%q): %v", q, err)
 	}
+	// Run the optimizer so FlattenVectorSetOp (#90) linearises the left-assoc
+	// nested binary chain into one NaryVectorSetOp single-pass — the whole
+	// point of this harness post-#90. Mirrors the prom handler's pipeline
+	// (LowerAt -> optimizer.Default().Run -> chsql.Emit).
+	plan = optimizer.Default().Run(context.Background(), plan)
 	sqlText, args, err := chsql.Emit(context.Background(), plan)
 	if err != nil {
 		t.Fatalf("Emit(%q): %v", q, err)

--- a/test/spec/chplan_print.go
+++ b/test/spec/chplan_print.go
@@ -246,6 +246,12 @@ func printNode(b *strings.Builder, n chplan.Node, depth int) {
 			indent, v.Op, printVectorMatch(v.Match))
 		printNode(b, v.Left, depth+1)
 		printNode(b, v.Right, depth+1)
+	case *chplan.NaryVectorSetOp:
+		fmt.Fprintf(b, "%sNaryVectorSetOp op=%s match=%s arms=%d\n",
+			indent, v.Op, printVectorMatch(v.Match), len(v.Arms))
+		for _, arm := range v.Arms {
+			printNode(b, arm, depth+1)
+		}
 	case *chplan.StructuralJoin:
 		fmt.Fprintf(b, "%sStructuralJoin op=%s", indent, v.Op)
 		if v.MaxDepth != 0 {


### PR DESCRIPTION
Task #90 — true linearization. A left-assoc chain of the **same associative** set-op (`a or b or c …`, `a and b and c …`) lowers to nested binary `VectorSetOp(VectorSetOp(a,b),c)`, which the emitter renders as per-level `_setop_has_left` passes. `FlattenVectorSetOp` (new optimizer rule) collapses the chain into one `chplan.NaryVectorSetOp`, and the new N-ary chsql emitter renders **one** `UNION ALL` + one `min(_setop_side)` window (`_setop_min_side`) — a single pass over each arm.

**`unless` is never flattened** (non-associative) — guarded at three levels: `flattenableVectorSetOp` (or/and only), `validateNaryVectorSetOpShape` (rejects non-associative on emit), and the `sameVectorSetOpShape` associativity check (op+match+4 cols). Unit-tested: `OrChainOfFour`, `AndChain`, `UnlessNeverFlattens`, `EmitNaryVectorSetOp_RejectsUnlessOp`.

## Verified in the *real* pipeline
The rule fires correctly in production (`engine.go` runs `optimizer.Default()`): `a or b or c` → `NaryVectorSetOp op=or arms=3` → single-pass `_setop_min_side` SQL, zero `_setop_has_left`. Parity-preserving — `expected_rows` byte-unchanged across all set-op fixtures; cardinality fan-out drops (a recorded improvement). Build + optimizer/chsql/chplan/spec/perf tests green; golangci 0 issues; go-arch-lint OK; gofumpt-extra clean.

**Note (not a gap in this PR):** the `test/spec/promql` lane is *pre-optimizer by design* (Layer 2a captures lowered SQL before `optimizer.Default()`; the optimizer's golden lane is Layer 4 `test/spec/optimizer/`), so the flatten isn't visible in the promql goldens — the rule + emitter are covered by the optimizer/chsql unit tests instead. An opt-in `-- optimize --` end-to-end golden marker is a worthwhile follow-up (task #54 territory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)