### PR TITLE
perf(logql): route k8s.* matchers to materialized columns over the wide Map

### DIFF
--- a/internal/logql/lower.go
+++ b/internal/logql/lower.go
@@ -1549,22 +1549,41 @@ func buildMatchersPredicate(matchers []*labels.Matcher, s schema.Logs) chplan.Ex
 }
 
 func matcherToExpr(m *labels.Matcher, s schema.Logs) chplan.Expr {
-	var lhs chplan.Expr
-	if isDetectedLevelLabel(m.Name) {
-		lhs = detectedLevelExpr(s)
-	} else {
-		mapLookup := attributeLookupColumn(s.ResourceAttributesColumn, m.Name)
-		if col := resourceFallbackColumn(s, m.Name); col != "" {
-			lhs = resourceAttributeFallbackLHS(col, mapLookup)
-		} else {
-			lhs = mapLookup
-		}
-	}
+	lhs := matcherLHS(m.Name, s)
 	return &chplan.Binary{
 		Op:    matchOp(m.Type),
 		Left:  lhs,
 		Right: &chplan.LitString{V: m.Value},
 	}
+}
+
+// matcherLHS resolves the left-hand side expression a stream-selector
+// matcher on `label` compares against, in reference-Loki precedence:
+//
+//  1. the `detected_level` family → the SeverityText-derived expression;
+//  2. an exporter-MATERIALIZED k8s.* resource column → a bare ColumnRef.
+//     The column's MATERIALIZED expression IS `ResourceAttributes[<key>]`,
+//     so the bare reference is byte-for-byte equivalent to the map access
+//     (including the empty-string default a missing key yields) while
+//     avoiding the wide ResourceAttributes Map decompression. The k8s.*
+//     keys are disjoint from the top-level scalar columns
+//     (SeverityText / ServiceName / …), so this never collides with the
+//     resourceFallbackColumn coalesce below;
+//  3. a top-level scalar column (ServiceName / SeverityText / …) →
+//     `coalesce(nullIf(<col>, ”), ResourceAttributes[<label>])`;
+//  4. otherwise the plain `ResourceAttributes[<label>]` map access.
+func matcherLHS(label string, s schema.Logs) chplan.Expr {
+	if isDetectedLevelLabel(label) {
+		return detectedLevelExpr(s)
+	}
+	if matCol, ok := materializedColumnFor(label, s); ok {
+		return &chplan.ColumnRef{Name: matCol}
+	}
+	mapLookup := attributeLookupColumn(s.ResourceAttributesColumn, label)
+	if col := resourceFallbackColumn(s, label); col != "" {
+		return resourceAttributeFallbackLHS(col, mapLookup)
+	}
+	return mapLookup
 }
 
 // resourceFallbackColumn returns the dedicated top-level CH column name

--- a/internal/logql/top_level_columns.go
+++ b/internal/logql/top_level_columns.go
@@ -1,9 +1,47 @@
 package logql
 
 import (
+	"strings"
+
 	"github.com/tsouza/cerberus/internal/chplan"
 	"github.com/tsouza/cerberus/internal/schema"
 )
