### PR TITLE
feat(promql): implement info() label-enrichment join

### DIFF
--- a/internal/chplan/clone.go
+++ b/internal/chplan/clone.go
@@ -128,52 +128,19 @@ func cloneCompositeNode(n Node) Node {
 		c.Match.Labels = cloneStrings(v.Match.Labels)
 		return &c
 	case *InfoJoin:
-		c := *v
-		c.Input = CloneNode(v.Input)
-		c.Info = CloneNode(v.Info)
-		c.IdentityLabels = cloneStrings(v.IdentityLabels)
-		c.DataLabels = cloneStrings(v.DataLabels)
-		return &c
+		return cloneInfoJoin(v)
 	case *NaryVectorSetOp:
 		return cloneNaryVectorSetOp(v)
 	case *HistogramQuantile:
-		c := *v
-		c.Input = CloneNode(v.Input)
-		c.PhiExpr = cloneExpr(v.PhiExpr)
-		c.GroupBy = cloneExprs(v.GroupBy)
-		c.GroupByAliases = cloneStrings(v.GroupByAliases)
-		return &c
+		return cloneHistogramQuantile(v)
 	case *HistogramQuantileNative:
-		c := *v
-		c.Input = CloneNode(v.Input)
-		c.PhiExpr = cloneExpr(v.PhiExpr)
-		c.GroupBy = cloneExprs(v.GroupBy)
-		c.GroupByAliases = cloneStrings(v.GroupByAliases)
-		return &c
+		return cloneHistogramQuantileNative(v)
 	case *MetricsAggregate:
-		c := *v
-		c.Attr = cloneExpr(v.Attr)
-		c.GroupBy = cloneExprs(v.GroupBy)
-		c.GroupByAliases = cloneStrings(v.GroupByAliases)
-		c.GroupByDisplayNames = cloneStrings(v.GroupByDisplayNames)
-		c.Quantiles = cloneFloats(v.Quantiles)
-		c.Inner = CloneNode(v.Inner)
-		return &c
+		return cloneMetricsAggregate(v)
 	case *MetricsCompare:
-		c := *v
-		c.Selection = cloneExpr(v.Selection)
-		c.Pairs = cloneExpr(v.Pairs)
-		c.RootLookup = CloneNode(v.RootLookup)
-		c.Inner = CloneNode(v.Inner)
-		return &c
+		return cloneMetricsCompare(v)
 	case *MetricsHistogramOverTime:
-		c := *v
-		c.Attr = cloneExpr(v.Attr)
-		c.GroupBy = cloneExprs(v.GroupBy)
-		c.GroupByAliases = cloneStrings(v.GroupByAliases)
-		c.GroupByDisplayNames = cloneStrings(v.GroupByDisplayNames)
-		c.Inner = CloneNode(v.Inner)
-		return &c
+		return cloneMetricsHistogramOverTime(v)
 	case *MetricsSecondStage:
 		c := *v
 		c.Input = CloneNode(v.Input)
@@ -198,6 +165,83 @@ func cloneNaryVectorSetOp(v *NaryVectorSetOp) Node {
 		c.Arms[i] = CloneNode(arm)
 	}
 	c.Match.Labels = cloneStrings(v.Match.Labels)
+	return &c
+}
+
+// cloneInfoJoin deep-copies an info() label-enrichment join, cloning both
+// plan inputs and the identity / data label slices. Split out of
+// cloneCompositeNode so that switch stays within the funlen budget.
+func cloneInfoJoin(v *InfoJoin) Node {
+	c := *v
+	c.Input = CloneNode(v.Input)
+	c.Info = CloneNode(v.Info)
+	c.IdentityLabels = cloneStrings(v.IdentityLabels)
+	c.DataLabels = cloneStrings(v.DataLabels)
+	return &c
+}
+
+// cloneHistogramQuantile deep-copies a classic-histogram quantile node.
+// Split out of cloneCompositeNode so that switch stays within the funlen
+// budget.
+func cloneHistogramQuantile(v *HistogramQuantile) Node {
+	c := *v
+	c.Input = CloneNode(v.Input)
+	c.PhiExpr = cloneExpr(v.PhiExpr)
+	c.GroupBy = cloneExprs(v.GroupBy)
+	c.GroupByAliases = cloneStrings(v.GroupByAliases)
+	return &c
+}
+
+// cloneHistogramQuantileNative deep-copies a native-histogram quantile node.
+// Split out of cloneCompositeNode so that switch stays within the funlen
+// budget.
+func cloneHistogramQuantileNative(v *HistogramQuantileNative) Node {
+	c := *v
+	c.Input = CloneNode(v.Input)
+	c.PhiExpr = cloneExpr(v.PhiExpr)
+	c.GroupBy = cloneExprs(v.GroupBy)
+	c.GroupByAliases = cloneStrings(v.GroupByAliases)
+	return &c
+}
+
+// cloneMetricsAggregate deep-copies a TraceQL metrics aggregate node, cloning
+// its attribute expr, group-by exprs/aliases/display-names, quantile slice,
+// and inner plan. Split out of cloneCompositeNode so that switch stays within
+// the funlen budget.
+func cloneMetricsAggregate(v *MetricsAggregate) Node {
+	c := *v
+	c.Attr = cloneExpr(v.Attr)
+	c.GroupBy = cloneExprs(v.GroupBy)
+	c.GroupByAliases = cloneStrings(v.GroupByAliases)
+	c.GroupByDisplayNames = cloneStrings(v.GroupByDisplayNames)
+	c.Quantiles = cloneFloats(v.Quantiles)
+	c.Inner = CloneNode(v.Inner)
+	return &c
+}
+
+// cloneMetricsCompare deep-copies a TraceQL compare() node, cloning its
+// selection / pairs exprs and both plan inputs. Split out of
+// cloneCompositeNode so that switch stays within the funlen budget.
+func cloneMetricsCompare(v *MetricsCompare) Node {
+	c := *v
+	c.Selection = cloneExpr(v.Selection)
+	c.Pairs = cloneExpr(v.Pairs)
+	c.RootLookup = CloneNode(v.RootLookup)
+	c.Inner = CloneNode(v.Inner)
+	return &c
+}
+
+// cloneMetricsHistogramOverTime deep-copies a TraceQL histogram_over_time
+// node, cloning its attribute expr, group-by exprs/aliases/display-names, and
+// inner plan. Split out of cloneCompositeNode so that switch stays within the
+// funlen budget.
+func cloneMetricsHistogramOverTime(v *MetricsHistogramOverTime) Node {
+	c := *v
+	c.Attr = cloneExpr(v.Attr)
+	c.GroupBy = cloneExprs(v.GroupBy)
+	c.GroupByAliases = cloneStrings(v.GroupByAliases)
+	c.GroupByDisplayNames = cloneStrings(v.GroupByDisplayNames)
+	c.Inner = CloneNode(v.Inner)
 	return &c
 }
 

