### PR TITLE
docs: pre-RC1 documentation audit — alignment, links, stale-vs-landed, timeless

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,15 @@ in.
 
 | Component            | Minimum                        | Notes                                                                                                                               |
 | -------------------- | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
-| ClickHouse           | **24.8**                       | The supported floor — proven by the differential compatibility suite. Enabling the experimental native rate requires 25.6 (below).  |
+| ClickHouse           | **24.8**                       | The supported floor — the SQL cerberus emits is correct down to it. Enabling the experimental native rate requires 25.6 (below).    |
 | OTel exporter schema | **clickhouseexporter 0.152.0** | A **schema shape**, not a binary version — see below.                                                                               |
 
-**ClickHouse.** The floor is the version cerberus is proven against end-to-end:
-the three differential compatibility harnesses — the source of truth for all
-three heads — run ClickHouse 24.8, so every emitted query is validated against
-it (the 24.8 empty-input / parse-unit / filter-path quirks are all worked around
-unconditionally). Enabling the experimental native-rate path
+**ClickHouse.** 24.8 is the lowest version cerberus's emitted SQL is correct on:
+the 24.8 empty-input / parse-unit / filter-path quirks are all worked around
+unconditionally, so a query that runs on 24.8 runs on every newer server too.
+The differential compatibility harnesses — the source of truth for all three
+heads — execute on ClickHouse 25.8, so the validated SQL is exercised forward of
+the floor as well. Enabling the experimental native-rate path
 (`CERBERUS_EXPERIMENTAL_TS_GRID_RANGE`, **default off**) **raises** the floor to
 **25.6**: it lowers eligible `rate(<counter>[range])` range queries to the
 compiled `timeSeriesRateToGrid` aggregate, which exists only from ClickHouse

--- a/cmd/bench-report/render_chdb.go
+++ b/cmd/bench-report/render_chdb.go
@@ -570,11 +570,12 @@ func renderScaling(b *strings.Builder, in docInput) error {
 			c.Points[0].FanRatio, c.Points[len(c.Points)-1].FanRatio)
 	}
 
-	b.WriteString("> **Note.** The `setop_chain` wall is a documented residual super-linearity: ")
-	b.WriteString("each `or` level re-scans the accumulated relation, so the *wall* tracks the ")
-	b.WriteString("parameter even though the *cardinality* axis stays flat. It is a tracked ")
-	b.WriteString("finding (the fix is an N-ary single-pass flatten); the scaling harness still ")
-	b.WriteString("hard-gates the cardinality axis, which is the one that bounds memory.\n\n")
+	b.WriteString("> **Note.** The `setop_chain` curve runs through the optimizer, so the ")
+	b.WriteString("`FlattenVectorSetOp` rule collapses the left-assoc `a or b or c …` nesting into ")
+	b.WriteString("one N-ary `UNION ALL` under a single window pass — the chain is one scan, not K ")
+	b.WriteString("nested window passes, so **both** the wall and the cardinality axis are flat in ")
+	b.WriteString("chain depth and the harness hard-gates both. (`unless` is not associative, so an ")
+	b.WriteString("`unless` chain keeps its binary nesting by construction.)\n\n")
 	return nil
 }
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -153,10 +153,10 @@ See `compatibility/loki/README.md` for the full mechanism.
 Cerberus's deliberate rejections — the HTTP 422 "valid query, but the
 lowering refuses it" paths in `internal/{promql,logql,traceql}` — are
 claims about reference behaviour: "the reference backend cannot answer
-this either". Historically nothing verified those claims
-differentially, which is how `kind != nil` ended up rejected by
-cerberus while reference Tempo accepts it. The rejection-parity layer
-closes that gap:
+this either". The rejection-parity layer verifies those claims
+differentially, so a query cerberus rejects but the reference accepts
+(the `kind != nil` class, which reference Tempo answers) surfaces as a
+real bug rather than a silent wrong-rejection:
 
 1. **Catalogue** — `test/rejection-parity/catalogue.json` is the
    machine-readable inventory of every prefixed error-construction
@@ -190,8 +190,8 @@ closes that gap:
    Reports land at `compatibility/prometheus/rejection-parity.json`,
    `compatibility/loki/reports/rejection-parity.json`, and
    `compatibility/tempo/reports/rejection-parity.json`. Like the main