+
+// materializedColumnFor reports whether `label` names a ResourceAttributes
+// map key the OTel ClickHouse Exporter MATERIALIZEs into a dedicated
+// top-level LowCardinality(String) column on the logs table (one of the 8
+// k8s.* / deployment.environment.name keys). When it does, the second
+// return is the materialized column name — a bare ColumnRef against it is
+// byte-for-byte equivalent to `ResourceAttributes[<key>]` (the column's
+// MATERIALIZED expression IS that map access, including the empty-string
+// default a missing key yields) but avoids decompressing the wide Map.
+//
+// Both the dotted OTel-semantic-convention form (`k8s.namespace.name`,
+// the actual map key) and the underscored Grafana form
+// (`k8s_namespace_name`, the identifier Grafana panels + the LogQL
+// grammar surface) resolve — the underscored form is normalised to dots
+// before the lookup, mirroring resourceFallbackColumn's `service_name`
+// alias. A custom-schema user whose otel_logs has no materialized columns
+// leaves schema.Logs.MaterializedResourceColumns nil and opts out: the
+// table is empty so this never fires and the lowering stays map-only.
+func materializedColumnFor(label string, s schema.Logs) (string, bool) {
+	if label == "" || len(s.MaterializedResourceColumns) == 0 {
+		return "", false
+	}
+	if col, ok := s.MaterializedResourceColumns[label]; ok {
+		return col, true
+	}
+	// Grafana panels + the LogQL grammar spell the dotted OTel key with
+	// underscores (`k8s_namespace_name`). The map is keyed by the dotted
+	// form (the literal ResourceAttributes key), so normalise before the
+	// second lookup.
+	if dotted := strings.ReplaceAll(label, "_", "."); dotted != label {
+		if col, ok := s.MaterializedResourceColumns[dotted]; ok {
+			return col, true
+		}
+	}
+	return "", false
+}
 
 // topLevelLogColumnFor reports whether `label` names a top-level OTel-CH
 // scalar column on the logs table (rather than a key inside the

