### PR TITLE
feat(traceql): lower unary minus over a field expression

### DIFF
--- a/internal/traceql/lower.go
+++ b/internal/traceql/lower.go
@@ -720,8 +720,47 @@ func lowerUnaryOperation(u traceql.UnaryOperation, s schema.Traces) (chplan.Expr
 		return lowerNilComparison(u.Op, attr, s)
 	case traceql.OpNot:
 		return lowerUnaryNot(u, s)
+	case traceql.OpSub:
+		return lowerUnaryMinus(u, s)
 	}
 	return nil, fmt.Errorf("traceql: unary operator %s is unsupported", u.Op)
+}
+
+// lowerUnaryMinus lowers the arithmetic negation `-<numeric-expr>`
+// (UnaryOperation{OpSub}) — e.g. `{ -span.foo > 0 }`,
+// `{ -(span.a + span.b) = -5 }`, `{ -span.duration < 0ns }`.
+//
+// Reference semantics (tsouza/tempo fork, ast_execute.go
+// UnaryOperation.execute, OpSub branch): the operand executes to a
+// Static; if its type is not numeric (int / float / duration) the
+// reference returns an error, otherwise it returns `-1 * n` preserving
+// the operand's numeric type (NewStaticInt / NewStaticFloat /
+// NewStaticDuration). The parser AST-rewrites a unary minus over a
+// constant operand into a folded negative Static (newUnaryOperation's
+// `!referencesSpan()` simplification), so a UnaryOperation{OpSub} that
+// survives to lowering always references a span — its operand is an
+// attribute (or arithmetic over attributes), never a bare literal.
+//
+// We mirror reference `-1 * n` as `0 - <operand>`: a Binary{OpSub} with
+// a zero-int left arm. This reuses the existing numeric-coercion path —
+// the operand's FieldAccess children are wrapped in toFloat64OrNull by
+// coerceFieldAccess so the Map(String,String) subscript computes as a
+// number server-side, with absent/non-numeric values folding to NULL
+// exactly as the binary-arithmetic path does. The enclosing comparison
+// (or outer arithmetic) then coerces the whole `0 - operand` Binary via
+// coerceNumericFieldAccess, so duration/int/float operands all land as
+// Float64 — numerically identical to reference's typed negation for the
+// comparisons TraceQL allows (`<neg-expr> <op> <numeric-literal>`).
+func lowerUnaryMinus(u traceql.UnaryOperation, s schema.Traces) (chplan.Expr, error) {
+	operand, err := lowerFieldExpr(u.Expression, s)
+	if err != nil {
+		return nil, err
+	}
+	return &chplan.Binary{
+		Op:    chplan.OpSub,
+		Left:  &chplan.LitInt{V: 0},
+		Right: coerceFieldAccess(operand),
+	}, nil
 }
 
 // lowerUnaryNot lowers the boolean negation `!( <bool-expr> )`. Tempo's

--- a/internal/traceql/unary_minus_test.go
+++ b/internal/traceql/unary_minus_test.go
@@ -1,0 +1,89 @@
+package traceql_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tempo "github.com/grafana/tempo/pkg/traceql"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/traceql"
+)
+
+// TestLowerUnaryMinus pins the arithmetic-negation lowering
+// (UnaryOperation{OpSub}). Reference Tempo (pkg/traceql
+// ast_execute.go UnaryOperation.execute OpSub) negates a numeric
+// operand and returns `-1 * n`; cerberus lowers it as `0 - <operand>`
+// (chplan.Binary{OpSub}) so the existing arithmetic emit + numeric
+// coercion paths apply. The parser constant-folds any non-span operand
+// (newUnaryOperation), so every shape exercised here references a span.
+//
+// This is the non-chdb companion to the txtar roundtrip fixtures
+// (test/spec/traceql/unary_minus_*.txtar) — those pin the
+// RESULT against real ClickHouse execution; this pins the SQL SHAPE so
+// a coercion or operator regression surfaces as a visible substring
+// failure even when libchdb is unavailable.
+func TestLowerUnaryMinus(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelTraces()
+
+	cases := []struct {
+		name       string
+		query      string
+		wantSubstr string
+	}{
+		{
+			// Bare numeric attribute operand: the operand FieldAccess is
+			// wrapped in toFloat64OrNull by the outer comparison's numeric
+			// coercion recursing into the `0 - x` arithmetic Binary.
+			name:       "bare_attr_negated_gt",
+			query:      `{ -.payload_bytes > -100 }`,
+			wantSubstr: "(? - toFloat64OrNull(`SpanAttributes`[?])) > ?",
+		},
+		{
+			name:       "bare_attr_negated_lt",
+			query:      `{ -.a < 5 }`,
+			wantSubstr: "(? - toFloat64OrNull(`SpanAttributes`[?])) < ?",
+		},
+		{
+			// Nested arithmetic operand: coercion recurses through both the
+			// negation Binary and the inner `+` Binary, wrapping the leaf
+			// FieldAccess.
+			name:       "nested_arith_operand",
+			query:      `{ -(.a + 1) < -10 }`,
+			wantSubstr: "(? - (toFloat64OrNull(`SpanAttributes`[?]) + ?)) < ?",
+		},
+		{
+			// Negated resource-scoped attribute resolves against the
+			// ResourceAttributes carrier.
+			name:       "resource_attr_negated",
+			query:      `{ -resource.replicas > -5 }`,
+			wantSubstr: "(? - toFloat64OrNull(`ResourceAttributes`[?])) > ?",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := tempo.Parse(tc.query)
+			if err != nil {
+				t.Fatalf("Parse(%q): %v", tc.query, err)
+			}
+			plan, err := traceql.Lower(context.Background(), expr, s)
+			if err != nil {
+				t.Fatalf("Lower(%q): %v", tc.query, err)
+			}
+			sql, _, err := chsql.Emit(context.Background(), plan)
+			if err != nil {
+				t.Fatalf("Emit(%q): %v", tc.query, err)
+			}
+			if !strings.Contains(sql, tc.wantSubstr) {
+				t.Fatalf("SQL missing wanted substring\n  want: %s\n   sql: %s", tc.wantSubstr, sql)
+			}
+		})
+	}
+}

