### PR TITLE
fix(e2e): close Playwright typecheck gate hole; fix latent never-narrow in time-ranges spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,10 +172,29 @@ jobs:
       # pull_request events: base.sha..head.sha, i.e. the commits
       # unique to the PR head. `fetch-depth: 0` on the checkout above
       # guarantees both SHAs exist locally.
+      # Shared by commitlint (pull_request only) and the Playwright
+      # typecheck below (every event) — set up unconditionally so both
+      # consumers find a Node toolchain.
       - uses: actions/setup-node@v6
-        if: github.event_name == 'pull_request'
         with:
           node-version: '20'
+          cache: npm
+          cache-dependency-path: test/e2e/playwright/package-lock.json
+
+      # The Playwright e2e specs run via Playwright's transpile-only
+      # esbuild loader, which strips types and NEVER type-checks. A
+      # latent TS error (e.g. a self-referential `as typeof x` cast that
+      # collapsed an error-envelope to `never` in
+      # iterate-time-ranges.spec.ts) therefore compiled green and the
+      # required compose-smoke gate stayed green over it. This step
+      # closes that hole: `tsc --noEmit` over the whole playwright
+      # tsconfig, no browser, sub-second. Fast enough to live in the
+      # lint job rather than gate behind the compose stack.
+      - name: typecheck e2e Playwright specs
+        working-directory: test/e2e/playwright
+        run: |
+          npm ci
+          npx --no -- tsc --noEmit -p tsconfig.json
 
       - name: commitlint
         if: github.event_name == 'pull_request'

