### PR TITLE
refactor(chsql): recompose remaining writeSQL escape-hatch sites via typed Frags

### DIFF
--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -1460,6 +1460,23 @@ func Subquery(s Subqueryable) Frag {
 	}
 }
 
+// Spliced returns a Frag that splices an already-rendered (sql, args)
+// pair into the stream verbatim — NO surrounding parens, unlike
+// Subquery. Used when the rendered SELECT must sit bare in a context
+// that supplies its own parens (e.g. the right-hand side of the list-
+// form In, which parenthesises its arguments): wrapping it in Subquery
+// would double-paren. The args splice at the position the Frag emits so
+// positional `?` ordering follows the SQL text. The narrow contract:
+// sql is emitter-rendered SQL (a QueryBuilder.Build() result), never
+// user input.
+func Spliced(s Subqueryable) Frag {
+	return func(b *Builder) {
+		sql, args := s.Build()
+		b.sb.WriteString(sql)
+		b.args = append(b.args, args...)
+	}
+}
+
 // PreRenderedSQL adapts an already-rendered (sql, args) pair into a
 // Subqueryable so it can flow through Subquery without raw-string
 // composition. Holds an opaque CH SQL string plus its positional args;
@@ -1649,6 +1666,23 @@ func In(left Frag, right ...Frag) Frag {
 			r(b)
 		}
 		b.sb.WriteByte(')')
+	}
+}
+
+// InSubquery returns a Frag rendering "<left> IN <sub>" — the set-
+// membership predicate where the right-hand side is a single subquery
+// Frag that already carries its own surrounding parens (e.g. a
+// traceScopeFrag's `(SELECT … )` or a QueryBuilder.Frag()). Unlike the
+// list-form In (which wraps a comma list in parens), this emits no
+// parens of its own, so a self-parenthesising subquery renders as the
+// CH-idiomatic `<left> IN (SELECT …)` with exactly one paren pair.
+// Sibling of NotInSubquery for the IN direction; used by the nested-set
+// annotate anchor's trace-id scope filter.
+func InSubquery(left, sub Frag) Frag {
+	return func(b *Builder) {
+		left(b)
+		b.sb.WriteString(" IN ")
+		sub(b)
 	}
 }
 