--- a/internal/logql/vector_aggregation.go
+++ b/internal/logql/vector_aggregation.go
@@ -210,6 +210,18 @@ func levelAwareRangeGroupKey(label string, s schema.Logs) chplan.Expr {
 	if isDetectedLevelGroupingLabel(label) {
 		return detectedLevelExpr(s)
 	}
+	if matCol, ok := materializedColumnFor(label, s); ok {
+		// At the inner range-aggregation layer the Scan/Filter sits
+		// directly below, so the exporter's MATERIALIZED k8s.* column is
+		// in scope and resolves to a bare ColumnRef — byte-for-byte
+		// equivalent to `ResourceAttributes[<key>]` (the column's
+		// MATERIALIZED expression) while avoiding the wide Map
+		// decompression. NOTE the OUTER post-RangeWindow companion
+		// [levelAwareGroupKey] is deliberately NOT routed here: after the
+		// RangeWindow identity Project only the augmented map survives,
+		// the bare column is out of scope, so it stays a map access.
+		return topLevelColumnRef(matCol)
+	}
 	if col, ok := topLevelLogColumnFor(label, s); ok {
 		// At the inner range-aggregation layer the top-level OTel
 		// column (SeverityText, ServiceName, ...) is still in scope —

--- a/internal/schema/logs.go
+++ b/internal/schema/logs.go
@@ -56,6 +56,30 @@ type Logs struct {
 	// `LogAttributes` — each can carry hundreds of bytes per row.
 	WideColumns []string
 
+	// MaterializedResourceColumns maps a ResourceAttributes map key
+	// (e.g. `k8s.namespace.name`) to the dedicated top-level
+	// LowCardinality(String) column the OTel ClickHouse Exporter
+	// MATERIALIZEs from that key (e.g. `__otel_materialized_k8s.namespace.name`).
+	//
+	// The exporter's `logs_table.sql` template defines each such column
+	// as `LowCardinality(String) MATERIALIZED ResourceAttributes['<key>']`,
+	// so reading the column is byte-for-byte equivalent to reading the
+	// map key — including the empty-string default a missing key yields —
+	// but avoids decompressing the wide ResourceAttributes Map. A
+	// stream-selector matcher (or inner range-aggregation group-by) whose
+	// label resolves through this table emits a bare ColumnRef against the
+	// materialized column instead of a Map access.
+	//
+	// This is the opt-in gate: DefaultOTelLogs() populates it from the
+	// exporter's exact DDL set; a custom-schema user whose otel_logs has
+	// no `__otel_materialized_*` columns (or who renamed
+	// ResourceAttributesColumn) leaves it nil and stays on the map read,
+	// mirroring the resourceFallbackColumn opt-out. Only the logs table
+	// carries these columns — the traces / metrics tables ship a plain
+	// ResourceAttributes Map with no materialized siblings — so the
+	// routing is LogQL-only by construction.
+	MaterializedResourceColumns map[string]string
+
 	// RowKey is the tuple of columns that uniquely identifies a row in
 	// the logs table. Used by the chsql late-materialisation rewrite
 	// as the JOIN key between the thin inner SELECT and the outer
@@ -76,6 +100,45 @@ type Logs struct {
 // for the late-materialisation rewrite. Custom-schema users with
 // non-unique storage layouts leave RowKey empty to bypass the rewrite.
 func (l Logs) HasUniqueRowKey() bool { return len(l.RowKey) > 0 }
+
+// materializedColumnPrefix is the literal prefix the OTel ClickHouse
+// Exporter prepends to a ResourceAttributes map key to name the
+// MATERIALIZED column it hoists that key into. The exporter's
+// `logs_table.sql` template spells the full column name as
+// `__otel_materialized_<key>` (the key verbatim, dots preserved) — see
+// the `MATERIALIZED ResourceAttributes['<key>']` column definitions.
+const materializedColumnPrefix = "__otel_materialized_"
+
+// defaultMaterializedResourceKeys lists the ResourceAttributes map keys
+// the OTel ClickHouse Exporter MATERIALIZEs into dedicated top-level
+// LowCardinality(String) columns on the logs table. Read verbatim from
+// the exporter's `logs_table.sql` template — the column for each key is
+// defined as `MATERIALIZED ResourceAttributes['<key>']`, so reading the
+// column is equivalent to reading the map key. The set is exporter DDL,
+// not a cerberus-chosen allow-list: it tracks exactly which keys the
+// shipped schema promotes.
+var defaultMaterializedResourceKeys = []string{
+	"k8s.cluster.name",
+	"k8s.container.name",
+	"k8s.deployment.name",
+	"k8s.namespace.name",
+	"k8s.node.name",
+	"k8s.pod.name",
+	"k8s.pod.uid",
+	"deployment.environment.name",
+}
+
+// defaultMaterializedResourceColumns builds the {map-key →
+// materialized-column} table from defaultMaterializedResourceKeys by
+// prepending materializedColumnPrefix to each key — mirroring the
+// exporter's column-naming rule exactly.
+func defaultMaterializedResourceColumns() map[string]string {
+	out := make(map[string]string, len(defaultMaterializedResourceKeys))
+	for _, key := range defaultMaterializedResourceKeys {
+		out[key] = materializedColumnPrefix + key
+	}
+	return out
+}
 
 // DefaultOTelLogs returns the schema produced by the upstream OTel
 // ClickHouse Exporter for logs.
@@ -103,5 +166,10 @@ func DefaultOTelLogs() Logs {
 		// log row when ingestion carries trace context. See the
 		// WideColumns godoc above.
 		RowKey: []string{"Timestamp", "TraceId", "SpanId"},
+		// The 8 k8s.* / deployment.environment.name resource attributes
+		// the exporter MATERIALIZEs into dedicated LowCardinality columns
+		// on the logs table — routing a matcher/group-by here avoids
+		// decompressing the wide ResourceAttributes Map.
+		MaterializedResourceColumns: defaultMaterializedResourceColumns(),
 	}
 }

--- a/test/perf/cardinality-baseline.json
+++ b/test/perf/cardinality-baseline.json
@@ -860,6 +860,16 @@
     "max_recursion_depth": 0
   },
   {
+    "fixture": "logql/matcher_k8s_namespace_materialized",
+    "fan_factor": 1,
+    "scan_rows": 2,
+    "peak_intermediate": 2,
+    "has_cross_join": false,
+    "has_array_join": false,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0
+  },
+  {
     "fixture": "logql/matcher_self_service",
     "fan_factor": 1,
     "scan_rows": 3,

--- a/test/perf/materialized_k8s_col_chdb_test.go
+++ b/test/perf/materialized_k8s_col_chdb_test.go
@@ -1,0 +1,325 @@
+//go:build chdb
+
+// Quantify the LogQL k8s.* materialized-column routing lever.
+//
+// The OTel ClickHouse Exporter MATERIALIZEs a fixed set of k8s.* /
+// deployment.environment.name ResourceAttributes keys into dedicated
+// LowCardinality(String) columns on the logs table — each defined as
+// `MATERIALIZED ResourceAttributes['<key>']`. cerberus's LogQL emit now
+// routes a stream-selector matcher (or inner range-aggregation group-by)
+// on one of those labels to the bare materialized column instead of
+// decompressing the wide ResourceAttributes Map (internal/logql +
+// internal/schema).
+//
+// This harness proves the two halves of the claim against a 2,000,000-row
+// otel_logs table that replicates the exporter's logs_table.sql shape
+// (ORDER BY (toStartOfFiveMinutes(Timestamp), ServiceName, Timestamp);
+// a 6-key ResourceAttributes Map incl. 4 k8s.* keys; the
+// `__otel_materialized_k8s.namespace.name` MATERIALIZED column):
+//
+//  1. CORRECTNESS — the BEFORE emit (origin/main: map read, reproduced by
+//     clearing schema.Logs.MaterializedResourceColumns) and the AFTER emit
+//     (materialized column) return BYTE-IDENTICAL result rows for the
+//     canonical `{k8s_namespace_name="ns-3"}` matcher and its group-by
+//     twin, including the missing-key BWC row.
+//
+//  2. BYTE-READ — `system.parts_columns` reports the on-disk
+//     compressed/uncompressed bytes ClickHouse must read+decompress for
+//     the column a predicate touches. The ResourceAttributes Map dwarfs
+//     the materialized column by a wide margin; we assert a generous
+//     FLOOR ratio so the lever can't silently regress to map reads.
+//
+// The column is NOT in the ORDER BY key, so EXPLAIN granule/read_rows are
+// identical BEFORE vs AFTER — this is a byte-read / CPU win, not a granule
+// prune. That is the honest characterization and the assertions reflect
+// it (we assert column bytes, not granules).
+//
+// Build-tagged `chdb`, same lane as the rest of the chDB execs.
+package perf
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+
+	_ "github.com/chdb-io/chdb-go/chdb/driver" // registers "chdb" sql driver
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/logql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+const (
+	// matK8sRows is the seeded row count — large enough that the
+	// compressed-byte gap between the wide Map and the LowCardinality
+	// column is unambiguous, small enough to seed in-process quickly.
+	matK8sRows = 2_000_000
+	// matK8sNamespaceCardinality is the number of distinct namespace
+	// values; LowCardinality keeps the materialized column tiny while the
+	// Map carries the full key+value payload per row.
+	matK8sNamespaceCardinality = 50
+	// matK8sByteRatioFloor is the generous FLOOR on
+	// compressed-bytes(Map) / compressed-bytes(materialized column). The
+	// measured ratio on this grid is ~50x+; the floor guards against a
+	// silent regression to map reads without pinning a brittle exact
+	// number.
+	matK8sByteRatioFloor = 8.0
+)
+
+// matK8sTable is the table name the seeded grid + emitted SQL share.
+const matK8sTable = "otel_logs_mat_k8s"
+
+// matK8sNamespaceColumn is the materialized column the lever routes the
+// k8s.namespace.name label to (the exporter's
+// `__otel_materialized_<key>` naming). materializedColumnMarker is the
+// shared prefix used to assert the BEFORE emit references NO materialized
+// column.
+const (
+	matK8sNamespaceColumn    = "__otel_materialized_k8s.namespace.name"
+	materializedColumnMarker = "__otel_materialized"
+)
+
+// matK8sDDL replicates the exporter's logs_table.sql column shape closely
+// enough to exercise the lever: the wide ResourceAttributes Map plus the
+// MATERIALIZED namespace column, on the production ORDER BY key.
+func matK8sDDL() string {
+	return fmt.Sprintf(`CREATE OR REPLACE TABLE %s (
+    Timestamp DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+    ServiceName LowCardinality(String) CODEC(ZSTD(1)),
+    Body String CODEC(ZSTD(1)),
+    ResourceAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    `+"`__otel_materialized_k8s.namespace.name`"+` LowCardinality(String) MATERIALIZED ResourceAttributes['k8s.namespace.name'] CODEC(ZSTD(1))
+) ENGINE = MergeTree()
+PARTITION BY toDate(Timestamp)
+ORDER BY (toStartOfFiveMinutes(Timestamp), ServiceName, Timestamp)
+SETTINGS index_granularity = 8192`, matK8sTable)
+}
+
+// matK8sInsert builds the grid via INSERT … SELECT FROM numbers(). The
+// ResourceAttributes Map carries 6 keys including the 4 k8s.* ones the
+// exporter promotes, so the Map's per-row payload is representative of a
+// real OTel deployment. The namespace value cycles through
+// matK8sNamespaceCardinality distinct values.
+func matK8sInsert() string {
+	return fmt.Sprintf(`INSERT INTO %s (Timestamp, ServiceName, Body, ResourceAttributes)
+SELECT
+    toDateTime64('2026-05-20 12:00:00', 9) + INTERVAL (number %% 3600) SECOND AS Timestamp,
+    concat('svc-', toString(number %% 12)) AS ServiceName,
+    concat('log line body number ', toString(number)) AS Body,
+    map(
+        'k8s.namespace.name', concat('ns-', toString(number %% %d)),
+        'k8s.pod.name',       concat('pod-', toString(number %% 5000)),
+        'k8s.container.name', concat('ctr-', toString(number %% 30)),
+        'k8s.node.name',      concat('node-', toString(number %% 200)),
+        'service.namespace',  concat('team-', toString(number %% 8)),
+        'host.name',          concat('host-', toString(number %% 400))
+    ) AS ResourceAttributes
+FROM numbers(%d)`, matK8sTable, matK8sNamespaceCardinality, matK8sRows)
+}
+
+// emitLogQL lowers + emits a LogQL query against the given logs schema,
+// returning the SQL + bound args. The schema choice is the A/B knob:
+// DefaultOTelLogs routes k8s.* to the materialized column; the same
+// schema with MaterializedResourceColumns cleared reproduces origin/main's
+// map read.
+func emitLogQL(t *testing.T, query string, s schema.Logs) (string, []any) {
+	t.Helper()
+	expr, err := logql.ParseExprPermissive(query)
+	if err != nil {
+		t.Fatalf("ParseExprPermissive(%q): %v", query, err)
+	}
+	plan, err := logql.Lower(context.Background(), expr, s)
+	if err != nil {
+		t.Fatalf("Lower(%q): %v", query, err)
+	}
+	sqlStr, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit(%q): %v", query, err)
+	}
+	return sqlStr, args
+}
+
+// schemaForTable returns DefaultOTelLogs pointed at the seeded table.
+func matK8sSchema() schema.Logs {
+	s := schema.DefaultOTelLogs()
+	s.LogsTable = matK8sTable
+	return s
+}
+
+// selectStarPrefix is the projection the LogQL matcher emit produces; we
+// swap it for a count() so the result-parity probe exercises the SAME
+// WHERE clause (the thing under test) without projecting the Map column —
+// chDB-go's parquet driver panics draining a raw Map projection.
+const selectStarPrefix = "SELECT * FROM"
+
+func runMatK8sQuery(t *testing.T, db *sql.DB, sqlStr string, args []any) [][]any {
+	t.Helper()
+	if !hasPrefix(sqlStr, selectStarPrefix) {
+		t.Fatalf("expected matcher SQL to start with %q, got %q", selectStarPrefix, sqlStr)
+	}
+	counted := "SELECT count() FROM" + sqlStr[len(selectStarPrefix):]
+	rows, err := db.Query(stripTrailingSemi(counted), args...)
+	if err != nil {
+		t.Fatalf("query %q: %v", counted, err)
+	}
+	defer rows.Close()
+	var out [][]any
+	for rows.Next() {
+		var n uint64
+		if err := rows.Scan(&n); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		out = append(out, []any{n})
+	}
+	if err := tolerantChdbErr(rows.Err()); err != nil {
+		t.Fatalf("rows.Err: %v", err)
+	}
+	return out
+}
+
+func TestMaterializedK8sColumn_ChDB(t *testing.T) {
+	db, err := sql.Open("chdb", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := db.Ping(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := db.Exec(matK8sDDL()); err != nil {
+		t.Fatalf("ddl: %v", err)
+	}
+	if _, err := db.Exec(matK8sInsert()); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	// Single part so the per-column byte accounting is comparable and not
+	// split across background-merge parts.
+	if _, err := db.Exec("OPTIMIZE TABLE " + matK8sTable + " FINAL"); err != nil {
+		t.Fatalf("optimize: %v", err)
+	}
+
+	after := matK8sSchema() // materialized routing ON (DefaultOTelLogs)
+	before := matK8sSchema()
+	before.MaterializedResourceColumns = nil // reproduces origin/main: map read
+
+	// --- (1) MATCHER: emit divergence + result parity. -------------------
+	// The matcher path is where the Scan sits directly below the Filter, so
+	// the bare materialized column wholly replaces the Map decompression —
+	// the big byte-read win. AFTER must reference the materialized column;
+	// BEFORE must read the ResourceAttributes Map.
+	matcher := `{k8s_namespace_name="ns-3"}`
+	beforeSQL, beforeArgs := emitLogQL(t, matcher, before)
+	afterSQL, afterArgs := emitLogQL(t, matcher, after)
+	t.Logf("matcher BEFORE (map):  %s", beforeSQL)
+	t.Logf("matcher AFTER  (mat):  %s", afterSQL)
+	if !containsSub(afterSQL, matK8sNamespaceColumn) {
+		t.Fatalf("AFTER matcher emit did not route to materialized column: %s", afterSQL)
+	}
+	if containsSub(beforeSQL, materializedColumnMarker) {
+		t.Fatalf("BEFORE matcher emit unexpectedly referenced a materialized column: %s", beforeSQL)
+	}
+	if !containsSub(beforeSQL, "ResourceAttributes") {
+		t.Fatalf("BEFORE matcher emit did not read ResourceAttributes Map: %s", beforeSQL)
+	}
+
+	gotBefore := runMatK8sQuery(t, db, beforeSQL, beforeArgs)
+	gotAfter := runMatK8sQuery(t, db, afterSQL, afterArgs)
+	if !rowsEqual(gotBefore, gotAfter) {
+		t.Fatalf("matcher result parity FAILED: before=%v after=%v", gotBefore, gotAfter)
+	}
+	t.Logf("matcher result parity OK: count(before)=count(after)=%v", gotAfter)
+
+	// --- (1b) GROUP-BY TWIN: inner-range by-key routing (SQL-level). -----
+	// `quantile_over_time(...) by (k8s_namespace_name)` resolves the inner
+	// range-aggregation group key through levelAwareRangeGroupKey, which
+	// AFTER routes to the bare materialized column (BEFORE reads the Map).
+	// A non-k8s selector isolates the by-key routing from the matcher path.
+	// The aggregation's top-level output is a rebuilt ResourceAttributes
+	// Map, which chDB-go's parquet driver cannot drain — so the twin is
+	// proven at the SQL level: BEFORE reads the Map for the group key,
+	// AFTER the materialized column, and the rest of the plan is identical.
+	groupBy := `quantile_over_time(0.9, {service_name="svc-1"} | unwrap bytes [5m]) by (k8s_namespace_name)`
+	gbBeforeSQL, _ := emitLogQL(t, groupBy, before)
+	gbAfterSQL, _ := emitLogQL(t, groupBy, after)
+	if !containsSub(gbAfterSQL, matK8sNamespaceColumn) {
+		t.Fatalf("AFTER group-by emit did not route by-key to materialized column: %s", gbAfterSQL)
+	}
+	if containsSub(gbBeforeSQL, materializedColumnMarker) {
+		t.Fatalf("BEFORE group-by emit unexpectedly referenced a materialized column: %s", gbBeforeSQL)
+	}
+	t.Logf("group-by twin OK: AFTER routes inner-range by-key to materialized column, BEFORE stays on Map")
+
+	// --- (2) BYTE-READ: per-column on-disk bytes. ------------------------
+	mapComp, mapUncomp := columnBytes(t, db, matK8sTable, "ResourceAttributes")
+	colComp, colUncomp := columnBytes(t, db, matK8sTable, matK8sNamespaceColumn)
+	t.Logf("ResourceAttributes Map : %d B compressed / %d B uncompressed", mapComp, mapUncomp)
+	t.Logf("materialized namespace : %d B compressed / %d B uncompressed", colComp, colUncomp)
+	if colComp == 0 {
+		t.Fatalf("materialized column reported 0 compressed bytes — not physically written?")
+	}
+	ratioComp := float64(mapComp) / float64(colComp)
+	ratioUncomp := float64(mapUncomp) / float64(colUncomp)
+	t.Logf("byte-read reduction: %.1fx compressed / %.1fx uncompressed (floor %.1fx)",
+		ratioComp, ratioUncomp, matK8sByteRatioFloor)
+	if ratioComp < matK8sByteRatioFloor {
+		t.Fatalf("compressed byte-read ratio %.2fx below floor %.2fx — lever not paying off",
+			ratioComp, matK8sByteRatioFloor)
+	}
+}
+
+// columnBytes reads the on-disk compressed/uncompressed bytes for a single
+// column from system.parts_columns (active parts only) — the disk bytes
+// ClickHouse must read+decompress when a predicate touches that column.
+func columnBytes(t *testing.T, db *sql.DB, table, column string) (compressed, uncompressed int64) {
+	t.Helper()
+	row := db.QueryRow(
+		`SELECT sum(column_data_compressed_bytes), sum(column_data_uncompressed_bytes)
+         FROM system.parts_columns
+         WHERE table = ? AND column = ? AND active`, table, column,
+	)
+	if err := row.Scan(&compressed, &uncompressed); err != nil {
+		t.Fatalf("columnBytes(%s.%s): %v", table, column, err)
+	}
+	return compressed, uncompressed
+}
+
+// chdbEOFSentinel is the benign end-of-iteration error chdb-go's parquet
+// reader returns in place of a clean io.EOF (parquet.go:
+// `return fmt.Errorf("empty row")`). Mirrors test/spec/runner_chdb.go's
+// tolerantRowsErr.
+const chdbEOFSentinel = "empty row"
+
+func tolerantChdbErr(err error) error {
+	if err != nil && containsSub(err.Error(), chdbEOFSentinel) {
+		return nil
+	}
+	return err
+}
+
+func containsSub(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}
+
+func rowsEqual(a, b [][]any) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if len(a[i]) != len(b[i]) {
+			return false
+		}
+		for j := range a[i] {
+			if fmt.Sprintf("%v", a[i][j]) != fmt.Sprintf("%v", b[i][j]) {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/test/spec/logql/matcher_k8s_namespace_materialized.txtar
+++ b/test/spec/logql/matcher_k8s_namespace_materialized.txtar
@@ -1,0 +1,50 @@
+-- query.logql --
+{k8s_namespace_name="ns-3"}
+-- seed --
+-- The exporter MATERIALIZEs `ResourceAttributes['k8s.namespace.name']`
+-- into the dedicated `__otel_materialized_k8s.namespace.name`
+-- LowCardinality column. cerberus routes the `{k8s_namespace_name=...}`
+-- stream-selector matcher to that bare column instead of decompressing
+-- the wide ResourceAttributes Map. This fixture proves the substitution
+-- is byte-for-byte result-equivalent.
+--
+-- Both columns are MATERIALIZED off Body (one Body value encodes each
+-- storage shape), so the runner's `SELECT *` returns just the two
+-- inserted columns — sidestepping the chdb-go Parquet driver's panic on
+-- Map column scans while leaving what the matcher predicate evaluates
+-- against unchanged. The materialized column's MATERIALIZED expression
+-- is LITERALLY `ResourceAttributes['k8s.namespace.name']`, so col-read
+-- and map-read agree on every row by construction — including the
+-- missing-key row where both yield ''.
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    ResourceAttributes Map(String, String) MATERIALIZED multiIf(
+        Body = 'dotted-ns3', map('k8s.namespace.name', 'ns-3'),
+        Body = 'dotted-ns3-extra', map('k8s.namespace.name', 'ns-3', 'k8s.pod.name', 'p1'),
+        Body = 'other-ns', map('k8s.namespace.name', 'ns-9'),
+        Body = 'no-key', CAST(map() AS Map(String, String)),
+        CAST(map() AS Map(String, String))
+    ),
+    `__otel_materialized_k8s.namespace.name` LowCardinality(String) MATERIALIZED ResourceAttributes['k8s.namespace.name']
+) ENGINE = Memory;
+-- Two matching rows (value in the dotted map key the materialized
+-- column mirrors), one non-matching namespace, one missing-key row
+-- (both sides resolve to '' → must NOT match "ns-3").
+INSERT INTO otel_logs (Timestamp, Body) VALUES
+    (toDateTime64('2026-05-20 12:00:00.000000000', 9), 'dotted-ns3'),
+    (toDateTime64('2026-05-20 12:01:00.000000000', 9), 'dotted-ns3-extra'),
+    (toDateTime64('2026-05-20 12:02:00.000000000', 9), 'other-ns'),
+    (toDateTime64('2026-05-20 12:03:00.000000000', 9), 'no-key');
+-- expected_rows --
+[
+  ["2026-05-20T12:00:00Z", "dotted-ns3"],
+  ["2026-05-20T12:01:00Z", "dotted-ns3-extra"]
+]
+-- args --
+[0] string = "ns-3"
+-- chplan --
+Filter predicate=(__otel_materialized_k8s.namespace.name = "ns-3")
+  Scan(otel_logs)
+-- sql --
+SELECT * FROM `otel_logs` WHERE (`__otel_materialized_k8s.namespace.name` = ?)


### PR DESCRIPTION
## What

Routes LogQL `k8s.*` (+ `deployment.environment.name`) stream-selector matchers and inner range-aggregation group-by keys to the 8 exporter-shipped `__otel_materialized_*` `LowCardinality(String)` columns on `otel_logs`, instead of decompressing the wide `ResourceAttributes` `Map`. Pure LogQL emit change (`chplan.ColumnRef`) — no schema / exporter / migration change, fully BWC.

## Why it's safe (measured)

- **Col-read ≡ map-read by construction:** the pinned exporter DDL (`v0.0.3-cerberus-ddl` `logs_table.sql`) defines each column as `LowCardinality(String) MATERIALIZED ResourceAttributes['<key>']`, including the empty-string default for a missing key.
- **Zero `-- expected_rows -- ` churn:** no existing fixture uses these keys, so the change is inert on the existing corpus; the chDB roundtrip lane (`TestRoundTripChDB`, 163 subtests + the new `matcher_k8s_namespace_materialized` fixture) passes on real chDB — the no-key row resolves `''` on both sides and is correctly excluded from `{k8s_namespace_name="ns-3"}`.
- Dotted-name hazard refuted: `Builder.Ident` backtick-wraps the whole key as one identifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
