### PR TITLE
test(perf): scale-wall pin — catch wall regressions the cardinality ratchet misses

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -221,6 +221,27 @@ update-solver-decision-baseline:
     @echo "Diff of regenerated baseline:"
     @git --no-pager diff --stat test/perf/solver-decision-baseline.json || true
 
+# Regenerate the SCALE-WALL pin baseline — the perf guard for the wall /
+# scan-amplification regression classes the cardinality ratchet is blind to
+# (it pins fan_factor only, so #97's 6x CPU-bound wall regression and the
+# anchor-grid sharding's 8x scan amplification both sailed through it). Seeds
+# a counter table at scale, lowers `sum(rate(http_requests_total[5m]))` on a
+# 1h/15s query_range grid through the real lower -> optimizer -> emit chain,
+# and records two bounds into test/perf/scale-wall-baseline.json: the
+# deterministic peak-intermediate/scan-rows amplification ceiling (PRONG 1)
+# and the in-run query/yardstick wall ratio ceiling (PRONG 2). Both carry
+# headroom over the measured floor (1.5x / 2.5x). Requires libchdb.so
+# (`just chdb-install`). Run this — and REVIEW THE DIFF — only when a bound
+# move is genuinely intended (a real, justified compute-cost increase); a
+# silent loosen is exactly the regression the pin exists to catch. The gating
+# assertion is TestScaleWallPin in the already-required `perf-guards` job.
+update-scale-wall-baseline:
+    @test -f "{{CHDB_INSTALL_PATH}}" || { echo "error: {{CHDB_INSTALL_PATH}} not found — run 'just chdb-install' first; the scale-wall bounds are measured by an in-process chDB run" >&2; exit 1; }
+    UPDATE_SCALE_WALL_BASELINE=1 go test -tags chdb -count=1 -run TestScaleWallPin ./test/perf/
+    @echo
+    @echo "Diff of regenerated baseline:"
+    @git --no-pager diff --stat test/perf/scale-wall-baseline.json || true
+
 # Regenerate the publishable benchmark document (docs/benchmarks.md) from
 # LIVE measurements: optimizer before/after wins, per-construct scaling
 # curves, per-stage Go micro-benchmarks, and end-to-end query latency on a

