### PR TITLE
ci: cheap-first gate on expensive compat + compose-smoke lanes

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -126,9 +126,79 @@ jobs:
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
           fi
 
+  # `gate` is the cheap-first tripwire. The compatibility harnesses are
+  # the most expensive PR lane (~8-10 min each, three Docker differential
+  # heads), so we DON'T want to burn that runner time when a trivial
+  # discipline-grep or a compile break would have failed the PR anyway.
+  # `gate` runs the same fast checks ci.yml's `forbid-skip` job runs
+  # (pure `git grep`, seconds) plus a `go build ./...` compile sanity
+  # check (~1-2 min with the module cache), and every expensive job below
+  # `needs: gate`. On a cheap-breakage PR the heavy heads are SKIPPED —
+  # which branch protection treats as satisfied, but that is safe because
+  # ci.yml's own `forbid-skip` / `check` go RED and block the merge. The
+  # gate only saves runner minutes; it never creates a merge hole. See
+  # the PR that introduced this for the full truth table.
+  #
+  # Docs-only short-circuit is preserved: `gate` itself is cheap enough
+  # to always run, and the heavy heads keep their own
+  # `needs.changes.outputs.docs_only != 'true'` guard, so a docs-only PR
+  # still skips them.
+  gate:
+    name: gate
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # The discipline scans diff against origin/main, so we need
+          # both refs reachable (mirrors ci.yml's forbid-skip checkout).
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      # The six discipline scans (pure `git grep` / `perl`, no Go
+      # toolchain) — byte-identical to ci.yml's `forbid-skip` job. These
+      # run first because they are the cheapest and the most common
+      # cause of a red PR.
+      - name: Reject t.Skip in test files
+        run: node .github/scripts/forbid-skip.mjs
+        env:
+          CHECK: t-skip
+      - name: Reject "not implemented" / "skipped" / "deferred" in tests + fixtures
+        run: node .github/scripts/forbid-skip.mjs
+        env:
+          CHECK: wording-tests
+      - name: Reject "not implemented" in production code
+        run: node .github/scripts/forbid-skip.mjs
+        env:
+          CHECK: not-implemented
+      - name: Reject soft-assertion / silent-recover patterns
+        run: node .github/scripts/forbid-skip.mjs
+        env:
+          CHECK: soft-assert
+      - name: Reject should_skip overlay entries
+        run: node .github/scripts/forbid-skip.mjs
+        env:
+          CHECK: should-skip
+      - name: Reject test escape-hatch patterns
+        run: node .github/scripts/forbid-skip.mjs
+        env:
+          CHECK: escape-hatch
+
+      # Compile sanity check. Far cheaper than `go test -race` (ci.yml's
+      # `check`), but catches a non-building tree before the Docker heads
+      # spin up — every head builds cerberus anyway.
+      - name: go build (compile sanity)
+        run: go build ./...
+
   prometheus:
     name: compatibility/prometheus
-    needs: changes
+    needs: [changes, gate]
     if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -345,7 +415,7 @@ jobs:
     # off the required-checks list avoids gating every unrelated PR on the
     # full forced-route corpus run.
     name: compatibility/prometheus-forced-route
-    needs: changes
+    needs: [changes, gate]
     if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -466,7 +536,7 @@ jobs:
     # This is a NORMAL CI job (not a branch-protection-required check) until
     # it has soaked on main — its green status on this PR is the proof.
     name: compatibility/promql-surface
-    needs: changes
+    needs: [changes, gate]
     if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -494,7 +564,7 @@ jobs:
 
   tempo:
     name: compatibility/tempo
-    needs: changes
+    needs: [changes, gate]
     if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -608,7 +678,7 @@ jobs:
 
   loki:
     name: compatibility/loki
-    needs: changes
+    needs: [changes, gate]
     if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -113,9 +113,78 @@ jobs:
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
           fi
 
