### PR TITLE
test(chsql,chplan): kill LIVED mutants from the typed-Frag sweep, restore efficacy >95%

### DIFF
--- a/internal/chplan/gremlins_kill_test.go
+++ b/internal/chplan/gremlins_kill_test.go
@@ -1,0 +1,401 @@
+package chplan_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// This file gathers targeted tests that kill the LIVED gremlins mutants
+// reported by the phase-1 mutation matrix in
+// `.github/workflows/mutation.yml` (`./internal/chplan @ 95%`). Each
+// test pins the exact behaviour a single mutation would break:
+//
+//   - An INVERT_LOGICAL on a `||`/`&&` inside an `Equal` method needs a
+//     case where EXACTLY ONE operand is true (a single field differs,
+//     all others equal). With the original operator the nodes are not
+//     Equal; flipping `||`→`&&` would wrongly report Equal because the
+//     other (equal) field makes the `&&` short-circuit elsewhere.
+//   - An ARITHMETIC_BASE / INVERT_NEGATIVES on the membership-window
+//     widen (`start - Offset - Lookback`) needs a nested node so the
+//     widened start is recorded and asserted against the exact value.
+//   - An INVERT_LOGICAL on the reanchor grid-prediction guards needs a
+//     partially-pinned node (one bound zero / one bound on-grid) so the
+//     `&&` and `||` forms diverge.
+//
+// These mirror the per-node `*_Equal_Negative_*` convention already in
+// equal_invariants_test.go; they sit here as a single mutation-budget
+// file so the kill set is easy to audit against the gremlins report.
+
+// --- cross_join.go:27:30 — `Left.Equal(o.Left) && Right.Equal(o.Right)` ---
+
+// TestCrossJoin_Equal_Negative_RightOnly / _LeftOnly exercise the
+// `Left && Right` tail of CrossJoin.Equal. A mutant flipping `&&` to
+// `||` would falsely report Equal when only one child differs, because
+// the matching child's Equal returns true.
+func TestCrossJoin_Equal_Negative_RightOnly(t *testing.T) {
+	t.Parallel()
+	a := &chplan.CrossJoin{Left: &chplan.Scan{Table: "shared"}, Right: &chplan.Scan{Table: "a"}}
+	b := &chplan.CrossJoin{Left: &chplan.Scan{Table: "shared"}, Right: &chplan.Scan{Table: "b"}}
+	if a.Equal(b) {
+		t.Errorf("CrossJoin: different Right (Left equal) should not be Equal")
+	}
+}
+
+func TestCrossJoin_Equal_Negative_LeftOnly(t *testing.T) {
+	t.Parallel()
+	a := &chplan.CrossJoin{Left: &chplan.Scan{Table: "a"}, Right: &chplan.Scan{Table: "shared"}}
+	b := &chplan.CrossJoin{Left: &chplan.Scan{Table: "b"}, Right: &chplan.Scan{Table: "shared"}}
+	if a.Equal(b) {
+		t.Errorf("CrossJoin: different Left (Right equal) should not be Equal")
+	}
+}
+
+// TestCrossJoin_Equal_Positive anchors the true case so the negatives
+// above are genuine single-field divergences off an otherwise-equal pair.
+func TestCrossJoin_Equal_Positive(t *testing.T) {
+	t.Parallel()
+	a := &chplan.CrossJoin{Left: &chplan.Scan{Table: "l"}, Right: &chplan.Scan{Table: "r"}}
+	b := &chplan.CrossJoin{Left: &chplan.Scan{Table: "l"}, Right: &chplan.Scan{Table: "r"}}
+	if !a.Equal(b) {
+		t.Errorf("identical CrossJoin trees should be Equal")
+	}
+}
+
+// --- nary_vector_set_op.go Equal disjunct chains ---
+
+func naryFixture() *chplan.NaryVectorSetOp {
+	return &chplan.NaryVectorSetOp{
+		Arms:             []chplan.Node{&chplan.Scan{Table: "a"}, &chplan.Scan{Table: "b"}},
+		Op:               chplan.VectorSetOr,
+		Match:            chplan.VectorMatch{Labels: []string{"job"}, On: true},
+		MetricNameColumn: "MetricName",
+		AttributesColumn: "Attributes",
+		TimestampColumn:  "TimeUnix",
+		ValueColumn:      "Value",
+	}
+}
+
+func TestNaryVectorSetOp_Equal_Positive(t *testing.T) {
+	t.Parallel()
+	if !naryFixture().Equal(naryFixture()) {
+		t.Errorf("identical NaryVectorSetOp trees should be Equal")
+	}
+}
+
+// TestNaryVectorSetOp_Equal_Negative_Fields exercises each disjunct in
+// NaryVectorSetOp.Equal individually:
+//   - nary_vector_set_op.go:72 — `Op != || !Match.Equal`
+//   - nary_vector_set_op.go:75/76/77 — the
+//     `MetricNameColumn != || AttributesColumn != || TimestampColumn !=
+//     || ValueColumn !=` chain
+//
+// Each row diverges in exactly ONE field; with `||` → `&&` the mutant
+// would require every column to differ before reporting not-Equal, so a
+// single-field mismatch keeps the kill tight.
+func TestNaryVectorSetOp_Equal_Negative_Fields(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		mutate func(n *chplan.NaryVectorSetOp)
+	}{
+		{"op", func(n *chplan.NaryVectorSetOp) { n.Op = chplan.VectorSetAnd }},
+		{"match", func(n *chplan.NaryVectorSetOp) {
+			n.Match = chplan.VectorMatch{Labels: []string{"instance"}, On: true}
+		}},
+		{"metricNameColumn", func(n *chplan.NaryVectorSetOp) { n.MetricNameColumn = "Other" }},
+		{"attributesColumn", func(n *chplan.NaryVectorSetOp) { n.AttributesColumn = "Other" }},
+		{"timestampColumn", func(n *chplan.NaryVectorSetOp) { n.TimestampColumn = "Other" }},
+		{"valueColumn", func(n *chplan.NaryVectorSetOp) { n.ValueColumn = "Other" }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			a, b := naryFixture(), naryFixture()
+			tc.mutate(b)
+			if a.Equal(b) || b.Equal(a) {
+				t.Errorf("NaryVectorSetOp.Equal must detect %s divergence", tc.name)
+			}
+		})
+	}
+}
+
+// --- range_bucket_fanout.go Equal disjunct chains ---
+
+func fanoutFixture() *chplan.RangeBucketFanout {
+	return &chplan.RangeBucketFanout{
+		Input:          &chplan.Scan{Table: "metrics"},
+		Start:          time.Unix(1000, 0).UTC(),
+		End:            time.Unix(4600, 0).UTC(),
+		Step:           30 * time.Second,
+		Lookback:       5 * time.Minute,
+		Offset:         time.Minute,
+		GroupBy:        []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+		GroupByAliases: []string{"g0"},
+		AggFuncs:       []chplan.AggFunc{{Name: "sum", Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}, Alias: "BucketCounts"}},
+		AnchorAlias:    "anchor_ts",
+		TimestampCol:   "TimeUnix",
+	}
+}
+
+func TestRangeBucketFanout_Equal_Positive(t *testing.T) {
+	t.Parallel()
+	if !fanoutFixture().Equal(fanoutFixture()) {
+		t.Errorf("identical RangeBucketFanout trees should be Equal")
+	}
+}
+
+// TestRangeBucketFanout_Equal_Negative_Fields exercises each `||`
+// disjunct in RangeBucketFanout.Equal one field at a time:
+//   - 99  — `!Start.Equal || !End.Equal`
+//   - 102 — `Step != || Lookback != || Offset !=`
+//   - 105 — `AnchorAlias != || TimestampCol !=`
+//   - 108 — `len(GroupBy) != || len(AggFuncs) !=`
+//
+// Single-field divergence means `||` → `&&` (which needs both sides of
+// a disjunct true) wrongly reports Equal — caught here.
+func TestRangeBucketFanout_Equal_Negative_Fields(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		mutate func(r *chplan.RangeBucketFanout)
+	}{
+		{"start", func(r *chplan.RangeBucketFanout) { r.Start = r.Start.Add(time.Second) }},
+		{"end", func(r *chplan.RangeBucketFanout) { r.End = r.End.Add(time.Second) }},
+		{"step", func(r *chplan.RangeBucketFanout) { r.Step = time.Minute }},
+		{"lookback", func(r *chplan.RangeBucketFanout) { r.Lookback = time.Hour }},
+		{"offset", func(r *chplan.RangeBucketFanout) { r.Offset = 2 * time.Minute }},
+		{"anchorAlias", func(r *chplan.RangeBucketFanout) { r.AnchorAlias = "other_anchor" }},
+		{"timestampCol", func(r *chplan.RangeBucketFanout) { r.TimestampCol = "Other" }},
+		{"groupByLen", func(r *chplan.RangeBucketFanout) {
+			r.GroupBy = append(r.GroupBy, &chplan.ColumnRef{Name: "Extra"})
+		}},
+		{"aggFuncsLen", func(r *chplan.RangeBucketFanout) {
+			r.AggFuncs = append(r.AggFuncs, chplan.AggFunc{Name: "count", Alias: "Extra"})
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			a, b := fanoutFixture(), fanoutFixture()
+			tc.mutate(b)
+			if a.Equal(b) || b.Equal(a) {
+				t.Errorf("RangeBucketFanout.Equal must detect %s divergence", tc.name)
+			}
+		})
+	}
+}
+
+// TestRangeBucketFanout_Equal_Negative_InputOneNil pins the `Input ==
+// nil || o.Input == nil` short-circuit (range_bucket_fanout.go:129). A
+// `||` → `&&` flip would skip the early-out when exactly one Input is
+// nil, walking into Input.Equal on a nil receiver / mis-reporting.
+func TestRangeBucketFanout_Equal_Negative_InputOneNil(t *testing.T) {
+	t.Parallel()
+	a := fanoutFixture()
+	b := fanoutFixture()
+	b.Input = nil
+	if a.Equal(b) {
+		t.Errorf("non-nil Input vs nil Input should not be Equal")
+	}
+	if b.Equal(a) {
+		t.Errorf("nil Input vs non-nil Input should not be Equal (reverse)")
+	}
+}
+
+// --- step_grid.go:38 — `Start.Equal && End.Equal && Step ==` ---
+
+func TestStepGrid_Equal_Positive(t *testing.T) {
+	t.Parallel()
+	g := func() *chplan.StepGrid {
+		return &chplan.StepGrid{
+			Start: time.Unix(1000, 0).UTC(),
+			End:   time.Unix(4600, 0).UTC(),
+			Step:  time.Minute,
+		}
+	}
+	if !g().Equal(g()) {
+		t.Errorf("identical StepGrid should be Equal")
+	}
+}
+
+// TestStepGrid_Equal_Negative_Fields exercises each `&&` conjunct in
+// StepGrid.Equal singly. A `&&` → `||` flip would report Equal when two
+// of the three fields match and one differs; single-field divergence
+// catches each conjunct (Start, End, Step).
+func TestStepGrid_Equal_Negative_Fields(t *testing.T) {
+	t.Parallel()
+	base := chplan.StepGrid{
+		Start: time.Unix(1000, 0).UTC(),
+		End:   time.Unix(4600, 0).UTC(),
+		Step:  time.Minute,
+	}
+	cases := []struct {
+		name   string
+		mutate func(g *chplan.StepGrid)
+	}{
+		{"start", func(g *chplan.StepGrid) { g.Start = g.Start.Add(time.Second) }},
+		{"end", func(g *chplan.StepGrid) { g.End = g.End.Add(time.Second) }},
+		{"step", func(g *chplan.StepGrid) { g.Step = 2 * time.Minute }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			a := base
+			b := base
+			tc.mutate(&b)
+			if a.Equal(&b) || b.Equal(&a) {
+				t.Errorf("StepGrid.Equal must detect %s divergence", tc.name)
+			}
+		})
+	}
+}
+
+// --- reanchor.go widen arithmetic + grid-prediction guards ---
+
+// TestReanchorRange_LWRWidenArithmetic kills the membership-window widen
+// math at reanchor.go:126 — `start.Add(-v.Offset - v.Lookback)`. The
+// outer RangeLWR's Input is itself an (unpinned) RangeLWR, so the
+// widened start is RECORDED as the inner node's Start and can be
+// asserted exactly. Offset and Lookback are distinct non-zero durations
+// so that:
+//   - ARITHMETIC_BASE (`-` → `+`) on either subtraction shifts the
+//     widened start by 2*Offset or 2*Lookback, and
+//   - INVERT_NEGATIVES (`-v.Offset` → `v.Offset`, `-v.Lookback` →
+//     `v.Lookback`) flips the sign of one term,
+//
+// all of which move the inner Start off the asserted value.
+func TestReanchorRange_LWRWidenArithmetic(t *testing.T) {
+	t.Parallel()
+
+	const (
+		offset   = 90 * time.Second
+		lookback = 7 * time.Minute
+	)
+	inner := &chplan.RangeLWR{
+		Input:         &chplan.Scan{Table: "metrics"},
+		Step:          time.Minute, // Step > 0 so the inner participates in the grid
+		Lookback:      2 * time.Minute,
+		Offset:        0,
+		MetricNameCol: "MetricName",
+		AttributesCol: "Attributes",
+		TimestampCol:  "TimeUnix",
+		ValueCol:      "Value",
+		// Start/End left zero → unpinned, accepted by the grid check.
+	}
+	outer := &chplan.RangeLWR{
+		Input:         inner,
+		Step:          time.Minute,
+		Lookback:      lookback,
+		Offset:        offset,
+		MetricNameCol: "MetricName",
+		AttributesCol: "Attributes",
+		TimestampCol:  "TimeUnix",
+		ValueCol:      "Value",
+		// Outer unpinned too.
+	}
+
+	start := time.Unix(100_000, 0).UTC()
+	end := time.Unix(200_000, 0).UTC()
+	out, err := chplan.ReanchorRange(outer, start, end)
+	if err != nil {
+		t.Fatalf("ReanchorRange: %v", err)
+	}
+	gotOuter := out.(*chplan.RangeLWR)
+	gotInner := gotOuter.Input.(*chplan.RangeLWR)
+
+	// The inner spine is reanchored to start - Offset - Lookback (and end).
+	wantInnerStart := start.Add(-offset - lookback)
+	if !gotInner.Start.Equal(wantInnerStart) {
+		t.Fatalf("inner widen start wrong: want %v (start - %v - %v), got %v",
+			wantInnerStart, offset, lookback, gotInner.Start)
+	}
+	if !gotInner.End.Equal(end) {
+		t.Fatalf("inner end wrong: want %v, got %v", end, gotInner.End)
+	}
+}
+
+// TestReanchorRange_RejectsPartialPin kills the matrix-window grid guards
+// at reanchor.go:185 (`Start.IsZero() && End.IsZero()`). A partially-
+// pinned node — Start zero, End pinned OFF the predicted grid — must be
+// rejected with ErrReanchorGridMismatch. With `&&` → `||` the unpinned
+// early-return would fire (Start.IsZero() alone is enough), wrongly
+// accepting the off-grid End.
+func TestReanchorRange_RejectsPartialPin(t *testing.T) {
+	t.Parallel()
+
+	in := matrixWindowKill(5*time.Minute, time.Minute, time.Hour)
+	in.Start = time.Time{}            // zero
+	in.End = time.Unix(9999, 0).UTC() // pinned, NOT the predicted grid end
+
+	start := time.Unix(1000, 0).UTC()
+	end := time.Unix(4600, 0).UTC()
+	if _, err := chplan.ReanchorRange(in, start, end); !errors.Is(err, chplan.ErrReanchorGridMismatch) {
+		t.Fatalf("partially-pinned matrix window should be rejected, got %v", err)
+	}
+}
+
+// TestReanchorRange_LWRRejectsPartialPinZeroStart kills the LWR
+// unpinned guard at reanchor.go:209 (`Start.IsZero() && End.IsZero()`):
+// Start zero, End off-grid → reject. `&&` → `||` would accept on the
+// zero Start alone.
+func TestReanchorRange_LWRRejectsPartialPinZeroStart(t *testing.T) {
+	t.Parallel()
+
+	in := lwrNodeKill(time.Time{}, time.Unix(9999, 0).UTC(), time.Minute, 5*time.Minute, 0)
+	start := time.Unix(1000, 0).UTC()
+	end := time.Unix(4600, 0).UTC()
+	if _, err := chplan.ReanchorRange(in, start, end); !errors.Is(err, chplan.ErrReanchorGridMismatch) {
+		t.Fatalf("LWR with zero Start + off-grid End should be rejected, got %v", err)
+	}
+}
+
+// TestReanchorRange_LWRRejectsGriddedStartOffGridEnd kills the LWR
+// already-gridded guard at reanchor.go:212 (`Start.Equal(predStart) &&
+// End.Equal(predEnd)`): Start sits exactly on the predicted grid but End
+// diverges → reject. With `&&` → `||` the matching Start alone would
+// satisfy the guard and wrongly accept the off-grid End.
+func TestReanchorRange_LWRRejectsGriddedStartOffGridEnd(t *testing.T) {
+	t.Parallel()
+
+	start := time.Unix(1000, 0).UTC()
+	end := time.Unix(4600, 0).UTC()
+	// Start == the predicted grid start; End pinned off-grid.
+	in := lwrNodeKill(start, time.Unix(9999, 0).UTC(), time.Minute, 5*time.Minute, 0)
+	if _, err := chplan.ReanchorRange(in, start, end); !errors.Is(err, chplan.ErrReanchorGridMismatch) {
+		t.Fatalf("LWR with on-grid Start + off-grid End should be rejected, got %v", err)
+	}
+}
+
+// matrixWindowKill / lwrNodeKill are local fixture builders for the
+// reanchor kills above — kept self-contained in this file so the kill
+// set does not depend on helper signatures in reanchor_test.go.
+func matrixWindowKill(rang, step, outerRange time.Duration) *chplan.RangeWindow {
+	return &chplan.RangeWindow{
+		Input:           &chplan.Scan{Table: "metrics", Columns: []string{"Value", "TimeUnix"}},
+		Func:            "rate",
+		Range:           rang,
+		Step:            step,
+		OuterRange:      outerRange,
+		TimestampColumn: "TimeUnix",
+		ValueColumn:     "Value",
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+	}
+}
+
+func lwrNodeKill(start, end time.Time, step, lookback, offset time.Duration) *chplan.RangeLWR {
+	return &chplan.RangeLWR{
+		Input:         &chplan.Scan{Table: "metrics", Columns: []string{"Value", "TimeUnix"}},
+		Start:         start,
+		End:           end,
+		Step:          step,
+		Lookback:      lookback,
+		Offset:        offset,
+		MetricNameCol: "MetricName",
+		AttributesCol: "Attributes",
+		TimestampCol:  "TimeUnix",
+		ValueCol:      "Value",
+	}
+}

