### PR TITLE
docs(config): give configuration its own reference doc + README spotlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,11 @@ ships a [SLSA build provenance](https://slsa.dev) attestation:
 gh attestation verify cerberus_*_linux_amd64.tar.gz --owner tsouza --repo cerberus
 ```
 
-The runtime + env-var contract (config, lifecycle, scaling, the solver
-and experimental knobs) lives in [`docs/operations.md`](docs/operations.md).
+Cerberus is configured **entirely** through `CERBERUS_*` environment
+variables — see the full [configuration reference](docs/configuration.md).
+The surrounding runtime contract (lifecycle, scaling, the solver and
+experimental knobs in context) lives in
+[`docs/operations.md`](docs/operations.md).
 
 ## Architecture
 
@@ -136,7 +139,8 @@ map, the CI-gate inventory, and the gremlins rollout.
 | Doc                                                | What's in it                                                                                    |
 | -------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
 | [`docs/engine.md`](docs/engine.md)                 | The shared query pipeline, the `Lang` contract, and the per-stage breakdown.                    |
-| [`docs/operations.md`](docs/operations.md)         | Runtime contract: configuration, env vars, lifecycle, scaling, the solver, experimental knobs.  |
+| [`docs/configuration.md`](docs/configuration.md)   | The full `CERBERUS_*` environment-variable reference, grouped by area, with types and defaults. |
+| [`docs/operations.md`](docs/operations.md)         | Runtime contract: lifecycle, scaling, the solver and experimental knobs in context.             |
 | [`docs/performance.md`](docs/performance.md)       | The compute-fan-out strategy, per-layer optimisations, and how they're held against regression. |
 | [`docs/solver.md`](docs/solver.md)                 | The sharded-pushdown solver: eligibility, slicing, execution, and the cancellation contract.    |
 | [`docs/benchmarks.md`](docs/benchmarks.md)         | Benchmark methodology and the recorded numbers (regenerable).                                   |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,173 @@
+# Configuration
+
+Cerberus is a stateless 12-factor binary configured **entirely** through
+`CERBERUS_*` environment variables — there is no YAML, INI, or TOML file to
+load. ClickHouse and the (optional) OpenTelemetry collector are attached
+resources reached through env-var connection inputs, so swapping a local
+single-node ClickHouse for a managed cluster, or a sidecar collector for a
+SaaS ingest URL, is a matter of flipping env vars and restarting. Every
+default below is the value `internal/config/config.go` ships out of the box.
+
+Misconfigured values fail fast: an unparseable duration, an out-of-range
+integer, an unknown log level, or a malformed OTLP header list aborts startup
+with a clear error rather than silently downgrading behaviour. Secrets (the
+ClickHouse password, OTLP bearer tokens) live in this same env-var namespace
+and are sourced from a Kubernetes `Secret`, a Docker `secrets:` mount, or a
+vault-injecting init container — never committed.
+
+For how these knobs interact with the running service — lifecycle, readiness,
+deployment, scaling — see [`operations.md`](operations.md).
+
+## HTTP server
+
+| Variable             | Type   | Default | Description                                                                                 |
+| -------------------- | ------ | ------- | ------------------------------------------------------------------------------------------- |
+| `CERBERUS_HTTP_ADDR` | string | `:8080` | HTTP listen address for the Prom / Loki / Tempo APIs and the `/healthz` / `/readyz` probes. |
+
+A single listener serves all three upstream APIs plus the health probes; there
+is no separate admin port. See [`operations.md`](operations.md#port-binding)
+for the port-binding contract (including h2c + gRPC on the same socket).
+
+## ClickHouse connection
+
+ClickHouse is the only mandatory backing service, reached exclusively through
+these connection inputs.
+
+| Variable                   | Type     | Default          | Description                                            |
+| -------------------------- | -------- | ---------------- | ------------------------------------------------------ |
+| `CERBERUS_CH_ADDR`         | string   | `localhost:9000` | ClickHouse native-protocol endpoint.                   |
+| `CERBERUS_CH_DATABASE`     | string   | `otel`           | ClickHouse database name.                              |
+| `CERBERUS_CH_USERNAME`     | string   | `default`        | ClickHouse user.                                       |
+| `CERBERUS_CH_PASSWORD`     | string   | (empty)          | ClickHouse password.                                   |
+| `CERBERUS_CH_DIAL_TIMEOUT` | duration | `5s`             | ClickHouse dial timeout (`time.ParseDuration` syntax). |
+
+## Connection pool
+
+These reproduce clickhouse-go/v2's previously-implicit pool defaults verbatim,
+made explicit so the sharded-pushdown solver can raise the ceiling for fan-out
+rather than inherit a hidden driver default. When the pool is exhausted an
+acquire blocks up to `CERBERUS_CH_DIAL_TIMEOUT` and then fails with a
+breaker-neutral acquire-timeout (a local pool-sizing signal, not a
+ClickHouse-health failure).
+
+| Variable                        | Type     | Default | Description                                                        |
+| ------------------------------- | -------- | ------- | ------------------------------------------------------------------ |
+| `CERBERUS_CH_MAX_OPEN_CONNS`    | int      | `10`    | Total pooled ClickHouse connections (busy + idle). Must be > 0.    |
+| `CERBERUS_CH_MAX_IDLE_CONNS`    | int      | `5`     | Idle ClickHouse connections kept warm for reuse. Must be > 0.      |
+| `CERBERUS_CH_CONN_MAX_LIFETIME` | duration | `1h`    | Max age of a pooled connection before it is recycled. Must be > 0. |
+
+## Query limits and memory
+
+| Variable                       | Type  | Default      | Description                                                                                                                                                                                                                                                                     |
+| ------------------------------ | ----- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CERBERUS_CH_QUERY_MAX_MEMORY` | int64 | `1073741824` | Per-query ClickHouse memory cap in bytes (`max_memory_usage` on every data-plane query; DDL exempt). 1 GiB default. `0` leaves it unset (CH server defaults apply). A query over the cap gets a breaker-neutral resource-exhausted rejection (Prom 422 / Loki 400 / Tempo 422). |
+| `CERBERUS_QUERY_MAX_SAMPLES`   | int64 | `50000000`   | Per-query sample budget, mirroring Prometheus `--query.max-samples`. Bounds cerberus-process memory by aborting a result-set drain that crosses the budget. `0` disables. Memory-constrained deploys should set this well below the default.                                    |
+
+## Circuit breaker
+
+Every ClickHouse-touching call is guarded by a per-`Client` circuit breaker
+(`internal/chclient/breaker.go`). The defaults reproduce the pre-tunable
+hardcoded values exactly, so out-of-the-box behaviour is unchanged. Pool-acquire
+timeouts, `MEMORY_LIMIT_EXCEEDED` rejections, and client-cancelled requests are
+treated as breaker-neutral and never advance the failure count. Set
+`CERBERUS_CH_BREAKER_ENABLED=false` to disable the breaker entirely — useful
+when an external proxy or service mesh already owns ClickHouse fail-fast. See
+[`operations.md`](operations.md#clickhouse-circuit-breaker) for the full state
+machine.
+
+| Variable                            | Type     | Default | Description                                                                                                               |
+| ----------------------------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `CERBERUS_CH_BREAKER_ENABLED`       | bool     | `true`  | Master switch. `false` makes the breaker a no-op (always-allow, never trips); a dead CH then surfaces as ordinary errors. |
+| `CERBERUS_CH_BREAKER_THRESHOLD`     | int      | `5`     | Consecutive CH-health failures within the window that trip the breaker CLOSED → OPEN. Must be >= 1.                       |
+| `CERBERUS_CH_BREAKER_WINDOW`        | duration | `10s`   | Rolling window over which the threshold failures must occur. Must be > 0.                                                 |
+| `CERBERUS_CH_BREAKER_OPEN_INTERVAL` | duration | `5s`    | OPEN-state backoff before the breaker admits a single HALF-OPEN probe. Must be > 0.                                       |
+
+## Admission control
+
+Each of the three API heads is fronted by a counted semaphore that caps
+simultaneous in-flight requests. Requests above the cap are rejected with HTTP
+503 + `Retry-After: 1` so well-behaved clients back off and ClickHouse stays out
+of overload. Tempo's cap is half of Prom / Loki because trace queries are
+typically the heaviest per-call. Setting an individual cap to `0` disables
+admission control for that head specifically.
+
+| Variable                  | Type | Default | Description                                                                  |
+| ------------------------- | ---- | ------- | ---------------------------------------------------------------------------- |
+| `CERBERUS_ADMIT_DISABLED` | bool | `false` | Disable per-handler concurrency caps entirely (handy for local development). |
+| `CERBERUS_ADMIT_PROM`     | int  | `64`    | Max simultaneous in-flight Prom API requests. `0` disables for this head.    |
+| `CERBERUS_ADMIT_LOKI`     | int  | `64`    | Max simultaneous in-flight Loki API requests. `0` disables for this head.    |
+| `CERBERUS_ADMIT_TEMPO`    | int  | `32`    | Max simultaneous in-flight Tempo API requests. `0` disables for this head.   |
+
+## Logging
+
+Cerberus's own structured logging (stdlib `log/slog`). The same records that
+print to stderr also bridge to OTLP when self-telemetry is enabled (see below).
+
+| Variable              | Type   | Default | Description                                                         |
+| --------------------- | ------ | ------- | ------------------------------------------------------------------- |
+| `CERBERUS_LOG_FORMAT` | string | `text`  | slog handler kind: `text` (human-readable) or `json` (aggregators). |
+| `CERBERUS_LOG_LEVEL`  | string | `info`  | Minimum slog level: `debug`, `info`, `warn`, or `error`.            |
+
+## Self-telemetry (OTLP export)
+
+The OpenTelemetry exporter configuration. When `CERBERUS_OTLP_ENDPOINT` is empty
+cerberus installs no-op trace, meter, and logger providers and runs as a
+zero-collector-dependency binary. Standard `OTEL_EXPORTER_OTLP_*` env vars are
+also honored by the OTel Go SDK and merge with these. See
+[`observability.md`](observability.md) for the full self-observability contract.
+
+| Variable                        | Type     | Default | Description                                                                                                                                                               |
+| ------------------------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CERBERUS_OTLP_ENDPOINT`        | string   | (empty) | gRPC OTLP target for self-telemetry (e.g. `otel-collector.observability.svc:4317`). Empty disables the exporters.                                                         |
+| `CERBERUS_OTLP_INSECURE`        | bool     | `false` | Dial the OTLP endpoint without TLS (handy for local dev / k3d).                                                                                                           |
+| `CERBERUS_OTLP_HEADERS`         | string   | (empty) | Comma-separated `key=value` gRPC metadata sent on every OTLP request (typically auth bearer tokens).                                                                      |
+| `CERBERUS_OTLP_TIMEOUT`         | duration | `10s`   | Per-request OTLP roundtrip timeout (applies to both the trace and metric exporters).                                                                                      |
+| `CERBERUS_OTLP_EXPORT_INTERVAL` | duration | `10s`   | Metric `PeriodicReader` flush interval. The quickstart default is tuned for time-to-first-panel; deployments at scale should raise it (e.g. `60s`) to cut collector load. |
+
+## Schema
+
+| Variable                      | Type | Default | Description                                                                                 |
+| ----------------------------- | ---- | ------- | ------------------------------------------------------------------------------------------- |
+| `CERBERUS_AUTO_CREATE_SCHEMA` | bool | `false` | When `true`, run the idempotent OTel-CH exporter DDL at startup before HTTP serving begins. |
+
+Schema-shape overrides — the table names cerberus reads when the ClickHouse
+layout deviates from the OTel-CH exporter defaults (`CERBERUS_SCHEMA_METRICS_*`,
+`CERBERUS_SCHEMA_LOGS_TABLE`, `CERBERUS_SCHEMA_TRACES_TABLE`) — are documented in
+[`observability.md`](observability.md#schema-shape-overrides).
+
+## Execution / solver
+
+The sharded-pushdown solver (`internal/solver`, [`solver.md`](solver.md))
+handles the one query class route A cannot bound: high **anchor fan-out**
+(`F = Range/Step`), where one statement's peak intermediate cardinality exceeds
+the ClickHouse memory cap. It is **on by default** (`CERBERUS_EVAL_ROUTE=auto`)
+and fails toward route A: only eligible plans that clear the cost thresholds
+take route B; everything else stays byte-identical on route A.
+
+| Variable                               | Type     | Default   | Description                                                                                                                                                                                                                                 |
+| -------------------------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CERBERUS_EVAL_ROUTE`                  | string   | `auto`    | Solver mode: `auto` routes eligible above-threshold plans; `single` disables routing (every request runs route A); `sharded` forces every eligible plan to route B (used by the forced-route compatibility lane, not a production setting). |
+| `CERBERUS_SHARD_MIN_FANOUT`            | int      | `16`      | `Fmin` — minimum anchor fan-out `F = max(Range/Step)` a plan must reach to be worth slicing (auto mode).                                                                                                                                    |
+| `CERBERUS_SHARD_MIN_ANCHOR_PAIRS`      | int      | `4000`    | Minimum expanded `(sample, anchor)` pair count `N×F` a plan must reach (auto mode).                                                                                                                                                         |
+| `CERBERUS_SHARD_MAX_K`                 | int      | `8`       | Caps the shard count `K`. Must be >= 2.                                                                                                                                                                                                     |
+| `CERBERUS_SHARD_MIN_ANCHORS_PER_SLICE` | int      | `16`      | Grid quantum — each slice owns at least this many anchors (never fewer than 2).                                                                                                                                                             |
+| `CERBERUS_SHARD_PARALLEL`              | int      | `3`       | `P` — per-request shard concurrency. Must be >= 1.                                                                                                                                                                                          |
+| `CERBERUS_SOLVER_TIMEOUT`              | duration | `60s`     | End-to-end bound on a routed request. Must be > 0.                                                                                                                                                                                          |
+| `CERBERUS_SHARD_MAX_OUTPUT_ROWS`       | int64    | `2000000` | Caps composed per-request output rows; an overrun is a typed `422`. Must be > 0.                                                                                                                                                            |
+| `CERBERUS_SHARD_MEMORY_APPORTION`      | bool     | `false`   | When `true`, per-shard `max_memory_usage` is `cap/P` (256 MiB floor), holding total exposure at the single-query cap.                                                                                                                       |
+
+## Experimental flags
+
+| Variable                              | Type | Default | Description                                                                                                                                                     |
+| ------------------------------------- | ---- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CERBERUS_EXPERIMENTAL_TS_GRID_RANGE` | bool | `false` | Emit ClickHouse-native `timeSeriesRateToGrid` for eligible `rate(<counter>[range])` query_range instead of the default arrayJoin fan-out. Scope is `rate` only. |
+
+`CERBERUS_EXPERIMENTAL_TS_GRID_RANGE` **requires ClickHouse ≥ 25.6** — the
+`timeSeries*ToGrid` family was introduced in CH v25.6.0; on any older server a
+native-path query errors with `UNKNOWN_FUNCTION`, so the flag **must stay off**
+unless the target ClickHouse is ≥ 25.6 (the compose / e2e / compatibility lanes
+run 25.8, so the floor is met there). The native operator computes the same
+Prometheus `extrapolatedRate` inside the engine, closing the execution-layer gap
+the SQL array machinery leaves at high cardinality. Default off is byte-for-byte
+the established fan-out. See [`performance.md`](performance.md#the-durable-answer)
+for the why and [`benchmarks.md`](benchmarks.md) for the recorded numbers.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -6,59 +6,32 @@ model, signals, and scaling.
 
 ## Configuration
 
+> **Full configuration reference → [`configuration.md`](configuration.md).**
+> Every `CERBERUS_*` variable, its type, default, and per-area grouping lives
+> there. This page covers how the key knobs interact with the running service.
+
 Every runtime knob is an environment variable read at startup by
-`internal/config/config.go` — no YAML, INI, or TOML files are loaded.
+`internal/config/config.go` (the solver knobs by `internal/solver`) — no YAML,
+INI, or TOML files are loaded. The most operationally significant knobs:
 
-| Variable                               | Default          | Meaning                                                                                                                                                                                                                                                            |
-| -------------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `CERBERUS_HTTP_ADDR`                   | `:8080`          | HTTP listen address for the Prom/Loki/Tempo APIs and health probes.                                                                                                                                                                                                |
-| `CERBERUS_CH_ADDR`                     | `localhost:9000` | ClickHouse native-protocol endpoint.                                                                                                                                                                                                                               |
-| `CERBERUS_CH_DATABASE`                 | `otel`           | ClickHouse database name.                                                                                                                                                                                                                                          |
-| `CERBERUS_CH_USERNAME`                 | `default`        | ClickHouse user.                                                                                                                                                                                                                                                   |
-| `CERBERUS_CH_PASSWORD`                 | (empty)          | ClickHouse password.                                                                                                                                                                                                                                               |
-| `CERBERUS_CH_DIAL_TIMEOUT`             | `5s`             | ClickHouse dial timeout (`time.ParseDuration` syntax).                                                                                                                                                                                                             |
-| `CERBERUS_CH_MAX_OPEN_CONNS`           | `10`             | Total pooled ClickHouse connections (busy + idle). Reproduces clickhouse-go's implicit default; explicit so it can be raised for fan-out. Pool exhaustion blocks up to the dial timeout then returns a breaker-neutral acquire-timeout. Must be > 0.               |
-| `CERBERUS_CH_MAX_IDLE_CONNS`           | `5`              | Idle ClickHouse connections kept warm for reuse. Reproduces clickhouse-go's implicit default. Must be > 0.                                                                                                                                                         |
-| `CERBERUS_CH_CONN_MAX_LIFETIME`        | `1h`             | Max age of a pooled ClickHouse connection before it is recycled (`time.ParseDuration` syntax). Reproduces clickhouse-go's implicit default. Must be > 0.                                                                                                           |
-| `CERBERUS_CH_QUERY_MAX_MEMORY`         | `1073741824`     | Per-query ClickHouse memory cap in bytes (`max_memory_usage` on every data-plane query; DDL exempt). `0` = don't set. Queries over the cap get a resource-exhausted rejection (Prom 422 / Loki 400 / Tempo 422), breaker-neutral.                                  |
-| `CERBERUS_QUERY_MAX_SAMPLES`           | `50000000`       | Per-query sample budget (Prometheus `--query.max-samples` parity); bounds cerberus-process memory. `0` disables.                                                                                                                                                   |
-| `CERBERUS_CH_BREAKER_ENABLED`          | `true`           | Master switch for the ClickHouse-disconnect circuit breaker. `false` makes the breaker a no-op (always-allow, never trips) — a saturated or dead CH then surfaces as ordinary dial/query errors instead of fast-fail `503 Retry-After: 5`.                         |
-| `CERBERUS_CH_BREAKER_THRESHOLD`        | `5`              | Consecutive CH-health failures within the window that trip the breaker CLOSED → OPEN. Must be >= 1.                                                                                                                                                                |
-| `CERBERUS_CH_BREAKER_WINDOW`           | `10s`            | Rolling window over which the threshold failures must occur (`time.ParseDuration` syntax). Must be > 0.                                                                                                                                                            |
-| `CERBERUS_CH_BREAKER_OPEN_INTERVAL`    | `5s`             | OPEN-state backoff before the breaker admits a single HALF-OPEN probe (`time.ParseDuration` syntax). Must be > 0.                                                                                                                                                  |
-| `CERBERUS_AUTO_CREATE_SCHEMA`          | `false`          | When `true`, apply the OTel-CH DDL at startup before serving.                                                                                                                                                                                                      |
-| `CERBERUS_EXPERIMENTAL_TS_GRID_RANGE`  | `false`          | **Experimental.** Emit native `timeSeriesRateToGrid` for eligible `rate(…[range])` query_range (needs CH ≥ 25.6; prod is on 25.8 so the floor is met, errors on < 25.6). OFF keeps the fan-out. See [native rate](#experimental-native-rate-timeseriesratetogrid). |
-| `CERBERUS_LOG_FORMAT`                  | `text`           | slog handler kind (`text` or `json`).                                                                                                                                                                                                                              |
-| `CERBERUS_LOG_LEVEL`                   | `info`           | Minimum slog level (`debug` / `info` / `warn` / `error`).                                                                                                                                                                                                          |
-| `CERBERUS_OTLP_ENDPOINT`               | (empty)          | gRPC OTLP target for self-telemetry. Empty disables exporters.                                                                                                                                                                                                     |
-| `CERBERUS_OTLP_INSECURE`               | `false`          | Dial OTLP endpoint without TLS.                                                                                                                                                                                                                                    |
-| `CERBERUS_OTLP_HEADERS`                | (empty)          | Comma-separated `key=value` gRPC metadata (e.g. auth tokens).                                                                                                                                                                                                      |
-| `CERBERUS_OTLP_TIMEOUT`                | `10s`            | Per-request OTLP roundtrip timeout.                                                                                                                                                                                                                                |
-| `CERBERUS_OTLP_EXPORT_INTERVAL`        | `10s`            | Metric `PeriodicReader` flush interval for self-telemetry. The quickstart default is tuned for time-to-first-panel; deployments running at scale should raise it (e.g. `60s`) to cut collector load.                                                               |
-| `CERBERUS_ADMIT_DISABLED`              | `false`          | Disable per-handler concurrency caps.                                                                                                                                                                                                                              |
-| `CERBERUS_ADMIT_PROM`                  | `64`             | Max simultaneous in-flight Prom API requests.                                                                                                                                                                                                                      |
-| `CERBERUS_ADMIT_LOKI`                  | `64`             | Max simultaneous in-flight Loki API requests.                                                                                                                                                                                                                      |
-| `CERBERUS_ADMIT_TEMPO`                 | `32`             | Max simultaneous in-flight Tempo API requests.                                                                                                                                                                                                                     |
-| `CERBERUS_EVAL_ROUTE`                  | `auto`           | Sharded-pushdown solver mode: `auto` routes eligible plans (route B); `single` disables routing; `sharded` forces every eligible plan to route B. See [Sharded-pushdown solver](#sharded-pushdown-solver).                                                         |
-| `CERBERUS_SHARD_MIN_FANOUT`            | `16`             | `Fmin` — minimum anchor fan-out `F = max(Range/Step)` a plan must reach to be worth slicing (auto mode).                                                                                                                                                           |
-| `CERBERUS_SHARD_MIN_ANCHOR_PAIRS`      | `4000`           | Minimum expanded `(sample, anchor)` pair count `N×F` a plan must reach (auto mode).                                                                                                                                                                                |
-| `CERBERUS_SHARD_MAX_K`                 | `8`              | Caps the shard count `K`.                                                                                                                                                                                                                                          |
-| `CERBERUS_SHARD_MIN_ANCHORS_PER_SLICE` | `16`             | Grid quantum — each slice owns at least this many anchors (never fewer than 2).                                                                                                                                                                                    |
-| `CERBERUS_SHARD_PARALLEL`              | `3`              | `P` — per-request shard concurrency.                                                                                                                                                                                                                               |
-| `CERBERUS_SOLVER_TIMEOUT`              | `60s`            | End-to-end bound on a routed request.                                                                                                                                                                                                                              |
-| `CERBERUS_SHARD_MAX_OUTPUT_ROWS`       | `2000000`        | Caps composed per-request output rows; an overrun is a typed `422`.                                                                                                                                                                                                |
-| `CERBERUS_SHARD_MEMORY_APPORTION`      | `false`          | When `true`, per-shard `max_memory_usage` is `cap/P` (256 MiB floor), holding total exposure at the single-query cap.                                                                                                                                              |
+- **`CERBERUS_CH_ADDR` / `_DATABASE` / `_USERNAME` / `_PASSWORD`** point cerberus
+  at ClickHouse; swapping a local node for a managed cluster is an env flip.
+- **`CERBERUS_CH_QUERY_MAX_MEMORY`** bounds per-query ClickHouse memory so a
+  single over-broad query gets a deterministic rejection instead of racing the
+  server-total cap; **`CERBERUS_QUERY_MAX_SAMPLES`** bounds cerberus-process
+  memory the same way.
+- **`CERBERUS_CH_BREAKER_*`** tune the ClickHouse-disconnect circuit breaker
+  (below); **`CERBERUS_ADMIT_*`** tune the per-handler concurrency caps
+  ([Scaling](#per-handler-concurrency-caps-admission-control)).
+- **`CERBERUS_EVAL_ROUTE`** + the `CERBERUS_SHARD_*` knobs tune the
+  sharded-pushdown solver (below); **`CERBERUS_OTLP_ENDPOINT`** enables
+  self-telemetry export.
 
-Schema-shape overrides (table names, when the CH layout deviates from
-the OTel-CH exporter defaults) are listed in
-[`observability.md`](observability.md#schema-shape-overrides).
-
-Misconfigured values fail fast: an unparseable duration, an unknown log
-level, or a malformed OTLP header list aborts startup with a clear error
-rather than silently downgrading behaviour. Secrets (CH password, OTLP
-bearer tokens) live in the same env-var namespace and are sourced from
-Kubernetes `Secret` / Docker `secrets:` / a vault-injecting init
-container — never committed.
+Misconfigured values fail fast: an unparseable duration, an unknown log level,
+or a malformed OTLP header list aborts startup with a clear error rather than
+silently downgrading behaviour. Secrets (CH password, OTLP bearer tokens) live
+in the same env-var namespace and are sourced from Kubernetes `Secret` / Docker
+`secrets:` / a vault-injecting init container — never committed.
 
 ### ClickHouse circuit breaker
 


### PR DESCRIPTION
## What

Configuration was buried inside `docs/operations.md`. This gives it its own
canonical reference doc and a proper spotlight in the README, while keeping
operations.md focused on the runtime contract.

## The extraction (operations.md → configuration.md)

New `docs/configuration.md` — a scannable, present-tense, area-grouped
reference. Each area has an `env var | type | default | description` table:

- **HTTP server** — `CERBERUS_HTTP_ADDR`
- **ClickHouse connection** — addr / database / username / password / dial timeout
- **Connection pool** — max-open / max-idle conns, conn max lifetime
- **Query limits & memory** — `CERBERUS_CH_QUERY_MAX_MEMORY`, `CERBERUS_QUERY_MAX_SAMPLES`
- **Circuit breaker** — the four `CERBERUS_CH_BREAKER_*` knobs + how to disable
- **Admission control** — `CERBERUS_ADMIT_DISABLED` / `_PROM` / `_LOKI` / `_TEMPO`
- **Logging** — `CERBERUS_LOG_FORMAT` / `_LEVEL`
- **Self-telemetry (OTLP)** — endpoint / insecure / headers / timeout / export interval
- **Schema** — `CERBERUS_AUTO_CREATE_SCHEMA` (+ pointer to observability.md for the schema-shape table-name overrides)
- **Execution / solver** — `CERBERUS_EVAL_ROUTE` + the `CERBERUS_SHARD_*` / `CERBERUS_SOLVER_TIMEOUT` knobs (links solver.md)
- **Experimental flags** — `CERBERUS_EXPERIMENTAL_TS_GRID_RANGE` (notes the CH ≥ 25.6 requirement; links performance.md / benchmarks.md)

Opens with a 2-paragraph intro: cerberus is a stateless 12-factor binary
configured entirely via `CERBERUS_*` env vars; ClickHouse + the OTel collector
are attached resources; fail-fast on misconfig; secrets via Secret/secrets/vault.

## What stayed in operations.md

The runtime **contract**, not the reference table:

- The breaker / sharded-pushdown-solver / experimental-native-rate subsections
  (operational narrative — state machine, routing modes, shadow header,
  parity), lifecycle (startup/shutdown), port binding (h2c + gRPC), scaling,
  admission control, HPA, dev/prod parity, build-release-run.
- The flat exhaustive env-var table is **removed** (no duplication). The
  Configuration section now opens with **"Full configuration reference →
  configuration.md"** plus a short key-knobs-in-context list (which knobs bound
  memory, point at CH, tune the breaker / caps / solver / OTLP).

## README spotlight

- Added a `docs/configuration.md` row to the Documentation index table:
  *"The full `CERBERUS_*` environment-variable reference, grouped by area, with
  types and defaults."* (operations.md's row trimmed to lifecycle/scaling/solver).
- One-line spotlight after the release quick start: *"Cerberus is configured
  entirely through `CERBERUS_*` environment variables — see the full
  [configuration reference](docs/configuration.md)."* README stays lean (link
  only, no table dump).

## Correctness

Every default cross-checked against `internal/config/config.go` (and the solver
knobs against `internal/solver/config_env.go`). Spot-checked 9 defaults
(HTTP_ADDR, CH_ADDR, CH_MAX_OPEN_CONNS, QUERY_MAX_SAMPLES, CH_QUERY_MAX_MEMORY,
OTLP_EXPORT_INTERVAL, ADMIT_TEMPO, SHARD_MIN_ANCHOR_PAIRS, SOLVER_TIMEOUT) — all
match. No env var in `FromEnv` is missing from the new doc; the
`CERBERUS_SCHEMA_*` table-name overrides are intentionally pointered to
observability.md rather than re-listed. Cross-doc links
(operations↔configuration, README→configuration, configuration→solver /
performance / benchmarks / observability) all resolve. markdownlint clean;
timeless present tense.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