-   testers (task #68), the driver is report-only: verdicts never
-   change the exit code; only infrastructure failures do.
+   testers, the driver is report-only: verdicts never change the exit
+   code; only infrastructure failures do.
 
 ## CI integration
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -184,8 +184,9 @@ The preflight runs two gates, both parameterised by the active
 
 - **Version gate.** `SELECT version()` is compared against
   `max(base, applicable-feature-floors)`. The base floor is **ClickHouse
-  24.8** (the supported floor — the differential compatibility suite runs
-  24.8 and is green). Enabling `CERBERUS_EXPERIMENTAL_TS_GRID_RANGE` adds the
+  24.8** — the minimum cerberus supports, with the 24.8 empty-input /
+  parse-unit / filter-path emit workarounds shipped unconditionally so the
+  SQL is correct on it. Enabling `CERBERUS_EXPERIMENTAL_TS_GRID_RANGE` adds the
   native-rate floor (CH 25.6); the effective requirement is the maximum, so
   the flag **raises** the floor from 24.8 to 25.6, and a future feature floor
   raises it further. An unreadable or unparseable version is a failure, never
@@ -245,9 +246,9 @@ take route B; everything else stays byte-identical on route A.
 `CERBERUS_EXPERIMENTAL_TS_GRID_RANGE` **requires ClickHouse ≥ 25.6** — the
 `timeSeries*ToGrid` family was introduced in CH v25.6.0; on any older server a
 native-path query errors with `UNKNOWN_FUNCTION`, so the flag **must stay off**
-unless the target ClickHouse is ≥ 25.6 (the compose / e2e lanes run 25.8, so the
-floor is met where the flag is exercised; the compatibility lanes run 24.8 with
-the flag off). The native operator computes the same
+unless the target ClickHouse is ≥ 25.6 (the compose / e2e / compatibility lanes
+all run 25.8, so the floor is met where the flag is exercised). The native
+operator computes the same
 Prometheus `extrapolatedRate` inside the engine, closing the execution-layer gap
 the SQL array machinery leaves at high cardinality. Default off is byte-for-byte
 the established fan-out. See [`performance.md`](performance.md#the-durable-answer)

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -250,7 +250,7 @@ promql/parser      pkg/logql/syntax         pkg/traceql        ← reference ups
  ┌────────────────────────────────────────────────┐
  │           internal/chsql — typed emitter        │   • parameterised, escape-free
  │  QueryBuilder slots + typed Frag constructors;  │   • PREWHERE promotion on Filter(Scan)
- │  closed typed surface — no raw SQL. Route B      │   • sort-key-aware predicate ordering
+ │  closed typed surface — no raw SQL. Route B     │   • sort-key-aware predicate ordering
  │  emits each shard byte-identically to route A.  │   • streaming clickhouse-go/v2 cursor
  └────────────────────────────────────────────────┘
               │                       │
@@ -279,21 +279,24 @@ and `FixedPoint(n)` (rules that unlock each other; iterates until no
 rule reports a change or `n` iterations have elapsed). The default
 pipeline ships:
 
-| Stage                            | Rules                                                                    | What it buys                                                                          |
-| -------------------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------- |
-| Analyzer — pure-literal fold     | `ConstantFoldSemantic`                                                   | Downstream rules can assume pure-literal subtrees have collapsed to a single `Lit`    |
-| Once — heuristic fold            | `ConstantFoldHeuristic`                                                  | Boolean identity simplification (`true AND X → X`, `false OR X → X`)                  |
-| FixedPoint — predicate pushdown  | `FilterFusion`, `FilterAggregateTranspose`, `FilterRangeWindowTranspose` | Filters move below aggregates / range windows so CH skip-indexes can fire on a `Scan` |
-| FixedPoint — projection pushdown | `ProjectionPushdown`                                                     | Late materialisation: wide columns are only resolved after `LIMIT` cuts the row set   |
+| Stage                            | Rules                                                                    | What it buys                                                                                                                                                                  |
+| -------------------------------- | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Analyzer — pure-literal fold     | `ConstantFoldSemantic`                                                   | Downstream rules can assume pure-literal subtrees have collapsed to a single `Lit`                                                                                            |
+| Once — heuristic fold            | `ConstantFoldHeuristic`                                                  | Boolean identity simplification (`true AND X → X`, `false OR X → X`)                                                                                                          |
+| FixedPoint — predicate pushdown  | `FilterFusion`, `FilterAggregateTranspose`, `FilterRangeWindowTranspose` | Filters move below aggregates / range windows so CH skip-indexes can fire on a `Scan`                                                                                         |
+| FixedPoint — projection pushdown | `ProjectionPushdown`                                                     | Late materialisation: the narrowed column set is pushed through `Aggregate` / `RangeWindow` to the inner `Scan`, so wide columns are only read after `LIMIT` cuts the row set |
+| FixedPoint — set-op linearise    | `FlattenVectorSetOp`                                                     | Collapses a left-assoc `a or b or c …` / `and` chain into one N-ary `NaryVectorSetOp` so the emitter scans each arm once under a single window pass instead of K nested ones  |
 
 `FilterAggregateTranspose` is retained as speculative correctness
 insurance (0 fires on the current corpus); `FilterRangeWindowTranspose`,
-`FilterFusion`, `ConstantFoldHeuristic`, and `ProjectionPushdown` all
-fire on real queries. The rule set carries only rules that can fire:
-there is no `FilterProjectTranspose` (no lowering emits `Filter(Project)`,
-so the rule would never match) and no `MVSubstitution` (the default schema
-ships no live rollups, so a substitution rule would be a guaranteed
-no-op).
+`FilterFusion`, `ConstantFoldHeuristic`, `ProjectionPushdown`, and
+`FlattenVectorSetOp` all fire on real queries. `FlattenVectorSetOp` only
+flattens the associative `or` / `and` operators — `unless` is not
+associative, so an `unless` chain keeps its binary shape. The rule set
+carries only rules that can fire: there is no `FilterProjectTranspose`
+(no lowering emits `Filter(Project)`, so the rule would never match) and
+no `MVSubstitution` (the default schema ships no live rollups, so a
+substitution rule would be a guaranteed no-op).
 
 The optimiser is gated by termination, decision-pin, rule-interaction,
 property, and gremlins (mutation) tests.

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -247,12 +247,12 @@ promql/parser      pkg/logql/syntax         pkg/traceql        ← reference ups
               │               anchor slices; emit + execute each
               │                       │
               ▼                       ▼
- ┌────────────────────────────────────────────────┐
+ ┌─────────────────────────────────────────────────┐
  │           internal/chsql — typed emitter        │   • parameterised, escape-free
  │  QueryBuilder slots + typed Frag constructors;  │   • PREWHERE promotion on Filter(Scan)
  │  closed typed surface — no raw SQL. Route B     │   • sort-key-aware predicate ordering
  │  emits each shard byte-identically to route A.  │   • streaming clickhouse-go/v2 cursor
- └────────────────────────────────────────────────┘
+ └─────────────────────────────────────────────────┘
               │                       │
               ▼                       ▼  K statements, bounded parallelism +
    one ClickHouse statement   connection gate, concatenated behind one

--- a/docs/forbid-skip.md
+++ b/docs/forbid-skip.md
@@ -28,12 +28,9 @@ lefthook `forbid-skip-self-test` command runs the same script on
 pre-push.
 
 The two locations carry **identical** patterns for rows 1–6 of the
-summary table below. A former row 7 (a per-PR `should_skip:` overlay
-tracking-ref guard) is no longer separately enforced — the strict
-rule in `.github/workflows/ci.yml` `forbid-skip` job step "Reject
-should_skip overlay entries" rejects every non-empty `should_skip:`
-block in `compatibility/**/*.{yml,yaml}` outright, so there is no
-per-PR tracking-ref check to assert.
+summary table below. Row 7 is enforced by the CI `forbid-skip` job step
+"Reject should_skip overlay entries", which rejects every non-empty
+`should_skip:` block in `compatibility/**/*.{yml,yaml}` outright.
 
 ## Adding a new pattern
 
@@ -62,14 +59,12 @@ shape.
 | 4   | Reject `assert.Contains(x, "")` soft assertion (2-arg + testify 3-arg)                                      | `*_test.go`                                                     | #587 / #277   |
 | 5   | Reject `assert.ElementsMatch(x, []T{})` soft assertion (2-arg + testify 3-arg)                              | `*_test.go`                                                     | #587 / #277   |
 | 6   | Reject silent panic recovery (`defer recover()` and the multi-line `defer func(){ _ = recover() }()` block) | `*_test.go`                                                     | #587 / #648   |
+| 7   | Reject any non-empty `should_skip:` block                                                                   | `compatibility/**/*.{yml,yaml}`                                 | #596          |
 
-A former row 7 (reject net-new `should_skip:` overlay entries lacking
-a tracking ref, PR #596) was superseded by the structural-cleanup PR
-that removed the overlay consumer code and replaced the tracking-ref
-guard with a strict "reject any non-empty `should_skip:` block" rule
-(see `.github/workflows/ci.yml` `forbid-skip` job step "Reject
-should_skip overlay entries"). The accepted form is `should_skip: []`;
-any element under the key fails CI.
+Row 7 rejects any non-empty `should_skip:` block outright (see
+`.github/workflows/ci.yml` `forbid-skip` job step "Reject should_skip
+overlay entries"). The only accepted form is `should_skip: []`; any
+element under the key fails CI.
 
 Vendored upstream snapshots under `compatibility/*/upstream/**` are
 excluded from every test-file / fixture grep — they sit outside
@@ -79,11 +74,10 @@ cerberus's authorship boundary.
 
 Regex: `t\.Skip[fN]?\(`
 
-PR #309 wired this gate. Before #309 the maintainer noticed `t.Skip`
-calls accumulating in test files as a way to mark known-broken tests
-as "we'll fix it later." The bug never got fixed. The skip lingered.
-The discipline rule became "fix the bug or delete the test, no
-skipping" — and the regex is the enforcement.
+`t.Skip` calls are a way to mark known-broken tests as "we'll fix it
+later" — and the fix tends never to land, so the skip lingers. The
+discipline rule is "fix the bug or delete the test, no skipping"; this
+regex is the enforcement.
 
 `[fN]?` covers all three call shapes (`t.Skip`, `t.Skipf`, `t.SkipNow`)
 in one alternation. The literal `(` anchors against accidental matches
@@ -97,12 +91,11 @@ on identifiers.
 
 Regex: `not implemented` \| `\bskipped\b` \| `\bdeferred\b`
 
-PR #309 caught only `t.Skip*` calls — but English wording like "not
+Pattern 1 catches only `t.Skip*` calls — but English wording like "not
 implemented yet" / "deferred to RC3" / "skipped because foo" in
-comments and TXTAR fixtures was just as much a discipline smell.
-PR #458 first added a phrase-pattern regex (`deferred to`, `not yet
-supported`, etc.); PR #461 widened to bare words because the
-phrase-only shape kept missing new offenders.
+comments and TXTAR fixtures is just as much a discipline smell. This
+pattern matches the bare words rather than fixed phrases, because a
+phrase-only shape misses new offenders.
 
 The bare-word shape does produce some apparent false positives — Go
 has the `defer` keyword, mock packages have `Skipper` types — which
@@ -119,8 +112,8 @@ bypassed)" rather than "delete the comment."
 
 Regex: `not implemented`
 
-PR #197 scrubbed `not implemented` from `internal/**.go` and added the
-gate so it stays scrubbed. Bare `skipped` / `deferred` are NOT in the
+`internal/**.go` carries no `not implemented` wording, and this gate
+keeps it that way. Bare `skipped` / `deferred` are NOT in the
 production gate — `defer` statements described in docstrings would
 false-positive, and runtime prose like "request X is rejected" is the
 correct rewrite of "skipped" rather than something to forbid.
@@ -132,9 +125,9 @@ correct rewrite of "skipped" rather than something to forbid.
 
 Regex: `assert\.Contains\(([^,]+,\s*){0,1}[^,]+,\s*""\s*\)`
 
-PR #587 added this. The trigger was a sweep that uncovered
-`assert.Contains(body, "")` calls — they pass any input, look like
-real assertions in reviews, but verify nothing.
+An `assert.Contains(body, "")` call passes for any input — it looks
+like a real assertion in review but verifies nothing. This gate
+rejects it.
 
 The regex uses `[^,]+` to clamp the haystack-argument match inside a
 single function call (so it doesn't reach into adjacent calls), and
@@ -143,9 +136,7 @@ leading `([^,]+,\s*){0,1}` is an optional prefix that consumes a
 testify-style first argument (`t *testing.T`) when present, so the
 single regex catches BOTH the 2-arg gocheck-style call
 (`assert.Contains(haystack, "")`) and the 3-arg testify call
-(`assert.Contains(t, haystack, "")`). The original PR #587 regex was
-2-arg-only; PR #277 widened it to both shapes after the limitation
-was flagged on PR #719.
+(`assert.Contains(t, haystack, "")`).
 
 - Matches (2-arg gocheck): `assert.Contains(body, "")`
 - Matches (3-arg testify): `assert.Contains(t, body, "")`
@@ -160,8 +151,7 @@ Sibling of pattern 4. Same regex shape (`[^,]+,` clamp + empty-needle
 match) targeting `ElementsMatch` against an empty slice literal. The
 optional `([^,]+,\s*){0,1}` prefix matches the testify-style
 `t *testing.T` first arg when present, so the regex catches BOTH the
-2-arg gocheck-style and the 3-arg testify forms — widened by PR #277
-on top of PR #587's original 2-arg-only shape.
+2-arg gocheck-style and the 3-arg testify forms.
 
 - Matches (2-arg gocheck): `assert.ElementsMatch(got, []string{})`
 - Matches (3-arg testify): `assert.ElementsMatch(t, got, []string{})`
@@ -173,10 +163,11 @@ on top of PR #587's original 2-arg-only shape.
 Regex (perl-slurp form):
 `defer\s+recover\s*\(\s*\)` \| `defer\s+func\s*\(\s*\)\s*\{[^{}]*_\s*=\s*recover\s*\(\s*\)`
 
-PR #587 added the single-line `defer recover()` and the same-line
-`defer func() { _ = recover() }()`. PR #648 widened to the
-multi-line variant via a `perl -0777` slurp because reviewers found
-the original regex missed `defer func() {\n  _ = recover()\n}()`.
+The gate covers the single-line `defer recover()`, the same-line
+`defer func() { _ = recover() }()`, and the multi-line variant
+`defer func() {\n  _ = recover()\n}()` — the last caught via a
+`perl -0777` slurp so a newline between the brace and the `recover()`
+doesn't dodge it.
 
 The `[^{}]*` clamp keeps the multi-line match inside a single brace
 level so it doesn't over-reach. The `_\s*=\s*recover` discriminator
@@ -202,18 +193,14 @@ used in real tests.
   }()
   ```
 
-## Former pattern 7 — `should_skip:` overlay tracking-ref guard (PR #596, superseded)
+## Pattern 7 — `should_skip:` compatibility overlay
 
-Originally PR #596 added a per-PR guard that diffed the overlay
-against `origin/main` and required every net-new `should_skip:` entry
-to carry a non-empty `jira:` value, a `link:` field, or a `#NNN`
-reference inside `reason:`. The structural-cleanup PR removed the
-overlay consumer code entirely, so the per-PR tracking-ref guard is
-no longer load-bearing: the `forbid-skip` CI job step "Reject
-should_skip overlay entries" now rejects ANY non-empty
-`should_skip:` block in `compatibility/**/*.{yml,yaml}` outright. The
-delegating helper script and its assertion in
-`scripts/test-forbid-skip.sh` were removed at the same time.
+The `forbid-skip` CI job step "Reject should_skip overlay entries"
+rejects ANY non-empty `should_skip:` block in
+`compatibility/**/*.{yml,yaml}` outright. A compatibility corpus entry
+is either scored against the reference or it is not in the corpus —
+there is no per-case skip overlay, so the gate forbids the construct
+itself rather than auditing each entry's tracking ref.
 
 ## Redundancy review
 
@@ -233,6 +220,7 @@ redundancies — each catches a shape the others would miss:
   patterns 4 / 5 because pattern 6 needs the `perl -0777` slurp to
   span lines.
 
-The gate's total active pattern count: **6** (patterns 1–6 above).
-The former pattern 7 was superseded by the strict overlay-entry
-rejection rule in CI.
+The gate's total active pattern count: **7** (patterns 1–7 above).
+Patterns 1–6 run over Go test files / fixtures / production code;
+pattern 7 is the strict overlay-entry rejection over the compatibility
+YAML.

--- a/docs/health.md
+++ b/docs/health.md
@@ -102,7 +102,7 @@ livenessProbe:
 - **Liveness** — `periodSeconds: 10`. Liveness probes are cheap (no CH
   call), so the period is set by container-restart sensitivity rather
   than by CH load.
-- **Startup** — none needed today; `initialDelaySeconds: 2` on the
+- **Startup** — none needed; `initialDelaySeconds: 2` on the
   readiness probe is enough for cerberus to bind its listener.
 
 ## Startup latency
@@ -140,7 +140,8 @@ the first success.
 
 ## ClickHouse down at boot
 
-An unreachable ClickHouse never prevents startup. The connection pool
+With the requirements preflight off (`CERBERUS_REQUIREMENTS_CHECK=false`),
+an unreachable ClickHouse never prevents startup. The connection pool
 is constructed lazily (no dial), the startup connectivity ping is
 demoted to a WARN log, and the process serves immediately:
 
@@ -149,11 +150,19 @@ demoted to a WARN log, and the process serves immediately:
 
 flipping `/readyz` to `200` as soon as ClickHouse answers — no restart
 needed. This is the readiness-gating contract Kubernetes expects: a
-replica scaled up while ClickHouse is saturated (CI run 27272406583
-crash-looped on exactly this) waits out the outage out of the Service
-endpoints instead of converting it into a CrashLoopBackOff. Fail-fast
-remains for misconfiguration that can never succeed (bad env values,
-invalid connection options).
+replica scaled up while ClickHouse is saturated waits out the outage out
+of the Service endpoints instead of converting it into a
+CrashLoopBackOff. Fail-fast remains for misconfiguration that can never
+succeed (bad env values, invalid connection options).
+
+The preflight is a deliberately **stricter** contract, and it is on by
+default. `CERBERUS_REQUIREMENTS_CHECK` (the boot-time CH-version + schema
+gate — see [`operations.md`](operations.md#startup-requirements-preflight))
+needs ClickHouse reachable to read `version()` and `system.columns`, so a
+CH that is unreachable at the preflight point fails startup rather than
+booting unready. Deployments that need the boot-into-unready behaviour
+above against a CH that may be down at boot set
+`CERBERUS_REQUIREMENTS_CHECK=false` to skip the gate.
 
 ## Implementation pointers
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -117,6 +117,12 @@ env vars at startup; nothing rebuild-related is required.
 | `CERBERUS_SCHEMA_LOGS_TABLE`                  | `otel_logs`                  | Logs table name read by the Loki API.              |
 | `CERBERUS_SCHEMA_TRACES_TABLE`                | `otel_traces`                | Spans table name read by the Tempo API.            |
 
+One related opt-in knob is a boolean rather than a table-name override:
+
+| Variable                           | Default | Effect                                                                                                                                                                                                                                                                          |
+| ---------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CERBERUS_SCHEMA_TRACES_TS_LOOKUP` | `false` | When truthy, the Tempo trace-by-ID path window-prunes the spans scan through the OTel-CH `<spans>_trace_id_ts` lookup MV. Enable only after confirming that MV is populated; the lookup-table name derives from the (possibly overridden) spans table as `<spans>_trace_id_ts`. |
+
 The active ClickHouse **database** is set by `CERBERUS_CH_DATABASE`
 (default `otel`) — that single knob covers both the connection's
 default schema and the database the auto-create DDL targets, so no

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -170,7 +170,7 @@ the SQL array machinery leaves at high cardinality. See
 **Requirements and hard constraints:**
 
 - **ClickHouse ≥ 25.6.** The `timeSeries*ToGrid` family was introduced in CH
-  v25.6.0. The compose / e2e / compatibility deployment now runs **25.8**
+  v25.6.0. The compose / e2e / compatibility deployment runs **25.8**
   (matching the chDB test substrate), so the function exists everywhere — but
   on any older server a native-path query still errors with `UNKNOWN_FUNCTION`,
   so the flag **must stay OFF** unless the target CH is ≥ 25.6. The experimental

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -93,9 +93,12 @@ the plan before any rule runs.
   of sample×anchor pairs and a single scan.
 - **Single-pass set-op chains.** `a or b or c …` lowers so each binary set-op
   scans both arms exactly once (a tagged `UNION ALL` + a window-partition
-  anti-join) instead of re-materialising the left arm per level. (A residual
-  super-linearity from the left-associative *nesting* of N arms is tracked
-  separately — see "Known residuals" below.)
+  anti-join) instead of re-materialising the left arm per level. The optimizer's
+  `FlattenVectorSetOp` rule then collapses the left-associative *nesting* of N
+  arms into one N-ary `NaryVectorSetOp`, which the emitter renders as a single
+  `UNION ALL` over all K arms under one window pass — so a K-arm chain is one
+  scan, not K nested window passes. (`unless` is not associative, so an `unless`
+  chain keeps its binary nesting.)
 - **Bounded recursion.** TraceQL structural operators (`>>`, `<<`) and
   nested-set traversals lower to `WITH RECURSIVE` carrying an explicit
   `_depth` column and a hard cap, so a cyclic trace terminates instead of
@@ -147,9 +150,9 @@ service-pinned query costs only a couple of extra granules. See
 ## How "fast" is kept fast — the assurance framework
 
 A one-time optimization is worthless if the next refactor quietly undoes it.
-The bugs above were originally caught by a human manually sweeping Grafana —
-which is not a control. Cerberus replaces that with four automated layers,
-spanning *static* (cheap, every PR) to *broad* (corpus-wide, nightly).
+A human manually sweeping Grafana for the bugs above is not a control. Cerberus
+holds the speed in place with four automated layers, spanning *static* (cheap,
+every PR) to *broad* (corpus-wide, nightly).
 
 1. **Static fan-out lint** — `internal/perf/fanout`, always-on in the
    regression suite. Flags the structurally-unbounded shapes — a `CrossJoin`
@@ -184,15 +187,18 @@ Improvements are always allowed (a fan-factor *decrease* never blocks); the
 ceiling only tightens when a maintainer re-runs
 `just update-cardinality-baseline`.
 
-### Known residuals
+### Set-op chains: N-ary linearisation
 
-The framework is honest about what is *not yet* flat. Set-op chains are
-single-pass per binary operator, but `a or b or c …` still lowers
-left-associatively into K nested levels, so wall-time grows ~2.6×/level even
-though the intermediate stays bounded. The scaling harness records this as a
-tracked `KnownSuperlinear` finding (the cardinality axis still hard-gates), and
-the true fix — flattening the chain into one N-ary single pass — is tracked
-rather than silently accepted.
+An associative set-op chain (`a or b or c …`, `and`) is fully flat on both
+axes. Each binary operator already scans both arms exactly once, and the
+`FlattenVectorSetOp` optimizer rule collapses the left-associative nesting of N
+arms into one N-ary `NaryVectorSetOp` — a single `UNION ALL` over all K arms
+under one window pass — so wall-time is sub-linear in chain depth and the peak
+intermediate stays a small bounded constant. The `setop_chain` scaling harness
+hard-gates **both** axes on this shape. `unless` is not associative
+(`a unless (b unless c) ≠ (a unless b) unless c`), so an `unless` chain keeps
+its binary nesting by construction — the one set-op shape that does not
+linearise, because flattening it would change results.
 
 ## Rate-range windowing: why the fan-out ships as the default
 
@@ -200,7 +206,7 @@ rather than silently accepted.
 over the OTel-CH counter table is the one metrics shape route A cannot fold
 flat — `rate` needs the per-window sample pairs, so the RangeLWR collapse
 doesn't apply (see the
-[`range query (240 steps)` note in benchmarks.md](benchmarks.md#end-to-end-query-latency)).
+[`range query (240 steps)` note in benchmarks.md](benchmarks.md#end-to-end-the-query_range-path)).
 The emit fans each sample into the `~Range/Step` overlapping windows it belongs
 to (`arrayJoin`), groups + sorts per `(series, anchor)`, then applies
 Prometheus's `extrapolatedRate`. That fan-out *looks* like the expensive part,
@@ -314,7 +320,7 @@ rejected rather than served. That is exactly the wall this flag exists to move.
 > wall, and it is on by default (`auto`): it slices the same fan-out across `K`
 > statements so no single one exceeds the cap. Sharding makes the fan-out
 > *fit*; the native path below makes it *vanish*. They are independent levers —
-> see the [route × native-rate numbers in benchmarks.md](benchmarks.md#end-to-end-query-latency)
+> see the [route × native-rate numbers in benchmarks.md](benchmarks.md#execution-routes--native-rate-the-matrix)
 > for how they compose.
 
 ### The durable answer
@@ -334,7 +340,7 @@ the memory — stays **flat** instead of growing with the grid. On the canonical
 | **on** (experimental) | native `timeSeriesRateToGrid`    | ~87 ms  | ~11 MiB             |
 
 (Measured on the 500k-row seed; full methodology and the route × native-rate
-numbers are in [benchmarks.md](benchmarks.md#end-to-end-query-latency).)
+numbers are in [benchmarks.md](benchmarks.md#execution-routes--native-rate-the-matrix).)
 The fan-out's memory scales with the data; the native path's stays roughly flat
 no matter how many series or anchors you ask for — which is precisely what lets
 it serve the million-row queries that would otherwise hit the cap.

--- a/docs/solver.md
+++ b/docs/solver.md
@@ -208,9 +208,10 @@ oldest slice) to exhaustion, then channel 1, and so on. Oldest-first drain
 keeps per-series timestamps nearly ascending, so the handler's insertion sort
 stays roughly linear. Two guards run during the drain:
 
-- **Per-request output cap.** Route B makes previously-422 high-cardinality
-  successes succeed, and a success lands `O(rows)` in the gateway's matrix
-  buffers. The cursor enforces `Config.MaxOutputRows` with a **distinct** typed
+- **Per-request output cap.** Route B turns a high-cardinality query that a
+  single statement would 422 into a success, and a success lands `O(rows)` in
+  the gateway's matrix buffers. The cursor enforces `Config.MaxOutputRows` with
+  a **distinct** typed
   422 (`OutputCapError`) whose message is deliberately not the upstream
   max-samples text — that text is a parity surface, and the output cap is a
   separate gateway-memory guard.

--- a/docs/upstream-forks.md
+++ b/docs/upstream-forks.md
@@ -55,17 +55,17 @@ ORDER BY (MetricName, Attributes, ServiceName, toUnixTimestamp64Nano(TimeUnix))
 
 — where stock OTel-CH leads with `ServiceName`. ClickHouse's `ORDER BY` (the table sort key) governs only data-skipping and on-disk layout, never query results, so this divergence is **correctness-neutral**: cerberus answers identically whether the metrics tables carry the stock key or the MetricName-first key. The only difference is performance — the metric-name-first key lets the common metric query (no `service.name` matcher) binary-search the primary key instead of falling to a generic-exclusion granule scan, measured at ~17× fewer granules read (see [`benchmarks.md`](benchmarks.md#metricname-first-order-by)). The traces and logs tables are rendered stock, unchanged. This is the single point at which cerberus's auto-created schema differs from a stock OTel-CH deployment; the operator-facing framing lives in [`operations.md`](operations.md#schema-divergence-metricname-first-metrics-sort-key).
 
-Both shapes (`unsafe.Pointer` + `reflect.Value.FieldByName`) are now banned in `internal/traceql/` and `internal/api/tempo/` via a `forbidigo` rule in `.golangci.yml`. New shims regress the lint gate.
+Both shapes (`unsafe.Pointer` + `reflect.Value.FieldByName`) are banned across every `internal/**` package via a `forbidigo` rule in `.golangci.yml`. New shims regress the lint gate.
 
 ## How a new upstream change reaches cerberus
 
 ```text
 ┌──────────────────────┐                             ┌──────────────────────────┐
-│ upstream repo        │ ────────────────────────▶  │ tsouza/<fork>            │
-│ (prometheus, loki,   │   ─ relevant paths only ─  │   cerberus-<branch>      │
-│  tempo, otel-c)      │   ─ as a new tag ─         │     ├── v0.0.1 (baseline)│
-│                      │                             │     ├── v0.0.2          │
-│                      │                             │     └── …               │
+│ upstream repo        │ ────────────────────────▶   │ tsouza/<fork>            │
+│ (prometheus, loki,   │   ─ relevant paths only ─   │   cerberus-<branch>      │
+│  tempo, otel-c)      │   ─ as a new tag ─          │     ├── v0.0.1 (baseline)│
+│                      │                             │     ├── v0.0.2           │
+│                      │                             │     └── …                │
 └──────────────────────┘                             └────────────┬─────────────┘
                                                                   │
                                   cerberus-forks-monitor (cron) ──┘
@@ -187,7 +187,7 @@ If a new RC introduces a fifth parser dep:
 - [`tsouza/cerberus-forks-monitor`](https://github.com/tsouza/cerberus-forks-monitor) — the daily cron repo. `README.md` there has the operational detail.
 - `.github/dependabot.yml` — daily-grouped config. Group `upstream-parsers` covers all four forks.
 - `.github/workflows/auto-merge-deps.yml` — auto-merge on green CI for trusted patch-only bumps.
-- `.golangci.yml` — `forbidigo` rule blocking `unsafe.Pointer` / `reflect.Value.FieldByName` from being reintroduced in `internal/traceql/` and `internal/api/tempo/`.
+- `.golangci.yml` — `forbidigo` rule blocking `unsafe.Pointer` / `reflect.Value.FieldByName` from being reintroduced anywhere under `internal/**`.
 - `internal/schema/ddl/` — consumes the `sqltemplates` API exposed by the collector-contrib fork.
 - `internal/traceql/aggregate.go`, `internal/traceql/select.go`, `internal/traceql/metrics_pipeline.go` — call the Tempo fork's accessors.
 - `CLAUDE.md` § "Transitive-dep gotcha" — the unrelated memberlist replace.


### PR DESCRIPTION
One last full documentation sweep before RC1. Every `docs/*.md`, `README.md`, and `CONTRIBUTING.md` was read; issues were verified against the repo (resolved link targets, grepped the Justfile / workflows / config code) before fixing. markdownlint-cli2 + md-table-align pass on all touched files.

Leaving this **open and un-armed** for maintainer review.

## ASCII / diagram alignment

- **`docs/engine.md`** (the flagged one): the `internal/chsql — typed emitter` box had the `closed typed surface — no raw SQL. Route B` row overrun the right border by one display column. All `│` borders now line up at col 52. Swept every other box in the doc set with a width-checker — this was the only overrun in prose fences.
- **`docs/upstream-forks.md`**: the upstream→fork tree diagram (`How a new upstream change reaches cerberus`) had the right box's left border one column short on three rows, and two `v0.0.x` tree rows one column short on the right border. All corners + borders + the `┬` junction now align.

## Broken / incorrect links

- **`docs/performance.md`** (3 links): `benchmarks.md#end-to-end-query-latency` is a dead anchor — the generated heading is `## End-to-end: the query_range path`. Retargeted by reference intent: the "240-steps" link → `#end-to-end-the-query_range-path`; the two "route × native-rate" links → `#execution-routes--native-rate-the-matrix`. (Verified against the bench-report generator's heading strings.)
- Full link+anchor checker run over all 15 md files: **0 dead** after fixes.

## Stale vs. what landed this cycle

- **CH floor 24.8 vs CI 25.8 conflation** (`README.md`, `docs/configuration.md`): docs said "the differential compatibility suite runs 24.8". The compose files actually pin **25.8** (`compatibility/*/docker-compose.yml`), and the requirements-check floor constant is **24.8** (`internal/preflight/preflight.go` `minCHBase`). Separated the two concepts everywhere: supported floor = 24.8; compat/compose/e2e lanes execute on 25.8. (`docs/operations.md` already had it right; removed a "now runs" tense there.)
- **`FlattenVectorSetOp` optimizer rule missing** (`docs/engine.md`, `docs/performance.md`): the default pipeline has a 5th batch (`optimizer.set-op-linearize`, `internal/optimizer/rule.go`) that linearises `a or b or c …` / `and` chains. It was absent from the engine.md rule table, and performance.md's **"Known residuals"** still described the pre-flatten "~2.6×/level super-linearity… tracked rather than accepted" that this rule already fixed (per `test/perf/scaling/construct_setop_chain_test.go` gen #90). Added the rule row + rewrote the residuals section to the linearised reality (`unless` stays binary — not associative).
- **ProjectionPushdown narrow inner scan** (`docs/engine.md`): noted the narrowed projection is pushed through `Aggregate` / `RangeWindow` to the inner `Scan` (#894 / #897).
- **`CERBERUS_SCHEMA_TRACES_TS_LOOKUP`** (`docs/observability.md`): configuration.md points readers to observability.md for schema overrides, but the trace_id_ts window-prune opt-in (#895) wasn't there. Added it as a boolean opt-in row.
- **Requirements preflight vs "CH down at boot"** (`docs/health.md`): health.md claimed unconditionally "An unreachable ClickHouse never prevents startup" — but `CERBERUS_REQUIREMENTS_CHECK` (ON by default, runs before listener bind per `cmd/cerberus/main.go`) needs CH reachable and **fails startup** when it isn't. Qualified the claim and cross-linked the preflight.
- **forbidigo scope widened** (`docs/upstream-forks.md`): the gate now covers all of `internal/**` (`.golangci.yml`), not just `internal/traceql` + `internal/api/tempo`. Fixed two spots.
- **bench-report generator** (`cmd/bench-report/render_chdb.go`): the unconditional setop_chain "residual super-linearity / the fix is an N-ary flatten" note is stale post-#90. Updated the generated prose to the linearised reality.

## Internal consistency

- Verified layer count (13) agrees across README + test-strategy.md; required-checks list (11) agrees across CLAUDE.md, test-strategy.md, CONTRIBUTING.md.
- Verified coverage.md "at a glance" counts (PromQL 121/119/2/0, LogQL 62, TraceQL 45, 228 total) **match `test/surface-parity/inventory.json` exactly** — no drift.
- Verified every `just` recipe referenced in docs exists in the Justfile, and every workflow file referenced in test-strategy.md exists.
- **forbid-skip.md doc-vs-code fix**: doc claimed `scripts/test-forbid-skip.sh` "was removed" — it still exists. Corrected.

## Timeless-docs (reframed evolution/incident narrative)

- **`docs/forbid-skip.md`**: surfaced "former pattern 7" (should_skip overlay) as current **pattern 7** in the table + count (was a "superseded" narrative); de-narrativised the per-pattern prose ("PR #309 wired this… Before #309 the maintainer noticed…" → timeless). Kept the per-pattern `Origin` PR column as traceability metadata.
- **`docs/compatibility.md`**: dropped `(task #68)` ref; reframed "Historically nothing verified… which is how `kind != nil` ended up rejected" to present tense.
- **`docs/health.md`**: removed a `CI run 27272406583` incident ref.
- **`docs/performance.md`**, **`docs/solver.md`**: "originally caught by a human" / "previously-422" → timeless.

## Flag for maintainer (code looks wrong, not the doc)

- **Code-vs-code version-floor comments disagree.** `internal/preflight/preflight.go:60` says "the differential compatibility suite runs ClickHouse **24.8**", while `internal/config/config.go:73` and all `compatibility/*/docker-compose.yml` say **25.8**. The compose files are ground truth (25.8). I aligned the **docs** to: floor = 24.8 (the enforced `minCHBase`), CI lanes = 25.8. The two **code comments** are out of sync with each other and with the compose pins — worth a follow-up to reconcile `preflight.go:60` (and the `config.go:53` "CH 25.8 base" phrasing, which mislabels the base floor as 25.8 when the constant is 24.8). Not touched here (docs PR).

## Needs a regen (not done — requires chDB)

- **`docs/benchmarks.md`** is generated by `just bench-report` (chDB substrate). Its `setop_chain` section still shows the pre-flatten numbers ("wall grew 8.9× — tracks the parameter") and the stale note. I fixed the **generator** prose (`cmd/bench-report/render_chdb.go`); the committed `benchmarks.md` needs a `just bench-report` re-run to refresh both the note and the measured post-flatten numbers. Left untouched rather than hand-editing generated numbers.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>