--- a/internal/chplan/metrics_compare_test.go
+++ b/internal/chplan/metrics_compare_test.go
@@ -60,6 +60,14 @@ func TestMetricsCompare_Equal_Negative_Fields(t *testing.T) {
 		}},
 		{"pairsNil", func(m *chplan.MetricsCompare) { m.Pairs = nil }},
 		{"rootLookupNil", func(m *chplan.MetricsCompare) { m.RootLookup = nil }},
+		// Both RootLookups non-nil but with different content. Kills the
+		// CONDITIONALS_NEGATION at metrics_compare.go (the `!m.RootLookup.Equal`
+		// guard): dropping the `!` would make divergent-but-present RootLookups
+		// fall through to "equal". rootLookupNil only exercises the nil-mismatch
+		// guard a line above; this exercises the content comparison.
+		{"rootLookupContent", func(m *chplan.MetricsCompare) {
+			m.RootLookup = &chplan.Scan{Table: "different_root_lookup"}
+		}},
 		{"traceIDColumn", func(m *chplan.MetricsCompare) { m.TraceIDColumn = "Other" }},
 		{"rootNameAlias", func(m *chplan.MetricsCompare) { m.RootNameAlias = "x" }},
 		{"rootServiceAlias", func(m *chplan.MetricsCompare) { m.RootServiceAlias = "x" }},