+  # `gate` is the cheap-first tripwire for the `compose-smoke` required
+  # check. compose-smoke is the single most expensive PR lane (~14-45 min
+  # full Docker compose stack + Grafana Playwright catch-net), so we
+  # DON'T want to burn that runner time when a trivial discipline-grep or
+  # a compile break would have failed the PR anyway. `gate` runs the same
+  # fast checks ci.yml's `forbid-skip` job runs (pure `git grep`, seconds)
+  # plus a `go build ./...` compile sanity check (~1-2 min with the module
+  # cache); compose-smoke `needs: gate` and refuses to start on a PR until
+  # gate is green.
+  #
+  # PR-ONLY by design (mirrors `changes`): on push / schedule / dispatch
+  # the gate is skipped and compose-smoke's `if:` short-circuits the gate
+  # clause to true, so the nightly + push lanes keep running unconditionally
+  # (a nightly run has no diff to gate on, and push-to-main already merged).
+  #
+  # SAFETY: when gate FAILS on a PR, compose-smoke is SKIPPED — which
+  # branch protection treats as satisfied — but that is NOT a merge hole,
+  # because ci.yml's own `forbid-skip` / `check` go RED on the same
+  # breakage and block the merge. The gate only saves runner minutes.
+  gate:
+    name: gate
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.docs_only != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # The discipline scans diff against origin/main, so we need
+          # both refs reachable (mirrors ci.yml's forbid-skip checkout).
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      # The six discipline scans (pure `git grep` / `perl`, no Go
+      # toolchain) — byte-identical to ci.yml's `forbid-skip` job.
+      - name: Reject t.Skip in test files
+        run: node .github/scripts/forbid-skip.mjs
+        env:
+          CHECK: t-skip
+      - name: Reject "not implemented" / "skipped" / "deferred" in tests + fixtures
+        run: node .github/scripts/forbid-skip.mjs
+        env:
+          CHECK: wording-tests
+      - name: Reject "not implemented" in production code
+        run: node .github/scripts/forbid-skip.mjs
+        env:
+          CHECK: not-implemented
+      - name: Reject soft-assertion / silent-recover patterns
+        run: node .github/scripts/forbid-skip.mjs
+        env:
+          CHECK: soft-assert
+      - name: Reject should_skip overlay entries
+        run: node .github/scripts/forbid-skip.mjs
+        env:
+          CHECK: should-skip
+      - name: Reject test escape-hatch patterns
+        run: node .github/scripts/forbid-skip.mjs
+        env:
+          CHECK: escape-hatch
+
+      # Compile sanity check. Far cheaper than the full compose stack;
+      # catches a non-building tree before Docker buildx + k3d spin up.
+      - name: go build (compile sanity)
+        run: go build ./...
+
   compose-smoke:
     name: compose-smoke
-    needs: changes
+    needs: [changes, gate]
     # Lane doctrine: PR + push run at SWEEP_DEPTH=lean (the required
     # fast-feedback gate); the nightly schedule runs at
     # SWEEP_DEPTH=full. The schedule lane exists because the
@@ -129,7 +198,8 @@ jobs:
     if: |
       always() &&
       (github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'schedule') &&