--- a/test/perf/profile/sql.go
+++ b/test/perf/profile/sql.go
@@ -56,6 +56,15 @@ func planHasRecursiveCTE(plan string) bool {
 // `count()` on a stripped inner level would fail (caught + excluded by the
 // caller). The outer count() still measures the post-CTE result, and the
 // EXPLAIN plan flags still detect the recursive/cross operators.
+// FromSourceLevels is the exported wrapper over [fromSourceLevels] for
+// callers outside the corpus profiler that need the same per-level
+// decomposition — notably the scale-wall pin (test/perf), which counts
+// each level over its own seeded-at-scale table to derive the peak
+// intermediate cardinality. Keeping the decomposition in ONE place means
+// the corpus ratchet and the scale-wall pin agree on what "a pipeline
+// level" is by construction.
+func FromSourceLevels(query string) []string { return fromSourceLevels(query) }
+
 func fromSourceLevels(query string) []string {
 	query = strings.TrimSpace(query)
 	levels := []string{query}

--- a/test/perf/scale-wall-baseline.json
+++ b/test/perf/scale-wall-baseline.json
@@ -1,0 +1,4 @@
+{
+  "scan_amplification_bound": 7,
+  "wall_ratio_bound": 12
+}

--- a/test/perf/scale_wall_pin_chdb_test.go
+++ b/test/perf/scale_wall_pin_chdb_test.go
@@ -1,0 +1,436 @@
+//go:build chdb
+
+// The SCALE-WALL pin: the perf guard for the regression classes the
+// cardinality ratchet is structurally BLIND to.
+//
+// # Why this exists (the gap the cardinality ratchet leaves open)
+//
+// cardinality_ratchet_test.go pins fan_factor = peak_intermediate/scan_rows
+// over the TXTAR corpus — a DETERMINISTIC structural signal that
+// DELIBERATELY EXCLUDES timing as "environment-noisy". That blind spot let
+// two real, separately-catalogued perf regressions through:
+//
+//	(a) #97 (ASOF rate path): fan_factor DROPPED to 1.0 — cardinality fell —
+//	    while wall time went 6.31s -> 36.90s. A CPU-bound blow-up with FLAT
+//	    or FALLING cardinality is invisible to a cardinality-only ratchet.
+//	(b) the anchor-grid sharding regression: per-statement cardinality stayed
+//	    flat, but the query read 8x the rows (40M vs 5M). A scan-amplification
+//	    that holds the FINAL result cardinality constant is likewise invisible
+//	    to a peak_intermediate/scan_rows ratio measured on tiny fixtures.
+//
+// This pin closes both gaps with a representative OOM-class query — a
+// `sum(rate(http_requests_total[5m]))` query_range over a counter table
+// seeded at scale — run through the REAL pipeline (parse -> lower ->
+// optimizer.Default().Run -> emit -> chDB exec). It asserts two invariants,
+// each targeting one of the two regression classes above:
+//
+//	PRONG 1 — deterministic total-work / scan-amplification pin (ZERO
+//	tolerance, catches the SHARDING class). Decomposes the EMITTED SQL into
+//	its FROM-source pipeline levels (via profile.FromSourceLevels — the SAME
+//	decomposition the corpus ratchet uses) and counts each over the
+//	seeded-at-scale table. Asserts the PEAK intermediate cardinality stays
+//	<= scanAmplificationBound x scan_rows. An 8x scan amplification (more
+//	rows read at flat result cardinality) blows straight past the bound and
+//	fails immediately. This is the PRIMARY guard: pure row counts, fully
+//	deterministic, reproduces run-to-run.
+//
+//	PRONG 2 — ratio-based wall pin (catches the GROSS-WALL class like #97's
+//	6x). Times the real query best-of-N (the floor strips GC / scheduler
+//	jitter) and divides by an IN-RUN yardstick measured in the SAME process:
+//	a bare groupArray/arraySort window-pairing aggregate over the SAME scan
+//	that does comparable per-row array machinery but carries NO anchor
+//	fan-out. Because both timings ride the same chDB engine on the same
+//	machine in the same process, machine speed AND the CGO/chDB call
+//	overhead CANCEL in the ratio — the gate is a ratio-of-walls with NO
+//	absolute-ms threshold, so it does not flap across CI runners. The
+//	committed bound (wallRatioBound) has ~2.5x headroom over the measured
+//	floor; a #97-class 6x CPU regression pushes the ratio ~6x past its
+//	baseline and trips it.
+//
+// # Robustness (a flaky perf gate is worse than none)
+//
+// The bounds below were calibrated on the chDB runner: over 36 measurements
+// (3 separate processes x 12 trials, best-of-5 each) the wall ratio stayed
+// in 4.2-5.8 (max 5.77), spread <=1.39x within a process. wallRatioBound is
+// set generously above that envelope so 2-3x CI variance passes but a 6x
+// regression FAILS. PRONG 1 is deterministic and is the primary guard;
+// PRONG 2 adds the CPU-bound coverage PRONG 1 cannot see, with a bound wide
+// enough that it never flaps. Both bounds live in scale-wall-baseline.json;
+// `just update-scale-wall-baseline` regenerates them (mirrors
+// `just update-cardinality-baseline`).
+//
+// Build-tagged chdb; rides the already-required `perf-guards` job
+// (`just perf-chdb` = `go test -tags chdb ./test/perf/...`).
+package perf
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	_ "github.com/chdb-io/chdb-go/chdb/driver"
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/optimizer"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/test/perf/profile"
+)
+
+// scaleWallBaselinePath is the committed bound file, relative to this package.
+const scaleWallBaselinePath = "scale-wall-baseline.json"
+
+// scaleWallUpdateEnv, when "1", rewrites the baseline from the current
+// measurement instead of asserting against it. Driven by
+// `just update-scale-wall-baseline`; mirrors UPDATE_CARDINALITY_BASELINE.
+const scaleWallUpdateEnv = "UPDATE_SCALE_WALL_BASELINE"
+
+// --- seeded-at-scale fixture parameters --------------------------------
+//
+// A counter table large enough to expose a 6x wall regression / 8x scan
+// amplification, but capped so the perf-guards job stays fast (the seed +
+// both prongs run in ~1s on the chDB runner). 300k rows over 300 series is
+// ~1000 samples/series across 1h — plenty of per-window samples for the
+// rate machinery to do real work, plenty of total rows for an amplification
+// to show.
+const (
+	scaleSeedRows     = 300_000
+	scaleSeedSeries   = 300
+	scaleSampleStepS  = 15 // seconds between samples per series
+	scaleRateMetric   = "http_requests_total"
+	scaleQueryRangeQL = "sum(rate(" + scaleRateMetric + "[5m]))"
+	// best-of-N: the floor strips GC / scheduler jitter. N=9 (not the
+	// scaling harness's 5) because under whole-process load a single GC
+	// pause can occasionally land on a best-of-5 minimum and inflate the
+	// numerator — the floor over 9 trials is far harder to perturb, which
+	// tightens PRONG 2's ratio spread (verified: max observed ratio drops
+	// well back under the calibration envelope).
+	scaleWallIters = 9
+)
+
+// scaleWallBaseline is the committed bound pair. Kept tiny + JSON so the
+// diff is a one-line review when a bound is deliberately moved.
+type scaleWallBaseline struct {
+	// ScanAmplificationBound is the max PEAK intermediate cardinality, as a
+	// multiple of scan_rows, PRONG 1 tolerates. The seeded rate query's
+	// bounded anchor fan-out measures ~4.6x scan_rows on main; the committed
+	// bound carries headroom over that while an 8x scan-amplification
+	// regression blows past it. ZERO tolerance above this number.
+	ScanAmplificationBound float64 `json:"scan_amplification_bound"`
+
+	// WallRatioBound is the max (query wall / yardstick wall) ratio PRONG 2
+	// tolerates. Calibrated floor ~5; bound carries ~2.5x headroom so CI
+	// variance passes but a #97-class 6x CPU regression fails. A ratio, so
+	// machine speed cancels and it does not flap across runners.
+	WallRatioBound float64 `json:"wall_ratio_bound"`
+}
+
+func TestScaleWallPin(t *testing.T) {
+	db := openScaleWallDB(t)
+	scanRows := seedCounterAtScale(t, db)
+
+	sqlText, args := emitRateRangeSQL(t)
+
+	// --- PRONG 1: deterministic scan-amplification / total-work pin -------
+	//
+	// Decompose the emitted SQL into its pipeline levels and count each over
+	// the seeded table. The MAX is the peak intermediate cardinality — the
+	// widest the row set gets anywhere in the pipeline. A scan amplification
+	// (more rows pulled through at flat result cardinality) shows up here as
+	// a peak that overshoots scan_rows x bound.
+	levels := profile.FromSourceLevels(stripTrailingScaleSemi(sqlText))
+	var peak int64
+	for _, lvl := range levels {
+		c, ok := countLevel(t, db, lvl, args)
+		if !ok {
+			// A level that references a name only in scope at an outer level
+			// can't be counted standalone — the corpus profiler excludes
+			// these too. The outer level (depth 0) and the leaf scan still
+			// anchor the decomposition.
+			continue
+		}
+		if c > peak {
+			peak = c
+		}
+	}
+	if peak == 0 {
+		t.Fatalf("PRONG 1: no countable pipeline level — the decomposition is broken, the pin would silently pass")
+	}
+	amplification := float64(peak) / float64(scanRows)
+	t.Logf("PRONG 1 (deterministic): peak_intermediate=%d = %.2fx scan_rows(%d)", peak, amplification, scanRows)
+
+	// --- PRONG 2: ratio-based wall pin -----------------------------------
+	//
+	// best-of-N wall of the real query / best-of-N wall of the in-run
+	// yardstick. Both ride the same engine in the same process, so machine
+	// speed + CGO overhead cancel — the ratio is portable.
+	queryWall := bestOfWall(t, db, "SELECT count() FROM ("+stripTrailingScaleSemi(sqlText)+")", args, scaleWallIters)
+	yardWall := bestOfWall(t, db, yardstickSQL(), nil, scaleWallIters)
+	wallRatio := float64(queryWall) / float64(yardWall)
+	t.Logf("PRONG 2 (wall ratio): query=%v yard=%v ratio=%.2f",
+		queryWall.Round(time.Microsecond), yardWall.Round(time.Microsecond), wallRatio)
+
+	if os.Getenv(scaleWallUpdateEnv) == "1" {
+		writeScaleWallBaseline(t, scaleWallBaseline{
+			// Round the measured values UP to a stable, generous bound so the
+			// committed number is a deliberate ceiling, not a brittle
+			// transcription of one run's float. The recipe prints the diff
+			// for review.
+			ScanAmplificationBound: ceilTo(amplification*scanAmplificationHeadroom, 0.5),
+			WallRatioBound:         ceilTo(wallRatio*wallRatioHeadroom, 1.0),
+		})
+		t.Logf("wrote %s (amplification=%.2f -> bound %.2f, wall_ratio=%.2f -> bound %.2f)",
+			scaleWallBaselinePath, amplification, ceilTo(amplification*scanAmplificationHeadroom, 0.5),
+			wallRatio, ceilTo(wallRatio*wallRatioHeadroom, 1.0))
+		return
+	}
+
+	base := loadScaleWallBaseline(t)
+
+	if amplification > base.ScanAmplificationBound {
+		t.Errorf("PRONG 1 FAIL (scan-amplification): peak intermediate cardinality is %.2fx scan_rows "+
+			"(%d / %d), over the committed %.2fx bound. The pipeline is pulling more rows through than the "+
+			"seeded scan justifies — the anchor-grid SHARDING class (8x scan amplification at flat result "+
+			"cardinality). Root-cause the extra rows; only run `just update-scale-wall-baseline` if the "+
+			"increase is genuinely intended.", amplification, peak, scanRows, base.ScanAmplificationBound)
+	}
+
+	if wallRatio > base.WallRatioBound {
+		t.Errorf("PRONG 2 FAIL (wall ratio): the rate query took %.2fx the yardstick's wall (query=%v, "+
+			"yard=%v), over the committed %.2fx bound. The query got CPU-bound-slower relative to a "+
+			"same-scan reference that did comparable array machinery — the #97 class (wall 6x UP while "+
+			"cardinality fell). Because this is a ratio measured in-process, machine speed cancels, so a "+
+			"breach is a real compute regression, not runner noise. Profile the rate path; only run "+
+			"`just update-scale-wall-baseline` if the cost is genuinely intended.",
+			wallRatio, queryWall.Round(time.Microsecond), yardWall.Round(time.Microsecond), base.WallRatioBound)
+	}
+}
+
+// scanAmplificationHeadroom / wallRatioHeadroom are the multipliers the
+// update recipe applies to a fresh measurement to derive the committed
+// bound. The headroom must clear normal runner variance (PRONG 2's ratio
+// spread was <=1.39x within a process across the calibration runs) while
+// staying comfortably under the regression each prong targets (8x scan
+// amplification / 6x wall). 1.5x on the deterministic amplification (it
+// barely varies) and 2.5x on the noisier wall ratio.
+const (
+	scanAmplificationHeadroom = 1.5
+	wallRatioHeadroom         = 2.5
+)
+
+// openScaleWallDB opens an in-process chDB database/sql handle, pinged.
+func openScaleWallDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("chdb", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.Ping(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec("CREATE DATABASE IF NOT EXISTS default"); err != nil {
+		t.Fatalf("create db: %v", err)
+	}
+	return db
+}
+
+// seedCounterAtScale builds the fixed-scale counter table and returns its
+// scan-row count (the PRONG-1 denominator). scaleSeedSeries instances each
+// carry a monotonically rising counter sampled every scaleSampleStepS.
+func seedCounterAtScale(t *testing.T, db *sql.DB) int64 {
+	t.Helper()
+	stmts := []string{
+		`DROP TABLE IF EXISTS otel_metrics_sum`,
+		`CREATE TABLE otel_metrics_sum (
+		  MetricName String, Attributes Map(String,String),
+		  TimeUnix DateTime64(9), Value Float64
+		) ENGINE = MergeTree() ORDER BY (MetricName, Attributes, TimeUnix)`,
+		`INSERT INTO otel_metrics_sum SELECT
+		  '` + scaleRateMetric + `',
+		  map('instance', concat('i', toString(number % ` + itoa(scaleSeedSeries) + `))),
+		  toDateTime64('2026-01-01 00:00:00', 9)
+		    + toIntervalSecond((intDiv(number, ` + itoa(scaleSeedSeries) + `)) * ` + itoa(scaleSampleStepS) + `),
+		  toFloat64(number)
+		FROM numbers(` + itoa(scaleSeedRows) + `)`,
+	}
+	for _, s := range stmts {
+		if _, err := db.Exec(s); err != nil {
+			t.Fatalf("seed: %v\n%s", err, s)
+		}
+	}
+	var scanRows int64
+	if err := db.QueryRow(`SELECT count() FROM otel_metrics_sum`).Scan(&scanRows); err != nil {
+		t.Fatalf("scan-row count: %v", err)
+	}
+	if scanRows <= 0 {
+		t.Fatalf("seed produced no rows — the pin is mis-seeded")
+	}
+	return scanRows
+}
+
+// emitRateRangeSQL lowers the representative query_range query through the
+// REAL parse -> lower -> optimizer.Default().Run -> emit chain (the same
+// chain the HTTP path runs), so the SQL the pin times is the production
+// shape. The eval grid is 1h at scaleSampleStepS step.
+func emitRateRangeSQL(t *testing.T) (string, []any) {
+	t.Helper()
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(1 * time.Hour)
+	step := time.Duration(scaleSampleStepS) * time.Second
+
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	expr, err := p.ParseExpr(scaleQueryRangeQL)
+	if err != nil {
+		t.Fatalf("ParseExpr: %v", err)
+	}
+	plan, err := promql.LowerAtRange(context.Background(), expr, schema.DefaultOTelMetrics(), start, end, step)
+	if err != nil {
+		t.Fatalf("LowerAtRange: %v", err)
+	}
+	plan = optimizer.Default().Run(context.Background(), plan)
+	sqlText, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	return sqlText, args
+}
+
+// yardstickSQL is the in-run PRONG-2 reference: a bare groupArray/arraySort
+// window-pairing aggregate over the SAME counter scan. It exercises the same
+// array machinery (groupArray of (TimeUnix, Value) tuples + arraySort per
+// series) the rate query's inner window stage does, but carries NO anchor
+// fan-out — so a #97-style fan-out / CPU regression in the rate path widens
+// the (query / yardstick) ratio without moving the yardstick. Bare SQL is
+// acceptable here: it is a test-local timing reference, NOT part of the
+// lowering path under test (which goes through the typed chsql emitter).
+func yardstickSQL() string {
+	return `SELECT max(length(window_pairs)) FROM (
+	  SELECT Attributes, arraySort(groupArray((TimeUnix, Value))) AS window_pairs
+	  FROM otel_metrics_sum WHERE MetricName = '` + scaleRateMetric + `'
+	  GROUP BY Attributes)`
+}
+
+// countLevel runs `count() FROM (<level>)` and returns the count. ok=false
+// when the level can't be counted standalone (e.g. it references an
+// out-of-scope CTE name) — the caller skips it, exactly as the corpus
+// profiler does.
+func countLevel(t *testing.T, db *sql.DB, level string, args []any) (int64, bool) {
+	t.Helper()
+	var c int64
+	if err := db.QueryRow("SELECT count() FROM ("+level+")", args...).Scan(&c); err != nil {
+		return 0, false
+	}
+	return c, true
+}
+
+// bestOfWall times `q` `iters` times and returns the fastest wall (the floor
+// strips GC / scheduler jitter — the floor is what the ratio compares).
+func bestOfWall(t *testing.T, db *sql.DB, q string, args []any, iters int) time.Duration {
+	t.Helper()
+	if iters <= 0 {
+		iters = scaleWallIters
+	}
+	// One untimed warm-up so first-call codegen / page faults / mark-tables
+	// don't land inside the sampled minimum.
+	var warm int64
+	if err := db.QueryRow(q, args...).Scan(&warm); err != nil {
+		t.Fatalf("warm-up query: %v\nSQL: %s", err, q)
+	}
+	best := time.Hour
+	for i := 0; i < iters; i++ {
+		s := time.Now()
+		var c int64
+		if err := db.QueryRow(q, args...).Scan(&c); err != nil {
+			t.Fatalf("wall query: %v\nSQL: %s", err, q)
+		}
+		if d := time.Since(s); d < best {
+			best = d
+		}
+	}
+	return best
+}
+
+// stripTrailingScaleSemi drops a trailing `;` / whitespace so the emitted
+// statement embeds as a `count() FROM (...)` subquery.
+func stripTrailingScaleSemi(s string) string {
+	for len(s) > 0 && (s[len(s)-1] == ';' || s[len(s)-1] == '\n' || s[len(s)-1] == ' ') {
+		s = s[:len(s)-1]
+	}
+	return s
+}
+
+// itoa is strconv.Itoa for an int — local helper so the seed builder reads
+// without an import alias collision in this package.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}
+
+// ceilTo rounds x UP to the nearest multiple of `unit` so a regenerated
+// bound is a clean, stable ceiling rather than a brittle float transcription.
+func ceilTo(x, unit float64) float64 {
+	if unit <= 0 {
+		return x
+	}
+	n := x / unit
+	r := float64(int64(n))
+	if n > r {
+		r++
+	}
+	return r * unit
+}
+
+// writeScaleWallBaseline serialises the bound pair as pretty JSON (trailing
+// newline) so the committed file diffs cleanly.
+func writeScaleWallBaseline(t *testing.T, b scaleWallBaseline) {
+	t.Helper()
+	buf, err := json.MarshalIndent(b, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal baseline: %v", err)
+	}
+	buf = append(buf, '\n')
+	if err := os.WriteFile(scaleWallBaselinePath, buf, 0o644); err != nil {
+		t.Fatalf("write baseline: %v", err)
+	}
+}
+
+// loadScaleWallBaseline reads the committed bound pair.
+func loadScaleWallBaseline(t *testing.T) scaleWallBaseline {
+	t.Helper()
+	buf, err := os.ReadFile(scaleWallBaselinePath)
+	if err != nil {
+		t.Fatalf("read baseline %s: %v — run `just update-scale-wall-baseline` to create it",
+			scaleWallBaselinePath, err)
+	}
+	var b scaleWallBaseline
+	if err := json.Unmarshal(buf, &b); err != nil {
+		t.Fatalf("parse baseline %s: %v", scaleWallBaselinePath, err)
+	}
+	if b.ScanAmplificationBound <= 0 || b.WallRatioBound <= 0 {
+		t.Fatalf("baseline %s has a non-positive bound (amplification=%.2f, wall_ratio=%.2f) — regenerate it",
+			scaleWallBaselinePath, b.ScanAmplificationBound, b.WallRatioBound)
+	}
+	return b
+}


### PR DESCRIPTION
## The gap

`test/perf/cardinality_ratchet_test.go` pins only `fan_factor =
peak_intermediate/scan_rows` and **deliberately excludes timing** as
environment-noisy. That blind spot let two real, separately-catalogued perf
regressions through:

- **#97 (ASOF rate path):** `fan_factor` *dropped* to 1.0 — cardinality fell —
  while wall went **6.31s → 36.90s**. A CPU-bound blow-up with flat/falling
  cardinality is invisible to a cardinality-only ratchet.
- **anchor-grid sharding regression:** per-statement cardinality stayed flat,
  but the query read **8× the rows** (40M vs 5M). A scan amplification that
  holds final result cardinality constant is likewise invisible.

## What this adds

`TestScaleWallPin` (chdb-tagged, rides the already-required `perf-guards` job
via `just perf-chdb`). A representative OOM-class query —
`sum(rate(http_requests_total[5m]))` `query_range` over a counter table seeded
at 300k rows / 300 series — run through the **real pipeline** (`parse → lower →
optimizer.Default().Run → emit → chDB exec`). Two prongs, one per regression
class:

### PRONG 1 — deterministic scan-amplification pin (zero tolerance)

Decomposes the **emitted SQL** into its FROM-source pipeline levels (via
`profile.FromSourceLevels` — the *same* decomposition the corpus ratchet uses,
now exported so there's one source of truth) and counts each over the
seeded-at-scale table. Asserts **peak intermediate cardinality ≤
`scan_amplification_bound` × scan_rows**. The 8×-scan sharding class blows past
the bound and fails immediately. Pure row counts → fully deterministic
(measured **exactly 4.63× every run**). This is the primary guard.

### PRONG 2 — ratio-based wall pin (catches #97's 6×)

best-of-9 wall of the real query ÷ best-of-9 wall of an **in-run yardstick**: a
bare `groupArray`/`arraySort` window-pairing aggregate over the *same* scan
that does comparable per-row array machinery but carries **no anchor fan-out**.
Both timings ride the same engine in the same process, so **machine speed AND
the CGO/chDB call overhead cancel** in the ratio — a ratio-of-walls with no
absolute-ms threshold, so it does not flap across runners. A #97-class 6× CPU
regression pushes the ratio ~6× past baseline and trips it.

## Robustness (verified — a flaky perf gate is worse than none)

Calibrated on the chDB runner. PRONG 1 is deterministic (4.63× every run).
PRONG 2 ratio over **10 separate-process runs** stayed **4.30–5.29** (N=9
best-of + an untimed warm-up tightened it from an earlier best-of-5 spike of
8.06). Committed bounds: `scan_amplification_bound: 7` (4.63 × 1.5 headroom),
`wall_ratio_bound: 12` (~4.6 × 2.5 headroom) — generous enough that 2–3× CI
variance passes, tight enough that the targeted regressions fail hard. A
negative test (tightening both bounds below the measured values) confirms both
prongs fire with actionable messages.

## Baseline + recipe

Bounds live in `test/perf/scale-wall-baseline.json`;
`just update-scale-wall-baseline` regenerates them (mirrors
`update-cardinality-baseline`, chDB-gated, prints the diff for review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)