### PR TITLE
feat(promql): implement experimental limitk aggregator (LIMIT K BY)

### DIFF
--- a/internal/api/prom/lang_test.go
+++ b/internal/api/prom/lang_test.go
@@ -77,26 +77,31 @@ func TestLang_Parse_ParseError(t *testing.T) {
 }
 
 // TestLang_Parse_LowerError — a parseable but unsupported PromQL form
-// (`limitk`, an experimental aggregation cerberus rejects at lowering) surfaces as a parseStageError tagged
-// "lower". Verifies the parse → lower split is preserved through the
-// adapter.
+// (`limit_ratio`, an experimental aggregation cerberus rejects at
+// lowering) surfaces as a parseStageError tagged "lower". Verifies the
+// parse → lower split is preserved through the adapter.
+//
+// `limitk` was the original example here; it now lowers (the
+// experimental-aggregator burndown wired limitk → LIMIT K BY), so the
+// still-unsupported sibling `limit_ratio` carries the parse→lower-split
+// assertion forward.
 func TestLang_Parse_LowerError(t *testing.T) {
 	t.Parallel()
 
 	l := langForTest()
-	_, _, err := l.Parse(context.Background(), `limitk(2, up)`)
+	_, _, err := l.Parse(context.Background(), `limit_ratio(0.5, up)`)
 	if err == nil {
-		t.Fatalf("Parse(limitk): expected lower failure, got nil")
+		t.Fatalf("Parse(limit_ratio): expected lower failure, got nil")
 	}
 	var ps *parseStageError
 	if !errors.As(err, &ps) {
-		t.Fatalf("Parse(limitk): err type = %T, want *parseStageError; err=%v", err, err)
+		t.Fatalf("Parse(limit_ratio): err type = %T, want *parseStageError; err=%v", err, err)
 	}
 	if ps.stage != "lower" {
 		t.Errorf("parseStageError.stage: got %q, want %q (got err=%v)", ps.stage, "lower", err)
 	}
-	if !strings.Contains(err.Error(), "limitk") {
-		t.Errorf("err message: got %q, want it to mention limitk", err.Error())
+	if !strings.Contains(err.Error(), "limit_ratio") {
+		t.Errorf("err message: got %q, want it to mention limit_ratio", err.Error())
 	}
 }
 

--- a/internal/chplan/topk.go
+++ b/internal/chplan/topk.go
@@ -10,9 +10,13 @@ package chplan
 // every input column — `by(g1, g2)` only partitions, it does not drop
 // labels.
 //
-// SQL form (literal-K, KExpr == nil):
+// SQL form (literal-K, KExpr == nil, Unordered == false):
 //
 //	SELECT <Columns> FROM (<input>) ORDER BY <SortExpr> [DESC] LIMIT K [BY <By>...]
+//
+// SQL form (literal-K, Unordered == true — limitk):
+//
+//	SELECT <Columns> FROM (<input>) LIMIT K [BY <By>...]
 //
 // SQL form (computed-K, KExpr != nil):
 //
@@ -47,14 +51,24 @@ package chplan
 // K integer; the emitter wraps it as `(SELECT toUInt64(Value) FROM
 // <KExpr> LIMIT 1)`. `K` and `KExpr` are mutually exclusive — set one
 // or the other, never both.
+//
+// `Unordered` models PromQL's experimental `limitk(K, v)` aggregator:
+// per group, return up to K *arbitrary* series — no ranking, no value
+// ordering, the surviving series keep their original samples unchanged.
+// When `Unordered` is true the emitter omits the ORDER BY entirely and
+// renders a bare `LIMIT K BY <By>` (or `LIMIT K` when `By` is empty),
+// and `SortExpr` is nil. `Unordered` only composes with the literal-K
+// path (`K > 0`, `KExpr == nil`); the ranking variants (topk/bottomk,
+// computed-K) keep `Unordered == false`.
 type TopK struct {
-	Input    Node
-	K        int64
-	KExpr    Node // computed-K subtree (mutually exclusive with K > 0)
-	By       []Expr
-	SortExpr Expr     // value column reference used as the ORDER BY key
-	Desc     bool     // true = topk (DESC), false = bottomk (ASC)
-	Columns  []string // explicit outer SELECT column list; empty = `SELECT *`
+	Input     Node
+	K         int64
+	KExpr     Node // computed-K subtree (mutually exclusive with K > 0)
+	By        []Expr
+	SortExpr  Expr     // value column reference used as the ORDER BY key; nil when Unordered
+	Desc      bool     // true = topk (DESC), false = bottomk (ASC)
+	Unordered bool     // true = limitk (no ORDER BY, arbitrary K-per-group)
+	Columns   []string // explicit outer SELECT column list; empty = `SELECT *`
 }
 
 func (*TopK) planNode() {}
@@ -68,7 +82,7 @@ func (t *TopK) Children() []Node {
 
 func (t *TopK) Equal(other Node) bool {
 	o, ok := other.(*TopK)
-	if !ok || t.K != o.K || t.Desc != o.Desc ||
+	if !ok || t.K != o.K || t.Desc != o.Desc || t.Unordered != o.Unordered ||
 		len(t.By) != len(o.By) || len(t.Columns) != len(o.Columns) {
 		return false
 	}

--- a/internal/chsql/emit_node.go
+++ b/internal/chsql/emit_node.go
@@ -652,9 +652,21 @@ func (e *emitter) emitLimit(l *chplan.Limit) error {
 // (MetricName, Attributes, TimeUnix, Value) and we read the `Value`
 // column. The integer cast guards against the (rare) case where the
 // scalar evaluates to a non-integer; PromQL semantics truncate.
+//
+// When t.Unordered (PromQL `limitk(K, v)`), the ORDER BY is omitted
+// entirely: the result is K *arbitrary* rows per partition, no ranking.
+// CH's `LIMIT K BY <by>` already returns the first K rows it encounters
+// per group, which is exactly limitk's "any K series" contract. SortExpr
+// is nil in this shape, so the pre-flight and ORDER BY clause are skipped.
 func (e *emitter) emitTopK(t *chplan.TopK) error {
-	if t.SortExpr == nil {
+	if !t.Unordered && t.SortExpr == nil {
 		return fmt.Errorf("%w: TopK with nil SortExpr", ErrUnsupported)
+	}
+	if t.Unordered && t.SortExpr != nil {
+		return fmt.Errorf("%w: limitk TopK must not carry a SortExpr", ErrUnsupported)
+	}
+	if t.Unordered && t.KExpr != nil {
+		return fmt.Errorf("%w: limitk TopK does not support computed K", ErrUnsupported)
 	}
 	if t.KExpr == nil && t.K <= 0 {
 		return fmt.Errorf("%w: TopK with non-positive K=%d", ErrUnsupported, t.K)
@@ -663,8 +675,10 @@ func (e *emitter) emitTopK(t *chplan.TopK) error {
 		return fmt.Errorf("%w: TopK with both literal K=%d and KExpr set", ErrUnsupported, t.K)
 	}
 	// Pre-flight expressions so chplan errors surface synchronously.
-	if err := (&Builder{}).Expr(t.SortExpr); err != nil {
-		return err
+	if t.SortExpr != nil {
+		if err := (&Builder{}).Expr(t.SortExpr); err != nil {
+			return err
+		}
 	}
 	for _, by := range t.By {
 		if err := (&Builder{}).Expr(by); err != nil {
@@ -680,21 +694,24 @@ func (e *emitter) emitTopK(t *chplan.TopK) error {
 	if err != nil {
 		return err
 	}
-	sortExpr := t.SortExpr
 
-	// Inner SELECT applies the ORDER BY + LIMIT BY combo. We keep it as
-	// `SELECT *` so the inner subquery's column names flow through to
-	// LIMIT BY's resolution unambiguously. If we instead aliased the
-	// columns here (e.g. `Attributes AS Attributes`), CH's name
-	// resolution for `LIMIT BY Attributes['key']` would prefer the
+	// Inner SELECT applies the (optional) ORDER BY + LIMIT BY combo. We
+	// keep it as `SELECT *` so the inner subquery's column names flow
+	// through to LIMIT BY's resolution unambiguously. If we instead
+	// aliased the columns here (e.g. `Attributes AS Attributes`), CH's
+	// name resolution for `LIMIT BY Attributes['key']` would prefer the
 	// SELECT-list alias over the FROM subquery's column — fine when
 	// they're the same type, but fragile when an outer wrapper rewrites
 	// the alias's type (e.g. the chDB roundtrip runner wraps Map columns
 	// in toJSONString(...) on the outermost SELECT).
-	inner := NewQuery().From(sub).OrderBy(
-		func(b *Builder) { _ = b.Expr(sortExpr) },
-		t.Desc,
-	).Limit(t.K)
+	inner := NewQuery().From(sub)
+	if t.SortExpr != nil {
+		// topk/bottomk: rank by Value before truncating. limitk
+		// (Unordered) skips this — its surviving series are arbitrary.
+		sortExpr := t.SortExpr
+		inner.OrderBy(func(b *Builder) { _ = b.Expr(sortExpr) }, t.Desc)
+	}
+	inner.Limit(t.K)
 	if len(t.By) > 0 {
 		byFrags := make([]Frag, 0, len(t.By))
 		for _, by := range t.By {

--- a/internal/promql/limitk_test.go
+++ b/internal/promql/limitk_test.go
@@ -1,0 +1,212 @@
+package promql_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// experimentalParser returns a PromQL parser with the experimental
+// function set enabled so `limitk` / `limit_ratio` parse. The default
+// parser used elsewhere in the package keeps experimental functions
+// OFF, mirroring the production handler's pre-parse experimental gate.
+func experimentalParser() parser.Parser {
+	return parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+}
+
+// TestLower_LimitK_Shape pins the lowered chplan + emitted SQL shape for
+// PromQL's experimental `limitk(K, v)` aggregator. limitk returns up to
+// K arbitrary series per aggregation group with their samples unchanged
+// — no ranking. The lowering reuses chplan.TopK with Unordered=true, so
+// the emitter renders `LIMIT K BY <partition>` with NO ORDER BY (the
+// "arbitrary K-per-group" contract).
+func TestLower_LimitK_Shape(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := experimentalParser()
+
+	cases := []struct {
+		name        string
+		query       string
+		wantK       int64
+		wantLimitBy string // substring the emitted SQL must contain
+	}{
+		{
+			name:        "by job",
+			query:       `limitk(3, up) by (job)`,
+			wantK:       3,
+			wantLimitBy: "LIMIT 3 BY",
+		},
+		{
+			name:        "without instance",
+			query:       `limitk(2, up) without (instance)`,
+			wantK:       2,
+			wantLimitBy: "LIMIT 2 BY mapFilter",
+		},
+		{
+			name:        "bare (no grouping)",
+			query:       `limitk(5, up)`,
+			wantK:       5,
+			wantLimitBy: "LIMIT 5",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", tc.query, err)
+			}
+			plan, err := promql.Lower(context.Background(), expr, s)
+			if err != nil {
+				t.Fatalf("Lower(%q): %v", tc.query, err)
+			}
+			tk, ok := plan.(*chplan.TopK)
+			if !ok {
+				t.Fatalf("Lower(%q) = %T, want *chplan.TopK", tc.query, plan)
+			}
+			if !tk.Unordered {
+				t.Fatalf("Lower(%q): TopK.Unordered = false, want true (limitk has no ranking)", tc.query)
+			}
+			if tk.SortExpr != nil {
+				t.Fatalf("Lower(%q): TopK.SortExpr = %#v, want nil (limitk does not rank)", tc.query, tk.SortExpr)
+			}
+			if tk.K != tc.wantK {
+				t.Fatalf("Lower(%q): K = %d, want %d", tc.query, tk.K, tc.wantK)
+			}
+
+			sql, _, err := chsql.Emit(context.Background(), plan)
+			if err != nil {
+				t.Fatalf("Emit(%q): %v", tc.query, err)
+			}
+			if strings.Contains(sql, "ORDER BY") {
+				t.Errorf("Emit(%q): SQL must not contain ORDER BY (limitk is unranked).\nSQL: %s", tc.query, sql)
+			}
+			if !strings.Contains(sql, tc.wantLimitBy) {
+				t.Errorf("Emit(%q): SQL missing %q.\nSQL: %s", tc.query, tc.wantLimitBy, sql)
+			}
+		})
+	}
+}
+
+// TestLower_LimitK_KDomain pins the reference-faithful K parameter
+// domain for limitk — shared verbatim with topk/bottomk (topKDomain):
+//
+//   - K < 1 (0, negatives, sub-1 fractions) → an EMPTY result, not an
+//     error: the lowering folds to a constant-false Filter over the
+//     lowered input so the canonical column shape survives.
+//   - Fractional K >= 1 truncates toward zero (`int64(fParam)`).
+//   - NaN / int64-overflow K are rejected exactly where the reference
+//     engine rejects them.
+func TestLower_LimitK_KDomain(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := experimentalParser()
+
+	t.Run("K below one folds to constant-false filter", func(t *testing.T) {
+		t.Parallel()
+		for _, q := range []string{
+			`limitk(0, up)`,
+			`limitk(-1, up)`,
+			`limitk(0.5, up)`,
+			`limitk(0, up) by (job)`,
+		} {
+			expr, err := p.ParseExpr(q)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", q, err)
+			}
+			plan, err := promql.Lower(context.Background(), expr, s)
+			if err != nil {
+				t.Fatalf("Lower(%q): %v", q, err)
+			}
+			f, ok := plan.(*chplan.Filter)
+			if !ok {
+				t.Fatalf("Lower(%q) = %T, want *chplan.Filter", q, plan)
+			}
+			lit, ok := f.Predicate.(*chplan.LitBool)
+			if !ok || lit.V {
+				t.Fatalf("Lower(%q) predicate = %#v, want LitBool{false}", q, f.Predicate)
+			}
+		}
+	})
+
+	t.Run("fractional K truncates toward zero", func(t *testing.T) {
+		t.Parallel()
+		expr, err := p.ParseExpr(`limitk(2.9, up)`)
+		if err != nil {
+			t.Fatalf("ParseExpr: %v", err)
+		}
+		plan, err := promql.Lower(context.Background(), expr, s)
+		if err != nil {
+			t.Fatalf("Lower: %v", err)
+		}
+		tk, ok := plan.(*chplan.TopK)
+		if !ok {
+			t.Fatalf("Lower = %T, want *chplan.TopK", plan)
+		}
+		if tk.K != 2 {
+			t.Fatalf("K = %d, want 2 (int64 truncation of 2.9)", tk.K)
+		}
+	})
+}
+
+// TestLower_LimitK_Errors covers limitk's observable error contract:
+// NaN / overflow K (shared with topKDomain) and the computed-K
+// rejection (limitk(scalar(<vector>), v) is unsupported — CH's LIMIT
+// needs a constant and limitk's arbitrary-selection gives no natural
+// row_number() ordering to filter on).
+func TestLower_LimitK_Errors(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := experimentalParser()
+
+	cases := []struct {
+		name    string
+		query   string
+		wantErr string
+	}{
+		{
+			name:    "NaN K rejected",
+			query:   `limitk(NaN, up)`,
+			wantErr: "K must not be NaN",
+		},
+		{
+			name:    "overflow K rejected",
+			query:   `limitk(1e300, up)`,
+			wantErr: "overflows int64",
+		},
+		{
+			name:    "computed K rejected",
+			query:   `limitk(scalar(up), up)`,
+			wantErr: "computed-K",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", tc.query, err)
+			}
+			_, err = promql.Lower(context.Background(), expr, s)
+			if err == nil {
+				t.Fatalf("Lower(%q): expected error containing %q, got nil", tc.query, tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("Lower(%q): error %q does not contain %q", tc.query, err.Error(), tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -1784,6 +1784,9 @@ func lowerAggregate(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) (ch
 	if a.Op == parser.TOPK || a.Op == parser.BOTTOMK {
 		return lowerTopK(a, s, ctx)
 	}
+	if a.Op == parser.LIMITK {
+		return lowerLimitK(a, s, ctx)
+	}
 	if a.Op == parser.COUNT_VALUES {
 		return lowerCountValues(a, s, ctx)
 	}
@@ -2214,6 +2217,75 @@ func lowerTopK(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) (chplan.
 		By:       by,
 		SortExpr: &chplan.ColumnRef{Name: s.ValueColumn},
 		Desc:     a.Op == parser.TOPK,
+		Columns: []string{
+			s.MetricNameColumn,
+			s.AttributesColumn,
+			s.TimestampColumn,
+			s.ValueColumn,
+		},
+	}, nil
+}
+
+// lowerLimitK lowers PromQL's experimental `limitk(K, expr) [by(g) |
+// without(g)] (...)` aggregator. Unlike topk/bottomk, limitk does NOT
+// rank: per aggregation group it returns up to K *arbitrary* series,
+// with their samples unchanged. The result vector keeps every original
+// label of the surviving series — `by(...)` only partitions, it does
+// not drop labels (same shape contract as topk).
+//
+// SQL shape:
+//
+//	SELECT MetricName, Attributes, TimeUnix, Value FROM (<inner>)
+//	  LIMIT K [BY <partition_exprs>]
+//
+// There is no ORDER BY — CH's `LIMIT K BY <group>` returns the first K
+// rows it encounters per partition, which is exactly limitk's "any K
+// series per group" contract. The partition shape and the K-domain
+// rules are shared verbatim with topk/bottomk (topKPartition /
+// topKDomain): K < 1 short-circuits to an empty result, fractional
+// K >= 1 truncates toward zero, NaN / int64-overflow K are rejected.
+//
+// Computed K (`limitk(scalar(<vector>), v)`) is not modelled — CH's
+// LIMIT requires a constant and limitk's arbitrary-selection contract
+// gives no natural row_number() ordering to filter on. The literal-K
+// fast path is the only supported shape; a scalar()-K form is rejected
+// with a clear error rather than silently mis-lowered.
+//
+// Range mode (ctx.step > 0): like topk, limitk selects K series per
+// evaluation step. topKPartition appends the per-step TimeUnix anchor
+// so `LIMIT K BY (<user-partition>, TimeUnix)` fires per anchor.
+func lowerLimitK(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	kF, ok := tryScalarLiteral(a.Param)
+	if !ok {
+		return nil, fmt.Errorf("promql: limitk K must be a scalar literal; computed-K (e.g. scalar(<vector>)) is not supported")
+	}
+	k, empty, err := topKDomain(a.Op, kF)
+	if err != nil {
+		return nil, err
+	}
+
+	input, err := lower(a.Expr, s, ctx)
+	if err != nil {
+		return nil, err
+	}
+	if empty {
+		// K < 1 → empty result per reference semantics (see
+		// topKDomain). Filter the lowered input to zero rows so the
+		// plan keeps the canonical column shape — same posture as
+		// lowerTopK's K-too-small fold.
+		return &chplan.Filter{
+			Input:     input,
+			Predicate: &chplan.LitBool{V: false},
+		}, nil
+	}
+
+	by := topKPartition(a, s, ctx)
+
+	return &chplan.TopK{
+		Input:     input,
+		K:         k,
+		By:        by,
+		Unordered: true,
 		Columns: []string{
 			s.MetricNameColumn,
 			s.AttributesColumn,

--- a/internal/promql/subquery.go
+++ b/internal/promql/subquery.go
@@ -713,10 +713,11 @@ func subqueryAnchor(e *parser.SubqueryExpr, ctx lowerCtx) (evalAnchor, error) {
 // caring that the underlying series identity came from a `by(...)` /
 // `without(...)` clause rather than the raw scan's Attributes map.
 //
-// Shape-changing aggregations (`topk` / `bottomk` / `count_values`) are
-// dispatched to dedicated helpers — topk/bottomk preserve every input
-// label and emit a TopK plan node, count_values builds a synthetic
-// label from the per-bucket value via toString().
+// Shape-changing aggregations (`topk` / `bottomk` / `limitk` /
+// `count_values`) are dispatched to dedicated helpers — topk/bottomk/
+// limitk preserve every input label and emit a TopK plan node (limitk
+// via the Unordered LIMIT-K-BY shape, no ranking), count_values builds
+// a synthetic label from the per-bucket value via toString().
 func lowerSubqueryOverAggregate(
 	sub *parser.SubqueryExpr,
 	agg *parser.AggregateExpr,
@@ -725,7 +726,7 @@ func lowerSubqueryOverAggregate(
 	ctx lowerCtx,
 ) (chplan.Node, error) {
 	switch agg.Op {
-	case parser.TOPK, parser.BOTTOMK:
+	case parser.TOPK, parser.BOTTOMK, parser.LIMITK:
 		return lowerSubqueryOverTopK(sub, agg, step, s, ctx)
 	case parser.COUNT_VALUES:
 		return lowerSubqueryOverCountValues(sub, agg, step, s, ctx)
@@ -947,17 +948,32 @@ func lowerSubqueryOverTopK(
 	}
 	by = append(by, &chplan.ColumnRef{Name: "anchor_ts"})
 
+	columns := []string{
+		s.AttributesColumn,
+		"anchor_ts",
+		s.ValueColumn,
+	}
+
+	if agg.Op == parser.LIMITK {
+		// limitk: K arbitrary series per (partition, anchor) — no
+		// ranking. Unordered emits `LIMIT K BY <by>` with no ORDER BY
+		// and a nil SortExpr (mirrors lower.go's lowerLimitK).
+		return &chplan.TopK{
+			Input:     matrix,
+			K:         k,
+			By:        by,
+			Unordered: true,
+			Columns:   columns,
+		}, nil
+	}
+
 	return &chplan.TopK{
 		Input:    matrix,
 		K:        k,
 		By:       by,
 		SortExpr: &chplan.ColumnRef{Name: s.ValueColumn},
 		Desc:     agg.Op == parser.TOPK,
-		Columns: []string{
-			s.AttributesColumn,
-			"anchor_ts",
-			s.ValueColumn,
-		},
+		Columns:  columns,
 	}, nil
 }
 

--- a/test/e2e/grafana/compose/dashboards/showcase-promql.json
+++ b/test/e2e/grafana/compose/dashboards/showcase-promql.json
@@ -2611,6 +2611,100 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "cerberus-prometheus"
+      },
+      "description": "Cerberus lowers PromQL's experimental `limitk(K, v)` aggregator to ClickHouse's `LIMIT K BY <group>` (no ORDER BY): up to K arbitrary series per group, samples unchanged.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 63
+      },
+      "id": 74,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "cerberus-prometheus"
+          },
+          "editorMode": "code",
+          "expr": "limitk(2, up)",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "limitk",
+      "type": "timeseries",
+      "cerberus": {
+        "expect": "nonempty",
+        "why": "Cerberus implements this construct; the panel asserts a live nonempty result. Previously a parity-rejection pin \u2014 the experimental-aggregator burndown landed the lowering (limitk \u2192 LIMIT K BY), so the contract is upgraded to nonempty per the bidirectional ratchet."
+      }
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
@@ -6549,100 +6643,6 @@
             }
           ],
           "title": "histogram_quantiles \u2014 parity rejection",
-          "type": "timeseries",
-          "cerberus": {
-            "expect": "error:not yet supported",
-            "why": "Cerberus rejects this construct today; the declaration is a bidirectional parity pin \u2014 the moment lowering support lands, this panel fails the sweep and the contract must be upgraded to nonempty."
-          }
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "cerberus-prometheus"
-          },
-          "description": "Cerberus rejects `limitk(2, up)` today; this panel pins the rejection.",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 7,
-            "w": 8,
-            "x": 8,
-            "y": 172
-          },
-          "id": 74,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "cerberus-prometheus"
-              },
-              "editorMode": "code",
-              "expr": "limitk(2, up)",
-              "legendFormat": "__auto",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "limitk \u2014 parity rejection",
           "type": "timeseries",
           "cerberus": {
             "expect": "error:not yet supported",

--- a/test/perf/cardinality-baseline.json
+++ b/test/perf/cardinality-baseline.json
@@ -3330,6 +3330,46 @@
     "max_recursion_depth": 0
   },
   {
+    "fixture": "promql/limitk_below_one_empty",
+    "fan_factor": 1,
+    "scan_rows": 2,
+    "peak_intermediate": 2,
+    "has_cross_join": false,
+    "has_array_join": false,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0
+  },
+  {
+    "fixture": "promql/limitk_by_job_all_survive",
+    "fan_factor": 1,
+    "scan_rows": 4,
+    "peak_intermediate": 4,
+    "has_cross_join": false,
+    "has_array_join": false,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0
+  },
+  {
+    "fixture": "promql/limitk_by_job_truncates",
+    "fan_factor": 1,
+    "scan_rows": 4,
+    "peak_intermediate": 4,
+    "has_cross_join": false,
+    "has_array_join": false,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0
+  },
+  {
+    "fixture": "promql/limitk_without_instance",
+    "fan_factor": 1,
+    "scan_rows": 4,
+    "peak_intermediate": 4,
+    "has_cross_join": false,
+    "has_array_join": false,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0
+  },
+  {
     "fixture": "promql/ln_metric",
     "fan_factor": 1,
     "scan_rows": 1,
@@ -4264,6 +4304,16 @@
     "fan_factor": 3,
     "scan_rows": 2,
     "peak_intermediate": 6,
+    "has_cross_join": false,
+    "has_array_join": true,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0
+  },
+  {
+    "fixture": "promql/subquery_over_limitk",
+    "fan_factor": 1.3333333333333333,
+    "scan_rows": 6,
+    "peak_intermediate": 8,
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,

--- a/test/perf/solver-decision-baseline.json
+++ b/test/perf/solver-decision-baseline.json
@@ -1068,6 +1068,30 @@
     "reason": "routed"
   },
   {
+    "query": "limitk_below_one_empty",
+    "routed": true,
+    "k": 8,
+    "reason": "routed"
+  },
+  {
+    "query": "limitk_by_job_all_survive",
+    "routed": false,
+    "k": 0,
+    "reason": "not-sliceable"
+  },
+  {
+    "query": "limitk_by_job_truncates",
+    "routed": false,
+    "k": 0,
+    "reason": "not-sliceable"
+  },
+  {
+    "query": "limitk_without_instance",
+    "routed": false,
+    "k": 0,
+    "reason": "not-sliceable"
+  },
+  {
     "query": "ln_metric",
     "routed": true,
     "k": 8,
@@ -1630,6 +1654,12 @@
     "routed": false,
     "k": 0,
     "reason": "instant"
+  },
+  {
+    "query": "subquery_over_limitk",
+    "routed": false,
+    "k": 0,
+    "reason": "not-sliceable"
   },
   {
     "query": "subquery_over_quantile",

--- a/test/perf/solver_decision_ratchet_test.go
+++ b/test/perf/solver_decision_ratchet_test.go
@@ -159,9 +159,9 @@ func classifyCorpus(t *testing.T) map[string]decisionEntry {
 	// Mirror the production PromQL head, which builds its parser with
 	// EnableExperimentalFunctions=true (see internal/api/prom/lang.go) so
 	// the deliberately-supported experimental subset
-	// (mad_over_time / ts_of_*_over_time / range() / step() / …) parses.
-	// Without this the ratchet rejects those corpus fixtures at parse time
-	// even though the engine accepts them.
+	// (mad_over_time / ts_of_*_over_time / range() / step() / limitk() / …)
+	// parses. Without this the ratchet rejects those corpus fixtures at parse
+	// time even though the engine accepts them.
 	parse := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
 	meta := solver.RequestMeta{
 		Lang:  "promql",

--- a/test/rejection-parity/catalogue.json
+++ b/test/rejection-parity/catalogue.json
@@ -503,7 +503,7 @@
       "site": "internal/promql/lower.go:buildAggFunc#a6e9df79",
       "message": "promql: aggregation op %s is not yet supported",
       "class": "rejection",
-      "trigger_query": "limitk(2, up)"
+      "trigger_query": "limit_ratio(0.5, up)"
     },
     {
       "head": "promql",
@@ -539,6 +539,13 @@
       "message": "promql: count_values requires a non-empty label name",
       "class": "rejection",
       "trigger_query": "count_values(\"\", up)"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/lower.go:lowerLimitK#5ff80394",
+      "message": "promql: limitk K must be a scalar literal; computed-K (e.g. scalar(\u003cvector\u003e)) is not supported",
+      "class": "rejection",
+      "trigger_query": "limitk(scalar(up), up)"
     },
     {
       "head": "promql",
@@ -769,7 +776,7 @@
       "site": "internal/promql/subquery.go:lowerSubqueryOverAggregate#534fdfbe",
       "message": "promql: subquery over %s aggregation is not supported",
       "class": "rejection",
-      "trigger_query": "max_over_time(limitk(2, up)[5m:1m])"
+      "trigger_query": "max_over_time(limit_ratio(0.5, up)[5m:1m])"
     },
     {
       "head": "promql",

--- a/test/spec/chplan_print.go
+++ b/test/spec/chplan_print.go
@@ -114,9 +114,13 @@ func printNode(b *strings.Builder, n chplan.Node, depth int) {
 		if v.Desc {
 			dir = "DESC"
 		}
-		if v.KExpr != nil {
+		switch {
+		case v.Unordered:
+			// limitk: no ranking — arbitrary K rows per partition.
+			fmt.Fprintf(b, "%sLimitK k=%d", indent, v.K)
+		case v.KExpr != nil:
 			fmt.Fprintf(b, "%sTopK k=<expr> sort=%s %s", indent, printExpr(v.SortExpr), dir)
-		} else {
+		default:
 			fmt.Fprintf(b, "%sTopK k=%d sort=%s %s", indent, v.K, printExpr(v.SortExpr), dir)
 		}
 		if len(v.By) > 0 {

--- a/test/spec/promql/limitk_below_one_empty.txtar
+++ b/test/spec/promql/limitk_below_one_empty.txtar
@@ -1,0 +1,30 @@
+-- query.promql --
+limitk(0, up)
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api', 'instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 0.4),
+    ('up', map('job', 'web', 'instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 0.9);
+-- expected_rows --
+[]
+-- args --
+[0] string = "up"
+[1] string = "2026-01-01 00:00:01.000000000"
+[2] int64 = 9
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] int64 = 300000000000
+[6] bool = false
+-- chplan --
+Filter predicate=false
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(merge(otel_metrics_gauge|otel_metrics_sum))
+-- sql --
+SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) WHERE ?

--- a/test/spec/promql/limitk_by_job_all_survive.txtar
+++ b/test/spec/promql/limitk_by_job_all_survive.txtar
@@ -1,0 +1,37 @@
+-- query.promql --
+limitk(5, up) by (job)
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api', 'instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 0.1),
+    ('up', map('job', 'api', 'instance', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 0.5),
+    ('up', map('job', 'web', 'instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 0.3),
+    ('up', map('job', 'web', 'instance', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 0.8);
+-- expected_rows --
+[
+  ["up", {"instance": "a", "job": "api"}, "2026-01-01T00:00:00Z", 0.1],
+  ["up", {"instance": "a", "job": "web"}, "2026-01-01T00:00:00Z", 0.3],
+  ["up", {"instance": "b", "job": "api"}, "2026-01-01T00:00:00Z", 0.5],
+  ["up", {"instance": "b", "job": "web"}, "2026-01-01T00:00:00Z", 0.8]
+]
+-- args --
+[0] string = "up"
+[1] string = "2026-01-01 00:00:01.000000000"
+[2] int64 = 9
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] int64 = 300000000000
+[6] string = "job"
+-- chplan --
+LimitK k=5 by=[Attributes["job"]] columns=[MetricName, Attributes, TimeUnix, Value]
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(merge(otel_metrics_gauge|otel_metrics_sum))
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) LIMIT 5 BY `Attributes`[?])

--- a/test/spec/promql/limitk_by_job_truncates.txtar
+++ b/test/spec/promql/limitk_by_job_truncates.txtar
@@ -1,0 +1,35 @@
+-- query.promql --
+limitk(1, up) by (job)
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api', 'instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 0.1),
+    ('up', map('job', 'api', 'instance', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 0.5),
+    ('up', map('job', 'web', 'instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 0.3),
+    ('up', map('job', 'web', 'instance', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 0.8);
+-- expected_rows --
+[
+  ["up", {"instance": "b", "job": "api"}, "2026-01-01T00:00:00Z", 0.5],
+  ["up", {"instance": "b", "job": "web"}, "2026-01-01T00:00:00Z", 0.8]
+]
+-- args --
+[0] string = "up"
+[1] string = "2026-01-01 00:00:01.000000000"
+[2] int64 = 9
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] int64 = 300000000000
+[6] string = "job"
+-- chplan --
+LimitK k=1 by=[Attributes["job"]] columns=[MetricName, Attributes, TimeUnix, Value]
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(merge(otel_metrics_gauge|otel_metrics_sum))
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) LIMIT 1 BY `Attributes`[?])

--- a/test/spec/promql/limitk_without_instance.txtar
+++ b/test/spec/promql/limitk_without_instance.txtar
@@ -1,0 +1,37 @@
+-- query.promql --
+limitk(2, up) without (instance)
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api', 'instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 0.1),
+    ('up', map('job', 'api', 'instance', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 0.5),
+    ('up', map('job', 'web', 'instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 0.3),
+    ('up', map('job', 'web', 'instance', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 0.8);
+-- expected_rows --
+[
+  ["up", {"instance": "a", "job": "api"}, "2026-01-01T00:00:00Z", 0.1],
+  ["up", {"instance": "a", "job": "web"}, "2026-01-01T00:00:00Z", 0.3],
+  ["up", {"instance": "b", "job": "api"}, "2026-01-01T00:00:00Z", 0.5],
+  ["up", {"instance": "b", "job": "web"}, "2026-01-01T00:00:00Z", 0.8]
+]
+-- args --
+[0] string = "up"
+[1] string = "2026-01-01 00:00:01.000000000"
+[2] int64 = 9
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] int64 = 300000000000
+[6] string = "instance"
+-- chplan --
+LimitK k=2 by=[mapWithout(Attributes, [instance])] columns=[MetricName, Attributes, TimeUnix, Value]
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(merge(otel_metrics_gauge|otel_metrics_sum))
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) LIMIT 2 BY mapFilter((k, v) -> NOT (k IN (?)), `Attributes`))

--- a/test/spec/promql/subquery_over_limitk.txtar
+++ b/test/spec/promql/subquery_over_limitk.txtar
@@ -1,0 +1,34 @@
+-- query.promql --
+max_over_time(limitk(2, rate(http_requests_total[1m]))[1h:30s])
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('http_requests_total', map('job', 'api', 'instance', 'a'), toDateTime64('2025-12-31 23:59:30', 9), 100.0),
+    ('http_requests_total', map('job', 'api', 'instance', 'a'), toDateTime64('2025-12-31 23:59:45', 9), 110.0),
+    ('http_requests_total', map('job', 'api', 'instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 120.0),
+    ('http_requests_total', map('job', 'api', 'instance', 'b'), toDateTime64('2025-12-31 23:59:30', 9), 50.0),
+    ('http_requests_total', map('job', 'api', 'instance', 'b'), toDateTime64('2025-12-31 23:59:45', 9), 55.0),
+    ('http_requests_total', map('job', 'api', 'instance', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 60.0);
+-- expected_rows --
+[
+  [{"instance": "a", "job": "api"}, 0.4166666666666667],
+  [{"instance": "b", "job": "api"}, 0.20833333333333334]
+]
+-- args --
+[0] string = "http_requests_total"
+[1] string = "http.requests.total"
+[2] string = "http.requests_total"
+[3] string = "http_requests.total"
+-- chplan --
+RangeWindow func=max_over_time range=1h0m0s step=0s ts=anchor_ts value=Value groupBy=[Attributes]
+  LimitK k=2 by=[anchor_ts] columns=[Attributes, anchor_ts, Value]
+    RangeWindow func=rate range=1m0s step=30s outerRange=1h0m0s ts=TimeUnix value=Value groupBy=[Attributes]
+      Filter predicate=(MetricName IN ("http_requests_total", "http.requests.total", "http.requests_total", "http_requests.total"))
+        Scan(otel_metrics_sum)
+-- sql --
+SELECT `Attributes`, max(`Value`) AS `Value` FROM (SELECT `Attributes`, `anchor_ts`, `Value` FROM (SELECT * FROM (SELECT `Attributes`, `anchor_ts`, anchor_ts AS `TimeUnix`, if(sampled_interval > 0, counter_delta * (sampled_interval + if(counter_delta > 0 AND first_val >= 0, least(duration_to_start, sampled_interval * first_val / counter_delta), duration_to_start) + duration_to_end) / sampled_interval / 60, nan) AS `Value` FROM (SELECT `Attributes`, `anchor_ts`, `window_vals`, `counter_delta`, `first_val`, toFloat64(dateDiff('nanosecond', first_ts, last_ts)) / 1e9 AS `sampled_interval`, if(toFloat64(dateDiff('nanosecond', anchor_ts - toIntervalNanosecond(60000000000), first_ts)) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', anchor_ts - toIntervalNanosecond(60000000000), first_ts)) / 1e9) AS `duration_to_start`, if(toFloat64(dateDiff('nanosecond', last_ts, anchor_ts)) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', last_ts, anchor_ts)) / 1e9) AS `duration_to_end` FROM (SELECT `Attributes`, `anchor_ts`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta`, tupleElement(window_pairs[1], 1) AS `first_ts`, tupleElement(window_pairs[length(window_pairs)], 1) AS `last_ts`, tupleElement(window_pairs[1], 2) AS `first_val` FROM (SELECT `Attributes`, `anchor_ts`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `window_pairs` FROM (SELECT `Attributes`, `TimeUnix`, `Value`, arrayJoin(arrayMap(i -> fromUnixTimestamp64Nano(intDiv(toUnixTimestamp64Nano(now64(9)), 30000000000) * 30000000000) - toIntervalNanosecond(i * 30000000000), range(greatest(0, intDiv(dateDiff('nanosecond', `TimeUnix`, fromUnixTimestamp64Nano(intDiv(toUnixTimestamp64Nano(now64(9)), 30000000000) * 30000000000)) - 60000000000, toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, fromUnixTimestamp64Nano(intDiv(toUnixTimestamp64Nano(now64(9)), 30000000000) * 30000000000)) - 60000000000, toInt64(30000000000)) < 0) + 1), least(121, intDiv(dateDiff('nanosecond', `TimeUnix`, fromUnixTimestamp64Nano(intDiv(toUnixTimestamp64Nano(now64(9)), 30000000000) * 30000000000)), toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, fromUnixTimestamp64Nano(intDiv(toUnixTimestamp64Nano(now64(9)), 30000000000) * 30000000000)), toInt64(30000000000)) < 0) + 1)))) AS `anchor_ts` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` IN (?, ?, ?, ?)))) GROUP BY `Attributes`, `anchor_ts`))) WHERE length(`window_vals`) >= 2) LIMIT 2 BY `anchor_ts`)) WHERE `anchor_ts` > now64(9) - toIntervalNanosecond(3600000000000) AND `anchor_ts` <= now64(9) GROUP BY `Attributes`

--- a/test/surface-parity/inventory.json
+++ b/test/surface-parity/inventory.json
@@ -61,10 +61,9 @@
       "symbol": "agg:limitk",
       "kind": "aggregator",
       "probe": "limitk(3, up)",
-      "cerberus": "reject",
+      "cerberus": "accept",
       "reference": "reject",
-      "class": "parity-reject",
-      "cerberus_error": "promql: aggregation op limitk is not yet supported"
+      "class": "wrong-accept"
     },
     {
       "head": "promql",


### PR DESCRIPTION
## What

Implements PromQL's experimental **`limitk(K, v)`** aggregator for real (lower → emit ClickHouse SQL), so it returns correct data matching reference Prometheus instead of 422-ing at the generic "function … is not yet supported" fall-through. This was masquerading as a "parity rejection" in the showcase.

## Reference semantics

`limitk(K, v) [by(g) | without(g)]` returns **up to K arbitrary series per aggregation group**, with their samples unchanged. Unlike `topk`/`bottomk` there is **no ranking** — the reference engine (`aggregationK` in prometheus/promql) picks an arbitrary K-subset. The parity-relevant invariant is the per-group cardinality (≤ K), not which specific series survive.

K-domain (shared verbatim with topk/bottomk):
- `K < 1` (0, negatives, sub-1 fractions) → **empty result** (not an error).
- Fractional `K >= 1` truncates toward zero.
- `NaN` / `int64`-overflow K → rejected exactly where the reference engine rejects them.

## Lowering + emit approach

- **chplan.TopK gains an `Unordered bool`** field. When set, `SortExpr` is nil and the emitter renders `SELECT … FROM (<input>) LIMIT K BY <By>` with **no ORDER BY** — CH's `LIMIT K BY <group>` already returns the first K rows per partition, which is exactly limitk's "any K series per group" contract.
- `lowerLimitK` (internal/promql/lower.go) mirrors `lowerTopK`: routed from `lowerAggregate` via `case parser.LIMITK`, reuses `topKDomain` (K-domain) and `topKPartition` (by/without/range partition shape, including the per-step TimeUnix anchor in range mode).
- Computed-K (`limitk(scalar(<vector>), v)`) is rejected with a clear error — CH's LIMIT needs a constant and limitk's arbitrary-selection gives no natural `row_number()` ordering to filter on.
- The **subquery-over-aggregate** path (`max_over_time(limitk(…)[1h:30s])`) routes through the same TopK/Unordered shape with the per-anchor partition key.
- Typed Frags only — no raw SQL. The emit change composes via `QueryBuilder.LimitBy` / the existing clause renderer; the `grep 'sb.Write\|writeSQL\|strings.Builder'` self-check is clean.

## Unmasked showcase panel

`test/e2e/grafana/compose/dashboards/showcase-promql.json`: the `limitk(2, up)` panel moved **out** of the collapsed "Parity rejections — declared error contracts" row and **into** the Aggregations row, flipped from `cerberus.expect: error:not yet supported` to **`nonempty`**. The compose seed already produces multi-series `up` (`{job=api}`=1.0, `{job=db}`=0.0), so `limitk(2, up)` renders both series.

## Tests added

- **Unit (internal/promql/limitk_test.go):** lowered chplan + emitted SQL shape (Unordered, nil SortExpr, `LIMIT K BY`, no ORDER BY) for by/without/bare; K-domain (K<1 → constant-false Filter, fractional truncation); error contract (NaN / overflow / computed-K).
- **chDB-backed roundtrip fixtures (test/spec/promql/):** `limitk_by_job_all_survive` (K≥group size → all survive), `limitk_by_job_truncates` (K=1 → exactly 1 per group), `limitk_without_instance`, `limitk_below_one_empty` (K=0 → []), and `subquery_over_limitk`. Each pins the SQL + chplan + the live chDB result.
- The prom parse→lower-split test (`internal/api/prom/lang_test.go::TestLang_Parse_LowerError`) moves its still-unsupported example from `limitk` (now lowered) to the sibling `limit_ratio`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)