--- a/test/e2e/grafana/compose/dashboards/showcase-traceql.json
+++ b/test/e2e/grafana/compose/dashboards/showcase-traceql.json
@@ -790,7 +790,7 @@
     "type": "tempo",
     "uid": "cerberus-tempo"
    },
-   "description": "All six arithmetic operators against the seeded payload_bytes span attribute; toFloat64OrNull coercion keeps spans without the attribute out of the result instead of aborting the query.",
+   "description": "The six binary arithmetic operators plus unary minus (-x) against the seeded payload_bytes span attribute; toFloat64OrNull coercion keeps spans without the attribute out of the result instead of aborting the query.",
    "fieldConfig": {
     "defaults": {
      "color": {
@@ -900,6 +900,17 @@
      "query": "{ .payload_bytes ^ 2 > 100 }",
      "queryType": "traceql",
      "refId": "F",
+     "tableType": "traces"
+    },
+    {
+     "datasource": {
+      "type": "tempo",
+      "uid": "cerberus-tempo"
+     },
+     "limit": 20,
+     "query": "{ -.payload_bytes < 0 }",
+     "queryType": "traceql",
+     "refId": "G",
      "tableType": "traces"
     }
    ],

--- a/test/e2e/grafana/ql-inventory/traceql-feature-inventory.json
+++ b/test/e2e/grafana/ql-inventory/traceql-feature-inventory.json
@@ -369,6 +369,12 @@
       "pin": "{ .payload_bytes - 1 \u003e 100 }"
     },
     {
+      "id": "op:unary-minus",
+      "class": "arithmetic",
+      "token": "-x",
+      "pin": "{ -.payload_bytes \u003c 0 }"
+    },
+    {
       "id": "pipe:avg",
       "class": "spanset-aggregate",
       "token": "avg()",

--- a/test/inventory/traceql.go
+++ b/test/inventory/traceql.go
@@ -115,6 +115,11 @@ func curatedTraceQLRows() []Row {
 
 		// --- Field-expression arithmetic ---
 		mk("op:add", "arithmetic", "+", `{ .payload_bytes + 1 > 100 }`),
+		// Unary minus (arithmetic negation). The operand must reference a
+		// span (a bare `-5` is constant-folded by the parser into a
+		// negative Static, which would never reach the UnaryOperation
+		// matcher), so the pin negates an attribute.
+		mk("op:unary-minus", "arithmetic", "-x", `{ -.payload_bytes < 0 }`),
 		mk("op:sub", "arithmetic", "-", `{ .payload_bytes - 1 > 100 }`),
 		mk("op:mult", "arithmetic", "*", `{ .payload_bytes * 2 > 100 }`),
 		mk("op:div", "arithmetic", "/", `{ .payload_bytes / 2 > 100 }`),
@@ -455,6 +460,13 @@ func collectTraceQLUnary(ids map[string]bool, u traceql.UnaryOperation) {
 		ids["op:not-exists"] = true
 	case traceql.OpNot:
 		ids["op:not"] = true
+	case traceql.OpSub:
+		// Unary minus (arithmetic negation `-<expr>`). The same OpSub
+		// token reaches binaryOpRowID for the binary `a - b` form; the
+		// two never collide because the parser emits distinct
+		// BinaryOperation vs UnaryOperation nodes, so a UnaryOperation
+		// carrying OpSub is unambiguously the negation row.
+		ids["op:unary-minus"] = true
 	}
 	collectTraceQLFieldExpr(ids, u.Expression)
 }

--- a/test/perf/cardinality-baseline.json
+++ b/test/perf/cardinality-baseline.json
@@ -6550,6 +6550,36 @@
     "max_recursion_depth": 0
   },
   {
+    "fixture": "traceql/unary_minus_arith",
+    "fan_factor": 1,
+    "scan_rows": 1,
+    "peak_intermediate": 1,
+    "has_cross_join": false,
+    "has_array_join": false,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0
+  },
+  {
+    "fixture": "traceql/unary_minus_attr",
+    "fan_factor": 1,
+    "scan_rows": 1,
+    "peak_intermediate": 1,
+    "has_cross_join": false,
+    "has_array_join": false,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0
+  },
+  {
+    "fixture": "traceql/unary_minus_duration",
+    "fan_factor": 1,
+    "scan_rows": 2,
+    "peak_intermediate": 2,
+    "has_cross_join": false,
+    "has_array_join": false,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0
+  },
+  {
     "fixture": "traceql/unary_not_attr",
     "fan_factor": 1,
     "scan_rows": 1,

--- a/test/spec/traceql/unary_minus_arith.txtar
+++ b/test/spec/traceql/unary_minus_arith.txtar
@@ -1,0 +1,22 @@
+-- query.traceql --
+{ -(span.a + span.b) < -10 }
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    SpanAttributes Map(String, String) MATERIALIZED map('a', if(_idx = 0, '7', '3'), 'b', if(_idx = 0, '8', '4'))
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1);
+-- expected_rows --
+[
+  [0]
+]
+-- args --
+[0] int64 = 0
+[1] string = "a"
+[2] string = "b"
+[3] int64 = -10
+-- chplan --
+Filter predicate=((0 - (toFloat64OrNull(SpanAttributes["a"]) + toFloat64OrNull(SpanAttributes["b"]))) < -10)
+  Scan(otel_traces)
+-- sql --
+SELECT * FROM `otel_traces` WHERE ((? - (toFloat64OrNull(`SpanAttributes`[?]) + toFloat64OrNull(`SpanAttributes`[?]))) < ?)

