### PR TITLE
docs(engine): rehome the three-heads pipeline diagram into engine.md

### DIFF
--- a/docs/engine.md
+++ b/docs/engine.md
@@ -206,7 +206,44 @@ losing the cause.
 
 The middle of the pipeline — lower → optimize → emit → schema
 resolution — is the part the three heads share. Each stage is
-described below.
+described below. The three heads converge on it: each parses with its
+reference upstream parser, lowers to the shared IR, and from there runs
+the same optimize → emit → execute path.
+
+```text
+   PromQL                LogQL                TraceQL
+     │                     │                     │
+     ▼                     ▼                     ▼
+prometheus/        grafana/loki/v3/         grafana/tempo/
+promql/parser      pkg/logql/syntax         pkg/traceql        ← reference upstream parsers, imported directly
+     │                     │                     │
+     │      per-QL lowering (head → chplan)      │
+     ▼                     ▼                     ▼
+ ┌──────────────────────────────────────────────────┐
+ │           internal/chplan — shared IR            │   Scan • Filter • Project •
+ │  one algebra; the optimiser and the emitter      │   Aggregate • RangeWindow •
+ │  don't know which head produced the plan         │   Limit • expression tree
+ └──────────────────────────────────────────────────┘
+                       │
+                       ▼
+ ┌──────────────────────────────────────────────────┐
+ │          internal/optimizer — rule-based         │   Catalyst-style batches:
+ │  Analyzer (semantic) → Once (heuristic) →        │   semantic + heuristic +
+ │  FixedPoint (rules that unlock each other)       │   fixpoint rewrites; no cost
+ │                                                  │   model (see performance.md)
+ └──────────────────────────────────────────────────┘
+                       │
+                       ▼
+ ┌──────────────────────────────────────────────────┐
+ │           internal/chsql — typed emitter         │   • parameterised, escape-free
+ │  QueryBuilder slots + typed Frag constructors;   │   • PREWHERE promotion on Filter(Scan)
+ │  the typed surface is closed — external packages │   • sort-key-aware predicate ordering
+ │  cannot compose raw SQL by construction          │   • streaming clickhouse-go/v2 cursor
+ └──────────────────────────────────────────────────┘
+                       │
+                       ▼
+                  ClickHouse
+```
 
 ### One IR for three languages — `internal/chplan`
 


### PR DESCRIPTION
The lean-README pass (#862) trimmed the README's architecture box-art on the assumption engine.md already carried it. It didn't — engine.md only had the *request-lifecycle* flow, not the three-heads-converge-to-one-pipeline diagram with the per-stage annotations (parsers → chplan IR → optimizer → chsql emitter → ClickHouse).

This restores that diagram into engine.md's **Pipeline stages in depth** section, where it visually annotates exactly the stages the section then details. The README's lean Architecture section already links to engine.md, so the diagram now has a stable, dedicated home — which is what it should have had in #862.

Docs-only.