-      (github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true')
+      (github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true') &&
+      (github.event_name != 'pull_request' || needs.gate.result == 'success')
     runs-on: ubuntu-latest
     # Timeout is per-lane. PR/push run SWEEP_DEPTH=lean: the catch-net
     # smoke + the iterate-* specs + the lean crawl (root + nav + one


### PR DESCRIPTION
## What

Make the **expensive** required PR lanes fail-fast on **cheap** breakage:
add an in-workflow `gate` job to `compatibility.yml` and `e2e.yml` that
runs the fast discipline scans + a `go build ./...` compile check, and
make the Docker compat heads and the full compose+Playwright stack
`needs: gate`. Cheap-first: don't burn 8–45 min of runner time on a PR
that a 30-second `forbid-skip` grep would have failed anyway.

## Phase 1 — current trigger + dependency DAG (the finding)

Today every required PR check fires **fully in parallel on `pull_request`
with no cross-gating**. The only staging is the cheap `changes`
(docs-only path filter) job inside each workflow.

| Required check | Workflow file | Job | Triggers (PR-relevant) | `needs:` (before) | Cost |
|---|---|---|---|---|---|
| `check` (`go test -race` + build) | `ci.yml` | `check` | `pull_request`, push | `changes` | **cheap-ish** (~3–6 min) |
| `lint` | `ci.yml` | `lint` | `pull_request`, push | — | **cheap** (~2–3 min) |
| `forbid-skip` | `ci.yml` | `forbid-skip` | `pull_request`, push | — | **cheap** (~30 s, pure git-grep) |
| `probe` | `chdb.yml` | `probe` | `pull_request`, push, dispatch, schedule | `changes` | medium (~10–15 min, chDB build) |
| `roundtrip (promql\|logql\|traceql)` | `chdb.yml` | `roundtrip` (matrix) | same | `changes` | medium (~10–20 min) |
| `compatibility/prometheus` | `compatibility.yml` | `prometheus` | `pull_request`, push, dispatch, 3× nightly cron | `changes` | **expensive** (~8–10 min Docker differential) |
| `compatibility/tempo` | `compatibility.yml` | `tempo` | same | `changes` | **expensive** (~8–10 min) |
| `compatibility/loki` | `compatibility.yml` | `loki` | same | `changes` | **expensive** (~8–10 min) |
| `compose-smoke` | `e2e.yml` | `compose-smoke` | `pull_request`, push, nightly cron, dispatch | `changes` | **expensive** (full compose stack + Grafana Playwright, ~14–45 min) |

Non-required lanes that also fan out in parallel: `compatibility/prometheus-forced-route`,
`compatibility/promql-surface` (PR-run but not required), and the
push/nightly-only `dashboard` / `startup-bench` / `chaos` / mutation /
property lanes (already correctly event-gated off PR).

**Conclusion: NOT already gated — all parallel.** Exactly the
runner-minute waste the maintainer flagged.

## Phase 2 — design (the crux: cross-workflow gating)

GitHub `needs:` only chains jobs **within one workflow file**. The cheap
checks live in `ci.yml`; the expensive lanes live in `compatibility.yml`
and `e2e.yml` — separate files, so they cannot `needs:` each other.

- **(A) In-workflow fast `gate` job — CHOSEN.** Add a cheap `gate` job
  inside each expensive workflow that re-runs the six `forbid-skip.mjs`
  discipline scans (byte-identical to `ci.yml`'s `forbid-skip`) + a
  `go build ./...` compile check, and make each expensive job
  `needs: gate`. Self-contained per workflow, fail-fasts on cheap
  breakage, zero impact on branch-protection check reporting.
- **(B) `workflow_run` chaining — REJECTED.** `workflow_run` runs in a
  detached context and does **not** associate its checks with the PR the
  way `pull_request` runs do — it would break required-status-check
  reporting on branch protection. Not worth the risk.
- **(C) Consolidate everything into one DAG workflow — REJECTED.**
  Wrecks the per-head separation, the `changes` path-filter structure,
  and the compat-score-per-job summary flow; huge diff.

The gate duplicates ~30 s of grep + a `go build` per expensive workflow —
a deliberate, cheap trade for fail-fast.

### Branch-protection truth table (the safety argument)

cerberus branch protection treats a **skipped** required check as
**satisfied** (evidence: docs-only PR #890 merged with `compatibility/*`
+ `check` "skipping" via path filter). The gate must not turn that into a
merge hole. It doesn't, because the gate is **redundant** with `ci.yml`'s
own cheap checks:

| Scenario | `gate` | Expensive lane | `ci.yml` cheap checks | PR mergeable? |
|---|---|---|---|---|
| cheap pass | success | **runs** → must pass | green | only if expensive green ✅ |
| cheap fail (discipline/compile) | **failure** | **skipped** (= satisfied) | **RED** (`forbid-skip` / `check`) | **NO — blocked by red cheap check** ✅ |
| docs-only PR | skipped | skipped (= satisfied, unchanged) | green | yes (unchanged) ✅ |

The expensive-lane skip on a red PR is moot: the same breakage that fails
`gate` also fails `ci.yml`'s `forbid-skip` / `check`, which are **required
and go red**, blocking the merge. No path makes a real failure mergeable.

### Tradeoff (honest)

- **Win:** on a red PR, the three Docker compat heads + the compose stack
  **never start** — saves ~40–80 runner-minutes per broken push.
- **Cost:** on a **green** PR the expensive lanes are now **serialized
  behind the gate** (cheap → then expensive) instead of fully parallel,
  adding the gate's wall-clock (~30 s grep + ~1–2 min `go build`) to the
  green-path latency. The maintainer explicitly wants cheap-first, so this
  is the intended trade.

## Phase 3 — implementation

- `compatibility.yml`: new `gate` job (`needs: changes`, docs-only
  guarded); `prometheus`, `tempo`, `loki`, `prometheus-forced-route`,
  `promql-surface` flipped to `needs: [changes, gate]`.
- `e2e.yml`: new PR-only `gate` job; `compose-smoke` flipped to
  `needs: [changes, gate]` with one added `if:` clause —
  `(github.event_name != 'pull_request' || needs.gate.result == 'success')` —
  so on a PR it refuses to start until gate is green, while push / nightly
  / dispatch (where `gate` is skipped) short-circuit the clause to true and
  keep running unconditionally.
- `chdb.yml` (`probe` / `roundtrip`) left untouched — classified
  cheap-side per the maintainer's framing; gating them would risk the
  matrix-skip branch-protection gotcha already documented in that file.
- Discipline logic stays in `.github/scripts/forbid-skip.mjs` (repo
  convention); the gate steps are trivial `run: node …` one-liners, which
  the convention allows inline. Preserved: docs-only path-filter skips,
  the non-required forced-route / promql-surface lanes, the per-job
  compat-score summary flow. `actionlint` clean.

## Risk for the maintainer to confirm

The e2e `compose-smoke` `if:` relies on `needs.gate.result == 'success'`
gating **only** on `pull_request` (the `always()` keeps push/nightly
running while `gate` is skipped there). Please sanity-check that the
nightly + push compose-smoke runs are unaffected — the first push-to-main
run after merge is the proof. Everything else (compat heads) uses a plain
`needs: [changes, gate]` with no `always()`, so a skipped/failed gate
cleanly skips them.

This is a CI-structure change — **leaving open for maintainer review, no
auto-merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