--- a/test/spec/traceql/unary_minus_attr.txtar
+++ b/test/spec/traceql/unary_minus_attr.txtar
@@ -1,0 +1,21 @@
+-- query.traceql --
+{ -span.x > -3 }
+-- seed --
+CREATE TABLE otel_traces (
+    _idx UInt64,
+    SpanAttributes Map(String, String) MATERIALIZED map('x', if(_idx = 0, '5', '1'))
+) ENGINE = MergeTree ORDER BY _idx;
+INSERT INTO otel_traces (_idx) VALUES (0), (1);
+-- expected_rows --
+[
+  [1]
+]
+-- args --
+[0] int64 = 0
+[1] string = "x"
+[2] int64 = -3
+-- chplan --
+Filter predicate=((0 - toFloat64OrNull(SpanAttributes["x"])) > -3)
+  Scan(otel_traces)
+-- sql --
+SELECT * FROM `otel_traces` WHERE ((? - toFloat64OrNull(`SpanAttributes`[?])) > ?)

--- a/test/spec/traceql/unary_minus_duration.txtar
+++ b/test/spec/traceql/unary_minus_duration.txtar
@@ -1,0 +1,23 @@
+-- query.traceql --
+{ -duration < 0ns }
+-- seed --
+CREATE TABLE otel_traces (
+    Duration UInt64
+) ENGINE = Memory;
+INSERT INTO otel_traces VALUES
+    (0),
+    (10000000),
+    (50000000);
+-- expected_rows --
+[
+  [10000000],
+  [50000000]
+]
+-- args --
+[0] int64 = 0
+[1] int64 = 0
+-- chplan --
+Filter predicate=((0 - Duration) < 0)
+  Scan(otel_traces)
+-- sql --
+SELECT * FROM `otel_traces` WHERE ((? - `Duration`) < ?)


### PR DESCRIPTION
## Function