--- a/internal/chplan/clone.go
+++ b/internal/chplan/clone.go
@@ -127,6 +127,13 @@ func cloneCompositeNode(n Node) Node {
 		c.Right = CloneNode(v.Right)
 		c.Match.Labels = cloneStrings(v.Match.Labels)
 		return &c
+	case *InfoJoin:
+		c := *v
+		c.Input = CloneNode(v.Input)
+		c.Info = CloneNode(v.Info)
+		c.IdentityLabels = cloneStrings(v.IdentityLabels)
+		c.DataLabels = cloneStrings(v.DataLabels)
+		return &c
 	case *NaryVectorSetOp:
 		return cloneNaryVectorSetOp(v)
 	case *HistogramQuantile:

--- a/internal/chplan/clone_test.go
+++ b/internal/chplan/clone_test.go
@@ -67,6 +67,12 @@ func allNodeKinds() []chplan.Node {
 		&chplan.MetricsHistogramOverTime{Attr: expr, GroupBy: []chplan.Expr{expr}, GroupByAliases: []string{"g0"}, GroupByDisplayNames: []string{"g"}, Inner: leaf},
 		&chplan.MetricsSecondStage{Input: leaf, K: 5, PartitionBy: []string{"p"}, ValueAlias: "v"},
 		&chplan.NestedSetAnnotate{Input: leaf, SpansTable: "spans", TraceIDColumn: "TraceId"},
+		&chplan.InfoJoin{
+			Input: leaf, Info: &chplan.Scan{Table: "info"},
+			IdentityLabels: []string{"instance", "job"}, DataLabels: []string{"version"},
+			MetricNameColumn: "MetricName", AttributesColumn: "Attributes",
+			TimestampColumn: "TimeUnix", ValueColumn: "Value",
+		},
 	}
 }
 