--- a/internal/chplan/range_lwr_test.go
+++ b/internal/chplan/range_lwr_test.go
@@ -69,6 +69,73 @@ func TestRangeLWR_Equal_Negative_Cols(t *testing.T) {
 	}
 }
 
+// TestRangeLWR_Equal_Negative_Start / _End pin the `!Start.Equal ||
+// !End.Equal` disjunct: flipping the `||` to `&&` would only report a
+// divergence when BOTH bounds differ, so a single-bound mismatch must
+// still come back not-Equal. (The Step/Offset/Lookback cases above sit
+// on a different line; this one is the time-bound clause.)
+func TestRangeLWR_Equal_Negative_Start(t *testing.T) {
+	t.Parallel()
+	a := newRangeLWR()
+	b := newRangeLWR()
+	b.Start = b.Start.Add(time.Second) // End stays equal
+	if a.Equal(b) {
+		t.Errorf("different Start (End equal) should not be Equal")
+	}
+}
+
+func TestRangeLWR_Equal_Negative_End(t *testing.T) {
+	t.Parallel()
+	a := newRangeLWR()
+	b := newRangeLWR()
+	b.End = b.End.Add(time.Second) // Start stays equal
+	if a.Equal(b) {
+		t.Errorf("different End (Start equal) should not be Equal")
+	}
+}
+
+// TestRangeLWR_Equal_Negative_MetricNameCol / _AttributesCol pin the
+// `MetricNameCol != || AttributesCol !=` disjunct (a different line
+// from the ValueCol case above). `||` → `&&` would require both columns
+// to differ before reporting not-Equal.
+func TestRangeLWR_Equal_Negative_MetricNameCol(t *testing.T) {
+	t.Parallel()
+	a := newRangeLWR()
+	b := newRangeLWR()
+	b.MetricNameCol = "OtherMetricName" // AttributesCol stays equal
+	if a.Equal(b) {
+		t.Errorf("different MetricNameCol (AttributesCol equal) should not be Equal")
+	}
+}
+
+func TestRangeLWR_Equal_Negative_AttributesCol(t *testing.T) {
+	t.Parallel()
+	a := newRangeLWR()
+	b := newRangeLWR()
+	b.AttributesCol = "OtherAttributes" // MetricNameCol stays equal
+	if a.Equal(b) {
+		t.Errorf("different AttributesCol (MetricNameCol equal) should not be Equal")
+	}
+}
+
+// TestRangeLWR_Equal_Negative_InputOneNil pins the `Input == nil ||
+// o.Input == nil` short-circuit: one side has a nil Input, the other a
+// real one. `||` → `&&` would skip the early-out and walk into
+// Input.Equal on a nil receiver (or mis-report equality), so the nodes
+// must come back not-Equal both ways.
+func TestRangeLWR_Equal_Negative_InputOneNil(t *testing.T) {
+	t.Parallel()
+	a := newRangeLWR()
+	b := newRangeLWR()
+	b.Input = nil
+	if a.Equal(b) {
+		t.Errorf("non-nil Input vs nil Input should not be Equal")
+	}
+	if b.Equal(a) {
+		t.Errorf("nil Input vs non-nil Input should not be Equal (reverse)")
+	}
+}
+
 func TestRangeLWR_Equal_Negative_Input(t *testing.T) {
 	t.Parallel()
 	a := newRangeLWR()

--- a/internal/chsql/gremlins_kill_test.go
+++ b/internal/chsql/gremlins_kill_test.go
@@ -3702,3 +3702,333 @@ func TestEmitStructuralSiblingJoin_Succeeds(t *testing.T) {
 		}
 	}
 }