--- a/test/e2e/playwright/iterate-time-ranges.spec.ts
+++ b/test/e2e/playwright/iterate-time-ranges.spec.ts
@@ -180,6 +180,27 @@ type PromQueryRangeResponse = {
 };
 
 /**
+ * Prometheus error-envelope shape (the subset we read) returned on a
+ * non-2xx `/api/v1/query_range` — `status: "error"` with an
+ * `errorType` + human `error` message. Used to assert the pinned
+ * 422 memory-limit rejection (errorType=execution + MEMORY_LIMIT_MESSAGE)
+ * byte-for-byte. Named (rather than inlined at the cast site) because a
+ * self-referential `JSON.parse(body) as typeof parsed` cast resolves
+ * `typeof parsed` to the variable's control-flow-narrowed type at the
+ * assignment — `null` there, since the only prior write is `= null` —
+ * which collapses the parsed value to `null` and makes every downstream
+ * `parsed?.status === …` comparison narrow to `never` (TS2339). The
+ * specs run via Playwright's transpile-only esbuild loader, so that
+ * latent error never surfaces at runtime; a named cast target keeps the
+ * type honest under the typecheck gate.
+ */
+type PromErrorEnvelope = {
+  status?: string;
+  errorType?: string;
+  error?: string;
+};
+
+/**
  * Lift a Prometheus `/api/v1/query_range` response into the
  * `DsQueryResponse` shape the assertion helpers consume. Mirrors the
  * lift in `iterate-panel-shape.spec.ts` and
@@ -402,13 +423,9 @@ test('time-ranges: every aggregating / histogram panel re-asserts under (range, 
         // which tuples took the rejection branch.
         if (resp.status() === 422) {
           const body = await resp.text().catch(() => '<unreadable>');
-          let parsed: {
-            status?: string;
-            errorType?: string;
-            error?: string;
-          } | null = null;
+          let parsed: PromErrorEnvelope | null = null;
           try {
-            parsed = JSON.parse(body) as typeof parsed;
+            parsed = JSON.parse(body) as PromErrorEnvelope;
           } catch {
             parsed = null;
           }


### PR DESCRIPTION
## The weirdness

A sibling change surfaced **3 pre-existing TypeScript errors** in `test/e2e/playwright/iterate-time-ranges.spec.ts` at L416–418:

```
L416 TS2339 Property 'status' does not exist on type 'never'
L417 TS2339 Property 'errorType' does not exist on type 'never'
L418 TS2339 Property 'error' does not exist on type 'never'
```

…yet CI was **green** and `compose-smoke` (which executes these specs) passed. Type errors + green CI ⇒ a typecheck gate hole.

## Phase 1 — investigation

### What was `never`-typed, and why

The 422 memory-limit branch parses the response body like this:

```ts
let parsed: { status?: string; errorType?: string; error?: string } | null = null;
try {
  parsed = JSON.parse(body) as typeof parsed;   // ← the bug
} catch {
  parsed = null;
}
if (parsed?.status === 'error' && parsed?.errorType === 'execution' && parsed?.error === MEMORY_LIMIT_MESSAGE) { … }
```

The root cause is the **self-referential `as typeof parsed` cast**. `typeof parsed` resolves to the variable's *control-flow-narrowed* type **at the assignment site** — and the only prior write to `parsed` is `= null` at its declaration, so `typeof parsed` is `null` there. `JSON.parse(body) as null` collapses `parsed` to `null`; the subsequent optional-chain comparisons (`parsed?.status === 'error'`) then narrow it to `never`, and reading `.status/.errorType/.error` off `never` is the TS2339.

Minimal repro confirmed it: swapping `typeof parsed` for a named type (identical shape) flips tsc from 3 errors to 0. The self-reference is the whole bug.

### Was the assertion VACUOUS / dead?  → **No (at runtime).**

This is the important finding. The block is TS-*dead* (TS believes `parsed` is `null`, so the `if` can never be true at the type level) but **fully live at runtime**. Playwright executes specs through its transpile-only esbuild loader — types are *stripped*, never enforced — so at runtime JavaScript reads the real parsed object: a matching 422 envelope takes the pinned-contract branch, any other 422 / garbage body falls through to a hard failure. Verified by simulating the exact JS:

```
matching 422 → MEMORY_LIMIT_BRANCH
other 422     → FAILURE_BRANCH
garbage body  → FAILURE_BRANCH
```

So there is **no user-visible test hole today** — the assertion does meaningfully check. The hazard is latent: the type was a lie, nothing guarded it, and a future refactor of this block could silently break under TS's wrong belief with zero gate to catch it.

### The gate hole — confirmed

- **Transpile-only Playwright.** Specs run via `npx playwright test` (esbuild loader). No type checking at runtime.
- **No `tsc` step anywhere.** Grepped `.github/workflows/*.yml`, `.github/scripts/`, the `Justfile`, and `package.json` scripts — **zero** `tsc` / `--noEmit` / typecheck invocations. Nothing ever type-checks the Playwright project.

### Full-project tsc scope

`tsc --noEmit -p test/e2e/playwright/tsconfig.json` over the **entire** Playwright project (all 28 specs + helpers + crawl) reports exactly these **3 errors in 1 file** — no other latent errors. Scope is **small**, so this PR fixes them all *and* wires the gate (rather than deferring it as a follow-up).

## Phase 2 — fix

1. **Root fix (no masking).** Extracted a named `PromErrorEnvelope` type and cast `JSON.parse(body) as PromErrorEnvelope`. Runtime behavior is byte-identical (same shape, same comparisons); the type is now honest. No `as any` / `@ts-ignore` / `as never` — those would have *hidden* the latent error instead of fixing it.
2. **Gate added.** New `typecheck e2e Playwright specs` step in the existing `lint` job: `npm ci` + `tsc --noEmit -p tsconfig.json`. Browser-free, sub-second, so it lives in `lint` rather than gating behind the compose stack. The shared `setup-node` is now unconditional (commitlint keeps its own `pull_request` guard) with npm caching keyed on the playwright lockfile. **The gate is green** — full-project tsc passes after the fix, verified locally via the exact `npm ci` + `tsc` the step runs. actionlint clean.

## Posture

Leaving this **OPEN and un-armed** — it changes CI structure (new required-adjacent gate in `lint`) and test semantics (cast shape), so the maintainer should review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)