### PR TITLE
fix(compose): scrape virtual filesystems so host fs panel populates on macOS

### DIFF
--- a/test/e2e/otel-collector/compose-config.yaml
+++ b/test/e2e/otel-collector/compose-config.yaml
@@ -127,6 +127,76 @@ receivers:
           system.network.conntrack.max:
             enabled: true
       filesystem:
+        # Portability across the two compose hosts (Linux vs Docker
+        # Desktop for Mac). The "Filesystem utilisation by mount" panel
+        # on the host dashboard queries
+        # `max by (mountpoint) (system_filesystem_utilization)`, so it
+        # only renders if at least one real mount is scraped.
+        #
+        # The scraper has no default filters, so out of the box it emits
+        # whatever gopsutil's disk.Partitions returns. With
+        # include_virtual_filesystems unset (false) gopsutil keeps only
+        # "physical" filesystems — those listed in /proc/filesystems
+        # *without* the `nodev` marker:
+        #   - On native Linux (CI), the host root mounted at /hostfs is a
+        #     real device fs (ext4 / xfs / btrfs), which is physical, so
+        #     `/` is emitted and the panel populates.
+        #   - On Docker Desktop for Mac, /hostfs is the LinuxKit VM's root,
+        #     and the user's Mac volumes are shared into that VM over
+        #     virtiofs / grpcfuse / 9p — all `nodev` (virtual) in the VM's
+        #     /proc/filesystems, alongside the overlay VM root. gopsutil
+        #     therefore drops *every* partition, no series is produced, and
+        #     the panel renders empty.
+        #
+        # Fix: opt the virtual filesystems back in, then blocklist the
+        # kernel pseudo-filesystems that carry no meaningful "utilisation".
+        # A blocklist (exclude pseudo-fs) is portable where an allowlist
+        # (include only ext4/xfs) would not be — it keeps the real macOS
+        # shared mounts (virtiofs / grpcfuse / 9p) and the Linux device
+        # root, while dropping proc / sysfs / cgroup / tmpfs / overlay on
+        # both. Linux still emits its ext4/xfs `/` mount, so CI's
+        # compose-smoke path is unchanged.
+        include_virtual_filesystems: true
+        exclude_fs_types:
+          match_type: strict
+          fs_types:
+            - autofs
+            - binfmt_misc
+            - bpf
+            - cgroup
+            - cgroup2
+            - configfs
+            - debugfs
+            - devpts
+            - devtmpfs
+            - fusectl
+            - hugetlbfs
+            - mqueue
+            - nsfs
+            - overlay
+            - proc
+            - procfs
+            - pstore
+            - ramfs
+            - securityfs
+            - selinuxfs
+            - squashfs
+            - sysfs
+            - tmpfs
+            - tracefs
+        exclude_mount_points:
+          # Host-perspective paths (the scraper resolves these against the
+          # un-rerooted mountpoint even though root_path is /hostfs). These
+          # drop the kernel/runtime plumbing trees that survive the fs-type
+          # blocklist, leaving only operator-meaningful volumes.
+          match_type: regexp
+          mount_points:
+            - /dev/.*
+            - /proc/.*
+            - /sys/.*
+            - /run/.*
+            - /var/lib/docker/.*
+            - /var/lib/kubelet/.*
         metrics:
           system.filesystem.utilization:
             enabled: true


### PR DESCRIPTION
## Problem

The compose-stack `host-observability` (`host`) Grafana dashboard's **"Filesystem utilisation by mount"** panel renders **empty on Docker Desktop for Mac**, while it populates correctly on Linux (where CI's `compose-smoke` runs). This is a cross-platform / works-out-of-the-box portability gap, not a CI failure — but it's an RC1 polish item: the host dashboard ships with the quickstart and should populate on a maintainer's Mac.

## Panel query