+
+// =====================================================================
+// Phase-2 (chsql) LIVED-mutant kills from the push-to-main mutation run
+// 27469747395 (commit fef5109a). The typed-Frag sweep (#850) plus
+// accumulated test-quality gaps left 40 LIVED chsql mutants — efficacy
+// 94.13% < the 95% bar. The block below kills the clearly-killable set
+// (validation disjunct chains, off-by-one / sign boundaries on the
+// emitted SQL, and the computed-phi / qualifier branches), each by
+// asserting the EXACT emitted SQL or error so the mutated operator
+// produces observably-different output.
+// =====================================================================
+
+// --- range_lwr.go column-validation disjunct (65:26/46/71) ---
+
+// TestEmitRangeLWR_EachColumnEmptyErrors kills the INVERT_LOGICAL
+// mutants on the `TimestampCol == "" || ValueCol == "" || MetricNameCol
+// == "" || AttributesCol == ""` validation chain. Each case blanks
+// exactly ONE column; `||` → `&&` would require every column blank
+// before erroring, so a single missing name must still be rejected.
+func TestEmitRangeLWR_EachColumnEmptyErrors(t *testing.T) {
+	t.Parallel()
+	base := func() *chplan.RangeLWR {
+		return &chplan.RangeLWR{
+			Input:         &chplan.Scan{Table: "otel_metrics_gauge"},
+			Step:          30 * time.Second,
+			MetricNameCol: "MetricName",
+			AttributesCol: "Attributes",
+			TimestampCol:  "TimeUnix",
+			ValueCol:      "Value",
+		}
+	}
+	cases := []struct {
+		name  string
+		blank func(r *chplan.RangeLWR)
+	}{
+		{"timestamp", func(r *chplan.RangeLWR) { r.TimestampCol = "" }},
+		{"value", func(r *chplan.RangeLWR) { r.ValueCol = "" }},
+		{"metricName", func(r *chplan.RangeLWR) { r.MetricNameCol = "" }},
+		{"attributes", func(r *chplan.RangeLWR) { r.AttributesCol = "" }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r := base()
+			tc.blank(r)
+			if _, _, err := Emit(context.Background(), r); err == nil {
+				t.Errorf("RangeLWR with empty %s column must error", tc.name)
+			}
+		})
+	}
+}
+
+// --- range_lwr.go Start/End guard + span boundary (76:23, 78:11) ---
+
+// TestEmitRangeLWR_AnchorCountBounds kills two mutants in the anchor-
+// count computation:
+//   - 76:23 INVERT_LOGICAL on `!Start.IsZero() && !End.IsZero()`: with a
+//     pinned [Start,End] grid the anchor count is computed from the span
+//     (least(11, …)); the `&&` → `||` flip would still take the computed
+//     branch when only one bound is set, but more importantly the
+//     pinned-grid case below proves the computed branch runs (least(11)).
+//   - 78:11 CONDITIONALS_BOUNDARY on `span < 0` → `span <= 0`: a
+//     ZERO-span grid (Start == End) is legal — one anchor — and must NOT
+//     error; the `<=` mutant would reject it.
+func TestEmitRangeLWR_AnchorCountBounds(t *testing.T) {
+	t.Parallel()
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// Pinned grid → computed anchor count least(11, …) (5m / 30s + 1).
+	pinned := &chplan.RangeLWR{
+		Input:         &chplan.Scan{Table: "otel_metrics_gauge"},
+		Start:         start,
+		End:           start.Add(5 * time.Minute),
+		Step:          30 * time.Second,
+		Lookback:      5 * time.Minute,
+		MetricNameCol: "MetricName", AttributesCol: "Attributes",
+		TimestampCol: "TimeUnix", ValueCol: "Value",
+	}
+	sql, _, err := Emit(context.Background(), pinned)
+	if err != nil {
+		t.Fatalf("pinned-grid RangeLWR: %v", err)
+	}
+	if !strings.Contains(sql, "least(11,") {
+		t.Errorf("pinned [Start,End] grid must compute 11 anchors (least(11, …)); got:\n%s", sql)
+	}
+
+	// Zero-span grid (Start == End): exactly one anchor, must NOT error.
+	zeroSpan := &chplan.RangeLWR{
+		Input:         &chplan.Scan{Table: "otel_metrics_gauge"},
+		Start:         start,
+		End:           start, // span == 0
+		Step:          30 * time.Second,
+		Lookback:      5 * time.Minute,
+		MetricNameCol: "MetricName", AttributesCol: "Attributes",
+		TimestampCol: "TimeUnix", ValueCol: "Value",
+	}
+	zsSQL, _, err := Emit(context.Background(), zeroSpan)
+	if err != nil {
+		t.Fatalf("zero-span RangeLWR must emit (1 anchor), got error: %v", err)
+	}
+	if !strings.Contains(zsSQL, "least(1,") {
+		t.Errorf("zero-span grid must yield exactly one anchor (least(1, …)); got:\n%s", zsSQL)
+	}
+
+	// 76:23 INVERT_LOGICAL on `!Start.IsZero() && !End.IsZero()`: only
+	// when BOTH bounds are pinned is the span computed. With Start set
+	// but End zero the guard is false → single anchor, no span math, must
+	// emit cleanly. The `&&` → `||` mutant would enter the span branch on
+	// the zero End, computing a negative span and erroring.
+	oneBound := &chplan.RangeLWR{
+		Input:         &chplan.Scan{Table: "otel_metrics_gauge"},
+		Start:         start,
+		End:           time.Time{}, // zero
+		Step:          30 * time.Second,
+		Lookback:      5 * time.Minute,
+		MetricNameCol: "MetricName", AttributesCol: "Attributes",
+		TimestampCol: "TimeUnix", ValueCol: "Value",
+	}
+	obSQL, _, err := Emit(context.Background(), oneBound)
+	if err != nil {
+		t.Fatalf("RangeLWR with only Start pinned must emit (1 anchor), got error: %v", err)
+	}
+	if !strings.Contains(obSQL, "least(1,") {
+		t.Errorf("single pinned bound must yield exactly one anchor (least(1, …)); got:\n%s", obSQL)
+	}
+}
+
+// --- range_lwr.go lookback sign in the floor-index numerator (189:72) ---
+
+// TestEmitRangeLWR_LookbackSign kills the INVERT_NEGATIVES /
+// ARITHMETIC_BASE on `-lookbackNS` in the floor-index numerator. The
+// window floor walks BACK by the lookback, so the emitted numerator is
+// `dist - <lookbackNS>`; flipping the sign to `+ <lookbackNS>` (or
+// changing the op) would walk the window the wrong way and is caught by
+// the exact subtraction substring.
+func TestEmitRangeLWR_LookbackSign(t *testing.T) {
+	t.Parallel()
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	plan := &chplan.RangeLWR{
+		Input:         &chplan.Scan{Table: "otel_metrics_gauge"},
+		Start:         start,
+		End:           start.Add(5 * time.Minute),
+		Step:          30 * time.Second,
+		Lookback:      5 * time.Minute, // 300000000000 ns
+		MetricNameCol: "MetricName", AttributesCol: "Attributes",
+		TimestampCol: "TimeUnix", ValueCol: "Value",
+	}
+	sql, _, err := Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	// The floor numerator subtracts the lookback (greatest(0, intDiv(dist
+	// - lookbackNS, …))). A sign flip would render "+ 300000000000".
+	if !strings.Contains(sql, "- 300000000000, toInt64(30000000000)) - (modulo") {
+		t.Errorf("floor index must subtract the lookback (dist - 300000000000); got:\n%s", sql)
+	}
+	if strings.Contains(sql, "+ 300000000000") {
+		t.Errorf("lookback must be subtracted, never added; got:\n%s", sql)
+	}
+}
+
+// --- histogram_quantile_native.go computed-phi guard (196:15) ---
+
+// TestEmitHistogramQuantileNative_ComputedPhiNaNGuard kills the
+// CONDITIONALS_NEGATION on `if h.PhiExpr == nil`. With a computed phi
+// (PhiExpr set) the emitter wraps the core in an `isNaN(phi)` guard
+// (Prometheus's NaN-phi contract); the literal-phi path omits it. The
+// `== nil` → `!= nil` flip would swap which path gets the wrapper, so
+// the isNaN token must be PRESENT for computed phi and ABSENT for
+// literal phi.
+func TestEmitHistogramQuantileNative_ComputedPhiNaNGuard(t *testing.T) {
+	t.Parallel()
+	build := func(phiExpr chplan.Expr) string {
+		t.Helper()
+		plan := &chplan.HistogramQuantileNative{
+			Phi:                        0.9,
+			PhiExpr:                    phiExpr,
+			ScaleColumn:                "Scale",
+			ZeroCountColumn:            "ZeroCount",
+			PositiveOffsetColumn:       "PositiveOffset",
+			PositiveBucketCountsColumn: "PositiveBucketCounts",
+			NegativeOffsetColumn:       "NegativeOffset",
+			NegativeBucketCountsColumn: "NegativeBucketCounts",
+			Input:                      &chplan.Scan{Table: "otel_metrics_exp_histogram"},
+		}
+		sql, _, err := Emit(context.Background(), plan)
+		if err != nil {
+			t.Fatalf("Emit: %v", err)
+		}
+		return sql
+	}
+	computed := build(&chplan.FuncCall{Name: "scalar"})
+	if !strings.Contains(computed, "isNaN") {
+		t.Errorf("computed-phi native quantile must carry the isNaN NaN-guard; got:\n%s", computed)
+	}
+	literal := build(nil)
+	if strings.Contains(literal, "isNaN") {
+		t.Errorf("literal-phi native quantile must NOT carry the isNaN guard; got:\n%s", literal)
+	}
+}
+
+// --- nested_set_annotate.go optQualColFrag qualifier branch (410:10) ---
+
+// TestOptQualColFrag_QualifierBranch kills the CONDITIONALS_NEGATION on
+// `if qual == ""` in optQualColFrag: an empty qualifier renders the bare
+// `col`, a non-empty one renders `qual`.`col`. The `== ""` → `!= ""`
+// flip would swap the two branches.
+func TestOptQualColFrag_QualifierBranch(t *testing.T) {
+	t.Parallel()
+	render := func(f Frag) string {
+		b := &Builder{}
+		f(b)
+		return b.String()
+	}
+	if got := render(optQualColFrag("", "col")); got != "`col`" {
+		t.Errorf("empty qualifier should render bare `col`, got %q", got)
+	}
+	if got := render(optQualColFrag("c", "col")); got != "`c`.`col`" {
+		t.Errorf("non-empty qualifier should render `c`.`col`, got %q", got)
+	}
+}
+
+// --- structural_join.go nil-node guard (714:7) ---
+
+// TestSubtreeHasRecursiveStructural_NilGuard kills the
+// CONDITIONALS_NEGATION on `if n == nil { return false }`. A nil node
+// must short-circuit to false; the `== nil` → `!= nil` flip would skip
+// the early-out and call n.Children() on a nil node, panicking. The
+// test asserts the nil case returns false WITHOUT panicking.
+func TestSubtreeHasRecursiveStructural_NilGuard(t *testing.T) {
+	t.Parallel()
+	if subtreeHasRecursiveStructural(nil) {
+		t.Errorf("subtreeHasRecursiveStructural(nil) must be false")
+	}
+	// A non-recursive subtree (a bare Scan) must also be false — anchors
+	// the positive side so the nil case is a genuine early-out, not a
+	// blanket false.
+	if subtreeHasRecursiveStructural(&chplan.Scan{Table: "t"}) {
+		t.Errorf("subtreeHasRecursiveStructural(Scan) must be false")
+	}
+}
+
+// --- range_window.go over-time matrix anchor count + mode split ---
+
+// TestEmitRangeWindowOverTimeMatrix_AnchorArithmetic kills the
+// ARITHMETIC_BASE mutants on `OuterRange/Step + 1` (the anchor count) in
+// the direct-matrix over-time emitter. A 5m OuterRange at 30s Step is 11
+// anchors → `least(11, …)`; the `/` or `+1` mutation moves that count.
+func TestEmitRangeWindowOverTimeMatrix_AnchorArithmetic(t *testing.T) {
+	t.Parallel()
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	plan := &chplan.RangeWindow{
+		Input:           &chplan.Scan{Table: "otel_metrics_gauge"},
+		Func:            "max_over_time",
+		Range:           time.Minute,
+		Step:            30 * time.Second,
+		OuterRange:      5 * time.Minute, // 5m / 30s + 1 = 11
+		Start:           start,
+		End:             start.Add(5 * time.Minute),
+		TimestampColumn: "TimeUnix",
+		ValueColumn:     "Value",
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+	}
+	sql, _, err := Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if !strings.Contains(sql, "least(11,") {
+		t.Errorf("matrix over-time must compute 11 anchors (least(11, …)); got:\n%s", sql)
+	}
+	// The +1 mutation would yield 10; assert the off-by-one neighbour is absent.
+	if strings.Contains(sql, "least(10,") {
+		t.Errorf("anchor count must be 11, not 10 (off-by-one mutant); got:\n%s", sql)
+	}
+}
+
+// TestEmitRangeWindowOverTime_OuterRangeBoundary kills the
+// CONDITIONALS_BOUNDARY on `if r.OuterRange > 0` (instant vs matrix
+// mode). With OuterRange == 0 the emitter takes the INSTANT path — a
+// single windowed aggregate, NO anchor fan-out. The `> 0` → `>= 0`
+// mutant would wrongly route the instant case through the matrix
+// variant, introducing the `arrayJoin(arrayMap` / `least(` fan-out.
+func TestEmitRangeWindowOverTime_OuterRangeBoundary(t *testing.T) {
+	t.Parallel()
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	plan := &chplan.RangeWindow{
+		Input:           &chplan.Scan{Table: "otel_metrics_gauge"},
+		Func:            "max_over_time",
+		Range:           time.Minute,
+		Step:            30 * time.Second,
+		OuterRange:      0, // instant mode
+		End:             start.Add(5 * time.Minute),
+		TimestampColumn: "TimeUnix",
+		ValueColumn:     "Value",
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+	}
+	sql, _, err := Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if strings.Contains(sql, "arrayJoin(arrayMap(i ->") || strings.Contains(sql, "least(") {
+		t.Errorf("instant over-time (OuterRange=0) must NOT fan out across anchors; got:\n%s", sql)
+	}
+}
+
+// --- builder.go Window PARTITION-BY boundary (1575:23) ---
+
+// TestWindowFrag_PartitionByBoundary kills the CONDITIONALS_BOUNDARY on
+// `if len(partitionBy) > 0` inside the Window OVER frag. An empty
+// partition list must omit `PARTITION BY` entirely; the `> 0` → `>= 0`
+// mutant would emit a dangling `PARTITION BY ` with no columns.
+func TestWindowFrag_PartitionByBoundary(t *testing.T) {
+	t.Parallel()
+	render := func(f Frag) string {
+		b := &Builder{}
+		f(b)
+		return b.String()
+	}
+	with := render(Window(Call("row_number"), []Frag{Col("a")}, nil))
+	if !strings.Contains(with, "OVER (PARTITION BY `a`)") {
+		t.Errorf("non-empty partition list must render PARTITION BY; got %q", with)
+	}
+	without := render(Window(Call("row_number"), nil, nil))
+	if without != "row_number() OVER ()" {
+		t.Errorf("empty partition list must omit PARTITION BY entirely; got %q", without)
+	}
+	if strings.Contains(without, "PARTITION BY") {
+		t.Errorf("empty partition list must NOT emit a dangling PARTITION BY; got %q", without)
+	}
+}


