### PR TITLE
fix(e2e): de-flake compose-smoke Error-rate-by-language No-data (rate-window readiness)

### DIFF
--- a/test/e2e/playwright/crawl/crawl.spec.ts
+++ b/test/e2e/playwright/crawl/crawl.spec.ts
@@ -109,6 +109,7 @@ import {
 } from '@playwright/test';
 
 import {
+  awaitSelfTelemetryRangeSignal,
   captureConsoleErrors,
   describeSweepDepth,
   generateSelfTraffic,
@@ -605,6 +606,18 @@ test('crawl: BFS over every reachable Grafana surface with universal oracles + i
     stack.defaultGrafanaURL;
 
   await generateSelfTraffic(request, SEED_TRAFFIC_SECONDS);
+  // Flake #89: url=/ is the first surface this BFS audits, and the
+  // cerberus-self home dashboard's "Error rate by language" panel
+  // divides rate(cerberus_queries_total{result="error"}[5m]) by the
+  // aggregate rate — both need ≥2 exported samples in the [5m] window
+  // before they emit a point. generateSelfTraffic guarantees REQUESTS,
+  // not that their exported samples have landed in ClickHouse, so on a
+  // cold stack the panel could render "No data" and trip the
+  // panel-no-data-undeclared oracle. This bounded, data-driven wait
+  // gates the whole crawl until the panel's data is provably
+  // rate()-able — parity with dsquery.spec.ts + lints.spec.ts. Loud
+  // deadline failure, never a skip.
+  await awaitSelfTelemetryRangeSignal(request);
 
   // The engine drives no login flow — every stack config declares
   // anonymousAuth and the crawl proves the assumption live before

--- a/test/e2e/playwright/helpers/sweep.ts
+++ b/test/e2e/playwright/helpers/sweep.ts
@@ -164,6 +164,85 @@ export async function generateSelfTraffic(
   }
 }
 
+// Each probe expression must yield at least this many range points
+// before we treat the underlying series as rate()-able. Two samples
+// are the arithmetic floor for `rate(x[5m])` to emit a single point;
+// we demand a third as step-alignment margin (see the comment in
+// awaitSelfTelemetryExprSignal) so "probe passed" implies "any
+// consumer window over the same range has data".
+const MIN_SELF_TELEMETRY_POINTS = 3;
+
+// How far in the PAST the probe window ends. Grafana's Prometheus
+// plugin backend step-aligns the replay window, which can exclude the
+// single newest evaluation step — ending the probe window here keeps
+// the probe and any consumer panel looking at the same settled range.
+const SELF_TELEMETRY_PROBE_LAG_SEC = 30;
+
+// Width of the probe's range window, matching the panel's [5m] rate
+// lookback so the probe exercises the same number of in-window samples
+// the consumer panel needs.
+const SELF_TELEMETRY_PROBE_WINDOW_SEC = 300;
+
+// Poll cadence while waiting for a self-telemetry expression to become
+// rate()-able. One OTel export cycle is 10s; 5s keeps the loop
+// responsive without hammering cerberus.
+const SELF_TELEMETRY_POLL_INTERVAL_MS = 5_000;
+
+/**
+ * Block until a single cerberus self-telemetry expression supports
+ * rate()-over-range queries (>= MIN_SELF_TELEMETRY_POINTS points), or
+ * throw after `deadlineSec`.
+ *
+ * Polls cerberus DIRECTLY (not through Grafana) on purpose: it
+ * isolates "the data exists on the wire" from "the consumer decodes
+ * it". The deadline failure is loud and actionable, never a skip.
+ */
+async function awaitSelfTelemetryExprSignal(
+  request: APIRequestContext,
+  expr: string,
+  deadlineSec: number,
+): Promise<void> {
+  const cerberusURL = process.env.CERBERUS_URL ?? DEFAULT_CERBERUS_URL;
+  const deadline = Date.now() + deadlineSec * 1000;
+  let lastBody = '';
+  for (;;) {
+    // The probe window deliberately ends SELF_TELEMETRY_PROBE_LAG_SEC
+    // in the PAST and demands MIN_SELF_TELEMETRY_POINTS points: a
+    // probe satisfied by one fresh point green-lit a replay that
+    // still saw zero rows (reproduced on the 2026-06-10 cold-boot
+    // verification). Requiring margin makes "probe passed" imply "any
+    // consumer window over the same range has data".
+    const nowSec = Math.floor(Date.now() / 1000) - SELF_TELEMETRY_PROBE_LAG_SEC;
+    const url =
+      `${cerberusURL}/api/v1/query_range?query=${encodeURIComponent(expr)}` +
+      `&start=${nowSec - SELF_TELEMETRY_PROBE_WINDOW_SEC}&end=${nowSec}&step=15`;
+    try {
+      const resp = await request.get(url);
+      lastBody = await resp.text();
+      if (resp.status() === 200) {
+        const parsed = JSON.parse(lastBody) as {
+          data?: { result?: Array<{ values?: unknown[] }> };
+        };
+        const points = (parsed.data?.result ?? []).reduce(
+          (acc, s) => acc + (s.values?.length ?? 0),
+          0,
+        );
+        if (points >= MIN_SELF_TELEMETRY_POINTS) return;
+      }
+    } catch {
+      // transient — the deadline below is the failure path
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `awaitSelfTelemetryExprSignal: ${expr} returned <${MIN_SELF_TELEMETRY_POINTS} points within ${deadlineSec}s of seed traffic — ` +
+          `cerberus self-telemetry is not reaching ClickHouse (seed, OTel export, or ingest regression). ` +
+          `Last response: ${lastBody.slice(0, 400)}`,
+      );
+    }
+    await new Promise((r) => setTimeout(r, SELF_TELEMETRY_POLL_INTERVAL_MS));
+  }
+}
+
 /**
  * Block until cerberus's own self-telemetry supports rate()-over-range
  * queries, or throw after `deadlineSec`.
@@ -179,6 +258,20 @@ export async function generateSelfTraffic(
  * EMPTY — adversarial verification on 2026-06-10 reproduced exactly
  * that red on a healthy stack at ~2min uptime.
  *
+ * We gate on TWO expressions, both of which the cerberus-self "Error
+ * rate by language" panel depends on (flake #89):
+ *   - the AGGREGATE denominator  sum(rate(cerberus_queries_total[5m]))
+ *   - the sparser NUMERATOR
+ *       sum by (cerberus_ql) (rate(cerberus_queries_total{result="error"}[5m]))
+ * The numerator is partitioned by (cerberus_ql) AND filtered to the
+ * error path, so a single (result="error", cerberus_ql) bucket can lag
+ * the aggregate by an export cycle. Gating on the aggregate alone left
+ * a residual race where the denominator was rate()-able but the
+ * numerator wasn't yet — the panel's `numerator / clamp_min(denom, …)`
+ * then yields no series and renders "No data". Probing the exact panel
+ * numerator closes that gap: once this returns, an empty "Error rate
+ * by language" panel is a real bug, not a boot race.
+ *
  * The wait polls cerberus DIRECTLY (not through Grafana) on purpose:
  * it isolates "the data exists on the wire" from "the consumer decodes
  * it", so the caller's plugin-backend / lint assertions stay
@@ -190,45 +283,14 @@ export async function awaitSelfTelemetryRangeSignal(
   request: APIRequestContext,
   deadlineSec = 120,
 ): Promise<void> {
-  const cerberusURL = process.env.CERBERUS_URL ?? DEFAULT_CERBERUS_URL;
-  const expr = 'sum(rate(cerberus_queries_total[5m]))';
-  const deadline = Date.now() + deadlineSec * 1000;
-  let lastBody = '';
-  for (;;) {
-    // The probe window deliberately ends 30s in the PAST and demands
-    // >=3 points: Grafana's Prometheus plugin backend step-aligns the
-    // replay window, which can exclude the single newest evaluation
-    // step — a probe satisfied by one fresh point green-lit a replay
-    // that still saw zero rows (reproduced on the 2026-06-10
-    // cold-boot verification). Requiring margin makes "probe passed"
-    // imply "any consumer window over the same range has data".
-    const nowSec = Math.floor(Date.now() / 1000) - 30;
-    const url =
-      `${cerberusURL}/api/v1/query_range?query=${encodeURIComponent(expr)}` +
-      `&start=${nowSec - 300}&end=${nowSec}&step=15`;
-    try {
-      const resp = await request.get(url);
-      lastBody = await resp.text();
-      if (resp.status() === 200) {
-        const parsed = JSON.parse(lastBody) as {
-          data?: { result?: Array<{ values?: unknown[] }> };
-        };
-        const points = (parsed.data?.result ?? []).reduce(
-          (acc, s) => acc + (s.values?.length ?? 0),
-          0,
-        );
-        if (points >= 3) return;
-      }
-    } catch {
-      // transient — the deadline below is the failure path
-    }
-    if (Date.now() >= deadline) {
-      throw new Error(
-        `awaitSelfTelemetryRangeSignal: ${expr} returned <3 points within ${deadlineSec}s of seed traffic — ` +
-          `cerberus self-telemetry is not reaching ClickHouse (seed, OTel export, or ingest regression). ` +
-          `Last response: ${lastBody.slice(0, 400)}`,
-      );
-    }
-    await new Promise((r) => setTimeout(r, 5_000));
+  // The aggregate denominator the panel divides by, plus the strictly
+  // sparser by-language error numerator. Both must be rate()-able
+  // before the consumer panel can render a non-empty frame.
+  const exprs = [
+    'sum(rate(cerberus_queries_total[5m]))',
+    'sum by (cerberus_ql) (rate(cerberus_queries_total{result="error"}[5m]))',
+  ];
+  for (const expr of exprs) {
+    await awaitSelfTelemetryExprSignal(request, expr, deadlineSec);
   }
 }

--- a/test/e2e/playwright/iterate-all-dashboards.spec.ts
+++ b/test/e2e/playwright/iterate-all-dashboards.spec.ts
@@ -61,6 +61,7 @@ import {
 
 import {
   type VariableJSON,
+  awaitSelfTelemetryRangeSignal,
   checkDashboardVariable,
   describeSweepDepth,
   enforceExpectation,
@@ -519,6 +520,15 @@ test.describe('iterate-all-dashboards: full provisioned-dashboard sweep', () => 
     // Single warmup for the whole describe block — the per-dashboard
     // tests inherit the populated counters.
     await generateSelfTraffic(request, SEED_TRAFFIC_SECONDS);
+    // Flake #89: this sweep renders cerberus-self directly via
+    // /d/<uid>, whose "Error rate by language" panel needs ≥2 exported
+    // samples of both the aggregate rate and the {result="error"}
+    // numerator in the [5m] window before it emits a point.
+    // generateSelfTraffic guarantees REQUESTS, not that their exported
+    // samples reached ClickHouse — gate the per-dashboard renders on a
+    // bounded, data-driven wait so an empty panel is a real bug, not a
+    // boot race. Loud deadline failure, never a skip.
+    await awaitSelfTelemetryRangeSignal(request);
   });
 
   for (const d of dashboards) {


### PR DESCRIPTION
## Flake #89 — compose-smoke "Error rate by language" intermittent "No data"

### Symptom
The `compose-smoke` crawl (a **required** PR check) intermittently failed with:

```
[crawl:/] panel-no-data-undeclared: panel "Error rate by language" rendered "No data"
with no cerberus.expect declaration (dashboard=<not a dashboard>, url=/) — fix the bug at the source
```

It bit PR #849 this session (compose-smoke failed, re-run passed) — the classic intermittent signature.

### Root cause — a boot-time data-accumulation race with no readiness gate
The flaky panel is **"Error rate by language"** (id=3) on the `cerberus-self` home dashboard
(`test/e2e/grafana/compose/dashboards/cerberus.json:300`), rendered at `url=/` as the Grafana home page. Its PromQL:

```promql
sum by (cerberus_ql) (rate(cerberus_queries_total{result="error"}[5m]))
  / clamp_min(sum by (cerberus_ql) (rate(cerberus_queries_total[5m])), 1e-9)
```

`cerberus_queries_total` is a cerberus **self-metric**, incremented per served query. It reaches ClickHouse only on
cerberus's 10s OTLP export cadence (then otel-collector ~1s batch). `rate(x[5m])` over a cumulative counter needs
**≥2 distinct exported samples in the window** before it emits any point.

The crawl spec fires `generateSelfTraffic(request, 30s)` and then **immediately** audits `url=/` as the **first**
surface. `generateSelfTraffic` guarantees REQUESTS happened, but not that ≥2 of their exported samples have landed in
ClickHouse. There was **no per-panel readiness gate** — the only sync was `tolerateRepaintFlicker` (networkidle +
settle), which waits for the network to go quiet, not for any panel to be non-empty.

The proximate defect is an asymmetry: `crawl.spec.ts` was the **lone** crawl spec missing the readiness gate. Its
siblings `dsquery.spec.ts` and `lints.spec.ts` both call `awaitSelfTelemetryRangeSignal` after
`generateSelfTraffic`; `crawl.spec.ts` called `generateSelfTraffic` alone and didn't even import the gate.
`iterate-all-dashboards.spec.ts` (which renders `cerberus-self` via `/d/<uid>`) had the same latent gap.

### The fix — a deterministic readiness gate (no skip, no allowlist)
A data-driven gate that polls cerberus's own `/api/v1/query_range` until the panel's data is provably rate()-able
(120s deadline, **loud throw** on timeout, never a skip). It blocks the crawl from auditing any surface until the
data the panel needs provably exists in ClickHouse — it cannot race.

1. **`crawl/crawl.spec.ts`** — import + call `awaitSelfTelemetryRangeSignal` immediately after
   `generateSelfTraffic`, before the BFS audits `url=/` (parity with `dsquery.spec.ts` + `lints.spec.ts`).
2. **`helpers/sweep.ts`** — hardened `awaitSelfTelemetryRangeSignal` to close a residual race. The old gate probed
   only the aggregate denominator `sum(rate(cerberus_queries_total[5m]))`, but the panel's **numerator** is the
   strictly-sparser `sum by (cerberus_ql) (rate(cerberus_queries_total{result="error"}[5m]))` — a single
   `(result="error", cerberus_ql)` bucket can lag the aggregate by an export cycle. I factored the poll loop into
   `awaitSelfTelemetryExprSignal(expr)` and now gate on **both** the aggregate denominator **and** the exact panel
   numerator (each requires ≥3 points over a window ending 30s in the past for step-alignment margin). Once the gate
   returns, an empty panel is a real bug, not a boot race. The public `awaitSelfTelemetryRangeSignal` signature is
   unchanged, so the existing `dsquery`/`lints` callers inherit the stronger gate for free.
3. **`iterate-all-dashboards.spec.ts`** — same gate in the describe-block `beforeAll`, closing the identical latent
   exposure on the `cerberus-self` render.

The four touched/affected magic numbers (`3`, `30`, `300`, `5_000`) are lifted to named consts
(`MIN_SELF_TELEMETRY_POINTS`, `SELF_TELEMETRY_PROBE_LAG_SEC`, `SELF_TELEMETRY_PROBE_WINDOW_SEC`,
`SELF_TELEMETRY_POLL_INTERVAL_MS`).

### Why not an allowlist / window change
This is a pure harness fix that makes the data **deterministically present** before the assertion runs. It touches
**no** escape hatch — no `EXPECTED_EMPTY`, no `should_skip`, no `cerberus.expect=empty`, no `t.Skip`. The
panel-no-data oracle still fires unconditionally for every real regression; the fix only removes the boot-time race
that made it fire on healthy data.

The allowlist route is moreover **impossible** here, which confirms a readiness gate is the only correct fix:
(1) `cerberus.json` is an ops-family dashboard (not `showcase-`-prefixed), so `expectation-contracts.spec.ts` **bans**
any `cerberus.expect` declaration on it; (2) at `url=/` the oracle's `contractsFor()` derives `dashUid` via
`/^\/d\/([^/?#]+)/`, which does not match `/`, so `dashUid` is undefined and `noDataDeclared` is the empty set —
exactly why the failure message reads `dashboard=<not a dashboard>`. A declared contract would never even be
consulted at the home URL.

Shrinking the panel's `[5m]` rate window would alter the **shipped** user-facing home dashboard's semantics to paper
over a harness race — wrong layer. The data genuinely exists ~20–30s after boot; the correct fix is to wait for it
deterministically.

### Verification status
Source/typecheck verified locally (`tsc --noEmit` clean on the 3 touched files; the only 3 pre-existing errors are in
the untouched `iterate-time-ranges.spec.ts`; all six `forbid-skip` sub-checks pass). **Compose-stack verification is
pending** — per the sweep-rebuild rule the running stack is stale and must be torn down + rebuilt at origin/main + this
fix before the crawl is rerun N≥10 times on cold stacks. Auto-merge intentionally **not** armed until that Verify
phase confirms the flake is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
