### PR TITLE
chore(demo): enable native timeSeriesRateToGrid in the compose stack (#104)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -193,6 +193,14 @@ services:
       # ClickHouse's server-total cap into a mid-stream 502 (k3d run
       # 27277793810).
       CERBERUS_CH_QUERY_MAX_MEMORY: "1073741824"
+      # CERBERUS_EXPERIMENTAL_TS_GRID_RANGE   route rate()-over-range to
+      # ClickHouse's native timeSeriesRateToGrid aggregate (CH >= 25.6,
+      # satisfied by the 25.8 server above) instead of the per-anchor
+      # array fan-out. Default-off in prod (parity is exact to <=1 ULP,
+      # not byte-identical); enabled here so the demo dogfoods the native
+      # path against a real 25.8 server — the compose-smoke crawl is its
+      # first real-CH exercise.
+      CERBERUS_EXPERIMENTAL_TS_GRID_RANGE: "true"
     depends_on:
       clickhouse:
         condition: service_healthy

--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -808,6 +808,13 @@ func isMatrixRangeWindow(plan chplan.Node) bool {
 	switch v := plan.(type) {
 	case *chplan.RangeWindow:
 		return v.OuterRange > 0
+	case *chplan.RangeWindowNative:
+		// The native timeSeriesRateToGrid path is always matrix-shape: it
+		// explodes the grid into one row per anchor and surfaces the
+		// per-row `anchor_ts` column, exactly like the fan-out matrix
+		// RangeWindow. The TimeUnix source is therefore that column, not
+		// the now64() instant synthesis.
+		return true
 	case *chplan.Project:
 		return isMatrixRangeWindow(v.Input)
 	case *chplan.Filter:
@@ -842,7 +849,12 @@ func synthesizedAnchor() chplan.Expr {
 // the missing-column reference with a 502 on `query_range`.
 func isDerivedShape(plan chplan.Node, s schema.Metrics) bool {
 	switch v := plan.(type) {
-	case *chplan.RangeWindow, *chplan.Aggregate:
+	case *chplan.RangeWindow, *chplan.Aggregate, *chplan.RangeWindowNative:
+		// RangeWindowNative emits the same derived (group-keys…, anchor_ts,
+		// value) shape as the fan-out RangeWindow — MetricName never exists
+		// in that scope, so it must be synthesised as the empty string
+		// rather than referenced as a bare column (CH would 502 with
+		// "Unknown expression identifier MetricName").
 		return true
 	case *chplan.Filter:
 		return isDerivedShape(v.Input, s)

--- a/internal/api/prom/native_projection_test.go
+++ b/internal/api/prom/native_projection_test.go
@@ -1,0 +1,82 @@
+package prom
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestWrapSampleProjection_NativeRangeWindowIsDerivedMatrix pins the
+// classification of chplan.RangeWindowNative inside the HTTP-layer sample
+// projection wrapper.
+//
+// Regression for the compose-smoke 502 surfaced by enabling the
+// experimental native rate-range path on a real ClickHouse (#104): the
+// native node's output schema is the SAME derived (group-keys…, anchor_ts,
+// value) shape the fan-out matrix RangeWindow produces — MetricName never
+// exists in that scope. Before the fix, isDerivedShape / isMatrixRangeWindow
+// lacked a *chplan.RangeWindowNative case, so wrapWithSampleProjection took
+// the canonical branch and emitted a bare `MetricName` column reference
+// against the native subquery, which ClickHouse rejects with
+// `code 47, Unknown expression identifier 'MetricName'`.
+//
+// The wrapper must instead synthesise `” AS MetricName` (derived branch)
+// and source TimeUnix from the per-row `anchor_ts` column (matrix branch),
+// exactly as it does for the fan-out RangeWindow.
+func TestWrapSampleProjection_NativeRangeWindowIsDerivedMatrix(t *testing.T) {
+	s := schema.DefaultOTelMetrics()
+
+	native := &chplan.RangeWindowNative{
+		Input:           &chplan.Scan{Table: "otel_metrics_gauge"},
+		Func:            "rate",
+		Range:           5 * time.Minute,
+		Step:            time.Minute,
+		Start:           time.Unix(1000, 0).UTC(),
+		End:             time.Unix(4600, 0).UTC(),
+		TimestampColumn: s.TimestampColumn,
+		ValueColumn:     s.ValueColumn,
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}},
+	}
+
+	if !isDerivedShape(native, s) {
+		t.Fatal("RangeWindowNative must be a derived shape (MetricName absent from its scope)")
+	}
+	if !isMatrixRangeWindow(native) {
+		t.Fatal("RangeWindowNative must be matrix-shape (exposes per-row anchor_ts)")
+	}
+
+	wrapped, ok := wrapWithSampleProjection(native, s).(*chplan.Project)
+	if !ok {
+		t.Fatalf("wrapWithSampleProjection returned %T, want *chplan.Project", wrapped)
+	}
+	if len(wrapped.Projections) != 4 {
+		t.Fatalf("got %d projections, want 4 (MetricName, Attributes, TimeUnix, Value)", len(wrapped.Projections))
+	}
+
+	// MetricName must be the synthesised empty-string literal, NOT a bare
+	// column reference into the native subquery (which would 502).
+	mn := wrapped.Projections[0]
+	if mn.Alias != s.MetricNameColumn {
+		t.Fatalf("projection[0] alias = %q, want %q", mn.Alias, s.MetricNameColumn)
+	}
+	lit, ok := mn.Expr.(*chplan.LitString)
+	if !ok {
+		t.Fatalf("MetricName projection is %T, want *chplan.LitString (synthesised); a ColumnRef here is the 502 bug", mn.Expr)
+	}
+	if lit.V != "" {
+		t.Fatalf("MetricName literal = %q, want empty string", lit.V)
+	}
+
+	// TimeUnix must source from the per-row anchor_ts column (matrix
+	// branch), not the now64() instant synthesis.
+	ts := wrapped.Projections[2]
+	if ts.Alias != s.TimestampColumn {
+		t.Fatalf("projection[2] alias = %q, want %q", ts.Alias, s.TimestampColumn)
+	}
+	col, ok := ts.Expr.(*chplan.ColumnRef)
+	if !ok || col.Name != "anchor_ts" {
+		t.Fatalf("TimeUnix projection = %#v, want ColumnRef{anchor_ts}", ts.Expr)
+	}
+}


### PR DESCRIPTION
## What

Flip `CERBERUS_EXPERIMENTAL_TS_GRID_RANGE: "true"` in the docker-compose **demo** stack only.

## Why

The compose demo now runs ClickHouse **25.8** (#858), which ships the native `timeSeriesRateToGrid` family (CH ≥ 25.6). Enabling the flag makes cerberus route `rate()`-over-range to the native aggregate instead of the per-anchor array fan-out, so the demo **dogfoods the native path against a real CH server**. The chDB lanes already cover emission, but only the demo exercises it on a Docker ClickHouse server — the **compose-smoke** Playwright crawl becomes its first real-CH validation of #856's native emit.

## Scope / safety

- **Demo only.** Prod default stays off — native parity is exact to ≤1 ULP, not byte-identical (see #856).
- **Compat compose files left untouched** on purpose: the native path must not enter the `compatibility/{prometheus,loki,tempo}` 574/574 differential lanes (24.8 there lacks the function anyway; the differential demands byte-identity).

One-line env flip; `compose-smoke` validates it.