### PR TITLE
feat(chclient): make ch circuit breaker observable + fix peek interval

### DIFF
--- a/internal/chclient/breaker.go
+++ b/internal/chclient/breaker.go
@@ -137,6 +137,16 @@ type breaker struct {
 	threshold    int
 	window       time.Duration
 	openInterval time.Duration
+
+	// metrics carries the OTel state gauge + trips counter the breaker
+	// fires on every transition. A nil pointer is the no-telemetry
+	// sentinel — the zero-value breaker (and any breaker built without a
+	// MeterProvider) records nothing, so the un-instrumented path pays
+	// zero cost. client.New always wires a non-nil set off the global
+	// MeterProvider. Recording happens inside the b.mu critical section
+	// (the transition site) so the gauge level can never lag or reorder
+	// against the state field it mirrors.
+	metrics *breakerMetrics
 }
 
 // resolveThreshold returns the configured consecutive-failure threshold,
@@ -208,6 +218,9 @@ func (b *breaker) allow() bool {
 		}
 		b.state = stateHalfOpen
 		b.probeInFlight = true
+		b.metrics.recordState(breakerGaugeHalfOpen, "half-open")
+		breakerLogger().Warn("ch circuit breaker entering half-open: admitting one recovery probe",
+			"from", "open", "to", "half-open")
 		return true
 	case stateHalfOpen:
 		// Another goroutine already grabbed the probe slot. Wait
