### PR TITLE
fix(api): recover handler panics into per-head 500 envelope + balanced metrics

### DIFF
--- a/internal/api/loki/chaos_test.go
+++ b/internal/api/loki/chaos_test.go
@@ -2,6 +2,7 @@ package loki_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -31,12 +32,16 @@ type chaosQuerier struct {
 	statsRow     chclient.IndexStatsRow
 	volumeRows   []chclient.IndexVolumeRow
 	err          error
+	wrapPanic    bool
 	queryLatency time.Duration
 	calls        atomic.Int32
 }
 
 func (c *chaosQuerier) Query(ctx context.Context, _ string, _ ...any) ([]chclient.Sample, error) {
 	c.calls.Add(1)
+	if c.wrapPanic {
+		panic("chaos: simulated panic in Query")
+	}
 	if c.queryLatency > 0 {
 		select {
 		case <-time.After(c.queryLatency):
@@ -316,6 +321,49 @@ func TestLokiCH_MissingQuery_400(t *testing.T) {
 	if !strings.Contains(body, "missing query") {
 		t.Errorf("body: missing %q in %s", "missing query", body)
 	}
+}
+
+// assertLokiErrorEnvelope decodes body as a Loki error response and
+// asserts the fields Grafana reads: status = "error", errorType matches,
+// and the message is non-empty.
+func assertLokiErrorEnvelope(t *testing.T, body, wantKind string) {
+	t.Helper()
+	var env loki.Response
+	if err := json.Unmarshal([]byte(body), &env); err != nil {
+		t.Fatalf("error body not parseable JSON: %v; body=%s", err, body)
+	}
+	if env.Status != "error" {
+		t.Errorf("envelope.status: got %q, want \"error\"; body=%s", env.Status, body)
+	}
+	if env.ErrorType != wantKind {
+		t.Errorf("envelope.errorType: got %q, want %q; body=%s", env.ErrorType, wantKind, body)
+	}
+	if env.Error == "" {
+		t.Errorf("envelope.error: empty (Grafana renders this string); body=%s", body)
+	}
+}
+
+// TestLokiCH_PanicQuerier_Returns500Envelope — RC1 robustness contract
+// for the Loki head, mirroring the Prom + Tempo panic tests. A panicking
+// Querier must NOT drop the TCP connection: the shared
+// telemetry.QueryMiddleware recover path renders a clean Loki 500 error
+// envelope and counts the failed query, instead of unwinding through
+// net/http and leaving a bare conn-reset.
+func TestLokiCH_PanicQuerier_Returns500Envelope(t *testing.T) {
+	t.Parallel()
+	q := &chaosQuerier{wrapPanic: true}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + `/loki/api/v1/query?query=%7Bjob%3D%22api%22%7D`)
+	if err != nil {
+		t.Fatalf("GET: connection dropped on panic (want clean 500): %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status: got %d, want 500; body=%s", resp.StatusCode, body)
+	}
+	assertLokiErrorEnvelope(t, body, loki.ErrInternal)
 }
 
 // TestLokiCH_Pointer_Querier_AssertedInterface — compile-time sanity

--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -114,7 +114,7 @@ func (h *Handler) Mount(mux *http.ServeMux) {
 		// — rejections are accounted on cerberus.admit.rejected_total,
 		// not on cerberus.queries.*. See prom.Handler.Mount for the
 		// full layering note.
-		mux.Handle(pattern, h.Limiter.Middleware(1, telemetry.QueryMiddleware("logql", hf)))
+		mux.Handle(pattern, h.Limiter.Middleware(1, telemetry.QueryMiddleware("logql", panicEnvelope, hf)))
 	}
 	register("GET /loki/api/v1/query", h.handleQuery)
 	register("POST /loki/api/v1/query", h.handleQuery)
@@ -749,6 +749,17 @@ func (h *Handler) respondError(w http.ResponseWriter, err error) {
 // encoding identically across all three handlers.
 func writeJSON(w http.ResponseWriter, status int, body any) {
 	httperr.WriteJSON(w, status, body)
+}
+
+// panicEnvelope is the [telemetry.PanicRenderer] for the Loki head: when
+// QueryMiddleware recovers a handler panic before any response was
+// committed, it renders the canonical Loki 500 envelope so Grafana sees
+// `{status:"error", errorType:"internal"}` instead of a dropped
+// connection. The recovered value + stack are logged by the middleware
+// via the OTLP slog bridge; this only shapes the wire response.
+func panicEnvelope(w http.ResponseWriter, _ *http.Request) {
+	writeError(w, http.StatusInternalServerError, ErrInternal,
+		errors.New("internal server error"))
 }
 
 // writeError emits the Loki JSON envelope `{status, errorType, error}`.

--- a/internal/api/prom/chaos_test.go
+++ b/internal/api/prom/chaos_test.go
@@ -239,10 +239,15 @@ func TestCH_SlowResponse_RespectsClientCancel(t *testing.T) {
 	}
 }
 
-// TestCH_NoPanicOnPanicQuerier — a panicking Querier must not crash
-// the test server; the handler / runtime recovers and the connection
-// is closed.
-func TestCH_NoPanicOnPanicQuerier(t *testing.T) {
+// TestCH_PanicQuerier_Returns500Envelope — a panicking Querier must NOT
+// drop the TCP connection. The shared telemetry.QueryMiddleware recover
+// path renders a clean Prom 500 error envelope and counts the failed
+// query. This is the RC1 robustness contract: the pre-fix behaviour was
+// a bare conn-reset (the panic unwound through net/http invisibly,
+// rendering no envelope and skipping the metric), and this test
+// previously lenient-accepted EITHER a conn-reset OR a 5xx. It now pins
+// the clean-500 outcome unconditionally.
+func TestCH_PanicQuerier_Returns500Envelope(t *testing.T) {
 	t.Parallel()
 	q := &chaosQuerier{wrapPanic: true}
 	srv := newServer(q)
@@ -250,16 +255,13 @@ func TestCH_NoPanicOnPanicQuerier(t *testing.T) {
 
 	resp, err := http.Get(srv.URL + "/api/v1/query?query=up")
 	if err != nil {
-		// net/http recovers; the connection may be reset depending on
-		// timing. Either failure is acceptable: no test crash.
-		t.Logf("Get returned err on panic path: %v (acceptable)", err)
-		return
+		t.Fatalf("GET: connection dropped on panic (want clean 500): %v", err)
 	}
-	defer resp.Body.Close()
-	// If we got a response, it should be 500-class.
-	if resp.StatusCode < 500 {
-		t.Errorf("status: got %d, want 5xx", resp.StatusCode)
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status: got %d, want 500; body=%s", resp.StatusCode, body)
 	}
+	assertPromErrorEnvelope(t, body, prom.ErrInternal)
 }
 
 // TestCH_OversizeQuery_Tolerated — a very long query string should not

--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -132,7 +132,7 @@ func (h *Handler) Mount(mux *http.ServeMux) {
 		// Rejections are not counted by QueryMiddleware (the inner
 		// handler never runs); they show up on
 		// cerberus.admit.rejected_total instead.
-		handler := promHeadersMiddleware(telemetry.QueryMiddleware("promql", hf))
+		handler := promHeadersMiddleware(telemetry.QueryMiddleware("promql", panicEnvelope, hf))
 		mux.Handle(pattern, h.Limiter.Middleware(1, handler))
 	}
 	register("GET /api/v1/query", h.handleQuery)
@@ -1073,6 +1073,17 @@ func (h *Handler) respondError(w http.ResponseWriter, err error) {
 // encoding identically across all three handlers.
 func writeJSON(w http.ResponseWriter, status int, body any) {
 	httperr.WriteJSON(w, status, body)
+}
+
+// panicEnvelope is the [telemetry.PanicRenderer] for the Prom head: when
+// QueryMiddleware recovers a handler panic before any response was
+// committed, it renders the canonical Prom 500 envelope so Grafana sees
+// `{status:"error", errorType:"internal"}` instead of a dropped
+// connection. The recovered value + stack are logged by the middleware
+// via the OTLP slog bridge; this only shapes the wire response.
+func panicEnvelope(w http.ResponseWriter, _ *http.Request) {
+	writeError(w, http.StatusInternalServerError, ErrInternal,
+		errors.New("internal server error"))
 }
 
 // writeError emits the Prom JSON envelope `{status, errorType, error}`.

--- a/internal/api/tempo/chaos_test.go
+++ b/internal/api/tempo/chaos_test.go
@@ -2,6 +2,7 @@ package tempo_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -21,12 +22,16 @@ type chaosQuerier struct {
 	samples      []chclient.Sample
 	strings      []string
 	err          error
+	wrapPanic    bool
 	queryLatency time.Duration
 	calls        atomic.Int32
 }
 
 func (c *chaosQuerier) Query(ctx context.Context, _ string, _ ...any) ([]chclient.Sample, error) {
 	c.calls.Add(1)
+	if c.wrapPanic {
+		panic("chaos: simulated panic in Query")
+	}
 	if c.queryLatency > 0 {
 		select {
 		case <-time.After(c.queryLatency):
@@ -49,6 +54,46 @@ func (c *chaosQuerier) QueryStrings(_ context.Context, _ string, _ ...any) ([]st
 }
 
 var _ tempo.Querier = (*chaosQuerier)(nil)
+
+// assertTempoErrorEnvelope decodes body as Tempo's distinct error shape
+// (`{traceID, spanID, error, message}`) and asserts error=true with a
+// non-empty message — the fields Grafana's Tempo datasource reads.
+func assertTempoErrorEnvelope(t *testing.T, body string) {
+	t.Helper()
+	var env tempo.ErrorResponse
+	if err := json.Unmarshal([]byte(body), &env); err != nil {
+		t.Fatalf("error body not parseable JSON: %v; body=%s", err, body)
+	}
+	if !env.Error {
+		t.Errorf("envelope.error: got false, want true; body=%s", body)
+	}
+	if env.Message == "" {
+		t.Errorf("envelope.message: empty (Grafana renders this string); body=%s", body)
+	}
+}
+
+// TestTempoCH_PanicQuerier_Returns500Envelope — RC1 robustness contract
+// for the Tempo head, mirroring the Prom + Loki panic tests. A panicking
+// Querier must NOT drop the TCP connection: the shared
+// telemetry.QueryMiddleware recover path renders a clean Tempo 500 error
+// envelope and counts the failed query, instead of unwinding through
+// net/http and leaving a bare conn-reset.
+func TestTempoCH_PanicQuerier_Returns500Envelope(t *testing.T) {
+	t.Parallel()
+	q := &chaosQuerier{wrapPanic: true}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + `/api/search?q=%7B%7D`)
+	if err != nil {
+		t.Fatalf("GET: connection dropped on panic (want clean 500): %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status: got %d, want 500; body=%s", resp.StatusCode, body)
+	}
+	assertTempoErrorEnvelope(t, body)
+}
 
 // TestTempoCH_SearchUpstreamError_Returns502 — CH-side failure on
 // /api/search must surface as 502 with the Tempo error envelope.

--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -175,7 +175,7 @@ func (h *Handler) Mount(mux *http.ServeMux) {
 		// admit.Middleware (outer) → telemetry.QueryMiddleware (inner)
 		// — same layering as the Prom + Loki heads. Rejections land
 		// on cerberus.admit.rejected_total, not cerberus.queries.*.
-		mux.Handle(pattern, h.Limiter.Middleware(1, telemetry.QueryMiddleware("traceql", hf)))
+		mux.Handle(pattern, h.Limiter.Middleware(1, telemetry.QueryMiddleware("traceql", panicEnvelope, hf)))
 	}
 	register("GET /api/echo", h.handleEcho)
 	register("GET /api/status/version", h.handleVersion)
@@ -1943,4 +1943,16 @@ func writeError(w http.ResponseWriter, status int, traceID, spanID string, err e
 		TraceID: traceID, SpanID: spanID, Error: true,
 		Message: err.Error(),
 	})
+}
+
+// panicEnvelope is the [telemetry.PanicRenderer] for the Tempo head:
+// when QueryMiddleware recovers a handler panic before any response was
+// committed, it renders Tempo's distinct error shape
+// (`{traceID, spanID, error, message}`) with a 500 status so Grafana's
+// Tempo datasource sees a clean error instead of a dropped connection.
+// The recovered value + stack are logged by the middleware via the OTLP
+// slog bridge; this only shapes the wire response.
+func panicEnvelope(w http.ResponseWriter, _ *http.Request) {
+	writeError(w, http.StatusInternalServerError, "", "",
+		errors.New("internal server error"))
 }

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -314,7 +314,7 @@ func TestQueryMiddleware_ResultOK(t *testing.T) {
 	// handlers wire the middleware — that ordering lets the middleware
 	// see r.Pattern after the mux resolves the route.
 	mux := http.NewServeMux()
-	mux.Handle("GET /api/v1/query", telemetry.QueryMiddleware("promql", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	mux.Handle("GET /api/v1/query", telemetry.QueryMiddleware("promql", noopPanicRenderer, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})))
 	srv := httptest.NewServer(mux)
@@ -362,7 +362,7 @@ func TestQueryMiddleware_ResultError(t *testing.T) {
 
 			mux := http.NewServeMux()
 			status := tc.status
-			mux.Handle("GET /api/v1/query", telemetry.QueryMiddleware("promql", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			mux.Handle("GET /api/v1/query", telemetry.QueryMiddleware("promql", noopPanicRenderer, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(status)
 			})))
 			srv := httptest.NewServer(mux)
@@ -384,6 +384,119 @@ func TestQueryMiddleware_ResultError(t *testing.T) {
 				t.Errorf("result: got %q want error", v.AsString())
 			}
 		})
+	}
+}
+
+// noopPanicRenderer is the [telemetry.PanicRenderer] the success/error
+// middleware tests pass when no panic is expected. It writes a minimal
+// 500 envelope so a regression that starts panicking still produces a
+// well-formed response the test can observe.
+func noopPanicRenderer(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusInternalServerError)
+	_, _ = w.Write([]byte(`{"status":"error"}`))
+}
+
+// TestQueryMiddleware_PanicRecovered_RendersEnvelopeAndCountsError pins
+// the RC1 robustness contract at the shared-middleware layer: a handler
+// panic must NOT drop the connection. The middleware must (a) recover,
+// (b) invoke the head's PanicRenderer so a 500 body reaches the client,
+// and (c) still record the failed query on cerberus_queries_total with
+// result=error — the metric-defer fix. Before the fix, t.Done() ran
+// inline after ServeHTTP and a panic bypassed it entirely.
+func TestQueryMiddleware_PanicRecovered_RendersEnvelopeAndCountsError(t *testing.T) {
+	reader := installManualReader(t)
+
+	rendered := false
+	renderer := func(w http.ResponseWriter, _ *http.Request) {
+		rendered = true
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"status":"error","errorType":"internal"}`))
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("GET /api/v1/query", telemetry.QueryMiddleware("promql", renderer,
+		http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			panic("boom: simulated handler panic")
+		})))
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/query?query=up")
+	if err != nil {
+		t.Fatalf("GET: %v (connection must not drop on panic)", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("status: got %d want 500", resp.StatusCode)
+	}
+	if !rendered {
+		t.Error("PanicRenderer was not invoked on the recovered panic")
+	}
+
+	sm := collect(t, reader)
+	total := findMetric(t, sm, "cerberus_queries_total")
+	sum := total.Data.(metricdata.Sum[int64])
+	if len(sum.DataPoints) != 1 {
+		t.Fatalf("queries.total DPs: got %d want 1 (panic must still count)", len(sum.DataPoints))
+	}
+	if v, _ := sum.DataPoints[0].Attributes.Value("result"); v.AsString() != telemetry.ResultError {
+		t.Errorf("result: got %q want error", v.AsString())
+	}
+	// The duration histogram must also record the panicked query so its
+	// count stays balanced with the total counter.
+	dur := findMetric(t, sm, "cerberus_queries_duration_seconds")
+	dh := dur.Data.(metricdata.Histogram[float64])
+	if len(dh.DataPoints) != 1 || dh.DataPoints[0].Count != 1 {
+		t.Errorf("query_duration: got %+v want one DP with count=1", dh.DataPoints)
+	}
+}
+
+// TestQueryMiddleware_PanicAfterCommit_NoDoubleWrite verifies that when a
+// handler panics AFTER it already committed a status line / body bytes,
+// the middleware does NOT call the renderer (the wire is past the point
+// of re-rendering) but still records the query so the metric stays
+// balanced.
+func TestQueryMiddleware_PanicAfterCommit_NoDoubleWrite(t *testing.T) {
+	reader := installManualReader(t)
+
+	rendererCalled := false
+	renderer := func(w http.ResponseWriter, _ *http.Request) {
+		rendererCalled = true
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("GET /api/v1/query", telemetry.QueryMiddleware("promql", renderer,
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("partial body"))
+			panic("boom: panic after partial write")
+		})))
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/query?query=up")
+	if err == nil {
+		defer resp.Body.Close()
+		// A 200 status line already went out; the body is truncated but
+		// the status can't change. The renderer must not have fired.
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("status: got %d want 200 (already committed)", resp.StatusCode)
+		}
+	}
+	if rendererCalled {
+		t.Error("PanicRenderer must NOT fire once the response is committed")
+	}
+
+	sm := collect(t, reader)
+	total := findMetric(t, sm, "cerberus_queries_total")
+	sum := total.Data.(metricdata.Sum[int64])
+	if len(sum.DataPoints) != 1 {
+		t.Fatalf("queries.total DPs: got %d want 1", len(sum.DataPoints))
+	}
+	if v, _ := sum.DataPoints[0].Attributes.Value("result"); v.AsString() != telemetry.ResultError {
+		t.Errorf("result: got %q want error (committed-200 then panic is still a failed query)", v.AsString())
 	}
 }
 

--- a/internal/telemetry/middleware.go
+++ b/internal/telemetry/middleware.go
@@ -3,8 +3,10 @@ package telemetry
 import (
 	"bufio"
 	"errors"
+	"log/slog"
 	"net"
 	"net/http"
+	"runtime/debug"
 	"strings"
 )
 
@@ -21,13 +23,32 @@ import (
 type statusRecorder struct {
 	http.ResponseWriter
 	status int
+	// wrote is set the moment any byte (status line or body) has gone to
+	// the client. The panic-recovery path reads it to decide whether it
+	// can still synthesize a clean 500 error envelope: if the handler
+	// already committed a status line (or streamed body bytes) before
+	// panicking, the wire is past the point of no return and the
+	// recovery can only log + count, not re-render.
+	wrote bool
 }
 
 func (r *statusRecorder) WriteHeader(code int) {
 	if r.status == 0 {
 		r.status = code
 	}
+	r.wrote = true
 	r.ResponseWriter.WriteHeader(code)
+}
+
+// Write marks the response as committed (an implicit 200 if the handler
+// streamed body bytes without an explicit WriteHeader) so the recovery
+// path knows the envelope can no longer be rendered.
+func (r *statusRecorder) Write(b []byte) (int, error) {
+	if r.status == 0 {
+		r.status = http.StatusOK
+	}
+	r.wrote = true
+	return r.ResponseWriter.Write(b)
 }
 
 // Hijack delegates to the underlying ResponseWriter when it implements
@@ -42,6 +63,7 @@ func (r *statusRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	if r.status == 0 {
 		r.status = http.StatusSwitchingProtocols
 	}
+	r.wrote = true
 	return h.Hijack()
 }
 
@@ -52,15 +74,25 @@ func (r *statusRecorder) Flush() {
 	}
 }
 
+// PanicRenderer renders a head's own 500 error envelope (the Prom /
+// Loki / Tempo JSON shape) when a handler in the request path panics
+// before it had a chance to write any response. It is invoked by
+// [QueryMiddleware] only when nothing has been committed to the wire
+// yet, so it owns the full response: it must call WriteHeader(500) and
+// write the body. Each head passes the closure that knows its own
+// envelope shape — telemetry stays decoupled from per-head wire formats.
+type PanicRenderer func(w http.ResponseWriter, r *http.Request)
+
 // QueryMiddleware wraps next so every request increments
-// cerberus.queries.total and records cerberus.queries.duration.seconds
-// labelled with the QL identifier, the matched route, and the outcome.
+// cerberus.queries.total and records cerberus.queries.duration.seconds,
+// and so a panic in the request path produces a clean per-head 500
+// error envelope instead of a dropped TCP connection.
 //
 // ql is the constant for the API head — "promql" for prom.Handler,
 // "logql" for loki.Handler, "traceql" for tempo.Handler. The route
 // label is r.Pattern (Go 1.22+ exposes the matched http.ServeMux
 // pattern); when it's empty (404 / unmatched) we fall back to the
-// request URL's path prefix so the cardinality stays bounded.
+// request method so the cardinality stays bounded.
 //
 // Outcome bucketing: any status >= 400 maps to ResultError, anything
 // else (including the implicit-200 path where the handler never calls
@@ -70,9 +102,25 @@ func (r *statusRecorder) Flush() {
 // IS a failed query from the caller's point of view, and the
 // "Error rate by language" dashboard panel reads this bucket to show
 // users how many of their queries failed. The HTTP-layer SLO (which
-// would legitimately treat 4xx as "gateway behaved correctly")
-// rides the separate `http.server.*` instrument set.
-func QueryMiddleware(ql string, next http.Handler) http.Handler {
+// would legitimately treat 4xx as "gateway behaved correctly") rides
+// the separate `http.server.*` instrument set.
+//
+// renderPanic is the head's own 500-envelope writer (see [PanicRenderer]).
+// When a panic unwinds through next.ServeHTTP, the deferred recovery:
+//
+//  1. logs the recovered value + stack at ERROR via slog.Default()
+//     (the OTLP slog bridge ships it to the collector's otel_logs);
+//  2. renders the head's 500 envelope via renderPanic — but only if the
+//     handler hadn't already committed a status line / body, in which
+//     case the wire is past the point of re-rendering and we only log;
+//  3. records the query on cerberus.queries.* as ResultError.
+//
+// Step 3 runs in its own deferred call that always fires — even on
+// panic or early return — so the failed query is never silently dropped
+// from cerberus_queries_total / cerberus_query_duration. Before this,
+// t.Done() ran inline after ServeHTTP and a panic skipped it entirely,
+// leaving the metrics unbalanced and the OTLP outcome unrecorded.
+func QueryMiddleware(ql string, renderPanic PanicRenderer, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		route := r.Pattern
 		if route == "" {
@@ -80,11 +128,56 @@ func QueryMiddleware(ql string, next http.Handler) http.Handler {
 		}
 		t := ObserveQuery(ql, route)
 		sr := &statusRecorder{ResponseWriter: w}
+		// panicked is set by the recover defer so the metric defer can
+		// bucket the query as an error even when the handler had already
+		// committed a 2xx status line before panicking (a truncated
+		// success is still a failed query from the caller's point of view).
+		panicked := false
+
+		// Outermost defer: classify + record the outcome on
+		// cerberus.queries.*. Deferred so it fires on the normal return,
+		// on an early return inside next, AND on a panic that the inner
+		// defer recovered (the recover re-runs the deferred chain). Any
+		// status >= 400 — including the synthesized 500 from a recovered
+		// panic — buckets as ResultError, keeping the {result} label
+		// cardinality fixed at {ok, error}. Without the defer the panic
+		// would skip t.Done() entirely and the failed query would never
+		// land on cerberus_queries_total / cerberus_query_duration.
+		defer func() {
+			result := ResultOK
+			if panicked || sr.status >= 400 {
+				result = ResultError
+			}
+			t.Done(r.Context(), result)
+		}()
+
+		// Inner defer: recover a handler panic, log it via the OTLP slog
+		// bridge, and synthesize the head's 500 envelope. Registered after
+		// the metric defer, so it runs first on unwind and the panicked
+		// flag it sets is visible to the metric classification above.
+		defer func() {
+			rec := recover()
+			if rec == nil {
+				return
+			}
+			panicked = true
+			slog.Default().Error(
+				"cerberus handler panic recovered",
+				"cerberus.ql", ql,
+				"cerberus.route", route,
+				"panic", rec,
+				"stack", string(debug.Stack()),
+			)
+			// If the handler already committed a status / body, the wire
+			// is past re-rendering; we've logged + flagged the error, so
+			// just unwind.
+			if sr.wrote {
+				return
+			}
+			sr.status = http.StatusInternalServerError
+			renderPanic(sr, r)
+		}()
+
 		next.ServeHTTP(sr, r)
-		result := ResultOK
-		if sr.status >= 400 {
-			result = ResultError
-		}
-		t.Done(r.Context(), result)
 	})
 }


### PR DESCRIPTION
## The bug (evidenced)

A panic in the request path unwound through `net/http` and dropped the TCP connection invisibly. Two failures:

1. **No error JSON.** None of the Prometheus / Loki / Tempo error envelopes were rendered — Grafana saw a bare conn-reset, not a typed error.
2. **Unbalanced self-metrics + no OTLP log.** `internal/telemetry/middleware.go` called `t.Done()` *inline* after `ServeHTTP` (not via `defer`), so a panic skipped it entirely: the failed query never recorded on `cerberus_queries_total` / `cerberus_query_duration` and bypassed the OTLP slog bridge.

The only chaos test (`internal/api/prom/chaos_test.go`) lenient-accepted EITHER a conn-reset OR a 5xx; loki/tempo had no such test at all.

## The fix

All at the shared `telemetry.QueryMiddleware` layer that already wraps all three heads:

- **Recover middleware.** A `recover()` in the request path that, on panic: logs the recovered value + full stack at ERROR via `slog.Default()` (the existing OTLP slog bridge ships it to the collector's `otel_logs`), and renders the head's OWN 500 error envelope via a new `PanicRenderer` callback. Envelope shaping stays per-head — Prom/Loki emit `{status:"error", errorType:"internal"}`, Tempo emits its distinct `{traceID, spanID, error, message}` shape — so `telemetry` stays decoupled from the wire formats (matching the existing `httperr` design note). If the handler already committed a status line / body before panicking, the wire is past re-rendering, so we only log + count.
- **Metric-defer fix.** `t.Done()` is now wrapped in a `defer` so the outcome records EVEN on panic / early return, tagged `ResultError`. The `{result}` label stays bounded to `{ok, error}` — **cardinality is unchanged.**

## The contract (all 3 heads)

- `prom/chaos_test.go`: the lenient either/or panic test is replaced with `TestCH_PanicQuerier_Returns500Envelope`, which asserts a clean **500 + valid Prom error JSON** unconditionally.
- `loki/chaos_test.go` + `tempo/chaos_test.go`: new mirrored `*_PanicQuerier_Returns500Envelope` tests pin the clean-500 + valid-envelope behaviour per head.
- `telemetry/metrics_test.go`: middleware-level tests pin the recover + deferred-metric behaviour, including the after-commit no-double-write path and the assertion that a panicked query still increments `cerberus_queries_total{result=error}` + the duration histogram.

## Verification

`go build ./...`, `go test -race ./internal/api/{prom,loki,tempo}/ ./internal/telemetry/`, the goleak regression detectors, `go vet`, and `gofumpt -extra` all green locally. Discipline greps (forbid-skip wording) clean.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>