TraceQL **unary minus** — arithmetic negation `-( <field-expr> )` (`UnaryOperation{OpSub}`) over a span-referencing operand: a bare numeric attribute (`-.payload_bytes`, `-span.x`), the duration intrinsic (`-duration`), or a nested arithmetic expression (`-(span.a + span.b)`).

Before this PR cerberus **parsed** the unary-minus AST (the Tempo parser runs with experimental functions enabled) then **422'd** at the generic `"unary operator is unsupported"` fall-through in `lowerUnaryOperation` — a silent wrong-rejection masquerading as a parity gap.

## Reference semantics

`tsouza/tempo` `pkg/traceql/ast_execute.go` `UnaryOperation.execute`, `OpSub` branch: the operand executes to a `Static`; if it is not numeric (int / float / duration) execution returns an error **per span**, otherwise it returns `-1 * n` preserving the operand's numeric type. The parser AST-rewrites a unary minus over a **constant** operand into a folded negative `Static` (`newUnaryOperation`'s `!referencesSpan()` simplification), so any `UnaryOperation{OpSub}` that survives to lowering necessarily references a span. Validation (`unaryTypesValid`) accepts a bare-attribute operand (`impliedType()==TypeAttribute`) and defers the numeric check to per-span execution — a non-numeric value drops that span, it does not 422 the query.

## Lowering + emit approach

`lowerUnaryMinus` lowers the operand via `lowerFieldExpr`, coerces its `Map(String,String)` `FieldAccess` children with `coerceFieldAccess` (`toFloat64OrNull`), and wraps the result as `0 - <operand>` (`chplan.Binary{OpSub}`, `LitInt{0}` left arm) — **typed Frags only, no raw SQL**, mirroring the existing binary-arithmetic field-expr path. Routing through the `Binary` node means:

- a span lacking the attribute (or carrying a non-numeric value) coerces to `NULL`, `0 - NULL` is `NULL`, and the enclosing comparison drops the row — exactly reference Tempo's "the span simply doesn't match" semantics;
- the duration intrinsic lowers to its Int64 `Duration` column, so `0 - Duration` stays signed (no UInt64 wraparound — chDB confirms).

Emitted SQL (attr form): `((? - toFloat64OrNull(`SpanAttributes`[?])) > ?)`.

## Parity evidence (chDB-backed)

Three `-- seed --` / `-- expected_rows --` fixtures pin the actual rows against real ClickHouse execution via chDB (`just update-golden` regenerated them):

| fixture | query | seeded | matched rows | reference check |
|---|---|---|---|---|
| `unary_minus_attr` | `{ -span.x > -3 }` | x∈{5,1} | x=1 | `-1 > -3` ✓, `-5 > -3` ✗ |
| `unary_minus_arith` | `{ -(span.a + span.b) < -10 }` | (7,8),(3,4) | (7,8) | `-15 < -10` ✓, `-7 < -10` ✗ |
| `unary_minus_duration` | `{ -duration < 0ns }` | {0, 1e7, 5e7} | 1e7, 5e7 | `-d < 0 ⇔ d > 0`; 0-row excluded ✓ |

`internal/traceql/unary_minus_test.go` pins the SQL shape for the non-chdb lane.

## Unmasked panel

`showcase-traceql.json` had **no** unary-minus panel and the feature inventory had no `op:unary-minus` row (only the binary `op:sub`). Added:

- `op:unary-minus` inventory row + `collectTraceQLUnary` matcher case (`UnaryOperation{OpSub}` → `op:unary-minus`, unambiguous vs the binary `op:sub` which arrives as a `BinaryOperation`);
- regenerated `traceql-feature-inventory.json`;
- a covering target `{ -.payload_bytes < 0 }` (refId G) on the existing **"Arithmetic on numeric attributes"** showcase panel — a real data panel (nonempty; `payload_bytes` is already seeded across the showcase spans, no new seed data needed).

`TestTraceQLInventoryIsRegenerable` + `TestTraceQLShowcaseCoversInventory` green.

## Residual risk

- **Non-numeric operand parity is on the drop-the-span path, not the error path.** Reference errors per span at execution; cerberus reaches the same observable result (the span doesn't match) via `toFloat64OrNull → NULL`. A whole-query 422 only happens upstream when *every* operand is constant non-numeric, which the parser constant-folds before lowering — so it never reaches cerberus's lowering. No fixture exercises a query-wide reference error because no such reachable shape exists.
- The duration `0 - Duration` signedness relies on chDB/ClickHouse promoting the subtraction to a signed result; the `unary_minus_duration` fixture's 0-row exclusion pins this against regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