@@ -109,7 +115,7 @@ func TestCloneNodeExhaustive(t *testing.T) {
 	// Lock-step guard: every concrete planNode() implementer in chplan must
 	// appear here. When this count drifts, a Node type was added — extend
 	// allNodeKinds AND the CloneNode switch in clone.go.
-	const wantNodeTypes = 28
+	const wantNodeTypes = 29
 	if len(nodes) != wantNodeTypes {
 		t.Fatalf("expected %d Node types, listed %d — a Node type was added: "+
 			"extend allNodeKinds + CloneNode", wantNodeTypes, len(nodes))

--- a/internal/chplan/info_join.go
+++ b/internal/chplan/info_join.go
@@ -1,0 +1,75 @@
+package chplan
+
+import "slices"
+
+// InfoJoin models PromQL's `info(v[, {label matchers}])` label-enrichment
+// join. PromQL's reference engine (promql/info.go::evalInfo) enriches each
+// base series in `v` with the data labels carried by a companion info
+// metric (default `target_info`) that shares the same identifying labels
+// (`instance` / `job`). Sample values + timestamps pass through unchanged;
+// only the label set grows.
+//
+// Lowering shape:
+//
+//   - Input  — the base vector (arg[0] of `info`), already lowered to the
+//     canonical per-series-latest Sample shape (MetricName, Attributes,
+//     TimeUnix, Value).
+//   - Info   — the info-metric scan (default `target_info`, or the name
+//     selected by the second arg's `__name__` matcher), also lowered to
+//     the per-series-latest Sample shape so each base series matches at
+//     most one info series per identity key.
+//
+// IdentityLabels are the labels the join keys on — the reference engine
+// hard-codes `{instance, job}`. The emitter renders a LEFT JOIN so base
+// series with no matching info series pass through unchanged (the default
+// `target_info` case has no data-label matcher, so unmatched base series
+// are always kept — see combineWithInfoVector's `allMatchersMatchEmpty`
+// branch).
+//
+// DataLabels, when non-empty, restricts the set of info labels copied onto
+// the output to exactly those names — the second-arg label-matcher case
+// (`info(v, {k=~"…"})`). Empty DataLabels means "copy every info label not
+// already present on the base" (the default case). The identity labels are
+// never copied (they're already on the base by construction), and the info
+// metric's `__name__` is never copied.
+//
+// The output Attributes is `mapConcat(infoExtras, base.Attributes)` so the
+// base side wins on any conflicting key — matching the reference rule that
+// skips info labels already present on the base series.
+type InfoJoin struct {
+	Input Node
+	Info  Node
+
+	// IdentityLabels are the labels the join matches on (instance/job).
+	IdentityLabels []string
+	// DataLabels restricts which info labels are copied onto the output.
+	// Empty → copy every non-identity, non-__name__ info label.
+	DataLabels []string
+
+	MetricNameColumn string
+	AttributesColumn string
+	TimestampColumn  string
+	ValueColumn      string
+}
+
+func (*InfoJoin) planNode() {}
+
+func (j *InfoJoin) Children() []Node { return []Node{j.Input, j.Info} }
+
+func (j *InfoJoin) Equal(other Node) bool {
+	o, ok := other.(*InfoJoin)
+	if !ok {
+		return false
+	}
+	if !slices.Equal(j.IdentityLabels, o.IdentityLabels) ||
+		!slices.Equal(j.DataLabels, o.DataLabels) {
+		return false
+	}
+	if j.MetricNameColumn != o.MetricNameColumn ||
+		j.AttributesColumn != o.AttributesColumn ||
+		j.TimestampColumn != o.TimestampColumn ||
+		j.ValueColumn != o.ValueColumn {
+		return false
+	}
+	return j.Input.Equal(o.Input) && j.Info.Equal(o.Info)
+}

--- a/internal/chplan/sliceinvariant_test.go
+++ b/internal/chplan/sliceinvariant_test.go
@@ -63,7 +63,7 @@ func TestIsSliceInvariant_UnregisteredKinds(t *testing.T) {
 		}
 	}
 
-	// 28 total node kinds, 9 registered → 19 must be default-denied. If this
+	// 29 total node kinds, 9 registered → 20 must be default-denied. If this
 	// drifts, a node kind was added: decide explicitly whether it is
 	// slice-invariant (extend sliceInvariantKinds + the registered set here)
 	// or not (it falls into the default-deny count).
@@ -73,8 +73,10 @@ func TestIsSliceInvariant_UnregisteredKinds(t *testing.T) {
 	// slice-invariance proof + §Parity lanes land. RangeWindowNative is also
 	// default-denied: the experimental native-rate node is never routed by
 	// the solver (ReanchorRange does not re-grid it), so it fails closed to
-	// route A — exactly the safe default for an opt-in node.
-	const wantUnregistered = 28 - 9
+	// route A — exactly the safe default for an opt-in node. InfoJoin is a
+	// join-family node (like VectorJoin) and is default-denied for the same
+	// reason: its two arms aren't a simple sliced row stream.
+	const wantUnregistered = 29 - 9
 	if unregisteredSeen != wantUnregistered {
 		t.Fatalf("expected %d default-denied node kinds, saw %d — a node kind was added; "+
 			"make an explicit slice-invariance decision", wantUnregistered, unregisteredSeen)

--- a/internal/chsql/emit.go
+++ b/internal/chsql/emit.go
@@ -133,6 +133,8 @@ func (e *emitter) emitNode(n chplan.Node) error {
 		return e.emitVectorSetOp(v)
 	case *chplan.NaryVectorSetOp:
 		return e.emitNaryVectorSetOp(v)
+	case *chplan.InfoJoin:
+		return e.emitInfoJoin(v)
 	case *chplan.StructuralJoin:
 		return e.emitStructuralJoin(v)
 	case *chplan.NestedSetAnnotate:

--- a/internal/chsql/info_join.go
+++ b/internal/chsql/info_join.go
@@ -1,0 +1,147 @@
+package chsql
+
+import (
+	"fmt"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// infoMetricNameLabel is the reserved label carrying a series' metric
+// name in the Attributes-keyed label space. The info-enrichment join must
+// never copy it from the info series onto the base series — the base
+// series keeps its own `__name__` (PromQL's info() preserves the base
+// sample's identity and only grows its data labels).
+const infoMetricNameLabel = "__name__"
+
+// emitInfoJoin renders PromQL's `info(v[, {matchers}])` label-enrichment
+// join. The output keeps the base side's MetricName / TimeUnix / Value
+// verbatim and grows its Attributes with the info series' data labels.
+//
+// Shape:
+//
+//	SELECT
+//	    L.MetricName AS MetricName,
+//	    mapConcat(<info extras>, L.Attributes) AS Attributes,
+//	    L.TimeUnix    AS TimeUnix,
+//	    L.Value       AS Value
+//	FROM (<base>) AS L
+//	LEFT JOIN (<info>) AS R
+//	  ON L.Attributes['job'] = R.Attributes['job']
+//	 AND L.Attributes['instance'] = R.Attributes['instance']
+//
+// The join is LEFT so base series with no matching info series pass
+// through unchanged — matching the reference engine, whose default
+// `target_info` case (no data-label matcher) keeps every unmatched base
+// series. `<info extras>` is the info Attributes with the identity labels
+// + `__name__` stripped (and, when DataLabels is set, narrowed to exactly
+// those names); `mapConcat(extras, base)` lets the base side win on any
+// conflicting key, mirroring the reference rule that skips info labels
+// already present on the base.
+//
+// CH map subscript of a missing key returns the empty string, so the
+// per-identity-label equality matches the reference identity semantics:
+// a base series carrying only `job` joins an info series carrying only
+// `job` (both sides see `”` for the absent `instance`), and a base
+// carrying `instance` does NOT match an info series lacking it.
+func (e *emitter) emitInfoJoin(j *chplan.InfoJoin) error {
+	if err := e.validateInfoJoinCols(j); err != nil {
+		return err
+	}
+	if len(j.IdentityLabels) == 0 {
+		return fmt.Errorf("%w: InfoJoin.IdentityLabels empty", ErrUnsupported)
+	}
+
+	leftFrag, err := e.subqueryFrag(j.Input)
+	if err != nil {
+		return err
+	}
+	rightFrag, err := e.subqueryFrag(j.Info)
+	if err != nil {
+		return err
+	}
+
+	sb := NewQuery().
+		Select(
+			As(qualColFrag("L", j.MetricNameColumn), j.MetricNameColumn),
+			As(infoOutputAttributesFrag(j), j.AttributesColumn),
+			As(qualColFrag("L", j.TimestampColumn), j.TimestampColumn),
+			As(qualColFrag("L", j.ValueColumn), j.ValueColumn),
+		).
+		From(aliasedFrag(leftFrag, "L")).
+		Join(
+			LeftJoin,
+			aliasedFrag(rightFrag, "R"),
+			infoJoinPredicateFrag(j),
+		)
+	e.emitSelect(sb)
+	return nil
+}
+
+func (e *emitter) validateInfoJoinCols(j *chplan.InfoJoin) error {
+	switch {
+	case j.AttributesColumn == "":
+		return fmt.Errorf("%w: InfoJoin.AttributesColumn unset", ErrUnsupported)
+	case j.MetricNameColumn == "":
+		return fmt.Errorf("%w: InfoJoin.MetricNameColumn unset", ErrUnsupported)
+	case j.TimestampColumn == "":
+		return fmt.Errorf("%w: InfoJoin.TimestampColumn unset", ErrUnsupported)
+	case j.ValueColumn == "":
+		return fmt.Errorf("%w: InfoJoin.ValueColumn unset", ErrUnsupported)
+	}
+	return nil
+}
+
+// infoJoinPredicateFrag renders the LEFT JOIN ON clause: an AND of
+// `L.Attributes[<id>] = R.Attributes[<id>]` over every identity label.
+func infoJoinPredicateFrag(j *chplan.InfoJoin) Frag {
+	parts := make([]Frag, 0, len(j.IdentityLabels))
+	for _, id := range j.IdentityLabels {
+		parts = append(parts, Eq(
+			Subscript(qualColFrag("L", j.AttributesColumn), Lit(id)),
+			Subscript(qualColFrag("R", j.AttributesColumn), Lit(id)),
+		))
+	}
+	return And(parts...)
+}
+
+// infoOutputAttributesFrag renders `mapConcat(<info extras>, L.Attributes)`.
+// The info-extras map is the info side's Attributes with the identity
+// labels + `__name__` stripped (default case) or narrowed to exactly the
+// DataLabels names (the second-arg label-matcher case). `mapConcat` is
+// later-key-wins, so listing L.Attributes second keeps the base side's
+// value on any conflicting key — matching the reference engine's rule of
+// skipping info labels already present on the base.
+func infoOutputAttributesFrag(j *chplan.InfoJoin) Frag {
+	return Call(
+		"mapConcat",
+		infoExtrasFrag(j),
+		qualColFrag("L", j.AttributesColumn),
+	)
+}
+
+// infoExtrasFrag renders the info side's contributing labels as a
+// `mapFilter((k, v) -> <keep>, R.Attributes)`.
+//
+//   - Default (DataLabels empty): keep every key that is NOT an identity
+//     label and NOT `__name__` → `NOT (k IN ('instance','job','__name__'))`.
+//   - DataLabels set: keep only the listed names → `k IN (<names>)`. The
+//     identity labels and `__name__` are excluded from DataLabels by the
+//     lowering, so no extra NOT-clause is needed here.
+func infoExtrasFrag(j *chplan.InfoJoin) Frag {
+	attrs := qualColFrag("R", j.AttributesColumn)
+	if len(j.DataLabels) == 0 {
+		excluded := make([]Frag, 0, len(j.IdentityLabels)+1)
+		for _, id := range j.IdentityLabels {
+			excluded = append(excluded, Lit(id))
+		}
+		excluded = append(excluded, Lit(infoMetricNameLabel))
+		keep := Not(Paren(In(BareIdent("k"), excluded...)))
+		return Call("mapFilter", Lambda2("k", "v", keep), attrs)
+	}
+	wanted := make([]Frag, 0, len(j.DataLabels))
+	for _, name := range j.DataLabels {
+		wanted = append(wanted, Lit(name))
+	}
+	keep := In(BareIdent("k"), wanted...)
+	return Call("mapFilter", Lambda2("k", "v", keep), attrs)
+}

--- a/internal/optimizer/rewrite_children_exhaustive_test.go
+++ b/internal/optimizer/rewrite_children_exhaustive_test.go
@@ -107,6 +107,12 @@ func allNodeCases() []nodeExhaustivenessCase {
 		//     two-child path. ---
 		{"MetricsCompare", &chplan.MetricsCompare{Inner: sentinelChild(), RootLookup: sentinelChild()}, false},
 
+		// --- InfoJoin: Input (base) + Info (info-metric scan). Plant the
+		//     sentinel in both so the recursion assertion exercises the
+		//     two-child path; field names differ from Left/Right so it
+		//     lands in the irregular arm. ---
+		{"InfoJoin", &chplan.InfoJoin{Input: sentinelChild(), Info: sentinelChild()}, false},
+
 		// --- multi-arm interior nodes ---
 		{"UnionAll", &chplan.UnionAll{Inputs: []chplan.Node{sentinelChild(), sentinelChild()}}, false},
 		{"NaryVectorSetOp", &chplan.NaryVectorSetOp{Arms: []chplan.Node{sentinelChild(), sentinelChild()}}, false},
@@ -124,7 +130,7 @@ func allNodeCases() []nodeExhaustivenessCase {
 // implementations. Cross-checked against
 // `grep -rn 'planNode()' internal/chplan/*.go`. Bump this (and add a table
 // row + a rewriteChildren arm) when a new Node type lands.
-const expectedNodeTypeCount = 28
+const expectedNodeTypeCount = 29
 
 // TestRewriteChildren_TableCoversEveryNodeType is the count guard. If a new
 // chplan.Node type is added without a corresponding allNodeCases() row, the

--- a/internal/optimizer/rule.go
+++ b/internal/optimizer/rule.go
@@ -534,6 +534,25 @@ func rewriteIrregularNode(n chplan.Node, fn func(chplan.Node) (chplan.Node, bool
 		cp := *v
 		cp.Arms = newArms
 		return &cp, true, true
+	case *chplan.InfoJoin:
+		// Two always-present children carried as Input (the base vector)
+		// + Info (the info-metric scan). Recurse into both so the per-
+		// side LWR / PREWHERE-promotable Filter(Scan) subtrees stay
+		// reachable to the optimizer. Field names differ from the
+		// Left/Right binary shape, so this lands in the irregular arm.
+		newInput, inCh := fn(v.Input)
+		newInfo, infoCh := fn(v.Info)
+		if !inCh && !infoCh {
+			return v, false, true
+		}
+		cp := *v
+		if inCh {
+			cp.Input = newInput
+		}
+		if infoCh {
+			cp.Info = newInfo
+		}
+		return &cp, true, true
 	case *chplan.MetricsCompare:
 		// Inner is the always-present child; RootLookup is an optional
 		// second child (the service-graph root-name join side). Recurse

--- a/internal/promql/info_fn.go
+++ b/internal/promql/info_fn.go
@@ -1,0 +1,135 @@
+package promql
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// targetInfoMetric is the default info metric name PromQL's `info(v)`
+// enriches from when no second-argument `__name__` matcher narrows it —
+// the OpenTelemetry `target_info` resource-attribute series. Mirrors the
+// reference engine's `targetInfo` constant (promql/info.go).
+const targetInfoMetric = "target_info"
+
+// infoIdentityLabels are the labels the info-enrichment join keys on. The
+// reference engine hard-codes `{instance, job}` (promql/info.go's
+// `identifyingLabels`); the SQL join matches base ↔ info series on these.
+var infoIdentityLabels = []string{"instance", "job"}
+
+// lowerInfo lowers PromQL's
+//
+//	info(v)
+//	info(v, {label matchers})
+//
+// the label-enrichment join. The reference engine (promql/info.go::
+// evalInfo) joins target-identifying data labels from a companion
+// `target_info`-style series onto the input vector `v` by the data-source
+// identity labels (`instance` / `job`), enriching each input series' label
+// set while leaving the sample values + timestamps unchanged.
+//
+// Lowering:
+//
+//   - arg[0] (`v`) lowers normally to the canonical per-series-latest
+//     Sample shape.
+//   - The info metric (default `target_info`, or the name a second-arg
+//     `__name__` matcher selects) lowers through the same VectorSelector
+//     path so the info side is also per-series-latest — each base series
+//     matches at most one info series per identity key.
+//   - The two sides wrap in a chplan.InfoJoin keyed on `{instance, job}`.
+//
+// The optional second argument is a label-selector: its `__name__`
+// matcher (if any) picks the info metric; its non-`__name__` matchers
+// both filter the info series and restrict which info labels copy onto
+// the output (the InfoJoin.DataLabels list).
+func lowerInfo(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	if len(c.Args) < 1 || len(c.Args) > 2 {
+		return nil, fmt.Errorf("promql: info expects 1 or 2 arguments, got %d", len(c.Args))
+	}
+
+	base, err := lower(c.Args[0], s, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	infoName := targetInfoMetric
+	var dataMatchers []*labels.Matcher
+	if len(c.Args) == 2 {
+		sel, ok := c.Args[1].(*parser.VectorSelector)
+		if !ok {
+			return nil, fmt.Errorf("promql: info(...) second argument must be a label selector, got %T", c.Args[1])
+		}
+		for _, m := range sel.LabelMatchers {
+			if m.Name == model.MetricNameLabel {
+				if m.Type != labels.MatchEqual {
+					return nil, fmt.Errorf("promql: info(...) second-argument __name__ matcher must be an equality match, got %q", m.Type)
+				}
+				infoName = m.Value
+				continue
+			}
+			dataMatchers = append(dataMatchers, m)
+		}
+	}
+
+	infoNode, err := lowerInfoMetric(infoName, dataMatchers, s, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	dataLabels := infoDataLabelNames(dataMatchers)
+
+	return &chplan.InfoJoin{
+		Input:            base,
+		Info:             infoNode,
+		IdentityLabels:   slices.Clone(infoIdentityLabels),
+		DataLabels:       dataLabels,
+		MetricNameColumn: s.MetricNameColumn,
+		AttributesColumn: s.AttributesColumn,
+		TimestampColumn:  s.TimestampColumn,
+		ValueColumn:      s.ValueColumn,
+	}, nil
+}
+
+// lowerInfoMetric lowers the info-metric side of the join: a synthetic
+// VectorSelector for `infoName` carrying any data-label matchers, run
+// through the regular VectorSelector lowering so the info side gets the
+// same per-series-latest (LWR) / per-step-matrix treatment as the base
+// vector.
+func lowerInfoMetric(infoName string, dataMatchers []*labels.Matcher, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	matchers := make([]*labels.Matcher, 0, len(dataMatchers)+1)
+	matchers = append(matchers, labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, infoName))
+	matchers = append(matchers, dataMatchers...)
+
+	sel := &parser.VectorSelector{
+		Name:          infoName,
+		LabelMatchers: matchers,
+	}
+	return lowerVectorSelector(sel, s, ctx)
+}
+
+// infoDataLabelNames returns the de-duplicated set of label names the
+// second-argument matchers reference (excluding `__name__`). Non-empty
+// → the InfoJoin copies only these info labels onto the output; empty →
+// every non-identity info label copies (the default `info(v)` case).
+func infoDataLabelNames(dataMatchers []*labels.Matcher) []string {
+	if len(dataMatchers) == 0 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	names := make([]string, 0, len(dataMatchers))
+	for _, m := range dataMatchers {
+		if _, ok := seen[m.Name]; ok {
+			continue
+		}
+		seen[m.Name] = struct{}{}
+		names = append(names, m.Name)
+	}
+	slices.Sort(names)
+	return names
+}

--- a/internal/promql/info_fn_test.go
+++ b/internal/promql/info_fn_test.go
@@ -1,0 +1,84 @@
+package promql_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestLower_Info covers PromQL's `info(v[, {matchers}])` label-enrichment
+// join. `info` is experimental, so the parser must enable experimental
+// functions. The lowering builds a chplan.InfoJoin keyed on
+// {instance, job}; the chsql emitter renders a LEFT JOIN whose output
+// keeps the base side's value/timestamp and grows its Attributes with the
+// info series' data labels via mapConcat.
+func TestLower_Info(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+
+	cases := []struct {
+		name      string
+		query     string
+		wantInSQL []string
+	}{
+		{
+			name:  "default target_info enrichment",
+			query: `info(up)`,
+			wantInSQL: []string{
+				"LEFT JOIN",
+				"L.`Attributes`[?] = R.`Attributes`[?]",
+				"mapConcat(",
+				"mapFilter((k, v) -> NOT (k IN (?, ?, ?))",
+				"L.`Value` AS `Value`",
+				"L.`MetricName` AS `MetricName`",
+			},
+		},
+		{
+			name:  "second-arg name matcher selects info metric",
+			query: `info(up, {__name__="build_info"})`,
+			wantInSQL: []string{
+				"LEFT JOIN",
+				"mapConcat(",
+			},
+		},
+		{
+			name:  "second-arg data-label matcher restricts copied labels",
+			query: `info(up, {version=~".+"})`,
+			wantInSQL: []string{
+				"LEFT JOIN",
+				"mapFilter((k, v) -> k IN (?)",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr: %v", err)
+			}
+			plan, err := promql.Lower(context.Background(), expr, s)
+			if err != nil {
+				t.Fatalf("Lower: %v", err)
+			}
+			sql, _, err := chsql.Emit(context.Background(), plan)
+			if err != nil {
+				t.Fatalf("Emit: %v", err)
+			}
+			for _, want := range tc.wantInSQL {
+				if !strings.Contains(sql, want) {
+					t.Errorf("expected SQL to contain %q; full SQL:\n%s", want, sql)
+				}
+			}
+		})
+	}
+}

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -1409,6 +1409,8 @@ func lowerCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, err
 		return lowerLabelReplace(c, s, ctx)
 	case "label_join":
 		return lowerLabelJoin(c, s, ctx)
+	case "info":
+		return lowerInfo(c, s, ctx)
 	case "time":
 		return lowerTime(c, s, ctx)
 	case "vector":

--- a/test/e2e/grafana/compose/dashboards/showcase-promql.json
+++ b/test/e2e/grafana/compose/dashboards/showcase-promql.json
@@ -5432,7 +5432,7 @@
             "type": "prometheus",
             "uid": "cerberus-prometheus"
           },
-          "description": "Cerberus rejects `info(up)` today; this panel pins the rejection.",
+          "description": "Cerberus implements `info(up)` — the label-enrichment join that grafts `target_info` data labels onto each `up` series by the data-source identity labels (job / instance).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -5514,11 +5514,11 @@
               "refId": "A"
             }
           ],
-          "title": "info \u2014 parity rejection",
+          "title": "info",
           "type": "timeseries",
           "cerberus": {
-            "expect": "error:not yet supported",
-            "why": "Cerberus rejects this construct today; the declaration is a bidirectional parity pin \u2014 the moment lowering support lands, this panel fails the sweep and the contract must be upgraded to nonempty."
+            "expect": "nonempty",
+            "why": "Cerberus implements `info(v)` \u2014 the label-enrichment join lowers to a LEFT JOIN of `up` against `target_info` keyed on the {instance, job} identity labels, grafting each matched target's data labels (e.g. `version`) onto the base series. Previously a parity-rejection pin; the surface burndown landed the lowering, so the contract is upgraded to nonempty per the bidirectional ratchet."
           }
         },
         {

--- a/test/e2e/seed/cmd/seed/main.go
+++ b/test/e2e/seed/cmd/seed/main.go
@@ -239,6 +239,44 @@ SELECT
     0.0
 FROM numbers(40)`
 
+	// target_info companion series for the two `up` targets (job=api /
+	// job=db). PromQL's `info(up)` enriches each `up` series with the
+	// data labels of the `target_info` series that shares its identity
+	// labels (instance / job) — here `version` + `language`. The showcase
+	// `info` panel renders `info(up)`, which the cerberus head lowers to a
+	// LEFT JOIN of `up` against `target_info` keyed on {instance, job}; the
+	// output is the two `up` series grown by `{version, language}`.
+	//
+	// `target_info` is conventionally a gauge that holds the constant 1.0;
+	// the value carries no meaning (only the label set does). Rolling
+	// re-seed discipline: 40 samples × 15 s centred on now64(9) so the
+	// info join's per-series-latest pick always lands a fresh row.
+	insertShowcaseTargetInfoSQL = `INSERT INTO otel_metrics_gauge
+  (ResourceAttributes, ServiceName, MetricName, MetricDescription, MetricUnit, Attributes, StartTimeUnix, TimeUnix, Value)
+SELECT
+    map('service.name', 'api'),
+    'api',
+    'target_info',
+    'Target metadata',
+    '1',
+    map('job', 'api', 'version', '1.2.3', 'language', 'go'),
+    now64(9) + INTERVAL ((number - 20) * 15) SECOND,
+    now64(9) + INTERVAL ((number - 20) * 15) SECOND,
+    1.0
+FROM numbers(40)
+UNION ALL
+SELECT
+    map('service.name', 'db'),
+    'db',
+    'target_info',
+    'Target metadata',
+    '1',
+    map('job', 'db', 'version', '4.5.6', 'language', 'rust'),
+    now64(9) + INTERVAL ((number - 20) * 15) SECOND,
+    now64(9) + INTERVAL ((number - 20) * 15) SECOND,
+    1.0
+FROM numbers(40)`
+
 	// 600 samples at 1 s cadence cover a 10-minute window centred on
 	// the (current) seed timestamp: [seed_now - 300 s, seed_now + 299 s].
 	// The rolling re-seeder re-runs this INSERT every 30 s, so any 1m /
@@ -474,6 +512,9 @@ FROM numbers(40)`
 func insertMetrics(ctx context.Context, conn driver.Conn) error {
 	if err := conn.Exec(ctx, insertGaugeSQL); err != nil {
 		return fmt.Errorf("gauge: %w", err)
+	}
+	if err := conn.Exec(ctx, insertShowcaseTargetInfoSQL); err != nil {
+		return fmt.Errorf("target_info: %w", err)
 	}
 	if err := conn.Exec(ctx, insertSumSQL); err != nil {
 		return fmt.Errorf("sum: %w", err)

--- a/test/perf/cardinality-baseline.json
+++ b/test/perf/cardinality-baseline.json
@@ -3250,6 +3250,16 @@
     "max_recursion_depth": 0
   },
   {
+    "fixture": "promql/info_target_info_enrichment",
+    "fan_factor": 1,
+    "scan_rows": 2,
+    "peak_intermediate": 2,
+    "has_cross_join": false,
+    "has_array_join": false,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0
+  },
+  {
     "fixture": "promql/irate_over_subquery",
     "fan_factor": 1,
     "scan_rows": 3,

--- a/test/perf/solver-decision-baseline.json
+++ b/test/perf/solver-decision-baseline.json
@@ -1020,6 +1020,12 @@
     "reason": "not-sliceable"
   },
   {
+    "query": "info_target_info_enrichment",
+    "routed": false,
+    "k": 0,
+    "reason": "not-sliceable"
+  },
+  {
     "query": "irate_over_subquery",
     "routed": true,
     "k": 8,

--- a/test/perf/solver_decision_ratchet_test.go
+++ b/test/perf/solver_decision_ratchet_test.go
@@ -160,10 +160,10 @@ func classifyCorpus(t *testing.T) map[string]decisionEntry {
 	// EnableExperimentalFunctions=true (see internal/api/prom/lang.go) so
 	// the deliberately-supported experimental subset
 	// (mad_over_time / ts_of_*_over_time / range() / step() / limitk() /
-	// histogram_quantiles / …) parses here exactly as it does in production
-	// and contributes its routing decision to the ratchet. Without this the
-	// ratchet rejects those corpus fixtures at parse time even though the
-	// engine accepts them.
+	// histogram_quantiles / info() / …) parses here exactly as it does in
+	// production and contributes its routing decision to the ratchet. Without
+	// this the ratchet rejects those corpus fixtures at parse time even though
+	// the engine accepts them.
 	parse := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
 	meta := solver.RequestMeta{
 		Lang:  "promql",

--- a/test/rejection-parity/catalogue.json
+++ b/test/rejection-parity/catalogue.json
@@ -451,6 +451,27 @@
     },
     {
       "head": "promql",
+      "site": "internal/promql/info_fn.go:lowerInfo#4ef6f344",
+      "message": "promql: info(...) second-argument __name__ matcher must be an equality match, got %q",
+      "class": "rejection",
+      "trigger_query": "info(up, {__name__=~\"target.*\"})"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/info_fn.go:lowerInfo#9e913846",
+      "message": "promql: info expects 1 or 2 arguments, got %d",
+      "class": "internal",
+      "rationale": "The PromQL parser pins info() arity via Variadic:1 over a two-vector ArgTypes signature, so a call with zero or three-plus arguments is rejected at parse time and never reaches lowering."
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/info_fn.go:lowerInfo#a1d855c7",
+      "message": "promql: info(...) second argument must be a label selector, got %T",
+      "class": "internal",
+      "rationale": "The reference engine's evalInfo itself type-asserts args[1] to *parser.VectorSelector; a non-selector vector second argument is not a meaningful info label-selector and the guard mirrors that upstream assumption rather than panicking on the cast."
+    },
+    {
+      "head": "promql",
       "site": "internal/promql/instant_fns.go:lowerClamp#dd15dfed",
       "message": "promql: clamp expects 3 arguments, got %d",
       "class": "internal",
@@ -538,7 +559,7 @@
       "site": "internal/promql/lower.go:lowerCall#ab321c46",
       "message": "promql: function %s is not yet supported",
       "class": "rejection",
-      "trigger_query": "info(up)"
+      "trigger_query": "sort_by_label(up, \"job\")"
     },
     {
       "head": "promql",

--- a/test/spec/chplan_print.go
+++ b/test/spec/chplan_print.go
@@ -280,6 +280,14 @@ func printNode(b *strings.Builder, n chplan.Node, depth int) {
 		for _, arm := range v.Arms {
 			printNode(b, arm, depth+1)
 		}
+	case *chplan.InfoJoin:
+		fmt.Fprintf(b, "%sInfoJoin identity=[%s]", indent, strings.Join(v.IdentityLabels, ", "))
+		if len(v.DataLabels) > 0 {
+			fmt.Fprintf(b, " dataLabels=[%s]", strings.Join(v.DataLabels, ", "))
+		}
+		b.WriteString("\n")
+		printNode(b, v.Input, depth+1)
+		printNode(b, v.Info, depth+1)
 	case *chplan.StructuralJoin:
 		fmt.Fprintf(b, "%sStructuralJoin op=%s", indent, v.Op)
 		if v.MaxDepth != 0 {

--- a/test/spec/promql/info_target_info_enrichment.txtar
+++ b/test/spec/promql/info_target_info_enrichment.txtar
@@ -1,0 +1,52 @@
+-- query.promql --
+info(up)
+-- args --
+[0] string = "instance"
+[1] string = "job"
+[2] string = "__name__"
+[3] string = "up"
+[4] string = "2026-01-01 00:00:01.000000000"
+[5] int64 = 9
+[6] string = "2026-01-01 00:00:01.000000000"
+[7] int64 = 9
+[8] int64 = 300000000000
+[9] string = "target_info"
+[10] string = "target.info"
+[11] string = "2026-01-01 00:00:01.000000000"
+[12] int64 = 9
+[13] string = "2026-01-01 00:00:01.000000000"
+[14] int64 = 9
+[15] int64 = 300000000000
+[16] string = "instance"
+[17] string = "instance"
+[18] string = "job"
+[19] string = "job"
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('up', map('job', 'db'), toDateTime64('2026-01-01 00:00:00', 9), 0.0),
+    ('target_info', map('job', 'api', 'version', '1.2.3'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('target_info', map('job', 'db', 'version', '4.5.6'), toDateTime64('2026-01-01 00:00:00', 9), 1.0);
+-- expected_rows --
+[
+  ["up", {"job": "api", "version": "1.2.3"}, "2026-01-01T00:00:00Z", 1.0],
+  ["up", {"job": "db", "version": "4.5.6"}, "2026-01-01T00:00:00Z", 0.0]
+]
+-- chplan --
+InfoJoin identity=[instance, job]
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName = "up") AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(merge(otel_metrics_gauge|otel_metrics_sum))
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=(((MetricName IN ("target_info", "target.info")) AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Scan(merge(otel_metrics_gauge|otel_metrics_sum))
+-- sql --
+SELECT L.`MetricName` AS `MetricName`, mapConcat(mapFilter((k, v) -> NOT (k IN (?, ?, ?)), R.`Attributes`), L.`Attributes`) AS `Attributes`, L.`TimeUnix` AS `TimeUnix`, L.`Value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') PREWHERE (`MetricName` = ?) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) AS L LEFT JOIN (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') PREWHERE (`MetricName` IN (?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `MetricName`, `Attributes`)) AS R ON L.`Attributes`[?] = R.`Attributes`[?] AND L.`Attributes`[?] = R.`Attributes`[?]

--- a/test/surface-parity/inventory.json
+++ b/test/surface-parity/inventory.json
@@ -505,10 +505,9 @@
       "symbol": "fn:info",
       "kind": "function",
       "probe": "info(http_server_request_duration_count)",
-      "cerberus": "reject",
+      "cerberus": "accept",
       "reference": "reject",
-      "class": "parity-reject",
-      "cerberus_error": "promql: function info is not yet supported"
+      "class": "wrong-accept"
     },
     {
       "head": "promql",


### PR DESCRIPTION
## What

Implements the PromQL **`info()`** label-enrichment join for real (lower → emit ClickHouse SQL), matching reference Prometheus semantics, and unmasks its showcase panel. Previously cerberus parsed `info(...)` (experimental functions enabled) then 422'd at the generic `function X is not yet supported` fall-through in `internal/promql/lower.go`, so it masqueraded as a "parity rejection" in the showcase.

## Reference semantics (promql/info.go::evalInfo)

`info(v[, {label matchers}])` grafts the data labels of a companion `target_info`-style series onto each input series, keyed by the data-source identity labels (`instance` / `job`). Sample values + timestamps are unchanged; only the label set grows.

- **`info(v)`** — enrich from `target_info`; each base series joins the info series sharing its `{instance, job}`. Info labels not already on the base are copied; the base wins on conflicts; the base `__name__` is preserved.
- **`info(v, {__name__="x"})`** — select a custom info-metric name; non-`__name__` matchers restrict which info labels copy onto the output.
- Unmatched base series pass through unchanged (the default `target_info` case keeps every base series → **LEFT JOIN**).

## Lowering + emit

- **`chplan.InfoJoin(Input, Info)`** keyed on `{instance, job}`. The info side lowers through the regular `VectorSelector` path, so both sides are per-series-latest (LWR) and each base series matches at most one info series per identity key.
- **`chsql.emitInfoJoin`** renders a `LEFT JOIN` whose output keeps `L.MetricName / TimeUnix / Value` and grows `Attributes` via `mapConcat(mapFilter(<info extras>, R.Attributes), L.Attributes)` — **typed Frags only, no raw SQL**. CH map subscript of a missing key returns `''`, so the per-identity-label equality reproduces the reference identity semantics (a base carrying only `job` joins an info series carrying only `job`; a base carrying `instance` does not match an info series lacking it).
- Wired into the optimizer `rewriteChildren` walk, `CloneNode`, the chplan-IR pretty-printer, and the node-count exhaustiveness + slice-invariance guards (28 → 29).

## Unmasked showcase panel

`info(up)` flips from `cerberus.expect: error:not yet supported` to `expect: nonempty` (it was a flat panel in a normal showcase row, not inside the collapsed parity-rejections row). The compose seed gains a `target_info` companion — `job=api {version=1.2.3, language=go}` and `job=db {version=4.5.6, language=rust}` — so the panel renders the two enriched `up` series.

## Ledgers re-pinned (reviewed)

- **rejection-parity catalogue** — the generic fall-through's trigger query is repointed from `info(up)` (now lowers) to `sort_by_label(up, "job")` (still unsupported); the three new `lowerInfo` arg-guard sites are classified (the regex-`__name__` matcher is a tracked `rejection`; the arity + selector-type guards are `internal`/parser-guaranteed).
- **surface-parity inventory** — `fn:info` moves to `wrong-accept`: cerberus accepts a deliberately-supported experimental extension the bare reference (experimental feature off) gates off — the same posture as `predict_linear` / `@start()`.
- **solver-decision + cardinality baselines** — gain the new fixture; the info join is `fan_factor=1` (LEFT JOIN on identity keys, no cross product). The ratchet test's parser now enables experimental functions to match production.

## Tests

- `test/spec/promql/info_target_info_enrichment.txtar` — chDB-backed roundtrip fixture pinning the enriched result (`up{job=api,version=1.2.3}=1`, `up{job=db,version=4.5.6}=0`) against reference semantics, plus the SQL + chplan goldens.
- `internal/promql/info_fn_test.go` — lowering+emit unit test covering the default, custom-name, and data-label-matcher shapes (runs without chDB).

Full `go test ./...` green (5043 non-chdb), chDB lanes (spec roundtrip + perf ratchets) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)