--- a/internal/chsql/histogram_quantile.go
+++ b/internal/chsql/histogram_quantile.go
@@ -91,12 +91,6 @@ func (e *emitter) emitHistogramQuantile(h *chplan.HistogramQuantile) error {
 func histogramQuantileValueFrag(h *chplan.HistogramQuantile) Frag {
 	bc := h.BucketCountsColumn
 	eb := h.ExplicitBoundsColumn
-	// Reusable typed Frags for the function-call shapes; closures below
-	// inline these into the if() chain. The non-Call structure (if()
-	// nesting, "[idx]" array indexing, inline phi formatFloat literal)
-	// keeps the in-package b.writeSQL path — no typed Frag covers those
-	// shapes yet.
-	//
 	// BucketCounts is Array(UInt64) in the OTel-CH schema; arraySum /
 	// arrayCumSum on it return UInt64. The downstream linear-interpolation
 	// arithmetic mixes those with Float64 ExplicitBounds and the `0.0`
@@ -105,192 +99,109 @@ func histogramQuantileValueFrag(h *chplan.HistogramQuantile) Frag {
 	// to Array(Float64) once at the entry so every sum / cumsum derives
 	// Float64 and the interpolation arithmetic stays in a single numeric
 	// domain. CSE folds the cast across the many references.
-	var bcFloat Frag = func(b *Builder) {
-		b.writeSQL("arrayMap(x -> toFloat64(x), ")
-		b.Ident(bc)
-		b.writeSQL(")")
-	}
+	bcFloat := Call("arrayMap", Lambda1("x", Call("toFloat64", BareIdent("x"))), Col(bc))
 	lengthBC := Call("length", Col(bc))
 	lengthEB := Call("length", Col(eb))
 	arraySumBC := Call("arraySum", bcFloat)
 	arrayCumSumBC := Call("arrayCumSum", bcFloat)
-	return func(b *Builder) {
-		// writePhi renders the phi parameter: computed expression when
-		// PhiExpr is set, inline literal otherwise.
-		writePhi := func() {
-			if h.PhiExpr != nil {
-				_ = b.Expr(h.PhiExpr)
-				return
-			}
-			b.writeSQL(formatFloat(h.Phi))
-		}
-		// Computed phi can be NaN at runtime; every comparison branch
-		// below evaluates false on NaN and the interpolation arithmetic
-		// would index cum[0] — guard with a leading isNaN → nan branch
-		// (Prom's bucketQuantile NaN-phi contract). The literal path
-		// skips the wrapper so existing fixtures stay byte-stable.
+
+	// phi renders the phi parameter: the computed expression when PhiExpr
+	// is set, the inline float literal (query-shape param, mirrors
+	// holtWintersValueExpr's sf / tf) otherwise. Re-invoked at each phi
+	// position so each carries its own `?` placeholder for the PhiExpr
+	// case — matching the legacy emitter's per-position re-emission.
+	phi := func() Frag {
 		if h.PhiExpr != nil {
-			b.writeSQL("if(isNaN(")
-			writePhi()
-			b.writeSQL("), nan, ")
+			return func(b *Builder) { _ = b.Expr(h.PhiExpr) }
 		}
-		// Empty histogram → NaN. arrayCumSum on an empty array is empty;
-		// `length(cum) = 0` and `total = 0`. Guard the divide-by-zero +
-		// the empty path with a single outer if() on total.
-		//
-		// We emit one binding of phi for the multiply-by-total branch;
-		// the phi-bounds short-circuits below bind it again so each
-		// branch carries its own `?` placeholder.
-		b.writeSQL("if(")
-		lengthBC(b)
-		b.writeSQL(" = 0, nan, ")
-		// total = cum[length(cum)]; cum = arrayCumSum(bc).
-		// Outer if: total = 0 → NaN. We materialise `cum` and `total`
-		// inline via subexpression rather than CTE to keep the shape flat.
-		//
-		// Structure:
-		//   if(arraySum(bc) = 0, nan,
-		//      if(phi <= 0, lowest_bound,
-		//         if(phi >= 1, highest_bound,
-		//            <interpolation>)))
-		//
-		// `lowest_bound` for OTel-CH classic histograms is 0 (the lower
-		// edge of bucket 1 is conventionally 0 for non-negative
-		// observations; matches upstream Prom's p0 behavior).
-		// `highest_bound` is the last entry in ExplicitBounds.
-		b.writeSQL("if(")
-		arraySumBC(b)
-		b.writeSQL(" = 0, nan, ")
-		b.writeSQL("if(")
-		writePhi()
-		b.writeSQL(" <= 0, 0.0, ")
-		b.writeSQL("if(")
-		writePhi()
-		b.writeSQL(" >= 1, ")
-		b.Ident(eb)
-		b.writeSQL("[")
-		lengthEB(b)
-		b.writeSQL("], ")
-		// Interpolation branch.
-		// Bind phi for the target multiplier and build the lookup.
-		// Using CH's let-like binding by re-evaluating subexprs is
-		// cheap (CH's planner CSEs) and keeps the SQL self-contained
-		// inside the if() — no CTE needed.
-		//
-		// target = phi * arraySum(bc)
-		// cum = arrayCumSum(bc)
-		// idx = arrayFirstIndex(c -> c >= target, cum)
-		// If idx = length(cum) (only the +Inf bucket crosses target),
-		//   return ExplicitBounds[length(ExplicitBounds)] (highest bound).
-		// Otherwise:
-		//   bound_lo = idx = 1 ? 0 : ExplicitBounds[idx-1]
-		//   bound_hi = ExplicitBounds[idx]
-		//   cum_lo   = idx = 1 ? 0 : cum[idx-1]
-		//   cum_hi   = cum[idx]
-		//   result   = bound_lo + (bound_hi - bound_lo) * (target - cum_lo) / (cum_hi - cum_lo)
-		//
-		// `idx` is rendered three times in the sub-expression; we
-		// recompute it each time rather than CTE-ing. CH CSE folds it.
-		// arrayFirstIndex(c -> ..., arrayCumSum(bc)) — the lambda body
-		// uses a bound var `c`; Builder.Lambda emits "(c) -> ..." which
-		// drifts vs. the existing "c -> ..." output, so the in-package
-		// b.writeSQL path is kept for the lambda. The outer
-		// arrayFirstIndex call wraps the cum frag via Call once the
-		// lambda is emitted.
-		// Computed phi: ClickHouse 24.8 rejects a scalar subquery
-		// anywhere in arrayFirstIndex's argument tree with ILLEGAL_COLUMN
-		// ("Unexpected type of filter column") — the lambda's comparison
-		// result stops being the plain UInt8 filter column the
-		// higher-order filter machinery expects (newer CH accepts it).
-		// Wrapping the predicate as `if(<cmp>, 1, 0) = 1` restores the
-		// constant-folded UInt8 the 24.8 filter path requires. The
-		// literal path keeps the bare comparison (byte-stable fixtures).
-		writeIdx := func() {
-			b.writeSQL("arrayFirstIndex(c -> ")
-			if h.PhiExpr != nil {
-				b.writeSQL("(if(")
-			}
-			b.writeSQL("c >= (")
-			writePhi()
-			b.writeSQL(" * ")
-			arraySumBC(b)
-			b.writeSQL(")")
-			if h.PhiExpr != nil {
-				b.writeSQL(", 1, 0) = 1)")
-			}
-			b.writeSQL(", ")
-			arrayCumSumBC(b)
-			b.writeSQL(")")
-		}
-		writeCumAt := func(offset string) {
-			arrayCumSumBC(b)
-			b.writeSQL("[")
-			writeIdx()
-			b.writeSQL(offset)
-			b.writeSQL("]")
-		}
-		writeBoundAt := func(offset string) {
-			b.Ident(eb)
-			b.writeSQL("[")
-			writeIdx()
-			b.writeSQL(offset)
-			b.writeSQL("]")
-		}
-		// if(idx = length(cum), highest_bound, interpolate)
-		b.writeSQL("if(")
-		writeIdx()
-		b.writeSQL(" = ")
-		Call("length", arrayCumSumBC)(b)
-		b.writeSQL(", ")
-		b.Ident(eb)
-		b.writeSQL("[")
-		lengthEB(b)
-		b.writeSQL("], ")
-		// Interpolate. bound_lo / cum_lo branch on idx = 1.
-		// bound_hi = ExplicitBounds[idx]; cum_hi = cum[idx].
-		// bound_lo = if(idx = 1, 0, ExplicitBounds[idx - 1]);
-		// cum_lo   = if(idx = 1, 0, cum[idx - 1]).
-		b.writeSQL("(if(")
-		writeIdx()
-		b.writeSQL(" = 1, 0.0, ")
-		writeBoundAt(" - 1")
-		b.writeSQL(") + (")
-		writeBoundAt("")
-		b.writeSQL(" - if(")
-		writeIdx()
-		b.writeSQL(" = 1, 0.0, ")
-		writeBoundAt(" - 1")
-		b.writeSQL(")) * ((")
-		writePhi()
-		b.writeSQL(" * ")
-		arraySumBC(b)
-		b.writeSQL(") - if(")
-		writeIdx()
-		b.writeSQL(" = 1, 0.0, ")
-		writeCumAt(" - 1")
-		b.writeSQL(")) / (")
-		writeCumAt("")
-		b.writeSQL(" - if(")
-		writeIdx()
-		b.writeSQL(" = 1, 0.0, ")
-		writeCumAt(" - 1")
-		// Three closes: close the `if(idx=1, ...)`, close the
-		// `(cum_hi - cum_lo)` paren, and close the outer `(if(idx=1, ..., bl) + ...)`
-		// expression wrapper.
-		b.writeSQL(")))")
-		// Close the if(idx = length(cum), highest, <interp>)
-		b.writeSQL(")")
-		// Close the if(phi >= 1, …, interpolation)
-		b.writeSQL(")")
-		// Close the if(phi <= 0, 0.0, …)
-		b.writeSQL(")")
-		// Close the if(arraySum = 0, nan, …)
-		b.writeSQL(")")
-		// Close the if(length(bc) = 0, nan, …)
-		b.writeSQL(")")
-		// Close the computed-phi `if(isNaN(phi), nan, …)` wrapper.
-		if h.PhiExpr != nil {
-			b.writeSQL(")")
-		}
+		return InlineLit(h.Phi)
 	}
+	// `nan` / `0.0` are CH-portable shape tokens, not data: InlineLit
+	// would render `nan` as the quoted string `'nan'` and `0.0` as the
+	// canonicalised `0`, so they ride verbatim (the same posture as
+	// IfNonZero's `0.0` fallback in builder.go).
+	nan := verbatim("nan")
+	zeroF := verbatim("0.0")
+	highestBound := Subscript(Col(eb), lengthEB) // ExplicitBounds[length(ExplicitBounds)]
+	target := Paren(Mul(phi(), arraySumBC))      // (phi * arraySum(bc))
+
+	// idx = arrayFirstIndex(c -> c >= target, cum). Computed phi:
+	// ClickHouse 24.8 rejects a scalar subquery anywhere in
+	// arrayFirstIndex's argument tree with ILLEGAL_COLUMN ("Unexpected
+	// type of filter column") — the lambda's comparison result stops
+	// being the plain UInt8 filter column the higher-order filter
+	// machinery expects (newer CH accepts it). Wrapping the predicate as
+	// `(if(<cmp>, 1, 0) = 1)` restores the constant-folded UInt8 the 24.8
+	// filter path requires. The literal path keeps the bare comparison
+	// (byte-stable fixtures). idx is re-evaluated at each use site rather
+	// than CTE- d; CH's CSE folds it.
+	idx := func() Frag {
+		cmp := Gte(BareIdent("c"), target)
+		pred := cmp
+		if h.PhiExpr != nil {
+			pred = Paren(Eq(If(cmp, InlineLit(1), InlineLit(0)), InlineLit(1)))
+		}
+		return Call("arrayFirstIndex", Lambda1("c", pred), arrayCumSumBC)
+	}
+	// idxAtOffset renders `<idx>` or `<idx> - 1` (the `idx - 1` lower-edge
+	// lookups). offsetMinusOne selects the `- 1` form.
+	idxAtOffset := func(offsetMinusOne bool) Frag {
+		if offsetMinusOne {
+			return Sub(idx(), InlineLit(1))
+		}
+		return idx()
+	}
+	cumAt := func(offsetMinusOne bool) Frag {
+		return Subscript(arrayCumSumBC, idxAtOffset(offsetMinusOne))
+	}
+	boundAt := func(offsetMinusOne bool) Frag {
+		return Subscript(Col(eb), idxAtOffset(offsetMinusOne))
+	}
+	// Lower-edge selectors branch on idx = 1 → 0.0, else the [idx-1]
+	// lookup. bound_lo / cum_lo per the interpolation below.
+	boundLo := If(Eq(idx(), InlineLit(1)), zeroF, boundAt(true))
+	cumLo := If(Eq(idx(), InlineLit(1)), zeroF, cumAt(true))
+
+	// Interpolation:
+	//   bound_lo + (bound_hi - bound_lo) * (target - cum_lo) / (cum_hi - cum_lo)
+	// bound_hi = ExplicitBounds[idx]; cum_hi = cum[idx]; target = phi *
+	// arraySum(bc). The grouping parens match the legacy emitter exactly:
+	//   (bound_lo + (bound_hi - bound_lo) * ((target) - cum_lo) / (cum_hi - cum_lo))
+	interp := Paren(
+		Add(
+			boundLo,
+			Div(
+				Mul(
+					Paren(Sub(boundAt(false), boundLo)),
+					Paren(Sub(target, cumLo)),
+				),
+				Paren(Sub(cumAt(false), cumLo)),
+			),
+		),
+	)
+
+	// if(idx = length(cum), highest_bound, <interp>) — the +Inf bucket
+	// (only the trailing bucket crosses target) returns the highest
+	// explicit bound.
+	idxBranch := If(Eq(idx(), Call("length", arrayCumSumBC)), highestBound, interp)
+
+	// Nested edge-case chain, outermost first:
+	//   if(length(bc) = 0, nan,
+	//      if(arraySum(bc) = 0, nan,
+	//         if(phi <= 0, 0.0,
+	//            if(phi >= 1, highest_bound, idxBranch))))
+	core := If(Eq(lengthBC, InlineLit(0)), nan,
+		If(Eq(arraySumBC, InlineLit(0)), nan,
+			If(Lte(phi(), InlineLit(0)), zeroF,
+				If(Gte(phi(), InlineLit(1)), highestBound, idxBranch))))
+
+	if h.PhiExpr == nil {
+		return core
+	}
+	// Computed phi can be NaN at runtime; every comparison branch above
+	// evaluates false on NaN and the interpolation would index cum[0] —
+	// guard with a leading isNaN → nan branch (Prom's bucketQuantile
+	// NaN-phi contract). The literal path skips the wrapper so existing
+	// fixtures stay byte-stable.
+	return If(Call("isNaN", phi()), nan, core)
 }

--- a/internal/chsql/histogram_quantile_native.go
+++ b/internal/chsql/histogram_quantile_native.go
@@ -129,139 +129,101 @@ func histogramQuantileNativeValueFrag(h *chplan.HistogramQuantileNative) Frag {
 	po := h.PositiveOffsetColumn
 	no := h.NegativeOffsetColumn
 	zc := h.ZeroCountColumn
+	w := newHQNativeWriters(h)
 
-	return func(b *Builder) {
-		w := newHQNativeWriters(h, b)
+	// `nan` is a CH-portable shape token, not data — InlineLit would
+	// quote it. `0.0` similarly can't ride InlineLit (FormatFloat
+	// canonicalises it to `0`). Both ride verbatim (the IfNonZero
+	// precedent in builder.go).
+	nan := verbatim("nan")
+	zeroF := verbatim("0.0")
 
-		// Outer chain:
-		//   if(total = 0, nan,
-		//     if(phi <= 0, <smallest-bucket lower edge>,
-		//       if(phi >= 1, <largest-bucket upper edge>,
-		//         if(idx <= nlen, <negative interp>,
-		//           if(idx = nlen + 1, <zero interp>,
-		//             <positive interp>)))))
+	// phi <= 0 → smallest-bucket lower edge:
+	//   if(nlen > 0, -pow(base, no + nlen), 0.0)
+	phiLow := If(
+		Gt(w.nLen(), InlineLit(0)),
+		Neg(Call("pow", w.base(), Add(Col(no), w.nLen()))),
+		zeroF,
+	)
+	// phi >= 1 → largest-bucket upper edge:
+	//   if(plen > 0, pow(base, po + plen),
+	//      if(zc > 0, zt, -pow(base, no)))
+	phiHigh := If(
+		Gt(w.pLen(), InlineLit(0)),
+		Call("pow", w.base(), Add(Col(po), w.pLen())),
+		If(
+			Gt(Col(zc), InlineLit(0)),
+			w.zt(),
+			Neg(Call("pow", w.base(), Col(no))),
+		),
+	)
+	// Negative bucket interp (idx <= nlen):
+	//   -pow(base, no + (nlen - idx) + 1 - fraction)
+	negInterp := Neg(Call(
+		"pow",
+		w.base(),
+		Sub(
+			Add(Add(Col(no), Paren(Sub(w.nLen(), w.idx()))), InlineLit(1)),
+			w.fraction(),
+		),
+	))
+	// Zero bucket interp (idx = nlen + 1):
+	//   -ZeroThreshold + 2 * ZeroThreshold * fraction
+	zeroInterp := Add(Neg(w.zt()), Mul(Mul(InlineLit(2), w.zt()), w.fraction()))
+	// Positive bucket interp (idx > nlen + 1):
+	//   pow(base, po + (idx - nlen - 2) + fraction)
+	posInterp := Call(
+		"pow",
+		w.base(),
+		Add(
+			Add(Col(po), Paren(Sub(Sub(w.idx(), w.nLen()), InlineLit(2)))),
+			w.fraction(),
+		),
+	)
 
-		// Computed phi can be NaN at runtime (PromQL `scalar()` over
-		// zero / many series); every comparison branch below evaluates
-		// false on NaN and the interpolation would walk cum[0] — guard
-		// with a leading isNaN → nan branch (Prom's bucketQuantile
-		// NaN-phi contract). The literal path skips the wrapper so
-		// existing fixtures stay byte-stable.
-		if h.PhiExpr != nil {
-			b.writeSQL("if(isNaN(")
-			w.phi()
-			b.writeSQL("), nan, ")
-		}
-		// if(total = 0, nan, ...
-		b.writeSQL("if(")
-		w.total()
-		b.writeSQL(" = 0, nan, ")
-		// if(phi <= 0, if(nlen > 0, -pow(base, no + nlen), 0.0), ...
-		b.writeSQL("if(")
-		w.phi()
-		b.writeSQL(" <= 0, if(")
-		w.nLen()
-		b.writeSQL(" > 0, -pow(")
-		w.base()
-		b.writeSQL(", ")
-		b.Ident(no)
-		b.writeSQL(" + ")
-		w.nLen()
-		b.writeSQL("), 0.0), ")
-		// if(phi >= 1, <upper edge>, ...
-		// upper edge:
-		//   if(plen > 0, pow(base, po + plen),
-		//      if(zc > 0, zt, -pow(base, no)))
-		b.writeSQL("if(")
-		w.phi()
-		b.writeSQL(" >= 1, if(")
-		w.pLen()
-		b.writeSQL(" > 0, pow(")
-		w.base()
-		b.writeSQL(", ")
-		b.Ident(po)
-		b.writeSQL(" + ")
-		w.pLen()
-		b.writeSQL("), if(")
-		b.Ident(zc)
-		b.writeSQL(" > 0, ")
-		w.zt()
-		b.writeSQL(", -pow(")
-		w.base()
-		b.writeSQL(", ")
-		b.Ident(no)
-		b.writeSQL("))), ")
-		// if(idx <= nlen, <negative interp>, ...
-		// negative interp:
-		//   -pow(base, no + (nlen - idx) + 1 - fraction)
-		b.writeSQL("if(")
-		w.idx()
-		b.writeSQL(" <= ")
-		w.nLen()
-		b.writeSQL(", -pow(")
-		w.base()
-		b.writeSQL(", ")
-		b.Ident(no)
-		b.writeSQL(" + (")
-		w.nLen()
-		b.writeSQL(" - ")
-		w.idx()
-		b.writeSQL(") + 1 - ")
-		w.fraction()
-		b.writeSQL("), ")
-		// if(idx = nlen + 1, <zero interp>, <positive interp>)
-		// zero interp:
-		//   -ZeroThreshold + 2 * ZeroThreshold * fraction
-		// positive interp:
-		//   pow(base, po + (idx - nlen - 2) + fraction)
-		b.writeSQL("if(")
-		w.idx()
-		b.writeSQL(" = ")
-		w.nLen()
-		b.writeSQL(" + 1, -")
-		w.zt()
-		b.writeSQL(" + 2 * ")
-		w.zt()
-		b.writeSQL(" * ")
-		w.fraction()
-		b.writeSQL(", pow(")
-		w.base()
-		b.writeSQL(", ")
-		b.Ident(po)
-		b.writeSQL(" + (")
-		w.idx()
-		b.writeSQL(" - ")
-		w.nLen()
-		b.writeSQL(" - 2) + ")
-		w.fraction()
-		b.writeSQL("))")
-		// Close: if(idx=nlen+1), if(idx<=nlen), if(phi>=1), if(phi<=0), if(total=0)
-		b.writeSQL("))))")
-		// Close the computed-phi `if(isNaN(phi), nan, …)` wrapper.
-		if h.PhiExpr != nil {
-			b.writeSQL(")")
-		}
+	// Outer chain:
+	//   if(total = 0, nan,
+	//     if(phi <= 0, phiLow,
+	//       if(phi >= 1, phiHigh,
+	//         if(idx <= nlen, negInterp,
+	//           if(idx = nlen + 1, zeroInterp, posInterp)))))
+	core := If(Eq(w.total(), InlineLit(0)), nan,
+		If(Lte(w.phi(), InlineLit(0)), phiLow,
+			If(Gte(w.phi(), InlineLit(1)), phiHigh,
+				If(Lte(w.idx(), w.nLen()), negInterp,
+					If(Eq(w.idx(), Add(w.nLen(), InlineLit(1))), zeroInterp, posInterp)))))
+
+	if h.PhiExpr == nil {
+		return core
 	}
+	// Computed phi can be NaN at runtime (PromQL `scalar()` over zero /
+	// many series); every comparison branch evaluates false on NaN and
+	// the interpolation would walk cum[0] — guard with a leading isNaN →
+	// nan branch (Prom's bucketQuantile NaN-phi contract). The literal
+	// path skips the wrapper so existing fixtures stay byte-stable.
+	return If(Call("isNaN", w.phi()), nan, core)
 }
 
-// hqNativeWriters bundles the per-row SQL sub-expression writers the
-// native quantile value fragment composes, bound to one Builder
-// invocation. Extracted from histogramQuantileNativeValueFrag so the
-// fragment body stays focused on the if() chain layout.
+// hqNativeWriters bundles the per-row sub-expression Frag builders the
+// native quantile value fragment composes. Each field is a closure
+// returning a fresh Frag so a sub-expression re-rendered at multiple
+// positions (base / total / idx / fraction — all CSE-folded by CH)
+// re-emits its own `?` placeholders, matching the legacy emitter's
+// per-position re-emission.
 type hqNativeWriters struct {
-	phi      func()
-	base     func()
-	cum      func()
-	total    func()
-	idx      func()
-	cumAt    func(offset string)
-	nLen     func()
-	pLen     func()
-	zt       func()
-	fraction func()
+	phi      func() Frag
+	base     func() Frag
+	cum      func() Frag
+	total    func() Frag
+	idx      func() Frag
+	cumAt    func(offsetMinusOne bool) Frag
+	nLen     func() Frag
+	pLen     func() Frag
+	zt       func() Frag
+	fraction func() Frag
 }
 
-func newHQNativeWriters(h *chplan.HistogramQuantileNative, b *Builder) hqNativeWriters {
+func newHQNativeWriters(h *chplan.HistogramQuantileNative) hqNativeWriters {
 	pbc := h.PositiveBucketCountsColumn
 	nbc := h.NegativeBucketCountsColumn
 	scale := h.ScaleColumn
@@ -269,126 +231,80 @@ func newHQNativeWriters(h *chplan.HistogramQuantileNative, b *Builder) hqNativeW
 	zt := h.ZeroThresholdColumn
 	var w hqNativeWriters
 
-	// phi renders the parameter: the computed expression when PhiExpr
-	// is set (typically a scalar subquery — CH folds it as a
-	// constant), the inline literal otherwise.
-	w.phi = func() {
+	// phi: the computed expression when PhiExpr is set (typically a
+	// scalar subquery — CH folds it as a constant), the inline literal
+	// (InlineLit float == formatFloat) otherwise.
+	w.phi = func() Frag {
 		if h.PhiExpr != nil {
-			_ = b.Expr(h.PhiExpr)
-			return
+			return func(b *Builder) { _ = b.Expr(h.PhiExpr) }
 		}
-		b.writeSQL(formatFloat(h.Phi))
+		return InlineLit(h.Phi)
 	}
-	// base = pow(2, pow(2, -Scale)). Re-rendered inline at each
-	// use; CH's planner CSEs. Inline literal `2` and array-literal
-	// `[col]` have no typed Frag (no inline-int / array-literal
-	// helpers), so the in-package b.writeSQL path is kept for the
-	// shape's outer layout; the inner pow/arrayCumSum/arrayReverse
-	// function shells use typed Call where they would otherwise
-	// duplicate "fn(" + ... + ")" string fragments.
-	w.base = func() {
-		b.writeSQL("pow(2, pow(2, -")
-		b.Ident(scale)
-		b.writeSQL("))")
+	// base = pow(2, pow(2, -Scale)). Higher scale = finer buckets.
+	w.base = func() Frag {
+		return Call("pow", InlineLit(2), Call("pow", InlineLit(2), Neg(Col(scale))))
 	}
 	// cum = arrayCumSum(arrayConcat(
 	//         arrayReverse(NegativeBucketCounts),
 	//         [ZeroCount],
 	//         PositiveBucketCounts)).
-	// arrayReverse on an empty array yields [], so the walk
-	// collapses to the Phase 1 shape when NegativeBucketCounts
-	// is empty.
-	cumBody := func(b *Builder) {
-		b.writeSQL("arrayConcat(")
-		Call("arrayReverse", Col(nbc))(b)
-		b.writeSQL(", [")
-		b.Ident(zc)
-		b.writeSQL("], ")
-		b.Ident(pbc)
-		b.writeSQL(")")
-	}
-	w.cum = func() {
-		Call("arrayCumSum", cumBody)(b)
+	// arrayReverse on an empty array yields [], so the walk collapses to
+	// the Phase 1 shape when NegativeBucketCounts is empty.
+	w.cum = func() Frag {
+		return Call(
+			"arrayCumSum",
+			Call("arrayConcat", Call("arrayReverse", Col(nbc)), Array(Col(zc)), Col(pbc)),
+		)
 	}
 	// total = cum[length(cum)] — last element of cum.
-	w.total = func() {
-		w.cum()
-		b.writeSQL("[")
-		Call("length", func(b *Builder) { w.cum() })(b)
-		b.writeSQL("]")
+	w.total = func() Frag {
+		return Subscript(w.cum(), Call("length", w.cum()))
 	}
-	// idx = arrayFirstIndex(c -> c >= phi*total, cum).
-	// Lambda body uses bound var `c`; Builder.Lambda emits "(c) ->"
-	// which drifts vs. "c ->" output, so the in-package writeSQL
-	// path is kept here.
-	// Computed phi: wrap the lambda predicate as `if(<cmp>, 1, 0) = 1`
-	// — CH 24.8 rejects a scalar subquery anywhere in
-	// arrayFirstIndex's argument tree with ILLEGAL_COLUMN (see the
-	// classic emitter's writeIdx for the full rationale). The
-	// literal path keeps the bare comparison (byte-stable fixtures).
-	w.idx = func() {
-		b.writeSQL("arrayFirstIndex(c -> ")
+	// idx = arrayFirstIndex(c -> c >= phi*total, cum). Computed phi:
+	// wrap the lambda predicate as `(if(<cmp>, 1, 0) = 1)` — CH 24.8
+	// rejects a scalar subquery anywhere in arrayFirstIndex's argument
+	// tree with ILLEGAL_COLUMN (see the classic emitter for the full
+	// rationale). The literal path keeps the bare comparison
+	// (byte-stable fixtures).
+	w.idx = func() Frag {
+		cmp := Gte(BareIdent("c"), Paren(Mul(w.phi(), w.total())))
+		pred := cmp
 		if h.PhiExpr != nil {
-			b.writeSQL("(if(")
+			pred = Paren(Eq(If(cmp, InlineLit(1), InlineLit(0)), InlineLit(1)))
 		}
-		b.writeSQL("c >= (")
-		w.phi()
-		b.writeSQL(" * ")
-		w.total()
-		b.writeSQL(")")
-		if h.PhiExpr != nil {
-			b.writeSQL(", 1, 0) = 1)")
+		return Call("arrayFirstIndex", Lambda1("c", pred), w.cum())
+	}
+	// cum[idx] (offsetMinusOne=false) / cum[idx - 1] (true). idx=1 with
+	// the `- 1` form indexes cum[0], which CH evaluates to the array
+	// element's default (0) — matches the "no bucket consumed yet"
+	// semantics the fraction formula needs.
+	w.cumAt = func(offsetMinusOne bool) Frag {
+		key := w.idx()
+		if offsetMinusOne {
+			key = Sub(w.idx(), InlineLit(1))
 		}
-		b.writeSQL(", ")
-		w.cum()
-		b.writeSQL(")")
+		return Subscript(w.cum(), key)
 	}
-	// cum[idx + offset]. offset is a string fragment like " - 1"
-	// or "" — caller-supplied so the same helper covers cum[idx]
-	// (offset="") and cum[idx-1] (offset=" - 1"). idx=1 with
-	// offset=" - 1" indexes cum[0], which CH evaluates to the
-	// array element's default (0) — matches the
-	// "no bucket consumed yet" semantics the fraction formula
-	// needs.
-	w.cumAt = func(offset string) {
-		w.cum()
-		b.writeSQL("[")
-		w.idx()
-		b.writeSQL(offset)
-		b.writeSQL("]")
-	}
-	w.nLen = func() {
-		Call("length", Col(nbc))(b)
-	}
-	w.pLen = func() {
-		Call("length", Col(pbc))(b)
-	}
-	// Zero-bucket upper edge. With a configured ZeroThreshold
-	// column the edge is the stored per-row value; an empty
-	// column name means the physical schema doesn't persist the
-	// OTLP zero_threshold (the upstream OTel-CH DDL doesn't) and
-	// the zero bucket collapses to a point at 0.
-	w.zt = func() {
+	w.nLen = func() Frag { return Call("length", Col(nbc)) }
+	w.pLen = func() Frag { return Call("length", Col(pbc)) }
+	// Zero-bucket upper edge. With a configured ZeroThreshold column the
+	// edge is the stored per-row value; an empty column name means the
+	// physical schema doesn't persist the OTLP zero_threshold (the
+	// upstream OTel-CH DDL doesn't) and the zero bucket collapses to a
+	// point at 0 — emitted as the CH-portable shape token `0.`.
+	w.zt = func() Frag {
 		if zt == "" {
-			b.writeSQL("0.")
-			return
+			return verbatim("0.")
 		}
-		b.Ident(zt)
+		return Col(zt)
 	}
-	// fraction = (target - cum[idx-1]) / (cum[idx] - cum[idx-1]).
+	// fraction = (target - cum[idx-1]) / (cum[idx] - cum[idx-1]),
 	// target = phi * total.
-	w.fraction = func() {
-		b.writeSQL("((")
-		w.phi()
-		b.writeSQL(" * ")
-		w.total()
-		b.writeSQL(") - ")
-		w.cumAt(" - 1")
-		b.writeSQL(") / (")
-		w.cumAt("")
-		b.writeSQL(" - ")
-		w.cumAt(" - 1")
-		b.writeSQL(")")
+	w.fraction = func() Frag {
+		return Div(
+			Paren(Sub(Paren(Mul(w.phi(), w.total())), w.cumAt(true))),
+			Paren(Sub(w.cumAt(false), w.cumAt(true))),
+		)
 	}
 
 	return w

--- a/internal/chsql/nested_set_annotate.go
+++ b/internal/chsql/nested_set_annotate.go
@@ -7,13 +7,17 @@ import (
 	"github.com/tsouza/cerberus/internal/chplan"
 )
 
-// nestedSetPathElemWidth is the byte width of one DFS-path element:
-// 20 zero-padded decimal digits of the span's start timestamp in
-// nanoseconds + 20 zero-padded decimal digits of sipHash64(SpanId).
-// Fixed-width elements make plain string comparison of concatenated
-// paths equivalent to lexicographic tuple comparison, and
-// length(path) / width recovers the span's depth.
-const nestedSetPathElemWidth = 40
+// nestedSetPathElemHalf is the zero-padded decimal width of each half of
+// a DFS-path element: 20 digits of the span's start timestamp in
+// nanoseconds, and 20 digits of sipHash64(SpanId).
+const nestedSetPathElemHalf = 20
+
+// nestedSetPathElemWidth is the byte width of one DFS-path element: the
+// two nestedSetPathElemHalf halves concatenated. Fixed-width elements
+// make plain string comparison of concatenated paths equivalent to
+// lexicographic tuple comparison, and length(path) / width recovers the
+// span's depth.
+const nestedSetPathElemWidth = 2 * nestedSetPathElemHalf
 
 // emitNestedSetAnnotate renders a chplan.NestedSetAnnotate: the input
 // rows LEFT JOINed against a per-trace nested-set numbering computed
@@ -125,18 +129,15 @@ func (e *emitter) emitNestedSetAnnotate(n *chplan.NestedSetAnnotate) error {
 	numbering := buildNestedSetNumbering(n, scope)
 
 	aliasedNS := func(nsCol, outCol string) Frag {
-		return func(b *Builder) {
-			b.writeSQL("ifNull(")
-			b.QualIdent("ns", nsCol)
-			b.writeSQL(", 0) AS ")
-			b.Ident(outCol)
-		}
+		// The `ns` qualifier is backtick-quoted (Qual/QualIdent), matching
+		// the legacy emitter; the bare-qualifier qualColFrag is only for
+		// the L / R / m single-letter aliases elsewhere.
+		return As(Call("ifNull", Qual("ns", nsCol), InlineLit(0)), outCol)
 	}
-	onClause := func(b *Builder) {
-		spanIDPairFrag("m", n.TraceIDColumn, "ns", n.TraceIDColumn)(b)
-		b.writeSQL(" AND ")
-		spanIDPairFrag("m", n.SpanIDColumn, "ns", n.SpanIDColumn)(b)
-	}
+	onClause := And(
+		spanIDPairFrag("m", n.TraceIDColumn, "ns", n.TraceIDColumn),
+		spanIDPairFrag("m", n.SpanIDColumn, "ns", n.SpanIDColumn),
+	)
 
 	sb := NewQuery().
 		Select(
@@ -160,13 +161,17 @@ func buildNestedSetNumbering(n *chplan.NestedSetAnnotate, scope Frag) *QueryBuil
 	// One fixed-width path element for the span row `qual` qualifies
 	// (empty qual = bare column references in the anchor SELECT).
 	pathElem := func(qual string) Frag {
-		return func(b *Builder) {
-			b.writeSQL("concat(leftPad(toString(toUnixTimestamp64Nano(")
-			writeOptQualCol(b, qual, n.TimestampColumn)
-			b.writeSQL(")), 20, '0'), leftPad(toString(sipHash64(")
-			writeOptQualCol(b, qual, n.SpanIDColumn)
-			b.writeSQL(")), 20, '0'))")
+		// One fixed-width element = zero-padded ns-timestamp ++
+		// zero-padded sipHash64(SpanId). Each half is nestedSetPathElemHalf
+		// digits; the two halves concatenate to nestedSetPathElemWidth.
+		padded := func(inner Frag) Frag {
+			return Call("leftPad", Call("toString", inner), InlineLit(nestedSetPathElemHalf), InlineLit("0"))
 		}
+		return Call(
+			"concat",
+			padded(Call("toUnixTimestamp64Nano", optQualColFrag(qual, n.TimestampColumn))),
+			padded(Call("sipHash64", optQualColFrag(qual, n.SpanIDColumn))),
+		)
 	}
 
 	// Anchor: the root spans (ParentSpanId = '') of every trace the
@@ -186,13 +191,12 @@ func buildNestedSetNumbering(n *chplan.NestedSetAnnotate, scope Frag) *QueryBuil
 			verbatim("0 AS `_depth`"),
 		).
 		From(Col(n.SpansTable)).
-		Where(func(b *Builder) {
-			b.Ident(n.ParentSpanIDColumn)
-			b.writeSQL(" = '' AND ")
-			b.Ident(n.TraceIDColumn)
-			b.writeSQL(" IN ")
-			scope(b)
-		})
+		Where(
+			Eq(Col(n.ParentSpanIDColumn), InlineLit("")),
+			// scope already carries its own parens; InSubquery adds none,
+			// giving `<TraceId> IN (SELECT …)` with a single paren pair.
+			InSubquery(Col(n.TraceIDColumn), scope),
+		)
 
 	// Recursive step: append one path element per child level and carry
 	// `_depth + 1`. The `c._depth < <cap>` bound (shared with the
@@ -209,24 +213,20 @@ func buildNestedSetNumbering(n *chplan.NestedSetAnnotate, scope Frag) *QueryBuil
 			qualColFrag("t", n.TraceIDColumn),
 			qualColFrag("t", n.SpanIDColumn),
 			qualColFrag("t", n.ParentSpanIDColumn),
-			func(b *Builder) {
-				b.writeSQL("concat(c.`_path`, ")
-				pathElem("t")(b)
-				b.writeSQL(")")
-			},
+			// `c.\`_path\`` is the recursive CTE's synthetic path column,
+			// referenced bare-qualified (alias `c`, backtick-quoted
+			// `_path`) — emitter-pinned, so verbatim; concat composes.
+			Call("concat", verbatim("c.`_path`"), pathElem("t")),
 			verbatim("c.`_depth` + 1 AS `_depth`"),
 		).
 		From(aliasedFrag(Col(n.SpansTable), "t")).
 		Join(
 			InnerJoin,
 			aliasedFrag(verbatim("`_cerberus_ns_paths`"), "c"),
-			func(b *Builder) {
-				spanIDPairFrag("t", n.TraceIDColumn, "c", n.TraceIDColumn)(b)
-				b.writeSQL(" AND ")
-				writeSideCol(b, "t", n.ParentSpanIDColumn)
-				b.writeSQL(" = ")
-				writeSideCol(b, "c", n.SpanIDColumn)
-			},
+			And(
+				spanIDPairFrag("t", n.TraceIDColumn, "c", n.TraceIDColumn),
+				Eq(qualColFrag("t", n.ParentSpanIDColumn), qualColFrag("c", n.SpanIDColumn)),
+			),
 		).
 		Where(structuralDepthBoundFrag(0))
 
@@ -359,13 +359,8 @@ func (e *emitter) traceScopeFrag(n chplan.Node, traceIDCol string) (Frag, error)
 	if err != nil {
 		return nil, err
 	}
-	return func(b *Builder) {
-		b.writeSQL("(SELECT ")
-		b.Ident(traceIDCol)
-		b.writeSQL(" FROM ")
-		sub(b)
-		b.writeSQL(")")
-	}, nil
+	// `(SELECT <traceIDCol> FROM <sub>)` — the leaf-scope exact form.
+	return NewQuery().Select(Col(traceIDCol)).From(sub).Frag(), nil
 }
 
 // unionTraceScopeFrag renders `(<scope(left)> UNION ALL <scope(right)>)`
@@ -379,13 +374,7 @@ func (e *emitter) unionTraceScopeFrag(left, right chplan.Node, traceIDCol string
 	if err != nil {
 		return nil, err
 	}
-	return func(b *Builder) {
-		b.writeSQL("(")
-		l(b)
-		b.writeSQL(" UNION ALL ")
-		r(b)
-		b.writeSQL(")")
-	}, nil
+	return Paren(UnionAll(l, r)), nil
 }
 
 // projectsBareColumn reports whether p projects col through unchanged:
@@ -412,6 +401,16 @@ func writeOptQualCol(b *Builder, qual, col string) {
 		return
 	}
 	b.QualIdent(qual, col)
+}
+
+// optQualColFrag is the Frag form of writeOptQualCol: `<qual>.<col>`
+// (both backtick-quoted) when qual is non-empty, bare backtick-quoted
+// `<col>` otherwise.
+func optQualColFrag(qual, col string) Frag {
+	if qual == "" {
+		return Col(col)
+	}
+	return Qual(qual, col)
 }
 
 // quoteIdent backtick-quotes a column name for use inside verbatim

--- a/internal/chsql/set_op.go
+++ b/internal/chsql/set_op.go
@@ -40,15 +40,10 @@ func (e *emitter) emitSetOperation(s *chplan.SetOperation) error {
 		//   ON L.TraceId = R.TraceId AND L.SpanId = R.SpanId
 		traceID := s.TraceIDColumn
 		spanID := s.SpanIDColumn
-		on := func(b *Builder) {
-			b.QualIdent("L", traceID)
-			b.writeSQL(" = ")
-			b.QualIdent("R", traceID)
-			b.writeSQL(" AND ")
-			b.QualIdent("L", spanID)
-			b.writeSQL(" = ")
-			b.QualIdent("R", spanID)
-		}
+		on := And(
+			Eq(Qual("L", traceID), Qual("R", traceID)),
+			Eq(Qual("L", spanID), Qual("R", spanID)),
+		)
 		sb := NewQuery().
 			Select(verbatim("L.*")).
 			From(As(leftFrag, "L")).

--- a/internal/chsql/structural_join.go
+++ b/internal/chsql/structural_join.go
@@ -242,43 +242,49 @@ func (e *emitter) emitStructuralSiblingJoin(j *chplan.StructuralJoin) error {
 	rightProj := structuralProjectionFrags(j, "R")
 	leftProj := structuralProjectionFrags(j, "L")
 
-	onEq := func(b *Builder) {
-		spanIDPairFrag("L", j.TraceIDColumn, "R", j.TraceIDColumn)(b)
-		b.writeSQL(" AND ")
-		spanIDPairFrag("L", j.ParentSpanIDColumn, "R", j.ParentSpanIDColumn)(b)
-	}
-	distinctSpan := func(b *Builder) {
-		writeSideCol(b, "L", j.SpanIDColumn)
-		b.writeSQL(" != ")
-		writeSideCol(b, "R", j.SpanIDColumn)
-	}
+	onEq := And(
+		spanIDPairFrag("L", j.TraceIDColumn, "R", j.TraceIDColumn),
+		spanIDPairFrag("L", j.ParentSpanIDColumn, "R", j.ParentSpanIDColumn),
+	)
+	distinctSpan := Neq(qualColFrag("L", j.SpanIDColumn), qualColFrag("R", j.SpanIDColumn))
 
 	switch {
 	case j.Op.IsNegated():
 		// Aggregate L per (TraceId, ParentSpanId): how many L spans the
 		// group holds and which span ids they are.
+		// `_l_cnt` / `_l_span_ids` are emitter-pinned bare aliases (no
+		// backticks); the AS suffix rides verbatim while count() /
+		// groupUniqArray(...) compose as Frags.
+		cntAgg := func(b *Builder) { Call("count")(b); verbatim(" AS _l_cnt")(b) }
+		spanIDsAgg := func(b *Builder) {
+			Call("groupUniqArray", Col(j.SpanIDColumn))(b)
+			verbatim(" AS _l_span_ids")(b)
+		}
 		aggL := NewQuery().
 			Select(
 				Col(j.TraceIDColumn),
 				Col(j.ParentSpanIDColumn),
-				func(b *Builder) { b.writeSQL("count() AS _l_cnt") },
-				func(b *Builder) {
-					b.writeSQL("groupUniqArray(")
-					b.Ident(j.SpanIDColumn)
-					b.writeSQL(") AS _l_span_ids")
-				},
+				cntAgg,
+				spanIDsAgg,
 			).
 			From(aliasedFrag(leftSub, "_l")).
 			GroupBy(Col(j.TraceIDColumn), Col(j.ParentSpanIDColumn))
+		// `(L._l_cnt - has(L._l_span_ids, R.<spanID>)) = 0`. The two
+		// synthetic aggregate columns are referenced bare-qualified
+		// (`L._l_cnt`) — emitter-pinned tokens, so verbatim; the has()
+		// call and arithmetic compose as Frags.
+		negWhere := Eq(
+			Paren(Sub(
+				verbatim("L._l_cnt"),
+				Call("has", verbatim("L._l_span_ids"), qualColFrag("R", j.SpanIDColumn)),
+			)),
+			InlineLit(0),
+		)
 		sb := NewQuery().
 			Select(rightProj...).
 			From(aliasedFrag(rightSub, "R")).
 			Join(LeftJoin, aliasedFrag(aggL.Frag(), "L"), onEq).
-			Where(func(b *Builder) {
-				b.writeSQL("(L._l_cnt - has(L._l_span_ids, ")
-				writeSideCol(b, "R", j.SpanIDColumn)
-				b.writeSQL(")) = 0")
-			})
+			Where(negWhere)
 		e.emitSelect(sb)
 		return nil
 	case j.Op.IsUnion():
@@ -352,29 +358,28 @@ func structuralProjectionFrags(j *chplan.StructuralJoin, side string) []Frag {
 }
 
 // aliasedSideCol renders `<side>.<col> AS <alias>` with `col` and
-// `alias` both backtick-quoted.
+// `alias` both backtick-quoted. The bare side (L / R) rides qualColFrag;
+// As applies the alias's backtick quoting.
 func aliasedSideCol(side, col, alias string) Frag {
-	return func(b *Builder) {
-		writeSideCol(b, side, col)
-		b.writeSQL(" AS ")
-		b.Ident(alias)
-	}
+	return As(qualColFrag(side, col), alias)
 }
 
 // starExceptKeys renders `<side>.* EXCEPT (<k1>, <k2>, <k3>)` with each
 // key backtick-quoted. Used in tandem with the leading aliased-key
 // projections to pass through every other column without re-emitting
-// the keys twice.
+// the keys twice. The `<side>.* EXCEPT (` and `)` glue is an
+// emitter-chosen synthetic shape (bare side alias + CH's EXCEPT modifier
+// on a star projection — no Frag constructor covers a star-except), so
+// it rides verbatim; the keys flow through Col's quoting.
 func starExceptKeys(side, k1, k2, k3 string) Frag {
 	return func(b *Builder) {
-		b.writeSQL(side)
-		b.writeSQL(".* EXCEPT (")
-		b.Ident(k1)
-		b.writeSQL(", ")
-		b.Ident(k2)
-		b.writeSQL(", ")
-		b.Ident(k3)
-		b.writeSQL(")")
+		verbatim(side + ".* EXCEPT (")(b)
+		Col(k1)(b)
+		verbatim(", ")(b)
+		Col(k2)(b)
+		verbatim(", ")(b)
+		Col(k3)(b)
+		verbatim(")")(b)
 	}
 }
 
@@ -402,22 +407,14 @@ func structuralDirectRelFrag(j *chplan.StructuralJoin) (Frag, error) {
 
 // spanIDPairFrag returns a Frag for `<lside>.<lcol> = <rside>.<rcol>`.
 func spanIDPairFrag(lside, lcol, rside, rcol string) Frag {
-	return func(b *Builder) {
-		writeSideCol(b, lside, lcol)
-		b.writeSQL(" = ")
-		writeSideCol(b, rside, rcol)
-	}
+	return Eq(qualColFrag(lside, lcol), qualColFrag(rside, rcol))
 }
 
 // structuralDirectOnFrag composes the full ON clause:
 // `L.<TraceID> = R.<TraceID> AND <rel>`. The trace-id equality is
 // always present — direct ops scope every relation to within a trace.
 func structuralDirectOnFrag(j *chplan.StructuralJoin, rel Frag) Frag {
-	return func(b *Builder) {
-		spanIDPairFrag("L", j.TraceIDColumn, "R", j.TraceIDColumn)(b)
-		b.writeSQL(" AND ")
-		rel(b)
-	}
+	return And(spanIDPairFrag("L", j.TraceIDColumn, "R", j.TraceIDColumn), rel)
 }
 
 // emitStructuralRecursive renders `>>` / `<<` as a `WITH RECURSIVE`
@@ -538,11 +535,7 @@ func (e *emitter) emitStructuralRecursive(j *chplan.StructuralJoin) error {
 	// Recursive step: SELECT t.<...>, c._depth + 1 FROM `<table>` AS t
 	// INNER JOIN _struct_closure AS c ON <stepOn>
 	// WHERE c._depth < <cap> [AND t.TraceId IN (SELECT TraceId FROM (<L>) AS _seed_ids)].
-	stepOn := func(b *Builder) {
-		spanIDPairFrag("t", j.TraceIDColumn, "c", j.TraceIDColumn)(b)
-		b.writeSQL(" AND ")
-		stepRel(b)
-	}
+	stepOn := And(spanIDPairFrag("t", j.TraceIDColumn, "c", j.TraceIDColumn), stepRel)
 	step := NewQuery().
 		Select(
 			Distinct(qualColFrag("t", j.TraceIDColumn)),
@@ -568,11 +561,10 @@ func (e *emitter) emitStructuralRecursive(j *chplan.StructuralJoin) error {
 		From(verbatim(cteName)).
 		Where(verbatim("_depth > 0"))
 
-	onClause := func(b *Builder) {
-		spanIDPairFrag("L", j.TraceIDColumn, "R", j.TraceIDColumn)(b)
-		b.writeSQL(" AND ")
-		spanIDPairFrag("L", j.SpanIDColumn, "R", j.SpanIDColumn)(b)
-	}
+	onClause := And(
+		spanIDPairFrag("L", j.TraceIDColumn, "R", j.TraceIDColumn),
+		spanIDPairFrag("L", j.SpanIDColumn, "R", j.SpanIDColumn),
+	)
 	rightProj := structuralProjectionFrags(j, "R")
 	leftProj := structuralProjectionFrags(j, "L")
 	switch {
@@ -663,11 +655,7 @@ func buildStructuralInverseClosure(j *chplan.StructuralJoin, seedNode chplan.Nod
 		).
 		From(aliasedFrag(rightSub, "_seed"))
 
-	stepOn := func(b *Builder) {
-		spanIDPairFrag("t", j.TraceIDColumn, "c", j.TraceIDColumn)(b)
-		b.writeSQL(" AND ")
-		stepRel(b)
-	}
+	stepOn := And(spanIDPairFrag("t", j.TraceIDColumn, "c", j.TraceIDColumn), stepRel)
 	step := NewQuery().
 		Select(
 			Distinct(qualColFrag("t", j.TraceIDColumn)),
@@ -778,14 +766,10 @@ func structuralSeedTraceFilter(traceIDCol string, seedSub Frag) Frag {
 	seedIDs := NewQuery().
 		Select(Col(traceIDCol)).
 		From(aliasedFrag(seedSub, "_seed_ids"))
-	// In() already parenthesises its right-hand list, so render the
-	// seed-id SELECT bare (Build, not Frag, which would double-wrap).
-	seedSQL, seedArgs := seedIDs.Build()
-	bareSeed := func(b *Builder) {
-		b.writeSQL(seedSQL)
-		b.args = append(b.args, seedArgs...)
-	}
-	return In(qualColFrag("t", traceIDCol), bareSeed)
+	// In() already parenthesises its right-hand list, so splice the
+	// seed-id SELECT bare (Spliced, not Subquery — the latter would
+	// double-wrap in parens).
+	return In(qualColFrag("t", traceIDCol), Spliced(seedIDs))
 }
 
 // findScanTable walks a plan subtree looking for the first chplan.Scan

--- a/internal/chsql/vector_join.go
+++ b/internal/chsql/vector_join.go
@@ -523,15 +523,6 @@ func aliasedFrag(inner Frag, bareAlias string) Frag {
 	}
 }
 
-// writeSideCol emits `<side>.<col>` where <side> is the unquoted alias
-// (L or R) and <col> is the backtick-quoted column identifier. The
-// unquoted alias matches the legacy emitter's output so existing
-// fixtures that pre-date the Builder port stay stable. Thin shim over
-// qualColFrag so the predicate constructors below can read as Frags.
-func writeSideCol(b *Builder, side, col string) {
-	qualColFrag(side, col)(b)
-}
-
 // vectorMatchPredicateFrag returns a Frag for the join's ON clause.
 //
 //   - default (Labels empty, On false) → L.Attributes = R.Attributes

--- a/internal/chsql/vector_join.go
+++ b/internal/chsql/vector_join.go
@@ -28,10 +28,10 @@ import (
 //   - CardOneToMany (`group_right(<labels>)`): mirror of CardManyToOne.
 //
 // The outer SELECT, each per-side aggregation subquery, and the INNER
-// JOIN slot all flow through typed QueryBuilder slots. The bare-alias glue (`AS L` /
-// `AS R`) is operator-token-style writeSQL inside a Frag — CH accepts
-// unquoted single-letter aliases and the existing fixtures pin that
-// shape.
+// JOIN slot all flow through typed QueryBuilder slots. The bare-alias
+// glue (`AS L` / `AS R`) is an emitter-chosen synthetic token spliced
+// via verbatim inside aliasedFrag — CH accepts unquoted single-letter
+// aliases and the existing fixtures pin that shape.
 func (e *emitter) emitVectorJoin(j *chplan.VectorJoin) error {
 	if err := e.validateVectorJoinCols(j); err != nil {
 		return err
@@ -263,22 +263,12 @@ func joinAlias(col string) string {
 
 // aggMaxAs returns a Frag for `max(<col>) AS <alias>`.
 func aggMaxAs(col, alias string) Frag {
-	return As(func(b *Builder) {
-		b.writeSQL("max(")
-		b.Ident(col)
-		b.writeSQL(")")
-	}, alias)
+	return As(Call("max", Col(col)), alias)
 }
 
 // argMaxAs returns a Frag for `argMax(<valCol>, <byCol>) AS <alias>`.
 func argMaxAs(valCol, byCol, alias string) Frag {
-	return As(func(b *Builder) {
-		b.writeSQL("argMax(")
-		b.Ident(valCol)
-		b.writeSQL(", ")
-		b.Ident(byCol)
-		b.writeSQL(")")
-	}, alias)
+	return As(Call("argMax", Col(valCol), Col(byCol)), alias)
 }
 
 // matchCheckFrag returns a Frag for the runtime uniqueness guard:
@@ -290,12 +280,16 @@ func argMaxAs(valCol, byCol, alias string) Frag {
 // fixtures pin that shape; CH accepts unquoted aliases for ASCII
 // underscore-prefixed names.
 func matchCheckFrag(attrsCol string) Frag {
+	check := Call(
+		"throwIf",
+		Gt(Call("uniqExact", Col(attrsCol)), InlineLit(1)),
+		Lit("many-to-many matching not allowed: matching labels must be unique on one side"),
+	)
+	// `_cerberus_match_check` is an emitter-pinned bare alias (no
+	// backticks); the AS suffix rides verbatim, not the quoting As Frag.
 	return func(b *Builder) {
-		b.writeSQL("throwIf(uniqExact(")
-		b.Ident(attrsCol)
-		b.writeSQL(") > 1, ")
-		b.Arg("many-to-many matching not allowed: matching labels must be unique on one side")
-		b.writeSQL(") AS _cerberus_match_check")
+		check(b)
+		verbatim(" AS _cerberus_match_check")(b)
 	}
 }
 
@@ -305,40 +299,31 @@ func matchCheckFrag(attrsCol string) Frag {
 // it's `mapFilter((k, v) -> k IN (...), Attributes)`; for
 // ignoring(labels) it's the complementary mapFilter.
 func matchKeyGroupExprFrag(m chplan.VectorMatch, attrsCol string) Frag {
-	return func(b *Builder) { writeMatchKeyGroupExpr(b, m, attrsCol) }
-}
-
-// writeMatchKeyGroupExpr emits the GROUP BY expression that collapses
-// rows onto a single matching key. For default matching (full
-// Attributes) this is just the Attributes column; for on(labels) it's
-// `mapFilter((k,v) -> k IN (...), Attributes)`; for ignoring(labels)
-// it's the complementary mapFilter.
-func writeMatchKeyGroupExpr(b *Builder, m chplan.VectorMatch, attrsCol string) {
 	if len(m.Labels) == 0 && !m.On {
-		b.Ident(attrsCol)
-		return
+		return Col(attrsCol)
 	}
 	if m.On && len(m.Labels) == 0 {
 		// on() with no labels — group everything onto a single
 		// match-key. CH doesn't allow an empty IN list, so emit a
 		// constant tuple.
-		b.writeSQL("tuple()")
-		return
+		return Call("tuple")
 	}
 	if m.On {
-		b.writeSQL("mapFilter((k, v) -> k IN (")
+		// mapFilter((k, v) -> k IN (?, ?, …), Attributes) — keep only
+		// the on(...) labels.
+		lbls := make([]Frag, len(m.Labels))
 		for i, lbl := range m.Labels {
-			if i > 0 {
-				b.writeSQL(", ")
-			}
-			b.Arg(lbl)
+			lbls[i] = Lit(lbl)
 		}
-		b.writeSQL("), ")
-		b.Ident(attrsCol)
-		b.writeSQL(")")
-		return
+		return Call(
+			"mapFilter",
+			Lambda2("k", "v", In(BareIdent("k"), lbls...)),
+			Col(attrsCol),
+		)
 	}
-	b.MapFilterExcept(attrsCol, m.Labels...)
+	// ignoring(...) — the complementary mapFilter. MapFilterExcept is a
+	// Builder helper that renders `mapFilter((k, v) -> NOT (k IN (…)), col)`.
+	return func(b *Builder) { b.MapFilterExcept(attrsCol, m.Labels...) }
 }
 
 // outputAttributesFrag returns a Frag for the output Attributes
@@ -353,10 +338,7 @@ func writeMatchKeyGroupExpr(b *Builder, m chplan.VectorMatch, attrsCol string) {
 // Prometheus's behaviour where bare group_left/right copies nothing
 // beyond the matching key.
 func outputAttributesFrag(j *chplan.VectorJoin) Frag {
-	return func(b *Builder) { writeOutputAttributes(b, j) }
-}
-
-func writeOutputAttributes(b *Builder, j *chplan.VectorJoin) {
+	attrs := j.AttributesColumn
 	manySide := ""
 	switch j.Card {
 	case chplan.CardManyToOne:
@@ -378,10 +360,7 @@ func writeOutputAttributes(b *Builder, j *chplan.VectorJoin) {
 		if manySide == "R" {
 			side = "R"
 		}
-		writeSideCol(b, side, j.AttributesColumn)
-		b.writeSQL(" AS ")
-		b.Ident(j.AttributesColumn)
-		return
+		return As(qualColFrag(side, attrs), attrs)
 	}
 
 	// group_left/right with Include labels — overlay the "one" side's
@@ -391,19 +370,20 @@ func writeOutputAttributes(b *Builder, j *chplan.VectorJoin) {
 	if manySide == "R" {
 		oneSide = "L"
 	}
-	b.writeSQL("mapConcat(")
-	writeSideCol(b, manySide, j.AttributesColumn)
-	b.writeSQL(", mapFilter((k, v) -> k IN (")
+	includes := make([]Frag, len(j.Include))
 	for i, lbl := range j.Include {
-		if i > 0 {
-			b.writeSQL(", ")
-		}
-		b.Arg(lbl)
+		includes[i] = Lit(lbl)
 	}
-	b.writeSQL("), ")
-	writeSideCol(b, oneSide, j.AttributesColumn)
-	b.writeSQL(")) AS ")
-	b.Ident(j.AttributesColumn)
+	merged := Call(
+		"mapConcat",
+		qualColFrag(manySide, attrs),
+		Call(
+			"mapFilter",
+			Lambda2("k", "v", In(BareIdent("k"), includes...)),
+			qualColFrag(oneSide, attrs),
+		),
+	)
+	return As(merged, attrs)
 }
 
 // outputMetricNameFrag returns a Frag for the joined output's
@@ -427,7 +407,7 @@ func writeOutputAttributes(b *Builder, j *chplan.VectorJoin) {
 // bare-compare + group_left variants.
 func outputMetricNameFrag(j *chplan.VectorJoin, outerSide string) Frag {
 	if vectorJoinDropsName(j) {
-		return As(func(b *Builder) { b.Arg("") }, j.MetricNameColumn)
+		return As(Lit(""), j.MetricNameColumn)
 	}
 	return qualColFrag(outerSide, j.MetricNameColumn)
 }
@@ -519,31 +499,37 @@ func isComparisonOp(op chplan.BinaryOp) bool {
 }
 
 // qualColFrag returns a Frag for `<bareSide>.<col>` — the bare-alias
-// L / R qualifier the legacy emitter pins.
+// L / R qualifier the legacy emitter pins. The side is a synthetic,
+// emitter-chosen single-letter alias (never user input) so it rides
+// `verbatim` rather than Ident's backtick quoting; the column is a real
+// identifier and flows through Col.
 func qualColFrag(side, col string) Frag {
-	return func(b *Builder) { writeSideCol(b, side, col) }
+	return func(b *Builder) {
+		verbatim(side + ".")(b)
+		Col(col)(b)
+	}
 }
 
 // aliasedFrag wraps inner in a trailing ` AS <bareAlias>`. The alias
 // is rendered bare (no backticks) — CH accepts unquoted single-letter
 // aliases, and the vector_join / structural_join fixtures pin that
-// shape.
+// shape. The bare alias is an emitter-chosen synthetic token (L / R /
+// _seed / ns / …), so the AS-suffix is a verbatim synthetic-token
+// splice rather than the backtick-quoting As Frag.
 func aliasedFrag(inner Frag, bareAlias string) Frag {
 	return func(b *Builder) {
 		inner(b)
-		b.writeSQL(" AS ")
-		b.writeSQL(bareAlias)
+		verbatim(" AS " + bareAlias)(b)
 	}
 }
 
 // writeSideCol emits `<side>.<col>` where <side> is the unquoted alias
 // (L or R) and <col> is the backtick-quoted column identifier. The
 // unquoted alias matches the legacy emitter's output so existing
-// fixtures that pre-date the Builder port stay stable.
+// fixtures that pre-date the Builder port stay stable. Thin shim over
+// qualColFrag so the predicate constructors below can read as Frags.
 func writeSideCol(b *Builder, side, col string) {
-	b.writeSQL(side)
-	b.writeSQL(".")
-	b.Ident(col)
+	qualColFrag(side, col)(b)
 }
 
 // vectorMatchPredicateFrag returns a Frag for the join's ON clause.
@@ -561,66 +547,51 @@ func writeSideCol(b *Builder, side, col string) {
 // across anchors (roleMany) or fold the matrix down to a single per-
 // match-key row at the surviving anchor (roleOne).
 func vectorMatchPredicateFrag(m chplan.VectorMatch, attrsCol, tsCol string, stepAligned bool) Frag {
-	return func(b *Builder) { writeVectorMatchPredicate(b, m, attrsCol, tsCol, stepAligned) }
-}
-
-func writeVectorMatchPredicate(b *Builder, m chplan.VectorMatch, attrsCol, tsCol string, stepAligned bool) {
-	writeMatchKeyPredicate(b, m, attrsCol)
-	if stepAligned {
-		b.writeSQL(" AND ")
-		writeSideCol(b, "L", tsCol)
-		b.writeSQL(" = ")
-		writeSideCol(b, "R", tsCol)
+	key := matchKeyPredicateFrag(m, attrsCol)
+	if !stepAligned {
+		return key
 	}
+	// Step-aligned (range mode): additionally pin each anchor to its own
+	// per-anchor pair — `<key> AND L.<tsCol> = R.<tsCol>`.
+	return And(key, Eq(qualColFrag("L", tsCol), qualColFrag("R", tsCol)))
 }
 
-// writeMatchKeyPredicate renders just the label-matching half of the
+// matchKeyPredicateFrag renders just the label-matching half of the
 // join's ON clause — extracted so the step-alignment AND can be
 // composed on top without copying the per-shape branches.
-func writeMatchKeyPredicate(b *Builder, m chplan.VectorMatch, attrsCol string) {
+func matchKeyPredicateFrag(m chplan.VectorMatch, attrsCol string) Frag {
 	if len(m.Labels) == 0 && !m.On {
-		writeSideCol(b, "L", attrsCol)
-		b.writeSQL(" = ")
-		writeSideCol(b, "R", attrsCol)
-		return
+		return Eq(qualColFrag("L", attrsCol), qualColFrag("R", attrsCol))
 	}
 	if m.On && len(m.Labels) == 0 {
 		// on() with no labels — every row on the left pairs with
 		// every row on the right. The per-side aggregation already
 		// collapses each side to one row via the throwIf-guard, so
 		// the join condition is just a constant TRUE.
-		b.writeSQL("1 = 1")
-		return
+		return Eq(InlineLit(1), InlineLit(1))
 	}
 	if m.On {
+		// `L.<attrs>[?] = R.<attrs>[?]` per on(...) label, AND-joined.
+		perLabel := make([]Frag, len(m.Labels))
 		for i, lbl := range m.Labels {
-			if i > 0 {
-				b.writeSQL(" AND ")
-			}
-			writeSideCol(b, "L", attrsCol)
-			b.writeSQL("[")
-			b.Arg(lbl)
-			b.writeSQL("] = ")
-			writeSideCol(b, "R", attrsCol)
-			b.writeSQL("[")
-			b.Arg(lbl)
-			b.writeSQL("]")
+			perLabel[i] = Eq(
+				Subscript(qualColFrag("L", attrsCol), Lit(lbl)),
+				Subscript(qualColFrag("R", attrsCol), Lit(lbl)),
+			)
 		}
-		return
+		return And(perLabel...)
 	}
-	for i, side := range []string{"L", "R"} {
-		if i == 1 {
-			b.writeSQL(" = ")
+	// ignoring(...) — equate the complementary mapFilter on each side.
+	ignFilter := func(side string) Frag {
+		lbls := make([]Frag, len(m.Labels))
+		for i, lbl := range m.Labels {
+			lbls[i] = Lit(lbl)
 		}
-		b.writeSQL("mapFilter((k, v) -> NOT (k IN (")
-		for j, lbl := range m.Labels {
-			if j > 0 {
-				b.writeSQL(", ")
-			}
-			b.Arg(lbl)
-		}
-		b.writeSQL(")), ")
-		writeSideCol(b, side, attrsCol)
-		b.writeSQL(")")
+		return Call(
+			"mapFilter",
+			Lambda2("k", "v", Not(Paren(In(BareIdent("k"), lbls...)))),
+			qualColFrag(side, attrsCol),
+		)
 	}
+	return Eq(ignFilter("L"), ignFilter("R"))
 }

--- a/internal/chsql/vector_set_op.go
+++ b/internal/chsql/vector_set_op.go
@@ -472,17 +472,15 @@ func (e *emitter) validateVectorSetOpCols(s *chplan.VectorSetOp) error {
 // per signature; set ops are inherently many-to-many on labels so a
 // per-series subquery would otherwise emit one row per LHS+RHS series.
 func setOpInSubqueryFrag(m chplan.VectorMatch, attrsCol string, sub Frag, in bool) Frag {
-	return func(b *Builder) {
-		matchKeyGroupExprFrag(m, attrsCol)(b)
-		if in {
-			b.writeSQL(" IN (")
-		} else {
-			b.writeSQL(" NOT IN (")
-		}
-		inner := NewQuery().
-			Select(Distinct(matchKeyGroupExprFrag(m, attrsCol))).
-			From(sub)
-		inner.Frag()(b)
-		b.writeSQL(")")
+	sig := matchKeyGroupExprFrag(m, attrsCol)
+	inner := NewQuery().
+		Select(Distinct(matchKeyGroupExprFrag(m, attrsCol))).
+		From(sub)
+	// inner.Frag() already wraps the SELECT in parens; In / NotInSubquery
+	// each add the outer membership parens, giving the existing
+	// `<sig> [NOT] IN ((SELECT DISTINCT … FROM …))` byte shape.
+	if in {
+		return In(sig, inner.Frag())
 	}
+	return NotInSubquery(sig, inner.Frag())
 }


### PR DESCRIPTION
Finishes the typed-Frag sweep PR #848 started. #848 recomposed the 7 `sb.Write*` domain emitters but deliberately deferred ~206 `writeSQL` raw-SQL escape-hatch sites across 6 more files. This PR recomposes every one of them into typed Frags. **Pure refactor** — all goldens are byte-identical.

## Per-file writeSQL/sb.Write sites recomposed → 0

| file | sites |
|---|---|
| `histogram_quantile.go` | 55 |
| `histogram_quantile_native.go` | 70 |
| `vector_join.go` | 38 |
| `structural_join.go` | 19 |
| `nested_set_annotate.go` | 18 |
| `set_op.go` | 3 |
| `vector_set_op.go` | 3 |
| **total** | **206** |

The deeply-nested `if()` interpolation chains in both histogram_quantile emitters are now `If`/`Call`/binop/`Subscript` Frag trees; the vector/structural join ON-clauses + match-key predicates are `Eq`/`And`/`Neq`/`In`/`Subscript`/`Lambda2`; the nested-set recursive-CTE anchor/step predicates are `And`/`Eq`/`InSubquery`; set-op / vector-set-op membership is `In`/`NotInSubquery`/`UnionAll`/`Paren`.

## Goldens byte-identical (pure refactor)

After regenerating both lanes (`GOLDEN_UPDATE=1 go test -count=1 ./...` and `GOLDEN_UPDATE=1 go test -tags chdb -count=1 ./test/spec/...`):

- `git diff test/spec/` → **EMPTY**
- `git diff internal/chsql/*_test.go` → **EMPTY**

Only the 8 source files changed (net -192 lines).

## New typed builder.go constructors (no primitive touched)

- **`InSubquery(left, sub)`** — `<left> IN <sub>` where `sub` is a self-parenthesising subquery Frag (e.g. a traceScopeFrag's `(SELECT …)`); emits no parens of its own (sibling of the existing `NotInSubquery`). Used by the nested-set annotate anchor's trace-id scope filter.
- **`Spliced(Subqueryable)`** — bare (no-paren) splice of a pre-rendered `(sql, args)` pair, for the right-hand side of the list-form `In` where `Subquery` would double-paren. Used by the structural seed-trace filter.

## Remaining sanctioned writeSQL/sb.Write sites

Low-level synthetic-token helpers (bare `L`/`R`/`ns` aliases, `AS <bare-alias>`, `<side>.* EXCEPT (...)`, the CTE's `c.\`_path\`` reference) now ride `verbatim(...)`, the documented in-package escape for emitter-chosen synthetic tokens — never for expression shapes.

Post-sweep guardrail:

```
$ grep -rn 'writeSQL\|sb.Write' internal/chsql/ | grep -v builder.go | grep -v _test.go
internal/chsql/range_window.go:744:		b.sb.WriteString(" AS ")
internal/chsql/range_window.go:745:		b.sb.WriteString(alias)
internal/chsql/emit_node.go:39:		b.sb.WriteString(sql)
```

These three are the **two pre-existing sanctioned sites #848 left outside this scope** and which `CLAUDE.md`'s self-check explicitly names: the `range_window.go` `rawAs` synthetic-alias helper and the `emit_node.go` pre-rendered-subquery splice. All 6 in-scope files are now `writeSQL`-free.

## Verification

`go build ./...`, `golangci-lint run ./internal/chsql/...` (no issues), `gofumpt -extra -l` (clean on all 8 files), `go-arch-lint check` (OK), full `go test ./...` + `go test -tags chdb ./test/spec/... ./internal/solver/... ./internal/chsql/...` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)