### PR DESCRIPTION
## What

The push-to-main mutation run [27469747395](https://github.com/tsouza/cerberus/actions/runs/27469747395) (commit `fef5109a`, #850 — the `writeSQL` → typed-Frag sweep) dropped **both** per-package gremlins phases below the 95% efficacy gate:

| phase | package | efficacy | LIVED |
|-------|---------|----------|-------|
| phase1 | `internal/chplan` | **94.90%** | 24 |
| phase2 | `internal/chsql`  | **94.13%** | 40 |

The LIVED set is broader than just #850's recomposed emitters — it is accumulated test-quality gaps the per-package matrix surfaced: `Equal`-method disjunct chains, the reanchor grid-prediction guards, and emit-time boundary / sign arithmetic. This PR adds targeted kill-tests that pin the exact behaviour each surviving mutation would break, asserting concrete IR / SQL output so a flipped operator (inverted logical, negated conditional, boundary off-by-one, arithmetic-base / sign swap) produces observably-different output and fails the test. **Tests only — no source changes.**

Mirrors the precedent in #63 / #836 (kill LIVED chsql/optimizer mutants).

## chplan — all 24 LIVED killed → **100%** locally

The chplan gremlins run is timeout-free, so the local re-run (KILLED=477, LIVED=0, TIMED_OUT=0, efficacy 100%) is fully trustworthy. Mutants killed:

- **`Equal`-method `||`/`&&` chains** (per-field asymmetric negatives — exactly one field differs): `cross_join.go:27`, `nary_vector_set_op.go:72/75/76/77`, `range_bucket_fanout.go:99/102/105/108/129`, `range_lwr.go:77/83/89`, `step_grid.go:38`.
- **`metrics_compare.go:128`** — RootLookup content-divergence (the `!m.RootLookup.Equal(...)` guard; the existing table only had `rootLookupNil`, which hits the line above).
- **`reanchor.go`** — the membership-window widen arithmetic `start.Add(-Offset-Lookback)` (`126`, INVERT_NEGATIVES + ARITHMETIC_BASE; nested RangeLWR so the widened start is recorded and asserted exactly) and the partial-pin grid-prediction guards (`185`, `209`, `212`).

## chsql — 14 LIVED killed (injection-verified) → projected **~96.2%** (from 94.13%)

The local chsql gremlins run is dominated by per-mutant recompile timeouts on this machine (610 TIMED_OUT, only 72 KILLED), so it can't re-verify the package end-to-end. Instead each kill was verified by **injecting the exact CI-reported mutation into the source and confirming the new test fails**. 14 of the 40 CI LIVED mutants killed (math: `(641+14)/681 = 96.18% ≥ 95%`):

- **`range_lwr.go`** — column-validation `||` chain (`65:26/46/71`), the Start/End anchor-count guard (`76`), the zero-span boundary `span < 0` (`78`), and the lookback sign in the floor-index numerator (`189`, INVERT_NEGATIVES + ARITHMETIC_BASE).
- **`histogram_quantile_native.go:196`** — the computed-phi `isNaN` NaN-guard (the previously-uncovered `PhiExpr != nil` path).
- **`nested_set_annotate.go:410`** — `optQualColFrag` qualifier branch.
- **`structural_join.go:714`** — `subtreeHasRecursiveStructural` nil guard.
- **`range_window.go`** — over-time direct-matrix anchor count `OuterRange/Step + 1` (`2114`) and the instant-vs-matrix mode split `OuterRange > 0` (`2052`).
- **`builder.go:1575`** — `Window` PARTITION-BY emptiness boundary.

The remaining CI LIVED mutants not targeted here are equivalent-given-fixed-inputs (slice-capacity hints like `len(...)*2+6`; `break`-after-flag loop-ctrl flips; the `late_mat` package-init guards over fixed schema defaults), or low-yield prewhere insertion-sort internals — killing the 14 above already clears the 95% bar with headroom.

## Verification

- `go test ./internal/chplan/... ./internal/chsql/...` — 1113 pass.
- Every kill confirmed by mutation injection (test passes on clean source, fails on the mutated source).
- `golangci-lint` clean on both packages; `gofumpt -extra` clean; all `forbid-skip` discipline scans green.
- chplan re-run with gremlins → 100% efficacy (0 LIVED).

🤖 Generated with [Claude Code](https://claude.com/claude-code)