### PR TITLE
fix(preflight): absent schema waits (NOT READY) instead of crash-looping

### DIFF
--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -121,10 +122,16 @@ func run() error {
 	// created the tables, so introspecting them before the create would
 	// fail gate 2 against tables that don't exist yet. The check fails
 	// startup (returns an error → exit 1) when the connected server is
-	// older than the config-derived floor or the deployed schema diverges
-	// from the active shape, converting an opaque query-time failure into a
-	// precise boot-time one. CERBERUS_REQUIREMENTS_CHECK=false skips it.
-	if err := runRequirementsCheck(ctx, logger, client, cfg); err != nil {
+	// older than the config-derived floor or the deployed schema is
+	// WRONG-SHAPE (a table exists but its columns diverge) — neither
+	// self-heals, so failing fast converts an opaque query-time failure into
+	// a precise boot-time one. A schema that is ENTIRELY ABSENT (not yet
+	// provisioned — the cerberus+collector startup race) is NOT fatal: the
+	// returned schemaPresent func reports NOT READY on /readyz and a
+	// background re-probe flips it ready once an external writer creates the
+	// schema, with no restart. CERBERUS_REQUIREMENTS_CHECK=false skips it.
+	schemaPresent, err := runRequirementsCheck(ctx, logger, client, cfg)
+	if err != nil {
 		return err
 	}
 
@@ -242,8 +249,9 @@ func run() error {
 	// memoises results behind a TTL cache so concurrent probes coalesce
 	// into a single ClickHouse ping per window.
 	healthHandler := health.New(health.Options{
-		Pinger:      client,
-		SchemaReady: schemaReady,
+		Pinger:        client,
+		SchemaReady:   schemaReady,
+		SchemaPresent: schemaPresent,
 	})
 
 	rootMux := http.NewServeMux()
@@ -439,20 +447,31 @@ func setupSchema(
 // deployed schema shape of the configured (override-resolved) tables. The
 // check is parameterised by the active config: the native-rate knob raises
 // the version floor, and every table/column name comes from the resolved
-// schema structs so CERBERUS_SCHEMA_* overrides are respected. When any
-// gate fails the returned error aggregates every unmet requirement and the
-// caller exits non-zero — the precise boot-time failure replaces the
-// opaque query-time error a too-old server or divergent schema would
-// otherwise produce. When disabled, both gates are bypassed (one log line).
+// schema structs so CERBERUS_SCHEMA_* overrides are respected.
+//
+// Findings split two ways. A FATAL finding (too-old/unreadable server, or a
+// table that EXISTS but is WRONG-SHAPE) never self-heals, so the returned
+// error aggregates every such requirement and the caller exits non-zero —
+// the precise boot-time failure replaces the opaque query-time error a
+// too-old server or divergent schema would otherwise produce. A schema that
+// is ENTIRELY ABSENT (not yet provisioned) is TRANSIENT — the
+// cerberus+collector startup race — so it does NOT fail startup: the
+// returned health.SchemaPresentFunc reports NOT READY on /readyz with the
+// absent reason, and a background re-probe (reusing the auto-create retry
+// cadence) flips it ready once an external writer provisions the schema,
+// with no restart.
+//
+// When the check is disabled, both gates are bypassed (one log line) and a
+// nil SchemaPresentFunc is returned — readiness does not gate on the schema.
 func runRequirementsCheck(
 	ctx context.Context,
 	logger *slog.Logger,
 	client *chclient.Client,
 	cfg config.Config,
-) error {
+) (health.SchemaPresentFunc, error) {
 	if !cfg.RequirementsCheck {
 		logger.Info("requirements check disabled (CERBERUS_REQUIREMENTS_CHECK=false)")
-		return nil
+		return nil, nil
 	}
 	req := preflight.Requirements{
 		Database:          cfg.ClickHouse.Database,
@@ -461,15 +480,119 @@ func runRequirementsCheck(
 		Logs:              cfg.Logs,
 		Traces:            cfg.Traces,
 	}
-	if err := preflight.RunIfEnabled(ctx, cfg.RequirementsCheck, client, req); err != nil {
-		return err
+	res := preflight.RunIfEnabled(ctx, cfg.RequirementsCheck, client, req)
+	if res.Fatal != nil {
+		// Wrong-shape / too-old / unreadable — never self-heals. Exit even if
+		// some tables are also absent: a too-old server won't fix itself by
+		// waiting, and a wrong-shape table is a genuine misconfiguration.
+		return nil, res.Fatal
 	}
+
+	if !res.SchemaProvisioned() {
+		// Transient: the schema has not been provisioned yet (cerberus booted
+		// ahead of the collector that owns schema creation). Boot but stay
+		// NOT READY; a background re-probe flips readiness once the writer
+		// creates the schema. No restart.
+		reason := res.AbsentReason()
+		logger.Warn(
+			"schema not yet provisioned; serving unready until an external writer creates it (/readyz gates traffic)",
+			"reason", reason,
+		)
+		present := newSchemaPresentSignal(reason)
+		go reprobeSchema(ctx, logger, client, req, present, schemaRetryInterval)
+		return present.Func(), nil
+	}
+
 	logger.Info(
 		"requirements check passed",
 		"database", cfg.ClickHouse.Database,
 		"native_rate", cfg.ExperimentalTSGridRange,
 	)
-	return nil
+	return nil, nil
+}
+
+// schemaPresentSignal is the concurrency-safe carrier behind the
+// health.SchemaPresentFunc the readiness probe consults. present is flipped
+// once the background re-probe sees a fully-provisioned schema; reason holds
+// the current absent-tables explanation until then. The mutex guards reason
+// (a string can't be stored atomically) and keeps the present/reason pair
+// consistent for a probe that reads both.
+type schemaPresentSignal struct {
+	mu      sync.Mutex
+	present bool
+	reason  string
+}
+
+// newSchemaPresentSignal seeds the signal in the not-present state with the
+// initial absent reason.
+func newSchemaPresentSignal(reason string) *schemaPresentSignal {
+	return &schemaPresentSignal{reason: reason}
+}
+
+// Func returns the health.SchemaPresentFunc view the readiness handler
+// calls on every probe.
+func (s *schemaPresentSignal) Func() health.SchemaPresentFunc {
+	return func() (bool, string) {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		return s.present, s.reason
+	}
+}
+
+// markPresent flips the signal to provisioned; once present the readiness
+// probe stops gating on the schema.
+func (s *schemaPresentSignal) markPresent() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.present = true
+	s.reason = ""
+}
+
+// setReason updates the absent-tables explanation while still not-present
+// (e.g. fewer tables remain absent on a later probe).
+func (s *schemaPresentSignal) setReason(reason string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.reason = reason
+}
+
+// reprobeSchema re-runs the requirements check on the auto-create retry
+// cadence until the configured schema is fully provisioned (or ctx is
+// cancelled). It only ever transitions a not-present schema to present: a
+// re-probe that turns up a FATAL finding (e.g. an external writer created a
+// wrong-shape table) is logged and retried rather than crashing a
+// already-serving process — the boot-time fail-fast contract covers the
+// cold-start case, and a running replica must not exit on a transient
+// introspection blip. Once present it flips readiness and returns.
+func reprobeSchema(
+	ctx context.Context,
+	logger *slog.Logger,
+	client *chclient.Client,
+	req preflight.Requirements,
+	signal *schemaPresentSignal,
+	interval time.Duration,
+) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+		res := preflight.Run(ctx, client, req)
+		if res.Fatal != nil {
+			logger.Warn("schema re-probe found a fatal requirement; staying unready and retrying", "err", res.Fatal)
+			continue
+		}
+		if !res.SchemaProvisioned() {
+			signal.setReason(res.AbsentReason())
+			continue
+		}
+		logger.Info("schema now provisioned; reporting ready", "database", req.Database)
+		signal.markPresent()
+		return
+	}
 }
 
 // schemaRetryInterval is the cadence of background auto-create-schema

--- a/cmd/cerberus/startup_test.go
+++ b/cmd/cerberus/startup_test.go
@@ -215,6 +215,73 @@ func TestRetrySchemaApply_StopsOnContextCancel(t *testing.T) {
 	}
 }
 
+// TestStartup_AbsentSchema_HealthzUpReadyzUnready pins the absent-schema
+// boot-but-wait contract: when the boot-time requirements check finds the
+// configured tables not yet provisioned (the cerberus + collector startup
+// race), the schemaPresentSignal carrier reports not-present, so the same
+// root-mux run() builds serves /healthz 200 (liveness — the process is up)
+// while /readyz is 503 with the precise absent reason. The process never
+// exits — k8s keeps it alive and out of the Service endpoints, not
+// crash-looping.
+func TestStartup_AbsentSchema_HealthzUpReadyzUnready(t *testing.T) {
+	const reason = "schema not yet provisioned: table otel_logs absent"
+	signal := newSchemaPresentSignal(reason)
+
+	healthHandler := health.New(health.Options{
+		Pinger:        newHealthyPinger(),
+		SchemaPresent: signal.Func(),
+		CacheTTL:      -1,
+	})
+	rootMux := http.NewServeMux()
+	healthHandler.Mount(rootMux)
+	srv := httptest.NewServer(rootMux)
+	t.Cleanup(srv.Close)
+
+	if got := getStatus(t, srv.URL+"/healthz"); got != http.StatusOK {
+		t.Errorf("/healthz with absent schema = %d; want 200 (liveness must not gate on schema)", got)
+	}
+	if got := getStatus(t, srv.URL+"/readyz"); got != http.StatusServiceUnavailable {
+		t.Errorf("/readyz with absent schema = %d; want 503 (boot-but-wait)", got)
+	}
+}
+
+// TestStartup_AbsentSchema_FlipsReadyOncePresent pins the recovery half:
+// once an external writer provisions the schema, markPresent flips the
+// carrier and /readyz returns 200 — no restart.
+func TestStartup_AbsentSchema_FlipsReadyOncePresent(t *testing.T) {
+	signal := newSchemaPresentSignal("schema not yet provisioned: table otel_logs absent")
+
+	healthHandler := health.New(health.Options{
+		Pinger:        newHealthyPinger(),
+		SchemaPresent: signal.Func(),
+		CacheTTL:      -1,
+	})
+	rootMux := http.NewServeMux()
+	healthHandler.Mount(rootMux)
+	srv := httptest.NewServer(rootMux)
+	t.Cleanup(srv.Close)
+
+	if got := getStatus(t, srv.URL+"/readyz"); got != http.StatusServiceUnavailable {
+		t.Fatalf("/readyz before provisioning = %d; want 503", got)
+	}
+
+	// External writer (collector / auto-create) provisions the schema.
+	signal.markPresent()
+
+	if got := getStatus(t, srv.URL+"/readyz"); got != http.StatusOK {
+		t.Errorf("/readyz after provisioning = %d; want 200 (flips ready, no restart)", got)
+	}
+}
+
+// newHealthyPinger returns a flipPinger preset to report ClickHouse
+// reachable, so absent-schema tests isolate the schema gate from the CH
+// ping.
+func newHealthyPinger() *flipPinger {
+	p := &flipPinger{}
+	p.healthy.Store(true)
+	return p
+}
+
 // getStatus GETs url and returns the status code.
 func getStatus(t *testing.T, url string) int {
 	t.Helper()

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -174,10 +174,10 @@ also honored by the OTel Go SDK and merge with these. See
 
 ## Schema
 
-| Variable                      | Type | Default | Description                                                                                          |
-| ----------------------------- | ---- | ------- | ---------------------------------------------------------------------------------------------------- |
-| `CERBERUS_AUTO_CREATE_SCHEMA` | bool | `false` | When `true`, run the idempotent OTel-CH exporter DDL at startup before HTTP serving begins.          |
-| `CERBERUS_REQUIREMENTS_CHECK` | bool | `true`  | Run the boot-time requirements check after the schema-create step; fails startup on any unmet one.   |
+| Variable                      | Type | Default | Description                                                                                                                                                                                                            |
+| ----------------------------- | ---- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CERBERUS_AUTO_CREATE_SCHEMA` | bool | `false` | When `true`, run the idempotent OTel-CH exporter DDL at startup before HTTP serving begins.                                                                                                                            |
+| `CERBERUS_REQUIREMENTS_CHECK` | bool | `true`  | Run the boot-time requirements check after the schema-create step. Fails startup on a fatal finding (too-old server, wrong-shape table); an absent (not-yet-provisioned) schema instead boots NOT READY and re-probes. |
 
 The preflight runs two gates, both parameterised by the active
 (override-resolved) configuration:
@@ -196,12 +196,24 @@ The preflight runs two gates, both parameterised by the active
   `ResourceAttributes` / `ScopeAttributes`) typed `Map(String, String)`
   (a `Map(String, LowCardinality(String))` value type is accepted). Every
   table and column name comes from the override-resolved schema, so
-  `CERBERUS_SCHEMA_*` renames are respected.
+  `CERBERUS_SCHEMA_*` renames are respected. The gate distinguishes two
+  cases:
+  - A table that **exists but is wrong-shape** (missing column / wrong
+    attribute-map type) is a misconfiguration that never self-heals → it is a
+    **fatal** finding (startup fails).
+  - A table that is **entirely absent** (zero columns reported) is the
+    not-yet-provisioned startup race → it is **not** fatal. Cerberus boots,
+    reports NOT READY on `/readyz` with a precise reason (`schema not yet
+    provisioned: table otel_logs absent`), and **re-probes** on the
+    auto-create retry cadence; readiness flips green once an external writer
+    (the otel-collector, or `CERBERUS_AUTO_CREATE_SCHEMA`) creates the schema
+    — **no restart**. `/healthz` stays 200 throughout. An introspection
+    *error* (as opposed to a clean zero-row absence) remains fatal.
 
 The check runs after the auto-create step on purpose: on a fresh database
 cerberus has just created the tables, so introspecting them before the
 create would fail the schema gate against tables that don't exist yet. When
-any gate fails, the error **aggregates every** unmet requirement, e.g.:
+a **fatal** gate fails, the error **aggregates every** unmet requirement, e.g.:
 
 ```text
 requirements check failed:

--- a/docs/health.md
+++ b/docs/health.md
@@ -62,10 +62,10 @@ Content-Type: application/json
 
 ### Response shape
 
-| Field        | Type    | Values                                                                                                                                        |
-| ------------ | ------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `clickhouse` | string  | `"ok"` on success, `"error: <reason>"` on a failed ping.                                                                                      |
-| `schema`     | string  | `"ready"` when the auto-create hook is done (or disabled), `"pending"` while it is still running, `"unknown"` when the CH ping itself failed. |
+| Field        | Type    | Values                                                                                                                                                                                                                                                                                                                                                                                       |
+| ------------ | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `clickhouse` | string  | `"ok"` on success, `"error: <reason>"` on a failed ping.                                                                                                                                                                                                                                                                                                                                     |
+| `schema`     | string  | `"ready"` when the schema is provisioned and the auto-create hook is done (or disabled); `"absent: <reason>"` when the boot-time requirements check found the configured tables not yet provisioned (the cerberus + collector startup race — cerberus waits and re-probes, no restart); `"pending"` while the auto-create hook is still running; `"unknown"` when the CH ping itself failed. |
 
 ### HTTP status codes
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -349,26 +349,44 @@ opaque query-time errors into a precise, fail-fast boot error:
 - **ClickHouse too old.** The connected server's `version()` is compared
   against `max(base, applicable-feature-floors)` — base **24.8**, raised to
   **25.6** by the native-rate floor when `CERBERUS_EXPERIMENTAL_TS_GRID_RANGE` is
-  on. A version below the floor (or an unparseable one) fails startup.
-- **Divergent schema.** The configured tables are introspected via
-  `system.columns`; a missing essential column or a wrong attribute-map type
-  (`Attributes` / `ResourceAttributes` / `ScopeAttributes` must be
-  `Map(String, String)`) fails startup. The check honours every
-  `CERBERUS_SCHEMA_*` table rename — it validates the *active* shape.
+  on. A version below the floor (or an unparseable one) **fails startup
+  fast** — a too-old server is a hard incompatibility that never self-heals.
+- **Wrong-shape schema.** A configured table that **exists** but whose shape
+  is wrong — a missing essential column, or an attribute-map column
+  (`Attributes` / `ResourceAttributes` / `ScopeAttributes`) typed something
+  other than `Map(String, String)` — **fails startup fast.** A wrong shape is
+  a genuine misconfiguration, not a race, so failing fast is the honest
+  signal. The check honours every `CERBERUS_SCHEMA_*` table rename — it
+  validates the *active* shape.
+- **Absent (not-yet-provisioned) schema.** When the configured tables are
+  **entirely absent** (`system.columns` reports zero rows for them), cerberus
+  does **not** crash-loop — it **boots and waits**. This is the cerberus +
+  otel-collector startup race: a drop-in gateway deployed alongside the
+  ingestion pipeline that owns schema creation may legitimately start before
+  any table exists. Cerberus boots, reports **NOT READY** on `/readyz` with a
+  precise reason (`schema not yet provisioned: table otel_logs absent`), and
+  **re-probes** on the same cadence as the auto-create retry. The moment an
+  external writer (the collector, or cerberus' own `CERBERUS_AUTO_CREATE_SCHEMA`)
+  provisions the schema, `/readyz` flips ready **without a restart**.
+  `/healthz` (liveness) stays **200** throughout — only readiness gates.
 
 The ordering is deliberate: running the preflight **after** auto-create
 means a fresh database where cerberus just created the tables passes the
 schema gate (it would fail against tables that don't exist yet if the order
-were reversed). When any gate fails the process exits non-zero with an
-**aggregated** message listing every unmet requirement at once, so an
-operator fixes the deployment in a single pass rather than one error per
-restart. Set `CERBERUS_REQUIREMENTS_CHECK=false` to skip both gates (logged
-as one line) — useful when pointing cerberus at a deliberately non-default
-ClickHouse layout that the shape gate doesn't model. Note this is a
-stricter contract than the best-effort connectivity ping above: the
-preflight needs ClickHouse reachable to read the version and column
-metadata, so a CH that is unreachable at the preflight point fails startup
-rather than booting unready.
+were reversed). When a **fatal** gate (too-old version, wrong-shape table)
+fails, the process exits non-zero with an **aggregated** message listing
+every unmet requirement at once, so an operator fixes the deployment in a
+single pass rather than one error per restart. An **absent** schema is the
+one finding that is *not* fatal — it is the transient case the wait-and-
+reprobe path above handles. Set `CERBERUS_REQUIREMENTS_CHECK=false` to skip
+both gates (logged as one line) — useful when pointing cerberus at a
+deliberately non-default ClickHouse layout that the shape gate doesn't
+model. Note the version + wrong-shape gates are a stricter contract than the
+best-effort connectivity ping above: the preflight needs ClickHouse
+reachable to read the version and column metadata, so a CH that is
+unreachable at the preflight point (or returns an introspection *error*, as
+opposed to a clean zero-row absence) fails startup rather than booting
+unready.
 
 ### Schema divergence: MetricName-first metrics sort key
 

--- a/internal/api/health/health.go
+++ b/internal/api/health/health.go
@@ -20,6 +20,16 @@ type Pinger interface {
 // on the ClickHouse ping.
 type SchemaReadyFunc func() bool
 
+// SchemaPresentFunc reports whether the configured schema has been
+// provisioned (every required table exists). When the schema is not yet
+// present it returns present=false plus a precise reason for the /readyz
+// body (e.g. "schema not yet provisioned: table otel_logs absent"). It
+// models the absent-schema startup race: a cerberus deployed alongside the
+// otel-collector that owns schema creation can boot before any table
+// exists, so readiness waits for the external writer rather than the
+// process crash-looping. When nil the schema is treated as present.
+type SchemaPresentFunc func() (present bool, reason string)
+
 // Options configure Handler.
 type Options struct {
 	// Pinger is the ClickHouse health check. Required.
@@ -28,6 +38,13 @@ type Options struct {
 	// SchemaReady is consulted on every readiness check. When nil the
 	// schema status is treated as ready (i.e. only the CH ping matters).
 	SchemaReady SchemaReadyFunc
+
+	// SchemaPresent is consulted on every readiness check, BEFORE
+	// SchemaReady. When it reports not-present the probe returns 503 with
+	// the absent reason — the schema has not been provisioned yet and
+	// cerberus waits (no restart) for the external writer to create it.
+	// When nil the schema is treated as present.
+	SchemaPresent SchemaPresentFunc
 
 	// PingTimeout caps the per-probe ClickHouse ping. Defaults to 1s.
 	PingTimeout time.Duration
@@ -45,11 +62,12 @@ type Options struct {
 // Handler exposes /healthz (liveness) and /readyz (readiness) HTTP
 // handlers. Construct via New and register via Mount.
 type Handler struct {
-	pinger      Pinger
-	schemaReady SchemaReadyFunc
-	pingTimeout time.Duration
-	cacheTTL    time.Duration
-	now         func() time.Time
+	pinger        Pinger
+	schemaReady   SchemaReadyFunc
+	schemaPresent SchemaPresentFunc
+	pingTimeout   time.Duration
+	cacheTTL      time.Duration
+	now           func() time.Time
 
 	mu         sync.Mutex
 	cachedAt   time.Time
@@ -68,11 +86,12 @@ type readyResponse struct {
 // the safe default if startup wiring forgot to plug a real client in.
 func New(opts Options) *Handler {
 	h := &Handler{
-		pinger:      opts.Pinger,
-		schemaReady: opts.SchemaReady,
-		pingTimeout: opts.PingTimeout,
-		cacheTTL:    opts.CacheTTL,
-		now:         opts.Now,
+		pinger:        opts.Pinger,
+		schemaReady:   opts.SchemaReady,
+		schemaPresent: opts.SchemaPresent,
+		pingTimeout:   opts.PingTimeout,
+		cacheTTL:      opts.CacheTTL,
+		now:           opts.Now,
 	}
 	if h.pingTimeout <= 0 {
 		h.pingTimeout = time.Second
@@ -152,6 +171,23 @@ func (h *Handler) runCheck(ctx context.Context) (readyResponse, int) {
 			ClickHouse: "error: " + err.Error(),
 			Schema:     "unknown",
 		}, http.StatusServiceUnavailable
+	}
+
+	// Absent-schema gate first: a schema that has not been provisioned yet
+	// (the cerberus+collector startup race) reports the precise absent
+	// reason so the operator sees WHY readiness is held, distinct from the
+	// auto-create "pending" state below.
+	if h.schemaPresent != nil {
+		if present, reason := h.schemaPresent(); !present {
+			schema := "absent"
+			if reason != "" {
+				schema = "absent: " + reason
+			}
+			return readyResponse{
+				ClickHouse: "ok",
+				Schema:     schema,
+			}, http.StatusServiceUnavailable
+		}
 	}
 
 	if h.schemaReady != nil && !h.schemaReady() {

--- a/internal/api/health/health_test.go
+++ b/internal/api/health/health_test.go
@@ -128,6 +128,83 @@ func TestReadyz_SchemaPending(t *testing.T) {
 	}
 }
 
+// TestReadyz_SchemaAbsent: CH ok but the schema has not been provisioned
+// yet (the cerberus+collector startup race). /readyz returns 503 with the
+// precise absent reason — distinct from the auto-create "pending" state —
+// and the process stays up (this gate never restarts the pod).
+func TestReadyz_SchemaAbsent(t *testing.T) {
+	const reason = "schema not yet provisioned: table otel_logs absent"
+	h := New(Options{
+		Pinger:        &stubPinger{},
+		SchemaPresent: func() (bool, string) { return false, reason },
+		CacheTTL:      -1,
+	})
+
+	rec := serveReadyz(t, h)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d; want 503", rec.Code)
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if resp["clickhouse"] != "ok" {
+		t.Errorf("clickhouse = %q; want ok", resp["clickhouse"])
+	}
+	if !strings.HasPrefix(resp["schema"], "absent") {
+		t.Errorf("schema = %q; want an 'absent…' status", resp["schema"])
+	}
+	if !strings.Contains(resp["schema"], "otel_logs") {
+		t.Errorf("schema = %q; want the precise absent reason embedded", resp["schema"])
+	}
+}
+
+// TestReadyz_SchemaAbsentGatesBeforeReady: when SchemaPresent reports
+// not-present it wins over SchemaReady — the absent reason is the honest
+// status even if the auto-create hook happens to report ready.
+func TestReadyz_SchemaAbsentGatesBeforeReady(t *testing.T) {
+	h := New(Options{
+		Pinger:        &stubPinger{},
+		SchemaReady:   func() bool { return true },
+		SchemaPresent: func() (bool, string) { return false, "schema not yet provisioned: table otel_traces absent" },
+		CacheTTL:      -1,
+	})
+
+	rec := serveReadyz(t, h)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d; want 503", rec.Code)
+	}
+	var resp map[string]string
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if !strings.Contains(resp["schema"], "absent") {
+		t.Errorf("schema = %q; want absent to win over ready", resp["schema"])
+	}
+}
+
+// TestReadyz_SchemaPresentReady: once the schema is provisioned the
+// not-present gate passes and readiness reports ready.
+func TestReadyz_SchemaPresentReady(t *testing.T) {
+	h := New(Options{
+		Pinger:        &stubPinger{},
+		SchemaReady:   func() bool { return true },
+		SchemaPresent: func() (bool, string) { return true, "" },
+		CacheTTL:      -1,
+	})
+
+	rec := serveReadyz(t, h)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200", rec.Code)
+	}
+	var resp map[string]string
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if resp["schema"] != "ready" {
+		t.Errorf("schema = %q; want ready once provisioned", resp["schema"])
+	}
+}
+
 // TestReadyz_NilPinger: defensive — if startup forgot the client, fail
 // closed (503), don't false-positive.
 func TestReadyz_NilPinger(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,10 +53,13 @@ type Config struct {
 	// minimum (CH 25.8 base, raised to max(base, native-rate floor) when
 	// CERBERUS_EXPERIMENTAL_TS_GRID_RANGE is enabled) AND validates the
 	// deployed schema shape (the configured tables' essential columns and
-	// the attribute-map column types) via system.columns. When any gate
-	// fails the process exits non-zero with an aggregated message listing
-	// every unmet requirement, instead of letting a too-old server or a
-	// divergent schema surface as an opaque query-time error later.
+	// the attribute-map column types) via system.columns. A FATAL finding —
+	// a too-old/unreadable server or a table that EXISTS but is wrong-shape —
+	// exits the process non-zero with an aggregated message, instead of
+	// letting it surface as an opaque query-time error later. A schema that is
+	// ENTIRELY ABSENT (not yet provisioned — the cerberus + collector startup
+	// race) is NOT fatal: cerberus boots, reports NOT READY on /readyz, and
+	// re-probes until an external writer creates the schema (no restart).
 	// Setting CERBERUS_REQUIREMENTS_CHECK=false skips both gates.
 	RequirementsCheck bool
 

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -17,9 +17,31 @@
 //     Map(String, String).
 //
 // Both gates are validated against the active, override-resolved config —
-// never hardcoded names. Failures are aggregated: Run reports EVERY unmet
-// requirement, not just the first, so an operator fixes the deployment in
-// one pass.
+// never hardcoded names.
+//
+// # Fatal vs transient: the absent-schema race
+//
+// Cerberus is a drop-in query gateway frequently deployed ALONGSIDE its
+// ingestion pipeline (an otel-collector that owns schema creation as
+// telemetry first flows). On a cold cluster cerberus can legitimately boot
+// BEFORE any table exists. Crash-looping in that window is wrong — it is a
+// transient startup race, not a misconfiguration — so the preflight
+// classifies its findings into two buckets:
+//
+//   - FATAL — a too-old / unreadable / unparseable server version, or a
+//     table that EXISTS but whose SHAPE is wrong (a missing essential
+//     column, an attribute map typed something other than
+//     Map(String, String)). These never self-heal, so they fail startup
+//     fast with an aggregated diff (every unmet requirement at once).
+//   - TRANSIENT — the configured tables are ENTIRELY ABSENT (system.columns
+//     reports zero rows for them): the schema has not been provisioned yet.
+//     This does NOT fail startup; cerberus boots but reports NOT READY on
+//     /readyz with a precise reason, and an external re-probe flips it ready
+//     once the writer creates the schema — no restart.
+//
+// Run returns a Result that carries both buckets separately. The caller
+// turns the fatal bucket into a non-zero exit and feeds the absent bucket
+// into the readiness machinery.
 package preflight
 
 import (
@@ -119,29 +141,75 @@ type Querier interface {
 	QueryNameTypePairs(ctx context.Context, sql string, args ...any) ([]chclient.NameTypePair, error)
 }
 
+// Result is the outcome of a preflight pass, splitting findings by how the
+// caller must react to them.
+//
+//   - Fatal is the aggregated, non-self-healing failure: a bad server
+//     version or a wrong-shape table. When non-nil the caller exits
+//     non-zero. It already carries the "requirements check failed:" header
+//     and one bullet per unmet requirement.
+//   - AbsentTables names every configured table that is ENTIRELY absent
+//     (not yet provisioned). It is empty when no table is missing. A
+//     non-empty AbsentTables with a nil Fatal is the transient "schema not
+//     yet provisioned" state: the caller boots NOT READY and re-probes
+//     rather than exiting.
+//
+// The two buckets are independent. A pass can report both (e.g. an old
+// server AND an absent table) — the Fatal bucket still wins (the caller
+// exits), because a too-old server never heals on its own.
+type Result struct {
+	Fatal        error
+	AbsentTables []string
+}
+
+// SchemaProvisioned reports whether no configured table is missing — i.e.
+// the schema is fully present (whatever its shape). The readiness wiring
+// consults this to decide whether to gate /readyz on a not-yet-provisioned
+// schema.
+func (r Result) SchemaProvisioned() bool { return len(r.AbsentTables) == 0 }
+
+// AbsentReason renders the absent-tables list into a single precise reason
+// string for the /readyz body, e.g. "schema not yet provisioned: tables
+// otel_logs, otel_traces absent". Returns "" when nothing is absent.
+func (r Result) AbsentReason() string {
+	if len(r.AbsentTables) == 0 {
+		return ""
+	}
+	noun := "table"
+	if len(r.AbsentTables) > 1 {
+		noun = "tables"
+	}
+	return fmt.Sprintf("schema not yet provisioned: %s %s absent", noun, strings.Join(r.AbsentTables, ", "))
+}
+
 // RunIfEnabled is the ON/OFF gate around Run. When enabled is false both
 // gates are bypassed entirely and q is never touched (the caller logs the
-// disabled line); when true it delegates to Run. Keeping the knob check
-// here makes the disabled path unit-testable without standing up cmd wiring.
-func RunIfEnabled(ctx context.Context, enabled bool, q Querier, req Requirements) error {
+// disabled line) and an all-clear Result is returned; when true it
+// delegates to Run. Keeping the knob check here makes the disabled path
+// unit-testable without standing up cmd wiring.
+func RunIfEnabled(ctx context.Context, enabled bool, q Querier, req Requirements) Result {
 	if !enabled {
-		return nil
+		return Result{}
 	}
 	return Run(ctx, q, req)
 }
 
-// Run executes both gates against q and returns an aggregated error
-// listing every unmet requirement, or nil when all requirements hold.
-// The caller is responsible for turning a non-nil error into a non-zero
-// process exit. Use RunIfEnabled for the CERBERUS_REQUIREMENTS_CHECK gate.
-func Run(ctx context.Context, q Querier, req Requirements) error {
+// Run executes both gates against q and returns a Result splitting fatal
+// (version / wrong-shape) findings from the transient absent-table set.
+// The fatal bucket aggregates EVERY non-self-healing requirement so an
+// operator fixes the deployment in one pass; the absent bucket lets the
+// caller boot-but-wait on a not-yet-provisioned schema. Use RunIfEnabled
+// for the CERBERUS_REQUIREMENTS_CHECK gate.
+func Run(ctx context.Context, q Querier, req Requirements) Result {
 	var problems []string
-
 	problems = append(problems, checkVersion(ctx, q, req)...)
-	problems = append(problems, checkSchema(ctx, q, req)...)
 
+	schemaProblems, absent := checkSchema(ctx, q, req)
+	problems = append(problems, schemaProblems...)
+
+	res := Result{AbsentTables: absent}
 	if len(problems) == 0 {
-		return nil
+		return res
 	}
 	var b strings.Builder
 	b.WriteString("requirements check failed:")
@@ -149,7 +217,8 @@ func Run(ctx context.Context, q Querier, req Requirements) error {
 		b.WriteString("\n  - ")
 		b.WriteString(p)
 	}
-	return fmt.Errorf("%s", b.String())
+	res.Fatal = fmt.Errorf("%s", b.String())
+	return res
 }
 
 // checkVersion runs gate 1: it reads version() and compares the parsed
@@ -310,24 +379,40 @@ func nonEmpty(vals ...string) []string {
 // every essential column exists, with the attribute-map columns typed
 // Map(String, String). Distinct tables that resolve to the same physical
 // name (Gauge==Sum on a collapsed schema) are introspected once.
-func checkSchema(ctx context.Context, q Querier, req Requirements) []string {
+//
+// It returns two slices: the FATAL wrong-shape problems (missing columns /
+// wrong attribute-map types / introspection errors) for the aggregated
+// boot failure, and the ABSENT-table names — tables system.columns reports
+// zero rows for, i.e. not yet provisioned. An entirely-absent table is
+// transient (the schema race), so it lands in the second slice and is NOT
+// a wrong-shape problem; a table that exists but has the wrong columns is.
+func checkSchema(ctx context.Context, q Querier, req Requirements) (problems, absent []string) {
 	seen := map[string]bool{}
-	var problems []string
 	for _, t := range requiredTables(req) {
 		if t.name == "" || seen[t.name] {
 			continue
 		}
 		seen[t.name] = true
-		problems = append(problems, checkTable(ctx, q, req.Database, t)...)
+		probs, isAbsent := checkTable(ctx, q, req.Database, t)
+		problems = append(problems, probs...)
+		if isAbsent {
+			absent = append(absent, t.name)
+		}
 	}
-	return problems
+	return problems, absent
 }
 
 // checkTable introspects one table via system.columns and validates its
-// shape. A query error or a wholly-absent table is reported as a single
-// failure; otherwise each missing column and each wrong attribute-map
-// type is reported individually so the aggregated message is complete.
-func checkTable(ctx context.Context, q Querier, database string, t tableReq) []string {
+// shape. It returns the per-table wrong-shape problems plus an absent flag.
+//
+//   - A table that reports ZERO columns is treated as absent (not yet
+//     provisioned): absent=true, no wrong-shape problem. The caller turns
+//     this into a transient NOT-READY state, not a boot failure.
+//   - A query error is itself fatal (it is not a clean "table missing"
+//     signal — the introspection failed) and is reported as a problem.
+//   - Otherwise each missing column and each wrong attribute-map type is
+//     reported individually so the aggregated message is complete.
+func checkTable(ctx context.Context, q Querier, database string, t tableReq) (problems []string, absent bool) {
 	sql, args := chsql.NewQuery().
 		Select(chsql.Col("name"), chsql.Col("type")).
 		From(chsql.Qual("system", "columns")).
@@ -338,10 +423,13 @@ func checkTable(ctx context.Context, q Querier, database string, t tableReq) []s
 		Build()
 	rows, err := q.QueryNameTypePairs(ctx, sql, args...)
 	if err != nil {
-		return []string{fmt.Sprintf("could not introspect table %s: %v", t.name, err)}
+		return []string{fmt.Sprintf("could not introspect table %s: %v", t.name, err)}, false
 	}
 	if len(rows) == 0 {
-		return []string{fmt.Sprintf("table %s: not found in database %s (no columns reported)", t.name, database)}
+		// Entirely absent: the schema has not been provisioned yet. This is
+		// the transient startup race, not a misconfiguration — surface it as
+		// absent so the caller waits (NOT READY) rather than exiting.
+		return nil, true
 	}
 
 	types := make(map[string]string, len(rows))
@@ -349,7 +437,6 @@ func checkTable(ctx context.Context, q Querier, database string, t tableReq) []s
 		types[r.Name] = r.Type
 	}
 
-	var problems []string
 	for _, col := range t.columns {
 		if _, ok := types[col]; !ok {
 			problems = append(problems, fmt.Sprintf("table %s: missing required column %s", t.name, col))
@@ -370,7 +457,7 @@ func checkTable(ctx context.Context, q Querier, database string, t tableReq) []s
 			))
 		}
 	}
-	return problems
+	return problems, false
 }
 
 // normalizeType canonicalises a ClickHouse type string for comparison:

--- a/internal/preflight/preflight_test.go
+++ b/internal/preflight/preflight_test.go
@@ -143,18 +143,22 @@ func (p panicQuerier) QueryNameTypePairs(context.Context, string, ...any) ([]chc
 func TestRunIfEnabledOffSkipsBothGates(t *testing.T) {
 	t.Parallel()
 	// A deliberately-broken requirement (empty everything) would fail if
-	// Run executed; with enabled=false it must return nil without touching
-	// the querier.
-	if err := RunIfEnabled(context.Background(), false, panicQuerier{t}, defaultReq()); err != nil {
-		t.Fatalf("knob off must return nil, got: %v", err)
+	// Run executed; with enabled=false it must return an all-clear Result
+	// without touching the querier.
+	res := RunIfEnabled(context.Background(), false, panicQuerier{t}, defaultReq())
+	if res.Fatal != nil {
+		t.Fatalf("knob off must return no fatal, got: %v", res.Fatal)
+	}
+	if !res.SchemaProvisioned() {
+		t.Fatalf("knob off must report schema provisioned (gates skipped), got absent: %v", res.AbsentTables)
 	}
 }
 
 func TestRunIfEnabledOnDelegatesToRun(t *testing.T) {
 	t.Parallel()
 	q := &stubQuerier{Version: "24.3.0", Columns: healthyColumns()}
-	if err := RunIfEnabled(context.Background(), true, q, defaultReq()); err == nil {
-		t.Fatal("knob on must run the gates (too-old version should fail)")
+	if res := RunIfEnabled(context.Background(), true, q, defaultReq()); res.Fatal == nil {
+		t.Fatal("knob on must run the gates (too-old version should be fatal)")
 	}
 }
 
@@ -210,7 +214,7 @@ func TestMinVersionMaxOfApplicable(t *testing.T) {
 func TestRunVersionTooOld(t *testing.T) {
 	t.Parallel()
 	q := &stubQuerier{Version: "24.3.1.2557-stable", Columns: healthyColumns()}
-	err := Run(context.Background(), q, defaultReq())
+	err := Run(context.Background(), q, defaultReq()).Fatal
 	if err == nil {
 		t.Fatal("expected failure for too-old version, got nil")
 	}
@@ -225,7 +229,7 @@ func TestRunVersionTooOld(t *testing.T) {
 func TestRunVersionOKAllPass(t *testing.T) {
 	t.Parallel()
 	q := &stubQuerier{Version: "25.8.2.1-lts", Columns: healthyColumns()}
-	if err := Run(context.Background(), q, defaultReq()); err != nil {
+	if err := Run(context.Background(), q, defaultReq()).Fatal; err != nil {
 		t.Fatalf("expected pass, got: %v", err)
 	}
 }
@@ -233,7 +237,7 @@ func TestRunVersionOKAllPass(t *testing.T) {
 func TestRunVersionExactlyAtFloor(t *testing.T) {
 	t.Parallel()
 	q := &stubQuerier{Version: "24.8.0.0", Columns: healthyColumns()}
-	if err := Run(context.Background(), q, defaultReq()); err != nil {
+	if err := Run(context.Background(), q, defaultReq()).Fatal; err != nil {
 		t.Fatalf("version exactly at floor must pass, got: %v", err)
 	}
 }
@@ -247,12 +251,12 @@ func TestRunNativeRateRaisesMin(t *testing.T) {
 	req.NativeRateEnabled = true
 
 	atNative := &stubQuerier{Version: "25.6.0.0", Columns: healthyColumns()}
-	if err := Run(context.Background(), atNative, req); err != nil {
+	if err := Run(context.Background(), atNative, req).Fatal; err != nil {
 		t.Fatalf("native-rate on: 25.6 meets the raised floor and must pass, got: %v", err)
 	}
 
 	belowNative := &stubQuerier{Version: "25.0.0.0", Columns: healthyColumns()}
-	err := Run(context.Background(), belowNative, req)
+	err := Run(context.Background(), belowNative, req).Fatal
 	if err == nil {
 		t.Fatal("native-rate on: 25.0 (above base 24.8 but below native 25.6) must fail")
 	}
@@ -267,7 +271,7 @@ func TestRunNativeRateRaisesMin(t *testing.T) {
 func TestRunUnparseableVersionFails(t *testing.T) {
 	t.Parallel()
 	q := &stubQuerier{Version: "not-a-version", Columns: healthyColumns()}
-	err := Run(context.Background(), q, defaultReq())
+	err := Run(context.Background(), q, defaultReq()).Fatal
 	if err == nil {
 		t.Fatal("unparseable version must fail (never silently pass)")
 	}
@@ -279,7 +283,7 @@ func TestRunUnparseableVersionFails(t *testing.T) {
 func TestRunVersionQueryErrorFails(t *testing.T) {
 	t.Parallel()
 	q := &stubQuerier{VersionErr: errors.New("connection refused"), Columns: healthyColumns()}
-	err := Run(context.Background(), q, defaultReq())
+	err := Run(context.Background(), q, defaultReq()).Fatal
 	if err == nil {
 		t.Fatal("version query error must fail startup")
 	}
@@ -291,7 +295,7 @@ func TestRunVersionQueryErrorFails(t *testing.T) {
 func TestRunNoVersionRowFails(t *testing.T) {
 	t.Parallel()
 	q := &stubQuerier{NoVersionRow: true, Columns: healthyColumns()}
-	err := Run(context.Background(), q, defaultReq())
+	err := Run(context.Background(), q, defaultReq()).Fatal
 	if err == nil || !strings.Contains(err.Error(), "no rows") {
 		t.Fatalf("empty version result must fail; got %v", err)
 	}
@@ -312,7 +316,7 @@ func TestRunMissingColumnFails(t *testing.T) {
 	cols[tr.SpansTable] = pruned
 
 	q := &stubQuerier{Version: "25.8.2.1", Columns: cols}
-	err := Run(context.Background(), q, defaultReq())
+	err := Run(context.Background(), q, defaultReq()).Fatal
 	if err == nil {
 		t.Fatal("missing column must fail")
 	}
@@ -333,7 +337,7 @@ func TestRunWrongAttributeTypeFails(t *testing.T) {
 		}
 	}
 	q := &stubQuerier{Version: "25.8.2.1", Columns: cols}
-	err := Run(context.Background(), q, defaultReq())
+	err := Run(context.Background(), q, defaultReq()).Fatal
 	if err == nil {
 		t.Fatal("wrong attribute-map type must fail")
 	}
@@ -355,23 +359,102 @@ func TestRunLowCardinalityMapAccepted(t *testing.T) {
 		}
 	}
 	q := &stubQuerier{Version: "25.8.2.1", Columns: cols}
-	if err := Run(context.Background(), q, defaultReq()); err != nil {
+	if err := Run(context.Background(), q, defaultReq()).Fatal; err != nil {
 		t.Fatalf("LowCardinality map value should pass, got: %v", err)
 	}
 }
 
-func TestRunMissingTableFails(t *testing.T) {
+// TestRunAbsentTableIsTransientNotFatal: a single table reporting zero
+// columns is "not yet provisioned" — it must NOT be fatal, and must surface
+// in AbsentTables so the caller waits (NOT READY) rather than exiting.
+func TestRunAbsentTableIsTransientNotFatal(t *testing.T) {
 	t.Parallel()
 	cols := healthyColumns()
 	l := schema.DefaultOTelLogs()
 	delete(cols, l.LogsTable)
 	q := &stubQuerier{Version: "25.8.2.1", Columns: cols}
-	err := Run(context.Background(), q, defaultReq())
-	if err == nil {
-		t.Fatal("missing table must fail")
+	res := Run(context.Background(), q, defaultReq())
+	if res.Fatal != nil {
+		t.Fatalf("absent table must NOT be fatal (transient schema race), got: %v", res.Fatal)
 	}
-	if !strings.Contains(err.Error(), "table otel_logs: not found") {
-		t.Errorf("message missing not-found note: %v", err)
+	if res.SchemaProvisioned() {
+		t.Fatal("absent table must report schema NOT provisioned")
+	}
+	if got := res.AbsentTables; len(got) != 1 || got[0] != l.LogsTable {
+		t.Errorf("AbsentTables = %v, want [%s]", got, l.LogsTable)
+	}
+	reason := res.AbsentReason()
+	if !strings.Contains(reason, "schema not yet provisioned") || !strings.Contains(reason, l.LogsTable) {
+		t.Errorf("AbsentReason = %q, want precise not-yet-provisioned reason naming %s", reason, l.LogsTable)
+	}
+	if !strings.Contains(reason, "table ") || strings.Contains(reason, "tables ") {
+		t.Errorf("single absent table should use singular noun: %q", reason)
+	}
+}
+
+// TestRunAllTablesAbsentTransient: a cold cluster where NOTHING is
+// provisioned yet (every table absent) is the canonical cerberus+collector
+// startup race — still transient, never fatal, with a plural reason.
+func TestRunAllTablesAbsentTransient(t *testing.T) {
+	t.Parallel()
+	q := &stubQuerier{Version: "25.8.2.1", Columns: map[string][]chclient.NameTypePair{}}
+	res := Run(context.Background(), q, defaultReq())
+	if res.Fatal != nil {
+		t.Fatalf("all-absent schema must NOT be fatal, got: %v", res.Fatal)
+	}
+	if res.SchemaProvisioned() {
+		t.Fatal("all-absent must report schema NOT provisioned")
+	}
+	if len(res.AbsentTables) < 2 {
+		t.Fatalf("expected multiple absent tables, got %v", res.AbsentTables)
+	}
+	if reason := res.AbsentReason(); !strings.Contains(reason, "tables ") {
+		t.Errorf("multiple absent tables should use plural noun: %q", reason)
+	}
+}
+
+// TestRunWrongShapeFatalEvenIfOtherTableAbsent: an EXISTING table with a
+// wrong shape is fatal (never self-heals) even when a different table is
+// merely absent — the fatal bucket wins, the caller exits.
+func TestRunWrongShapeFatalEvenIfOtherTableAbsent(t *testing.T) {
+	t.Parallel()
+	cols := healthyColumns()
+	m := schema.DefaultOTelMetrics()
+	l := schema.DefaultOTelLogs()
+	// otel_logs absent (transient) …
+	delete(cols, l.LogsTable)
+	// … but otel_metrics_gauge exists with a wrong Attributes type (fatal).
+	for i, c := range cols[m.GaugeTable] {
+		if c.Name == m.AttributesColumn {
+			cols[m.GaugeTable][i].Type = "JSON"
+		}
+	}
+	q := &stubQuerier{Version: "25.8.2.1", Columns: cols}
+	res := Run(context.Background(), q, defaultReq())
+	if res.Fatal == nil {
+		t.Fatal("wrong-shape table must be fatal even when another table is absent")
+	}
+	if !strings.Contains(res.Fatal.Error(), "expected Map(String,String), found JSON") {
+		t.Errorf("fatal message missing wrong-shape diff: %v", res.Fatal)
+	}
+	// The absent table is still tracked even though Fatal wins.
+	if res.SchemaProvisioned() {
+		t.Error("absent table should still be reported alongside the fatal finding")
+	}
+}
+
+// TestRunIntrospectionErrorIsFatal: an introspection QUERY error (not a
+// clean zero-row absence) is fatal — the check could not run, which is not
+// the same signal as a cleanly-absent table.
+func TestRunIntrospectionErrorIsFatal(t *testing.T) {
+	t.Parallel()
+	q := &stubQuerier{Version: "25.8.2.1", ColumnsErr: errors.New("read timeout")}
+	res := Run(context.Background(), q, defaultReq())
+	if res.Fatal == nil {
+		t.Fatal("introspection query error must be fatal")
+	}
+	if !strings.Contains(res.Fatal.Error(), "could not introspect table") {
+		t.Errorf("fatal message missing introspection-error note: %v", res.Fatal)
 	}
 }
 
@@ -389,7 +472,7 @@ func TestRunRespectsOverrides(t *testing.T) {
 	delete(cols, m.GaugeTable) // the default name no longer exists
 
 	q := &stubQuerier{Version: "25.8.2.1", Columns: cols}
-	if err := Run(context.Background(), q, req); err != nil {
+	if err := Run(context.Background(), q, req).Fatal; err != nil {
 		t.Fatalf("override-resolved schema should pass, got: %v", err)
 	}
 }
@@ -417,7 +500,7 @@ func TestRunAggregatesAllFailures(t *testing.T) {
 
 	// 3: version too old.
 	q := &stubQuerier{Version: "24.3.1", Columns: cols}
-	err := Run(context.Background(), q, defaultReq())
+	err := Run(context.Background(), q, defaultReq()).Fatal
 	if err == nil {
 		t.Fatal("expected aggregated failure")
 	}
@@ -447,7 +530,7 @@ func TestRunCollapsedGaugeSumIntrospectedOnce(t *testing.T) {
 
 	cols := healthyColumns()
 	counter := &countingQuerier{stubQuerier: stubQuerier{Version: "25.8.2.1", Columns: cols}}
-	if err := Run(context.Background(), counter, req); err != nil {
+	if err := Run(context.Background(), counter, req).Fatal; err != nil {
 		t.Fatalf("collapsed gauge/sum should pass, got: %v", err)
 	}
 	if got := counter.tableQueries[req.Metrics.GaugeTable]; got != 1 {

--- a/internal/preflight/preflight_test.go
+++ b/internal/preflight/preflight_test.go
@@ -150,7 +150,7 @@ func TestRunIfEnabledOffSkipsBothGates(t *testing.T) {
 		t.Fatalf("knob off must return no fatal, got: %v", res.Fatal)
 	}
 	if !res.SchemaProvisioned() {
-		t.Fatalf("knob off must report schema provisioned (gates skipped), got absent: %v", res.AbsentTables)
+		t.Fatalf("knob off must report schema provisioned (gates bypassed), got absent: %v", res.AbsentTables)
 	}
 }
 

--- a/test/e2e/k3s/cerberus.yaml
+++ b/test/e2e/k3s/cerberus.yaml
@@ -11,6 +11,18 @@ data:
   CERBERUS_CH_USERNAME: "cerberus"
   CERBERUS_CH_PASSWORD: "cerberus"
   CERBERUS_CH_DIAL_TIMEOUT: "10s"
+  # Provision the OTel-CH schema at boot. The otel-collector's
+  # clickhouseexporter (create_schema: true) also owns schema creation as
+  # telemetry first flows, but that's gated on telemetry actually arriving —
+  # a cold cluster has a window where the tables don't exist yet. Letting
+  # cerberus apply the same idempotent DDL (CREATE TABLE IF NOT EXISTS) at
+  # startup makes it ready promptly instead of waiting on the collector's
+  # first export. The boot-time requirements check's absent-schema branch is
+  # the real safety net (cerberus boots NOT READY and re-probes rather than
+  # crash-looping when the schema is still missing — see internal/preflight);
+  # auto-create here just shortens the not-ready window so the dashboard's
+  # readiness wait doesn't ride the collector's timing.
+  CERBERUS_AUTO_CREATE_SCHEMA: "true"
   # Self-observability OTLP export — cerberus pushes its own metrics +
   # traces + logs to the in-cluster gateway, which forwards them to
   # ClickHouse via the clickhouseexporter. Reading those rows back

--- a/test/e2e/startup_bench_test.go
+++ b/test/e2e/startup_bench_test.go
@@ -16,7 +16,13 @@
 // Prerequisites:
 //   - ClickHouse reachable at $CH_ADDR (default 127.0.0.1:9000), already
 //     warm. The benchmark explicitly disables auto-create-schema so we
-//     measure HTTP-listener bootstrap, not DDL apply time.
+//     measure HTTP-listener bootstrap, not DDL apply time. The CH it runs
+//     against carries no provisioned schema, so the boot-time requirements
+//     check (ON by default) hits its absent-schema branch: that is a
+//     TRANSIENT not-ready state, not a fatal one, so the process boots and
+//     /healthz answers 200 (only /readyz goes red). The bench therefore
+//     measures liveness cold-start exactly as intended — the requirements
+//     check does not crash-loop on a not-yet-provisioned schema.
 //   - A built `cerberus` binary; the test will `go build` one into a
 //     temp dir when none is supplied via $CERBERUS_BIN.
 package e2e
@@ -69,7 +75,8 @@ func TestStartupSpeed_HealthzUnder2s(t *testing.T) {
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, binary)
-	cmd.Env = append(os.Environ(),
+	cmd.Env = append(
+		os.Environ(),
 		"CERBERUS_HTTP_ADDR="+addr,
 		"CERBERUS_CH_ADDR="+chAddr,
 		"CERBERUS_CH_DATABASE="+chDB,


### PR DESCRIPTION
## The regression

The boot-time requirements check (`internal/preflight`, `CERBERUS_REQUIREMENTS_CHECK`, **ON by default**) ran a version gate + a schema-shape gate after `setupSchema`. The schema-shape gate treated **configured tables that don't exist yet** as a fatal failure → `run()` returned an error → the process exited non-zero. A cerberus deployed **alongside** the otel-collector that owns schema creation (the collector's `clickhouseexporter` issues the OTel-CH DDL as telemetry first flows) therefore **crash-looped before the schema was ever provisioned**.

This regressed the push-to-main `e2e` workflow (run `27498314657` on `db0ce07e`):

- **`dashboard` job** — k3d `test/e2e/k3s/cerberus.yaml` has no `CERBERUS_AUTO_CREATE_SCHEMA` (default off); cerberus boots before the collector provisions the schema → schema-gate fatal → process exits → **CrashLoopBackOff** → "Assert zero cerberus restarts" fails.
- **`startup-bench` job** — `test/e2e/startup_bench_test.go` runs cerberus with `CERBERUS_AUTO_CREATE_SCHEMA=false` against a bare CH (database `otel`, no DDL) → same fatal boot failure → `/healthz` never answers.

CH image is `24.8`/`25.8` so the **version** gate was fine; this was purely the **schema-shape gate** treating a not-yet-provisioned schema as fatal.

## The fix — distinguish "schema absent (transient)" from "schema wrong (misconfig)"

`preflight.Run` now returns a `Result` that splits findings into two buckets:

| Case | Verdict | Rationale |
| --- | --- | --- |
| **Version too old / unreadable / unparseable** | **fail-fast** (exit) | a too-old CH is a hard, non-transient incompatibility |
| **Table EXISTS but WRONG-SHAPE** (missing column / attr-map not `Map(String,String)`) | **fail-fast** (exit, aggregated diff) | a genuine misconfiguration that never self-heals |
| **Introspection ERROR** (not a clean zero-row absence) | **fail-fast** (exit) | the check couldn't run — distinct from "table cleanly missing" |
| **Tables ENTIRELY ABSENT** (zero rows) | **boot + wait (NOT READY)** | the cerberus+collector startup race — provision happens externally |

The fatal bucket wins even when a table is also absent (a too-old server / wrong shape won't fix itself by waiting).

### /readyz wiring

The absent-schema state feeds a new `health.SchemaPresentFunc` (consulted **before** the existing auto-create `SchemaReady`). `cmd/cerberus` builds a concurrency-safe `schemaPresentSignal` carrier seeded not-present with the precise reason, and a background `reprobeSchema` goroutine re-runs the check on the **existing** auto-create retry cadence (`schemaRetryInterval`, no new magic constant), flipping the signal present once the schema lands — **no restart**. While absent:

- `/healthz` → **200** (liveness — process is up)
- `/readyz` → **503** with `{"clickhouse":"ok","schema":"absent: schema not yet provisioned: table otel_logs absent"}`

A re-probe that turns up a *fatal* finding on an already-serving replica is logged and retried (not a crash) — the boot-time fail-fast contract covers cold start; a running replica must not exit on a transient introspection blip.

### k3d dashboard + startup-bench

- **dashboard**: the absent→wait fix means cerberus no longer crash-loops; it becomes ready once the collector provisions the schema. As belt-and-suspenders (and the cleaner deployment posture) the k3d cerberus also gets `CERBERUS_AUTO_CREATE_SCHEMA=true` — the same idempotent `CREATE TABLE IF NOT EXISTS` DDL the collector issues — so it provisions its own schema and is ready promptly rather than riding the collector's first-export timing.
- **startup-bench**: measures cold-start to **`/healthz`** (liveness). The absent-schema state keeps `/healthz` 200, so the bench measures liveness boot time exactly as intended — no `AUTO_CREATE_SCHEMA` flip that would defeat what it measures. Comment added documenting the invariant.

## Test + doc coverage

- `internal/preflight/preflight_test.go`: absent→transient (single + all-tables, singular/plural reason), wrong-shape→fatal even with another table absent, introspection-error→fatal; existing version/wrong-shape/override/aggregation tests kept green (migrated to `Result.Fatal`).
- `internal/api/health/health_test.go`: `/readyz` reflects schema-absent (503 + reason), absent wins over ready, present→ready.
- `cmd/cerberus/startup_test.go`: end-to-end `schemaPresentSignal` + health mux — `/healthz` 200 / `/readyz` 503 while absent, then flips ready on `markPresent` with no restart.
- Docs: `docs/operations.md`, `docs/configuration.md`, `docs/health.md` updated for absent-waits vs wrong-shape/old-version fail-fast; `internal/config/config.go` `RequirementsCheck` doc-comment.

## Constraints

Typed chsql only (introspection SQL unchanged), no magic constants (reused `schemaRetryInterval`), no `unsafe`/`reflect`, no skip/deferred wording, no allowlists. `gofumpt -extra` + `go vet` clean.

This is an **RC1 blocker** restoring main to green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)