### PR TITLE
fix(api/prom): classify RangeWindowNative as derived matrix shape so __name__ synthesises

### DIFF
--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -808,6 +808,13 @@ func isMatrixRangeWindow(plan chplan.Node) bool {
 	switch v := plan.(type) {
 	case *chplan.RangeWindow:
 		return v.OuterRange > 0
+	case *chplan.RangeWindowNative:
+		// The native timeSeriesRateToGrid path is always matrix-shape: it
+		// explodes the grid into one row per anchor and surfaces the
+		// per-row `anchor_ts` column, exactly like the fan-out matrix
+		// RangeWindow. The TimeUnix source is therefore that column, not
+		// the now64() instant synthesis.
+		return true
 	case *chplan.Project:
 		return isMatrixRangeWindow(v.Input)
 	case *chplan.Filter:
@@ -842,7 +849,12 @@ func synthesizedAnchor() chplan.Expr {
 // the missing-column reference with a 502 on `query_range`.
 func isDerivedShape(plan chplan.Node, s schema.Metrics) bool {
 	switch v := plan.(type) {
-	case *chplan.RangeWindow, *chplan.Aggregate:
+	case *chplan.RangeWindow, *chplan.Aggregate, *chplan.RangeWindowNative:
+		// RangeWindowNative emits the same derived (group-keys…, anchor_ts,
+		// value) shape as the fan-out RangeWindow — MetricName never exists
+		// in that scope, so it must be synthesised as the empty string
+		// rather than referenced as a bare column (CH would 502 with
+		// "Unknown expression identifier MetricName").
 		return true
 	case *chplan.Filter:
 		return isDerivedShape(v.Input, s)

--- a/internal/api/prom/native_projection_test.go
+++ b/internal/api/prom/native_projection_test.go
@@ -1,0 +1,82 @@
+package prom
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestWrapSampleProjection_NativeRangeWindowIsDerivedMatrix pins the
+// classification of chplan.RangeWindowNative inside the HTTP-layer sample
+// projection wrapper.
+//
+// Regression for the compose-smoke 502 surfaced by enabling the
+// experimental native rate-range path on a real ClickHouse (#104): the
+// native node's output schema is the SAME derived (group-keys…, anchor_ts,
+// value) shape the fan-out matrix RangeWindow produces — MetricName never
+// exists in that scope. Before the fix, isDerivedShape / isMatrixRangeWindow
+// lacked a *chplan.RangeWindowNative case, so wrapWithSampleProjection took
+// the canonical branch and emitted a bare `MetricName` column reference
+// against the native subquery, which ClickHouse rejects with
+// `code 47, Unknown expression identifier 'MetricName'`.
+//
+// The wrapper must instead synthesise `” AS MetricName` (derived branch)
+// and source TimeUnix from the per-row `anchor_ts` column (matrix branch),
+// exactly as it does for the fan-out RangeWindow.
+func TestWrapSampleProjection_NativeRangeWindowIsDerivedMatrix(t *testing.T) {
+	s := schema.DefaultOTelMetrics()
+
+	native := &chplan.RangeWindowNative{
+		Input:           &chplan.Scan{Table: "otel_metrics_gauge"},
+		Func:            "rate",
+		Range:           5 * time.Minute,
+		Step:            time.Minute,
+		Start:           time.Unix(1000, 0).UTC(),
+		End:             time.Unix(4600, 0).UTC(),
+		TimestampColumn: s.TimestampColumn,
+		ValueColumn:     s.ValueColumn,
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}},
+	}
+
+	if !isDerivedShape(native, s) {
+		t.Fatal("RangeWindowNative must be a derived shape (MetricName absent from its scope)")
+	}
+	if !isMatrixRangeWindow(native) {
+		t.Fatal("RangeWindowNative must be matrix-shape (exposes per-row anchor_ts)")
+	}
+
+	wrapped, ok := wrapWithSampleProjection(native, s).(*chplan.Project)
+	if !ok {
+		t.Fatalf("wrapWithSampleProjection returned %T, want *chplan.Project", wrapped)
+	}
+	if len(wrapped.Projections) != 4 {
+		t.Fatalf("got %d projections, want 4 (MetricName, Attributes, TimeUnix, Value)", len(wrapped.Projections))
+	}
+
+	// MetricName must be the synthesised empty-string literal, NOT a bare
+	// column reference into the native subquery (which would 502).
+	mn := wrapped.Projections[0]
+	if mn.Alias != s.MetricNameColumn {
+		t.Fatalf("projection[0] alias = %q, want %q", mn.Alias, s.MetricNameColumn)
+	}
+	lit, ok := mn.Expr.(*chplan.LitString)
+	if !ok {
+		t.Fatalf("MetricName projection is %T, want *chplan.LitString (synthesised); a ColumnRef here is the 502 bug", mn.Expr)
+	}
+	if lit.V != "" {
+		t.Fatalf("MetricName literal = %q, want empty string", lit.V)
+	}
+
+	// TimeUnix must source from the per-row anchor_ts column (matrix
+	// branch), not the now64() instant synthesis.
+	ts := wrapped.Projections[2]
+	if ts.Alias != s.TimestampColumn {
+		t.Fatalf("projection[2] alias = %q, want %q", ts.Alias, s.TimestampColumn)
+	}
+	col, ok := ts.Expr.(*chplan.ColumnRef)
+	if !ok || col.Name != "anchor_ts" {
+		t.Fatalf("TimeUnix projection = %#v, want ColumnRef{anchor_ts}", ts.Expr)
+	}
+}


### PR DESCRIPTION
## The bug

Enabling the experimental native rate-range path (`timeSeriesRateToGrid`) on a **real ClickHouse 25.8** (PR #860 / #104, the compose-smoke crawl) surfaced a 502 on every standard `rate()` metric panel:

```
panel="Go runtime memory" expr="rate(otelcol_process_runtime_total_alloc_bytes[5m])"
HTTP 502: code 47, Unknown expression identifier `MetricName` in scope
  SELECT MetricName, Attributes, TimeUnix, Value FROM (native subquery)
```

## Root cause

The HTTP-layer sample-projection wrapper (`wrapWithSampleProjection`) decides between a **canonical** projection (bare `MetricName` column) and a **derived** one (synthesised `'' AS MetricName`) via two shape predicates — `isDerivedShape` and `isMatrixRangeWindow`. Neither had a `*chplan.RangeWindowNative` case.

The native node emits the **same** derived `(group-keys…, anchor_ts, value)` shape the fan-out matrix `RangeWindow` does — `MetricName` never exists in that scope. Absent the case, the wrapper fell through to the canonical branch and emitted a bare `MetricName` column reference against a subquery that doesn't project it → CH code 47.

## The fix

Classify `RangeWindowNative` **identically to the fan-out `RangeWindow`**:
- `isDerivedShape` → true (synthesise `'' AS MetricName`)
- `isMatrixRangeWindow` → true (source `TimeUnix` from the per-row `anchor_ts` column, not the `now64()` instant synthesis)

Two-line predicate fix; no emit-logic change.

## Why the existing test missed it

The #856 `TestNativeTSGridRate_DualEmitParity` exercised the chsql subquery **in isolation**, never through the handler wrapper. This PR adds a white-box regression test in the always-on **`check`** lane asserting the wrapped native plan synthesises the MetricName **literal** (a `ColumnRef` here is exactly the 502 bug).

## Scope

The native path is **default-off in prod** (`CERBERUS_EXPERIMENTAL_TS_GRID_RANGE`), so this has **zero effect on the fan-out default** — it makes the experimental path actually correct. #860 (the demo flag flip) rebases on top of this and its compose-smoke becomes the end-to-end confirmation.