@@ -255,7 +268,7 @@ func (b *breaker) peek() string {
 	case stateOpen:
 		// The backoff has elapsed but no probe is reserved yet — report
 		// half-open so the solver still defers to route-A probing.
-		if b.nowOrTime().Sub(b.openedAt) >= breakerOpenInterval {
+		if b.nowOrTime().Sub(b.openedAt) >= b.resolveOpenInterval() {
 			return "half-open"
 		}
 		return "open"
@@ -385,6 +398,9 @@ func (b *breaker) record(ctx context.Context, err error) {
 			b.state = stateClosed
 			b.failures = 0
 			b.failureWindowStart = time.Time{}
+			b.metrics.recordState(breakerGaugeClosed, "closed")
+			breakerLogger().Warn("ch circuit breaker recovered: probe succeeded, circuit closed",
+				"from", "half-open", "to", "closed")
 			return
 		}
 		// Probe failed: stay OPEN and reset the timer so we try
@@ -396,6 +412,9 @@ func (b *breaker) record(ctx context.Context, err error) {
 		// the probe outcome matters.
 		b.failures = 0
 		b.failureWindowStart = time.Time{}
+		b.metrics.recordState(breakerGaugeOpen, "open")
+		breakerLogger().Warn("ch circuit breaker probe failed: circuit re-opened, backoff restarted",
+			"from", "half-open", "to", "open")
 		return
 
 	case stateClosed:
@@ -425,6 +444,12 @@ func (b *breaker) record(ctx context.Context, err error) {
 			b.openedAt = now
 			b.failures = 0
 			b.failureWindowStart = time.Time{}
+			b.metrics.recordState(breakerGaugeOpen, "open")
+			b.metrics.recordTrip()
+			breakerLogger().Warn("ch circuit breaker tripped OPEN: fast-failing all queries (503) until recovery",
+				"from", "closed", "to", "open",
+				"threshold", b.resolveThreshold(),
+				"window", b.resolveWindow().String())
 		}
 		return
 

--- a/internal/chclient/breaker_metrics.go
+++ b/internal/chclient/breaker_metrics.go
@@ -1,0 +1,137 @@
+package chclient
+
+import (
+	"context"
+	"log/slog"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// breakerMeterName is the instrumentation-scope identifier stamped on the
+// circuit-breaker telemetry. Distinct from the execute-span tracer scope so
+// dashboards can pivot on the breaker-specific scope when drilling into
+// trip events.
+const breakerMeterName = "github.com/tsouza/cerberus/internal/chclient"
+
+// attrBreakerState labels the gauge with the lifecycle phase the gauge sample
+// corresponds to — "closed" / "open" / "half-open" — using the same stable
+// vocabulary peek() / currentState() return.
+const attrBreakerState = attribute.Key("state")
+
+// breakerState gauge values. The gauge is a single 0/1/2 level so a dashboard
+// can render the current phase as a state-timeline without needing three
+// separate boolean series; the numeric mapping matches the breakerState iota
+// order (closed=0, open=1, half-open=2) so the gauge value and the internal
+// enum never drift.
+const (
+	breakerGaugeClosed   = 0
+	breakerGaugeOpen     = 1
+	breakerGaugeHalfOpen = 2
+)
+
+// breakerMetrics holds the OTel instruments a breaker fires on every state
+// transition. A nil *breakerMetrics is the "no telemetry" sentinel: the
+// zero-value breaker (and any breaker built without a MeterProvider) carries
+// nil and the fire helpers are no-ops, so the un-instrumented hot path pays
+// nothing. The production breaker, built in client.New, always carries a
+// non-nil set wired to the global MeterProvider.
+type breakerMetrics struct {
+	// state is a 0/1/2 gauge of the current lifecycle phase
+	// (closed/open/half-open). Recorded on every transition so a
+	// dashboard state-timeline tracks the breaker live.
+	state metric.Int64Gauge
+	// trips is the cumulative count of CLOSED->OPEN trips — the
+	// highest-blast-radius event (one trip 503s all three heads and
+	// flips /readyz). Monotonic counter so `increase(...[5m])` resolves
+	// to the number of outages in the window.
+	trips metric.Int64Counter
+}
+
+// newBreakerMetrics builds the breaker instrument set off mp and
+// zero-initialises both streams so the dashboard renders a flat 0 — not
+// "No data" — on a healthy replica whose breaker never trips.
+//
+// The zero-init mirrors internal/api/admit/admit.go's rejected_total
+// pre-registration: OTel synchronous instruments export NOTHING until their
+// first record/Add, so without seeding the trips counter and the closed-state
+// gauge at construction, a replica that stays CLOSED forever exports no
+// breaker stream at all and the "ClickHouse circuit breaker" panel shows
+// "No data" instead of a reassuring flat 0 / closed. Pre-registering at
+// construction is the standard Prometheus practice for series whose label set
+// is known in advance: the stream exists from process start, so rate() /
+// the state-timeline resolve immediately.
+func newBreakerMetrics(mp metric.MeterProvider) *breakerMetrics {
+	meter := mp.Meter(breakerMeterName)
+	state, err := meter.Int64Gauge(
+		"cerberus_ch_breaker_state",
+		metric.WithDescription(
+			"ClickHouse circuit-breaker lifecycle phase: "+
+				"0=closed, 1=open, 2=half-open. One trip OPEN fast-fails "+
+				"(503) every promql/logql/traceql query and flips /readyz.",
+		),
+		metric.WithUnit("{state}"),
+	)
+	if err != nil {
+		// Instrument validation only fails on a misconfigured
+		// MeterProvider; surface loudly rather than silently dropping
+		// the breaker's only time-series.
+		panic("chclient: build breaker state gauge: " + err.Error())
+	}
+	trips, err := meter.Int64Counter(
+		"cerberus_ch_breaker_trips_total",
+		metric.WithDescription(
+			"Cumulative CLOSED->OPEN trips of the ClickHouse circuit "+
+				"breaker. Each trip fast-fails (503) every "+
+				"promql/logql/traceql query and flips /readyz to unready "+
+				"until the breaker recovers.",
+		),
+		metric.WithUnit("{trip}"),
+	)
+	if err != nil {
+		panic("chclient: build breaker trips counter: " + err.Error())
+	}
+	m := &breakerMetrics{state: state, trips: trips}
+	// Zero-init: seed the trips counter (so increase() has a baseline) and
+	// the gauge at the closed level (so the state-timeline starts CLOSED,
+	// not blank). Both records happen before any transition fires.
+	m.trips.Add(context.Background(), 0)
+	m.state.Record(context.Background(), breakerGaugeClosed, metric.WithAttributes(
+		attrBreakerState.String("closed"),
+	))
+	return m
+}
+
+// recordState fires the state gauge for the phase the breaker just entered.
+// A nil receiver is the no-telemetry no-op for the zero-value breaker.
+func (m *breakerMetrics) recordState(level int64, label string) {
+	if m == nil {
+		return
+	}
+	m.state.Record(context.Background(), level, metric.WithAttributes(
+		attrBreakerState.String(label),
+	))
+}
+
+// recordTrip increments the CLOSED->OPEN trip counter. A nil receiver is the
+// no-telemetry no-op for the zero-value breaker.
+func (m *breakerMetrics) recordTrip() {
+	if m == nil {
+		return
+	}
+	m.trips.Add(context.Background(), 1)
+}
+
+// breakerLogger is the slog handle WARN transition logs flow through. Kept as
+// a package var (defaulting to the global default logger) so tests can swap in
+// a capturing handler without a logger plumbed through every breaker.
+var breakerLogger = func() *slog.Logger { return slog.Default() }
+
+// newGlobalBreakerMetrics builds the breaker instrument set off the OTel
+// global MeterProvider. client.New calls this so the production breaker's
+// telemetry flows to the configured OTLP exporter once cmd/cerberus installs
+// the cerberus telemetry provider.
+func newGlobalBreakerMetrics() *breakerMetrics {
+	return newBreakerMetrics(otel.GetMeterProvider())
+}

--- a/internal/chclient/breaker_metrics_test.go
+++ b/internal/chclient/breaker_metrics_test.go
@@ -1,0 +1,217 @@
+package chclient
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// breakerGaugeLevels collects every cerberus_ch_breaker_state data point from
+// a manual-reader snapshot, keyed by its "state" attribute. The gauge is
+// last-value, so the map holds the most recent level recorded per label.
+func breakerGaugeLevels(t *testing.T, reader *metric.ManualReader) map[string]int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	levels := map[string]int64{}
+	var found bool
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "cerberus_ch_breaker_state" {
+				continue
+			}
+			found = true
+			g, ok := m.Data.(metricdata.Gauge[int64])
+			if !ok {
+				t.Fatalf("breaker_state data: want Gauge[int64], got %T", m.Data)
+			}
+			for _, dp := range g.DataPoints {
+				st, ok := dp.Attributes.Value("state")
+				if !ok {
+					t.Fatalf("breaker_state data point missing state attribute: %v", dp.Attributes.ToSlice())
+				}
+				levels[st.AsString()] = dp.Value
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("cerberus_ch_breaker_state not exported")
+	}
+	return levels
+}
+
+// breakerTripsTotal returns the cumulative cerberus_ch_breaker_trips_total
+// counter value from a manual-reader snapshot.
+func breakerTripsTotal(t *testing.T, reader *metric.ManualReader) int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	var found bool
+	var sum int64
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "cerberus_ch_breaker_trips_total" {
+				continue
+			}
+			found = true
+			s, ok := m.Data.(metricdata.Sum[int64])
+			if !ok {
+				t.Fatalf("breaker_trips_total data: want Sum[int64], got %T", m.Data)
+			}
+			if !s.IsMonotonic {
+				t.Fatalf("breaker_trips_total: want monotonic sum (counter), got non-monotonic")
+			}
+			for _, dp := range s.DataPoints {
+				sum += dp.Value
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("cerberus_ch_breaker_trips_total not exported")
+	}
+	return sum
+}
+
+// TestBreakerMetrics_ZeroInitAtConstruction pins the anti-"No data" invariant:
+// both breaker streams exist at value 0 / closed the moment the breaker is
+// constructed, BEFORE any transition. OTel sync instruments export nothing
+// until their first record/Add, so without the zero-init in newBreakerMetrics
+// the "ClickHouse circuit breaker" dashboard panel would render "No data" on a
+// healthy replica whose breaker never trips. Mirrors admit.go's
+// rejected_total zero-init contract.
+func TestBreakerMetrics_ZeroInitAtConstruction(t *testing.T) {
+	t.Parallel()
+	reader := metric.NewManualReader()
+	mp := metric.NewMeterProvider(metric.WithReader(reader))
+
+	// Construct the metric set; never drive a transition.
+	_ = newBreakerMetrics(mp)
+
+	if got := breakerTripsTotal(t, reader); got != 0 {
+		t.Errorf("trips_total before any trip: want 0, got %d", got)
+	}
+	levels := breakerGaugeLevels(t, reader)
+	got, ok := levels["closed"]
+	if !ok {
+		t.Fatalf("breaker_state: missing zero-init closed stream (panel would show No data)")
+	}
+	if got != breakerGaugeClosed {
+		t.Errorf("breaker_state closed: want %d at construction, got %d", breakerGaugeClosed, got)
+	}
+}
+
+// TestBreakerMetrics_TransitionsRecorded drives the breaker through the full
+// CLOSED -> OPEN -> HALF-OPEN -> CLOSED lifecycle and asserts the gauge tracks
+// each phase and the trips counter increments on the CLOSED->OPEN edge.
+func TestBreakerMetrics_TransitionsRecorded(t *testing.T) {
+	t.Parallel()
+	reader := metric.NewManualReader()
+	mp := metric.NewMeterProvider(metric.WithReader(reader))
+
+	base := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+	now := base
+	b := &breaker{
+		threshold:    1,
+		openInterval: time.Second,
+		now:          func() time.Time { return now },
+		metrics:      newBreakerMetrics(mp),
+	}
+	failErr := errors.New("simulated CH outage")
+
+	// CLOSED -> OPEN (threshold 1).
+	_ = b.allow()
+	b.record(context.Background(), failErr)
+	if got := b.currentState(); got != "open" {
+		t.Fatalf("after trip: state = %q, want open", got)
+	}
+	if got := breakerTripsTotal(t, reader); got != 1 {
+		t.Fatalf("trips_total after one trip: want 1, got %d", got)
+	}
+	if lv := breakerGaugeLevels(t, reader); lv["open"] != breakerGaugeOpen {
+		t.Fatalf("gauge open level after trip: want %d, got %d", breakerGaugeOpen, lv["open"])
+	}
+
+	// OPEN -> HALF-OPEN (probe admitted past the 1s backoff).
+	now = base.Add(1500 * time.Millisecond)
+	if !b.allow() {
+		t.Fatal("allow() did not admit the half-open probe")
+	}
+	if lv := breakerGaugeLevels(t, reader); lv["half-open"] != breakerGaugeHalfOpen {
+		t.Fatalf("gauge half-open level: want %d, got %d", breakerGaugeHalfOpen, lv["half-open"])
+	}
+
+	// HALF-OPEN -> CLOSED (probe succeeds).
+	b.record(context.Background(), nil)
+	if got := b.currentState(); got != "closed" {
+		t.Fatalf("after probe success: state = %q, want closed", got)
+	}
+	if lv := breakerGaugeLevels(t, reader); lv["closed"] != breakerGaugeClosed {
+		t.Fatalf("gauge closed level after recovery: want %d, got %d", breakerGaugeClosed, lv["closed"])
+	}
+	// The trip counter is monotonic: recovery does NOT decrement it.
+	if got := breakerTripsTotal(t, reader); got != 1 {
+		t.Fatalf("trips_total after recovery: want 1 (monotonic), got %d", got)
+	}
+
+	// A second trip increments the counter again (not a stuck gauge).
+	now = base.Add(2 * time.Second)
+	_ = b.allow()
+	b.record(context.Background(), failErr)
+	if got := breakerTripsTotal(t, reader); got != 2 {
+		t.Fatalf("trips_total after second trip: want 2, got %d", got)
+	}
+}
+
+// TestBreakerMetrics_NilIsNoOp pins that the zero-value breaker (nil metrics)
+// drives the full lifecycle without panicking — the un-instrumented hot path
+// must stay allocation-free and crash-free.
+func TestBreakerMetrics_NilIsNoOp(t *testing.T) {
+	t.Parallel()
+	base := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+	now := base
+	b := &breaker{threshold: 1, openInterval: time.Second, now: func() time.Time { return now }}
+	failErr := errors.New("ch down")
+
+	_ = b.allow()
+	b.record(context.Background(), failErr) // CLOSED -> OPEN, nil metrics
+	now = base.Add(2 * time.Second)
+	_ = b.allow()                       // OPEN -> HALF-OPEN
+	b.record(context.Background(), nil) // HALF-OPEN -> CLOSED
+	if got := b.currentState(); got != "closed" {
+		t.Fatalf("nil-metrics breaker state = %q, want closed", got)
+	}
+}
+
+// TestBreakerMetrics_WarnLogOnTrip pins that the CLOSED->OPEN edge emits a
+// WARN slog line — the trip is the highest-blast-radius event (503s all three
+// heads, flips /readyz) and must leave a transition log, not just a metric.
+func TestBreakerMetrics_WarnLogOnTrip(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	orig := breakerLogger
+	breakerLogger = func() *slog.Logger { return logger }
+	t.Cleanup(func() { breakerLogger = orig })
+
+	b := &breaker{threshold: 1}
+	_ = b.allow()
+	b.record(context.Background(), errors.New("ch down"))
+
+	out := buf.String()
+	if !strings.Contains(out, "tripped OPEN") {
+		t.Fatalf("trip did not emit a WARN transition log; got: %q", out)
+	}
+	if !strings.Contains(out, "level=WARN") {
+		t.Fatalf("trip transition log not at WARN level; got: %q", out)
+	}
+}

--- a/internal/chclient/budget_peek_test.go
+++ b/internal/chclient/budget_peek_test.go
@@ -94,6 +94,37 @@ func TestPeekBreakerState_ReadOnly(t *testing.T) {
 	}
 }
 
+// TestPeekBreakerState_CustomOpenInterval — peek() must honor the per-breaker
+// openInterval (via resolveOpenInterval), not the hardcoded GA 5s default.
+// Mirrors the allow()-side TestBreaker_CustomOpenInterval. The pre-existing
+// peek tests use a zero openInterval, so the literal-vs-resolver bug was
+// invisible there: with a 1s custom interval, a peek at +1.5s must already
+// report half-open even though the GA 5s has NOT elapsed.
+func TestPeekBreakerState_CustomOpenInterval(t *testing.T) {
+	t.Parallel()
+	base := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+	now := base
+	b := &breaker{threshold: 1, openInterval: time.Second, now: func() time.Time { return now }}
+
+	_ = b.allow()
+	b.record(context.Background(), errors.New("simulated CH outage")) // trips OPEN
+	if got := b.peek(); got != "open" {
+		t.Fatalf("freshly tripped breaker peek = %q, want open", got)
+	}
+
+	// At +1.5s the custom 1s interval has elapsed but the GA 5s has not.
+	// With the bug (hardcoded breakerOpenInterval) peek would still report
+	// "open"; with resolveOpenInterval it correctly reports "half-open".
+	now = base.Add(1500 * time.Millisecond)
+	if got := b.peek(); got != "half-open" {
+		t.Fatalf("peek after custom 1s open-interval = %q, want half-open", got)
+	}
+	// peek is read-only: the probe slot is still free for allow() to take.
+	if !b.allow() {
+		t.Fatalf("peek consumed the half-open probe — allow() denied")
+	}
+}
+
 // TestPeekBreakerState_ClientSurface — the *Client wrapper exposes the
 // stable string vocabulary.
 func TestPeekBreakerState_ClientSurface(t *testing.T) {

--- a/internal/chclient/client.go
+++ b/internal/chclient/client.go
@@ -251,6 +251,11 @@ func New(cfg Config) (*Client, error) {
 			threshold:    cfg.BreakerThreshold,
 			window:       cfg.BreakerWindow,
 			openInterval: cfg.BreakerOpenInterval,
+			// Wire the transition telemetry (state gauge + trips counter)
+			// off the global MeterProvider. Zero-initialised at
+			// construction so a healthy replica's breaker exports a flat
+			// closed/0 series instead of "No data" — see breaker_metrics.go.
+			metrics: newGlobalBreakerMetrics(),
 		},
 		maxSamples: cfg.MaxQuerySamples,
 		maxMemory:  cfg.MaxQueryMemoryBytes,


### PR DESCRIPTION
## Why

The ClickHouse circuit breaker is cerberus's **highest-blast-radius failure mode**: one trip fast-fails (503) every PromQL/LogQL/TraceQL query *and* flips `/readyz` to unready until it recovers. Yet it emitted **no time-series and no transition log** — an operator had no way to tell the breaker had tripped, or why a deployment went unready and started 503ing all three heads.

This PR makes the breaker observable and fixes a `peek()` fidelity bug found alongside it.

## Observability (zero-init like admit)

Two OTel instruments on the existing `chclient` meter scope:

- `cerberus_ch_breaker_state` — gauge, `0=closed / 1=open / 2=half-open` (renders as a state-timeline).
- `cerberus_ch_breaker_trips_total` — counter, cumulative `CLOSED→OPEN` trips (`increase(...[5m])` = outages in the window).

Both are **zero-initialised at construction**, mirroring `internal/api/admit/admit.go`'s `cerberus_admit_rejected_total` pre-registration (same anti-"No data" rationale, copied with its comment): OTel synchronous instruments export nothing until their first record, so a healthy replica whose breaker never trips would otherwise render **"No data"** instead of a reassuring flat `closed / 0`.

The gauge fires on **every** transition (`CLOSED→OPEN`, `OPEN→HALF-OPEN`, `HALF-OPEN→CLOSED`, `HALF-OPEN→OPEN`) and the trips counter on the `CLOSED→OPEN` edge — all **inside the `b.mu` critical section** at each transition site, so the gauge level can never lag or reorder against the `state` field it mirrors. The previously-scaffolded `currentState()` accessor remains; the transitions record directly. **WARN slog** lines are added on the edge changes (trip / enter-half-open / recover / probe-fail-reopen) carrying the relevant counts. A nil `*breakerMetrics` is the no-telemetry no-op for the zero-value breaker, so the un-instrumented path pays nothing.

## `peek()` open-interval fix

`peek()` used the hardcoded `breakerOpenInterval` (5s) while the authoritative `allow()` honors the per-breaker `openInterval` via `resolveOpenInterval()` (wired from `CERBERUS_CH_BREAKER_OPEN_INTERVAL` / `cfg.BreakerOpenInterval`). A breaker with a custom interval reported `"open"` past its own backoff window — the sharded solver's read-only pre-flight saw stale state. One-line swap of the literal for `b.resolveOpenInterval()`. The pre-existing `peek` tests used a zero `openInterval`, so the bug was invisible; a new custom-interval test mirrors the allow()-side `TestBreaker_CustomOpenInterval`.

## Tests

- `TestBreakerMetrics_ZeroInitAtConstruction` — both streams exist at `closed`/`0` before any transition (anti-No-data invariant).
- `TestBreakerMetrics_TransitionsRecorded` — drives `CLOSED→OPEN→HALF-OPEN→CLOSED`, asserts the gauge tracks each phase and the (monotonic) counter increments per trip.
- `TestBreakerMetrics_NilIsNoOp` — zero-value breaker drives the full lifecycle without panicking.
- `TestBreakerMetrics_WarnLogOnTrip` — the trip edge emits a WARN transition log.
- `TestPeekBreakerState_CustomOpenInterval` — the peek fix.

`go build ./...` + `go test ./internal/chclient/...` green; `gofumpt -extra` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)