### PR TITLE
refactor(config): load configuration via spf13/viper (env contract unchanged)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter v0.152.0
 	github.com/prometheus/common v0.68.1
 	github.com/prometheus/prometheus v0.311.3
+	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go/modules/clickhouse v0.42.0
 	go.opentelemetry.io/contrib/bridges/otelslog v0.19.0
@@ -228,6 +229,7 @@ require (
 	github.com/pb33f/jsonpath v0.8.2 // indirect
 	github.com/pb33f/libopenapi v0.36.3 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
+	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pierrec/lz4/v4 v4.1.26 // indirect
 	github.com/pires/go-proxyproto v0.11.0 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
@@ -244,6 +246,7 @@ require (
 	github.com/prometheus/sigv4 v0.4.1 // indirect
 	github.com/puzpuzpuz/xsync/v4 v4.5.0 // indirect
 	github.com/redis/go-redis/v9 v9.18.0 // indirect
+	github.com/sagikazarmark/locafero v0.11.0 // indirect
 	github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/sercand/kuberesolver/v6 v6.0.1 // indirect
@@ -251,8 +254,12 @@ require (
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/sony/gobreaker/v2 v2.4.0 // indirect
+	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
+	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
+	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect
+	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/testcontainers/testcontainers-go v0.42.0 // indirect
 	github.com/tjhop/slog-gokit v0.2.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect

--- a/go.sum
+++ b/go.sum
@@ -579,6 +579,8 @@ github.com/pb33f/libopenapi-validator v0.13.7/go.mod h1:zkbQL07GQANm5UNSvm7Lk5of
 github.com/pb33f/ordered-map/v2 v2.3.1 h1:5319HDO0aw4DA4gzi+zv4FXU9UlSs3xGZ40wcP1nBjY=
 github.com/pb33f/ordered-map/v2 v2.3.1/go.mod h1:qxFQgd0PkVUtOMCkTapqotNgzRhMPL7VvaHKbd1HnmQ=
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
+github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
+github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/philhofer/fwd v1.1.1/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=
 github.com/pierrec/lz4/v4 v4.1.26 h1:GrpZw1gZttORinvzBdXPUXATeqlJjqUG/D87TKMnhjY=
 github.com/pierrec/lz4/v4 v4.1.26/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
@@ -638,6 +640,8 @@ github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfS
 github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/sagikazarmark/locafero v0.11.0 h1:1iurJgmM9G3PA/I+wWYIOw/5SyBtxapeHDcg+AAIFXc=
+github.com/sagikazarmark/locafero v0.11.0/go.mod h1:nVIGvgyzw595SUSUE6tvCp3YYTeHs15MvlmU87WwIik=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/scaleway/scaleway-sdk-go v1.0.0-beta.36 h1:ObX9hZmK+VmijreZO/8x9pQ8/P/ToHD/bdSb4Eg4tUo=
@@ -661,10 +665,16 @@ github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
 github.com/sony/gobreaker/v2 v2.4.0 h1:g2KJRW1Ubty3+ZOcSEUN7K+REQJdN6yo6XvaML+jptg=
 github.com/sony/gobreaker/v2 v2.4.0/go.mod h1:pTyFJgcZ3h2tdQVLZZruK2C0eoFL1fb/G83wK1ZQl+s=
+github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 h1:+jumHNA0Wrelhe64i8F6HNlS8pkoyMv5sreGx2Ry5Rw=
+github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8/go.mod h1:3n1Cwaq1E1/1lhQhtRK2ts/ZwZEhjcQeJQ1RuC6Q/8U=
+github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=
+github.com/spf13/afero v1.15.0/go.mod h1:NC2ByUVxtQs4b3sIUphxK0NioZnmxgyCrfzeuq8lxMg=
 github.com/spf13/cast v1.10.0 h1:h2x0u2shc1QuLHfxi+cTJvs30+ZAHOGRic8uyGTDWxY=
 github.com/spf13/cast v1.10.0/go.mod h1:jNfB8QC9IA6ZuY2ZjDp0KtFO2LZZlg4S/7bzP6qqeHo=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/viper v1.21.0 h1:x5S+0EU27Lbphp4UKm1C+1oQO+rKx36vfCoaVebLFSU=
+github.com/spf13/viper v1.21.0/go.mod h1:P0lhsswPGWD/1lZJ9ny3fYnVqxiegrlNrEmgLjbTCAY=
 github.com/stackitcloud/stackit-sdk-go/core v0.26.0 h1:jQEb9gkehfp6VCP6TcYk7BI10cz4l0KM2L6hqYBH2QA=
 github.com/stackitcloud/stackit-sdk-go/core v0.26.0/go.mod h1:WU1hhxnjXw2EV7CYa1nlEvNpMiRY6CvmIOaHuL3pOaA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -686,6 +696,8 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
+github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/testcontainers/testcontainers-go v0.42.0 h1:He3IhTzTZOygSXLJPMX7n44XtK+qhjat1nI9cneBbUY=
 github.com/testcontainers/testcontainers-go v0.42.0/go.mod h1:vZjdY1YmUA1qEForxOIOazfsrdyORJAbhi0bp8plN30=
 github.com/testcontainers/testcontainers-go/modules/clickhouse v0.42.0 h1:SwtkmOTGr0P2+XA2WuDYYNMv2rx7XdIZLZcqJGHB4yA=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,17 +1,22 @@
-// Package config loads cerberus runtime configuration from environment
-// variables (the seed source — YAML loading lands when there's an actual
-// need for nested config).
+// Package config loads cerberus runtime configuration. The value source
+// is a github.com/spf13/viper instance (per-loader, not the global
+// singleton) wired with the CERBERUS_ env prefix; an optional
+// `cerberus.yaml` config file may supply values, but environment
+// variables always win over the file and explicit defaults sit beneath
+// both. The CERBERUS_* environment-variable contract — names, Go types,
+// defaults, and fail-fast validation — is unchanged from the prior
+// hand-rolled env parser; viper is a mechanism swap, not a redesign.
 package config
 
 import (
 	"fmt"
 	"io"
 	"log/slog"
-	"os"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/spf13/viper"
 	otellog "go.opentelemetry.io/otel/log"
 
 	"github.com/tsouza/cerberus/internal/chclient"
@@ -151,8 +156,51 @@ type OTLPConfig struct {
 	ExportInterval time.Duration
 }
 
-// FromEnv reads configuration from environment variables, falling back to
-// reasonable defaults for local development.
+// Environment-variable keys. Centralised so the viper SetDefault /
+// BindEnv wiring and the per-field reads reference the exact same
+// strings — the CERBERUS_* contract is load-bearing (docs + surface
+// tests pin these names).
+const (
+	envHTTPAddr            = "CERBERUS_HTTP_ADDR"
+	envCHAddr              = "CERBERUS_CH_ADDR"
+	envCHDatabase          = "CERBERUS_CH_DATABASE"
+	envCHUsername          = "CERBERUS_CH_USERNAME"
+	envCHPassword          = "CERBERUS_CH_PASSWORD"
+	envCHDialTimeout       = "CERBERUS_CH_DIAL_TIMEOUT"
+	envCHMaxOpenConns      = "CERBERUS_CH_MAX_OPEN_CONNS"
+	envCHMaxIdleConns      = "CERBERUS_CH_MAX_IDLE_CONNS"
+	envCHConnMaxLifetime   = "CERBERUS_CH_CONN_MAX_LIFETIME"
+	envQueryMaxSamples     = "CERBERUS_QUERY_MAX_SAMPLES"
+	envCHQueryMaxMemory    = "CERBERUS_CH_QUERY_MAX_MEMORY"
+	envCHBreakerEnabled    = "CERBERUS_CH_BREAKER_ENABLED"
+	envCHBreakerThreshold  = "CERBERUS_CH_BREAKER_THRESHOLD"
+	envCHBreakerWindow     = "CERBERUS_CH_BREAKER_WINDOW"
+	envCHBreakerOpenIntrvl = "CERBERUS_CH_BREAKER_OPEN_INTERVAL"
+	envAutoCreateSchema    = "CERBERUS_AUTO_CREATE_SCHEMA"
+	envExperimentalTSGrid  = "CERBERUS_EXPERIMENTAL_TS_GRID_RANGE"
+	envLogFormat           = "CERBERUS_LOG_FORMAT"
+	envLogLevel            = "CERBERUS_LOG_LEVEL"
+	envOTLPEndpoint        = "CERBERUS_OTLP_ENDPOINT"
+	envOTLPInsecure        = "CERBERUS_OTLP_INSECURE"
+	envOTLPHeaders         = "CERBERUS_OTLP_HEADERS"
+	envOTLPTimeout         = "CERBERUS_OTLP_TIMEOUT"
+	envOTLPExportInterval  = "CERBERUS_OTLP_EXPORT_INTERVAL"
+	envAdmitDisabled       = "CERBERUS_ADMIT_DISABLED"
+	envAdmitProm           = "CERBERUS_ADMIT_PROM"
+	envAdmitLoki           = "CERBERUS_ADMIT_LOKI"
+	envAdmitTempo          = "CERBERUS_ADMIT_TEMPO"
+)
+
+// configFileBaseName is the base name (without extension) viper looks
+// for when probing for an optional config file: cerberus.yaml.
+const configFileBaseName = "cerberus"
+
+// FromEnv reads configuration via a per-call viper loader. Values are
+// resolved with viper's standard precedence — environment variable >
+// config file > built-in default — so the CERBERUS_* environment
+// contract always wins. An optional `cerberus.yaml` in the working
+// directory (or /etc/cerberus) supplies file-level defaults; its
+// absence is not an error.
 //
 //	CERBERUS_HTTP_ADDR             default ":8080"
 //	CERBERUS_CH_ADDR               default "localhost:9000"
@@ -199,76 +247,78 @@ type OTLPConfig struct {
 //	CERBERUS_SCHEMA_LOGS_TABLE                  default "otel_logs"
 //	CERBERUS_SCHEMA_TRACES_TABLE                default "otel_traces"
 func FromEnv() (Config, error) {
-	dial, err := time.ParseDuration(envDefault("CERBERUS_CH_DIAL_TIMEOUT", "5s"))
+	v := newLoader()
+
+	dial, err := getDuration(v, envCHDialTimeout)
 	if err != nil {
-		return Config{}, fmt.Errorf("CERBERUS_CH_DIAL_TIMEOUT: %w", err)
+		return Config{}, err
 	}
-	autoCreate, err := envBool("CERBERUS_AUTO_CREATE_SCHEMA", false)
+	autoCreate, err := getBool(v, envAutoCreateSchema)
 	if err != nil {
-		return Config{}, fmt.Errorf("CERBERUS_AUTO_CREATE_SCHEMA: %w", err)
+		return Config{}, err
 	}
-	tsGridRange, err := envBool("CERBERUS_EXPERIMENTAL_TS_GRID_RANGE", false)
+	tsGridRange, err := getBool(v, envExperimentalTSGrid)
 	if err != nil {
-		return Config{}, fmt.Errorf("CERBERUS_EXPERIMENTAL_TS_GRID_RANGE: %w", err)
+		return Config{}, err
 	}
-	maxOpenConns, err := envInt("CERBERUS_CH_MAX_OPEN_CONNS", defaultCHMaxOpenConns)
+	maxOpenConns, err := getInt(v, envCHMaxOpenConns)
 	if err != nil {
-		return Config{}, fmt.Errorf("CERBERUS_CH_MAX_OPEN_CONNS: %w", err)
+		return Config{}, err
 	}
 	if maxOpenConns <= 0 {
-		return Config{}, fmt.Errorf("CERBERUS_CH_MAX_OPEN_CONNS: must be > 0, got %d", maxOpenConns)
+		return Config{}, fmt.Errorf("%s: must be > 0, got %d", envCHMaxOpenConns, maxOpenConns)
 	}
-	maxIdleConns, err := envInt("CERBERUS_CH_MAX_IDLE_CONNS", defaultCHMaxIdleConns)
+	maxIdleConns, err := getInt(v, envCHMaxIdleConns)
 	if err != nil {
-		return Config{}, fmt.Errorf("CERBERUS_CH_MAX_IDLE_CONNS: %w", err)
+		return Config{}, err
 	}
 	if maxIdleConns <= 0 {
-		return Config{}, fmt.Errorf("CERBERUS_CH_MAX_IDLE_CONNS: must be > 0, got %d", maxIdleConns)
+		return Config{}, fmt.Errorf("%s: must be > 0, got %d", envCHMaxIdleConns, maxIdleConns)
 	}
-	connMaxLifetime, err := time.ParseDuration(envDefault("CERBERUS_CH_CONN_MAX_LIFETIME", defaultCHConnMaxLifetime.String()))
+	connMaxLifetime, err := getDuration(v, envCHConnMaxLifetime)
 	if err != nil {
-		return Config{}, fmt.Errorf("CERBERUS_CH_CONN_MAX_LIFETIME: %w", err)
+		return Config{}, err
 	}
 	if connMaxLifetime <= 0 {
-		return Config{}, fmt.Errorf("CERBERUS_CH_CONN_MAX_LIFETIME: must be > 0, got %s", connMaxLifetime)
+		return Config{}, fmt.Errorf("%s: must be > 0, got %s", envCHConnMaxLifetime, connMaxLifetime)
 	}
-	maxSamples, err := envInt64("CERBERUS_QUERY_MAX_SAMPLES", defaultQueryMaxSamples)
+	maxSamples, err := getInt64(v, envQueryMaxSamples)
 	if err != nil {
-		return Config{}, fmt.Errorf("CERBERUS_QUERY_MAX_SAMPLES: %w", err)
+		return Config{}, err
 	}
 	if maxSamples < 0 {
-		return Config{}, fmt.Errorf("CERBERUS_QUERY_MAX_SAMPLES: must be >= 0, got %d", maxSamples)
+		return Config{}, fmt.Errorf("%s: must be >= 0, got %d", envQueryMaxSamples, maxSamples)
 	}
-	maxMemory, err := envInt64("CERBERUS_CH_QUERY_MAX_MEMORY", defaultCHQueryMaxMemory)
+	maxMemory, err := getInt64(v, envCHQueryMaxMemory)
 	if err != nil {
-		return Config{}, fmt.Errorf("CERBERUS_CH_QUERY_MAX_MEMORY: %w", err)
+		return Config{}, err
 	}
 	if maxMemory < 0 {
-		return Config{}, fmt.Errorf("CERBERUS_CH_QUERY_MAX_MEMORY: must be >= 0, got %d", maxMemory)
+		return Config{}, fmt.Errorf("%s: must be >= 0, got %d", envCHQueryMaxMemory, maxMemory)
 	}
-	breaker, err := breakerFromEnv()
+	breaker, err := breakerFromEnv(v)
 	if err != nil {
 		return Config{}, err
 	}
-	logCfg, err := envLog()
+	logCfg, err := envLog(v)
 	if err != nil {
 		return Config{}, err
 	}
-	otlp, err := otlpFromEnv()
+	otlp, err := otlpFromEnv(v)
 	if err != nil {
 		return Config{}, err
 	}
-	admit, err := admitFromEnv()
+	admit, err := admitFromEnv(v)
 	if err != nil {
 		return Config{}, err
 	}
 	return Config{
-		HTTPAddr: envDefault("CERBERUS_HTTP_ADDR", ":8080"),
+		HTTPAddr: v.GetString(envHTTPAddr),
 		ClickHouse: chclient.Config{
-			Addr:                envDefault("CERBERUS_CH_ADDR", "localhost:9000"),
-			Database:            envDefault("CERBERUS_CH_DATABASE", "otel"),
-			Username:            envDefault("CERBERUS_CH_USERNAME", "default"),
-			Password:            envDefault("CERBERUS_CH_PASSWORD", ""),
+			Addr:                v.GetString(envCHAddr),
+			Database:            v.GetString(envCHDatabase),
+			Username:            v.GetString(envCHUsername),
+			Password:            v.GetString(envCHPassword),
 			DialTimeout:         dial,
 			MaxOpenConns:        maxOpenConns,
 			MaxIdleConns:        maxIdleConns,
@@ -290,6 +340,141 @@ func FromEnv() (Config, error) {
 		Admit:                   admit,
 	}, nil
 }
+
+// allEnvKeys is every CERBERUS_* var the loader resolves. Each is both
+// the viper key and the literal environment-variable name — they are
+// identical by design so the historical CERBERUS_* contract is byte-exact.
+var allEnvKeys = []string{
+	envHTTPAddr,
+	envCHAddr,
+	envCHDatabase,
+	envCHUsername,
+	envCHPassword,
+	envCHDialTimeout,
+	envCHMaxOpenConns,
+	envCHMaxIdleConns,
+	envCHConnMaxLifetime,
+	envQueryMaxSamples,
+	envCHQueryMaxMemory,
+	envCHBreakerEnabled,
+	envCHBreakerThreshold,
+	envCHBreakerWindow,
+	envCHBreakerOpenIntrvl,
+	envAutoCreateSchema,
+	envExperimentalTSGrid,
+	envLogFormat,
+	envLogLevel,
+	envOTLPEndpoint,
+	envOTLPInsecure,
+	envOTLPHeaders,
+	envOTLPTimeout,
+	envOTLPExportInterval,
+	envAdmitDisabled,
+	envAdmitProm,
+	envAdmitLoki,
+	envAdmitTempo,
+}
+
+// newLoader builds the per-call viper instance: a fresh viper.New()
+// (never the package-global singleton, so the loader is testable and
+// embeddable), with every CERBERUS_* key explicitly bound to its
+// identically-named environment variable via BindEnv(key, key) and seeded
+// with the exact historical default. Per-key BindEnv (rather than
+// SetEnvPrefix + AutomaticEnv) is deliberate: our viper keys are already
+// the full CERBERUS_<NAME> strings, and AutomaticEnv would re-apply the
+// prefix and look up CERBERUS_CERBERUS_<NAME>, breaking the contract.
+// An optional `cerberus.yaml` config file is merged in beneath env vars;
+// its absence is silently tolerated. Precedence is viper's native
+// ordering — env var > config file > default — so a CERBERUS_* env var
+// always wins over a file value.
+func newLoader() *viper.Viper {
+	v := viper.New()
+	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	for _, key := range allEnvKeys {
+		// Two-arg BindEnv binds the viper key to the literal env-var
+		// name with no prefix munging — key and env var are the same
+		// CERBERUS_<NAME> string. BindEnv only errors on an empty key,
+		// which is impossible here.
+		_ = v.BindEnv(key, key)
+	}
+
+	// Defaults — the exact historical values. Durations/bools are stored
+	// as their typed Go values so viper's getters and config-file
+	// unmarshalling agree.
+	v.SetDefault(envHTTPAddr, defaultHTTPAddr)
+	v.SetDefault(envCHAddr, defaultCHAddr)
+	v.SetDefault(envCHDatabase, defaultCHDatabase)
+	v.SetDefault(envCHUsername, defaultCHUsername)
+	v.SetDefault(envCHPassword, defaultCHPassword)
+	v.SetDefault(envCHDialTimeout, defaultCHDialTimeout.String())
+	v.SetDefault(envCHMaxOpenConns, defaultCHMaxOpenConns)
+	v.SetDefault(envCHMaxIdleConns, defaultCHMaxIdleConns)
+	v.SetDefault(envCHConnMaxLifetime, defaultCHConnMaxLifetime.String())
+	v.SetDefault(envQueryMaxSamples, defaultQueryMaxSamples)
+	v.SetDefault(envCHQueryMaxMemory, defaultCHQueryMaxMemory)
+	v.SetDefault(envCHBreakerEnabled, defaultCHBreakerEnabled)
+	v.SetDefault(envCHBreakerThreshold, defaultCHBreakerThreshold)
+	v.SetDefault(envCHBreakerWindow, defaultCHBreakerWindow.String())
+	v.SetDefault(envCHBreakerOpenIntrvl, defaultCHBreakerOpenInterval.String())
+	v.SetDefault(envAutoCreateSchema, defaultAutoCreateSchema)
+	v.SetDefault(envExperimentalTSGrid, defaultExperimentalTSGrid)
+	v.SetDefault(envLogFormat, defaultLogFormat)
+	v.SetDefault(envLogLevel, defaultLogLevel)
+	v.SetDefault(envOTLPEndpoint, defaultOTLPEndpoint)
+	v.SetDefault(envOTLPInsecure, defaultOTLPInsecure)
+	v.SetDefault(envOTLPHeaders, defaultOTLPHeaders)
+	v.SetDefault(envOTLPTimeout, defaultOTLPTimeout.String())
+	v.SetDefault(envOTLPExportInterval, defaultOTLPExportInterval.String())
+	v.SetDefault(envAdmitDisabled, defaultAdmitDisabled)
+	v.SetDefault(envAdmitProm, defaultAdmitProm)
+	v.SetDefault(envAdmitLoki, defaultAdmitLoki)
+	v.SetDefault(envAdmitTempo, defaultAdmitTempo)
+
+	// Optional config file: cerberus.yaml in the working directory or
+	// /etc/cerberus. Env vars always win (viper precedence: explicit
+	// Set > env > config file > default), so the file is purely additive
+	// and never overrides an operator's environment. A missing file is
+	// not an error; a malformed file is tolerated here and surfaces later
+	// only if a value fails the same fail-fast validation env values get.
+	v.SetConfigName(configFileBaseName)
+	v.SetConfigType("yaml")
+	v.AddConfigPath(".")
+	v.AddConfigPath("/etc/cerberus")
+	// Every ReadInConfig error is tolerated, not just file-not-found: the
+	// CERBERUS_* env contract is the source of truth, and a missing OR
+	// malformed cerberus.yaml must never take cerberus down. Values still
+	// resolve from env vars and built-in defaults, and each one is run
+	// through the same fail-fast typed validation regardless of source.
+	_ = v.ReadInConfig()
+	return v
+}
+
+// Built-in defaults, kept as named constants so newLoader's SetDefault
+// calls and the doc comment can't drift. String/bool defaults that have
+// no other natural home live here; the int / duration budget defaults
+// keep their original homes below (they carry longer rationale comments).
+const (
+	defaultHTTPAddr           = ":8080"
+	defaultCHAddr             = "localhost:9000"
+	defaultCHDatabase         = "otel"
+	defaultCHUsername         = "default"
+	defaultCHPassword         = ""
+	defaultAutoCreateSchema   = false
+	defaultExperimentalTSGrid = false
+	defaultLogFormat          = "text"
+	defaultLogLevel           = "info"
+	defaultOTLPEndpoint       = ""
+	defaultOTLPInsecure       = false
+	defaultOTLPHeaders        = ""
+	defaultCHBreakerEnabled   = true
+	defaultAdmitDisabled      = false
+)
+
+const (
+	defaultCHDialTimeout      time.Duration = 5 * time.Second
+	defaultOTLPTimeout        time.Duration = 10 * time.Second
+	defaultOTLPExportInterval time.Duration = 10 * time.Second
+)
 
 // defaultQueryMaxSamples is the default per-query sample budget,
 // mirroring upstream Prometheus's --query.max-samples default
@@ -356,8 +541,8 @@ type breakerConfig struct {
 	OpenInterval time.Duration
 }
 
-// breakerFromEnv reads the CERBERUS_CH_BREAKER_* env vars into a
-// breakerConfig. Unset values use the defaults above, which reproduce the
+// breakerFromEnv reads the CERBERUS_CH_BREAKER_* knobs from the viper
+// loader. Unset values use the defaults above, which reproduce the
 // pre-#95 hardcoded breaker constants exactly (so defaults are
 // byte-unchanged). CERBERUS_CH_BREAKER_ENABLED=false disables the breaker
 // entirely (always-allow, never trips); when disabled the threshold /
@@ -365,31 +550,31 @@ type breakerConfig struct {
 // silently, but they have no runtime effect.
 //
 // Fail-fast validation: threshold must be >= 1, window > 0, interval > 0.
-func breakerFromEnv() (breakerConfig, error) {
-	enabled, err := envBool("CERBERUS_CH_BREAKER_ENABLED", true)
+func breakerFromEnv(v *viper.Viper) (breakerConfig, error) {
+	enabled, err := getBool(v, envCHBreakerEnabled)
 	if err != nil {
-		return breakerConfig{}, fmt.Errorf("CERBERUS_CH_BREAKER_ENABLED: %w", err)
+		return breakerConfig{}, err
 	}
-	threshold, err := envInt("CERBERUS_CH_BREAKER_THRESHOLD", defaultCHBreakerThreshold)
+	threshold, err := getInt(v, envCHBreakerThreshold)
 	if err != nil {
-		return breakerConfig{}, fmt.Errorf("CERBERUS_CH_BREAKER_THRESHOLD: %w", err)
+		return breakerConfig{}, err
 	}
 	if threshold < 1 {
-		return breakerConfig{}, fmt.Errorf("CERBERUS_CH_BREAKER_THRESHOLD: must be >= 1, got %d", threshold)
+		return breakerConfig{}, fmt.Errorf("%s: must be >= 1, got %d", envCHBreakerThreshold, threshold)
 	}
-	window, err := time.ParseDuration(envDefault("CERBERUS_CH_BREAKER_WINDOW", defaultCHBreakerWindow.String()))
+	window, err := getDuration(v, envCHBreakerWindow)
 	if err != nil {
-		return breakerConfig{}, fmt.Errorf("CERBERUS_CH_BREAKER_WINDOW: %w", err)
+		return breakerConfig{}, err
 	}
 	if window <= 0 {
-		return breakerConfig{}, fmt.Errorf("CERBERUS_CH_BREAKER_WINDOW: must be > 0, got %s", window)
+		return breakerConfig{}, fmt.Errorf("%s: must be > 0, got %s", envCHBreakerWindow, window)
 	}
-	openInterval, err := time.ParseDuration(envDefault("CERBERUS_CH_BREAKER_OPEN_INTERVAL", defaultCHBreakerOpenInterval.String()))
+	openInterval, err := getDuration(v, envCHBreakerOpenIntrvl)
 	if err != nil {
-		return breakerConfig{}, fmt.Errorf("CERBERUS_CH_BREAKER_OPEN_INTERVAL: %w", err)
+		return breakerConfig{}, err
 	}
 	if openInterval <= 0 {
-		return breakerConfig{}, fmt.Errorf("CERBERUS_CH_BREAKER_OPEN_INTERVAL: must be > 0, got %s", openInterval)
+		return breakerConfig{}, fmt.Errorf("%s: must be > 0, got %s", envCHBreakerOpenIntrvl, openInterval)
 	}
 	return breakerConfig{
 		Disabled:     !enabled,
@@ -408,36 +593,36 @@ const (
 	defaultAdmitTempo = 32
 )
 
-// admitFromEnv reads CERBERUS_ADMIT_* env vars into an AdmitConfig.
+// admitFromEnv reads CERBERUS_ADMIT_* knobs from the viper loader.
 // Unset values use the conservative defaults above. Setting any cap
 // to 0 disables admission control for that head specifically (a
 // finer-grained alternative to CERBERUS_ADMIT_DISABLED, which kills
 // every head). Negative caps are rejected — they almost certainly
 // mean a typo.
-func admitFromEnv() (AdmitConfig, error) {
-	disabled, err := envBool("CERBERUS_ADMIT_DISABLED", false)
+func admitFromEnv(v *viper.Viper) (AdmitConfig, error) {
+	disabled, err := getBool(v, envAdmitDisabled)
 	if err != nil {
-		return AdmitConfig{}, fmt.Errorf("CERBERUS_ADMIT_DISABLED: %w", err)
+		return AdmitConfig{}, err
 	}
-	prom, err := envInt("CERBERUS_ADMIT_PROM", defaultAdmitProm)
+	prom, err := getInt(v, envAdmitProm)
 	if err != nil {
-		return AdmitConfig{}, fmt.Errorf("CERBERUS_ADMIT_PROM: %w", err)
+		return AdmitConfig{}, err
 	}
-	loki, err := envInt("CERBERUS_ADMIT_LOKI", defaultAdmitLoki)
+	loki, err := getInt(v, envAdmitLoki)
 	if err != nil {
-		return AdmitConfig{}, fmt.Errorf("CERBERUS_ADMIT_LOKI: %w", err)
+		return AdmitConfig{}, err
 	}
-	tempo, err := envInt("CERBERUS_ADMIT_TEMPO", defaultAdmitTempo)
+	tempo, err := getInt(v, envAdmitTempo)
 	if err != nil {
-		return AdmitConfig{}, fmt.Errorf("CERBERUS_ADMIT_TEMPO: %w", err)
+		return AdmitConfig{}, err
 	}
-	for name, v := range map[string]int{
-		"CERBERUS_ADMIT_PROM":  prom,
-		"CERBERUS_ADMIT_LOKI":  loki,
-		"CERBERUS_ADMIT_TEMPO": tempo,
+	for name, val := range map[string]int{
+		envAdmitProm:  prom,
+		envAdmitLoki:  loki,
+		envAdmitTempo: tempo,
 	} {
-		if v < 0 {
-			return AdmitConfig{}, fmt.Errorf("%s: must be >= 0, got %d", name, v)
+		if val < 0 {
+			return AdmitConfig{}, fmt.Errorf("%s: must be >= 0, got %d", name, val)
 		}
 	}
 	return AdmitConfig{
@@ -503,28 +688,28 @@ func newLocalHandler(w io.Writer, cfg LogConfig) slog.Handler {
 	}
 }
 
-// otlpFromEnv parses the CERBERUS_OTLP_* env vars into an OTLPConfig.
+// otlpFromEnv parses the CERBERUS_OTLP_* knobs from the viper loader.
 // Empty endpoint is the documented "disabled" state and not an error —
 // the caller installs noop providers in that case.
-func otlpFromEnv() (OTLPConfig, error) {
-	timeout, err := time.ParseDuration(envDefault("CERBERUS_OTLP_TIMEOUT", "10s"))
+func otlpFromEnv(v *viper.Viper) (OTLPConfig, error) {
+	timeout, err := getDuration(v, envOTLPTimeout)
 	if err != nil {
-		return OTLPConfig{}, fmt.Errorf("CERBERUS_OTLP_TIMEOUT: %w", err)
+		return OTLPConfig{}, err
 	}
-	insecure, err := envBool("CERBERUS_OTLP_INSECURE", false)
+	insecure, err := getBool(v, envOTLPInsecure)
 	if err != nil {
-		return OTLPConfig{}, fmt.Errorf("CERBERUS_OTLP_INSECURE: %w", err)
+		return OTLPConfig{}, err
 	}
-	headers, err := parseHeaders(os.Getenv("CERBERUS_OTLP_HEADERS"))
+	headers, err := parseHeaders(v.GetString(envOTLPHeaders))
 	if err != nil {
-		return OTLPConfig{}, fmt.Errorf("CERBERUS_OTLP_HEADERS: %w", err)
+		return OTLPConfig{}, fmt.Errorf("%s: %w", envOTLPHeaders, err)
 	}
-	exportInterval, err := time.ParseDuration(envDefault("CERBERUS_OTLP_EXPORT_INTERVAL", "10s"))
+	exportInterval, err := getDuration(v, envOTLPExportInterval)
 	if err != nil {
-		return OTLPConfig{}, fmt.Errorf("CERBERUS_OTLP_EXPORT_INTERVAL: %w", err)
+		return OTLPConfig{}, err
 	}
 	return OTLPConfig{
-		Endpoint:       strings.TrimSpace(os.Getenv("CERBERUS_OTLP_ENDPOINT")),
+		Endpoint:       strings.TrimSpace(v.GetString(envOTLPEndpoint)),
 		Insecure:       insecure,
 		Headers:        headers,
 		Timeout:        timeout,
@@ -552,79 +737,95 @@ func parseHeaders(raw string) (map[string]string, error) {
 			return nil, fmt.Errorf("entry %q: missing '='", part)
 		}
 		k := strings.TrimSpace(part[:eq])
-		v := strings.TrimSpace(part[eq+1:])
+		val := strings.TrimSpace(part[eq+1:])
 		if k == "" {
 			return nil, fmt.Errorf("entry %q: empty key", part)
 		}
-		out[k] = v
+		out[k] = val
 	}
 	return out, nil
 }
 
-func envDefault(key, def string) string {
-	if v := os.Getenv(key); v != "" {
-		return v
-	}
-	return def
+// getString returns the resolved string value for key (env > file >
+// default), trimmed of surrounding whitespace so a pasted newline /
+// space is treated the same as the historical os.Getenv-based parser.
+func getString(v *viper.Viper, key string) string {
+	return strings.TrimSpace(v.GetString(key))
 }
 
-// envInt parses an integer env var. An unset or empty value returns
-// def. Anything that fails strconv.Atoi is rejected with an error so
-// misconfiguration fails fast at startup.
-func envInt(key string, def int) (int, error) {
-	v := strings.TrimSpace(os.Getenv(key))
-	if v == "" {
-		return def, nil
+// getInt resolves key and parses it as a base-10 int, preserving the
+// historical fail-fast contract: a non-integer value is rejected with
+// an error that names the offending env var. An empty resolved value
+// falls back to the parsed default (viper SetDefault guarantees a
+// non-empty default exists for every int key).
+func getInt(v *viper.Viper, key string) (int, error) {
+	raw := getString(v, key)
+	if raw == "" {
+		return 0, fmt.Errorf("%s: missing value", key)
 	}
-	n, err := strconv.Atoi(v)
+	n, err := strconv.Atoi(raw)
 	if err != nil {
-		return 0, fmt.Errorf("invalid integer %q: %w", v, err)
+		return 0, fmt.Errorf("%s: invalid integer %q: %w", key, raw, err)
 	}
 	return n, nil
 }
 
-// envInt64 parses a 64-bit integer env var. An unset or empty value
-// returns def. Anything that fails strconv.ParseInt is rejected with
-// an error so misconfiguration fails fast at startup.
-func envInt64(key string, def int64) (int64, error) {
-	v := strings.TrimSpace(os.Getenv(key))
-	if v == "" {
-		return def, nil
+// getInt64 resolves key and parses it as a base-10 int64 with the same
+// fail-fast, env-var-naming contract as getInt.
+func getInt64(v *viper.Viper, key string) (int64, error) {
+	raw := getString(v, key)
+	if raw == "" {
+		return 0, fmt.Errorf("%s: missing value", key)
 	}
-	n, err := strconv.ParseInt(v, 10, 64)
+	n, err := strconv.ParseInt(raw, 10, 64)
 	if err != nil {
-		return 0, fmt.Errorf("invalid integer %q: %w", v, err)
+		return 0, fmt.Errorf("%s: invalid integer %q: %w", key, raw, err)
 	}
 	return n, nil
 }
 
-// envBool parses a boolean env var. Accepts the standard strconv.ParseBool
-// vocabulary: "1"/"0", "t"/"f", "true"/"false", "TRUE"/"FALSE",
-// case-insensitive. An unset or empty value returns def. Anything else is
-// rejected with an error so misconfiguration fails fast at startup.
-func envBool(key string, def bool) (bool, error) {
-	v := strings.TrimSpace(os.Getenv(key))
-	if v == "" {
-		return def, nil
+// getBool resolves key and parses it with the standard strconv.ParseBool
+// vocabulary ("1"/"0", "t"/"f", "true"/"false", case-insensitive). A
+// value that fails to parse is rejected with an error naming the env
+// var — preserving the historical fail-fast-on-misconfiguration contract.
+func getBool(v *viper.Viper, key string) (bool, error) {
+	raw := getString(v, key)
+	if raw == "" {
+		return false, fmt.Errorf("%s: missing value", key)
 	}
-	b, err := strconv.ParseBool(v)
+	b, err := strconv.ParseBool(raw)
 	if err != nil {
-		return false, fmt.Errorf("invalid boolean %q: %w", v, err)
+		return false, fmt.Errorf("%s: invalid boolean %q: %w", key, raw, err)
 	}
 	return b, nil
 }
 
-// envLog parses CERBERUS_LOG_FORMAT + CERBERUS_LOG_LEVEL into a LogConfig.
-// Unset values default to "text" / "info"; invalid values fail fast at
-// startup so a typo never silently downgrades observability.
-func envLog() (LogConfig, error) {
-	format := strings.ToLower(strings.TrimSpace(envDefault("CERBERUS_LOG_FORMAT", "text")))
+// getDuration resolves key and parses it with time.ParseDuration,
+// rejecting a malformed value with an error naming the env var.
+func getDuration(v *viper.Viper, key string) (time.Duration, error) {
+	raw := getString(v, key)
+	if raw == "" {
+		return 0, fmt.Errorf("%s: missing value", key)
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("%s: %w", key, err)
+	}
+	return d, nil
+}
+
+// envLog parses CERBERUS_LOG_FORMAT + CERBERUS_LOG_LEVEL from the viper
+// loader into a LogConfig. Unset values default to "text" / "info";
+// invalid values fail fast at startup so a typo never silently downgrades
+// observability.
+func envLog(v *viper.Viper) (LogConfig, error) {
+	format := strings.ToLower(getString(v, envLogFormat))
 	switch format {
 	case "text", "json":
 	default:
-		return LogConfig{}, fmt.Errorf("CERBERUS_LOG_FORMAT: invalid value %q (want \"text\" or \"json\")", format)
+		return LogConfig{}, fmt.Errorf("%s: invalid value %q (want \"text\" or \"json\")", envLogFormat, format)
 	}
-	levelStr := strings.ToLower(strings.TrimSpace(envDefault("CERBERUS_LOG_LEVEL", "info")))
+	levelStr := strings.ToLower(getString(v, envLogLevel))
 	var level slog.Level
 	switch levelStr {
 	case "debug":
@@ -636,7 +837,7 @@ func envLog() (LogConfig, error) {
 	case "error":
 		level = slog.LevelError
 	default:
-		return LogConfig{}, fmt.Errorf("CERBERUS_LOG_LEVEL: invalid value %q (want \"debug\", \"info\", \"warn\", or \"error\")", levelStr)
+		return LogConfig{}, fmt.Errorf("%s: invalid value %q (want \"debug\", \"info\", \"warn\", or \"error\")", envLogLevel, levelStr)
 	}
 	return LogConfig{Format: format, Level: level}, nil
 }

--- a/internal/config/viper_test.go
+++ b/internal/config/viper_test.go
@@ -1,0 +1,204 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestFromEnv_ViperDefaults_NoEnv asserts that with no CERBERUS_* env
+// vars set the viper-backed loader resolves every var to its historical
+// default — the contract the prior hand-rolled parser guaranteed. This
+// is the "(a) defaults resolve correctly with no env set" case.
+func TestFromEnv_ViperDefaults_NoEnv(t *testing.T) {
+	// Clear every key the loader reads so a value leaking in from the
+	// ambient shell can't mask a broken default.
+	clearAllEnv(t)
+
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+
+	if cfg.HTTPAddr != ":8080" {
+		t.Errorf("HTTPAddr = %q; want :8080", cfg.HTTPAddr)
+	}
+	if cfg.ClickHouse.Addr != "localhost:9000" {
+		t.Errorf("CH.Addr = %q; want localhost:9000", cfg.ClickHouse.Addr)
+	}
+	if cfg.ClickHouse.Database != "otel" {
+		t.Errorf("CH.Database = %q; want otel", cfg.ClickHouse.Database)
+	}
+	if cfg.ClickHouse.Username != "default" {
+		t.Errorf("CH.Username = %q; want default", cfg.ClickHouse.Username)
+	}
+	if cfg.ClickHouse.Password != "" {
+		t.Errorf("CH.Password = %q; want empty", cfg.ClickHouse.Password)
+	}
+	if cfg.ClickHouse.DialTimeout != 5*time.Second {
+		t.Errorf("DialTimeout = %v; want 5s", cfg.ClickHouse.DialTimeout)
+	}
+	if cfg.ClickHouse.MaxOpenConns != 10 {
+		t.Errorf("MaxOpenConns = %d; want 10", cfg.ClickHouse.MaxOpenConns)
+	}
+	if cfg.ClickHouse.MaxIdleConns != 5 {
+		t.Errorf("MaxIdleConns = %d; want 5", cfg.ClickHouse.MaxIdleConns)
+	}
+	if cfg.ClickHouse.ConnMaxLifetime != time.Hour {
+		t.Errorf("ConnMaxLifetime = %v; want 1h", cfg.ClickHouse.ConnMaxLifetime)
+	}
+	if cfg.ClickHouse.MaxQuerySamples != 50_000_000 {
+		t.Errorf("MaxQuerySamples = %d; want 50000000", cfg.ClickHouse.MaxQuerySamples)
+	}
+	if cfg.ClickHouse.MaxQueryMemoryBytes != 1_073_741_824 {
+		t.Errorf("MaxQueryMemoryBytes = %d; want 1073741824", cfg.ClickHouse.MaxQueryMemoryBytes)
+	}
+	if cfg.ClickHouse.BreakerDisabled {
+		t.Errorf("BreakerDisabled = true; want false")
+	}
+	if cfg.ClickHouse.BreakerThreshold != 5 {
+		t.Errorf("BreakerThreshold = %d; want 5", cfg.ClickHouse.BreakerThreshold)
+	}
+	if cfg.ClickHouse.BreakerWindow != 10*time.Second {
+		t.Errorf("BreakerWindow = %v; want 10s", cfg.ClickHouse.BreakerWindow)
+	}
+	if cfg.ClickHouse.BreakerOpenInterval != 5*time.Second {
+		t.Errorf("BreakerOpenInterval = %v; want 5s", cfg.ClickHouse.BreakerOpenInterval)
+	}
+	if cfg.AutoCreateSchema {
+		t.Errorf("AutoCreateSchema = true; want false")
+	}
+	if cfg.ExperimentalTSGridRange {
+		t.Errorf("ExperimentalTSGridRange = true; want false")
+	}
+	if cfg.Log.Format != "text" {
+		t.Errorf("Log.Format = %q; want text", cfg.Log.Format)
+	}
+	if cfg.OTLP.Endpoint != "" {
+		t.Errorf("OTLP.Endpoint = %q; want empty", cfg.OTLP.Endpoint)
+	}
+	if cfg.OTLP.Insecure {
+		t.Errorf("OTLP.Insecure = true; want false")
+	}
+	if cfg.OTLP.Timeout != 10*time.Second {
+		t.Errorf("OTLP.Timeout = %v; want 10s", cfg.OTLP.Timeout)
+	}
+	if cfg.OTLP.ExportInterval != 10*time.Second {
+		t.Errorf("OTLP.ExportInterval = %v; want 10s", cfg.OTLP.ExportInterval)
+	}
+	if cfg.Admit.Disabled {
+		t.Errorf("Admit.Disabled = true; want false")
+	}
+	if cfg.Admit.MaxInflightProm != defaultAdmitProm {
+		t.Errorf("MaxInflightProm = %d; want %d", cfg.Admit.MaxInflightProm, defaultAdmitProm)
+	}
+	if cfg.Admit.MaxInflightLoki != defaultAdmitLoki {
+		t.Errorf("MaxInflightLoki = %d; want %d", cfg.Admit.MaxInflightLoki, defaultAdmitLoki)
+	}
+	if cfg.Admit.MaxInflightTempo != defaultAdmitTempo {
+		t.Errorf("MaxInflightTempo = %d; want %d", cfg.Admit.MaxInflightTempo, defaultAdmitTempo)
+	}
+}
+
+// TestFromEnv_ViperEnvBeatsDefault asserts a CERBERUS_<VAR> override
+// beats the built-in default for one representative var of each type
+// (string, int, int64, bool, duration). This is the "(b) a
+// CERBERUS_<VAR> override beats the default" case.
+func TestFromEnv_ViperEnvBeatsDefault(t *testing.T) {
+	clearAllEnv(t)
+	t.Setenv(envHTTPAddr, "127.0.0.1:7777") // string
+	t.Setenv(envCHMaxOpenConns, "99")       // int
+	t.Setenv(envQueryMaxSamples, "123")     // int64
+	t.Setenv(envAutoCreateSchema, "true")   // bool
+	t.Setenv(envCHDialTimeout, "12s")       // duration
+
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if cfg.HTTPAddr != "127.0.0.1:7777" {
+		t.Errorf("HTTPAddr = %q; want 127.0.0.1:7777 (env beats default)", cfg.HTTPAddr)
+	}
+	if cfg.ClickHouse.MaxOpenConns != 99 {
+		t.Errorf("MaxOpenConns = %d; want 99 (env beats default)", cfg.ClickHouse.MaxOpenConns)
+	}
+	if cfg.ClickHouse.MaxQuerySamples != 123 {
+		t.Errorf("MaxQuerySamples = %d; want 123 (env beats default)", cfg.ClickHouse.MaxQuerySamples)
+	}
+	if !cfg.AutoCreateSchema {
+		t.Errorf("AutoCreateSchema = false; want true (env beats default)")
+	}
+	if cfg.ClickHouse.DialTimeout != 12*time.Second {
+		t.Errorf("DialTimeout = %v; want 12s (env beats default)", cfg.ClickHouse.DialTimeout)
+	}
+}
+
+// TestFromEnv_ViperEnvBeatsConfigFile asserts the precedence ordering
+// that makes config-file support safe: an environment variable always
+// wins over a value supplied by cerberus.yaml, while the file is still
+// honoured when the env var is absent. This is the "(c) env beats
+// config-file" case. The test runs from a temp working directory holding
+// a cerberus.yaml so the loader's AddConfigPath(".") finds it.
+func TestFromEnv_ViperEnvBeatsConfigFile(t *testing.T) {
+	clearAllEnv(t)
+	dir := t.TempDir()
+	yaml := "" +
+		"CERBERUS_HTTP_ADDR: \"fromfile:1111\"\n" +
+		"CERBERUS_CH_DATABASE: \"file_db\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "cerberus.yaml"), []byte(yaml), 0o600); err != nil {
+		t.Fatalf("write cerberus.yaml: %v", err)
+	}
+	chdir(t, dir)
+
+	// (1) env unset → the file value is used.
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv (file only): %v", err)
+	}
+	if cfg.HTTPAddr != "fromfile:1111" {
+		t.Errorf("HTTPAddr = %q; want fromfile:1111 (config file honoured when env unset)", cfg.HTTPAddr)
+	}
+	if cfg.ClickHouse.Database != "file_db" {
+		t.Errorf("CH.Database = %q; want file_db (config file honoured)", cfg.ClickHouse.Database)
+	}
+
+	// (2) env set → env wins over the file.
+	t.Setenv(envHTTPAddr, "fromenv:2222")
+	cfg, err = FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv (env over file): %v", err)
+	}
+	if cfg.HTTPAddr != "fromenv:2222" {
+		t.Errorf("HTTPAddr = %q; want fromenv:2222 (env beats config file)", cfg.HTTPAddr)
+	}
+	// The non-overridden file value still comes through.
+	if cfg.ClickHouse.Database != "file_db" {
+		t.Errorf("CH.Database = %q; want file_db (untouched file value)", cfg.ClickHouse.Database)
+	}
+}
+
+// clearAllEnv unsets every CERBERUS_* var the loader reads so a test
+// observes pristine defaults regardless of the ambient environment.
+func clearAllEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range allEnvKeys {
+		t.Setenv(key, "")
+		os.Unsetenv(key)
+	}
+}
+
+// chdir changes the working directory to dir for the duration of the
+// test, restoring the original on cleanup. Used by the config-file test
+// so the loader's relative AddConfigPath(".") resolves the temp yaml.
+func chdir(t *testing.T, dir string) {
+	t.Helper()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir %s: %v", dir, err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+}


### PR DESCRIPTION
## What

Swaps `internal/config`'s configuration backend from hand-rolled environment parsing (`envBool` / `envInt` / `envInt64` / `envDefault` / `envDuration` helpers) to a per-call **`github.com/spf13/viper`** loader. This is a **mechanism swap, not a config redesign** — the `CERBERUS_*` environment-variable contract (names, Go types, defaults, fail-fast validation) is byte-identical to before.

## Mechanism

- Each call to `FromEnv()` builds a fresh `viper.New()` instance (never the package-global singleton, so the loader stays testable / embeddable).
- Every `CERBERUS_*` var is bound to its **identically-named** env var via `BindEnv(key, key)`. (Per-key `BindEnv` rather than `SetEnvPrefix("CERBERUS") + AutomaticEnv()`: our viper keys are already the full `CERBERUS_<NAME>` strings, and `AutomaticEnv` would re-apply the prefix and look up `CERBERUS_CERBERUS_<NAME>`, breaking the contract — verified empirically.)
- `SetDefault(...)` seeds every var with the exact historical default.
- Typed getters (`getString` / `getInt` / `getInt64` / `getBool` / `getDuration`) preserve the fail-fast validation: an invalid value is rejected with an error that **names the offending env var** (the existing breaker / pool / max-memory / max-samples tests assert this).

The public surface is **unchanged**: `Config` / `AdmitConfig` / `LogConfig` / `OTLPConfig` structs, `FromEnv()`, `NewLogger`, `NewTelemetryLogger`, `parseHeaders` keep their shapes and types, so `cmd/cerberus`, `chclient`, `engine` compile without churn.

## Preserved CERBERUS_* contract (28 vars, names + defaults byte-identical)

| Env var | Type | Default |
| --- | --- | --- |
| `CERBERUS_HTTP_ADDR` | string | `:8080` |
| `CERBERUS_CH_ADDR` | string | `localhost:9000` |
| `CERBERUS_CH_DATABASE` | string | `otel` |
| `CERBERUS_CH_USERNAME` | string | `default` |
| `CERBERUS_CH_PASSWORD` | string | `` (empty) |
| `CERBERUS_CH_DIAL_TIMEOUT` | duration | `5s` |
| `CERBERUS_CH_MAX_OPEN_CONNS` | int | `10` |
| `CERBERUS_CH_MAX_IDLE_CONNS` | int | `5` |
| `CERBERUS_CH_CONN_MAX_LIFETIME` | duration | `1h` |
| `CERBERUS_QUERY_MAX_SAMPLES` | int64 | `50000000` (0 disables) |
| `CERBERUS_CH_QUERY_MAX_MEMORY` | int64 | `1073741824` (1 GiB; 0 = don't set) |
| `CERBERUS_CH_BREAKER_ENABLED` | bool | `true` |
| `CERBERUS_CH_BREAKER_THRESHOLD` | int | `5` |
| `CERBERUS_CH_BREAKER_WINDOW` | duration | `10s` |
| `CERBERUS_CH_BREAKER_OPEN_INTERVAL` | duration | `5s` |
| `CERBERUS_AUTO_CREATE_SCHEMA` | bool | `false` |
| `CERBERUS_EXPERIMENTAL_TS_GRID_RANGE` | bool | `false` |
| `CERBERUS_LOG_FORMAT` | string | `text` |
| `CERBERUS_LOG_LEVEL` | string | `info` |
| `CERBERUS_OTLP_ENDPOINT` | string | `` (empty → exporters disabled) |
| `CERBERUS_OTLP_INSECURE` | bool | `false` |
| `CERBERUS_OTLP_HEADERS` | string | `` (`k=v,k2=v2`) |
| `CERBERUS_OTLP_TIMEOUT` | duration | `10s` |
| `CERBERUS_OTLP_EXPORT_INTERVAL` | duration | `10s` |
| `CERBERUS_ADMIT_DISABLED` | bool | `false` |
| `CERBERUS_ADMIT_PROM` | int | `64` |
| `CERBERUS_ADMIT_LOKI` | int | `64` |
| `CERBERUS_ADMIT_TEMPO` | int | `32` |

The `CERBERUS_SCHEMA_*` table-override vars remain owned by `internal/schema` (its `DefaultOTel*FromEnv()` factories), unchanged — `FromEnv()` still delegates to them.

## Config-file support — ADDED (low-risk, env still wins)

Viper's main value-add over the old parser is config files, so it's enabled: the loader looks for **`cerberus.yaml`** in `.` and `/etc/cerberus`. Viper's native precedence is **env var > config file > default**, so a `CERBERUS_*` env var always beats a file value. A missing *or* malformed `cerberus.yaml` is tolerated and never fatal — the env contract stays the source of truth.

New precedence: **environment variable › `cerberus.yaml` › built-in default.**

> Doc note: `docs/configuration.md` / `docs/operations.md` are owned by a concurrent agent and untouched here; the new `cerberus.yaml` knob is a **doc follow-up**.

## Tests

- All existing `internal/config` tests pass unchanged — they were already contract-based (`FromEnv()` → assert resolved `Config` + that errors name the env var), which is exactly what survives the swap.
- New `internal/config/viper_test.go` adds: **(a)** defaults resolve with no env set; **(b)** a `CERBERUS_<VAR>` override beats the default (one var per type); **(c)** env beats a `cerberus.yaml` value while the file is honoured when env is unset.
- `go build ./...`, `go test ./internal/...` and `go test ./cmd/cerberus/...` green. `golangci-lint` clean on the package (fixed one `errorlint` finding). `gofumpt -extra` clean. `go-arch-lint` passes with **no allowance needed** (vendor import checks are off via `depOnAnyVendor: true`).

## go.mod additions

- Direct: `github.com/spf13/viper v1.21.0`
- New indirect transitives: `spf13/pflag`, `spf13/afero`, `sagikazarmark/locafero`, `sourcegraph/conc`, `pelletier/go-toml/v2`, `subosito/gotenv` (`fsnotify/fsnotify` + `go-viper/mapstructure/v2` were already present). None collide with the existing `hashicorp/memberlist → grafana/memberlist` replace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