```promql
max by (mountpoint) (system_filesystem_utilization)
```
(`test/e2e/grafana/compose/dashboards/host.json`, panel id 16 — groups by `mountpoint`, so it only renders if at least one real mount is scraped.)

## Receiver config (before)

`test/e2e/otel-collector/compose-config.yaml`, `host_metrics` receiver:

```yaml
host_metrics:
  collection_interval: 15s
  root_path: /hostfs           # docker-compose.yml bind-mounts host / -> /hostfs:ro,rslave
  scrapers:
    filesystem:
      metrics:
        system.filesystem.utilization:
          enabled: true
```

No `include_*` / `exclude_*` / `include_virtual_filesystems` set — so the scraper uses upstream defaults.

## Root cause (the macOS empty)

The hostmetrics `filesystem` scraper has **no default filters**, so it emits whatever gopsutil's `disk.Partitions` returns. With `include_virtual_filesystems` **unset (false)**, gopsutil keeps only *physical* filesystems — those listed in `/proc/filesystems` **without** the `nodev` marker:

- **Linux (CI / native Docker):** `/hostfs` is the host's real root, a device filesystem (`ext4` / `xfs` / `btrfs`) — physical, no `nodev`. gopsutil keeps the `/` mount → `system_filesystem_utilization{mountpoint="/"}` is emitted → **panel populates.**
- **Docker Desktop for Mac:** containers run inside a LinuxKit VM. `/:/hostfs` bind-mounts the **VM's** root, not the Mac's. The Mac's volumes are shared into the VM over **`virtiofs` / `grpcfuse` / `9p`** — all marked `nodev` (virtual) in the VM's `/proc/filesystems`, alongside the `overlay` VM root. So gopsutil drops **every** partition → no series produced → **panel renders empty.**

The mismatch is the `nodev`/physical classification, not a label-value filter and not a cerberus PromQL→CH translation issue: on Mac the metric series genuinely isn't produced, so there's nothing to query.

## Portable fix

```yaml
filesystem:
  include_virtual_filesystems: true     # opt virtiofs/grpcfuse/9p/overlay back in
  exclude_fs_types:                     # then blocklist kernel pseudo-fs (no real utilisation)
    match_type: strict
    fs_types: [autofs, binfmt_misc, bpf, cgroup, cgroup2, configfs, debugfs,
               devpts, devtmpfs, fusectl, hugetlbfs, mqueue, nsfs, overlay,
               proc, procfs, pstore, ramfs, securityfs, selinuxfs, squashfs,
               sysfs, tmpfs, tracefs]
  exclude_mount_points:                 # drop plumbing trees that survive the fs-type blocklist
    match_type: regexp
    mount_points: [/dev/.*, /proc/.*, /sys/.*, /run/.*, /var/lib/docker/.*, /var/lib/kubelet/.*]
  metrics:
    system.filesystem.utilization:
      enabled: true
```

A **blocklist** (exclude pseudo-fs) is portable where an **allowlist** (include only `ext4`/`xfs`) would not be: it keeps the macOS shared mounts (`virtiofs` / `grpcfuse` / `9p`) and the Linux device root, while dropping `proc` / `sysfs` / `cgroup` / `tmpfs` / `overlay` on both. This is a real fix — a maintainer on macOS sees their actual shared volume mounts — not a panel hide or a platform allowlist.

## Why Linux (CI) stays green

On native Linux the host root is `ext4`/`xfs`/`btrfs` (not in `exclude_fs_types`) at mountpoint `/` (not matched by any `exclude_mount_points` glob). So with `include_virtual_filesystems: true` + these excludes, the `/` mount is **still emitted** exactly as before — the only change on Linux is that the now-opted-in virtual filesystems are immediately re-dropped by the pseudo-fs blocklist, leaving the panel's series set unchanged. `compose-smoke`'s contract (no non-empty error in any `/api/ds/query` response; no panel-shape spec asserts this metric by name) is unaffected. YAML validated (`yaml.safe_load`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
