### PR TITLE
docs(readme): add version requirements spotlight (CH + OTel schema)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,39 @@ SQL underneath.
   `grafana/loki/v3/pkg/logql/syntax`, and `grafana/tempo/pkg/traceql`
   directly. If upstream parses it, cerberus parses it.
 
+## Version requirements
+
+Two axes decide whether a deployment is compatible: the **ClickHouse server
+version** cerberus queries, and the **OTel schema shape** the data was written
+in.
+
+| Component                | Minimum                        | Notes                                                                                                                                                                                          |
+| ------------------------ | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ClickHouse (base)        | **25.8**                       | The supported floor. Every head emits SQL that real ClickHouse 25.8 answers correctly — the chDB / compose / e2e / compatibility substrate is all 25.8.                                        |
+| ClickHouse (native rate) | **25.6**                       | Only when `CERBERUS_EXPERIMENTAL_TS_GRID_RANGE` is on. The `timeSeriesRateToGrid` aggregate family ships in CH ≥ 25.6; the flag is off by default and rides an experimental per-query setting. |
+| OTel exporter schema     | **clickhouseexporter 0.152.0** | A **schema shape**, not a binary version — see below.                                                                                                                                          |
+
+**ClickHouse.** The base floor is the version cerberus is proven against: the
+test substrate (chDB), the compose stack, the e2e cluster, and the three
+differential compatibility harnesses all run ClickHouse 25.8, so that is the
+version every emitted query is validated on. The experimental native-rate path
+(`CERBERUS_EXPERIMENTAL_TS_GRID_RANGE`, **default off**) lowers eligible
+`rate(<counter>[range])` range queries to the compiled `timeSeriesRateToGrid`
+aggregate, which exists only on ClickHouse ≥ 25.6; on a supported 25.8 server
+that floor is already met. See
+[`docs/operations.md`](docs/operations.md#experimental-native-rate-timeseriesratetogrid)
+for the runtime contract and the experimental-setting details.
+
+**OTel schema — the shape, not the exporter.** Cerberus reads the
+**OpenTelemetry ClickHouse schema shape** pinned to `clickhouseexporter`
+**v0.152.0** (via the `tsouza/…:cerberus-ddl` fork in
+[`go.mod`](go.mod)). What matters is the **table layout** — column names,
+types, and `Map` shapes — not which binary produced it. Any exporter, collector
+pipeline, or ingestion path that writes tables in that shape works; the exporter
+binary version itself is irrelevant. If your layout deviates from the exporter
+defaults, point cerberus at it with the `CERBERUS_SCHEMA_*` overrides — see
+[`docs/configuration.md`](docs/configuration.md#schema).
+
 ## Quick start
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -53,20 +53,20 @@ Two axes decide whether a deployment is compatible: the **ClickHouse server
 version** cerberus queries, and the **OTel schema shape** the data was written
 in.
 
-| Component                | Minimum                        | Notes                                                                                                                                                                                          |
-| ------------------------ | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ClickHouse (base)        | **25.8**                       | The supported floor. Every head emits SQL that real ClickHouse 25.8 answers correctly — the chDB / compose / e2e / compatibility substrate is all 25.8.                                        |
-| ClickHouse (native rate) | **25.6**                       | Only when `CERBERUS_EXPERIMENTAL_TS_GRID_RANGE` is on. The `timeSeriesRateToGrid` aggregate family ships in CH ≥ 25.6; the flag is off by default and rides an experimental per-query setting. |
-| OTel exporter schema     | **clickhouseexporter 0.152.0** | A **schema shape**, not a binary version — see below.                                                                                                                                          |
+| Component            | Minimum                        | Notes                                                                                                                                       |
+| -------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| ClickHouse           | **25.8**                       | The supported floor — every head emits SQL proven against ClickHouse 25.8. The experimental native rate needs no newer version (see below). |
+| OTel exporter schema | **clickhouseexporter 0.152.0** | A **schema shape**, not a binary version — see below.                                                                                       |
 
-**ClickHouse.** The base floor is the version cerberus is proven against: the
-test substrate (chDB), the compose stack, the e2e cluster, and the three
-differential compatibility harnesses all run ClickHouse 25.8, so that is the
-version every emitted query is validated on. The experimental native-rate path
-(`CERBERUS_EXPERIMENTAL_TS_GRID_RANGE`, **default off**) lowers eligible
-`rate(<counter>[range])` range queries to the compiled `timeSeriesRateToGrid`
-aggregate, which exists only on ClickHouse ≥ 25.6; on a supported 25.8 server
-that floor is already met. See
+**ClickHouse.** The floor is the version cerberus is proven against: the test
+substrate (chDB), the compose stack, the e2e cluster, and the three differential
+compatibility harnesses all run ClickHouse 25.8, so that is the version every
+emitted query is validated on. Enabling the experimental native-rate path
+(`CERBERUS_EXPERIMENTAL_TS_GRID_RANGE`, **default off**) does **not** raise this
+floor: it lowers eligible `rate(<counter>[range])` range queries to the compiled
+`timeSeriesRateToGrid` aggregate, which exists from ClickHouse 25.6 — already
+below the 25.8 floor, so any supported deployment can turn it on without a
+version bump. See
 [`docs/operations.md`](docs/operations.md#experimental-native-rate-timeseriesratetogrid)
 for the runtime contract and the experimental-setting details.
 


### PR DESCRIPTION
## What

Adds a prominent **Version requirements** spotlight to `README.md`, placed
after *Why cerberus?* and before *Quick start*. Two axes, in a scannable table:

| Component | Minimum | Notes |
| --- | --- | --- |
| ClickHouse | **25.8** | The supported floor — every head emits SQL proven against ClickHouse 25.8. The experimental native rate needs no newer version. |
| OTel exporter schema | **clickhouseexporter 0.152.0** | A schema **shape**, not a binary version. |

There is **one** ClickHouse floor, 25.8. The experimental native-rate path
(`CERBERUS_EXPERIMENTAL_TS_GRID_RANGE`, default off) lowers eligible
`rate(<counter>[range])` queries to `timeSeriesRateToGrid`, which exists from
CH 25.6 — *below* the 25.8 floor — so enabling it adds **no** version
requirement. (An earlier draft listed native rate as a separate "25.6" row,
which read as if turning on an extra experimental feature *reduced* the
minimum — nonsense; collapsed to the single honest floor.)

Links out to `docs/operations.md#experimental-native-rate-timeseriesratetogrid`
and `docs/configuration.md#schema`. README-only change; no doc/code edits.

## Version-floor evidence (audit trail)

I derived the floor from the code, not from guesswork. The key question was
whether the base floor is 24.8 or pushed higher by version-specific behaviour.

**Floor = 25.8 (the *supported/tested* floor, CI-backed).** No emitted SQL
*requires* a CH above 25.6 for correctness — every version-specific comment is
either a forward-safe workaround or a stricter-analyzer accommodation:

- `internal/qlcommon/label_replace.go:177-189` + `internal/chsql/builder.go:824-837`
  — the CH ≤ 24.8 `replaceRegexpOne('')` divergence is patched **unconditionally**
  at SQL-build time. The short-circuit is explicitly "forward-safe… collapses
  harmlessly on 25.8… keeps emission byte-identical." So it does **not** force a
  25.8 floor for correctness — it proves cerberus *intends* to be correct on ≤24.8.
- `internal/logql/duration.go:25-41` — the `µs`/`μs` micro-sign is normalised to
  `us` before `parseTimeDelta`; "forward-safe — a no-op on 25.8 and keeps the emit
  identical." Works on both 24.8 and 25.8.
- `internal/chsql/histogram_quantile.go:128-143` — the `(if(<cmp>,1,0)=1)` wrap is
  emitted precisely to satisfy "the constant-folded UInt8 the 24.8 filter path
  requires." Active 24.8 support.
- `internal/chsql/structural_join.go:123-126,329-335` + `internal/traceql/lower.go:406-411`
  — these go the *other* way: cerberus emits bare-name aliases so **25.8's stricter
  analyzer** accepts the self-join projection. That shape is also valid on older CH —
  a forward-compat accommodation, not a floor.
- `internal/schema/ddl/ddl.go:243-250` — the bloom-filter index branch is rendered
  with `HasFullTextSearch: false`, which "works everywhere cerberus deploys." The
  text-index branch that "needs ClickHouse >= 26.2" is **off by default**, so 26.2
  is **not** a floor.

So why state **25.8** and not 24.8? Because 25.8 is what CI actually *proves*: the
chDB test substrate (`chdb-go v1.11.0 = 25.8.2.1-lts`), the compose stack, the e2e
cluster, and all three differential compatibility harnesses run 25.8
(`internal/config/config.go:58-66`, `internal/logql/duration.go:26-27`,
`docs/operations.md:188`). The code carries deliberate ≤24.8 workarounds, but no
run validates 24.8 end-to-end — so the *honest supported floor is the tested one,
25.8*. The existing docs already frame it that way ("the deployment floor is now CH
25.8", `docs/performance.md:212`).

**Native rate adds no version floor.** The `timeSeriesRateToGrid` family was
introduced in CH v25.6.0 (`internal/chclient/experimental.go:7-18`,
`internal/config/config.go:59`, `internal/chplan/range_window_native.go:43`). Gated
behind `CERBERUS_EXPERIMENTAL_TS_GRID_RANGE` (default off) and an experimental
per-query setting `allow_experimental_time_series_aggregate_functions=1`. Because
25.6 < the 25.8 base floor, on any supported deployment the native-rate CH-version
requirement is already met — what keeps the flag experimental is the setting + the
not-yet-swept-on-real-CH parity, not the version. So it does not warrant a separate
"minimum" row.

**OTel schema = clickhouseexporter v0.152.0 (the SHAPE, not the binary).** `go.mod`
requires `clickhouseexporter v0.152.0`, replaced by `tsouza/…:cerberus-ddl`
(`v0.0.3-cerberus-ddl`). Cerberus consumes the exporter's DDL **templates** as the
schema source-of-truth; what matters is the table layout (columns, types, Map shapes),
not which binary wrote it. Any pipeline that produces that shape works; the
`CERBERUS_SCHEMA_*` overrides cover layout deviations.

**Ambiguity, stated honestly:** the floor is the one judgement call. The *code*
would run on 24.8 (the workarounds are all present), but nothing *tests* 24.8. I chose
the higher, CI-backed number (25.8) per the "state the safer one" rule, and the
existing docs agree. If the maintainer wants to advertise 24.8 as a best-effort
lower bound, the workarounds support it — but it would be untested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
